### PR TITLE
[stdlib] Add MutableCollection.swapAt(_:_:)

### DIFF
--- a/stdlib/private/StdlibUnittest/StdlibCoreExtras.swift
+++ b/stdlib/private/StdlibUnittest/StdlibCoreExtras.swift
@@ -149,7 +149,7 @@ extension MutableCollection
     var f = subrange.lowerBound
     var l = index(before: subrange.upperBound)
     while f < l {
-      swap(&self[f], &self[l])
+      swapAt(f, l)
       formIndex(after: &f)
       formIndex(before: &l)
     }
@@ -195,7 +195,7 @@ extension MutableCollection
         repeat {
           formIndex(before: &j)
         } while !(elementAtBeforeI < self[j])
-        swap(&self[beforeI], &self[j])
+        swapAt(beforeI, j)
         _reverseSubrange(i..<endIndex)
         return .success
       }

--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -1710,7 +1710,7 @@ extension ${Self} {
   ///     var numbers = [1, 2, 3, 4, 5]
   ///     numbers.withUnsafeMutableBufferPointer { buffer in
   ///         for i in stride(from: buffer.startIndex, to: buffer.endIndex - 1, by: 2) {
-  ///             swap(&buffer[i], &buffer[i + 1])
+  ///             buffer.swapAt(i, i + 1)
   ///         }
   ///     }
   ///     print(numbers)
@@ -1756,7 +1756,7 @@ extension ${Self} {
     // empty array.
 
     var work = ${Self}()
-    swap(&work, &self)
+    (work, self) = (self, work)
 
     // Create an UnsafeBufferPointer over work that we can pass to body
     let pointer = work._buffer.firstElementAddress
@@ -1770,7 +1770,7 @@ extension ${Self} {
         inoutBufferPointer.count == count,
         "${Self} withUnsafeMutableBufferPointer: replacing the buffer is not allowed")
 
-      swap(&work, &self)
+      (work, self) = (self, work)
     }
 
     // Invoke the body.

--- a/stdlib/public/core/CollectionAlgorithms.swift.gyb
+++ b/stdlib/public/core/CollectionAlgorithms.swift.gyb
@@ -165,7 +165,7 @@ extension MutableCollection {
     var i = index(after: pivot)
     while i < endIndex {
       if try !belongsInSecondPartition(self[i]) {
-        swap(&self[i], &self[pivot])
+        swapAt(i, pivot)
         formIndex(after: &pivot)
       }
       formIndex(after: &i)
@@ -217,7 +217,7 @@ extension MutableCollection where Self : BidirectionalCollection {
         break Loop
       } while false
 
-      swap(&self[lo], &self[hi])
+      swapAt(lo, hi)
       formIndex(after: &lo)
     }
 

--- a/stdlib/public/core/ContiguousArrayBuffer.swift
+++ b/stdlib/public/core/ContiguousArrayBuffer.swift
@@ -582,7 +582,7 @@ internal func += <Element, C : Collection>(
     newLHS.firstElementAddress.moveInitialize(
       from: lhs.firstElementAddress, count: oldCount)
     lhs.count = 0
-    swap(&lhs, &newLHS)
+    (lhs, newLHS) = (newLHS, lhs)
     buf = UnsafeMutableBufferPointer(start: lhs.firstElementAddress + oldCount, count: numericCast(rhs.count))
   }
 
@@ -746,7 +746,7 @@ internal struct _UnsafePartiallyInitializedContiguousArrayBuffer<Element> {
       newResult.firstElementAddress.moveInitialize(
         from: result.firstElementAddress, count: result.capacity)
       result.count = 0
-      swap(&result, &newResult)
+      (result, newResult) = (newResult, result)
     }
     addWithExistingCapacity(element)
   }
@@ -789,7 +789,7 @@ internal struct _UnsafePartiallyInitializedContiguousArrayBuffer<Element> {
     _sanityCheck(remainingCapacity == result.capacity - result.count,
       "_UnsafePartiallyInitializedContiguousArrayBuffer has incorrect count")
     var finalResult = _ContiguousArrayBuffer<Element>()
-    swap(&finalResult, &result)
+    (finalResult, result) = (result, finalResult)
     remainingCapacity = 0
     return ContiguousArray(_buffer: finalResult)
   }

--- a/stdlib/public/core/MutableCollection.swift
+++ b/stdlib/public/core/MutableCollection.swift
@@ -398,6 +398,29 @@ extension MutableCollection where Self: RandomAccessCollection {
   }
 }
 
+extension MutableCollection {
+  /// Exchange the values at indices `i` and `j`.
+  ///
+  /// Has no effect when `i` and `j` are equal.
+  @_inlineable
+  public mutating func swapAt(_ i: Index, _ j: Index) {
+    guard i != j else { return }
+    
+    // Semantically equivalent to (i, j) = (j, i).
+    // Microoptimized to avoid retain/release traffic.
+    let p1 = Builtin.addressof(&self[i])
+    let p2 = Builtin.addressof(&self[j])
+    _sanityCheck(p1 != p2)
+
+    // Take from P1.
+    let tmp: Iterator.Element = Builtin.take(p1)
+    // Transfer P2 into P1.
+    Builtin.initialize(Builtin.take(p2) as Iterator.Element, p1)
+    // Initialize P2.
+    Builtin.initialize(tmp, p2)
+  }  
+}
+
 @available(*, unavailable, renamed: "MutableCollection")
 public typealias MutableCollectionType = MutableCollection
 

