### PR TITLE
Reinstate diagnostics for assignment from Int to unsigned types.

### DIFF
--- a/validation-test/stdlib/FixedPointDiagnostics.swift.gyb
+++ b/validation-test/stdlib/FixedPointDiagnostics.swift.gyb
@@ -2,13 +2,13 @@
 // RUN: %line-directive %t/main.swift -- %target-swift-frontend -typecheck -verify %t/main.swift
 
 func testUnaryMinusInUnsigned() {
-  var a: UInt8 = -(1) // expected-error {{}} expected-note * {{}} expected-warning * {{}}
+  var a: UInt8 = -(1) // expected-error {{cannot convert value of type 'Int' to specified type 'UInt8'}} expected-note * {{}} expected-warning * {{}}
 
-  var b: UInt16 = -(1) // expected-error {{}} expected-note * {{}} expected-warning * {{}}
+  var b: UInt16 = -(1) // expected-error {{cannot convert value of type 'Int' to specified type 'UInt16'}} expected-note * {{}} expected-warning * {{}}
 
-  var c: UInt32 = -(1) // expected-error {{}} expected-note * {{}} expected-warning * {{}}
+  var c: UInt32 = -(1) // expected-error {{cannot convert value of type 'Int' to specified type 'UInt32'}} expected-note * {{}} expected-warning * {{}}
 
-  var d: UInt64 = -(1) // expected-error {{}} expected-note * {{}} expected-warning * {{}}
+  var d: UInt64 = -(1) // expected-error {{cannot convert value of type 'Int' to specified type 'UInt64'}} expected-note * {{}} expected-warning * {{}}
 }
 
 // Int and UInt are not identical to any fixed-size integer type


### PR DESCRIPTION
These had previously been removed in
9c2bc50acd14e8cdd92d776fdb76b0146192952c because of differences in the
diagnostics being emitted across different platforms.

It looks like we're always emitting the same diagnostic now, so restore
a specific message.

Resolves: rdar://problem/19677545
