### PR TITLE
[AST Printer] Don't resugar base types when printing "A.B".

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3368,6 +3368,9 @@ private:
 class ProtocolDecl : public NominalTypeDecl {
   SourceLoc ProtocolLoc;
 
+  /// The location of the 'class' keyword for class-bound protocols.
+  SourceLoc ClassRequirementLoc;
+
   /// The syntactic representation of the where clause in a protocol like
   /// `protocol ... where ... { ... }`.
   TrailingWhereClause *TrailingWhere;
@@ -3443,6 +3446,17 @@ public:
     ProtocolDeclBits.RequiresClassValid = true;
     ProtocolDeclBits.RequiresClass = requiresClass;
   }
+
+  /// Specify that this protocol is class-bounded, recording the location of
+  /// the 'class' keyword.
+  void setClassBounded(SourceLoc loc) {
+    ClassRequirementLoc = loc;
+    ProtocolDeclBits.RequiresClassValid = true;
+    ProtocolDeclBits.RequiresClass = true;
+  }
+
+  /// Retrieve the source location of the 'class' keyword.
+  SourceLoc getClassBoundedLoc() const { return ClassRequirementLoc; }
 
   /// Determine whether an existential conforming to this protocol can be
   /// matched with a generic type parameter constrained to this protocol.

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3747,9 +3747,21 @@ public:
     printGenericArgs(T->getGenericArgs());
   }
 
