### PR TITLE
Resolve an issue with indirect enum's match for opaque values

### DIFF
--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -814,7 +814,7 @@ emitEnumMatch(ManagedValue value, EnumElementDecl *ElementDecl,
     SILValue boxedValue = SGF.B.createProjectBox(loc, eltMV.getValue(), 0);
     auto &boxedTL = SGF.getTypeLowering(boxedValue->getType());
     // SEMANTIC ARC TODO: Revisit this when the verifier is enabled.
-    if (boxedTL.isLoadable())
+    if (boxedTL.isLoadable() || !SGF.silConv.useLoweredAddresses())
       boxedValue = boxedTL.emitLoad(SGF.B, loc, boxedValue,
                                     LoadOwnershipQualifier::Take);
 


### PR DESCRIPTION
Small part of radar rdar://problem/30080769

This PR adds support for guards and indirect enums for opaque values