### PR TITLE
emitLocalVariableWithCleanups refactor

### DIFF
--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -200,7 +200,7 @@ void SILGenFunction::emitValueConstructor(ConstructorDecl *ctor) {
          && "can't emit a class ctor here");
 
   // Allocate the local variable for 'self'.
-  emitLocalVariableWithCleanup(selfDecl, false)->finishInitialization(*this);
+  emitLocalVariableWithCleanup(selfDecl, None)->finishInitialization(*this);
   
   // Mark self as being uninitialized so that DI knows where it is and how to
   // check for it.
@@ -575,7 +575,7 @@ void SILGenFunction::emitClassConstructorInitializer(ConstructorDecl *ctor) {
 
   if (NeedsBoxForSelf) {
     // Allocate the local variable for 'self'.
-    emitLocalVariableWithCleanup(selfDecl, false)->finishInitialization(*this);
+    emitLocalVariableWithCleanup(selfDecl, None)->finishInitialization(*this);
 
     auto &SelfVarLoc = VarLocs[selfDecl];
     SelfVarLoc.value = B.createMarkUninitialized(selfDecl,

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -200,18 +200,10 @@ void SILGenFunction::emitValueConstructor(ConstructorDecl *ctor) {
          && "can't emit a class ctor here");
 
   // Allocate the local variable for 'self'.
-  emitLocalVariableWithCleanup(selfDecl, None)->finishInitialization(*this);
-  
-  // Mark self as being uninitialized so that DI knows where it is and how to
-  // check for it.
-  SILValue selfLV;
-  {
-    auto &SelfVarLoc = VarLocs[selfDecl];
-    auto MUIKind =  isDelegating ? MarkUninitializedInst::DelegatingSelf
-                                 : MarkUninitializedInst::RootSelf;
-    selfLV = B.createMarkUninitialized(selfDecl, SelfVarLoc.value, MUIKind);
-    SelfVarLoc.value = selfLV;
-  }
+  auto MUIKind = isDelegating ? MarkUninitializedInst::DelegatingSelf
+                              : MarkUninitializedInst::RootSelf;
+  emitLocalVariableWithCleanup(selfDecl, MUIKind)->finishInitialization(*this);
+  SILValue selfLV = VarLocs[selfDecl].value;
 
   // Emit the prolog.
   emitProlog(ctor->getParameterList(1),

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -369,7 +369,8 @@ public:
   /// Sets up an initialization for the allocated box. This pushes a
   /// CleanupUninitializedBox cleanup that will be replaced when
   /// initialization is completed.
-  LocalVariableInitialization(VarDecl *decl, bool NeedsMarkUninit,
+  LocalVariableInitialization(VarDecl *decl,
+                              Optional<MarkUninitializedInst::Kind> kind,
                               unsigned ArgNo, SILGenFunction &SGF)
       : decl(decl), SGF(SGF) {
     assert(decl->getDeclContext()->isLocalContext() &&
@@ -390,8 +391,8 @@ public:
     SILValue addr = SGF.B.createProjectBox(decl, allocBox, 0);
 
     // Mark the memory as uninitialized, so DI will track it for us.
-    if (NeedsMarkUninit)
-      addr = SGF.B.createMarkUninitializedVar(decl, addr);
+    if (kind)
+      addr = SGF.B.createMarkUninitialized(decl, addr, kind.getValue());
 
     /// Remember that this is the memory location that we're emitting the
     /// decl to.
@@ -1096,7 +1097,11 @@ InitializationPtr SILGenFunction::emitInitializationForVarDecl(VarDecl *vd) {
     VarLocs[vd] = SILGenFunction::VarLoc::get(addr);
     Result = InitializationPtr(new KnownAddressInitialization(addr));
   } else {
-    Result = emitLocalVariableWithCleanup(vd, isUninitialized);
+    Optional<MarkUninitializedInst::Kind> uninitKind;
+    if (isUninitialized) {
+      uninitKind = MarkUninitializedInst::Kind::Var;
+    }
+    Result = emitLocalVariableWithCleanup(vd, uninitKind);
   }
 
   // If we're initializing a weak or unowned variable, this requires a change in
@@ -1392,11 +1397,10 @@ void SILGenModule::emitExternalDefinition(Decl *d) {
 }
 
 /// Create a LocalVariableInitialization for the uninitialized var.
-InitializationPtr
-SILGenFunction::emitLocalVariableWithCleanup(VarDecl *vd, bool NeedsMarkUninit,
-                                             unsigned ArgNo) {
+InitializationPtr SILGenFunction::emitLocalVariableWithCleanup(
+    VarDecl *vd, Optional<MarkUninitializedInst::Kind> kind, unsigned ArgNo) {
   return InitializationPtr(
-      new LocalVariableInitialization(vd, NeedsMarkUninit, ArgNo, *this));
+      new LocalVariableInitialization(vd, kind, ArgNo, *this));
 }
 
 /// Create an Initialization for an uninitialized temporary.

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1658,7 +1658,8 @@ public:
   /// \param ArgNo optionally describes this function argument's
   /// position for debug info.
   std::unique_ptr<Initialization>
-  emitLocalVariableWithCleanup(VarDecl *D, bool NeedsMarkUninit,
+  emitLocalVariableWithCleanup(VarDecl *D,
+                               Optional<MarkUninitializedInst::Kind> kind,
                                unsigned ArgNo = 0);
 
   /// Emit the allocation for a local temporary, provides an


### PR DESCRIPTION
This PR does the following:

1. It refactors emitLocalVariablesWithCleanup so that it takes an optional mark uninitialized kind parameter.
2. It changes SILGenConstructor to use the new cleaned up APIs mark uninitialized kind parameter to create its mark uninitialized instead of doing the work later afterwards.

rdar://31521023