### PR TITLE
[stdlib] Alter RRC.+ to make a full copy rather than rely on CoW

### DIFF
--- a/stdlib/public/core/RangeReplaceableCollection.swift.gyb
+++ b/stdlib/public/core/RangeReplaceableCollection.swift.gyb
@@ -1142,11 +1142,11 @@ extension RangeReplaceableCollection
 public func + <C : RangeReplaceableCollection, S : Sequence>(lhs: C, rhs: S) -> C
   where S.Iterator.Element == C.Iterator.Element {
 
-  var lhs = lhs
-  // FIXME: what if lhs is a reference type?  This will mutate it.
-  lhs.reserveCapacity(lhs.count + numericCast(rhs.underestimatedCount))
-  lhs.append(contentsOf: rhs)
-  return lhs
+  var result = C()
+  result.reserveCapacity(lhs.count + numericCast(rhs.underestimatedCount))
+  result.append(contentsOf: lhs)
+  result.append(contentsOf: rhs)
+  return result
 }
 
 /// Creates a new collection by concatenating the elements of a sequence and a


### PR DESCRIPTION
Removes the reliance on the collection being a value type by constructing a fresh value from the ground up using `init()` and `append(contentsOf:)`. This is already done with the version of `+` with a sequence on the lhs.