### PR TITLE
StackNesting: use the right debug locations for inserted deallocation instructions

### DIFF
--- a/include/swift/SILOptimizer/Utils/StackNesting.h
+++ b/include/swift/SILOptimizer/Utils/StackNesting.h
@@ -143,7 +143,8 @@ private:
   ///
   /// Returns true if any deallocations were inserted.
   bool insertDeallocs(const BitVector &AliveBefore, const BitVector &AliveAfter,
-                      SILInstruction *InsertionPoint);
+                      SILInstruction *InsertionPoint,
+                      Optional<SILLocation> Location);
 
   /// Modifies the SIL to end up with a correct stack nesting.
   ///

--- a/lib/SILOptimizer/Utils/StackNesting.cpp
+++ b/lib/SILOptimizer/Utils/StackNesting.cpp
@@ -148,15 +148,15 @@ bool StackNesting::solve() {
 }
 
 static SILInstruction *createDealloc(SILInstruction *Alloc,
-                                     SILInstruction *InsertionPoint) {
+                                     SILInstruction *InsertionPoint,
+                                     SILLocation Location) {
   SILBuilder B(InsertionPoint);
   switch (Alloc->getKind()) {
     case ValueKind::AllocStackInst:
-      return B.createDeallocStack(InsertionPoint->getLoc(), Alloc);
+      return B.createDeallocStack(Location, Alloc);
     case ValueKind::AllocRefInst:
       assert(cast<AllocRefInst>(Alloc)->canAllocOnStack());
-      return B.createDeallocRef(InsertionPoint->getLoc(), Alloc,
-                                /*canBeOnStack*/true);
+      return B.createDeallocRef(Location, Alloc, /*canBeOnStack*/true);
     default:
       llvm_unreachable("unknown stack allocation");
   }
@@ -164,7 +164,8 @@ static SILInstruction *createDealloc(SILInstruction *Alloc,
 
 bool StackNesting::insertDeallocs(const BitVector &AliveBefore,
                                   const BitVector &AliveAfter,
-                                  SILInstruction *InsertionPoint) {
+                                  SILInstruction *InsertionPoint,
+                                  Optional<SILLocation> Location) {
   if (!AliveBefore.test(AliveAfter))
     return false;
 
@@ -175,7 +176,9 @@ bool StackNesting::insertDeallocs(const BitVector &AliveBefore,
   for (int LocNr = AliveBefore.find_first(); LocNr >= 0;
        LocNr = AliveBefore.find_next(LocNr)) {
     if (!AliveAfter.test(LocNr)) {
-      InsertionPoint = createDealloc(StackLocs[LocNr].Alloc, InsertionPoint);
+      SILInstruction *Alloc = StackLocs[LocNr].Alloc;
+      InsertionPoint = createDealloc(Alloc, InsertionPoint,
+                   Location.hasValue() ? Location.getValue() : Alloc->getLoc());
       changesMade = true;
     }
   }
@@ -234,7 +237,7 @@ StackNesting::Changes StackNesting::adaptDeallocs() {
         CFGChanged = true;
       }
       InstChanged |= insertDeallocs(Bits, SuccBI->AliveStackLocsAtEntry,
-                                    &InsertionBlock->front());
+                                    &InsertionBlock->front(), None);
     }
 
     // Insert/remove deallocations inside blocks.
@@ -264,7 +267,7 @@ StackNesting::Changes StackNesting::adaptDeallocs() {
         // Insert deallocations for all locations which are not alive after
         // StackInst but _are_ alive at the StackInst.
         InstChanged |= insertDeallocs(StackLocs[BitNr].AliveLocs, Bits,
-                                      InsertionPoint);
+                                      InsertionPoint, StackInst->getLoc());
         Bits |= StackLocs[BitNr].AliveLocs;
       }
     }

--- a/test/SILOptimizer/allocbox_to_stack.sil
+++ b/test/SILOptimizer/allocbox_to_stack.sil
@@ -760,9 +760,9 @@ bb5(%25 : $Error):                                // Preds: bb4 bb3
 // CHECK:      bb2:
 // CHECK:        store
 // CHECK:        [[STACK2:%[0-9]+]] = alloc_stack $Bool
-// CHECK-NEXT:   dealloc_stack [[STACK2]]
-// CHECK-NEXT:   dealloc_stack [[BOX]]
-// CHECK-NEXT:   dealloc_stack [[STACK1]]
+// CHECK-NEXT:   dealloc_stack [[STACK2]] : $*Bool, loc "testloc":27:27
+// CHECK-NEXT:   dealloc_stack [[BOX]] : $*Int, loc "testloc":27:27
+// CHECK-NEXT:   dealloc_stack [[STACK1]] : $*Bool, loc "testloc":27:27
 // CHECK:      bb3:
 // CHECK-NEXT:   tuple
 // CHECK-NEXT:   return
@@ -784,7 +784,7 @@ bb2:
   %3 = load %1a : $*Int
   %as2 = alloc_stack $Bool
   strong_release %1 : ${ var Int }
-  dealloc_stack %as2 : $*Bool
+  dealloc_stack %as2 : $*Bool, loc "testloc":27:27
   br bb3
 
 bb3:


### PR DESCRIPTION
Fixes a crash because we used a return-location for a deallocation instruction.

rdar://problem/31458587
rdar://problem/31458617

