### PR TITLE
Fixed a typo

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -3832,7 +3832,7 @@ public:
 
   using TrailingCallArguments::getArgumentLabels;
 
-  /// Retrieve the expression that direct represents the callee.
+  /// Retrieve the expression that directly represents the callee.
   ///
   /// The "direct" callee is the expression representing the callee
   /// after looking through top-level constructs that don't affect the


### PR DESCRIPTION
Changed "Retrieve the expression that direct represents the callee." to "Retrieve the expression that directly represents the callee.", on line 3835

What's in this pull request?
A typo correction

If this pull request resolves any bugs in the Swift bug tracker, provide a link:
N/A, as far as I know.

Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci 
You're welcome to run it if you want, but since the only change is in one of those "///" lines, I can't see how it'd actually affect anything.
