### PR TITLE
[build-script] Set the TOOLCHAINS variable in the environment.

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -2173,6 +2173,7 @@ iterations with -O",
 
     # Prepare and validate toolchain
     toolchain = host_toolchain(xcrun_toolchain=args.darwin_xcrun_toolchain)
+    os.environ['TOOLCHAINS'] = args.darwin_xcrun_toolchain
 
     if args.host_cc is not None:
         toolchain.cc = args.host_cc


### PR DESCRIPTION
Set TOOLCHAINS in the environment so that we use the linker from the toolchain specified by the build-script's darwin-xcrun-toolchain option.