### PR TITLE
IDE: Fix USR mangling for unnamed subscript parameters

### DIFF
--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -385,26 +385,43 @@ static bool isInPrivateOrLocalContext(const ValueDecl *D) {
   return isInPrivateOrLocalContext(nominal);
 }
 
-static unsigned getUnnamedParamIndex(const Decl *D) {
-  unsigned UnnamedIndex = 0;
+static bool getUnnamedParamIndex(const ParameterList *ParamList,
+                                 const ParamDecl *D,
+                                 unsigned &UnnamedIndex) {
+  for (auto Param : *ParamList) {
+    if (!Param->hasName()) {
+      if (Param == D)
+        return true;
+      ++UnnamedIndex;
+    }
+  }
+  return false;
+}
+
+static unsigned getUnnamedParamIndex(const ParamDecl *D) {
+  if (auto SD = dyn_cast<SubscriptDecl>(D->getDeclContext())) {
+    unsigned UnnamedIndex = 0;
+    auto *ParamList = SD->getIndices();
+    if (getUnnamedParamIndex(ParamList, D, UnnamedIndex))
+      return UnnamedIndex;
+    llvm_unreachable("param not found");
+  }
+
   ArrayRef<ParameterList *> ParamLists;
 
   if (auto AFD = dyn_cast<AbstractFunctionDecl>(D->getDeclContext())) {
     ParamLists = AFD->getParameterLists();
-  } else if (auto ACE = dyn_cast<AbstractClosureExpr>(D->getDeclContext())) {
-    ParamLists = ACE->getParameterLists();
   } else {
-    llvm_unreachable("unhandled param context");
+    auto ACE = cast<AbstractClosureExpr>(D->getDeclContext());
+    ParamLists = ACE->getParameterLists();
   }
+
+  unsigned UnnamedIndex = 0;
   for (auto ParamList : ParamLists) {
-    for (auto Param : *ParamList) {
-      if (!Param->hasName()) {
-        if (Param == D)
-          return UnnamedIndex;
-        ++UnnamedIndex;
-      }
-    }
+    if (getUnnamedParamIndex(ParamList, D, UnnamedIndex))
+      return UnnamedIndex;
   }
+
   llvm_unreachable("param not found");
 }
 
@@ -427,9 +444,11 @@ void ASTMangler::appendDeclName(const ValueDecl *decl) {
   }
 
   if (decl->getDeclContext()->isLocalContext()) {
-    if (isa<ParamDecl>(decl) && !decl->hasName()) {
-      // Mangle unnamed params with their ordering.
-      return appendOperator("L", Index(getUnnamedParamIndex(decl)));
+    if (auto *paramDecl = dyn_cast<ParamDecl>(decl)) {
+      if (!decl->hasName()) {
+        // Mangle unnamed params with their ordering.
+        return appendOperator("L", Index(getUnnamedParamIndex(paramDecl)));
+      }
     }
     // Mangle local declarations with a numeric discriminator.
     return appendOperator("L", Index(decl->getLocalDiscriminator()));

--- a/test/IDE/print_usrs.swift
+++ b/test/IDE/print_usrs.swift
@@ -27,6 +27,13 @@ class MyCls {
     // CHECK: [[@LINE+1]]:5 s:14swift_ide_test5MyClsC9subscriptSfSicfs{{$}}
     set {}
   }
+  // CHECK: [[@LINE+1]]:3 s:14swift_ide_test5MyClsC9subscriptSfSi_Sitci{{$}}
+  subscript(_: Int, _: Int) -> Float {
+    // CHECK: [[@LINE+1]]:5 s:14swift_ide_test5MyClsC9subscriptSfSi_Sitcfg{{$}}
+    get { return 0.0 }
+    // CHECK: [[@LINE+1]]:5 s:14swift_ide_test5MyClsC9subscriptSfSi_Sitcfs{{$}}
+    set {}
+  }
 }
 
 // CHECK: [[@LINE+1]]:7 s:14swift_ide_test12GenericClassC{{$}}


### PR DESCRIPTION
Fixes <https://bugs.swift.org/browse/SR-4286>.