### PR TITLE
Update capture promotion for semantic sil and move ownership model eliminator after it

### DIFF
--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -174,6 +174,7 @@ public:
   bool use_empty() const { return FirstUse == nullptr; }
 
   using use_iterator = ValueBaseUseIterator;
+  using use_range = iterator_range<use_iterator>;
 
   inline use_iterator use_begin() const;
   inline use_iterator use_end() const;
@@ -181,12 +182,16 @@ public:
   /// Returns a range of all uses, which is useful for iterating over all uses.
   /// To ignore debug-info instructions use swift::getNonDebugUses instead
   /// (see comment in DebugUtils.h).
-  inline iterator_range<use_iterator> getUses() const;
+  inline use_range getUses() const;
 
   /// Returns true if this value has exactly one use.
   /// To ignore debug-info instructions use swift::hasOneNonDebugUse instead
   /// (see comment in DebugUtils.h).
   inline bool hasOneUse() const;
+
+  /// Returns .some(single user) if this value has a single user. Returns .none
+  /// otherwise.
+  inline Operand *getSingleUse() const;
 
   /// Pretty-print the value.
   void dump() const;
@@ -498,6 +503,13 @@ inline bool ValueBase::hasOneUse() const {
   auto I = use_begin(), E = use_end();
   if (I == E) return false;
   return ++I == E;
+}
+inline Operand *ValueBase::getSingleUse() const {
+  auto I = use_begin(), E = use_end();
+  if (I == E) return nullptr;
+  ++I;
+  if (I != E) return nullptr;
+  return *I;
 }
 
 /// A constant-size list of the operands of an instruction.

