### PR TITLE
IRGen: value witness tables and lazy metadata cache variables never need to be public

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1092,8 +1092,33 @@ SILLinkage LinkEntity::getLinkage(IRGenModule &IGM,
                                   ForDefinition_t forDefinition) const {
   switch (getKind()) {
   // Most type metadata depend on the formal linkage of their type.
-  case Kind::ValueWitnessTable:
-    return getSILLinkage(getTypeLinkage(getType()), forDefinition);
+  case Kind::ValueWitnessTable: {
+    auto type = getType();
+
+    // Builtin types, (), () -> () and so on are in the runtime.
+    if (!type.getAnyNominal())
+      return getSILLinkage(FormalLinkage::PublicUnique, forDefinition);
+
+    // Imported types.
+    if (getTypeMetadataAccessStrategy(IGM, type) ==
+          MetadataAccessStrategy::NonUniqueAccessor)
+      return SILLinkage::Shared;
+
+    // Everything else is only referenced inside its module.
+    return SILLinkage::Private;
+  }
+
+  case Kind::TypeMetadataLazyCacheVariable: {
+    auto type = getType();
+
+    // Imported types, non-primitive structural types.
+    if (getTypeMetadataAccessStrategy(IGM, type) ==
+          MetadataAccessStrategy::NonUniqueAccessor)
+      return SILLinkage::Shared;
+
+    // Everything else is only referenced inside its module.
+    return SILLinkage::Private;
+  }
 
   case Kind::TypeMetadata:
     switch (getMetadataAddress()) {
@@ -1114,7 +1139,6 @@ SILLinkage LinkEntity::getLinkage(IRGenModule &IGM,
     return SILLinkage::Shared;
 
   case Kind::TypeMetadataAccessFunction:
-  case Kind::TypeMetadataLazyCacheVariable:
     switch (getTypeMetadataAccessStrategy(IGM, getType())) {
     case MetadataAccessStrategy::PublicUniqueAccessor:
       return getSILLinkage(FormalLinkage::PublicUnique, forDefinition);

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -45,11 +45,6 @@ class TBDGenVisitor : public ASTVisitor<TBDGenVisitor> {
     if (isPrivateDecl(NTD))
       return;
 
-    auto declaredType = NTD->getDeclaredType()->getCanonicalType();
-
-    auto vwt = irgen::LinkEntity::forValueWitnessTable(declaredType);
-    addSymbol(vwt.mangleAsString());
-
     visitNominalTypeDecl(NTD);
   }
 
@@ -105,12 +100,6 @@ public:
     if (isPrivateDecl(CD))
       return;
 
-    auto declaredType = CD->getDeclaredType()->getCanonicalType();
-
-    auto tmlcv =
-        irgen::LinkEntity::forTypeMetadataLazyCacheVariable(declaredType);
-    addSymbol(tmlcv.mangleAsString());
-
     visitNominalTypeDecl(CD);
   }
 
@@ -125,6 +114,9 @@ public:
 
     // There's no relevant information about members of a protocol at individual
     // protocols, each conforming type has to handle them individually.
+
+    // FIXME: Eventually we might allow nominal type members of protocols.
+    // Should just visit that here or at least assert that there aren't any.
   }
 
   void visitVarDecl(VarDecl *VD);

--- a/test/IRGen/access_control.sil
+++ b/test/IRGen/access_control.sil
@@ -4,23 +4,23 @@ import Builtin
 import Swift
 
 public struct PublicStruct { var x: Int }
-// CHECK: @_T014access_control12PublicStructVWV = {{(protected )?}}constant
+// CHECK: @_T014access_control12PublicStructVWV = internal constant
 // CHECK: @_T014access_control12PublicStructVMn = {{(protected )?}}constant
 // CHECK: @_T014access_control12PublicStructVMf = internal constant
 
 internal struct InternalStruct { var x: Int }
-// CHECK: @_T014access_control14InternalStructVWV = hidden constant
+// CHECK: @_T014access_control14InternalStructVWV = internal constant
 // CHECK: @_T014access_control14InternalStructVMn = hidden constant
 // CHECK: @_T014access_control14InternalStructVMf = internal constant
 
 private struct PrivateStruct { var x: Int }
-// CHECK: @_T014access_control13PrivateStruct33_8F630B0A1EEF3ED34B761E3ED76C95A8LLVWV = hidden constant
+// CHECK: @_T014access_control13PrivateStruct33_8F630B0A1EEF3ED34B761E3ED76C95A8LLVWV = internal constant
 // CHECK: @_T014access_control13PrivateStruct33_8F630B0A1EEF3ED34B761E3ED76C95A8LLVMn = hidden constant
 // CHECK: @_T014access_control13PrivateStruct33_8F630B0A1EEF3ED34B761E3ED76C95A8LLVMf = internal constant
 
 func local() {
   struct LocalStruct { var x: Int }
-  // CHECK: @_T014access_control5localyyF11LocalStructL_VWV = hidden constant
+  // CHECK: @_T014access_control5localyyF11LocalStructL_VWV = internal constant
   // CHECK: @_T014access_control5localyyF11LocalStructL_VMn = hidden constant
   // CHECK: @_T014access_control5localyyF11LocalStructL_VMf = internal constant
 }

--- a/test/IRGen/dllexport.swift
+++ b/test/IRGen/dllexport.swift
@@ -27,8 +27,6 @@ open class d {
 // CHECK-DAG: @_T09dllexport2ciAA1cCv = dllexport global %T9dllexport1cC* null, align 4
 // CHECK-DAG: @_T09dllexport1pMp = dllexport constant %swift.protocol
 // CHECK-DAG: @_T09dllexport1cCMn = dllexport constant
-// CHECK-DAG: @_T09dllexport1cCML = dllexport global %swift.type* null, align 4
-// CHECK-DAG: @_T09dllexport1dCML = dllexport global %swift.type* null, align 4
 // CHECK-DAG: @_T09dllexport1cCN = dllexport alias %swift.type
 // CHECK-DAG: @_T09dllexport1dCN = dllexport alias %swift.type, bitcast ({{.*}})
 // CHECK-DAG-OPT: @_T09dllexport1dC1m33_C57BA610BA35E21738CC992438E660E9LLyyF = dllexport alias void (), void ()* @_swift_dead_method_stub

--- a/test/IRGen/enum.sil
+++ b/test/IRGen/enum.sil
@@ -131,7 +131,7 @@ import Swift
 
 // -- No-payload enums have extra inhabitants in
 //    their value witness table.
-// CHECK: @_T04enum10NoPayloadsOWV = hidden constant [26 x i8*] [
+// CHECK: @_T04enum10NoPayloadsOWV = internal constant [26 x i8*] [
 // -- ...
 // -- size
 // CHECK:   i8* inttoptr ([[WORD:i32|i64]] 1 to i8*),
@@ -149,7 +149,7 @@ import Swift
 
 // -- Single-payload enums take unused extra inhabitants from their payload
 //    as their own.
-// CHECK: @_T04enum19SinglePayloadNestedOWV = hidden constant [26 x i8*] [
+// CHECK: @_T04enum19SinglePayloadNestedOWV = internal constant [26 x i8*] [
 // -- ...
 // -- size
 // CHECK:   i8* inttoptr ([[WORD]] 1 to i8*),
@@ -172,7 +172,7 @@ import Swift
 // CHECK:   i8* bitcast (void (%swift.opaque*, i32, %swift.type*)* @_T04enum20DynamicSinglePayloadOwxs to i8*)
 // CHECK:   i8* bitcast (i32 (%swift.opaque*, %swift.type*)* @_T04enum20DynamicSinglePayloadOwxg to i8*)
 
-// CHECK: @_T04enum18MultiPayloadNestedOWV = hidden constant [26 x i8*] [
+// CHECK: @_T04enum18MultiPayloadNestedOWV = internal constant [26 x i8*] [
 // CHECK:   i8* inttoptr ([[WORD]] 9 to i8*),
 // CHECK:   i8* inttoptr ([[WORD]] 16 to i8*)
 // CHECK: ]

--- a/test/IRGen/enum_value_semantics.sil
+++ b/test/IRGen/enum_value_semantics.sil
@@ -94,7 +94,7 @@ enum GenericFixedLayout<T> {
 }
 
 
-// CHECK-LABEL: @_T020enum_value_semantics20SinglePayloadTrivialOWV = hidden constant [26 x i8*] [
+// CHECK-LABEL: @_T020enum_value_semantics20SinglePayloadTrivialOWV = internal constant [26 x i8*] [
 // CHECK:   i8* bitcast (void (i8*, %swift.type*)* @__swift_noop_void_return to i8*),
 // CHECK:   i8* bitcast (i8* (i8*, i8*, %swift.type*)* @__swift_memcpy9_8 to i8*),
 // CHECK:   i8* bitcast (i8* (i8*, %swift.type*)* @__swift_noop_self_return to i8*),
@@ -133,7 +133,7 @@ enum GenericFixedLayout<T> {
 // CHECK-SAME: }>
 
 
-// CHECK-LABEL: @_T020enum_value_semantics23SinglePayloadNontrivialOWV = hidden constant [26 x i8*] [
+// CHECK-LABEL: @_T020enum_value_semantics23SinglePayloadNontrivialOWV = internal constant [26 x i8*] [
 // CHECK:   i8* bitcast (void ([24 x i8]*, %swift.type*)* @_T020enum_value_semantics23SinglePayloadNontrivialOwXX to i8*),
 // CHECK:   i8* bitcast (%swift.opaque* ([24 x i8]*, [24 x i8]*, %swift.type*)* @_T020enum_value_semantics23SinglePayloadNontrivialOwCP to i8*),
 // CHECK:   i8* bitcast (i8* (i8*, %swift.type*)* @__swift_noop_self_return to i8*),

--- a/test/IRGen/indirect_enum.sil
+++ b/test/IRGen/indirect_enum.sil
@@ -2,8 +2,8 @@
 
 import Swift
 
-// CHECK-64: @_T013indirect_enum5TreeAOWV = hidden constant {{.*}} i8* inttoptr ([[WORD:i64]] 8 to i8*), i8* inttoptr (i64 2162695 to i8*), i8* inttoptr (i64 8 to i8*)
-// CHECK-32: @_T013indirect_enum5TreeAOWV = hidden constant {{.*}} i8* inttoptr ([[WORD:i32]] 4 to i8*), i8* inttoptr (i32 2162691 to i8*), i8* inttoptr (i32 4 to i8*)
+// CHECK-64: @_T013indirect_enum5TreeAOWV = internal constant {{.*}} i8* inttoptr ([[WORD:i64]] 8 to i8*), i8* inttoptr (i64 2162695 to i8*), i8* inttoptr (i64 8 to i8*)
+// CHECK-32: @_T013indirect_enum5TreeAOWV = internal constant {{.*}} i8* inttoptr ([[WORD:i32]] 4 to i8*), i8* inttoptr (i32 2162691 to i8*), i8* inttoptr (i32 4 to i8*)
 
 // CHECK-LABEL: define{{( protected)?}} private %swift.type** @get_field_types_TreeA
 // -- Leaf(T)

--- a/test/IRGen/local_types.swift
+++ b/test/IRGen/local_types.swift
@@ -9,14 +9,14 @@
 import local_types_helper
 
 public func singleFunc() {
-  // CHECK-DAG: @_T011local_types10singleFuncyyF06SingleD6StructL_VWV = hidden constant
+  // CHECK-DAG: @_T011local_types10singleFuncyyF06SingleD6StructL_VWV = internal constant
   struct SingleFuncStruct {
     let i: Int
   }
 }
 
 public let singleClosure: () -> () = {
-  // CHECK-DAG: @_T011local_types13singleClosureyycvfiyycfU_06SingleD6StructL_VWV = hidden constant
+  // CHECK-DAG: @_T011local_types13singleClosureyycvfiyycfU_06SingleD6StructL_VWV = internal constant
   struct SingleClosureStruct {
     let i: Int
   }
@@ -24,7 +24,7 @@ public let singleClosure: () -> () = {
 
 public struct PatternStruct {
   public var singlePattern: Int = ({
-    // CHECK-DAG: @_T011local_types13PatternStructV06singleC0SivfiSiycfU_06SinglecD0L_VWV = hidden constant
+    // CHECK-DAG: @_T011local_types13PatternStructV06singleC0SivfiSiycfU_06SinglecD0L_VWV = internal constant
     struct SinglePatternStruct {
       let i: Int
     }
@@ -33,7 +33,7 @@ public struct PatternStruct {
 }
 
 public func singleDefaultArgument(i: Int = {
-  // CHECK-DAG: @_T011local_types21singleDefaultArgumentySi1i_tFfA_SiycfU_06SingledE6StructL_VWV = hidden constant
+  // CHECK-DAG: @_T011local_types21singleDefaultArgumentySi1i_tFfA_SiycfU_06SingledE6StructL_VWV = internal constant
   struct SingleDefaultArgumentStruct {
     let i: Int
   }

--- a/test/IRGen/struct_layout.sil
+++ b/test/IRGen/struct_layout.sil
@@ -9,9 +9,9 @@ import Swift
 // 64: %T4main14Rdar15410780_CV = type <{ %TSSSg }>
 // 64: %TSSSg = type <{ [24 x i8], [1 x i8] }>
 
-// 64: @_T04main14Rdar15410780_AVWV = hidden constant {{.*}} (i64 257
-// 64: @_T04main14Rdar15410780_BVWV = hidden constant {{.*}} (i64 258
-// 64: @_T04main14Rdar15410780_CVWV = hidden constant {{.*}} (i64 25
+// 64: @_T04main14Rdar15410780_AVWV = internal constant {{.*}} (i64 257
+// 64: @_T04main14Rdar15410780_BVWV = internal constant {{.*}} (i64 258
+// 64: @_T04main14Rdar15410780_CVWV = internal constant {{.*}} (i64 25
 
 
 // 32: %T4main14Rdar15410780_AV = type <{ i2048, %Ts4Int8V }>
@@ -20,9 +20,9 @@ import Swift
 // 32: %T4main14Rdar15410780_CV = type <{ %TSSSg }>
 // 32: %TSSSg = type <{ [12 x i8], [1 x i8] }>
 
-// 32: @_T04main14Rdar15410780_AVWV = hidden constant {{.*}} (i32 257
-// 32: @_T04main14Rdar15410780_BVWV = hidden constant {{.*}} (i32 258
-// 32: @_T04main14Rdar15410780_CVWV = hidden constant {{.*}} (i32 13
+// 32: @_T04main14Rdar15410780_AVWV = internal constant {{.*}} (i32 257
+// 32: @_T04main14Rdar15410780_BVWV = internal constant {{.*}} (i32 258
+// 32: @_T04main14Rdar15410780_CVWV = internal constant {{.*}} (i32 13
 
 
 // <rdar://problem/15410780>


### PR DESCRIPTION
This simplifies TBDGen too, even though it's still TBD.

I have a few more of these fixes queued up, but I'm releasing them one at a time to hopefully not break the world too much.