### PR TITLE
[Parse] [Syntax] Simplify TupleTypeRepr parsing and add attributes for Syntax

### DIFF
--- a/include/swift/AST/TypeRepr.h
+++ b/include/swift/AST/TypeRepr.h
@@ -628,7 +628,7 @@ public:
     }
   }
 
-  TypeRepr *getType(unsigned i) const {
+  TypeRepr *getElementType(unsigned i) const {
     return getElement(i).Type;
   }
 

--- a/include/swift/AST/TypeRepr.h
+++ b/include/swift/AST/TypeRepr.h
@@ -622,6 +622,12 @@ public:
     return { getTrailingObjects<TupleTypeReprElement>(), NumElements };
   }
 
+  void getElementTypes(SmallVectorImpl<TypeRepr *> &Types) const {
+    for (auto &Element : getElements()) {
+      Types.push_back(Element.Type);
+    }
+  }
+
   TypeRepr *getType(unsigned i) const {
     return getElement(i).Type;
   }

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2635,7 +2635,7 @@ public:
 
     for (auto elem : T->getElements()) {
       OS << '\n';
-      printRec(elem);
+      printRec(elem.Type);
     }
     PrintWithColorRAII(OS, ParenthesisColor) << ')';
   }

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -612,58 +612,6 @@ uint8_t swift::getKeywordLen(tok keyword) {
 
 StringRef swift::getCodePlaceholder() { return "<#code#>"; }
 
-void swift::
-printEnumElmentsAsCases(llvm::DenseSet<EnumElementDecl*> &UnhandledElements,
-                        llvm::raw_ostream &OS) {
-  // Sort the missing elements to a vector because set does not guarantee orders.
-  SmallVector<EnumElementDecl*, 4> SortedElements;
-  SortedElements.insert(SortedElements.begin(), UnhandledElements.begin(),
-                        UnhandledElements.end());
-  std::sort(SortedElements.begin(),SortedElements.end(),
-            [](EnumElementDecl *LHS, EnumElementDecl *RHS) {
-              return LHS->getNameStr().compare(RHS->getNameStr()) < 0;
-            });
-
-  auto printPayloads = [](EnumElementDecl *EE, llvm::raw_ostream &OS) {
-    // If the enum element has no payloads, return.
-    auto TL = EE->getArgumentTypeLoc();
-    if (TL.isNull())
-      return;
-    TypeRepr* TR = EE->getArgumentTypeLoc().getTypeRepr();
-    if (auto *TTR = dyn_cast<TupleTypeRepr>(TR)) {
-      SmallVector<Identifier, 4> Names;
-      if (TTR->hasElementNames()) {
-        // Get the name from the tuple repr, if exist.
-        TTR->getElementNames(Names);
-      } else {
-        // Create same amount of empty names to the elements.
-        Names.resize(TTR->getNumElements());
-      }
-      OS << "(";
-      // Print each element in the pattern match.
-      for (unsigned I = 0, N = Names.size(); I < N; I ++) {
-        auto Id = Names[I];
-        if (Id.empty())
-          OS << "_";
-        else
-          OS << tok::kw_let << " " << Id.str();
-        if (I + 1 != N) {
-          OS << ", ";
-        }
-      }
-      OS << ")";
-    }
-  };
-
-  // Print each enum element name.
-  std::for_each(SortedElements.begin(), SortedElements.end(),
-                [&](EnumElementDecl *EE) {
-                  OS << tok::kw_case << " ." << EE->getNameStr();
-                  printPayloads(EE, OS);
-                  OS <<": " << getCodePlaceholder() << "\n";
-                });
-}
-
 ASTPrinter &operator<<(ASTPrinter &printer, tok keyword) {
   SmallString<16> Buffer;
   llvm::raw_svector_ostream OS(Buffer);

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -612,6 +612,58 @@ uint8_t swift::getKeywordLen(tok keyword) {
 
 StringRef swift::getCodePlaceholder() { return "<#code#>"; }
 
+void swift::
+printEnumElmentsAsCases(llvm::DenseSet<EnumElementDecl*> &UnhandledElements,
+                        llvm::raw_ostream &OS) {
+  // Sort the missing elements to a vector because set does not guarantee orders.
+  SmallVector<EnumElementDecl*, 4> SortedElements;
+  SortedElements.insert(SortedElements.begin(), UnhandledElements.begin(),
+                        UnhandledElements.end());
+  std::sort(SortedElements.begin(),SortedElements.end(),
+            [](EnumElementDecl *LHS, EnumElementDecl *RHS) {
+              return LHS->getNameStr().compare(RHS->getNameStr()) < 0;
+            });
+
+  auto printPayloads = [](EnumElementDecl *EE, llvm::raw_ostream &OS) {
+    // If the enum element has no payloads, return.
+    auto TL = EE->getArgumentTypeLoc();
+    if (TL.isNull())
+      return;
+    TypeRepr* TR = EE->getArgumentTypeLoc().getTypeRepr();
+    if (auto *TTR = dyn_cast<TupleTypeRepr>(TR)) {
+      SmallVector<Identifier, 4> Names;
+      if (TTR->hasElementNames()) {
+        // Get the name from the tuple repr, if exist.
+        TTR->getElementNames(Names);
+      } else {
+        // Create same amount of empty names to the elements.
+        Names.resize(TTR->getNumElements());
+      }
+      OS << "(";
+      // Print each element in the pattern match.
+      for (unsigned I = 0, N = Names.size(); I < N; I ++) {
+        auto Id = Names[I];
+        if (Id.empty())
+          OS << "_";
+        else
+          OS << tok::kw_let << " " << Id.str();
+        if (I + 1 != N) {
+          OS << ", ";
+        }
+      }
+      OS << ")";
+    }
+  };
+
+  // Print each enum element name.
+  std::for_each(SortedElements.begin(), SortedElements.end(),
+                [&](EnumElementDecl *EE) {
+                  OS << tok::kw_case << " ." << EE->getNameStr();
+                  printPayloads(EE, OS);
+                  OS <<": " << getCodePlaceholder() << "\n";
+                });
+}
+
 ASTPrinter &operator<<(ASTPrinter &printer, tok keyword) {
   SmallString<16> Buffer;
   llvm::raw_svector_ostream OS(Buffer);

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -1638,8 +1638,8 @@ bool Traversal::visitImplicitlyUnwrappedOptionalTypeRepr(ImplicitlyUnwrappedOpti
 }
 
 bool Traversal::visitTupleTypeRepr(TupleTypeRepr *T) {
-  for (auto elem : T->getElements()) {
-    if (doIt(elem))
+  for (auto &elem : T->getElements()) {
+    if (doIt(elem.Type))
       return true;
   }
   return false;

--- a/lib/AST/TypeRepr.cpp
+++ b/lib/AST/TypeRepr.cpp
@@ -503,7 +503,7 @@ void TupleTypeRepr::printImpl(ASTPrinter &Printer,
         Printer << ": ";
       }
     }
-    printTypeRepr(getType(i), Printer, Opts);
+    printTypeRepr(getElementType(i), Printer, Opts);
     Printer.printStructurePost(PrintStructureKind::TupleElement);
 
     if (hasEllipsis() && getEllipsisIndex() == i)

--- a/lib/AST/TypeRepr.cpp
+++ b/lib/AST/TypeRepr.cpp
@@ -405,12 +405,13 @@ void ImplicitlyUnwrappedOptionalTypeRepr::printImpl(ASTPrinter &Printer,
 TupleTypeRepr::TupleTypeRepr(ArrayRef<TupleTypeReprElement> Elements,
                              SourceRange Parens,
                              SourceLoc Ellipsis, unsigned EllipsisIdx)
-    : TypeRepr(TypeReprKind::Tuple), NumElements(Elements.size()),
-      Parens(Parens) {
+    : TypeRepr(TypeReprKind::Tuple), Parens(Parens) {
 
   // Copy elements.
   std::uninitialized_copy(Elements.begin(), Elements.end(),
                           getTrailingObjects<TupleTypeReprElement>());
+  TupleTypeReprBits.HasEllipsis = Ellipsis.isValid();
+  TupleTypeReprBits.NumElements = Elements.size();
 
   // Set ellipsis location and index.
   if (Ellipsis.isValid()) {
@@ -472,7 +473,7 @@ void TupleTypeRepr::printImpl(ASTPrinter &Printer,
 
   Printer << "(";
 
-  for (unsigned i = 0, e = NumElements; i != e; ++i) {
+  for (unsigned i = 0, e = TupleTypeReprBits.NumElements; i != e; ++i) {
     if (i) Printer << ", ";
     Printer.callPrintStructurePre(PrintStructureKind::TupleElement);
     auto name = getElementName(i);

--- a/lib/Migrator/APIDiffMigratorPass.cpp
+++ b/lib/Migrator/APIDiffMigratorPass.cpp
@@ -168,9 +168,11 @@ public:
     // as their own index level
     if (T->getNumElements() == 1) {
       ParentIsOptional = false;
-      return visit(T->getElement(0));
+      return visit(T->getType(0));
     }
-    return handleParent(T, T->getElements());
+    llvm::SmallVector<TypeRepr *, 8> Children;
+    T->getElementTypes(Children);
+    return handleParent(T, ArrayRef<TypeRepr *>(Children));
   }
 
   FoundResult visitFunctionTypeRepr(FunctionTypeRepr *T) {

--- a/lib/Migrator/APIDiffMigratorPass.cpp
+++ b/lib/Migrator/APIDiffMigratorPass.cpp
@@ -168,7 +168,7 @@ public:
     // as their own index level
     if (T->getNumElements() == 1) {
       ParentIsOptional = false;
-      return visit(T->getType(0));
+      return visit(T->getElementType(0));
     }
     llvm::SmallVector<TypeRepr *, 8> Children;
     T->getElementTypes(Children);

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -2146,7 +2146,9 @@ static void printTupleNames(const TypeRepr *typeRepr, llvm::raw_ostream &OS) {
   
   OS << "(";
   unsigned elementIndex = 0;
-  interleave(tupleRepr->getElements(),
+  llvm::SmallVector<TypeRepr *, 10> elementTypes;
+  tupleRepr->getElementTypes(elementTypes);
+  interleave(elementTypes,
              [&](const TypeRepr *element) {
                if (isa<TupleTypeRepr>(element)) {
                  printTupleNames(element, OS);

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1304,13 +1304,13 @@ TypeExpr *PreCheckExpression::simplifyTypeExpr(Expr *E) {
       auto *TRE = dyn_cast_or_null<TupleTypeRepr>(TE->getTypeRepr());
       if (!TRE || TRE->getEllipsisLoc().isValid()) return nullptr;
       while (TRE->isParenType()) {
-        TRE = dyn_cast_or_null<TupleTypeRepr>(TRE->getType(0));
+        TRE = dyn_cast_or_null<TupleTypeRepr>(TRE->getElementType(0));
         if (!TRE || TRE->getEllipsisLoc().isValid()) return nullptr;
       }
 
       assert(TRE->getElements().size() == 2);
-      keyTypeRepr = TRE->getType(0);
-      valueTypeRepr = TRE->getType(1);
+      keyTypeRepr = TRE->getElementType(0);
+      valueTypeRepr = TRE->getElementType(1);
     }
 
     auto *NewTypeRepr =

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1235,7 +1235,6 @@ TypeExpr *PreCheckExpression::simplifyTypeExpr(Expr *E) {
       return nullptr;
 
     SmallVector<TupleTypeReprElement, 4> Elts;
-    Elts.resize(TE->getNumElements());
     unsigned EltNo = 0;
     for (auto Elt : TE->getElements()) {
       auto *eltTE = dyn_cast<TypeExpr>(Elt);

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -829,7 +829,7 @@ static bool isDefaultInitializable(TypeRepr *typeRepr) {
       return false;
 
     for (auto elt : tuple->getElements()) {
-      if (!isDefaultInitializable(elt))
+      if (!isDefaultInitializable(elt.Type))
         return false;
     }
 
@@ -4914,7 +4914,7 @@ public:
     // Look through parentheses.
     if (auto parenRepr = dyn_cast<TupleTypeRepr>(typeRepr)) {
       if (!parenRepr->isParenType()) return false;
-      return checkDynamicSelfReturn(func, parenRepr->getElement(0),
+      return checkDynamicSelfReturn(func, parenRepr->getType(0),
                                     optionalDepth);
     }
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4914,7 +4914,7 @@ public:
     // Look through parentheses.
     if (auto parenRepr = dyn_cast<TupleTypeRepr>(typeRepr)) {
       if (!parenRepr->isParenType()) return false;
-      return checkDynamicSelfReturn(func, parenRepr->getType(0),
+      return checkDynamicSelfReturn(func, parenRepr->getElementType(0),
                                     optionalDepth);
     }
 

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2333,7 +2333,7 @@ Type TypeResolver::resolveASTFunctionType(FunctionTypeRepr *repr,
     if (const auto Tuple = dyn_cast<TupleTypeRepr>(args)) {
       if (Tuple->getNumElements() == 1) {
         if (const auto Void =
-            dyn_cast<SimpleIdentTypeRepr>(Tuple->getType(0))) {
+            dyn_cast<SimpleIdentTypeRepr>(Tuple->getElementType(0))) {
           if (Void->getIdentifier().str() == "Void") {
             TC.diagnose(args->getStartLoc(), diag::paren_void_probably_void)
               .fixItReplace(args->getSourceRange(), "()");
@@ -2866,7 +2866,7 @@ Type TypeResolver::resolveTupleType(TupleTypeRepr *repr,
   }
 
   for (unsigned i = 0, end = repr->getNumElements(); i != end; ++i) {
-    auto *tyR = repr->getType(i);
+    auto *tyR = repr->getElementType(i);
     Type ty;
     Identifier name;
     bool variadic = false;
@@ -2912,7 +2912,7 @@ Type TypeResolver::resolveTupleType(TupleTypeRepr *repr,
         TC.diagnose(repr->getElementNameLoc(0),
                     diag::tuple_single_element)
           .fixItRemoveChars(repr->getElementNameLoc(0),
-                            repr->getType(0)->getStartLoc());
+                            repr->getElementType(0)->getStartLoc());
       }
 
       elements[0] = TupleTypeElt(elements[0].getType());

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2333,7 +2333,7 @@ Type TypeResolver::resolveASTFunctionType(FunctionTypeRepr *repr,
     if (const auto Tuple = dyn_cast<TupleTypeRepr>(args)) {
       if (Tuple->getNumElements() == 1) {
         if (const auto Void =
-            dyn_cast<SimpleIdentTypeRepr>(Tuple->getElement(0))) {
+            dyn_cast<SimpleIdentTypeRepr>(Tuple->getType(0))) {
           if (Void->getIdentifier().str() == "Void") {
             TC.diagnose(args->getStartLoc(), diag::paren_void_probably_void)
               .fixItReplace(args->getSourceRange(), "()");

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -1371,18 +1371,17 @@ private:
       if (auto *FTR = dyn_cast<FunctionTypeRepr>(T)) {
         FoundFunctionTypeRepr = true;
         if (auto *TTR = dyn_cast_or_null<TupleTypeRepr>(FTR->getArgsTypeRepr())) {
-          for (unsigned i = 0, end = TTR->getNumElements(); i != end; ++i) {
-            auto *ArgTR = TTR->getElement(i);
+          for (auto &ArgElt : TTR->getElements()) {
             CharSourceRange NR;
             CharSourceRange TR;
-            auto name = TTR->getElementName(i);
+            auto name = ArgElt.Name;
             if (!name.empty()) {
-              NR = CharSourceRange(TTR->getElementNameLoc(i),
+              NR = CharSourceRange(ArgElt.NameLoc,
                                    name.getLength());
             }
             SourceLoc SRE = Lexer::getLocForEndOfToken(SM,
-                                                       ArgTR->getEndLoc());
-            TR = CharSourceRange(SM, ArgTR->getStartLoc(), SRE);
+                                                    ArgElt.Type->getEndLoc());
+            TR = CharSourceRange(SM, ArgElt.Type->getStartLoc(), SRE);
             Info.Params.emplace_back(NR, TR);
           }
         } else if (FTR->getArgsTypeRepr()) {


### PR DESCRIPTION
<!-- What's in this pull request? -->
This patch adds more `SourceLoc`s to `TupleTypeRepr`'s elements and simplifies its implementation. Rather than adding extra trailing object arrays with indices that need to line up, instead just store a trailing array of `TupleTypeReprElement`s.

~~Also removes the single trailing `EllipsisLoc`, which obviated the need for the `HasEllipsis` bit field, the removal of which obviated the need for `TupleTypeReprBitfields` overall.~~