### PR TITLE
Debug Info: Emit debug info for Swift types using the default alignment.

### DIFF
--- a/lib/IRGen/DebugTypeInfo.cpp
+++ b/lib/IRGen/DebugTypeInfo.cpp
@@ -17,7 +17,6 @@
 
 #include "DebugTypeInfo.h"
 #include "FixedTypeInfo.h"
-#include "IRGen.h"
 #include "swift/SIL/SILGlobalVariable.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
@@ -27,11 +26,21 @@ using namespace irgen;
 
 DebugTypeInfo::DebugTypeInfo(DeclContext *DC, GenericEnvironment *GE,
                              swift::Type Ty, llvm::Type *StorageTy, Size size,
-                             Alignment align)
+                             Alignment align, bool HasDefaultAlignment)
     : DeclCtx(DC), GenericEnv(GE), Type(Ty.getPointer()),
-      StorageType(StorageTy), size(size), align(align) {
+      StorageType(StorageTy), size(size), align(align),
+      DefaultAlignment(HasDefaultAlignment) {
   assert(StorageType && "StorageType is a nullptr");
   assert(align.getValue() != 0);
+}
+
+/// Determine whether this type has a custom @_alignment attribute.
+static bool hasDefaultAlignment(swift::Type Ty) {
+  if (auto CanTy = Ty->getCanonicalType())
+    if (auto *TyDecl = CanTy.getNominalOrBoundGenericNominal())
+      if (TyDecl->getAttrs().getAttribute<AlignmentAttr>())
+        return false;
+  return true;
 }
 
 DebugTypeInfo DebugTypeInfo::getFromTypeInfo(DeclContext *DC,
@@ -48,7 +57,7 @@ DebugTypeInfo DebugTypeInfo::getFromTypeInfo(DeclContext *DC,
     size = Size(0);
   }
   return DebugTypeInfo(DC, GE, Ty.getPointer(), Info.getStorageType(), size,
-                       Info.getBestKnownAlignment());
+                       Info.getBestKnownAlignment(), hasDefaultAlignment(Ty));
 }
 
 DebugTypeInfo DebugTypeInfo::getLocalVariable(DeclContext *DC,
@@ -82,7 +91,7 @@ DebugTypeInfo DebugTypeInfo::getLocalVariable(DeclContext *DC,
 DebugTypeInfo DebugTypeInfo::getMetadata(swift::Type Ty, llvm::Type *StorageTy,
                                          Size size, Alignment align) {
   DebugTypeInfo DbgTy(nullptr, nullptr, Ty.getPointer(), StorageTy, size,
-                      align);
+                      align, true);
   assert(!DbgTy.isArchetype() && "type metadata cannot contain an archetype");
   return DbgTy;
 }
@@ -105,7 +114,8 @@ DebugTypeInfo DebugTypeInfo::getGlobal(SILGlobalVariable *GV,
     if (DeclType->isEqual(LowTy))
       Type = DeclType.getPointer();
   }
-  DebugTypeInfo DbgTy(DC, GE, Type, StorageTy, size, align);
+  DebugTypeInfo DbgTy(DC, GE, Type, StorageTy, size, align,
+                      hasDefaultAlignment(Type));
   assert(StorageTy && "StorageType is a nullptr");
   assert(!DbgTy.isArchetype() &&
          "type of a global var cannot contain an archetype");
@@ -118,7 +128,7 @@ DebugTypeInfo DebugTypeInfo::getObjCClass(ClassDecl *theClass,
                                           Alignment align) {
   DebugTypeInfo DbgTy(nullptr, nullptr,
                       theClass->getInterfaceType().getPointer(), StorageType,
-                      size, align);
+                      size, align, true);
   assert(!DbgTy.isArchetype() &&
          "type of an objc class cannot contain an archetype");
   return DbgTy;

--- a/lib/IRGen/DebugTypeInfo.h
+++ b/lib/IRGen/DebugTypeInfo.h
@@ -52,12 +52,13 @@ public:
   /// the storage type for undefined variables.
   llvm::Type *StorageType = nullptr;
   Size size = Size(0);
-  Alignment align = Alignment(1);
+  Alignment align = Alignment(0);
+  bool DefaultAlignment = true;
 
   DebugTypeInfo() {}
   DebugTypeInfo(DeclContext *DC, GenericEnvironment *GE, swift::Type Ty,
-                llvm::Type *StorageTy, Size SizeInBytes,
-                Alignment AlignInBytes);
+                llvm::Type *StorageTy, Size SizeInBytes, Alignment AlignInBytes,
+                bool HasDefaultAlignment);
   /// Create type for a local variable.
   static DebugTypeInfo getLocalVariable(DeclContext *DeclCtx,
                                         GenericEnvironment *GE, VarDecl *Decl,
@@ -123,7 +124,7 @@ template <> struct DenseMapInfo<swift::irgen::DebugTypeInfo> {
     return swift::irgen::DebugTypeInfo(
         nullptr, nullptr,
         llvm::DenseMapInfo<swift::TypeBase *>::getTombstoneKey(), nullptr,
-        swift::irgen::Size(0), swift::irgen::Alignment(0));
+        swift::irgen::Size(0), swift::irgen::Alignment(0), false);
   }
   static unsigned getHashValue(swift::irgen::DebugTypeInfo Val) {
     return DenseMapInfo<swift::CanType>::getHashValue(Val.getType());

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -3293,7 +3293,7 @@ void IRGenSILFunction::emitErrorResultVar(SILResultInfo ErrorInfo,
                                 Var.Name, Var.ArgNo);
   DebugTypeInfo DTI(nullptr, nullptr, ErrorInfo.getType(),
                     ErrorResultSlot->getType(), IGM.getPointerSize(),
-                    IGM.getPointerAlignment());
+                    IGM.getPointerAlignment(), true);
   IGM.DebugInfo->emitVariableDeclaration(Builder, Storage, DTI, getDebugScope(),
                                          nullptr, Var.Name, Var.ArgNo,
                                          IndirectValue, ArtificialValue);

