### PR TITLE
Improve error message for missing response file in line-directive

### DIFF
--- a/cmake/modules/SwiftSource.cmake
+++ b/cmake/modules/SwiftSource.cmake
@@ -469,7 +469,7 @@ function(_compile_swift_files
       OUTPUT ${standard_outputs}
       DEPENDS
         ${swift_compiler_tool_dep}
-        ${source_files} ${SWIFTFILE_DEPENDS}
+        ${file_path} ${source_files} ${SWIFTFILE_DEPENDS}
         ${swift_ide_test_dependency} ${api_notes_dependency_target}
         ${obj_dirs_dependency_target}
       COMMENT "Compiling ${first_output}")


### PR DESCRIPTION
Related: https://bugs.swift.org/browse/SR-4511

New error message if the response file is missing:

> ninja: error: 'stdlib/public/core/udfcL.txt', needed by 'stdlib/public/core/windows/x86_64/Swift.obj', missing and no known rule to make it
