### PR TITLE
Tiny bit more progress on IRGen support for subclass existentials

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -528,7 +528,10 @@ ERROR(sil_member_decl_type_mismatch,none,
       "member defined with mismatching type %0 (expected %1)", (Type, Type))
 ERROR(sil_substitution_mismatch,none,
       "substitution replacement type %0 does not conform to protocol %1",
-      (Type, DeclName))
+      (Type, Type))
+ERROR(sil_not_class,none,
+      "substitution replacement type %0 is not a class type",
+      (Type))
 ERROR(sil_missing_substitutions,none,
       "missing substitutions", ())
 ERROR(sil_too_many_substitutions,none,

--- a/include/swift/AST/Type.h
+++ b/include/swift/AST/Type.h
@@ -351,8 +351,6 @@ class CanType : public Type {
   static bool isReferenceTypeImpl(CanType type, bool functionsCount);
   static bool isExistentialTypeImpl(CanType type);
   static bool isAnyExistentialTypeImpl(CanType type);
-  static void getExistentialTypeProtocolsImpl(CanType type,
-                                    SmallVectorImpl<ProtocolDecl*> &protocols);
   static bool isObjCExistentialTypeImpl(CanType type);
   static CanType getAnyOptionalObjectTypeImpl(CanType type,
                                               OptionalTypeKind &kind);
@@ -405,11 +403,6 @@ public:
   bool isAnyExistentialType() const {
     return isAnyExistentialTypeImpl(*this);
   }
-
-  /// Given that this type is an existential, return its
-  /// protocols in a canonical order.
-  void getExistentialTypeProtocols(
-      SmallVectorImpl<ProtocolDecl *> &protocols);
 
   /// Break an existential down into a set of constraints.
   ExistentialLayout getExistentialLayout();

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -586,10 +586,6 @@ public:
   /// bound.
   bool isClassExistentialType();
 
-  /// Given that this type is an existential type, produce
-  /// its list of protocols.
-  void getExistentialTypeProtocols(SmallVectorImpl<ProtocolDecl *> &protocols);
-
   /// Break an existential down into a set of constraints.
   ExistentialLayout getExistentialLayout();
 

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -1128,11 +1128,10 @@ public:
         abort();
       }
 
-      SmallVector<ProtocolDecl*, 1> protocols;
-      srcTy->getExistentialTypeProtocols(protocols);
-
-      if (protocols.size() != 1
-          || !protocols[0]->isObjC()) {
+      auto layout = srcTy->getExistentialLayout();
+      if (layout.superclass ||
+          !layout.isObjC() ||
+          layout.getProtocols().size() != 1) {
         Out << "ProtocolMetatypeToObject with non-ObjC-protocol metatype:\n";
         E->print(Out);
         Out << "\n";

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -208,22 +208,6 @@ bool TypeBase::allowsOwnership() {
   return getCanonicalType().isAnyClassReferenceType();
 }
 
-void TypeBase::getExistentialTypeProtocols(
-                                   SmallVectorImpl<ProtocolDecl*> &protocols) {
-  getCanonicalType().getExistentialTypeProtocols(protocols);
-}
-
-void CanType::getExistentialTypeProtocols(
-                                   SmallVectorImpl<ProtocolDecl*> &protocols) {
-  // FIXME: Remove this completely
-  auto layout = getExistentialLayout();
-  assert(!layout.superclass && "Subclass existentials not fully supported yet");
-  assert((!layout.requiresClass || layout.requiresClassImplied) &&
-         "Explicit AnyObject should not appear yet");
-  for (auto proto : layout.getProtocols())
-    protocols.push_back(proto->getDecl());
-}
-
 ExistentialLayout::ExistentialLayout(ProtocolType *type) {
   assert(type->isCanonical());
 

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2621,7 +2621,7 @@ void ArchetypeType::populateNestedTypes() const {
   ProtocolType::visitAllProtocols(getConformsTo(),
                                   [&](ProtocolDecl *proto) -> bool {
     // Objective-C protocols don't have type members.
-    if (proto->hasClangNode()) return false;
+    if (proto->isObjC()) return false;
 
     for (auto member : proto->getMembers()) {
       if (auto assocType = dyn_cast<AssociatedTypeDecl>(member)) {

--- a/lib/IRGen/GenArchetype.cpp
+++ b/lib/IRGen/GenArchetype.cpp
@@ -277,32 +277,28 @@ llvm::Value *irgen::emitAssociatedTypeMetadataRef(IRGenFunction &IGF,
 const TypeInfo *TypeConverter::convertArchetypeType(ArchetypeType *archetype) {
   assert(isExemplarArchetype(archetype) && "lowering non-exemplary archetype");
 
-  LayoutConstraint LayoutInfo = archetype->getLayoutConstraint();
+  auto layout = archetype->getLayoutConstraint();
 
   // If the archetype is class-constrained, use a class pointer
   // representation.
   if (archetype->requiresClass() ||
-      (LayoutInfo && LayoutInfo->isRefCounted())) {
-    ReferenceCounting refcount;
-    llvm::PointerType *reprTy;
+      (layout && layout->isRefCounted())) {
+    auto refcount = getReferenceCountingForType(IGM, CanType(archetype));
 
-    if (!IGM.ObjCInterop) {
-      refcount = ReferenceCounting::Native;
-      reprTy = IGM.RefCountedPtrTy;
-    } else {
-      refcount = ReferenceCounting::Unknown;
-      reprTy = IGM.UnknownRefCountedPtrTy;
-    }
+    llvm::PointerType *reprTy;
 
     // If the archetype has a superclass constraint, it has at least the
     // retain semantics of its superclass, and it can be represented with
     // the supertype's pointer type.
-    if (Type super = archetype->getSuperclass()) {
-      ClassDecl *superClass = super->getClassOrBoundGenericClass();
-      refcount = getReferenceCountingForClass(IGM, superClass);
-
+    if (auto super = archetype->getSuperclass()) {
       auto &superTI = IGM.getTypeInfoForUnlowered(super);
       reprTy = cast<llvm::PointerType>(superTI.StorageType);
+    } else {
+      if (refcount == ReferenceCounting::Native) {
+        reprTy = IGM.RefCountedPtrTy;
+      } else {
+        reprTy = IGM.UnknownRefCountedPtrTy;
+      }
     }
 
     // As a hack, assume class archetypes never have spare bits. There's a
@@ -320,9 +316,9 @@ const TypeInfo *TypeConverter::convertArchetypeType(ArchetypeType *archetype) {
 
   // If the archetype is trivial fixed-size layout-constrained, use a fixed size
   // representation.
-  if (LayoutInfo && LayoutInfo->isFixedSizeTrivial()) {
-    Size size(LayoutInfo->getTrivialSizeInBytes());
-    Alignment align(LayoutInfo->getTrivialSizeInBytes());
+  if (layout && layout->isFixedSizeTrivial()) {
+    Size size(layout->getTrivialSizeInBytes());
+    Alignment align(layout->getTrivialSizeInBytes());
     auto spareBits =
       SpareBitVector::getConstant(size.getValueInBits(), false);
     // Get an integer type of the required size.
@@ -336,7 +332,7 @@ const TypeInfo *TypeConverter::convertArchetypeType(ArchetypeType *archetype) {
   // If the archetype is a trivial layout-constrained, use a POD
   // representation. This type is not loadable, but it is known
   // to be a POD.
-  if (LayoutInfo && LayoutInfo->isAddressOnlyTrivial()) {
+  if (layout && layout->isAddressOnlyTrivial()) {
     // TODO: Create NonFixedSizeArchetypeTypeInfo and return it.
   }
 

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -63,20 +63,25 @@ static ClassDecl *getRootClass(ClassDecl *theClass) {
   return theClass;
 }
 
-/// What reference counting mechanism does a class have?
-ReferenceCounting irgen::getReferenceCountingForClass(IRGenModule &IGM,
-                                                      ClassDecl *theClass) {
+/// What reference counting mechanism does a class-like type have?
+ReferenceCounting irgen::getReferenceCountingForType(IRGenModule &IGM,
+                                                     CanType type) {
   // If ObjC interop is disabled, we have a Swift refcount.
   if (!IGM.ObjCInterop)
     return ReferenceCounting::Native;
 
-  // NOTE: if you change this, change Type::usesNativeReferenceCounting.
-  // If the root class is implemented in swift, then we have a swift
-  // refcount; otherwise, we have an ObjC refcount.
-  if (getRootClass(theClass)->hasKnownSwiftImplementation())
+  if (type->usesNativeReferenceCounting(ResilienceExpansion::Maximal))
     return ReferenceCounting::Native;
 
-  return ReferenceCounting::ObjC;
+  // Class-constrained archetypes and existentials that don't use
+  // native reference counting and yet have a superclass must be
+  // using ObjC reference counting.
+  auto superclass = type->getSuperclass(nullptr);
+  if (superclass)
+    return ReferenceCounting::ObjC;
+
+  // Otherwise, it could be either one.
+  return ReferenceCounting::Unknown;
 }
 
 /// What isa encoding mechanism does a type have?
@@ -2087,7 +2092,7 @@ const TypeInfo *
 TypeConverter::convertClassType(CanType type, ClassDecl *D) {
   llvm::StructType *ST = IGM.createNominalType(type);
   llvm::PointerType *irType = ST->getPointerTo();
-  ReferenceCounting refcount = ::getReferenceCountingForClass(IGM, D);
+  ReferenceCounting refcount = ::getReferenceCountingForType(IGM, type);
   
   SpareBitVector spareBits;
   

--- a/lib/IRGen/GenClass.h
+++ b/lib/IRGen/GenClass.h
@@ -132,11 +132,11 @@ namespace irgen {
   /// correspond to the runtime alignment of instances of the class.
   llvm::Constant *tryEmitClassConstantFragileInstanceAlignMask(IRGenModule &IGM,
                                                         ClassDecl *theClass);
-  
-  /// What reference counting mechanism does a class use?
-  ReferenceCounting getReferenceCountingForClass(IRGenModule &IGM,
-                                                 ClassDecl *theClass);
-  
+
+  /// What reference counting mechanism does a class-like type use?
+  ReferenceCounting getReferenceCountingForType(IRGenModule &IGM,
+                                                CanType type);
+
   /// What isa-encoding mechanism does a type use?
   IsaEncoding getIsaEncodingForType(IRGenModule &IGM, CanType type);
   

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -388,7 +388,8 @@ class FieldTypeMetadataBuilder : public ReflectionMetadataBuilder {
     auto kind = FieldDescriptorKind::Struct;
 
     if (auto CD = dyn_cast<ClassDecl>(NTD)) {
-      auto RC = getReferenceCountingForClass(IGM, const_cast<ClassDecl *>(CD));
+      auto type = CD->getDeclaredType()->getCanonicalType();
+      auto RC = getReferenceCountingForType(IGM, type);
       if (RC == ReferenceCounting::ObjC)
         kind = FieldDescriptorKind::ObjCClass;
       else

--- a/lib/Sema/ITCDecl.cpp
+++ b/lib/Sema/ITCDecl.cpp
@@ -19,6 +19,7 @@
 #include "swift/Sema/IterativeTypeChecker.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/Decl.h"
+#include "swift/AST/ExistentialLayout.h"
 #include <tuple>
 using namespace swift;
 
@@ -256,9 +257,12 @@ void IterativeTypeChecker::processInheritedProtocols(
     // Collect existential types.
     // FIXME: We'd prefer to keep what the user wrote here.
     if (inherited.getType()->isExistentialType()) {
-      SmallVector<ProtocolDecl *, 4> protocols;
-      inherited.getType()->getExistentialTypeProtocols(protocols);
-      for (auto inheritedProtocol: protocols) {
+      auto layout = inherited.getType()->getExistentialLayout();
+      assert(!layout.superclass && "Need to redo inheritance clause "
+             "typechecking");
+      for (auto inheritedProtocolTy: layout.getProtocols()) {
+        auto *inheritedProtocol = inheritedProtocolTy->getDecl();
+
         if (inheritedProtocol == protocol ||
             inheritedProtocol->inheritsFrom(protocol)) {
           if (!diagnosedCircularity) {

--- a/test/IRGen/subclass_existentials.sil
+++ b/test/IRGen/subclass_existentials.sil
@@ -1,0 +1,71 @@
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -enable-experimental-subclass-existentials | %FileCheck %s --check-prefix=CHECK-%target-runtime --check-prefix=CHECK
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+class C {}
+protocol P {}
+
+class D : C, P {}
+
+// Make sure we use native reference counting when the existential has a Swift
+// class bound.
+
+// CHECK-objc-LABEL: define{{( protected)?}} swiftcc void @checkRefcounting(%T21subclass_existentials1CC*, i8**, %objc_object*, i8**)
+// CHECK-native-LABEL: define{{( protected)?}} swiftcc void @checkRefcounting(%T21subclass_existentials1CC*, i8**, %swift.refcounted*, i8**)
+// CHECK-NEXT: entry:
+// CHECK-objc-NEXT:   call void @swift_unknownRelease(%objc_object* %2)
+// CHECK-native-NEXT: call void @swift_rt_swift_release(%swift.refcounted* %2)
+// CHECK-NEXT:   call void bitcast (void (%swift.refcounted*)* @swift_rt_swift_release to void (%T21subclass_existentials1CC*)*)(%T21subclass_existentials1CC* %0)
+// CHECK-NEXT:   ret void
+
+sil @checkRefcounting : $@convention(thin) (@owned C & P, @owned AnyObject & P) -> () {
+bb0(%0 : $C & P, %1 : $AnyObject & P):
+  destroy_value %1 : $AnyObject & P
+  destroy_value %0 : $C & P
+  %6 = tuple ()
+  return %6 : $()
+}
+
+// Make sure we call the runtime function with the right arguments when we
+// instantiate metadata for a subclass existential.
+
+sil @takesMetadata : $@convention(thin) <T> (@thick T.Type) -> ()
+
+// CHECK-LABEL: define{{( protected)?}} swiftcc void @checkMetadata()
+// CHECK-NEXT: entry:
+// CHECK-NEXT:   %0 = call %swift.type* @_T021subclass_existentials1P_AA1CCXcMa()
+// CHECK-NEXT:   call swiftcc void @takesMetadata(%swift.type* %0, %swift.type* %0)
+// CHECK-NEXT:   ret void
+
+// CHECK-LABEL: define linkonce_odr hidden %swift.type* @_T021subclass_existentials1P_AA1CCXcMa()
+// CHECK:      entry:
+// CHECK-NEXT:   [[PROTOCOL_ARRAY:%.*]] = alloca [1 x %swift.protocol*]
+// CHECK:      cacheIsNull:
+// CHECK:        [[PROTOCOLS:%.*]] = bitcast [1 x %swift.protocol*]* [[PROTOCOL_ARRAY]] to %swift.protocol**
+// CHECK-NEXT:   [[PROTOCOL:%.*]] = getelementptr inbounds %swift.protocol*, %swift.protocol** [[PROTOCOLS]], i32 0
+// CHECK-NEXT:   store %swift.protocol* @_T021subclass_existentials1PMp, %swift.protocol** [[PROTOCOL]]
+// CHECK-NEXT:   [[SUPERCLASS:%.*]] = call %swift.type* @_T021subclass_existentials1CCMa()
+// CHECK-NEXT:   [[METATYPE:%.*]] = call %swift.type* @swift_rt_swift_getExistentialTypeMetadata(i1 false, %swift.type* [[SUPERCLASS]], {{i32|i64}} 1, %swift.protocol** [[PROTOCOLS]])
+// CHECK:        ret
+
+sil @checkMetadata : $@convention(thin) () -> () {
+bb0:
+  %0 = function_ref @takesMetadata : $@convention(thin) <τ_0_0> (@thick τ_0_0.Type) -> ()
+  %1 = metatype $@thin (C & P).Protocol
+  %2 = metatype $@thick (C & P).Protocol
+  %3 = apply %0<(C & P)>(%2) : $@convention(thin) <τ_0_0> (@thick τ_0_0.Type) -> ()
+  %4 = tuple ()
+  return %4 : $()
+}
+
+sil @eraseToExistential : $@convention(thin) (@owned D) -> @owned C & P {
+bb0(%0 : $D):
+  %2 = init_existential_ref %0 : $D : $D, $C & P
+  return %2 : $C & P
+}
+
+sil_vtable C {}
+sil_vtable D {}

--- a/test/IRGen/type_layout_reference_storage.swift
+++ b/test/IRGen/type_layout_reference_storage.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir %s | %FileCheck %s --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir -enable-experimental-subclass-existentials %s | %FileCheck %s --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK
 
 class C {}
 protocol P: class {}
@@ -6,7 +6,7 @@ protocol Q: class {}
 
 // CHECK: @_T029type_layout_reference_storage26ReferenceStorageTypeLayoutVMP = internal global {{.*}} @create_generic_metadata_ReferenceStorageTypeLayout
 // CHECK: define private %swift.type* @create_generic_metadata_ReferenceStorageTypeLayout
-struct ReferenceStorageTypeLayout<T> {
+struct ReferenceStorageTypeLayout<T, Native : C, Unknown : AnyObject> {
   var z: T
 
   // -- Known-Swift-refcounted type
@@ -18,6 +18,16 @@ struct ReferenceStorageTypeLayout<T> {
   weak            var cwo: C?
   // CHECK: store i8** getelementptr inbounds (i8*, i8** @_T0BoSgXwWV, i32 17)
   weak            var cwi: C!
+
+  // -- Known-Swift-refcounted archetype
+  // CHECK: store i8** getelementptr inbounds (i8*, i8** @_T0BoXoWV, i32 17)
+  unowned(safe)   var nc:  Native
+  // CHECK: store i8** getelementptr inbounds (i8*, i8** @_T0BomWV, i32 17)
+  unowned(unsafe) var nu:  Native
+  // CHECK: store i8** getelementptr inbounds (i8*, i8** @_T0BoSgXwWV, i32 17)
+  weak            var nwo: Native?
+  // CHECK: store i8** getelementptr inbounds (i8*, i8** @_T0BoSgXwWV, i32 17)
+  weak            var nwi: Native!
 
   // -- Open-code layout for protocol types with witness tables.
   //   Note that the layouts for unowned(safe) references are
@@ -48,6 +58,19 @@ struct ReferenceStorageTypeLayout<T> {
   // CHECK-32: store i8** getelementptr inbounds ([3 x i8*], [3 x i8*]* @type_layout_12_4_[[WEAK_XI]], i32 0, i32 0)
   weak            var pqwi: (P & Q)!
 
+  // CHECK-64: store i8** getelementptr inbounds ([4 x i8*], [4 x i8*]* @type_layout_24_8_[[UNOWNED_XI]]{{(,|_bt,)}} i32 0, i32 0)
+  // CHECK-32: store i8** getelementptr inbounds ([4 x i8*], [4 x i8*]* @type_layout_12_4_[[UNOWNED_XI]]{{(,|_bt,)}} i32 0, i32 0)
+  unowned(safe)   var pqcs:  P & Q & C
+  // CHECK-64: store i8** getelementptr inbounds ([4 x i8*], [4 x i8*]* @type_layout_24_8_[[REF_XI]]_pod, i32 0, i32 0)
+  // CHECK-32: store i8** getelementptr inbounds ([4 x i8*], [4 x i8*]* @type_layout_12_4_[[REF_XI]]_pod, i32 0, i32 0)
+  unowned(unsafe) var pqcu:  P & Q & C
+  // CHECK-64: store i8** getelementptr inbounds ([4 x i8*], [4 x i8*]* @type_layout_24_8_[[WEAK_XI]], i32 0, i32 0)
+  // CHECK-32: store i8** getelementptr inbounds ([3 x i8*], [3 x i8*]* @type_layout_12_4_[[WEAK_XI]], i32 0, i32 0)
+  weak            var pqcwo: (P & Q & C)?
+  // CHECK-64: store i8** getelementptr inbounds ([4 x i8*], [4 x i8*]* @type_layout_24_8_[[WEAK_XI]], i32 0, i32 0)
+  // CHECK-32: store i8** getelementptr inbounds ([3 x i8*], [3 x i8*]* @type_layout_12_4_[[WEAK_XI]], i32 0, i32 0)
+  weak            var pqcwi: (P & Q & C)!
+
   // -- Unknown-refcounted existential without witness tables.
   // CHECK: store i8** getelementptr inbounds (i8*, i8** @_T0[[UNKNOWN:B[Oo]]]XoWV, i32 17)
   unowned(safe)   var aos:  AnyObject
@@ -57,4 +80,14 @@ struct ReferenceStorageTypeLayout<T> {
   weak            var aowo: AnyObject?
   // CHECK: store i8** getelementptr inbounds (i8*, i8** @_T0[[UNKNOWN]]SgXwWV, i32 17)
   weak            var aowi: AnyObject!
+
+  // -- Unknown-refcounted archetype
+  // CHECK: store i8** getelementptr inbounds (i8*, i8** @_T0[[UNKNOWN:B[Oo]]]XoWV, i32 17)
+  unowned(safe)   var us:  Unknown
+  // CHECK: store i8** getelementptr inbounds (i8*, i8** @_T0BomWV, i32 17)
+  unowned(unsafe) var uu:  Unknown
+  // CHECK: store i8** getelementptr inbounds (i8*, i8** @_T0[[UNKNOWN]]SgXwWV, i32 17)
+  weak            var uwo: Unknown?
+  // CHECK: store i8** getelementptr inbounds (i8*, i8** @_T0[[UNKNOWN]]SgXwWV, i32 17)
+  weak            var uwi: Unknown!
 }

--- a/test/IRGen/type_layout_reference_storage_objc.swift
+++ b/test/IRGen/type_layout_reference_storage_objc.swift
@@ -1,8 +1,9 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-ir %s -enable-experimental-subclass-existentials | %FileCheck %s
 // REQUIRES: objc_interop
 
 import Foundation
 
+class NativeClass {}
 class C: NSObject {}
 @objc protocol P {}
 @objc protocol Q {}
@@ -10,7 +11,7 @@ protocol NonObjC: class {}
 
 // CHECK: @_T034type_layout_reference_storage_objc26ReferenceStorageTypeLayoutVMP = internal global {{.*}} @create_generic_metadata_ReferenceStorageTypeLayout
 // CHECK: define private %swift.type* @create_generic_metadata_ReferenceStorageTypeLayout
-struct ReferenceStorageTypeLayout<T> {
+struct ReferenceStorageTypeLayout<T, ObjC: C> {
   var z: T
 
   // -- ObjC-refcounted class
@@ -22,6 +23,16 @@ struct ReferenceStorageTypeLayout<T> {
   weak            var cwo: C?
   // CHECK: store i8** getelementptr inbounds (i8*, i8** @_T0BOSgXwWV, i32 17)
   weak            var cwi: C!
+
+  // -- ObjC-refcounted archetype
+  // CHECK: store i8** getelementptr inbounds (i8*, i8** @_T0BOXoWV, i32 17)
+  unowned(safe)   var os:  ObjC
+  // CHECK: store i8** getelementptr inbounds (i8*, i8** @_T0BomWV, i32 17)
+  unowned(unsafe) var ou:  ObjC
+  // CHECK: store i8** getelementptr inbounds (i8*, i8** @_T0BOSgXwWV, i32 17)
+  weak            var owo: ObjC?
+  // CHECK: store i8** getelementptr inbounds (i8*, i8** @_T0BOSgXwWV, i32 17)
+  weak            var owi: ObjC!
 
   // -- Pure ObjC protocols are unknown-refcounted
   // CHECK: store i8** getelementptr inbounds (i8*, i8** @_T0BOXoWV, i32 17)
@@ -42,6 +53,16 @@ struct ReferenceStorageTypeLayout<T> {
   // CHECK: store i8** getelementptr inbounds (i8*, i8** @_T0BOSgXwWV, i32 17)
   weak            var pqwi: (P & Q)!
 
+  // -- Composition with ObjC protocol and native class is native-refcounted
+  // CHECK: store i8** getelementptr inbounds (i8*, i8** @_T0BoXoWV, i32 17)
+  unowned(safe)   var pncs:  (P & NativeClass)
+  // CHECK: store i8** getelementptr inbounds (i8*, i8** @_T0BomWV, i32 17)
+  unowned(unsafe) var pncu:  (P & NativeClass)
+  // CHECK: store i8** getelementptr inbounds (i8*, i8** @_T0BoSgXwWV, i32 17)
+  weak            var pncwo: (P & NativeClass)?
+  // CHECK: store i8** getelementptr inbounds (i8*, i8** @_T0BoSgXwWV, i32 17)
+  weak            var pncwi: (P & NativeClass)!
+
   // -- Open-code layouts when there are witness tables.
   // CHECK-64: store i8** getelementptr inbounds ([4 x i8*], [4 x i8*]* @type_layout_16_8_7fffffff_bt, i32 0, i32 0)
   unowned(safe)   var pqrs:  P & Q & NonObjC
@@ -51,4 +72,13 @@ struct ReferenceStorageTypeLayout<T> {
   weak            var pqrwo: (P & Q & NonObjC)?
   // CHECK-64: store i8** getelementptr inbounds ([4 x i8*], [4 x i8*]* @type_layout_16_8_1, i32 0, i32 0)
   weak            var pqrwi: (P & Q & NonObjC)!
+
+  // CHECK-64: store i8** getelementptr inbounds ([4 x i8*], [4 x i8*]* @type_layout_16_8_7fffffff_bt, i32 0, i32 0)
+  unowned(safe)   var pqrncs:  P & Q & NonObjC & NativeClass
+  // CHECK-64: store i8** getelementptr inbounds ([4 x i8*], [4 x i8*]* @type_layout_16_8_7fffffff_pod, i32 0, i32 0)
+  unowned(unsafe) var pqrncu:  P & Q & NonObjC & NativeClass
+  // CHECK-64: store i8** getelementptr inbounds ([4 x i8*], [4 x i8*]* @type_layout_16_8_1, i32 0, i32 0)
+  weak            var pqrncwo: (P & Q & NonObjC & NativeClass)?
+  // CHECK-64: store i8** getelementptr inbounds ([4 x i8*], [4 x i8*]* @type_layout_16_8_1, i32 0, i32 0)
+  weak            var pqrncwi: (P & Q & NonObjC & NativeClass)!
 }


### PR DESCRIPTION
The next step after https://github.com/apple/swift/pull/8770. Make sure we use the right reference counting style for subclass existentials and class-constrained archetypes. Also, finally remove the `getExistentialTypeProtocols()` utility method.