### PR TITLE
Removing the tmp folder even when api-stability test fails

### DIFF
--- a/test/api-digester/source-stability.swift
+++ b/test/api-digester/source-stability.swift
@@ -4,5 +4,4 @@
 // RUN: %api-digester -diagnose-sdk -input-paths %S/stdlib-stable.json -input-paths %S/tmp/current-stdlib.json >> %S/tmp/changes.txt
 // RUN: %clang -E -P -x c %S/source-stability.swift.expected -o - | sed '/^\s*$/d' > %S/tmp/source-stability.swift.expected
 // RUN: %clang -E -P -x c %S/tmp/changes.txt -o - | sed '/^\s*$/d' > %S/tmp/changes.txt.tmp
-// RUN: diff -u %S/tmp/source-stability.swift.expected %S/tmp/changes.txt.tmp
-// RUN: rm -rf %S/tmp
+// RUN: diff -u %S/tmp/source-stability.swift.expected %S/tmp/changes.txt.tmp ; rm -rf %S/tmp


### PR DESCRIPTION
If the api-stability test fails, the temporary folder does not get removed, and can be accidentally committed to the repo, which is undesirable.
This change unconditionally removes the temporary folder after the test has been executed.