### PR TITLE
[Type checker] The superclass of a superclass constraint can have type parameters

### DIFF
--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -631,17 +631,16 @@ static void checkReferencedGenericParams(GenericContext *dc,
 
   auto requirements = sig->getRequirements();
   for (auto req : requirements) {
-    if (req.getKind() == RequirementKind::SameType) {
-      // Same type requirements may allow for generic
-      // inference, even if this generic parameter
-      // is not mentioned in the function signature.
-      // TODO: Make the test more precise.
-      auto left = req.getFirstType();
-      auto right = req.getSecondType();
-      // For now consider any references inside requirements
-      // as a possibility to infer the generic type.
-      left.visit(visitorFn);
-      right.visit(visitorFn);
+    switch (req.getKind()) {
+      case RequirementKind::SameType:
+      case RequirementKind::Superclass:
+        req.getSecondType().visit(visitorFn);
+        LLVM_FALLTHROUGH;
+
+      case RequirementKind::Conformance:
+      case RequirementKind::Layout:
+        req.getFirstType().visit(visitorFn);
+        break;
     }
   }
 

--- a/test/Generics/unbound.swift
+++ b/test/Generics/unbound.swift
@@ -67,3 +67,8 @@ func callfoor20792596<T>(x: T) -> T {
   return foor20792596(x) // expected-error {{generic parameter 'T' could not be inferred}}
 }
 
+// <rdar://problem/31181895> parameter "not used in function signature" when part of a superclass constraint
+struct X1<T> {
+  func bar<U>() where T: X2<U> {}
+}
+class X2<T> {}


### PR DESCRIPTION
Fixes <rdar://problem/31181895>.
