### PR TITLE
[swiftc (32 vs. 5511)] Add crasher in swift::TypeChecker::substMemberTypeWithBase

### DIFF
--- a/validation-test/compiler_crashers/28733-parent-parent-is-nominaltype-parent-is-boundgenerictype-parent-is-unboundgeneric.swift
+++ b/validation-test/compiler_crashers/28733-parent-parent-is-nominaltype-parent-is-boundgenerictype-parent-is-unboundgeneric.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol P{class a:Self.a


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeChecker::substMemberTypeWithBase`.

Current number of unresolved compiler crashers: 32 (5511 resolved)

/cc @slavapestov - just wanted to let you know that this crasher caused an assertion failure for the assertion `(!Parent || Parent->is<NominalType>() || Parent->is<BoundGenericType>() || Parent->is<UnboundGenericType>()) && "parent must be a nominal type"` added on 2016-11-03 by you in commit 5780a9f52 :-)

Assertion failure in [`lib/AST/ASTContext.cpp (line 2695)`](https://github.com/apple/swift/blob/6f8adcc56a2701d8644c26bcaa8dbc77617b9183/lib/AST/ASTContext.cpp#L2695):

```
Assertion `(!Parent || Parent->is<NominalType>() || Parent->is<BoundGenericType>() || Parent->is<UnboundGenericType>()) && "parent must be a nominal type"' failed.

When executing: static swift::NominalType *swift::NominalType::get(swift::NominalTypeDecl *, swift::Type, const swift::ASTContext &)
```

Assertion context:

```c++
  assert((isa<ProtocolDecl>(D) || !D->getGenericParams()) &&
         "must be a non-generic type decl");
  assert((!Parent || Parent->is<NominalType>() ||
          Parent->is<BoundGenericType>() ||
          Parent->is<UnboundGenericType>()) &&
         "parent must be a nominal type");

  switch (D->getKind()) {
  case DeclKind::Enum:
    return EnumType::get(cast<EnumDecl>(D), Parent, C);
  case DeclKind::Struct:
```
Stack trace:

```
0 0x0000000003970728 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3970728)
1 0x0000000003970e66 SignalHandler(int) (/path/to/swift/bin/swift+0x3970e66)
2 0x00007ff1b6c75390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007ff1b519b428 gsignal /build/glibc-9tT8Do/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007ff1b519d02a abort /build/glibc-9tT8Do/glibc-2.23/stdlib/abort.c:91:0
5 0x00007ff1b5193bd7 __assert_fail_base /build/glibc-9tT8Do/glibc-2.23/assert/assert.c:92:0
6 0x00007ff1b5193c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x00000000013e588e (/path/to/swift/bin/swift+0x13e588e)
8 0x0000000001323ba3 swift::TypeChecker::substMemberTypeWithBase(swift::ModuleDecl*, swift::TypeDecl*, swift::Type) (/path/to/swift/bin/swift+0x1323ba3)
9 0x00000000012e776d swift::TypeChecker::lookupMemberType(swift::DeclContext*, swift::Type, swift::Identifier, swift::OptionSet<swift::NameLookupFlags, unsigned int>) (/path/to/swift/bin/swift+0x12e776d)
10 0x000000000132564c resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x132564c)
11 0x0000000001324e43 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x1324e43)
12 0x0000000001325f57 (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0x1325f57)
13 0x0000000001325e5c swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x1325e5c)
14 0x000000000132455a swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x132455a)
15 0x00000000012ad137 swift::TypeChecker::checkInheritanceClause(swift::Decl*, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0x12ad137)
16 0x00000000012b5371 swift::TypeChecker::validateDecl(swift::ValueDecl*) (/path/to/swift/bin/swift+0x12b5371)
17 0x00000000012c3d1c (anonymous namespace)::DeclChecker::visitClassDecl(swift::ClassDecl*) (/path/to/swift/bin/swift+0x12c3d1c)
18 0x00000000012b398b (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x12b398b)
19 0x00000000012c4e1b (anonymous namespace)::DeclChecker::visitProtocolDecl(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0x12c4e1b)
20 0x00000000012b3a97 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x12b3a97)
21 0x00000000012b3893 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x12b3893)
22 0x00000000013329c5 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x13329c5)
23 0x0000000000fa1066 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xfa1066)
24 0x00000000004a873f swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a873f)
25 0x00000000004650b7 main (/path/to/swift/bin/swift+0x4650b7)
26 0x00007ff1b5186830 __libc_start_main /build/glibc-9tT8Do/glibc-2.23/csu/../csu/libc-start.c:325:0
27 0x0000000000462759 _start (/path/to/swift/bin/swift+0x462759)
```