### PR TITLE
Add a functionality to produce canonical conformances and substitutions to fix a bug with SILBoxType’s generic arguments

### DIFF
--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -138,6 +138,14 @@ public:
            getState() == ProtocolConformanceState::Checking;
   }
 
+  /// Determine whether this conformance is canonical.
+  bool isCanonical() const;
+
+  /// Create a canonical conformance from the current one.
+  /// If the current conformance is canonical already, it will be returned.
+  /// Otherwise a new conformance will be created.
+  ProtocolConformance *getCanonicalConformance();
+
   /// Return true if the conformance has a witness for the given associated
   /// type.
   bool hasTypeWitness(AssociatedTypeDecl *assocType,
@@ -703,7 +711,7 @@ public:
 
   static void Profile(llvm::FoldingSetNodeID &ID, Type type,
                       ProtocolConformance *inheritedConformance) {
-    ID.AddPointer(type->getCanonicalType().getPointer());
+    ID.AddPointer(type.getPointer());
     ID.AddPointer(inheritedConformance);
   }
 

--- a/include/swift/AST/ProtocolConformanceRef.h
+++ b/include/swift/AST/ProtocolConformanceRef.h
@@ -127,6 +127,12 @@ public:
                        ProtocolConformanceRef conformance,
                        Identifier name,
                        LazyResolver *resolver);
+
+  /// Determine whether this conformance is canonical.
+  bool isCanonical() const;
+
+  /// Create a canonical conformance from the current one.
+  ProtocolConformanceRef getCanonicalConformanceRef() const;
 };
 
 } // end namespace swift

--- a/include/swift/AST/Substitution.h
+++ b/include/swift/AST/Substitution.h
@@ -48,7 +48,7 @@ public:
   
   Substitution(Type Replacement, ArrayRef<ProtocolConformanceRef> Conformance);
 
-  /// Checks whether the current substituion is canonical.
+  /// Checks whether the current substitution is canonical.
   bool isCanonical() const;
 
   /// Get the canonicalized substitution. If wasCanonical is not nullptr,

--- a/include/swift/AST/Substitution.h
+++ b/include/swift/AST/Substitution.h
@@ -48,6 +48,10 @@ public:
   
   Substitution(Type Replacement, ArrayRef<ProtocolConformanceRef> Conformance);
 
+  /// Get the canonicalized substitution. If wasCanonical is not nullptr,
+  /// store there whether the current substitution was canonical already.
+  Substitution getCanonicalSubstitution(bool *wasCanonical = nullptr) const;
+
   bool operator!=(const Substitution &other) const { return !(*this == other); }
   bool operator==(const Substitution &other) const;
   void print(llvm::raw_ostream &os,

--- a/include/swift/AST/Substitution.h
+++ b/include/swift/AST/Substitution.h
@@ -48,6 +48,9 @@ public:
   
   Substitution(Type Replacement, ArrayRef<ProtocolConformanceRef> Conformance);
 
+  /// Checks whether the current substituion is canonical.
+  bool isCanonical() const;
+
   /// Get the canonicalized substitution. If wasCanonical is not nullptr,
   /// store there whether the current substitution was canonical already.
   Substitution getCanonicalSubstitution(bool *wasCanonical = nullptr) const;

--- a/include/swift/AST/SubstitutionList.h
+++ b/include/swift/AST/SubstitutionList.h
@@ -29,9 +29,18 @@ using SubstitutionList = ArrayRef<Substitution>;
 
 void dump(SubstitutionList subs);
 
-/// Create a canonicalized substitution list.
-/// It may return the argument substitution list if it is canonical already.
-SubstitutionList getCanonicalSubstitutionList(SubstitutionList subs);
+/// Create a canonicalized substitution list from subs.
+/// subs is the substitution list to be canonicalized.
+/// canSubs is an out-parameter, which is used to store the results in case
+/// the list of substitutions was not canonical.
+/// The function returns a list of canonicalized substitutions.
+/// If the substitution list subs was canonical already, it will be returned and
+/// canSubs out-parameter will be empty.
+/// If something had to be canonicalized, then the canSubs out-parameter will be
+/// populated and the returned SubstitutionList would refer to canSubs storage.
+SubstitutionList
+getCanonicalSubstitutionList(SubstitutionList subs,
+                             SmallVectorImpl<Substitution> &canSubs);
 } // end namespace swift
 
 #endif

--- a/include/swift/AST/SubstitutionList.h
+++ b/include/swift/AST/SubstitutionList.h
@@ -29,6 +29,9 @@ using SubstitutionList = ArrayRef<Substitution>;
 
 void dump(SubstitutionList subs);
 
