### PR TITLE
AllocBoxToStack: Improve alloc_stack/dealloc_stack scoping

### DIFF
--- a/include/swift/SILOptimizer/Utils/StackNesting.h
+++ b/include/swift/SILOptimizer/Utils/StackNesting.h
@@ -1,0 +1,156 @@
+//===--- StackNesting.h - Utility for stack nesting -------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SILOPTIMIZER_UTILS_STACKNESTING_H
+#define SWIFT_SILOPTIMIZER_UTILS_STACKNESTING_H
+
+#include "swift/SIL/SILInstruction.h"
+#include "llvm/ADT/SmallBitVector.h"
+
+#include <vector>
+
+namespace swift {
+
+/// A utility to correct the nesting of stack allocating/deallocating
+/// instructions.
+///
+/// This utility is useful for optimizations which create stack allocations
+/// without caring about correct nesting with existing allocations. This may
+/// result in code like
+/// \code
+///   %1 = alloc_stack
+///     ...
+///   %2 = alloc_stack
+///     ...
+///   dealloc_stack %1
+///     ...
+///   dealloc_stack %2
+/// \endcode
+///
+/// The StackNesting utility is able to correct the code:
+/// \code
+///   %1 = alloc_stack
+///     ...
+///   %2 = alloc_stack
+///     ...
+///   dealloc_stack %2
+///   dealloc_stack %1
+/// \endcode
+///
+class StackNesting {
+
+  typedef llvm::SmallBitVector BitVector;
+
+  /// Data stored for each block (actually for each block which is not dead).
+  struct BlockInfo {
+
+    /// Back-link to the block.
+    SILBasicBlock *Block;
+
+    /// The cached list of successors.
+    llvm::SmallVector<BlockInfo *, 8> Successors;
+
+    /// The list of stack allocating/deallocating instructions in the block.
+    llvm::SmallVector<SILInstruction *, 8> StackInsts;
+
+    /// The bit-set of alive stack locations at the block entry.
+    BitVector AliveStackLocsAtEntry;
+
+    /// True if there is a path from this block to a function-exit.
+    ///
+    /// In other words: this block does not end in an unreachable-instruction.
+    /// This flag is only used for verifying that the lifetime of a stack
+    /// location does not end at the end of a block.
+    bool ExitReachable = false;
+
+    BlockInfo(SILBasicBlock *Block) : Block(Block) { }
+  };
+
+  /// Data stored for each stack location (= allocation).
+  ///
+  /// Each stack location is allocated by a single allocation instruction.
+  struct StackLoc {
+    StackLoc(SILInstruction *Alloc) : Alloc(Alloc) { }
+
+    /// Back-link to the allocation instruction.
+    SILInstruction *Alloc;
+
+    /// Bit-set which represents all alive locations at this allocation.
+    /// It obviously includes this location itself. And it includes all "outer"
+    /// locations which surround this location.
+    BitVector AliveLocs;
+  };
+
+  /// Mapping from stack allocations (= locations) to bit numbers.
+  llvm::DenseMap<SILInstruction *, unsigned> StackLoc2BitNumbers;
+
+  /// The list of stack locations. The index into this array is also the bit
+  /// number in the bit-sets.
+  llvm::SmallVector<StackLoc, 8> StackLocs;
+
+  /// Block data for all (non-dead) blocks.
+  std::vector<BlockInfo> BlockInfos;
+
+public:
+
+  /// The possible return values of correctStackNesting().
+  enum class Changes {
+    /// No changes are made.
+    None,
+
+    /// Only instructions were inserted or deleted.
+    Instructions,
+
+    /// Instructions were inserted or deleted and new blocks were inserted.
+    CFG
+  };
+
+  StackNesting() { }
+
+  /// Performs correction of stack nesting by moving stack-deallocation
+  /// instructions down the control flow.
+  ///
+  /// Returns the status of what changes were made.
+  Changes correctStackNesting(SILFunction *F);
+  
+  /// For debug dumping.
+  void dump() const;
+
+  static void dumpBits(const BitVector &Bits);
+
+private:
+  /// Initializes the data structures.
+  void setup(SILFunction *F);
+
+  /// Solves the dataflow problem.
+  ///
+  /// Returns true if there is a nesting of locations in any way, which can
+  /// potentially in the wrong order.
+  bool solve();
+
+  /// Insert deallocation instructions for all locations which are alive before
+  /// the InsertionPoint (AliveBefore) but not alive after the InsertionPoint
+  /// (AliveAfter).
+  ///
+  /// Returns true if any deallocations were inserted.
+  bool insertDeallocs(const BitVector &AliveBefore, const BitVector &AliveAfter,
+                      SILInstruction *InsertionPoint);
+
+  /// Modifies the SIL to end up with a correct stack nesting.
+  ///
+  /// Returns the status of what changes were made.
+  Changes adaptDeallocs();
+};
+
+} // end namespace swift
+
+#endif // SWIFT_SILOPTIMIZER_UTILS_STACKNESTING_H

--- a/lib/SILOptimizer/Utils/CMakeLists.txt
+++ b/lib/SILOptimizer/Utils/CMakeLists.txt
@@ -13,5 +13,6 @@ set(UTILS_SOURCES
   Utils/SILInliner.cpp
   Utils/SILSSAUpdater.cpp
   Utils/SpecializationMangler.cpp
+  Utils/StackNesting.cpp
   PARENT_SCOPE)
 