--- a/test/DebugInfo/NestedTypes.swift
+++ b/test/DebugInfo/NestedTypes.swift
@@ -12,7 +12,7 @@ public class C { }
 public let e : Enum = .WithClass(C())
 
 // CHECK: !DIDerivedType(tag: DW_TAG_member, name: "WithClass",
-// CHECK-SAME:           size: {{32|64}},
+// CHECK-SAME:           size: {{32|64}})
 // CHECK: !DIDerivedType(tag: DW_TAG_member, name: "WithStruct",
-// CHECK-SAME:           size: 128,
+// CHECK-SAME:           size: 128)
 

--- a/test/DebugInfo/alignment.swift
+++ b/test/DebugInfo/alignment.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-frontend %s -emit-ir -g -o - | %FileCheck %s
+
+@_alignment(32)
+// CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "S32"
+// CHECK-SAME:             align: 256,
+struct S32 { var x, y, z, w: Float }
+
+@_alignment(16)
+// CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "E16"
+// CHECK-SAME:             align: 128,
+enum E16 {
+  case F(Float)
+  case I(Int64)
+}
+
+var s: S32
+var e: E16

--- a/test/DebugInfo/enum.swift
+++ b/test/DebugInfo/enum.swift
@@ -15,28 +15,28 @@ let E : Either = .Neither;
 
 // CHECK: !DICompositeType({{.*}}name: "Color",
 // CHECK-SAME:             line: [[@LINE+3]]
-// CHECK-SAME:             size: 8, align: 8,
+// CHECK-SAME:             size: 8,
 // CHECK-SAME:             identifier: "_T04enum5ColorOD"
 enum Color : UInt64 {
 // This is effectively a 2-bit bitfield:
 // DWARF: !DIDerivedType(tag: DW_TAG_member, name: "Red"
 // DWARF-SAME:           baseType: ![[UINT64:[0-9]+]]
-// DWARF-SAME:           size: 8, align: 8{{[,)]}}
+// DWARF-SAME:           size: 8{{[,)]}}
 // DWARF: ![[UINT64]] = !DICompositeType({{.*}}identifier: "_T0s6UInt64VD"
   case Red, Green, Blue
 }
 
 // CHECK: !DICompositeType({{.*}}name: "MaybeIntPair",
 // CHECK-SAME:             line: [[@LINE+3]],
