### PR TITLE
[utils] Add message when run-test is run w/o args

### DIFF
--- a/utils/run-test
+++ b/utils/run-test
@@ -171,6 +171,7 @@ def main():
         # build_dir.
         paths = args.paths
         if not paths:
+            parser.print_usage()
             error_exit("error: too few arguments")
 
         if args.build != 'skip':


### PR DESCRIPTION
This prints the usage info if you run `utils/run-test` without any arguments.

```bash
$ utils/run-test
usage: run-test [-h] [-v] [--build-dir PATH] [--build {true,verbose,skip}]
                [--target TARGETS]
                [--mode {optimize_none,optimize,optimize_unchecked,only_executable,only_non_executable}]
                [--subset {primary,validation,all,only_validation,only_long}]
                [--param PARAM] [--result-dir PATH] [--lit PATH]
                [PATH [PATH ...]]
run-test: error: too few arguments
```