### PR TITLE
VTable visitor refactoring

### DIFF
--- a/include/swift/SIL/SILVTableVisitor.h
+++ b/include/swift/SIL/SILVTableVisitor.h
@@ -1,0 +1,110 @@
+//===--- SILVTableVisitor.h - Class vtable visitor -------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the SILVTableVisitor class, which is used to generate and
+// perform lookups in class method vtables.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SIL_SILVTABLEVISITOR_H
+#define SWIFT_SIL_SILVTABLEVISITOR_H
+
+#include "swift/AST/Attr.h"
+#include "swift/AST/Decl.h"
+#include "swift/AST/Types.h"
+
+namespace swift {
+
+/// A CRTP class for visiting virtually-dispatched methods of a class.
+///
+/// You must override addMethod(SILDeclRef) in your subclass.
+template <class T> class SILVTableVisitor {
+  T &asDerived() { return *static_cast<T*>(this); }
+
+  void maybeAddMethod(FuncDecl *fd) {
+    assert(!fd->hasClangNode());
+
+    // Observing accessors don't get a vtable entry.
+    if (fd->isObservingAccessor())
+      return;
+
+    maybeAddEntry(SILDeclRef(fd, SILDeclRef::Kind::Func));
+  }
+
+  void maybeAddConstructor(ConstructorDecl *cd) {
+    assert(!cd->hasClangNode());
+
+    SILDeclRef initRef(cd, SILDeclRef::Kind::Initializer);
+
+    // Stub constructors don't get a vtable entry unless they were synthesized
+    // to override a base class initializer.
+    if (cd->hasStubImplementation() &&
+        !initRef.getNextOverriddenVTableEntry())
+      return;
+
+    // Required constructors (or overrides thereof) have their allocating entry
+    // point in the vtable.
+    if (cd->isRequired())
+      maybeAddEntry(SILDeclRef(cd, SILDeclRef::Kind::Allocator));
+
+    // All constructors have their initializing constructor in the
+    // vtable, which can be used by a convenience initializer.
+    maybeAddEntry(SILDeclRef(cd, SILDeclRef::Kind::Initializer));
+  }
+
+  void maybeAddEntry(SILDeclRef declRef) {
+    // If the method overrides something, we don't need a new entry.
+    //
+    // FIXME: We do, if the override changes the AST type.
+    if (declRef.getNextOverriddenVTableEntry()) {
+      auto baseRef = declRef.getBaseOverriddenVTableEntry();
+      asDerived().addMethodOverride(baseRef, declRef);
+      return;
+    }
+
+    auto *decl = declRef.getDecl();
+
+    // Final members are always be called directly.
+    // Dynamic methods are always accessed by objc_msgSend().
+    if (decl->isFinal() || decl->isDynamic())
+      return;
+
+    // Special case -- materializeForSet on dynamic storage is not
+    // itself dynamic, but should be treated as such for the
+    // purpose of constructing the vtable.
+    if (auto *fd = dyn_cast<FuncDecl>(decl)) {
+      if (fd->getAccessorKind() == AccessorKind::IsMaterializeForSet &&
+          fd->getAccessorStorageDecl()->isDynamic())
+        return;
+    }
+
+    asDerived().addMethod(declRef);
+  }
+
+protected:
+  void addVTableEntries(ClassDecl *theClass) {
+    // Imported classes do not have a vtable.
+    if (!theClass->hasKnownSwiftImplementation())
+      return;
+
+    for (auto member : theClass->getMembers()) {
+      if (auto *fd = dyn_cast<FuncDecl>(member))
+        maybeAddMethod(fd);
+      else if (auto *cd = dyn_cast<ConstructorDecl>(member))
+        maybeAddConstructor(cd);
+    }
+  }
+};
+
+}
+
+#endif

--- a/lib/IRGen/ClassMetadataLayout.h
+++ b/lib/IRGen/ClassMetadataLayout.h
@@ -18,6 +18,7 @@
 #define SWIFT_IRGEN_CLASSMETADATALAYOUT_H
 
 #include "swift/SIL/SILDeclRef.h"
+#include "swift/SIL/SILVTableVisitor.h"
 #include "IRGen.h"
 #include "MetadataLayout.h"
 
@@ -28,7 +29,9 @@ class IRGenModule;
 
 /// A CRTP class for laying out class metadata.  Note that this does
 /// *not* handle the metadata template stuff.
