### PR TITLE
IRGen: Fix -sil-serialize-all linkage issue

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1355,10 +1355,13 @@ getIRLinkage(IRGenModule &IGM, SILLinkage linkage, bool isFragile,
       linkage = SILLinkage::Public;
       break;
 
-    case SILLinkage::Public:
-    case SILLinkage::Shared:
     case SILLinkage::HiddenExternal:
     case SILLinkage::PrivateExternal:
+      linkage = SILLinkage::PublicExternal;
+      break;
+
+    case SILLinkage::Public:
+    case SILLinkage::Shared:
     case SILLinkage::PublicExternal:
     case SILLinkage::SharedExternal:
       break;


### PR DESCRIPTION
External private definitions coming from a -sil-serialize-all
module must be effectively public at the LLVM level too, fixing
a linker error when referencing closures from a deserialized
function body.