### PR TITLE
Remove old .swiftdoc file before creating new .swiftdoc file

### DIFF
--- a/cmake/modules/SwiftSource.cmake
+++ b/cmake/modules/SwiftSource.cmake
@@ -491,6 +491,8 @@ function(_compile_swift_files
         COMMAND
           "${CMAKE_COMMAND}" "-E" "remove" "-f" "${module_file}"
         COMMAND
+          "${CMAKE_COMMAND}" "-E" "remove" "-f" "${module_doc_file}"
+        COMMAND
           "${PYTHON_EXECUTABLE}" "${line_directive_tool}" "@${file_path}" --
           "${swift_compiler_tool}" "-emit-module" "-o" "${module_file}" ${swift_flags}
           "@${file_path}"


### PR DESCRIPTION
Just now, I interrupted compilation of generating the Swift.swiftdoc file.

This meant that I got a permission denied error and had to manually cleanup the file to fix this.

To avoid this in the future, we can delete the file before generating it, in the same way that we do for the .swiftmodule file