### PR TITLE
String prototype: FCCNormalizedSegments

### DIFF
--- a/stdlib/public/core/UnboundCapacity.swift
+++ b/stdlib/public/core/UnboundCapacity.swift
@@ -83,17 +83,18 @@ extension UnboundCapacity {
   /// Converts our contents into an array with at least the given
   /// capacity, and presents it to `body` for mutation.
   //
-  // Michael NOTE: temporarily public, should probably make private
-  //
   // Michael NOTE: forwarding version added due to odd linker behavior. Linker
-  // couldn't find the version with a default argument.
+  // couldn't find the version with a default argument. This is just for the
+  // prototype, we should remove and restore the default parameter.
   //
-  public mutating func withMutableArray<R>(
+  // Michael NOTE: I'll also be dropping the use of this in favor of adding a
+  // withUnsafeMutableBufferPointer.
+  internal mutating func withMutableArray<R>(
     body: (inout [Base.Iterator.Element]) throws->R
   ) rethrows -> R {
     return try withMutableArray(minCapacity: 0, body: body)
   }
-  public mutating func withMutableArray<R>(
+  internal mutating func withMutableArray<R>(
     minCapacity: Int,
     body: (inout [Base.Iterator.Element]) throws->R
   ) rethrows -> R {
@@ -121,9 +122,7 @@ extension UnboundCapacity {
 
   /// Returns the small (`Base`) representation iff we have it and it has at
   /// least the given capacity.
-  ///
-  /// Michael: I made this public to squash linker errors in prototypes
-  public func _small(minCapacity: Int) -> Base? {
+  internal func _small(minCapacity: Int) -> Base? {
     if case .small(let base) = self,
       minCapacity <= numericCast(base.maxCapacity) {
       return base

--- a/stdlib/public/core/UnboundCapacity.swift
+++ b/stdlib/public/core/UnboundCapacity.swift
@@ -82,8 +82,19 @@ extension UnboundCapacity {
 
   /// Converts our contents into an array with at least the given
   /// capacity, and presents it to `body` for mutation.
-  internal mutating func withMutableArray<R>(
-    minCapacity: Int = 0,
+  //
+  // Michael NOTE: temporarily public, should probably make private
+  //
+  // Michael NOTE: forwarding version added due to odd linker behavior. Linker
+  // couldn't find the version with a default argument.
+  //
+  public mutating func withMutableArray<R>(
+    body: (inout [Base.Iterator.Element]) throws->R
+  ) rethrows -> R {
+    return try withMutableArray(minCapacity: 0, body: body)
+  }
+  public mutating func withMutableArray<R>(
+    minCapacity: Int,
     body: (inout [Base.Iterator.Element]) throws->R
   ) rethrows -> R {
     var result: [Base.Iterator.Element]
@@ -110,7 +121,9 @@ extension UnboundCapacity {
 
   /// Returns the small (`Base`) representation iff we have it and it has at
   /// least the given capacity.
-  internal func _small(minCapacity: Int) -> Base? {
+  ///
+  /// Michael: I made this public to squash linker errors in prototypes
+  public func _small(minCapacity: Int) -> Base? {
     if case .small(let base) = self,
       minCapacity <= numericCast(base.maxCapacity) {
       return base

--- a/stdlib/public/core/UnicodeViews.swift
+++ b/stdlib/public/core/UnicodeViews.swift
@@ -533,8 +533,7 @@ internal func _makeFCCNormalizer() -> OpaquePointer {
   return ret!
 }
 
-// Michael NOTE: I don't think this is thread safe. It seems like the
-// Normalizer2Impl's trie pointer can be modified even by simple queries.
+// Michael NOTE: made public for prototype, should be internal
 public var _fccNormalizer = _makeFCCNormalizer()
 
 extension _UnicodeViews {

--- a/stdlib/public/core/UnicodeViews.swift
+++ b/stdlib/public/core/UnicodeViews.swift
@@ -22,11 +22,11 @@ public func _debugLog(_ arg0: @autoclosure ()->Any, _ arg1: @autoclosure ()->Any
   print(arg0(), arg1())
 }
 
-internal func __swift_stdlib_U_SUCCESS(_ x: __swift_stdlib_UErrorCode) -> Bool {
+public func __swift_stdlib_U_SUCCESS(_ x: __swift_stdlib_UErrorCode) -> Bool {
  return x.rawValue <= __swift_stdlib_U_ZERO_ERROR.rawValue
 }
 
-internal func __swift_stdlib_U_FAILURE(_ x: __swift_stdlib_UErrorCode) -> Bool {
+public func __swift_stdlib_U_FAILURE(_ x: __swift_stdlib_UErrorCode) -> Bool {
  return x.rawValue > __swift_stdlib_U_ZERO_ERROR.rawValue
 }
 
@@ -533,7 +533,9 @@ internal func _makeFCCNormalizer() -> OpaquePointer {
   return ret!
 }
 
-internal var _fccNormalizer = _makeFCCNormalizer()
+// Michael NOTE: I don't think this is thread safe. It seems like the
+// Normalizer2Impl's trie pointer can be modified even by simple queries.
+public var _fccNormalizer = _makeFCCNormalizer()
 
 extension _UnicodeViews {
   

--- a/stdlib/public/stubs/UnicodeNormalization.cpp
+++ b/stdlib/public/stubs/UnicodeNormalization.cpp
@@ -379,3 +379,10 @@ swift::__swift_stdlib_unorm2_normalize(const __swift_stdlib_UNormalizer2 *norm2,
                           ptr_cast<UChar>(dest), capacity,
                           ptr_cast<UErrorCode>(pErrorCode));
 }
+
+swift::__swift_stdlib_UBool
+swift::__swift_stdlib_unorm2_hasBoundaryBefore(
+  const __swift_stdlib_UNormalizer2 *norm2,
+  __swift_stdlib_UChar32 c) {
+  return unorm2_hasBoundaryBefore(ptr_cast<const UNormalizer2>(norm2), c);
+}

--- a/test/Prototypes/string_prototype/StringComparison.swift
+++ b/test/Prototypes/string_prototype/StringComparison.swift
@@ -1,6 +1,7 @@
 // Prototype code for an eventual StringComparison.swift
 
 import Swift
+import SwiftShims
 
 // TODO: put these on protocol decl, and have impls provide functionality
 // instead
@@ -505,7 +506,7 @@ extension UnsignedInteger {
 extension Character {
   func ordered(with other: Character) -> SortOrder {
     // FIXME: this will do UCA-based ordering :-(. We can't even use the unicode
-    // scalars as those are not guarenteed to be canonicalized :-(. Such
+    // scalars as those are not guaranteed to be canonicalized :-(. Such
     // sadness.
     if _fastPath(self == other) {
       return .same
@@ -632,4 +633,394 @@ where
     }
   }
 }
+
+//
+// A "normalization segment" is a sequence that starts with a unicode scalar
+// value which has a normalization boundary before it, and includes all
+// subsequent unicode scalar values who do not.
+//
+// A "native index" is an index into the original String's code units. It can be
+// interchanged with many of the other String indices. TODO: I think this is
+// what UnicodeView solves, phrase it in those terms.
+//
+//
+//
+
+// Michael TODO: Why doesn't the following work?
+//
+// extension UnsignedInteger : _DefaultConstructible {
+//   init() { self = 0 }
+// }
+
+extension UInt16 : _DefaultConstructible {}
+
+typealias UTF16CodeUnitBuffer =
+  UnboundCapacity<_BoundedCapacity<_Array8<UInt16>>>
+
+// A normalization segment that is FCC-normalized. This is a collection of
+// normalized UTF16 code units.
+//
+// Note that indices into a normalized segment are not native indices, and do
+// not necessarily correspond to any particular code unit as they may of
+// undergone composition or decomposition. Thus, FCCNormalizedSegments are not
+// suitable for queries needing sub-segment granularity. However,
+// FCCNormalizedSegments are suitable for segment-level-or-coarser granularity
+// queries, which include any grapheme-level queries as segments are sub-
+// grapheme.
+//
+// TODO: Explore coalescing small segments together
+struct FCCNormalizedSegment : BidirectionalCollection {
+  let buffer: UTF16CodeUnitBuffer
+
+  init(_ buffer: UTF16CodeUnitBuffer) {
+    self.buffer = buffer
+  }
+  init() {
+    self.buffer = UTF16CodeUnitBuffer()
+  }
+
+  typealias Index = UTF16CodeUnitBuffer.Index
+
+  public var startIndex : Index {
+    return buffer.startIndex
+  }
+  public var endIndex : Index {
+    return buffer.endIndex
+  }
+  public subscript(i: Index) -> UInt16 {
+    return buffer[i]
+  }
+  public func index(after i: Index) -> Index {
+    return buffer.index(after: i)
+  }
+  public func index(before i: Index) -> Index {
+    return buffer.index(before: i)
+  }
+  public typealias SubSequence = BidirectionalSlice<FCCNormalizedSegment>
+}
+
+// Initialize an UnboundCapacity from any sequence
+extension UnboundCapacity {
+  public init<S : Sequence>(_ elements: S)
+  where S.Iterator.Element == Base.Iterator.Element {
+    self.init()
+    self.reserveCapacity(elements.underestimatedCount)
+    for elt in elements {
+      self.append(elt)
+    }
+  }
+}
+
+// Ask ICU if the given unicode scalar value has a normalization boundary before
+// it, that is it begins a new normalization segment.
+public func _hasBoundary(before value: UInt32) -> Bool {
+  return __swift_stdlib_unorm2_hasBoundaryBefore(_fccNormalizer, value) != 0
+}
+
+struct FCCNormalizedLazySegments<
+  CodeUnits : RandomAccessCollection,
+  FromEncoding : UnicodeEncoding
+> : BidirectionalCollection
+where
+  CodeUnits.Index == CodeUnits.SubSequence.Index,
+  CodeUnits.SubSequence : RandomAccessCollection,
+  CodeUnits.SubSequence == CodeUnits.SubSequence.SubSequence,
+  CodeUnits.Iterator.Element == CodeUnits.SubSequence.Iterator.Element,
+  CodeUnits.Iterator.Element == FromEncoding.EncodedScalar.Iterator.Element
+{
+  let codeUnits: CodeUnits
+
+  public init(
+    _ codeUnits: CodeUnits,
+    _: FromEncoding.Type = FromEncoding.self
+  ) {
+    self.codeUnits = codeUnits
+  }
+
+  public init(_ unicodeView: _UnicodeViews<CodeUnits, FromEncoding>) {
+    self.init(unicodeView.codeUnits)
+  }
+
+  private func priorSegment(
+    endingAt end: CodeUnits.Index
+  ) -> Index {
+    _debug("priorSegment endingAt: end")
+    precondition(end != codeUnits.startIndex)
+
+    // Decode scalars backwards, including them until we after we find one that
+    // has a boundary before it (and include that one).
+    var start = end
+    while start != codeUnits.startIndex {
+      // Include this scalar
+      let (scalarValue: value, startIndex: scalarStart, e)
+        = decodeOne(priorTo: start)
+      assert(e == start, "Internal inconsistency in decodeOne")
+
+      // Include this scalar
+      start = scalarStart
+
+      if _hasBoundary(before: value) {
+        // We're done
+        break
+      }
+    }
+
+    return Index(
+      nativeStartIndex: start,
+      nativeEndIndex: end,
+      segment: formSegment(from: start, until: end)
+    )
+  }
+
+  // Scan ahead and produce the next segment. `from` must be valid index (not
+  // end).
+  private func nextSegment(
+    startingAt start: CodeUnits.Index
+  ) -> Index {
+    if start == codeUnits.endIndex {
+      return endIndex
+    }
+
+    // Parse the first scalar, it will always be in the segment
+    var (scalarValue: value, startIndex: s, endIndex: end)
+      = decodeOne(from: start)
+    assert(_hasBoundary(before: value), "Not on segment boundary")
+    assert(s == start, "Internal inconsistency in decodeOne")
+
+    // Include any subsequent scalars that don't have boundaries before them
+    while end != codeUnits.endIndex {
+      let (scalarValue: value, startIndex: s, endIndex: scalarEnd)
+        = decodeOne(from: end)
+      assert(s == end, "Internal inconsistency in decodeOne")
+
+      if _hasBoundary(before: value) {
+        // Exclude this scalar
+        break
+      }
+
+      // Include this scalar
+      end = scalarEnd
+    }
+
+    return Index(
+      nativeStartIndex: start,
+      nativeEndIndex: end,
+      segment: formSegment(from: start, until: end)
+    )
+  }
+
+  // Normalize a segment. Indices must be on scalar boundaries.
+  private func formSegment(
+    from start: CodeUnits.Index,
+    until end: CodeUnits.Index
+  ) -> FCCNormalizedSegment {
+    precondition(start != end, "TODO: should we just have empty segment?")
+
+    let utf16CodeUnits = unicodeView(
+      from: start, until: end
+    ).scalarsTranscoded(
+      to: UTF16.self
+    )
+
+    // TODO: Find way to re-use the storage, maybe iterator pattern?
+    var buffer = UTF16CodeUnitBuffer(utf16CodeUnits.lazy.joined())
+
+    // Single scalar is trivial segment, no need to normalize
+    //
+    // TODO: fast pre-normalized checks (worth doing before calling over to
+    //       ICU)
+    //
+    // TODO: non-BMP can hit this path too
+    if end == codeUnits.index(after: start) {
+      return FCCNormalizedSegment(buffer)
+    }
+
+    assert(buffer.count > 0, "How did this happen? Failed precondition?")
+
+    // Ask ICU to normalize
+    //
+    // FIXME: withMutableArray kind of defeats the purpose of the small
+    // buffer :-(
+    buffer.withMutableArray { (array: inout [UInt16]) -> () in
+      array.withUnsafeBufferPointer {
+        // TODO: Just reserving one or two extra up front. If we're segment-
+        // based, should be finite number of possible decomps.
+        let originalCount = buffer.count
+        while true {
+          var error = __swift_stdlib_U_ZERO_ERROR
+          let usedCount = __swift_stdlib_unorm2_normalize(
+            _fccNormalizer, $0.baseAddress, numericCast($0.count),
+            &array, numericCast(array.count), &error)
+          if __swift_stdlib_U_SUCCESS(error) {
+            array.removeLast(array.count - numericCast(usedCount))
+            return
+          }
+          _sanityCheck(
+            error == __swift_stdlib_U_BUFFER_OVERFLOW_ERROR,
+            "Unknown normalization error")
+
+          // Maximum number of NFC to FCC decompositions for a single unicode
+          // scalar value
+          //
+          // TODO: what is this really? Should be much less
+          let maxDecompSize = 8
+
+          // Very loose canary to check that we haven't grown exceedingly large
+          // (indicative of error). Loose by assuming that every original
+          // character could be decomposed the maximum number of times. Without
+          // this, an error would loop until we run out of memory or the array
+          // is larger than 2^32 on 64bit platforms.
+          //
+          // FIXME: should go away by construction, or else be sanity check.
+          assert(buffer.count < originalCount*maxDecompSize)
+
+          // extend array storage by 25%
+          array.append(
+            contentsOf: repeatElement(0, count: (array.count + 3) >> 2))
+        }
+      }
+    }
+
+    return FCCNormalizedSegment(buffer)
+  }
+
+  // Decode one or more code units, returning the unicode scalar value and the
+  // number of code units parsed. `startingFrom` should be on scalar boundary
+  private func decodeOne(from start: CodeUnits.Index)
+    -> (scalarValue: UInt32,
+        startIndex: CodeUnits.Index,
+        endIndex: CodeUnits.Index) {
+    precondition(start != codeUnits.endIndex, "Given empty slice")
+
+    let encodedScalar = unicodeView(from: start).scalars.first!
+    return (scalarValue: encodedScalar.utf32[0],
+            startIndex: start,
+            endIndex: codeUnits.index(start, offsetBy: numericCast(encodedScalar.count)))
+  }
+
+  // As decodeOne, but in reverse. `priorTo` is the index after the last code
+  // unit in the scalar, i.e. it is exclusive.
+  private func decodeOne(priorTo end: CodeUnits.Index)
+    -> (scalarValue: UInt32,
+        startIndex: CodeUnits.Index,
+        endIndex: CodeUnits.Index) {
+    precondition(end != codeUnits.startIndex, "Given empty slice")
+
+    let encodedScalar = unicodeView(until: end).scalars.last!
+    return (scalarValue: encodedScalar.utf32[0],
+            startIndex: codeUnits.index(end, offsetBy: -numericCast(encodedScalar.count)),
+            endIndex: end)
+  }
+
+  // Get the rest of the Unicode view
+  private func unicodeView(
+    from start: CodeUnits.Index? = nil,
+    until end: CodeUnits.Index? = nil
+  ) -> _UnicodeViews<CodeUnits.SubSequence, FromEncoding> {
+    let end = end ?? codeUnits.endIndex
+    let start = start ?? codeUnits.startIndex
+    return _UnicodeViews(codeUnits[start..<end], FromEncoding.self)
+  }
+
+  //
+  // Be a BidirectionalCollection
+  //
+
+  // TODO?: This is really more like an iterator...
+  struct Index: Comparable {
+    // The corresponding native begin/end indices for this segment
+    let nativeStartIndex: CodeUnits.Index
+    let nativeEndIndex: CodeUnits.Index
+    let segment: FCCNormalizedSegment
+
+    public static func <(lhs: Index, rhs: Index) -> Bool {
+      _debug("\(lhs.nativeStartIndex, lhs.nativeEndIndex) < \(rhs.nativeStartIndex, rhs.nativeEndIndex)")
+      if lhs.nativeStartIndex < rhs.nativeStartIndex {
+        // Our ends should be ordered similarly, unless lhs is the last index
+        // before endIndex and rhs is the endIndex.
+        assert(
+          lhs.nativeEndIndex < rhs.nativeEndIndex ||
+          rhs.nativeStartIndex == rhs.nativeEndIndex,
+          "overlapping segments?")
+
+        return true
+      }
+
+      return false
+    }
+
+    public static func ==(lhs: Index, rhs: Index) -> Bool {
+      _debug("\(lhs.nativeStartIndex, lhs.nativeEndIndex) == \(rhs.nativeStartIndex, rhs.nativeEndIndex)")
+
+      if lhs.nativeStartIndex == rhs.nativeStartIndex {
+        assert(
+          lhs.nativeEndIndex == rhs.nativeEndIndex,
+          "overlapping segments?")
+
+        return true
+      }
+
+      // assert(
+      //   lhs.nativeEndIndex != rhs.nativeEndIndex
+      //   "overlapping segments?")
+      return false
+    }
+  }
+
+  var startIndex: Index {
+    _debug("startIndex")
+    return nextSegment(startingAt: codeUnits.startIndex)
+  }
+  var endIndex: Index {
+    _debug("endIndex")
+    return Index(
+      nativeStartIndex: codeUnits.endIndex,
+      nativeEndIndex: codeUnits.endIndex,
+      segment: FCCNormalizedSegment())
+  }
+
+  func index(after idx: Index) -> Index {
+    _debug("index after: \(idx.nativeStartIndex, idx.nativeEndIndex)")
+    return nextSegment(startingAt: idx.nativeEndIndex)
+  }
+  func index(before idx: Index) -> Index {
+    _debug("index before: \(idx.nativeStartIndex, idx.nativeEndIndex)")
+    return priorSegment(endingAt: idx.nativeStartIndex)
+  }
+  subscript(position: Index) -> FCCNormalizedSegment {
+    _debug("subscript: \(position.nativeStartIndex, position.nativeEndIndex)")
+    return position.segment
+  }
+
+  public typealias SubSequence = BidirectionalSlice<FCCNormalizedLazySegments>
+}
+
+typealias FCCNormalizedUTF16View_2<
+  CodeUnits: RandomAccessCollection,
+  Encoding: UnicodeEncoding
+> = FlattenBidirectionalCollection<
+  FCCNormalizedLazySegments<CodeUnits, Encoding>
+>
+where
+  CodeUnits.Index == CodeUnits.SubSequence.Index,
+  CodeUnits.SubSequence : RandomAccessCollection,
+  CodeUnits.SubSequence == CodeUnits.SubSequence.SubSequence,
+  CodeUnits.Iterator.Element == CodeUnits.SubSequence.Iterator.Element,
+  CodeUnits.Iterator.Element == Encoding.EncodedScalar.Iterator.Element
+
+
+// struct FCCNormalizedUTF16View_2<
+//   CodeUnits : RandomAccessCollection,
+//   FromEncoding : UnicodeEncoding
+// > : BidirectionalCollection
+// where
+//   CodeUnits.Index == CodeUnits.SubSequence.Index,
+//   CodeUnits.SubSequence : RandomAccessCollection,
+//   CodeUnits.SubSequence == CodeUnits.SubSequence.SubSequence,
+//   CodeUnits.SubSequence == CodeUnits, // TODO: necessary?
+//   CodeUnits.Iterator.Element == CodeUnits.SubSequence.Iterator.Element,
+//   CodeUnits.Iterator.Element == FromEncoding.EncodedScalar.Iterator.Element
+// {
+
+// }
 

--- a/test/Prototypes/string_prototype/main.swift
+++ b/test/Prototypes/string_prototype/main.swift
@@ -446,6 +446,27 @@ testSuite.test("fcc-normalized-view") {
     expectEqualSequence(newNorm3rev, norm3rev)
   }
 
+  // Test non-start first scalars
+  do {
+    let form1 = [0x0300, a, 0x0300]
+    let form2 = [0x0300, aTic] // In FCC normal form
+    let (norm1, norm1rev) = oldFCCNormView(form1)
+    let (norm2, norm2rev) = oldFCCNormView(form2)
+
+    // Sanity check existing impl
+    expectEqualSequence(norm1, norm2)
+    expectEqualSequence(norm1rev, norm2rev)
+    expectEqualSequence(norm1, form2)
+
+    // Test the new one
+    let (newNorm1, newNorm1rev) = newFCCNormView(form1)
+    let (newNorm2, newNorm2rev) = newFCCNormView(form2)
+    expectEqualSequence(newNorm1, newNorm2)
+    expectEqualSequence(newNorm2, norm2)
+    expectEqualSequence(newNorm1rev, newNorm2rev)
+    expectEqualSequence(newNorm2rev, norm2rev)
+  }
+
   do {
     // Test that the new normalizer is same result as old normalizer
     let s = "abcdefghijklmnopqrstuvwxyz\n"


### PR DESCRIPTION
<!-- What's in this pull request? -->

String prototype: Normalization Segments
    
Introduces FCCNormalizedSegment, which presents a normalization
segment as a (bidi)collection of normalized UTF16 code
units. Introduces a lazy (bidi)collection of segments capable of
partially-normalizing an String, as well as a flattened view of it.
    
Tests added.
