### PR TITLE
[GSB] Diagnose explicit constraints made redundant by inferred ones.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1574,22 +1574,25 @@ ERROR(protocol_typealias_conflict, none,
 WARNING(redundant_conformance_constraint,none,
         "redundant conformance constraint %0: %1", (Type, ProtocolDecl *))
 NOTE(redundant_conformance_here,none,
-     "conformance constraint %1: %2 %select{written here|implied here}0",
-     (bool, Type, ProtocolDecl *))
+     "conformance constraint %1: %2 %select{written here|implied here|"
+     "inferred from type here}0",
+     (unsigned, Type, ProtocolDecl *))
 
 WARNING(redundant_same_type_to_concrete,none,
         "redundant same-type constraint %0 == %1", (Type, Type))
 NOTE(same_type_redundancy_here,none,
-     "same-type constraint %1 == %2 %select{written here|implied here}0",
-     (bool, Type, Type))
+     "same-type constraint %1 == %2 %select{written here|implied here|"
+     "inferred from type here}0",
+     (unsigned, Type, Type))
 ERROR(requires_superclass_conflict,none,
       "%select{generic parameter |protocol |}0%1 cannot be a subclass of both "
       "%2 and %3", (unsigned, Type, Type, Type))
 WARNING(redundant_superclass_constraint,none,
         "redundant superclass constraint %0 : %1", (Type, Type))
 NOTE(superclass_redundancy_here,none,
-     "superclass constraint %1 : %2 %select{written here|implied here}0",
-     (bool, Type, Type))
+     "superclass constraint %1 : %2 %select{written here|implied here|"
+     "inferred from type here}0",
+     (unsigned, Type, Type))
 
 ERROR(conflicting_layout_constraints,none,
       "%select{generic parameter |protocol |}0%1 has conflicting layout "
@@ -1598,15 +1601,16 @@ ERROR(conflicting_layout_constraints,none,
 WARNING(redundant_layout_constraint,none,
         "redundant layout constraint %0 : %1", (Type, LayoutConstraint))
 NOTE(previous_layout_constraint, none,
-     "layout constraint constraint %1 : %2 %select{written here|implied here}0",
-     (bool, Type, LayoutConstraint))
+     "layout constraint constraint %1 : %2 %select{written here|implied here|"
+     "inferred from type here}0",
+     (unsigned, Type, LayoutConstraint))
 
 WARNING(redundant_same_type_constraint,none,
         "redundant same-type constraint %0 == %1", (Type, Type))
 NOTE(previous_same_type_constraint, none,
      "previous same-type constraint %1 == %2 "
-     "%select{written here|implied here}0",
-     (bool, Type, Type))
+     "%select{written here|implied here|inferred from type here}0",
+     (unsigned, Type, Type))
 
 ERROR(generic_param_access,none,
       "%0 %select{must be declared %select{"

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -476,7 +476,7 @@ private:
                            Optional<Diag<unsigned, Type, T, T>>
                              conflictingDiag,
                            Diag<Type, T> redundancyDiag,
-                           Diag<bool, Type, T> otherNoteDiag);
+                           Diag<unsigned, Type, T> otherNoteDiag);
 
   /// Check a list of constraints, removing self-derived constraints
   /// and diagnosing redundant constraints.
@@ -500,7 +500,7 @@ private:
                            Optional<Diag<unsigned, Type, DiagT, DiagT>>
                              conflictingDiag,
                            Diag<Type, DiagT> redundancyDiag,
-                           Diag<bool, Type, DiagT> otherNoteDiag,
+                           Diag<unsigned, Type, DiagT> otherNoteDiag,
                            llvm::function_ref<DiagT(const T&)> diagValue,
                            bool removeSelfDerived);
 
@@ -869,6 +869,9 @@ public:
   bool isInferredRequirement() const {
     return getRoot()->kind == Inferred;
   }
+
+  /// Classify the kind of this source for diagnostic purposes.
+  unsigned classifyDiagKind() const;
 
   /// Whether the requirement can be derived from something in its path.
   ///