+  void visitParentType(Type T) {
+    PrintOptions innerOptions = Options;
+    innerOptions.SynthesizeSugarOnTypes = false;
+
+    if (auto sugarType = dyn_cast<SyntaxSugarType>(T.getPointer()))
+      T = sugarType->getImplementationType();
+    else if (auto dictType = dyn_cast<DictionaryType>(T.getPointer()))
+      T = dictType->getImplementationType();
+
+    TypePrinter(Printer, innerOptions).visit(T);
+  }
+
   void visitEnumType(EnumType *T) {
     if (auto ParentType = T->getParent()) {
-      visit(ParentType);
+      visitParentType(ParentType);
       Printer << ".";
     } else if (shouldPrintFullyQualified(T)) {
       printModuleContext(T);
@@ -3760,7 +3772,7 @@ public:
 
   void visitStructType(StructType *T) {
     if (auto ParentType = T->getParent()) {
-      visit(ParentType);
+      visitParentType(ParentType);
       Printer << ".";
     } else if (shouldPrintFullyQualified(T)) {
       printModuleContext(T);
@@ -3771,7 +3783,7 @@ public:
 
   void visitClassType(ClassType *T) {
     if (auto ParentType = T->getParent()) {
-      visit(ParentType);
+      visitParentType(ParentType);
       Printer << ".";
     } else if (shouldPrintFullyQualified(T)) {
       printModuleContext(T);
@@ -4212,7 +4224,7 @@ public:
   }
 
   void visitDependentMemberType(DependentMemberType *T) {
-    visit(T->getBase());
+    visitParentType(T->getBase());
     Printer << ".";
     Printer.printName(T->getName());
   }

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -3555,10 +3555,6 @@ namespace {
     /// potential archetypes in this component equivalent to the concrete type.
     const RequirementSource *concreteTypeSource;
 
-    /// The (best) requirement source within the component that introduces
-    /// the superclass constraint.
-    const RequirementSource *superclassSource;
-
     friend bool operator<(const SameTypeComponent &lhs,
                           const SameTypeComponent &rhs) {
       return compareDependentTypes(&lhs.anchor, &rhs.anchor) < 0;
@@ -3615,7 +3611,7 @@ static SmallVector<SameTypeComponent, 2> getSameTypeComponents(
     auto anchor = sameTypeDFS(pa, components.size(), paToComponent);
 
     // Record the anchor.
-    components.push_back({anchor, nullptr, nullptr});
+    components.push_back({anchor, nullptr});
   }
 
   // If there is a concrete type, figure out the best concrete type anchor
@@ -3634,27 +3630,24 @@ static SmallVector<SameTypeComponent, 2> getSameTypeComponents(
       bestConcreteTypeSource = concrete.source;
   }
 
-  // If there is a superclass and no concrete type, figure out the best
-  // superclass source per component.
-  if (equivClass->superclass && !equivClass->concreteType) {
-    for (const auto &superclass : equivClass->superclassConstraints) {
-    // Dig out the component associated with constraint.
-    assert(paToComponent.count(superclass.archetype) > 0);
-    auto &component = components[paToComponent[superclass.archetype]];
-
-    // If it has a better source than we'd seen before for this component,
-    // keep it.
-    auto &bestSuperclassSource = component.superclassSource;
-    if (!bestSuperclassSource ||
-        superclass.source->compare(bestSuperclassSource) < 0)
-      bestSuperclassSource = superclass.source;
-    }
-  }
-
   // Sort the components.
   llvm::array_pod_sort(components.begin(), components.end());
 
   return components;
+}
+
+namespace {
+  /// Retrieve the best requirement source from a set of constraints.
+  template<typename T>
+  const RequirementSource *getBestConstraintSource(
+                                        ArrayRef<Constraint<T>> constraints) {
+    auto bestSource = constraints.front().source;
+    for (const auto &constraint : constraints) {
+      if (constraint.source->compare(bestSource) < 0)
+        bestSource = constraint.source;
+    }
+    return bestSource;
+  }
 }
 
 void GenericSignatureBuilder::enumerateRequirements(llvm::function_ref<
@@ -3730,14 +3723,6 @@ void GenericSignatureBuilder::enumerateRequirements(llvm::function_ref<
         continue;
       }
 
-      // If we have a superclass, produce a superclass requirement
-      if (Type superclass = rep->getSuperclass()) {
-        f(RequirementKind::Superclass, archetype, superclass,
-          knownAnchor->superclassSource
-            ? knownAnchor->superclassSource
-            : RequirementSource::forAbstract(archetype));
-      }
-
       // If we're at the last anchor in the component, do nothing;
       auto nextAnchor = knownAnchor;
       ++nextAnchor;
@@ -3762,6 +3747,12 @@ void GenericSignatureBuilder::enumerateRequirements(llvm::function_ref<
 
     auto equivClass = rep->getEquivalenceClassIfPresent();
 
+    // If we have a superclass, produce a superclass requirement
+    if (equivClass && equivClass->superclass) {
+      f(RequirementKind::Superclass, archetype, equivClass->superclass,
+        getBestConstraintSource<Type>(equivClass->superclassConstraints));
+    }
+
     // If we have a layout constraint, produce a layout requirement.
     if (equivClass && equivClass->layout) {
       // Find the best source among the constraints that describe the layout
@@ -3772,7 +3763,9 @@ void GenericSignatureBuilder::enumerateRequirements(llvm::function_ref<
           bestSource = constraint.source;
       }
 
-      f(RequirementKind::Layout, archetype, equivClass->layout, bestSource);
+      f(RequirementKind::Layout, archetype, equivClass->layout,
+        getBestConstraintSource<LayoutConstraint>(
+                                              equivClass->layoutConstraints));
     }
 
     // Enumerate conformance requirements.
@@ -3792,7 +3785,9 @@ void GenericSignatureBuilder::enumerateRequirements(llvm::function_ref<
             bestSource = constraint.source;
         }
 
-        protocolSources.insert({conforms.first, bestSource});
+        protocolSources.insert(
+          {conforms.first,
+           getBestConstraintSource<ProtocolDecl *>(conforms.second)});
       }
     }
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -5306,7 +5306,7 @@ parseDeclProtocol(ParseDeclOptions Flags, DeclAttributes &Attributes) {
 
   // If there was a 'class' requirement, mark this as a class-bounded protocol.
   if (classRequirementLoc.isValid())
-    Proto->setRequiresClass();
+    Proto->setClassBounded(classRequirementLoc);
 
   Proto->getAttrs() = Attributes;
 

--- a/test/Generics/superclass_constraint.swift
+++ b/test/Generics/superclass_constraint.swift
@@ -126,3 +126,10 @@ protocol P7 {
 	// expected-note@-2{{superclass constraint 'Self.Assoc' : 'A' written here}}
 	// expected-error@-3{{'Self.Assoc' cannot be a subclass of both 'Other' and 'A'}}
 }
+
+// CHECK: superclassConformance4
+// CHECK: Generic signature: <T, U where T : P3, U : P3, T.T : C, T.T == U.T>
+func superclassConformance4<T: P3, U: P3>(_: T, _: U)
+  where T.T: C, // expected-note{{superclass constraint 'T.T' : 'C' written here}}
+        U.T: C, // expected-warning{{redundant superclass constraint 'U.T' : 'C'}}
+        T.T == U.T { }


### PR DESCRIPTION

Fixes the recent regression in the SIL parse_stdlib tests.