### PR TITLE
[silgen] Fix up EnumElementPatternInitialization::emitEnumMatch to use ownership.

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2971,7 +2971,51 @@ public:
   ElementRange getAllElements() const {
     return ElementRange(getMembers());
   }
-  
+
+  unsigned getNumElements() const {
+    auto eltRange = getAllElements();
+    return std::distance(eltRange.begin(), eltRange.end());
+  }
+
+  /// If this is an enum with two cases, return the other case. Otherwise,
+  /// return nullptr.
+  EnumElementDecl *getOppositeBinaryDecl(EnumElementDecl *decl) const {
+    ElementRange range = getAllElements();
+    auto iter = range.begin();
+    if (iter == range.end())
+      return nullptr;
+    bool seenDecl = false;
+    EnumElementDecl *result = nullptr;
+    if (*iter == decl) {
+      seenDecl = true;
+    } else {
+      result = *iter;
+    }
+
+    ++iter;
+    if (iter == range.end())
+      return nullptr;
+    if (seenDecl) {
+      assert(!result);
+      result = *iter;
+    } else {
+      if (decl != *iter)
+        return nullptr;
+      seenDecl = true;
+    }
+    ++iter;
+
+    // If we reach this point, we saw the decl we were looking for and one other
+    // case. If we have any additional cases, then we do not have a binary enum.
+    if (iter != range.end())
+      return nullptr;
+
+    // This is always true since we have already returned earlier nullptr if we
+    // did not see the decl at all.
+    assert(seenDecl);
+    return result;
+  }
+
   /// Return a range that iterates over all the cases of an enum.
   CaseRange getAllCases() const {
     return CaseRange(getMembers());

--- a/include/swift/SIL/SILBasicBlock.h
+++ b/include/swift/SIL/SILBasicBlock.h
@@ -322,6 +322,9 @@ public:
   /// no-return apply or builtin.
   bool isNoReturn() const;
 
+  /// Returns true if this instruction only contains a branch instruction.
+  bool isTrampoline() const;
+
   //===--------------------------------------------------------------------===//
   // Debugging
   //===--------------------------------------------------------------------===//

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -5323,6 +5323,9 @@ public:
     return {getCaseBuf()[i], getSuccessorBuf()[i].getBB()};
   }
 
+  // Swap the cases at indices \p i and \p j.
+  void swapCase(unsigned i, unsigned j);
+
   /// \brief Return the block that will be branched to on the specified enum
   /// case.
   SILBasicBlock *getCaseDestination(EnumElementDecl *D) {

--- a/lib/SIL/SILBasicBlock.cpp
+++ b/lib/SIL/SILBasicBlock.cpp
@@ -346,3 +346,10 @@ bool SILBasicBlock::isNoReturn() const {
 
   return false;
 }
+
+bool SILBasicBlock::isTrampoline() const {
+  auto *Branch = dyn_cast<BranchInst>(getTerminator());
+  if (!Branch)
+    return false;
+  return begin() == Branch->getIterator();
+}

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -3330,7 +3330,7 @@ public:
                     SOI->getOperand()->getType(),
                 "Switch enum default block should have one argument that is "
                 "the same as the input type");
-      } else {
+      } else if (F.hasUnqualifiedOwnership()) {
         require(SOI->getDefaultBB()->args_empty(),
                 "switch_enum default destination must take no arguments");
       }

--- a/lib/SILGen/ManagedValue.cpp
+++ b/lib/SILGen/ManagedValue.cpp
@@ -144,3 +144,15 @@ ManagedValue ManagedValue::formalAccessBorrow(SILGenFunction &SGF,
     return ManagedValue::forUnmanaged(getValue());
   return SGF.emitFormalEvaluationManagedBeginBorrow(loc, getValue());
 }
+
+void ManagedValue::print(raw_ostream &os) const {
+  if (SILValue v = getValue()) {
+    v->print(os);
+  }
+}
+
+void ManagedValue::dump() const {
+#ifndef NDEBUG
+  print(llvm::dbgs());
+#endif
+}

--- a/lib/SILGen/ManagedValue.h
+++ b/lib/SILGen/ManagedValue.h
@@ -296,6 +296,9 @@ public:
     // "InContext" is not considered false.
     return bool(getValue()) || valueAndFlag.getInt();
   }
+
+  void dump() const;
+  void print(raw_ostream &os) const;
 };
 
 /// A ManagedValue which may not be intended to be consumed.

--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -674,6 +674,28 @@ void SwitchEnumBuilder::emit() && {
     }
   }
 
