### PR TITLE
SILOptimizer: avoid "deprecation" warnings

### DIFF
--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -1078,7 +1078,7 @@ void FunctionSignaturePartialSpecializer::
           LookUpConformanceInSignature(*CallerGenericSig));
 
   DEBUG(llvm::dbgs() << "\n\nCallerInterfaceToSpecializedInterfaceMap map:\n";
-        CallerInterfaceToSpecializedInterfaceMap.dump());
+        CallerInterfaceToSpecializedInterfaceMap.dump(llvm::dbgs()));
 }
 
 void FunctionSignaturePartialSpecializer::
@@ -1092,7 +1092,7 @@ void FunctionSignaturePartialSpecializer::
           LookUpConformanceInSignature(*CalleeGenericSig));
 
   DEBUG(llvm::dbgs() << "\n\nCalleeInterfaceToSpecializedInterfaceMap:\n";
-        CalleeInterfaceToSpecializedInterfaceMap.dump());
+        CalleeInterfaceToSpecializedInterfaceMap.dump(llvm::dbgs()));
 }
 
 /// Generate a new generic type parameter for each used archetype from
@@ -1299,7 +1299,7 @@ void FunctionSignaturePartialSpecializer::computeCallerParamSubs(
           LookUpConformanceInSignature(*SpecializedGenericSig));
 
   DEBUG(llvm::dbgs() << "\n\nSpecializedInterfaceToCallerArchetypeMap map:\n";
-        SpecializedInterfaceToCallerArchetypeMap.dump());
+        SpecializedInterfaceToCallerArchetypeMap.dump(llvm::dbgs()));
 
   SpecializedGenericSig->getSubstitutions(
       SpecializedInterfaceToCallerArchetypeMap, List);
@@ -1325,7 +1325,7 @@ void FunctionSignaturePartialSpecializer::computeCallerInterfaceSubs(
       LookUpConformanceInSignature(*CalleeGenericSig));
 
   DEBUG(llvm::dbgs() << "\n\nCallerInterfaceSubs map:\n";
-        CallerInterfaceSubs.dump());
+        CallerInterfaceSubs.dump(llvm::dbgs()));
 }
 
 CanSILFunctionType


### PR DESCRIPTION
The `dump` method is meant for interactive use in debuggers only.  Use
the parameter form to avoid the warning.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
