### PR TITLE
[gardening] Remove redundant logic

### DIFF
--- a/include/swift/SILOptimizer/Analysis/EpilogueARCAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/EpilogueARCAnalysis.h
@@ -172,9 +172,7 @@ public:
   bool mayBlockEpilogueRelease(SILInstruction *II, SILValue Ptr) { 
     // Check whether this instruction read reference count, i.e. uniqueness
     // check. Moving release past that may result in additional COW.
-   if (II->mayReleaseOrReadRefCount())
-      return true;
-    return false;
+    return II->mayReleaseOrReadRefCount();
   } 
 
   /// Does this instruction block the interested ARC instruction ?

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -191,9 +191,7 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
   }
 
   bool visitTypeAliasDecl(TypeAliasDecl *TAD) {
-    if (doIt(TAD->getUnderlyingTypeLoc()))
-      return true;
-    return false;
+    return doIt(TAD->getUnderlyingTypeLoc());
   }
 
   bool visitAbstractTypeParamDecl(AbstractTypeParamDecl *TPD) {
@@ -1501,9 +1499,7 @@ bool Traversal::visitErrorTypeRepr(ErrorTypeRepr *T) {
 }
 
 bool Traversal::visitAttributedTypeRepr(AttributedTypeRepr *T) {
-  if (doIt(T->getTypeRepr()))
-    return true;
-  return false;
+  return doIt(T->getTypeRepr());
 }
 
 bool Traversal::visitSimpleIdentTypeRepr(SimpleIdentTypeRepr *T) {
@@ -1527,37 +1523,23 @@ bool Traversal::visitCompoundIdentTypeRepr(CompoundIdentTypeRepr *T) {
 }
 
 bool Traversal::visitFunctionTypeRepr(FunctionTypeRepr *T) {
-  if (doIt(T->getArgsTypeRepr()))
-    return true;
-  if (doIt(T->getResultTypeRepr()))
-    return true;
-  return false;
+  return doIt(T->getArgsTypeRepr()) || doIt(T->getResultTypeRepr());
 }
 
 bool Traversal::visitArrayTypeRepr(ArrayTypeRepr *T) {
-  if (doIt(T->getBase()))
-    return true;
-  return false;
+  return doIt(T->getBase());
 }
 
 bool Traversal::visitDictionaryTypeRepr(DictionaryTypeRepr *T) {
-  if (doIt(T->getKey()))
-    return true;
-  if (doIt(T->getValue()))
-    return true;
-  return false;
+  return doIt(T->getKey()) || doIt(T->getValue());
 }
 
 bool Traversal::visitOptionalTypeRepr(OptionalTypeRepr *T) {
-  if (doIt(T->getBase()))
-    return true;
-  return false;
+  return doIt(T->getBase());
 }
 
 bool Traversal::visitImplicitlyUnwrappedOptionalTypeRepr(ImplicitlyUnwrappedOptionalTypeRepr *T) {
-  if (doIt(T->getBase()))
-    return true;
-  return false;
+  return doIt(T->getBase());
 }
 
 bool Traversal::visitTupleTypeRepr(TupleTypeRepr *T) {
@@ -1577,21 +1559,15 @@ bool Traversal::visitCompositionTypeRepr(CompositionTypeRepr *T) {
 }
 
 bool Traversal::visitMetatypeTypeRepr(MetatypeTypeRepr *T) {
-  if (doIt(T->getBase()))
-    return true;
-  return false;
+  return doIt(T->getBase());
 }
 
 bool Traversal::visitProtocolTypeRepr(ProtocolTypeRepr *T) {
-  if (doIt(T->getBase()))
-    return true;
-  return false;
+  return doIt(T->getBase());
 }
 
 bool Traversal::visitInOutTypeRepr(InOutTypeRepr *T) {
-  if (doIt(T->getBase()))
-    return true;
-  return false;
+  return doIt(T->getBase());
 }
 
 bool Traversal::visitFixedTypeRepr(FixedTypeRepr *T) {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1451,9 +1451,7 @@ bool ValueDecl::needsCapture() const {
   if (!getDeclContext()->isLocalContext())
     return false;
   // We don't need to capture types.
-  if (isa<TypeDecl>(this))
-    return false;
-  return true;
+  return !isa<TypeDecl>(this);
 }
 
 ValueDecl *ValueDecl::getOverriddenDecl() const {
@@ -4893,9 +4891,7 @@ ConstructorDecl::getDelegatingOrChainedInitKind(DiagnosticEngine *diags,
 
     bool walkToDeclPre(class Decl *D) override {
       // Don't walk into further nominal decls.
-      if (isa<NominalTypeDecl>(D))
-        return false;
-      return true;
+      return !isa<NominalTypeDecl>(D);
     }
     
     std::pair<bool, Expr*> walkToExprPre(Expr *E) override {

--- a/lib/AST/ModuleNameLookup.cpp
+++ b/lib/AST/ModuleNameLookup.cpp
@@ -49,9 +49,7 @@ static bool isOverloadable(const ValueDecl *VD) {
 static bool isValidOverload(CanTypeSet &overloads, const ValueDecl *VD) {
   if (!isOverloadable(VD))
     return overloads.empty();
-  if (overloads.count(VD->getInterfaceType()->getCanonicalType()))
-    return false;
-  return true;
+  return !overloads.count(VD->getInterfaceType()->getCanonicalType());
 }
 
 static bool isValidOverload(NamedCanTypeSet &overloads, const ValueDecl *VD) {

--- a/lib/AST/SourceEntityWalker.cpp
+++ b/lib/AST/SourceEntityWalker.cpp
@@ -346,9 +346,7 @@ Expr *SemaAnnotator::walkToExprPost(Expr *E) {
 }
 
 bool SemaAnnotator::walkToTypeReprPost(TypeRepr *T) {
-  if (isDone())
-    return false;
-  return true;
+  return !isDone();
 }
 
 std::pair<bool, Pattern *> SemaAnnotator::walkToPatternPre(Pattern *P) {

--- a/lib/AST/TypeWalker.cpp
+++ b/lib/AST/TypeWalker.cpp
@@ -158,9 +158,7 @@ class Traversal : public TypeVisitor<Traversal, bool>
   bool visitTypeVariableType(TypeVariableType *ty) { return false; }
   
   bool visitSILBlockStorageType(SILBlockStorageType *ty) {
-    if (doIt(ty->getCaptureType()))
-      return true;
-    return false;
+    return doIt(ty->getCaptureType());
   }
 
   bool visitSILBoxType(SILBoxType *ty) {

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2014,13 +2014,8 @@ public:
       : NextConsumer(consumer), ClangASTContext(clangASTContext) {}
 
   static bool needsBlacklist(const clang::Module *topLevelModule) {
-    if (!topLevelModule)
-      return false;
-    if (topLevelModule->Name == "Darwin")
-      return true;
-    if (topLevelModule->Name == "CoreServices")
-      return true;
-    return false;
+    return topLevelModule && (topLevelModule->Name == "Darwin" ||
+                              topLevelModule->Name == "CoreServices");
   }
 
   void foundDecl(ValueDecl *VD, DeclVisibilityKind Reason) override {

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -93,9 +93,7 @@ getDefaultMakeStructRawValuedOptions() {
 }
 
 static bool isInSystemModule(DeclContext *D) {
-  if (cast<ClangModuleUnit>(D->getModuleScopeContext())->isSystemModule())
-    return true;
-  return false;
+  return cast<ClangModuleUnit>(D->getModuleScopeContext())->isSystemModule();
 }
 
 static Accessibility getOverridableAccessibility(DeclContext *dc) {

--- a/lib/ClangImporter/ImportMacro.cpp
+++ b/lib/ClangImporter/ImportMacro.cpp
@@ -66,9 +66,7 @@ parseNumericLiteral(ClangImporter::Implementation &impl,
 
 // FIXME: Duplicated from ImportDecl.cpp.
 static bool isInSystemModule(DeclContext *D) {
-  if (cast<ClangModuleUnit>(D->getModuleScopeContext())->isSystemModule())
-    return true;
-  return false;
+  return cast<ClangModuleUnit>(D->getModuleScopeContext())->isSystemModule();
 }
 
 static ValueDecl *

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -506,9 +506,7 @@ static bool moduleIsInferImportAsMember(const clang::NamedDecl *decl,
     if (submodule->IsSwiftInferImportAsMember) {
       // HACK HACK HACK: This is a workaround for some module invalidation issue
       // and inconsistency. This will go away soon.
-      if (submodule->Name != "CoreGraphics")
-        return false;
-      return true;
+      return submodule->Name == "CoreGraphics";
     }
     submodule = submodule->Parent;
   }

--- a/lib/Demangling/NodePrinter.cpp
+++ b/lib/Demangling/NodePrinter.cpp
@@ -263,9 +263,7 @@ private:
       return true;
 
     case Node::Kind::ProtocolList:
-      if (pointer->getChild(0)->getNumChildren() <= 1)
-        return true;
-      return false;
+      return pointer->getChild(0)->getNumChildren() <= 1;
 
     case Node::Kind::Allocator:
     case Node::Kind::ArgumentTuple:

--- a/lib/IDE/SwiftSourceDocInfo.cpp
+++ b/lib/IDE/SwiftSourceDocInfo.cpp
@@ -350,9 +350,8 @@ private:
 
       // Explicitly allow the selection of multiple case statments.
       auto IsCase = [](ASTNode N) { return N.isStmt(StmtKind::Case); };
-      if (llvm::any_of(StartMatches, IsCase) && llvm::any_of(EndMatches, IsCase))
-        return true;
-      return false;
+      return llvm::any_of(StartMatches, IsCase) &&
+          llvm::any_of(EndMatches, IsCase);
     }
   };
 
@@ -603,14 +602,12 @@ public:
     for (auto N : Nodes) {
       if (Stmt *S = N.is<Stmt*>() ? N.get<Stmt*>() : nullptr) {
         if (S->getKind() == StmtKind::Case)
-          CaseCount ++;
+          CaseCount++;
       }
     }
     // If there are more than one case/default statements, there are more than
     // one entry point.
-    if (CaseCount > 1)
-      return false;
-    return true;
+    return CaseCount == 0;
   }
 
   OrphanKind getOrphanKind(ArrayRef<ASTNode> Nodes) {

--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -1055,9 +1055,7 @@ bool ModelASTWalker::annotateIfConfigConditionIdentifiers(Expr *Cond) {
   };
 
   IdRefWalker<decltype(passNode)> Walker(passNode);
-  if (!Cond->walk(Walker))
-    return false;
-  return true;
+  return Cond->walk(Walker);
 }
 
 bool ModelASTWalker::handleSpecialDeclAttribute(const DeclAttribute *D,
@@ -1248,9 +1246,7 @@ bool ModelASTWalker::passNode(const SyntaxNode &Node) {
     }
   }
 
-  if (!Walker.walkToNodePost(Node))
-    return false;
-  return true;
+  return Walker.walkToNodePost(Node);
 }
 
 bool ModelASTWalker::pushStructureNode(const SyntaxStructureNode &Node,

--- a/lib/IRGen/AllocStackHoisting.cpp
+++ b/lib/IRGen/AllocStackHoisting.cpp
@@ -59,9 +59,7 @@ static bool isHoistable(AllocStackInst *Inst, irgen::IRGenModule &Mod) {
 
   // Don't hoist generics with opened archetypes. We would have to hoist the
   // open archetype instruction which might not be possible.
-  if (!Inst->getTypeDependentOperands().empty())
-    return false;
-  return true;
+  return Inst->getTypeDependentOperands().empty();
 }
 
 /// A partition of alloc_stack instructions.

--- a/lib/SIL/SILInstruction.cpp
+++ b/lib/SIL/SILInstruction.cpp
@@ -369,9 +369,7 @@ namespace {
 
     bool visitRefTailAddrInst(RefTailAddrInst *RHS) {
       auto *X = cast<RefTailAddrInst>(LHS);
-      if (X->getTailType() != RHS->getTailType())
-        return false;
-      return true;
+      return X->getTailType() == RHS->getTailType();
     }
 
     bool visitStructElementAddrInst(const StructElementAddrInst *RHS) {
@@ -447,9 +445,7 @@ namespace {
 
     bool visitTailAddrInst(TailAddrInst *RHS) {
       auto *X = cast<TailAddrInst>(LHS);
-      if (X->getTailType() != RHS->getTailType())
-        return false;
-      return true;
+      return X->getTailType() == RHS->getTailType();
     }
 
     bool visitCondFailInst(CondFailInst *RHS) {

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -664,9 +664,7 @@ private:
 
     assert(SGF.silConv.useLoweredAddresses() ==
            SGF.silConv.isSILIndirect(getSelfParameterInfo()));
-    if (!SGF.silConv.useLoweredAddresses())
-      return false;
-    return true;
+    return SGF.silConv.useLoweredAddresses();
   }
 
   // If we're calling a member of a non-class-constrained protocol,

--- a/lib/SILOptimizer/IPO/CapturePropagation.cpp
+++ b/lib/SILOptimizer/IPO/CapturePropagation.cpp
@@ -320,9 +320,7 @@ static bool onlyContainsReturnOrThrowOfArg(SILBasicBlock *BB) {
   for (SILInstruction &I : *BB) {
     if (isa<ReturnInst>(&I) || isa<ThrowInst>(&I)) {
       SILValue RetVal = I.getOperand(0);
-      if (BB->getNumArguments() == 1 && RetVal == BB->getArgument(0))
-        return true;
-      return false;
+      return BB->getNumArguments() == 1 && RetVal == BB->getArgument(0);
     }
     if (I.mayHaveSideEffects() || isa<TermInst>(&I))
       return false;

--- a/lib/SILOptimizer/IPO/GlobalPropertyOpt.cpp
+++ b/lib/SILOptimizer/IPO/GlobalPropertyOpt.cpp
@@ -147,9 +147,7 @@ class GlobalPropertyOpt {
         linkage = SILLinkage::Public;
         break;
     }
-    if (isPossiblyUsedExternally(linkage, M.isWholeModule()))
-      return true;
-    return false;
+    return isPossiblyUsedExternally(linkage, M.isWholeModule());
   }
   
   static bool canAddressEscape(SILValue V, bool acceptStore);

--- a/lib/SILOptimizer/LoopTransforms/ArrayBoundsCheckOpts.cpp
+++ b/lib/SILOptimizer/LoopTransforms/ArrayBoundsCheckOpts.cpp
@@ -651,9 +651,7 @@ static bool isLessThanCheck(SILValue Start, SILValue End,
       // Special case: if it is a 0-to-count loop, we know that the count cannot
       // be negative. In this case the 'Start < End' check can also be done with
       // 'count != 0'.
-      if (getZeroToCountArray(Start, End))
-        return true;
-      return false;
+      return getZeroToCountArray(Start, End);
     default:
       return false;
   }

--- a/lib/SILOptimizer/LoopTransforms/LICM.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LICM.cpp
@@ -269,9 +269,7 @@ static bool hoistInstructions(SILLoop *Loop, DominanceInfo *DT,
     // that dominate all exits.
     if (!std::all_of(ExitingBBs.begin(), ExitingBBs.end(),
                      [=](SILBasicBlock *ExitBB) {
-          if (DT->dominates(CurBB, ExitBB))
-            return true;
-          return false;
+          return DT->dominates(CurBB, ExitBB);
         })) {
       DEBUG(llvm::dbgs() << "  skipping conditional block " << *CurBB << "\n");
       It.skipChildren();

--- a/lib/SILOptimizer/Transforms/CSE.cpp
+++ b/lib/SILOptimizer/Transforms/CSE.cpp
@@ -822,10 +822,7 @@ bool CSE::canHandle(SILInstruction *Inst) {
         case ArrayCallKind::kGetCapacity:
         case ArrayCallKind::kCheckIndex:
         case ArrayCallKind::kCheckSubscript:
-          if (SemCall.hasGuaranteedSelf()) {
-            return true;
-          }
-          return false;
+          return SemCall.hasGuaranteedSelf();
         default:
           return false;
       }

--- a/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
@@ -46,9 +46,7 @@ static bool seemsUseful(SILInstruction *I) {
   if (auto *BI = dyn_cast<BuiltinInst>(I)) {
     // Although the onFastPath builtin has no side-effects we don't want to
     // remove it.
-    if (BI->getBuiltinInfo().ID == BuiltinValueKind::OnFastPath)
-      return true;
-    return false;
+    return BI->getBuiltinInfo().ID == BuiltinValueKind::OnFastPath;
   }
 
   if (isa<ReturnInst>(I) || isa<UnreachableInst>(I) || isa<ThrowInst>(I))

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -6998,9 +6998,7 @@ bool FailureDiagnosis::visitUnresolvedMemberExpr(UnresolvedMemberExpr *E) {
   case CC_Unavailable:
   case CC_Inaccessible:
     // Diagnose some simple and common errors.
-    if (candidateInfo.diagnoseSimpleErrors(E))
-      return true;
-    return false;
+    return candidateInfo.diagnoseSimpleErrors(E);
       
   case CC_ArgumentLabelMismatch: { // Argument labels are not correct.
     auto argExpr = typeCheckArgumentChildIndependently(E->getArgument(),


### PR DESCRIPTION
Replace …

```c++
if (foo)
  return true;
return false;
```

… with …

```c++
return foo;
```