### PR TITLE
Revert non-optional unsafe buffer base address

### DIFF
--- a/stdlib/private/SwiftPrivate/IO.swift
+++ b/stdlib/private/SwiftPrivate/IO.swift
@@ -55,7 +55,7 @@ public struct _FDInputStream {
     let readResult: __swift_ssize_t = _buffer.withUnsafeMutableBufferPointer {
       (_buffer) in
       let fd = self.fd
-      let addr = _buffer.baseAddress + self._bufferUsed
+      let addr = _buffer.baseAddress! + self._bufferUsed
       let size = bufferFree
       return _swift_stdlib_read(fd, addr, size)
     }
@@ -107,7 +107,7 @@ public struct _FDOutputStream : TextOutputStream {
       let bufferSize = utf8CStr.count - 1
       while writtenBytes != bufferSize {
         let result = _swift_stdlib_write(
-          self.fd, UnsafeRawPointer(utf8CStr.baseAddress + Int(writtenBytes)),
+          self.fd, UnsafeRawPointer(utf8CStr.baseAddress! + Int(writtenBytes)),
           bufferSize - writtenBytes)
         if result < 0 {
           fatalError("write() returned an error")

--- a/stdlib/private/SwiftPrivate/SwiftPrivate.swift
+++ b/stdlib/private/SwiftPrivate/SwiftPrivate.swift
@@ -81,7 +81,7 @@ public func withArrayOfCStrings<R>(
 
   return argsBuffer.withUnsafeMutableBufferPointer {
     (argsBuffer) in
-    let ptr = UnsafeMutableRawPointer(argsBuffer.baseAddress).bindMemory(
+    let ptr = UnsafeMutableRawPointer(argsBuffer.baseAddress!).bindMemory(
       to: CChar.self, capacity: argsBuffer.count)
     var cStrings: [UnsafeMutablePointer<CChar>?] = argsOffsets.map { ptr + numericCast($0) }
     cStrings[cStrings.count - 1] = nil

--- a/stdlib/private/SwiftPrivateLibcExtras/SwiftPrivateLibcExtras.swift
+++ b/stdlib/private/SwiftPrivateLibcExtras/SwiftPrivateLibcExtras.swift
@@ -27,8 +27,8 @@ public func _stdlib_mkstemps(_ template: inout String, _ suffixlen: CInt) -> CIn
   var utf8CStr = template.utf8CString
   let (fd, fileName) = utf8CStr.withUnsafeMutableBufferPointer {
     (utf8CStr) -> (CInt, String) in
-    let fd = mkstemps(utf8CStr.baseAddress, suffixlen)
-    let fileName = String(cString: utf8CStr.baseAddress)
+    let fd = mkstemps(utf8CStr.baseAddress!, suffixlen)
+    let fileName = String(cString: utf8CStr.baseAddress!)
     return (fd, fileName)
   }
   template = fileName

--- a/stdlib/public/SDK/CoreAudio/CoreAudio.swift
+++ b/stdlib/public/SDK/CoreAudio/CoreAudio.swift
@@ -19,9 +19,7 @@ extension UnsafeBufferPointer {
     let count = Int(audioBuffer.mDataByteSize) / MemoryLayout<Element>.stride
     let elementPtr = audioBuffer.mData?.bindMemory(
       to: Element.self, capacity: count)
-    
-    if let start = elementPtr { self.init(start: start, count: count) }
-    else { self.init() }
+    self.init(start: elementPtr, count: count)
   }
 }
 
@@ -32,8 +30,7 @@ extension UnsafeMutableBufferPointer {
     let count = Int(audioBuffer.mDataByteSize) / MemoryLayout<Element>.stride
     let elementPtr = audioBuffer.mData?.bindMemory(
       to: Element.self, capacity: count)
-    if let start = elementPtr { self.init(start: start, count: count) }
-    else { self.init() }
+    self.init(start: elementPtr, count: count)
   }
 }
 

--- a/stdlib/public/SDK/Dispatch/Data.swift
+++ b/stdlib/public/SDK/Dispatch/Data.swift
@@ -132,6 +132,7 @@ public struct DispatchData : RandomAccessCollection, _ObjectiveCBridgeable {
 	/// - parameter count: The number of bytes to copy.
 	public mutating func append(_ bytes: UnsafeRawBufferPointer) {
 		// Nil base address does nothing.
+		guard bytes.baseAddress != nil else { return }
 		let data = _swift_dispatch_data_create(bytes.baseAddress!, bytes.count, nil, _swift_dispatch_data_destructor_default()) as! __DispatchData
 		self.append(DispatchData(data: data))
 	}
@@ -185,6 +186,7 @@ public struct DispatchData : RandomAccessCollection, _ObjectiveCBridgeable {
 	/// - parameter count: The number of bytes to copy.
 	public func copyBytes(to pointer: UnsafeMutableRawBufferPointer, count: Int) {
 		assert(count <= pointer.count, "Buffer too small to copy \(count) bytes")
+		guard pointer.baseAddress != nil else { return }
 		_copyBytesHelper(to: pointer.baseAddress!, from: 0..<count)
 	}
 
@@ -205,6 +207,7 @@ public struct DispatchData : RandomAccessCollection, _ObjectiveCBridgeable {
 	/// - parameter range: The range in the `Data` to copy.
 	public func copyBytes(to pointer: UnsafeMutableRawBufferPointer, from range: CountableRange<Index>) {
 		assert(range.count <= pointer.count, "Buffer too small to copy \(range.count) bytes")
+		guard pointer.baseAddress != nil else { return }
 		_copyBytesHelper(to: pointer.baseAddress!, from: range)
 	}
 

--- a/stdlib/public/SDK/Dispatch/Data.swift
+++ b/stdlib/public/SDK/Dispatch/Data.swift
@@ -46,7 +46,8 @@ public struct DispatchData : RandomAccessCollection, _ObjectiveCBridgeable {
 	/// - parameter count: The number of bytes to copy.
 	@available(swift, deprecated: 4, message: "Use init(bytes: UnsafeRawBufferPointer) instead")
 	public init(bytes buffer: UnsafeBufferPointer<UInt8>) {
-		__wrapped = _swift_dispatch_data_create(buffer.baseAddress, buffer.count, nil,
+		__wrapped = buffer.baseAddress == nil ? _swift_dispatch_data_empty()
+				: _swift_dispatch_data_create(buffer.baseAddress!, buffer.count, nil,
 					_swift_dispatch_data_destructor_default()) as! __DispatchData
 	}
 
@@ -55,7 +56,8 @@ public struct DispatchData : RandomAccessCollection, _ObjectiveCBridgeable {
 	/// - parameter bytes: A pointer to the memory. It will be copied.
 	/// - parameter count: The number of bytes to copy.
 	public init(bytes buffer: UnsafeRawBufferPointer) {
-		__wrapped = _swift_dispatch_data_create(buffer.baseAddress, buffer.count, nil,
+		__wrapped = buffer.baseAddress == nil ? _swift_dispatch_data_empty()
+				: _swift_dispatch_data_create(buffer.baseAddress!, buffer.count, nil,
 					_swift_dispatch_data_destructor_default()) as! __DispatchData
 	}
 
@@ -67,7 +69,8 @@ public struct DispatchData : RandomAccessCollection, _ObjectiveCBridgeable {
 	@available(swift, deprecated: 4, message: "Use init(bytesNoCopy: UnsafeRawBufferPointer, deallocater: Deallocator) instead")
 	public init(bytesNoCopy bytes: UnsafeBufferPointer<UInt8>, deallocator: Deallocator = .free) {
 		let (q, b) = deallocator._deallocator
-		__wrapped = _swift_dispatch_data_create(bytes.baseAddress, bytes.count, q, b) as! __DispatchData
+		__wrapped = bytes.baseAddress == nil ? _swift_dispatch_data_empty()
+				: _swift_dispatch_data_create(bytes.baseAddress!, bytes.count, q, b) as! __DispatchData
 	}
 
 	/// Initialize a `Data` without copying the bytes.
@@ -77,7 +80,8 @@ public struct DispatchData : RandomAccessCollection, _ObjectiveCBridgeable {
 	/// - parameter deallocator: Specifies the mechanism to free the indicated buffer.
 	public init(bytesNoCopy bytes: UnsafeRawBufferPointer, deallocator: Deallocator = .free) {
 		let (q, b) = deallocator._deallocator
-		__wrapped = _swift_dispatch_data_create(bytes.baseAddress, bytes.count, q, b) as! __DispatchData
+		__wrapped = bytes.baseAddress == nil ? _swift_dispatch_data_empty()
+				: _swift_dispatch_data_create(bytes.baseAddress!, bytes.count, q, b) as! __DispatchData
 	}
 
 	internal init(data: __DispatchData) {
@@ -128,7 +132,7 @@ public struct DispatchData : RandomAccessCollection, _ObjectiveCBridgeable {
 	/// - parameter count: The number of bytes to copy.
 	public mutating func append(_ bytes: UnsafeRawBufferPointer) {
 		// Nil base address does nothing.
-		let data = _swift_dispatch_data_create(bytes.baseAddress, bytes.count, nil, _swift_dispatch_data_destructor_default()) as! __DispatchData
+		let data = _swift_dispatch_data_create(bytes.baseAddress!, bytes.count, nil, _swift_dispatch_data_destructor_default()) as! __DispatchData
 		self.append(DispatchData(data: data))
 	}
 
@@ -144,7 +148,7 @@ public struct DispatchData : RandomAccessCollection, _ObjectiveCBridgeable {
 	///
 	/// - parameter buffer: The buffer of bytes to append. The size is calculated from `SourceType` and `buffer.count`.
 	public mutating func append<SourceType>(_ buffer : UnsafeBufferPointer<SourceType>) {
-		buffer.baseAddress.withMemoryRebound(to: UInt8.self, capacity: buffer.count * MemoryLayout<SourceType>.stride) {
+		buffer.baseAddress!.withMemoryRebound(to: UInt8.self, capacity: buffer.count * MemoryLayout<SourceType>.stride) {
 			self.append($0, count: buffer.count * MemoryLayout<SourceType>.stride)
 		}
 	}
@@ -181,7 +185,7 @@ public struct DispatchData : RandomAccessCollection, _ObjectiveCBridgeable {
 	/// - parameter count: The number of bytes to copy.
 	public func copyBytes(to pointer: UnsafeMutableRawBufferPointer, count: Int) {
 		assert(count <= pointer.count, "Buffer too small to copy \(count) bytes")
-		_copyBytesHelper(to: pointer.baseAddress, from: 0..<count)
+		_copyBytesHelper(to: pointer.baseAddress!, from: 0..<count)
 	}
 
 	/// Copy a subset of the contents of the data to a pointer.
@@ -201,7 +205,7 @@ public struct DispatchData : RandomAccessCollection, _ObjectiveCBridgeable {
 	/// - parameter range: The range in the `Data` to copy.
 	public func copyBytes(to pointer: UnsafeMutableRawBufferPointer, from range: CountableRange<Index>) {
 		assert(range.count <= pointer.count, "Buffer too small to copy \(range.count) bytes")
-		_copyBytesHelper(to: pointer.baseAddress, from: range)
+		_copyBytesHelper(to: pointer.baseAddress!, from: range)
 	}
 
 	/// Copy the contents of the data into a buffer.
@@ -231,7 +235,7 @@ public struct DispatchData : RandomAccessCollection, _ObjectiveCBridgeable {
 
 		guard !copyRange.isEmpty else { return 0 }
 
-		_copyBytesHelper(to: buffer.baseAddress, from: copyRange)
+		_copyBytesHelper(to: buffer.baseAddress!, from: copyRange)
 		return copyRange.count
 	}
 

--- a/stdlib/public/SDK/Foundation/Data.swift
+++ b/stdlib/public/SDK/Foundation/Data.swift
@@ -177,20 +177,14 @@ public final class _DataStorage {
     }
     
     public func enumerateBytes(_ block: (_ buffer: UnsafeBufferPointer<UInt8>, _ byteIndex: Data.Index, _ stop: inout Bool) -> Void) {
-    var stop: Bool = false
-    
-    var buf : UnsafeBufferPointer<UInt8> {
-      guard let b = _bytes else { return UnsafeBufferPointer() }
-      return UnsafeBufferPointer(start: b.assumingMemoryBound(to: UInt8.self), count: _length)
-    }
-    
+        var stop: Bool = false
         switch _backing {
         case .swift:
-            block(buf, 0, &stop)
+            block(UnsafeBufferPointer<UInt8>(start: _bytes?.assumingMemoryBound(to: UInt8.self), count: _length), 0, &stop)
         case .immutable:
-            block(buf, 0, &stop)
+            block(UnsafeBufferPointer<UInt8>(start: _bytes?.assumingMemoryBound(to: UInt8.self), count: _length), 0, &stop)
         case .mutable:
-            block(buf, 0, &stop)
+            block(UnsafeBufferPointer<UInt8>(start: _bytes?.assumingMemoryBound(to: UInt8.self), count: _length), 0, &stop)
         case .customReference(let d):
             d.enumerateBytes { (ptr, range, stop) in
                 var stopv = false
@@ -367,7 +361,7 @@ public final class _DataStorage {
     @inline(__always)
     public func append(_ otherData: Data) {
         otherData.enumerateBytes { (buffer: UnsafeBufferPointer<UInt8>, _, _) in
-            append(buffer.baseAddress, length: buffer.count)
+            append(buffer.baseAddress!, length: buffer.count)
         }
     }
     
@@ -1172,7 +1166,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
         guard !copyRange.isEmpty else { return 0 }
         
         let nsRange = NSMakeRange(copyRange.lowerBound, copyRange.upperBound - copyRange.lowerBound)
-        _copyBytesHelper(to: buffer.baseAddress, from: nsRange)
+        _copyBytesHelper(to: buffer.baseAddress!, from: nsRange)
         return copyRange.count
     }
     
@@ -1275,7 +1269,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
         if !isKnownUniquelyReferenced(&_backing) {
             _backing = _backing.mutableCopy(_sliceRange)
         }
-        _backing.append(buffer.baseAddress, length: buffer.count * MemoryLayout<SourceType>.stride)
+        _backing.append(buffer.baseAddress!, length: buffer.count * MemoryLayout<SourceType>.stride)
         _sliceRange = _sliceRange.lowerBound..<(_sliceRange.upperBound + buffer.count * MemoryLayout<SourceType>.stride)
     }
     

--- a/stdlib/public/SDK/Foundation/NSFastEnumeration.swift
+++ b/stdlib/public/SDK/Foundation/NSFastEnumeration.swift
@@ -50,7 +50,7 @@ final public class NSFastEnumerationIterator : IteratorProtocol {
     objects.withUnsafeMutableBufferPointer {
       count = enumerable.countByEnumerating(
         with: &state,
-        objects: AutoreleasingUnsafeMutablePointer($0.baseAddress),
+        objects: AutoreleasingUnsafeMutablePointer($0.baseAddress!),
         count: $0.count)
     }
   }

--- a/stdlib/public/SDK/os/os_log.swift
+++ b/stdlib/public/SDK/os/os_log.swift
@@ -28,7 +28,7 @@ public func os_log(
   message.withUTF8Buffer { (buf: UnsafeBufferPointer<UInt8>) in
     // Since dladdr is in libc, it is safe to unsafeBitCast
     // the cstring argument type.
-    buf.baseAddress.withMemoryRebound(
+    buf.baseAddress!.withMemoryRebound(
       to: CChar.self, capacity: buf.count
     ) { str in
       withVaList(args) { valist in

--- a/stdlib/public/core/ArrayBuffer.swift
+++ b/stdlib/public/core/ArrayBuffer.swift
@@ -480,10 +480,8 @@ extension _ArrayBuffer {
       "Array is bridging an opaque NSArray; can't get a pointer to the elements"
     )
     defer { _fixLifetime(self) }
-    return try body(
-      !_isNative ? UnsafeMutableBufferPointer()
-      : UnsafeMutableBufferPointer(
-        start: firstElementAddressIfContiguous!, count: count))
+    return try body(UnsafeMutableBufferPointer(
+      start: firstElementAddressIfContiguous, count: count))
   }
   
   /// An object that keeps the elements stored in this buffer alive.

--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -1573,7 +1573,7 @@ extension ${Self} : RangeReplaceableCollection, _ArrayProtocol {
   ) rethrows -> R? {
     return try withUnsafeMutableBufferPointer {
       (bufferPointer) -> R in
-      let r = try body(bufferPointer.baseAddress, bufferPointer.count)
+      let r = try body(bufferPointer.baseAddress!, bufferPointer.count)
       return r
     }
   }
@@ -1777,8 +1777,9 @@ extension ${Self} {
 
     // It is not OK for there to be no pointer/not enough space, as this is
     // a precondition and Array never lies about its count.
-    var p = buffer.baseAddress
-        _precondition(self.count <= buffer.count, 
+    guard var p = buffer.baseAddress
+      else { _preconditionFailure("Attempt to copy contents into nil buffer pointer") }
+    _precondition(self.count <= buffer.count, 
       "Insufficient space allocated to copy array contents")
 
     if let s = _baseAddressIfContiguous {

--- a/stdlib/public/core/AssertCommon.swift
+++ b/stdlib/public/core/AssertCommon.swift
@@ -92,9 +92,9 @@ func _assertionFailure(
       file.withUTF8Buffer {
         (file) -> Void in
         _swift_stdlib_reportFatalErrorInFile(
-          prefix.baseAddress, CInt(prefix.count),
-          message.baseAddress, CInt(message.count),
-          file.baseAddress, CInt(file.count), UInt32(line),
+          prefix.baseAddress!, CInt(prefix.count),
+          message.baseAddress!, CInt(message.count),
+          file.baseAddress!, CInt(file.count), UInt32(line),
           flags)
         Builtin.int_trap()
       }
@@ -123,9 +123,9 @@ func _assertionFailure(
       file.withUTF8Buffer {
         (file) -> Void in
         _swift_stdlib_reportFatalErrorInFile(
-          prefix.baseAddress, CInt(prefix.count),
-          messageUTF8.baseAddress, CInt(messageUTF8.count),
-          file.baseAddress, CInt(file.count), UInt32(line),
+          prefix.baseAddress!, CInt(prefix.count),
+          messageUTF8.baseAddress!, CInt(messageUTF8.count),
+          file.baseAddress!, CInt(file.count), UInt32(line),
           flags)
       }
     }
@@ -156,9 +156,9 @@ func _fatalErrorMessage(
       file.withUTF8Buffer {
         (file) in
         _swift_stdlib_reportFatalErrorInFile(
-          prefix.baseAddress, CInt(prefix.count),
-          message.baseAddress, CInt(message.count),
-          file.baseAddress, CInt(file.count), UInt32(line),
+          prefix.baseAddress!, CInt(prefix.count),
+          message.baseAddress!, CInt(message.count),
+          file.baseAddress!, CInt(file.count), UInt32(line),
           flags)
       }
     }
@@ -169,8 +169,8 @@ func _fatalErrorMessage(
     message.withUTF8Buffer {
       (message) in
       _swift_stdlib_reportFatalError(
-        prefix.baseAddress, CInt(prefix.count),
-        message.baseAddress, CInt(message.count),
+        prefix.baseAddress!, CInt(prefix.count),
+        message.baseAddress!, CInt(message.count),
         flags)
     }
   }
@@ -202,9 +202,9 @@ func _unimplementedInitializer(className: StaticString,
         file.withUTF8Buffer {
           (file) in
           _swift_stdlib_reportUnimplementedInitializerInFile(
-            className.baseAddress, CInt(className.count),
-            initName.baseAddress, CInt(initName.count),
-            file.baseAddress, CInt(file.count),
+            className.baseAddress!, CInt(className.count),
+            initName.baseAddress!, CInt(initName.count),
+            file.baseAddress!, CInt(file.count),
             UInt32(line), UInt32(column),
             /*flags:*/ 0)
         }
@@ -216,8 +216,8 @@ func _unimplementedInitializer(className: StaticString,
       initName.withUTF8Buffer {
         (initName) in
         _swift_stdlib_reportUnimplementedInitializer(
-          className.baseAddress, CInt(className.count),
-          initName.baseAddress, CInt(initName.count),
+          className.baseAddress!, CInt(className.count),
+          initName.baseAddress!, CInt(initName.count),
           /*flags:*/ 0)
       }
     }

--- a/stdlib/public/core/BoundedBufferReference.swift
+++ b/stdlib/public/core/BoundedBufferReference.swift
@@ -263,11 +263,11 @@ extension _BoundedBufferReference {
       let (_, i0) = head._copyContents(initializing: b0)
       
       let b1 = UnsafeMutableBufferPointer(
-        start: b0.baseAddress + i0, count: b0.count - b0[..<i0].count)
+        start: b0.baseAddress! + i0, count: b0.count - b0[..<i0].count)
       let (_, i1) = middle._copyContents(initializing: b1)
 
       let b2 = UnsafeMutableBufferPointer(
-        start: b1.baseAddress + i1, count: b1.count - b1[..<i1].count)
+        start: b1.baseAddress! + i1, count: b1.count - b1[..<i1].count)
       let (_, i2) = tail._copyContents(initializing: b2)
       
       assert(i2 == b2.endIndex, "Failed to consume input")

--- a/stdlib/public/core/ContiguousArrayBuffer.swift
+++ b/stdlib/public/core/ContiguousArrayBuffer.swift
@@ -36,7 +36,7 @@ internal final class _EmptyArrayStorage
   override func _withVerbatimBridgedUnsafeBuffer<R>(
     _ body: (UnsafeBufferPointer<AnyObject>) throws -> R
   ) rethrows -> R? {
-    return try body(UnsafeBufferPointer())
+    return try body(UnsafeBufferPointer(start: nil, count: 0))
   }
 
   @_inlineable

--- a/stdlib/public/core/ICU.swift
+++ b/stdlib/public/core/ICU.swift
@@ -39,14 +39,14 @@ extension _UText {
   }
   
   mutating func validate() {
-    let base = self.withBuffer { $0.baseAddress }
+    let base = self.withBuffer { $0.baseAddress! }
     _debugPrecondition(chunkContents == base, "UText moved!")
     _debugPrecondition(chunkNativeStart <= chunkNativeLimit, "Invalid native range")
     _debugPrecondition(chunkLength >= 0, "Negative chunkLength")
   }
 
   mutating func setup() {
-    chunkContents = self.withBuffer { UnsafePointer($0.baseAddress) }
+    chunkContents = self.withBuffer { UnsafePointer($0.baseAddress!) }
     pExtra = withUnsafeMutablePointer(to: &self) {
       UnsafeMutableRawPointer($0 + 1)
     }

--- a/stdlib/public/core/Misc.swift
+++ b/stdlib/public/core/Misc.swift
@@ -96,7 +96,7 @@ public // SPI(Foundation)
 func _typeByName(_ name: String) -> Any.Type? {
   let nameUTF8 = Array(name.utf8)
   return nameUTF8.withUnsafeBufferPointer { (nameUTF8) in
-    let type = _getTypeByName(nameUTF8.baseAddress,
+    let type = _getTypeByName(nameUTF8.baseAddress!,
                               UInt(nameUTF8.endIndex))
 
     return type

--- a/stdlib/public/core/MutableCollection.swift
+++ b/stdlib/public/core/MutableCollection.swift
@@ -350,8 +350,9 @@ extension MutableCollection {
   public mutating func _withUnsafeMutableBufferPointerIfSupported<R>(
     _ body: (UnsafeMutablePointer<Iterator.Element>, Int) throws -> R
   ) rethrows -> R? {
-    return try withExistingUnsafeMutableBuffer {
-      try body($0.baseAddress, $0.count)
+    return try withExistingUnsafeMutableBuffer { buffer in
+      // FIXME: audit force unwrap
+      try body(buffer.baseAddress!, buffer.count)
     }
   }
 

--- a/stdlib/public/core/NewString.swift.gyb
+++ b/stdlib/public/core/NewString.swift.gyb
@@ -1082,7 +1082,7 @@ extension String {
     result.append(contentsOf: source.lazy.map(Int8.init(bitPattern:)))
     result.append(0)
     return try result.withUnsafeBufferPointer {
-      try body($0.baseAddress)
+      try body($0.baseAddress!)
     }
   }
 }

--- a/stdlib/public/core/OutputStream.swift
+++ b/stdlib/public/core/OutputStream.swift
@@ -518,7 +518,7 @@ internal struct _Stdout : TextOutputStream {
       defer { _fixLifetime(string) }
 
       _swift_stdlib_fwrite_stdout(
-        UnsafePointer(asciiBuffer.baseAddress),
+        UnsafePointer(asciiBuffer.baseAddress!),
         asciiBuffer.count,
         1)
       return

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -1447,7 +1447,7 @@ extension Sequence {
     initializing buffer: UnsafeMutableBufferPointer<Iterator.Element>
   ) -> (Iterator,UnsafeMutableBufferPointer<Iterator.Element>.Index) {
       var it = self.makeIterator()
-      var ptr = buffer.baseAddress
+      guard var ptr = buffer.baseAddress else { return (it,buffer.startIndex) }
       for idx in buffer.startIndex..<buffer.count {
         guard let x = it.next() else {
           return (it, idx)

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -656,7 +656,7 @@ extension String {
   public func lowercased() -> String {
     if let asciiBuffer = self._core.asciiBuffer {
       let count = asciiBuffer.count
-      let source = asciiBuffer.baseAddress
+      let source = asciiBuffer.baseAddress!
       let buffer = _StringBuffer(
         capacity: count, initialSize: count, elementWidth: 1)
       let dest = buffer.start
@@ -706,7 +706,7 @@ extension String {
   public func uppercased() -> String {
     if let asciiBuffer = self._core.asciiBuffer {
       let count = asciiBuffer.count
-      let source = asciiBuffer.baseAddress
+      let source = asciiBuffer.baseAddress!
       let buffer = _StringBuffer(
         capacity: count, initialSize: count, elementWidth: 1)
       let dest = buffer.start

--- a/stdlib/public/core/StringLegacy.swift
+++ b/stdlib/public/core/StringLegacy.swift
@@ -126,8 +126,8 @@ extension String {
         return false
       }
       return Int(_swift_stdlib_memcmp(
-        selfASCIIBuffer.baseAddress,
-        prefixASCIIBuffer.baseAddress,
+        selfASCIIBuffer.baseAddress!,
+        prefixASCIIBuffer.baseAddress!,
         prefixASCIIBuffer.count)) == 0
     }
     if selfCore.hasContiguousStorage && prefixCore.hasContiguousStorage {
@@ -184,9 +184,9 @@ extension String {
         return false
       }
       return Int(_swift_stdlib_memcmp(
-        selfASCIIBuffer.baseAddress
+        selfASCIIBuffer.baseAddress!
           + (selfASCIIBuffer.count - suffixASCIIBuffer.count),
-        suffixASCIIBuffer.baseAddress,
+        suffixASCIIBuffer.baseAddress!,
         suffixASCIIBuffer.count)) == 0
     }
     if selfCore.hasContiguousStorage && suffixCore.hasContiguousStorage {

--- a/stdlib/public/core/StringNormalization.swift
+++ b/stdlib/public/core/StringNormalization.swift
@@ -213,7 +213,8 @@ where
         while true {
           var error = __swift_stdlib_U_ZERO_ERROR
           let usedCount = __swift_stdlib_unorm2_normalize(
-            _fccNormalizer, $0.baseAddress, numericCast($0.count),
+            // FIXME: check valid force-unwrap
+            _fccNormalizer, $0.baseAddress!, numericCast($0.count),
             &array, numericCast(array.count), &error)
           if __swift_stdlib_U_SUCCESS(error) {
             array.removeLast(array.count - numericCast(usedCount))

--- a/stdlib/public/core/StringUTF8.swift
+++ b/stdlib/public/core/StringUTF8.swift
@@ -45,7 +45,7 @@ extension _StringCore {
 
       _memcpy(
         dest: UnsafeMutableRawPointer(Builtin.addressof(&result)),
-        src: asciiBuffer.baseAddress + i,
+        src: asciiBuffer.baseAddress! + i,
         size: numericCast(utf16Count))
 
       // Convert the _UTF8Chunk into host endianness.

--- a/stdlib/public/core/SwiftNativeNSArray.swift
+++ b/stdlib/public/core/SwiftNativeNSArray.swift
@@ -97,7 +97,7 @@ extension _SwiftNativeNSArrayWithContiguousStorage : _NSArrayCore {
       // avoid retains. Copy bytes via a raw pointer to circumvent reference
       // counting while correctly aliasing with all other pointer types.
       UnsafeMutableRawPointer(aBuffer).copyBytes(
-        from: objects.baseAddress + range.location,
+        from: objects.baseAddress! + range.location,
         count: range.length * MemoryLayout<AnyObject>.stride)
     }
   }

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -24,19 +24,19 @@ public struct UnsafeBufferPointerIterator<Element>
   public mutating func next() -> Element? {
     if _position == _end { return nil }
 
-    let result = _position.pointee
-    _position += 1
+    let result = _position!.pointee
+    _position! += 1
     return result
   }
 
   @_inlineable
-  public init(_position: UnsafePointer<Element>, _end: UnsafePointer<Element>) {
+  public init(_position: UnsafePointer<Element>?, _end: UnsafePointer<Element>?) {
     self._position = _position
     self._end = _end
   }
   
   @_versioned
-  internal var _position, _end: UnsafePointer<Element>
+  internal var _position, _end: UnsafePointer<Element>?
 }
 
 % for mutable in (True, False):
@@ -224,13 +224,13 @@ public struct Unsafe${Mutable}BufferPointer<Element>
     get {
       _debugPrecondition(i >= 0)
       _debugPrecondition(i < endIndex)
-      return _position[i]
+      return _position![i]
     }
 %if Mutable:
     nonmutating set {
       _debugPrecondition(i >= 0)
       _debugPrecondition(i < endIndex)
-      _position[i] = newValue
+      _position![i] = newValue
     }
 %end
   }
@@ -255,15 +255,6 @@ public struct Unsafe${Mutable}BufferPointer<Element>
 %  end
   }
 
-  /// Creates an empty instance.
-  public init() {
-    // This is known to create a suitably-aligned pointer on all
-    // currently-supported platforms.
-    _position = Unsafe${Mutable}Pointer(
-      bitPattern: MemoryLayout<Element>.stride)!
-    _end = _position
-  }
-  
   /// Creates a new buffer pointer over the specified number of contiguous
   /// instances beginning at the given pointer.
   ///
@@ -275,11 +266,14 @@ public struct Unsafe${Mutable}BufferPointer<Element>
   ///   - count: The number of instances in the buffer. `count` must not be
   ///     negative.
   @_inlineable
-  public init(start: Unsafe${Mutable}Pointer<Element>, count: Int) {
+  public init(start: Unsafe${Mutable}Pointer<Element>?, count: Int) {
     _precondition(
       count >= 0, "Unsafe${Mutable}BufferPointer with negative count")
+    _precondition(
+      count == 0 || start != nil,
+      "Unsafe${Mutable}BufferPointer has a nil start and nonzero count")
     _position = start
-    _end = start + count
+    _end = start.map { $0 + count }
   }
 
   /// Returns an iterator over the elements of this buffer.
@@ -295,7 +289,7 @@ public struct Unsafe${Mutable}BufferPointer<Element>
   /// If the `baseAddress` of this buffer is `nil`, the count is zero. However,
   /// a buffer can have a `count` of zero even with a non-`nil` base address.
   @_inlineable
-  public var baseAddress: Unsafe${Mutable}Pointer<Element> {
+  public var baseAddress: Unsafe${Mutable}Pointer<Element>? {
     return _position
   }
 
@@ -305,18 +299,21 @@ public struct Unsafe${Mutable}BufferPointer<Element>
   /// a buffer can have a `count` of zero even with a non-`nil` base address.
   @_inlineable
   public var count: Int {
-    return _end - _position
+    if let pos = _position {
+      return _end! - pos
+    }
+    return 0
   }
 
   @_versioned
-  let _position, _end: Unsafe${Mutable}Pointer<Element>
+  let _position, _end: Unsafe${Mutable}Pointer<Element>?
 }
 
 extension Unsafe${Mutable}BufferPointer : CustomDebugStringConvertible {
   /// A textual representation of the buffer, suitable for debugging.
   public var debugDescription: String {
     return "Unsafe${Mutable}BufferPointer"
-      + "(start: \(_position), count: \(count))"
+      + "(start: \(_position.map(String.init(describing:)) ?? "nil"), count: \(count))"
   }
 }
 %end

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -129,7 +129,7 @@ public struct Unsafe${Mutable}RawBufferPointer
 
     @_versioned
     @_inlineable
-    init(_position: UnsafeRawPointer, _end: UnsafeRawPointer) {
+    init(_position: UnsafeRawPointer?, _end: UnsafeRawPointer?) {
       self._position = _position
       self._end = _end
     }

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -119,13 +119,13 @@ public struct Unsafe${Mutable}RawBufferPointer
     public mutating func next() -> UInt8? {
       if _position == _end { return nil }
 
-      let result = _position.load(as: UInt8.self)
-      _position += 1
+      let result = _position!.load(as: UInt8.self)
+      _position! += 1
       return result
     }
 
     @_versioned
-    internal var _position, _end: UnsafeRawPointer
+    internal var _position, _end: UnsafeRawPointer?
 
     @_versioned
     @_inlineable
@@ -160,7 +160,7 @@ public struct Unsafe${Mutable}RawBufferPointer
   /// bytes referenced by `p` are deallocated.
   @_inlineable
   public func deallocate() {
-    _position.deallocate(
+    _position?.deallocate(
       bytes: count, alignedTo: MemoryLayout<UInt>.alignment)
   }
 
@@ -195,7 +195,7 @@ public struct Unsafe${Mutable}RawBufferPointer
     _debugPrecondition(offset >= 0, "${Self}.load with negative offset")
     _debugPrecondition(offset + MemoryLayout<T>.size <= self.count,
       "${Self}.load out of bounds")
-    return baseAddress.load(fromByteOffset: offset, as: T.self)
+    return baseAddress!.load(fromByteOffset: offset, as: T.self)
   }
 
 %  if mutable:
@@ -232,7 +232,7 @@ public struct Unsafe${Mutable}RawBufferPointer
     _debugPrecondition(offset + MemoryLayout<T>.size <= self.count,
       "${Self}.storeBytes out of bounds")
 
-    baseAddress.storeBytes(of: value, toByteOffset: offset, as: T.self)
+    baseAddress!.storeBytes(of: value, toByteOffset: offset, as: T.self)
   }
 
   /// Copies the specified number of bytes from the given raw pointer's memory
@@ -255,7 +255,7 @@ public struct Unsafe${Mutable}RawBufferPointer
   public func copyBytes(from source: UnsafeRawBufferPointer) {
     _debugPrecondition(source.count <= self.count,
       "${Self}.copyBytes source has too many elements")
-    baseAddress.copyBytes(from: source.baseAddress, count: source.count)
+    baseAddress?.copyBytes(from: source.baseAddress!, count: source.count)
   }
 
   /// Copies from a collection of `UInt8` into this buffer's memory.
@@ -276,7 +276,9 @@ public struct Unsafe${Mutable}RawBufferPointer
   ) where C.Iterator.Element == UInt8 {
     _debugPrecondition(numericCast(source.count) <= self.count,
       "${Self}.copyBytes source has too many elements")
-    let position = _position
+    guard let position = _position else {
+      return
+    }
     for (index, byteValue) in source.enumerated() {
       position.storeBytes(
         of: byteValue, toByteOffset: index, as: UInt8.self)
@@ -284,12 +286,6 @@ public struct Unsafe${Mutable}RawBufferPointer
   }
 %  end # mutable
 
-  /// Creates an empty instance.
-  public init() {
-    _position = Unsafe${Mutable}RawPointer(bitPattern: 1)!
-    _end = _position
-  }
-  
   /// Creates a buffer over the specified number of contiguous bytes starting
   /// at the given pointer.
   ///
@@ -300,10 +296,12 @@ public struct Unsafe${Mutable}RawBufferPointer
   ///   - count: The number of bytes to include in the buffer. `count` must not
   ///     be negative.
   @_inlineable
-  public init(start: Unsafe${Mutable}RawPointer, count: Int) {
+  public init(start: Unsafe${Mutable}RawPointer?, count: Int) {
     _precondition(count >= 0, "${Self} with negative count")
+    _precondition(count == 0 || start != nil,
+      "${Self} has a nil start and nonzero count")
     _position = start
-    _end = start + count
+    _end = start.map { $0 + count }
   }
 
   /// Creates a new buffer over the same memory as the given buffer.
@@ -339,7 +337,7 @@ public struct Unsafe${Mutable}RawBufferPointer
   ///   buffer's type `T` must be a trivial type.
   @_inlineable
   public init<T>(_ buffer: UnsafeMutableBufferPointer<T>) {
-    self.init(start: buffer.baseAddress,
+    self.init(start: buffer.baseAddress!,
       count: buffer.count * MemoryLayout<T>.stride)
   }
 
@@ -350,7 +348,7 @@ public struct Unsafe${Mutable}RawBufferPointer
   ///   buffer's type `T` must be a trivial type.
   @_inlineable
   public init<T>(_ buffer: UnsafeBufferPointer<T>) {
-    self.init(start: buffer.baseAddress,
+    self.init(start: buffer.baseAddress!,
       count: buffer.count * MemoryLayout<T>.stride)
   }
 %  end # !mutable
@@ -389,13 +387,13 @@ public struct Unsafe${Mutable}RawBufferPointer
     get {
       _debugPrecondition(i >= 0)
       _debugPrecondition(i < endIndex)
-      return _position.load(fromByteOffset: i, as: UInt8.self)
+      return _position!.load(fromByteOffset: i, as: UInt8.self)
     }
 %  if mutable:
     nonmutating set {
       _debugPrecondition(i >= 0)
       _debugPrecondition(i < endIndex)
-      _position.storeBytes(of: newValue, toByteOffset: i, as: UInt8.self)
+      _position!.storeBytes(of: newValue, toByteOffset: i, as: UInt8.self)
     }
 %  end # mutable
   }
@@ -410,7 +408,7 @@ public struct Unsafe${Mutable}RawBufferPointer
       _debugPrecondition(bounds.lowerBound >= startIndex)
       _debugPrecondition(bounds.upperBound <= endIndex)
       return Unsafe${Mutable}RawBufferPointer(
-        start: baseAddress + bounds.lowerBound,
+        start: baseAddress.map { $0 + bounds.lowerBound },
         count: bounds.count)
     }
 %  if mutable:
@@ -420,8 +418,8 @@ public struct Unsafe${Mutable}RawBufferPointer
       _debugPrecondition(bounds.count == newValue.count)
 
       if newValue.count > 0 {
-        (baseAddress + bounds.lowerBound).copyBytes(
-          from: newValue.baseAddress,
+        (baseAddress! + bounds.lowerBound).copyBytes(
+          from: newValue.baseAddress!,
           count: newValue.count)
       }
     }
@@ -439,7 +437,7 @@ public struct Unsafe${Mutable}RawBufferPointer
   /// If the `baseAddress` of this buffer is `nil`, the count is zero. However,
   /// a buffer can have a `count` of zero even with a non-`nil` base address.
   @_inlineable
-  public var baseAddress: Unsafe${Mutable}RawPointer {
+  public var baseAddress: Unsafe${Mutable}RawPointer? {
     return _position
   }
 
@@ -449,7 +447,10 @@ public struct Unsafe${Mutable}RawBufferPointer
   /// a buffer can have a `count` of zero even with a non-`nil` base address.
   @_inlineable
   public var count: Int {
-    return _end - _position
+    if let pos = _position {
+      return _end! - pos
+    }
+    return 0
   }
 
   %  if mutable:
@@ -487,7 +488,12 @@ public struct Unsafe${Mutable}RawBufferPointer
     // This has to be a debug precondition due to the cost of walking over some collections.
     _debugPrecondition(source.underestimatedCount <= (count / elementStride),
       "insufficient space to accommodate source.underestimatedCount elements")
-    let base = baseAddress
+    guard let base = baseAddress else {
+      // this can be a precondition since only an invalid argument should be costly
+      _precondition(source.underestimatedCount == 0, 
+        "no memory available to initialize from source")
+      return (it, UnsafeMutableBufferPointer(start: nil, count: 0))
+    }  
 
     for p in stride(from: base, 
       // only advance to as far as the last element that will fit
@@ -508,14 +514,14 @@ public struct Unsafe${Mutable}RawBufferPointer
   %  end # mutable
 
   @_versioned
-  let _position, _end: Unsafe${Mutable}RawPointer
+  let _position, _end: Unsafe${Mutable}RawPointer?
 }
 
 extension Unsafe${Mutable}RawBufferPointer : CustomDebugStringConvertible {
   /// A textual representation of the buffer, suitable for debugging.
   public var debugDescription: String {
     return "${Self}"
-      + "(start: \(_position), count: \(count))"
+      + "(start: \(_position.map(String.init(describing:)) ?? "nil"), count: \(count))"
   }
 }
 

--- a/test/stdlib/BridgeNonVerbatim.swift
+++ b/test/stdlib/BridgeNonVerbatim.swift
@@ -90,7 +90,7 @@ func testScope() {
     // FIXME: Can't elide signature and use $0 here <rdar://problem/17770732> 
     (buf: inout UnsafeMutableBufferPointer<Int>) -> () in
     nsx.available_getObjects(
-      AutoreleasingUnsafeMutablePointer(buf.baseAddress), // Michael NOTE: unsafe buffer pointer ! change
+      AutoreleasingUnsafeMutablePointer(buf.baseAddress!),
       range: NSRange(location: 1, length: 2))
     return
   }

--- a/test/stdlib/Dispatch.swift
+++ b/test/stdlib/Dispatch.swift
@@ -426,14 +426,12 @@ DispatchAPI.test("DispatchData.buffers") {
 		expectEqual(data[i], bytes[i])
 	}
 
-	// Michael NOTE: disabled as part of buffer-pointer being non-nullable
-	//
-	// ptr = UnsafeBufferPointer<UInt8>(start: nil, count: 0)
-	// data = DispatchData(bytes: ptr)
-	// expectEqual(data.count, 0)
+	ptr = UnsafeBufferPointer<UInt8>(start: nil, count: 0)
+	data = DispatchData(bytes: ptr)
+	expectEqual(data.count, 0)
 
-	// data = DispatchData(bytesNoCopy: ptr, deallocator: .custom(nil, {}))
-	// expectEqual(data.count, 0)
+	data = DispatchData(bytesNoCopy: ptr, deallocator: .custom(nil, {}))
+	expectEqual(data.count, 0)
 }
 
 DispatchAPI.test("DispatchData.bufferUnsafeRawBufferPointer") {

--- a/test/stdlib/ErrorHandling.swift
+++ b/test/stdlib/ErrorHandling.swift
@@ -106,25 +106,22 @@ ErrorHandlingTests.test("ErrorHandling/index(where:)") {
 }
 
 ErrorHandlingTests.test("ErrorHandling/split") {
-  // Michael NOTE: No idea how this ever compiled first. I thought all splits
-  // needed a separator? Disable for now.
-  //
-  // do {
-  //   let _: [String.CharacterView] = try "foo".characters.split { _ in
-  //     throw SillyError.JazzHands
-  //     return false
-  //   }
-  //   expectUnreachable()
-  // } catch {}
-  //
-  // do {
-  //   let _: [AnySequence<Character>]
-  //     = try AnySequence("foo".characters).split { _ in
-  //       throw SillyError.JazzHands
-  //       return false
-  //     }
-  //   expectUnreachable()
-  // } catch {}
+  do {
+    let _: [String.CharacterView] = try "foo".characters.split { _ in
+      throw SillyError.JazzHands
+      return false
+    }
+    expectUnreachable()
+  } catch {}
+
+  do {
+    let _: [AnySequence<Character>]
+      = try AnySequence("foo".characters).split { _ in
+        throw SillyError.JazzHands
+        return false
+      }
+    expectUnreachable()
+  } catch {}
 }
 
 ErrorHandlingTests.test("ErrorHandling/forEach") {

--- a/test/stdlib/TestData.swift
+++ b/test/stdlib/TestData.swift
@@ -81,8 +81,7 @@ class TestData : TestDataSuper {
         
         override var bytes : UnsafeRawPointer {
             if let d = _pointer {
-                // Michael NOTE: non-nil buffer pointer base address
-                return UnsafeRawPointer(d.baseAddress)
+                return UnsafeRawPointer(d.baseAddress!)
             } else {
                 // Need to allocate the buffer now.
                 // It doesn't matter if the buffer is uniquely referenced or not here.
@@ -91,8 +90,7 @@ class TestData : TestDataSuper {
                 let bytePtr = buffer!.bindMemory(to: UInt8.self, capacity: length)
                 let result = UnsafeMutableBufferPointer(start: bytePtr, count: length)
                 _pointer = result
-                // Michael NOTE: non-nil buffer pointer base address
-                return UnsafeRawPointer(result.baseAddress)
+                return UnsafeRawPointer(result.baseAddress!)
             }
         }
         
@@ -110,8 +108,7 @@ class TestData : TestDataSuper {
             let result = UnsafeMutableBufferPointer(start: bytePtr, count: newBufferLength)
             _pointer = result
             _length = newBufferLength
-            // Michael NOTE: non-nil buffer pointer base address
-            return UnsafeMutableRawPointer(result.baseAddress)
+            return UnsafeMutableRawPointer(result.baseAddress!)
         }
         
         override func getBytes(_ buffer: UnsafeMutableRawPointer, length: Int) {
@@ -131,8 +128,7 @@ class TestData : TestDataSuper {
     func dataFrom(_ string : String) -> Data {
         // Create a Data out of those bytes
         return string.utf8CString.withUnsafeBufferPointer { (ptr) in
-            // Michael NOTE: non-nil buffer pointer base address
-            ptr.baseAddress.withMemoryRebound(to: UInt8.self, capacity: ptr.count) {
+            ptr.baseAddress!.withMemoryRebound(to: UInt8.self, capacity: ptr.count) {
                 // Subtract 1 so we don't get the null terminator byte. This matches NSString behavior.
                 return Data(bytes: $0, count: ptr.count - 1)
             }

--- a/test/stdlib/TestUUID.swift
+++ b/test/stdlib/TestUUID.swift
@@ -75,8 +75,7 @@ class TestUUID : TestUUIDSuper {
         var bytes: [UInt8] = [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
         let valFromBytes = bytes.withUnsafeMutableBufferPointer { buffer -> UUID in
             ref.getBytes(buffer.baseAddress)
-            // Michael NOTE: non-nil buffer pointer base address
-            return UUID(uuid: UnsafeRawPointer(buffer.baseAddress).load(as: uuid_t.self))
+            return UUID(uuid: UnsafeRawPointer(buffer.baseAddress!).load(as: uuid_t.self))
         }
         let valFromStr = UUID(uuidString: ref.uuidString)
         expectEqual(ref.uuidString, valFromRef.uuidString)

--- a/test/stdlib/Unicode.swift
+++ b/test/stdlib/Unicode.swift
@@ -24,13 +24,11 @@ UnicodeInternals.test("copy") {
 
   u16.withUnsafeMutableBufferPointer {
     (u16) -> () in
-    // Michael NOTE: non-nil buffer pointer base address
-    let p16 = u16.baseAddress
+    let p16 = u16.baseAddress!
 
     u8.withUnsafeMutableBufferPointer {
       (u8) -> () in
-      // Michael NOTE: non-nil buffer pointer base address
-      let p8 = u8.baseAddress
+      let p8 = u8.baseAddress!
 
       UTF16._copy(source: p8, destination: p16, count: 3)
       expectEqual([ 0, 1, 2, 9, 10, 11 ], Array(u16))

--- a/test/stdlib/UnsafePointer.swift.gyb
+++ b/test/stdlib/UnsafePointer.swift.gyb
@@ -364,8 +364,7 @@ UnsafeMutablePointerTestSuite.test("initialize:from:/immutable") {
   }
   let source = (0..<3).map(Missile.init)
   source.withUnsafeBufferPointer { bufferPtr in
-    // Michael NOTE: non-nil buffer pointer base address
-    ptr.initialize(from: bufferPtr.baseAddress, count: 3)
+    ptr.initialize(from: bufferPtr.baseAddress!, count: 3)
     expectEqual(0, ptr[0].number)
     expectEqual(1, ptr[1].number)
     expectEqual(2, ptr[2].number)
@@ -382,8 +381,7 @@ UnsafeMutablePointerTestSuite.test("assign/immutable") {
   (ptr + 1).initialize(to: Missile(2))
   let source = (3..<5).map(Missile.init)
   source.withUnsafeBufferPointer { bufferPtr in
-    // Michael NOTE: non-nil buffer pointer base address
-    ptr.assign(from: bufferPtr.baseAddress, count: 2)
+    ptr.assign(from: bufferPtr.baseAddress!, count: 2)
     expectEqual(3, ptr[0].number)
     expectEqual(4, ptr[1].number)
   }

--- a/test/stdlib/UnsafePointerDiagnostics.swift
+++ b/test/stdlib/UnsafePointerDiagnostics.swift
@@ -132,9 +132,8 @@ func unsafeRawBufferPointerConversions(
   _ = UnsafeRawBufferPointer(mbpi)
   _ = UnsafeMutableRawBufferPointer(bpi) // expected-error {{cannot invoke initializer for type 'UnsafeMutableRawBufferPointer' with an argument list of type '(UnsafeBufferPointer<Int>)'}} expected-note {{overloads for 'UnsafeMutableRawBufferPointer' exist with these partially matching parameter lists: (UnsafeMutableRawBufferPointer), (UnsafeMutableBufferPointer<T>)}}
   _ = UnsafeRawBufferPointer(bpi)
-  // Michael NOTE: non-nil buffer pointer base address
-  _ = UnsafeMutableRawBufferPointer(start: omrp!, count: 1)
-  _ = UnsafeRawBufferPointer(start: omrp!, count: 1)
-  _ = UnsafeMutableRawBufferPointer(start: orp!, count: 1) // expected-error {{cannot convert value of type 'UnsafeRawPointer?' to expected argument type 'UnsafeMutableRawPointer?'}}
-  _ = UnsafeRawBufferPointer(start: orp!, count: 1)
+  _ = UnsafeMutableRawBufferPointer(start: omrp, count: 1)
+  _ = UnsafeRawBufferPointer(start: omrp, count: 1)
+  _ = UnsafeMutableRawBufferPointer(start: orp, count: 1) // expected-error {{cannot convert value of type 'UnsafeRawPointer?' to expected argument type 'UnsafeMutableRawPointer?'}}
+  _ = UnsafeRawBufferPointer(start: orp, count: 1)
 }

--- a/test/stdlib/UnsafeRawBufferPointer.swift
+++ b/test/stdlib/UnsafeRawBufferPointer.swift
@@ -117,23 +117,19 @@ UnsafeRawBufferPointerTestSuite.test("initializeMemory(as:from:).exact") {
 }
 
 UnsafeRawBufferPointerTestSuite.test("initializeMemory(as:from:).invalidNilPtr") {
-  // Michael NOTE: non-nil buffer pointer base address. Disabling...
-  //
-  //
-  // let buffer = UnsafeMutableRawBufferPointer(start: nil, count: 0)
-  // let source: [Int64] = [5, 4, 3, 2, 1]
-  // expectCrashLater()
-  // var (it, bound) = buffer.initializeMemory(as: Int64.self, from: source)
+  let buffer = UnsafeMutableRawBufferPointer(start: nil, count: 0)
+  let source: [Int64] = [5, 4, 3, 2, 1]
+  expectCrashLater()
+  var (it, bound) = buffer.initializeMemory(as: Int64.self, from: source)
 }
 
 UnsafeRawBufferPointerTestSuite.test("initializeMemory(as:from:).validNilPtr") {
-  // Michael NOTE: non-nil buffer pointer base address. Disabling...
-  // let buffer = UnsafeMutableRawBufferPointer(start: nil, count: 0)
-  // let source: [Int64] = []
-  // var (it, bound) = buffer.initializeMemory(as: Int64.self, from: source)
-  // let idx = bound.endIndex * MemoryLayout<Int64>.stride
-  // expectNil(it.next())
-  // expectEqual(idx, source.endIndex)
+  let buffer = UnsafeMutableRawBufferPointer(start: nil, count: 0)
+  let source: [Int64] = []
+  var (it, bound) = buffer.initializeMemory(as: Int64.self, from: source)
+  let idx = bound.endIndex * MemoryLayout<Int64>.stride
+  expectNil(it.next())
+  expectEqual(idx, source.endIndex)
 }
 
 
@@ -151,16 +147,15 @@ UnsafeRawBufferPointerTestSuite.test("withUnsafeBytes.Sequence") {
 
 // Test the empty buffer.
 UnsafeRawBufferPointerTestSuite.test("empty") {
-  // Michael NOTE: non-nil buffer pointer base address. Disabling...
-  // let emptyBytes = UnsafeRawBufferPointer(start: nil, count: 0)
-  // for byte in emptyBytes {
-  //   expectUnreachable()
-  // }
-  // let emptyMutableBytes = UnsafeMutableRawBufferPointer.allocate(count: 0)
-  // for byte in emptyMutableBytes {
-  //   expectUnreachable()
-  // }
-  // emptyMutableBytes.deallocate()
+  let emptyBytes = UnsafeRawBufferPointer(start: nil, count: 0)
+  for byte in emptyBytes {
+    expectUnreachable()
+  }
+  let emptyMutableBytes = UnsafeMutableRawBufferPointer.allocate(count: 0)
+  for byte in emptyMutableBytes {
+    expectUnreachable()
+  }
+  emptyMutableBytes.deallocate()
 }
 
 // Store a sequence of integers to raw memory, and reload them as structs.


### PR DESCRIPTION
Reverts changes on unicode-rethink related to non-optional unsafe buffer base address.