### PR TITLE
[stdlib][WIP do not merge] Add compare function to the std lib

### DIFF
--- a/include/swift/AST/KnownStdlibTypes.def
+++ b/include/swift/AST/KnownStdlibTypes.def
@@ -58,6 +58,7 @@ KNOWN_STDLIB_TYPE_DECL(Optional, EnumDecl, 1)
 KNOWN_STDLIB_TYPE_DECL(ImplicitlyUnwrappedOptional, EnumDecl, 1)
 
 KNOWN_STDLIB_TYPE_DECL(OptionSet, NominalTypeDecl, 1)
+KNOWN_STDLIB_TYPE_DECL(ComparisonResult, NominalTypeDecl, 0)
 
 KNOWN_STDLIB_TYPE_DECL(UnsafeMutableRawPointer, NominalTypeDecl, 0)
 KNOWN_STDLIB_TYPE_DECL(UnsafeRawPointer, NominalTypeDecl, 0)

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2379,6 +2379,14 @@ namespace {
         if (declaredNative && nativeDecl)
           return nativeDecl;
 
+        // Special case for NSComparisonResult, which is imported as Swift's
+        // ComparisonResult.
+        if (decl->getName() == "NSComparisonResult") {
+          if (clang::Module *M = decl->getImportedOwningModule())
+            if (M->getTopLevelModuleName() == C.Id_Foundation.str())
+              return C.getComparisonResultDecl();
+        }
+
         // Compute the underlying type.
         auto underlyingType = Impl.importType(
             decl->getIntegerType(), ImportTypeKind::Enum, isInSystemModule(dc),

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -1280,6 +1280,7 @@ private:
       MAP(Int, "NSInteger", false);
       MAP(UInt, "NSUInteger", false);
       MAP(Bool, "BOOL", false);
+      MAP(ComparisonResult, "NSComparisonResult", false);
 
       MAP(OpaquePointer, "void *", true);
       MAP(UnsafeRawPointer, "void const *", true);
@@ -1553,6 +1554,10 @@ private:
 
   void visitEnumType(EnumType *ET, Optional<OptionalTypeKind> optionalKind) {
     const EnumDecl *ED = ET->getDecl();
+
+    // Handle known type names.
+    if (printIfKnownSimpleType(ED, optionalKind))
+      return;
 
     // Handle bridged types.
     if (printIfObjCBridgeable(ED, { }, optionalKind))

--- a/stdlib/public/SDK/Foundation/Measurement.swift
+++ b/stdlib/public/SDK/Foundation/Measurement.swift
@@ -183,7 +183,7 @@ extension Measurement {
 
     /// Compare two measurements of the same `Unit`.
     /// - returns: `true` if the measurements can be compared and the `lhs` is less than the `rhs` converted value.
-    public static func <<LeftHandSideType, RightHandSideType>(lhs: Measurement<LeftHandSideType>, rhs: Measurement<RightHandSideType>) -> Bool {
+    public static func < <LeftHandSideType, RightHandSideType>(lhs: Measurement<LeftHandSideType>, rhs: Measurement<RightHandSideType>) -> Bool {
         if lhs.unit == rhs.unit {
             return lhs.value < rhs.value
         } else {
@@ -197,6 +197,25 @@ extension Measurement {
             }
             fatalError("Attempt to compare measurements with non-equal dimensions")
         }
+    }
+
+    /// FIXME: temporary duplication for overload resolution
+    /// Compare two measurements of the same `Unit`.
+    /// - returns: `true` if the measurements can be compared and the `lhs` is less than the `rhs` converted value.
+    public static func < <T>(lhs: Measurement<T>, rhs: Measurement<T>) -> Bool {
+      if lhs.unit == rhs.unit {
+          return lhs.value < rhs.value
+      } else {
+          if let lhsDimensionalUnit = lhs.unit as? Dimension,
+             let rhsDimensionalUnit = rhs.unit as? Dimension {
+              if type(of: lhsDimensionalUnit).baseUnit() == type(of: rhsDimensionalUnit).baseUnit() {
+                  let lhsValueInTermsOfBase = lhsDimensionalUnit.converter.baseUnitValue(fromValue: lhs.value)
+                  let rhsValueInTermsOfBase = rhsDimensionalUnit.converter.baseUnitValue(fromValue: rhs.value)
+                  return lhsValueInTermsOfBase < rhsValueInTermsOfBase
+              }
+          }
+          fatalError("Attempt to compare measurements with non-equal dimensions")
+      }
     }
 }
 

--- a/stdlib/public/core/Comparable.swift
+++ b/stdlib/public/core/Comparable.swift
@@ -146,6 +146,11 @@
 ///   equal to any normal floating-point value. Exceptional values need not
 ///   take part in the strict total order.
 public protocol Comparable : Equatable {
+  
+  /// Returns a ComparisonResult indicating whether the value of self
+  /// is in ascending, same or descending order with respect to other.
+  func compare(_ other: Self) -> ComparisonResult
+  
   /// Returns a Boolean value indicating whether the value of the first
   /// argument is less than that of the second argument.
   ///
@@ -160,44 +165,59 @@ public protocol Comparable : Equatable {
 }
 
 extension Comparable {
-  /// Returns a Boolean value indicating whether the value of the first argument
-  /// is greater than that of the second argument.
-  ///
-  /// This is the default implementation of the greater-than operator (`>`) for
-  /// any type that conforms to `Comparable`.
-  ///
-  /// - Parameters:
-  ///   - lhs: A value to compare.
-  ///   - rhs: Another value to compare.
-  public static func > (lhs: Self, rhs: Self) -> Bool {
-    return rhs < lhs
-  }
-
-  /// Returns a Boolean value indicating whether the value of the first argument
-  /// is less than or equal to that of the second argument.
-  ///
-  /// This is the default implementation of the less-than-or-equal-to
-  /// operator (`<=`) for any type that conforms to `Comparable`.
-  ///
-  /// - Parameters:
-  ///   - lhs: A value to compare.
-  ///   - rhs: Another value to compare.
-  public static func <= (lhs: Self, rhs: Self) -> Bool {
-    return !(rhs < lhs)
-  }
-
-  /// Returns a Boolean value indicating whether the value of the first argument
-  /// is greater than or equal to that of the second argument.
-  ///
-  /// This is the default implementation of the greater-than-or-equal-to operator
-  /// (`>=`) for any type that conforms to `Comparable`.
-  ///
-  /// - Parameters:
-  ///   - lhs: A value to compare.
-  ///   - rhs: Another value to compare.
-  /// - Returns: `true` if `lhs` is greater than or equal to `rhs`; otherwise,
-  ///   `false`.
-  public static func >= (lhs: Self, rhs: Self) -> Bool {
-    return !(lhs < rhs)
+  public func compare(_ other: Self) -> ComparisonResult {
+    if self ==  other {
+      return .orderedSame
+    } else if self <  other {
+      return .orderedAscending
+    } else {
+      return .orderedDescending
+    } 
   }
 }
+
+public func < <T: Comparable>(lhs: T, rhs: T) -> Bool {
+  return lhs.compare(rhs) == .orderedAscending
+}
+
+/// Returns a Boolean value indicating whether the value of the first argument
+/// is greater than that of the second argument.
+///
+/// This is the default implementation of the greater-than operator (`>`) for
+/// any type that conforms to `Comparable`.
+///
+/// - Parameters:
+///   - lhs: A value to compare.
+///   - rhs: Another value to compare.
+public func > <T : Comparable>(lhs: T, rhs: T) -> Bool {
+  return rhs < lhs
+}
+
+/// Returns a Boolean value indicating whether the value of the first argument
+/// is less than or equal to that of the second argument.
+///
+/// This is the default implementation of the less-than-or-equal-to
+/// operator (`<=`) for any type that conforms to `Comparable`.
+///
+/// - Parameters:
+///   - lhs: A value to compare.
+///   - rhs: Another value to compare.
+public func <= <T : Comparable>(lhs: T, rhs: T) -> Bool {
+  return !(rhs < lhs)
+}
+
+/// Returns a Boolean value indicating whether the value of the first argument
+/// is greater than or equal to that of the second argument.
+///
+/// This is the default implementation of the greater-than-or-equal-to operator
+/// (`>=`) for any type that conforms to `Comparable`.
+///
+/// - Parameters:
+///   - lhs: A value to compare.
+///   - rhs: Another value to compare.
+/// - Returns: `true` if `lhs` is greater than or equal to `rhs`; otherwise,
+///   `false`.
+public func >= <T : Comparable>(lhs: T, rhs: T) -> Bool {
+  return !(lhs < rhs)
+}
+

--- a/stdlib/public/core/Comparable.swift
+++ b/stdlib/public/core/Comparable.swift
@@ -10,6 +10,16 @@
 //
 //===----------------------------------------------------------------------===//
 
+/// A value used to indicate how items in a request are ordered, from the first
+/// one given in a method invocation or function call to the last (that is, left
+/// to right in code).
+@objc public enum ComparisonResult : Int {
+  case orderedAscending = -1
+  case orderedSame = 0
+  case orderedDescending = 1
+}
+
+
 /// A type that can be compared using the relational operators `<`, `<=`, `>=`,
 /// and `>`.
 ///

--- a/stdlib/public/core/Comparable.swift
+++ b/stdlib/public/core/Comparable.swift
@@ -157,30 +157,6 @@ public protocol Comparable : Equatable {
   ///   - lhs: A value to compare.
   ///   - rhs: Another value to compare.
   static func < (lhs: Self, rhs: Self) -> Bool
-
-  /// Returns a Boolean value indicating whether the value of the first
-  /// argument is less than or equal to that of the second argument.
-  ///
-  /// - Parameters:
-  ///   - lhs: A value to compare.
-  ///   - rhs: Another value to compare.
-  static func <= (lhs: Self, rhs: Self) -> Bool
-
-  /// Returns a Boolean value indicating whether the value of the first
-  /// argument is greater than or equal to that of the second argument.
-  ///
-  /// - Parameters:
-  ///   - lhs: A value to compare.
-  ///   - rhs: Another value to compare.
-  static func >= (lhs: Self, rhs: Self) -> Bool
-
-  /// Returns a Boolean value indicating whether the value of the first
-  /// argument is greater than that of the second argument.
-  ///
-  /// - Parameters:
-  ///   - lhs: A value to compare.
-  ///   - rhs: Another value to compare.
-  static func > (lhs: Self, rhs: Self) -> Bool
 }
 
 extension Comparable {

--- a/stdlib/public/core/FloatingPoint.swift.gyb
+++ b/stdlib/public/core/FloatingPoint.swift.gyb
@@ -1913,6 +1913,52 @@ extension BinaryFloatingPoint {
   */
 }
 
+
+// Comparable comparison operators (provides a total ordering)
+extension FloatingPoint {
+  public func compare(_ other: Self) -> ComparisonResult {
+    // Can potentially be implemented more efficiently -- this is just the clearest version
+    if self.isLess(than: other) {
+      return .orderedAscending
+    } else if other.isLess(than: self) {
+      return .orderedDescending
+    } else {
+      // Special cases
+
+      // -0 < +0
+      if self.isZero && other.isZero {
+        // .plus == 0 and .minus == 1, so flip ordering to get - < +
+        return other.sign.rawValue.compare(self.sign.rawValue)
+      }
+
+      // NaN == NaN, NaN > +Inf
+      if self.isNaN {
+        if other.isNaN {
+          return .orderedSame
+        } else {
+          return .orderedDescending
+        }
+      } else if other.isNaN {
+        return .orderedAscending
+      }
+
+      // Otherwise equality agrees with normal IEEE
+      return .orderedSame
+    }
+  }
+
+  @_implements(Equatable, ==(_:_:))
+  public static func _comparableEqual(lhs: Self, rhs: Self) -> Bool {
+    fatalError("NaNaNaNaaaaaa....")
+    return lhs.compare(rhs) == .orderedSame
+  }
+
+  @_implements(Comparable, <(_:_:))
+  public static func _comparableLessThan(lhs: Self, rhs: Self) -> Bool {
+    return lhs.compare(rhs) == .orderedDescending
+  }
+}
+
 /// Returns the absolute value of `x`.
 @_transparent
 public func abs<T : FloatingPoint>(_ x: T) -> T where T.Magnitude == T {

--- a/test/ClangImporter/objc_parse.swift
+++ b/test/ClangImporter/objc_parse.swift
@@ -629,3 +629,12 @@ class NewtypeUser {
   @objc func intNewtype(a: MyInt) {}
   @objc func intNewtypeOptional(a: MyInt?) {} // expected-error {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
 }
+
+func testComparisonResult(str: NSString) {
+  let ordering = str.compare(str as String)
+  switch ordering {
+  case .orderedAscending: break
+  case ComparisonResult.orderedSame: break
+  case Swift.ComparisonResult.orderedDescending: break
+  }
+}

--- a/test/Inputs/clang-importer-sdk/usr/include/Foundation.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/Foundation.h
@@ -297,6 +297,8 @@ typedef NSPoint *NSPointArray;
 #define NS_ENUM(_type, _name) CF_ENUM(_type, _name)
 #define NS_OPTIONS(_type, _name) CF_OPTIONS(_type, _name)
 
+typedef NS_ENUM(NSInteger, NSComparisonResult) {NSOrderedAscending = -1L, NSOrderedSame, NSOrderedDescending};
+
 /// Aaa.  NSRuncingMode.  Bbb.
 typedef NS_ENUM(NSUInteger, NSRuncingMode) {
   NSRuncingMince,
@@ -759,9 +761,7 @@ NSSet *setToSet(NSSet *dict);
 
 @interface NSString(FoundationExts)
 - (void)notBridgedMethod;
-@end
-
-@interface NSString(FoundationExts)
+- (NSComparisonResult)compare:(NSString *)other;
 @property (nonatomic, copy) NSString *uppercaseString;
 @end
 

--- a/test/Interpreter/SDK/Foundation_test.swift
+++ b/test/Interpreter/SDK/Foundation_test.swift
@@ -117,6 +117,29 @@ FoundationTestSuite.test("arrayConversions") {
   nsArrayToAnyObjectArray(aoa as NSArray)
 }
 
+FoundationTestSuite.test("ComparisonResult") {
+  class IntBox: NSObject {
+    var value: Int
+    init(_ value: Int) {
+      self.value = value
+    }
+    
+    @objc func compare(_ other: IntBox) -> Swift.ComparisonResult {
+      // This is a reverse sort.
+      if value == other.value { return .orderedSame }
+      if value <  other.value { return .orderedDescending }
+      return .orderedAscending
+    }
+  }
+
+  let array = [IntBox(2), IntBox(3), IntBox(1)] as NSArray
+  let sorted = array.sortedArray(using: #selector(IntBox.compare))
+  let result = sorted as! [IntBox]
+  expectEqual(3, result[0].value)
+  expectEqual(2, result[1].value)
+  expectEqual(1, result[2].value)
+}
+
 //===----------------------------------------------------------------------===//
 // Dictionaries
 //===----------------------------------------------------------------------===//

--- a/test/PrintAsObjC/enums.swift
+++ b/test/PrintAsObjC/enums.swift
@@ -23,6 +23,7 @@ import Foundation
 // CHECK-NEXT: - (enum ObjcEnumNamed)takeAndReturnRenamedEnum:(enum ObjcEnumNamed)foo SWIFT_WARN_UNUSED_RESULT;
 // CHECK-NEXT: - (void)acceptTopLevelImportedWithA:(enum TopLevelRaw)a b:(TopLevelEnum)b c:(TopLevelOptions)c d:(TopLevelTypedef)d e:(TopLevelAnon)e;
 // CHECK-NEXT: - (void)acceptMemberImportedWithA:(enum MemberRaw)a b:(enum MemberEnum)b c:(MemberOptions)c d:(enum MemberTypedef)d e:(MemberAnon)e ee:(MemberAnon2)ee;
+// CHECK-NEXT: - (void)comparisonResultIsSpecial:(NSComparisonResult)_;
 // CHECK: @end
 @objc class AnEnumMethod {
   @objc func takeAndReturnEnum(_ foo: FooComments) -> NegativeValues {
@@ -35,6 +36,8 @@ import Foundation
 
   @objc func acceptTopLevelImported(a: TopLevelRaw, b: TopLevelEnum, c: TopLevelOptions, d: TopLevelTypedef, e: TopLevelAnon) {}
   @objc func acceptMemberImported(a: Wrapper.Raw, b: Wrapper.Enum, c: Wrapper.Options, d: Wrapper.Typedef, e: Wrapper.Anon, ee: Wrapper.Anon2) {}
+
+  @objc func comparisonResultIsSpecial(_: ComparisonResult) {}
 }
 
 // CHECK-LABEL: typedef SWIFT_ENUM_NAMED(NSInteger, ObjcEnumNamed, "EnumNamed") {

--- a/test/SIL/Parser/witness_bug.sil
+++ b/test/SIL/Parser/witness_bug.sil
@@ -1,4 +1,6 @@
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil %s
+// TODO: decide whether to delete this test or move to test another method since <= isn't on Comparable no more
+// XFAIL: *
 
 import Builtin
 import Swift

--- a/test/SIL/Serialization/Inputs/clang_conformances.sil
+++ b/test/SIL/Serialization/Inputs/clang_conformances.sil
@@ -9,14 +9,14 @@ sil public [serialized] @inlineMe : $@convention(thin) () -> Bool {
 bb0:
   // function_ref Swift.!= infix <A : Swift.Equatable>(A, A) -> Swift.Bool
   %0 = function_ref @_TFsoi2neUs9Equatable__FTQ_Q__Sb : $@convention(thin) <τ_0_0 where τ_0_0 : Equatable> (@in τ_0_0, @in τ_0_0) -> Bool // user: %7
-  %1 = alloc_stack $ComparisonResult            // users: %3, %7, %9
-  %2 = enum $ComparisonResult, #ComparisonResult.Same!enumelt // user: %3
-  store %2 to %1 : $*ComparisonResult         // id: %3
-  %4 = alloc_stack $ComparisonResult            // users: %6, %7, %8
-  %5 = enum $ComparisonResult, #ComparisonResult.Same!enumelt // user: %6
-  store %5 to %4 : $*ComparisonResult         // id: %6
-  %7 = apply %0<ComparisonResult>(%1, %4) : $@convention(thin) <τ_0_0 where τ_0_0 : Equatable> (@in τ_0_0, @in τ_0_0) -> Bool // user: %10
-  dealloc_stack %4 : $*ComparisonResult // id: %8
-  dealloc_stack %1 : $*ComparisonResult // id: %9
+  %1 = alloc_stack $MyComparisonResult            // users: %3, %7, %9
+  %2 = enum $MyComparisonResult, #MyComparisonResult.Same!enumelt // user: %3
+  store %2 to %1 : $*MyComparisonResult         // id: %3
+  %4 = alloc_stack $MyComparisonResult            // users: %6, %7, %8
+  %5 = enum $MyComparisonResult, #MyComparisonResult.Same!enumelt // user: %6
+  store %5 to %4 : $*MyComparisonResult         // id: %6
+  %7 = apply %0<MyComparisonResult>(%1, %4) : $@convention(thin) <τ_0_0 where τ_0_0 : Equatable> (@in τ_0_0, @in τ_0_0) -> Bool // user: %10
+  dealloc_stack %4 : $*MyComparisonResult // id: %8
+  dealloc_stack %1 : $*MyComparisonResult // id: %9
   return %7 : $Bool                               // id: %10
 }

--- a/test/SIL/Serialization/Inputs/clang_conformances_helper.h
+++ b/test/SIL/Serialization/Inputs/clang_conformances_helper.h
@@ -1,5 +1,5 @@
 #define CF_ENUM(_type, _name) enum _name : _type _name; enum _name : _type
-typedef CF_ENUM(int, ComparisonResult) {
+typedef CF_ENUM(int, MyComparisonResult) {
   Ascending,
   Same,
   Descending


### PR DESCRIPTION
Work investigating sinking ComparisonResult down to the standard library and using it for a ternary comparison function on `Comparable`