### PR TITLE
Preliminary Sema and AST support for subclass existentials (SE-0156)

### DIFF
--- a/include/swift/AST/ConcreteDeclRef.h
+++ b/include/swift/AST/ConcreteDeclRef.h
@@ -93,8 +93,12 @@ public:
   /// given declaration. This array will be copied into the ASTContext by the
   /// constructor.
   ConcreteDeclRef(ASTContext &ctx, ValueDecl *decl,
-                  SubstitutionList substitutions)
-    : Data(SpecializedDeclRef::create(ctx, decl, substitutions)) { }
+                  SubstitutionList substitutions) {
+    if (substitutions.empty())
+      Data = decl;
+    else
+      Data = SpecializedDeclRef::create(ctx, decl, substitutions);
+  }
 
   /// Determine whether this declaration reference refers to anything.
   explicit operator bool() const { return !Data.isNull(); }

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -699,9 +699,9 @@ ERROR(tuple_type_multiple_labels,none,
 
 // Protocol Types
 ERROR(expected_rangle_protocol,PointsToFirstBadToken,
-      "expected '>' to complete protocol composition type", ())
+      "expected '>' to complete protocol-constrained type", ())
 ERROR(disallowed_protocol_composition,PointsToFirstBadToken,
-      "protocol composition is neither allowed nor needed here", ())
+      "protocol-constrained type is neither allowed nor needed here", ())
 
 WARNING(deprecated_protocol_composition,none,
         "'protocol<...>' composition syntax is deprecated; join the protocols using '&'", ())
@@ -1361,7 +1361,7 @@ ERROR(unexpected_class_constraint,none,
 NOTE(suggest_anyobject,none,
      "did you mean to constrain %0 with the 'AnyObject' protocol?", (Identifier))
 ERROR(expected_generics_type_restriction,none,
-      "expected a type name or protocol composition restricting %0",
+      "expected a class type or protocol-constrained type restricting %0",
       (Identifier))
 ERROR(requires_single_equal,none,
       "use '==' for same-type requirements rather than '='", ())

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1548,13 +1548,18 @@ ERROR(circular_protocol_def,none,
       "circular protocol inheritance %0", (StringRef))
 NOTE(protocol_here,none,
      "protocol %0 declared here", (Identifier))
-ERROR(protocol_composition_not_protocol,none,
-      "non-protocol type %0 cannot be used within a protocol composition", (Type))
 ERROR(objc_protocol_inherits_non_objc_protocol,none,
       "@objc protocol %0 cannot refine non-@objc protocol %1", (Type, Type))
 WARNING(protocol_composition_with_postfix,none,
-        "protocol composition with postfix '%0' is ambiguous "
+        "protocol-constrained type with postfix '%0' is ambiguous "
         "and will be rejected in future version of Swift", (StringRef))
+
+ERROR(invalid_protocol_composition_member,none,
+      "non-protocol, non-class type %0 cannot be used within a "
+      "protocol-constrained type", (Type))
+ERROR(protocol_composition_one_class,none,
+      "protocol-constrained type cannot contain class %0 because it already "
+      "contains class %1", (Type, Type))
 
 ERROR(requires_conformance_nonprotocol,none,
       "type %0 constrained to non-protocol type %1", (TypeLoc, TypeLoc))
@@ -3086,7 +3091,7 @@ NOTE(not_objc_empty_protocol_composition,none,
 NOTE(not_objc_protocol,none,
      "protocol %0 is not '@objc'", (Type))
 NOTE(not_objc_error_protocol_composition,none,
-     "protocol composition involving 'Error' cannot be represented "
+     "protocol-constrained type containing 'Error' cannot be represented "
      "in Objective-C", ())
 NOTE(not_objc_empty_tuple,none,
       "empty tuple type cannot be represented in Objective-C", ())

--- a/include/swift/AST/ExistentialLayout.h
+++ b/include/swift/AST/ExistentialLayout.h
@@ -1,0 +1,80 @@
+//===--- ExistentialLayout.h - Existential type decomposition ---*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the ExistentialLayout struct.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_EXISTENTIAL_LAYOUT_H
+#define SWIFT_EXISTENTIAL_LAYOUT_H
+
+#include "swift/AST/ASTContext.h"
+#include "swift/AST/Type.h"
+#include "llvm/ADT/SmallVector.h"
+
+namespace swift {
+  class ProtocolDecl;
+  class ProtocolType;
+  class ProtocolCompositionType;
+
+struct ExistentialLayout {
+  ExistentialLayout() {
+    requiresClass = false;
+    requiresClassImplied = false;
+    containsNonObjCProtocol = false;
+    singleProtocol = nullptr;
+  }
+
+  ExistentialLayout(ProtocolType *type);
+  ExistentialLayout(ProtocolCompositionType *type);
+
+  /// The superclass constraint, if any.
+  Type superclass;
+
+  /// Whether the existential requires a class, either via an explicit
+  /// '& AnyObject' member or because of a superclass or protocol constraint.
+  bool requiresClass : 1;
+
+  /// Whether the class constraint was implied by another constraint and therefore
+  /// does not need to be stated explicitly.
+  bool requiresClassImplied : 1;
+
+  /// Whether any protocol members are non-@objc.
+  bool containsNonObjCProtocol : 1;
+
+  bool isAnyObject() const;
+
+  bool isObjC() const {
+    // FIXME: Does the superclass have to be @objc?
+    return requiresClass && !containsNonObjCProtocol;
+  }
+
+  bool isExistentialWithError(ASTContext &ctx) const;
+
+  ArrayRef<ProtocolType *> getProtocols() const {
+    if (singleProtocol)
+      return ArrayRef<ProtocolType *>{&singleProtocol, 1};
+    return multipleProtocols;
+  }
+
+private:
+  // Inline storage for 'protocols' member above when computing
+  // layout of a single ProtocolType
+  ProtocolType *singleProtocol;
+
+  /// Zero or more protocol constraints.
+  ArrayRef<ProtocolType *> multipleProtocols;
+};
+
+}
+
+#endif  // SWIFT_EXISTENTIAL_LAYOUT_H

--- a/include/swift/AST/Type.h
+++ b/include/swift/AST/Type.h
@@ -51,6 +51,7 @@ class SubstitutionMap;
 class TypeBase;
 class Type;
 class TypeWalker;
+struct ExistentialLayout;
 
 /// \brief Type substitution mapping from substitutable types to their
 /// replacements.
@@ -410,16 +411,15 @@ public:
   /// Given that this type is an existential, return its
   /// protocols in a canonical order.
   void getExistentialTypeProtocols(
-                                SmallVectorImpl<ProtocolDecl *> &protocols) {
-    return getExistentialTypeProtocolsImpl(*this, protocols);
-  }
+      SmallVectorImpl<ProtocolDecl *> &protocols);
 
   /// Given that this type is any kind of existential, return its
   /// protocols in a canonical order.
   void getAnyExistentialTypeProtocols(
-                                SmallVectorImpl<ProtocolDecl *> &protocols) {
-    return getAnyExistentialTypeProtocolsImpl(*this, protocols);
-  }
+      SmallVectorImpl<ProtocolDecl *> &protocols);
+
+  /// Break an existential down into a set of constraints.
+  ExistentialLayout getExistentialLayout();
 
   /// Is this an ObjC-compatible existential type?
   bool isObjCExistentialType() const {

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3689,10 +3689,11 @@ private:
   static ProtocolCompositionType *build(const ASTContext &C,
                                         ArrayRef<Type> Protocols);
 
-  ProtocolCompositionType(const ASTContext *Ctx, ArrayRef<Type> Protocols)
-    : TypeBase(TypeKind::ProtocolComposition, /*Context=*/Ctx,
-               RecursiveTypeProperties()),
-      Protocols(Protocols) { }
+  ProtocolCompositionType(const ASTContext *ctx, ArrayRef<Type> protocols,
+                          RecursiveTypeProperties properties)
+    : TypeBase(TypeKind::ProtocolComposition, /*Context=*/ctx,
+               properties),
+      Protocols(protocols) { }
 };
 BEGIN_CAN_TYPE_WRAPPER(ProtocolCompositionType, Type)
   /// In the canonical representation, these are all ProtocolTypes.

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -4556,8 +4556,13 @@ inline bool TypeBase::mayHaveSuperclass() {
   if (getClassOrBoundGenericClass())
     return true;
 
+  // FIXME: requiresClass() is not the same as having an explicit superclass;
+  // is this wrong?
   if (auto archetype = getAs<ArchetypeType>())
     return (bool)archetype->requiresClass();
+
+  if (isExistentialType())
+    return (bool)getSuperclass(nullptr);
 
   return is<DynamicSelfType>();
 }

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3669,9 +3669,6 @@ public:
   /// \brief Retrieve the set of protocols composed to create this type.
   ArrayRef<Type> getProtocols() const { return Protocols; }
 
-  /// \brief Return the protocols of this type in canonical order.
-  void getAnyExistentialTypeProtocols(SmallVectorImpl<ProtocolDecl *> &protos);
-
   void Profile(llvm::FoldingSetNodeID &ID) {
     Profile(ID, Protocols);
   }

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3605,7 +3605,7 @@ public:
   }
 
   /// True if only classes may conform to the protocol.
