### PR TITLE
[GSB] Delay requirements on recursive types

### DIFF
--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -370,7 +370,7 @@ private:
   /// relative to the given module.
   ConstraintResult addInheritedRequirements(
                                 TypeDecl *decl,
-                                PotentialArchetype *pa,
+                                UnresolvedType type,
                                 const RequirementSource *parentSource,
                                 llvm::SmallPtrSetImpl<ProtocolDecl *> &visited,
                                 ModuleDecl *inferForModule);

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -59,6 +59,22 @@ class TypeRepr;
 class ASTContext;
 class DiagnosticEngine;
 
+/// Determines how to resolve a dependent type to a potential archetype.
+enum class ArchetypeResolutionKind {
+  /// Always create a new potential archetype to describe this dependent type,
+  /// which might be invalid and may not provide complete information.
+  AlwaysPartial,
+
+  /// Only create a potential archetype when it is well-formed (e.g., a nested
+  /// type should exist) and make sure we have complete information about
+  /// that potential archetype.
+  CompleteWellFormed,
+
+  /// Only create a new potential archetype to describe this dependent type
+  /// if it is already known.
+  AlreadyKnown,
+};
+
 /// \brief Collects a set of requirements of generic parameters, both explicitly
 /// stated and inferred, and determines the set of archetypes for each of
 /// the generic parameters.
@@ -623,14 +639,15 @@ private:
 public:
   /// \brief Resolve the given type to the potential archetype it names.
   ///
-  /// This routine will synthesize nested types as required to refer to a
-  /// potential archetype, even in cases where no requirement specifies the
-  /// requirement for such an archetype. FIXME: The failure to include such a
-  /// requirement will be diagnosed at some point later (when the types in the
-  /// signature are fully resolved).
+  /// The \c resolutionKind parameter describes how resolution should be
+  /// performed. If the potential archetype named by the given dependent type
+  /// already exists, it will be always returned. If it doesn't exist yet,
+  /// the \c resolutionKind dictates whether the potential archetype will
+  /// be created or whether null will be returned.
   ///
   /// For any type that cannot refer to an archetype, this routine returns null.
-  PotentialArchetype *resolveArchetype(Type type);
+  PotentialArchetype *resolveArchetype(Type type,
+                                       ArchetypeResolutionKind resolutionKind);
 
   /// \brief Resolve the given type as far as this Builder knows how.
   ///
@@ -1171,6 +1188,10 @@ public:
   /// Return the "inferred" version of this source, if it isn't already
   /// inferred.
   FloatingRequirementSource asInferred(const TypeRepr *typeRepr) const;
+
+  /// Whether this requirement source is recursive when composed with
+  /// the given type.
+  bool isRecursive(Type rootType, GenericSignatureBuilder &builder) const;
 };
 
 class GenericSignatureBuilder::PotentialArchetype {
@@ -1504,15 +1525,6 @@ public:
   PotentialArchetype *getNestedType(TypeAliasDecl *typealias,
                                     GenericSignatureBuilder &builder);
 
-  /// \brief Retrieve (or create) a nested type that is the current best
-  /// nested archetype anchor (locally) with the given name.
-  ///
-  /// When called on the archetype anchor, this will produce the named
-  /// archetype anchor.
-  PotentialArchetype *getNestedArchetypeAnchor(
-                                           Identifier name,
-                                           GenericSignatureBuilder &builder);
-
   /// Describes the kind of update that is performed.
   enum class NestedTypeUpdate {
     /// Resolve an existing potential archetype, but don't create a new
@@ -1524,6 +1536,16 @@ public:
     /// create it.
     AddIfBetterAnchor,
   };
+
+  /// \brief Retrieve (or create) a nested type that is the current best
+  /// nested archetype anchor (locally) with the given name.
+  ///
+  /// When called on the archetype anchor, this will produce the named
+  /// archetype anchor.
+  PotentialArchetype *getNestedArchetypeAnchor(
+                       Identifier name,
+                       GenericSignatureBuilder &builder,
+                       NestedTypeUpdate kind = NestedTypeUpdate::AddIfMissing);
 
   /// Update the named nested type when we know this type conforms to the given
   /// protocol.

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -267,12 +267,6 @@ private:
                                              ProtocolDecl *Proto,
                                              const RequirementSource *Source);
 
