### PR TITLE
Return a context-allocated StringRef for the SinglePCHImport / Clang module filename

### DIFF
--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -306,10 +306,10 @@ public:
   DeclName importName(const clang::NamedDecl *D,
                       clang::DeclarationName givenName);
 
-  Optional<std::string>
+  StringRef
   getOrCreatePCH(const ClangImporterOptions &ImporterOptions,
                  const std::string &SwiftPCHHash);
-  Optional<std::string>
+  StringRef
   getPCHFilename(const ClangImporterOptions &ImporterOptions,
                  const std::string &SwiftPCHHash);
 };

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -541,7 +541,7 @@ private:
   /// If there is a single .PCH file imported into the __ObjC module, this
   /// is the filename of that PCH. When other files are imported, this should
   /// be llvm::None.
-  Optional<std::string> SinglePCHImport = None;
+  StringRef SinglePCHImport;
 
 public:
   importer::NameImporter &getNameImporter() {
@@ -1170,10 +1170,9 @@ public:
   /// Dump the Swift-specific name lookup tables we generate.
   void dumpSwiftLookupTables();
 
-  void setSinglePCHImport(Optional<std::string> PCHFilename) {
-    if (PCHFilename.hasValue()) {
-      assert(llvm::sys::path::extension(PCHFilename.getValue())
-                 .endswith(PCH_EXTENSION) &&
+  void setSinglePCHImport(StringRef PCHFilename) {
+    if (!PCHFilename.empty()) {
+      assert(llvm::sys::path::extension(PCHFilename).endswith(PCH_EXTENSION) &&
              "Single PCH imported filename doesn't have .pch extension!");
     }
     SinglePCHImport = PCHFilename;
@@ -1182,7 +1181,7 @@ public:
   /// If there was is a single .pch bridging header without other imported
   /// files, we can provide the PCH filename for declaration caching,
   /// especially in code completion. If there are other
-  Optional<std::string> getSinglePCHImport() const {
+  StringRef getSinglePCHImport() const {
     return SinglePCHImport;
   }
 };


### PR DESCRIPTION
Return a context-allocated StringRef for the SinglePCHImport / Clang module filename.
This was previously implicitly converting a std::string to StringRef, which was triggering a use-after-free.

rdar://problem/31455870
