### PR TITLE
[Serialization] Follow typealiases when nominals are renamed.

### DIFF
--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -2255,6 +2255,7 @@ public:
       verifyGenericEnvironment(generic,
                                generic->getGenericSignature(),
                                generic->getGenericEnvironment());
+      verifyCheckedBase(generic);
     }
 
     void verifyChecked(NominalTypeDecl *nominal) {

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4693,18 +4693,16 @@ Decl *SwiftDeclConverter::importCompatibilityTypeAlias(
   if (!typeDecl)
     return nullptr;
 
-  // Handle generic types.
-  GenericParamList *genericParams = nullptr;
-  GenericEnvironment *genericEnv = nullptr;
-  auto underlyingType = typeDecl->getDeclaredInterfaceType();
-
-  if (auto generic = dyn_cast<GenericTypeDecl>(typeDecl)) {
-    if (generic->getGenericSignature() && !isa<ProtocolDecl>(typeDecl)) {
-      genericParams = generic->getGenericParams();
-      genericEnv = generic->getGenericEnvironment();
-
-      underlyingType = generic->mapTypeIntoContext(underlyingType);
-    }
+  // Deliberately use an UnboundGenericType to avoid having to translate over
+  // generic parameters.
+  Type underlyingType;
+  if (auto *underlyingAlias = dyn_cast<TypeAliasDecl>(typeDecl)) {
+    if (underlyingAlias->isGeneric())
+      underlyingType = underlyingAlias->getUnboundGenericType();
+    else
+      underlyingType = underlyingAlias->getDeclaredInterfaceType();
+  } else {
+    underlyingType = cast<NominalTypeDecl>(typeDecl)->getDeclaredType();
   }
 
   auto dc = Impl.importDeclContextOf(decl,
@@ -4716,9 +4714,8 @@ Decl *SwiftDeclConverter::importCompatibilityTypeAlias(
   auto alias = Impl.createDeclWithClangNode<TypeAliasDecl>(
       decl, Accessibility::Public, Impl.importSourceLoc(decl->getLocStart()),
       SourceLoc(), compatibilityName.getDeclName().getBaseName(),
-      Impl.importSourceLoc(decl->getLocation()), genericParams, dc);
+      Impl.importSourceLoc(decl->getLocation()), /*generic params*/nullptr, dc);
   alias->setUnderlyingType(underlyingType);
-  alias->setGenericEnvironment(genericEnv);
 
   // Record that this is the official version of this declaration.
   Impl.ImportedDecls[{decl->getCanonicalDecl(), getVersion()}] = alias;

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4428,7 +4428,7 @@ Expected<Type> ModuleFile::getTypeChecked(TypeID TID) {
     decls_block::UnboundGenericTypeLayout::readRecord(scratch,
                                                       genericID, parentID);
 
-    auto genericDecl = cast<NominalTypeDecl>(getDecl(genericID));
+    auto genericDecl = cast<GenericTypeDecl>(getDecl(genericID));
     typeOrOffset = UnboundGenericType::get(genericDecl, getType(parentID), ctx);
     break;
   }

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -760,7 +760,7 @@ ProtocolConformanceRef ModuleFile::readConformance(
     ProtocolConformanceXrefLayout::readRecord(scratch, protoID, nominalID,
                                               moduleID);
 
-    auto nominal = cast<NominalTypeDecl>(getDecl(nominalID));
+    auto nominal = castIgnoringSugar<NominalTypeDecl>(getDecl(nominalID));
     PrettyStackTraceDecl trace("cross-referencing conformance for", nominal);
     auto proto = castIgnoringSugar<ProtocolDecl>(getDecl(protoID));
     PrettyStackTraceDecl traceTo("... to", proto);

--- a/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/APINotesFrameworkTest.apinotes
+++ b/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/APINotesFrameworkTest.apinotes
@@ -86,6 +86,8 @@ SwiftVersions:
             SwiftImportAsAccessors: true
       - Name: NewlyGenericSub
         SwiftImportAsNonGeneric: true
+      - Name: RenamedGeneric
+        SwiftName: OldRenamedGeneric
     Protocols:
       - Name: ProtoWithVersionedUnavailableMember
         Methods:

--- a/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/Classes.h
+++ b/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/Classes.h
@@ -5,5 +5,8 @@
 + (Element)defaultElement;
 @end
 
+@interface RenamedGeneric<Element: Base *> : Base
+@end
+
 #pragma clang assume_nonnull end
 #endif // __OBJC__

--- a/test/APINotes/versioned-objc.swift
+++ b/test/APINotes/versioned-objc.swift
@@ -23,4 +23,24 @@ func testNonGeneric() {
   // CHECK-DIAGS-4:[[@LINE-1]]:{{[0-9]+}}: error: cannot convert value of type 'Base' to specified type 'Int'
 }
 
+func testRenamedGeneric() {
+  // CHECK-DIAGS-3:[[@LINE+1]]:{{[0-9]+}}: error: 'RenamedGeneric' has been renamed to 'OldRenamedGeneric'
+  let _: OldRenamedGeneric<Base> = RenamedGeneric<Base>()
+  // FIXME-DIAGS-4:[[@LINE-1]]:{{[0-9]+}}: error: 'OldRenamedGeneric' has been renamed to 'RenamedGeneric'
+
+  // FIXME-DIAGS-3:[[@LINE+1]]:{{[0-9]+}}: error: 'RenamedGeneric' has been renamed to 'OldRenamedGeneric'
+  let _: RenamedGeneric<Base> = OldRenamedGeneric<Base>()
+  // CHECK-DIAGS-4:[[@LINE-1]]:{{[0-9]+}}: error: 'OldRenamedGeneric' has been renamed to 'RenamedGeneric'
+
+  class SwiftClass {}
+
+  // CHECK-DIAGS-3:[[@LINE+1]]:{{[0-9]+}}: error: 'OldRenamedGeneric' requires that 'SwiftClass' inherit from 'Base'
+  let _: OldRenamedGeneric<SwiftClass> = RenamedGeneric<SwiftClass>()
+  // CHECK-DIAGS-4:[[@LINE-1]]:{{[0-9]+}}: error: 'OldRenamedGeneric' requires that 'SwiftClass' inherit from 'Base'
+
+  // CHECK-DIAGS-3:[[@LINE+1]]:{{[0-9]+}}: error: 'RenamedGeneric' requires that 'SwiftClass' inherit from 'Base'
+  let _: RenamedGeneric<SwiftClass> = OldRenamedGeneric<SwiftClass>()
+  // CHECK-DIAGS-4:[[@LINE-1]]:{{[0-9]+}}: error: 'RenamedGeneric' requires that 'SwiftClass' inherit from 'Base'
+}
+
 let unrelatedDiagnostic: Int = nil

--- a/test/APINotes/versioned-objc.swift
+++ b/test/APINotes/versioned-objc.swift
@@ -26,9 +26,9 @@ func testNonGeneric() {
 func testRenamedGeneric() {
   // CHECK-DIAGS-3:[[@LINE+1]]:{{[0-9]+}}: error: 'RenamedGeneric' has been renamed to 'OldRenamedGeneric'
   let _: OldRenamedGeneric<Base> = RenamedGeneric<Base>()
-  // FIXME-DIAGS-4:[[@LINE-1]]:{{[0-9]+}}: error: 'OldRenamedGeneric' has been renamed to 'RenamedGeneric'
+  // CHECK-DIAGS-4:[[@LINE-1]]:{{[0-9]+}}: error: 'OldRenamedGeneric' has been renamed to 'RenamedGeneric'
 
-  // FIXME-DIAGS-3:[[@LINE+1]]:{{[0-9]+}}: error: 'RenamedGeneric' has been renamed to 'OldRenamedGeneric'
+  // CHECK-DIAGS-3:[[@LINE+1]]:{{[0-9]+}}: error: 'RenamedGeneric' has been renamed to 'OldRenamedGeneric'
   let _: RenamedGeneric<Base> = OldRenamedGeneric<Base>()
   // CHECK-DIAGS-4:[[@LINE-1]]:{{[0-9]+}}: error: 'OldRenamedGeneric' has been renamed to 'RenamedGeneric'
 
@@ -36,9 +36,9 @@ func testRenamedGeneric() {
 
   // CHECK-DIAGS-3:[[@LINE+1]]:{{[0-9]+}}: error: 'OldRenamedGeneric' requires that 'SwiftClass' inherit from 'Base'
   let _: OldRenamedGeneric<SwiftClass> = RenamedGeneric<SwiftClass>()
-  // CHECK-DIAGS-4:[[@LINE-1]]:{{[0-9]+}}: error: 'OldRenamedGeneric' requires that 'SwiftClass' inherit from 'Base'
+  // CHECK-DIAGS-4:[[@LINE-1]]:{{[0-9]+}}: error: 'RenamedGeneric' requires that 'SwiftClass' inherit from 'Base'
 
-  // CHECK-DIAGS-3:[[@LINE+1]]:{{[0-9]+}}: error: 'RenamedGeneric' requires that 'SwiftClass' inherit from 'Base'
+  // CHECK-DIAGS-3:[[@LINE+1]]:{{[0-9]+}}: error: 'OldRenamedGeneric' requires that 'SwiftClass' inherit from 'Base'
   let _: RenamedGeneric<SwiftClass> = OldRenamedGeneric<SwiftClass>()
   // CHECK-DIAGS-4:[[@LINE-1]]:{{[0-9]+}}: error: 'RenamedGeneric' requires that 'SwiftClass' inherit from 'Base'
 }

--- a/test/Serialization/Inputs/alias.swift
+++ b/test/Serialization/Inputs/alias.swift
@@ -31,3 +31,6 @@ public protocol ProtoWrapper {}
 extension ProtoWrapper {
   public typealias Boolean = Bool
 }
+
+public struct Outer { public typealias G<T> = T }
+public typealias GG = Outer.G

--- a/test/Serialization/Recovery/Inputs/custom-modules/Types.apinotes
+++ b/test/Serialization/Recovery/Inputs/custom-modules/Types.apinotes
@@ -1,0 +1,19 @@
+Name: Types
+SwiftVersions:
+- Version: 3
+  Classes:
+  - Name: RenamedClass
+    SwiftName: Swift3RenamedClass
+  - Name: RenamedGenericClass
+    SwiftName: Swift3RenamedGenericClass
+  Typedefs:
+  - Name: RenamedTypedef
+    SwiftName: Swift3RenamedTypedef
+  Tags:
+  - Name: RenamedStruct
+    SwiftName: Swift3RenamedStruct
+  - Name: RenamedEnum
+    SwiftName: Swift3RenamedEnum
+  Protocols:
+  - Name: RenamedProtocol
+    SwiftName: Swift3RenamedProtocol

--- a/test/Serialization/Recovery/Inputs/custom-modules/Types.h
+++ b/test/Serialization/Recovery/Inputs/custom-modules/Types.h
@@ -22,3 +22,6 @@ typedef CF_ENUM(long, RenamedEnum) {
 
 @protocol RenamedProtocol
 @end
+
+@interface RenamedClass (RenamedProtocol) <RenamedProtocol>
+@end

--- a/test/Serialization/Recovery/Inputs/custom-modules/Types.h
+++ b/test/Serialization/Recovery/Inputs/custom-modules/Types.h
@@ -1,0 +1,24 @@
+@interface Object
+- (nonnull instancetype)init;
+@end
+
+@interface RenamedClass : Object
+@end
+
+@interface RenamedGenericClass<Element> : Object
+@end
+
+typedef int RenamedTypedef;
+
+struct RenamedStruct {
+  int value;
+};
+
+#define CF_ENUM(_type, _name) enum _name : _type _name; enum _name : _type
+
+typedef CF_ENUM(long, RenamedEnum) {
+  RenamedEnumA
+};
+
+@protocol RenamedProtocol
+@end

--- a/test/Serialization/Recovery/Inputs/custom-modules/module.modulemap
+++ b/test/Serialization/Recovery/Inputs/custom-modules/module.modulemap
@@ -1,1 +1,2 @@
 module Overrides { header "Overrides.h" }
+module Types { header "Types.h" }

--- a/test/Serialization/Recovery/types.swift
+++ b/test/Serialization/Recovery/types.swift
@@ -14,6 +14,7 @@
 import Lib
 
 func requiresConformance(_: B_RequiresConformance<B_ConformsToProto>) {}
+func requiresConformance(_: B_RequiresConformance<C_RelyOnConformanceImpl.Assoc>) {}
 
 
 #else // TEST
@@ -73,5 +74,13 @@ public struct B_RequiresConformance<T: RenamedProtocol> {}
 
 // CHECK-LABEL: struct B_RequiresConformance<T> where T : RenamedProtocol
 // CHECK-RECOVERY-LABEL: struct B_RequiresConformance<T> where T : Swift3RenamedProtocol
+
+public protocol C_RelyOnConformance {
+  associatedtype Assoc: RenamedProtocol
+}
+
+public class C_RelyOnConformanceImpl: C_RelyOnConformance {
+  public typealias Assoc = RenamedClass
+}
 
 #endif

--- a/test/Serialization/Recovery/types.swift
+++ b/test/Serialization/Recovery/types.swift
@@ -1,0 +1,51 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: %target-swift-frontend -emit-module -o %t -module-name Lib -I %S/Inputs/custom-modules -swift-version 4 %s
+
+// RUN: %target-swift-ide-test -source-filename=x -print-module -module-to-print Lib -I %t -I %S/Inputs/custom-modules -swift-version 4 | %FileCheck %s
+
+// RUN: %target-swift-ide-test -source-filename=x -print-module -module-to-print Lib -I %t -I %S/Inputs/custom-modules -enable-experimental-deserialization-recovery -swift-version 3 | %FileCheck -check-prefix CHECK-RECOVERY %s
+
+// REQUIRES: objc_interop
+
+import Types
+
+public func renameAllTheThings(
+  a: RenamedClass?,
+  b: RenamedGenericClass<AnyObject>?,
+  c: RenamedTypedef,
+  d: RenamedStruct,
+  e: RenamedEnum,
+  f: RenamedProtocol
+) {}
+
+// CHECK-LABEL: func renameAllTheThings(
+// CHECK-SAME: a: RenamedClass?
+// CHECK-SAME: b: RenamedGenericClass<AnyObject>?
+// CHECK-SAME: c: RenamedTypedef
+// CHECK-SAME: d: RenamedStruct
+// CHECK-SAME: e: RenamedEnum
+// CHECK-SAME: f: RenamedProtocol
+// CHECK-SAME: )
+
+
+// CHECK-RECOVERY-LABEL: func renameAllTheThings(
+// CHECK-RECOVERY-SAME: a: Swift3RenamedClass?
+// CHECK-RECOVERY-SAME: b: Swift3RenamedGenericClass<AnyObject>?
+
+// Unfortunately we can't use the presence of a forwarding typealias to
+// automatically look for the new name, because it's /already/ a typealias.
+// CHECK-RECOVERY-SAME: c: RenamedTypedef
+
+// CHECK-RECOVERY-SAME: d: Swift3RenamedStruct
+// CHECK-RECOVERY-SAME: e: Swift3RenamedEnum
+// CHECK-RECOVERY-SAME: f: Swift3RenamedProtocol
+// CHECK-RECOVERY-SAME: )
+
+
+public func renameGeneric<T: RenamedProtocol>(obj: T) {}
+
+// CHECK-LABEL: func renameGeneric<T>(
+// CHECK-SAME: where T : RenamedProtocol
+
+// CHECK-RECOVERY-LABEL: func renameGeneric<T>(
+// CHECK-RECOVERY-SAME: where T : Swift3RenamedProtocol

--- a/test/Serialization/Recovery/types.swift
+++ b/test/Serialization/Recovery/types.swift
@@ -5,11 +5,25 @@
 
 // RUN: %target-swift-ide-test -source-filename=x -print-module -module-to-print Lib -I %t -I %S/Inputs/custom-modules -enable-experimental-deserialization-recovery -swift-version 3 | %FileCheck -check-prefix CHECK-RECOVERY %s
 
+// RUN: %target-swift-frontend -typecheck %s -I %t -I %S/Inputs/custom-modules  -swift-version 3 -enable-experimental-deserialization-recovery -D TEST -verify
+
 // REQUIRES: objc_interop
+
+#if TEST
+
+import Lib
+
+func requiresConformance(_: B_RequiresConformance<B_ConformsToProto>) {}
+
+
+#else // TEST
 
 import Types
 
-public func renameAllTheThings(
+// Please use prefixes to keep the printed parts of this file in alphabetical
+// order.
+
+public func A_renameAllTheThings(
   a: RenamedClass?,
   b: RenamedGenericClass<AnyObject>?,
   c: RenamedTypedef,
@@ -18,7 +32,7 @@ public func renameAllTheThings(
   f: RenamedProtocol
 ) {}
 
-// CHECK-LABEL: func renameAllTheThings(
+// CHECK-LABEL: func A_renameAllTheThings(
 // CHECK-SAME: a: RenamedClass?
 // CHECK-SAME: b: RenamedGenericClass<AnyObject>?
 // CHECK-SAME: c: RenamedTypedef
@@ -28,7 +42,7 @@ public func renameAllTheThings(
 // CHECK-SAME: )
 
 
-// CHECK-RECOVERY-LABEL: func renameAllTheThings(
+// CHECK-RECOVERY-LABEL: func A_renameAllTheThings(
 // CHECK-RECOVERY-SAME: a: Swift3RenamedClass?
 // CHECK-RECOVERY-SAME: b: Swift3RenamedGenericClass<AnyObject>?
 
@@ -42,10 +56,22 @@ public func renameAllTheThings(
 // CHECK-RECOVERY-SAME: )
 
 
-public func renameGeneric<T: RenamedProtocol>(obj: T) {}
+public func A_renameGeneric<T: RenamedProtocol>(obj: T) {}
 
-// CHECK-LABEL: func renameGeneric<T>(
+// CHECK-LABEL: func A_renameGeneric<T>(
 // CHECK-SAME: where T : RenamedProtocol
 
-// CHECK-RECOVERY-LABEL: func renameGeneric<T>(
+// CHECK-RECOVERY-LABEL: func A_renameGeneric<T>(
 // CHECK-RECOVERY-SAME: where T : Swift3RenamedProtocol
+
+public class B_ConformsToProto: RenamedProtocol {}
+
+// CHECK-LABEL: class B_ConformsToProto : RenamedProtocol
+// CHECK-RECOVERY-LABEL: class B_ConformsToProto : Swift3RenamedProtocol
+
+public struct B_RequiresConformance<T: RenamedProtocol> {}
+
+// CHECK-LABEL: struct B_RequiresConformance<T> where T : RenamedProtocol
+// CHECK-RECOVERY-LABEL: struct B_RequiresConformance<T> where T : Swift3RenamedProtocol
+
+#endif

--- a/test/Serialization/typealias.swift
+++ b/test/Serialization/typealias.swift
@@ -52,3 +52,5 @@ print("\(dyadic((named.b, i))) \(dyadic(both))\n", terminator: "")
 func check(_: BaseAlias) {
 }
 
+let x: GG<Int> = 0
+


### PR DESCRIPTION
When an Objective-C type is renamed, the importer leaves behind a typealias marked "unavailable". Look through that when we're expecting a nominal type or bound generic type.

There's still more work to do here: in the case of a typealias *not* left behind by the importer, there's a chance the generic arguments of the typealias aren't just directly forwarded to the underlying nominal. The right thing to do here is to build a substitution map and call `subst()` on the underlying type.