### PR TITLE
DeadStoreElimination: fix wrong elimination of dead store before is_unique instruction

### DIFF
--- a/lib/SILOptimizer/Transforms/DeadStoreElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadStoreElimination.cpp
@@ -139,8 +139,6 @@ static bool isDeadStoreInertInstruction(SILInstruction *Inst) {
   case ValueKind::RetainValueInst:
   case ValueKind::DeallocStackInst:
   case ValueKind::CondFailInst:
-  case ValueKind::IsUniqueInst:
-  case ValueKind::IsUniqueOrPinnedInst:
   case ValueKind::FixLifetimeInst:
     return true;
   default:

--- a/test/SILOptimizer/dead_store_elim.sil
+++ b/test/SILOptimizer/dead_store_elim.sil
@@ -1389,3 +1389,31 @@ bb2:
   %14 = tuple ()
   return %14 : $()
 }
+
+// CHECK-LABEL: test_is_unique
+// CHECK: %1 = alloc_stack
+// CHECK: store %0 to %1 
+// CHECK: is_unique
+// CHECK: return
+sil @test_is_unique : $@convention(thin) (@guaranteed AB) -> Builtin.Int1 {
+bb0(%0 : $AB):                     // Preds: bb6 bb5 bb4 bb3
+  %1 = alloc_stack $AB
+  store %0 to %1 : $*AB
+  %2 = is_unique %1 : $*AB
+  dealloc_stack %1 : $*AB
+  return %2 : $Builtin.Int1
+}
+
+// CHECK-LABEL: test_is_unique_or_pinned
+// CHECK: %1 = alloc_stack
+// CHECK: store %0 to %1 
+// CHECK: is_unique_or_pinned
+// CHECK: return
+sil @test_is_unique_or_pinned : $@convention(thin) (@guaranteed AB) -> Builtin.Int1 {
+bb0(%0 : $AB):                     // Preds: bb6 bb5 bb4 bb3
+  %1 = alloc_stack $AB
+  store %0 to %1 : $*AB
+  %2 = is_unique_or_pinned %1 : $*AB
+  dealloc_stack %1 : $*AB
+  return %2 : $Builtin.Int1
+}


### PR DESCRIPTION
fixes SR-4524
