### PR TITLE
Add regression test for recent line-directive breakage (SR-4238 )

### DIFF
--- a/utils/line-directive
+++ b/utils/line-directive
@@ -251,6 +251,330 @@ def run():
     >>> print subprocess.check_output([sys.executable, __file__, 'foo.bar', '8', target2.name]).replace('\\r', ''),
     3
 
+    Simulate errors on different line numbers
+    >>> long_output = NamedTemporaryFile(delete=False)
+    >>> long_output.write('''... // ###sourceLocation(file: "/public/core/Map.swift.gyb", line: 1)
+    ... // ###sourceLocation(file: "/public/core/Map.swift.gyb", line: 1)
+    ... //===--- Map.swift.gyb - Lazily map over a Sequence -----------*- swift -*-===//
+    ... //
+    ... // This source file is part of the Swift.org open source project
+    ... //
+    ... // Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+    ... // Licensed under Apache License v2.0 with Runtime Library Exception
+    ... //
+    ... // See https://swift.org/LICENSE.txt for license information
+    ... // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+    ... //
+    ... //===----------------------------------------------------------------------===//
+    ... 
+    ... // ###sourceLocation(file: "/public/core/Map.swift.gyb", line: 20)
+    ... 
+    ... /// The `IteratorProtocol` used by `MapSequence` and `MapCollection`.
+    ... /// Produces each element by passing the output of the `Base`
+    ... /// `IteratorProtocol` through a transform function returning `Element`.
+    ... @_fixed_layout
+    ... public struct LazyMapIterator<
+    ...   Base : IteratorProtocol, Element
+    ... > : IteratorProtocol, Sequence {
+    ...   /// Advances to the next element and returns it, or `nil` if no next element
+    ...   /// exists.
+    ...   ///
+    ...   /// Once `nil` has been returned, all subsequent calls return `nil`.
+    ...   ///
+    ...   /// - Precondition: `next()` has not been applied to a copy of `self`
+    ...   ///   since the copy was made.
+    ...   @_inlineable
+    ...   public mutating func next() -> Element? {
+    ...     return _base.next().map(_transform)
+    ...   }
+    ... 
+    ...   @_inlineable
+    ...   public var base: Base { return _base }
+    ... 
+    ...   @_versioned
+    ...   internal var _base: Base
+    ...   @_versioned
+    ...   internal let _transform: (Base.Element) -> Element
+    ... 
+    ...   @_inlineable
+    ...   @_versioned
+    ...   internal init(_base: Base, _transform: @escaping (Base.Element) -> Element) {
+    ...     self._base = _base
+    ...     self._transform = _transform
+    ...   }
+    ... }
+    ... 
+    ... /// A `Sequence` whose elements consist of those in a `Base`
+    ... /// `Sequence` passed through a transform function returning `Element`.
+    ... /// These elements are computed lazily, each time they're read, by
+    ... /// calling the transform function on a base element.
+    ... @_fixed_layout
+    ... public struct LazyMapSequence<Base : Sequence, Element>
+    ...   : LazySequenceProtocol {
+    ... 
+    ...   public typealias Elements = LazyMapSequence
+    ... 
+    ...   /// Returns an iterator over the elements of this sequence.
+    ...   ///
+    ...   /// - Complexity: O(1).
+    ...   @_inlineable
+    ...   public func makeIterator() -> LazyMapIterator<Base.Iterator, Element> {
+    ...     return LazyMapIterator(_base: _base.makeIterator(), _transform: _transform)
+    ...   }
+    ... 
+    ...   /// Returns a value less than or equal to the number of elements in
+    ...   /// `self`, **nondestructively**.
+    ...   ///
+    ...   /// - Complexity: O(*n*)
+    ...   @_inlineable
+    ...   public var underestimatedCount: Int {
+    ...     return _base.underestimatedCount
+    ...   }
+    ... 
+    ...   /// Creates an instance with elements `transform(x)` for each element
+    ...   /// `x` of base.
+    ...   @_inlineable
+    ...   @_versioned
+    ...   internal init(_base: Base, transform: @escaping (Base.Iterator.Element) -> Element) {
+    ...     self._base = _base
+    ...     self._transform = transform
+    ...   }
+    ... 
+    ...   @_versioned
+    ...   internal var _base: Base
+    ...   @_versioned
+    ...   internal let _transform: (Base.Iterator.Element) -> Element
+    ... }
+    ... 
+    ... //===--- Collections ------------------------------------------------------===//
+    ... 
+    ... // FIXME(ABI)#45 (Conditional Conformance): `LazyMap*Collection` types should be
+    ... // collapsed into one `LazyMapCollection` using conditional conformances.
+    ... // Maybe even combined with `LazyMapSequence`.
+    ... // rdar://problem/17144340
+    ... 
+    ... // ###sourceLocation(file: "/public/core/Map.swift.gyb", line: 108)
+    ... 
+    ... /// A `Collection` whose elements consist of those in a `Base`
+    ... /// `Collection` passed through a transform function returning `Element`.
+    ... /// These elements are computed lazily, each time they're read, by
+    ... /// calling the transform function on a base element.
+    ... @_fixed_layout
+    ... public struct LazyMapCollection<
+    ...   Base : Collection, Element
+    ... > : LazyCollectionProtocol, 
+    ...     _CollectionWrapper
+    ... {
+    ...   public typealias Base = Base_
+    ...   public typealias Index = Base.Index
+    ...   public typealias _Element = Base._Element
+    ...   public typealias SubSequence = Base.SubSequence
+    ...   typealias Indices = Base.Indices
+    ... 
+    ...   @_inlineable
+    ...   public subscript(position: Base.Index) -> Element {
+    ...     return _transform(_base[position])
+    ...   }
+    ...   
+    ...   /// Create an instance with elements `transform(x)` for each element
+    ...   /// `x` of base.
+    ...   @_inlineable
+    ...   @_versioned
+    ...   internal init(_base: Base, transform: @escaping (Base.Iterator.Element) -> Element) {
+    ...     self._base = _base
+    ...     self._transform = transform
+    ...   }
+    ... 
+    ...   @_versioned
+    ...   internal var _base: Base
+    ...   @_versioned
+    ...   internal let _transform: (Base.Iterator.Element) -> Element
+    ... }
+    ... 
+    ... // ###sourceLocation(file: "/public/core/Map.swift.gyb", line: 108)
+    ... 
+    ... /// A `Collection` whose elements consist of those in a `Base`
+    ... /// `Collection` passed through a transform function returning `Element`.
+    ... /// These elements are computed lazily, each time they're read, by
+    ... /// calling the transform function on a base element.
+    ... @_fixed_layout
+    ... public struct LazyMapBidirectionalCollection<
+    ...   Base : BidirectionalCollection, Element
+    ... > : LazyCollectionProtocol, 
+    ...     _BidirectionalCollectionWrapper
+    ... {
+    ...   public typealias Base = Base_
+    ...   public typealias Index = Base.Index
+    ...   public typealias _Element = Base._Element
+    ...   public typealias SubSequence = Base.SubSequence
+    ...   typealias Indices = Base.Indices
+    ... 
+    ...   @_inlineable
+    ...   public subscript(position: Base.Index) -> Element {
+    ...     return _transform(_base[position])
+    ...   }
+    ...   
+    ...   /// Create an instance with elements `transform(x)` for each element
+    ...   /// `x` of base.
+    ...   @_inlineable
+    ...   @_versioned
+    ...   internal init(_base: Base, transform: @escaping (Base.Iterator.Element) -> Element) {
+    ...     self._base = _base
+    ...     self._transform = transform
+    ...   }
+    ... 
+    ...   @_versioned
+    ...   internal var _base: Base
+    ...   @_versioned
+    ...   internal let _transform: (Base.Iterator.Element) -> Element
+    ... }
+    ... 
+    ... // ###sourceLocation(file: "/public/core/Map.swift.gyb", line: 108)
+    ... 
+    ... /// A `Collection` whose elements consist of those in a `Base`
+    ... /// `Collection` passed through a transform function returning `Element`.
+    ... /// These elements are computed lazily, each time they're read, by
+    ... /// calling the transform function on a base element.
+    ... @_fixed_layout
+    ... public struct LazyMapRandomAccessCollection<
+    ...   Base : RandomAccessCollection, Element
+    ... > : LazyCollectionProtocol, 
+    ...     _RandomAccessCollectionWrapper
+    ... {
+    ...   public typealias Base = Base_
+    ...   public typealias Index = Base.Index
+    ...   public typealias _Element = Base._Element
+    ...   public typealias SubSequence = Base.SubSequence
+    ...   typealias Indices = Base.Indices
+    ... 
+    ...   @_inlineable
+    ...   public subscript(position: Base.Index) -> Element {
+    ...     return _transform(_base[position])
+    ...   }
+    ...   
+    ...   /// Create an instance with elements `transform(x)` for each element
+    ...   /// `x` of base.
+    ...   @_inlineable
+    ...   @_versioned
+    ...   internal init(_base: Base, transform: @escaping (Base.Iterator.Element) -> Element) {
+    ...     self._base = _base
+    ...     self._transform = transform
+    ...   }
+    ... 
+    ...   @_versioned
+    ...   internal var _base: Base
+    ...   @_versioned
+    ...   internal let _transform: (Base.Iterator.Element) -> Element
+    ... }
+    ... 
+    ... // ###sourceLocation(file: "/public/core/Map.swift.gyb", line: 146)
+    ... 
+    ... //===--- Support for s.lazy -----------------------------------------------===//
+    ... 
+    ... extension LazySequenceProtocol {
+    ...   /// Returns a `LazyMapSequence` over this `Sequence`.  The elements of
+    ...   /// the result are computed lazily, each time they are read, by
+    ...   /// calling `transform` function on a base element.
+    ...   @_inlineable
+    ...   public func map<U>(
+    ...     _ transform: @escaping (Elements.Iterator.Element) -> U
+    ...   ) -> LazyMapSequence<Self.Elements, U> {
+    ...     return LazyMapSequence(_base: self.elements, transform: transform)
+    ...   }
+    ... }
+    ... 
+    ... // ###sourceLocation(file: "/public/core/Map.swift.gyb", line: 162)
+    ... 
+    ... extension LazyCollectionProtocol
+    ... // ###sourceLocation(file: "/public/core/Map.swift.gyb", line: 169)
+    ... {
+    ...   /// Returns a `LazyMapCollection` over this `Collection`.  The elements of
+    ...   /// the result are computed lazily, each time they are read, by
+    ...   /// calling `transform` function on a base element.
+    ...   @_inlineable
+    ...   public func map<U>(
+    ...     _ transform: @escaping (Elements.Iterator.Element) -> U
+    ...   ) -> LazyMapCollection<Self.Elements, U> {
+    ...     return LazyMapCollection(
+    ...       _base: self.elements,
+    ...       transform: transform)
+    ...   }
+    ... }
+    ... 
+    ... // ###sourceLocation(file: "/public/core/Map.swift.gyb", line: 162)
+    ... 
+    ... extension LazyCollectionProtocol
+    ... // ###sourceLocation(file: "/public/core/Map.swift.gyb", line: 165)
+    ...   where
+    ...   Self : BidirectionalCollection,
+    ...   Elements : BidirectionalCollection
+    ... // ###sourceLocation(file: "/public/core/Map.swift.gyb", line: 169)
+    ... {
+    ...   /// Returns a `LazyMapCollection` over this `Collection`.  The elements of
+    ...   /// the result are computed lazily, each time they are read, by
+    ...   /// calling `transform` function on a base element.
+    ...   @_inlineable
+    ...   public func map<U>(
+    ...     _ transform: @escaping (Elements.Iterator.Element) -> U
+    ...   ) -> LazyMapBidirectionalCollection<Self.Elements, U> {
+    ...     return LazyMapBidirectionalCollection(
+    ...       _base: self.elements,
+    ...       transform: transform)
+    ...   }
+    ... }
+    ... 
+    ... // ###sourceLocation(file: "/public/core/Map.swift.gyb", line: 162)
+    ... 
+    ... extension LazyCollectionProtocol
+    ... // ###sourceLocation(file: "/public/core/Map.swift.gyb", line: 165)
+    ...   where
+    ...   Self : RandomAccessCollection,
+    ...   Elements : RandomAccessCollection
+    ... // ###sourceLocation(file: "/public/core/Map.swift.gyb", line: 169)
+    ... {
+    ...   /// Returns a `LazyMapCollection` over this `Collection`.  The elements of
+    ...   /// the result are computed lazily, each time they are read, by
+    ...   /// calling `transform` function on a base element.
+    ...   @_inlineable
+    ...   public func map<U>(
+    ...     _ transform: @escaping (Elements.Iterator.Element) -> U
+    ...   ) -> LazyMapRandomAccessCollection<Self.Elements, U> {
+    ...     return LazyMapRandomAccessCollection(
+    ...       _base: self.elements,
+    ...       transform: transform)
+    ...   }
+    ... }
+    ... 
+    ... // ###sourceLocation(file: "/public/core/Map.swift.gyb", line: 184)
+    ... 
+    ... @available(*, unavailable, renamed: "LazyMapIterator")
+    ... public struct LazyMapGenerator<Base : IteratorProtocol, Element> {}
+    ... 
+    ... extension LazyMapSequence {
+    ...   @available(*, unavailable, message: "use '.lazy.map' on the sequence")
+    ...   public init(_ base: Base, transform: (Base.Iterator.Element) -> Element) {
+    ...     Builtin.unreachable()
+    ...   }
+    ... }
+    ... 
+    ... extension LazyMapCollection {
+    ...   @available(*, unavailable, message: "use '.lazy.map' on the collection")
+    ...   public init(_ base: Base, transform: (Base.Iterator.Element) -> Element) {
+    ...     Builtin.unreachable()
+    ...   }
+    ... }
+    ... 
+    ... // Local Variables:
+    ... // eval: (read-only-mode 1)
+    ... // End:
+    ... ''')
+    >>> long_output.flush()
+    >>> long_output_result = subprocess.check_output(sys.executable + ' ' +
+    ...    __file__ + ' ' + long_output.name + ' -- ' + "echo '" +
+    ...    long_output.name + ":112:27: error:'",
+    ...    shell=True).rstrip()
+    >>> print long_output_result
+    /public/core/Map.swift.gyb:118:27: error:
     >>> target1.close()
     >>> os.remove(target1.name)
     >>> target2.close()


### PR DESCRIPTION
@dabrahams

In https://bugs.swift.org/browse/SR-4238 you said you get the output

> "/Users/Shared/dabrahams/s/swift/stdlib/public/core/Map.swift.gyb:119:27: error:"

however, I get the output

> "/Users/Shared/dabrahams/s/swift/stdlib/public/core/Map.swift.gyb:118:27: error:"

I assume this is no problem