### PR TITLE
Small Type::subst() fixes

### DIFF
--- a/include/swift/AST/Requirement.h
+++ b/include/swift/AST/Requirement.h
@@ -98,15 +98,14 @@ public:
       return None;
 
     switch (getKind()) {
+    case RequirementKind::Conformance:
+    case RequirementKind::Superclass:
     case RequirementKind::SameType: {
       auto newSecond = getSecondType().subst(std::forward<Args>(args)...);
       if (!newSecond)
         return None;
       return Requirement(getKind(), newFirst, newSecond);
     }
-    case RequirementKind::Conformance:
-    case RequirementKind::Superclass:
-      return Requirement(getKind(), newFirst, getSecondType());
     case RequirementKind::Layout:
       return Requirement(getKind(), newFirst, getLayoutConstraint());
     }

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -1143,11 +1143,7 @@ RequirementCheckResult TypeChecker::checkGenericArguments(
     Type rawSecondType, secondType;
     if (kind != RequirementKind::Layout) {
       rawSecondType = rawReq.getSecondType();
-      secondType = req->getSecondType().subst(substitutions, conformances);
-      if (!secondType) {
-        valid = false;
-        continue;
-      }
+      secondType = req->getSecondType();
     }
 
     if (listener && !listener->shouldCheck(kind, firstType, secondType))


### PR DESCRIPTION
Not quite ready to enable the stronger asserts in Type::subst(), just clean up a couple of things for now.