### PR TITLE
swiftenv-script: Fix some issues with swiftenvs.

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -611,8 +611,6 @@ class BuildScriptInvocation(object):
             "--darwin-deployment-version-watchos=%s" % (
                 args.darwin_deployment_version_watchos),
             "--cmake", toolchain.cmake,
-            "--cmake-c-compiler", toolchain.cc,
-            "--cmake-cxx-compiler", toolchain.cxx,
             "--cmark-build-type", args.cmark_build_variant,
             "--llvm-build-type", args.llvm_build_variant,
             "--swift-build-type", args.swift_build_variant,
@@ -1062,10 +1060,6 @@ def handle_swiftenv_args(args):
             sys.exit(2) # 2 is the same as `argparse` error exit code.
 
     if args.swiftenv_path is not None:
-        # mkdir the swiftenv_path
-        if not os.path.exists(args.swiftenv_path):
-            os.makedirs(args.swiftenv_path)
-
         # Only use swiftenv_make/swiftenv_script if one is provided
         # utils/swiftenv-make is default
         if args.swiftenv_make is None:
@@ -2046,19 +2040,6 @@ iterations with -O",
              "directory.".format(android.adb.commands.DEVICE_TEMP_DIR),
         default=android.adb.commands.DEVICE_TEMP_DIR,
         metavar="PATH")
-
-    parser.add_argument(
-        "--cmake-c-compiler",
-        help="the absolute path to CC, the 'clang' compiler for the host "
-             "platform. Default is auto detected.",
-        type=arguments.type.executable,
-        metavar="PATH")
-    parser.add_argument(
-        "--cmake-cxx-compiler",
-        help="the absolute path to CXX, the 'clang++' compiler for the host "
-             "platform. Default is auto detected.",
-        type=arguments.type.executable,
-        metavar="PATH")
     parser.add_argument(
         "--swiftenv-path",
         help="the absolute path to a directory containing replacement compiler commands")
@@ -2246,19 +2227,6 @@ iterations with -O",
 
     # Abstracted swiftenv_args for --preset and not
     handle_swiftenv_args(args)
-
-    # Let args.cmake_c_compiler win over swiftenv's cc/cxx
-    if args.cmake_c_compiler is None and args.swiftenv_path is not None:
-        if os.path.exists(args.swiftenv_path + "/clang"):
-            args.cmake_c_compiler = args.swiftenv_path + "/clang"
-    if args.cmake_cxx_compiler is None and args.swiftenv_path is not None:
-        if os.path.exists(args.swiftenv_path + "/clang++"):
-            args.cmake_cxx_compiler = args.swiftenv_path + "/clang++"
-
-    if args.cmake_c_compiler is not None:
-        toolchain.cc = args.cmake_c_compiler
-    if args.cmake_cxx_compiler is not None:
-        toolchain.cxx = args.cmake_cxx_compiler
 
     if args.cmake is not None:
         toolchain.cmake = args.cmake

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1081,7 +1081,7 @@ check_swiftenv_args
 # If we are using a swiftenv, do this next block
 if [ "${SWIFTENV_PATH}" ]; then
 
-  if [[ ! -d "${SWIFTENV_PATH}" ]]; then
+  if [ ! -d "${SWIFTENV_PATH}" ]; then
       echo "${COMMAND_NAME}: SWIFTENV_PATH does not exist, it will be created"
   fi
   if [[ "${SWIFTENV_RECREATE}" ]]; then
@@ -1089,7 +1089,7 @@ if [ "${SWIFTENV_PATH}" ]; then
   fi
 
   # redo the swiftenv by deleting, mkdir, and running the SWIFTENV_MAKE script
-  if [[ ! -d "${SWIFTENV_PATH}" ]] || [[ "${SWIFTENV_RECREATE}" ]]; then
+  if [ ! -d "${SWIFTENV_PATH}" ] || [[ "${SWIFTENV_RECREATE}" ]]; then
     if [ ! -f "${SWIFTENV_MAKE}" ]; then
       echo "${COMMAND_NAME} error: SWIFTENV_MAKE is not set."
       exit 2
@@ -1099,17 +1099,10 @@ if [ "${SWIFTENV_PATH}" ]; then
       exit 2
     fi
 
