### PR TITLE
Unicode rethink: Use FCCNormSegment for small string; 10x speedup

### DIFF
--- a/stdlib/public/core/AnyUnicode.swift.gyb
+++ b/stdlib/public/core/AnyUnicode.swift.gyb
@@ -357,6 +357,8 @@ case unicodeScalar(encodedOffset: Int, width: Int, scalar: UnicodeScalar?)
       return tl == tr && l < r
     case (.character(_, let l), .character(_, let r)):
       return l < r
+    case (.fccNormalizedUTF16(_, let l), .fccNormalizedUTF16(_, let r)):
+      return l < r
     default:
       return false
     }
@@ -370,6 +372,8 @@ case unicodeScalar(encodedOffset: Int, width: Int, scalar: UnicodeScalar?)
     case (.transcoded(_, let l, let tl), (.transcoded(_, let r, let tr))):
       return tl != tr || l == r
     case (.character(_, let l), .character(_, let r)):
+      return l == r
+    case (.fccNormalizedUTF16(_, let l), .fccNormalizedUTF16(_, let r)):
       return l == r
     default:
       return true

--- a/stdlib/public/core/NewString.swift.gyb
+++ b/stdlib/public/core/NewString.swift.gyb
@@ -372,11 +372,24 @@ extension String.Content.Inline${N}or${W} : UnicodeContent {
         _UnicodeViews(_utf16, UTF16.self).transcoded(to: UTF8.self))
   }
   
-  public var fccNormalizedUTF16: AnyUInt16UnicodeView {
-    return bitsPerElement <= 8
-    ? AnyUInt16UnicodeView(utf16)
-    : AnyUInt16UnicodeView(
-      _UnicodeViews(_utf16, UTF16.self).fccNormalizedUTF16)
+  public var fccNormalizedUTF16: FCCNormalizedSegment {
+    let utf16CUs = self._utf16
+    let buffer = UTF16CodeUnitBuffer(utf16CUs)
+
+    // Latin1 already pre-normal
+    if (bitsPerElement <= 8) {
+      return FCCNormalizedSegment(
+        buffer,
+        nativeStart: utf16CUs.startIndex,
+        nativeEnd: utf16CUs.endIndex)
+    }
+
+    // UTF16 needs to be normalized
+    return FCCNormalizedSegment(
+      normalizing: buffer,
+      nativeStart: utf16CUs.startIndex,
+      nativeEnd: utf16CUs.endIndex
+    )
   }
   
   public var characters: AnyCharacterUnicodeView {


### PR DESCRIPTION
This makes FCCNormalizedSegment be a UnicodeView. We can then use it
for the fccNormalizedUTF16 property on the small string types, rather
than a Any construct. This yields a 10x perf improvement for comparing
small Latin1 strings, and likely much more for full unicode strings.
