### PR TITLE
Fix top of tree Clang compilation errors

### DIFF
--- a/lib/SIL/Projection.cpp
+++ b/lib/SIL/Projection.cpp
@@ -905,7 +905,7 @@ processUsersOfValue(ProjectionTree &Tree,
     DEBUG(llvm::dbgs() << "        " << *User);
 
     // First try to create a Projection for User.
-    auto P = Projection::Projection(User);
+    auto P = Projection(User);
 
     // If we fail to create a projection, add User as a user to this node and
     // continue.

--- a/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
+++ b/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
@@ -499,7 +499,7 @@ static bool tryToSpeculateTarget(FullApplySite AI,
     if (auto EMT = SubType.getAs<AnyMetatypeType>()) {
       auto InstTy = ClassType.getSwiftRValueType();
       auto *MetaTy = MetatypeType::get(InstTy, EMT->getRepresentation());
-      auto CanMetaTy = CanMetatypeType::CanTypeWrapper(MetaTy);
+      auto CanMetaTy = CanMetatypeType(MetaTy);
       ClassOrMetatypeType = SILType::getPrimitiveObjectType(CanMetaTy);
     }
 

--- a/lib/SILOptimizer/Utils/Local.cpp
+++ b/lib/SILOptimizer/Utils/Local.cpp
@@ -2225,7 +2225,7 @@ CastOptimizer::optimizeCheckedCastBranchInst(CheckedCastBranchInst *Inst) {
         auto EMT = EmiTy.castTo<AnyMetatypeType>();
         auto *MetaTy = MetatypeType::get(LoweredConcreteTy.getSwiftRValueType(),
                                          EMT->getRepresentation());
-        auto CanMetaTy = CanMetatypeType::CanTypeWrapper(MetaTy);
+        auto CanMetaTy = CanTypeWrapper<MetatypeType>(MetaTy);
         auto SILMetaTy = SILType::getPrimitiveObjectType(CanMetaTy);
         SILBuilderWithScope B(Inst);
         auto *MI = B.createMetatype(FoundIEI->getLoc(), SILMetaTy);
@@ -2280,7 +2280,7 @@ CastOptimizer::optimizeCheckedCastBranchInst(CheckedCastBranchInst *Inst) {
         // Get the SIL metatype of this type.
         auto EMT = EMI->getType().castTo<AnyMetatypeType>();
         auto *MetaTy = MetatypeType::get(ConcreteTy, EMT->getRepresentation());
-        auto CanMetaTy = CanMetatypeType::CanTypeWrapper(MetaTy);
+        auto CanMetaTy = CanTypeWrapper<MetatypeType>(MetaTy);
         auto SILMetaTy = SILType::getPrimitiveObjectType(CanMetaTy);
         SILBuilderWithScope B(Inst);
         auto *MI = B.createMetatype(FoundIERI->getLoc(), SILMetaTy);


### PR DESCRIPTION
I'm using the top-of-tree clang-cl compiler and am getting some errors:

```
C:\Users\hughb\Documents\GitHub\swift\swift\lib\SILOptimizer\Utils\Local.cpp(2228,43):  error: qualified reference to 'CanTypeWrapper' is a constructor name rather than a type in this context
        auto CanMetaTy = CanMetatypeType::CanTypeWrapper(MetaTy);
                                          ^
C:\Users\hughb\Documents\GitHub\swift\swift\lib\SILOptimizer\Utils\Local.cpp(2283,43):  error: qualified reference to 'CanTypeWrapper' is a constructor name rather than a type in this context
        auto CanMetaTy = CanMetatypeType::CanTypeWrapper(MetaTy);
                                          ^
2 errors generated.
```