### PR TITLE
Lazily compute error message only when the condition fails

### DIFF
--- a/benchmark/utils/TestsUtils.swift
+++ b/benchmark/utils/TestsUtils.swift
@@ -49,12 +49,11 @@ public func Random() -> Int64 {
   return lfsrRandomGenerator.randInt()
 }
 
-public func CheckResults(_ res: Bool, _ message: String = "") {
-  if res {
-    return
-  }
-  print(message)
-  abort()
+public func CheckResults(_ resultsMatch: Bool, _ message: @autoclosure () -> String){
+    guard resultsMatch else {
+        print(message())
+        abort()
+    }
 }
 
 public func False() -> Bool { return false }


### PR DESCRIPTION
This modifies the `CheckResults` implementation in `benchmark/utils/TestUtils.swift` to evaluate the error message only in case the condition failed, avoiding always performing the string interpolation in many of the error messages in benchmarks.

Resolves [SR-4373](https://bugs.swift.org/browse/SR-4373).