### PR TITLE
Optional cast of opaque values

### DIFF
--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3358,7 +3358,7 @@ RValue RValueEmitter::visitOptionalEvaluationExpr(OptionalEvaluationExpr *E,
   RestoreOptionalFailureDest restoreFailureDest(SGF,
                     JumpDest(failureBB, SGF.Cleanups.getCleanupsDepth(), E));
 
-  SILValue NormalArgument;
+  SILValue NormalArgument = nullptr;
   if (emitOptimizedOptionalEvaluation(E, NormalArgument, optInit, *this)) {
     // Already emitted code for this.
   } else if (isByAddress) {
@@ -3384,7 +3384,7 @@ RValue RValueEmitter::visitOptionalEvaluationExpr(OptionalEvaluationExpr *E,
     failureBB->eraseFromParent();
     
     // The value we provide is the one we've already got.
-    if (!isByAddress)
+    if (!isByAddress && NormalArgument)
       return RValue(SGF, E,
                     SGF.emitManagedRValueWithCleanup(NormalArgument, optTL));
 

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3334,8 +3334,9 @@ RValue RValueEmitter::visitOptionalEvaluationExpr(OptionalEvaluationExpr *E,
 
   // Form the optional using address operations if the type is address-only or
   // if we already have an address to use.
-  bool isByAddress = usingProvidedContext || optTL.isAddressOnly();
-  
+  bool isByAddress = ((usingProvidedContext || optTL.isAddressOnly()) &&
+                      SGF.silConv.useLoweredAddresses());
+
   std::unique_ptr<TemporaryInitialization> optTemp;
   if (!usingProvidedContext && isByAddress) {
     // Allocate the temporary for the Optional<T> if we didn't get one from the

--- a/test/SILGen/opaque_values_silgen.swift
+++ b/test/SILGen/opaque_values_silgen.swift
@@ -710,7 +710,7 @@ func s360________guardEnum<T>(_ e: IndirectEnum<T>) {
   }
 }
 
-// Tests casting optional opaques to optional opaques
+// Tests contextual init() of opaque value types
 // ---
 // CHECK-LABEL: sil hidden @_T020opaque_values_silgen21s370_____optToOptCastxSgSQyxGlF : $@convention(thin) <T> (@in Optional<T>) -> @out Optional<T> {
 // CHECK: bb0([[ARG:%.*]] : $Optional<T>):
@@ -722,6 +722,20 @@ func s360________guardEnum<T>(_ e: IndirectEnum<T>) {
 // CHECK-LABEL: } // end sil function '_T020opaque_values_silgen21s370_____optToOptCastxSgSQyxGlF'
 func s370_____optToOptCast<T>(_ x : T!) -> T? {
   return x
+}
+
+// Tests casting optional opaques to optional opaques
+// ---
+// CHECK-LABEL: sil hidden @_T020opaque_values_silgen21s380___contextualInitySiSgF : $@convention(thin) (Optional<Int>) -> () {
+// CHECK: bb0([[ARG:%.*]] : $Optional<Int>):
+// CHECK:   [[ALLOC_OF_BOX:%.*]] = alloc_box ${ var Optional<Int> }, var
+// CHECK:   [[PROJ_BOX:%.*]] = project_box [[ALLOC_OF_BOX]]
+// CHECK:   store [[ARG]] to [trivial] [[PROJ_BOX]] : $*Optional<Int>
+// CHECK:   destroy_value [[ALLOC_OF_BOX]]
+// CHECK:   return %{{.*}} : $()
+// CHECK-LABEL: } // end sil function '_T020opaque_values_silgen21s380___contextualInitySiSgF'
+func s380___contextualInit(_ a : Int?) {
+  var x: Int! = a
 }
 
 // Tests conditional value casts and correspondingly generated reabstraction thunk, with <T> types

--- a/test/SILGen/opaque_values_silgen.swift
+++ b/test/SILGen/opaque_values_silgen.swift
@@ -710,6 +710,20 @@ func s360________guardEnum<T>(_ e: IndirectEnum<T>) {
   }
 }
 
+// Tests casting optional opaques to optional opaques
+// ---
+// CHECK-LABEL: sil hidden @_T020opaque_values_silgen21s370_____optToOptCastxSgSQyxGlF : $@convention(thin) <T> (@in Optional<T>) -> @out Optional<T> {
+// CHECK: bb0([[ARG:%.*]] : $Optional<T>):
+// CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+// CHECK:   [[COPY__ARG:%.*]] = copy_value [[BORROWED_ARG]]
+// CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]] : $Optional<T>, $Optional<T>
+// CHECK:   destroy_value [[ARG]]
+// CHECK:   return [[COPY__ARG]] : $Optional<T>
+// CHECK-LABEL: } // end sil function '_T020opaque_values_silgen21s370_____optToOptCastxSgSQyxGlF'
+func s370_____optToOptCast<T>(_ x : T!) -> T? {
+  return x
+}
+
 // Tests conditional value casts and correspondingly generated reabstraction thunk, with <T> types
 // ---
 // CHECK-LABEL: sil hidden @_T020opaque_values_silgen21s999_____condTFromAnyyyp_xtlF : $@convention(thin) <T> (@in Any, @in T) -> () {


### PR DESCRIPTION
Small part of radar rdar://problem/30080769

This PR adds support for optional casts under opaque values mode - supporting cast of optional to optional + contextual init of opaque optional types