### PR TITLE
AST: Targeted fix for conformance lookup issue

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2875,7 +2875,17 @@ Optional<ProtocolConformanceRef>
 LookUpConformanceInSubstitutionMap::operator()(CanType dependentType,
                                        Type conformingReplacementType,
                                        ProtocolType *conformedProtocol) const {
-  return Subs.lookupConformance(dependentType, conformedProtocol->getDecl());
+  auto result = Subs.lookupConformance(dependentType, conformedProtocol->getDecl());
+  if ((result && result->isConcrete()) ||
+      conformingReplacementType->hasError() ||
+      conformingReplacementType->isTypeParameter())
+    return result;
+
+  // FIXME: Rip this out once ConformanceAccessPaths are plumbed through
+  auto *M = conformedProtocol->getDecl()->getParentModule();
+  return M->lookupConformance(conformingReplacementType,
+                              conformedProtocol->getDecl(),
+                              nullptr);
 }
 
 Optional<ProtocolConformanceRef>

--- a/test/Generics/protocol_where_clause.swift
+++ b/test/Generics/protocol_where_clause.swift
@@ -12,7 +12,7 @@ extension Int: Foo, Foo2 {}
 extension Float: Foo {}
 
 protocol Parent {
-    associatedtype T
+  associatedtype T
 }
 func needsParent<X: Parent>(_: X.Type) {}
 struct ConcreteParent: Parent { typealias T = Int }
@@ -20,7 +20,7 @@ struct ConcreteParent2: Parent { typealias T = Int }
 struct ConcreteParentNonFoo2: Parent { typealias T = Float }
 
 protocol SecondParent {
-    associatedtype U
+  associatedtype U
 }
 struct ConcreteSecondParent: SecondParent { typealias U = Int }
 struct ConcreteSecondParent2: SecondParent { typealias U = Int }
@@ -29,37 +29,37 @@ struct ConcreteSecondParentNonFoo2: SecondParent { typealias U = Float }
 protocol Conforms: Parent where T: Foo {}
 extension Conforms { func foo(_: T) {} }
 func needsConforms<X: Conforms>(_: X.Type) {
-    needsFoo(X.T.self)
+  needsFoo(X.T.self)
 }
 struct ConcreteConforms: Conforms {
-    typealias T = Int
+  typealias T = Int
 }
 struct BadConcreteConforms: Conforms {
-    // expected-error@-1 {{type 'BadConcreteConforms.T' (aka 'String') does not conform to protocol 'Foo'}}
-    typealias T = String
+  // expected-error@-1 {{type 'BadConcreteConforms.T' (aka 'String') does not conform to protocol 'Foo'}}
+  typealias T = String
 }
 
 protocol SameType: Parent, SecondParent where T == U { }
 func needsSameTypeProtocol<X: SameType>(_: X.Type) {
-    needsSameType(X.T.self, X.U.self)
+  needsSameType(X.T.self, X.U.self)
 }
 struct ConcreteSameType: SameType {
-    typealias T = Int
-    typealias U = Int
+  typealias T = Int
+  typealias U = Int
 }
 struct BadConcreteSameType: SameType { // expected-error{{'SameType' requires the types 'BadConcreteSameType.T' (aka 'Int') and 'BadConcreteSameType.U' (aka 'Float') be equivalent}}
 	// expected-note@-1{{requirement specified as 'Self.T' == 'Self.U' [with Self = BadConcreteSameType]}}
-    typealias T = Int
-    typealias U = Float
+  typealias T = Int
+  typealias U = Float
 }
 
 protocol NestedConforms: SecondParent where U: Parent, U.T: Foo2 {}
 func needsNestedConforms<X: NestedConforms>(_: X.Type) {
-    needsParent(X.U.self)
-    needsFoo2(X.U.T.self)
+  needsParent(X.U.self)
+  needsFoo2(X.U.T.self)
 }
 struct ConcreteNestedConforms: NestedConforms {
-    typealias U = ConcreteParent
+  typealias U = ConcreteParent
 }
 struct BadConcreteNestedConforms: NestedConforms {
   // expected-error@-1 {{type 'ConcreteParentNonFoo2.T' (aka 'Float') does not conform to protocol 'Foo2'}}

--- a/test/Generics/protocol_where_clause.swift
+++ b/test/Generics/protocol_where_clause.swift
@@ -61,12 +61,7 @@ func needsNestedConforms<X: NestedConforms>(_: X.Type) {
 struct ConcreteNestedConforms: NestedConforms {
     typealias U = ConcreteParent
 }
-// FIXME: this should hit "type 'BadConcreteNestedConforms.U.T' (aka 'Float')
-// does not conform to protocol 'Foo2'", but the SubstitutionMap used in
-// ensureRequirementsAreSatified can't find the conformance of Self.U: Parent
-// because it only looks for the conformances implied directly by a protocol's
-// associated types. SubstitutionMap should use the requirement
-// signature/conformance access path.
 struct BadConcreteNestedConforms: NestedConforms {
-    typealias U = ConcreteParentNonFoo2
+  // expected-error@-1 {{type 'ConcreteParentNonFoo2.T' (aka 'Float') does not conform to protocol 'Foo2'}}
+  typealias U = ConcreteParentNonFoo2
 }

--- a/validation-test/compiler_crashers_2_fixed/0059-sr3321.swift
+++ b/validation-test/compiler_crashers_2_fixed/0059-sr3321.swift
@@ -1,12 +1,6 @@
 // RUN: %target-swift-frontend %s -emit-ir
 // RUN: %target-swift-frontend %s -emit-ir -O
 
-// XFAIL: *
-
-// Note: this was passing for the wrong reasons before. We need to
-// correctly model cases where a nested type of an abstract conformance is
-// in fact concrete and, therefore, has concrete conformances.
-
 protocol ControllerB {
     associatedtype T: Controller
 }

--- a/validation-test/compiler_crashers_2_fixed/0076-sr3500.swift
+++ b/validation-test/compiler_crashers_2_fixed/0076-sr3500.swift
@@ -1,4 +1,4 @@
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: %target-swift-frontend %s -emit-ir
 
 protocol A {
   associatedtype Coordinate: Strideable


### PR DESCRIPTION
When substituting a type like T.A.B where A and B are
associated types and the conformance requirement on T.A
is implied by conformance requirements on T, we would
crash.

The problem is that we have no way of representing an
abstract conformance with nested concrete types.

This patch adds a workaround that we can live with until
ConformanceAccessPaths are plumbed through all the way.

Fixes <rdar://problem/30737546> and
<https://bugs.swift.org/browse/SR-3500>.
