### PR TITLE
Sema: Don't construct naked ErrorTypes in valid code

### DIFF
--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1315,7 +1315,7 @@ void CleanupIllFormedExpressionRAII::doIt(Expr *expr, ASTContext &Context) {
       // If the type of this expression has a type variable or is invalid,
       // overwrite it with ErrorType.
       Type type = expr->getType();
-      if (!type || type->hasTypeVariable())
+      if (type && type->hasTypeVariable())
         expr->setType(ErrorType::get(context));
 
       return { true, expr };

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4082,7 +4082,7 @@ void ConformanceChecker::resolveTypeWitnesses() {
           if (known != typeWitnesses.end())
             substitutions[archetype] = known->first;
           else
-            substitutions[archetype] = ErrorType::get(TC.Context);
+            substitutions[archetype] = ErrorType::get(archetype);
         }
       }
     }


### PR DESCRIPTION
It is useful to set a breakpoint on ErrorType::get(ASTContext)
to see what is going wrong immediately instead of after the
fact when an ErrorType pops up where you don't expect it.

Unfortunately associated type inference, domain shrinking and
the type cleanup RAII utility would all build ErrorTypes even
with valid code.

Refactor things a bit so that this is no longer the case; at
least now the standard library and overlays build with
'assert(false)' inserted into ErrorType::get(ASTContext).

ErrorType::get(Type) is still expected to come up in associated
type inference since it is used as a signal while sorting
through potential type witness candidates.