### PR TITLE
Frontend: Add a new -sil-merge-partial-modules flag

### DIFF
--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -56,6 +56,11 @@ public:
   /// Controls how to perform SIL linking.
   LinkingMode LinkMode = LinkNormal;
 
+  /// Controls whether to pull in SIL from partial modules during the
+  /// merge modules step. Could perhaps be merged with the link mode
+  /// above but the interactions between all the flags are tricky.
+  bool MergePartialModules = false;
+
   /// Remove all runtime assertions during optimizations.
   bool RemoveRuntimeAsserts = false;
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -321,6 +321,9 @@ def sil_inline_threshold : Separate<["-"], "sil-inline-threshold">,
   MetaVarName<"<50>">,
   HelpText<"Controls the aggressiveness of performance inlining">;
 
+def sil_merge_partial_modules : Flag<["-"], "sil-merge-partial-modules">,
+  HelpText<"Merge SIL from all partial swiftmodules into the final module">;
+
 def sil_link_all : Flag<["-"], "sil-link-all">,
   HelpText<"Link all SIL functions">;
 

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -459,6 +459,10 @@ public:
   /// Link in all VTables in the module.
   void linkAllVTables();
 
+  /// Link all definitions in all segments that are logically part of
+  /// the same AST module.
+  void linkAllFromCurrentModule();
+
   /// \brief Return the declaration of a utility function that can,
   /// but needn't, be shared between modules.
   SILFunction *getOrCreateSharedFunction(SILLocation loc,

--- a/include/swift/Serialization/SerializedSILLoader.h
+++ b/include/swift/Serialization/SerializedSILLoader.h
@@ -112,6 +112,12 @@ public:
 
   /// Deserialize all SILFunctions, VTables, and WitnessTables for
   /// a given Module.
+  ///
+  /// If PrimaryFile is nullptr, all definitions are brought in with
+  /// definition linkage.
+  ///
+  /// Otherwise, definitions not in the primary file are brought in
+  /// with external linkage.
   void getAllForModule(Identifier Mod, FileUnit *PrimaryFile);
 
   /// Deserialize all SILFunctions in all SILModules.

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1218,6 +1218,9 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
       llvm_unreachable("Unknown SIL linking option!");
   }
 
