### PR TITLE
Fix GYB doctests on Windows

### DIFF
--- a/utils/gyb.py
+++ b/utils/gyb.py
@@ -1009,14 +1009,15 @@ def execute_template(ast, line_directive='', **local_bindings):
     ... THIS SHOULD NOT APPEAR IN THE OUTPUT
     ... ''')
     >>> out = execute_template(ast, line_directive='//#sourceLocation', x=1)
+    >>> out = out.replace(os.path.abspath(os.sep) + 'dummy.file', "DUMMY-FILE")
     >>> print(out, end="")
-    //#sourceLocation(file: "/dummy.file", line: 1)
+    //#sourceLocation(file: "DUMMY-FILE", line: 1)
     Nothing
-    //#sourceLocation(file: "/dummy.file", line: 4)
+    //#sourceLocation(file: "DUMMY-FILE", line: 4)
     0
-    //#sourceLocation(file: "/dummy.file", line: 4)
+    //#sourceLocation(file: "DUMMY-FILE", line: 4)
     1
-    //#sourceLocation(file: "/dummy.file", line: 4)
+    //#sourceLocation(file: "DUMMY-FILE", line: 4)
     2
 
     >>> ast = parse_template('/dummy.file', text=
@@ -1028,10 +1029,11 @@ def execute_template(ast, line_directive='', **local_bindings):
     ... ${a}
     ... ''')
     >>> out = execute_template(ast, line_directive='//#sourceLocation', x=1)
+    >>> out = out.replace(os.path.abspath(os.sep) + 'dummy.file', "DUMMY-FILE")
     >>> print(out, end="")
-    //#sourceLocation(file: "/dummy.file", line: 1)
+    //#sourceLocation(file: "DUMMY-FILE", line: 1)
     Nothing
-    //#sourceLocation(file: "/dummy.file", line: 6)
+    //#sourceLocation(file: "DUMMY-FILE", line: 6)
     [0, 1, 2]
     """
     execution_context = ExecutionContext(


### PR DESCRIPTION
These tests fail because we hardcoded unix paths.

Windows:
- `/dummy.file` -> `C:/dummy.file`

Unix:
- `/dummy.file` -> `/dummy.file`

This caused two test failures:
```
**********************************************************************
File "gyb.py", line 1012, in __main__.execute_template
Failed example:
    print(out, end="")
Expected:
    //#sourceLocation(file: "/dummy.file", line: 1)
    Nothing
    //#sourceLocation(file: "/dummy.file", line: 4)
    0
    //#sourceLocation(file: "/dummy.file", line: 4)
    1
    //#sourceLocation(file: "/dummy.file", line: 4)
    2
Got:
    //#sourceLocation(file: "C:\dummy.file", line: 1)
    Nothing
    //#sourceLocation(file: "C:\dummy.file", line: 4)
    0
    //#sourceLocation(file: "C:\dummy.file", line: 4)
    1
    //#sourceLocation(file: "C:\dummy.file", line: 4)
    2
**********************************************************************
File "gyb.py", line 1031, in __main__.execute_template
Failed example:
    print(out, end="")
Expected:
    //#sourceLocation(file: "/dummy.file", line: 1)
    Nothing
    //#sourceLocation(file: "/dummy.file", line: 6)
    [0, 1, 2]
Got:
    //#sourceLocation(file: "C:\dummy.file", line: 1)
    Nothing
    //#sourceLocation(file: "C:\dummy.file", line: 6)
    [0, 1, 2]
**********************************************************************
1 items had failures:
   2 of   6 in __main__.execute_template
***Test Failed*** 2 failures.
```