### PR TITLE
WIP: utils: Add swiftenvs, which allow the overriding of compiler tools.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -420,10 +420,10 @@ swift_configure_components()
 # lipo is used to create universal binaries.
 if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
   include(SwiftDarwin)
-  if(SWIFT_LIPO)
-    set(LIPO ${SWIFT_LIPO})
+  if(CMAKE_LIPO)
+    set(CMAKE_LIPO ${CMAKE_LIPO})
   else()
-    find_toolchain_tool(LIPO "${SWIFT_DARWIN_XCRUN_TOOLCHAIN}" lipo)
+    find_toolchain_tool(CMAKE_LIPO "${SWIFT_DARWIN_XCRUN_TOOLCHAIN}" lipo)
   endif()
 endif()
 

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -147,7 +147,7 @@ if(NOT SWIFT_LIBRARY_PATH)
 endif()
 
 # If the CMAKE_C_COMPILER is already clang, don't find it again,
-# thus allowing the --host-cc build-script argument to work here.
+# thus allowing the --cmake-c-compiler build-script argument to work here.
 get_filename_component(c_compiler ${CMAKE_C_COMPILER} NAME)
 
 if(${c_compiler} STREQUAL "clang")

--- a/benchmark/cmake/modules/AddSwiftBenchmarkSuite.cmake
+++ b/benchmark/cmake/modules/AddSwiftBenchmarkSuite.cmake
@@ -349,7 +349,7 @@ function (swift_benchmark_compile_archopts)
         ${objcfile}
         "-o" "${OUTPUT_EXEC}"
       COMMAND
-        "codesign" "-f" "-s" "-" "${OUTPUT_EXEC}")
+        ${CMAKE_CODESIGN} "-f" "-s" "-" "${OUTPUT_EXEC}")
   set(new_output_exec "${OUTPUT_EXEC}" PARENT_SCOPE)
 endfunction()
 

--- a/benchmark/scripts/generate_harness/CMakeLists.txt_template
+++ b/benchmark/scripts/generate_harness/CMakeLists.txt_template
@@ -68,7 +68,7 @@ if(NOT SWIFT_LIBRARY_PATH)
 endif()
 
 # If the CMAKE_C_COMPILER is already clang, don't find it again,
-# thus allowing the --host-cc build-script argument to work here.
+# thus allowing the --cmake-c-compiler build-script argument to work here.
 get_filename_component(c_compiler ${CMAKE_C_COMPILER} NAME)
 
 if(${c_compiler} STREQUAL "clang")

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -465,22 +465,22 @@ function(_add_swift_lipo_target)
   is_darwin_based_sdk("${LIPO_SDK}" IS_DARWIN)
   if(IS_DARWIN)
     if(LIPO_CODESIGN)
-      set(codesign_command COMMAND "codesign" "-f" "-s" "-" "${LIPO_OUTPUT}")
+      set(codesign_command COMMAND "${CMAKE_CODESIGN}" "-f" "-s" "-" "${LIPO_OUTPUT}")
     endif()
     # Use lipo to create the final binary.
     add_custom_command_target(unused_var
-        COMMAND "${LIPO}" "-create" "-output" "${LIPO_OUTPUT}" ${source_binaries}
-        ${codesign_command}
-        CUSTOM_TARGET_NAME "${LIPO_TARGET}"
-        OUTPUT "${LIPO_OUTPUT}"
-        DEPENDS ${source_targets})
+      COMMAND "${CMAKE_LIPO}" "-create" "-output" "${LIPO_OUTPUT}" ${source_binaries}
+      ${codesign_command}
+      CUSTOM_TARGET_NAME "${LIPO_TARGET}"
+      OUTPUT "${LIPO_OUTPUT}"
+      DEPENDS ${source_targets})
   else()
     # We don't know how to create fat binaries for other platforms.
     add_custom_command_target(unused_var
-        COMMAND "${CMAKE_COMMAND}" "-E" "copy" "${source_binaries}" "${LIPO_OUTPUT}"
-        CUSTOM_TARGET_NAME "${LIPO_TARGET}"
-        OUTPUT "${LIPO_OUTPUT}"
-        DEPENDS ${source_targets})
+      COMMAND "${CMAKE_COMMAND}" "-E" "copy" "${source_binaries}" "${LIPO_OUTPUT}"
+      CUSTOM_TARGET_NAME "${LIPO_TARGET}"
+      OUTPUT "${LIPO_OUTPUT}"
+      DEPENDS ${source_targets})
   endif()
 endfunction()
 

--- a/cmake/modules/SwiftHandleGybSources.cmake
+++ b/cmake/modules/SwiftHandleGybSources.cmake
@@ -41,8 +41,13 @@ function(handle_gyb_source_single dependency_out_var_name)
       ${SWIFT_GYB_FLAGS}
       ${GYB_SINGLE_FLAGS})
 
-  set(gyb_tool "${SWIFT_SOURCE_DIR}/utils/gyb")
-  set(gyb_tool_source "${gyb_tool}" "${gyb_tool}.py")
+  if(NOT "${CMAKE_GYB}" STREQUAL "")
+    set(gyb_tool "${CMAKE_GYB}")
+    set(gyb_tool_source "${gyb_tool}" "${gyb_tool}")
+  else()
+    set(gyb_tool "${SWIFT_SOURCE_DIR}/utils/gyb")
+    set(gyb_tool_source "${gyb_tool}" "${gyb_tool}.py")
+  endif()
 
   get_filename_component(dir "${GYB_SINGLE_OUTPUT}" DIRECTORY)
   get_filename_component(basename "${GYB_SINGLE_OUTPUT}" NAME)

--- a/utils/build-script
+++ b/utils/build-script
@@ -601,8 +601,6 @@ class BuildScriptInvocation(object):
             "--host-target", args.host_target,
             "--stdlib-deployment-targets",
             " ".join(args.stdlib_deployment_targets),
-            "--host-cc", toolchain.cc,
-            "--host-cxx", toolchain.cxx,
             "--darwin-xcrun-toolchain", args.darwin_xcrun_toolchain,
             "--darwin-deployment-version-osx=%s" % (
                 args.darwin_deployment_version_osx),
@@ -613,6 +611,8 @@ class BuildScriptInvocation(object):
             "--darwin-deployment-version-watchos=%s" % (
                 args.darwin_deployment_version_watchos),
             "--cmake", toolchain.cmake,
+            "--cmake-c-compiler", toolchain.cc,
+            "--cmake-cxx-compiler", toolchain.cxx,
             "--cmark-build-type", args.cmark_build_variant,
             "--llvm-build-type", args.llvm_build_variant,
             "--swift-build-type", args.swift_build_variant,
@@ -682,6 +682,14 @@ class BuildScriptInvocation(object):
                 "--distcc",
                 "--distcc-pump=%s" % toolchain.distcc_pump
             ]
+        if args.swiftenv_path:
+            impl_args += [ "--swiftenv-path=%s" % args.swiftenv_path]
+        if args.swiftenv_recreate:
+            impl_args += [ "--swiftenv-recreate"]
+        if args.swiftenv_script:
+            impl_args += [ "--swiftenv-script=%s" % args.swiftenv_script]
+        if args.swiftenv_make:
+            impl_args += [ "--swiftenv-make=%s" % args.swiftenv_make]
         if args.enable_asan:
             impl_args += ["--enable-asan"]
         if args.enable_ubsan:
@@ -819,12 +827,6 @@ class BuildScriptInvocation(object):
                 "--toolchain-prefix",
                 swift_build_support.targets.darwin_toolchain_prefix(
                     args.install_prefix),
-                "--host-lipo", toolchain.lipo,
-            ]
-
-        if toolchain.libtool is not None:
-            impl_args += [
-                "--host-libtool", toolchain.libtool,
             ]
 
         # If we have extra_swift_args, combine all of them together and then