--- a/lib/SILOptimizer/Analysis/ARCAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/ARCAnalysis.cpp
@@ -948,7 +948,8 @@ bool swift::getFinalReleasesForValue(SILValue V, ReleaseTracker &Tracker) {
     UseBlocks.insert(BB);
 
     // Try to speed up the trivial case of single release/dealloc.
-    if (isa<StrongReleaseInst>(User) || isa<DeallocBoxInst>(User)) {
+    if (isa<StrongReleaseInst>(User) || isa<DeallocBoxInst>(User) ||
+        isa<DestroyValueInst>(User)) {
       if (!seenRelease)
         OneRelease = User;
       else

--- a/lib/SILOptimizer/IPO/CapturePromotion.cpp
+++ b/lib/SILOptimizer/IPO/CapturePromotion.cpp
@@ -211,14 +211,16 @@ private:
 
   void visitDebugValueAddrInst(DebugValueAddrInst *Inst);
   void visitStrongReleaseInst(StrongReleaseInst *Inst);
+  void visitDestroyValueInst(DestroyValueInst *Inst);
   void visitStructElementAddrInst(StructElementAddrInst *Inst);
   void visitLoadInst(LoadInst *Inst);
+  void visitLoadBorrowInst(LoadBorrowInst *Inst);
   void visitProjectBoxInst(ProjectBoxInst *Inst);
 
   SILFunction *Orig;
   IndicesSet &PromotableIndices;
-  llvm::DenseMap<SILArgument*, SILValue> BoxArgumentMap;
-  llvm::DenseMap<ProjectBoxInst*, SILValue> ProjectBoxArgumentMap;
+  llvm::DenseMap<SILArgument *, SILValue> BoxArgumentMap;
+  llvm::DenseMap<ProjectBoxInst *, SILValue> ProjectBoxArgumentMap;
 };
 } // end anonymous namespace
 
@@ -436,36 +438,45 @@ ClosureCloner::populateCloned() {
   // Create arguments for the entry block
   SILBasicBlock *OrigEntryBB = &*Orig->begin();
   SILBasicBlock *ClonedEntryBB = Cloned->createBasicBlock();
+  getBuilder().setInsertionPoint(ClonedEntryBB);
+
   unsigned ArgNo = 0;
   auto I = OrigEntryBB->args_begin(), E = OrigEntryBB->args_end();
-  while (I != E) {
-    if (PromotableIndices.count(ArgNo)) {
-      // Handle the case of a promoted capture argument.
-      auto BoxTy = (*I)->getType().castTo<SILBoxType>();
-      assert(BoxTy->getLayout()->getFields().size() == 1
-             && "promoting compound box not implemented");
-      auto BoxedTy = BoxTy->getFieldType(Cloned->getModule(),0).getObjectType();
-      SILValue MappedValue =
-          ClonedEntryBB->createFunctionArgument(BoxedTy, (*I)->getDecl());
-      BoxArgumentMap.insert(std::make_pair(*I, MappedValue));
-      
-      // Track the projections of the box.
-      for (auto *Use : (*I)->getUses()) {
-        if (auto Proj = dyn_cast<ProjectBoxInst>(Use->getUser())) {
-          ProjectBoxArgumentMap.insert(std::make_pair(Proj, MappedValue));
-        }
-      }
-    } else {
+  for (; I != E; ++ArgNo, ++I) {
+    if (!PromotableIndices.count(ArgNo)) {
       // Otherwise, create a new argument which copies the original argument
       SILValue MappedValue = ClonedEntryBB->createFunctionArgument(
           (*I)->getType(), (*I)->getDecl());
       ValueMap.insert(std::make_pair(*I, MappedValue));
+      continue;
     }
-    ++ArgNo;
-    ++I;
+
+    // Handle the case of a promoted capture argument.
+    auto BoxTy = (*I)->getType().castTo<SILBoxType>();
+    assert(BoxTy->getLayout()->getFields().size() == 1 &&
+           "promoting compound box not implemented");
+    auto BoxedTy = BoxTy->getFieldType(Cloned->getModule(), 0).getObjectType();
+    SILValue MappedValue =
+        ClonedEntryBB->createFunctionArgument(BoxedTy, (*I)->getDecl());
+
+    // If SIL ownership is enabled, we need to perform a borrow here if we have
+    // a non-trivial value. We know that our value is not written to and it does
+    // not escape. The use of a borrow enforces this.
+    if (Cloned->hasQualifiedOwnership() &&
+        MappedValue.getOwnershipKind() != ValueOwnershipKind::Trivial) {
+      SILLocation Loc(const_cast<ValueDecl *>((*I)->getDecl()));
+      MappedValue = getBuilder().createBeginBorrow(Loc, MappedValue);
+    }
+    BoxArgumentMap.insert(std::make_pair(*I, MappedValue));
+
+    // Track the projections of the box.
+    for (auto *Use : (*I)->getUses()) {
+      if (auto Proj = dyn_cast<ProjectBoxInst>(Use->getUser())) {
+        ProjectBoxArgumentMap.insert(std::make_pair(Proj, MappedValue));
+      }
+    }
   }
 
-  getBuilder().setInsertionPoint(ClonedEntryBB);
   BBMap.insert(std::make_pair(OrigEntryBB, ClonedEntryBB));
   // Recursively visit original BBs in depth-first preorder, starting with the
   // entry block, cloning all instructions other than terminators.
@@ -502,6 +513,9 @@ void ClosureCloner::visitDebugValueAddrInst(DebugValueAddrInst *Inst) {
 /// normally.
 void
 ClosureCloner::visitStrongReleaseInst(StrongReleaseInst *Inst) {
+  assert(
+      Inst->getFunction()->hasUnqualifiedOwnership() &&
+      "Should not see strong release in a function with qualified ownership");
   SILValue Operand = Inst->getOperand();
   if (SILArgument *A = dyn_cast<SILArgument>(Operand)) {
     auto I = BoxArgumentMap.find(A);
@@ -519,8 +533,43 @@ ClosureCloner::visitStrongReleaseInst(StrongReleaseInst *Inst) {
   SILCloner<ClosureCloner>::visitStrongReleaseInst(Inst);
 }
 
-/// \brief Handle a struct_element_addr instruction during cloning of a closure;
-/// if its operand is the promoted address argument then ignore it, otherwise it
+/// \brief Handle a destroy_value instruction during cloning of a closure; if
+/// it is a strong release of a promoted box argument, then it is replaced with
+/// a destroy_value of the new object type argument, otherwise it is handled
+/// normally.
+void ClosureCloner::visitDestroyValueInst(DestroyValueInst *Inst) {
+  SILValue Operand = Inst->getOperand();
+  if (SILArgument *A = dyn_cast<SILArgument>(Operand)) {
+    auto I = BoxArgumentMap.find(A);
+    if (I != BoxArgumentMap.end()) {
+      // Releases of the box arguments get replaced with an end_borrow,
+      // destroy_value of the new object type argument.
+      SILFunction &F = getBuilder().getFunction();
+      auto &typeLowering = F.getModule().getTypeLowering(I->second->getType());
+      SILBuilderWithPostProcess<ClosureCloner, 1> B(this, Inst);
+
+      SILValue Value = I->second;
+
+      // If ownership is enabled, then we must emit a begin_borrow for any
+      // non-trivial value.
+      if (F.hasQualifiedOwnership() &&
+          Value.getOwnershipKind() != ValueOwnershipKind::Trivial) {
+        auto *BBI = cast<BeginBorrowInst>(Value);
+        Value = BBI->getOperand();
+        B.createEndBorrow(Inst->getLoc(), BBI, Value);
+      }
+
+      typeLowering.emitDestroyValue(B, Inst->getLoc(), Value);
+      return;
+    }
+  }
+
+  SILCloner<ClosureCloner>::visitDestroyValueInst(Inst);
+}
+
+/// Handle a struct_element_addr instruction during cloning of a closure.
+///
+/// If its operand is the promoted address argument then ignore it, otherwise it
 /// is handled normally.
 void
 ClosureCloner::visitStructElementAddrInst(StructElementAddrInst *Inst) {
@@ -544,37 +593,87 @@ ClosureCloner::visitProjectBoxInst(ProjectBoxInst *I) {
   SILCloner<ClosureCloner>::visitProjectBoxInst(I);
 }
 
-/// \brief Handle a load instruction during cloning of a closure; the two
-/// relevant cases are a direct load from a promoted address argument or a load
-/// of a struct_element_addr of a promoted address argument.
-void
-ClosureCloner::visitLoadInst(LoadInst *Inst) {
-  SILValue Operand = Inst->getOperand();
+/// \brief Handle a load_borrow instruction during cloning of a closure.
+///
+/// The two relevant cases are a direct load from a promoted address argument or
+/// a load of a struct_element_addr of a promoted address argument.
+void ClosureCloner::visitLoadBorrowInst(LoadBorrowInst *LI) {
+  assert(LI->getFunction()->hasQualifiedOwnership() &&
+         "We should only see a load borrow in ownership qualified SIL");
+  SILValue Operand = LI->getOperand();
   if (auto *A = dyn_cast<ProjectBoxInst>(Operand)) {
     auto I = ProjectBoxArgumentMap.find(A);
     if (I != ProjectBoxArgumentMap.end()) {
       // Loads of the address argument get eliminated completely; the uses of
       // the loads get mapped to uses of the new object type argument.
-      ValueMap.insert(std::make_pair(Inst, I->second));
+      //
+      // We assume that the value is already guaranteed.
+      assert(I->second.getOwnershipKind() == ValueOwnershipKind::Guaranteed &&
+             "Expected out argument value to be guaranteed");
+      ValueMap.insert(std::make_pair(LI, I->second));
       return;
-    }
-  } else if (auto *SEAI = dyn_cast<StructElementAddrInst>(Operand)) {
-    if (auto *A = dyn_cast<ProjectBoxInst>(SEAI->getOperand())) {
-      auto I = ProjectBoxArgumentMap.find(A);
-      if (I != ProjectBoxArgumentMap.end()) {
-        // Loads of a struct_element_addr of an argument get replaced with
-        // struct_extract of the new object type argument.
-        SILBuilderWithPostProcess<ClosureCloner, 1> B(this, Inst);
-        SILValue V = B.emitStructExtract(Inst->getLoc(), I->second,
-                                         SEAI->getField(),
-                                         Inst->getType());
-        ValueMap.insert(std::make_pair(Inst, V));
-        return;
-      }
     }
   }
 
-  SILCloner<ClosureCloner>::visitLoadInst(Inst);
+  SILCloner<ClosureCloner>::visitLoadBorrowInst(LI);
+  return;
+}
+
+/// \brief Handle a load instruction during cloning of a closure.
+///
+/// The two relevant cases are a direct load from a promoted address argument or
+/// a load of a struct_element_addr of a promoted address argument.
+void ClosureCloner::visitLoadInst(LoadInst *LI) {
+  SILValue Operand = LI->getOperand();
+  if (auto *A = dyn_cast<ProjectBoxInst>(Operand)) {
+    auto I = ProjectBoxArgumentMap.find(A);
+    if (I != ProjectBoxArgumentMap.end()) {
+      // Loads of the address argument get eliminated completely; the uses of
+      // the loads get mapped to uses of the new object type argument.
+      //
+      // If we are compiling with SIL ownership, we need to take different
+      // behaviors depending on the type of load. Specifically, if we have a
+      // load [copy], then we need to add a copy_value here. If we have a take
+      // or trivial, we just propagate the value through.
+      SILValue Value = I->second;
+      if (A->getFunction()->hasQualifiedOwnership() &&
+          LI->getOwnershipQualifier() == LoadOwnershipQualifier::Copy) {
+        Value = getBuilder().createCopyValue(LI->getLoc(), Value);
+      }
+      ValueMap.insert(std::make_pair(LI, Value));
+      return;
+    }
+    SILCloner<ClosureCloner>::visitLoadInst(LI);
+    return;
+  }
+
+  auto *SEAI = dyn_cast<StructElementAddrInst>(Operand);
+  if (!SEAI) {
+    SILCloner<ClosureCloner>::visitLoadInst(LI);
+    return;
+  }
+
+  auto *PBI = dyn_cast<ProjectBoxInst>(SEAI->getOperand());
+  if (!PBI) {
+    SILCloner<ClosureCloner>::visitLoadInst(LI);
+    return;
+  }
+
+  auto I = ProjectBoxArgumentMap.find(PBI);
+  if (I == ProjectBoxArgumentMap.end()) {
+    SILCloner<ClosureCloner>::visitLoadInst(LI);
+    return;
+  }
+
+  // Loads of a struct_element_addr of an argument get replaced with a
+  // struct_extract of the new passed in value. The value should be borrowed
+  // already.
+  SILBuilderWithPostProcess<ClosureCloner, 1> B(this, LI);
+  assert(B.getFunction().hasUnqualifiedOwnership() ||
+         I->second.getOwnershipKind() == ValueOwnershipKind::Guaranteed);
+  SILValue V = B.emitStructExtract(LI->getLoc(), I->second, SEAI->getField(),
+                                   LI->getType());
+  ValueMap.insert(std::make_pair(LI, V));
 }
 
 static SILArgument *getBoxFromIndex(SILFunction *F, unsigned Index) {
@@ -595,7 +694,8 @@ isNonMutatingCapture(SILArgument *BoxArg) {
   // strong_release or projection, since this is the pattern expected from
   // SILGen.
   for (auto *O : BoxArg->getUses()) {
-    if (isa<StrongReleaseInst>(O->getUser()))
+    if (isa<StrongReleaseInst>(O->getUser()) ||
+        isa<DestroyValueInst>(O->getUser()))
       continue;
     
     if (auto Projection = dyn_cast<ProjectBoxInst>(O->getUser())) {
@@ -620,10 +720,11 @@ isNonMutatingCapture(SILArgument *BoxArg) {
             return false;
         continue;
       }
-      if (!isa<LoadInst>(O->getUser())
-          && !isa<DebugValueAddrInst>(O->getUser())
-          && !isa<MarkFunctionEscapeInst>(O->getUser()))
+      if (!isa<LoadInst>(O->getUser()) &&
+          !isa<DebugValueAddrInst>(O->getUser()) &&
+          !isa<MarkFunctionEscapeInst>(O->getUser())) {
         return false;
+      }
     }
   }
 
@@ -675,7 +776,7 @@ public:
   ///
   /// These are considered to be escapes.
   bool visitValueBase(ValueBase *V) {
-    DEBUG(llvm::dbgs() << "    Have unknown escaping user: " << *V);
+    DEBUG(llvm::dbgs() << "    FAIL! Have unknown escaping user: " << *V);
     return false;
   }
 
@@ -687,6 +788,7 @@ public:
   ALWAYS_NON_ESCAPING_INST(StrongRetain)
   ALWAYS_NON_ESCAPING_INST(Load)
   ALWAYS_NON_ESCAPING_INST(StrongRelease)
+  ALWAYS_NON_ESCAPING_INST(DestroyValue)
 #undef ALWAYS_NON_ESCAPING_INST
 
   bool visitDeallocBoxInst(DeallocBoxInst *DBI) {
@@ -699,6 +801,7 @@ public:
     SILFunctionConventions substConv(AI->getSubstCalleeType(), AI->getModule());
     auto convention = substConv.getSILArgumentConvention(argIndex);
     if (!convention.isIndirectConvention()) {
+      DEBUG(llvm::dbgs() << "    FAIL! Found non indirect apply user: " << *AI);
       return false;
     }
     Mutations.push_back(AI);
@@ -729,7 +832,16 @@ public:
     addUserOperandsToWorklist(I);                 \
     return true;                                  \
   }
-  RECURSIVE_INST_VISITOR(IsNotMutating, CopyValue)
+  // *NOTE* It is important that we do not have copy_value here. The reason why
+  // is that we only want to handle copy_value directly of the alloc_box without
+  // going through any other instructions. This protects our optimization later
+  // on.
+  //
+  // Additionally, copy_value is not a valid use of any of the instructions that
+  // we allow through.
+  //
+  // TODO: Can we ever hit copy_values here? If we do, we may be missing
+  // opportunities.
   RECURSIVE_INST_VISITOR(IsNotMutating, StructElementAddr)
   RECURSIVE_INST_VISITOR(IsNotMutating, TupleElementAddr)
   RECURSIVE_INST_VISITOR(IsNotMutating, InitEnumDataAddr)
@@ -744,18 +856,38 @@ public:
   }
 
   bool visitStoreInst(StoreInst *SI) {
-    if (CurrentOp.get()->getOperandNumber() != 1)
+    if (CurrentOp.get()->getOperandNumber() != 1) {
+      DEBUG(llvm::dbgs() << "    FAIL! Found store of pointer: " << *SI);
       return false;
+    }
     Mutations.push_back(SI);
     return true;
   }
 
   bool visitAssignInst(AssignInst *AI) {
-    if (CurrentOp.get()->getOperandNumber() != 1)
+    if (CurrentOp.get()->getOperandNumber() != 1) {
+      DEBUG(llvm::dbgs() << "    FAIL! Found store of pointer: " << *AI);
       return false;
+    }
     Mutations.push_back(AI);
     return true;
   }
+};
+
+} // end anonymous namespace
+
+namespace {
+
+struct EscapeMutationScanningState {
+  /// The list of mutations that we found while checking for escapes.
+  llvm::SmallVector<SILInstruction *, 8> Mutations;
+
+  /// A flag that we use to ensure that we only ever see 1 project_box on an
+  /// alloc_box.
+  bool SawProjectBoxInst;
+
+  /// The global partial_apply -> index map.
+  llvm::DenseMap<PartialApplyInst *, unsigned> &IM;
 };
 
 } // end anonymous namespace
@@ -765,14 +897,12 @@ public:
 /// instruction which possibly mutates the contents of the box, then add it to
 /// the Mutations vector.
 static bool isNonEscapingUse(Operand *InitialOp,
-                             SmallVectorImpl<SILInstruction *> &Mutations) {
-  return NonEscapingUserVisitor(InitialOp, Mutations).compute();
+                             EscapeMutationScanningState &State) {
+  return NonEscapingUserVisitor(InitialOp, State.Mutations).compute();
 }
 
-bool isPartialApplyNonEscapingUser(
-    Operand *CurrentOp, PartialApplyInst *PAI,
-    llvm::SmallVectorImpl<SILInstruction *> &Mutations,
-    llvm::DenseMap<PartialApplyInst *, unsigned> &IM) {
+bool isPartialApplyNonEscapingUser(Operand *CurrentOp, PartialApplyInst *PAI,
+                                   EscapeMutationScanningState &State) {
   DEBUG(llvm::dbgs() << "    Found partial: " << *PAI);
 
   unsigned OpNo = CurrentOp->getOperandNumber();
@@ -781,8 +911,8 @@ bool isPartialApplyNonEscapingUser(
   // If we've already seen this partial apply, then it means the same alloc
   // box is being captured twice by the same closure, which is odd and
   // unexpected: bail instead of trying to handle this case.
-  if (IM.count(PAI)) {
-    DEBUG(llvm::dbgs() << "        Already seen... bailing!\n");
+  if (State.IM.count(PAI)) {
+    DEBUG(llvm::dbgs() << "        FAIL! Already seen.\n");
     return false;
   }
 
@@ -797,8 +927,8 @@ bool isPartialApplyNonEscapingUser(
 
   auto *Fn = PAI->getReferencedFunction();
   if (!Fn || !Fn->isDefinition()) {
-    DEBUG(llvm::dbgs() << "        Not a direct function definition "
-                          "reference. Bailing!\n");
+    DEBUG(llvm::dbgs() << "        FAIL! Not a direct function definition "
+                          "reference.\n");
     return false;
   }
 
@@ -811,8 +941,7 @@ bool isPartialApplyNonEscapingUser(
   assert(BoxTy->getLayout()->getFields().size() == 1 &&
          "promoting compound box not implemented yet");
   if (BoxTy->getFieldType(M, 0).isAddressOnly(M)) {
-    DEBUG(llvm::dbgs()
-          << "        Box is an address only argument... Bailing!\n");
+    DEBUG(llvm::dbgs() << "        FAIL! Box is an address only argument!\n");
     return false;
   }
 
@@ -820,20 +949,20 @@ bool isPartialApplyNonEscapingUser(
   // it does, then conservatively refuse to promote any captures of this
   // value.
   if (!isNonMutatingCapture(BoxArg)) {
-    DEBUG(llvm::dbgs() << "        Is a mutating capture... Bailing!\n");
+    DEBUG(llvm::dbgs() << "        FAIL: Have a mutating capture!\n");
     return false;
   }
 
   // Record the index and continue.
-  DEBUG(llvm::dbgs() << "        Can be optimized!\n");
+  DEBUG(llvm::dbgs()
+        << "        Partial apply does not escape, may be optimizable!\n");
   DEBUG(llvm::dbgs() << "        Index: " << Index << "\n");
-  IM.insert(std::make_pair(PAI, Index));
+  State.IM.insert(std::make_pair(PAI, Index));
   return true;
 }
 
-static bool
-isProjectBoxNonEscapingUse(ProjectBoxInst *PBI,
-                           llvm::SmallVectorImpl<SILInstruction *> &Mutations) {
+static bool isProjectBoxNonEscapingUse(ProjectBoxInst *PBI,
+                                       EscapeMutationScanningState &State) {
   DEBUG(llvm::dbgs() << "    Found project box: " << *PBI);
 
   // Check for mutations of the address component.
@@ -848,8 +977,8 @@ isProjectBoxNonEscapingUse(ProjectBoxInst *PBI,
   }
 
   for (Operand *AddrOp : Addr->getUses()) {
-    if (!isNonEscapingUse(AddrOp, Mutations)) {
-      DEBUG(llvm::dbgs() << "    Has escaping user of addr... bailing: "
+    if (!isNonEscapingUse(AddrOp, State)) {
+      DEBUG(llvm::dbgs() << "    FAIL! Has escaping user of addr:"
                          << *AddrOp->getUser());
       return false;
     }
@@ -858,20 +987,42 @@ isProjectBoxNonEscapingUse(ProjectBoxInst *PBI,
   return true;
 }
 
-static bool scanUsesForEscapesAndMutations(
-    Operand *Op, llvm::SmallVectorImpl<SILInstruction *> &Mutations,
-    llvm::DenseMap<PartialApplyInst *, unsigned> &IM) {
+static bool scanUsesForEscapesAndMutations(Operand *Op,
+                                           EscapeMutationScanningState &State) {
   if (auto *PAI = dyn_cast<PartialApplyInst>(Op->getUser())) {
-    return isPartialApplyNonEscapingUser(Op, PAI, Mutations, IM);
+    return isPartialApplyNonEscapingUser(Op, PAI, State);
   }
 
   if (auto *PBI = dyn_cast<ProjectBoxInst>(Op->getUser())) {
-    return isProjectBoxNonEscapingUse(PBI, Mutations);
+    // It is assumed in later code that we will only have 1 project_box. This
+    // can be seen since there is no code for reasoning about multiple
+    // boxes. Just put in the restriction so we are consistent.
+    if (State.SawProjectBoxInst)
+      return false;
+    State.SawProjectBoxInst = true;
+    return isProjectBoxNonEscapingUse(PBI, State);
+  }
+
+  // Given a top level copy value use, check all of its user operands as if
+  // they were apart of the use list of the base operand.
+  //
+  // This is because even though we are copying the box, a copy of the box is
+  // just a retain + bitwise copy of the pointer. This has nothing to do with
+  // whether or not the address escapes in some way.
+  //
+  // This is a separate code path from the non escaping user visitor check since
+  // we want to be more conservative around non-top level copies (i.e. a copy
+  // derived from a projection like instruction). In fact such a thing may not
+  // even make any sense!
+  if (auto *CVI = dyn_cast<CopyValueInst>(Op->getUser())) {
+    return all_of(CVI->getUses(), [&State](Operand *CopyOp) -> bool {
+      return scanUsesForEscapesAndMutations(CopyOp, State);
+    });
   }
 
   // Verify that this use does not otherwise allow the alloc_box to
   // escape.
-  return isNonEscapingUse(Op, Mutations);
+  return isNonEscapingUse(Op, State);
 }
 
 /// \brief Examine an alloc_box instruction, returning true if at least one
@@ -882,14 +1033,18 @@ static bool
 examineAllocBoxInst(AllocBoxInst *ABI, ReachabilityInfo &RI,
                     llvm::DenseMap<PartialApplyInst *, unsigned> &IM) {
   DEBUG(llvm::dbgs() << "Visiting alloc box: " << *ABI);
-  SmallVector<SILInstruction *, 32> Mutations;
+  EscapeMutationScanningState State{{}, false, IM};
 
   // Scan the box for interesting uses.
-  if (any_of(ABI->getUses(), [&Mutations, &IM](Operand *Op) {
-        return !scanUsesForEscapesAndMutations(Op, Mutations, IM);
+  if (any_of(ABI->getUses(), [&State](Operand *Op) {
+        return !scanUsesForEscapesAndMutations(Op, State);
       })) {
+    DEBUG(llvm::dbgs()
+          << "Found an escaping use! Can not optimize this alloc box?!\n");
     return false;
   }
+
+  DEBUG(llvm::dbgs() << "We can optimize this alloc box!\n");
 
   // Helper lambda function to determine if instruction b is strictly after
   // instruction a, assuming both are in the same basic block.
@@ -908,7 +1063,7 @@ examineAllocBoxInst(AllocBoxInst *ABI, ReachabilityInfo &RI,
   DEBUG(llvm::dbgs()
         << "Checking for any mutations that invalidate captures...\n");
   // Loop over all mutations to possibly invalidate captures.
-  for (auto *I : Mutations) {
+  for (auto *I : State.Mutations) {
     auto Iter = IM.begin();
     while (Iter != IM.end()) {
       auto *PAI = Iter->first;
@@ -962,6 +1117,66 @@ constructClonedFunction(PartialApplyInst *PAI, FunctionRefInst *FRI,
   return cloner.getCloned();
 }
 
+/// For an alloc_box or iterated copy_value alloc_box, get or create the
+/// project_box for the copy or original alloc_box.
+///
+/// There are two possible case here:
+///
+/// 1. It could be an alloc box.
+/// 2. It could be an iterated copy_value from an alloc_box.
+///
+/// Some important constraints from our initial safety condition checks:
+///
+/// 1. We only see a project_box paired with an alloc_box. e.x.:
+///
+///       (project_box (alloc_box)).
+///
+/// 2. We only see a mark_uninitialized when paired with an (alloc_box,
+///    project_box). e.x.:
+///
+///       (mark_uninitialized (project_box (alloc_box)))
+///
+/// The asserts are to make sure that if the initial safety condition check
+/// is changed, this code is changed as well.
+static SILValue getOrCreateProjectBoxHelper(SILValue PartialOperand) {
+  // If we have a copy_value, just create a project_box on the copy and return.
+  if (auto *CVI = dyn_cast<CopyValueInst>(PartialOperand)) {
+    SILBuilder B(std::next(CVI->getIterator()));
+    return B.createProjectBox(CVI->getLoc(), CVI, 0);
+  }
+
+  // Otherwise, handle the alloc_box case.
+  auto *ABI = cast<AllocBoxInst>(PartialOperand);
+  // Load and copy from the address value, passing the result as an argument
+  // to the new closure.
+  //
+  // *NOTE* This code assumes that we only have one project box user. We
+  // enforce this with the assert below.
+  assert(count_if(ABI->getUses(), [](Operand *Op) -> bool {
+           return isa<ProjectBoxInst>(Op->getUser());
+         }) == 1);
+
+  // If the address is marked uninitialized, load through the mark, so
+  // that DI can reason about it.
+  for (Operand *BoxValueUse : ABI->getUses()) {
+    auto *PBI = dyn_cast<ProjectBoxInst>(BoxValueUse->getUser());
+    if (!PBI)
+      continue;
+
+    auto *OptIter = PBI->getSingleUse();
+    if (!OptIter)
+      continue;
+
+    if (!isa<MarkUninitializedInst>(OptIter->getUser()))
+      continue;
+
+    return OptIter->getUser();
+  }
+
+  // Otherwise, just return a project_box.
+  return getOrCreateProjectBox(ABI, 0);
+}
+
 /// \brief Given a partial_apply instruction and a set of promotable indices,
 /// clone the closure with the promoted captures and replace the partial_apply
 /// with a partial_apply of the new closure, fixing up reference counting as
@@ -998,46 +1213,33 @@ processPartialApplyInst(PartialApplyInst *PAI, IndicesSet &PromotableIndices,
   unsigned OpNo = 1, OpCount = PAI->getNumOperands();
   SmallVector<SILValue, 16> Args;
   auto NumIndirectResults = calleeConv.getNumIndirectSILResults();
-  while (OpNo != OpCount) {
+  for (; OpNo != OpCount; ++OpNo) {
     unsigned Index = OpNo - 1 + FirstIndex;
-    if (PromotableIndices.count(Index)) {
-      SILValue BoxValue = PAI->getOperand(OpNo);
-      AllocBoxInst *ABI = cast<AllocBoxInst>(BoxValue);
-
-      SILParameterInfo CPInfo = CalleePInfo[Index - NumIndirectResults];
-      assert(calleeConv.getSILType(CPInfo) == BoxValue->getType()
-             && "SILType of parameter info does not match type of parameter");
-      // Load and copy from the address value, passing the result as an argument
-      // to the new closure.
-      SILValue Addr;
-      for (Operand *BoxUse : ABI->getUses()) {
-        auto *PBI = dyn_cast<ProjectBoxInst>(BoxUse->getUser());
-          // If the address is marked uninitialized, load through the mark, so
-          // that DI can reason about it.
-        if (PBI && PBI->hasOneUse()) {
-          SILInstruction *PBIUser = PBI->use_begin()->getUser();
-          if (isa<MarkUninitializedInst>(PBIUser))
-            Addr = PBIUser;
-          break;
-        }
-      }
-      // We only reuse an existing project_box if it directly follows the
-      // alloc_box. This makes sure that the project_box dominates the
-      // partial_apply.
-      if (!Addr)
-        Addr = getOrCreateProjectBox(ABI, 0);
-
-      auto &typeLowering = M.getTypeLowering(Addr->getType());
-      Args.push_back(
-        typeLowering.emitLoadOfCopy(B, PAI->getLoc(), Addr, IsNotTake));
-      // Cleanup the captured argument.
-      releasePartialApplyCapturedArg(B, PAI->getLoc(), BoxValue,
-                                     CPInfo);
-      ++NumCapturesPromoted;
-    } else {
+    if (!PromotableIndices.count(Index)) {
       Args.push_back(PAI->getOperand(OpNo));
+      continue;
     }
-    ++OpNo;
+
+    // First the grab the box and projected_box for the box value.
+    //
+    // *NOTE* Box may be a copy_value.
+    SILValue Box = PAI->getOperand(OpNo);
+    SILValue Addr = getOrCreateProjectBoxHelper(Box);
+
+    auto &typeLowering = M.getTypeLowering(Addr->getType());
+    Args.push_back(
+        typeLowering.emitLoadOfCopy(B, PAI->getLoc(), Addr, IsNotTake));
+
+    // Cleanup the captured argument.
+    //
+    // *NOTE* If we initially had a box, then this is on the actual
+    // alloc_box. Otherwise, it is on the specific iterated copy_value that we
+    // started with.
+    SILParameterInfo CPInfo = CalleePInfo[Index - NumIndirectResults];
+    assert(calleeConv.getSILType(CPInfo) == Box->getType() &&
+           "SILType of parameter info does not match type of parameter");
+    releasePartialApplyCapturedArg(B, PAI->getLoc(), Box, CPInfo);
+    ++NumCapturesPromoted;
   }
 
   auto SubstFnTy = FnTy.substGenericArgs(M, PAI->getSubstitutions());
@@ -1076,27 +1278,32 @@ constructMapFromPartialApplyToPromotableIndices(SILFunction *F,
           for (auto &IndexPair : IndexMap)
             Map[IndexPair.first].insert(IndexPair.second);
         }
+        DEBUG(llvm::dbgs() << "\n");
       }
     }
   }
 }
 
 namespace {
+
 class CapturePromotionPass : public SILModuleTransform {
   /// The entry point to the transformation.
   void run() override {
     SmallVector<SILFunction*, 128> Worklist;
-    for (auto &F : *getModule())
+    for (auto &F : *getModule()) {
       processFunction(&F, Worklist);
+    }
 
-    while (!Worklist.empty())
+    while (!Worklist.empty()) {
       processFunction(Worklist.pop_back_val(), Worklist);
+    }
   }
 
   void processFunction(SILFunction *F, SmallVectorImpl<SILFunction*> &Worklist);
 
   StringRef getName() override { return "Capture Promotion"; }
 };
+
 } // end anonymous namespace
 
 void CapturePromotionPass::processFunction(SILFunction *F,

--- a/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
+++ b/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
@@ -18,6 +18,7 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/SaveAndRestore.h"
 #include "llvm/ADT/StringExtras.h"
+
 using namespace swift;
 
 //===----------------------------------------------------------------------===//

--- a/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
+++ b/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
@@ -100,7 +100,10 @@ static unsigned computeSubelement(SILValue Pointer, SILInstruction *RootInst) {
     auto *Inst = cast<SILInstruction>(Pointer);
     if (auto *PBI = dyn_cast<ProjectBoxInst>(Inst)) {
       Pointer = PBI->getOperand();
-    } else if (auto *TEAI = dyn_cast<TupleElementAddrInst>(Inst)) {
+      continue;
+    }
+
+    if (auto *TEAI = dyn_cast<TupleElementAddrInst>(Inst)) {
       SILType TT = TEAI->getOperand()->getType();
       
       // Keep track of what subelement is being referenced.
@@ -108,7 +111,10 @@ static unsigned computeSubelement(SILValue Pointer, SILInstruction *RootInst) {
         SubEltNumber += getNumSubElements(TT.getTupleElementType(i), M);
       }
       Pointer = TEAI->getOperand();
-    } else if (auto *SEAI = dyn_cast<StructElementAddrInst>(Inst)) {
+      continue;
+    }
+
+    if (auto *SEAI = dyn_cast<StructElementAddrInst>(Inst)) {
       SILType ST = SEAI->getOperand()->getType();
       
       // Keep track of what subelement is being referenced.
@@ -119,12 +125,14 @@ static unsigned computeSubelement(SILValue Pointer, SILInstruction *RootInst) {
       }
       
       Pointer = SEAI->getOperand();
-    } else {
-      assert((isa<InitExistentialAddrInst>(Inst) || isa<InjectEnumAddrInst>(Inst))&&
-             "Unknown access path instruction");
-      // Cannot promote loads and stores from within an existential projection.
-      return ~0U;
+      continue;
     }
+
+    
+    assert((isa<InitExistentialAddrInst>(Inst) || isa<InjectEnumAddrInst>(Inst))&&
+           "Unknown access path instruction");
+    // Cannot promote loads and stores from within an existential projection.
+    return ~0U;
   }
 }
 

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -74,6 +74,8 @@ static void addOwnershipModelEliminatorPipeline(SILPassPipelinePlan &P) {
 static void addMandatoryOptPipeline(SILPassPipelinePlan &P) {
   P.startPipeline("Guaranteed Passes");
   P.addCapturePromotion();
+  P.addOwnershipModelEliminator();
+
   P.addAllocBoxToStack();
   P.addNoReturnFolding();
   P.addDefiniteInitialization();
@@ -103,9 +105,6 @@ SILPassPipelinePlan::getDiagnosticPassPipeline(const SILOptions &Options) {
     addMandatoryDebugSerialization(P);
     return P;
   }
-
-  // Lower all ownership instructions right after SILGen for now.
-  addOwnershipModelEliminatorPipeline(P);
 
   // Otherwise run the rest of diagnostics.
   addMandatoryOptPipeline(P);

--- a/test/SILOptimizer/capture_promotion_generic_context_ownership.sil
+++ b/test/SILOptimizer/capture_promotion_generic_context_ownership.sil
@@ -1,0 +1,127 @@
+// RUN: %target-swift-frontend -enable-sil-ownership -emit-sil -O %s | %FileCheck %s
+
+sil_stage raw
+
+import Builtin
+
+typealias Int = Builtin.Int32
+
+// rdar://problem/28945854: When a nongeneric closure was formed inside a
+// generic function, the capture promotion pass would erroneously try to
+// apply the generic caller's substitutions to the nongeneric callee, violating
+// invariants.
+
+// CHECK-LABEL: sil @_T014promotable_boxTf2i_n : $@convention(thin) (Builtin.Int32) -> Builtin.Int32
+sil @promotable_box : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Int>) -> Int {
+entry(%b : @owned $<τ_0_0> { var τ_0_0 } <Int>):
+  %a = project_box %b : $<τ_0_0> { var τ_0_0 } <Int>, 0
+  %v = load [trivial] %a : $*Int
+  destroy_value %b : $<τ_0_0> { var τ_0_0 } <Int>
+  return %v : $Int
+}
+
+// CHECK-LABEL: sil @call_promotable_box_from_generic
+// CHECK:         [[F:%.*]] = function_ref @_T014promotable_boxTf2i_n
+// CHECK:         partial_apply [[F]](
+
+sil @call_promotable_box_from_generic : $@convention(thin) <T> (@in T, Int) -> @owned @callee_owned () -> Int {
+entry(%0 : @trivial $*T, %1 : @trivial $Int):
+  destroy_addr %0 : $*T
+  %f = function_ref @promotable_box : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Int>) -> Int
+  %b = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
+  %a = project_box %b : $<τ_0_0> { var τ_0_0 } <Int>, 0
+  store %1 to [trivial] %a : $*Int
+  %k = partial_apply %f(%b) : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Int>) -> Int
+  return %k : $@callee_owned () -> Int
+}
+
+protocol P {}
+
+// CHECK-LABEL: sil @_T022generic_promotable_boxTf2ni_n : $@convention(thin) <T> (@in T, Builtin.Int32) -> Builtin.Int32
+// CHECK:       bb0([[ARG0:%.*]] : @trivial $*T, [[ARG1:%.*]] : @trivial $Builtin.Int32):
+// CHECK-NEXT:    return [[ARG1]] : $Builtin.Int32
+
+sil @generic_promotable_box : $@convention(thin) <T> (@in T, @owned <τ_0_0> { var τ_0_0 } <Int>) -> Int {
+entry(%0 : @trivial $*T, %b : @owned $<τ_0_0> { var τ_0_0 } <Int>):
+  %a = project_box %b : $<τ_0_0> { var τ_0_0 } <Int>, 0
+  %v = load [trivial] %a : $*Int
+  destroy_value %b : $<τ_0_0> { var τ_0_0 } <Int>
+  return %v : $Int
+}
+
+// CHECK-LABEL: sil @call_generic_promotable_box_from_different_generic
+// CHECK:       bb0([[ARG0:%.*]] : @trivial $*T, [[ARG1:%.*]] : @trivial $*U, [[ARG2:%.*]] : @trivial $Builtin.Int32):
+// CHECK-NEXT:    destroy_addr [[ARG0]] : $*T
+// CHECK-NEXT:    destroy_addr [[ARG1]] : $*U
+// CHECK:         [[F:%.*]] = function_ref @_T022generic_promotable_boxTf2ni_n : $@convention(thin) <τ_0_0> (@in τ_0_0, Builtin.Int32) -> Builtin.Int32
+// CHECK-NEXT:    [[CLOSURE:%.*]] = partial_apply [[F]]<U>([[ARG2]])
+// CHECK-NEXT:    return [[CLOSURE]]
+
+sil @call_generic_promotable_box_from_different_generic : $@convention(thin) <T, U: P> (@in T, @in U, Int) -> @owned @callee_owned (@in U) -> Int {
+entry(%0 : @trivial $*T, %1 : @trivial $*U, %2 : @trivial $Int):
+  destroy_addr %0 : $*T
+  destroy_addr %1 : $*U
+  %f = function_ref @generic_promotable_box : $@convention(thin) <V> (@in V, @owned <τ_0_0> { var τ_0_0 } <Int>) -> Int
+  %b = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
+  %a = project_box %b : $<τ_0_0> { var τ_0_0 } <Int>, 0
+  store %2 to [trivial] %a : $*Int
+  %k = partial_apply %f<U>(%b) : $@convention(thin) <V> (@in V, @owned <τ_0_0> { var τ_0_0 } <Int>) -> Int
+  return %k : $@callee_owned (@in U) -> Int
+}
+
+enum E<X> {
+  case None
+  case Some(X)
+}
+
+struct R<T> {
+}
+
+// Check that the capture promotion took place and the function now
+// take argument of a type  E<(R<T>) -> Builtin.Int32>, which used
+// to be a slot inside a box.
+// CHECK-LABEL: sil @_T023generic_promotable_box2Tf2nni_n : $@convention(thin) <T> (@in R<T>, @in Builtin.Int32, @owned E<(R<T>) -> Builtin.Int32>) -> () 
+// CHECK:       bb0([[ARG0:%.*]] : @trivial $*R<T>, [[ARG1:%.*]] : @trivial $*Builtin.Int32, [[ARG2:%.*]] : @owned $E<(R<T>) -> Builtin.Int32>):
+// CHECK-NOT:     project_box
+// CHECK:         switch_enum [[ARG2]] : $E<(R<T>) -> Builtin.Int32>
+// CHECK-NOT:     project_box
+// CHECK:       } // end sil function '_T023generic_promotable_box2Tf2nni_n'
+sil @generic_promotable_box2 : $@convention(thin) <T> (@in R<T>, @in Int, @owned <τ_0_0> { var E<(R<τ_0_0>) -> Int> } <T>) -> () {
+entry(%0 : @trivial $*R<T>, %1 : @trivial $*Int, %b : @owned $<τ_0_0> { var E<(R<τ_0_0>)->Int> } <T>):
+  %a = project_box %b : $<τ_0_0> { var E<(R<τ_0_0>)->Int> } <T>, 0
+  %e = load [copy] %a : $*E<(R<T>)->Int>
+  switch_enum %e : $E<(R<T>)->Int>, case #E.Some!enumelt.1 : bb1, default bb2
+
+bb1(%f : @owned $@callee_owned (@in R<T>) -> @out Int):
+  apply %f(%1, %0) : $@callee_owned (@in R<T>) -> @out Int
+  br exit
+
+bb2(%original : @owned $E<(R<T>)->Int>):
+  destroy_value %original : $E<(R<T>)->Int>
+  br exit
+
+exit:
+  destroy_value %b : $<τ_0_0> { var E<(R<τ_0_0>)->Int> } <T>
+  %r = tuple ()
+  return %r : $()
+}
+
+// Check that alloc_box was eliminated and a specialized version of the
+// closure is invoked.
+// CHECK-LABEL: sil @call_generic_promotable_box_from_different_generic2
+// CHECK:       bb0([[ARG0:%.*]] : @trivial $*R<T>, [[ARG1:%.*]] : @trivial $*E<(R<U>) -> Builtin.Int32>, [[ARG2:%.*]] : @trivial $*Builtin.Int32):
+// CHECK:         %3 = load [[ARG1]] : $*E<(R<U>) -> Builtin.Int32>
+// CHECK:         [[F:%.*]] = function_ref @_T023generic_promotable_box2Tf2nni_n : $@convention(thin) <τ_0_0> (@in R<τ_0_0>, @in Builtin.Int32, @owned E<(R<τ_0_0>) -> Builtin.Int32>) -> ()
+// CHECK-NEXT:    [[CLOSURE:%.*]] = partial_apply [[F]]<U>(%2, %3)
+// CHECK-NEXT:    return [[CLOSURE]]
+
+sil @call_generic_promotable_box_from_different_generic2 : $@convention(thin) <T, U: P> (@in R<T>, @in E<(R<U>)->Int>, @in Int) -> @owned @callee_owned (@in R<U>) -> () {
+entry(%0 : @trivial $*R<T>, %1 : @trivial $*E<(R<U>)->Int>, %2 : @trivial $*Int):
+  destroy_addr %0 : $*R<T>
+  %f = function_ref @generic_promotable_box2 : $@convention(thin) <V> (@in R<V>, @in Int, @owned <τ_0_0> { var E<(R<τ_0_0>)->Int> } <V>) -> ()
+  %b = alloc_box $<τ_0_0> { var E<(R<τ_0_0>)->Int> } <U>
+  %a = project_box %b : $<τ_0_0> { var E<(R<τ_0_0>)->Int> } <U>, 0
+  copy_addr [take] %1 to [initialization] %a : $*E<(R<U>)->Int>
+  %k = partial_apply %f<U>(%2, %b) : $@convention(thin) <V> (@in R<V>, @in Int, @owned <τ_0_0> { var E<(R<τ_0_0>)->Int> } <V>) -> ()
+  return %k : $@callee_owned (@in R<U>) -> ()
+}

--- a/test/SILOptimizer/capture_promotion_ownership.sil
+++ b/test/SILOptimizer/capture_promotion_ownership.sil
@@ -1,0 +1,328 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s -capture-promotion -enable-sil-ownership | %FileCheck %s
+
+// Check to make sure that the process of promoting closure captures results in
+// a correctly cloned and modified closure function body. This test
+// intentionally only includes one promotable closure so that there is minimal
+// ordering dependence in the checked output.
+
+sil_stage raw
+
+import Builtin
+
+struct Int {
+  var value : Builtin.Int64
+}
+
+class Foo {
+  func foo() -> Int
+}
+
+class Bar {
+}
+
+struct Baz {
+  var bar: Bar
+  var x: Int
+}
+
+sil @convert_from_integer_literal : $@convention(thin) (Builtin.Word, @thin Int.Type) -> Int
+sil @foo_allocating_init : $@convention(thin) (@thick Foo.Type) -> @owned Foo
+sil @baz_init : $@convention(thin) (@thin Baz.Type) -> @owned Baz
+sil @dummy_func : $@convention(thin) (Int, Int, Int) -> Int
+
+// CHECK-LABEL: sil @test_capture_promotion
+sil @test_capture_promotion : $@convention(thin) () -> @owned @callee_owned () -> Int {
+bb0:
+  // CHECK: [[BOX1:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <Foo>
+  %1 = alloc_box $<τ_0_0> { var τ_0_0 } <Foo>
+  %1a = project_box %1 : $<τ_0_0> { var τ_0_0 } <Foo>, 0
+  %2 = function_ref @foo_allocating_init : $@convention(thin) (@thick Foo.Type) -> @owned Foo
+  %3 = metatype $@thick Foo.Type
+  %4 = apply %2(%3) : $@convention(thin) (@thick Foo.Type) -> @owned Foo
+  store %4 to [init] %1a : $*Foo
+
+  // CHECK: [[BOX2:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <Baz>
+  %6 = alloc_box $<τ_0_0> { var τ_0_0 } <Baz>
+  %6a = project_box %6 : $<τ_0_0> { var τ_0_0 } <Baz>, 0
+  %7 = function_ref @baz_init : $@convention(thin) (@thin Baz.Type) -> @owned Baz
+  %8 = metatype $@thin Baz.Type
+  %9 = apply %7(%8) : $@convention(thin) (@thin Baz.Type) -> @owned Baz
+  store %9 to [init] %6a : $*Baz
+
+  // CHECK: [[BOX3:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
+  %11 = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
+  %11a = project_box %11 : $<τ_0_0> { var τ_0_0 } <Int>, 0
+  %12 = function_ref @convert_from_integer_literal : $@convention(thin) (Builtin.Word, @thin Int.Type) -> Int
+  %13 = metatype $@thin Int.Type
+  %14 = integer_literal $Builtin.Word, 3
+  %15 = apply %12(%14, %13) : $@convention(thin) (Builtin.Word, @thin Int.Type) -> Int
+  store %15 to [trivial] %11a : $*Int
+
+// CHECK: [[BOX1_COPY:%.*]] = copy_value [[BOX1]]
+// CHECK: [[BOX1_COPY_PB:%.*]] = project_box [[BOX1_COPY]]
+// CHECK: [[BOX2_COPY:%.*]] = copy_value [[BOX2]]
+// CHECK: [[BOX2_COPY_PB:%.*]] = project_box [[BOX2_COPY]]
+// CHECK: [[BOX3_COPY:%.*]] = copy_value [[BOX3]]
+// CHECK: [[BOX3_COPY_PB:%.*]] = project_box [[BOX3_COPY]]
+
+// CHECK-NOT: function_ref @closure0 :
+// CHECK: [[CLOSURE_PROMOTE:%.*]] = function_ref @_T08closure0Tf2iii_n
+// CHECK-NOT: function_ref @closure0 :
+
+// The Foo variable is loaded from and retained, because it is a reference type
+// CHECK-NEXT: [[LOADFOO:%.*]] = load [copy] [[BOX1_COPY_PB]] : $*Foo
+// CHECK-NEXT: destroy_value [[BOX1_COPY]]
+//
+// The Baz variable is loaded and copied, because it is a non-trivial
+// aggregate type
+// CHECK-NEXT: [[LOADBAZ:%.*]] = load [copy] [[BOX2_COPY_PB]] : $*Baz
+// CHECK-NEXT: destroy_value [[BOX2_COPY]]
+
+// The Int variable is loaded only, because it is trivial
+// CHECK-NEXT: [[LOADINT:%.*]] = load [trivial] [[BOX3_COPY_PB]] : $*Int
+// CHECK-NEXT: destroy_value [[BOX3_COPY]]
+
+// The partial apply has one value argument for each pair of arguments that was
+// previously used to capture and pass the variable by reference
+// CHECK-NEXT: {{.*}} = partial_apply [[CLOSURE_PROMOTE]]([[LOADFOO]], [[LOADBAZ]], [[LOADINT]])
+
+  %17 = function_ref @closure0 : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Foo>, @owned <τ_0_0> { var τ_0_0 } <Baz>, @owned <τ_0_0> { var τ_0_0 } <Int>) -> Int
+  %18 = copy_value %1 : $<τ_0_0> { var τ_0_0 } <Foo>
+  %19 = copy_value %6 : $<τ_0_0> { var τ_0_0 } <Baz>
+  %20 = copy_value %11 : $<τ_0_0> { var τ_0_0 } <Int>
+  %21 = partial_apply %17(%18, %19, %20) : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Foo>, @owned <τ_0_0> { var τ_0_0 } <Baz>, @owned <τ_0_0> { var τ_0_0 } <Int>) -> Int
+
+  destroy_value %11 : $<τ_0_0> { var τ_0_0 } <Int>
+  destroy_value %6 : $<τ_0_0> { var τ_0_0 } <Baz>
+  destroy_value %1 : $<τ_0_0> { var τ_0_0 } <Foo>
+
+  return %21 : $@callee_owned () -> Int
+}
+
+// CHECK-LABEL: sil @test_capture_promotion_indirect
+sil @test_capture_promotion_indirect : $@convention(thin) () -> @owned @callee_owned () -> @out Int {
+bb0:
+  // CHECK: [[BOX1:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <Foo>
+  %1 = alloc_box $<τ_0_0> { var τ_0_0 } <Foo>
+  %1a = project_box %1 : $<τ_0_0> { var τ_0_0 } <Foo>, 0
+  %2 = function_ref @foo_allocating_init : $@convention(thin) (@thick Foo.Type) -> @owned Foo
+  %3 = metatype $@thick Foo.Type
+  %4 = apply %2(%3) : $@convention(thin) (@thick Foo.Type) -> @owned Foo
+  store %4 to [init] %1a : $*Foo
+
+  // CHECK: [[BOX2:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <Baz>
+  %6 = alloc_box $<τ_0_0> { var τ_0_0 } <Baz>
+  %6a = project_box %6 : $<τ_0_0> { var τ_0_0 } <Baz>, 0
+  %7 = function_ref @baz_init : $@convention(thin) (@thin Baz.Type) -> @owned Baz
+  %8 = metatype $@thin Baz.Type
+  %9 = apply %7(%8) : $@convention(thin) (@thin Baz.Type) -> @owned Baz
+  store %9 to [init] %6a : $*Baz
+
+  // CHECK: [[BOX3:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
+  %11 = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
+  %11a = project_box %11 : $<τ_0_0> { var τ_0_0 } <Int>, 0
+  %12 = function_ref @convert_from_integer_literal : $@convention(thin) (Builtin.Word, @thin Int.Type) -> Int
+  %13 = metatype $@thin Int.Type
+  %14 = integer_literal $Builtin.Word, 3
+  %15 = apply %12(%14, %13) : $@convention(thin) (Builtin.Word, @thin Int.Type) -> Int
+  store %15 to [trivial] %11a : $*Int
+
+  // CHECK: [[BOX1_COPY:%.*]] = copy_value [[BOX1]]
+  // CHECK: [[BOX1_COPY_PB:%.*]] = project_box [[BOX1_COPY]]
+  // CHECK: [[BOX2_COPY:%.*]] = copy_value [[BOX2]]
+  // CHECK: [[BOX2_COPY_PB:%.*]] = project_box [[BOX2_COPY]]
+  // CHECK: [[BOX3_COPY:%.*]] = copy_value [[BOX3]]
+  // CHECK: [[BOX3_COPY_PB:%.*]] = project_box [[BOX3_COPY]]
+
+  // CHECK-NOT: function_ref @closure_indirect_result :
+  // CHECK: [[CLOSURE_PROMOTE:%.*]] = function_ref @_T023closure_indirect_resultTf2niii_n
+  // CHECK-NOT: function_ref @closure_indirect_result :
+  %17 = function_ref @closure_indirect_result : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Foo>, @owned <τ_0_0> { var τ_0_0 } <Baz>, @owned <τ_0_0> { var τ_0_0 } <Int>) -> @out Int
+
+  // CHECK-NEXT: [[LOADFOO:%.*]] = load [copy] [[BOX1_COPY_PB]] : $*Foo
+  // CHECK-NEXT: destroy_value [[BOX1_COPY]]
+  // CHECK-NEXT: [[LOADBAZ:%.*]] = load [copy] [[BOX2_COPY_PB]] : $*Baz
+  // CHECK-NEXT: destroy_value [[BOX2_COPY]]
+  // CHECK-NEXT: [[LOADINT:%.*]] = load [trivial] [[BOX3_COPY_PB]] : $*Int
+  // CHECK-NEXT: destroy_value [[BOX3_COPY]]
+  %18 = copy_value %1 : $<τ_0_0> { var τ_0_0 } <Foo>
+  %19 = copy_value %6 : $<τ_0_0> { var τ_0_0 } <Baz>
+  %20 = copy_value %11 : $<τ_0_0> { var τ_0_0 } <Int>
+
+  // The partial apply has one value argument for each pair of arguments that was
+  // previously used to capture and pass the variable by reference
+  // CHECK-NEXT: {{.*}} = partial_apply [[CLOSURE_PROMOTE]]([[LOADFOO]], [[LOADBAZ]], [[LOADINT]])
+  %21 = partial_apply %17(%18, %19, %20) : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Foo>, @owned <τ_0_0> { var τ_0_0 } <Baz>, @owned <τ_0_0> { var τ_0_0 } <Int>) -> @out Int
+
+  destroy_value %11 : $<τ_0_0> { var τ_0_0 } <Int>
+  destroy_value %6 : $<τ_0_0> { var τ_0_0 } <Baz>
+  destroy_value %1 : $<τ_0_0> { var τ_0_0 } <Foo>
+
+  return %21 : $@callee_owned () -> @out Int
+}
+
+// CHECK-LABEL: sil private @_T08closure0Tf2iii_n : $@convention(thin) (@owned Foo, @owned Baz, Int) -> Int {
+// CHECK: bb0([[ORIGINAL_ARG0:%.*]] : @owned $Foo, [[ORIGINAL_ARG1:%.*]] : @owned $Baz, [[ARG2:%.*]] : @trivial $Int):
+// CHECK:   [[ARG0:%.*]] = begin_borrow [[ORIGINAL_ARG0]]
+// CHECK:   [[ARG1:%.*]] = begin_borrow [[ORIGINAL_ARG1]]
+// CHECK:   [[DUMMY_FUNC:%.*]] = function_ref @dummy_func : $@convention(thin) (Int, Int, Int) -> Int
+
+// CHECK:   [[ARG0_COPY:%.*]] = copy_value [[ARG0]]
+// CHECK:   [[METHOD_FOO:%.*]] = class_method [[ARG0_COPY]] : $Foo, #Foo.foo!1 : (Foo) -> () -> Int, $@convention(method) (@guaranteed Foo) -> Int
+// CHECK:   [[BORROWED_ARG0_COPY:%.*]] = begin_borrow [[ARG0_COPY]]
+// CHECK:   [[APPLY_FOO:%.*]] = apply [[METHOD_FOO]]([[BORROWED_ARG0_COPY]]) : $@convention(method) (@guaranteed Foo) -> Int
+// CHECK:   end_borrow [[BORROWED_ARG0_COPY]] from [[ARG0_COPY]]
+// CHECK:   destroy_value [[ARG0_COPY]]
+
+// CHECK: [[EXTRACT_BAZ_X:%.*]] = struct_extract [[ARG1]] : $Baz, #Baz.x
+// CHECK: [[RETVAL:%.*]] = apply [[DUMMY_FUNC]]([[APPLY_FOO]], [[EXTRACT_BAZ_X]], {{.*}}) : $@convention(thin) (Int, Int, Int) -> Int
+
+// The release of %4 is removed because the Int type is trivial
+
+// The release of %2 is replaced by a release_value of the Baz argument, since
+// it is a non-trivial aggregate
+// CHECK: end_borrow [[ARG1]] from [[ORIGINAL_ARG1]]
+// CHECK: destroy_value [[ORIGINAL_ARG1]] : $Baz
+
+// The release of %0 is replaced by a strong_release of the Foo argument, since
+// it is a reference type
+// CHECK: end_borrow [[ARG0]] from [[ORIGINAL_ARG0]]
+// CHECK: destroy_value [[ORIGINAL_ARG0]]
+// CHECK: return [[RETVAL]] : $Int
+// CHECK: } // end sil function '_T08closure0Tf2iii_n'
+
+sil private @closure0 : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Foo>, @owned <τ_0_0> { var τ_0_0 } <Baz>, @owned <τ_0_0> { var τ_0_0 } <Int>) -> Int {
+bb0(%0 : @owned $<τ_0_0> { var τ_0_0 } <Foo>, %2 : @owned $<τ_0_0> { var τ_0_0 } <Baz>, %4 : @owned $<τ_0_0> { var τ_0_0 } <Int>):
+  %1 = project_box %0 : $<τ_0_0> { var τ_0_0 } <Foo>, 0
+  %3 = project_box %2 : $<τ_0_0> { var τ_0_0 } <Baz>, 0
+  %5 = project_box %4 : $<τ_0_0> { var τ_0_0 } <Int>, 0
+  %6 = tuple ()
+  // function_ref test14.plus (a : Swift.Int, b : Swift.Int, c : Swift.Int) -> Swift.Int
+  %7 = function_ref @dummy_func : $@convention(thin) (Int, Int, Int) -> Int
+  %8 = load [copy] %1 : $*Foo
+  %10 = class_method %8 : $Foo, #Foo.foo!1 : (Foo) -> () -> Int, $@convention(method) (@guaranteed Foo) -> Int
+  %9 = begin_borrow %8 : $Foo
+  %11 = apply %10(%9) : $@convention(method) (@guaranteed Foo) -> Int
+  end_borrow %9 from %8 : $Foo, $Foo
+  destroy_value %8 : $Foo
+  %12 = struct_element_addr %3 : $*Baz, #Baz.x
+  %13 = load [trivial] %12 : $*Int
+  %14 = load [trivial] %5 : $*Int
+  %15 = apply %7(%11, %13, %14) : $@convention(thin) (Int, Int, Int) -> Int
+  destroy_value %4 : $<τ_0_0> { var τ_0_0 } <Int>
+  destroy_value %2 : $<τ_0_0> { var τ_0_0 } <Baz>
+  destroy_value %0 : $<τ_0_0> { var τ_0_0 } <Foo>
+  return %15 : $Int
+}
+
+// The closure in this function is not promotable because it mutates its argument
+
+// CHECK-LABEL: sil @test_unpromotable
+sil @test_unpromotable : $@convention(thin) () -> @owned @callee_owned () -> Int {
+bb0:
+  %0 = tuple ()
+  %1 = alloc_box $<τ_0_0> { var τ_0_0 } <Foo>
+  %1a = project_box %1 : $<τ_0_0> { var τ_0_0 } <Foo>, 0
+  %2 = function_ref @foo_allocating_init : $@convention(thin) (@thick Foo.Type) -> @owned Foo
+  %3 = metatype $@thick Foo.Type
+  %4 = apply %2(%3) : $@convention(thin) (@thick Foo.Type) -> @owned Foo
+  store %4 to [init] %1a : $*Foo
+  %17 = function_ref @closure1 : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Foo>) -> Int
+  %18 = copy_value %1 : $<τ_0_0> { var τ_0_0 } <Foo>
+  // CHECK: partial_apply {{%.*}}({{%.*}})
+  %21 = partial_apply %17(%18) : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Foo>) -> Int
+  destroy_value %1 : $<τ_0_0> { var τ_0_0 } <Foo>
+  return %21 : $@callee_owned () -> Int
+}
+
+sil @mutate_foo : $@convention(thin) (@inout Foo) -> ()
+
+sil private @closure1 : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Foo>) -> Int {
+bb0(%0 : @owned $<τ_0_0> { var τ_0_0 } <Foo>):
+  %1 = project_box %0 : $<τ_0_0> { var τ_0_0 } <Foo>, 0
+  %6 = tuple ()
+  // function_ref test14.plus (a : Swift.Int, b : Swift.Int, c : Swift.Int) -> Swift.Int
+  %7 = function_ref @dummy_func : $@convention(thin) (Int, Int, Int) -> Int
+  %8 = load [copy] %1 : $*Foo
+  %10 = class_method %8 : $Foo, #Foo.foo!1 : (Foo) -> () -> Int, $@convention(method) (@guaranteed Foo) -> Int
+  %9 = begin_borrow %8 : $Foo
+  %11 = apply %10(%9) : $@convention(method) (@guaranteed Foo) -> Int
+  end_borrow %9 from %8 : $Foo, $Foo
+  destroy_value %8 : $Foo
+  %12 = function_ref @mutate_foo : $@convention(thin) (@inout Foo) -> ()
+  %13 = apply %12(%1) : $@convention(thin) (@inout Foo) -> ()
+  destroy_value %0 : $<τ_0_0> { var τ_0_0 } <Foo>
+  return %11 : $Int
+}
+
+sil @apply : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+
+// CHECK-LABEL: sil @captureWithinGeneric
+sil @captureWithinGeneric : $@convention(thin) <T> (@inout Int, @inout Int) -> () {
+// CHECK: bb0
+bb0(%0 : @trivial $*Int, %1 : @trivial $*Int):
+  %2 = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
+  %2a = project_box %2 : $<τ_0_0> { var τ_0_0 } <Int>, 0
+  copy_addr %0 to [initialization] %2a : $*Int
+  %4 = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
+  %4a = project_box %4 : $<τ_0_0> { var τ_0_0 } <Int>, 0
+  copy_addr %1 to [initialization] %4a : $*Int
+  %6 = function_ref @apply : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  // CHECK: [[PROMOTED:%[0-9a-zA-Z]+]] = function_ref @_T027closureWithGenericSignatureTf2ni_n : $@convention(thin) <τ_0_0> (@owned <τ_0_0> { var τ_0_0 } <Int>, Int) -> ()
+  %7 = function_ref @closureWithGenericSignature : $@convention(thin) <τ_0_0> (@owned <τ_0_0> { var τ_0_0 } <Int>, @owned <τ_0_0> { var τ_0_0 } <Int>) -> ()
+  %8 = copy_value %4 : $<τ_0_0> { var τ_0_0 } <Int>
+  %9 = copy_value %2 : $<τ_0_0> { var τ_0_0 } <Int>
+  // CHECK: partial_apply [[PROMOTED]]<{{[^>]+}}>(
+  %10 = partial_apply %7<T>(%8, %9) : $@convention(thin) <τ_0_0> (@owned <τ_0_0> { var τ_0_0 } <Int>, @owned <τ_0_0> { var τ_0_0 } <Int>) -> ()
+  %11 = apply %6(%10) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  copy_addr %4a to %1 : $*Int
+  destroy_value %4 : $<τ_0_0> { var τ_0_0 } <Int>
+  copy_addr %2a to %0 : $*Int
+  destroy_value %2 : $<τ_0_0> { var τ_0_0 } <Int>
+  %16 = tuple ()
+  return %16 : $()
+}
+
+// CHECK: sil @_T027closureWithGenericSignatureTf2ni_n : $@convention(thin) <{{[^>]+}}> (@owned <τ_0_0> { var τ_0_0 } <Int>, Int) -> ()
+sil @closureWithGenericSignature : $@convention(thin) <T> (@owned <τ_0_0> { var τ_0_0 } <Int>, @owned <τ_0_0> { var τ_0_0 } <Int>) -> () {
+bb0(%0 : @owned $<τ_0_0> { var τ_0_0 } <Int>, %2 : @owned $<τ_0_0> { var τ_0_0 } <Int>):
+  %1 = project_box %0 : $<τ_0_0> { var τ_0_0 } <Int>, 0
+  %3 = project_box %2 : $<τ_0_0> { var τ_0_0 } <Int>, 0
+  %4 = function_ref @_T0s1poiSiSi_SitF : $@convention(thin) (Int, Int) -> Int
+  %5 = load [trivial] %3 : $*Int
+  %6 = load [trivial] %3 : $*Int
+  %7 = apply %4(%5, %6) : $@convention(thin) (Int, Int) -> Int
+  assign %7 to %1 : $*Int
+  destroy_value %2 : $<τ_0_0> { var τ_0_0 } <Int>
+  destroy_value %0 : $<τ_0_0> { var τ_0_0 } <Int>
+  %11 = tuple ()
+  return %11 : $()
+}
+
+sil [transparent] [serialized] @_T0s1poiSiSi_SitF : $@convention(thin) (Int, Int) -> Int
+
+
+sil private @closure_indirect_result : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Foo>, @owned <τ_0_0> { var τ_0_0 } <Baz>, @owned <τ_0_0> { var τ_0_0 } <Int>) -> @out Int {
+bb0(%0: @trivial $*Int, %1 : @owned $<τ_0_0> { var τ_0_0 } <Foo>, %2 : @owned $<τ_0_0> { var τ_0_0 } <Baz>, %4 : @owned $<τ_0_0> { var τ_0_0 } <Int>):
+  %17 = project_box %1 : $<τ_0_0> { var τ_0_0 } <Foo>, 0
+  %3 = project_box %2 : $<τ_0_0> { var τ_0_0 } <Baz>, 0
+  %5 = project_box %4 : $<τ_0_0> { var τ_0_0 } <Int>, 0
+  // function_ref test14.plus (a : Swift.Int, b : Swift.Int, c : Swift.Int) -> Swift.Int
+  %7 = function_ref @dummy_func : $@convention(thin) (Int, Int, Int) -> Int
+  %8 = load [copy] %17 : $*Foo
+  %10 = class_method %8 : $Foo, #Foo.foo!1 : (Foo) -> () -> Int, $@convention(method) (@guaranteed Foo) -> Int
+  %9 = begin_borrow %8 : $Foo
+  %11 = apply %10(%9) : $@convention(method) (@guaranteed Foo) -> Int
+  end_borrow %9 from %8 : $Foo, $Foo
+  destroy_value %8 : $Foo
+  %12 = struct_element_addr %3 : $*Baz, #Baz.x
+  %13 = load [trivial] %12 : $*Int
+  %14 = load [trivial] %5 : $*Int
+  %15 = apply %7(%11, %13, %14) : $@convention(thin) (Int, Int, Int) -> Int
+  destroy_value %4 : $<τ_0_0> { var τ_0_0 } <Int>
+  destroy_value %2 : $<τ_0_0> { var τ_0_0 } <Baz>
+  destroy_value %1 : $<τ_0_0> { var τ_0_0 } <Foo>
+  store %15 to [trivial] %0 : $*Int
+  %16 = tuple()
+  return %16 : $()
+}

--- a/test/SILOptimizer/capture_promotion_ownership.swift
+++ b/test/SILOptimizer/capture_promotion_ownership.swift
@@ -1,0 +1,37 @@
+// RUN: %target-swift-frontend %s -enable-sil-ownership -disable-sil-linking -emit-sil -o - -verify | %FileCheck %s
+
+// NOTE: We add -disable-sil-linking to the compile line to ensure that we have
+// access to declarations for standard library types, but not definitions. This
+// ensures that we are able to safely use standard library types for this test
+// without needing the standard library to be ownership correct in its body.
+
+class Foo {
+  func foo() -> Int {
+    return 1
+  }
+}
+
+class Bar {
+}
+
+struct Baz {
+  var bar = Bar()
+  var x = 42
+}
+
+// CHECK: sil hidden @_T027capture_promotion_ownership05test_a1_B0SiycyF
+func test_capture_promotion() -> () -> Int {
+  var x : Int = 1; x = 1
+  var y : Foo = Foo(); y = Foo()
+  var z : Baz = Baz(); z = Baz()
+
+// CHECK-NOT: alloc_box
+
+// CHECK: [[CLOSURE0_PROMOTE0:%.*]] = function_ref @_T027capture_promotion_ownership05test_a1_B0SiycyFSiycfU_Tf2iii_n
+// CHECK: partial_apply [[CLOSURE0_PROMOTE0]]({{%[0-9]*}}, {{%[0-9]*}}, {{%[0-9]*}})
+
+  return { x + y.foo() + z.x }
+}
+
+// CHECK: sil private @_T027capture_promotion_ownership05test_a1_B0SiycyFSiycfU_Tf2iii_n : $@convention(thin) (Int, @owned Foo, @owned Baz) -> Int
+


### PR DESCRIPTION
This is the first in a series of PRs that updates the Mandatory passes for semantic sil.

In this PR, I update capture-promotion and move the ownership model eliminator after it.

rdar://29870610