-    if [[ -d "${SWIFTENV_PATH}" ]] && [[ "${SWIFTENV_RECREATE}" ]]; then
-      echo "${COMMAND_NAME}: SWIFTENV_PATH does exists, it will be deleted and recreated"
-      call rm -rf "${SWIFTENV_PATH}"
-      echo "${COMMAND_NAME}: Calling mkdir on SWIFTENV_PATH: ${SWIFTENV_PATH}"
-      call mkdir -p "${SWIFTENV_PATH}"
-      echo "${COMMAND_NAME}: Calling \"${SWIFTENV_MAKE}\" \"${SWIFTENV_PATH}\" \"${SWIFTENV_SCRIPT}\""
-      call "${SWIFTENV_MAKE}" "${SWIFTENV_PATH}" "${SWIFTENV_SCRIPT}"
-    fi
-
-  else
-    echo "${COMMAND_NAME}: SWIFTENV_PATH exists, not recreating the SWIFTENV"
+    call rm -rf "${SWIFTENV_PATH}"
+    call mkdir -p "${SWIFTENV_PATH}"
+    echo "${COMMAND_NAME}: Calling \"${SWIFTENV_MAKE}\" \"${SWIFTENV_PATH}\" \"${SWIFTENV_SCRIPT}\""
+    call "${SWIFTENV_MAKE}" "${SWIFTENV_PATH}" "${SWIFTENV_SCRIPT}"
   fi
 fi
 
@@ -1186,8 +1179,10 @@ function set_cmake_tools {
   if [ "${CMAKE_C_COMPILER}" ]; then cmake_options=( "${cmake_options[@]}" -DCMAKE_C_COMPILER:PATH="${CMAKE_C_COMPILER}"); fi
   if [ "${CMAKE_CXX_COMPILER}" ]; then cmake_options=( "${cmake_options[@]}" -DCMAKE_CXX_COMPILER:PATH="${CMAKE_CXX_COMPILER}"); fi
   if [ "${CMAKE_AR}" ]; then cmake_options=( "${cmake_options[@]}" -DCMAKE_AR:PATH="${CMAKE_AR}"); fi
+  if [ "${CMAKE_LD}" ]; then cmake_options=( "${cmake_options[@]}" -DCMAKE_LD:PATH="${CMAKE_LD}"); fi
   if [ "${CMAKE_RANLIB}" ]; then cmake_options=( "${cmake_options[@]}" -DCMAKE_RANLIB:PATH="${CMAKE_RANLIB}"); fi
   if [ "${CMAKE_LIPO}" ]; then cmake_options=( "${cmake_options[@]}" -DCMAKE_LIPO:PATH="${CMAKE_LIPO}"); fi
+  if [ "${CMAKE_LIBTOOL}" ]; then cmake_options=( "${cmake_options[@]}" -DCMAKE_LIBTOOL:PATH="${CMAKE_LIBTOOL}"); fi
   if [ "${CMAKE_INSTALL_NAME_TOOL}" ]; then cmake_options=( "${cmake_options[@]}" -DCMAKE_INSTALL_NAME_TOOL:PATH="${CMAKE_INSTALL_NAME_TOOL}"); fi
   if [ "${CMAKE_CODESIGN}" ]; then cmake_options=( "${cmake_options[@]}" -DCMAKE_CODESIGN:PATH="${CMAKE_CODESIGN}"); fi
   if [ "${CMAKE_PYTHON}" ]; then cmake_options=( "${cmake_options[@]}" -DPYTHON_EXECUTABLE:PATH="${CMAKE_PYTHON}"); fi
@@ -2112,12 +2107,7 @@ for host in "${ALL_HOSTS[@]}"; do
                     build_targets=(llvm-tblgen clang-headers)
                 fi
 
-                if [ "${CMAKE_LIBTOOL}" ] ; then
-                    cmake_options=(
-                        "${cmake_options[@]}"
-                        -DCMAKE_LIBTOOL:PATH="${CMAKE_LIBTOOL}"
-                    )
-                fi
+                set_cmake_tools
 
                 # Note: we set the variable:
                 #

--- a/utils/swift_build_support/swift_build_support/cmake.py
+++ b/utils/swift_build_support/swift_build_support/cmake.py
@@ -98,15 +98,6 @@ class CMake(object):
         if args.export_compile_commands:
             define("CMAKE_EXPORT_COMPILE_COMMANDS", "ON")
 
-        if args.distcc:
-            define("CMAKE_C_COMPILER:PATH", toolchain.distcc)
-            define("CMAKE_C_COMPILER_ARG1", toolchain.cc)
-            define("CMAKE_CXX_COMPILER:PATH", toolchain.distcc)
-            define("CMAKE_CXX_COMPILER_ARG1", toolchain.cxx)
-        else:
-            define("CMAKE_C_COMPILER:PATH", toolchain.cc)
-            define("CMAKE_CXX_COMPILER:PATH", toolchain.cxx)
-
         if args.cmake_generator == 'Xcode':
             define("CMAKE_CONFIGURATION_TYPES",
                    "Debug;Release;MinSizeRel;RelWithDebInfo")

--- a/utils/swift_build_support/tests/test_cmake.py
+++ b/utils/swift_build_support/tests/test_cmake.py
@@ -28,9 +28,7 @@ class CMakeTestCase(unittest.TestCase):
     def default_args(self):
         """Return new args object with default values
         """
-        return Namespace(cmake_c_compiler="/path/to/clang",
-                         cmake_cxx_compiler="/path/to/clang++",
-                         enable_asan=False,
+        return Namespace(enable_asan=False,
                          enable_ubsan=False,
                          enable_tsan=False,
                          export_compile_commands=False,
@@ -54,8 +52,6 @@ class CMakeTestCase(unittest.TestCase):
         """Return new CMake object initialized with given args
         """
         toolchain = host_toolchain()
-        toolchain.cc = args.cmake_c_compiler
-        toolchain.cxx = args.cmake_cxx_compiler
         if args.distcc:
             toolchain.distcc = self.mock_distcc_path()
         toolchain.ninja = self.which_ninja(args)
@@ -67,8 +63,6 @@ class CMakeTestCase(unittest.TestCase):
         self.assertEqual(
             list(cmake.common_options()),
             ["-G", "Ninja",
-             "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
-             "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
              "-DCMAKE_MAKE_PROGRAM=" + self.which_ninja(args)])
 
     def test_common_options_asan(self):
@@ -79,8 +73,6 @@ class CMakeTestCase(unittest.TestCase):
             list(cmake.common_options()),
             ["-G", "Ninja",
              "-DLLVM_USE_SANITIZER=Address",
-             "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
-             "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
              "-DCMAKE_MAKE_PROGRAM=" + self.which_ninja(args)])
 
     def test_common_options_ubsan(self):
@@ -91,8 +83,6 @@ class CMakeTestCase(unittest.TestCase):
             list(cmake.common_options()),
             ["-G", "Ninja",
              "-DLLVM_USE_SANITIZER=Undefined",
-             "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
-             "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
              "-DCMAKE_MAKE_PROGRAM=" + self.which_ninja(args)])
 
     def test_common_options_tsan(self):
@@ -103,8 +93,6 @@ class CMakeTestCase(unittest.TestCase):
             list(cmake.common_options()),
             ["-G", "Ninja",
              "-DLLVM_USE_SANITIZER=Thread",
-             "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
-             "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
              "-DCMAKE_MAKE_PROGRAM=" + self.which_ninja(args)])
 
     def test_common_options_asan_ubsan(self):
