### PR TITLE
[Parser] Don't warn about unescaping the _ in foo(`_`: 3).

### DIFF
--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1145,9 +1145,12 @@ public:
   ParserResult<Expr> parseExprStringLiteral();
   ParserResult<Expr> parseExprTypeOf();
 
-  /// If the token is an escaped identifier being used as an argument
-  /// label, but doesn't need to be, diagnose it.
-  void diagnoseEscapedArgumentLabel(const Token &tok);
+  /// Parse an argument label `identifier ':'`, if it exists.
+  ///
+  /// \param name The parsed name of the label (empty if it doesn't exist, or is
+  /// _)
+  /// \param loc The location of the label (empty if it doesn't exist)
+  void parseOptionalArgumentLabel(Identifier &name, SourceLoc &loc);
 
   /// Parse an unqualified-decl-name.
   ///

--- a/test/decl/func/keyword-argument-labels.swift
+++ b/test/decl/func/keyword-argument-labels.swift
@@ -49,3 +49,9 @@ func testCalls(_ range: SomeRange) {
   // Fix-Its
   paramName(0, `in`: range) // expected-warning{{keyword 'in' does not need to be escaped in argument list}}{{16-17=}}{{19-20=}}
 }
+
+// rdar://problem/31077797
+func foo(`_`: Int) {}
+foo(`_`: 3)
+let f = foo(`_`:)
+f(3)


### PR DESCRIPTION
`foo(_: 3)` is equivalent to `foo(3)`, so calling a function that has _ as
an argument label (``func foo(`_`: 3)``) still requires the _ to be
escaped. Before this patch, the compiler would suggest removing the `s,
even though that changes behaviour.

Fixes rdar://problem/31077797.
