### PR TITLE
SILOptimizer: Replace [].append(contentsOf:) with [].append(element:)

### DIFF
--- a/docs/HighLevelSILOptimizations.rst
+++ b/docs/HighLevelSILOptimizations.rst
@@ -207,6 +207,18 @@ array.get_capacity() -> Int
   Read the array capacity from the storage descriptor. The semantics
   are identical to ``get_count`` except for the meaning of the return value.
 
+array.append_element(newElement: Element)
+
+  Appends a single element to the array. No elements are read.
+  The operation is itself guarded by ``make_mutable``.
+  In contrast to other semantics operations, this operation is allowed to be
+  inlined in the early stages of the compiler.
+
+array.append_contentsOf(contentsOf newElements: S)
+
+  Appends all elements from S, which is a Sequence. No elements are read.
+  The operation is itself guarded by ``make_mutable``.
+
 array.make_mutable()
 
   This operation guards mutating operations that don't already imply

--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -450,7 +450,10 @@ public:
 
   /// Retrieve the declaration of Swift.==(Int, Int) -> Bool.
   FuncDecl *getEqualIntDecl() const;
-  
+
+  /// Retrieve the declaration of Array.append(element:)
+  FuncDecl *getArrayAppendElementDecl() const;
+
   /// Retrieve the declaration of Swift._unimplementedInitializer.
   FuncDecl *getUnimplementedInitializerDecl(LazyResolver *resolver) const;
 

--- a/include/swift/SILOptimizer/Analysis/ArraySemantic.h
+++ b/include/swift/SILOptimizer/Analysis/ArraySemantic.h
@@ -135,6 +135,12 @@ public:
   /// Returns true on success, false otherwise.
   bool replaceByValue(SILValue V);
 
