### PR TITLE
[3.1] Sema: Fix for SourceKit crash in inheritsSuperclassInitializers()

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2431,6 +2431,10 @@ DestructorDecl *ClassDecl::getDestructor() {
 }
 
 bool ClassDecl::inheritsSuperclassInitializers(LazyResolver *resolver) {
+  // Get a resolver from the ASTContext if we don't have one already.
+  if (resolver == nullptr)
+    resolver = getASTContext().getLazyResolver();
+
   // Check whether we already have a cached answer.
   switch (static_cast<StoredInheritsSuperclassInits>(
             ClassDeclBits.InheritsSuperclassInits)) {
@@ -2471,8 +2475,10 @@ bool ClassDecl::inheritsSuperclassInitializers(LazyResolver *resolver) {
       return false;
 
     // Resolve this initializer, if needed.
-    if (!ctor->hasInterfaceType())
+    if (!ctor->hasInterfaceType()) {
+      assert(resolver && "Should have a resolver here");
       resolver->resolveDeclSignature(ctor);
+    }
 
     // Ignore any stub implementations.
     if (ctor->hasStubImplementation())

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -598,6 +598,13 @@ void swift::performTypeChecking(SourceFile &SF, TopLevelContext &TLC,
   if (SF.ASTStage == SourceFile::TypeChecked)
     return;
 
+  auto &Ctx = SF.getASTContext();
+
+  // Make sure we have a type checker.
+  Optional<TypeChecker> MyTC;
+  if (!Ctx.getLazyResolver())
+    MyTC.emplace(Ctx);
+
   // Make sure that name binding has been completed before doing any type
   // checking.
   {
@@ -605,32 +612,35 @@ void swift::performTypeChecking(SourceFile &SF, TopLevelContext &TLC,
     performNameBinding(SF, StartElem);
   }
 
-  auto &Ctx = SF.getASTContext();
   {
     // NOTE: The type checker is scoped to be torn down before AST
     // verification.
-    TypeChecker TC(Ctx);
     SharedTimer timer("Type checking / Semantic analysis");
 
-    TC.setWarnLongFunctionBodies(WarnLongFunctionBodies);
-    if (Options.contains(TypeCheckingFlags::DebugTimeFunctionBodies))
-      TC.enableDebugTimeFunctionBodies();
+    if (MyTC) {
+      MyTC->setWarnLongFunctionBodies(WarnLongFunctionBodies);
+      if (Options.contains(TypeCheckingFlags::DebugTimeFunctionBodies))
+        MyTC->enableDebugTimeFunctionBodies();
 
-    if (Options.contains(TypeCheckingFlags::DebugTimeExpressions))
-      TC.enableDebugTimeExpressions();
+      if (Options.contains(TypeCheckingFlags::DebugTimeExpressions))
+        MyTC->enableDebugTimeExpressions();
 
-    if (Options.contains(TypeCheckingFlags::ForImmediateMode))
-      TC.setInImmediateMode(true);
-    
-    // Lookup the swift module.  This ensures that we record all known
-    // protocols in the AST.
-    (void) TC.getStdlibModule(&SF);
+      if (Options.contains(TypeCheckingFlags::ForImmediateMode))
+        MyTC->setInImmediateMode(true);
+      
+      // Lookup the swift module.  This ensures that we record all known
+      // protocols in the AST.
+      (void) MyTC->getStdlibModule(&SF);
 
-    if (!Ctx.LangOpts.DisableAvailabilityChecking) {
-      // Build the type refinement hierarchy for the primary
-      // file before type checking.
-      TC.buildTypeRefinementContextHierarchy(SF, StartElem);
+      if (!Ctx.LangOpts.DisableAvailabilityChecking) {
+        // Build the type refinement hierarchy for the primary
+        // file before type checking.
+        MyTC->buildTypeRefinementContextHierarchy(SF, StartElem);
+      }
     }
+
+    TypeChecker &TC =
+      MyTC ? *MyTC : *static_cast<TypeChecker *>(Ctx.getLazyResolver());
 
     // Resolve extensions. This has to occur first during type checking,
     // because the extensions need to be wired into the AST for name lookup
@@ -687,11 +697,12 @@ void swift::performTypeChecking(SourceFile &SF, TopLevelContext &TLC,
 
     // If we're in REPL mode, inject temporary result variables and other stuff
     // that the REPL needs to synthesize.
-    if (SF.Kind == SourceFileKind::REPL && !TC.Context.hadError())
+    if (SF.Kind == SourceFileKind::REPL && !Ctx.hadError())
       TC.processREPLTopLevel(SF, TLC, StartElem);
 
     typeCheckFunctionsAndExternalDecls(TC);
   }
+  MyTC.reset();
 
   // Checking that benefits from having the whole module available.
   if (!(Options & TypeCheckingFlags::DelayWholeModuleChecking)) {

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -702,7 +702,6 @@ void swift::performTypeChecking(SourceFile &SF, TopLevelContext &TLC,
 
     typeCheckFunctionsAndExternalDecls(TC);
   }
-  MyTC.reset();
 
   // Checking that benefits from having the whole module available.
   if (!(Options & TypeCheckingFlags::DelayWholeModuleChecking)) {

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -709,6 +709,8 @@ void swift::performTypeChecking(SourceFile &SF, TopLevelContext &TLC,
     performWholeModuleTypeChecking(SF);
   }
 
+  MyTC.reset();
+
   // Verify that we've checked types correctly.
   SF.ASTStage = SourceFile::TypeChecked;
 

--- a/test/SourceKit/Indexing/Inputs/index_constructors_other.swift
+++ b/test/SourceKit/Indexing/Inputs/index_constructors_other.swift
@@ -1,0 +1,7 @@
+class DogObject : CatObject {
+  override init() {
+    super.init()
+  }
+}
+
+class CatObject : NSObject {}

--- a/test/SourceKit/Indexing/index_constructors.swift
+++ b/test/SourceKit/Indexing/index_constructors.swift
@@ -1,0 +1,10 @@
+// RUN: %sourcekitd-test -req=index %s -- %s %S/Inputs/index_constructors_other.swift | %sed_clean > %t.response
+// RUN: diff -u %s.response %t.response
+
+import Foundation
+
+class HorseObject : DogObject {
+  var name: NSString
+
+  @objc public func flip() {}
+}

--- a/test/SourceKit/Indexing/index_constructors.swift.response
+++ b/test/SourceKit/Indexing/index_constructors.swift.response
@@ -1,0 +1,58 @@
+{
+  key.hash: <hash>,
+  key.dependencies: [
+    {
+      key.kind: source.lang.swift.import.module.swift,
+      key.name: "Swift",
+      key.filepath: Swift.swiftmodule,
+      key.hash: <hash>,
+      key.is_system: 1
+    }
+  ],
+  key.entities: [
+    {
+      key.kind: source.lang.swift.decl.class,
+      key.name: "HorseObject",
+      key.usr: "s:18index_constructors11HorseObjectC",
+      key.line: 6,
+      key.column: 7,
+      key.related: [
+        {
+          key.kind: source.lang.swift.ref.class,
+          key.name: "DogObject",
+          key.usr: "s:18index_constructors9DogObjectC",
+          key.line: 6,
+          key.column: 21
+        }
+      ],
+      key.entities: [
+        {
+          key.kind: source.lang.swift.ref.class,
+          key.name: "DogObject",
+          key.usr: "s:18index_constructors9DogObjectC",
+          key.line: 6,
+          key.column: 21
+        },
+        {
+          key.kind: source.lang.swift.decl.var.instance,
+          key.name: "name",
+          key.usr: "s:18index_constructors11HorseObjectC4nameXev",
+          key.line: 7,
+          key.column: 7
+        },
+        {
+          key.kind: source.lang.swift.decl.function.method.instance,
+          key.name: "flip()",
+          key.usr: "s:18index_constructors11HorseObjectC4flipyyF",
+          key.line: 9,
+          key.column: 21,
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.objc
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/SourceKit/Indexing/index_constructors.swift.response
+++ b/test/SourceKit/Indexing/index_constructors.swift.response
@@ -13,14 +13,14 @@
     {
       key.kind: source.lang.swift.decl.class,
       key.name: "HorseObject",
-      key.usr: "s:18index_constructors11HorseObjectC",
+      key.usr: "s:C18index_constructors11HorseObject",
       key.line: 6,
       key.column: 7,
       key.related: [
         {
           key.kind: source.lang.swift.ref.class,
           key.name: "DogObject",
-          key.usr: "s:18index_constructors9DogObjectC",
+          key.usr: "s:C18index_constructors9DogObject",
           key.line: 6,
           key.column: 21
         }
@@ -29,21 +29,21 @@
         {
           key.kind: source.lang.swift.ref.class,
           key.name: "DogObject",
-          key.usr: "s:18index_constructors9DogObjectC",
+          key.usr: "s:C18index_constructors9DogObject",
           key.line: 6,
           key.column: 21
         },
         {
           key.kind: source.lang.swift.decl.var.instance,
           key.name: "name",
-          key.usr: "s:18index_constructors11HorseObjectC4nameXev",
+          key.usr: "s:vC18index_constructors11HorseObject4nameERR",
           key.line: 7,
           key.column: 7
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
           key.name: "flip()",
-          key.usr: "s:18index_constructors11HorseObjectC4flipyyF",
+          key.usr: "s:FC18index_constructors11HorseObject4flipFT_T_",
           key.line: 9,
           key.column: 21,
           key.attributes: [


### PR DESCRIPTION
Two problems:

1) We were tearing down the type checker too early, before all
   relevant decls in other files had been type checked, so there
   was no LazyResolver available for use in the ASTContext.

   This might explain the crashes coming through
   diagnoseUnintendedObjCMethodOverrides().

2) When a lazy resolver was set in the ASTContext, we were not
   using it in the case where nullptr was passed in as the
   'resolver' parameter to inheritsSuperclassInitializers().

   This might fix the crashes where we were coming in from other
   code paths, but I'm less confident about this case.

Possibly fixes <rdar://problem/29043074>, <rdar://problem/30976765>,
<rdar://problem/31122590>, and <rdar://problem/31286627>, and the
many other similar-looking dupes.

(cherry picked from commit 9a3f0fc527a1e008ccddba16d94352c53d572c8a)

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