@@ -1044,6 +1046,47 @@ def clean_delay():
     print('\b\b\b\bnow.')
 
 
+def handle_swiftenv_args(args):
+    # Find clang in swiftenv if present
+    if args.swiftenv_path is None:
+        if args.swiftenv_recreate:
+            print(sys.argv[0], "error: using a swiftenv_recreate to make a swiftenv requires a destination in --swiftenv-path=", file=sys.stderr)
+            sys.exit(2) # 2 is the same as `argparse` error exit code.
+
+        if args.swiftenv_script is not None:
+            print(sys.argv[0], "error: using a swiftenv_script to make a swiftenv requires a destination in --swiftenv-path=", file=sys.stderr)
+            sys.exit(2) # 2 is the same as `argparse` error exit code.
+
+        if args.swiftenv_make is not None:
+            print(sys.argv[0], "error: using a swiftenv_make to make a swiftenv requires a destination in --swiftenv-path=", file=sys.stderr)
+            sys.exit(2) # 2 is the same as `argparse` error exit code.
+
+    if args.swiftenv_path is not None:
+        # mkdir the swiftenv_path
+        if not os.path.exists(args.swiftenv_path):
+            os.makedirs(args.swiftenv_path)
+
+        # Only use swiftenv_make/swiftenv_script if one is provided
+        # utils/swiftenv-make is default
+        if args.swiftenv_make is None:
+            args.swiftenv_make = os.path.join(
+                SWIFT_SOURCE_ROOT, "swift", "utils", "swiftenv-make")
+        else:
+            args.swiftenv_make = os.path.abspath(args.swiftenv_make)
+
+        # utils/swiftenv-script is default
+        if args.swiftenv_script is None:
+            args.swiftenv_script = os.path.join(
+                SWIFT_SOURCE_ROOT, "swift", "utils", "swiftenv-script")
+        else:
+            args.swiftenv_script = os.path.abspath(args.swiftenv_script)
+
+        print("args.swiftenv_path", args.swiftenv_path)
+        print("args.swiftenv_recreate", args.swiftenv_recreate)
+        print("args.swiftenv_make", args.swiftenv_make)
+        print("args.swiftenv_script", args.swiftenv_script)
+
+
 # Main entry point for the preset mode.
 def main_preset():
     parser = argparse.ArgumentParser(
@@ -1070,6 +1113,19 @@ def main_preset():
         "--show-presets",
         help="list all presets and exit",
         action=arguments.action.optional_bool)