-template <class Impl> class ClassMetadataLayout : public MetadataLayout<Impl> {
+template <class Impl> class ClassMetadataLayout
+    : public MetadataLayout<Impl>,
+      public SILVTableVisitor<Impl> {
   typedef MetadataLayout<Impl> super;
 
 protected:
@@ -101,48 +104,8 @@ private:
     // parameters for the parent context are handled by the parent.
     asImpl().addGenericFields(theClass, type, theClass);
 
-    // Add entries for the methods.
-    for (auto member : theClass->getMembers()) {
-      // If this is a non-overriding final member, we don't need table entries.
-      // FIXME: do we really need entries for final overrides?  The
-      // superclass should provide the entries it needs, and
-      // reabstracting overrides shouldn't be required: if we know
-      // enough to call the override, we know enough to call it
-      // directly.
-      if (auto *VD = dyn_cast<ValueDecl>(member))
-        if (VD->isFinal() && VD->getOverriddenDecl() == nullptr)
-          continue;
-
-      // @NSManaged properties and methods don't have vtable entries.
-      if (member->getAttrs().hasAttribute<NSManagedAttr>())
-        continue;
-
-      // Add entries for methods.
-      if (auto fn = dyn_cast<FuncDecl>(member)) {
-        // Ignore accessors.  These get added when their AbstractStorageDecl is
-        // visited.
-        if (fn->isAccessor())
-          continue;
-
-        addMethodEntries(fn);
-      } else if (auto ctor = dyn_cast<ConstructorDecl>(member)) {
-        // Stub constructors don't get an entry.
-        if (ctor->hasStubImplementation())
-          continue;
-
-        // Add entries for constructors.
-        addMethodEntries(ctor);
-      } else if (auto *asd = dyn_cast<AbstractStorageDecl>(member)) {
-        // FIXME: Stored properties should either be final or have accessors.
-        if (!asd->hasAccessorFunctions()) continue;
-
-        addMethodEntries(asd->getGetter());
-        if (auto *setter = asd->getSetter())
-          addMethodEntries(setter);
-        if (auto *materializeForSet = asd->getMaterializeForSetFunc())
-          addMethodEntries(materializeForSet);
-      }
-    }
+    // Add vtable entries.
+    asImpl().addVTableEntries(theClass);
 
     // A class only really *needs* a field-offset vector in the
     // metadata if:
@@ -176,32 +139,6 @@ private:
   void addFieldEntries(VarDecl *field) {
     asImpl().addFieldOffset(field);
   }
-
-  void addMethodEntries(AbstractFunctionDecl *fn) {
-    // If the method does not have a vtable entry, don't add any.
-    if (!hasKnownVTableEntry(IGM, fn))
-      return;
-
-    if (isa<FuncDecl>(fn))
-      maybeAddMethod(fn, SILDeclRef::Kind::Func);
-    else {
-      auto ctor = cast<ConstructorDecl>(fn);
-      if (ctor->isRequired())
-        maybeAddMethod(fn, SILDeclRef::Kind::Allocator);
-      maybeAddMethod(fn, SILDeclRef::Kind::Initializer);
-    }
-  }
-
-  void maybeAddMethod(AbstractFunctionDecl *fn,
-                      SILDeclRef::Kind kind) {
-    SILDeclRef declRef(fn, kind);
-    // If the method overrides something, we don't need a new entry.
-    if (declRef.getNextOverriddenVTableEntry())
-      return;
-
-    // Both static and non-static functions go in the metadata.
-    asImpl().addMethod(declRef);
-  }
 };
 
 /// An "implementation" of ClassMetadataLayout that just scans through
@@ -232,9 +169,10 @@ public:
   void addClassAddressPoint() { addInt32(); }
   void addClassCacheData() { addPointer(); addPointer(); }
   void addClassDataPointer() { addPointer(); }
-  void addMethod(SILDeclRef fn) {
+  void addMethod(SILDeclRef declRef) {
     addPointer();
   }
+  void addMethodOverride(SILDeclRef baseRef, SILDeclRef declRef) {}
   void addFieldOffset(VarDecl *var) { addPointer(); }
   void addGenericArgument(CanType argument, ClassDecl *forClass) {
     addPointer();

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -429,17 +429,6 @@ bool irgen::hasKnownSwiftMetadata(IRGenModule &IGM, ClassDecl *theClass) {
   return theClass->hasKnownSwiftImplementation();
 }
 
-/// Is the given method known to be callable by vtable lookup?
-bool irgen::hasKnownVTableEntry(IRGenModule &IGM,
-                                AbstractFunctionDecl *theMethod) {
-  auto theClass = dyn_cast<ClassDecl>(theMethod->getDeclContext());
-  // Extension methods don't get vtable entries.
-  if (!theClass) {
-    return false;
-  }
-  return theClass->hasKnownSwiftImplementation();
-}
-
 /// Is it basically trivial to access the given metadata?  If so, we don't
 /// need a cache variable in its accessor.
 bool irgen::isTypeMetadataAccessTrivial(IRGenModule &IGM, CanType type) {
@@ -3512,6 +3501,8 @@ namespace {
         B.addBitCast(IGM.getDeletedMethodErrorFn(), IGM.FunctionPtrTy);
       }
     }
+
+    void addMethodOverride(SILDeclRef baseRef, SILDeclRef declRef) {}
 
     void addGenericArgument(CanType argTy, ClassDecl *forClass) {
       B.addNullPointer(IGM.TypeMetadataPtrTy);

--- a/lib/IRGen/GenMeta.h
+++ b/lib/IRGen/GenMeta.h
@@ -62,9 +62,6 @@ namespace irgen {
   /// metadata?
   bool hasKnownSwiftMetadata(IRGenModule &IGM, CanType theType);
 
-  /// Is the given method known to be callable by vtable dispatch?
-  bool hasKnownVTableEntry(IRGenModule &IGM, AbstractFunctionDecl *theMethod);
-
   /// Emit the body of a lazy cache access function.
   void emitLazyCacheAccessFunction(IRGenModule &IGM,
                                    llvm::Function *accessor,

--- a/lib/SIL/SILDeclRef.cpp
+++ b/lib/SIL/SILDeclRef.cpp
@@ -772,11 +772,13 @@ SILDeclRef SILDeclRef::getNextOverriddenVTableEntry() const {
     // @NSManaged property, then it won't be in the vtable.
     if (overridden.getDecl()->hasClangNode())
       return SILDeclRef();
-    if (overridden.getDecl()->getAttrs().hasAttribute<DynamicAttr>())
+    if (overridden.getDecl()->isDynamic())
       return SILDeclRef();
     if (auto *ovFD = dyn_cast<FuncDecl>(overridden.getDecl()))
       if (auto *asd = ovFD->getAccessorStorageDecl()) {
         if (asd->hasClangNode())
+          return SILDeclRef();
+        if (asd->isDynamic())
           return SILDeclRef();
       }
 

--- a/test/DebugInfo/generic_enum_closure.swift
+++ b/test/DebugInfo/generic_enum_closure.swift
@@ -9,10 +9,8 @@ struct CErrorOr<T>
     // CHECK-NOT: define
     // This is a SIL-level debug_value_addr instruction.
     // CHECK: call void @llvm.dbg.value({{.*}}, metadata ![[SELF:.*]], metadata !{{[0-9]+}})
-    // CHECK: ![[SELF]] = !DILocalVariable(name: "self", scope
-    // CHECK-SAME:                         type: ![[T1:.*]])
-    // CHECK: ![[T1]] = !DICompositeType(
-    // CHECK-SAME: identifier: "_T020generic_enum_closure8CErrorOrVyACQq_GD"
+    // CHECK: ![[T1:.*]] = !DICompositeType({{.*}}, identifier: "_T020generic_enum_closure8CErrorOrVyACQq_GD")
+    // CHECK: ![[SELF]] = !DILocalVariable(name: "self", scope: {{.*}}, type: ![[T1]])
     value = .none
   }
   func isError() -> Bool {

--- a/test/DebugInfo/initializer.swift
+++ b/test/DebugInfo/initializer.swift
@@ -6,12 +6,12 @@ protocol Named {
     var name : String { get }
 }
 
-// initializer.Person.init (initializer.Person.Type)() -> initializer.Person
-// CHECK: define hidden {{.*}}%T11initializer6PersonC* @_T011initializer6PersonCACycfc(%T11initializer6PersonC*{{.*}}) {{.*}} {
-
 // initializer.Person.__allocating_init (initializer.Person.Type)() -> initializer.Person
 // CHECK: define hidden {{.*}}%T11initializer6PersonC* @_T011initializer6PersonCACycfC(%swift.type*{{.*}}) {{.*}} {
 // CHECK:  call {{.*}}%T11initializer6PersonC* @_T011initializer6PersonCACycfc(%T11initializer6PersonC* {{.*}}%3), !dbg ![[ALLOCATING_INIT:.*]]
+
+// initializer.Person.init (initializer.Person.Type)() -> initializer.Person
+// CHECK: define hidden {{.*}}%T11initializer6PersonC* @_T011initializer6PersonCACycfc(%T11initializer6PersonC*{{.*}}) {{.*}} {
 
 // CHECK-DAG: ![[ALLOCATING_INIT]]  = !DILocation(line: 0, scope
 class Person : Named {

--- a/test/IRGen/class_resilience.swift
+++ b/test/IRGen/class_resilience.swift
@@ -115,6 +115,17 @@ public class MyResilientChild : MyResilientParent {
 }
 
 
+// ClassWithResilientProperty.color getter
+
+// CHECK-LABEL: define{{( protected)?}} swiftcc i32 @_T016class_resilience26ClassWithResilientPropertyC5colors5Int32Vfg(%T16class_resilience26ClassWithResilientPropertyC* swiftself)
+// CHECK:      [[OFFSET:%.*]] = load [[INT]], [[INT]]* @_T016class_resilience26ClassWithResilientPropertyC5colors5Int32VvWvd
+// CHECK-NEXT: [[PTR:%.*]] = bitcast %T16class_resilience26ClassWithResilientPropertyC* %0 to i8*
+// CHECK-NEXT: [[FIELD_ADDR:%.*]] = getelementptr inbounds i8, i8* [[PTR]], [[INT]] [[OFFSET]]
+// CHECK-NEXT: [[FIELD_PTR:%.*]] = bitcast i8* [[FIELD_ADDR]] to %Ts5Int32V*
+// CHECK-NEXT: [[FIELD_PAYLOAD:%.*]] = getelementptr inbounds %Ts5Int32V, %Ts5Int32V* [[FIELD_PTR]], i32 0, i32 0
+// CHECK-NEXT: [[FIELD_VALUE:%.*]] = load i32, i32* [[FIELD_PAYLOAD]]
+// CHECK-NEXT: ret i32 [[FIELD_VALUE]]
+
 // ClassWithResilientProperty metadata accessor
 
 // CHECK-LABEL: define{{( protected)?}} %swift.type* @_T016class_resilience26ClassWithResilientPropertyCMa()
@@ -131,17 +142,16 @@ public class MyResilientChild : MyResilientParent {
 // CHECK-NEXT: [[RESULT:%.*]] = phi %swift.type* [ [[CACHE]], %entry ], [ [[METADATA]], %cacheIsNull ]
 // CHECK-NEXT: ret %swift.type* [[RESULT]]
 
-// ClassWithResilientProperty.color getter
+// ClassWithResilientlySizedProperty.color getter
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc i32 @_T016class_resilience26ClassWithResilientPropertyC5colors5Int32Vfg(%T16class_resilience26ClassWithResilientPropertyC* swiftself)
-// CHECK:      [[OFFSET:%.*]] = load [[INT]], [[INT]]* @_T016class_resilience26ClassWithResilientPropertyC5colors5Int32VvWvd
-// CHECK-NEXT: [[PTR:%.*]] = bitcast %T16class_resilience26ClassWithResilientPropertyC* %0 to i8*
+// CHECK-LABEL: define{{( protected)?}} swiftcc i32 @_T016class_resilience33ClassWithResilientlySizedPropertyC5colors5Int32Vfg(%T16class_resilience33ClassWithResilientlySizedPropertyC* swiftself)
+// CHECK:      [[OFFSET:%.*]] = load [[INT]], [[INT]]* @_T016class_resilience33ClassWithResilientlySizedPropertyC5colors5Int32VvWvd
+// CHECK-NEXT: [[PTR:%.*]] = bitcast %T16class_resilience33ClassWithResilientlySizedPropertyC* %0 to i8*
 // CHECK-NEXT: [[FIELD_ADDR:%.*]] = getelementptr inbounds i8, i8* [[PTR]], [[INT]] [[OFFSET]]
 // CHECK-NEXT: [[FIELD_PTR:%.*]] = bitcast i8* [[FIELD_ADDR]] to %Ts5Int32V*
 // CHECK-NEXT: [[FIELD_PAYLOAD:%.*]] = getelementptr inbounds %Ts5Int32V, %Ts5Int32V* [[FIELD_PTR]], i32 0, i32 0
 // CHECK-NEXT: [[FIELD_VALUE:%.*]] = load i32, i32* [[FIELD_PAYLOAD]]
 // CHECK-NEXT: ret i32 [[FIELD_VALUE]]
-
 
 // ClassWithResilientlySizedProperty metadata accessor
 
@@ -158,18 +168,6 @@ public class MyResilientChild : MyResilientParent {
 // CHECK:    cont:
 // CHECK-NEXT: [[RESULT:%.*]] = phi %swift.type* [ [[CACHE]], %entry ], [ [[METADATA]], %cacheIsNull ]
 // CHECK-NEXT: ret %swift.type* [[RESULT]]
-
-
-// ClassWithResilientlySizedProperty.color getter
-
-// CHECK-LABEL: define{{( protected)?}} swiftcc i32 @_T016class_resilience33ClassWithResilientlySizedPropertyC5colors5Int32Vfg(%T16class_resilience33ClassWithResilientlySizedPropertyC* swiftself)
-// CHECK:      [[OFFSET:%.*]] = load [[INT]], [[INT]]* @_T016class_resilience33ClassWithResilientlySizedPropertyC5colors5Int32VvWvd
-// CHECK-NEXT: [[PTR:%.*]] = bitcast %T16class_resilience33ClassWithResilientlySizedPropertyC* %0 to i8*
-// CHECK-NEXT: [[FIELD_ADDR:%.*]] = getelementptr inbounds i8, i8* [[PTR]], [[INT]] [[OFFSET]]
-// CHECK-NEXT: [[FIELD_PTR:%.*]] = bitcast i8* [[FIELD_ADDR]] to %Ts5Int32V*
-// CHECK-NEXT: [[FIELD_PAYLOAD:%.*]] = getelementptr inbounds %Ts5Int32V, %Ts5Int32V* [[FIELD_PTR]], i32 0, i32 0
-// CHECK-NEXT: [[FIELD_VALUE:%.*]] = load i32, i32* [[FIELD_PAYLOAD]]
-// CHECK-NEXT: ret i32 [[FIELD_VALUE]]
 
 
 // ClassWithIndirectResilientEnum.color getter

--- a/test/SILGen/SILDeclRef.swift
+++ b/test/SILGen/SILDeclRef.swift
@@ -55,16 +55,16 @@ public func testBase(b: Base) -> Int32 {
 // Check that vtables and witness tables contain SILDeclRefs with signatures.
 
 // CHECK: sil_vtable Base {
-// CHECK:  #Base.foo!1: (Base) -> () -> Int32 : _T010SILDeclRef4BaseC3foos5Int32VyF	// Base.foo() -> Int32
-// CHECK:  #Base.foo!1: (Base) -> (Int32) -> () : _T010SILDeclRef4BaseC3fooys5Int32V1n_tF	// Base.foo(n : Int32) -> ()
-// CHECK:  #Base.foo!1: (Base) -> (Float) -> Int32 : _T010SILDeclRef4BaseC3foos5Int32VSf1f_tF	// Base.foo(f : Float) -> Int32
-// CHECK:  #Base.deinit!deallocator: _T010SILDeclRef4BaseCfD	// Base.__deallocating_deinit
-// CHECK:  #Base.init!initializer.1: (Base.Type) -> () -> Base : _T010SILDeclRef4BaseCACycfc	// Base.init() -> Base
-// CHECK: }
+// CHECK-NEXT:  #Base.foo!1: (Base) -> () -> Int32 : _T010SILDeclRef4BaseC3foos5Int32VyF	// Base.foo() -> Int32
+// CHECK-NEXT:  #Base.foo!1: (Base) -> (Int32) -> () : _T010SILDeclRef4BaseC3fooys5Int32V1n_tF	// Base.foo(n : Int32) -> ()
+// CHECK-NEXT:  #Base.foo!1: (Base) -> (Float) -> Int32 : _T010SILDeclRef4BaseC3foos5Int32VSf1f_tF	// Base.foo(f : Float) -> Int32
+// CHECK-NEXT:  #Base.init!initializer.1: (Base.Type) -> () -> Base : _T010SILDeclRef4BaseCACycfc	// Base.init() -> Base
+// CHECK-NEXT:  #Base.deinit!deallocator: _T010SILDeclRef4BaseCfD	// Base.__deallocating_deinit
+// CHECK-NEXT: }
 
 // CHECK:sil_witness_table [fragile] Base: P module SILDeclRef {
-// CHECK: method #P.foo!1: <Self where Self : P> (Self) -> () -> Int32 : @_T010SILDeclRef4BaseCAA1PA2aDP3foos5Int32VyFTW	// protocol witness for P.foo() -> Int32 in conformance Base
-// CHECK: method #P.foo!1: <Self where Self : P> (Self) -> (Int32) -> () : @_T010SILDeclRef4BaseCAA1PA2aDP3fooys5Int32V1n_tFTW	// protocol witness for P.foo(n : Int32) -> () in conformance Base
-// CHECK: }
+// CHECK-NEXT: method #P.foo!1: <Self where Self : P> (Self) -> () -> Int32 : @_T010SILDeclRef4BaseCAA1PA2aDP3foos5Int32VyFTW	// protocol witness for P.foo() -> Int32 in conformance Base
+// CHECK-NEXT: method #P.foo!1: <Self where Self : P> (Self) -> (Int32) -> () : @_T010SILDeclRef4BaseCAA1PA2aDP3fooys5Int32V1n_tFTW	// protocol witness for P.foo(n : Int32) -> () in conformance Base
+// CHECK-NEXT: }
 
 

--- a/test/SILGen/addressors.swift
+++ b/test/SILGen/addressors.swift
@@ -95,7 +95,7 @@ var global: Int32 {
 func test_global() -> Int32 {
   return global
 }
-// CHECK: sil hidden @_T010addressors11test_globals5Int32VyF : $@convention(thin) () -> Int32 {
+// CHECK-LABEL: sil hidden @_T010addressors11test_globals5Int32VyF : $@convention(thin) () -> Int32 {
 // CHECK:   [[T0:%.*]] = function_ref @_T010addressors6globals5Int32Vflu : $@convention(thin) () -> UnsafePointer<Int32>
 // CHECK:   [[T1:%.*]] = apply [[T0]]() : $@convention(thin) () -> UnsafePointer<Int32>
 // CHECK:   [[T2:%.*]] = struct_extract [[T1]] : $UnsafePointer<Int32>, #UnsafePointer._rawValue
@@ -116,7 +116,7 @@ struct B : Subscriptable {
   }
 }
 
-// CHECK: sil hidden @_T010addressors6test_ByAA1BVzF : $@convention(thin) (@inout B) -> () {
+// CHECK-LABEL: sil hidden @_T010addressors6test_ByAA1BVzF : $@convention(thin) (@inout B) -> () {
 // CHECK: bb0([[B:%.*]] : $*B):
 // CHECK:   [[T0:%.*]] = integer_literal $Builtin.Int32, 0
 // CHECK:   [[INDEX:%.*]] = struct $Int32 ([[T0]] : $Builtin.Int32)
@@ -184,7 +184,7 @@ struct D : Subscriptable {
 // SILGEN:   assign [[VALUE]] to [[ADDR]] : $*Int32
 
 // materializeForSet.
-// SILGEN: sil hidden [transparent] @_T010addressors1DV9subscripts5Int32VAFcfm
+// SILGEN-LABEL: sil hidden [transparent] @_T010addressors1DV9subscripts5Int32VAFcfm
 // SILGEN: bb0([[BUFFER:%.*]] : $Builtin.RawPointer, [[STORAGE:%.*]] : $*Builtin.UnsafeValueBuffer, [[I:%.*]] : $Int32, [[SELF:%.*]] : $*D):
 // SILGEN:   [[T0:%.*]] = function_ref @_T010addressors1DV9subscripts5Int32VAFcfau
 // SILGEN:   [[PTR:%.*]] = apply [[T0]]([[I]], [[SELF]])
@@ -256,13 +256,13 @@ class F {
   }
 }
 
-// CHECK: sil hidden @_T010addressors1FC5values5Int32Vflo : $@convention(method) (@guaranteed F) -> (UnsafePointer<Int32>, @owned Builtin.NativeObject) {
-// CHECK: sil hidden @_T010addressors1FC5values5Int32Vfao : $@convention(method) (@guaranteed F) -> (UnsafeMutablePointer<Int32>, @owned Builtin.NativeObject) {
+// CHECK-LABEL: sil hidden @_T010addressors1FC5values5Int32Vflo : $@convention(method) (@guaranteed F) -> (UnsafePointer<Int32>, @owned Builtin.NativeObject) {
+// CHECK-LABEL: sil hidden @_T010addressors1FC5values5Int32Vfao : $@convention(method) (@guaranteed F) -> (UnsafeMutablePointer<Int32>, @owned Builtin.NativeObject) {
 
 func test_f0(_ f: F) -> Int32 {
   return f.value
 }
-// CHECK: sil hidden @_T010addressors7test_f0s5Int32VAA1FCF : $@convention(thin) (@owned F) -> Int32 {
+// CHECK-LABEL: sil hidden @_T010addressors7test_f0s5Int32VAA1FCF : $@convention(thin) (@owned F) -> Int32 {
 // CHECK: bb0([[SELF:%0]] : $F):
 // CHECK:   [[ADDRESSOR:%.*]] = function_ref @_T010addressors1FC5values5Int32Vflo : $@convention(method) (@guaranteed F) -> (UnsafePointer<Int32>, @owned Builtin.NativeObject)
 // CHECK:   [[T0:%.*]] = apply [[ADDRESSOR]]([[SELF]])
@@ -279,7 +279,7 @@ func test_f0(_ f: F) -> Int32 {
 func test_f1(_ f: F) {
   f.value = 14
 }
-// CHECK: sil hidden @_T010addressors7test_f1yAA1FCF : $@convention(thin) (@owned F) -> () {
+// CHECK-LABEL: sil hidden @_T010addressors7test_f1yAA1FCF : $@convention(thin) (@owned F) -> () {
 // CHECK: bb0([[SELF:%0]] : $F):
 // CHECK:   [[T0:%.*]] = integer_literal $Builtin.Int32, 14
 // CHECK:   [[VALUE:%.*]] = struct $Int32 ([[T0]] : $Builtin.Int32)
@@ -306,7 +306,7 @@ class G {
     }
   }
 }
-// CHECK: sil hidden [transparent] @_T010addressors1GC5values5Int32Vfg : $@convention(method) (@guaranteed G) -> Int32 {
+// CHECK-LABEL: sil hidden [transparent] @_T010addressors1GC5values5Int32Vfg : $@convention(method) (@guaranteed G) -> Int32 {
 // CHECK: bb0([[SELF:%0]] : $G):
 // CHECK:   [[ADDRESSOR:%.*]] = function_ref @_T010addressors1GC5values5Int32Vflo : $@convention(method) (@guaranteed G) -> (UnsafePointer<Int32>, @owned Builtin.NativeObject)
 // CHECK:   [[T0:%.*]] = apply [[ADDRESSOR]]([[SELF]])
@@ -319,7 +319,7 @@ class G {
 // CHECK:   strong_release [[OWNER]] : $Builtin.NativeObject
 // CHECK:   return [[VALUE]] : $Int32
 
-// CHECK: sil hidden [transparent] @_T010addressors1GC5values5Int32Vfs : $@convention(method) (Int32, @guaranteed G) -> () {
+// CHECK-LABEL: sil hidden [transparent] @_T010addressors1GC5values5Int32Vfs : $@convention(method) (Int32, @guaranteed G) -> () {
 // CHECK: bb0([[VALUE:%0]] : $Int32, [[SELF:%1]] : $G):
 // CHECK:   [[ADDRESSOR:%.*]] = function_ref @_T010addressors1GC5values5Int32Vfao : $@convention(method) (@guaranteed G) -> (UnsafeMutablePointer<Int32>, @owned Builtin.NativeObject)
 // CHECK:   [[T0:%.*]] = apply [[ADDRESSOR]]([[SELF]])
@@ -399,7 +399,7 @@ func test_h0(_ f: H) -> Int32 {
 func test_h1(_ f: H) {
   f.value = 14
 }
-// CHECK: sil hidden @_T010addressors7test_h1yAA1HCF : $@convention(thin) (@owned H) -> () {
+// CHECK-LABEL: sil hidden @_T010addressors7test_h1yAA1HCF : $@convention(thin) (@owned H) -> () {
 // CHECK: bb0([[SELF:%0]] : $H):
 // CHECK:   [[T0:%.*]] = integer_literal $Builtin.Int32, 14
 // CHECK:   [[VALUE:%.*]] = struct $Int32 ([[T0]] : $Builtin.Int32)

--- a/test/SILGen/complete_object_init.swift
+++ b/test/SILGen/complete_object_init.swift
@@ -3,7 +3,14 @@
 struct X { }
 
 class A {
-  // CHECK-LABEL: sil hidden @_T020complete_object_init1AC{{[_0-9a-zA-Z]*}}fc : $@convention(method) (@owned A) -> @owned A
+// CHECK-LABEL: sil hidden @_T020complete_object_init1AC{{[_0-9a-zA-Z]*}}fC : $@convention(method) (@thick A.Type) -> @owned A
+// CHECK: bb0([[SELF_META:%[0-9]+]] : $@thick A.Type):
+// CHECK:   [[SELF:%[0-9]+]] = alloc_ref_dynamic [[SELF_META]] : $@thick A.Type, $A
+// CHECK:   [[OTHER_INIT:%[0-9]+]] = function_ref @_T020complete_object_init1AC{{[_0-9a-zA-Z]*}}fc : $@convention(method) (@owned A) -> @owned A
+// CHECK:   [[RESULT:%[0-9]+]] = apply [[OTHER_INIT]]([[SELF]]) : $@convention(method) (@owned A) -> @owned A
+// CHECK:   return [[RESULT]] : $A
+
+// CHECK-LABEL: sil hidden @_T020complete_object_init1AC{{[_0-9a-zA-Z]*}}fc : $@convention(method) (@owned A) -> @owned A
 // CHECK: bb0([[SELF_PARAM:%[0-9]+]] : $A):
 // CHECK:   [[SELF_BOX:%[0-9]+]] = alloc_box ${ var A }
 // CHECK:   [[PB:%.*]] = project_box [[SELF_BOX]]
@@ -20,13 +27,7 @@ class A {
 // CHECK:   destroy_value [[SELF_BOX]] : ${ var A }
 // CHECK:   return [[RESULT]] : $A
 
-  // CHECK-LABEL: sil hidden @_T020complete_object_init1AC{{[_0-9a-zA-Z]*}}fC : $@convention(method) (@thick A.Type) -> @owned A
   convenience init() {
-    // CHECK: bb0([[SELF_META:%[0-9]+]] : $@thick A.Type):
-    // CHECK:   [[SELF:%[0-9]+]] = alloc_ref_dynamic [[SELF_META]] : $@thick A.Type, $A
-    // CHECK:   [[OTHER_INIT:%[0-9]+]] = function_ref @_T020complete_object_init1AC{{[_0-9a-zA-Z]*}}fc : $@convention(method) (@owned A) -> @owned A
-    // CHECK:   [[RESULT:%[0-9]+]] = apply [[OTHER_INIT]]([[SELF]]) : $@convention(method) (@owned A) -> @owned A
-    // CHECK:   return [[RESULT]] : $A
     self.init(x: X())
   }
 

--- a/test/SILGen/dynamic.swift
+++ b/test/SILGen/dynamic.swift
@@ -448,28 +448,28 @@ public class Sub : Base {
   override var x: Bool { return false || super.x }
 }
 
-
-// Vtable contains entries for native and @objc methods, but not dynamic ones
 // CHECK-LABEL: sil_vtable Foo {
-// CHECK-LABEL:   #Foo.init!initializer.1: {{.*}} :   _T07dynamic3FooCACSi6native_tcfc
-// CHECK-LABEL:   #Foo.nativeMethod!1: {{.*}} :       _T07dynamic3FooC12nativeMethodyyF
-// CHECK-LABEL:   #Foo.subscript!getter.1: {{.*}} :   _T07dynamic3FooC9subscriptS2i6native_tcfg    // dynamic.Foo.subscript.getter : (native : Swift.Int) -> Swift.Int
-// CHECK-LABEL:   #Foo.subscript!setter.1: {{.*}} :   _T07dynamic3FooC9subscriptS2i6native_tcfs    // dynamic.Foo.subscript.setter : (native : Swift.Int) -> Swift.Int
-// CHECK-LABEL:   #Foo.init!initializer.1: {{.*}} :   _T07dynamic3FooCACSi4objc_tcfc
-// CHECK-LABEL:   #Foo.objcMethod!1: {{.*}} :         _T07dynamic3FooC10objcMethodyyF
-// CHECK-LABEL:   #Foo.subscript!getter.1: {{.*}} : _T07dynamic3FooC9subscriptSis9AnyObject_p4objc_tcfg // dynamic.Foo.subscript.getter : (objc : Swift.AnyObject) -> Swift.Int
-// CHECK-LABEL:   #Foo.subscript!setter.1: {{.*}} : _T07dynamic3FooC9subscriptSis9AnyObject_p4objc_tcfs // dynamic.Foo.subscript.setter : (objc : Swift.AnyObject) -> Swift.Int
-// CHECK-NOT:     dynamic.Foo.init (dynamic.Foo.Type)(dynamic : Swift.Int) -> dynamic.Foo
-// CHECK-NOT:     dynamic.Foo.dynamicMethod
-// CHECK-NOT:     dynamic.Foo.subscript.getter (dynamic : Swift.Int) -> Swift.Int
-// CHECK-NOT:     dynamic.Foo.subscript.setter (dynamic : Swift.Int) -> Swift.Int
-// CHECK-LABEL:   #Foo.overriddenByDynamic!1: {{.*}} : _T07dynamic3FooC19overriddenByDynamic{{[_0-9a-zA-Z]*}}F
-// CHECK-LABEL:   #Foo.nativeProp!getter.1: {{.*}} :  _T07dynamic3FooC10nativePropSifg     // dynamic.Foo.nativeProp.getter : Swift.Int
-// CHECK-LABEL:   #Foo.nativeProp!setter.1: {{.*}} :  _T07dynamic3FooC10nativePropSifs     // dynamic.Foo.nativeProp.setter : Swift.Int
-// CHECK-LABEL:   #Foo.objcProp!getter.1: {{.*}} :    _T07dynamic3FooC8objcPropSifg  // dynamic.Foo.objcProp.getter : Swift.Int
-// CHECK-LABEL:   #Foo.objcProp!setter.1: {{.*}} :    _T07dynamic3FooC8objcPropSifs  // dynamic.Foo.objcProp.setter : Swift.Int
-// CHECK-NOT:     dynamic.Foo.dynamicProp.getter
-// CHECK-NOT:     dynamic.Foo.dynamicProp.setter
+// CHECK-NEXT:   #Foo.init!initializer.1: {{.*}} :   _T07dynamic3FooCACSi6native_tcfc
+// CHECK-NEXT:   #Foo.nativeMethod!1: {{.*}} :       _T07dynamic3FooC12nativeMethodyyF
+// CHECK-NEXT:   #Foo.nativeProp!getter.1: {{.*}} :  _T07dynamic3FooC10nativePropSifg     // dynamic.Foo.nativeProp.getter : Swift.Int
+// CHECK-NEXT:   #Foo.nativeProp!setter.1: {{.*}} :  _T07dynamic3FooC10nativePropSifs     // dynamic.Foo.nativeProp.setter : Swift.Int
+// CHECK-NEXT:   #Foo.nativeProp!materializeForSet.1
+// CHECK-NEXT:   #Foo.subscript!getter.1: {{.*}} :   _T07dynamic3FooC9subscriptS2i6native_tcfg    // dynamic.Foo.subscript.getter : (native : Swift.Int) -> Swift.Int
+// CHECK-NEXT:   #Foo.subscript!setter.1: {{.*}} :   _T07dynamic3FooC9subscriptS2i6native_tcfs    // dynamic.Foo.subscript.setter : (native : Swift.Int) -> Swift.Int
+// CHECK-NEXT:   #Foo.subscript!materializeForSet.1
+// CHECK-NEXT:   #Foo.init!initializer.1: {{.*}} :   _T07dynamic3FooCACSi4objc_tcfc
+// CHECK-NEXT:   #Foo.objcMethod!1: {{.*}} :         _T07dynamic3FooC10objcMethodyyF
+// CHECK-NEXT:   #Foo.objcProp!getter.1: {{.*}} :    _T07dynamic3FooC8objcPropSifg  // dynamic.Foo.objcProp.getter : Swift.Int
+// CHECK-NEXT:   #Foo.objcProp!setter.1: {{.*}} :    _T07dynamic3FooC8objcPropSifs  // dynamic.Foo.objcProp.setter : Swift.Int
+// CHECK-NEXT:   #Foo.objcProp!materializeForSet.1
+// CHECK-NEXT:   #Foo.subscript!getter.1: {{.*}} : _T07dynamic3FooC9subscriptSis9AnyObject_p4objc_tcfg // dynamic.Foo.subscript.getter : (objc : Swift.AnyObject) -> Swift.Int
+// CHECK-NEXT:   #Foo.subscript!setter.1: {{.*}} : _T07dynamic3FooC9subscriptSis9AnyObject_p4objc_tcfs // dynamic.Foo.subscript.setter : (objc : Swift.AnyObject) -> Swift.Int
+// CHECK-NEXT:   #Foo.subscript!materializeForSet
+// CHECK-NEXT:   #Foo.dynamicProp!materializeForSet.1: (Foo) -> (Builtin.RawPointer, inout Builtin.UnsafeValueBuffer) -> (Builtin.RawPointer, Builtin.RawPointer?) : _T07dynamic3FooC0A4PropSifm	// dynamic.Foo.dynamicProp.materializeForSet : Swift.Int
+// CHECK-NEXT:   #Foo.subscript!materializeForSet.1: (Foo) -> (Builtin.RawPointer, inout Builtin.UnsafeValueBuffer, Int) -> (Builtin.RawPointer, Builtin.RawPointer?) : _T07dynamic3FooC9subscriptS2iAA_tcfm	// dynamic.Foo.subscript.materializeForSet : (dynamic : Swift.Int) -> Swift.Int
+// CHECK-NEXT:   #Foo.overriddenByDynamic!1: {{.*}} : _T07dynamic3FooC19overriddenByDynamic{{[_0-9a-zA-Z]*}}
+// CHECK-NEXT:   #Foo.deinit!deallocator: {{.*}}
+// CHECK-NEXT: }
 
 // Vtable uses a dynamic thunk for dynamic overrides
 // CHECK-LABEL: sil_vtable Subclass {

--- a/test/SILGen/dynamic.swift
+++ b/test/SILGen/dynamic.swift
@@ -448,6 +448,21 @@ public class Sub : Base {
   override var x: Bool { return false || super.x }
 }
 
+public class BaseExt : NSObject {}
+
+extension BaseExt {
+  public var count: Int {
+    return 0
+  }
+}
+
+public class SubExt : BaseExt {
+  public override var count: Int {
+    return 1
+  }
+}
+
+// Vtable contains entries for native and @objc methods, but not dynamic ones
 // CHECK-LABEL: sil_vtable Foo {
 // CHECK-NEXT:   #Foo.init!initializer.1: {{.*}} :   _T07dynamic3FooCACSi6native_tcfc
 // CHECK-NEXT:   #Foo.nativeMethod!1: {{.*}} :       _T07dynamic3FooC12nativeMethodyyF
@@ -465,13 +480,17 @@ public class Sub : Base {
 // CHECK-NEXT:   #Foo.subscript!getter.1: {{.*}} : _T07dynamic3FooC9subscriptSis9AnyObject_p4objc_tcfg // dynamic.Foo.subscript.getter : (objc : Swift.AnyObject) -> Swift.Int
 // CHECK-NEXT:   #Foo.subscript!setter.1: {{.*}} : _T07dynamic3FooC9subscriptSis9AnyObject_p4objc_tcfs // dynamic.Foo.subscript.setter : (objc : Swift.AnyObject) -> Swift.Int
 // CHECK-NEXT:   #Foo.subscript!materializeForSet
-// CHECK-NEXT:   #Foo.dynamicProp!materializeForSet.1: (Foo) -> (Builtin.RawPointer, inout Builtin.UnsafeValueBuffer) -> (Builtin.RawPointer, Builtin.RawPointer?) : _T07dynamic3FooC0A4PropSifm	// dynamic.Foo.dynamicProp.materializeForSet : Swift.Int
-// CHECK-NEXT:   #Foo.subscript!materializeForSet.1: (Foo) -> (Builtin.RawPointer, inout Builtin.UnsafeValueBuffer, Int) -> (Builtin.RawPointer, Builtin.RawPointer?) : _T07dynamic3FooC9subscriptS2iAA_tcfm	// dynamic.Foo.subscript.materializeForSet : (dynamic : Swift.Int) -> Swift.Int
 // CHECK-NEXT:   #Foo.overriddenByDynamic!1: {{.*}} : _T07dynamic3FooC19overriddenByDynamic{{[_0-9a-zA-Z]*}}
 // CHECK-NEXT:   #Foo.deinit!deallocator: {{.*}}
 // CHECK-NEXT: }
 
 // Vtable uses a dynamic thunk for dynamic overrides
 // CHECK-LABEL: sil_vtable Subclass {
-// CHECK-LABEL:   #Foo.overriddenByDynamic!1: {{.*}} : public _T07dynamic8SubclassC19overriddenByDynamic{{[_0-9a-zA-Z]*}}FTD
+// CHECK:   #Foo.overriddenByDynamic!1: {{.*}} : public _T07dynamic8SubclassC19overriddenByDynamic{{[_0-9a-zA-Z]*}}FTD
+// CHECK: }
 
+// No vtable entry for override of @objc extension property
+// CHECK-LABEL: sil_vtable SubExt {
+// CHECK-NEXT: #BaseExt.init!initializer.1: (BaseExt.Type) -> () -> BaseExt : _T07dynamic6SubExtCACycfc // dynamic.SubExt.init () -> dynamic.SubExt
+// CHECK-NEXT: #SubExt.deinit!deallocator: _T07dynamic6SubExtCfD // dynamic.SubExt.__deallocating_deinit
+// CHECK-NEXT: }

--- a/test/SILGen/errors.swift
+++ b/test/SILGen/errors.swift
@@ -169,15 +169,6 @@ class HasThrowingInit {
     field = value
   }
 }
-// CHECK-LABEL: sil hidden @_T06errors15HasThrowingInit{{.*}} : $@convention(method) (Int, @owned HasThrowingInit) -> (@owned HasThrowingInit, @error Error) {
-// CHECK:      [[T0:%.*]] = mark_uninitialized [rootself] %1 : $HasThrowingInit
-// CHECK-NEXT: [[BORROWED_T0:%.*]] = begin_borrow [[T0]]
-// CHECK-NEXT: [[T1:%.*]] = ref_element_addr [[BORROWED_T0]] : $HasThrowingInit
-// CHECK-NEXT: assign %0 to [[T1]] : $*Int
-// CHECK-NEXT: end_borrow [[BORROWED_T0]] from [[T0]]
-// CHECK-NEXT: [[T0_RET:%.*]] = copy_value [[T0]]
-// CHECK-NEXT: destroy_value [[T0]]
-// CHECK-NEXT: return [[T0_RET]] : $HasThrowingInit
 
 // CHECK-LABEL: sil hidden @_T06errors15HasThrowingInit{{.*}} : $@convention(method) (Int, @thick HasThrowingInit.Type) -> (@owned HasThrowingInit, @error Error)
 // CHECK:      [[SELF:%.*]] = alloc_ref $HasThrowingInit
@@ -188,6 +179,16 @@ class HasThrowingInit {
 // CHECK:    bb2([[ERROR:%.*]] : $Error):
 // CHECK-NEXT: builtin "willThrow"
 // CHECK-NEXT: throw [[ERROR]]
+
+// CHECK-LABEL: sil hidden @_T06errors15HasThrowingInit{{.*}} : $@convention(method) (Int, @owned HasThrowingInit) -> (@owned HasThrowingInit, @error Error) {
+// CHECK:      [[T0:%.*]] = mark_uninitialized [rootself] %1 : $HasThrowingInit
+// CHECK-NEXT: [[BORROWED_T0:%.*]] = begin_borrow [[T0]]
+// CHECK-NEXT: [[T1:%.*]] = ref_element_addr [[BORROWED_T0]] : $HasThrowingInit
+// CHECK-NEXT: assign %0 to [[T1]] : $*Int
+// CHECK-NEXT: end_borrow [[BORROWED_T0]] from [[T0]]
+// CHECK-NEXT: [[T0_RET:%.*]] = copy_value [[T0]]
+// CHECK-NEXT: destroy_value [[T0]]
+// CHECK-NEXT: return [[T0_RET]] : $HasThrowingInit
 
 
 enum ColorError : Error {
@@ -939,8 +940,8 @@ func testOptionalTryNeverFailsAddressOnlyVar<T>(_ obj: T) {
 class SomeErrorClass : Error { }
 
 // CHECK-LABEL: sil_vtable SomeErrorClass
-// CHECK-NEXT:   #SomeErrorClass.deinit!deallocator: _T06errors14SomeErrorClassCfD
 // CHECK-NEXT:   #SomeErrorClass.init!initializer.1: {{.*}} : _T06errors14SomeErrorClassCACycfc
+// CHECK-NEXT:   #SomeErrorClass.deinit!deallocator: _T06errors14SomeErrorClassCfD
 // CHECK-NEXT: }
 
 class OtherErrorSub : OtherError { }

--- a/test/SILGen/final.swift
+++ b/test/SILGen/final.swift
@@ -36,8 +36,8 @@ func testDirectDispatch(c : TestClass) -> Int {
 // Verify that the non-overriding final methods don't get emitted to the vtable.
 // CHECK-LABEL: sil_vtable TestClass {
 // CHECK-NEXT:  #TestClass.baseMethod!1: {{.*}} : _T05final9TestClassC10baseMethod{{[_0-9a-zA-Z]*}}F
-// CHECK-NEXT:  #TestClass.deinit!
 // CHECK-NEXT:  #TestClass.init!initializer.1: {{.*}} : _T05final9TestClassC{{[_0-9a-zA-Z]*}}fc
+// CHECK-NEXT:  #TestClass.deinit!
 // CHECK-NEXT: }
 
 // Verify that overriding final methods don't get emitted to the vtable.

--- a/test/SILGen/functions.swift
+++ b/test/SILGen/functions.swift
@@ -41,11 +41,11 @@ class SomeClass {
   // -- Constructors and methods are uncurried in 'self'
   // -- Instance methods use 'method' cc
 
-  // CHECK-LABEL: sil hidden @_T09functions9SomeClassC{{[_0-9a-zA-Z]*}}fc : $@convention(method) (Builtin.Int64, Builtin.Int64, @owned SomeClass) -> @owned SomeClass
-  // CHECK: bb0(%0 : $Builtin.Int64, %1 : $Builtin.Int64, %2 : $SomeClass):
-
   // CHECK-LABEL: sil hidden @_T09functions9SomeClassC{{[_0-9a-zA-Z]*}}fC : $@convention(method) (Builtin.Int64, Builtin.Int64, @thick SomeClass.Type) -> @owned SomeClass
   // CHECK: bb0(%0 : $Builtin.Int64, %1 : $Builtin.Int64, %2 : $@thick SomeClass.Type):
+
+  // CHECK-LABEL: sil hidden @_T09functions9SomeClassC{{[_0-9a-zA-Z]*}}fc : $@convention(method) (Builtin.Int64, Builtin.Int64, @owned SomeClass) -> @owned SomeClass
+  // CHECK: bb0(%0 : $Builtin.Int64, %1 : $Builtin.Int64, %2 : $SomeClass):
   init(x:Int, y:Int) {}
 
   // CHECK-LABEL: sil hidden @_T09functions9SomeClassC6method{{[_0-9a-zA-Z]*}}F : $@convention(method) (Builtin.Int64, @guaranteed SomeClass) -> () 

--- a/test/SILGen/guaranteed_self.swift
+++ b/test/SILGen/guaranteed_self.swift
@@ -56,6 +56,23 @@ struct S: Fooable {
 
   var prop1: Int = 0
 
+  // Getter for prop1
+  // CHECK-LABEL: sil hidden [transparent] @_T015guaranteed_self1SV5prop1Sifg : $@convention(method) (@guaranteed S) -> Int
+  // CHECK:       bb0([[SELF:%.*]] : $S):
+  // CHECK-NOT:     destroy_value [[SELF]]
+
+  // Setter for prop1
+  // CHECK-LABEL: sil hidden [transparent] @_T015guaranteed_self1SV5prop1Sifs : $@convention(method) (Int, @inout S) -> ()
+  // CHECK:       bb0({{.*}} [[SELF_ADDR:%.*]] : $*S):
+  // CHECK-NOT:     load [[SELF_ADDR]]
+  // CHECK-NOT:     destroy_addr [[SELF_ADDR]]
+
+  // materializeForSet for prop1
+  // CHECK-LABEL: sil hidden [transparent] @_T015guaranteed_self1SV5prop1Sifm : $@convention(method) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout S) -> (Builtin.RawPointer, Optional<Builtin.RawPointer>)
+  // CHECK:       bb0({{.*}} [[SELF_ADDR:%.*]] : $*S):
+  // CHECK-NOT:     load [[SELF_ADDR]]
+  // CHECK-NOT:     destroy_addr [[SELF_ADDR]]
+
   var prop2: Int {
     // CHECK-LABEL: sil hidden @_T015guaranteed_self1SV5prop2Sifg : $@convention(method) (@guaranteed S) -> Int
     // CHECK:       bb0([[SELF:%.*]] : $S):
@@ -79,23 +96,6 @@ struct S: Fooable {
     // CHECK-NOT:     destroy_value [[SELF]]
     nonmutating set { }
   }
-
-  // Getter for prop1
-  // CHECK-LABEL: sil hidden [transparent] @_T015guaranteed_self1SV5prop1Sifg : $@convention(method) (@guaranteed S) -> Int
-  // CHECK:       bb0([[SELF:%.*]] : $S):
-  // CHECK-NOT:     destroy_value [[SELF]]
-
-  // Setter for prop1
-  // CHECK-LABEL: sil hidden [transparent] @_T015guaranteed_self1SV5prop1Sifs : $@convention(method) (Int, @inout S) -> ()
-  // CHECK:       bb0({{.*}} [[SELF_ADDR:%.*]] : $*S):
-  // CHECK-NOT:     load [[SELF_ADDR]]
-  // CHECK-NOT:     destroy_addr [[SELF_ADDR]]
-
-  // materializeForSet for prop1
-  // CHECK-LABEL: sil hidden [transparent] @_T015guaranteed_self1SV5prop1Sifm : $@convention(method) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout S) -> (Builtin.RawPointer, Optional<Builtin.RawPointer>)
-  // CHECK:       bb0({{.*}} [[SELF_ADDR:%.*]] : $*S):
-  // CHECK-NOT:     load [[SELF_ADDR]]
-  // CHECK-NOT:     destroy_addr [[SELF_ADDR]]
 }
 
 // Witness thunk for nonmutating 'foo'

--- a/test/SILGen/ivar_destroyer.swift
+++ b/test/SILGen/ivar_destroyer.swift
@@ -34,8 +34,8 @@ class DerivedClassWithNonTrivialProperties : RootClassWithoutProperties {
 // CHECK-NEXT:    return [[RESULT]]
 
 // CHECK-LABEL: sil_vtable RootClassWithoutProperties {
-// CHECK-NEXT:    #RootClassWithoutProperties.deinit!deallocator
 // CHECK-NEXT:    #RootClassWithoutProperties.init!initializer.1
+// CHECK-NEXT:    #RootClassWithoutProperties.deinit!deallocator
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: sil_vtable RootClassWithTrivialProperties {
@@ -45,16 +45,16 @@ class DerivedClassWithNonTrivialProperties : RootClassWithoutProperties {
 // CHECK-NEXT:    #RootClassWithTrivialProperties.y!getter.1
 // CHECK-NEXT:    #RootClassWithTrivialProperties.y!setter.1
 // CHECK-NEXT:    #RootClassWithTrivialProperties.y!materializeForSet.1
-// CHECK-NEXT:    #RootClassWithTrivialProperties.deinit!deallocator
 // CHECK-NEXT:    #RootClassWithTrivialProperties.init!initializer.1
+// CHECK-NEXT:    #RootClassWithTrivialProperties.deinit!deallocator
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: sil_vtable RootClassWithNonTrivialProperties {
 // CHECK-NEXT:    #RootClassWithNonTrivialProperties.x!getter.1
 // CHECK-NEXT:    #RootClassWithNonTrivialProperties.x!setter.1
 // CHECK-NEXT:    #RootClassWithNonTrivialProperties.x!materializeForSet.1
-// CHECK-NEXT:    #RootClassWithNonTrivialProperties.deinit!deallocator
 // CHECK-NEXT:    #RootClassWithNonTrivialProperties.init!initializer.1
+// CHECK-NEXT:    #RootClassWithNonTrivialProperties.deinit!deallocator
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: sil_vtable DerivedClassWithTrivialProperties {

--- a/test/SILGen/ivar_destroyer.swift
+++ b/test/SILGen/ivar_destroyer.swift
@@ -39,37 +39,37 @@ class DerivedClassWithNonTrivialProperties : RootClassWithoutProperties {
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: sil_vtable RootClassWithTrivialProperties {
-// CHECK-NEXT:    #RootClassWithTrivialProperties.deinit!deallocator
 // CHECK-NEXT:    #RootClassWithTrivialProperties.x!getter.1
 // CHECK-NEXT:    #RootClassWithTrivialProperties.x!setter.1
 // CHECK-NEXT:    #RootClassWithTrivialProperties.x!materializeForSet.1
 // CHECK-NEXT:    #RootClassWithTrivialProperties.y!getter.1
 // CHECK-NEXT:    #RootClassWithTrivialProperties.y!setter.1
 // CHECK-NEXT:    #RootClassWithTrivialProperties.y!materializeForSet.1
+// CHECK-NEXT:    #RootClassWithTrivialProperties.deinit!deallocator
 // CHECK-NEXT:    #RootClassWithTrivialProperties.init!initializer.1
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: sil_vtable RootClassWithNonTrivialProperties {
-// CHECK-NEXT:    #RootClassWithNonTrivialProperties.deinit!deallocator
 // CHECK-NEXT:    #RootClassWithNonTrivialProperties.x!getter.1
 // CHECK-NEXT:    #RootClassWithNonTrivialProperties.x!setter.1
 // CHECK-NEXT:    #RootClassWithNonTrivialProperties.x!materializeForSet.1
+// CHECK-NEXT:    #RootClassWithNonTrivialProperties.deinit!deallocator
 // CHECK-NEXT:    #RootClassWithNonTrivialProperties.init!initializer.1
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: sil_vtable DerivedClassWithTrivialProperties {
 // CHECK-NEXT:    #RootClassWithoutProperties.init!initializer.1
-// CHECK-NEXT:    #DerivedClassWithTrivialProperties.deinit!deallocator
 // CHECK-NEXT:    #DerivedClassWithTrivialProperties.z!getter.1
 // CHECK-NEXT:    #DerivedClassWithTrivialProperties.z!setter.1
 // CHECK-NEXT:    #DerivedClassWithTrivialProperties.z!materializeForSet.1
+// CHECK-NEXT:    #DerivedClassWithTrivialProperties.deinit!deallocator
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: sil_vtable DerivedClassWithNonTrivialProperties {
 // CHECK-NEXT:    #RootClassWithoutProperties.init!initializer.1
-// CHECK-NEXT:    #DerivedClassWithNonTrivialProperties.deinit!deallocator
-// CHECK-NEXT:    #DerivedClassWithNonTrivialProperties!ivardestroyer.1
 // CHECK-NEXT:    #DerivedClassWithNonTrivialProperties.z!getter.1
 // CHECK-NEXT:    #DerivedClassWithNonTrivialProperties.z!setter.1
 // CHECK-NEXT:    #DerivedClassWithNonTrivialProperties.z!materializeForSet.1
+// CHECK-NEXT:    #DerivedClassWithNonTrivialProperties.deinit!deallocator
+// CHECK-NEXT:    #DerivedClassWithNonTrivialProperties!ivardestroyer.1
 // CHECK-NEXT:  }

--- a/test/SILGen/materializeForSet.swift
+++ b/test/SILGen/materializeForSet.swift
@@ -3,10 +3,16 @@
 class Base {
   var stored: Int = 0
 
-// The ordering here is unfortunate: we generate the property
-// getters and setters after we've processed the decl.
+// CHECK-LABEL: sil hidden [transparent] @_T017materializeForSet4BaseC6storedSifm : $@convention(method) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @guaranteed Base) -> (Builtin.RawPointer, Optional<Builtin.RawPointer>) {
+// CHECK: bb0([[BUFFER:%.*]] : $Builtin.RawPointer, [[STORAGE:%.*]] : $*Builtin.UnsafeValueBuffer, [[SELF:%.*]] : $Base):
+// CHECK:   [[T0:%.*]] = ref_element_addr [[SELF]] : $Base, #Base.stored
+// CHECK:   [[T1:%.*]] = address_to_pointer [[T0]] : $*Int to $Builtin.RawPointer
+// CHECK:   [[T2:%.*]] = enum $Optional<Builtin.RawPointer>, #Optional.none
+// CHECK:   [[T3:%.*]] = tuple ([[T1]] : $Builtin.RawPointer, [[T2]] : $Optional<Builtin.RawPointer>)
+// CHECK:   return [[T3]] : $(Builtin.RawPointer, Optional<Builtin.RawPointer>)
+// CHECK: }
 
-  // CHECK-LABEL: sil hidden [transparent] @_T017materializeForSet4BaseC8computedSifmytfU_ : $@convention(method) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout Base, @thick Base.Type) -> () {
+// CHECK-LABEL: sil hidden [transparent] @_T017materializeForSet4BaseC8computedSifmytfU_ : $@convention(method) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout Base, @thick Base.Type) -> () {
 // CHECK: bb0([[BUFFER:%.*]] : $Builtin.RawPointer, [[STORAGE:%.*]] : $*Builtin.UnsafeValueBuffer, [[SELF:%.*]] : $*Base, [[SELFTYPE:%.*]] : $@thick Base.Type):
 // CHECK:   [[T0:%.*]] = load_borrow [[SELF]]
 // CHECK:   [[T1:%.*]] = pointer_to_address [[BUFFER]] : $Builtin.RawPointer to [strict] $*Int
@@ -26,15 +32,6 @@ class Base {
 // CHECK:   [[T3:%.*]] = enum $Optional<Builtin.RawPointer>, #Optional.some!enumelt.1, [[T2]] : $Builtin.RawPointer
 // CHECK:   [[T4:%.*]] = tuple ([[BUFFER]] : $Builtin.RawPointer, [[T3]] : $Optional<Builtin.RawPointer>)
 // CHECK:   return [[T4]] : $(Builtin.RawPointer, Optional<Builtin.RawPointer>)
-// CHECK: }
-
-// CHECK-LABEL: sil hidden [transparent] @_T017materializeForSet4BaseC6storedSifm : $@convention(method) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @guaranteed Base) -> (Builtin.RawPointer, Optional<Builtin.RawPointer>) {
-// CHECK: bb0([[BUFFER:%.*]] : $Builtin.RawPointer, [[STORAGE:%.*]] : $*Builtin.UnsafeValueBuffer, [[SELF:%.*]] : $Base):
-// CHECK:   [[T0:%.*]] = ref_element_addr [[SELF]] : $Base, #Base.stored
-// CHECK:   [[T1:%.*]] = address_to_pointer [[T0]] : $*Int to $Builtin.RawPointer
-// CHECK:   [[T2:%.*]] = enum $Optional<Builtin.RawPointer>, #Optional.none
-// CHECK:   [[T3:%.*]] = tuple ([[T1]] : $Builtin.RawPointer, [[T2]] : $Optional<Builtin.RawPointer>)
-// CHECK:   return [[T3]] : $(Builtin.RawPointer, Optional<Builtin.RawPointer>)
 // CHECK: }
 
   var computed: Int {
@@ -579,12 +576,12 @@ func testMaterializedSetter() {
 }
 
 // CHECK-LABEL: sil_vtable DerivedForOverride {
-// CHECK:   #BaseForOverride.valueComputed!getter.1: (BaseForOverride) -> () -> Int : _T017materializeForSet07DerivedB8OverrideC13valueComputedSifg
-// CHECK:   #BaseForOverride.valueComputed!setter.1: (BaseForOverride) -> (Int) -> () : _T017materializeForSet07DerivedB8OverrideC13valueComputedSifs
-// CHECK:   #BaseForOverride.valueComputed!materializeForSet.1: (BaseForOverride) -> (Builtin.RawPointer, inout Builtin.UnsafeValueBuffer) -> (Builtin.RawPointer, Builtin.RawPointer?) : _T017materializeForSet07DerivedB8OverrideC13valueComputedSifm
 // CHECK:   #BaseForOverride.valueStored!getter.1: (BaseForOverride) -> () -> Int : _T017materializeForSet07DerivedB8OverrideC11valueStoredSifg
 // CHECK:   #BaseForOverride.valueStored!setter.1: (BaseForOverride) -> (Int) -> () : _T017materializeForSet07DerivedB8OverrideC11valueStoredSifs
 // CHECK:   #BaseForOverride.valueStored!materializeForSet.1: (BaseForOverride) -> (Builtin.RawPointer, inout Builtin.UnsafeValueBuffer) -> (Builtin.RawPointer, Builtin.RawPointer?) : _T017materializeForSet07DerivedB8OverrideC11valueStoredSifm
+// CHECK:   #BaseForOverride.valueComputed!getter.1: (BaseForOverride) -> () -> Int : _T017materializeForSet07DerivedB8OverrideC13valueComputedSifg
+// CHECK:   #BaseForOverride.valueComputed!setter.1: (BaseForOverride) -> (Int) -> () : _T017materializeForSet07DerivedB8OverrideC13valueComputedSifs
+// CHECK:   #BaseForOverride.valueComputed!materializeForSet.1: (BaseForOverride) -> (Builtin.RawPointer, inout Builtin.UnsafeValueBuffer) -> (Builtin.RawPointer, Builtin.RawPointer?) : _T017materializeForSet07DerivedB8OverrideC13valueComputedSifm
 // CHECK: }
 
 // CHECK-LABEL: sil_witness_table hidden Bill: Totalled module materializeForSet {

--- a/test/SILGen/objc_attr_NSManaged.swift
+++ b/test/SILGen/objc_attr_NSManaged.swift
@@ -104,9 +104,9 @@ extension ProtoAdopter {
 // CHECK-LABEL: sil_vtable SwiftGizmo {
 // CHECK-NEXT:   #SwiftGizmo.modifyX!1: {{.*}} : _T019objc_attr_NSManaged10SwiftGizmoC7modifyXyyF
 // CHECK-NEXT:   #SwiftGizmo.testFunc!1: {{.*}} : _T019objc_attr_NSManaged10SwiftGizmoC8testFuncyyF
-// CHECK-NEXT:   #SwiftGizmo.deinit!deallocator: _T019objc_attr_NSManaged10SwiftGizmoCfD
 // CHECK-NEXT:   #SwiftGizmo.init!initializer.1: {{.*}} : _T019objc_attr_NSManaged10SwiftGizmoCSQyACGycfc
 // CHECK-NEXT:   #SwiftGizmo.init!initializer.1: {{.*}} : _T019objc_attr_NSManaged10SwiftGizmoCSQyACGSi7bellsOn_tcfc
+// CHECK-NEXT:   #SwiftGizmo.deinit!deallocator: _T019objc_attr_NSManaged10SwiftGizmoCfD
 // CHECK-NEXT: }
 
 // CHECK-LABEL: sil_vtable FinalGizmo {

--- a/test/SILGen/sil_locations_top_level.swift
+++ b/test/SILGen/sil_locations_top_level.swift
@@ -19,30 +19,29 @@ var topLevelObject2:TopLevelObjectTyWithoutDestructor
 // CHECK: integer_literal ${{.*}}, 0, {{.*}} top_level
 // CHECK: return    {{.*}} top_level
 
-// Check default constructor
-// CHECK-LABEL: sil_locations_top_level.TopLevelObjectTy.init
-// CHECK: bb
-// CHECK: return {{.*}}// {{.*}} line:5:12
-
 // Check allocating initializer
 // CHECK-LABEL: sil_locations_top_level.TopLevelObjectTy.__allocating_init
 // CHECK: sil hidden @_T023sil_locations_top_level16TopLevelObjectTyC{{[_0-9a-zA-Z]*}}fC
 // CHECK: alloc_ref {{.*}}line:5:3:auto_gen
 // CHECK: function_ref
 
+// Check default constructor
+// CHECK-LABEL: sil_locations_top_level.TopLevelObjectTy.init
+// CHECK: bb
+// CHECK: return {{.*}}// {{.*}} line:5:12
+
 // Check explicit destructor
 // CHECK_LABEL: sil hidden @_T023sil_locations_top_level16TopLevelObjectTyCfd
 // CHECK:   return {{.*}}// {{.*}} line:8:3
+
+// Check allocating constructor
+// CHECK-LABEL: sil_locations_top_level.TopLevelObjectTyWithoutDestructor.__allocating_init
+// CHECK: return {{.*}}// {{.*}} line:14:3:imp_return:auto_gen
 
 // Check explicit constructor
 // FIXME: The ConstructorDecl location is wrong here (looks like it's wrong in the AST).
 // CHECK-LABEL: sil hidden @_T023sil_locations_top_level33TopLevelObjectTyWithoutDestructorC{{[_0-9a-zA-Z]*}}fc
 // CHECK: return {{.*}}// {{.*}} line:14:3:imp_return
-
-
-// Check allocating constructor
-// CHECK-LABEL: sil_locations_top_level.TopLevelObjectTyWithoutDestructor.__allocating_init
-// CHECK: return {{.*}}// {{.*}} line:14:3:imp_return:auto_gen
 
 // Check implicit destructor
 // CHECK_LABEL: sil hidden @_T023sil_locations_top_level33TopLevelObjectTyWithoutDestructorCfd

--- a/test/SILGen/specialize_attr.swift
+++ b/test/SILGen/specialize_attr.swift
@@ -91,18 +91,18 @@ public class Addressable<Element> : TestSubscriptable {
   }
 }
 
-// Addressable.subscript.unsafeAddressor with _specialize
-// CHECK-LABEL: sil [_specialize exported: false, kind: full, where Element == Int] @_T015specialize_attr11AddressableC9subscriptxSicflu : $@convention(method) <Element> (Int, @guaranteed Addressable<Element>) -> UnsafePointer<Element> {
-
-// Addressable.subscript.unsafeMutableAddressor with _specialize
-// CHECK-LABEL: sil [_specialize exported: false, kind: full, where Element == Int] @_T015specialize_attr11AddressableC9subscriptxSicfau : $@convention(method) <Element> (Int, @guaranteed Addressable<Element>) -> UnsafeMutablePointer<Element> {
-
-
 // Addressable.subscript.getter with no attribute
 // CHECK-LABEL: sil [transparent] [fragile] @_T015specialize_attr11AddressableC9subscriptxSicfg : $@convention(method) <Element> (Int, @guaranteed Addressable<Element>) -> @out Element {
+
+// Addressable.subscript.unsafeAddressor with _specialize
+// CHECK-LABEL: sil [_specialize exported: false, kind: full, where Element == Int] @_T015specialize_attr11AddressableC9subscriptxSicflu : $@convention(method) <Element> (Int, @guaranteed Addressable<Element>) -> UnsafePointer<Element> {
 
 // Addressable.subscript.setter with no attribute
 // CHECK-LABEL: sil [transparent] [fragile] @_T015specialize_attr11AddressableC9subscriptxSicfs : $@convention(method) <Element> (@in Element, Int, @guaranteed Addressable<Element>) -> () {
 
+// Addressable.subscript.unsafeMutableAddressor with _specialize
+// CHECK-LABEL: sil [_specialize exported: false, kind: full, where Element == Int] @_T015specialize_attr11AddressableC9subscriptxSicfau : $@convention(method) <Element> (Int, @guaranteed Addressable<Element>) -> UnsafeMutablePointer<Element> {
+
 // Addressable.subscript.materializeForSet with no attribute
 // CHECK-LABEL: sil [transparent] [fragile] @_T015specialize_attr11AddressableC9subscriptxSicfm : $@convention(method) <Element> (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, Int, @guaranteed Addressable<Element>) -> (Builtin.RawPointer, Optional<Builtin.RawPointer>) {
+


### PR DESCRIPTION
This PR introduces a SILVTableVisitor class which allows us to share some logic between SILGen and IRGen.

This will be used to emit multiple vtable entries per method and add class resilience, both of which will complicate vtable construction.