### PR TITLE
[swiftc (35 vs. 5512)] Add crasher in swift::TypeChecker::checkGenericParamList

### DIFF
--- a/validation-test/compiler_crashers/28738-impl-genericparams-empty-key-depth-impl-genericparams-back-getdepth-key-index-im.swift
+++ b/validation-test/compiler_crashers/28738-impl-genericparams-empty-key-depth-impl-genericparams-back-getdepth-key-index-im.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol P}extension P{{}typealias a:P}extension P.a{protocol P


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeChecker::checkGenericParamList`.

Current number of unresolved compiler crashers: 35 (5512 resolved)

/cc @DougGregor - just wanted to let you know that this crasher caused an assertion failure for the assertion `Impl->GenericParams.empty() || ((Key.Depth == Impl->GenericParams.back()->getDepth() && Key.Index == Impl->GenericParams.back()->getIndex() + 1) || (Key.Depth > Impl->GenericParams.back()->getDepth() && Key.Index == 0))` added on 2017-02-07 by you in commit 0c76a9d8 :-)

Assertion failure in [`lib/AST/GenericSignatureBuilder.cpp (line 2127)`](https://github.com/apple/swift/blob/4463bb8287710b954dd6be595da81a1aa637f2f3/lib/AST/GenericSignatureBuilder.cpp#L2127):

```
Assertion `Impl->GenericParams.empty() || ((Key.Depth == Impl->GenericParams.back()->getDepth() && Key.Index == Impl->GenericParams.back()->getIndex() + 1) || (Key.Depth > Impl->GenericParams.back()->getDepth() && Key.Index == 0))' failed.

When executing: void swift::GenericSignatureBuilder::addGenericParameter(swift::GenericTypeParamType *)
```

Assertion context:

```c++
  return ResolvedType::forPotentialArchetype(pa);
}

void GenericSignatureBuilder::addGenericParameter(GenericTypeParamDecl *GenericParam) {
  addGenericParameter(
     GenericParam->getDeclaredInterfaceType()->castTo<GenericTypeParamType>());
}

bool GenericSignatureBuilder::addGenericParameterRequirements(
                                           GenericTypeParamDecl *GenericParam) {
  GenericParamKey Key(GenericParam);
```
Stack trace:

```
0 0x000000000395fc48 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x395fc48)
1 0x0000000003960386 SignalHandler(int) (/path/to/swift/bin/swift+0x3960386)
2 0x00007f5c3d37d390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007f5c3b8a3428 gsignal /build/glibc-9tT8Do/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f5c3b8a502a abort /build/glibc-9tT8Do/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f5c3b89bbd7 __assert_fail_base /build/glibc-9tT8Do/glibc-2.23/assert/assert.c:92:0
6 0x00007f5c3b89bc82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x00000000014b3f98 (/path/to/swift/bin/swift+0x14b3f98)
8 0x00000000012e575c swift::TypeChecker::checkGenericParamList(swift::GenericSignatureBuilder*, swift::GenericParamList*, swift::GenericSignature*, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0x12e575c)
9 0x00000000012e8c38 swift::TypeChecker::checkGenericEnvironment(swift::GenericParamList*, swift::DeclContext*, swift::GenericSignature*, bool, llvm::function_ref<void (swift::GenericSignatureBuilder&)>) (/path/to/swift/bin/swift+0x12e8c38)
10 0x00000000012e9089 swift::TypeChecker::validateGenericTypeSignature(swift::GenericTypeDecl*) (/path/to/swift/bin/swift+0x12e9089)
11 0x00000000012b991e swift::TypeChecker::validateDecl(swift::ValueDecl*) (/path/to/swift/bin/swift+0x12b991e)
12 0x00000000012c8943 (anonymous namespace)::DeclChecker::visitProtocolDecl(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0x12c8943)
13 0x00000000012b7b57 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x12b7b57)
14 0x00000000012c763b (anonymous namespace)::DeclChecker::visitExtensionDecl(swift::ExtensionDecl*) (/path/to/swift/bin/swift+0x12c763b)
15 0x00000000012b7a1b (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x12b7a1b)
16 0x00000000012b7953 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x12b7953)
17 0x00000000013360a5 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x13360a5)
18 0x0000000000fa3286 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xfa3286)
19 0x00000000004a8892 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a8892)
20 0x00000000004651d7 main (/path/to/swift/bin/swift+0x4651d7)
21 0x00007f5c3b88e830 __libc_start_main /build/glibc-9tT8Do/glibc-2.23/csu/../csu/libc-start.c:325:0
22 0x0000000000462879 _start (/path/to/swift/bin/swift+0x462879)
```