### PR TITLE
[Driver] Fix passing -Fsystem to the linker.

### DIFF
--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -1143,7 +1143,11 @@ toolchains::Darwin::constructInvocation(const LinkJobAction &job,
 
   context.Args.AddAllArgValues(Arguments, options::OPT_Xlinker);
   context.Args.AddAllArgs(Arguments, options::OPT_linker_option_Group);
-  context.Args.AddAllArgs(Arguments, options::OPT_F, options::OPT_Fsystem);
+  for (const Arg *arg : context.Args.filtered(options::OPT_F,
+                                              options::OPT_Fsystem)) {
+    Arguments.push_back("-F");
+    Arguments.push_back(arg->getValue());
+  }
 
   if (context.Args.hasArg(options::OPT_enable_app_extension)) {
     // Keep this string fixed in case the option used by the
@@ -1465,7 +1469,14 @@ toolchains::GenericUnix::constructInvocation(const LinkJobAction &job,
 
   context.Args.AddAllArgs(Arguments, options::OPT_Xlinker);
   context.Args.AddAllArgs(Arguments, options::OPT_linker_option_Group);
-  context.Args.AddAllArgs(Arguments, options::OPT_F, options::OPT_Fsystem);
+  for (const Arg *arg : context.Args.filtered(options::OPT_F,
+                                              options::OPT_Fsystem)) {
+    if (arg->getOption().matches(options::OPT_Fsystem))
+      Arguments.push_back("-iframework");
+    else
+      Arguments.push_back(context.Args.MakeArgString(arg->getSpelling()));
+    Arguments.push_back(arg->getValue());
+  }
 
   if (!context.OI.SDKPath.empty()) {
     Arguments.push_back("--sysroot");

--- a/test/Driver/linker-arclite.swift
+++ b/test/Driver/linker-arclite.swift
@@ -1,0 +1,25 @@
+// REQUIRES: OS=macosx
+// Note: This is really about the /host/ environment, but since there are RUN
+// lines for multiple targets anyway it doesn't make a huge difference.
+
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 %S/../Inputs/empty.swift | %FileCheck %s
+
+// CHECK: bin/ld{{"? }}
+// CHECK-SAME: -force_load {{[^ ]+/lib/arc/libarclite_macosx.a}} -framework CoreFoundation
+// CHECK-SAME: -o {{[^ ]+}}
+
+
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-ios8.0 %S/../Inputs/empty.swift | %FileCheck -check-prefix IOS_ARCLITE %s
+
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.11 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO_ARCLITE %s
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-ios9.0 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO_ARCLITE %s
+// RUN: %swiftc_driver -driver-print-jobs -target arm64-apple-tvos9.0 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO_ARCLITE %s
+// RUN: %swiftc_driver -driver-print-jobs -target armv7k-apple-watchos2.0 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO_ARCLITE %s
+
+// IOS_ARCLITE: bin/ld{{"? }}
+// IOS_ARCLITE: -force_load {{[^ ]+/lib/arc/libarclite_iphonesimulator.a}}
+// IOS_ARCLITE: -o {{[^ ]+}}
+
+// NO_ARCLITE: bin/ld{{"? }}
+// NO_ARCLITE-NOT: arclite
+// NO_ARCLITE: -o {{[^ ]+}}

--- a/test/Driver/linker.swift
+++ b/test/Driver/linker.swift
@@ -40,14 +40,6 @@
 // RUN: %FileCheck %s < %t.simple-macosx10.10.txt
 // RUN: %FileCheck -check-prefix SIMPLE %s < %t.simple-macosx10.10.txt
 
-// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-ios8.0        %s > %t.simple-ios8.txt
-// RUN: %FileCheck -check-prefix IOS_ARCLITE %s < %t.simple-ios8.txt
-
-// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.11   %s | %FileCheck -check-prefix NO_ARCLITE %s
-// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-ios9.0        %s | %FileCheck -check-prefix NO_ARCLITE %s
-// RUN: %swiftc_driver -driver-print-jobs -target arm64-apple-tvos9.0        %s | %FileCheck -check-prefix NO_ARCLITE %s
-// RUN: %swiftc_driver -driver-print-jobs -target armv7k-apple-watchos2.0    %s | %FileCheck -check-prefix NO_ARCLITE %s
-
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: touch %t/a.o
 // RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 %s %t/a.o -o linker 2>&1 | %FileCheck -check-prefix COMPILE_AND_LINK %s
@@ -58,12 +50,6 @@
 
 // There are more RUN lines further down in the file.
 
-// REQUIRES: CODEGENERATOR=X86
-
-// FIXME: Need to set up a sysroot for osx so the DEBUG checks work on linux/freebsd
-// rdar://problem/19692770
-// XFAIL: freebsd, linux
-
 // CHECK: swift
 // CHECK: -o [[OBJECTFILE:.*]]
 
@@ -73,7 +59,6 @@
 // CHECK-DAG: -rpath [[STDLIB_PATH]]
 // CHECK-DAG: -lSystem
 // CHECK-DAG: -arch x86_64
-// CHECK-DAG: -force_load {{[^ ]+/lib/arc/libarclite_macosx.a}} -framework CoreFoundation
 // CHECK: -o {{[^ ]+}}
 
 
@@ -231,19 +216,9 @@
 // DEBUG-NEXT: bin/ld{{"? }}
 // DEBUG: -add_ast_path {{.*}}/{{[^/]+}}.swiftmodule
 // DEBUG: -o linker
-// DEBUG-NEXT: bin/dsymutil
+// DEBUG-NEXT: {{^|bin/}}dsymutil
 // DEBUG: linker
 // DEBUG: -o linker.dSYM
-
-
-
-// IOS_ARCLITE: bin/ld{{"? }}
-// IOS_ARCLITE: -force_load {{[^ ]+/lib/arc/libarclite_iphonesimulator.a}}
-// IOS_ARCLITE: -o {{[^ ]+}}
-
-// NO_ARCLITE: bin/ld{{"? }}
-// NO_ARCLITE-NOT: arclite
-// NO_ARCLITE: -o {{[^ ]+}}
 
 
 // COMPILE_AND_LINK: bin/swift
@@ -268,7 +243,7 @@
 // INFERRED_NAME: bin/swift
 // INFERRED_NAME: -module-name LINKER
 // INFERRED_NAME: bin/ld{{"? }}
-// INFERRED_NAME: -o libLINKER.dylib
+// INFERRED_NAME: -o libLINKER.{{dylib|so}}
 
 
 // Test ld detection. We use hard links to make sure
@@ -279,7 +254,7 @@
 // RUN: touch %t/DISTINCTIVE-PATH/usr/bin/ld
 // RUN: chmod +x %t/DISTINCTIVE-PATH/usr/bin/ld
 // RUN: %hardlink-or-copy(from: %swift_driver_plain, to: %t/DISTINCTIVE-PATH/usr/bin/swiftc)
-// RUN: %t/DISTINCTIVE-PATH/usr/bin/swiftc %s -### | %FileCheck -check-prefix=RELATIVE-LINKER %s
+// RUN: %t/DISTINCTIVE-PATH/usr/bin/swiftc -target x86_64-apple-macosx10.9 %s -### | %FileCheck -check-prefix=RELATIVE-LINKER %s
 
 // RELATIVE-LINKER: /DISTINCTIVE-PATH/usr/bin/swift
 // RELATIVE-LINKER: /DISTINCTIVE-PATH/usr/bin/ld

--- a/test/Driver/linker.swift
+++ b/test/Driver/linker.swift
@@ -11,26 +11,26 @@
 // RUN: %swiftc_driver -driver-print-jobs -target i386-apple-watchos2.0 %s 2>&1 > %t.simple.txt
 // RUN: %FileCheck -check-prefix watchOS_SIMPLE %s < %t.simple.txt
 
-// RUN: %swiftc_driver -driver-print-jobs -target x86_64-unknown-linux-gnu -Ffoo -framework bar -Lbaz -lboo -Xlinker -undefined %s 2>&1 > %t.linux.txt
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-unknown-linux-gnu -Ffoo -Fsystem car -F cdr -framework bar -Lbaz -lboo -Xlinker -undefined %s 2>&1 > %t.linux.txt
 // RUN: %FileCheck -check-prefix LINUX-x86_64 %s < %t.linux.txt
 
-// RUN: %swiftc_driver -driver-print-jobs -target armv6-unknown-linux-gnueabihf -Ffoo -framework bar -Lbaz -lboo -Xlinker -undefined %s 2>&1 > %t.linux.txt
+// RUN: %swiftc_driver -driver-print-jobs -target armv6-unknown-linux-gnueabihf -Ffoo -Fsystem car -F cdr -framework bar -Lbaz -lboo -Xlinker -undefined %s 2>&1 > %t.linux.txt
 // RUN: %FileCheck -check-prefix LINUX-armv6 %s < %t.linux.txt
 
-// RUN: %swiftc_driver -driver-print-jobs -target armv7-unknown-linux-gnueabihf -Ffoo -framework bar -Lbaz -lboo -Xlinker -undefined %s 2>&1 > %t.linux.txt
+// RUN: %swiftc_driver -driver-print-jobs -target armv7-unknown-linux-gnueabihf -Ffoo -Fsystem car -F cdr -framework bar -Lbaz -lboo -Xlinker -undefined %s 2>&1 > %t.linux.txt
 // RUN: %FileCheck -check-prefix LINUX-armv7 %s < %t.linux.txt
 
-// RUN: %swiftc_driver -driver-print-jobs -target thumbv7-unknown-linux-gnueabihf -Ffoo -framework bar -Lbaz -lboo -Xlinker -undefined %s 2>&1 > %t.linux.txt
+// RUN: %swiftc_driver -driver-print-jobs -target thumbv7-unknown-linux-gnueabihf -Ffoo -Fsystem car -F cdr -framework bar -Lbaz -lboo -Xlinker -undefined %s 2>&1 > %t.linux.txt
 // RUN: %FileCheck -check-prefix LINUX-thumbv7 %s < %t.linux.txt
 
-// RUN: %swiftc_driver -driver-print-jobs -target armv7-none-linux-androideabi -Ffoo -framework bar -Lbaz -lboo -Xlinker -undefined %s 2>&1 > %t.android.txt
+// RUN: %swiftc_driver -driver-print-jobs -target armv7-none-linux-androideabi -Ffoo -Fsystem car -F cdr -framework bar -Lbaz -lboo -Xlinker -undefined %s 2>&1 > %t.android.txt
 // RUN: %FileCheck -check-prefix ANDROID-armv7 %s < %t.android.txt
 // RUN: %FileCheck -check-prefix ANDROID-armv7-NEGATIVE %s < %t.android.txt
 
-// RUN: %swiftc_driver -driver-print-jobs -target x86_64-unknown-windows-cygnus -Ffoo -framework bar -Lbaz -lboo -Xlinker -undefined %s 2>&1 > %t.cygwin.txt
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-unknown-windows-cygnus -Ffoo -Fsystem car -F cdr -framework bar -Lbaz -lboo -Xlinker -undefined %s 2>&1 > %t.cygwin.txt
 // RUN: %FileCheck -check-prefix CYGWIN-x86_64 %s < %t.cygwin.txt
 
-// RUN: %swiftc_driver -driver-print-jobs -emit-library -target x86_64-apple-macosx10.9.1 %s -sdk %S/../Inputs/clang-importer-sdk -lfoo -framework bar -Lbaz -Fgarply -Xlinker -undefined -Xlinker dynamic_lookup -o sdk.out 2>&1 > %t.complex.txt
+// RUN: %swiftc_driver -driver-print-jobs -emit-library -target x86_64-apple-macosx10.9.1 %s -sdk %S/../Inputs/clang-importer-sdk -lfoo -framework bar -Lbaz -Fgarply -Fsystem car -F cdr -Xlinker -undefined -Xlinker dynamic_lookup -o sdk.out 2>&1 > %t.complex.txt
 // RUN: %FileCheck %s < %t.complex.txt
 // RUN: %FileCheck -check-prefix COMPLEX %s < %t.complex.txt
 
@@ -113,7 +113,7 @@
 // LINUX-x86_64-DAG: -lswiftCore
 // LINUX-x86_64-DAG: -L [[STDLIB_PATH:[^ ]+/lib/swift]]
 // LINUX-x86_64-DAG: -Xlinker -rpath -Xlinker [[STDLIB_PATH]]
-// LINUX-x86_64-DAG: -F foo
+// LINUX-x86_64-DAG: -F foo -iframework car -F cdr
 // LINUX-x86_64-DAG: -framework bar
 // LINUX-x86_64-DAG: -L baz
 // LINUX-x86_64-DAG: -lboo
@@ -129,7 +129,7 @@
 // LINUX-armv6-DAG: -L [[STDLIB_PATH:[^ ]+/lib/swift]]
 // LINUX-armv6-DAG: -target armv6-unknown-linux-gnueabihf
 // LINUX-armv6-DAG: -Xlinker -rpath -Xlinker [[STDLIB_PATH]]
-// LINUX-armv6-DAG: -F foo
+// LINUX-armv6-DAG: -F foo -iframework car -F cdr
 // LINUX-armv6-DAG: -framework bar
 // LINUX-armv6-DAG: -L baz
 // LINUX-armv6-DAG: -lboo
@@ -145,7 +145,7 @@
 // LINUX-armv7-DAG: -L [[STDLIB_PATH:[^ ]+/lib/swift]]
 // LINUX-armv7-DAG: -target armv7-unknown-linux-gnueabihf
 // LINUX-armv7-DAG: -Xlinker -rpath -Xlinker [[STDLIB_PATH]]
-// LINUX-armv7-DAG: -F foo
+// LINUX-armv7-DAG: -F foo -iframework car -F cdr
 // LINUX-armv7-DAG: -framework bar
 // LINUX-armv7-DAG: -L baz
 // LINUX-armv7-DAG: -lboo
@@ -161,7 +161,7 @@
 // LINUX-thumbv7-DAG: -L [[STDLIB_PATH:[^ ]+/lib/swift]]
 // LINUX-thumbv7-DAG: -target thumbv7-unknown-linux-gnueabihf
 // LINUX-thumbv7-DAG: -Xlinker -rpath -Xlinker [[STDLIB_PATH]]
-// LINUX-thumbv7-DAG: -F foo
+// LINUX-thumbv7-DAG: -F foo -iframework car -F cdr
 // LINUX-thumbv7-DAG: -framework bar
 // LINUX-thumbv7-DAG: -L baz
 // LINUX-thumbv7-DAG: -lboo
@@ -176,7 +176,7 @@
 // ANDROID-armv7-DAG: -lswiftCore
 // ANDROID-armv7-DAG: -L [[STDLIB_PATH:[^ ]+/lib/swift]]
 // ANDROID-armv7-DAG: -target armv7-none-linux-androideabi
-// ANDROID-armv7-DAG: -F foo
+// ANDROID-armv7-DAG: -F foo -iframework car -F cdr
 // ANDROID-armv7-DAG: -framework bar
 // ANDROID-armv7-DAG: -L baz
 // ANDROID-armv7-DAG: -lboo
@@ -192,7 +192,7 @@
 // CYGWIN-x86_64-DAG: -lswiftCore
 // CYGWIN-x86_64-DAG: -L [[STDLIB_PATH:[^ ]+/lib/swift]]
 // CYGWIN-x86_64-DAG: -Xlinker -rpath -Xlinker [[STDLIB_PATH]]
-// CYGWIN-x86_64-DAG: -F foo
+// CYGWIN-x86_64-DAG: -F foo -iframework car -F cdr
 // CYGWIN-x86_64-DAG: -framework bar
 // CYGWIN-x86_64-DAG: -L baz
 // CYGWIN-x86_64-DAG: -lboo
@@ -205,7 +205,7 @@
 // COMPLEX-DAG: -lfoo
 // COMPLEX-DAG: -framework bar
 // COMPLEX-DAG: -L baz
-// COMPLEX-DAG: -F garply
+// COMPLEX-DAG: -F garply -F car -F cdr
 // COMPLEX-DAG: -undefined dynamic_lookup
 // COMPLEX-DAG: -macosx_version_min 10.9.1
 // COMPLEX: -o sdk.out


### PR DESCRIPTION
-Fsystem is not a linker flag. Pass it as -F to ld on Apple platforms, and -iframework to Clang on other platforms.

Built on #8403.