### PR TITLE
[SE-0160] Add support of @objc and @nonobjc extensions of classes

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -92,7 +92,7 @@ SIMPLE_DECL_ATTR(final, Final,
                  OnClass | OnFunc | OnVar | OnSubscript|DeclModifier, 2)
 
 DECL_ATTR(objc, ObjC,
-          OnFunc | OnClass | OnProtocol | OnVar | OnSubscript |
+          OnFunc | OnClass | OnProtocol | OnExtension | OnVar | OnSubscript |
           OnConstructor | OnDestructor | OnEnum | OnEnumElement, 3)
 
 SIMPLE_DECL_ATTR(required, Required,

--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -158,7 +158,7 @@ DECL_ATTR(autoclosure, AutoClosure, OnParam, 28)
 SIMPLE_DECL_ATTR(noescape, NoEscape, OnParam, 29)
 
 SIMPLE_DECL_ATTR(nonobjc, NonObjC,
-                 OnFunc | OnVar | OnSubscript | OnConstructor, 30)
+                 OnExtension | OnFunc | OnVar | OnSubscript | OnConstructor, 30)
 
 SIMPLE_DECL_ATTR(_fixed_layout, FixedLayout,
                  OnVar | OnClass | OnStruct | OnEnum | UserInaccessible, 31)

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2990,6 +2990,9 @@ ERROR(invalid_objc_swift_rooted_class,none,
 ERROR(invalid_nonobjc_decl,none,
       "only methods, initializers, properties and subscript declarations can "
       "be declared @nonobjc", ())
+ERROR(invalid_nonobjc_extension,none,
+      "only extensions of classes can be declared @nonobjc", ())
+
 ERROR(objc_in_extension_context,none,
       "members of constrained extensions cannot be declared @objc", ())
 ERROR(objc_in_generic_extension,none,
@@ -3054,7 +3057,7 @@ ERROR(objc_extension_not_class,none,
       "'@objc' can only be applied to an extension of a class", ())
 
 // If you change this, also change enum ObjCReason
-#define OBJC_ATTR_SELECT "select{marked @_cdecl|marked dynamic|marked @objc|marked @IBOutlet|marked @IBAction|marked @NSManaged|a member of an @objc protocol|implicitly @objc|an @objc override|an implementation of an @objc requirement|marked @IBInspectable|marked @GKInspectable|in an @objc extension of a class (without @nonobjc)}"
+#define OBJC_ATTR_SELECT "select{marked @_cdecl|marked dynamic|marked @objc|marked @IBOutlet|marked @IBAction|marked @NSManaged|a member of an @objc protocol|implicitly @objc|an @objc override|an implementation of an @objc requirement|marked @IBInspectable|marked @GKInspectable|in an @objc extension of a class (without @nonobjc)}"
 
 ERROR(objc_invalid_on_var,none,
       "property cannot be %" OBJC_ATTR_SELECT "0 "

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2983,8 +2983,8 @@ ERROR(invalid_objc_decl_context,none,
       "@objc can only be used with members of classes, @objc protocols, and "
       "concrete extensions of classes", ())
 ERROR(invalid_objc_decl,none,
-      "only classes, protocols, methods, initializers, properties, and "
-      "subscript declarations can be declared @objc", ())
+      "only classes (and their extensions), protocols, methods, initializers, "
+      "properties, and subscript declarations can be declared @objc", ())
 ERROR(invalid_objc_swift_rooted_class,none,
       "only classes that inherit from NSObject can be declared @objc", ())
 ERROR(invalid_nonobjc_decl,none,
@@ -3050,8 +3050,11 @@ ERROR(objc_enum_case_req_objc_enum,none,
 ERROR(objc_enum_case_multi,none,
       "'@objc' enum case declaration defines multiple enum cases with the same Objective-C name", ())
 
+ERROR(objc_extension_not_class,none,
+      "'@objc' can only be applied to an extension of a class", ())
+
 // If you change this, also change enum ObjCReason
-#define OBJC_ATTR_SELECT "select{marked @_cdecl|marked dynamic|marked @objc|marked @IBOutlet|marked @IBAction|marked @NSManaged|a member of an @objc protocol|implicitly @objc|an @objc override|an implementation of an @objc requirement|marked @IBInspectable|marked @GKInspectable}"
+#define OBJC_ATTR_SELECT "select{marked @_cdecl|marked dynamic|marked @objc|marked @IBOutlet|marked @IBAction|marked @NSManaged|a member of an @objc protocol|implicitly @objc|an @objc override|an implementation of an @objc requirement|marked @IBInspectable|marked @GKInspectable|in an @objc extension of a class (without @nonobjc)}"
 
 ERROR(objc_invalid_on_var,none,
       "property cannot be %" OBJC_ATTR_SELECT "0 "

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -539,6 +539,8 @@ enum class ObjCReason {
   ExplicitlyIBInspectable,
   /// Has an explicit '@GKInspectable' attribute.
   ExplicitlyGKInspectable,
+  /// Is it a member of an @objc extension of a class.
+  MemberOfObjCExtension,
   /// Is it a member of an @objcMembers class.
   MemberOfObjCMembersClass,
   /// A member of an Objective-C-defined class or subclass.
@@ -547,7 +549,8 @@ enum class ObjCReason {
   Accessor,
 };
 
-/// Determine whether we should diagnose conflicts due yo
+/// Determine whether we should diagnose conflicts due to inferring @objc
+/// with this particular reason.
 static inline bool shouldDiagnoseObjCReason(ObjCReason reason) {
   switch(reason) {
   case ObjCReason::ExplicitlyCDecl:
@@ -562,6 +565,7 @@ static inline bool shouldDiagnoseObjCReason(ObjCReason reason) {
   case ObjCReason::ImplicitlyObjC:
   case ObjCReason::ExplicitlyIBInspectable:
   case ObjCReason::ExplicitlyGKInspectable:
+  case ObjCReason::MemberOfObjCExtension:
     return true;
 
   case ObjCReason::MemberOfObjCSubclass:
@@ -587,6 +591,7 @@ static inline unsigned getObjCDiagnosticAttrKind(ObjCReason reason) {
   case ObjCReason::ImplicitlyObjC:
   case ObjCReason::ExplicitlyIBInspectable:
   case ObjCReason::ExplicitlyGKInspectable:
+  case ObjCReason::MemberOfObjCExtension:
     return static_cast<unsigned>(reason);
 
   case ObjCReason::MemberOfObjCSubclass:

--- a/test/attr/attr_nonobjc.swift
+++ b/test/attr/attr_nonobjc.swift
@@ -102,3 +102,6 @@ class NSManagedAndNonObjCNotAllowed {
     }
   }
 }
+
+struct SomeStruct { }
+@nonobjc extension SomeStruct { } // expected-error{{only extensions of classes can be declared @nonobjc}}

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -30,7 +30,7 @@ protocol Protocol_Class2 : class {}
 
 //===--- Subjects of @objc attribute.
 
-@objc extension PlainStruct { } // expected-error{{'@objc' cannot be applied to an extension of a class}}{{1-7=}}
+@objc extension PlainStruct { } // expected-error{{'@objc' can only be applied to an extension of a class}}{{1-7=}}
 
 @objc  
 var subject_globalVar: Int // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
@@ -2160,16 +2160,15 @@ class ConformsToProtocolThrowsObjCName2 : ProtocolThrowsObjCName {
 }
 
 @objc extension PlainClass {
-  // CHECK-LABEL: @objc func objc_ext_objc_okay(_: Int) { }
-  func objc_ext_objc_okay(_: Int) { }
+  // CHECK-LABEL: @objc final func objc_ext_objc_okay(_: Int) {
+  final func objc_ext_objc_okay(_: Int) { }
 
-  // CHECK-LABEL: {{^}} func objc_ext_objc_not_okay(_: PlainStruct) { }
-  func objc_ext_objc_not_okay(_: PlainStruct) { }
-  // expected-error@-1 {{method cannot be in an @objc extension of a class because the type of the parameter cannot be represented in Objective-C}}
+  final func objc_ext_objc_not_okay(_: PlainStruct) { }
+  // expected-error@-1{{method cannot be in an @objc extension of a class (without @nonobjc) because the type of the parameter cannot be represented in Objective-C}}
   // expected-note@-2 {{Swift structs cannot be represented in Objective-C}}
 
-  // CHECK-LABEL: {{^}} @nonobjc func objc_ext_objc_explicit_nonobjc(_: PlainStruct) { }
-  @nonobjc func objc_ext_objc_explicit_nonobjc(_: PlainStruct) { }
+  // CHECK-LABEL: {{^}} @nonobjc final func objc_ext_objc_explicit_nonobjc(_: PlainStruct) {
+  @nonobjc final func objc_ext_objc_explicit_nonobjc(_: PlainStruct) { }
 }
 
 @objc class ObjC_Class1 : Hashable { 

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -30,7 +30,7 @@ protocol Protocol_Class2 : class {}
 
 //===--- Subjects of @objc attribute.
 
-@objc extension PlainClass { } // expected-error{{@objc cannot be applied to this declaration}}{{1-7=}}
+@objc extension PlainStruct { } // expected-error{{'@objc' cannot be applied to an extension of a class}}{{1-7=}}
 
 @objc  
 var subject_globalVar: Int // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
@@ -2159,6 +2159,18 @@ class ConformsToProtocolThrowsObjCName2 : ProtocolThrowsObjCName {
   @objc func func_dictionary2b(x: Dictionary<String, Int>) { }
 }
 
+@objc extension PlainClass {
+  // CHECK-LABEL: @objc func objc_ext_objc_okay(_: Int) { }
+  func objc_ext_objc_okay(_: Int) { }
+
+  // CHECK-LABEL: {{^}} func objc_ext_objc_not_okay(_: PlainStruct) { }
+  func objc_ext_objc_not_okay(_: PlainStruct) { }
+  // expected-error@-1 {{method cannot be in an @objc extension of a class because the type of the parameter cannot be represented in Objective-C}}
+  // expected-note@-2 {{Swift structs cannot be represented in Objective-C}}
+
+  // CHECK-LABEL: {{^}} @nonobjc func objc_ext_objc_explicit_nonobjc(_: PlainStruct) { }
+  @nonobjc func objc_ext_objc_explicit_nonobjc(_: PlainStruct) { }
+}
 
 @objc class ObjC_Class1 : Hashable { 
   var hashValue: Int { return 0 }

--- a/test/attr/attr_objcMembers.swift
+++ b/test/attr/attr_objcMembers.swift
@@ -31,3 +31,11 @@ func selectorTest() {
   _ = #selector(SubClassOfSomeClassWithObjCMembers.baz)
   _ = #selector(SubClassOfSomeClassWithObjCMembers.wibble)
 }
+
+@nonobjc extension SomeClassWithObjCMembers {
+  func notInferredObjC() { } // expected-note{{add '@objc' to expose this instance method to Objective-C}}
+}
+
+func selectorTestFail() {
+  _ = #selector(SomeClassWithObjCMembers.notInferredObjC) // expected-error{{argument of '#selector' refers to instance method 'notInferredObjC()' that is not exposed to Objective-C}}
+}


### PR DESCRIPTION
* `@objc` on an extension of a class requires all members not marked `@nonobjc` to be exposed to Objective-C
* `@nonobjc` on an extension of a class is equivalence to `@nonobjc` on each of the members that doesn't have an explicit `@objc` or attribute that directly infers it