### PR TITLE
Don't use substiutions when mangling ObjC runtime class names.

### DIFF
--- a/include/swift/Basic/Mangler.h
+++ b/include/swift/Basic/Mangler.h
@@ -64,6 +64,9 @@ protected:
   /// If enabled, non-ASCII names are encoded in modified Punycode.
   bool UsePunycode = true;
 
+  /// If enabled, repeated entities are mangled using substitutions ('A...').
+  bool UseSubstitutions = true;
+
   /// A helpful little wrapper for an integer value that should be mangled
   /// in a particular, compressed value.
   class Index {
@@ -109,10 +112,12 @@ protected:
   void appendIdentifier(StringRef ident);
 
   void addSubstitution(const void *ptr) {
-    Substitutions[ptr] = Substitutions.size() + StringSubstitutions.size();
+    if (UseSubstitutions)
+      Substitutions[ptr] = Substitutions.size() + StringSubstitutions.size();
   }
   void addSubstitution(StringRef Str) {
-    StringSubstitutions[Str] = Substitutions.size() + StringSubstitutions.size();
+    if (UseSubstitutions)
+      StringSubstitutions[Str] = Substitutions.size() + StringSubstitutions.size();
   }
 
   bool tryMangleSubstitution(const void *ptr);

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -303,6 +303,7 @@ std::string ASTMangler::mangleObjCRuntimeName(const NominalTypeDecl *Nominal) {
     // Don't use word-substitutions and punycode encoding.
     MaxNumWords = 0;
     UsePunycode = false;
+    UseSubstitutions = false;
     Buffer << "_Tt";
     bool isProto = false;
     if (isa<ClassDecl>(Nominal)) {

--- a/test/IRGen/class_is_module.swift
+++ b/test/IRGen/class_is_module.swift
@@ -1,0 +1,11 @@
+// RUN: %target-swift-frontend -module-name=Hello -emit-ir %s | %FileCheck %s
+// REQUIRES: OS=macosx
+
+// Check if we mangle the objc runtime name correctly if a class has the same name as the module.
+
+class Hello {}
+
+// CHECK-DAG: _METACLASS_DATA__TtC5Hello5Hello
+// CHECK-DAG: c"_TtC5Hello5Hello\00"
+// CHECK-DAG: _DATA__TtC5Hello5Hello
+


### PR DESCRIPTION
This caused a problem for classes which had the same name as the containing module.

SR-4374, rdar://problem/31272389
