### PR TITLE
[cursor-info] Fix crash due to invalid base type in the PrintOptions passed to the AST printer

### DIFF
--- a/test/SourceKit/CursorInfo/rdar_30248264.swift
+++ b/test/SourceKit/CursorInfo/rdar_30248264.swift
@@ -1,0 +1,14 @@
+// Checks that we don't crash.
+// RUN: %sourcekitd-test -req=cursor -pos=9:25 %s -- %s | %FileCheck %s
+// RUN: %sourcekitd-test -req=cursor -pos=11:13 %s -- %s | %FileCheck -check-prefix=CHECK2 %s
+
+class A {
+  static prefix func +(_:A) {}
+
+  func method() {
+    let _ = "" /*here:*/== ""
+    // CHECK: source.lang.swift.ref.function.operator.infix
+    /*here*/+A()
+    // CHECK2: source.lang.swift.ref.function.operator.prefix
+  }
+}

--- a/test/SourceKit/CursorInfo/rdar_30292429.swift
+++ b/test/SourceKit/CursorInfo/rdar_30292429.swift
@@ -1,0 +1,16 @@
+// Checks that we don't crash.
+// RUN: %sourcekitd-test -req=cursor -pos=10:17 %s -- %s | %FileCheck -check-prefix=CHECK %s
+// RUN: %sourcekitd-test -req=cursor -pos=13:22 %s -- %s | %FileCheck -check-prefix=CHECK2 %s
+
+class A {
+  var field: Bool = true
+  var items: [Int] = []
+
+  func method() {
+    if /*here:*/field {}
+    // CHECK: source.lang.swift.ref.var.instance
+
+    for _ in /*here*/items {}
+    // CHECK2: source.lang.swift.ref.var.instance
+  }
+}

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -455,7 +455,7 @@ template <typename FnTy>
 void walkRelatedDecls(const ValueDecl *VD, const FnTy &Fn) {
   llvm::SmallDenseMap<DeclName, unsigned, 16> NamesSeen;
   ++NamesSeen[VD->getFullName()];
-  SmallVector<ValueDecl *, 8> RelatedDecls;
+  SmallVector<UnqualifiedLookupResult, 8> RelatedDecls;
 
   if (isa<ParamDecl>(VD))
     return; // Parameters don't have interesting related declarations.
@@ -473,13 +473,16 @@ void walkRelatedDecls(const ValueDecl *VD, const FnTy &Fn) {
 
     if (RelatedVD != VD) {
       ++NamesSeen[RelatedVD->getFullName()];
-      RelatedDecls.push_back(RelatedVD);
+      RelatedDecls.push_back(result);
     }
   }
 
   // Now provide the results along with whether the name is duplicate or not.
-  for (auto RelatedVD : RelatedDecls) {
-    Fn(RelatedVD, NamesSeen[RelatedVD->getFullName()] > 1);
+  ValueDecl *OriginalBase = VD->getDeclContext()->getAsNominalTypeOrNominalTypeExtensionContext();
+  for (auto Related : RelatedDecls) {
+    ValueDecl *RelatedVD = Related.getValueDecl();
+    bool SameBase = Related.getBaseDecl() && Related.getBaseDecl() == OriginalBase;
+    Fn(RelatedVD, SameBase, NamesSeen[RelatedVD->getFullName()] > 1);
   }
 }
 
@@ -741,7 +744,7 @@ static bool passCursorInfoForDecl(const ValueDecl *VD,
   });
 
   DelayedStringRetriever RelDeclsStream(SS);
-  walkRelatedDecls(VD, [&](const ValueDecl *RelatedDecl, bool DuplicateName) {
+  walkRelatedDecls(VD, [&](const ValueDecl *RelatedDecl, bool UseOriginalBase, bool DuplicateName) {
     RelDeclsStream.startPiece();
     {
       RelDeclsStream<<"<RelatedName usr=\"";
@@ -755,7 +758,7 @@ static bool passCursorInfoForDecl(const ValueDecl *VD,
         PO.SkipIntroducerKeywords = true;
         PO.ArgAndParamPrinting = PrintOptions::ArgAndParamPrintingMode::ArgumentOnly;
         XMLEscapingPrinter Printer(RelDeclsStream);
-        if (BaseType) {
+        if (UseOriginalBase && BaseType) {
           PO.setBaseType(BaseType);
           PO.PrintAsMember = true;
         }


### PR DESCRIPTION
<!-- What's in this pull request? -->
Also added test cases for rdar://problem/30292429 (already fixed) to catch any regressions

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves rdar://problem/30248264


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->