### PR TITLE
[SIL][DI] Don’t crash when emitting closure errors

### DIFF
--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -1079,9 +1079,9 @@ void LifetimeChecker::handleInOutUse(const DIMemoryUse &Use) {
             // Normal method calls are curried, so they are:
             // (call_expr (dot_syntax_call_expr (decl_ref_expr METHOD)))
             FD = dyn_cast<FuncDecl>(DSCE->getCalledValue());
-          else if (CE->getCalledValue() != nullptr)
+          else
             // Operators and normal function calls are just (CallExpr DRE)
-            FD = dyn_cast<FuncDecl>(CE->getCalledValue());
+            FD = dyn_cast_or_null<FuncDecl>(CE->getCalledValue());
         }
       }
     }

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -1079,7 +1079,7 @@ void LifetimeChecker::handleInOutUse(const DIMemoryUse &Use) {
             // Normal method calls are curried, so they are:
             // (call_expr (dot_syntax_call_expr (decl_ref_expr METHOD)))
             FD = dyn_cast<FuncDecl>(DSCE->getCalledValue());
-          else
+          else if (CE->getCalledValue() != nullptr)
             // Operators and normal function calls are just (CallExpr DRE)
             FD = dyn_cast<FuncDecl>(CE->getCalledValue());
         }

--- a/test/SILOptimizer/definite_init_diagnostics.swift
+++ b/test/SILOptimizer/definite_init_diagnostics.swift
@@ -14,6 +14,7 @@ func test1() -> Int {
 }
 
 func takes_inout(_ a: inout Int) {}
+func takes_inout_any(_ a: inout Any) {}
 func takes_closure(_ fn: () -> ()) {}
 
 class SomeClass { 
@@ -81,6 +82,10 @@ func test2() {
     markUsed(b4!)
   }
   b4 = 7
+  
+  let b5: Any
+  b5 = "x"   
+  ({ takes_inout_any(&b5) })()   // expected-error {{immutable value 'b5' may not be passed inout}}
 
   // Structs
   var s1 : SomeStruct


### PR DESCRIPTION
When the DI lifetime checker diagnoses an `inout`-related error, it tries to examine the function you’re calling to emit its name in the error message. Unfortunately, it implicitly assumes that `ApplyExpr::getCalledValue()` will find a `ValueDecl` to return; if the `ApplyExpr` directly calls a closure, it won’t, and so `handleInOutUse` will try to `dyn_cast` a `nullptr`. This change adds a check to avoid that.