### PR TITLE
[Coverage] Simplify a check (NFC)

### DIFF
--- a/lib/SILGen/SILGenProfiling.cpp
+++ b/lib/SILGen/SILGenProfiling.cpp
@@ -641,7 +641,7 @@ public:
       assignCounter(E);
     } else if (auto *IE = dyn_cast<IfExpr>(E)) {
       CounterExpr &ThenCounter = assignCounter(IE->getThenExpr());
-      if (Parent.isNull() || RegionStack.empty())
+      if (RegionStack.empty())
         assignCounter(IE->getElseExpr());
       else
         assignCounter(IE->getElseExpr(),


### PR DESCRIPTION
When handling ternary expressions, we check that an active region exists
before attempting to access its counter. It's not necessary to check
that the parent AST node is null, and also that the region stack is
empty. The second check is stronger than the first one.