### PR TITLE
[Driver] Add command-line flags for enforcement of law of exclusivity

### DIFF
--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -134,6 +134,12 @@ public:
   /// Indicates which sanitizer is turned on.
   SanitizerKind Sanitize : 2;
 
+  /// Emit compile-time diagnostics when the law of exclusivity is violated.
+  bool EnforceExclusivityStatic = false;
+
+  /// Emit checks to trap at run time when the law of exclusivity is violated.
+  bool EnforceExclusivityDynamic = false;
+
   SILOptions() : Sanitize(SanitizerKind::None) {}
 
 };

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -570,4 +570,8 @@ def sanitize_coverage_EQ : CommaJoined<["-"], "sanitize-coverage=">,
   HelpText<"Specify the type of coverage instrumentation for Sanitizers and"
   " additional options separated by commas">;
 
+def enforce_exclusivity_EQ : Joined<["-"], "enforce-exclusivity=">,
+  Flags<[FrontendOption]>, MetaVarName<"<enforcement>">,
+  HelpText<"Enforce law of exclusivity">;
+
 include "FrontendOptions.td"

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -146,6 +146,7 @@ static void addCommonFrontendArgs(const ToolChain &TC,
   inputArgs.AddLastArg(arguments, options::OPT_sanitize_EQ);
   inputArgs.AddLastArg(arguments, options::OPT_sanitize_coverage_EQ);
   inputArgs.AddLastArg(arguments, options::OPT_swift_version);
+  inputArgs.AddLastArg(arguments, options::OPT_enforce_exclusivity_EQ);
 
   // Pass on any build config options
   inputArgs.AddAllArgs(arguments, options::OPT_D);

--- a/test/Driver/options.swift
+++ b/test/Driver/options.swift
@@ -113,3 +113,7 @@
 // RUN: %swiftc_driver -incremental -output-file-map %S/Inputs/empty-ofm.json %s -### 2>&1 | %FileCheck -check-prefix=INCREMENTAL_WITHOUT_OFM_ENTRY %s
 // INCREMENTAL_WITHOUT_OFM_ENTRY: ignoring -incremental; output file map has no master dependencies entry ("swift-dependencies" under "")
 // INCREMENTAL_WITHOUT_OFM_ENTRY: swift -frontend
+
+// RUN: %swiftc_driver -driver-print-jobs -enforce-exclusivity=checked %s | %FileCheck -check-prefix=EXCLUSIVITY_CHECKED %s
+// EXCLUSIVITY_CHECKED: swift
+// EXCLUSIVITY_CHECKED: -enforce-exclusivity=checked

--- a/test/Frontend/enforce-exclusivity.swift
+++ b/test/Frontend/enforce-exclusivity.swift
@@ -1,0 +1,11 @@
+// Test command-line flags for enforcement of the law of exclusivity.
+
+// RUN: %swift -enforce-exclusivity=checked %s -emit-silgen
+// RUN: %swift -enforce-exclusivity=unchecked %s -emit-silgen
+
+// Staging flags; eventually these will not be accepted.
+// RUN: %swift -enforce-exclusivity=dynamic-only %s -emit-silgen
+// RUN: %swift -enforce-exclusivity=none %s -emit-silgen
+
+// RUN: not %swift -enforce-exclusivity=other %s -emit-silgen 2>&1 | %FileCheck -check-prefix=EXCLUSIVITY_UNRECOGNIZED %s
+// EXCLUSIVITY_UNRECOGNIZED: unsupported argument 'other' to option '-enforce-exclusivity='


### PR DESCRIPTION
Add an -enforce-exclusivity=... flag to control enforcement of the law of
exclusivity. The flag takes one of four options:

"checked": Perform both static (compile-time) and dynamic (run-time) checks.
"unchecked": Perform only static enforcement. This is analogous to -Ounchecked.
"dynamic-only": Perform only dynamic checks. This is for staging purposes.
"none": Perform no checks at all. This is also for staging purposes.

The default, for now, is "none".

The intent is that in the fullness of time, "checked" and "unchecked" will
be the only legal options with "checked" the default. That is, static
enforcement will always be enabled and dynamic enforcement will be enabled
by default.
