### PR TITLE
Revert "Index: Expose the logic for deciding whether to index a symbol. NFC. (#8438)"

### DIFF
--- a/include/swift/Index/Index.h
+++ b/include/swift/Index/Index.h
@@ -25,7 +25,7 @@ void indexSourceFile(SourceFile *SF, StringRef hash,
                      IndexDataConsumer &consumer);
 void indexModule(ModuleDecl *module, StringRef hash,
                  IndexDataConsumer &consumer);
-bool shouldIndex(ValueDecl *D, bool IsRef);
+
 } // end namespace index
 } // end namespace swift
 

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -403,6 +403,17 @@ private:
     return SrcMgr.getLineAndColumn(Loc, BufferID);
   }
 
+  bool shouldIndex(ValueDecl *D, bool IsRef) const {
+    if (D->isImplicit())
+      return false;
+    if (isLocalSymbol(D) && (!isa<ParamDecl>(D) || IsRef))
+      return false;
+    if (D->isPrivateStdlibDecl())
+      return false;
+
+    return true;
+  }
+
   void getModuleHash(SourceFileOrModule SFOrMod, llvm::raw_ostream &OS);
   llvm::hash_code hashModule(llvm::hash_code code, SourceFileOrModule SFOrMod);
   llvm::hash_code hashFileReference(llvm::hash_code code,
@@ -1248,14 +1259,4 @@ void index::indexModule(ModuleDecl *module, StringRef hash,
                              /*bufferID*/ -1);
   walker.visitModule(*module, hash);
   consumer.finish();
-}
-
-bool index::shouldIndex(ValueDecl *D, bool IsRef) {
-  if (D->isImplicit())
-    return false;
-  if (isLocalSymbol(D) && (!isa<ParamDecl>(D) || IsRef))
-    return false;
-  if (D->isPrivateStdlibDecl())
-    return false;
-  return true;
 }


### PR DESCRIPTION
We currently don't need this logic elsewhere, thus it's good to give
indexer some privacy.
