### PR TITLE
[SourceKit] Use offset to indicate the locations of parameters' parents. rdar://30702790

### DIFF
--- a/test/SourceKit/CursorInfo/cursor_label.swift
+++ b/test/SourceKit/CursorInfo/cursor_label.swift
@@ -10,6 +10,6 @@ c.foo(aa : 1)
 // RUN: %sourcekitd-test -req=cursor -pos=3:13 %s -- %s | %FileCheck %s -check-prefix=CHECK2
 // RUN: %sourcekitd-test -req=cursor -pos=4:24 %s -- %s | %FileCheck %s -check-prefix=CHECK3
 
-// CHECK1: PARENT LOC: 2:3
-// CHECK2: PARENT LOC: 3:8
-// CHECK3: PARENT LOC: 4:3
+// CHECK1: PARENT OFFSET: 13
+// CHECK2: PARENT OFFSET: 37
+// CHECK3: PARENT OFFSET: 56

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -285,7 +285,7 @@ struct CursorInfo {
   /// All available actions on the code under cursor.
   ArrayRef<StringRef> AvailableActions;
   bool IsSystem = false;
-  llvm::Optional<std::pair<unsigned, unsigned>> ParentNameLoc;
+  llvm::Optional<unsigned> ParentNameOffset;
 };
 
 struct RangeInfo {

--- a/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
@@ -1269,15 +1269,8 @@ static void printCursorInfo(sourcekitd_variant_t Info, StringRef FilenameIn,
                                                                 KeyActionName));
   }
 
-  Optional<std::pair<unsigned, unsigned>> ParentLoc;
-  sourcekitd_variant_t ParentLocObj =
-    sourcekitd_variant_dictionary_get_value(Info, KeyParentLoc);
-  if (sourcekitd_variant_get_type(ParentLocObj) ==
-      SOURCEKITD_VARIANT_TYPE_DICTIONARY) {
-    ParentLoc.emplace(
-      sourcekitd_variant_dictionary_get_int64(ParentLocObj, KeyLine),
-      sourcekitd_variant_dictionary_get_int64(ParentLocObj, KeyColumn));
-  }
+  uint64_t ParentOffset =
+    sourcekitd_variant_dictionary_get_int64(Info, KeyParentLoc);
 
   OS << Kind << " (";
   if (Offset.hasValue()) {
@@ -1335,8 +1328,8 @@ static void printCursorInfo(sourcekitd_variant_t Info, StringRef FilenameIn,
   for (auto Action : AvailableActions)
     OS << Action << '\n';
   OS << "ACTIONS END\n";
-  if (ParentLoc) {
-    OS << "PARENT LOC: " << ParentLoc->first << ":" << ParentLoc->second << "\n";
+  if (ParentOffset) {
+    OS << "PARENT OFFSET: " << ParentOffset << "\n";
   }
 }
 

--- a/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
@@ -1430,10 +1430,8 @@ static void reportCursorInfo(const CursorInfo &Info, ResponseReceiver Rec) {
       Entry.set(KeyActionName, Name);
     }
   }
-  if (Info.ParentNameLoc) {
-    auto PL = Elem.setDictionary(KeyParentLoc);
-    PL.set(KeyLine, Info.ParentNameLoc->first);
-    PL.set(KeyColumn, Info.ParentNameLoc->second);
+  if (Info.ParentNameOffset) {
+    Elem.set(KeyParentLoc, Info.ParentNameOffset.getValue());
   }
   if (!Info.AnnotatedRelatedDeclarations.empty()) {
     auto RelDecls = Elem.setArray(KeyRelatedDecls);


### PR DESCRIPTION
This facilitates subsequent requests. 