### PR TITLE
[README] Fixed Markdown for new GitHub parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 <img src="https://swift.org/assets/images/swift.svg" alt="Swift logo" height="70" >
+
 # Swift Programming Language
 
-|| **Swift** | **Package** |
-|---|---|---|
+| | **Swift** | **Package** |
+|---|:---:|:---:|
 |**macOS**         |[![Build Status](https://ci.swift.org/job/oss-swift-incremental-RA-osx/badge/icon)](https://ci.swift.org/job/oss-swift-incremental-RA-osx)|[![Build Status](https://ci.swift.org/job/oss-swift-package-osx/badge/icon)](https://ci.swift.org/job/oss-swift-package-osx)|
 |**Ubuntu 14.04** |[![Build Status](https://ci.swift.org/job/oss-swift-incremental-RA-linux-ubuntu-14_04/badge/icon)](https://ci.swift.org/job/oss-swift-incremental-RA-linux-ubuntu-14_04)|[![Build Status](https://ci.swift.org/job/oss-swift-package-linux-ubuntu-14_04/badge/icon)](https://ci.swift.org/job/oss-swift-package-linux-ubuntu-14_04)|
 |**Ubuntu 16.04** |[![Build Status](https://ci.swift.org/job/oss-swift-incremental-RA-linux-ubuntu-16_04/badge/icon)](https://ci.swift.org/job/oss-swift-incremental-RA-linux-ubuntu-16_04)|[![Build Status](https://ci.swift.org/job/oss-swift-package-linux-ubuntu-16_04/badge/icon)](https://ci.swift.org/job/oss-swift-package-linux-ubuntu-16_04)|


### PR DESCRIPTION
GitHub recently updated its Markdown parser (https://github.com/blog/2333-a-formal-spec-for-github-flavored-markdown). This PR fixes the broken table at the top of the readme.