### PR TITLE
[master-next] Adjust for LLVM r300277

### DIFF
--- a/lib/IRGen/GenCoverage.cpp
+++ b/lib/IRGen/GenCoverage.cpp
@@ -32,12 +32,8 @@ using namespace irgen;
 using llvm::coverage::CovMapVersion;
 using llvm::coverage::CounterMappingRegion;
 
-static bool isMachO(IRGenModule &IGM) {
-  return SwiftTargetInfo::get(IGM).OutputObjectFormat == llvm::Triple::MachO;
-}
-
 static StringRef getCoverageSection(IRGenModule &IGM) {
-  return llvm::getInstrProfCoverageSectionName(isMachO(IGM));
+  return llvm::getInstrProfCoverageSectionName(&IGM.Module);
 }
 
 void IRGenModule::emitCoverageMapping() {


### PR DESCRIPTION
llvm::getInstrProfCoverageSectionName was changed to take the LLVM module
as an argument.