### PR TITLE
[WIP] [ClangImporter] pick one property decl and stick with it.

### DIFF
--- a/test/ClangImporter/Inputs/frameworks/PrivatelyReadwrite.framework/Headers/PrivatelyReadwrite.h
+++ b/test/ClangImporter/Inputs/frameworks/PrivatelyReadwrite.framework/Headers/PrivatelyReadwrite.h
@@ -1,0 +1,19 @@
+__attribute__((objc_root_class))
+@interface Base
+- (nonnull instancetype)init;
+@end
+
+@interface GenericClass<T>: Base
+@end
+
+@interface PropertiesA : Base
+@property (readonly, nonnull) Base *nullabilityChange;
+@property (readonly, nonnull) GenericClass<Base *> *missingGenerics;
+@property (readonly, nonnull) Base *typeChange;
+@end
+
+@interface PropertiesB : Base
+@property (readonly, nonnull) Base *nullabilityChange;
+@property (readonly, nonnull) GenericClass<Base *> *missingGenerics;
+@property (readonly, nonnull) Base *typeChange;
+@end

--- a/test/ClangImporter/Inputs/frameworks/PrivatelyReadwrite.framework/Modules/module.modulemap
+++ b/test/ClangImporter/Inputs/frameworks/PrivatelyReadwrite.framework/Modules/module.modulemap
@@ -1,0 +1,7 @@
+framework module PrivatelyReadwrite {
+  umbrella header "PrivatelyReadwrite.h"
+  module * {
+    export *
+  }
+  exclude header "Private.h"
+}

--- a/test/ClangImporter/Inputs/frameworks/PrivatelyReadwrite.framework/PrivateHeaders/Private.h
+++ b/test/ClangImporter/Inputs/frameworks/PrivatelyReadwrite.framework/PrivateHeaders/Private.h
@@ -1,0 +1,16 @@
+#import <PrivatelyReadwrite/PrivatelyReadwrite.h>
+
+@interface PrivateSubclass : Base
+@end
+
+@interface PropertiesA ()
+@property (readwrite, nullable) Base *nullabilityChange;
+@property (readwrite, nonnull) GenericClass *missingGenerics;
+@property (readwrite, nonnull) PrivateSubclass *typeChange;
+@end
+
+@interface PropertiesB ()
+@property (readwrite, nullable) Base *nullabilityChange;
+@property (readwrite, nonnull) GenericClass *missingGenerics;
+@property (readwrite, nonnull) PrivateSubclass *typeChange;
+@end

--- a/test/ClangImporter/objc_redeclared_properties_incompatible.swift
+++ b/test/ClangImporter/objc_redeclared_properties_incompatible.swift
@@ -1,0 +1,43 @@
+// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -F %S/Inputs/frameworks %s 2>&1 | %FileCheck -check-prefix=CHECK-PUBLIC-ONLY %s
+
+// RUN: echo '#import <PrivatelyReadwrite/Private.h>' > %t.h
+// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -F %S/Inputs/frameworks -import-objc-header %t.h %s 2>&1 | %FileCheck -check-prefix=CHECK-PRIVATE %s
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-pch -F %S/Inputs/frameworks -o %t.pch %t.h
+// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -F %S/Inputs/frameworks -import-objc-header %t.pch %s 2>&1 | %FileCheck -check-prefix=CHECK-PRIVATE %s
+
+// REQUIRES: objc_interop
+
+import PrivatelyReadwrite
+
+// In the original bug, it made a difference whether the type was instantiated;
+// it resulted in members being imported in a different order.
+func testWithInitializer() {
+  let obj = PropertiesA()
+
+  let _: Int = obj.nullabilityChange
+  // CHECK-PUBLIC-ONLY: [[@LINE-1]]:20: error: cannot convert value of type 'Base' to specified type 'Int'
+  // CHECK-PRIVATE: [[@LINE-2]]:20: error: cannot convert value of type 'Base?' to specified type 'Int'
+
+  let _: Int = obj.missingGenerics
+  // CHECK-PUBLIC-ONLY: [[@LINE-1]]:20: error: cannot convert value of type 'GenericClass<Base>' to specified type 'Int'
+  // CHECK-PRIVATE: [[@LINE-2]]:20: error: cannot convert value of type 'GenericClass<AnyObject>' to specified type 'Int'
+
+  let _: Int = obj.typeChange
+  // CHECK-PUBLIC-ONLY: [[@LINE-1]]:20: error: cannot convert value of type 'Base' to specified type 'Int'
+  // CHECK-PRIVATE: [[@LINE-2]]:20: error: cannot convert value of type 'PrivateSubclass' to specified type 'Int'
+}
+
+func testWithoutInitializer(obj: PropertiesB) {
+  let _: Int = obj.nullabilityChange
+  // CHECK-PUBLIC-ONLY: [[@LINE-1]]:20: error: cannot convert value of type 'Base' to specified type 'Int'
+  // CHECK-PRIVATE: [[@LINE-2]]:20: error: cannot convert value of type 'Base' to specified type 'Int'
+
+  let _: Int = obj.missingGenerics
+  // CHECK-PUBLIC-ONLY: [[@LINE-1]]:20: error: cannot convert value of type 'GenericClass<Base>' to specified type 'Int'
+  // CHECK-PRIVATE: [[@LINE-2]]:20: error: cannot convert value of type 'GenericClass<Base>' to specified type 'Int'
+
+  let _: Int = obj.typeChange
+  // CHECK-PUBLIC-ONLY: [[@LINE-1]]:20: error: cannot convert value of type 'Base' to specified type 'Int'
+  // CHECK-PRIVATE: [[@LINE-2]]:20: error: cannot convert value of type 'Base' to specified type 'Int'
+}


### PR DESCRIPTION
In certain situations (which I have yet to pin down) the members of an Objective-C class extension (a special kind of category) can get imported before the members of the class itself. Class extensions are often used to redeclare publicly `readonly` properties as `readwrite`. Unfortunately, if the class extension's property has a different type than the original property, the AST verifier (rightfully) flags the getter and setter as having different types. This usually takes the form of mismatched nullability, or providing Objective-C generics in the main interface but not in the class extension.

This first attempt at a fix follows Clang's lead in preferring the version in the class extension. That seems a little odd since that's the version that developers are less likely to be careful about, but it matches the idea that the class extension version is supposed to supersede the one in the main `@interface` when visible.

(This PR is only supposed to be about the second commit. I'll rebase before merging.)