+    parser.add_argument(
+        "--swiftenv-path",
+        help="the absolute path to a directory containing replacement compiler commands")
+    parser.add_argument(
+        "--swiftenv-recreate",
+        help="a flag that, when present, will recreate the swiftenv",
+        action=arguments.action.optional_bool)
+    parser.add_argument(
+        "--swiftenv-script",
+        help="the absolute path to a script that takes the place of toolchain commands, default uses utils/swiftenv-script")
+    parser.add_argument(
+        "--swiftenv-make",
+        help="the absolute path to a script that will set up a swiftenv, default uses utils/swiftenv-make")
     parser.add_argument(
         "--distcc",
         help="use distcc",
@@ -1124,6 +1180,17 @@ def main_preset():
         build_script_args += ["--distcc"]
     if args.build_jobs:
         build_script_args += ["--jobs", str(args.build_jobs)]
+
+    handle_swiftenv_args(args)
+
+    if args.swiftenv_path is not None:
+        build_script_args += ["--swiftenv-path", str(args.swiftenv_path)]
+    if args.swiftenv_recreate:
+        build_script_args += ["--swiftenv-recreate"]
+    if args.swiftenv_make is not None:
+        build_script_args += ["--swiftenv-make", str(args.swiftenv_make)]
+    if args.swiftenv_script is not None:
+        build_script_args += ["--swiftenv-script", str(args.swiftenv_script)]
 
     diagnostics.note(
         "using preset '" + args.preset + "', which expands to \n\n" +
@@ -1981,27 +2048,31 @@ iterations with -O",
         metavar="PATH")
 
     parser.add_argument(
-        "--host-cc",
+        "--cmake-c-compiler",
         help="the absolute path to CC, the 'clang' compiler for the host "
              "platform. Default is auto detected.",
         type=arguments.type.executable,
         metavar="PATH")
     parser.add_argument(
-        "--host-cxx",
+        "--cmake-cxx-compiler",
         help="the absolute path to CXX, the 'clang++' compiler for the host "
              "platform. Default is auto detected.",
         type=arguments.type.executable,
         metavar="PATH")
     parser.add_argument(
-        "--host-lipo",
-        help="the absolute path to lipo. Default is auto detected.",
-        type=arguments.type.executable,
-        metavar="PATH")
+        "--swiftenv-path",
+        help="the absolute path to a directory containing replacement compiler commands")
     parser.add_argument(
-        "--host-libtool",
-        help="the absolute path to libtool. Default is auto detected.",
-        type=arguments.type.executable,
-        metavar="PATH")
+        "--swiftenv-recreate",
+        help="a flag that, when present, will recreate the swiftenv",
+        default="false",
+        action=arguments.action.optional_bool)
+    parser.add_argument(
+        "--swiftenv-script",
+        help="the absolute path to a script that takes the place of toolchain commands")
+    parser.add_argument(
+        "--swiftenv-make",
+        help="the absolute path to a script that will set up a swiftenv, default uses utils/swiftenv-make")
     parser.add_argument(
         "--distcc",
         help="use distcc in pump mode",
@@ -2173,14 +2244,22 @@ iterations with -O",
     # Prepare and validate toolchain
     toolchain = host_toolchain(xcrun_toolchain=args.darwin_xcrun_toolchain)
 
-    if args.host_cc is not None:
-        toolchain.cc = args.host_cc
-    if args.host_cxx is not None:
-        toolchain.cxx = args.host_cxx
-    if args.host_lipo is not None:
-        toolchain.lipo = args.host_lipo
-    if args.host_libtool is not None:
-        toolchain.libtool = args.host_libtool
+    # Abstracted swiftenv_args for --preset and not
+    handle_swiftenv_args(args)
+
+    # Let args.cmake_c_compiler win over swiftenv's cc/cxx
+    if args.cmake_c_compiler is None and args.swiftenv_path is not None:
+        if os.path.exists(args.swiftenv_path + "/clang"):
+            args.cmake_c_compiler = args.swiftenv_path + "/clang"
+    if args.cmake_cxx_compiler is None and args.swiftenv_path is not None:
+        if os.path.exists(args.swiftenv_path + "/clang++"):
+            args.cmake_cxx_compiler = args.swiftenv_path + "/clang++"
+
+    if args.cmake_c_compiler is not None:
+        toolchain.cc = args.cmake_c_compiler
+    if args.cmake_cxx_compiler is not None:
+        toolchain.cxx = args.cmake_cxx_compiler
+
     if args.cmake is not None:
         toolchain.cmake = args.cmake
 

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -45,16 +45,28 @@ KNOWN_SETTINGS=(
     dry-run                     ""               "print the commands that would be executed, but do not execute them"
     build-args                  ""               "arguments to the build tool; defaults to -j8 when CMake generator is \"Unix Makefiles\""
     build-dir                   ""               "out-of-tree build directory; default is in-tree. **This argument is required**"
-    host-cc                     ""               "the path to CC, the 'clang' compiler for the host platform. **This argument is required**"
-    host-cxx                    ""               "the path to CXX, the 'clang++' compiler for the host platform. **This argument is required**"
-    host-lipo                   ""               "the path to lipo for creating universal binaries on Darwin"
-    host-libtool                ""               "the path to libtool"
+    cmake-c-compiler            ""               "the path to CC, the 'clang' compiler for the host platform. **This argument is required**"
+    cmake-cxx-compiler          ""               "the path to CXX, the 'clang++' compiler for the host platform. **This argument is required**"
+    cmake-lipo                  ""               "the path to lipo for creating universal binaries on Darwin"
+    cmake-libtool               ""               "the path to libtool, auto-detected but can be overridden"
+    cmake-linker                ""               "the path to ld, auto-detected but can be overridden"
+    cmake-ar                    ""               "the path to ar, auto-detected but can be overridden"
+    cmake-nm                    ""               "the path to nm, auto-detected but can be overridden"
+    cmake-objdump               ""               "the path to objdump, auto-detected but can be overridden"
+    cmake-ranlib                ""               "the path to ranlib, auto-detected but can be overridden"
+    cmake-strip                 ""               "the path to strip, auto-detected but can be overridden"
+    cmake-dsymutil              ""               "the path to dsymutil, auto-detected but can be overridden"
+    cmake-codesign              ""               "the path to codesign, auto-detected but can be overridden"
+    swiftenv-path               ""               "a path containing the above host tools which is searched unless the specific tool path is set"
+    swiftenv-recreate           ""               "a flag that, when present, will recreate the swiftenv"
+    swiftenv-make               ""               "a path to a script that will make a swiftenv in swiftenv-path"
+    swiftenv-script             ""               "a path to a script that intercepts host tools"
     darwin-xcrun-toolchain      "default"        "the name of the toolchain to use on Darwin"
     ninja-bin                   ""               "the path to Ninja tool"
     cmark-build-type            "Debug"          "the CMake build variant for CommonMark (Debug, RelWithDebInfo, Release, MinSizeRel).  Defaults to Debug."
     lldb-extra-cmake-args       ""               "extra command line args to pass to lldb cmake"
     lldb-extra-xcodebuild-args  ""               "extra command line args to pass to lldb xcodebuild"
-    lldb-test-cc                ""               "CC to use for building LLDB testsuite test inferiors.  Defaults to just-built, in-tree clang.  If set to 'host-toolchain', sets it to same as host-cc."
+    lldb-test-cc                ""               "CC to use for building LLDB testsuite test inferiors.  Defaults to just-built, in-tree clang.  If set to 'host-toolchain', sets it to same as cmake-cc."
     lldb-test-with-curses       ""               "run test lldb test runner using curses terminal control"
     lldb-test-swift-only        ""               "when running lldb tests, only include Swift-specific tests"
     lldb-no-debugserver         ""               "delete debugserver after building it, and don't try to codesign it"
@@ -978,22 +990,218 @@ if [ ! -e "${WORKSPACE}" ] ; then
     exit 1
 fi
 
-# FIXME: HOST_CC and CMAKE are set, and their presence is validated by,
-#        utils/build-script. These checks are redundant, but must remain until
-#        build-script-impl is merged completely with utils/build-script.
-#        For additional information, see: https://bugs.swift.org/browse/SR-237
-if [ -z "${HOST_CC}" ] ; then
-    echo "Can't find clang.  Please install clang-3.5 or a later version."
-    exit 1
-fi
 if [ -z "${CMAKE}" ] ; then
     echo "Environment variable CMAKE must be specified."
     exit 1
 fi
 
-function xcrun_find_tool() {
-  xcrun --sdk macosx --toolchain "${DARWIN_XCRUN_TOOLCHAIN}" --find "$@"
+#
+# Calculate source directories for each product.
+#
+NINJA_SOURCE_DIR="${WORKSPACE}/ninja"
+SWIFT_SOURCE_DIR="${WORKSPACE}/swift"
+LLVM_SOURCE_DIR="${WORKSPACE}/llvm"
+CMARK_SOURCE_DIR="${WORKSPACE}/cmark"
+LLDB_SOURCE_DIR="${WORKSPACE}/lldb"
+LLBUILD_SOURCE_DIR="${WORKSPACE}/llbuild"
+SWIFTPM_SOURCE_DIR="${WORKSPACE}/swiftpm"
+XCTEST_SOURCE_DIR="${WORKSPACE}/swift-corelibs-xctest"
+FOUNDATION_SOURCE_DIR="${WORKSPACE}/swift-corelibs-foundation"
+LIBDISPATCH_SOURCE_DIR="${WORKSPACE}/swift-corelibs-libdispatch"
+LIBICU_SOURCE_DIR="${WORKSPACE}/icu"
+PLAYGROUNDLOGGER_SOURCE_DIR="${WORKSPACE}/swift-xcode-playground-support/PlaygroundLogger"
+PLAYGROUNDSUPPORT_SOURCE_DIR="${WORKSPACE}/swift-xcode-playground-support/PlaygroundSupport"
+
+if [[ ! "${SKIP_BUILD_PLAYGROUNDLOGGER}" && ! -d ${PLAYGROUNDLOGGER_SOURCE_DIR} ]]; then
+    echo "Couldn't find PlaygroundLogger source directory."
+    exit 1
+fi
+
+if [[ ! "${SKIP_BUILD_PLAYGROUNDSUPPORT}" && ! -d ${PLAYGROUNDSUPPORT_SOURCE_DIR} ]]; then
+    echo "Couldn't find PlaygroundSupport source directory."
+    exit 1
+fi
+
+function make_relative_symlink() {
+    local SOURCE=$1
+    local TARGET=$2
+    local TARGET_DIR=$(dirname $2)
+    local RELATIVE_SOURCE=$(python -c "import os.path; print(os.path.relpath(\"${SOURCE}\", \"${TARGET_DIR}\"))")
+    call ln -sf "${RELATIVE_SOURCE}" "${TARGET}"
 }
+
+# Symlink clang into the llvm tree.
+CLANG_SOURCE_DIR="${LLVM_SOURCE_DIR}/tools/clang"
+
+if [ ! -e "${WORKSPACE}/clang" ] ; then
+    # If llvm/tools/clang is already a directory, use that and skip the symlink.
+    if [ ! -d "${CLANG_SOURCE_DIR}" ] ; then
+        echo "Can't find source directory for clang (tried ${WORKSPACE}/clang and ${CLANG_SOURCE_DIR})"
+        exit 1
+    fi
+fi
+if [ ! -d "${CLANG_SOURCE_DIR}" ] ; then
+    make_relative_symlink "${WORKSPACE}/clang" "${CLANG_SOURCE_DIR}"
+fi
+
+# Symlink compiler-rt into the llvm tree, if it exists.
+COMPILER_RT_SOURCE_DIR="${LLVM_SOURCE_DIR}/projects/compiler-rt"
+if [ -e "${WORKSPACE}/compiler-rt" ] ; then
+    if [ ! -d "${COMPILER_RT_SOURCE_DIR}" ] ; then
+        make_relative_symlink "${WORKSPACE}/compiler-rt" "${COMPILER_RT_SOURCE_DIR}"
+    fi
+fi
+
+function check_swiftenv_args() {
+    if [ "${SWIFTENV_PATH}" ]; then
+        echo "SWIFTENV_PATH: ${SWIFTENV_PATH}"
+        echo "SWIFTENV_MAKE: ${SWIFTENV_MAKE}"
+        echo "SWIFTENV_SCRIPT: ${SWIFTENV_SCRIPT}"
+        echo "SWIFTENV_RECREATE: ${SWIFTENV_RECREATE}"
+    fi
+
+    if [ ! "${SWIFTENV_PATH}" ]; then
+        if [ "${SWIFTENV_RECREATE}" ]; then
+            echo "${COMMAND_NAME} error: SWIFTENV_RECREATE requires a SWIFTENV_PATH" && exit 2; fi
+        if [ "${SWIFTENV_MAKE}" ]; then
+            echo "${COMMAND_NAME} error: SWIFTENV_MAKE requires a SWIFTENV_PATH" && exit 2; fi
+        if [ "${SWIFTENV_SCRIPT}" ]; then
+            echo "${COMMAND_NAME} error: SWIFTENV_SCRIPT requires a SWIFTENV_PATH" && exit 2; fi
+    fi
+    if [ "${SWIFTENV_PATH}" ]; then
+        if [ "${SWIFTENV_SCRIPT}" ] && [ ! -f "${SWIFTENV_SCRIPT}" ]; then
+            echo "${COMMAND_NAME} error: SWIFTENV_SCRIPT not found at ${SWIFTENV_SCRIPT}" && exit 2; fi
+        if [ "${SWIFTENV_MAKE}" ] && [ ! -f "${SWIFTENV_MAKE}" ]; then
+            echo "${COMMAND_NAME} error: SWIFTENV_MAKE not found at ${SWIFTENV_MAKE}" && exit 2; fi
+    fi
+}
+
+check_swiftenv_args
+
+# If we are using a swiftenv, do this next block
+if [ "${SWIFTENV_PATH}" ]; then
+
+  if [[ ! -d "${SWIFTENV_PATH}" ]]; then
+      echo "${COMMAND_NAME}: SWIFTENV_PATH does not exist, it will be created"
+  fi
+  if [[ "${SWIFTENV_RECREATE}" ]]; then
+      echo "${COMMAND_NAME}: SWIFTENV_PATH will be recreated because SWIFTENV_RECREATE is true"
+  fi
+
+  # redo the swiftenv by deleting, mkdir, and running the SWIFTENV_MAKE script
+  if [[ ! -d "${SWIFTENV_PATH}" ]] || [[ "${SWIFTENV_RECREATE}" ]]; then
+    if [ ! -f "${SWIFTENV_MAKE}" ]; then
+      echo "${COMMAND_NAME} error: SWIFTENV_MAKE is not set."
+      exit 2
+    fi
+    if [ ! -f "${SWIFTENV_SCRIPT}" ]; then
+      echo "${COMMAND_NAME} error: SWIFTENV_SCRIPT is not set."
+      exit 2
+    fi
+
+    if [[ -d "${SWIFTENV_PATH}" ]] && [[ "${SWIFTENV_RECREATE}" ]]; then
+      echo "${COMMAND_NAME}: SWIFTENV_PATH does exists, it will be deleted and recreated"
+      call rm -rf "${SWIFTENV_PATH}"
+      echo "${COMMAND_NAME}: Calling mkdir on SWIFTENV_PATH: ${SWIFTENV_PATH}"
+      call mkdir -p "${SWIFTENV_PATH}"
+      echo "${COMMAND_NAME}: Calling \"${SWIFTENV_MAKE}\" \"${SWIFTENV_PATH}\" \"${SWIFTENV_SCRIPT}\""
+      call "${SWIFTENV_MAKE}" "${SWIFTENV_PATH}" "${SWIFTENV_SCRIPT}"
+    fi
+
+  else
+    echo "${COMMAND_NAME}: SWIFTENV_PATH exists, not recreating the SWIFTENV"
+  fi
+fi
+
+function xcrun_find_tool() {
+  if [[ ! -z "${SWIFTENV_PATH}" ]] && [[ -f "${SWIFTENV_PATH}/$1" ]]; then
+    echo "${SWIFTENV_PATH}/$1"
+  else
+    xcrun --sdk macosx --toolchain "${DARWIN_XCRUN_TOOLCHAIN}" --find "$1" 2>/dev/null
+  fi
+
+  if [[ "$?" -ne 0 ]]; then
+    >&2 echo "xcrun_find_tool: \`\`xcrun -find\`\` failed for $1"
+    exit 1
+  fi
+}
+
+UNAME=$(uname -s)
+
+# if HOST_$TOOLNAME is not set, set it with xcrun or which
+# args: uname CMAKE_VAR command-name
+function find_tool() {
+  if [[ "${SWIFTENV_PATH}" ]]; then
+    SWIFT_PATH="${SWIFTENV_PATH}:$PATH"
+  fi
+
+  if [[ -z "${!1}" ]]; then
+    if [[ "${UNAME}" == "Darwin" ]]; then
+      eval "$1=$(xcrun_find_tool "$2")"
+    elif [[ "${UNAME}" == "Linux" ]]; then
+      eval "$1=$(env PATH="${SWIFT_PATH}" which "$2")"
+    fi
+  fi
+
+  if [[ -z "${!1}" ]]; then
+    if [[ "$2" ]]; then
+      eval "$1=$2"
+    else
+      echo "Could not find ${2}"
+      exit 3
+    fi
+  fi
+  if [[ "${1}" ]]; then
+    echo "Found ${2}: ${!1}"
+  fi
+}
+
+function find_host_tools() {
+  find_tool CMAKE_C_COMPILER clang
+  find_tool CMAKE_CXX_COMPILER clang++
+
+  find_tool CMAKE_AR ar
+  find_tool CMAKE_RANLIB ranlib
+  find_tool CMAKE_DSYMUTIL dsymutil
+  find_tool CMAKE_STRIP strip
+  find_tool CMAKE_LIBTOOL libtool
+  find_tool CMAKE_PYTHON python
+  CMAKE_GYB="${SWIFT_SOURCE_DIR}/utils/gyb"
+  echo "Found gyb: ${CMAKE_GYB}"
+  find_tool CMAKE_LINKER ld
+  find_tool CMAKE_NM nm
+  find_tool CMAKE_OBJDUMP objdump
+
+  if [[ "${UNAME}" == "Darwin" ]]; then
+    find_tool CMAKE_LIPO lipo
+    find_tool CMAKE_CODESIGN codesign
+    find_tool CMAKE_INSTALL_NAME_TOOL install_name_tool
+  fi
+}
+
+find_host_tools
+
+# Sets the cmake_options for a particular project, e.g. LLVM or Swift.
+function set_cmake_tools {
+  if [ "${CMAKE_C_COMPILER}" ]; then cmake_options=( "${cmake_options[@]}" -DCMAKE_C_COMPILER:PATH="${CMAKE_C_COMPILER}"); fi
+  if [ "${CMAKE_CXX_COMPILER}" ]; then cmake_options=( "${cmake_options[@]}" -DCMAKE_CXX_COMPILER:PATH="${CMAKE_CXX_COMPILER}"); fi
+  if [ "${CMAKE_AR}" ]; then cmake_options=( "${cmake_options[@]}" -DCMAKE_AR:PATH="${CMAKE_AR}"); fi
+  if [ "${CMAKE_RANLIB}" ]; then cmake_options=( "${cmake_options[@]}" -DCMAKE_RANLIB:PATH="${CMAKE_RANLIB}"); fi
+  if [ "${CMAKE_LIPO}" ]; then cmake_options=( "${cmake_options[@]}" -DCMAKE_LIPO:PATH="${CMAKE_LIPO}"); fi
+  if [ "${CMAKE_INSTALL_NAME_TOOL}" ]; then cmake_options=( "${cmake_options[@]}" -DCMAKE_INSTALL_NAME_TOOL:PATH="${CMAKE_INSTALL_NAME_TOOL}"); fi
+  if [ "${CMAKE_CODESIGN}" ]; then cmake_options=( "${cmake_options[@]}" -DCMAKE_CODESIGN:PATH="${CMAKE_CODESIGN}"); fi
+  if [ "${CMAKE_PYTHON}" ]; then cmake_options=( "${cmake_options[@]}" -DPYTHON_EXECUTABLE:PATH="${CMAKE_PYTHON}"); fi
+  if [ "${CMAKE_GYB}" ]; then cmake_options=( "${cmake_options[@]}" -DCMAKE_GYB:PATH="${CMAKE_GYB}"); fi
+}
+
+# FIXME: CMAKE_C_COMPILER and CMAKE are set, and their presence is validated by,
+#        utils/build-script. These checks are redundant, but must remain until
+#        build-script-impl is merged completely with utils/build-script.
+#        For additional information, see: https://bugs.swift.org/browse/SR-237
+if [ -z "${CMAKE_C_COMPILER}" ]; then
+    echo "Can't find clang.  Please install clang-3.5 or a later version."
+    exit 1
+fi
 
 function not() {
     if [[ ! "$1" ]] ; then
@@ -1030,14 +1238,6 @@ function copy_swift_stdlib_tool_substitute() {
         echo "--- Copy swift-stdlib-tool ---"
         call cp "${SWIFT_SOURCE_DIR}/utils/swift-stdlib-tool-substitute" "$1"
     fi
-}
-
-function make_relative_symlink() {
-    local SOURCE=$1
-    local TARGET=$2
-    local TARGET_DIR=$(dirname $2)
-    local RELATIVE_SOURCE=$(python -c "import os.path; print(os.path.relpath(\"${SOURCE}\", \"${TARGET_DIR}\"))")
-    call ln -sf "${RELATIVE_SOURCE}" "${TARGET}"
 }
 
 # Sanitize the list of cross-compilation targets.
@@ -1193,54 +1393,6 @@ function should_build_stdlib_target() {
         fi
     fi
 }
-
-#
-# Calculate source directories for each product.
-#
-NINJA_SOURCE_DIR="${WORKSPACE}/ninja"
-SWIFT_SOURCE_DIR="${WORKSPACE}/swift"
-LLVM_SOURCE_DIR="${WORKSPACE}/llvm"
-CMARK_SOURCE_DIR="${WORKSPACE}/cmark"
-LLDB_SOURCE_DIR="${WORKSPACE}/lldb"
-LLBUILD_SOURCE_DIR="${WORKSPACE}/llbuild"
-SWIFTPM_SOURCE_DIR="${WORKSPACE}/swiftpm"
-XCTEST_SOURCE_DIR="${WORKSPACE}/swift-corelibs-xctest"
-FOUNDATION_SOURCE_DIR="${WORKSPACE}/swift-corelibs-foundation"
-LIBDISPATCH_SOURCE_DIR="${WORKSPACE}/swift-corelibs-libdispatch"
-LIBICU_SOURCE_DIR="${WORKSPACE}/icu"
-PLAYGROUNDLOGGER_SOURCE_DIR="${WORKSPACE}/swift-xcode-playground-support/PlaygroundLogger"
-PLAYGROUNDSUPPORT_SOURCE_DIR="${WORKSPACE}/swift-xcode-playground-support/PlaygroundSupport"
-
-if [[ ! "${SKIP_BUILD_PLAYGROUNDLOGGER}" && ! -d ${PLAYGROUNDLOGGER_SOURCE_DIR} ]]; then
-    echo "Couldn't find PlaygroundLogger source directory."
-    exit 1
-fi
-
-if [[ ! "${SKIP_BUILD_PLAYGROUNDSUPPORT}" && ! -d ${PLAYGROUNDSUPPORT_SOURCE_DIR} ]]; then
-    echo "Couldn't find PlaygroundSupport source directory."
-    exit 1
-fi
-
-# Symlink clang into the llvm tree.
-CLANG_SOURCE_DIR="${LLVM_SOURCE_DIR}/tools/clang"
-if [ ! -e "${WORKSPACE}/clang" ] ; then
-    # If llvm/tools/clang is already a directory, use that and skip the symlink.
-    if [ ! -d "${CLANG_SOURCE_DIR}" ] ; then
-        echo "Can't find source directory for clang (tried ${WORKSPACE}/clang and ${CLANG_SOURCE_DIR})"
-        exit 1
-    fi
-fi
-if [ ! -d "${CLANG_SOURCE_DIR}" ] ; then
-    make_relative_symlink "${WORKSPACE}/clang" "${CLANG_SOURCE_DIR}"
-fi
-
-# Symlink compiler-rt into the llvm tree, if it exists.
-COMPILER_RT_SOURCE_DIR="${LLVM_SOURCE_DIR}/projects/compiler-rt"
-if [ -e "${WORKSPACE}/compiler-rt" ] ; then
-    if [ ! -d "${COMPILER_RT_SOURCE_DIR}" ] ; then
-        make_relative_symlink "${WORKSPACE}/compiler-rt" "${COMPILER_RT_SOURCE_DIR}"
-    fi
-fi
 
 PRODUCTS=(cmark llvm)
 if [[ ! "${SKIP_BUILD_LIBICU}" ]] ; then
@@ -1499,16 +1651,17 @@ eval EXTRA_CMAKE_OPTIONS=(${EXTRA_CMAKE_OPTIONS})
 eval BUILD_ARGS=(${BUILD_ARGS})
 
 if [[ -n "${DISTCC}" ]]; then
-    if [[ "$(uname -s)" == "Darwin" ]] ; then
+    if [[ "${UNAME}" == "Darwin" ]] ; then
         # These are normally deduced by CMake, but when the compiler is set to
         # distcc which is installed elsewhere, we need to set them explicitly.
         COMMON_CMAKE_OPTIONS=(
-            "${COMMON_CMAKE_OPTIONS[@]}" "-DCMAKE_AR=$(xcrun_find_tool ar)"
-            "-DCMAKE_LINKER=$(xcrun_find_tool ld)"
-            "-DCMAKE_NM=$(xcrun_find_tool nm)"
-            "-DCMAKE_OBJDUMP=$(xcrun_find_tool objdump)"
-            "-DCMAKE_RANLIB=$(xcrun_find_tool ranlib)"
-            "-DCMAKE_STRIP=$(xcrun_find_tool strip)"
+            "${COMMON_CMAKE_OPTIONS[@]}"
+            "-DCMAKE_AR=${CMAKE_AR}"
+            "-DCMAKE_LINKER=${CMAKE_LD}"
+            "-DCMAKE_NM=${CMAKE_NM}"
+            "-DCMAKE_OBJDUMP=${CMAKE_OBJDUMP}"
+            "-DCMAKE_RANLIB=${CMAKE_RANLIB}"
+            "-DCMAKE_STRIP=${CMAKE_STRIP}"
         )
     fi
 fi
@@ -1830,9 +1983,10 @@ for host in "${ALL_HOSTS[@]}"; do
         if [[ "${CROSS_COMPILE_WITH_HOST_TOOLS}" ]]; then
             # Optionally use the freshly-built host copy of clang to build
             # for foreign hosts.
+            LLVM_NATIVE_BUILD=$(build_directory "${LOCAL_HOST}" llvm)
             common_cmake_options_host+=(
-                -DCMAKE_C_COMPILER="$(build_directory ${LOCAL_HOST} llvm)/bin/clang"
-                -DCMAKE_CXX_COMPILER="$(build_directory ${LOCAL_HOST} llvm)/bin/clang++"
+                -DCMAKE_C_COMPILER="$LLVM_NATIVE_BUILD/bin/clang"
+                -DCMAKE_CXX_COMPILER="$LLVM_NATIVE_BUILD/bin/clang++"
             )
         fi
 
@@ -1858,7 +2012,7 @@ for host in "${ALL_HOSTS[@]}"; do
         )
     fi
 
-    if [[ "${ENABLE_ASAN}" || "$(uname -s)" == "Linux" ]] ; then
+    if [[ "${ENABLE_ASAN}" || "${UNAME}" == "Linux" ]] ; then
         swift_cmake_options=(
             "${swift_cmake_options[@]}"
             -DSWIFT_SOURCEKIT_USE_INPROC_LIBRARY:BOOL=TRUE
@@ -1938,6 +2092,7 @@ for host in "${ALL_HOSTS[@]}"; do
 
         case ${product} in
             cmark)
+                set_cmake_tools
                 cmake_options=(
                   "${cmake_options[@]}"
                   -DCMAKE_BUILD_TYPE:STRING="${CMARK_BUILD_TYPE}"
@@ -1957,10 +2112,10 @@ for host in "${ALL_HOSTS[@]}"; do
                     build_targets=(llvm-tblgen clang-headers)
                 fi
 
-                if [ "${HOST_LIBTOOL}" ] ; then
+                if [ "${CMAKE_LIBTOOL}" ] ; then
                     cmake_options=(
                         "${cmake_options[@]}"
-                        -DCMAKE_LIBTOOL:PATH="${HOST_LIBTOOL}"
+                        -DCMAKE_LIBTOOL:PATH="${CMAKE_LIBTOOL}"
                     )
                 fi
 
@@ -2013,12 +2168,26 @@ for host in "${ALL_HOSTS[@]}"; do
                 fi
 
                 if [[ $(is_cross_tools_host ${host}) ]] ; then
+                    # Find these tools from the LLVM_NATIVE_BUILD directory
+                    LLVM_NATIVE_BUILD=$(build_directory "${LOCAL_HOST}" llvm)
+                    CMAKE_C_COMPILER="${LLVM_NATIVE_BUILD}/bin/clang"
+                    CMAKE_CXX_COMPILER="${LLVM_NATIVE_BUILD}/bin/clang++"
+                    CMAKE_LLVM_TABLEGEN="${LLVM_NATIVE_BUILD}/bin/llvm-tblgen"
+                    CMAKE_CLANG_TABLEGEN="${LLVM_NATIVE_BUILD}/bin/clang-tblgen"
+                    echo "Cross compiling with CMAKE_C_COMPILER: ${CMAKE_C_COMPILER}"
+                    echo "Cross compiling with CMAKE_CXX_COMPILER: ${CMAKE_CXX_COMPILER}"
+                    echo "Cross compiling with CMAKE_LLVM_TABLEGEN: ${CMAKE_LLVM_TABLEGEN}"
+                    echo "Cross compiling with CMAKE_CLANG_TABLEGEN: ${CMAKE_CLANG_TABLEGEN}"
+
                     cmake_options=(
                         "${cmake_options[@]}"
-                        -DLLVM_TABLEGEN=$(build_directory "${LOCAL_HOST}" llvm)/bin/llvm-tblgen
-                        -DCLANG_TABLEGEN=$(build_directory "${LOCAL_HOST}" llvm)/bin/clang-tblgen
-                        -DLLVM_NATIVE_BUILD=$(build_directory "${LOCAL_HOST}" llvm)
+                        -DLLVM_TABLEGEN="${CMAKE_LLVM_TABLEGEN}"
+                        -DCLANG_TABLEGEN="${CMAKE_CLANG_TABLEGEN}"
+                        -DLLVM_NATIVE_BUILD="${LLVM_NATIVE_BUILD}"
                     )
+
+                    # LLVM, sets CMAKE_C_COMPILER, CMAKE_CXX_COMPILER
+                    set_cmake_tools
                 fi
 
                 ;;
@@ -2098,12 +2267,19 @@ for host in "${ALL_HOSTS[@]}"; do
                     )
                 fi
 
-                if [ "${HOST_LIPO}" ] ; then
-                    cmake_options=(
-                        "${cmake_options[@]}"
-                        -DSWIFT_LIPO:PATH="${HOST_LIPO}"
-                    )
+                echo "CMAKE_C_COMPILER: ${CMAKE_C_COMPILER}"
+                echo "CMAKE_CXX_COMPILER: ${CMAKE_CXX_COMPILER}"
+                echo "CMAKE_RANLIB: ${CMAKE_RANLIB}"
+                echo "CMAKE_PYTHON: ${CMAKE_PYTHON}"
+                echo "CMAKE_GYB: ${CMAKE_GYB}"
+                if [[ "${UNAME}" == "Darwin" ]] ; then
+                    echo "CMAKE_LIPO: ${CMAKE_LIPO}"
+                    echo "CMAKE_INSTALL_NAME_TOOL: ${CMAKE_INSTALL_NAME_TOOL}"
+                    echo "CMAKE_CODESIGN: ${CMAKE_CODESIGN}"
                 fi
+
+                # Swift
+                set_cmake_tools
 
                 cmake_options=(
                     "${cmake_options[@]}"
@@ -2362,7 +2538,7 @@ for host in "${ALL_HOSTS[@]}"; do
                     LIBDISPATCH_BUILD_ARGS="--libdispatch-src-dir=${LIBDISPATCH_SOURCE_DIR} --libdispatch-build-dir=${LIBDISPATCH_BUILD_DIR}"
                 fi
                 
-                if [[ "$(uname -s)" == "Darwin" ]] ; then
+                if [[ "${UNAME}" == "Darwin" ]] ; then
                     # xcodebuild requires swift-stdlib-tool to build a Swift
                     # framework. This is normally present when building XCTest
                     # via a packaged .xctoolchain, but here we are using the
@@ -2570,8 +2746,14 @@ for host in "${ALL_HOSTS[@]}"; do
             if [[ -n "${DISTCC}" ]]; then
                 EXTRA_DISTCC_OPTIONS=("DISTCC_HOSTS=localhost,lzo,cpp")
             fi
+            if [[ "${SWIFTENV_PATH}" ]]; then
+                call echo "configure" > "${SWIFTENV_PATH}/cmake-step"
+            fi
             with_pushd "${build_dir}" \
                 call env "${EXTRA_DISTCC_OPTIONS[@]}" "${CMAKE}" "${cmake_options[@]}" "${EXTRA_CMAKE_OPTIONS[@]}" "${source_dir}"
+            if [[ "${SWIFTENV_PATH}" ]]; then
+                call rm "${SWIFTENV_PATH}/cmake-step"
+            fi
         fi
 
         # When we are building LLVM create symlinks to the c++ headers. We need
@@ -2582,8 +2764,8 @@ for host in "${ALL_HOSTS[@]}"; do
         # swift. So we need to do configure's work here.
         if [[ "${product}" == "llvm" ]]; then
             # Find the location of the c++ header dir.
-            if [[ "$(uname -s)" == "Darwin" ]] ; then
-              HOST_CXX_DIR=$(dirname ${HOST_CXX})
+            if [[ "${UNAME}" == "Darwin" ]] ; then
+              HOST_CXX_DIR=$(dirname ${CMAKE_CXX_COMPILER})
               HOST_CXX_HEADERS_DIR="$HOST_CXX_DIR/../../usr/include/c++"
             else # Linux
               HOST_CXX_HEADERS_DIR="/usr/include/c++"
@@ -2684,7 +2866,7 @@ for host in "${ALL_HOSTS[@]}"; do
                 lldb_build_dir=$(build_directory ${host} lldb)
 
                 # Run the gtests.
-                if [[ "$(uname -s)" == "Darwin" ]] ; then
+                if [[ "${UNAME}" == "Darwin" ]] ; then
                     set_lldb_xcodebuild_options
                     # Run the LLDB unittests (gtests).
                     with_pushd ${LLDB_SOURCE_DIR} \
@@ -2702,7 +2884,7 @@ for host in "${ALL_HOSTS[@]}"; do
 
                 swift_build_dir=$(build_directory ${host} swift)
                 # Setup lldb executable path
-                if [[ "$(uname -s)" == "Darwin" ]] ; then
+                if [[ "${UNAME}" == "Darwin" ]] ; then
                     lldb_executable="${lldb_build_dir}"/${LLDB_BUILD_MODE}/lldb
                 else
                     lldb_executable="${lldb_build_dir}"/bin/lldb
@@ -2723,7 +2905,7 @@ for host in "${ALL_HOSTS[@]}"; do
                                        -O--xpass=success \
                                        -O--xfail=success"
                     # Setup the xUnit results formatter.
-                    if [[ "$(uname -s)" != "Darwin" ]] ; then
+                    if [[ "${UNAME}" != "Darwin" ]] ; then
                         # On non-Darwin, we ignore skipped tests entirely
                         # so that they don't pollute our xUnit results with
                         # non-actionable content.
@@ -2740,8 +2922,8 @@ for host in "${ALL_HOSTS[@]}"; do
 
                 # figure out which C/C++ compiler we should use for building test inferiors.
                 if [[ "${LLDB_TEST_CC}" == "host-toolchain" ]]; then
-                    # Use the host toolchain: i.e. the toolchain specified by HOST_CC
-                    LLDB_DOTEST_CC_OPTS="-C ${HOST_CC}"
+                    # Use the host toolchain: i.e. the toolchain specified by CMAKE_C_COMPILER
+                    LLDB_DOTEST_CC_OPTS="-C ${CMAKE_C_COMPILER}"
                 elif [[ -n "${LLDB_TEST_CC}" ]]; then
                     # Use exactly the compiler path specified by the user.
                     LLDB_DOTEST_CC_OPTS="-C ${LLDB_TEST_CC}"
@@ -3135,7 +3317,7 @@ for host in "${ALL_HOSTS[@]}"; do
                 # Note that installing directly to /usr/lib/swift usually
                 # requires root permissions.
                 set -x
-                case "$(uname -s)" in
+                case "${UNAME}" in
                     Linux)
                         PLAYGROUNDLOGGER_INSTALL_DIR="$(get_host_install_destdir ${host})/$(get_host_install_prefix ${host})/lib/swift/linux"
                         mkdir -p "${PLAYGROUNDLOGGER_INSTALL_DIR}"
@@ -3162,7 +3344,7 @@ for host in "${ALL_HOSTS[@]}"; do
                 if [[ -z "${INSTALL_PLAYGROUNDSUPPORT}" ]] ; then
                     continue
                 fi
-                case "$(uname -s)" in
+                case "${UNAME}" in
                     Linux)
                         ;;
                     FreeBSD)
@@ -3218,13 +3400,13 @@ for host in "${ALL_HOSTS[@]}"; do
                grep -v swift-stdlib-tool | \
                grep -v crashlog.py | \
                grep -v symbolication.py | \
-               xargs -n 1 -P ${BUILD_JOBS} $(xcrun_find_tool dsymutil))
+               xargs -n 1 -P ${BUILD_JOBS} ${CMAKE_DSYMUTIL})
 
             # Strip executables, shared libraries and static libraries in
             # `host_install_destdir`.
             find "${host_install_destdir}${TOOLCHAIN_PREFIX}/" \
               '(' -perm -0111 -or -name "*.a" ')' -type f -print | \
