### PR TITLE
[Serialization] Drop overriding initializers with missing bases.

### DIFF
--- a/include/swift/Serialization/ModuleFile.h
+++ b/include/swift/Serialization/ModuleFile.h
@@ -526,15 +526,6 @@ private:
                    GenericContext *genericDecl,
                    serialization::GenericEnvironmentID envID);
 
-  /// Populates the vector with members of a DeclContext from \c DeclTypeCursor.
-  ///
-  /// Returns true if there is an error.
-  ///
-  /// Note: this destroys the cursor's position in the stream. Furthermore,
-  /// because it reads from the cursor, it is not possible to reset the cursor
-  /// after reading. Nothing should ever follow a MEMBERS record.
-  bool readMembers(SmallVectorImpl<Decl *> &Members);
-
   /// Populates the protocol's default witness table.
   ///
   /// Returns true if there is an error.

--- a/test/Serialization/Recovery/Inputs/custom-modules/Overrides.h
+++ b/test/Serialization/Recovery/Inputs/custom-modules/Overrides.h
@@ -68,3 +68,50 @@
 // - (nonnull Element)objectAtIndexedSubscript:(nonnull id)key;
 #endif
 @end
+
+
+@interface DesignatedInitDisappearsBase : Object
+- (nonnull instancetype)init __attribute__((objc_designated_initializer));
+- (nonnull instancetype)initConvenience:(long)value;
+#if !BAD
+- (nonnull instancetype)initWithValue:(long)value __attribute__((objc_designated_initializer));
+#else
+//- (nonnull instancetype)initWithValue:(long)value __attribute__((objc_designated_initializer));
+#endif
+@end
+
+@interface OnlyDesignatedInitDisappearsBase : Object
+- (nonnull instancetype)initConvenience:(long)value;
+#if !BAD
+- (nonnull instancetype)initWithValue:(long)value __attribute__((objc_designated_initializer));
+#else
+//- (nonnull instancetype)initWithValue:(long)value __attribute__((objc_designated_initializer));
+#endif
+@end
+
+@interface ConvenienceInitDisappearsBase : Object
+- (nonnull instancetype)init __attribute__((objc_designated_initializer));
+- (nonnull instancetype)initConvenience:(long)value;
+#if !BAD
+- (nonnull instancetype)initWithValue:(long)value;
+#else
+//- (nonnull instancetype)initWithValue:(long)value;
+#endif
+@end
+
+@interface UnknownInitDisappearsBase : Object
+- (nonnull instancetype)init;
+#if !BAD
+- (nonnull instancetype)initWithValue:(long)value;
+#else
+//- (nonnull instancetype)initWithValue:(long)value;
+#endif
+@end
+
+@interface OnlyUnknownInitDisappearsBase : Object
+#if !BAD
+- (nonnull instancetype)initWithValue:(long)value;
+#else
+//- (nonnull instancetype)initWithValue:(long)value;
+#endif
+@end


### PR DESCRIPTION
This is the same as the last few commits (#8580, #8698), but with the additional complication of designated initializers affecting other behavior around the type. In particular, convenience initializers cannot be invoked on subclasses if the designated initializers are not all present on the subclass. If a designated initializer is dropped, it's not possible to satisfy that.

It would be nice to do better here, since a class's initializers are mostly independent of the superclass's initializers. Unfortunately, it still affects whether *this* class can inherit convenience initializers, as well as vtable layout. This is conservative, at least.

This PR currently slurps in #8708, building on the same feature.