### PR TITLE
Copy-on-write existential performance work

### DIFF
--- a/include/swift/Runtime/HeapObject.h
+++ b/include/swift/Runtime/HeapObject.h
@@ -160,6 +160,14 @@ BoxPair::Return swift_allocBox(Metadata const *type);
 SWIFT_RUNTIME_EXPORT
 BoxPair::Return (*_swift_allocBox)(Metadata const *type);
 
+/// Performs a uniqueness check on the pointer to a box structure. If the check
+/// fails allocates a new box and stores the pointer in the buffer.
+///
+///  if (!isUnique(buffer[0]))
+///    buffer[0] = swift_allocBox(type)
+SWIFT_RUNTIME_EXPORT
+BoxPair::Return swift_makeBoxUnique(OpaqueValue *buffer, Metadata const *type,
+                                    size_t alignMask);
 
 // Allocate plain old memory. This is the generalized entry point
 // Never returns nil. The returned memory is uninitialized. 

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -55,6 +55,14 @@ FUNCTION_WITH_GLOBAL_SYMBOL_AND_IMPL(AllocBox, swift_allocBox,
          ARGS(TypeMetadataPtrTy),
          ATTRS(NoUnwind))
 
+//  BoxPair swift_makeBoxUnique(OpaqueValue *buffer, Metadata *type, size_t alignMask);
+FUNCTION(MakeBoxUnique,
+         swift_makeBoxUnique,
+         DefaultCC,
+         RETURNS(RefCountedPtrTy, OpaquePtrTy),
+         ARGS(OpaquePtrTy, TypeMetadataPtrTy, SizeTy),
+         ATTRS(NoUnwind, ZExt))
+
 FUNCTION(DeallocBox, swift_deallocBox, DefaultCC,
          RETURNS(VoidTy),
          ARGS(RefCountedPtrTy),

--- a/lib/IRGen/GenExistential.cpp
+++ b/lib/IRGen/GenExistential.cpp
@@ -356,7 +356,7 @@ public:
     auto layout = getLayout();
 
     // Use copy-on-write existentials?
-    if (IGF.IGM.getSILModule().getOptions().UseCOWExistentials) {
+    if (false && IGF.IGM.getSILModule().getOptions().UseCOWExistentials) {
       auto fn = getInitWithCopyBoxedOpaqueExistentialBufferFunction(
           IGF.IGM, getLayout(), src.getAddress()->getType());
       auto call =
@@ -383,7 +383,7 @@ public:
     auto layout = getLayout();
 
     // Use copy-on-write existentials?
-    if (IGF.IGM.getSILModule().getOptions().UseCOWExistentials) {
+    if (false && IGF.IGM.getSILModule().getOptions().UseCOWExistentials) {
       auto fn = getInitWithTakeBoxedOpaqueExistentialBufferFunction(
           IGF.IGM, getLayout(), src.getAddress()->getType());
       auto call =

--- a/lib/IRGen/GenExistential.cpp
+++ b/lib/IRGen/GenExistential.cpp
@@ -2230,7 +2230,6 @@ static llvm::Constant *getAllocateBoxedOpaqueExistentialBufferFunction(
         auto *metadata = existLayout.loadMetadataRef(IGF, existentialContainer);
         llvm::Value *isInline, *flags;
         std::tie(isInline, flags) = emitLoadOfIsInline(IGF, metadata);
-        auto *origBB = IGF.Builder.GetInsertBlock();
         llvm::BasicBlock *doneBB = IGF.createBasicBlock("done");
         llvm::BasicBlock *allocateBB = IGF.createBasicBlock("allocateBox");
         llvm::Value *addressInBox;
@@ -2239,6 +2238,9 @@ static llvm::Constant *getAllocateBoxedOpaqueExistentialBufferFunction(
         llvm::Value *addressInline = IGF.Builder.CreateBitCast(
             existentialBuffer.getAddress(), IGF.IGM.OpaquePtrTy);
         IGF.Builder.CreateCondBr(isInline, doneBB, allocateBB);
+
+        IGF.Builder.emitBlock(doneBB);
+        IGF.Builder.CreateRet(addressInline);
 
         // Use the runtime to allocate a box of the appropriate size.
         {
@@ -2253,14 +2255,9 @@ static llvm::Constant *getAllocateBoxedOpaqueExistentialBufferFunction(
               Address(IGF.Builder.CreateBitCast(existentialBuffer.getAddress(),
                                                 box->getType()->getPointerTo()),
                       existLayout.getAlignment(IGF.IGM)));
-          IGF.Builder.CreateBr(doneBB);
+          IGF.Builder.CreateRet(addressInBox);
         }
 
-        IGF.Builder.emitBlock(doneBB);
-        auto *addressOfValue = IGF.Builder.CreatePHI(IGF.IGM.OpaquePtrTy, 2);
-        addressOfValue->addIncoming(addressInline, origBB);
-        addressOfValue->addIncoming(addressInBox, allocateBB);
-        IGF.Builder.CreateRet(addressOfValue);
       }, true /*noinline*/);
 }
 
@@ -2331,6 +2328,10 @@ static llvm::Constant *getDeallocateBoxedOpaqueExistentialBufferFunction(
         llvm::BasicBlock *deallocateBB = IGF.createBasicBlock("deallocateBox");
         Builder.CreateCondBr(isInline, doneBB, deallocateBB);
 
+        // We are done. Return.
+        Builder.emitBlock(doneBB);
+        Builder.CreateRetVoid();
+
         // We have an allocated uninitialized box. Deallocate the box.
         // No ConditionalDominanceScope because no code is executed that could
         // affect the caches.
@@ -2364,12 +2365,8 @@ static llvm::Constant *getDeallocateBoxedOpaqueExistentialBufferFunction(
             IGF.IGM.SizeTy, IGF.IGM.getPointerAlignment().getValue() - 1);
         alignmentMask = Builder.CreateOr(alignmentMask, pointerAlignMask);
         emitDeallocateHeapObject(IGF, boxReference, size, alignmentMask);
-        Builder.CreateBr(doneBB);
-
         // We are done. Return.
-        Builder.emitBlock(doneBB);
         Builder.CreateRetVoid();
-
       }, true /*noinline*/);
 }
 
@@ -2425,8 +2422,11 @@ getProjectBoxedOpaqueExistentialFunction(IRGenFunction &IGF,
         llvm::BasicBlock *boxedBB = IGF.createBasicBlock("boxed");
         llvm::Value *addressInline = Builder.CreateBitCast(
             existentialBuffer.getAddress(), IGM.OpaquePtrTy);
-        auto *origBB = Builder.GetInsertBlock();
         Builder.CreateCondBr(isInline, doneBB, boxedBB);
+
+        // We are done. Return the pointer to the address of the value.
+        Builder.emitBlock(doneBB);
+        IGF.Builder.CreateRet(addressInline);
 
         // We have an allocated uninitialized box. Deallocate the box.
         Builder.emitBlock(boxedBB);
@@ -2491,19 +2491,9 @@ getProjectBoxedOpaqueExistentialFunction(IRGenFunction &IGF,
           auto uniqueAddressInBox = Builder.CreatePHI(IGM.OpaquePtrTy, 2);
           uniqueAddressInBox->addIncoming(addressInBox, boxedBB);
           uniqueAddressInBox->addIncoming(addressInNewBox, makeUniqueBB);
-          Builder.CreateBr(doneBB);
           addressInBox = uniqueAddressInBox;
-          boxedBB = uniqueBB;
-        } else {
-          Builder.CreateBr(doneBB);
         }
-
-        // We are done. Return the pointer to the address of the value.
-        Builder.emitBlock(doneBB);
-        auto *addressOfValue = IGF.Builder.CreatePHI(IGM.OpaquePtrTy, 2);
-        addressOfValue->addIncoming(addressInline, origBB);
-        addressOfValue->addIncoming(addressInBox, boxedBB);
-        IGF.Builder.CreateRet(addressOfValue);
+        IGF.Builder.CreateRet(addressInBox);
       }, true /*noinline*/);
 }
 

