### PR TITLE
Add -pch-output-directory driver flag and ClangImporter option

### DIFF
--- a/include/swift/ClangImporter/ClangImporterOptions.h
+++ b/include/swift/ClangImporter/ClangImporterOptions.h
@@ -35,8 +35,12 @@ public:
   /// Equivalent to Clang's -mcpu=.
   std::string TargetCPU;
 
-  // The bridging header or PCH that will be imported.
+  /// The bridging header or PCH that will be imported.
   std::string BridgingHeader;
+
+  /// When automatically generating a precompiled header from the bridging
+  /// header, place it in this directory.
+  std::string PrecompiledHeaderOutputDir;
 
   /// \see Mode
   enum class Modes {

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -160,6 +160,10 @@ def import_objc_header : Separate<["-"], "import-objc-header">,
   Flags<[FrontendOption, HelpHidden]>,
   HelpText<"Implicitly imports an Objective-C header file">;
 
+def pch_output_dir: Separate<["-"], "pch-output-dir">,
+  Flags<[FrontendOption, HelpHidden]>,
+  HelpText<"Directory to persist automatically created precompiled bridging headers">;
+
 // FIXME: Unhide this once it doesn't depend on an output file map.
 def incremental : Flag<["-"], "incremental">,
   Flags<[NoInteractiveOption, HelpHidden, DoesNotAffectIncrementalBuild]>,

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1003,6 +1003,10 @@ static bool ParseClangImporterArgs(ClangImporterOptions &Opts,
 
   Opts.DisableModulesValidateSystemHeaders |= Args.hasArg(OPT_disable_modules_validate_system_headers);
 
+  if (const Arg *A = Args.getLastArg(OPT_pch_output_dir)) {
+    Opts.PrecompiledHeaderOutputDir = A->getValue();
+  }
+
   return false;
 }
 


### PR DESCRIPTION
This will control the output path of a precompiled header (PCH) file
generated from the bridging header.

rdar://problem/31198711