### PR TITLE
[4.0] SILGen: Push 'usingImplicitVariablesForPattern' hack into 'where' clause expr evaluation.

### DIFF
--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -422,7 +422,9 @@ private:
   void bindExprPattern(ExprPattern *pattern, ConsumableManagedValue v,
                        const FailureHandler &failure);
   void emitGuardBranch(SILLocation loc, Expr *guard,
-                       const FailureHandler &failure);
+                       const FailureHandler &failure,
+                       Pattern *usingImplicitVariablesFromPattern,
+                       CaseStmt *usingImplicitVariablesFromStmt);
 
   void bindIrrefutablePatterns(const ClauseRow &row, ArgArray args,
                                bool forIrrefutableRow, bool hasMultipleItems);
@@ -1056,9 +1058,8 @@ void PatternMatchEmission::emitWildcardDispatch(ClauseMatrix &clauses,
 
   // Emit the guard branch, if it exists.
   if (guardExpr) {
-    SGF.usingImplicitVariablesForPattern(clauses[row].getCasePattern(), dyn_cast<CaseStmt>(stmt), [&]{
-      this->emitGuardBranch(guardExpr, guardExpr, failure);
-    });
+    this->emitGuardBranch(guardExpr, guardExpr, failure,
+                      clauses[row].getCasePattern(), dyn_cast<CaseStmt>(stmt));
   }
 
   // Enter the row.
@@ -1120,7 +1121,8 @@ void PatternMatchEmission::bindExprPattern(ExprPattern *pattern,
   bindVariable(pattern, pattern->getMatchVar(), value,
                pattern->getType()->getCanonicalType(),
                /*isForSuccess*/ false, /* hasMultipleItems */ false);
-  emitGuardBranch(pattern, pattern->getMatchExpr(), failure);
+  emitGuardBranch(pattern, pattern->getMatchExpr(), failure,
+                  nullptr, nullptr);
 }
 
 /// Bind all the irrefutable patterns in the given row, which is nothing
@@ -1229,7 +1231,9 @@ void PatternMatchEmission::bindVariable(SILLocation loc, VarDecl *var,
 /// Evaluate a guard expression and, if it returns false, branch to
 /// the given destination.
 void PatternMatchEmission::emitGuardBranch(SILLocation loc, Expr *guard,
-                                           const FailureHandler &failure) {
+                                   const FailureHandler &failure,
+                                   Pattern *usingImplicitVariablesFromPattern,
+                                   CaseStmt *usingImplicitVariablesFromStmt) {
   SILBasicBlock *falseBB = SGF.B.splitBlockForFallthrough();
   SILBasicBlock *trueBB = SGF.B.splitBlockForFallthrough();
 
@@ -1237,7 +1241,16 @@ void PatternMatchEmission::emitGuardBranch(SILLocation loc, Expr *guard,
   SILValue testBool;
   {
     FullExpr scope(SGF.Cleanups, CleanupLocation(guard));
-    testBool = SGF.emitRValueAsSingleValue(guard).getUnmanagedValue();
+    auto emitTest = [&]{
+      testBool = SGF.emitRValueAsSingleValue(guard).getUnmanagedValue();
+    };
+    
+    if (usingImplicitVariablesFromPattern)
+      SGF.usingImplicitVariablesForPattern(usingImplicitVariablesFromPattern,
+                                           usingImplicitVariablesFromStmt,
+                                           emitTest);
+    else
+      emitTest();
   }
 
   SGF.B.createCondBranch(loc, testBool, trueBB, falseBB);

--- a/test/Interpreter/switch_where_clause.swift
+++ b/test/Interpreter/switch_where_clause.swift
@@ -1,0 +1,37 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+
+import StdlibUnittest
+
+func boo(_: LifetimeTracked) -> Bool { return true }
+
+var tests = TestSuite("switches with where clauses")
+
+enum Foo {
+  case a(LifetimeTracked)
+  case b(LifetimeTracked)
+}
+
+func foo(_ x: Foo, _ y: Foo, _ condition: (LifetimeTracked) -> Bool) -> Bool {
+     switch (x, y) {
+     case (.a(let xml), _),
+          (_, .a(let xml)) where condition(xml):
+          return true
+     default:
+        return false
+     }
+}
+
+tests.test("all paths through a switch with guard") {
+  _ = foo(.a(LifetimeTracked(0)), .a(LifetimeTracked(1)), { _ in true })
+  _ = foo(.a(LifetimeTracked(2)), .b(LifetimeTracked(3)), { _ in true })
+  _ = foo(.b(LifetimeTracked(4)), .a(LifetimeTracked(5)), { _ in true })
+  _ = foo(.b(LifetimeTracked(6)), .b(LifetimeTracked(7)), { _ in true })
+
+  _ = foo(.a(LifetimeTracked(10)), .a(LifetimeTracked(11)), { _ in false })
+  _ = foo(.a(LifetimeTracked(12)), .b(LifetimeTracked(13)), { _ in false })
+  _ = foo(.b(LifetimeTracked(14)), .a(LifetimeTracked(15)), { _ in false })
+  _ = foo(.b(LifetimeTracked(16)), .b(LifetimeTracked(17)), { _ in false })
+}
+
+runAllTests()


### PR DESCRIPTION
We swapped the pattern variables at the wrong level, leaving them bound incorrectly on the cleanup path through a failed 'where' clause check. Fixes rdar://problem/31539726.
