### PR TITLE
[WIP] Remove AnyObject protocol

### DIFF
--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -404,7 +404,8 @@ class ExistentialTypeFlags {
   enum : int_type {
     NumWitnessTablesMask  = 0x00FFFFFFU,
     ClassConstraintMask   = 0x80000000U,
-    SpecialProtocolMask   = 0x7F000000U,
+    HasSuperclassMask     = 0x40000000U,
+    SpecialProtocolMask   = 0x3F000000U,
     SpecialProtocolShift  = 24U,
   };
   int_type Data;
@@ -421,6 +422,11 @@ public:
                                   | (bool(c) ? ClassConstraintMask : 0));
   }
   constexpr ExistentialTypeFlags
+  withHasSuperclass(bool hasSuperclass) const {
+    return ExistentialTypeFlags((Data & ~HasSuperclassMask)
+                                  | (hasSuperclass ? HasSuperclassMask : 0));
+  }
+  constexpr ExistentialTypeFlags
   withSpecialProtocol(SpecialProtocol sp) const {
     return ExistentialTypeFlags((Data & ~SpecialProtocolMask)
                                   | (int_type(sp) << SpecialProtocolShift));
@@ -433,7 +439,11 @@ public:
   ProtocolClassConstraint getClassConstraint() const {
     return ProtocolClassConstraint(bool(Data & ClassConstraintMask));
   }
-  
+
+  bool hasSuperclassConstraint() const {
+    return bool(Data & HasSuperclassMask);
+  }
+
   /// Return whether this existential type represents an uncomposed special
   /// protocol.
   SpecialProtocol getSpecialProtocol() const {

--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -226,10 +226,8 @@ enum class SpecialProtocol: uint8_t {
   ///
   /// This must be 0 for ABI compatibility with Objective-C protocol_t records.
   None = 0,
-  /// The AnyObject protocol.
-  AnyObject = 1,
   /// The Error protocol.
-  Error = 2,
+  Error = 1,
 };
 
 /// Identifiers for protocol method dispatch strategies.
@@ -244,10 +242,6 @@ enum class ProtocolDispatchStrategy: uint8_t {
   /// To invoke methods of this protocol, a pointer to a protocol witness table
   /// corresponding to the protocol conformance must be available.
   Swift = 1,
-  
-  /// The protocol guarantees that it has no methods to dispatch. It requires
-  /// neither Objective-C metadata nor a witness table.
-  Empty = 2,
 };
 
 /// Flags in a generic nominal type descriptor.
@@ -375,7 +369,6 @@ public:
   static bool needsWitnessTable(ProtocolDispatchStrategy strategy) {
     switch (strategy) {
     case ProtocolDispatchStrategy::ObjC:
-    case ProtocolDispatchStrategy::Empty:
       return false;
     case ProtocolDispatchStrategy::Swift:
       return true;

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1298,8 +1298,6 @@ ERROR(extension_protocol_inheritance,none,
 ERROR(extension_protocol_via_typealias,none,
       "protocol %0 in the module being compiled cannot be extended via a "
       "type alias", (Type))
-ERROR(extension_anyobject,none,
-      "'AnyObject' protocol cannot be extended", ())
 ERROR(objc_generic_extension_using_type_parameter,none,
       "extension of a generic Objective-C class cannot access the class's "
       "generic parameters at runtime", ())

--- a/include/swift/AST/GenericEnvironment.h
+++ b/include/swift/AST/GenericEnvironment.h
@@ -226,12 +226,6 @@ public:
   /// generic parameter types by their sugared form.
   Type getSugaredType(Type type) const;
 
-  /// Derive a contextual type substitution map from a substitution array.
-  /// This is just like GenericSignature::getSubstitutionMap(), except
-  /// with contextual types instead of interface types.
-  SubstitutionMap
-  getSubstitutionMap(SubstitutionList subs) const;
-
   /// Build a contextual type substitution map from a type substitution function
   /// and conformance lookup function.
   SubstitutionMap

--- a/include/swift/AST/KnownProtocols.def
+++ b/include/swift/AST/KnownProtocols.def
@@ -50,7 +50,6 @@
 
 PROTOCOL(Sequence)
 PROTOCOL(IteratorProtocol)
-PROTOCOL(AnyObject)
 PROTOCOL(RawRepresentable)
 PROTOCOL(Equatable)
 PROTOCOL(Hashable)

--- a/include/swift/AST/SubstitutionMap.h
+++ b/include/swift/AST/SubstitutionMap.h
@@ -41,6 +41,7 @@ namespace swift {
 class GenericSignature;
 class GenericEnvironment;
 class SubstitutableType;
+typedef CanTypeWrapper<GenericTypeParamType> CanGenericTypeParamType;
 
 template<class Type> class CanTypeWrapper;
 typedef CanTypeWrapper<SubstitutableType> CanSubstitutableType;
@@ -55,7 +56,7 @@ class SubstitutionMap {
   GenericSignature *genericSig;
 
   // FIXME: Switch to a more efficient representation.
-  llvm::DenseMap<SubstitutableType *, Type> subMap;
+  llvm::DenseMap<GenericTypeParamType *, Type> subMap;
   llvm::DenseMap<TypeBase *, SmallVector<ProtocolConformanceRef, 1>>
     conformanceMap;
 
@@ -165,7 +166,7 @@ private:
   // instead, use GenericSignature::getSubstitutionMap() or
   // GenericEnvironment::getSubstitutionMap().
 
-  void addSubstitution(CanSubstitutableType type, Type replacement);
+  void addSubstitution(CanGenericTypeParamType type, Type replacement);
   void addConformance(CanType type, ProtocolConformanceRef conformance);
 };
 

--- a/include/swift/Reflection/TypeRef.h
+++ b/include/swift/Reflection/TypeRef.h
@@ -421,28 +421,39 @@ public:
 };
 
 class ProtocolCompositionTypeRef final : public TypeRef {
-  std::vector<const TypeRef *> Protocols;
+  std::vector<const TypeRef *> Members;
+  bool HasExplicitAnyObject;
 
-  static TypeRefID Profile(const std::vector<const TypeRef *> &Protocols) {
+  static TypeRefID Profile(const std::vector<const TypeRef *> &Members,
+                           bool HasExplicitAnyObject) {
     TypeRefID ID;
-    for (auto Protocol : Protocols) {
-      ID.addPointer(Protocol);
+    ID.addInteger((uint32_t)HasExplicitAnyObject);
+    for (auto Member : Members) {
+      ID.addPointer(Member);
     }
     return ID;
   }
 
 public:
-  ProtocolCompositionTypeRef(std::vector<const TypeRef *> Protocols)
-    : TypeRef(TypeRefKind::ProtocolComposition), Protocols(Protocols) {}
+  ProtocolCompositionTypeRef(std::vector<const TypeRef *> Members,
+                            bool HasExplicitAnyObject)
+    : TypeRef(TypeRefKind::ProtocolComposition),
+      Members(Members), HasExplicitAnyObject(HasExplicitAnyObject) {}
 
   template <typename Allocator>
   static const ProtocolCompositionTypeRef *
-  create(Allocator &A, std::vector<const TypeRef *> Protocols) {
-    FIND_OR_CREATE_TYPEREF(A, ProtocolCompositionTypeRef, Protocols);\
+  create(Allocator &A, std::vector<const TypeRef *> Members,
+        bool HasExplicitAnyObject) {
+    FIND_OR_CREATE_TYPEREF(A, ProtocolCompositionTypeRef, Members,
+                           HasExplicitAnyObject);
   }
 
-  const std::vector<const TypeRef *> &getProtocols() const {
-    return Protocols;
+  const std::vector<const TypeRef *> &getMembers() const {
+    return Members;
+  }
+
+  bool hasExplicitAnyObject() const {
+    return HasExplicitAnyObject;
   }
 
   static bool classof(const TypeRef *TR) {

--- a/include/swift/Reflection/TypeRefBuilder.h
+++ b/include/swift/Reflection/TypeRefBuilder.h
@@ -213,12 +213,16 @@ public:
   }
 
   const ProtocolCompositionTypeRef *
-  createProtocolCompositionType(const std::vector<const TypeRef*> &protocols) {
-    for (auto protocol : protocols) {
-      if (!isa<ProtocolTypeRef>(protocol))
+  createProtocolCompositionType(const std::vector<const TypeRef*> &members,
+                                bool hasExplicitAnyObject) {
+    for (auto member : members) {
+      if (!isa<ProtocolTypeRef>(member) &&
+          !isa<NominalTypeRef>(member) &&
+          !isa<BoundGenericTypeRef>(member))
         return nullptr;
     }
-    return ProtocolCompositionTypeRef::create(*this, protocols);
+    return ProtocolCompositionTypeRef::create(*this, members,
+                                              hasExplicitAnyObject);
   }
 
   const ExistentialMetatypeTypeRef *

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -2445,9 +2445,16 @@ struct TargetExistentialTypeMetadata : public TargetMetadata<Runtime> {
     return Flags.getClassConstraint() == ProtocolClassConstraint::Class;
   }
 
-  const Metadata *getSuperclassConstraint() const {
-    // FIXME
-    return nullptr;
+  const TargetMetadata<Runtime> *getSuperclassConstraint() const {
+    if (!Flags.hasSuperclassConstraint())
+      return nullptr;
+
+    // Get a pointer to tail-allocated storage for this metadata record.
+    auto Pointer = reinterpret_cast<
+      ConstTargetMetadataPointer<Runtime, TargetMetadata> const *>(this + 1);
+
+    // The superclass immediately follows the list of protocol descriptors.
+    return Pointer[Protocols.NumProtocols];
   }
 
   static bool classof(const TargetMetadata<Runtime> *metadata) {

--- a/include/swift/SIL/TypeSubstCloner.h
+++ b/include/swift/SIL/TypeSubstCloner.h
@@ -41,8 +41,9 @@ class TypeSubstCloner : public SILClonerWithScopes<ImplClass> {
   }
 
   void computeSubsMap() {
-    if (auto *env = Original.getGenericEnvironment()) {
-      SubsMap = env->getSubstitutionMap(ApplySubs);
+    if (auto genericSig = Original.getLoweredFunctionType()
+          ->getGenericSignature()) {
+      SubsMap = genericSig->getSubstitutionMap(ApplySubs);
     }
   }
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -183,7 +183,6 @@ struct SynthesizedExtensionAnalyzer::Implementation {
   typedef std::vector<ExtensionMergeGroup> MergeGroupVector;
 
   NominalTypeDecl *Target;
-  Type BaseType;
   DeclContext *DC;
   bool IncludeUnconditional;
   PrintOptions Options;
@@ -194,7 +193,6 @@ struct SynthesizedExtensionAnalyzer::Implementation {
                  bool IncludeUnconditional,
                  PrintOptions Options):
     Target(Target),
-    BaseType(Target->getDeclaredInterfaceType()),
     DC(Target),
     IncludeUnconditional(IncludeUnconditional),
     Options(Options), AllGroups(MergeGroupVector()),
@@ -211,6 +209,8 @@ struct SynthesizedExtensionAnalyzer::Implementation {
 
   std::pair<SynthesizedExtensionInfo, ExtensionMergeInfo>
   isApplicable(ExtensionDecl *Ext, bool IsSynthesized) {
+    auto BaseType = Target->getDeclaredTypeInContext();
+
     SynthesizedExtensionInfo Result(IsSynthesized);
     ExtensionMergeInfo MergeInfo;
     MergeInfo.HasDocComment = !Ext->getRawComment().isEmpty();
@@ -221,30 +221,43 @@ struct SynthesizedExtensionAnalyzer::Implementation {
       return {Result, MergeInfo};
     }
 
-    // Get the substitutions from the generic signature of
-    // the extension to the interface types of the base type's
-    // declaration.
-    auto *M = DC->getParentModule();
-    SubstitutionMap subMap;
-    if (!BaseType->isExistentialType())
-      subMap = BaseType->getContextSubstitutionMap(M, Ext);
-
     assert(Ext->getGenericSignature() && "No generic signature.");
+
+    // Protocol vs protocol extension.
+    //
+    // Just keep all the requirements.
+    if (BaseType->isExistentialType()) {
+      for (auto Req : Ext->getGenericSignature()->getRequirements()) {
+        auto Kind = Req.getKind();
+        auto First = Req.getFirstType();
+        auto Second = Req.getSecondType();
+        MergeInfo.addRequirement(First, Second, Kind);
+      }
+
+      Result.Ext = Ext;
+      return {Result, MergeInfo};
+    }
+
+    // Concrete type vs concrete extension or protocol extension.
+    //
+    // The general idea is that we keep the requirements which are
+    // conditionally satisfied, discard requirements that are
+    // always satisfied, and discard the extension altogether
+    // if any requirements are insatisfiable.
+    auto *M = DC->getParentModule();
+    auto subMap = BaseType->getContextSubstitutionMap(M, Ext);
+
     for (auto Req : Ext->getGenericSignature()->getRequirements()) {
       auto Kind = Req.getKind();
 
-      auto First = Req.getFirstType();
-      auto Second = Req.getSecondType();
-      if (!BaseType->isExistentialType()) {
-        First = First.subst(subMap);
-        Second = Second.subst(subMap);
+      auto First = Req.getFirstType().subst(subMap);
+      auto Second = Req.getSecondType().subst(subMap);
 
-        if (!First || !Second) {
-          // Substitution with interface type bases can only fail
-          // if a concrete type fails to conform to a protocol.
-          // In this case, just give up on the extension altogether.
-          return {Result, MergeInfo};
-        }
+      if (!First || !Second) {
+        // Substitution with interface type bases can only fail
+        // if a concrete type fails to conform to a protocol.
+        // In this case, just give up on the extension altogether.
+        return {Result, MergeInfo};
       }
 
       switch (Kind) {

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2079,11 +2079,6 @@ void PrintAST::printInherited(const Decl *decl,
   if (inherited.empty() && superclass.isNull() && !explicitClass) {
     if (protos.empty())
       return;
-    // If only conforms to AnyObject protocol, nothing to print.
-    if (protos.size() == 1) {
-      if (protos.front()->isSpecificProtocol(KnownProtocolKind::AnyObject))
-        return;
-    }
   }
 
   if (inherited.empty()) {
@@ -2107,8 +2102,6 @@ void PrintAST::printInherited(const Decl *decl,
 
     for (auto Proto : protos) {
       if (!shouldPrint(Proto))
-        continue;
-      if (Proto->isSpecificProtocol(KnownProtocolKind::AnyObject))
         continue;
       if (auto Enum = dyn_cast<EnumDecl>(decl)) {
         // Conformance to RawRepresentable is implied by having a raw type.

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2853,9 +2853,6 @@ bool ProtocolDecl::existentialConformsToSelfSlow() {
   ProtocolDeclBits.ExistentialConformsToSelfValid = true;
   ProtocolDeclBits.ExistentialConformsToSelf = true;
 
-  if (isSpecificProtocol(KnownProtocolKind::AnyObject))
-    return true;
-
   if (!isObjC()) {
     ProtocolDeclBits.ExistentialConformsToSelf = false;
     return false;

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2824,25 +2824,33 @@ bool ProtocolDecl::inheritsFrom(const ProtocolDecl *super) const {
 }
 
 bool ProtocolDecl::requiresClassSlow() {
+  if (!isRequirementSignatureComputed()) {
+    ProtocolDeclBits.RequiresClass =
+      walkInheritedProtocols([&](ProtocolDecl *proto) {
+          // If the 'requires class' bit is valid, we don't need to search any
+          // further.
+          if (proto->ProtocolDeclBits.RequiresClassValid) {
+            // If this protocol has a class requirement, we're done.
+            if (proto->ProtocolDeclBits.RequiresClass)
+              return TypeWalker::Action::Stop;
+
+            return TypeWalker::Action::SkipChildren;
+          }
+
+          // Quick check: @objc indicates that it requires a class.
+          if (proto->getAttrs().hasAttribute<ObjCAttr>() || proto->isObjC())
+            return TypeWalker::Action::Stop;
+
+          // Keep looking.
+          return TypeWalker::Action::Continue;
+        });
+    return ProtocolDeclBits.RequiresClass;
+  }
+
+  auto selfType = getProtocolSelfType();
   ProtocolDeclBits.RequiresClass =
-    walkInheritedProtocols([&](ProtocolDecl *proto) {
-      // If the 'requires class' bit is valid, we don't need to search any
-      // further.
-      if (proto->ProtocolDeclBits.RequiresClassValid) {
-        // If this protocol has a class requirement, we're done.
-        if (proto->ProtocolDeclBits.RequiresClass)
-          return TypeWalker::Action::Stop;
-
-        return TypeWalker::Action::SkipChildren;
-      }
-
-      // Quick check: @objc indicates that it requires a class.
-      if (proto->getAttrs().hasAttribute<ObjCAttr>() || proto->isObjC())
-        return TypeWalker::Action::Stop;
-
-      // Keep looking.
-      return TypeWalker::Action::Continue;
-    });
+    getRequirementSignature()->requiresClass(selfType, *getParentModule());
+  ProtocolDeclBits.RequiresClassValid = true;
 
   return ProtocolDeclBits.RequiresClass;
 }

--- a/lib/AST/GenericEnvironment.cpp
+++ b/lib/AST/GenericEnvironment.cpp
@@ -349,38 +349,6 @@ GenericEnvironment::getForwardingSubstitutions() const {
   return getGenericSignature()->getASTContext().AllocateCopy(result);
 }
 
-SubstitutionMap GenericEnvironment::
-getSubstitutionMap(SubstitutionList subs) const {
-  SubstitutionMap result(const_cast<GenericEnvironment *>(this));
-
-  getGenericSignature()->enumeratePairedRequirements(
-    [&](Type depTy, ArrayRef<Requirement> reqts) -> bool {
-      // Map the interface type to a context type.
-      auto contextTy = depTy.subst(QueryInterfaceTypeSubstitutions(this),
-                                   MakeAbstractConformanceForGenericType());
-
-      auto sub = subs.front();
-      subs = subs.slice(1);
-
-      // Record the replacement type and its conformances.
-      if (auto *archetype = contextTy->getAs<ArchetypeType>()) {
-        result.addSubstitution(CanArchetypeType(archetype), sub.getReplacement());
-        assert(reqts.size() == sub.getConformances().size());
-        for (auto conformance : sub.getConformances())
-          result.addConformance(CanType(archetype), conformance);
-        return false;
-      }
-
-      assert(contextTy->hasError());
-      return false;
-    });
-
-  assert(subs.empty() && "did not use all substitutions?!");
-
-  result.verify();
-  return result;
-}
-
 SubstitutionMap
 GenericEnvironment::
 getSubstitutionMap(TypeSubstitutionFn subs,
@@ -389,6 +357,7 @@ getSubstitutionMap(TypeSubstitutionFn subs,
 
   getGenericSignature()->enumeratePairedRequirements(
     [&](Type depTy, ArrayRef<Requirement> reqs) -> bool {
+      auto canTy = depTy->getCanonicalType();
 
       // Map the interface type to a context type.
       auto contextTy = depTy.subst(QueryInterfaceTypeSubstitutions(this),
@@ -397,20 +366,19 @@ getSubstitutionMap(TypeSubstitutionFn subs,
       // Compute the replacement type.
       Type currentReplacement = contextTy.subst(subs, lookupConformance,
                                                 SubstFlags::UseErrorType);
-      if (auto archetypeTy = contextTy->getAs<ArchetypeType>()) {
-        subMap.addSubstitution(CanArchetypeType(archetypeTy),
-                               currentReplacement);
 
-        // Collect the conformances.
-        for (auto req: reqs) {
-          assert(req.getKind() == RequirementKind::Conformance);
-          auto protoType = req.getSecondType()->castTo<ProtocolType>();
-          auto conformance = lookupConformance(CanArchetypeType(archetypeTy),
-                                               currentReplacement,
-                                               protoType);
-          if (conformance)
-            subMap.addConformance(CanArchetypeType(archetypeTy), *conformance);
-        }
+      if (auto paramTy = dyn_cast<GenericTypeParamType>(canTy))
+        subMap.addSubstitution(paramTy, currentReplacement);
+
+      // Collect the conformances.
+      for (auto req: reqs) {
+        assert(req.getKind() == RequirementKind::Conformance);
+        auto protoType = req.getSecondType()->castTo<ProtocolType>();
+        auto conformance = lookupConformance(canTy,
+                                             currentReplacement,
+                                             protoType);
+        if (conformance)
+          subMap.addConformance(canTy, *conformance);
       }
 
       return false;

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -387,8 +387,8 @@ GenericSignature::getSubstitutionMap(SubstitutionList subs) const {
       subs = subs.slice(1);
 
       auto canTy = depTy->getCanonicalType();
-      if (isa<SubstitutableType>(canTy))
-        result.addSubstitution(cast<SubstitutableType>(canTy),
+      if (auto paramTy = dyn_cast<GenericTypeParamType>(canTy))
+        result.addSubstitution(paramTy,
                                sub.getReplacement());
       assert(reqts.size() == sub.getConformances().size());
       for (auto conformance : sub.getConformances())
@@ -415,8 +415,8 @@ getSubstitutionMap(TypeSubstitutionFn subs,
     // Compute the replacement type.
     Type currentReplacement = depTy.subst(subs, lookupConformance,
                                           SubstFlags::UseErrorType);
-    if (auto substTy = dyn_cast<SubstitutableType>(canTy))
-      subMap.addSubstitution(substTy, currentReplacement);
+    if (auto paramTy = dyn_cast<GenericTypeParamType>(canTy))
+      subMap.addSubstitution(paramTy, currentReplacement);
 
     // Collect the conformances.
     for (auto req: reqs) {

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -3413,6 +3413,8 @@ static Identifier typoCorrectNestedType(
       unsigned dist = name.edit_distance(assocType->getName().str(),
                                          /*AllowReplacements=*/true,
                                          maxScore);
+      if (dist == 0)
+        continue;
       assert(dist > 0 && "nested type should have matched associated type");
       if (bestEditDistance == 0 || dist == bestEditDistance) {
         bestEditDistance = dist;

--- a/lib/AST/LookupVisibleDecls.cpp
+++ b/lib/AST/LookupVisibleDecls.cpp
@@ -471,11 +471,12 @@ static void lookupVisibleProtocolMemberDecls(
     Type BaseTy, ProtocolType *PT, VisibleDeclConsumer &Consumer,
     const DeclContext *CurrDC, LookupState LS, DeclVisibilityKind Reason,
     LazyResolver *TypeResolver, VisitedSet &Visited) {
-  if (PT->getDecl()->isSpecificProtocol(KnownProtocolKind::AnyObject)) {
+  // FIXME FIXME FIXME
+  /*if (PT->getDecl()->isSpecificProtocol(KnownProtocolKind::AnyObject)) {
     // Handle AnyObject in a special way.
     doDynamicLookup(Consumer, CurrDC, LS, TypeResolver);
     return;
-  }
+    }*/
   if (!Visited.insert(PT->getDecl()).second)
     return;
 

--- a/lib/AST/LookupVisibleDecls.cpp
+++ b/lib/AST/LookupVisibleDecls.cpp
@@ -742,7 +742,7 @@ public:
 
     // Don't pass UnboundGenericType here. If you see this assertion
     // being hit, fix the caller, don't remove it.
-    assert(!BaseTy->hasUnboundGenericType());
+    //assert(!BaseTy->hasUnboundGenericType());
 
     // If the base type is AnyObject, we might be doing a dynamic
     // lookup, so the base type won't match the type of the member's

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -587,14 +587,6 @@ ModuleDecl::lookupConformance(Type type, ProtocolDecl *protocol,
       }
     }
 
-    // FIXME: This will go away soon.
-    if (protocol->isSpecificProtocol(KnownProtocolKind::AnyObject)) {
-      if (archetype->requiresClass())
-        return ProtocolConformanceRef(protocol);
-
-      return None;
-    }
-
     for (auto ap : archetype->getConformsTo()) {
       if (ap == protocol || ap->inheritsFrom(protocol))
         return ProtocolConformanceRef(protocol);
@@ -620,12 +612,6 @@ ModuleDecl::lookupConformance(Type type, ProtocolDecl *protocol,
     // @objc protocols.
     if (!layout.isObjC())
       return None;
-
-    // Special-case AnyObject, which may not be in the list of conformances.
-    //
-    // FIXME: This is going away soon.
-    if (protocol->isSpecificProtocol(KnownProtocolKind::AnyObject))
-      return ProtocolConformanceRef(protocol);
 
     // If the existential is class-constrained, the class might conform
     // concretely.

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1389,17 +1389,6 @@ bool DeclContext::lookupQualified(Type type,
   if (auto nominal = type->getAnyNominal()) {
     visited.insert(nominal);
     stack.push_back(nominal);
-    
-    // If we want dynamic lookup and we're searching in the
-    // AnyObject protocol, note this for later.
-    //
-    // FIXME: This will go away soon.
-    if (options & NL_DynamicLookup) {
-      if (auto proto = dyn_cast<ProtocolDecl>(nominal)) {
-        if (proto->isSpecificProtocol(KnownProtocolKind::AnyObject))
-          wantLookupInAllClasses = true;
-      }
-    }
   }
   // Handle archetypes
   else if (auto archetypeTy = type->getAs<ArchetypeType>()) {

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -122,44 +122,11 @@ ProtocolConformanceRef::subst(Type origType,
 
   auto *proto = getRequirement();
 
-  // If the original type was an archetype, check the conformance map.
-  if (origType->is<SubstitutableType>()
-      || origType->is<DependentMemberType>()) {
-    if (auto result = conformances(origType->getCanonicalType(),
-                                   substType,
-                                   proto->getDeclaredType())) {
-      return *result;
-    }
-  }
-
-  // If that didn't find anything, we can still synthesize AnyObject
-  // conformances from thin air.  FIXME: this is going away soon.
-  if (proto->isSpecificProtocol(KnownProtocolKind::AnyObject)) {
-    if (substType->isExistentialType())
-      return *this;
-
-    ClassDecl *classDecl = nullptr;
-    auto archetype = substType->getAs<ArchetypeType>();
-
-    if (archetype) {
-      if (archetype->getSuperclass())
-        classDecl = archetype->getSuperclass()->getClassOrBoundGenericClass();
-
-      // A class-constrained archetype without a superclass constraint
-      // conforms to AnyObject abstractly.
-      if (!classDecl && archetype->requiresClass())
-        return ProtocolConformanceRef(proto);
-    } else {
-      classDecl = substType->getClassOrBoundGenericClass();
-    }
-
-    assert(classDecl);
-
-    // Create a concrete conformance based on the conforming class.
-    SmallVector<ProtocolConformance *, 1> lookupResults;
-    classDecl->lookupConformance(classDecl->getParentModule(), proto,
-                                 lookupResults);
-    return ProtocolConformanceRef(lookupResults.front());
+  // Check the conformance map.
+  if (auto result = conformances(origType->getCanonicalType(),
+                                 substType,
+                                 proto->getDeclaredType())) {
+    return *result;
   }
 
   llvm_unreachable("Invalid conformance substitution");
@@ -882,13 +849,7 @@ void NominalTypeDecl::prepareConformanceTable() const {
     return;
 
   // Add any synthesized conformances.
-  if (isa<ClassDecl>(this)) {
-    // FIXME: This is going away soon.
-    if (auto anyObject = getASTContext().getProtocol(
-                           KnownProtocolKind::AnyObject)) {
-      ConformanceTable->addSynthesizedConformance(mutableThis, anyObject);
-    }
-  } else if (auto theEnum = dyn_cast<EnumDecl>(mutableThis)) {
+  if (auto theEnum = dyn_cast<EnumDecl>(mutableThis)) {
     if (theEnum->hasCases() && theEnum->hasOnlyCasesWithoutAssociatedValues()) {
       // Simple enumerations conform to Equatable.
       if (auto equatable = ctx.getProtocol(KnownProtocolKind::Equatable)) {

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -696,10 +696,10 @@ SpecializedProtocolConformance::getTypeWitnessAndDecl(
   }
 
   // Otherwise, perform substitutions to create this witness now.
-  auto *genericEnv = GenericConformance->getGenericEnvironment();
+  auto *genericSig = GenericConformance->getGenericSignature();
 
   auto substitutionMap =
-      genericEnv->getSubstitutionMap(GenericSubstitutions);
+      genericSig->getSubstitutionMap(GenericSubstitutions);
 
   auto genericWitnessAndDecl
     = GenericConformance->getTypeWitnessAndDecl(assocType, resolver);
@@ -730,8 +730,8 @@ SpecializedProtocolConformance::getAssociatedConformance(Type assocType,
   ProtocolConformanceRef conformance =
     GenericConformance->getAssociatedConformance(assocType, protocol, resolver);
 
-  auto genericEnv = GenericConformance->getGenericEnvironment();
-  auto subMap = genericEnv->getSubstitutionMap(GenericSubstitutions);
+  auto genericSig = GenericConformance->getGenericSignature();
+  auto subMap = genericSig->getSubstitutionMap(GenericSubstitutions);
 
   Type origType =
     (conformance.isConcrete()
@@ -811,30 +811,10 @@ ProtocolConformance::subst(Type substType,
                == substType->getNominalOrBoundGenericNominal()
              && "substitution mapped to different nominal?!");
 
-      // Since this is a normal conformance, the substitution maps archetypes
-      // in the environment of the conformance to types containing archetypes
-      // of some other generic environment.
-      //
-      // ASTContext::getSpecializedConformance() wants a substitution map
-      // with interface types as keys, so do the mapping here.
-      //
-      // Once the type of a normal conformance becomes an interface type,
-      // we can remove this.
       SubstitutionMap subMap;
       if (auto *genericSig = getGenericSignature()) {
         auto *genericEnv = getGenericEnvironment();
-        subMap = genericSig->getSubstitutionMap(
-          [&](SubstitutableType *t) -> Type {
-            return genericEnv->mapTypeIntoContext(
-              t).subst(subs, conformances, SubstFlags::UseErrorType);
-          },
-          [&](CanType origType, Type substType, ProtocolType *protoType)
-            -> Optional<ProtocolConformanceRef> {
-            origType = CanType(
-              genericEnv->mapTypeIntoContext(
-                origType)->castTo<ArchetypeType>());
-            return conformances(origType, substType, protoType);
-          });
+        subMap = genericEnv->getSubstitutionMap(subs, conformances);
       }
 
       return substType->getASTContext()

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -119,13 +119,6 @@ SubstitutionMap::lookupConformance(CanType type, ProtocolDecl *proto) const {
   auto genericSig = getGenericSignature();
   auto &mod = *proto->getModuleContext();
 
-  // HACK: Deal with AnyObject conformances, which get magically dropped in
-  // frustrating ways.
-  // FIXME: This hack dies with AnyObject-as-a-protocol.
-  if (proto->isSpecificProtocol(KnownProtocolKind::AnyObject) &&
-      genericSig->requiresClass(type, mod))
-    return ProtocolConformanceRef(proto);
-
   // If the type doesn't conform to this protocol, fail.
   if (!genericSig->conformsToProtocol(type, proto, mod))
     return None;
@@ -383,9 +376,8 @@ void SubstitutionMap::verify() const {
       // AnyObject or an @objc protocol.
       if (citer->isAbstract() && replacement->isExistentialType()) {
         auto *proto = citer->getRequirement();
-        assert((proto->isSpecificProtocol(KnownProtocolKind::AnyObject) ||
-                proto->isObjC()) &&
-               "an existential type can conform only to AnyObject or an "
+        assert(proto->isObjC() &&
+               "an existential type can conform only to an "
                "@objc-protocol");
         continue;
       }

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -236,10 +236,7 @@ ExistentialLayout::ExistentialLayout(ProtocolType *type) {
     requiresClassImplied = false;
   }
 
-  containsNonObjCProtocol =
-    !(protoDecl->isSpecificProtocol(KnownProtocolKind::AnyObject) ||
-      protoDecl->isObjC());
-
+  containsNonObjCProtocol = !protoDecl->isObjC();
   singleProtocol = type;
 }
 
@@ -266,9 +263,7 @@ ExistentialLayout::ExistentialLayout(ProtocolCompositionType *type) {
       requiresClassImplied = true;
     }
 
-    containsNonObjCProtocol |=
-      !(protoDecl->isSpecificProtocol(KnownProtocolKind::AnyObject) ||
-        protoDecl->isObjC());
+    containsNonObjCProtocol |= !protoDecl->isObjC();
   }
 
   singleProtocol = nullptr;
@@ -292,14 +287,8 @@ ExistentialLayout CanType::getExistentialLayout() {
 }
 
 bool ExistentialLayout::isAnyObject() const {
-  // New implementation
   auto protocols = getProtocols();
-  if (requiresClass && !requiresClassImplied && protocols.empty())
-    return true;
-
-  // Old implementation -- FIXME: remove this
-  return protocols.size() == 1 &&
-    protocols[0]->getDecl()->isSpecificProtocol(KnownProtocolKind::AnyObject);
+  return (requiresClass && !requiresClassImplied && protocols.empty());
 }
 
 bool TypeBase::isObjCExistentialType() {

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -642,6 +642,14 @@ ToolChain::constructInvocation(const MergeModuleJobAction &job,
   // serialized ASTs.
   Arguments.push_back("-parse-as-library");
 
+  // Merge serialized SIL from partial modules.
+  Arguments.push_back("-sil-merge-partial-modules");
+
+  // Disable SIL optimization passes; we've already optimized the code in each
+  // partial mode.
+  Arguments.push_back("-disable-diagnostic-passes");
+  Arguments.push_back("-disable-sil-perf-optzns");
+
   addCommonFrontendArgs(*this, context.OI, context.Output, context.Args,
                         Arguments);
   context.Args.AddLastArg(Arguments, options::OPT_import_objc_header);

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -919,9 +919,11 @@ static CodeCompletionResult::ExpectedTypeRelation calculateTypeRelation(
                                                                 Type Ty,
                                                                 Type ExpectedTy,
                                                                 DeclContext *DC) {
-  if (Ty.isNull() || ExpectedTy.isNull() ||
-      Ty->is<ErrorType>() ||
-      ExpectedTy->is<ErrorType>())
+  Ty = DC->mapTypeIntoContext(Ty);
+  if (ExpectedTy->hasTypeParameter())
+    ExpectedTy = DC->mapTypeIntoContext(ExpectedTy);
+
+  if (Ty->hasError() || ExpectedTy->hasError())
     return CodeCompletionResult::ExpectedTypeRelation::Unrelated;
   if (Ty->isEqual(ExpectedTy))
     return CodeCompletionResult::ExpectedTypeRelation::Identical;
@@ -939,21 +941,21 @@ calculateTypeRelationForDecl(const Decl *D, Type ExpectedType,
                              bool IsImplicitlyCurriedInstanceMethod,
                              bool UseFuncResultType = true) {
   auto VD = dyn_cast<ValueDecl>(D);
-  auto DC = D->getDeclContext();
+  auto DC = D->getInnermostDeclContext();
   if (!VD)
     return CodeCompletionResult::ExpectedTypeRelation::Unrelated;
 
   if (auto FD = dyn_cast<AbstractFunctionDecl>(VD)) {
-    auto funcType = FD->getInterfaceType()->getAs<AnyFunctionType>();
-    if (DC->isTypeContext() && funcType && funcType->is<AnyFunctionType>() &&
-        !IsImplicitlyCurriedInstanceMethod)
-      funcType = funcType->getResult()->getAs<AnyFunctionType>();
-    if (funcType) {
+    if (auto funcType = FD->getInterfaceType()->getAs<AnyFunctionType>()) {
+      if (FD->getDeclContext()->isTypeContext() &&
+          !IsImplicitlyCurriedInstanceMethod)
+        funcType = funcType->getResult()->getAs<AnyFunctionType>();
+
       auto relation = calculateTypeRelation(funcType, ExpectedType, DC);
       if (UseFuncResultType)
         relation =
-            std::max(relation, calculateTypeRelation(funcType->getResult(),
-                                                     ExpectedType, DC));
+          std::max(relation, calculateTypeRelation(funcType->getResult(),
+                                                   ExpectedType, DC));
       return relation;
     }
   }
@@ -3115,19 +3117,8 @@ public:
     Kind = LookupKind::ValueExpr;
     NeedLeadingDot = !HaveDot;
 
-    // This is horrible
     ExprType = ExprType->getRValueType();
     this->ExprType = ExprType;
-    if (ExprType->hasTypeParameter()) {
-      DeclContext *DC;
-      if (VD) {
-        DC = VD->getInnermostDeclContext();
-        this->ExprType = DC->mapTypeIntoContext(ExprType);
-      } else if (auto NTD = ExprType->getRValueInstanceType()->getAnyNominal()) {
-        DC = NTD;
-        this->ExprType = DC->mapTypeIntoContext(ExprType);
-      }
-    }
 
     bool Done = false;
     if (tryFunctionCallCompletions(ExprType, VD))

--- a/lib/IRGen/GenCast.cpp
+++ b/lib/IRGen/GenCast.cpp
@@ -495,15 +495,6 @@ void irgen::emitScalarExistentialDowncast(IRGenFunction &IGF,
     // to check for it independent of protocol witnesses.
     if (protoDecl->requiresClass()) {
       assert(hasClassConstraint);
-
-      if (protoDecl->getKnownProtocolKind()
-          && *protoDecl->getKnownProtocolKind() == KnownProtocolKind::AnyObject) {
-        // AnyObject only requires that the type be a class.
-        continue;
-      }
-      
-      // If this protocol is class-constrained but not AnyObject, checking its
-      // conformance will check the class constraint too.
       hasClassConstraintByProtocol = true;
     }
 

--- a/lib/IRGen/GenClangType.cpp
+++ b/lib/IRGen/GenClangType.cpp
@@ -350,10 +350,6 @@ clang::CanQualType GenClangType::visitTupleType(CanTupleType type) {
 clang::CanQualType GenClangType::visitProtocolType(CanProtocolType type) {
   auto proto = type->getDecl();
 
-  // AnyObject -> id.
-  if (proto->isSpecificProtocol(KnownProtocolKind::AnyObject))
-    return getClangIdType(getClangASTContext());
-
   // Single protocol -> id<Proto>
   if (proto->isObjC()) {
     auto &clangCtx = getClangASTContext();
@@ -605,6 +601,10 @@ clang::CanQualType GenClangType::visitProtocolCompositionType(
   SmallVector<const clang::ObjCProtocolDecl *, 4> Protocols;
   auto layout = type.getExistentialLayout();
   assert(layout.isObjC() && "Cannot represent opaque existential in Clang");
+
+  // AnyObject -> id.
+  if (layout.isAnyObject())
+    return getClangIdType(getClangASTContext());
 
   auto superclassTy = clangCtx.ObjCBuiltinIdTy;
   if (layout.superclass) {

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -1123,10 +1123,6 @@ namespace {
       for (ProtocolDecl *p : theProtocol->getInheritedProtocols()) {
         if (!p->isObjC())
           continue;
-        // Don't emit the magic AnyObject conformance.
-        if (auto known = p->getKnownProtocolKind())
-          if (*known == KnownProtocolKind::AnyObject)
-            continue;
         Protocols.push_back(p);
       }
 
@@ -1146,11 +1142,6 @@ namespace {
       }
 
       for (ProtocolDecl *proto : protocols) {
-        // Don't emit the magic AnyObject conformance.
-        if (auto known = proto->getKnownProtocolKind())
-          if (*known == KnownProtocolKind::AnyObject)
-            continue;
-
         Protocols.push_back(proto);
       }
     }

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -740,11 +740,6 @@ hasExplicitProtocolConformance(NominalTypeDecl *decl) {
     if (P->isObjC())
       continue;
 
-    // neither does AnyObject
-    if (P->getKnownProtocolKind().hasValue() &&
-        *P->getKnownProtocolKind() == KnownProtocolKind::AnyObject)
-      continue;
-
     return true;
   }
 

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -5495,8 +5495,6 @@ SpecialProtocol irgen::getSpecialProtocolID(ProtocolDecl *P) {
   if (!known)
     return SpecialProtocol::None;
   switch (*known) {
-  case KnownProtocolKind::AnyObject:
-    return SpecialProtocol::AnyObject;
   case KnownProtocolKind::Error:
     return SpecialProtocol::Error;
     

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -961,11 +961,6 @@ void IRGenModule::emitFieldMetadataRecord(const NominalTypeDecl *Decl) {
   FieldTypeMetadataBuilder builder(*this, Decl);
   builder.emit();
 
-  // So that -parse-stdlib tests don't need to define an AnyObject
-  // protocol (which will go away one day anyway).
-  if (!Context.getProtocol(KnownProtocolKind::AnyObject))
-    return;
-
   // If this is a class declaration with a superclass, record the
   // superclass as a special associated type named 'super' on the
   // 'AnyObject' protocol.

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4919,9 +4919,10 @@ ParserResult<EnumDecl> Parser::parseDeclEnum(ParseDeclOptions Flags,
   setLocalDiscriminator(ED);
   ED->getAttrs() = Attributes;
 
+  ContextChange CC(*this, ED);
+
   // Parse optional inheritance clause within the context of the enum.
   if (Tok.is(tok::colon)) {
-    ContextChange CC(*this, ED);
     SmallVector<TypeLoc, 2> Inherited;
     Status |= parseInheritance(Inherited, /*classRequirementLoc=*/nullptr);
     ED->setInherited(Context.AllocateCopy(Inherited));
@@ -4943,7 +4944,6 @@ ParserResult<EnumDecl> Parser::parseDeclEnum(ParseDeclOptions Flags,
     RBLoc = LBLoc;
     Status.setIsParseError();
   } else {
-    ContextChange CC(*this, ED);
     Scope S(this, ScopeKind::ClassBody);
     ParseDeclOptions Options(PD_HasContainerType | PD_AllowEnumElement | PD_InEnum);
     if (parseDeclList(LBLoc, RBLoc, diag::expected_rbrace_enum,
@@ -5176,9 +5176,10 @@ ParserResult<StructDecl> Parser::parseDeclStruct(ParseDeclOptions Flags,
   setLocalDiscriminator(SD);
   SD->getAttrs() = Attributes;
 
+  ContextChange CC(*this, SD);
+
   // Parse optional inheritance clause within the context of the struct.
   if (Tok.is(tok::colon)) {
-    ContextChange CC(*this, SD);
     SmallVector<TypeLoc, 2> Inherited;
     Status |= parseInheritance(Inherited, /*classRequirementLoc=*/nullptr);
     SD->setInherited(Context.AllocateCopy(Inherited));
@@ -5202,7 +5203,6 @@ ParserResult<StructDecl> Parser::parseDeclStruct(ParseDeclOptions Flags,
     Status.setIsParseError();
   } else {
     // Parse the body.
-    ContextChange CC(*this, SD);
     Scope S(this, ScopeKind::StructBody);
     ParseDeclOptions Options(PD_HasContainerType | PD_InStruct);
     if (parseDeclList(LBLoc, RBLoc, diag::expected_rbrace_struct,
@@ -5255,13 +5255,12 @@ ParserResult<ClassDecl> Parser::parseDeclClass(SourceLoc ClassLoc,
   ClassDecl *CD = new (Context) ClassDecl(ClassLoc, ClassName, ClassNameLoc,
                                           { }, GenericParams, CurDeclContext);
   setLocalDiscriminator(CD);
-
-  // Attach attributes.
   CD->getAttrs() = Attributes;
+
+  ContextChange CC(*this, CD);
 
   // Parse optional inheritance clause within the context of the class.
   if (Tok.is(tok::colon)) {
-    ContextChange CC(*this, CD);
     SmallVector<TypeLoc, 2> Inherited;
     Status |= parseInheritance(Inherited, /*classRequirementLoc=*/nullptr);
     CD->setInherited(Context.AllocateCopy(Inherited));
@@ -5284,7 +5283,6 @@ ParserResult<ClassDecl> Parser::parseDeclClass(SourceLoc ClassLoc,
     Status.setIsParseError();
   } else {
     // Parse the body.
-    ContextChange CC(*this, CD);
     Scope S(this, ScopeKind::ClassBody);
     ParseDeclOptions Options(PD_HasContainerType | PD_AllowDestructor |
                              PD_InClass);

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -5340,6 +5340,11 @@ parseDeclProtocol(ParseDeclOptions Flags, DeclAttributes &Attributes) {
   }
 
   DebuggerContextChange DCC (*this);
+
+  ProtocolDecl *Proto = new (Context)
+      ProtocolDecl(CurDeclContext, ProtocolLoc, NameLoc, ProtocolName,
+                   {}, nullptr);
+  ContextChange CC(*this, Proto);
   
   // Parse optional inheritance clause.
   SmallVector<TypeLoc, 4> InheritedProtocols;
@@ -5350,8 +5355,7 @@ parseDeclProtocol(ParseDeclOptions Flags, DeclAttributes &Attributes) {
     Status |= parseInheritance(InheritedProtocols, &classRequirementLoc);
   }
 
-  // Parse a 'where' clause if present. These are not supported, but we will
-  // get better QoI this way.
+  // Parse a 'where' clause if present.
   TrailingWhereClause *TrailingWhere = nullptr;
   // Parse a 'where' clause if present.
   if (Tok.is(tok::kw_where)) {
@@ -5361,9 +5365,9 @@ parseDeclProtocol(ParseDeclOptions Flags, DeclAttributes &Attributes) {
       return whereStatus;
   }
 
-  ProtocolDecl *Proto = new (Context)
-      ProtocolDecl(CurDeclContext, ProtocolLoc, NameLoc, ProtocolName,
-                   Context.AllocateCopy(InheritedProtocols), TrailingWhere);
+  Proto->setInherited(Context.AllocateCopy(InheritedProtocols));
+  Proto->setTrailingWhereClause(TrailingWhere);
+
   // No need to setLocalDiscriminator: protocols can't appear in local contexts.
 
   // If there was a 'class' requirement, mark this as a class-bounded protocol.
@@ -5372,7 +5376,6 @@ parseDeclProtocol(ParseDeclOptions Flags, DeclAttributes &Attributes) {
 
   Proto->getAttrs() = Attributes;
 
-  ContextChange CC(*this, Proto);
   Scope ProtocolBodyScope(this, ScopeKind::ProtocolBody);
 
   // Parse the body.

--- a/lib/Parse/ParseGeneric.cpp
+++ b/lib/Parse/ParseGeneric.cpp
@@ -386,11 +386,7 @@ ParserStatus Parser::parseProtocolOrAssociatedTypeWhereClause(
         TrailingWhereClause::create(Context, whereLoc, requirements);
   } else if (whereStatus.hasCodeCompletion()) {
     // FIXME: this is completely (hah) cargo culted.
-    if (CodeCompletion && firstTypeInComplete) {
-      CodeCompletion->completeGenericParams(nullptr);
-    } else {
-      return makeParserCodeCompletionStatus();
-    }
+    return makeParserCodeCompletionStatus();
   }
 
   return ParserStatus();

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -215,19 +215,13 @@ public:
 private:
   /// Prints a protocol adoption list: <code>&lt;NSCoding, NSCopying&gt;</code>
   ///
-  /// This method filters out non-ObjC protocols, along with the special
-  /// AnyObject protocol.
+  /// This method filters out non-ObjC protocols.
   void printProtocols(ArrayRef<ProtocolDecl *> protos) {
     SmallVector<ProtocolDecl *, 4> protosToPrint;
     std::copy_if(protos.begin(), protos.end(),
                  std::back_inserter(protosToPrint),
                  [this](const ProtocolDecl *PD) -> bool {
-      if (!shouldInclude(PD))
-        return false;
-      auto knownProtocol = PD->getKnownProtocolKind();
-      if (!knownProtocol)
-        return true;
-      return *knownProtocol != KnownProtocolKind::AnyObject;
+      return shouldInclude(PD);
     });
 
     // Drop protocols from the list that are implied by other protocols.
@@ -1901,16 +1895,7 @@ class ReferencedTypeFinder : public TypeVisitor<ReferencedTypeFinder> {
       return true;
 
     auto conformsTo = sig->getConformsTo(paramTy, mod);
-
-    if (conformsTo.size() > 1)
-      return true;
-    if (conformsTo.size() == 0)
-      return false;
-
-    const ProtocolDecl *proto = conformsTo.front();
-    if (auto knownKind = proto->getKnownProtocolKind())
-      return knownKind.getValue() != KnownProtocolKind::AnyObject;
-    return true;
+    return conformsTo.size() > 0;
   }
 
   void visitBoundGenericType(BoundGenericType *boundGeneric) {
@@ -2077,7 +2062,6 @@ public:
 
   void forwardDeclare(const ProtocolDecl *PD) {
     assert(PD->isObjC() ||
-           *PD->getKnownProtocolKind() == KnownProtocolKind::AnyObject ||
            *PD->getKnownProtocolKind() == KnownProtocolKind::Error);
     forwardDeclare(PD, [&]{
       os << "@protocol " << getNameForObjC(PD) << ";\n";
@@ -2236,10 +2220,6 @@ public:
 
   bool writeProtocol(const ProtocolDecl *PD) {
     if (addImport(PD))
-      return true;
-
-    auto knownProtocol = PD->getKnownProtocolKind();
-    if (knownProtocol && *knownProtocol == KnownProtocolKind::AnyObject)
       return true;
 
     if (seenTypes[PD].first == EmissionState::Defined)

--- a/lib/RemoteAST/RemoteAST.cpp
+++ b/lib/RemoteAST/RemoteAST.cpp
@@ -317,14 +317,15 @@ public:
     return decl->getDeclaredType();
   }
 
-  Type createProtocolCompositionType(ArrayRef<Type> protocols) {
-    for (auto protocol : protocols) {
-      if (!protocol->is<ProtocolType>())
+  Type createProtocolCompositionType(ArrayRef<Type> members,
+                                     bool hasExplicitAnyObject) {
+    for (auto member : members) {
+      if (!member->isExistentialType() &&
+          !member->getClassOrBoundGenericClass())
         return Type();
     }
-    return ProtocolCompositionType::get(Ctx, protocols,
-                                        // FIXME
-                                        /*HasExplicitAnyObject=*/false);
+
+    return ProtocolCompositionType::get(Ctx, members, hasExplicitAnyObject);
   }
 
   Type createExistentialMetatypeType(Type instance) {

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -2109,16 +2109,8 @@ void TypeConverter::popGenericContext(CanGenericSignature sig) {
 
 ProtocolDispatchStrategy
 TypeConverter::getProtocolDispatchStrategy(ProtocolDecl *P) {
-  // AnyObject has no requirements (other than the object being a class), so
-  // needs no method dispatch.
-  if (auto known = P->getKnownProtocolKind()) {
-    if (*known == KnownProtocolKind::AnyObject)
-      return ProtocolDispatchStrategy::Empty;
-  }
-  
-  // Otherwise, ObjC protocols use ObjC method dispatch, and Swift protocols
+  // ObjC protocols use ObjC method dispatch, and Swift protocols
   // use witness tables.
-  
   if (P->isObjC())
     return ProtocolDispatchStrategy::ObjC;
   

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -2770,21 +2770,9 @@ private:
           emittedArg = ManagedValue(opened, emittedArg.getCleanup());
         }
         
-        // Erase to AnyObject.
-        auto conformance = SGF.SGM.SwiftModule->lookupConformance(
-          emittedArgTy,
-          SGF.getASTContext().getProtocol(KnownProtocolKind::AnyObject),
-          nullptr);
-        assert(conformance &&
-               "no AnyObject conformance for class?!");
-        
-        ArrayRef<ProtocolConformanceRef> conformances(*conformance);
-        auto ctxConformances = SGF.getASTContext().AllocateCopy(conformances);
-        
         auto erased = SGF.B.createInitExistentialRef(loc,
                          SILType::getPrimitiveObjectType(getAnyObjectType()),
-                         emittedArgTy, emittedArg.getValue(),
-                         ctxConformances);
+                         emittedArgTy, emittedArg.getValue(), {});
         emittedArg = ManagedValue(erased, emittedArg.getCleanup());
       }
       

--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -641,21 +641,13 @@ ManagedValue SILGenFunction::emitExistentialErasure(
   
     // If the concrete value is a pseudogeneric archetype, first erase it to
     // its upper bound.
-    auto anyObjectProto = getASTContext()
-      .getProtocol(KnownProtocolKind::AnyObject);
     auto anyObjectTy = getASTContext().getAnyObjectType();
     auto eraseToAnyObject =
     [&, concreteFormalType, F](SGFContext C) -> ManagedValue {
       auto concreteValue = F(SGFContext());
-      auto anyObjectConformance = SGM.SwiftModule
-        ->lookupConformance(concreteFormalType, anyObjectProto, nullptr);
-      ProtocolConformanceRef buf[] = {
-        *anyObjectConformance,
-      };
-
       return B.createInitExistentialRef(
           loc, SILType::getPrimitiveObjectType(anyObjectTy), concreteFormalType,
-          concreteValue, getASTContext().AllocateCopy(buf));
+          concreteValue, {});
     };
     
     auto concreteTLPtr = &concreteTL;

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -478,11 +478,6 @@ void SILGenFunction::emitArtificialTopLevel(ClassDecl *mainClass) {
         ->getCanonicalType();
     CanType mainClassMetaty = CanMetatypeType::get(mainClassTy,
                                                    MetatypeRepresentation::ObjC);
-    ProtocolDecl *anyObjectProtocol =
-      ctx.getProtocol(KnownProtocolKind::AnyObject);
-    auto mainClassAnyObjectConformance = ProtocolConformanceRef(
-      *SGM.M.getSwiftModule()->lookupConformance(mainClassTy, anyObjectProtocol,
-                                                nullptr));
     CanType anyObjectTy = ctx.getAnyObjectType();
     CanType anyObjectMetaTy = CanExistentialMetatypeType::get(anyObjectTy,
                                                   MetatypeRepresentation::ObjC);
@@ -507,9 +502,7 @@ void SILGenFunction::emitArtificialTopLevel(ClassDecl *mainClass) {
     SILValue metaTy = B.createMetatype(mainClass,
                              SILType::getPrimitiveObjectType(mainClassMetaty));
     metaTy = B.createInitExistentialMetatype(mainClass, metaTy,
-                          SILType::getPrimitiveObjectType(anyObjectMetaTy),
-                          ctx.AllocateCopy(
-                            llvm::makeArrayRef(mainClassAnyObjectConformance)));
+                          SILType::getPrimitiveObjectType(anyObjectMetaTy), {});
     SILValue optName = B.createApply(mainClass,
                                NSStringFromClass,
                                NSStringFromClass->getType(),

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -2646,7 +2646,7 @@ buildThunkSignature(SILGenFunction &gen,
     genericEnv = gen.F.getGenericEnvironment();
     auto subsArray = gen.F.getForwardingSubstitutions();
     interfaceSubs = genericSig->getSubstitutionMap(subsArray);
-    contextSubs = genericEnv->getSubstitutionMap(subsArray);
+    contextSubs = interfaceSubs;
     return genericSig;
   }
 
@@ -2681,11 +2681,11 @@ buildThunkSignature(SILGenFunction &gen,
 
   // Calculate substitutions to map the caller's archetypes to the thunk's
   // archetypes.
-  if (auto *calleeGenericEnv = gen.F.getGenericEnvironment()) {
-    contextSubs = calleeGenericEnv->getSubstitutionMap(
+  if (auto calleeGenericSig = gen.F.getLoweredFunctionType()
+          ->getGenericSignature()) {
+    contextSubs = calleeGenericSig->getSubstitutionMap(
       [&](SubstitutableType *type) -> Type {
-        auto depTy = calleeGenericEnv->mapTypeOutOfContext(type);
-        return genericEnv->mapTypeIntoContext(depTy);
+        return genericEnv->mapTypeIntoContext(type);
       },
       MakeAbstractConformanceForGenericType());
   }

--- a/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
+++ b/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
@@ -194,7 +194,8 @@ static bool calleeHasPartialApplyWithOpenedExistentials(FullApplySite AI) {
   if (HasNoOpenedExistentials)
     return false;
 
-  auto SubsMap = Callee->getGenericEnvironment()->getSubstitutionMap(Subs);
+  auto SubsMap = Callee->getLoweredFunctionType()
+    ->getGenericSignature()->getSubstitutionMap(Subs);
 
   for (auto &BB : *Callee) {
     for (auto &I : BB) {
@@ -355,7 +356,8 @@ bool SILPerformanceInliner::isProfitableToInline(FullApplySite AI,
 
   SubstitutionMap CalleeSubstMap;
   if (IsGeneric) {
-    CalleeSubstMap = Callee->getGenericEnvironment()
+    CalleeSubstMap = Callee->getLoweredFunctionType()
+      ->getGenericSignature()
       ->getSubstitutionMap(AI.getSubstitutions());
   }
 

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -4287,9 +4287,6 @@ bool FailureDiagnosis::diagnoseContextualConversionError() {
     tryRawRepresentableFixIts(diag, CS, exprType, contextualType,
                               KnownProtocolKind::ExpressibleByStringLiteral,
                               expr) ||
-    tryRawRepresentableFixIts(diag, CS, exprType, contextualType,
-                              KnownProtocolKind::AnyObject,
-                              expr) ||
     tryIntegerCastFixIts(diag, CS, exprType, contextualType, expr) ||
     addTypeCoerceFixit(diag, CS, exprType, contextualType, expr);
     break;

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -848,6 +848,9 @@ static PotentialBindings getPotentialBindings(ConstraintSystem &cs,
       result.InvolvesTypeVariables = true;
       continue;
 
+    case ConstraintKind::Layout:
+      continue;
+
     case ConstraintKind::ConformsTo:
     case ConstraintKind::SelfObjectOfProtocol:
       // Swift 3 allowed the use of default types for normal conformances

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -1489,13 +1489,13 @@ bool TypeChecker::getDefaultGenericArgumentsString(
       genericParamText << "<#" << genericParam->getName() << ": ";
       superclass.print(genericParamText);
       for (const ProtocolDecl *proto : protocols) {
-        if (proto->isSpecificProtocol(KnownProtocolKind::AnyObject))
-          continue;
         genericParamText << " & " << proto->getName();
       }
       genericParamText << "#>";
       return;
     }
+
+    // FIXME FIXME FIXME requiresClass()!
 
     if (protocols.empty()) {
       genericParamText << Context.Id_Any;
@@ -1503,8 +1503,7 @@ bool TypeChecker::getDefaultGenericArgumentsString(
     }
 
     if (protocols.size() == 1 &&
-        (protocols.front()->isObjC() ||
-         protocols.front()->isSpecificProtocol(KnownProtocolKind::AnyObject))) {
+        protocols.front()->isObjC()) {
       genericParamText << protocols.front()->getName();
       return;
     }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -7655,15 +7655,6 @@ void TypeChecker::validateExtension(ExtensionDecl *ext) {
 
     ext->getExtendedTypeLoc().setType(extendedType);
     ext->setGenericEnvironment(env);
-
-    // Speculatively ban extension of AnyObject; it won't be a
-    // protocol forever, and we don't want to allow code that we know
-    // we'll break later.
-    if (proto->getDecl()->isSpecificProtocol(
-          KnownProtocolKind::AnyObject)) {
-      diagnose(ext, diag::extension_anyobject)
-        .highlight(ext->getExtendedTypeLoc().getSourceRange());
-    }
     return;
   }
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1984,8 +1984,7 @@ namespace {
     }
 
     // Foreign classes cannot conform to objc protocols.
-    if (Proto->isObjC() &&
-        !Proto->isSpecificProtocol(KnownProtocolKind::AnyObject)) {
+    if (Proto->isObjC()) {
       if (auto clas = canT->getClassOrBoundGenericClass()) {
         Optional<decltype(diag::cf_class_cannot_conform_to_objc_protocol)>
         diagKind;
@@ -5184,16 +5183,7 @@ Optional<ProtocolConformanceRef> TypeChecker::containsProtocol(
   if (T->isExistentialType()) {
     auto layout = T->getExistentialLayout();
 
-    // First, any class-constrained existential semantically contains
-    // AnyObject.
-    //
-    // FIXME: This check is moving elsewhere soon.
-    if (layout.requiresClass &&
-        Proto->isSpecificProtocol(KnownProtocolKind::AnyObject)) {
-      return ProtocolConformanceRef(Proto);
-    }
-
-    // Next, if we have a superclass constraint, the class may conform
+    // First, if we have a superclass constraint, the class may conform
     // concretely.
     if (layout.superclass) {
       if (auto result = conformsToProtocol(layout.superclass, Proto,
@@ -5202,7 +5192,7 @@ Optional<ProtocolConformanceRef> TypeChecker::containsProtocol(
       }
     }
 
-    // Finally, check if the existential contains the protocol in question.
+    // Next, check if the existential contains the protocol in question.
     for (auto P : layout.getProtocols()) {
       auto *PD = P->getDecl();
       // If we found the protocol we're looking for, return an abstract

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1268,7 +1268,7 @@ resolveTopLevelIdentTypeComponent(TypeChecker &TC, DeclContext *DC,
     if (options & TR_NonEnumInheritanceClauseOuterLayer) {
       auto protocolOrClass =
           hasError ? (isa<ProtocolDecl>(typeDecl) || isa<ClassDecl>(typeDecl))
-                   : (type->is<ProtocolType>() || type->is<ClassType>());
+                   : (type->isExistentialType() || type->is<ClassType>());
       if (!protocolOrClass) {
         auto diagnosedType = hasError ? typeDecl->getDeclaredInterfaceType() : type;
         if (diagnosedType && /*FIXME:*/!hasError) {
@@ -1530,7 +1530,7 @@ static Type resolveNestedIdentTypeComponent(
 
   if (options & TR_NonEnumInheritanceClauseOuterLayer) {
     auto protocolOrClass =
-        memberType->is<ProtocolType>() || memberType->is<ClassType>();
+        memberType->isExistentialType() || memberType->is<ClassType>();
     if (!protocolOrClass) {
       TC.diagnose(comp->getIdLoc(),
                   diag::inheritance_from_non_protocol_or_class, memberType);

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -500,6 +500,9 @@ Type TypeChecker::resolveTypeInContext(
 
   // If we found a generic parameter, map to the archetype if there is one.
   if (auto genericParam = dyn_cast<GenericTypeParamDecl>(typeDecl)) {
+    if (genericParam->getDepth() == GenericTypeParamDecl::InvalidDepth)
+      return ErrorType::get(Context);
+
     return resolver->resolveGenericTypeParamType(
         genericParam->getDeclaredInterfaceType()
             ->castTo<GenericTypeParamType>());

--- a/stdlib/public/Reflection/TypeRef.cpp
+++ b/stdlib/public/Reflection/TypeRef.cpp
@@ -140,8 +140,10 @@ public:
 
   void visitProtocolCompositionTypeRef(const ProtocolCompositionTypeRef *PC) {
     printHeader("protocol_composition");
-    for (auto protocol : PC->getProtocols())
-      printRec(protocol);
+    if (PC->hasExplicitAnyObject())
+      OS << " any_object";
+    for (auto member : PC->getMembers())
+      printRec(member);
     OS << ')';
   }
 
@@ -266,8 +268,8 @@ struct TypeRefIsConcrete
 
   bool
   visitProtocolCompositionTypeRef(const ProtocolCompositionTypeRef *PC) {
-    for (auto Protocol : PC->getProtocols())
-      if (!visit(Protocol))
+    for (auto Member : PC->getMembers())
+      if (!visit(Member))
         return false;
     return true;
   }

--- a/stdlib/public/core/Policy.swift
+++ b/stdlib/public/core/Policy.swift
@@ -250,22 +250,12 @@ public typealias _MaxBuiltinFloatType = Builtin.FPIEEE64
 ///     // Prints "The value of 'obj' is 100"
 ///
 /// - SeeAlso: `AnyClass`
-@objc
-public protocol AnyObject : class {}
 #else
 /// The protocol to which all classes implicitly conform.
 ///
 /// - SeeAlso: `AnyClass`
-public protocol AnyObject : class {}
 #endif
-// Implementation note: the `AnyObject` protocol *must* not have any method or
-// property requirements.
-
-// FIXME: AnyObject should have an alternate version for non-objc without
-// the @objc attribute, but AnyObject needs to be not be an address-only
-// type to be able to be the target of castToNativeObject and an empty
-// non-objc protocol appears not to be. There needs to be another way to make
-// this the right kind of object.
+public typealias AnyObject = Builtin.AnyObject
 
 /// The protocol to which all class types implicitly conform.
 ///

--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -313,38 +313,6 @@ static bool _conformsToProtocol(const OpaqueValue *value,
                                 const Metadata *type,
                                 const ProtocolDescriptor *protocol,
                                 const WitnessTable **conformance) {
-  // Handle AnyObject directly.
-  if (protocol->Flags.getSpecialProtocol() == SpecialProtocol::AnyObject) {
-    switch (type->getKind()) {
-    case MetadataKind::Class:
-    case MetadataKind::ObjCClassWrapper:
-    case MetadataKind::ForeignClass:
-      // Classes conform to AnyObject.
-      return true;
-
-    case MetadataKind::Existential: {
-      auto sourceExistential = cast<ExistentialTypeMetadata>(type);
-      // The existential conforms to AnyObject if it's class-constrained.
-      // FIXME: It also must not carry witness tables.
-      return sourceExistential->isClassBounded();
-    }
-      
-    case MetadataKind::ExistentialMetatype:
-    case MetadataKind::Metatype:
-    case MetadataKind::Function:
-    case MetadataKind::HeapLocalVariable:
-    case MetadataKind::HeapGenericLocalVariable:
-    case MetadataKind::ErrorObject:
-    case MetadataKind::Enum:
-    case MetadataKind::Optional:
-    case MetadataKind::Opaque:
-    case MetadataKind::Struct:
-    case MetadataKind::Tuple:
-      return false;
-    }
-    _failCorruptType(type);
-  }
-
   // Look up the witness table for protocols that need them.
   if (protocol->Flags.needsWitnessTable()) {
     auto witness = swift_conformsToProtocol(type, protocol);
@@ -448,15 +416,7 @@ static void _maybeDeallocateOpaqueExistential(OpaqueValue *srcExistential,
 static bool
 isAnyObjectExistentialType(const ExistentialTypeMetadata *targetType) {
   unsigned numProtos =  targetType->Protocols.NumProtocols;
-  if (numProtos != 1)
-    return false;
-  const ProtocolDescriptor *protocol = targetType->Protocols[0];
-  bool isAnyObjectProtocol =
-      protocol->Flags.getSpecialProtocol() == SpecialProtocol::AnyObject;
-  // Assert that AnyObject does not need any witness tables. We rely on this.
-  assert(!isAnyObjectProtocol || !protocol->Flags.needsWitnessTable() &&
-         "AnyObject should not require witness tables");
-  return isAnyObjectProtocol;
+  return numProtos == 0 && targetType->isClassBounded();
 }
 
 /// Given a possibly-existential value, find its dynamic type and the
@@ -1062,10 +1022,6 @@ _dynamicCastUnknownClassToExistential(const void *object,
       return nullptr;
     case ProtocolDispatchStrategy::ObjC:
 #if SWIFT_OBJC_INTEROP
-      // All classes conform to AnyObject.
-      if (protocol->Flags.getSpecialProtocol() == SpecialProtocol::AnyObject)
-        break;
-
       if (!objectConformsToObjCProtocol(object, protocol))
         return nullptr;
       break;
@@ -1073,13 +1029,6 @@ _dynamicCastUnknownClassToExistential(const void *object,
       assert(false && "ObjC interop disabled?!");
       return nullptr;
 #endif
-    case ProtocolDispatchStrategy::Empty:
-      // The only non-@objc, non-witness-table-requiring protocol should be
-      // AnyObject for now.
-      assert(protocol->Flags.getSpecialProtocol() == SpecialProtocol::AnyObject
-             && "swift protocols besides AnyObject should always require a "
-                "witness table");
-      break;
     }
   }
   
@@ -2203,9 +2152,7 @@ static bool tryDynamicCastBoxedSwiftValue(OpaqueValue *dest,
   // Swift type should be AnyObject or a class type.
   if (!srcType->isAnyClass()) {
     auto existential = dyn_cast<ExistentialTypeMetadata>(srcType);
-    if (!existential ||
-        existential->Flags.getSpecialProtocol()
-          != SpecialProtocol::AnyObject)
+    if (!existential || isAnyObjectExistentialType(existential))
       return false;
   }
   
@@ -2556,8 +2503,7 @@ bool swift::swift_dynamicCast(OpaqueValue *dest, OpaqueValue *src,
     if (auto srcExistentialType = dyn_cast<ExistentialTypeMetadata>(srcType)) {
 #if SWIFT_OBJC_INTEROP
       // If coming from AnyObject, we may want to bridge.
-      if (srcExistentialType->Flags.getSpecialProtocol()
-            == SpecialProtocol::AnyObject) {
+      if (isAnyObjectExistentialType(srcExistentialType)) {
         if (auto targetBridgeWitness = findBridgeWitness(targetType)) {
           return _dynamicCastClassToValueViaObjCBridgeable(dest, src, srcType,
                                                            targetType,

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -2282,7 +2282,6 @@ getExistentialValueWitnesses(ProtocolClassConstraint classConstraint,
 #endif
       
   // Other existentials use standard representation.
-  case SpecialProtocol::AnyObject:
   case SpecialProtocol::None:
     break;
   }
@@ -2305,7 +2304,6 @@ ExistentialTypeMetadata::getRepresentation() const {
   switch (Flags.getSpecialProtocol()) {
   case SpecialProtocol::Error:
     return ExistentialTypeRepresentation::Error;
-  case SpecialProtocol::AnyObject:
   case SpecialProtocol::None:
     break;
   }

--- a/stdlib/public/runtime/SwiftValue.mm
+++ b/stdlib/public/runtime/SwiftValue.mm
@@ -223,19 +223,7 @@ swift::findSwiftValueConformances(const ProtocolDescriptorList &protocols,
   for (size_t i = 0, e = protocols.NumProtocols; i != e; ++i) {
     auto protocol = protocols[i];
 
-    // _SwiftValue does conform to AnyObject.
-    switch (protocol->Flags.getSpecialProtocol()) {
-    case SpecialProtocol::AnyObject:
-      continue;
-
-    case SpecialProtocol::Error:
-      return false;
-
-    case SpecialProtocol::None:
-      break;
-    }
-
-    // Otherwise, it only conforms to ObjC protocols.  We specifically
+    // _SwiftValue only conforms to ObjC protocols.  We specifically
     // don't want to say that _SwiftValue conforms to the Swift protocols
     // that NSObject conforms to because that would create a situation
     // where arguably an arbitrary type would conform to those protocols

--- a/test/IDE/complete_enum_elements.swift
+++ b/test/IDE/complete_enum_elements.swift
@@ -197,9 +197,9 @@ enum BazEnum<T> {
 // BAZ_T_ENUM_NO_DOT: Begin completions
 // BAZ_T_ENUM_NO_DOT-NEXT: Decl[EnumElement]/CurrNominal:    .Baz1[#BazEnum<T>#]{{; name=.+$}}
 // BAZ_T_ENUM_NO_DOT-NEXT: Decl[EnumElement]/CurrNominal:    .Baz2({#T#})[#(T) -> BazEnum<T>#]{{; name=.+$}}
-// BAZ_T_ENUM_NO_DOT-NEXT: Decl[InstanceMethod]/CurrNominal: .bazInstanceFunc({#self: &BazEnum<T>#})[#() -> Void#]{{; name=.+$}}
+// BAZ_T_ENUM_NO_DOT-NEXT: Decl[InstanceMethod]/CurrNominal: .bazInstanceFunc({#self: &BazEnum<τ_0_0>#})[#() -> Void#]{{; name=.+$}}
 // BAZ_T_ENUM_NO_DOT-NEXT: Decl[StaticVar]/CurrNominal:      .staticVar[#Int#]{{; name=.+$}}
-// BAZ_T_ENUM_NO_DOT-NEXT: Decl[StaticVar]/CurrNominal:      .staticVarT[#T#]{{; name=.+$}}
+// BAZ_T_ENUM_NO_DOT-NEXT: Decl[StaticVar]/CurrNominal:      .staticVarT[#τ_0_0#]{{; name=.+$}}
 // BAZ_T_ENUM_NO_DOT-NEXT: Decl[StaticMethod]/CurrNominal:   .bazStaticFunc()[#Void#]{{; name=.+$}}
 // BAZ_T_ENUM_NO_DOT-NEXT: Decl[InfixOperatorFunction]/OtherModule[Swift]: != {#Any.Type?#}[#Bool#]
 // BAZ_T_ENUM_NO_DOT-NEXT: End completions
@@ -216,9 +216,9 @@ enum BazEnum<T> {
 // BAZ_T_ENUM_DOT: Begin completions, 6 items
 // BAZ_T_ENUM_DOT-NEXT: Decl[EnumElement]/CurrNominal:    Baz1[#BazEnum<T>#]{{; name=.+$}}
 // BAZ_T_ENUM_DOT-NEXT: Decl[EnumElement]/CurrNominal:    Baz2({#T#})[#(T) -> BazEnum<T>#]{{; name=.+$}}
-// BAZ_T_ENUM_DOT-NEXT: Decl[InstanceMethod]/CurrNominal: bazInstanceFunc({#self: &BazEnum<T>#})[#() -> Void#]{{; name=.+$}}
+// BAZ_T_ENUM_DOT-NEXT: Decl[InstanceMethod]/CurrNominal: bazInstanceFunc({#self: &BazEnum<τ_0_0>#})[#() -> Void#]{{; name=.+$}}
 // BAZ_T_ENUM_DOT-NEXT: Decl[StaticVar]/CurrNominal:      staticVar[#Int#]{{; name=.+$}}
-// BAZ_T_ENUM_DOT-NEXT: Decl[StaticVar]/CurrNominal:      staticVarT[#T#]{{; name=.+$}}
+// BAZ_T_ENUM_DOT-NEXT: Decl[StaticVar]/CurrNominal:      staticVarT[#τ_0_0#]{{; name=.+$}}
 // BAZ_T_ENUM_DOT-NEXT: Decl[StaticMethod]/CurrNominal:   bazStaticFunc()[#Void#]{{; name=.+$}}
 // BAZ_T_ENUM_DOT-NEXT: End completions
 

--- a/test/IDE/complete_from_swift_module.swift
+++ b/test/IDE/complete_from_swift_module.swift
@@ -63,8 +63,8 @@ func testCompleteModuleQualified3() {
   foo_swift_module.BarGenericSwiftStruct1#^MODULE_QUALIFIED_3^#
 }
 // MODULE_QUALIFIED_3: Begin completions
-// MODULE_QUALIFIED_3-NEXT: Decl[Constructor]/CurrNominal:    ({#t: T#})[#BarGenericSwiftStruct1<T>#]
-// MODULE_QUALIFIED_3-NEXT: Decl[InstanceMethod]/CurrNominal: .bar1InstanceFunc({#self: BarGenericSwiftStruct1<T>#})[#() -> Void#]{{; name=.+$}}
+// MODULE_QUALIFIED_3-NEXT: Decl[Constructor]/CurrNominal:    ({#t: τ_0_0#})[#BarGenericSwiftStruct1<τ_0_0>#]
+// MODULE_QUALIFIED_3-NEXT: Decl[InstanceMethod]/CurrNominal: .bar1InstanceFunc({#self: BarGenericSwiftStruct1<τ_0_0>#})[#() -> Void#]{{; name=.+$}}
 // MODULE_QUALIFIED_3: Decl[InfixOperatorFunction]/OtherModule[Swift]: != {#Any.Type?#}[#Bool#];
 // MODULE_QUALIFIED_3: End completions
 
@@ -72,8 +72,8 @@ func testCompleteModuleQualified4() {
   foo_swift_module.BarGenericSwiftStruct2#^MODULE_QUALIFIED_4^#
 }
 // MODULE_QUALIFIED_4: Begin completions
-// MODULE_QUALIFIED_4-NEXT: Decl[Constructor]/CurrNominal:    ({#t: BarProtocol#}, {#u: U#})[#BarGenericSwiftStruct2<BarProtocol, U>#]
-// MODULE_QUALIFIED_4-NEXT: Decl[InstanceMethod]/CurrNominal: .bar2InstanceFunc({#self: BarGenericSwiftStruct2<BarProtocol, U>#})[#() -> Void#]
+// MODULE_QUALIFIED_4-NEXT: Decl[Constructor]/CurrNominal:    ({#t: BarProtocol#}, {#u: τ_0_1#})[#BarGenericSwiftStruct2<BarProtocol, τ_0_1>#]
+// MODULE_QUALIFIED_4-NEXT: Decl[InstanceMethod]/CurrNominal: .bar2InstanceFunc({#self: BarGenericSwiftStruct2<BarProtocol, τ_0_1>#})[#() -> Void#]
 // MODULE_QUALIFIED_4: Decl[InfixOperatorFunction]/OtherModule[Swift]: != {#Any.Type?#}[#Bool#];
 // MODULE_QUALIFIED_4-NEXT: End completions
 

--- a/test/IDE/complete_value_expr.swift
+++ b/test/IDE/complete_value_expr.swift
@@ -1266,8 +1266,8 @@ func testTypeCheckWithUnsolvedVariables1() {
 }
 // TC_UNSOLVED_VARIABLES_1: Begin completions
 // TC_UNSOLVED_VARIABLES_1-NEXT: Decl[InstanceVar]/CurrNominal: count[#Int#]{{; name=.+$}}
-// TC_UNSOLVED_VARIABLES_1-NEXT: Decl[InstanceMethod]/CurrNominal: addString({#(s): String#})[#BuilderStyle<T>#]{{; name=.+$}}
-// TC_UNSOLVED_VARIABLES_1-NEXT: Decl[InstanceMethod]/CurrNominal: add({#(t): T#})[#BuilderStyle<T>#]{{; name=.+$}}
+// TC_UNSOLVED_VARIABLES_1-NEXT: Decl[InstanceMethod]/CurrNominal: addString({#(s): String#})[#BuilderStyle<τ_0_0>#]{{; name=.+$}}
+// TC_UNSOLVED_VARIABLES_1-NEXT: Decl[InstanceMethod]/CurrNominal: add({#(t): τ_0_0#})[#BuilderStyle<τ_0_0>#]{{; name=.+$}}
 // TC_UNSOLVED_VARIABLES_1-NEXT: Decl[InstanceMethod]/CurrNominal: get()[#Int#]{{; name=.+$}}
 // TC_UNSOLVED_VARIABLES_1-NEXT: End completions
 
@@ -1276,8 +1276,8 @@ func testTypeCheckWithUnsolvedVariables2() {
 }
 // TC_UNSOLVED_VARIABLES_2: Begin completions
 // TC_UNSOLVED_VARIABLES_2-NEXT: Decl[InstanceVar]/CurrNominal:    count[#Int#]{{; name=.+$}}
-// TC_UNSOLVED_VARIABLES_2-NEXT: Decl[InstanceMethod]/CurrNominal: addString({#(s): String#})[#BuilderStyle<T>#]{{; name=.+$}}
-// TC_UNSOLVED_VARIABLES_2-NEXT: Decl[InstanceMethod]/CurrNominal: add({#(t): T#})[#BuilderStyle<T>#]{{; name=.+$}}
+// TC_UNSOLVED_VARIABLES_2-NEXT: Decl[InstanceMethod]/CurrNominal: addString({#(s): String#})[#BuilderStyle<τ_0_0>#]{{; name=.+$}}
+// TC_UNSOLVED_VARIABLES_2-NEXT: Decl[InstanceMethod]/CurrNominal: add({#(t): τ_0_0#})[#BuilderStyle<τ_0_0>#]{{; name=.+$}}
 // TC_UNSOLVED_VARIABLES_2-NEXT: Decl[InstanceMethod]/CurrNominal: get()[#Int#]{{; name=.+$}}
 // TC_UNSOLVED_VARIABLES_2-NEXT: End completions
 

--- a/unittests/Reflection/TypeRef.cpp
+++ b/unittests/Reflection/TypeRef.cpp
@@ -166,10 +166,10 @@ TEST(TypeRefTest, UniqueProtocolTypeRef) {
   EXPECT_NE(P2, P3);
   EXPECT_NE(P3, P4);
 
-  auto PC1 = Builder.createProtocolCompositionType({P1, P2});
-  auto PC2 = Builder.createProtocolCompositionType({P1, P2});
-  auto PC3 = Builder.createProtocolCompositionType({P1, P2, P2});
-  auto Any = Builder.createProtocolCompositionType({});
+  auto PC1 = Builder.createProtocolCompositionType({P1, P2}, false);
+  auto PC2 = Builder.createProtocolCompositionType({P1, P2}, false);
+  auto PC3 = Builder.createProtocolCompositionType({P1, P2, P2}, false);
+  auto Any = Builder.createProtocolCompositionType({}, false);
 
   EXPECT_EQ(PC1, PC2);
   EXPECT_NE(PC2, PC3);

--- a/unittests/runtime/Metadata.cpp
+++ b/unittests/runtime/Metadata.cpp
@@ -402,6 +402,8 @@ TEST(MetadataTest, getExistentialMetadata) {
       EXPECT_EQ(0U, any->Protocols.NumProtocols);
       EXPECT_EQ(SpecialProtocol::None,
                 any->Flags.getSpecialProtocol());
+      EXPECT_EQ(nullptr,
+                any->getSuperclassConstraint());
       return any;
     });
 
@@ -420,6 +422,8 @@ TEST(MetadataTest, getExistentialMetadata) {
       EXPECT_EQ(&ProtocolA, a->Protocols[0]);
       EXPECT_EQ(SpecialProtocol::None,
                 a->Flags.getSpecialProtocol());
+      EXPECT_EQ(nullptr,
+                a->getSuperclassConstraint());
       return a;
     });
 
@@ -439,6 +443,8 @@ TEST(MetadataTest, getExistentialMetadata) {
       EXPECT_EQ(&ProtocolB, b->Protocols[0]);
       EXPECT_EQ(SpecialProtocol::None,
                 b->Flags.getSpecialProtocol());
+      EXPECT_EQ(nullptr,
+                b->getSuperclassConstraint());
       return b;
     });
 
@@ -472,8 +478,8 @@ TEST(MetadataTest, getExistentialMetadata) {
         || (ab->Protocols[0]==&ProtocolB && ab->Protocols[1]==&ProtocolA));
       EXPECT_EQ(SpecialProtocol::None,
                 ab->Flags.getSpecialProtocol());
-      EXPECT_EQ(SpecialProtocol::None,
-                ba->Flags.getSpecialProtocol());
+      EXPECT_EQ(nullptr,
+                ab->getSuperclassConstraint());
       return ab;
     });
 
@@ -494,6 +500,8 @@ TEST(MetadataTest, getExistentialMetadata) {
       EXPECT_EQ(SpecialProtocol::None,
                 classConstrained->Flags.getSpecialProtocol());
       EXPECT_EQ(&ProtocolClassConstrained, classConstrained->Protocols[0]);
+      EXPECT_EQ(nullptr,
+                classConstrained->getSuperclassConstraint());
       return classConstrained;
     });
 
@@ -514,6 +522,8 @@ TEST(MetadataTest, getExistentialMetadata) {
       EXPECT_EQ(SpecialProtocol::None,
                 noWitnessTable->Flags.getSpecialProtocol());
       EXPECT_EQ(&ProtocolNoWitnessTable, noWitnessTable->Protocols[0]);
+      EXPECT_EQ(nullptr,
+                noWitnessTable->getSuperclassConstraint());
       return noWitnessTable;
     });
 
@@ -536,6 +546,8 @@ TEST(MetadataTest, getExistentialMetadata) {
       EXPECT_EQ(3U, mixedWitnessTable->Protocols.NumProtocols);
       EXPECT_EQ(SpecialProtocol::None,
                 mixedWitnessTable->Flags.getSpecialProtocol());
+      EXPECT_EQ(nullptr,
+                mixedWitnessTable->getSuperclassConstraint());
       return mixedWitnessTable;
     });
   
@@ -561,6 +573,8 @@ TEST(MetadataTest, getExistentialMetadata) {
                 special->Flags.getSpecialProtocol());
       EXPECT_EQ(ExpectedErrorValueWitnesses,
                 special->getValueWitnesses());
+      EXPECT_EQ(nullptr,
+                special->getSuperclassConstraint());
       return special;
     });
 
@@ -582,6 +596,8 @@ TEST(MetadataTest, getExistentialMetadata) {
                 special->Flags.getSpecialProtocol());
       EXPECT_NE(ExpectedErrorValueWitnesses,
                 special->getValueWitnesses());
+      EXPECT_EQ(nullptr,
+                special->getSuperclassConstraint());
       return special;
     });
 }
@@ -710,6 +726,8 @@ TEST(MetadataTest, getExistentialTypeMetadata_opaque) {
       EXPECT_EQ(alignof(void*), ex1->getValueWitnesses()->getAlignment());
       EXPECT_FALSE(ex1->getValueWitnesses()->isPOD());
       EXPECT_FALSE(ex1->getValueWitnesses()->isBitwiseTakable());
+      EXPECT_EQ(nullptr,
+                ex1->getSuperclassConstraint());
       return ex1;
     });
 
@@ -726,6 +744,8 @@ TEST(MetadataTest, getExistentialTypeMetadata_opaque) {
       EXPECT_EQ(alignof(void*), ex2->getValueWitnesses()->getAlignment());
       EXPECT_FALSE(ex2->getValueWitnesses()->isPOD());
       EXPECT_FALSE(ex2->getValueWitnesses()->isBitwiseTakable());
+      EXPECT_EQ(nullptr,
+                ex2->getSuperclassConstraint());
       return ex2;
     });
 
@@ -742,6 +762,8 @@ TEST(MetadataTest, getExistentialTypeMetadata_opaque) {
       EXPECT_EQ(alignof(void*), ex3->getValueWitnesses()->getAlignment());
       EXPECT_FALSE(ex3->getValueWitnesses()->isPOD());
       EXPECT_FALSE(ex3->getValueWitnesses()->isBitwiseTakable());
+      EXPECT_EQ(nullptr,
+                ex3->getSuperclassConstraint());
       return ex3;
     });
 }
@@ -760,6 +782,8 @@ TEST(MetadataTest, getExistentialTypeMetadata_class) {
       EXPECT_EQ(alignof(void*), ex1->getValueWitnesses()->getAlignment());
       EXPECT_FALSE(ex1->getValueWitnesses()->isPOD());
       EXPECT_TRUE(ex1->getValueWitnesses()->isBitwiseTakable());
+      EXPECT_EQ(nullptr,
+                ex1->getSuperclassConstraint());
       return ex1;
     });
 
@@ -776,6 +800,8 @@ TEST(MetadataTest, getExistentialTypeMetadata_class) {
       EXPECT_EQ(alignof(void*), ex2->getValueWitnesses()->getAlignment());
       EXPECT_FALSE(ex2->getValueWitnesses()->isPOD());
       EXPECT_TRUE(ex2->getValueWitnesses()->isBitwiseTakable());
+      EXPECT_EQ(nullptr,
+                ex2->getSuperclassConstraint());
       return ex2;
     });
 
@@ -792,7 +818,58 @@ TEST(MetadataTest, getExistentialTypeMetadata_class) {
       EXPECT_EQ(alignof(void*), ex3->getValueWitnesses()->getAlignment());
       EXPECT_FALSE(ex3->getValueWitnesses()->isPOD());
       EXPECT_TRUE(ex3->getValueWitnesses()->isBitwiseTakable());
+      EXPECT_EQ(nullptr,
+                ex3->getSuperclassConstraint());
       return ex3;
+    });
+}
+
+TEST(MetadataTest, getExistentialTypeMetadata_subclass) {
+  RaceTest_ExpectEqual<const ExistentialTypeMetadata *>(
+    [&]() -> const ExistentialTypeMetadata * {
+      const ProtocolDescriptor *protoList1[] = {
+        &OpaqueProto1
+      };
+      auto ex1 = swift_getExistentialTypeMetadata(ProtocolClassConstraint::Class,
+                                                  /*superclass=*/&MetadataTest2,
+                                                  1, protoList1);
+      EXPECT_EQ(MetadataKind::Existential, ex1->getKind());
+      EXPECT_EQ(2 * sizeof(void*), ex1->getValueWitnesses()->getSize());
+      EXPECT_EQ(alignof(void*), ex1->getValueWitnesses()->getAlignment());
+      EXPECT_FALSE(ex1->getValueWitnesses()->isPOD());
+      EXPECT_TRUE(ex1->getValueWitnesses()->isBitwiseTakable());
+      EXPECT_EQ(ProtocolClassConstraint::Class,
+                ex1->Flags.getClassConstraint());
+      EXPECT_EQ(1U, ex1->Protocols.NumProtocols);
+      EXPECT_EQ(&OpaqueProto1, ex1->Protocols[0]);
+      EXPECT_EQ(&MetadataTest2, ex1->getSuperclassConstraint());
+      return ex1;
+    });
+
+
+  RaceTest_ExpectEqual<const ExistentialTypeMetadata *>(
+    [&]() -> const ExistentialTypeMetadata * {
+      const ProtocolDescriptor *protoList2[] = {
+        &OpaqueProto1,
+        &ClassProto1
+      };
+      auto ex2 = swift_getExistentialTypeMetadata(ProtocolClassConstraint::Class,
+                                                  /*superclass=*/&MetadataTest2,
+                                                  2, protoList2);
+      EXPECT_EQ(MetadataKind::Existential, ex2->getKind());
+      EXPECT_EQ(3 * sizeof(void*), ex2->getValueWitnesses()->getSize());
+      EXPECT_EQ(alignof(void*), ex2->getValueWitnesses()->getAlignment());
+      EXPECT_FALSE(ex2->getValueWitnesses()->isPOD());
+      EXPECT_TRUE(ex2->getValueWitnesses()->isBitwiseTakable());
+      EXPECT_EQ(ProtocolClassConstraint::Class,
+                ex2->Flags.getClassConstraint());
+      EXPECT_EQ(2U, ex2->Protocols.NumProtocols);
+      EXPECT_TRUE((ex2->Protocols[0] == &OpaqueProto1 &&
+                   ex2->Protocols[1] == &ClassProto1) ||
+                  (ex2->Protocols[0] == &ClassProto1 &&
+                   ex2->Protocols[1] == &OpaqueProto1));
+      EXPECT_EQ(&MetadataTest2, ex2->getSuperclassConstraint());
+      return ex2;
     });
 }
 

--- a/validation-test/Evolution/test_function_change_transparent_body.swift
+++ b/validation-test/Evolution/test_function_change_transparent_body.swift
@@ -1,8 +1,5 @@
-// RUN: %target-resilience-test-wmo
+// RUN: %target-resilience-test
 // REQUIRES: executable_test
-
-// FIXME: shouldn't need -whole-module-optimization here; we need to fix the
-// frontend to merge serialized SIL functions from different translation units
 
 import StdlibUnittest
 import function_change_transparent_body


### PR DESCRIPTION
The basic idea is that AnyObject is now defined as `typealias AnyObject = Builtin.AnyObject`, and `Builtin.AnyObject` is a special `ProtocolCompositionType` with a class constraint but no fixed superclass.

Most of the PR is plumbing through this new constraint to `ProtocolExistentialType`. It is ultimately exposed as `ExistentialLayout::getLayoutConstraint()` returning a `LayoutConstraint`.

Not quite done; in particular casts need a lot of work. This is the same work as supporting casts between subclass existentials, though.