### PR TITLE
SILGen: Support for covariant method overrides

### DIFF
--- a/docs/ABI.rst
+++ b/docs/ABI.rst
@@ -819,7 +819,7 @@ types where the metadata itself has unknown layout.)
   global ::= global 'To'                 // swift-as-ObjC thunk
   global ::= global 'TD'                 // dynamic dispatch thunk
   global ::= global 'Td'                 // direct method reference thunk
-  global ::= global 'TV'                 // vtable override thunk
+  global ::= entity entity 'TV'          // vtable override thunk, derived followed by base
   global ::= type 'D'                    // type mangling for the debugger. TODO: check if we really need this
   global ::= protocol-conformance entity 'TW' // protocol witness thunk
   global ::= context identifier identifier 'TB' // property behavior initializer thunk (not used currently)

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -1791,8 +1791,94 @@ bool TypeConverter::requiresNewVTableEntry(SILDeclRef method) {
   return result;
 }
 
-bool TypeConverter::requiresNewVTableEntryUncached(SILDeclRef method) {
-  auto *decl = method.getDecl();
+// This check duplicates TypeConverter::checkForABIDifferences(),
+// but on AST types. The issue is we only want to introduce a new
+// vtable thunk if the AST type changes, but an abstraction change
+// is OK; we don't want a new entry if an @in parameter became
+// @guaranteed or whatever.
+static bool checkASTTypeForABIDifferences(CanType type1,
+                                          CanType type2) {
+  // Unwrap optionals, but remember that we did.
+  bool type1WasOptional = false;
+  bool type2WasOptional = false;
+  if (auto object = type1.getAnyOptionalObjectType()) {
+    type1WasOptional = true;
+    type1 = object;
+  }
+  if (auto object = type2.getAnyOptionalObjectType()) {
+    type2WasOptional = true;
+    type2 = object;
+  }
+
+  // Forcing IUOs always requires a new vtable entry.
+  if (type1WasOptional && !type2WasOptional)
+    return true;
+
+  // Except for the above case, we should not be making a value less optional.
+
+  // If we're introducing a level of optionality, only certain types are
+  // ABI-compatible -- check below.
+  bool optionalityChange = (!type1WasOptional && type2WasOptional);
+
+  // If the types are identical and there was no optionality change,
+  // we're done.
+  if (type1 == type2 && !optionalityChange)
+    return false;
+
+  // Classes, class-constrained archetypes, and pure-ObjC existential types
+  // all have single retainable pointer representation; optionality change
+  // is allowed.
+  if ((type1->mayHaveSuperclass() ||
+       type1->isObjCExistentialType()) &&
+      (type2->mayHaveSuperclass() ||
+       type2->isObjCExistentialType()))
+    return false;
+
+  // Class metatypes are ABI-compatible even under optionality change.
+  if (auto metaTy1 = dyn_cast<MetatypeType>(type1)) {
+    if (auto metaTy2 = dyn_cast<MetatypeType>(type2)) {
+      if (metaTy1.getInstanceType().getClassOrBoundGenericClass() &&
+          metaTy2.getInstanceType().getClassOrBoundGenericClass())
+        return false;
+    }
+  }
+
+  if (!optionalityChange) {
+    // Function parameters are ABI compatible if their differences are
+    // trivial.
+    if (auto fnTy1 = dyn_cast<AnyFunctionType>(type1)) {
+      if (auto fnTy2 = dyn_cast<AnyFunctionType>(type2)) {
+        return (
+            checkASTTypeForABIDifferences(fnTy2.getInput(), fnTy1.getInput()) ||
+            checkASTTypeForABIDifferences(fnTy1.getResult(), fnTy2.getResult()));
+      }
+    }
+
+    // Tuple types are ABI-compatible if their elements are.
+    if (auto tuple1 = dyn_cast<TupleType>(type1)) {
+      if (auto tuple2 = dyn_cast<TupleType>(type2)) {
+        if (tuple1->getNumElements() != tuple2->getNumElements())
+          return true;
+
+        for (unsigned i = 0, e = tuple1->getNumElements(); i < e; i++) {
+          if (checkASTTypeForABIDifferences(tuple1.getElementType(i),
+                                            tuple2.getElementType(i)))
+            return true;
+        }
+
+        // Tuple lengths and elements match
+        return false;
+      }
+    }
+  }
+
+  // The types are different, or there was an optionality change resulting
+  // in a change in representation.
+  return true;
+}
+
+bool TypeConverter::requiresNewVTableEntryUncached(SILDeclRef derived) {
+  auto *decl = derived.getDecl();
 
   // Final members are always be called directly.
   // Dynamic methods are always accessed by objc_msgSend().
@@ -1808,10 +1894,27 @@ bool TypeConverter::requiresNewVTableEntryUncached(SILDeclRef method) {
       return false;
   }
 
-  // If the method overrides something, we only need a new entry
-  // if the override changes the AST type.
-  if (method.getNextOverriddenVTableEntry()) {
-    // FIXME: Check the type here.
+  // If the method overrides something, we only need a new entry if the
+  // override has a more general AST type. However an abstraction
+  // change is OK; we don't want to add a whole new vtable entry just
+  // because an @in parameter because @owned, or whatever.
+  if (auto base = derived.getNextOverriddenVTableEntry()) {
+    auto baseInfo = getConstantInfo(base);
+    auto derivedInfo = getConstantInfo(derived);
+
+    auto baseInterfaceTy = baseInfo.FormalInterfaceType;
+    auto derivedInterfaceTy = derivedInfo.FormalInterfaceType;
+
+    auto selfInterfaceTy = derivedInterfaceTy.getInput()->getRValueInstanceType();
+
+    auto overrideInterfaceTy =
+        selfInterfaceTy->adjustSuperclassMemberDeclType(
+            base.getDecl(), derived.getDecl(), baseInterfaceTy,
+            /*resolver=*/nullptr)->getCanonicalType();
+
+    if (checkASTTypeForABIDifferences(derivedInterfaceTy, overrideInterfaceTy))
+      return true;
+
     return false;
   }
 
@@ -1843,8 +1946,7 @@ SILConstantInfo TypeConverter::getConstantOverrideInfo(SILDeclRef derived,
   if (found != ConstantOverrideTypes.end())
     return found->second;
 
-  assert(base.getNextOverriddenVTableEntry().isNull()
-         && "base must not be an override");
+  assert(requiresNewVTableEntry(base) && "base must not be an override");
 
   auto baseInfo = getConstantInfo(base);
   auto derivedInfo = getConstantInfo(derived);
@@ -1853,8 +1955,8 @@ SILConstantInfo TypeConverter::getConstantOverrideInfo(SILDeclRef derived,
   // vtable thunk the same signature as the derived method.
   auto basePattern = AbstractionPattern(baseInfo.LoweredInterfaceType);
 
-  auto baseInterfaceTy = makeConstantInterfaceType(base);
-  auto derivedInterfaceTy = makeConstantInterfaceType(derived);
+  auto baseInterfaceTy = baseInfo.FormalInterfaceType;
+  auto derivedInterfaceTy = derivedInfo.FormalInterfaceType;
 
   auto selfInterfaceTy = derivedInterfaceTy.getInput()->getRValueInstanceType();
 

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -90,7 +90,9 @@ SILGenModule::emitVTableMethod(SILDeclRef derived, SILDeclRef base) {
   // The override member type is semantically a subtype of the base
   // member type. If the override is ABI compatible, we do not need
   // a thunk.
-  if (overrideInfo == derivedInfo)
+  if (M.Types.checkFunctionForABIDifferences(derivedInfo.SILFnType,
+                                             overrideInfo.SILFnType)
+      == TypeConverter::ABIDifference::Trivial)
     return {base, implFn, implLinkage};
 
   // Generate the thunk name.

--- a/test/SILGen/vtable_thunks.swift
+++ b/test/SILGen/vtable_thunks.swift
@@ -2,6 +2,46 @@
 
 protocol AddrOnly {}
 
+func callMethodsOnD<U>(d: D, b: B, a: AddrOnly, u: U, i: Int) {
+  _ = d.iuo(x: b, y: b, z: b)
+  _ = d.f(x: b, y: b)
+  _ = d.f2(x: b, y: b)
+  _ = d.f3(x: b, y: b)
+  _ = d.f4(x: b, y: b)
+  _ = d.g(x: a, y: a)
+  _ = d.g2(x: a, y: a)
+  _ = d.g3(x: a, y: a)
+  _ = d.g4(x: a, y: a)
+  _ = d.h(x: u, y: u)
+  _ = d.h2(x: u, y: u)
+  _ = d.h3(x: u, y: u)
+  _ = d.h4(x: u, y: u)
+  _ = d.i(x: i, y: i)
+  _ = d.i2(x: i, y: i)
+  _ = d.i3(x: i, y: i)
+  _ = d.i4(x: i, y: i)
+}
+
+func callMethodsOnF<U>(d: F, b: B, a: AddrOnly, u: U, i: Int) {
+  _ = d.iuo(x: b, y: b, z: b)
+  _ = d.f(x: b, y: b)
+  _ = d.f2(x: b, y: b)
+  _ = d.f3(x: b, y: b)
+  _ = d.f4(x: b, y: b)
+  _ = d.g(x: a, y: a)
+  _ = d.g2(x: a, y: a)
+  _ = d.g3(x: a, y: a)
+  _ = d.g4(x: a, y: a)
+  _ = d.h(x: u, y: u)
+  _ = d.h2(x: u, y: u)
+  _ = d.h3(x: u, y: u)
+  _ = d.h4(x: u, y: u)
+  _ = d.i(x: i, y: i)
+  _ = d.i2(x: i, y: i)
+  _ = d.i3(x: i, y: i)
+  _ = d.i4(x: i, y: i)
+}
+
 @objc class B {
   // We only allow B! -> B overrides for @objc methods.
   // The IUO force-unwrap requires a thunk.

--- a/test/SILGen/vtable_thunks_reabstraction.swift
+++ b/test/SILGen/vtable_thunks_reabstraction.swift
@@ -43,18 +43,18 @@ func callMethodsOnConcreteClass<U>(o: ConcreteClass, t: C, u: U, tt: C.Type) {
   _ = o.inAndOutGeneric(x: t, y: u)
   _ = o.inAndOutMetatypes(x: tt)
   _ = o.inAndOutTuples(x: (t, (tt, { $0 })))
-  //_ = o.variantOptionality(x: t) // FIXME
+  _ = o.variantOptionality(x: t)
   _ = o.variantOptionalityMetatypes(x: tt)
   _ = o.variantOptionalityFunctions(x: { $0 })
   _ = o.variantOptionalityTuples(x: (t, (tt, { $0 })))
 }
 
 func callMethodsOnConcreteClassVariance<U>(o: ConcreteClassVariance, b: B, c: C, u: U, tt: C.Type) {
-  //_ = o.inAndOut(x: b) // FIXME
+  _ = o.inAndOut(x: b)
   _ = o.inAndOutGeneric(x: c, y: u)
   _ = o.inAndOutMetatypes(x: tt)
   _ = o.inAndOutTuples(x: (c, (tt, { $0 })))
-  //_ = o.variantOptionality(x: t) // FIXME
+  _ = o.variantOptionality(x: b)
   _ = o.variantOptionalityMetatypes(x: tt)
   _ = o.variantOptionalityFunctions(x: { $0 })
   _ = o.variantOptionalityTuples(x: (c, (tt, { $0 })))
@@ -131,7 +131,7 @@ func callMethodsOnConcreteClassMetatype<U>(o: ConcreteClassMetatype, t: C.Type, 
   _ = o.inAndOutGeneric(x: t, y: u)
   _ = o.inAndOutMetatypes(x: tt)
   _ = o.inAndOutTuples(x: (t, (tt, { $0 })))
-  //_ = o.variantOptionality(x: t) // FIXME
+  _ = o.variantOptionality(x: t)
   _ = o.variantOptionalityMetatypes(x: tt)
   _ = o.variantOptionalityFunctions(x: { $0 })
   _ = o.variantOptionalityTuples(x: (t, (tt, { $0 })))

--- a/test/SILGen/vtable_thunks_reabstraction.swift
+++ b/test/SILGen/vtable_thunks_reabstraction.swift
@@ -5,6 +5,149 @@ class B {}
 class C: B {}
 class D: C {}
 
+func callMethodsOnOpaque<T, U>(o: Opaque<T>, t: T, u: U, tt: T.Type) {
+  _ = o.inAndOut(x: t)
+  _ = o.inAndOutGeneric(x: t, y: u)
+  _ = o.inAndOutMetatypes(x: tt)
+  _ = o.inAndOutTuples(x: (t, (tt, { $0 })))
+  _ = o.variantOptionality(x: t)
+  _ = o.variantOptionalityMetatypes(x: tt)
+  _ = o.variantOptionalityFunctions(x: { $0 })
+  _ = o.variantOptionalityTuples(x: (t, (tt, { $0 })))
+}
+
+func callMethodsOnStillOpaque<T, U>(o: StillOpaque<T>, t: T, u: U, tt: T.Type) {
+  _ = o.inAndOut(x: t)
+  _ = o.inAndOutGeneric(x: t, y: u)
+  _ = o.inAndOutMetatypes(x: tt)
+  _ = o.inAndOutTuples(x: (t, (tt, { $0 })))
+  _ = o.variantOptionality(x: t)
+  _ = o.variantOptionalityMetatypes(x: tt)
+  _ = o.variantOptionalityFunctions(x: { $0 })
+  _ = o.variantOptionalityTuples(x: (t, (tt, { $0 })))
+}
+
+func callMethodsOnConcreteValue<U>(o: ConcreteValue, t: S, u: U, tt: S.Type) {
+  _ = o.inAndOut(x: t)
+  _ = o.inAndOutGeneric(x: t, y: u)
+  _ = o.inAndOutMetatypes(x: tt)
+  _ = o.inAndOutTuples(x: (t, (tt, { $0 })))
+  _ = o.variantOptionality(x: t)
+  _ = o.variantOptionalityMetatypes(x: tt)
+  _ = o.variantOptionalityFunctions(x: { $0 })
+  _ = o.variantOptionalityTuples(x: (t, (tt, { $0 })))
+}
+
+func callMethodsOnConcreteClass<U>(o: ConcreteClass, t: C, u: U, tt: C.Type) {
+  _ = o.inAndOut(x: t)
+  _ = o.inAndOutGeneric(x: t, y: u)
+  _ = o.inAndOutMetatypes(x: tt)
+  _ = o.inAndOutTuples(x: (t, (tt, { $0 })))
+  //_ = o.variantOptionality(x: t) // FIXME
+  _ = o.variantOptionalityMetatypes(x: tt)
+  _ = o.variantOptionalityFunctions(x: { $0 })
+  _ = o.variantOptionalityTuples(x: (t, (tt, { $0 })))
+}
+
+func callMethodsOnConcreteClassVariance<U>(o: ConcreteClassVariance, b: B, c: C, u: U, tt: C.Type) {
+  //_ = o.inAndOut(x: b) // FIXME
+  _ = o.inAndOutGeneric(x: c, y: u)
+  _ = o.inAndOutMetatypes(x: tt)
+  _ = o.inAndOutTuples(x: (c, (tt, { $0 })))
+  //_ = o.variantOptionality(x: t) // FIXME
+  _ = o.variantOptionalityMetatypes(x: tt)
+  _ = o.variantOptionalityFunctions(x: { $0 })
+  _ = o.variantOptionalityTuples(x: (c, (tt, { $0 })))
+}
+
+func callMethodsOnOpaqueTuple<T, U>(o: OpaqueTuple<T>, t: (T, T), u: U, tt: (T, T).Type) {
+  _ = o.inAndOut(x: t)
+  _ = o.inAndOutGeneric(x: t, y: u)
+  _ = o.inAndOutMetatypes(x: tt)
+  _ = o.inAndOutTuples(x: (t, (tt, { $0 })))
+  _ = o.variantOptionality(x: t)
+  _ = o.variantOptionalityMetatypes(x: tt)
+  _ = o.variantOptionalityFunctions(x: { $0 })
+  _ = o.variantOptionalityTuples(x: (t, (tt, { $0 })))
+}
+
+func callMethodsOnConcreteTuple<U>(o: ConcreteTuple, t: (S, S), u: U, tt: (S, S).Type) {
+  _ = o.inAndOut(x: t)
+  _ = o.inAndOutGeneric(x: t, y: u)
+  _ = o.inAndOutMetatypes(x: tt)
+  _ = o.inAndOutTuples(x: (t, (tt, { $0 })))
+  _ = o.variantOptionality(x: t)
+  _ = o.variantOptionalityMetatypes(x: tt)
+  _ = o.variantOptionalityFunctions(x: { $0 })
+  _ = o.variantOptionalityTuples(x: (t, (tt, { $0 })))
+}
+
+func callMethodsOnOpaqueFunction<X, Y, U>(o: OpaqueFunction<X, Y>, t: @escaping (X) -> Y, u: U, tt: ((X) -> Y).Type) {
+  _ = o.inAndOut(x: t)
+  _ = o.inAndOutGeneric(x: t, y: u)
+  _ = o.inAndOutMetatypes(x: tt)
+  _ = o.inAndOutTuples(x: (t, (tt, { $0 })))
+  _ = o.variantOptionality(x: t)
+  _ = o.variantOptionalityMetatypes(x: tt)
+  _ = o.variantOptionalityFunctions(x: { $0 })
+  _ = o.variantOptionalityTuples(x: (t, (tt, { $0 })))
+}
+
+func callMethodsOnConcreteFunction<U>(o: ConcreteFunction, t: @escaping (S) -> S, u: U, tt: ((S) -> S).Type) {
+  _ = o.inAndOut(x: t)
+  _ = o.inAndOutGeneric(x: t, y: u)
+  _ = o.inAndOutMetatypes(x: tt)
+  _ = o.inAndOutTuples(x: (t, (tt, { $0 })))
+  _ = o.variantOptionality(x: t)
+  _ = o.variantOptionalityMetatypes(x: tt)
+  _ = o.variantOptionalityFunctions(x: { $0 })
+  _ = o.variantOptionalityTuples(x: (t, (tt, { $0 })))
+}
+
+func callMethodsOnOpaqueMetatype<T, U>(o: OpaqueMetatype<T>, t: T.Type, u: U, tt: T.Type.Type) {
+  _ = o.inAndOut(x: t)
+  _ = o.inAndOutGeneric(x: t, y: u)
+  _ = o.inAndOutMetatypes(x: tt)
+  _ = o.inAndOutTuples(x: (t, (tt, { $0 })))
+  _ = o.variantOptionality(x: t)
+  _ = o.variantOptionalityMetatypes(x: tt)
+  _ = o.variantOptionalityFunctions(x: { $0 })
+  _ = o.variantOptionalityTuples(x: (t, (tt, { $0 })))
+}
+
+func callMethodsOnConcreteValueMetatype<U>(o: ConcreteValueMetatype, t: S.Type, u: U, tt: S.Type.Type) {
+  _ = o.inAndOut(x: t)
+  _ = o.inAndOutGeneric(x: t, y: u)
+  _ = o.inAndOutMetatypes(x: tt)
+  _ = o.inAndOutTuples(x: (t, (tt, { $0 })))
+  _ = o.variantOptionality(x: t)
+  _ = o.variantOptionalityMetatypes(x: tt)
+  _ = o.variantOptionalityFunctions(x: { $0 })
+  _ = o.variantOptionalityTuples(x: (t, (tt, { $0 })))
+}
+
+func callMethodsOnConcreteClassMetatype<U>(o: ConcreteClassMetatype, t: C.Type, u: U, tt: C.Type.Type) {
+  _ = o.inAndOut(x: t)
+  _ = o.inAndOutGeneric(x: t, y: u)
+  _ = o.inAndOutMetatypes(x: tt)
+  _ = o.inAndOutTuples(x: (t, (tt, { $0 })))
+  //_ = o.variantOptionality(x: t) // FIXME
+  _ = o.variantOptionalityMetatypes(x: tt)
+  _ = o.variantOptionalityFunctions(x: { $0 })
+  _ = o.variantOptionalityTuples(x: (t, (tt, { $0 })))
+}
+
+func callMethodsOnConcreteOptional<U>(o: ConcreteOptional, t: S?, u: U, tt: S?.Type) {
+  _ = o.inAndOut(x: t)
+  _ = o.inAndOutGeneric(x: t, y: u)
+  _ = o.inAndOutMetatypes(x: tt)
+  _ = o.inAndOutTuples(x: (t, (tt, { $0 })))
+  _ = o.variantOptionality(x: t)
+  _ = o.variantOptionalityMetatypes(x: tt)
+  _ = o.variantOptionalityFunctions(x: { $0 })
+  _ = o.variantOptionalityTuples(x: (t, (tt, { $0 })))
+}
+
 class Opaque<T> {
   typealias ObnoxiousTuple = (T, (T.Type, (T) -> T))
 
@@ -48,6 +191,11 @@ class StillOpaque<T>: Opaque<T> {
 // CHECK-NEXT:   #Opaque.variantOptionalityFunctions!1: <T> (Opaque<T>) -> (@escaping (T) -> T) -> ((T) -> T)? : _T027vtable_thunks_reabstraction6OpaqueC27variantOptionalityFunctionsxxcSgxxc1x_tF	// Opaque.variantOptionalityFunctions(x : (A) -> A) -> (A) -> A?
 // CHECK-NEXT:   #Opaque.variantOptionalityTuples!1: <T> (Opaque<T>) -> ((T, (T.Type, (T) -> T))) -> (T, (T.Type, (T) -> T))? : hidden _T027vtable_thunks_reabstraction11StillOpaqueC24variantOptionalityTuplesx_xm_xxcttx_xm_xxcttSg1x_tFAA0E0CAdEx_xm_xxcttAF_tFTV	// vtable thunk for Opaque.variantOptionalityTuples(x : (A, (A.Type, (A) -> A))) -> (A, (A.Type, (A) -> A))? dispatching to StillOpaque.variantOptionalityTuples(x : (A, (A.Type, (A) -> A))?) -> (A, (A.Type, (A) -> A))
 // CHECK-NEXT:   #Opaque.init!initializer.1: <T> (Opaque<T>.Type) -> () -> Opaque<T> : _T027vtable_thunks_reabstraction11StillOpaqueCACyxGycfc	// StillOpaque.init() -> StillOpaque<A>
+
+// Tuple becomes more optional -- needs new vtable entry
+
+// CHECK-NEXT:  #StillOpaque.variantOptionalityTuples!1: <T> (StillOpaque<T>) -> ((T, (T.Type, (T) -> T))?) -> (T, (T.Type, (T) -> T)) : _T027vtable_thunks_reabstraction11StillOpaqueC24variantOptionalityTuplesx_xm_xxcttx_xm_xxcttSg1x_tF	// StillOpaque.variantOptionalityTuples(x : (A, (A.Type, (A) -> A))?) -> (A, (A.Type, (A) -> A))
+
 // CHECK-NEXT:   #StillOpaque.deinit!deallocator: _T027vtable_thunks_reabstraction11StillOpaqueCfD	// StillOpaque.__deallocating_deinit
 // CHECK-NEXT: }
 
@@ -74,6 +222,14 @@ class ConcreteValue: Opaque<S> {
 // CHECK-NEXT:   #Opaque.variantOptionalityFunctions!1: <T> (Opaque<T>) -> (@escaping (T) -> T) -> ((T) -> T)? : hidden _T027vtable_thunks_reabstraction13ConcreteValueC27variantOptionalityFunctionsAA1SVAFcA2FcSg1x_tFAA6OpaqueCADxxcSgxxcAH_tFTV	// vtable thunk for Opaque.variantOptionalityFunctions(x : (A) -> A) -> (A) -> A? dispatching to ConcreteValue.variantOptionalityFunctions(x : (S) -> S?) -> (S) -> S
 // CHECK-NEXT:   #Opaque.variantOptionalityTuples!1: <T> (Opaque<T>) -> ((T, (T.Type, (T) -> T))) -> (T, (T.Type, (T) -> T))? : hidden _T027vtable_thunks_reabstraction13ConcreteValueC24variantOptionalityTuplesAA1SV_AFm_A2FcttAF_AFm_A2FcttSg1x_tFAA6OpaqueCADx_xm_xxcttSgx_xm_xxcttAH_tFTV	// vtable thunk for Opaque.variantOptionalityTuples(x : (A, (A.Type, (A) -> A))) -> (A, (A.Type, (A) -> A))? dispatching to ConcreteValue.variantOptionalityTuples(x : (S, (S.Type, (S) -> S))?) -> (S, (S.Type, (S) -> S))
 // CHECK-NEXT:   #Opaque.init!initializer.1: <T> (Opaque<T>.Type) -> () -> Opaque<T> : _T027vtable_thunks_reabstraction13ConcreteValueCACycfc	// ConcreteValue.init() -> ConcreteValue
+
+// Value types becoming more optional -- needs new vtable entry
+
+// CHECK-NEXT:   #ConcreteValue.variantOptionality!1: (ConcreteValue) -> (S?) -> S : _T027vtable_thunks_reabstraction13ConcreteValueC18variantOptionalityAA1SVAFSg1x_tF // ConcreteValue.variantOptionality(x : S?) -> S
+// CHECK-NEXT:   #ConcreteValue.variantOptionalityMetatypes!1: (ConcreteValue) -> (S.Type?) -> S.Type : _T027vtable_thunks_reabstraction13ConcreteValueC27variantOptionalityMetatypesAA1SVmAFmSg1x_tF // ConcreteValue.variantOptionalityMetatypes(x : S.Type?) -> S.Type
+// CHECK-NEXT:   #ConcreteValue.variantOptionalityFunctions!1: (ConcreteValue) -> (((S) -> S)?) -> (S) -> S : _T027vtable_thunks_reabstraction13ConcreteValueC27variantOptionalityFunctionsAA1SVAFcA2FcSg1x_tF	// ConcreteValue.variantOptionalityFunctions(x : (S) -> S?) -> (S) -> S
+// CHECK-NEXT:   #ConcreteValue.variantOptionalityTuples!1: (ConcreteValue) -> ((S, (S.Type, (S) -> S))?) -> (S, (S.Type, (S) -> S)) : _T027vtable_thunks_reabstraction13ConcreteValueC24variantOptionalityTuplesAA1SV_AFm_A2FcttAF_AFm_A2FcttSg1x_tF	// ConcreteValue.variantOptionalityTuples(x : (S, (S.Type, (S) -> S))?) -> (S, (S.Type, (S) -> S))
+
 // CHECK-NEXT:   #ConcreteValue.deinit!deallocator: _T027vtable_thunks_reabstraction13ConcreteValueCfD	// ConcreteValue.__deallocating_deinit
 // CHECK-NEXT: }
 
@@ -99,6 +255,16 @@ class ConcreteClass: Opaque<C> {
 // CHECK-NEXT:   #Opaque.variantOptionalityFunctions!1: <T> (Opaque<T>) -> (@escaping (T) -> T) -> ((T) -> T)? : hidden _T027vtable_thunks_reabstraction13ConcreteClassC27variantOptionalityFunctionsAA1CCAFcA2FcSg1x_tFAA6OpaqueCADxxcSgxxcAH_tFTV	// vtable thunk for Opaque.variantOptionalityFunctions(x : (A) -> A) -> (A) -> A? dispatching to ConcreteClass.variantOptionalityFunctions(x : (C) -> C?) -> (C) -> C
 // CHECK-NEXT:   #Opaque.variantOptionalityTuples!1: <T> (Opaque<T>) -> ((T, (T.Type, (T) -> T))) -> (T, (T.Type, (T) -> T))? : hidden _T027vtable_thunks_reabstraction13ConcreteClassC24variantOptionalityTuplesAA1CC_AFm_A2FcttAF_AFm_A2FcttSg1x_tFAA6OpaqueCADx_xm_xxcttSgx_xm_xxcttAH_tFTV	// vtable thunk for Opaque.variantOptionalityTuples(x : (A, (A.Type, (A) -> A))) -> (A, (A.Type, (A) -> A))? dispatching to ConcreteClass.variantOptionalityTuples(x : (C, (C.Type, (C) -> C))?) -> (C, (C.Type, (C) -> C))
 // CHECK-NEXT:   #Opaque.init!initializer.1: <T> (Opaque<T>.Type) -> () -> Opaque<T> : _T027vtable_thunks_reabstraction13ConcreteClassCACycfc	// ConcreteClass.init() -> ConcreteClass
+
+// Class references are ABI-compatible with optional class references, and
+// similarly for class metatypes.
+//
+// Function and tuple optionality change still needs a new vtable entry
+// as above.
+
+// CHECK-NEXT:   #ConcreteClass.variantOptionalityFunctions!1: (ConcreteClass) -> (((C) -> C)?) -> (C) -> C : _T027vtable_thunks_reabstraction13ConcreteClassC27variantOptionalityFunctionsAA1CCAFcA2FcSg1x_tF	// ConcreteClass.variantOptionalityFunctions(x : (C) -> C?) -> (C) -> C
+// CHECK-NEXT:   #ConcreteClass.variantOptionalityTuples!1: (ConcreteClass) -> ((C, (C.Type, (C) -> C))?) -> (C, (C.Type, (C) -> C)) : _T027vtable_thunks_reabstraction13ConcreteClassC24variantOptionalityTuplesAA1CC_AFm_A2FcttAF_AFm_A2FcttSg1x_tF	// ConcreteClass.variantOptionalityTuples(x : (C, (C.Type, (C) -> C))?) -> (C, (C.Type, (C) -> C))
+
 // CHECK-NEXT:   #ConcreteClass.deinit!deallocator: _T027vtable_thunks_reabstraction13ConcreteClassCfD	// ConcreteClass.__deallocating_deinit
 // CHECK-NEXT: }
 
@@ -118,6 +284,10 @@ class ConcreteClassVariance: Opaque<C> {
 // CHECK-NEXT:   #Opaque.variantOptionalityFunctions!1: <T> (Opaque<T>) -> (@escaping (T) -> T) -> ((T) -> T)? : _T027vtable_thunks_reabstraction6OpaqueC27variantOptionalityFunctionsxxcSgxxc1x_tF	// Opaque.variantOptionalityFunctions(x : (A) -> A) -> (A) -> A?
 // CHECK-NEXT:   #Opaque.variantOptionalityTuples!1: <T> (Opaque<T>) -> ((T, (T.Type, (T) -> T))) -> (T, (T.Type, (T) -> T))? : _T027vtable_thunks_reabstraction6OpaqueC24variantOptionalityTuplesx_xm_xxcttSgx_xm_xxctt1x_tF	// Opaque.variantOptionalityTuples(x : (A, (A.Type, (A) -> A))) -> (A, (A.Type, (A) -> A))?
 // CHECK-NEXT:   #Opaque.init!initializer.1: <T> (Opaque<T>.Type) -> () -> Opaque<T> : _T027vtable_thunks_reabstraction21ConcreteClassVarianceCACycfc	// ConcreteClassVariance.init() -> ConcreteClassVariance
+
+// No new vtable entries -- class references are ABI compatible with
+// optional class references.
+
 // CHECK-NEXT:   #ConcreteClassVariance.deinit!deallocator: _T027vtable_thunks_reabstraction21ConcreteClassVarianceCfD	// ConcreteClassVariance.__deallocating_deinit
 // CHECK-NEXT: }
 
@@ -137,6 +307,11 @@ class OpaqueTuple<U>: Opaque<(U, U)> {
 // CHECK-NEXT:   #Opaque.variantOptionalityFunctions!1: <T> (Opaque<T>) -> (@escaping (T) -> T) -> ((T) -> T)? : _T027vtable_thunks_reabstraction6OpaqueC27variantOptionalityFunctionsxxcSgxxc1x_tF	// Opaque.variantOptionalityFunctions(x : (A) -> A) -> (A) -> A?
 // CHECK-NEXT:   #Opaque.variantOptionalityTuples!1: <T> (Opaque<T>) -> ((T, (T.Type, (T) -> T))) -> (T, (T.Type, (T) -> T))? : _T027vtable_thunks_reabstraction6OpaqueC24variantOptionalityTuplesx_xm_xxcttSgx_xm_xxctt1x_tF	// Opaque.variantOptionalityTuples(x : (A, (A.Type, (A) -> A))) -> (A, (A.Type, (A) -> A))?
 // CHECK-NEXT:   #Opaque.init!initializer.1: <T> (Opaque<T>.Type) -> () -> Opaque<T> : _T027vtable_thunks_reabstraction11OpaqueTupleCACyxGycfc	// OpaqueTuple.init() -> OpaqueTuple<A>
+
+// Optionality change of tuple.
+
+// CHECK-NEXT:  #OpaqueTuple.variantOptionality!1: <U> (OpaqueTuple<U>) -> ((U, U)?) -> (U, U) : _T027vtable_thunks_reabstraction11OpaqueTupleC18variantOptionalityx_xtx_xtSg1x_tF	// OpaqueTuple.variantOptionality(x : (A, A)?) -> (A, A)
+
 // CHECK-NEXT:   #OpaqueTuple.deinit!deallocator: _T027vtable_thunks_reabstraction11OpaqueTupleCfD	// OpaqueTuple.__deallocating_deinit
 // CHECK-NEXT: }
 
@@ -156,6 +331,11 @@ class ConcreteTuple: Opaque<(S, S)> {
 // CHECK-NEXT:   #Opaque.variantOptionalityFunctions!1: <T> (Opaque<T>) -> (@escaping (T) -> T) -> ((T) -> T)? : _T027vtable_thunks_reabstraction6OpaqueC27variantOptionalityFunctionsxxcSgxxc1x_tF	// Opaque.variantOptionalityFunctions(x : (A) -> A) -> (A) -> A?
 // CHECK-NEXT:   #Opaque.variantOptionalityTuples!1: <T> (Opaque<T>) -> ((T, (T.Type, (T) -> T))) -> (T, (T.Type, (T) -> T))? : _T027vtable_thunks_reabstraction6OpaqueC24variantOptionalityTuplesx_xm_xxcttSgx_xm_xxctt1x_tF	// Opaque.variantOptionalityTuples(x : (A, (A.Type, (A) -> A))) -> (A, (A.Type, (A) -> A))?
 // CHECK-NEXT:   #Opaque.init!initializer.1: <T> (Opaque<T>.Type) -> () -> Opaque<T> : _T027vtable_thunks_reabstraction13ConcreteTupleCACycfc	// ConcreteTuple.init() -> ConcreteTuple
+
+// Optionality change of tuple.
+
+// CHECK-NEXT:   #ConcreteTuple.variantOptionality!1: (ConcreteTuple) -> ((S, S)?) -> (S, S) : _T027vtable_thunks_reabstraction13ConcreteTupleC18variantOptionalityAA1SV_AFtAF_AFtSg1x_tF	// ConcreteTuple.variantOptionality(x : (S, S)?) -> (S, S)
+
 // CHECK-NEXT:   #ConcreteTuple.deinit!deallocator: _T027vtable_thunks_reabstraction13ConcreteTupleCfD	// ConcreteTuple.__deallocating_deinit
 // CHECK-NEXT: }
 
@@ -175,6 +355,11 @@ class OpaqueFunction<U, V>: Opaque<(U) -> V> {
 // CHECK-NEXT:   #Opaque.variantOptionalityFunctions!1: <T> (Opaque<T>) -> (@escaping (T) -> T) -> ((T) -> T)? : _T027vtable_thunks_reabstraction6OpaqueC27variantOptionalityFunctionsxxcSgxxc1x_tF	// Opaque.variantOptionalityFunctions(x : (A) -> A) -> (A) -> A?
 // CHECK-NEXT:   #Opaque.variantOptionalityTuples!1: <T> (Opaque<T>) -> ((T, (T.Type, (T) -> T))) -> (T, (T.Type, (T) -> T))? : _T027vtable_thunks_reabstraction6OpaqueC24variantOptionalityTuplesx_xm_xxcttSgx_xm_xxctt1x_tF	// Opaque.variantOptionalityTuples(x : (A, (A.Type, (A) -> A))) -> (A, (A.Type, (A) -> A))?
 // CHECK-NEXT:   #Opaque.init!initializer.1: <T> (Opaque<T>.Type) -> () -> Opaque<T> : _T027vtable_thunks_reabstraction14OpaqueFunctionCACyxq_Gycfc	// OpaqueFunction.init() -> OpaqueFunction<A, B>
+
+// Optionality change of function.
+
+// CHECK-NEXT:  #OpaqueFunction.variantOptionality!1: <U, V> (OpaqueFunction<U, V>) -> (((U) -> V)?) -> (U) -> V : _T027vtable_thunks_reabstraction14OpaqueFunctionC18variantOptionalityq_xcq_xcSg1x_tF	// OpaqueFunction.variantOptionality(x : (A) -> B?) -> (A) -> B
+
 // CHECK-NEXT:   #OpaqueFunction.deinit!deallocator: _T027vtable_thunks_reabstraction14OpaqueFunctionCfD	// OpaqueFunction.__deallocating_deinit
 // CHECK-NEXT: }
 
@@ -194,6 +379,11 @@ class ConcreteFunction: Opaque<(S) -> S> {
 // CHECK-NEXT:   #Opaque.variantOptionalityFunctions!1: <T> (Opaque<T>) -> (@escaping (T) -> T) -> ((T) -> T)? : _T027vtable_thunks_reabstraction6OpaqueC27variantOptionalityFunctionsxxcSgxxc1x_tF	// Opaque.variantOptionalityFunctions(x : (A) -> A) -> (A) -> A?
 // CHECK-NEXT:   #Opaque.variantOptionalityTuples!1: <T> (Opaque<T>) -> ((T, (T.Type, (T) -> T))) -> (T, (T.Type, (T) -> T))? : _T027vtable_thunks_reabstraction6OpaqueC24variantOptionalityTuplesx_xm_xxcttSgx_xm_xxctt1x_tF	// Opaque.variantOptionalityTuples(x : (A, (A.Type, (A) -> A))) -> (A, (A.Type, (A) -> A))?
 // CHECK-NEXT:   #Opaque.init!initializer.1: <T> (Opaque<T>.Type) -> () -> Opaque<T> : _T027vtable_thunks_reabstraction16ConcreteFunctionCACycfc	// ConcreteFunction.init() -> ConcreteFunction
+
+// Optionality change of function.
+
+// CHECK-NEXT:   #ConcreteFunction.variantOptionality!1: (ConcreteFunction) -> (((S) -> S)?) -> (S) -> S : _T027vtable_thunks_reabstraction16ConcreteFunctionC18variantOptionalityAA1SVAFcA2FcSg1x_tF	// ConcreteFunction.variantOptionality(x : (S) -> S?) -> (S) -> S
+
 // CHECK-NEXT:   #ConcreteFunction.deinit!deallocator: _T027vtable_thunks_reabstraction16ConcreteFunctionCfD	// ConcreteFunction.__deallocating_deinit
 // CHECK-NEXT: }
 
@@ -213,6 +403,11 @@ class OpaqueMetatype<U>: Opaque<U.Type> {
 // CHECK-NEXT:   #Opaque.variantOptionalityFunctions!1: <T> (Opaque<T>) -> (@escaping (T) -> T) -> ((T) -> T)? : _T027vtable_thunks_reabstraction6OpaqueC27variantOptionalityFunctionsxxcSgxxc1x_tF	// Opaque.variantOptionalityFunctions(x : (A) -> A) -> (A) -> A?
 // CHECK-NEXT:   #Opaque.variantOptionalityTuples!1: <T> (Opaque<T>) -> ((T, (T.Type, (T) -> T))) -> (T, (T.Type, (T) -> T))? : _T027vtable_thunks_reabstraction6OpaqueC24variantOptionalityTuplesx_xm_xxcttSgx_xm_xxctt1x_tF	// Opaque.variantOptionalityTuples(x : (A, (A.Type, (A) -> A))) -> (A, (A.Type, (A) -> A))?
 // CHECK-NEXT:   #Opaque.init!initializer.1: <T> (Opaque<T>.Type) -> () -> Opaque<T> : _T027vtable_thunks_reabstraction14OpaqueMetatypeCACyxGycfc	// OpaqueMetatype.init() -> OpaqueMetatype<A>
+
+// Optionality change of metatype.
+
+// CHECK-NEXT:   #OpaqueMetatype.variantOptionality!1: <U> (OpaqueMetatype<U>) -> (U.Type?) -> U.Type : _T027vtable_thunks_reabstraction14OpaqueMetatypeC18variantOptionalityxmxmSg1x_tF	// OpaqueMetatype.variantOptionality(x : A.Type?) -> A.Type
+
 // CHECK-NEXT:   #OpaqueMetatype.deinit!deallocator: _T027vtable_thunks_reabstraction14OpaqueMetatypeCfD	// OpaqueMetatype.__deallocating_deinit
 // CHECK-NEXT: }
 
@@ -232,6 +427,11 @@ class ConcreteValueMetatype: Opaque<S.Type> {
 // CHECK-NEXT:   #Opaque.variantOptionalityFunctions!1: <T> (Opaque<T>) -> (@escaping (T) -> T) -> ((T) -> T)? : _T027vtable_thunks_reabstraction6OpaqueC27variantOptionalityFunctionsxxcSgxxc1x_tF	// Opaque.variantOptionalityFunctions(x : (A) -> A) -> (A) -> A?
 // CHECK-NEXT:   #Opaque.variantOptionalityTuples!1: <T> (Opaque<T>) -> ((T, (T.Type, (T) -> T))) -> (T, (T.Type, (T) -> T))? : _T027vtable_thunks_reabstraction6OpaqueC24variantOptionalityTuplesx_xm_xxcttSgx_xm_xxctt1x_tF	// Opaque.variantOptionalityTuples(x : (A, (A.Type, (A) -> A))) -> (A, (A.Type, (A) -> A))?
 // CHECK-NEXT:   #Opaque.init!initializer.1: <T> (Opaque<T>.Type) -> () -> Opaque<T> : _T027vtable_thunks_reabstraction21ConcreteValueMetatypeCACycfc	// ConcreteValueMetatype.init() -> ConcreteValueMetatype
+
+// Optionality change of metatype.
+
+// CHECK-NEXT:   #ConcreteValueMetatype.variantOptionality!1: (ConcreteValueMetatype) -> (S.Type?) -> S.Type : _T027vtable_thunks_reabstraction21ConcreteValueMetatypeC18variantOptionalityAA1SVmAFmSg1x_tF	// ConcreteValueMetatype.variantOptionality(x : S.Type?) -> S.Type
+
 // CHECK-NEXT:   #ConcreteValueMetatype.deinit!deallocator: _T027vtable_thunks_reabstraction21ConcreteValueMetatypeCfD	// ConcreteValueMetatype.__deallocating_deinit
 // CHECK-NEXT: }
 
@@ -251,11 +451,16 @@ class ConcreteClassMetatype: Opaque<C.Type> {
 // CHECK-NEXT:   #Opaque.variantOptionalityFunctions!1: <T> (Opaque<T>) -> (@escaping (T) -> T) -> ((T) -> T)? : _T027vtable_thunks_reabstraction6OpaqueC27variantOptionalityFunctionsxxcSgxxc1x_tF	// Opaque.variantOptionalityFunctions(x : (A) -> A) -> (A) -> A?
 // CHECK-NEXT:   #Opaque.variantOptionalityTuples!1: <T> (Opaque<T>) -> ((T, (T.Type, (T) -> T))) -> (T, (T.Type, (T) -> T))? : _T027vtable_thunks_reabstraction6OpaqueC24variantOptionalityTuplesx_xm_xxcttSgx_xm_xxctt1x_tF	// Opaque.variantOptionalityTuples(x : (A, (A.Type, (A) -> A))) -> (A, (A.Type, (A) -> A))?
 // CHECK-NEXT:   #Opaque.init!initializer.1: <T> (Opaque<T>.Type) -> () -> Opaque<T> : _T027vtable_thunks_reabstraction21ConcreteClassMetatypeCACycfc	// ConcreteClassMetatype.init() -> ConcreteClassMetatype
+
+// Class metatypes are ABI compatible with optional class metatypes.
+
 // CHECK-NEXT:   #ConcreteClassMetatype.deinit!deallocator: _T027vtable_thunks_reabstraction21ConcreteClassMetatypeCfD	// ConcreteClassMetatype.__deallocating_deinit
 // CHECK-NEXT: }
 
 class ConcreteOptional: Opaque<S?> {
   override func inAndOut(x: S?) -> S? { return x }
+
+  // FIXME: Should we allow this override in Sema?
   // override func variantOptionality(x: S??) -> S? { return x! }
 }
 


### PR DESCRIPTION
We had problems with two cases:

- The override had a more general calling convention (eg, a value type parameter was non-optional in the base class and became optional in the derived class)
- The override required a thunk because of re-abstraction (eg, a parameter was generic in the base class but concrete in the derived class) and the override had an ABI-compatible type but different AST type (eg, it was an optional of a reference type)

The case where the override had an ABI-compatible type but different AST type with no re-abstraction required already worked, so I just beefed up the tests a bit in this case.

This is the followup to https://github.com/apple/swift/pull/8313 that addresses <rdar://problem/20470738> and https://bugs.swift.org/browse/SR-1529.