### PR TITLE
String prototype: Switch to using the new FCCNormalizedUTF16View.

### DIFF
--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -130,6 +130,7 @@ set(SWIFTLIB_ESSENTIAL
   StringHashable.swift
   StringInterpolation.swift
   StringLegacy.swift
+  StringNormalization.swift
   StringRangeReplaceableCollection.swift.gyb
   StringIndexConversions.swift
   StringStorage.swift

--- a/stdlib/public/core/GroupInfo.json
+++ b/stdlib/public/core/GroupInfo.json
@@ -18,6 +18,7 @@
     "StringIndexConversions.swift",
     "StringInterpolation.swift",
     "StringLegacy.swift",
+    "StringNormalization.swift",
     "StringRangeReplaceableCollection.swift",
     "StringStorage.swift",
     "StringUTF16.swift",

--- a/stdlib/public/core/StringNormalization.swift
+++ b/stdlib/public/core/StringNormalization.swift
@@ -1,0 +1,354 @@
+//===--- StringNormalization.swift ----------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftShims
+
+//
+// A "normalization segment" is a sequence that starts with a unicode scalar
+// value which has a normalization boundary before it, and includes all
+// subsequent unicode scalar values who do not.
+//
+// A "native index" is an index into the original String's code units. It can be
+// interchanged with many of the other String indices. This is what is
+// represented by UnicodeView's "EncodedOffset" Int64.
+//
+
+extension UInt16 : _DefaultConstructible {}
+
+// TODO: Figure out a more sensible size
+typealias UTF16CodeUnitBuffer =
+  UnboundCapacity<_BoundedCapacity<_Array8<UInt16>>>
+
+// A normalization segment that is FCC-normalized. This is a collection of
+// normalized UTF16 code units.
+//
+// Note that this is not a UnicodeView. Indices into a normalized segment are
+// not native indices, and do not necessarily correspond to any particular code
+// unit as they may of undergone composition or decomposition, which in turn may
+// also re-order code units. Thus, FCCNormalizedSegments are not suitable for
+// queries needing sub-segment granularity. However, FCCNormalizedSegments are
+// suitable for segment-level-or-coarser granularity queries, which include any
+// grapheme-level queries as segments are sub- grapheme.
+//
+// TODO: Explore coalescing small segments together
+struct FCCNormalizedSegment : BidirectionalCollection {
+  let buffer: UTF16CodeUnitBuffer
+
+  init(_ buffer: UTF16CodeUnitBuffer) {
+    self.buffer = buffer
+  }
+  init() {
+    self.buffer = UTF16CodeUnitBuffer()
+  }
+
+  typealias Index = UTF16CodeUnitBuffer.Index
+
+  public var startIndex : Index {
+    return buffer.startIndex
+  }
+  public var endIndex : Index {
+    return buffer.endIndex
+  }
+  public subscript(i: Index) -> UInt16 {
+    return buffer[i]
+  }
+  public func index(after i: Index) -> Index {
+    return buffer.index(after: i)
+  }
+  public func index(before i: Index) -> Index {
+    return buffer.index(before: i)
+  }
+  public typealias SubSequence = BidirectionalSlice<FCCNormalizedSegment>
+}
+
+// Ask ICU if the given unicode scalar value has a normalization boundary before
+// it, that is it begins a new normalization segment.
+internal func _hasBoundary(before value: UInt32) -> Bool {
+  return __swift_stdlib_unorm2_hasBoundaryBefore(_fccNormalizer, value) != 0
+}
+
+struct FCCNormalizedLazySegments<
+  CodeUnits : RandomAccessCollection,
+  FromEncoding : UnicodeEncoding
+>
+where
+  CodeUnits.Index == CodeUnits.SubSequence.Index,
+  CodeUnits.SubSequence : RandomAccessCollection,
+  CodeUnits.SubSequence == CodeUnits.SubSequence.SubSequence,
+  CodeUnits.Iterator.Element == CodeUnits.SubSequence.Iterator.Element,
+  CodeUnits.Iterator.Element == FromEncoding.EncodedScalar.Iterator.Element
+{
+  let codeUnits: CodeUnits
+
+  public init(
+    _ codeUnits: CodeUnits,
+    _: FromEncoding.Type = FromEncoding.self
+  ) {
+    self.codeUnits = codeUnits
+  }
+
+  public init(_ unicodeView: _UnicodeViews<CodeUnits, FromEncoding>) {
+    self.init(unicodeView.codeUnits)
+  }
+
+  internal func priorSegment(
+    endingAt end: CodeUnits.Index
+  ) -> Index {
+    precondition(end != codeUnits.startIndex)
+
+    // Decode scalars backwards, including them until we after we find one that
+    // has a boundary before it (and include that one).
+    var start = end
+    while start != codeUnits.startIndex {
+      // Include this scalar
+      let (scalarValue: value, startIndex: scalarStart, e)
+        = decodeOne(priorTo: start)
+      _sanityCheck(e == start, "Internal inconsistency in decodeOne")
+
+      // Include this scalar
+      start = scalarStart
+
+      if _hasBoundary(before: value) {
+        // We're done
+        break
+      }
+    }
+
+    return Index(
+      nativeStartIndex: start,
+      nativeEndIndex: end,
+      segment: formSegment(from: start, until: end)
+    )
+  }
+
+  // Scan ahead and produce the next segment. `from` must be valid index (not
+  // end).
+  internal func nextSegment(
+    startingAt start: CodeUnits.Index
+  ) -> Index {
+    if start == codeUnits.endIndex {
+      return endIndex
+    }
+
+    // Parse the first scalar, it will always be in the segment
+    var (scalarValue: value, startIndex: s, endIndex: end)
+      = decodeOne(from: start)
+    _sanityCheck(start == codeUnits.startIndex || 
+                 _hasBoundary(before: value), "Not on segment boundary")
+    _sanityCheck(s == start, "Internal inconsistency in decodeOne")
+
+    // Include any subsequent scalars that don't have boundaries before them
+    while end != codeUnits.endIndex {
+      let (scalarValue: value, startIndex: s, endIndex: scalarEnd)
+        = decodeOne(from: end)
+      _sanityCheck(s == end, "Internal inconsistency in decodeOne")
+
+      if _hasBoundary(before: value) {
+        // Exclude this scalar
+        break
+      }
+
+      // Include this scalar
+      end = scalarEnd
+    }
+
+    return Index(
+      nativeStartIndex: start,
+      nativeEndIndex: end,
+      segment: formSegment(from: start, until: end)
+    )
+  }
+
+  // Normalize a segment. Indices must be on scalar boundaries.
+  internal func formSegment(
+    from start: CodeUnits.Index,
+    until end: CodeUnits.Index
+  ) -> FCCNormalizedSegment {
+    precondition(start != end, "TODO: should we just have empty segment?")
+
+    let utf16CodeUnits = unicodeView(
+      from: start, until: end
+    ).scalarsTranscoded(
+      to: UTF16.self
+    )
+
+    // TODO: Find way to re-use the storage, maybe iterator pattern?
+    var buffer = UTF16CodeUnitBuffer(utf16CodeUnits.lazy.joined())
+
+    // Single scalar is trivial segment, no need to normalize
+    //
+    // TODO: fast pre-normalized checks (worth doing before calling over to
+    //       ICU)
+    //
+    // TODO: non-BMP can hit this path too
+    if end == codeUnits.index(after: start) {
+      return FCCNormalizedSegment(buffer)
+    }
+
+    _sanityCheck(buffer.count > 0, "How did this happen? Failed precondition?")
+
+    // Ask ICU to normalize
+    //
+    // FIXME: withMutableArray kind of defeats the purpose of the small
+    // buffer :-(
+    buffer.withMutableArray { (array: inout [UInt16]) -> () in
+      array.withUnsafeBufferPointer {
+        // TODO: Just reserving one or two extra up front. If we're segment-
+        // based, should be finite number of possible decomps.
+        let originalCount = buffer.count
+        while true {
+          var error = __swift_stdlib_U_ZERO_ERROR
+          let usedCount = __swift_stdlib_unorm2_normalize(
+            _fccNormalizer, $0.baseAddress, numericCast($0.count),
+            &array, numericCast(array.count), &error)
+          if __swift_stdlib_U_SUCCESS(error) {
+            array.removeLast(array.count - numericCast(usedCount))
+            return
+          }
+          _sanityCheck(
+            error == __swift_stdlib_U_BUFFER_OVERFLOW_ERROR,
+            "Unknown normalization error")
+
+          // Maximum number of NFC to FCC decompositions for a single unicode
+          // scalar value
+          //
+          // TODO: what is this really? Should be much less
+          let maxDecompSize = 8
+
+          // Very loose canary to check that we haven't grown exceedingly large
+          // (indicative of logic error). Loose by assuming that every original
+          // character could be decomposed the maximum number of times. Without
+          // this, an error would loop until we run out of memory or the array
+          // is larger than 2^32 on 64bit platforms.
+          _sanityCheck(buffer.count < originalCount*maxDecompSize)
+
+          // extend array storage by 25%
+          array.append(
+            contentsOf: repeatElement(0, count: (array.count + 3) >> 2))
+        }
+      }
+    }
+
+    return FCCNormalizedSegment(buffer)
+  }
+
+  // Decode one or more code units, returning the unicode scalar value and the
+  // number of code units parsed. `startingFrom` should be on scalar boundary
+  internal func decodeOne(from start: CodeUnits.Index)
+    -> (scalarValue: UInt32,
+        startIndex: CodeUnits.Index,
+        endIndex: CodeUnits.Index) {
+    precondition(start != codeUnits.endIndex, "Given empty slice")
+
+    let encodedScalar = unicodeView(from: start).encodedScalars.first!
+    return (scalarValue: encodedScalar.utf32[0],
+            startIndex: start,
+            endIndex: codeUnits.index(start, offsetBy: numericCast(encodedScalar.count)))
+  }
+
+  // As decodeOne, but in reverse. `priorTo` is the index after the last code
+  // unit in the scalar, i.e. it is exclusive.
+  internal func decodeOne(priorTo end: CodeUnits.Index)
+    -> (scalarValue: UInt32,
+        startIndex: CodeUnits.Index,
+        endIndex: CodeUnits.Index) {
+    precondition(end != codeUnits.startIndex, "Given empty slice")
+
+    let encodedScalar = unicodeView(until: end).encodedScalars.last!
+    return (scalarValue: encodedScalar.utf32[0],
+            startIndex: codeUnits.index(end, offsetBy: -numericCast(encodedScalar.count)),
+            endIndex: end)
+  }
+
+  // Get the rest of the Unicode view
+  internal func unicodeView(
+    from start: CodeUnits.Index? = nil,
+    until end: CodeUnits.Index? = nil
+  ) -> _UnicodeViews<CodeUnits.SubSequence, FromEncoding> {
+    let end = end ?? codeUnits.endIndex
+    let start = start ?? codeUnits.startIndex
+    return _UnicodeViews(codeUnits[start..<end], FromEncoding.self)
+  }
+}
+
+extension FCCNormalizedLazySegments: BidirectionalCollection {
+  // TODO?: This is really more like an iterator...
+  struct Index: Comparable {
+    // The corresponding native begin/end indices for this segment
+    let nativeStartIndex: CodeUnits.Index
+    let nativeEndIndex: CodeUnits.Index
+    let segment: FCCNormalizedSegment
+
+    public static func <(lhs: Index, rhs: Index) -> Bool {
+      if lhs.nativeStartIndex < rhs.nativeStartIndex {
+        // Our ends should be ordered similarly, unless lhs is the last index
+        // before endIndex and rhs is the endIndex.
+        _sanityCheck(
+          lhs.nativeEndIndex < rhs.nativeEndIndex ||
+          rhs.nativeStartIndex == rhs.nativeEndIndex,
+          "overlapping segments?")
+
+        return true
+      }
+
+      return false
+    }
+
+    public static func ==(lhs: Index, rhs: Index) -> Bool {
+
+      if lhs.nativeStartIndex == rhs.nativeStartIndex {
+        _sanityCheck(
+          lhs.nativeEndIndex == rhs.nativeEndIndex,
+          "overlapping segments?")
+
+        return true
+      }
+
+      return false
+    }
+  }
+
+  var startIndex: Index {
+    return nextSegment(startingAt: codeUnits.startIndex)
+  }
+  var endIndex: Index {
+    return Index(
+      nativeStartIndex: codeUnits.endIndex,
+      nativeEndIndex: codeUnits.endIndex,
+      segment: FCCNormalizedSegment())
+  }
+
+  func index(after idx: Index) -> Index {
+    return nextSegment(startingAt: idx.nativeEndIndex)
+  }
+  func index(before idx: Index) -> Index {
+    return priorSegment(endingAt: idx.nativeStartIndex)
+  }
+  subscript(position: Index) -> FCCNormalizedSegment {
+    return position.segment
+  }
+
+  public typealias SubSequence = BidirectionalSlice<FCCNormalizedLazySegments>
+}
+
+typealias FCCNormalizedUTF16View_2<
+  CodeUnits: RandomAccessCollection,
+  Encoding: UnicodeEncoding
+> = FlattenBidirectionalCollection<
+  FCCNormalizedLazySegments<CodeUnits, Encoding>
+>
+where
+  CodeUnits.Index == CodeUnits.SubSequence.Index,
+  CodeUnits.SubSequence : RandomAccessCollection,
+  CodeUnits.SubSequence == CodeUnits.SubSequence.SubSequence,
+  CodeUnits.Iterator.Element == CodeUnits.SubSequence.Iterator.Element,
+  CodeUnits.Iterator.Element == Encoding.EncodedScalar.Iterator.Element

--- a/stdlib/public/core/UnicodeViews.swift
+++ b/stdlib/public/core/UnicodeViews.swift
@@ -730,9 +730,6 @@ internal func _makeFCCNormalizer() -> OpaquePointer {
 public var _fccNormalizer = _makeFCCNormalizer()
 
 extension _UnicodeViews {
-  
-  public typealias FCCNormalizedUTF16View = RandomAccessUnicodeView<[UInt16]>
-
   /// Invokes `body` on a contiguous buffer of our UTF16.
   ///
   /// - Note: `body` should be prepared to deal with invalid UTF16.
@@ -747,30 +744,5 @@ extension _UnicodeViews {
       if r != nil { return r! }
     }
     return Array(self.transcoded(to: UTF16.self)).withUnsafeBufferPointer(body)
-  }
-
-  public var fccNormalizedUTF16: FCCNormalizedUTF16View {
-    return _withContiguousUTF16 {
-      // Start by assuming we need no more storage than we started with for the
-      // result.
-      var result  = Array<UInt16>(repeating: 0, count: $0.count)
-      while true {
-        var error = __swift_stdlib_U_ZERO_ERROR
-        let usedCount = __swift_stdlib_unorm2_normalize(
-          _fccNormalizer, $0.baseAddress, numericCast($0.count),
-          &result, numericCast(result.count), &error)
-        if __swift_stdlib_U_SUCCESS(error) {
-          result.removeLast(result.count - numericCast(usedCount))
-          return RandomAccessUnicodeView(result)
-        }
-        _sanityCheck(
-          error == __swift_stdlib_U_BUFFER_OVERFLOW_ERROR,
-          "Unknown normalization error")
-
-        // extend result storage by 25%
-        result.append(
-          contentsOf: repeatElement(0, count: (result.count + 3) >> 2))
-      }
-    }
   }
 }

--- a/test/Prototypes/AU3.swift.gyb
+++ b/test/Prototypes/AU3.swift.gyb
@@ -810,6 +810,85 @@ suite.test("RandomAccess/UnicodeScalar") {
   }
 }
 
