### PR TITLE
[stdlib] Revamp Character

### DIFF
--- a/stdlib/public/core/UnicodeViews.swift
+++ b/stdlib/public/core/UnicodeViews.swift
@@ -701,21 +701,12 @@ extension _UnicodeViews {
 
     public subscript(i: Index) -> Character {
       let j = index(after: i)
-      let contents = _UnicodeViews_(
-        storage.codeUnits[
+
+      let source = storage.codeUnits[
           storage.codeUnits.index(atOffset: i.base)
-          ..< storage.codeUnits.index(atOffset: j.base)],
-        Encoding.self)
-        
-      if let small = Character(_smallUtf8: contents.transcoded(to: UTF8.self)) {
-        return small
-      }
-      else {
-        // FIXME: there is undoubtley a less ridiculous way to do this
-        let scalars = contents.encodedScalars.lazy.map(UnicodeScalar.init)
-        let string = Swift.String(Swift.String.UnicodeScalarView(scalars))
-        return Character(_largeRepresentationString: string)
-      }
+        ..< storage.codeUnits.index(atOffset: j.base)]
+
+      return Character(_codeUnits: source, Encoding.self)
     }     
 
     public func index(after i: Index) -> Index {


### PR DESCRIPTION
simplify; improve storage efficiency.  Should run much faster now.

@milseman I didn't simply commit this to unicode-rethink because I think it probably causes more tests to fail and I didn't want to interfere with your progress, though the failures look mostly benign.  Please feel free to merge it when you're comfortable, or it can go in as part of my optimization work.

Incidentally, we should start aggressively deleting test code that clearly no longer applies, such as string_prototype and test code that looks for Swift 2->3 migration help in diagnostics.  Re-running these tests and waiting for them to fail can't be helping ;-)

Failing Tests (51):
    Swift(macosx-x86_64) :: stdlib/NSStringAPI.swift
    Swift(macosx-x86_64) :: Prototypes/string_prototype/main.swift
    Swift(macosx-x86_64) :: stdlib/StringAPI.swift
    Swift(macosx-x86_64) :: DebugInfo/letstring.swift
    Swift(macosx-x86_64) :: IRGen/alloc.sil
    Swift(macosx-x86_64) :: IRGen/existentials_objc.sil
    Swift(macosx-x86_64) :: IRGen/fixed_size_buffer_peepholes.sil
    Swift(macosx-x86_64) :: IRGen/generic_metatypes.swift
    Swift(macosx-x86_64) :: IRGen/generic_metatypes_arm.swift
    Swift(macosx-x86_64) :: IRGen/global_resilience.sil
    Swift(macosx-x86_64) :: IRGen/struct_layout.sil
    Swift(macosx-x86_64) :: IRGen/witness_table_multifile.swift
    Swift(macosx-x86_64) :: sil-llvm-gen/alloc.sil
    Swift(macosx-x86_64) :: SILGen/address_only_types.swift
    Swift(macosx-x86_64) :: SILGen/existential_erasure.swift
    Swift(macosx-x86_64) :: SILGen/function_conversion.swift
    Swift(macosx-x86_64) :: SILGen/functions.swift
    Swift(macosx-x86_64) :: SILGen/objc_bridging_any.swift
    Swift(macosx-x86_64) :: SILGen/opaque_values_silgen.swift
    Swift(macosx-x86_64) :: SILGen/protocol_extensions.swift
    Swift(macosx-x86_64) :: stdlib/TestCharacterSet.swift
    Swift(macosx-x86_64) :: stdlib/StringDiagnostics.swift
    Swift(macosx-x86_64) :: stdlib/Renames.swift
    Swift(macosx-x86_64) :: IRGen/vtable_multi_file.swift
    Swift(macosx-x86_64) :: IRGen/partial_apply.sil
    Swift(macosx-x86_64) :: SourceKit/InterfaceGen/gen_stdlib.swift
    Swift(macosx-x86_64) :: stdlib/Runtime.swift.gyb
    Swift(macosx-x86_64) :: stdlib/UnavailableStringAPIs.swift.gyb
    Swift(macosx-x86_64) :: Parse/pointer_conversion.swift.gyb
    Swift(macosx-x86_64) :: IDE/complete_enum_elements.swift
    Swift(macosx-x86_64) :: api-digester/source-stability.swift
    Swift(macosx-x86_64) :: decl/func/operator.swift
    Swift(macosx-x86_64) :: Parse/recovery.swift
    Swift(macosx-x86_64) :: Constraints/closures.swift
    Swift(macosx-x86_64) :: stdlib/RuntimeObjC.swift
    Swift(macosx-x86_64) :: SourceKit/Indexing/index_with_swift_module.swift
    Swift(macosx-x86_64) :: Constraints/diagnostics.swift
    Swift(macosx-x86_64) :: IDE/print_stdlib.swift
    Swift(macosx-x86_64) :: stdlib/StringDiagnostics_without_Foundation.swift
    Swift(macosx-x86_64) :: IDE/complete_literal.swift
    Swift(macosx-x86_64) :: IDE/complete_from_stdlib.swift
    Swift(macosx-x86_64) :: IDE/complete_from_foundation_overlay.swift
    Swift(macosx-x86_64) :: Interpreter/SDK/objc_bridge_cast.swift
    Swift(macosx-x86_64) :: IRGen/UseObjCMethod.swift
    Swift(macosx-x86_64) :: stdlib/Character.swift
    Swift(macosx-x86_64) :: stdlib/ErrorHandling.swift
    Swift(macosx-x86_64) :: stdlib/NewString.swift
    Swift(macosx-x86_64) :: stdlib/NewStringAppending.swift
    Swift(macosx-x86_64) :: stdlib/ReflectionHashing.swift
    Swift(macosx-x86_64) :: stdlib/StringReallocation.swift
    Swift(macosx-x86_64) :: stdlib/StringTraps.swift

********************
Unresolved Tests (8):
    Swift(macosx-x86_64) :: Prototypes/UnicodeViews.swift
    Swift(macosx-x86_64) :: Prototypes/string_prototype/StringComparison.swift
    Swift(macosx-x86_64) :: Prototypes/string_prototype/String.swift
    Swift(macosx-x86_64) :: Prototypes/string_prototype/CanonicalString.swift
    Swift(macosx-x86_64) :: Prototypes/string_prototype/Latin1String.swift
    Swift(macosx-x86_64) :: Prototypes/string_prototype/StringCompatibility.swift
    Swift(macosx-x86_64) :: Prototypes/string_prototype/StringStorage.swift
    Swift(macosx-x86_64) :: Prototypes/string_prototype/Substring.swift

  Expected Passes    : 3305
  Expected Failures  : 13
  Unsupported Tests  : 71
  Unresolved Tests   : 8
  Unexpected Failures: 51
