### PR TITLE
[silgen] Copy the body of emitEnumElementDispatch to emitEnumElementDispatchWithOwnership.

### DIFF
--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -467,7 +467,8 @@ public:
   SILFunction &getFunction() { return F; }
   SILModule &getModule() { return F.getModule(); }
   SILGenBuilder &getBuilder() { return B; }
-  
+  SILOptions &getOptions() { return getModule().getOptions(); }
+
   const TypeLowering &getTypeLowering(AbstractionPattern orig, Type subst) {
     return SGM.Types.getTypeLowering(orig, subst);
   }


### PR DESCRIPTION
[silgen] Copy the body of emitEnumElementDispatch to emitEnumElementDispatchWithOwnership.

The reason I am doing this is that I am going to in the next couple of commits
change enum element dispatch to use proper ownership.

In this commit, I just did the copy and eliminated any parts of the code that
were predicated on having an address.

rdar://31145255