### PR TITLE
[swiftc (33 vs. 5512)] Add crasher in swift::constraints::ConstraintSystem::resolveOverload

### DIFF
--- a/validation-test/compiler_crashers/28735-reftype-hastypeparameter-cannot-have-a-dependent-type-here.swift
+++ b/validation-test/compiler_crashers/28735-reftype-hastypeparameter-cannot-have-a-dependent-type-here.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol A{protocol A:A{class a{let c=a}typealias a


### PR DESCRIPTION
Add test case for crash triggered in `swift::constraints::ConstraintSystem::resolveOverload`.

Current number of unresolved compiler crashers: 33 (5512 resolved)

/cc @DougGregor - just wanted to let you know that this crasher caused an assertion failure for the assertion `!refType->hasTypeParameter() && "Cannot have a dependent type here"` added on 2015-07-07 by you in commit 3023a710 :-)

Assertion failure in [`lib/Sema/ConstraintSystem.cpp (line 1501)`](https://github.com/apple/swift/blob/be430ae88caedf2f8f78126fef428026b7b9de7d/lib/Sema/ConstraintSystem.cpp#L1501):

```
Assertion `!refType->hasTypeParameter() && "Cannot have a dependent type here"' failed.

When executing: void swift::constraints::ConstraintSystem::resolveOverload(swift::constraints::ConstraintLocator *, swift::Type, swift::constraints::OverloadChoice, swift::DeclContext *)
```

Assertion context:

```c++
      auto tuple = choice.getBaseType()->castTo<TupleType>();
      refType = tuple->getElementType(choice.getTupleIndex())->getRValueType();
    }
    break;
  }
  assert(!refType->hasTypeParameter() && "Cannot have a dependent type here");

  // If we're binding to an init member, the 'throws' need to line up between
  // the bound and reference types.
  if (choice.isDecl()) {
    auto decl = choice.getDecl();
```
Stack trace:

```
0 0x000000000395ec18 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x395ec18)
1 0x000000000395f356 SignalHandler(int) (/path/to/swift/bin/swift+0x395f356)
2 0x00007fe5f6c91390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007fe5f51b7428 gsignal /build/glibc-9tT8Do/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007fe5f51b902a abort /build/glibc-9tT8Do/glibc-2.23/stdlib/abort.c:91:0
5 0x00007fe5f51afbd7 __assert_fail_base /build/glibc-9tT8Do/glibc-2.23/assert/assert.c:92:0
6 0x00007fe5f51afc82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x000000000128cd28 swift::constraints::ConstraintSystem::resolveOverload(swift::constraints::ConstraintLocator*, swift::Type, swift::constraints::OverloadChoice, swift::DeclContext*) (/path/to/swift/bin/swift+0x128cd28)
8 0x000000000125f24d swift::constraints::ConstraintSystem::simplifyConstraint(swift::constraints::Constraint const&) (/path/to/swift/bin/swift+0x125f24d)
9 0x000000000126cccd swift::constraints::ConstraintSystem::solveSimplified(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0x126cccd)
10 0x0000000001264895 swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0x1264895)
11 0x0000000001264252 swift::constraints::ConstraintSystem::solve(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0x1264252)
12 0x0000000001267588 swift::constraints::ConstraintSystem::solve(swift::Expr*&, swift::Type, swift::ExprTypeCheckListener*, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0x1267588)
13 0x000000000129f074 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0x129f074)
14 0x00000000012a26e6 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x12a26e6)
15 0x00000000012a63d1 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*, bool) (/path/to/swift/bin/swift+0x12a63d1)
16 0x00000000012a6596 swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int, bool) (/path/to/swift/bin/swift+0x12a6596)
17 0x00000000012bcb58 validatePatternBindingEntries(swift::TypeChecker&, swift::PatternBindingDecl*) (/path/to/swift/bin/swift+0x12bcb58)
18 0x00000000012b6fd4 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x12b6fd4)
19 0x00000000012c72db (anonymous namespace)::DeclChecker::visitClassDecl(swift::ClassDecl*) (/path/to/swift/bin/swift+0x12c72db)
20 0x00000000012b6f8b (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x12b6f8b)
21 0x00000000012c819b (anonymous namespace)::DeclChecker::visitProtocolDecl(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0x12c819b)
22 0x00000000012b7097 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x12b7097)
23 0x00000000012c819b (anonymous namespace)::DeclChecker::visitProtocolDecl(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0x12c819b)
24 0x00000000012b7097 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x12b7097)
25 0x00000000012b6e93 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x12b6e93)
26 0x0000000001335945 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x1335945)
27 0x0000000000fa1dc6 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xfa1dc6)
28 0x00000000004a8892 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a8892)
29 0x00000000004651d7 main (/path/to/swift/bin/swift+0x4651d7)
30 0x00007fe5f51a2830 __libc_start_main /build/glibc-9tT8Do/glibc-2.23/csu/../csu/libc-start.c:325:0
31 0x0000000000462879 _start (/path/to/swift/bin/swift+0x462879)
```