### PR TITLE
[Constraint Solver] Respect availability in operator-performance hacks.

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -624,11 +624,14 @@ namespace {
       // into "favored" and non-favored lists.
       SmallVector<Constraint *, 4> favoredConstraints;
       SmallVector<Constraint *, 4> fallbackConstraints;
-      for (auto oldConstraint : oldConstraints)
-        if (isFavored(oldConstraint->getOverloadChoice().getDecl()))
+      for (auto oldConstraint : oldConstraints) {
+        auto decl = oldConstraint->getOverloadChoice().getDecl();
+        if (!decl->getAttrs().isUnavailable(CS.getASTContext()) &&
+            isFavored(decl))
           favoredConstraints.push_back(oldConstraint);
         else
           fallbackConstraints.push_back(oldConstraint);
+      }
 
       // If we did not find any favored constraints, we're done.
       if (favoredConstraints.empty()) break;

--- a/test/Constraints/operator_availability.swift
+++ b/test/Constraints/operator_availability.swift
@@ -1,0 +1,31 @@
+// RUN: %target-typecheck-verify-swift -swift-version 4
+
+
+// rdar://problem/31592529
+infix operator <=< : BitwiseShiftPrecedence
+infix operator >=> : BitwiseShiftPrecedence
+
+public protocol P {}
+
+extension P {
+  public static func <=< <Other : P>(_ x: Self, _ y: Other) { }
+
+  @available(swift, obsoleted: 4)
+  public static func >=> <Other : P>(_ x: Self, _ y: Other) { }
+}
+
+extension Int : P {}
+extension Int32 : P {}
+
+extension Int32 {
+  @available(swift, obsoleted: 4)
+  public static func <=< (_ x: Int32, _ y: Int32) {}
+
+  @available(swift, obsoleted: 4)
+  public static func >=> (_ x: Int32, _ y: Int32) {} // expected-note{{'>=>' was obsoleted in Swift 4}}
+}
+
+func testAvailability() {
+  _ = (1 as Int32) <=< (1 as Int32)   // okay
+  _ = (1 as Int32) >=> (1 as Int32)   // expected-error{{'>=>' is unavailable}}
+}


### PR DESCRIPTION
We have various hacks in the constraint solver to improve the
compile-time performance characteristics of operators. Some of those
didn't respect availability annotations, causing us to incorrectly
choose an unavailable operator when available options exist.

Fixes rdar://problem/31592529.
