### PR TITLE
[AST] Start using conformance access paths in SubstitutionMap

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -208,10 +208,6 @@ ERROR(decl_already_static,none,
 ERROR(enum_case_dot_prefix,none,
       "extraneous '.' in enum 'case' declaration", ())
 
-ERROR(protocol_associatedtype_where_swift_3,none,
-      "where clauses on %0 are fragile; use '-swift-version 4' to experiment.", (StringRef))
-
-
 // Variable getters/setters
 ERROR(static_var_decl_global_scope,none,
       "%select{%error|static properties|class properties}0 may only be declared on a type",

--- a/include/swift/AST/GenericEnvironment.h
+++ b/include/swift/AST/GenericEnvironment.h
@@ -142,8 +142,6 @@ class alignas(1 << DeclAlignInBits) GenericEnvironment final
   };
   friend class QueryArchetypeToInterfaceSubstitutions;
 
-  void populateParentMap(SubstitutionMap &subMap) const;
-
 public:
   GenericSignature *getGenericSignature() const {
     return Signature;

--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -285,6 +285,9 @@ public:
   /// must conform.
   ConformsToArray getConformsTo(Type type, ModuleDecl &mod);
 
+  /// Determine whether the given dependent type conforms to this protocol.
+  bool conformsToProtocol(Type type, ProtocolDecl *proto, ModuleDecl &mod);
+
   /// Determine whether the given dependent type is equal to a concrete type.
   bool isConcreteType(Type type, ModuleDecl &mod);
 

--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -134,8 +134,6 @@ class alignas(1 << TypeAlignInBits) GenericSignature final
   /// Retrieve the generic signature builder for the given generic signature.
   GenericSignatureBuilder *getGenericSignatureBuilder(ModuleDecl &mod);
 
-  void populateParentMap(SubstitutionMap &subMap) const;
-
   friend class ArchetypeType;
 
 public:

--- a/include/swift/AST/SubstitutionMap.h
+++ b/include/swift/AST/SubstitutionMap.h
@@ -55,33 +55,10 @@ class SubstitutionMap {
   /// are performing substitutions.
   llvm::PointerUnion<GenericSignature *, GenericEnvironment *> genericSigOrEnv;
 
-  using ParentType = std::pair<CanType, AssociatedTypeDecl *>;
-
   // FIXME: Switch to a more efficient representation.
   llvm::DenseMap<SubstitutableType *, Type> subMap;
   llvm::DenseMap<TypeBase *, SmallVector<ProtocolConformanceRef, 1>>
     conformanceMap;
-  llvm::DenseMap<TypeBase *, SmallVector<ParentType, 1>> parentMap;
-
-  // Call the given function for each parent of the given type. The
-  // function \c fn should return an \c Optional<T>. \c forEachParent() will
-  // return the first non-empty \C Optional<T> returned by \c fn.
-  template<typename T>
-  Optional<T> forEachParent(
-                CanType type,
-                llvm::SmallPtrSetImpl<CanType> &visitedParents,
-                llvm::function_ref<Optional<T>(CanType,
-                                               AssociatedTypeDecl *)> fn) const;
-
-  // Call the given function for each conformance of the given type. The
-  // function \c fn should return an \c Optional<T>. \c forEachConformance()
-  // will return the first non-empty \C Optional<T> returned by \c fn.
-  template<typename T>
-  Optional<T> forEachConformance(
-                  CanType type,
-                  llvm::SmallPtrSetImpl<CanType> &visitedParents,
-                  llvm::function_ref<Optional<T>(ProtocolConformanceRef)> fn)
-                const;
 
 public:
   SubstitutionMap()
@@ -96,9 +73,7 @@ public:
   GenericSignature *getGenericSignature() const;
 
   Optional<ProtocolConformanceRef>
-  lookupConformance(
-                CanType type, ProtocolDecl *proto,
-                llvm::SmallPtrSetImpl<CanType> *visitedParents = nullptr) const;
+  lookupConformance(CanType type, ProtocolDecl *proto) const;
 
   bool empty() const {
     return subMap.empty();
@@ -194,8 +169,6 @@ private:
 
   void addSubstitution(CanSubstitutableType type, Type replacement);
   void addConformance(CanType type, ProtocolConformanceRef conformance);
-  void addParent(CanType type, CanType parent,
-                 AssociatedTypeDecl *assocType);
 };
 
 } // end namespace swift

--- a/include/swift/AST/SubstitutionMap.h
+++ b/include/swift/AST/SubstitutionMap.h
@@ -51,6 +51,10 @@ enum class CombineSubstitutionMaps {
 };
 
 class SubstitutionMap {
+  /// The generic signature (or full-fledged environment) for which we
+  /// are performing substitutions.
+  llvm::PointerUnion<GenericSignature *, GenericEnvironment *> genericSigOrEnv;
+
   using ParentType = std::pair<CanType, AssociatedTypeDecl *>;
 
   // FIXME: Switch to a more efficient representation.
@@ -80,6 +84,17 @@ class SubstitutionMap {
                 const;
 
 public:
+  SubstitutionMap()
+    : SubstitutionMap(static_cast<GenericSignature *>(nullptr)) { }
+
+  SubstitutionMap(llvm::PointerUnion<GenericSignature *, GenericEnvironment *>
+                    genericSigOrEnv)
+    : genericSigOrEnv(genericSigOrEnv) { }
+
+  /// Retrieve the generic signature describing the environment in which
+  /// substitutions occur.
+  GenericSignature *getGenericSignature() const;
+
   Optional<ProtocolConformanceRef>
   lookupConformance(
                 CanType type, ProtocolDecl *proto,

--- a/lib/AST/GenericEnvironment.cpp
+++ b/lib/AST/GenericEnvironment.cpp
@@ -393,7 +393,7 @@ void GenericEnvironment::populateParentMap(SubstitutionMap &subMap) const {
 
 SubstitutionMap GenericEnvironment::
 getSubstitutionMap(SubstitutionList subs) const {
-  SubstitutionMap result;
+  SubstitutionMap result(const_cast<GenericEnvironment *>(this));
 
   getGenericSignature()->enumeratePairedRequirements(
     [&](Type depTy, ArrayRef<Requirement> reqts) -> bool {
@@ -428,7 +428,7 @@ SubstitutionMap
 GenericEnvironment::
 getSubstitutionMap(TypeSubstitutionFn subs,
                    GenericSignature::LookupConformanceFn lookupConformance) const {
-  SubstitutionMap subMap;
+  SubstitutionMap subMap(const_cast<GenericEnvironment *>(this));
 
   getGenericSignature()->enumeratePairedRequirements(
     [&](Type depTy, ArrayRef<Requirement> reqs) -> bool {

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -554,6 +554,28 @@ SmallVector<ProtocolDecl *, 2> GenericSignature::getConformsTo(Type type,
   return result;
 }
 
+bool GenericSignature::conformsToProtocol(Type type, ProtocolDecl *proto,
+                                          ModuleDecl &mod) {
+  // FIXME: Deal with concrete conformances here?
+  if (!type->isTypeParameter()) return false;
+
+  auto &builder = *getGenericSignatureBuilder(mod);
+  auto pa = builder.resolveArchetype(type);
+  if (!pa) return false;
+
+  pa = pa->getRepresentative();
+
+  // FIXME: Deal with concrete conformances here?
+  if (pa->isConcreteType()) return false;
+
+  // Check whether the representative conforms to this protocol.
+  if (auto equivClass = pa->getEquivalenceClassIfPresent())
+    if (equivClass->conformsTo.count(proto) > 0)
+      return true;
+
+  return false;
+}
+
 /// Determine whether the given dependent type is equal to a concrete type.
 bool GenericSignature::isConcreteType(Type type, ModuleDecl &mod) {
   return bool(getConcreteType(type, mod));

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -404,7 +404,7 @@ void GenericSignature::populateParentMap(SubstitutionMap &subMap) const {
 
 SubstitutionMap
 GenericSignature::getSubstitutionMap(SubstitutionList subs) const {
-  SubstitutionMap result;
+  SubstitutionMap result(const_cast<GenericSignature *>(this));
 
   enumeratePairedRequirements(
     [&](Type depTy, ArrayRef<Requirement> reqts) -> bool {
@@ -432,7 +432,7 @@ SubstitutionMap
 GenericSignature::
 getSubstitutionMap(TypeSubstitutionFn subs,
                    GenericSignature::LookupConformanceFn lookupConformance) const {
-  SubstitutionMap subMap;
+  SubstitutionMap subMap(const_cast<GenericSignature *>(this));
 
   // Enumerate all of the requirements that require substitution.
   enumeratePairedRequirements([&](Type depTy, ArrayRef<Requirement> reqs) {

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -377,31 +377,6 @@ bool GenericSignature::enumeratePairedRequirements(
   return enumerateGenericParamsUpToDependentType(CanType());
 }
 
-void GenericSignature::populateParentMap(SubstitutionMap &subMap) const {
-  for (auto reqt : getRequirements()) {
-    if (reqt.getKind() != RequirementKind::SameType)
-      continue;
-
-    auto first = reqt.getFirstType();
-    auto second = reqt.getSecondType();
-
-    if (!first->isTypeParameter() || !second->isTypeParameter())
-      continue;
-
-    if (auto *firstMemTy = first->getAs<DependentMemberType>()) {
-      subMap.addParent(second->getCanonicalType(),
-                       firstMemTy->getBase()->getCanonicalType(),
-                       firstMemTy->getAssocType());
-    }
-
-    if (auto *secondMemTy = second->getAs<DependentMemberType>()) {
-      subMap.addParent(first->getCanonicalType(),
-                       secondMemTy->getBase()->getCanonicalType(),
-                       secondMemTy->getAssocType());
-    }
-  }
-}
-
 SubstitutionMap
 GenericSignature::getSubstitutionMap(SubstitutionList subs) const {
   SubstitutionMap result(const_cast<GenericSignature *>(this));
@@ -423,7 +398,6 @@ GenericSignature::getSubstitutionMap(SubstitutionList subs) const {
     });
 
   assert(subs.empty() && "did not use all substitutions?!");
-  populateParentMap(result);
   result.verify();
   return result;
 }
@@ -458,7 +432,6 @@ getSubstitutionMap(TypeSubstitutionFn subs,
     return false;
   });
 
-  populateParentMap(subMap);
   subMap.verify();
   return subMap;
 }

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -3530,11 +3530,11 @@ static PotentialArchetype *sameTypeDFS(PotentialArchetype *pa,
     // Skip non-derived constraints.
     if (!constraint.source->isDerivedRequirement()) continue;
 
-    sameTypeDFS(constraint.value, component, paToComponent);
+    auto newAnchor = sameTypeDFS(constraint.value, component, paToComponent);
 
     // If this type is better than the anchor, use it for the anchor.
-    if (compareDependentTypes(&constraint.value, &anchor) < 0)
-      anchor = constraint.value;
+    if (compareDependentTypes(&newAnchor, &anchor) < 0)
+      anchor = newAnchor;
   }
 
   return anchor;

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -473,6 +473,8 @@ NormalProtocolConformance::getAssociatedConformance(Type assocType,
                                                 LazyResolver *resolver) const {
   assert(assocType->isTypeParameter() &&
          "associated type must be a type parameter");
+  assert(!getSignatureConformances().empty() &&
+         "signature conformances not yet computed");
 
   unsigned conformanceIndex = 0;
   for (auto &reqt :

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -647,9 +647,22 @@ ProtocolConformanceRef
 InheritedProtocolConformance::getAssociatedConformance(Type assocType,
                          ProtocolDecl *protocol,
                          LazyResolver *resolver) const {
-  // FIXME: Substitute!
-  return InheritedConformance->getAssociatedConformance(assocType, protocol,
-                                                        resolver);
+  auto underlying =
+    InheritedConformance->getAssociatedConformance(assocType, protocol,
+                                                   resolver);
+
+
+  // If the conformance is for Self, return an inherited conformance.
+  if (underlying.isConcrete() &&
+      assocType->isEqual(getProtocol()->getSelfInterfaceType())) {
+    auto subclassType = getType();
+    ASTContext &ctx = subclassType->getASTContext();
+    return ProtocolConformanceRef(
+             ctx.getInheritedConformance(subclassType,
+                                         underlying.getConcrete()));
+  }
+
+  return underlying;
 }
 
 const NormalProtocolConformance *

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -162,6 +162,11 @@ SubstitutionMap::lookupConformance(CanType type, ProtocolDecl *proto) const {
     if (normal->getSignatureConformances().empty()) {
       auto lazyResolver = canonType->getASTContext().getLazyResolver();
       lazyResolver->resolveTypeWitness(normal, nullptr);
+
+      // Error case: the conformance is broken, so we cannot handle this
+      // substitution.
+      if (normal->getSignatureConformances().empty())
+        return None;
     }
 
     // Get the associated conformance.

--- a/lib/Parse/ParseGeneric.cpp
+++ b/lib/Parse/ParseGeneric.cpp
@@ -393,11 +393,5 @@ ParserStatus Parser::parseProtocolOrAssociatedTypeWhereClause(
     }
   }
 
-  if (Context.isSwiftVersion3()) {
-    diagnose(whereLoc, diag::protocol_associatedtype_where_swift_3,
-             isProtocol ? "protocols" : "associated types");
-    // There's nothing to see here, move along.
-    trailingWhere = nullptr;
-  }
   return ParserStatus();
 }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -6187,7 +6187,10 @@ void TypeChecker::resolveTypeWitness(
                        *this, 
                        const_cast<NormalProtocolConformance*>(conformance),
                        MissingWitnesses);
-  checker.resolveSingleTypeWitness(assocType);
+  if (!assocType)
+    checker.resolveTypeWitnesses();
+  else
+    checker.resolveSingleTypeWitness(assocType);
 }
 
 void TypeChecker::resolveWitness(const NormalProtocolConformance *conformance,

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4899,7 +4899,9 @@ void ConformanceChecker::ensureRequirementsAreSatisfied() {
       // FIXME: maybe this should be the conformance's type
       proto->getDeclaredInterfaceType(), reqSig,
       QuerySubstitutionMap{substitutions},
-      LookUpConformanceInSubstitutionMap{substitutions}, nullptr,
+      LookUpConformanceInModule(
+        Conformance->getDeclContext()->getParentModule()),
+      nullptr,
       ConformanceCheckFlags::Used, &listener);
 
   // If there were no errors, record the conformances.

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1344,6 +1344,10 @@ public:
   /// Resolve the inherited protocols of a given protocol.
   void resolveInheritedProtocols(ProtocolDecl *protocol) override;
 
+  /// Validate a protocol's where clause, along with the where clauses of
+  /// its associated types.
+  void validateWhereClauses(ProtocolDecl *protocol);
+
   /// Resolve the types in the inheritance clause of the given
   /// declaration context, which will be a nominal type declaration or
   /// extension declaration.

--- a/test/Generics/invalid.swift
+++ b/test/Generics/invalid.swift
@@ -7,9 +7,11 @@ typealias gimel where A : B // expected-error {{'where' clause cannot be attache
 
 class dalet where A : B {} // expected-error {{'where' clause cannot be attached to a non-generic declaration}}
 
-protocol he where A : B { // expected-error {{where clauses on protocols are fragile; use '-swift-version 4' to experiment.}}
+protocol he where A : B { // expected-error 2 {{use of undeclared type 'A'}}
+  // expected-error@-1 3{{type 'A' in conformance requirement does not refer to a generic parameter or associated type}}
 
-  associatedtype vav where A : B // expected-error {{where clauses on associated types are fragile; use '-swift-version 4' to experiment.}}
+  associatedtype vav where A : B // expected-error{{use of undeclared type 'A'}}
+    // expected-error@-1 3{{type 'A' in conformance requirement does not refer to a generic parameter or associated type}}
 }
 
 

--- a/test/Generics/protocol_where_clause.swift
+++ b/test/Generics/protocol_where_clause.swift
@@ -65,3 +65,12 @@ struct BadConcreteNestedConforms: NestedConforms {
   // expected-error@-1 {{type 'ConcreteParentNonFoo2.T' (aka 'Float') does not conform to protocol 'Foo2'}}
   typealias U = ConcreteParentNonFoo2
 }
+
+// <rdar://problem/31041997> Some where-clause requirements aren't checked on conforming types
+protocol P1 {}
+protocol P2 { associatedtype T }
+protocol P3 { associatedtype U }
+protocol P4: P3 where U: P2, U.T: P1 {}
+
+struct X: P2 { typealias T = Int }
+struct Y: P4 { typealias U = X } // expected-error{{type 'X.T' (aka 'Int') does not conform to protocol 'P1'}}

--- a/test/Generics/protocol_where_clause.swift
+++ b/test/Generics/protocol_where_clause.swift
@@ -53,6 +53,7 @@ struct BadConcreteSameType: SameType { // expected-error{{'SameType' requires th
   typealias U = Float
 }
 
+// <rdar://problem/31041997> Some where-clause requirements aren't checked on conforming types
 protocol NestedConforms: SecondParent where U: Parent, U.T: Foo2 {}
 func needsNestedConforms<X: NestedConforms>(_: X.Type) {
   needsParent(X.U.self)
@@ -65,12 +66,3 @@ struct BadConcreteNestedConforms: NestedConforms {
   // expected-error@-1 {{type 'ConcreteParentNonFoo2.T' (aka 'Float') does not conform to protocol 'Foo2'}}
   typealias U = ConcreteParentNonFoo2
 }
-
-// <rdar://problem/31041997> Some where-clause requirements aren't checked on conforming types
-protocol P1 {}
-protocol P2 { associatedtype T }
-protocol P3 { associatedtype U }
-protocol P4: P3 where U: P2, U.T: P1 {}
-
-struct X: P2 { typealias T = Int }
-struct Y: P4 { typealias U = X } // expected-error{{type 'X.T' (aka 'Int') does not conform to protocol 'P1'}}

--- a/test/SILOptimizer/specialize_inherited.sil
+++ b/test/SILOptimizer/specialize_inherited.sil
@@ -39,7 +39,7 @@ bb0(%0 : $Int, %1 : $Int):
 
 // CHECK-LABEL: @_T06callee7inherit8MMStringC_SQyAB6MMFontCGTg5 : $@convention(method) (@owned MMString, Int, @owned MMStorage<MMString, ImplicitlyUnwrappedOptional<MMFont>>) -> Bool {
 // CHECK: [[META:%[0-9]+]] = metatype $@thick MMString.Type
-// CHECK: [[ID3:%[0-9]+]] = witness_method $MMObject, #Equatable."=="!1 :
+// CHECK: [[ID3:%[0-9]+]] = witness_method $MMString, #Equatable."=="!1 :
 // CHECK: [[STACK2:%[0-9]+]] = alloc_stack $MMString
 // CHECK: [[STACK3:%[0-9]+]] = alloc_stack $MMString
 // CHECK: apply [[ID3]]<MMString>([[STACK2]], [[STACK3]], [[META]]) : $@convention(witness_method) <τ_0_0 where τ_0_0 : Equatable> (@in τ_0_0, @in τ_0_0, @thick τ_0_0.Type) -> Bool

--- a/test/SILOptimizer/specialize_inherited.sil
+++ b/test/SILOptimizer/specialize_inherited.sil
@@ -39,7 +39,7 @@ bb0(%0 : $Int, %1 : $Int):
 
 // CHECK-LABEL: @_T06callee7inherit8MMStringC_SQyAB6MMFontCGTg5 : $@convention(method) (@owned MMString, Int, @owned MMStorage<MMString, ImplicitlyUnwrappedOptional<MMFont>>) -> Bool {
 // CHECK: [[META:%[0-9]+]] = metatype $@thick MMString.Type
-// CHECK: [[ID3:%[0-9]+]] = witness_method $MMString, #Equatable."=="!1 :
+// CHECK: [[ID3:%[0-9]+]] = witness_method $MMObject, #Equatable."=="!1 :
 // CHECK: [[STACK2:%[0-9]+]] = alloc_stack $MMString
 // CHECK: [[STACK3:%[0-9]+]] = alloc_stack $MMString
 // CHECK: apply [[ID3]]<MMString>([[STACK2]], [[STACK3]], [[META]]) : $@convention(witness_method) <τ_0_0 where τ_0_0 : Equatable> (@in τ_0_0, @in τ_0_0, @thick τ_0_0.Type) -> Bool


### PR DESCRIPTION
Reimplement `SubstitutionMap::lookupConformance()` in terms of the `ConformanceAccessPath`, eliminating the ugly "parent map" hack and ensuring that all stages of substitutions are depending on the same core abstractions (`GenericSignature`, `ConformanceAccessPath`.

While here, remove the error blocking the use of associated type where clauses [SE-0142](https://github.com/apple/swift-evolution/blob/master/proposals/0142-associated-types-constraints.md), because we should be able to start experimenting with them in earnest now regardless of language mode.

Fixes rdar://problem/31041997 and rdar://problem/31309863.