### PR TITLE
[stdlib] Fix Collection discussion typo

### DIFF
--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -551,8 +551,8 @@ public struct IndexingIterator<
 ///     }
 ///     // Prints "Highest second-half absences: 3"
 ///
-/// Slice Inherit Collection Semantics
-/// ----------------------------------
+/// Slices Inherit Collection Semantics
+/// -----------------------------------
 ///
 /// A slice inherits the value or reference semantics of its base collection.
 /// That is, when working with a slice of a mutable

--- a/stdlib/public/core/FloatingPoint.swift.gyb
+++ b/stdlib/public/core/FloatingPoint.swift.gyb
@@ -1536,8 +1536,6 @@ public func >= <T : FloatingPoint>(lhs: T, rhs: T) -> Bool {
 /// the standard library by `Float`, `Double`, and `Float80` where available.
 ///
 /// [spec]: http://ieeexplore.ieee.org/servlet/opac?punumber=4610933
-///
-/// - SeeAlso: `FloatingPoint`
 public protocol BinaryFloatingPoint: FloatingPoint, ExpressibleByFloatLiteral {
 
   /// A type that represents the encoded significand of a value.


### PR DESCRIPTION
Fixes a typo in the discussion for `Collection` and removes an unnecessary "See Also".