### PR TITLE
[Benchmark] Eliminate redundant conformance requirements.

### DIFF
--- a/benchmark/single-source/DictTest.swift
+++ b/benchmark/single-source/DictTest.swift
@@ -157,7 +157,7 @@ class Box<T : Hashable> : Hashable {
     return value.hashValue
   }
 
-  static func ==<T: Equatable>(lhs: Box<T>, rhs: Box<T>) -> Bool {
+  static func ==<T>(lhs: Box<T>, rhs: Box<T>) -> Bool {
     return lhs.value == rhs.value
   }
 }

--- a/benchmark/single-source/DictTest2.swift
+++ b/benchmark/single-source/DictTest2.swift
@@ -37,7 +37,7 @@ public func run_Dictionary2(_ N: Int) {
   CheckResults(res == ref_result, "Incorrect results in Dictionary2: \(res) != \(ref_result)")
 }
 
-class Box<T : Hashable> : Hashable where T : Equatable {
+class Box<T : Hashable> : Hashable {
   var value: T
 
   init(_ v: T) {
@@ -48,7 +48,7 @@ class Box<T : Hashable> : Hashable where T : Equatable {
     return value.hashValue
   }
 
-  static func ==<T: Equatable>(lhs: Box<T>, rhs: Box<T>) -> Bool {
+  static func ==<T>(lhs: Box<T>, rhs: Box<T>) -> Bool {
     return lhs.value == rhs.value
   }
 }

--- a/benchmark/single-source/DictTest3.swift
+++ b/benchmark/single-source/DictTest3.swift
@@ -56,10 +56,7 @@ class Box<T : Hashable> : Hashable {
   }
 }
 
-extension Box : Equatable {
-}
-
-func ==<T: Equatable>(lhs: Box<T>, rhs: Box<T>) -> Bool {
+func ==<T>(lhs: Box<T>, rhs: Box<T>) -> Bool {
   return lhs.value == rhs.value
 }
 

--- a/benchmark/single-source/DictionaryRemove.swift
+++ b/benchmark/single-source/DictionaryRemove.swift
@@ -53,7 +53,7 @@ class Box<T : Hashable> : Hashable {
     return value.hashValue
   }
 
-  static func ==<T: Equatable>(lhs: Box<T>, rhs: Box<T>) -> Bool {
+  static func ==<T>(lhs: Box<T>, rhs: Box<T>) -> Bool {
     return lhs.value == rhs.value
   }
 }

--- a/benchmark/single-source/DictionarySwap.swift
+++ b/benchmark/single-source/DictionarySwap.swift
@@ -56,7 +56,7 @@ class Box<T : Hashable> : Hashable {
     return value.hashValue
   }
 
-  static func ==<T: Equatable>(lhs: Box<T>, rhs: Box<T>) -> Bool {
+  static func ==<T>(lhs: Box<T>, rhs: Box<T>) -> Bool {
     return lhs.value == rhs.value
   }
 }

--- a/benchmark/single-source/RGBHistogram.swift
+++ b/benchmark/single-source/RGBHistogram.swift
@@ -124,7 +124,7 @@ class Box<T : Hashable> : Hashable {
     return value.hashValue
   }
 
-  static func ==<T: Equatable>(lhs: Box<T>, rhs: Box<T>) -> Bool {
+  static func ==<T>(lhs: Box<T>, rhs: Box<T>) -> Bool {
     return lhs.value == rhs.value
   }
 }

--- a/benchmark/single-source/SetTests.swift
+++ b/benchmark/single-source/SetTests.swift
@@ -115,7 +115,7 @@ class Box<T : Hashable> : Hashable {
     return value.hashValue
   }
 
-  static func ==<T: Equatable>(lhs: Box<T>, rhs: Box<T>) -> Bool {
+  static func ==<T>(lhs: Box<T>, rhs: Box<T>) -> Bool {
     return lhs.value == rhs.value
   }
 }


### PR DESCRIPTION
This is a followup to #7946 to eliminate redundant conformance constraint warnings from benchmark suite.