+  // If we are asked to create a default block and it is specified that the
+  // default block should be emitted before normal cases, emit it now.
+  if (defaultBlockData &&
+      defaultBlockData->dispatchTime ==
+          DefaultDispatchTime::BeforeNormalCases) {
+    SILBasicBlock *defaultBlock = defaultBlockData->block;
+    NullablePtr<SILBasicBlock> contBB = defaultBlockData->contBlock;
+    DefaultCaseHandler handler = defaultBlockData->handler;
+
+    // Don't allow cleanups to escape the conditional block.
+    SwitchCaseFullExpr presentScope(builder.getSILGenFunction(),
+                                    CleanupLocation::get(loc),
+                                    contBB.getPtrOrNull());
+    builder.emitBlock(defaultBlock);
+    ManagedValue input = optional;
+    if (!isAddressOnly) {
+      input = builder.createOwnedPHIArgument(optional.getType());
+    }
+    handler(input, presentScope);
+    assert(!builder.hasValidInsertionPoint());
+  }
+
   for (NormalCaseData &caseData : caseDataArray) {
     EnumElementDecl *decl = caseData.decl;
     SILBasicBlock *caseBlock = caseData.block;
@@ -684,6 +706,7 @@ void SwitchEnumBuilder::emit() && {
     SwitchCaseFullExpr presentScope(builder.getSILGenFunction(),
                                     CleanupLocation::get(loc),
                                     contBlock.getPtrOrNull());
+
     builder.emitBlock(caseBlock);
 
     ManagedValue input;
@@ -700,9 +723,10 @@ void SwitchEnumBuilder::emit() && {
     assert(!builder.hasValidInsertionPoint());
   }
 
-  // If we have a default BB, create an argument for the original loaded value
-  // and destroy it there.
-  if (defaultBlockData) {
+  // If we are asked to create a default block and it is specified that the
+  // default block should be emitted after normal cases, emit it now.
+  if (defaultBlockData &&
+      defaultBlockData->dispatchTime == DefaultDispatchTime::AfterNormalCases) {
     SILBasicBlock *defaultBlock = defaultBlockData->block;
     NullablePtr<SILBasicBlock> contBB = defaultBlockData->contBlock;
     DefaultCaseHandler handler = defaultBlockData->handler;

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -276,6 +276,8 @@ public:
   using DefaultCaseHandler =
       std::function<void(ManagedValue, SwitchCaseFullExpr &)>;
 
+  enum class DefaultDispatchTime { BeforeNormalCases, AfterNormalCases };
+
 private:
   struct NormalCaseData {
     EnumElementDecl *decl;
@@ -294,10 +296,13 @@ private:
     SILBasicBlock *block;
     NullablePtr<SILBasicBlock> contBlock;
     DefaultCaseHandler handler;
+    DefaultDispatchTime dispatchTime;
 
     DefaultCaseData(SILBasicBlock *block, NullablePtr<SILBasicBlock> contBlock,
-                    DefaultCaseHandler handler)
-        : block(block), contBlock(contBlock), handler(handler) {}
+                    DefaultCaseHandler handler,
+                    DefaultDispatchTime dispatchTime)
+        : block(block), contBlock(contBlock), handler(handler),
+          dispatchTime(dispatchTime) {}
     ~DefaultCaseData() = default;
   };
 
@@ -314,8 +319,10 @@ public:
 
   void addDefaultCase(SILBasicBlock *defaultBlock,
                       NullablePtr<SILBasicBlock> contBlock,
-                      DefaultCaseHandler handle) {
-    defaultBlockData.emplace(defaultBlock, contBlock, handle);
+                      DefaultCaseHandler handle,
+                      DefaultDispatchTime dispatchTime =
+                          DefaultDispatchTime::AfterNormalCases) {
+    defaultBlockData.emplace(defaultBlock, contBlock, handle, dispatchTime);
   }
 
   void addCase(EnumElementDecl *decl, SILBasicBlock *caseBlock,

--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -340,14 +340,14 @@ SILGenFunction::emitOptionalToOptional(SILLocation loc,
 
         if (!(resultTL.isAddressOnly() && silConv.useLoweredAddresses())) {
           SILValue some = B.createOptionalSome(loc, result).forward(*this);
-          return scope.exit(loc, some);
+          return scope.exitAndBranch(loc, some);
         }
 
         RValue R(*this, loc, noOptResultTy.getSwiftRValueType(), result);
         ArgumentSource resultValueRV(loc, std::move(R));
         emitInjectOptionalValueInto(loc, std::move(resultValueRV),
                                     finalResult.getValue(), resultTL);
-        return scope.exit(loc);
+        return scope.exitAndBranch(loc);
       });
 
   SEBuilder.addCase(
@@ -356,11 +356,11 @@ SILGenFunction::emitOptionalToOptional(SILLocation loc,
         if (!(resultTL.isAddressOnly() && silConv.useLoweredAddresses())) {
           SILValue none =
               B.createManagedOptionalNone(loc, resultTy).forward(*this);
-          return scope.exit(loc, none);
+          return scope.exitAndBranch(loc, none);
         }
 
         emitInjectOptionalNothingInto(loc, finalResult.getValue(), resultTL);
-        return scope.exit(loc);
+        return scope.exitAndBranch(loc);
       });
 
   std::move(SEBuilder).emit();

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -300,11 +300,22 @@ public:
     gen.destroyLocalVariable(l, Var);
   }
 
-  void dump(SILGenFunction &) const override {
+  void dump(SILGenFunction &SGF) const override {
 #ifndef NDEBUG
     llvm::errs() << "DestroyLocalVariable\n"
-                 << "State:" << getState() << "\n";
-    // TODO: Make sure we dump var.
+                 << "State:" << getState() << "\n"
+                 << "Decl: ";
+    Var->print(llvm::errs());
+    llvm::errs() << "\n";
+    if (isActive()) {
+      auto loc = SGF.VarLocs[Var];
+      assert((loc.box || loc.value) && "One of box or value should be set");
+      if (loc.box) {
+        llvm::errs() << "Box: " << loc.box << "\n";
+      } else {
+        llvm::errs() << "Value: " << loc.value << "\n";
+      }
+    }
     llvm::errs() << "\n";
 #endif
   }

--- a/lib/SILGen/SILGenStmt.cpp
+++ b/lib/SILGen/SILGenStmt.cpp
@@ -861,7 +861,7 @@ void StmtEmitter::visitForEachStmt(ForEachStmt *S) {
         // Otherwise, associate the loop body's closing brace with this branch.
         RegularLocation L(S->getBody());
         L.pointToEnd();
-        scope.exit(L);
+        scope.exitAndBranch(L);
       });
 
   // We add loop fail block, just to be defensive about intermediate
@@ -872,7 +872,7 @@ void StmtEmitter::visitForEachStmt(ForEachStmt *S) {
       failExitingBlock,
       [&](ManagedValue inputValue, SwitchCaseFullExpr &scope) {
         assert(!inputValue && "None should not be passed an argument!");
-        scope.exit(S);
+        scope.exitAndBranch(S);
       });
 
   std::move(switchEnumBuilder).emit();

--- a/lib/SILGen/SwitchCaseFullExpr.h
+++ b/lib/SILGen/SwitchCaseFullExpr.h
@@ -30,18 +30,23 @@ class SwitchCaseFullExpr {
   SILGenFunction &SGF;
   Scope scope;
   CleanupLocation loc;
-  SILBasicBlock &contBlock;
+  NullablePtr<SILBasicBlock> contBlock;
 
 public:
-  explicit SwitchCaseFullExpr(SILGenFunction &SGF, CleanupLocation loc,
-                              SILBasicBlock *contBlock = nullptr);
+  SwitchCaseFullExpr(SILGenFunction &SGF, CleanupLocation loc);
+  SwitchCaseFullExpr(SILGenFunction &SGF, CleanupLocation loc,
+                     SILBasicBlock *contBlock);
 
   ~SwitchCaseFullExpr() = default;
 
   SwitchCaseFullExpr(const SwitchCaseFullExpr &) = delete;
   SwitchCaseFullExpr &operator=(const SwitchCaseFullExpr &) = delete;
 
-  void exit(SILLocation loc, ArrayRef<SILValue> result = {});
+  /// Pop the scope and branch to the cont block.
+  void exitAndBranch(SILLocation loc, ArrayRef<SILValue> result = {});
+
+  /// Pop the scope and do not branch to the cont block.
+  void exit();
 };
 
 } // namespace Lowering

--- a/test/SILGen/if_while_binding.swift
+++ b/test/SILGen/if_while_binding.swift
@@ -16,7 +16,10 @@ func marker_3() {}
 func if_no_else() {
   // CHECK:   [[FOO:%.*]] = function_ref @_T016if_while_binding3fooSSSgyF
   // CHECK:   [[OPT_RES:%.*]] = apply [[FOO]]()
-  // CHECK:   switch_enum [[OPT_RES]] : $Optional<String>, case #Optional.some!enumelt.1: [[YES:bb[0-9]+]], default [[CONT:bb[0-9]+]]
+  // CHECK:   switch_enum [[OPT_RES]] : $Optional<String>, case #Optional.some!enumelt.1: [[YES:bb[0-9]+]], case #Optional.none!enumelt: [[NO:bb[0-9]+]]
+  //
+  // CHECK: [[NO]]:
+  // CHECK:  br [[CONT:bb[0-9]+]]
   if let x = foo() {
   // CHECK: [[YES]]([[VAL:%[0-9]+]] : $String):
   // CHECK:   [[A:%.*]] = function_ref @_T016if_while_binding1a
@@ -37,8 +40,11 @@ func if_no_else() {
 func if_else_chain() {
   // CHECK:   [[FOO:%.*]] = function_ref @_T016if_while_binding3foo{{[_0-9a-zA-Z]*}}F
   // CHECK-NEXT:   [[OPT_RES:%.*]] = apply [[FOO]]()
-  // CHECK-NEXT:   switch_enum [[OPT_RES]] : $Optional<String>, case #Optional.some!enumelt.1: [[YESX:bb[0-9]+]], default [[NOX:bb[0-9]+]]
+  // CHECK-NEXT:   switch_enum [[OPT_RES]] : $Optional<String>, case #Optional.some!enumelt.1: [[YESX:bb[0-9]+]], case #Optional.none!enumelt: [[NOX:bb[0-9]+]]
   if let x = foo() {
+  // CHECK: [[NOX]]:
+  // CHECK:   br [[FAILURE_DESTX:bb[0-9]+]]
+  //
   // CHECK: [[YESX]]([[VAL:%[0-9]+]] : $String):
   // CHECK:   debug_value [[VAL]] : $String, let, name "x"
   // CHECK:   [[A:%.*]] = function_ref @_T016if_while_binding1a
@@ -49,24 +55,27 @@ func if_else_chain() {
   // CHECK:   destroy_value [[VAL]]
   // CHECK:   br [[CONT_X:bb[0-9]+]]
     a(x)
-  // CHECK: [[NOX]]:
+  //
+  // CHECK: [[FAILURE_DESTX]]:
   // CHECK:   alloc_box ${ var String }, var, name "y"
-  // CHECK:   switch_enum {{.*}} : $Optional<String>, case #Optional.some!enumelt.1: [[YESY:bb[0-9]+]], default [[ELSE1:bb[0-9]+]]
+  // CHECK:   switch_enum {{.*}} : $Optional<String>, case #Optional.some!enumelt.1: [[YESY:bb[0-9]+]], case #Optional.none!enumelt: [[ELSE1:bb[0-9]+]]
     // CHECK: [[ELSE1]]:
     // CHECK:   dealloc_box {{.*}} ${ var String }
     // CHECK:   br [[ELSE:bb[0-9]+]]
   } else if var y = bar() {
   // CHECK: [[YESY]]([[VAL:%[0-9]+]] : $String):
   // CHECK:   br [[CONT_Y:bb[0-9]+]]
+  // CHECK: [[CONT_Y]]:
+  // CHECK:   br [[CONT_Y2:bb[0-9]+]]
     b(y)
   } else {
     // CHECK: [[ELSE]]:
     // CHECK: function_ref if_while_binding.c
     c("")
-    // CHECK:   br [[CONT_Y]]
+    // CHECK:   br [[CONT_Y2]]
   }
 
-  // CHECK: [[CONT_Y]]:
+  // CHECK: [[CONT_Y2]]:
   //   br [[CONT_X]]
   // CHECK: [[CONT_X]]:
 }
@@ -74,12 +83,18 @@ func if_else_chain() {
 // CHECK-LABEL: sil hidden @_T016if_while_binding0B5_loopyyF : $@convention(thin) () -> () {
 func while_loop() {
   // CHECK:   br [[LOOP_ENTRY:bb[0-9]+]]
+  //
   // CHECK: [[LOOP_ENTRY]]:
-  
-  // CHECK:   switch_enum {{.*}} : $Optional<String>, case #Optional.some!enumelt.1: [[LOOP_BODY:bb[0-9]+]], default [[LOOP_EXIT:bb[0-9]+]]
+  // CHECK:   switch_enum {{.*}} : $Optional<String>, case #Optional.some!enumelt.1: [[LOOP_BODY:bb[0-9]+]], case #Optional.none!enumelt: [[NO_TRAMPOLINE:bb[0-9]+]]
+  //
+  // CHECK: [[NO_TRAMPOLINE]]:
+  // CHECK:   br [[LOOP_EXIT:bb[0-9]+]]
   while let x = foo() {
   // CHECK: [[LOOP_BODY]]([[X:%[0-9]+]] : $String):
-  // CHECK:   switch_enum {{.*}} : $Optional<String>, case #Optional.some!enumelt.1: [[YES:bb[0-9]+]], default [[NO:bb[0-9]+]]
+  // CHECK:   switch_enum {{.*}} : $Optional<String>, case #Optional.some!enumelt.1: [[YES:bb[0-9]+]], case #Optional.none!enumelt: [[NO_TRAMPOLINE_2:bb[0-9]+]]
+  //
+  // CHECK: [[NO_TRAMPOLINE_2]]:
+  // CHECK:   br [[FAILURE_DEST_2:bb[0-9]+]]
     if let y = bar() {
   // CHECK: [[YES]]([[Y:%[0-9]+]] : $String):
       a(y)
@@ -88,7 +103,7 @@ func while_loop() {
       // CHECK: destroy_value [[X]]
       // CHECK:     br [[LOOP_EXIT]]
     }
-  // CHECK: [[NO]]:
+  // CHECK: [[FAILURE_DEST_2]]:
   // CHECK:   destroy_value [[X]]
   // CHECK:   br [[LOOP_ENTRY]]
   }
@@ -104,7 +119,7 @@ func while_loop() {
 // CHECK:       [[COND]]:
 // CHECK:         [[X:%.*]] = alloc_stack $T, let, name "x"
 // CHECK:         [[OPTBUF:%[0-9]+]] = alloc_stack $Optional<T>
-// CHECK:         switch_enum_addr {{.*}}, case #Optional.some!enumelt.1: [[LOOPBODY:bb.*]], default [[OUT:bb[0-9]+]]
+// CHECK:         switch_enum_addr {{.*}}, case #Optional.some!enumelt.1: [[LOOPBODY:bb.*]], case #Optional.none!enumelt: [[OUT:bb[0-9]+]]
 // CHECK:       [[OUT]]:
 // CHECK:         dealloc_stack [[OPTBUF]]
 // CHECK:         dealloc_stack [[X]]
@@ -127,12 +142,15 @@ func while_loop_generic<T>(_ source: () -> T?) {
 func while_loop_multi() {
   // CHECK:   br [[LOOP_ENTRY:bb[0-9]+]]
   // CHECK: [[LOOP_ENTRY]]:
-  // CHECK:         switch_enum {{.*}}, case #Optional.some!enumelt.1: [[CHECKBUF2:bb.*]], default [[LOOP_EXIT0:bb[0-9]+]]
+  // CHECK:         switch_enum {{.*}}, case #Optional.some!enumelt.1: [[CHECKBUF2:bb.*]], case #Optional.none!enumelt: [[NONE_TRAMPOLINE:bb[0-9]+]]
+  //
+  // CHECK: [[NONE_TRAMPOLINE]]:
+  // CHECK:   br [[LOOP_EXIT0:bb[0-9]+]]
 
   // CHECK: [[CHECKBUF2]]([[A:%[0-9]+]] : $String):
   // CHECK:   debug_value [[A]] : $String, let, name "a"
 
-  // CHECK:   switch_enum {{.*}}, case #Optional.some!enumelt.1: [[LOOP_BODY:bb.*]], default [[LOOP_EXIT2a:bb[0-9]+]]
+  // CHECK:   switch_enum {{.*}}, case #Optional.some!enumelt.1: [[LOOP_BODY:bb.*]], case #Optional.none!enumelt: [[LOOP_EXIT2a:bb[0-9]+]]
 
   // CHECK: [[LOOP_EXIT2a]]:
   // CHECK: destroy_value [[A]]
@@ -158,13 +176,16 @@ func while_loop_multi() {
 
 // CHECK-LABEL: sil hidden @_T016if_while_binding0A6_multiyyF
 func if_multi() {
-  // CHECK:   switch_enum {{.*}}, case #Optional.some!enumelt.1: [[CHECKBUF2:bb.*]], default [[IF_DONE:bb[0-9]+]]
+  // CHECK:   switch_enum {{.*}}, case #Optional.some!enumelt.1: [[CHECKBUF2:bb.*]], case #Optional.none!enumelt: [[NONE_TRAMPOLINE:bb[0-9]+]]
+  //
+  // CHECK: [[NONE_TRAMPOLINE]]:
+  // CHECK:   br [[IF_DONE:bb[0-9]+]]
 
   // CHECK: [[CHECKBUF2]]([[A:%[0-9]+]] : $String):
   // CHECK:   debug_value [[A]] : $String, let, name "a"
   // CHECK:   [[B:%[0-9]+]] = alloc_box ${ var String }, var, name "b"
   // CHECK:   [[PB:%[0-9]+]] = project_box [[B]]
-  // CHECK:   switch_enum {{.*}}, case #Optional.some!enumelt.1: [[IF_BODY:bb.*]], default [[IF_EXIT1a:bb[0-9]+]]
+  // CHECK:   switch_enum {{.*}}, case #Optional.some!enumelt.1: [[IF_BODY:bb.*]], case #Optional.none!enumelt: [[IF_EXIT1a:bb[0-9]+]]
 
   // CHECK: [[IF_EXIT1a]]:
   // CHECK:   dealloc_box {{.*}} ${ var String }
@@ -187,12 +208,15 @@ func if_multi() {
 
 // CHECK-LABEL: sil hidden @_T016if_while_binding0A11_multi_elseyyF
 func if_multi_else() {
-  // CHECK:   switch_enum {{.*}}, case #Optional.some!enumelt.1: [[CHECKBUF2:bb.*]], default [[ELSE:bb[0-9]+]]
+  // CHECK:   switch_enum {{.*}}, case #Optional.some!enumelt.1: [[CHECKBUF2:bb.*]], case #Optional.none!enumelt: [[NONE_TRAMPOLINE:bb[0-9]+]]
+  //
+  // CHECK: [[NONE_TRAMPOLINE]]:
+  // CHECK:   br [[ELSE:bb[0-9]+]]
   // CHECK: [[CHECKBUF2]]([[A:%[0-9]+]] : $String):
   // CHECK:   debug_value [[A]] : $String, let, name "a"
   // CHECK:   [[B:%[0-9]+]] = alloc_box ${ var String }, var, name "b"
   // CHECK:   [[PB:%[0-9]+]] = project_box [[B]]
-  // CHECK:   switch_enum {{.*}}, case #Optional.some!enumelt.1: [[IF_BODY:bb.*]], default [[IF_EXIT1a:bb[0-9]+]]
+  // CHECK:   switch_enum {{.*}}, case #Optional.some!enumelt.1: [[IF_BODY:bb.*]], case #Optional.none!enumelt: [[IF_EXIT1a:bb[0-9]+]]
   
     // CHECK: [[IF_EXIT1a]]:
     // CHECK:   dealloc_box {{.*}} ${ var String }
@@ -220,12 +244,15 @@ func if_multi_else() {
 
 // CHECK-LABEL: sil hidden @_T016if_while_binding0A12_multi_whereyyF
 func if_multi_where() {
-  // CHECK:   switch_enum {{.*}}, case #Optional.some!enumelt.1: [[CHECKBUF2:bb.*]], default [[ELSE:bb[0-9]+]]
+  // CHECK:   switch_enum {{.*}}, case #Optional.some!enumelt.1: [[CHECKBUF2:bb.*]], case #Optional.none!enumelt: [[NONE_TRAMPOLINE:bb[0-9]+]]
+  //
+  // CHECK: [[NONE_TRAMPOLINE]]:
+  // CHECK:   br [[ELSE:bb[0-9]+]]
   // CHECK: [[CHECKBUF2]]([[A:%[0-9]+]] : $String):
   // CHECK:   debug_value [[A]] : $String, let, name "a"
   // CHECK:   [[BBOX:%[0-9]+]] = alloc_box ${ var String }, var, name "b"
   // CHECK:   [[PB:%[0-9]+]] = project_box [[BBOX]]
-  // CHECK:   switch_enum {{.*}}, case #Optional.some!enumelt.1: [[CHECK_WHERE:bb.*]], default [[IF_EXIT1a:bb[0-9]+]]
+  // CHECK:   switch_enum {{.*}}, case #Optional.some!enumelt.1: [[CHECK_WHERE:bb.*]], case #Optional.none!enumelt: [[IF_EXIT1a:bb[0-9]+]]
   // CHECK: [[IF_EXIT1a]]:
   // CHECK:   dealloc_box {{.*}} ${ var String }
   // CHECK:   destroy_value [[A]]
@@ -266,7 +293,7 @@ func if_leading_boolean(_ a : Int) {
 // CHECK: [[CHECKFOO]]:
   // CHECK: [[OPTRESULT:%[0-9]+]] = apply {{.*}}() : $@convention(thin) () -> @owned Optional<String>
   
-  // CHECK:   switch_enum [[OPTRESULT]] : $Optional<String>, case #Optional.some!enumelt.1: [[SUCCESS:bb.*]], default [[IF_DONE:bb[0-9]+]]
+  // CHECK:   switch_enum [[OPTRESULT]] : $Optional<String>, case #Optional.some!enumelt.1: [[SUCCESS:bb.*]], case #Optional.none!enumelt: [[IF_DONE:bb[0-9]+]]
 
 // CHECK: [[SUCCESS]]([[B:%[0-9]+]] : $String):
   // CHECK:   debug_value [[B]] : $String, let, name "b"
@@ -296,7 +323,7 @@ func testAsPatternInIfLet(_ a : BaseClass?) {
   // CHECK:   debug_value [[ARG]] : $Optional<BaseClass>, let, name "a"
   // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
   // CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]] : $Optional<BaseClass>
-  // CHECK:   switch_enum [[ARG_COPY]] : $Optional<BaseClass>, case #Optional.some!enumelt.1: [[OPTPRESENTBB:bb[0-9]+]], default [[NILBB:bb[0-9]+]]
+  // CHECK:   switch_enum [[ARG_COPY]] : $Optional<BaseClass>, case #Optional.some!enumelt.1: [[OPTPRESENTBB:bb[0-9]+]], case #Optional.none!enumelt: [[NILBB:bb[0-9]+]]
 
   // CHECK: [[NILBB]]:
   // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
@@ -315,7 +342,7 @@ func testAsPatternInIfLet(_ a : BaseClass?) {
   // CHECK:   br [[MERGE]](
 
   // CHECK: [[MERGE]]([[OPTVAL:%[0-9]+]] : $Optional<DerivedClass>):
-  // CHECK:    switch_enum [[OPTVAL]] : $Optional<DerivedClass>, case #Optional.some!enumelt.1: [[ISDERIVEDBB:bb[0-9]+]], default [[NILBB:bb[0-9]+]]
+  // CHECK:    switch_enum [[OPTVAL]] : $Optional<DerivedClass>, case #Optional.some!enumelt.1: [[ISDERIVEDBB:bb[0-9]+]], case #Optional.none!enumelt: [[NILBB:bb[0-9]+]]
 
   // CHECK: [[ISDERIVEDBB]]([[DERIVEDVAL:%[0-9]+]] : $DerivedClass):
   // CHECK:   debug_value [[DERIVEDVAL]] : $DerivedClass
@@ -336,30 +363,45 @@ func testAsPatternInIfLet(_ a : BaseClass?) {
 // <rdar://problem/22312114> if case crashes swift - bools not supported in let/else yet
 // CHECK-LABEL: sil hidden @_T016if_while_binding12testCaseBoolySbSgF
 func testCaseBool(_ value : Bool?) {
-  // CHECK: bb0(%0 : $Optional<Bool>):
-  // CHECK: switch_enum %0 : $Optional<Bool>, case #Optional.some!enumelt.1: bb1, default bb3
-  // CHECK: bb1(%3 : $Bool):
-  // CHECK: [[ISTRUE:%[0-9]+]] = struct_extract %3 : $Bool, #Bool._value
-  // CHECK: cond_br [[ISTRUE]], bb2, bb3
-  // CHECK: bb2:
-  // CHECK: function_ref @_T016if_while_binding8marker_1yyF
-  // CHECK: br bb3{{.*}}                                      // id: %8
+  // CHECK: bb0([[ARG:%.*]] : $Optional<Bool>):
+  // CHECK: switch_enum [[ARG]] : $Optional<Bool>, case #Optional.some!enumelt.1: [[SOME_BB:bb[0-9]+]], case #Optional.none!enumelt: [[NONE_TRAMPOLINE:bb[0-9]+]]
+  //
+  // CHECK: [[NONE_TRAMPOLINE]]:
+  // CHECK:   br [[CONT_BB:bb[0-9]+]]
+  //
+  // CHECK: [[SOME_BB]]([[PAYLOAD:%.*]] : $Bool):
+  // CHECK:   [[ISTRUE:%[0-9]+]] = struct_extract [[PAYLOAD]] : $Bool, #Bool._value
+  // CHECK:   cond_br [[ISTRUE]], [[TRUE_TRAMPOLINE_BB:bb[0-9]+]], [[CONT_BB]]
+  //
+  // CHECK: [[TRUE_TRAMPOLINE_BB:bb[0-9]+]]
+  // CHECK:   br [[TRUE_BB:bb[0-9]+]]
+  //
+  // CHECK: [[TRUE_BB]]:
+  // CHECK:   function_ref @_T016if_while_binding8marker_1yyF
+  // CHECK:   br [[CONT_BB]]
   if case true? = value {
     marker_1()
   }
 
-  // CHECK:   bb3:                                              // Preds: bb2 bb1 bb0
-  // CHECK:   switch_enum %0 : $Optional<Bool>, case #Optional.some!enumelt.1: bb4, default bb6
+  // CHECK: [[CONT_BB]]:
+  // CHECK:   switch_enum [[ARG]] : $Optional<Bool>, case #Optional.some!enumelt.1: [[SUCC_BB_2:bb[0-9]+]], case #Optional.none!enumelt: [[NO_TRAMPOLINE_2:bb[0-9]+]]
 
-  // CHECK:   bb4(
-  // CHECK:   [[ISTRUE:%[0-9]+]] = struct_extract %10 : $Bool, #Bool._value{{.*}}// user: %12
-  // CHECK:   cond_br [[ISTRUE]], bb6, bb5
+  // CHECK: [[NO_TRAMPOLINE_2]]:
+  // CHECK:   br [[EPILOG_BB:bb[0-9]+]]
 
-  // CHECK: bb5:
-  // CHECK: function_ref @_T016if_while_binding8marker_2yyF
-  // CHECK: br bb6{{.*}}                                      // id: %15
+  // CHECK: [[SUCC_BB_2]]([[PAYLOAD2:%.*]] : $Bool):
+  // CHECK:   [[ISTRUE:%[0-9]+]] = struct_extract [[PAYLOAD2]] : $Bool, #Bool._value
+  // CHECK:   cond_br [[ISTRUE]], [[EPILOG_BB]], [[FALSE2_TRAMPOLINE_BB:bb[0-9]+]]
 
-  // CHECK: bb6:                                              // Preds: bb5 bb4 bb3
+  // CHECK: [[FALSE2_TRAMPOLINE_BB]]:
+  // CHECK:   br [[FALSE2_BB:bb[0-9]+]]
+  //
+  // CHECK: [[FALSE2_BB]]:
+  // CHECK:   function_ref @_T016if_while_binding8marker_2yyF
+  // CHECK:   br [[EPILOG_BB]]
+
+  // CHECK: [[EPILOG_BB]]:
+  // CHECK:   return
   if case false? = value {
     marker_2()
   }

--- a/test/SILGen/indirect_enum.swift
+++ b/test/SILGen/indirect_enum.swift
@@ -342,11 +342,10 @@ func guardTreeA<T>(_ tree: TreeA<T>) {
     // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
     // CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
     // CHECK:   switch_enum [[ARG_COPY]] : $TreeA<T>, case #TreeA.Nil!enumelt: [[YES:bb[0-9]+]], default [[NO:bb[0-9]+]]
-    // CHECK: [[NO]]:
-    // CHECK:   destroy_value [[ARG_COPY]]
+    // CHECK: [[NO]]([[ORIGINAL_VALUE:%.*]] : $TreeA<T>):
+    // CHECK:   destroy_value [[ORIGINAL_VALUE]]
     // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
     // CHECK: [[YES]]:
-    // CHECK:   destroy_value [[ARG_COPY]]
     // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
     guard case .Nil = tree else { return }
 
@@ -354,8 +353,8 @@ func guardTreeA<T>(_ tree: TreeA<T>) {
     // CHECK:   [[BORROWED_ARG_2:%.*]] = begin_borrow [[ARG]]
     // CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG_2]]
     // CHECK:   switch_enum [[ARG_COPY]] : $TreeA<T>, case #TreeA.Leaf!enumelt.1: [[YES:bb[0-9]+]], default [[NO:bb[0-9]+]]
-    // CHECK: [[NO]]:
-    // CHECK:   destroy_value [[ARG_COPY]]
+    // CHECK: [[NO]]([[ORIGINAL_VALUE:%.*]] : $TreeA<T>):
+    // CHECK:   destroy_value [[ORIGINAL_VALUE]]
     // CHECK:   end_borrow [[BORROWED_ARG_2]] from [[ARG]]
     // CHECK: [[YES]]([[BOX:%.*]] : $<τ_0_0> { var τ_0_0 } <T>):
     // CHECK:   [[VALUE_ADDR:%.*]] = project_box [[BOX]]
@@ -368,8 +367,8 @@ func guardTreeA<T>(_ tree: TreeA<T>) {
     // CHECK:   [[BORROWED_ARG_3:%.*]] = begin_borrow [[ARG]]
     // CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG_3]]
     // CHECK:   switch_enum [[ARG_COPY]] : $TreeA<T>, case #TreeA.Branch!enumelt.1: [[YES:bb[0-9]+]], default [[NO:bb[0-9]+]]
-    // CHECK: [[NO]]:
-    // CHECK:   destroy_value [[ARG_COPY]]
+    // CHECK: [[NO]]([[ORIGINAL_VALUE:%.*]] : $TreeA<T>):
+    // CHECK:   destroy_value [[ORIGINAL_VALUE]]
     // CHECK:   end_borrow [[BORROWED_ARG_3]] from [[ARG]]
     // CHECK: [[YES]]([[BOX:%.*]] : $<τ_0_0> { var τ_0_0 } <(left: TreeA<T>, right: TreeA<T>)>):
     // CHECK:   [[VALUE_ADDR:%.*]] = project_box [[BOX]]
@@ -395,11 +394,10 @@ func guardTreeA<T>(_ tree: TreeA<T>) {
     // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
     // CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
     // CHECK:   switch_enum [[ARG_COPY]] : $TreeA<T>, case #TreeA.Nil!enumelt: [[YES:bb[0-9]+]], default [[NO:bb[0-9]+]]
-    // CHECK: [[NO]]:
-    // CHECK:   destroy_value [[ARG_COPY]]
+    // CHECK: [[NO]]([[ORIGINAL_VALUE:%.*]] : $TreeA<T>):
+    // CHECK:   destroy_value [[ORIGINAL_VALUE]]
     // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
     // CHECK: [[YES]]:
-    // CHECK:   destroy_value [[ARG_COPY]]
     // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
     if case .Nil = tree { }
 
@@ -407,8 +405,8 @@ func guardTreeA<T>(_ tree: TreeA<T>) {
     // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
     // CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
     // CHECK:   switch_enum [[ARG_COPY]] : $TreeA<T>, case #TreeA.Leaf!enumelt.1: [[YES:bb[0-9]+]], default [[NO:bb[0-9]+]]
-    // CHECK: [[NO]]:
-    // CHECK:   destroy_value [[ARG_COPY]]
+    // CHECK: [[NO]]([[ORIGINAL_VALUE:%.*]] : $TreeA<T>):
+    // CHECK:   destroy_value [[ORIGINAL_VALUE]]
     // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
     // CHECK: [[YES]]([[BOX:%.*]] : $<τ_0_0> { var τ_0_0 } <T>):
     // CHECK:   [[VALUE_ADDR:%.*]] = project_box [[BOX]]
@@ -424,8 +422,8 @@ func guardTreeA<T>(_ tree: TreeA<T>) {
     // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
     // CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
     // CHECK:   switch_enum [[ARG_COPY]] : $TreeA<T>, case #TreeA.Branch!enumelt.1: [[YES:bb[0-9]+]], default [[NO:bb[0-9]+]]
-    // CHECK: [[NO]]:
-    // CHECK:   destroy_value [[ARG_COPY]]
+    // CHECK: [[NO]]([[ORIGINAL_VALUE:%.*]] : $TreeA<T>):
+    // CHECK:   destroy_value [[ORIGINAL_VALUE]]
     // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
     // CHECK: [[YES]]([[BOX:%.*]] : $<τ_0_0> { var τ_0_0 } <(left: TreeA<T>, right: TreeA<T>)>):
     // CHECK:   [[VALUE_ADDR:%.*]] = project_box [[BOX]]
@@ -540,22 +538,25 @@ func dontDisableCleanupOfIndirectPayload(_ x: TrivialButIndirect) {
   // CHECK: bb0([[ARG:%.*]] : $TrivialButIndirect):
   // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
   // CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
-  // CHECK:   switch_enum [[ARG_COPY]] : $TrivialButIndirect, case #TrivialButIndirect.Direct!enumelt.1:  [[YES:bb[0-9]+]], default [[NO:bb[0-9]+]]
-  // CHECK: [[NO]]:
-  // CHECK:   destroy_value [[ARG_COPY]]
+  // CHECK:   switch_enum [[ARG_COPY]] : $TrivialButIndirect, case #TrivialButIndirect.Direct!enumelt.1:  [[YES:bb[0-9]+]], case #TrivialButIndirect.Indirect!enumelt.1: [[NO:bb[0-9]+]]
+  //
+  // CHECK: [[NO]]([[PAYLOAD:%.*]] : $<τ_0_0> { var τ_0_0 } <Int>):
+  // CHECK:   destroy_value [[PAYLOAD]]
   // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
   guard case .Direct(let foo) = x else { return }
 
-  // -- Cleanup isn't necessary on "no" path because .Direct is trivial
+  // CHECK: [[YES]]({{%.*}} : $Int):
+  // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
   // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
   // CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
-  // CHECK:   switch_enum [[ARG_COPY]] : $TrivialButIndirect, case #TrivialButIndirect.Indirect!enumelt.1:  [[YES:bb[0-9]+]], default [[NO:bb[0-9]+]]
+  // CHECK:   switch_enum [[ARG_COPY]] : $TrivialButIndirect, case #TrivialButIndirect.Indirect!enumelt.1:  [[YES:bb[0-9]+]], case #TrivialButIndirect.Direct!enumelt.1: [[NO:bb[0-9]+]]
 
-  // => SEMANTIC SIL TODO: This test case needs to be extended below
-  // CHECK: [[NO]]:
+  // CHECK: [[NO]]({{%.*}} : $Int):
+  // CHECK-NOT: destroy_value
   // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
 
-  // CHECK: [[YES]]({{.*}}):
+  // CHECK: [[YES]]([[BOX:%.*]] : $<τ_0_0> { var τ_0_0 } <Int>):
+  // CHECK:   destroy_value [[BOX]]
 
   guard case .Indirect(let bar) = x else { return }
 }

--- a/test/SILGen/opaque_values_silgen.swift
+++ b/test/SILGen/opaque_values_silgen.swift
@@ -756,21 +756,28 @@ func s350_______addrOnlyIf(x: Bool) -> EmptyP {
 // CHECK: bb0([[ARG:%.*]] : $IndirectEnum<T>):
 // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
 // CHECK:   [[COPY__ARG:%.*]] = copy_value [[BORROWED_ARG]]
-// CHECK:   switch_enum [[COPY__ARG]] : $IndirectEnum<T>, case #IndirectEnum.Node!enumelt.1: bb3, default bb1
-// CHECK: bb1:
+// CHECK:   switch_enum [[COPY__ARG]] : $IndirectEnum<T>, case #IndirectEnum.Node!enumelt.1: [[NODE_BB:bb[0-9]+]], case #IndirectEnum.Nil!enumelt: [[NIL_BB:bb[0-9]+]]
+//
+// CHECK: [[NIL_BB]]:
 // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]] : $IndirectEnum<T>, $IndirectEnum<T>
-// CHECK:   br bb2
-// CHECK: bb2:
-// CHECK:   br bb4
-// CHECK: bb3([[EARG:%.*]] : $<τ_0_0> { var τ_0_0 } <T>):
+// CHECK:   br [[NIL_TRAMPOLINE:bb[0-9]+]]
+//
+// CHECK: [[NIL_TRAMPOLINE]]:
+// CHECK:   br [[EPILOG_BB:bb[0-9]+]]
+//
+// CHECK: [[NODE_BB]]([[EARG:%.*]] : $<τ_0_0> { var τ_0_0 } <T>):
 // CHECK:   [[PROJ_BOX:%.*]] = project_box [[EARG]]
 // CHECK:   [[LOAD_BOX:%.*]] = load [take] [[PROJ_BOX]] : $*T
 // CHECK:   [[COPY_BOX:%.*]] = copy_value [[LOAD_BOX]] : $T
 // CHECK:   destroy_value [[EARG]]
+// CHECK:   br [[CONT_BB:bb[0-9]+]]
+//
+// CHECK: [[CONT_BB]]:
 // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]] : $IndirectEnum<T>, $IndirectEnum<T>
 // CHECK:   destroy_value [[COPY_BOX]]
-// CHECK:   br bb4
-// CHECK: bb4:
+// CHECK:   br [[EPILOG_BB]]
+//
+// CHECK: [[EPILOG_BB]]:
 // CHECK:   destroy_value [[ARG]]
 // CHECK:   return %{{.*}} : $()
 // CHECK-LABEL: } // end sil function '_T020opaque_values_silgen21s360________guardEnumyAA08IndirectF0OyxGlF'
@@ -909,21 +916,30 @@ func s430_callUnreachableF<T>(t: T) {
 // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
 // CHECK:   [[COPY_ARG:%.*]] = copy_value [[BORROWED_ARG]]
 // CHECK:   checked_cast_value_br [[COPY_ARG]] : $T to $EmptyP, bb2, bb1
+//
 // CHECK: bb2([[PTYPE:%.*]] : $EmptyP):
 // CHECK:   [[PSOME:%.*]] = enum $Optional<EmptyP>, #Optional.some!enumelt.1, [[PTYPE]] : $EmptyP
 // CHECK:   br bb3([[PSOME]] : $Optional<EmptyP>)
+//
 // CHECK: bb3([[ENUMRES:%.*]] : $Optional<EmptyP>):
-// CHECK:   switch_enum [[ENUMRES]] : $Optional<EmptyP>, case #Optional.some!enumelt.1: bb6, default bb4
-// CHECK: bb4:
+// CHECK:   switch_enum [[ENUMRES]] : $Optional<EmptyP>, case #Optional.some!enumelt.1: [[SOME_BB:bb[0-9]+]], case #Optional.none!enumelt: [[NONE_BB:bb[0-9]+]]
+//
+// CHECK: [[NONE_BB]]:
 // CHECK:   end_borrow [[BORROWED_ARG]]
-// CHECK:   br bb5
-// CHECK: bb5:
-// CHECK:   br bb7
-// CHECK: bb6([[ENUMRES2:%.*]] : $EmptyP):
+// CHECK:   br [[NONE_TRAMPOLINE:bb[0-9]+]]
+//
+// CHECK: [[NONE_TRAMPOLINE]]:
+// CHECK:   br [[EPILOG_BB:bb[0-9]+]]
+//
+// CHECK: [[SOME_BB]]([[ENUMRES2:%.*]] : $EmptyP):
+// CHECK:   br [[CONT_BB:bb[0-9]+]]
+//
+// CHECK: [[CONT_BB]]:
 // CHECK:   end_borrow [[BORROWED_ARG]]
 // CHECK:   destroy_value [[ENUMRES2]]
-// CHECK:   br bb7
-// CHECK: bb7:
+// CHECK:   br [[EPILOG_BB]]
+//
+// CHECK: [[EPILOG_BB]]:
 // CHECK:   destroy_value [[ARG]]
 // CHECK:   return %{{.*}} : $()
 // CHECK-LABEL: } // end sil function '_T020opaque_values_silgen21s440__cleanupEmissionyxlF'

--- a/test/SILGen/statements.swift
+++ b/test/SILGen/statements.swift
@@ -245,7 +245,7 @@ func test_if_break(_ c : C?) {
 label1:
   // CHECK: [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
   // CHECK: [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
-  // CHECK: switch_enum [[ARG_COPY]] : $Optional<C>, case #Optional.some!enumelt.1: [[TRUE:bb[0-9]+]], default [[FALSE:bb[0-9]+]]
+  // CHECK: switch_enum [[ARG_COPY]] : $Optional<C>, case #Optional.some!enumelt.1: [[TRUE:bb[0-9]+]], case #Optional.none!enumelt: [[FALSE:bb[0-9]+]]
   if let x = c {
 // CHECK: [[TRUE]]({{.*}} : $C):
 
@@ -268,7 +268,7 @@ func test_if_else_break(_ c : C?) {
 label2:
   // CHECK: [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
   // CHECK: [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
-  // CHECK: switch_enum [[ARG_COPY]] : $Optional<C>, case #Optional.some!enumelt.1: [[TRUE:bb[0-9]+]], default [[FALSE:bb[0-9]+]]
+  // CHECK: switch_enum [[ARG_COPY]] : $Optional<C>, case #Optional.some!enumelt.1: [[TRUE:bb[0-9]+]], case #Optional.none!enumelt: [[FALSE:bb[0-9]+]]
 
   // CHECK: [[FALSE]]:
   // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
@@ -276,16 +276,18 @@ label2:
   if let x = c {
     // CHECK: [[TRUE]]({{.*}} : $C):
     use(x)
-    // CHECK: br [[CONT:bb[0-9]+]]
+    // CHECK:   br [[CONT:bb[0-9]+]]
+    // CHECK: [[CONT]]:
+    // CHECK:   br [[EPILOG:bb[0-9]+]]
   } else {
     // CHECK: [[AFTER_FALSE]]:
     // CHECK: apply
-    // CHECK: br [[CONT]]
+    // CHECK: br [[EPILOG]]
     foo()
     break label2
     foo() // expected-warning {{will never be executed}}
   }
-  // CHECK: [[CONT]]:
+  // CHECK: [[EPILOG]]:
   // CHECK: return
 }
 
@@ -295,28 +297,33 @@ label3:
   // CHECK: bb0({{.*}}, [[ARG2:%.*]] : $Optional<C>):
   // CHECK: [[BORROWED_ARG2:%.*]] = begin_borrow [[ARG2]]
   // CHECK: [[ARG2_COPY:%.*]] = copy_value [[BORROWED_ARG2]]
-  // CHECK: switch_enum [[ARG2_COPY]] : $Optional<C>, case #Optional.some!enumelt.1: [[TRUE:bb[0-9]+]], default [[FALSE:bb[0-9]+]]
+  // CHECK: switch_enum [[ARG2_COPY]] : $Optional<C>, case #Optional.some!enumelt.1: [[TRUE:bb[0-9]+]], case #Optional.none!enumelt: [[FALSE:bb[0-9]+]]
 
   // CHECK: [[FALSE]]:
   // CHECK:   end_borrow [[BORROWED_ARG2]] from [[ARG2]]
-  // CHECK:   br [[FALSE_2:bb[0-9]+]]
+  // CHECK:   br [[COND2:bb[0-9]+]]
   if let x = c {
     // CHECK: [[TRUE]]({{.*}} : $C):
     use(x)
-    // CHECK: br [[CONT:bb[0-9]+]]
+    // CHECK:   br [[TRUE_TRAMPOLINE:bb[0-9]+]]
+    //
+    // CHECK: [[TRUE_TRAMPOLINE]]:
+    // CHECK:   br [[EPILOG_BB:bb[0-9]+]]
   } else if a {
-    // CHECK: [[FALSE_2]]:
-    // CHECK: cond_br {{.*}}, [[TRUE2:bb[0-9]+]], [[FALSE2:bb[0-9]+]]
-    // CHECK: apply
-    // CHECK: br [[CONT]]
+    // CHECK: [[COND2]]:
+    // CHECK:   cond_br {{.*}}, [[TRUE2:bb[0-9]+]], [[FALSE2:bb[0-9]+]]
+    //
+    // CHECK: [[TRUE2]]:
+    // CHECK:   apply
+    // CHECK:   br [[EPILOG_BB]]
     foo()
     break label3
     foo()    // expected-warning {{will never be executed}}
   }
-
   // CHECK: [[FALSE2]]:
-  // CHECK: br [[CONT]]
-  // CHECK: [[CONT]]:
+  // CHECK: br [[EPILOG_BB]]
+
+  // CHECK: [[EPILOG_BB]]:
   // CHECK: return
 
 
@@ -569,20 +576,26 @@ func testRequireExprPattern(_ a : Int) {
 
 
 // CHECK-LABEL: sil hidden @_T010statements20testRequireOptional1S2iSgF
-// CHECK: bb0(%0 : $Optional<Int>):
-// CHECK-NEXT:   debug_value %0 : $Optional<Int>, let, name "a"
-// CHECK-NEXT:   switch_enum %0 : $Optional<Int>, case #Optional.some!enumelt.1: bb1, default bb2
+// CHECK: bb0([[ARG:%.*]] : $Optional<Int>):
+// CHECK-NEXT:   debug_value [[ARG]] : $Optional<Int>, let, name "a"
+// CHECK-NEXT:   switch_enum [[ARG]] : $Optional<Int>, case #Optional.some!enumelt.1: [[SOME:bb[0-9]+]], case #Optional.none!enumelt: [[NONE:bb[0-9]+]]
 func testRequireOptional1(_ a : Int?) -> Int {
 
-  // CHECK: bb1(%3 : $Int):
-  // CHECK-NEXT:   debug_value %3 : $Int, let, name "t"
-  // CHECK-NEXT:   return %3 : $Int
+  // CHECK: [[NONE]]:
+  // CHECK:   br [[ABORT:bb[0-9]+]]
+
+  // CHECK: [[SOME]]([[PAYLOAD:%.*]] : $Int):
+  // CHECK-NEXT:   debug_value [[PAYLOAD]] : $Int, let, name "t"
+  // CHECK-NEXT:   br [[EPILOG:bb[0-9]+]]
+  //
+  // CHECK: [[EPILOG]]:
+  // CHECK-NEXT:   return [[PAYLOAD]] : $Int
   guard let t = a else { abort() }
 
-  // CHECK:  bb2:
+  // CHECK:  [[ABORT]]:
   // CHECK-NEXT:    // function_ref statements.abort () -> Swift.Never
-  // CHECK-NEXT:    %6 = function_ref @_T010statements5aborts5NeverOyF
-  // CHECK-NEXT:    %7 = apply %6() : $@convention(thin) () -> Never
+  // CHECK-NEXT:    [[FUNC_REF:%.*]] = function_ref @_T010statements5aborts5NeverOyF
+  // CHECK-NEXT:    apply [[FUNC_REF]]() : $@convention(thin) () -> Never
   // CHECK-NEXT:    unreachable
   return t
 }
@@ -592,16 +605,19 @@ func testRequireOptional1(_ a : Int?) -> Int {
 // CHECK-NEXT:   debug_value [[ARG]] : $Optional<String>, let, name "a"
 // CHECK-NEXT:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
 // CHECK-NEXT:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]] : $Optional<String>
-// CHECK-NEXT:   switch_enum [[ARG_COPY]] : $Optional<String>, case #Optional.some!enumelt.1: bb2, default bb1
+// CHECK-NEXT:   switch_enum [[ARG_COPY]] : $Optional<String>, case #Optional.some!enumelt.1: [[SOME_BB:bb[0-9]+]], case #Optional.none!enumelt: [[NONE_BB:bb[0-9]+]]
 func testRequireOptional2(_ a : String?) -> String {
   guard let t = a else { abort() }
 
-  // CHECK: bb1:
+  // CHECK: [[NONE_BB]]:
   // CHECK-NEXT: end_borrow [[BORROWED_ARG]] from [[ARG]]
+  // CHECK-NEXT: br [[ABORT_BB:bb[0-9]+]]
   
-  // CHECK:  bb2([[STR:%.*]] : $String):
+  // CHECK:  [[SOME_BB]]([[STR:%.*]] : $String):
   // CHECK-NEXT:   debug_value [[STR]] : $String, let, name "t"
-  // CHECK-NEXT: end_borrow [[BORROWED_ARG]] from [[ARG]]
+  // CHECK-NEXT:   br [[CONT_BB:bb[0-9]+]]
+  // CHECK:  [[CONT_BB]]:
+  // CHECK-NEXT:   end_borrow [[BORROWED_ARG]] from [[ARG]]
   // CHECK-NEXT:   [[BORROWED_STR:%.*]] = begin_borrow [[STR]]
   // CHECK-NEXT:   [[RETURN:%.*]] = copy_value [[BORROWED_STR]]
   // CHECK-NEXT:   end_borrow [[BORROWED_STR]] from [[STR]]
@@ -609,7 +625,7 @@ func testRequireOptional2(_ a : String?) -> String {
   // CHECK-NEXT:   destroy_value [[ARG]]
   // CHECK-NEXT:   return [[RETURN]] : $String
 
-  // CHECK:        bb3:
+  // CHECK:        [[ABORT_BB]]:
   // CHECK-NEXT:   // function_ref statements.abort () -> Swift.Never
   // CHECK-NEXT:   [[ABORT_FUNC:%.*]] = function_ref @_T010statements5aborts5NeverOyF
   // CHECK-NEXT:   [[NEVER:%.*]] = apply [[ABORT_FUNC]]()
@@ -648,6 +664,8 @@ func test_as_pattern(_ y : BaseClass) -> DerivedClass {
 
   // CHECK: bb{{.*}}([[PTR:%[0-9]+]] : $DerivedClass):
   // CHECK-NEXT: debug_value [[PTR]] : $DerivedClass, let, name "result"
+  // CHECK-NEXT: br [[CONT_BB:bb[0-9]+]]
+  // CHECK: [[CONT_BB]]:
   // CHECK-NEXT: end_borrow [[BORROWED_ARG]] from [[ARG]]
   // CHECK-NEXT: [[BORROWED_PTR:%.*]] = begin_borrow [[PTR]]
   // CHECK-NEXT: [[RESULT:%.*]] = copy_value [[BORROWED_PTR]]
@@ -660,19 +678,21 @@ func test_as_pattern(_ y : BaseClass) -> DerivedClass {
 // CHECK-LABEL: sil hidden @_T010statements22let_else_tuple_bindingS2i_SitSgF
 func let_else_tuple_binding(_ a : (Int, Int)?) -> Int {
 
-  // CHECK: bb0(%0 : $Optional<(Int, Int)>):
-  // CHECK-NEXT:   debug_value %0 : $Optional<(Int, Int)>, let, name "a"
-  // CHECK-NEXT:   switch_enum %0 : $Optional<(Int, Int)>, case #Optional.some!enumelt.1: bb1, default bb2
+  // CHECK: bb0([[ARG:%.*]] : $Optional<(Int, Int)>):
+  // CHECK-NEXT:   debug_value [[ARG]] : $Optional<(Int, Int)>, let, name "a"
+  // CHECK-NEXT:   switch_enum [[ARG]] : $Optional<(Int, Int)>, case #Optional.some!enumelt.1: [[SOME_BB:bb[0-9]+]], case #Optional.none!enumelt: [[NONE_BB:bb[0-9]+]]
 
   guard let (x, y) = a else { }
   _ = y
   return x
 
-  // CHECK: bb1(%3 : $(Int, Int)):
-  // CHECK-NEXT:   %4 = tuple_extract %3 : $(Int, Int), 0
-  // CHECK-NEXT:   debug_value %4 : $Int, let, name "x"
-  // CHECK-NEXT:   %6 = tuple_extract %3 : $(Int, Int), 1
-  // CHECK-NEXT:   debug_value %6 : $Int, let, name "y"
-  // CHECK-NEXT:   return %4 : $Int
+  // CHECK: [[SOME_BB]]([[PAYLOAD:%.*]] : $(Int, Int)):
+  // CHECK-NEXT:   [[PAYLOAD_1:%.*]] = tuple_extract [[PAYLOAD]] : $(Int, Int), 0
+  // CHECK-NEXT:   debug_value [[PAYLOAD_1]] : $Int, let, name "x"
+  // CHECK-NEXT:   [[PAYLOAD_2:%.*]] = tuple_extract [[PAYLOAD]] : $(Int, Int), 1
+  // CHECK-NEXT:   debug_value [[PAYLOAD_2]] : $Int, let, name "y"
+  // CHECK-NEXT:   br [[CONT_BB:bb[0-9]+]]
+  // CHECK: [[CONT_BB]]:
+  // CHECK-NEXT:   return [[PAYLOAD_1]] : $Int
 }
 

--- a/test/SILGen/toplevel.swift
+++ b/test/SILGen/toplevel.swift
@@ -72,7 +72,7 @@ print_y()
 
 // -- treat 'guard' vars as locals
 // CHECK-LABEL: function_ref toplevel.A.__allocating_init
-// CHECK: switch_enum {{%.+}} : $Optional<A>, case #Optional.some!enumelt.1: [[SOME_CASE:.+]], default
+// CHECK: switch_enum {{%.+}} : $Optional<A>, case #Optional.some!enumelt.1: [[SOME_CASE:.+]], case #Optional.none!
 // CHECK: [[SOME_CASE]]([[VALUE:%.+]] : $A):
 // CHECK: store [[VALUE]] to [init] [[BOX:%.+]] : $*A
 // CHECK-NOT: destroy_value


### PR DESCRIPTION
[silgen] Fix up EnumElementPatternInitialization::emitEnumMatch to use ownership.

This commit does a few things:

1. It uses SwitchEnumBuilder so we are not re-inventing any wheels.
2. Instead of hacking around not putting in a destroy for .None on the fail
pass, just *do the right thing* and recognize that we have a binary case enum
and in such a case, just emit code for the other case rather than use a default
case (meaning no cleanup on .none).

rdar://31145255
