### PR TITLE
Unicode rethink: walk bits way faster; 2x smallstr compare

### DIFF
--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -58,6 +58,7 @@ set(SWIFTLIB_ESSENTIAL
   Existential.swift
   Filter.swift.gyb
   FixedArray.swift
+  FixedArray2.swift.gyb
   FixedPoint.swift.gyb
   FlatMap.swift
   Flatten.swift.gyb

--- a/stdlib/public/core/FixedArray2.swift.gyb
+++ b/stdlib/public/core/FixedArray2.swift.gyb
@@ -1,0 +1,87 @@
+// WIP: Trying out a hard(er)-coded fixed size array to wrap. The _DoubleLength
+// approach yields absurd debug-stdlib performance, and absurd generic-
+// specialization compilation times in release.
+//
+
+// WIP NOTE: Just add whatever sized array you need to this list
+% for N in 8, 16:
+
+public struct _FixedArray${N}<T> {
+	// ABI TODO: The has assumptions about tuple layout in the ABI, namely that they
+	// are laid out contiguously and individually addressable (i.e. strided).
+	//
+  public var storage: (
+  	// A ${N}-wide tuple of type T
+% for i in range(0, N-1):
+  	T,
+% end
+    T
+  )
+
+  static var _arraySize : Int { return ${N} }
+}
+
+extension _FixedArray${N} : RandomAccessCollection, MutableCollection {
+  public typealias Index = Int
+  public typealias IndexDistance = Int
+
+  public var startIndex : Index {
+    return 0
+  }
+  public var endIndex : Index {
+    return _FixedArray${N}._arraySize
+  }
+  public var count : IndexDistance { return _FixedArray${N}._arraySize }
+
+  public subscript(i: Index) -> T {
+    @inline(__always)
+    get {
+      var copy = storage
+      let res: T = withUnsafeBytes(of: &copy) {
+        (rawPtr : UnsafeRawBufferPointer) -> T in
+        let stride = MemoryLayout<T>.stride
+        _sanityCheck(rawPtr.count == ${N}*stride, "layout mismatch?")
+        let bufPtr = UnsafeBufferPointer(
+          start: rawPtr.baseAddress!.assumingMemoryBound(to: T.self),
+          count: count)
+        return bufPtr[i]
+      }
+      return res
+    }
+    @inline(__always)
+    set {
+      withUnsafeBytes(of: &storage) {
+        (rawPtr : UnsafeRawBufferPointer) -> () in
+        let rawPtr = UnsafeMutableRawBufferPointer(mutating: rawPtr)
+        let stride = MemoryLayout<T>.stride
+        _sanityCheck(rawPtr.count == ${N}*stride, "layout mismatch?")
+        let bufPtr = UnsafeMutableBufferPointer(
+          start: rawPtr.baseAddress!.assumingMemoryBound(to: T.self),
+          count: count)
+        bufPtr[i] = newValue
+      }
+    }
+  }
+  public func index(after i: Index) -> Index {
+    return i+1
+  }
+  public func index(before i: Index) -> Index {
+    return i-1
+  }
+
+  // TODO: Any customization hooks it's profitable to override, e.g. append?
+
+}
+extension _FixedArray${N} : _FixedSizeCollection {
+  public init(repeating x: Iterator.Element) {
+    storage = (
+% for i in range(0, N-1):
+	  	x,
+% end
+	    x
+    )
+  }
+}
+
+% end
+

--- a/stdlib/public/core/GroupInfo.json
+++ b/stdlib/public/core/GroupInfo.json
@@ -43,6 +43,7 @@
     "ContiguouslyStored.swift",
     "Counted.swift",
     "FixedArray.swift",
+    "FixedArray2.swift",
     "BidirectionalCollection.swift",
     "RandomAccessCollection.swift",
     "MutableCollection.swift",

--- a/stdlib/public/core/NewString.swift.gyb
+++ b/stdlib/public/core/NewString.swift.gyb
@@ -741,6 +741,42 @@ public struct PackedUnsignedIntegers<
   public let representation: Representation
 }
 
+extension PackedUnsignedIntegers : Sequence {
+  public struct Iterator : IteratorProtocol {
+    public var bits: Representation
+    public let shift: Representation
+
+    @inline(__always)
+    public mutating func next() -> Element? {
+      if (bits == 0) {
+        return nil
+      }
+
+      // Zero means empty, so we bias every element by 1
+      let bias: Representation = 1
+      let mask = (1 << shift) &- 1
+
+      let result = mask & (bits &- bias)
+      bits = bits >> shift
+      return numericCast(result)
+    }
+
+    public init(bits: Representation, shift: Representation) {
+      self.bits = bits
+      self.shift = shift
+    }
+  }
+
+  @inline(__always)
+  public func makeIterator() -> Iterator {
+    return Iterator(
+      bits: numericCast(representation),
+      shift: numericCast(bitsPerElement)
+    )
+  }
+
+}
+
 extension PackedUnsignedIntegers : RandomAccessCollection {
   public var startIndex: Int { return 0 }
   public var endIndex: Int { return count }

--- a/stdlib/public/core/NewString.swift.gyb
+++ b/stdlib/public/core/NewString.swift.gyb
@@ -230,7 +230,7 @@ extension String.Content {
   public struct ExplodedUTF16CodeUnits {
     typealias _Self = ExplodedUTF16CodeUnits
     // TODO: could be smaller. e.g. 5or6 could just expode to UInt8.
-    public typealias Base = _BoundedCapacity<_CodeUnitArray16<UInt16>>
+    public typealias Base = _BoundedCapacity<_FixedArray16<UInt16>>
     public var base: Base
 
     public init(_ inlineStr: String.Content.Inline5or6) {

--- a/stdlib/public/core/StringNormalization.swift
+++ b/stdlib/public/core/StringNormalization.swift
@@ -167,13 +167,12 @@ extension FCCNormalizedSegment {
     // As a quick check, see if we're just a coalesced buffer of pre-normalized
     // scalars.
     for cu in buffer {
+      // TODO: Other checks
       guard _fastPath(isPreNormalized(utf16CodeUnit: cu)) else {
         return false
       }
     }
-
-    // TODO: Other checks
-    return false
+    return true
   }
 
   static func isPreNormalized(utf16CodeUnit cu: UInt16) -> Bool {


### PR DESCRIPTION
<!-- What's in this pull request? -->
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