-              xargs -n 1 -P ${BUILD_JOBS} $(xcrun_find_tool strip) -S
+              xargs -n 1 -P ${BUILD_JOBS} ${CMAKE_STRIP} -S
 
             { set +x; } 2>/dev/null
         fi
@@ -3310,7 +3492,7 @@ function build_and_test_installable_package() {
               call tar -c -z -f "${package_for_host}" "${TOOLCHAIN_PREFIX/#\/}"
         else
             # tar on OS X doesn't support --owner/--group.
-            if [[ "$(uname -s)" == "Darwin" ]] ; then
+            if [[ "${UNAME}" == "Darwin" ]] ; then
                 with_pushd "${host_install_destdir}" \
                     tar -c -z -f "${package_for_host}" "${host_install_prefix/#\/}"
             else
@@ -3371,13 +3553,7 @@ if [[ ${#LIPO_SRC_DIRS[@]} -gt 0 ]]; then
     
     echo "--- Merging and running lipo ---"
     
-    # Allow passing lipo with --host-lipo
-    if [[ -z "${HOST_LIPO}" ]] ; then
-        LIPO_PATH=$(xcrun_find_tool lipo)
-    else
-        LIPO_PATH="${HOST_LIPO}"
-    fi
-    call "${SWIFT_SOURCE_DIR}"/utils/recursive-lipo --lipo=${LIPO_PATH} --copy-subdirs="$(get_host_install_prefix ${host})lib/swift $(get_host_install_prefix ${host})lib/swift_static" --destination="$(get_host_install_destdir ${mergedHost})" ${LIPO_SRC_DIRS[@]}
+    call "${SWIFT_SOURCE_DIR}"/utils/recursive-lipo --lipo=${CMAKE_LIPO} --copy-subdirs="$(get_host_install_prefix ${host})lib/swift $(get_host_install_prefix ${host})lib/swift_static" --destination="$(get_host_install_destdir ${mergedHost})" ${LIPO_SRC_DIRS[@]}
 
     # Build and test the lipo-ed package.
     build_and_test_installable_package ${mergedHost}

--- a/utils/find-overlay-dependencies.sh
+++ b/utils/find-overlay-dependencies.sh
@@ -66,6 +66,7 @@ echo $1
 for sdk in ${(k)SDKS}; do
   arch=$SDKS[$sdk]
   printf "%s:\n\t" "$sdk"
+  echo "\"@import $1;\" | xcrun -sdk $sdk clang -arch $arch -x objective-c - -M -fmodules 2>/dev/null"
   deps=$(echo "@import $1;" | xcrun -sdk $sdk clang -arch $arch -x objective-c - -M -fmodules 2>/dev/null)
   if [[ $? != 0 ]]; then
     # Clear the cmake file of this unsupported platform and loop

--- a/utils/swift_build_support/swift_build_support/toolchain.py
+++ b/utils/swift_build_support/swift_build_support/toolchain.py
@@ -58,8 +58,6 @@ _register("distcc", "distcc")
 _register("distcc_pump", "distcc-pump", "pump")
 _register("llvm_profdata", "llvm-profdata")
 _register("llvm_cov", "llvm-cov")
-_register("lipo", "lipo")
-_register("libtool", "libtool")
 
 
 class Darwin(Toolchain):

--- a/utils/swift_build_support/tests/test_cmake.py
+++ b/utils/swift_build_support/tests/test_cmake.py
@@ -28,8 +28,8 @@ class CMakeTestCase(unittest.TestCase):
     def default_args(self):
         """Return new args object with default values
         """
-        return Namespace(host_cc="/path/to/clang",
-                         host_cxx="/path/to/clang++",
+        return Namespace(cmake_c_compiler="/path/to/clang",
+                         cmake_cxx_compiler="/path/to/clang++",
                          enable_asan=False,
                          enable_ubsan=False,
                          enable_tsan=False,
@@ -54,8 +54,8 @@ class CMakeTestCase(unittest.TestCase):
         """Return new CMake object initialized with given args
         """
         toolchain = host_toolchain()
-        toolchain.cc = args.host_cc
-        toolchain.cxx = args.host_cxx
+        toolchain.cc = args.cmake_c_compiler
+        toolchain.cxx = args.cmake_cxx_compiler
         if args.distcc:
             toolchain.distcc = self.mock_distcc_path()
         toolchain.ninja = self.which_ninja(args)

--- a/utils/swiftenv-make
+++ b/utils/swiftenv-make
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -o pipefail
+set -e
+function check_usage { if [[ $# -ne 2 ]]; then echo "usage: $0 directory script"; exit 1; fi; }
+function dir_name { echo "${1%/*}"; }
+function file_name { echo "${1##*/}"; }
+function absolute_path { if [[ "$1" == /* ]]; then echo "$1"; else local name; name=$(file_name "$1"); echo "$PWD/${name}"; fi } # force to start with /
+function canonical_path { (pushd "$(dirname "$1")" > /dev/null 2>&1; absolute_path "$1") }
+function write_shim {
+    local dir="$1"
+    local shim_path="$dir/shim"
+    local script_path="$dir/script"
+    cat <<EOF > "$shim_path"
+#!/bin/bash -e
+echo "\$0" "\$@" >> "${dir}/log"
+${script_path} "\$0" "\$@"; exit 0
+#-- Commands are copy/paste runnable.
+EOF
+    chmod a+x "$shim_path"
+}
+function make_links {
+    local cmds=(ar clang clang++ codesign dsymutil gyb install_name_tool libtool ld lipo nm objdump python ranlib strip)
+    for cmd in "${cmds[@]}"
+        do ln -sf "shim" "$cmd"
+    done
+}
+check_usage "$@"
+swiftenv_path=$(canonical_path "$1")
+script_path=$(canonical_path "$2")
+mkdir -p "$swiftenv_path"
+cp "$script_path" "$swiftenv_path/script"
+cd "$swiftenv_path"
+write_shim "$swiftenv_path"
+make_links

--- a/utils/swiftenv-script
+++ b/utils/swiftenv-script
@@ -1,0 +1,162 @@
+#!/bin/bash
+UNAME=$(uname)
+function dir_name { echo "${1%/*}"; }
+function file_name { echo "${1##*/}"; }
+function first { echo "${@:1:1}"; }
+function second { echo "${@:2:1}"; }
+function last { echo "${@: -1}"; }
+function absolute_path { if [[ "$1" == /* ]]; then echo "$1"; else local name; name=$(file_name "$1"); echo "$PWD/${name}"; fi } # force to start with /
+function canonical_path { (pushd "$(dirname "$1")" > /dev/null 2>&1; absolute_path "$1") }
+function split_paths { IFS=':' read -ra PATHS <<<"$PATH"; }
+function find_path_for {
+    local name=$1
+    split_paths
+    for path in "${PATHS[@]}"; do
+        local full_path="${path}/${name}"
+        if [ -f "${full_path}" ]; then echo "${full_path}"; fi
+    done
+}
+function xcrun_find { local cmd; cmd="$1"; xcrun -find "$cmd"; }
+function find_real_command {
+    local command_name; command_name=$(file_name "$1")
+    local find_util=
+    if [[ "${UNAME}" == "Linux" ]]; then
+        find_util="find_path_for"
+    else
+        find_util="xcrun_find"
+    fi
+    case "$command_name" in
+        clang|clang++|ld|swift|swiftc|lipo|ar|codesign|dsymutil|libtool|ranlib|strip|llvm-tblgen|python) "${find_util}" "${command_name}";;
+        *) echo "${command_name}";;
+    esac
+}
+function find_o_target { # last -o wins, can short circuit for faster compiles
+    local o_target=""
+    while test $# -gt 0; do
+        case "$1" in
+            -o|--output|-output) o_target="$2"; shift;;
+            -output*) o_target="${1:7}"; shift;;
+            -o*) o_target="${1:2}"; shift;;
+            *) shift;;
+        esac; done
+    echo "${o_target}"
+}
+function find_module_target {
+    while test $# -gt 0; do
+        case "$1" in
+            -emit-module-path) echo "$2"; break;;
+            *) shift;;
+        esac; done
+}
+function emit_module_p { #emit -o's arg + swiftmodule
+    while test $# -gt 0; do
+        case "$1" in
+            -emit-module) return 0;;
+            *) shift;;
+        esac; done; return 1
+}
+function find_command_targets { # sets: outfiles
+    local name="$1"
+    local args=("${@:2}")
+    case "$name" in
+        clang|clang++|ld|libtool|clang-tblgen|llvm-tblgen|lipo|gyb)
+            outfiles=("${outfiles[@]}" $(find_o_target "${args[@]}"));;
+        swift|swiftc)
+            outfiles=("${outfiles[@]}" $(find_o_target "${args[@]}"));
+            if emit_module_p "${args[@]}" ; then
+                local last_outfile; last_outfile=("${outfiles[@]: -1}")
+                outfiles=("${outfiles[@]}" "${last_outfile:0:${#last_outfile}-12}.swiftdoc"); fi
+            find_module_target "${args[@]}";;
+        ranlib) outfiles=("${outfiles[@]}" $(first "${args[@]}"));;
+        ar) outfiles=("${outfiles[@]}" $(second "${args[@]}"));;
+        codesign|dsymutil|install_name_tool|strip) outfiles=("${outfiles[@]}" $(last "${args[@]}"));;
+        line-directive|llvm-build|python);;
+        *) >&2 echo "find_command_targets: unknown command: $1";; # not fatal error
+    esac
+}
+
+function write_outfile {
+    local outfile="$1"
+    local cmd="$2"
+    local args=("${@:3}")
+    if [[ ! -f "${outfile}" ]]; then
+        cp "$shim_path" "$outfile"
+    fi
+    local full_cmd; full_cmd=$(canonical_path "${cmd}")
+    # Write command as a runnable comment
+    echo -en "# (pushd ${PWD}; { \"${full_cmd//\"/\\\"}\""  >> "$outfile"
+    for arg in "${args[@]}"; do
+        case $arg in
+            *\"*) echo -n " \"${arg//\"/\\\"}\"" >> "$outfile";;
+            *) echo -n " \"${arg}\"" >> "$outfile";; esac; done;
+    echo "; })" >> "$outfile"
+    # Write command as exploded array
+    echo -e "{\n  \"${full_cmd//\"/\\\"}\"" >> "$outfile"
+    for arg in "${args[@]}"; do
+        case $arg in
+            *\"*) echo "  \"${arg//\"/\\\"}\"" >> "$outfile";;
+            *) echo "  \"${arg}\"" >> "$outfile";; esac; done;
+    echo -e "}" >> "$outfile"
+}
+
+function main {
+    local script_args=("${@:2}")
+
+    local original_command_absolute_path; original_command_absolute_path=$(canonical_path "${original_command}")
+    local script_dir; script_dir=$(dir_name "${original_command_absolute_path}")
+    local shim_path; shim_path="${script_dir}/shim"
+
+    # see if configuring or not
+    cmake_step_path="${script_dir}/cmake-step"
+    cmake_step=""
+    if [ -f "${cmake_step_path}" ]; then cmake_step=$(<"${cmake_step_path}"); fi
+
+    local command; command="${script_args[@]:0:1}"
+    local command_args; command_args=("${script_args[@]:1}")
+    local subcommand=""
+    local subcommand_args=()
+    local command_name; command_name=$(file_name "${command}")
+
+    case "$command_name" in
+        python)
+            case "${command_args[@]:0:1}" in
+                -c|--version);; # flags aren't subcommands
+                *) subcommand="${command_args[@]:0:1}"; subcommand_args=("${command_args[@]:1}");;
+            esac
+    esac
+
+    local computed_command=""
+    local computed_args=""
+
+    if [[ "${subcommand}" != "" ]]; then
+        computed_command="${subcommand}"
+        computed_args=("${subcommand_args[@]}")
+        command_name=$(file_name "${subcommand}")
+    else
+        computed_command="${command}"
+        computed_args=("${command_args[@]}")
+    fi
+
+    local real_command=""
+    local real_args; real_args=("${computed_args[@]}")
+    case $cmake_step in
+        configure) real_command=$(find_real_command "${computed_command}");;
+        *) real_command="${computed_command}"
+    esac
+
+    # which object files to write
+    outfiles=()
+    find_command_targets "$command_name" "${real_args[@]}"
+
+    # Always run the real line-directive command
+    if [[ "${cmake_step}" == "configure" ]] || [[ "$real_command" == *line-directive ]]; then
+        exec "${real_command}" "${real_args[@]}"
+    else
+        for outfile in "${outfiles[@]}"; do
+            write_outfile "${outfile}" "${real_command}" "${real_args[@]}"
+        done
+    fi
+}
+
+original_command=$(first "${BASH_SOURCE[@]}")
+main "$0" "${@}"


### PR DESCRIPTION
This PR lets you fake a build or instrument an actual build of Swift using ``build-script`` and ``cmake``. My hope is that it will reduce the compilation time to seconds and allow faster iteration on ``cmake`` changes. This is just to test that it can pass CI tests--it needs some documentation as well.

I know there are builtin ninja and cmake tools to do things like this.