### PR TITLE
SE-0138: Proposed amendment to SE-0138: Normalize UnsafeRawBufferPointer Slices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,48 @@ CHANGELOG
 Swift 4.0
 ---------
 
+* [SE-0138](https://github.com/apple/swift-evolution/blob/master/proposals/0138-unsaferawbufferpointer.md#amendment-to-normalize-the-slice-type):
+
+  Slicing a raw buffer no longer results in the same raw buffer
+  type. Specifically, `Unsafe[Mutable]BufferPointer.SubSequence` now has type
+  `[Mutable]RandomAccessSlice<Unsafe[Mutable]RawBufferPointer>`. Therefore,
+  indexing into a raw buffer slice is no longer zero-based. This is required for
+  raw buffers to fully conform to generic `Collection`. Changing the slice type
+  resulted in the following behavioral changes:
+
+  Passing a region within buffer to another function that takes a buffer can no
+  longer be done via subscript:
+
+  Incorrect: `takesRawBuffer(buffer[i..<j])`
+
+  This now requires explicit initialization, using a `rebasing:` initializer,
+  which converts from a slice to a zero-based `Unsafe[Mutable]RawBufferPointer`:
+
+  Correct: `takesRawBuffer(UnsafeRawBufferPointer(rebasing: buffer[i..<j]))`
+
+  Subscript assignment directly from a buffer no longer compiles:
+
+  Incorrect: `buffer[n..<m] = smaller_buffer`
+
+  This now requires creation of a slice from the complete source buffer:
+
+  Correct: `buffer[n..<m] = smaller_buffer.suffix(from: 0)`
+
+  `UnsafeRawBufferPointer`'s slice type no longer has a nonmutating subscript
+  setter. So assigning into a mutable `let` buffer no longer compiles:
+
+  ```
+  let slice = buffer[n..<m]
+  slice[i..<j] = buffer[k..<l]
+  ```
+
+  The assigned buffer slice now needs to be a `var`.
+
+  ```
+  var slice = buffer[n..<m]
+  slice[i..<j] = buffer[k..<l]
+  ```
+
 * [SR-1529](https://bugs.swift.org/browse/SR-1529):
 
   Covariant method overrides are now fully supported, fixing many crashes

--- a/stdlib/private/StdlibCollectionUnittest/CheckCollectionInstance.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/CheckCollectionInstance.swift.gyb
@@ -337,8 +337,12 @@ public func check${Traversal}Collection<
   C.SubSequence.Index == C.Index,
   C.SubSequence.Indices.Iterator.Element == C.Index {
 
-  _checkOneLevelOf${Traversal}Collection(expected, collection, ${trace},
+  checkOneLevelOf${Traversal}Collection(expected, collection, ${trace},
     resiliencyChecks: resiliencyChecks, sameValue: sameValue)
+
+  // Avoid validation of all possible (n^2) slices on large collection.
+  // Test cases should call checkOneLevelOf${Traversal}Collection instead.
+  expectLT(expected.count, 30)
 
   _checkSliceableWith${Traversal}Index(expected, collection, ${trace},
     resiliencyChecks: resiliencyChecks, sameValue: sameValue)
@@ -352,7 +356,7 @@ public func check${Traversal}Collection<
 // associated type properties of SubSequence.
 //
 // Checks all slices: O(n^2).
-internal func _checkOneLevelOf${Traversal}Collection<
+public func checkOneLevelOf${Traversal}Collection<
   ${genericParam}, C : ${TraversalCollection}
 >(
   _ expected: ${Expected}, _ collection: C,
@@ -581,7 +585,7 @@ ${genericParam}, S : ${TraversalCollection}
       expectEqual(start, slice.startIndex)
       expectEqual(end, slice.endIndex)
 
-      _checkOneLevelOf${Traversal}Collection(expectedSlice, slice, ${trace},
+      checkOneLevelOf${Traversal}Collection(expectedSlice, slice, ${trace},
         resiliencyChecks: resiliencyChecks,
         sameValue: sameValue)
 

--- a/stdlib/private/StdlibCollectionUnittest/CheckCollectionInstance.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/CheckCollectionInstance.swift.gyb
@@ -576,8 +576,10 @@ ${genericParam}, S : ${TraversalCollection}
 %       end
       let expectedSlice = expectedArray[startNumericIndex..<endNumericIndex]
       let slice = sliceable[start..<end]
-      //FIXME!!!: expectEqual(start, slice.startIndex)
-      //FIXME!!!: expectEqual(end, slice.endIndex)
+      // For every possible slice, verify that the slice's bounds are identical
+      // to the indices used to form the slice.
+      expectEqual(start, slice.startIndex)
+      expectEqual(end, slice.endIndex)
 
       _checkOneLevelOf${Traversal}Collection(expectedSlice, slice, ${trace},
         resiliencyChecks: resiliencyChecks,

--- a/stdlib/private/StdlibCollectionUnittest/CheckCollectionInstance.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/CheckCollectionInstance.swift.gyb
@@ -269,9 +269,57 @@ public func checkAdvancesAndDistances<Instances, Distances, BaseCollection>(
 %   ('Expected: Collection',  'Expected.Iterator.Element',  'Expected'),
 %   ('Element'             ,  'Element'                  ,  'Array<Element>')]:
 
+// Top-level check for Collection instances. Alias for checkForwardCollection.
+// Checks all slices: O(n^2).
+public func checkCollection<${genericParam}, C : Collection>(
+  _ expected: ${Expected},
+  _ collection: C,
+  ${TRACE},
+  resiliencyChecks: CollectionMisuseResiliencyChecks = .all,
+  sameValue: (${Element}, ${Element}) -> Bool
+) where C.Iterator.Element == ${Element},
+  // FIXME(ABI) (Associated Types with where clauses): these constraints should be applied to
+  // associated types of Collection.
+  C.Indices.Iterator.Element == C.Index,
+  C.SubSequence : Collection,
+  C.SubSequence.Iterator.Element == ${Element},
+  C.SubSequence.Indices.Iterator.Element == C.Index,
+  C.SubSequence.Index == C.Index {
+
+  checkForwardCollection(expected, collection, message(),
+    stackTrace: stackTrace, showFrame: showFrame, file: file, line: line,
+    resiliencyChecks: resiliencyChecks,
+    sameValue: sameValue)
+}
+
 %   for Traversal in TRAVERSALS:
 %     TraversalCollection = collectionForTraversal(Traversal)
 
+// Calls check${Traversal}Collection with default `sameValue`.
+public func check${Traversal}Collection<
+  ${genericParam}, C : ${TraversalCollection}
+>(
+  _ expected: ${Expected}, _ collection: C,
+  ${TRACE},
+  resiliencyChecks: CollectionMisuseResiliencyChecks = .all
+) where
+  C.Iterator.Element == ${Element},
+  C.Indices.Iterator.Element == C.Index,
+  C.SubSequence : ${TraversalCollection},
+  C.SubSequence.Iterator.Element == ${Element},
+  C.SubSequence.Indices.Iterator.Element == C.Index,
+  C.SubSequence.Index == C.Index,
+  ${Element} : Equatable {
+
+  check${Traversal}Collection(
+    expected, collection, ${trace},
+    resiliencyChecks: resiliencyChecks) { $0 == $1 }
+}
+
+// Top-Level check for all ${TraversalCollection} semantics on a single
+// instance. This constrains SubSequence associated types in order to check
+// slice semantics.
+// Checks all slices: O(n^2).
 public func check${Traversal}Collection<
   ${genericParam}, C : ${TraversalCollection}
 >(
@@ -281,6 +329,40 @@ public func check${Traversal}Collection<
   sameValue: (${Element}, ${Element}) -> Bool
 ) where
   C.Iterator.Element == ${Element},
+  // FIXME(ABI) (Associated Types with where clauses): these constraints should be applied to
+  // associated types of Collection.
+  C.Indices.Iterator.Element == C.Index,
+  C.SubSequence : ${TraversalCollection},
+  C.SubSequence.Iterator.Element == ${Element},
+  C.SubSequence.Index == C.Index,
+  C.SubSequence.Indices.Iterator.Element == C.Index {
+
+  _checkOneLevelOf${Traversal}Collection(expected, collection, ${trace},
+    resiliencyChecks: resiliencyChecks, sameValue: sameValue)
+
+  _checkSliceableWith${Traversal}Index(expected, collection, ${trace},
+    resiliencyChecks: resiliencyChecks, sameValue: sameValue)
+}
+
+// Helper for check${Traversal}Collection. Check that instance of `C`,
+// `collection`, upholds the semantics of `${TraversalCollection}`,
+// non-recursively. This does not check subsequences. It may be called for each
+// subsequence without combinatorial explosion. Also, since recursive protocol
+// contraints are not supported, our second level of checks cannot depend on the
+// associated type properties of SubSequence.
+//
+// Checks all slices: O(n^2).
+internal func _checkOneLevelOf${Traversal}Collection<
+  ${genericParam}, C : ${TraversalCollection}
+>(
+  _ expected: ${Expected}, _ collection: C,
+  ${TRACE},
+  resiliencyChecks: CollectionMisuseResiliencyChecks = .all,
+  sameValue: (${Element}, ${Element}) -> Bool
+) where
+  C.Iterator.Element == ${Element},
+  // FIXME(ABI) (Associated Types with where clauses): these constraints should be applied to
+  // associated types of Collection.
   C.Indices.Iterator.Element == C.Index {
 
   // A `Collection` is a multi-pass `Sequence`.
@@ -289,6 +371,10 @@ public func check${Traversal}Collection<
       expected, collection, ${trace},
       resiliencyChecks: resiliencyChecks, sameValue: sameValue)
   }
+
+  //===------------------------------------------------------------------===//
+  // Check Index semantics
+  //===------------------------------------------------------------------===//
 
   let succ = { collection.index(after: $0) }
 %     if Traversal != 'Forward':
@@ -356,8 +442,13 @@ public func check${Traversal}Collection<
 
   let expectedArray = Array(expected)
 
+  // Check `count`.
   expectEqual(
     expectedArray.count.toIntMax(), collection.count.toIntMax(), ${trace})
+
+  //===------------------------------------------------------------------===//
+  // Check Iteration behavior.
+  //===------------------------------------------------------------------===//
 
   for _ in 0..<3 {
     do {
@@ -414,7 +505,7 @@ public func check${Traversal}Collection<
           expectedArray[i], collection[index], ${trace}, sameValue: sameValue)
       }
 
-%       end
+%       end # Traversal == "Bidirectional"
 
     } // end of `if expectedArray.count >= 2`
 
@@ -440,65 +531,57 @@ public func check${Traversal}Collection<
   // FIXME: more checks for bidirectional and random access collections.
 }
 
-public func check${Traversal}Collection<
-  ${genericParam}, C : ${TraversalCollection}
+// Helper for check${Traversal}Collection to check Slices.
+//
+// Checks all slices: O(n^2).
+internal func _checkSliceableWith${Traversal}Index<
+${genericParam}, S : ${TraversalCollection}
 >(
-  _ expected: ${Expected}, _ collection: C,
-  ${TRACE},
-  resiliencyChecks: CollectionMisuseResiliencyChecks = .all
-) where
-  C.Iterator.Element == ${Element},
-  C.Indices.Iterator.Element == C.Index,
-  ${Element} : Equatable {
-
-  check${Traversal}Collection(
-    expected, collection, ${trace},
-    resiliencyChecks: resiliencyChecks) { $0 == $1 }
-}
-
-%   end
-
-// FIXME: merge into checkCollection()
-public func checkSliceableWithBidirectionalIndex<
-  ${genericParam}, S : BidirectionalCollection
->(
-  _ expected: ${Expected}, _ sliceable: S, ${TRACE}
+  _ expected: ${Expected}, _ sliceable: S, ${TRACE},
+  resiliencyChecks: CollectionMisuseResiliencyChecks = .all,
+  sameValue: (${Element}, ${Element}) -> Bool
 ) where
   S.Iterator.Element == ${Element},
-  S.Indices.Iterator.Element == S.Index,
-  S.SubSequence : BidirectionalCollection,
+  S.SubSequence : ${TraversalCollection},
   S.SubSequence.Iterator.Element == ${Element},
-  S.SubSequence.Indices.Iterator.Element == S.SubSequence.Index,
-  ${Element} : Equatable {
-
-  // A `Sliceable` is a `Collection`.
-  checkBidirectionalCollection(expected, sliceable, ${trace})
+  S.SubSequence.Index == S.Index,
+  S.SubSequence.Indices.Iterator.Element == S.Index {
 
   let expectedArray = Array(expected)
 
   let succ = { sliceable.index(after: $0) }
+%       if Traversal != "Forward":
   let pred = { sliceable.index(before: $0) }
+%       end
 
   var start = sliceable.startIndex
   for startNumericIndex in 0...expectedArray.count {
+%       if Traversal != "Forward":
     if start != sliceable.endIndex {
       start = succ(start)
       start = pred(start)
       start = succ(start)
       start = pred(start)
     }
+%       end
     var end = start
     for endNumericIndex in startNumericIndex...expectedArray.count {
+%       if Traversal != "Forward":
       if end != sliceable.endIndex {
         end = succ(end)
         end = pred(end)
         end = succ(end)
         end = pred(end)
       }
+%       end
       let expectedSlice = expectedArray[startNumericIndex..<endNumericIndex]
       let slice = sliceable[start..<end]
+      //FIXME!!!: expectEqual(start, slice.startIndex)
+      //FIXME!!!: expectEqual(end, slice.endIndex)
 
-      checkBidirectionalCollection(expectedSlice, slice, ${trace})
+      _checkOneLevelOf${Traversal}Collection(expectedSlice, slice, ${trace},
+        resiliencyChecks: resiliencyChecks,
+        sameValue: sameValue)
 
       if end != sliceable.endIndex {
         end = succ(end)
@@ -510,9 +593,13 @@ public func checkSliceableWithBidirectionalIndex<
   }
 }
 
-% end
+%   end # Traversal
 
+% end # genericParam, Elements, Expected
 
+// Check RangeReplaceableCollection using a factory.
+//
+// Note: This does not invoke other collection tests.
 public func checkRangeReplaceable<C, N>(
   _ makeCollection: @escaping () -> C,
   _ makeNewValues: (Int) -> N
@@ -574,13 +661,3 @@ public func checkRangeReplaceable<C, N>(
     }
   }
 }
-
-public func checkCollection<C : Collection, Expected : Collection>(
-  _ subject: C,
-  expected: Expected,
-  ${TRACE},
-  resiliencyChecks: CollectionMisuseResiliencyChecks = .all,
-  sameValue: (Expected.Iterator.Element, Expected.Iterator.Element) -> Bool
-) where C.Iterator.Element == Expected.Iterator.Element {
-}
-

--- a/stdlib/private/StdlibCollectionUnittest/CheckCollectionType.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/CheckCollectionType.swift.gyb
@@ -120,85 +120,85 @@ public let subscriptRangeTests = [
 
   // Slice to the full extent.
   SubscriptRangeTest(
-    expected: [ 1010 ],
-    collection: [ 1010 ],
+    expected: [1010],
+    collection: [1010],
     bounds: 0..<1,
     count: 1),
   SubscriptRangeTest(
-    expected: [ 1010, 2020, 3030 ],
-    collection: [ 1010, 2020, 3030 ],
+    expected: [1010, 2020, 3030],
+    collection: [1010, 2020, 3030],
     bounds: 0..<3,
     count: 3),
   SubscriptRangeTest(
-    expected: [ 1010, 2020, 3030, 4040, 5050 ],
-    collection: [ 1010, 2020, 3030, 4040, 5050 ],
+    expected: [1010, 2020, 3030, 4040, 5050],
+    collection: [1010, 2020, 3030, 4040, 5050],
     bounds: 0..<5,
     count: 5),
 
   // Slice an empty prefix.
   SubscriptRangeTest(
     expected: [],
-    collection: [ 1010, 2020, 3030 ],
+    collection: [1010, 2020, 3030],
     bounds: 0..<0,
     count: 3),
 
   // Slice a prefix.
   SubscriptRangeTest(
-    expected: [ 1010, 2020 ],
-    collection: [ 1010, 2020, 3030 ],
+    expected: [1010, 2020],
+    collection: [1010, 2020, 3030],
     bounds: 0..<2,
     count: 3),
   SubscriptRangeTest(
-    expected: [ 1010, 2020 ],
-    collection: [ 1010, 2020, 3030, 4040, 5050 ],
+    expected: [1010, 2020],
+    collection: [1010, 2020, 3030, 4040, 5050],
     bounds: 0..<2,
     count: 5),
 
   // Slice an empty suffix.
   SubscriptRangeTest(
     expected: [],
-    collection: [ 1010, 2020, 3030 ],
+    collection: [1010, 2020, 3030],
     bounds: 3..<3,
     count: 3),
 
   // Slice a suffix.
   SubscriptRangeTest(
-    expected: [ 2020, 3030 ],
-    collection: [ 1010, 2020, 3030 ],
+    expected: [2020, 3030],
+    collection: [1010, 2020, 3030],
     bounds: 1..<3,
     count: 3),
   SubscriptRangeTest(
-    expected: [ 4040, 5050 ],
-    collection: [ 1010, 2020, 3030, 4040, 5050 ],
+    expected: [4040, 5050],
+    collection: [1010, 2020, 3030, 4040, 5050],
     bounds: 3..<5,
     count: 5),
 
   // Slice an empty range in the middle.
   SubscriptRangeTest(
     expected: [],
-    collection: [ 1010, 2020, 3030 ],
+    collection: [1010, 2020, 3030],
     bounds: 1..<1,
     count: 3),
   SubscriptRangeTest(
     expected: [],
-    collection: [ 1010, 2020, 3030 ],
+    collection: [1010, 2020, 3030],
     bounds: 2..<2,
     count: 3),
 
   // Slice the middle part.
   SubscriptRangeTest(
-    expected: [ 2020 ],
-    collection: [ 1010, 2020, 3030 ],
+    expected: [2020],
+    collection: [1010, 2020, 3030],
     bounds: 1..<2,
     count: 3),
   SubscriptRangeTest(
-    expected: [ 3030 ],
-    collection: [ 1010, 2020, 3030, 4040 ],
-    bounds: 3..<4,
+    expected: [3030],
+    collection: [1010, 2020, 3030, 4040],
+    bounds: 2..<3,
     count: 4),
   SubscriptRangeTest(
-    expected: [ 2020, 3030, 4040 ],
-    collection: [ 1010, 2020, 3030, 4040, 5050, 6060 ],
+    expected: [2020, 3030, 4040],
+    collection: [1010, 2020, 3030, 4040, 5050, 6060],
     bounds: 1..<4,
     count: 6),
 ]
@@ -690,8 +690,8 @@ extension TestSuite {
         // TODO: swift-3-indexing-model: uncomment the following.
         // FIXME: improve checkForwardCollection to check the SubSequence type.
         checkCollection(
-          slice,
           expected: test.expected.map(wrapValue),
+          slice,
           resiliencyChecks: .none) {
           extractValue($0).value == extractValue($1).value
         }

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -276,6 +276,45 @@ public struct Unsafe${Mutable}BufferPointer<Element>
     _end = start.map { $0 + count }
   }
 
+%  if not Mutable:
+  /// Creates a buffer over the same memory as the given buffer slice.
+  ///
+  /// The new buffer will represent the same region of memory as the slice,
+  /// but it's indices will be rebased to zero. Given:
+  ///
+  ///   let slice = buffer[n..<m]
+  ///   let rebased = UnsafeBufferPointer(rebasing: slice)
+  ///
+  /// One may assume `rebased.startIndex == 0` and `rebased[0] == slice[n]`.
+  ///
+  /// - Parameter slice: the raw buffer slice to rebase.
+  @_inlineable
+  public init(rebasing slice: RandomAccessSlice<UnsafeBufferPointer<Element>>) {
+    self.init(start: slice.base.baseAddress! + slice.startIndex,
+      count: slice.count)
+  }
+%  end # !mutable
+
+  /// Creates a buffer over the same memory as the given buffer slice.
+  ///
+  /// The new buffer will represent the same region of memory as the slice,
+  /// but it's indices will be rebased to zero. Given:
+  ///
+  ///   let slice = buffer[n..<m]
+  ///   let rebased = UnsafeBufferPointer(rebasing: slice)
+  ///
+  /// One may assume `rebased.startIndex == 0` and `rebased[0] == slice[n]`.
+  ///
+  /// - Parameter slice: the buffer slice to rebase.
+  @_inlineable
+  public init(
+    rebasing slice:
+    MutableRandomAccessSlice<UnsafeMutableBufferPointer<Element>>
+  ) {
+    self.init(start: slice.base.baseAddress! + slice.startIndex,
+      count: slice.count)
+  }
+
   /// Returns an iterator over the elements of this buffer.
   ///
   /// - Returns: An iterator over the elements of this buffer.

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -102,7 +102,6 @@ public struct Unsafe${Mutable}RawBufferPointer
 
   public typealias Index = Int
   public typealias IndexDistance = Int
-  public typealias SubSequence = ${Self}
 
   /// An iterator over the bytes viewed by a raw buffer pointer.
   @_fixed_layout
@@ -403,13 +402,13 @@ public struct Unsafe${Mutable}RawBufferPointer
   /// - Parameter bounds: The range of byte offsets to access. The upper and
   ///   lower bounds of the range must be in the range `0...count`.
   @_inlineable
-  public subscript(bounds: Range<Int>) -> Unsafe${Mutable}RawBufferPointer {
+  public subscript(
+    bounds: Range<Int>
+  ) -> ${Mutable}RandomAccessSlice<Unsafe${Mutable}RawBufferPointer> {
     get {
       _debugPrecondition(bounds.lowerBound >= startIndex)
       _debugPrecondition(bounds.upperBound <= endIndex)
-      return Unsafe${Mutable}RawBufferPointer(
-        start: baseAddress.map { $0 + bounds.lowerBound },
-        count: bounds.count)
+      return ${Mutable}RandomAccessSlice(base: self, bounds: bounds)
     }
 %  if mutable:
     nonmutating set {
@@ -419,7 +418,7 @@ public struct Unsafe${Mutable}RawBufferPointer
 
       if newValue.count > 0 {
         (baseAddress! + bounds.lowerBound).copyBytes(
-          from: newValue.baseAddress!,
+          from: newValue.base.baseAddress! + newValue.startIndex,
           count: newValue.count)
       }
     }

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -23,7 +23,7 @@
 /// uniqueness checks and release mode bounds checks. Bounds checks are always
 /// performed in debug mode.
 ///
-% if mutable:
+%  if mutable:
 /// An `${Self}` instance is a view of the raw bytes in a region of memory.
 /// Each byte in memory is viewed as a `UInt8` value independent of the type
 /// of values held in that memory. Reading from and writing to memory through
@@ -37,7 +37,7 @@
 /// - `load(fromByteOffset:as:)`
 /// - `storeBytes(of:toByteOffset:as:)`
 /// - `copyBytes(from:count:)`
-% else:
+%  else:
 /// An `${Self}` instance is a view of the raw bytes in a region of memory.
 /// Each byte in memory is viewed as a `UInt8` value independent of the type
 /// of values held in that memory. Reading from memory through a raw buffer is
@@ -46,7 +46,7 @@
 /// In addition to its collection interface, an `${Self}` instance also supports
 /// the `load(fromByteOffset:as:)` method provided by `UnsafeRawPointer`,
 /// including bounds checks in debug mode.
-% end
+%  end
 ///
 /// To access the underlying memory through typed operations, the memory must
 /// be bound to a trivial type.
@@ -102,6 +102,7 @@ public struct Unsafe${Mutable}RawBufferPointer
 
   public typealias Index = Int
   public typealias IndexDistance = Int
+  public typealias SubSequence = ${Mutable}RandomAccessSlice<${Self}>
 
   /// An iterator over the bytes viewed by a raw buffer pointer.
   @_fixed_layout
@@ -352,6 +353,44 @@ public struct Unsafe${Mutable}RawBufferPointer
   }
 %  end # !mutable
 
+%  if not mutable:
+  /// Creates a raw buffer over the same memory as the given raw buffer slice.
+  ///
+  /// The new raw buffer will represent the same region of memory as the slice,
+  /// but it's indices will be rebased to zero. Given:
+  ///
+  ///   let slice = buffer[n..<m]
+  ///   let rebased = UnsafeRawBufferPointer(rebasing: slice)
+  ///
+  /// One may assume `rebased.startIndex == 0` and `rebased[0] == slice[n]`.
+  ///
+  /// - Parameter slice: the raw buffer slice to rebase.
+  @_inlineable
+  public init(rebasing slice: RandomAccessSlice<UnsafeRawBufferPointer>) {
+    self.init(start: slice.base.baseAddress! + slice.startIndex,
+      count: slice.count)
+  }
+%  end # !mutable
+
+  /// Creates a raw buffer over the same memory as the given raw buffer slice.
+  ///
+  /// The new raw buffer will represent the same region of memory as the slice,
+  /// but it's indices will be rebased to zero. Given:
+  ///
+  ///   let slice = buffer[n..<m]
+  ///   let rebased = UnsafeRawBufferPointer(rebasing: slice)
+  ///
+  /// One may assume `rebased.startIndex == 0` and `rebased[0] == slice[n]`.
+  ///
+  /// - Parameter slice: the raw buffer slice to rebase.
+  @_inlineable
+  public init(
+    rebasing slice: MutableRandomAccessSlice<UnsafeMutableRawBufferPointer>
+  ) {
+    self.init(start: slice.base.baseAddress! + slice.startIndex,
+      count: slice.count)
+  }
+
   /// Always zero, which is the index of the first byte in a
   /// nonempty buffer.
   @_inlineable
@@ -522,6 +561,26 @@ extension Unsafe${Mutable}RawBufferPointer : CustomDebugStringConvertible {
     return "${Self}"
       + "(start: \(_position.map(String.init(describing:)) ?? "nil"), count: \(count))"
   }
+}
+
+extension ${Self} {
+  @available(*, unavailable, message:
+    "use 'Unsafe${Mutable}RawBufferPointer(rebasing:)' to convert a slice into a zero-based raw buffer.")
+  public subscript(bounds: Range<Int>) -> ${Self} {
+    get { return ${Self}(start: nil, count: 0) }
+%  if mutable:
+    nonmutating set {}
+%  end # mutable
+  }
+
+%  if mutable:
+  @available(*, unavailable, message:
+    "use 'UnsafeRawBufferPointer(rebasing:)' to convert a slice into a zero-based raw buffer.")
+  public subscript(bounds: Range<Int>) -> UnsafeRawBufferPointer {
+    get { return UnsafeRawBufferPointer(start: nil, count: 0) }
+    nonmutating set {}
+  }
+%  end # mutable
 }
 
 % end # for mutable

--- a/test/Parse/pointer_conversion.swift.gyb
+++ b/test/Parse/pointer_conversion.swift.gyb
@@ -334,3 +334,12 @@ func f23202128() {
   UP(pipe)    // ok
   UP(&pipe)   // expected-error {{'&' is not allowed passing array value as 'UnsafePointer<Int32>' argument}} {{6-7=}}
 }
+
+func takesRawBuffer(_ b: UnsafeRawBufferPointer) {}
+
+// <rdar://problem/29586888> UnsafeRawBufferPointer range subscript is inconsistent with Collection.
+func f29586888(b: UnsafeRawBufferPointer) {
+  takesRawBuffer(b[1..<2]) // expected-error {{'subscript' is unavailable: use 'UnsafeRawBufferPointer(rebasing:)' to convert a slice into a zero-based raw buffer.}}
+  let slice = b[1..<2]
+  takesRawBuffer(slice) // expected-error {{cannot convert value of type 'RandomAccessSlice<UnsafeRawBufferPointer>' to expected argument type 'UnsafeRawBufferPointer'}}
+}

--- a/test/stdlib/Inputs/CommonArrayTests.gyb
+++ b/test/stdlib/Inputs/CommonArrayTests.gyb
@@ -87,7 +87,7 @@ ${Suite}.test("${ArrayType}/Sliceable/Enums") {
   do {
     let expected = [E.A, E.B, E.C, E.D]
     let sliceable = ${ArrayType}(expected)
-    checkSliceableWithBidirectionalIndex(expected, sliceable)
+    checkBidirectionalCollection(expected, sliceable)
   }
 
   /*
@@ -95,7 +95,7 @@ ${Suite}.test("${ArrayType}/Sliceable/Enums") {
   do {
     let expected = [[E.A, E.B], [E.B, E.C], [E.D], [E.A, E.B, E.D]]
     let sliceable = ${ArrayType}(expected)
-    checkSliceableWithBidirectionalIndex(
+    checkBidirectionalCollection(
       expected, sliceable, SourceLocStack().withCurrentLoc())
   }
   */

--- a/test/stdlib/UnsafeRawBufferPointer.swift
+++ b/test/stdlib/UnsafeRawBufferPointer.swift
@@ -9,6 +9,26 @@ import StdlibUnittest
 
 var UnsafeRawBufferPointerTestSuite = TestSuite("UnsafeRawBufferPointer")
 
+UnsafeRawBufferPointerTestSuite.test("rebasing") {
+  let buffer = UnsafeMutableRawBufferPointer.allocate(count: 4)
+  defer { buffer.deallocate() }
+
+  buffer.copyBytes(from: [0, 1, 2, 3] as [UInt8])
+
+  let slice = buffer[1..<3]
+  let rebased = UnsafeRawBufferPointer(rebasing: slice)
+  assert(rebased.startIndex == 0 && rebased.endIndex == 2)
+  assert(rebased[0] == slice[1] && rebased[1] == slice[2])
+
+  let mutableRebased = UnsafeMutableRawBufferPointer(rebasing: slice)
+  assert(mutableRebased.startIndex == 0 && mutableRebased.endIndex == 2)
+  assert(mutableRebased[0] == slice[1] && mutableRebased[1] == slice[2])
+
+  let rebased2 = UnsafeRawBufferPointer(rebasing: rebased[1..<2])
+  assert(rebased2.startIndex == 0 && rebased2.endIndex == 1)
+  assert(rebased2[0] == slice[2])
+}
+
 // View an in-memory value's bytes.
 // Use copyBytes to overwrite the value's bytes.
 UnsafeRawBufferPointerTestSuite.test("initFromValue") {
@@ -46,19 +66,14 @@ UnsafeRawBufferPointerTestSuite.test("nonmutating_subscript_setter") {
   buffer.copyBytes(from: [0, 1, 2, 3] as [UInt8])
   let leftBytes = buffer[0..<2]
 
-  // Assign into a `var` mutable slice.
-  var rightBytes = buffer[0..<2]
-  rightBytes = leftBytes
+  // Subscript assign.
+  var rightBytes = buffer[2..<4]
+  buffer[2..<4] = leftBytes
   expectEqualSequence(leftBytes, rightBytes)
   
   // Subscript assign into a `var` mutable slice.
   buffer.copyBytes(from: [0, 1, 2, 3] as [UInt8])
-  rightBytes[3..<4] = leftBytes
-  expectEqualSequence(leftBytes, rightBytes)
-
-  // Subscript assign into a `let` mutable buffer.
-  buffer.copyBytes(from: [0, 1, 2, 3] as [UInt8])
-  buffer[3..<4] = leftBytes
+  rightBytes[2..<4] = leftBytes
   expectEqualSequence(leftBytes, rightBytes)
 }
 
@@ -81,7 +96,7 @@ UnsafeRawBufferPointerTestSuite.test("initFromArray") {
     // Mutable view of array2's bytes.
     array2.withUnsafeMutableBytes { bytes2 in
       expectEqual(bytes1.count, bytes2.count)
-      bytes2[0..<bytes2.count].copyBytes(from: bytes1)
+      bytes2.copyBytes(from: bytes1)
     }
   }
   expectEqual(array2, array1)
@@ -132,7 +147,7 @@ UnsafeRawBufferPointerTestSuite.test("initializeMemory(as:from:).invalidNilPtr")
   let buffer = UnsafeMutableRawBufferPointer(start: nil, count: 0)
   let source: [Int64] = [5, 4, 3, 2, 1]
   expectCrashLater()
-  var (it, bound) = buffer.initializeMemory(as: Int64.self, from: source)
+  _ = buffer.initializeMemory(as: Int64.self, from: source)
 }
 
 UnsafeRawBufferPointerTestSuite.test("initializeMemory(as:from:).validNilPtr") {
@@ -160,11 +175,11 @@ UnsafeRawBufferPointerTestSuite.test("withUnsafeBytes.Sequence") {
 // Test the empty buffer.
 UnsafeRawBufferPointerTestSuite.test("empty") {
   let emptyBytes = UnsafeRawBufferPointer(start: nil, count: 0)
-  for byte in emptyBytes {
+  for _ in emptyBytes {
     expectUnreachable()
   }
   let emptyMutableBytes = UnsafeMutableRawBufferPointer.allocate(count: 0)
-  for byte in emptyMutableBytes {
+  for _ in emptyMutableBytes {
     expectUnreachable()
   }
   emptyMutableBytes.deallocate()
@@ -198,7 +213,8 @@ UnsafeRawBufferPointerTestSuite.test("reinterpret") {
   for i in 0..<MemoryLayout<Int32>.stride {
     expectEqual(0xFF, bytes[i])
   }
-  let bytes2 = bytes[MemoryLayout<Int32>.stride..<bytes.count]
+  let bytes2 = UnsafeMutableRawBufferPointer(
+    rebasing: bytes[MemoryLayout<Int32>.stride..<bytes.count])
   for i in 0..<MemoryLayout<Int32>.stride {
     expectEqual(0, bytes2[i])
   }
@@ -230,7 +246,7 @@ UnsafeRawBufferPointerTestSuite.test("inBounds") {
   }
   let median = (numInts/2 * MemoryLayout<Int>.stride)
   var firstHalf = bytes[0..<median]
-  var secondHalf = bytes[median..<bytes.count]
+  let secondHalf = bytes[median..<bytes.count]
   firstHalf[0..<firstHalf.count] = secondHalf
   expectEqualSequence(firstHalf, secondHalf)
 }
@@ -265,7 +281,7 @@ UnsafeRawBufferPointerTestSuite.test("subscript.set.underflow") {
   let buffer = UnsafeMutableRawBufferPointer.allocate(count: 2)
   defer { buffer.deallocate() }
 
-  let bytes = buffer[1..<2]
+  var bytes = buffer[1..<2]
 
   if _isDebugAssertConfiguration() {
     expectCrashLater()
@@ -278,7 +294,7 @@ UnsafeRawBufferPointerTestSuite.test("subscript.set.overflow") {
   let buffer = UnsafeMutableRawBufferPointer.allocate(count: 2)
   defer { buffer.deallocate() }
 
-  let bytes = buffer[0..<1]
+  var bytes = buffer[0..<1]
 
   if _isDebugAssertConfiguration() {
     expectCrashLater()
@@ -365,26 +381,27 @@ UnsafeRawBufferPointerTestSuite.test("copyBytes.overflow") {
   var buffer = UnsafeMutableRawBufferPointer.allocate(count: 3)
   defer { buffer.deallocate() }
 
-  var bytes = buffer[0..<2]
+  let bytes = buffer[0..<2]
 
   if _isDebugAssertConfiguration() {
     expectCrashLater()
   }
   // Performs a valid byte-wise copy but triggers a debug range size check.
-  bytes.copyBytes(from: buffer)
+  UnsafeMutableRawBufferPointer(rebasing: bytes).copyBytes(from: buffer)
 }
 
 UnsafeRawBufferPointerTestSuite.test("copyBytes.sequence.overflow") {
   var buffer = UnsafeMutableRawBufferPointer.allocate(count: 3)
   defer { buffer.deallocate() }
   
-  var bytes = buffer[0..<2]
+  let bytes = buffer[0..<2]
 
   if _isDebugAssertConfiguration() {
     expectCrashLater()
   }
   // Performs a valid byte-wise copy but triggers a debug range size check.
-  bytes.copyBytes(from: [0, 1, 2] as [UInt8])
+  UnsafeMutableRawBufferPointer(rebasing: bytes).copyBytes(
+    from: [0, 1, 2] as [UInt8])
 }
 
 UnsafeRawBufferPointerTestSuite.test("load.before")
@@ -466,7 +483,7 @@ UnsafeRawBufferPointerTestSuite.test("copy.sequence.overflow")
 }
 
 UnsafeRawBufferPointerTestSuite.test("copy.overlap") {
-  var bytes = UnsafeMutableRawBufferPointer.allocate(count: 4)
+  let bytes = UnsafeMutableRawBufferPointer.allocate(count: 4)
   // Right Overlap
   bytes[0] = 1
   bytes[1] = 2

--- a/test/stdlib/UnsafeRawBufferPointer.swift
+++ b/test/stdlib/UnsafeRawBufferPointer.swift
@@ -9,26 +9,6 @@ import StdlibUnittest
 
 var UnsafeRawBufferPointerTestSuite = TestSuite("UnsafeRawBufferPointer")
 
-UnsafeRawBufferPointerTestSuite.test("rebasing") {
-  let buffer = UnsafeMutableRawBufferPointer.allocate(count: 4)
-  defer { buffer.deallocate() }
-
-  buffer.copyBytes(from: [0, 1, 2, 3] as [UInt8])
-
-  let slice = buffer[1..<3]
-  let rebased = UnsafeRawBufferPointer(rebasing: slice)
-  assert(rebased.startIndex == 0 && rebased.endIndex == 2)
-  assert(rebased[0] == slice[1] && rebased[1] == slice[2])
-
-  let mutableRebased = UnsafeMutableRawBufferPointer(rebasing: slice)
-  assert(mutableRebased.startIndex == 0 && mutableRebased.endIndex == 2)
-  assert(mutableRebased[0] == slice[1] && mutableRebased[1] == slice[2])
-
-  let rebased2 = UnsafeRawBufferPointer(rebasing: rebased[1..<2])
-  assert(rebased2.startIndex == 0 && rebased2.endIndex == 1)
-  assert(rebased2[0] == slice[2])
-}
-
 // View an in-memory value's bytes.
 // Use copyBytes to overwrite the value's bytes.
 UnsafeRawBufferPointerTestSuite.test("initFromValue") {

--- a/test/stdlib/UnsafeRawBufferPointer.swift
+++ b/test/stdlib/UnsafeRawBufferPointer.swift
@@ -23,7 +23,7 @@ UnsafeRawBufferPointerTestSuite.test("initFromValue") {
     // Mutable view of value2's bytes.
     withUnsafeMutableBytes(of: &value2) { bytes2 in
       expectEqual(bytes1.count, bytes2.count)
-      bytes2[0..<bytes2.count].copyBytes(from: bytes1)
+      bytes2.copyBytes(from: bytes1)
     }
   }
   expectEqual(value2, value1)
@@ -45,8 +45,20 @@ UnsafeRawBufferPointerTestSuite.test("nonmutating_subscript_setter") {
   defer { buffer.deallocate() }
   buffer.copyBytes(from: [0, 1, 2, 3] as [UInt8])
   let leftBytes = buffer[0..<2]
-  let rightBytes = buffer[0..<2]
-  leftBytes[0..<2] = rightBytes
+
+  // Assign into a `var` mutable slice.
+  var rightBytes = buffer[0..<2]
+  rightBytes = leftBytes
+  expectEqualSequence(leftBytes, rightBytes)
+  
+  // Subscript assign into a `var` mutable slice.
+  buffer.copyBytes(from: [0, 1, 2, 3] as [UInt8])
+  rightBytes[3..<4] = leftBytes
+  expectEqualSequence(leftBytes, rightBytes)
+
+  // Subscript assign into a `let` mutable buffer.
+  buffer.copyBytes(from: [0, 1, 2, 3] as [UInt8])
+  buffer[3..<4] = leftBytes
   expectEqualSequence(leftBytes, rightBytes)
 }
 

--- a/validation-test/stdlib/Collection/LazyFilterCollection.swift.gyb
+++ b/validation-test/stdlib/Collection/LazyFilterCollection.swift.gyb
@@ -109,12 +109,12 @@ CollectionTests.test("LazyFilterCollection instances (${traversal}${kind})") {
       expected,
       MinimalSequence(elements: base).lazy.filter(predicate))
 % elif traversal == '' and kind == 'Collection':
-    checkForwardCollection(
+    checkOneLevelOfForwardCollection(
       expected,
       MinimalCollection(elements: base).lazy.filter(predicate),
       sameValue: { $0 == $1 })
 % else:
-    check${traversal}${kind}(
+    checkOneLevelOf${traversal}${kind}(
       expected,
       Minimal${traversal}${kind}(elements: base).lazy.filter(predicate),
       sameValue: { $0 == $1 })

--- a/validation-test/stdlib/CollectionType.swift.gyb
+++ b/validation-test/stdlib/CollectionType.swift.gyb
@@ -474,8 +474,8 @@ CollectionTypeTests.test("Collection.makeIterator()/DefaultImplementation") {
     }
 
     checkCollection(
-      collection,
-      expected: Array(1..<count+1).map(OpaqueValue.init) as [OpaqueValue<Int>]
+      Array(1..<count+1).map(OpaqueValue.init) as [OpaqueValue<Int>],
+      collection
     ) { $0.value == $1.value }
   }
 }
@@ -547,8 +547,8 @@ CollectionTypeTests.test("Collection.makeIterator()/CustomImplementation") {
     }
 
     checkCollection(
+      Array(1..<count+1).map(OpaqueValue.init) as [OpaqueValue<Int>],
       collection,
-      expected: Array(1..<count+1).map(OpaqueValue.init) as [OpaqueValue<Int>],
       resiliencyChecks: .none) { $0.value == $1.value }
   }
 }

--- a/validation-test/stdlib/Data.swift
+++ b/validation-test/stdlib/Data.swift
@@ -59,6 +59,8 @@ DataTestSuite.test("Data SubSequence") {
         expectEqual(dataSlice.startIndex, i)
         expectEqual(dataSlice.endIndex, j)
         
+        expectEqual(dataSlice[i], arraySlice[i])
+
         dataSlice[i] = 0xFF
         
         expectEqual(dataSlice.startIndex, i)

--- a/validation-test/stdlib/Data.swift
+++ b/validation-test/stdlib/Data.swift
@@ -7,6 +7,7 @@ import StdlibCollectionUnittest
 import Foundation
 
 var DataTestSuite = TestSuite("Data")
+
 DataTestSuite.test("Data.Iterator semantics") {
   // Empty data
   checkSequence([], Data())
@@ -45,7 +46,10 @@ DataTestSuite.test("Data SubSequence") {
   let array: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7]
   var data = Data(bytes: array)
 
-  checkRandomAccessCollection(array, data)
+  // FIXME: Iteration over Data slices is currently broken:
+  // [SR-4292] Foundation.Data.copyBytes is zero-based.
+  //           Data.Iterator assumes it is not.
+  // checkRandomAccessCollection(array, data)
 
   for i in 0..<data.count {
     for j in i..<data.count {

--- a/validation-test/stdlib/Data.swift
+++ b/validation-test/stdlib/Data.swift
@@ -59,7 +59,10 @@ DataTestSuite.test("Data SubSequence") {
         expectEqual(dataSlice.startIndex, i)
         expectEqual(dataSlice.endIndex, j)
         
-        expectEqual(dataSlice[i], arraySlice[i])
+        // FIXME: Iteration over Data slices is currently broken:
+        // [SR-4292] Foundation.Data.copyBytes is zero-based.
+        //           Data.Iterator assumes it is not.
+        // expectEqual(dataSlice[i], arraySlice[i])
 
         dataSlice[i] = 0xFF
         

--- a/validation-test/stdlib/Lazy.swift.gyb
+++ b/validation-test/stdlib/Lazy.swift.gyb
@@ -698,7 +698,7 @@ tests.test("Lazy${TraversalCollection}/Collection") {
     Minimal${TraversalCollection}<OpaqueValue<Int>>
   >.self, &again)
 
-  check${Traversal}Collection(
+  checkOneLevelOf${Traversal}Collection(
     expected, base.lazy, resiliencyChecks: .none
   ) { $0.value == $1.value }
 
@@ -1124,7 +1124,7 @@ tests.test("LazyFilterCollection") {
     LazyFilterCollection<MinimalCollection<OpaqueValue<Int>>>
   >.test(filtered)
 
-  checkForwardCollection(
+  checkOneLevelOfForwardCollection(
     stride(from: 0, to: 100, by: 2).map(OpaqueValue.init), filtered,
     resiliencyChecks: .none
   ) {

--- a/validation-test/stdlib/Slice.swift.gyb
+++ b/validation-test/stdlib/Slice.swift.gyb
@@ -83,8 +83,8 @@ SliceTests.test("${Slice}/init(base:bounds:)") {
     expectType(${Slice}<${Collection}<OpaqueValue<Int>>>.self, &slice)
 
     checkCollection(
+      test.expected,
       slice,
-      expected: test.expected,
       stackTrace: SourceLocStack().with(test.loc))
       { $0.value == $1.value }
   }

--- a/validation-test/stdlib/Unicode.swift.gyb
+++ b/validation-test/stdlib/Unicode.swift.gyb
@@ -1607,7 +1607,7 @@ func checkUTF8View(_ expected: [UInt8], _ subject: String,
 
 func checkUTF16View(_ expected: [UInt16], _ subject: String,
     _ stackTrace: SourceLocStack) {
-  checkSliceableWithBidirectionalIndex(expected, subject.utf16)
+  checkBidirectionalCollection(expected, subject.utf16)
 }
 
 func forStringsWithUnpairedSurrogates(_ checkClosure: (UTF16Test, String) -> Void) {
@@ -1848,7 +1848,7 @@ StringCookedViews.test("UnicodeScalars").forEach(in: utfTests) {
   test in
 
   let subject = NonContiguousNSString(test.utf32) as String
-  checkSliceableWithBidirectionalIndex(
+  checkBidirectionalCollection(
     test.unicodeScalars, subject.unicodeScalars)
 }
 
@@ -1858,7 +1858,7 @@ StringCookedViews.test("UnicodeScalars/StringsWithUnpairedSurrogates") {
     let expectedScalars = (test.scalarsHead + test.scalarsRepairedTail).map {
       UnicodeScalar($0)!
     }
-    checkSliceableWithBidirectionalIndex(
+    checkBidirectionalCollection(
       expectedScalars, subject.unicodeScalars)
   }
 }

--- a/validation-test/stdlib/UnicodeTrie.swift.gyb
+++ b/validation-test/stdlib/UnicodeTrie.swift.gyb
@@ -144,7 +144,7 @@ func checkGraphemeClusterSegmentation(
   )
 
   let expectedCharacters: [Character] = Array(subject.characters)
-  checkSliceableWithBidirectionalIndex(expectedCharacters, subject.characters)
+  checkBidirectionalCollection(expectedCharacters, subject.characters)
 }
 
 func checkGraphemeClusterSegmentation(

--- a/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
+++ b/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
@@ -63,6 +63,39 @@ ${SelfName}TestSuite.test("AssociatedTypes") {
   expect${'Mutable' if IsMutable else ''}CollectionType(${SelfType}.self)
 }
 
+${SelfName}TestSuite.test("rebasing") {
+  let rawbuffer = UnsafeMutableRawBufferPointer.allocate(count: 4 * MemoryLayout<Int>.stride)
+  defer { rawbuffer.deallocate() }
+
+  rawbuffer.copyBytes(from: [0, 1, 2, 3])
+
+%   if IsRaw:
+  let buffer = rawbuffer
+%   else:
+  let intPtr = rawbuffer.baseAddress!.bindMemory(to: Int.self, capacity: 4)
+  let buffer = UnsafeMutableBufferPointer(start: intPtr, count: 4)
+%   end
+
+  for i in buffer.indices {
+    let slice = buffer[i..<buffer.endIndex]
+    let rebased = ${SelfName}(rebasing: slice)
+    expectEqual(rebased.startIndex, 0)
+    expectEqual(rebased.endIndex, rebased.count)
+    expectEqual(rebased.endIndex, buffer.endIndex - i)
+    expectEqual(rebased[0], slice[i])
+    if rebased.count > 1 {
+      expectEqual(rebased[1], slice[i + 1])
+
+      // Rebase again. Tests Mutable->Immutable initializer
+      // and an rvalue slice with literal indices.
+      let rebased2 = ${SelfName}(rebasing: rebased[1..<2])
+      expectEqual(rebased2.startIndex, 0)
+      expectEqual(rebased2.endIndex, 1)
+      expectEqual(rebased2[0], slice[i + 1])
+    }
+  }
+}
+
 // Allocate two buffers. Initialize one and copy it into the other. Pass those
 // to the specified generic collection test function `checkBuffers`.
 func checkWithExpectedBuffer(checkBuffers: (${SelfType}, ${SelfType}) -> Void) {

--- a/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
+++ b/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
@@ -475,15 +475,15 @@ ${SelfName}TestSuite.test("RandomAccessCollection") {
   defer { SubscriptGetTest.deallocateFor${'Raw' if IsRaw else ''}Buffer(
       memoryCopy, count: elementCount) }
 
-  var buffer = SubscriptGetTest.create${SelfName}(from: memory)
-  var expected = UnsafeMutable${'Raw' if IsRaw else ''}BufferPointer(
+  let buffer = SubscriptGetTest.create${SelfName}(from: memory)
+  let expected = UnsafeMutable${'Raw' if IsRaw else ''}BufferPointer(
     start: memoryCopy, count: buffer.count)
 
 %   if IsRaw:
   expected.copyBytes(from: buffer)
   checkRandomAccessCollection(expected, buffer) { $0 == $1 }
 %   else:
-  expected.baseAddress!.initialize(from: buffer)
+  _ = expected.initialize(from: buffer)
   checkRandomAccessCollection(expected, buffer) { $0.value == $1.value }
 %   end
 }
@@ -542,15 +542,15 @@ ${SelfName}TestSuite.test("subscript/${RangeName}/get").forEach(in: subscriptGet
     )
   }
 }
-%    end
-
-% end
+%   end # RangeName
+% end # SelfName, IsMutable, IsRaw, SelfType, PointerType
 
 % for (SelfName, IsRaw) in [
 %   ('UnsafeMutableBufferPointer', False),
 %   ('UnsafeMutableRawBufferPointer', True)
 % ]:
 %   for RangeName in ['range', 'countableRange', 'closedRange', 'countableClosedRange']:
+
 UnsafeMutable${'Raw' if IsRaw else ''}BufferPointerTestSuite.test("subscript/${RangeName}/set")
 %     if not IsRaw:
   // UnsafeRawBuffer (currently) invokes Collection._failEarlyRangeCheck
@@ -585,7 +585,7 @@ UnsafeMutable${'Raw' if IsRaw else ''}BufferPointerTestSuite.test("subscript/${R
       return false
     }
   }
-%      else:
+%      else: # !closed
   expectedValues = test.expectedValues
   replacementValues = test.replacementValues
   let isOutOfBounds: () -> Bool = {
@@ -596,7 +596,7 @@ UnsafeMutable${'Raw' if IsRaw else ''}BufferPointerTestSuite.test("subscript/${R
       return false
     }
   }
-%      end
+%      end # !closed
 
   var memory = SubscriptSetTest.allocateFor${'Raw' if IsRaw else ''}Buffer(
     count: elementCount)
@@ -640,7 +640,9 @@ UnsafeMutable${'Raw' if IsRaw else ''}BufferPointerTestSuite.test("subscript/${R
     )
   }
 }
+
 %   end # RangeName
+
 % end # SelfName
 
 UnsafeMutableRawBufferPointerTestSuite.test("changeElementViaBuffer") {

--- a/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
+++ b/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
@@ -6,30 +6,302 @@ import StdlibCollectionUnittest
 
 // Tests
 
+func allocateForRawBuffer(count: Int) -> UnsafeMutableRawPointer {
+  return UnsafeMutableRawPointer.allocate(bytes: count, alignedTo: 1)
+}
+func allocateForBuffer<T>(count: Int) -> UnsafeMutablePointer<T> {
+  return UnsafeMutablePointer<T>.allocate(capacity: count)
+}
+func deallocateForRawBuffer(
+  _ memory: UnsafeMutableRawPointer, count: Int
+) {
+  memory.deallocate(bytes: count, alignedTo: 1)
+}
+func deallocateForBuffer<T>(
+  _ memory: UnsafeMutablePointer<T>, count: Int
+) {
+  memory.deallocate(capacity: count)
+}
+
+// Initialize memory with arbitrary equatable, comparable values.
+func initUnsafeRawBufferPointer(_ b: UnsafeMutableRawBufferPointer) {
+  _ = b.initializeMemory(as: UInt8.self, from: UInt8(0)..<numericCast(b.count))
+}
+func initUnsafeBufferPointer(_ b: UnsafeMutableBufferPointer<Float>) {
+  _ = b.initialize(from: (0..<b.count).lazy.map {Float($0)})
+}
+
+// Test Suites
+
+var UnsafeBufferPointerTestSuite = TestSuite("UnsafeBufferPointer")
+var UnsafeMutableBufferPointerTestSuite = TestSuite("UnsafeMutableBufferPointer")
+var UnsafeRawBufferPointerTestSuite = TestSuite("UnsafeRawBufferPointer")
+var UnsafeMutableRawBufferPointerTestSuite = TestSuite("UnsafeMutableRawBufferPointer")
+
+% for (SelfName, IsMutable, IsRaw, SelfType, PointerType) in [
+%   ('UnsafeBufferPointer', False, False, 'UnsafeBufferPointer<Float>', 'UnsafePointer<Float>'),
+%   ('UnsafeMutableBufferPointer', True, False, 'UnsafeMutableBufferPointer<Float>', 'UnsafeMutablePointer<Float>'),
+%   ('UnsafeRawBufferPointer', False, True, 'UnsafeRawBufferPointer', 'UnsafeRawPointer'),
+%   ('UnsafeMutableRawBufferPointer', True, True, 'UnsafeMutableRawBufferPointer', 'UnsafeMutableRawPointer')
+% ]:
+%   Raw = 'Raw' if IsRaw else ''
+%   Element = 'UInt8' if IsRaw else 'Float'
+
+%   if IsRaw:
+${SelfName}TestSuite.test("AssociatedTypes") {
+  expectRandomAccessCollectionAssociatedTypes(
+    collectionType: ${SelfType}.self,
+    iteratorType: ${SelfType}.Iterator.self,
+    subSequenceType: ${SelfType}.self,
+    indexType: Int.self,
+    indexDistanceType: Int.self,
+    indicesType: CountableRange<Int>.self)
+
+  expect${'Mutable' if IsMutable else ''}CollectionType(${SelfType}.self)
+}
+%   else: # !IsRaw
+${SelfName}TestSuite.test("AssociatedTypes") {
+  typealias Subject = ${SelfName}<OpaqueValue<Int>>
+  expectRandomAccessCollectionAssociatedTypes(
+    collectionType: Subject.self,
+    iteratorType: IndexingIterator<Subject>.self,
+    subSequenceType: ${'Mutable' if IsMutable else ''}RandomAccessSlice<Subject>.self,
+    indexType: Int.self,
+    indexDistanceType: Int.self,
+    indicesType: CountableRange<Int>.self)
+
+  expect${'Mutable' if IsMutable else ''}CollectionType(Subject.self)
+}
+%   end # !IsRaw
+
+// Allocate two buffers. Initialize one and copy it into the other. Pass those
+// to the specified generic collection test function `checkBuffers`.
+func checkWithExpectedBuffer(checkBuffers: (${SelfType}, ${SelfType}) -> Void) {
+  // A collection just big enough to be sliced up interestingly.
+  let elementCount = 4
+
+%   if IsRaw:
+  var memory: UnsafeMutableRawPointer
+  var memoryCopy: UnsafeMutableRawPointer
+%   else:
+  var memory: UnsafeMutablePointer<Float>
+  var memoryCopy: UnsafeMutablePointer<Float>
+%   end
+
+  memory = allocateFor${Raw}Buffer(count: elementCount)
+  defer { deallocateFor${Raw}Buffer(
+      memory, count: elementCount) }
+
+  memoryCopy = allocateFor${Raw}Buffer(count: elementCount)
+  defer { deallocateFor${Raw}Buffer(memoryCopy, count: elementCount) }
+
+  initUnsafe${Raw}BufferPointer(
+    UnsafeMutable${Raw}BufferPointer(start: memory, count: elementCount))
+
+  let buffer = ${SelfType}(start: memory, count: elementCount)
+
+  let expectedBuffer = UnsafeMutable${Raw}BufferPointer(start: memoryCopy,
+    count: elementCount)
+
+%   if IsRaw:
+    expectedBuffer.copyBytes(from: buffer)
+%   else:
+    _ = expectedBuffer.initialize(from: buffer)
+%   end
+
+  let expected = ${SelfType}(
+    start: expectedBuffer.baseAddress, count: expectedBuffer.count)
+
+  checkBuffers(expected, buffer)
+}
+
+${SelfName}TestSuite.test("RandomAccessCollection") {
+  checkWithExpectedBuffer { (expected: ${SelfType}, buffer: ${SelfType}) in
+    checkRandomAccessCollection(expected, buffer,
+      sameValue: { (a: ${Element}, b: ${Element}) in a == b })
+  }
+}
+
+${SelfName}TestSuite.test("nilBaseAddress") {
+  let emptyBuffer = ${SelfType}(start: nil, count: 0)
+  expectNil(emptyBuffer.baseAddress)
+  expectEqual(0, emptyBuffer.count)
+  expectTrue(emptyBuffer.startIndex == emptyBuffer.endIndex)
+
+  var iter = emptyBuffer.makeIterator()
+  expectNil(iter.next())
+
+  expectEqualSequence([], emptyBuffer)
+}
+
+${SelfName}TestSuite.test("nonNilButEmpty") {
+  let emptyAllocated = UnsafeMutablePointer<Float>.allocate(capacity: 0)
+  defer { emptyAllocated.deallocate(capacity: 0) }
+
+  let emptyBuffer = ${SelfType}(start: ${PointerType}(emptyAllocated), count: 0)
+  expectEqual(emptyAllocated, emptyBuffer.baseAddress)
+  expectEqual(0, emptyBuffer.count)
+  expectTrue(emptyBuffer.startIndex == emptyBuffer.endIndex)
+
+  var iter = emptyBuffer.makeIterator()
+  expectNil(iter.next())
+
+  expectEqualSequence([], emptyBuffer)
+}
+
+%   if IsRaw:
+${SelfName}TestSuite.test("nonNilNonEmpty") {
+  let count = 4
+  let allocated = UnsafeMutableRawPointer.allocate(bytes: count, alignedTo: 1)
+  defer { allocated.deallocate(bytes: count, alignedTo: 1) }
+  let uint8Ptr = allocated.initializeMemory(as: UInt8.self, count: count, to: 1)
+  uint8Ptr[count - 1] = 2
+
+  let buffer = ${SelfType}(start: ${PointerType}(allocated), count: count - 1)
+  expectEqual(allocated, buffer.baseAddress)
+  expectEqual(count - 1, buffer.count)
+  expectEqual(count - 1, buffer.endIndex - buffer.startIndex)
+
+  uint8Ptr[1] = 0
+  expectEqual(1, buffer[0])
+  expectEqual(0, buffer[1])
+  expectEqual(1, buffer[2])
+
+  var iter = buffer.makeIterator()
+  expectEqual(1, iter.next())
+  expectEqual(0, iter.next())
+  expectEqual(1, iter.next())
+  expectNil(iter.next())
+
+  expectEqualSequence([1, 0, 1], buffer.map { Int($0) })
+
+  expectEqual(2, uint8Ptr[count-1])
+}
+%   else: # !IsRaw
+${SelfName}TestSuite.test("nonNilNonEmpty") {
+  let count = 4
+  let allocated = UnsafeMutablePointer<Float>.allocate(capacity: count)
+  defer { allocated.deallocate(capacity: count) }
+  allocated.initialize(to: 1.0, count: count)
+  allocated[count - 1] = 2.0
+
+  let buffer = ${SelfType}(start: ${PointerType}(allocated), count: count - 1)
+  expectEqual(allocated, buffer.baseAddress)
+  expectEqual(count - 1, buffer.count)
+  expectEqual(count - 1, buffer.endIndex - buffer.startIndex)
+
+  allocated[1] = 0.0
+  expectEqual(1.0, buffer[0])
+  expectEqual(0.0, buffer[1])
+  expectEqual(1.0, buffer[2])
+
+  var iter = buffer.makeIterator()
+  expectEqual(1.0, iter.next())
+  expectEqual(0.0, iter.next())
+  expectEqual(1.0, iter.next())
+  expectNil(iter.next())
+
+  expectEqualSequence([1.0, 0.0, 1.0], buffer)
+
+  expectEqual(2.0, allocated[count-1])
+}
+%   end # !IsRaw
+
+${SelfName}TestSuite.test("badCount")
+  .skip(.custom(
+    { _isFastAssertConfiguration() },
+    reason: "this trap is not guaranteed to happen in -Ounchecked"))
+  .code {
+  expectCrashLater()
+
+  let emptyAllocated = UnsafeMutablePointer<Float>.allocate(capacity: 0)
+  defer { emptyAllocated.deallocate(capacity: 0) }
+
+  let buffer = ${SelfType}(start: ${PointerType}(emptyAllocated), count: -1)
+  _ = buffer
+}
+
+${SelfName}TestSuite.test("badNilCount")
+  .skip(.custom(
+    { _isFastAssertConfiguration() },
+    reason: "this trap is not guaranteed to happen in -Ounchecked"))
+  .code {
+  expectCrashLater()
+
+  let buffer = ${SelfType}(start: nil, count: 1)
+  _ = buffer
+}
+% end # for SelfName, IsRaw, SelfType
+
+UnsafeMutableRawBufferPointerTestSuite.test("changeElementViaBuffer") {
+  let count = 4
+  let allocated = UnsafeMutableRawPointer.allocate(bytes: count, alignedTo: 1)
+  defer { allocated.deallocate(bytes: count, alignedTo: 1) }
+  let uint8Ptr = allocated.initializeMemory(as: UInt8.self, count: count, to: 1)
+  uint8Ptr[count-1] = UInt8.max
+
+  var buffer = UnsafeMutableRawBufferPointer(start: allocated, count: count - 1)
+
+  buffer[1] = 0
+  expectEqual(1, buffer[0])
+  expectEqual(0, buffer[1])
+  expectEqual(1, buffer[2])
+
+  expectEqual(1, uint8Ptr[0])
+  expectEqual(0, uint8Ptr[1])
+  expectEqual(1, uint8Ptr[2])
+  expectEqual(UInt8.max, uint8Ptr[count-1])
+
+  buffer.sort()
+  expectEqual(0, buffer[0])
+  expectEqual(1, buffer[1])
+  expectEqual(1, buffer[2])
+
+  expectEqual(0, uint8Ptr[0])
+  expectEqual(1, uint8Ptr[1])
+  expectEqual(1, uint8Ptr[2])
+  expectEqual(UInt8.max, uint8Ptr[count-1])
+}
+
+UnsafeMutableBufferPointerTestSuite.test("changeElementViaBuffer") {
+  let count = 4
+  let allocated = UnsafeMutablePointer<Float>.allocate(capacity: count)
+  defer { allocated.deallocate(capacity: count) }
+  allocated.initialize(to: 1.0, count: count)
+  allocated[count-1] = -1.0
+
+  var buffer = UnsafeMutableBufferPointer(start: allocated, count: count - 1)
+
+  buffer[1] = 0.0
+  expectEqual(1.0, buffer[0])
+  expectEqual(0.0, buffer[1])
+  expectEqual(1.0, buffer[2])
+
+  expectEqual(1.0, allocated[0])
+  expectEqual(0.0, allocated[1])
+  expectEqual(1.0, allocated[2])
+  expectEqual(-1.0, allocated[count-1])
+
+  buffer.sort()
+  expectEqual(0.0, buffer[0])
+  expectEqual(1.0, buffer[1])
+  expectEqual(1.0, buffer[2])
+
+  expectEqual(0.0, allocated[0])
+  expectEqual(1.0, allocated[1])
+  expectEqual(1.0, allocated[2])
+  expectEqual(-1.0, allocated[count-1])
+}
+
 protocol SubscriptTest {
   static var start: Int { get }
   static var end: Int { get }
   static var elementCount: Int { get }
 }
 
+// Initialize memory with opaque values, for use with subscript tests.
 extension SubscriptTest {
   static var elementCount: Int { get { return end - start } }
-
-  static func allocateForRawBuffer(count: Int) -> UnsafeMutableRawPointer {
-    return UnsafeMutableRawPointer.allocate(bytes: count, alignedTo: 1)
-  }
-  static func allocateForBuffer(count: Int
-  ) -> UnsafeMutablePointer<OpaqueValue<Int>> {
-    return UnsafeMutablePointer<OpaqueValue<Int>>.allocate(capacity: count)
-  }
-  static func deallocateForRawBuffer(
-    _ memory: UnsafeMutableRawPointer, count: Int) {
-    memory.deallocate(bytes: count, alignedTo: 1)
-  }
-  static func deallocateForBuffer(
-    _ memory: UnsafeMutablePointer<OpaqueValue<Int>>, count: Int) {
-    memory.deallocate(capacity: count)
-  }
 
 % for SelfType in ['UnsafeRawBufferPointer', 'UnsafeMutableRawBufferPointer']:
   /// Create and populate an `${SelfType}` for use with unit tests.
@@ -312,181 +584,14 @@ let subscriptSetTests : [SubscriptSetTest] = [
     replacementValues: [9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9]),
 ]
 
-
-// Test Suites
-
-var UnsafeBufferPointerTestSuite = TestSuite("UnsafeBufferPointer")
-var UnsafeMutableBufferPointerTestSuite = TestSuite("UnsafeMutableBufferPointer")
-var UnsafeRawBufferPointerTestSuite = TestSuite("UnsafeRawBufferPointer")
-var UnsafeMutableRawBufferPointerTestSuite = TestSuite("UnsafeMutableRawBufferPointer")
-
-% for (SelfName, IsMutable, IsRaw, SelfType, PointerType) in [
-%   ('UnsafeBufferPointer', False, False, 'UnsafeBufferPointer<Float>', 'UnsafePointer<Float>'),
-%   ('UnsafeMutableBufferPointer', True, False, 'UnsafeMutableBufferPointer<Float>', 'UnsafeMutablePointer<Float>'),
-%   ('UnsafeRawBufferPointer', False, True, 'UnsafeRawBufferPointer', 'UnsafeRawPointer'),
-%   ('UnsafeMutableRawBufferPointer', True, True, 'UnsafeMutableRawBufferPointer', 'UnsafeMutableRawPointer')
+% for (SelfName, IsRaw) in [
+%   ('UnsafeBufferPointer', False),
+%   ('UnsafeRawBufferPointer', True),
+%   ('UnsafeMutableBufferPointer', False),
+%   ('UnsafeMutableRawBufferPointer', True)
 % ]:
 
-%   if IsRaw:
-${SelfName}TestSuite.test("AssociatedTypes") {
-  expectRandomAccessCollectionAssociatedTypes(
-    collectionType: ${SelfType}.self,
-    iteratorType: ${SelfType}.Iterator.self,
-    subSequenceType: ${SelfType}.self,
-    indexType: Int.self,
-    indexDistanceType: Int.self,
-    indicesType: CountableRange<Int>.self)
-
-  expect${'Mutable' if IsMutable else ''}CollectionType(${SelfType}.self)
-}
-%   else: # !IsRaw
-${SelfName}TestSuite.test("AssociatedTypes") {
-  typealias Subject = ${SelfName}<OpaqueValue<Int>>
-  expectRandomAccessCollectionAssociatedTypes(
-    collectionType: Subject.self,
-    iteratorType: IndexingIterator<Subject>.self,
-    subSequenceType: ${'Mutable' if IsMutable else ''}RandomAccessSlice<Subject>.self,
-    indexType: Int.self,
-    indexDistanceType: Int.self,
-    indicesType: CountableRange<Int>.self)
-
-  expect${'Mutable' if IsMutable else ''}CollectionType(Subject.self)
-}
-%   end # !IsRaw
-
-${SelfName}TestSuite.test("nilBaseAddress") {
-  let emptyBuffer = ${SelfType}(start: nil, count: 0)
-  expectNil(emptyBuffer.baseAddress)
-  expectEqual(0, emptyBuffer.count)
-  expectTrue(emptyBuffer.startIndex == emptyBuffer.endIndex)
-
-  var iter = emptyBuffer.makeIterator()
-  expectNil(iter.next())
-
-  expectEqualSequence([], emptyBuffer)
-}
-
-${SelfName}TestSuite.test("nonNilButEmpty") {
-  let emptyAllocated = UnsafeMutablePointer<Float>.allocate(capacity: 0)
-  defer { emptyAllocated.deallocate(capacity: 0) }
-
-  let emptyBuffer = ${SelfType}(start: ${PointerType}(emptyAllocated), count: 0)
-  expectEqual(emptyAllocated, emptyBuffer.baseAddress)
-  expectEqual(0, emptyBuffer.count)
-  expectTrue(emptyBuffer.startIndex == emptyBuffer.endIndex)
-
-  var iter = emptyBuffer.makeIterator()
-  expectNil(iter.next())
-
-  expectEqualSequence([], emptyBuffer)
-}
-
-%   if IsRaw:
-${SelfName}TestSuite.test("nonNilNonEmpty") {
-  let count = 4
-  let allocated = UnsafeMutableRawPointer.allocate(bytes: count, alignedTo: 1)
-  defer { allocated.deallocate(bytes: count, alignedTo: 1) }
-  let uint8Ptr = allocated.initializeMemory(as: UInt8.self, count: count, to: 1)
-  uint8Ptr[count - 1] = 2
-
-  let buffer = ${SelfType}(start: ${PointerType}(allocated), count: count - 1)
-  expectEqual(allocated, buffer.baseAddress)
-  expectEqual(count - 1, buffer.count)
-  expectEqual(count - 1, buffer.endIndex - buffer.startIndex)
-
-  uint8Ptr[1] = 0
-  expectEqual(1, buffer[0])
-  expectEqual(0, buffer[1])
-  expectEqual(1, buffer[2])
-
-  var iter = buffer.makeIterator()
-  expectEqual(1, iter.next())
-  expectEqual(0, iter.next())
-  expectEqual(1, iter.next())
-  expectNil(iter.next())
-
-  expectEqualSequence([1, 0, 1], buffer.map { Int($0) })
-
-  expectEqual(2, uint8Ptr[count-1])
-}
-%   else: # !IsRaw
-${SelfName}TestSuite.test("nonNilNonEmpty") {
-  let count = 4
-  let allocated = UnsafeMutablePointer<Float>.allocate(capacity: count)
-  defer { allocated.deallocate(capacity: count) }
-  allocated.initialize(to: 1.0, count: count)
-  allocated[count - 1] = 2.0
-
-  let buffer = ${SelfType}(start: ${PointerType}(allocated), count: count - 1)
-  expectEqual(allocated, buffer.baseAddress)
-  expectEqual(count - 1, buffer.count)
-  expectEqual(count - 1, buffer.endIndex - buffer.startIndex)
-
-  allocated[1] = 0.0
-  expectEqual(1.0, buffer[0])
-  expectEqual(0.0, buffer[1])
-  expectEqual(1.0, buffer[2])
-
-  var iter = buffer.makeIterator()
-  expectEqual(1.0, iter.next())
-  expectEqual(0.0, iter.next())
-  expectEqual(1.0, iter.next())
-  expectNil(iter.next())
-
-  expectEqualSequence([1.0, 0.0, 1.0], buffer)
-
-  expectEqual(2.0, allocated[count-1])
-}
-%   end # !IsRaw
-
-${SelfName}TestSuite.test("badCount")
-  .skip(.custom(
-    { _isFastAssertConfiguration() },
-    reason: "this trap is not guaranteed to happen in -Ounchecked"))
-  .code {
-  expectCrashLater()
-
-  let emptyAllocated = UnsafeMutablePointer<Float>.allocate(capacity: 0)
-  defer { emptyAllocated.deallocate(capacity: 0) }
-
-  let buffer = ${SelfType}(start: ${PointerType}(emptyAllocated), count: -1)
-  _ = buffer
-}
-
-${SelfName}TestSuite.test("badNilCount")
-  .skip(.custom(
-    { _isFastAssertConfiguration() },
-    reason: "this trap is not guaranteed to happen in -Ounchecked"))
-  .code {
-  expectCrashLater()
-
-  let buffer = ${SelfType}(start: nil, count: 1)
-  _ = buffer
-}
-
-${SelfName}TestSuite.test("RandomAccessCollection") {
-  let elementCount = SubscriptGetTest.elementCount
-  var memory = SubscriptGetTest.allocateFor${'Raw' if IsRaw else ''}Buffer(
-    count: elementCount)
-  defer { SubscriptGetTest.deallocateFor${'Raw' if IsRaw else ''}Buffer(
-      memory, count: elementCount) }
-  var memoryCopy = SubscriptGetTest.allocateFor${'Raw' if IsRaw else ''}Buffer(
-    count: elementCount)
-  defer { SubscriptGetTest.deallocateFor${'Raw' if IsRaw else ''}Buffer(
-      memoryCopy, count: elementCount) }
-
-  let buffer = SubscriptGetTest.create${SelfName}(from: memory)
-  let expected = UnsafeMutable${'Raw' if IsRaw else ''}BufferPointer(
-    start: memoryCopy, count: buffer.count)
-
-%   if IsRaw:
-  expected.copyBytes(from: buffer)
-  checkRandomAccessCollection(expected, buffer) { $0 == $1 }
-%   else:
-  _ = expected.initialize(from: buffer)
-  checkRandomAccessCollection(expected, buffer) { $0.value == $1.value }
-%   end
-}
+%   Raw = 'Raw' if IsRaw else ''
 
 %   for RangeName in ['range', 'countableRange', 'closedRange', 'countableClosedRange']:
 ${SelfName}TestSuite.test("subscript/${RangeName}/get").forEach(in: subscriptGetTests) {
@@ -510,10 +615,14 @@ ${SelfName}TestSuite.test("subscript/${RangeName}/get").forEach(in: subscriptGet
 
   let elementCount = SubscriptGetTest.elementCount
 
-  var memory = SubscriptGetTest.allocateFor${'Raw' if IsRaw else ''}Buffer(
-    count: elementCount)
-  defer { SubscriptGetTest.deallocateFor${'Raw' if IsRaw else ''}Buffer(
-      memory, count: elementCount) }
+%     if IsRaw:
+  var memory: UnsafeMutableRawPointer
+%     else:
+  var memory: UnsafeMutablePointer<OpaqueValue<Int>>
+%     end
+
+  memory = allocateFor${Raw}Buffer(count: elementCount)
+  defer { deallocateFor${Raw}Buffer(memory, count: elementCount) }
 
   let buffer = SubscriptGetTest.create${SelfName}(from: memory)
 
@@ -542,6 +651,7 @@ ${SelfName}TestSuite.test("subscript/${RangeName}/get").forEach(in: subscriptGet
     )
   }
 }
+
 %   end # RangeName
 % end # SelfName, IsMutable, IsRaw, SelfType, PointerType
 
@@ -549,6 +659,7 @@ ${SelfName}TestSuite.test("subscript/${RangeName}/get").forEach(in: subscriptGet
 %   ('UnsafeMutableBufferPointer', False),
 %   ('UnsafeMutableRawBufferPointer', True)
 % ]:
+%   Raw = 'Raw' if IsRaw else ''
 %   for RangeName in ['range', 'countableRange', 'closedRange', 'countableClosedRange']:
 
 UnsafeMutable${'Raw' if IsRaw else ''}BufferPointerTestSuite.test("subscript/${RangeName}/set")
@@ -598,13 +709,19 @@ UnsafeMutable${'Raw' if IsRaw else ''}BufferPointerTestSuite.test("subscript/${R
   }
 %      end # !closed
 
-  var memory = SubscriptSetTest.allocateFor${'Raw' if IsRaw else ''}Buffer(
-    count: elementCount)
-  defer { SubscriptSetTest.deallocateFor${'Raw' if IsRaw else ''}Buffer(
-      memory, count: elementCount) }
-  var sliceMemory = SubscriptSetTest.allocateFor${'Raw' if IsRaw else ''}Buffer(
-    count: replacementValues.count)
-  defer { SubscriptSetTest.deallocateFor${'Raw' if IsRaw else ''}Buffer(
+%     if IsRaw:
+  var memory: UnsafeMutableRawPointer
+  var sliceMemory: UnsafeMutableRawPointer
+%     else:
+  var memory: UnsafeMutablePointer<OpaqueValue<Int>>
+  var sliceMemory: UnsafeMutablePointer<OpaqueValue<Int>>
+%     end
+
+  memory = allocateFor${Raw}Buffer(count: elementCount)
+  defer { deallocateFor${Raw}Buffer(memory, count: elementCount) }
+
+  sliceMemory = allocateFor${Raw}Buffer(count: replacementValues.count)
+  defer { deallocateFor${Raw}Buffer(
       sliceMemory, count: replacementValues.count) }
 
   var buffer = SubscriptSetTest.create${SelfName}(from: memory)
@@ -644,65 +761,5 @@ UnsafeMutable${'Raw' if IsRaw else ''}BufferPointerTestSuite.test("subscript/${R
 %   end # RangeName
 
 % end # SelfName
-
-UnsafeMutableRawBufferPointerTestSuite.test("changeElementViaBuffer") {
-  let count = 4
-  let allocated = UnsafeMutableRawPointer.allocate(bytes: count, alignedTo: 1)
-  defer { allocated.deallocate(bytes: count, alignedTo: 1) }
-  let uint8Ptr = allocated.initializeMemory(as: UInt8.self, count: count, to: 1)
-  uint8Ptr[count-1] = UInt8.max
-
-  var buffer = UnsafeMutableRawBufferPointer(start: allocated, count: count - 1)
-
-  buffer[1] = 0
-  expectEqual(1, buffer[0])
-  expectEqual(0, buffer[1])
-  expectEqual(1, buffer[2])
-
-  expectEqual(1, uint8Ptr[0])
-  expectEqual(0, uint8Ptr[1])
-  expectEqual(1, uint8Ptr[2])
-  expectEqual(UInt8.max, uint8Ptr[count-1])
-
-  buffer.sort()
-  expectEqual(0, buffer[0])
-  expectEqual(1, buffer[1])
-  expectEqual(1, buffer[2])
-
-  expectEqual(0, uint8Ptr[0])
-  expectEqual(1, uint8Ptr[1])
-  expectEqual(1, uint8Ptr[2])
-  expectEqual(UInt8.max, uint8Ptr[count-1])
-}
-
-UnsafeMutableBufferPointerTestSuite.test("changeElementViaBuffer") {
-  let count = 4
-  let allocated = UnsafeMutablePointer<Float>.allocate(capacity: count)
-  defer { allocated.deallocate(capacity: count) }
-  allocated.initialize(to: 1.0, count: count)
-  allocated[count-1] = -1.0
-
-  var buffer = UnsafeMutableBufferPointer(start: allocated, count: count - 1)
-
-  buffer[1] = 0.0
-  expectEqual(1.0, buffer[0])
-  expectEqual(0.0, buffer[1])
-  expectEqual(1.0, buffer[2])
-
-  expectEqual(1.0, allocated[0])
-  expectEqual(0.0, allocated[1])
-  expectEqual(1.0, allocated[2])
-  expectEqual(-1.0, allocated[count-1])
-
-  buffer.sort()
-  expectEqual(0.0, buffer[0])
-  expectEqual(1.0, buffer[1])
-  expectEqual(1.0, buffer[2])
-
-  expectEqual(0.0, allocated[0])
-  expectEqual(1.0, allocated[1])
-  expectEqual(1.0, allocated[2])
-  expectEqual(-1.0, allocated[count-1])
-}
 
 runAllTests()

--- a/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
+++ b/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
@@ -47,32 +47,21 @@ var UnsafeMutableRawBufferPointerTestSuite = TestSuite("UnsafeMutableRawBufferPo
 %   Raw = 'Raw' if IsRaw else ''
 %   Element = 'UInt8' if IsRaw else 'Float'
 
-%   if IsRaw:
 ${SelfName}TestSuite.test("AssociatedTypes") {
   expectRandomAccessCollectionAssociatedTypes(
     collectionType: ${SelfType}.self,
+%   if IsRaw:
     iteratorType: ${SelfType}.Iterator.self,
-    subSequenceType: ${SelfType}.self,
+%   else:
+    iteratorType: IndexingIterator<${SelfType}>.self,
+%   end
+    subSequenceType: ${'Mutable' if IsMutable else ''}RandomAccessSlice<${SelfType}>.self,
     indexType: Int.self,
     indexDistanceType: Int.self,
     indicesType: CountableRange<Int>.self)
 
   expect${'Mutable' if IsMutable else ''}CollectionType(${SelfType}.self)
 }
-%   else: # !IsRaw
-${SelfName}TestSuite.test("AssociatedTypes") {
-  typealias Subject = ${SelfName}<OpaqueValue<Int>>
-  expectRandomAccessCollectionAssociatedTypes(
-    collectionType: Subject.self,
-    iteratorType: IndexingIterator<Subject>.self,
-    subSequenceType: ${'Mutable' if IsMutable else ''}RandomAccessSlice<Subject>.self,
-    indexType: Int.self,
-    indexDistanceType: Int.self,
-    indicesType: CountableRange<Int>.self)
-
-  expect${'Mutable' if IsMutable else ''}CollectionType(Subject.self)
-}
-%   end # !IsRaw
 
 // Allocate two buffers. Initialize one and copy it into the other. Pass those
 // to the specified generic collection test function `checkBuffers`.
@@ -454,7 +443,7 @@ struct SubscriptSetTest : SubscriptTest {
   func replacementValuesSlice(
     from memory: UnsafeMutableRawPointer,
     replacementValues: [OpaqueValue<Int>]
-  ) -> UnsafeMutableRawBufferPointer
+  ) -> UnsafeMutableRawBufferPointer.SubSequence
   {
     for (i, value) in replacementValues.enumerated() {
       memory.initializeMemory(


### PR DESCRIPTION
See the swift-evolution PR to amend SE-0138:
apple/swift-evolution#651

There are several commits lumped into this PR. Summary:

1. Overhaul the Collection unit tests in CheckCollectionInstance.swift.gyb.
There are now three major entry points:
checkCollection, checkBidirectionalCollection, checkRandomCollection.
Call the correct entry point for your collection and you get rigorous
tests for all of the Collection semantics.

A handful of larger unit test cases call down into the non-recursive versions:
checkOneLevelOfCollection, checkOneLevelOfBidirectionalCollection, checkOneLevelOfRandomCollection.

2. Wire-up the Collection unit tests.

Unit test were calling into the Collection test entry point, but
nothing was being testing. Some of the unit tests were even broken.

3. Add common tests for Collection's slice semantics.

4. Add Unsafe[Mutable][Raw]BufferPointer.initialize(rebasing:).

5. SE-0138: Normalize UnsafeRawBufferPointer Slices


Fix: Change `Unsafe${Mutable}RawBufferPointer`'s SubSequence type

Original: `Unsafe${Mutable}RawBufferPointer.SubSequence = Unsafe${Mutable}RawBufferPointer`

Fixed: `Unsafe${Mutable}RawBufferPointer.SubSequence = ${Mutable}RandomAccessSlice<Unsafe${Mutable}RawBufferPointer>`

This is a source breaking bug fix that only applies to
post-3.0.1. It's extremely unlikely that any Swift 3 code would rely
on the Subsequence type beyond the simple use case of passing a
raw buffer subrange to an another raw buffer argument:

`takesRawBuffer(buffer[i..<j])`

A diagnostic message now instructs users to convert the slice to a
buffer using a rebasing initializer:

`takesRawBuffer(UnsafeRawBufferPointer(rebasing: buffer[i..<j]))`

To support this, the following rebasing initializers are added:

```
extension UnsafeRawBufferPointer {
  public init(rebasing slice: RandomAccessSlice<UnsafeRawBufferPointer>)
  public init(
    rebasing slice: MutableRandomAccessSlice<UnsafeMutableRawBufferPointer>
  )
}

extension UnsafeMutableRawBufferPointer {
  public init(
    rebasing slice: MutableRandomAccessSlice<UnsafeMutableRawBufferPointer>
  )
}
```
The source compatibility test builds are unnaffected by this change.