### PR TITLE
Add -DSWIFT_RUNTIME_ENABLE_COW_EXISTENTIALS=1 when compiling the front end

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -265,6 +265,10 @@ function(_add_variant_c_compile_flags)
         "-I${SWIFT_ANDROID_NDK_PATH}/sources/android/support/include")
   endif()
 
+  if(SWIFT_RUNTIME_ENABLE_COW_EXISTENTIALS)
+    list(APPEND result "-DSWIFT_RUNTIME_ENABLE_COW_EXISTENTIALS=1")
+  endif()
+
   set("${CFLAGS_RESULT_VAR_NAME}" "${result}" PARENT_SCOPE)
 endfunction()
 


### PR DESCRIPTION
This should fix building a --debug-build

A debug build fails tests because the SWIFT_RUNTIME_ENABLE_COW_EXISTENTIALS macro is not enabled when building frontend files. For some reason that only affects DEBUG builds.

./utils/build-script --release-debuginfo --debug-swift