--- a/lib/IRGen/IRGenFunction.cpp
+++ b/lib/IRGen/IRGenFunction.cpp
@@ -163,6 +163,24 @@ void IRGenFunction::emitAllocBoxCall(llvm::Value *typeMetadata,
   valueAddress = Builder.CreateExtractValue(call, 1);
 }
 
+void IRGenFunction::emitMakeBoxUniqueCall(llvm::Value *box,
+                                          llvm::Value *typeMetadata,
+                                          llvm::Value *alignMask,
+                                          llvm::Value *&outBox,
+                                          llvm::Value *&outValueAddress) {
+  auto attrs = llvm::AttributeSet::get(IGM.LLVMContext,
+                                       llvm::AttributeSet::FunctionIndex,
+                                       llvm::Attribute::NoUnwind);
+
+  llvm::CallInst *call = Builder.CreateCall(IGM.getMakeBoxUniqueFn(),
+                                            {box, typeMetadata, alignMask});
+  call->setAttributes(attrs);
+
+  outBox = Builder.CreateExtractValue(call, 0);
+  outValueAddress = Builder.CreateExtractValue(call, 1);
+}
+
+
 void IRGenFunction::emitDeallocBoxCall(llvm::Value *box,
                                         llvm::Value *typeMetadata) {
   auto attrs = llvm::AttributeSet::get(IGM.LLVMContext,

--- a/lib/IRGen/IRGenFunction.h
+++ b/lib/IRGen/IRGenFunction.h
@@ -177,6 +177,10 @@ public:
                          llvm::Value *&box,
                          llvm::Value *&valueAddress);
 
+  void emitMakeBoxUniqueCall(llvm::Value *box, llvm::Value *typeMetadata,
+                             llvm::Value *alignMask, llvm::Value *&outBox,
+                             llvm::Value *&outValueAddress);
+
   void emitDeallocBoxCall(llvm::Value *box, llvm::Value *typeMetadata);
 
   void emitTSanInoutAccessCall(llvm::Value *address);

--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -178,7 +178,7 @@ BoxPair::Return swift::swift_makeBoxUnique(OpaqueValue *buffer, const Metadata *
   HeapObject *box = reinterpret_cast<HeapObject *>(inlineBuffer->PrivateData[0]);
 
   if (!swift_isUniquelyReferenced_nonNull_native(box)) {
-    auto refAndObjectAddr = swift_allocBox(type);
+    auto refAndObjectAddr = BoxPair(swift_allocBox(type));
     // Compute the address of the old object.
     auto headerOffset = sizeof(HeapObject) + alignMask & ~alignMask;
     auto *oldObjectAddr = reinterpret_cast<OpaqueValue *>(
@@ -193,7 +193,7 @@ BoxPair::Return swift::swift_makeBoxUnique(OpaqueValue *buffer, const Metadata *
     auto headerOffset = sizeof(HeapObject) + alignMask & ~alignMask;
     auto *objectAddr = reinterpret_cast<OpaqueValue *>(
         reinterpret_cast<char *>(box) + headerOffset);
-    return {box, objectAddr};
+    return BoxPair{box, objectAddr};
   }
 }
 

--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -172,6 +172,31 @@ BoxPair::Return swift::swift_allocBox(const Metadata *type) {
   return SWIFT_RT_ENTRY_REF(swift_allocBox)(type);
 }
 
+BoxPair::Return swift::swift_makeBoxUnique(OpaqueValue *buffer, const Metadata *type,
+                                    size_t alignMask) {
+  auto *inlineBuffer = reinterpret_cast<ValueBuffer*>(buffer);
+  HeapObject *box = reinterpret_cast<HeapObject *>(inlineBuffer->PrivateData[0]);
+
+  if (!swift_isUniquelyReferenced_nonNull_native(box)) {
+    auto refAndObjectAddr = swift_allocBox(type);
+    // Compute the address of the old object.
+    auto headerOffset = sizeof(HeapObject) + alignMask & ~alignMask;
+    auto *oldObjectAddr = reinterpret_cast<OpaqueValue *>(
+        reinterpret_cast<char *>(box) + headerOffset);
+    // Copy the data.
+    type->vw_initializeWithCopy(refAndObjectAddr.second, oldObjectAddr);
+    inlineBuffer->PrivateData[0] = refAndObjectAddr.first;
+    // Release ownership of the old box.
+    swift_release(box);
+    return refAndObjectAddr;
+  } else {
+    auto headerOffset = sizeof(HeapObject) + alignMask & ~alignMask;
+    auto *objectAddr = reinterpret_cast<OpaqueValue *>(
+        reinterpret_cast<char *>(box) + headerOffset);
+    return {box, objectAddr};
+  }
+}
+
 SWIFT_RT_ENTRY_IMPL_VISIBILITY
 extern "C"
 BoxPair::Return SWIFT_RT_ENTRY_IMPL(swift_allocBox)(const Metadata *type) {

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -550,8 +550,18 @@ static OpaqueValue *tuple_projectBuffer(ValueBuffer *buffer,
 
   if (IsInline)
     return reinterpret_cast<OpaqueValue*>(buffer);
-  else
-    return *reinterpret_cast<OpaqueValue**>(buffer);
+
+#ifdef SWIFT_RUNTIME_ENABLE_COW_EXISTENTIALS
+  auto wtable = tuple_getValueWitnesses(metatype);
+  unsigned alignMask = wtable->getAlignmentMask();
+  // Compute the byte offset of the object in the box.
+  unsigned byteOffset = (sizeof(HeapObject) + alignMask) & ~alignMask;
+  auto *bytePtr =
+      reinterpret_cast<char *>(*reinterpret_cast<HeapObject **>(buffer));
+  return reinterpret_cast<OpaqueValue *>(bytePtr + byteOffset);
+#else
+  return *reinterpret_cast<OpaqueValue**>(buffer);
+#endif
 }
 
 /// Generic tuple value witness for 'allocateBuffer'
@@ -563,13 +573,18 @@ static OpaqueValue *tuple_allocateBuffer(ValueBuffer *buffer,
 
   if (IsInline)
     return reinterpret_cast<OpaqueValue*>(buffer);
-
+#ifdef SWIFT_RUNTIME_ENABLE_COW_EXISTENTIALS
+  BoxPair refAndValueAddr(swift_allocBox(metatype));
+  *reinterpret_cast<HeapObject **>(buffer) = refAndValueAddr.first;
+  return refAndValueAddr.second;
+#else
   auto wtable = tuple_getValueWitnesses(metatype);
   auto value = (OpaqueValue*) swift_slowAlloc(wtable->size,
                                               wtable->getAlignmentMask());
 
   *reinterpret_cast<OpaqueValue**>(buffer) = value;
   return value;
+#endif
 }
 
 /// Generic tuple value witness for 'deallocateBuffer'.
@@ -845,11 +860,23 @@ static OpaqueValue *tuple_initializeBufferWithCopyOfBuffer(ValueBuffer *dest,
                                                      const Metadata *metatype) {
   assert(IsPOD == tuple_getValueWitnesses(metatype)->isPOD());
   assert(IsInline == tuple_getValueWitnesses(metatype)->isValueInline());
+#ifdef SWIFT_RUNTIME_ENABLE_COW_EXISTENTIALS
+  if (IsInline) {
+    return tuple_initializeWithCopy<IsPOD, IsInline>(
+        tuple_projectBuffer<IsPOD, IsInline>(dest, metatype),
+        tuple_projectBuffer<IsPOD, IsInline>(src, metatype), metatype);
+  }
 
+  auto *srcReference = *reinterpret_cast<HeapObject**>(src);
+  *reinterpret_cast<HeapObject**>(dest) = srcReference;
+  swift_retain(srcReference);
+  return tuple_projectBuffer<IsPOD, IsInline>(dest, metatype);
+#else
   return tuple_initializeBufferWithCopy<IsPOD, IsInline>(
                             dest,
                             tuple_projectBuffer<IsPOD, IsInline>(src, metatype),
                             metatype);
+#endif
 }
 
 /// Generic tuple value witness for 'initializeBufferWithTakeOfBuffer'.
@@ -859,7 +886,16 @@ static OpaqueValue *tuple_initializeBufferWithTakeOfBuffer(ValueBuffer *dest,
                                                      const Metadata *metatype) {
   assert(IsPOD == tuple_getValueWitnesses(metatype)->isPOD());
   assert(IsInline == tuple_getValueWitnesses(metatype)->isValueInline());
-
+#ifdef SWIFT_RUNTIME_ENABLE_COW_EXISTENTIALS
+  if (IsInline) {
+    return tuple_initializeWithTake<IsPOD, IsInline>(
+        tuple_projectBuffer<IsPOD, IsInline>(dest, metatype),
+        tuple_projectBuffer<IsPOD, IsInline>(src, metatype), metatype);
+  }
+  auto *srcReference = *reinterpret_cast<HeapObject**>(src);
+  *reinterpret_cast<HeapObject**>(dest) = srcReference;
+  return tuple_projectBuffer<IsPOD, IsInline>(dest, metatype);
+#else
   if (IsInline) {
     return tuple_initializeWithTake<IsPOD, IsInline>(
                       tuple_projectBuffer<IsPOD, IsInline>(dest, metatype),
@@ -869,6 +905,7 @@ static OpaqueValue *tuple_initializeBufferWithTakeOfBuffer(ValueBuffer *dest,
     dest->PrivateData[0] = src->PrivateData[0];
     return (OpaqueValue*) dest->PrivateData[0];
   }
+#endif
 }
 
 static void tuple_storeExtraInhabitant(OpaqueValue *tuple,
@@ -1147,6 +1184,19 @@ static void pod_indirect_deallocateBuffer(ValueBuffer *buffer,
 
 static OpaqueValue *pod_indirect_initializeBufferWithCopyOfBuffer(
                     ValueBuffer *dest, ValueBuffer *src, const Metadata *self) {
+#ifdef SWIFT_RUNTIME_ENABLE_COW_EXISTENTIALS
+  auto wtable = self->getValueWitnesses();
+  auto *srcReference = *reinterpret_cast<HeapObject**>(src);
+  *reinterpret_cast<HeapObject**>(dest) = srcReference;
+  swift_retain(srcReference);
+
+  // Project the address of the value in the buffer.
+  unsigned alignMask = wtable->getAlignmentMask();
+  // Compute the byte offset of the object in the box.
+  unsigned byteOffset = (sizeof(HeapObject) + alignMask) & ~alignMask;
+  auto *bytePtr = reinterpret_cast<char *>(srcReference);
+  return reinterpret_cast<OpaqueValue *>(bytePtr + byteOffset);
+#else
   auto wtable = self->getValueWitnesses();
   auto destBuf = (OpaqueValue*)swift_slowAlloc(wtable->size,
                                                wtable->getAlignmentMask());
@@ -1154,17 +1204,40 @@ static OpaqueValue *pod_indirect_initializeBufferWithCopyOfBuffer(
   OpaqueValue *srcBuf = *reinterpret_cast<OpaqueValue**>(src);
   memcpy(destBuf, srcBuf, wtable->size);
   return destBuf;
+#endif
 }
 
 static OpaqueValue *pod_indirect_initializeBufferWithTakeOfBuffer(
                     ValueBuffer *dest, ValueBuffer *src, const Metadata *self) {
+#ifdef SWIFT_RUNTIME_ENABLE_COW_EXISTENTIALS
+  auto wtable = self->getValueWitnesses();
+  auto *srcReference = *reinterpret_cast<HeapObject**>(src);
+  *reinterpret_cast<HeapObject**>(dest) = srcReference;
+
+  // Project the address of the value in the buffer.
+  unsigned alignMask = wtable->getAlignmentMask();
+  // Compute the byte offset of the object in the box.
+  unsigned byteOffset = (sizeof(HeapObject) + alignMask) & ~alignMask;
+  auto *bytePtr = reinterpret_cast<char *>(srcReference);
+  return reinterpret_cast<OpaqueValue *>(bytePtr + byteOffset);
+#else
   memcpy(dest, src, sizeof(ValueBuffer));
   return *reinterpret_cast<OpaqueValue**>(dest);
+#endif
 }
 
 static OpaqueValue *pod_indirect_projectBuffer(ValueBuffer *buffer,
                                                const Metadata *self) {
+#ifdef SWIFT_RUNTIME_ENABLE_COW_EXISTENTIALS
+  unsigned alignMask = self->getValueWitnesses()->getAlignmentMask();
+  // Compute the byte offset of the object in the box.
+  unsigned byteOffset = (sizeof(HeapObject) + alignMask) & ~alignMask;
+  auto *bytePtr =
+      reinterpret_cast<char *>(*reinterpret_cast<HeapObject **>(buffer));
+  return reinterpret_cast<OpaqueValue *>(bytePtr + byteOffset);
+#else
   return *reinterpret_cast<OpaqueValue**>(buffer);
+#endif
 }
 
 static OpaqueValue *pod_indirect_allocateBuffer(ValueBuffer *buffer,

--- a/test/IRGen/existentials_opaque_boxed.sil
+++ b/test/IRGen/existentials_opaque_boxed.sil
@@ -218,7 +218,7 @@ bb0(%0 : $*Existential):
 // CHECK:   ret %swift.opaque* [[VALUEADDRINLINE]]
 
 // CHECK: boxed:
-// CHECK:  [[ALIGNMASK:%.*]] = and i64 [[FLAGS]], 65535
+// CHECK:  [[ALIGNMASK:%.*]] = and {{(i64|i32)}} [[FLAGS]], 65535
 // CHECK:  [[OPAQUE_ADDR:%.*]] = bitcast [{{(24|12)}} x i8]* %0 to %swift.opaque*
 // CHECK:  [[REFANDADDR:%.*]] = call { %swift.refcounted*, %swift.opaque* } @swift_makeBoxUnique(%swift.opaque* [[OPAQUE_ADDR]], %swift.type* %1, {{(i64|i32)}} [[ALIGNMASK]])
 // CHECK:  [[REF:%.*]] = extractvalue { %swift.refcounted*, %swift.opaque* } [[REFANDADDR]], 0

--- a/test/IRGen/existentials_opaque_boxed.sil
+++ b/test/IRGen/existentials_opaque_boxed.sil
@@ -50,18 +50,16 @@ entry(%0 : $*T):
 // CHECK:  [[EXISTENTIAL_BUFFER_OPAQUE:%.*]] = bitcast [{{(24|12)}} x i8]* [[EXISTENTIAL_BUFFER]] to %swift.opaque*
 // CHECK:  br i1 [[ISINLINE]], label %done, label %allocateBox
 //
-// CHECK:allocateBox:                                      ; preds = %entry
+// CHECK:done:
+// CHECK:  ret %swift.opaque* [[EXISTENTIAL_BUFFER_OPAQUE]]
+//
+// CHECK:allocateBox:
 // CHECK:  [[CALL:%.*]] = call { %swift.refcounted*, %swift.opaque* } @swift_allocBox(%swift.type* [[METATYPE]])
 // CHECK:  [[BOX:%.*]] = extractvalue { %swift.refcounted*, %swift.opaque* } [[CALL]], 0
 // CHECK:  [[ADDR:%.*]] = extractvalue { %swift.refcounted*, %swift.opaque* } [[CALL]], 1
 // CHECK:  [[ADDR_IN_BUFFER:%.*]] = bitcast [{{(24|12)}} x i8]* [[EXISTENTIAL_BUFFER]] to %swift.refcounted**
 // CHECK:  store %swift.refcounted* [[BOX]], %swift.refcounted** [[ADDR_IN_BUFFER]]
-// CHECK:  br label %done
-//
-// CHECK:done:                                             ; preds = %allocateBox, %entry
-// CHECK:  [[RES:%.*]] = phi %swift.opaque* [ [[EXISTENTIAL_BUFFER_OPAQUE]], %entry ], [ [[ADDR]], %allocateBox ]
-// CHECK:  ret %swift.opaque* [[RES]]
-
+// CHECK:  ret %swift.opaque* [[ADDR]]
 
 // CHECK-LABEL: define {{.*}} @test_init_existential_fixed
 // CHECK:  [[CONTAINER:%.*]] = alloca %T25existentials_opaque_boxed11ExistentialP
@@ -124,6 +122,9 @@ entry:
 // CHECK:   [[ISINLINE:%.*]] = icmp eq {{(i64|i32)}} [[MASKED]], 0
 // CHECK:   br i1 [[ISINLINE]], label %done, label %deallocateBox
 
+// CHECK: done:
+// CHECK: ret void
+
 // CHECK:  deallocateBox:
 // CHECK:   [[BUFFER:%.*]] = getelementptr inbounds %T25existentials_opaque_boxed11ExistentialP, %T25existentials_opaque_boxed11ExistentialP* %0, i32 0, i32 0
 // CHECK:   [[REFERENCE_ADDR:%.*]] = bitcast [{{(24|12)}} x i8]* [[BUFFER]] to %swift.refcounted**
@@ -141,10 +142,7 @@ entry:
 // CHECK:   [[HEAPSIZE:%.*]] = add {{(i64|i32)}} [[ALIGNEDSTART]], [[SIZE]]
 // CHECK:   [[ALIGNMASK_ATLEASTPOINTER:%.*]] = or {{(i64|i32)}} [[ALIGNMASK]], {{(7|3)}}
 // CHECK:   call void @swift_rt_swift_deallocObject(%swift.refcounted* %10, {{(i64|i32)}} [[HEAPSIZE]], {{(i64|i32)}} [[ALIGNMASK_ATLEASTPOINTER]])
-// CHECK:   br label %done
-//
-// CHECK: done:
-//  ret void
+// CHECK:   ret void
 
 // CHECK-LABEL: define {{.*}} @test_open_existential_addr_immutable(%T25existentials_opaque_boxed11ExistentialP*
 // CHECK:  [[META_ADDR:%.*]] = getelementptr inbounds %T25existentials_opaque_boxed11ExistentialP, %T25existentials_opaque_boxed11ExistentialP* %0, i32 0, i32 1
@@ -173,6 +171,9 @@ bb0(%0 : $*Existential):
 // CHECK:   [[VALUEADDRINLINE:%.*]] = bitcast [{{(24|12)}} x i8]* %0 to %swift.opaque*
 // CHECK:   br i1 [[ISINLINE]], label %done, label %boxed
 //
+// CHECK: done:
+// CHECK:   ret %swift.opaque* [[VALUEADDRINLINE]]
+//
 // CHECK: boxed:
 // CHECK:   [[REFADDR:%.*]] = bitcast [{{(24|12)}} x i8]* %0 to %swift.refcounted**
 // CHECK:   [[REF:%.*]] = load %swift.refcounted*, %swift.refcounted** [[REFADDR]]
@@ -183,11 +184,7 @@ bb0(%0 : $*Existential):
 // CHECK:   [[HEAPOBJ:%.*]] = bitcast %swift.refcounted* %9 to i8*
 // CHECK:   [[STARTOFVALUE:%.*]] = getelementptr inbounds i8, i8* [[HEAPOBJ]], {{(i64|i32)}} [[ALIGNEDSTART]]
 // CHECK:   [[VALUEADDRBOXED:%.*]] = bitcast i8* [[STARTOFVALUE]] to %swift.opaque*
-// CHECK:   br label %done
-//
-// CHECK: done:
-// CHECK:   %16 = phi %swift.opaque* [ [[VALUEADDRINLINE]], %entry ], [ [[VALUEADDRBOXED]], %boxed ]
-// CHECK:   ret %swift.opaque* %16
+// CHECK:   ret %swift.opaque* [[VALUEADDRBOXED]]
 
 
 // CHECK-LABEL: define{{( protected)?}} {{.*}} @test_open_existential_addr_mutable
@@ -217,42 +214,16 @@ bb0(%0 : $*Existential):
 // CHECK:   [[VALUEADDRINLINE:%.*]] = bitcast [{{(24|12)}} x i8]* %0 to %swift.opaque*
 // CHECK:   br i1 [[ISINLINE]], label %done, label %boxed
 //
-// CHECK: boxed:
-// CHECK:   [[REF_ADDR:%.*]] = bitcast [{{(24|12)}} x i8]* %0 to %swift.refcounted**
-// CHECK:   [[REF:%.*]] = load %swift.refcounted*, %swift.refcounted** [[REF_ADDR]]
-// CHECK:   [[ALIGNMASK:%.*]] = and {{(i64|i32)}} [[FLAGS]], 65535
-// CHECK:   [[HEADERSIZEPLUSALIGN:%.*]] = add {{(i64|i32)}} {{(16|12)}}, [[ALIGNMASK]]
-// CHECK:   [[NOTALIGNMASK:%.*]] = xor {{(i64|i32)}} [[ALIGNMASK]], -1
-// CHECK:   [[ALIGNEDSTART:%.*]] = and {{(i64|i32)}} [[HEADERSIZEPLUSALIGN]], [[NOTALIGNMASK]]
-// CHECK:   [[HEAPOBJ:%.*]] = bitcast %swift.refcounted* %9 to i8*
-// CHECK:   [[STARTOFVALUE:%.*]] = getelementptr inbounds i8, i8* [[HEAPOBJ]], {{(i64|i32)}} [[ALIGNEDSTART]]
-// CHECK:   [[ORIGBOXEDVALADDR:%.*]] = bitcast i8* [[STARTOFVALUE]] to %swift.opaque*
-// CHECK:   [[UNIQUE:%.*]] = call i1 @swift_rt_swift_isUniquelyReferenced_nonNull_native(%swift.refcounted* [[REF]])
-// CHECK:   br i1 [[UNIQUE]], label %unique, label %makeUnique
-//
-// CHECK: makeUnique:
-// CHECK:   [[BOXANDADDR:%.*]] = call { %swift.refcounted*, %swift.opaque* } @swift_allocBox(%swift.type* %1)
-// CHECK:   [[NEWREF:%.*]] = extractvalue { %swift.refcounted*, %swift.opaque* } [[BOXANDADDR]], 0
-// CHECK:   [[NEWBOX:%.*]] = extractvalue { %swift.refcounted*, %swift.opaque* } [[BOXANDADDR]], 1
-// CHECK:   [[REFADDR:%.*]] = bitcast [{{(24|12)}} x i8]* %0 to %swift.refcounted**
-// CHECK:   store %swift.refcounted* [[NEWREF]], %swift.refcounted** [[REFADDR]]
-// CHECK:   [[CAST:%.*]] = bitcast %swift.type* %1 to i8***
-// CHECK:   [[VWT_ADDR:%.*]] = getelementptr inbounds i8**, i8*** [[CAST]], {{(i64|i32)}} -1
-// CHECK:   [[VWT:%.*]] = load i8**, i8*** %22
-// CHECK:   [[VW_ADDR:%.*]] = getelementptr inbounds i8*, i8** %.valueWitnesses1, i32 6
-// CHECK:   [[VW:%.*]] = load i8*, i8** [[VW_ADDR]]
-// CHECK:   %initializeWithCopy = bitcast i8* [[VW]] to %swift.opaque* (%swift.opaque*, %swift.opaque*, %swift.type*)*
-// CHECK:   call %swift.opaque* %initializeWithCopy(%swift.opaque* [[NEWBOX]], %swift.opaque* [[ORIGBOXEDVALADDR]], %swift.type* %1)
-// CHECK:   call void @swift_rt_swift_release(%swift.refcounted* [[REF]])
-// CHECK:   br label %unique
-//
-// CHECK: unique:
-// CHECK:   [[BOXEDVALUEADDR:%.*]] = phi %swift.opaque* [ [[ORIGBOXEDVALADDR]], %boxed ], [ [[NEWBOX]], %makeUnique ]
-// CHECK:   br label %done
-//
 // CHECK: done:
-// CHECK:   [[VALUEADDR:%.*]] = phi %swift.opaque* [ [[VALUEADDRINLINE]], %entry ], [ [[BOXEDVALUEADDR]], %unique ]
-// CHECK:   ret %swift.opaque* [[VALUEADDR]]
+// CHECK:   ret %swift.opaque* [[VALUEADDRINLINE]]
+
+// CHECK: boxed:
+// CHECK:  [[ALIGNMASK:%.*]] = and i64 [[FLAGS]], 65535
+// CHECK:  [[OPAQUE_ADDR:%.*]] = bitcast [{{(24|12)}} x i8]* %0 to %swift.opaque*
+// CHECK:  [[REFANDADDR:%.*]] = call { %swift.refcounted*, %swift.opaque* } @swift_makeBoxUnique(%swift.opaque* [[OPAQUE_ADDR]], %swift.type* %1, {{(i64|i32)}} [[ALIGNMASK]])
+// CHECK:  [[REF:%.*]] = extractvalue { %swift.refcounted*, %swift.opaque* } [[REFANDADDR]], 0
+// CHECK:  [[ADDR:%.*]] = extractvalue { %swift.refcounted*, %swift.opaque* } [[REFANDADDR]], 1
+// CHECK:  ret %swift.opaque* [[ADDR]]
 
 
 // CHECK-LABEL: define{{( protected)?}} swiftcc void @test_destroy_existential_addr(%T25existentials_opaque_boxed11ExistentialP*
@@ -468,9 +439,16 @@ bb0(%0 : $*Existential):
 // CHECK:   [[ARG_PWT:%.*]] = load i8**, i8*** [[ARG_PWT_ADDR]]
 // CHECK:   [[LOCAL_PWT_ADDR:%.*]] = getelementptr inbounds %T25existentials_opaque_boxed11ExistentialP, %T25existentials_opaque_boxed11ExistentialP* [[ALLOCA]], i32 0, i32 2
 // CHECK:   store i8** [[ARG_PWT]], i8*** [[LOCAL_PWT_ADDR]]
-// CHECK:   call void @__swift_initWithTake_boxed_opaque_existential_1(%T25existentials_opaque_boxed11ExistentialP* [[ALLOCA]], %T25existentials_opaque_boxed11ExistentialP* %0)
+// CHECK:   [[BUFFER_ARG_ADDR:%.*]] = getelementptr inbounds %T25existentials_opaque_boxed11ExistentialP, %T25existentials_opaque_boxed11ExistentialP* %0, i32 0, i32 0
+// CHECK:   [[BUFFER_LOCAL_ADDR:%.*]] = getelementptr inbounds %T25existentials_opaque_boxed11ExistentialP, %T25existentials_opaque_boxed11ExistentialP* [[ALLOCA]], i32 0, i32 0
+// CHECK:   [[CAST_ADDR:%.*]] = bitcast %swift.type* [[ARG_TYPE]] to i8***
+// CHECK:   [[VWT_ADDR:%.*]] = getelementptr inbounds i8**, i8*** [[CAST_ADDR]], {{(i64|i32)}} -1
+// CHECK:   [[VWT:%.*]] = load i8**, i8*** [[VWT_ADDR]]
+// CHECK:   [[VW_ADDR:%.*]] = getelementptr inbounds i8*, i8** [[VWT]], i32 12
+// CHECK:   [[VW:%.*]] = load i8*, i8** [[VW_ADDR]]
+// CHECK:   [[INITWITHTAKEBUFFER:%.*]] = bitcast i8* [[VW]]
+// CHECK:     call %swift.opaque* [[INITWITHTAKEBUFFER]]({{.*}} [[BUFFER_LOCAL_ADDR]], {{.*}} [[BUFFER_ARG_ADDR]], %swift.type* [[ARG_TYPE]])
 // CHECK:   ret void
-// CHECK: }
 sil @test_assignWithTake_existential_addr : $@convention(thin) (@in Existential) -> () {
 bb0(%0 : $*Existential):
   %s = alloc_stack $Existential
@@ -479,40 +457,6 @@ bb0(%0 : $*Existential):
 	%t = tuple()
   return %t : $()
 }
-
-// CHECK-LABEL: define{{( protected)?}} linkonce_odr hidden void @__swift_initWithTake_boxed_opaque_existential_1(%T25existentials_opaque_boxed11ExistentialP*, %T25existentials_opaque_boxed11ExistentialP*
-// CHECK:  [[METADATA_ADDR:%.*]] = getelementptr inbounds %T25existentials_opaque_boxed11ExistentialP, %T25existentials_opaque_boxed11ExistentialP* %1, i32 0, i32 1
-// CHECK:  [[METADATA:%.*]] = load %swift.type*, %swift.type** [[METADATA_ADDR]]
-// CHECK:  [[SRCBUFFER_ADDR:%.*]] = getelementptr inbounds %T25existentials_opaque_boxed11ExistentialP, %T25existentials_opaque_boxed11ExistentialP* %1, i32 0, i32 0
-// CHECK:  [[DESTBUFFER_ADDR:%.*]] = getelementptr inbounds %T25existentials_opaque_boxed11ExistentialP, %T25existentials_opaque_boxed11ExistentialP* %0, i32 0, i32 0
-// CHECK:  [[CAST:%.*]] = bitcast %swift.type* [[METADATA]] to i8***
-// CHECK:  [[VWT_ADDR:%.*]] = getelementptr inbounds i8**, i8*** [[CAST]], {{(i64|i32)}} -1
-// CHECK:  [[VWT:%.*]] = load i8**, i8*** [[VWT_ADDR]]
-// CHECK:  [[VW_ADDR:%.*]] = getelementptr inbounds i8*, i8** [[VWT]], i32 18
-// CHECK:  [[VW:%.*]] = load i8*, i8** [[VW_ADDR]]
-// CHECK:  [[FLAGS:%.*]] = ptrtoint i8* [[VW]] to {{(i64|i32)}}
-// CHECK:  [[ISNOTINLINE:%.*]] = and {{(i64|i32)}} [[FLAGS]], 131072
-// CHECK:  [[ISINLINE:%.*]] = icmp eq {{(i64|i32)}} [[ISNOTINLINE]], 0
-// CHECK:   br i1 %flags.isInline, label %inline, label %outline
-//
-// CHECK: inline:                                           ; preds = %entry
-// CHECK:   [[DST_OPAQUE:%.*]] = bitcast [{{(24|12)}} x i8]* [[DESTBUFFER_ADDR]] to %swift.opaque*
-// CHECK:   [[SRC_OPAQUE:%.*]] = bitcast [{{(24|12)}} x i8]* [[SRCBUFFER_ADDR]] to %swift.opaque*
-// CHECK:   [[CAST:%.*]] = bitcast %swift.type* [[METADATA]] to i8***
-// CHECK:   [[VWT_ADDR:%.*]] = getelementptr inbounds i8**, i8*** [[CAST]], {{(i64|i32)}} -1
-// CHECK:   [[VWT:%.*]] = load i8**, i8*** [[VWT_ADDR]]
-// CHECK:   [[VW_ADDR:%.*]] = getelementptr inbounds i8*, i8** [[VWT]], i32 9
-// CHECK:   [[VW:%.*]] = load i8*, i8** [[VW_ADDR:%.*]]
-// CHECK:   [[INITWITHTAKE:%.*]] = bitcast i8* [[VW]] to %swift.opaque* (%swift.opaque*, %swift.opaque*, %swift.type*)*
-// CHECK:   call %swift.opaque* [[INITWITHTAKE]](%swift.opaque* [[DST_OPAQUE]], %swift.opaque* [[SRC_OPAQUE]], %swift.type* [[METADATA]])
-// CHECK:   ret void
-//
-// CHECK: outline:                                          ; preds = %entry
-// CHECK:   [[SRC_REFADDR:%.*]] = bitcast [{{(24|12)}} x i8]* [[SRCBUFFER_ADDR]] to %swift.refcounted**
-// CHECK:   [[SRC_REF:%.*]] = load %swift.refcounted*, %swift.refcounted** [[SRC_REFADDR]]
-// CHECK:   [[DST_REFADDR:%.*]] = bitcast [{{(24|12)}} x i8]* [[DESTBUFFER_ADDR]] to %swift.refcounted**
-// CHECK:   store %swift.refcounted* [[SRC_REF]], %swift.refcounted** [[DST_REFADDR]]
-// CHECK:   ret void
 
 // CHECK: define{{( protected)?}} swiftcc void @test_initWithTake_existential_addr(%T25existentials_opaque_boxed11ExistentialP*
 // CHECK:   [[LOCAL:%.*]] = alloca %T25existentials_opaque_boxed11ExistentialP
@@ -524,7 +468,15 @@ bb0(%0 : $*Existential):
 // CHECK:   [[PWT:%.*]] = load i8**, i8*** [[PWT_ADDR]]
 // CHECK:   [[LOCAL_PWT_ADDR:%.*]] = getelementptr inbounds %T25existentials_opaque_boxed11ExistentialP, %T25existentials_opaque_boxed11ExistentialP* [[LOCAL]], i32 0, i32 2
 // CHECK:   store i8** [[PWT]], i8*** [[LOCAL_PWT_ADDR]]
-// CHECK:   call void @__swift_initWithTake_boxed_opaque_existential_1(%T25existentials_opaque_boxed11ExistentialP* [[LOCAL]], %T25existentials_opaque_boxed11ExistentialP* %0)
+// CHECK:   [[BUFFER_ARG_ADDR:%.*]] = getelementptr inbounds %T25existentials_opaque_boxed11ExistentialP, %T25existentials_opaque_boxed11ExistentialP* %0, i32 0, i32 0
+// CHECK:   [[BUFFER_LOCAL_ADDR:%.*]] = getelementptr inbounds %T25existentials_opaque_boxed11ExistentialP, %T25existentials_opaque_boxed11ExistentialP* [[ALLOCA]], i32 0, i32 0
+// CHECK:   [[CAST_ADDR:%.*]] = bitcast %swift.type* [[ARG_TYPE]] to i8***
+// CHECK:   [[VWT_ADDR:%.*]] = getelementptr inbounds i8**, i8*** [[CAST_ADDR]], {{(i64|i32)}} -1
+// CHECK:   [[VWT:%.*]] = load i8**, i8*** [[VWT_ADDR]]
+// CHECK:   [[VW_ADDR:%.*]] = getelementptr inbounds i8*, i8** [[VWT]], i32 12
+// CHECK:   [[VW:%.*]] = load i8*, i8** [[VW_ADDR]]
+// CHECK:   [[INITWITHTAKEBUFFER:%.*]] = bitcast i8* [[VW]]
+// CHECK:     call %swift.opaque* [[INITWITHTAKEBUFFER]]({{.*}} [[BUFFER_LOCAL_ADDR]], {{.*}} [[BUFFER_ARG_ADDR]], %swift.type* [[ARG_TYPE]])
 // CHECK:   ret void
 sil @test_initWithTake_existential_addr : $@convention(thin) (@in Existential) -> () {
 bb0(%0 : $*Existential):
@@ -545,7 +497,15 @@ bb0(%0 : $*Existential):
 // CHECK:   [[PWT:%.*]] = load i8**, i8*** [[PWT_ADDR]]
 // CHECK:   [[LOCAL_PWT_ADDR:%.*]] = getelementptr inbounds %T25existentials_opaque_boxed11ExistentialP, %T25existentials_opaque_boxed11ExistentialP* [[LOCAL]], i32 0, i32 2
 // CHECK:   store i8** [[PWT]], i8*** [[LOCAL_PWT_ADDR]]
-// CHECK:   call void @__swift_initWithCopy_boxed_opaque_existential_1(%T25existentials_opaque_boxed11ExistentialP* [[LOCAL]], %T25existentials_opaque_boxed11ExistentialP* %0)
+// CHECK:   [[BUFFER_ARG_ADDR:%.*]] = getelementptr inbounds %T25existentials_opaque_boxed11ExistentialP, %T25existentials_opaque_boxed11ExistentialP* %0, i32 0, i32 0
+// CHECK:   [[BUFFER_LOCAL_ADDR:%.*]] = getelementptr inbounds %T25existentials_opaque_boxed11ExistentialP, %T25existentials_opaque_boxed11ExistentialP* [[ALLOCA]], i32 0, i32 0
+// CHECK:   [[CAST_ADDR:%.*]] = bitcast %swift.type* [[ARG_TYPE]] to i8***
+// CHECK:   [[VWT_ADDR:%.*]] = getelementptr inbounds i8**, i8*** [[CAST_ADDR]], {{(i64|i32)}} -1
+// CHECK:   [[VWT:%.*]] = load i8**, i8*** [[VWT_ADDR]]
+// CHECK:   [[VW_ADDR:%.*]] = getelementptr inbounds i8*, i8** [[VWT]], i32 1
+// CHECK:   [[VW:%.*]] = load i8*, i8** [[VW_ADDR]]
+// CHECK:   [[INITWITHCOPYBUFFER:%.*]] = bitcast i8* [[VW]]
+// CHECK:     call %swift.opaque* [[INITWITHCOPYBUFFER]]({{.*}} [[BUFFER_LOCAL_ADDR]], {{.*}} [[BUFFER_ARG_ADDR]], %swift.type* [[ARG_TYPE]])
 // CHECK:   ret void
 sil @test_initWithCopy_existential_addr : $@convention(thin) (@in Existential) -> () {
 bb0(%0 : $*Existential):
@@ -555,40 +515,6 @@ bb0(%0 : $*Existential):
 	%t = tuple()
   return %t : $()
 }
-
-// CHECK-LABEL: define{{( protected)?}} linkonce_odr hidden void @__swift_initWithCopy_boxed_opaque_existential_1(%T25existentials_opaque_boxed11ExistentialP*, %T25existentials_opaque_boxed11ExistentialP*)
-// CHECK:  [[METADATA_ADDR:%.*]] = getelementptr inbounds %T25existentials_opaque_boxed11ExistentialP, %T25existentials_opaque_boxed11ExistentialP* %1, i32 0, i32 1
-// CHECK:  [[METADATA:%.*]] = load %swift.type*, %swift.type** [[METADATA_ADDR]]
-// CHECK:  [[SRCBUFFER_ADDR:%.*]] = getelementptr inbounds %T25existentials_opaque_boxed11ExistentialP, %T25existentials_opaque_boxed11ExistentialP* %1, i32 0, i32 0
-// CHECK:  [[DESTBUFFER_ADDR:%.*]] = getelementptr inbounds %T25existentials_opaque_boxed11ExistentialP, %T25existentials_opaque_boxed11ExistentialP* %0, i32 0, i32 0
-// CHECK:  [[CAST:%.*]] = bitcast %swift.type* [[METADATA]] to i8***
-// CHECK:  [[VWT_ADDR:%.*]] = getelementptr inbounds i8**, i8*** [[CAST]], {{(i64|i32)}} -1
-// CHECK:  [[VWT:%.*]] = load i8**, i8*** [[VWT_ADDR]]
-// CHECK:  [[VW_ADDR:%.*]] = getelementptr inbounds i8*, i8** [[VWT]], i32 18
-// CHECK:  [[VW:%.*]] = load i8*, i8** [[VW_ADDR]]
-// CHECK:  [[FLAGS:%.*]] = ptrtoint i8* [[VW]] to {{(i64|i32)}}
-// CHECK:  [[ISNOTINLINE:%.*]] = and {{(i64|i32)}} [[FLAGS]], 131072
-// CHECK:  [[ISINLINE:%.*]] = icmp eq {{(i64|i32)}} [[ISNOTINLINE]], 0
-// CHECK:   br i1 %flags.isInline, label %inline, label %outline
-//
-// CHECK: inline:
-// CHECK:   [[DST_OPAQUE:%.*]] = bitcast [{{(24|12)}} x i8]* [[DESTBUFFER_ADDR]] to %swift.opaque*
-// CHECK:   [[SRC_OPAQUE:%.*]] = bitcast [{{(24|12)}} x i8]* [[SRCBUFFER_ADDR]] to %swift.opaque*
-// CHECK:   [[CAST:%.*]] = bitcast %swift.type* [[METADATA]] to i8***
-// CHECK:   [[VWT_ADDR:%.*]] = getelementptr inbounds i8**, i8*** [[CAST]], {{(i64|i32)}} -1
-// CHECK:   [[VWT:%.*]] = load i8**, i8*** [[VWT_ADDR]]
-// CHECK:   [[VW_ADDR:%.*]] = getelementptr inbounds i8*, i8** [[VWT]], i32 6
-// CHECK:   [[VW:%.*]] = load i8*, i8** [[VW_ADDR:%.*]]
-// CHECK:   [[INITWITHTAKE:%.*]] = bitcast i8* [[VW]] to %swift.opaque* (%swift.opaque*, %swift.opaque*, %swift.type*)*
-// CHECK:   call %swift.opaque* [[INITWITHTAKE]](%swift.opaque* [[DST_OPAQUE]], %swift.opaque* [[SRC_OPAQUE]], %swift.type* [[METADATA]])
-//
-// CHECK: outline:
-// CHECK:   [[DST_REFADDR:%.*]] = bitcast [{{(24|12)}} x i8]* [[DESTBUFFER_ADDR]] to %swift.refcounted**
-// CHECK:   [[SRC_REFADDR:%.*]] = bitcast [{{(24|12)}} x i8]* [[SRCBUFFER_ADDR]] to %swift.refcounted**
-// CHECK:   [[SRC_REF:%.*]] = load %swift.refcounted*, %swift.refcounted** [[SRC_REFADDR]]
-// CHECK:   call void @swift_rt_swift_retain(%swift.refcounted* [[SRC_REF]])
-// CHECK:   store %swift.refcounted* [[SRC_REF]], %swift.refcounted** [[DST_REFADDR]]
-// CHECK:   ret void
 
 @_alignment(32)
 struct FixedOveralign : Existential {

--- a/validation-test/stdlib/MicroStdlib/Inputs/RuntimeStubs.c
+++ b/validation-test/stdlib/MicroStdlib/Inputs/RuntimeStubs.c
@@ -8,4 +8,5 @@ void _swift_slowDealloc(void) {}
 void _swift_storeEnumTagSinglePayload(void) {}
 void swift_allocateGenericValueMetadata(void) {}
 void swift_initEnumValueWitnessTableSinglePayload(void) {}
-
+void _swift_retain(){}
+void swift_allocBox(){}


### PR DESCRIPTION
Performance improvements to the copy-on-write existential implementation.

- Implement and use value witness functions for initialzeBufferWith(Copy|Take)OfBuffer witnesses.
- IRGen: Use a common getCopyOutOfLineBoxPointerFunction (similar to getCopyOutOfLinePointerFunction).
- Change IRGen for mutating value projection on existentials: implement the full path of the outline box in the library.