### PR TITLE
Unicode rethink: explode code units; 3x speedup

### DIFF
--- a/stdlib/public/core/NewString.swift.gyb
+++ b/stdlib/public/core/NewString.swift.gyb
@@ -338,8 +338,40 @@ extension String.Content {
     let bits: UInt61
   }
 }
+% end
 
+// Faster, more tailored operations for specific forms
+extension String.Content.Inline5or6 {
+  public var fccNormalizedUTF16: UTF16View {
+    _sanityCheck(bitsPerElement <= 8, "5or6 can't encode UTF16")
 
+    // Already pre-normal. Just return the exploded code units
+    return utf16
+  }
+}
+extension String.Content.Inline7or16 {
+  public var fccNormalizedUTF16: FCCNormalizedSegment {
+    let utf16CUs = self._utf16
+    let buffer = UTF16CodeUnitBuffer(utf16CUs)
+
+    // Latin1 already pre-normal
+    if (bitsPerElement <= 8) {
+      return FCCNormalizedSegment(
+        buffer,
+        nativeStart: utf16CUs.startIndex,
+        nativeEnd: utf16CUs.endIndex)
+    }
+
+    // UTF16 needs to be normalized
+    return FCCNormalizedSegment(
+      normalizing: buffer,
+      nativeStart: utf16CUs.startIndex,
+      nativeEnd: utf16CUs.endIndex
+    )
+  }
+}
+
+% for (N,W) in (5,6), (7,16):
 extension String.Content.Inline${N}or${W} {
   public init?<Source: Collection>(utf16 source: Source)
   where Source.Iterator.Element == UTF16.CodeUnit {
@@ -392,29 +424,6 @@ extension String.Content.Inline${N}or${W} : UnicodeContent {
           UInt8(truncatingBitPattern: $0) }))
     : AnyUInt8UnicodeView(
         _UnicodeViews(_utf16, UTF16.self).transcoded(to: UTF8.self))
