### PR TITLE
[swiftc (28 vs. 5511)] Add crasher in swift::TypeChecker::resolveTypeInContext

### DIFF
--- a/validation-test/compiler_crashers/28729-archetype-bad-generic-context-nesting.swift
+++ b/validation-test/compiler_crashers/28729-archetype-bad-generic-context-nesting.swift
@@ -1,0 +1,13 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol P{
+protocol
+P{typealias a{}struct B{extension{protocol P{
+func a:a


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeChecker::resolveTypeInContext`.

Current number of unresolved compiler crashers: 28 (5511 resolved)

/cc @slavapestov - just wanted to let you know that this crasher caused an assertion failure for the assertion `archetype && "Bad generic context nesting?"` added on 2015-12-14 by you in commit 429fd7cc :-)

Assertion failure in [`lib/Sema/TypeCheckGeneric.cpp (line 56)`](https://github.com/apple/swift/blob/22fdc8977ab6f48485ce4a8c180790e93a8575e7/lib/Sema/TypeCheckGeneric.cpp#L56):

```
Assertion `archetype && "Bad generic context nesting?"' failed.

When executing: virtual swift::Type swift::DependentGenericTypeResolver::resolveSelfAssociatedType(swift::Type, swift::AssociatedTypeDecl *)
```

Assertion context:

```c++
}

Type DependentGenericTypeResolver::resolveSelfAssociatedType(
       Type selfTy, AssociatedTypeDecl *assocType) {
  auto archetype = Builder.resolveArchetype(selfTy);
  assert(archetype && "Bad generic context nesting?");

  return archetype
           ->getNestedType(assocType, Builder)
           ->getDependentType(GenericParams, /*allowUnresolved=*/true);
}
```
Stack trace:

```
0 0x0000000003964678 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3964678)
1 0x0000000003964db6 SignalHandler(int) (/path/to/swift/bin/swift+0x3964db6)
2 0x00007fc055a5e390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007fc053f84428 gsignal /build/glibc-9tT8Do/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007fc053f8602a abort /build/glibc-9tT8Do/glibc-2.23/stdlib/abort.c:91:0
5 0x00007fc053f7cbd7 __assert_fail_base /build/glibc-9tT8Do/glibc-2.23/assert/assert.c:92:0
6 0x00007fc053f7cc82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x00000000012d9492 (/path/to/swift/bin/swift+0x12d9492)
8 0x000000000131bd18 swift::TypeChecker::resolveTypeInContext(swift::TypeDecl*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0x131bd18)
9 0x0000000001323838 resolveTypeDecl(swift::TypeChecker&, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x1323838)
10 0x000000000132335f resolveTopLevelIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x132335f)
11 0x000000000131d9fe resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x131d9fe)
12 0x000000000131d423 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x131d423)
13 0x000000000131e537 (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0x131e537)
14 0x000000000131e43c swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x131e43c)
15 0x000000000131cb3a swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x131cb3a)
16 0x00000000012daf32 checkGenericFuncSignature(swift::TypeChecker&, swift::GenericSignatureBuilder*, swift::AbstractFunctionDecl*, swift::GenericTypeResolver&) (/path/to/swift/bin/swift+0x12daf32)
17 0x00000000012daa55 swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0x12daa55)
18 0x00000000012bfeb6 (anonymous namespace)::DeclChecker::visitFuncDecl(swift::FuncDecl*) (/path/to/swift/bin/swift+0x12bfeb6)
19 0x00000000012ad077 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x12ad077)
20 0x00000000012bdaab (anonymous namespace)::DeclChecker::visitProtocolDecl(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0x12bdaab)
21 0x00000000012ad057 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x12ad057)
22 0x00000000012bc34b (anonymous namespace)::DeclChecker::visitExtensionDecl(swift::ExtensionDecl*) (/path/to/swift/bin/swift+0x12bc34b)
23 0x00000000012acf1b (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x12acf1b)
24 0x00000000012bc93b (anonymous namespace)::DeclChecker::visitStructDecl(swift::StructDecl*) (/path/to/swift/bin/swift+0x12bc93b)
25 0x00000000012ad047 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x12ad047)
26 0x00000000012bdaab (anonymous namespace)::DeclChecker::visitProtocolDecl(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0x12bdaab)
27 0x00000000012ad057 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x12ad057)
28 0x00000000012bdaab (anonymous namespace)::DeclChecker::visitProtocolDecl(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0x12bdaab)
29 0x00000000012ad057 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x12ad057)
30 0x00000000012ace53 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x12ace53)
31 0x000000000132af85 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x132af85)
32 0x0000000000f9b146 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf9b146)
33 0x00000000004a8234 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a8234)
34 0x00000000004650b7 main (/path/to/swift/bin/swift+0x4650b7)
35 0x00007fc053f6f830 __libc_start_main /build/glibc-9tT8Do/glibc-2.23/csu/../csu/libc-start.c:325:0
36 0x0000000000462759 _start (/path/to/swift/bin/swift+0x462759)
```