### PR TITLE
Mangling: Make sure we have different names for function overloads with all args in a tuple.

### DIFF
--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -169,11 +169,11 @@ protected:
 
   void appendNominalType(const NominalTypeDecl *decl);
 
-  void appendFunctionType(AnyFunctionType *fn);
+  void appendFunctionType(AnyFunctionType *fn, bool forceSingleParam);
 
-  void appendFunctionSignature(AnyFunctionType *fn);
+  void appendFunctionSignature(AnyFunctionType *fn, bool forceSingleParam);
 
-  void appendParams(Type ParamsTy);
+  void appendParams(Type ParamsTy, bool forceSingleParam);
 
   void appendTypeList(Type listTy);
 
@@ -205,7 +205,7 @@ protected:
                                  ArrayRef<Requirement> &requirements,
                                  SmallVectorImpl<Requirement> &requirementsBuf);
 
-  void appendDeclType(const ValueDecl *decl);
+  void appendDeclType(const ValueDecl *decl, bool isFunctionMangling = false);
 
   bool tryAppendStandardSubstitution(const NominalTypeDecl *type);
 

--- a/test/IRGen/generic_tuples.swift
+++ b/test/IRGen/generic_tuples.swift
@@ -83,13 +83,13 @@ func lump3<T>(_ x: T) -> (T, T, T) { return (x,x,x) }
 // CHECK: define hidden swiftcc i64 @_T014generic_tuples5lump4x_SixtxlF(%swift.opaque* noalias nocapture, %swift.opaque* noalias nocapture, %swift.opaque* noalias nocapture, %swift.type* %T)
 func lump4<T>(_ x: T) -> (T, Int, T) { return (x,0,x) }
 
-// CHECK: define hidden swiftcc i64 @_T014generic_tuples6unlumpS2i_xxtlF(i64, %swift.opaque* noalias nocapture, %swift.opaque* noalias nocapture, %swift.type* %T)
+// CHECK: define hidden swiftcc i64 @_T014generic_tuples6unlumpS2i_xxt_tlF(i64, %swift.opaque* noalias nocapture, %swift.opaque* noalias nocapture, %swift.type* %T)
 func unlump<T>(_ x: (Int, T, T)) -> Int { return x.0 }
-// CHECK: define hidden swiftcc void @_T014generic_tuples7unlump1xSi_xxtlF(%swift.opaque* noalias nocapture sret, i64, %swift.opaque* noalias nocapture, %swift.opaque* noalias nocapture, %swift.type* %T)
+// CHECK: define hidden swiftcc void @_T014generic_tuples7unlump1xSi_xxt_tlF(%swift.opaque* noalias nocapture sret, i64, %swift.opaque* noalias nocapture, %swift.opaque* noalias nocapture, %swift.type* %T)
 func unlump1<T>(_ x: (Int, T, T)) -> T { return x.1 }
-// CHECK: define hidden swiftcc void @_T014generic_tuples7unlump2xx_SixtlF(%swift.opaque* noalias nocapture sret, %swift.opaque* noalias nocapture, i64, %swift.opaque* noalias nocapture, %swift.type* %T)
+// CHECK: define hidden swiftcc void @_T014generic_tuples7unlump2xx_Sixt_tlF(%swift.opaque* noalias nocapture sret, %swift.opaque* noalias nocapture, i64, %swift.opaque* noalias nocapture, %swift.type* %T)
 func unlump2<T>(_ x: (T, Int, T)) -> T { return x.0 }
-// CHECK: define hidden swiftcc i64 @_T014generic_tuples7unlump3Six_SixtlF(%swift.opaque* noalias nocapture, i64, %swift.opaque* noalias nocapture, %swift.type* %T)
+// CHECK: define hidden swiftcc i64 @_T014generic_tuples7unlump3Six_Sixt_tlF(%swift.opaque* noalias nocapture, i64, %swift.opaque* noalias nocapture, %swift.type* %T)
 func unlump3<T>(_ x: (T, Int, T)) -> Int { return x.1 }
 
 

