### PR TITLE
Attribute @_implements & deriving enum equality not-named ==

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -267,6 +267,11 @@ SIMPLE_DECL_ATTR(discardableResult, DiscardableResult,
 
 SIMPLE_DECL_ATTR(GKInspectable, GKInspectable, OnVar, 66)
 
+DECL_ATTR(_implements, Implements,
+          OnFunc | OnVar | OnSubscript | OnTypeAlias
+          | NotSerialized | UserInaccessible,
+          /* Not serialized */ 67)
+
 #undef TYPE_ATTR
 #undef DECL_ATTR_ALIAS
 #undef SIMPLE_DECL_ATTR

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -25,10 +25,12 @@
 #include "swift/AST/Identifier.h"
 #include "swift/AST/AttrKind.h"
 #include "swift/AST/ConcreteDeclRef.h"
+#include "swift/AST/DeclNameLoc.h"
 #include "swift/AST/KnownProtocols.h"
 #include "swift/AST/Ownership.h"
 #include "swift/AST/PlatformKind.h"
 #include "swift/AST/Requirement.h"
+#include "swift/AST/TypeLoc.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/ErrorHandling.h"
@@ -43,7 +45,6 @@ class Decl;
 class ClassDecl;
 class GenericFunctionType;
 class TrailingWhereClause;
-struct TypeLoc;
 
 /// TypeAttributes - These are attributes that may be applied to types.
 class TypeAttributes {
@@ -1124,6 +1125,36 @@ public:
 
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DAK_Specialize;
+  }
+};
+
+/// The @_implements attribute, which treats a decl as the implementation for
+/// some named protocol requirement (but otherwise not-visible by that name).
+class ImplementsAttr : public DeclAttribute {
+
+  TypeLoc ProtocolType;
+  DeclName MemberName;
+  DeclNameLoc MemberNameLoc;
+
+public:
+  ImplementsAttr(SourceLoc atLoc, SourceRange Range,
+                 TypeLoc ProtocolType,
+                 DeclName MemberName,
+                 DeclNameLoc MemberNameLoc);
+
+  static ImplementsAttr *create(ASTContext &Ctx, SourceLoc atLoc,
+                                SourceRange Range,
+                                TypeLoc ProtocolType,
+                                DeclName MemberName,
+                                DeclNameLoc MemberNameLoc);
+
+  TypeLoc getProtocolType() const;
+  TypeLoc &getProtocolType();
+  DeclName getMemberName() const { return MemberName; }
+  DeclNameLoc getMemberNameLoc() const { return MemberNameLoc; }
+
+  static bool classof(const DeclAttribute *DA) {
+    return DA->getKind() == DAK_Implements;
   }
 };
 

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -287,8 +287,12 @@ class alignas(1 << DeclAlignInBits) Decl {
     /// Whether we have already checked whether this declaration is a 
     /// redeclaration.
     unsigned CheckedRedeclaration : 1;
+
+    /// Whether the decl can be accessed by swift users; for instance,
+    /// a.storage for lazy var a is a decl that cannot be accessed.
+    unsigned IsUserAccessible : 1;
   };
