### PR TITLE
[sil-opt] Add a new option -disable-sil-linking to dump swiftmodules "as is"

### DIFF
--- a/test/ClangImporter/serialization-sil.swift
+++ b/test/ClangImporter/serialization-sil.swift
@@ -40,4 +40,4 @@ public func testPartialApply(_ obj: Test) {
     // CHECK: = apply [[PROP2_PARTIAL]]() : $@callee_owned () -> UnsafeMutableRawPointer
     _ = prop2
   }
-} // CHECK: {{^}$}}
+} // CHECK: // end sil function '_T04Test16testPartialApplyySoAA_pF'

--- a/tools/sil-func-extractor/SILFunctionExtractor.cpp
+++ b/tools/sil-func-extractor/SILFunctionExtractor.cpp
@@ -116,6 +116,11 @@ static llvm::cl::opt<bool> AssumeUnqualifiedOwnershipWhenParsing(
     llvm::cl::init(false),
     llvm::cl::desc("Assume all parsed functions have unqualified ownership"));
 
+static llvm::cl::opt<bool>
+DisableSILLinking("disable-sil-linking",
+                  llvm::cl::init(true),
+                  llvm::cl::desc("Disable SIL linking"));
+
 // This function isn't referenced outside its translation unit, but it
 // can't use the "static" keyword because its address is used for
 // getMainExecutable (since some platforms don't support taking the
@@ -303,7 +308,7 @@ int main(int argc, char **argv) {
     std::unique_ptr<SerializedSILLoader> SL = SerializedSILLoader::create(
         CI.getASTContext(), CI.getSILModule(), nullptr);
 
-    if (extendedInfo.isSIB())
+    if (extendedInfo.isSIB() || DisableSILLinking)
       SL->getAllForModule(CI.getMainModule()->getName(), nullptr);
     else
       SL->getAll();

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -121,6 +121,10 @@ static llvm::cl::opt<unsigned>
 AssertConfId("assert-conf-id", llvm::cl::Hidden,
              llvm::cl::init(0));
 
+static llvm::cl::opt<bool>
+DisableSILLinking("disable-sil-linking",
+                  llvm::cl::desc("Disable SIL linking"));
+
 static llvm::cl::opt<int>
 SILInlineThreshold("sil-inline-threshold", llvm::cl::Hidden,
                    llvm::cl::init(-1));
@@ -324,7 +328,7 @@ int main(int argc, char **argv) {
     std::unique_ptr<SerializedSILLoader> SL = SerializedSILLoader::create(
         CI.getASTContext(), CI.getSILModule(), nullptr);
 
-    if (extendedInfo.isSIB())
+    if (extendedInfo.isSIB() || DisableSILLinking)
       SL->getAllForModule(CI.getMainModule()->getName(), nullptr);
     else
       SL->getAll();


### PR DESCRIPTION
Usually, if you use `sil-opt my.swiftmodule` it would dump a lot of SIL, because it would try to link external SIL functions linked by the module (e.g. functions from the standard library) and dump them as well.

The new option allows for dumping only the SIL contained in the swiftmodule. This is very useful if you want to inspect the content of a swiftmodule.

