### PR TITLE
[Sema,SILGen] Support for fallthrough into cases with pattern variables.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2668,14 +2668,16 @@ ERROR(fallthrough_outside_switch,none,
 ERROR(fallthrough_from_last_case,none,
       "'fallthrough' without a following 'case' or 'default' block", ())
 ERROR(fallthrough_into_case_with_var_binding,none,
-      "'fallthrough' cannot transfer control to a case label that declares variables",
-      ())
+      "'fallthrough' from a case which doesn't bind variable %0",
+      (Identifier))
 
 ERROR(unnecessary_cast_over_optionset,none,
       "unnecessary cast over raw value of %0", (Type))
 
 ERROR(type_mismatch_multiple_pattern_list,none,
       "pattern variable bound to type %0, expected type %1", (Type, Type))
+ERROR(type_mismatch_fallthrough_pattern_list,none,
+      "pattern variable bound to type %0, fallthrough case bound to type %1", (Type, Type))
 
 WARNING(where_on_one_item, none,
         "'where' only applies to the second pattern match in this case", ())

--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -1097,18 +1097,29 @@ public:
 /// FallthroughStmt - The keyword "fallthrough".
 class FallthroughStmt : public Stmt {
   SourceLoc Loc;
+  CaseStmt *FallthroughSource;
   CaseStmt *FallthroughDest;
   
 public:
   FallthroughStmt(SourceLoc Loc, Optional<bool> implicit = None)
     : Stmt(StmtKind::Fallthrough, getDefaultImplicitFlag(implicit, Loc)),
-      Loc(Loc), FallthroughDest(nullptr)
+      Loc(Loc), FallthroughSource(nullptr), FallthroughDest(nullptr)
   {}
   
   SourceLoc getLoc() const { return Loc; }
   
   SourceRange getSourceRange() const { return Loc; }
-  
+
+  /// Get the CaseStmt block from which the fallthrough transfers control.
+  /// Set during Sema. (May stay null if fallthrough is invalid.)
+  CaseStmt *getFallthroughSource() const {
+    return FallthroughSource;
+  }
+  void setFallthroughSource(CaseStmt *C) {
+    assert(!FallthroughSource && "fallthrough source already set?!");
+    FallthroughSource = C;
+  }
+
   /// Get the CaseStmt block to which the fallthrough transfers control.
   /// Set during Sema.
   CaseStmt *getFallthroughDest() const {

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -2071,6 +2071,29 @@ public:
           });
         }
     }
+    
+    // A fallthrough dest case's bound variable means the source case's
+    // var of the same name is read.
+    if (auto FS = dyn_cast<FallthroughStmt>(S)) {
+      if (auto sourceCase = FS->getFallthroughSource()) {
+        SmallVector<VarDecl *, 4> SourceVars;
+        auto sourcePattern = sourceCase->getCaseLabelItems()[0].getPattern();
+        sourcePattern->collectVariables(SourceVars);
+        
+        auto destCase = FS->getFallthroughDest();
+        auto destPattern = destCase->getCaseLabelItems()[0].getPattern();
+        destPattern->forEachVariable([&](VarDecl *V) {
+          if (!V->hasName())
+            return;
+          for (auto var : SourceVars) {
+            if (var->hasName() && var->getName() == V->getName()) {
+              VarDecls[var] |= RK_Read;
+              break;
+            }
+          }
+        });
+      }
+    }
       
     return { true, S };
   }

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -2074,18 +2074,18 @@ public:
     
     // A fallthrough dest case's bound variable means the source case's
     // var of the same name is read.
