### PR TITLE
Cleanup recent line-directive and gyb test fixes

### DIFF
--- a/utils/gyb.py
+++ b/utils/gyb.py
@@ -1035,7 +1035,9 @@ def execute_template(
 
     Keyword arguments become local variable bindings in the execution context
 
-    >>> ast = parse_template('/dummy.file', text=
+    >>> root_directory = os.path.abspath('/')
+    >>> file_name = root_directory + 'dummy.file'
+    >>> ast = parse_template(file_name, text=
     ... '''Nothing
     ... % if x:
     ... %    for i in range(3):
@@ -1045,7 +1047,7 @@ def execute_template(
     ... THIS SHOULD NOT APPEAR IN THE OUTPUT
     ... ''')
     >>> out = execute_template(ast, line_directive='//#sourceLocation', x=1)
-    >>> out = out.replace(os.path.abspath(os.sep) + 'dummy.file', "DUMMY-FILE")
+    >>> out = out.replace(file_name, "DUMMY-FILE")
     >>> print(out, end="")
     //#sourceLocation(file: "DUMMY-FILE", line: 1)
     Nothing
@@ -1056,7 +1058,7 @@ def execute_template(
     //#sourceLocation(file: "DUMMY-FILE", line: 4)
     2
 
-    >>> ast = parse_template('/dummy.file', text=
+    >>> ast = parse_template(file_name, text=
     ... '''Nothing
     ... % a = []
     ... % for x in range(3):
@@ -1065,7 +1067,7 @@ def execute_template(
     ... ${a}
     ... ''')
     >>> out = execute_template(ast, line_directive='//#sourceLocation', x=1)
-    >>> out = out.replace(os.path.abspath(os.sep) + 'dummy.file', "DUMMY-FILE")
+    >>> out = out.replace(file_name, "DUMMY-FILE")
     >>> print(out, end="")
     //#sourceLocation(file: "DUMMY-FILE", line: 1)
     Nothing

--- a/utils/line-directive
+++ b/utils/line-directive
@@ -65,6 +65,10 @@ def fline_map(target_filename):
 def map_line_to_source_file(target_filename, target_line_num):
     """
     >>> from tempfile import *
+    >>> # On Windows, the name of a NamedTemporaryFile cannot be used to open
+    >>> # the file for a second time if delete=True. Therefore, we have to
+    >>> # manually handle closing and deleting this file to allow us to open
+    >>> # the file by its name across all platforms.
     >>> t = NamedTemporaryFile(delete=False)
     >>> t.write('''line 1
     ... line 2
@@ -111,6 +115,10 @@ def map_line_from_source_file(source_filename, source_line_num,
                               target_filename):
     """
     >>> from tempfile import *
+    >>> # On Windows, the name of a NamedTemporaryFile cannot be used to open
+    >>> # the file for a second time if delete=True. Therefore, we have to
+    >>> # manually handle closing and deleting this file to allow us to open
+    >>> # the file by its name across all platforms.
     >>> t = NamedTemporaryFile(delete=False)
     >>> t.write('''line 1
     ... line 2
@@ -189,6 +197,10 @@ def run():
     """Simulate a couple of gyb-generated files
 
     >>> from tempfile import *
+    >>> # On Windows, the name of a NamedTemporaryFile cannot be used to open
+    >>> # the file for a second time if delete=True. Therefore, we have to
+    >>> # manually handle closing and deleting this file to allow us to open
+    >>> # the file by its name across all platforms.
     >>> target1 = NamedTemporaryFile(delete=False)
     >>> target1.write('''line 1
     ... line 2
@@ -200,6 +212,10 @@ def run():
     ... line 8
     ... ''')
     >>> target1.flush()
+    >>> # On Windows, the name of a NamedTemporaryFile cannot be used to open
+    >>> # the file for a second time if delete=True. Therefore, we have to
+    >>> # manually handle closing and deleting this file to allow us to open
+    >>> # the file by its name across all platforms.
     >>> target2 = NamedTemporaryFile(delete=False)
     >>> target2.write('''// ###sourceLocation(file: "foo.bar", line: 7)
     ... line 2
@@ -212,6 +228,10 @@ def run():
 
     Simulate the raw output of compilation
 
+    >>> # On Windows, the name of a NamedTemporaryFile cannot be used to open
+    >>> # the file for a second time if delete=True. Therefore, we have to
+    >>> # manually handle closing and deleting this file to allow us to open
+    >>> # the file by its name across all platforms.
     >>> raw_output = NamedTemporaryFile(delete=False)
     >>> target1_name, target2_name = target1.name, target2.name
     >>> raw_output.write('''A
@@ -239,13 +259,12 @@ def run():
     ...    __file__, target1.name, target2.name, '--',
     ...    sys.executable, '-c',
     ...   'import sys;sys.stdout.write(open(sys.argv[1]).read())',
-    ...   raw_output.name])
+    ...   raw_output.name], universal_newlines=True)
 
     Replace temporary filenames and check it.
 
     >>> print(output.replace(target1.name,'TARGET1-NAME')
-    ...             .replace(target2.name,'TARGET2-NAME')
-    ...             .replace('\\r', '') + 'EOF')
+    ...             .replace(target2.name,'TARGET2-NAME') + 'EOF')
     A
     TARGET1-NAME:2:111: error one
     B
@@ -262,13 +281,19 @@ def run():
     glitch in [fox.box:28 assert six
     EOF
     >>> print(subprocess.check_output([sys.executable, __file__, 'foo.bar',
-    ...                                '21', target1.name]).rstrip())
+    ...                                '21', target1.name],
+    ...                               universal_newlines=True), end='')
     5
     >>> print(subprocess.check_output([sys.executable, __file__, 'foo.bar',
-    ...                                '8', target2.name]).rstrip())
+    ...                                '8', target2.name],
+    ...                               universal_newlines=True), end='')
     3
 
     Simulate errors on different line numbers
+    >>> # On Windows, the name of a NamedTemporaryFile cannot be used to open
+    >>> # the file for a second time if delete=True. Therefore, we have to
+    >>> # manually handle closing and deleting this file to allow us to open
+    >>> # the file by its name across all platforms.
     >>> long_output = NamedTemporaryFile(delete=False)
     >>> long_output.write('''
     ... // ###sourceLocation(file: "/public/core/Map.swift.gyb", line: 1)


### PR DESCRIPTION
- Add comments describing odd Windows behaviour
- Use universal newlines instead of stripping `\r`
- Clear up opaque use of `os.path.abspath(os.sep)`