-// CHECK-SAME:             size: 136, align: 64{{[,)]}}
+// CHECK-SAME:             size: 136{{[,)]}}
 // CHECK-SAME:             identifier: "_T04enum12MaybeIntPairOD"
 enum MaybeIntPair {
 // DWARF: !DIDerivedType(tag: DW_TAG_member, name: "none"
-// DWARF-SAME:           baseType: ![[INT]], align: 8{{[,)]}}
+// DWARF-SAME:           baseType: ![[INT]]{{[,)]}}
   case none
 // DWARF: !DIDerivedType(tag: DW_TAG_member, name: "just"
 // DWARF-SAME:           baseType: ![[INTTUP:[0-9]+]]
-// DWARF-SAME:           size: 128, align: 64{{[,)]}}
+// DWARF-SAME:           size: 128{{[,)]}}
 // DWARF: ![[INTTUP]] = !DICompositeType({{.*}}identifier: "_T0s5Int64V_ABtD"
   case just(Int64, Int64)
 }
@@ -50,7 +50,7 @@ let r = Color.Red
 let c = MaybeIntPair.just(74, 75)
 // CHECK: !DICompositeType({{.*}}name: "Maybe",
 // CHECK-SAME:             line: [[@LINE-8]],
-// CHECK-SAME:             size: 8, align: 8{{[,)]}}
+// CHECK-SAME:             size: 8{{[,)]}}
 // CHECK-SAME:             identifier: "_T04enum5MaybeOyAA5ColorOGD"
 let movie : Maybe<Color> = .none
 

--- a/test/DebugInfo/nostorage.swift
+++ b/test/DebugInfo/nostorage.swift
@@ -14,7 +14,7 @@ public class Foo {
       // CHECK1-SAME:                         line: [[@LINE+4]],
       // CHECK1-SAME:                         type: ![[METAFOO:[0-9]+]]
       // CHECK1: ![[METAFOO]] = !DICompositeType(tag: DW_TAG_structure_type,
-      // CHECK1-SAME:                            align: 8, flags:
+      // CHECK1-SAME:                            flags:
             let type = type(of: self)
             used(type)
         }()

--- a/test/DebugInfo/parent-scope.swift
+++ b/test/DebugInfo/parent-scope.swift
@@ -19,7 +19,7 @@ public struct Generic<T : P> {
 // But only one concrete type is expected.
 // CHECK: !DISubprogram({{.*}}linkageName: "_T04main8ConcreteV3getSiSgyF",
 // CHECK-SAME:          scope: ![[CONC:[0-9]+]],
-// CHECK: ![[CONC]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Concrete", scope: !{{[0-9]+}}, file: !{{[0-9]+}}, line: {{[0-9]+}}, align: {{[0-9]+}}, elements: !{{[0-9]+}}, runtimeLang: DW_LANG_Swift, identifier: "_T04main8ConcreteVD")
+// CHECK: ![[CONC]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Concrete", scope: !{{[0-9]+}}, file: !{{[0-9]+}}, line: {{[0-9]+}}, elements: !{{[0-9]+}}, runtimeLang: DW_LANG_Swift, identifier: "_T04main8ConcreteVD")
 public struct Concrete {
   public func get() -> Int? {
     return nil

--- a/test/DebugInfo/test_ints.swift
+++ b/test/DebugInfo/test_ints.swift
@@ -5,7 +5,7 @@
 // CHECK-SAME:              type: ![[INT64:[0-9]+]]
 var a : Int64 = 2
 // CHECK: ![[INT64]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Int64"
-// CHECK-SAME:             size: 64, align: 64
+// CHECK-SAME:             size: 64,
 // CHECK-NOT:              offset: 0
 // CHECK-NOT:              DIFlagFwdDecl
 // CHECK-SAME:             identifier: "_T0s5Int64VD"


### PR DESCRIPTION
Since Swift doesn't have a source-level mechanism for controlling the
alignment of types there is no point in encoding the default alignment
in the debug info. This change emits debug info for all swift types
with the default alignment value of 0.

This mirrors clang's behavior.

<rdar://problem/29007471>
