### PR TITLE
[ClangImporter] Use UnboundGenericTypes in compatibility typealiases.

### DIFF
--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -2255,6 +2255,7 @@ public:
       verifyGenericEnvironment(generic,
                                generic->getGenericSignature(),
                                generic->getGenericEnvironment());
+      verifyCheckedBase(generic);
     }
 
     void verifyChecked(NominalTypeDecl *nominal) {

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4693,18 +4693,16 @@ Decl *SwiftDeclConverter::importCompatibilityTypeAlias(
   if (!typeDecl)
     return nullptr;
 
-  // Handle generic types.
-  GenericParamList *genericParams = nullptr;
-  GenericEnvironment *genericEnv = nullptr;
-  auto underlyingType = typeDecl->getDeclaredInterfaceType();
-
-  if (auto generic = dyn_cast<GenericTypeDecl>(typeDecl)) {
-    if (generic->getGenericSignature() && !isa<ProtocolDecl>(typeDecl)) {
-      genericParams = generic->getGenericParams();
-      genericEnv = generic->getGenericEnvironment();
-
-      underlyingType = generic->mapTypeIntoContext(underlyingType);
-    }
+  // Deliberately use an UnboundGenericType to avoid having to translate over
+  // generic parameters.
+  Type underlyingType;
+  if (auto *underlyingAlias = dyn_cast<TypeAliasDecl>(typeDecl)) {
+    if (underlyingAlias->isGeneric())
+      underlyingType = underlyingAlias->getUnboundGenericType();
+    else
+      underlyingType = underlyingAlias->getDeclaredInterfaceType();
+  } else {
+    underlyingType = cast<NominalTypeDecl>(typeDecl)->getDeclaredType();
   }
 
   auto dc = Impl.importDeclContextOf(decl,
@@ -4716,9 +4714,8 @@ Decl *SwiftDeclConverter::importCompatibilityTypeAlias(
   auto alias = Impl.createDeclWithClangNode<TypeAliasDecl>(
       decl, Accessibility::Public, Impl.importSourceLoc(decl->getLocStart()),
       SourceLoc(), compatibilityName.getDeclName().getBaseName(),
-      Impl.importSourceLoc(decl->getLocation()), genericParams, dc);
+      Impl.importSourceLoc(decl->getLocation()), /*generic params*/nullptr, dc);
   alias->setUnderlyingType(underlyingType);
-  alias->setGenericEnvironment(genericEnv);
 
   // Record that this is the official version of this declaration.
   Impl.ImportedDecls[{decl->getCanonicalDecl(), getVersion()}] = alias;

--- a/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/APINotesFrameworkTest.apinotes
+++ b/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/APINotesFrameworkTest.apinotes
@@ -86,6 +86,8 @@ SwiftVersions:
             SwiftImportAsAccessors: true
       - Name: NewlyGenericSub
         SwiftImportAsNonGeneric: true
+      - Name: RenamedGeneric
+        SwiftName: OldRenamedGeneric
     Protocols:
       - Name: ProtoWithVersionedUnavailableMember
         Methods:

--- a/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/Classes.h
+++ b/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/Classes.h
@@ -5,5 +5,8 @@
 + (Element)defaultElement;
 @end
 
+@interface RenamedGeneric<Element: Base *> : Base
+@end
+
 #pragma clang assume_nonnull end
 #endif // __OBJC__

--- a/test/APINotes/versioned-objc.swift
+++ b/test/APINotes/versioned-objc.swift
@@ -23,4 +23,24 @@ func testNonGeneric() {
   // CHECK-DIAGS-4:[[@LINE-1]]:{{[0-9]+}}: error: cannot convert value of type 'Base' to specified type 'Int'
 }
 
+func testRenamedGeneric() {
+  // CHECK-DIAGS-3:[[@LINE+1]]:{{[0-9]+}}: error: 'RenamedGeneric' has been renamed to 'OldRenamedGeneric'
+  let _: OldRenamedGeneric<Base> = RenamedGeneric<Base>()
+  // FIXME-DIAGS-4:[[@LINE-1]]:{{[0-9]+}}: error: 'OldRenamedGeneric' has been renamed to 'RenamedGeneric'
+
+  // FIXME-DIAGS-3:[[@LINE+1]]:{{[0-9]+}}: error: 'RenamedGeneric' has been renamed to 'OldRenamedGeneric'
+  let _: RenamedGeneric<Base> = OldRenamedGeneric<Base>()
+  // CHECK-DIAGS-4:[[@LINE-1]]:{{[0-9]+}}: error: 'OldRenamedGeneric' has been renamed to 'RenamedGeneric'
+
+  class SwiftClass {}
+
+  // CHECK-DIAGS-3:[[@LINE+1]]:{{[0-9]+}}: error: 'OldRenamedGeneric' requires that 'SwiftClass' inherit from 'Base'
+  let _: OldRenamedGeneric<SwiftClass> = RenamedGeneric<SwiftClass>()
+  // CHECK-DIAGS-4:[[@LINE-1]]:{{[0-9]+}}: error: 'OldRenamedGeneric' requires that 'SwiftClass' inherit from 'Base'
+
+  // CHECK-DIAGS-3:[[@LINE+1]]:{{[0-9]+}}: error: 'RenamedGeneric' requires that 'SwiftClass' inherit from 'Base'
+  let _: RenamedGeneric<SwiftClass> = OldRenamedGeneric<SwiftClass>()
+  // CHECK-DIAGS-4:[[@LINE-1]]:{{[0-9]+}}: error: 'RenamedGeneric' requires that 'SwiftClass' inherit from 'Base'
+}
+
 let unrelatedDiagnostic: Int = nil

--- a/test/APINotes/versioned-objc.swift
+++ b/test/APINotes/versioned-objc.swift
@@ -26,9 +26,9 @@ func testNonGeneric() {
 func testRenamedGeneric() {
   // CHECK-DIAGS-3:[[@LINE+1]]:{{[0-9]+}}: error: 'RenamedGeneric' has been renamed to 'OldRenamedGeneric'
   let _: OldRenamedGeneric<Base> = RenamedGeneric<Base>()
-  // FIXME-DIAGS-4:[[@LINE-1]]:{{[0-9]+}}: error: 'OldRenamedGeneric' has been renamed to 'RenamedGeneric'
+  // CHECK-DIAGS-4:[[@LINE-1]]:{{[0-9]+}}: error: 'OldRenamedGeneric' has been renamed to 'RenamedGeneric'
 
-  // FIXME-DIAGS-3:[[@LINE+1]]:{{[0-9]+}}: error: 'RenamedGeneric' has been renamed to 'OldRenamedGeneric'
+  // CHECK-DIAGS-3:[[@LINE+1]]:{{[0-9]+}}: error: 'RenamedGeneric' has been renamed to 'OldRenamedGeneric'
   let _: RenamedGeneric<Base> = OldRenamedGeneric<Base>()
   // CHECK-DIAGS-4:[[@LINE-1]]:{{[0-9]+}}: error: 'OldRenamedGeneric' has been renamed to 'RenamedGeneric'
 
@@ -36,9 +36,9 @@ func testRenamedGeneric() {
 
   // CHECK-DIAGS-3:[[@LINE+1]]:{{[0-9]+}}: error: 'OldRenamedGeneric' requires that 'SwiftClass' inherit from 'Base'
   let _: OldRenamedGeneric<SwiftClass> = RenamedGeneric<SwiftClass>()
-  // CHECK-DIAGS-4:[[@LINE-1]]:{{[0-9]+}}: error: 'OldRenamedGeneric' requires that 'SwiftClass' inherit from 'Base'
+  // CHECK-DIAGS-4:[[@LINE-1]]:{{[0-9]+}}: error: 'RenamedGeneric' requires that 'SwiftClass' inherit from 'Base'
 
-  // CHECK-DIAGS-3:[[@LINE+1]]:{{[0-9]+}}: error: 'RenamedGeneric' requires that 'SwiftClass' inherit from 'Base'
+  // CHECK-DIAGS-3:[[@LINE+1]]:{{[0-9]+}}: error: 'OldRenamedGeneric' requires that 'SwiftClass' inherit from 'Base'
   let _: RenamedGeneric<SwiftClass> = OldRenamedGeneric<SwiftClass>()
   // CHECK-DIAGS-4:[[@LINE-1]]:{{[0-9]+}}: error: 'RenamedGeneric' requires that 'SwiftClass' inherit from 'Base'
 }


### PR DESCRIPTION
When a type is renamed, we leave behind a "compatibility typealias" whose underlying type uses the new name. For generic types, though, we were using the generic parameters and environment of the original type, which is completely bogus. "Fix" this by just dropping the generic part entirely and making a typealias that refers to the *unbound* generic type, as if written as `typealias OldName = NewName` instead of `typealias OldName<Element> = NewName<Element>`. The rest of the compiler can handle that fine.