### PR TITLE
Add shim for extern_proc's p_starttime.

### DIFF
--- a/stdlib/public/Platform/Darwin.swift.gyb
+++ b/stdlib/public/Platform/Darwin.swift.gyb
@@ -70,3 +70,12 @@ public let ${prefix}_TRUE_MIN = ${type}.leastNonzeroMagnitude
 #endif
 % end
 %end
+
+// Macros defined in bsd/sys/proc.h that do not import into Swift.
+extension extern_proc {
+    // #define p_starttime p_un.__p_starttime
+    @_transparent var p_starttime: timeval {
+        get { return self.p_un.__p_starttime }
+        set { self.p_un.__p_starttime = newValue }
+    }
+}


### PR DESCRIPTION
This constant is not imported by the ClangImporter:

  #define p_starttime p_un.__p_starttime

Add a shim to do the same thing.

Fixes rdar://problem/31549450