### PR TITLE
String prototype: Use _UTF16StringStorage for empty String isa pointe…

### DIFF
--- a/stdlib/public/stubs/GlobalObjects.cpp
+++ b/stdlib/public/stubs/GlobalObjects.cpp
@@ -28,6 +28,10 @@ namespace swift {
 SWIFT_RUNTIME_STDLIB_INTERFACE
 ClassMetadata CLASS_METADATA_SYM(s18_EmptyArrayStorage);
 
+// Michael NOTE: I have no idea what I'm doing, just cargo culting here...
+SWIFT_RUNTIME_STDLIB_INTERFACE
+ClassMetadata CLASS_METADATA_SYM(s19_UTF16StringStorage);
+
 // _direct type metadata for Swift._RawNativeDictionaryStorage
 SWIFT_RUNTIME_STDLIB_INTERFACE
 ClassMetadata CLASS_METADATA_SYM(s27_RawNativeDictionaryStorage);
@@ -54,7 +58,7 @@ swift::_SwiftEmptyArrayStorage swift::_swiftEmptyArrayStorage = {
 swift::_SwiftEmptyStringStorage swift::_swiftEmptyStringStorage = {
   // HeapObject header;
   {
-    &CLASS_METADATA_SYM(s18_EmptyArrayStorage), // isa pointer
+    &swift::CLASS_METADATA_SYM(s19_UTF16StringStorage), // isa pointer
   },
 
   // _SwiftStringBodyStorage body;


### PR DESCRIPTION
…r, not _EmptyArrayStorage

<!-- What's in this pull request? -->


<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