--- a/test/SILGen/arguments_as_tuple_overloads.swift
+++ b/test/SILGen/arguments_as_tuple_overloads.swift
@@ -1,0 +1,37 @@
+// RUN: %target-swift-frontend -parse-as-library -module-name=test -emit-silgen -primary-file %s | %FileCheck %s
+
+// Check if we mangle the following constructors and functions correctly.
+
+public struct Pair {
+  // CHECK: sil @_T04test4PairVACSi_SitcfC :
+  public init(_ a: Int, _ b: Int) {
+  }
+
+  // CHECK: sil @_T04test4PairVACSi_Sit_tcfC :
+  public init(_ t: (Int, Int)) {
+  }
+
+  // CHECK: sil @_T04test4PairVAAySi_SitF :
+  public func test(_ a: Int, _ b: Int) {
+  }
+
+  // CHECK: sil @_T04test4PairVAAySi_Sit_tF :
+  public func test(_ t: (Int, Int)) {
+  }
+}
+
+// CHECK: sil @_T04testAAySi_SitF :
+public func test(_ a: Int, _ b: Int) {
+}
+
+// CHECK: sil @_T04testAAySi_Sit_tF :
+public func test(_ t: (Int, Int)) {
+}
+
+// CHECK: sil @_T04test3fooyt_tyF :
+public func foo(_: ()) {
+}
+
+// CHECK: sil @_T04test3fooyyF :
+public func foo() {
+}

--- a/test/SILGen/mangling.swift
+++ b/test/SILGen/mangling.swift
@@ -40,9 +40,9 @@ postfix func +- <T>(a: T) {}
 // CHECK-LABEL: sil hidden @_T08mangling2psoiyx_xtlF
 func +- <T>(a: T, b: T) {}
 
-// CHECK-LABEL: sil hidden @_T08mangling2psopyx1a_x1btlF
+// CHECK-LABEL: sil hidden @_T08mangling2psopyx1a_x1bt_tlF
 prefix func +- <T>(_: (a: T, b: T)) {}
-// CHECK-LABEL: sil hidden @_T08mangling2psoPyx1a_x1btlF
+// CHECK-LABEL: sil hidden @_T08mangling2psoPyx1a_x1bt_tlF
 postfix func +- <T>(_: (a: T, b: T)) {}
 
 infix operator «+» {}

--- a/test/SILGen/opaque_values_silgen.swift
+++ b/test/SILGen/opaque_values_silgen.swift
@@ -195,7 +195,7 @@ func s030______assigninout<T>(_ a: inout T, _ b: T) {
 
 // Test that we no longer use copy_addr or tuple_element_addr when copy by value is possible
 // ---
-// CHECK-LABEL: sil hidden @_T020opaque_values_silgen21s040___tupleReturnIntS2i_xtlF : $@convention(thin) <T> (Int, @in T) -> Int {
+// CHECK-LABEL: sil hidden @_T020opaque_values_silgen21s040___tupleReturnIntS2i_xt_tlF : $@convention(thin) <T> (Int, @in T) -> Int {
 // CHECK: bb0([[ARG0:%.*]] : $Int, [[ARG1:%.*]] : $T):
 // CHECK:   [[TPL:%.*]] = tuple ([[ARG0]] : $Int, [[ARG1]] : $T)
 // CHECK:   [[BORROWED_ARG1:%.*]] = begin_borrow [[TPL]] : $(Int, T)
@@ -210,7 +210,7 @@ func s030______assigninout<T>(_ a: inout T, _ b: T) {
 // CHECK:   end_borrow [[BORROWED_ARG1]] from [[TPL]] : $(Int, T), $(Int, T)
 // CHECK:   destroy_value [[TPL]] : $(Int, T)
 // CHECK:   return [[INT]]
-// CHECK-LABEL: } // end sil function '_T020opaque_values_silgen21s040___tupleReturnIntS2i_xtlF'
+// CHECK-LABEL: } // end sil function '_T020opaque_values_silgen21s040___tupleReturnIntS2i_xt_tlF'
 func s040___tupleReturnInt<T>(_ x: (Int, T)) -> Int {
   let y = x.0
   return y


### PR DESCRIPTION
For example:
public func test(_ a: Int, _ b: Int)
public func test(_ t: (Int, Int))

fixes rdar://problem/31211238
