### PR TITLE
Use the directory name, not full directory in SwiftBuildSupport.SWIFT_REPO_NAME

### DIFF
--- a/utils/SwiftBuildSupport.py
+++ b/utils/SwiftBuildSupport.py
@@ -80,7 +80,8 @@ def _get_default_swift_repo_name():
         return result
     if not os.path.exists(os.path.join(swift_path, 'CMakeLists.txt')):
         return result
-    return swift_path
+    (_, swift_repo_name) = os.path.split(swift_path)
+    return swift_repo_name
 
 
 # Set SWIFT_REPO_NAME in your environment to control the name of the swift


### PR DESCRIPTION
@gottesmm, from https://github.com/apple/swift/pull/8439

If this isn't correct, then I'll update the comments to fix  #them.

The comments say:

> Set SWIFT_REPO_NAME in your environment to control the name of the swift
> directory name that is used.

However:
```py
print(SWIFT_REPO_NAME)
```

> C:\Users\hughb\Documents\GitHub\swift\swift

This is the full path, not the repo/directory name, which is not what this variable means.