### PR TITLE
Small fixes for unbound generic types and related problems

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -287,11 +287,11 @@ ERROR(extension_type_expected,none,
 
 // TypeAlias
 ERROR(expected_equal_in_typealias,PointsToFirstBadToken,
-      "expected '=' in typealias declaration", ())
+      "expected '=' in type alias declaration", ())
 ERROR(expected_type_in_typealias,PointsToFirstBadToken,
-      "expected type in typealias declaration", ())
+      "expected type in type alias declaration", ())
 ERROR(expected_type_in_associatedtype,PointsToFirstBadToken,
-      "expected type in associatedtype declaration", ())
+      "expected type in associated type declaration", ())
 ERROR(associated_type_generic_parameter_list,PointsToFirstBadToken,
       "associated types may not have a generic parameter list", ())
 
@@ -859,7 +859,7 @@ ERROR(expected_rbrace_in_brace_stmt,none,
 
 /// Associatedtype Statement
 ERROR(typealias_inside_protocol_without_type,none,
-      "typealias is missing an assigned type; use 'associatedtype' to define an associated type requirement", ())
+      "type alias is missing an assigned type; use 'associatedtype' to define an associated type requirement", ())
 ERROR(associatedtype_outside_protocol,none,
       "associated types can only be defined in a protocol; define a type or introduce a 'typealias' to satisfy an associated type requirement", ())
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1959,10 +1959,10 @@ ERROR(no_equal_overload_for_int,none,
 // Dynamic Self
 ERROR(dynamic_self_non_method,none,
       "%select{global|local}0 function cannot return 'Self'", (bool))
-ERROR(dynamic_self_struct_enum,none,
-      "%select{struct|enum}0 method cannot return 'Self'; "
-      "did you mean to use the %select{struct|enum}0 type %1?",
-      (int, Identifier))
+
+ERROR(self_in_nominal,none,
+      "'Self' is only available in a protocol or as the result of a "
+      "method in a class; did you mean '%0'?", (StringRef))
 
 // Duplicate declarations
 ERROR(duplicate_enum_element,none,
@@ -2912,9 +2912,6 @@ ERROR(array_literal_intrinsics_not_found,none,
       "Array<T>", ())
 ERROR(bool_intrinsics_not_found,none,
       "broken standard library: cannot find intrinsic operations on Bool", ())
-ERROR(self_in_nominal,none,
-      "'Self' is only available in a protocol or as the result of a "
-      "method in a class; did you mean %0?", (Identifier))
 ERROR(class_super_access,none,
       "class %select{must be declared %select{"
       "%select{private|fileprivate|internal|%error|%error}2|private or fileprivate}3"

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1297,7 +1297,7 @@ ERROR(extension_protocol_inheritance,none,
       "extension of protocol %0 cannot have an inheritance clause", (Type))
 ERROR(extension_protocol_via_typealias,none,
       "protocol %0 in the module being compiled cannot be extended via a "
-      "typealias", (Type))
+      "type alias", (Type))
 ERROR(extension_anyobject,none,
       "'AnyObject' protocol cannot be extended", ())
 ERROR(objc_generic_extension_using_type_parameter,none,
@@ -1556,7 +1556,7 @@ ERROR(assoc_type_outside_of_protocol,none,
       "associated type %0 can only be used with a concrete type or "
       "generic parameter base", (Identifier))
 ERROR(typealias_outside_of_protocol,none,
-      "typealias %0 can only be used with a concrete type or "
+      "type alias %0 can only be used with a concrete type or "
       "generic parameter base", (Identifier))
 
 ERROR(circular_protocol_def,none,
@@ -1609,7 +1609,7 @@ ERROR(requires_generic_param_same_type_does_not_conform,none,
 ERROR(requires_same_concrete_type,none,
       "generic signature requires types %0 and %1 to be the same", (Type, Type))
 ERROR(protocol_typealias_conflict, none,
-      "typealias %0 requires types %1 and %2 to be the same",
+      "type alias %0 requires types %1 and %2 to be the same",
       (Identifier, Type, Type))
 WARNING(redundant_conformance_constraint,none,
         "redundant conformance constraint %0: %1", (Type, ProtocolDecl *))

--- a/lib/Sema/ITCDecl.cpp
+++ b/lib/Sema/ITCDecl.cpp
@@ -340,7 +340,7 @@ void IterativeTypeChecker::processResolveTypeDecl(
         typeAliasDecl->getGenericParams() == nullptr) {
       typeAliasDecl->setValidationStarted();
 
-      TypeResolutionOptions options;
+      TypeResolutionOptions options = TR_TypeAliasUnderlyingType;
       if (typeAliasDecl->getFormalAccess() <= Accessibility::FilePrivate)
         options |= TR_KnownNonCascadingDependency;
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -7103,7 +7103,7 @@ void TypeChecker::validateDecl(ValueDecl *D) {
 
     validateGenericTypeSignature(typeAlias);
 
-    TypeResolutionOptions options;
+    TypeResolutionOptions options = TR_TypeAliasUnderlyingType;
     if (typeAlias->getFormalAccess() <= Accessibility::FilePrivate)
       options |= TR_KnownNonCascadingDependency;
 

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -308,6 +308,46 @@ LookupResult TypeChecker::lookupMember(DeclContext *dc,
   return result;
 }
 
+bool TypeChecker::isUnsupportedMemberTypeAccess(Type type, TypeDecl *typeDecl) {
+  auto memberType = typeDecl->getDeclaredInterfaceType();
+
+  // We don't allow lookups of a non-generic typealias of an unbound
+  // generic type, because we have no way to model such a type in the
+  // AST.
+  //
+  // For generic typealiases, the typealias itself has an unbound
+  // generic form whose parent type can be another unbound generic
+  // type.
+  //
+  // FIXME: Could lift this restriction once we have sugared
+  // "member types".
+  if (type->is<UnboundGenericType>() &&
+      isa<TypeAliasDecl>(typeDecl) &&
+      cast<TypeAliasDecl>(typeDecl)->getGenericParams() == nullptr &&
+      memberType->hasTypeParameter()) {
+    return true;
+  }
+
+  if (type->is<UnboundGenericType>() &&
+      isa<AssociatedTypeDecl>(typeDecl)) {
+    return true;
+  }
+
+  // We don't allow lookups of an associated type or typealias of an
+  // existential type, because we have no way to represent such types.
+  if (typeDecl->getDeclContext()->getAsProtocolOrProtocolExtensionContext()) {
+    if (type->isExistentialType() &&
+        (isa<TypeAliasDecl>(typeDecl) ||
+         isa<AssociatedTypeDecl>(typeDecl))) {
+      if (memberType->hasTypeParameter()) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
 LookupTypeResult TypeChecker::lookupMemberType(DeclContext *dc,
                                                Type type, Identifier name,
                                                NameLookupOptions options) {
@@ -338,29 +378,21 @@ LookupTypeResult TypeChecker::lookupMemberType(DeclContext *dc,
     if (!typeDecl->hasInterfaceType()) // FIXME: recursion-breaking hack
       continue;
 
-    // If we're looking up a member of a protocol, we must take special care.
+    auto memberType = typeDecl->getDeclaredInterfaceType();
+
+    if (isUnsupportedMemberTypeAccess(type, typeDecl)) {
+      // Add the type to the result set, so that we can diagnose the
+      // reference instead of just saying the member does not exist.
+      if (types.insert(memberType->getCanonicalType()).second)
+        result.Results.push_back({typeDecl, memberType});
+
+      continue;
+    }
+
+    // If we're looking up an associated type of a concrete type,
+    // record it later for conformance checking; we might find a more
+    // direct typealias with the same name later.
     if (typeDecl->getDeclContext()->getAsProtocolOrProtocolExtensionContext()) {
-      auto memberType = typeDecl->getDeclaredInterfaceType();
-
-      // We don't allow lookups of an associated type or typealias of an
-      // existential type, because we have no way to represent such types.
-      //
-      // This is diagnosed further on down in resolveNestedIdentTypeComponent().
-      if (type->isExistentialType() &&
-          (isa<TypeAliasDecl>(typeDecl) ||
-           isa<AssociatedTypeDecl>(typeDecl))) {
-        if (memberType->hasTypeParameter()) {
-          // If we haven't seen this type result yet, add it to the result set.
-          if (types.insert(memberType->getCanonicalType()).second)
-            result.Results.push_back({typeDecl, memberType});
-
-          continue;
-        }
-      }
-
-      // If we're looking up an associated type of a concrete type,
-      // record it later for conformance checking; we might find a more
-      // direct typealias with the same name later.
       if (auto assocType = dyn_cast<AssociatedTypeDecl>(typeDecl)) {
         if (!type->is<ArchetypeType>() &&
             !type->isTypeParameter()) {
@@ -381,8 +413,8 @@ LookupTypeResult TypeChecker::lookupMemberType(DeclContext *dc,
     }
 
     // Substitute the base into the member's type.
-    auto memberType = substMemberTypeWithBase(dc->getParentModule(),
-                                              typeDecl, type);
+    memberType = substMemberTypeWithBase(dc->getParentModule(),
+                                         typeDecl, type);
 
     // If we haven't seen this type result yet, add it to the result set.
     if (types.insert(memberType->getCanonicalType()).second)

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1940,6 +1940,11 @@ public:
                             NameLookupOptions options
                               = defaultMemberLookupOptions);
 
+  /// \brief Check whether the given declaration can be written as a
+  /// member of the given base type.
+  bool isUnsupportedMemberTypeAccess(Type type,
+                                     TypeDecl *typeDecl);
+
   /// \brief Look up a member type within the given type.
   ///
   /// This routine looks for member types with the given name within the

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -488,6 +488,9 @@ enum TypeResolutionFlags : unsigned {
   /// clause on something other than an enum (i.e. V, but not U or W, in class
   /// T: U.V<W>)
   TR_NonEnumInheritanceClauseOuterLayer = 0x2000000,
+
+  /// Whether we are checking the underlying type of a typealias.
+  TR_TypeAliasUnderlyingType = 0x4000000,
 };
 
 /// Option set describing how type resolution should work.

--- a/test/Generics/associated_types.swift
+++ b/test/Generics/associated_types.swift
@@ -178,7 +178,7 @@ C<CC>().c()
 
 // SR-511
 protocol sr511 {
-  typealias Foo // expected-error {{typealias is missing an assigned type; use 'associatedtype' to define an associated type requirement}}
+  typealias Foo // expected-error {{type alias is missing an assigned type; use 'associatedtype' to define an associated type requirement}}
 }
 
 associatedtype Foo = Int // expected-error {{associated types can only be defined in a protocol; define a type or introduce a 'typealias' to satisfy an associated type requirement}}

--- a/test/Generics/invalid.swift
+++ b/test/Generics/invalid.swift
@@ -3,7 +3,7 @@
 func bet() where A : B {} // expected-error {{'where' clause cannot be attached to a non-generic declaration}}
 
 typealias gimel where A : B // expected-error {{'where' clause cannot be attached to a non-generic declaration}}
-// expected-error@-1 {{expected '=' in typealias declaration}}
+// expected-error@-1 {{expected '=' in type alias declaration}}
 
 class dalet where A : B {} // expected-error {{'where' clause cannot be attached to a non-generic declaration}}
 

--- a/test/Generics/protocol_type_aliases.swift
+++ b/test/Generics/protocol_type_aliases.swift
@@ -53,14 +53,14 @@ func concreteRequirementOnConcreteNestedTypeAlias<T>(_: T) where T: Q2, S<T.C> =
 
 // Incompatible concrete typealias types are flagged as such
 protocol P3 {
-    typealias T = Int // expected-error{{typealias 'T' requires types 'Q3.T' (aka 'Float') and 'Int' to be the same}}
+    typealias T = Int // expected-error{{type alias 'T' requires types 'Q3.T' (aka 'Float') and 'Int' to be the same}}
 }
 protocol Q3: P3 {
     typealias T = Float
 }
 
 protocol P3_1 {
-    typealias T = Float // expected-error{{typealias 'T' requires types 'P3.T' (aka 'Int') and 'Float' to be the same}}
+    typealias T = Float // expected-error{{type alias 'T' requires types 'P3.T' (aka 'Int') and 'Float' to be the same}}
 }
 protocol Q3_1: P3, P3_1 {}
 

--- a/test/Generics/unbound.swift
+++ b/test/Generics/unbound.swift
@@ -8,17 +8,18 @@
 // Places where generic arguments are always required
 // --------------------------------------------------
 
-struct Foo<T> { // expected-note{{generic type 'Foo' declared here}} expected-note{{generic type 'Foo' declared here}}
+struct Foo<T> { // expected-note 3{{generic type 'Foo' declared here}}
   struct Wibble { }
 }
 
 class Dict<K, V> { } // expected-note{{generic type 'Dict' declared here}} expected-note{{generic type 'Dict' declared here}} expected-note{{generic type 'Dict' declared here}}
 
-// Cannot alias a generic type without arguments.
-typealias Bar = Foo // expected-error{{reference to generic type 'Foo' requires arguments in <...>}}
-
-// Cannot refer to a member of a generic type without arguments.
+// The underlying type of a typealias can only have unbound generic arguments
+// at the top level.
+typealias F = Foo // OK
 typealias FW = Foo.Wibble // expected-error{{reference to generic type 'Foo' requires arguments in <...>}}
+typealias FFW = () -> Foo // expected-error{{reference to generic type 'Foo' requires arguments in <...>}}
+typealias OFW = Optional<() -> Foo> // expected-error{{reference to generic type 'Foo' requires arguments in <...>}}
 
 // Cannot inherit from a generic type without arguments.
 class MyDict : Dict { } // expected-error{{reference to generic type 'Dict' requires arguments in <...>}}

--- a/test/Parse/diagnostic_points_to_first_bad_token.swift
+++ b/test/Parse/diagnostic_points_to_first_bad_token.swift
@@ -4,13 +4,13 @@
 
 typealias TestDiagPointsToEndOfLine =
 
-// CHECK: error: expected type in typealias declaration
+// CHECK: error: expected type in type alias declaration
 // CHECK-NEXT: {{^}}typealias TestDiagPointsToEndOfLine ={{$}}
 // CHECK-NEXT: {{^}}                                     ^{{$}}
 
 typealias TestDiagPointsToBadToken = =
 
-// CHECK: error: expected type in typealias declaration
+// CHECK: error: expected type in type alias declaration
 // CHECK-NEXT: {{^}}typealias TestDiagPointsToBadToken = ={{$}}
 // CHECK-NEXT: {{^}}                                     ^{{$}}
 

--- a/test/Parse/typealias.swift
+++ b/test/Parse/typealias.swift
@@ -9,26 +9,26 @@ var fiveInts : FiveInts = ((4,2), (1,2,3))
 
 
 // <rdar://problem/13339798> QoI: poor diagnostic in malformed typealias
-typealias Foo1 : Int  // expected-error {{expected '=' in typealias declaration}} {{16-17==}}
-typealias Foo2: Int  // expected-error {{expected '=' in typealias declaration}} {{15-16= =}}
-typealias Foo3 :Int  // expected-error {{expected '=' in typealias declaration}} {{16-17== }}
-typealias Foo4:/*comment*/Int  // expected-error {{expected '=' in typealias declaration}} {{15-16= = }}
+typealias Foo1 : Int  // expected-error {{expected '=' in type alias declaration}} {{16-17==}}
+typealias Foo2: Int  // expected-error {{expected '=' in type alias declaration}} {{15-16= =}}
+typealias Foo3 :Int  // expected-error {{expected '=' in type alias declaration}} {{16-17== }}
+typealias Foo4:/*comment*/Int  // expected-error {{expected '=' in type alias declaration}} {{15-16= = }}
 
 //===--- Tests for error recovery.
 
-typealias Recovery1 // expected-error {{expected '=' in typealias declaration}}
+typealias Recovery1 // expected-error {{expected '=' in type alias declaration}}
 
-typealias Recovery2 : // expected-error {{expected '=' in typealias declaration}}
-// expected-error @-1 {{expected type in typealias declaration}}
+typealias Recovery2 : // expected-error {{expected '=' in type alias declaration}}
+// expected-error @-1 {{expected type in type alias declaration}}
 
-typealias Recovery3 = // expected-error {{expected type in typealias declaration}}
+typealias Recovery3 = // expected-error {{expected type in type alias declaration}}
 
-typealias Recovery4 : Int // expected-error {{expected '=' in typealias declaration}}
+typealias Recovery4 : Int // expected-error {{expected '=' in type alias declaration}}
 
-typealias Recovery5 : Int, Float // expected-error {{expected '=' in typealias declaration}}
+typealias Recovery5 : Int, Float // expected-error {{expected '=' in type alias declaration}}
 // expected-error @-1 {{consecutive statements on a line must be separated by ';'}}
 // expected-error @-2 {{expected expression}}
 
-typealias Recovery6 = = // expected-error {{expected type in typealias declaration}}
+typealias Recovery6 = = // expected-error {{expected type in type alias declaration}}
 
 typealias switch = Int // expected-error {{keyword 'switch' cannot be used as an identifier here}} expected-note {{if this name is unavoidable, use backticks to escape it}} {{11-17=`switch`}}

--- a/test/decl/ext/protocol.swift
+++ b/test/decl/ext/protocol.swift
@@ -923,7 +923,7 @@ extension BadProto1 {
 
 protocol BadProto3 { }
 typealias BadProto4 = BadProto3
-extension BadProto4 { } // expected-error{{protocol 'BadProto3' in the module being compiled cannot be extended via a typealias}}{{11-20=BadProto3}}
+extension BadProto4 { } // expected-error{{protocol 'BadProto3' in the module being compiled cannot be extended via a type alias}}{{11-20=BadProto3}}
 
 typealias RawRepresentableAlias = RawRepresentable
 extension RawRepresentableAlias { } // okay
@@ -948,6 +948,6 @@ class BadClass5 : BadProto5 {} // expected-error{{type 'BadClass5' does not conf
 typealias A = BadProto1
 typealias B = BadProto1
 
-extension A & B { // expected-error{{protocol 'BadProto1' in the module being compiled cannot be extended via a typealias}}
+extension A & B { // expected-error{{protocol 'BadProto1' in the module being compiled cannot be extended via a type alias}}
 
 }

--- a/test/decl/func/dynamic_self.swift
+++ b/test/decl/func/dynamic_self.swift
@@ -10,13 +10,13 @@ func inFunction() {
 }
 
 struct S0 {
-  func f() -> Self { } // expected-error{{struct method cannot return 'Self'; did you mean to use the struct type 'S0'?}}{{15-19=S0}}
+  func f() -> Self { } // expected-error{{'Self' is only available in a protocol or as the result of a method in a class; did you mean 'S0'?}}{{15-19=S0}}
 
   func g(_ ds: Self) { } // expected-error{{'Self' is only available in a protocol or as the result of a method in a class; did you mean 'S0'?}}{{16-20=S0}}
 }
 
 enum E0 {
-  func f() -> Self { } // expected-error{{enum method cannot return 'Self'; did you mean to use the enum type 'E0'?}}{{15-19=E0}}
+  func f() -> Self { } // expected-error{{'Self' is only available in a protocol or as the result of a method in a class; did you mean 'E0'?}}{{15-19=E0}}
 
   func g(_ ds: Self) { } // expected-error{{'Self' is only available in a protocol or as the result of a method in a class; did you mean 'E0'?}}{{16-20=E0}}
 }

--- a/test/decl/nested/protocol.swift
+++ b/test/decl/nested/protocol.swift
@@ -50,12 +50,12 @@ protocol Racoon {
 }
 
 enum SillyRawEnum : SillyProtocol.InnerClass {}
-// expected-error@-1 {{raw type 'SillyProtocol.InnerClass' is not expressible by any literal}}
-// expected-error@-2 {{'SillyRawEnum' declares raw type 'SillyProtocol.InnerClass', but does not conform to RawRepresentable and conformance could not be synthesized}}
-// expected-error@-3 {{RawRepresentable conformance cannot be synthesized because raw type 'SillyProtocol.InnerClass' is not Equatable}}
+// expected-error@-1 {{reference to generic type 'SillyProtocol.InnerClass' requires arguments in <...>}}
+// expected-error@-2 {{type 'SillyRawEnum' does not conform to protocol 'RawRepresentable'}}
 
 protocol SillyProtocol {
   class InnerClass<T> {} // expected-error {{type 'InnerClass' cannot be nested in protocol 'SillyProtocol'}}
+  // expected-note@-1 {{generic type 'InnerClass' declared here}}
 }
 
 enum OuterEnum {

--- a/test/decl/nested/type_in_type.swift
+++ b/test/decl/nested/type_in_type.swift
@@ -388,3 +388,19 @@ func pets<T>(fur: T) -> Claws<Kitten>.Fangs<T> {
 func test() {
   let _: Claws<Kitten>.Fangs<Puppy> = pets(fur: Puppy())
 }
+
+// https://bugs.swift.org/browse/SR-4379
+extension OuterGeneric.MidNonGeneric {
+  func doStuff() -> OuterGeneric {
+    return OuterGeneric()
+  }
+
+  func doMoreStuff() -> OuterGeneric.MidNonGeneric {
+    return OuterGeneric.MidNonGeneric()
+  }
+
+  func doMoreStuffWrong() -> Self {
+    // expected-error@-1 {{'Self' is only available in a protocol or as the result of a method in a class; did you mean 'OuterGeneric.MidNonGeneric'?}}
+
+  }
+}

--- a/test/decl/protocol/protocols.swift
+++ b/test/decl/protocol/protocols.swift
@@ -26,6 +26,8 @@ protocol Test2 {
 
   associatedtype mytype
   associatedtype mybadtype = Int
+
+  associatedtype V : Test = // expected-error {{expected type in associated type declaration}}
 }
 
 func test1() {

--- a/test/decl/typealias/dependent_types.swift
+++ b/test/decl/typealias/dependent_types.swift
@@ -23,9 +23,11 @@ struct X1<T> : P1 {
   }
 }
 
-struct GenericStruct<T> {
+struct GenericStruct<T> { // expected-note 2{{generic type 'GenericStruct' declared here}}
   typealias Alias = T
   typealias MetaAlias = T.Type
+
+  typealias Concrete = Int
 
   func methodOne() -> Alias.Type {}
   func methodTwo() -> MetaAlias {}
@@ -40,3 +42,19 @@ struct GenericStruct<T> {
   var propertyTwo: MetaAlias.BadType
   // expected-error@-1 {{'BadType' is not a member type of 'T.Type'}}
 }
+
+// This was accepted in Swift 3.0 and sort of worked... but we can't
+// implement it correctly. In Swift 3.1 it triggered an assert.
+// Make sure it's banned now with a proper diagnostic.
+
+func foo() -> Int {}
+func metaFoo() -> Int.Type {}
+
+let _: GenericStruct.Alias = foo()
+// expected-error@-1 {{reference to generic type 'GenericStruct' requires arguments in <...>}}
+let _: GenericStruct.MetaAlias = metaFoo()
+// expected-error@-1 {{reference to generic type 'GenericStruct' requires arguments in <...>}}
+
+// ... but if the typealias has a fully concrete underlying type,
+// we are OK.
+let _: GenericStruct.Concrete = foo()

--- a/test/decl/typealias/generic.swift
+++ b/test/decl/typealias/generic.swift
@@ -1,6 +1,6 @@
 // RUN: %target-typecheck-verify-swift
 
-struct MyType<TyA, TyB> { // expected-note {{declared here}}
+struct MyType<TyA, TyB> {
   var a : TyA, b : TyB
 }
 
@@ -10,8 +10,7 @@ struct MyType<TyA, TyB> { // expected-note {{declared here}}
 // arguments to them.
 //
 
-// FIXME: This should work?
-typealias OurType = MyType  // expected-error {{reference to generic type 'MyType' requires arguments in <...>}}
+typealias OurType = MyType
 
 typealias YourType = Swift.Optional
 
@@ -19,8 +18,9 @@ struct Container {
   typealias YourType = Swift.Optional
 }
 
-let _ : YourType<Int>
-let _ : Container.YourType<Int>
+let _: OurType<Int, String>
+let _: YourType<Int>
+let _: Container.YourType<Int>
 
 //
 // Bona-fide generic type aliases

--- a/test/decl/typealias/protocol.swift
+++ b/test/decl/typealias/protocol.swift
@@ -4,7 +4,7 @@
 
 protocol Bad {
   associatedtype X<T>  // expected-error {{associated types may not have a generic parameter list}}
-  typealias Y<T>       // expected-error {{expected '=' in typealias declaration}}
+  typealias Y<T>       // expected-error {{expected '=' in type alias declaration}}
 }
 
 protocol Col {
@@ -137,10 +137,8 @@ func go3<T : P1, U : P2>(_ x: T) -> U where T.F == U.B {
 
 // Specific diagnosis for things that look like Swift 2.x typealiases
 protocol P3 {
-  typealias T // expected-error {{typealias is missing an assigned type; use 'associatedtype' to define an associated type requirement}}
-  typealias U : P2 // expected-error {{typealias is missing an assigned type; use 'associatedtype' to define an associated type requirement}}
-
-  associatedtype V : P2 = // expected-error {{expected type in associatedtype declaration}}
+  typealias T // expected-error {{type alias is missing an assigned type; use 'associatedtype' to define an associated type requirement}}
+  typealias U : P2 // expected-error {{type alias is missing an assigned type; use 'associatedtype' to define an associated type requirement}}
 }
 
 // Test for not crashing on recursive aliases
@@ -173,8 +171,8 @@ struct T5 : P5 {
   var a: P5.T1 // OK
 
   // Invalid -- cannot represent associated type of existential
-  var v2: P5.T2 // expected-error {{typealias 'T2' can only be used with a concrete type or generic parameter base}}
-  var v3: P5.X // expected-error {{typealias 'X' can only be used with a concrete type or generic parameter base}}
+  var v2: P5.T2 // expected-error {{type alias 'T2' can only be used with a concrete type or generic parameter base}}
+  var v3: P5.X // expected-error {{type alias 'X' can only be used with a concrete type or generic parameter base}}
 
   // Unqualified reference to typealias from a protocol conformance
   var v4: T1 // OK
@@ -185,7 +183,7 @@ struct T5 : P5 {
   var v7: T5.T2 // OK
 
   var v8 = P6.A.self
-  var v9 = P6.B.self // expected-error {{typealias 'B' can only be used with a concrete type or generic parameter base}}
+  var v9 = P6.B.self // expected-error {{type alias 'B' can only be used with a concrete type or generic parameter base}}
 }
 
 // Unqualified lookup finds typealiases in protocol extensions, though

--- a/test/type/self.swift
+++ b/test/type/self.swift
@@ -23,5 +23,5 @@ extension X {
 }
 
 extension X.Inner {
-  func foo(_ other: Self) { } // expected-error{{'Self' is only available in a protocol or as the result of a method in a class; did you mean 'Inner'?}}{{21-25=Inner}}
+  func foo(_ other: Self) { } // expected-error{{'Self' is only available in a protocol or as the result of a method in a class; did you mean 'X.Inner'?}}{{21-25=X.Inner}}
 }

--- a/test/type/subclass_composition.swift
+++ b/test/type/subclass_composition.swift
@@ -283,7 +283,7 @@ func dependentMemberTypes<T : BaseIntAndP2>(
   _: T.FullyConcrete,
 
   _: BaseIntAndP2.DependentInConcreteConformance, // FIXME expected-error {{}}
-  _: BaseIntAndP2.DependentProtocol, // expected-error {{typealias 'DependentProtocol' can only be used with a concrete type or generic parameter base}}
+  _: BaseIntAndP2.DependentProtocol, // expected-error {{type alias 'DependentProtocol' can only be used with a concrete type or generic parameter base}}
   _: BaseIntAndP2.DependentClass,
   _: BaseIntAndP2.FullyConcrete) {}
 

--- a/validation-test/compiler_crashers_fixed/28726-nominaltypedecl-hasfixedlayout.swift
+++ b/validation-test/compiler_crashers_fixed/28726-nominaltypedecl-hasfixedlayout.swift
@@ -5,6 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 // non-fuzz
 struct T<b{typealias a=(}let:T.a=


### PR DESCRIPTION
Some fixes for issues with nested types, unbound generic types and type aliases.

Fixes <rdar://problem/31480755>, <https://bugs.swift.org/browse/SR-4390>, <https://bugs.swift.org/browse/SR-4379>.