### PR TITLE
[SILGen] Fix crasher getting wrong phi type in shared case block

### DIFF
--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -2292,7 +2292,7 @@ JumpDest PatternMatchEmission::getSharedCaseBlockDest(CaseStmt *caseBlock,
       pattern->forEachVariable([&](VarDecl *V) {
         if (!V->hasName())
           return;
-        block->createPHIArgument(SGF.VarLocs[V].value->getType(),
+        block->createPHIArgument(SGF.getLoweredType(V->getType()),
                                  ValueOwnershipKind::Owned, V);
       });
     }

--- a/test/SILGen/switch.swift
+++ b/test/SILGen/switch.swift
@@ -1098,3 +1098,29 @@ func testOptionalEnumMixWithNil(_ a : Int?) -> Int {
   // CHECK: integer_literal $Builtin.Int2048, 42
   }
 }
+
+// SR-3518
+// CHECK-LABEL: sil hidden @_T06switch43testMultiPatternsWithOuterScopeSameNamedVarySiSg4base_AC6filtertF
+func testMultiPatternsWithOuterScopeSameNamedVar(base: Int?, filter: Int?) {
+  switch(base, filter) {
+    
+  case (.some(let base), .some(let filter)):
+    // CHECK: bb2(%10 : $Int):
+    // CHECK-NEXT: debug_value %10 : $Int, let, name "base"
+    // CHECK-NEXT: debug_value %8 : $Int, let, name "filter"
+    print("both: \(base), \(filter)")
+  case (.some(let base), .none), (.none, .some(let base)):
+    // CHECK: bb3:
+    // CHECK-NEXT: debug_value %8 : $Int, let, name "base"
+    // CHECK-NEXT: br bb6(%8 : $Int)
+
+    // CHECK: bb5([[OTHER_BASE:%.*]] : $Int)
+    // CHECK-NEXT: debug_value [[OTHER_BASE]] : $Int, let, name "base"
+    // CHECK-NEXT: br bb6([[OTHER_BASE]] : $Int)
+    
+    // CHECK: bb6([[ARG:%.*]] : $Int):
+    print("single: \(base)")
+  default:
+    print("default")
+  }
+}


### PR DESCRIPTION
If a shared case block dest got created before it's case's pattern vars were initialized, the block arg could get created with the type from an outer scope. (E.g. in SR-3518 the case block with multiple patterns would expect an incoming `Int?` from the outer `base` instead of an `Int` from the pattern `base`.)

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-3518](https://bugs.swift.org/browse/SR-3518).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->