### PR TITLE
[cursor-info] Fix invalid assertion firing for symbols referenced within nested interpolated strings

### DIFF
--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -2063,8 +2063,7 @@ static SourceLoc getLocForStartOfTokenInBuf(SourceManager &SM,
                                             unsigned BufferID,
                                             unsigned Offset,
                                             unsigned BufferStart,
-                                            unsigned BufferEnd,
-                                            bool InInterpolatedString) {
+                                            unsigned BufferEnd) {
   // Use fake language options; language options only affect validity
   // and the exact token produced.
   LangOptions FakeLangOptions;
@@ -2089,7 +2088,6 @@ static SourceLoc getLocForStartOfTokenInBuf(SourceManager &SM,
       // Current token encompasses our source location.
 
       if (Tok.is(tok::string_literal)) {
-        assert(!InInterpolatedString);
         SmallVector<Lexer::StringSegment, 4> Segments;
         Lexer::getStringLiteralSegments(Tok, Segments, /*Diags=*/nullptr);
         for (auto &Seg : Segments) {
@@ -2102,8 +2100,7 @@ static SourceLoc getLocForStartOfTokenInBuf(SourceManager &SM,
           if (Seg.Kind == Lexer::StringSegment::Expr && Offset < SegEnd)
             return getLocForStartOfTokenInBuf(SM, BufferID, Offset,
                                               /*BufferStart=*/SegOffs,
-                                              /*BufferEnd=*/SegEnd,
-                                              /*InInterpolatedString=*/true);
+                                              /*BufferEnd=*/SegEnd);
         }
       }
 
@@ -2159,8 +2156,7 @@ SourceLoc Lexer::getLocForStartOfToken(SourceManager &SM, unsigned BufferID,
 
   return getLocForStartOfTokenInBuf(SM, BufferID, Offset,
                                     /*BufferStart=*/LexStart-BufStart,
-                                    /*BufferEnd=*/Buffer.size(),
-                                    /*InInterpolatedString=*/false);
+                                    /*BufferEnd=*/Buffer.size());
 }
 
 SourceLoc Lexer::getLocForStartOfLine(SourceManager &SM, SourceLoc Loc) {

--- a/test/SourceKit/CursorInfo/rdar_31539499.swift
+++ b/test/SourceKit/CursorInfo/rdar_31539499.swift
@@ -1,0 +1,6 @@
+// Checks that we don't crash
+// RUN: %sourcekitd-test -req=cursor -pos=6:30 %s -- %s | %FileCheck %s
+// CHECK: source.lang.swift.ref.var.global
+
+let y = 1
+print("text: \( "he\(/*here*/y)lo" )")


### PR DESCRIPTION
<!-- What's in this pull request? -->
`getLocForStartOfTokenInBuf` would fire an assertion if it tried to find the supplied offset within a string literal when it had already recursed into the expression segment of a containing interpolated string. It seems like the assertion was intended to catch logic errors in the source ranges computed by `getLocForStartOfTokenInBuf` itself, but it also fires in valid cases, e.g. when finding the start of `myVar` on the second line of:
```
let myVar = 1
print("text: \( "he\(/*here*/myVar)lo" )")
```
This patch removes the assertion and the parameter used to track when it should fire.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves rdar://problem/31539499

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->