### PR TITLE
[ClangImporter] Collect deps via subclass of clang::DependencyCollector.

### DIFF
--- a/include/swift/AST/ModuleLoader.h
+++ b/include/swift/AST/ModuleLoader.h
@@ -44,7 +44,7 @@ class DependencyTracker {
   std::shared_ptr<clang::DependencyCollector> clangCollector;
 public:
 
-  DependencyTracker(const ClangImporterOptions &Options);
+  DependencyTracker();
 
   /// Adds a file as a dependency.
   ///

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -30,6 +30,7 @@ namespace clang {
   class ASTContext;
   class CodeGenOptions;
   class Decl;
+  class DependencyCollector;
   class EnumConstantDecl;
   class EnumDecl;
   class MacroInfo;
@@ -93,6 +94,11 @@ public:
   ClangImporter &operator=(ClangImporter &&) = delete;
 
   ~ClangImporter();
+
+  /// \brief Create a new clang::DependencyCollector customized to Swift's
+  /// specific uses.
+  static std::shared_ptr<clang::DependencyCollector>
+  createDependencyCollector(const ClangImporterOptions &Options);
 
   /// \brief Check whether the module with a given name can be imported without
   /// importing it.

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -95,10 +95,10 @@ public:
 
   ~ClangImporter();
 
-  /// \brief Create a new clang::DependencyCollector customized to Swift's
-  /// specific uses.
+  /// \brief Create a new clang::DependencyCollector customized to
+  /// ClangImporter's specific uses.
   static std::shared_ptr<clang::DependencyCollector>
-  createDependencyCollector(const ClangImporterOptions &Options);
+  createDependencyCollector();
 
   /// \brief Check whether the module with a given name can be imported without
   /// importing it.

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -34,6 +34,7 @@ add_swift_library(swiftAST STATIC
   LayoutConstraint.cpp
   LookupVisibleDecls.cpp
   Module.cpp
+  ModuleLoader.cpp
   ModuleNameLookup.cpp
   NameLookup.cpp
   Parameter.cpp

--- a/lib/AST/ModuleLoader.cpp
+++ b/lib/AST/ModuleLoader.cpp
@@ -1,0 +1,50 @@
+//===--- ModuleLoader.cpp - Swift Language Module Implementation ----------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file implements the ModuleLoader class and/or any helpers.
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/AST/ModuleLoader.h"
+#include "clang/Frontend/Utils.h"
+#include "swift/ClangImporter/ClangImporter.h"
+
+namespace swift {
+
+DependencyTracker::DependencyTracker(const ClangImporterOptions &Options)
+  : clangCollector(ClangImporter::createDependencyCollector(Options))
+{
+}
+
+void
+DependencyTracker::addDependency(StringRef File, bool IsSystem) {
+  // DependencyTracker exposes an interface that (intentionally) does not talk
+  // about clang at all, nor about missing deps. It does expose an IsSystem
+  // dimension, though it is presently always false, we accept it and pass it
+  // along to the clang DependencyCollector in case Swift callers start setting
+  // it to true someday.
+  clangCollector->maybeAddDependency(File, /*FromClangModule=*/false,
+                                     IsSystem, /*IsClangModuleFile=*/false,
+                                     /*IsMissing=*/false);
+}
+
+ArrayRef<std::string>
+DependencyTracker::getDependencies() const {
+  return clangCollector->getDependencies();
+}
+
+std::shared_ptr<clang::DependencyCollector>
+DependencyTracker::getClangCollector() {
+  return clangCollector;
+}
+
+}

--- a/lib/AST/ModuleLoader.cpp
+++ b/lib/AST/ModuleLoader.cpp
@@ -20,8 +20,13 @@
 
 namespace swift {
 
-DependencyTracker::DependencyTracker(const ClangImporterOptions &Options)
-  : clangCollector(ClangImporter::createDependencyCollector(Options))
+DependencyTracker::DependencyTracker()
+  // NB: The ClangImporter believes it's responsible for the construction of
+  // this instance, and it static_cast<>s the instance pointer to its own
+  // subclass based on that belief. If you change this to be some other
+  // instance, you will need to change ClangImporter's code to handle the
+  // difference.
+  : clangCollector(ClangImporter::createDependencyCollector())
 {
 }
 

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -256,7 +256,50 @@ private:
     Impl.BridgeHeaderMacros.push_back(MacroNameTok.getIdentifierInfo());
   }
 };
+
+class ClangImporterDependencyCollector : public clang::DependencyCollector
+{
+  llvm::StringSet<> ExcludedPaths;
+public:
+  ClangImporterDependencyCollector() = default;
+
+  void excludePath(StringRef filename) {
+    ExcludedPaths.insert(filename);
+  }
+
+  bool isClangImporterSpecialName(StringRef Filename) {
+    using ImporterImpl = ClangImporter::Implementation;
+    return (Filename == ImporterImpl::moduleImportBufferName
+            || Filename == ImporterImpl::bridgingHeaderBufferName);
+  }
+
+  // Currently preserving older ClangImporter behaviour of ignoring system
+  // dependencies, but possibly revisit?
+  bool needSystemDependencies() override { return false; }
+
+  bool sawDependency(StringRef Filename, bool FromClangModule,
+                     bool IsSystem, bool IsClangModuleFile,
+                     bool IsMissing) override {
+    if (!clang::DependencyCollector::sawDependency(Filename, FromClangModule,
+                                                   IsSystem, IsClangModuleFile,
+                                                   IsMissing))
+      return false;
+    // Currently preserving older ClangImporter behaviour of ignoring .pcm
+    // file dependencies, but possibly revisit?
+    if (IsClangModuleFile
+        || isClangImporterSpecialName(Filename)
+        || ExcludedPaths.count(Filename))
+      return false;
+    return true;
+  }
+};
 } // end anonymous namespace
+
+std::shared_ptr<clang::DependencyCollector>
+ClangImporter::createDependencyCollector()
+{
+  return std::make_shared<ClangImporterDependencyCollector>();
+}
 
 void ClangImporter::Implementation::addBridgeHeaderTopLevelDecls(
     clang::Decl *D) {
@@ -651,6 +694,14 @@ ClangImporter::create(ASTContext &ctx,
   if (llvm::sys::path::extension(importerOpts.BridgingHeader).endswith(
         PCH_EXTENSION)) {
     importer->Impl.IsReadingBridgingPCH = true;
+    if (tracker) {
+      // Currently ignoring dependency on bridging .pch files because they are
+      // temporaries; if and when they are no longer temporaries, this condition
+      // should be removed.
+      auto &coll = static_cast<ClangImporterDependencyCollector &>(
+        *tracker->getClangCollector());
+      coll.excludePath(importerOpts.BridgingHeader);
+    }
   }
 
   // FIXME: These can't be controlled from the command line.
@@ -839,59 +890,6 @@ bool ClangImporter::addSearchPath(StringRef newSearchPath, bool isFramework,
                                                /*IgnoreSysRoot=*/true);
   return false;
 }
-
-namespace {
-class ClangImporterDependencyCollector : public clang::DependencyCollector
-{
-  const ClangImporterOptions &Options;
-  const bool BridgingHeaderIsPCH;
-  public:
-  ClangImporterDependencyCollector(const ClangImporterOptions &Options)
-    : Options(Options),
-      BridgingHeaderIsPCH(
-          llvm::sys::path::extension(
-              Options.BridgingHeader).endswith(PCH_EXTENSION))
-  {}
-
-  bool isClangImporterSpecialName(StringRef Filename) {
-    using ImporterImpl = ClangImporter::Implementation;
-    return (Filename == ImporterImpl::moduleImportBufferName
-            || Filename == ImporterImpl::bridgingHeaderBufferName
-            // Currently ignoring dependency on bridging .pch files because
-            // they are temporaries; if and when they are no longer
-            // temporaries, this condition should be removed.
-            || (BridgingHeaderIsPCH
-                && Filename == Options.BridgingHeader));
-  }
-
-  // Currently preserving older ClangImporter behaviour of ignoring system
-  // dependencies, but possibly revisit?
-  bool needSystemDependencies() override { return false; }
-
-  bool sawDependency(StringRef Filename, bool FromClangModule,
-                     bool IsSystem, bool IsClangModuleFile,
-                     bool IsMissing) override {
-    if (!clang::DependencyCollector::sawDependency(Filename, FromClangModule,
-                                                   IsSystem, IsClangModuleFile,
-                                                   IsMissing))
-      return false;
-    // Currently preserving older ClangImporter behaviour of ignoring .pcm
-    // file dependencies, but possibly revisit?
-    if (IsClangModuleFile)
-      return false;
-    if (isClangImporterSpecialName(Filename))
-      return false;
-    return true;
-  }
-};
-}
-
-std::shared_ptr<clang::DependencyCollector>
-ClangImporter::createDependencyCollector(const ClangImporterOptions &Options)
-{
-  return std::make_shared<ClangImporterDependencyCollector>(Options);
-}
-
 
 bool ClangImporter::Implementation::importHeader(
     ModuleDecl *adapter, StringRef headerName, SourceLoc diagLoc,

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -965,7 +965,7 @@ int swift::performFrontend(ArrayRef<const char *> Args,
     enableDiagnosticVerifier(Instance->getSourceMgr());
   }
 
-  DependencyTracker depTracker(Invocation.getClangImporterOptions());
+  DependencyTracker depTracker;
   if (!Invocation.getFrontendOptions().DependenciesFilePath.empty() ||
       !Invocation.getFrontendOptions().ReferenceDependenciesFilePath.empty()) {
     Instance->setDependencyTracker(&depTracker);

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -964,7 +964,7 @@ int swift::performFrontend(ArrayRef<const char *> Args,
     enableDiagnosticVerifier(Instance->getSourceMgr());
   }
 
-  DependencyTracker depTracker;
+  DependencyTracker depTracker(Invocation.getClangImporterOptions());
   if (!Invocation.getFrontendOptions().DependenciesFilePath.empty() ||
       !Invocation.getFrontendOptions().ReferenceDependenciesFilePath.empty()) {
     Instance->setDependencyTracker(&depTracker);

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -116,10 +116,11 @@ static bool emitMakeDependencies(DiagnosticEngine &diags,
     out << escape(targetName) << " :";
     // First include all other files in the module. Make-style dependencies
     // need to be conservative!
-    for (StringRef path : opts.InputFilenames)
+    for (auto const &path : reversePathSortedFilenames(opts.InputFilenames))
       out << ' ' << escape(path);
     // Then print dependencies we've picked up during compilation.
-    for (StringRef path : depTracker.getDependencies())
+    for (auto const &path :
+           reversePathSortedFilenames(depTracker.getDependencies()))
       out << ' ' << escape(path);
     out << '\n';
   });

--- a/lib/FrontendTool/ReferenceDependencies.cpp
+++ b/lib/FrontendTool/ReferenceDependencies.cpp
@@ -102,6 +102,17 @@ static std::string mangleTypeAsContext(const NominalTypeDecl *type) {
   return Mangler.mangleTypeAsContextUSR(type);
 }
 
+std::vector<std::string>
+swift::reversePathSortedFilenames(const ArrayRef<std::string> elts) {
+  std::vector<std::string> tmp(elts.begin(), elts.end());
+  std::sort(tmp.begin(), tmp.end(), [](const std::string &a,
+                                       const std::string &b) -> bool {
+              return std::lexicographical_compare(a.rbegin(), a.rend(),
+                                                  b.rbegin(), b.rend());
+            });
+  return tmp;
+}
+
 bool swift::emitReferenceDependencies(DiagnosticEngine &diags,
                                       SourceFile *SF,
                                       DependencyTracker &depTracker,
@@ -391,7 +402,7 @@ bool swift::emitReferenceDependencies(DiagnosticEngine &diags,
   }
 
   out << "depends-external:\n";
-  for (auto &entry : depTracker.getDependencies()) {
+  for (auto &entry : reversePathSortedFilenames(depTracker.getDependencies())) {
     out << "- \"" << llvm::yaml::escape(entry) << "\"\n";
   }
 

--- a/lib/FrontendTool/ReferenceDependencies.h
+++ b/lib/FrontendTool/ReferenceDependencies.h
@@ -13,12 +13,22 @@
 #ifndef SWIFT_FRONTENDTOOL_REFERENCEDEPENDENCIES_H
 #define SWIFT_FRONTENDTOOL_REFERENCEDEPENDENCIES_H
 
+#include "llvm/ADT/ArrayRef.h"
+#include <vector>
+#include <string>
+
 namespace swift {
 
 class DependencyTracker;
 class DiagnosticEngine;
 class FrontendOptions;
 class SourceFile;
+
+/// Sort a set of paths in an order that's (comparatively) stable against
+/// variation in filesystem prefix: lexicographic comparison of the
+/// byte-reversals of each path. Used for emitting external dependencies.
+std::vector<std::string>
+reversePathSortedFilenames(const llvm::ArrayRef<std::string> paths);
 
 /// Emit a Swift-style dependencies file for \p SF.
 bool emitReferenceDependencies(DiagnosticEngine &diags,

--- a/test/ClangImporter/pch-bridging-header-deps.swift
+++ b/test/ClangImporter/pch-bridging-header-deps.swift
@@ -1,0 +1,19 @@
+// REQUIRES: objc_interop
+// RUN: rm -f %t.*
+//
+// Generate a bridging PCH, use it in a swift file, and check that the swift file's .swiftdeps
+// mention the .h the PCH was generated from, and any .h files included in it.
+//
+// RUN: %target-swift-frontend -emit-pch -o %t.pch %S/Inputs/chained-unit-test-bridging-header-to-pch.h
+// RUN: %target-swift-frontend -module-name test -c -emit-dependencies-path %t.d -emit-reference-dependencies-path %t.swiftdeps -primary-file %s %s -import-objc-header %t.pch
+// RUN: %FileCheck --check-prefix CHECK-DEPS %s < %t.d
+// RUN: %FileCheck --check-prefix CHECK-SWIFTDEPS %s < %t.swiftdeps
+
+print(app_function(1))
+
+// CHECK-DEPS: pch-bridging-header-deps.o : {{.*}}SOURCE_DIR/test/ClangImporter/Inputs/app-bridging-header-to-pch.h {{.*}}SOURCE_DIR/test/ClangImporter/Inputs/chained-unit-test-bridging-header-to-pch.h
+
+// CHECK-SWIFTDEPS: depends-external:
+// CHECK-SWIFTDEPS: - "SOURCE_DIR/test/ClangImporter/Inputs/app-bridging-header-to-pch.h"
+// CHECK-SWIFTDEPS: - "SOURCE_DIR/test/ClangImporter/Inputs/chained-unit-test-bridging-header-to-pch.h"
+

--- a/test/ClangImporter/pch-bridging-header-deps.swift
+++ b/test/ClangImporter/pch-bridging-header-deps.swift
@@ -8,6 +8,7 @@
 // RUN: %target-swift-frontend -module-name test -c -emit-dependencies-path %t.d -emit-reference-dependencies-path %t.swiftdeps -primary-file %s %s -import-objc-header %t.pch
 // RUN: %FileCheck --check-prefix CHECK-DEPS %s < %t.d
 // RUN: %FileCheck --check-prefix CHECK-SWIFTDEPS %s < %t.swiftdeps
+// RUN: %FileCheck --check-prefix CHECK-SWIFTDEPS2 %s < %t.swiftdeps
 
 print(app_function(1))
 
@@ -17,3 +18,4 @@ print(app_function(1))
 // CHECK-SWIFTDEPS: - "SOURCE_DIR/test/ClangImporter/Inputs/app-bridging-header-to-pch.h"
 // CHECK-SWIFTDEPS: - "SOURCE_DIR/test/ClangImporter/Inputs/chained-unit-test-bridging-header-to-pch.h"
 
+// CHECK-SWIFTDEPS2-NOT: {{.*}}.pch

--- a/test/Driver/multi-threaded.swift
+++ b/test/Driver/multi-threaded.swift
@@ -58,8 +58,8 @@
 // EXEC: ld
 // EXEC: /tmp/main{{[^ ]*}}.o /tmp/multi-threaded{{[^ ]*}}.o
 
-// DEPENDENCIES-DAG: {{.*}}/multi-threaded.o : {{.*}}/Inputs/main.swift {{.*}}/multi-threaded.swift
-// DEPENDENCIES-DAG: {{.*}}/main.o : {{.*}}/Inputs/main.swift {{.*}}/multi-threaded.swift
+// DEPENDENCIES-DAG: {{.*}}/multi-threaded.o : {{.*}}/multi-threaded.swift {{.*}}/Inputs/main.swift
+// DEPENDENCIES-DAG: {{.*}}/main.o : {{.*}}/multi-threaded.swift {{.*}}/Inputs/main.swift
 
 // PARSEABLE2: "name": "compile"
 // PARSEABLE2: "outputs": [

--- a/test/Frontend/dependencies.swift
+++ b/test/Frontend/dependencies.swift
@@ -43,26 +43,26 @@
 
 // CHECK-IMPORT-LABEL: - :
 // CHECK-IMPORT: dependencies.swift
-// CHECK-IMPORT-DAG: Inputs/dependencies/$$$$$$$$$$.h
-// CHECK-IMPORT-DAG: Inputs/dependencies/extra-header.h
 // CHECK-IMPORT-DAG: Swift.swiftmodule
-// CHECK-IMPORT-DAG: Foundation.swift
-// CHECK-IMPORT-DAG: ObjectiveC.swift
-// CHECK-IMPORT-DAG: CoreGraphics.swift
+// CHECK-IMPORT-DAG: Inputs/dependencies/$$$$$$$$$$.h
 // CHECK-IMPORT-DAG: Inputs/dependencies/UserClangModule.h
+// CHECK-IMPORT-DAG: Inputs/dependencies/extra-header.h
 // CHECK-IMPORT-DAG: Inputs/dependencies/module.modulemap
+// CHECK-IMPORT-DAG: ObjectiveC.swift
+// CHECK-IMPORT-DAG: Foundation.swift
+// CHECK-IMPORT-DAG: CoreGraphics.swift
 // CHECK-IMPORT-NOT: :
 
 // CHECK-IMPORT-YAML-LABEL: depends-external:
 // CHECK-IMPORT-YAML-NOT: dependencies.swift
-// CHECK-IMPORT-YAML-DAG: "{{.*}}Inputs/dependencies/$$$$$.h"
-// CHECK-IMPORT-YAML-DAG: "{{.*}}Inputs/dependencies/extra-header.h"
 // CHECK-IMPORT-YAML-DAG: "{{.*}}/Swift.swiftmodule"
-// CHECK-IMPORT-YAML-DAG: "{{.*}}/Foundation.swift"
-// CHECK-IMPORT-YAML-DAG: "{{.*}}/ObjectiveC.swift"
-// CHECK-IMPORT-YAML-DAG: "{{.*}}/CoreGraphics.swift"
+// CHECK-IMPORT-YAML-DAG: "{{.*}}Inputs/dependencies/$$$$$.h"
 // CHECK-IMPORT-YAML-DAG: "{{.*}}Inputs/dependencies/UserClangModule.h"
+// CHECK-IMPORT-YAML-DAG: "{{.*}}Inputs/dependencies/extra-header.h"
 // CHECK-IMPORT-YAML-DAG: "{{.*}}Inputs/dependencies/module.modulemap"
+// CHECK-IMPORT-YAML-DAG: "{{.*}}/ObjectiveC.swift"
+// CHECK-IMPORT-YAML-DAG: "{{.*}}/Foundation.swift"
+// CHECK-IMPORT-YAML-DAG: "{{.*}}/CoreGraphics.swift"
 // CHECK-IMPORT-YAML-NOT: {{^-}}
 // CHECK-IMPORT-YAML-NOT: {{:$}}
 


### PR DESCRIPTION
New approach to swift bridging PCH dependency-tracking problem previously attempted in #8143 

This modifies the ClangImporter and DependencyTracker to correctly observe dependencies between the outputs of a swift compilation, and the source files fed into a bridging PCH used as an input. It does so by removing some of the existing clang callbacks and delegating to a new subclass of clang::DependencyCollector, which in turn needs to be correctly hooked into external AST sources (see https://reviews.llvm.org/D31378 for the accompanying clang change).

The test in this patch will not pass until the clang change has merged.

rdar://31044067