### PR TITLE
Fix incorrect format specifiers passed to snprintf in Sema

### DIFF
--- a/lib/Sema/PCMacro.cpp
+++ b/lib/Sema/PCMacro.cpp
@@ -539,10 +539,10 @@ public:
     char *start_column_buf = (char *)Context.Allocate(buf_size, 1);
     char *end_column_buf = (char *)Context.Allocate(buf_size, 1);
 
-    ::snprintf(start_line_buf, buf_size, "%d", StartLC.first);
-    ::snprintf(start_column_buf, buf_size, "%d", StartLC.second);
-    ::snprintf(end_line_buf, buf_size, "%d", EndLC.first);
-    ::snprintf(end_column_buf, buf_size, "%d", EndLC.second);
+    ::snprintf(start_line_buf, buf_size, "%u", StartLC.first);
+    ::snprintf(start_column_buf, buf_size, "%u", StartLC.second);
+    ::snprintf(end_line_buf, buf_size, "%u", EndLC.first);
+    ::snprintf(end_column_buf, buf_size, "%u", EndLC.second);
 
     Expr *StartLine =
         new (Context) IntegerLiteralExpr(start_line_buf, SR.End, true);
@@ -622,10 +622,10 @@ public:
     char *start_column_buf = (char *)Context.Allocate(buf_size, 1);
     char *end_column_buf = (char *)Context.Allocate(buf_size, 1);
 
-    ::snprintf(start_line_buf, buf_size, "%d", StartLC.first);
-    ::snprintf(start_column_buf, buf_size, "%d", StartLC.second);
-    ::snprintf(end_line_buf, buf_size, "%d", EndLC.first);
-    ::snprintf(end_column_buf, buf_size, "%d", EndLC.second);
+    ::snprintf(start_line_buf, buf_size, "%u", StartLC.first);
+    ::snprintf(start_column_buf, buf_size, "%u", StartLC.second);
+    ::snprintf(end_line_buf, buf_size, "%u", EndLC.first);
+    ::snprintf(end_column_buf, buf_size, "%u", EndLC.second);
 
     Expr *StartLine =
         new (Context) IntegerLiteralExpr(start_line_buf, SR.End, true);

--- a/lib/Sema/PlaygroundTransform.cpp
+++ b/lib/Sema/PlaygroundTransform.cpp
@@ -818,10 +818,10 @@ public:
     char *start_column_buf = (char *)Context.Allocate(buf_size, 1);
     char *end_column_buf = (char *)Context.Allocate(buf_size, 1);
 
-    ::snprintf(start_line_buf, buf_size, "%d", StartLC.first);
-    ::snprintf(start_column_buf, buf_size, "%d", StartLC.second);
-    ::snprintf(end_line_buf, buf_size, "%d", EndLC.first);
-    ::snprintf(end_column_buf, buf_size, "%d", EndLC.second);
+    ::snprintf(start_line_buf, buf_size, "%u", StartLC.first);
+    ::snprintf(start_column_buf, buf_size, "%u", StartLC.second);
+    ::snprintf(end_line_buf, buf_size, "%u", EndLC.first);
+    ::snprintf(end_column_buf, buf_size, "%u", EndLC.second);
 
     Expr *StartLine =
         new (Context) IntegerLiteralExpr(start_line_buf, SR.End, true);


### PR DESCRIPTION
These are unsigned ints, not signed ints, so we should use `%u` instead of `%d` which gives incorrect results for values larger that `INT_MAX`