+  /// Replace a call to append(contentsOf: ) with a series of
+  /// append(element: ) calls.
+  bool replaceByAppendingValues(SILModule &M, SILFunction *AppendFn,
+                                const llvm::SmallVectorImpl<SILValue> &Vals,
+                                ArrayRef<Substitution> Subs);
+
   /// Hoist the call to the insert point.
   void hoist(SILInstruction *InsertBefore, DominanceInfo *DT) {
     hoistOrCopy(InsertBefore, DT, false);

--- a/include/swift/SILOptimizer/Analysis/ArraySemantic.h
+++ b/include/swift/SILOptimizer/Analysis/ArraySemantic.h
@@ -34,8 +34,12 @@ enum class ArrayCallKind {
   kMakeMutable,
   kMutateUnknown,
   kWithUnsafeMutableBufferPointer,
+  kAppendContentsOf,
+  kAppendElement,
   // The following two semantic function kinds return the result @owned
-  // instead of operating on self passed as parameter.
+  // instead of operating on self passed as parameter. If you are adding
+  // a function, and it has a self parameter, make sure that it is defined
+  // before this comment.
   kArrayInit,
   kArrayUninitialized
 };
@@ -152,6 +156,9 @@ public:
 
   /// Could this array be backed by an NSArray.
   bool mayHaveBridgedObjectElementType() const;
+  
+  /// Can this function be inlined by the early inliner.
+  bool canInlineEarly() const;
 
 protected:
   /// Validate the signature of this call.

--- a/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
+++ b/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
@@ -489,6 +489,8 @@ static bool isNonMutatingArraySemanticCall(SILInstruction *Inst) {
   case ArrayCallKind::kWithUnsafeMutableBufferPointer:
   case ArrayCallKind::kArrayInit:
   case ArrayCallKind::kArrayUninitialized:
+  case ArrayCallKind::kAppendContentsOf:
+  case ArrayCallKind::kAppendElement:
     return false;
   }
 
@@ -825,6 +827,8 @@ static bool mayChangeArrayValueToNonUniqueState(ArraySemanticsCall &Call) {
   case ArrayCallKind::kWithUnsafeMutableBufferPointer:
   case ArrayCallKind::kArrayInit:
   case ArrayCallKind::kArrayUninitialized:
+  case ArrayCallKind::kAppendContentsOf:
+  case ArrayCallKind::kAppendElement:
     return true;
   }
 

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -212,6 +212,11 @@ void addSSAPasses(SILPassPipelinePlan &P, OptimizationLevelKind OpLevel) {
   // Promote stack allocations to values.
   P.addMem2Reg();
 
+  // Cleanup, which is important if the inliner has restarted the pass pipeline.
+  P.addPerformanceConstantPropagation();
+  P.addSimplifyCFG();
+  P.addSILCombine();
+
   // Run the devirtualizer, specializer, and inliner. If any of these
   // makes a change we'll end up restarting the function passes on the
   // current function (after optimizing any new callees).

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -217,6 +217,9 @@ void addSSAPasses(SILPassPipelinePlan &P, OptimizationLevelKind OpLevel) {
   P.addSimplifyCFG();
   P.addSILCombine();
 
+  // Mainly for Array.append(contentsOf) optimization.
+  P.addArrayElementPropagation();
+  
   // Run the devirtualizer, specializer, and inliner. If any of these
   // makes a change we'll end up restarting the function passes on the
   // current function (after optimizing any new callees).

--- a/lib/SILOptimizer/Transforms/ArrayElementValuePropagation.cpp
+++ b/lib/SILOptimizer/Transforms/ArrayElementValuePropagation.cpp
@@ -11,7 +11,9 @@
 //===----------------------------------------------------------------------===//
 #define DEBUG_TYPE "array-element-propagation"
 
-#include "llvm/ADT/SetVector.h"
+#include "swift/AST/NameLookup.h"
+#include "swift/AST/ParameterList.h"
+#include "swift/AST/GenericEnvironment.h"
 #include "swift/SIL/SILBasicBlock.h"
 #include "swift/SIL/SILInstruction.h"
 #include "swift/SIL/DebugUtils.h"
@@ -23,12 +25,14 @@
 using namespace swift;
 
 /// Propagate the elements of array values to calls of the array's get_element
-/// method.
+/// method, and replace calls of append(contentsOf:) with append(element:).
 ///
 /// Array literal construction and array initialization of array values
 /// associates element values with the array value. These values can be
 /// propagated to the get_element method if we can prove that the array value
-/// has not changed until reading the array value's element.
+/// has not changed until reading the array value's element. These values can
+/// also be used to replace append(contentsOf:) with multiple append(element:)
+/// calls.
 ///
 /// Propagation of the elements of one array allocation.
 ///
@@ -42,53 +46,72 @@ using namespace swift;
 ///   The stores on the returned array element buffer pointer.
 ///
 namespace {
+
+/// Utility class for analysis array literal initializations.
+///
+/// Array literals are initialized by allocating an array buffer, and storing
+/// the elements into it.
+/// This class analysis all the code which does the array literal
+/// initialization. It also collects uses of the array, like getElement calls
+/// and append(contentsOf) calls.
 class ArrayAllocation {
-  /// The array allocation call.
-  ApplyInst *Alloc;
   /// The array value returned by the allocation call.
   SILValue ArrayValue;
 
-  /// The pointer to the returned array element buffer pointer.
-  SILValue ElementBuffer;
-
-  // The calls to Array get_element that use this array allocation.
+  /// The calls to Array get_element that use this array allocation.
   llvm::SmallSetVector<ApplyInst *, 16> GetElementCalls;
+
+  /// The calls to Array append_contentsOf that use this array allocation.
+  llvm::SmallVector<ApplyInst *, 4> AppendContentsOfCalls;
+
+  /// A map of Array indices to element values
   llvm::DenseMap<uint64_t, SILValue> ElementValueMap;
 
-  // Array get_element calls and their matching array element value for later
-  // replacement.
-  llvm::SmallVectorImpl<std::pair<ApplyInst *, SILValue>> &ReplacementMap;
-
-  ArrayAllocation(
-      ApplyInst *AI,
-      llvm::SmallVectorImpl<std::pair<ApplyInst *, SILValue>> &Replacements)
-      : Alloc(AI), ReplacementMap(Replacements) {}
-
-  bool findValueReplacements();
-  bool isInitializationWithKnownElements();
-  bool mapInitializationStores();
-  bool analyzeArrayValueUses();
+  bool mapInitializationStores(SILValue ElementBuffer);
   bool recursivelyCollectUses(ValueBase *Def);
   bool collectForwardableValues();
+  bool replacementsAreValid();
+
+  // After approx. this many elements, it's faster to use append(contentsOf:)
+  static constexpr unsigned APPEND_CONTENTSOF_REPLACEMENT_VALUES_MAX = 6;
 
 public:
 
-  /// Find a set of get_element calls that can be replace by the initialization
-  /// value of the array allocation call.
-  ///
-  /// Returns true if an access can be replaced. The replacements are stored in
-  /// the \p ReplacementMap.
-  static bool findValueReplacements(
-      ApplyInst *Inst,
-      llvm::SmallVectorImpl<std::pair<ApplyInst *, SILValue>> &Replacements) {
-    return ArrayAllocation(Inst, Replacements).findValueReplacements();
-  }
-};
-} // end anonymous namespace
+  /// Specifies the value with which a get-element call can be replaced.
+  struct GetElementReplacement {
+    ApplyInst *GetElementCall;
+    SILValue Replacement;
+  };
 
+  /// Specifies the set of elements with which a append-contentof call can be
+  /// replaced.
+  struct AppendContentOfReplacement {
+    ApplyInst *AppendContentOfCall;
+    llvm::SmallVector<SILValue, 4> ReplacementValues;
+    SILValue Array;
+  };
+
+  ArrayAllocation() {}
+
+  /// Analyzes an array allocation call.
+  ///
+  /// Returns true if \p Alloc is the allocation of an array literal (or a
+  /// similar pattern) and the array values can be used to replace get_element
+  /// or append(contentof) calls.
+  bool analyze(ApplyInst *Alloc);
+
+  /// Gets the list of get_element calls which can be replaced.
+  void getGetElementReplacements(
+    llvm::SmallVectorImpl<GetElementReplacement> &Replacements);
+
+  /// Gets the list of append(contentof) calls which can be replaced by a
+  /// set of values.
+  void getAppendContentOfReplacements(
+    llvm::SmallVectorImpl<AppendContentOfReplacement> &Replacements);
+};
 
 /// Map the indices of array element initialization stores to their values.
-bool ArrayAllocation::mapInitializationStores() {
+bool ArrayAllocation::mapInitializationStores(SILValue ElementBuffer) {
   assert(ElementBuffer &&
          "Must have identified an array element storage pointer");
 
@@ -148,44 +171,18 @@ bool ArrayAllocation::mapInitializationStores() {
   return !ElementValueMap.empty();
 }
 
-/// Check that we have an array initialization call with known elements.
-///
-/// The returned array value is known not to be aliased since it was just
-/// allocated.
-bool ArrayAllocation::isInitializationWithKnownElements() {
-  ArraySemanticsCall Uninitialized(Alloc, "array.uninitialized");
-  if (Uninitialized &&
-      (ArrayValue = Uninitialized.getArrayValue()) &&
-      (ElementBuffer = Uninitialized.getArrayElementStoragePointer()))
-    return mapInitializationStores();
+bool ArrayAllocation::replacementsAreValid() {
+  unsigned ElementCount = ElementValueMap.size();
 
-  return false;
-}
-
-/// Propagate the elements of an array literal to get_element method calls on
-/// the same array.
-///
-/// We have to prove that the array value is not changed in between the
-/// creation and the method call to get_element.
-bool ArrayAllocation::findValueReplacements() {
-  if (!isInitializationWithKnownElements())
+  if (ElementCount > APPEND_CONTENTSOF_REPLACEMENT_VALUES_MAX)
     return false;
 
-  // The array value was stored or has escaped.
-  if (!analyzeArrayValueUses())
-    return false;
+  // Bail if elements aren't contiguous
+  for (unsigned i = 0; i < ElementCount; ++i)
+    if (!ElementValueMap.count(i))
+      return false;
 
-  // No count users.
-  if (GetElementCalls.empty())
-    return false;
-
-  return collectForwardableValues();
-}
-
-/// Collect all get_element users and check that there are no escapes or uses
-/// that could change the array value.
-bool ArrayAllocation::analyzeArrayValueUses() {
-  return recursivelyCollectUses(ArrayValue);
+  return true;
 }
 
 /// Recursively look at all uses of this definition. Abort if the array value
@@ -206,10 +203,16 @@ bool ArrayAllocation::recursivelyCollectUses(ValueBase *Def) {
 
     // Check array semantic calls.
     ArraySemanticsCall ArrayOp(User);
-    if (ArrayOp && ArrayOp.doesNotChangeArray()) {
-      if (ArrayOp.getKind() == ArrayCallKind::kGetElement)
+    if (ArrayOp) {
+      if (ArrayOp.getKind() == ArrayCallKind::kAppendContentsOf) {
+        AppendContentsOfCalls.push_back(ArrayOp);
+        continue;
+      } else if (ArrayOp.getKind() == ArrayCallKind::kGetElement) {
         GetElementCalls.insert(ArrayOp);
-      continue;
+        continue;
+      } else if (ArrayOp.doesNotChangeArray()) {
+        continue;
+      }
     }
 
     // An operation that escapes or modifies the array value.
@@ -218,9 +221,32 @@ bool ArrayAllocation::recursivelyCollectUses(ValueBase *Def) {
   return true;
 }
 
-/// Look at the get_element calls and match them to values by index.
-bool ArrayAllocation::collectForwardableValues() {
-  bool FoundForwardableValue = false;
+bool ArrayAllocation::analyze(ApplyInst *Alloc) {
+  ArraySemanticsCall Uninitialized(Alloc, "array.uninitialized");
+  if (!Uninitialized)
+    return false;
+
+  ArrayValue = Uninitialized.getArrayValue();
+  if (!ArrayValue)
+    return false;
+
+  SILValue ElementBuffer = Uninitialized.getArrayElementStoragePointer();
+  if (!ElementBuffer)
+    return false;
+
+  // Figure out all stores to the array.
+  if (!mapInitializationStores(ElementBuffer))
+    return false;
+
+  // Check if the array value was stored or has escaped.
+  if (!recursivelyCollectUses(ArrayValue))
+    return false;
+
+  return true;
+}
+
+void ArrayAllocation::getGetElementReplacements(
+                   llvm::SmallVectorImpl<GetElementReplacement> &Replacements) {
   for (auto *GetElementCall : GetElementCalls) {
     ArraySemanticsCall GetElement(GetElementCall);
     assert(GetElement.getKind() == ArrayCallKind::kGetElement);
@@ -235,18 +261,28 @@ bool ArrayAllocation::collectForwardableValues() {
     if (EltValueIt == ElementValueMap.end())
       continue;
 
-    ReplacementMap.push_back(
-        std::make_pair(GetElementCall, EltValueIt->second));
-    FoundForwardableValue = true;
+    Replacements.push_back({GetElementCall, EltValueIt->second});
   }
-  return FoundForwardableValue;
+}
+
+void ArrayAllocation::getAppendContentOfReplacements(
+              llvm::SmallVectorImpl<AppendContentOfReplacement> &Replacements) {
+  if (AppendContentsOfCalls.empty())
+    return;
+  if (!replacementsAreValid())
+    return;
+
+  llvm::SmallVector<SILValue, 4> ElementValueVector;
+  for (unsigned i = 0; i < ElementValueMap.size(); ++i)
+    ElementValueVector.push_back(ElementValueMap[i]);
+
+  for (auto *Call : AppendContentsOfCalls)
+    Replacements.push_back({Call, ElementValueVector, ArrayValue});
 }
 
 // =============================================================================
 //                                 Driver
 // =============================================================================
-
-namespace {
 
 class ArrayElementPropagation : public SILFunctionTransform {
 public:
@@ -256,29 +292,82 @@ public:
     return "Array Element Propagation";
   }
 
+  bool replaceAppendCalls(
+                  ArrayRef<ArrayAllocation::AppendContentOfReplacement> Repls) {
+    auto &Fn = *getFunction();
+    auto &M = Fn.getModule();
+    auto &Ctx = M.getASTContext();
+
+    if (Repls.empty())
+      return false;
+
+    DEBUG(llvm::dbgs() << "Array append contentsOf calls replaced in "
+                       << Fn.getName() << " (" << Repls.size() << ")\n");
+
+    auto *AppendFnDecl = Ctx.getArrayAppendElementDecl();
+    if (!AppendFnDecl)
+      return false;
+
+    auto Mangled = SILDeclRef(AppendFnDecl, SILDeclRef::Kind::Func).mangle();
+    auto *AppendFn = M.findFunction(Mangled, SILLinkage::PublicExternal);
+    if (!AppendFn)
+      return false;
+    
+    for (const ArrayAllocation::AppendContentOfReplacement &Repl : Repls) {
+      ArraySemanticsCall AppendContentsOf(Repl.AppendContentOfCall);
+      assert(AppendContentsOf && "Must be AppendContentsOf call");
+      
+      SILType ArrayType = Repl.Array->getType();
+      auto *NTD = ArrayType.getSwiftRValueType()->getAnyNominal();
+      SubstitutionMap ArraySubMap = ArrayType.getSwiftRValueType()
+        ->getContextSubstitutionMap(M.getSwiftModule(), NTD);
+      
+      GenericSignature *Sig = NTD->getGenericSignature();
+      assert(Sig && "Array type must have generic signature");
+      SmallVector<Substitution, 4> Subs;
+      Sig->getSubstitutions(ArraySubMap, Subs);
+      
+      AppendContentsOf.replaceByAppendingValues(M, AppendFn,
+                                                Repl.ReplacementValues, Subs);
+    }
+    return true;
+  }
+
   void run() override {
     auto &Fn = *getFunction();
 
-    bool Changed = false;
-
     // Propagate the elements an of array value to its users.
-    SmallVector<std::pair<ApplyInst *, SILValue>, 16> ValueReplacements;
+    llvm::SmallVector<ArrayAllocation::GetElementReplacement, 16>
+      GetElementReplacements;
+    llvm::SmallVector<ArrayAllocation::AppendContentOfReplacement, 4>
+      AppendContentsOfReplacements;
+
     for (auto &BB :Fn) {
       for (auto &Inst : BB) {
-        if (auto *Apply = dyn_cast<ApplyInst>(&Inst))
-          Changed |=
-              ArrayAllocation::findValueReplacements(Apply, ValueReplacements);
+        if (auto *Apply = dyn_cast<ApplyInst>(&Inst)) {
+          ArrayAllocation ALit;
+          if (ALit.analyze(Apply)) {
+            ALit.getGetElementReplacements(GetElementReplacements);
+            ALit.getAppendContentOfReplacements(AppendContentsOfReplacements);
+          }
+        }
       }
     }
-    DEBUG(if (Changed) {
+
+    DEBUG(if (!GetElementReplacements.empty()) {
       llvm::dbgs() << "Array elements replaced in " << Fn.getName() << " ("
-                   << ValueReplacements.size() << ")\n";
+                   << GetElementReplacements.size() << ")\n";
     });
+    
+    bool Changed = false;
+    
     // Perform the actual replacement of the get_element call by its value.
-    for (auto &Repl : ValueReplacements) {
-      ArraySemanticsCall GetElement(Repl.first);
-      GetElement.replaceByValue(Repl.second);
+    for (ArrayAllocation::GetElementReplacement &Repl : GetElementReplacements) {
+      ArraySemanticsCall GetElement(Repl.GetElementCall);
+      Changed |= GetElement.replaceByValue(Repl.Replacement);
     }
+
+    Changed |= replaceAppendCalls(AppendContentsOfReplacements);
 
     if (Changed) {
       PM->invalidateAnalysis(

--- a/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
+++ b/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
@@ -566,8 +566,13 @@ decideInWarmBlock(FullApplySite AI,
 
   SILFunction *Callee = AI.getReferencedFunction();
 
-  if (Callee->getInlineStrategy() == AlwaysInline)
+  if (Callee->getInlineStrategy() == AlwaysInline) {
+    DEBUG(
+      dumpCaller(AI.getFunction());
+      llvm::dbgs() << "    always-inline decision " <<Callee->getName() << '\n';
+    );
     return true;
+  }
 
   return isProfitableToInline(AI, CallerWeight, callerTracker, NumCallerBlocks);
 }

--- a/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
+++ b/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
@@ -104,8 +104,11 @@ class SILPerformanceInliner {
     /// increasing the code size.
     TrivialFunctionThreshold = 18,
 
-    /// Configuration for the caller block limit.
-    BlockLimitDenominator = 10000,
+    /// Configuration for the "soft" caller block limit.
+    BlockLimitDenominator = 3000,
+
+    /// No inlining is done if the caller has more than this number of blocks.
+    OverallCallerBlockLimit = 400,
 
     /// The assumed execution length of a function call.
     DefaultApplyLength = 10
@@ -703,6 +706,9 @@ void SILPerformanceInliner::collectAppliesToInline(
           InitialCandidates.push_back(AI);
       }
     }
+    if (NumCallerBlocks > OverallCallerBlockLimit)
+      break;
+
     domOrder.pushChildrenIf(block, [&] (SILBasicBlock *child) {
       if (CBI.isSlowPath(block, child)) {
         // Handle cold blocks separately.

--- a/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
+++ b/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
@@ -227,7 +227,9 @@ SILFunction *SILPerformanceInliner::getEligibleFunction(FullApplySite AI) {
   // attribute if the inliner is asked not to inline them.
   if (Callee->hasSemanticsAttrs() || Callee->hasEffectsKind()) {
     if (WhatToInline == InlineSelection::NoSemanticsAndGlobalInit) {
-      return nullptr;
+      ArraySemanticsCall ASC(AI.getInstruction());
+      if (!ASC.canInlineEarly())
+        return nullptr;
     }
     // The "availability" semantics attribute is treated like global-init.
     if (Callee->hasSemanticsAttrs() &&

--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -1411,6 +1411,7 @@ extension ${Self} : RangeReplaceableCollection, _ArrayProtocol {
   ///   bridged `NSArray` instance as its storage, the efficiency is
   ///   unspecified.
   @_inlineable
+  @_semantics("array.append_element")
   public mutating func append(_ newElement: Element) {
     _makeUniqueAndReserveCapacityIfNotUnique()
     let oldCount = _getCount()
@@ -1433,6 +1434,7 @@ extension ${Self} : RangeReplaceableCollection, _ArrayProtocol {
   ///
   /// - Complexity: O(*n*), where *n* is the length of the resulting array.
   @_inlineable
+  @_semantics("array.append_contentsOf")
   public mutating func append<S : Sequence>(contentsOf newElements: S)
     where S.Iterator.Element == Element {
 

--- a/test/SILOptimizer/array_contentof_opt.swift
+++ b/test/SILOptimizer/array_contentof_opt.swift
@@ -1,0 +1,52 @@
+// RUN: %target-swift-frontend -O -emit-sil  %s | %FileCheck %s
+// REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
+
+// This is an end-to-end test of the array(contentsOf) -> array(Element) optimization
+
+// CHECK-LABEL: sil @{{.*}}testInt
+// CHECK-NOT: apply
+// CHECK:        [[F:%[0-9]+]] = function_ref @_T0Sa6appendyxFSi_Tg
+// CHECK-NOT: apply
+// CHECK:        apply [[F]]
+// CHECK-NEXT:   tuple
+// CHECK-NEXT:   return
+public func testInt(_ a: inout [Int]) {
+  a += [1]
+}
+
+// CHECK-LABEL: sil @{{.*}}testThreeInt
+// CHECK-NOT: apply
+// CHECK:        [[F:%[0-9]+]] = function_ref @_T0Sa6appendyxFSi_Tg
+// CHECK-NOT: apply
+// CHECK:        apply [[F]]
+// CHECK-NEXT:   apply [[F]]
+// CHECK-NEXT:   apply [[F]]
+// CHECK-NEXT:   tuple
+// CHECK-NEXT:   return
+public func testThreeInts(_ a: inout [Int]) {
+  a += [1, 2, 3]
+}
+
+// CHECK-LABEL: sil @{{.*}}testTooManyInts
+// CHECK-NOT: apply
+// CHECK:        [[F:%[0-9]+]] = function_ref @_T0Sa6appendyqd__10contentsOf_t8Iterator_7ElementQYd__Rszs8SequenceRd__lF
+// CHECK-NOT: apply
+// CHECK:        apply [[F]]
+// CHECK-NOT: apply
+// CHECK:        return
+public func testTooManyInts(_ a: inout [Int]) {
+  a += [1, 2, 3, 4, 5, 6, 7]
+}
+
+// CHECK-LABEL: sil @{{.*}}testString
+// CHECK-NOT: apply
+// CHECK:        [[F:%[0-9]+]] = function_ref @_T0Sa6appendyxFSS_Tg
+// CHECK-NOT: apply
+// CHECK:        apply [[F]]
+// CHECK-NOT: apply
+// CHECK:        tuple
+// CHECK-NEXT:   return
+public func testString(_ a: inout [String], s: String) {
+  a += [s]
+}
+

--- a/test/SILOptimizer/array_element_propagation.sil
+++ b/test/SILOptimizer/array_element_propagation.sil
@@ -31,6 +31,9 @@ sil [_semantics "array.check_subscript"] @checkSubscript : $@convention(method) 
 sil [_semantics "array.get_element"] @getElement : $@convention(method) (MyInt, MyBool, _MyDependenceToken, @guaranteed MyArray<MyInt>) -> @out MyInt
 sil [_semantics "array.get_element"] @getElement2 : $@convention(method) (MyInt, MyBool, _MyDependenceToken, @guaranteed MyArray<MyInt>) -> MyInt
 sil @unknown_array_use : $@convention(method) (@guaranteed MyArray<MyInt>) -> MyBool
+sil [_semantics "array.uninitialized"] @arrayAdoptStorage : $@convention(thin) (@owned AnyObject, MyInt, @thin Array<MyInt>.Type) -> @owned (Array<MyInt>, UnsafeMutablePointer<MyInt>)
+sil @arrayInit : $@convention(method) (@thin Array<MyInt>.Type) -> @owned Array<MyInt>
+sil [_semantics "array.append_contentsOf"] @arrayAppendContentsOf : $@convention(method) (@owned Array<MyInt>, @inout Array<MyInt>) -> ()
 
 // CHECK-LABEL: sil @propagate01
 // CHECK:    struct $MyInt
@@ -299,4 +302,84 @@ sil @unknown_use : $@convention(thin) () -> () {
   dealloc_stack %26 : $*MyInt
   strong_release %25 : $Builtin.BridgeObject
   return %52 : $()
+}
+
+// CHECK-LABEL: sil @append_contentsOf_int
+// CHECK:      [[ASFUN:%.*]] = function_ref @arrayAdoptStorage
+// CHECK-NEXT: [[ARR:%.*]] = apply [[ASFUN]]
+// CHECK-NEXT: [[OWNER:%.*]] = tuple_extract [[ARR]]{{.*}}, 0
+// CHECK-NOT:    apply [[ACFUN]]
+// CHECK:      [[AEFUN:%.*]] = function_ref @_T0Sa6appendyxF
+// CHECK-NEXT: [[STACK:%.*]] = alloc_stack $MyInt
+// CHECK-NEXT: store %{{[0-9]+}} to [[STACK]]
+// CHECK-NEXT: apply [[AEFUN]]<MyInt>([[STACK]]
+// CHECK-NEXT: dealloc_stack [[STACK]]
+// CHECK-NEXT: release_value [[OWNER]]
+// CHECK:      return
+sil @append_contentsOf_int : $@convention(thin) () -> () {
+  %0 = function_ref @swift_bufferAllocate : $@convention(thin) () -> @owned AnyObject
+  %1 = integer_literal $Builtin.Int64, 1
+  %2 = struct $MyInt (%1 : $Builtin.Int64)
+  %3 = apply %0() : $@convention(thin) () -> @owned AnyObject
+  %4 = metatype $@thin Array<MyInt>.Type
+  %5 = function_ref @arrayAdoptStorage : $@convention(thin) (@owned AnyObject, MyInt, @thin Array<MyInt>.Type) -> @owned (Array<MyInt>, UnsafeMutablePointer<MyInt>)
+  %6 = apply %5(%3, %2, %4) : $@convention(thin) (@owned AnyObject, MyInt, @thin Array<MyInt>.Type) -> @owned (Array<MyInt>, UnsafeMutablePointer<MyInt>)
+  %7 = tuple_extract %6 : $(Array<MyInt>, UnsafeMutablePointer<MyInt>), 0
+  %8 = tuple_extract %6 : $(Array<MyInt>, UnsafeMutablePointer<MyInt>), 1
+  %9 = struct_extract %8 : $UnsafeMutablePointer<MyInt>, #UnsafeMutablePointer._rawValue
+  %10 = pointer_to_address %9 : $Builtin.RawPointer to [strict] $*MyInt
+  %11 = integer_literal $Builtin.Int64, 27
+  %12 = struct $MyInt (%11 : $Builtin.Int64)
+  store %12 to %10 : $*MyInt
+  %13 = alloc_stack $Array<MyInt>
+  %14 = metatype $@thin Array<MyInt>.Type
+  %15 = function_ref @arrayInit : $@convention(method) (@thin Array<MyInt>.Type) -> @owned Array<MyInt>
+  %16 = apply %15(%14) : $@convention(method) (@thin Array<MyInt>.Type) -> @owned Array<MyInt>
+  store %16 to %13 : $*Array<MyInt>
+  %17 = function_ref @arrayAppendContentsOf : $@convention(method) (@owned Array<MyInt>, @inout Array<MyInt>) -> ()
+  %18 = apply %17(%7, %13) : $@convention(method) (@owned Array<MyInt>, @inout Array<MyInt>) -> ()
+  dealloc_stack %13 : $*Array<MyInt>
+  %19 = tuple ()
+  return %19 : $()
+}
+
+class Hello {
+}
+
+sil [_semantics "array.uninitialized"] @adoptStorageHello : $@convention(method) (@owned _ContiguousArrayStorage<Hello>, MyInt, @thin Array<Hello>.Type) -> (@owned Array<Hello>, UnsafeMutablePointer<Hello>)
+sil [_semantics "array.append_contentsOf"] @arrayAppendContentsOfHello : $@convention(method) (@owned Array<Hello>, @inout Array<Hello>) -> ()
+
+// CHECK-LABEL: sil @append_contentsOf_class
+// CHECK:      [[ASFUN:%.*]] = function_ref @adoptStorageHello
+// CHECK-NEXT: [[ARR:%.*]] = apply [[ASFUN]]
+// CHECK-NEXT: [[OWNER:%.*]] = tuple_extract [[ARR]]{{.*}}, 0
+// CHECK:      strong_retain %1 : $Hello
+// CHECK-NEXT: store %1 to %{{[0-9]+}} : $*Hello
+// CHECK-NOT:     apply
+// CHECK:      [[AEFUN:%.*]] = function_ref @_T0Sa6appendyxF
+// CHECK-NEXT: strong_retain %1 : $Hello
+// CHECK-NEXT: [[STACK:%.*]] = alloc_stack $Hello
+// CHECK-NEXT: store %1 to [[STACK]]
+// CHECK-NEXT: apply [[AEFUN]]<Hello>([[STACK]], %0)
+// CHECK-NEXT: dealloc_stack [[STACK]]
+// CHECK-NEXT: release_value [[OWNER]]
+// CHECK-NEXT: return
+sil @append_contentsOf_class : $@convention(thin) (@inout Array<Hello>, @owned Hello) -> @owned Hello {
+bb0(%0 : $*Array<Hello>, %1 : $Hello):
+  %4 = integer_literal $Builtin.Word, 1
+  %5 = integer_literal $Builtin.Int64, 1
+  %6 = struct $MyInt (%5 : $Builtin.Int64)
+  %7 = alloc_ref [tail_elems $Hello * %4 : $Builtin.Word] $_ContiguousArrayStorage<Hello>
+  %8 = metatype $@thin Array<Hello>.Type
+  %9 = function_ref @adoptStorageHello : $@convention(method) (@owned _ContiguousArrayStorage<Hello>, MyInt, @thin Array<Hello>.Type) -> (@owned Array<Hello>, UnsafeMutablePointer<Hello>)
+  %10 = apply %9(%7, %6, %8) : $@convention(method) (@owned _ContiguousArrayStorage<Hello>, MyInt, @thin Array<Hello>.Type) -> (@owned Array<Hello>, UnsafeMutablePointer<Hello>)
+  %11 = tuple_extract %10 : $(Array<Hello>, UnsafeMutablePointer<Hello>), 0
+  %12 = tuple_extract %10 : $(Array<Hello>, UnsafeMutablePointer<Hello>), 1
+  %13 = struct_extract %12 : $UnsafeMutablePointer<Hello>, #UnsafeMutablePointer._rawValue
+  %22 = pointer_to_address %13 : $Builtin.RawPointer to [strict] $*Hello
+  strong_retain %1 : $Hello
+  store %1 to %22 : $*Hello
+  %25 = function_ref @arrayAppendContentsOfHello : $@convention(method) (@owned Array<Hello>, @inout Array<Hello>) -> ()
+  %26 = apply %25(%11, %0) : $@convention(method) (@owned Array<Hello>, @inout Array<Hello>) -> ()
+  return %1 : $Hello
 }

--- a/test/SILOptimizer/devirt_specialized_inherited_interplay.swift
+++ b/test/SILOptimizer/devirt_specialized_inherited_interplay.swift
@@ -12,13 +12,7 @@
 
 // CHECK-LABEL: sil @_T038devirt_specialized_inherited_interplay6driveryyF : $@convention(thin) () -> () {
 // CHECK: bb0:
-// CHECK: [[A3:%[0-9]+]] = alloc_ref [stack] $A3<S>
-// CHECK: [[A4:%[0-9]+]] = alloc_ref [stack] $A4<S>
-// CHECK: [[A5:%[0-9]+]] = alloc_ref [stack] $A5<S>
-// CHECK: [[B1:%[0-9]+]] = alloc_ref [stack] $B1<S>
-// CHECK: [[B2:%[0-9]+]] = alloc_ref [stack] $B2<S>
-// CHECK: [[B3:%[0-9]+]] = alloc_ref [stack] $B3<S>
-// CHECK: [[B4:%[0-9]+]] = alloc_ref [stack] $B4<S>
+// CHECK-NOT: alloc_ref
 // CHECK: [[F0:%[0-9]+]] = function_ref @unknown0 : $@convention(thin) () -> ()
 // CHECK: apply [[F0]]
 // CHECK: apply [[F0]]
@@ -45,13 +39,7 @@
 // CHECK: [[F8:%[0-9]+]] = function_ref @unknown8 :
 // CHECK: apply [[F8]]
 // CHECK: apply [[F8]]
-// CHECK: dealloc_ref [stack] [[B4]]
-// CHECK: dealloc_ref [stack] [[B3]]
-// CHECK: dealloc_ref [stack] [[B2]]
-// CHECK: dealloc_ref [stack] [[B1]]
-// CHECK: dealloc_ref [stack] [[A5]]
-// CHECK: dealloc_ref [stack] [[A4]]
-// CHECK: dealloc_ref [stack] [[A3]]
+// CHECK-NOT: dealloc_ref
 // CHECK: return
 
 @_silgen_name("unknown0")

--- a/test/SILOptimizer/specialize_unconditional_checked_cast.swift
+++ b/test/SILOptimizer/specialize_unconditional_checked_cast.swift
@@ -99,6 +99,8 @@ ArchetypeToConcreteConvertUInt8(t: f)
 // CHECK-LABEL: sil shared [noinline] @_T037specialize_unconditional_checked_cast31ArchetypeToConcreteConvertUInt8{{[_0-9a-zA-Z]*}}3Not{{.*}}Tg5 : $@convention(thin) (NotUInt8) -> NotUInt8 {
 // CHECK: bb0
 // CHECK-NEXT: debug_value %0
+// TODO: the second debug_value is redundant and should be removed
+// CHECK-NEXT: debug_value %0
 // CHECK-NEXT: return %0
 
 // x -> y where y is a class but x is not.


### PR DESCRIPTION
if the argument is an array literal.

For example:
arr += [1, 2, 3]

is replaced by:
arr.append(1)
arr.append(2)
arr.append(3)

This gives considerable speedups up to 10x (for our micro-benchmarks which test this).

This is based on the work of @ben-ng, who implemented the first version of this optimization (thanks!). The original PR is https://github.com/apple/swift/pull/6652

This PR also contains a commit which adds some clean-up passes before the inliner. This is necessary for this optimization.

<rdar://problem/17750612>