### PR TITLE
AST: avoid "deprecation" warning

### DIFF
--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -423,9 +423,9 @@ void SubstitutionMap::verify() const {
       // All of the conformances should be concrete.
       if (!citer->isConcrete()) {
         llvm::dbgs() << "Concrete replacement type:\n";
-        replacement->dump();
+        replacement->dump(llvm::dbgs());
         llvm::dbgs() << "SubstitutionMap:\n";
-        dump();
+        dump(llvm::dbgs());
       }
       assert(citer->isConcrete() && "Conformance should be concrete");
     }


### PR DESCRIPTION
The "dump()" interface is meant for use in the debugger only.  Use the
parameter form to avoid the -Wdeprecated-declaration warning.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