-  enum { NumValueDeclBits = NumDeclBits + 2 };
+  enum { NumValueDeclBits = NumDeclBits + 3 };
   static_assert(NumValueDeclBits <= 32, "fits in an unsigned");
 
   class AbstractStorageDeclBitfields {
@@ -328,11 +332,8 @@ class alignas(1 << DeclAlignInBits) Decl {
     /// It is up to the debugger to instruct SIL how to access this variable.
     unsigned IsDebuggerVar : 1;
 
-    /// Whether the decl can be accessed by swift users; for instance,
-    /// a.storage for lazy var a is a decl that cannot be accessed.
-    unsigned IsUserAccessible : 1;
   };
-  enum { NumVarDeclBits = NumAbstractStorageDeclBits + 6 };
+  enum { NumVarDeclBits = NumAbstractStorageDeclBits + 5 };
   static_assert(NumVarDeclBits <= 32, "fits in an unsigned");
 
   class EnumElementDeclBitfields {
@@ -384,10 +385,8 @@ class alignas(1 << DeclAlignInBits) Decl {
     /// Whether this function has a dynamic Self return type.
     unsigned HasDynamicSelf : 1;
     
-    /// Whether we are statically dispatched even if overridable
-    unsigned ForcedStaticDispatch : 1;
   };
-  enum { NumFuncDeclBits = NumAbstractFunctionDeclBits + 6 };
+  enum { NumFuncDeclBits = NumAbstractFunctionDeclBits + 5 };
   static_assert(NumFuncDeclBits <= 32, "fits in an unsigned");
 
   class ConstructorDeclBitfields {
@@ -401,9 +400,6 @@ class alignas(1 << DeclAlignInBits) Decl {
     /// analysis and SIL generation.
     unsigned ComputedBodyInitKind : 3;
 
-    /// The kind of initializer we have.
-    unsigned InitKind : 2;
-
     /// Whether this initializer is a stub placed into a subclass to
     /// catch invalid delegations to a designated initializer not
     /// overridden by the subclass. A stub will always trap at runtime.
@@ -413,7 +409,7 @@ class alignas(1 << DeclAlignInBits) Decl {
     /// an object construction that will invoke a stub.
     unsigned HasStubImplementation : 1;
   };
-  enum { NumConstructorDeclBits = NumAbstractFunctionDeclBits + 6 };
+  enum { NumConstructorDeclBits = NumAbstractFunctionDeclBits + 4 };
   static_assert(NumConstructorDeclBits <= 32, "fits in an unsigned");
 
   class TypeDeclBitfields {
@@ -524,10 +520,8 @@ class alignas(1 << DeclAlignInBits) Decl {
     /// control inserting the implicit destructor.
     unsigned HasDestructorDecl : 1;
 
-    /// Whether the class has @objc ancestry.
-    unsigned ObjCClassKind : 3;
   };
-  enum { NumClassDeclBits = NumNominalTypeDeclBits + 11 };
+  enum { NumClassDeclBits = NumNominalTypeDeclBits + 8 };
   static_assert(NumClassDeclBits <= 32, "fits in an unsigned");
 
   class StructDeclBitfields {
@@ -2091,6 +2085,7 @@ protected:
     : Decl(K, context), Name(name), NameLoc(NameLoc) {
     ValueDeclBits.AlreadyInLookupTable = false;
     ValueDeclBits.CheckedRedeclaration = false;
+    ValueDeclBits.IsUserAccessible = true;
   }
 
 public:
@@ -2114,6 +2109,14 @@ public:
   /// redeclaration.
   void setCheckedRedeclaration(bool checked) {
     ValueDeclBits.CheckedRedeclaration = checked;
+  }
+
+  void setUserAccessible(bool Accessible) {
+    ValueDeclBits.IsUserAccessible = Accessible;
+  }
+
+  bool isUserAccessible() const {
+    return ValueDeclBits.IsUserAccessible;
   }
 
   bool hasName() const { return bool(Name); }
@@ -3182,6 +3185,9 @@ class ClassDecl : public NominalTypeDecl {
 
   SourceLoc ClassLoc;
   ObjCMethodLookupTable *ObjCMethodLookup = nullptr;
+
+  /// Whether the class has @objc ancestry.
+  unsigned ObjCKind : 3;
 
   /// Create the Objective-C member lookup table.
   void createObjCMethodLookup();
@@ -4278,7 +4284,6 @@ protected:
           SourceLoc NameLoc, Identifier Name, Type Ty, DeclContext *DC)
     : AbstractStorageDecl(Kind, DC, Name, NameLoc)
   {
-    VarDeclBits.IsUserAccessible = true;
     VarDeclBits.IsStatic = IsStatic;
     VarDeclBits.IsLet = IsLet;
     VarDeclBits.IsCaptureList = IsCaptureList;
@@ -4299,14 +4304,6 @@ public:
               DC) {}
 
   SourceRange getSourceRange() const;
-
-  void setUserAccessible(bool Accessible) {
-    VarDeclBits.IsUserAccessible = Accessible;
-  }
-
-  bool isUserAccessible() const {
-    return VarDeclBits.IsUserAccessible;
-  }
 
   TypeLoc &getTypeLoc() { return typeLoc; }
   TypeLoc getTypeLoc() const { return typeLoc; }
@@ -5031,6 +5028,9 @@ class FuncDecl final : public AbstractFunctionDecl,
   unsigned HaveSearchedForCommonOverloadReturnType : 1;
   unsigned HaveFoundCommonOverloadReturnType : 1;
 
+  /// Whether we are statically dispatched even if overridable
+  unsigned ForcedStaticDispatch : 1;
+
   /// \brief If this FuncDecl is an accessor for a property, this indicates
   /// which property and what kind of accessor.
   llvm::PointerIntPair<AbstractStorageDecl*, 3, AccessorKind> AccessorDecl;
@@ -5060,8 +5060,8 @@ class FuncDecl final : public AbstractFunctionDecl,
     assert(NumParameterLists > 0 && "Must have at least an empty tuple arg");
     FuncDeclBits.Mutating = false;
     FuncDeclBits.HasDynamicSelf = false;
-    FuncDeclBits.ForcedStaticDispatch = false;
-        
+
+    ForcedStaticDispatch = false;
     HaveSearchedForCommonOverloadReturnType = false;
     HaveFoundCommonOverloadReturnType = false;
   }
@@ -5291,10 +5291,10 @@ public:
   
   /// Returns true if the function is forced to be statically dispatched.
   bool hasForcedStaticDispatch() const {
-    return FuncDeclBits.ForcedStaticDispatch;
+    return ForcedStaticDispatch;
   }
   void setForcedStaticDispatch(bool flag) {
-    FuncDeclBits.ForcedStaticDispatch = flag;
+    ForcedStaticDispatch = flag;
   }
 
   static bool classof(const Decl *D) { return D->getKind() == DeclKind::Func; }
@@ -5511,6 +5511,9 @@ enum class CtorInitializerKind {
 /// }
 /// \endcode
 class ConstructorDecl : public AbstractFunctionDecl {
+  /// The kind of initializer we have.
+  unsigned InitKind : 2;
+
   /// The failability of this initializer, which is an OptionalTypeKind.
   unsigned Failability : 2;
 
@@ -5616,12 +5619,12 @@ public:
 
   /// Determine the kind of initializer this is.
   CtorInitializerKind getInitKind() const {
-    return static_cast<CtorInitializerKind>(ConstructorDeclBits.InitKind);
+    return static_cast<CtorInitializerKind>(InitKind);
   }
 
   /// Set whether this is a convenience initializer.
   void setInitKind(CtorInitializerKind kind) {
-    ConstructorDeclBits.InitKind = static_cast<unsigned>(kind);
+    InitKind = static_cast<unsigned>(kind);
   }
 
   /// Whether this is a designated initializer.

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -18,6 +18,7 @@
 #define SWIFT_DECL_H
 
 #include "swift/AST/AccessScope.h"
+#include "swift/AST/Attr.h"
 #include "swift/AST/CaptureInfo.h"
 #include "swift/AST/ClangNode.h"
 #include "swift/AST/ConcreteDeclRef.h"
@@ -3795,7 +3796,7 @@ struct alignas(1 << 3) BehaviorRecord {
     : ProtocolName(ProtocolName), Param(Param)
   {}
   
-  SourceLoc getLoc() const { return ProtocolName->getLoc(); }
+  SourceLoc getLoc() const;
 };
 
 /// AbstractStorageDecl - This is the common superclass for VarDecl and

--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -18,6 +18,7 @@
 #ifndef SWIFT_BASIC_DIAGNOSTICENGINE_H
 #define SWIFT_BASIC_DIAGNOSTICENGINE_H
 
+#include "swift/AST/Attr.h"
 #include "swift/AST/TypeLoc.h"
 #include "swift/AST/DeclNameLoc.h"
 #include "swift/AST/DiagnosticConsumer.h"

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1352,6 +1352,10 @@ ERROR(attr_specialize_parameter_already_defined,none,
 ERROR(attr_specialize_expected_partial_or_full,none,
       "expected 'partial' or 'full' as values of the 'kind' parameter in '_specialize' attribute", ())
 
+// _implements
+ERROR(attr_implements_expected_member_name,PointsToFirstBadToken,
+      "expected a member name as second parameter in '_implements' attribute", ())
+
 //------------------------------------------------------------------------------
 // Generics parsing diagnostics
 //------------------------------------------------------------------------------

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2154,6 +2154,17 @@ ERROR(lazy_not_observable,none,
 ERROR(attr_for_debugger_support_only,none,
       "@LLDBDebuggerSupport may only be used when debugger support is on", ())
 
+// @_implements
+ERROR(implements_attr_protocol_lacks_member,none,
+      "protocol %0 has no member %1", (DeclName, DeclName))
+
+ERROR(implements_attr_non_protocol_type,none,
+      "non-protocol type in @_implements attribute", ())
+
+ERROR(implements_attr_protocol_not_conformed_to,none,
+      "containing type %0 does not conform to protocol %1",
+      (DeclName, DeclName))
+
 //------------------------------------------------------------------------------
 // Type Check Expressions
 //------------------------------------------------------------------------------

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -24,6 +24,7 @@
 #include "swift/AST/ProtocolConformanceRef.h"
 #include "swift/AST/TypeAlignments.h"
 #include "swift/AST/TypeLoc.h"
+#include "swift/AST/TypeRepr.h"
 #include "swift/AST/Availability.h"
 #include "llvm/Support/TrailingObjects.h"
 

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -25,6 +25,7 @@
 #include "swift/AST/Identifier.h"
 #include "swift/AST/Types.h"
 #include "swift/AST/TypeLoc.h"
+#include "swift/AST/TypeRepr.h"
 #include "swift/Basic/LLVM.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/FoldingSet.h"

--- a/include/swift/AST/KnownIdentifiers.def
+++ b/include/swift/AST/KnownIdentifiers.def
@@ -90,6 +90,7 @@ IDENTIFIER_WITH_NAME(NativeClassLayout, "_NativeClass")
 // Operators
 IDENTIFIER_WITH_NAME(MatchOperator, "~=")
 IDENTIFIER_WITH_NAME(EqualsOperator, "==")
+IDENTIFIER_WITH_NAME(derived_enum_equals, "__derived_enum_equals")
 
 // Precedence groups
 IDENTIFIER(AssignmentPrecedence)

--- a/include/swift/AST/LazyResolver.h
+++ b/include/swift/AST/LazyResolver.h
@@ -173,6 +173,8 @@ public:
   }
 };
 
+class LazyMemberLoader;
+
 /// Context data for lazy deserialization.
 class LazyContextData {
 public:

--- a/include/swift/AST/TypeLoc.h
+++ b/include/swift/AST/TypeLoc.h
@@ -19,12 +19,12 @@
 
 #include "swift/Basic/SourceLoc.h"
 #include "swift/AST/Type.h"
-#include "swift/AST/TypeRepr.h"
 #include "llvm/ADT/PointerIntPair.h"
 
 namespace swift {
 
 class ASTContext;
+class TypeRepr;
 
 /// TypeLoc - Provides source location information for a parsed type.
 /// A TypeLoc is stored in AST nodes which use an explicitly written type.
@@ -54,11 +54,7 @@ public:
 
   /// Get the representative location of this type, for diagnostic
   /// purposes.
-  SourceLoc getLoc() const {
-    if (TyR) return TyR->getLoc();
-    return SourceLoc();
-  }
-
+  SourceLoc getLoc() const;
   SourceRange getSourceRange() const;
 
   bool hasLocation() const { return TyR != nullptr; }
@@ -72,15 +68,7 @@ public:
     TAndValidBit.setPointerAndInt(Ty, validated);
   }
 
-  TypeLoc clone(ASTContext &ctx) const {
-    if (TyR) {
-      TypeLoc result(TyR->clone(ctx));
-      result.TAndValidBit = this->TAndValidBit;
-      return result;
-    }
-
-    return *this;
-  }
+  TypeLoc clone(ASTContext &ctx) const;
 };
 
 } // end namespace llvm

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1162,8 +1162,10 @@ public:
   /// enables '.init' and '.default' like expressions.
   /// \param loc Will be populated with the location of the name.
   /// \param diag The diagnostic to emit if this is not a name.
+  /// \param allowOperators Whether to allow operator basenames too.
   DeclName parseUnqualifiedDeclName(bool afterDot, DeclNameLoc &loc,
-                                    const Diagnostic &diag);
+                                    const Diagnostic &diag,
+                                    bool allowOperators=false);
 
   Expr *parseExprIdentifier();
   Expr *parseExprEditorPlaceholder(Token PlaceholderTok,

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -730,6 +730,11 @@ public:
   bool parseSpecializeAttribute(swift::tok ClosingBrace, SourceLoc AtLoc,
                                 SourceLoc Loc, SpecializeAttr *&Attr);
 
+  /// Parse the @_implements attribute.
+  /// \p Attr is where to store the parsed attribute
+  ParserResult<ImplementsAttr> parseImplementsAttribute(SourceLoc AtLoc,
+                                                        SourceLoc Loc);
+
   /// Parse a specific attribute.
   bool parseDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc);
 

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1163,9 +1163,11 @@ public:
   /// \param loc Will be populated with the location of the name.
   /// \param diag The diagnostic to emit if this is not a name.
   /// \param allowOperators Whether to allow operator basenames too.
+  /// \param allowZeroArgCompoundNames Whether to allow empty argument lists.
   DeclName parseUnqualifiedDeclName(bool afterDot, DeclNameLoc &loc,
                                     const Diagnostic &diag,
-                                    bool allowOperators=false);
+                                    bool allowOperators=false,
+                                    bool allowZeroArgCompoundNames=false);
 
   Expr *parseExprIdentifier();
   Expr *parseExprEditorPlaceholder(Token PlaceholderTok,

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -1310,6 +1310,7 @@ namespace decls_block {
   using ObjCBridgedDeclAttrLayout = BCRecordLayout<ObjCBridged_DECL_ATTR>;
   using SynthesizedProtocolDeclAttrLayout
     = BCRecordLayout<SynthesizedProtocol_DECL_ATTR>;
+  using ImplementsDeclAttrLayout = BCRecordLayout<Implements_DECL_ATTR>;
 
   using InlineDeclAttrLayout = BCRecordLayout<
     Inline_DECL_ATTR,

--- a/lib/AST/ASTScope.cpp
+++ b/lib/AST/ASTScope.cpp
@@ -24,6 +24,7 @@
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/Pattern.h"
 #include "swift/AST/Stmt.h"
+#include "swift/AST/TypeRepr.h"
 #include "swift/Basic/STLExtras.h"
 #include "llvm/Support/Compiler.h"
 #include <algorithm>

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -598,6 +598,8 @@ StringRef DeclAttribute::getAttrName() const {
     return "<<synthesized protocol>>";
   case DAK_Specialize:
     return "_specialize";
+  case DAK_Implements:
+    return "_implements";
   }
   llvm_unreachable("bad DeclAttrKind");
 }
@@ -872,4 +874,34 @@ SpecializeAttr *SpecializeAttr::create(ASTContext &Ctx, SourceLoc atLoc,
   void *mem = Ctx.Allocate(size, alignof(SpecializeAttr));
   return new (mem)
       SpecializeAttr(atLoc, range, requirements, exported, kind);
+}
+
+
+ImplementsAttr::ImplementsAttr(SourceLoc atLoc, SourceRange range,
+                               TypeLoc ProtocolType,
+                               DeclName MemberName,
+                               DeclNameLoc MemberNameLoc)
+    : DeclAttribute(DAK_Implements, atLoc, range, /*Implicit=*/false),
+      ProtocolType(ProtocolType),
+      MemberName(MemberName),
+      MemberNameLoc(MemberNameLoc) {
+}
+
+
+ImplementsAttr *ImplementsAttr::create(ASTContext &Ctx, SourceLoc atLoc,
+                                       SourceRange range,
+                                       TypeLoc ProtocolType,
+                                       DeclName MemberName,
+                                       DeclNameLoc MemberNameLoc) {
+  void *mem = Ctx.Allocate(sizeof(ImplementsAttr), alignof(ImplementsAttr));
+  return new (mem) ImplementsAttr(atLoc, range, ProtocolType,
+                                  MemberName, MemberNameLoc);
+}
+
+TypeLoc ImplementsAttr::getProtocolType() const {
+  return ProtocolType;
+}
+
+TypeLoc &ImplementsAttr::getProtocolType() {
+  return ProtocolType;
 }

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -484,6 +484,15 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
     break;
   }
 
+  case DAK_Implements: {
+    Printer.printAttrName("@_implements");
+    Printer << "(";
+    auto *attr = cast<ImplementsAttr>(this);
+    attr->getProtocolType().getType().print(Printer, Options);
+    Printer << ", " << attr->getMemberName() << ")";
+    break;
+  }
+
   case DAK_Count:
     llvm_unreachable("exceed declaration attribute kinds");
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -362,6 +362,8 @@ case DeclKind::ID: return cast<ID##Decl>(this)->getLoc();
   llvm_unreachable("Unknown decl kind");
 }
 
+SourceLoc BehaviorRecord::getLoc() const { return ProtocolName->getLoc(); }
+
 bool AbstractStorageDecl::isTransparent() const {
   return getAttrs().hasAttribute<TransparentAttr>();
 }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -310,7 +310,7 @@ void Decl::setDeclContext(DeclContext *DC) {
 }
 
 bool Decl::isUserAccessible() const {
-  if (auto VD = dyn_cast<VarDecl>(this)) {
+  if (auto VD = dyn_cast<ValueDecl>(this)) {
     return VD->isUserAccessible();
   }
   return true;
@@ -2442,7 +2442,7 @@ ClassDecl::ClassDecl(SourceLoc ClassLoc, Identifier Name, SourceLoc NameLoc,
     = static_cast<unsigned>(StoredInheritsSuperclassInits::Unchecked);
   ClassDeclBits.RawForeignKind = 0;
   ClassDeclBits.HasDestructorDecl = 0;
-  ClassDeclBits.ObjCClassKind = 0;
+  ObjCKind = 0;
 }
 
 DestructorDecl *ClassDecl::getDestructor() {
@@ -2543,8 +2543,8 @@ bool ClassDecl::inheritsSuperclassInitializers(LazyResolver *resolver) {
 
 ObjCClassKind ClassDecl::checkObjCAncestry() const {
   // See if we've already computed this.
-  if (ClassDeclBits.ObjCClassKind)
-    return ObjCClassKind(ClassDeclBits.ObjCClassKind - 1);
+  if (ObjCKind)
+    return ObjCClassKind(ObjCKind - 1);
 
   llvm::SmallPtrSet<const ClassDecl *, 8> visited;
   bool genericAncestry = false, isObjC = false;
@@ -2581,7 +2581,7 @@ ObjCClassKind ClassDecl::checkObjCAncestry() const {
     kind = ObjCClassKind::ObjCWithSwiftRoot;
 
   // Save the result for later.
-  const_cast<ClassDecl *>(this)->ClassDeclBits.ObjCClassKind
+  const_cast<ClassDecl *>(this)->ObjCKind
     = unsigned(kind) + 1;
   return kind;
 }
@@ -4699,9 +4699,8 @@ ConstructorDecl::ConstructorDecl(DeclName Name, SourceLoc ConstructorLoc,
   setParameterLists(SelfDecl, BodyParams);
   
   ConstructorDeclBits.ComputedBodyInitKind = 0;
-  ConstructorDeclBits.InitKind
-    = static_cast<unsigned>(CtorInitializerKind::Designated);
   ConstructorDeclBits.HasStubImplementation = 0;
+  this->InitKind = static_cast<unsigned>(CtorInitializerKind::Designated);
   this->Failability = static_cast<unsigned>(Failability);
 }
 

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -28,6 +28,7 @@
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/SubstitutionMap.h"
 #include "swift/AST/TypeLoc.h"
+#include "swift/AST/TypeRepr.h"
 #include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallString.h"
@@ -63,6 +64,20 @@ SourceRange TypeLoc::getSourceRange() const {
   if (TyR)
     return TyR->getSourceRange();
   return SourceRange();
+}
+
+TypeLoc TypeLoc::clone(ASTContext &ctx) const {
+  if (TyR) {
+    TypeLoc result(TyR->clone(ctx));
+    result.TAndValidBit = this->TAndValidBit;
+    return result;
+  }
+  return *this;
+}
+
+SourceLoc TypeLoc::getLoc() const {
+  if (TyR) return TyR->getLoc();
+  return SourceLoc();
 }
 
 // Only allow allocation of Types using the allocator in ASTContext.

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -26,6 +26,7 @@
 #include "swift/AST/Module.h"
 #include "swift/AST/NameLookup.h"
 #include "swift/AST/Types.h"
+#include "swift/AST/TypeRepr.h"
 #include "swift/Basic/StringExtras.h"
 #include "swift/ClangImporter/ClangImporterOptions.h"
 #include "swift/Parse/Parser.h"

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -303,6 +303,9 @@ static bool shouldHideDeclFromCompletionResults(const ValueDecl *D) {
   if (D->getName().isEditorPlaceholder())
     return true;
 
+  if (!D->isUserAccessible())
+    return true;
+
   return false;
 }
 
@@ -2048,7 +2051,6 @@ public:
 
   void addVarDeclRef(const VarDecl *VD, DeclVisibilityKind Reason) {
     if (!VD->hasName() ||
-        !VD->isUserAccessible() ||
         (VD->hasAccessibility() && !VD->isAccessibleFrom(CurrDeclContext)) ||
         shouldHideDeclFromCompletionResults(VD))
       return;

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -437,6 +437,62 @@ bool Parser::parseSpecializeAttribute(swift::tok ClosingBrace, SourceLoc AtLoc,
   return true;
 }
 
+ParserResult<ImplementsAttr>
+Parser::parseImplementsAttribute(SourceLoc AtLoc, SourceLoc Loc) {
+  StringRef AttrName = "_implements";
+  ParserStatus Status;
+
+  if (Tok.isNot(tok::l_paren)) {
+    diagnose(Loc, diag::attr_expected_lparen, AttrName,
+             /*DeclModifier=*/false);
+    Status.setIsParseError();
+    return Status;
+  }
+
+  SourceLoc lParenLoc = consumeToken();
+
+  ParserResult<TypeRepr> ProtocolType = parseType();
+  Status |= ProtocolType;
+
+  if (!(Status.shouldStopParsing() || consumeIf(tok::comma))) {
+    diagnose(Tok.getLoc(), diag::attr_expected_comma, AttrName,
+             /*DeclModifier=*/false);
+    Status.setIsParseError();
+  }
+
+  DeclNameLoc MemberNameLoc;
+  DeclName MemberName;
+  if (!Status.shouldStopParsing()) {
+    MemberName =
+      parseUnqualifiedDeclName(/*afterDot=*/false, MemberNameLoc,
+                               diag::attr_implements_expected_member_name,
+                               /*allowOperators=*/true,
+                               /*allowZeroArgCompoundNames=*/true);
+    if (!MemberName) {
+      Status.setIsParseError();
+    }
+  }
+
+  if (Status.isError()) {
+    skipUntil(tok::r_paren);
+  }
+
+  SourceLoc rParenLoc;
+  if (!consumeIf(tok::r_paren, rParenLoc)) {
+    diagnose(lParenLoc, diag::attr_expected_rparen, AttrName,
+             /*DeclModifier=*/false);
+    Status.setIsParseError();
+  }
+
+  if (Status.isError()) {
+    return Status;
+  }
+
+  return ParserResult<ImplementsAttr>(
+    ImplementsAttr::create(Context, AtLoc, SourceRange(Loc, rParenLoc),
+                           ProtocolType.get(), MemberName, MemberNameLoc));
+}
+
 bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
                                    DeclAttrKind DK) {
   // Ok, it is a valid attribute, eat it, and then process it.
@@ -1258,6 +1314,14 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
     Attributes.add(Attr);
     break;
     }
+
+  case DAK_Implements: {
+    ParserResult<ImplementsAttr> Attr = parseImplementsAttribute(AtLoc, Loc);
+    if (Attr.isNonNull()) {
+      Attributes.add(Attr.get());
+    }
+    break;
+  }
   }
 
   if (DuplicateAttribute) {

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1800,12 +1800,16 @@ void Parser::parseOptionalArgumentLabel(Identifier &name, SourceLoc &loc) {
 
 DeclName Parser::parseUnqualifiedDeclName(bool afterDot,
                                           DeclNameLoc &loc,
-                                          const Diagnostic &diag) {
+                                          const Diagnostic &diag,
+                                          bool allowOperators) {
   // Consume the base name.
   Identifier baseName = Context.getIdentifier(Tok.getText());
   SourceLoc baseNameLoc;
   if (Tok.isAny(tok::identifier, tok::kw_Self, tok::kw_self)) {
     baseNameLoc = consumeIdentifier(&baseName);
+  } else if (allowOperators && Tok.isAnyOperator()) {
+    baseName = Context.getIdentifier(Tok.getText());
+    baseNameLoc = consumeToken();
   } else if (afterDot && Tok.isKeyword()) {
     baseNameLoc = consumeToken();
   } else {

--- a/lib/RemoteAST/RemoteAST.cpp
+++ b/lib/RemoteAST/RemoteAST.cpp
@@ -22,6 +22,7 @@
 #include "swift/AST/Module.h"
 #include "swift/AST/NameLookup.h"
 #include "swift/AST/Types.h"
+#include "swift/AST/TypeRepr.h"
 #include "swift/Basic/Mangler.h"
 #include "swift/ClangImporter/ClangImporter.h"
 

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -196,7 +196,9 @@ deriveEquatable_enum_eq(TypeChecker &tc, Decl *parentDecl, EnumDecl *enumDecl) {
   //   case A, B, C
   //
   //   @derived
-  //   func ==(a: SomeEnum<T...>, b: SomeEnum<T...>) -> Bool {
+  //   @_implements(Equatable, ==(_:_:))
+  //   func __derived_enum_equals(a: SomeEnum<T...>,
+  //                              b: SomeEnum<T...>) -> Bool {
   //     var index_a: Int
   //     switch a {
   //     case .A: index_a = 0
@@ -239,7 +241,7 @@ deriveEquatable_enum_eq(TypeChecker &tc, Decl *parentDecl, EnumDecl *enumDecl) {
 
   auto boolTy = C.getBoolDecl()->getDeclaredType();
 
-  DeclName name(C, C.Id_EqualsOperator, params[1]);
+  DeclName name(C, C.Id_derived_enum_equals, params[1]);
   auto eqDecl =
     FuncDecl::create(C, /*StaticLoc=*/SourceLoc(),
                      StaticSpellingKind::KeywordStatic,
@@ -251,19 +253,27 @@ deriveEquatable_enum_eq(TypeChecker &tc, Decl *parentDecl, EnumDecl *enumDecl) {
                      TypeLoc::withoutLoc(boolTy),
                      parentDC);
   eqDecl->setImplicit();
+  eqDecl->setUserAccessible(false);
   eqDecl->getAttrs().add(new (C) InfixAttr(/*implicit*/false));
-  auto op = C.getStdlibModule()->lookupInfixOperator(C.Id_EqualsOperator);
-  if (!op) {
-    tc.diagnose(parentDecl->getLoc(),
-                diag::broken_equatable_eq_operator);
-    return nullptr;
-  }
+
+  // Add the @_implements(Equatable, ==(_:_:)) attribute
+  auto equatableProto = C.getProtocol(KnownProtocolKind::Equatable);
+  auto equatableTy = equatableProto->getDeclaredType();
+  auto equatableTypeLoc = TypeLoc::withoutLoc(equatableTy);
+  SmallVector<Identifier, 2> argumentLabels = { Identifier(), Identifier() };
+  auto equalsDeclName = DeclName(C, DeclBaseName(C.Id_EqualsOperator),
+                                 argumentLabels);
+  eqDecl->getAttrs().add(new (C) ImplementsAttr(SourceLoc(),
+                                                SourceRange(),
+                                                equatableTypeLoc,
+                                                equalsDeclName,
+                                                DeclNameLoc()));
+
   if (!C.getEqualIntDecl()) {
     tc.diagnose(parentDecl->getLoc(), diag::no_equal_overload_for_int);
     return nullptr;
   }
 
-  eqDecl->setOperatorDecl(op);
   eqDecl->setBodySynthesizer(&deriveBodyEquatable_enum_eq);
 
   // Compute the type.

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -85,6 +85,7 @@ public:
   IGNORED_ATTR(Versioned)
   IGNORED_ATTR(ShowInInterface)
   IGNORED_ATTR(DiscardableResult)
+  IGNORED_ATTR(Implements)
 #undef IGNORED_ATTR
 
   // @noreturn has been replaced with a 'Never' return type.
@@ -755,6 +756,7 @@ public:
     IGNORED_ATTR(WarnUnqualifiedAccess)
     IGNORED_ATTR(ShowInInterface)
     IGNORED_ATTR(ObjCMembers)
+    IGNORED_ATTR(Implements)
 #undef IGNORED_ATTR
 
   void visitAvailableAttr(AvailableAttr *attr);

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -756,7 +756,6 @@ public:
     IGNORED_ATTR(WarnUnqualifiedAccess)
     IGNORED_ATTR(ShowInInterface)
     IGNORED_ATTR(ObjCMembers)
-    IGNORED_ATTR(Implements)
 #undef IGNORED_ATTR
 
   void visitAvailableAttr(AvailableAttr *attr);
@@ -797,6 +796,7 @@ public:
   void visitInlineableAttr(InlineableAttr *attr);
   
   void visitDiscardableResultAttr(DiscardableResultAttr *attr);
+  void visitImplementsAttr(ImplementsAttr *attr);
 };
 } // end anonymous namespace
 
@@ -1881,6 +1881,52 @@ void AttributeChecker::visitDiscardableResultAttr(DiscardableResultAttr *attr) {
         attr->setInvalid();
       }
     }
+  }
+}
+
+void AttributeChecker::visitImplementsAttr(ImplementsAttr *attr) {
+  TypeLoc &ProtoTypeLoc = attr->getProtocolType();
+  TypeResolutionOptions options;
+  options |= TR_AllowUnboundGenerics;
+
+  DeclContext *DC = D->getDeclContext();
+  Type T = TC.resolveType(ProtoTypeLoc.getTypeRepr(),
+                          DC, options);
+  ProtoTypeLoc.setType(T);
+
+  // Definite error-types were already diagnosed in resolveType.
+  if (!T || T->hasError())
+    return;
+
+  // Check that we got a ProtocolType.
+  if (auto PT = T->getAs<ProtocolType>()) {
+    ProtocolDecl *PD = PT->getDecl();
+
+    // Check that the ProtocolType has the specified member.
+    LookupResult R = TC.lookupMember(PD->getDeclContext(),
+                                     PT, attr->getMemberName());
+    if (!R) {
+      TC.diagnose(attr->getLocation(),
+                  diag::implements_attr_protocol_lacks_member,
+                  PD->getBaseName(), attr->getMemberName())
+        .highlight(attr->getMemberNameLoc().getSourceRange());
+    }
+
+    // Check that the decl we're decorating is a member of a type that actually
+    // conforms to the specified protocol.
+    NominalTypeDecl *NTD = DC->getAsNominalTypeOrNominalTypeExtensionContext();
+    SmallVector<ProtocolConformance *, 2> conformances;
+    if (!NTD->lookupConformance(DC->getParentModule(), PD, conformances)) {
+      TC.diagnose(attr->getLocation(),
+                  diag::implements_attr_protocol_not_conformed_to,
+                  NTD->getFullName(), PD->getFullName())
+        .highlight(ProtoTypeLoc.getTypeRepr()->getSourceRange());
+    }
+
+  } else {
+    TC.diagnose(attr->getLocation(),
+                diag::implements_attr_non_protocol_type)
+      .highlight(ProtoTypeLoc.getTypeRepr()->getSourceRange());
   }
 }
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -6098,6 +6098,7 @@ public:
     UNINTERESTING_ATTR(DiscardableResult)
 
     UNINTERESTING_ATTR(ObjCMembers)
+    UNINTERESTING_ATTR(Implements)
 
 #undef UNINTERESTING_ATTR
 

--- a/lib/Sema/TypeCheckRequest.cpp
+++ b/lib/Sema/TypeCheckRequest.cpp
@@ -16,6 +16,7 @@
 //===----------------------------------------------------------------------===//
 #include "swift/Sema/TypeCheckRequest.h"
 #include "swift/AST/Decl.h"
+#include "swift/AST/TypeRepr.h"
 
 using namespace swift;
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1914,6 +1914,7 @@ void Serializer::writeDeclAttribute(const DeclAttribute *DA) {
   case DAK_ObjCBridged:
   case DAK_SynthesizedProtocol:
   case DAK_Count:
+  case DAK_Implements:
     llvm_unreachable("cannot serialize attribute");
     return;
 

--- a/test/IDE/print_ast_tc_decls.swift
+++ b/test/IDE/print_ast_tc_decls.swift
@@ -585,7 +585,7 @@ struct d0200_EscapedIdentifiers {
   }
 // PASS_COMMON-NEXT: {{^}}  enum `enum` {{{$}}
 // PASS_COMMON-NEXT: {{^}}    case `case`{{$}}
-// PASS_COMMON-NEXT: {{^}}    static func ==(a: d0200_EscapedIdentifiers.`enum`, b: d0200_EscapedIdentifiers.`enum`) -> Bool
+// PASS_COMMON-NEXT: {{^}}    {{.*}}static func __derived_enum_equals(_ a: d0200_EscapedIdentifiers.`enum`, _ b: d0200_EscapedIdentifiers.`enum`) -> Bool
 // PASS_COMMON-NEXT: {{^}}    var hashValue: Int { get }{{$}}
 // PASS_COMMON-NEXT: {{^}}  }{{$}}
 
@@ -1010,7 +1010,7 @@ enum d2000_EnumDecl1 {
 // PASS_COMMON: {{^}}enum d2000_EnumDecl1 {{{$}}
 // PASS_COMMON-NEXT: {{^}}  case ED1_First{{$}}
 // PASS_COMMON-NEXT: {{^}}  case ED1_Second{{$}}
-// PASS_COMMON-NEXT: {{^}}  static func ==(a: d2000_EnumDecl1, b: d2000_EnumDecl1) -> Bool
+// PASS_COMMON-NEXT: {{^}}  {{.*}}static func __derived_enum_equals(_ a: d2000_EnumDecl1, _ b: d2000_EnumDecl1) -> Bool
 // PASS_COMMON-NEXT: {{^}}  var hashValue: Int { get }{{$}}
 // PASS_COMMON-NEXT: {{^}}}{{$}}
 

--- a/test/IRGen/enum_derived.swift
+++ b/test/IRGen/enum_derived.swift
@@ -18,8 +18,8 @@ enum E {
 
 // Check if the == comparison can be compiled to a simple icmp instruction.
 
-// CHECK-NORMAL-LABEL:define hidden swiftcc i1 @_T012enum_derived1EO2eeoiSbAC_ACtFZ(i8, i8)
-// CHECK-TESTABLE-LABEL:define{{( protected)?}} swiftcc i1 @_T012enum_derived1EO2eeoiSbAC_ACtFZ(i8, i8)
+// CHECK-NORMAL-LABEL:define hidden swiftcc i1 @_T012enum_derived1EO02__b1_A7_equalsSbAC_ACtFZ(i8, i8)
+// CHECK-TESTABLE-LABEL:define{{( protected)?}} swiftcc i1 @_T012enum_derived1EO02__b1_A7_equalsSbAC_ACtFZ(i8, i8)
 // CHECK: %2 = icmp eq i8 %0, %1
 // CHECK: ret i1 %2
 

--- a/test/attr/attr_implements.swift
+++ b/test/attr/attr_implements.swift
@@ -1,0 +1,72 @@
+// RUN: %target-run-simple-swift %s
+// REQUIRES: executable_test
+
+protocol P {
+  func f0() -> Int;
+  func f(x:Int, y:Int) -> Int;
+}
+
+protocol Q {
+  func f(x:Int, y:Int) -> Int;
+}
+
+struct S : P, Q, Equatable {
+
+  // Test that it's possible to denote a zero-arg requirement
+  // (This involved extended the parser for unqualified DeclNames)
+  @_implements(P, f0())
+  func g0() -> Int {
+    return 10
+  }
+
+  // Test that it's possible to implement two different protocols with the
+  // same-named requirements.
+  @_implements(P, f(x:y:))
+  func g(x:Int, y:Int) -> Int {
+    return 5
+  }
+
+  @_implements(Q, f(x:y:))
+  func h(x:Int, y:Int) -> Int {
+    return 6
+  }
+
+  // Test that it's possible to denote an operator requirement
+  // (This involved extended the parser for unqualified DeclNames)
+  @_implements(Equatable, ==(_:_:))
+  public static func isEqual(_ lhs: S, _ rhs: S) -> Bool {
+    return false
+  }
+}
+
+func call_P_f_generic<T:P>(p:T, x: Int, y: Int) -> Int {
+  return p.f(x:x, y:y)
+}
+
+func call_P_f_existential(p:P, x: Int, y: Int) -> Int {
+  return p.f(x:x, y:y)
+}
+
+func call_Q_f_generic<T:Q>(q:T, x: Int, y: Int) -> Int {
+  return q.f(x:x, y:y)
+}
+
+func call_Q_f_existential(q:Q, x: Int, y: Int) -> Int {
+  return q.f(x:x, y:y)
+}
+
+let s = S()
+assert(call_P_f_generic(p:s, x:1, y:2) == 5)
+assert(call_P_f_existential(p:s, x:1, y:2) == 5)
+assert(call_Q_f_generic(q:s, x:1, y:2) == 6)
+assert(call_Q_f_existential(q:s, x:1, y:2) == 6)
+assert(!(s == s))
+
+// Note: at the moment directly calling the member 'f' on the concrete type 'S'
+// doesn't work, because it's considered ambiguous between the 'g' and 'h'
+// members (each of which provide an 'f' via the 'P' and 'Q' protocol
+// conformances), and adding a non-@_implements member 'f' to S makes it win
+// over _both_ the @_implements members. Unclear if this is correct; I think so?
+
+// print(s.f(x:1, y:2))
+

--- a/test/attr/attr_implements_bad_parse.swift
+++ b/test/attr/attr_implements_bad_parse.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend -parse -verify %s
+
+struct S0 {
+  @_implements(1, Foo) // expected-error {{expected type}}
+  func f() { }
+}
+
+struct S1 {
+  @_implements(NeedsF0, 1) // expected-error {{expected a member name as second parameter in '_implements' attribute}}
+  func f() { }
+}
+
+struct S2 {
+  @_implements(NeedsF0) // expected-error {{expected ',' in '_implements' attribute}}
+  func f() { }
+}

--- a/test/attr/attr_implements_bad_types.swift
+++ b/test/attr/attr_implements_bad_types.swift
@@ -1,0 +1,25 @@
+// RUN: %target-swift-frontend -typecheck -verify %s
+
+protocol NeedsF0 {
+  func f0() // expected-note {{protocol requires function 'f0()' with type '() -> ()'; do you want to add a stub?}}
+}
+
+struct S0 : NeedsF0 {  // expected-error {{type 'S0' does not conform to protocol 'NeedsF0'}}
+  @_implements(NeedsF0, f0())
+  func g0() -> Bool {  // expected-note {{candidate has non-matching type '() -> Bool'}}
+    return true
+  }
+
+  @_implements(NeedsF0, ff0()) // expected-error {{protocol 'NeedsF0' has no member 'ff0()'}}
+  func gg0() {
+  }
+
+  @_implements(Int, zz) // expected-error {{non-protocol type in @_implements attribute}}
+  static func gg1(x:S0, y:S0) -> Bool {
+  }
+
+  @_implements(Equatable, ==(_:_:)) // expected-error {{containing type 'S0' does not conform to protocol 'Equatable'}}
+  static func gg2(x:S0, y:S0) -> Bool {
+  }
+}
+

--- a/unittests/AST/TestContext.h
+++ b/unittests/AST/TestContext.h
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/AST/ASTContext.h"
+#include "swift/AST/ASTScope.h"
 #include "swift/AST/DiagnosticEngine.h"
 #include "swift/Basic/LangOptions.h"
 #include "swift/Basic/SourceManager.h"


### PR DESCRIPTION
This implements (non-user-facing) attribute @_implements(Protocol, DeclName) that can be used to conform to a protocol requirement using a decl with a different name than the requirement.

This might sound weird, but it has (at least?) two uses we've already hit:

  1. Conforming to two protocols that use the same name for different operations (this arises when comparing floating point values)
  2. Conforming to a protocol that has a requirement that's an operator-name, without adding a new operator to the global operator list (this happens via implicit Equatable conformances on enums, and causes a lot of needless top-level inter-file dependencies)

After initial post and review, I've ticked off the following todos:
  - [x] Limit lookup to only happen when locating witnesses
  - [x] Limit lookup to the Context (protocol) name specified; currently it ignores that part of the name
  - [x] Get it working for Operator names (including protocol members)
  - [x] Add ~~~lots~~~ some more tests and fix all bugs those reveal
  - [x] Check that @_implements only mentions protocols the decl conforms to

rdar://31607695

This was originally motivated by 30959593 (operators defeat incrementality), and I've now tacked on to the end a change that @_implements the derived enum == operator in terms of a different function (creatively named `__derived_enum_equals`)