### PR TITLE
More crashers to investigate

### DIFF
--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -503,6 +503,9 @@ namespace {
 static LoweredTypeKind classifyType(CanType type, SILModule &M,
                                     CanGenericSignature sig,
                                     ResilienceExpansion expansion) {
+  assert(!type->hasError() &&
+         "Error types should not appear in type-checked AST");
+
   return TypeClassifier(M, sig, expansion).visit(type);
 }
 
@@ -1561,6 +1564,9 @@ CanSILFunctionType TypeConverter::getSILFunctionType(
 
 CanType TypeConverter::getLoweredRValueType(AbstractionPattern origType,
                                             CanType substType) {
+  assert(!substType->hasError() &&
+         "Error types should not appear in type-checked AST");
+
   // AST function types are turned into SIL function types:
   //   - the type is uncurried as desired
   //   - types are turned into their unbridged equivalents, depending

--- a/validation-test/compiler_crashers_2/0083-rdar31163470-1.swift
+++ b/validation-test/compiler_crashers_2/0083-rdar31163470-1.swift
@@ -1,0 +1,10 @@
+// RUN: not --crash %target-swift-frontend -primary-file %s -emit-ir
+// REQUIRES: asserts
+
+struct First<T> {}
+struct Second<T> {}
+
+struct Node<T> {
+  func create<U>() where T == First<U> { }
+  func create<U>() where T == Second<U> { }
+}

--- a/validation-test/compiler_crashers_2/0083-rdar31163470-2.swift
+++ b/validation-test/compiler_crashers_2/0083-rdar31163470-2.swift
@@ -1,0 +1,24 @@
+// RUN: not --crash %target-swift-frontend -primary-file %s -emit-ir
+// REQUIRES: asserts
+
+protocol C {
+  associatedtype I
+}
+
+protocol PST {
+  associatedtype LT : C
+}
+
+protocol SL {
+  associatedtype S : PST
+}
+
+struct PEN<_S : PST> : SL {
+  typealias S = _S
+  let l: _S.LT.I
+}
+
+struct PE<N : SL> {
+  let n: N
+  static func c<S>(_: PE<N>) where N == PEN<S> {}
+}


### PR DESCRIPTION
The new asserts don't change the pass/fail status of the tests, they just make them crash sooner when the problem first appears.