### PR TITLE
[type-checker] More correct way to determine if a given generic parameter of a function cannot be inferred because it is not used

### DIFF
--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -616,32 +616,124 @@ static void checkReferencedGenericParams(GenericContext *dc,
 
   auto *decl = cast<ValueDecl>(dc->getInnermostDeclarationDeclContext());
 
-  // Collect all generic params referenced in parameter types,
-  // return type or requirements.
-  SmallPtrSet<GenericTypeParamDecl *, 4> referencedGenericParams;
+  // A helper class to collect referenced generic type parameters
+  // and dependent memebr types.
+  class ReferencedGenericTypeWalker : public TypeWalker {
+    SmallPtrSet<CanType, 4> ReferencedGenericParams;
 
-  auto visitorFn = [&referencedGenericParams](Type t) {
-    if (auto *paramTy = t->getAs<GenericTypeParamType>())
-      referencedGenericParams.insert(paramTy->getDecl());
+  public:
+    ReferencedGenericTypeWalker() {}
+    Action walkToTypePre(Type ty) override {
+      // Find generic parameters or dependent member types.
+      // Once such a type is found, don't recurse into its children.
+      if (ty->hasTypeParameter()) {
+        if (ty->isTypeParameter()) {
+          ReferencedGenericParams.insert(ty->getCanonicalType());
+          return Action::SkipChildren;
+        }
+        return Action::Continue;
+      }
+      return Action::SkipChildren;
+    }
+
+    SmallPtrSet<CanType, 4> &getReferencedGenericParams() {
+      return ReferencedGenericParams;
+    }
   };
 
+  // Collect all generic params referenced in parameter types and
+  // return type.
+  ReferencedGenericTypeWalker ParamsAndResultWalker;
   auto *funcTy = decl->getInterfaceType()->castTo<GenericFunctionType>();
-  funcTy->getInput().visit(visitorFn);
-  funcTy->getResult().visit(visitorFn);
+  funcTy->getInput().walk(ParamsAndResultWalker);
+  funcTy->getResult().walk(ParamsAndResultWalker);
+
+  // Set of generic params referenced in parameter types,
+  // return type or requirements.
+  auto &referencedGenericParams =
+      ParamsAndResultWalker.getReferencedGenericParams();
+
+  // Check if at least one of the generic params in the requirment refers
+  // to an already referenced generic parameter. If this is the case,
+  // then the other type is also considered as referenced, because
+  // it is used to put requirements on the first type.
+  auto reqTypesVisitor = [&referencedGenericParams](Requirement req) -> bool {
+    Type first;
+    Type second;
+
+    switch (req.getKind()) {
+    case RequirementKind::SameType:
+      second = req.getSecondType();
+      LLVM_FALLTHROUGH;
+
+    case RequirementKind::Superclass:
+    case RequirementKind::Conformance:
+    case RequirementKind::Layout:
+      first = req.getFirstType();
+      break;
+    }
+
+    // Collect generic parameter types refereced by types used in a requirement.
+    ReferencedGenericTypeWalker Walker;
+    if (first && first->hasTypeParameter())
+      first.walk(Walker);
+    if (second && second->hasTypeParameter())
+      second.walk(Walker);
+    auto &genericParamsUsedByRequirementTypes =
+        Walker.getReferencedGenericParams();
+
+    // If at least one of the collected generic types or a root generic
+    // parameter of dependent member types is known to be referenced by
+    // parameter types, return types or other types known to be "referenced",
+    // then all the types used in the requirement are considered to be
+    // referenced, because they are used to defined something that is known
+    // to be referenced.
+    bool FoundNewReferencedGenericParam = false;
+    if (std::any_of(genericParamsUsedByRequirementTypes.begin(),
+                    genericParamsUsedByRequirementTypes.end(),
+                    [&referencedGenericParams](CanType t) {
+                      assert(t->isTypeParameter());
+                      return referencedGenericParams.find(
+                                 t->getRootGenericParam()
+                                     ->getCanonicalType()) !=
+                             referencedGenericParams.end();
+                    })) {
+      std::for_each(genericParamsUsedByRequirementTypes.begin(),
+                    genericParamsUsedByRequirementTypes.end(),
+                    [&referencedGenericParams,
+                     &FoundNewReferencedGenericParam](CanType t) {
+                      // Add only generic type parameters, but ignore any
+                      // dependent member types, because requirement
+                      // on a dependent member type does not provide enough
+                      // information to infer the base generic type
+                      // parameter.
+                      if (!t->is<GenericTypeParamType>())
+                        return;
+                      FoundNewReferencedGenericParam |=
+                          referencedGenericParams.insert(t).second;
+                    });
+    }
+    return FoundNewReferencedGenericParam;
+  };
 
   auto requirements = sig->getRequirements();
-  for (auto req : requirements) {
-    switch (req.getKind()) {
-      case RequirementKind::SameType:
-      case RequirementKind::Superclass:
-        req.getSecondType().visit(visitorFn);
-        LLVM_FALLTHROUGH;
 
-      case RequirementKind::Conformance:
-      case RequirementKind::Layout:
-        req.getFirstType().visit(visitorFn);
-        break;
+  // Try to find new referenced generic parameter types in requirements until we
+  // reach a fix point. We need to iterate until a fix point, because we may
+  // have e.g. chains of same-type requirements like:
+  // not-yet-referenced-T1 == not-yet-referenced-T2.DepType2,
+  // not-yet-referenced-T2 == not-yet-referenced-T3.DepType3,
+  // not-yet-referenced-T3 == referenced-T4.DepType4.
+  // When we process the first of these requirements, we don't know yet that T2
+  // will be referenced, because T3 will be referenced,
+  // because T3 == T4.DepType4.
+  while (true) {
+    bool FoundNewReferencedGenericParam = false;
+    for (auto req : requirements) {
+      FoundNewReferencedGenericParam |= reqTypesVisitor(req);
     }
+    if (!FoundNewReferencedGenericParam)
+      break;
   }
 
   // Find the depth of the function's own generic parameters.
@@ -653,7 +745,7 @@ static void checkReferencedGenericParams(GenericContext *dc,
     auto *paramDecl = genParam->getDecl();
     if (paramDecl->getDepth() != fnGenericParamsDepth)
       continue;
-    if (!referencedGenericParams.count(paramDecl)) {
+    if (!referencedGenericParams.count(genParam->getCanonicalType())) {
       // Produce an error that this generic parameter cannot be bound.
       TC.diagnose(paramDecl->getLoc(), diag::unreferenced_generic_parameter,
                   paramDecl->getNameStr());

--- a/test/Generics/associated_type_typo.swift
+++ b/test/Generics/associated_type_typo.swift
@@ -15,18 +15,18 @@ protocol P3 { }
 protocol P4 { }
 
 // expected-error@+1{{'T' does not have a member type named 'assoc'; did you mean 'Assoc'?}}{{30-35=Assoc}}
-func typoAssoc1<T : P1>(x: T.assoc) { } 
+func typoAssoc1<T : P1>(x: T.assoc, _: T) { } 
 
-// expected-error@+2{{'T' does not have a member type named 'assoc'; did you mean 'Assoc'?}}{{43-48=Assoc}}
-// expected-error@+1{{'U' does not have a member type named 'assoc'; did you mean 'Assoc'?}}{{54-59=Assoc}}
-func typoAssoc2<T : P1, U : P1>() where T.assoc == U.assoc {}
+// expected-error@+2{{'T' does not have a member type named 'assoc'; did you mean 'Assoc'?}}{{53-58=Assoc}}
+// expected-error@+1{{'U' does not have a member type named 'assoc'; did you mean 'Assoc'?}}{{64-69=Assoc}}
+func typoAssoc2<T : P1, U : P1>(_: T, _: U) where T.assoc == U.assoc {}
 
 // CHECK-GENERIC-LABEL: .typoAssoc2
 // CHECK-GENERIC: Generic signature: <T, U where T : P1, U : P1, T.Assoc == U.Assoc>
 
 // expected-error@+3{{'T.AssocP2' does not have a member type named 'assoc'; did you mean 'Assoc'?}}{{42-47=Assoc}}
 // expected-error@+2{{'U.AssocP2' does not have a member type named 'assoc'; did you mean 'Assoc'?}}{{19-24=Assoc}}
-func typoAssoc3<T : P2, U : P2>()
+func typoAssoc3<T : P2, U : P2>(t: T, u: U)
   where U.AssocP2.assoc : P3,  T.AssocP2.assoc : P4,
         T.AssocP2 == U.AssocP2 {}
 

--- a/test/Generics/function_defs.swift
+++ b/test/Generics/function_defs.swift
@@ -244,7 +244,7 @@ protocol GeneratesMetaAssoc2 {
 
 func recursiveSameType
        <T : GeneratesMetaAssoc1, U : GeneratesMetaAssoc2, V : GeneratesAssoc1>
-       (_ t: T, u: U)
+       (_ t: T, u: U, v: V)
   where T.MetaAssoc1 == V.Assoc1, V.Assoc1 == U.MetaAssoc2
 {
   t.get().accept(t.get().makeIterator())
@@ -295,5 +295,5 @@ func badTypeConformance1<T>(_: T) where Int : EqualComparable {} // expected-err
 
 func badTypeConformance2<T>(_: T) where T.Blarg : EqualComparable { } // expected-error{{'Blarg' is not a member type of 'T'}}
 
-func badSameType<T, U : GeneratesAnElement, V>(_ : T)
+func badSameType<T, U : GeneratesAnElement, V>(_ : T, _ : U)
   where T == U.Element, U.Element == V {} // expected-error{{same-type requirement makes generic parameters 'T' and 'V' equivalent}}

--- a/test/IDE/print_types.swift
+++ b/test/IDE/print_types.swift
@@ -134,7 +134,7 @@ func testInGenericFunc1<A, B : FooProtocol, C : FooProtocol & BarProtocol>(_ a: 
 // FULL:          ConstructorRefCallExpr:[[@LINE-7]] '''GenericStruct<A, B>''' () -> swift_ide_test.GenericStruct<A, B>
 }
 
-func testInGenericFunc2<T : QuxProtocol, U : QuxProtocol>() where T.Qux == U.Qux {}
-// CHECK: FuncDecl '''testInGenericFunc2''' <T, U where T : QuxProtocol, U : QuxProtocol, T.Qux == U.Qux> () -> (){{$}}
-// FULL:  FuncDecl '''testInGenericFunc2''' <T, U where T : QuxProtocol, U : QuxProtocol, T.Qux == U.Qux> () -> (){{$}}
+func testInGenericFunc2<T : QuxProtocol, U : QuxProtocol>(_: T, _: U) where T.Qux == U.Qux {}
+// CHECK: FuncDecl '''testInGenericFunc2''' <T, U where T : QuxProtocol, U : QuxProtocol, T.Qux == U.Qux> (T, U) -> (){{$}}
+// FULL:  FuncDecl '''testInGenericFunc2''' <T, U where T : QuxProtocol, U : QuxProtocol, T.Qux == U.Qux> (T, U) -> (){{$}}
 

--- a/test/SILGen/generic_closures.swift
+++ b/test/SILGen/generic_closures.swift
@@ -307,7 +307,7 @@ protocol Doggo {}
 
 struct DogSnacks<A : Doggo> {}
 
-func capture_same_type_representative<Daisy: Doge, Roo: Doggo>(slobber: Roo)
+func capture_same_type_representative<Daisy: Doge, Roo: Doggo>(slobber: Roo, daisy: Daisy)
     where Roo == Daisy.Nose.Squeegee {
   var s = DogSnacks<Daisy.Nose.Squeegee>()
   _ = { _ = s }

--- a/test/SILGen/generic_signatures.swift
+++ b/test/SILGen/generic_signatures.swift
@@ -68,16 +68,16 @@ struct FooBar<T: Fooable>: Barrable {
 
 // Test that associated types can be constrained to concrete types
 
-func concreteJungle<T where T : Fooable, T.Foo == C>() -> T.Foo {
+func concreteJungle<T where T : Fooable, T.Foo == C>(_: T) -> T.Foo {
   return C()
 }
 
-func concreteJungle<T where T : Fooable, T.Foo == C>(t: T.Foo) -> C {
+func concreteJungle<T where T : Fooable, T.Foo == C>(_: T, t: T.Foo) -> C {
   let c: C = t
   return c
 }
 
-func concreteJungle<T where T : Fooable, T.Foo == C>(f: @escaping (T.Foo) -> C) -> T.Foo {
+func concreteJungle<T where T : Fooable, T.Foo == C>(_: T, f: @escaping (T.Foo) -> C) -> T.Foo {
   let ff: (C) -> T.Foo = f
   return ff(C())
 }

--- a/test/SourceKit/CursorInfo/cursor_info.swift
+++ b/test/SourceKit/CursorInfo/cursor_info.swift
@@ -78,7 +78,7 @@ class C3 {
 }
 
 struct S2<T, U where T == U> {
-  func foo<V, W where V == W> (_ closure: ()->()) -> ()->() { return closure }
+  func foo<V, W where V == W> (_: V, _: W, _ closure: ()->()) -> ()->() { return closure }
 }
 class C4<T, U where T == U> {}
 enum E1<T, U where T == U> {}
@@ -433,12 +433,12 @@ func hasLocalizationKey2() {}
 // CHECK33-NEXT: <decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>S2</decl.name>&lt;<decl.generic_type_param usr="s:11cursor_info2S2V1Txmfp"><decl.generic_type_param.name>T</decl.generic_type_param.name></decl.generic_type_param>, <decl.generic_type_param usr="s:11cursor_info2S2V1Uq_mfp"><decl.generic_type_param.name>U</decl.generic_type_param.name></decl.generic_type_param>&gt; <syntaxtype.keyword>where</syntaxtype.keyword> <decl.generic_type_requirement>T == U</decl.generic_type_requirement></decl.struct>
 
 // RUN: %sourcekitd-test -req=cursor -pos=81:8 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck %s -check-prefix=CHECK34
-// CHECK34: source.lang.swift.decl.function.method.instance (81:8-81:50)
-// CHECK34-NEXT: foo(_:)
-// CHECK34-NEXT: s:11cursor_info2S2V3fooyycyycqd_0_Rsd__r0_lF
-// CHECK34-NEXT: <T, U, V, W where T == U, V == W> (S2<T, U>) -> (() -> ()) -> () -> ()
-// CHECK34: <Declaration>func foo&lt;V, W&gt;(_ closure: () -&gt; ()) -&gt; () -&gt; () where V == W</Declaration>
-// CHECK34-NEXT: <decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>foo</decl.name>&lt;<decl.generic_type_param usr="s:11cursor_info2S2V3fooyycyycqd_0_Rsd__r0_lF1VL_qd__mfp"><decl.generic_type_param.name>V</decl.generic_type_param.name></decl.generic_type_param>, <decl.generic_type_param usr="s:11cursor_info2S2V3fooyycyycqd_0_Rsd__r0_lF1WL_qd_0_mfp"><decl.generic_type_param.name>W</decl.generic_type_param.name></decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>closure</decl.var.parameter.name>: <decl.var.parameter.type>() -&gt; <decl.function.returntype><tuple>()</tuple></decl.function.returntype></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype>() -&gt; <decl.function.returntype><tuple>()</tuple></decl.function.returntype></decl.function.returntype> <syntaxtype.keyword>where</syntaxtype.keyword> <decl.generic_type_requirement>V == W</decl.generic_type_requirement></decl.function.method.instance>
+// CHECK34: source.lang.swift.decl.function.method.instance (81:8-81:62)
+// CHECK34-NEXT: foo(_:_:_:)
+// CHECK34-NEXT: s:11cursor_info2S2V3fooyycqd___qd__yyctqd_0_Rsd__r0_lF
+// CHECK34-NEXT: <T, U, V, W where T == U, V == W> (S2<T, U>) -> (V, W, () -> ()) -> () -> ()
+// CHECK34: <Declaration>func foo&lt;V, W&gt;(_: <Type usr="s:11cursor_info2S2V3fooyycqd___qd__yyctqd_0_Rsd__r0_lF1VL_qd__mfp">V</Type>, _: <Type usr="s:11cursor_info2S2V3fooyycqd___qd__yyctqd_0_Rsd__r0_lF1WL_qd_0_mfp">W</Type>, _ closure: () -&gt; ()) -&gt; () -&gt; () where V == W</Declaration>
+// CHECK34: <decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>foo</decl.name>&lt;<decl.generic_type_param usr="s:11cursor_info2S2V3fooyycqd___qd__yyctqd_0_Rsd__r0_lF1VL_qd__mfp"><decl.generic_type_param.name>V</decl.generic_type_param.name></decl.generic_type_param>, <decl.generic_type_param usr="s:11cursor_info2S2V3fooyycqd___qd__yyctqd_0_Rsd__r0_lF1WL_qd_0_mfp"><decl.generic_type_param.name>W</decl.generic_type_param.name></decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.generic_type_param usr="s:11cursor_info2S2V3fooyycqd___qd__yyctqd_0_Rsd__r0_lF1VL_qd__mfp">V</ref.generic_type_param></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.generic_type_param usr="s:11cursor_info2S2V3fooyycqd___qd__yyctqd_0_Rsd__r0_lF1WL_qd_0_mfp">W</ref.generic_type_param></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>closure</decl.var.parameter.name>: <decl.var.parameter.type>() -&gt; <decl.function.returntype><tuple>()</tuple></decl.function.returntype></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype>() -&gt; <decl.function.returntype><tuple>()</tuple></decl.function.returntype></decl.function.returntype> <syntaxtype.keyword>where</syntaxtype.keyword> <decl.generic_type_requirement>V == W</decl.generic_type_requirement></decl.function.method.instance>
 
 // RUN: %sourcekitd-test -req=cursor -pos=83:7 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck %s -check-prefix=CHECK35
 // CHECK35: source.lang.swift.decl.class (83:7-83:9)

--- a/test/decl/typealias/associated_types.swift
+++ b/test/decl/typealias/associated_types.swift
@@ -17,5 +17,5 @@ protocol DerivedProto : BaseProto {
 }
 
 
-func generic<T: BaseProto>(_ assoc: T.AssocTy) {} // no-warning
+func generic<T: BaseProto>(_: T, _ assoc: T.AssocTy) {} // no-warning
 

--- a/validation-test/compiler_crashers_2_fixed/0069-sr3657.swift
+++ b/validation-test/compiler_crashers_2_fixed/0069-sr3657.swift
@@ -8,4 +8,4 @@ class C : P3 {
   typealias T = Int
 }
 
-func superclassConformance1<T>(t: T.T) where T : P3, T : C {}
+func superclassConformance1<T>(_: T, t: T.T) where T : P3, T : C {}


### PR DESCRIPTION
The overall idea is like this:
- first, collect the generic params that are explicitly used by types of arguments or return type
- then perform a fix-point analysis, where at each step, a set of generic signature’s requirements is checked.
   - If there is a requirement where one of the involved generic params is already proven to be used, then all other generic params from the same requirement are also considered to be implicitly used in the function signature, because they are used to put a requirement on a generic param that is already known to be used in the function signature.

The fix-point iteration is required to handle chains of dependencies between requirements. See the updated test case for an example.

Fixes rdar://29585211
