### PR TITLE
Partial reapply 41f425a5033a30fdd545752b8bb10374bbf1de12

### DIFF
--- a/lib/SILGen/ArgumentScope.h
+++ b/lib/SILGen/ArgumentScope.h
@@ -60,12 +60,7 @@ public:
   void pop() { popImpl(); }
 
   /// Pop the formal evaluation and argument scopes preserving the value mv.
-  ///
-  /// *NOTE* If mv is an address, it is assumed that one of the scopes will
-  /// cause a dealloc stack to be emitted for mv and that the alloc_stack is
-  /// within our scope. This means that we are essentially creating a lifetime
-  /// extension of this value.
-  ManagedValue popPreservingValue(ManagedValue mv) &&;
+  ManagedValue popPreservingValue(ManagedValue mv);
 
 private:
   void popImpl() {

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -2556,7 +2556,19 @@ namespace {
       if (param.isConsumed() &&
           value.getOwnershipKind() == ValueOwnershipKind::Guaranteed) {
         value = value.copyUnmanaged(SGF, arg.getLocation());
+        Args.push_back(value);
+        return;
       }
+
+      if (SGF.F.getModule().getOptions().EnableSILOwnership) {
+        if (param.isDirectGuaranteed() &&
+            value.getOwnershipKind() == ValueOwnershipKind::Owned) {
+          value = value.borrow(SGF, arg.getLocation());
+          Args.push_back(value);
+          return;
+        }
+      }
+
       Args.push_back(value);
     }
     
@@ -3939,7 +3951,12 @@ RValue CallEmission::applyPartiallyAppliedSuperMethod(
   auto loc = uncurriedLoc.getValue();
   auto subs = callee.getSubstitutions();
   auto upcastedSelf = uncurriedArgs.back();
-  auto self = cast<UpcastInst>(upcastedSelf.getValue())->getOperand();
+  SILValue upcastedSelfValue = upcastedSelf.getValue();
+  // Support stripping off a borrow.
+  if (auto *borrowedSelf = dyn_cast<BeginBorrowInst>(upcastedSelfValue)) {
+    upcastedSelfValue = borrowedSelf->getOperand();
+  }
+  SILValue self = cast<UpcastInst>(upcastedSelfValue)->getOperand();
   auto constantInfo = SGF.getConstantInfo(callee.getMethodName());
   auto functionTy = constantInfo.getSILType();
   SILValue superMethodVal =
@@ -5369,4 +5386,11 @@ RValue SILGenFunction::emitDynamicSubscriptExpr(DynamicSubscriptExpr *e,
   if (optTL.isLoadable())
     optResult = optTL.emitLoad(B, e, optResult, LoadOwnershipQualifier::Take);
   return RValue(*this, e, emitManagedRValueWithCleanup(optResult, optTL));
+}
+
+ManagedValue ArgumentScope::popPreservingValue(ManagedValue mv) {
+  CleanupCloner cloner(SGF, mv);
+  SILValue value = mv.forward(SGF);
+  pop();
+  return cloner.clone(value);
 }

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -336,12 +336,12 @@ class CleanupCloner {
   ValueOwnershipKind ownershipKind;
 
 public:
-  CleanupCloner(SILGenBuilder &builder, ManagedValue mv)
-      : CleanupCloner(builder.getSILGenFunction(), mv) {}
-
   CleanupCloner(SILGenFunction &SGF, ManagedValue mv)
       : SGF(SGF), hasCleanup(mv.hasCleanup()), isLValue(mv.isLValue()),
         ownershipKind(mv.getOwnershipKind()) {}
+
+  CleanupCloner(SILGenBuilder &builder, ManagedValue mv)
+      : CleanupCloner(builder.getSILGenFunction(), mv) {}
 
   ManagedValue clone(SILValue value) const;
 };


### PR DESCRIPTION
This PR partially reapplies 41f425a5033a30fdd545752b8bb10374bbf1de12. Specifically:

1. The code in SILGen is placed behind the -enable-sil-ownership flag.
2. The test code has not been re-applied.

The reason why is that I need a mandatory pass fix for SILOwnership. Specifically AllocBoxToStack needs to support Type Dependent operands. Erik is going to take care of that next week.

rdar://31145255