### PR TITLE
[Foundation] Ensure data can be subscripted with all range types

### DIFF
--- a/stdlib/public/SDK/Foundation/Data.swift
+++ b/stdlib/public/SDK/Foundation/Data.swift
@@ -350,11 +350,11 @@ public final class _DataStorage {
     
     // fast-path for appending directly from another data storage
     @inline(__always)
-    public func append(_ otherData: _DataStorage) {
+    public func append(_ otherData: _DataStorage, startingAt start: Int) {
         let otherLength = otherData.length
         if otherLength == 0 { return }
         if let bytes = otherData.bytes {
-            append(bytes, length: otherLength)
+            append(bytes.advanced(by: start), length: otherLength)
         }
     }
     
@@ -1089,7 +1089,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     /// - warning: The byte pointer argument should not be stored and used outside of the lifetime of the call to the closure.
     @inline(__always)
     public func withUnsafeBytes<ResultType, ContentType>(_ body: (UnsafePointer<ContentType>) throws -> ResultType) rethrows -> ResultType {
-        let bytes =  _backing.bytes ?? UnsafeRawPointer(bitPattern: 0xBAD0)!
+        let bytes =  _backing.bytes?.advanced(by: _sliceRange.lowerBound) ?? UnsafeRawPointer(bitPattern: 0xBAD0)!
         let contentPtr = bytes.bindMemory(to: ContentType.self, capacity: count / MemoryLayout<ContentType>.stride)
         return try body(contentPtr)
     }
@@ -1104,7 +1104,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
         if !isKnownUniquelyReferenced(&_backing) {
             _backing = _backing.mutableCopy(_sliceRange)
         }
-        let mutableBytes = _backing.mutableBytes ?? UnsafeMutableRawPointer(bitPattern: 0xBAD0)!
+        let mutableBytes = _backing.mutableBytes?.advanced(by: _sliceRange.lowerBound) ?? UnsafeMutableRawPointer(bitPattern: 0xBAD0)!
         let contentPtr = mutableBytes.bindMemory(to: ContentType.self, capacity: count / MemoryLayout<ContentType>.stride)
         return try body(UnsafeMutablePointer(contentPtr))
     }
@@ -1126,7 +1126,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     @inline(__always)
     private func _copyBytesHelper(to pointer: UnsafeMutableRawPointer, from range: NSRange) {
         if range.length == 0 { return }
-        memcpy(UnsafeMutableRawPointer(pointer), _backing.bytes!.advanced(by: range.location + _sliceRange.lowerBound), range.length)
+        memcpy(UnsafeMutableRawPointer(pointer), _backing.bytes!.advanced(by: range.location), range.length)
     }
     
     /// Copy a subset of the contents of the data to a pointer.
@@ -1256,7 +1256,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
         if !isKnownUniquelyReferenced(&_backing) {
             _backing = _backing.mutableCopy(_sliceRange)
         }
-        _backing.append(other._backing)
+        _backing.append(other._backing, startingAt: other._sliceRange.lowerBound)
         _sliceRange = _sliceRange.lowerBound..<(_sliceRange.upperBound + other.count)
     }
     
@@ -1271,15 +1271,6 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
         }
         _backing.append(buffer.baseAddress!, length: buffer.count * MemoryLayout<SourceType>.stride)
         _sliceRange = _sliceRange.lowerBound..<(_sliceRange.upperBound + buffer.count * MemoryLayout<SourceType>.stride)
-    }
-    
-    @inline(__always)
-    public mutating func append(_ other: MutableRangeReplaceableRandomAccessSlice<Data>) {
-        let count = other.count
-        if count == 0 { return }
-        other.base.withUnsafeBytes { (bytes: UnsafePointer<UInt8>) -> Void in
-            append(bytes, count: count)
-        }
     }
     
     @inline(__always)
@@ -1337,12 +1328,27 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
         if !isKnownUniquelyReferenced(&_backing) {
             _backing = _backing.mutableCopy(_sliceRange)
         }
