### PR TITLE
Unicode rethink: Switch dispatch more, speedups.

### DIFF
--- a/stdlib/public/core/NewString.swift.gyb
+++ b/stdlib/public/core/NewString.swift.gyb
@@ -1143,14 +1143,36 @@ extension Substring : CustomDebugStringConvertible {
 //===--- Comparable/Hashable ----------------------------------------------===//
 extension String : Comparable {
   public static func < (lhs: String, rhs: String) -> Bool {
-    return lhs.content.fccNormalizedUTF16.lexicographicallyPrecedes(
-      rhs.content.fccNormalizedUTF16
-    )
+    // return lhs.content.fccNormalizedUTF16.lexicographicallyPrecedes(
+    //   rhs.content.fccNormalizedUTF16
+    switch lhs.content._rep {
+  % for outerTag,_ in allCases:
+    case .${outerTag}(let outerContent):
+      switch rhs.content._rep {
+    % for innerTag,_ in allCases:
+      case .${innerTag}(let innerContent):
+        return outerContent.fccNormalizedUTF16.lexicographicallyPrecedes(
+          innerContent.fccNormalizedUTF16)
+    % end
+      }
+  % end
+    }
   }
   public static func == (lhs: String, rhs: String) -> Bool {
-    return lhs.content.fccNormalizedUTF16.elementsEqual(
-      rhs.content.fccNormalizedUTF16
-    )
+    // return lhs.content.fccNormalizedUTF16.elementsEqual(
+    //   rhs.content.fccNormalizedUTF16
+    switch lhs.content._rep {
+  % for outerTag,_ in allCases:
+    case .${outerTag}(let outerContent):
+      switch rhs.content._rep {
+    % for innerTag,_ in allCases:
+      case .${innerTag}(let innerContent):
+        return outerContent.fccNormalizedUTF16.elementsEqual(
+          innerContent.fccNormalizedUTF16)
+    % end
+      }
+  % end
+    }
   }
 }
 

--- a/stdlib/public/core/NewString.swift.gyb
+++ b/stdlib/public/core/NewString.swift.gyb
@@ -1157,7 +1157,14 @@ extension String : Comparable {
 extension String : Hashable {
   public var hashValue : Int {
     var hasher = _SipHash13Context(key: _Hashing.secretKey)
-    for x in content.fccNormalizedUTF16 { hasher.append(x) }
+
+    // for x in content.fccNormalizedUTF16 { hasher.append(x) }
+    switch content._rep {
+  % for tag,_ in allCases:
+    case .${tag}(let content): for x in content.fccNormalizedUTF16 { hasher.append(x) }
+  % end
+    }
+
     let resultBits = hasher.finalizeAndReturnHash()
 #if arch(i386) || arch(arm)
     return Int(truncatingBitPattern: resultBits)


### PR DESCRIPTION
<!-- What's in this pull request? -->
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

By using switch dispatch, we can access the FCC normalized UTF16
without type erasure for many of our content kinds. This results in
generic specialization for many of our collection wrappers, allowing
for a ~40x speedup for e.g. Latin1Strings.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
