### PR TITLE
[swiftc (36 vs. 5512)] Add crasher in swift::Expr::walk(...)

### DIFF
--- a/validation-test/compiler_crashers/28739-unreachable-executed-at-swift-lib-ast-type-cpp-229.swift
+++ b/validation-test/compiler_crashers/28739-unreachable-executed-at-swift-lib-ast-type-cpp-229.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+(Int==_{


### PR DESCRIPTION
Add test case for crash triggered in `swift::Expr::walk(...)`.

Current number of unresolved compiler crashers: 36 (5512 resolved)

Stack trace:

```
0 0x000000000395fc48 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x395fc48)
1 0x0000000003960386 SignalHandler(int) (/path/to/swift/bin/swift+0x3960386)
2 0x00007f2691f92390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007f26904b8428 gsignal /build/glibc-9tT8Do/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f26904ba02a abort /build/glibc-9tT8Do/glibc-2.23/stdlib/abort.c:91:0
5 0x00000000038fbfed llvm::llvm_unreachable_internal(char const*, char const*, unsigned int) (/path/to/swift/bin/swift+0x38fbfed)
6 0x00000000014fcfe6 (/path/to/swift/bin/swift+0x14fcfe6)
7 0x00000000013465a3 (anonymous namespace)::ExprRewriter::coerceExistential(swift::Expr*, swift::Type, swift::constraints::ConstraintLocatorBuilder) (/path/to/swift/bin/swift+0x13465a3)
8 0x000000000133d624 (anonymous namespace)::ExprRewriter::coerceToType(swift::Expr*, swift::Type, swift::constraints::ConstraintLocatorBuilder, llvm::Optional<swift::Pattern*>) (/path/to/swift/bin/swift+0x133d624)
9 0x000000000133c5c9 (anonymous namespace)::ExprRewriter::coerceToType(swift::Expr*, swift::Type, swift::constraints::ConstraintLocatorBuilder, llvm::Optional<swift::Pattern*>) (/path/to/swift/bin/swift+0x133c5c9)
10 0x0000000001356784 (anonymous namespace)::ExprRewriter::coerceCallArguments(swift::Expr*, swift::Type, llvm::PointerUnion<swift::ApplyExpr*, llvm::PointerEmbeddedInt<unsigned int, 2> >, llvm::ArrayRef<swift::Identifier>, bool, swift::constraints::ConstraintLocatorBuilder) (/path/to/swift/bin/swift+0x1356784)
11 0x00000000013420a8 (anonymous namespace)::ExprRewriter::finishApply(swift::ApplyExpr*, swift::Type, swift::constraints::ConstraintLocatorBuilder) (/path/to/swift/bin/swift+0x13420a8)
12 0x0000000001357d23 (anonymous namespace)::ExprRewriter::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0x1357d23)
13 0x000000000133e9e4 (anonymous namespace)::ExprRewriter::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0x133e9e4)
14 0x0000000001344171 (anonymous namespace)::ExprWalker::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0x1344171)
15 0x00000000014608fc swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x14608fc)
16 0x000000000133b83f swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) (/path/to/swift/bin/swift+0x133b83f)
17 0x00000000012a3230 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x12a3230)
18 0x0000000001368ee6 (anonymous namespace)::FailureDiagnosis::typeCheckChildIndependently(swift::Expr*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<TCCFlags, unsigned int>, swift::ExprTypeCheckListener*, bool) (/path/to/swift/bin/swift+0x1368ee6)
19 0x0000000001365093 swift::ASTVisitor<(anonymous namespace)::FailureDiagnosis, bool, void, void, void, void, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x1365093)
20 0x000000000135d72a swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) (/path/to/swift/bin/swift+0x135d72a)
21 0x0000000001364482 swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) (/path/to/swift/bin/swift+0x1364482)
22 0x000000000129fb78 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0x129fb78)
23 0x00000000012a31a6 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x12a31a6)
24 0x0000000001321e35 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x1321e35)
25 0x0000000001321646 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0x1321646)
26 0x0000000001336120 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x1336120)
27 0x0000000000fa3286 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xfa3286)
28 0x00000000004a8892 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a8892)
29 0x00000000004651d7 main (/path/to/swift/bin/swift+0x4651d7)
30 0x00007f26904a3830 __libc_start_main /build/glibc-9tT8Do/glibc-2.23/csu/../csu/libc-start.c:325:0
31 0x0000000000462879 _start (/path/to/swift/bin/swift+0x462879)
```