### PR TITLE
Correctly implement SILBasicBlock::erase().

### DIFF
--- a/lib/SIL/SILBasicBlock.cpp
+++ b/lib/SIL/SILBasicBlock.cpp
@@ -90,13 +90,16 @@ void SILBasicBlock::remove(SILInstruction *I) {
   InstList.remove(I);
 }
 
+/// Returns the iterator following the erased instruction, STL-style.
 SILBasicBlock::iterator SILBasicBlock::erase(SILInstruction *I) {
   // Notify the delete handlers that this instruction is going away.
   getModule().notifyDeleteHandlers(&*I);
   auto *F = getParent();
-  auto II = InstList.erase(I);
+  // LLVM does not currently implement ilist::erase correctly. Compensate.
+  iterator next = std::next(SILBasicBlock::iterator(I));
+  InstList.erase(I);
   F->getModule().deallocateInst(I);
-  return II;
+  return next;
 }
 
 /// This method unlinks 'self' from the containing SILFunction and deletes it.


### PR DESCRIPTION
LLVM ilist::erase does not return the following iterator the way an STL list
would. Compensate by computing the next iterator and ignoring LLVM's result.

I expect this to fix the ASAN bots:
<rdar://problem/31550303> OSS Swift CI ASAN bot fails on AccessMarker tests.
