### PR TITLE
[silgen] Add SILParameterInfo::isDirectGuaranteed().

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -2802,6 +2802,10 @@ public:
     return isIndirectFormalParameter(getConvention());
   }
 
+  bool isDirectGuaranteed() const {
+    return getConvention() == ParameterConvention::Direct_Guaranteed;
+  }
+
   bool isIndirectInGuaranteed() const {
     return getConvention() == ParameterConvention::Indirect_In_Guaranteed;
   }


### PR DESCRIPTION
This is just a direct counterpart of SILParameterInfo::isIndirect*().

rdar://31145255