### PR TITLE
[swiftc (26 vs. 5511)] Add crasher in swift::LValueType::get(...)

### DIFF
--- a/validation-test/compiler_crashers/28727-objectty-haserror-cannot-have-errortype-wrapped-inside-lvaluetype.swift
+++ b/validation-test/compiler_crashers/28727-objectty-haserror-cannot-have-errortype-wrapped-inside-lvaluetype.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol P}extension P{lazy var f={extension{var f=((self


### PR DESCRIPTION
Add test case for crash triggered in `swift::LValueType::get(...)`.

Current number of unresolved compiler crashers: 26 (5511 resolved)

/cc @DougGregor - just wanted to let you know that this crasher caused an assertion failure for the assertion `!objectTy->hasError() && "cannot have ErrorType wrapped inside LValueType"` added on 2016-10-06 by you in commit 50341da32 :-)

Assertion failure in [`lib/AST/ASTContext.cpp (line 3303)`](https://github.com/apple/swift/blob/2f0f49e028535f0399d88b05156acce4c6b88443/lib/AST/ASTContext.cpp#L3303):

```
Assertion `!objectTy->hasError() && "cannot have ErrorType wrapped inside LValueType"' failed.

When executing: static swift::LValueType *swift::LValueType::get(swift::Type)
```

Assertion context:

```c++
  ID.AddPointer(Parent.getPointer());
}

LValueType *LValueType::get(Type objectTy) {
  assert(!objectTy->hasError() &&
         "cannot have ErrorType wrapped inside LValueType");
  assert(!objectTy->is<LValueType>() && !objectTy->is<InOutType>() &&
         "cannot have 'inout' or @lvalue wrapped inside an @lvalue");

  auto properties = objectTy->getRecursiveProperties()
                    | RecursiveTypeProperties::IsLValue;
```
Stack trace:

```
0 0x0000000003962c58 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3962c58)
1 0x0000000003963396 SignalHandler(int) (/path/to/swift/bin/swift+0x3963396)
2 0x00007f4e8e2fd390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007f4e8c823428 gsignal /build/glibc-9tT8Do/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f4e8c82502a abort /build/glibc-9tT8Do/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f4e8c81bbd7 __assert_fail_base /build/glibc-9tT8Do/glibc-2.23/assert/assert.c:92:0
6 0x00007f4e8c81bc82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x00000000013de964 swift::LValueType::get(swift::Type) (/path/to/swift/bin/swift+0x13de964)
8 0x00000000012d5a50 swift::TypeChecker::getUnopenedTypeOfReference(swift::ValueDecl*, swift::Type, swift::DeclContext*, swift::DeclRefExpr const*, bool) (/path/to/swift/bin/swift+0x12d5a50)
9 0x000000000127eb96 swift::constraints::ConstraintSystem::getTypeOfReference(swift::ValueDecl*, bool, bool, swift::FunctionRefKind, swift::constraints::ConstraintLocatorBuilder, swift::DeclRefExpr const*) (/path/to/swift/bin/swift+0x127eb96)
10 0x00000000012813db swift::constraints::ConstraintSystem::resolveOverload(swift::constraints::ConstraintLocator*, swift::Type, swift::constraints::OverloadChoice, swift::DeclContext*) (/path/to/swift/bin/swift+0x12813db)
11 0x000000000123849e swift::ASTVisitor<(anonymous namespace)::ConstraintGenerator, swift::Type, void, void, void, void, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x123849e)
12 0x000000000123d9b8 (anonymous namespace)::ConstraintWalker::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0x123d9b8)
13 0x000000000145469b swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x145469b)
14 0x0000000001453be8 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x1453be8)
15 0x0000000001452e1b swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x1452e1b)
16 0x0000000001234b81 swift::constraints::ConstraintSystem::generateConstraints(swift::Expr*) (/path/to/swift/bin/swift+0x1234b81)
17 0x000000000125cbf6 swift::constraints::ConstraintSystem::solve(swift::Expr*&, swift::Type, swift::ExprTypeCheckListener*, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0x125cbf6)
18 0x00000000012947a4 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0x12947a4)
19 0x0000000001297e16 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x1297e16)
20 0x000000000129bb01 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*, bool) (/path/to/swift/bin/swift+0x129bb01)
21 0x000000000129bcc6 swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int, bool) (/path/to/swift/bin/swift+0x129bcc6)
22 0x00000000012b2028 validatePatternBindingEntries(swift::TypeChecker&, swift::PatternBindingDecl*) (/path/to/swift/bin/swift+0x12b2028)
23 0x00000000012ac454 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x12ac454)
24 0x00000000012bb80b (anonymous namespace)::DeclChecker::visitExtensionDecl(swift::ExtensionDecl*) (/path/to/swift/bin/swift+0x12bb80b)
25 0x00000000012ac3db (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x12ac3db)
26 0x00000000012ac313 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x12ac313)
27 0x0000000001316146 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x1316146)
28 0x00000000013157fb swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) (/path/to/swift/bin/swift+0x13157fb)
29 0x000000000132fefc swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) (/path/to/swift/bin/swift+0x132fefc)
30 0x0000000001297ea0 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x1297ea0)
31 0x000000000129bb01 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*, bool) (/path/to/swift/bin/swift+0x129bb01)
32 0x000000000129bcc6 swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int, bool) (/path/to/swift/bin/swift+0x129bcc6)
33 0x00000000012ac4c6 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x12ac4c6)
34 0x00000000012ac313 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x12ac313)
35 0x0000000001316146 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x1316146)
36 0x000000000131445d swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) (/path/to/swift/bin/swift+0x131445d)
37 0x00000000013142cd swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) (/path/to/swift/bin/swift+0x13142cd)
38 0x0000000001314ff1 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0x1314ff1)
39 0x0000000001329768 typeCheckFunctionsAndExternalDecls(swift::TypeChecker&) (/path/to/swift/bin/swift+0x1329768)
40 0x000000000132a548 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x132a548)
41 0x0000000000f9a7a6 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf9a7a6)
42 0x00000000004a8234 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a8234)
43 0x00000000004650b7 main (/path/to/swift/bin/swift+0x4650b7)
44 0x00007f4e8c80e830 __libc_start_main /build/glibc-9tT8Do/glibc-2.23/csu/../csu/libc-start.c:325:0
45 0x0000000000462759 _start (/path/to/swift/bin/swift+0x462759)
```