### PR TITLE
[GSB] Keep track of all layout constraints.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1591,11 +1591,15 @@ NOTE(superclass_redundancy_here,none,
      "superclass constraint %1 : %2 %select{written here|implied here}0",
      (bool, Type, Type))
 
-ERROR(mutiple_layout_constraints,none,
-      "multiple layout constraints cannot be used at the same time: %0 and %1",
-      (LayoutConstraint, LayoutConstraint))
+ERROR(conflicting_layout_constraints,none,
+      "%select{generic parameter |protocol |}0%1 has conflicting layout "
+      "constraints %2 and %3",
+      (unsigned, Type, LayoutConstraint, LayoutConstraint))
+WARNING(redundant_layout_constraint,none,
+        "redundant layout constraint %0 : %1", (Type, LayoutConstraint))
 NOTE(previous_layout_constraint, none,
-    "previous layout constraint declaration %0 was here", (LayoutConstraint))
+     "layout constraint constraint %1 : %2 %select{written here|implied here}0",
+     (bool, Type, LayoutConstraint))
 
 ERROR(generic_param_access,none,
       "%0 %select{must be declared %select{"

--- a/test/attr/attr_specialize.swift
+++ b/test/attr/attr_specialize.swift
@@ -157,7 +157,11 @@ public func anotherFuncWithTwoGenericParameters<X: P, Y>(x: X, y: Y) {
 func funcWithForbiddenSpecializeRequirement<T>(_ t: T) {
 }
 
-@_specialize(where T: _Trivial(32), T: _Trivial(64), T: _Trivial, T: _RefCountedObject) // expected-error{{multiple layout constraints cannot be used at the same time: '_Trivial(64)' and '_Trivial(32)'}} expected-note{{previous layout constraint declaration '_Trivial(32)' was here}} expected-error{{multiple layout constraints cannot be used at the same time: '_Trivial' and '_Trivial(32)'}} expected-note{{previous layout constraint declaration '_Trivial(32)' was here}} expected-error{{multiple layout constraints cannot be used at the same time: '_RefCountedObject' and '_Trivial(32)'}} expected-note{{previous layout constraint declaration '_Trivial(32)' was here}}
+@_specialize(where T: _Trivial(32), T: _Trivial(64), T: _Trivial, T: _RefCountedObject)
+// expected-error@-1{{generic parameter 'T' has conflicting layout constraints '_Trivial(64)' and '_Trivial(32)'}}
+// expected-error@-2{{generic parameter 'T' has conflicting layout constraints '_RefCountedObject' and '_Trivial(32)'}}
+// expected-error@-3{{generic parameter 'T' has conflicting layout constraints '_Trivial' and '_Trivial(32)'}}
+// expected-note@-4 3{{layout constraint constraint 'T' : '_Trivial(32)' written here}}
 @_specialize(where Array<T> == Int) // expected-error{{Only requirements on generic parameters are supported by '_specialize' attribute}}
 // expected-error@-1{{generic signature requires types 'Array<T>' and 'Int' to be the same}}
 @_specialize(where T.Element == Int) // expected-error{{Only requirements on generic parameters are supported by '_specialize' attribute}}


### PR DESCRIPTION
As we've done with all of the other kinds of constraints, keep track
of all of the layout constraints on the equivalence class. Use the
normal mechanism to diagnose conflicts between different layout
constraints, warn about duplicate layout constraints, etc.
