### PR TITLE
Leaks runner improvements

### DIFF
--- a/benchmark/scripts/Benchmark_RuntimeLeaksRunner.in
+++ b/benchmark/scripts/Benchmark_RuntimeLeaksRunner.in
@@ -89,9 +89,15 @@ class LeaksRunnerBenchmarkDriver(perf_test_driver.BenchmarkDriver):
                 "--num-iters={}".format(num_iters), data['test_name']],
                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             error_out = p.communicate()[1].split("\n")
-        except OSError:
-            print("Child Process Failed! (%s,%s)" % (
+            result = p.returncode
+            if result is None:
+                raise RuntimeError("Expected one line of output")
+            if result != 0:
+                raise RuntimeError("Process segfaulted")
+        except:
+            sys.stderr.write("Child Process Failed! (%s,%s)\n" % (
                 data['path'], data['test_name']))
+            sys.stderr.flush()
             return None
 
         try:
@@ -104,9 +110,10 @@ class LeaksRunnerBenchmarkDriver(perf_test_driver.BenchmarkDriver):
 
             total_count = d['objc_count'] + d['swift_count']
             return total_count
-        except (KeyError, ValueError):
-            print("Failed parse output! (%s,%s)" %
-                  (data['path'], data['test_name']))
+        except:
+            tmp = (data['path'], data['test_name'])
+            sys.stderr.write("Failed parse output! (%s,%s)\n" % tmp)
+            sys.stderr.flush()
             return None
 
     def process_input(self, data):

--- a/benchmark/scripts/perf_test_driver/perf_test_driver.py
+++ b/benchmark/scripts/perf_test_driver/perf_test_driver.py
@@ -99,7 +99,7 @@ class BenchmarkDriver(object):
         if self.enable_parallel:
             p = multiprocessing.Pool()
             z = zip([self] * len(prepared_input), prepared_input)
-            results = p.map(_unwrap_self, z)
+            results = p.map_async(_unwrap_self, z).get(999999)
         else:
             results = map(self.process_input, prepared_input)
 


### PR DESCRIPTION
This PR does two different things:

1. It makes leaks runner support C-c.
2. It makes leaks runner fail nicely when a subtask segfaults instead of just throwing an IndexError.

rdar://31544274
