### PR TITLE
Improve the performance of IRGenDebugInfo.

### DIFF
--- a/include/swift/SIL/SILDebugScope.h
+++ b/include/swift/SIL/SILDebugScope.h
@@ -46,82 +46,28 @@ public:
   /// An optional chain of inlined call sites.
   ///
   /// If this scope is inlined, this points to a special "scope" that
-  /// holds only the location of the call site. The parent scope will be
-  /// the scope of the inlined call site.
-  ///
-  /// Note that compared to the inlinedAt chain in llvm::DILocation
-  /// SILDebugScope represents an inline tree.
+  /// holds the location of the call site.
   const SILDebugScope *InlinedCallSite;
 
   SILDebugScope(SILLocation Loc, SILFunction *SILFn,
                 const SILDebugScope *ParentScope = nullptr,
-                const SILDebugScope *InlinedCallSite = nullptr)
-      : Loc(Loc), InlinedCallSite(InlinedCallSite) {
-    if (ParentScope)
-      Parent = ParentScope;
-    else {
-      assert(SILFn && "no parent provided");
-      Parent = SILFn;
-    }
-  }
+                const SILDebugScope *InlinedCallSite = nullptr);
 
   /// Create a scope for an artificial function.
-  SILDebugScope(SILLocation Loc)
-      : Loc(Loc), InlinedCallSite(nullptr) {}
-
-  /// Create an inlined version of CalleeScope.
-  SILDebugScope(const SILDebugScope *CallSiteScope,
-                const SILDebugScope *CalleeScope)
-    : Loc(CalleeScope->Loc), Parent(CalleeScope),
-        InlinedCallSite(CallSiteScope) {
-    assert(CallSiteScope && CalleeScope);
-    if (InlinedCallSite)
-      assert(!InlinedCallSite->InlinedCallSite &&
-             "a call site scope cannot have an inlined call site");
-  }
+  SILDebugScope(SILLocation Loc);
 
   /// Return the function this scope originated from before being inlined.
-  SILFunction *getInlinedFunction() const {
-    if (Parent.isNull())
-      return nullptr;
+  SILFunction *getInlinedFunction() const;
 
-    const SILDebugScope *Scope = this;
-    while (Scope->Parent.is<const SILDebugScope *>())
-      Scope = Scope->Parent.get<const SILDebugScope *>();
-    assert(Scope->Parent.is<SILFunction *>() && "orphaned scope");
-    return Scope->Parent.get<SILFunction *>();
-  }
-
-  /// Return this scope without inline information.
-  const SILDebugScope *getInlinedScope() const {
-    return InlinedCallSite ? Parent.get<const SILDebugScope*>() : this;
-  }
-  
   /// Return the parent function of this scope. If the scope was
   /// inlined this recursively returns the function it was inlined
   /// into.
-  SILFunction *getParentFunction() const {
-    if (InlinedCallSite)
-      return InlinedCallSite->Parent.get<const SILDebugScope *>()
-          ->getParentFunction();
-    if (auto *ParentScope = Parent.dyn_cast<const SILDebugScope *>())
-      return ParentScope->getParentFunction();
-    return Parent.get<SILFunction *>();
-  }
+  SILFunction *getParentFunction() const;
 
-  typedef SmallVector<const SILDebugScope *, 8> InlineScopeList;
-  static void flatten(const SILDebugScope *DS, InlineScopeList &List);
-
-  // Return a flattened representation of the inline scope tree that
-  // is equivalent to the reversed inlined-at chain.
-  InlineScopeList flattenedInlineTree() const {
-    InlineScopeList List;
-    flatten(this, List);
-    return List;
-  }
-
+#ifndef NDEBUG
   void dump(SourceManager &SM, llvm::raw_ostream &OS = llvm::errs(),
             unsigned Indent = 0) const;
+#endif
 };
 
 #ifndef NDEBUG

--- a/include/swift/SIL/SILLocation.h
+++ b/include/swift/SIL/SILLocation.h
@@ -410,9 +410,12 @@ public:
   SourceLoc getSourceLoc() const;
   SourceLoc getStartSourceLoc() const;
   SourceLoc getEndSourceLoc() const;
-  
   SourceRange getSourceRange() const {
-    return { getStartSourceLoc(), getEndSourceLoc() };
+    return {getStartSourceLoc(), getEndSourceLoc()};
+  }
+  DebugLoc getDebugInfoLoc() const {
+    assert(isDebugInfoLoc());
+    return Loc.DebugInfoLoc;
   }
 
   /// Fingerprint a DebugLoc for use in a DenseMap.

--- a/include/swift/SILOptimizer/Utils/SILInliner.h
+++ b/include/swift/SILOptimizer/Utils/SILInliner.h
@@ -51,7 +51,7 @@ public:
              CloneCollector::CallbackType Callback = nullptr)
       : TypeSubstCloner<SILInliner>(To, From, ApplySubs,
                                     OpenedArchetypesTracker, true),
-        IKind(IKind), CalleeEntryBB(nullptr), CallSiteScope(nullptr),
+        IKind(IKind), CalleeEntryBB(nullptr),
         Callback(Callback) {
   }
 
