### PR TITLE
[GSB] Don't emit same-type-to-concrete requirements for nested types.

### DIFF
--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -4092,11 +4092,10 @@ void GenericSignatureBuilder::enumerateRequirements(llvm::function_ref<
       // If this equivalence class is bound to a concrete type, equate the
       // anchor with a concrete type.
       if (Type concreteType = rep->getConcreteType()) {
-        // If the parent of this anchor is also in the equivalence class,
-        // don't create a requirement... it's covered by the "parent"
-        // relationship.
+        // If the parent of this anchor is also a concrete type, don't
+        // create a requirement.
         if (!archetype->isGenericParam() &&
-            archetype->getParent()->getRepresentative() == rep)
+            archetype->getParent()->isConcreteType())
           continue;
 
         auto source =

--- a/test/Prototypes/CollectionTransformers.swift
+++ b/test/Prototypes/CollectionTransformers.swift
@@ -11,8 +11,6 @@
 //===----------------------------------------------------------------------===//
 // RUN: %target-run-stdlib-swift
 // REQUIRES: executable_test
-// Remove XFAIL once rdar://31286125 is resolved.
-// REQUIRES: rdar31286125
 
 // FIXME: This test runs very slowly on watchOS.
 // UNSUPPORTED: OS=watchos


### PR DESCRIPTION
When enumerating same-type-to-concrete requirements, don't emit a
same-type-to-concrete requirement for a nested archetype anchor when
it's parent also is equivalent to a concrete type, because the former
can always be derived from the latter.

Fixes SR-4456 / rdar://problem/31286125.
