### PR TITLE
[4.0] [ClangImporter] Always load a class's members before any categories

### DIFF
--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1181,14 +1181,14 @@ void NominalTypeDecl::makeMemberVisible(ValueDecl *member) {
 TinyPtrVector<ValueDecl *> NominalTypeDecl::lookupDirect(
                                                   DeclName name,
                                                   bool ignoreNewExtensions) {
+  (void)getMembers();
+
   // Make sure we have the complete list of members (in this nominal and in all
   // extensions).
   if (!ignoreNewExtensions) {
     for (auto E : getExtensions())
       (void)E->getMembers();
   }
-
-  (void)getMembers();
 
   prepareLookupTable(ignoreNewExtensions);
 

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4361,7 +4361,7 @@ namespace {
         const DeclContext *overrideContext = overridden->getDeclContext();
         // It's okay to compare interface types directly because Objective-C
         // does not have constrained extensions.
-        if (overrideContext != dc && overridden->hasClangNode() && 
+        if (overrideContext != dc && overridden->hasClangNode() &&
             overrideContext->getDeclaredInterfaceType()->isEqual(containerTy)) {
           // We've encountered a redeclaration of the property.
           // HACK: Just update the original declaration instead of importing a
@@ -7591,16 +7591,9 @@ ClangImporter::Implementation::loadAllMembers(Decl *D, uint64_t extra) {
     const NominalTypeDecl *base = ext->getExtendedType()->getAnyNominal();
     if (auto *clangBase = base->getClangDecl()) {
       base->loadAllMembers();
-
-      // Sanity check: make sure we don't jump over to a category /while/
-      // loading the original class's members. Right now we only check if this
-      // happens on the first member.
-      if (auto *clangContainer = dyn_cast<clang::ObjCContainerDecl>(clangBase)){
-        if (!clangContainer->decls_empty()) {
-          assert(!base->getMembers().empty() &&
-                 "can't load extension members before base has finished");
-        }
-      }
+      // FIXME: Assert that we don't jump over to a category /while/
+      // loading the original class's members. Unfortunately there are some
+      // cases where this does happen today.
     }
   }
 

--- a/test/ClangImporter/Inputs/custom-modules/ObjCParseExtras.h
+++ b/test/ClangImporter/Inputs/custom-modules/ObjCParseExtras.h
@@ -26,6 +26,20 @@ __attribute__((objc_root_class))
 + (void)classRef:(id)obj doSomething:(SEL)selector;
 @end
 
+@interface PropertyAndMethodCollisionInOneClass
+- (void)object;
++ (void)classRef;
+@property (getter=getObject) id object;
+@property (class,getter=getClassRef) id classRef;
+@end
+
+@interface PropertyAndMethodReverseCollisionInOneClass
+@property (getter=getObject) id object;
+@property (class,getter=getClassRef) id classRef;
+- (void)object;
++ (void)classRef;
+@end
+
 @protocol PropertyProto
 @property id protoProp;
 @property(readonly) id protoPropRO;

--- a/test/ClangImporter/Inputs/frameworks/PrivatelyReadwrite.framework/Headers/PrivatelyReadwrite.h
+++ b/test/ClangImporter/Inputs/frameworks/PrivatelyReadwrite.framework/Headers/PrivatelyReadwrite.h
@@ -1,0 +1,55 @@
+__attribute__((objc_root_class))
+@interface Base
+- (nonnull instancetype)init;
+@end
+
+@interface GenericClass<T>: Base
+@end
+
+@interface PropertiesInit : Base
+@property (readonly, nonnull) Base *readwriteChange;
+@property (readonly, nonnull) Base *nullabilityChange;
+@property (readonly, nonnull) GenericClass<Base *> *missingGenerics;
+@property (readonly, nonnull) Base *typeChange;
+@end
+
+@interface PropertiesNoInit : Base
+@property (readonly, nonnull) Base *readwriteChange;
+@property (readonly, nonnull) Base *nullabilityChange;
+@property (readonly, nonnull) GenericClass<Base *> *missingGenerics;
+@property (readonly, nonnull) Base *typeChange;
+@end
+
+@interface PropertiesInitGeneric<T> : Base
+@property (readonly, nonnull) Base *readwriteChange;
+@property (readonly, nonnull) Base *nullabilityChange;
+@property (readonly, nonnull) GenericClass<Base *> *missingGenerics;
+@property (readonly, nonnull) Base *typeChange;
+@end
+
+@interface PropertiesNoInitGeneric<T> : Base
+@property (readonly, nonnull) Base *readwriteChange;
+@property (readonly, nonnull) Base *nullabilityChange;
+@property (readonly, nonnull) GenericClass<Base *> *missingGenerics;
+@property (readonly, nonnull) Base *typeChange;
+@end
+
+@interface PropertiesInitCategory : Base
+@end
+
+@interface PropertiesInitCategory (Category)
+@property (readonly, nonnull) Base *readwriteChange;
+@property (readonly, nonnull) Base *nullabilityChange;
+@property (readonly, nonnull) GenericClass<Base *> *missingGenerics;
+@property (readonly, nonnull) Base *typeChange;
+@end
+
+@interface PropertiesNoInitCategory : Base
+@end
+
+@interface PropertiesNoInitCategory (Category)
+@property (readonly, nonnull) Base *readwriteChange;
+@property (readonly, nonnull) Base *nullabilityChange;
+@property (readonly, nonnull) GenericClass<Base *> *missingGenerics;
+@property (readonly, nonnull) Base *typeChange;
+@end

--- a/test/ClangImporter/Inputs/frameworks/PrivatelyReadwrite.framework/Modules/module.modulemap
+++ b/test/ClangImporter/Inputs/frameworks/PrivatelyReadwrite.framework/Modules/module.modulemap
@@ -1,0 +1,7 @@
+framework module PrivatelyReadwrite {
+  umbrella header "PrivatelyReadwrite.h"
+  module * {
+    export *
+  }
+  exclude header "Private.h"
+}

--- a/test/ClangImporter/Inputs/frameworks/PrivatelyReadwrite.framework/PrivateHeaders/Private.h
+++ b/test/ClangImporter/Inputs/frameworks/PrivatelyReadwrite.framework/PrivateHeaders/Private.h
@@ -1,0 +1,46 @@
+#import <PrivatelyReadwrite/PrivatelyReadwrite.h>
+
+@interface PrivateSubclass : Base
+@end
+
+@interface PropertiesInit ()
+@property (readwrite, nonnull) Base *readwriteChange;
+@property (readwrite, nullable) Base *nullabilityChange;
+@property (readwrite, nonnull) GenericClass *missingGenerics;
+@property (readwrite, nonnull) PrivateSubclass *typeChange;
+@end
+
+@interface PropertiesNoInit ()
+@property (readwrite, nonnull) Base *readwriteChange;
+@property (readwrite, nullable) Base *nullabilityChange;
+@property (readwrite, nonnull) GenericClass *missingGenerics;
+@property (readwrite, nonnull) PrivateSubclass *typeChange;
+@end
+
+@interface PropertiesInitGeneric<T> ()
+@property (readwrite, nonnull) Base *readwriteChange;
+@property (readwrite, nullable) Base *nullabilityChange;
+@property (readwrite, nonnull) GenericClass *missingGenerics;
+@property (readwrite, nonnull) PrivateSubclass *typeChange;
+@end
+
+@interface PropertiesNoInitGeneric<T> ()
+@property (readwrite, nonnull) Base *readwriteChange;
+@property (readwrite, nullable) Base *nullabilityChange;
+@property (readwrite, nonnull) GenericClass *missingGenerics;
+@property (readwrite, nonnull) PrivateSubclass *typeChange;
+@end
+
+@interface PropertiesInitCategory ()
+@property (readwrite, nonnull) Base *readwriteChange;
+@property (readwrite, nullable) Base *nullabilityChange;
+@property (readwrite, nonnull) GenericClass *missingGenerics;
+@property (readwrite, nonnull) PrivateSubclass *typeChange;
+@end
+
+@interface PropertiesNoInitCategory ()
+@property (readwrite, nonnull) Base *readwriteChange;
+@property (readwrite, nullable) Base *nullabilityChange;
+@property (readwrite, nonnull) GenericClass *missingGenerics;
+@property (readwrite, nonnull) PrivateSubclass *typeChange;
+@end

--- a/test/ClangImporter/objc_diags.swift
+++ b/test/ClangImporter/objc_diags.swift
@@ -6,5 +6,5 @@ import ObjectiveC
 
 func instanceMethod(_ b: B) {
   b.method(1, 2.5) // expected-error {{argument labels '(_:, _:)' do not match any available overloads}}
-  // expected-note @-1 {{overloads for 'method' exist with these partially matching parameter lists: (Int32, onExtB: Double), (Int32, with: Float), (Int32, withFloat: Float), (Int32, onExtA: Double), (Int32, onCat1: Double), (Int32, with: Double), (Int32, withDouble: Double)}}
+  // expected-note @-1 {{overloads for 'method' exist with these partially matching parameter lists: (Int32, with: Float), (Int32, withFloat: Float), (Int32, onExtB: Double), (Int32, with: Double), (Int32, withDouble: Double), (Int32, onExtA: Double), (Int32, onCat1: Double)}}
 }

--- a/test/ClangImporter/objc_parse.swift
+++ b/test/ClangImporter/objc_parse.swift
@@ -403,6 +403,23 @@ func testPropertyAndMethodCollision(_ obj: PropertyAndMethodCollision,
   _ = value
 }
 
+func testPropertyAndMethodCollisionInOneClass(
+  obj: PropertyAndMethodCollisionInOneClass,
+  rev: PropertyAndMethodReverseCollisionInOneClass
+) {
+  obj.object = nil
+  obj.object()
+
+  type(of: obj).classRef = nil
+  type(of: obj).classRef()
+
+  rev.object = nil
+  rev.object()
+
+  type(of: rev).classRef = nil
+  type(of: rev).classRef()
+}
+
 func testSubscriptAndPropertyRedeclaration(_ obj: SubscriptAndProperty) {
   _ = obj.x
   obj.x = 5

--- a/test/ClangImporter/objc_redeclared_properties_incompatible.swift
+++ b/test/ClangImporter/objc_redeclared_properties_incompatible.swift
@@ -1,0 +1,103 @@
+// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -F %S/Inputs/frameworks %s 2>&1 | %FileCheck -check-prefix=CHECK -check-prefix=CHECK-PUBLIC %s
+
+// RUN: echo '#import <PrivatelyReadwrite/Private.h>' > %t.h
+// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -F %S/Inputs/frameworks -import-objc-header %t.h %s 2>&1 | %FileCheck -check-prefix=CHECK -check-prefix=CHECK-PRIVATE %s
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-pch -F %S/Inputs/frameworks -o %t.pch %t.h
+// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -F %S/Inputs/frameworks -import-objc-header %t.pch %s 2>&1 | %FileCheck -check-prefix=CHECK -check-prefix=CHECK-PRIVATE %s
+
+// REQUIRES: objc_interop
+
+import PrivatelyReadwrite
+
+// In the original bug, it made a difference whether the type was instantiated;
+// it resulted in members being imported in a different order.
+func testWithInitializer() {
+  let obj = PropertiesInit()
+
+  let _: Int = obj.nullabilityChange
+  // CHECK: [[@LINE-1]]:20: error: cannot convert value of type 'Base' to specified type 'Int'
+
+  let _: Int = obj.missingGenerics
+  // CHECK: [[@LINE-1]]:20: error: cannot convert value of type 'GenericClass<Base>' to specified type 'Int'
+
+  let _: Int = obj.typeChange
+  // CHECK: [[@LINE-1]]:20: error: cannot convert value of type 'Base' to specified type 'Int'
+
+  obj.readwriteChange = Base() // CHECK-PRIVATE-NOT: [[@LINE]]:{{.+}}: error
+  // CHECK-PUBLIC: [[@LINE-1]]:23: error: cannot assign to property: 'readwriteChange' is a get-only property
+}
+
+func testWithoutInitializer(obj: PropertiesNoInit) {
+  let _: Int = obj.nullabilityChange
+  // CHECK: [[@LINE-1]]:20: error: cannot convert value of type 'Base' to specified type 'Int'
+
+  let _: Int = obj.missingGenerics
+  // CHECK: [[@LINE-1]]:20: error: cannot convert value of type 'GenericClass<Base>' to specified type 'Int'
+
+  let _: Int = obj.typeChange
+  // CHECK: [[@LINE-1]]:20: error: cannot convert value of type 'Base' to specified type 'Int'
+
+  obj.readwriteChange = Base() // CHECK-PRIVATE-NOT: [[@LINE]]:{{.+}}: error
+  // CHECK-PUBLIC: [[@LINE-1]]:23: error: cannot assign to property: 'readwriteChange' is a get-only property
+}
+
+func testGenericWithInitializer() {
+  let obj = PropertiesInitGeneric<Base>()
+
+  let _: Int = obj.nullabilityChange
+  // CHECK: [[@LINE-1]]:20: error: cannot convert value of type 'Base' to specified type 'Int'
+
+  let _: Int = obj.missingGenerics
+  // CHECK: [[@LINE-1]]:20: error: cannot convert value of type 'GenericClass<Base>' to specified type 'Int'
+
+  let _: Int = obj.typeChange
+  // CHECK: [[@LINE-1]]:20: error: cannot convert value of type 'Base' to specified type 'Int'
+
+  obj.readwriteChange = Base() // CHECK-PRIVATE-NOT: [[@LINE]]:{{.+}}: error
+  // CHECK-PUBLIC: [[@LINE-1]]:23: error: cannot assign to property: 'readwriteChange' is a get-only property
+}
+
+func testGenericWithoutInitializer(obj: PropertiesNoInitGeneric<Base>) {
+  let _: Int = obj.nullabilityChange
+  // CHECK: [[@LINE-1]]:20: error: cannot convert value of type 'Base' to specified type 'Int'
+
+  let _: Int = obj.missingGenerics
+  // CHECK: [[@LINE-1]]:20: error: cannot convert value of type 'GenericClass<Base>' to specified type 'Int'
+
+  let _: Int = obj.typeChange
+  // CHECK: [[@LINE-1]]:20: error: cannot convert value of type 'Base' to specified type 'Int'
+
+  obj.readwriteChange = Base() // CHECK-PRIVATE-NOT: [[@LINE]]:{{.+}}: error
+  // CHECK-PUBLIC: [[@LINE-1]]:23: error: cannot assign to property: 'readwriteChange' is a get-only property
+}
+
+func testCategoryWithInitializer() {
+  let obj = PropertiesInitCategory()
+
+  let _: Int = obj.nullabilityChange
+  // CHECK: [[@LINE-1]]:20: error: cannot convert value of type 'Base' to specified type 'Int'
+
+  let _: Int = obj.missingGenerics
+  // CHECK: [[@LINE-1]]:20: error: cannot convert value of type 'GenericClass<Base>' to specified type 'Int'
+
+  let _: Int = obj.typeChange
+  // CHECK: [[@LINE-1]]:20: error: cannot convert value of type 'Base' to specified type 'Int'
+
+  obj.readwriteChange = Base() // CHECK-PRIVATE-NOT: [[@LINE]]:{{.+}}: error
+  // CHECK-PUBLIC: [[@LINE-1]]:23: error: cannot assign to property: 'readwriteChange' is a get-only property
+}
+
+func testCategoryWithoutInitializer(obj: PropertiesNoInitCategory) {
+  let _: Int = obj.nullabilityChange
+  // CHECK: [[@LINE-1]]:20: error: cannot convert value of type 'Base' to specified type 'Int'
+
+  let _: Int = obj.missingGenerics
+  // CHECK: [[@LINE-1]]:20: error: cannot convert value of type 'GenericClass<Base>' to specified type 'Int'
+
+  let _: Int = obj.typeChange
+  // CHECK: [[@LINE-1]]:20: error: cannot convert value of type 'Base' to specified type 'Int'
+
+  obj.readwriteChange = Base() // CHECK-PRIVATE-NOT: [[@LINE]]:{{.+}}: error
+  // CHECK-PUBLIC: [[@LINE-1]]:23: error: cannot assign to property: 'readwriteChange' is a get-only property
+}


### PR DESCRIPTION
Cherry-pick of #8444 to swift-4.0-branch for testing purposes, along with #8468 that disables the problematic assertion I added. I still don't consider this finished until there's a way to turn on that assertion again, but this will at least keep the 4.0 branch from running into the original issue in rdar://problem/30785976.