### PR TITLE
Addressor vtable fixes

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5185,7 +5185,7 @@ public:
     // A function cannot be an override if it is also a derived global decl
     // (since derived decls are at global scope).
     assert((!OverriddenOrBehaviorParamDecl
-            || !OverriddenOrBehaviorParamDecl.is<FuncDecl*>())
+            || OverriddenOrBehaviorParamDecl.get<FuncDecl*>() == over)
          && "function can only be one of override, derived, or behavior param");
     OverriddenOrBehaviorParamDecl = over;
     over->setIsOverridden();
@@ -5201,8 +5201,7 @@ public:
   void setParamBehavior(BehaviorRecord *behavior) {
     // Behavior param blocks cannot be overrides or derived.
     assert((!OverriddenOrBehaviorParamDecl
-            || !OverriddenOrBehaviorParamDecl
-                  .is<BehaviorRecord *>())
+            || OverriddenOrBehaviorParamDecl.is<BehaviorRecord *>())
          && "function can only be one of override, derived, or behavior param");
     OverriddenOrBehaviorParamDecl = behavior;
   }

--- a/include/swift/SIL/SILVTableVisitor.h
+++ b/include/swift/SIL/SILVTableVisitor.h
@@ -33,8 +33,9 @@ template <class T> class SILVTableVisitor {
   void maybeAddMethod(FuncDecl *fd) {
     assert(!fd->hasClangNode());
 
-    // Observing accessors don't get a vtable entry.
-    if (fd->isObservingAccessor())
+    // Observing accessors and addressors don't get vtable entries.
+    if (fd->isObservingAccessor() ||
+        fd->getAddressorKind() != AddressorKind::NotAddressor)
       return;
 
     maybeAddEntry(SILDeclRef(fd, SILDeclRef::Kind::Func));


### PR DESCRIPTION
Addressors should not get vtable entries. Overriding a property with a property that has addressors should probably mark the synthesized accessors as overrides.