### PR TITLE
Sema: Fix up override matching in the presence of non-canonical type parameters

### DIFF
--- a/test/attr/attr_override.swift
+++ b/test/attr/attr_override.swift
@@ -416,3 +416,24 @@ class MoreGenericSub1<T, TT> : GenericBase<T> {
 class MoreGenericSub2<TT, T> : GenericBase<T> {
   override func doStuff<U>(t: T, u: U) {}
 }
+
+// Issue with insufficient canonicalization when
+// comparing types
+protocol SI {}
+protocol CI {}
+
+protocol Sequence {
+  associatedtype I : SI
+}
+
+protocol Collection : Sequence {
+  associatedtype I : CI
+}
+
+class Index<F, T> {
+  func map(_ f: F) -> T {}
+}
+
+class CollectionIndex<C : Collection> : Index<C, C.I> {
+  override func map(_ f: C) -> C.I {}
+}


### PR DESCRIPTION
If there are multiple ways to spell an associated type appearing in a parameter type or result, we want to make sure we still accept the override.

Fixes <https://bugs.swift.org/browse/SR-4321>.