### PR TITLE
Fix opaque value corner-cases for classes and vtables

### DIFF
--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -1057,7 +1057,7 @@ namespace {
       auto loweredTy = loweredTL.getLoweredType();
       auto optionalTy = SGF.getSILType(claimNextOutputType());
       auto someDecl = SGF.getASTContext().getOptionalSomeDecl();
-      if (loweredTL.isLoadable()) {
+      if (loweredTL.isLoadable() || !SGF.silConv.useLoweredAddresses()) {
         auto payload =
           translateAndImplodeIntoValue(inputOrigType, inputTupleType,
                                        outputOrigType, outputTupleType,
@@ -1171,7 +1171,8 @@ namespace {
         auto outputEltOrigType = outputOrigType.getTupleElementType(index);
         auto outputEltSubstType = outputSubstType.getElementType(index);
         auto inputEltAddr = inputEltAddrs[index].first;
-        assert(inputEltAddr.getType().isAddress());
+        assert(inputEltAddr.getType().isAddress() ||
+               !SGF.silConv.useLoweredAddresses());
 
         if (auto outputEltTupleType = dyn_cast<TupleType>(outputEltSubstType)) {
           assert(outputEltOrigType.isTuple());
@@ -1993,7 +1994,7 @@ ResultPlanner::planIntoDirectResult(AbstractionPattern innerOrigType,
                                     CanType outerSubstType,
                                     PlanData &planData,
                                     SILResultInfo outerResult) {
-  assert(!outerOrigType.isTuple());
+  assert(!outerOrigType.isTuple() || !Gen.silConv.useLoweredAddresses());
 
   // If the inner pattern is a tuple, expand it.
   if (innerOrigType.isTuple()) {


### PR DESCRIPTION
Small part of radar rdar://problem/30080769

This PR adds support for "tricky" vtables under opaque value mode