### PR TITLE
[ClangImporter] Don't crash on versioned import-as-member stubs.

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -7506,13 +7506,14 @@ ClangImporter::Implementation::loadAllMembers(Decl *D, uint64_t extra) {
 
       // Import the member.
       auto member = importDecl(decl, CurrentVersion);
-      if (!member) continue;
+      if (!member || member->getDeclContext() != ext) continue;
 
       // Add the member.
       ext->addMember(member);
 
       for (auto alternate : getAlternateDecls(member)) {
-        ext->addMember(alternate);
+        if (alternate->getDeclContext() == ext)
+          ext->addMember(alternate);
       }
 
       // Import the Swift 2 stub declaration.

--- a/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/APINotesFrameworkTest.apinotes
+++ b/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/APINotesFrameworkTest.apinotes
@@ -35,6 +35,9 @@ Classes:
 Functions:
   - Name: jumpToLocation
     SwiftName: 'jumpTo(x:y:z:)'
+Tags:
+  - Name: InnerInSwift4
+    SwiftName: Outer.Inner
 SwiftVersions:
   - Version: 3.0
     Classes:
@@ -92,3 +95,5 @@ SwiftVersions:
     Tags:
       - Name: SomeCStruct
         SwiftName: ImportantCStruct
+      - Name: InnerInSwift4
+        SwiftName: InnerInSwift4

--- a/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/APINotesFrameworkTest.h
+++ b/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/APINotesFrameworkTest.h
@@ -17,6 +17,7 @@ __attribute__((objc_root_class))
 
 #endif // __OBJC__
 
+#import <APINotesFrameworkTest/ImportAsMember.h>
 #import <APINotesFrameworkTest/Properties.h>
 #import <APINotesFrameworkTest/Protocols.h>
 #import <APINotesFrameworkTest/Types.h>

--- a/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/ImportAsMember.h
+++ b/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/ImportAsMember.h
@@ -1,0 +1,11 @@
+#pragma clang assume_nonnull begin
+
+struct Outer {
+  int value;
+};
+
+struct InnerInSwift4 {
+  int value;
+};
+
+#pragma clang assume_nonnull end

--- a/test/APINotes/versioned.swift
+++ b/test/APINotes/versioned.swift
@@ -55,4 +55,13 @@ func testRenamedTopLevel() {
   _ = VeryImportantCStruct()
   // CHECK-DIAGS-3: versioned.swift:[[@LINE-1]]:7: error: 'VeryImportantCStruct' has been renamed to 'ImportantCStruct'
   // CHECK-DIAGS-3: note: 'VeryImportantCStruct' was introduced in Swift 4
+
+  // CHECK-DIAGS-3-NOT: versioned.swift:[[@LINE+1]]:
+  _ = InnerInSwift4()
+  // CHECK-DIAGS-4: versioned.swift:[[@LINE-1]]:7: error: 'InnerInSwift4' has been renamed to 'Outer.Inner'
+  // CHECK-DIAGS-4: note: 'InnerInSwift4' was obsoleted in Swift 4
+
+  // CHECK-DIAGS-4-NOT: versioned.swift:[[@LINE+1]]:
+  _ = Outer.Inner()
+  // CHECK-DIAGS-3: versioned.swift:[[@LINE-1]]:7: error: type 'Outer' has no member 'Inner'
 }


### PR DESCRIPTION
If a top-level declaration is imported as a member in Swift 4 but not in Swift 3, it would still show up in the lookup table for the containing type in Swift 3 mode. We would import it, and then try to add the top-level declaration to the containing type.

I'm about to redo this anyway so that the versioned stub will show up (the one for the Swift 4 name) but this is the narrow fix that avoids the assertion failure we were seeing.

rdar://problem/31161489