### PR TITLE
[swiftc (37 vs. 5514)] Add crasher in swift::ASTContext::getOrCreateGenericSignatureBuilder

### DIFF
--- a/validation-test/compiler_crashers/28740-unreachable-executed-at-swift-lib-ast-astcontext-cpp-1324.swift
+++ b/validation-test/compiler_crashers/28740-unreachable-executed-at-swift-lib-ast-astcontext-cpp-1324.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol P{typealias e:P}extension P{{}typealias e:Self


### PR DESCRIPTION
Add test case for crash triggered in `swift::ASTContext::getOrCreateGenericSignatureBuilder`.

Current number of unresolved compiler crashers: 37 (5514 resolved)

Stack trace:

```
0 0x00000000039749d8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x39749d8)
1 0x0000000003975116 SignalHandler(int) (/path/to/swift/bin/swift+0x3975116)
2 0x00007fcf74c03390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007fcf73129428 gsignal /build/glibc-9tT8Do/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007fcf7312b02a abort /build/glibc-9tT8Do/glibc-2.23/stdlib/abort.c:91:0
5 0x0000000003910d7d llvm::llvm_unreachable_internal(char const*, char const*, unsigned int) (/path/to/swift/bin/swift+0x3910d7d)
6 0x00000000013f2334 swift::ASTContext::getOrCreateGenericSignatureBuilder(swift::CanGenericSignature, swift::ModuleDecl*) (/path/to/swift/bin/swift+0x13f2334)
7 0x00000000014b9d89 swift::GenericSignature::createGenericEnvironment(swift::ModuleDecl&) (/path/to/swift/bin/swift+0x14b9d89)
8 0x00000000012f5e47 swift::TypeChecker::checkGenericEnvironment(swift::GenericParamList*, swift::DeclContext*, swift::GenericSignature*, bool, llvm::function_ref<void (swift::GenericSignatureBuilder&)>) (/path/to/swift/bin/swift+0x12f5e47)
9 0x00000000012f5fd9 swift::TypeChecker::validateGenericTypeSignature(swift::GenericTypeDecl*) (/path/to/swift/bin/swift+0x12f5fd9)
10 0x00000000012c6e5e swift::TypeChecker::validateDecl(swift::ValueDecl*) (/path/to/swift/bin/swift+0x12c6e5e)
11 0x00000000012d6653 (anonymous namespace)::DeclChecker::visitProtocolDecl(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0x12d6653)
12 0x00000000012c5217 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x12c5217)
13 0x00000000012c5013 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x12c5013)
14 0x0000000001343265 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x1343265)
15 0x0000000000faa676 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xfaa676)
16 0x00000000004a97bf swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a97bf)
17 0x0000000000465167 main (/path/to/swift/bin/swift+0x465167)
18 0x00007fcf73114830 __libc_start_main /build/glibc-9tT8Do/glibc-2.23/csu/../csu/libc-start.c:325:0
19 0x0000000000462809 _start (/path/to/swift/bin/swift+0x462809)
```