### PR TITLE
[GSB] Remove constraints derived from concrete conformances

### DIFF
--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -962,8 +962,21 @@ public:
   PotentialArchetype *getRootPotentialArchetype() const;
 
   /// Retrieve the potential archetype to which this source refers.
-  PotentialArchetype *getAffectedPotentialArchetype(
-                                        GenericSignatureBuilder &builder) const;
+  PotentialArchetype *getAffectedPotentialArchetype() const;
+
+  /// Visit each of the potential archetypes along the path, from the root
+  /// potential archetype to each potential archetype named via (e.g.) a
+  /// protocol requirement or parent source.
+  ///
+  /// \param visitor Called with each potential archetype along the path along
+  /// with the requirement source that is being applied on top of that
+  /// potential archetype. Can return \c true to halt the search.
+  ///
+  /// \returns nullptr if any call to \c visitor returned true. Otherwise,
+  /// returns the potential archetype to which the entire source refers.
+  PotentialArchetype *visitPotentialArchetypesAlongPath(
+           llvm::function_ref<bool(PotentialArchetype *,
+                                   const RequirementSource *)> visitor) const;
 
   /// Whether the requirement is inferred or derived from an inferred
   /// requirment.

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -994,7 +994,8 @@ public:
   /// Determine whether a requirement \c pa: proto, when formed from this
   /// requirement source, is dependent on itself.
   bool isSelfDerivedConformance(PotentialArchetype *pa,
-                                ProtocolDecl *proto) const;
+                                ProtocolDecl *proto,
+                                bool &derivedViaConcrete) const;
 
   /// Retrieve a source location that corresponds to the requirement.
   SourceLoc getLoc() const;

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -992,11 +992,6 @@ public:
   /// path.
   bool isDerivedRequirement() const;
 
-  /// Whether the requirement is derived via some concrete conformance, e.g.,
-  /// a concrete type's conformance to a protocol or a superclass's conformance
-  /// to a protocol.
-  bool isDerivedViaConcreteConformance() const;
-
   /// Determine whether the given derived requirement \c source, when rooted at
   /// the potential archetype \c pa, is actually derived from the same
   /// requirement. Such "self-derived" requirements do not make the original

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -1002,7 +1002,8 @@ public:
   /// requirement. Such "self-derived" requirements do not make the original
   /// requirement redundant, because without said original requirement, the
   /// derived requirement ceases to hold.
-  bool isSelfDerivedSource(PotentialArchetype *pa) const;
+  bool isSelfDerivedSource(PotentialArchetype *pa,
+                           bool &derivedViaConcrete) const;
 
   /// Determine whether a requirement \c pa: proto, when formed from this
   /// requirement source, is dependent on itself.

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -230,29 +230,6 @@ bool RequirementSource::isDerivedRequirement() const {
   llvm_unreachable("Unhandled RequirementSourceKind in switch.");
 }
 
