### PR TITLE
[sil] Require that a mark_uninitialized of a project_box must be the project_box's only user.

### DIFF
--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -1556,6 +1556,17 @@ public:
     require(I->getType() == boxTy->getFieldType(F.getModule(),
                                                 I->getFieldIndex()),
             "project_box result should be address of boxed type");
+
+    // If we have a mark_uninitialized as a user, the mark_uninitialized must be
+    // our only user. This is a requirement that is asserted by allocbox to
+    // stack. This check just embeds the requirement into the IR.
+    require(I->hasOneUse() ||
+            none_of(I->getUses(),
+                    [](Operand *Op) -> bool {
+                      return isa<MarkUninitializedInst>(Op->getUser());
+                    }),
+            "project_box with more than one user when a user is a "
+            "mark_uninitialized");
   }
 
   void checkProjectExistentialBoxInst(ProjectExistentialBoxInst *PEBI) {


### PR DESCRIPTION
[sil] Require that a mark_uninitialized of a project_box must be the project_box's only user.

This is already asserted by AllocBoxToStack and hinting at in other passes.
Rather than having the requirement be cargo-culted around, this commit just
reifies the requirement into an assert check.

rdar://29870610