### PR TITLE
[Syntax] Refactor Tuple Type Syntax

### DIFF
--- a/include/swift/Syntax/RawSyntax.h
+++ b/include/swift/Syntax/RawSyntax.h
@@ -150,6 +150,7 @@ public:
 enum class SyntaxKind {
   Token,
 #define SYNTAX(Id, Parent) Id,
+#define SYNTAX_COLLECTION(Id, Element) Id,
 #define MISSING_SYNTAX(Id, Parent) Id,
 #define SYNTAX_RANGE(Id, First, Last) First_##Id = First, Last_##Id = Last,
 #include "swift/Syntax/SyntaxKinds.def"

--- a/include/swift/Syntax/Rewriter.h
+++ b/include/swift/Syntax/Rewriter.h
@@ -40,6 +40,7 @@ struct SyntaxRewriter {
   virtual Id##Syntax rewrite##Id(Id##Syntax Node) { \
     return Node; \
   }
+#define SYNTAX_COLLECTION(Id, Element) SYNTAX(Id, {})
 #include "swift/Syntax/SyntaxKinds.def"
   virtual ~SyntaxRewriter() = default;
 };

--- a/include/swift/Syntax/SyntaxCollection.h
+++ b/include/swift/Syntax/SyntaxCollection.h
@@ -54,6 +54,18 @@ class SyntaxCollection : public Syntax {
   friend class Syntax;
   using DataType = SyntaxCollectionData<CollectionKind, Element>;
 
+private:
+  static RC<DataType>
+  makeData(std::vector<Element> &Elements) {
+    RawSyntax::LayoutList List;
+    for (auto &Elt : Elements) {
+      List.push_back(Elt.getRaw());
+    }
+    auto Raw = RawSyntax::make(CollectionKind, List,
+                               SourcePresence::Present);
+    return DataType::make(Raw);
+  }
+
 protected:
   SyntaxCollection(const RC<SyntaxData> Root, const DataType *Data)
     : Syntax(Root, Data) {}

--- a/include/swift/Syntax/SyntaxCollection.h
+++ b/include/swift/Syntax/SyntaxCollection.h
@@ -189,6 +189,12 @@ public:
   }
 };
 
+#define SYNTAX(Id, Parent)
+#define SYNTAX_COLLECTION(Id, Element) \
+  class Element;                       \
+  using Id##Syntax = SyntaxCollection<SyntaxKind::Id, Element>;
+#include "swift/Syntax/SyntaxKinds.def"
+
 } // end namespace syntax
 } // end namespace swift
 

--- a/include/swift/Syntax/SyntaxCollectionData.h
+++ b/include/swift/Syntax/SyntaxCollectionData.h
@@ -30,12 +30,6 @@ class SyntaxCollectionData : public SyntaxData {
   friend class SyntaxData;
   friend class FunctionCallExprSyntaxBuilder;
 
-  SyntaxCollectionData(RC<RawSyntax> Raw, const SyntaxData *Parent = nullptr,
-                       CursorIndex IndexInParent = 0)
-      : SyntaxData(Raw, Parent, IndexInParent),
-        CachedElements(Raw->Layout.size(), nullptr) {
-    assert(Raw->Kind == CollectionKind);
-  }
 
   static RC<SyntaxCollectionData<CollectionKind, ElementType>>
   make(RC<RawSyntax> Raw, const SyntaxData *Parent = nullptr,
@@ -53,11 +47,25 @@ class SyntaxCollectionData : public SyntaxData {
     return make(Raw);
   }
 
+protected:
+  SyntaxCollectionData(RC<RawSyntax> Raw, const SyntaxData *Parent = nullptr,
+                       CursorIndex IndexInParent = 0)
+  : SyntaxData(Raw, Parent, IndexInParent),
+  CachedElements(Raw->Layout.size(), nullptr) {
+      assert(Raw->Kind == CollectionKind);
+  }
+
 public:
   static bool classof(const SyntaxData *SD) {
     return SD->getKind() == CollectionKind;
   }
 };
+
+#define SYNTAX(Id, Parent)
+#define SYNTAX_COLLECTION(Id, Element) \
+  class Element;                       \
+  using Id##SyntaxData = SyntaxCollectionData<SyntaxKind::Id, Element>;
+#include "swift/Syntax/SyntaxKinds.def"
 
 } // end namespace syntax
 } // end namespace swift

