### PR TITLE
[GSB] Basic infrastructure for delaying and reprocessing requirements

### DIFF
--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -2287,12 +2287,11 @@ ConstraintResult GenericSignatureBuilder::addConformanceRequirement(
       // Add requirements placed directly on this associated type.
       auto AssocPA = T->getNestedType(AssocType, *this);
 
-      if (AssocPA != T) {
-        auto assocResult =
-          addInheritedRequirements(AssocType, AssocPA, Source, Visited);
-        if (isErrorResult(assocResult))
-          return assocResult;
-      }
+      auto assocResult =
+        addInheritedRequirements(AssocType, AssocPA, Source, Visited);
+      if (isErrorResult(assocResult))
+        return assocResult;
+
       if (auto WhereClause = AssocType->getTrailingWhereClause()) {
         for (auto &req : WhereClause->getRequirements()) {
           auto innerSource =

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -909,7 +909,7 @@ static void remapRequirements(GenericSignature *GenSig,
 
       Requirement Req(Kind, first, second);
       auto Failure = Builder.addRequirement(Req, source);
-      assert(!Failure);
+      assert(!isErrorResult(Failure));
       DEBUG(llvm::dbgs() << "\nRe-mapped requirement:\n"; Req.dump());
       break;
     }
@@ -920,7 +920,7 @@ static void remapRequirements(GenericSignature *GenSig,
       Requirement Req(RequirementKind::Layout, first,
                       reqReq.getLayoutConstraint());
       auto Failure = Builder.addRequirement(Req, source);
-      assert(!Failure);
+      assert(!!isErrorResult(Failure));
       DEBUG(llvm::dbgs() << "\nRe-mapped requirement:\n"; Req.dump());
       break;
     }

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -350,7 +350,7 @@ void TypeChecker::checkGenericParamList(GenericSignatureBuilder *builder,
                             options, resolver))
       continue;
 
-    if (builder && builder->addRequirement(&req))
+    if (builder && isErrorResult(builder->addRequirement(&req)))
       req.setInvalid();
   }
 }

--- a/validation-test/compiler_crashers_fixed/28730-unreachable-executed-at-swift-lib-ast-astcontext-cpp-1229.swift
+++ b/validation-test/compiler_crashers_fixed/28730-unreachable-executed-at-swift-lib-ast-astcontext-cpp-1229.swift
@@ -5,5 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 class a=protocol P{{}typealias e:P}}extension P{func a{}typealias e:a


### PR DESCRIPTION
Start staging in support for delaying the processing of a requirement in the `GenericSignatureBuilder` when one of the involved types cannot be immediately resolved. In such cases, stash the requirement to be resolved later. Most of this infrastructure is unused at this point, but is important for the detection of recursion in constraint systems.

While here... fix an issue where the `GenericSignatureBuilder` was placing conformance requirements on the representative of the equivalence class rather than on the potential archetype that was named, which breaks some invariants. That in turn uncovered a latent idempotency problem in the GSB, where we wouldn't necessarily have the appropriate anchor within a component within the implied same-type constraint graphs.