### PR TITLE
python: Fix nosetests tests.

### DIFF
--- a/utils/swift_build_support/swift_build_support/SwiftBuildSupport.py
+++ b/utils/swift_build_support/swift_build_support/SwiftBuildSupport.py
@@ -174,7 +174,8 @@ def get_preset_options(substitutions, preset_file_names, preset_name):
         sdks_to_configure = swift_sdks_opt.split("=")[1].split(";")
         tgts = []
         # Expand SDKs in to their deployment targets
-        from swift_build_support.targets import StdlibDeploymentTarget
+        from swift_build_support.swift_build_support.targets \
+            import StdlibDeploymentTarget
         for sdk in sdks_to_configure:
             if sdk == "OSX":
                 tgts += StdlibDeploymentTarget.OSX.targets

--- a/utils/swift_build_support/tests/products/test_llvm.py
+++ b/utils/swift_build_support/tests/products/test_llvm.py
@@ -22,10 +22,10 @@ except ImportError:
     # py3
     from io import StringIO
 
-from swift_build_support import shell
-from swift_build_support.products import LLVM
-from swift_build_support.toolchain import host_toolchain
-from swift_build_support.workspace import Workspace
+from swift_build_support.swift_build_support import shell
+from swift_build_support.swift_build_support.products import LLVM
+from swift_build_support.swift_build_support.toolchain import host_toolchain
+from swift_build_support.swift_build_support.workspace import Workspace
 
 
 class LLVMTestCase(unittest.TestCase):

--- a/utils/swift_build_support/tests/products/test_ninja.py
+++ b/utils/swift_build_support/tests/products/test_ninja.py
@@ -23,11 +23,11 @@ except ImportError:
     # py3
     from io import StringIO
 
-from swift_build_support import shell
-from swift_build_support import xcrun
-from swift_build_support.products import Ninja
-from swift_build_support.toolchain import host_toolchain
-from swift_build_support.workspace import Workspace
+from swift_build_support.swift_build_support import shell
+from swift_build_support.swift_build_support import xcrun
+from swift_build_support.swift_build_support.products import Ninja
+from swift_build_support.swift_build_support.toolchain import host_toolchain
+from swift_build_support.swift_build_support.workspace import Workspace
 
 
 class NinjaTestCase(unittest.TestCase):

--- a/utils/swift_build_support/tests/products/test_swift.py
+++ b/utils/swift_build_support/tests/products/test_swift.py
@@ -22,10 +22,10 @@ except ImportError:
     # py3
     from io import StringIO
 
-from swift_build_support import shell
-from swift_build_support.products import Swift
-from swift_build_support.toolchain import host_toolchain
-from swift_build_support.workspace import Workspace
+from swift_build_support.swift_build_support import shell
+from swift_build_support.swift_build_support.products import Swift
+from swift_build_support.swift_build_support.toolchain import host_toolchain
+from swift_build_support.swift_build_support.workspace import Workspace
 
 
 class SwiftTestCase(unittest.TestCase):

--- a/utils/swift_build_support/tests/test_arguments.py
+++ b/utils/swift_build_support/tests/test_arguments.py
@@ -21,7 +21,7 @@ except ImportError:
     # py3
     from io import StringIO
 
