### PR TITLE
[swiftc (31 vs. 5511)] Add crasher in swift::TypeAliasDecl::setUnderlyingType(...)

### DIFF
--- a/validation-test/compiler_crashers/28732-type-hasarchetype-not-fully-substituted.swift
+++ b/validation-test/compiler_crashers/28732-type-hasarchetype-not-fully-substituted.swift
@@ -1,0 +1,15 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+{
+protocol A{
+struct A:P{
+}typealias a
+protocol
+P{typealias e:=a


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeAliasDecl::setUnderlyingType(...)`.

Current number of unresolved compiler crashers: 31 (5511 resolved)

/cc @slavapestov - just wanted to let you know that this crasher caused an assertion failure for the assertion `!type->hasArchetype() && "not fully substituted"` added on 2016-08-24 by you in commit 1c1ab0b8 :-)

Assertion failure in [`lib/AST/GenericEnvironment.cpp (line 183)`](https://github.com/apple/swift/blob/8e137a63714a7ad6dc0426e45d6ab81d691c7114/lib/AST/GenericEnvironment.cpp#L183):

```
Assertion `!type->hasArchetype() && "not fully substituted"' failed.

When executing: swift::Type swift::GenericEnvironment::mapTypeOutOfContext(swift::Type) const
```

Assertion context:

```c++

Type GenericEnvironment::mapTypeOutOfContext(Type type) const {
  type = type.subst(QueryArchetypeToInterfaceSubstitutions(this),
                    MakeAbstractConformanceForGenericType(),
                    SubstFlags::AllowLoweredTypes);
  assert(!type->hasArchetype() && "not fully substituted");
  return type;
}

Type GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(
                                                SubstitutableType *type) const {
```
Stack trace:

```
0 0x0000000003970728 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3970728)
1 0x0000000003970e66 SignalHandler(int) (/path/to/swift/bin/swift+0x3970e66)
2 0x00007fe3e8b77390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007fe3e709d428 gsignal /build/glibc-9tT8Do/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007fe3e709f02a abort /build/glibc-9tT8Do/glibc-2.23/stdlib/abort.c:91:0
5 0x00007fe3e7095bd7 __assert_fail_base /build/glibc-9tT8Do/glibc-2.23/assert/assert.c:92:0
6 0x00007fe3e7095c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x00000000014a2563 (/path/to/swift/bin/swift+0x14a2563)
8 0x00000000014818b5 swift::TypeAliasDecl::setUnderlyingType(swift::Type) (/path/to/swift/bin/swift+0x14818b5)
9 0x00000000012ffd1e (anonymous namespace)::ConformanceChecker::recordTypeWitness(swift::AssociatedTypeDecl*, swift::Type, swift::TypeDecl*, bool) (/path/to/swift/bin/swift+0x12ffd1e)
10 0x00000000012faaa4 (anonymous namespace)::ConformanceChecker::resolveTypeWitnesses() (/path/to/swift/bin/swift+0x12faaa4)
11 0x00000000012f32d4 (anonymous namespace)::MultiConformanceChecker::checkAllConformances() (/path/to/swift/bin/swift+0x12f32d4)
12 0x00000000012f41da swift::TypeChecker::checkConformancesInContext(swift::DeclContext*, swift::IterableDeclContext*) (/path/to/swift/bin/swift+0x12f41da)
13 0x00000000012c3c87 (anonymous namespace)::DeclChecker::visitStructDecl(swift::StructDecl*) (/path/to/swift/bin/swift+0x12c3c87)
14 0x00000000012b3a87 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x12b3a87)
15 0x00000000012c4e1b (anonymous namespace)::DeclChecker::visitProtocolDecl(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0x12c4e1b)
16 0x00000000012b3a97 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x12b3a97)
17 0x00000000012b3893 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x12b3893)
18 0x000000000131e6a6 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x131e6a6)
19 0x000000000131dd5b swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) (/path/to/swift/bin/swift+0x131dd5b)
20 0x000000000133847c swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) (/path/to/swift/bin/swift+0x133847c)
21 0x000000000129f2e0 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x129f2e0)
22 0x000000000131e705 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x131e705)
23 0x000000000131df16 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0x131df16)
24 0x0000000001332a40 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x1332a40)
25 0x0000000000fa1066 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xfa1066)
26 0x00000000004a873f swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a873f)
27 0x00000000004650b7 main (/path/to/swift/bin/swift+0x4650b7)
28 0x00007fe3e7088830 __libc_start_main /build/glibc-9tT8Do/glibc-2.23/csu/../csu/libc-start.c:325:0
29 0x0000000000462759 _start (/path/to/swift/bin/swift+0x462759)
```