### PR TITLE
[semantic-sil] Move the ownership model eliminator past no return folding.

### DIFF
--- a/lib/SIL/SILOwnershipVerifier.cpp
+++ b/lib/SIL/SILOwnershipVerifier.cpp
@@ -176,7 +176,8 @@ static bool compatibleOwnershipKinds(ValueOwnershipKind K1,
 
 static bool isValueAddressOrTrivial(SILValue V, SILModule &M) {
   return V->getType().isAddress() ||
-         V.getOwnershipKind() == ValueOwnershipKind::Trivial;
+         V.getOwnershipKind() == ValueOwnershipKind::Trivial ||
+         V.getOwnershipKind() == ValueOwnershipKind::Any;
 }
 
 static bool isOwnershipForwardingValueKind(ValueKind K) {

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -80,9 +80,8 @@ static void addMandatoryOptPipeline(SILPassPipelinePlan &P,
   P.addDiagnoseStaticExclusivity();
   P.addCapturePromotion();
   P.addAllocBoxToStack();
-
-  P.addOwnershipModelEliminator();
   P.addNoReturnFolding();
+  P.addOwnershipModelEliminator();
   P.addDefiniteInitialization();
 
   P.addAccessEnforcementSelection();

--- a/test/SILOptimizer/noreturn_folding_ownership.sil
+++ b/test/SILOptimizer/noreturn_folding_ownership.sil
@@ -1,0 +1,45 @@
+// RUN: %target-sil-opt -module-name Swift -enable-sil-ownership -enable-sil-verify-all -noreturn-folding < %s | %FileCheck %s
+
+import Builtin
+
+enum Never {}
+
+struct Int64 {
+  var value: Builtin.Int64
+}
+
+// We used to crash on this IR. We would delete "%4" while there is still a
+// (dead) user "%7" around.
+
+// CHECK-LABEL: unreachable_outside_block_user
+// CHECK: %[[E:.+]] = function_ref @exit
+// CHECK: apply %[[E]]
+// CHECK: unreachable
+
+sil private @unreachable_outside_block_user : $@convention(thin) () -> Int64 {
+bb0:
+  %0 = integer_literal $Builtin.Int1, -1
+  %1 = integer_literal $Builtin.Int32, 3
+  // function_ref exit
+  %2 = function_ref @exit : $@convention(thin) (Builtin.Int32) -> Never
+  %3 = apply %2(%1) : $@convention(thin) (Builtin.Int32) -> Never
+  %4 = integer_literal $Builtin.Int64, 7
+  cond_br %0, bb1, bb2
+
+bb1:
+  %5 = metatype $@thin Int64.Type
+  %6 = integer_literal $Builtin.Int64, 42
+  %7 = struct $Int64 (%4 : $Builtin.Int64)
+  br bb3(%7 : $Int64)
+
+bb2:
+  %8 = metatype $@thin Int64.Type
+  %9 = integer_literal $Builtin.Int64, 17
+  %10 = struct $Int64 (%9 : $Builtin.Int64)
+  br bb3(%10 : $Int64)
+
+bb3 (%11: @trivial $Int64):
+  return %11 : $Int64
+}
+
+sil @exit : $@convention(thin) (Builtin.Int32) -> Never


### PR DESCRIPTION
[semantic-sil] Move the ownership model eliminator past no return folding.

rdar://31521023
