### PR TITLE
Catch llvm::report_fatal_error and try to emit a proper diagnostic.

### DIFF
--- a/lib/AST/DiagnosticList.cpp
+++ b/lib/AST/DiagnosticList.cpp
@@ -21,6 +21,8 @@ enum class swift::DiagID : uint32_t {
 #define DIAG(KIND,ID,Options,Text,Signature) ID,
 #include "swift/AST/DiagnosticsAll.def"
 };
+static_assert(static_cast<uint32_t>(swift::DiagID::invalid_diagnostic) == 0,
+              "0 is not the invalid diagnostic ID");
 
 // Define all of the diagnostic objects and initialize them with their 
 // diagnostic IDs.

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -60,6 +60,7 @@
 #include "llvm/IRReader/IRReader.h"
 #include "llvm/Option/Option.h"
 #include "llvm/Option/OptTable.h"
+#include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Support/TargetSelect.h"
@@ -898,9 +899,44 @@ int swift::performFrontend(ArrayRef<const char *> Args,
   llvm::InitializeAllAsmPrinters();
   llvm::InitializeAllAsmParsers();
 
+  PrintingDiagnosticConsumer PDC;
+
+  // Hopefully we won't trigger any LLVM-level fatal errors, but if we do try
+  // to route them through our usual textual diagnostics before crashing.
+  //
+  // Unfortunately it's not really safe to do anything else, since very
+  // low-level operations in LLVM can trigger fatal errors.
+  auto diagnoseFatalError = [&PDC](const std::string &reason, bool shouldCrash){
+    static const std::string *recursiveFatalError = nullptr;
+    if (recursiveFatalError) {
+      // Report the /original/ error through LLVM's default handler, not
+      // whatever we encountered.
+      llvm::remove_fatal_error_handler();
+      llvm::report_fatal_error(*recursiveFatalError, shouldCrash);
+    }
+    recursiveFatalError = &reason;
+
+    SourceManager dummyMgr;
+
+    PDC.handleDiagnostic(dummyMgr, SourceLoc(), DiagnosticKind::Error,
+                         "fatal error encountered during compilation; please "
+                           "file a bug report with your project and the crash "
+                           "log",
+                         DiagnosticInfo());
+    PDC.handleDiagnostic(dummyMgr, SourceLoc(), DiagnosticKind::Note, reason,
+                         DiagnosticInfo());
+    if (shouldCrash)
+      abort();
+  };
+  llvm::ScopedFatalErrorHandler handler([](void *rawCallback,
+                                           const std::string &reason,
+                                           bool shouldCrash) {
+    auto *callback = static_cast<decltype(&diagnoseFatalError)>(rawCallback);
+    (*callback)(reason, shouldCrash);
+  }, &diagnoseFatalError);
+
   std::unique_ptr<CompilerInstance> Instance =
     llvm::make_unique<CompilerInstance>();
-  PrintingDiagnosticConsumer PDC;
   Instance->addDiagnosticConsumer(&PDC);
 
   if (Args.empty()) {

--- a/test/Interpreter/SDK/autolinking.swift
+++ b/test/Interpreter/SDK/autolinking.swift
@@ -7,7 +7,7 @@
 // RUN: not %target-jit-run -lLinkMe %s 2>&1
 
 // RUN: %target-jit-run -lLinkMe -DUSE_DIRECTLY %s -L %t 2>&1
-// RUN: not %target-jit-run -DUSE_DIRECTLY -lLinkMe %s 2>&1
+// RUN: not --crash %target-jit-run -DUSE_DIRECTLY -lLinkMe %s 2>&1
 // REQUIRES: executable_test
 
 

--- a/test/Misc/opt-debug-forbid-typecheck-prefix.swift
+++ b/test/Misc/opt-debug-forbid-typecheck-prefix.swift
@@ -1,65 +1,65 @@
 // This makes sure -debug-forbid-typecheck-prefix works as expected.
 
-// RUN: not %target-swift-frontend -typecheck %s -D TRY1 -debug-forbid-typecheck-prefix FORBID_ 2> %t.txt
+// RUN: not --crash %target-swift-frontend -typecheck %s -D TRY1 -debug-forbid-typecheck-prefix FORBID_ 2> %t.txt
 // RUN: %FileCheck -check-prefix=CHECK1 -input-file %t.txt %s
 #if TRY1
-// CHECK1: LLVM ERROR: forbidden typecheck occurred: FORBID_global
+// CHECK1: note: forbidden typecheck occurred: FORBID_global
 var FORBID_global = 0
 #endif
 
-// RUN: not %target-swift-frontend -typecheck %s -D TRY2 -debug-forbid-typecheck-prefix FORBID_ 2> %t.txt
+// RUN: not --crash %target-swift-frontend -typecheck %s -D TRY2 -debug-forbid-typecheck-prefix FORBID_ 2> %t.txt
 // RUN: %FileCheck -check-prefix=CHECK2 -input-file %t.txt %s
 #if TRY2
-// CHECK2: LLVM ERROR: forbidden typecheck occurred: FORBID_class
+// CHECK2: note: forbidden typecheck occurred: FORBID_class
 class FORBID_class {}
 #endif
 
-// RUN: not %target-swift-frontend -typecheck %s -D TRY3 -debug-forbid-typecheck-prefix FORBID_ 2> %t.txt
+// RUN: not --crash %target-swift-frontend -typecheck %s -D TRY3 -debug-forbid-typecheck-prefix FORBID_ 2> %t.txt
 // RUN: %FileCheck -check-prefix=CHECK3 -input-file %t.txt %s
 #if TRY3
 class C {
-  // CHECK3: LLVM ERROR: forbidden typecheck occurred: FORBID_member
+  // CHECK3: note: forbidden typecheck occurred: FORBID_member
   var FORBID_member = 0
 }
 #endif
 
-// RUN: not %target-swift-frontend -typecheck %s -D TRY4 -debug-forbid-typecheck-prefix FORBID_ 2> %t.txt
+// RUN: not --crash %target-swift-frontend -typecheck %s -D TRY4 -debug-forbid-typecheck-prefix FORBID_ 2> %t.txt
 // RUN: %FileCheck -check-prefix=CHECK4 -input-file %t.txt %s
 #if TRY4
 class C {
-  // CHECK4: LLVM ERROR: forbidden typecheck occurred: FORBID_memberFunc
+  // CHECK4: note: forbidden typecheck occurred: FORBID_memberFunc
   func FORBID_memberFunc() {}
 }
 #endif
 
-// RUN: not %target-swift-frontend -typecheck %s -D TRY5 -debug-forbid-typecheck-prefix FORBID_ 2> %t.txt
+// RUN: not --crash %target-swift-frontend -typecheck %s -D TRY5 -debug-forbid-typecheck-prefix FORBID_ 2> %t.txt
 // RUN: %FileCheck -check-prefix=CHECK5 -input-file %t.txt %s
 #if TRY5
-// CHECK5: LLVM ERROR: forbidden typecheck occurred: FORBID_func
+// CHECK5: note: forbidden typecheck occurred: FORBID_func
 func FORBID_func() {}
 #endif
 
-// RUN: not %target-swift-frontend -typecheck %s -D TRY6 -debug-forbid-typecheck-prefix FORBID_ 2> %t.txt
+// RUN: not --crash %target-swift-frontend -typecheck %s -D TRY6 -debug-forbid-typecheck-prefix FORBID_ 2> %t.txt
 // RUN: %FileCheck -check-prefix=CHECK6 -input-file %t.txt %s
 #if TRY6
-// CHECK6: LLVM ERROR: forbidden typecheck occurred: FORBID_local
+// CHECK6: note: forbidden typecheck occurred: FORBID_local
 func globalFunc() {
 	var FORBID_local = 0
 }
 #endif
 
-// RUN: not %target-swift-frontend -typecheck %s -D TRY7 -debug-forbid-typecheck-prefix FORBID_ 2> %t.txt
+// RUN: not --crash %target-swift-frontend -typecheck %s -D TRY7 -debug-forbid-typecheck-prefix FORBID_ 2> %t.txt
 // RUN: %FileCheck -check-prefix=CHECK7 -input-file %t.txt %s
 #if TRY7
-// CHECK7: LLVM ERROR: forbidden typecheck occurred: FORBID_ref
+// CHECK7: note: forbidden typecheck occurred: FORBID_ref
 var global = FORBID_ref
 #endif
 
-// RUN: not %target-swift-frontend -typecheck %s -D TRY8 -debug-forbid-typecheck-prefix FORBID_ 2> %t.txt
+// RUN: not --crash %target-swift-frontend -typecheck %s -D TRY8 -debug-forbid-typecheck-prefix FORBID_ 2> %t.txt
 // RUN: %FileCheck -check-prefix=CHECK8 -input-file %t.txt %s
 #if TRY8
 class C {
-  // CHECK8: LLVM ERROR: forbidden typecheck occurred: FORBID_ref
+  // CHECK8: note: forbidden typecheck occurred: FORBID_ref
   var member = FORBID_ref
 }
 #endif


### PR DESCRIPTION
This only affects the textual output, but should still improve the experience when we *do* hit one of these LLVM errors. In addition to showing up better in Xcode, it'll also give us a proper PrettyStackTrace because of the call to `abort()` instead of `exit(1)`.

(There's a bit of finger-crossing that the act of printing the diagnostic doesn't cause more errors. I only tested the fallback path a little.)