### PR TITLE
Annotate LazyFilter* functions to get a good performance even in resilient mode

### DIFF
--- a/stdlib/public/core/Filter.swift.gyb
+++ b/stdlib/public/core/Filter.swift.gyb
@@ -22,6 +22,7 @@ from gyb_stdlib_support import (
 ///
 /// - Note: This is the associated `Iterator` of `LazyFilterSequence`
 /// and `LazyFilterCollection`.
+@_fixed_layout
 public struct LazyFilterIterator<
   Base : IteratorProtocol
 > : IteratorProtocol, Sequence {
@@ -32,6 +33,7 @@ public struct LazyFilterIterator<
   ///
   /// - Precondition: `next()` has not been applied to a copy of `self`
   ///   since the copy was made.
+  @_inlineable
   public mutating func next() -> Base.Element? {
     while let n = _base.next() {
       if _predicate(n) {
@@ -43,6 +45,8 @@ public struct LazyFilterIterator<
 
   /// Creates an instance that produces the elements `x` of `base`
   /// for which `isIncluded(x) == true`.
+  @_inlineable
+  @_versioned
   internal init(
     _base: Base,
     _ isIncluded: @escaping (Base.Element) -> Bool
@@ -52,12 +56,15 @@ public struct LazyFilterIterator<
   }
 
   /// The underlying iterator whose elements are being filtered.
+  @_inlineable
   public var base: Base { return _base }
 
+  @_versioned
   internal var _base: Base
 
   /// The predicate used to determine which elements produced by
   /// `base` are also produced by `self`.
+  @_versioned
   internal let _predicate: (Base.Element) -> Bool
 }
 
@@ -66,12 +73,14 @@ public struct LazyFilterIterator<
 ///
 /// - Note: `s.lazy.filter { ... }`, for an arbitrary sequence `s`,
 ///   is a `LazyFilterSequence`.
+@_fixed_layout
 public struct LazyFilterSequence<Base : Sequence>
   : LazySequenceProtocol {
 
   /// Returns an iterator over the elements of this sequence.
   ///
   /// - Complexity: O(1).
+  @_inlineable
   public func makeIterator() -> LazyFilterIterator<Base.Iterator> {
     return LazyFilterIterator(
       _base: base.makeIterator(), _include)
@@ -79,6 +88,7 @@ public struct LazyFilterSequence<Base : Sequence>
 
   /// Creates an instance consisting of the elements `x` of `base` for
   /// which `isIncluded(x) == true`.
+  @_inlineable
   public // @testable
   init(
     _base base: Base,
@@ -93,6 +103,7 @@ public struct LazyFilterSequence<Base : Sequence>
 
   /// The predicate used to determine which elements of `base` are
   /// also elements of `self`.
+  @_versioned
   internal let _include: (Base.Iterator.Element) -> Bool
 }
 
@@ -107,13 +118,21 @@ public struct LazyFilterSequence<Base : Sequence>
 ///   depends on how sparsely the filtering predicate is satisfied,
 ///   and may not offer the usual performance given by models of
 ///   `Collection`.
+@_fixed_layout
 public struct LazyFilterIndex<Base : Collection> {
+
+  @_inlineable
+  public
+  init(base: Base.Index) {
+    self.base = base
+  }
 
   /// The position corresponding to `self` in the underlying collection.
   public let base: Base.Index
 }
 
 extension LazyFilterIndex : Comparable {
+  @_inlineable
   public static func == (
     lhs: LazyFilterIndex<Base>,
     rhs: LazyFilterIndex<Base>
@@ -121,6 +140,7 @@ extension LazyFilterIndex : Comparable {
     return lhs.base == rhs.base
   }
 
+  @_inlineable
   public static func != (
     lhs: LazyFilterIndex<Base>,
     rhs: LazyFilterIndex<Base>
@@ -128,6 +148,7 @@ extension LazyFilterIndex : Comparable {
     return lhs.base != rhs.base
   }
 
+  @_inlineable
   public static func < (
     lhs: LazyFilterIndex<Base>,
     rhs: LazyFilterIndex<Base>
@@ -135,6 +156,7 @@ extension LazyFilterIndex : Comparable {
     return lhs.base < rhs.base
   }
 
+  @_inlineable
   public static func <= (
     lhs: LazyFilterIndex<Base>,
     rhs: LazyFilterIndex<Base>
@@ -142,6 +164,7 @@ extension LazyFilterIndex : Comparable {
     return lhs.base <= rhs.base
   }
 
+  @_inlineable
   public static func >= (
     lhs: LazyFilterIndex<Base>,
     rhs: LazyFilterIndex<Base>
@@ -149,6 +172,7 @@ extension LazyFilterIndex : Comparable {
     return lhs.base >= rhs.base
   }
 
+  @_inlineable
   public static func > (
     lhs: LazyFilterIndex<Base>,
     rhs: LazyFilterIndex<Base>
@@ -175,6 +199,7 @@ extension LazyFilterIndex : Comparable {
 ///   the usual performance given by `Collection`. Be aware, therefore, that
 ///   general operations on `LazyFilterCollection` instances may not have the
 ///   documented complexity.
+@_fixed_layout
 public struct ${Self}<
   Base : ${collectionForTraversal(Traversal)}
 > : LazyCollectionProtocol, ${collectionForTraversal(Traversal)} {
@@ -189,6 +214,7 @@ public struct ${Self}<
 
   /// Creates an instance containing the elements of `base` that
   /// satisfy `isIncluded`.
+  @_inlineable
   public // @testable
   init(
     _base: Base,
@@ -204,6 +230,7 @@ public struct ${Self}<
   ///
   /// - Complexity: O(*n*), where *n* is the ratio between unfiltered and
   ///   filtered collection counts.
+  @_inlineable
   public var startIndex: Index {
     var index = _base.startIndex
     while index != _base.endIndex && !_predicate(_base[index]) {
@@ -217,17 +244,20 @@ public struct ${Self}<
   ///
   /// `endIndex` is always reachable from `startIndex` by zero or more
   /// applications of `index(after:)`.
+  @_inlineable
   public var endIndex: Index {
     return LazyFilterIndex(base: _base.endIndex)
   }
 
   // TODO: swift-3-indexing-model - add docs
+  @_inlineable
   public func index(after i: Index) -> Index {
     var i = i
     formIndex(after: &i)
     return i
   }
 
+  @_inlineable
   public func formIndex(after i: inout Index) {
     // TODO: swift-3-indexing-model: _failEarlyRangeCheck i?
     var index = i.base
@@ -239,12 +269,14 @@ public struct ${Self}<
   }
 
 %   if Traversal == 'Bidirectional':
+  @_inlineable
   public func index(before i: Index) -> Index {
     var i = i
     formIndex(before: &i)
     return i
   }
 
+  @_inlineable
   public func formIndex(before i: inout Index) {
     // TODO: swift-3-indexing-model: _failEarlyRangeCheck i?
     var index = i.base
@@ -260,10 +292,12 @@ public struct ${Self}<
   ///
   /// - Precondition: `position` is a valid position in `self` and
   /// `position != endIndex`.
+  @_inlineable
   public subscript(position: Index) -> Base.Iterator.Element {
     return _base[position.base]
   }
 
+  @_inlineable
   public subscript(bounds: Range<Index>) -> ${Slice}<${Self}<Base>> {
     return ${Slice}(base: self, bounds: bounds)
   }
@@ -281,12 +315,15 @@ public struct ${Self}<
   /// Returns an iterator over the elements of this sequence.
   ///
   /// - Complexity: O(1).
+  @_inlineable
   public func makeIterator() -> LazyFilterIterator<Base.Iterator> {
     return LazyFilterIterator(
       _base: _base.makeIterator(), _predicate)
   }
 
+  @_versioned
   var _base: Base
+  @_versioned
   let _predicate: (Base.Iterator.Element) -> Bool
 }
 
@@ -299,6 +336,7 @@ extension LazySequenceProtocol {
   ///   the result is used. No buffering storage is allocated and each
   ///   traversal step invokes `predicate` on one or more underlying
   ///   elements.
+  @_inlineable
   public func filter(
     _ isIncluded: @escaping (Elements.Iterator.Element) -> Bool
   ) -> LazyFilterSequence<Self.Elements> {
@@ -322,6 +360,7 @@ extension LazyCollectionProtocol
   ///   the result is used. No buffering storage is allocated and each
   ///   traversal step invokes `predicate` on one or more underlying
   ///   elements.
+  @_inlineable
   public func filter(
     _ isIncluded: @escaping (Elements.Iterator.Element) -> Bool
   ) -> LazyFilter${collectionForTraversal(Traversal)}<Self.Elements> {


### PR DESCRIPTION
This is a followup to #7350 that added lot of resilience-related annotations to stdlib, but missed the LazyFilter*.

cc @swiftix 