### PR TITLE
ArrayElementValuePropagation: explicitly reserve space for new elements when doing the array-content-of optimization

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -457,6 +457,10 @@ public:
   /// Retrieve the declaration of Array.append(element:)
   FuncDecl *getArrayAppendElementDecl() const;
 
+  /// Retrieve the declaration of
+  /// Array.reserveCapacityForAppend(newElementsCount: Int)
+  FuncDecl *getArrayReserveCapacityDecl() const;
+
   /// Retrieve the declaration of Swift._unimplementedInitializer.
   FuncDecl *getUnimplementedInitializerDecl(LazyResolver *resolver) const;
 

--- a/include/swift/SILOptimizer/Analysis/ArraySemantic.h
+++ b/include/swift/SILOptimizer/Analysis/ArraySemantic.h
@@ -33,6 +33,7 @@ enum class ArrayCallKind {
   kGetElementAddress,
   kMakeMutable,
   kMutateUnknown,
+  kReserveCapacityForAppend,
   kWithUnsafeMutableBufferPointer,
   kAppendContentsOf,
   kAppendElement,
@@ -138,6 +139,7 @@ public:
   /// Replace a call to append(contentsOf: ) with a series of
   /// append(element: ) calls.
   bool replaceByAppendingValues(SILModule &M, SILFunction *AppendFn,
+                                SILFunction *ReserveFn,
                                 const llvm::SmallVectorImpl<SILValue> &Vals,
                                 ArrayRef<Substitution> Subs);
 

--- a/lib/SILOptimizer/Analysis/ArraySemantic.cpp
+++ b/lib/SILOptimizer/Analysis/ArraySemantic.cpp
@@ -162,6 +162,8 @@ ArrayCallKind swift::ArraySemanticsCall::getKind() const {
             .Case("array.get_element_address",
                   ArrayCallKind::kGetElementAddress)
             .Case("array.mutate_unknown", ArrayCallKind::kMutateUnknown)
+            .Case("array.reserve_capacity_for_append",
+                  ArrayCallKind::kReserveCapacityForAppend)
             .Case("array.withUnsafeMutableBufferPointer",
                   ArrayCallKind::kWithUnsafeMutableBufferPointer)
             .Case("array.append_contentsOf", ArrayCallKind::kAppendContentsOf)
@@ -570,6 +572,7 @@ bool swift::ArraySemanticsCall::canInlineEarly() const {
     default:
       return false;
     case ArrayCallKind::kAppendContentsOf:
+    case ArrayCallKind::kReserveCapacityForAppend:
     case ArrayCallKind::kAppendElement:
       // append(Element) calls other semantics functions. Therefore it's
       // important that it's inlined by the early inliner (which is before all

--- a/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
+++ b/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
@@ -486,6 +486,7 @@ static bool isNonMutatingArraySemanticCall(SILInstruction *Inst) {
     return true;
   case ArrayCallKind::kMakeMutable:
   case ArrayCallKind::kMutateUnknown:
+  case ArrayCallKind::kReserveCapacityForAppend:
   case ArrayCallKind::kWithUnsafeMutableBufferPointer:
   case ArrayCallKind::kArrayInit:
   case ArrayCallKind::kArrayUninitialized:
@@ -824,6 +825,7 @@ static bool mayChangeArrayValueToNonUniqueState(ArraySemanticsCall &Call) {
 
   case ArrayCallKind::kNone:
   case ArrayCallKind::kMutateUnknown:
+  case ArrayCallKind::kReserveCapacityForAppend:
   case ArrayCallKind::kWithUnsafeMutableBufferPointer:
   case ArrayCallKind::kArrayInit:
   case ArrayCallKind::kArrayUninitialized:

--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -749,11 +749,9 @@ bool SimplifyCFG::simplifyAfterDroppingPredecessor(SILBasicBlock *BB) {
   return false;
 }
 
-/// Tries to figure out the enum case of an enum value \p Val which is used in
-/// block \p UsedInBB.
-static NullablePtr<EnumElementDecl> getEnumCase(SILValue Val,
-                                                SILBasicBlock *UsedInBB,
-                                                int RecursionDepth) {
+static NullablePtr<EnumElementDecl>
+getEnumCaseRecursive(SILValue Val, SILBasicBlock *UsedInBB, int RecursionDepth,
+                     llvm::SmallPtrSet<SILArgument *, 8> HandledArgs) {
   // Limit the number of recursions. This is an easy way to cope with cycles
   // in the SSA graph.
   if (RecursionDepth > 3)
@@ -784,13 +782,16 @@ static NullablePtr<EnumElementDecl> getEnumCase(SILValue Val,
   // In case of a block argument, recursively check the enum cases of all
   // incoming predecessors.
   if (auto *Arg = dyn_cast<SILArgument>(Val)) {
+    HandledArgs.insert(Arg);
     llvm::SmallVector<std::pair<SILBasicBlock *, SILValue>, 8> IncomingVals;
     if (!Arg->getIncomingValues(IncomingVals))
       return nullptr;
 
     EnumElementDecl *CommonCase = nullptr;
     for (std::pair<SILBasicBlock *, SILValue> Incoming : IncomingVals) {
-      TermInst *TI = Incoming.first->getTerminator();
+      SILBasicBlock *IncomingBlock = Incoming.first;
+      SILValue IncomingVal = Incoming.second;
+      TermInst *TI = IncomingBlock->getTerminator();
 
       // If the terminator of the incoming value is e.g. a switch_enum, the
       // incoming value is the switch_enum operand and not the enum payload
@@ -798,8 +799,13 @@ static NullablePtr<EnumElementDecl> getEnumCase(SILValue Val,
       if (!isa<BranchInst>(TI) && !isa<CondBranchInst>(TI))
         return nullptr;
 
+      SILArgument *IncomingArg = dyn_cast<SILArgument>(IncomingVal);
+      if (IncomingArg && HandledArgs.count(IncomingArg) != 0)
+        continue;
+
       NullablePtr<EnumElementDecl> IncomingCase =
-        getEnumCase(Incoming.second, Incoming.first, RecursionDepth + 1);
+        getEnumCaseRecursive(Incoming.second, IncomingBlock, RecursionDepth + 1,
+                             HandledArgs);
       if (!IncomingCase)
         return nullptr;
       if (IncomingCase.get() != CommonCase) {
@@ -808,37 +814,80 @@ static NullablePtr<EnumElementDecl> getEnumCase(SILValue Val,
         CommonCase = IncomingCase.get();
       }
     }
-    assert(CommonCase);
     return CommonCase;
   }
   return nullptr;
 }
 
+/// Tries to figure out the enum case of an enum value \p Val which is used in
+/// block \p UsedInBB.
+static NullablePtr<EnumElementDecl> getEnumCase(SILValue Val,
+                                                SILBasicBlock *UsedInBB) {
+  llvm::SmallPtrSet<SILArgument *, 8> HandledArgs;
+  return getEnumCaseRecursive(Val, UsedInBB, /*RecursionDepth*/ 0, HandledArgs);
+}
+
+static int getThreadingCost(SILInstruction *I) {
+  if (!isa<DeallocStackInst>(I) && !I->isTriviallyDuplicatable())
+    return 1000;
+
+  // Don't jumpthread function calls.
+  if (isa<ApplyInst>(I))
+    return 1000;
+
+  // This is a really trivial cost model, which is only intended as a starting
+  // point.
+  if (instructionInlineCost(*I) != InlineCost::Free)
+    return 1;
+
+  return 0;
+}
+
 /// couldSimplifyUsers - Check to see if any simplifications are possible if
 /// "Val" is substituted for BBArg.  If so, return true, if nothing obvious
 /// is possible, return false.
-static bool couldSimplifyUsers(SILArgument *BBArg, BranchInst *BI,
-                              SILValue BIArg) {
-  // If the value being substituted is an enum, check to see if there are any
-  // switches on it.
-  if (!getEnumCase(BIArg, BI->getParent(), 0))
-    return false;
+static bool couldSimplifyEnumUsers(SILArgument *BBArg, int Budget) {
+  SILBasicBlock *BB = BBArg->getParent();
+  int BudgetForBranch = 100;
 
-  for (auto UI : BBArg->getUses()) {
+  for (Operand *UI : BBArg->getUses()) {
     auto *User = UI->getUser();
-    if (BBArg->getParent() == User->getParent()) {
-      // We only know we can simplify if the switch_enum user is in the block we
-      // are trying to jump thread.
-      // The value must not be define in the same basic block as the switch enum
-      // user. If this is the case we have a single block switch_enum loop.
-      if (isa<SwitchEnumInst>(User) || isa<SelectEnumInst>(User))
-        return true;
+    if (User->getParent() != BB)
+      continue;
 
-      // Also allow enum of enum, which usually can be combined to a single
-      // instruction. This helps to simplify the creation of an enum from an
-      // integer raw value.
-      if (isa<EnumInst>(User))
+    // We only know we can simplify if the switch_enum user is in the block we
+    // are trying to jump thread.
+    // The value must not be define in the same basic block as the switch enum
+    // user. If this is the case we have a single block switch_enum loop.
+    if (isa<SwitchEnumInst>(User) || isa<SelectEnumInst>(User))
+      return true;
+
+    // Also allow enum of enum, which usually can be combined to a single
+    // instruction. This helps to simplify the creation of an enum from an
+    // integer raw value.
+    if (isa<EnumInst>(User))
+      return true;
+
+    if (SwitchValueInst *SWI = dyn_cast<SwitchValueInst>(User)) {
+      if (SWI->getOperand() == BBArg)
         return true;
+    }
+
+    if (BranchInst *BI = dyn_cast<BranchInst>(User)) {
+      if (BudgetForBranch > Budget) {
+        BudgetForBranch = Budget;
+        for (SILInstruction &I : *BB) {
+          BudgetForBranch -= getThreadingCost(&I);
+          if (BudgetForBranch < 0)
+            break;
+        }
+      }
+      if (BudgetForBranch > 0) {
+        SILBasicBlock *DestBB = BI->getDestBB();
+        unsigned OpIdx = UI->getOperandNumber();
+        if (couldSimplifyEnumUsers(DestBB->getArgument(OpIdx), BudgetForBranch))
+          return true;
+      }
     }
   }
   return false;
@@ -909,43 +958,41 @@ bool SimplifyCFG::tryJumpThreading(BranchInst *BI) {
   // major second order simplifications.  Here we only do it if there are
   // "constant" arguments to the branch or if we know how to fold something
   // given the duplication.
-  bool WantToThread = false;
+  int ThreadingBudget = 0;
 
-  if (isa<CondBranchInst>(DestBB->getTerminator()))
+  for (unsigned i = 0, e = BI->getArgs().size(); i != e; ++i) {
+    // If the value being substituted is an enum, check to see if there are any
+    // switches on it.
+    SILValue Arg = BI->getArg(i);
+    if (!getEnumCase(Arg, BI->getParent()) &&
+        !isa<IntegerLiteralInst>(Arg))
+      continue;
+
+    if (couldSimplifyEnumUsers(DestBB->getArgument(i), 8)) {
+      ThreadingBudget = 8;
+      break;
+    }
+  }
+
+  if (ThreadingBudget == 0 && isa<CondBranchInst>(DestBB->getTerminator())) {
     for (auto V : BI->getArgs()) {
       if (isa<IntegerLiteralInst>(V) || isa<FloatLiteralInst>(V)) {
-        WantToThread = true;
+        ThreadingBudget = 4;
         break;
       }
     }
-
-  if (!WantToThread) {
-    for (unsigned i = 0, e = BI->getArgs().size(); i != e; ++i)
-      if (couldSimplifyUsers(DestBB->getArgument(i), BI, BI->getArg(i))) {
-        WantToThread = true;
-        break;
-      }
   }
 
   // If we don't have anything that we can simplify, don't do it.
-  if (!WantToThread) return false;
+  if (ThreadingBudget == 0)
+    return false;
 
   // If it looks potentially interesting, decide whether we *can* do the
   // operation and whether the block is small enough to be worth duplicating.
-  unsigned Cost = 0;
-
   for (auto &Inst : *DestBB) {
-    if (!Inst.isTriviallyDuplicatable())
+    ThreadingBudget -= getThreadingCost(&Inst);
+    if (ThreadingBudget <= 0)
       return false;
-
-    // Don't jumpthread function calls.
-    if (isa<ApplyInst>(Inst))
-      return false;
-
-    // This is a really trivial cost model, which is only intended as a starting
-    // point.
-    if (instructionInlineCost(Inst) != InlineCost::Free)
-      if (++Cost == 4) return false;
 
     // We need to update ssa if a value is used outside the duplicated block.
     if (!NeedToUpdateSSA)
@@ -1617,7 +1664,7 @@ bool SimplifyCFG::simplifySwitchEnumUnreachableBlocks(SwitchEnumInst *SEI) {
 /// switch_enum instruction that gets its operand from an enum
 /// instruction.
 bool SimplifyCFG::simplifySwitchEnumBlock(SwitchEnumInst *SEI) {
-  auto EnumCase = getEnumCase(SEI->getOperand(), SEI->getParent(), 0);
+  auto EnumCase = getEnumCase(SEI->getOperand(), SEI->getParent());
   if (!EnumCase)
     return false;
 

--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -1439,18 +1439,9 @@ extension ${Self} : RangeReplaceableCollection, _ArrayProtocol {
     where S.Iterator.Element == Element {
 
     let newElementsCount = newElements.underestimatedCount
+    reserveCapacityForAppend(newElementsCount: newElementsCount)
 
     let oldCount = self.count
-    let oldCapacity = self.capacity
-    let newCount = oldCount + newElementsCount
-
-    // Ensure uniqueness, mutability, and sufficient storage.  Note that
-    // for consistency, we need unique self even if newElements is empty.
-    self.reserveCapacity(
-      newCount > oldCapacity ?
-      Swift.max(newCount, _growArrayCapacity(oldCapacity))
-      : newCount)
-
     let startNewElements = _buffer.firstElementAddress + oldCount
     let buf = UnsafeMutableBufferPointer(
                 start: startNewElements, 
@@ -1471,6 +1462,22 @@ extension ${Self} : RangeReplaceableCollection, _ArrayProtocol {
       // append them in slow sequence-only mode
       _buffer._arrayAppendSequence(IteratorSequence(remainder))
     }
+  }
+
+  @_inlineable
+  @_versioned
+  @_semantics("array.reserve_capacity_for_append")
+  internal mutating func reserveCapacityForAppend(newElementsCount: Int) {
+    let oldCount = self.count
+    let oldCapacity = self.capacity
+    let newCount = oldCount + newElementsCount
+
+    // Ensure uniqueness, mutability, and sufficient storage.  Note that
+    // for consistency, we need unique self even if newElements is empty.
+    self.reserveCapacity(
+      newCount > oldCapacity ?
+      Swift.max(newCount, _growArrayCapacity(oldCapacity))
+      : newCount)
   }
 
 %if Self == 'ArraySlice':

--- a/test/SILOptimizer/array_contentof_opt.swift
+++ b/test/SILOptimizer/array_contentof_opt.swift
@@ -16,6 +16,9 @@ public func testInt(_ a: inout [Int]) {
 
 // CHECK-LABEL: sil @{{.*}}testThreeInt
 // CHECK-NOT: apply
+// CHECK:        [[FR:%[0-9]+]] = function_ref @_T0Sa15reserveCapacityySiFSi_Tg5
+// CHECK-NEXT:   apply [[FR]]
+// CHECK-NOT: apply
 // CHECK:        [[F:%[0-9]+]] = function_ref @_T0Sa6appendyxFSi_Tg
 // CHECK-NOT: apply
 // CHECK:        apply [[F]]

--- a/test/SILOptimizer/sil_combine.sil
+++ b/test/SILOptimizer/sil_combine.sil
@@ -3246,3 +3246,71 @@ bb2:                                                // Preds: bb0
 bb3(%16 : $Int32):                                  // Preds: bb1 bb2
   return %16 : $Int32                               // id: %17
 }
+
+// CHECK-LABEL: sil @switch_value_to_cond_br_1
+// CHECK:      bb0({{.*}}):
+// CHECK-NEXT:   cond_br %0, bb1, bb2
+sil @switch_value_to_cond_br_1 : $@convention(thin) (Builtin.Int1) -> Int32 {
+bb0(%0 : $Builtin.Int1):
+  %t1 = integer_literal $Builtin.Int1, -1
+  switch_value %0 : $Builtin.Int1, case %t1: bb1, default bb2
+
+bb1:                                                // Preds: bb0
+  %1 = integer_literal $Builtin.Int32, 0
+  %2 = struct $Int32 (%1 : $Builtin.Int32)          // user: %12
+  br bb3(%2 : $Int32)                               // id: %12
+
+bb2:                                                // Preds: bb0
+  %3 = integer_literal $Builtin.Int32, 1
+  %4 = struct $Int32 (%3 : $Builtin.Int32)          // user: %12
+  br bb3(%4 : $Int32)                               // id: %15
+
+bb3(%16 : $Int32):                                  // Preds: bb1 bb2
+  return %16 : $Int32                               // id: %17
+}
+
+// CHECK-LABEL: sil @switch_value_to_cond_br_2
+// CHECK:      bb0({{.*}}):
+// CHECK-NEXT:   cond_br %0, bb2, bb1
+sil @switch_value_to_cond_br_2 : $@convention(thin) (Builtin.Int1) -> Int32 {
+bb0(%0 : $Builtin.Int1):
+  %f1 = integer_literal $Builtin.Int1, 0
+  switch_value %0 : $Builtin.Int1, case %f1: bb1, default bb2
+
+bb1:                                                // Preds: bb0
+  %1 = integer_literal $Builtin.Int32, 0
+  %2 = struct $Int32 (%1 : $Builtin.Int32)          // user: %12
+  br bb3(%2 : $Int32)                               // id: %12
+
+bb2:                                                // Preds: bb0
+  %3 = integer_literal $Builtin.Int32, 1
+  %4 = struct $Int32 (%3 : $Builtin.Int32)          // user: %12
+  br bb3(%4 : $Int32)                               // id: %15
+
+bb3(%16 : $Int32):                                  // Preds: bb1 bb2
+  return %16 : $Int32                               // id: %17
+}
+
+// CHECK-LABEL: sil @switch_value_to_cond_br_3
+// CHECK:      bb0({{.*}}):
+// CHECK-NEXT:   cond_br %0, bb1, bb2
+sil @switch_value_to_cond_br_3 : $@convention(thin) (Builtin.Int1) -> Int32 {
+bb0(%0 : $Builtin.Int1):
+  %t1 = integer_literal $Builtin.Int1, -1
+  %f1 = integer_literal $Builtin.Int1, 0
+  switch_value %0 : $Builtin.Int1, case %t1: bb1, case %f1: bb2
+
+bb1:                                                // Preds: bb0
+  %1 = integer_literal $Builtin.Int32, 0
+  %2 = struct $Int32 (%1 : $Builtin.Int32)          // user: %12
+  br bb3(%2 : $Int32)                               // id: %12
+
+bb2:                                                // Preds: bb0
+  %3 = integer_literal $Builtin.Int32, 1
+  %4 = struct $Int32 (%3 : $Builtin.Int32)          // user: %12
+  br bb3(%4 : $Int32)                               // id: %15
+
+bb3(%16 : $Int32):                                  // Preds: bb1 bb2
+  return %16 : $Int32                               // id: %17
+}
+

--- a/test/SILOptimizer/simplify_cfg.sil
+++ b/test/SILOptimizer/simplify_cfg.sil
@@ -1414,6 +1414,95 @@ bb6(%r : $Int32):
   return %r : $Int32
 }
 
+// CHECK-LABEL: sil @jumpthread_switch_enum4
+// CHECK:      bb0:
+// CHECK-NEXT:   cond_br undef, bb1, bb2
+// CHECK:      bb1:
+// CHECK-NEXT:   cond_br undef, bb3, bb4
+// CHECK:      bb2:
+// CHECK:        integer_literal {{.*}}, 27
+// CHECK:        br bb5
+// CHECK:      bb3:
+// CHECK:        br bb4
+// CHECK:      bb4:
+// CHECK:        integer_literal {{.*}}, 28
+// CHECK:        br bb5
+// CHECK:      bb5({{.*}}):
+// CHECK-NEXT:   return
+sil @jumpthread_switch_enum4 : $@convention(thin) () -> Builtin.Int32 {
+bb0:
+  cond_br undef, bb1, bb2
+
+bb1:
+  %4 = enum $Optional<Int32>, #Optional.none!enumelt
+  cond_br undef, bb3(%4 : $Optional<Int32>), bb4(%4 : $Optional<Int32>)
+
+bb2:
+  %6 = integer_literal $Builtin.Int32, 0
+  %7 = struct $Int32 (%6 : $Builtin.Int32)
+  %8 = enum $Optional<Int32>, #Optional.some!enumelt.1, %7 : $Int32
+  br bb3(%8 : $Optional<Int32>)
+
+
+bb3(%10 : $Optional<Int32>):
+  // Some instruction which is not "trivial"
+  %c1 = builtin "assert_configuration"() : $Builtin.Int32
+  br bb4(%10 : $Optional<Int32>)
+
+
+bb4(%13 : $Optional<Int32>):
+  switch_enum %13 : $Optional<Int32>, case #Optional.some!enumelt.1: bb5, case #Optional.none!enumelt: bb6
+
+bb5:
+  %r1 = integer_literal $Builtin.Int32, 27
+  %c2 = builtin "assert_configuration"() : $Builtin.Int32
+  br bb7(%r1 : $Builtin.Int32)
+
+bb6:
+  %r2 = integer_literal $Builtin.Int32, 28
+  %c3 = builtin "assert_configuration"() : $Builtin.Int32
+  br bb7(%r2 : $Builtin.Int32)
+
+bb7(%r : $Builtin.Int32):
+  return %r : $Builtin.Int32
+}
+
+// CHECK-LABEL: sil @jumpthread_switch_enum5
+// CHECK:      bb0:
+// CHECK:        br bb1
+// CHECK:      bb1({{.*}}):
+// CHECK-NEXT:   cond_br undef, bb2, bb3
+// CHECK:      bb2:
+// CHECK:        br bb1
+// CHECK:      bb3:
+// CHECK-NEXT:   tuple
+// CHECK-NEXT:   return
+sil @jumpthread_switch_enum5 : $@convention(thin) () -> () {
+bb0:
+  %6 = integer_literal $Builtin.Int32, 0
+  %7 = struct $Int32 (%6 : $Builtin.Int32)
+  %8 = enum $Optional<Int32>, #Optional.some!enumelt.1, %7 : $Int32
+  br bb1(%8 : $Optional<Int32>)
+
+bb1(%13 : $Optional<Int32>):
+  switch_enum %13 : $Optional<Int32>, case #Optional.some!enumelt.1: bb2, case #Optional.none!enumelt: bb3
+
+bb2:
+  br bb4
+
+bb3:
+  %55 = function_ref @external_f : $@convention(thin) () -> ()
+  apply %55() : $@convention(thin) () -> ()
+  br bb4
+
+bb4:
+  cond_br undef, bb1(%13 : $Optional<Int32>), bb5
+
+bb5:
+  %r = tuple ()
+  return %r : $()
+}
+
 /// Don't jumpthread blocks that contain objc method instructions. We don't
 /// support building phis with objc method values.
 


### PR DESCRIPTION
When Array.append(contentOf:) is replaced by individual Array.append(element) calls, an explicit reserveCapacityForAppend is inserted.

Also improve some SILCombine/SimplifyCFG enum-related optimizations to deal with the slightly different code.

This changes are mostly neutral for most of our benchmarks.
Except for ArrayPlusEqualThreeElements, where it gives a 2.5x improvement.
