### PR TITLE
[GSB] Distinguish "unresolved" vs. "direct" requirement handling

### DIFF
--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -232,7 +232,8 @@ public:
   /// called with the two types that don't match (\c Bar<T> and \c Baz for the
   /// previous example).
   bool
-  addSameTypeRequirement(ResolvedType paOrT1, ResolvedType paOrT2,
+  addSameTypeRequirementDirect(
+                         ResolvedType paOrT1, ResolvedType paOrT2,
                          FloatingRequirementSource Source,
                          llvm::function_ref<void(Type, Type)> diagnoseMismatch);
 
@@ -240,8 +241,8 @@ public:
   /// (output of GenericSignatureBuilder::resolve).
   ///
   /// The two types must not be incompatible concrete types.
-  bool addSameTypeRequirement(ResolvedType paOrT1, ResolvedType paOrT2,
-                              FloatingRequirementSource Source);
+  bool addSameTypeRequirementDirect(ResolvedType paOrT1, ResolvedType paOrT2,
+                                    FloatingRequirementSource Source);
 
   /// \brief Add a new same-type requirement between two unresolved types.
   ///

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -191,6 +191,16 @@ private:
   GenericSignatureBuilder(const GenericSignatureBuilder &) = delete;
   GenericSignatureBuilder &operator=(const GenericSignatureBuilder &) = delete;
 
+  /// When a particular requirement cannot be resolved due to, e.g., a
+  /// currently-unresolvable or nested type, this routine should be
+  /// called to record the unresolved requirement to be reconsidered later.
+  ///
+  /// \returns false, which is used elsewhere to indicate "no failure".
+  bool recordUnresolvedRequirement(RequirementKind kind,
+                                   UnresolvedType lhs,
+                                   RequirementRHS rhs,
+                                   FloatingRequirementSource source);
+
   /// Retrieve the constraint source conformance for the superclass constraint
   /// of the given potential archetype (if present) to the given protocol.
   ///
@@ -547,9 +557,12 @@ public:
 
   /// \brief Resolve the given type as far as this Builder knows how.
   ///
-  /// This returns either a non-typealias potential archetype or a Type, if \c
-  /// type is concrete.
-  ResolvedType resolve(UnresolvedType type);
+  /// If successful, this returns either a non-typealias potential archetype
+  /// or a Type, if \c type is concrete.
+  /// If the type cannot be resolved, e.g., because it is "too" recursive
+  /// given the source, returns \c None.
+  Optional<ResolvedType> resolve(UnresolvedType type,
+                                 FloatingRequirementSource source);
 
   /// \brief Dump all of the requirements, both specified and inferred.
   LLVM_ATTRIBUTE_DEPRECATED(

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -295,6 +295,23 @@ private:
       Type T1, Type T2, FloatingRequirementSource Source,
       llvm::function_ref<void(Type, Type)> diagnoseMismatch);
 
+  /// \brief Add a new layout requirement directly on the potential archetype.
+  ///
+  /// \returns true if this requirement makes the set of requirements
+  /// inconsistent, in which case a diagnostic will have been issued.
+  bool addLayoutRequirementDirect(PotentialArchetype *PAT,
+                                  LayoutConstraint Layout,
+                                  const RequirementSource *Source);
+
+  /// Add a new layout requirement to the subject.
+  ///
+  /// FIXME: The "dependent type" is the subject type pre-substitution. We
+  /// should be able to compute this!
+  bool addLayoutRequirement(UnresolvedType subject,
+                            LayoutConstraint layout,
+                            FloatingRequirementSource source,
+                            Type dependentType);
+
   /// Add the requirements placed on the given type parameter
   /// to the given potential archetype.
   ///
@@ -388,15 +405,6 @@ public:
   bool addRequirement(const Requirement &req, FloatingRequirementSource source,
                       const SubstitutionMap *subMap,
                       llvm::SmallPtrSetImpl<ProtocolDecl *> &Visited);
-
-  /// \brief Add a new requirement.
-  ///
-  /// \returns true if this requirement makes the set of requirements
-  /// inconsistent, in which case a diagnostic will have been issued.
-
-  bool addLayoutRequirement(PotentialArchetype *PAT,
-                            LayoutConstraint Layout,
-                            const RequirementSource *Source);
 
   /// \brief Add all of a generic signature's parameters and requirements.
   void addGenericSignature(GenericSignature *sig);
@@ -1060,6 +1068,9 @@ public:
 
   /// Retrieve the source location for this requirement.
   SourceLoc getLoc() const;
+
+  /// Whether this is an explicitly-stated requirement.
+  bool isExplicit() const;
 };
 
 class GenericSignatureBuilder::PotentialArchetype {

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -549,11 +549,7 @@ public:
   ///
   /// This returns either a non-typealias potential archetype or a Type, if \c
   /// type is concrete.
-  // FIXME: the hackTypeFromGenericTypeAlias is just temporarily patching over
-  // problems with generic typealiases (see the comment on the ResolvedType
-  // function)
-  ResolvedType resolve(UnresolvedType type,
-                       bool hackTypeFromGenericTypeAlias = false);
+  ResolvedType resolve(UnresolvedType type);
 
   /// \brief Dump all of the requirements, both specified and inferred.
   LLVM_ATTRIBUTE_DEPRECATED(

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -270,9 +270,18 @@ public:
 private:
   /// \brief Add a new superclass requirement specifying that the given
   /// potential archetype has the given type as an ancestor.
-  bool addSuperclassRequirement(PotentialArchetype *T,
-                                Type Superclass,
-                                const RequirementSource *Source);
+  bool addSuperclassRequirementDirect(PotentialArchetype *T,
+                                      Type Superclass,
+                                      const RequirementSource *Source);
+
+  /// \brief Add a new type requirement specifying that the given
+  /// type conforms-to or is a superclass of the second type.
+  bool addTypeRequirement(UnresolvedType subject,
+                          UnresolvedType constraint,
+                          FloatingRequirementSource source,
+                          Type dependentType,
+                          llvm::SmallPtrSetImpl<ProtocolDecl *> *visited
+                            = nullptr);
 
   /// \brief Add a new conformance requirement specifying that the given
   /// potential archetypes are equivalent.

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -1004,14 +1004,6 @@ public:
     return ResolvedType(t);
   }
 
-  // FIXME: this probably shouldn't exist, the potential archetype modelling of
-  // generic typealiases is fundamentally broken (aka they're not modelled at
-  // all), but some things with them mostly work, so we just maintain that,
-  // despite this causing crashes and weird behavior.
-  static ResolvedType forConcreteTypeFromGenericTypeAlias(Type t) {
-    return ResolvedType(t);
-  }
-
   static ResolvedType forPotentialArchetype(PotentialArchetype *pa) {
     return ResolvedType(pa);
   }
@@ -2027,15 +2019,12 @@ auto GenericSignatureBuilder::resolveArchetype(Type type) -> PotentialArchetype 
   return nullptr;
 }
 
