### PR TITLE
Pass CLANG_VERSION_* cmake flags to the LLVM build.

### DIFF
--- a/utils/swift_build_support/swift_build_support/cmake.py
+++ b/utils/swift_build_support/swift_build_support/cmake.py
@@ -111,11 +111,15 @@ class CMake(object):
             define("CMAKE_CONFIGURATION_TYPES",
                    "Debug;Release;MinSizeRel;RelWithDebInfo")
 
-        if args.clang_compiler_version:
-            major, minor, patch, _ = args.clang_compiler_version.components
+        if args.clang_user_visible_version:
+            major, minor, patch, _ = args.clang_user_visible_version.components
             define("LLVM_VERSION_MAJOR:STRING", major)
             define("LLVM_VERSION_MINOR:STRING", minor)
             define("LLVM_VERSION_PATCH:STRING", patch)
+            define("CLANG_VERSION_MAJOR:STRING", major)
+            define("CLANG_VERSION_MINOR:STRING", minor)
+            define("CLANG_VERSION_PATCH:STRING", patch)
+
 
         if args.build_ninja and args.cmake_generator == 'Ninja':
             define('CMAKE_MAKE_PROGRAM', toolchain.ninja)

--- a/utils/swift_build_support/tests/test_cmake.py
+++ b/utils/swift_build_support/tests/test_cmake.py
@@ -37,6 +37,7 @@ class CMakeTestCase(unittest.TestCase):
                          distcc=False,
                          cmake_generator="Ninja",
                          clang_compiler_version=None,
+                         clang_user_visible_version=None,
                          build_jobs=8,
                          build_args=[],
                          verbose_build=False,
@@ -187,17 +188,33 @@ class CMakeTestCase(unittest.TestCase):
     def test_common_options_clang_compiler_version(self):
         args = self.default_args()
         args.clang_compiler_version = CompilerVersion(
-            string_representation="3.8.0",
-            components=("3", "8", "0", None))
+            string_representation="999.0.999",
+            components=("999", "0", "999", None))
         cmake = self.cmake(args)
         self.assertEqual(
             list(cmake.common_options()),
             ["-G", "Ninja",
              "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
              "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
-             "-DLLVM_VERSION_MAJOR:STRING=3",
-             "-DLLVM_VERSION_MINOR:STRING=8",
+             "-DCMAKE_MAKE_PROGRAM=" + self.which_ninja(args)])
+
+    def test_common_options_clang_user_visible_version(self):
+        args = self.default_args()
+        args.clang_user_visible_version = CompilerVersion(
+            string_representation="9.0.0",
+            components=("9", "0", "0", None))
+        cmake = self.cmake(args)
+        self.assertEqual(
+            list(cmake.common_options()),
+            ["-G", "Ninja",
+             "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
+             "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
+             "-DLLVM_VERSION_MAJOR:STRING=9",
+             "-DLLVM_VERSION_MINOR:STRING=0",
              "-DLLVM_VERSION_PATCH:STRING=0",
+             "-DCLANG_VERSION_MAJOR:STRING=9",
+             "-DCLANG_VERSION_MINOR:STRING=0",
+             "-DCLANG_VERSION_PATCH:STRING=0",
              "-DCMAKE_MAKE_PROGRAM=" + self.which_ninja(args)])
 
     def test_common_options_build_ninja(self):
@@ -218,9 +235,12 @@ class CMakeTestCase(unittest.TestCase):
         args.export_compile_commands = True
         args.distcc = True
         args.cmake_generator = 'Xcode'
+        args.clang_user_visible_version = CompilerVersion(
+            string_representation="9.0.0",
+            components=("9", "0", "0", None))
         args.clang_compiler_version = CompilerVersion(
-            string_representation="3.8.0",
-            components=("3", "8", "0", None))
+            string_representation="999.0.900",
+            components=("999", "0", "900", None))
         args.build_ninja = True
         cmake = self.cmake(args)
         self.assertEqual(
@@ -234,9 +254,12 @@ class CMakeTestCase(unittest.TestCase):
              "-DCMAKE_CXX_COMPILER_ARG1=/path/to/clang++",
              "-DCMAKE_CONFIGURATION_TYPES=" +
              "Debug;Release;MinSizeRel;RelWithDebInfo",
-             "-DLLVM_VERSION_MAJOR:STRING=3",
-             "-DLLVM_VERSION_MINOR:STRING=8",
-             "-DLLVM_VERSION_PATCH:STRING=0"])
+             "-DLLVM_VERSION_MAJOR:STRING=9",
+             "-DLLVM_VERSION_MINOR:STRING=0",
+             "-DLLVM_VERSION_PATCH:STRING=0",
+             "-DCLANG_VERSION_MAJOR:STRING=9",
+             "-DCLANG_VERSION_MINOR:STRING=0",
+             "-DCLANG_VERSION_PATCH:STRING=0"])
         # NOTE: No "-DCMAKE_MAKE_PROGRAM=/path/to/built/ninja" because
         #       cmake_generator is 'Xcode'
 


### PR DESCRIPTION
In a normal swiftless clang build, if it doesnt know CLANG_VERSION_*,
clang's cmake falls back on LLVM_VERSION_*. We pass a CLANG_COMPILER_VERSION
to swift, but it is not necessarily what clang wants to know.

The intention of this CLANG_VERSION_* flag in Clang is to know
what Swift calls clang_user_visible_version. This is the non-specific
version of Clang. For example, clang-900 - this is 9.0.0, while Swift
would like clang_compiler_version to be the specific version that the
driver will print out.

Flag naming!

Fix tests

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
