### PR TITLE
[Constraint solver] Remove invalid assert from constraint propagation.

### DIFF
--- a/lib/Sema/CSPropagate.cpp
+++ b/lib/Sema/CSPropagate.cpp
@@ -52,12 +52,9 @@ getBindOverloadDisjunction(ConstraintSystem &CS, Constraint *applicableFn) {
   }
 #endif
 
-  // Ensure that we're applying this binding in our applicable
-  // function constraint.
+  // Verify the disjunction consists of BindOverload constraints.
   assert(found->getNestedConstraints().front()->getKind() ==
          ConstraintKind::BindOverload);
-  assert(tyvar->isEqual(
-             found->getNestedConstraints().front()->getFirstType()));
 
   return found;
 }


### PR DESCRIPTION
It turns out that for disjunctions formed for subscripts, we have an
explicit function type (e.g. ($T1)->$T2) for the LHS of the bind
overload constraint, and when a subscript is mixed with an explicit
call (e.g. x[i](2)) we end up with an applicable function constraint
where the RHS is $T2 (which is a function type itself), so this assert
was invalid.

Fundamentally the assert wasn't checking anything important, so it won't
be missed. The important check here is that the applicable function
constraint that we started with is only involved in one disjunction
since we're only returning one.

This shows up in test/Constraints/overload.swift when I run it with
-propagate-constraints enabled:
  func test20886179(_ handlers: [(Int) -> Void], buttonIndex: Int) {
    handlers[buttonIndex](buttonIndex)
  }
