### PR TITLE
Remove obsolete assertion

### DIFF
--- a/lib/IRGen/DebugTypeInfo.cpp
+++ b/lib/IRGen/DebugTypeInfo.cpp
@@ -30,8 +30,6 @@ DebugTypeInfo::DebugTypeInfo(DeclContext *DC, GenericEnvironment *GE,
                              Alignment align)
     : DeclCtx(DC), GenericEnv(GE), Type(Ty.getPointer()),
       StorageType(StorageTy), size(size), align(align) {
-  assert((!isArchetype() || (isArchetype() && DC)) &&
-         "archetype without a declcontext");
   assert(StorageType && "StorageType is a nullptr");
   assert(align.getValue() != 0);
 }


### PR DESCRIPTION
b872127 made this check unncessary because we are now using the
GenericEnvironment to map Archetypes.

rdar://problem/31482203