--- a/include/swift/Syntax/SyntaxFactory.h
+++ b/include/swift/Syntax/SyntaxFactory.h
@@ -477,7 +477,9 @@ struct SyntaxFactory {
   /// Make a tuple type from an array of types, with one space between each
   /// type.
   static TupleTypeSyntax
-  makeTupleType(llvm::ArrayRef<TupleTypeElementSyntax> Types);
+  makeTupleType(RC<TokenSyntax> LParen,
+                llvm::ArrayRef<TupleTypeElementSyntax> Types,
+                RC<TokenSyntax> RParen);
 
   /// Make a tuple type element of the form 'Name: ElementType'
   static TupleTypeElementSyntax

--- a/include/swift/Syntax/SyntaxFactory.h
+++ b/include/swift/Syntax/SyntaxFactory.h
@@ -492,6 +492,10 @@ struct SyntaxFactory {
   makeTupleTypeElement(TypeSyntax ElementType,
                        llvm::Optional<RC<TokenSyntax>> MaybeComma = llvm::None);
 
+  /// Make a tuple type element list.
+  static TupleTypeElementListSyntax
+  makeTupleTypeElementList(std::vector<TupleTypeElementSyntax> ElementTypes);
+
 #pragma mark - optional-type
 
   /// Make an optional type, such as `Int?`

--- a/include/swift/Syntax/SyntaxFactory.h
+++ b/include/swift/Syntax/SyntaxFactory.h
@@ -481,7 +481,8 @@ struct SyntaxFactory {
 
   /// Make a tuple type element of the form 'Name: ElementType'
   static TupleTypeElementSyntax
-  makeTupleTypeElement(RC<TokenSyntax> Name, TypeSyntax ElementType,
+  makeTupleTypeElement(RC<TokenSyntax> Name, RC<TokenSyntax> Colon,
+                       TypeSyntax ElementType,
                        llvm::Optional<RC<TokenSyntax>> MaybeComma = llvm::None);
 
   /// Make a tuple type element without a label.
@@ -572,7 +573,7 @@ struct SyntaxFactory {
   static FunctionTypeSyntax
   makeFunctionType(TypeAttributesSyntax TypeAttributes,
                    RC<TokenSyntax> LeftParen,
-                   TypeArgumentListSyntax ArgumentList,
+                   TupleTypeElementListSyntax ArgumentList,
                    RC<TokenSyntax> RightParen, RC<TokenSyntax> ThrowsOrRethrows,
                    RC<TokenSyntax> Arrow, TypeSyntax ReturnType);
 
@@ -582,7 +583,7 @@ struct SyntaxFactory {
 #pragma mark - type-argument-list
 
   /// Make a list of type arguments with all elements marked as missing.
-  static TypeArgumentListSyntax makeBlankTypeArgumentList();
+  static TupleTypeElementListSyntax makeBlankTypeArgumentList();
 
 #pragma mark - Generics
 

--- a/include/swift/Syntax/SyntaxFactory.h
+++ b/include/swift/Syntax/SyntaxFactory.h
@@ -474,12 +474,20 @@ struct SyntaxFactory {
   /// Make a bare "()" void tuple type
   static TupleTypeSyntax makeVoidTupleType();
 
+  /// Make a tuple type from an array of types, with one space between each
+  /// type.
+  static TupleTypeSyntax
+  makeTupleType(llvm::ArrayRef<TupleTypeElementSyntax> Types);
+
   /// Make a tuple type element of the form 'Name: ElementType'
   static TupleTypeElementSyntax
-  makeTupleTypeElement(RC<TokenSyntax> Name, TypeSyntax ElementType);
+  makeTupleTypeElement(RC<TokenSyntax> Name, TypeSyntax ElementType,
+                       llvm::Optional<RC<TokenSyntax>> MaybeComma = llvm::None);
 
   /// Make a tuple type element without a label.
-  static TupleTypeElementSyntax makeTupleTypeElement(TypeSyntax ElementType);
+  static TupleTypeElementSyntax
+  makeTupleTypeElement(TypeSyntax ElementType,
+                       llvm::Optional<RC<TokenSyntax>> MaybeComma = llvm::None);
 
 #pragma mark - optional-type
 

--- a/include/swift/Syntax/SyntaxFactory.h
+++ b/include/swift/Syntax/SyntaxFactory.h
@@ -580,10 +580,10 @@ struct SyntaxFactory {
   /// Make a function type with all elements marked as missing.
   static FunctionTypeSyntax makeBlankFunctionType();
 
-#pragma mark - type-argument-list
+#pragma mark - tuple-type-element-list
 
   /// Make a list of type arguments with all elements marked as missing.
-  static TupleTypeElementListSyntax makeBlankTypeArgumentList();
+  static TupleTypeElementListSyntax makeBlankTupleTypeElementList();
 
 #pragma mark - Generics
 

--- a/include/swift/Syntax/SyntaxFactory.h
+++ b/include/swift/Syntax/SyntaxFactory.h
@@ -474,11 +474,11 @@ struct SyntaxFactory {
   /// Make a bare "()" void tuple type
   static TupleTypeSyntax makeVoidTupleType();
 
-  /// Make a tuple type from an array of types, with one space between each
-  /// type.
+  /// Make a tuple type from an array of types and the provided left/right
+  /// paren tokens.
   static TupleTypeSyntax
   makeTupleType(RC<TokenSyntax> LParen,
-                llvm::ArrayRef<TupleTypeElementSyntax> Types,
+                TupleTypeElementListSyntax Elements,
                 RC<TokenSyntax> RParen);
 
   /// Make a tuple type element of the form 'Name: ElementType'

--- a/include/swift/Syntax/SyntaxFactory.h
+++ b/include/swift/Syntax/SyntaxFactory.h
@@ -474,7 +474,7 @@ struct SyntaxFactory {
   /// Make a bare "()" void tuple type
   static TupleTypeSyntax makeVoidTupleType();
 
-  /// Make a tuple type from an array of types and the provided left/right
+  /// Make a tuple type from a type element list and the provided left/right
   /// paren tokens.
   static TupleTypeSyntax
   makeTupleType(RC<TokenSyntax> LParen,

--- a/include/swift/Syntax/SyntaxKinds.def
+++ b/include/swift/Syntax/SyntaxKinds.def
@@ -109,7 +109,7 @@ SYNTAX(FunctionParameter, Syntax)
 SYNTAX(DeclModifier, Syntax)
 SYNTAX(DeclModifierList, Syntax)
 
-SYNTAX_COLLECTION(TypeArgumentList, TupleTypeElementSyntax)
+SYNTAX_COLLECTION(TupleTypeElementList, TupleTypeElementSyntax)
 
 #undef SYNTAX_COLLECTION
 #undef ABSTRACT_SYNTAX

--- a/include/swift/Syntax/SyntaxKinds.def
+++ b/include/swift/Syntax/SyntaxKinds.def
@@ -32,6 +32,10 @@
 #define MISSING_SYNTAX(Id, Parent)
 #endif
 
+#ifndef SYNTAX_COLLECTION
+#define SYNTAX_COLLECTION(Id, Element)
+#endif
+
 SYNTAX(Unknown, Syntax)
 
 // Decls
@@ -56,7 +60,6 @@ SYNTAX(GenericArgumentList, Syntax)
 ABSTRACT_SYNTAX(GenericRequirementSyntax, Syntax)
   SYNTAX(ConformanceRequirement, GenericRequirementSyntax)
   SYNTAX(SameTypeRequirement, GenericRequirementSyntax)
-SYNTAX(TypeArgumentList, Syntax)
 
 // Types
 ABSTRACT_SYNTAX(TypeSyntax, Syntax)
@@ -106,6 +109,9 @@ SYNTAX(FunctionParameter, Syntax)
 SYNTAX(DeclModifier, Syntax)
 SYNTAX(DeclModifierList, Syntax)
 
+SYNTAX_COLLECTION(TypeArgumentList, TupleTypeElementSyntax)
+
+#undef SYNTAX_COLLECTION
 #undef ABSTRACT_SYNTAX
 #undef DECL
 #undef STMT

--- a/include/swift/Syntax/TypeSyntax.h
+++ b/include/swift/Syntax/TypeSyntax.h
@@ -315,27 +315,6 @@ public:
   }
 };
 
-#pragma mark - type-argument-list Data
-
-class TypeArgumentListSyntaxData final : public SyntaxData {
-  friend class SyntaxData;
-  friend struct SyntaxFactory;
-
-  TypeArgumentListSyntaxData(RC<RawSyntax> Raw,
-                             const SyntaxData *Parent = nullptr,
-                             CursorIndex IndexInParent = 0);
-
-  static RC<TypeArgumentListSyntaxData> make(RC<RawSyntax> Raw,
-                                             const SyntaxData *Parent = nullptr,
-                                             CursorIndex IndexInParent = 0);
-  static RC<TypeArgumentListSyntaxData> makeBlank();
-
-public:
-  static bool classof(const SyntaxData *S) {
-    return S->getKind() == SyntaxKind::TypeArgumentList;
-  }
-};
-
 #pragma mark - tuple-type-element Data
 
 class TupleTypeElementSyntaxData final : public SyntaxData {
@@ -366,19 +345,20 @@ class TupleTypeElementSyntax final : public Syntax {
   friend class TupleTypeElementSyntaxData;
   friend class SyntaxData;
 
-  using DataType = TupleTypeElementSyntaxData;
-
   enum class Cursor : CursorIndex {
     Label,
     ColonToken,
     Attributes,
     InoutToken,
     Type,
+    CommaToken,
   };
 
   TupleTypeElementSyntax(RC<SyntaxData> Root,
                          const TupleTypeElementSyntaxData *Data);
 public:
+  using DataType = TupleTypeElementSyntaxData;
+  
   /// Return the label of the tuple type element.
   RC<TokenSyntax> getLabel() const;
 
@@ -392,6 +372,14 @@ public:
   /// using the specified leading and trailing trivia.
   TupleTypeElementSyntax
   withColonToken(RC<TokenSyntax> NewColonToken) const;
+
+  /// Return the comma token of the tuple type element.
+  RC<TokenSyntax> getCommaToken() const;
+
+  /// Return a new named tuple type element with a comma token replacement
+  /// using the specified leading and trailing trivia.
+  TupleTypeElementSyntax
+  withCommaToken(RC<TokenSyntax> NewCommaToken) const;
 
   /// Return the type attributes for the tuple type element.
   TypeAttributesSyntax getTypeAttributes() const;
@@ -415,33 +403,7 @@ public:
     return S->getKind() == SyntaxKind::TupleTypeElement;
   }
 };
-
-
-#pragma mark - type-argument-list API
-
-/// type-argument-list
-///   -> function-type-argument
-///    | function-type-argument ',' function-type-argument-list
-class TypeArgumentListSyntax final : public Syntax {
-  friend struct SyntaxFactory;
-  friend class SyntaxData;
-
-  using DataType = TypeArgumentListSyntaxData;
-
-  TypeArgumentListSyntax(RC<SyntaxData> Root,
-                         const TypeArgumentListSyntaxData *Data);
-
-public:
-  // TODO: TODO: getType
-  TypeArgumentListSyntax
-  addType(llvm::Optional<RC<TokenSyntax>> MaybeComma,
-          TupleTypeElementSyntax NewTypeArgument) const;
-
-  static bool classof(const Syntax *S) {
-    return S->getKind() == SyntaxKind::TypeArgumentList;
-  }
-};
-
+  
 #pragma mark - tuple-type Data
 
 class TupleTypeSyntaxData final : public TypeSyntaxData {
@@ -519,8 +481,7 @@ public:
 
   /// Add an element type to the eventual tuple type syntax.
   TupleTypeSyntaxBuilder &
-  addElementTypeSyntax(llvm::Optional<RC<TokenSyntax>> MaybeComma,
-                       TupleTypeElementSyntax ElementTypeSyntax);
+  addElementTypeSyntax(TupleTypeElementSyntax ElementTypeSyntax);
 
   /// Use the given left paren '(' token when building the tuple type syntax.
   TupleTypeSyntaxBuilder &useRightParen(RC<TokenSyntax> RightParen);

--- a/include/swift/Syntax/TypeSyntax.h
+++ b/include/swift/Syntax/TypeSyntax.h
@@ -438,7 +438,7 @@ class TupleTypeSyntax final : public TypeSyntax {
 
   enum class Cursor : CursorIndex {
     LeftParenToken,
-    TypeArgumentList,
+    TypeElementList,
     RightParenToken,
   };
 
@@ -450,11 +450,11 @@ public:
   TupleTypeSyntax withLeftParen(RC<TokenSyntax> NewLeftParen) const;
 
   /// Get the type argument list inside the tuple type syntax.
-  TupleTypeElementListSyntax getTypeArgumentList() const;
+  TupleTypeElementListSyntax getTypeElementList() const;
 
   /// Return a new tuple type syntax with the given type argument list.
   TupleTypeSyntax
-  withTypeArgumentList(TupleTypeElementListSyntax NewTypeArgumentList) const;
+  withTypeElementList(TupleTypeElementListSyntax NewTypeElementList) const;
 
   /// Return the right paren ')' token surrounding the tuple type syntax.
   RC<TokenSyntax> getRightParen() const;
@@ -934,13 +934,13 @@ public:
                   FunctionTypeArgumentSyntax NewArgument) const;
 
   /// Return the type arguments list for this function type syntax.
-  TupleTypeElementListSyntax getTypeArgumentList() const;
+  TupleTypeElementListSyntax getTypeElementList() const;
 
   /// Return a new function type with the given type argument list.
   ///
   /// This replaces all of the argument types.
   FunctionTypeSyntax
-  withTypeArgumentList(TupleTypeElementListSyntax NewArgumentList) const;
+  withTypeElementList(TupleTypeElementListSyntax NewArgumentList) const;
 
   /// Return the right parenthesis ')' token surrounding the argument type.
   RC<TokenSyntax> getRightArgumentsParen() const;

--- a/include/swift/Syntax/TypeSyntax.h
+++ b/include/swift/Syntax/TypeSyntax.h
@@ -450,11 +450,11 @@ public:
   TupleTypeSyntax withLeftParen(RC<TokenSyntax> NewLeftParen) const;
 
   /// Get the type argument list inside the tuple type syntax.
-  TypeArgumentListSyntax getTypeArgumentList() const;
+  TupleTypeElementListSyntax getTypeArgumentList() const;
 
   /// Return a new tuple type syntax with the given type argument list.
   TupleTypeSyntax
-  withTypeArgumentList(TypeArgumentListSyntax NewTypeArgumentList) const;
+  withTypeArgumentList(TupleTypeElementListSyntax NewTypeArgumentList) const;
 
   /// Return the right paren ')' token surrounding the tuple type syntax.
   RC<TokenSyntax> getRightParen() const;
@@ -934,13 +934,13 @@ public:
                   FunctionTypeArgumentSyntax NewArgument) const;
 
   /// Return the type arguments list for this function type syntax.
-  TypeArgumentListSyntax getTypeArgumentList() const;
+  TupleTypeElementListSyntax getTypeArgumentList() const;
 
   /// Return a new function type with the given type argument list.
   ///
   /// This replaces all of the argument types.
   FunctionTypeSyntax
-  withTypeArgumentList(TypeArgumentListSyntax NewArgumentList) const;
+  withTypeArgumentList(TupleTypeElementListSyntax NewArgumentList) const;
 
   /// Return the right parenthesis ')' token surrounding the argument type.
   RC<TokenSyntax> getRightArgumentsParen() const;

--- a/lib/Syntax/GenericSyntax.cpp
+++ b/lib/Syntax/GenericSyntax.cpp
@@ -374,7 +374,7 @@ GenericArgumentClauseSyntaxData::makeBlank() {
   auto Raw = RawSyntax::make(SyntaxKind::GenericArgumentClause,
                              {
                                TokenSyntax::missingToken(tok::l_angle, "<"),
-                               RawSyntax::missing(SyntaxKind::TypeArgumentList),
+                               RawSyntax::missing(SyntaxKind::GenericArgumentList),
                                TokenSyntax::missingToken(tok::r_angle, ">"),
                              },
                              SourcePresence::Present);
@@ -439,7 +439,7 @@ useRightAngleBracket(RC<TokenSyntax> RightAngle) {
 
 
 GenericArgumentClauseSyntax GenericArgumentClauseBuilder::build() const {
-  auto ArgListRaw = RawSyntax::make(SyntaxKind::TypeArgumentList,
+  auto ArgListRaw = RawSyntax::make(SyntaxKind::GenericParameterList,
                                     ArgumentListLayout,
                                     SourcePresence::Present);
   auto Raw = RawSyntax::make(SyntaxKind::GenericArgumentClause,

--- a/lib/Syntax/RawSyntax.cpp
+++ b/lib/Syntax/RawSyntax.cpp
@@ -28,6 +28,7 @@ void dumpSyntaxKind(llvm::raw_ostream &OS, const SyntaxKind Kind) {
     OS << #Id;                                                                 \
     break;
 #define MISSING_SYNTAX(Id, Parent) SYNTAX(Id, Parent)
+#define SYNTAX_COLLECTION(Id, Element) SYNTAX(Id, {})
 #include "swift/Syntax/SyntaxKinds.def"
   case SyntaxKind::Token: OS << "Token"; break;
   }

--- a/lib/Syntax/SyntaxData.cpp
+++ b/lib/Syntax/SyntaxData.cpp
@@ -41,6 +41,8 @@ RC<SyntaxData> SyntaxData::makeDataFromRaw(RC<RawSyntax> Raw,
   case SyntaxKind::Id: \
     return ParentType##Data::make(Raw, Parent, IndexInParent);
 
+#define SYNTAX_COLLECTION(Id, Element) SYNTAX(Id, {})
+
 #include "swift/Syntax/SyntaxKinds.def"
   case SyntaxKind::Token:
     llvm_unreachable("Can't make a SyntaxData from a Token!");

--- a/lib/Syntax/SyntaxFactory.cpp
+++ b/lib/Syntax/SyntaxFactory.cpp
@@ -1071,6 +1071,13 @@ SyntaxFactory::makeTupleTypeElement(TypeSyntax ElementType,
     .withCommaToken(Comma);
 }
 
+TupleTypeElementListSyntax
+SyntaxFactory::makeTupleTypeElementList(
+  std::vector<TupleTypeElementSyntax> ElementTypes) {
+  auto Data = TupleTypeElementListSyntax::makeData(ElementTypes);
+  return TupleTypeElementListSyntax { Data, Data.get() };
+}
+
 #pragma mark - optional-type
 
 OptionalTypeSyntax

--- a/lib/Syntax/SyntaxFactory.cpp
+++ b/lib/Syntax/SyntaxFactory.cpp
@@ -1233,7 +1233,7 @@ TypeAttributesSyntax SyntaxFactory::makeBlankTypeAttributes() {
   return TypeAttributesSyntax { Data, Data.get() };
 }
 
-TupleTypeElementListSyntax SyntaxFactory::makeBlankTypeArgumentList() {
+TupleTypeElementListSyntax SyntaxFactory::makeBlankTupleTypeElementList() {
   auto Data = TupleTypeElementListSyntaxData::makeBlank();
   return TupleTypeElementListSyntax { Data, Data.get() };
 }

--- a/lib/Syntax/SyntaxFactory.cpp
+++ b/lib/Syntax/SyntaxFactory.cpp
@@ -1013,7 +1013,7 @@ TupleTypeSyntax SyntaxFactory::makeVoidTupleType() {
   auto Raw = RawSyntax::make(SyntaxKind::TupleType,
     {
       SyntaxFactory::makeLeftParenToken({}, {}),
-      RawSyntax::missing(SyntaxKind::TypeArgumentList),
+      RawSyntax::missing(SyntaxKind::TupleTypeElementList),
       SyntaxFactory::makeRightParenToken({}, {}),
     },
     SourcePresence::Present);
@@ -1029,7 +1029,7 @@ SyntaxFactory::makeTupleType(llvm::ArrayRef<TupleTypeElementSyntax> Types) {
   for (auto &Type : Types) {
     RawTypes.push_back(Type.getRaw());
   }
-  auto ArgListRaw = RawSyntax::make(SyntaxKind::TypeArgumentList,
+  auto ArgListRaw = RawSyntax::make(SyntaxKind::TupleTypeElementList,
                                     RawTypes,
                                     SourcePresence::Present);
   auto Raw = RawSyntax::make(SyntaxKind::TupleType,
@@ -1047,6 +1047,7 @@ SyntaxFactory::makeTupleType(llvm::ArrayRef<TupleTypeElementSyntax> Types) {
 
 TupleTypeElementSyntax
 SyntaxFactory::makeTupleTypeElement(RC<TokenSyntax> Name,
+                                    RC<TokenSyntax> Colon,
                                     TypeSyntax ElementTypeSyntax,
                                     Optional<RC<TokenSyntax>> MaybeComma) {
   auto Data = TupleTypeElementSyntaxData::makeBlank();
@@ -1058,7 +1059,7 @@ SyntaxFactory::makeTupleTypeElement(RC<TokenSyntax> Name,
   }
   return TupleTypeElementSyntax { Data, Data.get() }
     .withLabel(Name)
-    .withColonToken(SyntaxFactory::makeColonToken({}, Trivia::spaces(1)))
+    .withColonToken(Colon)
     .withTypeSyntax(ElementTypeSyntax)
     .withCommaToken(Comma);
 }
@@ -1146,7 +1147,7 @@ MetatypeTypeSyntax SyntaxFactory::makeBlankMetatypeType() {
 
 FunctionTypeSyntax SyntaxFactory::makeFunctionType(
     TypeAttributesSyntax TypeAttributes, RC<TokenSyntax> LeftParen,
-    TypeArgumentListSyntax ArgumentList, RC<TokenSyntax> RightParen,
+    TupleTypeElementListSyntax ArgumentList, RC<TokenSyntax> RightParen,
     RC<TokenSyntax> ThrowsOrRethrows, RC<TokenSyntax> Arrow,
     TypeSyntax ReturnType) {
   auto Raw =
@@ -1232,9 +1233,9 @@ TypeAttributesSyntax SyntaxFactory::makeBlankTypeAttributes() {
   return TypeAttributesSyntax { Data, Data.get() };
 }
 
-TypeArgumentListSyntax SyntaxFactory::makeBlankTypeArgumentList() {
-  auto Data = TypeArgumentListSyntaxData::makeBlank();
-  return TypeArgumentListSyntax { Data, Data.get() };
+TupleTypeElementListSyntax SyntaxFactory::makeBlankTypeArgumentList() {
+  auto Data = TupleTypeElementListSyntaxData::makeBlank();
+  return TupleTypeElementListSyntax { Data, Data.get() };
 }
 
 #pragma mark - array-type

--- a/lib/Syntax/SyntaxFactory.cpp
+++ b/lib/Syntax/SyntaxFactory.cpp
@@ -1025,17 +1025,10 @@ TupleTypeSyntax SyntaxFactory::makeVoidTupleType() {
 
 TupleTypeSyntax
 SyntaxFactory::makeTupleType(RC<TokenSyntax> LParen,
-                             llvm::ArrayRef<TupleTypeElementSyntax> Types,
+                             TupleTypeElementListSyntax Elements,
                              RC<TokenSyntax> RParen) {
-  RawSyntax::LayoutList RawTypes;
-  for (auto &Type : Types) {
-    RawTypes.push_back(Type.getRaw());
-  }
-  auto ArgListRaw = RawSyntax::make(SyntaxKind::TupleTypeElementList,
-                                    RawTypes,
-                                    SourcePresence::Present);
   auto Raw = RawSyntax::make(SyntaxKind::TupleType,
-                             { LParen, ArgListRaw, RParen },
+                             { LParen, Elements.getRaw(), RParen },
                              SourcePresence::Present);
   auto Data = TupleTypeSyntaxData::make(std::move(Raw));
   return TupleTypeSyntax {

--- a/lib/Syntax/SyntaxFactory.cpp
+++ b/lib/Syntax/SyntaxFactory.cpp
@@ -1024,7 +1024,9 @@ TupleTypeSyntax SyntaxFactory::makeVoidTupleType() {
 }
 
 TupleTypeSyntax
-SyntaxFactory::makeTupleType(llvm::ArrayRef<TupleTypeElementSyntax> Types) {
+SyntaxFactory::makeTupleType(RC<TokenSyntax> LParen,
+                             llvm::ArrayRef<TupleTypeElementSyntax> Types,
+                             RC<TokenSyntax> RParen) {
   RawSyntax::LayoutList RawTypes;
   for (auto &Type : Types) {
     RawTypes.push_back(Type.getRaw());
@@ -1033,12 +1035,8 @@ SyntaxFactory::makeTupleType(llvm::ArrayRef<TupleTypeElementSyntax> Types) {
                                     RawTypes,
                                     SourcePresence::Present);
   auto Raw = RawSyntax::make(SyntaxKind::TupleType,
-    {
-      SyntaxFactory::makeLeftParenToken({}, {}),
-      ArgListRaw,
-      SyntaxFactory::makeRightParenToken({}, {})
-    },
-    SourcePresence::Present);
+                             { LParen, ArgListRaw, RParen },
+                             SourcePresence::Present);
   auto Data = TupleTypeSyntaxData::make(std::move(Raw));
   return TupleTypeSyntax {
     Data, Data.get()

--- a/lib/Syntax/TypeSyntax.cpp
+++ b/lib/Syntax/TypeSyntax.cpp
@@ -303,7 +303,7 @@ TupleTypeSyntaxData::TupleTypeSyntaxData(RC<RawSyntax> Raw,
   syntax_assert_child_token_text(Raw, TupleTypeSyntax::Cursor::LeftParenToken,
                                  tok::l_paren,
                                  "(");
-  syntax_assert_child_kind(Raw, TupleTypeSyntax::Cursor::TypeArgumentList,
+  syntax_assert_child_kind(Raw, TupleTypeSyntax::Cursor::TypeElementList,
                            SyntaxKind::TupleTypeElementList);
   syntax_assert_child_token_text(Raw, TupleTypeSyntax::Cursor::RightParenToken,
                                  tok::r_paren,
@@ -345,9 +345,9 @@ TupleTypeSyntax::withLeftParen(RC<TokenSyntax> NewLeftParen) const {
 }
 
 TupleTypeSyntax TupleTypeSyntax::
-withTypeArgumentList(TupleTypeElementListSyntax NewTypeArgumentList) const {
-  auto NewRaw = getRaw()->replaceChild(Cursor::TypeArgumentList,
-                                       NewTypeArgumentList.getRaw());
+withTypeElementList(TupleTypeElementListSyntax NewTypeElementList) const {
+  auto NewRaw = getRaw()->replaceChild(Cursor::TypeElementList,
+                                       NewTypeElementList.getRaw());
   return Data->replaceSelf<TupleTypeSyntax>(NewRaw);
 }
 

--- a/lib/Syntax/TypeSyntax.cpp
+++ b/lib/Syntax/TypeSyntax.cpp
@@ -304,7 +304,7 @@ TupleTypeSyntaxData::TupleTypeSyntaxData(RC<RawSyntax> Raw,
                                  tok::l_paren,
                                  "(");
   syntax_assert_child_kind(Raw, TupleTypeSyntax::Cursor::TypeArgumentList,
-                           SyntaxKind::TypeArgumentList);
+                           SyntaxKind::TupleTypeElementList);
   syntax_assert_child_token_text(Raw, TupleTypeSyntax::Cursor::RightParenToken,
                                  tok::r_paren,
                                  ")");
@@ -325,7 +325,7 @@ TupleTypeSyntaxData::makeBlank() {
       RawSyntax::make(SyntaxKind::TupleType,
                       {
                         TokenSyntax::missingToken(tok::l_paren, "("),
-                        RawSyntax::missing(SyntaxKind::TypeArgumentList),
+                        RawSyntax::missing(SyntaxKind::TupleTypeElementList),
                         TokenSyntax::missingToken(tok::r_paren, ")"),
                       },
                       SourcePresence::Present));
@@ -345,7 +345,7 @@ TupleTypeSyntax::withLeftParen(RC<TokenSyntax> NewLeftParen) const {
 }
 
 TupleTypeSyntax TupleTypeSyntax::
-withTypeArgumentList(TypeArgumentListSyntax NewTypeArgumentList) const {
+withTypeArgumentList(TupleTypeElementListSyntax NewTypeArgumentList) const {
   auto NewRaw = getRaw()->replaceChild(Cursor::TypeArgumentList,
                                        NewTypeArgumentList.getRaw());
   return Data->replaceSelf<TupleTypeSyntax>(NewRaw);
@@ -383,7 +383,7 @@ TupleTypeSyntaxBuilder::useRightParen(RC<TokenSyntax> RightParen) {
 }
 
 TupleTypeSyntax TupleTypeSyntaxBuilder::build() const {
-  auto ElementsRaw = RawSyntax::make(SyntaxKind::TypeArgumentList,
+  auto ElementsRaw = RawSyntax::make(SyntaxKind::TupleTypeElementList,
                                      { ElementTypeLayout },
                                      SourcePresence::Present);
   auto Raw = RawSyntax::make(SyntaxKind::TupleType,
@@ -878,8 +878,11 @@ FunctionTypeSyntaxData::FunctionTypeSyntaxData(RC<RawSyntax> Raw,
                            SyntaxKind::TypeAttributes);
   syntax_assert_child_token_text(Raw, FunctionTypeSyntax::Cursor::LeftParen,
                                  tok::l_paren, "(");
+
+  // FIXME: This needs its own element and element list.
   syntax_assert_child_kind(Raw, FunctionTypeSyntax::Cursor::ArgumentList,
-                           SyntaxKind::TypeArgumentList);
+                           SyntaxKind::TupleTypeElementList);
+
   syntax_assert_child_token_text(Raw, FunctionTypeSyntax::Cursor::RightParen,
                                  tok::r_paren, ")");
 #ifndef NDEBUG
@@ -908,7 +911,8 @@ RC<FunctionTypeSyntaxData> FunctionTypeSyntaxData::makeBlank() {
     {
       RawSyntax::missing(SyntaxKind::TypeAttributes),
       TokenSyntax::missingToken(tok::l_paren, "("),
-      RawSyntax::missing(SyntaxKind::TypeArgumentList),
+      // FIXME: This needs its own element and element list.
+      RawSyntax::missing(SyntaxKind::TupleTypeElementList),
       TokenSyntax::missingToken(tok::r_paren, ")"),
       TokenSyntax::missingToken(tok::kw_throws, "throws"),
       TokenSyntax::missingToken(tok::arrow, "->"),
@@ -1038,7 +1042,7 @@ addArgumentTypeSyntax(Optional<RC<TokenSyntax>> MaybeComma,
 
   TypeArgumentsLayout.push_back(NewTypeArgument.getRaw());
 
-  FunctionTypeLayout[Index] = RawSyntax::make(SyntaxKind::TypeArgumentList,
+  FunctionTypeLayout[Index] = RawSyntax::make(SyntaxKind::TupleTypeElementList,
                                               TypeArgumentsLayout,
                                               SourcePresence::Present);
   return *this;

--- a/lib/Syntax/TypeSyntax.cpp
+++ b/lib/Syntax/TypeSyntax.cpp
@@ -362,7 +362,7 @@ withRightParen(RC<TokenSyntax> NewRightParen) const {
 
 TupleTypeSyntaxBuilder::TupleTypeSyntaxBuilder()
   : ElementTypeLayout(
-      SyntaxFactory::makeBlankTypeArgumentList().getRaw()->Layout) {}
+      SyntaxFactory::makeBlankTupleTypeElementList().getRaw()->Layout) {}
 
 TupleTypeSyntaxBuilder &TupleTypeSyntaxBuilder::
 addElementTypeSyntax(TupleTypeElementSyntax ElementTypeSyntax) {

--- a/test/Syntax/round_trip_tuple.swift
+++ b/test/Syntax/round_trip_tuple.swift
@@ -1,5 +1,4 @@
-// RUN: %round-trip-syntax-test --swift-syntax-test %swift-syntax-test --round-trip-lex
-// RUN: %round-trip-syntax-test --swift-syntax-test %swift-syntax-test --round-trip-parse
+// RUN: %round-trip-syntax-test --swift-syntax-test %swift-syntax-test --file %s
 
 typealias TwoInts = (Int, Int)
 typealias TwoNamedInts = (a: Int, b: Int)

--- a/test/Syntax/round_trip_tuple.swift
+++ b/test/Syntax/round_trip_tuple.swift
@@ -1,0 +1,7 @@
+// RUN: %round-trip-syntax-test --swift-syntax-test %swift-syntax-test --round-trip-lex
+// RUN: %round-trip-syntax-test --swift-syntax-test %swift-syntax-test --round-trip-parse
+
+typealias TwoInts = (Int, Int)
+typealias TwoNamedInts = (a: Int, b: Int)
+typealias VoidTuple = ()
+typealias TupleWithTrivia = (   Int ,  b  :Int   )

--- a/unittests/Syntax/TypeSyntaxTests.cpp
+++ b/unittests/Syntax/TypeSyntaxTests.cpp
@@ -248,7 +248,10 @@ TEST(TypeSyntaxTests, TupleMakeAPIs) {
     TypeElements.push_back(SyntaxFactory::makeTupleTypeElement(Int, Comma));
     TypeElements.push_back(SyntaxFactory::makeTupleTypeElement(Bool, Comma));
     TypeElements.push_back(SyntaxFactory::makeTupleTypeElement(Int, None));
-    auto TupleType = SyntaxFactory::makeTupleType(TypeElements);
+    auto TupleType = SyntaxFactory::makeTupleType(
+                        SyntaxFactory::makeLeftParenToken({}, {}),
+                        TypeElements,
+                        SyntaxFactory::makeRightParenToken({}, {}));
     TupleType.print(OS);
     ASSERT_EQ(OS.str().str(),
               "(Int, Bool, Int, Bool, Int)");

--- a/unittests/Syntax/TypeSyntaxTests.cpp
+++ b/unittests/Syntax/TypeSyntaxTests.cpp
@@ -239,18 +239,18 @@ TEST(TypeSyntaxTests, TupleMakeAPIs) {
   {
     SmallString<10> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    llvm::SmallVector<TupleTypeElementSyntax, 10> TypeElements;
     auto Int = SyntaxFactory::makeTypeIdentifier("Int", {}, {});
     auto Bool = SyntaxFactory::makeTypeIdentifier("Bool", {}, {});
     auto Comma = SyntaxFactory::makeCommaToken({}, { Trivia::spaces(1) });
-    TypeElements.push_back(SyntaxFactory::makeTupleTypeElement(Int, Comma));
-    TypeElements.push_back(SyntaxFactory::makeTupleTypeElement(Bool, Comma));
-    TypeElements.push_back(SyntaxFactory::makeTupleTypeElement(Int, Comma));
-    TypeElements.push_back(SyntaxFactory::makeTupleTypeElement(Bool, Comma));
-    TypeElements.push_back(SyntaxFactory::makeTupleTypeElement(Int, None));
+    auto Elements = SyntaxFactory::makeBlankTupleTypeElementList()
+      .appending(SyntaxFactory::makeTupleTypeElement(Int, Comma))
+      .appending(SyntaxFactory::makeTupleTypeElement(Bool, Comma))
+      .appending(SyntaxFactory::makeTupleTypeElement(Int, Comma))
+      .appending(SyntaxFactory::makeTupleTypeElement(Bool, Comma))
+      .appending(SyntaxFactory::makeTupleTypeElement(Int, None));
     auto TupleType = SyntaxFactory::makeTupleType(
                         SyntaxFactory::makeLeftParenToken({}, {}),
-                        TypeElements,
+                        Elements,
                         SyntaxFactory::makeRightParenToken({}, {}));
     TupleType.print(OS);
     ASSERT_EQ(OS.str().str(),

--- a/unittests/Syntax/TypeSyntaxTests.cpp
+++ b/unittests/Syntax/TypeSyntaxTests.cpp
@@ -467,11 +467,11 @@ TEST(TypeSyntaxTests, FunctionTypeMakeAPIs) {
     auto yArg = SyntaxFactory::makeTupleTypeElement(y, Colon, Int);
 
     auto Attrs = SyntaxFactory::makeBlankTypeAttributes();
-    auto ArgList = SyntaxFactory::makeBlankTypeArgumentList()
+    auto TypeList = SyntaxFactory::makeBlankTupleTypeElementList()
       .appending(xArg)
       .appending(yArg);
     SyntaxFactory::makeFunctionType(Attrs,
-                                    LeftParen, ArgList, RightParen,
+                                    LeftParen, TypeList, RightParen,
                                     Throws,
                                     Arrow,
                                     Int)
@@ -484,14 +484,14 @@ TEST(TypeSyntaxTests, FunctionTypeMakeAPIs) {
     llvm::raw_svector_ostream OS(Scratch);
     auto IntArgComma = IntArg.withCommaToken(Comma);
     auto Attrs = SyntaxFactory::makeBlankTypeAttributes();
-    auto ArgList = SyntaxFactory::makeBlankTypeArgumentList()
+    auto TypeList = SyntaxFactory::makeBlankTupleTypeElementList()
       .appending(IntArg.withCommaToken(Comma))
       .appending(IntArg);
     SyntaxFactory::makeFunctionType(Attrs,
-                                      LeftParen, ArgList, RightParen,
-                                      Rethrows,
-                                      Arrow,
-                                      Int).print(OS);
+                                    LeftParen, TypeList, RightParen,
+                                    Rethrows,
+                                    Arrow,
+                                    Int).print(OS);
     ASSERT_EQ(OS.str().str(), "(Int, Int) rethrows -> Int");
   }
 
@@ -504,14 +504,14 @@ TEST(TypeSyntaxTests, FunctionTypeMakeAPIs) {
     auto yArg = SyntaxFactory::makeTupleTypeElement(y, Colon, Int);
 
     auto Attrs = SyntaxFactory::makeBlankTypeAttributes();
-    auto ArgList = SyntaxFactory::makeBlankTypeArgumentList();
+    auto TypeList = SyntaxFactory::makeBlankTupleTypeElementList();
     auto Void = SyntaxFactory::makeVoidTupleType();
     SyntaxFactory::makeFunctionType(Attrs,
-                                      LeftParen, ArgList, RightParen,
-                                      TokenSyntax::missingToken(tok::kw_throws,
-                                                                "throws"),
-                                      Arrow,
-                                      Void).print(OS);
+                                    LeftParen, TypeList, RightParen,
+                                    TokenSyntax::missingToken(tok::kw_throws,
+                                                              "throws"),
+                                    Arrow,
+                                    Void).print(OS);
     ASSERT_EQ(OS.str().str(), "() -> ()");
   }
 

--- a/unittests/Syntax/TypeSyntaxTests.cpp
+++ b/unittests/Syntax/TypeSyntaxTests.cpp
@@ -175,6 +175,20 @@ TEST(TypeSyntaxTests, TupleWithAPIs) {
     Void.print(OS);
     ASSERT_EQ(OS.str(), "()");
   }
+  {
+    SmallString<2> Scratch;
+    llvm::raw_svector_ostream OS { Scratch };
+    auto Comma = SyntaxFactory::makeCommaToken({}, {});
+    auto Foo = SyntaxFactory::makeTypeIdentifier("Foo", {},
+                                                 { Trivia::spaces(2) });
+    auto Void = SyntaxFactory::makeVoidTupleType()
+      .withTypeArgumentList(SyntaxFactory::makeTupleTypeElementList({
+        SyntaxFactory::makeTupleTypeElement(Foo, Comma),
+        SyntaxFactory::makeTupleTypeElement(Foo)
+      }));
+    Void.print(OS);
+    ASSERT_EQ(OS.str().str(), "(Foo  ,Foo  )");
+  }
 }
 
 TEST(TypeSyntaxTests, TupleBuilderAPIs) {
@@ -242,15 +256,15 @@ TEST(TypeSyntaxTests, TupleMakeAPIs) {
     auto Int = SyntaxFactory::makeTypeIdentifier("Int", {}, {});
     auto Bool = SyntaxFactory::makeTypeIdentifier("Bool", {}, {});
     auto Comma = SyntaxFactory::makeCommaToken({}, { Trivia::spaces(1) });
-    auto Elements = SyntaxFactory::makeBlankTupleTypeElementList()
-      .appending(SyntaxFactory::makeTupleTypeElement(Int, Comma))
-      .appending(SyntaxFactory::makeTupleTypeElement(Bool, Comma))
-      .appending(SyntaxFactory::makeTupleTypeElement(Int, Comma))
-      .appending(SyntaxFactory::makeTupleTypeElement(Bool, Comma))
-      .appending(SyntaxFactory::makeTupleTypeElement(Int, None));
     auto TupleType = SyntaxFactory::makeTupleType(
                         SyntaxFactory::makeLeftParenToken({}, {}),
-                        Elements,
+                        SyntaxFactory::makeTupleTypeElementList({
+                          SyntaxFactory::makeTupleTypeElement(Int, Comma),
+                          SyntaxFactory::makeTupleTypeElement(Bool, Comma),
+                          SyntaxFactory::makeTupleTypeElement(Int, Comma),
+                          SyntaxFactory::makeTupleTypeElement(Bool, Comma),
+                          SyntaxFactory::makeTupleTypeElement(Int, None)
+                        }),
                         SyntaxFactory::makeRightParenToken({}, {}));
     TupleType.print(OS);
     ASSERT_EQ(OS.str().str(),

--- a/unittests/Syntax/TypeSyntaxTests.cpp
+++ b/unittests/Syntax/TypeSyntaxTests.cpp
@@ -207,11 +207,13 @@ TEST(TypeSyntaxTests, TupleBuilderAPIs) {
     TupleTypeSyntaxBuilder Builder;
     Builder.useLeftParen(SyntaxFactory::makeLeftParenToken({}, {}));
     auto Comma = SyntaxFactory::makeCommaToken({}, { Trivia::spaces(1) });
+    auto Colon = SyntaxFactory::makeColonToken({}, { Trivia::spaces(1) });
     auto Int = SyntaxFactory::makeTypeIdentifier("Int", {}, {});
     auto xLabel = SyntaxFactory::makeIdentifier("x", {} , {});
-    auto xTypeElt = SyntaxFactory::makeTupleTypeElement(xLabel, Int, Comma);
+    auto xTypeElt = SyntaxFactory::makeTupleTypeElement(xLabel, Colon,
+                                                        Int, Comma);
     auto yLabel = SyntaxFactory::makeIdentifier("y", {} , {});
-    auto yTypeElt = SyntaxFactory::makeTupleTypeElement(yLabel, Int)
+    auto yTypeElt = SyntaxFactory::makeTupleTypeElement(yLabel, Colon, Int)
       .withInoutToken(
         SyntaxFactory::makeInoutKeyword({}, { Trivia::spaces(1) }));
     Builder.addElementTypeSyntax(xTypeElt);
@@ -444,6 +446,7 @@ TEST(TypeSyntaxTests, DictionaryTypeMakeAPIs) {
 
 TEST(TypeSyntaxTests, FunctionTypeMakeAPIs) {
   auto Comma = SyntaxFactory::makeCommaToken({}, { Trivia::spaces(1) });
+  auto Colon = SyntaxFactory::makeColonToken({}, { Trivia::spaces(1) });
   auto LeftParen = SyntaxFactory::makeLeftParenToken({}, {});
   auto RightParen = SyntaxFactory::makeRightParenToken({},
                                                          {Trivia::spaces(1)});
@@ -460,8 +463,8 @@ TEST(TypeSyntaxTests, FunctionTypeMakeAPIs) {
 
     auto x = SyntaxFactory::makeIdentifier("x", {}, {});
     auto y = SyntaxFactory::makeIdentifier("y", {}, {});
-    auto xArg = SyntaxFactory::makeTupleTypeElement(x, Int, Comma);
-    auto yArg = SyntaxFactory::makeTupleTypeElement(y, Int);
+    auto xArg = SyntaxFactory::makeTupleTypeElement(x, Colon, Int, Comma);
+    auto yArg = SyntaxFactory::makeTupleTypeElement(y, Colon, Int);
 
     auto Attrs = SyntaxFactory::makeBlankTypeAttributes();
     auto ArgList = SyntaxFactory::makeBlankTypeArgumentList()
@@ -497,8 +500,8 @@ TEST(TypeSyntaxTests, FunctionTypeMakeAPIs) {
     llvm::raw_svector_ostream OS(Scratch);
     auto x = SyntaxFactory::makeIdentifier("x", {}, {});
     auto y = SyntaxFactory::makeIdentifier("y", {}, {});
-    auto xArg = SyntaxFactory::makeTupleTypeElement(x, Int);
-    auto yArg = SyntaxFactory::makeTupleTypeElement(y, Int);
+    auto xArg = SyntaxFactory::makeTupleTypeElement(x, Colon, Int);
+    auto yArg = SyntaxFactory::makeTupleTypeElement(y, Colon, Int);
 
     auto Attrs = SyntaxFactory::makeBlankTypeAttributes();
     auto ArgList = SyntaxFactory::makeBlankTypeArgumentList();

--- a/unittests/Syntax/TypeSyntaxTests.cpp
+++ b/unittests/Syntax/TypeSyntaxTests.cpp
@@ -182,7 +182,7 @@ TEST(TypeSyntaxTests, TupleWithAPIs) {
     auto Foo = SyntaxFactory::makeTypeIdentifier("Foo", {},
                                                  { Trivia::spaces(2) });
     auto Void = SyntaxFactory::makeVoidTupleType()
-      .withTypeArgumentList(SyntaxFactory::makeTupleTypeElementList({
+      .withTypeElementList(SyntaxFactory::makeTupleTypeElementList({
         SyntaxFactory::makeTupleTypeElement(Foo, Comma),
         SyntaxFactory::makeTupleTypeElement(Foo)
       }));


### PR DESCRIPTION
<!-- What's in this pull request? -->
This patch:

- Refactors `TypeArgumentListSyntax` and
  `TypeArgumentListSyntaxData` to use the `SyntaxCollection` and
  `SyntaxCollectionData` APIs.
- Refactors `TupleTypeElementSyntax` to own its trailing comma and
  updates the tests accordingly.
- Provides an infrastructure for promoting types to use
  the `SyntaxCollection` APIs
- Reworks `TypeArgumentList` as `TupleTypeElementList`
- Adds a round-trip test for tuple parsing.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves #46890.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->