--- a/lib/SILOptimizer/Utils/StackNesting.cpp
+++ b/lib/SILOptimizer/Utils/StackNesting.cpp
@@ -1,0 +1,327 @@
+//===--- StackNesting.cpp - Utility for stack nesting  --------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/SILOptimizer/Utils/StackNesting.h"
+#include "swift/SILOptimizer/Utils/CFG.h"
+#include "swift/SIL/SILFunction.h"
+#include "swift/SIL/SILBuilder.h"
+#include "llvm/Support/Debug.h"
+
+using namespace swift;
+
+void StackNesting::setup(SILFunction *F) {
+  SmallVector<BlockInfo *, 8> WorkList;
+  llvm::DenseMap<SILBasicBlock *, BlockInfo *> BlockMapping;
+
+  // We use pointers to BlockInfo structs. Therefore it's important that the
+  // BlockInfos vector is never re-allocated.
+  BlockInfos.reserve(F->size());
+
+  // Start with the function entry block and add blocks while walking down along
+  // the successor edges.
+  // This ensures a correct ordering of stack locations: an inner location has
+  // a higher bit-number than it's outer parent location.
+  // This ordering is only important for inserting multiple deallocation
+  // instructions (see below).
+  BlockInfos.emplace_back(F->getEntryBlock());
+  BlockInfo *EntryBI = &BlockInfos.back();
+  BlockMapping[F->getEntryBlock()] = EntryBI;
+  WorkList.push_back(EntryBI);
+
+  while (!WorkList.empty()) {
+    BlockInfo *BI = WorkList.pop_back_val();
+    for (SILInstruction &I : *BI->Block) {
+      if (I.isAllocatingStack()) {
+        // Register this stack location.
+        unsigned CurrentBitNumber = StackLocs.size();
+        StackLoc2BitNumbers[&I] = CurrentBitNumber;
+        StackLocs.push_back(StackLoc(&I));
+
+        BI->StackInsts.push_back(&I);
+
+      } else if (I.isDeallocatingStack()) {
+        auto *AllocInst = cast<SILInstruction>(I.getOperand(0));
+        if (!BI->StackInsts.empty() && BI->StackInsts.back() == AllocInst) {
+          // As an optimization, we ignore perfectly nested alloc-dealloc pairs
+          // inside a basic block.
+          // Actually, this catches most of the cases and keeps our bitsets
+          // small.
+          assert(StackLocs.back().Alloc == AllocInst);
+          StackLocs.pop_back();
+          BI->StackInsts.pop_back();
+        } else {
+          // Register the stack deallocation.
+          BI->StackInsts.push_back(&I);
+        }
+      }
+    }
+    if (BI->Block->getTerminator()->isFunctionExiting())
+      BI->ExitReachable = true;
+
+    for (auto *SuccBB : BI->Block->getSuccessorBlocks()) {
+      BlockInfo *&SuccBI = BlockMapping[SuccBB];
+      if (!SuccBI) {
+        // Push the next reachable block onto the WorkList.
+        BlockInfos.emplace_back(SuccBB);
+        SuccBI = &BlockInfos.back();
+        WorkList.push_back(SuccBI);
+      }
+      // Cache the successors in our own list.
+      BI->Successors.push_back(SuccBI);
+    }
+  }
+  assert(EntryBI == &BlockInfos[0] &&
+         "BlockInfo vector should not re-allocate");
+
+  unsigned NumLocs = StackLocs.size();
+  for (unsigned Idx = 0; Idx < NumLocs; ++Idx) {
+    StackLocs[Idx].AliveLocs.resize(NumLocs);
+    // Initially each location gets it's own alive-bit.
+    StackLocs[Idx].AliveLocs.set(Idx);
+  }
+}
+
+bool StackNesting::solve() {
+  bool changed = false;
+  bool isNested = false;
+  BitVector Bits(StackLocs.size());
+
+  // Iterate until we reach a fixed-point.
+  do {
+    changed = false;
+
+    // It's a backward dataflow problem.
+    for (BlockInfo &BI : reversed(BlockInfos)) {
+      // Collect the alive-bits (at the block exit) from the successor blocks.
+      Bits.reset();
+      for (BlockInfo *SuccBI : BI.Successors) {
+        Bits |= SuccBI->AliveStackLocsAtEntry;
+
+        // Also get the ExitReachable flag from the successor blocks.
+        if (!BI.ExitReachable && SuccBI->ExitReachable) {
+          BI.ExitReachable = true;
+          changed = true;
+        }
+      }
+      for (SILInstruction *StackInst : reversed(BI.StackInsts)) {
+        if (StackInst->isAllocatingStack()) {
+          int BitNr = StackLoc2BitNumbers[StackInst];
+          if (Bits != StackLocs[BitNr].AliveLocs) {
+            // More locations are alive around the StackInst's location.
+            // Update the AlivaLocs bitset, which contains all those alive
+            // locations.
+            assert(Bits.test(BitNr) && "no dealloc found for alloc stack");
+            StackLocs[BitNr].AliveLocs = Bits;
+            changed = true;
+            isNested = true;
+          }
+          // The allocation ends the lifetime of it's stack location (in reverse
+          // order)
+          Bits.reset(BitNr);
+        } else if (StackInst->isDeallocatingStack()) {
+          // A stack deallocation begins the lifetime of its location (in
+          // reverse order). And it also begins the lifetime of all other
+          // locations which are alive at the allocation point.
+          auto *AllocInst = cast<SILInstruction>(StackInst->getOperand(0));
+          int BitNr = StackLoc2BitNumbers[AllocInst];
+          Bits |= StackLocs[BitNr].AliveLocs;
+        }
+      }
+      if (Bits != BI.AliveStackLocsAtEntry) {
+        BI.AliveStackLocsAtEntry = Bits;
+        changed = true;
+      }
+    }
+  } while (changed);
+  
+  return isNested;
+}
+
+static SILInstruction *createDealloc(SILInstruction *Alloc,
+                                     SILInstruction *InsertionPoint) {
+  SILBuilder B(InsertionPoint);
+  switch (Alloc->getKind()) {
+    case ValueKind::AllocStackInst:
+      return B.createDeallocStack(InsertionPoint->getLoc(), Alloc);
+    case ValueKind::AllocRefInst:
+      assert(cast<AllocRefInst>(Alloc)->canAllocOnStack());
+      return B.createDeallocRef(InsertionPoint->getLoc(), Alloc,
+                                /*canBeOnStack*/true);
+    default:
+      llvm_unreachable("unknown stack allocation");
+  }
+}
+
+bool StackNesting::insertDeallocs(const BitVector &AliveBefore,
+                                  const BitVector &AliveAfter,
+                                  SILInstruction *InsertionPoint) {
+  if (!AliveBefore.test(AliveAfter))
+    return false;
+
+  // The order matters here if we have to insert more than one
+  // deallocation. We already ensured in setup() that the bit numbers
+  // are allocated in the right order.
+  bool changesMade = false;
+  for (int LocNr = AliveBefore.find_first(); LocNr >= 0;
+       LocNr = AliveBefore.find_next(LocNr)) {
+    if (!AliveAfter.test(LocNr)) {
+      InsertionPoint = createDealloc(StackLocs[LocNr].Alloc, InsertionPoint);
+      changesMade = true;
+    }
+  }
+  return changesMade;
+}
+
+StackNesting::Changes StackNesting::adaptDeallocs() {
+
+  bool InstChanged = false;
+  bool CFGChanged = false;
+  BitVector Bits(StackLocs.size());
+
+  // Visit all blocks. Actuallly the order doesn't matter, but let's to it in
+  // the same order as in solve().
+  for (const BlockInfo &BI : reversed(BlockInfos)) {
+    // Collect the alive-bits (at the block exit) from the successor blocks.
+    Bits.reset();
+    for (BlockInfo *SuccBI : BI.Successors) {
+      Bits |= SuccBI->AliveStackLocsAtEntry;
+    }
+
+    // Insert deallocations at block boundaries.
+    // This can be necessary for unreachable blocks. Example:
+    //
+    //   %1 = alloc_stack
+    //   %2 = alloc_stack
+    //   cond_br %c, bb2, bb3
+    // bb2:   <--- need to insert a dealloc_stack %2 at the begin of bb2
+    //   dealloc_stack %1
+    //   unreachable
+    // bb3:
+    //   dealloc_stack %2
+    //   dealloc_stack %1
+    //
+    for (unsigned SuccIdx = 0, NumSuccs = BI.Successors.size();
+         SuccIdx < NumSuccs; ++ SuccIdx) {
+      BlockInfo *SuccBI = BI.Successors[SuccIdx];
+
+      // It's acceptable to not deallocate alive locations in unreachable
+      // blocks - as long as the nesting is not violated. So if there are no
+      // alive locations at the unreachable successor block, we can ignore it.
+      if (!SuccBI->ExitReachable && !SuccBI->AliveStackLocsAtEntry.any())
+        continue;
+
+      if (SuccBI->AliveStackLocsAtEntry == Bits)
+        continue;
+
+      // Insert dellocations for all locations which are alive at the end of
+      // the current block, but not at the begin of the successor block.
+      SILBasicBlock *InsertionBlock = SuccBI->Block;
+      if (!InsertionBlock->getSinglePredecessorBlock()) {
+        // If the current block is not the only predecessor of the successor
+        // block, we have to insert a new block where we can add the
+        // deallocations.
+        InsertionBlock = splitEdge(BI.Block->getTerminator(), SuccIdx);
+        CFGChanged = true;
+      }
+      InstChanged |= insertDeallocs(Bits, SuccBI->AliveStackLocsAtEntry,
+                                    &InsertionBlock->front());
+    }
+
+    // Insert/remove deallocations inside blocks.
+    for (SILInstruction *StackInst : reversed(BI.StackInsts)) {
+      if (StackInst->isAllocatingStack()) {
+        // For allocations we just update the bit-set.
+        int BitNr = StackLoc2BitNumbers.lookup(StackInst);
+        assert(Bits == StackLocs[BitNr].AliveLocs &&
+               "dataflow didn't converge");
+        Bits.reset(BitNr);
+      } else if (StackInst->isDeallocatingStack()) {
+        // Handle deallocations.
+        auto *AllocInst = cast<SILInstruction>(StackInst->getOperand(0));
+        int BitNr = StackLoc2BitNumbers.lookup(AllocInst);
+        SILInstruction *InsertionPoint = &*std::next(StackInst->getIterator());
+        if (Bits.test(BitNr)) {
+          // The location of StackInst is alive after StackInst. So we have to
+          // remove this deallocation.
+          StackInst->eraseFromParent();
+          InstChanged = true;
+        } else {
+          // Avoid inserting another deallocation for BitNr (which is already
+          // StackInst).
+          Bits.set(BitNr);
+        }
+
+        // Insert deallocations for all locations which are not alive after
+        // StackInst but _are_ alive at the StackInst.
+        InstChanged |= insertDeallocs(StackLocs[BitNr].AliveLocs, Bits,
+                                      InsertionPoint);
+        Bits |= StackLocs[BitNr].AliveLocs;
+      }
+    }
+    assert(Bits == BI.AliveStackLocsAtEntry && "dataflow didn't converge");
+  }
+  if (CFGChanged)
+    return Changes::CFG;
+  if (InstChanged)
+    return Changes::Instructions;
+  return Changes::None;
+}
+
+StackNesting::Changes StackNesting::correctStackNesting(SILFunction *F) {
+  setup(F);
+  if (solve()) {
+    return adaptDeallocs();
+  }
+  return Changes::None;
+}
+
+void StackNesting::dump() const {
+  for (const BlockInfo &BI : BlockInfos) {
+    if (!BI.Block)
+      continue;
+
+    llvm::dbgs() << "Block " << BI.Block->getDebugID();
+    if (!BI.ExitReachable)
+      llvm::dbgs() << " (unreachable exit)";
+    llvm::dbgs() << ": bits=";
+    dumpBits(BI.AliveStackLocsAtEntry);
+    for (SILInstruction *StackInst : BI.StackInsts) {
+      if (StackInst->isAllocatingStack()) {
+        int BitNr = StackLoc2BitNumbers.lookup(StackInst);
+        llvm::dbgs() << "  alloc #" << BitNr << ": alive=";
+        dumpBits(StackLocs[BitNr].AliveLocs);
+        llvm::dbgs() << "    " << *StackInst;
+      } else if (StackInst->isDeallocatingStack()) {
+        auto *AllocInst = cast<SILInstruction>(StackInst->getOperand(0));
+        int BitNr = StackLoc2BitNumbers.lookup(AllocInst);
+        llvm::dbgs() << "  dealloc for #" << BitNr << "\n"
+                        "    " << *StackInst;
+      }
+    }
+    llvm::dbgs() << "  successors:";
+    for (BlockInfo *SuccBI : BI.Successors) {
+      llvm::dbgs() << ' ' << SuccBI->Block->getDebugID();
+    }
+    llvm::dbgs() << '\n';
+  }
+}
+
+void StackNesting::dumpBits(const BitVector &Bits) {
+  llvm::dbgs() << '<';
+  const char *separator = "";
+  for (int Bit = Bits.find_first(); Bit >= 0; Bit = Bits.find_next(Bit)) {
+    llvm::dbgs() << separator << Bit;
+    separator = ",";
+  }
+  llvm::dbgs() << ">\n";
+}
+

