### PR TITLE
[SILDiagnostics] Add static enforcement of Law of Exclusivity

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -84,6 +84,13 @@ ERROR(inout_argument_alias,none,
 NOTE(previous_inout_alias,none,
       "previous aliasing argument", ())
 
+ERROR(exclusivity_access_required,none,
+      "%select{initialization|read|modification|deinitialization}0 requires "
+      "%select{exclusive|shared}1 access", (unsigned, unsigned))
+NOTE(exclusivity_conflicting_access,none,
+     "conflicting %select{initialization|read|modification|deinitialization}0 "
+     "requires %select{exclusive|shared}1 access", (unsigned, unsigned))
+
 ERROR(unsupported_c_function_pointer_conversion,none,
       "C function pointer signature %0 is not compatible with expected type %1",
       (Type, Type))

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -112,6 +112,8 @@ PASS(DefiniteInitialization, "definite-init",
      "Definite Initialization for Diagnostics")
 PASS(Devirtualizer, "devirtualizer",
      "Indirect Call Devirtualization")
+PASS(DiagnoseStaticExclusivity, "diagnose-static-exclusivity",
+     "Static Enforcement of Law of Exclusivity")
 PASS(DiagnoseUnreachable, "diagnose-unreachable",
      "Diagnose Unreachable Code")
 PASS(DiagnosticConstantPropagation, "diagnostic-constant-propagation",

--- a/lib/SILOptimizer/Mandatory/CMakeLists.txt
+++ b/lib/SILOptimizer/Mandatory/CMakeLists.txt
@@ -3,6 +3,7 @@ set(MANDATORY_SOURCES
   Mandatory/DefiniteInitialization.cpp
   Mandatory/DIMemoryUseCollector.cpp
   Mandatory/DataflowDiagnostics.cpp
+  Mandatory/DiagnoseStaticExclusivity.cpp
   Mandatory/DiagnoseUnreachable.cpp
   Mandatory/GuaranteedARCOpts.cpp
   Mandatory/MandatoryInlining.cpp

--- a/lib/SILOptimizer/Mandatory/DiagnoseStaticExclusivity.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseStaticExclusivity.cpp
@@ -1,0 +1,349 @@
+//===--- DiagnoseStaticExclusivity.cpp - Find violations of exclusivity ---===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements a diagnostic pass that finds violations of the
+// "Law of Exclusivity" at compile time. The Law of Exclusivity requires
+// that the access duration of any access to an address not overlap
+// with an access to the same address unless both accesses are reads.
+//
+// This pass relies on 'begin_access' and 'end_access' SIL instruction
+// markers inserted during SILGen to determine when an access to an address
+// begins and ends. It models the in-progress accesses with a map from
+// storage locations to the counts of read and write-like accesses in progress
+// for that location.
+//
+//===----------------------------------------------------------------------===//
+
+#define DEBUG_TYPE "static-exclusivity"
+#include "swift/AST/DiagnosticsSIL.h"
+#include "swift/SIL/CFG.h"
+#include "swift/SIL/SILInstruction.h"
+#include "swift/SILOptimizer/PassManager/Passes.h"
+#include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "llvm/ADT/PostOrderIterator.h"
+#include "llvm/Support/Debug.h"
+using namespace swift;
+
+template <typename... T, typename... U>
+static InFlightDiagnostic diagnose(ASTContext &Context, SourceLoc loc,
+                                   Diag<T...> diag, U &&... args) {
+  return Context.Diags.diagnose(loc, diag, std::forward<U>(args)...);
+}
+
+namespace {
+
+enum class AccessedStorageKind : unsigned {
+  /// The access is to a location represented by a SIL value
+  /// (for example, an 'alloc_box' instruction for a local variable).
+  /// Two accesses accessing the exact same SILValue are considered to be
+  /// accessing the same storage location.
+  Value,
+
+  /// The access is to a global variable.
+  GlobalVar
+};
+
+/// Represents the identity of a storage location being accessed.
+/// This is used to determine when two 'begin_access' instructions
+/// definitely access the same underlying location.
+class AccessedStorage {
+  AccessedStorageKind Kind;
+
+  union {
+    SILValue Value;
+    SILGlobalVariable *Global;
+  };
+
+public:
+  AccessedStorage(SILValue V)
+      : Kind(AccessedStorageKind::Value), Value(V) { }
+
+  AccessedStorage(SILGlobalVariable *Global)
+      : Kind(AccessedStorageKind::GlobalVar), Global(Global) {}
+
+  AccessedStorageKind getKind() const { return Kind; }
+
+  SILValue getValue() const {
+    assert(Kind == AccessedStorageKind::Value);
+    return Value;
+  }
+
+  SILGlobalVariable *getGlobal() const {
+    assert(Kind == AccessedStorageKind::GlobalVar);
+    return Global;
+  }
+};
+
+/// Models the in-progress accesses for a single storage location.
+class AccessInfo {
+
+  /// The number of in-progress 'read' accesses (that is 'begin_access [read]'
+  /// instructions that have not yet had the corresponding 'end_access').
+  unsigned Reads = 0;
+
+  /// The number of in-progress write-like accesses.
+  unsigned NonReads = 0;
+
+  /// The instruction that began the first in-progress access to the storage
+  /// location. Used for diagnostic purposes.
+  const BeginAccessInst *FirstAccess = nullptr;
+
+public:
+  // Returns true when beginning an access of the given Kind will
+  // result in a conflict with a previous access.
+  bool conflictsWithAccess(SILAccessKind Kind) {
+    if (Kind == SILAccessKind::Read) {
+      // A read conflicts with any non-read accesses.
+      return NonReads > 0;
+    } else {
+      // A non-read access conflicts any other access.
+      return NonReads > 0 || Reads > 0;
+    }
+  }
+
+  /// Returns true when there must have already been a conflict diagnosed
+  /// for an in-progress access. Used to suppress multiple diagnostics for
+  /// the same underlying access violation.
+  bool alreadyHadConflict() {
+    return (NonReads > 0 && Reads > 0) || (NonReads > 1);
+  }
+
+  /// Returns true when there are any accesses to this location in progress.
+  bool hasAccessesInProgress() { return Reads > 0 || NonReads > 0; }
+
+  /// Increment the count for given access.
+  void beginAccess(const BeginAccessInst *BAI) {
+    if (!FirstAccess) {
+      assert(Reads == 0 && NonReads == 0);
+      FirstAccess = BAI;
+    }
+
+    if (BAI->getAccessKind() == SILAccessKind::Read)
+      Reads++;
+    else
+      NonReads++;
+  }
+
+  /// Decrement the count for given access.
+  void endAccess(const EndAccessInst *EAI) {
+    if (EAI->getBeginAccess()->getAccessKind() == SILAccessKind::Read)
+      Reads--;
+    else
+      NonReads--;
+
+    // If all open accesses are now ended, forget the location of the
+    // first access.
+    if (Reads == 0 && NonReads == 0)
+      FirstAccess = nullptr;
+  }
+
+  /// Returns the instruction that began the first in-progress access.
+  const BeginAccessInst *getFirstAccess() { return FirstAccess; }
+};
+
+} // end anonymous namespace
+
+namespace llvm {
+/// Enable using AccessedStorage as a key in DenseMap.
+template <> struct DenseMapInfo<AccessedStorage> {
+  static AccessedStorage getEmptyKey() {
+    return AccessedStorage(swift::SILValue::getFromOpaqueValue(
+        llvm::DenseMapInfo<void *>::getEmptyKey()));
+  }
+
+  static AccessedStorage getTombstoneKey() {
+    return AccessedStorage(swift::SILValue::getFromOpaqueValue(
+        llvm::DenseMapInfo<void *>::getTombstoneKey()));
+  }
+
+  static unsigned getHashValue(AccessedStorage Storage) {
+    switch (Storage.getKind()) {
+    case AccessedStorageKind::Value:
+      return DenseMapInfo<swift::SILValue>::getHashValue(Storage.getValue());
+    case AccessedStorageKind::GlobalVar:
+      return DenseMapInfo<void *>::getHashValue(Storage.getGlobal());
+    }
+    llvm_unreachable("Unhandled AccessedStorageKind");
+  }
+
+  static bool isEqual(AccessedStorage LHS, AccessedStorage RHS) {
+    if (LHS.getKind() != RHS.getKind())
+      return false;
+
+    switch (LHS.getKind()) {
+    case AccessedStorageKind::Value:
+      return LHS.getValue() == RHS.getValue();
+    case AccessedStorageKind::GlobalVar:
+      return LHS.getGlobal() == RHS.getGlobal();
+    }
+    llvm_unreachable("Unhandled AccessedStorageKind");
+  }
+};
+
+} // end namespace llvm
+
+/// Emits a diagnostic if beginning an access with the given in-progress
+/// accesses violates the law of exclusivity. Returns true when a
+/// diagnostic was emitted.
+static void diagnoseExclusivityViolation(const BeginAccessInst *PriorAccess,
+                                         const BeginAccessInst *NewAccess,
+                                         ASTContext &Ctx) {
+  // This enum needs to be kept in sync with diag::exclusivity_access_required
+  // and diag::exclusivity_conflicting_access.
+  enum ExclusiveOrShared_t : unsigned { ExclusiveAccess = 0, SharedAccess = 1 };
+
+  // Can't have a conflict if both accesses are reads.
+  assert(!(PriorAccess->getAccessKind() == SILAccessKind::Read &&
+           NewAccess->getAccessKind() == SILAccessKind::Read));
+
+  ExclusiveOrShared_t NewRequires;
+  if (NewAccess->getAccessKind() == SILAccessKind::Read) {
+    NewRequires = SharedAccess;
+  } else {
+    NewRequires = ExclusiveAccess;
+  }
+
+  ExclusiveOrShared_t PriorRequires;
+  if (PriorAccess->getAccessKind() == SILAccessKind::Read) {
+    PriorRequires = SharedAccess;
+  } else {
+    PriorRequires = ExclusiveAccess;
+  }
+
+  diagnose(Ctx, NewAccess->getLoc().getSourceLoc(),
+           diag::exclusivity_access_required,
+           static_cast<unsigned>(NewAccess->getAccessKind()),
+           static_cast<unsigned>(NewRequires));
+  diagnose(Ctx, PriorAccess->getLoc().getSourceLoc(),
+           diag::exclusivity_conflicting_access,
+           static_cast<unsigned>(PriorAccess->getAccessKind()),
+           static_cast<unsigned>(PriorRequires));
+}
+
+/// Look through a value to find the underlying storage
+/// accessed.
+static AccessedStorage findAccessedStorage(SILValue Source) {
+  SILValue Iter = Source;
+  while (true) {
+    if (auto *PBI = dyn_cast<ProjectBoxInst>(Iter)) {
+      Iter = PBI->getOperand();
+    } else if (auto *CVI = dyn_cast<CopyValueInst>(Iter)) {
+      Iter = CVI->getOperand();
+    } else if (auto *GAI = dyn_cast<GlobalAddrInst>(Iter)) {
+      return AccessedStorage(GAI->getReferencedGlobal());
+    } else {
+      assert(Iter->getType().isAddress() || Iter->getType().is<SILBoxType>());
+      return AccessedStorage(Iter);
+    }
+  }
+}
+
+using StorageMap = llvm::SmallDenseMap<AccessedStorage, AccessInfo, 4>;
+
+static void checkStaticExclusivity(SILFunction &Fn) {
+  // The implementation relies on the following SIL invariants:
+  //    - All incoming edges to a block must have the same in-progress
+  //      accesses. This enables the analysis to not perform a data flow merge
+  //      on incoming edges.
+  //    - Further, for a given address each of the in-progress
+  //      accesses must have begun in the same order on all edges. This ensures
+  //      consistent diagnostics across changes to the exploration of the CFG.
+  //    - On return from a function there are no in-progress accesses. This
+  //      enables a sanity check for lean analysis state at function exit.
+  //    - Each end_access instruction corresponds to exactly one begin access
+  //      instruction. (This is encoded in the EndAccessInst itself)
+  //    - begin_access arguments cannot be basic block arguments.
+  //      This enables the analysis to look back to find the *single* storage
+  //      storage location accessed.
+
+  if (Fn.empty())
+    return;
+
+  // This is a staging flag. Eventually the ability to turn off static
+  // enforcement will be removed.
+  if (!Fn.getModule().getOptions().EnforceExclusivityStatic)
+    return;
+
+  // For each basic block, track the stack of current accesses on
+  // exit from that block.
+  llvm::SmallDenseMap<SILBasicBlock *, Optional<StorageMap>, 32>
+      BlockOutAccesses;
+
+  BlockOutAccesses[Fn.getEntryBlock()] = StorageMap();
+
+  llvm::ReversePostOrderTraversal<SILFunction *> RPOT(&Fn);
+  for (auto *BB : RPOT) {
+    Optional<StorageMap> &BBState = BlockOutAccesses[BB];
+
+    // Because we use a reverse post-order traversal, unless this is the entry
+    // at least one of its predecessors must have been reached. Use the out
+    // state for that predecessor as our in state. The SIL verifier guarantees
+    // that all incoming edges must have the same current accesses.
+    for (auto *Pred : BB->getPredecessorBlocks()) {
+      const Optional<StorageMap> &PredAccesses = BlockOutAccesses[Pred];
+      if (PredAccesses) {
+        BBState = PredAccesses;
+        break;
+      }
+    }
+
+    // The in-progress accesses for the current program point, represented
+    // as map from storage locations to the accesses in progress for the
+    // location.
+    StorageMap &Accesses = *BBState;
+
+    for (auto I = BB->begin(), E = BB->end(); I != E; ++I) {
+      // Apply transfer functions. Beginning an access
+      // increments the read or write count for the storage location;
+      // Ending onr decrements the count.
+      if (auto *BAI = dyn_cast<BeginAccessInst>(I)) {
+        SILAccessKind Kind = BAI->getAccessKind();
+        AccessInfo &Info = Accesses[findAccessedStorage(BAI->getSource())];
+        if (Info.conflictsWithAccess(Kind) && !Info.alreadyHadConflict()) {
+          const BeginAccessInst *Conflict = Info.getFirstAccess();
+          assert(Conflict && "Must already have had access to conflict!");
+          diagnoseExclusivityViolation(Conflict, BAI, Fn.getASTContext());
+        }
+
+        Info.beginAccess(BAI);
+      } else if (auto *EAI = dyn_cast<EndAccessInst>(I)) {
+        auto It = Accesses.find(findAccessedStorage(EAI->getSource()));
+        AccessInfo &Info = It->getSecond();
+        Info.endAccess(EAI);
+
+        // If the storage location has no more in-progress accesses, remove
+        // it to keep the StorageMap lean.
+        if (!Info.hasAccessesInProgress())
+          Accesses.erase(It);
+      } else if (auto *RI = dyn_cast<ReturnInst>(I)) {
+        // Sanity check to make sure entries are properly removed.
+        assert(Accesses.size() == 0);
+      }
+    }
+  }
+}
+
+namespace {
+
+class DiagnoseStaticExclusivity : public SILFunctionTransform {
+public:
+  DiagnoseStaticExclusivity() {}
+
+private:
+  void run() override { checkStaticExclusivity(*getFunction()); }
+};
+
+} // end anonymous namespace
+
+SILTransform *swift::createDiagnoseStaticExclusivity() {
+  return new DiagnoseStaticExclusivity();
+}

--- a/test/SILOptimizer/exclusivity_static_diagnostics.sil
+++ b/test/SILOptimizer/exclusivity_static_diagnostics.sil
@@ -1,0 +1,343 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s -enforce-exclusivity-static=true -diagnose-static-exclusivity -verify | %FileCheck %s
+
+sil_stage raw
+
+import Builtin
+import Swift
+
+
+sil @takesTwoInouts : $@convention(thin) (@inout Int, @inout Int) -> ()
+sil @takesOneInout : $@convention(thin) (@inout Int) -> ()
+sil @makesInt : $@convention(thin) () -> Int
+
+// CHECK-LABEL: sil hidden @twoLocalInoutsDisaliased
+sil hidden @twoLocalInoutsDisaliased : $@convention(thin) (Int) -> () {
+bb0(%0 : $Int):
+  %2 = alloc_box ${ var Int }
+  %3 = project_box %2 : ${ var Int }, 0
+  store %0 to [trivial] %3 : $*Int
+  %5 = alloc_box ${ var Int }
+  %6 = project_box %5 : ${ var Int }, 0
+  store %0 to [trivial] %6 : $*Int
+  %8 = function_ref @takesTwoInouts : $@convention(thin) (@inout Int, @inout Int) -> ()
+  %9 = begin_access [modify] [unknown] %3 : $*Int
+  %10 = begin_access [modify] [unknown] %6 : $*Int  // no-error
+  %11 = apply %8(%9, %10) : $@convention(thin) (@inout Int, @inout Int) -> ()
+  end_access %10 : $*Int
+  end_access %9: $*Int
+  destroy_value %5 : ${ var Int }
+  destroy_value %2 : ${ var Int }
+  %14 = tuple ()
+  return %14 : $()
+}
+
+// CHECK-LABEL: sil hidden @twoLocalInoutsSimpleAliasing
+sil hidden @twoLocalInoutsSimpleAliasing : $@convention(thin) (Int) -> () {
+bb0(%0 : $Int):
+  %2 = alloc_box ${ var Int }
+  %3 = project_box %2 : ${ var Int }, 0
+  store %0 to [trivial] %3 : $*Int
+  %4 = function_ref @takesTwoInouts : $@convention(thin) (@inout Int, @inout Int) -> ()
+  %5 = begin_access [modify] [unknown] %3 : $*Int  // expected-note {{conflicting modification requires exclusive access}}
+  %6 = begin_access [modify] [unknown] %3 : $*Int  // expected-error {{modification requires exclusive access}}
+  %7 = apply %4(%5, %6) : $@convention(thin) (@inout Int, @inout Int) -> ()
+  end_access %6 : $*Int
+  end_access %5: $*Int
+  destroy_value %2 : ${ var Int }
+  %8 = tuple ()
+  return %8 : $()
+}
+
+// CHECK-LABEL: sil hidden @conflictingPriorAccess
+sil hidden @conflictingPriorAccess : $@convention(thin) (Int) -> () {
+bb0(%0 : $Int):
+  %2 = alloc_box ${ var Int }
+  %3 = project_box %2 : ${ var Int }, 0
+  store %0 to [trivial] %3 : $*Int
+  %4 = function_ref @takesTwoInouts : $@convention(thin) (@inout Int, @inout Int) -> ()
+  %5 = begin_access [modify] [unknown] %3 : $*Int  // expected-note {{conflicting modification requires exclusive access}}
+  %6 = begin_access [modify] [unknown] %5 : $*Int
+  %7 = begin_access [modify] [unknown] %3 : $*Int  // expected-error {{modification requires exclusive access}}
+  %8 = apply %4(%5, %6) : $@convention(thin) (@inout Int, @inout Int) -> ()
+  end_access %7 : $*Int
+  end_access %6 : $*Int
+  end_access %5: $*Int
+  destroy_value %2 : ${ var Int }
+  %9 = tuple ()
+  return %9 : $()
+}
+
+// CHECK-LABEL: sil hidden @twoSequentialInouts
+sil hidden @twoSequentialInouts : $@convention(thin) (Int) -> () {
+bb0(%0 : $Int):
+  %2 = alloc_box ${ var Int }
+  %3 = project_box %2 : ${ var Int }, 0
+  store %0 to [trivial] %3 : $*Int
+  %4 = function_ref @takesOneInout : $@convention(thin) (@inout Int) -> ()
+  %5 = begin_access [modify] [unknown] %3 : $*Int
+  %6 = apply %4(%5) : $@convention(thin) (@inout Int) -> ()
+  end_access %5 : $*Int
+  %7 = begin_access [modify] [unknown] %3 : $*Int // no-error
+  %8 = apply %4(%7) : $@convention(thin) (@inout Int) -> ()
+  end_access %7: $*Int
+  destroy_value %2 : ${ var Int }
+  %9 = tuple ()
+  return %8 : $()
+}
+
+
+// CHECK-LABEL: sil hidden @unconditionalBranch
+sil hidden @unconditionalBranch : $@convention(thin) (Int) -> () {
+bb0(%0 : $Int):
+  %2 = alloc_box ${ var Int }
+  %3 = project_box %2 : ${ var Int }, 0
+  store %0 to [trivial] %3 : $*Int
+  %4 = begin_access [modify] [unknown] %3 : $*Int
+  br finish
+finish:
+  end_access %4: $*Int
+  destroy_value %2 : ${ var Int }
+  %5 = tuple ()
+  return %5 : $()
+}
+
+// CHECK-LABEL: sil hidden @diamondMergeStacks
+sil hidden @diamondMergeStacks : $@convention(thin) (Int, Builtin.Int1) -> () {
+bb0(%0 : $Int, %1 : $Builtin.Int1):
+  %2 = alloc_box ${ var Int }
+  %3 = project_box %2 : ${ var Int }, 0
+  store %0 to [trivial] %3 : $*Int
+  %4 = begin_access [modify] [unknown] %3 : $*Int
+  cond_br %1, then, else
+then:
+  br finish
+else:
+  br finish
+finish:
+  end_access %4: $*Int
+  destroy_value %2 : ${ var Int }
+  %5 = tuple ()
+  return %5 : $()
+}
+
+
+// CHECK-LABEL: sil hidden @loopMergeStacks
+sil hidden @loopMergeStacks : $@convention(thin) (Int, Builtin.Int1) -> () {
+bb0(%0 : $Int, %1 : $Builtin.Int1):
+  %2 = alloc_box ${ var Int }
+  %3 = project_box %2 : ${ var Int }, 0
+  store %0 to [trivial] %3 : $*Int
+  %4 = begin_access [modify] [unknown] %3 : $*Int
+  br bb1
+bb1:
+  cond_br %1, bb1, bb2
+bb2:
+  end_access %4: $*Int
+  destroy_value %2 : ${ var Int }
+  %5 = tuple ()
+  return %5 : $()
+}
+
+// CHECK-LABEL: sil hidden @loopWithError
+sil hidden @loopWithError : $@convention(thin) (Int, Builtin.Int1) -> () {
+bb0(%0 : $Int, %1 : $Builtin.Int1):
+  %2 = alloc_box ${ var Int }
+  %3 = project_box %2 : ${ var Int }, 0
+  store %0 to [trivial] %3 : $*Int
+  br bb1
+bb1:
+  // Make sure we don't diagnose twice.
+  %4 = begin_access [modify] [unknown] %3 : $*Int // expected-note {{conflicting modification requires exclusive access}}
+  %5 = begin_access [modify] [unknown] %3 : $*Int // expected-error {{modification requires exclusive access}}
+  end_access %5: $*Int
+  end_access %4: $*Int
+  cond_br %1, bb1, bb2
+bb2:
+  destroy_value %2 : ${ var Int }
+  %6 = tuple ()
+  return %6 : $()
+}
+
+// CHECK-LABEL: sil hidden @modifySubAccessesAreAllowed
+sil hidden @modifySubAccessesAreAllowed : $@convention(thin) (Int) -> () {
+bb0(%0 : $Int):
+  %2 = alloc_box ${ var Int }
+  %3 = project_box %2 : ${ var Int }, 0
+  store %0 to [trivial] %3 : $*Int
+  %4 = function_ref @takesTwoInouts : $@convention(thin) (@inout Int, @inout Int) -> ()
+  %5 = begin_access [modify] [unknown] %3 : $*Int
+  %6 = begin_access [modify] [unknown] %5 : $*Int  // no-error
+  %7 = apply %4(%5, %6) : $@convention(thin) (@inout Int, @inout Int) -> ()
+  end_access %6 : $*Int
+  end_access %5: $*Int
+  destroy_value %2 : ${ var Int }
+  %8 = tuple ()
+  return %8 : $()
+}
+
+// Multiple access kinds
+
+// CHECK-LABEL: sil hidden @twoLocalReadsSimpleAliasing
+sil hidden @twoLocalReadsSimpleAliasing : $@convention(thin) (Int) -> () {
+bb0(%0 : $Int):
+  %1 = alloc_box ${ var Int }
+  %2 = project_box %1 : ${ var Int }, 0
+  store %0 to [trivial] %2 : $*Int
+  %4 = begin_access [read] [unknown] %2 : $*Int
+  %5 = begin_access [read] [unknown] %2 : $*Int  // no-error
+  end_access %5 : $*Int
+  end_access %4: $*Int
+  destroy_value %1 : ${ var Int }
+  %6 = tuple ()
+  return %6 : $()
+}
+
+// CHECK-LABEL: sil hidden @localReadFollowedByModify
+sil hidden @localReadFollowedByModify : $@convention(thin) (Int) -> () {
+bb0(%0 : $Int):
+  %1 = alloc_box ${ var Int }
+  %2 = project_box %1 : ${ var Int }, 0
+  store %0 to [trivial] %2 : $*Int
+  %4 = begin_access [read] [unknown] %2 : $*Int // expected-note {{conflicting read requires shared access}}
+  %5 = begin_access [modify] [unknown] %2 : $*Int // expected-error {{modification requires exclusive access}}
+  end_access %5 : $*Int
+  end_access %4: $*Int
+  destroy_value %1 : ${ var Int }
+  %6 = tuple ()
+  return %6 : $()
+}
+
+// CHECK-LABEL: sil hidden @localModifyFollowedByRead
+sil hidden @localModifyFollowedByRead : $@convention(thin) (Int) -> () {
+bb0(%0 : $Int):
+  %1 = alloc_box ${ var Int }
+  %2 = project_box %1 : ${ var Int }, 0
+  store %0 to [trivial] %2 : $*Int
+  %4 = begin_access [modify] [unknown] %2 : $*Int // expected-note {{conflicting modification requires exclusive access}}
+  %5 = begin_access [read] [unknown] %2 : $*Int // expected-error {{read requires shared access}}
+  end_access %5 : $*Int
+  end_access %4: $*Int
+  destroy_value %1 : ${ var Int }
+  %6 = tuple ()
+  return %6 : $()
+}
+
+
+// Tests for address identity
+
+// Treat 'alloc_box' as identity for project_box
+
+// CHECK-LABEL: sil hidden @twoAllocBoxProjections
+sil hidden @twoAllocBoxProjections : $@convention(thin) (Int) -> () {
+bb0(%0 : $Int):
+  %2 = alloc_box ${ var Int }
+  %3 = project_box %2 : ${ var Int }, 0
+  store %0 to [trivial] %3 : $*Int
+  %4 = copy_value %2 : ${ var Int }
+  %5 = project_box %4 : ${ var Int }, 0
+  %6 = begin_access [modify] [unknown] %3 : $*Int  // expected-note {{conflicting modification requires exclusive access}}
+  %7 = begin_access [modify] [unknown] %5 : $*Int  // expected-error {{modification requires exclusive access}}
+  end_access %7 : $*Int
+  end_access %6: $*Int
+  destroy_value %2 : ${ var Int }
+  destroy_value %4 : ${ var Int }
+  %8 = tuple ()
+  return %8 : $()
+}
+
+
+// Treat global as identity for global_addr instruction-
+sil_global hidden @global1 : $Int
+sil_global hidden @global2 : $Int
+
+// CHECK-LABEL: sil hidden @modifySameGlobal
+sil hidden @modifySameGlobal : $@convention(thin) (Int) -> () {
+bb0(%0 : $Int):
+  %1 = global_addr @global1 :$*Int
+  %2 = global_addr @global1 :$*Int
+  %3 = begin_access [modify] [unknown] %1 : $*Int  // expected-note {{conflicting modification requires exclusive access}}
+  %4 = begin_access [modify] [unknown] %2 : $*Int  // expected-error {{modification requires exclusive access}}
+  end_access %4 : $*Int
+  end_access %3: $*Int
+  %5 = tuple ()
+  return %5 : $()
+}
+
+// CHECK-LABEL: sil hidden @modifyDifferentGlobal
+sil hidden @modifyDifferentGlobal : $@convention(thin) (Int) -> () {
+bb0(%0 : $Int):
+  %1 = global_addr @global1 :$*Int
+  %2 = global_addr @global2 :$*Int
+  %3 = begin_access [modify] [unknown] %1 : $*Int
+  %4 = begin_access [modify] [unknown] %2 : $*Int  // no-error
+  end_access %4 : $*Int
+  end_access %3: $*Int
+  %5 = tuple ()
+  return %5 : $()
+}
+
+// Multiple errors accessing the same location
+
+// If we have a sequence of begin read - begin write - begin read accesses make
+// sure the the second read doesn't report a confusing read-read conflict.
+// CHECK-LABEL: sil hidden @readWriteReadConflictingThirdAccess
+sil hidden @readWriteReadConflictingThirdAccess : $@convention(thin) (Int) -> () {
+bb0(%0 : $Int):
+  %2 = alloc_box ${ var Int }
+  %3 = project_box %2 : ${ var Int }, 0
+  store %0 to [trivial] %3 : $*Int
+  %4 = function_ref @takesTwoInouts : $@convention(thin) (@inout Int, @inout Int) -> ()
+  %5 = begin_access [read] [unknown] %3 : $*Int  // expected-note {{conflicting read requires shared access}}
+  %6 = begin_access [modify] [unknown] %3 : $*Int  // expected-error {{modification requires exclusive access}}
+  %7 = begin_access [read] [unknown] %3 : $*Int // no-error
+  %8 = apply %4(%5, %6) : $@convention(thin) (@inout Int, @inout Int) -> ()
+  end_access %7 : $*Int
+  end_access %6 : $*Int
+  end_access %5: $*Int
+  destroy_value %2 : ${ var Int }
+  %9 = tuple ()
+  return %9 : $()
+}
+
+// If we have a sequence of begin write - begin write - begin write accesses make sure the
+// third write doesn't report a conflict.
+// CHECK-LABEL: sil hidden @writeWriteWriteConflictingThirdAccess
+sil hidden @writeWriteWriteConflictingThirdAccess : $@convention(thin) (Int) -> () {
+bb0(%0 : $Int):
+  %2 = alloc_box ${ var Int }
+  %3 = project_box %2 : ${ var Int }, 0
+  store %0 to [trivial] %3 : $*Int
+  %4 = function_ref @takesTwoInouts : $@convention(thin) (@inout Int, @inout Int) -> ()
+  %5 = begin_access [modify] [unknown] %3 : $*Int  // expected-note {{conflicting modification requires exclusive access}}
+  %6 = begin_access [modify] [unknown] %3 : $*Int  // expected-error {{modification requires exclusive access}}
+  %7 = begin_access [modify] [unknown] %3 : $*Int  // no-error
+  %8 = apply %4(%5, %6) : $@convention(thin) (@inout Int, @inout Int) -> ()
+  end_access %7 : $*Int
+  end_access %6 : $*Int
+  end_access %5: $*Int
+  destroy_value %2 : ${ var Int }
+  %9 = tuple ()
+  return %9 : $()
+}
+
+// If we have a sequence of begin write - end write - begin write - begin write
+// accesses make sure the it is the second begin write that gets the note
+// about the conflict and not the first
+// CHECK-LABEL: sil hidden @resetFirstAccessForNote
+sil hidden @resetFirstAccessForNote : $@convention(thin) (Int) -> () {
+bb0(%0 : $Int):
+  %2 = alloc_box ${ var Int }
+  %3 = project_box %2 : ${ var Int }, 0
+  store %0 to [trivial] %3 : $*Int
+  %4 = function_ref @takesTwoInouts : $@convention(thin) (@inout Int, @inout Int) -> ()
+  %5 = begin_access [modify] [unknown] %3 : $*Int  // no-note
+  end_access %5 : $*Int
+  %6 = begin_access [modify] [unknown] %3 : $*Int  // expected-note {{conflicting modification requires exclusive access}}
+  %7 = begin_access [modify] [unknown] %3 : $*Int  // expected-error {{modification requires exclusive access}}
+  %8 = apply %4(%5, %6) : $@convention(thin) (@inout Int, @inout Int) -> ()
+  end_access %7 : $*Int
+  end_access %6: $*Int
+  destroy_value %2 : ${ var Int }
+  %9 = tuple ()
+  return %9 : $()
+}

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -178,6 +178,10 @@ AssumeUnqualifiedOwnershipWhenParsing(
     "assume-parsing-unqualified-ownership-sil", llvm::cl::Hidden, llvm::cl::init(false),
     llvm::cl::desc("Assume all parsed functions have unqualified ownership"));
 
+static llvm::cl::opt<bool> EnforceExclusivityStatic(
+    "enforce-exclusivity-static", llvm::cl::Hidden, llvm::cl::init(false),
+    llvm::cl::desc("Diagnose static violations of law of exclusivity."));
+
 static void runCommandLineSelectedPasses(SILModule *Module,
                                          irgen::IRGenModule *IRGenMod) {
   SILPassManager PM(Module, IRGenMod);
@@ -264,6 +268,7 @@ int main(int argc, char **argv) {
   SILOpts.EnableSILOwnership = EnableSILOwnershipOpt;
   SILOpts.AssumeUnqualifiedOwnershipWhenParsing =
     AssumeUnqualifiedOwnershipWhenParsing;
+  SILOpts.EnforceExclusivityStatic = EnforceExclusivityStatic;
 
   // Load the input file.
   llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> FileBufOrErr =


### PR DESCRIPTION
Add a diagnostic pass that emits errors when a violation of the "Law of
Exclusivity" is detected at compile time. The Law of Exclusivity requires
that the access duration of any access to an address not overlap
with an access to the same address unless both accesses are reads.

This pass relies on 'begin_access' and 'end_access' SIL instruction
markers inserted by SILGen to determine when an access to an address begins and
ends. It models the in-progress accesses with a stack of 'begin_access'
instructions.