### PR TITLE
[Serialization] Proof-of-concept: drop overriding methods if the base is missing

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -549,6 +549,11 @@ ERROR(serialization_target_too_new_repl,none,
       "module file's minimum deployment target is %0 v%1.%2%select{|.%3}3: %4",
       (StringRef, unsigned, unsigned, unsigned, StringRef))
 
+ERROR(serialization_fatal,Fatal,
+      "fatal error encountered while reading from module '%0'; "
+      "please file a bug report with your project and the crash log",
+      (StringRef))
+
 ERROR(reserved_member_name,none,
       "type member may not be named %0, since it would conflict with the"
       " 'foo.%1' expression", (DeclName, StringRef))

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -175,6 +175,12 @@ namespace swift {
     /// new enough?
     bool EnableTargetOSChecking = true;
 
+    /// Whether to attempt to recover from missing cross-references and other
+    /// errors when deserializing from a Swift module.
+    ///
+    /// This is a staging flag; eventually it will be on by default.
+    bool EnableDeserializationRecovery = false;
+
     /// Should we use \c ASTScope-based resolution for unqualified name lookup?
     bool EnableASTScopeLookup = false;
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -260,6 +260,10 @@ def enable_experimental_property_behaviors :
   Flag<["-"], "enable-experimental-property-behaviors">,
   HelpText<"Enable experimental property behaviors">;
 
+def enable_experimental_deserialization_recovery :
+  Flag<["-"], "enable-experimental-deserialization-recovery">,
+  HelpText<"Attempt to recover from missing xrefs (etc) in swiftmodules">;
+
 def enable_cow_existentials : Flag<["-"], "enable-cow-existentials">,
   HelpText<"Enable the copy-on-write existential implementation">;
 

--- a/include/swift/Serialization/ModuleFile.h
+++ b/include/swift/Serialization/ModuleFile.h
@@ -436,6 +436,10 @@ public:
     return getStatus();
   }
 
+  /// Emits one last diagnostic, logs the error, and then aborts for the stack
+  /// trace.
+  void fatal(llvm::Error error) LLVM_ATTRIBUTE_NORETURN;
+
   ASTContext &getContext() const {
     assert(FileContext && "no associated context yet");
     return FileContext->getParentModule()->getASTContext();

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -874,6 +874,9 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.EnableClassResilience |=
     Args.hasArg(OPT_enable_class_resilience);
 
+  Opts.EnableDeserializationRecovery |=
+    Args.hasArg(OPT_enable_experimental_deserialization_recovery);
+
   Opts.DisableAvailabilityChecking |=
       Args.hasArg(OPT_disable_availability_checking);
 

--- a/test/Serialization/Recovery/Inputs/custom-modules/Overrides.h
+++ b/test/Serialization/Recovery/Inputs/custom-modules/Overrides.h
@@ -1,0 +1,5 @@
+@interface Base
+#ifndef BAD
+- (void)method;
+#endif
+@end

--- a/test/Serialization/Recovery/Inputs/custom-modules/module.modulemap
+++ b/test/Serialization/Recovery/Inputs/custom-modules/module.modulemap
@@ -1,0 +1,1 @@
+module Overrides { header "Overrides.h" }

--- a/test/Serialization/Recovery/overrides.swift
+++ b/test/Serialization/Recovery/overrides.swift
@@ -1,0 +1,27 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: %target-swift-frontend -emit-module -o %t -module-name Lib -I %S/Inputs/custom-modules %s
+
+// RUN: %target-swift-ide-test -source-filename=x -print-module -module-to-print Lib -I %t -I %S/Inputs/custom-modules | %FileCheck %s
+
+// RUN: not --crash %target-swift-ide-test -source-filename=x -print-module -module-to-print Lib -I %t -I %S/Inputs/custom-modules -Xcc -DBAD 2>&1 | %FileCheck -check-prefix CHECK-CRASH %s
+// RUN: %target-swift-ide-test -source-filename=x -print-module -module-to-print Lib -I %t -I %S/Inputs/custom-modules -Xcc -DBAD -enable-experimental-deserialization-recovery | %FileCheck -check-prefix CHECK-RECOVERY %s
+
+// REQUIRES: objc_interop
+
+import Overrides
+
+public class Sub: Base {
+  public override func method() {}
+}
+
+// CHECK-LABEL: class Sub : Base {
+// CHECK-NEXT: func method()
+// CHECK-NEXT: {{^}$}}
+
+// CHECK-CRASH: error: fatal error encountered while reading from module 'Lib'; please file a bug report with your project and the crash log
+// CHECK-CRASH-LABEL: *** DESERIALIZATION FAILURE (please include this section in any bug report) ***
+// CHECK-CRASH: could not find 'method()' in parent class
+// CHECK-CRASH: While loading members for 'Sub' in module 'Lib'
+
+// CHECK-RECOVERY-LABEL: class Sub : Base {
+// CHECK-RECOVERY-NEXT: {{^}$}}

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -319,6 +319,12 @@ EnableSwift3ObjCInference(
                   llvm::cl::init(false));
 
 static llvm::cl::opt<bool>
+EnableDeserializationRecovery(
+    "enable-experimental-deserialization-recovery",
+    llvm::cl::desc("Attempt to recover from missing xrefs (etc) in swiftmodules"),
+    llvm::cl::init(false));
+
+static llvm::cl::opt<bool>
 DisableObjCAttrRequiresFoundationModule(
     "disable-objc-attr-requires-foundation-module",
     llvm::cl::desc("Allow @objc to be used freely"),
@@ -2995,6 +3001,8 @@ int main(int argc, char *argv[]) {
   InitInvok.getLangOptions().EnableSwift3ObjCInference =
     options::EnableSwift3ObjCInference ||
     InitInvok.getLangOptions().isSwiftVersion3();
+  InitInvok.getLangOptions().EnableDeserializationRecovery |=
+    options::EnableDeserializationRecovery;
   InitInvok.getClangImporterOptions().ImportForwardDeclarations |=
     options::ObjCForwardDeclarations;
   InitInvok.getClangImporterOptions().InferImportAsMember |=


### PR DESCRIPTION
Proof-of-concept for this sort of recovery. In the real world, it's more likely that this will happen due to differences between Swift 3 and Swift 4, rather than changes in what macros are defined, but the latter can still happen when debugging.

There's a lot to do here to consider this production-ready. There are no generics involved and no potential circular references, and the *rest* of the compiler isn't prepared for this either. But it's cool to see it working!

Actually recovering is hidden behind the new -enable-experimental-deserialization-recovery option; without it the compiler will continue to eagerly abort.