### PR TITLE
Shallow clone specific branch

### DIFF
--- a/utils/update_checkout.py
+++ b/utils/update_checkout.py
@@ -220,8 +220,9 @@ def obtain_additional_swift_sources(pool_args):
         print("Cloning '" + repo_name + "'")
 
         if skip_history:
-            shell.run(['git', 'clone', '--recursive', '--depth', '1', '--branch', repo_branch,
-                       remote, repo_name], echo=True)
+            shell.run(['git', 'clone', '--recursive', '--depth', '1', 
+                       '--branch', repo_branch, remote, repo_name],
+                      echo=True)
         else:
             shell.run(['git', 'clone', '--recursive', remote,
                        repo_name], echo=True)

--- a/utils/update_checkout.py
+++ b/utils/update_checkout.py
@@ -220,7 +220,7 @@ def obtain_additional_swift_sources(pool_args):
         print("Cloning '" + repo_name + "'")
 
         if skip_history:
-            shell.run(['git', 'clone', '--recursive', '--depth', '1',
+            shell.run(['git', 'clone', '--recursive', '--depth', '1', '--branch', repo_branch,
                        remote, repo_name], echo=True)
         else:
             shell.run(['git', 'clone', '--recursive', remote,


### PR DESCRIPTION
This allows one to say `./utils/update-checkout --clone --skip-history --scheme swift-3.1-branch`. This would otherwise fail, as it would do a shallow clone of master, which doesn't contain `swift-3.1-branch`. I'm not familiar with this build script, so it'd be wise to thoroughly verify it.