### PR TITLE
Sema: Fix for SourceKit crash in inheritsSuperclassInitializers()

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2450,6 +2450,10 @@ DestructorDecl *ClassDecl::getDestructor() {
 }
 
 bool ClassDecl::inheritsSuperclassInitializers(LazyResolver *resolver) {
+  // Get a resolver from the ASTContext if we don't have one already.
+  if (resolver == nullptr)
+    resolver = getASTContext().getLazyResolver();
+
   // Check whether we already have a cached answer.
   switch (static_cast<StoredInheritsSuperclassInits>(
             ClassDeclBits.InheritsSuperclassInits)) {
@@ -2490,8 +2494,10 @@ bool ClassDecl::inheritsSuperclassInitializers(LazyResolver *resolver) {
       return false;
 
     // Resolve this initializer, if needed.
-    if (!ctor->hasInterfaceType())
+    if (!ctor->hasInterfaceType()) {
+      assert(resolver && "Should have a resolver here");
       resolver->resolveDeclSignature(ctor);
+    }
 
     // Ignore any stub implementations.
     if (ctor->hasStubImplementation())

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -714,12 +714,13 @@ void swift::performTypeChecking(SourceFile &SF, TopLevelContext &TLC,
 
     typeCheckFunctionsAndExternalDecls(TC);
   }
-  MyTC.reset();
 
   // Checking that benefits from having the whole module available.
   if (!(Options & TypeCheckingFlags::DelayWholeModuleChecking)) {
     performWholeModuleTypeChecking(SF);
   }
+
+  MyTC.reset();
 
   // Verify that we've checked types correctly.
   SF.ASTStage = SourceFile::TypeChecked;

--- a/test/SourceKit/Indexing/Inputs/index_constructors_other.swift
+++ b/test/SourceKit/Indexing/Inputs/index_constructors_other.swift
@@ -1,0 +1,7 @@
+class DogObject : CatObject {
+  override init() {
+    super.init()
+  }
+}
+
+class CatObject : NSObject {}

--- a/test/SourceKit/Indexing/index_constructors.swift
+++ b/test/SourceKit/Indexing/index_constructors.swift
@@ -1,0 +1,10 @@
+// RUN: %sourcekitd-test -req=index %s -- %s %S/Inputs/index_constructors_other.swift | %sed_clean > %t.response
+// RUN: diff -u %s.response %t.response
+
+import Foundation
+
+class HorseObject : DogObject {
+  var name: NSString
+
+  @objc public func flip() {}
+}

--- a/test/SourceKit/Indexing/index_constructors.swift.response
+++ b/test/SourceKit/Indexing/index_constructors.swift.response
@@ -1,0 +1,58 @@
+{
+  key.hash: <hash>,
+  key.dependencies: [
+    {
+      key.kind: source.lang.swift.import.module.swift,
+      key.name: "Swift",
+      key.filepath: Swift.swiftmodule,
+      key.hash: <hash>,
+      key.is_system: 1
+    }
+  ],
+  key.entities: [
+    {
+      key.kind: source.lang.swift.decl.class,
+      key.name: "HorseObject",
+      key.usr: "s:18index_constructors11HorseObjectC",
+      key.line: 6,
+      key.column: 7,
+      key.related: [
+        {
+          key.kind: source.lang.swift.ref.class,
+          key.name: "DogObject",
+          key.usr: "s:18index_constructors9DogObjectC",
+          key.line: 6,
+          key.column: 21
+        }
+      ],
+      key.entities: [
+        {
+          key.kind: source.lang.swift.ref.class,
+          key.name: "DogObject",
+          key.usr: "s:18index_constructors9DogObjectC",
+          key.line: 6,
+          key.column: 21
+        },
+        {
+          key.kind: source.lang.swift.decl.var.instance,
+          key.name: "name",
+          key.usr: "s:18index_constructors11HorseObjectC4nameXev",
+          key.line: 7,
+          key.column: 7
+        },
+        {
+          key.kind: source.lang.swift.decl.function.method.instance,
+          key.name: "flip()",
+          key.usr: "s:18index_constructors11HorseObjectC4flipyyF",
+          key.line: 9,
+          key.column: 21,
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.objc
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Two problems:

1) We were tearing down the type checker too early, before all
   relevant decls in other files had been type checked, so there
   was no LazyResolver available for use in the ASTContext.

   This might explain the crashes coming through
   diagnoseUnintendedObjCMethodOverrides().

2) When a lazy resolver was set in the ASTContext, we were not
   using it in the case where nullptr was passed in as the
   'resolver' parameter to inheritsSuperclassInitializers().

   This might fix the crashes where we were coming in from other
   code paths, but I'm less confident about this case.

Possibly fixes <rdar://problem/29043074>, <rdar://problem/30976765>,
<rdar://problem/31122590>, and <rdar://problem/31286627>, and the
many other similar-looking dupes.