### PR TITLE
[GSB] Don't emit redundant superclass constraints.

### DIFF
--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -3555,10 +3555,6 @@ namespace {
     /// potential archetypes in this component equivalent to the concrete type.
     const RequirementSource *concreteTypeSource;
 
-    /// The (best) requirement source within the component that introduces
-    /// the superclass constraint.
-    const RequirementSource *superclassSource;
-
     friend bool operator<(const SameTypeComponent &lhs,
                           const SameTypeComponent &rhs) {
       return compareDependentTypes(&lhs.anchor, &rhs.anchor) < 0;
@@ -3615,7 +3611,7 @@ static SmallVector<SameTypeComponent, 2> getSameTypeComponents(
     auto anchor = sameTypeDFS(pa, components.size(), paToComponent);
 
     // Record the anchor.
-    components.push_back({anchor, nullptr, nullptr});
+    components.push_back({anchor, nullptr});
   }
 
   // If there is a concrete type, figure out the best concrete type anchor
@@ -3634,27 +3630,24 @@ static SmallVector<SameTypeComponent, 2> getSameTypeComponents(
       bestConcreteTypeSource = concrete.source;
   }
 
-  // If there is a superclass and no concrete type, figure out the best
-  // superclass source per component.
-  if (equivClass->superclass && !equivClass->concreteType) {
-    for (const auto &superclass : equivClass->superclassConstraints) {
-    // Dig out the component associated with constraint.
-    assert(paToComponent.count(superclass.archetype) > 0);
-    auto &component = components[paToComponent[superclass.archetype]];
-
-    // If it has a better source than we'd seen before for this component,
-    // keep it.
-    auto &bestSuperclassSource = component.superclassSource;
-    if (!bestSuperclassSource ||
-        superclass.source->compare(bestSuperclassSource) < 0)
-      bestSuperclassSource = superclass.source;
-    }
-  }
-
   // Sort the components.
   llvm::array_pod_sort(components.begin(), components.end());
 
   return components;
+}
+
+namespace {
+  /// Retrieve the best requirement source from a set of constraints.
+  template<typename T>
+  const RequirementSource *getBestConstraintSource(
+                                        ArrayRef<Constraint<T>> constraints) {
+    auto bestSource = constraints.front().source;
+    for (const auto &constraint : constraints) {
+      if (constraint.source->compare(bestSource) < 0)
+        bestSource = constraint.source;
+    }
+    return bestSource;
+  }
 }
 
 void GenericSignatureBuilder::enumerateRequirements(llvm::function_ref<
@@ -3730,14 +3723,6 @@ void GenericSignatureBuilder::enumerateRequirements(llvm::function_ref<
         continue;
       }
 
-      // If we have a superclass, produce a superclass requirement
-      if (Type superclass = rep->getSuperclass()) {
-        f(RequirementKind::Superclass, archetype, superclass,
-          knownAnchor->superclassSource
-            ? knownAnchor->superclassSource
-            : RequirementSource::forAbstract(archetype));
-      }
-
       // If we're at the last anchor in the component, do nothing;
       auto nextAnchor = knownAnchor;
       ++nextAnchor;
@@ -3762,6 +3747,12 @@ void GenericSignatureBuilder::enumerateRequirements(llvm::function_ref<
 
     auto equivClass = rep->getEquivalenceClassIfPresent();
 
+    // If we have a superclass, produce a superclass requirement
+    if (equivClass && equivClass->superclass) {
+      f(RequirementKind::Superclass, archetype, equivClass->superclass,
+        getBestConstraintSource<Type>(equivClass->superclassConstraints));
+    }
+
     // If we have a layout constraint, produce a layout requirement.
     if (equivClass && equivClass->layout) {
       // Find the best source among the constraints that describe the layout
@@ -3772,7 +3763,9 @@ void GenericSignatureBuilder::enumerateRequirements(llvm::function_ref<
           bestSource = constraint.source;
       }
 
-      f(RequirementKind::Layout, archetype, equivClass->layout, bestSource);
+      f(RequirementKind::Layout, archetype, equivClass->layout,
+        getBestConstraintSource<LayoutConstraint>(
+                                              equivClass->layoutConstraints));
     }
 
     // Enumerate conformance requirements.
@@ -3792,7 +3785,9 @@ void GenericSignatureBuilder::enumerateRequirements(llvm::function_ref<
             bestSource = constraint.source;
         }
 
-        protocolSources.insert({conforms.first, bestSource});
+        protocolSources.insert(
+          {conforms.first,
+           getBestConstraintSource<ProtocolDecl *>(conforms.second)});
       }
     }
 

--- a/test/Generics/superclass_constraint.swift
+++ b/test/Generics/superclass_constraint.swift
@@ -126,3 +126,10 @@ protocol P7 {
 	// expected-note@-2{{superclass constraint 'Self.Assoc' : 'A' written here}}
 	// expected-error@-3{{'Self.Assoc' cannot be a subclass of both 'Other' and 'A'}}
 }
+
+// CHECK: superclassConformance4
+// CHECK: Generic signature: <T, U where T : P3, U : P3, T.T : C, T.T == U.T>
+func superclassConformance4<T: P3, U: P3>(_: T, _: U)
+  where T.T: C, // expected-note{{superclass constraint 'T.T' : 'C' written here}}
+        U.T: C, // expected-warning{{redundant superclass constraint 'U.T' : 'C'}}
+        T.T == U.T { }


### PR DESCRIPTION
We were emitting a superclass constraint for each connected component
of derived same-type constraints within an equivalence class, when in
fact we only need one superclass constraint for the entire equivalence
class.