### PR TITLE
[swiftc (24 vs. 5511)] Add crasher in swift::TypeBase::getCanonicalType(...)

### DIFF
--- a/validation-test/compiler_crashers/28725-gpdecl-getdepth-generictypeparamdecl-invaliddepth-parameter-hasnt-been-validated.swift
+++ b/validation-test/compiler_crashers/28725-gpdecl-getdepth-generictypeparamdecl-invaliddepth-parameter-hasnt-been-validated.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+struct B{let f=a}protocol P{}extension P{extension{func&(U=


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeBase::getCanonicalType(...)`.

Current number of unresolved compiler crashers: 24 (5511 resolved)

/cc @slavapestov - just wanted to let you know that this crasher caused an assertion failure for the assertion `gpDecl->getDepth() != GenericTypeParamDecl::InvalidDepth && "parameter hasn't been validated"` added on 2017-02-22 by you in commit fdb0a186 :-)

Assertion failure in [`lib/AST/Type.cpp (line 1045)`](https://github.com/apple/swift/blob/fba882ff21dba4bb53e995805d275e3b6cdd22aa/lib/AST/Type.cpp#L1045):

```
Assertion `gpDecl->getDepth() != GenericTypeParamDecl::InvalidDepth && "parameter hasn't been validated"' failed.

When executing: swift::CanType swift::TypeBase::getCanonicalType()
```

Assertion context:

```c++

  case TypeKind::GenericTypeParam: {
    GenericTypeParamType *gp = cast<GenericTypeParamType>(this);
    auto gpDecl = gp->getDecl();
    assert(gpDecl->getDepth() != GenericTypeParamDecl::InvalidDepth &&
           "parameter hasn't been validated");
    Result = GenericTypeParamType::get(gpDecl->getDepth(), gpDecl->getIndex(),
                                       gpDecl->getASTContext());
    break;
  }

```
Stack trace:

```
0 0x000000000394ec88 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x394ec88)
1 0x000000000394f3c6 SignalHandler(int) (/path/to/swift/bin/swift+0x394f3c6)
2 0x00007f435f948390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007f435de6e428 gsignal /build/glibc-9tT8Do/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f435de7002a abort /build/glibc-9tT8Do/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f435de66bd7 __assert_fail_base /build/glibc-9tT8Do/glibc-2.23/assert/assert.c:92:0
6 0x00007f435de66c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x00000000014de90c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x14de90c)
8 0x00000000013c8713 swift::ErrorType::get(swift::Type) (/path/to/swift/bin/swift+0x13c8713)
9 0x00000000014eb982 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::OptionSet<swift::SubstFlags, unsigned int>)::$_17>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x14eb982)
10 0x00000000014e81e9 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x14e81e9)
11 0x00000000014e73fe swift::Type::substDependentTypesWithErrorTypes() const (/path/to/swift/bin/swift+0x14e73fe)
12 0x0000000001485982 swift::GenericEnvironment::mapTypeIntoContext(swift::GenericEnvironment*, swift::Type) (/path/to/swift/bin/swift+0x1485982)
13 0x00000000014c3bf0 swift::UnqualifiedLookup::UnqualifiedLookup(swift::DeclName, swift::DeclContext*, swift::LazyResolver*, bool, swift::SourceLoc, bool, bool, bool) (/path/to/swift/bin/swift+0x14c3bf0)
14 0x00000000012cd847 swift::TypeChecker::lookupUnqualifiedType(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) (/path/to/swift/bin/swift+0x12cd847)
15 0x000000000131130e resolveTopLevelIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x131130e)
16 0x000000000130ba7e resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x130ba7e)
17 0x000000000130b4a3 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x130b4a3)
18 0x000000000130c5b7 (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0x130c5b7)
19 0x000000000130c4bc swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x130c4bc)
20 0x000000000130abba swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x130abba)
21 0x00000000012d0389 validateParameterType(swift::ParamDecl*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver&, swift::TypeChecker&) (/path/to/swift/bin/swift+0x12d0389)
22 0x00000000012d0239 swift::TypeChecker::typeCheckParameterList(swift::ParameterList*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver&) (/path/to/swift/bin/swift+0x12d0239)
23 0x00000000012ba9e3 (anonymous namespace)::DeclChecker::semaFuncParamPatterns(swift::AbstractFunctionDecl*, swift::GenericTypeResolver&) (/path/to/swift/bin/swift+0x12ba9e3)
24 0x00000000012ae314 (anonymous namespace)::DeclChecker::visitFuncDecl(swift::FuncDecl*) (/path/to/swift/bin/swift+0x12ae314)
25 0x000000000129b417 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x129b417)
26 0x000000000129d272 swift::TypeChecker::validateDecl(swift::ValueDecl*) (/path/to/swift/bin/swift+0x129d272)
27 0x00000000014c0e45 swift::namelookup::ResolutionKind recordImportDecls<llvm::DenseMap<swift::Identifier, std::pair<swift::namelookup::ResolutionKind, llvm::SmallSet<swift::CanType, 4u, (anonymous namespace)::SortCanType> >, llvm::DenseMapInfo<swift::Identifier>, llvm::detail::DenseMapPair<swift::Identifier, std::pair<swift::namelookup::ResolutionKind, llvm::SmallSet<swift::CanType, 4u, (anonymous namespace)::SortCanType> > > > >(swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&, llvm::ArrayRef<swift::ValueDecl*>, llvm::DenseMap<swift::Identifier, std::pair<swift::namelookup::ResolutionKind, llvm::SmallSet<swift::CanType, 4u, (anonymous namespace)::SortCanType> >, llvm::DenseMapInfo<swift::Identifier>, llvm::detail::DenseMapPair<swift::Identifier, std::pair<swift::namelookup::ResolutionKind, llvm::SmallSet<swift::CanType, 4u, (anonymous namespace)::SortCanType> > > >&, swift::namelookup::ResolutionKind) (/path/to/swift/bin/swift+0x14c0e45)
28 0x00000000014bf05a void lookupInModule<llvm::DenseMap<swift::Identifier, std::pair<swift::namelookup::ResolutionKind, llvm::SmallSet<swift::CanType, 4u, (anonymous namespace)::SortCanType> >, llvm::DenseMapInfo<swift::Identifier>, llvm::detail::DenseMapPair<swift::Identifier, std::pair<swift::namelookup::ResolutionKind, llvm::SmallSet<swift::CanType, 4u, (anonymous namespace)::SortCanType> > > >, swift::namelookup::lookupVisibleDeclsInModule(swift::ModuleDecl*, llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, llvm::SmallVectorImpl<swift::ValueDecl*>&, swift::NLKind, swift::namelookup::ResolutionKind, swift::LazyResolver*, swift::DeclContext const*, llvm::ArrayRef<std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*> >)::$_1>(swift::ModuleDecl*, llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, llvm::SmallVectorImpl<swift::ValueDecl*>&, swift::namelookup::ResolutionKind, bool, swift::LazyResolver*, llvm::SmallDenseMap<std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*>, llvm::TinyPtrVector<swift::ValueDecl*>, 32u, llvm::DenseMapInfo<std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*> >, llvm::detail::DenseMapPair<std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*>, llvm::TinyPtrVector<swift::ValueDecl*> > >&, swift::DeclContext const*, bool, llvm::ArrayRef<std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*> >, swift::namelookup::lookupVisibleDeclsInModule(swift::ModuleDecl*, llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, llvm::SmallVectorImpl<swift::ValueDecl*>&, swift::NLKind, swift::namelookup::ResolutionKind, swift::LazyResolver*, swift::DeclContext const*, llvm::ArrayRef<std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*> >)::$_1) (/path/to/swift/bin/swift+0x14bf05a)
29 0x00000000014be8a3 swift::namelookup::lookupVisibleDeclsInModule(swift::ModuleDecl*, llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, llvm::SmallVectorImpl<swift::ValueDecl*>&, swift::NLKind, swift::namelookup::ResolutionKind, swift::LazyResolver*, swift::DeclContext const*, llvm::ArrayRef<std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*> >) (/path/to/swift/bin/swift+0x14be8a3)
30 0x00000000014acf4d swift::lookupVisibleDecls(swift::VisibleDeclConsumer&, swift::DeclContext const*, swift::LazyResolver*, bool, swift::SourceLoc) (/path/to/swift/bin/swift+0x14acf4d)
31 0x00000000012ce638 swift::TypeChecker::performTypoCorrection(swift::DeclContext*, swift::DeclRefKind, swift::Type, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>, swift::LookupResult&, unsigned int) (/path/to/swift/bin/swift+0x12ce638)
32 0x00000000012823e4 swift::TypeChecker::resolveDeclRefExpr(swift::UnresolvedDeclRefExpr*, swift::DeclContext*) (/path/to/swift/bin/swift+0x12823e4)
33 0x000000000128e8d2 (anonymous namespace)::PreCheckExpression::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x128e8d2)
34 0x000000000144121b swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x144121b)
35 0x0000000001283665 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0x1283665)
36 0x0000000001286d96 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x1286d96)
37 0x000000000128aa81 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*, bool) (/path/to/swift/bin/swift+0x128aa81)
38 0x000000000128ac46 swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int, bool) (/path/to/swift/bin/swift+0x128ac46)
39 0x00000000012a0e28 validatePatternBindingEntries(swift::TypeChecker&, swift::PatternBindingDecl*) (/path/to/swift/bin/swift+0x12a0e28)
40 0x000000000129b334 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x129b334)
41 0x00000000012aac7b (anonymous namespace)::DeclChecker::visitStructDecl(swift::StructDecl*) (/path/to/swift/bin/swift+0x12aac7b)
42 0x000000000129b3e7 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x129b3e7)
43 0x000000000129b1f3 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x129b1f3)
44 0x0000000001319005 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x1319005)
45 0x0000000000f8f5b6 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf8f5b6)
46 0x00000000004a76bb swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a76bb)
47 0x00000000004650b7 main (/path/to/swift/bin/swift+0x4650b7)
48 0x00007f435de59830 __libc_start_main /build/glibc-9tT8Do/glibc-2.23/csu/../csu/libc-start.c:325:0
49 0x0000000000462759 _start (/path/to/swift/bin/swift+0x462759)
```