+  if (Args.hasArg(OPT_sil_merge_partial_modules))
+    Opts.MergePartialModules = true;
+
   // Parse the optimization level.
   if (const Arg *A = Args.getLastArg(OPT_O_Group)) {
     if (A->getOption().matches(OPT_Onone)) {

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -625,6 +625,9 @@ static bool performCompile(std::unique_ptr<CompilerInstance> &Instance,
   if (Invocation.getSILOptions().LinkMode == SILOptions::LinkAll)
     performSILLinking(SM.get(), true);
 
+  if (Invocation.getSILOptions().MergePartialModules)
+    SM->linkAllFromCurrentModule();
+
   {
     SharedTimer timer("SIL verification, pre-optimization");
     SM->verify();

--- a/lib/SIL/SILModule.cpp
+++ b/lib/SIL/SILModule.cpp
@@ -568,6 +568,11 @@ bool SILModule::hasFunction(StringRef Name) {
   return Visitor.hasFunction(Name);
 }
 
+void SILModule::linkAllFromCurrentModule() {
+  getSILLoader()->getAllForModule(getSwiftModule()->getName(),
+                                  /*PrimaryFile=*/nullptr);
+}
+
 void SILModule::linkAllWitnessTables() {
   getSILLoader()->getAllWitnessTables();
 }

--- a/test/Frontend/Inputs/sil-merge-partial-modules-other.swift
+++ b/test/Frontend/Inputs/sil-merge-partial-modules-other.swift
@@ -1,0 +1,14 @@
+@inline(__always)
+func internalFunction() {}
+
+@_versioned
+func versionedFunction() {}
+
+public protocol Shape {
+  func draw()
+  var area: Float { get }
+}
+
+public class ShapeManager {
+  public func manage() {}
+}

--- a/test/Frontend/sil-merge-partial-modules.swift
+++ b/test/Frontend/sil-merge-partial-modules.swift
@@ -1,0 +1,77 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+
+// RUN: %target-swift-frontend -emit-module -primary-file %s %S/Inputs/sil-merge-partial-modules-other.swift -module-name test -enable-resilience -o %t/partial.a.swiftmodule
+// RUN: %target-swift-frontend -emit-module %s -primary-file %S/Inputs/sil-merge-partial-modules-other.swift -module-name test -enable-resilience -o %t/partial.b.swiftmodule
+
+// RUN: %target-swift-frontend -emit-module %t/partial.a.swiftmodule %t/partial.b.swiftmodule -module-name test -enable-resilience -sil-merge-partial-modules -disable-diagnostic-passes -disable-sil-perf-optzns -o %t/test.swiftmodule
+
+// RUN: %target-sil-opt %t/test.swiftmodule -disable-sil-linking > %t/dump.sil
+// RUN: %FileCheck %s < %t/dump.sil
+// RUN: %FileCheck %s --check-prefix=NEGATIVE < %t/dump.sil
+
+public func publicFunction() {
+  internalFunction()
+}
+
+@_inlineable
+public func inlineableFunction() {
+  let fn = { versionedFunction() }
+
+  fn()
+}
+
+@_fixed_layout
+public struct Rectangle : Shape {
+  @_inlineable
+  public func draw() {
+    publicFunction()
+  }
+
+  public var area: Float { return 10.0 }
+}
+
+public struct Circle : Shape {
+  public func draw() {}
+
+  public var area: Float { return 22.0 / 7 }
+}
+
+public class CircleManager : ShapeManager {
+  public override func manage() {}
+}
+
+// FIXME: Why is the definition order totally random?
+
+// CHECK-LABEL: sil shared [serialized] @_T04test18inlineableFunctionyyFyycfU_ : $@convention(thin) () -> () {
+// CHECK: function_ref @_T04test17versionedFunctionyyF
+// CHECK: }
+
+// CHECK-LABEL: sil @_T04test17versionedFunctionyyF : $@convention(thin) () -> ()
+
+// CHECK-LABEL: sil shared [transparent] [serialized] [thunk] @_T04test9RectangleVAA5ShapeA2aDP4drawyyFTW : $@convention(witness_method) (@in_guaranteed Rectangle) -> () {
+// CHECK: function_ref @_T04test14publicFunctionyyF
+// CHECK: }
+
+// CHECK-LABEL: sil [serialized] @_T04test18inlineableFunctionyyF : $@convention(thin) () -> () {
+// CHECK: function_ref @_T04test18inlineableFunctionyyFyycfU_
+// CHECK: }
+
+// CHECK-LABEL: sil @_T04test14publicFunctionyyF : $@convention(thin) () -> ()
+
+// CHECK-LABEL: sil shared [transparent] [serialized] [thunk] @_T04test9RectangleVAA5ShapeA2aDP4areaSffgTW : $@convention(witness_method) (@in_guaranteed Rectangle) -> Float {
+// CHECK: function_ref @_T04test9RectangleV4areaSffg
+// CHECK: }
+
+// CHECK-LABEL: sil @_T04test9RectangleV4areaSffg : $@convention(method) (Rectangle) -> Float
+
+// CHECK-LABEL: sil_witness_table [serialized] Rectangle: Shape module test {
+// CHECK-LABEL:   method #Shape.draw!1: <Self where Self : Shape> (Self) -> () -> () : @_T04test9RectangleVAA5ShapeA2aDP4drawyyFTW
+// CHECK-LABEL:   method #Shape.area!getter.1: <Self where Self : Shape> (Self) -> () -> Float : @_T04test9RectangleVAA5ShapeA2aDP4areaSffgTW
+// CHECK-LABEL: }
+
+// NEGATIVE-NOT: sil {{.*}}internalFunction
+
+// NEGATIVE-NOT: sil_witness_table {{.*}}Circle: Shape
+
+// NEGATIVE-NOT: sil_vtable


### PR DESCRIPTION
This adds the first part of https://github.com/apple/swift/pull/8388. The new code is exercised in a frontend test but is otherwise completely disabled, since the driver change to enable it exposed more bugs.

Progress on <rdar://problem/18913977>.