### PR TITLE
[SEMA][SR4226] Change emitted error for @nonobjc attribute

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1761,7 +1761,7 @@ ERROR(override_ownership_mismatch,none,
       "with %select{strong|weak|unowned|unowned(unsafe)}1 property",
       (/*Ownership*/unsigned, /*Ownership*/unsigned))
 ERROR(override_class_declaration_in_extension,none,
-      "cannot override a non-dynamic class declaration from an extension", 
+      "cannot override a non-dynamic class declaration from an extension",
       ())
 WARNING(override_class_declaration_in_extension_warning,none,
       "cannot override a non-dynamic class declaration from an extension",
@@ -3007,8 +3007,7 @@ ERROR(invalid_objc_decl,none,
 ERROR(invalid_objc_swift_rooted_class,none,
       "only classes that inherit from NSObject can be declared @objc", ())
 ERROR(invalid_nonobjc_decl,none,
-      "only methods, initializers, properties and subscript declarations can "
-      "be declared @nonobjc", ())
+      "only class members and extensions of classes can be declared @nonobjc", ())
 ERROR(invalid_nonobjc_extension,none,
       "only extensions of classes can be declared @nonobjc", ())
 

--- a/test/attr/attr_nonobjc.swift
+++ b/test/attr/attr_nonobjc.swift
@@ -79,7 +79,7 @@ class NSManagedAndNonObjCNotAllowed {
   @nonobjc @NSManaged var rosie : NSObject // expected-error {{declaration is marked @NSManaged, and cannot be marked @nonobjc}}
 }
 
-@nonobjc func nonObjCTopLevelFuncNotAllowed() { } // expected-error {{only methods, initializers, properties and subscript declarations can be declared @nonobjc}} {{1-10=}}
+@nonobjc func nonObjCTopLevelFuncNotAllowed() { } // expected-error {{only class members and extensions of classes can be declared @nonobjc}} {{1-10=}}
 
 @objc class NonObjCPropertyObjCProtocolNotAllowed : ObjCProtocol { // expected-error {{does not conform to protocol}}
   @nonobjc func protocolMethod() { } // expected-note {{candidate is explicitly '@nonobjc'}}
@@ -105,3 +105,9 @@ class NSManagedAndNonObjCNotAllowed {
 
 struct SomeStruct { }
 @nonobjc extension SomeStruct { } // expected-error{{only extensions of classes can be declared @nonobjc}}
+
+protocol SR4226_Protocol : class {}
+
+extension SR4226_Protocol {
+  @nonobjc func function() {} // expected-error {{only class members and extensions of classes can be declared @nonobjc}}
+}


### PR DESCRIPTION
Resolves [SR-4226](https://bugs.swift.org/browse/SR-4226)

The error emitted when the `@nonobjc` attribute is misused was a little bit confusing, I have update it with the similar one used for `@objc`