### PR TITLE
[SILDiagnostics] Add DiagnoseStaticExclusivity to mandatory opt pipeline

### DIFF
--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -77,6 +77,7 @@ static void addMandatoryOptPipeline(SILPassPipelinePlan &P,
   if (Options.EnableMandatorySemanticARCOpts) {
     P.addSemanticARCOpts();
   }
+  P.addDiagnoseStaticExclusivity();
   P.addCapturePromotion();
   P.addAllocBoxToStack();
 


### PR DESCRIPTION
These diagnostics are still off by default. They can be enabled
with -enforce-exclusivity=checked.
