### PR TITLE
[semantic-sil] Change DefiniteInitialization to use the DIMemoryUseCollectorOwnership header instead of the normal DIMemoryUseCollector.

### DIFF
--- a/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
+++ b/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
@@ -19,6 +19,10 @@
 #include "llvm/Support/SaveAndRestore.h"
 #include "llvm/ADT/StringExtras.h"
 
+#ifdef SWIFT_SILOPTIMIZER_PASSMANAGER_DIMEMORYUSECOLLECTOROWNERSHIP_H
+#error "Included ownership header?!"
+#endif
+
 using namespace swift;
 
 //===----------------------------------------------------------------------===//

--- a/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.h
+++ b/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.h
@@ -17,8 +17,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef SWIFT_SILOPTIMIZER_PASSMANAGER_DI_MEMORY_USE_COLLECTOR_H
-#define SWIFT_SILOPTIMIZER_PASSMANAGER_DI_MEMORY_USE_COLLECTOR_H
+#ifndef SWIFT_SILOPTIMIZER_MANDATORY_DIMEMORYUSECOLLECTOR_H
+#define SWIFT_SILOPTIMIZER_MANDATORY_DIMEMORYUSECOLLECTOR_H
 
 #include "swift/Basic/LLVM.h"
 #include "llvm/ADT/APInt.h"

--- a/lib/SILOptimizer/Mandatory/DIMemoryUseCollectorOwnership.cpp
+++ b/lib/SILOptimizer/Mandatory/DIMemoryUseCollectorOwnership.cpp
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #define DEBUG_TYPE "definite-init"
-#include "DIMemoryUseCollector.h"
+#include "DIMemoryUseCollectorOwnership.h"
 #include "swift/AST/Expr.h"
 #include "swift/SIL/SILArgument.h"
 #include "swift/SIL/SILBuilder.h"
@@ -19,7 +19,12 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/SaveAndRestore.h"
 
+#ifdef SWIFT_SILOPTIMIZER_MANDATORY_DIMEMORYUSECOLLECTOR_H
+#error "Included non ownership header?!"
+#endif
+
 using namespace swift;
+using namespace ownership;
 
 //===----------------------------------------------------------------------===//
 //                  DIMemoryObjectInfo Implementation
@@ -1574,7 +1579,7 @@ void ElementUseCollector::collectDelegatingValueTypeInitSelfUses() {
 /// collectDIElementUsesFrom - Analyze all uses of the specified allocation
 /// instruction (alloc_box, alloc_stack or mark_uninitialized), classifying them
 /// and storing the information found into the Uses and Releases lists.
-void swift::collectDIElementUsesFrom(
+void swift::ownership::collectDIElementUsesFrom(
     const DIMemoryObjectInfo &MemoryInfo, SmallVectorImpl<DIMemoryUse> &Uses,
     SmallVectorImpl<TermInst *> &FailableInits,
     SmallVectorImpl<SILInstruction *> &Releases, bool isDIFinished,

--- a/lib/SILOptimizer/Mandatory/DIMemoryUseCollectorOwnership.h
+++ b/lib/SILOptimizer/Mandatory/DIMemoryUseCollectorOwnership.h
@@ -17,8 +17,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef SWIFT_SILOPTIMIZER_PASSMANAGER_DI_MEMORY_USE_COLLECTOR_H
-#define SWIFT_SILOPTIMIZER_PASSMANAGER_DI_MEMORY_USE_COLLECTOR_H
+#ifndef SWIFT_SILOPTIMIZER_PASSMANAGER_DIMEMORYUSECOLLECTOROWNERSHIP_H
+#define SWIFT_SILOPTIMIZER_PASSMANAGER_DIMEMORYUSECOLLECTOROWNERSHIP_H
 
 #include "swift/Basic/LLVM.h"
 #include "swift/SIL/SILInstruction.h"
@@ -26,7 +26,10 @@
 #include "llvm/ADT/APInt.h"
 
 namespace swift {
+
 class SILBuilder;
+
+namespace ownership {
 
 /// DIMemoryObjectInfo - This struct holds information about the memory object
 /// being analyzed that is required to correctly break it down into elements.
@@ -288,6 +291,7 @@ void collectDIElementUsesFrom(const DIMemoryObjectInfo &MemoryInfo,
                               bool isDefiniteInitFinished,
                               bool TreatAddressToPointerAsInout);
 
+} // end namespace ownership
 } // end namespace swift
 
 #endif

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -12,7 +12,7 @@
 
 #define DEBUG_TYPE "definite-init"
 #include "swift/SILOptimizer/PassManager/Passes.h"
-#include "DIMemoryUseCollector.h"
+#include "DIMemoryUseCollectorOwnership.h"
 #include "swift/AST/DiagnosticEngine.h"
 #include "swift/AST/DiagnosticsSIL.h"
 #include "swift/AST/Expr.h"
@@ -28,7 +28,12 @@
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/Debug.h"
 
+#ifdef SWIFT_SILOPTIMIZER_PASSMANAGER_DIMEMORYUSECOLLECTOR_H
+#error "Included non ownership header?!"
+#endif
+
 using namespace swift;
+using namespace ownership;
 
 STATISTIC(NumAssignRewritten, "Number of assigns rewritten");
 


### PR DESCRIPTION
[semantic-sil] Change DefiniteInitialization to use the DIMemoryUseCollectorOwnership header instead of the normal DIMemoryUseCollector.

This is necessary since other passes rely on DIMemoryUseCollector.h and I want
to update each one of them individually to minimize disruption.

rdar://31521023
