### PR TITLE
Fix DeadStoreElim by not lying about instruction semantics

### DIFF
--- a/include/swift/SIL/SILNodes.def
+++ b/include/swift/SIL/SILNodes.def
@@ -202,7 +202,7 @@ ABSTRACT_VALUE(SILInstruction, ValueBase)
 
   // Metatypes
   INST(MetatypeInst, SILInstruction, metatype, None, DoesNotRelease)
-  INST(ValueMetatypeInst, SILInstruction, value_metatype, None, DoesNotRelease)
+  INST(ValueMetatypeInst, SILInstruction, value_metatype, MayRead, DoesNotRelease)
   INST(ExistentialMetatypeInst, SILInstruction, existential_metatype, MayRead, DoesNotRelease)
   INST(ObjCProtocolInst, SILInstruction, objc_protocol, None, DoesNotRelease)
 

--- a/test/SILOptimizer/dead_store_elim.sil
+++ b/test/SILOptimizer/dead_store_elim.sil
@@ -1417,3 +1417,19 @@ bb0(%0 : $AB):                     // Preds: bb6 bb5 bb4 bb3
   dealloc_stack %1 : $*AB
   return %2 : $Builtin.Int1
 }
+
+// CHECK-LABEL: dont_remove_store
+// CHECK: load
+// CHECK: store
+// CHECK: value_metatype
+// CHECK: return
+sil @dont_remove_store : $@convention(thin) (@in_guaranteed foo) -> () {
+bb0(%0 : $*foo):
+  %1 = alloc_stack $foo
+  %2 = load %0 : $*foo
+  store %2 to %1 : $*foo
+  %3 = value_metatype $@thick foo.Type, %1 : $*foo
+  dealloc_stack %1 : $*foo
+  %20 = tuple()
+  return %20 : $()
+}


### PR DESCRIPTION
We would remove a store because we did not know that value_metatype reads its pointer argument's value.

rdar://31414977