### PR TITLE
[Constraint system] Fix debug output for constraint dumping.

### DIFF
--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -219,7 +219,7 @@ void Constraint::print(llvm::raw_ostream &Out, SourceManager *sm) const {
 
     interleave(getNestedConstraints(),
                [&](Constraint *constraint) {
-                 if (isDisabled())
+                 if (constraint->isDisabled())
                    Out << "[disabled] ";
                  constraint->print(Out, sm);
                },


### PR DESCRIPTION
I updated this incorrectly to test the disabled bit on the disjunction
rather than the members.
