### PR TITLE
[SE-0160] Map Clang's swift_objc_members attribute to @objcMembers

### DIFF
--- a/apinotes/XCTest.apinotes
+++ b/apinotes/XCTest.apinotes
@@ -18,6 +18,7 @@ Classes:
     MethodKind: Instance
     SwiftName: 'matching(identifier:)'
 - Name: XCTestCase
+  SwiftObjCMembers: true
   Methods:
   - Selector: 'waitForExpectationsWithTimeout:handler:'
     MethodKind: Instance

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -6722,6 +6722,14 @@ void ClangImporter::Implementation::importAttributes(
       return;
     }
 
+    // Map Clang's swift_objc_members attribute to @objcMembers.
+    if (ID->hasAttr<clang::SwiftObjCMembersAttr>()) {
+      if (!MappedDecl->getAttrs().hasAttribute<ObjCMembersAttr>()) {
+        auto attr = new (C) ObjCMembersAttr(/*implicit=*/true);
+        MappedDecl->getAttrs().add(attr);
+      }
+    }
+
     // Infer @objcMembers on XCTestCase.
     if (ID->getName() == "XCTestCase") {
       if (!MappedDecl->getAttrs().hasAttribute<ObjCMembersAttr>()) {

--- a/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/APINotesFrameworkTest.apinotes
+++ b/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/APINotesFrameworkTest.apinotes
@@ -1,5 +1,7 @@
 Name: APINotesFrameworkTest
 Classes:
+  - Name: A
+    SwiftObjCMembers: true
   - Name: TestProperties
     Properties:
       - Name: accessorsOnly

--- a/test/APINotes/basic.swift
+++ b/test/APINotes/basic.swift
@@ -2,6 +2,7 @@
 import APINotesTest
 import APINotesFrameworkTest
 
+#if _runtime(_ObjC)
 extension A {
   func implicitlyObjC() { }
 }
@@ -9,6 +10,7 @@ extension A {
 func testSelectors(a: AnyObject) {
   a.implicitlyObjC?()  // okay: would complain without SwiftObjCMembers
 }
+#endif
 
 func testSwiftName() {
   moveTo(x: 0, y: 0, z: 0)

--- a/test/APINotes/basic.swift
+++ b/test/APINotes/basic.swift
@@ -2,6 +2,14 @@
 import APINotesTest
 import APINotesFrameworkTest
 
+extension A {
+  func implicitlyObjC() { }
+}
+
+func testSelectors(a: AnyObject) {
+  a.implicitlyObjC?()  // okay: would complain without SwiftObjCMembers
+}
+
 func testSwiftName() {
   moveTo(x: 0, y: 0, z: 0)
   moveTo(0, 0, 0) // expected-error{{missing argument labels 'x:y:z:' in call}}


### PR DESCRIPTION
This finishes the implementation of SE-0160, tracked by #47058.

Resolves #47058
rdar://problem/28497874