### PR TITLE
ValueLifetimeAnalysis: fix the lifetime computation in case the value definition is in a single-block loop.

### DIFF
--- a/include/swift/SILOptimizer/Utils/Local.h
+++ b/include/swift/SILOptimizer/Utils/Local.h
@@ -277,6 +277,11 @@ private:
 
   /// Returns the last use of the value in the live block \p BB.
   SILInstruction *findLastUserInBlock(SILBasicBlock *BB);
+
+  /// Returns true if the value is alive at the begin of block \p BB.
+  bool isAliveAtBeginOfBlock(SILBasicBlock *BB) {
+    return LiveBlocks.count(BB) && BB != DefValue->getParentBlock();
+  }
 };
 
 /// Base class for BB cloners.

--- a/lib/SILOptimizer/Utils/Local.cpp
+++ b/lib/SILOptimizer/Utils/Local.cpp
@@ -1082,7 +1082,7 @@ bool ValueLifetimeAnalysis::computeFrontier(Frontier &Fr, Mode mode) {
     bool LiveInSucc = false;
     bool DeadInSucc = false;
     for (const SILSuccessor &Succ : BB->getSuccessors()) {
-      if (LiveBlocks.count(Succ)) {
+      if (isAliveAtBeginOfBlock(Succ)) {
         LiveInSucc = true;
       } else {
         DeadInSucc = true;
@@ -1105,7 +1105,7 @@ bool ValueLifetimeAnalysis::computeFrontier(Frontier &Fr, Mode mode) {
       // The value is not live in some of the successor blocks.
       LiveOutBlocks.insert(BB);
       for (const SILSuccessor &Succ : BB->getSuccessors()) {
-        if (!LiveBlocks.count(Succ)) {
+        if (!isAliveAtBeginOfBlock(Succ)) {
           // It's an "exit" edge from the lifetime region.
           FrontierBlocks.insert(Succ);
         }
@@ -1167,7 +1167,7 @@ bool ValueLifetimeAnalysis::isWithinLifetime(SILInstruction *Inst) {
     // live at the end of BB and therefore Inst is definitely in the lifetime
     // region (Note that we don't check in upward direction against the value's
     // definition).
-    if (LiveBlocks.count(Succ))
+    if (isAliveAtBeginOfBlock(Succ))
       return true;
   }
   // The value is live in the block but not at the end of the block. Check if

--- a/test/SILOptimizer/dead_array_elim.sil
+++ b/test/SILOptimizer/dead_array_elim.sil
@@ -216,3 +216,37 @@ bb3:
   return %18 : $()
 }
 
+// CHECK-LABEL: sil @dead_array_in_single_cycle_loop
+// CHECK: bb0(%0 : $TrivialDestructor):
+// CHECK-NEXT: br bb1
+// CHECK: bb1:
+// CHECK-NEXT: strong_retain %0
+// CHECK-NEXT: strong_release %0
+// CHECK-NEXT: cond_br
+// CHECK: bb2:
+// CHECK-NEXT: tuple
+// CHECK-NEXT: return
+sil @dead_array_in_single_cycle_loop : $@convention(thin) (@guaranteed TrivialDestructor) -> () {
+bb0(%0 : $TrivialDestructor):
+  br bb1
+
+bb1:
+  %2 = integer_literal $Builtin.Word, 2
+  %3 = function_ref @allocArray : $@convention(thin) <τ_0_0> (Builtin.Word) -> @owned (Array<τ_0_0>, Builtin.RawPointer)
+  %4 = apply %3<TrivialDestructor>(%2) : $@convention(thin) <τ_0_0> (Builtin.Word) -> @owned (Array<τ_0_0>, Builtin.RawPointer)
+  %5 = tuple_extract %4 : $(Array<TrivialDestructor>, Builtin.RawPointer), 0
+  %6 = tuple_extract %4 : $(Array<TrivialDestructor>, Builtin.RawPointer), 1
+  %7 = pointer_to_address %6 : $Builtin.RawPointer to [strict] $*TrivialDestructor
+  %13 = struct_extract %5 : $Array<TrivialDestructor>, #Array._buffer
+  %14 = struct_extract %13 : $_ArrayBuffer<TrivialDestructor>, #_ArrayBuffer._storage
+  %15 = struct_extract %14 : $_BridgeStorage<_ContiguousArrayStorageBase, _NSArrayCore>, #_BridgeStorage.rawValue
+  strong_retain %0 : $TrivialDestructor
+  store %0 to %7 : $*TrivialDestructor
+  strong_release %15 : $Builtin.BridgeObject
+  cond_br undef, bb1, bb2
+
+bb2:
+  %18 = tuple ()
+  return %18 : $()
+}
+


### PR DESCRIPTION
This caused DeadObjectElimination to generate a memory leak in case a dead array is in a single-block loop.
rdar://problem/31420889
