### PR TITLE
Get update-checkout working on Windows

### DIFF
--- a/utils/coverage/coverage-generate-data
+++ b/utils/coverage/coverage-generate-data
@@ -225,15 +225,15 @@ def main():
 
     logging.info('Starting merge on %s', build_dir)
     folders = find_folders(build_dir, '.profdir')
-    pool.map_async(merge_profdir, folders).get(9999999)
+    pool.map_async(merge_profdir, folders).get(999999)
 
     logging.info('Starting coverage data dump...')
     merged_profraw_files = find_files(build_dir, 'merged.profraw')
-    pool.map_async(dump_coverage_data, merged_profraw_files).get(9999999)
+    pool.map_async(dump_coverage_data, merged_profraw_files).get(999999)
 
     logging.info('Starting coverage data dump demangling...')
     coverage_log_files = find_files(build_dir, 'coverage.log')
-    pool.map_async(demangle_coverage_data, coverage_log_files).get(9999999)
+    pool.map_async(demangle_coverage_data, coverage_log_files).get(999999)
     return 0
 
 

--- a/utils/coverage/coverage-touch-tests
+++ b/utils/coverage/coverage-touch-tests
@@ -126,7 +126,7 @@ def main():
     covering_tests = set().union(*pool.map_async(
         worker,
         enumerate(relevant_changes)
-    ).get(9999999))
+    ).get(999999))
 
     logging.info('Combined covering tests:')
     for covering_test in covering_tests:

--- a/utils/swift_build_support/swift_build_support/shell.py
+++ b/utils/swift_build_support/swift_build_support/shell.py
@@ -229,7 +229,7 @@ def run_parallel(fn, pool_args, n_processes=0):
     print("Running ``%s`` with up to %d processes." %
           (fn.__name__, n_processes))
     pool = Pool(processes=n_processes, initializer=init, initargs=(l,))
-    results = pool.map_async(func=fn, iterable=pool_args).get(9999999)
+    results = pool.map_async(func=fn, iterable=pool_args).get(999999)
     pool.close()
     pool.join()
     return results

--- a/utils/update-checkout
+++ b/utils/update-checkout
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+
+import sys
+import update_checkout
+
+# The internal Windows implementation tries to import the current module using
+# sys.modules[__name__]. This file (called 'update-checkout') is not a valid
+# Python module name, as it contains a '-' and doesn't end with '.py'. This
+# results in errors running update-checkout on Windows:'ImportError: No module
+# named update-checkout'.
+# As such, we need to manually set sys.modules[__name__] to a valid module
+# identifier to work around these errors.
+sys.modules[__name__] = sys.modules['update_checkout']
+update_checkout.main()

--- a/utils/update_checkout.py
+++ b/utils/update_checkout.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# utils/update-checkout - Utility to update your local checkouts -*- python -*-
+# utils/update_checkout.py - Utility to update local checkouts --*- python -*-
 #
 # This source file is part of the Swift.org open source project
 #

--- a/utils/update_checkout.py
+++ b/utils/update_checkout.py
@@ -356,6 +356,7 @@ def validate_config(config):
 
 
 def main():
+    freeze_support()
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawDescriptionHelpFormatter,
         description="""
@@ -478,15 +479,13 @@ By default, updates your checkouts of Swift, SourceKit, LLDB, and SwiftPM.""")
 
     update_results = update_all_repositories(args, config, scheme,
                                              cross_repos_pr)
-    return (clone_results, update_results)
-
-
-if __name__ == "__main__":
-    freeze_support()
-    clone_results, update_results = main()
     fail_count = 0
     fail_count += shell.check_parallel_results(clone_results, "CLONE")
     fail_count += shell.check_parallel_results(update_results, "UPDATE")
     if fail_count > 0:
         print("update-checkout failed, fix errors and try again")
     sys.exit(fail_count)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
So this is *grim*.

### Problem
The internal implementation of forking on Windows calls `find_module(sys.modules[__name__], ...)`. 

However, `sys.modules[__name__]` == `update-checkout`. `update-checkout` is **not a valid python module name**, as it contains `-` and doesn't end with `.py`.

This means that Python is not able to find the module `update-checkout`, and can't continue forking, as seen in this error log:
```sh
C:\Users\hughb\Documents\GitHub\swift>python ./swift/utils/update-checkout -j=1
Running ``update_single_repository`` with up to 1 processes.
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "C:\Python27\lib\multiprocessing\forking.py", line 380, in main
    prepare(preparation_data)
  File "C:\Python27\lib\multiprocessing\forking.py", line 503, in prepare
    file, path_name, etc = imp.find_module(main_name, dirs)
ImportError: No module named update-checkout
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "C:\Python27\lib\multiprocessing\forking.py", line 380, in main
    prepare(preparation_data)
  File "C:\Python27\lib\multiprocessing\forking.py", line 503, in prepare
    file, path_name, etc = imp.find_module(main_name, dirs)
ImportError: No module named update-checkout
...
```

### Fix
The fix here is to move the contents of `update-checkout` to a file called `update_checkout`. Since we want to preserve `update-checkout`, we call `update_checkout.main()` from `update-checkout`.

However (ugh), internally, Python doesn't use the current module when forking. Nope, it uses the original module when forking (remember `sys.modules[__name__]`?). This means that we need to manually set `sys.modules[__name__]`:
```py
sys.modules[__name__] = sys.modules['update_checkout']
```
An alternative would be to call `subprocess.call` but this is complicated
