### PR TITLE
Test: use StdlibUnittest in BridgeNonVerbatim

### DIFF
--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
@@ -158,6 +158,10 @@ public func expectEqual<T : Equatable, U : Equatable, V : Equatable, W : Equatab
   expectEqualTest(expected.3, actual.3, ${trace}, showFrame: false) {$0 == $1}
 }
 
+public func expectEqualReference(_ expected: AnyObject?, _ actual: AnyObject?, ${TRACE}) {
+  expectEqualTest(expected, actual, ${trace}, showFrame: false) {$0 === $1}
+}
+
 public func expectationFailure(
   _ reason: String,
   trace message: String,


### PR DESCRIPTION
Convert tests in BridgeNonVerbatim.swift to use StdlibUnittest.

Also add a function that compares references in StdlibUnittest.
