### PR TITLE
[stdlib] Use default collator instead of root collator on collating unicode

### DIFF
--- a/stdlib/public/stubs/UnicodeNormalization.cpp
+++ b/stdlib/public/stubs/UnicodeNormalization.cpp
@@ -60,6 +60,26 @@ static const UCollator *GetRootCollator() {
   return SWIFT_LAZY_CONSTANT(MakeRootCollator());
 }
 
+static const UCollator *MakeDefaultCollator() {
+  UErrorCode ErrorCode = U_ZERO_ERROR;
+  UCollator *root = ucol_open(NULL, &ErrorCode);
+  if (U_FAILURE(ErrorCode)) {
+    swift::crash("ucol_open: Failure setting up default collation.");
+  }
+  ucol_setAttribute(root, UCOL_NORMALIZATION_MODE, UCOL_ON, &ErrorCode);
+  ucol_setAttribute(root, UCOL_STRENGTH, UCOL_TERTIARY, &ErrorCode);
+  ucol_setAttribute(root, UCOL_NUMERIC_COLLATION, UCOL_OFF, &ErrorCode);
+  ucol_setAttribute(root, UCOL_CASE_LEVEL, UCOL_OFF, &ErrorCode);
+  if (U_FAILURE(ErrorCode)) {
+    swift::crash("ucol_setAttribute: Failure setting up default collation.");
+  }
+  return root;
+}
+
+static const UCollator *GetDefaultCollator() {
+  return SWIFT_LAZY_CONSTANT(MakeDefaultCollator());
+}
+
 /// This class caches the collation element results for the ASCII subset of
 /// unicode.
 class ASCIICollation {
@@ -131,11 +151,11 @@ swift::_swift_stdlib_unicode_compare_utf16_utf16(const uint16_t *LeftString,
   // ICU UChar type is platform dependent. In Cygwin, it is defined
   // as wchar_t which size is 2. It seems that the underlying binary
   // representation is same with swift utf16 representation.
-  return ucol_strcoll(GetRootCollator(),
+  return ucol_strcoll(GetDefaultCollator(),
     reinterpret_cast<const UChar *>(LeftString), LeftLength,
     reinterpret_cast<const UChar *>(RightString), RightLength);
 #else
-  return ucol_strcoll(GetRootCollator(),
+  return ucol_strcoll(GetDefaultCollator(),
     LeftString, LeftLength,
     RightString, RightLength);
 #endif
@@ -163,7 +183,7 @@ swift::_swift_stdlib_unicode_compare_utf8_utf16(const unsigned char *LeftString,
   uiter_setString(&RightIterator, RightString, RightLength);
 #endif
 
-  uint32_t Diff = ucol_strcollIter(GetRootCollator(),
+  uint32_t Diff = ucol_strcollIter(GetDefaultCollator(),
     &LeftIterator, &RightIterator, &ErrorCode);
   if (U_FAILURE(ErrorCode)) {
     swift::crash("ucol_strcollIter: Unexpected error doing utf8<->utf16 string comparison.");
@@ -188,7 +208,7 @@ swift::_swift_stdlib_unicode_compare_utf8_utf8(const unsigned char *LeftString,
   uiter_setUTF8(&LeftIterator, reinterpret_cast<const char *>(LeftString), LeftLength);
   uiter_setUTF8(&RightIterator, reinterpret_cast<const char *>(RightString), RightLength);
 
-  uint32_t Diff = ucol_strcollIter(GetRootCollator(),
+  uint32_t Diff = ucol_strcollIter(GetDefaultCollator(),
     &LeftIterator, &RightIterator, &ErrorCode);
   if (U_FAILURE(ErrorCode)) {
     swift::crash("ucol_strcollIter: Unexpected error doing utf8<->utf8 string comparison.");
@@ -201,11 +221,11 @@ void *swift::_swift_stdlib_unicodeCollationIterator_create(
   UErrorCode ErrorCode = U_ZERO_ERROR;
 #if defined(__CYGWIN__) || defined(_MSC_VER)
   UCollationElements *CollationIterator = ucol_openElements(
-    GetRootCollator(), reinterpret_cast<const UChar *>(Str), Length,
+    GetDefaultCollator(), reinterpret_cast<const UChar *>(Str), Length,
     &ErrorCode);
 #else
   UCollationElements *CollationIterator = ucol_openElements(
-    GetRootCollator(), Str, Length, &ErrorCode);
+    GetDefaultCollator(), Str, Length, &ErrorCode);
 #endif
   if (U_FAILURE(ErrorCode)) {
     swift::crash("_swift_stdlib_unicodeCollationIterator_create: ucol_openElements() failed.");

--- a/test/stdlib/StringAPI.swift
+++ b/test/stdlib/StringAPI.swift
@@ -179,10 +179,6 @@ func checkStringComparison(
 let comparisonTests = tests.map {
   (test: ComparisonTest) -> ComparisonTest in
   switch (test.expectedUnicodeCollation, test.lhs, test.rhs) {
-  case (.gt, "t", "Tt"), (.lt, "A\u{30a}", "a"):
-    return test.replacingPredicate(.nativeRuntime(
-      "Comparison reversed between ICU and CFString, https://bugs.swift.org/browse/SR-530"))
-
   case (.gt, "\u{0}", ""), (.lt, "\u{0}", "\u{0}\u{0}"):
     return test.replacingPredicate(.nativeRuntime(
       "Null-related issue: https://bugs.swift.org/browse/SR-630"))


### PR DESCRIPTION


<!-- What's in this pull request? -->
This PR changes to use default collator instead of root collator.
http://icu-project.org/apiref/icu4c/ucol_8h.html said about `ucol_open()`'s  `locale` parameter as:
> `loc`	The locale containing the required collation rules. Special values for locales can be passed in - if `NULL` is passed for the locale, the default locale collation rules will be used. If empty string ("") or "root" are passed, the root collator will be returned.

Default locale will be picked up by `uprv_getDefaultLocaleID()` in icu:
https://github.com/unicode-org/icu/blob/4c4f79b52308d87ccc97958779766cbce18d0426/icu4c/source/common/putil.cpp#L1489

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-530](https://bugs.swift.org/browse/SR-530).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->