### PR TITLE
[lit.cfg] Add SIL_TEST_OPTIONS env var.

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -343,6 +343,10 @@ if test_options:
     config.swift_test_options += ' '
     config.swift_test_options += test_options
 
+config.sil_test_options = os.environ.get('SIL_TEST_OPTIONS')
+if not config.sil_test_options:
+    config.sil_test_options = ''
+
 clang_module_cache_path = tempfile.mkdtemp(prefix="swift-testsuite-clang-module-cache")
 mcp_opt = "-module-cache-path %r" % clang_module_cache_path
 clang_mcp_opt = "-fmodules-cache-path=%r" % clang_module_cache_path
@@ -361,7 +365,7 @@ config.substitutions.append( ('%swift_driver_plain', "%r" % config.swift) )
 config.substitutions.append( ('%swiftc_driver_plain', "%r" % config.swiftc) )
 config.substitutions.append( ('%swift_driver', "env SDKROOT= %r %s %s" % (config.swift, mcp_opt, config.swift_test_options)) )
 config.substitutions.append( ('%swiftc_driver', "env SDKROOT= %r %s %s" % (config.swiftc, mcp_opt, config.swift_test_options)) )
-config.substitutions.append( ('%sil-opt', "%r %s" % (config.sil_opt, mcp_opt)) )
+config.substitutions.append( ('%sil-opt', "%r %s %s" % (config.sil_opt, mcp_opt, config.sil_test_options)) )
 config.substitutions.append( ('%sil-func-extractor', "%r %s" % (config.sil_func_extractor, mcp_opt)) )
 config.substitutions.append( ('%sil-llvm-gen', "%r %s" % (config.sil_llvm_gen, mcp_opt)) )
 config.substitutions.append( ('%sil-nm', "%r %s" % (config.sil_nm, mcp_opt)) )
@@ -718,8 +722,8 @@ if run_vendor == 'apple':
     subst_target_swift_frontend_mock_sdk_after = \
         target_options_for_mock_sdk_after
     config.target_sil_opt = (
-        "%s %s %s" %
-        (xcrun_prefix, config.sil_opt, target_options))
+        "%s %s %s %s" %
+        (xcrun_prefix, config.sil_opt, target_options, config.sil_test_options))
     config.target_swift_ide_test = (
         "%s %s %s %s" %
         (xcrun_prefix, config.swift_ide_test, target_options, ccp_opt))
@@ -787,8 +791,8 @@ elif run_os in ['linux-gnu', 'linux-gnueabihf', 'freebsd', 'windows-cygnus', 'wi
         config.available_features.add('interpret')
         config.environment['SWIFT_INTERPRETER'] = config.swift
     config.target_sil_opt = (
-        '%s -target %s %s %s' %
-        (config.sil_opt, config.variant_triple, resource_dir_opt, mcp_opt))
+        '%s -target %s %s %s %s' %
+        (config.sil_opt, config.variant_triple, resource_dir_opt, mcp_opt, config.sil_test_options))
     config.target_swift_ide_test = (
         '%s -target %s %s %s %s' %
         (config.swift_ide_test, config.variant_triple, resource_dir_opt,
@@ -840,8 +844,8 @@ elif run_os == 'linux-androideabi':
         config.swift_src_root, 'utils', 'android', 'adb_test_runner.py')
     # FIXME: Include -sdk in this invocation.
     config.target_sil_opt = (
-        '%s -target %s %s %s' %
-        (config.sil_opt, config.variant_triple, resource_dir_opt, mcp_opt))
+        '%s -target %s %s %s %s' %
+        (config.sil_opt, config.variant_triple, resource_dir_opt, mcp_opt, config.sil_test_options))
     config.target_swift_ide_test = (
         '%s -target %s %s %s %s' %
         (config.swift_ide_test, config.variant_triple, resource_dir_opt,


### PR DESCRIPTION
This is analogous to SWIFT_TEST_OPTIONS.
Sometimes we need to pass a driver option for testing
and that option needs to be consistent across `swiftc`
and `sil-opt` tests. e.g. "-enforce-exclusivity=unchecked".
