### PR TITLE
TSan: Enable treating inout accesses as Thread Sanitizer writes by de…

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -164,7 +164,7 @@ namespace swift {
 
     /// \brief Staging flag for treating inout parameters as Thread Sanitizer
     /// accesses.
-    bool EnableTSANInoutInstrumentation = false;
+    bool DisableTsanInoutInstrumentation = false;
 
     /// \brief Staging flag for class resilience, which we do not want to enable
     /// fully until more code is in place, to allow the standard library to be

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -267,9 +267,9 @@ def disable_availability_checking : Flag<["-"],
   "disable-availability-checking">,
   HelpText<"Disable checking for potentially unavailable APIs">;
 
-def enable_experimental_tsan_inout_instrumentation : Flag<["-"],
-  "enable-experimental-tsan-inout-instrumentation">,
-  HelpText<"Enable treatment of inout parameters as Thread Sanitizer accesses">;
+def disable_tsan_inout_instrumentation : Flag<["-"],
+  "disable-tsan-inout-instrumentation">,
+  HelpText<"Disable treatment of inout parameters as Thread Sanitizer accesses">;
 
 def enable_infer_import_as_member :
   Flag<["-"], "enable-infer-import-as-member">,

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -860,8 +860,8 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.DisableAvailabilityChecking |=
       Args.hasArg(OPT_disable_availability_checking);
 
-  Opts.EnableTSANInoutInstrumentation |=
-      Args.hasArg(OPT_enable_experimental_tsan_inout_instrumentation);
+  Opts.DisableTsanInoutInstrumentation |=
+      Args.hasArg(OPT_disable_tsan_inout_instrumentation);
 
   if (FrontendOpts.InputKind == InputFileKind::IFK_SIL)
     Opts.DisableAvailabilityChecking = true;

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -2428,7 +2428,8 @@ static ManagedValue drillIntoComponent(SILGenFunction &SGF,
     addr = std::move(lcomponent).getMaterialized(SGF, loc, base, accessKind);
   }
 
-  if (SGF.getASTContext().LangOpts.EnableTSANInoutInstrumentation &&
+  if (!SGF.getASTContext().LangOpts.DisableTsanInoutInstrumentation &&
+      SGF.getModule().getOptions().Sanitize == SanitizerKind::Thread &&
       tsanKind == TSanKind::InoutAccess && !component.isRValue()) {
     emitTsanInoutAccess(SGF, loc, addr);
   }

--- a/test/SILGen/tsan_instrumentation.swift
+++ b/test/SILGen/tsan_instrumentation.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -sanitize=thread -enable-experimental-tsan-inout-instrumentation -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -sanitize=thread -emit-silgen %s | %FileCheck %s
 // REQUIRES: tsan_runtime
 // XFAIL: linux
 

--- a/test/Sanitizers/tsan-inout.swift
+++ b/test/Sanitizers/tsan-inout.swift
@@ -1,6 +1,6 @@
 // RUN: %target-build-swift %S/Inputs/tsan-uninstrumented.swift -module-name TSanUninstrumented -emit-module -emit-module-path %T/TSanUninstrumented.swiftmodule -parse-as-library
 // RUN: %target-build-swift %S/Inputs/tsan-uninstrumented.swift -c -module-name TSanUninstrumented -parse-as-library -o %T/TSanUninstrumented.o
-// RUN: %target-swiftc_driver -Xfrontend -enable-experimental-tsan-inout-instrumentation %s %T/TSanUninstrumented.o -I%T -L%T -g -sanitize=thread -o %t_tsan-binary
+// RUN: %target-swiftc_driver %s %T/TSanUninstrumented.o -I%T -L%T -g -sanitize=thread -o %t_tsan-binary
 // RUN: not env TSAN_OPTIONS=abort_on_error=0 %target-run %t_tsan-binary 2>&1 | %FileCheck %s
 // RUN: not env TSAN_OPTIONS=abort_on_error=0:ignore_interceptors_accesses=0 %target-run %t_tsan-binary 2>&1 | %FileCheck %s --check-prefix CHECK-INTERCEPTORS-ACCESSES
 // REQUIRES: executable_test


### PR DESCRIPTION
…fault

Flip the polarity of the frontend flag controlling whether TSan treats inout
accesses as conceptual writes. It is now on by default. This lets TSan detect
racing mutating methods even when those methods are not themselves instrumented
(such as methods on Standard Library collections).

This behavior can be disabled by passing:

  -Xfrontend -disable-tsan-inout-instrumentation

when compiling under TSan.

rdar://problem/31069963