### PR TITLE
[Clang importer] Resolve synthesized type witnesses without the type checker

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -1212,6 +1212,21 @@ addProtocolsToStruct(ClangImporter::Implementation &Impl,
                                    SynthesizedProtocolAttr(kind));
 }
 
+/// Add the RawValue type to a RawRepresentable struct.
+static void addRawValueType(StructDecl *structDecl, Type rawType) {
+  auto &ctx = structDecl->getASTContext();
+
+  auto typealias = new (ctx) TypeAliasDecl(SourceLoc(), SourceLoc(),
+                                           ctx.Id_RawValue, SourceLoc(),
+                                           nullptr, structDecl);
+  typealias->setUnderlyingType(rawType);
+  typealias->setEarlyAttrValidation(true);
+  typealias->setAccessibility(Accessibility::Public);
+  typealias->setValidationStarted();
+  typealias->setImplicit();
+  structDecl->addMember(typealias);
+}
+
 /// Make a struct declaration into a raw-value-backed struct
 ///
 /// \param structDecl the struct to make a raw value for
@@ -1258,6 +1273,8 @@ static void makeStructRawValued(
                              /*wantBody=*/!Impl.hasFinishedTypeChecking()));
   structDecl->addMember(patternBinding);
   structDecl->addMember(var);
+
+  addRawValueType(structDecl, underlyingType);
 }
 
 /// Create a rawValue-ed constructor that bridges to its underlying storage.
