### PR TITLE
Fix multifile infinite-type checks.

### DIFF
--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -575,6 +575,17 @@ static void typeCheckFunctionsAndExternalDecls(TypeChecker &TC) {
   // FIXME: Horrible hack. Store this somewhere more appropriate.
   TC.Context.LastCheckedExternalDefinition = currentExternalDef;
 
+  // Now that all types have been finalized, run any delayed
+  // circularity checks.
+  // This has been written carefully to fail safe + finitely if
+  // for some reason a type gets re-delayed.
+  for (size_t i = 0, e = TC.DelayedCircularityChecks.size(); i != e; ++i) {
+    TC.checkDeclCircularity(TC.DelayedCircularityChecks[i]);
+    assert(e == TC.DelayedCircularityChecks.size() &&
+           "circularity checking for type was re-delayed!");
+  }
+  TC.DelayedCircularityChecks.clear();
+
   // Compute captures for functions and closures we visited.
   for (AnyFunctionRef closure : TC.ClosuresWithUncomputedCaptures) {
     TC.computeCaptures(closure);

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -660,6 +660,9 @@ public:
   /// to be finalized before we can hand off to SILGen etc.
   llvm::SetVector<NominalTypeDecl *> TypesToFinalize;
 
+  /// The list of types whose circularity checks were delayed.
+  SmallVector<NominalTypeDecl*, 8> DelayedCircularityChecks;
+
   using TypeAccessScopeCacheMap = llvm::DenseMap<const ValueDecl *, AccessScope>;
 
   /// Caches the outermost scope where a particular declaration can be used,

--- a/test/Sema/Inputs/unsupported_recursive_value_type_multifile_helper.swift
+++ b/test/Sema/Inputs/unsupported_recursive_value_type_multifile_helper.swift
@@ -1,0 +1,3 @@
+struct B {
+  var a: A
+}

--- a/test/Sema/unsupported_recursive_value_type_multifile.swift
+++ b/test/Sema/unsupported_recursive_value_type_multifile.swift
@@ -1,0 +1,7 @@
+// RUN: %target-swift-frontend -emit-silgen -verify -primary-file %s %S/Inputs/unsupported_recursive_value_type_multifile_helper.swift
+
+struct A {
+  var b: B?
+  // expected-error@-1 {{value type 'A' cannot have a stored property that recursively contains it}}
+  // expected-note@-2 {{cycle beginning here: B? -> (some: B) -> (a: A)}}
+}


### PR DESCRIPTION
If checking succeeds, but we found an untyped property/case,
we just need to wait and re-check after everything has been typed.

Fixes rdar://30010094