### PR TITLE
Add tests for IntegerLiteralExprSyntax

### DIFF
--- a/include/swift/Syntax/SyntaxFactory.h
+++ b/include/swift/Syntax/SyntaxFactory.h
@@ -419,7 +419,7 @@ struct SyntaxFactory {
 #pragma mark - Operators
 
   /// Make a prefix operator with the given text.
-  static RC<TokenSyntax> makePrefixOpereator(OwnedString Name,
+  static RC<TokenSyntax> makePrefixOperator(OwnedString Name,
                                              const Trivia &LeadingTrivia);
 
 #pragma mark - Types

--- a/lib/Syntax/ExprSyntax.cpp
+++ b/lib/Syntax/ExprSyntax.cpp
@@ -114,6 +114,13 @@ IntegerLiteralExprSyntax::withDigits(RC<TokenSyntax> NewDigits) const {
                                                       Cursor::Digits);
 }
 
+IntegerLiteralExprSyntax
+IntegerLiteralExprSyntax::withSign(RC<swift::syntax::TokenSyntax> NewSign)
+    const {
+    assert(NewSign->getTokenKind() == tok::oper_prefix);
+    return Data->replaceChild<IntegerLiteralExprSyntax>(NewSign, Cursor::Sign);
+}
+
 #pragma mark - symbolic-reference Data
 
 SymbolicReferenceExprSyntaxData::

--- a/lib/Syntax/SyntaxFactory.cpp
+++ b/lib/Syntax/SyntaxFactory.cpp
@@ -910,7 +910,7 @@ GenericRequirementListSyntax SyntaxFactory::makeBlankGenericRequirementList() {
 
 /// Make a prefix operator with the given text.
 RC<TokenSyntax>
-SyntaxFactory::makePrefixOpereator(OwnedString Name,
+SyntaxFactory::makePrefixOperator(OwnedString Name,
                                    const Trivia &LeadingTrivia) {
   return TokenSyntax::make(tok::oper_prefix, Name,
                            SourcePresence::Present, LeadingTrivia, {});

--- a/unittests/Syntax/DeclSyntaxTests.cpp
+++ b/unittests/Syntax/DeclSyntaxTests.cpp
@@ -208,7 +208,7 @@ FunctionParameterSyntax getCannedFunctionParameter() {
   auto NoEllipsis = TokenSyntax::missingToken(tok::identifier, "...");
   auto Equal = SyntaxFactory::makeEqualToken({}, Trivia::spaces(1));
 
-  auto Sign = SyntaxFactory::makePrefixOpereator("-", {});
+  auto Sign = SyntaxFactory::makePrefixOperator("-", {});
   auto OneDigits = SyntaxFactory::makeIntegerLiteralToken("1", {}, {});
   auto One = SyntaxFactory::makeIntegerLiteralExpr(Sign, OneDigits);
   auto Comma = SyntaxFactory::makeCommaToken({}, Trivia::spaces(1));
@@ -243,7 +243,7 @@ TEST(DeclSyntaxTests, FunctionParameterGetAPIs) {
   auto NoEllipsis = TokenSyntax::missingToken(tok::identifier, "...");
   auto Equal = SyntaxFactory::makeEqualToken({}, Trivia::spaces(1));
 
-  auto Sign = SyntaxFactory::makePrefixOpereator("-", {});
+  auto Sign = SyntaxFactory::makePrefixOperator("-", {});
   auto OneDigits = SyntaxFactory::makeIntegerLiteralToken("1", {}, {});
   auto One = SyntaxFactory::makeIntegerLiteralExpr(Sign, OneDigits);
   auto Comma = SyntaxFactory::makeCommaToken({}, {});

--- a/unittests/Syntax/ExprSyntaxTests.cpp
+++ b/unittests/Syntax/ExprSyntaxTests.cpp
@@ -8,7 +8,52 @@ using namespace swift::syntax;
 
 #pragma mark - integer-literal-expression
 
-// TODO
+TEST(ExprSyntaxTests, IntegerLiteralExprMakeAPIs) {
+  {
+    auto LiteralToken = SyntaxFactory::makeIntegerLiteralToken("100", {}, {});
+    auto Sign = SyntaxFactory::makePrefixOperator("-", {});
+    auto Literal = SyntaxFactory::makeIntegerLiteralExpr(Sign, LiteralToken);
+
+    llvm::SmallString<10> Scratch;
+    llvm::raw_svector_ostream OS(Scratch);
+    Literal.print(OS);
+    ASSERT_EQ(OS.str().str(), "-100");
+    ASSERT_EQ(Literal.getKind(), SyntaxKind::IntegerLiteralExpr);
+  }
+  {
+    auto LiteralToken = SyntaxFactory::makeIntegerLiteralToken("1_000", {}, {});
+    auto NoSign = TokenSyntax::missingToken(tok::oper_prefix, "");
+    auto Literal = SyntaxFactory::makeIntegerLiteralExpr(NoSign, LiteralToken);
+
+    llvm::SmallString<10> Scratch;
+    llvm::raw_svector_ostream OS(Scratch);
+    Literal.print(OS);
+    ASSERT_EQ(OS.str().str(), "1_000");
+  }
+  {
+    auto Literal = SyntaxFactory::makeBlankIntegerLiteralExpr()
+    .withSign(TokenSyntax::missingToken(tok::oper_prefix, ""))
+    .withDigits(SyntaxFactory::makeIntegerLiteralToken("0", {}, {
+      Trivia::spaces(4)
+    }));
+
+    llvm::SmallString<10> Scratch;
+    llvm::raw_svector_ostream OS(Scratch);
+    Literal.print(OS);
+    ASSERT_EQ(OS.str().str(), "0    ");
+  }
+  {
+    auto LiteralToken = SyntaxFactory::makeIntegerLiteralToken("1_000", {}, {});
+    auto NoSign = TokenSyntax::missingToken(tok::oper_prefix, "");
+    auto OneThousand = SyntaxFactory::makeIntegerLiteralExpr(NoSign,
+                                                             LiteralToken);
+
+    llvm::SmallString<10> Scratch;
+    llvm::raw_svector_ostream OS(Scratch);
+    OneThousand.print(OS);
+    ASSERT_EQ(OS.str().str(), "1_000");
+  }
+}
 
 #pragma mark - symbolic-reference
 

--- a/unittests/Syntax/ExprSyntaxTests.cpp
+++ b/unittests/Syntax/ExprSyntaxTests.cpp
@@ -43,15 +43,16 @@ TEST(ExprSyntaxTests, IntegerLiteralExprMakeAPIs) {
     ASSERT_EQ(OS.str().str(), "0    ");
   }
   {
-    auto LiteralToken = SyntaxFactory::makeIntegerLiteralToken("1_000", {}, {});
-    auto NoSign = TokenSyntax::missingToken(tok::oper_prefix, "");
-    auto OneThousand = SyntaxFactory::makeIntegerLiteralExpr(NoSign,
+    auto LiteralToken =
+      SyntaxFactory::makeIntegerLiteralToken("1_000_000_000_000", {}, {});
+    auto PlusSign = SyntaxFactory::makePrefixOperator("+", {});
+    auto OneThousand = SyntaxFactory::makeIntegerLiteralExpr(PlusSign,
                                                              LiteralToken);
 
     llvm::SmallString<10> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
     OneThousand.print(OS);
-    ASSERT_EQ(OS.str().str(), "1_000");
+    ASSERT_EQ(OS.str().str(), "+1_000_000_000_000");
   }
 }
 

--- a/unittests/Syntax/StmtSyntaxTests.cpp
+++ b/unittests/Syntax/StmtSyntaxTests.cpp
@@ -209,7 +209,7 @@ TEST(StmtSyntaxTests, ContinueStmtMakeAPIs) {
 
 TEST(StmtSyntaxTests, ReturnStmtMakeAPIs) {
   auto ReturnKW = SyntaxFactory::makeReturnKeyword({}, Trivia::spaces(1));
-  auto Minus = SyntaxFactory::makePrefixOpereator("-", {});
+  auto Minus = SyntaxFactory::makePrefixOperator("-", {});
   auto OneDigits = SyntaxFactory::makeIntegerLiteralToken("1", {}, {});
   auto MinusOne = SyntaxFactory::makeIntegerLiteralExpr(Minus, OneDigits);
 
@@ -230,7 +230,7 @@ TEST(StmtSyntaxTests, ReturnStmtMakeAPIs) {
 
 TEST(StmtSyntaxTests, ReturnStmtGetAPIs) {
   auto ReturnKW = SyntaxFactory::makeReturnKeyword({}, Trivia::spaces(1));
-  auto Minus = SyntaxFactory::makePrefixOpereator("-", {});
+  auto Minus = SyntaxFactory::makePrefixOperator("-", {});
   auto OneDigits = SyntaxFactory::makeIntegerLiteralToken("1", {}, {});
   auto MinusOne = SyntaxFactory::makeIntegerLiteralExpr(Minus, OneDigits);
   auto Return = SyntaxFactory::makeReturnStmt(ReturnKW, MinusOne);
@@ -243,7 +243,7 @@ TEST(StmtSyntaxTests, ReturnStmtGetAPIs) {
 
 TEST(StmtSyntaxTests, ReturnStmtWithAPIs) {
   auto ReturnKW = SyntaxFactory::makeReturnKeyword({}, Trivia::spaces(1));
-  auto Minus = SyntaxFactory::makePrefixOpereator("-", {});
+  auto Minus = SyntaxFactory::makePrefixOperator("-", {});
   auto OneDigits = SyntaxFactory::makeIntegerLiteralToken("1", {}, {});
   auto MinusOne = SyntaxFactory::makeIntegerLiteralExpr(Minus, OneDigits);
 

--- a/unittests/Syntax/ThreadSafeCachingTests.cpp
+++ b/unittests/Syntax/ThreadSafeCachingTests.cpp
@@ -82,7 +82,7 @@ public:
 // - Both threads get the exact same child (by identity)
 TEST(ThreadSafeCachingTests, ReturnGetExpression) {
   auto ReturnKW = SyntaxFactory::makeReturnKeyword({}, Trivia::spaces(1));
-  auto Minus = SyntaxFactory::makePrefixOpereator("-", {});
+  auto Minus = SyntaxFactory::makePrefixOperator("-", {});
   auto One = SyntaxFactory::makeIntegerLiteralToken("1", {}, {});
   auto MinusOne = SyntaxFactory::makeIntegerLiteralExpr(Minus, One);
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
This path adds some simple tests to `IntegerLiteralExprSyntax`, fixes a typo in `SyntaxFactory::makePrefixOperator`, and implements
`IntegerLiteralExprSyntax::withSign`.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves #46640

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->