### PR TITLE
Remove -O from a couple type checker perf tests, and add another test.

### DIFF
--- a/validation-test/Sema/type_checker_perf_failing/nil_coalescing.swift.gyb
+++ b/validation-test/Sema/type_checker_perf_failing/nil_coalescing.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: not %scale-test -O --begin 1 --end 3 --step 1 --select incrementScopeCounter %s
+// RUN: not %scale-test --begin 1 --end 3 --step 1 --select incrementScopeCounter %s
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf_failing/rdar30606089.swift.gyb
+++ b/validation-test/Sema/type_checker_perf_failing/rdar30606089.swift.gyb
@@ -2,8 +2,11 @@
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 
-let a = [
-%for i in range(0, N):
-  (1, 1),
+let derivative = { (t: Double) -> (Double) in
+  return -2.0 / (
+  (1.0 + t)
+%for i in range(1, N):
+  * (1.0 + t)
 %end
-]
+  )
+}


### PR DESCRIPTION
We don't need -O here. The new test is another known failure.
