### PR TITLE
[swiftc (27 vs. 5511)] Add crasher in swift::TypeChecker::validateDecl(...)

### DIFF
--- a/validation-test/compiler_crashers/28728-d-isbeingvalidated-d-hasvalidsignature.swift
+++ b/validation-test/compiler_crashers/28728-d-isbeingvalidated-d-hasvalidsignature.swift
@@ -1,0 +1,11 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+typealias e:a
+struct A:a{}typealias a=A


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeChecker::validateDecl(...)`.

Current number of unresolved compiler crashers: 27 (5511 resolved)

/cc Huon Wilson - just wanted to let you know that this crasher caused an assertion failure for the assertion `D->isBeingValidated() || D->hasValidSignature()` added on 2017-02-21 by you in commit 84e0a109 :-)

Assertion failure in [`lib/Sema/TypeCheckDecl.cpp (line 6983)`](https://github.com/apple/swift/blob/6e27be1b6bc282ef0bde33108410080748bfcbcd/lib/Sema/TypeCheckDecl.cpp#L6983):

```
Assertion `D->isBeingValidated() || D->hasValidSignature()' failed.

When executing: void swift::TypeChecker::validateDecl(swift::ValueDecl *)
```

Assertion context:

```c++
  // up to the caller, who must call hasValidSignature() to
  // check that validateDecl() returned a fully-formed decl.
  if (D->hasValidationStarted()) {
    // If this isn't reentrant (i.e. D has already been validated), the
    // signature better be valid.
    assert(D->isBeingValidated() || D->hasValidSignature());
    return;
  }

  PrettyStackTraceDecl StackTrace("validating", D);

```
Stack trace:

```
0 0x0000000003962c58 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3962c58)
1 0x0000000003963396 SignalHandler(int) (/path/to/swift/bin/swift+0x3963396)
2 0x00007f90f65de390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007f90f4b04428 gsignal /build/glibc-9tT8Do/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f90f4b0602a abort /build/glibc-9tT8Do/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f90f4afcbd7 __assert_fail_base /build/glibc-9tT8Do/glibc-2.23/assert/assert.c:92:0
6 0x00007f90f4afcc82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x00000000012add1e swift::TypeChecker::validateDecl(swift::ValueDecl*) (/path/to/swift/bin/swift+0x12add1e)
8 0x0000000001322cba resolveTypeDecl(swift::TypeChecker&, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x1322cba)
9 0x000000000132281f resolveTopLevelIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x132281f)
10 0x000000000131cebe resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x131cebe)
11 0x000000000131c8e3 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x131c8e3)
12 0x000000000131d9f7 (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0x131d9f7)
13 0x000000000131d8fc swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x131d8fc)
14 0x000000000131bffa swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x131bffa)
15 0x00000000012a5d47 swift::TypeChecker::checkInheritanceClause(swift::Decl*, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0x12a5d47)
16 0x00000000012addf1 swift::TypeChecker::validateDecl(swift::ValueDecl*) (/path/to/swift/bin/swift+0x12addf1)
17 0x0000000001391f36 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1391f36)
18 0x0000000001391ffb swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1391ffb)
19 0x0000000001391ffb swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1391ffb)
20 0x00000000012ae650 swift::TypeChecker::validateDecl(swift::ValueDecl*) (/path/to/swift/bin/swift+0x12ae650)
21 0x00000000012bb8bf (anonymous namespace)::DeclChecker::visitTypeAliasDecl(swift::TypeAliasDecl*) (/path/to/swift/bin/swift+0x12bb8bf)
22 0x00000000012ac3eb (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x12ac3eb)
23 0x00000000012ac313 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x12ac313)
24 0x000000000132a445 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x132a445)
25 0x0000000000f9a7a6 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf9a7a6)
26 0x00000000004a8234 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a8234)
27 0x00000000004650b7 main (/path/to/swift/bin/swift+0x4650b7)
28 0x00007f90f4aef830 __libc_start_main /build/glibc-9tT8Do/glibc-2.23/csu/../csu/libc-start.c:325:0
29 0x0000000000462759 _start (/path/to/swift/bin/swift+0x462759)
```