--- a/test/DebugInfo/ProtocolContainer.swift
+++ b/test/DebugInfo/ProtocolContainer.swift
@@ -13,7 +13,7 @@ class AClass : AProtocol {
 }
 // CHECK: define hidden {{.*}}void @_T017ProtocolContainer3foo{{[_0-9a-zA-Z]*}}F
 // CHECK-NEXT: entry:
-// CHECK-NEXT: %[[X:.*]] = alloca %T17ProtocolContainer9AProtocolP, align {{(4|8)}}
+// CHECK:      %[[X:.*]] = alloca %T17ProtocolContainer9AProtocolP, align {{(4|8)}}
 // CHECK:      call void @llvm.dbg.declare(metadata %T17ProtocolContainer9AProtocolP* %[[X]], metadata ![[XMD:.*]], metadata !{{[0-9]+}})
 // CHECK-NOT: !DILocalVariable({{.*}} name: "x"
 // CHECK-NOT: !DILocalVariable({{.*}} name: "x"

--- a/test/DebugInfo/letstring.swift
+++ b/test/DebugInfo/letstring.swift
@@ -7,15 +7,16 @@ class AppDelegate {
   // CHECK: define hidden {{.*}}i1 {{.*}}11AppDelegateC1f
   func f() -> Bool {
     // Test for -O0 shadow copies.
-    // CHECK: call void @llvm.dbg.declare({{.*}}, metadata ![[B:.*]], metadata !{{[0-9]+}})
-    // CHECK-NOT: call void @llvm.dbg.value({{.*}}, metadata ![[B]], metadata !{{[0-9]+}})
     // CHECK: call void @llvm.dbg.declare({{.*}}, metadata ![[SELF:.*]], metadata !{{[0-9]+}})
-    let a = "let"
-    // CHECK-NOT: call void @llvm.dbg.value({{.*}}, metadata ![[SELF]], metadata !{{[0-9]+}})
+    // CHECK-NOT: call void @llvm.dbg.value
     // CHECK: call void @llvm.dbg.declare({{.*}}, metadata ![[A:.*]], metadata !{{[0-9]+}})
-    // CHECK-NOT: call void @llvm.dbg.value({{.*}}, metadata ![[A]], metadata !{{[0-9]+}})
-    // CHECK-DAG: ![[A]] = !DILocalVariable(name: "a",{{.*}} line: [[@LINE-4]],
+    let a = "let"
+    // CHECK-NOT: call void @llvm.dbg.value
+    // CHECK: call void @llvm.dbg.declare({{.*}}, metadata ![[B:.*]], metadata !{{[0-9]+}})
+    // CHECK-NOT: call void @llvm.dbg.value
+    // CHECK: ret
     // CHECK-DAG: ![[SELF]] = !DILocalVariable(name: "self", arg: 1{{.*}} line: [[@LINE-10]],
+    // CHECK-DAG: ![[A]] = !DILocalVariable(name: "a",{{.*}} line: [[@LINE-6]],
     // CHECK-DAG: ![[B]] = !DILocalVariable(name: "b",{{.*}} line: [[@LINE+1]],
     var b = "var"
     self.window = UIWindow()
@@ -32,7 +33,7 @@ class AppDelegate {
 // DWARF-CHECK:  DW_AT_name {{.*}} "self"
 //
 // DWARF-CHECK:  DW_TAG_variable
-// DWARF-CHECK:  DW_AT_name {{.*}} "b"
+// DWARF-CHECK:  DW_AT_name {{.*}} "a"
 //
 // DWARF-CHECK:  DW_TAG_variable
-// DWARF-CHECK:  DW_AT_name {{.*}} "a"
+// DWARF-CHECK:  DW_AT_name {{.*}} "b"

--- a/test/DebugInfo/linetable-cleanups.swift
+++ b/test/DebugInfo/linetable-cleanups.swift
@@ -1,5 +1,8 @@
 // RUN: %target-swift-frontend %s -emit-ir -g -o - | %FileCheck %s
 
+// TODO: check why this is failing on linux
+// REQUIRES: OS=macosx
+
 func markUsed<T>(_ t: T) {}
 
 class Person {
@@ -21,12 +24,10 @@ func main() {
 // CHECK: call void {{.*[rR]}}elease{{.*}} {{#[0-9]+}}, !dbg ![[LOOPHEADER_LOC]]
 // CHECK: call {{.*}}void @_T04main8markUsedyxlF
 // The cleanups should share the line number with the ret stmt.
-// CHECK:  call void {{.*[rR]}}elease{{.*}} {{#[0-9]+}}, !dbg ![[CLEANUPS:.*]]
+// CHECK:  call void @swift_bridgeObjectRelease({{.*}}) {{#[0-9]+}}, !dbg ![[CLEANUPS:.*]]
 // CHECK-NEXT:  !dbg ![[CLEANUPS]]
-// CHECK-NEXT:  bitcast
 // CHECK-NEXT:  llvm.lifetime.end
 // CHECK-NEXT:  bitcast
-// CHECK-NEXT:  llvm.lifetime.end
 // CHECK-NEXT:  bitcast
 // CHECK-NEXT:  llvm.lifetime.end
 // CHECK-NEXT:  ret void, !dbg ![[CLEANUPS]]

--- a/test/DebugInfo/linetable.swift
+++ b/test/DebugInfo/linetable.swift
@@ -34,9 +34,9 @@ func main(_ x: Int64) -> Void
             var result = my_class.do_something(x)
             markUsed(result)
 // CHECK: call {{.*}} @swift_rt_swift_release {{.*}}
+// CHECK: bitcast
+// CHECK: llvm.lifetime.end
 // CHECK: call {{.*}} @swift_rt_swift_release {{.*}}, !dbg ![[CLOSURE_END:.*]]
-// CHECK-NEXT: bitcast
-// CHECK-NEXT: llvm.lifetime.end
 // CHECK-NEXT: ret void, !dbg ![[CLOSURE_END]]
 // CHECK: ![[CLOSURE_END]] = !DILocation(line: [[@LINE+1]],
         }

--- a/test/DebugInfo/protocolarg.swift
+++ b/test/DebugInfo/protocolarg.swift
@@ -8,21 +8,21 @@ public protocol IGiveOutInts {
 }
 
 // CHECK: define {{.*}}@_T011protocolarg16printSomeNumbersyAA12IGiveOutInts_pF
-// CHECK: @llvm.dbg.declare(metadata %T11protocolarg12IGiveOutIntsP* %
-// CHECK-SAME:              metadata ![[VAR:.*]], metadata ![[EMPTY:.*]])
 // CHECK: @llvm.dbg.declare(metadata %T11protocolarg12IGiveOutIntsP** %
 // CHECK-SAME:              metadata ![[ARG:.*]], metadata ![[DEREF:.*]])
+// CHECK: @llvm.dbg.declare(metadata %T11protocolarg12IGiveOutIntsP* %
+// CHECK-SAME:              metadata ![[VAR:.*]], metadata ![[EMPTY:.*]])
 
 // CHECK: ![[EMPTY]] = !DIExpression()
 
 public func printSomeNumbers(_ gen: IGiveOutInts) {
   var gen = gen
-  // CHECK: ![[VAR]] = !DILocalVariable(name: "gen", {{.*}} line: [[@LINE-1]]
   // FIXME: Should be DW_TAG_interface_type
-  // CHECK: ![[PT:.*]] = !DICompositeType(tag: DW_TAG_structure_type, name: "IGiveOutInts"
   // CHECK: ![[ARG]] = !DILocalVariable(name: "gen", arg: 1,
-  // CHECK-SAME:                        line: [[@LINE-6]], type: ![[PT]]
+  // CHECK-SAME:                        line: [[@LINE-4]], type: ![[PT:[0-9]+]]
+  // CHECK: ![[PT]] = !DICompositeType(tag: DW_TAG_structure_type, name: "IGiveOutInts"
   // CHECK: ![[DEREF]] = !DIExpression(DW_OP_deref)
+  // CHECK: ![[VAR]] = !DILocalVariable(name: "gen", {{.*}} line: [[@LINE-6]]
   markUsed(gen.callMe())
   use(&gen)
 }

--- a/test/IRGen/dynamic_lookup.sil
+++ b/test/IRGen/dynamic_lookup.sil
@@ -76,6 +76,8 @@ bb2:
   br bb3
 
 bb3:
+  strong_release %1 : $<τ_0_0> { var τ_0_0 } <AnyObject>
+  strong_release %3 : $<τ_0_0> { var τ_0_0 } <Optional<() -> ()>>
   %43 = tuple ()
   return %43 : $()
 }
@@ -119,6 +121,7 @@ bb2:
   br bb3
 
 bb3:
+  strong_release %1 : $<τ_0_0> { var τ_0_0 } <AnyObject>
   %43 = tuple ()
   return %43 : $()
 }
@@ -153,6 +156,8 @@ bb2:
   br bb3
 
 bb3:
+  strong_release %3 : $<τ_0_0> { var τ_0_0 } <Int>
+  strong_release %2 : $<τ_0_0> { var τ_0_0 } <AnyObject>
   %30 = tuple ()
   return %30 : $()
 }

--- a/test/SILOptimizer/allocbox_to_stack.sil
+++ b/test/SILOptimizer/allocbox_to_stack.sil
@@ -243,8 +243,8 @@ bb0:
   strong_release %1 : ${ var SomeUnion }
   %10 = tuple ()
   return %10 : $()
-// CHECK:  [[T0:%.*]] = tuple ()
 // CHECK: dealloc_stack [[UNION]]
+// CHECK:  [[T0:%.*]] = tuple ()
 // CHECK-NEXT:  return [[T0]] : $()
 }
 
