### PR TITLE
Added -help option to sourcekitd-test

### DIFF
--- a/test/SourceKit/Misc/usage.swift
+++ b/test/SourceKit/Misc/usage.swift
@@ -1,0 +1,6 @@
+// Sanity check that -help works
+
+// RUN: not %sourcekitd-test -help | %FileCheck %s
+
+// CHECK: USAGE: sourcekitd-test [options] <inputs>
+

--- a/test/SourceKit/Misc/wrong_arguments.swift
+++ b/test/SourceKit/Misc/wrong_arguments.swift
@@ -1,0 +1,7 @@
+// Check that from invalid input, program suggests using -help
+
+// RUN: not %sourcekitd-test -this_option_does_not_exist 2>&1 | %FileCheck %s
+
+// CHECK: error: unknown argument: -this_option_does_not_exist
+// CHECK: Use -h or -help for assistance
+

--- a/tools/SourceKit/tools/sourcekitd-test/Options.td
+++ b/tools/SourceKit/tools/sourcekitd-test/Options.td
@@ -102,3 +102,8 @@ def objc_name : Separate<["-"], "objc-name">,
 
 def objc_selector : Separate<["-"], "objc-selector">,
   HelpText<"Objective-C selector name to translate from">;
+
+def help : Flag<["-", "--"], "help">,
+  HelpText<"Display available options">;
+
+def h : Flag<["-"], "h">, Alias<help>;

--- a/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
@@ -146,6 +146,12 @@ bool TestOptions::parseArgs(llvm::ArrayRef<const char *> Args) {
       }
       break;
 
+    case OPT_help: {
+      printHelp(false);
+      return true;
+      break;
+    }
+
     case OPT_offset:
       if (StringRef(InputArg->getValue()).getAsInteger(10, Offset)) {
         llvm::errs() << "error: expected integer for 'offset'\n";
@@ -279,7 +285,8 @@ bool TestOptions::parseArgs(llvm::ArrayRef<const char *> Args) {
 
     case OPT_UNKNOWN:
       llvm::errs() << "error: unknown argument: "
-                   << InputArg->getAsString(ParsedArgs) << '\n';
+                   << InputArg->getAsString(ParsedArgs) << '\n'
+                   << "Use -h or -help for assistance" << '\n';
       return true;
     }
   }
@@ -291,4 +298,17 @@ bool TestOptions::parseArgs(llvm::ArrayRef<const char *> Args) {
   }
 
   return false;
+}
+
+void TestOptions::printHelp(bool ShowHidden) const {
+
+  // Based off of swift/lib/Driver/Driver.cpp, at Driver::printHelp
+  //FIXME: should we use IncludedFlagsBitmask and ExcludedFlagsBitmask?
+  // Maybe not for modes such as Interactive, Batch, AutolinkExtract, etc,
+  // as in Driver.cpp. But could be useful for extra info, like HelpHidden.
+
+  TestOptTable Table;
+
+  Table.PrintHelp(llvm::outs(), "sourcekitd-test", "SourceKit Testing Tool",
+                      ShowHidden);
 }

--- a/tools/SourceKit/tools/sourcekitd-test/TestOptions.h
+++ b/tools/SourceKit/tools/sourcekitd-test/TestOptions.h
@@ -90,6 +90,7 @@ struct TestOptions {
   bool CollectActionables = false;
   bool isAsyncRequest = false;
   bool parseArgs(llvm::ArrayRef<const char *> Args);
+  void printHelp(bool ShowHidden) const;
 };
 
 }


### PR DESCRIPTION


<!-- What's in this pull request? -->
### What the PR includes
Addresses one of the current starter bugs, adding the feature mentioned in the title.

I've added a `FIXME:` in the **printHelp** function to suggest a possible expansion for its functionality (allowing to hide/include certain options from the Help Text). I don't think that's necessary for this command, but could be useful if we want it to have as many options as `Driver.cpp` has. 

### Where has this been tested

I've compiled this in Linux, using a slightly modified version of the default presets. I used #8485 and #8189, and added a `cmake` option to compile `sourcekitd-test`. It passed the **buildbot_linux, smoketest** tests on my pc :+1: 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-1421](https://bugs.swift.org/browse/SR-1421).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
