### PR TITLE
[silgen] Eliminate an unnecessary writeback scope.

### DIFF
--- a/lib/SILGen/Cleanup.cpp
+++ b/lib/SILGen/Cleanup.cpp
@@ -276,3 +276,9 @@ void CleanupManager::dump(CleanupHandle handle) const {
   llvm::errs() << "CLEANUP DEPTH: " << handle.getDepth() << "\n";
   stackCleanup.dump(SGF);
 }
+
+void CleanupManager::checkIterator(CleanupHandle handle) const {
+#ifndef NDEBUG
+  stack.checkIterator(handle);
+#endif
+}

--- a/lib/SILGen/Cleanup.h
+++ b/lib/SILGen/Cleanup.h
@@ -209,6 +209,9 @@ public:
 
   /// Dump the given cleanup handle if it is on the current stack.
   void dump(CleanupHandle handle) const;
+
+  /// Verify that the given cleanup handle is valid.
+  void checkIterator(CleanupHandle handle) const;
 };
 
 /// An RAII object that allows the state of a cleanup to be

--- a/lib/SILGen/FormalEvaluation.h
+++ b/lib/SILGen/FormalEvaluation.h
@@ -65,6 +65,8 @@ public:
 
   bool isFinished() const { return finished; }
 
+  void verify(SILGenFunction &SGF) const;
+
 protected:
   virtual void finishImpl(SILGenFunction &SGF) = 0;
 };
@@ -201,6 +203,10 @@ public:
 
   FormalEvaluationScope(FormalEvaluationScope &&o);
   FormalEvaluationScope &operator=(FormalEvaluationScope &&o) = delete;
+
+  /// Verify that we can successfully access all of the inner lexical scopes
+  /// that would be popped by this scope.
+  void verify() const;
 
 private:
   void popImpl();

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -1744,12 +1744,8 @@ RValue SILGenFunction::emitApply(ResultPlanPtr &&resultPlan,
   }
 
   // If there's a foreign error parameter, fill it in.
-  Optional<FormalEvaluationScope> errorTempWriteback;
   ManagedValue errorTemp;
   if (auto foreignError = calleeTypeInfo.foreignError) {
-    // Error-temporary emission may need writeback.
-    errorTempWriteback.emplace(*this);
-
     unsigned errorParamIndex =
         calleeTypeInfo.foreignError->getErrorParameterIndex();
 
@@ -1850,9 +1846,6 @@ RValue SILGenFunction::emitApply(ResultPlanPtr &&resultPlan,
   // TODO: maybe this should happen after managing the result if it's
   // not a result-checking convention?
   if (auto foreignError = calleeTypeInfo.foreignError) {
-    // Force immediate writeback to the error temporary.
-    errorTempWriteback.reset();
-
     bool doesNotThrow = (options & ApplyOptions::DoesNotThrow);
     emitForeignErrorCheck(loc, directResults, errorTemp,
                           doesNotThrow, *foreignError);

--- a/test/Inputs/clang-importer-sdk/usr/include/Foundation.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/Foundation.h
@@ -257,6 +257,9 @@ __attribute__((warn_unused_result)) NSString *NSStringToNSString(NSString *str);
 @interface NSURL : NSObject
 - (instancetype)URLWithString:(NSString *)URLString;
 + (instancetype)URLWithString:(NSString *)URLString;
+- (BOOL)getResourceValue:(out id _Nullable *)value
+                  forKey:(NSString *)key
+                   error:(out NSError *_Nullable *)error;
 @end
 
 @interface NSAttributedString : NSString

--- a/test/SILGen/foreign_errors.swift
+++ b/test/SILGen/foreign_errors.swift
@@ -298,3 +298,14 @@ func testPreservedResultInverted() throws {
 // CHECK-NOT: destroy_value
 // CHECK:   return {{%.+}} : $()
 // CHECK: [[ERROR_BB]]
+
+// Make sure that we do not crash when emitting the error value here.
+//
+// TODO: Add some additional filecheck tests.
+extension NSURL {
+  func resourceValue<T>(forKey key: String) -> T? {
+    var prop: AnyObject? = nil
+    _ = try? self.getResourceValue(&prop, forKey: key)
+    return prop as? T
+  }
+}


### PR DESCRIPTION
[silgen] Eliminate an unnecessary writeback scope.

This writeback scope's writeback is handled by the ArgumentScope for argument
emission. Since the scope will be destroyed after argument scope, we get
mismatched scope depths.

rdar://31313534
