### PR TITLE
Don't inherit convenience inits if a designated init is missing.

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3186,9 +3186,6 @@ class ClassDecl : public NominalTypeDecl {
   SourceLoc ClassLoc;
   ObjCMethodLookupTable *ObjCMethodLookup = nullptr;
 
-  /// Whether the class has @objc ancestry.
-  unsigned ObjCKind : 3;
-
   /// Create the Objective-C member lookup table.
   void createObjCMethodLookup();
 
@@ -3197,6 +3194,11 @@ class ClassDecl : public NominalTypeDecl {
     /// superclass was computed yet or not.
     llvm::PointerIntPair<Type, 1, bool> Superclass;
   } LazySemanticInfo;
+
+  /// Whether the class has @objc ancestry.
+  unsigned ObjCKind : 3;
+
+  unsigned HasMissingDesignatedInitializers : 1;
 
   friend class IterativeTypeChecker;
 
@@ -3280,6 +3282,17 @@ public:
   /// \see getForeignClassKind
   bool isForeign() const {
     return getForeignClassKind() != ForeignKind::Normal;
+  }
+
+  /// Returns true if the class has designated initializers that are not listed
+  /// in its members.
+  ///
+  /// This can occur, for example, if the class is an Objective-C class with
+  /// initializers that cannot be represented in Swift.
+  bool hasMissingDesignatedInitializers() const;
+
+  void setHasMissingDesignatedInitializers(bool newValue = true) {
+    HasMissingDesignatedInitializers = newValue;
   }
 
   /// Find a method of a class that overrides a given method.

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -6908,7 +6908,8 @@ ClangImporter::Implementation::importDeclImpl(const clang::NamedDecl *ClangDecl,
   }
   if (!Result && version == CurrentVersion) {
     // If we couldn't import this Objective-C entity, determine
-    // whether it was a required member of a protocol.
+    // whether it was a required member of a protocol, or a designated
+    // initializer of a class.
     bool hasMissingRequiredMember = false;
     if (auto clangProto
           = dyn_cast<clang::ObjCProtocolDecl>(ClangDecl->getDeclContext())) {
@@ -6927,6 +6928,21 @@ ClangImporter::Implementation::importDeclImpl(const clang::NamedDecl *ClangDecl,
         if (auto proto = cast_or_null<ProtocolDecl>(
                 importDecl(clangProto, CurrentVersion))) {
           proto->setHasMissingRequirements(true);
+        }
+      }
+    }
+    if (auto method = dyn_cast<clang::ObjCMethodDecl>(ClangDecl)) {
+      if (!SwiftContext.LangOpts.isSwiftVersion3() &&
+          method->isDesignatedInitializerForTheInterface()) {
+        const clang::ObjCInterfaceDecl *theClass = method->getClassInterface();
+        assert(theClass && "cannot be a protocol method here");
+        // Only allow this to affect declarations in the same top-level module
+        // as the original class.
+        if (getClangModuleForDecl(theClass) == getClangModuleForDecl(method)) {
+          if (auto swiftClass = cast_or_null<ClassDecl>(
+                  importDecl(theClass, CurrentVersion))) {
+            swiftClass->setHasMissingDesignatedInitializers();
+          }
         }
       }
     }

--- a/test/ClangImporter/Inputs/custom-modules/UnimportableMembers.h
+++ b/test/ClangImporter/Inputs/custom-modules/UnimportableMembers.h
@@ -1,0 +1,34 @@
+__attribute__((objc_root_class))
+@interface Base
+- (instancetype)init;
+@end
+
+@interface IncompleteDesignatedInitializers : Base
+- (instancetype)initFirst:(long)x __attribute__((objc_designated_initializer));
+- (instancetype)initSecond:(long)x __attribute__((objc_designated_initializer));
+- (instancetype)initMissing:(long)x, ... __attribute__((objc_designated_initializer));
+- (instancetype)initConveniently:(long)x;
+@end
+@interface IncompleteDesignatedInitializers (CategoryConvenience)
+- (instancetype)initCategory:(long)x;
+@end
+
+@interface IncompleteConvenienceInitializers : Base
+- (instancetype)initFirst:(long)x __attribute__((objc_designated_initializer));
+- (instancetype)initSecond:(long)x __attribute__((objc_designated_initializer));
+- (instancetype)initMissing:(long)x, ...;
+- (instancetype)initConveniently:(long)x;
+@end
+@interface IncompleteConvenienceInitializers (CategoryConvenience)
+- (instancetype)initCategory:(long)x;
+@end
+
+@interface IncompleteUnknownInitializers : Base
+- (instancetype)initFirst:(long)x;
+- (instancetype)initSecond:(long)x;
+- (instancetype)initMissing:(long)x, ...;
+- (instancetype)initConveniently:(long)x;
+@end
+@interface IncompleteUnknownInitializers (CategoryConvenience)
+- (instancetype)initCategory:(long)x;
+@end

--- a/test/ClangImporter/Inputs/custom-modules/module.map
+++ b/test/ClangImporter/Inputs/custom-modules/module.map
@@ -138,6 +138,10 @@ module TypeAndValue {
   export *
 }
 
+module UnimportableMembers {
+  header "UnimportableMembers.h"
+}
+
 module UsesSubmodule {
   header "UsesSubmodule.h"
   export *

--- a/test/ClangImporter/objc_missing_designated_init.swift
+++ b/test/ClangImporter/objc_missing_designated_init.swift
@@ -1,0 +1,68 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/custom-modules %s -swift-version 4 -verify
+
+// REQUIRES: objc_interop
+
+import UnimportableMembers
+
+class IncompleteInitSubclassImplicit : IncompleteDesignatedInitializers {
+  var myOneNewMember = 1
+}
+
+class IncompleteInitSubclass : IncompleteDesignatedInitializers {
+  override init(first: Int) {}
+  override init(second: Int) {}
+}
+
+class IncompleteConvenienceInitSubclass : IncompleteConvenienceInitializers {}
+
+class IncompleteUnknownInitSubclass : IncompleteUnknownInitializers {}
+
+func testBaseClassesBehaveAsExpected() {
+  _ = IncompleteDesignatedInitializers(first: 0) // okay
+  _ = IncompleteDesignatedInitializers(second: 0) // okay
+  _ = IncompleteDesignatedInitializers(missing: 0) // expected-error {{argument labels '(missing:)' do not match any available overloads}} expected-note {{overloads}}
+  _ = IncompleteDesignatedInitializers(conveniently: 0) // okay
+  _ = IncompleteDesignatedInitializers(category: 0) // okay
+
+  _ = IncompleteConvenienceInitializers(first: 0) // okay
+  _ = IncompleteConvenienceInitializers(second: 0) // okay
+  _ = IncompleteConvenienceInitializers(missing: 0) // expected-error {{argument labels '(missing:)' do not match any available overloads}} expected-note {{overloads}}
+  _ = IncompleteConvenienceInitializers(conveniently: 0) // okay
+  _ = IncompleteConvenienceInitializers(category: 0) // okay
+
+  _ = IncompleteUnknownInitializers(first: 0) // okay
+  _ = IncompleteUnknownInitializers(second: 0) // okay
+  _ = IncompleteUnknownInitializers(missing: 0) // expected-error {{argument labels '(missing:)' do not match any available overloads}} expected-note {{overloads}}
+  _ = IncompleteUnknownInitializers(conveniently: 0) // okay
+  _ = IncompleteUnknownInitializers(category: 0) // okay
+}
+
+func testSubclasses() {
+  _ = IncompleteInitSubclass(first: 0) // okay
+  _ = IncompleteInitSubclass(second: 0) // okay
+  _ = IncompleteInitSubclass(missing: 0) // expected-error {{argument labels '(missing:)' do not match any available overloads}} expected-note {{overloads}}
+  _ = IncompleteInitSubclass(conveniently: 0) // expected-error {{argument labels '(conveniently:)' do not match any available overloads}} expected-note {{overloads}}
+  _ = IncompleteInitSubclass(category: 0) // expected-error {{argument labels '(category:)' do not match any available overloads}} expected-note {{overloads}}
+
+  _ = IncompleteInitSubclassImplicit(first: 0) // okay
+  _ = IncompleteInitSubclassImplicit(second: 0) // okay
+  _ = IncompleteInitSubclassImplicit(missing: 0) // expected-error {{argument labels '(missing:)' do not match any available overloads}} expected-note {{overloads}}
+  _ = IncompleteInitSubclassImplicit(conveniently: 0) // expected-error {{argument labels '(conveniently:)' do not match any available overloads}} expected-note {{overloads}}
+  _ = IncompleteInitSubclassImplicit(category: 0) // expected-error {{argument labels '(category:)' do not match any available overloads}} expected-note {{overloads}}
+
+  _ = IncompleteConvenienceInitSubclass(first: 0) // okay
+  _ = IncompleteConvenienceInitSubclass(second: 0) // okay
+  _ = IncompleteConvenienceInitSubclass(missing: 0) // expected-error {{argument labels '(missing:)' do not match any available overloads}} expected-note {{overloads}}
+  _ = IncompleteConvenienceInitSubclass(conveniently: 0) // okay
+  _ = IncompleteConvenienceInitSubclass(category: 0) // okay
+
+  _ = IncompleteUnknownInitSubclass(first: 0) // okay
+  _ = IncompleteUnknownInitSubclass(second: 0) // okay
+  _ = IncompleteUnknownInitSubclass(missing: 0) // expected-error {{argument labels '(missing:)' do not match any available overloads}} expected-note {{overloads}}
+  _ = IncompleteUnknownInitSubclass(conveniently: 0) // okay
+
+  // FIXME: This initializer isn't being inherited for some reason, unrelated
+  // to the non-importable -initMissing:.
+  // https://bugs.swift.org/browse/SR-4566
+  _ = IncompleteUnknownInitSubclass(category: 0) // expected-error {{argument labels '(category:)' do not match any available overloads}} expected-note {{overloads}}
+}


### PR DESCRIPTION
(which can happen if an imported class has un-importable initializers)

Our initializer model guarantees that it's safe to inherit convenience initializers when a subclass has implemented all designated initializers, since each convenience initializer will be implemented by calling one of the designated initializers. If one of the designated initializers *can't* be implemented in Swift, however, then inheriting the convenience initializer would not be safe.

This is potentially a source-breaking change, so the importer will only actually record that it failed to import something in when compiling in Swift 4 mode. I also found an unrelated bug about initializer inheritance, which I filed as [SR-4566](https://bugs.swift.org/browse/SR-4566).

I'm using this as groundwork for the "deserialization recovery" I've been doing. I'd *like* to do something better than dropping a designated initializer just because the declaration it overrides has changed, but this is a safe default, at least.

rdar://problem/31563662