-  bool requiresClass() const;
+  bool requiresClass();
 
   // Implement isa/cast/dyncast/etc.
   static bool classof(const TypeBase *T) {
@@ -3678,7 +3678,7 @@ public:
   static void Profile(llvm::FoldingSetNodeID &ID, ArrayRef<Type> Protocols);
 
   /// True if one or more of the protocols is class.
-  bool requiresClass() const;
+  bool requiresClass();
   
   // Implement isa/cast/dyncast/etc.
   static bool classof(const TypeBase *T) {

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -584,6 +584,9 @@ public:
   /// its list of protocols.
   void getAnyExistentialTypeProtocols(SmallVectorImpl<ProtocolDecl *> &protocols);
 
+  /// Break an existential down into a set of constraints.
+  ExistentialLayout getExistentialLayout();
+
   /// Determines the element type of a known *UnsafeMutablePointer
   /// variant, or returns null if the type is not a pointer.
   Type getAnyPointerElementType(PointerTypeKind &PTK);

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -162,6 +162,9 @@ namespace swift {
     /// optimized custom allocator, so that memory debugging tools can be used.
     bool UseMalloc = false;
 
+    /// \brief Enable classes to appear in protocol composition types.
+    bool EnableExperimentalSubclassExistentials = false;
+
     /// \brief Enable experimental property behavior feature.
     bool EnableExperimentalPropertyBehaviors = false;
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -267,6 +267,10 @@ def enable_experimental_deserialization_recovery :
   Flag<["-"], "enable-experimental-deserialization-recovery">,
   HelpText<"Attempt to recover from missing xrefs (etc) in swiftmodules">;
 
+def enable_experimental_subclass_existentials : Flag<["-"],
+  "enable-experimental-subclass-existentials">,
+  HelpText<"Enable classes to appear in protocol composition types">;
+
 def enable_cow_existentials : Flag<["-"], "enable-cow-existentials">,
   HelpText<"Enable the copy-on-write existential implementation">;
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2727,16 +2727,16 @@ ProtocolDecl::getInheritedProtocols() const {
   // FIXME: Gather inherited protocols from the "inherited" list.
   // We shouldn't need this, but it shows up in recursive invocations.
   if (!isRequirementSignatureComputed()) {
+    SmallPtrSet<ProtocolDecl *, 4> known;
     for (auto inherited : getInherited()) {
-      SmallPtrSet<ProtocolDecl *, 4> known;
       if (auto type = inherited.getType()) {
-        if (type->isExistentialType()) {
-          SmallVector<ProtocolDecl *, 4> protocols;
-          type->getExistentialTypeProtocols(protocols);
-          for (auto proto : protocols) {
-            if (known.insert(proto).second)
-              result.push_back(proto);
-          }
+        // Only protocols can appear in the inheritance clause
+        // of a protocol -- anything else should get diagnosed
+        // elsewhere.
+        if (auto *protoTy = type->getAs<ProtocolType>()) {
+          auto *protoDecl = protoTy->getDecl();
+          if (known.insert(protoDecl).second)
+            result.push_back(protoDecl);
         }
       }
     }

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1321,6 +1321,7 @@ MemberRefExpr::MemberRefExpr(Expr *base, SourceLoc dotLoc,
    
   MemberRefExprBits.Semantics = (unsigned) semantics;
   MemberRefExprBits.IsSuper = false;
+  assert(Member);
 }
 
 Type OverloadSetRefExpr::getBaseType() const {

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -22,6 +22,7 @@
 #include "swift/AST/ASTWalker.h"
 #include "swift/AST/Builtins.h"
 #include "swift/AST/DiagnosticsSema.h"
+#include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/LazyResolver.h"
 #include "swift/AST/LinkLibrary.h"
@@ -586,6 +587,7 @@ ModuleDecl::lookupConformance(Type type, ProtocolDecl *protocol,
       }
     }
 
+    // FIXME: This will go away soon.
     if (protocol->isSpecificProtocol(KnownProtocolKind::AnyObject)) {
       if (archetype->requiresClass())
         return ProtocolConformanceRef(protocol);
@@ -605,35 +607,38 @@ ModuleDecl::lookupConformance(Type type, ProtocolDecl *protocol,
   // existential's list of conformances and the existential conforms to
   // itself.
   if (type->isExistentialType()) {
-    SmallVector<ProtocolDecl *, 4> protocols;
-    type->getExistentialTypeProtocols(protocols);
-
-    // Due to an IRGen limitation, witness tables cannot be passed from an
-    // existential to an archetype parameter, so for now we restrict this to
-    // @objc protocols.
-    for (auto proto : protocols) {
-      if (!proto->isObjC() &&
-          !proto->isSpecificProtocol(KnownProtocolKind::AnyObject))
-        return None;
-    }
-
     // If the existential type cannot be represented or the protocol does not
     // conform to itself, there's no point in looking further.
     if (!protocol->existentialConformsToSelf() ||
         !protocol->existentialTypeSupported(resolver))
       return None;
 
-    // Special-case AnyObject, which may not be in the list of conformances.
-    if (protocol->isSpecificProtocol(KnownProtocolKind::AnyObject)) {
-      if (type->isClassExistentialType())
-        return ProtocolConformanceRef(protocol);
+    auto layout = type->getExistentialLayout();
 
+    // Due to an IRGen limitation, witness tables cannot be passed from an
+    // existential to an archetype parameter, so for now we restrict this to
+    // @objc protocols.
+    if (!layout.isObjC())
       return None;
+
+    // Special-case AnyObject, which may not be in the list of conformances.
+    //
+    // FIXME: This is going away soon.
+    if (protocol->isSpecificProtocol(KnownProtocolKind::AnyObject))
+      return ProtocolConformanceRef(protocol);
+
+    // If the existential is class-constrained, the class might conform
+    // concretely.
+    if (layout.superclass) {
+      if (auto result = lookupConformance(layout.superclass, protocol,
+                                          resolver))
+        return result;
     }
 
-    // Look for this protocol within the existential's list of conformances.
-    for (auto proto : protocols) {
-      if (proto == protocol || proto->inheritsFrom(protocol))
+    // Otherwise, the existential might conform abstractly.
+    for (auto proto : layout.getProtocols()) {
+      auto *protoDecl = proto->getDecl();
+      if (protoDecl == protocol || protoDecl->inheritsFrom(protocol))
         return ProtocolConformanceRef(protocol);
     }
 

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1574,8 +1574,11 @@ Type TypeBase::getSuperclass(LazyResolver *resolver) {
     if (auto dynamicSelfTy = getAs<DynamicSelfType>())
       return dynamicSelfTy->getSelfType();
 
+    if (auto compositionTy = getAs<ProtocolCompositionType>())
+      return compositionTy->getExistentialLayout().superclass;
+
     // No other types have superclasses.
-    return nullptr;
+    return Type();
   }
 
   // We have a class, so get the superclass type.

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2744,21 +2744,12 @@ void ProtocolCompositionType::Profile(llvm::FoldingSetNodeID &ID,
     ID.AddPointer(P.getPointer());
 }
 
-bool ProtocolType::requiresClass() const {
+bool ProtocolType::requiresClass() {
   return getDecl()->requiresClass();
 }
 
-bool ProtocolCompositionType::requiresClass() const {
-  for (Type t : getProtocols()) {
-    if (const ProtocolType *proto = t->getAs<ProtocolType>()) {
-      if (proto->requiresClass())
-        return true;
-    } else {
-      if (t->castTo<ProtocolCompositionType>()->requiresClass())
-        return true;
-    }
-  }
-  return false;
+bool ProtocolCompositionType::requiresClass() {
+  return getExistentialLayout().requiresClass;
 }
 
 Type ProtocolCompositionType::get(const ASTContext &C,

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -871,6 +871,9 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.EnableExperimentalPropertyBehaviors |=
     Args.hasArg(OPT_enable_experimental_property_behaviors);
 
+  Opts.EnableExperimentalSubclassExistentials |=
+    Args.hasArg(OPT_enable_experimental_subclass_existentials);
+
   Opts.EnableClassResilience |=
     Args.hasArg(OPT_enable_class_resilience);
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -19,6 +19,7 @@
 #include "ConstraintSystem.h"
 #include "swift/AST/ASTVisitor.h"
 #include "swift/AST/ASTWalker.h"
+#include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/SubstitutionMap.h"
@@ -52,10 +53,7 @@ static bool isOpenedAnyObject(Type type) {
   if (!existential)
     return false;
 
-  SmallVector<ProtocolDecl *, 2> protocols;
-  existential->getExistentialTypeProtocols(protocols);
-  return protocols.size() == 1 &&
-         protocols[0]->isSpecificProtocol(KnownProtocolKind::AnyObject);
+  return existential->isAnyObject();
 }
 
 void Solution::computeSubstitutions(
@@ -4600,13 +4598,12 @@ Expr *ExprRewriter::coerceScalarToTuple(Expr *expr, TupleType *toTuple,
 static ArrayRef<ProtocolConformanceRef>
 collectExistentialConformances(TypeChecker &tc, Type fromType, Type toType,
                                DeclContext *DC) {
-  SmallVector<ProtocolDecl *, 4> protocols;
-  toType->getExistentialTypeProtocols(protocols);
+  auto layout = toType->getExistentialLayout();
 
   SmallVector<ProtocolConformanceRef, 4> conformances;
-  for (auto proto : protocols) {
+  for (auto proto : layout.getProtocols()) {
     conformances.push_back(
-      *tc.containsProtocol(fromType, proto, DC,
+      *tc.containsProtocol(fromType, proto->getDecl(), DC,
                            (ConformanceCheckFlags::InExpression|
                             ConformanceCheckFlags::Used)));
   }

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -442,7 +442,7 @@ static bool isProtocolExtensionAsSpecializedAs(TypeChecker &tc,
   // Form a constraint system where we've opened up all of the requirements of
   // the second protocol extension.
   ConstraintSystem cs(tc, dc1, None);
-  llvm::DenseMap<CanType, TypeVariableType *> replacements;
+  OpenedTypeMap replacements;
   cs.openGeneric(dc2, dc2, sig2,
                  /*skipProtocolSelfConstraint=*/false,
                  ConstraintLocatorBuilder(nullptr),
@@ -453,7 +453,7 @@ static bool isProtocolExtensionAsSpecializedAs(TypeChecker &tc,
   Type selfType1 = sig1->getGenericParams()[0];
   Type selfType2 = sig2->getGenericParams()[0];
   cs.addConstraint(ConstraintKind::Bind,
-                   replacements[selfType2->getCanonicalType()],
+                   replacements[cast<GenericTypeParamType>(selfType2->getCanonicalType())],
                    dc1->mapTypeIntoContext(selfType1),
                    nullptr);
 
@@ -568,7 +568,7 @@ static bool isDeclAsSpecializedAs(TypeChecker &tc, DeclContext *dc,
       auto locator = cs.getConstraintLocator(nullptr);
       // FIXME: Locator when anchored on a declaration.
       // Get the type of a reference to the second declaration.
-      llvm::DenseMap<CanType, TypeVariableType *> unused;
+      OpenedTypeMap unused;
       Type openedType2;
       if (auto *funcType = type2->getAs<AnyFunctionType>()) {
         openedType2 = cs.openFunctionType(
@@ -583,7 +583,7 @@ static bool isDeclAsSpecializedAs(TypeChecker &tc, DeclContext *dc,
 
       // Get the type of a reference to the first declaration, swapping in
       // archetypes for the dependent types.
-      llvm::DenseMap<CanType, TypeVariableType *> replacements;
+      OpenedTypeMap replacements;
       auto dc1 = decl1->getInnermostDeclContext();
       Type openedType1;
       if (auto *funcType = type1->getAs<AnyFunctionType>()) {

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3760,7 +3760,9 @@ retry:
 
     // If our type constraints is for a FunctionType, move over the @noescape
     // flag.
-    if (func1->isNoEscape() && !func2->isNoEscape()) {
+    if (func1->isNoEscape() &&
+        !func2->isNoEscape() &&
+        func2->hasTypeVariable()) {
       auto &extraExtInfo = extraFunctionAttrs[func2];
       extraExtInfo = extraExtInfo.withNoEscape();
     }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -16,6 +16,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "ConstraintSystem.h"
+#include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/ParameterList.h"
 #include "swift/Basic/StringExtras.h"
 #include "swift/ClangImporter/ClangModule.h"
@@ -1180,11 +1181,28 @@ ConstraintSystem::matchExistentialTypes(Type type1, Type type2,
   if (!type2->isExistentialType())
     return SolutionKind::Error;
 
-  SmallVector<ProtocolDecl *, 4> protocols;
-  type2->getExistentialTypeProtocols(protocols);
+  auto layout = type2->getExistentialLayout();
 
-  for (auto proto : protocols) {
-    switch (simplifyConformsToConstraint(type1, proto, kind, locator,
+  assert((!layout.requiresClass || layout.requiresClassImplied) &&
+         "explicit AnyObject not yet supported");
+
+  if (layout.superclass) {
+    llvm::errs() << "superclass case\n";
+    auto subKind = std::min(ConstraintKind::Subtype, kind);
+    switch (matchTypes(type1, layout.superclass, subKind, subflags, locator)) {
+    case SolutionKind::Solved:
+    case SolutionKind::Unsolved:
+      break;
+
+    case SolutionKind::Error:
+      return SolutionKind::Error;
+    }
+  }
+
+  for (auto *proto : layout.getProtocols()) {
+    auto *protoDecl = proto->getDecl();
+
+    switch (simplifyConformsToConstraint(type1, protoDecl, kind, locator,
                                          subflags)) {
       case SolutionKind::Solved:
       case SolutionKind::Unsolved:
@@ -1809,14 +1827,14 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
     }
 
     // Subclass-to-superclass conversion.
-    if (type1->mayHaveSuperclass() && type2->mayHaveSuperclass() &&
+    if (type1->mayHaveSuperclass() &&
+        type2->mayHaveSuperclass() &&
         type2->getClassOrBoundGenericClass() &&
         type1->getClassOrBoundGenericClass()
           != type2->getClassOrBoundGenericClass()) {
-      assert(!type2->is<LValueType>() && "Unexpected lvalue type!");
       conversionsOrFixes.push_back(ConversionRestrictionKind::Superclass);
     }
-    
+
     // T -> AnyHashable.
     if (isAnyHashableType(desugar2)) {
       // Don't allow this in operator contexts or we'll end up allowing
@@ -2059,18 +2077,31 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
   // equivalent to a conformance relationship on the instance types.
   // This applies to nested metatype levels, so if A : P then
   // A.Type : P.Type.
-  if (concrete && kind >= ConstraintKind::Subtype &&
-      type1->is<MetatypeType>() && type2->is<ExistentialMetatypeType>()) {
+  if (concrete &&
+      kind >= ConstraintKind::Subtype &&
+      type1->is<MetatypeType>() &&
+      type2->is<ExistentialMetatypeType>()) {
     conversionsOrFixes.push_back(
       ConversionRestrictionKind::MetatypeToExistentialMetatype);
   }
-  
+
+  // An existential metatype can be upcast to a class metatype if the
+  // existential contains a superclass constraint.
+  if (concrete &&
+      kind >= ConstraintKind::Subtype &&
+      type1->is<ExistentialMetatypeType>() &&
+      type2->is<MetatypeType>()) {
+    conversionsOrFixes.push_back(
+      ConversionRestrictionKind::ExistentialMetatypeToMetatype);
+  }
+
   // Instance type check for the above. We are going to check conformance once
   // we hit commit_to_conversions below, but we have to add a token restriction
   // to ensure we wrap the metatype value in a metatype erasure.
-  if (concrete && type2->isExistentialType() &&
+  if (concrete &&
+      kind >= ConstraintKind::Subtype &&
       !type1->is<LValueType>() &&
-      kind >= ConstraintKind::Subtype) {
+      type2->isExistentialType()) {
 
     // Penalize conversions to Any.
     if (kind >= ConstraintKind::Conversion && type2->isAny())
@@ -3893,10 +3924,10 @@ ConstraintSystem::simplifyRestrictedConstraintImpl(
                                  subflags, locator);
 
   // for $< in { <, <c, <oc }:
-  //   for T protocol,
-  //     T : S ===> T.Protocol $< S.Type
-  //   else,
-  //     T : S ===> T.Type $< S.Type
+  //   for P protocol, Q protocol,
+  //     P : Q ===> T.Protocol $< Q.Type
+  //   for P protocol, Q protocol,
+  //     P $< Q ===> P.Type $< Q.Type
   case ConversionRestrictionKind::MetatypeToExistentialMetatype:
     addContextualScore();
 
@@ -3907,6 +3938,27 @@ ConstraintSystem::simplifyRestrictedConstraintImpl(
              subflags,
              locator.withPathElement(ConstraintLocator::InstanceType));
 
+  // for $< in { <, <c, <oc }:
+  //   for P protocol, C class, D class,
+  //     (P & C) : D ===> (P & C).Type $< D.Type
+  case ConversionRestrictionKind::ExistentialMetatypeToMetatype: {
+    addContextualScore();
+
+    auto instance1 = type1->castTo<ExistentialMetatypeType>()->getInstanceType();
+    auto instance2 = type2->castTo<MetatypeType>()->getInstanceType();
+    auto superclass1 = TC.getSuperClassOf(instance1);
+
+    if (!superclass1)
+      return SolutionKind::Error;
+
+    return matchTypes(
+             superclass1,
+             instance2,
+             ConstraintKind::Subtype,
+             subflags,
+             locator.withPathElement(ConstraintLocator::InstanceType));
+
+  }
   // for $< in { <, <c, <oc }:
   //   T $< U ===> T $< U?
   case ConversionRestrictionKind::ValueToOptional: {

--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -371,6 +371,8 @@ StringRef swift::constraints::getName(ConversionRestrictionKind kind) {
     return "[existential]";
   case ConversionRestrictionKind::MetatypeToExistentialMetatype:
     return "[metatype-to-existential-metatype]";
+  case ConversionRestrictionKind::ExistentialMetatypeToMetatype:
+    return "[existential-metatype-to-metatype]";
   case ConversionRestrictionKind::ValueToOptional:
     return "[value-to-optional]";
   case ConversionRestrictionKind::OptionalToOptional:

--- a/lib/Sema/Constraint.h
+++ b/lib/Sema/Constraint.h
@@ -187,6 +187,8 @@ enum class ConversionRestrictionKind {
   Existential,
   /// Metatype to existential metatype conversion.
   MetatypeToExistentialMetatype,
+  /// Existential metatype to metatype conversion.
+  ExistentialMetatypeToMetatype,
   /// T -> U? value to optional conversion (or to implicitly unwrapped optional).
   ValueToOptional,
   /// T? -> U? optional to optional conversion (or unchecked to unchecked).

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1214,10 +1214,12 @@ ConstraintSystem::getTypeOfMemberReference(
     type = openedFnType->replaceSelfParameterType(baseObjTy);
   }
 
-  // When accessing members of an existential, replace the 'Self' type
-  // parameter with the existential type, since formally the access will
-  // operate on existentials and not type parameters.
-  if (!isDynamicResult && baseObjTy->isExistentialType()) {
+  // When accessing protocol members with an existential base, replace
+  // the 'Self' type parameter with the existential type, since formally
+  // the access will operate on existentials and not type parameters.
+  if (!isDynamicResult &&
+      baseObjTy->isExistentialType() &&
+      outerDC->getAsProtocolOrProtocolExtensionContext()) {
     auto selfTy = replacements[
       cast<GenericTypeParamType>(outerDC->getSelfInterfaceType()
                                  ->getCanonicalType())];
@@ -1226,7 +1228,7 @@ ConstraintSystem::getTypeOfMemberReference(
         t = selfTy->getSelfType();
       if (t->is<TypeVariableType>())
         if (t->isEqual(selfTy))
-        return baseObjTy;
+          return baseObjTy;
       if (auto *metatypeTy = t->getAs<MetatypeType>())
         if (metatypeTy->getInstanceType()->isEqual(selfTy))
           return ExistentialMetatypeType::get(baseObjTy);

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -355,14 +355,13 @@ namespace {
   class ReplaceDependentTypes {
     ConstraintSystem &cs;
     ConstraintLocatorBuilder &locator;
-    llvm::DenseMap<CanType, TypeVariableType *> &replacements;
-    llvm::DenseMap<CanType, Type> dependentMemberReplacements;
+    OpenedTypeMap &replacements;
 
   public:
     ReplaceDependentTypes(
         ConstraintSystem &cs,
         ConstraintLocatorBuilder &locator,
-        llvm::DenseMap<CanType, TypeVariableType *> &replacements)
+        OpenedTypeMap &replacements)
       : cs(cs), locator(locator), replacements(replacements) { }
 
     Type operator()(Type type) {
@@ -371,7 +370,8 @@ namespace {
 
       // Replace a generic type parameter with its corresponding type variable.
       if (auto genericParam = type->getAs<GenericTypeParamType>()) {
-        auto known = replacements.find(genericParam->getCanonicalType());
+        auto known = replacements.find(
+          cast<GenericTypeParamType>(genericParam->getCanonicalType()));
         
         if (known == replacements.end())
           return cs.createTypeVariable(nullptr, TVO_PrefersSubtypeBinding);
@@ -382,21 +382,11 @@ namespace {
       // Replace a dependent member with a fresh type variable and make it a
       // member of its base type.
       if (auto dependentMember = type->getAs<DependentMemberType>()) {
-        // Check whether we've already dealt with this dependent member.
-        auto known = dependentMemberReplacements.find(
-                       dependentMember->getCanonicalType());
-        if (known != dependentMemberReplacements.end())
-          return known->second;
-
-        // Replace archetypes in the base type.
-        // FIXME: Tracking the dependent members seems unnecessary.
+        // Replace type parameters in the base type.
         if (auto base =
             ((*this)(dependentMember->getBase()))->getAs<TypeVariableType>()) {
-          auto result =
+          return
             DependentMemberType::get(base, dependentMember->getAssocType());
-          dependentMemberReplacements[dependentMember->getCanonicalType()] =
-            result;
-          return result;
         }
       }
 
@@ -421,7 +411,7 @@ namespace {
           return ErrorType::get(type);
         }
 
-        llvm::DenseMap<CanType, TypeVariableType *> unboundReplacements;
+        OpenedTypeMap unboundReplacements;
 
         // Open up the generic type.
         cs.openGeneric(unboundDecl->getInnermostDeclContext(),
@@ -435,7 +425,8 @@ namespace {
         // Map the generic parameters to their corresponding type variables.
         llvm::SmallVector<TypeLoc, 4> arguments;
         for (auto gp : unboundDecl->getInnermostGenericParamTypes()) {
-          auto found = unboundReplacements.find(gp->getCanonicalType());
+          auto found = unboundReplacements.find(
+            cast<GenericTypeParamType>(gp->getCanonicalType()));
           assert(found != unboundReplacements.end() &&
                  "Missing generic parameter?");
           arguments.push_back(TypeLoc::withoutLoc(found->second));
@@ -461,7 +452,7 @@ namespace {
 Type ConstraintSystem::openType(
        Type startingType,
        ConstraintLocatorBuilder locator,
-       llvm::DenseMap<CanType, TypeVariableType *> &replacements) {
+       OpenedTypeMap &replacements) {
   if (!startingType->hasTypeParameter() &&
       !startingType->hasUnboundGenericType())
     return startingType;
@@ -498,7 +489,7 @@ Type ConstraintSystem::openFunctionType(
        AnyFunctionType *funcType,
        unsigned numArgumentLabelsToRemove,
        ConstraintLocatorBuilder locator,
-       llvm::DenseMap<CanType, TypeVariableType *> &replacements,
+       OpenedTypeMap &replacements,
        DeclContext *innerDC,
        DeclContext *outerDC,
        bool skipProtocolSelfConstraint) {
@@ -645,7 +636,7 @@ Type ConstraintSystem::getFixedTypeRecursive(Type type,
 
 void ConstraintSystem::recordOpenedTypes(
        ConstraintLocatorBuilder locator,
-       const llvm::DenseMap<CanType, TypeVariableType *> &replacements) {
+       const OpenedTypeMap &replacements) {
   if (replacements.empty())
     return;
 
@@ -720,7 +711,7 @@ ConstraintSystem::getTypeOfReference(ValueDecl *value,
                                      FunctionRefKind functionRefKind,
                                      ConstraintLocatorBuilder locator,
                                      const DeclRefExpr *base) {
-  llvm::DenseMap<CanType, TypeVariableType *> replacements;
+  OpenedTypeMap replacements;
 
   if (value->getDeclContext()->isTypeContext() && isa<FuncDecl>(value)) {
     // Unqualified lookup can find operator names within nominal types.
@@ -829,7 +820,7 @@ void ConstraintSystem::openGeneric(
        GenericSignature *signature,
        bool skipProtocolSelfConstraint,
        ConstraintLocatorBuilder locator,
-       llvm::DenseMap<CanType, TypeVariableType *> &replacements) {
+       OpenedTypeMap &replacements) {
   openGeneric(innerDC,
               outerDC,
               signature->getGenericParams(),
@@ -874,7 +865,7 @@ static void bindArchetypesFromContext(
     ConstraintSystem &cs,
     DeclContext *outerDC,
     ConstraintLocator *locatorPtr,
-    const llvm::DenseMap<CanType, TypeVariableType *> &replacements) {
+    const OpenedTypeMap &replacements) {
 
   auto *genericEnv = outerDC->getGenericEnvironmentOfContext();
 
@@ -891,7 +882,8 @@ static void bindArchetypesFromContext(
       break;
 
     for (auto *paramTy : genericSig->getGenericParams()) {
-      auto found = replacements.find(paramTy->getCanonicalType());
+      auto found = replacements.find(cast<GenericTypeParamType>(
+                                       paramTy->getCanonicalType()));
 
       // We might not have a type variable for this generic parameter
       // because either we're opening up an UnboundGenericType,
@@ -917,7 +909,7 @@ void ConstraintSystem::openGeneric(
        ArrayRef<Requirement> requirements,
        bool skipProtocolSelfConstraint,
        ConstraintLocatorBuilder locator,
-       llvm::DenseMap<CanType, TypeVariableType *> &replacements) {
+       OpenedTypeMap &replacements) {
   auto locatorPtr = getConstraintLocator(locator);
   auto *genericEnv = innerDC->getGenericEnvironmentOfContext();
 
@@ -932,7 +924,8 @@ void ConstraintSystem::openGeneric(
                                       TVO_PrefersSubtypeBinding |
                                       TVO_MustBeMaterializable);
     auto result = replacements.insert(
-        std::make_pair(gp->getCanonicalType(), typeVar));
+      std::make_pair(cast<GenericTypeParamType>(gp->getCanonicalType()),
+                     typeVar));
     assert(result.second);
     (void) result;
   }
@@ -1033,7 +1026,7 @@ ConstraintSystem::getTypeOfMemberReference(
     FunctionRefKind functionRefKind,
     ConstraintLocatorBuilder locator,
     const DeclRefExpr *base,
-    llvm::DenseMap<CanType, TypeVariableType *> *replacementsPtr) {
+    OpenedTypeMap *replacementsPtr) {
   // Figure out the instance type used for the base.
   Type baseObjTy = getFixedTypeRecursive(baseTy, /*wantRValue=*/true);
   bool isInstance = true;
@@ -1077,7 +1070,7 @@ ConstraintSystem::getTypeOfMemberReference(
 
   // Open the type of the generic function or member of a generic type.
   Type openedType;
-  llvm::DenseMap<CanType, TypeVariableType *> localReplacements;
+  OpenedTypeMap localReplacements;
   auto &replacements = replacementsPtr ? *replacementsPtr : localReplacements;
   bool isCurriedInstanceReference = value->isInstanceMember() && !isInstance;
   unsigned numRemovedArgumentLabels =
@@ -1225,8 +1218,9 @@ ConstraintSystem::getTypeOfMemberReference(
   // parameter with the existential type, since formally the access will
   // operate on existentials and not type parameters.
   if (!isDynamicResult && baseObjTy->isExistentialType()) {
-    auto selfTy = replacements[outerDC->getSelfInterfaceType()
-          ->getCanonicalType()];
+    auto selfTy = replacements[
+      cast<GenericTypeParamType>(outerDC->getSelfInterfaceType()
+                                 ->getCanonicalType())];
     type = type.transform([&](Type t) -> Type {
       if (auto *selfTy = t->getAs<DynamicSelfType>())
         t = selfTy->getSelfType();

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1654,6 +1654,9 @@ Type simplifyTypeImpl(ConstraintSystem &cs, Type type, Fn getFixedTypeFn) {
 }
 
 Type ConstraintSystem::simplifyType(Type type) {
+  if (!type->hasTypeVariable())
+    return type;
+
   // Map type variables down to the fixed types of their representatives.
   return simplifyTypeImpl(
       *this, type,
@@ -1668,6 +1671,9 @@ Type ConstraintSystem::simplifyType(Type type) {
 }
 
 Type Solution::simplifyType(Type type) const {
+  if (!type->hasTypeVariable())
+    return type;
+
   // Map type variables to fixed types from bindings.
   return simplifyTypeImpl(
       getConstraintSystem(), type,

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -494,7 +494,9 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &out, const Score &score);
 
 /// Describes a dependent type that has been opened to a particular type
 /// variable.
-typedef std::pair<CanType, TypeVariableType *> OpenedType;
+typedef std::pair<GenericTypeParamType *, TypeVariableType *> OpenedType;
+
+typedef llvm::DenseMap<GenericTypeParamType *, TypeVariableType *> OpenedTypeMap;
 
 /// \brief A complete solution to a constraint system.
 ///
@@ -1874,7 +1876,7 @@ public:
   ///
   /// \returns The opened type.
   Type openType(Type type, ConstraintLocatorBuilder locator) {
-    llvm::DenseMap<CanType, TypeVariableType *> replacements;
+    OpenedTypeMap replacements;
     return openType(type, locator, replacements);
   }
 
@@ -1889,7 +1891,7 @@ public:
   /// \returns The opened type, or \c type if there are no archetypes in it.
   Type openType(Type type,
                 ConstraintLocatorBuilder locator,
-                llvm::DenseMap<CanType, TypeVariableType *> &replacements);
+                OpenedTypeMap &replacements);
 
   /// \brief "Open" the given function type.
   ///
@@ -1914,7 +1916,7 @@ public:
       AnyFunctionType *funcType,
       unsigned numArgumentLabelsToRemove,
       ConstraintLocatorBuilder locator,
-      llvm::DenseMap<CanType, TypeVariableType *> &replacements,
+      OpenedTypeMap &replacements,
       DeclContext *innerDC,
       DeclContext *outerDC,
       bool skipProtocolSelfConstraint);
@@ -1938,19 +1940,19 @@ public:
                    GenericSignature *signature,
                    bool skipProtocolSelfConstraint,
                    ConstraintLocatorBuilder locator,
-                   llvm::DenseMap<CanType, TypeVariableType *> &replacements);
+                   OpenedTypeMap &replacements);
   void openGeneric(DeclContext *innerDC,
                    DeclContext *outerDC,
                    ArrayRef<GenericTypeParamType *> params,
                    ArrayRef<Requirement> requirements,
                    bool skipProtocolSelfConstraint,
                    ConstraintLocatorBuilder locator,
-                   llvm::DenseMap<CanType, TypeVariableType *> &replacements);
+                   OpenedTypeMap &replacements);
 
   /// Record the set of opened types for the given locator.
   void recordOpenedTypes(
          ConstraintLocatorBuilder locator,
-         const llvm::DenseMap<CanType, TypeVariableType *> &replacements);
+         const OpenedTypeMap &replacements);
 
   /// \brief Retrieve the type of a reference to the given value declaration.
   ///
@@ -1997,8 +1999,7 @@ public:
                           FunctionRefKind functionRefKind,
                           ConstraintLocatorBuilder locator,
                           const DeclRefExpr *base = nullptr,
-                          llvm::DenseMap<CanType, TypeVariableType *>
-                            *replacements = nullptr);
+                          OpenedTypeMap *replacements = nullptr);
 
   /// \brief Add a new overload set to the list of unresolved overload
   /// sets.

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -611,24 +611,23 @@ public:
   /// contains a value.
   Expr *convertOptionalToBool(Expr *expr, ConstraintLocator *locator) const;
 
-  /// Compute the set of substitutions required to map the given type
-  /// to the provided "opened" type.
+  /// Compute the set of substitutions for a generic signature opened at the
+  /// given locator.
   ///
   /// \param sig The generic signature.
-  ///
-  /// \param openedType The type to which this reference to the given
-  /// generic function type was opened.
   ///
   /// \param locator The locator that describes where the substitutions came
   /// from.
   ///
   /// \param substitutions Will be populated with the set of substitutions
   /// to be applied to the generic function type.
-  ///
-  /// \returns The opened type after applying the computed substitutions.
-  Type computeSubstitutions(GenericSignature *sig,
-                            Type openedType,
+  void computeSubstitutions(GenericSignature *sig,
                             ConstraintLocator *locator,
+                            SmallVectorImpl<Substitution> &substitutions) const;
+
+  /// Same as above but with a lazily-constructed locator.
+  void computeSubstitutions(GenericSignature *sig,
+                            ConstraintLocatorBuilder locator,
                             SmallVectorImpl<Substitution> &substitutions) const;
 
   /// Return the disjunction choice for the given constraint location.

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2694,7 +2694,7 @@ void Solution::dump(raw_ostream &out) const {
       out << " opens ";
       interleave(opened.second.begin(), opened.second.end(),
                  [&](OpenedType opened) {
-                   opened.first.print(out);
+                   opened.first->print(out);
                    out << " -> ";
                    opened.second->print(out);
                  },
@@ -2852,7 +2852,7 @@ void ConstraintSystem::print(raw_ostream &out) {
       out << " opens ";
       interleave(opened.second.begin(), opened.second.end(),
                  [&](OpenedType opened) {
-                   opened.first.print(out);
+                   opened.first->print(out);
                    out << " -> ";
                    opened.second->print(out);
                  },

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -24,6 +24,7 @@
 #include "swift/AST/ASTPrinter.h"
 #include "swift/AST/ASTVisitor.h"
 #include "swift/AST/ASTWalker.h"
+#include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/Expr.h"
 #include "swift/AST/ForeignErrorConvention.h"
 #include "swift/AST/GenericEnvironment.h"
@@ -442,10 +443,11 @@ void TypeChecker::checkInheritanceClause(Decl *decl,
     // If this is a protocol or protocol composition type, record the
     // protocols.
     if (inheritedTy->isExistentialType()) {
-      SmallVector<ProtocolDecl *, 4> protocols;
-      inheritedTy->getExistentialTypeProtocols(protocols);
-
-      allProtocols.insert(protocols.begin(), protocols.end());
+      auto layout = inheritedTy->getExistentialLayout();
+      for (auto proto : layout.getProtocols()) {
+        auto *protoDecl = proto->getDecl();
+        allProtocols.insert(protoDecl);
+      }
       continue;
     }
     

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1282,17 +1282,11 @@ matchWitness(TypeChecker &tc,
                             witnessType,
                             optionalAdjustments);
 
-    // Record the substitutions.
-    if (openedFullWitnessType->hasTypeVariable()) {
-      // Figure out the context we're substituting into.
-      auto witnessDC = witness->getInnermostDeclContext();
-
-      // Compute the set of substitutions we'll need for the witness.
-      solution->computeSubstitutions(witnessDC->getGenericSignatureOfContext(),
-                                     openedFullWitnessType,
-                                     witnessLocator,
-                                     result.WitnessSubstitutions);
-    }
+    // Compute the set of substitutions we'll need for the witness.
+    solution->computeSubstitutions(
+      witness->getInnermostDeclContext()->getGenericSignatureOfContext(),
+      witnessLocator,
+      result.WitnessSubstitutions);
     
     return result;
   };

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -225,26 +225,43 @@ void TypeChecker::forceExternalDeclMembers(NominalTypeDecl *nominalDecl) {
 // Walk up through the type scopes to find the context containing the type
 // being resolved.
 //
+// Name lookup tells us that a given type is visible via unqualified
+// lookup from a given context. Since unqualified lookup visits outer
+// scopes, the type might be defined in an outer context, or a
+// conforming protocol or superclass thereof.
+//
 // FIXME: UnqualifiedLookup already has this information; it needs to be
 // plumbed through.
-static std::tuple<DeclContext *, NominalTypeDecl *, bool>
+//
+// Returns a tuple of the following:
+//
+// - Type: the empty type if the typeDecl is not defined inside another
+//   type. Otherwise, the base type to use for computing the substituted
+//   type of typeDecl.
+//
+//   This is either a type conforming to the protocol in which typeDecl
+//   can be found, or a concrete type that contains typeDecl.
+//
+// - bool: valid: false if the lookup failed.
+static std::tuple<Type, bool>
 findDeclContextForType(TypeChecker &TC,
                        TypeDecl *typeDecl,
                        DeclContext *fromDC,
-                       TypeResolutionOptions options) {
+                       TypeResolutionOptions options,
+                       GenericTypeResolver *resolver) {
 
   auto ownerDC = typeDecl->getDeclContext();
 
   // If the type is declared at the top level, there's nothing we can learn from
   // walking our parent contexts.
   if (ownerDC->isModuleScopeContext())
-    return std::make_tuple(ownerDC, nullptr, true);
+    return std::make_tuple(Type(), true);
 
   // Workaround for issue where generic typealias generic parameters are
   // looked up with the wrong 'fromDC'.
   if (isa<TypeAliasDecl>(ownerDC)) {
     assert(isa<GenericTypeParamDecl>(typeDecl));
-    return std::make_tuple(ownerDC, nullptr, true);
+    return std::make_tuple(Type(), true);
   }
 
   bool needsBaseType = (ownerDC->isTypeContext() &&
@@ -253,32 +270,71 @@ findDeclContextForType(TypeChecker &TC,
       ownerDC->getAsNominalTypeOrNominalTypeExtensionContext();
 
   // We might have an invalid extension that didn't resolve.
+  //
+  // FIXME: How did UnqualifiedLookup find the decl then?
   if (needsBaseType && ownerNominal == nullptr)
-    return std::make_tuple(nullptr, nullptr, false);
+    return std::make_tuple(Type(), false);
 
-  // First, check for containment in one of our parent contexts.
+  auto getSelfType = [&](DeclContext *DC) -> Type {
+    if (!needsBaseType)
+      return Type();
+
+    // When looking up a nominal type declaration inside of a
+    // protocol extension, always use the nominal type and
+    // not the protocol 'Self' type.
+    if (auto *nominalDecl = dyn_cast<NominalTypeDecl>(typeDecl))
+      return resolver->resolveTypeOfDecl(
+        DC->getAsNominalTypeOrNominalTypeExtensionContext());
+
+    // Otherwise, we want the protocol 'Self' type for
+    // substituting into alias types and associated types.
+    return resolver->resolveTypeOfContext(DC);
+  };
+
+  // First, check for direct containment in one of our parent contexts.
   for (auto parentDC = fromDC; !parentDC->isModuleContext();
        parentDC = parentDC->getParent()) {
     auto parentNominal =
         parentDC->getAsNominalTypeOrNominalTypeExtensionContext();
 
+    // If this type is defined in this exact context, we are done.
     if (ownerDC == parentDC)
-      return std::make_tuple(parentDC, parentNominal, true);
+      return std::make_tuple(getSelfType(parentDC), true);
 
+    // If we're inside a nominal type context and the member type
+    // is defined in a different extension, we are done.
+    if (parentNominal &&
+        parentNominal == ownerNominal)
+      return std::make_tuple(getSelfType(parentDC), true);
+
+    // An unqualified reference to the extended type from within
+    // an extension.
+    //
+    // An extension is formally nested in the module, and not in the
+    // parent type of the extended type -- so we need a special rule
+    // so that 'B' is visible below:
+    //
+    // struct A { struct B { } }
+    // extension A.B { ... B ... }
+    //
     if (isa<ExtensionDecl>(parentDC) && typeDecl == parentNominal) {
       assert(parentDC->getParent()->isModuleScopeContext());
-      return std::make_tuple(parentDC, parentNominal, true);
+      return std::make_tuple(getSelfType(parentDC), true);
     }
+
+    // We're going to check the next parent context.
 
     // FIXME: Horrible hack. Don't allow us to reference a generic parameter
     // from a context outside a ProtocolDecl.
     if (isa<ProtocolDecl>(parentDC) && isa<GenericTypeParamDecl>(typeDecl))
-      return std::make_tuple(nullptr, nullptr, false);
+      return std::make_tuple(Type(), false);
   }
 
+  // If we didn't find the member in an immediate parent context and
+  // there is no base type, something went wrong.
   if (!needsBaseType) {
     assert(false && "Should have found non-type context by now");
-    return std::make_tuple(nullptr, nullptr, false);
+    return std::make_tuple(Type(), false);
   }
 
   // Now, search the supertypes or refined protocols of each parent
@@ -290,74 +346,110 @@ findDeclContextForType(TypeChecker &TC,
       continue;
 
     llvm::SmallPtrSet<NominalTypeDecl *, 8> visited;
-    llvm::SmallVector<NominalTypeDecl *, 8> stack;
-
-    // Start with the type of the current context.
-    auto fromNominal = parentDC->getAsNominalTypeOrNominalTypeExtensionContext();
-    if (!fromNominal)
-      return std::make_tuple(nullptr, nullptr, false);
+    llvm::SmallVector<ProtocolDecl *, 8> protocols;
+    Type superclass;
 
     // Break circularity.
-    auto pushDecl = [&](NominalTypeDecl *nominal) -> void {
-      if (visited.insert(nominal).second)
-        stack.push_back(nominal);
+    auto pushProtocol = [&](ProtocolDecl *protocol) -> void {
+      if (visited.insert(protocol).second)
+        protocols.push_back(protocol);
     };
-    pushDecl(fromNominal);
 
-    // If we are in a protocol extension there might be other type aliases and
-    // nominal types brought into the context through requirements on Self,
-    // for example:
+    auto pushRefined = [&](ProtocolDecl *protocol) -> void {
+      for (auto *refined : protocol->getInheritedProtocols())
+        pushProtocol(refined);
+    };
+
+    // If we are in a protocol or protocol extension there might be other
+    // type aliases and nominal types brought into the context through
+    // requirements on Self, for example:
     //
     // extension MyProtocol where Self : YourProtocol { ... }
-    if (parentDC->getAsProtocolExtensionContext()) {
-      auto ED = cast<ExtensionDecl>(parentDC);
-      if (auto genericSig = ED->getGenericSignature()) {
-        for (auto req : genericSig->getRequirements()) {
-          if (req.getKind() == RequirementKind::Conformance ||
-              req.getKind() == RequirementKind::Superclass) {
-            if (req.getFirstType()->isEqual(ED->getSelfInterfaceType()))
-              if (auto *nominal = req.getSecondType()->getAnyNominal())
-                pushDecl(nominal);
+    //
+    // FIXME: If we want to support protocols inheriting classes, we need
+    // to walk the protocol requirement signature here.
+    if (auto *proto = parentDC->getAsProtocolOrProtocolExtensionContext()) {
+      pushRefined(proto);
+
+      if (auto ED = dyn_cast<ExtensionDecl>(parentDC)) {
+        if (auto genericSig = ED->getGenericSignature()) {
+          for (auto req : genericSig->getRequirements()) {
+            if (!req.getFirstType()->isEqual(ED->getSelfInterfaceType()))
+              continue;
+
+            switch (req.getKind()) {
+            case RequirementKind::Conformance:
+              pushProtocol(req.getSecondType()->castTo<ProtocolType>()->getDecl());
+              break;
+            case RequirementKind::Superclass: {
+              auto *classDecl = req.getSecondType()->getClassOrBoundGenericClass();
+
+              if (!options.contains(TR_InheritanceClause))
+                for (auto conforms : classDecl->getAllProtocols())
+                  pushProtocol(conforms);
+
+              assert(!superclass);
+              superclass = req.getSecondType();
+              break;
+            }
+            default:
+              break;
+            }
           }
         }
       }
+    } else {
+      // Get the substituted superclass type, if any.
+      superclass = resolver->resolveTypeOfContext(parentDC)
+        ->getSuperclass(nullptr);
+
+      // Start with the type of the current context.
+      auto fromNominal = parentDC->getAsNominalTypeOrNominalTypeExtensionContext();
+      if (!fromNominal)
+        return std::make_tuple(Type(), false);
+
+      // Add any protocols this nominal conforms to -- there's no need to do
+      // this for any superclasses that we visit, because this list will
+      // already include protocols from the superclass.
+      if (!options.contains(TR_InheritanceClause))
+        for (auto conforms : fromNominal->getAllProtocols())
+          pushProtocol(conforms);
     }
 
-    while (!stack.empty()) {
-      auto parentNominal = stack.back();
+    // Walk superclasses.
+    while (superclass) {
+      auto *superclassDecl = superclass->getAnyNominal();
+      if (!visited.insert(superclassDecl).second)
+        break;
 
-      stack.pop_back();
+      if (superclassDecl == ownerNominal)
+        return std::make_tuple(superclass, true);
+
+      superclass = superclass->getSuperclass(nullptr);
+    }
+
+    // Walk refined protocols.
+    while (!protocols.empty()) {
+      auto protoDecl = protocols.back();
 
       // Check if we found the right context.
-      if (parentNominal == ownerNominal)
-        return std::make_tuple(parentDC, parentNominal, true);
+      if (protoDecl == ownerNominal)
+        return std::make_tuple(getSelfType(parentDC), true);
 
-      // If not, walk into the superclass and inherited protocols, if any.
-      if (auto *protoDecl = dyn_cast<ProtocolDecl>(parentNominal)) {
-        for (auto *refined : protoDecl->getInheritedProtocols())
-          pushDecl(refined);
-      } else {
-        if (auto *classDecl = dyn_cast<ClassDecl>(parentNominal))
-          if (auto superclassTy = classDecl->getSuperclass())
-            if (auto superclassDecl = superclassTy->getClassOrBoundGenericClass())
-              pushDecl(superclassDecl);
-        if (!options.contains(TR_InheritanceClause)) {
-          // FIXME: wrong nominal decl
-          for (auto conforms : fromNominal->getAllProtocols()) {
-            pushDecl(conforms);
-          }
-        }
-      }
+      protocols.pop_back();
+
+      // If not, walk into the refined protocols, if any.
+      pushRefined(protoDecl);
     }
 
     // FIXME: Horrible hack. Don't allow us to reference a generic parameter
     // or associated type from a context outside a ProtocolDecl.
     if (isa<ProtocolDecl>(parentDC) && isa<AbstractTypeParamDecl>(typeDecl))
-      return std::make_tuple(nullptr, nullptr, false);
+      return std::make_tuple(Type(), false);
   }
 
   assert(false && "Should have found context by now");
-  return std::make_tuple(nullptr, nullptr, false);
+  return std::make_tuple(Type(), false);
 }
 
 Type TypeChecker::resolveTypeInContext(
@@ -370,17 +462,14 @@ Type TypeChecker::resolveTypeInContext(
   if (!resolver)
     resolver = &defaultResolver;
 
-  // FIXME: foundDC and foundNominal should come from UnqualifiedLookup
-  DeclContext *foundDC;
-  NominalTypeDecl *foundNominal;
+  // FIXME: selfType should come from UnqualifiedLookup
+  Type selfType;
   bool valid;
-  std::tie(foundDC, foundNominal, valid) =
-      findDeclContextForType(*this, typeDecl, fromDC, options);
+  std::tie(selfType, valid) =
+      findDeclContextForType(*this, typeDecl, fromDC, options, resolver);
 
-  if (!valid)
+  if (!valid || (selfType && selfType->hasError()))
     return ErrorType::get(Context);
-
-  assert(foundDC && "Should have found DeclContext by now");
 
   // If we are referring to a type within its own context, and we have either
   // a generic type with no generic arguments or a non-generic type, use the
@@ -398,8 +487,6 @@ Type TypeChecker::resolveTypeInContext(
     }
   }
 
-  bool hasDependentType = typeDecl->getDeclaredInterfaceType()
-      ->hasTypeParameter();
   // If we found a generic parameter, map to the archetype if there is one.
   if (auto genericParam = dyn_cast<GenericTypeParamDecl>(typeDecl)) {
     return resolver->resolveGenericTypeParamType(
@@ -407,15 +494,20 @@ Type TypeChecker::resolveTypeInContext(
             ->castTo<GenericTypeParamType>());
   }
 
-  if (!foundNominal || !hasDependentType) {
-    // If this is a typealias not in type context, we still need the
-    // interface type; the typealias might be in a function context, and
-    // its underlying type might reference outer generic parameters.
+  bool hasDependentType = typeDecl->getDeclaredInterfaceType()
+    ->hasTypeParameter();
+
+  // Simple case -- the type is not nested inside of another type.
+  // However, it might be nested inside another generic context, so
+  // we do want to write the type in terms of interface types or
+  // context archetypes, depending on the resolver given to us.
+  if (!selfType || !hasDependentType) {
     if (auto *aliasDecl = dyn_cast<TypeAliasDecl>(typeDecl)) {
       // For a generic typealias, return the unbound generic form of the type.
       if (aliasDecl->getGenericParams())
         return aliasDecl->getUnboundGenericType();
 
+      // Otherwise, simply return the underlying type.
       return resolver->resolveTypeOfDecl(aliasDecl);
     }
 
@@ -428,29 +520,9 @@ Type TypeChecker::resolveTypeInContext(
     return typeDecl->getDeclaredInterfaceType();
   }
 
-  // Now let's get the base type.
-  Type selfType;
-
-  // If we started from a protocol but found a member of a concrete type,
-  // we have a protocol extension with a superclass constraint on 'Self'.
-  // Use the concrete type and not the protocol 'Self' type as the base
-  // of the substitution.
-  if (foundDC->getAsProtocolExtensionContext() &&
-      !isa<ProtocolDecl>(foundNominal))
-    selfType = foundNominal->getDeclaredType();
-  // Otherwise, just use the type of the context we're looking at.
-  else if (isa<NominalTypeDecl>(typeDecl))
-    selfType = resolver->resolveTypeOfDecl(foundNominal);
-  else
-    selfType = resolver->resolveTypeOfContext(foundDC);
-
-  if (!selfType || selfType->hasError())
-    return ErrorType::get(Context);
-
   // If we started from a protocol and found an associated type member
   // of a (possibly inherited) protocol, resolve it via the resolver.
   if (auto *assocType = dyn_cast<AssociatedTypeDecl>(typeDecl)) {
-    // Odd special case, ask Doug to explain it over pizza one day
     if (selfType->isTypeParameter())
       return resolver->resolveSelfAssociatedType(
           selfType, assocType);
@@ -2962,9 +3034,8 @@ Type TypeChecker::substMemberTypeWithBase(ModuleDecl *module,
     baseTy = baseTy->getSuperclassForDecl(ownerClass, this);
   }
 
-  auto parentTy = baseTy;
   if (baseTy->is<ModuleType>())
-    parentTy = Type();
+    baseTy = Type();
 
   // The declared interface type for a generic type will have the type
   // arguments; strip them off.
@@ -2972,11 +3043,11 @@ Type TypeChecker::substMemberTypeWithBase(ModuleDecl *module,
     if (!isa<ProtocolDecl>(nominalDecl) &&
         nominalDecl->getGenericParams()) {
       return UnboundGenericType::get(
-          nominalDecl, parentTy,
+          nominalDecl, baseTy,
           nominalDecl->getASTContext());
     } else {
       return NominalType::get(
-          nominalDecl, parentTy,
+          nominalDecl, baseTy,
           nominalDecl->getASTContext());
     }
   }
@@ -2984,16 +3055,16 @@ Type TypeChecker::substMemberTypeWithBase(ModuleDecl *module,
   if (auto *aliasDecl = dyn_cast<TypeAliasDecl>(member)) {
     if (aliasDecl->getGenericParams()) {
       return UnboundGenericType::get(
-          aliasDecl, parentTy,
+          aliasDecl, baseTy,
           aliasDecl->getASTContext());
     }
   }
 
   auto memberType = member->getDeclaredInterfaceType();
-  if (!parentTy)
+  if (!baseTy)
     return memberType;
 
-  auto subs = parentTy->getContextSubstitutionMap(
+  auto subs = baseTy->getContextSubstitutionMap(
       module, member->getDeclContext());
   return memberType.subst(subs, SubstFlags::UseErrorType);
 }

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3030,8 +3030,6 @@ Type TypeChecker::substMemberTypeWithBase(ModuleDecl *module,
   // derived class as the parent type.
   if (auto *ownerClass = member->getDeclContext()
           ->getAsClassOrClassExtensionContext()) {
-    if (auto *archetypeTy = baseTy->getAs<ArchetypeType>())
-      baseTy = archetypeTy->getSuperclass();
     baseTy = baseTy->getSuperclassForDecl(ownerClass, this);
   }
 

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -22,6 +22,7 @@
 #include "swift/Strings.h"
 #include "swift/AST/ASTVisitor.h"
 #include "swift/AST/ASTWalker.h"
+#include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/ForeignErrorConvention.h"
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/NameLookup.h"
@@ -3902,14 +3903,14 @@ public:
         if (T->isInvalid())
           return false;
         if (type->isExistentialType()) {
-          SmallVector<ProtocolDecl*, 2> protocols;
-          type->getExistentialTypeProtocols(protocols);
-          for (auto *proto : protocols) {
-            if (proto->existentialTypeSupported(&TC))
+          for (auto *proto : type->getExistentialLayout().getProtocols()) {
+            auto *protoDecl = proto->getDecl();
+
+            if (protoDecl->existentialTypeSupported(&TC))
               continue;
             
             TC.diagnose(comp->getIdLoc(), diag::unsupported_existential_type,
-                        proto->getName());
+                        protoDecl->getName());
             T->setInvalid();
           }
         }

--- a/test/Compatibility/protocol_composition.swift
+++ b/test/Compatibility/protocol_composition.swift
@@ -15,7 +15,7 @@ protocol P2 {
 
 // Warning for mistakenly accepted protocol composition production.
 func foo(x: P1 & Any & P2.Type?) {
-  // expected-warning @-1 {{protocol composition with postfix '.Type' is ambiguous and will be rejected in future version of Swift}} {{13-13=(}} {{26-26=)}}
+  // expected-warning @-1 {{protocol-constrained type with postfix '.Type' is ambiguous and will be rejected in future version of Swift}} {{13-13=(}} {{26-26=)}}
   let _: (P1 & P2).Type? = x
   let _: (P1 & P2).Type = x!
   let _: Int = x!.p1()
@@ -25,16 +25,16 @@ func foo(x: P1 & Any & P2.Type?) {
 // Type expression
 func bar() -> ((P1 & P2)?).Type {
   let x = (P1 & P2?).self
-  // expected-warning @-1 {{protocol composition with postfix '?' is ambiguous and will be rejected in future version of Swift}} {{12-12=(}} {{19-19=)}}
+  // expected-warning @-1 {{protocol-constrained type with postfix '?' is ambiguous and will be rejected in future version of Swift}} {{12-12=(}} {{19-19=)}}
   return x
 }
 
 // Non-ident type at non-last position are rejected anyway.
-typealias A1 = P1.Type & P2 // expected-error {{type 'P1.Type' cannot be used within a protocol composition}}
+typealias A1 = P1.Type & P2 // expected-error {{non-protocol, non-class type 'P1.Type' cannot be used within a protocol-constrained type}}
 
 // BEGIN swift4.swift
 
-func foo(x: P1 & Any & P2.Type?) { // expected-error {{non-protocol type 'P2.Type?' cannot be used within a protocol composition}}
+func foo(x: P1 & Any & P2.Type?) { // expected-error {{non-protocol, non-class type 'P2.Type?' cannot be used within a protocol-constrained type}}
   let _: (P1 & P2).Type? = x // expected-error {{cannot convert value of type 'P1' to specified type '(P1 & P2).Type?'}}
   let _: (P1 & P2).Type = x! // expected-error {{cannot force unwrap value of non-optional type 'P1'}}
   let _: Int = x!.p1() // expected-error {{cannot force unwrap value of non-optional type 'P1'}}
@@ -42,8 +42,8 @@ func foo(x: P1 & Any & P2.Type?) { // expected-error {{non-protocol type 'P2.Typ
 }
 
 func bar() -> ((P1 & P2)?).Type {
-  let x = (P1 & P2?).self // expected-error {{non-protocol type 'P2?' cannot be used within a protocol composition}}
+  let x = (P1 & P2?).self // expected-error {{non-protocol, non-class type 'P2?' cannot be used within a protocol-constrained type}}
   return x // expected-error {{cannot convert return expression}}
 }
 
-typealias A1 = P1.Type & P2 // expected-error {{type 'P1.Type' cannot be used within a protocol composition}}
+typealias A1 = P1.Type & P2 // expected-error {{non-protocol, non-class type 'P1.Type' cannot be used within a protocol-constrained type}}

--- a/test/Generics/function_decls.swift
+++ b/test/Generics/function_decls.swift
@@ -7,7 +7,7 @@
 func f0<T>(x: Int, y: Int, t: T) { }
 func f1<T : Any>(x: Int, y: Int, t: T) { }
 func f2<T : IteratorProtocol>(x: Int, y: Int, t: T) { }
-func f3<T : () -> ()>(x: Int, y: Int, t: T) { } // expected-error{{expected a type name or protocol composition restricting 'T'}}
+func f3<T : () -> ()>(x: Int, y: Int, t: T) { } // expected-error{{expected a class type or protocol-constrained type restricting 'T'}}
 func f4<T>(x: T, y: T) { }
 
 // Non-protocol type constraints.

--- a/test/Generics/superclass_constraint.swift
+++ b/test/Generics/superclass_constraint.swift
@@ -136,3 +136,19 @@ func superclassConformance4<T: P3, U: P3>(_: T, _: U)
   where T.T: C, // expected-note{{superclass constraint 'T.T' : 'C' written here}}
         U.T: C, // expected-warning{{redundant superclass constraint 'U.T' : 'C'}}
         T.T == U.T { }
+
+// Lookup of superclass associated types from inheritance clause
+
+protocol Elementary {
+  associatedtype Element
+
+  func get() -> Element
+}
+
+class Classical : Elementary {
+  func get() -> Int {
+    return 0
+  }
+}
+
+func genericFunc<T : Elementary, U : Classical>(_: T, _: U) where T.Element == U.Element {}

--- a/test/Parse/recovery.swift
+++ b/test/Parse/recovery.swift
@@ -333,7 +333,7 @@ struct ErrorTypeInVarDecl7 {
 }
 
 struct ErrorTypeInVarDecl8 {
-  var v1 : protocol<FooProtocol // expected-error {{expected '>' to complete protocol composition type}} expected-note {{to match this opening '<'}}
+  var v1 : protocol<FooProtocol // expected-error {{expected '>' to complete protocol-constrained type}} expected-note {{to match this opening '<'}}
   var v2 : Int
 }
 
@@ -343,7 +343,7 @@ struct ErrorTypeInVarDecl9 {
 }
 
 struct ErrorTypeInVarDecl10 {
-  var v1 : protocol<FooProtocol // expected-error {{expected '>' to complete protocol composition type}} expected-note {{to match this opening '<'}}
+  var v1 : protocol<FooProtocol // expected-error {{expected '>' to complete protocol-constrained type}} expected-note {{to match this opening '<'}}
   var v2 : Int
 }
 
@@ -353,7 +353,7 @@ struct ErrorTypeInVarDecl11 {
 }
 
 func ErrorTypeInPattern1(_: protocol<) { } // expected-error {{expected identifier for type name}}
-func ErrorTypeInPattern2(_: protocol<F) { } // expected-error {{expected '>' to complete protocol composition type}}
+func ErrorTypeInPattern2(_: protocol<F) { } // expected-error {{expected '>' to complete protocol-constrained type}}
                                             // expected-note@-1 {{to match this opening '<'}}
                                             // expected-error@-2 {{use of undeclared type 'F'}}
 

--- a/test/Parse/type_expr.swift
+++ b/test/Parse/type_expr.swift
@@ -265,11 +265,11 @@ func compositionType() {
   _ = P1 & P2.self // expected-error {{binary operator '&' cannot be applied to operands of type 'P1.Protocol' and 'P2.Protocol'}} expected-note {{overloads for '&' exist }}
   _ = (P1 & P2).self // Ok.
   _ = (P1 & (P2)).self // FIXME: OK? while `typealias P = P1 & (P2)` is rejected.
-  _ = (P1 & (P2, P3)).self // expected-error {{non-protocol type '(P2, P3)' cannot be used within a protocol composition}}
-  _ = (P1 & Int).self // expected-error {{non-protocol type 'Int' cannot be used within a protocol composition}}
-  _ = (P1? & P2).self // expected-error {{non-protocol type 'P1?' cannot be used within a protocol composition}}
+  _ = (P1 & (P2, P3)).self // expected-error {{non-protocol, non-class type '(P2, P3)' cannot be used within a protocol-constrained type}}
+  _ = (P1 & Int).self // expected-error {{non-protocol, non-class type 'Int' cannot be used within a protocol-constrained type}}
+  _ = (P1? & P2).self // expected-error {{non-protocol, non-class type 'P1?' cannot be used within a protocol-constrained type}}
 
-  _ = (P1 & P2.Type).self // expected-error {{non-protocol type 'P2.Type' cannot be used within a protocol composition}}
+  _ = (P1 & P2.Type).self // expected-error {{non-protocol, non-class type 'P2.Type' cannot be used within a protocol-constrained type}}
 
   _ = P1 & P2 -> P3
   // expected-error @-1 {{single argument function types require parentheses}} {{7-7=(}} {{14-14=)}}

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -2024,7 +2024,7 @@ class ClassThrows1 {
 
   @objc func fooWithErrorProtocolComposition1(x: Error & Protocol_ObjC1) { }
   // expected-error@-1{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
-  // expected-note@-2{{protocol composition involving 'Error' cannot be represented in Objective-C}}
+  // expected-note@-2{{protocol-constrained type containing 'Error' cannot be represented in Objective-C}}
 
   // CHECK: {{^}} func fooWithErrorProtocolComposition2(x: Error & Protocol_ObjC1)
   func fooWithErrorProtocolComposition2(x: Error & Protocol_ObjC1) { }

--- a/test/decl/ext/protocol.swift
+++ b/test/decl/ext/protocol.swift
@@ -225,6 +225,44 @@ func testP4(_ s4a: S4a, s4b: S4b, s4c: S4c, s4d: S4d) {
   _ = b1
 }
 
+
+// ----------------------------------------------------------------------------
+// Protocol extensions with a superclass constraint on Self
+// ----------------------------------------------------------------------------
+
+protocol ConformedProtocol {
+  typealias ConcreteConformanceAlias = Self
+}
+
+class BaseWithAlias<T> : ConformedProtocol {
+  typealias ConcreteAlias = T
+
+  func baseMethod(_: T) {}
+}
+
+class DerivedWithAlias : BaseWithAlias<Int> {}
+
+protocol ExtendedProtocol {
+  typealias AbstractConformanceAlias = Self
+}
+
+extension ExtendedProtocol where Self : DerivedWithAlias {
+  func f0(x: T) {} // expected-error {{use of undeclared type 'T'}}
+
+  func f1(x: ConcreteAlias) {
+    let _: Int = x
+    baseMethod(x)
+  }
+
+  func f2(x: ConcreteConformanceAlias) {
+    let _: DerivedWithAlias = x
+  }
+
+  func f3(x: AbstractConformanceAlias) {
+    let _: DerivedWithAlias = x
+  }
+}
+
 // ----------------------------------------------------------------------------
 // Using protocol extensions to satisfy requirements
 // ----------------------------------------------------------------------------

--- a/test/decl/inherit/inherit.swift
+++ b/test/decl/inherit/inherit.swift
@@ -29,14 +29,14 @@ struct S2 : struct { } // expected-error{{expected identifier for type name}}
 
 // Protocol composition in inheritance clauses
 struct S3 : P, P & Q { } // expected-error {{duplicate inheritance from 'P'}}
-                         // expected-error @-1 {{protocol composition is neither allowed nor needed here}}
+                         // expected-error @-1 {{protocol-constrained type is neither allowed nor needed here}}
                          // expected-error @-2 {{'Q' requires that 'S3' inherit from 'A'}}
                          // expected-note @-3 {{requirement specified as 'Self' : 'A' [with Self = S3]}}
 struct S4 : P, P { }     // expected-error {{duplicate inheritance from 'P'}}
 struct S6 : P & { }      // expected-error {{expected identifier for type name}}
-                         // expected-error @-1 {{protocol composition is neither allowed nor needed here}}
+                         // expected-error @-1 {{protocol-constrained type is neither allowed nor needed here}}
 struct S7 : protocol<P, Q> { }  // expected-warning {{'protocol<...>' composition syntax is deprecated; join the protocols using '&'}}
-                                // expected-error @-1 {{protocol composition is neither allowed nor needed here}}{{13-22=}} {{26-27=}}
+                                // expected-error @-1 {{protocol-constrained type is neither allowed nor needed here}}{{13-22=}} {{26-27=}}
                                 // expected-error @-2 {{'Q' requires that 'S7' inherit from 'A'}}
                                 // expected-note @-3 {{requirement specified as 'Self' : 'A' [with Self = S7]}}
 

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -257,7 +257,7 @@ func test_lambda() {
 func test_lambda2() {
   { () -> protocol<Int> in
     // expected-warning @-1 {{'protocol<...>' composition syntax is deprecated and not needed here}} {{11-24=Int}}
-    // expected-error @-2 {{non-protocol type 'Int' cannot be used within a protocol composition}}
+    // expected-error @-2 {{non-protocol, non-class type 'Int' cannot be used within a protocol-constrained type}}
     // expected-warning @-3 {{result of call is unused}}
     return 1
   }()

--- a/test/type/protocol_composition.swift
+++ b/test/type/protocol_composition.swift
@@ -28,12 +28,12 @@ typealias Any2 = protocol< > // expected-warning {{'protocol<>' syntax is deprec
 // Okay to inherit a typealias for Any type.
 protocol P5 : Any { }
 protocol P6 : protocol<> { } // expected-warning {{'protocol<>' syntax is deprecated; use 'Any' instead}}
-                             // expected-error@-1 {{protocol composition is neither allowed nor needed here}}
+                             // expected-error@-1 {{protocol-constrained type is neither allowed nor needed here}}
 typealias P7 = Any & Any1
 
 extension Int : P5 { }
 
-typealias Bogus = P1 & Int // expected-error{{non-protocol type 'Int' cannot be used within a protocol composition}}
+typealias Bogus = P1 & Int // expected-error{{non-protocol, non-class type 'Int' cannot be used within a protocol-constrained type}}
 
 func testEquality() {
   // Remove duplicates from protocol-conformance types.
@@ -143,19 +143,19 @@ typealias H = protocol<P1>! // expected-warning {{'protocol<...>' composition sy
 typealias J = protocol<P1, P2>.Protocol // expected-warning {{'protocol<...>' composition syntax is deprecated; join the protocols using '&'}} {{15-31=(P1 & P2)}}
 typealias K = protocol<P1, P2>? // expected-warning {{'protocol<...>' composition syntax is deprecated; join the protocols using '&'}} {{15-32=(P1 & P2)?}}
 
-typealias T01 = P1.Protocol & P2 // expected-error {{non-protocol type 'P1.Protocol' cannot be used within a protocol composition}}
-typealias T02 = P1.Type & P2 // expected-error {{non-protocol type 'P1.Type' cannot be used within a protocol composition}}
-typealias T03 = P1? & P2 // expected-error {{non-protocol type 'P1?' cannot be used within a protocol composition}}
-typealias T04 = P1 & P2! // expected-error {{non-protocol type 'P2!' cannot be used within a protocol composition}} expected-error {{implicitly unwrapped optionals}} {{24-25=?}}
+typealias T01 = P1.Protocol & P2 // expected-error {{non-protocol, non-class type 'P1.Protocol' cannot be used within a protocol-constrained type}}
+typealias T02 = P1.Type & P2 // expected-error {{non-protocol, non-class type 'P1.Type' cannot be used within a protocol-constrained type}}
+typealias T03 = P1? & P2 // expected-error {{non-protocol, non-class type 'P1?' cannot be used within a protocol-constrained type}}
+typealias T04 = P1 & P2! // expected-error {{non-protocol, non-class type 'P2!' cannot be used within a protocol-constrained type}} expected-error {{implicitly unwrapped optionals}} {{24-25=?}}
 typealias T05 = P1 & P2 -> P3 // expected-error {{single argument function types require parentheses}} {{17-17=(}} {{24-24=)}}
 typealias T06 = P1 -> P2 & P3 // expected-error {{single argument function types require parentheses}} {{17-17=(}} {{19-19=)}}
 typealias T07 = P1 & protocol<P2, P3> // expected-warning {{protocol<...>' composition syntax is deprecated; join the protocols using '&'}} {{22-38=P2 & P3}}
 func fT07(x: T07) -> P1 & P2 & P3 { return x } // OK, 'P1 & protocol<P2, P3>' is parsed as 'P1 & P2 & P3'.
 let _: P1 & P2 & P3 -> P1 & P2 & P3 = fT07 // expected-error {{single argument function types require parentheses}} {{8-8=(}} {{20-20=)}}
 
-struct S01: P5 & P6 {} // expected-error {{protocol composition is neither allowed nor needed here}} {{none}}
+struct S01: P5 & P6 {} // expected-error {{protocol-constrained type is neither allowed nor needed here}} {{none}}
 struct S02: P5? & P6 {} // expected-error {{inheritance from non-named type 'P5?'}}
-struct S03: Optional<P5> & P6 {} // expected-error {{inheritance from non-protocol type 'Optional<P5>'}} expected-error {{protocol composition is neither allowed nor needed here}}
+struct S03: Optional<P5> & P6 {} // expected-error {{inheritance from non-protocol type 'Optional<P5>'}} expected-error {{protocol-constrained type is neither allowed nor needed here}}
 struct S04<T : P5 & (P6)> {} // expected-error {{inheritance from non-named type '(P6)'}}
 struct S05<T> where T : P5? & P6 {} // expected-error {{inheritance from non-named type 'P5?'}}
 

--- a/test/type/subclass_composition.swift
+++ b/test/type/subclass_composition.swift
@@ -1,0 +1,287 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-subclass-existentials
+
+protocol P1 {
+  typealias DependentInConcreteConformance = Self
+}
+
+class Base<T> : P1 {
+  typealias DependentClass = T
+
+  func classSelfReturn() -> Self {}
+}
+
+protocol P2 {
+  typealias FullyConcrete = Int
+  typealias DependentProtocol = Self
+
+  func protocolSelfReturn() -> Self
+}
+
+typealias BaseAndP2<T> = Base<T> & P2
+typealias BaseIntAndP2 = BaseAndP2<Int>
+
+class Derived : Base<Int>, P2 {
+  func protocolSelfReturn() -> Self {}
+}
+
+class Other : Base<Int> {}
+
+typealias OtherAndP2 = Other & P2
+
+protocol P3 : class {}
+
+//
+// If a class conforms to a protocol concretely, the resulting protocol
+// composition type should be equivalent to the class type.
+//
+// FIXME: Not implemented yet.
+//
+
+func alreadyConforms<T>(_: Base<T>) {}
+func alreadyConforms<T>(_: Base<T> & P1) {}
+func alreadyConforms<T>(_: Base<T> & AnyObject) {}
+func alreadyConforms<T>(_: Base<T> & P1 & AnyObject) {}
+
+func alreadyConforms(_: P3) {}
+func alreadyConforms(_: P3 & AnyObject) {}
+
+// SE-0156 stipulates that a composition can contain multiple classes, as long
+// as they are all the same.
+func basicDiagnostics(
+  _: Base<Int> & Base<Int>,
+  _: Base<Int> & Derived, // expected-error{{protocol-constrained type cannot contain class 'Derived' because it already contains class 'Base<Int>'}}
+
+  // Invalid typealias case
+  _: Derived & OtherAndP2, // expected-error{{protocol-constrained type cannot contain class 'Other' because it already contains class 'Derived'}}
+
+  // Valid typealias case
+  _: OtherAndP2 & P3) {}
+
+// Test that subtyping behaves as you would expect.
+func basicSubtyping(
+  base: Base<Int>,
+  baseAndP1: Base<Int> & P1,
+  baseAndP2: Base<Int> & P2,
+  baseAndP2AndAnyObject: Base<Int> & P2 & AnyObject,
+  baseAndAnyObject: Base<Int> & AnyObject,
+  derived: Derived,
+  derivedAndP2: Derived & P2,
+  derivedAndP3: Derived & P3,
+  derivedAndAnyObject: Derived & AnyObject,
+  p1AndAnyObject: P1 & AnyObject,
+  p2AndAnyObject: P2 & AnyObject) {
+
+  // Errors
+  let _: Base & P2 = base // expected-error {{value of type 'Base<Int>' does not conform to specified type 'Base & P2'}}
+  let _: Base<Int> & P2 = base // expected-error {{value of type 'Base<Int>' does not conform to specified type 'Base<Int> & P2'}}
+  let _: P3 = baseAndP1 // expected-error {{value of type 'Base<Int> & P1' does not conform to specified type 'P3'}}
+  let _: P3 = baseAndP2 // expected-error {{value of type 'Base<Int> & P2' does not conform to specified type 'P3'}}
+  let _: Derived = baseAndP1 // expected-error {{cannot convert value of type 'Base<Int> & P1' to specified type 'Derived'}}
+  let _: Derived = baseAndP2 // expected-error {{cannot convert value of type 'Base<Int> & P2' to specified type 'Derived'}}
+  let _: Derived & P2 = baseAndP2 // expected-error {{value of type 'Base<Int> & P2' does not conform to specified type 'Derived & P2'}}
+
+  // No-ops
+  let _: Base & P1 = base
+  let _: Base<Int> & P1 = base
+  let _: Base & AnyObject = base
+  let _: Base<Int> & AnyObject = base
+  let _: Derived & AnyObject = derived
+
+  // Erasing superclass constraint
+  let _: P1 = baseAndP1
+  let _: P1 & AnyObject = baseAndP1
+  let _: P1 = derived
+  let _: P1 & AnyObject = derived
+  let _: AnyObject = baseAndP1
+  let _: AnyObject = baseAndP2
+  let _: AnyObject = derived
+  let _: AnyObject = derivedAndP2
+  let _: AnyObject = derivedAndP3
+  let _: AnyObject = derivedAndAnyObject
+
+  // Erasing conformance constraint
+  let _: Base = baseAndP1
+  let _: Base<Int> = baseAndP1
+  let _: Base = derivedAndP3
+  let _: Base<Int> = derivedAndP3
+  let _: Derived = derivedAndP2
+  let _: Derived = derivedAndAnyObject
+
+  // Upcasts
+  let _: Base & P2 = derived
+  let _: Base<Int> & P2 = derived
+  let _: Base & P2 & AnyObject = derived
+  let _: Base<Int> & P2 & AnyObject = derived
+  let _: Base & P3 = derivedAndP3
+  let _: Base<Int> & P3 = derivedAndP3
+
+  // Calling methods with Self return
+  let _: Base & P2 = baseAndP2.classSelfReturn()
+  let _: Base<Int> & P2 = baseAndP2.classSelfReturn()
+  let _: Base & P2 = baseAndP2.protocolSelfReturn()
+  let _: Base<Int> & P2 = baseAndP2.protocolSelfReturn()
+}
+
+//
+// Looking up member types of subclass existentials.
+//
+
+func dependentMemberTypes<T : BaseIntAndP2>(
+  _: T.DependentInConcreteConformance,
+  _: T.DependentProtocol,
+  _: T.DependentClass,
+  _: T.FullyConcrete,
+
+  _: BaseIntAndP2.DependentInConcreteConformance, // FIXME expected-error {{}}
+  _: BaseIntAndP2.DependentProtocol, // expected-error {{typealias 'DependentProtocol' can only be used with a concrete type or generic parameter base}}
+  _: BaseIntAndP2.DependentClass,
+  _: BaseIntAndP2.FullyConcrete) {}
+
+func conformsToAnyObject<T : AnyObject>(_: T) {}
+func conformsToP1<T : P1>(_: T) {}
+func conformsToP2<T : P2>(_: T) {}
+func conformsToBaseIntAndP2<T : Base<Int> & P2>(_: T) {}
+// expected-note@-1 4 {{in call to function 'conformsToBaseIntAndP2'}}
+
+func conformsToBaseIntAndP2WithWhereClause<T>(_: T) where T : Base<Int> & P2 {}
+// expected-note@-1 2 {{in call to function 'conformsToBaseIntAndP2WithWhereClause'}}
+
+class FakeDerived : Base<String>, P2 {
+  func protocolSelfReturn() -> Self { return self }
+}
+
+//
+// Metatype subtyping.
+//
+
+func metatypeSubtyping(
+  base: Base<Int>.Type,
+  derived: Derived.Type,
+  derivedAndAnyObject: (Derived & AnyObject).Type,
+  baseIntAndP2: (Base<Int> & P2).Type,
+  baseIntAndP2AndAnyObject: (Base<Int> & P2 & AnyObject).Type) {
+
+  // Erasing conformance constraint
+  let _: Base<Int>.Type = baseIntAndP2
+  let _: Base<Int>.Type = baseIntAndP2AndAnyObject
+  let _: Derived.Type = derivedAndAnyObject
+  let _: BaseAndP2<Int>.Type = baseIntAndP2AndAnyObject
+
+  // Upcast
+  let _: BaseAndP2<Int>.Type = derived
+  let _: BaseAndP2<Int>.Type = derivedAndAnyObject
+
+  // Erasing superclass constraint
+  let _: P2.Type = baseIntAndP2
+  let _: P2.Type = derived
+  let _: P2.Type = derivedAndAnyObject
+  let _: (P2 & AnyObject).Type = derived
+  let _: (P2 & AnyObject).Type = derivedAndAnyObject
+}
+
+// There's a code path in CSApply that's hard to hit.
+func takesBase<T>(_: Base<T>) {}
+func takesBaseMetatype<T>(_: Base<T>.Type) {}
+
+func takesBaseIntAndP2(x: Base<Int> & P2) {
+  takesBase(x)
+}
+
+func takesBaseIntAndP2Metatype(x: (Base<Int> & P2).Type) {
+  takesBaseMetatype(x)
+}
+
+//
+// Conformance relation.
+//
+
+func conformsTo<T1 : P2, T2 : Base<Int> & P2>(
+  anyObject: AnyObject,
+  p1: P1,
+  p2: P2,
+  p3: P3,
+  base: Base<Int>,
+  badBase: Base<String>,
+  derived: Derived,
+  fakeDerived: FakeDerived,
+  p2Archetype: T1,
+  baseAndP2Archetype: T2) {
+
+  // FIXME: Uninformative diagnostics
+
+  // Errors
+  conformsToAnyObject(p1)
+  // expected-error@-1 {{cannot invoke 'conformsToAnyObject' with an argument list of type '(P1)'}}
+  // expected-note@-2 {{expected an argument list of type '(T)'}}
+
+  conformsToP1(p1)
+  // expected-error@-1 {{cannot invoke 'conformsToP1' with an argument list of type '(P1)'}}
+  // expected-note@-2 {{expected an argument list of type '(T)'}}
+
+  conformsToBaseIntAndP2(base)
+  // expected-error@-1 {{generic parameter 'T' could not be inferred}}
+
+  conformsToBaseIntAndP2(badBase)
+  // expected-error@-1 {{generic parameter 'T' could not be inferred}}
+
+  conformsToBaseIntAndP2(fakeDerived)
+  // expected-error@-1 {{generic parameter 'T' could not be inferred}}
+
+  conformsToBaseIntAndP2WithWhereClause(fakeDerived)
+  // expected-error@-1 {{generic parameter 'T' could not be inferred}}
+
+  conformsToBaseIntAndP2(p2Archetype)
+  // expected-error@-1 {{generic parameter 'T' could not be inferred}}
+
+  conformsToBaseIntAndP2WithWhereClause(p2Archetype)
+  // expected-error@-1 {{generic parameter 'T' could not be inferred}}
+
+  // Good
+  conformsToAnyObject(anyObject)
+  conformsToAnyObject(baseAndP2Archetype)
+  conformsToP1(derived)
+  conformsToP1(baseAndP2Archetype)
+  conformsToP2(derived)
+  conformsToP2(baseAndP2Archetype)
+  conformsToBaseIntAndP2(derived)
+  conformsToBaseIntAndP2(baseAndP2Archetype)
+  conformsToBaseIntAndP2WithWhereClause(derived)
+  conformsToBaseIntAndP2WithWhereClause(baseAndP2Archetype)
+}
+
+//
+// Protocols with superclass-constrained Self -- not supported yet.
+//
+
+protocol ProtoConstraintsSelfToClass where Self : Base<Int> {}
+
+protocol ProtoRefinesClass : Base<Int> {} // FIXME expected-error {{}}
+protocol ProtoRefinesClassAndProtocolAlias : BaseIntAndP2 {} // FIXME expected-error {{}}
+protocol ProtoRefinesClassAndProtocolDirect : Base<Int> & P2 {} // FIXME expected-error 2 {{}}
+protocol ProtoRefinesClassAndProtocolExpanded : Base<Int>, P2 {} // FIXME expected-error {{}}
+
+class ClassConformsToClassProtocolBad1 : ProtoConstraintsSelfToClass {}
+// expected-error@-1 {{'ProtoConstraintsSelfToClass' requires that 'ClassConformsToClassProtocolBad1' inherit from 'Base<Int>'}}
+// expected-note@-2 {{requirement specified as 'Self' : 'Base<Int>' [with Self = ClassConformsToClassProtocolBad1]}}
+class ClassConformsToClassProtocolGood1 : Derived, ProtoConstraintsSelfToClass {}
+
+class ClassConformsToClassProtocolBad2 : ProtoRefinesClass {} // FIXME
+class ClassConformsToClassProtocolGood2 : Derived, ProtoRefinesClass {}
+
+// Subclass existentials inside inheritance clauses
+class CompositionInClassInheritanceClauseAlias : BaseIntAndP2 {
+  func protocolSelfReturn() -> Self { return self }
+  func asBase() -> Base<Int> { return self }
+  // FIXME expected-error@-1 {{}}
+}
+
+class CompositionInClassInheritanceClauseDirect : Base<Int> & P2 {
+  // expected-error@-1 {{protocol-constrained type is neither allowed nor needed here}}
+  func protocolSelfReturn() -> Self { return self }
+  func asBase() -> Base<Int> { return self }
+}
+
+protocol CompositionInAssociatedTypeInheritanceClause {
+  associatedtype A : BaseIntAndP2
+  // FIXME expected-error@-1 {{}}
+}

--- a/validation-test/compiler_crashers_fixed/28674-unreachable-executed-at-swift-lib-sema-csapply-cpp-5856.swift
+++ b/validation-test/compiler_crashers_fixed/28674-unreachable-executed-at-swift-lib-sema-csapply-cpp-5856.swift
@@ -5,6 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 for{_=(_
 [{


### PR DESCRIPTION
Work in progress.

TODO:
- If a class C conforms to P, then `C & P` should be the same type as `C`. While we can convert back and forth, they currently appear as distinct types for purposes of overloading, etc.
- If a class C is a subclass of D, the proposal says `C & D` should be equivalent to `D`; for now, it is an error. `C & C` is equivalent to C, though.
- Type alias lookup on a subclass existential is not quite right if the typealias is a member of a protocol that the superclass conforms to concretely.
- Protocol inheritance clauses cannot contain superclasses yet.
- AnyObject is not yet lowered away completely.
- Mangling, SILGen, IRGen, serialization, runtime support.
- Importing Objective-C subclass existentials.