### PR TITLE
Reenable some raw buffer tests in release build.

### DIFF
--- a/test/stdlib/UnsafeRawBufferPointer.swift
+++ b/test/stdlib/UnsafeRawBufferPointer.swift
@@ -231,16 +231,11 @@ UnsafeRawBufferPointerTestSuite.test("inBounds") {
   expectEqualSequence(firstHalf, secondHalf)
 }
 
-// FIXME: rdar:31495442. Enable this in release builds too.
-UnsafeRawBufferPointerTestSuite.test("subscript.get.underflow")
-.skip(.custom(
-    { !_isDebugAssertConfiguration() },
-    reason: "This tests a debug precondition."))
-.code {
+UnsafeRawBufferPointerTestSuite.test("subscript.get.underflow") {
   let buffer = UnsafeMutableRawBufferPointer.allocate(count: 2)
   defer { buffer.deallocate() }
 
-  let bytes = buffer[1..<2]
+  let bytes = UnsafeRawBufferPointer(rebasing: buffer[1..<2])
 
   if _isDebugAssertConfiguration() {
     expectCrashLater()
@@ -249,16 +244,11 @@ UnsafeRawBufferPointerTestSuite.test("subscript.get.underflow")
   _ = bytes[-1]
 }
 
-// FIXME: rdar:31495442. Enable this in release builds too.
-UnsafeRawBufferPointerTestSuite.test("subscript.get.overflow")
-.skip(.custom(
-    { !_isDebugAssertConfiguration() },
-    reason: "This tests a debug precondition."))
-.code {
+UnsafeRawBufferPointerTestSuite.test("subscript.get.overflow") {
   let buffer = UnsafeMutableRawBufferPointer.allocate(count: 2)
   defer { buffer.deallocate() }
 
-  let bytes = buffer[0..<1]
+  let bytes = UnsafeRawBufferPointer(rebasing: buffer[0..<1])
 
   if _isDebugAssertConfiguration() {
     expectCrashLater()
@@ -267,16 +257,11 @@ UnsafeRawBufferPointerTestSuite.test("subscript.get.overflow")
   _ = bytes[1]
 }
 
-// FIXME: rdar:31495442. Enable this in release builds too.
-UnsafeRawBufferPointerTestSuite.test("subscript.set.underflow")
-.skip(.custom(
-    { !_isDebugAssertConfiguration() },
-    reason: "This tests a debug precondition."))
-.code {
+UnsafeRawBufferPointerTestSuite.test("subscript.set.underflow") {
   let buffer = UnsafeMutableRawBufferPointer.allocate(count: 2)
   defer { buffer.deallocate() }
 
-  var bytes = buffer[1..<2]
+  var bytes = UnsafeMutableRawBufferPointer(rebasing: buffer[1..<2])
 
   if _isDebugAssertConfiguration() {
     expectCrashLater()
@@ -285,16 +270,11 @@ UnsafeRawBufferPointerTestSuite.test("subscript.set.underflow")
   bytes[-1] = 0
 }
 
-// FIXME: rdar:31495442. Enable this in release builds too.
-UnsafeRawBufferPointerTestSuite.test("subscript.set.overflow")
-.skip(.custom(
-    { !_isDebugAssertConfiguration() },
-    reason: "This tests a debug precondition."))
-.code {
+UnsafeRawBufferPointerTestSuite.test("subscript.set.overflow") {
   let buffer = UnsafeMutableRawBufferPointer.allocate(count: 2)
   defer { buffer.deallocate() }
 
-  var bytes = buffer[0..<1]
+  var bytes = UnsafeMutableRawBufferPointer(rebasing: buffer[0..<1])
 
   if _isDebugAssertConfiguration() {
     expectCrashLater()
@@ -303,16 +283,11 @@ UnsafeRawBufferPointerTestSuite.test("subscript.set.overflow")
   bytes[1] = 0
 }
 
-// FIXME: rdar:31495442. Enable this in release builds too.
-UnsafeRawBufferPointerTestSuite.test("subscript.range.get.underflow")
-.skip(.custom(
-    { !_isDebugAssertConfiguration() },
-    reason: "This tests a debug precondition."))
-.code {
+UnsafeRawBufferPointerTestSuite.test("subscript.range.get.underflow") {
   let buffer = UnsafeMutableRawBufferPointer.allocate(count: 3)
   defer { buffer.deallocate() }
 
-  let bytes = buffer[1..<3]
+  let bytes = UnsafeRawBufferPointer(rebasing: buffer[1..<3])
 
   if _isDebugAssertConfiguration() {
     expectCrashLater()
@@ -321,16 +296,11 @@ UnsafeRawBufferPointerTestSuite.test("subscript.range.get.underflow")
   _ = bytes[-1..<1]
 }
 
-// FIXME: rdar:31495442. Enable this in release builds too.
-UnsafeRawBufferPointerTestSuite.test("subscript.range.get.overflow")
-.skip(.custom(
-    { !_isDebugAssertConfiguration() },
-    reason: "This tests a debug precondition."))
-.code {
+UnsafeRawBufferPointerTestSuite.test("subscript.range.get.overflow") {
   let buffer = UnsafeMutableRawBufferPointer.allocate(count: 3)
   defer { buffer.deallocate() }
 
-  let bytes = buffer[0..<2]
+  let bytes = UnsafeRawBufferPointer(rebasing: buffer[0..<2])
 
   if _isDebugAssertConfiguration() {
     expectCrashLater()
@@ -339,16 +309,11 @@ UnsafeRawBufferPointerTestSuite.test("subscript.range.get.overflow")
   _ = bytes[1..<3]
 }
 
-// FIXME: rdar:31495442. Enable this in release builds too.
-UnsafeRawBufferPointerTestSuite.test("subscript.range.set.underflow")
-.skip(.custom(
-    { !_isDebugAssertConfiguration() },
-    reason: "This tests a debug precondition."))
-.code {
+UnsafeRawBufferPointerTestSuite.test("subscript.range.set.underflow") {
   var buffer = UnsafeMutableRawBufferPointer.allocate(count: 3)
   defer { buffer.deallocate() }
 
-  var bytes = buffer[1..<3]
+  var bytes = UnsafeMutableRawBufferPointer(rebasing: buffer[1..<3])
 
   if _isDebugAssertConfiguration() {
     expectCrashLater()
@@ -357,16 +322,12 @@ UnsafeRawBufferPointerTestSuite.test("subscript.range.set.underflow")
   bytes[-1..<1] = bytes[0..<2]
 }
 
-// FIXME: rdar:31495442. Enable this in release builds too.
-UnsafeRawBufferPointerTestSuite.test("subscript.range.set.overflow")
-.skip(.custom(
-    { !_isDebugAssertConfiguration() },
-    reason: "This tests a debug precondition."))
-.code {
+UnsafeRawBufferPointerTestSuite.test("subscript.range.set.overflow") {
   var buffer = UnsafeMutableRawBufferPointer.allocate(count: 3)
   defer { buffer.deallocate() }
 
-  var bytes = buffer[0..<2]
+  var bytes = UnsafeMutableRawBufferPointer(rebasing: buffer[0..<2])
+
   if _isDebugAssertConfiguration() {
     expectCrashLater()
   }


### PR DESCRIPTION
These subtests were actually meant to test the raw buffer
type itself, not its slice type. So adding an `init(rebasing:)`
does what we want.

Now that the Collection tests are wired up, these test cases will be run on the
slice type automatically. No need to do it here.