### PR TITLE
[Constraint solver] Exit immediately from solve() if we already have …

### DIFF
--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -462,6 +462,8 @@ ConstraintSystem::SolverScope::SolverScope(ConstraintSystem &cs)
   PreviousScore = cs.CurrentScore;
 
   cs.solverState->registerScope(this);
+  assert(!cs.failedConstraint && "Unexpected failed constraint!");
+
   ++cs.solverState->NumStatesExplored;
 }
 
@@ -1986,7 +1988,7 @@ bool ConstraintSystem::solve(SmallVectorImpl<Solution> &solutions,
   // Simplify any constraints left active after constraint generation
   // and optimization. Return if the resulting system has no
   // solutions.
-  if (simplify())
+  if (failedConstraint || simplify())
     return true;
 
   // If the experimental constraint propagation pass is enabled, run it.


### PR DESCRIPTION
…a failed constraint.

As solveRec() already does, exit immediately if we have a failed
constraint from constraint generation. Not doing so means that we can
create a SolverScope in constraint propagation, and on destruction of
that SolverScope we clear out the failedConstraint field, obscuring the
fact that we had a failure.