@@ -276,24 +276,27 @@ bb0(%0 : $Bool):
 //
 // CHECK-LABEL: sil @box_reachable_from_release_test
 sil @box_reachable_from_release_test : $@convention(thin) () -> () {
-// CHECK: bb0:
-// CHECK: alloc_stack
 bb0:
   br bb1
 
+// CHECK: bb1:
+// CHECK-NEXT: alloc_stack
 bb1:
   %1 = alloc_box ${ var Bool }
   cond_br undef, bb2, bb3
 
+// CHECK: bb2:
+// CHECK-NEXT: dealloc_stack
 bb2:
   strong_release %1 : ${ var Bool }
   br bb1
 
+// CHECK: bb3:
+// CHECK-NEXT: dealloc_stack
 bb3:
   strong_release %1 : ${ var Bool }
   %2 = tuple ()
-// CHECK: dealloc_stack
-// CHECK-NEXT: return
+// CHECK: return
   return %2 : $()
 }
 
@@ -334,18 +337,19 @@ bb1:
 
   strong_release %2 : ${ var SomeClass }
   // CHECK: destroy_addr [[MUI]]
+  // CHECK-NEXT: dealloc_stack [[STACK]]
   br bb2
 
   // CHECK: bb2
 bb2:
   %17 = tuple ()
