### PR TITLE
[Exclusivity] Fix Definite Initialization for Diagnostics.

### DIFF
--- a/lib/SILOptimizer/Mandatory/DIMemoryUseCollectorOwnership.cpp
+++ b/lib/SILOptimizer/Mandatory/DIMemoryUseCollectorOwnership.cpp
@@ -610,6 +610,19 @@ void ElementUseCollector::collectContainerUses(AllocBoxInst *ABI) {
   }
 }
 
+/// Return the underlying accessed pointer value. This peeks through
+/// begin_access patterns such as:
+///
+/// %mark = mark_uninitialized [rootself] %alloc : $*T
+/// %access = begin_access [modify] [unknown] %mark : $*T
+/// apply %f(%access) : $(@inout T) -> ()
+static SILValue getAccessedPointer(SILValue Pointer) {
+  if (auto *Access = dyn_cast<BeginAccessInst>(Pointer))
+    return Access->getSource();
+
+  return Pointer;
+}
+
 /// Returns true when the instruction represents added instrumentation for
 /// run-time sanitizers.
 static bool isSanitizerInstrumentation(SILInstruction *Instruction,
@@ -804,8 +817,8 @@ void ElementUseCollector::collectUses(SILValue Pointer, unsigned BaseEltNo) {
         // individual sub-member is passed as inout, then we model that as an
         // inout use.
         auto Kind = DIUseKind::InOutUse;
-        if ((TheMemory.isStructInitSelf() || TheMemory.isProtocolInitSelf()) &&
-            Pointer == TheMemory.getAddress())
+        if ((TheMemory.isStructInitSelf() || TheMemory.isProtocolInitSelf())
+            && getAccessedPointer(Pointer) == TheMemory.getAddress())
           Kind = DIUseKind::Escape;
 
         addElementUses(BaseEltNo, PointeeType, User, Kind);


### PR DESCRIPTION
Handle mutating methods in initializers properly.

This only affects --enforce-exclusivity mode.
It will be unit tested by default soon.