### PR TITLE
[WIP][SourceManager] Reorganize methods for line and column

### DIFF
--- a/include/swift/Parse/Lexer.h
+++ b/include/swift/Parse/Lexer.h
@@ -338,8 +338,6 @@ public:
   static SourceLoc getLocForStartOfToken(SourceManager &SM, unsigned BufferID,
                                          unsigned Offset);
 
-  static SourceLoc getLocForStartOfToken(SourceManager &SM, SourceLoc Loc);
-
   /// Retrieve the start location of the line containing the given location.
   /// the given location.
   static SourceLoc getLocForStartOfLine(SourceManager &SM, SourceLoc Loc);

--- a/lib/AST/ASTScope.cpp
+++ b/lib/AST/ASTScope.cpp
@@ -1973,8 +1973,8 @@ void ASTScope::print(llvm::raw_ostream &out, unsigned level,
       return;
     }
 
-    auto startLineAndCol = sourceMgr.getLineAndColumn(range.Start);
-    auto endLineAndCol = sourceMgr.getLineAndColumn(range.End);
+    auto startLineAndCol = sourceMgr.getPresumedLineAndColumnForLoc(range.Start);
+    auto endLineAndCol = sourceMgr.getPresumedLineAndColumnForLoc(range.End);
 
     out << " [" << startLineAndCol.first << ":" << startLineAndCol.second
         << " - " << endLineAndCol.first << ":" << endLineAndCol.second << "]";

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -651,7 +651,7 @@ static unsigned getLineNumber(DCType *DC) {
     return 0;
 
   const ASTContext &ctx = static_cast<const DeclContext *>(DC)->getASTContext();
-  return ctx.SourceMgr.getLineAndColumn(loc).first;
+  return ctx.SourceMgr.getPresumedLineAndColumnForLoc(loc).first;
 }
 
 bool DeclContext::classof(const Decl *D) {

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -596,7 +596,7 @@ void RequirementSource::print(llvm::raw_ostream &out,
 
     unsigned bufferID = srcMgr->findBufferContainingLoc(loc);
 
-    auto lineAndCol = srcMgr->getLineAndColumn(loc, bufferID);
+    auto lineAndCol = srcMgr->getPresumedLineAndColumnForLoc(loc, bufferID);
     out << " @ " << lineAndCol.first << ':' << lineAndCol.second;
   };
 

--- a/lib/AST/RawComment.cpp
+++ b/lib/AST/RawComment.cpp
@@ -58,10 +58,10 @@ SingleRawComment::SingleRawComment(CharSourceRange Range,
                                    const SourceManager &SourceMgr)
     : Range(Range), RawText(SourceMgr.extractText(Range)),
       Kind(static_cast<unsigned>(getCommentKind(RawText))),
-      EndLine(SourceMgr.getLineNumber(Range.getEnd())) {
-  auto StartLineAndColumn = SourceMgr.getLineAndColumn(Range.getStart());
-  StartLine = StartLineAndColumn.first;
-  StartColumn = StartLineAndColumn.second;
+      EndLine(SourceMgr.getLineAndColumnInBuffer(Range.getEnd()).first) {
+  auto Start = SourceMgr.getPresumedLineAndColumnForLoc(Range.getStart());
+  StartLine = Start.first;
+  StartColumn = Start.second;
 }
 
 SingleRawComment::SingleRawComment(StringRef RawText, unsigned StartColumn)

--- a/lib/AST/RawComment.cpp
+++ b/lib/AST/RawComment.cpp
@@ -59,7 +59,7 @@ SingleRawComment::SingleRawComment(CharSourceRange Range,
     : Range(Range), RawText(SourceMgr.extractText(Range)),
       Kind(static_cast<unsigned>(getCommentKind(RawText))),
       EndLine(SourceMgr.getLineAndColumnInBuffer(Range.getEnd()).first) {
-  auto Start = SourceMgr.getPresumedLineAndColumnForLoc(Range.getStart());
+  auto Start = SourceMgr.getLineAndColumnInBuffer(Range.getStart());
   StartLine = Start.first;
   StartColumn = Start.second;
 }

--- a/lib/Basic/SourceLoc.cpp
+++ b/lib/Basic/SourceLoc.cpp
@@ -208,7 +208,7 @@ void SourceLoc::printLineAndColumn(raw_ostream &OS,
     return;
   }
 
-  auto LineAndCol = SM.getLineAndColumn(*this);
+  auto LineAndCol = SM.getPresumedLineAndColumnForLoc(*this);
   OS << "line:" << LineAndCol.first << ':' << LineAndCol.second;
 }
 
@@ -227,7 +227,7 @@ void SourceLoc::print(raw_ostream &OS, const SourceManager &SM,
     OS << "line";
   }
 
-  auto LineAndCol = SM.getLineAndColumn(*this, BufferID);
+  auto LineAndCol = SM.getPresumedLineAndColumnForLoc(*this, BufferID);
   OS << ':' << LineAndCol.first << ':' << LineAndCol.second;
 }
 
@@ -281,9 +281,9 @@ void CharSourceRange::dump(const SourceManager &SM) const {
   print(llvm::errs(), SM);
 }
 
-llvm::Optional<unsigned> SourceManager::resolveFromLineCol(unsigned BufferId,
-                                                           unsigned Line,
-                                                           unsigned Col) const {
+llvm::Optional<unsigned>
+SourceManager::getOffsetForLineAndColumnInBuffer(unsigned BufferId, unsigned Line,
+                                              unsigned Col) const {
   if (Line == 0 || Col == 0) {
     return None;
   }

--- a/lib/Frontend/DiagnosticVerifier.cpp
+++ b/lib/Frontend/DiagnosticVerifier.cpp
@@ -323,7 +323,7 @@ bool DiagnosticVerifier::verifyFile(unsigned BufferID,
     if (PrevExpectedContinuationLine)
       Expected.LineNo = PrevExpectedContinuationLine;
     else
-      Expected.LineNo = SM.getLineAndColumn(
+      Expected.LineNo = SM.getPresumedLineAndColumnForLoc(
           BufferStartLoc.getAdvancedLoc(MatchStart.data() - InputFile.data()),
           BufferID).first;
     Expected.LineNo += LineOffset;

--- a/lib/Frontend/PrintingDiagnosticConsumer.cpp
+++ b/lib/Frontend/PrintingDiagnosticConsumer.cpp
@@ -121,7 +121,7 @@ SourceManager::GetMessage(SourceLoc Loc, llvm::SourceMgr::DiagKind Kind,
   std::string LineStr;
 
   if (Loc.isValid()) {
-    BufferID = getBufferIdentifierForLoc(Loc);
+    BufferID = getPresumedFilenameForLoc(Loc);
     auto CurMB = LLVMSourceMgr.getMemoryBuffer(findBufferContainingLoc(Loc));
 
     // Scan backward to find the start of the line.
@@ -160,7 +160,7 @@ SourceManager::GetMessage(SourceLoc Loc, llvm::SourceMgr::DiagKind Kind,
                                          R.End.getPointer()-LineStart));
     }
 
-    LineAndCol = getLineAndColumn(Loc);
+    LineAndCol = getPresumedLineAndColumnForLoc(Loc);
   }
 
   return llvm::SMDiagnostic(LLVMSourceMgr, Loc.Value, BufferID,

--- a/lib/Frontend/SerializedDiagnosticConsumer.cpp
+++ b/lib/Frontend/SerializedDiagnosticConsumer.cpp
@@ -239,7 +239,7 @@ void SerializedDiagnosticConsumer::addLocToRecord(SourceLoc Loc,
   }
 
   unsigned line, col;
-  std::tie(line, col) = SM.getLineAndColumn(Loc);
+  std::tie(line, col) = SM.getPresumedLineAndColumnForLoc(Loc);
 
   Record.push_back(getEmitFile(Filename));
   Record.push_back(line);

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -443,9 +443,8 @@ static bool performCompile(std::unique_ptr<CompilerInstance> &Instance,
         SourceManager &sourceMgr = Instance->getSourceMgr();
         // Probe each of the locations, and dump what we find.
         for (auto lineColumn : opts.DumpScopeMapLocations) {
-          SourceLoc loc = sourceMgr.getLocForLineCol(*bufferID,
-                                                     lineColumn.first,
-                                                     lineColumn.second);
+          SourceLoc loc = sourceMgr.getLocForLineAndColumnInBuffer(
+              *bufferID, lineColumn.first, lineColumn.second);
           if (loc.isInvalid()) continue;
 
           llvm::errs() << "***Scope at " << lineColumn.first << ":"

--- a/lib/IDE/CommentConversion.cpp
+++ b/lib/IDE/CommentConversion.cpp
@@ -302,7 +302,7 @@ void CommentToXMLConverter::visitDocComment(const DocComment *DC) {
       const auto &SM = D->getASTContext().SourceMgr;
       unsigned BufferID = SM.findBufferContainingLoc(Loc);
       StringRef FileName = SM.getIdentifierForBuffer(BufferID);
-      auto LineAndColumn = SM.getLineAndColumn(Loc);
+      auto LineAndColumn = SM.getPresumedLineAndColumnForLoc(Loc);
       OS << " file=\"";
       appendWithXMLEscaping(OS, FileName);
       OS << "\"";

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -399,7 +399,7 @@ private:
   std::pair<unsigned, unsigned> getLineCol(SourceLoc Loc) {
     if (Loc.isInvalid())
       return std::make_pair(0, 0);
-    return SrcMgr.getLineAndColumn(Loc, BufferID);
+    return SrcMgr.getPresumedLineAndColumnForLoc(Loc, BufferID);
   }
 
   bool shouldIndex(ValueDecl *D, bool IsRef) const {

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -2129,15 +2129,6 @@ static const char *findStartOfLine(const char *bufStart, const char *current) {
   return current;
 }
 
-SourceLoc Lexer::getLocForStartOfToken(SourceManager &SM, SourceLoc Loc) {
-  Optional<unsigned> BufferIdOp = SM.getIDForBufferIdentifier(SM.
-    getPresumedFilenameForLoc(Loc));
-  if (!BufferIdOp.hasValue())
-    return SourceLoc();
-  return getLocForStartOfToken(SM, BufferIdOp.getValue(),
-    SM.getLocOffsetInBuffer(Loc, BufferIdOp.getValue()));
-}
-
 SourceLoc Lexer::getLocForStartOfToken(SourceManager &SM, unsigned BufferID,
                                        unsigned Offset) {
   CharSourceRange entireRange = SM.getRangeForBuffer(BufferID);

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -2131,7 +2131,7 @@ static const char *findStartOfLine(const char *bufStart, const char *current) {
 
 SourceLoc Lexer::getLocForStartOfToken(SourceManager &SM, SourceLoc Loc) {
   Optional<unsigned> BufferIdOp = SM.getIDForBufferIdentifier(SM.
-    getBufferIdentifierForLoc(Loc));
+    getPresumedFilenameForLoc(Loc));
   if (!BufferIdOp.hasValue())
     return SourceLoc();
   return getLocForStartOfToken(SM, BufferIdOp.getValue(),

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2987,7 +2987,8 @@ ParserStatus Parser::parseLineDirective(bool isLine) {
     return makeParserError();
   }
   
-  int LineOffset = StartLine - SourceMgr.getLineNumber(nextLineStartLoc);
+  int LineOffset =
+    StartLine - SourceMgr.getLineAndColumnInBuffer(nextLineStartLoc).first;
  
   // Create a new virtual file for the region started by the #line marker.
   bool isNewFile = SourceMgr.openVirtualFile(nextLineStartLoc,

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -2658,8 +2658,8 @@ ParserResult<Expr> Parser::parseTrailingClosure(SourceRange calleeRange) {
   // Warn if the trailing closure is separated from its callee by more than
   // one line. A single-line separation is acceptable for a trailing closure
   // call, and will be diagnosed later only if the call fails to typecheck.
-  auto origLine = SourceMgr.getLineNumber(calleeRange.End);
-  auto braceLine = SourceMgr.getLineNumber(braceLoc);
+  auto origLine = SourceMgr.getLineAndColumnInBuffer(calleeRange.End).first;
+  auto braceLine = SourceMgr.getLineAndColumnInBuffer(braceLoc).first;
   if (braceLine > origLine + 1) {
     diagnose(braceLoc, diag::trailing_closure_after_newlines);
     diagnose(calleeRange.Start, diag::trailing_closure_callee_here);

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -661,8 +661,8 @@ ParserResult<Stmt> Parser::parseStmtReturn(SourceLoc tryLoc) {
 
     // Issue a warning when the returned expression is on a different line than
     // the return keyword, but both have the same indentation.
-    if (SourceMgr.getLineAndColumn(ReturnLoc).second ==
-        SourceMgr.getLineAndColumn(ExprLoc).second) {
+    if (SourceMgr.getPresumedLineAndColumnForLoc(ReturnLoc).second ==
+        SourceMgr.getPresumedLineAndColumnForLoc(ExprLoc).second) {
       diagnose(ExprLoc, diag::unindented_code_after_return);
       diagnose(ExprLoc, diag::indent_expression_to_silence);
     }

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -661,8 +661,8 @@ ParserResult<Stmt> Parser::parseStmtReturn(SourceLoc tryLoc) {
 
     // Issue a warning when the returned expression is on a different line than
     // the return keyword, but both have the same indentation.
-    if (SourceMgr.getPresumedLineAndColumnForLoc(ReturnLoc).second ==
-        SourceMgr.getPresumedLineAndColumnForLoc(ExprLoc).second) {
+    if (SourceMgr.getLineAndColumnInBuffer(ReturnLoc).second ==
+        SourceMgr.getLineAndColumnInBuffer(ExprLoc).second) {
       diagnose(ExprLoc, diag::unindented_code_after_return);
       diagnose(ExprLoc, diag::indent_expression_to_silence);
     }

--- a/lib/SIL/SILLocation.cpp
+++ b/lib/SIL/SILLocation.cpp
@@ -148,8 +148,8 @@ SILLocation::DebugLoc SILLocation::decode(SourceLoc Loc,
                                           const SourceManager &SM) {
   DebugLoc DL;
   if (Loc.isValid()) {
-    DL.Filename = SM.getBufferIdentifierForLoc(Loc);
-    std::tie(DL.Line, DL.Column) = SM.getLineAndColumn(Loc);
+    DL.Filename = SM.getPresumedFilenameForLoc(Loc);
+    std::tie(DL.Line, DL.Column) = SM.getPresumedLineAndColumnForLoc(Loc);
   }
   return DL;
 }

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -4452,7 +4452,7 @@ RValue SILGenFunction::emitLiteral(LiteralExpr *literal, SGFContext C) {
     case MagicIdentifierLiteralExpr::File: {
       StringRef value = "";
       if (loc.isValid())
-        value = ctx.SourceMgr.getBufferIdentifierForLoc(loc);
+        value = ctx.SourceMgr.getPresumedFilenameForLoc(loc);
       builtinLiteralArgs = emitStringLiteral(*this, literal, value, C,
                                              magicLiteral->getStringEncoding());
       builtinInit = magicLiteral->getBuiltinInitializer();

--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -142,8 +142,7 @@ static void emitSourceLocationArgs(SILGenFunction &gen,
   StringRef filename = "";
   unsigned line = 0;
   if (sourceLoc.isValid()) {
-    unsigned bufferID = ctx.SourceMgr.findBufferContainingLoc(sourceLoc);
-    filename = ctx.SourceMgr.getIdentifierForBuffer(bufferID);
+    filename = ctx.SourceMgr.getPresumedFilenameForLoc(sourceLoc);
     line = ctx.SourceMgr.getPresumedLineAndColumnForLoc(sourceLoc).first;
   }
   

--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -144,7 +144,7 @@ static void emitSourceLocationArgs(SILGenFunction &gen,
   if (sourceLoc.isValid()) {
     unsigned bufferID = ctx.SourceMgr.findBufferContainingLoc(sourceLoc);
     filename = ctx.SourceMgr.getIdentifierForBuffer(bufferID);
-    line = ctx.SourceMgr.getLineAndColumn(sourceLoc).first;
+    line = ctx.SourceMgr.getPresumedLineAndColumnForLoc(sourceLoc).first;
   }
   
   bool isASCII = true;

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2405,7 +2405,7 @@ visitMagicIdentifierLiteralExpr(MagicIdentifierLiteralExpr *E, SGFContext C) {
   case MagicIdentifierLiteralExpr::Line: {
     unsigned Value = 0;
     if (Loc.isValid())
-      Value = Ctx.SourceMgr.getLineAndColumn(Loc).first;
+      Value = Ctx.SourceMgr.getPresumedLineAndColumnForLoc(Loc).first;
 
     SILValue V = SGF.B.createIntegerLiteral(E, Ty, Value);
     return RValue(SGF, E, ManagedValue::forUnmanaged(V));
@@ -2413,7 +2413,7 @@ visitMagicIdentifierLiteralExpr(MagicIdentifierLiteralExpr *E, SGFContext C) {
   case MagicIdentifierLiteralExpr::Column: {
     unsigned Value = 0;
     if (Loc.isValid())
-      Value = Ctx.SourceMgr.getLineAndColumn(Loc).second;
+      Value = Ctx.SourceMgr.getPresumedLineAndColumnForLoc(Loc).second;
 
     SILValue V = SGF.B.createIntegerLiteral(E, Ty, Value);
     return RValue(SGF, E, ManagedValue::forUnmanaged(V));

--- a/lib/SILGen/SILGenProfiling.cpp
+++ b/lib/SILGen/SILGenProfiling.cpp
@@ -482,8 +482,8 @@ public:
       assert(Region.hasStartLoc() && "invalid region");
       assert(Region.hasEndLoc() && "incomplete region");
 
-      auto Start = SM.getLineAndColumn(Region.getStartLoc());
-      auto End = SM.getLineAndColumn(Region.getEndLoc());
+      auto Start = SM.getPresumedLineAndColumnForLoc(Region.getStartLoc());
+      auto End = SM.getPresumedLineAndColumnForLoc(Region.getEndLoc());
       assert(Start.first <= End.first && "region start and end out of order");
 
       Regions.emplace_back(Start.first, Start.second, End.first, End.second,

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -5896,8 +5896,8 @@ bool FailureDiagnosis::visitApplyExpr(ApplyExpr *callExpr) {
         auto &SM = CS->getASTContext().SourceMgr;
         if (closure->hasAnonymousClosureVars() &&
             closure->getParameters()->size() == 0 &&
-            1 + SM.getLineNumber(callExpr->getFn()->getEndLoc()) ==
-            SM.getLineNumber(closure->getStartLoc())) {
+            1 + SM.getLineAndColumnInBuffer(callExpr->getFn()->getEndLoc()).first ==
+            SM.getLineAndColumnInBuffer(closure->getStartLoc()).first) {
           diagnose(closure->getStartLoc(), diag::brace_stmt_suggest_do)
             .fixItInsert(closure->getStartLoc(), "do ");
         }

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -2683,8 +2683,8 @@ static void checkSwitch(TypeChecker &TC, const SwitchStmt *stmt) {
         continue;
       
       auto &SM = TC.Context.SourceMgr;
-      auto prevLineCol = SM.getLineAndColumn(prevLoc);
-      if (SM.getLineNumber(thisLoc) != prevLineCol.first)
+      auto prevLineCol = SM.getPresumedLineAndColumnForLoc(prevLoc);
+      if (SM.getLineAndColumnInBuffer(thisLoc).first != prevLineCol.first)
         continue;
       
       TC.diagnose(items[i].getWhereLoc(), diag::where_on_one_item)

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -2683,7 +2683,7 @@ static void checkSwitch(TypeChecker &TC, const SwitchStmt *stmt) {
         continue;
       
       auto &SM = TC.Context.SourceMgr;
-      auto prevLineCol = SM.getPresumedLineAndColumnForLoc(prevLoc);
+      auto prevLineCol = SM.getLineAndColumnInBuffer(prevLoc);
       if (SM.getLineAndColumnInBuffer(thisLoc).first != prevLineCol.first)
         continue;
       

--- a/lib/Sema/PCMacro.cpp
+++ b/lib/Sema/PCMacro.cpp
@@ -527,10 +527,11 @@ public:
     }
 
     std::pair<unsigned, unsigned> StartLC =
-        Context.SourceMgr.getLineAndColumn(SR.Start);
+        Context.SourceMgr.getPresumedLineAndColumnForLoc(SR.Start);
 
-    std::pair<unsigned, unsigned> EndLC = Context.SourceMgr.getLineAndColumn(
-        Lexer::getLocForEndOfToken(Context.SourceMgr, SR.End));
+    std::pair<unsigned, unsigned> EndLC =
+      Context.SourceMgr.getPresumedLineAndColumnForLoc(
+          Lexer::getLocForEndOfToken(Context.SourceMgr, SR.End));
 
     const size_t buf_size = 8;
 
@@ -610,10 +611,11 @@ public:
     }
 
     std::pair<unsigned, unsigned> StartLC =
-        Context.SourceMgr.getLineAndColumn(SR.Start);
+        Context.SourceMgr.getPresumedLineAndColumnForLoc(SR.Start);
 
-    std::pair<unsigned, unsigned> EndLC = Context.SourceMgr.getLineAndColumn(
-        Lexer::getLocForEndOfToken(Context.SourceMgr, SR.End));
+    std::pair<unsigned, unsigned> EndLC =
+      Context.SourceMgr.getPresumedLineAndColumnForLoc(
+          Lexer::getLocForEndOfToken(Context.SourceMgr, SR.End));
 
     const size_t buf_size = 8;
 

--- a/lib/Sema/PlaygroundTransform.cpp
+++ b/lib/Sema/PlaygroundTransform.cpp
@@ -806,9 +806,10 @@ public:
     }
 
     std::pair<unsigned, unsigned> StartLC =
-        Context.SourceMgr.getLineAndColumn(SR.Start);
+        Context.SourceMgr.getPresumedLineAndColumnForLoc(SR.Start);
 
-    std::pair<unsigned, unsigned> EndLC = Context.SourceMgr.getLineAndColumn(
+    std::pair<unsigned, unsigned> EndLC =
+      Context.SourceMgr.getPresumedLineAndColumnForLoc(
         Lexer::getLocForEndOfToken(Context.SourceMgr, SR.End));
 
     const size_t buf_size = 8;

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -689,8 +689,8 @@ static void diagnoseAndMigrateVarParameterToBody(ParamDecl *decl,
   std::string start;
   std::string end;
   
-  auto lBraceLine = SM.getLineNumber(declBody->getLBraceLoc());
-  auto rBraceLine = SM.getLineNumber(declBody->getRBraceLoc());
+  auto lBraceLine = SM.getLineAndColumnInBuffer(declBody->getLBraceLoc()).first;
+  auto rBraceLine = SM.getLineAndColumnInBuffer(declBody->getRBraceLoc()).first;
 
   if (!declBody->getNumElements()) {
     
@@ -711,7 +711,7 @@ static void diagnoseAndMigrateVarParameterToBody(ParamDecl *decl,
   } else {
     auto firstLine = declBody->getElement(0);
     insertionStartLoc = firstLine.getStartLoc();
-    if (lBraceLine == SM.getLineNumber(firstLine.getStartLoc())) {
+    if (lBraceLine == SM.getLineAndColumnInBuffer(firstLine.getStartLoc()).first) {
       // Function on same line, insert with semi-colon. Not ideal but
       // better than weird space alignment.
       start = "";

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -105,7 +105,7 @@ void EditorDiagConsumer::handleDiagnostic(SourceManager &SM, SourceLoc Loc,
   }
 
   SKInfo.Offset = SM.getLocOffsetInBuffer(Loc, BufferID);
-  std::tie(SKInfo.Line, SKInfo.Column) = SM.getLineAndColumn(Loc, BufferID);
+  std::tie(SKInfo.Line, SKInfo.Column) = SM.getPresumedLineAndColumnForLoc(Loc, BufferID);
   SKInfo.Filename = SM.getIdentifierForBuffer(BufferID);
 
   for (auto R : Info.Ranges) {
@@ -1250,8 +1250,8 @@ public:
 
     ++NestingLevel;
     SourceLoc StartLoc = Node.Range.getStart();
-    auto StartLineAndColumn = SrcManager.getLineAndColumn(StartLoc);
-    auto EndLineAndColumn = SrcManager.getLineAndColumn(Node.Range.getEnd());
+    auto StartLineAndColumn = SrcManager.getPresumedLineAndColumnForLoc(StartLoc);
+    auto EndLineAndColumn = SrcManager.getPresumedLineAndColumnForLoc(Node.Range.getEnd());
     unsigned StartLine = StartLineAndColumn.first;
     unsigned EndLine = EndLineAndColumn.second > 1 ? EndLineAndColumn.first
                                                    : EndLineAndColumn.first - 1;
@@ -1676,8 +1676,8 @@ ImmutableTextSnapshotRef SwiftEditorDocument::replaceText(
   unsigned BufID = Impl.SyntaxInfo->getBufferID();
   SourceLoc StartLoc = SrcManager.getLocForBufferStart(BufID).getAdvancedLoc(
                                                                         Offset);
-  unsigned StartLine = SrcManager.getLineAndColumn(StartLoc).first;
-  unsigned EndLine = SrcManager.getLineAndColumn(
+  unsigned StartLine = SrcManager.getPresumedLineAndColumnForLoc(StartLoc).first;
+  unsigned EndLine = SrcManager.getPresumedLineAndColumnForLoc(
                                          StartLoc.getAdvancedLoc(Length)).first;
 
   // Delete all syntax map data from start line through end line.


### PR DESCRIPTION
Reorganize `SourceManager` methods regarding filename, line and column.
https://lists.swift.org/pipermail/swift-dev/Week-of-Mon-20170313/004232.html
The first commit is strictly NFC.


**Presumed locations ( respects `#sourceLocation` directive)**
`getBufferIdentifierForLoc(Loc)`  → `getPresumedFilenameForLoc(Loc)`
`getLineAndColumn(Loc)` → `getPresumedLineAndColumnForLoc(Loc)`

**Physical locations (ignores `#sourceLocation` directive)**
`getIdentifierForBuffer(BufferID)` → ASIS
new `getIdentifierForBuffer(Loc)` 
`getLineNumber(Loc)` → `getLineAndColumnInBuffer(Loc).first`
`resolveFromLineCol(BufferID, Line, Column)` → `getOffsetForLineAndColumnInBuffer(BufferID, Line, Column)`
`getLocForLineCol(BufferID, Line, Column)` → `getLocForLineAndColumnInBuffer(BufferID, Line, Column)`


---

### Audit checklist

* AST
  * [ ] `ASTScope::print`
  * [ ] `ConformanceLookupTable::compareProtocolConformances`
  * [ ] `DeclContext::printContext`
  * [ ] `GenericSignatureBuilder::RequirementSource::print`
  * [x] `SingleRawComment::SingleRawComment` → Use physical line and column, modified
* Basic
  * [ ] `SourceLoc::printLineAndColumn`
  * [x] `swift::writeEditsInJson` → Use physical filename, asis
* Frontend
  * [ ] `DiagnosticVerifier::verifyFile`
  * [x] `SourceManager::GetMessage` → Use presumed filename, line and column, asis.
* IDE
  * [ ] `SerializedDiagnosticConsumer::addLocToRecord`
  * [ ] `CommentToXMLConverter::visitDocComment`
  * [ ] `swift::ide::getLocationInfo`
  * [ ] `swift::ide::reformat` (lib/IDE/Formatting.cpp)
* IRGen
  * [ ] `PrettySourceFileEmission::print`
  * [ ] `IRGenDebugInfo::IRGenDebugInfo`
* Index
  * [ ] `index::indexSourceFile`
* Parse
  * [x] `Lexer::getLocForStartOfToken` → Unused function, removed
  * [x] `Parser::parseLineDirective` → Use physical line, asis
  * [x] `Parser::parseTrailingClosure` → Use physical line, asis
  * [x] `Parser::parseStmtReturn` → Use physical column, modified
* SIL
  * [ ] `SILLocation::decode`
* SILGen
  * [x] `SILGenFunction::emitLiteral` (`#file` value) Use presumed filename, asis
  * [x] `SILGenFunction::emitPreconditionOptionalHasValue` Use presumed filename and line, modified
  * [x] `RValueEmitter::visitMagicIdentifierLiteralExpr` (`#line` and `#column` value) Use presumed line and column, asis
  * [ ] `CoverageMapping::emitSourceRegions`
* Sema
  * [ ] `NameBinder::addImport`
  * [x] `FailureDiagnosis::visitApplyExpr` → Use physical line, asis
  * [x] `swift::performStmtDiagnostics` → Use physical line and column, modified
  * [ ] `swift::performPCMacro`
  * [ ] `swift::performPlaygroundTransform`
  * [x] `static diagnoseAndMigrateVarParameterToBody` → Use physical line, asis
* Serialization
  * [ ] `GroupNameCollectorFromJson::getGroupNameInternal`
* SourceKit
  * [ ] `EditorDiagConsumer::handleDiagnostic`
  * [ ] `SwiftEditorSyntaxWalker::walkToNodePre`
  * [ ] `SwiftEditorDocument::replaceText`
* swift-ide-test
  * [ ] `AnnotationPrinter::printLoc`
  * [ ] `ASTTypePrinter::walkToExprPre`
  * [ ] `ASTCommentPrinter::walkToDeclPre`
  * [ ] `USRPrinter::printLoc`