### PR TITLE
SILOptimizer: remove unused variable

### DIFF
--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -1426,7 +1426,6 @@ FunctionSignaturePartialSpecializer::createSpecializedGenericSignature(
 void ReabstractionInfo::specializeConcreteAndGenericSubstitutions(
     ApplySite Apply, SILFunction *Callee, ArrayRef<Substitution> ParamSubs) {
   SILModule &M = Callee->getModule();
-  auto *SM = M.getSwiftModule();
   auto &Ctx = M.getASTContext();
 
   // Caller is the SILFunction containing the apply instruction.


### PR DESCRIPTION
swift/lib/SILOptimizer/Utils/Generics.cpp:1429:9: warning: unused variable 'SM' [-Wunused-variable]

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