-bool RequirementSource::isDerivedViaConcreteConformance() const {
-  for (auto source = this; source; source = source->parent) {
-    switch (source->kind) {
-    case Explicit:
-    case Inferred:
-    case NestedTypeNameMatch:
-    case RequirementSignatureSelf:
-      return false;
-
-    case Parent:
-    case ProtocolRequirement:
-    case InferredProtocolRequirement:
-      continue;
-
-    case Superclass:
-    case Concrete:
-      return true;
-    }
-  }
-
-  return false;
-}
-
 bool RequirementSource::isSelfDerivedSource(PotentialArchetype *pa,
                                             bool &derivedViaConcrete) const {
   derivedViaConcrete = false;

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -324,8 +324,43 @@ protocol P22 {
   associatedtype B where A == X20<B>
 }
 
+// CHECK: Generic signature: <Self where Self : P23>
+// CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : P23>
+// CHECK: Protocol requirement signature:
+// CHECK: .P23@
+// CHECK-NEXT: Requirement signature: <Self where Self.B : P20, Self.A == X20<Self.B>>
+// CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0.B : P20, τ_0_0.A == X20<τ_0_0.B>>
 protocol P23 {
   associatedtype A
   associatedtype B: P20 // expected-warning{{redundant conformance constraint 'Self.B': 'P20'}}
     where A == X20<B> // expected-note{{conformance constraint 'Self.B': 'P20' inferred from type here}}
+}
+
+protocol P24 {
+  associatedtype C: P20
+}
+
+struct X24<T: P20> : P24 {
+  typealias C = T
+}
+
+// CHECK-LABEL: .P25a@
+// CHECK-NEXT: Requirement signature: <Self where Self.B : P20, Self.A == X24<Self.B>>
+// CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0.B : P20, τ_0_0.A == X24<τ_0_0.B>>
+protocol P25a {
+  associatedtype A: P24 // expected-warning{{redundant conformance constraint 'Self.A': 'P24'}}
+  associatedtype B where A == X24<B> // expected-note{{conformance constraint 'Self.A': 'P24' implied here}}
+}
+
+// CHECK-LABEL: .P25b@
+// CHECK-NEXT: Requirement signature: <Self where Self.B : P20, Self.A == X24<Self.B>>
+// CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0.B : P20, τ_0_0.A == X24<τ_0_0.B>>
+protocol P25b {
+  associatedtype A
+  associatedtype B where A == X24<B>
+}
+
+protocol P25c {
+  associatedtype A: P24
+  associatedtype B where A == X<B> // expected-error{{use of undeclared type 'X'}}
 }

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -364,3 +364,28 @@ protocol P25c {
   associatedtype A: P24
   associatedtype B where A == X<B> // expected-error{{use of undeclared type 'X'}}
 }
+
+// Similar to the above, but with superclass constraints.
+protocol P26 {
+  associatedtype C: X3
+}
+
+struct X26<T: X3> : P26 {
+  typealias C = T
+}
+
+// CHECK-LABEL: .P27a@
+// CHECK-NEXT: Requirement signature: <Self where Self.B : X3, Self.A == X26<Self.B>>
+// CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0.B : X3, τ_0_0.A == X26<τ_0_0.B>>
+protocol P27a {
+  associatedtype A: P26 // expected-warning{{redundant conformance constraint 'Self.A': 'P26'}}
+  associatedtype B where A == X26<B> // expected-note{{conformance constraint 'Self.A': 'P26' implied here}}
+}
+
+// CHECK-LABEL: .P27b@
+// CHECK-NEXT: Requirement signature: <Self where Self.B : X3, Self.A == X26<Self.B>>
+// CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0.B : X3, τ_0_0.A == X26<τ_0_0.B>>
+protocol P27b {
+  associatedtype A
+  associatedtype B where A == X26<B>
+}

--- a/validation-test/compiler_crashers_2_fixed/0083-rdar31163470-2.swift
+++ b/validation-test/compiler_crashers_2_fixed/0083-rdar31163470-2.swift
@@ -1,5 +1,4 @@
-// RUN: not --crash %target-swift-frontend -primary-file %s -emit-ir
-// REQUIRES: asserts
+// RUN: %target-swift-frontend -primary-file %s -emit-ir
 
 protocol C {
   associatedtype I

--- a/validation-test/compiler_crashers_2_fixed/0089-sr4458.swift
+++ b/validation-test/compiler_crashers_2_fixed/0089-sr4458.swift
@@ -1,0 +1,8 @@
+// RUN: %target-swift-frontend -primary-file %s -emit-ir
+import Foundation
+
+extension _MutableIndexable {
+  typealias SubSequence = MutableRangeReplaceableRandomAccessSlice<Data>
+}
+
+print(type(of: Data.self.SubSequence.self))

--- a/validation-test/compiler_crashers_2_fixed/0089-sr4458.swift
+++ b/validation-test/compiler_crashers_2_fixed/0089-sr4458.swift
@@ -1,4 +1,7 @@
 // RUN: %target-swift-frontend -primary-file %s -emit-ir
+
+// REQUIRES: objc_interop
+
 import Foundation
 
 extension _MutableIndexable {


### PR DESCRIPTION
When an otherwise abstract constraint can also be derived from a concrete conformance, the path via the concrete conformance caused the abstract constraint to be considered redundant. However, this depends on the idea that the concrete conformance itself is always recoverable and usable---which it isn't.

Therefore, remove constraints derived via a concrete conformance so long as there is some other path to get to that constraint. That way, the abstract derivation of the constraint will remain, and be part of the resulting generic signature.

This fixes a class of annoying bugs where *adding* a redundant constraint can break the generic signature (losing requirements), including rdar://problem/31163470,  rdar://problem/31520386, and SR-4458 / rdar://problem/31375569.