### PR TITLE
stdlib: Add an abstraction interface for libdl functions

### DIFF
--- a/stdlib/public/SwiftShims/CMakeLists.txt
+++ b/stdlib/public/SwiftShims/CMakeLists.txt
@@ -4,6 +4,7 @@ set(sources
   FoundationShims.h
   GlobalObjects.h
   HeapObject.h
+  ImageInspectionShims.h
   LibcShims.h
   RefCount.h
   RuntimeShims.h

--- a/stdlib/public/SwiftShims/ImageInspectionShims.h
+++ b/stdlib/public/SwiftShims/ImageInspectionShims.h
@@ -1,0 +1,56 @@
+//===--- ImageInspectionShims.h ---------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Abstraction of libdl functions.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_STDLIB_SHIMS_IMAGEINSPECTIONSHIMS_H
+#define SWIFT_STDLIB_SHIMS_IMAGEINSPECTIONSHIMS_H
+
+#include "Visibility.h"
+#include <dlfcn.h>
+
+#ifdef __cplusplus
+namespace swift { extern "C" {
+#endif
+
+SWIFT_BEGIN_NULLABILITY_ANNOTATIONS
+
+// A direct interface to dlerror() is not supported, instead an error argument
+// is passed. If the error argument is passed non-NULL and an error string is
+// set by the callee (from dlerror()), then it should be passed to free() by
+// the caller after use.
+SWIFT_RUNTIME_STDLIB_INTERFACE
+void * _Nullable _swift_stdlib_dlopen(const char * _Nullable filename,
+                                      int flags,
+                                      char * _Nullable * _Nonnull error);
+
+SWIFT_RUNTIME_STDLIB_INTERFACE
+int _swift_stdlib_dlclose(void * _Nonnull handle,
+                          char * _Nullable * _Nonnull error);
+
+SWIFT_RUNTIME_STDLIB_INTERFACE
+void * _Nullable _swift_stdlib_dlsym(void * _Nullable handle,
+                                     const char * _Nonnull symbol,
+                                     char * _Nullable * _Nonnull error);
+
+SWIFT_RUNTIME_STDLIB_INTERFACE
+int _swift_stdlib_dladdr(void * _Nonnull addr, Dl_info * _Nonnull info);
+
+SWIFT_END_NULLABILITY_ANNOTATIONS
+
+#ifdef __cplusplus
+}} // extern "C", namespace swift
+#endif
+
+#endif // SWIFT_STDLIB_SHIMS_IMAGEINSPECTIONSHIMS_H

--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -74,6 +74,7 @@ set(LLVM_OPTIONAL_SOURCES
     MutexWin32.cpp
     CygwinPort.cpp
     ImageInspectionInit.cpp
+    ImageInspectionDL.cpp
     ImageInspectionELF.cpp
     ImageInspectionStatic.cpp
     StaticBinaryELF.cpp

--- a/stdlib/public/runtime/ImageInspectionDL.cpp
+++ b/stdlib/public/runtime/ImageInspectionDL.cpp
@@ -1,0 +1,74 @@
+//===--- ImageInspectionDL.cpp - Mach-O/ELF/Win32 shared libdl emulation --===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file contains code used by ImageInspectionMachO.cpp,
+// ImageInspectionELF.cpp and ImageInspectionWin32.cpp (CYGWIN). It is used
+// via #include.
+//
+//===----------------------------------------------------------------------===//
+
+#include "../SwiftShims/ImageInspectionShims.h"
+#include <cstring>
+
+int swift::lookupSymbol(const void *address, SymbolInfo *info) {
+  Dl_info dlinfo;
+  if (dladdr(address, &dlinfo) == 0) {
+    return 0;
+  }
+
+  info->fileName = dlinfo.dli_fname;
+  info->baseAddress = dlinfo.dli_fbase;
+  info->symbolName = dlinfo.dli_sname;
+  info->symbolAddress = dlinfo.dli_saddr;
+  return 1;
+}
+
+
+static
+void saveError(char **error) {
+  if (error) {
+    char *msg = dlerror();
+    if (msg) {
+      *error = strdup(msg);
+    } else {
+      *error = nullptr;
+    }
+  }
+}
+
+SWIFT_RUNTIME_STDLIB_INTERFACE
+void *swift::_swift_stdlib_dlopen(const char *filename, int flags,
+                                  char **error) {
+  void *ret = dlopen(filename, flags);
+  saveError(error);
+  return ret;
+}
+
+SWIFT_RUNTIME_STDLIB_INTERFACE
+int swift::_swift_stdlib_dlclose(void *handle, char **error) {
+  int ret = dlclose(handle);
+  saveError(error);
+  return ret;
+}
+
+SWIFT_RUNTIME_STDLIB_INTERFACE
+void *swift::_swift_stdlib_dlsym(void *handle, const char *symbol,
+                                   char **error) {
+  void *ret = dlsym(handle, symbol);
+  saveError(error);
+  return ret;
+}
+
+SWIFT_RUNTIME_STDLIB_INTERFACE
+int swift::_swift_stdlib_dladdr(void *addr, Dl_info *info) {
+  return dladdr(addr, info);
+}

--- a/stdlib/public/runtime/ImageInspectionELF.cpp
+++ b/stdlib/public/runtime/ImageInspectionELF.cpp
@@ -155,17 +155,6 @@ void swift_addNewDSOImage(const void *addr) {
   }
 }
 
-int swift::lookupSymbol(const void *address, SymbolInfo *info) {
-  Dl_info dlinfo;
-  if (dladdr(address, &dlinfo) == 0) {
-    return 0;
-  }
-
-  info->fileName = dlinfo.dli_fname;
-  info->baseAddress = dlinfo.dli_fbase;
-  info->symbolName = dlinfo.dli_sname;
-  info->symbolAddress = dlinfo.dli_saddr;
-  return 1;
-}
+#include "ImageInspectionDL.cpp"
 
 #endif // defined(__ELF__) || defined(__ANDROID__)

--- a/stdlib/public/runtime/ImageInspectionMachO.cpp
+++ b/stdlib/public/runtime/ImageInspectionMachO.cpp
@@ -68,20 +68,9 @@ void swift::initializeTypeMetadataRecordLookup() {
   _dyld_register_func_for_add_image(
     addImageCallback<TypeMetadataRecordSection,
                      addImageTypeMetadataRecordBlockCallback>);
-  
+
 }
 
-int swift::lookupSymbol(const void *address, SymbolInfo *info) {
-  Dl_info dlinfo;
-  if (dladdr(address, &dlinfo) == 0) {
-    return 0;
-  }
-
-  info->fileName = dlinfo.dli_fname;
-  info->baseAddress = dlinfo.dli_fbase;
-  info->symbolName = dlinfo.dli_sname;
-  info->symbolAddress = dlinfo.dli_saddr;
-  return 1;
-}
+#include "ImageInspectionDL.cpp"
 
 #endif // defined(__APPLE__) && defined(__MACH__)

--- a/stdlib/public/runtime/ImageInspectionWin32.cpp
+++ b/stdlib/public/runtime/ImageInspectionWin32.cpp
@@ -218,21 +218,46 @@ void swift::initializeTypeMetadataRecordLookup() {
 }
 
 
-int swift::lookupSymbol(const void *address, SymbolInfo *info) {
 #if defined(__CYGWIN__)
-  Dl_info dlinfo;
-  if (dladdr(address, &dlinfo) == 0) {
-    return 0;
-  }
-
-  info->fileName = dlinfo.dli_fname;
-  info->baseAddress = dlinfo.dli_fbase;
-  info->symbolName = dli_info.dli_sname;
-  info->symbolAddress = dli_saddr;
-  return 1;
+#include "ImageInspectionDL.cpp"
 #else
+
+// FIXME: These need a non-CYGWIN implmentation.
+int swift::lookupSymbol(const void *address, SymbolInfo *info) {
   return 0;
-#endif // __CYGWIN__
 }
+
+SWIFT_RUNTIME_STDLIB_INTERFACE
+void *swift::_swift_stdlib_dlopen(const char *filename, int flags,
+                                  char **error) {
+  if (error) {
+    *error = strdup("_swift_stdlib_dlopen: Unimplemented");
+  }
+  return nullptr;
+}
+
+SWIFT_RUNTIME_STDLIB_INTERFACE
+int swift::_swift_stdlib_dlclose(void *handle, char **error) {
+  if (error) {
+    *error = strdup("_swift_stdlib_dlclose: Unimplemented");
+  }
+  return -1;
+}
+
+SWIFT_RUNTIME_STDLIB_INTERFACE
+  void *swift::_swift_stdlib_dlsym(void *handle, const char *symbol,
+                                   char **error) {
+  if (error) {
+    *error = strdup("_swift_stdlib_dlsym: Unimplemented");
+  }
+  return nullptr;
+}
+
+SWIFT_RUNTIME_STDLIB_INTERFACE
+int swift::_swift_stdlib_dladdr(void *addr, Dl_info *info) {
+  return 0;
+}
+
+#endif // defined(__CYGWIN__)
 
 #endif // defined(_WIN32) || defined(__CYGWIN__)


### PR DESCRIPTION
- Add _swift_stdlib_dl{open,close,sym,addr} functions that
  are also exported when the runtime is built on Linux for
  use in statically linked binaries.

- dlerror() is not exported under this change as it normally
  returns a pointer to a per-thread static buffer, so instead an
  error pointer can be passed to the open/close/sym functions to
  get back an optional error mesage that has to be free()'d by
  the caller.

- The main purpose of this change is to allow CoreFoundation on
  Linux to be linked into static binaries.


This change, along with some changes to swift-corelibs-foundation, allow a static version of TestFoundation to be built. I wanted to get an idea of whether this is the correct approach - if so there will also be a companion PR for foundation which makes use of it. 

I only reused the dl function names so it was obvious what the functionality was, if there is a more appropriate naming scheme then it is no problem to change it. The functions are not intended to be called directly from swift, although they could be, they are purely a fix for building static binaries which require Foundation.

Also, to build a fully static TestFoundation I also had to recompile some of the C libraries it uses (libcurl  etc) but that is no different to the issue with libicu and swift whereby the distro supplied libraries are compiled to use plugins and just need to be rebuilt with different `./configure` options.