### PR TITLE
[build-script] Give ubsan, tsan the same treatment I gave asan in 824 ffa685740315e10c51ea281f7c8559e3471e0

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -682,10 +682,11 @@ class BuildScriptInvocation(object):
                 "--distcc",
                 "--distcc-pump=%s" % toolchain.distcc_pump
             ]
+
+        # *NOTE* We use normal cmake to pass through tsan/ubsan options. We do
+        # NOT pass them to build-script-impl.
         if args.enable_asan:
             impl_args += ["--enable-asan"]
-        if args.enable_ubsan:
-            impl_args += ["--enable-ubsan"]
         if args.verbose_build:
             impl_args += ["--verbose-build"]
         if args.install_symroot:

--- a/utils/swift_build_support/swift_build_support/workspace.py
+++ b/utils/swift_build_support/swift_build_support/workspace.py
@@ -85,7 +85,11 @@ def compute_build_subdir(args):
         build_subdir += "+swift-" + swift_build_dir_label
         build_subdir += "+stdlib-" + swift_stdlib_build_dir_label
 
-    # IF we have asan enabled, mangle it into the build directory name.
+    # If we have a sanitizer enabled, mangle it into the subdir.
     if args.enable_asan:
         build_subdir += "+asan"
+    if args.enable_ubsan:
+        build_subdir += "+ubsan"
+    if args.enable_tsan:
+        build_subdir += "+tsan"
     return build_subdir

--- a/utils/swift_build_support/tests/test_workspace.py
+++ b/utils/swift_build_support/tests/test_workspace.py
@@ -51,7 +51,8 @@ class WorkspaceTestCase(unittest.TestCase):
 class ComputeBuildSubdirTestCase(unittest.TestCase):
 
     def create_basic_args(self, generator, variant, assertions,
-                          enable_asan=False):
+                          enable_asan=False, enable_ubsan=False,
+                          enable_tsan=False):
         return argparse.Namespace(
             cmake_generator=generator,
             cmark_build_variant=variant,
@@ -63,13 +64,27 @@ class ComputeBuildSubdirTestCase(unittest.TestCase):
             llvm_assertions=assertions,
             swift_assertions=assertions,
             swift_stdlib_assertions=assertions,
-            enable_asan=enable_asan)
+            enable_asan=enable_asan,
+            enable_ubsan=enable_ubsan,
+            enable_tsan=enable_tsan)
 
     def test_Ninja_ReleaseAssert_asan(self):  # noqa (N802 function name should be lowercase)
         args = self.create_basic_args(
             "Ninja", variant="Release", assertions=True, enable_asan=True)
         self.assertEqual(compute_build_subdir(args),
                          "Ninja-ReleaseAssert+asan")
+
+    def test_Ninja_ReleaseAssert_ubsan(self):  # noqa (N802 function name should be lowercase)
+        args = self.create_basic_args(
+            "Ninja", variant="Release", assertions=True, enable_ubsan=True)
+        self.assertEqual(compute_build_subdir(args),
+                         "Ninja-ReleaseAssert+ubsan")
+
+    def test_Ninja_ReleaseAssert_tsan(self):  # noqa (N802 function name should be lowercase)
+        args = self.create_basic_args(
+            "Ninja", variant="Release", assertions=True, enable_tsan=True)
+        self.assertEqual(compute_build_subdir(args),
+                         "Ninja-ReleaseAssert+tsan")
 
     def test_Ninja_ReleaseAssert(self):  # noqa (N802 function name should be lowercase)
         # build-script -R
@@ -141,7 +156,9 @@ class ComputeBuildSubdirTestCase(unittest.TestCase):
         def generate():
             for c in productions:
                 args = argparse.Namespace(cmake_generator="Ninja",
-                                          enable_asan=False)
+                                          enable_asan=False,
+                                          enable_ubsan=False,
+                                          enable_tsan=False)
                 for key, val in zip(keys, c):
                     setattr(args, key, val)
                 yield compute_build_subdir(args)


### PR DESCRIPTION
This basically just mangles ubsan or tsan into the build subdir name.
