### PR TITLE
[NOT TO MERGE][stdlib] Overriding underestimatedCount for a UTF8 view

### DIFF
--- a/stdlib/public/core/StringUTF8.swift
+++ b/stdlib/public/core/StringUTF8.swift
@@ -190,6 +190,10 @@ extension String {
       self._endIndex = e
     }
 
+    public var underestimatedCount: Int {
+      return _core.count
+    }
+
     /// A position in a string's `UTF8View` instance.
     ///
     /// You can convert between indices of the different string views by using


### PR DESCRIPTION
StringCore has the count property that's accessible in O(1), so for
algorithms that use a UTF8 view as a Sequence, implementing an
underestimatedCount using StringCore.count should give some speedup
compared to the default, which is Collection.count, and traverses the
whole view.

Rewrite of `String` is on the way, so this is more of a test to see how this change affects benchmarks.