### PR TITLE
[Docs] Added end braces to code example 

### DIFF
--- a/docs/GenericsManifesto.md
+++ b/docs/GenericsManifesto.md
@@ -511,13 +511,13 @@ protocol P {
 }
 
 extension P {
-  func foo() { print("P.foo()")
-  func bar() { print("P.bar()")
+  func foo() { print("P.foo()") }
+  func bar() { print("P.bar()") }
 }
 
 struct X : P {
-  func foo() { print("X.foo()")
-  func bar() { print("X.bar()")
+  func foo() { print("X.foo()") }
+  func bar() { print("X.bar()") }
 }
 
 let x = X()


### PR DESCRIPTION
<!-- What's in this pull request? -->
This PR fixes a code example in the docs that was missing end braces (and wouldn't compile).

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