-auto GenericSignatureBuilder::resolve(UnresolvedType paOrT,
-                                      bool hackTypeFromGenericTypeAlias)
+auto GenericSignatureBuilder::resolve(UnresolvedType paOrT)
     -> ResolvedType {
   auto pa = paOrT.dyn_cast<PotentialArchetype *>();
   if (auto type = paOrT.dyn_cast<Type>()) {
     pa = resolveArchetype(type);
     if (!pa) {
-      if (hackTypeFromGenericTypeAlias)
-        return ResolvedType::forConcreteTypeFromGenericTypeAlias(type);
       return ResolvedType::forConcreteType(type);
     }
   }

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -2787,21 +2787,22 @@ bool GenericSignatureBuilder::addSameTypeRequirement(
                                        toRequirementRHS(paOrT2), source);
   }
 
-  return addSameTypeRequirement(*resolved1, *resolved2, source,
-                                diagnoseMismatch);
+  return addSameTypeRequirementDirect(*resolved1, *resolved2, source,
+                                      diagnoseMismatch);
 }
 
-bool GenericSignatureBuilder::addSameTypeRequirement(ResolvedType paOrT1,
-                                                     ResolvedType paOrT2,
-                                                     FloatingRequirementSource source) {
-  return addSameTypeRequirement(paOrT1, paOrT2, source,
-                                [&](Type type1, Type type2) {
+bool GenericSignatureBuilder::addSameTypeRequirementDirect(
+                                           ResolvedType paOrT1,
+                                           ResolvedType paOrT2,
+                                           FloatingRequirementSource source) {
+  return addSameTypeRequirementDirect(paOrT1, paOrT2, source,
+                                      [&](Type type1, Type type2) {
     Diags.diagnose(source.getLoc(), diag::requires_same_concrete_type,
                    type1, type2);
   });
 }
 
-bool GenericSignatureBuilder::addSameTypeRequirement(
+bool GenericSignatureBuilder::addSameTypeRequirementDirect(
     ResolvedType paOrT1, ResolvedType paOrT2, FloatingRequirementSource source,
     llvm::function_ref<void(Type, Type)> diagnoseMismatch) {
   auto pa1 = paOrT1.getPotentialArchetype();

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -373,17 +373,6 @@ bool TypeChecker::validateRequirement(SourceLoc whereLoc, RequirementRepr &req,
       req.setInvalid();
     }
 
-    // FIXME: Feels too early to perform this check.
-    if (!req.isInvalid() &&
-        !req.getConstraint()->isExistentialType() &&
-        !req.getConstraint()->getClassOrBoundGenericClass()) {
-      diagnose(whereLoc, diag::requires_conformance_nonprotocol,
-               req.getSubjectLoc(), req.getConstraintLoc());
-      req.getConstraintLoc().setInvalidType(Context);
-      req.setInvalid();
-      return true;
-    }
-
     return req.isInvalid();
   }
 

--- a/test/Generics/invalid.swift
+++ b/test/Generics/invalid.swift
@@ -8,12 +8,10 @@ typealias gimel where A : B // expected-error {{'where' clause cannot be attache
 class dalet where A : B {} // expected-error {{'where' clause cannot be attached to a non-generic declaration}}
 
 protocol he where A : B { // expected-error 2 {{use of undeclared type 'A'}}
-  // expected-error@-1 3{{type 'A' in conformance requirement does not refer to a generic parameter or associated type}}
-  // expected-error@-2 {{use of undeclared type 'B'}}
+  // expected-error@-1 {{use of undeclared type 'B'}}
 
   associatedtype vav where A : B // expected-error{{use of undeclared type 'A'}}
-    // expected-error@-1 3{{type 'A' in conformance requirement does not refer to a generic parameter or associated type}}
-  // expected-error@-2 {{use of undeclared type 'B'}}
+  // expected-error@-1 {{use of undeclared type 'B'}}
 }
 
 

--- a/test/attr/attr_specialize.swift
+++ b/test/attr/attr_specialize.swift
@@ -151,8 +151,10 @@ public func anotherFuncWithTwoGenericParameters<X: P, Y>(x: X, y: Y) {
 
 @_specialize(where T: P) // expected-error{{Only same-type and layout requirements are supported by '_specialize' attribute}}
 @_specialize(where T: Int) // expected-error{{Only conformances to protocol types are supported by '_specialize' attribute}} expected-error{{Only same-type and layout requirements are supported by '_specialize' attribute}}
+// expected-error@-1{{type 'T' constrained to non-protocol type 'Int'}}
 
 @_specialize(where T: S1) // expected-error{{Only conformances to protocol types are supported by '_specialize' attribute}} expected-error{{Only same-type and layout requirements are supported by '_specialize' attribute}}
+// expected-error@-1{{type 'T' constrained to non-protocol type 'S1'}}
 @_specialize(where T: C1) // expected-error{{Only conformances to protocol types are supported by '_specialize' attribute}} expected-error{{Only same-type and layout requirements are supported by '_specialize' attribute}}
 @_specialize(where Int: P) // expected-error{{type 'Int' in conformance requirement does not refer to a generic parameter or associated type}} expected-error{{Only same-type and layout requirements are supported by '_specialize' attribute}} expected-error{{too few type parameters are specified in '_specialize' attribute (got 0, but expected 1)}} expected-error{{Missing constraint for 'T' in '_specialize' attribute}}
 func funcWithForbiddenSpecializeRequirement<T>(_ t: T) {

--- a/test/decl/ext/generic.swift
+++ b/test/decl/ext/generic.swift
@@ -138,7 +138,7 @@ extension GenericClass : P3 where T : P3 { } // expected-error{{extension of typ
 
 extension GenericClass where Self : P3 { }
 // expected-error@-1{{'Self' is only available in a protocol or as the result of a method in a class; did you mean 'GenericClass'?}} {{30-34=GenericClass}}
-// expected-error@-2{{type 'GenericClass' in conformance requirement does not refer to a generic parameter or associated type}}
+// expected-error@-2{{type 'GenericClass<T>' in conformance requirement does not refer to a generic parameter or associated type}}
 
 protocol P4 {
   associatedtype T


### PR DESCRIPTION
Start separating out functions in the GSB that deal with requirements that have potentially-unresolved types (e.g., we haven't called `resolveArchetype` yet, or looked at the resolve) from those that have resolved types and can be applied directly. The intent is for the former to be able to (eventually) break recursion by stashing the unresolved requirements somewhere else, for later processing on an as-needed basis.

Most of this is nearly-NFC cleanup, centralizing diagnostics and requirement handling in the GSB.