### PR TITLE
[Type checker] Improve validation of types in associated type where clauses

### DIFF
--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -2770,9 +2770,14 @@ bool GenericSignatureBuilder::addRequirement(const RequirementRepr *Req,
     // parameter.
     if (!Req->getFirstType()->hasTypeParameter() &&
         !Req->getSecondType()->hasTypeParameter()) {
-      Diags.diagnose(Req->getEqualLoc(), diag::requires_no_same_type_archetype)
-        .highlight(Req->getFirstTypeLoc().getSourceRange())
-        .highlight(Req->getSecondTypeLoc().getSourceRange());
+      if (!Req->getFirstType()->hasError() &&
+          !Req->getSecondType()->hasError()) {
+        Diags.diagnose(Req->getEqualLoc(),
+                       diag::requires_no_same_type_archetype)
+          .highlight(Req->getFirstTypeLoc().getSourceRange())
+          .highlight(Req->getSecondTypeLoc().getSourceRange());
+      }
+
       return true;
     }
 

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -158,7 +158,20 @@ Type ProtocolRequirementTypeResolver::resolveTypeOfDecl(TypeDecl *decl) {
 }
 
 bool ProtocolRequirementTypeResolver::areSameType(Type type1, Type type2) {
-  return type1->isEqual(type2);
+  if (type1->isEqual(type2))
+    return true;
+
+  // If both refer to associated types with the same name, they'll implicitly
+  // be considered equivalent.
+  auto depMem1 = type1->getAs<DependentMemberType>();
+  if (!depMem1) return false;
+
+  auto depMem2 = type2->getAs<DependentMemberType>();
+  if (!depMem2) return false;
+
+  if (depMem1->getName() != depMem2->getName()) return false;
+
+  return areSameType(depMem1->getBase(), depMem2->getBase());
 }
 
 void ProtocolRequirementTypeResolver::recordParamType(ParamDecl *decl,

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -354,16 +354,15 @@ bool TypeChecker::validateRequirement(SourceLoc whereLoc, RequirementRepr &req,
     // Validate the types.
     if (validateType(req.getSubjectLoc(), lookupDC, options, resolver)) {
       req.setInvalid();
-      return true;
     }
 
     if (validateType(req.getConstraintLoc(), lookupDC, options, resolver)) {
       req.setInvalid();
-      return true;
     }
 
     // FIXME: Feels too early to perform this check.
-    if (!req.getConstraint()->isExistentialType() &&
+    if (!req.isInvalid() &&
+        !req.getConstraint()->isExistentialType() &&
         !req.getConstraint()->getClassOrBoundGenericClass()) {
       diagnose(whereLoc, diag::requires_conformance_nonprotocol,
                req.getSubjectLoc(), req.getConstraintLoc());
@@ -371,34 +370,32 @@ bool TypeChecker::validateRequirement(SourceLoc whereLoc, RequirementRepr &req,
       req.setInvalid();
       return true;
     }
-    return false;
+
+    return req.isInvalid();
   }
 
   case RequirementReprKind::LayoutConstraint: {
     // Validate the types.
     if (validateType(req.getSubjectLoc(), lookupDC, options, resolver)) {
       req.setInvalid();
-      return true;
     }
 
     if (req.getLayoutConstraintLoc().isNull()) {
       req.setInvalid();
-      return true;
     }
-    return false;
+    return req.isInvalid();
   }
 
   case RequirementReprKind::SameType: {
     if (validateType(req.getFirstTypeLoc(), lookupDC, options, resolver)) {
       req.setInvalid();
-      return true;
     }
 
     if (validateType(req.getSecondTypeLoc(), lookupDC, options, resolver)) {
       req.setInvalid();
-      return true;
     }
-    return false;
+
+    return req.isInvalid();
   }
   }
 

--- a/test/Generics/associated_type_where_clause.swift
+++ b/test/Generics/associated_type_where_clause.swift
@@ -135,3 +135,25 @@ protocol P {
 	associatedtype P2 where P2 == P1, P2 == X
 	// expected-warning@-1{{redundant same-type constraint 'Self.P2' == 'X'}}
 }
+
+// Lookup of same-named associated types aren't ambiguous in this context.
+protocol P1 {
+  associatedtype A
+}
+
+protocol P2: P1 {
+  associatedtype A
+  associatedtype B where A == B
+}
+
+protocol P3: P1 {
+  associatedtype A
+}
+
+protocol P4 {
+  associatedtype A
+}
+
+protocol P5: P3, P4 {
+  associatedtype B where B == A?
+}

--- a/test/Generics/generic_types.swift
+++ b/test/Generics/generic_types.swift
@@ -241,3 +241,4 @@ struct UnsolvableInheritance2<T : U.A, U : T.A> {}
 // expected-error@-2 {{inheritance from non-protocol, non-class type 'T.A'}}
 
 enum X7<T> where X7.X : G { case X } // expected-error{{enum element 'X' is not a member type of 'X7<T>'}}
+// expected-error@-1{{use of undeclared type 'G'}}

--- a/test/Generics/invalid.swift
+++ b/test/Generics/invalid.swift
@@ -9,9 +9,11 @@ class dalet where A : B {} // expected-error {{'where' clause cannot be attached
 
 protocol he where A : B { // expected-error 2 {{use of undeclared type 'A'}}
   // expected-error@-1 3{{type 'A' in conformance requirement does not refer to a generic parameter or associated type}}
+  // expected-error@-2 {{use of undeclared type 'B'}}
 
   associatedtype vav where A : B // expected-error{{use of undeclared type 'A'}}
     // expected-error@-1 3{{type 'A' in conformance requirement does not refer to a generic parameter or associated type}}
+  // expected-error@-2 {{use of undeclared type 'B'}}
 }
 
 
@@ -90,4 +92,14 @@ class OuterGeneric<T> {
       _ = method
     }
   }
+}
+
+// Crash with missing types in requirements.
+protocol P1 {
+  associatedtype A where A == ThisTypeDoesNotExist
+  // expected-error@-1{{use of undeclared type 'ThisTypeDoesNotExist'}}
+  associatedtype B where ThisTypeDoesNotExist == B
+  // expected-error@-1{{use of undeclared type 'ThisTypeDoesNotExist'}}
+  associatedtype C where ThisTypeDoesNotExist == ThisTypeDoesNotExist
+  // expected-error@-1 2{{use of undeclared type 'ThisTypeDoesNotExist'}}
 }

--- a/validation-test/compiler_crashers_2_fixed/0084-rdar31093854.swift
+++ b/validation-test/compiler_crashers_2_fixed/0084-rdar31093854.swift
@@ -1,4 +1,4 @@
-// RUN: not --crash %target-swift-frontend -swift-version 4 %s -typecheck -o /dev/null
+// RUN: not %target-swift-frontend -swift-version 4 %s -typecheck -o /dev/null
 
 // This should actually type check successfully.
 


### PR DESCRIPTION
Two fixes here:

* If we encounter an error when validating requirements, don't leave null types around; they cause crashes! Fixes rdar://problem/31093854.
* When performing this lookup in a protocol, if we find two different associated types with the same name, don't consider lookup ambiguous: there will be an implicit same-type constraint here.