### PR TITLE
[Syntax] Make FunctionTypeSyntax use a FunctionParameterList

### DIFF
--- a/include/swift/Syntax/DeclSyntax.h
+++ b/include/swift/Syntax/DeclSyntax.h
@@ -635,12 +635,6 @@ public:
   }
 };
 
-#pragma mark - function-parameter-list Data
-
-using FunctionParameterListSyntaxData =
-  SyntaxCollectionData<SyntaxKind::FunctionParameterList,
-  FunctionParameterSyntax>;
-
 #pragma mark - function-parameter-list API
 
 /// parameter-list -> parameteter | parameter ',' parameter-list

--- a/include/swift/Syntax/SyntaxCollection.h
+++ b/include/swift/Syntax/SyntaxCollection.h
@@ -201,12 +201,6 @@ public:
   }
 };
 
-#define SYNTAX(Id, Parent)
-#define SYNTAX_COLLECTION(Id, Element) \
-  class Element;                       \
-  using Id##Syntax = SyntaxCollection<SyntaxKind::Id, Element>;
-#include "swift/Syntax/SyntaxKinds.def"
-
 } // end namespace syntax
 } // end namespace swift
 

--- a/include/swift/Syntax/SyntaxFactory.h
+++ b/include/swift/Syntax/SyntaxFactory.h
@@ -126,7 +126,7 @@ struct SyntaxFactory {
 
   /// Make a function parameter list with the given parameters.
   static FunctionParameterListSyntax makeFunctionParameterList(
-    const std::vector<FunctionParameterSyntax> &Parameters);
+    std::vector<FunctionParameterSyntax> Parameters);
 
   /// Make an empty function parameter list.
   static FunctionParameterListSyntax makeBlankFunctionParameterList();
@@ -579,7 +579,7 @@ struct SyntaxFactory {
   static FunctionTypeSyntax
   makeFunctionType(TypeAttributesSyntax TypeAttributes,
                    RC<TokenSyntax> LeftParen,
-                   TupleTypeElementListSyntax ArgumentList,
+                   FunctionParameterListSyntax ArgumentList,
                    RC<TokenSyntax> RightParen, RC<TokenSyntax> ThrowsOrRethrows,
                    RC<TokenSyntax> Arrow, TypeSyntax ReturnType);
 

--- a/include/swift/Syntax/SyntaxKinds.def
+++ b/include/swift/Syntax/SyntaxKinds.def
@@ -104,11 +104,11 @@ SYNTAX(FunctionTypeArgument, Syntax)
 SYNTAX(FunctionCallArgumentList, Syntax)
 SYNTAX(FunctionCallArgument, Syntax)
 SYNTAX(FunctionSignature, Syntax)
-SYNTAX(FunctionParameterList, Syntax)
 SYNTAX(FunctionParameter, Syntax)
 SYNTAX(DeclModifier, Syntax)
 SYNTAX(DeclModifierList, Syntax)
 
+SYNTAX_COLLECTION(FunctionParameterList, FunctionParameterSyntax)
 SYNTAX_COLLECTION(TupleTypeElementList, TupleTypeElementSyntax)
 
 #undef SYNTAX_COLLECTION

--- a/include/swift/Syntax/TypeSyntax.h
+++ b/include/swift/Syntax/TypeSyntax.h
@@ -403,7 +403,12 @@ public:
     return S->getKind() == SyntaxKind::TupleTypeElement;
   }
 };
