### PR TITLE
[indexer] Add an option to index local symbols too, and a new index::indexDeclContext() entry point

### DIFF
--- a/include/swift/Index/Index.h
+++ b/include/swift/Index/Index.h
@@ -18,9 +18,11 @@
 namespace swift {
 class ModuleDecl;
 class SourceFile;
+class DeclContext;
 
 namespace index {
 
+void indexDeclContext(DeclContext *DC, IndexDataConsumer &consumer);
 void indexSourceFile(SourceFile *SF, StringRef hash,
                      IndexDataConsumer &consumer);
 void indexModule(ModuleDecl *module, StringRef hash,

--- a/include/swift/Index/IndexDataConsumer.h
+++ b/include/swift/Index/IndexDataConsumer.h
@@ -26,9 +26,11 @@ public:
 
   virtual ~IndexDataConsumer() {}
 
+  virtual bool enableWarnings() { return false; }
+  virtual bool indexLocals() { return false; }
+
   virtual void failed(StringRef error) = 0;
   virtual void warning(StringRef warning) {}
-  virtual bool enableWarnings() { return false; }
 
   virtual bool recordHash(StringRef hash, bool isKnown) = 0;
   virtual bool startDependency(StringRef name, StringRef path, bool isClangModule,

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -227,12 +227,14 @@ class IndexSwiftASTWalker : public SourceEntityWalker {
 
 public:
   IndexSwiftASTWalker(IndexDataConsumer &IdxConsumer, ASTContext &Ctx,
-                      unsigned BufferID)
+                      unsigned BufferID = -1)
       : IdxConsumer(IdxConsumer), SrcMgr(Ctx.SourceMgr), BufferID(BufferID),
         enableWarnings(IdxConsumer.enableWarnings()) {}
+
   ~IndexSwiftASTWalker() override { assert(Cancelled || EntitiesStack.empty()); }
 
   void visitModule(ModuleDecl &Mod, StringRef Hash);
+  void visitDeclContext(DeclContext *DC);
 
 private:
   bool visitImports(SourceFileOrModule Mod,
@@ -406,7 +408,7 @@ private:
   bool shouldIndex(ValueDecl *D, bool IsRef) const {
     if (D->isImplicit())
       return false;
-    if (isLocalSymbol(D) && (!isa<ParamDecl>(D) || IsRef))
+    if (!IdxConsumer.indexLocals() && isLocalSymbol(D) && (!isa<ParamDecl>(D) || IsRef))
       return false;
     if (D->isPrivateStdlibDecl())
       return false;
@@ -437,6 +439,12 @@ private:
   llvm::DenseMap<ModuleDecl *, llvm::SmallVector<ModuleDecl *, 4>> ImportsMap;
 };
 } // anonymous namespace
+
+void IndexSwiftASTWalker::visitDeclContext(DeclContext *Context) {
+  IsModuleFile = false;
+  isSystemModule = Context->getParentModule()->isSystemModule();
+  walk(Context);
+}
 
 void IndexSwiftASTWalker::visitModule(ModuleDecl &Mod, StringRef KnownHash) {
   SourceFile *SrcFile = nullptr;
@@ -1243,6 +1251,14 @@ void IndexSwiftASTWalker::getModuleHash(SourceFileOrModule Mod,
 // Indexing entry points
 //===----------------------------------------------------------------------===//
 
+void index::indexDeclContext(DeclContext *DC, IndexDataConsumer &consumer) {
+  assert(DC);
+  unsigned bufferId = DC->getParentSourceFile()->getBufferID().getValue();
+  IndexSwiftASTWalker walker(consumer, DC->getASTContext(), bufferId);
+  walker.visitDeclContext(DC);
+  consumer.finish();
+}
+
 void index::indexSourceFile(SourceFile *SF, StringRef hash,
                             IndexDataConsumer &consumer) {
   assert(SF);
@@ -1255,8 +1271,7 @@ void index::indexSourceFile(SourceFile *SF, StringRef hash,
 void index::indexModule(ModuleDecl *module, StringRef hash,
                         IndexDataConsumer &consumer) {
   assert(module);
-  IndexSwiftASTWalker walker(consumer, module->getASTContext(),
-                             /*bufferID*/ -1);
+  IndexSwiftASTWalker walker(consumer, module->getASTContext());
   walker.visitModule(*module, hash);
   consumer.finish();
 }

--- a/lib/Index/IndexSymbol.cpp
+++ b/lib/Index/IndexSymbol.cpp
@@ -136,8 +136,6 @@ static SymbolKind getVarSymbolKind(const VarDecl *VD) {
     }
     return SymbolKind::InstanceProperty;
   }
-
-  assert(!DC->isLocalContext() && "local variable seen while indexing");
   return SymbolKind::Variable;
 }
 

--- a/test/Index/local.swift
+++ b/test/Index/local.swift
@@ -1,0 +1,43 @@
+// RUN: %target-swift-ide-test -print-indexed-symbols -source-filename %s | %FileCheck -check-prefix=CHECK %s
+// RUN: %target-swift-ide-test -print-indexed-symbols -include-locals  -source-filename %s | %FileCheck -check-prefix=LOCAL %s
+
+func foo(a: Int, b: Int, c: Int) {
+    let x = a + b
+    // LOCAL: [[@LINE-1]]:9 | variable(local)/Swift | x | [[x_USR:.*]] | Def,RelChild | rel: 1
+    // CHECK-NOT: [[@LINE-2]]:9 | variable(local)/Swift | x | [[x_USR:.*]] | Def,RelChild | rel: 1
+
+    let y = x + c
+    // LOCAL: [[@LINE-1]]:9 | variable(local)/Swift | y | [[y_USR:.*]] | Def,RelChild | rel: 1
+    // CHECK-NOT: [[@LINE-2]]:9 | variable(local)/Swift | y | [[y_USR:.*]] | Def,RelChild | rel: 1
+    // LOCAL: [[@LINE-3]]:13 | variable(local)/Swift | x | [[x_USR]] | Ref,Read,RelCont | rel: 1
+    // CHECK-NOT: [[@LINE-4]]:13 | variable(local)/Swift | x | [[x_USR]] | Ref,Read,RelCont | rel: 1
+
+    struct LocalStruct {
+        // LOCAL: [[@LINE-1]]:12 | struct(local)/Swift | LocalStruct | [[LocalStruct_USR:.*]] | Def,RelChild | rel: 1
+        // CHECK-NOT: [[@LINE-2]]:12 | struct(local)/Swift | LocalStruct | [[LocalStruct_USR:.*]] | Def,RelChild | rel: 1
+
+        let member = 2
+        // LOCAL: [[@LINE-1]]:13 | instance-property(local)/Swift | member | {{.*}} | Def,RelChild | rel: 1
+        // LOCAL-NEXT: RelChild | struct(local)/Swift | LocalStruct | [[LocalStruct_USR]]
+        // CHECK-NOT: [[@LINE-3]]:13 | instance-property(local)/Swift | member | {{.*}} | Def,RelChild | rel: 1
+    }
+
+    enum LocalEnum {
+        // LOCAL: [[@LINE-1]]:10 | enum(local)/Swift | LocalEnum | [[LocalEnum_USR:.*]] | Def,RelChild | rel: 1
+        // CHECK-NOT: [[@LINE-2]]:10 | enum(local)/Swift | LocalEnum | [[LocalEnum_USR:.*]] | Def,RelChild | rel: 1
+
+        case foo(x: LocalStruct)
+        // LOCAL: [[@LINE-1]]:14 | enumerator(local)/Swift | foo | [[LocalEnum_foo_USR:.*]] | Def,RelChild | rel: 1
+        // CHECK-NOT: [[@LINE-2]]:14 | enumerator(local)/Swift | foo | [[LocalEnum_foo_USR:.*]] | Def,RelChild | rel: 1
+        // LOCAL: [[@LINE-3]]:21 | struct(local)/Swift | LocalStruct | [[LocalStruct_USR]] | Ref | rel: 0
+    }
+
+    let _ = LocalEnum.foo(x: LocalStruct())
+    // LOCAL: [[@LINE-1]]:13 | enum(local)/Swift | LocalEnum | [[LocalEnum_USR]] | Ref,RelCont | rel: 1
+    // CHECK-NOT: [[@LINE-2]]:13 | enum(local)/Swift | LocalEnum | [[LocalEnum_USR]] | Ref,RelCont | rel: 1
+    // LOCAL: [[@LINE-3]]:23 | enumerator(local)/Swift | foo | [[LocalEnum_foo_USR]] | Ref,RelCont | rel: 1
+    // CHECK-NOT: [[@LINE-4]]:23 | enumerator(local)/Swift | foo | [[LocalEnum_foo_USR]] | Ref,RelCont | rel: 1
+    // LOCAL: [[@LINE-5]]:30 | struct(local)/Swift | LocalStruct | [[LocalStruct_USR]] | Ref,RelCont | rel: 1
+    // CHECK-NOT: [[@LINE-6]]:30 | struct(local)/Swift | LocalStruct | [[LocalStruct_USR]] | Ref,RelCont | rel: 1
+
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves rdar://problem/31433002.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->