### PR TITLE
[Conformance checking Minor cleanups

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5306,14 +5306,9 @@ Optional<ProtocolConformanceRef> TypeChecker::conformsToProtocol(
     }
   }
 
-  // When debugging, compute the conformance access path for each requirement.
-  // This acts as an assertion that the path itself makes sense.
-#ifndef NDEBUG
-  bool computeConformanceAccessPath = true;
-#else
-  bool computeConformanceAccessPath = Context.LangOpts.DebugGenericSignatures;
-#endif
-  if (computeConformanceAccessPath &&
+  // When requested, print the conformance access path used to find this
+  // conformance.
+  if (Context.LangOpts.DebugGenericSignatures &&
       InExpression && T->is<ArchetypeType>() && lookupResult->isAbstract() &&
       !T->castTo<ArchetypeType>()->isOpenedExistential() &&
       !T->castTo<ArchetypeType>()->requiresClass() &&
@@ -5327,13 +5322,11 @@ Optional<ProtocolConformanceRef> TypeChecker::conformsToProtocol(
 
       // Debugging aid: display the conformance access path for archetype
       // conformances.
-      if (Context.LangOpts.DebugGenericSignatures) {
-        llvm::errs() << "Conformance access path for ";
-        T.print(llvm::errs());
-        llvm::errs() << ": " << Proto->getName() << " is ";
-        path.print(llvm::errs());
-        llvm::errs() << "\n";
-      }
+      llvm::errs() << "Conformance access path for ";
+      T.print(llvm::errs());
+      llvm::errs() << ": " << Proto->getName() << " is ";
+      path.print(llvm::errs());
+      llvm::errs() << "\n";
     }
   }
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1728,6 +1728,9 @@ namespace {
     /// Whether we've already complained about problems with this conformance.
     bool AlreadyComplained = false;
 
+    /// Whether we checked the requirement signature already.
+    bool CheckedRequirementSignature = false;
+
     /// Retrieve the associated types that are referenced by the given
     /// requirement with a base of 'Self'.
     ArrayRef<AssociatedTypeDecl *> getReferencedAssociatedTypes(ValueDecl *req);
@@ -3990,6 +3993,12 @@ compareDeclsForInference(TypeChecker &TC, DeclContext *DC,
 void ConformanceChecker::resolveTypeWitnesses() {
   llvm::SetVector<AssociatedTypeDecl *> unresolvedAssocTypes;
 
+  SWIFT_DEFER {
+    // Resolution attempts to have the witnesses be correct by construction, but
+    // this isn't guaranteed, so let's double check.
+    ensureRequirementsAreSatisfied();
+  };
+
   // Track when we are checking type witnesses.
   ProtocolConformanceState initialState = Conformance->getState();
   Conformance->setState(ProtocolConformanceState::CheckingTypeWitnesses);
@@ -4398,7 +4407,6 @@ void ConformanceChecker::resolveTypeWitnesses() {
     }
   };
   findSolutions(0);
-
 
   // Go make sure that type declarations that would act as witnesses
   // did not get injected while we were performing checks above. This
@@ -4866,6 +4874,11 @@ void ConformanceChecker::ensureRequirementsAreSatisfied() {
     return;
   }
 
+  if (CheckedRequirementSignature)
+    return;
+
+  CheckedRequirementSignature = true;
+
   auto reqSig = proto->getRequirementSignature();
 
   auto substitutions = SubstitutionMap::getProtocolSubstitutions(
@@ -4921,10 +4934,6 @@ void ConformanceChecker::checkConformance(MissingWitnessDiagnosisKind Kind) {
 
   // Diagnose missing type witnesses for now.
   diagnoseMissingWitnesses(Kind);
-
-  // Resolution attempts to have the witnesses be correct by construction, but
-  // this isn't guaranteed, so let's double check.
-  ensureRequirementsAreSatisfied();
 
   // Ensure the conforming type is used.
   //


### PR DESCRIPTION
Just a few minor cleanups:

* Stop building conformance access paths for everything in +Asserts builds; it's a waste of time, now that the conformance access path code is exercised elsewhere (IRGen) and will soon become even more prevalent
* Move checking of the requirement signature of a protocol a bit earlier, to try to make the ordering of diagnostics more sane