-  ConstraintResult addConformanceRequirement(
-                               PotentialArchetype *T,
-                               ProtocolDecl *Proto,
-                               const RequirementSource *Source,
-                               llvm::SmallPtrSetImpl<ProtocolDecl *> &Visited);
-
 public:
   /// \brief Add a new same-type requirement between two fully resolved types
   /// (output of \c GenericSignatureBuilder::resolve).
@@ -338,9 +332,7 @@ private:
                           UnresolvedType subject,
                           UnresolvedType constraint,
                           FloatingRequirementSource source,
-                          UnresolvedHandlingKind unresolvedHandling,
-                          llvm::SmallPtrSetImpl<ProtocolDecl *> *visited
-                            = nullptr);
+                          UnresolvedHandlingKind unresolvedHandling);
 
   /// \brief Add a new conformance requirement specifying that the given
   /// potential archetypes are equivalent.
@@ -388,7 +380,6 @@ private:
                                 TypeDecl *decl,
                                 UnresolvedType type,
                                 const RequirementSource *parentSource,
-                                llvm::SmallPtrSetImpl<ProtocolDecl *> &visited,
                                 ModuleDecl *inferForModule);
 
   /// Visit all of the potential archetypes.
@@ -479,13 +470,6 @@ public:
                                   FloatingRequirementSource source,
                                   ModuleDecl *inferForModule,
                                   const SubstitutionMap *subMap = nullptr);
