### PR TITLE
[ClangImporter] Don't do a full conformance check for swift_wrapper types.

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -718,7 +718,7 @@ ClangImporter::create(ASTContext &ctx,
   addCommonInvocationArguments(invocationArgStrs, ctx, importerOpts);
 
   if (importerOpts.DumpClangDiagnostics) {
-    llvm::errs() << "clang '";
+    llvm::errs() << "'";
     interleave(invocationArgStrs,
                [](StringRef arg) { llvm::errs() << arg; },
                [] { llvm::errs() << "' '"; });

--- a/test/ClangImporter/Inputs/MoreSwiftNewtypes_conformances.swift
+++ b/test/ClangImporter/Inputs/MoreSwiftNewtypes_conformances.swift
@@ -1,0 +1,41 @@
+// Helper for newtype_conformance.swift
+
+@_exported import MoreSwiftNewtypes
+import Foundation
+
+extension UnbridgedNonNSObject: Equatable /* but not Hashable */ {
+  public static func ==(lhs: UnbridgedNonNSObject, rhs: UnbridgedNonNSObject) -> Bool { return true }
+}
+
+// Pick something other than "Equatable" to test that we're not just looking at
+// immediately inherited protocols.
+protocol EquatablePlus: Equatable {}
+
+public struct BridgedValue : EquatablePlus /* but not Hashable */ {
+  public static func ==(lhs: BridgedValue, rhs: BridgedValue) -> Bool { return true }
+}
+
+extension BridgedValue: _ObjectiveCBridgeable {
+  public func _bridgeToObjectiveC() -> BridgedNonNSObject {
+    return BridgedNonNSObject()
+  }
+
+  public static func _forceBridgeFromObjectiveC(
+    _ x: BridgedNonNSObject,
+    result: inout BridgedValue?) {
+  }
+
+  public static func _conditionallyBridgeFromObjectiveC(
+    _ x: BridgedNonNSObject,
+    result: inout BridgedValue?
+  ) -> Bool {
+    return true
+  }
+
+  public static func _unconditionallyBridgeFromObjectiveC(_ source: BridgedNonNSObject?)
+      -> BridgedValue {
+    var result: BridgedValue?
+    _forceBridgeFromObjectiveC(source!, result: &result)
+    return result!
+  }
+}

--- a/test/ClangImporter/Inputs/MoreSwiftNewtypes_tests.swift
+++ b/test/ClangImporter/Inputs/MoreSwiftNewtypes_tests.swift
@@ -1,0 +1,24 @@
+// Helper for newtype_conformance.swift
+
+@_exported import MoreSwiftNewtypes
+
+func acceptEquatable<T: Equatable>(_: T) {}
+
+func testEquatable(wrappedRef: WrappedRef, wrappedValue: WrappedValue) {
+  acceptEquatable(wrappedRef)
+  acceptEquatable(wrappedValue)
+}
+
+
+func intIfNonHashable<T>(_: T) -> Int { return 0 }
+func intIfNonHashable<T: Hashable>(_: T) -> Bool { return false }
+
+func testNotHashable(wrappedRef: WrappedRef, wrappedValue: WrappedValue) {
+  let refResult = intIfNonHashable(wrappedRef)
+  let _: Int = refResult
+  let valueResult = intIfNonHashable(wrappedValue)
+  let _: Int = valueResult
+
+  let baselineResult = intIfNonHashable(0)
+  let _: Bool = baselineResult
+}

--- a/test/ClangImporter/Inputs/custom-modules/MoreSwiftNewtypes.h
+++ b/test/ClangImporter/Inputs/custom-modules/MoreSwiftNewtypes.h
@@ -1,0 +1,16 @@
+@import Foundation;
+
+__attribute__((objc_root_class))
+@interface Base
+- (instancetype)init;
+@end
+
+@interface UnbridgedNonNSObject : Base
+@end
+
+__attribute__((swift_bridge("BridgedValue")))
+@interface BridgedNonNSObject : Base
+@end
+
+typedef UnbridgedNonNSObject *WrappedRef __attribute__((swift_wrapper(struct)));
+typedef BridgedNonNSObject *WrappedValue __attribute__((swift_wrapper(struct)));

--- a/test/ClangImporter/Inputs/custom-modules/module.map
+++ b/test/ClangImporter/Inputs/custom-modules/module.map
@@ -69,6 +69,10 @@ module MissingHeader {
   header "this-header-does-not-exist.h"
 }
 
+module MoreSwiftNewtypes {
+  header "MoreSwiftNewtypes.h"
+}
+
 module Newtype {
   header "Newtype.h"
 }

--- a/test/ClangImporter/newtype_conformance.swift
+++ b/test/ClangImporter/newtype_conformance.swift
@@ -1,12 +1,15 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/custom-modules %s
+// RUN: rm -rf %t && mkdir -p %t
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/custom-modules -primary-file %S/Inputs/MoreSwiftNewtypes_conformances.swift %S/Inputs/MoreSwiftNewtypes_tests.swift -module-name MoreSwiftNewtypes
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/custom-modules %S/Inputs/MoreSwiftNewtypes_conformances.swift -primary-file %S/Inputs/MoreSwiftNewtypes_tests.swift -module-name MoreSwiftNewtypes
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -I %S/Inputs/custom-modules -o %t %S/Inputs/MoreSwiftNewtypes_conformances.swift %S/Inputs/MoreSwiftNewtypes_tests.swift -module-name MoreSwiftNewtypes
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/custom-modules -I %t %s -verify
+
 // REQUIRES: objc_interop
 
-// This test can't use '-verify' mode, because the potential error wouldn't
-// belong to any file.
-// e.g.:
-//   <unknown>:0: error: type 'NSNotification.Name' does not conform to protocol 'Comparable'
-
 import Foundation
+import MoreSwiftNewtypes
 
 func acceptEquatable<T: Equatable>(_: T) {}
 func acceptHashable<T: Hashable>(_: T) {}
@@ -25,4 +28,12 @@ func testNewTypeWrapperComparable(x: NSNotification.Name, y: NSNotification.Name
   _ = x <= y
   _ = x >= y
   _ = x as NSString
+}
+
+
+func testCustomWrappers(wrappedRef: WrappedRef, wrappedValue: WrappedValue) {
+  acceptEquatable(wrappedRef)
+  acceptEquatable(wrappedValue)
+  acceptHashable(wrappedRef) // expected-error {{does not conform to expected type 'Hashable'}}
+  acceptHashable(wrappedValue) // expected-error {{does not conform to expected type 'Hashable'}}
 }


### PR DESCRIPTION
Avoids yet another circular import issue: conformance on type X -> associated types -> members -> members of superclass type (for naming conflicts) -> SwiftWrapper type -> conformances on underlying type X. Normally this circularity is fine, but I still want to put back the assertion I reverted in #8468.

Still needs tests, although I don't have a reduced version of the circularity issue. I mostly just want to make sure this doesn't perturb the way existing bridged types are imported.

More rdar://problem/30785976
