### PR TITLE
Mangling: Fix bug in the logic for dropping same-type constraints

### DIFF
--- a/validation-test/compiler_crashers_2_fixed/0083-rdar31163470-1.swift
+++ b/validation-test/compiler_crashers_2_fixed/0083-rdar31163470-1.swift
@@ -1,5 +1,4 @@
-// RUN: not --crash %target-swift-frontend -primary-file %s -emit-ir
-// REQUIRES: asserts
+// RUN: %target-swift-frontend -primary-file %s -emit-ir
 
 struct First<T> {}
 struct Second<T> {}


### PR DESCRIPTION
It's not correct to drop a constraint if one of the two types
structurally contains generic parameters at the method depth.