-from swift_build_support.arguments import (
+from swift_build_support.swift_build_support.arguments import (
     action as argaction,
     type as argtype,
 )

--- a/utils/swift_build_support/tests/test_cache_util.py
+++ b/utils/swift_build_support/tests/test_cache_util.py
@@ -12,7 +12,7 @@
 
 import unittest
 
-from swift_build_support import cache_util
+from swift_build_support.swift_build_support import cache_util
 
 
 my_func_called = 0

--- a/utils/swift_build_support/tests/test_cmake.py
+++ b/utils/swift_build_support/tests/test_cmake.py
@@ -12,9 +12,9 @@ import os
 import unittest
 from argparse import Namespace
 
-from swift_build_support.arguments import CompilerVersion
-from swift_build_support.cmake import CMake, CMakeOptions
-from swift_build_support.toolchain import host_toolchain
+from swift_build_support.swift_build_support.arguments import CompilerVersion
+from swift_build_support.swift_build_support.cmake import CMake, CMakeOptions
+from swift_build_support.swift_build_support.toolchain import host_toolchain
 
 
 class CMakeTestCase(unittest.TestCase):

--- a/utils/swift_build_support/tests/test_debug.py
+++ b/utils/swift_build_support/tests/test_debug.py
@@ -17,7 +17,7 @@ except ImportError:
     # py3
     from io import StringIO
 
-from swift_build_support import debug
+from swift_build_support.swift_build_support import debug
 
 
 class PrintXcodebuildVersionsTestCase(unittest.TestCase):

--- a/utils/swift_build_support/tests/test_host.py
+++ b/utils/swift_build_support/tests/test_host.py
@@ -11,7 +11,7 @@
 import platform
 import unittest
 
-import swift_build_support.host as sbs_host
+import swift_build_support.swift_build_support.host as sbs_host
 
 
 class HostTestCase(unittest.TestCase):

--- a/utils/swift_build_support/tests/test_migration.py
+++ b/utils/swift_build_support/tests/test_migration.py
@@ -12,7 +12,7 @@ import argparse
 import os
 import unittest
 
-from swift_build_support import migration
+from swift_build_support.swift_build_support import migration
 
 
 class MigrateImplArgsTestCase(unittest.TestCase):

--- a/utils/swift_build_support/tests/test_shell.py
+++ b/utils/swift_build_support/tests/test_shell.py
@@ -22,7 +22,7 @@ except ImportError:
     # py3
     from io import StringIO
 
-from swift_build_support import shell
+from swift_build_support.swift_build_support import shell
 
 
 class ShellTestCase(unittest.TestCase):

--- a/utils/swift_build_support/tests/test_tar.py
+++ b/utils/swift_build_support/tests/test_tar.py
@@ -18,7 +18,7 @@ try:
 except ImportError:
     from io import StringIO
 
-from swift_build_support.tar import tar
+from swift_build_support.swift_build_support.tar import tar
 
 
 class TarTestCase(unittest.TestCase):

--- a/utils/swift_build_support/tests/test_targets.py
+++ b/utils/swift_build_support/tests/test_targets.py
@@ -10,7 +10,8 @@
 
 import unittest
 
-from swift_build_support.targets import StdlibDeploymentTarget
+from swift_build_support.swift_build_support.targets \
+    import StdlibDeploymentTarget
 
 
 class HostTargetTestCase(unittest.TestCase):

--- a/utils/swift_build_support/tests/test_toolchain.py
+++ b/utils/swift_build_support/tests/test_toolchain.py
@@ -12,8 +12,8 @@
 import os
 import unittest
 
-from swift_build_support import toolchain
-from swift_build_support.toolchain import host_toolchain
+from swift_build_support.swift_build_support import toolchain
+from swift_build_support.swift_build_support.toolchain import host_toolchain
 
 
 def get_suffix(path, prefix):

--- a/utils/swift_build_support/tests/test_which.py
+++ b/utils/swift_build_support/tests/test_which.py
@@ -11,7 +11,7 @@
 import os
 import unittest
 
-from swift_build_support.which import which
+from swift_build_support.swift_build_support.which import which
 
 
 class WhichTestCase(unittest.TestCase):

--- a/utils/swift_build_support/tests/test_workspace.py
+++ b/utils/swift_build_support/tests/test_workspace.py
@@ -17,7 +17,7 @@ import shutil
 import tempfile
 import unittest
 
-from swift_build_support.workspace import (
+from swift_build_support.swift_build_support.workspace import (
     Workspace,
     compute_build_subdir,
 )

--- a/utils/swift_build_support/tests/test_xcrun.py
+++ b/utils/swift_build_support/tests/test_xcrun.py
@@ -11,7 +11,7 @@
 import platform
 import unittest
 
-from swift_build_support import xcrun
+from swift_build_support.swift_build_support import xcrun
 
 
 @unittest.skipUnless(platform.system() == 'Darwin',


### PR DESCRIPTION
Why are the python reasons for having our code nested in a directory
called ``swift_build_support/swift_build_support/`` instead of simply
``swift_build_support/``? Is that what we really want here?

https://github.com/apple/swift/pull/8389

All of the python tests and ``build-script`` broke after the above patch. Here are some fixes.

It also turns out we might not be running ``nosetests`` on PRs.