### PR TITLE
[docs][Android] Update location of Android NDK's libc++ and libgcc

### DIFF
--- a/docs/Android.md
+++ b/docs/Android.md
@@ -118,7 +118,7 @@ $ build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swiftc \                     
     -target armv7-none-linux-androideabi \                                       # Targeting android-armv7.
     -sdk /path/to/android-ndk-r14/platforms/android-21/arch-arm \                # Use the same NDK path and API version as you used to build the stdlib in the previous step.
     -L /path/to/android-ndk-r14/sources/cxx-stl/llvm-libc++/libs/armeabi-v7a \   # Link the Android NDK's libc++ and libgcc.
-    -L /path/to/android-ndk-r14/toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/lib/gcc/arm-linux-androideabi/4.9 \
+    -L /path/to/android-ndk-r14/toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/lib/gcc/arm-linux-androideabi/4.9.x \
     hello.swift
 ```
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
The latest version of the [Android NDK](https://developer.android.com/ndk/downloads/index.html) has the required `gcc` library that the Swift Android documentation uses at `toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/lib/gcc/arm-linux-androideabi/4.9.x`.

Previously, the directory was just `toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/lib/gcc/arm-linux-androideabi/4.9`.

I ran into this while trying to compile a Swift file to Android on `ubuntu/xenial64` using `android-ndk-r14b`.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-4440](https://bugs.swift.org/browse/SR-4440).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
