### PR TITLE
Drop SwiftBridge API notes from ObjectiveC.apinotes.

### DIFF
--- a/apinotes/ObjectiveC.apinotes
+++ b/apinotes/ObjectiveC.apinotes
@@ -1,14 +1,6 @@
 ---
 Name: ObjectiveC
 Classes:
-- Name: NSArray
-  SwiftBridge: 'Swift.Array'
-- Name: NSDictionary
-  SwiftBridge: 'Swift.Dictionary'
-- Name: NSSet
-  SwiftBridge: 'Swift.Set'
-- Name: NSString
-  SwiftBridge: 'Swift.String'
 - Name: List
   Methods:
   - Selector: init


### PR DESCRIPTION
These classes are defined in Foundation and the API notes should be applied there (and are). No functionality change – if a Swift target only imported ObjectiveC, they wouldn't be able to bridge the types anyway, since the bridging code is applied in Foundation.