### PR TITLE
Don't emit debug info for generic types with no declcontext.

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -895,6 +895,11 @@ void IRGenDebugInfo::emitVariableDeclaration(
   if (Opts.DebugInfoKind <= IRGenDebugInfoKind::LineTables)
     return;
 
+  // Currently, the DeclContext is needed to mangle archetypes. Bail out if it's
+  // missing.
+  if (DbgTy.Type->hasArchetype() && !DbgTy.DeclCtx)
+    return;
+
   if (!DbgTy.size)
     DbgTy.size = getStorageSize(IGM.DataLayout, Storage);
 


### PR DESCRIPTION
Follow-up to 991a66fd99741df57583597c1565306e359269d5.

rdar://problem/31482203
