### PR TITLE
[SILGen] Disable emitAssignLValueToLValue peephole when enforcing exc…

### DIFF
--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -146,6 +146,12 @@ public:
   /// Emit checks to trap at run time when the law of exclusivity is violated.
   bool EnforceExclusivityDynamic = false;
 
+  /// Returns true when either static or dynamic exclusivity enforcement
+  /// is enabled.
+  bool isAnyExclusivityEnforcementEnabled() {
+    return EnforceExclusivityStatic || EnforceExclusivityDynamic;
+  }
+
   /// Enable the mandatory semantic arc optimizer.
   bool EnableMandatorySemanticARCOpts = false;
 

--- a/lib/SILGen/LValue.h
+++ b/lib/SILGen/LValue.h
@@ -456,6 +456,13 @@ public:
     return getTypeData().OrigFormalType;
   }
 
+  /// Returns true when the other access definitely does not begin a formal
+  /// access that would conflict with this the accesses begun by this
+  /// LValue. This is a best-effort attempt; it may return false in cases
+  /// where the two LValues do not conflict.
+  bool isObviouslyNonConflicting(const LValue &other, AccessKind selfAccess,
+                                 AccessKind otherAccess);
+
   void dump() const;
   void print(raw_ostream &OS) const;
 };

--- a/test/SILGen/access_marker_gen.swift
+++ b/test/SILGen/access_marker_gen.swift
@@ -72,3 +72,22 @@ func readGlobal() -> AnyObject? {
 // CHECK-NEXT:    [[T4:%.*]] = load [copy] [[T3]]
 // CHECK-NEXT:    end_access [[T2]]
 // CHECK-NEXT:    return [[T4]]
+
+
+public struct HasTwoStoredProperties {
+  var f: Int = 7
+  var g: Int = 9
+
+// CHECK-LABEL: sil hidden @_T017access_marker_gen22HasTwoStoredPropertiesV027noOverlapOnAssignFromPropToM0yyF : $@convention(method) (@inout HasTwoStoredProperties) -> ()
+// CHECK:       [[ACCESS1:%.*]] = begin_access [read] [unknown] [[SELF_ADDR:%.*]] : $*HasTwoStoredProperties
+// CHECK-NEXT:  [[G_ADDR:%.*]] = struct_element_addr [[ACCESS1]] : $*HasTwoStoredProperties, #HasTwoStoredProperties.g
+// CHECK-NEXT:  [[G_VAL:%.*]] = load [trivial] [[G_ADDR]] : $*Int
+// CHECK-NEXT:  end_access [[ACCESS1]] : $*HasTwoStoredProperties
+// CHECK-NEXT:  [[ACCESS2:%.*]] = begin_access [modify] [unknown] [[SELF_ADDR]] : $*HasTwoStoredProperties
+// CHECK-NEXT:  [[F_ADDR:%.*]] = struct_element_addr [[ACCESS2]] : $*HasTwoStoredProperties, #HasTwoStoredProperties.f
+// CHECK-NEXT:  assign [[G_VAL]] to [[F_ADDR]] : $*Int
+// CHECK-NEXT:  end_access [[ACCESS2]] : $*HasTwoStoredProperties
+  mutating func noOverlapOnAssignFromPropToProp() {
+    f = g
+  }
+}


### PR DESCRIPTION
…lusivity

The peephole causes the the formal access to the source and destination to
overlap. This results in unwanted exclusive access conflicts when assigning
from one struct stored property to another.

At John's suggestion I've added an isObviouslyNonConflicting() helper
method on LValue that tells when when it is safe to use the peephole
even when exclusivity enforcement enabled. For now, the helper is toothless. It
can be extended to claw back some of the peephole opportunities.