### PR TITLE
Implement partial specialization which supports generic substitutions

### DIFF
--- a/include/swift/SILOptimizer/Utils/Generics.h
+++ b/include/swift/SILOptimizer/Utils/Generics.h
@@ -197,6 +197,10 @@ public:
     return SpecializedGenericEnv;
   }
 
+  GenericSignature *getSpecializedGenericSignature() const {
+    return SpecializedGenericSig;
+  }
+
   SubstitutionList getCallerParamSubstitutions() const {
     return CallerParamSubs;
   }
@@ -236,6 +240,8 @@ public:
   /// Returns true if a given apply can be specialized.
   static bool canBeSpecialized(ApplySite Apply, SILFunction *Callee,
                                SubstitutionList ParamSubs);
+
+  void verify() const;
 };
 
 /// Helper class for specializing a generic function given a list of


### PR DESCRIPTION
Use -sil-partial-specialization-with-generic-substitutions to enable the partial specialization even in cases of substitutions containing generic replacement types.

