### PR TITLE
Couple of fixes to python-linting

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,5 @@
 [flake8]
+ignore = W291
 filename = *.py,
            ./utils/80+-check,
            ./utils/backtrace-check,

--- a/utils/SwiftFloatingPointTypes.py
+++ b/utils/SwiftFloatingPointTypes.py
@@ -38,9 +38,9 @@ class SwiftFloatType(object):
 
 def floating_point_bits_to_type():
     return {
-        32: SwiftFloatType(name="Float",   cFuncSuffix="f", significandBits=23,
-                           exponentBits=8,  significandSize=32, totalBits=32),
-        64: SwiftFloatType(name="Double",  cFuncSuffix="",  significandBits=52,
+        32: SwiftFloatType(name="Float", cFuncSuffix="f", significandBits=23,
+                           exponentBits=8, significandSize=32, totalBits=32),
+        64: SwiftFloatType(name="Double", cFuncSuffix="", significandBits=52,
                            exponentBits=11, significandSize=64, totalBits=64),
         80: SwiftFloatType(name="Float80", cFuncSuffix="l", significandBits=63,
                            exponentBits=15, significandSize=64, totalBits=80),

--- a/utils/bug_reducer/bug_reducer/list_reducer.py
+++ b/utils/bug_reducer/bug_reducer/list_reducer.py
@@ -115,7 +115,7 @@ class ListReducer(object):
 
             # Split the list into a prefix, suffix list and then run test on
             # those.
-            mid = self.mid_top/2
+            mid = self.mid_top / 2
             if not self._test_prefix_suffix(mid, self.target_list[:mid],
                                             self.target_list[mid:]):
                 # If we returned false, then we did some sort of work and there
@@ -151,7 +151,7 @@ class ListReducer(object):
             # Check interior elements, using an offset to make sure we do not
             # skip elements when we trim.
             offset = 0
-            for i in range(1, len(self.target_list)-1):
+            for i in range(1, len(self.target_list) - 1):
                 real_i = i + offset
                 test_list = self.target_list[real_i:]
                 (result, prefix, suffix) = self.run_test([], test_list)

--- a/utils/coverage/coverage-build-db
+++ b/utils/coverage/coverage-build-db
@@ -52,10 +52,11 @@ def parse_coverage_log(filepath):
             new_section = [section[0]]
             i = 1
             if len(section) > 2:
-                while i < len(section)-1:
-                    while i < len(section)-1 and section[i][0] in ['0', None]:
+                while i < len(section) - 1:
+                    while i < len(section) - 1 and \
+                            section[i][0] in ['0', None]:
                         i += 1
-                    if i == len(section)-1:
+                    if i == len(section) - 1:
                         if section[i][0] not in ['0', None]:
                             istart = int(section[i][1])
                             iend = istart
@@ -63,9 +64,9 @@ def parse_coverage_log(filepath):
                         break
                     istart = int(section[i][1])
                     iend = istart  # single line interval starting
-                    while i < len(section)-1 and \
-                            int(section[i+1][1]) == iend + 1 and \
-                            section[i+1][0] not in ['0', None]:
+                    while i < len(section) - 1 and \
+                            int(section[i + 1][1]) == iend + 1 and \
+                            section[i + 1][0] not in ['0', None]:
                         iend += 1
                         i += 1
                     new_section.append((istart, iend))

--- a/utils/gyb.py
+++ b/utils/gyb.py
@@ -1079,6 +1079,16 @@ def execute_template(
 
 
 def main():
+    """
+    Lint this file.
+    >>> import sys
+    >>> gyb_path = os.path.realpath(__file__)
+    >>> sys.path.append(os.path.dirname(gyb_path))
+    >>> import python_lint
+    >>> python_lint.lint([gyb_path], verbose=False)
+    0
+    """
+
     import argparse
     import sys
 

--- a/utils/gyb_foundation_support.py
+++ b/utils/gyb_foundation_support.py
@@ -42,10 +42,10 @@ extension {Type}: _ObjectiveCBridgeable {{
 
 
 def ObjectiveCBridgeableImplementationForNSValueWithCategoryMethods(
-  Type,
-  initializer,
-  getter,
-  objCType="_getObjCTypeEncoding"
+    Type,
+    initializer,
+    getter,
+    objCType="_getObjCTypeEncoding"
 ):
     return """
 extension {Type}: _ObjectiveCBridgeable {{

--- a/utils/line-directive
+++ b/utils/line-directive
@@ -599,6 +599,11 @@ def run():
     >>> os.remove(target2.name)
     >>> raw_output.close()
     >>> os.remove(raw_output.name)
+
+    Lint this file.
+    >>> import python_lint
+    >>> python_lint.lint([os.path.realpath(__file__)], verbose=False)
+    0
     """
     if len(sys.argv) <= 1:
         import doctest

--- a/utils/python_lint.py
+++ b/utils/python_lint.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# python-lint.py - Runs flake8 linting over the repository ------*- python -*-
+# python_lint.py - Runs flake8 linting over the repository ------*- python -*-
 #
 # This source file is part of the Swift.org open source project
 #
@@ -17,24 +17,26 @@ import subprocess
 import sys
 
 
-def main():
+def lint(arguments, verbose=True):
     flake8_result = subprocess.call(
-      [sys.executable, "-c", "import flake8; import flake8_import_order"]
+        [sys.executable, "-c", "import flake8; import flake8_import_order"]
     )
     if flake8_result != 0:
-        print("Missing modules flake8 or flake8-import-order. Please be sure "
-              "to install these python packages before linting.")
-        sys.exit(0)
+        if verbose:
+            print("Missing modules flake8 or flake8-import-order. Please be"
+                  " sure to install these python packages before linting.")
+        return 0
 
     utils_directory = os.path.dirname(os.path.abspath(__file__))
     parent_directory = os.path.dirname(utils_directory)
     linting_result = subprocess.call(
-      [sys.executable, "-m", "flake8"] + sys.argv[1:],
-      cwd=parent_directory,
-      universal_newlines=True
+        [sys.executable, "-m", "flake8"] + arguments,
+        cwd=parent_directory,
+        universal_newlines=True
     )
-    sys.exit(linting_result)
+    return linting_result
 
 
 if __name__ == '__main__':
-    main()
+    linting_result = lint(sys.argv[1:])
+    sys.exit(linting_result)

--- a/utils/round-trip-syntax-test
+++ b/utils/round-trip-syntax-test
@@ -33,10 +33,8 @@ class RoundTripTask(object):
 
     @property
     def test_command(self):
-        return [
-                self.swift_syntax_test, self.action,
-                '-input-source-filename', self.input_filename
-                ]
+        return [self.swift_syntax_test, self.action,
+                '-input-source-filename', self.input_filename]
 
     @property
     def diff_command(self):

--- a/utils/scale-test
+++ b/utils/scale-test
@@ -172,10 +172,10 @@ def linear_regression(x, y):
     sum_y = sum(y)
     sum_prod = sum(a * b for a, b in zip(x, y))
     sum_x_sq = sum(a ** 2 for a in x)
-    mean_x = sum_x/n
-    mean_y = sum_y/n
-    mean_prod = sum_prod/n
-    mean_x_sq = sum_x_sq/n
+    mean_x = sum_x / n
+    mean_y = sum_y / n
+    mean_prod = sum_prod / n
+    mean_x_sq = sum_x_sq / n
     covar_xy = mean_prod - mean_x * mean_y
     var_x = mean_x_sq - mean_x**2
     slope = covar_xy / var_x

--- a/utils/swift_build_support/swift_build_support/host.py
+++ b/utils/swift_build_support/swift_build_support/host.py
@@ -63,7 +63,7 @@ def _darwin_max_num_llvm_parallel_lto_link_jobs():
     #
     # This is a bit conservative, but I have found that this number
     # prevents me from swapping on my test machine.
-    return int((_darwin_system_memory()/1000000000.0 - 3.0)/6.0)
+    return int((_darwin_system_memory() / 1000000000.0 - 3.0) / 6.0)
 
 
 def _darwin_max_num_swift_parallel_lto_link_jobs():
@@ -75,7 +75,7 @@ def _darwin_max_num_swift_parallel_lto_link_jobs():
     #
     # This is a bit conservative, but I have found that this number
     # prevents me from swapping on my test machine.
-    return int((_darwin_system_memory()/1000000000.0 - 3.0)/8.0)
+    return int((_darwin_system_memory() / 1000000000.0 - 3.0) / 8.0)
 
 
 _PER_PLATFORM_MAX_PARALLEL_LTO_JOBS = {

--- a/utils/symbolicate-linux-fatal
+++ b/utils/symbolicate-linux-fatal
@@ -93,7 +93,7 @@ def process_stack(binary, dyn_libs, stack):
         use_orig_line = True
         frame_addr = frame["framePC"]
         dynlib_fname = frame["dynlib_fname"]
-        so_addr = lldb_target.ResolveLoadAddress(frame_addr-1)
+        so_addr = lldb_target.ResolveLoadAddress(frame_addr - 1)
         sym_ctx = so_addr.GetSymbolContext(lldb.eSymbolContextEverything)
         frame_fragment = "{0: <4d} {1:20s} 0x{2:016x}".format(
             frame_idx, dynlib_fname, frame_addr)

--- a/utils/update-checkout
+++ b/utils/update-checkout
@@ -295,7 +295,7 @@ def obtain_all_additional_swift_sources(args, config, with_ssh, scheme_name,
 def dump_repo_hashes(config):
     max_len = reduce(lambda acc, x: max(acc, len(x)),
                      config['repos'].keys(), 0)
-    fmt = "{:<%r}{}" % (max_len+5)
+    fmt = "{:<%r}{}" % (max_len + 5)
     for repo_name, repo_info in sorted(config['repos'].items(),
                                        key=lambda x: x[0]):
         with shell.pushd(os.path.join(SWIFT_SOURCE_ROOT, repo_name),

--- a/validation-test/Python/python-lint.swift
+++ b/validation-test/Python/python-lint.swift
@@ -1,4 +1,4 @@
-// RUN: %{python} %utils/python-lint
+// RUN: %{python} %utils/python_lint.py
 // Continuous integration for the OS X Platform also runs the tests in the iPhone, Apple TV and Apple Watch simulators.
 // We only need to run python linting once per OSX Platform test run, rather than once for each supported Apple device.
 // UNSUPPORTED: OS=watchos


### PR DESCRIPTION
Unfortunately

> This commit broke the development process. We have a very specific and intentional policy against caring about trailing whitespace, as it creates busywork for no benefit. Please turn off the trailing whitespace check if you're going to enable python-lint. Ideally, also, every Python file with doctests should lint itself when tested, so we don't have to find out from CI that some trivial style point has been violated.


@dabrahams