### PR TITLE
Preserve SIL when merging modules

### DIFF
--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -663,13 +663,11 @@ ModuleDecl::lookupConformance(Type type, ProtocolDecl *protocol) {
   if (auto inherited = dyn_cast<InheritedProtocolConformance>(conformance)) {
     // Dig out the conforming nominal type.
     auto rootConformance = inherited->getRootNormalConformance();
-    auto conformingNominal
+    auto conformingClass
       = rootConformance->getType()->getClassOrBoundGenericClass();
 
     // Map up to our superclass's type.
-    Type superclassTy = type->getSuperclass();
-    while (superclassTy->getAnyNominal() != conformingNominal)
-      superclassTy = superclassTy->getSuperclass();
+    auto superclassTy = type->getSuperclassForDecl(conformingClass);
 
     // Compute the conformance for the inherited type.
     auto inheritedConformance = lookupConformance(superclassTy, protocol);

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -687,6 +687,14 @@ ToolChain::constructInvocation(const MergeModuleJobAction &job,
   // serialized ASTs.
   Arguments.push_back("-parse-as-library");
 
+  // Merge serialized SIL from partial modules.
+  Arguments.push_back("-sil-merge-partial-modules");
+
+  // Disable SIL optimization passes; we've already optimized the code in each
+  // partial mode.
+  Arguments.push_back("-disable-diagnostic-passes");
+  Arguments.push_back("-disable-sil-perf-optzns");
+
   addCommonFrontendArgs(*this, context.OI, context.Output, context.Args,
                         Arguments);
   context.Args.AddLastArg(Arguments, options::OPT_import_objc_header);

--- a/test/multifile/imported-conformance/option-set/library.swift
+++ b/test/multifile/imported-conformance/option-set/library.swift
@@ -1,0 +1,8 @@
+// RUN: true
+
+import Foundation
+
+@inline(__always)
+public func replace(rgx: NSRegularExpression, in: String, with: String, x: NSRange) -> String {
+  return rgx.stringByReplacingMatches(in: `in`, options: [], range: x, withTemplate: with)
+}

--- a/test/multifile/imported-conformance/option-set/main.swift
+++ b/test/multifile/imported-conformance/option-set/main.swift
@@ -1,0 +1,15 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %empty-directory(%t/linker)
+// RUN: %target-build-swift -emit-module -emit-library %S/library.swift -o %t/linker/liblibrary.%target-dylib-extension -emit-module-path %t/linker/library.swiftmodule -module-name library
+// RUN: %target-build-swift %S/main.swift -I %t/linker/ -L %t/linker/ -llibrary -o %t/linker/main
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+import Foundation
+import library
+
+public func rreplace(rgx: NSRegularExpression, in: String, with: String, x: NSRange) -> String {
+  return replace(rgx: rgx, in: `in`, with: with, x: x)
+}

--- a/validation-test/Evolution/test_function_change_transparent_body.swift
+++ b/validation-test/Evolution/test_function_change_transparent_body.swift
@@ -1,8 +1,5 @@
-// RUN: %target-resilience-test-wmo
+// RUN: %target-resilience-test
 // REQUIRES: executable_test
-
-// FIXME: shouldn't need -whole-module-optimization here; we need to fix the
-// frontend to merge serialized SIL functions from different translation units
 
 import StdlibUnittest
 import function_change_transparent_body


### PR DESCRIPTION
Fixes <rdar://problem/18913977>.

Now that https://github.com/apple/swift/pull/11909 and previous PRs are in, we can finally look up associated types in imported conformances after Sema has been torn down. Phew!

Next steps in this area:
- Emit default argument generators with shared linkage and serialized bit set in Swift 4 mode
- Finish investigating emitting inlineable functions with shared linkage