### PR TITLE
AST: Deep sugar type reconstitution should be optional.

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -367,7 +367,7 @@ public:
 
   /// Reconstitute type sugar, e.g., for array types, dictionary
   /// types, optionals, etc.
-  TypeBase *reconstituteSugar();
+  TypeBase *reconstituteSugar(bool Recursive);
 
   /// getASTContext - Return the ASTContext that this type belongs to.
   ASTContext &getASTContext() {

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1168,8 +1168,8 @@ CanType TypeBase::getCanonicalType() {
   return CanType(Result);
 }
 
-TypeBase *TypeBase::reconstituteSugar() {
-  return Type(this).transform([](Type Ty) -> Type {
+TypeBase *TypeBase::reconstituteSugar(bool Recursive) {
+  auto Func = [](Type Ty) -> Type {
     if (auto boundGeneric = dyn_cast<BoundGenericType>(Ty.getPointer())) {
       auto &ctx = boundGeneric->getASTContext();
       if (boundGeneric->getDecl() == ctx.getArrayDecl())
@@ -1184,7 +1184,11 @@ TypeBase *TypeBase::reconstituteSugar() {
         get(boundGeneric->getGenericArgs()[0]);
     }
     return Ty;
-  }).getPointer();
+  };
+  if (Recursive)
+    return Type(this).transform(Func).getPointer();
+  else
+    return Func(this).getPointer();
 }
 
 TypeBase *TypeBase::getDesugaredType() {

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -141,7 +141,7 @@ Solution ConstraintSystem::finalize(
 
   // For each of the type variables, get its fixed type.
   for (auto tv : TypeVariables) {
-    solution.typeBindings[tv] = simplifyType(tv)->reconstituteSugar();
+    solution.typeBindings[tv] = simplifyType(tv)->reconstituteSugar(false);
   }
 
   // For each of the overload sets, get its overload choice.


### PR DESCRIPTION
Tentatively fixing a test failure in Sil parser.
