### PR TITLE
[build-script] Add skip reconfigure flag to build-script-impl

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -99,6 +99,7 @@ KNOWN_SETTINGS=(
     installable-package         ""               "the path to the archive of the installation directory"
     test-installable-package    ""               "whether to run post-packaging tests on the produced package"
     reconfigure                 ""               "force a CMake configuration run even if CMakeCache.txt already exists"
+    skip-reconfigure            ""               "set to skip reconfigure"
     swift-primary-variant-sdk   ""               "default SDK for target binaries"
     swift-primary-variant-arch  ""               "default arch for target binaries"
     skip-build-cmark            ""               "set to skip building CommonMark"
@@ -941,6 +942,10 @@ fi
 # FIXME: We currently do not support cross-compiling swift with compiler-rt.
 if [[ "${CROSS_COMPILE_HOSTS}" ]]; then
     SKIP_BUILD_COMPILER_RT=1
+fi
+
+if [[ "${SKIP_RECONFIGURE}" ]]; then
+    RECONFIGURE=""
 fi
 
 # WORKSPACE, BUILD_DIR and INSTALLABLE_PACKAGE must be absolute paths


### PR DESCRIPTION
Add support to skip reconfigure flag by using `--skip-reconfigure`