### PR TITLE
[GSB] Infer requirements from concrete types in requirements.

### DIFF
--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -454,15 +454,20 @@ public:
   /// Adding an already-checked requirement cannot fail. This is used to
   /// re-inject requirements from outer contexts.
   ///
+  /// \param inferForModule Infer additional requirements from the types
+  /// relative to the given module.
+  ///
   /// \returns true if this requirement makes the set of requirements
   /// inconsistent, in which case a diagnostic will have been issued.
   ConstraintResult addRequirement(const Requirement &req,
                                   FloatingRequirementSource source,
+                                  ModuleDecl *inferForModule,
                                   const SubstitutionMap *subMap = nullptr);
 
   ConstraintResult addRequirement(
                                 const Requirement &req,
                                 FloatingRequirementSource source,
+                                ModuleDecl *inferForModule,
                                 const SubstitutionMap *subMap,
                                 llvm::SmallPtrSetImpl<ProtocolDecl *> &Visited);
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3133,7 +3133,8 @@ void ProtocolDecl::computeRequirementSignature() {
   builder.addRequirement(
          requirement,
          GenericSignatureBuilder::RequirementSource
-          ::forRequirementSignature(builder.resolveArchetype(selfType), this));
+          ::forRequirementSignature(builder.resolveArchetype(selfType), this),
+         nullptr);
   builder.finalize(SourceLoc(), { selfType });
   
   RequirementSignature = builder.getGenericSignature();

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -808,7 +808,8 @@ ConformanceAccessPath GenericSignature::getConformanceAccessPath(
   buildPath = [&](GenericSignature *sig, const RequirementSource *source,
                   ProtocolDecl *conformingProto, Type rootType) {
     // Each protocol requirement is a step along the path.
-    if (source->kind == RequirementSource::ProtocolRequirement) {
+    if (source->kind == RequirementSource::ProtocolRequirement ||
+        source->kind == RequirementSource::InferredProtocolRequirement) {
       // Follow the rest of the path to derive the conformance into which
       // this particular protocol requirement step would look.
       auto inProtocol = source->getProtocolDecl();

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -116,6 +116,7 @@ bool RequirementSource::isAcceptableStorageKind(Kind kind,
     }
 
   case ProtocolRequirement:
+  case InferredProtocolRequirement:
     switch (storageKind) {
     case StorageKind::StoredType:
       return true;
@@ -178,6 +179,27 @@ const void *RequirementSource::getOpaqueStorage3() const {
   return nullptr;
 }
 
+bool RequirementSource::isInferredRequirement() const {
+  for (auto source = this; source; source = source->parent) {
+    switch (source->kind) {
+    case Inferred:
+    case InferredProtocolRequirement:
+      return true;
+
+    case Concrete:
+    case Explicit:
+    case NestedTypeNameMatch:
+    case Parent:
+    case ProtocolRequirement:
+    case RequirementSignatureSelf:
+    case Superclass:
+      break;
+    }
+  }
+
+  return false;
+}
+
 unsigned RequirementSource::classifyDiagKind() const {
   if (isInferredRequirement()) return 2;
   if (isDerivedRequirement()) return 1;
@@ -198,6 +220,7 @@ bool RequirementSource::isDerivedRequirement() const {
     return true;
 
   case ProtocolRequirement:
+  case InferredProtocolRequirement:
     // Requirements based on protocol requirements are derived unless they are
     // direct children of the requirement-signature source, in which case we
     // need to keep them for the requirement signature.
@@ -218,6 +241,7 @@ bool RequirementSource::isDerivedViaConcreteConformance() const {
 
     case Parent:
     case ProtocolRequirement:
+    case InferredProtocolRequirement:
       continue;
 
     case Superclass:
@@ -258,6 +282,7 @@ bool RequirementSource::isSelfDerivedSource(PotentialArchetype *pa) const {
 
     case RequirementSource::Concrete:
     case RequirementSource::ProtocolRequirement:
+    case RequirementSource::InferredProtocolRequirement:
     case RequirementSource::Superclass:
       break;
     }
@@ -497,14 +522,20 @@ const RequirementSource *RequirementSource::forNestedTypeNameMatch(
 }
 
 const RequirementSource *RequirementSource::viaProtocolRequirement(
-    GenericSignatureBuilder &builder, Type dependentType,
-    ProtocolDecl *protocol,
-    GenericSignatureBuilder::WrittenRequirementLoc writtenLoc) const {
+            GenericSignatureBuilder &builder, Type dependentType,
+            ProtocolDecl *protocol,
+            bool inferred,
+            GenericSignatureBuilder::WrittenRequirementLoc writtenLoc) const {
   REQUIREMENT_SOURCE_FACTORY_BODY(
-                        (nodeID, ProtocolRequirement, this,
+                        (nodeID,
+                         inferred ? InferredProtocolRequirement
+                                  : ProtocolRequirement,
+                         this,
                          dependentType.getPointer(), protocol,
                          writtenLoc.getOpaqueValue()),
-                        (ProtocolRequirement, this, dependentType,
+                        (inferred ? InferredProtocolRequirement
+                                  : ProtocolRequirement,
+                         this, dependentType,
                          protocol, writtenLoc),
                         1, writtenLoc);
 }
@@ -574,6 +605,7 @@ PotentialArchetype *RequirementSource::getAffectedPotentialArchetype(GenericSign
     return parent->getAffectedPotentialArchetype(builder);
 
   case RequirementSource::ProtocolRequirement:
+  case RequirementSource::InferredProtocolRequirement:
     return replaceSelfWithPotentialArchetype(
              parent->getAffectedPotentialArchetype(builder),
              getStoredType());
@@ -657,7 +689,8 @@ SourceLoc RequirementSource::getLoc() const {
 static unsigned sourcePathLength(const RequirementSource *source) {
   unsigned count = 0;
   for (; source; source = source->parent) {
-    if (source->kind == RequirementSource::ProtocolRequirement)
+    if (source->kind == RequirementSource::ProtocolRequirement ||
+        source->kind == RequirementSource::InferredProtocolRequirement)
       ++count;
   }
   return count;
@@ -731,6 +764,10 @@ void RequirementSource::print(llvm::raw_ostream &out,
 
   case ProtocolRequirement:
     out << "Protocol requirement";
+    break;
+
+  case InferredProtocolRequirement:
+    out << "Inferred protocol requirement";
     break;
 
   case RequirementSignatureSelf:
@@ -817,7 +854,8 @@ const RequirementSource *FloatingRequirementSource::getSource(
 
   case AbstractProtocol: {
     // Derive the dependent type on which this requirement was written. It is
-    // the path from
+    // the path from the requirement source on which this requirement is based
+    // to the potential archetype on which the requirement is being placed.
     auto baseSource = storage.get<const RequirementSource *>();
     auto baseSourcePA =
       baseSource->getAffectedPotentialArchetype(*pa->getBuilder());
@@ -827,7 +865,8 @@ const RequirementSource *FloatingRequirementSource::getSource(
 
     return storage.get<const RequirementSource *>()
       ->viaProtocolRequirement(*pa->getBuilder(), dependentType,
-                               protocolReq.protocol, protocolReq.written);
+                               protocolReq.protocol, protocolReq.inferred,
+                               protocolReq.written);
   }
   }
 
@@ -874,6 +913,7 @@ bool FloatingRequirementSource::isExplicit() const {
     case RequirementSource::NestedTypeNameMatch:
     case RequirementSource::Parent:
     case RequirementSource::ProtocolRequirement:
+    case RequirementSource::InferredProtocolRequirement:
     case RequirementSource::Superclass:
       return false;
     }
@@ -888,6 +928,7 @@ bool FloatingRequirementSource::isExplicit() const {
         == RequirementSource::RequirementSignatureSelf;
 
     case RequirementSource::Inferred:
+    case RequirementSource::InferredProtocolRequirement:
     case RequirementSource::RequirementSignatureSelf:
     case RequirementSource::Concrete:
     case RequirementSource::NestedTypeNameMatch:
@@ -895,6 +936,23 @@ bool FloatingRequirementSource::isExplicit() const {
     case RequirementSource::Superclass:
       return false;
     }
+  }
+}
+
+FloatingRequirementSource FloatingRequirementSource::asInferred(
+                                              const TypeRepr *typeRepr) const {
+  switch (kind) {
+  case Explicit:
+    return forInferred(typeRepr);
+
+  case Inferred:
+  case Resolved:
+    return *this;
+
+  case AbstractProtocol:
+    return viaProtocolRequirement(storage.get<const RequirementSource *>(),
+                                  protocolReq.protocol, typeRepr,
+                                  /*inferred=*/true);
   }
 }
 
@@ -2166,7 +2224,8 @@ bool GenericSignatureBuilder::addGenericParameterRequirements(
   // Add the requirements from the declaration.
   llvm::SmallPtrSet<ProtocolDecl *, 8> visited;
   return isErrorResult(
-           addInheritedRequirements(GenericParam, PA, nullptr, visited));
+           addInheritedRequirements(GenericParam, PA, nullptr, visited,
+                                    GenericParam->getModuleContext()));
 }
 
 void GenericSignatureBuilder::addGenericParameter(GenericTypeParamType *GenericParam) {
@@ -2269,7 +2328,8 @@ ConstraintResult GenericSignatureBuilder::addConformanceRequirement(
     auto reqSig = Proto->getRequirementSignature();
 
     auto innerSource =
-      FloatingRequirementSource::viaProtocolRequirement(Source, Proto);
+      FloatingRequirementSource::viaProtocolRequirement(Source, Proto,
+                                                        /*inferred=*/false);
     for (auto req : reqSig->getRequirements()) {
       auto reqResult = addRequirement(req, innerSource, &protocolSubMap,
                                       Visited);
@@ -2283,8 +2343,10 @@ ConstraintResult GenericSignatureBuilder::addConformanceRequirement(
   if (auto resolver = getLazyResolver())
     resolver->resolveInheritedProtocols(Proto);
 
+  auto protoModule = Proto->getParentModule();
+
   auto inheritedReqResult =
-    addInheritedRequirements(Proto, PAT, Source, Visited);
+    addInheritedRequirements(Proto, PAT, Source, Visited, protoModule);
   if (isErrorResult(inheritedReqResult))
     return inheritedReqResult;
 
@@ -2292,8 +2354,8 @@ ConstraintResult GenericSignatureBuilder::addConformanceRequirement(
   if (auto WhereClause = Proto->getTrailingWhereClause()) {
     for (auto &req : WhereClause->getRequirements()) {
       auto innerSource = FloatingRequirementSource::viaProtocolRequirement(
-          Source, Proto, &req);
-      addRequirement(&req, innerSource, &protocolSubMap);
+          Source, Proto, &req, /*inferred=*/false);
+      addRequirement(&req, innerSource, &protocolSubMap, protoModule);
     }
   }
 
@@ -2304,16 +2366,17 @@ ConstraintResult GenericSignatureBuilder::addConformanceRequirement(
       auto AssocPA = PAT->getNestedType(AssocType, *this);
 
       auto assocResult =
-        addInheritedRequirements(AssocType, AssocPA, Source, Visited);
+        addInheritedRequirements(AssocType, AssocPA, Source, Visited,
+                                 protoModule);
       if (isErrorResult(assocResult))
         return assocResult;
 
       if (auto WhereClause = AssocType->getTrailingWhereClause()) {
         for (auto &req : WhereClause->getRequirements()) {
           auto innerSource =
-            FloatingRequirementSource::viaProtocolRequirement(Source, Proto,
-                                                              &req);
-          addRequirement(&req, innerSource, &protocolSubMap);
+            FloatingRequirementSource::viaProtocolRequirement(
+                                      Source, Proto, &req, /*inferred=*/false);
+          addRequirement(&req, innerSource, &protocolSubMap, protoModule);
         }
       }
     } else if (auto TypeAlias = dyn_cast<TypeAliasDecl>(Member)) {
@@ -2929,7 +2992,8 @@ ConstraintResult GenericSignatureBuilder::addInheritedRequirements(
                              TypeDecl *decl,
                              PotentialArchetype *pa,
                              const RequirementSource *parentSource,
-                             llvm::SmallPtrSetImpl<ProtocolDecl *> &visited) {
+                             llvm::SmallPtrSetImpl<ProtocolDecl *> &visited,
+                             ModuleDecl *inferForModule) {
   if (isa<AssociatedTypeDecl>(decl) &&
       decl->hasInterfaceType() &&
       decl->getInterfaceType()->is<ErrorType>())
@@ -2940,18 +3004,22 @@ ConstraintResult GenericSignatureBuilder::addInheritedRequirements(
     resolver->resolveInheritanceClause(decl);
 
   // Local function to get the source.
-  auto getFloatingSource = [&](const TypeRepr *typeRepr) {
+  auto getFloatingSource = [&](const TypeRepr *typeRepr, bool forInferred) {
     if (parentSource) {
       if (auto assocType = dyn_cast<AssociatedTypeDecl>(decl)) {
         auto proto = assocType->getProtocol();
         return FloatingRequirementSource::viaProtocolRequirement(
-          parentSource, proto, typeRepr);
+          parentSource, proto, typeRepr, forInferred);
       }
 
       auto proto = cast<ProtocolDecl>(decl);
       return FloatingRequirementSource::viaProtocolRequirement(
-        parentSource, proto, typeRepr);
+        parentSource, proto, typeRepr, forInferred);
     }
+
+    // We are inferring requirements.
+    if (forInferred)
+      return FloatingRequirementSource::forInferred(typeRepr);
 
     // Explicit requirement.
     if (typeRepr)
@@ -2962,29 +3030,44 @@ ConstraintResult GenericSignatureBuilder::addInheritedRequirements(
   };
 
   auto visitType = [&](Type inheritedType, const TypeRepr *typeRepr) {
-    return addTypeRequirement(pa, inheritedType, getFloatingSource(typeRepr),
+    if (inferForModule) {
+      inferRequirements(*inferForModule,
+                        TypeLoc(const_cast<TypeRepr *>(typeRepr),
+                                inheritedType),
+                        getFloatingSource(typeRepr, /*forInferred=*/true));
+    }
+
+    return addTypeRequirement(pa, inheritedType,
+                              getFloatingSource(typeRepr,
+                                                /*forInferred=*/false),
                               UnresolvedHandlingKind::GenerateConstraints,
                               &visited);
   };
 
   auto visitLayout = [&](LayoutConstraint layout, const TypeRepr *typeRepr) {
-    return addLayoutRequirement(pa, layout, getFloatingSource(typeRepr),
+    return addLayoutRequirement(pa, layout,
+                                getFloatingSource(typeRepr,
+                                                  /*forInferred=*/false),
                                 UnresolvedHandlingKind::GenerateConstraints);
   };
 
   return visitInherited(decl->getInherited(), visitType, visitLayout);
 }
 
-ConstraintResult GenericSignatureBuilder::addRequirement(const RequirementRepr *req) {
+ConstraintResult GenericSignatureBuilder::addRequirement(
+                                                 const RequirementRepr *req,
+                                                 ModuleDecl *inferForModule) {
   return addRequirement(req,
                         FloatingRequirementSource::forExplicit(req),
-                        nullptr);
+                        nullptr,
+                        inferForModule);
 }
 
 ConstraintResult GenericSignatureBuilder::addRequirement(
                                              const RequirementRepr *Req,
                                              FloatingRequirementSource source,
-                                             const SubstitutionMap *subMap) {
+                                             const SubstitutionMap *subMap,
+                                             ModuleDecl *inferForModule) {
   auto subst = [&](Type t) {
     if (subMap)
       return t.subst(*subMap);
@@ -2992,20 +3075,44 @@ ConstraintResult GenericSignatureBuilder::addRequirement(
     return t;
   };
 
+  auto getInferredTypeLoc = [=](Type type, TypeLoc existingTypeLoc) {
+    if (subMap) return TypeLoc::withoutLoc(type);
+    return existingTypeLoc;
+  };
+
   switch (Req->getKind()) {
-  case RequirementReprKind::LayoutConstraint:
-    return addLayoutRequirement(subst(Req->getSubject()),
+  case RequirementReprKind::LayoutConstraint: {
+    auto subject = subst(Req->getSubject());
+    if (inferForModule) {
+      inferRequirements(*inferForModule,
+                        getInferredTypeLoc(subject, Req->getSubjectLoc()),
+                        source.asInferred(Req->getSubjectLoc().getTypeRepr()));
+    }
+
+    return addLayoutRequirement(subject,
                                 Req->getLayoutConstraint(),
                                 source,
                                 UnresolvedHandlingKind::GenerateConstraints);
+  }
 
-  case RequirementReprKind::TypeConstraint:
-    return addTypeRequirement(subst(Req->getSubject()),
-                              subst(Req->getConstraint()),
-                              source,
+  case RequirementReprKind::TypeConstraint: {
+    auto subject = subst(Req->getSubject());
+    auto constraint = subst(Req->getConstraint());
+    if (inferForModule) {
+      inferRequirements(*inferForModule,
+                        getInferredTypeLoc(subject, Req->getSubjectLoc()),
+                        source.asInferred(Req->getSubjectLoc().getTypeRepr()));
+      inferRequirements(*inferForModule,
+                        getInferredTypeLoc(constraint,
+                                           Req->getConstraintLoc()),
+                        source.asInferred(
+                                      Req->getConstraintLoc().getTypeRepr()));
+    }
+    return addTypeRequirement(subject, constraint, source,
                               UnresolvedHandlingKind::GenerateConstraints);
+  }
 
-  case RequirementReprKind::SameType:
+  case RequirementReprKind::SameType: {
     // Require that at least one side of the requirement contain a type
     // parameter.
     if (!Req->getFirstType()->hasTypeParameter() &&
@@ -3021,10 +3128,23 @@ ConstraintResult GenericSignatureBuilder::addRequirement(
       return ConstraintResult::Concrete;
     }
 
+    auto firstType = subst(Req->getFirstType());
+    auto secondType = subst(Req->getSecondType());
+    if (inferForModule) {
+      inferRequirements(*inferForModule,
+                        getInferredTypeLoc(firstType, Req->getFirstTypeLoc()),
+                        source.asInferred(
+                                        Req->getFirstTypeLoc().getTypeRepr()));
+      inferRequirements(*inferForModule,
+                        getInferredTypeLoc(secondType,
+                                           Req->getSecondTypeLoc()),
+                        source.asInferred(
+                                        Req->getSecondTypeLoc().getTypeRepr()));
+    }
     return addRequirement(Requirement(RequirementKind::SameType,
-                                      subst(Req->getFirstType()),
-                                      subst(Req->getSecondType())),
+                                      firstType, secondType),
                           source);
+  }
   }
 
   llvm_unreachable("Unhandled requirement?");
@@ -3084,13 +3204,13 @@ ConstraintResult GenericSignatureBuilder::addRequirement(
 class GenericSignatureBuilder::InferRequirementsWalker : public TypeWalker {
   ModuleDecl &module;
   GenericSignatureBuilder &Builder;
-  TypeRepr *typeRepr;
+  FloatingRequirementSource source;
 
 public:
   InferRequirementsWalker(ModuleDecl &module,
                           GenericSignatureBuilder &builder,
-                          TypeRepr *typeRepr)
-    : module(module), Builder(builder), typeRepr(typeRepr) { }
+                          FloatingRequirementSource source)
+    : module(module), Builder(builder), source(source) { }
 
   Action walkToTypePost(Type ty) override {
     auto boundGeneric = ty->getAs<BoundGenericType>();
@@ -3108,7 +3228,6 @@ public:
 
     // Handle the requirements.
     // FIXME: Inaccurate TypeReprs.
-    auto source = FloatingRequirementSource::forInferred(typeRepr);
     for (const auto &req : genericSig->getRequirements()) {
       Builder.addRequirement(req, source, &subMap);
     }
@@ -3117,12 +3236,14 @@ public:
   }
 };
 
-void GenericSignatureBuilder::inferRequirements(ModuleDecl &module,
-                                                TypeLoc type) {
+void GenericSignatureBuilder::inferRequirements(
+                                          ModuleDecl &module,
+                                          TypeLoc type,
+                                          FloatingRequirementSource source) {
   if (!type.getType())
     return;
   // FIXME: Crummy source-location information.
-  InferRequirementsWalker walker(module, *this, type.getTypeRepr());
+  InferRequirementsWalker walker(module, *this, source);
   type.getType().walk(walker);
 }
 
@@ -3133,8 +3254,11 @@ void GenericSignatureBuilder::inferRequirements(
   if (genericParams == nullptr)
     return;
 
-  for (auto P : *params)
-    inferRequirements(module, P->getTypeLoc());
+  for (auto P : *params) {
+    inferRequirements(module, P->getTypeLoc(),
+                      FloatingRequirementSource::forInferred(
+                                            P->getTypeLoc().getTypeRepr()));
+  }
 }
 
 /// Perform typo correction on the given nested type, producing the

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -4572,14 +4572,6 @@ void GenericSignatureBuilder::enumerateRequirements(llvm::function_ref<
 
     // If we have a layout constraint, produce a layout requirement.
     if (equivClass->layout) {
-      // Find the best source among the constraints that describe the layout
-      // of this type.
-      auto bestSource = equivClass->layoutConstraints.front().source;
-      for (const auto &constraint : equivClass->layoutConstraints) {
-        if (constraint.source->compare(bestSource) < 0)
-          bestSource = constraint.source;
-      }
-
       f(RequirementKind::Layout, archetype, equivClass->layout,
         getBestConstraintSource<LayoutConstraint>(
                                               equivClass->layoutConstraints));
@@ -4593,14 +4585,6 @@ void GenericSignatureBuilder::enumerateRequirements(llvm::function_ref<
         protocols.push_back(conforms.first);
         assert(protocolSources.count(conforms.first) == 0 && 
                "redundant protocol requirement?");
-
-        // Find the best source among the constraints that describe conformance
-        // to this protocol.
-        auto bestSource = conforms.second.front().source;
-        for (const auto &constraint : conforms.second) {
-          if (constraint.source->compare(bestSource) < 0)
-            bestSource = constraint.source;
-        }
 
         protocolSources.insert(
           {conforms.first,

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -2669,7 +2669,7 @@ buildThunkSignature(SILGenFunction &gen,
                              openedExistential->getOpenedExistentialType());
   auto source =
     GenericSignatureBuilder::FloatingRequirementSource::forAbstract();
-  builder.addRequirement(newRequirement, source);
+  builder.addRequirement(newRequirement, source, nullptr);
 
   builder.finalize(SourceLoc(), {newGenericParam},
                    /*allowConcreteGenericParams=*/true);

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -604,7 +604,7 @@ getSignatureWithRequirements(GenericSignature *OrigGenSig,
   // For each substitution with a concrete type as a replacement,
   // add a new concrete type equality requirement.
   for (auto &Req : Requirements) {
-    Builder.addRequirement(Req, Source);
+    Builder.addRequirement(Req, Source, M.getSwiftModule());
   }
 
   Builder.finalize(SourceLoc(), OrigGenSig->getGenericParams(),
@@ -882,7 +882,7 @@ static void remapRequirements(GenericSignature *GenSig,
   // caller's archetypes mapped to the specialized signature.
   for (auto &reqReq : GenSig->getRequirements()) {
     DEBUG(llvm::dbgs() << "\n\nRe-mapping the requirement:\n"; reqReq.dump());
-    Builder.addRequirement(reqReq, source, &SubsMap);
+    Builder.addRequirement(reqReq, source, SM, &SubsMap);
   }
 }
 
@@ -1164,7 +1164,7 @@ void FunctionSignaturePartialSpecializer::
 
     Requirement Req(RequirementKind::SameType, SubstGenericParamCanTy,
                     SpecializedReplacementCallerInterfaceTy);
-    Builder.addRequirement(Req, Source);
+    Builder.addRequirement(Req, Source, SM);
 
     DEBUG(llvm::dbgs() << "Added a requirement:\n"; Req.dump());
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1786,7 +1786,7 @@ void AttributeChecker::visitSpecializeAttr(SpecializeAttr *attr) {
 
   // Add the requirements to the builder.
   for (auto &req : resolvedRequirements)
-    Builder.addRequirement(&req);
+    Builder.addRequirement(&req, DC->getParentModule());
 
   // Check the result.
   Builder.finalize(attr->getLocation(), genericSig->getGenericParams(),

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -7570,8 +7570,12 @@ checkExtensionGenericParams(TypeChecker &tc, ExtensionDecl *ext, Type type,
 
   // Local function used to infer requirements from the extended type.
   auto inferExtendedTypeReqs = [&](GenericSignatureBuilder &builder) {
+    auto source =
+      GenericSignatureBuilder::FloatingRequirementSource::forInferred(nullptr);
+
     builder.inferRequirements(*ext->getModuleContext(),
-                              TypeLoc::withoutLoc(extInterfaceType));
+                              TypeLoc::withoutLoc(extInterfaceType),
+                              source);
   };
 
   // Validate the generic type signature.

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -306,7 +306,8 @@ void TypeChecker::checkGenericParamList(GenericSignatureBuilder *builder,
   if (!genericParams)
     return;
 
-  assert(genericParams->size() > 0 && "Parsed an empty generic parameter list?");
+  assert(genericParams->size() > 0 &&
+         "Parsed an empty generic parameter list?");
 
   // Determine where and how to perform name lookup for the generic
   // parameter lists and where clause.
@@ -333,14 +334,8 @@ void TypeChecker::checkGenericParamList(GenericSignatureBuilder *builder,
   for (auto param : *genericParams) {
     checkInheritanceClause(param, resolver);
 
-    if (builder) {
+    if (builder)
       builder->addGenericParameterRequirements(param);
-
-      // Infer requirements from the inherited types.
-      for (const auto &inherited : param->getInherited()) {
-        builder->inferRequirements(*lookupDC->getParentModule(), inherited);
-      }
-    }
   }
 
   // Visit each of the requirements, adding them to the builder.
@@ -351,7 +346,9 @@ void TypeChecker::checkGenericParamList(GenericSignatureBuilder *builder,
                             options, resolver))
       continue;
 
-    if (builder && isErrorResult(builder->addRequirement(&req)))
+    if (builder &&
+        isErrorResult(builder->addRequirement(&req,
+                                              lookupDC->getParentModule())))
       req.setInvalid();
   }
 }
@@ -529,8 +526,12 @@ static bool checkGenericFuncSignature(TypeChecker &tc,
       // Infer requirements from it.
       if (builder && genericParams &&
           fn->getBodyResultTypeLoc().getTypeRepr()) {
+        auto source =
+          GenericSignatureBuilder::FloatingRequirementSource::forInferred(
+                                      fn->getBodyResultTypeLoc().getTypeRepr());
         builder->inferRequirements(*func->getParentModule(),
-                                   fn->getBodyResultTypeLoc());
+                                   fn->getBodyResultTypeLoc(),
+                                   source);
       }
     }
   }
@@ -966,10 +967,14 @@ static bool checkGenericSubscriptSignature(TypeChecker &tc,
                              &resolver);
 
   // Infer requirements from it.
-  if (genericParams && builder &&
-      subscript->getElementTypeLoc().getTypeRepr()) {
+  if (genericParams && builder) {
+    auto source =
+      GenericSignatureBuilder::FloatingRequirementSource::forInferred(
+                                  subscript->getElementTypeLoc().getTypeRepr());
+
     builder->inferRequirements(*subscript->getParentModule(),
-                               subscript->getElementTypeLoc());
+                               subscript->getElementTypeLoc(),
+                               source);
   }
 
   // Check the indices.

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1080,7 +1080,8 @@ RequirementEnvironment::RequirementEnvironment(
   auto source =
     GenericSignatureBuilder::FloatingRequirementSource::forAbstract();
   for (auto &req : reqSig->getRequirements()) {
-    builder.addRequirement(req, source, &reqToSyntheticEnvMap);
+    builder.addRequirement(req, source, conformanceDC->getParentModule(),
+                           &reqToSyntheticEnvMap);
   }
 
   // Finalize the generic signature builder.

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1079,70 +1079,8 @@ RequirementEnvironment::RequirementEnvironment(
   // interface types into the abstract type parameters).
   auto source =
     GenericSignatureBuilder::FloatingRequirementSource::forAbstract();
-  for (auto &reqReq : reqSig->getRequirements()) {
-    switch (reqReq.getKind()) {
-    case RequirementKind::Conformance: {
-      // Substitute the constrained types.
-      auto first = reqReq.getFirstType().subst(reqToSyntheticEnvMap,
-                                               SubstFlags::UseErrorType);
-      if (!first->isTypeParameter()) break;
-
-      builder.addRequirement(Requirement(RequirementKind::Conformance,
-                                         first, reqReq.getSecondType()),
-                             source);
-      break;
-    }
-
-    case RequirementKind::Layout: {
-      // Substitute the constrained types.
-      auto first = reqReq.getFirstType().subst(reqToSyntheticEnvMap);
-      if (!first->isTypeParameter()) break;
-
-      builder.addRequirement(Requirement(RequirementKind::Layout, first,
-                                         reqReq.getLayoutConstraint()),
-                             source);
-      break;
-    }
-
-    case RequirementKind::Superclass: {
-      // Substitute the constrained types.
-      auto first = reqReq.getFirstType().subst(reqToSyntheticEnvMap,
-                                               SubstFlags::UseErrorType);
-      auto second = reqReq.getSecondType().subst(reqToSyntheticEnvMap,
-                                                 SubstFlags::UseErrorType);
-
-      if (!first->isTypeParameter()) break;
-
-      builder.addRequirement(Requirement(RequirementKind::Superclass,
-                                         first, second),
-                             source);
-      break;
-    }
-
-    case RequirementKind::SameType: {
-      // Substitute the constrained types.
-      auto first = reqReq.getFirstType().subst(reqToSyntheticEnvMap,
-                                               SubstFlags::UseErrorType);
-      auto second = reqReq.getSecondType().subst(reqToSyntheticEnvMap,
-                                                 SubstFlags::UseErrorType);
-
-      // FIXME: We really want to check hasTypeParameter here, but the
-      // GenericSignatureBuilder isn't ready for that.
-      if (!first->isTypeParameter()) {
-        // When the second is not a type parameter either, drop the requirement.
-        // If the types were different, this requirement will be unsatisfiable.
-        if (!second->isTypeParameter()) continue;
-
-        // Put the type parameter first.
-        std::swap(first, second);
-      }
-
-      builder.addRequirement(Requirement(RequirementKind::SameType,
-                                         first, second),
-                             source);
-      break;
-    }
-    }
+  for (auto &req : reqSig->getRequirements()) {
+    builder.addRequirement(req, source, &reqToSyntheticEnvMap);
   }
 
   // Finalize the generic signature builder.

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -295,3 +295,37 @@ struct X18: P18, P17 {
 struct X19<T: P18> where T == T.A {
   func foo<U>(_: U) where T == X18 { }
 }
+
+// rdar://problem/31520386
+protocol P20 { }
+
+struct X20<T: P20> { }
+
+// CHECK-LABEL: .X21.f@
+// CHECK: Generic signature: <T, U, V where T : P20, U == X20<T>>
+// CHECK: Canonical generic signature: <τ_0_0, τ_0_1, τ_1_0 where τ_0_0 : P20, τ_0_1 == X20<τ_0_0>>
+struct X21<T, U> {
+  func f<V>(_: V) where U == X20<T> { }
+}
+
+struct X22<T, U> {
+  func g<V>(_: V) where T: P20, // expected-warning{{redundant conformance constraint 'T': 'P20'}}
+                  U == X20<T> { } // expected-note{{conformance constraint 'T': 'P20' inferred from type here}}
+}
+
+// CHECK: Generic signature: <Self where Self : P22>
+// CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : P22>
+// CHECK: Protocol requirement signature:
+// CHECK: .P22@
+// CHECK-NEXT: Requirement signature: <Self where Self.B : P20, Self.A == X20<Self.B>>
+// CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0.B : P20, τ_0_0.A == X20<τ_0_0.B>>
+protocol P22 {
+  associatedtype A
+  associatedtype B where A == X20<B>
+}
+
+protocol P23 {
+  associatedtype A
+  associatedtype B: P20 // expected-warning{{redundant conformance constraint 'Self.B': 'P20'}}
+    where A == X20<B> // expected-note{{conformance constraint 'Self.B': 'P20' inferred from type here}}
+}

--- a/test/decl/protocol/req/recursion.swift
+++ b/test/decl/protocol/req/recursion.swift
@@ -98,6 +98,10 @@ struct S4<A: PI> : I where A : I {
 }
 
 struct S5<A: PI> : I where A : I, A.T == S4<A> {
+// expected-warning@-1{{redundant conformance constraint 'A': 'I'}}
+// expected-warning@-2{{redundant conformance constraint 'A': 'PI'}}
+// expected-note@-3{{conformance constraint 'A': 'PI' inferred from type here}}
+// expected-note@-4{{conformance constraint 'A': 'I' inferred from type here}}
 }
 
 // Used to hit ArchetypeBuilder assertions


### PR DESCRIPTION
When a requirement mentions a concrete type, that type might utter other types (e.g., `Set<T>`) that infer requirements (here, `T: Hashable`). Perform requirement inference for such types.

Part of rdar://problem/31520386.