### PR TITLE
Fix materializeForSet in constrained extensions and clean up type canonicalization a bit

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -365,6 +365,10 @@ public:
   /// sugar from all levels stripped off.
   CanType getCanonicalType();
 
+  /// getCanonicalType - Stronger canonicalization which folds away equivalent
+  /// associated types, or type parameters that have been made concrete.
+  CanType getCanonicalType(GenericSignature *sig, ModuleDecl &mod);
+
   /// Reconstitute type sugar, e.g., for array types, dictionary
   /// types, optionals, etc.
   TypeBase *reconstituteSugar(bool Recursive);

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1083,8 +1083,8 @@ CanType TypeBase::getCanonicalType() {
     // Transform the input and result types.
     auto &ctx = function->getInput()->getASTContext();
     auto &mod = *ctx.TheBuiltinModule;
-    auto inputTy = sig->getCanonicalTypeInContext(function->getInput(), mod);
-    auto resultTy = sig->getCanonicalTypeInContext(function->getResult(), mod);
+    auto inputTy = function->getInput()->getCanonicalType(sig, mod);
+    auto resultTy = function->getResult()->getCanonicalType(sig, mod);
 
     Result = GenericFunctionType::get(sig, inputTy, resultTy,
                                       function->getExtInfo());
@@ -1166,6 +1166,14 @@ CanType TypeBase::getCanonicalType() {
   assert(Result && "Case not implemented!");
   CanonicalType = Result;
   return CanType(Result);
+}
+
+CanType TypeBase::getCanonicalType(GenericSignature *sig,
+                                   ModuleDecl &mod) {
+  if (!sig)
+    return getCanonicalType();
+
+  return sig->getCanonicalTypeInContext(this, mod);
 }
 
 TypeBase *TypeBase::reconstituteSugar(bool Recursive) {

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -203,9 +203,8 @@ void PolymorphicConvention::enumerateRequirements(const RequirementCallback &cal
   if (!Generics) return;
 
   // Get all of the type metadata.
-  for (auto gp : Generics.getGenericParams()) {
-    if (Generics->getCanonicalTypeInContext(gp, M) == gp)
-      callback({gp, nullptr});
+  for (auto gp : Generics->getSubstitutableParams()) {
+    callback({CanType(gp), nullptr});
   }
 
   // Get the protocol conformances.

--- a/lib/SIL/AbstractionPattern.cpp
+++ b/lib/SIL/AbstractionPattern.cpp
@@ -52,9 +52,13 @@ TypeConverter::getIndicesAbstractionPattern(SubscriptDecl *decl) {
   CanGenericSignature genericSig;
   if (auto sig = decl->getGenericSignatureOfContext())
     genericSig = sig->getCanonicalSignature();
-  return AbstractionPattern(genericSig,
-                            decl->getIndicesInterfaceType()
-                                ->getCanonicalType());
+  auto indicesTy = decl->getIndicesInterfaceType();
+  auto indicesCanTy =
+    (genericSig
+     ? genericSig->getCanonicalTypeInContext(indicesTy,
+                                             *decl->getParentModule())
+     : indicesTy->getCanonicalType());
+  return AbstractionPattern(genericSig, indicesCanTy);
 }
 
 static const clang::Type *getClangType(const clang::Decl *decl) {

--- a/lib/SIL/AbstractionPattern.cpp
+++ b/lib/SIL/AbstractionPattern.cpp
@@ -53,11 +53,8 @@ TypeConverter::getIndicesAbstractionPattern(SubscriptDecl *decl) {
   if (auto sig = decl->getGenericSignatureOfContext())
     genericSig = sig->getCanonicalSignature();
   auto indicesTy = decl->getIndicesInterfaceType();
-  auto indicesCanTy =
-    (genericSig
-     ? genericSig->getCanonicalTypeInContext(indicesTy,
-                                             *decl->getParentModule())
-     : indicesTy->getCanonicalType());
+  auto indicesCanTy = indicesTy->getCanonicalType(genericSig,
+                                                  *decl->getParentModule());
   return AbstractionPattern(genericSig, indicesCanTy);
 }
 

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -766,10 +766,7 @@ static CanSILFunctionType getSILFunctionType(SILModule &M,
     auto origGenericSig
       = function->getGenericSignature();
     auto getCanonicalType = [origGenericSig, &M](Type t) -> CanType {
-      if (origGenericSig)
-        return origGenericSig->getCanonicalTypeInContext(t,
-                                                         *M.getSwiftModule());
-      return t->getCanonicalType();
+      return t->getCanonicalType(origGenericSig, *M.getSwiftModule());
     };
 
     auto &Types = M.Types;

--- a/lib/SILGen/SILGenMaterializeForSet.cpp
+++ b/lib/SILGen/SILGenMaterializeForSet.cpp
@@ -438,7 +438,11 @@ public:
     }
 
     CanType witnessSelfType =
-      Witness->computeInterfaceSelfType()->getCanonicalType();
+      (GenericSig
+       ? GenericSig->getCanonicalTypeInContext(
+           Witness->computeInterfaceSelfType(),
+           *SGM.M.getSwiftModule())
+       : Witness->computeInterfaceSelfType()->getCanonicalType());
     witnessSelfType = getSubstWitnessInterfaceType(witnessSelfType);
     witnessSelfType = witnessSelfType->getInOutObjectType()
       ->getCanonicalType();
@@ -646,7 +650,11 @@ collectIndicesFromParameters(SILGenFunction &gen, SILLocation loc,
                              ArrayRef<ManagedValue> sourceIndices) {
   auto witnessSubscript = cast<SubscriptDecl>(WitnessStorage);
   CanType witnessIndicesType =
-    witnessSubscript->getIndicesInterfaceType()->getCanonicalType();
+    (GenericSig
+       ? GenericSig->getCanonicalTypeInContext(
+           witnessSubscript->getIndicesInterfaceType(),
+           *SGM.M.getSwiftModule())
+       : witnessSubscript->getIndicesInterfaceType()->getCanonicalType());
   CanType substIndicesType =
     getSubstWitnessInterfaceType(witnessIndicesType);
 

--- a/lib/SILGen/SILGenMaterializeForSet.cpp
+++ b/lib/SILGen/SILGenMaterializeForSet.cpp
@@ -438,11 +438,8 @@ public:
     }
 
     CanType witnessSelfType =
-      (GenericSig
-       ? GenericSig->getCanonicalTypeInContext(
-           Witness->computeInterfaceSelfType(),
-           *SGM.M.getSwiftModule())
-       : Witness->computeInterfaceSelfType()->getCanonicalType());
+      Witness->computeInterfaceSelfType()->getCanonicalType(
+        GenericSig, *SGM.M.getSwiftModule());
     witnessSelfType = getSubstWitnessInterfaceType(witnessSelfType);
     witnessSelfType = witnessSelfType->getInOutObjectType()
       ->getCanonicalType();
@@ -650,11 +647,9 @@ collectIndicesFromParameters(SILGenFunction &gen, SILLocation loc,
                              ArrayRef<ManagedValue> sourceIndices) {
   auto witnessSubscript = cast<SubscriptDecl>(WitnessStorage);
   CanType witnessIndicesType =
-    (GenericSig
-       ? GenericSig->getCanonicalTypeInContext(
-           witnessSubscript->getIndicesInterfaceType(),
-           *SGM.M.getSwiftModule())
-       : witnessSubscript->getIndicesInterfaceType()->getCanonicalType());
+    witnessSubscript->getIndicesInterfaceType()
+      ->getCanonicalType(GenericSig,
+                         *SGM.M.getSwiftModule());
   CanType substIndicesType =
     getSubstWitnessInterfaceType(witnessIndicesType);
 

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -2773,9 +2773,7 @@ CanSILFunctionType SILGenFunction::buildThunkType(
 
   auto &mod = *F.getModule().getSwiftModule();
   auto getCanonicalType = [&](Type t) -> CanType {
-    if (genericSig)
-      return genericSig->getCanonicalTypeInContext(t, mod);
-    return t->getCanonicalType();
+    return t->getCanonicalType(genericSig, mod);
   };
 
   // Map the parameter and expected types out of context to get the interface

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -498,10 +498,9 @@ unsigned SILGenFunction::emitProlog(ArrayRef<ParameterList *> paramLists,
                                     Type resultType, DeclContext *DC,
                                     bool throws) {
   // Create the indirect result parameters.
-  if (auto *genericSig = DC->getGenericSignatureOfContext()) {
-    resultType = genericSig->getCanonicalTypeInContext(
-      resultType, *SGM.M.getSwiftModule());
-  }
+  auto *genericSig = DC->getGenericSignatureOfContext();
+  resultType = resultType->getCanonicalType(genericSig,
+                                            *SGM.M.getSwiftModule());
 
   emitIndirectResultParameters(*this, resultType, DC);
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -5578,19 +5578,14 @@ public:
         }
 
         // Canonicalize with respect to the override's generic signature, if any.
-        CanType canDeclTy;
-        CanType canParentDeclTy;
-        if (auto *genericSig = decl->getInnermostDeclContext()
-              ->getGenericSignatureOfContext()) {
-          auto *module = dc->getParentModule();
-          canDeclTy = genericSig->getCanonicalTypeInContext(
-            declTy, *module);
-          canParentDeclTy = genericSig->getCanonicalTypeInContext(
-            parentDeclTy, *module);
-        } else {
-          canDeclTy = declTy->getCanonicalType();
-          canParentDeclTy = parentDeclTy->getCanonicalType();
-        }
+        auto *genericSig = decl->getInnermostDeclContext()
+          ->getGenericSignatureOfContext();
+        auto *module = dc->getParentModule();
+
+        auto canDeclTy =
+          declTy->getCanonicalType(genericSig, *module);
+        auto canParentDeclTy =
+          parentDeclTy->getCanonicalType(genericSig, *module);
 
         if (canDeclTy == canParentDeclTy) {
           matches.push_back({parentDecl, true, parentDeclTy});

--- a/test/SILGen/constrained_extensions.swift
+++ b/test/SILGen/constrained_extensions.swift
@@ -1,6 +1,6 @@
-// RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -primary-file %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-sil -O %s
 // RUN: %target-swift-frontend -emit-ir %s
-// RUN: %target-swift-frontend -emit-ir -O %s
 
 extension Array where Element == Int {
   // CHECK-LABEL: sil @_T0Sa22constrained_extensionsSiRszlESaySiGyt1x_tcfC : $@convention(method) (@thin Array<Int>.Type) -> @owned Array<Int>
@@ -129,5 +129,45 @@ extension Dictionary where Key == Int {
     func increment(x: inout Value) { }
 
     increment(x: &instanceProperty)
+  }
+}
+
+public class GenericClass<X, Y> {}
+
+extension GenericClass where Y == () {
+  // CHECK-LABEL: sil @_T022constrained_extensions12GenericClassCAAytRs_r0_lE5valuexfg : $@convention(method) <X, Y where Y == ()> (@guaranteed GenericClass<X, ()>) -> @out X
+  // CHECK-LABEL: sil @_T022constrained_extensions12GenericClassCAAytRs_r0_lE5valuexfs : $@convention(method) <X, Y where Y == ()> (@in X, @guaranteed GenericClass<X, ()>) -> ()
+  // CHECK-LABEL: sil [transparent] [fragile] @_T022constrained_extensions12GenericClassCAAytRs_r0_lE5valuexfmytfU_ : $@convention(method) <X, Y where Y == ()> (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout GenericClass<X, ()>, @thick GenericClass<X, ()>.Type) -> ()
+  // CHECK-LABEL: sil [transparent] [fragile] @_T022constrained_extensions12GenericClassCAAytRs_r0_lE5valuexfm : $@convention(method) <X, Y where Y == ()> (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @guaranteed GenericClass<X, ()>) -> (Builtin.RawPointer, Optional<Builtin.RawPointer>)
+  public var value: X {
+    get { while true {} }
+    set {}
+  }
+
+  // CHECK-LABEL: sil @_T022constrained_extensions12GenericClassCAAytRs_r0_lE5emptyytfg : $@convention(method) <X, Y where Y == ()> (@guaranteed GenericClass<X, ()>) -> ()
+  // CHECK-LABEL: sil @_T022constrained_extensions12GenericClassCAAytRs_r0_lE5emptyytfs : $@convention(method) <X, Y where Y == ()> (@guaranteed GenericClass<X, ()>) -> ()
+  // CHECK-LABEL: sil [transparent] [fragile] @_T022constrained_extensions12GenericClassCAAytRs_r0_lE5emptyytfmytfU_ : $@convention(method) <X, Y where Y == ()> (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout GenericClass<X, ()>, @thick GenericClass<X, ()>.Type) -> ()
+  // CHECK-LABEL: sil [transparent] [fragile] @_T022constrained_extensions12GenericClassCAAytRs_r0_lE5emptyytfm : $@convention(method) <X, Y where Y == ()> (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @guaranteed GenericClass<X, ()>) -> (Builtin.RawPointer, Optional<Builtin.RawPointer>)
+  public var empty: Y {
+    get { return () }
+    set {}
+  }
+
+  // CHECK-LABEL: sil @_T022constrained_extensions12GenericClassCAAytRs_r0_lE9subscriptxycfg : $@convention(method) <X, Y where Y == ()> (@guaranteed GenericClass<X, ()>) -> @out X
+  // CHECK-LABEL: sil @_T022constrained_extensions12GenericClassCAAytRs_r0_lE9subscriptxycfs : $@convention(method) <X, Y where Y == ()> (@in X, @guaranteed GenericClass<X, ()>) -> ()
+  // CHECK-LABEL: sil [transparent] [fragile] @_T022constrained_extensions12GenericClassCAAytRs_r0_lE9subscriptxycfmytfU_ : $@convention(method) <X, Y where Y == ()> (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout GenericClass<X, ()>, @thick GenericClass<X, ()>.Type) -> ()
+  // CHECK-LABEL: sil [transparent] [fragile] @_T022constrained_extensions12GenericClassCAAytRs_r0_lE9subscriptxycfm : $@convention(method) <X, Y where Y == ()> (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @guaranteed GenericClass<X, ()>) -> (Builtin.RawPointer, Optional<Builtin.RawPointer>)
+  public subscript(_: Y) -> X {
+    get { while true {} }
+    set {}
+  }
+
+  // CHECK-LABEL: sil @_T022constrained_extensions12GenericClassCAAytRs_r0_lE9subscriptyxcfg : $@convention(method) <X, Y where Y == ()> (@in X, @guaranteed GenericClass<X, ()>) -> ()
+  // CHECK-LABEL: sil @_T022constrained_extensions12GenericClassCAAytRs_r0_lE9subscriptyxcfs : $@convention(method) <X, Y where Y == ()> (@in X, @guaranteed GenericClass<X, ()>) -> ()
+  // CHECK-LABEL: sil [transparent] [fragile] @_T022constrained_extensions12GenericClassCAAytRs_r0_lE9subscriptyxcfmytfU_ : $@convention(method) <X, Y where Y == ()> (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout GenericClass<X, ()>, @thick GenericClass<X, ()>.Type) -> ()
+  // CHECK-LABEL: sil [transparent] [fragile] @_T022constrained_extensions12GenericClassCAAytRs_r0_lE9subscriptyxcfm : $@convention(method) <X, Y where Y == ()> (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @in X, @guaranteed GenericClass<X, ()>) -> (Builtin.RawPointer, Optional<Builtin.RawPointer>)
+  public subscript(_: X) -> Y {
+    get { while true {} }
+    set {}
   }
 }


### PR DESCRIPTION
Just your average run of the mill "type was not being canonicalized with respect to a signature" bug. We've had too many of these and we need to figure out the right general solution to this problem.

In the meantime, take note of the new `TypeBase::getCanonicalType(GenericSignature *, ModuleDecl &)` utility method; you might need it.

Fixes <rdar://problem/31222187>.