### PR TITLE
[WIP] SR-827 - Improve #selector fixit to omit class name when on self

### DIFF
--- a/test/expr/unary/selector/fixits.swift
+++ b/test/expr/unary/selector/fixits.swift
@@ -49,6 +49,8 @@ class Bar : Foo {
 }
 
 class Foo {
+  @objc init(value: String) {}
+
   @objc(methodWithValue:label:) func method(_ value: Int, label: String) { }
 
   @objc(method2WithValue:) func method2(_ value: Int) { }
@@ -108,4 +110,18 @@ func testSelectorConstruction() {
 
   // Note: from Foundation
   _ = Selector("initWithArray:") // expected-warning{{use '#selector' instead of explicitly constructing a 'Selector'}}{{7-33=#selector(NSSet.init(array:))}}
+}
+
+extension Bar {
+  func testDeprecatedStringLiteralSelector() {
+    // method and properties fixit omits type when in scope
+    _ = "methodWithValue:label:" as Selector // expected-warning{{use of string literal for Objective-C selectors is deprecated; use '#selector' instead}}{{9-45=#selector(method(_:label:))}}
+    _ = "property" as Selector // expected-warning{{use of string literal for Objective-C selectors is deprecated; use '#selector' instead}}{{9-31=#selector(getter: property)}}
+    _ = "setProperty:" as Selector // expected-warning{{use of string literal for Objective-C selectors is deprecated; use '#selector' instead}}{{9-35=#selector(setter: property)}}
+
+    // init and static fixit don't omit type when in scope
+    _ = "initWithValue:" as Selector // expected-warning{{use of string literal for Objective-C selectors is deprecated; use '#selector' instead}}{{9-37=#selector(Foo.init(value:))}}
+    _ = "staticOrNonStatic:" as Selector // expected-warning{{use of string literal for Objective-C selectors is deprecated; use '#selector' instead}}{{9-41=#selector(staticOrNonStatic(_:))}}
+    _ = "theInstanceOne:" as Selector // expected-warning{{use of string literal for Objective-C selectors is deprecated; use '#selector' instead}}{{9-38=#selector(staticOrNonStatic2(_:) as (Int) -> ())}}
+  }
 }


### PR DESCRIPTION
Resolves [SR-827](https://bugs.swift.org/browse/SR-827).

This is close to working, but:

* the `classIsSubclass` method is the only way I found to test for subclassing ancestry. I get the impression there's a better way I've missed.
* the new tests I wrote in `test/expr/unary/selector/fixits.swift` are now crashing the compiler with a mysterious `l-value expression does not have l-value access kind set` assert somewhere else completely - looks unrelated:

```
1  swiftc                   0x0000000108d454c9 PrintStackTraceSignalHandler(void*) + 25
2  swiftc                   0x0000000108d411a9 llvm::sys::RunSignalHandlers() + 425
3  swiftc                   0x0000000108d45962 SignalHandler(int) + 354
4  libsystem_platform.dylib 0x00007fffcb0c4bba _sigtramp + 26
5  libsystem_platform.dylib 000000000000000000 _sigtramp + 888386656
6  libsystem_c.dylib        0x00007fffcaf4b420 abort + 129
7  swiftc                   0x0000000104299b87 (anonymous namespace)::Verifier::verifyChecked(swift::Expr*) + 295
8  swiftc                   0x000000010429c960 void (anonymous namespace)::Verifier::verifyCheckedBase<swift::MemberRefExpr*>(swift::MemberRefExpr*) + 48
9  swiftc                   0x000000010429c897 (anonymous namespace)::Verifier::verifyChecked(swift::MemberRefExpr*) + 535
10 swiftc                   0x000000010429432c swift::MemberRefExpr* (anonymous namespace)::Verifier::dispatchVisitPost<swift::MemberRefExpr*>(swift::MemberRefExpr*) + 268
11 swiftc                   0x0000000104284d07 (anonymous namespace)::Verifier::walkToExprPost(swift::Expr*) + 791
12 swiftc                   0x00000001042bd9f6 (anonymous namespace)::Traversal::doIt(swift::Expr*) + 134
13 swiftc                   0x00000001042c0fb0 (anonymous namespace)::Traversal::visitObjCSelectorExpr(swift::ObjCSelectorExpr*) + 48
14 swiftc                   0x00000001042bead3 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) + 2499
15 swiftc                   0x00000001042be0c6 (anonymous namespace)::Traversal::visit(swift::Expr*) + 70
16 swiftc                   0x00000001042bd9d0 (anonymous namespace)::Traversal::doIt(swift::Expr*) + 96
17 swiftc                   0x00000001042c77a8 (anonymous namespace)::Traversal::visitPatternBindingDecl(swift::PatternBindingDecl*) + 328
18 swiftc                   0x00000001042c7115 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Decl*) + 149
19 swiftc                   0x00000001042c6f96 (anonymous namespace)::Traversal::visit(swift::Decl*) + 70
20 swiftc                   0x00000001042bdfaa (anonymous namespace)::Traversal::doIt(swift::Decl*) + 122
21 swiftc                   0x00000001042c3314 (anonymous namespace)::Traversal::visitBraceStmt(swift::BraceStmt*) + 356
22 swiftc                   0x00000001042c2eab swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Stmt*) + 91
23 swiftc                   0x00000001042c2e06 (anonymous namespace)::Traversal::visit(swift::Stmt*) + 70
24 swiftc                   0x00000001042bdac1 (anonymous namespace)::Traversal::doIt(swift::Stmt*) + 97
25 swiftc                   0x00000001042c8855 (anonymous namespace)::Traversal::visitAbstractFunctionDecl(swift::AbstractFunctionDecl*) + 1109
26 swiftc                   0x00000001042c7d58 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visitFuncDecl(swift::FuncDecl*) + 40
27 swiftc                   0x00000001042c7376 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Decl*) + 758
28 swiftc                   0x00000001042c6f96 (anonymous namespace)::Traversal::visit(swift::Decl*) + 70
29 swiftc                   0x00000001042bdfaa (anonymous namespace)::Traversal::doIt(swift::Decl*) + 122
30 swiftc                   0x00000001042c7611 (anonymous namespace)::Traversal::visitExtensionDecl(swift::ExtensionDecl*) + 337
31 swiftc                   0x00000001042c70f8 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Decl*) + 120
32 swiftc                   0x00000001042c6f96 (anonymous namespace)::Traversal::visit(swift::Decl*) + 70
33 swiftc                   0x00000001042bdfaa (anonymous namespace)::Traversal::doIt(swift::Decl*) + 122
34 swiftc                   0x00000001042bdf20 swift::Decl::walk(swift::ASTWalker&) + 64
35 swiftc                   0x000000010447ff7d swift::SourceFile::walk(swift::ASTWalker&) + 525
36 swiftc                   0x00000001042831e6 swift::verify(swift::SourceFile&) + 150
37 swiftc                   0x0000000104138c71 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 2145
38 swiftc                   0x0000000103666267 swift::CompilerInstance::performSema() + 13751
39 swiftc                   0x0000000101f7045e performCompile(std::__1::unique_ptr<swift::CompilerInstance, std::__1::default_delete<swift::CompilerInstance> >&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*) + 4942
40 swiftc                   0x0000000101f6e3df swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 13279
41 swiftc                   0x0000000101ea45d9 main + 4809
42 libdyld.dylib            0x00007fffcaeb7255 start + 1
43 libdyld.dylib            0x0000000000000013 start + 890539455
```

I'd appreciate some help if someone can afford the time :)