### PR TITLE
[SILOpt] fix the ASAN issue in the new pass completely.

### DIFF
--- a/lib/SIL/SILBasicBlock.cpp
+++ b/lib/SIL/SILBasicBlock.cpp
@@ -90,16 +90,14 @@ void SILBasicBlock::remove(SILInstruction *I) {
   InstList.remove(I);
 }
 
-/// Returns the iterator following the erased instruction, STL-style.
+/// Returns the iterator following the erased instruction.
 SILBasicBlock::iterator SILBasicBlock::erase(SILInstruction *I) {
   // Notify the delete handlers that this instruction is going away.
   getModule().notifyDeleteHandlers(&*I);
   auto *F = getParent();
-  // LLVM does not currently implement ilist::erase correctly. Compensate.
-  iterator next = std::next(SILBasicBlock::iterator(I));
-  InstList.erase(I);
+  auto nextIter = InstList.erase(I);
   F->getModule().deallocateInst(I);
-  return next;
+  return nextIter;
 }
 
 /// This method unlinks 'self' from the containing SILFunction and deletes it.

--- a/lib/SILOptimizer/Mandatory/AccessMarkerElimination.cpp
+++ b/lib/SILOptimizer/Mandatory/AccessMarkerElimination.cpp
@@ -52,10 +52,12 @@ struct AccessMarkerElimination : SILModuleTransform {
           if (auto beginAccess = dyn_cast<BeginAccessInst>(inst)) {
             beginAccess->replaceAllUsesWith(beginAccess->getSource());
             II = BB.erase(beginAccess);
+            continue;
           }
           if (auto endAccess = dyn_cast<EndAccessInst>(inst)) {
             assert(endAccess->use_empty());
             II = BB.erase(endAccess);
+            continue;
           }
         }
       }

--- a/test/SILOptimizer/access_marker_elim.sil
+++ b/test/SILOptimizer/access_marker_elim.sil
@@ -1,5 +1,4 @@
 // RUN: %target-sil-opt -enforce-exclusivity=checked -emit-sorted-sil -access-marker-elim %s | %FileCheck %s
-// REQUIRES: rdar:31550303 OSS Swift CI ASAN bot fails on AccessMarker tests.
 
 sil_stage raw
 

--- a/test/SILOptimizer/access_marker_mandatory.swift
+++ b/test/SILOptimizer/access_marker_mandatory.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-frontend -parse-as-library -Xllvm -sil-full-demangle -enforce-exclusivity=checked -emit-sil %s | %FileCheck %s
-// REQUIRES: rdar:31550303 OSS Swift CI ASAN bot fails on AccessMarker tests.
 
 public struct S {
   var i: Int


### PR DESCRIPTION
LLVM's ilist::erase is actually correct. It just implements a nonstandard remove
method that modifies its iterator argument.

I forgot to add "continue" statements when fixing the iterator-invalidation problem.