### PR TITLE
Support for capture of a (im)mutable opaque value type

### DIFF
--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -665,7 +665,7 @@ ManagedValue SILGenFunction::emitExistentialErasure(
       }
     }
 
-    if (!C.getEmitInto() && !silConv.useLoweredAddresses()) {
+    if (!silConv.useLoweredAddresses()) {
       // We should never create new buffers just for init_existential under
       // opaque values mode: This is a case of an opaque value that we can
       // "treat" as a by-value one


### PR DESCRIPTION
Small part of radar rdar://problem/30080769

Adds support for guaranteed closure contexts in opaque values mode