### PR TITLE
[semantic-sil] Make emitEnumElementDispatchWithOwnership conform to ownership.

### DIFF
--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -467,7 +467,8 @@ public:
   SILFunction &getFunction() { return F; }
   SILModule &getModule() { return F.getModule(); }
   SILGenBuilder &getBuilder() { return B; }
-  
+  SILOptions &getOptions() { return getModule().getOptions(); }
+
   const TypeLowering &getTypeLowering(AbstractionPattern orig, Type subst) {
     return SGM.Types.getTypeLowering(orig, subst);
   }


### PR DESCRIPTION
[semantic-sil] Make emitEnumElementDispatchWithOwnership conform to ownership.

This means inserting an eager copy on the switch operand, eliminating the
unforwarding, and destroying the copy in the default case as well as the normal
cases.

I did not refactor this code to use the switch enum builder, but at some point
it should be refactored as such.

rdar://31145255
