### PR TITLE
[sil-generic-specializer] Don’t build a new generic signature in case of a full specialization. NFC.

### DIFF
--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -739,7 +739,7 @@ void ReabstractionInfo::specializeConcreteSubstitutions(
   auto InterfaceSubs = OrigGenericSig->getSubstitutionMap(ParamSubs);
 
   // This is a workaround for the rdar://30610428
-  if (!EnablePartialSpecialization) {
+  if (!EnablePartialSpecialization || !HasUnboundGenericParams) {
     SubstitutedType =
         Callee->getLoweredFunctionType()->substGenericArgs(M, InterfaceSubs);
     ClonerParamSubs = OriginalParamSubs;

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -1485,6 +1485,12 @@ GenericFuncSpecializer::GenericFuncSpecializer(SILFunction *GenericFunc,
 // Return an existing specialization if one exists.
 SILFunction *GenericFuncSpecializer::lookupSpecialization() {
   if (SILFunction *SpecializedF = M.lookUpFunction(ClonedName)) {
+    if (ReInfo.getSpecializedType() != SpecializedF->getLoweredFunctionType()) {
+      llvm::dbgs() << "Looking for a function: " << ClonedName << "\n"
+                   << "Expected type: " << ReInfo.getSpecializedType() << "\n"
+                   << "Found    type: "
+                   << SpecializedF->getLoweredFunctionType() << "\n";
+    }
     assert(ReInfo.getSpecializedType()
            == SpecializedF->getLoweredFunctionType() &&
            "Previously specialized function does not match expected type.");


### PR DESCRIPTION
In case of a full specialization, the specialized function does not have a generic signature. Therefore there is no need to build it.

This speeds up the compilation by avoiding doing a useless work.

Also, print more debug info when asserting during specialization lookups.