### PR TITLE
[silgen] Add helper methods to compute ArgumentSource::getSubst{RValue,}Type() as SILTypes.

### DIFF
--- a/lib/SILGen/ArgumentSource.cpp
+++ b/lib/SILGen/ArgumentSource.cpp
@@ -217,3 +217,17 @@ void ArgumentSource::forwardInto(SILGenFunction &SGF,
   auto substLoweredType = destTL.getLoweredType().getSwiftRValueType();
   RValue(SGF, loc, substLoweredType, outputValue).forwardInto(SGF, loc, dest);
 }
+
+SILType ArgumentSource::getSILSubstRValueType(SILGenFunction &SGF) const & {
+  CanSILFunctionType funcType = SGF.F.getLoweredFunctionType();
+  CanType substType = getSubstType();
+  AbstractionPattern origType(funcType->getGenericSignature(), substType);
+  return SGF.getLoweredType(origType, substType);
+}
+
+SILType ArgumentSource::getSILSubstType(SILGenFunction &SGF) const & {
+  CanSILFunctionType funcType = SGF.F.getLoweredFunctionType();
+  CanType substType = getSubstType();
+  AbstractionPattern origType(funcType->getGenericSignature(), substType);
+  return SGF.getLoweredType(origType, substType);
+}

--- a/lib/SILGen/ArgumentSource.h
+++ b/lib/SILGen/ArgumentSource.h
@@ -178,6 +178,8 @@ public:
     llvm_unreachable("bad kind");
   }
 
+  SILType getSILSubstType(SILGenFunction &SGF) const &;
+
   CanType getSubstRValueType() const & {
     switch (StoredKind) {
     case Kind::RValue:
@@ -189,6 +191,8 @@ public:
     }
     llvm_unreachable("bad kind");
   }
+
+  SILType getSILSubstRValueType(SILGenFunction &SGF) const &;
 
   bool hasLValueType() const & {
     switch (StoredKind) {


### PR DESCRIPTION
[silgen] Add helper methods to compute ArgumentSource::getSubst{RValue,}Type() as SILTypes.

rdar://31145255
