### PR TITLE
[swiftc (29 vs. 5511)] Add crasher in swift::GenericSignature::getCanonicalTypeInContext

### DIFF
--- a/validation-test/compiler_crashers/28730-unreachable-executed-at-swift-lib-ast-astcontext-cpp-1229.swift
+++ b/validation-test/compiler_crashers/28730-unreachable-executed-at-swift-lib-ast-astcontext-cpp-1229.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+class a=protocol P{{}typealias e:P}}extension P{func a{}typealias e:a


### PR DESCRIPTION
Add test case for crash triggered in `swift::GenericSignature::getCanonicalTypeInContext`.

Current number of unresolved compiler crashers: 29 (5511 resolved)

Stack trace:

```
0 0x0000000003968d08 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3968d08)
1 0x0000000003969446 SignalHandler(int) (/path/to/swift/bin/swift+0x3969446)
2 0x00007fe241b44390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007fe24006a428 gsignal /build/glibc-9tT8Do/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007fe24006c02a abort /build/glibc-9tT8Do/glibc-2.23/stdlib/abort.c:91:0
5 0x00000000039050dd llvm::llvm_unreachable_internal(char const*, char const*, unsigned int) (/path/to/swift/bin/swift+0x39050dd)
6 0x00000000013d8832 (/path/to/swift/bin/swift+0x13d8832)
7 0x00000000014a0d75 swift::GenericSignature::getCanonicalTypeInContext(swift::Type, swift::ModuleDecl&) (/path/to/swift/bin/swift+0x14a0d75)
8 0x00000000014f6652 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x14f6652)
9 0x0000000001479099 swift::ValueDecl::getOverloadSignature() const (/path/to/swift/bin/swift+0x1479099)
10 0x00000000012b0206 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x12b0206)
11 0x00000000012bf3bb (anonymous namespace)::DeclChecker::visitExtensionDecl(swift::ExtensionDecl*) (/path/to/swift/bin/swift+0x12bf3bb)
12 0x00000000012af81b (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x12af81b)
13 0x00000000012af753 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x12af753)
14 0x000000000132e6b5 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x132e6b5)
15 0x0000000000f9d636 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf9d636)
16 0x00000000004a8254 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a8254)
17 0x00000000004650b7 main (/path/to/swift/bin/swift+0x4650b7)
18 0x00007fe240055830 __libc_start_main /build/glibc-9tT8Do/glibc-2.23/csu/../csu/libc-start.c:325:0
19 0x0000000000462759 _start (/path/to/swift/bin/swift+0x462759)
```