-
-  ConstraintResult addRequirement(
-                                const Requirement &req,
-                                FloatingRequirementSource source,
-                                ModuleDecl *inferForModule,
-                                const SubstitutionMap *subMap,
-                                llvm::SmallPtrSetImpl<ProtocolDecl *> &Visited);
 
   /// \brief Add all of a generic signature's parameters and requirements.
   void addGenericSignature(GenericSignature *sig);

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3130,10 +3130,14 @@ void ProtocolDecl::computeRequirementSignature() {
   GenericSignatureBuilder builder(getASTContext(),
                                   LookUpConformanceInModule(module));
   builder.addGenericParameter(selfType);
+  auto selfPA =
+      builder.resolveArchetype(selfType,
+                               ArchetypeResolutionKind::CompleteWellFormed);
+
   builder.addRequirement(
          requirement,
          GenericSignatureBuilder::RequirementSource
-          ::forRequirementSignature(builder.resolveArchetype(selfType), this),
+          ::forRequirementSignature(selfPA, this),
          nullptr);
   builder.finalize(SourceLoc(), { selfType });
   

--- a/lib/AST/GenericEnvironment.cpp
+++ b/lib/AST/GenericEnvironment.cpp
@@ -201,7 +201,10 @@ Type GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(
     Type contextType = self->getContextTypes()[index];
     if (!contextType) {
       assert(self->Builder && "Missing generic signature builder for lazy query");
-      auto potentialArchetype = self->Builder->resolveArchetype(type);
+      auto potentialArchetype =
+        self->Builder->resolveArchetype(
+                                  type,
+                                  ArchetypeResolutionKind::CompleteWellFormed);
 
       auto mutableSelf = const_cast<GenericEnvironment *>(self);
       contextType =

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -489,7 +489,8 @@ bool GenericSignature::requiresClass(Type type, ModuleDecl &mod) {
   if (!type->isTypeParameter()) return false;
 
   auto &builder = *getGenericSignatureBuilder(mod);
-  auto pa = builder.resolveArchetype(type);
+  auto pa =
+    builder.resolveArchetype(type, ArchetypeResolutionKind::CompleteWellFormed);
   if (!pa) return false;
 
   pa = pa->getRepresentative();
@@ -519,7 +520,8 @@ Type GenericSignature::getSuperclassBound(Type type, ModuleDecl &mod) {
   if (!type->isTypeParameter()) return nullptr;
 
   auto &builder = *getGenericSignatureBuilder(mod);
-  auto pa = builder.resolveArchetype(type);
+  auto pa =
+    builder.resolveArchetype(type, ArchetypeResolutionKind::CompleteWellFormed);
   if (!pa) return nullptr;
 
   pa = pa->getRepresentative();
@@ -539,7 +541,8 @@ SmallVector<ProtocolDecl *, 2> GenericSignature::getConformsTo(Type type,
   if (!type->isTypeParameter()) return { };
 
   auto &builder = *getGenericSignatureBuilder(mod);
-  auto pa = builder.resolveArchetype(type);
+  auto pa =
+    builder.resolveArchetype(type, ArchetypeResolutionKind::CompleteWellFormed);
   if (!pa) return { };
 
   pa = pa->getRepresentative();
@@ -565,7 +568,8 @@ bool GenericSignature::conformsToProtocol(Type type, ProtocolDecl *proto,
   if (!type->isTypeParameter()) return false;
 
   auto &builder = *getGenericSignatureBuilder(mod);
-  auto pa = builder.resolveArchetype(type);
+  auto pa =
+    builder.resolveArchetype(type, ArchetypeResolutionKind::CompleteWellFormed);
   if (!pa) return false;
 
   pa = pa->getRepresentative();
@@ -593,7 +597,8 @@ Type GenericSignature::getConcreteType(Type type, ModuleDecl &mod) {
   if (!type->isTypeParameter()) return Type();
 
   auto &builder = *getGenericSignatureBuilder(mod);
-  auto pa = builder.resolveArchetype(type);
+  auto pa =
+    builder.resolveArchetype(type, ArchetypeResolutionKind::CompleteWellFormed);
   if (!pa) return Type();
 
   pa = pa->getRepresentative();
@@ -607,7 +612,8 @@ LayoutConstraint GenericSignature::getLayoutConstraint(Type type,
   if (!type->isTypeParameter()) return LayoutConstraint();
 
   auto &builder = *getGenericSignatureBuilder(mod);
-  auto pa = builder.resolveArchetype(type);
+  auto pa =
+    builder.resolveArchetype(type, ArchetypeResolutionKind::CompleteWellFormed);
   if (!pa) return LayoutConstraint();
 
   pa = pa->getRepresentative();
@@ -623,12 +629,16 @@ bool GenericSignature::areSameTypeParameterInContext(Type type1, Type type2,
     return true;
 
   auto &builder = *getGenericSignatureBuilder(mod);
-  auto pa1 = builder.resolveArchetype(type1);
+  auto pa1 =
+    builder.resolveArchetype(type1,
+                             ArchetypeResolutionKind::CompleteWellFormed);
   assert(pa1 && "not a valid dependent type of this signature?");
   pa1 = pa1->getRepresentative();
   assert(!pa1->isConcreteType());
 
-  auto pa2 = builder.resolveArchetype(type2);
+  auto pa2 =
+    builder.resolveArchetype(type2,
+                             ArchetypeResolutionKind::CompleteWellFormed);
   assert(pa2 && "not a valid dependent type of this signature?");
   pa2 = pa2->getRepresentative();
   assert(!pa2->isConcreteType());
@@ -667,7 +677,9 @@ bool GenericSignature::isCanonicalTypeInContext(Type type,
   return !type.findIf([&](Type component) -> bool {
     if (!component->isTypeParameter()) return false;
 
-    auto pa = builder.resolveArchetype(component);
+    auto pa =
+      builder.resolveArchetype(component,
+                               ArchetypeResolutionKind::CompleteWellFormed);
     if (!pa) return false;
 
     auto rep = pa->getArchetypeAnchor(builder);
@@ -692,7 +704,9 @@ CanType GenericSignature::getCanonicalTypeInContext(Type type,
 
     // Resolve the potential archetype.  This can be null in nested generic
     // types, which we can't immediately canonicalize.
-    auto pa = builder.resolveArchetype(Type(component));
+    auto pa =
+      builder.resolveArchetype(Type(component),
+                               ArchetypeResolutionKind::CompleteWellFormed);
     if (!pa) return None;
 
     auto rep = pa->getArchetypeAnchor(builder);
@@ -768,7 +782,8 @@ ConformanceAccessPath GenericSignature::getConformanceAccessPath(
 
   // Resolve this type to a potential archetype.
   auto &builder = *getGenericSignatureBuilder(mod);
-  auto pa = builder.resolveArchetype(type);
+  auto pa =
+    builder.resolveArchetype(type, ArchetypeResolutionKind::CompleteWellFormed);
   auto equivClass = pa->getOrCreateEquivalenceClass();
 
   // Dig out the conformance of this type to the given protocol, because we
@@ -859,7 +874,11 @@ ConformanceAccessPath GenericSignature::getConformanceAccessPath(
       Type storedType = eraseAssociatedTypes(source->getStoredType());
 
       // Dig out the potential archetype for this stored type.
-      auto pa = reqSigBuilder.resolveArchetype(storedType);
+      // FIXME: CompleteWellFormed here?
+      auto pa =
+        reqSigBuilder.resolveArchetype(
+                                 storedType,
+                                 ArchetypeResolutionKind::AlwaysPartial);
       auto equivClass = pa->getOrCreateEquivalenceClass();
 
       // Find the conformance of this potential archetype to the protocol in

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -2335,10 +2335,9 @@ ConstraintResult GenericSignatureBuilder::addConformanceRequirement(
   for (auto Member : getProtocolMembers(Proto)) {
     if (auto AssocType = dyn_cast<AssociatedTypeDecl>(Member)) {
       // Add requirements placed directly on this associated type.
-      auto AssocPA = PAT->getNestedType(AssocType, *this);
-
+      Type assocType = DependentMemberType::get(concreteSelf, AssocType);
       auto assocResult =
-        addInheritedRequirements(AssocType, AssocPA, Source, Visited,
+        addInheritedRequirements(AssocType, assocType, Source, Visited,
                                  protoModule);
       if (isErrorResult(assocResult))
         return assocResult;
@@ -2964,7 +2963,7 @@ void GenericSignatureBuilder::markPotentialArchetypeRecursive(
 
 ConstraintResult GenericSignatureBuilder::addInheritedRequirements(
                              TypeDecl *decl,
-                             PotentialArchetype *pa,
+                             UnresolvedType type,
                              const RequirementSource *parentSource,
                              llvm::SmallPtrSetImpl<ProtocolDecl *> &visited,
                              ModuleDecl *inferForModule) {
@@ -3011,7 +3010,7 @@ ConstraintResult GenericSignatureBuilder::addInheritedRequirements(
                         getFloatingSource(typeRepr, /*forInferred=*/true));
     }
 
-    return addTypeRequirement(pa, inheritedType,
+    return addTypeRequirement(type, inheritedType,
                               getFloatingSource(typeRepr,
                                                 /*forInferred=*/false),
                               UnresolvedHandlingKind::GenerateConstraints,
@@ -3019,7 +3018,7 @@ ConstraintResult GenericSignatureBuilder::addInheritedRequirements(
   };
 
   auto visitLayout = [&](LayoutConstraint layout, const TypeRepr *typeRepr) {
-    return addLayoutRequirement(pa, layout,
+    return addLayoutRequirement(type, layout,
                                 getFloatingSource(typeRepr,
                                                   /*forInferred=*/false),
                                 UnresolvedHandlingKind::GenerateConstraints);

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -42,7 +42,8 @@ Type DependentGenericTypeResolver::resolveDependentMemberType(
                                      DeclContext *DC,
                                      SourceRange baseRange,
                                      ComponentIdentTypeRepr *ref) {
-  auto archetype = Builder.resolveArchetype(baseTy);
+  auto archetype =
+    Builder.resolveArchetype(baseTy, ArchetypeResolutionKind::AlwaysPartial);
   assert(archetype && "Bad generic context nesting?");
 
   return archetype
@@ -52,7 +53,8 @@ Type DependentGenericTypeResolver::resolveDependentMemberType(
 
 Type DependentGenericTypeResolver::resolveSelfAssociatedType(
        Type selfTy, AssociatedTypeDecl *assocType) {
-  auto archetype = Builder.resolveArchetype(selfTy);
+  auto archetype =
+    Builder.resolveArchetype(selfTy, ArchetypeResolutionKind::AlwaysPartial);
   assert(archetype && "Bad generic context nesting?");
   
   return archetype
@@ -72,10 +74,12 @@ bool DependentGenericTypeResolver::areSameType(Type type1, Type type2) {
   if (!type1->hasTypeParameter() && !type2->hasTypeParameter())
     return type1->isEqual(type2);
 
-  auto pa1 = Builder.resolveArchetype(type1);
-  auto pa2 = Builder.resolveArchetype(type2);
+  auto pa1 =
+    Builder.resolveArchetype(type1, ArchetypeResolutionKind::AlwaysPartial);
+  auto pa2 =
+    Builder.resolveArchetype(type2, ArchetypeResolutionKind::AlwaysPartial);
   if (pa1 && pa2)
-    return pa1->getArchetypeAnchor(Builder) == pa2->getArchetypeAnchor(Builder);
+    return pa1->isInSameEquivalenceClassAs(pa2);
 
   return type1->isEqual(type2);
 }
@@ -194,7 +198,9 @@ Type CompleteGenericTypeResolver::resolveDependentMemberType(
                                     SourceRange baseRange,
                                     ComponentIdentTypeRepr *ref) {
   // Resolve the base to a potential archetype.
-  auto basePA = Builder.resolveArchetype(baseTy);
+  auto basePA =
+    Builder.resolveArchetype(baseTy,
+                             ArchetypeResolutionKind::CompleteWellFormed);
   assert(basePA && "Missing potential archetype for base");
 
   // Retrieve the potential archetype for the nested type.
@@ -257,7 +263,8 @@ Type CompleteGenericTypeResolver::resolveDependentMemberType(
 
 Type CompleteGenericTypeResolver::resolveSelfAssociatedType(
        Type selfTy, AssociatedTypeDecl *assocType) {
-  return Builder.resolveArchetype(selfTy)
+  return Builder.resolveArchetype(selfTy,
+                                  ArchetypeResolutionKind::CompleteWellFormed)
            ->getNestedType(assocType, Builder)
            ->getDependentType(GenericParams, /*allowUnresolved=*/false);
 }
@@ -274,10 +281,13 @@ bool CompleteGenericTypeResolver::areSameType(Type type1, Type type2) {
   if (!type1->hasTypeParameter() && !type2->hasTypeParameter())
     return type1->isEqual(type2);
 
-  auto pa1 = Builder.resolveArchetype(type1);
-  auto pa2 = Builder.resolveArchetype(type2);
+  // FIXME: Want CompleteWellFormed here?
+  auto pa1 =
+    Builder.resolveArchetype(type1, ArchetypeResolutionKind::AlwaysPartial);
+  auto pa2 =
+    Builder.resolveArchetype(type2, ArchetypeResolutionKind::AlwaysPartial);
   if (pa1 && pa2)
-    return pa1->getArchetypeAnchor(Builder) == pa2->getArchetypeAnchor(Builder);
+    return pa1->isInSameEquivalenceClassAs(pa2);
 
   return type1->isEqual(type2);
 }

--- a/test/decl/protocol/recursive_requirement.swift
+++ b/test/decl/protocol/recursive_requirement.swift
@@ -41,7 +41,7 @@ struct Y2 : P2 {
 }
 
 func f<T : P2>(_ z: T) {
- _ = X2<T.A>()
+ _ = X2<T.A>() // expected-error{{type 'T.A' does not conform to protocol 'P2'}}
 }
 
 // -----
@@ -69,11 +69,11 @@ f2(Y3())
 // -----
 
 protocol Alpha {
-  associatedtype Beta: Gamma // expected-error{{type may not reference itself as a requirement}}
+  associatedtype Beta: Gamma
 }
 
 protocol Gamma {
-  associatedtype Delta: Alpha // expected-error{{type may not reference itself as a requirement}}
+  associatedtype Delta: Alpha
 }
 
 // FIXME: Redundancy diagnostics are odd here.
@@ -111,7 +111,7 @@ protocol AsExistentialAssocTypeAgainB {
 
 // SR-547
 protocol A {
-    associatedtype B1: B // expected-error{{type may not reference itself as a requirement}}
+    associatedtype B1: B
     associatedtype C1: C
     
     mutating func addObserver(_ observer: B1, forProperty: C1)
@@ -122,7 +122,7 @@ protocol C {
 }
 
 protocol B {
-    associatedtype BA: A // expected-error{{type may not reference itself as a requirement}}
+    associatedtype BA: A
     associatedtype BC: C
     
     func observeChangeOfProperty(_ property: BC, observable: BA)


### PR DESCRIPTION
Delaying requirements that form new, recursively-defined types, providing an alternative to the current detect-recursion-complain-and-bail approach that bans recursive protocol requirements entirely. This is along the path toward recursive protocol conformances (which would require us to reprocess those requirements when we need to later), and eliminates some extraneous bookkeeping in the `GenericSignatureBuilder`.