-  // CHECK: dealloc_stack [[STACK]]
-  // CHECK-NEXT: return
+  // CHECK: return
   return %17 : $()
 
 bb3:
   strong_release %2 : ${ var SomeClass }
   // CHECK: destroy_addr [[MUI]]
+  // CHECK-NEXT: dealloc_stack [[STACK]]
   br bb2
 }
 
@@ -486,13 +490,13 @@ bb0(%0 : $@callee_owned () -> @out U):
 sil @callWithAutoclosure : $@convention(thin) <T where T : P> (@in T) -> () {
 // CHECK: bb0
 bb0(%0 : $*T):
-  // CHECK: [[STACK:%[0-9a-zA-Z_]+]] = alloc_stack $T
   // CHECK: debug_value_addr
   debug_value_addr %0 : $*T
   // CHECK: function_ref @mightApply
   %2 = function_ref @mightApply : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@owned @callee_owned () -> @out τ_0_0) -> ()
   %3 = function_ref @closure_to_specialize : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@owned <τ_0_0> { var τ_0_0 } <τ_0_0>) -> @out τ_0_0
   // CHECK-NOT: alloc_box
+  // CHECK: [[STACK:%[0-9a-zA-Z_]+]] = alloc_stack $T
   %4 = alloc_box $<τ_0_0> { var τ_0_0 } <T>
   %4a = project_box %4 : $<τ_0_0> { var τ_0_0 } <T>, 0
   // CHECK: copy_addr %0 to [initialization] [[STACK]] : $*T
@@ -502,10 +506,10 @@ bb0(%0 : $*T):
   %6 = partial_apply %3<T>(%4) : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@owned <τ_0_0> { var τ_0_0 } <τ_0_0>) -> @out τ_0_0
   %7 = apply %2<T>(%6) : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@owned @callee_owned () -> @out τ_0_0) -> ()
   // CHECK: destroy_addr [[STACK]] : $*T
+  // CHECK: dealloc_stack [[STACK]] : $*T
   destroy_addr %0 : $*T
   %9 = tuple ()
- // CHECK: dealloc_stack [[STACK]] : $*T
- // CHECK: return
+  // CHECK: return
   return %9 : $()
 }
 
@@ -745,3 +749,253 @@ bb5(%25 : $Error):                                // Preds: bb4 bb3
   strong_release %2 : ${ var ThrowDerivedClass }
   throw %25 : $Error
 }
