### PR TITLE
Add a syntax to express the new _Class and _Native class layout constraints

### DIFF
--- a/include/swift/AST/KnownIdentifiers.def
+++ b/include/swift/AST/KnownIdentifiers.def
@@ -84,6 +84,8 @@ IDENTIFIER_WITH_NAME(TrivialLayout, "_Trivial")
 IDENTIFIER_WITH_NAME(TrivialAtMostLayout, "_TrivialAtMost")
 IDENTIFIER_WITH_NAME(RefCountedObjectLayout, "_RefCountedObject")
 IDENTIFIER_WITH_NAME(NativeRefCountedObjectLayout, "_NativeRefCountedObject")
+IDENTIFIER_WITH_NAME(ClassLayout, "_Class")
+IDENTIFIER_WITH_NAME(NativeClassLayout, "_NativeClass")
 
 // Operators
 IDENTIFIER_WITH_NAME(MatchOperator, "~=")

--- a/lib/AST/LayoutConstraint.cpp
+++ b/lib/AST/LayoutConstraint.cpp
@@ -39,6 +39,14 @@ LayoutConstraint getLayoutConstraint(Identifier ID, ASTContext &Ctx) {
     return LayoutConstraint::getLayoutConstraint(
         LayoutConstraintKind::NativeRefCountedObject, Ctx);
 
+  if (ID == Ctx.Id_ClassLayout)
+    return LayoutConstraint::getLayoutConstraint(
+      LayoutConstraintKind::Class, Ctx);
+
+  if (ID == Ctx.Id_NativeClassLayout)
+    return LayoutConstraint::getLayoutConstraint(
+      LayoutConstraintKind::NativeClass, Ctx);
+
   return LayoutConstraint::getLayoutConstraint(
       LayoutConstraintKind::UnknownLayout, Ctx);
 }

--- a/test/attr/attr_specialize.swift
+++ b/test/attr/attr_specialize.swift
@@ -211,6 +211,9 @@ public func copyValue<S>(_ t: S, s: inout S) -> Int64 where S: P{
 @_specialize(exported: true, where S: _Trivial(64))
 @_specialize(exported: true, where S: _Trivial(32))
 @_specialize(exported: true, where S: _RefCountedObject)
+@_specialize(exported: true, where S: _NativeRefCountedObject)
+@_specialize(exported: true, where S: _Class)
+@_specialize(exported: true, where S: _NativeClass)
 @inline(never)
 public func copyValueAndReturn<S>(_ t: S, s: inout S) -> S where S: P{
   return s


### PR DESCRIPTION
The syntax is "T: _Class" and "T: _NativeClass".
