### PR TITLE
Eliminate redundant capacity reservation

### DIFF
--- a/stdlib/public/core/RangeReplaceableCollection.swift.gyb
+++ b/stdlib/public/core/RangeReplaceableCollection.swift.gyb
@@ -1144,7 +1144,6 @@ public func + <C : RangeReplaceableCollection, S : Sequence>(lhs: C, rhs: S) -> 
 
   var lhs = lhs
   // FIXME: what if lhs is a reference type?  This will mutate it.
-  lhs.reserveCapacity(lhs.count + numericCast(rhs.underestimatedCount))
   lhs.append(contentsOf: rhs)
   return lhs
 }
@@ -1205,7 +1204,6 @@ public func +<
 
   var lhs = lhs
   // FIXME: what if lhs is a reference type?  This will mutate it.
-  lhs.reserveCapacity(lhs.count + numericCast(rhs.count))
   lhs.append(contentsOf: rhs)
   return lhs
 }


### PR DESCRIPTION
append(contentsOf:) already reserves capacity.
