### PR TITLE
Make sure to lint the interpreted, not compiled python file

### DIFF
--- a/utils/gyb.py
+++ b/utils/gyb.py
@@ -1102,7 +1102,7 @@ def main():
     """
     Lint this file.
     >>> import sys
-    >>> gyb_path = os.path.realpath(__file__)
+    >>> gyb_path = os.path.realpath(__file__).replace('.pyc', '.py')
     >>> sys.path.append(os.path.dirname(gyb_path))
     >>> import python_lint
     >>> python_lint.lint([gyb_path], verbose=False)


### PR DESCRIPTION
Fixs strange failures in #8360

This looks like a doctest bug:

> cd <swift_source_dir>/utils
> python -m doctest gyb.py

**Success**

> cd <swift_source_dir>
> python -m doctest ./utils/gyb.py

**Failure**

Let's hope the never ending saga of gyb/python linting ends here

@shahmishal @moiseev