--- a/stdlib/private/StdlibCollectionUnittest/CheckMutableCollectionType.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/CheckMutableCollectionType.swift.gyb
@@ -68,13 +68,13 @@ internal func _mapInPlace<C : MutableCollection>(
 }
 
 internal func makeBufferAccessLoggingMutableCollection<
-  C : MutableCollection & BidirectionalCollection
+  C
 >(wrapping c: C) -> BufferAccessLoggingMutableBidirectionalCollection<C> {
   return BufferAccessLoggingMutableBidirectionalCollection(wrapping: c)
 }
 
 internal func makeBufferAccessLoggingMutableCollection<
-  C : MutableCollection & RandomAccessCollection
+  C
 >(wrapping c: C) -> BufferAccessLoggingMutableRandomAccessCollection<C> {
   return BufferAccessLoggingMutableRandomAccessCollection(wrapping: c)
 }

--- a/stdlib/private/StdlibCollectionUnittest/CheckMutableCollectionType.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/CheckMutableCollectionType.swift.gyb
@@ -75,8 +75,8 @@ internal func makeBufferAccessLoggingMutableCollection<
 
 internal func makeBufferAccessLoggingMutableCollection<
   C : MutableCollection & RandomAccessCollection
->(wrapping c: C) -> BufferAccessLoggingMutableBidirectionalCollection<C> {
-  return BufferAccessLoggingMutableBidirectionalCollection(wrapping: c)
+>(wrapping c: C) -> BufferAccessLoggingMutableRandomAccessCollection<C> {
+  return BufferAccessLoggingMutableRandomAccessCollection(wrapping: c)
 }
 
 extension TestSuite {

--- a/stdlib/private/StdlibCollectionUnittest/LoggingWrappers.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/LoggingWrappers.swift.gyb
@@ -42,7 +42,7 @@ extension LoggingType {
 //===----------------------------------------------------------------------===//
 
 public class IteratorLog {
-  public static func dispatchTester<I : IteratorProtocol>(
+  public static func dispatchTester<I>(
     _ iterator: I
   ) -> LoggingIterator<LoggingIterator<I>> {
     return LoggingIterator(wrapping: LoggingIterator(wrapping: iterator))
@@ -72,7 +72,7 @@ public struct LoggingIterator<Base : IteratorProtocol>
 //===----------------------------------------------------------------------===//
 
 public class SequenceLog {
-  public static func dispatchTester<S : Sequence>(
+  public static func dispatchTester<S>(
     _ s: S
   ) -> LoggingSequence<LoggingSequence<S>> {
     return LoggingSequence(wrapping: LoggingSequence(wrapping: s))
@@ -96,7 +96,7 @@ public class SequenceLog {
 }
 
 public class CollectionLog : SequenceLog {
-  public class func dispatchTester<C : Collection>(
+  public class func dispatchTester<C>(
     _ c: C
   ) -> LoggingCollection<LoggingCollection<C>> {
     return LoggingCollection(wrapping: LoggingCollection(wrapping: c))
@@ -123,7 +123,7 @@ public class CollectionLog : SequenceLog {
 }
 
 public class BidirectionalCollectionLog : SequenceLog {
-  public class func dispatchTester<C : BidirectionalCollection>(
+  public class func dispatchTester<C>(
     _ c: C
   ) -> LoggingBidirectionalCollection<LoggingBidirectionalCollection<C>> {
     return LoggingBidirectionalCollection(
@@ -135,7 +135,7 @@ public class BidirectionalCollectionLog : SequenceLog {
 }
 
 public class MutableCollectionLog : CollectionLog {
-  public class func dispatchTester<C : MutableCollection>(
+  public class func dispatchTester<C>(
     _ c: C
   ) -> LoggingMutableCollection<LoggingMutableCollection<C>> {
     return LoggingMutableCollection(
@@ -172,7 +172,7 @@ public class RangeReplaceableCollectionLog : CollectionLog {
   public static var replaceSubrange = TypeIndexed(0)
   public static var reserveCapacity = TypeIndexed(0)
 
-  public class func dispatchTester<C : RangeReplaceableCollection>(
+  public class func dispatchTester<C>(
     _ rrc: C
   ) -> LoggingRangeReplaceableCollection<LoggingRangeReplaceableCollection<C>> {
     return LoggingRangeReplaceableCollection(

--- a/stdlib/private/StdlibUnittest/RaceTest.swift
+++ b/stdlib/private/StdlibUnittest/RaceTest.swift
@@ -413,9 +413,7 @@ class _RaceTestSharedState<RT : RaceTestWithPerTrialData> {
   }
 }
 
-func _masterThreadStopWorkers<RT : RaceTestWithPerTrialData>(
-    _ sharedState: _RaceTestSharedState<RT>
-) {
+func _masterThreadStopWorkers<RT>( _ sharedState: _RaceTestSharedState<RT>) {
   // Workers are proceeding to the first barrier in _workerThreadOneTrial.
   sharedState.stopNow.store(1)
   // Allow workers to proceed past that first barrier. They will then see
@@ -423,9 +421,7 @@ func _masterThreadStopWorkers<RT : RaceTestWithPerTrialData>(
   sharedState.trialBarrier.wait()
 }
 
-func _masterThreadOneTrial<RT : RaceTestWithPerTrialData>(
-  _ sharedState: _RaceTestSharedState<RT>
-) {
+func _masterThreadOneTrial<RT>(_ sharedState: _RaceTestSharedState<RT>) {
   let racingThreadCount = sharedState.racingThreadCount
   let raceDataCount = racingThreadCount * racingThreadCount
   let rt = RT()
@@ -485,7 +481,7 @@ func _masterThreadOneTrial<RT : RaceTestWithPerTrialData>(
   }
 }
 
-func _workerThreadOneTrial<RT : RaceTestWithPerTrialData>(
+func _workerThreadOneTrial<RT>(
   _ tid: Int, _ sharedState: _RaceTestSharedState<RT>
 ) -> Bool {
   sharedState.trialBarrier.wait()

--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
@@ -290,7 +290,7 @@ public func expectGE<T : Comparable>(_ lhs: T, _ rhs: T, ${TRACE}) {
 extension Range
 %   if 'Countable' in OtherRange:
   where
-  Bound : Comparable & _Strideable, Bound.Stride : SignedInteger
+  Bound : _Strideable, Bound.Stride : SignedInteger
 %   end
 {
   internal func _contains(_ other: ${OtherRange}<Bound>) -> Bool {

--- a/stdlib/public/SDK/CoreData/NSManagedObjectContext.swift
+++ b/stdlib/public/SDK/CoreData/NSManagedObjectContext.swift
@@ -14,11 +14,11 @@
 import Foundation
 
 extension NSManagedObjectContext {
-  public func fetch<T: NSFetchRequestResult>(_ request: NSFetchRequest<T>) throws -> [T] {
+  public func fetch<T>(_ request: NSFetchRequest<T>) throws -> [T] {
     return try fetch(unsafeDowncast(request, to: NSFetchRequest<NSFetchRequestResult>.self)) as! [T]
   }
 
-  public func count<T: NSFetchRequestResult>(for request: NSFetchRequest<T>) throws -> Int {
+  public func count<T>(for request: NSFetchRequest<T>) throws -> Int {
     return try count(for: unsafeDowncast(request, to: NSFetchRequest<NSFetchRequestResult>.self))
   }
 }

--- a/stdlib/public/SDK/Foundation/Measurement.swift
+++ b/stdlib/public/SDK/Foundation/Measurement.swift
@@ -165,7 +165,7 @@ extension Measurement {
     ///
     /// If `lhs.unit == rhs.unit`, returns `lhs.value == rhs.value`. Otherwise, converts `rhs` to the same unit as `lhs` and then compares the resulting values.
     /// - returns: `true` if the measurements are equal.
-    public static func ==<LeftHandSideType : Unit, RightHandSideType : Unit>(_ lhs: Measurement<LeftHandSideType>, _ rhs: Measurement<RightHandSideType>) -> Bool {
+    public static func ==<LeftHandSideType, RightHandSideType>(_ lhs: Measurement<LeftHandSideType>, _ rhs: Measurement<RightHandSideType>) -> Bool {
         if lhs.unit == rhs.unit {
             return lhs.value == rhs.value
         } else {
@@ -183,7 +183,7 @@ extension Measurement {
 
     /// Compare two measurements of the same `Unit`.
     /// - returns: `true` if the measurements can be compared and the `lhs` is less than the `rhs` converted value.
-    public static func <<LeftHandSideType : Unit, RightHandSideType : Unit>(lhs: Measurement<LeftHandSideType>, rhs: Measurement<RightHandSideType>) -> Bool {
+    public static func <<LeftHandSideType, RightHandSideType>(lhs: Measurement<LeftHandSideType>, rhs: Measurement<RightHandSideType>) -> Bool {
         if lhs.unit == rhs.unit {
             return lhs.value < rhs.value
         } else {
@@ -240,7 +240,7 @@ extension NSMeasurement : _HasCustomAnyHashableRepresentation {
 // This workaround is required for the time being, because Swift doesn't support covariance for Measurement (26607639)
 @available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
 extension MeasurementFormatter {
-    public func string<UnitType: Unit>(from measurement: Measurement<UnitType>) -> String {
+    public func string<UnitType>(from measurement: Measurement<UnitType>) -> String {
         if let result = string(for: measurement) {
             return result
         } else {

--- a/stdlib/public/core/ClosedRange.swift
+++ b/stdlib/public/core/ClosedRange.swift
@@ -439,7 +439,7 @@ public struct ClosedRange<
 ///   - minimum: The lower bound for the range.
 ///   - maximum: The upper bound for the range.
 @_transparent
-public func ... <Bound : Comparable>(minimum: Bound, maximum: Bound)
+public func ... <Bound>(minimum: Bound, maximum: Bound)
   -> ClosedRange<Bound> {
   _precondition(
     minimum <= maximum, "Can't form Range with upperBound < lowerBound")
@@ -471,12 +471,7 @@ public func ... <Bound : Comparable>(minimum: Bound, maximum: Bound)
 @_transparent
 public func ... <Bound>(
   minimum: Bound, maximum: Bound
-) -> CountableClosedRange<Bound>
-  where
-  // FIXME(ABI)#176 (Type checker)
-  // WORKAROUND rdar://25214598 - should be just Bound : Strideable
-  Bound : _Strideable & Comparable,
-  Bound.Stride : SignedInteger {
+) -> CountableClosedRange<Bound> {
   // FIXME: swift-3-indexing-model: tests for traps.
   _precondition(
     minimum <= maximum, "Can't form Range with upperBound < lowerBound")

--- a/stdlib/public/core/DropWhile.swift.gyb
+++ b/stdlib/public/core/DropWhile.swift.gyb
@@ -105,14 +105,14 @@ public struct LazyDropWhileIndex<Base : Collection> : Comparable {
   public let base: Base.Index
 }
 
-public func == <Base : Collection>(
+public func == <Base>(
   lhs: LazyDropWhileIndex<Base>,
   rhs: LazyDropWhileIndex<Base>
 ) -> Bool {
   return lhs.base == rhs.base
 }
 
-public func < <Base : Collection>(
+public func < <Base>(
   lhs: LazyDropWhileIndex<Base>,
   rhs: LazyDropWhileIndex<Base>
 ) -> Bool {

--- a/stdlib/public/core/FlatMap.swift
+++ b/stdlib/public/core/FlatMap.swift
@@ -20,7 +20,7 @@ extension LazySequenceProtocol {
   /// `s.map(transform).joined()`.
   ///
   /// - Complexity: O(1)
-  public func flatMap<SegmentOfResult : Sequence>(
+  public func flatMap<SegmentOfResult>(
     _ transform: @escaping (Elements.Iterator.Element) -> SegmentOfResult
   ) -> LazySequence<
     FlattenSequence<LazyMapSequence<Elements, SegmentOfResult>>> {
@@ -58,7 +58,7 @@ extension LazyCollectionProtocol {
   /// `c.map(transform).joined()`.
   ///
   /// - Complexity: O(1)
-  public func flatMap<SegmentOfResult : Collection>(
+  public func flatMap<SegmentOfResult>(
     _ transform: @escaping (Elements.Iterator.Element) -> SegmentOfResult
   ) -> LazyCollection<
     FlattenCollection<
@@ -102,7 +102,7 @@ extension LazyCollectionProtocol
   /// `c.map(transform).joined()`.
   ///
   /// - Complexity: O(1)
-  public func flatMap<SegmentOfResult : BidirectionalCollection>(
+  public func flatMap<SegmentOfResult>(
     _ transform: @escaping (Elements.Iterator.Element) -> SegmentOfResult
   ) -> LazyCollection<
     FlattenBidirectionalCollection<

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -2078,7 +2078,7 @@ public struct Dictionary<Key : Hashable, Value> :
 
 }
 
-extension Dictionary where Key : Equatable, Value : Equatable {
+extension Dictionary where Value : Equatable {
   public static func == (lhs: [Key : Value], rhs: [Key : Value]) -> Bool {
     switch (lhs._variantBuffer, rhs._variantBuffer) {
     case (.native(let lhsNative), .native(let rhsNative)):

--- a/stdlib/public/core/PrefixWhile.swift.gyb
+++ b/stdlib/public/core/PrefixWhile.swift.gyb
@@ -113,7 +113,7 @@ public struct LazyPrefixWhileIndex<Base : Collection> : Comparable {
   }
 }
 
-public func == <Base : Collection>(
+public func == <Base>(
   lhs: LazyPrefixWhileIndex<Base>,
   rhs: LazyPrefixWhileIndex<Base>
 ) -> Bool {
@@ -127,7 +127,7 @@ public func == <Base : Collection>(
   }
 }
 
-public func < <Base : Collection>(
+public func < <Base>(
   lhs: LazyPrefixWhileIndex<Base>,
   rhs: LazyPrefixWhileIndex<Base>
 ) -> Bool {

--- a/stdlib/public/core/Range.swift.gyb
+++ b/stdlib/public/core/Range.swift.gyb
@@ -405,7 +405,7 @@ def get_init_warning(Self, OtherSelf):
 % for (Self, op) in all_range_types:
 %   for (OtherSelf, other_op) in all_range_types:
 extension ${Self}
-%   if 'Countable' in Self or 'Countable' in OtherSelf or 'Closed' in Self or 'Closed' in OtherSelf:
+%   if ('Countable' in OtherSelf or 'Closed' in OtherSelf or 'Closed' in Self) and not 'Countable' in Self:
   where
   Bound : _Strideable, Bound.Stride : SignedInteger
 %   end
@@ -431,7 +431,7 @@ ${get_init_warning(Self, OtherSelf)}
 }
 
 extension ${Self}
-%   if 'Countable' in Self or 'Countable' in OtherSelf:
+%   if 'Countable' in OtherSelf and not 'Countable' in Self:
   where
   Bound : _Strideable, Bound.Stride : SignedInteger
 %   end
@@ -658,7 +658,7 @@ extension ${Self} where Bound : _Strideable, Bound.Stride : SignedInteger {
 ///   - minimum: The lower bound for the range.
 ///   - maximum: The upper bound for the range.
 @_transparent
-public func ..< <Bound : Comparable>(minimum: Bound, maximum: Bound)
+public func ..< <Bound>(minimum: Bound, maximum: Bound)
   -> Range<Bound> {
   _precondition(minimum <= maximum,
     "Can't form Range with upperBound < lowerBound")
@@ -689,11 +689,7 @@ public func ..< <Bound : Comparable>(minimum: Bound, maximum: Bound)
 @_transparent
 public func ..< <Bound>(
   minimum: Bound, maximum: Bound
-) -> CountableRange<Bound>
-  where
-  // WORKAROUND rdar://25214598 - should be just Bound : Strideable
-  Bound : _Strideable & Comparable,
-  Bound.Stride : Integer {
+) -> CountableRange<Bound> {
 
   // FIXME: swift-3-indexing-model: tests for traps.
   _precondition(minimum <= maximum,

--- a/stdlib/public/core/SequenceWrapper.swift
+++ b/stdlib/public/core/SequenceWrapper.swift
@@ -20,7 +20,7 @@
 public // @testable
 protocol _SequenceWrapper : Sequence {
   associatedtype Base : Sequence
-  associatedtype Iterator : IteratorProtocol = Base.Iterator
+  associatedtype Iterator = Base.Iterator
   associatedtype SubSequence = Base.SubSequence
   
   var _base: Base { get }

--- a/stdlib/public/core/Stride.swift.gyb
+++ b/stdlib/public/core/Stride.swift.gyb
@@ -277,7 +277,7 @@ public struct StrideTo<Element : Strideable> : Sequence, CustomReflectable {
 /// 2 * stride`, ... *last*) where *last* is the last value in the
 /// progression that is less than `end`.
 @_inlineable
-public func stride<T : Strideable>(
+public func stride<T>(
   from start: T, to end: T, by stride: T.Stride
 ) -> StrideTo<T> {
   return StrideTo(_start: start, end: end, stride: stride)
@@ -375,7 +375,7 @@ public struct StrideThrough<
 ///
 /// - Note: There is no guarantee that `end` is an element of the sequence.
 @_inlineable
-public func stride<T : Strideable>(
+public func stride<T>(
   from start: T, through end: T, by stride: T.Stride
 ) -> StrideThrough<T> {
   return StrideThrough(_start: start, end: end, stride: stride)

--- a/stdlib/public/core/Zip.swift
+++ b/stdlib/public/core/Zip.swift
@@ -41,7 +41,7 @@
 ///   - sequence2: The second sequence or collection to zip.
 /// - Returns: A sequence of tuple pairs, where the elements of each pair are
 ///   corresponding elements of `sequence1` and `sequence2`.
-public func zip<Sequence1 : Sequence, Sequence2 : Sequence>(
+public func zip<Sequence1, Sequence2>(
   _ sequence1: Sequence1, _ sequence2: Sequence2
 ) -> Zip2Sequence<Sequence1, Sequence2> {
   return Zip2Sequence(_sequence1: sequence1, _sequence2: sequence2)

--- a/test/ClangImporter/cf.swift
+++ b/test/ClangImporter/cf.swift
@@ -5,7 +5,7 @@
 import CoreCooling
 import CFAndObjC
 
-func assertUnmanaged<T: AnyObject>(_ t: Unmanaged<T>) {}
+func assertUnmanaged<T>(_ t: Unmanaged<T>) {}
 func assertManaged<T: AnyObject>(_ t: T) {}
 
 func test0(_ fridge: CCRefrigerator) {

--- a/test/Constraints/bridging.swift
+++ b/test/Constraints/bridging.swift
@@ -214,8 +214,8 @@ func rdar19551164b(_ s: NSString, _ a: NSArray) {
 }
 
 // rdar://problem/19695671
-func takesSet<T: Hashable>(_ p: Set<T>) {}  // expected-note {{in call to function 'takesSet'}}
-func takesDictionary<K: Hashable, V>(_ p: Dictionary<K, V>) {} // expected-note {{in call to function 'takesDictionary'}}
+func takesSet<T>(_ p: Set<T>) {}  // expected-note {{in call to function 'takesSet'}}
+func takesDictionary<K, V>(_ p: Dictionary<K, V>) {} // expected-note {{in call to function 'takesDictionary'}}
 func takesArray<T>(_ t: Array<T>) {} // expected-note {{in call to function 'takesArray'}}
 func rdar19695671() {
   takesSet(NSSet() as! Set) // expected-error{{generic parameter 'T' could not be inferred}}

--- a/test/DebugInfo/generic_args.swift
+++ b/test/DebugInfo/generic_args.swift
@@ -28,7 +28,7 @@ aFunction(AClass(),AnotherClass(),"aFunction")
 
 struct Wrapper<T: AProtocol> {
 
-  init<U: AProtocol>(from : Wrapper<U>) {
+  init<U>(from : Wrapper<U>) {
   // CHECK-DAG: !DICompositeType(tag: DW_TAG_structure_type, name: "Wrapper",{{.*}} identifier: "_T012generic_args7WrapperVyA2CyxGACyqd__G4from_tcAA9AProtocolRd__lufcQq_GD")
     var wrapped = from
     wrapped = from

--- a/test/Generics/deduction.swift
+++ b/test/Generics/deduction.swift
@@ -292,7 +292,7 @@ protocol Bool_ {}
 struct False : Bool_ {}
 struct True : Bool_ {}
 
-postfix func <*> <B:Bool_>(_: Test<B>) -> Int? { return .none }
+postfix func <*> <B>(_: Test<B>) -> Int? { return .none }
 postfix func <*> (_: Test<True>) -> String? { return .none }
 
 class Test<C: Bool_> : MetaFunction {

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -76,7 +76,10 @@ struct V<T : Canidae> {}
 // CHECK-LABEL: .inferSuperclassRequirement1@
 // CHECK-NEXT: Requirements:
 // CHECK-NEXT:   τ_0_0 : Canidae
-func inferSuperclassRequirement1<T : Carnivora>(_ v: V<T>) {}
+func inferSuperclassRequirement1<T : Carnivora>(
+	_ v: V<T>) {}
+// expected-warning@-2{{redundant superclass constraint 'T' : 'Carnivora'}}
+// expected-note@-2{{superclass constraint 'T' : 'Canidae' inferred from type here}}
 
 // CHECK-LABEL: .inferSuperclassRequirement2@
 // CHECK-NEXT: Requirements:

--- a/test/Generics/same_type_constraints.swift
+++ b/test/Generics/same_type_constraints.swift
@@ -123,7 +123,7 @@ struct Composed<Left: Bindable, Right: Observable> where Left.Input == Right.Out
 infix operator <- : AssignmentPrecedence
 
 func <- <
-    Right : Observable
+    Right
     >(lhs: @escaping (Right.Output) -> Void, rhs: Right) -> Composed<SideEffect<Right>, Right>?
 {
   return nil
@@ -360,3 +360,8 @@ func intercomponentMoreThanSpanningTree<T: P10>(_: T)
         { }
 
 func trivialRedundancy<T: P10>(_: T) where T.A == T.A { } // expected-warning{{redundant same-type constraint 'T.A' == 'T.A'}}
+
+struct X11<T: P10> where T.A == T.B { }
+
+func intracomponentInferred<T>(_: X11<T>) // expected-note{{previous same-type constraint 'T.A' == 'T.B' inferred from type here}}
+  where T.A == T.B { } // expected-warning{{redundant same-type constraint 'T.A' == 'T.B'}}

--- a/test/Inputs/clang-importer-sdk/swift-modules/Foundation.swift
+++ b/test/Inputs/clang-importer-sdk/swift-modules/Foundation.swift
@@ -37,11 +37,11 @@ internal func _convertNSDictionaryToDictionary<K: NSObject, V: AnyObject>(
 }
 
 // NSSet bridging entry points
-internal func _convertSetToNSSet<T : Hashable>(_ s: Set<T>) -> NSSet {
+internal func _convertSetToNSSet<T>(_ s: Set<T>) -> NSSet {
   return NSSet()
 }
 
-internal func _convertNSSetToSet<T : Hashable>(_ s: NSSet?) -> Set<T> {
+internal func _convertNSSetToSet<T>(_ s: NSSet?) -> Set<T> {
   return Set<T>()
 }
 

--- a/test/SILGen/objc_bridged_generic_nonnull.swift
+++ b/test/SILGen/objc_bridged_generic_nonnull.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -emit-silgen -verify -import-objc-header %S/Inputs/objc_bridged_generic_nonnull.h %s
 // REQUIRES: objc_interop
 
-public func test<T: AnyObject>(_ x: NonnullMembers<T>) -> T? {
+public func test<T>(_ x: NonnullMembers<T>) -> T? {
   var z: T?
   z = x.method()
   z = x.property

--- a/test/decl/nested/type_in_type.swift
+++ b/test/decl/nested/type_in_type.swift
@@ -137,7 +137,7 @@ struct AnyStream<T : Sequence> {
   }
 }
 
-func enumerate<T : Sequence>(_ arg: T) -> AnyStream<T> {
+func enumerate<T>(_ arg: T) -> AnyStream<T> {
   return AnyStream<T>(input: arg)
 }
 


### PR DESCRIPTION
Extend the diagnosis of redundant constraints to also include explicitly-specified constraints made redundant by inferred constraints. The canonical example is something like:

     func f<T: Hashable>(_: Set<T>)

where the parameter of type `Set<T>` implies `T: Hashable`. With this PR, we start warning about the explicit `T: Hashable` constraint being redundant.
