### PR TITLE
[GSB] Improve handling of layout constraints

### DIFF
--- a/include/swift/AST/LayoutConstraint.h
+++ b/include/swift/AST/LayoutConstraint.h
@@ -259,6 +259,10 @@ class LayoutConstraint {
 
   LayoutConstraintInfo *operator->() const { return Ptr; }
 
+  /// Merge these two constraints and return a more specific one
+  /// or fail if they’re incompatible and return an unknown constraint.
+  LayoutConstraint merge(LayoutConstraint Other);
+
   explicit operator bool() const { return Ptr != 0; }
 
   void dump() const;

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -4074,6 +4074,12 @@ LayoutConstraint LayoutConstraint::getLayoutConstraint(LayoutConstraintKind Kind
                                                       unsigned SizeInBits,
                                                       unsigned Alignment,
                                                       ASTContext &C) {
+  if (!LayoutConstraintInfo::isKnownSizeTrivial(Kind)) {
+    assert(SizeInBits == 0);
+    assert(Alignment == 0);
+    return getLayoutConstraint(Kind);
+  }
+
   // Check to see if we've already seen this tuple before.
   llvm::FoldingSetNodeID ID;
   LayoutConstraintInfo::Profile(ID, Kind, SizeInBits, Alignment);
@@ -4094,7 +4100,4 @@ LayoutConstraint LayoutConstraint::getLayoutConstraint(LayoutConstraintKind Kind
   return LayoutConstraint(New);
 }
 
-LayoutConstraint LayoutConstraint::getUnknownLayout(ASTContext &C) {
-  return getLayoutConstraint(LayoutConstraintKind::UnknownLayout, 0, 0, C);
-}
 

--- a/lib/AST/LayoutConstraint.cpp
+++ b/lib/AST/LayoutConstraint.cpp
@@ -140,6 +140,168 @@ void *LayoutConstraintInfo::operator new(size_t bytes, const ASTContext &ctx,
 
 SourceRange LayoutConstraintLoc::getSourceRange() const { return getLoc(); }
 
+#define MERGE_LOOKUP(lhs, rhs)                                                 \
+  mergeTable[int(lhs)][int(rhs)]
+
+// Shortcut for spelling the whole enumerator.
+#define E(X) LayoutConstraintKind::X
+#define MERGE_CONFLICT LayoutConstraintKind::UnknownLayout
+
+/// This is a 2-D table defining the merging rules for layout constraints.
+/// It is indexed by means of LayoutConstraintKind.
+/// mergeTable[i][j] tells the kind of a layout constraint is the result
+/// of merging layout constraints of kinds 'i' and 'j'.
+///
+/// Some of the properties of the merge table, where C is any type of layout
+/// constraint:
+///   UnknownLayout x C -> C
+///   C x UnknownLayout -> C
+///   C x C -> C
+///   mergeTable[i][j] == mergeTable[j][i], i.e. the table is symmetric.
+///   mergeTable[i][j] == UnknownLayout if merging layout constraints of kinds i
+///   and j would result in a conflict.
+static LayoutConstraintKind mergeTable[unsigned(E(LastLayout)) +
+                                       1][unsigned(E(LastLayout)) + 1] = {
+    // Initialize the row for UnknownLayout.
+    {E(/* UnknownLayout */ UnknownLayout),
+     E(/* TrivialOfExactSize */ TrivialOfExactSize),
+     E(/* TrivialOfAtMostSize */ TrivialOfAtMostSize), E(/* Trivial */ Trivial),
+     E(/* Class */ Class), E(/* NativeClass */ NativeClass),
+     E(/* RefCountedObject*/ RefCountedObject),
+     E(/* NativeRefCountedObject */ NativeRefCountedObject)},
+
+    // Initiaze the row for TrivialOfExactSize.
+    {E(/* UnknownLayout */ TrivialOfExactSize),
+     E(/* TrivialOfExactSize */ TrivialOfExactSize), MERGE_CONFLICT,
+     E(/* Trivial */ TrivialOfExactSize), MERGE_CONFLICT, MERGE_CONFLICT,
+     MERGE_CONFLICT, MERGE_CONFLICT},
+
+    // Initiaze the row for TrivialOfAtMostSize.
+    {E(/* UnknownLayout */ TrivialOfAtMostSize), MERGE_CONFLICT,
+     E(/* TrivialOfAtMostSize */ TrivialOfAtMostSize),
+     E(/* Trivial */ TrivialOfAtMostSize), MERGE_CONFLICT, MERGE_CONFLICT,
+     MERGE_CONFLICT, MERGE_CONFLICT},
+
+    // Initiaze the row for Trivial.
+    {E(/* UnknownLayout */ Trivial),
+     E(/* TrivialOfExactSize */ TrivialOfExactSize),
+     E(/* TrivialOfAtMostSize */ TrivialOfAtMostSize), E(/* Trivial */ Trivial),
+     MERGE_CONFLICT, MERGE_CONFLICT, MERGE_CONFLICT, MERGE_CONFLICT},
+
+    // Initiaze the row for Class.
+    {E(/* UnknownLayout*/ Class), MERGE_CONFLICT, MERGE_CONFLICT,
+     MERGE_CONFLICT, E(/* Class */ Class), E(/* NativeClass */ NativeClass),
+     E(/* RefCountedObject */ Class),
+     E(/* NativeRefCountedObject */ NativeClass)},
+
+    // Initiaze the row for NativeClass.
+    {E(/* UnknownLayout */ NativeClass), MERGE_CONFLICT, MERGE_CONFLICT,
+     MERGE_CONFLICT, E(/* Class */ NativeClass),
+     E(/* NativeClass */ NativeClass), E(/* RefCountedObject */ NativeClass),
+     E(/* NativeRefCountedObject */ NativeClass)},
+
+    // Initiaze the row for RefCountedObject.
+    {E(/* UnknownLayout */ RefCountedObject), MERGE_CONFLICT, MERGE_CONFLICT,
+     MERGE_CONFLICT, E(/* Class */ Class), E(/* NativeClass */ NativeClass),
+     E(/* RefCountedObject */ RefCountedObject),
+     E(/* NativeRefCountedObject */ NativeRefCountedObject)},
+
+    // Initiaze the row for NativeRefCountedObject.
+    {E(/* UnknownLayout */ NativeRefCountedObject), MERGE_CONFLICT,
+     MERGE_CONFLICT, MERGE_CONFLICT, E(/* Class */ NativeClass),
+     E(/* NativeClass */ NativeClass),
+     E(/* RefCountedObject */ NativeRefCountedObject),
+     E(/* NativeRefCountedObject*/ NativeRefCountedObject)},
+};
+
+#undef E
+
+// Fixed-size trivial constraint can be combined with AtMostSize trivial
+// constraint into a fixed-size trivial constraint, if
+// fixed_size_layout.size <= at_most_size_layout.size and
+// their alignment requirements are not contradicting.
+//
+// Only merges if LHS would become the result of the merge.
+static LayoutConstraint
+mergeKnownSizeTrivialConstraints(LayoutConstraint LHS, LayoutConstraint RHS) {
+  assert(LHS->isKnownSizeTrivial() && RHS->isKnownSizeTrivial());
+
+  // LHS should be fixed-size.
+  if (!LHS->isFixedSizeTrivial())
+    return LayoutConstraint::getUnknownLayout();
+
+  // RHS should be at-most-size.
+  if (RHS->isFixedSizeTrivial())
+    return LayoutConstraint::getUnknownLayout();
+
+  // Check that sizes are compatible, i.e.
+  // fixed_size_layout.size <= at_most_size_layout.size
+  if (LHS->getMaxTrivialSizeInBits() > RHS->getMaxTrivialSizeInBits())
+    return LayoutConstraint::getUnknownLayout();
+
+  // Check alignments
+
+  // Quick exit if at_most_size_layout does not care about the alignment.
+  if (!RHS->getAlignment())
+    return LHS;
+
+  // Check if fixed_size_layout.alignment is a multple of
+  // at_most_size_layout.alignment.
+  if (LHS->getAlignment() && LHS->getAlignment() % RHS->getAlignment() == 0)
+    return LHS;
+
+  return LayoutConstraint::getUnknownLayout();
+}
+
+LayoutConstraint
+LayoutConstraint::merge(LayoutConstraint Other) {
+  auto Self = *this;
+
+  // If both constraints are the same, they are always equal.
+  if (Self == Other)
+    return Self;
+
+  // TrivialOfExactSize and TrivialOfAtMostSize are a special case,
+  // because not only their kind, but their parameters need to be compared as
+  // well.
+  if (Self->isKnownSizeTrivial() && Other->isKnownSizeTrivial()) {
+    // If we got here, it means that the Self == Other check above has failed.
+    // And that could only happen if either the kinds are different or
+    // size/alignment parameters are different.
+
+    // Try to merge fixed-size constraint with an at-most-size constraint,
+    // if possible.
+    LayoutConstraint MergedKnownSizeTrivial;
+    MergedKnownSizeTrivial = mergeKnownSizeTrivialConstraints(Self, Other);
+    if (MergedKnownSizeTrivial->isKnownLayout())
+      return MergedKnownSizeTrivial;
+
+    MergedKnownSizeTrivial = mergeKnownSizeTrivialConstraints(Other, Self);
+    if (MergedKnownSizeTrivial->isKnownLayout())
+      return MergedKnownSizeTrivial;
+
+    return LayoutConstraint::getUnknownLayout();
+  }
+
+  // Lookup in the mergeTable if this combination of layouts can be merged.
+  auto mergeKind = MERGE_LOOKUP(Self->getKind(), Other->getKind());
+  // The merge table should be symmetric.
+  assert(mergeKind == MERGE_LOOKUP(Other->getKind(), Self->getKind()));
+
+  // Merge is not possible, report a conflict.
+  if (mergeKind == LayoutConstraintKind::UnknownLayout)
+    return LayoutConstraint::getUnknownLayout();
+
+  if (Self->getKind() == mergeKind)
+    return Self;
+
+  if (Other->getKind() == mergeKind)
+    return Other;
+
+  // The result of the merge is not equal to any of the input constraints, e.g.
+  // Class x NativeRefCountedObject -> NativeClass.
+  return LayoutConstraint::getLayoutConstraint(mergeKind);
+}
 
 LayoutConstraint
 LayoutConstraint::getLayoutConstraint(LayoutConstraintKind Kind) {

--- a/lib/IRGen/GenArchetype.cpp
+++ b/lib/IRGen/GenArchetype.cpp
@@ -282,7 +282,7 @@ const TypeInfo *TypeConverter::convertArchetypeType(ArchetypeType *archetype) {
   // If the archetype is class-constrained, use a class pointer
   // representation.
   if (archetype->requiresClass() ||
-      (LayoutInfo && LayoutInfo->isRefCountedObject())) {
+      (LayoutInfo && LayoutInfo->isRefCounted())) {
     ReferenceCounting refcount;
     llvm::PointerType *reprTy;
 

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -111,24 +111,24 @@ LayoutConstraint Parser::parseLayoutConstraint(Identifier LayoutConstraintID) {
     // There was an error during parsing.
     skipUntil(tok::r_paren);
     consumeIf(tok::r_paren);
-    return LayoutConstraint::getUnknownLayout(Context);
+    return LayoutConstraint::getUnknownLayout();
   }
 
   if (!consumeIf(tok::r_paren)) {
     // Expected a closing r_paren.
     diagnose(Tok.getLoc(), diag::expected_rparen_layout_constraint);
     consumeToken();
-    return LayoutConstraint::getUnknownLayout(Context);
+    return LayoutConstraint::getUnknownLayout();
   }
 
   if (size < 0) {
     diagnose(Tok.getLoc(), diag::layout_size_should_be_positive);
-    return LayoutConstraint::getUnknownLayout(Context);
+    return LayoutConstraint::getUnknownLayout();
   }
 
   if (alignment < 0) {
     diagnose(Tok.getLoc(), diag::layout_alignment_should_be_positive);
-    return LayoutConstraint::getUnknownLayout(Context);
+    return LayoutConstraint::getUnknownLayout();
   }
 
   // Otherwise it is a trivial layout constraint with

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -337,7 +337,7 @@ namespace {
           return asImpl().handleTrivialAddressOnly(type);
         }
 
-        if (LayoutInfo->isRefCountedObject())
+        if (LayoutInfo->isRefCounted())
           return asImpl().handleReference(type);
       }
       return asImpl().handleAddressOnly(type);

--- a/lib/SILOptimizer/IPO/EagerSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/EagerSpecializer.cpp
@@ -354,7 +354,7 @@ void EagerDispatch::emitDispatchTo(SILFunction *NewFunc) {
         // Emit a check that it is a trivial type of a certain size.
         emitTrivialAndSizeCheck(FailedTypeCheckBB, ParamTy,
                                 Replacement, LayoutInfo);
-      } else if (LayoutInfo && LayoutInfo->isRefCountedObject()) {
+      } else if (LayoutInfo && LayoutInfo->isRefCounted()) {
         // Emit a check that it is an object of a reference counted type.
         emitRefCountedObjectCheck(FailedTypeCheckBB, ParamTy,
                                   Replacement, LayoutInfo);

--- a/test/Generics/superclass_constraint.swift
+++ b/test/Generics/superclass_constraint.swift
@@ -76,6 +76,7 @@ extension P2 where Self.T : C {
 // CHECK: superclassConformance1
 // CHECK: Requirements:
 // CHECK-NEXT: τ_0_0 : C [τ_0_0: Explicit @ {{.*}}:11]
+// CHECK-NEXT: τ_0_0 : _NativeClass [τ_0_0: Explicit @ {{.*}}:11 -> Superclass]
 // CHECK-NEXT: τ_0_0 : P3 [τ_0_0: Explicit @ {{.*}}:11 -> Superclass (C: P3)]
 // CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : C>
 func superclassConformance1<T>(t: T)
@@ -87,6 +88,7 @@ func superclassConformance1<T>(t: T)
 // CHECK: superclassConformance2
 // CHECK: Requirements:
 // CHECK-NEXT: τ_0_0 : C [τ_0_0: Explicit @ {{.*}}:11]
+// CHECK-NEXT: τ_0_0 : _NativeClass [τ_0_0: Explicit @ {{.*}}:11 -> Superclass]
 // CHECK-NEXT: τ_0_0 : P3 [τ_0_0: Explicit @ {{.*}}:11 -> Superclass (C: P3)]
 // CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : C>
 func superclassConformance2<T>(t: T)
@@ -100,6 +102,7 @@ class C2 : C, P4 { }
 // CHECK: superclassConformance3
 // CHECK: Requirements:
 // CHECK-NEXT: τ_0_0 : C2 [τ_0_0: Explicit @ {{.*}}:46]
+// CHECK-NEXT: τ_0_0 : _NativeClass [τ_0_0: Explicit @ {{.*}}:46 -> Superclass]
 // CHECK-NEXT: τ_0_0 : P4 [τ_0_0: Explicit @ {{.*}}:61 -> Superclass (C2: P4)]
 // CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : C2>
 func superclassConformance3<T>(t: T) where T : C, T : P4, T : C2 {}

--- a/test/attr/attr_specialize.swift
+++ b/test/attr/attr_specialize.swift
@@ -160,13 +160,32 @@ func funcWithForbiddenSpecializeRequirement<T>(_ t: T) {
 @_specialize(where T: _Trivial(32), T: _Trivial(64), T: _Trivial, T: _RefCountedObject)
 // expected-error@-1{{generic parameter 'T' has conflicting layout constraints '_Trivial(64)' and '_Trivial(32)'}}
 // expected-error@-2{{generic parameter 'T' has conflicting layout constraints '_RefCountedObject' and '_Trivial(32)'}}
-// expected-error@-3{{generic parameter 'T' has conflicting layout constraints '_Trivial' and '_Trivial(32)'}}
+// expected-warning@-3{{redundant layout constraint 'T' : '_Trivial'}}
 // expected-note@-4 3{{layout constraint constraint 'T' : '_Trivial(32)' written here}}
+@_specialize(where T: _Trivial, T: _Trivial(64))
+// expected-warning@-1{{redundant layout constraint 'T' : '_Trivial'}}
+// expected-note@-2 1{{layout constraint constraint 'T' : '_Trivial(64)' written here}}
+@_specialize(where T: _RefCountedObject, T: _NativeRefCountedObject)
+// expected-warning@-1{{redundant layout constraint 'T' : '_RefCountedObject'}}
+// expected-note@-2 1{{layout constraint constraint 'T' : '_NativeRefCountedObject' written here}}
 @_specialize(where Array<T> == Int) // expected-error{{Only requirements on generic parameters are supported by '_specialize' attribute}}
 // expected-error@-1{{generic signature requires types 'Array<T>' and 'Int' to be the same}}
 @_specialize(where T.Element == Int) // expected-error{{Only requirements on generic parameters are supported by '_specialize' attribute}}
 public func funcWithComplexSpecializeRequirements<T: ProtocolWithDep>(t: T) -> Int {
   return 55555
+}
+
+public protocol Proto: class {
+}
+
+@_specialize(where T: _RefCountedObject)
+// expected-warning@-1{{redundant layout constraint 'T' : '_RefCountedObject'}}
+@_specialize(where T: _Trivial)
+// expected-error@-1{{generic parameter 'T' has conflicting layout constraints '_Trivial' and '_NativeClass'}}
+@_specialize(where T: _Trivial(64))
+// expected-error@-1{{generic parameter 'T' has conflicting layout constraints '_Trivial(64)' and '_NativeClass'}}
+public func funcWithABaseClassRequirement<T>(t: T) -> Int where T: C1 {
+  return 44444
 }
 
 public struct S1 {


### PR DESCRIPTION
This PR addresses TODOs from #8241.

- It supports merging for layout constraints, e.g., if both a _Trivial constraint and a _Trivial(64) constraint appear on a type parameter, we keep only _Trivial(64) as a more specific layout constraint. We do a similar thing for ref-counted/native-ref-counted. The overall idea is to keep the more specific of two compatible layout constraints.
- The presence of a superclass constraint implies a layout constraint, e.g., a superclass constraint implies _Class or _NativeClass layout constraint.