### PR TITLE
SIL: Only give closures shared linkage if they're going to be serialized

### DIFF
--- a/lib/SIL/SILDeclRef.cpp
+++ b/lib/SIL/SILDeclRef.cpp
@@ -415,19 +415,23 @@ bool SILDeclRef::isImplicit() const {
 }
 
 SILLinkage SILDeclRef::getLinkage(ForDefinition_t forDefinition) const {
-  // Anonymous functions have shared linkage.
-  // FIXME: This should really be the linkage of the parent function.
-  if (getAbstractClosureExpr())
-    return SILLinkage::Shared;
-  
+  if (auto *ace = getAbstractClosureExpr()) {
+    if (isSerialized())
+      return SILLinkage::Shared;
+    return SILLinkage::Private;
+  }
+
   // Native function-local declarations have shared linkage.
   // FIXME: @objc declarations should be too, but we currently have no way
   // of marking them "used" other than making them external. 
   ValueDecl *d = getDecl();
   DeclContext *moduleContext = d->getDeclContext();
   while (!moduleContext->isModuleScopeContext()) {
-    if (!isForeign && moduleContext->isLocalContext())
-      return SILLinkage::Shared;
+    if (!isForeign && moduleContext->isLocalContext()) {
+      if (isSerialized())
+        return SILLinkage::Shared;
+      return SILLinkage::Private;
+    }
     moduleContext = moduleContext->getParent();
   }
 

--- a/test/DebugInfo/autoclosure.swift
+++ b/test/DebugInfo/autoclosure.swift
@@ -21,7 +21,7 @@ func &&&&&(lhs: Bool, rhs: @autoclosure () -> Bool) -> Bool {
 func call_me(_ input: Int64) -> Void {
 // rdar://problem/14627460
 // An autoclosure should have a line number in the debug info and a scope line of 0.
-// CHECK-DAG: !DISubprogram({{.*}}linkageName: "_T011autoclosure7call_meys5Int64VFSbyXKfu_",{{.*}} line: [[@LINE+3]],{{.*}} isLocal: false, isDefinition: true
+// CHECK-DAG: !DISubprogram({{.*}}linkageName: "_T011autoclosure7call_meys5Int64VFSbyXKfu_",{{.*}} line: [[@LINE+3]],{{.*}} isLocal: true, isDefinition: true
 // But not in the line table.
 // CHECK-DAG: ![[DBG]] = !DILocation(line: [[@LINE+1]],
   if input != 0 &&&&& ( get_truth (input * 2 + 1) > 0 ) {

--- a/test/DebugInfo/closure-args.swift
+++ b/test/DebugInfo/closure-args.swift
@@ -10,7 +10,7 @@ func main() -> Void
     var out_only = 2013
 
     var backward_ptr  =
-    // CHECK: define linkonce_odr hidden {{.*}} i1 @_T04mainAAyyFSbSS_SStcfU_(
+    // CHECK: define internal {{.*}} i1 @_T04mainAAyyFSbSS_SStcfU_(
     // CHECK: %[[RANDOM_STR_ADDR:.*]] = alloca %TSS*, align {{(4|8)}}
     // CHECK: store %TSS* %{{.*}}, %TSS** %[[RANDOM_STR_ADDR]], align {{(4|8)}}
     // CHECK-NEXT: call void @llvm.dbg.declare(metadata %TSS** %[[RANDOM_STR_ADDR]], metadata !{{.*}}, metadata !{{[0-9]+}}), !dbg

--- a/test/IRGen/c_globals.swift
+++ b/test/IRGen/c_globals.swift
@@ -20,7 +20,7 @@ public func testCaptureGlobal() {
   var f: Float = 0
   var i: CInt = 0
   var s: UnsafePointer<CChar>! = nil
-  // CHECK-LABEL: define linkonce_odr hidden swiftcc void @_T09c_globals17testCaptureGlobalyyFyycfU_{{.*}} {
+  // CHECK-LABEL: define internal swiftcc void @_T09c_globals17testCaptureGlobalyyFyycfU_{{.*}} {
   blackHole({ () -> Void in
     // CHECK: @staticFloat
     // CHECK: @staticInt

--- a/test/IRGen/closure.swift
+++ b/test/IRGen/closure.swift
@@ -11,7 +11,7 @@ func a(i i: Int) -> (Int) -> Int {
 }
 
 // -- Closure entry point
-// CHECK: define linkonce_odr hidden swiftcc i64 @_T07closure1aS2icSi1i_tFS2icfU_(i64, i64)
+// CHECK: define internal swiftcc i64 @_T07closure1aS2icSi1i_tFS2icfU_(i64, i64)
 
 protocol Ordinable {
   func ord() -> Int
@@ -26,7 +26,7 @@ func b<T : Ordinable>(seq seq: T) -> (Int) -> Int {
 // CHECK: }
 
 // -- Closure entry point
-// CHECK: define linkonce_odr hidden swiftcc i64 @_T07closure1bS2icx3seq_tAA9OrdinableRzlFS2icfU_(i64, %swift.refcounted*, %swift.type* %T, i8** %T.Ordinable) {{.*}} {
+// CHECK: define internal swiftcc i64 @_T07closure1bS2icx3seq_tAA9OrdinableRzlFS2icfU_(i64, %swift.refcounted*, %swift.type* %T, i8** %T.Ordinable) {{.*}} {
 
 // -- partial_apply stub
 // CHECK: define internal swiftcc i64 @_T07closure1bS2icx3seq_tAA9OrdinableRzlFS2icfU_TA(i64, %swift.refcounted* swiftself) {{.*}} {

--- a/test/SILGen/auto_closures.swift
+++ b/test/SILGen/auto_closures.swift
@@ -48,7 +48,7 @@ public class Sub : Base {
   // CHECK: return [[RET]] : $Bool
   // CHECK: }
 
-  // CHECK-LABEL: sil shared [transparent] @_T013auto_closures3SubC1xAA4BoolVfgAFyXKfu_ : $@convention(thin) (@owned Sub) -> Bool {
+  // CHECK-LABEL: sil private [transparent] @_T013auto_closures3SubC1xAA4BoolVfgAFyXKfu_ : $@convention(thin) (@owned Sub) -> Bool {
   // CHECK: [[SUPER:%[0-9]+]] = function_ref @_T013auto_closures4BaseC1xAA4BoolVfg : $@convention(method) (@guaranteed Base) -> Bool
   // CHECK: [[RET:%.*]] = apply [[SUPER]]({{%.*}})
   // CHECK: return [[RET]]
@@ -57,9 +57,9 @@ public class Sub : Base {
 
 // CHECK-LABEL: sil hidden @_T013auto_closures20closureInAutoclosureAA4BoolVAD_ADtF : $@convention(thin) (Bool, Bool) -> Bool {
 // CHECK: }
-// CHECK-LABEL: sil shared [transparent] @_T013auto_closures20closureInAutoclosureAA4BoolVAD_ADtFADyXKfu_ : $@convention(thin) (Bool, Bool) -> Bool {
+// CHECK-LABEL: sil private [transparent] @_T013auto_closures20closureInAutoclosureAA4BoolVAD_ADtFADyXKfu_ : $@convention(thin) (Bool, Bool) -> Bool {
 // CHECK: }
-// CHECK-LABEL: sil shared @_T013auto_closures20closureInAutoclosureAA4BoolVAD_ADtFADyXKfu_A2DcfU_ : $@convention(thin) (Bool, Bool) -> Bool {
+// CHECK-LABEL: sil private @_T013auto_closures20closureInAutoclosureAA4BoolVAD_ADtFADyXKfu_A2DcfU_ : $@convention(thin) (Bool, Bool) -> Bool {
 // CHECK: }
 func compareBool(_ lhs: Bool, _ rhs: Bool) -> Bool { return false_ }
 func testBool(_ x: Bool, _ pred: (Bool) -> Bool) -> Bool {

--- a/test/SILGen/c_function_pointers.swift
+++ b/test/SILGen/c_function_pointers.swift
@@ -54,8 +54,8 @@ func pointers_to_bad_swift_functions(_ x: Int) {
   calls(unsupported, x) // expected-error{{C function pointer signature '(Any) -> Int' is not compatible with expected type '@convention(c) (Int) -> Int'}}
 }
 
-// CHECK-LABEL: sil shared @_T019c_function_pointers22StructWithInitializersV3fn1yyXCvfiyycfU_ : $@convention(thin) () -> () {
-// CHECK-LABEL: sil shared [thunk] @_T019c_function_pointers22StructWithInitializersV3fn1yyXCvfiyycfU_To : $@convention(c) () -> () {
+// CHECK-LABEL: sil private @_T019c_function_pointers22StructWithInitializersV3fn1yyXCvfiyycfU_ : $@convention(thin) () -> () {
+// CHECK-LABEL: sil private [thunk] @_T019c_function_pointers22StructWithInitializersV3fn1yyXCvfiyycfU_To : $@convention(c) () -> () {
 
 struct StructWithInitializers {
   let fn1: @convention(c) () -> () = {}

--- a/test/SILGen/capture-canonicalization.swift
+++ b/test/SILGen/capture-canonicalization.swift
@@ -5,7 +5,7 @@ struct Bar {}
 
 extension Foo where T == Bar {
   func foo(x: T) -> Bar {
-    // CHECK-LABEL: sil shared @{{.*}}3foo{{.*}}4foo2{{.*}} : $@convention(thin) (Bar) -> Bar
+    // CHECK-LABEL: sil private @{{.*}}3foo{{.*}}4foo2{{.*}} : $@convention(thin) (Bar) -> Bar
     func foo2() -> Bar {
       return x
     }

--- a/test/SILGen/capture_inout.swift
+++ b/test/SILGen/capture_inout.swift
@@ -8,7 +8,7 @@ typealias Int = Builtin.Int64
 // CHECK:   [[FUNC:%.*]] = function_ref [[CLOSURE:@.*]] : $@convention(thin) (@inout_aliasable Builtin.Int64) -> Builtin.Int64
 // CHECK:   apply [[FUNC]]([[X_INOUT]])
 // CHECK: }
-// CHECK: sil shared [[CLOSURE]] : $@convention(thin) (@inout_aliasable Builtin.Int64) -> Builtin.Int64
+// CHECK: sil private [[CLOSURE]] : $@convention(thin) (@inout_aliasable Builtin.Int64) -> Builtin.Int64
 func localFoo(x: inout Int) {
   func bar() -> Int {
     return x
@@ -22,7 +22,7 @@ func localFoo(x: inout Int) {
 // CHECK:   [[FUNC:%.*]] = function_ref [[CLOSURE:@.*]] : $@convention(thin) (@inout_aliasable Builtin.Int64) -> Builtin.Int64
 // CHECK:   apply [[FUNC]]([[X_INOUT]])
 // CHECK: }
-// CHECK: sil shared [[CLOSURE]] : $@convention(thin) (@inout_aliasable Builtin.Int64) -> Builtin.Int64
+// CHECK: sil private [[CLOSURE]] : $@convention(thin) (@inout_aliasable Builtin.Int64) -> Builtin.Int64
 func anonFoo(x: inout Int) {
   { return x }()
 }

--- a/test/SILGen/capture_typealias.swift
+++ b/test/SILGen/capture_typealias.swift
@@ -19,4 +19,4 @@ func foo() {
   }
 }
 
-// CHECK: sil shared @_T017capture_typealias3fooyyFBi64_ycfU_ : $@convention(thin) () -> Builtin.Int64 {
+// CHECK: sil private @_T017capture_typealias3fooyyFBi64_ycfU_ : $@convention(thin) () -> Builtin.Int64 {

--- a/test/SILGen/capture_typed_boxes.swift
+++ b/test/SILGen/capture_typed_boxes.swift
@@ -4,7 +4,7 @@ func foo(_ x: Int) -> () -> Int {
   var x = x
   return { x }
 }
-// CHECK-LABEL: sil shared @_T019capture_typed_boxes3fooSiycSiFSiycfU_ : $@convention(thin) (@owned { var Int }) -> Int {
+// CHECK-LABEL: sil private @_T019capture_typed_boxes3fooSiycSiFSiycfU_ : $@convention(thin) (@owned { var Int }) -> Int {
 // CHECK:       bb0(%0 : ${ var Int }):
 
 func closure(_ f: @escaping (Int) -> Int) -> Int {
@@ -15,7 +15,7 @@ func closure(_ f: @escaping (Int) -> Int) -> Int {
 
   return bar(0)
 }
-// CHECK-LABEL: sil shared @_T019capture_typed_boxes7closureS3icF3barL_S2iF : $@convention(thin) (Int, @owned { var @callee_owned (Int) -> Int }) -> Int {
+// CHECK-LABEL: sil private @_T019capture_typed_boxes7closureS3icF3barL_S2iF : $@convention(thin) (Int, @owned { var @callee_owned (Int) -> Int }) -> Int {
 // CHECK:       bb0(%0 : $Int, %1 : ${ var @callee_owned (Int) -> Int }):
 
 func closure_generic<T>(_ f: @escaping (T) -> T, x: T) -> T {
@@ -26,6 +26,6 @@ func closure_generic<T>(_ f: @escaping (T) -> T, x: T) -> T {
 
   return bar(x)
 }
-// CHECK-LABEL: sil shared @_T019capture_typed_boxes15closure_generic{{.*}} : $@convention(thin) <T> (@in T, @owned <τ_0_0> { var @callee_owned (@in τ_0_0) -> @out τ_0_0 } <T>) -> @out T {
+// CHECK-LABEL: sil private @_T019capture_typed_boxes15closure_generic{{.*}} : $@convention(thin) <T> (@in T, @owned <τ_0_0> { var @callee_owned (@in τ_0_0) -> @out τ_0_0 } <T>) -> @out T {
 // CHECK-LABEL: bb0(%0 : $*T, %1 : $*T, %2 : $<τ_0_0> { var @callee_owned (@in τ_0_0) -> @out τ_0_0 } <T>):
 

--- a/test/SILGen/closure_inline_initializer.swift
+++ b/test/SILGen/closure_inline_initializer.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s
 
-// CHECK-LABEL: sil shared @_T026closure_inline_initializer3FooV3fooSivfiSiycfU_
+// CHECK-LABEL: sil private @_T026closure_inline_initializer3FooV3fooSivfiSiycfU_
 
 struct Foo {
   var foo: Int = { 2 }()

--- a/test/SILGen/closure_self_recursion.swift
+++ b/test/SILGen/closure_self_recursion.swift
@@ -3,13 +3,13 @@
 
 // CHECK-LABEL: sil @main
 
-// CHECK-LABEL: sil shared @_T03foo5recuryycfgyycfU_
+// CHECK-LABEL: sil private @_T03foo5recuryycfgyycfU_
 var recur : () -> () {
   // CHECK-LABEL: function_ref @_T03foo5recuryycfg
   return { recur() } // expected-warning {{attempting to access 'recur' within its own getter}}
 }
 
-// CHECK-LABEL: sil shared @_T03foo12recur_harderyycyyccfgyycyyccfU_
+// CHECK-LABEL: sil private @_T03foo12recur_harderyycyyccfgyycyyccfU_
 var recur_harder : (() -> ()) -> (() -> ()) {
   // CHECK-LABEL: function_ref @_T03foo12recur_harderyycyyccfg
   return { f in recur_harder(f) } // expected-warning {{attempting to access 'recur_harder' within its own getter}}

--- a/test/SILGen/closures.swift
+++ b/test/SILGen/closures.swift
@@ -48,7 +48,7 @@ func read_only_capture(_ x: Int) -> Int {
 }
 // CHECK:   } // end sil function '_T08closures17read_only_captureS2iF'
 
-// CHECK: sil shared @[[CAP_NAME]]
+// CHECK: sil private @[[CAP_NAME]]
 // CHECK: bb0([[XBOX:%[0-9]+]] : ${ var Int }):
 // CHECK: [[XADDR:%[0-9]+]] = project_box [[XBOX]]
 // CHECK: [[X:%[0-9]+]] = load [trivial] [[XADDR]]
@@ -90,7 +90,7 @@ func write_to_capture(_ x: Int) -> Int {
 }
 // CHECK:  } // end sil function '_T08closures16write_to_captureS2iF'
 
-// CHECK: sil shared @[[SCRIB_NAME]]
+// CHECK: sil private @[[SCRIB_NAME]]
 // CHECK: bb0([[XBOX:%[0-9]+]] : ${ var Int }):
 // CHECK:   [[XADDR:%[0-9]+]] = project_box [[XBOX]]
 // CHECK:   copy_addr {{%[0-9]+}} to [[XADDR]]
@@ -137,10 +137,10 @@ func capture_local_func(_ x: Int) -> () -> () -> Int {
 }
 // CHECK: } // end sil function '_T08closures18capture_local_funcSiycycSiF'
 
-// CHECK: sil shared @[[ALEPH_NAME:_T08closures18capture_local_funcSiycycSiF5alephL_SiyF]] : $@convention(thin) (@owned { var Int }) -> Int {
+// CHECK: sil private @[[ALEPH_NAME:_T08closures18capture_local_funcSiycycSiF5alephL_SiyF]] : $@convention(thin) (@owned { var Int }) -> Int {
 // CHECK: bb0([[XBOX:%[0-9]+]] : ${ var Int }):
 
-// CHECK: sil shared @[[BETH_NAME]] : $@convention(thin) (@owned { var Int }) -> @owned @callee_owned () -> Int {
+// CHECK: sil private @[[BETH_NAME]] : $@convention(thin) (@owned { var Int }) -> @owned @callee_owned () -> Int {
 // CHECK: bb0([[XBOX:%[0-9]+]] : ${ var Int }):
 // CHECK:   [[XBOX_PB:%.*]] = project_box [[XBOX]]
 // CHECK:   [[ALEPH_REF:%[0-9]+]] = function_ref @[[ALEPH_NAME]] : $@convention(thin) (@owned { var Int }) -> Int
@@ -168,7 +168,7 @@ func anon_read_only_capture(_ x: Int) -> Int {
   // CHECK: destroy_value [[XBOX]]
   // CHECK: return [[RET]]
 }
-// CHECK: sil shared @[[CLOSURE_NAME]]
+// CHECK: sil private @[[CLOSURE_NAME]]
 // CHECK: bb0([[XADDR:%[0-9]+]] : $*Int):
 // CHECK: [[X:%[0-9]+]] = load [trivial] [[XADDR]]
 // CHECK: return [[X]]
@@ -189,7 +189,7 @@ func small_closure_capture(_ x: Int) -> Int {
   // CHECK: destroy_value [[XBOX]]
   // CHECK: return [[RET]]
 }
-// CHECK: sil shared @[[CLOSURE_NAME]]
+// CHECK: sil private @[[CLOSURE_NAME]]
 // CHECK: bb0([[XADDR:%[0-9]+]] : $*Int):
 // CHECK: [[X:%[0-9]+]] = load [trivial] [[XADDR]]
 // CHECK: return [[X]]
@@ -209,7 +209,7 @@ func small_closure_capture_with_argument(_ x: Int) -> (_ y: Int) -> Int {
   // CHECK: destroy_value [[XBOX]]
   // CHECK: return [[ANON_CLOSURE_APP]]
 }
-// CHECK: sil shared @[[CLOSURE_NAME]] : $@convention(thin) (Int, @owned { var Int }) -> Int
+// CHECK: sil private @[[CLOSURE_NAME]] : $@convention(thin) (Int, @owned { var Int }) -> Int
 // CHECK: bb0([[DOLLAR0:%[0-9]+]] : $Int, [[XBOX:%[0-9]+]] : ${ var Int }):
 // CHECK: [[XADDR:%[0-9]+]] = project_box [[XBOX]]
 // CHECK: [[PLUS:%[0-9]+]] = function_ref @_T0s1poiS2i_SitF{{.*}}
@@ -225,7 +225,7 @@ func small_closure_no_capture() -> (_ y: Int) -> Int {
   // CHECK:   return [[ANON_THICK]]
   return { $0 }
 }
-// CHECK: sil shared @[[CLOSURE_NAME]] : $@convention(thin) (Int) -> Int
+// CHECK: sil private @[[CLOSURE_NAME]] : $@convention(thin) (Int) -> Int
 // CHECK: bb0([[YARG:%[0-9]+]] : $Int):
 
 // CHECK-LABEL: sil hidden @_T08closures17uncaptured_locals{{[_0-9a-zA-Z]*}}F :
@@ -268,11 +268,11 @@ class SomeGenericClass<T> {
     var z = { _ = T.self } ()
   }
 
-  // CHECK-LABEL: sil shared @_T08closures16SomeGenericClassCfdSiycfU_ : $@convention(thin) (@inout_aliasable Int) -> Int
+  // CHECK-LABEL: sil private @_T08closures16SomeGenericClassCfdSiycfU_ : $@convention(thin) (@inout_aliasable Int) -> Int
 
-  // CHECK-LABEL: sil shared @_T08closures16SomeGenericClassCfdSiycfU0_ : $@convention(thin) () -> Int
+  // CHECK-LABEL: sil private @_T08closures16SomeGenericClassCfdSiycfU0_ : $@convention(thin) () -> Int
 
-  // CHECK-LABEL: sil shared @_T08closures16SomeGenericClassCfdyycfU1_ : $@convention(thin) <T> () -> ()
+  // CHECK-LABEL: sil private @_T08closures16SomeGenericClassCfdyycfU1_ : $@convention(thin) <T> () -> ()
 }
 
 // This is basically testing that the constraint system ranking
@@ -284,7 +284,7 @@ func generateWithConstant(_ x : SomeSpecificClass) {
   takesSomeClassGenerator({ x })
 }
 
-// CHECK-LABEL: sil shared @_T08closures20generateWithConstantyAA17SomeSpecificClassCFAA0eG0CycfU_ : $@convention(thin) (@owned SomeSpecificClass) -> @owned SomeClass {
+// CHECK-LABEL: sil private @_T08closures20generateWithConstantyAA17SomeSpecificClassCFAA0eG0CycfU_ : $@convention(thin) (@owned SomeSpecificClass) -> @owned SomeClass {
 // CHECK: bb0([[T0:%.*]] : $SomeSpecificClass):
 // CHECK:   debug_value [[T0]] : $SomeSpecificClass, let, name "x", argno 1
 // CHECK:   [[BORROWED_T0:%.*]] = begin_borrow [[T0]]
@@ -369,7 +369,7 @@ func closeOverLetLValue() {
 
 // The let property needs to be captured into a temporary stack slot so that it
 // is loadable even though we capture the value.
-// CHECK-LABEL: sil shared @_T08closures18closeOverLetLValueyyFSiycfU_ : $@convention(thin) (@owned ClassWithIntProperty) -> Int {
+// CHECK-LABEL: sil private @_T08closures18closeOverLetLValueyyFSiycfU_ : $@convention(thin) (@owned ClassWithIntProperty) -> Int {
 // CHECK: bb0([[ARG:%.*]] : $ClassWithIntProperty):
 // CHECK:   [[TMP_CLASS_ADDR:%.*]] = alloc_stack $ClassWithIntProperty, let, name "a", argno 1
 // CHECK:   store [[ARG]] to [init] [[TMP_CLASS_ADDR]] : $*ClassWithIntProperty
@@ -407,7 +407,7 @@ struct StructWithMutatingMethod {
 // CHECK: partial_apply [[CLOSURE]](%0) : $@convention(thin) (@inout_aliasable StructWithMutatingMethod) -> Int
 
 // Check that the closure body only takes the pointer.
-// CHECK-LABEL: sil shared @_T08closures24StructWithMutatingMethodV08mutatingE0{{.*}} : $@convention(thin) (@inout_aliasable StructWithMutatingMethod) -> Int {
+// CHECK-LABEL: sil private @_T08closures24StructWithMutatingMethodV08mutatingE0{{.*}} : $@convention(thin) (@inout_aliasable StructWithMutatingMethod) -> Int {
 // CHECK:       bb0(%0 : $*StructWithMutatingMethod):
 
 class SuperBase {
@@ -423,7 +423,7 @@ class SuperSub : SuperBase {
   // CHECK:   apply [[INNER]]([[SELF_COPY]])
   // CHECK: } // end sil function '_T08closures8SuperSubC1ayyF'
   func a() {
-    // CHECK: sil shared @[[INNER_FUNC_1]] : $@convention(thin) (@owned SuperSub) -> () {
+    // CHECK: sil private @[[INNER_FUNC_1]] : $@convention(thin) (@owned SuperSub) -> () {
     // CHECK: bb0([[ARG:%.*]] : $SuperSub):
     // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
     // CHECK:   [[CLASS_METHOD:%.*]] = class_method [[BORROWED_ARG]] : $SuperSub, #SuperSub.boom!1
@@ -452,7 +452,7 @@ class SuperSub : SuperBase {
   // CHECK:   = apply [[INNER]]([[SELF_COPY]])
   // CHECK: } // end sil function '_T08closures8SuperSubC1byyF'
   func b() {
-    // CHECK: sil shared @[[INNER_FUNC_1]] : $@convention(thin) (@owned SuperSub) -> () {
+    // CHECK: sil private @[[INNER_FUNC_1]] : $@convention(thin) (@owned SuperSub) -> () {
     // CHECK: bb0([[ARG:%.*]] : $SuperSub):
     // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
     // CHECK:   [[INNER:%.*]] = function_ref @[[INNER_FUNC_2:_T08closures8SuperSubC1b.*]] : $@convention(thin) (@owned SuperSub) -> ()
@@ -460,7 +460,7 @@ class SuperSub : SuperBase {
     // CHECK:   destroy_value [[ARG]]
     // CHECK: } // end sil function '[[INNER_FUNC_1]]'
     func b1() {
-      // CHECK: sil shared @[[INNER_FUNC_2]] : $@convention(thin) (@owned SuperSub) -> () {
+      // CHECK: sil private @[[INNER_FUNC_2]] : $@convention(thin) (@owned SuperSub) -> () {
       // CHECK: bb0([[ARG:%.*]] : $SuperSub):
       // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
       // CHECK:   [[CLASS_METHOD:%.*]] = class_method [[BORROWED_ARG]] : $SuperSub, #SuperSub.boom!1
@@ -496,7 +496,7 @@ class SuperSub : SuperBase {
   // CHECK:   destroy_value [[PA]]
   // CHECK: } // end sil function '_T08closures8SuperSubC1cyyF'
   func c() {
-    // CHECK: sil shared @[[INNER_FUNC_1]] : $@convention(thin) (@owned SuperSub) -> ()
+    // CHECK: sil private @[[INNER_FUNC_1]] : $@convention(thin) (@owned SuperSub) -> ()
     // CHECK: bb0([[ARG:%.*]] : $SuperSub):
     // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
     // CHECK:   [[CLASS_METHOD:%.*]] = class_method [[BORROWED_ARG]] : $SuperSub, #SuperSub.boom!1
@@ -530,7 +530,7 @@ class SuperSub : SuperBase {
   // CHECK:   destroy_value [[PA]]
   // CHECK: } // end sil function '_T08closures8SuperSubC1dyyF'
   func d() {
-    // CHECK: sil shared @[[INNER_FUNC_1]] : $@convention(thin) (@owned SuperSub) -> () {
+    // CHECK: sil private @[[INNER_FUNC_1]] : $@convention(thin) (@owned SuperSub) -> () {
     // CHECK: bb0([[ARG:%.*]] : $SuperSub):
     // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
     // CHECK:   [[INNER:%.*]] = function_ref @[[INNER_FUNC_2:_T08closures8SuperSubC1d.*]] : $@convention(thin) (@owned SuperSub) -> ()
@@ -538,7 +538,7 @@ class SuperSub : SuperBase {
     // CHECK:   destroy_value [[ARG]]
     // CHECK: } // end sil function '[[INNER_FUNC_1]]'
     let d1 = { () -> Void in
-      // CHECK: sil shared @[[INNER_FUNC_2]] : $@convention(thin) (@owned SuperSub) -> () {
+      // CHECK: sil private @[[INNER_FUNC_2]] : $@convention(thin) (@owned SuperSub) -> () {
       // CHECK: bb0([[ARG:%.*]] : $SuperSub):
       // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
       // CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
@@ -564,7 +564,7 @@ class SuperSub : SuperBase {
   // CHECK: = apply [[INNER]]([[SELF_COPY]])
   // CHECK: } // end sil function '_T08closures8SuperSubC1eyyF'
   func e() {
-    // CHECK: sil shared @[[INNER_FUNC_NAME1]] : $@convention(thin)
+    // CHECK: sil private @[[INNER_FUNC_NAME1]] : $@convention(thin)
     // CHECK: bb0([[ARG:%.*]] : $SuperSub):
     // CHECK:   [[INNER:%.*]] = function_ref @[[INNER_FUNC_NAME2:_T08closures8SuperSubC1e.*]] : $@convention(thin)
     // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
@@ -577,7 +577,7 @@ class SuperSub : SuperBase {
     // CHECK:   destroy_value [[ARG]]
     // CHECK: } // end sil function '[[INNER_FUNC_NAME1]]'
     func e1() {
-      // CHECK: sil shared @[[INNER_FUNC_NAME2]] : $@convention(thin)
+      // CHECK: sil private @[[INNER_FUNC_NAME2]] : $@convention(thin)
       // CHECK: bb0([[ARG:%.*]] : $SuperSub):
       // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
       // CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
@@ -605,7 +605,7 @@ class SuperSub : SuperBase {
   // CHECK:   destroy_value [[PA]]
   // CHECK: } // end sil function '_T08closures8SuperSubC1fyyF'
   func f() {
-    // CHECK: sil shared @[[INNER_FUNC_1]] : $@convention(thin) (@owned SuperSub) -> () {
+    // CHECK: sil private @[[INNER_FUNC_1]] : $@convention(thin) (@owned SuperSub) -> () {
     // CHECK: bb0([[ARG:%.*]] : $SuperSub):
     // CHECK:   [[TRY_APPLY_AUTOCLOSURE:%.*]] = function_ref @_T0s2qqoixxSg_xyKXKtKlF : $@convention(thin) <τ_0_0> (@in Optional<τ_0_0>, @owned @callee_owned () -> (@out τ_0_0, @error Error)) -> (@out τ_0_0, @error Error)
     // CHECK:   [[INNER:%.*]] = function_ref @[[INNER_FUNC_2:_T08closures8SuperSubC1fyyFyycfU_yyKXKfu_]] : $@convention(thin) (@owned SuperSub) -> @error Error
@@ -617,7 +617,7 @@ class SuperSub : SuperBase {
     // CHECK:   destroy_value [[ARG]]
     // CHECK: } // end sil function '[[INNER_FUNC_1]]'
     let f1 = {
-      // CHECK: sil shared [transparent] @[[INNER_FUNC_2]]
+      // CHECK: sil private [transparent] @[[INNER_FUNC_2]]
       // CHECK: bb0([[ARG:%.*]] : $SuperSub):
       // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
       // CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
@@ -639,7 +639,7 @@ class SuperSub : SuperBase {
   // CHECK:   = apply [[INNER]]([[SELF_COPY]])
   // CHECK: } // end sil function '_T08closures8SuperSubC1gyyF'
   func g() {
-    // CHECK: sil shared @[[INNER_FUNC_1]] : $@convention(thin) (@owned SuperSub) -> ()
+    // CHECK: sil private @[[INNER_FUNC_1]] : $@convention(thin) (@owned SuperSub) -> ()
     // CHECK: bb0([[ARG:%.*]] : $SuperSub):
     // CHECK:   [[TRY_APPLY_FUNC:%.*]] = function_ref @_T0s2qqoixxSg_xyKXKtKlF : $@convention(thin) <τ_0_0> (@in Optional<τ_0_0>, @owned @callee_owned () -> (@out τ_0_0, @error Error)) -> (@out τ_0_0, @error Error)
     // CHECK:   [[INNER:%.*]] = function_ref @[[INNER_FUNC_2:_T08closures8SuperSubC1g.*]] : $@convention(thin) (@owned SuperSub) -> @error Error
@@ -651,7 +651,7 @@ class SuperSub : SuperBase {
     // CHECK:   destroy_value [[ARG]]
     // CHECK: } // end sil function '[[INNER_FUNC_1]]'
     func g1() {
-      // CHECK: sil shared [transparent] @[[INNER_FUNC_2]] : $@convention(thin) (@owned SuperSub) -> @error Error {
+      // CHECK: sil private [transparent] @[[INNER_FUNC_2]] : $@convention(thin) (@owned SuperSub) -> @error Error {
       // CHECK: bb0([[ARG:%.*]] : $SuperSub):
       // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
       // CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
@@ -706,7 +706,7 @@ class SuperSub : SuperBase {
 
 // -- outer closure
 // -- strong +0, unowned +1
-// CHECK: sil shared @[[OUTER_CLOSURE_FUN:_T08closures24UnownedSelfNestedCaptureC06nestedE0yyFACycycfU_]] : $@convention(thin) (@owned @sil_unowned UnownedSelfNestedCapture) -> @owned @callee_owned () -> @owned UnownedSelfNestedCapture {
+// CHECK: sil private @[[OUTER_CLOSURE_FUN:_T08closures24UnownedSelfNestedCaptureC06nestedE0yyFACycycfU_]] : $@convention(thin) (@owned @sil_unowned UnownedSelfNestedCapture) -> @owned @callee_owned () -> @owned UnownedSelfNestedCapture {
 // CHECK: bb0([[CAPTURED_SELF:%.*]] : $@sil_unowned UnownedSelfNestedCapture):
 // -- strong +0, unowned +2
 // CHECK:         [[CAPTURED_SELF_COPY:%.*]] = copy_value [[CAPTURED_SELF]] :
@@ -719,7 +719,7 @@ class SuperSub : SuperBase {
 
 // -- inner closure
 // -- strong +0, unowned +1
-// CHECK: sil shared @[[INNER_CLOSURE_FUN:_T08closures24UnownedSelfNestedCaptureC06nestedE0yyFACycycfU_ACycfU_]] : $@convention(thin) (@owned @sil_unowned UnownedSelfNestedCapture) -> @owned UnownedSelfNestedCapture {
+// CHECK: sil private @[[INNER_CLOSURE_FUN:_T08closures24UnownedSelfNestedCaptureC06nestedE0yyFACycycfU_ACycfU_]] : $@convention(thin) (@owned @sil_unowned UnownedSelfNestedCapture) -> @owned UnownedSelfNestedCapture {
 // CHECK: bb0([[CAPTURED_SELF:%.*]] : $@sil_unowned UnownedSelfNestedCapture):
 // -- strong +1, unowned +1
 // CHECK:         strong_retain_unowned [[CAPTURED_SELF:%.*]] :
@@ -741,7 +741,7 @@ class ConcreteBase {
   func swim() {}
 }
 
-// CHECK-LABEL: sil shared @_T08closures14GenericDerivedC4swimyyFyycfU_ : $@convention(thin) <Ocean> (@owned GenericDerived<Ocean>) -> ()
+// CHECK-LABEL: sil private @_T08closures14GenericDerivedC4swimyyFyycfU_ : $@convention(thin) <Ocean> (@owned GenericDerived<Ocean>) -> ()
 // CHECK: bb0([[ARG:%.*]] : $GenericDerived<Ocean>):
 // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
 // CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]

--- a/test/SILGen/default_arguments.swift
+++ b/test/SILGen/default_arguments.swift
@@ -58,10 +58,10 @@ func autocloseFile(x: @autoclosure () -> String = #file,
                    y: @autoclosure () -> Int = #line) { }
 // CHECK-LABEL: sil hidden @_T017default_arguments17testAutocloseFileyyF
 func testAutocloseFile() {
-  // CHECK-LABEL: sil shared [transparent] @_T017default_arguments17testAutocloseFileyyFSSyXKfu_ : $@convention(thin) () -> @owned String
+  // CHECK-LABEL: sil private [transparent] @_T017default_arguments17testAutocloseFileyyFSSyXKfu_ : $@convention(thin) () -> @owned String
   // CHECK: string_literal utf16{{.*}}default_arguments.swift
 
-  // CHECK-LABEL: sil shared [transparent] @_T017default_arguments17testAutocloseFileyyFSiyXKfu0_ : $@convention(thin) () -> Int
+  // CHECK-LABEL: sil private [transparent] @_T017default_arguments17testAutocloseFileyyFSiyXKfu0_ : $@convention(thin) () -> Int
   // CHECK: integer_literal $Builtin.Int2048, [[@LINE+1]]
   autocloseFile()
 }
@@ -92,9 +92,9 @@ func autoclosure(_: @autoclosure () -> ()) {}
 // CHECK-LABEL: sil hidden @_T017default_arguments25testCallWithMagicLiteralsyyF
 // CHECK:         string_literal utf16 "testCallWithMagicLiterals()"
 // CHECK:         string_literal utf16 "testCallWithMagicLiterals()"
-// CHECK-LABEL: sil shared @_T017default_arguments25testCallWithMagicLiteralsyyFyycfU_
+// CHECK-LABEL: sil private @_T017default_arguments25testCallWithMagicLiteralsyyFyycfU_
 // CHECK:         string_literal utf16 "testCallWithMagicLiterals()"
-// CHECK-LABEL: sil shared [transparent] @_T017default_arguments25testCallWithMagicLiteralsyyFyyXKfu_
+// CHECK-LABEL: sil private [transparent] @_T017default_arguments25testCallWithMagicLiteralsyyFyyXKfu_
 // CHECK:         string_literal utf16 "testCallWithMagicLiterals()"
 func testCallWithMagicLiterals() {
   testMagicLiterals()
@@ -262,5 +262,5 @@ func localFunctionWithDefaultArg() {
   }
   bar()
 }
-// CHECK-LABEL: sil shared @_T017default_arguments27localFunctionWithDefaultArgyyF3barL_ySiSgFfA_
+// CHECK-LABEL: sil private @_T017default_arguments27localFunctionWithDefaultArgyyF3barL_ySiSgFfA_
 // CHECK-SAME: $@convention(thin) () -> Optional<Int>

--- a/test/SILGen/dynamic.swift
+++ b/test/SILGen/dynamic.swift
@@ -434,7 +434,7 @@ public class Sub : Base {
   // CHECK:     return {{%.*}} : $Bool
   // CHECK: } // end sil function '_T07dynamic3SubC1xSbfg'
 
-  // CHECK-LABEL: sil shared [transparent] @_T07dynamic3SubC1xSbfgSbyKXKfu_ : $@convention(thin) (@owned Sub) -> (Bool, @error Error) {
+  // CHECK-LABEL: sil private [transparent] @_T07dynamic3SubC1xSbfgSbyKXKfu_ : $@convention(thin) (@owned Sub) -> (Bool, @error Error) {
   // CHECK: bb0([[VALUE:%.*]] : $Sub):
   // CHECK:     [[BORROWED_VALUE:%.*]] = begin_borrow [[VALUE]]
   // CHECK:     [[VALUE_COPY:%.*]] = copy_value [[BORROWED_VALUE]]

--- a/test/SILGen/functions.swift
+++ b/test/SILGen/functions.swift
@@ -442,7 +442,7 @@ func testNoescape() {
 // Despite being a noescape closure, this needs to capture 'a' by-box so it can
 // be passed to the capturing closure.closure
 // CHECK: functions.(testNoescape () -> ()).(closure #1)
-// CHECK-NEXT: sil shared @_T09functions12testNoescapeyyFyycfU_ : $@convention(thin) (@owned { var Int }) -> () {
+// CHECK-NEXT: sil private @_T09functions12testNoescapeyyFyycfU_ : $@convention(thin) (@owned { var Int }) -> () {
 
 
 
@@ -462,10 +462,10 @@ func testNoescape2() {
 // CHECK-LABEL: sil hidden @_T09functions13testNoescape2yyF : $@convention(thin) () -> () {
 
 // CHECK: // functions.(testNoescape2 () -> ()).(closure #1)
-// CHECK-NEXT: sil shared @_T09functions13testNoescape2yyFyycfU_ : $@convention(thin) (@owned { var Int }) -> () {
+// CHECK-NEXT: sil private @_T09functions13testNoescape2yyFyycfU_ : $@convention(thin) (@owned { var Int }) -> () {
 
 // CHECK: // functions.(testNoescape2 () -> ()).(closure #1).(closure #1)
-// CHECK-NEXT: sil shared @_T09functions13testNoescape2yyFyycfU_yycfU_ : $@convention(thin) (@owned { var Int }) -> () {
+// CHECK-NEXT: sil private @_T09functions13testNoescape2yyFyycfU_yycfU_ : $@convention(thin) (@owned { var Int }) -> () {
 
 enum PartialApplyEnumPayload<T, U> {
   case Left(T)

--- a/test/SILGen/generic_closures.swift
+++ b/test/SILGen/generic_closures.swift
@@ -122,9 +122,9 @@ class NestedGeneric<U> {
 
 // CHECK: sil hidden @_T016generic_closures018nested_closure_in_A0xxlF : $@convention(thin) <T> (@in T) -> @out T
 // CHECK:   function_ref [[OUTER_CLOSURE:@_T016generic_closures018nested_closure_in_A0xxlFxycfU_]]
-// CHECK: sil shared [[OUTER_CLOSURE]] : $@convention(thin) <T> (@inout_aliasable T) -> @out T
+// CHECK: sil private [[OUTER_CLOSURE]] : $@convention(thin) <T> (@inout_aliasable T) -> @out T
 // CHECK:   function_ref [[INNER_CLOSURE:@_T016generic_closures018nested_closure_in_A0xxlFxycfU_xycfU_]]
-// CHECK: sil shared [[INNER_CLOSURE]] : $@convention(thin) <T> (@inout_aliasable T) -> @out T {
+// CHECK: sil private [[INNER_CLOSURE]] : $@convention(thin) <T> (@inout_aliasable T) -> @out T {
 func nested_closure_in_generic<T>(_ x:T) -> T {
   return { { x }() }()
 }
@@ -291,9 +291,9 @@ func mixed_generic_nongeneric_nesting<T>(t: T) {
   outer()
 }
 
-// CHECK-LABEL: sil shared @_T016generic_closures06mixed_A19_nongeneric_nestingyx1t_tlF5outerL_yylF : $@convention(thin) <T> () -> ()
-// CHECK-LABEL: sil shared @_T016generic_closures06mixed_A19_nongeneric_nestingyx1t_tlF5outerL_yylF6middleL_yqd__1u_tr__lF : $@convention(thin) <T><U> (@in U) -> ()
-// CHECK-LABEL: sil shared @_T016generic_closures06mixed_A19_nongeneric_nestingyx1t_tlF5outerL_yylF6middleL_yqd__1u_tr__lF5innerL_qd__yr__lF : $@convention(thin) <T><U> (@owned <τ_0_0><τ_1_0> { var τ_1_0 } <T, U>) -> @out U
+// CHECK-LABEL: sil private @_T016generic_closures06mixed_A19_nongeneric_nestingyx1t_tlF5outerL_yylF : $@convention(thin) <T> () -> ()
+// CHECK-LABEL: sil private @_T016generic_closures06mixed_A19_nongeneric_nestingyx1t_tlF5outerL_yylF6middleL_yqd__1u_tr__lF : $@convention(thin) <T><U> (@in U) -> ()
+// CHECK-LABEL: sil private @_T016generic_closures06mixed_A19_nongeneric_nestingyx1t_tlF5outerL_yylF6middleL_yqd__1u_tr__lF5innerL_qd__yr__lF : $@convention(thin) <T><U> (@owned <τ_0_0><τ_1_0> { var τ_1_0 } <T, U>) -> @out U
 
 protocol Doge {
   associatedtype Nose : NoseProtocol

--- a/test/SILGen/guaranteed_closure_context.swift
+++ b/test/SILGen/guaranteed_closure_context.swift
@@ -66,4 +66,4 @@ func guaranteed_captures() {
 
 }
 
-// CHECK: sil shared [[FN_NAME]] : $@convention(thin) (@guaranteed { var S }, @guaranteed { var C }, @guaranteed { var P }, S, @guaranteed C, @guaranteed { var P })
+// CHECK: sil private [[FN_NAME]] : $@convention(thin) (@guaranteed { var S }, @guaranteed { var C }, @guaranteed { var P }, S, @guaranteed C, @guaranteed { var P })

--- a/test/SILGen/interface_type_mangling.swift
+++ b/test/SILGen/interface_type_mangling.swift
@@ -194,14 +194,14 @@ struct GenericTypeContext<T>: GenericWitnessTest {
   typealias Tee = T
 
   var a: T
-  // CHECK-LABEL: sil shared @_T023interface_type_mangling18GenericTypeContextV09closureIndF0yqd__lF3fooL_yx_qd__tr__lF
+  // CHECK-LABEL: sil private @_T023interface_type_mangling18GenericTypeContextV09closureIndF0yqd__lF3fooL_yx_qd__tr__lF
   func closureInGenericContext<U>(_ b: U) {
     func foo(_ x: T, _ y: U) { }
 
     foo(a, b)
   }
 
-  // CHECK-LABEL: sil shared @_T023interface_type_mangling18GenericTypeContextV09closureInd8PropertyF0xfg3fooL_xylF
+  // CHECK-LABEL: sil private @_T023interface_type_mangling18GenericTypeContextV09closureInd8PropertyF0xfg3fooL_xylF
   var closureInGenericPropertyContext: T {
     func foo() -> T { }
 

--- a/test/SILGen/let_decls.swift
+++ b/test/SILGen/let_decls.swift
@@ -41,7 +41,7 @@ func test2() {
 
 // The closure just returns its value, which it captured directly.
 
-// CHECK: sil shared @_T09let_decls5test2yyFSiycfU_ : $@convention(thin) (Int) -> Int
+// CHECK: sil private @_T09let_decls5test2yyFSiycfU_ : $@convention(thin) (Int) -> Int
 // CHECK: bb0(%0 : $Int):
 // CHECK:  return %0 : $Int
 

--- a/test/SILGen/local_captures.swift
+++ b/test/SILGen/local_captures.swift
@@ -6,16 +6,16 @@
 // CHECK-LABEL: sil hidden @_T014local_captures10globalfuncyycyF : $@convention(thin) () -> @owned @callee_owned () -> ()
 func globalfunc() -> () -> () {
 
-	// CHECK-LABEL: sil shared @_T014local_captures10globalfuncyycyF0A4FuncL_yyF : $@convention(thin) () -> ()
+	// CHECK-LABEL: sil private @_T014local_captures10globalfuncyycyF0A4FuncL_yyF : $@convention(thin) () -> ()
 	func localFunc() {
 	}
 
-	// CHECK-LABEL: sil shared @_T014local_captures10globalfuncyycyF6callitL_yyF : $@convention(thin) () -> ()
+	// CHECK-LABEL: sil private @_T014local_captures10globalfuncyycyF6callitL_yyF : $@convention(thin) () -> ()
 	func callit() {
 		localFunc()
 	}
 
-	// CHECK-LABEL: sil shared @_T014local_captures10globalfuncyycyF5getitL_yycyF : $@convention(thin) () -> @owned @callee_owned () -> ()
+	// CHECK-LABEL: sil private @_T014local_captures10globalfuncyycyF5getitL_yycyF : $@convention(thin) () -> @owned @callee_owned () -> ()
 	func getit() -> () -> () {
 		return localFunc
 	}

--- a/test/SILGen/local_recursion.swift
+++ b/test/SILGen/local_recursion.swift
@@ -76,25 +76,25 @@ func local_recursion(_ x: Int, y: Int) {
   f(x)
 }
 
-// CHECK: sil shared [[SELF_RECURSIVE]]
+// CHECK: sil private [[SELF_RECURSIVE]]
 // CHECK: bb0([[A:%0]] : $Int, [[X:%1]] : $Int):
 // CHECK:   [[SELF_REF:%.*]] = function_ref [[SELF_RECURSIVE]]
 // CHECK:   apply [[SELF_REF]]({{.*}}, [[X]])
 
-// CHECK: sil shared [[MUTUALLY_RECURSIVE_1]]
+// CHECK: sil private [[MUTUALLY_RECURSIVE_1]]
 // CHECK: bb0([[A:%0]] : $Int, [[Y:%1]] : $Int, [[X:%2]] : $Int):
 // CHECK:   [[MUTUALLY_RECURSIVE_REF:%.*]] = function_ref [[MUTUALLY_RECURSIVE_2:@_T015local_recursionAAySi_Si1ytF20mutually_recursive_2L_ySiF]]
 // CHECK:   apply [[MUTUALLY_RECURSIVE_REF]]({{.*}}, [[X]], [[Y]])
-// CHECK: sil shared [[MUTUALLY_RECURSIVE_2]]
+// CHECK: sil private [[MUTUALLY_RECURSIVE_2]]
 // CHECK: bb0([[B:%0]] : $Int, [[X:%1]] : $Int, [[Y:%2]] : $Int):
 // CHECK:   [[MUTUALLY_RECURSIVE_REF:%.*]] = function_ref [[MUTUALLY_RECURSIVE_1]]
 // CHECK:   apply [[MUTUALLY_RECURSIVE_REF]]({{.*}}, [[Y]], [[X]])
 
 
-// CHECK: sil shared [[TRANS_CAPTURE_1:@_T015local_recursionAAySi_Si1ytF20transitive_capture_1L_S2iF]]
+// CHECK: sil private [[TRANS_CAPTURE_1:@_T015local_recursionAAySi_Si1ytF20transitive_capture_1L_S2iF]]
 // CHECK: bb0([[A:%0]] : $Int, [[X:%1]] : $Int):
 
-// CHECK: sil shared [[TRANS_CAPTURE]]
+// CHECK: sil private [[TRANS_CAPTURE]]
 // CHECK: bb0([[B:%0]] : $Int, [[X:%1]] : $Int, [[Y:%2]] : $Int):
 // CHECK:   [[TRANS_CAPTURE_1_REF:%.*]] = function_ref [[TRANS_CAPTURE_1]]
 // CHECK:   apply [[TRANS_CAPTURE_1_REF]]({{.*}}, [[X]])

--- a/test/SILGen/mangling_private.swift
+++ b/test/SILGen/mangling_private.swift
@@ -53,7 +53,7 @@ extension PrivateStruct {
   private func extPrivateMethod() {}
 }
 
-// CHECK-LABEL: sil shared @_T016mangling_private10localTypesyyF11LocalStructL_V0B6MethodyyFZ
+// CHECK-LABEL: sil private @_T016mangling_private10localTypesyyF11LocalStructL_V0B6MethodyyFZ
 
 // CHECK-LABEL: sil_vtable Sub {
 class Sub : Base {

--- a/test/SILGen/nested-function-fragility.swift
+++ b/test/SILGen/nested-function-fragility.swift
@@ -3,17 +3,17 @@ internal func internalFunc() {}
 
 // CHECK-LABEL: sil @_T04main3fooyyF
 public func foo() {
-  // CHECK-LABEL: sil shared [always_inline] @_T04main3foo{{[_0-9a-zA-Z]*}}zim
+  // CHECK-LABEL: sil private [always_inline] @_T04main3foo{{[_0-9a-zA-Z]*}}zim
   @inline(__always)
   func zim() {
-    // CHECK-LABEL: sil shared @_T04main3fooyyF3zimL_yyF4zangL_yyF
+    // CHECK-LABEL: sil private @_T04main3fooyyF3zimL_yyF4zangL_yyF
     func zang() { internalFunc() }
     internalFunc()
   }
 
-  // CHECK-LABEL: sil shared @_T04main3foo{{[_0-9a-zA-Z]*}}U_
+  // CHECK-LABEL: sil private @_T04main3foo{{[_0-9a-zA-Z]*}}U_
   let zung = {
-    // CHECK-LABEL: sil shared [always_inline] @_T04main3fooyyFyycfU_7zippityL_yyF
+    // CHECK-LABEL: sil private [always_inline] @_T04main3fooyyFyycfU_7zippityL_yyF
     @inline(__always)
     func zippity() { internalFunc() }
     internalFunc()
@@ -23,17 +23,17 @@ public func foo() {
 // CHECK-LABEL: sil hidden [always_inline] @_T04main3baryyF
 @inline(__always)
 internal func bar() {
-  // CHECK-LABEL: sil shared [always_inline] @_T04main3baryyF3zimL_yyF
+  // CHECK-LABEL: sil private [always_inline] @_T04main3baryyF3zimL_yyF
   @inline(__always)
   func zim() {
-    // CHECK-LABEL: sil shared @_T04main3baryyF3zimL_yyF4zangL_yyF
+    // CHECK-LABEL: sil private @_T04main3baryyF3zimL_yyF4zangL_yyF
     func zang() { internalFunc() }
     internalFunc()
   }
 
-  // CHECK-LABEL: sil shared @_T04main3bar{{[_0-9a-zA-Z]*}}U_
+  // CHECK-LABEL: sil private @_T04main3bar{{[_0-9a-zA-Z]*}}U_
   let zung = {
-    // CHECK-LABEL: sil shared [always_inline] @_T04main3baryyFyycfU_7zippityL_yyF
+    // CHECK-LABEL: sil private [always_inline] @_T04main3baryyFyycfU_7zippityL_yyF
     @inline(__always)
     func zippity() { internalFunc() }
     internalFunc()

--- a/test/SILGen/nested_generics.swift
+++ b/test/SILGen/nested_generics.swift
@@ -23,8 +23,8 @@ protocol CuredMeat {}
 
 // Generic nested inside generic
 
-struct Lunch<T : Pizza where T.Topping : CuredMeat> {
-  struct Dinner<U : HotDog where U.Condiment == Deli<Pepper>.Mustard> {
+struct Lunch<T : Pizza> where T.Topping : CuredMeat {
+  struct Dinner<U : HotDog> where U.Condiment == Deli<Pepper>.Mustard {
     let firstCourse: T
     let secondCourse: U?
 
@@ -44,7 +44,7 @@ struct Lunch<T : Pizza where T.Topping : CuredMeat> {
 // CHECK-LABEL: sil hidden @_T015nested_generics5LunchV6DinnerV15coolCombinationy7ToppingQz1t_AA4DeliC7MustardOyAA6PepperV_G1utF : $@convention(method) <T where T : Pizza, T.Topping : CuredMeat><U where U : HotDog, U.Condiment == Deli<Pepper>.Mustard> (@in T.Topping, Deli<Pepper>.Mustard, @in_guaranteed Lunch<T>.Dinner<U>) -> ()
 
 // CHECK-LABEL: // nested_generics.Lunch.Dinner.(coolCombination (t : A.Topping, u : nested_generics.Deli<nested_generics.Pepper>.Mustard) -> ()).(nestedGeneric #1) <A><A1><A2, B2 where A: nested_generics.Pizza, A1: nested_generics.HotDog, A.Topping: nested_generics.CuredMeat, A1.Condiment == nested_generics.Deli<nested_generics.Pepper>.Mustard> (x : A2, y : B2) -> (A2, B2)
-// CHECK-LABEL: sil shared @_T015nested_generics5LunchV6DinnerV15coolCombinationy7ToppingQz1t_AA4DeliC7MustardOyAA6PepperV_G1utF0A7GenericL_qd0___qd0_0_tqd0__1x_qd0_0_1ytAA5PizzaRzAA6HotDogRd__AA9CuredMeatAHRQAP9CondimentRtd__r__0_lF : $@convention(thin) <T where T : Pizza, T.Topping : CuredMeat><U where U : HotDog, U.Condiment == Deli<Pepper>.Mustard><X, Y> (@in X, @in Y) -> (@out X, @out Y)
+// CHECK-LABEL: sil private @_T015nested_generics5LunchV6DinnerV15coolCombinationy7ToppingQz1t_AA4DeliC7MustardOyAA6PepperV_G1utF0A7GenericL_qd0___qd0_0_tqd0__1x_qd0_0_1ytAA5PizzaRzAA6HotDogRd__AA9CuredMeatAHRQAP9CondimentRtd__r__0_lF : $@convention(thin) <T where T : Pizza, T.Topping : CuredMeat><U where U : HotDog, U.Condiment == Deli<Pepper>.Mustard><X, Y> (@in X, @in Y) -> (@out X, @out Y)
 
 // CHECK-LABEL: // nested_generics.Lunch.Dinner.init (firstCourse : A, secondCourse : Swift.Optional<A1>, leftovers : A, transformation : (A) -> A1) -> nested_generics.Lunch<A>.Dinner<A1>
 // CHECK-LABEL: sil hidden @_T015nested_generics5LunchV6DinnerVAEyx_qd__Gx11firstCourse_qd__Sg06secondF0x9leftoversqd__xc14transformationtcfC : $@convention(method) <T where T : Pizza, T.Topping : CuredMeat><U where U : HotDog, U.Condiment == Deli<Pepper>.Mustard> (@owned T, @in Optional<U>, @owned T, @owned @callee_owned (@owned T) -> @out U, @thin Lunch<T>.Dinner<U>.Type) -> @out Lunch<T>.Dinner<U>
@@ -91,11 +91,11 @@ class HotDogs {
 extension String {
   func foo() {
     // CHECK-LABEL: // (extension in nested_generics):Swift.String.(foo () -> ()).(Cheese #1).init (material : A) -> (extension in nested_generics):Swift.String.(foo () -> ()).(Cheese #1)<A>
-    // CHECK-LABEL: sil shared @_T0SS15nested_genericsE3fooyyF6CheeseL_VADyxGx8material_tcfC
+    // CHECK-LABEL: sil private @_T0SS15nested_genericsE3fooyyF6CheeseL_VADyxGx8material_tcfC
     struct Cheese<Milk> {
       let material: Milk
     }
-    let r = Cheese(material: "cow")
+    let _ = Cheese(material: "cow")
   }
 }
 
@@ -103,12 +103,12 @@ extension String {
 extension HotDogs {
   func applyRelish() {
     // CHECK-LABEL: // nested_generics.HotDogs.(applyRelish () -> ()).(Relish #1).init (material : A) -> nested_generics.HotDogs.(applyRelish () -> ()).(Relish #1)<A>
-    // CHECK-LABEL: sil shared @_T015nested_generics7HotDogsC11applyRelishyyF0F0L_VAFyxGx8material_tcfC
+    // CHECK-LABEL: sil private @_T015nested_generics7HotDogsC11applyRelishyyF0F0L_VAFyxGx8material_tcfC
 
     struct Relish<Material> {
       let material: Material
     }
-    let r = Relish(material: "pickles")
+    let _ = Relish(material: "pickles")
   }
 }
 
@@ -179,7 +179,7 @@ func eatDinnerConcrete(d: inout Lunch<Pizzas<Pepper>.NewYork>.Dinner<HotDogs.Ame
 // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T015nested_generics6PizzasV7NewYorkCyAA6PepperV_GAA7HotDogsC8AmericanVIxxr_AhLIxxd_TR : $@convention(thin) (@owned Pizzas<Pepper>.NewYork, @owned @callee_owned (@owned Pizzas<Pepper>.NewYork) -> @out HotDogs.American) -> HotDogs.American
 
 // CHECK-LABEL: // nested_generics.(calls () -> ()).(closure #1)
-// CHECK-LABEL: sil shared @_T015nested_generics5callsyyFAA7HotDogsC8AmericanVAA6PizzasV7NewYorkCyAA6PepperV_GcfU_ : $@convention(thin) (@owned Pizzas<Pepper>.NewYork) -> HotDogs.American
+// CHECK-LABEL: sil private @_T015nested_generics5callsyyFAA7HotDogsC8AmericanVAA6PizzasV7NewYorkCyAA6PepperV_GcfU_ : $@convention(thin) (@owned Pizzas<Pepper>.NewYork) -> HotDogs.American
 
 func calls() {
 

--- a/test/SILGen/nested_types_referencing_nested_functions.swift
+++ b/test/SILGen/nested_types_referencing_nested_functions.swift
@@ -5,19 +5,19 @@ do {
   func bar<T>(_: T) { foo() }
 
   class Foo {
-    // CHECK-LABEL: sil shared @_T0025nested_types_referencing_A10_functions3FooL_CACycfc : $@convention(method) (@owned Foo) -> @owned Foo {
+    // CHECK-LABEL: sil private @_T0025nested_types_referencing_A10_functions3FooL_CACycfc : $@convention(method) (@owned Foo) -> @owned Foo {
     init() {
       foo()
     }
-    // CHECK-LABEL: sil shared @_T0025nested_types_referencing_A10_functions3FooL_C3zimyyF : $@convention(method) (@guaranteed Foo) -> ()
+    // CHECK-LABEL: sil private @_T0025nested_types_referencing_A10_functions3FooL_C3zimyyF : $@convention(method) (@guaranteed Foo) -> ()
     func zim() {
       foo()
     }
-    // CHECK-LABEL: sil shared @_T0025nested_types_referencing_A10_functions3FooL_C4zangyxlF : $@convention(method) <T> (@in T, @guaranteed Foo) -> ()
+    // CHECK-LABEL: sil private @_T0025nested_types_referencing_A10_functions3FooL_C4zangyxlF : $@convention(method) <T> (@in T, @guaranteed Foo) -> ()
     func zang<T>(_ x: T) {
       bar(x)
     }
-    // CHECK-LABEL: sil shared @_T0025nested_types_referencing_A10_functions3FooL_CfD : $@convention(method) (@owned Foo) -> ()
+    // CHECK-LABEL: sil private @_T0025nested_types_referencing_A10_functions3FooL_CfD : $@convention(method) (@owned Foo) -> ()
     deinit {
       foo()
     }

--- a/test/SILGen/objc_imported_generic.swift
+++ b/test/SILGen/objc_imported_generic.swift
@@ -106,7 +106,7 @@ public func arraysOfGenericParam<T: AnyObject>(y: Array<T>) {
   x.propertyArrayOfThings = y
 }
 
-// CHECK-LABEL: sil shared @_T021objc_imported_generic0C4Funcyxms9AnyObjectRzlFyycfU_ : $@convention(thin) <V where V : AnyObject> () -> () {
+// CHECK-LABEL: sil private @_T021objc_imported_generic0C4Funcyxms9AnyObjectRzlFyycfU_ : $@convention(thin) <V where V : AnyObject> () -> () {
 // CHECK:  [[INIT:%.*]] = function_ref @_T0So12GenericClassCAByxGycfC : $@convention(method) <τ_0_0 where τ_0_0 : AnyObject> (@thick GenericClass<τ_0_0>.Type) -> @owned GenericClass<τ_0_0>
 // CHECK:  [[META:%.*]] = metatype $@thick GenericClass<V>.Type
 // CHECK:  apply [[INIT]]<V>([[META]])

--- a/test/SILGen/objc_ownership_conventions.swift
+++ b/test/SILGen/objc_ownership_conventions.swift
@@ -4,7 +4,7 @@
 
 import gizmo
 
-// CHECK-LABEL: sil hidden  @_T026objc_ownership_conventions5test3So8NSObjectCyF
+// CHECK-LABEL: sil hidden @_T026objc_ownership_conventions5test3So8NSObjectCyF
 func test3() -> NSObject {
   // initializer returns at +1
   return Gizmo()
@@ -29,7 +29,7 @@ func test3() -> NSObject {
 
 
 // Normal message send with argument, no transfers.
-// CHECK-LABEL: sil hidden  @_T026objc_ownership_conventions5test5{{[_0-9a-zA-Z]*}}F
+// CHECK-LABEL: sil hidden @_T026objc_ownership_conventions5test5{{[_0-9a-zA-Z]*}}F
 func test5(_ g: Gizmo) {
   var g = g
   Gizmo.inspect(g)
@@ -53,7 +53,7 @@ func test5(_ g: Gizmo) {
 // CHECK: } // end sil function '_T026objc_ownership_conventions5test5{{[_0-9a-zA-Z]*}}F'
 
 // The argument to consume is __attribute__((ns_consumed)).
-// CHECK-LABEL: sil hidden  @_T026objc_ownership_conventions5test6{{[_0-9a-zA-Z]*}}F
+// CHECK-LABEL: sil hidden @_T026objc_ownership_conventions5test6{{[_0-9a-zA-Z]*}}F
 func test6(_ g: Gizmo) {
   var g = g
   Gizmo.consume(g)
@@ -79,7 +79,7 @@ func test6(_ g: Gizmo) {
 // CHECK: } // end sil function '_T026objc_ownership_conventions5test6{{[_0-9a-zA-Z]*}}F'
 
 // fork is __attribute__((ns_consumes_self)).
-// CHECK-LABEL: sil hidden  @_T026objc_ownership_conventions5test7{{[_0-9a-zA-Z]*}}F
+// CHECK-LABEL: sil hidden @_T026objc_ownership_conventions5test7{{[_0-9a-zA-Z]*}}F
 func test7(_ g: Gizmo) {
   var g = g
   g.fork()
@@ -102,7 +102,7 @@ func test7(_ g: Gizmo) {
 // CHECK: } // end sil function '_T026objc_ownership_conventions5test7{{[_0-9a-zA-Z]*}}F'
 
 // clone is __attribute__((ns_returns_retained)).
-// CHECK-LABEL: sil hidden  @_T026objc_ownership_conventions5test8{{[_0-9a-zA-Z]*}}F
+// CHECK-LABEL: sil hidden @_T026objc_ownership_conventions5test8{{[_0-9a-zA-Z]*}}F
 func test8(_ g: Gizmo) -> Gizmo {
   return g.clone()
   // CHECK: bb0([[G:%.*]] : $Gizmo):
@@ -117,7 +117,7 @@ func test8(_ g: Gizmo) -> Gizmo {
   // CHECK-NEXT: return [[RESULT]]
 }
 // duplicate returns an autoreleased object at +0.
-// CHECK-LABEL: sil hidden  @_T026objc_ownership_conventions5test9{{[_0-9a-zA-Z]*}}F
+// CHECK-LABEL: sil hidden @_T026objc_ownership_conventions5test9{{[_0-9a-zA-Z]*}}F
 func test9(_ g: Gizmo) -> Gizmo {
   return g.duplicate()
   // CHECK: bb0([[G:%.*]] : $Gizmo):

--- a/test/SILGen/objc_protocols.swift
+++ b/test/SILGen/objc_protocols.swift
@@ -24,7 +24,7 @@ protocol Ansible {
   func anse()
 }
 
-// CHECK-LABEL: sil hidden  @_T014objc_protocols0A8_generic{{[_0-9a-zA-Z]*}}F
+// CHECK-LABEL: sil hidden @_T014objc_protocols0A8_generic{{[_0-9a-zA-Z]*}}F
 // CHECK: bb0([[THIS:%.*]] : $T):
 // -- Result of runce is autoreleased according to default objc conv
 // CHECK: [[METHOD:%.*]] = witness_method [volatile] {{\$.*}},  #NSRuncing.runce!1.foreign

--- a/test/SILGen/objc_super.swift
+++ b/test/SILGen/objc_super.swift
@@ -8,19 +8,19 @@ import gizmo
 // a super_method instruction.
 class Hoozit : Gizmo {
 
-  // CHECK-LABEL: sil hidden  @_T010objc_super6HoozitC{{[_0-9a-zA-Z]*}}fc : $@convention(method) (@owned Hoozit) -> @owned Hoozit
+  // CHECK-LABEL: sil hidden @_T010objc_super6HoozitC{{[_0-9a-zA-Z]*}}fc : $@convention(method) (@owned Hoozit) -> @owned Hoozit
   override init() {
     // CHECK: super_method [volatile] {{%.*}} : $Hoozit, #Gizmo.init!initializer.1.foreign
     super.init()
   }
 
-  // CHECK-LABEL: sil hidden  @_T010objc_super6HoozitC5runce{{[_0-9a-zA-Z]*}}FZ : $@convention(method) (@thick Hoozit.Type) -> ()
+  // CHECK-LABEL: sil hidden @_T010objc_super6HoozitC5runce{{[_0-9a-zA-Z]*}}FZ : $@convention(method) (@thick Hoozit.Type) -> ()
   override class func runce() {
     // CHECK: super_method [volatile] {{%.*}} : $@thick Hoozit.Type, #Gizmo.runce!1.foreign
     super.runce()
   }
 
-  // CHECK-LABEL: sil hidden  @_T010objc_super6HoozitC4frob{{[_0-9a-zA-Z]*}}F : $@convention(method) (@guaranteed Hoozit) -> ()
+  // CHECK-LABEL: sil hidden @_T010objc_super6HoozitC4frob{{[_0-9a-zA-Z]*}}F : $@convention(method) (@guaranteed Hoozit) -> ()
   override func frob() {
     // CHECK: super_method [volatile] {{%.*}} : $Hoozit, #Gizmo.frob!1.foreign
     super.frob()

--- a/test/SILGen/objc_thunks.swift
+++ b/test/SILGen/objc_thunks.swift
@@ -439,7 +439,7 @@ extension Hoozit {
   // CHECK-LABEL: sil hidden [thunk] @_T011objc_thunks6HoozitC4foofyyFTo : $@convention(objc_method) (Hoozit) -> () {
 
   var extensionProperty: Int { return 0 }
-  // CHECK-LABEL: sil hidden  @_T011objc_thunks6HoozitC17extensionPropertySifg : $@convention(method) (@guaranteed Hoozit) -> Int
+  // CHECK-LABEL: sil hidden @_T011objc_thunks6HoozitC17extensionPropertySifg : $@convention(method) (@guaranteed Hoozit) -> Int
 }
 
 // Calling objc methods of subclass should go through native entry points

--- a/test/SILGen/opaque_values_silgen.swift
+++ b/test/SILGen/opaque_values_silgen.swift
@@ -687,7 +687,7 @@ func s320__transImplodeAny(_ t: @escaping (Any) -> ()) {
 
 // Tests support for address only let closures under opaque value mode - they are not by-address anymore
 // ---
-// CHECK-LABEL: sil shared @_T020opaque_values_silgen21s330___addrLetClosurexxlFxycfU_xycfU_ : $@convention(thin) <T> (@in T) -> @out T {
+// CHECK-LABEL: sil private @_T020opaque_values_silgen21s330___addrLetClosurexxlFxycfU_xycfU_ : $@convention(thin) <T> (@in T) -> @out T {
 // CHECK: bb0([[ARG:%.*]] : $T):
 // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]] : $T
 // CHECK:   [[COPY_ARG:%.*]] = copy_value [[BORROWED_ARG]] : $T

--- a/test/SILGen/properties.swift
+++ b/test/SILGen/properties.swift
@@ -6,7 +6,7 @@ func use(_: Int) {}
 func use(_: Double) {}
 func getInt() -> Int { return zero }
 
-// CHECK-LABEL: sil hidden  @{{.*}}physical_tuple_lvalue
+// CHECK-LABEL: sil hidden @{{.*}}physical_tuple_lvalue
 // CHECK: bb0(%0 : $Int):
 func physical_tuple_lvalue(_ c: Int) {
   var x : (Int, Int)
@@ -20,7 +20,7 @@ func physical_tuple_lvalue(_ c: Int) {
 
 func tuple_rvalue() -> (Int, Int) {}
 
-// CHECK-LABEL: sil hidden  @{{.*}}physical_tuple_rvalue
+// CHECK-LABEL: sil hidden @{{.*}}physical_tuple_rvalue
 func physical_tuple_rvalue() -> Int {
   return tuple_rvalue().1
   // CHECK: [[FUNC:%[0-9]+]] = function_ref @_T010properties12tuple_rvalue{{[_0-9a-zA-Z]*}}F
@@ -29,7 +29,7 @@ func physical_tuple_rvalue() -> Int {
   // CHECK: return [[RET]]
 }
 
-// CHECK-LABEL: sil hidden  @_T010properties16tuple_assignment{{[_0-9a-zA-Z]*}}F
+// CHECK-LABEL: sil hidden @_T010properties16tuple_assignment{{[_0-9a-zA-Z]*}}F
 func tuple_assignment(_ a: inout Int, b: inout Int) {
   // CHECK: bb0([[A_ADDR:%[0-9]+]] : $*Int, [[B_ADDR:%[0-9]+]] : $*Int):
   // CHECK: [[B:%[0-9]+]] = load [trivial] [[B_ADDR]]
@@ -39,7 +39,7 @@ func tuple_assignment(_ a: inout Int, b: inout Int) {
   (a, b) = (b, a)
 }
 
-// CHECK-LABEL: sil hidden  @_T010properties18tuple_assignment_2{{[_0-9a-zA-Z]*}}F
+// CHECK-LABEL: sil hidden @_T010properties18tuple_assignment_2{{[_0-9a-zA-Z]*}}F
 func tuple_assignment_2(_ a: inout Int, b: inout Int, xy: (Int, Int)) {
   // CHECK: bb0([[A_ADDR:%[0-9]+]] : $*Int, [[B_ADDR:%[0-9]+]] : $*Int, [[X:%[0-9]+]] : $Int, [[Y:%[0-9]+]] : $Int):
   (a, b) = xy
@@ -87,7 +87,7 @@ struct Val {
   subscript(i: Int) -> Float { get {} set {} }
 }
 
-// CHECK-LABEL: sil hidden  @_T010properties22physical_struct_lvalue{{[_0-9a-zA-Z]*}}F
+// CHECK-LABEL: sil hidden @_T010properties22physical_struct_lvalue{{[_0-9a-zA-Z]*}}F
 func physical_struct_lvalue(_ c: Int) {
   var v : Val
   // CHECK: [[VADDR:%[0-9]+]] = alloc_box ${ var Val }
@@ -95,7 +95,7 @@ func physical_struct_lvalue(_ c: Int) {
   // CHECK: assign %0 to [[X_1]]
 }
 
-// CHECK-LABEL: sil hidden  @_T010properties21physical_class_lvalue{{[_0-9a-zA-Z]*}}F : $@convention(thin) (@owned Ref, Int) -> ()
+// CHECK-LABEL: sil hidden @_T010properties21physical_class_lvalue{{[_0-9a-zA-Z]*}}F : $@convention(thin) (@owned Ref, Int) -> ()
 // CHECK: bb0([[ARG0:%.*]] : $Ref,
  func physical_class_lvalue(_ r: Ref, a: Int) {
     r.y = a
@@ -107,7 +107,7 @@ func physical_struct_lvalue(_ c: Int) {
   }
 
 
-// CHECK-LABEL: sil hidden  @_T010properties24physical_subclass_lvalue{{[_0-9a-zA-Z]*}}F
+// CHECK-LABEL: sil hidden @_T010properties24physical_subclass_lvalue{{[_0-9a-zA-Z]*}}F
 func physical_subclass_lvalue(_ r: RefSubclass, a: Int) {
   // CHECK: bb0([[ARG1:%.*]] : $RefSubclass, [[ARG2:%.*]] : $Int):
   r.y = a
@@ -131,7 +131,7 @@ func physical_subclass_lvalue(_ r: RefSubclass, a: Int) {
 
 func struct_rvalue() -> Val {}
 
-// CHECK-LABEL: sil hidden  @_T010properties22physical_struct_rvalue{{[_0-9a-zA-Z]*}}F
+// CHECK-LABEL: sil hidden @_T010properties22physical_struct_rvalue{{[_0-9a-zA-Z]*}}F
 func physical_struct_rvalue() -> Int {
   return struct_rvalue().y
   // CHECK: [[FUNC:%[0-9]+]] = function_ref @_T010properties13struct_rvalueAA3ValVyF
@@ -145,7 +145,7 @@ func physical_struct_rvalue() -> Int {
 
 func class_rvalue() -> Ref {}
 
-// CHECK-LABEL: sil hidden  @_T010properties21physical_class_rvalue{{[_0-9a-zA-Z]*}}F
+// CHECK-LABEL: sil hidden @_T010properties21physical_class_rvalue{{[_0-9a-zA-Z]*}}F
 func physical_class_rvalue() -> Int {
   return class_rvalue().y
   // CHECK: [[FUNC:%[0-9]+]] = function_ref @_T010properties12class_rvalueAA3RefCyF
@@ -156,7 +156,7 @@ func physical_class_rvalue() -> Int {
   // CHECK: return [[RET]]
 }
 
-// CHECK-LABEL: sil hidden  @_T010properties18logical_struct_get{{[_0-9a-zA-Z]*}}F
+// CHECK-LABEL: sil hidden @_T010properties18logical_struct_get{{[_0-9a-zA-Z]*}}F
 func logical_struct_get() -> Int {
   return struct_rvalue().z
   // CHECK: [[GET_RVAL:%[0-9]+]] = function_ref @_T010properties13struct_rvalue{{[_0-9a-zA-Z]*}}F
@@ -166,7 +166,7 @@ func logical_struct_get() -> Int {
   // CHECK: return [[VALUE]]
 }
 
-// CHECK-LABEL: sil hidden  @_T010properties18logical_struct_set{{[_0-9a-zA-Z]*}}F
+// CHECK-LABEL: sil hidden @_T010properties18logical_struct_set{{[_0-9a-zA-Z]*}}F
 func logical_struct_set(_ value: inout Val, z: Int) {
   // CHECK: bb0([[VAL:%[0-9]+]] : $*Val, [[Z:%[0-9]+]] : $Int):
   value.z = z
@@ -175,7 +175,7 @@ func logical_struct_set(_ value: inout Val, z: Int) {
   // CHECK: return
 }
 
-// CHECK-LABEL: sil hidden  @_T010properties27logical_struct_in_tuple_set{{[_0-9a-zA-Z]*}}F
+// CHECK-LABEL: sil hidden @_T010properties27logical_struct_in_tuple_set{{[_0-9a-zA-Z]*}}F
 func logical_struct_in_tuple_set(_ value: inout (Int, Val), z: Int) {
   // CHECK: bb0([[VAL:%[0-9]+]] : $*(Int, Val), [[Z:%[0-9]+]] : $Int):
   value.1.z = z
@@ -185,7 +185,7 @@ func logical_struct_in_tuple_set(_ value: inout (Int, Val), z: Int) {
   // CHECK: return
 }
 
-// CHECK-LABEL: sil hidden  @_T010properties29logical_struct_in_reftype_set{{[_0-9a-zA-Z]*}}F
+// CHECK-LABEL: sil hidden @_T010properties29logical_struct_in_reftype_set{{[_0-9a-zA-Z]*}}F
 func logical_struct_in_reftype_set(_ value: inout Val, z1: Int) {
   // CHECK: bb0([[VAL:%[0-9]+]] : $*Val, [[Z1:%[0-9]+]] : $Int):
   value.ref.val_prop.z_tuple.1 = z1
@@ -243,12 +243,12 @@ func logical_struct_in_reftype_set(_ value: inout Val, z1: Int) {
 
 func reftype_rvalue() -> Ref {}
 
-// CHECK-LABEL: sil hidden  @_T010properties18reftype_rvalue_set{{[_0-9a-zA-Z]*}}F
+// CHECK-LABEL: sil hidden @_T010properties18reftype_rvalue_set{{[_0-9a-zA-Z]*}}F
 func reftype_rvalue_set(_ value: Val) {
   reftype_rvalue().val_prop = value
 }
 
-// CHECK-LABEL: sil hidden  @_T010properties27tuple_in_logical_struct_set{{[_0-9a-zA-Z]*}}F
+// CHECK-LABEL: sil hidden @_T010properties27tuple_in_logical_struct_set{{[_0-9a-zA-Z]*}}F
 func tuple_in_logical_struct_set(_ value: inout Val, z1: Int) {
   // CHECK: bb0([[VAL:%[0-9]+]] : $*Val, [[Z1:%[0-9]+]] : $Int):
   value.z_tuple.1 = z1
@@ -273,17 +273,17 @@ func tuple_in_logical_struct_set(_ value: inout Val, z1: Int) {
 }
 
 var global_prop : Int {
-  // CHECK-LABEL: sil hidden  @_T010properties11global_prop{{[_0-9a-zA-Z]*}}fg
+  // CHECK-LABEL: sil hidden @_T010properties11global_prop{{[_0-9a-zA-Z]*}}fg
   get {
     return zero
   }
-  // CHECK-LABEL: sil hidden  @_T010properties11global_prop{{[_0-9a-zA-Z]*}}fs
+  // CHECK-LABEL: sil hidden @_T010properties11global_prop{{[_0-9a-zA-Z]*}}fs
   set {
     use(newValue)
   }
 }
 
-// CHECK-LABEL: sil hidden  @_T010properties18logical_global_get{{[_0-9a-zA-Z]*}}F
+// CHECK-LABEL: sil hidden @_T010properties18logical_global_get{{[_0-9a-zA-Z]*}}F
 func logical_global_get() -> Int {
   return global_prop
   // CHECK: [[GET:%[0-9]+]] = function_ref @_T010properties11global_prop{{[_0-9a-zA-Z]*}}fg
@@ -291,14 +291,14 @@ func logical_global_get() -> Int {
   // CHECK: return [[VALUE]]
 }
 
-// CHECK-LABEL: sil hidden  @_T010properties18logical_global_set{{[_0-9a-zA-Z]*}}F
+// CHECK-LABEL: sil hidden @_T010properties18logical_global_set{{[_0-9a-zA-Z]*}}F
 func logical_global_set(_ x: Int) {
   global_prop = x
   // CHECK: [[SET:%[0-9]+]] = function_ref @_T010properties11global_prop{{[_0-9a-zA-Z]*}}fs
   // CHECK: apply [[SET]](%0)
 }
 
-// CHECK-LABEL: sil hidden  @_T010properties17logical_local_get{{[_0-9a-zA-Z]*}}F
+// CHECK-LABEL: sil hidden @_T010properties17logical_local_get{{[_0-9a-zA-Z]*}}F
 func logical_local_get(_ x: Int) -> Int {
   var prop : Int {
     get {
@@ -309,10 +309,10 @@ func logical_local_get(_ x: Int) -> Int {
   // CHECK: apply [[GET_REF]](%0)
   return prop
 }
-// CHECK-: sil shared [[PROP_GET_CLOSURE]]
+// CHECK-: sil private [[PROP_GET_CLOSURE]]
 // CHECK: bb0(%{{[0-9]+}} : $Int):
 
-// CHECK-LABEL: sil hidden  @_T010properties26logical_local_captured_get{{[_0-9a-zA-Z]*}}F
+// CHECK-LABEL: sil hidden @_T010properties26logical_local_captured_get{{[_0-9a-zA-Z]*}}F
 func logical_local_captured_get(_ x: Int) -> Int {
   var prop : Int {
     get {
@@ -327,12 +327,12 @@ func logical_local_captured_get(_ x: Int) -> Int {
   // CHECK: [[FUNC_REF:%[0-9]+]] = function_ref @_T010properties26logical_local_captured_getS2iF0E5_propL_SiyF
   // CHECK: apply [[FUNC_REF]](%0)
 }
-// CHECK: sil shared @_T010properties26logical_local_captured_get{{.*}}fg
+// CHECK: sil private @_T010properties26logical_local_captured_get{{.*}}fg
 // CHECK: bb0(%{{[0-9]+}} : $Int):
 
 func inout_arg(_ x: inout Int) {}
 
-// CHECK-LABEL: sil hidden  @_T010properties14physical_inout{{[_0-9a-zA-Z]*}}F
+// CHECK-LABEL: sil hidden @_T010properties14physical_inout{{[_0-9a-zA-Z]*}}F
 func physical_inout(_ x: Int) {
   var x = x
   // CHECK: [[XADDR:%[0-9]+]] = alloc_box ${ var Int }
@@ -346,7 +346,7 @@ func physical_inout(_ x: Int) {
 /* TODO check writeback to more complex logical prop, check that writeback
  * reuses temporaries */
 
-// CHECK-LABEL: sil hidden  @_T010properties17val_subscript_get{{[_0-9a-zA-Z]*}}F : $@convention(thin) (@owned Val, Int) -> Float
+// CHECK-LABEL: sil hidden @_T010properties17val_subscript_get{{[_0-9a-zA-Z]*}}F : $@convention(thin) (@owned Val, Int) -> Float
 // CHECK: bb0([[VVAL:%[0-9]+]] : $Val, [[I:%[0-9]+]] : $Int):
 func val_subscript_get(_ v: Val, i: Int) -> Float {
   return v[i]
@@ -358,7 +358,7 @@ func val_subscript_get(_ v: Val, i: Int) -> Float {
   // CHECK: return [[RET]]
 }
 
-// CHECK-LABEL: sil hidden  @_T010properties17val_subscript_set{{[_0-9a-zA-Z]*}}F
+// CHECK-LABEL: sil hidden @_T010properties17val_subscript_set{{[_0-9a-zA-Z]*}}F
 // CHECK: bb0(%0 : $Val, [[I:%[0-9]+]] : $Int, [[X:%[0-9]+]] : $Float):
 func val_subscript_set(_ v: Val, i: Int, x: Float) {
   var v = v
@@ -378,27 +378,27 @@ struct Generic<T> {
 
   subscript(x: T) -> T { get {} set {} }
 
-  // CHECK-LABEL: sil hidden  @_T010properties7GenericV19copy_typevar_member{{[_0-9a-zA-Z]*}}F
+  // CHECK-LABEL: sil hidden @_T010properties7GenericV19copy_typevar_member{{[_0-9a-zA-Z]*}}F
   mutating
   func copy_typevar_member(_ x: Generic<T>) {
     typevar_member = x.typevar_member
   }
 }
 
-// CHECK-LABEL: sil hidden  @_T010properties21generic_mono_phys_get{{[_0-9a-zA-Z]*}}F
+// CHECK-LABEL: sil hidden @_T010properties21generic_mono_phys_get{{[_0-9a-zA-Z]*}}F
 func generic_mono_phys_get<T>(_ g: Generic<T>) -> Int {
   return g.mono_phys
   // CHECK: struct_element_addr %{{.*}}, #Generic.mono_phys
 }
 
-// CHECK-LABEL: sil hidden  @_T010properties20generic_mono_log_get{{[_0-9a-zA-Z]*}}F
+// CHECK-LABEL: sil hidden @_T010properties20generic_mono_log_get{{[_0-9a-zA-Z]*}}F
 func generic_mono_log_get<T>(_ g: Generic<T>) -> Int {
   return g.mono_log
   // CHECK: [[GENERIC_GET_METHOD:%[0-9]+]] = function_ref @_T010properties7GenericV8mono_log{{[_0-9a-zA-Z]*}}fg
   // CHECK: apply [[GENERIC_GET_METHOD]]<
 }
 
-// CHECK-LABEL: sil hidden  @_T010properties20generic_mono_log_set{{[_0-9a-zA-Z]*}}F
+// CHECK-LABEL: sil hidden @_T010properties20generic_mono_log_set{{[_0-9a-zA-Z]*}}F
 func generic_mono_log_set<T>(_ g: Generic<T>, x: Int) {
   var g = g
   g.mono_log = x
@@ -406,34 +406,34 @@ func generic_mono_log_set<T>(_ g: Generic<T>, x: Int) {
   // CHECK: apply [[GENERIC_SET_METHOD]]<
 }
 
-// CHECK-LABEL: sil hidden  @_T010properties26generic_mono_subscript_get{{[_0-9a-zA-Z]*}}F
+// CHECK-LABEL: sil hidden @_T010properties26generic_mono_subscript_get{{[_0-9a-zA-Z]*}}F
 func generic_mono_subscript_get<T>(_ g: Generic<T>, i: Int) -> Float {
   return g[i]
   // CHECK: [[GENERIC_GET_METHOD:%[0-9]+]] = function_ref @_T010properties7GenericV9subscript{{[_0-9a-zA-Z]*}}fg
   // CHECK: apply [[GENERIC_GET_METHOD]]<
 }
 
-// CHECK-LABEL: sil hidden  @{{.*}}generic_mono_subscript_set
+// CHECK-LABEL: sil hidden @{{.*}}generic_mono_subscript_set
 func generic_mono_subscript_set<T>(_ g: inout Generic<T>, i: Int, x: Float) {
   g[i] = x
   // CHECK: [[GENERIC_SET_METHOD:%[0-9]+]] = function_ref @_T010properties7GenericV9subscript{{[_0-9a-zA-Z]*}}fs
   // CHECK: apply [[GENERIC_SET_METHOD]]<
 }
 
-// CHECK-LABEL: sil hidden  @{{.*}}bound_generic_mono_phys_get
+// CHECK-LABEL: sil hidden @{{.*}}bound_generic_mono_phys_get
 func bound_generic_mono_phys_get(_ g: inout Generic<UnicodeScalar>, x: Int) -> Int {
   return g.mono_phys
   // CHECK: struct_element_addr %{{.*}}, #Generic.mono_phys
 }
 
-// CHECK-LABEL: sil hidden  @_T010properties26bound_generic_mono_log_get{{[_0-9a-zA-Z]*}}F
+// CHECK-LABEL: sil hidden @_T010properties26bound_generic_mono_log_get{{[_0-9a-zA-Z]*}}F
 func bound_generic_mono_log_get(_ g: Generic<UnicodeScalar>, x: Int) -> Int {
   return g.mono_log
 // CHECK: [[GENERIC_GET_METHOD:%[0-9]+]] = function_ref @_T010properties7GenericV8mono_log{{[_0-9a-zA-Z]*}}fg
   // CHECK: apply [[GENERIC_GET_METHOD]]<
 }
 
-// CHECK-LABEL: sil hidden  @_T010properties22generic_subscript_type{{[_0-9a-zA-Z]*}}F
+// CHECK-LABEL: sil hidden @_T010properties22generic_subscript_type{{[_0-9a-zA-Z]*}}F
 func generic_subscript_type<T>(_ g: Generic<T>, i: T, x: T) -> T {
   var g = g
   g[i] = x

--- a/test/SILGen/rethrows.swift
+++ b/test/SILGen/rethrows.swift
@@ -32,7 +32,7 @@ func test0() throws {
 // CHECK:     [[ERROR]]([[T0:%.*]] : $Error):
 // CHECK-NEXT:  throw [[T0]]
 //   Closure.
-// CHECK-LABEL: sil shared @_T08rethrows5test1yyKFSiyKcfU_ : $@convention(thin) () -> (Int, @error Error) {
+// CHECK-LABEL: sil private @_T08rethrows5test1yyKFSiyKcfU_ : $@convention(thin) () -> (Int, @error Error) {
 // CHECK:       [[RETHROWER:%.*]] = function_ref @_T08rethrows9rethrowerS2iyKcKF : $@convention(thin) (@owned @callee_owned () -> (Int, @error Error)) -> (Int, @error Error)
 // CHECK:       [[THROWER:%.*]] = function_ref @_T08rethrows7throwerSiyKF : $@convention(thin) () -> (Int, @error Error)
 // CHECK:       [[T0:%.*]] = thin_to_thick_function [[THROWER]]

--- a/test/SILGen/sil_locations.swift
+++ b/test/SILGen/sil_locations.swift
@@ -8,7 +8,7 @@ func ifexpr() -> Int {
     x+=1
   }
   return x
-  // CHECK-LABEL: sil hidden  @_T013sil_locations6ifexprSiyF
+  // CHECK-LABEL: sil hidden @_T013sil_locations6ifexprSiyF
   // CHECK: apply {{.*}}, loc "{{.*}}":[[@LINE-5]]:6
   // CHECK: cond_br {{%.*}}, [[TRUE_BB:bb[0-9]+]], [[FALSE_BB:bb[0-9]+]], loc "{{.*}}":[[@LINE-6]]:6
   // CHECK: br [[FALSE_BB]], loc "{{.*}}":[[@LINE-5]]:3
@@ -23,7 +23,7 @@ func ifelseexpr() -> Int {
     x-=1
   }
   return x
-  // CHECK-LABEL: sil hidden  @_T013sil_locations10ifelseexprSiyF
+  // CHECK-LABEL: sil hidden @_T013sil_locations10ifelseexprSiyF
   // CHECK: cond_br {{%.*}}, [[TRUE_BB:bb[0-9]+]], [[FALSE_BB:bb[0-9]+]], loc "{{.*}}":[[@LINE-7]]:6
   // CHECK: [[TRUE_BB]]:
   // CHECK: br bb{{[0-9]+}}, loc "{{.*}}":[[@LINE-7]]:3
@@ -40,7 +40,7 @@ func ifexpr_return() -> Int {
     return 5
   }
   return 6
-  // CHECK-LABEL: sil hidden  @_T013sil_locations13ifexpr_returnSiyF
+  // CHECK-LABEL: sil hidden @_T013sil_locations13ifexpr_returnSiyF
   // CHECK: apply {{.*}}, loc "{{.*}}":[[@LINE-5]]:6
   // CHECK: cond_br {{%.*}}, [[TRUE_BB:bb[0-9]+]], [[FALSE_BB:bb[0-9]+]], loc "{{.*}}":[[@LINE-6]]:6
   // CHECK: [[TRUE_BB]]:
@@ -53,7 +53,7 @@ func ifexpr_return() -> Int {
 func ifexpr_rval() -> Int {
   var x = true ? 5 : 6
   return x
-  // CHECK-LABEL: sil hidden  @_T013sil_locations11ifexpr_rvalSiyF
+  // CHECK-LABEL: sil hidden @_T013sil_locations11ifexpr_rvalSiyF
   // CHECK: apply {{.*}}, loc "{{.*}}":[[@LINE-3]]:11
   // CHECK: cond_br {{%.*}}, [[TRUE_BB:bb[0-9]+]], [[FALSE_BB:bb[0-9]+]], loc "{{.*}}":[[@LINE-4]]:11
   // CHECK: [[TRUE_BB]]:
@@ -62,20 +62,10 @@ func ifexpr_rval() -> Int {
   // CHECK: br bb{{[0-9]+}}({{%.*}}), loc "{{.*}}":[[@LINE-8]]:22
 }
 
-
-
-
-
-
-
-
-
-
-
 // --- Test function calls.
 func simpleDirectCallTest(_ i: Int) -> Int {
   return simpleDirectCallTest(i)
-  // CHECK-LABEL: sil hidden  @_T013sil_locations20simpleDirectCallTestS2iF
+  // CHECK-LABEL: sil hidden @_T013sil_locations20simpleDirectCallTestS2iF
   // CHECK: function_ref @_T013sil_locations20simpleDirectCallTestS2iF : {{.*}}, loc "{{.*}}":[[@LINE-2]]:10
   // CHECK: {{%.*}} apply {{%.*}} line:[[@LINE-3]]:10
 }
@@ -85,9 +75,8 @@ func templateTest<T>(_ value: T) -> T {
 }
 func useTemplateTest() -> Int {
   return templateTest(5);
-  // CHECK-LABEL: sil hidden  @_T013sil_locations15useTemplateTestSiyF
-
-  // CHECK: function_ref @_T0S2i{{[_0-9a-zA-Z]*}}fC :{{.*}}, loc "{{.*}}":87
+  // CHECK-LABEL: sil hidden @_T013sil_locations15useTemplateTestSiyF
+  // CHECK: function_ref @_T0S2i{{[_0-9a-zA-Z]*}}fC :{{.*}}, loc "{{.*}}":77
 }
 
 func foo(_ x: Int) -> Int {
@@ -95,7 +84,7 @@ func foo(_ x: Int) -> Int {
     return x + y
   }
   return bar(1)
-  // CHECK-LABEL: sil hidden  @_T013sil_locations3foo{{[_0-9a-zA-Z]*}}F
+  // CHECK-LABEL: sil hidden @_T013sil_locations3foo{{[_0-9a-zA-Z]*}}F
   // CHECK: [[CLOSURE:%[0-9]+]] = function_ref {{.*}}, loc "{{.*}}":[[@LINE-2]]:10
   // CHECK: apply [[CLOSURE:%[0-9]+]]
 }
@@ -106,7 +95,7 @@ class LocationClass {
 func testMethodCall() {
   var l: LocationClass
   l.mem();
-  // CHECK-LABEL: sil hidden  @_T013sil_locations14testMethodCallyyF
+  // CHECK-LABEL: sil hidden @_T013sil_locations14testMethodCallyyF
   
   // CHECK: class_method {{.[0-9]+}} : $LocationClass, #LocationClass.mem!1 {{.*}}, loc "{{.*}}":[[@LINE-3]]:5
 }
@@ -117,7 +106,7 @@ func multipleReturnsImplicitAndExplicit() {
     return
   }
   x += 1
-  // CHECK-LABEL: sil hidden  @_T013sil_locations34multipleReturnsImplicitAndExplicityyF
+  // CHECK-LABEL: sil hidden @_T013sil_locations34multipleReturnsImplicitAndExplicityyF
   // CHECK: cond_br
   // CHECK: br bb{{[0-9]+}}, loc "{{.*}}":[[@LINE-5]]:5, {{.*}}:return
   // CHECK: br bb{{[0-9]+}}, loc "{{.*}}":[[@LINE+2]]:1, {{.*}}:imp_return
@@ -126,7 +115,7 @@ func multipleReturnsImplicitAndExplicit() {
 
 func simplifiedImplicitReturn() -> () {
   var y = 0 
-  // CHECK-LABEL: sil hidden  @_T013sil_locations24simplifiedImplicitReturnyyF
+  // CHECK-LABEL: sil hidden @_T013sil_locations24simplifiedImplicitReturnyyF
   // CHECK: return {{.*}}, loc "{{.*}}":[[@LINE+1]]:1, {{.*}}:imp_return
 }
 
@@ -169,9 +158,6 @@ func testIf() {
   //
   //
   // CHECK: br {{.*}}, loc "{{.*}}":[[@LINE-13]]:6
-
-
-
 }
 
 func testFor() {
@@ -201,13 +187,11 @@ func testTuples() {
   var tt = (2, (4,5))
   var d = "foo"
   // CHECK-LABEL: sil hidden @_T013sil_locations10testTuplesyyF
-
-
-  // CHECK: tuple_element_addr {{.*}}, loc "{{.*}}":[[@LINE-6]]:11
-  // CHECK: integer_literal $Builtin.Int2048, 2, loc "{{.*}}":[[@LINE-7]]:12
-  // CHECK: integer_literal $Builtin.Int2048, 3, loc "{{.*}}":[[@LINE-8]]:14
-  // CHECK: tuple_element_addr {{.*}}, loc "{{.*}}":[[@LINE-8]]:12
-  // CHECK: tuple_element_addr {{.*}}, loc "{{.*}}":[[@LINE-9]]:16  
+  // CHECK: tuple_element_addr {{.*}}, loc "{{.*}}":[[@LINE-4]]:11
+  // CHECK: integer_literal $Builtin.Int2048, 2, loc "{{.*}}":[[@LINE-5]]:12
+  // CHECK: integer_literal $Builtin.Int2048, 3, loc "{{.*}}":[[@LINE-6]]:14
+  // CHECK: tuple_element_addr {{.*}}, loc "{{.*}}":[[@LINE-6]]:12
+  // CHECK: tuple_element_addr {{.*}}, loc "{{.*}}":[[@LINE-7]]:16  
 }
 
 // Test tuple imploding/exploding.
@@ -222,26 +206,18 @@ func b<T : Ordinable>(_ seq: T) -> (Int) -> Int {
 func captures_tuple<T, U>(x: (T, U)) -> () -> (T, U) {
   return {x}
   // CHECK-LABEL: sil hidden @_T013sil_locations14captures_tuple{{[_0-9a-zA-Z]*}}F
+  // CHECK: tuple_element_addr {{.*}}, loc "{{.*}}":[[@LINE-3]]:27
+  // CHECK: copy_addr [take] {{.*}}, loc "{{.*}}":[[@LINE-4]]:27
+  // CHECK: function_ref {{.*}}, loc "{{.*}}":[[@LINE-4]]:10
 
-
-  // CHECK: tuple_element_addr {{.*}}, loc "{{.*}}":[[@LINE-5]]:27
-  // CHECK: copy_addr [take] {{.*}}, loc "{{.*}}":[[@LINE-6]]:27
-  // CHECK: function_ref {{.*}}, loc "{{.*}}":[[@LINE-6]]:10
-
-  
-  // CHECK-LABEL: sil shared @_T013sil_locations14captures_tuple{{.*}}fU_
-  // CHECK: copy_addr {{.*}}, loc "{{.*}}":[[@LINE-10]]:11
+  // CHECK-LABEL: sil private @_T013sil_locations14captures_tuple{{.*}}fU_
+  // CHECK: copy_addr {{.*}}, loc "{{.*}}":[[@LINE-7]]:11
 }
 
 func interpolated_string(_ x: Int, y: String) -> String {
   return "The \(x) Million Dollar \(y)"
   // CHECK-LABEL: sil hidden @_T013sil_locations19interpolated_string{{[_0-9a-zA-Z]*}}F
-
-
-
-  // CHECK: copy_value{{.*}}, loc "{{.*}}":[[@LINE-5]]:37
-
-
+  // CHECK: copy_value{{.*}}, loc "{{.*}}":[[@LINE-2]]:37
 }
 
 

--- a/test/SILGen/statements.swift
+++ b/test/SILGen/statements.swift
@@ -32,7 +32,7 @@ func assignment(_ x: Int, y: Int) {
   (x, y) = (1,2)
 }
 
-// CHECK-LABEL: sil hidden  @{{.*}}assignment
+// CHECK-LABEL: sil hidden @{{.*}}assignment
 // CHECK: integer_literal $Builtin.Int2048, 42
 // CHECK: assign
 // CHECK: integer_literal $Builtin.Int2048, 57
@@ -45,7 +45,7 @@ func if_test(_ x: Int, y: Bool) {
   bar(x);
 }
 
-// CHECK-LABEL: sil hidden  @_T010statements7if_test{{[_0-9a-zA-Z]*}}F
+// CHECK-LABEL: sil hidden @_T010statements7if_test{{[_0-9a-zA-Z]*}}F
 
 func if_else(_ x: Int, y: Bool) {
   if (y) {
@@ -56,7 +56,7 @@ func if_else(_ x: Int, y: Bool) {
   bar(x);
 }
 
-// CHECK-LABEL: sil hidden  @_T010statements7if_else{{[_0-9a-zA-Z]*}}F
+// CHECK-LABEL: sil hidden @_T010statements7if_else{{[_0-9a-zA-Z]*}}F
 
 func nested_if(_ x: Int, y: Bool, z: Bool) {
   if (y) {
@@ -71,7 +71,7 @@ func nested_if(_ x: Int, y: Bool, z: Bool) {
   bar(x);
 }
 
-// CHECK-LABEL: sil hidden  @_T010statements9nested_if{{[_0-9a-zA-Z]*}}F
+// CHECK-LABEL: sil hidden @_T010statements9nested_if{{[_0-9a-zA-Z]*}}F
 
 func nested_if_merge_noret(_ x: Int, y: Bool, z: Bool) {
   if (y) {
@@ -85,7 +85,7 @@ func nested_if_merge_noret(_ x: Int, y: Bool, z: Bool) {
   }
 }
 
-// CHECK-LABEL: sil hidden  @_T010statements21nested_if_merge_noret{{[_0-9a-zA-Z]*}}F
+// CHECK-LABEL: sil hidden @_T010statements21nested_if_merge_noret{{[_0-9a-zA-Z]*}}F
 
 func nested_if_merge_ret(_ x: Int, y: Bool, z: Bool) -> Int {
   if (y) {
@@ -101,7 +101,7 @@ func nested_if_merge_ret(_ x: Int, y: Bool, z: Bool) -> Int {
   return 2
 }
 
-// CHECK-LABEL: sil hidden  @_T010statements19nested_if_merge_ret{{[_0-9a-zA-Z]*}}F
+// CHECK-LABEL: sil hidden @_T010statements19nested_if_merge_ret{{[_0-9a-zA-Z]*}}F
 
 func else_break(_ x: Int, y: Bool, z: Bool) {
   while z {
@@ -112,7 +112,7 @@ func else_break(_ x: Int, y: Bool, z: Bool) {
   }
 }
 
-// CHECK-LABEL: sil hidden  @_T010statements10else_break{{[_0-9a-zA-Z]*}}F
+// CHECK-LABEL: sil hidden @_T010statements10else_break{{[_0-9a-zA-Z]*}}F
 
 func loop_with_break(_ x: Int, _ y: Bool, _ z: Bool) -> Int {
   while (x > 2) {
@@ -123,7 +123,7 @@ func loop_with_break(_ x: Int, _ y: Bool, _ z: Bool) -> Int {
   }
 }
 
-// CHECK-LABEL: sil hidden  @_T010statements15loop_with_break{{[_0-9a-zA-Z]*}}F
+// CHECK-LABEL: sil hidden @_T010statements15loop_with_break{{[_0-9a-zA-Z]*}}F
 
 func loop_with_continue(_ x: Int, y: Bool, z: Bool) -> Int {
   while (x > 2) {
@@ -136,7 +136,7 @@ func loop_with_continue(_ x: Int, y: Bool, z: Bool) -> Int {
   bar(x);
 }
 
-// CHECK-LABEL: sil hidden  @_T010statements18loop_with_continue{{[_0-9a-zA-Z]*}}F
+// CHECK-LABEL: sil hidden @_T010statements18loop_with_continue{{[_0-9a-zA-Z]*}}F
 
 func do_loop_with_continue(_ x: Int, y: Bool, z: Bool) -> Int {
   repeat {
@@ -150,10 +150,10 @@ func do_loop_with_continue(_ x: Int, y: Bool, z: Bool) -> Int {
   bar(x);
 }
 
-// CHECK-LABEL: sil hidden  @_T010statements21do_loop_with_continue{{[_0-9a-zA-Z]*}}F 
+// CHECK-LABEL: sil hidden @_T010statements21do_loop_with_continue{{[_0-9a-zA-Z]*}}F 
 
 
-// CHECK-LABEL: sil hidden  @{{.*}}for_loops1
+// CHECK-LABEL: sil hidden @{{.*}}for_loops1
 func for_loops1(_ x: Int, c: Bool) {
   for i in 1..<100 {
     markUsed(i)
@@ -161,7 +161,7 @@ func for_loops1(_ x: Int, c: Bool) {
 
 }
 
-// CHECK-LABEL: sil hidden  @{{.*}}for_loops2
+// CHECK-LABEL: sil hidden @{{.*}}for_loops2
 func for_loops2() {
   // rdar://problem/19316670
   // CHECK: [[NEXT:%[0-9]+]] = function_ref @_T0s16IndexingIteratorV4next{{[_0-9a-zA-Z]*}}F
@@ -182,7 +182,7 @@ func void_return() {
     return
   }
 }
-// CHECK-LABEL: sil hidden  @_T010statements11void_return{{[_0-9a-zA-Z]*}}F
+// CHECK-LABEL: sil hidden @_T010statements11void_return{{[_0-9a-zA-Z]*}}F
 // CHECK: cond_br {{%[0-9]+}}, [[BB1:bb[0-9]+]], [[BB2:bb[0-9]+]]
 // CHECK: [[BB1]]:
 // CHECK:   br [[EPILOG:bb[0-9]+]]
@@ -195,7 +195,7 @@ func void_return() {
 func foo() {}
 
 // <rdar://problem/13549626>
-// CHECK-LABEL: sil hidden  @_T010statements14return_from_if{{[_0-9a-zA-Z]*}}F
+// CHECK-LABEL: sil hidden @_T010statements14return_from_if{{[_0-9a-zA-Z]*}}F
 func return_from_if(_ a: Bool) -> Int {
   // CHECK: bb0(%0 : $Bool):
   // CHECK: cond_br {{.*}}, [[THEN:bb[0-9]+]], [[ELSE:bb[0-9]+]]
@@ -468,10 +468,10 @@ func defer_test1() {
   // CHECK: [[C1:%.*]] = function_ref @_T010statements11defer_test1yyF6
   // CHECK: apply [[C1]]
 }
-// CHECK: sil shared @_T010statements11defer_test1yyF6
+// CHECK: sil private @_T010statements11defer_test1yyF6
 // CHECK: function_ref @{{.*}}callee1yyF
 
-// CHECK: sil shared @_T010statements11defer_test1yyF6
+// CHECK: sil private @_T010statements11defer_test1yyF6
 // CHECK: function_ref @{{.*}}callee2yyF
 
 // CHECK-LABEL: sil hidden @_T010statements11defer_test2ySbF

--- a/test/SILGen/super.swift
+++ b/test/SILGen/super.swift
@@ -117,14 +117,14 @@ public class GenericBase<T> {
 
 public class GenericDerived<T> : GenericBase<T> {
   public override func method() {
-    // CHECK-LABEL: sil shared @_T05super14GenericDerivedC6methodyyFyycfU_ : $@convention(thin) <T> (@owned GenericDerived<T>) -> ()
+    // CHECK-LABEL: sil private @_T05super14GenericDerivedC6methodyyFyycfU_ : $@convention(thin) <T> (@owned GenericDerived<T>) -> ()
     // CHECK: upcast {{.*}} : $GenericDerived<T> to $GenericBase<T>
     // CHECK: return
     {
       super.method()
     }()
 
-    // CHECK-LABEL: sil shared @_T05super14GenericDerivedC6methodyyF13localFunctionL_yylF : $@convention(thin) <T> (@owned GenericDerived<T>) -> ()
+    // CHECK-LABEL: sil private @_T05super14GenericDerivedC6methodyyF13localFunctionL_yylF : $@convention(thin) <T> (@owned GenericDerived<T>) -> ()
     // CHECK: upcast {{.*}} : $GenericDerived<T> to $GenericBase<T>
     // CHECK: return
 
@@ -133,7 +133,7 @@ public class GenericDerived<T> : GenericBase<T> {
     }
     localFunction()
 
-    // CHECK-LABEL: sil shared @_T05super14GenericDerivedC6methodyyF15genericFunctionL_yqd__r__lF : $@convention(thin) <T><U> (@in U, @owned GenericDerived<T>) -> ()
+    // CHECK-LABEL: sil private @_T05super14GenericDerivedC6methodyyF15genericFunctionL_yqd__r__lF : $@convention(thin) <T><U> (@in U, @owned GenericDerived<T>) -> ()
     // CHECK: upcast {{.*}} : $GenericDerived<T> to $GenericBase<T>
     // CHECK: return
     func genericFunction<U>(_: U) {

--- a/test/SILGen/switch.swift
+++ b/test/SILGen/switch.swift
@@ -25,7 +25,7 @@ func e() {}
 func f() {}
 func g() {}
 
-// CHECK-LABEL: sil hidden  @_T06switch5test1yyF
+// CHECK-LABEL: sil hidden @_T06switch5test1yyF
 func test1() {
   switch foo() {
   // CHECK:   function_ref @_T06switch3fooSiyF
@@ -39,7 +39,7 @@ func test1() {
   b()
 }
 
-// CHECK-LABEL: sil hidden  @_T06switch5test2yyF
+// CHECK-LABEL: sil hidden @_T06switch5test2yyF
 func test2() {
   switch foo() {
   // CHECK:   function_ref @_T06switch3fooSiyF
@@ -55,7 +55,7 @@ func test2() {
   c()
 }
 
-// CHECK-LABEL: sil hidden  @_T06switch5test3yyF
+// CHECK-LABEL: sil hidden @_T06switch5test3yyF
 func test3() {
   switch foo() {
   // CHECK:   function_ref @_T06switch3fooSiyF
@@ -81,7 +81,7 @@ func test3() {
   c()
 }
 
-// CHECK-LABEL: sil hidden  @_T06switch5test4yyF
+// CHECK-LABEL: sil hidden @_T06switch5test4yyF
 func test4() {
   switch (foo(), bar()) {
   // CHECK:   function_ref @_T06switch3fooSiyF
@@ -96,7 +96,7 @@ func test4() {
   b()
 }
 
-// CHECK-LABEL: sil hidden  @_T06switch5test5yyF
+// CHECK-LABEL: sil hidden @_T06switch5test5yyF
 func test5() {
   switch (foo(), bar()) {
   // CHECK:   function_ref @_T06switch3fooSiyF
@@ -131,7 +131,7 @@ func test5() {
   d()
 }
 
-// CHECK-LABEL: sil hidden  @_T06switch5test6yyF
+// CHECK-LABEL: sil hidden @_T06switch5test6yyF
 func test6() {
   switch (foo(), bar()) {
   // CHECK:   function_ref @_T06switch3fooSiyF
@@ -148,7 +148,7 @@ func test6() {
   c()
 }
 
-// CHECK-LABEL: sil hidden  @_T06switch5test7yyF
+// CHECK-LABEL: sil hidden @_T06switch5test7yyF
 func test7() {
   switch (foo(), bar()) {
   // CHECK:   function_ref @_T06switch3fooSiyF
@@ -174,7 +174,7 @@ func test7() {
   // CHECK:   function_ref @_T06switch1cyyF
 }
 
-// CHECK-LABEL: sil hidden  @_T06switch5test8yyF
+// CHECK-LABEL: sil hidden @_T06switch5test8yyF
 func test8() {
   switch (foo(), bar()) {
   // CHECK:   function_ref @_T06switch3fooSiyF
@@ -247,7 +247,7 @@ func test8() {
   g()
 }
 
-// CHECK-LABEL: sil hidden  @_T06switch5test9yyF
+// CHECK-LABEL: sil hidden @_T06switch5test9yyF
 func test9() {
   switch (foo(), bar()) {
   // CHECK:   function_ref @_T06switch3fooSiyF
@@ -282,7 +282,7 @@ func test9() {
   d()
 }
 
-// CHECK-LABEL: sil hidden  @_T06switch6test10yyF
+// CHECK-LABEL: sil hidden @_T06switch6test10yyF
 func test10() {
   switch (foo(), bar()) {
   // CHECK:   function_ref @_T06switch3fooSiyF
@@ -313,7 +313,7 @@ struct X : P { func p() {} }
 struct Y : P { func p() {} }
 struct Z : P { func p() {} }
 
-// CHECK-LABEL: sil hidden  @_T06switch10test_isa_1yAA1P_p1p_tF
+// CHECK-LABEL: sil hidden @_T06switch10test_isa_1yAA1P_p1p_tF
 func test_isa_1(p: P) {
   // CHECK: [[PTMPBUF:%[0-9]+]] = alloc_stack $P
   // CHECK-NEXT: copy_addr %0 to [initialization] [[PTMPBUF]] : $*P
@@ -360,7 +360,7 @@ func test_isa_1(p: P) {
   e()
 }
 
-// CHECK-LABEL: sil hidden  @_T06switch10test_isa_2yAA1P_p1p_tF
+// CHECK-LABEL: sil hidden @_T06switch10test_isa_2yAA1P_p1p_tF
 func test_isa_2(p: P) {
   switch (p, foo()) {
   // CHECK:   checked_cast_addr_br copy_on_success P in [[P:%.*]] : $*P to X in {{%.*}} : $*X, [[IS_X:bb[0-9]+]], [[IS_NOT_X:bb[0-9]+]]
@@ -648,7 +648,7 @@ enum MaybePair {
   case Both(Int, String)
 }
 
-// CHECK-LABEL: sil hidden  @_T06switch12test_union_1yAA9MaybePairO1u_tF
+// CHECK-LABEL: sil hidden @_T06switch12test_union_1yAA9MaybePairO1u_tF
 func test_union_1(u: MaybePair) {
   switch u {
   // CHECK: switch_enum [[SUBJECT:%.*]] : $MaybePair,
@@ -692,7 +692,7 @@ func test_union_1(u: MaybePair) {
   e()
 }
 
-// CHECK-LABEL: sil hidden  @_T06switch12test_union_2yAA9MaybePairO1u_tF
+// CHECK-LABEL: sil hidden @_T06switch12test_union_2yAA9MaybePairO1u_tF
 func test_union_2(u: MaybePair) {
   switch u {
   // CHECK: switch_enum {{%.*}} : $MaybePair,
@@ -729,7 +729,7 @@ func test_union_2(u: MaybePair) {
   d()
 }
 
-// CHECK-LABEL: sil hidden  @_T06switch12test_union_3yAA9MaybePairO1u_tF : $@convention(thin) (@owned MaybePair) -> () {
+// CHECK-LABEL: sil hidden @_T06switch12test_union_3yAA9MaybePairO1u_tF : $@convention(thin) (@owned MaybePair) -> () {
 func test_union_3(u: MaybePair) {
   // CHECK: bb0([[ARG:%.*]] : $MaybePair):
   // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
@@ -776,7 +776,7 @@ func test_union_3(u: MaybePair) {
   e()
 }
 
-// CHECK-LABEL: sil hidden  @_T06switch12test_union_4yAA9MaybePairO1u_tF
+// CHECK-LABEL: sil hidden @_T06switch12test_union_4yAA9MaybePairO1u_tF
 func test_union_4(u: MaybePair) {
   switch u {
   // CHECK: switch_enum {{%.*}} : $MaybePair,
@@ -815,7 +815,7 @@ func test_union_4(u: MaybePair) {
   e()
 }
 
-// CHECK-LABEL: sil hidden  @_T06switch12test_union_5yAA9MaybePairO1u_tF
+// CHECK-LABEL: sil hidden @_T06switch12test_union_5yAA9MaybePairO1u_tF
 func test_union_5(u: MaybePair) {
   switch u {
   // CHECK: switch_enum {{%.*}} : $MaybePair,

--- a/test/SILGen/switch_fallthrough.swift
+++ b/test/SILGen/switch_fallthrough.swift
@@ -16,7 +16,7 @@ func e() {}
 func f() {}
 func g() {}
 
-// CHECK-LABEL: sil hidden  @_T018switch_fallthrough5test1yyF
+// CHECK-LABEL: sil hidden @_T018switch_fallthrough5test1yyF
 func test1() {
   switch foo() {
   // CHECK:   cond_br {{%.*}}, [[YES_CASE1:bb[0-9]+]], {{bb[0-9]+}}
@@ -44,7 +44,7 @@ func test1() {
 }
 
 // Fallthrough should work even if the next case is normally unreachable
-// CHECK-LABEL: sil hidden  @_T018switch_fallthrough5test2yyF
+// CHECK-LABEL: sil hidden @_T018switch_fallthrough5test2yyF
 func test2() {
   switch foo() {
   // CHECK:   cond_br {{%.*}}, [[YES_CASE1:bb[0-9]+]], {{bb[0-9]+}}
@@ -71,7 +71,7 @@ func test2() {
   d()
 }
 
-// CHECK-LABEL: sil hidden  @_T018switch_fallthrough5test3yyF
+// CHECK-LABEL: sil hidden @_T018switch_fallthrough5test3yyF
 func test3() {
   switch (foo(), bar()) {
   // CHECK:   cond_br {{%.*}}, [[YES_CASE1:bb[0-9]+]], {{bb[0-9]+}}

--- a/test/SILGen/switch_var.swift
+++ b/test/SILGen/switch_var.swift
@@ -108,7 +108,7 @@ func test_var_2() {
   d()
 }
 
-// CHECK-LABEL: sil hidden  @_T010switch_var05test_B2_3yyF
+// CHECK-LABEL: sil hidden @_T010switch_var05test_B2_3yyF
 func test_var_3() {
   // CHECK:   function_ref @_T010switch_var3fooSiyF
   // CHECK:   function_ref @_T010switch_var3barSiyF
@@ -180,7 +180,7 @@ struct X : P { func p() {} }
 struct Y : P { func p() {} }
 struct Z : P { func p() {} }
 
-// CHECK-LABEL: sil hidden  @_T010switch_var05test_B2_4yAA1P_p1p_tF
+// CHECK-LABEL: sil hidden @_T010switch_var05test_B2_4yAA1P_p1p_tF
 func test_var_4(p p: P) {
   // CHECK:   function_ref @_T010switch_var3fooSiyF
   switch (p, foo()) {

--- a/test/SILGen/types.swift
+++ b/test/SILGen/types.swift
@@ -20,7 +20,7 @@ class C {
 struct S {
   var member: Int
 
-  // CHECK-LABEL: sil hidden  @{{.*}}1SV3foo{{.*}} : $@convention(method) (Int, @inout S) -> ()
+  // CHECK-LABEL: sil hidden @{{.*}}1SV3foo{{.*}} : $@convention(method) (Int, @inout S) -> ()
   mutating
   func foo(x x: Int) {
     var x = x
@@ -101,6 +101,6 @@ func referencedFromFunctionEnumFields(_ x: ReferencedFromFunctionEnum)
   }
 }
 
-// CHECK-LABEL: sil shared @_T05types1fyyF2FCL_C3zimyyF
-// CHECK-LABEL: sil shared @_T05types1gySb1b_tF2FCL_C3zimyyF
-// CHECK-LABEL: sil shared @_T05types1gySb1b_tF2FCL0_C3zimyyF
+// CHECK-LABEL: sil private @_T05types1fyyF2FCL_C3zimyyF
+// CHECK-LABEL: sil private @_T05types1gySb1b_tF2FCL_C3zimyyF
+// CHECK-LABEL: sil private @_T05types1gySb1b_tF2FCL0_C3zimyyF

--- a/test/SILGen/unowned.swift
+++ b/test/SILGen/unowned.swift
@@ -113,7 +113,7 @@ func test_unowned_let_capture(_ aC : C) {
   takeClosure { bC.f() }
 }
 
-// CHECK-LABEL: sil shared @_T07unowned05test_A12_let_captureyAA1CCFSiycfU_ : $@convention(thin) (@owned @sil_unowned C) -> Int {
+// CHECK-LABEL: sil private @_T07unowned05test_A12_let_captureyAA1CCFSiycfU_ : $@convention(thin) (@owned @sil_unowned C) -> Int {
 // CHECK: bb0([[ARG:%.*]] : $@sil_unowned C):
 // CHECK-NEXT:   debug_value %0 : $@sil_unowned C, let, name "bC", argno 1
 // CHECK-NEXT:   strong_retain_unowned [[ARG]] : $@sil_unowned C

--- a/test/SILGen/weak.swift
+++ b/test/SILGen/weak.swift
@@ -46,7 +46,7 @@ func test0(c c: C) {
 
 // <rdar://problem/16871284> silgen crashes on weak capture
 // CHECK: weak.(testClosureOverWeak () -> ()).(closure #1)
-// CHECK-LABEL: sil shared @_T04weak19testClosureOverWeakyyFSiycfU_ : $@convention(thin) (@owned { var @sil_weak Optional<C> }) -> Int {
+// CHECK-LABEL: sil private @_T04weak19testClosureOverWeakyyFSiycfU_ : $@convention(thin) (@owned { var @sil_weak Optional<C> }) -> Int {
 // CHECK: bb0(%0 : ${ var @sil_weak Optional<C> }):
 // CHECK-NEXT:  %1 = project_box %0
 // CHECK-NEXT:  debug_value_addr %1 : $*@sil_weak Optional<C>, var, name "bC", argno 1

--- a/test/SILOptimizer/caller_analysis_printer.sil
+++ b/test/SILOptimizer/caller_analysis_printer.sil
@@ -43,7 +43,7 @@ bb0:
   return %2 : $()
 }
 
-sil hidden  @call_bottom : $@convention(thin) () -> () {
+sil hidden @call_bottom : $@convention(thin) () -> () {
 bb0:
   %0 = tuple ()
   return %0 : $()

--- a/test/SILOptimizer/capture_promotion.swift
+++ b/test/SILOptimizer/capture_promotion.swift
@@ -28,5 +28,5 @@ func test_capture_promotion() -> () -> Int {
   return { x + y.foo() + z.x }
 }
 
-// CHECK: sil shared @_T017capture_promotion05test_a1_B0SiycyFSiycfU_Tf2iii_n : $@convention(thin) (Int, @owned Foo, @owned Baz) -> Int
+// CHECK: sil private @_T017capture_promotion05test_a1_B0SiycyFSiycfU_Tf2iii_n : $@convention(thin) (Int, @owned Foo, @owned Baz) -> Int
 

--- a/test/SILOptimizer/devirt_single_module_in_multiple_files.swift
+++ b/test/SILOptimizer/devirt_single_module_in_multiple_files.swift
@@ -6,12 +6,12 @@ public func test() {
   e.evaluate(1)
 }
 
-// CHECK-LABEL: sil shared @_T038devirt_single_module_in_multiple_files9EvaluatorCACycfcSiycfU_
+// CHECK-LABEL: sil private @_T038devirt_single_module_in_multiple_files9EvaluatorCACycfcSiycfU_
 // CHECK: %{{.*}} = class_method %{{.*}} : $Problem1, #Problem1.run!1 : (Problem1) -> () -> Int, $@convention(method) (@guaranteed Problem1) -> Int
 // CHECK-NEXT: apply
 // CHECK: return
 
-// CHECK-LABEL: sil shared @_T038devirt_single_module_in_multiple_files9EvaluatorCACycfcSiycfU0_
+// CHECK-LABEL: sil private @_T038devirt_single_module_in_multiple_files9EvaluatorCACycfcSiycfU0_
 // CHECK: %{{.*}} = class_method %{{.*}} : $Problem2, #Problem2.run!1 : (Problem2) -> () -> Int, $@convention(method) (@guaranteed Problem2) -> Int
 // CHECK-NEXT: apply
 // CHECK: return

--- a/test/SILOptimizer/devirt_unbound_generic.swift
+++ b/test/SILOptimizer/devirt_unbound_generic.swift
@@ -1,24 +1,24 @@
 // RUN: %target-swift-frontend -emit-sil -O %s | %FileCheck %s
 
 // We used to crash on this when trying to devirtualize t.boo(a, 1),
-// because it is an "apply" with unbound generic arguments and
-// devirtualizer is not able to devirtualize unbound generic
-// invocations yet.
+// because it is an "apply" with replacement types that contain
+// archetypes, and the devirtualizer was not able to handle that
+// case correctly.
 //
 // rdar://19912272
 
 protocol P {
-   associatedtype Node
+  associatedtype Node
 }
 
 class C<T:P> {
-   typealias Node = T.Node
+  typealias Node = T.Node
 
-   func foo(_ n:Node) {
-   }
+  func foo(_ n:Node) {
+  }
 
-   func boo<S>(_ n:Node, s:S) {
-   }
+  func boo<S>(_ n:Node, s:S) {
+  }
 }
 
 func test1<T>(_ t:C<T>, a: T.Node) {


### PR DESCRIPTION
Otherwise, we don't want them to be linkonce_odr at the LLVM level
to avoid unnecessary link-time overhead.