### PR TITLE
Fix IRGen/condfail.sil on s390x

### DIFF
--- a/test/IRGen/condfail.sil
+++ b/test/IRGen/condfail.sil
@@ -31,7 +31,7 @@ import Swift
 // CHECK-armv7s:      trap
 // CHECK-powerpc64:   trap
 // CHECK-powerpc64le: trap
-// CHECK-s390x:       trap
+// CHECK-s390x:       j       .Ltmp{{[0-9]+}}+2
 // CHECK-NOT-x86_64:      .cfi_endproc
 // CHECK-NOT-i386:        .cfi_endproc
 // CHECK-NOT-arm64:       .cfi_endproc
@@ -55,7 +55,7 @@ import Swift
 // CHECK-armv7s:      trap
 // CHECK-powerpc64:   trap
 // CHECK-powerpc64le: trap
-// CHECK-s390x:       trap
+// CHECK-s390x:       j       .Ltmp{{[0-9]+}}+2
 // CHECK-x86_64:      .cfi_endproc
 // CHECK-i386:        .cfi_endproc
 // CHECK-arm64:       .cfi_endproc


### PR DESCRIPTION
On s390x, traps are supported as legal DAG opcodes and "j .+2" are generated for them.
https://reviews.llvm.org/D21155