-        data.withUnsafeBytes { (bytes: UnsafePointer<UInt8>) -> Void in
+        let resultingLength = data.withUnsafeBytes { (bytes: UnsafePointer<UInt8>) -> Int in
             let currentLength = _backing.length
             _backing.replaceBytes(in: nsRange, with: bytes, length: cnt)
-            let resultingLength = currentLength - nsRange.length + cnt
-            _sliceRange = _sliceRange.lowerBound..<(_sliceRange.lowerBound + resultingLength)
+            return currentLength - nsRange.length + cnt
         }
+        _sliceRange = _sliceRange.lowerBound..<(_sliceRange.lowerBound + resultingLength)
+    }
+    
+    @inline(__always)
+    public mutating func replaceSubrange(_ subrange: CountableRange<Index>, with data: Data) {
+        let nsRange = NSMakeRange(subrange.lowerBound, subrange.upperBound - subrange.lowerBound)
+        let cnt = data.count
+        if !isKnownUniquelyReferenced(&_backing) {
+            _backing = _backing.mutableCopy(_sliceRange)
+        }
+        let resultingLength = data.withUnsafeBytes { (bytes: UnsafePointer<UInt8>) -> Int in
+            let currentLength = _backing.length
+            _backing.replaceBytes(in: nsRange, with: bytes, length: cnt)
+            return currentLength - nsRange.length + cnt
+        }
+        _sliceRange = _sliceRange.lowerBound..<(_sliceRange.lowerBound + resultingLength)
     }
     
     /// Replace a region of bytes in the data with new bytes from a buffer.
@@ -1489,9 +1495,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     public subscript(index: Index) -> UInt8 {
         @inline(__always)
         get {
-            return withUnsafeBytes { (bytes: UnsafePointer<UInt8>) -> UInt8 in
-                return bytes.advanced(by: index).pointee
-            }
+            return _backing.bytes!.advanced(by: _sliceRange.lowerBound + index).assumingMemoryBound(to: UInt8.self).pointee
         }
         @inline(__always)
         set {
@@ -1510,6 +1514,39 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
         @inline(__always)
         set {
             replaceSubrange(bounds, with: newValue)
+        }
+    }
+    
+    public subscript(bounds: CountableRange<Index>) -> Data {
+        @inline(__always)
+        get {
+            return Data(backing: _backing, range: bounds.lowerBound..<bounds.upperBound)
+        }
+        @inline(__always)
+        set {
+            replaceSubrange(bounds, with: newValue)
+        }
+    }
+    
+    public subscript(bounds: ClosedRange<Index>) -> Data {
+        @inline(__always)
+        get {
+            return Data(backing: _backing, range: bounds.lowerBound..<bounds.upperBound)
+        }
+        @inline(__always)
+        set {
+            replaceSubrange(bounds.lowerBound..<bounds.upperBound, with: newValue)
+        }
+    }
+    
+    public subscript(bounds: CountableClosedRange<Index>) -> Data {
+        @inline(__always)
+        get {
+            return Data(backing: _backing, range: bounds.lowerBound..<bounds.upperBound)
+        }
+        @inline(__always)
+        set {
+            replaceSubrange(bounds.lowerBound..<bounds.upperBound, with: newValue)
         }
     }
     

--- a/test/stdlib/TestData.swift
+++ b/test/stdlib/TestData.swift
@@ -944,6 +944,23 @@ class TestData : TestDataSuper {
             }
         }
     }
+
+    func test_rangeZoo() {
+        let r1 = Range(0..<1)
+        let r2 = CountableRange(0..<1)
+        let r3 = ClosedRange(0..<1)
+        let r4 = CountableClosedRange(0..<1)
+
+        let data = Data(bytes: [8, 1, 2, 3, 4])
+        let slice1: Data = data[r1]
+        let slice2: Data = data[r2]
+        let slice3: Data = data[r3]
+        let slice4: Data = data[r4]
+        expectEqual(slice1[0], 8)
+        expectEqual(slice2[0], 8)
+        expectEqual(slice3[0], 8)
+        expectEqual(slice4[0], 8)
+    }
 }
 
 #if !FOUNDATION_XCTEST
@@ -989,6 +1006,7 @@ DataTests.test("test_AnyHashableCreatedFromNSData") { TestData().test_AnyHashabl
 DataTests.test("test_noCopyBehavior") { TestData().test_noCopyBehavior() }
 DataTests.test("test_doubleDeallocation") { TestData().test_doubleDeallocation() }
 DataTests.test("test_repeatingValueInitialization") { TestData().test_repeatingValueInitialization() }
+DataTests.test("test_rangeZoo") { TestData().test_rangeZoo() }
 
 // XCTest does not have a crash detection, whereas lit does
 DataTests.test("bounding failure subdata") {


### PR DESCRIPTION
Fixes a potential regression that Data may not be sub-scriptable by all range variants
rdar://problem/31417569