### PR TITLE
Sema: Fix materializeForSet for members of extensions of imported classes

### DIFF
--- a/lib/SILGen/SILGenMaterializeForSet.cpp
+++ b/lib/SILGen/SILGenMaterializeForSet.cpp
@@ -359,7 +359,7 @@ public:
          emitter.WitnessStorage->hasAddressors()))
       emitter.TheAccessSemantics = AccessSemantics::DirectToStorage;
     else if (emitter.WitnessStorage->hasClangNode() ||
-             emitter.WitnessStorage->getAttrs().hasAttribute<NSManagedAttr>())
+             emitter.WitnessStorage->isDynamic())
       emitter.TheAccessSemantics = AccessSemantics::Ordinary;
     else
       emitter.TheAccessSemantics = AccessSemantics::DirectToAccessor;

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -848,6 +848,11 @@ synthesizeSetterForMutableAddressedStorage(AbstractStorageDecl *storage,
 /// Add a materializeForSet accessor to the given declaration.
 static FuncDecl *addMaterializeForSet(AbstractStorageDecl *storage,
                                       TypeChecker &TC) {
+  if (TC.Context.getOptionalDecl() == nullptr) {
+    TC.diagnose(storage->getStartLoc(), diag::optional_intrinsics_not_found);
+    return nullptr;
+  }
+
   auto materializeForSet = createMaterializeForSetPrototype(
       storage, storage->getSetter(), TC);
   addMemberToContextIfNeeded(materializeForSet, storage->getDeclContext(),

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -893,6 +893,8 @@ static void convertNSManagedStoredVarToComputed(VarDecl *VD, TypeChecker &TC) {
   // the members list.
   addMemberToContextIfNeeded(Get, VD->getDeclContext(), VD);
   addMemberToContextIfNeeded(Set, VD->getDeclContext(), Get);
+
+  maybeAddMaterializeForSet(VD, TC);
 }
 
 /// The specified AbstractStorageDecl was just found to satisfy a
@@ -1653,23 +1655,20 @@ void swift::maybeAddMaterializeForSet(AbstractStorageDecl *storage,
   if (!storage->getSetter()) return;
 
   // We only need materializeForSet in type contexts.
-  NominalTypeDecl *container = storage->getDeclContext()
-      ->getAsNominalTypeOrNominalTypeExtensionContext();
-  if (!container) return;
+  auto *dc = storage->getDeclContext();
+  if (!dc->isTypeContext())
+    return;
 
   // Requirements of ObjC protocols don't need this.
-  if (auto protocol = dyn_cast<ProtocolDecl>(container)) {
-    if (protocol->isObjC()) return;
+  if (auto protoDecl = dyn_cast<ProtocolDecl>(dc))
+    if (protoDecl->isObjC())
+      return;
 
-  // Types imported by Clang don't need this, because we can
+  // Members of structs imported by Clang don't need this, because we can
   // synthesize it later.
-  } else {
-    assert(isa<NominalTypeDecl>(container));
-    if (container->hasClangNode()) return;
-  }
-
-  // @NSManaged properties don't need this.
-  if (storage->getAttrs().hasAttribute<NSManagedAttr>()) return;
+  if (auto structDecl = dyn_cast<StructDecl>(dc))
+    if (structDecl->hasClangNode())
+      return;
 
   addMaterializeForSet(storage, TC);
 }

--- a/test/Interpreter/objc_class_properties.swift
+++ b/test/Interpreter/objc_class_properties.swift
@@ -207,5 +207,36 @@ ClassProperties.test("namingConflict/protocol") {
   expectNil(type.protoProp)
 }
 
+var global1: Int = 0
+
+var global2: Int = 0
+
+class Steak : NSObject {
+  @objc override var thickness: Int {
+    get { return global1 } set { global1 = newValue }
+  }
+}
+
+extension NSObject : HasThickness {
+  @objc var thickness: Int { get { return global2 } set { global2 = newValue } }
+}
+
+protocol HasThickness : class {
+  var thickness: Int { get set }
+}
+
+ClassProperties.test("dynamicOverride") {
+  // Calls NSObject.thickness
+  NSObject().thickness += 1
+
+  // Calls Steak.thickness
+  (Steak() as NSObject).thickness += 1
+  Steak().thickness += 1
+  (Steak() as HasThickness).thickness += 1
+
+  expectEqual(3, global1)
+  expectEqual(1, global2)
+}
+
 runAllTests()
 

--- a/test/SILGen/objc_witnesses.swift
+++ b/test/SILGen/objc_witnesses.swift
@@ -96,3 +96,27 @@ public class Positron : Lepton {
 
 // CHECK-LABEL: sil shared [transparent] [serialized] [thunk] @_T014objc_witnesses8PositronCAA6LeptonA2aDP4spinSffgTW
 // CHECK-LABEL: sil shared [transparent] [serializable] [thunk] @_T014objc_witnesses8PositronC4spinSffgTD
+
+// Override of property defined in @objc extension
+
+class Derived : NSObject {
+  override var valence: Int {
+    get { return 2 } set { }
+  }
+}
+
+extension NSObject : Atom {
+  var valence: Int { get { return 1 } set { } }
+}
+
+// CHECK-LABEL: sil hidden @_T0So8NSObjectC14objc_witnessesE7valenceSifmytfU_ : $@convention(method) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout NSObject, @thick NSObject.Type) -> () {
+// CHECK: class_method [volatile] %4 : $NSObject, #NSObject.valence!setter.1.foreign
+// CHECK: }
+
+// CHECK-LABEL: sil hidden @_T0So8NSObjectC14objc_witnessesE7valenceSifm : $@convention(method) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @guaranteed NSObject) -> (Builtin.RawPointer, Optional<Builtin.RawPointer>) {
+// CHECK: class_method [volatile] %2 : $NSObject, #NSObject.valence!getter.1.foreign
+// CHECK: }
+
+protocol Atom : class {
+  var valence: Int { get set }
+}

--- a/test/multifile/synthesized-accessors/one-module-imported/library.swift
+++ b/test/multifile/synthesized-accessors/one-module-imported/library.swift
@@ -2,6 +2,8 @@
 
 import CoreGraphics
 
+// Case 1 - witness is imported accessor
+
 protocol OtherPoint {
   associatedtype FloatType
 
@@ -10,3 +12,12 @@ protocol OtherPoint {
 }
 
 extension CGPoint: OtherPoint {}
+
+// Case 2 - witness is extension method of imported type
+
+extension CGPoint {
+  var z: Float {
+    get { return 0.0 }
+    set { }
+  }
+}

--- a/test/multifile/synthesized-accessors/one-module-imported/main.swift
+++ b/test/multifile/synthesized-accessors/one-module-imported/main.swift
@@ -8,6 +8,8 @@
 
 import CoreGraphics
 
+// Case 1 - witness is imported accessor
+
 protocol MyPoint {
   associatedtype FloatType
 
@@ -16,6 +18,14 @@ protocol MyPoint {
 }
 
 extension CGPoint: MyPoint {}
+
+// Case 2 - witness is extension method of imported type
+
+protocol MyProto {
+  var z: Float { get set }
+}
+
+extension CGPoint : MyProto {}
 
 // Dummy statement
 _ = ()


### PR DESCRIPTION
An assertion I added recently to check property overrides in
the ASTVerifier uncovered some bugs in this area:

- We did not synthesize a materializeForSet for properties
  defined in extensions of imported classes unless they
  witnessed a protocol requirement.

  This triggered an assertion if the property had an
  override that was checked before the protocol conformance,
  since the override's materializeForSet would not be marked
  as an override of the base materializeForSet.

- materializeForSet for properties defined in extensions would
  statically dispatch the getter and setter instead of dynamically
  dispatching. This is incorrect since we statically dispatch
  to the materializeForSet in this case, and we can in fact
  override it in a subclass.

Fixes <rdar://problem/31334272>.