-  }
-  
-  public var fccNormalizedUTF16: FCCNormalizedSegment {
-    let utf16CUs = self._utf16
-
-    // FIXME: The 5or6 view might burst out of the small size here needlessly.
-    // Should be typed as a ExplodedUTF16CodeUnits instead for that...
-    let buffer = UTF16CodeUnitBuffer(utf16CUs)
-
-    // Latin1 already pre-normal
-    if (bitsPerElement <= 8) {
-      return FCCNormalizedSegment(
-        buffer,
-        nativeStart: utf16CUs.startIndex,
-        nativeEnd: utf16CUs.endIndex)
-    }
-
-    // UTF16 needs to be normalized
-    return FCCNormalizedSegment(
-      normalizing: buffer,
-      nativeStart: utf16CUs.startIndex,
-      nativeEnd: utf16CUs.endIndex
-    )
   }
   
   public var characters: AnyCharacterUnicodeView {

--- a/stdlib/public/core/NewString.swift.gyb
+++ b/stdlib/public/core/NewString.swift.gyb
@@ -232,7 +232,65 @@ extension String.Content {
   = "eilotrm.apdnsIc ufkMShjTRxgC4013bDNvwyUL2O856P-B79AFKEWV_zGJ/HYX"
 
   public typealias Packed = PackedUnsignedIntegers<UInt60, UInt16>
-  
+
+  // An "exploded" or unpacked structure of UTF16 code units
+  public struct ExplodedUTF16CodeUnits {
+    typealias _Self = ExplodedUTF16CodeUnits
+    // TODO: could be smaller. e.g. 5or6 could just expode to UInt8.
+    public typealias Base = _BoundedCapacity<_CodeUnitArray16<UInt16>>
+    public var base: Base
+
+    public init(_ inlineStr: String.Content.Inline5or6) {
+      // TODO: try skipping the packing struct directly...
+      let source = String.Content.Packed(
+        representation: numericCast(inlineStr.bits & (~(0 as UInt61) >> 1)),
+        bitsPerElement: numericCast(inlineStr.bitsPerElement)
+      )
+      var storage = Base()
+      // dump(inlineStr)
+      String.Content.packingTable.withUTF8Buffer { table in
+        for cu in source {
+          // dump(cu)
+          // dump(table[Int(cu)])
+          storage.append(UInt16(table[Int(cu)]))
+        }
+      }
+      self.base = storage
+      // dump(storage)
+    }
+    public init(_ inlineStr: String.Content.Inline7or16) {
+      // TODO: try skipping the packing struct directly...
+      let source = String.Content.Packed(
+        representation: numericCast(inlineStr.bits & (~(0 as UInt61) >> 1)),
+        bitsPerElement: numericCast(inlineStr.bitsPerElement)
+      )
+      let mask = UInt16(
+        truncatingBitPattern: ~0 << UInt32(inlineStr.bitsPerElement))
+      // dump(inlineStr)
+      var storage = Base()
+      for cu in source {
+        storage.append((cu &+ 32) & ~mask)
+      }
+
+      self.base = Base(storage)
+    }
+  }
+}
+
+extension String.Content.ExplodedUTF16CodeUnits 
+: BidirectionalCollectionWrapper, RandomAccessCollection {
+  public typealias Index = Base.Index
+  public typealias IndexDistance = Base.IndexDistance
+  public typealias Iterator = Base.Iterator
+  ${gyb.expand(
+      'ForwardCollectionAPIs.swift.gyb',
+      base='base',
+      nonmutating=True,
+      Element='UInt16')}
+}
+
+
+extension String.Content {
   static func _pack<Source: Collection>(
     utf16 source: Source, bitsPerElement: UInt16
   ) -> Packed?
@@ -310,18 +368,19 @@ extension String.Content.Inline${N}or${W} : AnyUnicodeContent {
 }
 
 extension String.Content.Inline${N}or${W} : UnicodeContent {
-  public typealias _UTF16View = LazyMapRandomAccessCollection<
-    String.Content.Packed, UTF16.CodeUnit
-  >
-  
-  internal var _utf16: _UTF16View {
-    return String.Content._unpack(
-      bits: bits, 
-      bitsPerElement: numericCast(self.bitsPerElement)
-    )
-  }
+  // public typealias _UTF16View = LazyMapRandomAccessCollection<
+  //   String.Content.Packed, UTF16.CodeUnit
+  // >
 
-  public var utf16: RandomAccessUnicodeView<_UTF16View> {
+  // TODO: We could have a smaller size for 5or6 and 7or16.
+  public typealias _UTF16View = String.Content.ExplodedUTF16CodeUnits
+  public typealias UTF16View = RandomAccessUnicodeView<_UTF16View>
+  
+  public var _utf16: _UTF16View {
+    return _UTF16View(self)
+  }
+  // public var utf16: RandomAccessUnicodeView<UTF16View> {
+  public var utf16: UTF16View {
     return RandomAccessUnicodeView(_utf16)
   }
   
@@ -337,6 +396,9 @@ extension String.Content.Inline${N}or${W} : UnicodeContent {
   
   public var fccNormalizedUTF16: FCCNormalizedSegment {
     let utf16CUs = self._utf16
+
+    // FIXME: The 5or6 view might burst out of the small size here needlessly.
+    // Should be typed as a ExplodedUTF16CodeUnits instead for that...
     let buffer = UTF16CodeUnitBuffer(utf16CUs)
 
     // Latin1 already pre-normal

--- a/stdlib/public/core/StringNormalization.swift
+++ b/stdlib/public/core/StringNormalization.swift
@@ -24,9 +24,83 @@ import SwiftShims
 
 extension UInt16 : _DefaultConstructible {}
 
+// WIP: Trying out a hard(er)-coded fixed size array to wrap. The _DoubleLength
+// approach yields absurd debug-stdlib performance, and absurd generic-
+// specialization compilation times in release.
+public struct _CodeUnitArray8<T : UnsignedInteger> {
+  public var storage: (T, T, T, T, T, T, T, T)
+}
+
+extension _CodeUnitArray8 : RandomAccessCollection, MutableCollection {
+  public typealias Index = Int
+  public typealias IndexDistance = Int
+
+  public var startIndex : Index {
+    return 0
+  }
+  public var endIndex : Index {
+    return 8
+  }
+  public subscript(i: Index) -> T {
+    get {
+      // FIXME: unsafe pointer instead, for perf
+      switch i {
+        case 0: return storage.0
+        case 1: return storage.1
+        case 2: return storage.2
+        case 3: return storage.3
+        case 4: return storage.4
+        case 5: return storage.5
+        case 6: return storage.6
+        case 7: return storage.7
+        default:
+          _sanityCheck(false, "out of bounds access")
+          Builtin.unreachable()
+          // return numericCast(0)
+       }
+    }
+    set {
+      // FIXME: unsafe pointer instead, for perf
+      switch i {
+        case 0: storage.0 = newValue
+        case 1: storage.1 = newValue
+        case 2: storage.2 = newValue
+        case 3: storage.3 = newValue
+        case 4: storage.4 = newValue
+        case 5: storage.5 = newValue
+        case 6: storage.6 = newValue
+        case 7: storage.7 = newValue
+        default:
+          _sanityCheck(false, "out of bounds access")
+          Builtin.unreachable()
+          // fatalError("out of bounds")
+       }
+    }
+  }
+  public func index(after i: Index) -> Index {
+    return i+1
+  }
+  public func index(before i: Index) -> Index {
+    return i-1
+  }
+
+}
+extension _CodeUnitArray8 : _FixedSizeCollection {
+  public init(repeating x: Iterator.Element) {
+    storage = (x, x, x, x, x, x, x, x)
+  }
+}
+
+// With a hard-coded 8-wide, we have skipped the worst part. Use DoubleLength
+// for now.
+//
+public typealias _CodeUnitArray16<T : UnsignedInteger> 
+  = _DoubleLength<_CodeUnitArray8<T>>
+
+
 // TODO: Figure out a more sensible size
 public typealias UTF16CodeUnitBuffer =
-  UnboundCapacity<_BoundedCapacity<_Array8<UInt16>>>
+  UnboundCapacity<_BoundedCapacity<_CodeUnitArray8<UInt16>>>
 
 // A normalization segment that is FCC-normalized. This is a collection of
 // normalized UTF16 code units.
@@ -81,7 +155,6 @@ public struct FCCNormalizedSegment : BidirectionalCollection {
     return buffer.index(before: i)
   }
 
-  // Michael TODO: understand this
   public typealias SubSequence = UnicodeViewSlice<FCCNormalizedSegment>
   public subscript(bounds: Range<Index>) -> SubSequence {
     return SubSequence(base: self, bounds: bounds)
@@ -215,7 +288,6 @@ extension FCCNormalizedSegment : UnicodeView {
       offsetOfSegment: numericCast(nativeStart),
       offsetInSegment: i)
   }
-
 }
 
 // Ask ICU if the given unicode scalar value has a normalization boundary before

--- a/stdlib/public/core/StringNormalization.swift
+++ b/stdlib/public/core/StringNormalization.swift
@@ -228,6 +228,9 @@ extension FCCNormalizedSegment {
   }
 
   static func isPreNormalized(_ buffer: UTF16CodeUnitBuffer) -> Bool {
+    if _fastPath(buffer.count == 0) {
+      return true
+    }
     if _fastPath(buffer.count == 1) {
       return FCCNormalizedSegment.isPreNormalized(utf16CodeUnit: buffer[0])
     }

--- a/stdlib/public/core/UnboundCapacity.swift
+++ b/stdlib/public/core/UnboundCapacity.swift
@@ -142,6 +142,29 @@ extension UnboundCapacity : RangeReplaceableCollection {
     self.init(Base())
   }
 
+  public mutating func append(_ contents: Iterator.Element) {
+    let newCount = count + 1
+    let r = _small(minCapacity: newCount)
+    if _fastPath(r != nil), var s = r {
+      s.append(contents)
+      self = .small(s)
+      return
+    }
+    replaceSubrange(endIndex..<endIndex, with: CollectionOfOne(contents))
+  }
+
+  public mutating func append<C : Collection>(contentsOf contents: C)
+  where C.Iterator.Element == Iterator.Element {
+    let newCount = count + numericCast(contents.count)
+    let r = _small(minCapacity: newCount)
+    if _fastPath(r != nil), var s = r {
+      s.append(contentsOf: contents)
+      self = .small(s)
+      return
+    }
+    replaceSubrange(endIndex..<endIndex, with: contents)
+  }
+
   public mutating func replaceSubrange<C>(
     _ target: Range<Index>,
     with newElements: C

--- a/test/stdlib/StringTraps.swift
+++ b/test/stdlib/StringTraps.swift
@@ -38,6 +38,8 @@ StringTraps.test("endIndex/successor")
   i = s.index(after: i)
   expectCrashLater()
   i = s.index(after: i)
+  var c = s[i]
+  c = s[i]
 }
 
 StringTraps.test("subscript(_:)/endIndex")


### PR DESCRIPTION
<!-- What's in this pull request? -->
By "exploding" the code units for small strings, that is, make a fixed size array and unpack into it, we can net a 3x speedup right away. It also exposes more low-hanging fruit that I'm hoping will give us an even bigger bump soon.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->