+
+// CHECK-LABEL: sil @deal_with_wrong_nesting
+// CHECK:      bb0(%0 : $Int):
+// CHECK-NEXT:   [[STACK1:%[0-9]+]] = alloc_stack $Bool
+// CHECK-NEXT:   [[BOX:%[0-9]+]] = alloc_stack $Int
+// CHECK:      bb1:
+// CHECK-NEXT:   dealloc_stack [[BOX]]
+// CHECK-NEXT:   dealloc_stack [[STACK1]]
+// CHECK:      bb2:
+// CHECK:        store
+// CHECK:        [[STACK2:%[0-9]+]] = alloc_stack $Bool
+// CHECK-NEXT:   dealloc_stack [[STACK2]]
+// CHECK-NEXT:   dealloc_stack [[BOX]]
+// CHECK-NEXT:   dealloc_stack [[STACK1]]
+// CHECK:      bb3:
+// CHECK-NEXT:   tuple
+// CHECK-NEXT:   return
+sil @deal_with_wrong_nesting : $(Int) -> () {
+bb0(%0 : $Int):
+  %as1 = alloc_stack $Bool
+  %1 = alloc_box ${ var Int }
+  cond_br undef, bb1, bb2
+
+bb1:
+  strong_release %1 : ${ var Int }
+  dealloc_stack %as1 : $*Bool
+  br bb3
+
+bb2:
+  %1a = project_box %1 : ${ var Int }, 0
+  %2 = store %0 to %1a : $*Int
+  dealloc_stack %as1 : $*Bool
+  %3 = load %1a : $*Int
+  %as2 = alloc_stack $Bool
+  strong_release %1 : ${ var Int }
+  dealloc_stack %as2 : $*Bool
+  br bb3
+
+bb3:
+  %r = tuple ()
+  %5 = return %r : $()
+}
+
+// CHECK-LABEL: sil @wrong_nesting_with_alloc_ref
+// CHECK:      bb0(%0 : $Int):
+// CHECK-NEXT:   [[REF:%[0-9]+]] = alloc_ref [stack] $SomeClass
+// CHECK-NEXT:   [[BOX:%[0-9]+]] = alloc_stack $Int
+// CHECK:        store
+// CHECK:        dealloc_stack [[BOX]]
+// CHECK-NEXT:   dealloc_ref [stack] [[REF]]
+// CHECK-NEXT:   tuple
+// CHECK-NEXT:   return
+sil @wrong_nesting_with_alloc_ref : $(Int) -> () {
+bb0(%0 : $Int):
+  %as1 = alloc_ref [stack] $SomeClass
+  %1 = alloc_box ${ var Int }
+  %1a = project_box %1 : ${ var Int }, 0
+  %2 = store %0 to %1a : $*Int
+  dealloc_ref [stack] %as1 : $SomeClass
+  %3 = load %1a : $*Int
+  strong_release %1 : ${ var Int }
+  %r = tuple ()
+  %5 = return %r : $()
+}
+
+// CHECK-LABEL: sil @nesting_and_unreachable1
+// CHECK:      bb0(%0 : $Int):
+// CHECK-NEXT:   [[STACK1:%[0-9]+]] = alloc_stack $Bool
+// CHECK-NEXT:   [[BOX:%[0-9]+]] = alloc_stack $Int
+// CHECK:      bb1:
+// CHECK-NEXT:   [[STACK2:%[0-9]+]] = alloc_stack $Bool
+// CHECK-NEXT:   dealloc_stack [[STACK2]]
+// CHECK-NEXT:   unreachable
+// CHECK:      bb2:
+// CHECK:        store
+// CHECK:        dealloc_stack [[BOX]]
+// CHECK-NEXT:   dealloc_stack [[STACK1]]
+// CHECK-NEXT:   tuple
+// CHECK-NEXT:   return
+sil @nesting_and_unreachable1 : $(Int) -> () {
+bb0(%0 : $Int):
+  %as1 = alloc_stack $Bool
+  %1 = alloc_box ${ var Int }
+  %1a = project_box %1 : ${ var Int }, 0
+  cond_br undef, bb1, bb2
+
+bb1:
+  %as2 = alloc_stack $Bool
+  dealloc_stack %as2 : $*Bool
+  unreachable
+
+bb2:
+  %2 = store %0 to %1a : $*Int
+  dealloc_stack %as1 : $*Bool
+  %3 = load %1a : $*Int
+  strong_release %1 : ${ var Int }
+  %r = tuple ()
+  %5 = return %r : $()
+}
+
+// CHECK-LABEL: sil @nesting_and_unreachable2
+// CHECK:      bb0(%0 : $Int):
+// CHECK-NEXT:   [[STACK1:%[0-9]+]] = alloc_stack $Bool
+// CHECK-NEXT:   [[BOX:%[0-9]+]] = alloc_stack $Int
+// CHECK:      bb1:
+// CHECK-NEXT:   [[STACK2:%[0-9]+]] = alloc_stack $Bool
+// CHECK-NEXT:   dealloc_stack [[STACK2]]
+// CHECK-NEXT:   dealloc_stack [[BOX]]
+// CHECK-NEXT:   dealloc_stack [[STACK1]]
+// CHECK-NEXT:   unreachable
+// CHECK:      bb2:
+// CHECK:        store
+// CHECK:        dealloc_stack [[BOX]]
+// CHECK-NEXT:   dealloc_stack [[STACK1]]
+// CHECK-NEXT:   tuple
+// CHECK-NEXT:   return
+sil @nesting_and_unreachable2 : $(Int) -> () {
+bb0(%0 : $Int):
+  %as1 = alloc_stack $Bool
+  %1 = alloc_box ${ var Int }
+  %1a = project_box %1 : ${ var Int }, 0
+  cond_br undef, bb1, bb2
+
+bb1:
+  %as2 = alloc_stack $Bool
+  strong_release %1 : ${ var Int }
+  dealloc_stack %as2 : $*Bool
+  unreachable
+
+bb2:
+  %2 = store %0 to %1a : $*Int
+  dealloc_stack %as1 : $*Bool
+  %3 = load %1a : $*Int
+  strong_release %1 : ${ var Int }
+  %r = tuple ()
+  %5 = return %r : $()
+}
+
+// CHECK-LABEL: sil @nesting_and_unreachable3
+// CHECK:      bb0(%0 : $Int):
+// CHECK-NEXT:   [[BOX:%[0-9]+]] = alloc_stack $Int
+// CHECK-NEXT:   [[STACK:%[0-9]+]] = alloc_stack $Bool
+// CHECK:      bb1:
+// CHECK-NEXT:   dealloc_stack [[STACK]]
+// CHECK-NEXT:   dealloc_stack [[BOX]]
+// CHECK-NEXT:   unreachable
+// CHECK:      bb2:
+// CHECK:        store
+// CHECK:        dealloc_stack [[STACK]]
+// CHECK-NEXT:   dealloc_stack [[BOX]]
+// CHECK-NEXT:   tuple
+// CHECK-NEXT:   return
+sil @nesting_and_unreachable3 : $(Int) -> () {
+bb0(%0 : $Int):
+  %1 = alloc_box ${ var Int }
+  %as1 = alloc_stack $Bool
+  %1a = project_box %1 : ${ var Int }, 0
+  cond_br undef, bb1, bb2
+
+bb1:
+  strong_release %1 : ${ var Int }
+  unreachable
+
+bb2:
+  %2 = store %0 to %1a : $*Int
+  %3 = load %1a : $*Int
+  dealloc_stack %as1 : $*Bool
+  strong_release %1 : ${ var Int }
+  %r = tuple ()
+  %5 = return %r : $()
+}
+
+// CHECK-LABEL: sil @nesting_and_unreachable4
+// CHECK:      bb0(%0 : $Int):
+// CHECK-NEXT:   [[BOX:%[0-9]+]] = alloc_stack $Int
+// CHECK:      bb1:
+// CHECK-NEXT:   unreachable
+// CHECK:      bb2:
+// CHECK:        store
+// CHECK:        dealloc_stack [[BOX]]
+// CHECK-NEXT:   tuple
+// CHECK-NEXT:   return
+sil @nesting_and_unreachable4 : $(Int) -> () {
+bb0(%0 : $Int):
+  %1 = alloc_box ${ var Int }
+  %1a = project_box %1 : ${ var Int }, 0
+  cond_br undef, bb1, bb2
+
+bb1:
+  unreachable
+
+bb2:
+  %2 = store %0 to %1a : $*Int
+  %3 = load %1a : $*Int
+  strong_release %1 : ${ var Int }
+  %r = tuple ()
+  %5 = return %r : $()
+}
+
+// CHECK-LABEL: sil @nesting_and_unreachable_critical_edge
+// CHECK:      bb0(%0 : $Int):
+// CHECK-NEXT:   [[BOX:%[0-9]+]] = alloc_stack $Int
+// CHECK-NEXT:   [[STACK1:%[0-9]+]] = alloc_stack $Bool
+// CHECK-NEXT:   cond_br
+// CHECK:      bb1:
+// CHECK-NEXT:   dealloc_stack [[STACK1]]
+// CHECK-NEXT:   br bb5
+// CHECK:      bb2:
+// CHECK-NEXT:   [[STACK2:%[0-9]+]] = alloc_stack $Bool
+// CHECK-NEXT:   cond_br
+// CHECK:      bb3:
+// CHECK-NEXT:   dealloc_stack [[STACK2]]
+// CHECK-NEXT:   dealloc_stack [[STACK1]]
+// CHECK-NEXT:   br bb5
+// CHECK:      bb4:
+// CHECK:        store
+// CHECK:        dealloc_stack [[STACK2]]
+// CHECK-NEXT:   dealloc_stack [[STACK1]]
+// CHECK-NEXT:   dealloc_stack [[BOX]]
+// CHECK-NEXT:   tuple
+// CHECK-NEXT:   return
+// CHECK:      bb5:
+// CHECK-NEXT:   dealloc_stack [[BOX]]
+// CHECK-NEXT:   unreachable
+sil @nesting_and_unreachable_critical_edge : $(Int) -> () {
+bb0(%0 : $Int):
+  %1 = alloc_box ${ var Int }
+  %as1 = alloc_stack $Bool
+  %1a = project_box %1 : ${ var Int }, 0
+  cond_br undef, bb1, bb3
+
+bb1:
+  %as2 = alloc_stack $Bool
+  cond_br undef, bb2, bb3
+
+bb2:
+  %2 = store %0 to %1a : $*Int
+  %3 = load %1a : $*Int
+  dealloc_stack %as2 : $*Bool
+  dealloc_stack %as1 : $*Bool
+  strong_release %1 : ${ var Int }
+  %r = tuple ()
+  %5 = return %r : $()
+
+bb3:
+  strong_release %1 : ${ var Int }
+  unreachable
+
+}
+

