### PR TITLE
SILGen: Simplify curry thunks

### DIFF
--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -355,9 +355,9 @@ void SILGenFunction::bindParametersForForwarding(const ParameterList *params,
                                      SmallVectorImpl<SILValue> &parameters) {
   for (auto param : *params) {
     Type type = (param->hasType()
-                 ? param->getType()->eraseDynamicSelfType()
+                 ? param->getType()
                  : F.mapTypeIntoContext(param->getInterfaceType()));
-    makeArgument(type, param, parameters, *this);
+    makeArgument(type->eraseDynamicSelfType(), param, parameters, *this);
   }
 }
 


### PR DESCRIPTION
Now that methods are the only case where we have a function
with multiple parameter lists, we can remove the logic for
forwarding captures (methods cannot have captures), and
simplify what remains to only deal with the case of a single
'self' argument being curried.