@@ -114,7 +114,7 @@ private:
   /// Alternatively, it can be the SIL file location of the call site (in case
   /// of SIL-to-SIL transformations).
   Optional<SILLocation> Loc;
-  const SILDebugScope *CallSiteScope;
+  const SILDebugScope *CallSiteScope = nullptr;
   SILFunction *CalleeFunction;
   llvm::SmallDenseMap<const SILDebugScope *,
                       const SILDebugScope *> InlinedScopeCache;

--- a/lib/SIL/CMakeLists.txt
+++ b/lib/SIL/CMakeLists.txt
@@ -13,6 +13,7 @@ add_swift_library(swiftSIL STATIC
   SILBasicBlock.cpp
   SILBuilder.cpp
   SILCoverageMap.cpp
+  SILDebugScope.cpp
   SILDeclRef.cpp
   SILDefaultWitnessTable.cpp
   SILFunction.cpp

--- a/lib/SIL/SILDebugScope.cpp
+++ b/lib/SIL/SILDebugScope.cpp
@@ -1,0 +1,57 @@
+//===--- SILDebugScope.h - DebugScopes for SIL code -------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+///
+/// This file defines a container for scope information used to
+/// generate debug info.
+///
+//===----------------------------------------------------------------------===//
+
+#include "swift/SIL/SILDebugScope.h"
+#include "swift/SIL/SILFunction.h"
+
+using namespace swift;
+
+SILDebugScope::SILDebugScope(SILLocation Loc, SILFunction *SILFn,
+                             const SILDebugScope *ParentScope ,
+                             const SILDebugScope *InlinedCallSite)
+    : Loc(Loc), InlinedCallSite(InlinedCallSite) {
+  if (ParentScope)
+    Parent = ParentScope;
+  else {
+    assert(SILFn && "no parent provided");
+    Parent = SILFn;
+  }
+}
+
+SILDebugScope::SILDebugScope(SILLocation Loc)
+    : Loc(Loc), InlinedCallSite(nullptr) {}
+
+SILFunction *SILDebugScope::getInlinedFunction() const {
+  if (Parent.isNull())
+    return nullptr;
+
+  const SILDebugScope *Scope = this;
+  while (Scope->Parent.is<const SILDebugScope *>())
+    Scope = Scope->Parent.get<const SILDebugScope *>();
+  assert(Scope->Parent.is<SILFunction *>() && "orphaned scope");
+  return Scope->Parent.get<SILFunction *>();
+}
+
+SILFunction *SILDebugScope::getParentFunction() const {
+  if (InlinedCallSite)
+    return InlinedCallSite->getParentFunction();
+  if (auto *ParentScope = Parent.dyn_cast<const SILDebugScope *>())
+    return ParentScope->getParentFunction();
+  return Parent.get<SILFunction *>();
+}

--- a/test/DebugInfo/inlinedAt.swift
+++ b/test/DebugInfo/inlinedAt.swift
@@ -51,3 +51,4 @@ public func f(_ i : Int) -> Int { // 301
 // CHECK-SAME:                  inlinedAt: ![[L2:.*]])
 // CHECK: ![[L2]] = !DILocation(line: 203, column: 13, scope: ![[G_SCOPE]],
 // CHECK-SAME:                  inlinedAt: ![[L3]])
+

--- a/test/SILOptimizer/inline_tryApply.sil
+++ b/test/SILOptimizer/inline_tryApply.sil
@@ -7,10 +7,10 @@ import Swift
 import SwiftShims
 
 
-//CHECK-LABEL: caller_function
+//CHECK-LABEL: sil @caller_function
 //CHECK-NOT: try_apply
 //CHECK: throw {{.*}} : $Error
-sil  @caller_function : $@convention(thin) () -> @error Error {
+sil @caller_function : $@convention(thin) () -> @error Error {
 bb0:
   // function_ref main.inner () throws -> ()
   %0 = function_ref @callee_function : $@convention(thin) () -> @error Error // user: %1
@@ -24,7 +24,7 @@ bb2(%5 : $Error):                             // Preds: bb0
   throw %5 : $Error                           // id: %6
 }
 
-//CHECK-LABEL: callee_function
+//CHECK-LABEL: sil [always_inline] @callee_function
 //CHECK: return
 
 // main.inner () throws -> ()


### PR DESCRIPTION
This commit changes how inline information is stored in SILDebugScope
from a tree to a linear chain of inlined call sites (similar to what
LLVM is using). This makes creating inlined SILDebugScopes slightly
more expensive, but makes lowering SILDebugScopes into LLVM metadata
much faster because entire inlined-at chains can now be cached. This
means that SIL is no longer preserve the inlining history (i.e., ((a
was inlined into b) was inlined into c) is represented the same as (a
was inlined into (b was inlined into c)), but this information was not
used by anyone.

On my late 2012 i7 iMac, this saves about 4 seconds when compiling the
RelWithDebInfo x86_64 swift standard library — or 40% of IRGen time.

rdar://problem/28311051
rdar://problem/27658378