### PR TITLE
[GSB] Suppress same-type-to-concrete constraints for nested types.

### DIFF
--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1217,7 +1217,18 @@ GenericSignatureBuilder *ASTContext::getOrCreateGenericSignatureBuilder(
   builder->finalize(SourceLoc(), sig->getGenericParams(),
                     /*allowConcreteGenericParams=*/true);
 
-  assert(builder->getGenericSignature()->getCanonicalSignature() == sig);
+#ifndef NDEBUG
+  if (builder->getGenericSignature()->getCanonicalSignature() != sig) {
+    llvm::errs() << "ERROR: generic signature builder is not idempotent.\n";
+    llvm::errs() << "Original generic signature   : ";
+    sig->print(llvm::errs());
+    llvm::errs() << "\nReprocessed generic signature: ";
+    builder->getGenericSignature()->getCanonicalSignature()
+    ->print(llvm::errs());
+    llvm::errs() << "\n";
+    llvm_unreachable("idempotency problem with a generic signature");
+  }
+#endif
 
   // Store this generic signature builder (no generic environment yet).
   Impl.GenericSignatureBuilders[{sig, mod}] =

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -4092,6 +4092,13 @@ void GenericSignatureBuilder::enumerateRequirements(llvm::function_ref<
       // If this equivalence class is bound to a concrete type, equate the
       // anchor with a concrete type.
       if (Type concreteType = rep->getConcreteType()) {
+        // If the parent of this anchor is also in the equivalence class,
+        // don't create a requirement... it's covered by the "parent"
+        // relationship.
+        if (!archetype->isGenericParam() &&
+            archetype->getParent()->getRepresentative() == rep)
+          continue;
+
         auto source =
           knownAnchor->concreteTypeSource
             ? knownAnchor->concreteTypeSource

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -277,3 +277,21 @@ struct X16<X, Y> : P16 {
 struct X17<S: P16, T, U> where S.A == (T, U) {
 	func bar<V>(_: V) where S == X16<X3, X15> { }
 }
+
+// Same-type constraints that are self-derived via a parent need to be
+// supressed in the resulting signature.
+protocol P17 { }
+
+protocol P18 {
+  associatedtype A: P17
+}
+
+struct X18: P18, P17 {
+  typealias A = X18
+}
+
+// CHECK-LABEL: .X19.foo@
+// CHECK: Generic signature: <T, U where T == X18>
+struct X19<T: P18> where T == T.A {
+  func foo<U>(_: U) where T == X18 { }
+}


### PR DESCRIPTION
When a nested type is within the same equivalence class as its parent,
don't emit a redundant same-type-to-concrete constraint for the
corresponding potential archetype. The nested type's constraint will
be derived from the parent... which is technically a self-derived
constraint, yet needs to be suppressed.