@@ -116,8 +104,6 @@ class CMakeTestCase(unittest.TestCase):
             list(cmake.common_options()),
             ["-G", "Ninja",
              "-DLLVM_USE_SANITIZER=Address;Undefined",
-             "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
-             "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
              "-DCMAKE_MAKE_PROGRAM=" + self.which_ninja(args)])
 
     def test_common_options_ubsan_tsan(self):
@@ -129,8 +115,6 @@ class CMakeTestCase(unittest.TestCase):
             list(cmake.common_options()),
             ["-G", "Ninja",
              "-DLLVM_USE_SANITIZER=Undefined;Thread",
-             "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
-             "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
              "-DCMAKE_MAKE_PROGRAM=" + self.which_ninja(args)])
 
     def test_common_options_asan_ubsan_tsan(self):
@@ -143,8 +127,6 @@ class CMakeTestCase(unittest.TestCase):
             list(cmake.common_options()),
             ["-G", "Ninja",
              "-DLLVM_USE_SANITIZER=Address;Undefined;Thread",
-             "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
-             "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
              "-DCMAKE_MAKE_PROGRAM=" + self.which_ninja(args)])
 
     def test_common_options_export_compile_commands(self):
@@ -155,8 +137,6 @@ class CMakeTestCase(unittest.TestCase):
             list(cmake.common_options()),
             ["-G", "Ninja",
              "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON",
-             "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
-             "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
              "-DCMAKE_MAKE_PROGRAM=" + self.which_ninja(args)])
 
     def test_common_options_distcc(self):
@@ -166,10 +146,6 @@ class CMakeTestCase(unittest.TestCase):
         self.assertEqual(
             list(cmake.common_options()),
             ["-G", "Ninja",
-             "-DCMAKE_C_COMPILER:PATH=" + self.mock_distcc_path(),
-             "-DCMAKE_C_COMPILER_ARG1=/path/to/clang",
-             "-DCMAKE_CXX_COMPILER:PATH=" + self.mock_distcc_path(),
-             "-DCMAKE_CXX_COMPILER_ARG1=/path/to/clang++",
              "-DCMAKE_MAKE_PROGRAM=" + self.which_ninja(args)])
 
     def test_common_options_xcode(self):
@@ -179,8 +155,6 @@ class CMakeTestCase(unittest.TestCase):
         self.assertEqual(
             list(cmake.common_options()),
             ["-G", "Xcode",
-             "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
-             "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
              "-DCMAKE_CONFIGURATION_TYPES=" +
              "Debug;Release;MinSizeRel;RelWithDebInfo"])
 
