### PR TITLE
[DO NOT MERGE] Import Foundation's NSComparisonResult as Swift.ComparisonResult

### DIFF
--- a/include/swift/AST/KnownStdlibTypes.def
+++ b/include/swift/AST/KnownStdlibTypes.def
@@ -53,6 +53,7 @@ KNOWN_STDLIB_TYPE_DECL(Optional, EnumDecl, 1)
 KNOWN_STDLIB_TYPE_DECL(ImplicitlyUnwrappedOptional, EnumDecl, 1)
 
 KNOWN_STDLIB_TYPE_DECL(OptionSet, NominalTypeDecl, 1)
+KNOWN_STDLIB_TYPE_DECL(ComparisonResult, NominalTypeDecl, 0)
 
 KNOWN_STDLIB_TYPE_DECL(UnsafeMutableRawPointer, NominalTypeDecl, 0)
 KNOWN_STDLIB_TYPE_DECL(UnsafeRawPointer, NominalTypeDecl, 0)

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2364,6 +2364,14 @@ namespace {
         if (declaredNative && nativeDecl)
           return nativeDecl;
 
+        // Special case for NSComparisonResult, which is imported as Swift's
+        // ComparisonResult.
+        if (decl->getName() == "NSComparisonResult") {
+          if (clang::Module *M = decl->getImportedOwningModule())
+            if (M->getTopLevelModuleName() == C.Id_Foundation.str())
+              return C.getComparisonResultDecl();
+        }
+
         // Compute the underlying type.
         auto underlyingType = Impl.importType(
             decl->getIntegerType(), ImportTypeKind::Enum, isInSystemModule(dc),

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -1276,6 +1276,7 @@ private:
       MAP(Int, "NSInteger", false);
       MAP(UInt, "NSUInteger", false);
       MAP(Bool, "BOOL", false);
+      MAP(ComparisonResult, "NSComparisonResult", false);
 
       MAP(OpaquePointer, "void *", true);
       MAP(UnsafeRawPointer, "void const *", true);
@@ -1548,6 +1549,10 @@ private:
 
   void visitEnumType(EnumType *ET, Optional<OptionalTypeKind> optionalKind) {
     const EnumDecl *ED = ET->getDecl();
+
+    // Handle known type names.
+    if (printIfKnownSimpleType(ED, optionalKind))
+      return;
 
     // Handle bridged types.
     if (printIfObjCBridgeable(ED, { }, optionalKind))

--- a/stdlib/public/core/Comparable.swift
+++ b/stdlib/public/core/Comparable.swift
@@ -214,3 +214,8 @@ public func >= <T : Comparable>(lhs: T, rhs: T) -> Bool {
   return !(lhs < rhs)
 }
 
+@objc public enum ComparisonResult : Int {
+  case orderedAscending = -1
+  case orderedSame = 0
+  case orderedDescending = 1
+}

--- a/test/ClangImporter/objc_parse.swift
+++ b/test/ClangImporter/objc_parse.swift
@@ -629,3 +629,12 @@ class NewtypeUser {
   @objc func intNewtype(a: MyInt) {}
   @objc func intNewtypeOptional(a: MyInt?) {} // expected-error {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
 }
+
+func testComparisonResult(str: NSString) {
+  let ordering = str.compare(str as String)
+  switch ordering {
+  case .orderedAscending: break
+  case ComparisonResult.orderedSame: break
+  case Swift.ComparisonResult.orderedDescending: break
+  }
+}

--- a/test/Inputs/clang-importer-sdk/usr/include/Foundation.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/Foundation.h
@@ -297,6 +297,8 @@ typedef NSPoint *NSPointArray;
 #define NS_ENUM(_type, _name) CF_ENUM(_type, _name)
 #define NS_OPTIONS(_type, _name) CF_OPTIONS(_type, _name)
 
+typedef NS_ENUM(NSInteger, NSComparisonResult) {NSOrderedAscending = -1L, NSOrderedSame, NSOrderedDescending};
+
 /// Aaa.  NSRuncingMode.  Bbb.
 typedef NS_ENUM(NSUInteger, NSRuncingMode) {
   NSRuncingMince,
@@ -759,9 +761,7 @@ NSSet *setToSet(NSSet *dict);
 
 @interface NSString(FoundationExts)
 - (void)notBridgedMethod;
-@end
-
-@interface NSString(FoundationExts)
+- (NSComparisonResult)compare:(NSString *)other;
 @property (nonatomic, copy) NSString *uppercaseString;
 @end
 

--- a/test/Interpreter/SDK/Foundation_test.swift
+++ b/test/Interpreter/SDK/Foundation_test.swift
@@ -117,6 +117,29 @@ FoundationTestSuite.test("arrayConversions") {
   nsArrayToAnyObjectArray(aoa as NSArray)
 }
 
+FoundationTestSuite.test("ComparisonResult") {
+  class IntBox: NSObject {
+    var value: Int
+    init(_ value: Int) {
+      self.value = value
+    }
+    
+    @objc func compare(_ other: IntBox) -> Swift.ComparisonResult {
+      // This is a reverse sort.
+      if value == other.value { return .orderedSame }
+      if value <  other.value { return .orderedDescending }
+      return .orderedAscending
+    }
+  }
+
+  let array = [IntBox(2), IntBox(3), IntBox(1)] as NSArray
+  let sorted = array.sortedArray(using: #selector(IntBox.compare))
+  let result = sorted as! [IntBox]
+  expectEqual(3, result[0].value)
+  expectEqual(2, result[1].value)
+  expectEqual(1, result[2].value)
+}
+
 //===----------------------------------------------------------------------===//
 // Dictionaries
 //===----------------------------------------------------------------------===//

--- a/test/PrintAsObjC/enums.swift
+++ b/test/PrintAsObjC/enums.swift
@@ -23,6 +23,7 @@ import Foundation
 // CHECK-NEXT: - (enum ObjcEnumNamed)takeAndReturnRenamedEnum:(enum ObjcEnumNamed)foo SWIFT_WARN_UNUSED_RESULT;
 // CHECK-NEXT: - (void)acceptTopLevelImportedWithA:(enum TopLevelRaw)a b:(TopLevelEnum)b c:(TopLevelOptions)c d:(TopLevelTypedef)d e:(TopLevelAnon)e;
 // CHECK-NEXT: - (void)acceptMemberImportedWithA:(enum MemberRaw)a b:(enum MemberEnum)b c:(MemberOptions)c d:(enum MemberTypedef)d e:(MemberAnon)e ee:(MemberAnon2)ee;
+// CHECK-NEXT: - (void)comparisonResultIsSpecial:(NSComparisonResult)_;
 // CHECK: @end
 @objc class AnEnumMethod {
   @objc func takeAndReturnEnum(_ foo: FooComments) -> NegativeValues {
@@ -35,6 +36,8 @@ import Foundation
 
   @objc func acceptTopLevelImported(a: TopLevelRaw, b: TopLevelEnum, c: TopLevelOptions, d: TopLevelTypedef, e: TopLevelAnon) {}
   @objc func acceptMemberImported(a: Wrapper.Raw, b: Wrapper.Enum, c: Wrapper.Options, d: Wrapper.Typedef, e: Wrapper.Anon, ee: Wrapper.Anon2) {}
+
+  @objc func comparisonResultIsSpecial(_: ComparisonResult) {}
 }
 
 // CHECK-LABEL: typedef SWIFT_ENUM_NAMED(NSInteger, ObjcEnumNamed, "EnumNamed") {

--- a/test/SIL/Serialization/Inputs/clang_conformances.sil
+++ b/test/SIL/Serialization/Inputs/clang_conformances.sil
@@ -9,14 +9,14 @@ sil public [serialized] @inlineMe : $@convention(thin) () -> Bool {
 bb0:
   // function_ref Swift.!= infix <A : Swift.Equatable>(A, A) -> Swift.Bool
   %0 = function_ref @_TFsoi2neUs9Equatable__FTQ_Q__Sb : $@convention(thin) <τ_0_0 where τ_0_0 : Equatable> (@in τ_0_0, @in τ_0_0) -> Bool // user: %7
-  %1 = alloc_stack $ComparisonResult            // users: %3, %7, %9
-  %2 = enum $ComparisonResult, #ComparisonResult.Same!enumelt // user: %3
-  store %2 to %1 : $*ComparisonResult         // id: %3
-  %4 = alloc_stack $ComparisonResult            // users: %6, %7, %8
-  %5 = enum $ComparisonResult, #ComparisonResult.Same!enumelt // user: %6
-  store %5 to %4 : $*ComparisonResult         // id: %6
-  %7 = apply %0<ComparisonResult>(%1, %4) : $@convention(thin) <τ_0_0 where τ_0_0 : Equatable> (@in τ_0_0, @in τ_0_0) -> Bool // user: %10
-  dealloc_stack %4 : $*ComparisonResult // id: %8
-  dealloc_stack %1 : $*ComparisonResult // id: %9
+  %1 = alloc_stack $MyComparisonResult            // users: %3, %7, %9
+  %2 = enum $MyComparisonResult, #MyComparisonResult.Same!enumelt // user: %3
+  store %2 to %1 : $*MyComparisonResult         // id: %3
+  %4 = alloc_stack $MyComparisonResult            // users: %6, %7, %8
+  %5 = enum $MyComparisonResult, #MyComparisonResult.Same!enumelt // user: %6
+  store %5 to %4 : $*MyComparisonResult         // id: %6
+  %7 = apply %0<MyComparisonResult>(%1, %4) : $@convention(thin) <τ_0_0 where τ_0_0 : Equatable> (@in τ_0_0, @in τ_0_0) -> Bool // user: %10
+  dealloc_stack %4 : $*MyComparisonResult // id: %8
+  dealloc_stack %1 : $*MyComparisonResult // id: %9
   return %7 : $Bool                               // id: %10
 }

--- a/test/SIL/Serialization/Inputs/clang_conformances_helper.h
+++ b/test/SIL/Serialization/Inputs/clang_conformances_helper.h
@@ -1,5 +1,5 @@
 #define CF_ENUM(_type, _name) enum _name : _type _name; enum _name : _type
-typedef CF_ENUM(int, ComparisonResult) {
+typedef CF_ENUM(int, MyComparisonResult) {
   Ascending,
   Same,
   Descending


### PR DESCRIPTION
Compiler-side work to support sinking Foundation's ComparisonResult (formerly NSComparisonResult) down to the standard library—mainly just getting the importing and PrintAsObjC parts right. This needs special casing rather than our usual simple MappedTypes.def approach because NSComparisonResult is an enum rather than just a typedef of a primitive.

(This has not been proposed yet; consider this an exploratory PR.)

This is not intended to be merged as is. Rather, the second commit should be cherry-picked to whatever PR is actually going to add ComparisonResult properly.