### PR TITLE
Prepare SIL type lowering for multiple vtable entries

### DIFF
--- a/include/swift/SIL/SILDeclRef.h
+++ b/include/swift/SIL/SILDeclRef.h
@@ -351,10 +351,6 @@ struct SILDeclRef {
   /// declarations do not always have vtable entries.
   SILDeclRef getNextOverriddenVTableEntry() const;
 
-  /// Return a SILDeclRef referring to the ultimate base class's declaration,
-  /// which must be used with getConstantOverrideInfo.
-  SILDeclRef getBaseOverriddenVTableEntry() const;
-
   /// True if the referenced entity is some kind of thunk.
   bool isThunk() const;
 

--- a/include/swift/SIL/SILVTableVisitor.h
+++ b/include/swift/SIL/SILVTableVisitor.h
@@ -73,12 +73,16 @@ template <class T> class SILVTableVisitor {
   }
 
   void maybeAddEntry(SILDeclRef declRef) {
+    // Introduce a new entry if required.
     if (Types.requiresNewVTableEntry(declRef))
       asDerived().addMethod(declRef);
 
-    if (declRef.getNextOverriddenVTableEntry()) {
-      auto baseRef = declRef.getBaseOverriddenVTableEntry();
+    // Update any existing entries that it overrides.
+    auto nextRef = declRef;
+    while ((nextRef = nextRef.getNextOverriddenVTableEntry())) {
+      auto baseRef = Types.getOverriddenVTableEntry(nextRef);
       asDerived().addMethodOverride(baseRef, declRef);
+      nextRef = baseRef;
     }
   }
 

--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -663,6 +663,11 @@ public:
   /// overrides a method but has a more general AST type.
   bool requiresNewVTableEntry(SILDeclRef method);
 
+  /// Return the most derived override which requires a new vtable entry.
+  /// If the method does not override anything or no override is vtable
+  /// dispatched, will return the least derived method.
+  SILDeclRef getOverriddenVTableEntry(SILDeclRef method);
+
   /// Returns the SILFunctionType that must be used to perform a vtable dispatch
   /// to the given declaration.
   ///
@@ -683,7 +688,7 @@ public:
     if (next.isNull())
       return getConstantInfo(constant);
 
-    auto base = constant.getBaseOverriddenVTableEntry();
+    auto base = getOverriddenVTableEntry(constant);
     return getConstantOverrideInfo(constant, base);
   }
 

--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -500,7 +500,9 @@ class TypeConverter {
   llvm::DenseMap<SILDeclRef, SILConstantInfo> ConstantTypes;
   
   llvm::DenseMap<OverrideKey, SILConstantInfo> ConstantOverrideTypes;
-  
+
+  llvm::DenseMap<SILDeclRef, bool> RequiresVTableEntry;
+
   llvm::DenseMap<AnyFunctionRef, CaptureInfo> LoweredCaptures;
   
   /// The current generic context signature.
@@ -655,6 +657,11 @@ public:
   /// Returns the SILParameterInfo for the given declaration's `self` parameter.
   /// `constant` must refer to a method.
   SILParameterInfo getConstantSelfParameter(SILDeclRef constant);
+
+  /// Return if this method introduces a new vtable entry. This will be true
+  /// if the method does not override any method of its base class, or if it
+  /// overrides a method but has a more general AST type.
+  bool requiresNewVTableEntry(SILDeclRef method);
 
   /// Returns the SILFunctionType that must be used to perform a vtable dispatch
   /// to the given declaration.
@@ -831,6 +838,8 @@ private:
   CanAnyFunctionType getBridgedFunctionType(AbstractionPattern fnPattern,
                                             CanAnyFunctionType fnType,
                                             AnyFunctionType::ExtInfo extInfo);
+
+  bool requiresNewVTableEntryUncached(SILDeclRef method);
 };
 
 inline const TypeLowering &

--- a/lib/IRGen/ClassMetadataLayout.h
+++ b/lib/IRGen/ClassMetadataLayout.h
@@ -42,7 +42,7 @@ protected:
   ClassDecl *const Target;
 
   ClassMetadataLayout(IRGenModule &IGM, ClassDecl *target)
-    : super(IGM), Target(target) {}
+    : super(IGM), SILVTableVisitor<Impl>(IGM.getSILTypes()), Target(target) {}
 
 public:
   void layout() {

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -4604,8 +4604,8 @@ llvm::Value *irgen::emitVirtualMethodValue(IRGenFunction &IGF,
   AbstractFunctionDecl *methodDecl
     = cast<AbstractFunctionDecl>(method.getDecl());
 
-  // Find the function that's actually got an entry in the metadata.
-  SILDeclRef overridden = method.getBaseOverriddenVTableEntry();
+  // Find the vtable entry for this method.
+  SILDeclRef overridden = IGF.IGM.getSILTypes().getOverriddenVTableEntry(method);
 
   // Find the metadata.
   llvm::Value *metadata;

--- a/lib/SIL/SILDeclRef.cpp
+++ b/lib/SIL/SILDeclRef.cpp
@@ -796,19 +796,6 @@ SILDeclRef SILDeclRef::getNextOverriddenVTableEntry() const {
   return SILDeclRef();
 }
 
-SILDeclRef SILDeclRef::getBaseOverriddenVTableEntry() const {
-  // 'method' is the most final method in the hierarchy which we
-  // haven't yet found a compatible override for.  'cur' is the method
-  // we're currently looking at.  Compatibility is transitive,
-  // so we can forget our original method and just keep going up.
-  SILDeclRef method = *this;
-  SILDeclRef cur = method;
-  while ((cur = cur.getNextOverriddenVTableEntry())) {
-    method = cur;
-  }
-  return method;
-}
-
 SILLocation SILDeclRef::getAsRegularLocation() const {
   if (hasDecl())
     return RegularLocation(getDecl());

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -1819,6 +1819,18 @@ bool TypeConverter::requiresNewVTableEntryUncached(SILDeclRef method) {
   return true;
 }
 
+SILDeclRef TypeConverter::getOverriddenVTableEntry(SILDeclRef method) {
+  SILDeclRef cur = method, next = method;
+  do {
+    cur = next;
+    if (requiresNewVTableEntry(cur))
+      return cur;
+    next = cur.getNextOverriddenVTableEntry();
+  } while (next);
+
+  return cur;
+}
+
 /// Returns the ConstantInfo corresponding to the VTable thunk for overriding.
 /// Will be the same as getConstantInfo if the declaration does not override.
 SILConstantInfo TypeConverter::getConstantOverrideInfo(SILDeclRef derived,

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -279,7 +279,7 @@ public:
                                SILDeclRef c,
                                SubstitutionList subs,
                                SILLocation l) {
-    auto base = c.getBaseOverriddenVTableEntry();
+    auto base = SGF.SGM.Types.getOverriddenVTableEntry(c);
     auto formalType = getConstantFormalInterfaceType(SGF, base);
     auto substType = getConstantFormalInterfaceType(SGF, c);
     return Callee(Kind::ClassMethod, SGF, selfValue, c,
@@ -439,11 +439,9 @@ public:
              "Currying the self parameter of super method calls should've been emitted");
 
       constant = Constant.atUncurryLevel(level);
-      auto constantInfo = SGF.getConstantInfo(*constant);
 
-      if (SILDeclRef baseConstant = Constant.getBaseOverriddenVTableEntry())
-        constantInfo = SGF.SGM.Types.getConstantOverrideInfo(Constant,
-                                                             baseConstant);
+      auto base = SGF.SGM.Types.getOverriddenVTableEntry(*constant);
+      auto constantInfo = SGF.SGM.Types.getConstantOverrideInfo(*constant, base);
       auto methodVal = SGF.B.createSuperMethod(Loc,
                                                SelfValue,
                                                *constant,

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -181,7 +181,7 @@ public:
   SmallVector<std::pair<SILDeclRef, SILDeclRef>, 8> vtableMethods;
 
   SILGenVTable(SILGenModule &SGM, ClassDecl *theClass)
-    : SGM(SGM), theClass(theClass)
+    : SILVTableVisitor(SGM.Types), SGM(SGM), theClass(theClass)
   { }
 
   void emitVTable() {

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -173,7 +173,12 @@ class SILGenVTable : public SILVTableVisitor<SILGenVTable> {
 public:
   SILGenModule &SGM;
   ClassDecl *theClass;
-  std::vector<SILVTable::Entry> vtableEntries;
+
+  // Map a base SILDeclRef to the corresponding element in vtableMethods.
+  llvm::DenseMap<SILDeclRef, unsigned> baseToIndexMap;
+
+  // For each base method, store the corresponding override.
+  SmallVector<std::pair<SILDeclRef, SILDeclRef>, 8> vtableMethods;
 
   SILGenVTable(SILGenModule &SGM, ClassDecl *theClass)
     : SGM(SGM), theClass(theClass)
@@ -196,6 +201,16 @@ public:
     if (SGM.requiresIVarDestroyer(theClass))
       addMethod(SILDeclRef(theClass, SILDeclRef::Kind::IVarDestroyer));
 
+    SmallVector<SILVTable::Entry, 8> vtableEntries;
+    vtableEntries.reserve(vtableMethods.size());
+
+    for (auto method : vtableMethods) {
+      SILDeclRef baseRef, derivedRef;
+      std::tie(baseRef, derivedRef) = method;
+
+      vtableEntries.push_back(SGM.emitVTableMethod(derivedRef, baseRef));
+    }
+
     // Create the vtable.
     SILVTable::create(SGM.M, theClass, vtableEntries);
   }
@@ -210,24 +225,20 @@ public:
 
   // Try to find an overridden entry.
   void addMethodOverride(SILDeclRef baseRef, SILDeclRef declRef) {
-    // NB: Mutates vtableEntries in-place
-    // FIXME: O(n^2)
-    for (SILVTable::Entry &entry : vtableEntries) {
-      // Replace the overridden member.
-      if (entry.Method == baseRef) {
-        // The entry is keyed by the least derived method.
-        entry = SGM.emitVTableMethod(declRef, baseRef);
-        return;
-      }
-    }
-    baseRef.dump();
-    declRef.dump();
-    llvm_unreachable("no overridden vtable entry?!");
+    auto found = baseToIndexMap.find(baseRef);
+    assert(found != baseToIndexMap.end());
+    auto &method = vtableMethods[found->second];
+    assert(method.first == baseRef);
+    method.second = declRef;
   }
 
   // Add an entry to the vtable.
   void addMethod(SILDeclRef member) {
-    vtableEntries.push_back(SGM.emitVTableMethod(member, member));
+    unsigned index = vtableMethods.size();
+    vtableMethods.push_back(std::make_pair(member, member));
+    auto result = baseToIndexMap.insert(std::make_pair(member, index));
+    assert(result.second);
+    (void) result;
   }
 };
 


### PR DESCRIPTION
This PR introduces the abstractions necessary to correctly model covariant method overrides at the SIL level. For now, the code is still hard-wired to say that overrides never introduce vtable entries, so there's no functional change. All that remains now is fleshing out the `requiresNewVTableEntry()` predicate, and adding tests.

Previous PRs:
- https://github.com/apple/swift/pull/8304
- https://github.com/apple/swift/pull/8309
- https://github.com/apple/swift/pull/8310
- https://github.com/apple/swift/pull/8311