### PR TITLE
[SR-4294] Warn on excessive right-angle brackets

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1379,6 +1379,9 @@ ERROR(where_without_generic_params,none,
 WARNING(where_inside_brackets,none,
         "'where' clause next to generic parameters is deprecated "
         "and will be removed in the future version of Swift", ())
+WARNING(excessive_right_angle_brackets,none,
+      "generic closing brackets may be mistaken for version control conflict "
+      "markers; consider using a typealias", ())
 
 //------------------------------------------------------------------------------
 // Conditional compilation parsing diagnostics

--- a/test/Parse/generic_disambiguation.swift
+++ b/test/Parse/generic_disambiguation.swift
@@ -74,3 +74,15 @@ A<B?>(x: 0) // parses as type // expected-warning{{unused}}
 _ = a < b ? c : d
 
 A<(B) throws -> D>(x: 0) // expected-warning{{unused}}
+
+struct G<T,U> {}
+_ = A<A<A<A<A<B>>>>>() // not enough closing brackets
+_ = A<A<A<A<A<B>> >>>() // space in closing brackets
+_ = G<A<A<A<A<A<A<B>>>>>>, B>() // closing brackets inside
+// expected-warning@-1 {{generic closing brackets may be mistaken for version control conflict markers; consider using a typealias}}
+_ = G<B, A<A<A<A<A<B>>>>>>() // closing brackets at the end
+// expected-warning@-1 {{generic closing brackets may be mistaken for version control conflict markers; consider using a typealias}}
+_ = A<A<A<A<A<A<A<B>>>>>>>() // more than 6 closing brackets
+// expected-warning@-1 {{generic closing brackets may be mistaken for version control conflict markers; consider using a typealias}}
+_ = A<A<A<A<A<A<A<B> >>>>>>() // 7 with hole
+// expected-warning@-1 {{generic closing brackets may be mistaken for version control conflict markers; consider using a typealias}}


### PR DESCRIPTION
To warn against the consecutive use of 6 or more right-angle brackets in generic arguments (to avoid confusion with source-control conflict markets), the parser checks after each succesful `parseExprIdentifier` for generic type expressions and counts successive

I'm open to improvements on the implementation. I did it there to make sure we only warn once we've successfully parsed a generic type expression.

Resolves [SR-4294](https://bugs.swift.org/browse/SR-4294).