@@ -1372,6 +1389,9 @@ static void makeStructRawValuedWithBridge(
   structDecl->addMember(computedPatternBinding);
   structDecl->addMember(computedVar);
   structDecl->addMember(computedVarGetter);
+
+  addRawValueType(structDecl, bridgedType);
+
 }
 
 static Type getGenericMethodType(DeclContext *dc, AnyFunctionType *fnType) {

--- a/test/ClangImporter/Inputs/SwiftPrivateAttr.txt
+++ b/test/ClangImporter/Inputs/SwiftPrivateAttr.txt
@@ -94,12 +94,14 @@ struct __PrivNSOptions : OptionSet {
   init(rawValue: Int)
   let rawValue: Int
   typealias RawValue = Int
+  typealias Element = __PrivNSOptions
   static var A: __PrivNSOptions { get }
 }
 struct NSOptions : OptionSet {
   init(rawValue: Int)
   let rawValue: Int
   typealias RawValue = Int
+  typealias Element = NSOptions
   static var __privA: NSOptions { get }
   @available(swift, obsoleted: 3, renamed: "__privA")
   static var __PrivA: NSOptions { get }

--- a/test/ClangImporter/Inputs/SwiftPrivateAttr.txt
+++ b/test/ClangImporter/Inputs/SwiftPrivateAttr.txt
@@ -60,18 +60,21 @@ struct E0 : RawRepresentable, Equatable {
   init(_ rawValue: UInt32)
   init(rawValue: UInt32)
   var rawValue: UInt32
+  typealias RawValue = UInt32
 }
 var __E0PrivA: E0 { get }
 struct __PrivE1 : RawRepresentable, Equatable {
   init(_ rawValue: UInt32)
   init(rawValue: UInt32)
   var rawValue: UInt32
+  typealias RawValue = UInt32
 }
 var __PrivE1A: __PrivE1 { get }
 struct __PrivE2 : RawRepresentable, Equatable {
   init(_ rawValue: UInt32)
   init(rawValue: UInt32)
   var rawValue: UInt32
+  typealias RawValue = UInt32
 }
 var __PrivE2A: __PrivE2 { get }
 enum __PrivNSEnum : Int {
@@ -90,11 +93,13 @@ enum NSEnum : Int {
 struct __PrivNSOptions : OptionSet {
   init(rawValue: Int)
   let rawValue: Int
+  typealias RawValue = Int
   static var A: __PrivNSOptions { get }
 }
 struct NSOptions : OptionSet {
   init(rawValue: Int)
   let rawValue: Int
+  typealias RawValue = Int
   static var __privA: NSOptions { get }
   @available(swift, obsoleted: 3, renamed: "__privA")
   static var __PrivA: NSOptions { get }

--- a/test/ClangImporter/enum-with-target.swift
+++ b/test/ClangImporter/enum-with-target.swift
@@ -14,7 +14,7 @@ let calendarUnitsDep: NSCalendarUnitDeprecated = [.eraCalendarUnitDeprecated, .y
 // rdar://problem/21081557
 func pokeRawValue(_ random: SomeRandomEnum) {
   switch (random) {
-  case SomeRandomEnum.RawValue // expected-error{{expression pattern of type 'SomeRandomEnum.RawValue.Type' (aka 'Int.Type') cannot match values of type 'SomeRandomEnum'}}
+  case SomeRandomEnum.RawValue // expected-error{{type 'SomeRandomEnum' has no member 'RawValue'}}
     // expected-error@-1{{expected ':' after 'case'}}
   }
 }

--- a/test/IDE/import_as_member_objc.swift
+++ b/test/IDE/import_as_member_objc.swift
@@ -11,6 +11,7 @@
 // PRINT-CLASS-NEXT:   struct Options : OptionSet {
 // PRINT-CLASS-NEXT:     init(rawValue rawValue: Int)
 // PRINT-CLASS-NEXT:     let rawValue: Int
+// PRINT-CLASS-NEXT:     typealias RawValue = Int
 // PRINT-CLASS-NEXT:     static var fuzzyDice: SomeClass.Options { get }
 // PRINT-CLASS-NEXT:     static var spoiler: SomeClass.Options { get }
 // PRINT-CLASS-NEXT:   }

--- a/test/IDE/import_as_member_objc.swift
+++ b/test/IDE/import_as_member_objc.swift
@@ -12,6 +12,7 @@
 // PRINT-CLASS-NEXT:     init(rawValue rawValue: Int)
 // PRINT-CLASS-NEXT:     let rawValue: Int
 // PRINT-CLASS-NEXT:     typealias RawValue = Int
+// PRINT-CLASS-NEXT:     typealias Element = SomeClass
 // PRINT-CLASS-NEXT:     static var fuzzyDice: SomeClass.Options { get }
 // PRINT-CLASS-NEXT:     static var spoiler: SomeClass.Options { get }
 // PRINT-CLASS-NEXT:   }

--- a/test/IDE/newtype.swift
+++ b/test/IDE/newtype.swift
@@ -12,6 +12,7 @@
 // PRINT-NEXT:    var _rawValue: NSString
 // PRINT-NEXT:    var rawValue: String { get }
 // PRINT-NEXT:    typealias RawValue = String
+// PRINT-NEXT:    typealias _ObjectiveCType = NSString
 // PRINT-NEXT:  }
 // PRINT-NEXT:  extension ErrorDomain {
 // PRINT-NEXT:    func process()
@@ -32,6 +33,7 @@
 // PRINT-NEXT:    var _rawValue: NSString
 // PRINT-NEXT:    var rawValue: String { get }
 // PRINT-NEXT:    typealias RawValue = String
+// PRINT-NEXT:    typealias _ObjectiveCType = NSString
 // PRINT-NEXT:  }
 // PRINT-NEXT:  extension ClosedEnum {
 // PRINT-NEXT:    static let firstClosedEntryEnum: ClosedEnum
@@ -44,6 +46,7 @@
 // PRINT-NEXT:    var _rawValue: NSString
 // PRINT-NEXT:    var rawValue: String { get }
 // PRINT-NEXT:    typealias RawValue = String
+// PRINT-NEXT:    typealias _ObjectiveCType = NSString
 // PRINT-NEXT:  }
 // PRINT-NEXT:  struct MyFloat : RawRepresentable, _SwiftNewtypeWrapper, Equatable, Hashable, Comparable {
 // PRINT-NEXT:    init(_ rawValue: Float)
@@ -121,6 +124,7 @@
 // PRINT-NEXT:    var _rawValue: NSString
 // PRINT-NEXT:    var rawValue: String { get }
 // PRINT-NEXT:    typealias RawValue = String
+// PRINT-NEXT:    typealias _ObjectiveCType = NSString
 // PRINT-NEXT:  }
 // PRINT-NEXT:  typealias MyABIOldTypeNS = NSString
 // PRINT-NEXT:  func getMyABINewTypeNS() -> MyABINewTypeNS!
@@ -140,6 +144,7 @@
 // PRINT-NEXT:      var _rawValue: NSString
 // PRINT-NEXT:      var rawValue: String { get }
 // PRINT-NEXT:      typealias RawValue = String
+// PRINT-NEXT:      typealias _ObjectiveCType = NSString
 // PRINT-NEXT:    }
 // PRINT-NEXT:  }
 // PRINT-NEXT:  extension NSSomeContext.Name {

--- a/test/IDE/newtype.swift
+++ b/test/IDE/newtype.swift
@@ -11,6 +11,7 @@
 // PRINT-NEXT:    init(rawValue: String)
 // PRINT-NEXT:    var _rawValue: NSString
 // PRINT-NEXT:    var rawValue: String { get }
+// PRINT-NEXT:    typealias RawValue = String
 // PRINT-NEXT:  }
 // PRINT-NEXT:  extension ErrorDomain {
 // PRINT-NEXT:    func process()
@@ -30,6 +31,7 @@
 // PRINT-NEXT:    init(rawValue: String)
 // PRINT-NEXT:    var _rawValue: NSString
 // PRINT-NEXT:    var rawValue: String { get }
+// PRINT-NEXT:    typealias RawValue = String
 // PRINT-NEXT:  }
 // PRINT-NEXT:  extension ClosedEnum {
 // PRINT-NEXT:    static let firstClosedEntryEnum: ClosedEnum
@@ -41,11 +43,13 @@
 // PRINT-NEXT:    init(rawValue: String)
 // PRINT-NEXT:    var _rawValue: NSString
 // PRINT-NEXT:    var rawValue: String { get }
+// PRINT-NEXT:    typealias RawValue = String
 // PRINT-NEXT:  }
 // PRINT-NEXT:  struct MyFloat : RawRepresentable, _SwiftNewtypeWrapper, Equatable, Hashable, Comparable {
 // PRINT-NEXT:    init(_ rawValue: Float)
 // PRINT-NEXT:    init(rawValue: Float)
 // PRINT-NEXT:    let rawValue: Float
+// PRINT-NEXT:    typealias RawValue = Float
 // PRINT-NEXT:  }
 // PRINT-NEXT:  extension MyFloat {
 // PRINT-NEXT:    static let globalFloat: MyFloat{{$}}
@@ -57,6 +61,7 @@
 // PRINT-NEXT:    init(_ rawValue: Int32)
 // PRINT-NEXT:    init(rawValue: Int32)
 // PRINT-NEXT:    let rawValue: Int32
+// PRINT-NEXT:    typealias RawValue = Int32
 // PRINT-NEXT:  }
 // PRINT-NEXT:  extension MyInt {
 // PRINT-NEXT:    static let zero: MyInt{{$}}
@@ -83,6 +88,7 @@
 // PRINT-NEXT:    init(_ rawValue: CFString)
 // PRINT-NEXT:    init(rawValue: CFString)
 // PRINT-NEXT:    let rawValue: CFString
+// PRINT-NEXT:    typealias RawValue = CFString
 // PRINT-NEXT:  }
 // PRINT-NEXT:  extension CFNewType {
 // PRINT-NEXT:    static let MyCFNewTypeValue: CFNewType
@@ -96,6 +102,7 @@
 // PRINT-NEXT:    init(_ rawValue: CFString)
 // PRINT-NEXT:    init(rawValue: CFString)
 // PRINT-NEXT:    let rawValue: CFString
+// PRINT-NEXT:    typealias RawValue = CFString
 // PRINT-NEXT:  }
 // PRINT-NEXT:  typealias MyABIOldType = CFString
 // PRINT-NEXT:  extension MyABINewType {
@@ -113,6 +120,7 @@
 // PRINT-NEXT:    init(rawValue: String)
 // PRINT-NEXT:    var _rawValue: NSString
 // PRINT-NEXT:    var rawValue: String { get }
+// PRINT-NEXT:    typealias RawValue = String
 // PRINT-NEXT:  }
 // PRINT-NEXT:  typealias MyABIOldTypeNS = NSString
 // PRINT-NEXT:  func getMyABINewTypeNS() -> MyABINewTypeNS!
@@ -131,6 +139,7 @@
 // PRINT-NEXT:      init(rawValue: String)
 // PRINT-NEXT:      var _rawValue: NSString
 // PRINT-NEXT:      var rawValue: String { get }
+// PRINT-NEXT:      typealias RawValue = String
 // PRINT-NEXT:    }
 // PRINT-NEXT:  }
 // PRINT-NEXT:  extension NSSomeContext.Name {

--- a/test/IDE/print_clang_decls.swift
+++ b/test/IDE/print_clang_decls.swift
@@ -105,6 +105,7 @@
 // FOUNDATION-NEXT: {{^}}  init(rawValue: UInt){{$}}
 // FOUNDATION-NEXT: {{^}}  let rawValue: UInt{{$}}
 // FOUNDATION-NEXT: {{^}}  typealias RawValue = UInt
+// FOUNDATION-NEXT: {{^}}  typealias Element = NSRuncingOptions
 // FOUNDATION-NEXT: {{^}}  @available(*, unavailable, message: "use [] to construct an empty option set"){{$}}
 // FOUNDATION-NEXT: {{^}}  static var none: NSRuncingOptions { get }{{$}}
 // FOUNDATION-NEXT: {{^}}  @available(*, unavailable, message: "use [] to construct an empty option set"){{$}}

--- a/test/IDE/print_clang_decls.swift
+++ b/test/IDE/print_clang_decls.swift
@@ -104,6 +104,7 @@
 // FOUNDATION-NEXT: {{^}}struct NSRuncingOptions : OptionSet {{{$}}
 // FOUNDATION-NEXT: {{^}}  init(rawValue: UInt){{$}}
 // FOUNDATION-NEXT: {{^}}  let rawValue: UInt{{$}}
+// FOUNDATION-NEXT: {{^}}  typealias RawValue = UInt
 // FOUNDATION-NEXT: {{^}}  @available(*, unavailable, message: "use [] to construct an empty option set"){{$}}
 // FOUNDATION-NEXT: {{^}}  static var none: NSRuncingOptions { get }{{$}}
 // FOUNDATION-NEXT: {{^}}  @available(*, unavailable, message: "use [] to construct an empty option set"){{$}}

--- a/test/Serialization/Inputs/use_imported_enums.swift
+++ b/test/Serialization/Inputs/use_imported_enums.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+@inline(__always) @_transparent public func compareToSelf<T: Equatable>(_ t: T) -> Bool {
+  return t == t
+}
+
+@inline(__always) @_transparent public func compareImportedEnumToSelf(_ e: NSRuncingMode) -> Bool {
+  return compareToSelf(e)
+}

--- a/test/Serialization/sil-imported-enums.swift
+++ b/test/Serialization/sil-imported-enums.swift
@@ -1,0 +1,22 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+
+// FIXME: BEGIN -enable-source-import hackaround
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %clang-importer-sdk-path/swift-modules/CoreGraphics.swift
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %clang-importer-sdk-path/swift-modules/Foundation.swift
+// FIXME: END -enable-source-import hackaround
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-module -o %t -parse-as-library %S/Inputs/use_imported_enums.swift -module-name UsesImportedEnums
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-sil %s | %FileCheck %s
+
+// REQUIRES: objc_interop
+
+import Foundation
+import UsesImportedEnums
+
+// CHECK-LABEL: sil hidden @_T04main4testSbSC13NSRuncingModeO1e_tF
+func test(e: NSRuncingMode) -> Bool {
+  // CHECK-NOT: return
+  // CHECK: _T0s2eeoiSbx_xts16RawRepresentableRzs9Equatable0B5ValueRpzlF
+  return compareImportedEnumToSelf(e)
+}


### PR DESCRIPTION
The Clang importer synthesizes various types that conform to protocols known to the frontend. When those protocols include associated types, make sure we can compute type witnesses for those associated types even when there is no type checker around, e.g., when the SIL optimizers are running. This involves two steps:

* Teach the Clang importer to synthesize typealiases for each of these associated types. By itself, this is a performance optimization because the current code path goes through associated type witness inference to determine these types.
* Teach lazy resolution of type witnesses about these special cases, so we don't need to go through the type checker. This is effectively a hack, because we *should* have (or be able to reconstitute) a `TypeChecker`, but it eliminates a class of "unable to resolve type witness" problems we've been seeing in, e.g., the merge-modules phase or SIL optimization passes.

Fixes rdar://problem/30364905, rdar://problem/31053701, rdar://problem/31565413 / SR-4565.