--- a/test/SILOptimizer/definite_init_failable_initializers.swift
+++ b/test/SILOptimizer/definite_init_failable_initializers.swift
@@ -40,10 +40,10 @@ struct FailableStruct {
 // CHECK:         [[SELF_BOX:%.*]] = alloc_stack $FailableStruct
 // CHECK:         br bb1
 // CHECK:       bb1:
+// CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    [[SELF:%.*]] = enum $Optional<FailableStruct>, #Optional.none!enumelt
 // CHECK-NEXT:    br bb2
 // CHECK:       bb2:
-// CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    return [[SELF]]
   init?(failBeforeInitialization: ()) {
     return nil
@@ -59,10 +59,10 @@ struct FailableStruct {
 // CHECK:       bb1:
 // CHECK-NEXT:    [[X_ADDR:%.*]] = struct_element_addr [[SELF_BOX]]
 // CHECK-NEXT:    strong_release [[CANARY]]
+// CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    [[SELF:%.*]] = enum $Optional<FailableStruct>, #Optional.none!enumelt
 // CHECK-NEXT:    br bb2
 // CHECK:       bb2:
-// CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    return [[SELF]]
   init?(failAfterPartialInitialization: ()) {
     x = Canary()
@@ -82,10 +82,10 @@ struct FailableStruct {
 // CHECK:       bb1:
 // CHECK-NEXT:    [[SELF:%.*]] = struct $FailableStruct ([[CANARY1]] : $Canary, [[CANARY2]] : $Canary)
 // CHECK-NEXT:    release_value [[SELF]]
+// CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    [[NEW_SELF:%.*]] = enum $Optional<FailableStruct>, #Optional.none!enumelt
 // CHECK-NEXT:    br bb2
 // CHECK:       bb2:
-// CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    return [[NEW_SELF]]
   init?(failAfterFullInitialization: ()) {
     x = Canary()
@@ -101,10 +101,10 @@ struct FailableStruct {
 // CHECK-NEXT:    br bb1
 // CHECK:       bb1:
 // CHECK-NEXT:    release_value [[CANARY]]
+// CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    [[SELF_VALUE:%.*]] = enum $Optional<FailableStruct>, #Optional.none!enumelt
 // CHECK-NEXT:    br bb2
 // CHECK:       bb2:
-// CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    return [[SELF_VALUE]]
   init?(failAfterWholeObjectInitializationByAssignment: ()) {
     self = FailableStruct(noFail: ())
@@ -120,10 +120,10 @@ struct FailableStruct {
 // CHECK-NEXT:    br bb1
 // CHECK:       bb1:
 // CHECK-NEXT:    release_value [[NEW_SELF]]
+// CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    [[NEW_SELF:%.*]] = enum $Optional<FailableStruct>, #Optional.none!enumelt
 // CHECK-NEXT:    br bb2
 // CHECK:       bb2:
-// CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    return [[NEW_SELF]]
   init?(failAfterWholeObjectInitializationByDelegation: ()) {
     self.init(noFail: ())
@@ -146,14 +146,15 @@ struct FailableStruct {
 // CHECK-NEXT:    [[SELF_VALUE:%.*]] = unchecked_enum_data [[SELF_OPTIONAL]]
 // CHECK-NEXT:    store [[SELF_VALUE]] to [[SELF_BOX]]
 // CHECK-NEXT:    [[NEW_SELF:%.*]] = enum $Optional<FailableStruct>, #Optional.some!enumelt.1, [[SELF_VALUE]]
+// CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    br [[EPILOG_BB:bb[0-9]+]]([[NEW_SELF]] : $Optional<FailableStruct>)
 //
 // CHECK:       [[FAIL_EPILOG_BB]]:
+// CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    [[NEW_SELF:%.*]] = enum $Optional<FailableStruct>, #Optional.none!enumelt
 // CHECK-NEXT:    br [[EPILOG_BB]]([[NEW_SELF]] : $Optional<FailableStruct>)
 //
 // CHECK:       [[EPILOG_BB]]([[NEW_SELF:%.*]] : $Optional<FailableStruct>)
-// CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    return [[NEW_SELF]]
   // Optional to optional
   init?(failDuringDelegation: ()) {
@@ -204,11 +205,11 @@ struct FailableAddrOnlyStruct<T : Pachyderm> {
 // CHECK:         [[SELF_BOX:%.*]] = alloc_stack $FailableAddrOnlyStruct<T>
 // CHECK:         br bb1
 // CHECK:       bb1:
+// CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    inject_enum_addr %0
 // CHECK-NEXT:    br bb2
 // CHECK:       bb2:
-// CHECK:         dealloc_stack [[SELF_BOX]]
-// CHECK-NEXT:    return
+// CHECK:         return
   init?(failBeforeInitialization: ()) {
     return nil
   }
@@ -227,11 +228,11 @@ struct FailableAddrOnlyStruct<T : Pachyderm> {
 // CHECK:       bb1:
 // CHECK-NEXT:    [[X_ADDR:%.*]] = struct_element_addr [[SELF_BOX]]
 // CHECK-NEXT:    destroy_addr [[X_ADDR]]
+// CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    inject_enum_addr %0
 // CHECK-NEXT:    br bb2
 // CHECK:       bb2:
-// CHECK:         dealloc_stack [[SELF_BOX]]
-// CHECK-NEXT:    return
+// CHECK:         return
   init?(failAfterPartialInitialization: ()) {
     x = T()
     return nil
@@ -257,11 +258,11 @@ struct FailableAddrOnlyStruct<T : Pachyderm> {
 // CHECK-NEXT:    br bb1
 // CHECK:       bb1:
 // CHECK-NEXT:    destroy_addr [[SELF_BOX]]
+// CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    inject_enum_addr %0
 // CHECK-NEXT:    br bb2
 // CHECK:       bb2:
-// CHECK:         dealloc_stack [[SELF_BOX]]
-// CHECK-NEXT:    return
+// CHECK:         return
   init?(failAfterFullInitialization: ()) {
     x = T()
     y = T()
@@ -527,14 +528,15 @@ struct ThrowStruct {
 // CHECK-NEXT:    [[SELF_VALUE:%.*]] = unchecked_enum_data [[SELF_OPTIONAL]]
 // CHECK-NEXT:    store [[SELF_VALUE]] to [[SELF_BOX]]
 // CHECK-NEXT:    [[NEW_SELF:%.*]] = enum $Optional<ThrowStruct>, #Optional.some!enumelt.1, [[SELF_VALUE]]
+// CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    br [[EPILOG_BB:bb[0-9]+]]([[NEW_SELF]] : $Optional<ThrowStruct>)
 //
 // CHECK:       [[FAIL_EPILOG_BB]]:
+// CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    [[NEW_SELF:%.*]] = enum $Optional<ThrowStruct>, #Optional.none!enumelt
 // CHECK-NEXT:    br [[EPILOG_BB]]([[NEW_SELF]] : $Optional<ThrowStruct>)
 //
 // CHECK:       [[EPILOG_BB]]([[NEW_SELF:%.*]] : $Optional<ThrowStruct>):
-// CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    return [[NEW_SELF]] : $Optional<ThrowStruct>
 //
 // CHECK:       [[TRY_APPLY_FAIL_TRAMPOLINE_BB:bb[0-9]+]]:
@@ -746,10 +748,10 @@ class FailableBaseClass {
 // CHECK:       bb1:
 // CHECK-NEXT:    [[METATYPE:%.*]] = value_metatype $@thick FailableBaseClass.Type, %0 : $FailableBaseClass
 // CHECK-NEXT:    dealloc_partial_ref %0 : $FailableBaseClass, [[METATYPE]] : $@thick FailableBaseClass.Type
+// CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    [[RESULT:%.*]] = enum $Optional<FailableBaseClass>, #Optional.none!enumelt
 // CHECK-NEXT:    br bb2
 // CHECK:       bb2:
-// CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    return [[RESULT]]
   convenience init?(failBeforeDelegation: ()) {
     return nil
@@ -765,10 +767,10 @@ class FailableBaseClass {
 // CHECK-NEXT:    br bb1
 // CHECK:       bb1:
 // CHECK-NEXT:    strong_release [[NEW_SELF]]
+// CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    [[RESULT:%.*]] = enum $Optional<FailableBaseClass>, #Optional.none!enumelt
 // CHECK-NEXT:    br bb2
 // CHECK:       bb2:
-// CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    return [[RESULT]]
   convenience init?(failAfterDelegation: ()) {
     self.init(noFail: ())
@@ -792,14 +794,15 @@ class FailableBaseClass {
 // CHECK-NEXT:    [[SELF_VALUE:%.*]] = unchecked_enum_data [[SELF_OPTIONAL]]
 // CHECK-NEXT:    store [[SELF_VALUE]] to [[SELF_BOX]]
 // CHECK-NEXT:    [[NEW_SELF:%.*]] = enum $Optional<FailableBaseClass>, #Optional.some!enumelt.1, [[SELF_VALUE]]
+// CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    br [[EPILOG_BB:bb[0-9]+]]([[NEW_SELF]] : $Optional<FailableBaseClass>)
 //
 // CHECK:       [[FAIL_TRAMPOLINE_BB]]:
+// CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    [[NEW_SELF:%.*]] = enum $Optional<FailableBaseClass>, #Optional.none!enumelt
 // CHECK-NEXT:    br [[EPILOG_BB]]([[NEW_SELF]] : $Optional<FailableBaseClass>)
 //
 // CHECK:       [[EPILOG_BB]]([[NEW_SELF:%.*]] : $Optional<FailableBaseClass>):
-// CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    return [[NEW_SELF]]
   // Optional to optional
   convenience init?(failDuringDelegation: ()) {
@@ -840,10 +843,10 @@ class FailableDerivedClass : FailableBaseClass {
 // CHECK:       bb1:
 // CHECK-NEXT:    [[METATYPE:%.*]] = metatype $@thick FailableDerivedClass.Type
 // CHECK-NEXT:    dealloc_partial_ref %0 : $FailableDerivedClass, [[METATYPE]] : $@thick FailableDerivedClass.Type
+// CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    [[RESULT:%.*]] = enum $Optional<FailableDerivedClass>, #Optional.none!enumelt
 // CHECK-NEXT:    br bb2
 // CHECK:       bb2:
-// CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    return [[RESULT]]
   init?(derivedFailBeforeDelegation: ()) {
     return nil
@@ -871,14 +874,15 @@ class FailableDerivedClass : FailableBaseClass {
 // CHECK-NEXT:    [[SELF_VALUE:%.*]] = unchecked_ref_cast [[BASE_SELF_VALUE]]
 // CHECK-NEXT:    store [[SELF_VALUE]] to [[SELF_BOX]]
 // CHECK-NEXT:    [[NEW_SELF:%.*]] = enum $Optional<FailableDerivedClass>, #Optional.some!enumelt.1, [[SELF_VALUE]]
+// CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    br [[EPILOG_BB:bb[0-9]+]]([[NEW_SELF]] : $Optional<FailableDerivedClass>)
 //
 // CHECK:       [[FAIL_TRAMPOLINE_BB]]:
+// CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    [[NEW_SELF:%.*]] = enum $Optional<FailableDerivedClass>, #Optional.none!enumelt
 // CHECK-NEXT:    br [[EPILOG_BB]]([[NEW_SELF]] : $Optional<FailableDerivedClass>)
 //
 // CHECK:       [[EPILOG_BB]]([[NEW_SELF:%.*]] : $Optional<FailableDerivedClass>):
-// CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    return [[NEW_SELF]] : $Optional<FailableDerivedClass>
   init?(derivedFailDuringDelegation: ()) {
     self.otherMember = Canary()

--- a/test/SILOptimizer/definite_init_protocol_init.swift
+++ b/test/SILOptimizer/definite_init_protocol_init.swift
@@ -100,8 +100,8 @@ struct AddressOnlyStruct : TriviallyConstructible {
 // CHECK-NEXT: copy_addr [take] [[SELF_BOX]] to [initialization] [[SELF]]
 // CHECK-NEXT: dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT: copy_addr [take] [[SELF]] to [initialization] %0
-// CHECK-NEXT: [[RESULT:%.*]] = tuple ()
 // CHECK-NEXT: dealloc_stack [[SELF]]
+// CHECK-NEXT: [[RESULT:%.*]] = tuple ()
 // CHECK-NEXT: return [[RESULT]]
   init(upper: Int) {
     self.init(middle: upper)

--- a/test/SILOptimizer/sroa_unreferenced_members.swift
+++ b/test/SILOptimizer/sroa_unreferenced_members.swift
@@ -3,7 +3,7 @@
 import gizmo
 
 // CHECK: ModifyStruct
-// CHECK: %1 = alloc_stack $Drill
+// CHECK:   = alloc_stack $Drill
 // CHECK: ret
 func ModifyStruct(inDrill : Drill) -> Int32 {
   var D : Drill = inDrill


### PR DESCRIPTION
Instead of inserting all alloc_stack/dealloc_stack instructions at the begin/end of the function, insert them at the actual lifetime boundaries.

rdar://problem/16723128