### PR TITLE
Sema: Fix captures of lvalues from nested generic functions

### DIFF
--- a/lib/Sema/TypeCheckExpr.cpp
+++ b/lib/Sema/TypeCheckExpr.cpp
@@ -580,6 +580,16 @@ Type TypeChecker::getUnopenedTypeOfReference(ValueDecl *value, Type baseType,
 
   Type requestedType = getTypeOfRValue(value, wantInterfaceType);
 
+  // If we're dealing with contextual types, and we referenced this type from
+  // a different context, map the type.
+  if (!wantInterfaceType && requestedType->hasArchetype()) {
+    auto valueDC = value->getDeclContext();
+    if (valueDC != UseDC) {
+      Type mapped = valueDC->mapTypeOutOfContext(requestedType);
+      requestedType = UseDC->mapTypeIntoContext(mapped);
+    }
+  }
+
   // Qualify storage declarations with an lvalue when appropriate.
   // Otherwise, they yield rvalues (and the access must be a load).
   if (auto *storage = dyn_cast<AbstractStorageDecl>(value)) {
@@ -602,16 +612,6 @@ Type TypeChecker::getUnopenedTypeOfReference(ValueDecl *value, Type baseType,
       return FunctionType::get(genericFn->getInput(),
                                genericFn->getResult(),
                                genericFn->getExtInfo());
-    }
-  }
-
-  // If we're dealing with contextual types, and we referenced this type from
-  // a different context, map the type.
-  if (!wantInterfaceType && requestedType->hasArchetype()) {
-    auto valueDC = value->getDeclContext();
-    if (valueDC != UseDC) {
-      Type mapped = valueDC->mapTypeOutOfContext(requestedType);
-      requestedType = UseDC->mapTypeIntoContext(mapped);
     }
   }
 

--- a/test/expr/closure/closures.swift
+++ b/test/expr/closure/closures.swift
@@ -338,3 +338,18 @@ func r25993258a() {
 func r25993258b() {
   r25993258_helper { _ in () }
 }
+
+// We have to map the captured var type into the right generic environment.
+class GenericClass<T> {}
+
+func lvalueCapture<T>(c: GenericClass<T>) {
+  var cc = c
+  weak var wc = c
+
+  func innerGeneric<U>(_: U) {
+    _ = cc
+    _ = wc
+
+    cc = wc!
+  }
+}


### PR DESCRIPTION
The "map into the right context" logic was only getting hit
if we didn't exit early to handle the lvalue case. Move it up
to the top of the function.

Fixes <https://bugs.swift.org/browse/SR-4369>.