### PR TITLE
Mangler: Classify protocol witnesses as thunks.

### DIFF
--- a/include/swift/Demangling/Demangle.h
+++ b/include/swift/Demangling/Demangle.h
@@ -299,8 +299,9 @@ public:
   /// Returns the mangled name of the target of a thunk.
   ///
   /// \returns Returns the remaining name after removing the thunk mangling
-  /// characters from \p MangledName. If \p MangledName is not a thunk symbol,
-  /// an empty string is returned.
+  /// characters from \p MangledName. If \p MangledName is not a thunk symbol
+  /// or the thunk target cannot be derived from the mangling, an empty string
+  /// is returned.
   std::string getThunkTarget(llvm::StringRef MangledName);
 
   /// Returns true if the \p mangledName refers to a function which conforms to

--- a/lib/Demangling/Context.cpp
+++ b/lib/Demangling/Context.cpp
@@ -82,7 +82,8 @@ bool Context::isThunkSymbol(llvm::StringRef MangledName) {
     if (MangledName.endswith("TA") ||  // partial application forwarder
         MangledName.endswith("Ta") ||  // ObjC partial application forwarder
         MangledName.endswith("To") ||  // swift-as-ObjC thunk
-        MangledName.endswith("TO")) {  // ObjC-as-swift thunk
+        MangledName.endswith("TO") ||  // ObjC-as-swift thunk
+        MangledName.endswith("TW")) {  // protocol witness thunk
 
       // To avoid false positives, we need to fully demangle the symbol.
       NodePointer Nd = D->demangleSymbol(MangledName);
@@ -95,6 +96,7 @@ bool Context::isThunkSymbol(llvm::StringRef MangledName) {
         case Node::Kind::NonObjCAttribute:
         case Node::Kind::PartialApplyObjCForwarder:
         case Node::Kind::PartialApplyForwarder:
+        case Node::Kind::ProtocolWitness:
           return true;
         default:
           break;
@@ -124,6 +126,10 @@ std::string Context::getThunkTarget(llvm::StringRef MangledName) {
       // Also accept the future mangling prefix.
       // TODO: remove this line as soon as MANGLING_PREFIX_STR gets "_S".
       || MangledName.startswith("_S")) {
+
+    // The target of a protocol witness is not derivable from the mangling.
+    if (MangledName.endswith("TW"))
+      return std::string();
 
     return MangledName.substr(0, MangledName.size() - 2).str();
   }

--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -173,6 +173,7 @@ _TFIvVs8_Process10_argumentsGSaSS_iU_FT_GSaSS_ ---> closure #1 () -> [Swift.Stri
 _TFCSo1AE ---> __ObjC.A.__ivar_destroyer
 _TFCSo1Ae ---> __ObjC.A.__ivar_initializer
 _TTWC13call_protocol1CS_1PS_FS1_3foofT_Si ---> protocol witness for call_protocol.P.foo() -> Swift.Int in conformance call_protocol.C : call_protocol.P in call_protocol
+_T013call_protocol1CCAA1PA2aDP3fooSiyFTW ---> {T:} protocol witness for call_protocol.P.foo() -> Swift.Int in conformance call_protocol.C : call_protocol.P in call_protocol
 _TFC12dynamic_self1X1ffT_DS0_ ---> dynamic_self.X.f() -> Self
 _TTSg5Si___TFSqcfT_GSqx_ ---> generic specialization <Swift.Int> of Swift.Optional.init() -> A?
 _TTSgq5Si___TFSqcfT_GSqx_ ---> generic specialization <preserving fragile attribute, Swift.Int> of Swift.Optional.init() -> A?


### PR DESCRIPTION
Protocol witnesses just call the actual implementation in the conforming type.
