### PR TITLE
[swiftc (36 vs. 5513)] Add crasher in swift::SILVisitor

### DIFF
--- a/validation-test/compiler_crashers/28736-anonymous-namespacesilverifier-require.swift
+++ b/validation-test/compiler_crashers/28736-anonymous-namespacesilverifier-require.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+// RUN: not --crash %target-swift-frontend -primary-file %s -emit-ir -O
+// non-fuzz (@dusek)
+
+func f<T>(_ a:T)->Void{f(nil as[Any]?)}


### PR DESCRIPTION
Add test case for crash triggered in `swift::SILVisitor`.

Current number of unresolved compiler crashers: 36 (5513 resolved)

Stack trace:

```
0 0x0000000003966f78 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3966f78)
1 0x00000000039676b6 SignalHandler(int) (/path/to/swift/bin/swift+0x39676b6)
2 0x00007fa7b0abb390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007fa7aefe1428 gsignal /build/glibc-9tT8Do/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007fa7aefe302a abort /build/glibc-9tT8Do/glibc-2.23/stdlib/abort.c:91:0
5 0x0000000001039070 (anonymous namespace)::SILVerifier::verifySILFunctionType(swift::CanTypeWrapper<swift::SILFunctionType>) (/path/to/swift/bin/swift+0x1039070)
6 0x000000000103f971 swift::SILVisitor<(anonymous namespace)::SILVerifier, void>::visit(swift::ValueBase*) (/path/to/swift/bin/swift+0x103f971)
7 0x000000000103aa53 (anonymous namespace)::SILVerifier::visitSILBasicBlock(swift::SILBasicBlock*) (/path/to/swift/bin/swift+0x103aa53)
8 0x0000000001035bf6 swift::SILFunction::verify(bool) const (/path/to/swift/bin/swift+0x1035bf6)
9 0x00000000010380c0 swift::SILModule::verify() const (/path/to/swift/bin/swift+0x10380c0)
10 0x00000000004aa8d7 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4aa8d7)
11 0x00000000004651d7 main (/path/to/swift/bin/swift+0x4651d7)
12 0x00007fa7aefcc830 __libc_start_main /build/glibc-9tT8Do/glibc-2.23/csu/../csu/libc-start.c:325:0
13 0x0000000000462879 _start (/path/to/swift/bin/swift+0x462879)
```