### PR TITLE
SILGen: Fixes for *static* 'Self'-returning methods

### DIFF
--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -354,6 +354,12 @@ public:
 
   /// Returns true if this function either has a self metadata argument or
   /// object that Self metadata may be derived from.
+  ///
+  /// Note that this is not the same as hasSelfParam().
+  ///
+  /// For closures that capture DynamicSelfType, hasSelfMetadataParam()
+  /// is true and hasSelfParam() is false. For methods on value types,
+  /// hasSelfParam() is true and hasSelfMetadataParam() is false.
   bool hasSelfMetadataParam() const;
 
   /// Return the mangled name of this SILFunction.

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -779,7 +779,7 @@ static CanSILFunctionType getSILFunctionType(SILModule &M,
       if (capture.isDynamicSelfMetadata()) {
         ParameterConvention convention = ParameterConvention::Direct_Unowned;
         auto selfMetatype = MetatypeType::get(
-            loweredCaptures.getDynamicSelfType()->getSelfType(),
+            loweredCaptures.getDynamicSelfType(),
             MetatypeRepresentation::Thick);
         auto canSelfMetatype = getCanonicalType(selfMetatype);
         SILParameterInfo param(canSelfMetatype, convention);

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -2678,9 +2678,13 @@ public:
         Def = OpenedArchetypes.getOpenedArchetypeDef(archetypeTy);
         require(Def, "Opened archetype should be registered in SILFunction");
       } else if (t->hasDynamicSelfType()) {
-        require(I->getFunction()->hasSelfParam(),
+        require(I->getFunction()->hasSelfParam() ||
+                I->getFunction()->hasSelfMetadataParam(),
               "Function containing dynamic self type must have self parameter");
-        Def = I->getFunction()->getSelfArgument();
+        if (I->getFunction()->hasSelfMetadataParam())
+          Def = I->getFunction()->getArguments().back();
+        else
+          Def = I->getFunction()->getSelfArgument();
       } else {
         return;
       }

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -233,20 +233,10 @@ void SILGenFunction::emitCaptures(SILLocation loc,
       // The parameter type is the static Self type, but the value we
       // want to pass is the dynamic Self type, so upcast it.
       auto dynamicSelfMetatype = MetatypeType::get(
-          captureInfo.getDynamicSelfType(),
-          MetatypeRepresentation::Thick)
-              ->getCanonicalType();
-      auto staticSelfMetatype = MetatypeType::get(
-          captureInfo.getDynamicSelfType()->getSelfType(),
-          MetatypeRepresentation::Thick)
-              ->getCanonicalType();
-      SILType dynamicSILType = SILType::getPrimitiveObjectType(
-          dynamicSelfMetatype);
-      SILType staticSILType = SILType::getPrimitiveObjectType(
-          staticSelfMetatype);
+        captureInfo.getDynamicSelfType());
+      SILType dynamicSILType = getLoweredType(dynamicSelfMetatype);
 
       SILValue value = B.createMetatype(loc, dynamicSILType);
-      value = B.createUpcast(loc, value, staticSILType);
       capturedArgs.push_back(ManagedValue::forUnmanaged(value));
       continue;
     }
@@ -286,10 +276,10 @@ void SILGenFunction::emitCaptures(SILLocation loc,
       // loaded it into a normal retained class pointer, but we capture it as
       // an unowned pointer.  Convert back now.
       if (var->getType()->is<ReferenceStorageType>()) {
-        auto type = getTypeLowering(var->getType()).getLoweredType();
+        auto type = getLoweredType(var->getType());
         Val = emitConversionFromSemanticValue(loc, Val, type);
       }
-      
+
       capturedArgs.push_back(emitManagedRValueWithCleanup(Val));
       break;
     }

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -236,7 +236,7 @@ struct ArgumentInitHelper {
     assert(ty && "no type?!");
 
     // Create an RValue by emitting destructured arguments into a basic block.
-    CanType canTy = ty->getCanonicalType();
+    CanType canTy = ty->eraseDynamicSelfType()->getCanonicalType();
     return EmitBBArguments(gen, parent, l, /*functionArgs*/ true,
                            parameters).visit(canTy);
   }
@@ -267,6 +267,17 @@ struct ArgumentInitHelper {
         return;
       }
       assert(argrv.getType().isAddress() && "expected inout to be address");
+    } else if (auto *metatypeTy = ty->getAs<MetatypeType>()) {
+      // This is a hack to deal with the fact that Self.Type comes in as a
+      // static metatype, but we have to downcast it to a dynamic Self
+      // metatype to get the right semantics.
+      if (metatypeTy->getInstanceType()->is<DynamicSelfType>()) {
+        auto loweredTy = gen.getLoweredType(ty);
+        if (loweredTy != argrv.getType()) {
+          argrv = ManagedValue::forUnmanaged(
+            gen.B.createUncheckedBitCast(loc, argrv.getValue(), loweredTy));
+        }
+      }
     } else {
       assert(vd->isLet() && "expected parameter to be immutable!");
       // If the variable is immutable, we can bind the value as is.
@@ -281,9 +292,7 @@ struct ArgumentInitHelper {
   }
 
   void emitParam(ParamDecl *PD) {
-    // The contextual type of a ParamDecl has DynamicSelfType. We don't want
-    // that here.
-    auto type = PD->getType()->eraseDynamicSelfType();
+    auto type = PD->getType();
 
     ++ArgNo;
     if (PD->hasName()) {
@@ -364,16 +373,9 @@ static void emitCaptureArguments(SILGenFunction &gen,
   // Local function to get the captured variable type within the capturing
   // context.
   auto getVarTypeInCaptureContext = [&]() -> Type {
-    auto interfaceType = cast<VarDecl>(VD)->getInterfaceType();
-    if (!interfaceType->hasTypeParameter()) return interfaceType;
-
-    // NB: The generic signature may be elided from the lowered function type
-    // if the function is in a fully-specialized context, but we still need to
-    // canonicalize references to the generic parameters that may appear in
-    // non-canonical types in that context. We need the original generic
-    // environment from the AST for that.
-    auto genericEnv = closure.getGenericEnvironment();
-    return genericEnv->mapTypeIntoContext(interfaceType);
+    auto interfaceType = VD->getInterfaceType();
+    return GenericEnvironment::mapTypeIntoContext(
+      closure.getGenericEnvironment(), interfaceType);
   };
 
   switch (gen.SGM.Types.getDeclCaptureKind(capture)) {
@@ -450,10 +452,8 @@ void SILGenFunction::emitProlog(AnyFunctionRef TheClosure,
   for (auto capture : captureInfo.getCaptures()) {
     if (capture.isDynamicSelfMetadata()) {
       auto selfMetatype = MetatypeType::get(
-          captureInfo.getDynamicSelfType()->getSelfType(),
-          MetatypeRepresentation::Thick)
-              ->getCanonicalType();
-      SILType ty = SILType::getPrimitiveObjectType(selfMetatype);
+        captureInfo.getDynamicSelfType());
+      SILType ty = getLoweredType(selfMetatype);
       SILValue val = F.begin()->createFunctionArgument(ty);
       (void) val;
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1167,7 +1167,8 @@ static void configureImplicitSelf(TypeChecker &tc,
   auto selfDecl = func->getImplicitSelfDecl();
 
   // Compute the type of self.
-  Type selfIfaceTy = func->computeInterfaceSelfType(/*isInitializingCtor*/true);
+  Type selfIfaceTy = func->computeInterfaceSelfType(/*isInitializingCtor*/true,
+                                                    /*wantDynamicSelf*/true);
   assert(selfDecl && selfIfaceTy && "Not a method");
 
   // 'self' is 'let' for reference types (i.e., classes) or when 'self' is


### PR DESCRIPTION
Take a seat and pour yourself a beer because this is
going to get pretty intense.

Recall that class methods that return 'Self', have a
'self' type of @dynamic_self X or @dynamic_self X.Type,
for some class X, based on if the method is an instance
method or a static method.

The instance type of a metatype is not lowered, and we
preserve DynamicSelfType there. This is required for
correct behavior with the SIL optimizer.

For example if you specialize a function that contains a
'metatype $((T) -> Int, T).Type' SIL instruction or
some other metatype of a structural type containing a
generic parameter, we might end up with something like
'metatype $((@dynamic_self X) -> Int, X).Type'
after substitution, for some class 'X'. Note that the
second occurrence of 'X', is in "lowered position" so
the @dynamic_self did, indeed, get stripped away.

So while *values* of @dynamic_self type don't need to
carry the fact that they're @dynamic_self at the SIL
level, because Sema has inserted all the right casts.

Metatypes do though, because when lowering the 'metatype'
instruction, IRGen has to know to emit the type metadata
from the method's 'self' parameter, and not the static
metadata for the exact class type.

Essentially, 'metatype @dynamic_self X.Type' is
the same as 'value_metatype %self : X.Type', except that
the @dynamic_self type can appear inside other structural
types also, which is something we cannot write in the
AST.

This is all well and good, but when lowering a
SILFunctionType we erase @dynamic_self from the 'self'
parameter type because when you *call* such a function
from another function, you are not necessarily calling
it on your own 'self' value. And if you are, Sema
already emitted the right unchecked downcast there to
turn the result into the right type.

The problem is that the type of an argument (the value
"inside" the function) used to always be identical to
the type of the parameter (the type from "outside" the
function, in the SILFunctionType). Of course this
assumption is no longer correct for static methods,
where the 'self' argument should really have type
@dynamic_self X.Type, not X.Type.

A further complication is closure captures, whose types
can also contain @dynamic_self inside metatypes in other
structural types. We used to erase @dynamic_self from
these.

Both of these are wrong, because if you call a generic
function <T> (T.Type) -> () with a T := @dynamic_self X
substitution (recall that substitutions are written in
terms of AST types and not lowered types) and pass in
the 'self' argument, we would pass in a value of type
X.Type and not @dynamic_self X.Type.

There were similar issues with captures, with
additional complications from nested closures.

Fix all this by having SILGenProlog emit a downcast
to turn the X.Type argument into a value of type
@dynamic_self X.Type, and tweak capture lowering to
not erase @dynamic_self from capture types.

This fixes several cases that used to fail with
asserts in SILGenApply or the SIL verifier, in particular
the example outlined in <rdar://problem/31226650>,
where we would crash when calling a protocol extension
method from a static class method (oops!).

If you got this far and still follow along,
congratulations, you now know more about DynamicSelfType
than I do.