### PR TITLE
Ownership Model Eliminator: switch enum default argument elimination

### DIFF
--- a/lib/SILGen/Initialization.h
+++ b/lib/SILGen/Initialization.h
@@ -24,10 +24,12 @@
 
 namespace swift {
 namespace Lowering {
-  class SILGenFunction;
 
+class SILGenFunction;
 class Initialization;
 using InitializationPtr = std::unique_ptr<Initialization>;
+class TemporaryInitialization;
+using TemporaryInitializationPtr = std::unique_ptr<TemporaryInitialization>;
   
 /// An abstract class for consuming a value.  This is used for initializing
 /// variables, although that is not the only way it is used.

--- a/lib/SILGen/ManagedValue.h
+++ b/lib/SILGen/ManagedValue.h
@@ -372,6 +372,12 @@ public:
   ConsumableManagedValue asBorrowedOperand() const {
     return { asUnmanagedValue(), CastConsumptionKind::CopyOnSuccess };
   }
+
+  /// Return a managed value that's appropriate for copying this value and
+  /// always consuming it.
+  ConsumableManagedValue copy(SILGenFunction &SGF, SILLocation loc) const {
+    return ConsumableManagedValue::forOwned(asUnmanagedValue().copy(SGF, loc));
+  }
 };
 
 } // namespace Lowering

--- a/test/SILOptimizer/ownership_model_eliminator.sil
+++ b/test/SILOptimizer/ownership_model_eliminator.sil
@@ -7,6 +7,11 @@ import Builtin
 sil @use_native_object : $@convention(thin) (@owned Builtin.NativeObject) -> ()
 sil @use_int32 : $@convention(thin) (Builtin.Int32) -> ()
 
+enum Either<T, R> {
+case left(T)
+case some(R)
+}
+
 class C {}
 
 // CHECK-LABEL: sil @load : $@convention(thin) (@in Builtin.NativeObject, @in Builtin.Int32) -> () {
@@ -193,3 +198,34 @@ bb0(%0 : @guaranteed $Builtin.NativeObject):
   return %1 : $Builtin.NativeObject
 }
 
+// CHECK-LABEL: sil @switch_enum_default_case : $@convention(thin) (@owned Either<Builtin.NativeObject, Builtin.UnknownObject>) -> () {
+// CHECK: bb0([[ARG:%.*]] : @owned $Either<Builtin.NativeObject, Builtin.UnknownObject>):
+// CHECK:   switch_enum [[ARG]] : $Either<Builtin.NativeObject, Builtin.UnknownObject>, case #Either.left!enumelt.1: [[SUCC_BB:bb[0-9]+]], default [[DEFAULT_BB:bb[0-9]+]]
+//
+// CHECK: [[SUCC_BB]]([[LHS:%.*]] : @owned $Builtin.NativeObject
+// CHECK:   strong_release [[LHS]]
+// CHECK:   br [[EPILOG_BB:bb[0-9]+]]
+//
+// CHECK: [[DEFAULT_BB]]:
+// CHECK:   release_value [[ARG]]
+// CHECK:   br [[EPILOG_BB]]
+//
+// CHECK: [[EPILOG_BB]]:
+// CHECK:   return
+// CHECK: } // end sil function 'switch_enum_default_case'
+sil @switch_enum_default_case : $@convention(thin) (@owned Either<Builtin.NativeObject, Builtin.UnknownObject>) -> () {
+bb0(%0 : @owned $Either<Builtin.NativeObject, Builtin.UnknownObject>):
+  switch_enum %0 : $Either<Builtin.NativeObject, Builtin.UnknownObject>, case #Either.left!enumelt.1: bb1, default bb2
+
+bb1(%1 : @owned $Builtin.NativeObject):
+  destroy_value %1 : $Builtin.NativeObject
+  br bb3
+
+bb2(%2 : @owned $Either<Builtin.NativeObject, Builtin.UnknownObject>):
+  destroy_value %2 : $Either<Builtin.NativeObject, Builtin.UnknownObject>
+  br bb3
+
+bb3:
+  %9999 = tuple()
+  return %9999 : $()
+}


### PR DESCRIPTION
[ownership-model] Teach the ownership model eliminator how to eliminate the default argument of a switch_enum and tighten up assertions in SILVerifier.

rdar://31145255