### PR TITLE
[GSB and AST Printing] Clean up handling of same-type requirements

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -932,6 +932,7 @@ public:
     PrintRequirements = 2,
     InnermostOnly = 4,
     SkipSelfRequirement = 8,
+    SwapSelfAndDependentMemberType = 16,
   };
 
   void printWhereClauseFromRequirementSignature(ProtocolDecl *proto,
@@ -1323,8 +1324,11 @@ bestRequirementPrintLocation(ProtocolDecl *proto, const Requirement &req) {
 void PrintAST::printWhereClauseFromRequirementSignature(ProtocolDecl *proto,
                                                         Decl *attachingTo) {
   assert(proto->isRequirementSignatureComputed());
+  unsigned flags = PrintRequirements;
+  if (isa<AssociatedTypeDecl>(attachingTo))
+    flags |= SwapSelfAndDependentMemberType;
   printGenericSignature(
-      proto->getRequirementSignature(), PrintRequirements,
+      proto->getRequirementSignature(), flags,
       [&](const Requirement &req) {
         auto location = bestRequirementPrintLocation(proto, req);
         return location.AttachedTo == attachingTo && location.InWhereClause;
@@ -1441,6 +1445,8 @@ void PrintAST::printSingleDepthOfGenericSignature(
     llvm::function_ref<bool(const Requirement &)> filter) {
   bool printParams = (flags & PrintParams);
   bool printRequirements = (flags & PrintRequirements);
+  bool swapSelfAndDependentMemberType =
+    (flags & SwapSelfAndDependentMemberType);
 
   SubstitutionMap subMap;
   if (CurrentType) {
@@ -1516,6 +1522,13 @@ void PrintAST::printSingleDepthOfGenericSignature(
       } else {
         Printer << ", ";
       }
+
+      // Swap the order of Self == Self.A requirements if requested.
+      if (swapSelfAndDependentMemberType &&
+          req.getKind() == RequirementKind::SameType &&
+          first->is<GenericTypeParamType>() &&
+          second->is<DependentMemberType>())
+        std::swap(first, second);
 
       Printer.callPrintStructurePre(PrintStructureKind::GenericRequirement);
       if (second) {

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -1300,7 +1300,9 @@ bestRequirementPrintLocation(ProtocolDecl *proto, const Requirement &req) {
     // Self.T.U == Self should go on T (third condition).
     auto rhsBetterDirect =
         !lhsResult.second && rhsResult.second && rhsResult.first != proto;
-    if (lhsDoesntExist || rhsBetterDirect)
+    auto rhsOfSelfToAssoc = lhsResult.first == proto && rhsResult.first;
+    // e.g. Self == Self.T.U
+    if (lhsDoesntExist || rhsBetterDirect || rhsOfSelfToAssoc)
       bestDecl = rhsResult.first;
 
     // Same-type requirements can only occur in where clauses

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -3484,20 +3484,8 @@ static PotentialArchetype *sameTypeDFS(PotentialArchetype *pa,
 
   // Visit its adjacent potential archetypes.
   for (const auto &sameType : pa->getSameTypeConstraints()) {
-    switch (sameType.second->kind) {
-    case RequirementSource::Explicit:
-    case RequirementSource::Inferred:
-    case RequirementSource::RequirementSignatureSelf:
-      // Skip explicit constraints.
-      continue;
-
-    case RequirementSource::Concrete:
-    case RequirementSource::NestedTypeNameMatch:
-    case RequirementSource::Parent:
-    case RequirementSource::ProtocolRequirement:
-    case RequirementSource::Superclass:
-      break;
-    }
+    // Skip non-derived constraints.
+    if (!sameType.second->isDerivedRequirement()) continue;
 
     sameTypeDFS(sameType.first, component, paToComponent);
 

--- a/test/Generics/protocol_where_clause.swift
+++ b/test/Generics/protocol_where_clause.swift
@@ -47,7 +47,8 @@ struct ConcreteSameType: SameType {
     typealias T = Int
     typealias U = Int
 }
-struct BadConcreteSameType: SameType {
+struct BadConcreteSameType: SameType { // expected-error{{'SameType' requires the types 'BadConcreteSameType.T' (aka 'Int') and 'BadConcreteSameType.U' (aka 'Float') be equivalent}}
+	// expected-note@-1{{requirement specified as 'Self.T' == 'Self.U' [with Self = BadConcreteSameType]}}
     typealias T = Int
     typealias U = Float
 }

--- a/test/IDE/print_ast_tc_decls.swift
+++ b/test/IDE/print_ast_tc_decls.swift
@@ -1345,7 +1345,7 @@ protocol ProtocolWithWhereClauseAndAssoc : QuxProtocol where Qux == Int, Self : 
 
   // FIXME: this same type requirement with Self should be printed here
   associatedtype A2 : QuxProtocol where A2.Qux == Self
-// PREFER_TYPE_REPR_PRINTING-DAG: {{^}}  associatedtype A2 : QuxProtocol where Self == Self.A2.Qux{{$}}
+// PREFER_TYPE_REPR_PRINTING-DAG: {{^}}  associatedtype A2 : QuxProtocol where Self.A2.Qux == Self{{$}}
 }
 
 #if true

--- a/test/IDE/print_ast_tc_decls.swift
+++ b/test/IDE/print_ast_tc_decls.swift
@@ -1339,12 +1339,11 @@ protocol ProtocolWithWhereClause : QuxProtocol where Qux == Int, Self : FooProto
 // PREFER_TYPE_REPR_PRINTING: protocol ProtocolWithWhereClause : QuxProtocol where Self : FooProtocol, Self.Qux == Int {
 
 protocol ProtocolWithWhereClauseAndAssoc : QuxProtocol where Qux == Int, Self : FooProtocol {
-// PREFER_TYPE_REPR_PRINTING-DAG: protocol ProtocolWithWhereClauseAndAssoc : QuxProtocol where Self : FooProtocol, Self.Qux == Int {
+// PREFER_TYPE_REPR_PRINTING-DAG: protocol ProtocolWithWhereClauseAndAssoc : QuxProtocol where Self : FooProtocol, Self == Self.A2.Qux, Self.Qux == Int {
   associatedtype A1 : QuxProtocol where A1 : FooProtocol, A1.Qux : QuxProtocol, Int == A1.Qux.Qux
 // PREFER_TYPE_REPR_PRINTING-DAG: {{^}}  associatedtype A1 : QuxProtocol where Self.A1 : FooProtocol, Self.A1.Qux : QuxProtocol, Self.A1.Qux.Qux == Int{{$}}
 
-  // FIXME: this same type requirements between archetypes is dropped from the
-  // requirement signature, but should be printed here
+  // FIXME: this same type requirement with Self should be printed here
   associatedtype A2 : QuxProtocol where A2.Qux == Self
 // PREFER_TYPE_REPR_PRINTING-DAG: {{^}}  associatedtype A2 : QuxProtocol{{$}}
 }

--- a/test/IDE/print_ast_tc_decls.swift
+++ b/test/IDE/print_ast_tc_decls.swift
@@ -1339,13 +1339,13 @@ protocol ProtocolWithWhereClause : QuxProtocol where Qux == Int, Self : FooProto
 // PREFER_TYPE_REPR_PRINTING: protocol ProtocolWithWhereClause : QuxProtocol where Self : FooProtocol, Self.Qux == Int {
 
 protocol ProtocolWithWhereClauseAndAssoc : QuxProtocol where Qux == Int, Self : FooProtocol {
-// PREFER_TYPE_REPR_PRINTING-DAG: protocol ProtocolWithWhereClauseAndAssoc : QuxProtocol where Self : FooProtocol, Self == Self.A2.Qux, Self.Qux == Int {
+// PREFER_TYPE_REPR_PRINTING-DAG: protocol ProtocolWithWhereClauseAndAssoc : QuxProtocol where Self : FooProtocol, Self.Qux == Int {
   associatedtype A1 : QuxProtocol where A1 : FooProtocol, A1.Qux : QuxProtocol, Int == A1.Qux.Qux
 // PREFER_TYPE_REPR_PRINTING-DAG: {{^}}  associatedtype A1 : QuxProtocol where Self.A1 : FooProtocol, Self.A1.Qux : QuxProtocol, Self.A1.Qux.Qux == Int{{$}}
 
   // FIXME: this same type requirement with Self should be printed here
   associatedtype A2 : QuxProtocol where A2.Qux == Self
-// PREFER_TYPE_REPR_PRINTING-DAG: {{^}}  associatedtype A2 : QuxProtocol{{$}}
+// PREFER_TYPE_REPR_PRINTING-DAG: {{^}}  associatedtype A2 : QuxProtocol where Self == Self.A2.Qux{{$}}
 }
 
 #if true


### PR DESCRIPTION
Miscellaneous cleanups for same-type requirements:

* Use `isDerivedRequirement()` consistently, which fixes an issue that showed up in printing,
* Clean up printing via requirement signatures a little, associating `Self == Self.A` requirements with `A` when we can