-  
+
+#pragma mark - tuple-type-element-list API
+
+using TupleTypeElementListSyntax =
+  SyntaxCollection<SyntaxKind::TupleTypeElementList, TupleTypeElementSyntax>;
+
 #pragma mark - tuple-type Data
 
 class TupleTypeSyntaxData final : public TypeSyntaxData {

--- a/lib/Syntax/SyntaxFactory.cpp
+++ b/lib/Syntax/SyntaxFactory.cpp
@@ -174,16 +174,9 @@ FunctionParameterSyntax SyntaxFactory::makeBlankFunctionParameter() {
 #pragma mark - function-parameter-list
 
 FunctionParameterListSyntax SyntaxFactory::makeFunctionParameterList(
-    const std::vector<FunctionParameterSyntax> &Parameters) {
-  RawSyntax::LayoutList Layout;
-  for (auto Param : Parameters) {
-    Layout.push_back(Param.getRaw());
-  }
-
-  auto Raw = RawSyntax::make(SyntaxKind::FunctionParameterList, Layout,
-                             SourcePresence::Present);
-  auto Data = FunctionParameterListSyntaxData::make(Raw);
-  return { Data, Data.get() };
+    std::vector<FunctionParameterSyntax> Parameters) {
+  auto Data = FunctionParameterListSyntax::makeData(Parameters);
+  return FunctionParameterListSyntax { Data, Data.get() };
 }
 
 FunctionParameterListSyntax SyntaxFactory::makeBlankFunctionParameterList() {
@@ -1145,7 +1138,7 @@ MetatypeTypeSyntax SyntaxFactory::makeBlankMetatypeType() {
 
 FunctionTypeSyntax SyntaxFactory::makeFunctionType(
     TypeAttributesSyntax TypeAttributes, RC<TokenSyntax> LeftParen,
-    TupleTypeElementListSyntax ArgumentList, RC<TokenSyntax> RightParen,
+    FunctionParameterListSyntax ArgumentList, RC<TokenSyntax> RightParen,
     RC<TokenSyntax> ThrowsOrRethrows, RC<TokenSyntax> Arrow,
     TypeSyntax ReturnType) {
   auto Raw =

--- a/lib/Syntax/TypeSyntax.cpp
+++ b/lib/Syntax/TypeSyntax.cpp
@@ -879,9 +879,8 @@ FunctionTypeSyntaxData::FunctionTypeSyntaxData(RC<RawSyntax> Raw,
   syntax_assert_child_token_text(Raw, FunctionTypeSyntax::Cursor::LeftParen,
                                  tok::l_paren, "(");
 
-  // FIXME: This needs its own element and element list.
   syntax_assert_child_kind(Raw, FunctionTypeSyntax::Cursor::ArgumentList,
-                           SyntaxKind::TupleTypeElementList);
+                           SyntaxKind::FunctionParameterList);
 
   syntax_assert_child_token_text(Raw, FunctionTypeSyntax::Cursor::RightParen,
                                  tok::r_paren, ")");
@@ -911,8 +910,7 @@ RC<FunctionTypeSyntaxData> FunctionTypeSyntaxData::makeBlank() {
     {
       RawSyntax::missing(SyntaxKind::TypeAttributes),
       TokenSyntax::missingToken(tok::l_paren, "("),
-      // FIXME: This needs its own element and element list.
-      RawSyntax::missing(SyntaxKind::TupleTypeElementList),
+      RawSyntax::missing(SyntaxKind::FunctionParameterList),
       TokenSyntax::missingToken(tok::r_paren, ")"),
       TokenSyntax::missingToken(tok::kw_throws, "throws"),
       TokenSyntax::missingToken(tok::arrow, "->"),
@@ -1042,7 +1040,7 @@ addArgumentTypeSyntax(Optional<RC<TokenSyntax>> MaybeComma,
 
   TypeArgumentsLayout.push_back(NewTypeArgument.getRaw());
 
-  FunctionTypeLayout[Index] = RawSyntax::make(SyntaxKind::TupleTypeElementList,
+  FunctionTypeLayout[Index] = RawSyntax::make(SyntaxKind::FunctionParameterList,
                                               TypeArgumentsLayout,
                                               SourcePresence::Present);
   return *this;

--- a/test/Syntax/round_trip_function.swift
+++ b/test/Syntax/round_trip_function.swift
@@ -1,0 +1,16 @@
+// RUN: %round-trip-syntax-test --swift-syntax-test %swift-syntax-test --file %s
+
+func noArgs() {}
+func oneArg(x: Int) {}
+func oneUnlabelledArg(_ x: Int) {}
+
+typealias FunctionAlias = (_ x: inout Int) -> Bool
+typealias FunctionAliasNoLabel = (Int) -> Bool
+
+func manyArgs(x: Int, y: Int, _ z: Bool, _ a: String) throws -> [Int] {
+  return []
+}
+
+func rethrowing(_ f: (Bool) throws -> Int) rethrows -> Int {
+  return try f(false)
+}

--- a/unittests/Syntax/TypeSyntaxTests.cpp
+++ b/unittests/Syntax/TypeSyntaxTests.cpp
@@ -466,9 +466,10 @@ TEST(TypeSyntaxTests, FunctionTypeMakeAPIs) {
   auto Colon = SyntaxFactory::makeColonToken({}, { Trivia::spaces(1) });
   auto LeftParen = SyntaxFactory::makeLeftParenToken({}, {});
   auto RightParen = SyntaxFactory::makeRightParenToken({},
-                                                         {Trivia::spaces(1)});
+                                                       {Trivia::spaces(1)});
   auto Int = SyntaxFactory::makeTypeIdentifier("Int", {}, {});
-  auto IntArg = SyntaxFactory::makeTupleTypeElement(Int);
+  auto IntArg = SyntaxFactory::makeBlankFunctionParameter()
+    .withTypeSyntax(Int);
   auto Throws = SyntaxFactory::makeThrowsKeyword({}, { Trivia::spaces(1) });
   auto Rethrows = SyntaxFactory::makeRethrowsKeyword({},
                                                        { Trivia::spaces(1) });
@@ -480,15 +481,24 @@ TEST(TypeSyntaxTests, FunctionTypeMakeAPIs) {
 
     auto x = SyntaxFactory::makeIdentifier("x", {}, {});
     auto y = SyntaxFactory::makeIdentifier("y", {}, {});
-    auto xArg = SyntaxFactory::makeTupleTypeElement(x, Colon, Int, Comma);
-    auto yArg = SyntaxFactory::makeTupleTypeElement(y, Colon, Int);
+    auto xArg = SyntaxFactory::makeBlankFunctionParameter()
+      .withExternalName(x)
+      .withColonToken(Colon)
+      .withTypeSyntax(Int)
+      .withTrailingComma(Comma);
+    auto yArg = SyntaxFactory::makeBlankFunctionParameter()
+      .withExternalName(y)
+      .withColonToken(Colon)
+      .withTypeSyntax(Int);
 
     auto Attrs = SyntaxFactory::makeBlankTypeAttributes();
-    auto TypeList = SyntaxFactory::makeBlankTupleTypeElementList()
-      .appending(xArg)
-      .appending(yArg);
+    auto TypeList = SyntaxFactory::makeFunctionParameterList({
+      xArg, yArg
+    });
     SyntaxFactory::makeFunctionType(Attrs,
-                                    LeftParen, TypeList, RightParen,
+                                    LeftParen,
+                                    TypeList,
+                                    RightParen,
                                     Throws,
                                     Arrow,
                                     Int)
@@ -499,13 +509,15 @@ TEST(TypeSyntaxTests, FunctionTypeMakeAPIs) {
   {
     SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    auto IntArgComma = IntArg.withCommaToken(Comma);
     auto Attrs = SyntaxFactory::makeBlankTypeAttributes();
-    auto TypeList = SyntaxFactory::makeBlankTupleTypeElementList()
-      .appending(IntArg.withCommaToken(Comma))
-      .appending(IntArg);
+    auto TypeList = SyntaxFactory::makeFunctionParameterList({
+      IntArg.withTrailingComma(Comma),
+      IntArg
+    });
     SyntaxFactory::makeFunctionType(Attrs,
-                                    LeftParen, TypeList, RightParen,
+                                    LeftParen,
+                                    TypeList,
+                                    RightParen,
                                     Rethrows,
                                     Arrow,
                                     Int).print(OS);
@@ -521,10 +533,12 @@ TEST(TypeSyntaxTests, FunctionTypeMakeAPIs) {
     auto yArg = SyntaxFactory::makeTupleTypeElement(y, Colon, Int);
 
     auto Attrs = SyntaxFactory::makeBlankTypeAttributes();
-    auto TypeList = SyntaxFactory::makeBlankTupleTypeElementList();
+    auto TypeList = SyntaxFactory::makeBlankFunctionParameterList();
     auto Void = SyntaxFactory::makeVoidTupleType();
     SyntaxFactory::makeFunctionType(Attrs,
-                                    LeftParen, TypeList, RightParen,
+                                    LeftParen,
+                                    TypeList,
+                                    RightParen,
                                     TokenSyntax::missingToken(tok::kw_throws,
                                                               "throws"),
                                     Arrow,

--- a/unittests/Syntax/TypeSyntaxTests.cpp
+++ b/unittests/Syntax/TypeSyntaxTests.cpp
@@ -527,11 +527,6 @@ TEST(TypeSyntaxTests, FunctionTypeMakeAPIs) {
   {
     SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    auto x = SyntaxFactory::makeIdentifier("x", {}, {});
-    auto y = SyntaxFactory::makeIdentifier("y", {}, {});
-    auto xArg = SyntaxFactory::makeTupleTypeElement(x, Colon, Int);
-    auto yArg = SyntaxFactory::makeTupleTypeElement(y, Colon, Int);
-
     auto Attrs = SyntaxFactory::makeBlankTypeAttributes();
     auto TypeList = SyntaxFactory::makeBlankFunctionParameterList();
     auto Void = SyntaxFactory::makeVoidTupleType();


### PR DESCRIPTION
<!-- What's in this pull request? -->
This opens up support for `inout` and labels in `FunctionTypeSyntax`, which was previously using
`TupleTypeElementList`s.

This also adds a round-trip test for function types.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-4313](https://bugs.swift.org/browse/SR-4313).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
