### PR TITLE
[swiftc (32 vs. 5512)] Add crasher in swift::Type::transformRec

### DIFF
--- a/validation-test/compiler_crashers/28734-conformingreplacementtype-is-substitutabletype-conformingreplacementtype-is-depe.swift
+++ b/validation-test/compiler_crashers/28734-conformingreplacementtype-is-substitutabletype-conformingreplacementtype-is-depe.swift
@@ -1,0 +1,14 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol P{typealias a
+struct A{{}func a:a
+{
+}
+struct A{extension{var f=a


### PR DESCRIPTION
Add test case for crash triggered in `swift::Type::transformRec`.

Current number of unresolved compiler crashers: 32 (5512 resolved)

/cc @jckarter - just wanted to let you know that this crasher caused an assertion failure for the assertion `(conformingReplacementType->is<SubstitutableType>() || conformingReplacementType->is<DependentMemberType>()) && "replacement requires looking up a concrete conformance"` added on 2016-12-15 by you in commit 57d9ad0a :-)

Assertion failure in [`lib/AST/Type.cpp (line 2875)`](https://github.com/apple/swift/blob/43106a610eb2b286780e5651a439398ffb59fbcc/lib/AST/Type.cpp#L2875):

```
Assertion `(conformingReplacementType->is<SubstitutableType>() || conformingReplacementType->is<DependentMemberType>()) && "replacement requires looking up a concrete conformance"' failed.

When executing: Optional<swift::ProtocolConformanceRef> swift::MakeAbstractConformanceForGenericType::operator()(swift::CanType, swift::Type, swift::ProtocolType *) const
```

Assertion context:

```c++
MakeAbstractConformanceForGenericType::operator()(CanType dependentType,
                                       Type conformingReplacementType,
                                       ProtocolType *conformedProtocol) const {
  assert((conformingReplacementType->is<SubstitutableType>()
          || conformingReplacementType->is<DependentMemberType>())
         && "replacement requires looking up a concrete conformance");
  return ProtocolConformanceRef(conformedProtocol->getDecl());
}

Optional<ProtocolConformanceRef>
LookUpConformanceInSignature::operator()(CanType dependentType,
```
Stack trace:

```
0 0x000000000395ec18 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x395ec18)
1 0x000000000395f356 SignalHandler(int) (/path/to/swift/bin/swift+0x395f356)
2 0x00007fecf3068390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007fecf158e428 gsignal /build/glibc-9tT8Do/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007fecf159002a abort /build/glibc-9tT8Do/glibc-2.23/stdlib/abort.c:91:0
5 0x00007fecf1586bd7 __assert_fail_base /build/glibc-9tT8Do/glibc-2.23/assert/assert.c:92:0
6 0x00007fecf1586c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x0000000001503af9 (/path/to/swift/bin/swift+0x1503af9)
8 0x00000000005a4d89 llvm::Optional<swift::ProtocolConformanceRef> llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>::callback_fn<swift::MakeAbstractConformanceForGenericType>(long, swift::CanType, swift::Type, swift::ProtocolType*) (/path/to/swift/bin/swift+0x5a4d89)
9 0x0000000001503f12 getMemberForBaseType(llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::Type, swift::Type, swift::AssociatedTypeDecl*, swift::Identifier, swift::OptionSet<swift::SubstFlags, unsigned int>) (/path/to/swift/bin/swift+0x1503f12)
10 0x0000000001508378 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::OptionSet<swift::SubstFlags, unsigned int>)::$_17>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x1508378)
11 0x0000000001504f09 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x1504f09)
12 0x00000000015054ad swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15054ad)
13 0x00000000015054ad swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15054ad)
14 0x000000000150421e swift::Type::substDependentTypesWithErrorTypes() const (/path/to/swift/bin/swift+0x150421e)
15 0x00000000014a4560 swift::GenericEnvironment::mapTypeOutOfContext(swift::GenericEnvironment*, swift::Type) (/path/to/swift/bin/swift+0x14a4560)
16 0x00000000012ef5f2 swift::TypeChecker::coercePatternToType(swift::Pattern*&, swift::DeclContext*, swift::Type, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, swift::TypeLoc) (/path/to/swift/bin/swift+0x12ef5f2)
17 0x00000000012ac374 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*, bool)::BindingListener::appliedSolution(swift::constraints::Solution&, swift::Expr*) (/path/to/swift/bin/swift+0x12ac374)
18 0x00000000012a2819 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x12a2819)
19 0x00000000012a63d1 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*, bool) (/path/to/swift/bin/swift+0x12a63d1)
20 0x00000000012a6596 swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int, bool) (/path/to/swift/bin/swift+0x12a6596)
21 0x00000000012bcb58 validatePatternBindingEntries(swift::TypeChecker&, swift::PatternBindingDecl*) (/path/to/swift/bin/swift+0x12bcb58)
22 0x00000000012b6fd4 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x12b6fd4)
23 0x00000000012c6b7b (anonymous namespace)::DeclChecker::visitExtensionDecl(swift::ExtensionDecl*) (/path/to/swift/bin/swift+0x12c6b7b)
24 0x00000000012b6f5b (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x12b6f5b)
25 0x00000000012c716b (anonymous namespace)::DeclChecker::visitStructDecl(swift::StructDecl*) (/path/to/swift/bin/swift+0x12c716b)
26 0x00000000012b7087 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x12b7087)
27 0x00000000012c716b (anonymous namespace)::DeclChecker::visitStructDecl(swift::StructDecl*) (/path/to/swift/bin/swift+0x12c716b)
28 0x00000000012b7087 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x12b7087)
29 0x00000000012c819b (anonymous namespace)::DeclChecker::visitProtocolDecl(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0x12c819b)
30 0x00000000012b7097 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x12b7097)
31 0x00000000012b6e93 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x12b6e93)
32 0x0000000001335945 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x1335945)
33 0x0000000000fa1dc6 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xfa1dc6)
34 0x00000000004a8892 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a8892)
35 0x00000000004651d7 main (/path/to/swift/bin/swift+0x4651d7)
36 0x00007fecf1579830 __libc_start_main /build/glibc-9tT8Do/glibc-2.23/csu/../csu/libc-start.c:325:0
37 0x0000000000462879 _start (/path/to/swift/bin/swift+0x462879)
```