### PR TITLE
Copy-on-write existential improvements

### DIFF
--- a/lib/IRGen/GenOpaque.cpp
+++ b/lib/IRGen/GenOpaque.cpp
@@ -24,6 +24,7 @@
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/IR/DerivedTypes.h"
 
+#include "FixedTypeInfo.h"
 #include "IRGenFunction.h"
 #include "IRGenModule.h"
 #include "ProtocolInfo.h"
@@ -948,41 +949,161 @@ void irgen::emitDestroyCall(IRGenFunction &IGF, llvm::Value *metadata,
 
 Address irgen::emitAllocateValueInBuffer(IRGenFunction &IGF, SILType type,
                                          Address buffer) {
-  auto *size = emitLoadOfSize(IGF, type);
-  auto *alignMask = emitLoadOfAlignmentMask(IGF, type);
-  // TODO: check whether we fit in the inline value buffer.
-  auto valueAddr = IGF.emitAllocRawCall(size, alignMask, "outline.ValueBuffer");
-  IGF.Builder.CreateStore(
-      valueAddr,
-      Address(IGF.Builder.CreateBitCast(buffer.getAddress(),
-                                        valueAddr->getType()->getPointerTo()),
-              Alignment(1)));
-  valueAddr =
-      IGF.Builder.CreateBitCast(valueAddr, IGF.IGM.getStoragePointerType(type));
-  return Address(valueAddr, Alignment(1));
+  // Handle FixedSize types.
+  auto &IGM = IGF.IGM;
+  auto storagePtrTy = IGM.getStoragePointerType(type);
+  if (auto *fixedTI = dyn_cast<FixedTypeInfo>(&IGF.getTypeInfo(type))) {
+    auto packing = fixedTI->getFixedPacking(IGM);
 
+    // Inline representation.
+    if (packing == FixedPacking::OffsetZero) {
+      return Address(
+          IGF.Builder.CreateBitCast(buffer.getAddress(), storagePtrTy),
+          buffer.getAlignment());
+    }
+
+    // Outline representation.
+    assert(packing == FixedPacking::Allocate && "Expect non dynamic packing");
+    auto size = fixedTI->getStaticSize(IGM);
+    auto alignMask = fixedTI->getStaticAlignmentMask(IGM);
+    auto valueAddr =
+        IGF.emitAllocRawCall(size, alignMask, "outline.ValueBuffer");
+    IGF.Builder.CreateStore(
+        valueAddr,
+        Address(IGF.Builder.CreateBitCast(buffer.getAddress(),
+                                          valueAddr->getType()->getPointerTo()),
+                buffer.getAlignment()));
+    return Address(IGF.Builder.CreateBitCast(valueAddr, storagePtrTy),
+                   buffer.getAlignment());
+  }
+
+  // Dynamic packing.
+  llvm::Value *isInline = emitLoadOfIsInline(IGF, type);
+  auto *outlineBB = IGF.createBasicBlock("outline.allocateValueInBuffer");
+  auto *doneBB = IGF.createBasicBlock("done");
+  llvm::Value *addressInline, *addressOutline;
+  auto *origBB = IGF.Builder.GetInsertBlock();
+  addressInline = IGF.Builder.CreateBitCast(buffer.getAddress(), storagePtrTy);
+  IGF.Builder.CreateCondBr(isInline, doneBB, outlineBB);
+
+  IGF.Builder.emitBlock(outlineBB);
+  {
+    ConditionalDominanceScope scope(IGF);
+    auto *size = emitLoadOfSize(IGF, type);
+    auto *alignMask = emitLoadOfAlignmentMask(IGF, type);
+    auto valueAddr =
+        IGF.emitAllocRawCall(size, alignMask, "outline.ValueBuffer");
+    IGF.Builder.CreateStore(
+        valueAddr,
+        Address(IGF.Builder.CreateBitCast(buffer.getAddress(),
+                                          valueAddr->getType()->getPointerTo()),
+                Alignment(1)));
+    addressOutline = IGF.Builder.CreateBitCast(valueAddr, storagePtrTy);
+    IGF.Builder.CreateBr(doneBB);
+  }
+
+  IGF.Builder.emitBlock(doneBB);
+  auto *addressOfValue = IGF.Builder.CreatePHI(storagePtrTy, 2);
+  addressOfValue->addIncoming(addressInline, origBB);
+  addressOfValue->addIncoming(addressOutline, outlineBB);
+
+  return Address(addressOfValue, Alignment(1));
 }
 
-Address irgen::emitProjectValueInBuffer(IRGenFunction &IGF,
-                            SILType type,
-                            Address buffer) {
-  // TODO: check whether we fit in the inline value buffer.
-  auto ptr = IGF.Builder.CreateLoad(Address(
-      IGF.Builder.CreateBitCast(buffer.getAddress(), IGF.IGM.Int8PtrPtrTy),
-      Alignment(1)));
-  auto valueAddr =
-      IGF.Builder.CreateBitCast(ptr, IGF.IGM.getStoragePointerType(type));
-  return Address(valueAddr, Alignment(1));
+Address irgen::emitProjectValueInBuffer(IRGenFunction &IGF, SILType type,
+                                        Address buffer) {
+  // Handle FixedSize types.
+  auto &IGM = IGF.IGM;
+  auto storagePtrTy = IGM.getStoragePointerType(type);
+  if (auto *fixedTI = dyn_cast<FixedTypeInfo>(&IGF.getTypeInfo(type))) {
+    auto packing = fixedTI->getFixedPacking(IGM);
+
+    // Inline representation.
+    if (packing == FixedPacking::OffsetZero) {
+      return Address(
+          IGF.Builder.CreateBitCast(buffer.getAddress(), storagePtrTy),
+          buffer.getAlignment());
+    }
+
+    // Outline representation.
+    assert(packing == FixedPacking::Allocate && "Expect non dynamic packing");
+    auto valueAddr = IGF.Builder.CreateLoad(
+        Address(IGF.Builder.CreateBitCast(buffer.getAddress(),
+                                          storagePtrTy->getPointerTo()),
+                buffer.getAlignment()));
+    return Address(IGF.Builder.CreateBitCast(valueAddr, storagePtrTy),
+                   buffer.getAlignment());
+  }
+
+  // Dynamic packing.
+  llvm::Value *isInline = emitLoadOfIsInline(IGF, type);
+  auto *outlineBB = IGF.createBasicBlock("outline.projectValueInBuffer");
+  auto *doneBB = IGF.createBasicBlock("done");
+  llvm::Value *addressInline, *addressOutline;
+  auto *origBB = IGF.Builder.GetInsertBlock();
+  addressInline = IGF.Builder.CreateBitCast(buffer.getAddress(), storagePtrTy);
+
+  IGF.Builder.CreateCondBr(isInline, doneBB, outlineBB);
+
+  IGF.Builder.emitBlock(outlineBB);
+  {
+    auto ptr = IGF.Builder.CreateLoad(
+        Address(IGF.Builder.CreateBitCast(buffer.getAddress(),
+                                          storagePtrTy->getPointerTo()),
+                Alignment(1)));
+    addressOutline = IGF.Builder.CreateBitCast(ptr, storagePtrTy);
+    IGF.Builder.CreateBr(doneBB);
+  }
+
+  IGF.Builder.emitBlock(doneBB);
+  auto *addressOfValue = IGF.Builder.CreatePHI(storagePtrTy, 2);
+  addressOfValue->addIncoming(addressInline, origBB);
+  addressOfValue->addIncoming(addressOutline, outlineBB);
+
+  return Address(addressOfValue, Alignment(1));
 }
 
 void irgen::emitDeallocateValueInBuffer(IRGenFunction &IGF,
                                  SILType type,
                                  Address buffer) {
-  auto *size = emitLoadOfSize(IGF, type);
-  auto *alignMask = emitLoadOfAlignmentMask(IGF, type);
-  auto *ptr = IGF.Builder.CreateLoad(Address(
-      IGF.Builder.CreateBitCast(buffer.getAddress(), IGF.IGM.Int8PtrPtrTy),
-      Alignment(1)));
-  // TODO: check whether we fit in the inline value buffer.
-  IGF.emitDeallocRawCall(ptr, size, alignMask);
+  // Handle FixedSize types.
+  auto &IGM = IGF.IGM;
+  if (auto *fixedTI = dyn_cast<FixedTypeInfo>(&IGF.getTypeInfo(type))) {
+    auto packing = fixedTI->getFixedPacking(IGM);
+
+    // Inline representation.
+    if (packing == FixedPacking::OffsetZero)
+      return;
+
+    // Outline representation.
+    assert(packing == FixedPacking::Allocate && "Expect non dynamic packing");
+    auto size = fixedTI->getStaticSize(IGM);
+    auto alignMask = fixedTI->getStaticAlignmentMask(IGM);
+    auto *ptr = IGF.Builder.CreateLoad(Address(
+        IGF.Builder.CreateBitCast(buffer.getAddress(), IGM.Int8PtrPtrTy),
+        buffer.getAlignment()));
+    IGF.emitDeallocRawCall(ptr, size, alignMask);
+    return;
+  }
+
+  // Dynamic packing.
+  llvm::Value *isInline = emitLoadOfIsInline(IGF, type);
+  auto *outlineBB = IGF.createBasicBlock("outline.projectValueInBuffer");
+  auto *doneBB = IGF.createBasicBlock("done");
+
+  IGF.Builder.CreateCondBr(isInline, doneBB, outlineBB);
+
+  IGF.Builder.emitBlock(outlineBB);
+  {
+    ConditionalDominanceScope scope(IGF);
+    auto *size = emitLoadOfSize(IGF, type);
+    auto *alignMask = emitLoadOfAlignmentMask(IGF, type);
+    auto *ptr = IGF.Builder.CreateLoad(Address(
+        IGF.Builder.CreateBitCast(buffer.getAddress(), IGM.Int8PtrPtrTy),
+        buffer.getAlignment()));
+    IGF.emitDeallocRawCall(ptr, size, alignMask);
+    IGF.Builder.CreateBr(doneBB);
+  }
+
+  IGF.Builder.emitBlock(doneBB);
 }

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -2228,8 +2228,13 @@ ExistentialTypeMetadata::mayTakeValue(const OpaqueValue *container) const {
   // Opaque existential containers uniquely own their contained value.
   case ExistentialTypeRepresentation::Opaque:
 #ifdef SWIFT_RUNTIME_ENABLE_COW_EXISTENTIALS
+  {
     // We can't take from a shared existential box without checking uniqueness.
-    return false;
+    auto *opaque =
+        reinterpret_cast<const OpaqueExistentialContainer *>(container);
+    auto *vwt = opaque->Type->getValueWitnesses();
+    return vwt->isValueInline();
+  }
 #else
     return true;
 #endif


### PR DESCRIPTION
Runtime: Allow taking out of inline opaque existentials
Only values stored in the outline boxed existential representation can be
shared.

Use the inline value buffer for allocate/project/deallocateValueBuffer functions
Also handle fixed size types.