+suite.test("fcc-normalized-view") {
+  let a: UInt16 = 0x0061
+  let aTic: UInt16 = 0x00e0
+  let aBackTic: UInt16 = 0x00e1
+  typealias UTF16String = _UnicodeViews<[UInt16], UTF16>
+  // typealias NormalizedView = FCCNormalizedUTF16View_2<[UInt16], UTF16>
+
+  // Helper functions, eagerly forms arrays of the forwards and reverse
+  // FCC normalized UTF16 code units
+  func fccNormView(_ codeUnits: [UInt16])
+    -> (forward: [UInt16], reversed: [UInt16]) {
+    let view = UTF16String(codeUnits).fccNormalizedUTF16
+    return (forward: Array(view),
+            reversed: Array(view.reversed()))
+  }
+
+  // Test canonical equivalence for:
+  //   1) a + ̀ + ́ == à + ́
+  //   2) a + ́ + ̀ == á + ̀
+  // BUT, the two are distinct, #1 != #2
+  do {
+    let str1form1 = [a, 0x0300, 0x0301]
+    let str1form2 = [aTic, 0x0301]
+    let str2form1 = [a, 0x0301, 0x0300]
+    let str2form2 = [aBackTic, 0x0300]
+
+    let (norm1_1, norm1_1rev) = fccNormView(str1form1)
+    let (norm1_2, norm1_2rev) = fccNormView(str1form2)
+    let (norm2_1, norm2_1rev) = fccNormView(str2form1)
+    let (norm2_2, norm2_2rev) = fccNormView(str2form2)
+
+    expectEqualSequence(norm1_1, norm1_2)
+    expectEqualSequence(norm2_1, norm2_2)
+    for (cu1, cu2) in zip(norm1_1, norm2_1) {
+      expectNotEqual(cu1, cu2)
+    }
+    expectEqualSequence(norm1_1rev, norm1_2rev)
+    expectEqualSequence(norm2_1rev, norm2_2rev)
+    for (cu1, cu2) in zip(norm1_1rev, norm2_1rev) {
+      expectNotEqual(cu1, cu2)
+    }
+  }
+
+  // Test canonical equivalence, and non-combining-ness of FCC for:
+  //   1) a + ̖ + ̀ == à + ̖ == a + ̀ + ̖
+  //   All will normalize under FCC as a + ̖ + ̀
+  do {
+    let form1 = [a, 0x0316, 0x0300]
+    let form2 = [a, 0x0300, 0x0316]
+    let form3 = [aTic, 0x0316]
+
+    let (norm1, norm1rev) = fccNormView(form1)
+    let (norm2, norm2rev) = fccNormView(form2)
+    let (norm3, norm3rev) = fccNormView(form3)
+
+    expectEqualSequence(norm1, norm2)
+    expectEqualSequence(norm2, norm3)
+    expectEqualSequence(norm1rev, norm2rev)
+    expectEqualSequence(norm2rev, norm3rev)
+
+    // Form 1 is already in FCC
+    expectEqualSequence(norm3, form1)
+    expectEqualSequence(norm3rev, form1.reversed())
+  }
+
+  // Test non-start first scalars
+  do {
+    let form1 = [0x0300, a, 0x0300]
+    let form2 = [0x0300, aTic] // In FCC normal form
+    let (norm1, norm1rev) = fccNormView(form1)
+    let (norm2, norm2rev) = fccNormView(form2)
+
+    // Sanity check existing impl
+    expectEqualSequence(norm1, norm2)
+    expectEqualSequence(norm1rev, norm2rev)
+    expectEqualSequence(norm1, form2)
+  }
+}
+
 runAllTests()
 
 // ${'Local Variables'}:


### PR DESCRIPTION
<!-- What's in this pull request? -->

String prototype: Switch to using the new FCCNormalizedUTF16View.
    
Hook up the new lazy segmented normalized view, and use that inside of _UnicodeViews.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
