### PR TITLE
[3.1] Fix dead store elimination

### DIFF
--- a/include/swift/SIL/SILNodes.def
+++ b/include/swift/SIL/SILNodes.def
@@ -194,7 +194,7 @@ ABSTRACT_VALUE(SILInstruction, ValueBase)
 
   // Metatypes
   INST(MetatypeInst, SILInstruction, metatype, None, DoesNotRelease)
-  INST(ValueMetatypeInst, SILInstruction, value_metatype, None, DoesNotRelease)
+  INST(ValueMetatypeInst, SILInstruction, value_metatype, MayRead, DoesNotRelease)
   INST(ExistentialMetatypeInst, SILInstruction, existential_metatype, MayRead, DoesNotRelease)
   INST(ObjCProtocolInst, SILInstruction, objc_protocol, None, DoesNotRelease)
 

--- a/test/SILOptimizer/dead_store_elim.sil
+++ b/test/SILOptimizer/dead_store_elim.sil
@@ -1389,3 +1389,19 @@ bb2:
   %14 = tuple ()
   return %14 : $()
 }
+
+// CHECK-LABEL: dont_remove_store
+// CHECK: load
+// CHECK: store
+// CHECK: value_metatype
+// CHECK: return
+sil @dont_remove_store : $@convention(thin) (@in_guaranteed foo) -> () {
+bb0(%0 : $*foo):
+  %1 = alloc_stack $foo
+  %2 = load %0 : $*foo
+  store %2 to %1 : $*foo
+  %3 = value_metatype $@thick foo.Type, %1 : $*foo
+  dealloc_stack %1 : $*foo
+  %20 = tuple()
+  return %20 : $()
+}


### PR DESCRIPTION
• Explanation: Dead store elimination would eliminate a store before a value_metatype instruction that reads the stores destination address. The problem was the instruction description claimed that the value_metatype instructions is read none.

• Scope of Issue: The following code fails

import Foundation
final class Foobar : Error {}
Foobar() as Error as NSError

• Origination: Always been there AFAICT.

• Risk: Low. We only make the compile aware of an instruction that really reads memory.

• Testing: Swift CI - regression test was added.