### PR TITLE
Fix a memory error introduced by recent changes

### DIFF
--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -163,8 +163,9 @@ namespace {
 static ArrayRef<ProtocolConformanceRef>
 collectExistentialConformances(ModuleDecl *M, CanType fromType, CanType toType) {
   assert(!fromType.isAnyExistentialType());
-  
-  auto protocols = toType.getExistentialLayout().getProtocols();
+
+  auto layout = toType.getExistentialLayout();
+  auto protocols = layout.getProtocols();
   
   SmallVector<ProtocolConformanceRef, 4> conformances;
   for (auto proto : protocols) {

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5315,7 +5315,8 @@ TypeChecker::conformsToProtocol(Type T, ProtocolDecl *Proto, DeclContext *DC,
 
     if (T->isExistentialType()) {
       bool anyUnsatisfied = false;
-      for (auto *proto : T->getExistentialLayout().getProtocols()) {
+      auto layout = T->getExistentialLayout();
+      for (auto *proto : layout.getProtocols()) {
         auto *protoDecl = proto->getDecl();
         if ((*unsatisfiedDependency)(requestInheritedProtocols(protoDecl)))
           anyUnsatisfied = true;

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3941,7 +3941,8 @@ public:
         if (T->isInvalid())
           return false;
         if (type->isExistentialType()) {
-          for (auto *proto : type->getExistentialLayout().getProtocols()) {
+          auto layout = type->getExistentialLayout();
+          for (auto *proto : layout.getProtocols()) {
             auto *protoDecl = proto->getDecl();
 
             if (protoDecl->existentialTypeSupported(&TC))


### PR DESCRIPTION
ExistentialLayout::getProtocols() can return an interior
pointer if the layout describes a single protocol type.

In this case we must not hold on to the result after
the layout goes out of scope.

Fix a few places where this was happening, which should
address a test failure we've been seeing.

Fixes <rdar://problem/31586433>.