### PR TITLE
[Constraint system] Fix some issues with constraint propagation.

### DIFF
--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2361,18 +2361,19 @@ private:
   /// \param expr The expression to find reductions for.
   void shrink(Expr *expr);
 
-  bool simplifyForConstraintPropagation(Constraint *applicableFn,
-                 llvm::SmallVectorImpl<Constraint *> &workList);
+  void gatherNeighboringApplicableFunctionConstraints(
+      Constraint *applicableFn,
+      SmallVectorImpl<Constraint *> &otherApplicableFn);
+  bool simplifyForConstraintPropagation();
   bool isBindOverloadConsistent(Constraint *bindConstraint,
                                 Constraint *applicableFn,
-                         llvm::SmallVectorImpl<Constraint *> &otherApplicableFn,
-                                int depth);
+                                llvm::SetVector<Constraint *> &workList,
+                                bool topLevel);
   bool isApplicableFunctionConsistent(Constraint *applicableFn,
                                       llvm::SetVector<Constraint *> &workList,
-                                      int depth);
+                                      bool topLevel);
 
- public:
-
+public:
   /// \brief Solve the system of constraints generated from provided expression.
   ///
   /// \param expr The expression to generate constraints from.


### PR DESCRIPTION
There are a handful of things, but the primary ones are that we really
don't want to track depth of recursion so much as whether we are
processing at the "top level" of constraints we're looking at or not so
that we can determine whether we can disable elements from a
disjunction.

Related, there are places where we can bail out earlier if we know
that *any* neighboring constraint passes.

Also updating the way we gather neighboring constraints to be
independent of the function that simplifies them. The original code was
wrong in that in bailed as soon as one of the simplifications
failed (which meant we might not gather all of them).
