### PR TITLE
[Coverage] Audit uses of getCurrentCounter() (SR-4453)

### DIFF
--- a/lib/SILGen/SILGenProfiling.cpp
+++ b/lib/SILGen/SILGenProfiling.cpp
@@ -641,7 +641,7 @@ public:
       assignCounter(E);
     } else if (auto *IE = dyn_cast<IfExpr>(E)) {
       CounterExpr &ThenCounter = assignCounter(IE->getThenExpr());
-      if (Parent.isNull())
+      if (Parent.isNull() || RegionStack.empty())
         assignCounter(IE->getElseExpr());
       else
         assignCounter(IE->getElseExpr(),

--- a/test/SILGen/coverage_toplevel.swift
+++ b/test/SILGen/coverage_toplevel.swift
@@ -14,3 +14,40 @@ var i : Int32 = 0
 while (i < 10) {
   i += 1
 }
+
+// CHECK: sil_coverage_map{{.*}}__tlcd_line:[[@LINE+3]]:1
+// CHECK-NEXT:  [[@LINE+2]]:17 -> [[@LINE+2]]:18 : 1
+// CHECK-NEXT:  [[@LINE+1]]:21 -> [[@LINE+1]]:22 : 0
+var i2 = true ? 1 : 0;
+
+// CHECK: sil_coverage_map{{.*}}__tlcd_line:[[@LINE+4]]:1
+// CHECK-NEXT:  [[@LINE+3]]:11 -> [[@LINE+5]]:2 : 1
+// CHECK-NEXT:  [[@LINE+2]]:1 -> [[@LINE+4]]:2 : 0
+// CHECK-NEXT:  [[@LINE+3]]:2 -> [[@LINE+3]]:2 : 0
+if (true) {
+  i2 = 2
+}
+
+// Crash tests:
+
+if (true) {
+  i2 = 3
+} else {
+  i2 = 4
+}
+
+while (i2 > 0) {
+  if (true) {
+    i2 -= 1
+    continue
+  } else {
+    i2 -= 1
+    break
+  }
+}
+
+switch (1) {
+  case 0: fallthrough
+  case 1: break
+  default: break
+}


### PR DESCRIPTION
We use getCurrentCounter() in one spot where there isn't guaranteed to
be an active region: the `else' part of an IfExpr in a TopLevelCodeDecl.

Fix this issue by assigning a pseudo-counter to the `else' part when the
region stack is empty. This patch also adds crash tests which cover
other code paths which rely on getCurrentCounter() when handling
TopLevelCodeDecls.

Resolves [SR-4453](https://bugs.swift.org/browse/SR-4453).