### PR TITLE
Remove default from DeclAttributes::isUnavailableInSwiftVersion.

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -1144,10 +1144,9 @@ public:
   }
 
   /// Determine whether there is a swiftVersionSpecific attribute that's
-  /// unavailable relative to the provided language version (defaulting to
-  /// current language version).
-  bool isUnavailableInSwiftVersion(const version::Version &effectiveVersion =
-           version::Version::getCurrentLanguageVersion()) const;
+  /// unavailable relative to the provided language version.
+  bool
+  isUnavailableInSwiftVersion(const version::Version &effectiveVersion) const;
 
   /// Returns the first @available attribute that indicates
   /// a declaration is unavailable, or null otherwise.

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -609,9 +609,10 @@ UnqualifiedLookup::UnqualifiedLookup(DeclName Name, DeclContext *DC,
           // Predicate that determines whether a lookup result should
           // be unavailable except as a last-ditch effort.
           auto unavailableLookupResult =
-            [&](const UnqualifiedLookupResult &result) {
+              [&](const UnqualifiedLookupResult &result) {
+            auto &effectiveVersion = Ctx.LangOpts.EffectiveLanguageVersion;
             return result.getValueDecl()->getAttrs()
-                     .isUnavailableInSwiftVersion();
+                .isUnavailableInSwiftVersion(effectiveVersion);
           };
 
           // If all of the results we found are unavailable, keep looking.
@@ -825,8 +826,9 @@ UnqualifiedLookup::UnqualifiedLookup(DeclName Name, DeclContext *DC,
             // be unavailable except as a last-ditch effort.
             auto unavailableLookupResult =
               [&](const UnqualifiedLookupResult &result) {
+              auto &effectiveVersion = Ctx.LangOpts.EffectiveLanguageVersion;
               return result.getValueDecl()->getAttrs()
-                       .isUnavailableInSwiftVersion();
+                  .isUnavailableInSwiftVersion(effectiveVersion);
             };
 
             // If all of the results we found are unavailable, keep looking.

--- a/test/attr/attr_availability_swift_v3.swift
+++ b/test/attr/attr_availability_swift_v3.swift
@@ -59,3 +59,23 @@ swiftFourPointOh() // expected-error {{is unavailable}}
 swiftFourPointOhWithMessage() // expected-error {{is unavailable: uses abc}}
 let aa : SwiftShortFour // expected-error {{is unavailable}}
 let bb : SwiftFourWithMessage // expected-error {{is unavailable: uses pqr}}
+
+@available(*, deprecated, message: "found the top-level decl")
+func shadowedByMember3() {}
+@available(*, deprecated, message: "found the top-level decl")
+func shadowedByMember4() {}
+
+struct Wrapper {
+  @available(swift, introduced: 3.0, obsoleted: 4.0)
+  @available(*, deprecated, message: "found the member decl")
+  func shadowedByMember3() {}
+
+  @available(swift, introduced: 4.0)
+  @available(*, deprecated, message: "found the member decl")
+  func shadowedByMember4() {}
+
+  func test() {
+    shadowedByMember3() // expected-warning {{found the member decl}}
+    shadowedByMember4() // expected-warning {{found the top-level decl}}
+  }
+}

--- a/test/attr/attr_availability_swift_v4.swift
+++ b/test/attr/attr_availability_swift_v4.swift
@@ -56,3 +56,23 @@ swiftShortFourPointOh()
 swiftFour()
 swiftFourPointOh()
 let aa : SwiftShortFour
+
+@available(*, deprecated, message: "found the top-level decl")
+func shadowedByMember3() {}
+@available(*, deprecated, message: "found the top-level decl")
+func shadowedByMember4() {}
+
+struct Wrapper {
+  @available(swift, introduced: 3.0, obsoleted: 4.0)
+  @available(*, deprecated, message: "found the member decl")
+  func shadowedByMember3() {}
+
+  @available(swift, introduced: 4.0)
+  @available(*, deprecated, message: "found the member decl")
+  func shadowedByMember4() {}
+
+  func test() {
+    shadowedByMember3() // expected-warning {{found the top-level decl}}
+    shadowedByMember4() // expected-warning {{found the member decl}}
+  }
+}


### PR DESCRIPTION
If this had a default, it should be the effective language version, not the compiler language version. That is, in the Swift 4 compiler's Swift 3 mode, we want to be acting like Swift 3, not Swift 4.