### PR TITLE
Verify the construction of SubstitutionMaps

### DIFF
--- a/include/swift/AST/SubstitutionMap.h
+++ b/include/swift/AST/SubstitutionMap.h
@@ -154,6 +154,9 @@ public:
                           unsigned origDepthOrIndex,
                           GenericSignature *genericSig);
 
+  /// Verify that this substitution map is valid.
+  void verify() const;
+
   /// Dump the contents of this substitution map for debugging purposes.
   void dump(llvm::raw_ostream &out) const;
 

--- a/lib/AST/GenericEnvironment.cpp
+++ b/lib/AST/GenericEnvironment.cpp
@@ -420,6 +420,7 @@ getSubstitutionMap(SubstitutionList subs) const {
   assert(subs.empty() && "did not use all substitutions?!");
 
   populateParentMap(result);
+  result.verify();
   return result;
 }
 
@@ -459,5 +460,6 @@ getSubstitutionMap(TypeSubstitutionFn subs,
     });
 
   populateParentMap(subMap);
+  subMap.verify();
   return subMap;
 }

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -424,6 +424,7 @@ GenericSignature::getSubstitutionMap(SubstitutionList subs) const {
 
   assert(subs.empty() && "did not use all substitutions?!");
   populateParentMap(result);
+  result.verify();
   return result;
 }
 
@@ -458,6 +459,7 @@ getSubstitutionMap(TypeSubstitutionFn subs,
   });
 
   populateParentMap(subMap);
+  subMap.verify();
   return subMap;
 }
 

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -28,6 +28,7 @@
 #include "swift/AST/Module.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/Types.h"
+#include "llvm/Support/Debug.h"
 
 using namespace swift;
 
@@ -251,6 +252,8 @@ SubstitutionMap SubstitutionMap::subst(TypeSubstitutionFn subs,
     }
   }
 
+  result.verify();
+
   return result;
 }
 
@@ -393,6 +396,41 @@ SubstitutionMap::combineSubstitutionMaps(const SubstitutionMap &firstSubMap,
       return firstSubMap.lookupConformance(type,
                                            conformedProtocol->getDecl());
     });
+}
+
+void SubstitutionMap::verify() const {
+#ifndef NDEBUG
+  for (auto iter = conformanceMap.begin(), end = conformanceMap.end();
+       iter != end; ++iter) {
+    auto replacement = Type(iter->first).subst(*this, SubstFlags::UseErrorType);
+    if (replacement->isTypeParameter() || replacement->is<ArchetypeType>() ||
+        replacement->isTypeVariableOrMember() ||
+        replacement->is<UnresolvedType>() || replacement->hasError())
+      continue;
+    // Check conformances of a concrete replacement type.
+    for (auto citer = iter->second.begin(), cend = iter->second.end();
+         citer != cend; ++citer) {
+      // An existential type can have an abstract conformance to
+      // AnyObject or an @objc protocol.
+      if (citer->isAbstract() && replacement->isExistentialType()) {
+        auto *proto = citer->getRequirement();
+        assert((proto->isSpecificProtocol(KnownProtocolKind::AnyObject) ||
+                proto->isObjC()) &&
+               "an existential type can conform only to AnyObject or an "
+               "@objc-protocol");
+        continue;
+      }
+      // All of the conformances should be concrete.
+      if (!citer->isConcrete()) {
+        llvm::dbgs() << "Concrete replacement type:\n";
+        replacement->dump();
+        llvm::dbgs() << "SubstitutionMap:\n";
+        dump();
+      }
+      assert(citer->isConcrete() && "Conformance should be concrete");
+    }
+  }
+#endif
 }
 
 void SubstitutionMap::dump(llvm::raw_ostream &out) const {


### PR DESCRIPTION
After substitution maps are constructed, check their invariants. It helps to catch very subtle bugs related to substitutions.