--- a/stdlib/public/core/Reverse.swift
+++ b/stdlib/public/core/Reverse.swift
@@ -27,7 +27,7 @@ extension MutableCollection where Self : BidirectionalCollection {
     var f = startIndex
     var l = index(before: endIndex)
     while f < l {
-      swap(&self[f], &self[l])
+      swapAt(f, l)
       formIndex(after: &f)
       formIndex(before: &l)
     }

--- a/stdlib/public/core/SequenceAlgorithms.swift.gyb
+++ b/stdlib/public/core/SequenceAlgorithms.swift.gyb
@@ -642,7 +642,7 @@ extension Sequence {
     var result = Array(self)
     let count = result.count
     for i in 0..<count/2 {
-      swap(&result[i], &result[count - ((i + 1) as Int)])
+      result.swapAt(i, count - ((i + 1) as Int))
     }
     return result
   }

--- a/stdlib/public/core/Sort.swift.gyb
+++ b/stdlib/public/core/Sort.swift.gyb
@@ -144,28 +144,28 @@ func _sort3<C>(
   case (true, true):
     // 1 swap: 321
     // swap(a, c): 312->123
-    swap(&elements[a], &elements[c])
+    elements.swapAt(a, c)
 
   case (true, false):
     // 1 swap: 213, 212 --- 2 swaps: 312, 211
     // swap(a, b): 213->123, 212->122, 312->132, 211->121
-    swap(&elements[a], &elements[b])
+    elements.swapAt(a, b)
 
     if ${cmp("elements[c]", "elements[b]", p)} {
       // 132 (started as 312), 121 (started as 211)
       // swap(b, c): 132->123, 121->112
-      swap(&elements[b], &elements[c])
+      elements.swapAt(b, c)
     }
 
   case (false, true):
     // 1 swap: 132, 121 --- 2 swaps: 231, 221
     // swap(b, c): 132->123, 121->112, 231->213, 221->212
-    swap(&elements[b], &elements[c])
+    elements.swapAt(b, c)
 
     if ${cmp("elements[b]", "elements[a]", p)} {
       // 213 (started as 231), 212 (started as 221)
       // swap(a, b): 213->123, 212->122
-      swap(&elements[a], &elements[b])
+      elements.swapAt(a, b)
     }
   }
 }
@@ -221,7 +221,7 @@ func _partition<C>(
       break Loop
     }
 
-    swap(&elements[lo], &elements[hi])
+    elements.swapAt(lo, hi)
   }
 
   return lo
@@ -334,7 +334,7 @@ func _siftDown<C>(
   // If a child is bigger than the current node, swap them and continue sifting
   // down.
   if largest != index {
-    swap(&elements[index], &elements[largest])
+    elements.swapAt(index, largest)
     ${try_} _siftDown(
       &elements,
       index: largest,
@@ -393,7 +393,7 @@ func _heapSort<C>(
     ${", by: areInIncreasingOrder" if p else ""})
   elements.formIndex(before: &hi)
   while hi != lo {
-    swap(&elements[lo], &elements[hi])
+    elements.swapAt(lo, hi)
     ${try_} _siftDown(
       &elements,
       index: lo,

--- a/stdlib/public/core/StringCharacterView.swift
+++ b/stdlib/public/core/StringCharacterView.swift
@@ -124,9 +124,9 @@ extension String {
     // exist at the point of mutation. Instead, temporarily move the
     // core of this string into a CharacterView.
     var tmp = CharacterView("")
-    swap(&_core, &tmp._core)
+    (_core, tmp._core) = (tmp._core, _core)
     let r = body(&tmp)
-    swap(&_core, &tmp._core)
+    (_core, tmp._core) = (tmp._core, _core)
     return r
   }
 

--- a/test/Prototypes/Algorithms.swift.gyb
+++ b/test/Prototypes/Algorithms.swift.gyb
@@ -70,7 +70,7 @@ extension MutableCollectionAlgorithms {
     var p = lhs.lowerBound
     var q = rhs.lowerBound
     repeat {
-      swap(&self[p], &self[q])
+      swapAt(p, q)
       formIndex(after: &p)
       formIndex(after: &q)
     }
@@ -195,7 +195,7 @@ extension MutableCollection where Self: BidirectionalCollection {
     var f = bounds.lowerBound
     var l = index(before: bounds.upperBound)
     while f < l {
-      swap(&self[f], &self[l])
+      swapAt(f, l)
       formIndex(after: &f)
       formIndex(before: &l)
     }
@@ -208,7 +208,7 @@ extension MutableCollection where Self: BidirectionalCollection {
     var l = endIndex
     while f != limit && l != limit {
       formIndex(before: &l)
-      swap(&self[f], &self[l])
+      swapAt(f, l)
       formIndex(after: &f)
     }
     return (f, l)

--- a/test/Prototypes/BigInt.swift
+++ b/test/Prototypes/BigInt.swift
@@ -888,7 +888,7 @@ public struct _BigInt<Word: FixedWidthInteger & UnsignedInteger> :
     while !x.isZero {
       // Swap values to ensure that `x >= y`.
       if x._compareMagnitude(to: y) == .lessThan {
-        swap(&x, &y)
+        (x, y) = (y, x)
       }
 
       // Subtract smaller and remove any factors of two


### PR DESCRIPTION
Introduces a `MutableColleciton.swapAt(_:_:)` and migrates standard library usage off `swap`