+/// Create a canonicalized substitution list.
+/// It may return the argument substitution list if it is canonical already.
+SubstitutionList getCanonicalSubstitutionList(SubstitutionList subs);
 } // end namespace swift
 
 #endif

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -4189,7 +4189,8 @@ CanSILBoxType SILBoxType::get(ASTContext &C,
   llvm::FoldingSetNodeID id;
 
   // Canonicalize substitutions.
-  Args = getCanonicalSubstitutionList(Args);
+  SmallVector<Substitution, 4> CanArgs;
+  Args = getCanonicalSubstitutionList(Args, CanArgs);
 
   Profile(id, Layout, Args);
 

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -4187,8 +4187,12 @@ CanSILBoxType SILBoxType::get(ASTContext &C,
                               SILLayout *Layout,
                               SubstitutionList Args) {
   llvm::FoldingSetNodeID id;
+
+  // Canonicalize substitutions.
+  Args = getCanonicalSubstitutionList(Args);
+
   Profile(id, Layout, Args);
-  
+
   // Return an existing layout if there is one.
   void *insertPos;
   auto &SILBoxTypes = C.Impl.SILBoxTypes;

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -1073,11 +1073,8 @@ bool ProtocolConformance::isCanonical() const {
 
   switch (getKind()) {
   case ProtocolConformanceKind::Normal: {
-    auto normalConformance = cast<NormalProtocolConformance>(this);
-    auto sigConformances = normalConformance->getSignatureConformances();
-    for (auto conf : sigConformances)
-      if (!conf.isCanonical())
-        return false;
+    // Normal conformances are considered canonical by
+    // construction.
     return true;
   }
   case ProtocolConformanceKind::Inherited: {
@@ -1093,13 +1090,9 @@ bool ProtocolConformance::isCanonical() const {
     if (!genericConformance->isCanonical())
       return false;
     auto specSubs = spec->getGenericSubstitutions();
-    for (auto sub : specSubs) {
-      if (!sub.getReplacement()->isCanonical())
+    for (const auto &sub : specSubs) {
+      if (!sub.isCanonical())
         return false;
-      for (auto conf : sub.getConformances()) {
-        if (!conf.isCanonical())
-          return false;
-      }
     }
     return true;
   }

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -1059,3 +1059,151 @@ DeclContext::getLocalConformances(
 
   return result;
 }
+
+/// Check of all types used by the conformance are canonical.
+bool ProtocolConformance::isCanonical() const {
+  // Normal conformances are considered canonical by
+  // construction.
+  if (getKind() != ProtocolConformanceKind::Normal) {
+    if (!getType()->isCanonical())
+      return false;
+    if (!getInterfaceType()->isCanonical())
+      return false;
+  }
+
+  switch (getKind()) {
+  case ProtocolConformanceKind::Normal: {
+    auto normalConformance = cast<NormalProtocolConformance>(this);
+    auto sigConformances = normalConformance->getSignatureConformances();
+    for (auto conf : sigConformances)
+      if (!conf.isCanonical())
+        return false;
+    return true;
+  }
+  case ProtocolConformanceKind::Inherited: {
+    // Substitute the base.
+    auto inheritedConformance
+      = cast<InheritedProtocolConformance>(this);
+    return inheritedConformance->getInheritedConformance()->isCanonical();
+  }
+  case ProtocolConformanceKind::Specialized: {
+    // Substitute the substitutions in the specialized conformance.
+    auto spec = cast<SpecializedProtocolConformance>(this);
+    auto genericConformance = spec->getGenericConformance();
+    if (!genericConformance->isCanonical())
+      return false;
+    auto specSubs = spec->getGenericSubstitutions();
+    for (auto sub : specSubs) {
+      if (!sub.getReplacement()->isCanonical())
+        return false;
+      for (auto conf : sub.getConformances()) {
+        if (!conf.isCanonical())
+          return false;
+      }
+    }
+    return true;
+  }
+  }
+  llvm_unreachable("bad ProtocolConformanceKind");
+}
+
+Substitution Substitution::getCanonicalSubstitution(bool *wasCanonical) const {
+  bool createdNewCanonicalConformances = false;
+  bool createdCanReplacement = false;
+  SmallVector<ProtocolConformanceRef, 4> newCanConformances;
+
+  CanType canReplacement = getReplacement()->getCanonicalType();
+
+  if (!getReplacement()->isCanonical()) {
+    createdCanReplacement = true;
+  }
+
+  for (auto conf : getConformances()) {
+    if (conf.isCanonical()) {
+      newCanConformances.push_back(conf);
+      continue;
+    }
+    newCanConformances.push_back(conf.getCanonicalConformanceRef());
+    createdNewCanonicalConformances = true;
+  }
+
+  ArrayRef<ProtocolConformanceRef> canConformances = getConformances();
+  if (createdNewCanonicalConformances) {
+    auto &C = canReplacement->getASTContext();
+    canConformances = C.AllocateCopy(newCanConformances);
+  }
+
+  if (createdCanReplacement || createdNewCanonicalConformances) {
+    if (wasCanonical)
+      *wasCanonical = false;
+    return Substitution(canReplacement, canConformances);
+  }
+  if (wasCanonical)
+    *wasCanonical = true;
+  return *this;
+}
+
+SubstitutionList swift::getCanonicalSubstitutionList(SubstitutionList subs) {
+  SmallVector<Substitution, 4> newCanSubstitutions;
+  bool subListWasCanonical = true;
+  for (auto &sub : subs) {
+    bool subWasCanonical = false;
+    auto canSub = sub.getCanonicalSubstitution(&subWasCanonical);
+    if (!subWasCanonical)
+      subListWasCanonical = false;
+    newCanSubstitutions.push_back(canSub);
+  }
+  if (subListWasCanonical)
+    return subs;
+  return newCanSubstitutions[0].getReplacement()->getASTContext().AllocateCopy(
+      newCanSubstitutions);
+}
+
+/// Check of all types used by the conformance are canonical.
+ProtocolConformance *ProtocolConformance::getCanonicalConformance() {
+  if (isCanonical())
+    return this;
+
+  switch (getKind()) {
+  case ProtocolConformanceKind::Normal: {
+    //assert(isCanonical() && "Normal conformances should always be canonical");
+    return this;
+  }
+
+  case ProtocolConformanceKind::Inherited: {
+    auto &Ctx = getType()->getASTContext();
+    auto inheritedConformance = cast<InheritedProtocolConformance>(this);
+    return Ctx.getInheritedConformance(
+        getType()->getCanonicalType(),
+        inheritedConformance->getInheritedConformance()
+            ->getCanonicalConformance());
+  }
+
+  case ProtocolConformanceKind::Specialized: {
+    auto &Ctx = getType()->getASTContext();
+    // Substitute the substitutions in the specialized conformance.
+    auto spec = cast<SpecializedProtocolConformance>(this);
+    auto genericConformance = spec->getGenericConformance();
+    auto specSubs = spec->getGenericSubstitutions();
+    auto canSpecSubs = getCanonicalSubstitutionList(specSubs);
+    return Ctx.getSpecializedConformance(
+        getType()->getCanonicalType(),
+        genericConformance->getCanonicalConformance(), canSpecSubs);
+  }
+  }
+  llvm_unreachable("bad ProtocolConformanceKind");
+}
+
+/// Check of all types used by the conformance are canonical.
+bool ProtocolConformanceRef::isCanonical() const {
+  if (isAbstract())
+    return true;
+  return getConcrete()->isCanonical();
+}
+
+ProtocolConformanceRef
+ProtocolConformanceRef::getCanonicalConformanceRef() const {
+  if (isAbstract())
+    return *this;
+  return ProtocolConformanceRef(getConcrete()->getCanonicalConformance());
+}

--- a/lib/AST/Substitution.cpp
+++ b/lib/AST/Substitution.cpp
@@ -42,3 +42,13 @@ Substitution::Substitution(Type Replacement,
   assert(Replacement->isMaterializable()
          && "cannot substitute with a non-materializable type");
 }
+
+bool Substitution::isCanonical() const {
+  if (!getReplacement()->isCanonical())
+    return false;
+  for (auto conf : getConformances()) {
+    if (!conf.isCanonical())
+      return false;
+  }
+  return true;
+}

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -2492,13 +2492,6 @@ TypeConverter::checkFunctionForABIDifferences(SILFunctionType *fnTy1,
   return ABIDifference::Trivial;
 }
 
-void canonicalizeSubstitutions(MutableArrayRef<Substitution> subs) {
-  for (auto &sub : subs) {
-    sub = Substitution(sub.getReplacement()->getCanonicalType(),
-                       sub.getConformances());
-  }
-}
-
 CanSILBoxType
 TypeConverter::getInterfaceBoxTypeForCapture(ValueDecl *captured,
                                              CanType loweredInterfaceType,
@@ -2536,8 +2529,7 @@ TypeConverter::getInterfaceBoxTypeForCapture(ValueDecl *captured,
       return ProtocolConformanceRef(conformedTy->getDecl());
     },
     genericArgs);
-  canonicalizeSubstitutions(genericArgs);
-  
+
   auto boxTy = SILBoxType::get(C, layout, genericArgs);
 #ifndef NDEBUG
   // FIXME: Map the box type out of context when asserting the field so


### PR DESCRIPTION
Fix a bug with SILBoxType’s generic arguments

The set of SILBoxType’s generic arguments should be canonical, otherwise getCanonicalType() produces wrong results.

A canonical conformance is defined as a conformance which:
- does not contain any non-canonical types.
- Its type and interface type should be canonical.
- Any referenced conformances should be canonical.
- Any used substitutions should be canonical as well.

A substitution is canonical if:
- its replacement type is canonical
- all of its conformances are canonical

Resolves one of the issues in rdar://31603112