### PR TITLE
Fix Swift lit tests after LLVM r299775

### DIFF
--- a/test/SourceKit/lit.local.cfg
+++ b/test/SourceKit/lit.local.cfg
@@ -2,17 +2,12 @@ if 'OS=macosx' not in config.available_features:
     config.unsupported = True
 
 else:
-    config.sourcekitd_test = config.inferSwiftBinary('sourcekitd-test')
-    config.complete_test = config.inferSwiftBinary('complete-test')
-
-    def sed_clean(x):
-        sed_cmd = "grep -v 'key.hash: \"0\"'"
-        sed_cmd += " | sed -e 's/key.filepath: \".*[/\\\\]\\(.*\\)\\.swiftmodule\"/key.filepath: \\1.swiftmodule/g'"
-        sed_cmd += " | sed -e 's/key.filepath: \".*[/\\\\]\\(.*\\)\\.swift\"/key.filepath: \\1.swift/g'"
-        sed_cmd += " | sed -e 's/key.filepath: \".*[/\\\\]\\(.*\\)-[0-9A-Z]*\\.pcm\"/key.filepath: \\1.pcm/g'"
-        sed_cmd += " | sed -e 's/ file=\\\\\".*[/\\\\]\\(.*\\)\\.h\\\\\"/ file=\\1.h/g'"
-        sed_cmd += " | sed -e 's/key.hash: \".*\"/key.hash: <hash>/g'"
-        return sed_cmd
+    sed_clean = r"grep -v 'key.hash: \"0\"'"
+    sed_clean += r" | sed -e 's/key.filepath: \".*[/\\\\]\\(.*\\)\\.swiftmodule\"/key.filepath: \\1.swiftmodule/g'"
+    sed_clean += r" | sed -e 's/key.filepath: \".*[/\\\\]\\(.*\\)\\.swift\"/key.filepath: \\1.swift/g'"
+    sed_clean += r" | sed -e 's/key.filepath: \".*[/\\\\]\\(.*\\)-[0-9A-Z]*\\.pcm\"/key.filepath: \\1.pcm/g'"
+    sed_clean += r" | sed -e 's/ file=\\\\\".*[/\\\\]\\(.*\\)\\.h\\\\\"/ file=\\1.h/g'"
+    sed_clean += r" | sed -e 's/key.hash: \".*\"/key.hash: <hash>/g'"
 
     config.substitutions.append( ('%sourcekitd-test', config.sourcekitd_test) )
     config.substitutions.append( ('%complete-test', config.complete_test) )

--- a/test/api-digester/lit.local.cfg
+++ b/test/api-digester/lit.local.cfg
@@ -2,5 +2,4 @@ if 'OS=macosx' not in config.available_features:
     config.unsupported = True
 
 else:
-    config.swift_api_digester = config.inferSwiftBinary('swift-api-digester')
     config.substitutions.append(('%api-digester', config.swift_api_digester))

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -33,6 +33,10 @@ import lit
 import lit.formats
 import lit.util
 
+import site
+site.addsitedir(os.path.dirname(__file__))
+import swift_test
+
 #
 # Helper functions.
 #
@@ -134,48 +138,6 @@ if config.test_exec_root is None:
 
 ###
 
-class SwiftTest(lit.formats.ShTest, object):
-    def __init__(self, coverage_mode=None, execute_external=True):
-        super(SwiftTest, self).__init__(execute_external=execute_external)
-        if coverage_mode == "FALSE":
-            self.coverage_mode = None
-        else:
-            self.coverage_mode = coverage_mode
-        self.skipped_tests = set()
-
-    def before_test(self, test, litConfig):
-        if self.coverage_mode:
-            # FIXME: The compiler crashers run so fast they fill up the
-            # merger's queue (and therefore the build bot's disk)
-            if 'crasher' in test.getSourcePath():
-                test.config.environment["LLVM_PROFILE_FILE"] = os.devnull
-                self.skipped_tests.add(test.getSourcePath())
-                return
-
-            _, tmp_base = lit.TestRunner.getTempPaths(test)
-            if self.coverage_mode == "NOT_MERGED":
-                profdir = tmp_base + '.profdir'
-                if not os.path.exists(profdir):
-                    os.makedirs(profdir)
-
-                test.config.environment["LLVM_PROFILE_FILE"] = \
-                    os.path.join(profdir, "swift-%p.profraw")
-            else:
-                test.config.environment["LLVM_PROFILE_FILE"] = \
-                    os.path.join(config.swift_test_results_dir,
-                                 "swift-%4m.profraw")
-
-    def after_test(self, test, litConfig, result):
-        if test.getSourcePath() in self.skipped_tests:
-            self.skipped_tests.remove(test.getSourcePath())
-        return result
-
-
-    def execute(self, test, litConfig):
-        self.before_test(test, litConfig)
-        result = super(SwiftTest, self).execute(test, litConfig)
-        return self.after_test(test, litConfig, result)
-
 # name: The name of this test suite.
 config.name = 'Swift(%s)' % config.variant_suffix[1:]
 
