### PR TITLE
[Constraint solver] Fix a fix-it formatting issue.

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7056,6 +7056,9 @@ bool ConstraintSystem::applySolutionFix(Expr *expr,
   }
 
   case FixKind::ForceDowncast: {
+    if (auto *paren = dyn_cast<ParenExpr>(affected))
+      affected = paren->getSubExpr();
+
     auto fromType = solution.simplifyType(getType(affected))
                       ->getRValueObjectType();
     Type toType = solution.simplifyType(fix.first.getTypeArgument(*this));
@@ -7078,7 +7081,7 @@ bool ConstraintSystem::applySolutionFix(Expr *expr,
       insertAfter += ")";
     }
     insertAfter += useAs ? " as " : " as! ";
-    insertAfter += toType.getString();
+    insertAfter += toType->getWithoutParens()->getString();
     if (needsParensOutside)
       insertAfter += ")";
     


### PR DESCRIPTION
With constraint propagation enabled, we go down a different path in the
solver that results in a type with ParenType wrapped around it. Normally
in diagnostic formatting we would strip these off, but in explicitly
forming a string for a fixit, we need to do it ourself. Hits in
test/Parse/try.swift with constraint propagation enabled.
