### PR TITLE
[sil-function-signature-opt] Support FSO for generic functions

### DIFF
--- a/include/swift/SILOptimizer/Analysis/ARCAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/ARCAnalysis.h
@@ -196,6 +196,7 @@ private:
   SILFunction *F;
   RCIdentityFunctionInfo *RCFI;
   ExitKind Kind;
+  ArrayRef<SILArgumentConvention> ArgumentConventions;
   llvm::SmallMapVector<SILArgument *, ReleaseList, 8> ArgInstMap;
 
   /// Set to true if we found some releases but not all for the argument.
@@ -221,6 +222,10 @@ private:
   /// arguments. 
   void collectMatchingReleases(SILBasicBlock *BB);
 
+  /// Walk the function and find all the destroy_addr instructions that match
+  /// to function arguments. 
+  void collectMatchingDestroyAddresses(SILBasicBlock *BB);
+
   /// For every argument in the function, check to see whether all epilogue
   /// releases are found. Clear all releases for the argument if not all 
   /// epilogue releases are found.
@@ -228,9 +233,12 @@ private:
 
 public:
   /// Finds matching releases in the return block of the function \p F.
-  ConsumedArgToEpilogueReleaseMatcher(RCIdentityFunctionInfo *RCFI,
-                                      SILFunction *F,
-                                      ExitKind Kind = ExitKind::Return);
+  ConsumedArgToEpilogueReleaseMatcher(
+      RCIdentityFunctionInfo *RCFI,
+      SILFunction *F,
+      ArrayRef<SILArgumentConvention> ArgumentConventions =
+          {SILArgumentConvention::Direct_Owned},
+      ExitKind Kind = ExitKind::Return);
 
   /// Finds matching releases in the provided block \p BB.
   void findMatchingReleases(SILBasicBlock *BB);