-    if (auto FS = dyn_cast<FallthroughStmt>(S)) {
-      if (auto sourceCase = FS->getFallthroughSource()) {
-        SmallVector<VarDecl *, 4> SourceVars;
+    if (auto *fallthroughStmt = dyn_cast<FallthroughStmt>(S)) {
+      if (auto *sourceCase = fallthroughStmt->getFallthroughSource()) {
+        SmallVector<VarDecl *, 4> sourceVars;
         auto sourcePattern = sourceCase->getCaseLabelItems()[0].getPattern();
-        sourcePattern->collectVariables(SourceVars);
+        sourcePattern->collectVariables(sourceVars);
         
-        auto destCase = FS->getFallthroughDest();
+        auto destCase = fallthroughStmt->getFallthroughDest();
         auto destPattern = destCase->getCaseLabelItems()[0].getPattern();
         destPattern->forEachVariable([&](VarDecl *V) {
           if (!V->hasName())
             return;
-          for (auto var : SourceVars) {
+          for (auto *var : sourceVars) {
             if (var->hasName() && var->getName() == V->getName()) {
               VarDecls[var] |= RK_Read;
               break;

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -973,12 +973,12 @@ public:
           // was in the first label item's pattern.
           auto firstPattern = caseBlock->getCaseLabelItems()[0].getPattern();
           if (pattern != firstPattern) {
-            SmallVector<VarDecl *, 4> Vars;
-            firstPattern->collectVariables(Vars);
+            SmallVector<VarDecl *, 4> vars;
+            firstPattern->collectVariables(vars);
             pattern->forEachVariable([&](VarDecl *VD) {
               if (!VD->hasName())
                 return;
-              for (auto expected : Vars) {
+              for (auto *expected : vars) {
                 if (expected->hasName() && expected->getName() == VD->getName()) {
                   if (!VD->getType()->isEqual(expected->getType())) {
                     TC.diagnose(VD->getLoc(), diag::type_mismatch_multiple_pattern_list,

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -369,7 +369,9 @@ public:
   /// The destination block for a 'fallthrough' statement. Null if the switch
   /// scope depth is zero or if we are checking the final 'case' of the current
   /// switch.
+  CaseStmt /*nullable*/ *FallthroughSource = nullptr;
   CaseStmt /*nullable*/ *FallthroughDest = nullptr;
+  FallthroughStmt /*nullable*/ *PreviousFallthrough = nullptr;
 
   SourceLoc EndTypeCheckLoc;
 
@@ -921,9 +923,9 @@ public:
       TC.diagnose(S->getLoc(), diag::fallthrough_from_last_case);
       return nullptr;
     }
-    if (FallthroughDest->hasBoundDecls())
-      TC.diagnose(S->getLoc(), diag::fallthrough_into_case_with_var_binding);
+    S->setFallthroughSource(FallthroughSource);
     S->setFallthroughDest(FallthroughDest);
+    PreviousFallthrough = S;
     return S;
   }
   
@@ -947,6 +949,7 @@ public:
       auto *caseBlock = S->getCases()[i];
       // Fallthrough transfers control to the next case block. In the
       // final case block, it is invalid.
+      FallthroughSource = caseBlock;
       FallthroughDest = i+1 == e ? nullptr : S->getCases()[i+1];
 
       for (auto &labelItem : caseBlock->getMutableCaseLabelItems()) {
@@ -989,15 +992,51 @@ public:
             });
           }
         }
-
         // Check the guard expression, if present.
         if (auto *guard = labelItem.getGuardExpr()) {
           TC.typeCheckCondition(guard, DC);
           labelItem.setGuardExpr(guard);
         }
       }
+        
+      // If the previous case fellthrough, similarly check that that case's bindings
+      // includes our first label item's pattern bindings and types.
+      if (PreviousFallthrough) {
+        auto firstPattern = caseBlock->getCaseLabelItems()[0].getPattern();
+        SmallVector<VarDecl *, 4> Vars;
+        firstPattern->collectVariables(Vars);
+
+        auto previousBlock = S->getCases()[i-1];
+        for (auto &labelItem : previousBlock->getCaseLabelItems()) {
+          const Pattern *pattern = labelItem.getPattern();
+          SmallVector<VarDecl *, 4> PreviousVars;
+          pattern->collectVariables(PreviousVars);
+          for (auto expected : Vars) {
+            bool matched = false;
+            if (!expected->hasName())
+              continue;
+            for (auto previous: PreviousVars) {
+              if (previous->hasName() && expected->getName() == previous->getName()) {
+                if (!previous->getType()->isEqual(expected->getType())) {
+                  TC.diagnose(previous->getLoc(), diag::type_mismatch_fallthrough_pattern_list,
+                              previous->getType(), expected->getType());
+                  previous->markInvalid();
+                  expected->markInvalid();
+                }
+                matched = true;
+                break;
+              }
+            }
+            if (!matched) {
+              TC.diagnose(PreviousFallthrough->getLoc(),
+                          diag::fallthrough_into_case_with_var_binding, expected->getName());
+            }
+          }
+        }
+      }
       
       // Type-check the body statements.
+      PreviousFallthrough = nullptr;
       Stmt *body = caseBlock->getBody();
       typeCheckStmt(body);
       caseBlock->setBody(body);


### PR DESCRIPTION
This pull request makes it so that `fallthrough` is now allowed into cases with bound pattern variables, so long as the same or a superset of those variables are also bound in the case we are falling from. This is a pretty straightforward extension of the existing support for binding the same variables in multiple patterns of the same case.

@jckarter suggested this to me quite a while ago now, and I'm finally getting to it. It seems to me like the sort of thing that is removing a limitation, rather than adding a new feature, but if it seems like a language enhancement that ought to go through swift-evolution before adding, I'd be happy to do that. 