@@ -185,7 +147,7 @@ if platform.system() == 'Darwin':
     config.environment['TOOLCHAINS'] = 'default'
 
 # testFormat: The test format to use to interpret tests.
-config.test_format = SwiftTest(coverage_mode=config.coverage_mode)
+config.test_format = swift_test.SwiftTest(coverage_mode=config.coverage_mode)
 
 # suffixes: A list of file extensions to treat as test files.
 config.suffixes = ['.swift', '.ll', '.sil', '.gyb', '.m', '.test-sh']
@@ -269,9 +231,6 @@ if 'gmalloc' in lit_config.params:
     config.environment['MALLOC_LOG_FILE'] = '/dev/null'
     config.available_features.add('gmalloc')
 
-# Make inferSwiftBinary() available to be used later on.
-config.inferSwiftBinary = inferSwiftBinary
-
 config.swift = inferSwiftBinary('swift')
 config.swiftc = inferSwiftBinary('swiftc')
 config.sil_opt = inferSwiftBinary('sil-opt')
@@ -292,6 +251,9 @@ config.llvm_profdata = inferSwiftBinary('llvm-profdata')
 config.llvm_cov = inferSwiftBinary('llvm-cov')
 config.filecheck = inferSwiftBinary('FileCheck')
 config.llvm_dwarfdump = inferSwiftBinary('llvm-dwarfdump')
+config.sourcekitd_test = inferSwiftBinary('sourcekitd-test')
+config.complete_test = inferSwiftBinary('complete-test')
+config.swift_api_digester = inferSwiftBinary('swift-api-digester')
 
 config.swift_utils = os.path.join(config.swift_src_root, 'utils')
 config.line_directive = os.path.join(config.swift_utils, 'line-directive')

--- a/test/swift_test.py
+++ b/test/swift_test.py
@@ -1,0 +1,61 @@
+# swift/test/swift_test.py - SwiftTest format for lit tests -*- python -*-
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# -----------------------------------------------------------------------------
+#
+# This is a test format file for the 'lit' test runner.
+#
+# -----------------------------------------------------------------------------
+
+import os
+import lit
+import lit.formats
+import lit.util
+
+class SwiftTest(lit.formats.ShTest, object):
+    def __init__(self, coverage_mode=None, execute_external=True):
+        super(SwiftTest, self).__init__(execute_external=execute_external)
+        if coverage_mode == "FALSE":
+            self.coverage_mode = None
+        else:
+            self.coverage_mode = coverage_mode
+        self.skipped_tests = set()
+
+    def before_test(self, test, litConfig):
+        if self.coverage_mode:
+            # FIXME: The compiler crashers run so fast they fill up the
+            # merger's queue (and therefore the build bot's disk)
+            if 'crasher' in test.getSourcePath():
+                test.config.environment["LLVM_PROFILE_FILE"] = os.devnull
+                self.skipped_tests.add(test.getSourcePath())
+                return
+
+            _, tmp_base = lit.TestRunner.getTempPaths(test)
+            if self.coverage_mode == "NOT_MERGED":
+                profdir = tmp_base + '.profdir'
+                if not os.path.exists(profdir):
+                    os.makedirs(profdir)
+
+                test.config.environment["LLVM_PROFILE_FILE"] = \
+                    os.path.join(profdir, "swift-%p.profraw")
+            else:
+                test.config.environment["LLVM_PROFILE_FILE"] = \
+                    os.path.join(config.swift_test_results_dir,
+                                 "swift-%4m.profraw")
+
+    def after_test(self, test, litConfig, result):
+        if test.getSourcePath() in self.skipped_tests:
+            self.skipped_tests.remove(test.getSourcePath())
+        return result
+
+    def execute(self, test, litConfig):
+        self.before_test(test, litConfig)
+        result = super(SwiftTest, self).execute(test, litConfig)
+        return self.after_test(test, litConfig, result)


### PR DESCRIPTION
LLVM's lit implementation switched to use process pools in r299775.
This exposed some pickling problems in Swift's lit files. For a function
or class to be pickle-able, it has to be in the top-level of a real
Python module.

* The SwiftTest lit format class was embedded in the lit.cfg file, so
I moved it out to a separate Python file.

* The inferSwiftBinary function was being stashed in the
config.inferSwiftBinary field and later used to find tools for SourceKit
testing. I moved the config settings for those tools into the top-level
lit.cfg file. I expect this will cause warnings about them not existing
in some cases, but that should be fairly harmless. Maybe someone can
come up with a better solution later.

* The config.substitutions for SourceKit's lit.local.cfg was storing a
reference to an embedded sed_clean function, which just returned a
constant string. I changed the function to be a string, using Python's
raw string feature to avoid the problems that likely led to it being a
function in the first place. (Just guessing.)