--- a/include/swift/SILOptimizer/Utils/FunctionSignatureOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/FunctionSignatureOptUtils.h
@@ -36,7 +36,7 @@ struct ArgumentDescriptor {
   SILFunctionArgument *Arg;
 
   /// Parameter Info.
-  SILParameterInfo PInfo;
+  Optional<SILParameterInfo> PInfo;
 
   /// The original index of this argument.
   unsigned Index;
@@ -78,11 +78,17 @@ struct ArgumentDescriptor {
   /// have access to the original argument's state if we modify the argument
   /// when optimizing.
   ArgumentDescriptor(SILFunctionArgument *A)
-      : Arg(A), PInfo(A->getKnownParameterInfo()), Index(A->getIndex()),
+      : Arg(A),
+        PInfo(A->getKnownParameterInfo()),
+        Index(A->getIndex()),
         Decl(A->getDecl()), IsEntirelyDead(false), Explode(false),
         OwnedToGuaranteed(false), IsIndirectResult(A->isIndirectResult()),
         CalleeRelease(), CalleeReleaseInThrowBlock(),
-        ProjTree(A->getModule(), A->getType()) {}
+        ProjTree(A->getModule(), A->getType()) {
+        if(!A->isIndirectResult()) {
+           PInfo = Arg->getKnownParameterInfo();
+        }
+  }
 
   ArgumentDescriptor(const ArgumentDescriptor &) = delete;
   ArgumentDescriptor(ArgumentDescriptor &&) = default;
@@ -95,7 +101,15 @@ struct ArgumentDescriptor {
   }
 
   bool canOptimizeLiveArg() const {
-    return Arg->getType().isObject();
+    if (Arg->getType().isObject())
+      return true;
+    // @in arguments of generic types can be processed.
+    if (Arg->getType().getSwiftRValueType()->hasArchetype() &&
+        Arg->getType().isAddress() &&
+        (Arg->hasConvention(SILArgumentConvention::Indirect_In) ||
+         Arg->hasConvention(SILArgumentConvention::Indirect_In_Guaranteed)))
+      return true;
+    return false;
   }
 
   /// Return true if it's both legal and a good idea to explode this argument.

--- a/lib/SILOptimizer/Analysis/ARCAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/ARCAnalysis.cpp
@@ -664,10 +664,13 @@ findMatchingRetains(SILBasicBlock *BB) {
 //                          Owned Argument Utilities
 //===----------------------------------------------------------------------===//
 
-ConsumedArgToEpilogueReleaseMatcher::
-ConsumedArgToEpilogueReleaseMatcher(RCIdentityFunctionInfo *RCFI,
-                                    SILFunction *F, ExitKind Kind)
-   : F(F), RCFI(RCFI), Kind(Kind), ProcessedBlock(nullptr) {
+ConsumedArgToEpilogueReleaseMatcher::ConsumedArgToEpilogueReleaseMatcher(
+    RCIdentityFunctionInfo *RCFI,
+    SILFunction *F,
+    ArrayRef<SILArgumentConvention> ArgumentConventions,
+    ExitKind Kind)
+    : F(F), RCFI(RCFI), Kind(Kind), ArgumentConventions(ArgumentConventions),
+      ProcessedBlock(nullptr) {
   recompute();
 }
 
@@ -770,6 +773,52 @@ processMatchingReleases() {
   }
 }
 
+/// Check if a given argument convention is in the list
+/// of possible argument conventions.
+static bool
+isOneOfConventions(SILArgumentConvention Convention,
+                   ArrayRef<SILArgumentConvention> ArgumentConventions) {
+  for (auto ArgumentConvention : ArgumentConventions) {
+    if (Convention == ArgumentConvention)
+      return true;
+  }
+  return false;
+}
+
+void
+ConsumedArgToEpilogueReleaseMatcher::
+collectMatchingDestroyAddresses(SILBasicBlock *BB) {
+  // Check if we can find destory_addr for each @in argument.
+  SILFunction::iterator AnotherEpilogueBB =
+      (Kind == ExitKind::Return) ? F->findThrowBB() : F->findReturnBB();
+  for (auto Arg : F->begin()->getFunctionArguments()) {
+    if (Arg->isIndirectResult())
+      continue;
+    if (Arg->getArgumentConvention() != SILArgumentConvention::Indirect_In)
+      continue;
+    bool HasDestroyAddrOutsideEpilogueBB = false;
+    // This is an @in argument. Check if there are any destroy_addr
+    // instructions for it.
+    for (auto Use : getNonDebugUses(Arg)) {
+      auto User = Use->getUser();
+      if (!isa<DestroyAddrInst>(User))
+        continue;
+      // Do not take into account any uses in the other
+      // epilogue BB.
+      if (AnotherEpilogueBB != F->end() &&
+          User->getParent() == &*AnotherEpilogueBB)
+        continue;
+      if (User->getParent() != BB )
+        HasDestroyAddrOutsideEpilogueBB = true;
+      ArgInstMap[Arg].push_back(dyn_cast<SILInstruction>(User));
+    }
+
+    // Don't know how to handle destroy_addr outside of the epilogue.
+    if (HasDestroyAddrOutsideEpilogueBB)
+      ArgInstMap.erase(Arg);
+  }
+}
+
 void
 ConsumedArgToEpilogueReleaseMatcher::
 collectMatchingReleases(SILBasicBlock *BB) {
@@ -789,7 +838,14 @@ collectMatchingReleases(SILBasicBlock *BB) {
   // 3. A release that is mapped to an argument which already has a release
   // that overlaps with this release. This release for sure is not the final
   // release.
+  bool IsTrackingInArgs = isOneOfConventions(SILArgumentConvention::Indirect_In,
+                                             ArgumentConventions);
+
   for (auto II = std::next(BB->rbegin()), IE = BB->rend(); II != IE; ++II) {
+    if (IsTrackingInArgs && isa<DestroyAddrInst>(*II)) {
+      // It is probably a destroy addr for an @in argument.
+      continue;
+    }
     // If we do not have a release_value or strong_release. We can continue
     if (!isa<ReleaseValueInst>(*II) && !isa<StrongReleaseInst>(*II)) {
 
@@ -825,13 +881,14 @@ collectMatchingReleases(SILBasicBlock *BB) {
     // we could make this more general by allowing for intervening non-arg
     // releases in the sense that we do not allow for race conditions in between
     // destructors.
-    if (!Arg->hasConvention(SILArgumentConvention::Direct_Owned))
+    if (!Arg ||
+        !isOneOfConventions(Arg->getArgumentConvention(), ArgumentConventions))
       break;
 
-    // Ok, we have a release on a SILArgument that is direct owned. Attempt to
-    // put it into our arc opts map. If we already have it, we have exited the
-    // return value sequence so break. Otherwise, continue looking for more arc
-    // operations.
+    // Ok, we have a release on a SILArgument that has a consuming convention.
+    // Attempt to put it into our arc opts map. If we already have it, we have
+    // exited the return value sequence so break. Otherwise, continue looking
+    // for more arc operations.
     auto Iter = ArgInstMap.find(Arg);
     if (Iter == ArgInstMap.end()) {
       ArgInstMap[Arg].push_back(Target);
@@ -843,12 +900,18 @@ collectMatchingReleases(SILBasicBlock *BB) {
     //
     // If we are seeing a redundant release we have exited the return value
     // sequence, so break.
-    if (isRedundantRelease(Iter->second, Arg, OrigOp)) 
-      break;
+    if (!isa<DestroyAddrInst>(Target))
+      if (isRedundantRelease(Iter->second, Arg, OrigOp)) 
+        break;
     
     // We've seen part of this base, but this is a part we've have not seen.
     // Record it. 
     Iter->second.push_back(Target);
+  }
+
+  if (IsTrackingInArgs) {
+    // Find destory_addr for each @in argument.
+    collectMatchingDestroyAddresses(BB);
   }
 }
 

--- a/lib/SILOptimizer/Transforms/ARCCodeMotion.cpp
+++ b/lib/SILOptimizer/Transforms/ARCCodeMotion.cpp
@@ -1055,7 +1055,9 @@ public:
     if (Kind == Release) {
       // TODO: we should consider Throw block as well, or better we should
       // abstract the Return block or Throw block away in the matcher.
-      ConsumedArgToEpilogueReleaseMatcher ERM(RCFI, F, 
+      SILArgumentConvention Conv[] = {SILArgumentConvention::Direct_Owned};
+      ConsumedArgToEpilogueReleaseMatcher ERM(RCFI, F,
+            Conv,
             ConsumedArgToEpilogueReleaseMatcher::ExitKind::Return);
 
       ReleaseCodeMotionContext RelCM(BPA, F, PO, AA, RCFI, 

--- a/lib/SILOptimizer/Utils/FunctionSignatureOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/FunctionSignatureOptUtils.cpp
@@ -21,6 +21,12 @@
 
 using namespace swift;
 
+/// Set to true to enable the support for partial specialization.
+llvm::cl::opt<bool> FSOEnableGenerics(
+  "sil-fso-enable-generics", llvm::cl::init(true),
+    llvm::cl::desc("Support function signature optimization "
+                   "of generic functions"));
+
 bool swift::hasNonTrivialNonDebugUse(SILArgument *Arg) {
   llvm::SmallVector<SILInstruction *, 8> Worklist;
   llvm::SmallPtrSet<SILInstruction *, 8> SeenInsts;
@@ -92,7 +98,7 @@ bool swift::canSpecializeFunction(SILFunction *F,
     return false;
 
   // For now ignore generic functions to keep things simple...
-  if (F->getLoweredFunctionType()->isPolymorphic())
+  if (!FSOEnableGenerics && F->getLoweredFunctionType()->isPolymorphic())
     return false;
 
   // Make sure F has a linkage that we can optimize.

--- a/test/SILOptimizer/capture_promotion_generic_context.sil
+++ b/test/SILOptimizer/capture_promotion_generic_context.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-sil -O %s | %FileCheck %s
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-sil -O -Xllvm -sil-fso-enable-generics=false %s | %FileCheck %s
 
 sil_stage raw
 
@@ -20,7 +20,7 @@ entry(%b : $<τ_0_0> { var τ_0_0 } <Int>):
   return %v : $Int
 }
 
-// CHECK-LABEL: sil @call_promotable_box_from_generic
+// CHECK-LABEL: sil {{.*}}@call_promotable_box_from_generic
 // CHECK:         [[F:%.*]] = function_ref @_T014promotable_boxTf2i_n
 // CHECK:         partial_apply [[F]](
 

--- a/test/SILOptimizer/capture_promotion_generic_context_ownership.sil
+++ b/test/SILOptimizer/capture_promotion_generic_context_ownership.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-sil-ownership -emit-sil -O %s | %FileCheck %s
+// RUN: %target-swift-frontend -enable-sil-ownership -emit-sil -O -Xllvm -sil-fso-enable-generics=false %s | %FileCheck %s
 
 sil_stage raw
 
@@ -20,7 +20,7 @@ entry(%b : @owned $<τ_0_0> { var τ_0_0 } <Int>):
   return %v : $Int
 }
 
-// CHECK-LABEL: sil @call_promotable_box_from_generic
+// CHECK-LABEL: sil {{.*}}@call_promotable_box_from_generic
 // CHECK:         [[F:%.*]] = function_ref @_T014promotable_boxTf2i_n
 // CHECK:         partial_apply [[F]](
 

--- a/test/SILOptimizer/functionsigopts.sil
+++ b/test/SILOptimizer/functionsigopts.sil
@@ -49,7 +49,23 @@ struct goo {
   var bottom : foo
 }
 
+public protocol P {
+  func foo() -> Int64
+}
+
+public protocol KlassFoo : class {
+  func bar() -> Int64
+}
+
+public class KlassBar : KlassFoo {
+  public func bar() -> Int64
+  deinit
+  init()
+}
+
 sil @use_Int : $@convention(thin) (Int) -> ()
+sil @use_Int64 : $@convention(thin) (Int64) -> ()
+sil @use_Generic : $@convention(thin) <T>(@in_guaranteed T) -> ()
 
 
 // CHECK-LABEL: sil [thunk] [always_inline] @argument_with_incomplete_epilogue_release
@@ -1479,6 +1495,212 @@ bb0(%0 : $Builtin.Int32):
   return %9999 : $()
 }
 
+// CHECK-LABEL: sil hidden [thunk] [always_inline] @generic_owned_to_guaranteed : $@convention(thin) <T where T : KlassFoo> (@owned T) -> Int64
+// CHECK: function_ref @_T027generic_owned_to_guaranteedTf4g_n 
+// CHECK: apply
+// CHECK: release_value
+// CHECK: end sil function 'generic_owned_to_guaranteed'
+
+// CHECK-LABEL: sil [thunk] [always_inline] @generic_owned_to_guaranteed_caller : $@convention(thin) <T where T : KlassFoo> (@owned T) -> Int64 
+// CHECK: function_ref @_T034generic_owned_to_guaranteed_callerTf4g_n 
+// CHECK: apply
+// CHECK: release_value
+// CHECK: end sil function 'generic_owned_to_guaranteed_caller'
+
+sil hidden [noinline] @generic_owned_to_guaranteed : $@convention(thin) <T where T : KlassFoo> (@owned T) -> Int64 {
+bb0(%0 : $T):
+  %2 = witness_method $T, #KlassFoo.bar!1 : <Self where Self : KlassFoo> (Self) -> () -> Int64 : $@convention(witness_method) <τ_0_0 where τ_0_0 : KlassFoo> (@guaranteed τ_0_0) -> Int64
+  %3 = apply %2<T>(%0) : $@convention(witness_method) <τ_0_0 where τ_0_0 : KlassFoo> (@guaranteed τ_0_0) -> Int64
+  strong_release %0 : $T
+  return %3 : $Int64
+}
+
+sil @generic_owned_to_guaranteed_caller : $@convention(thin) <T where T : KlassFoo> (@owned T) -> Int64 {
+bb0(%0 : $T):
+  %2 = function_ref @generic_owned_to_guaranteed : $@convention(thin) <τ_0_0 where τ_0_0 : KlassFoo> (@owned τ_0_0) -> Int64
+  strong_retain %0 : $T
+  %4 = apply %2<T>(%0) : $@convention(thin) <τ_0_0 where τ_0_0 : KlassFoo> (@owned τ_0_0) -> Int64
+  %5 = function_ref @generic_owned_to_guaranteed : $@convention(thin) <τ_0_0 where τ_0_0 : KlassFoo> (@owned τ_0_0) -> Int64
+  strong_retain %0 : $T
+  %7 = apply %5<T>(%0) : $@convention(thin) <τ_0_0 where τ_0_0 : KlassFoo> (@owned τ_0_0) -> Int64
+  %8 = struct_extract %4 : $Int64, #Int64._value
+  %9 = struct_extract %7 : $Int64, #Int64._value
+  %10 = integer_literal $Builtin.Int1, -1
+  %11 = builtin "sadd_with_overflow_Int64"(%8 : $Builtin.Int64, %9 : $Builtin.Int64, %10 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
+  %12 = tuple_extract %11 : $(Builtin.Int64, Builtin.Int1), 0
+  %13 = tuple_extract %11 : $(Builtin.Int64, Builtin.Int1), 1
+  cond_fail %13 : $Builtin.Int1
+  %15 = struct $Int64 (%12 : $Builtin.Int64)
+  strong_release %0 : $T
+  return %15 : $Int64
+}
+
+// CHECK-LABEL: sil hidden [thunk] [always_inline] @generic_in_to_guaranteed : $@convention(thin) <T where T : P> (@in T) -> Int64
+// CHECK: function_ref @_T024generic_in_to_guaranteedTf4g_n 
+// CHECK: apply
+// CHECK: destroy_addr
+// CHECK: end sil function 'generic_in_to_guaranteed'
+
+// CHECK-LABEL: sil [thunk] [always_inline] @generic_in_to_guaranteed_caller : $@convention(thin) <T where T : P> (@in T) -> Int64 
+// CHECK: function_ref @_T031generic_in_to_guaranteed_callerTf4g_n 
+// CHECK: apply
+// CHECK: destroy_addr
+// CHECK: end sil function 'generic_in_to_guaranteed_caller'
+
+sil hidden [noinline] @generic_in_to_guaranteed : $@convention(thin) <T where T : P> (@in T) -> Int64 {
+bb0(%0 : $*T):
+  %2 = witness_method $T, #P.foo!1 : <Self where Self : P> (Self) -> () -> Int64 : $@convention(witness_method) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> Int64
+  %3 = apply %2<T>(%0) : $@convention(witness_method) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> Int64
+  destroy_addr %0 : $*T
+  return %3 : $Int64
+}
+
+sil @generic_in_to_guaranteed_caller : $@convention(thin) <T where T : P> (@in T) -> Int64 {
+bb0(%0 : $*T):
+  %2 = function_ref @generic_in_to_guaranteed : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in τ_0_0) -> Int64
+  %3 = alloc_stack $T
+  copy_addr %0 to [initialization] %3 : $*T
+  %5 = apply %2<T>(%3) : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in τ_0_0) -> Int64
+  dealloc_stack %3 : $*T
+  %7 = apply %2<T>(%0) : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in τ_0_0) -> Int64
+  %8 = struct_extract %5 : $Int64, #Int64._value
+  %9 = struct_extract %7 : $Int64, #Int64._value
+  %10 = integer_literal $Builtin.Int1, -1
+  %11 = builtin "sadd_with_overflow_Int64"(%8 : $Builtin.Int64, %9 : $Builtin.Int64, %10 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
+  %12 = tuple_extract %11 : $(Builtin.Int64, Builtin.Int1), 0
+  %13 = tuple_extract %11 : $(Builtin.Int64, Builtin.Int1), 1
+  cond_fail %13 : $Builtin.Int1
+  %15 = struct $Int64 (%12 : $Builtin.Int64)
+  return %15 : $Int64
+}
+
+// CHECK-LABEL: sil [thunk] [always_inline] @generic_func_with_dead_non_generic_arg : $@convention(thin) <T> (@owned foo, @in T) -> ()
+// CHECK: function_ref @_T0027generic_func_with_dead_non_A4_argTf4dd_n : $@convention(thin) () -> ()
+// Call the specialization which is not polymorphic.
+// CHECK: apply
+// CHECK: destroy_addr
+// CHECK: end sil function 'generic_func_with_dead_non_generic_arg'
+sil [noinline] @generic_func_with_dead_non_generic_arg : $@convention(thin) <T> (@owned foo, @in T) -> () {
+bb0(%0 : $foo, %1 : $*T):
+  destroy_addr %1 : $*T
+  %r = tuple()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil [thunk] [always_inline] @generic_func_with_dead_generic_arg : $@convention(thin) <T> (Int64, @in T) -> Int64
+// CHECK: function_ref @_T0023generic_func_with_dead_A4_argTf4nd_n : $@convention(thin) (Int64) -> Int64 
+// Call the specialization which is not polymorphic.
+// CHECK: apply
+// CHECK: destroy_addr
+// CHECK: end sil function 'generic_func_with_dead_generic_arg'
+sil [noinline] @generic_func_with_dead_generic_arg : $@convention(thin) <T> (Int64, @in T) -> Int64 {
+bb0(%0 : $Int64, %1 : $*T):
+  destroy_addr %1 : $*T
+  return %0 : $Int64
+}
+
+// CHECK-LABEL: sil [thunk] [always_inline] @generic_func_with_unused_generic_param_and_non_generic_arg : $@convention(thin) <T> (Int64) -> Int64 
+// CHECK: function_ref @_T0025generic_func_with_unused_a15_param_and_non_A4_argTf4n_n : $@convention(thin) (Int64) -> Int64 
+// Call the specialization which is not polymorphic.
+// CHECK: apply
+// CHECK: end sil function 'generic_func_with_unused_generic_param_and_non_generic_arg'
+sil [noinline] @generic_func_with_unused_generic_param_and_non_generic_arg : $@convention(thin) <T> (Int64) -> Int64 {
+bb0(%0 : $Int64):
+  return %0 : $Int64
+}
+
+sil [noinline] @generic_func_with_unused_generic_param_and_non_generic_arg_caller : $@convention(thin) <T> (Int64) -> Int64 {
+bb0(%0 : $Int64):
+  %f = function_ref @generic_func_with_unused_generic_param_and_non_generic_arg : $@convention(thin) <T> (Int64) -> Int64 
+  %r = apply %f<T>(%0) : $@convention(thin) <T> (Int64) -> Int64 
+  return %r : $Int64
+}
+
+// CHECK-LABEL: sil [thunk] [always_inline] @generic_func_with_unused_generic_param_and_dead_non_generic_arg : $@convention(thin) <T> (Int64, Int64) -> Int64
+// CHECK: function_ref @_T0025generic_func_with_unused_a20_param_and_dead_non_A4_argTf4nd_n : $@convention(thin) (Int64) -> Int64 
+// Call the specialization which is not polymorphic.
+// CHECK: apply
+// CHECK: end sil function 'generic_func_with_unused_generic_param_and_dead_non_generic_arg'
+sil [noinline] @generic_func_with_unused_generic_param_and_dead_non_generic_arg : $@convention(thin) <T> (Int64, Int64) -> Int64 {
+bb0(%0 : $Int64, %1 : $Int64):
+  return %0 : $Int64
+}
+
+sil [noinline] @generic_func_with_unused_generic_param_and_dead_non_generic_arg_caller : $@convention(thin) <T> (Int64) -> Int64 {
+bb0(%0 : $Int64):
+  %f = function_ref @generic_func_with_unused_generic_param_and_dead_non_generic_arg : $@convention(thin) <T> (Int64, Int64) -> Int64 
+  %r = apply %f<T>(%0, %0) : $@convention(thin) <T> (Int64, Int64) -> Int64 
+  return %r : $Int64
+}
+
+// CHECK-LABEL: sil [thunk] [always_inline] @generic_func_with_unused_generic_param_and_dead_generic_arg : $@convention(thin) <T> (@in_guaranteed T) -> ()
+// CHECK: function_ref @_T0025generic_func_with_unused_a16_param_and_dead_A4_argTf4d_n : $@convention(thin) () -> ()
+// Call the specialization which is not polymorphic.
+// CHECK: apply
+// CHECK: end sil function 'generic_func_with_unused_generic_param_and_dead_generic_arg'
+sil [noinline] @generic_func_with_unused_generic_param_and_dead_generic_arg : $@convention(thin) <T> (@in_guaranteed T) -> () {
+bb0(%0 : $*T):
+  %r = tuple()
+  return %r : $()
+}
+
+sil [noinline] @generic_func_with_unused_generic_param_and_dead_generic_arg_caller : $@convention(thin) <T> (@in_guaranteed T) -> () {
+bb0(%0 : $*T):
+  %f = function_ref @generic_func_with_unused_generic_param_and_dead_generic_arg : $@convention(thin) <T> (@in_guaranteed T) -> () 
+  apply %f<T>(%0) : $@convention(thin) <T> (@in_guaranteed T) -> ()  
+  %r = tuple()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil [thunk] [always_inline] @generic_func_with_unused_generic_param_and_dead_owned_generic_arg : $@convention(thin) <T where T : KlassFoo> (@owned T) -> ()
+// CHECK: function_ref @_T0025generic_func_with_unused_a22_param_and_dead_owned_A4_argTf4d_n : $@convention(thin) () -> ()
+// Call the specialization which is not polymorphic.
+// CHECK: apply
+// CHECK: release_value %0
+// CHECK: end sil function 'generic_func_with_unused_generic_param_and_dead_owned_generic_arg'
+sil [noinline] @generic_func_with_unused_generic_param_and_dead_owned_generic_arg : $@convention(thin) <T where T: KlassFoo> (@owned T) -> () {
+bb0(%0 : $T):
+  release_value %0 : $T
+  %r = tuple()
+  return %r : $()
+}
+
+sil [noinline] @generic_func_with_unused_generic_param_and_dead_owned_generic_arg_caller : $@convention(thin) <T where T: KlassFoo> (@owned T) -> () {
+bb0(%0 : $T):
+  %f = function_ref @generic_func_with_unused_generic_param_and_dead_owned_generic_arg : $@convention(thin) <T where T: KlassFoo> (@owned T) -> () 
+  apply %f<T>(%0) : $@convention(thin) <T where T: KlassFoo> (@owned T) -> ()  
+  %r = tuple()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil [thunk] [always_inline] @generic_func_with_multple_generic_args_and_dead_generic_arg : $@convention(thin) <T, S> (@in T, @in S) -> ()
+// CHECK: function_ref @_T0026generic_func_with_multple_a15_args_and_dead_A4_argTf4nd_n : $@convention(thin) <τ_0_0, τ_0_1> (@in τ_0_0) -> ()
+// Call the specialization which has only one function argument, because another one is dead
+// and was eliminated.
+// CHECK: apply
+// CHECK: end sil function 'generic_func_with_multple_generic_args_and_dead_generic_arg'
+sil [noinline] @generic_func_with_multple_generic_args_and_dead_generic_arg : $@convention(thin) <T, S> (@in T, @in S) -> () {
+bb0(%0 : $*T, %1 : $*S):
+  %f = function_ref @use_Generic : $@convention(thin) <T>(@in_guaranteed T) -> ()
+  apply %f<T>(%0) : $@convention(thin) <T>(@in_guaranteed T) -> ()
+  %r = tuple()
+  return %r : $()
+}
+
+sil [noinline] @generic_func_with_multple_generic_args_and_dead_generic_arg_caller : $@convention(thin) <T> (@in T) -> () {
+bb0(%0 : $*T):
+  %2 = alloc_stack $T
+  copy_addr %0 to [initialization] %2 : $*T
+  %4 = alloc_stack $T
+  copy_addr %0 to [initialization] %4 : $*T
+  %f = function_ref @generic_func_with_multple_generic_args_and_dead_generic_arg : $@convention(thin) <T, S> (@in T, @in S) -> ()
+  apply %f<T, T>(%2, %4) : $@convention(thin) <T, S> (@in T, @in S) -> () 
+  dealloc_stack %4 : $*T
+  dealloc_stack %2 : $*T
+  %r = tuple()
+  return %r : $()
+}
+
 // CHECK-LABEL: sil @_T036exploded_release_to_guaranteed_paramTf4gX_n
 // CHECK: bb0([[INPUT_ARG0:%[0-9]+]] : $Int):
 // CHECK-NOT: strong_release
@@ -1552,4 +1774,30 @@ bb0(%0 : $Builtin.Int32):
 // CHECK:  apply
 // CHECK:  tuple
 // CHECK:  return
+
+// Check that a owned-to-guaranteed has happened.
+// CHECK-LABEL: sil hidden [noinline] @_T027generic_owned_to_guaranteedTf4g_n : $@convention(thin) <T where T : KlassFoo> (@guaranteed T) -> Int64
+// CHECK-NOT: release_value 
+// CHECK-NOT: strong_release 
+// CHECK-NOT: destroy_addr 
+// CHECK: end sil function '_T027generic_owned_to_guaranteedTf4g_n'
+
+// Check that a owned-to-guaranteed has happened.
+// CHECK-LABEL: sil @_T034generic_owned_to_guaranteed_callerTf4g_n : $@convention(thin) <T where T : KlassFoo> (@guaranteed T) -> Int64
+// Call the specialized function. It should have a guaranteed param now. 
+// CHECK: function_ref @_T027generic_owned_to_guaranteedTf4g_n : $@convention(thin) <τ_0_0 where τ_0_0 : KlassFoo> (@guaranteed τ_0_0) -> Int64
+// CHECK: apply
+// CHECK: end sil function '_T034generic_owned_to_guaranteed_callerTf4g_n'
+
+// Check that a in-to-guaranteed has happened.
+// CHECK-LABEL: sil hidden [noinline] @_T024generic_in_to_guaranteedTf4g_n : $@convention(thin) <T where T : P> (@in_guaranteed T) -> Int64
+// CHECK-NOT: destroy_addr
+// CHECK: end sil function '_T024generic_in_to_guaranteedTf4g_n'
+
+// Check that a in-to-guaranteed has happened.
+// CHECK-LABEL: sil @_T031generic_in_to_guaranteed_callerTf4g_n : $@convention(thin) <T where T : P> (@in_guaranteed T) -> Int64
+// Call the specialized function. It should have a guaranteed param now. 
+// CHECK: function_ref @_T024generic_in_to_guaranteedTf4g_n : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> Int64
+// CHECK: apply
+// CHECK: end sil function '_T031generic_in_to_guaranteed_callerTf4g_n'
 


### PR DESCRIPTION
In particular, support the following optimizations:
- owned-to-guaranteed
- dead argument elimination

Argument explosion is disabled for generics at the moment as it usually leads to a slower code.

rdar://26268241