@@ -193,8 +167,6 @@ class CMakeTestCase(unittest.TestCase):
         self.assertEqual(
             list(cmake.common_options()),
             ["-G", "Ninja",
-             "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
-             "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
              "-DLLVM_VERSION_MAJOR:STRING=3",
              "-DLLVM_VERSION_MINOR:STRING=8",
              "-DLLVM_VERSION_PATCH:STRING=0",
@@ -207,8 +179,6 @@ class CMakeTestCase(unittest.TestCase):
         self.assertEqual(
             list(cmake.common_options()),
             ["-G", "Ninja",
-             "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
-             "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
              "-DCMAKE_MAKE_PROGRAM=" + self.which_ninja(args)])
 
     def test_common_options_full(self):
@@ -228,10 +198,6 @@ class CMakeTestCase(unittest.TestCase):
             ["-G", "Xcode",
              "-DLLVM_USE_SANITIZER=Address;Undefined",
              "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON",
-             "-DCMAKE_C_COMPILER:PATH=" + self.mock_distcc_path(),
-             "-DCMAKE_C_COMPILER_ARG1=/path/to/clang",
-             "-DCMAKE_CXX_COMPILER:PATH=" + self.mock_distcc_path(),
-             "-DCMAKE_CXX_COMPILER_ARG1=/path/to/clang++",
              "-DCMAKE_CONFIGURATION_TYPES=" +
              "Debug;Release;MinSizeRel;RelWithDebInfo",
              "-DLLVM_VERSION_MAJOR:STRING=3",

--- a/utils/swiftenv-script
+++ b/utils/swiftenv-script
@@ -27,7 +27,7 @@ function find_real_command {
     fi
     case "$command_name" in
         clang|clang++|ld|swift|swiftc|lipo|ar|codesign|dsymutil|libtool|ranlib|strip|llvm-tblgen|python) "${find_util}" "${command_name}";;
-        *) echo "${command_name}";;
+        *) echo "$1";;
     esac
 }
 function find_o_target { # last -o wins, can short circuit for faster compiles
@@ -41,19 +41,27 @@ function find_o_target { # last -o wins, can short circuit for faster compiles
         esac; done
     echo "${o_target}"
 }
-function find_module_target {
+function find_swift_targets {
     while test $# -gt 0; do
         case "$1" in
-            -emit-module-path) echo "$2"; break;;
+            -o)
+                local out="$2";
+                outfiles=("${outfiles[@]}" "${out}")
+                if [[ "$2" == *.swiftmodule ]]; then
+                    outfiles=("${outfiles[@]}" "${out:0:${#out}-12}.swiftdoc")
+                fi
+                shift; shift;;
+            -output-file-map)
+                outfiles=("${outfiles[@]}" "$2"); shift; shift;;
+            -emit-module-path)
+                local module_path="$2";
+                outfiles=("${outfiles[@]}" "${module_path}")
+                outfiles=("${outfiles[@]}" "${module_path:0:${#module_path}-12}.swiftdoc")
+                shift; shift;;
+            -emit-objc-header-path)
+                outfiles=("${outfiles[@]}" "$2"); shift; shift;;
             *) shift;;
         esac; done
-}
-function emit_module_p { #emit -o's arg + swiftmodule
-    while test $# -gt 0; do
-        case "$1" in
-            -emit-module) return 0;;
-            *) shift;;
-        esac; done; return 1
 }
 function find_command_targets { # sets: outfiles
     local name="$1"
@@ -61,12 +69,7 @@ function find_command_targets { # sets: outfiles
     case "$name" in
         clang|clang++|ld|libtool|clang-tblgen|llvm-tblgen|lipo|gyb)
             outfiles=("${outfiles[@]}" $(find_o_target "${args[@]}"));;
-        swift|swiftc)
-            outfiles=("${outfiles[@]}" $(find_o_target "${args[@]}"));
-            if emit_module_p "${args[@]}" ; then
-                local last_outfile; last_outfile=("${outfiles[@]: -1}")
-                outfiles=("${outfiles[@]}" "${last_outfile:0:${#last_outfile}-12}.swiftdoc"); fi
-            find_module_target "${args[@]}";;
+        swift|swiftc) find_swift_targets "${args[@]}";;
         ranlib) outfiles=("${outfiles[@]}" $(first "${args[@]}"));;
         ar) outfiles=("${outfiles[@]}" $(second "${args[@]}"));;
         codesign|dsymutil|install_name_tool|strip) outfiles=("${outfiles[@]}" $(last "${args[@]}"));;


### PR DESCRIPTION
clang from build-script to build-script-impl like all the other
commands. Pass more args to LLVM. Fix swiftenv creation.
