### PR TITLE
[semantic-sil] Update capture promotion for moving mark_uninitialized onto alloc_box instead of project_box and move the fixup pass behind it.

### DIFF
--- a/include/swift/Basic/STLExtras.h
+++ b/include/swift/Basic/STLExtras.h
@@ -711,6 +711,17 @@ inline void copy(const Container &C, OutputIterator iter) {
   std::copy(C.begin(), C.end(), iter);
 }
 
+template <typename Container, typename OutputIterator, typename Predicate>
+inline void copy_if(const Container &C, OutputIterator result, Predicate pred) {
+  std::copy_if(C.begin(), C.end(), result, pred);
+}
+
+template <typename Container, typename OutputIterator, typename UnaryOperation>
+inline OutputIterator transform(const Container &C, OutputIterator result,
+                                UnaryOperation op) {
+  return std::transform(C.begin(), C.end(), result, op);
+}
+
 //===----------------------------------------------------------------------===//
 //                              Function Traits
 //===----------------------------------------------------------------------===//

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -895,6 +895,11 @@ public:
     return getType().castTo<SILBoxType>();
   }
 
+  // Return the type of the memory stored in the alloc_box.
+  SILType getAddressType() const {
+    return getBoxType()->getFieldType(getModule(), 0).getAddressType();
+  }
+
   /// Return the underlying variable declaration associated with this
   /// allocation, or null if this is a temporary allocation.
   VarDecl *getDecl() const;

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -261,6 +261,8 @@ PASS(ValueOwnershipKindDumper, "value-ownership-kind-dumper",
      "Print Value Ownership Kind for Testing")
 PASS(SemanticARCOpts, "semantic-arc-opts",
      "Semantic ARC Optimization")
+PASS(MarkUninitializedFixup, "mark-uninitialized-fixup",
+     "Temporary pass for staging in mark_uninitialized changes.")
 PASS(BugReducerTester, "bug-reducer-tester",
      "sil-bug-reducer Tool Testing by Asserting on a Sentinel Function")
 PASS_RANGE(AllPasses, AADumper, BugReducerTester)

--- a/lib/SIL/SILOwnershipVerifier.cpp
+++ b/lib/SIL/SILOwnershipVerifier.cpp
@@ -303,7 +303,8 @@ public:
   bool isAddressOrTrivialType() const {
     if (getType().isAddress())
       return true;
-    return getOwnershipKind() == ValueOwnershipKind::Trivial;
+    return getOwnershipKind() == ValueOwnershipKind::Trivial ||
+      getOwnershipKind() == ValueOwnershipKind::Any;
   }
 
   /// Depending on our initialization, either return false or call Func and
@@ -1927,6 +1928,9 @@ void SILInstruction::verifyOperandOwnership() const {
   auto *Self = const_cast<SILInstruction *>(this);
   for (const Operand &Op : getAllOperands()) {
     if (isTypeDependentOperand(Op))
+      continue;
+    // Skip any SILUndef that we see.
+    if (isa<SILUndef>(Op.get()))
       continue;
     OwnershipCompatibilityUseChecker(getModule(), Op, Op.get(), ErrorBehavior)
         .check(Self);

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -1415,9 +1415,17 @@ public:
     require(MU->getModule().getStage() == SILStage::Raw,
             "mark_uninitialized instruction can only exist in raw SIL");
     require(Src->getType().isAddress() ||
-            Src->getType().getSwiftRValueType()->getClassOrBoundGenericClass(),
-            "mark_uninitialized must be an address or class");
+                Src->getType()
+                    .getSwiftRValueType()
+                    ->getClassOrBoundGenericClass() ||
+                Src->getType().getAs<SILBoxType>(),
+            "mark_uninitialized must be an address, class, or box type");
     require(Src->getType() == MU->getType(),"operand and result type mismatch");
+#if 0
+    // This will be turned back on in a couple of commits.
+    require(isa<AllocationInst>(Src) || isa<SILArgument>(Src),
+            "Mark Uninitialized should always be on the storage location");
+#endif
   }
   
   void checkMarkUninitializedBehaviorInst(MarkUninitializedBehaviorInst *MU) {
@@ -1888,9 +1896,19 @@ public:
 
     require(AI->getType().isObject(),
             "result of alloc_box must be an object");
-    for (unsigned field : indices(AI->getBoxType()->getLayout()->getFields()))
+    for (unsigned field : indices(AI->getBoxType()->getLayout()->getFields())) {
       verifyOpenedArchetype(AI,
                    AI->getBoxType()->getFieldLoweredType(F.getModule(), field));
+    }
+
+    // An alloc_box with a mark_uninitialized user can not have any other users.
+    require(none_of(AI->getUses(),
+                    [](Operand *Op) -> bool {
+                      return isa<MarkUninitializedInst>(Op->getUser());
+                    }) ||
+                AI->hasOneUse(),
+            "An alloc_box with a mark_uninitialized user can not have any "
+            "other users.");
   }
 
   void checkDeallocBoxInst(DeallocBoxInst *DI) {

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -567,11 +567,7 @@ void SILGenFunction::emitClassConstructorInitializer(ConstructorDecl *ctor) {
 
   if (NeedsBoxForSelf) {
     // Allocate the local variable for 'self'.
-    emitLocalVariableWithCleanup(selfDecl, None)->finishInitialization(*this);
-
-    auto &SelfVarLoc = VarLocs[selfDecl];
-    SelfVarLoc.value = B.createMarkUninitialized(selfDecl,
-                                                 SelfVarLoc.value, MUKind);
+    emitLocalVariableWithCleanup(selfDecl, MUKind)->finishInitialization(*this);
   }
 
   // Emit the prolog for the non-self arguments.

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -386,13 +386,14 @@ public:
 
     // The variable may have its lifetime extended by a closure, heap-allocate
     // it using a box.
-    AllocBoxInst *allocBox =
+    SILInstruction *allocBox =
         SGF.B.createAllocBox(decl, boxType, {decl->isLet(), ArgNo});
-    SILValue addr = SGF.B.createProjectBox(decl, allocBox, 0);
 
     // Mark the memory as uninitialized, so DI will track it for us.
     if (kind)
-      addr = SGF.B.createMarkUninitialized(decl, addr, kind.getValue());
+      allocBox = SGF.B.createMarkUninitialized(decl, allocBox, kind.getValue());
+
+    SILValue addr = SGF.B.createProjectBox(decl, allocBox, 0);
 
     /// Remember that this is the memory location that we're emitting the
     /// decl to.

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -276,7 +276,8 @@ void SILGenFunction::emitCaptures(SILLocation loc,
         
         AllocBoxInst *allocBox = B.createAllocBox(loc, boxTy);
         ProjectBoxInst *boxAddress = B.createProjectBox(loc, allocBox, 0);
-        B.createCopyAddr(loc, vl.value, boxAddress, IsNotTake,IsInitialization);
+        B.createCopyAddr(loc, vl.value, boxAddress, IsNotTake,
+                         IsInitialization);
         capturedArgs.push_back(emitManagedRValueWithCleanup(allocBox));
       }
 

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -74,6 +74,7 @@ static void addOwnershipModelEliminatorPipeline(SILPassPipelinePlan &P) {
 static void addMandatoryOptPipeline(SILPassPipelinePlan &P,
                                     const SILOptions &Options) {
   P.startPipeline("Guaranteed Passes");
+  P.addMarkUninitializedFixup();
   if (Options.EnableMandatorySemanticARCOpts) {
     P.addSemanticARCOpts();
   }

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -79,8 +79,8 @@ static void addMandatoryOptPipeline(SILPassPipelinePlan &P,
   }
   P.addDiagnoseStaticExclusivity();
   P.addCapturePromotion();
-  P.addMarkUninitializedFixup();
   P.addAllocBoxToStack();
+  P.addMarkUninitializedFixup();
   P.addNoReturnFolding();
   P.addOwnershipModelEliminator();
   P.addDefiniteInitialization();

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -74,12 +74,12 @@ static void addOwnershipModelEliminatorPipeline(SILPassPipelinePlan &P) {
 static void addMandatoryOptPipeline(SILPassPipelinePlan &P,
                                     const SILOptions &Options) {
   P.startPipeline("Guaranteed Passes");
-  P.addMarkUninitializedFixup();
   if (Options.EnableMandatorySemanticARCOpts) {
     P.addSemanticARCOpts();
   }
   P.addDiagnoseStaticExclusivity();
   P.addCapturePromotion();
+  P.addMarkUninitializedFixup();
   P.addAllocBoxToStack();
   P.addNoReturnFolding();
   P.addOwnershipModelEliminator();

--- a/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
+++ b/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
@@ -109,12 +109,13 @@ static bool addLastRelease(SILValue V, SILBasicBlock *BB,
 // Find the final releases of the alloc_box along any given path.
 // These can include paths from a release back to the alloc_box in a
 // loop.
-static bool getFinalReleases(AllocBoxInst *ABI,
-                             llvm::SmallVectorImpl<SILInstruction*> &Releases) {
+static bool
+getFinalReleases(SILValue Box,
+                 llvm::SmallVectorImpl<SILInstruction *> &Releases) {
   llvm::SmallPtrSet<SILBasicBlock*, 16> LiveIn;
   llvm::SmallPtrSet<SILBasicBlock*, 16> UseBlocks;
 
-  auto *DefBB = ABI->getParent();
+  auto *DefBB = Box->getParentBlock();
 
   auto seenRelease = false;
   SILInstruction *OneRelease = nullptr;
@@ -122,7 +123,7 @@ static bool getFinalReleases(AllocBoxInst *ABI,
   // We'll treat this like a liveness problem where the alloc_box is
   // the def. Each block that has a use of the owning pointer has the
   // value live-in unless it is the block with the alloc_box.
-  llvm::SmallVector<Operand *, 32> Worklist(ABI->use_begin(), ABI->use_end());
+  llvm::SmallVector<Operand *, 32> Worklist(Box->use_begin(), Box->use_end());
   while (!Worklist.empty()) {
     auto *Op = Worklist.pop_back_val();
     auto *User = Op->getUser();
@@ -137,12 +138,10 @@ static bool getFinalReleases(AllocBoxInst *ABI,
     // Also keep track of the blocks with uses.
     UseBlocks.insert(BB);
 
-    // If we have a copy value, add its uses to the work list and continue.
-    //
-    // We are actually performing multiple operations here. We are eliminating
-    // copies of the box and the box itself.
-    if (auto *CVI = dyn_cast<CopyValueInst>(User)) {
-      std::copy(CVI->use_begin(), CVI->use_end(), std::back_inserter(Worklist));
+    // If we have a copy value or a mark_uninitialized, add its uses to the work
+    // list and continue.
+    if (isa<MarkUninitializedInst>(User) || isa<CopyValueInst>(User)) {
+      copy(User->getUses(), std::back_inserter(Worklist));
       continue;
     }
 
@@ -171,7 +170,7 @@ static bool getFinalReleases(AllocBoxInst *ABI,
   // release/dealloc.
   for (auto *BB : UseBlocks)
     if (!successorHasLiveIn(BB, LiveIn))
-      if (!addLastRelease(ABI, BB, Releases))
+      if (!addLastRelease(Box, BB, Releases))
         return false;
 
   return true;
@@ -213,9 +212,8 @@ static bool partialApplyEscapes(SILValue V, bool examineApply) {
     // If we have a copy_value, the copy value does not cause an escape, but its
     // uses might do so... so add the copy_value's uses to the worklist and
     // continue.
-    if (auto *Copy = dyn_cast<CopyValueInst>(User)) {
-      std::copy(Copy->use_begin(), Copy->use_end(),
-                std::back_inserter(Worklist));
+    if (isa<CopyValueInst>(User)) {
+      copy(User->getUses(), std::back_inserter(Worklist));
       continue;
     }
 
@@ -353,11 +351,9 @@ static bool checkPartialApplyBody(Operand *O) {
                                PromotedOperands);
 }
 
-
-/// findUnexpectedBoxUse - Validate that the uses of a pointer to a
-/// box do not eliminate it from consideration for promotion to a
-/// stack element. Optionally examine the body of partial_apply
-/// to see if there is an unexpected use inside.  Return the
+/// Validate that the uses of a pointer to a box do not eliminate it from
+/// consideration for promotion to a stack element. Optionally examine the body
+/// of partial_apply to see if there is an unexpected use inside.  Return the
 /// instruction with the unexpected use if we find one.
 static SILInstruction* findUnexpectedBoxUse(SILValue Box,
                                             bool examinePartialApply,
@@ -386,9 +382,10 @@ static SILInstruction* findUnexpectedBoxUse(SILValue Box,
         (!inAppliedFunction && isa<DeallocBoxInst>(User)))
       continue;
 
-    // If we have a copy_value, visit the users of the copy_value.
-    if (auto *CVI = dyn_cast<CopyValueInst>(User)) {
-      std::copy(CVI->use_begin(), CVI->use_end(), std::back_inserter(Worklist));
+    // If our user instruction is a copy_value or a marked_uninitialized, visit
+    // the users recursively.
+    if (isa<MarkUninitializedInst>(User) || isa<CopyValueInst>(User)) {
+      copy(User->getUses(), std::back_inserter(Worklist));
       continue;
     }
 
@@ -432,19 +429,20 @@ static bool canPromoteAllocBox(AllocBoxInst *ABI,
   return true;
 }
 
-static void replaceProjectBoxUsers(AllocBoxInst *ABI, AllocStackInst *ASI) {
-  llvm::SmallVector<Operand *, 8> Worklist(ABI->use_begin(), ABI->use_end());
+static void replaceProjectBoxUsers(SILValue HeapBox, SILValue StackBox) {
+  llvm::SmallVector<Operand *, 8> Worklist(HeapBox->use_begin(),
+                                           HeapBox->use_end());
   while (!Worklist.empty()) {
     auto *Op = Worklist.pop_back_val();
     if (auto *PBI = dyn_cast<ProjectBoxInst>(Op->getUser())) {
-      PBI->replaceAllUsesWith(ASI);
+      PBI->replaceAllUsesWith(StackBox);
       continue;
     }
 
     auto *CVI = dyn_cast<CopyValueInst>(Op->getUser());
     if (!CVI)
       continue;
-    std::copy(CVI->use_begin(), CVI->use_end(), std::back_inserter(Worklist));
+    copy(CVI->getUses(), std::back_inserter(Worklist));
   }
 }
 
@@ -453,36 +451,40 @@ static void replaceProjectBoxUsers(AllocBoxInst *ABI, AllocStackInst *ASI) {
 static bool rewriteAllocBoxAsAllocStack(AllocBoxInst *ABI) {
   DEBUG(llvm::dbgs() << "*** Promoting alloc_box to stack: " << *ABI);
 
+  SILValue HeapBox = ABI;
+  Optional<MarkUninitializedInst::Kind> Kind;
+  if (HeapBox->hasOneUse()) {
+    auto *User = HeapBox->getSingleUse()->getUser();
+    if (auto *MUI = dyn_cast<MarkUninitializedInst>(User)) {
+      HeapBox = MUI;
+      Kind = MUI->getKind();
+    }
+  }
+
   llvm::SmallVector<SILInstruction *, 4> FinalReleases;
-  if (!getFinalReleases(ABI, FinalReleases))
+  if (!getFinalReleases(HeapBox, FinalReleases))
     return false;
 
   // Promote this alloc_box to an alloc_stack. Insert the alloc_stack
   // at the beginning of the function.
-  SILBuilder BuildAlloc(ABI);
-  BuildAlloc.setCurrentDebugScope(ABI->getDebugScope());
+  SILBuilder Builder(ABI);
+  Builder.setCurrentDebugScope(ABI->getDebugScope());
   assert(ABI->getBoxType()->getLayout()->getFields().size() == 1
          && "rewriting multi-field box not implemented");
-  auto *ASI = BuildAlloc.createAllocStack(ABI->getLoc(),
-                          ABI->getBoxType()->getFieldType(ABI->getModule(), 0),
-                          ABI->getVarInfo());
+  auto *ASI = Builder.createAllocStack(
+      ABI->getLoc(), ABI->getBoxType()->getFieldType(ABI->getModule(), 0),
+      ABI->getVarInfo());
+
+  // Transfer a mark_uninitialized if we have one.
+  SILValue StackBox = ASI;
+  if (Kind) {
+    StackBox =
+        Builder.createMarkUninitialized(ASI->getLoc(), ASI, Kind.getValue());
+  }
 
   // Replace all uses of the address of the box's contained value with
   // the address of the stack location.
-  replaceProjectBoxUsers(ABI, ASI);
-
-  // Check to see if the alloc_box was used by a mark_uninitialized instruction.
-  // If so, any uses of the pointer result need to keep using the MUI, not the
-  // alloc_stack directly.  If we don't do this, DI will miss the uses.
-  SILValue PointerResult = ASI;
-  for (auto UI : ASI->getUses()) {
-    if (auto *MUI = dyn_cast<MarkUninitializedInst>(UI->getUser())) {
-      assert(ASI->hasOneUse() &&
-             "alloc_stack used by mark_uninitialized, but not exclusively!");
-      PointerResult = MUI;
-      break;
-    }
-  }
+  replaceProjectBoxUsers(HeapBox, StackBox);
 
   assert(ABI->getBoxType()->getLayout()->getFields().size() == 1
          && "promoting multi-field box not implemented");
@@ -495,7 +497,7 @@ static bool rewriteAllocBoxAsAllocStack(AllocBoxInst *ABI) {
     if (!isa<DeallocBoxInst>(LastRelease)&& !Lowering.isTrivial()) {
       // For non-trivial types, insert destroys for each final release-like
       // instruction we found that isn't an explicit dealloc_box.
-      Builder.emitDestroyAddrAndFold(Loc, PointerResult);
+      Builder.emitDestroyAddrAndFold(Loc, StackBox);
     }
     Builder.createDeallocStack(Loc, ASI);
   }
@@ -509,10 +511,10 @@ static bool rewriteAllocBoxAsAllocStack(AllocBoxInst *ABI) {
   while (!Worklist.empty()) {
     auto *User = Worklist.pop_back_val();
 
-    if (isa<CopyValueInst>(User)) {
-      std::transform(
-          User->use_begin(), User->use_end(), std::back_inserter(Worklist),
-          [](Operand *Op) -> SILInstruction * { return Op->getUser(); });
+    // Look through any mark_uninitialized, copy_values.
+    if (isa<MarkUninitializedInst>(User) || isa<CopyValueInst>(User)) {
+      transform(User->getUses(), std::back_inserter(Worklist),
+                [](Operand *Op) -> SILInstruction * { return Op->getUser(); });
       User->replaceAllUsesWith(
           SILUndef::get(User->getType(), User->getModule()));
       User->eraseFromParent();

--- a/lib/SILOptimizer/Transforms/CMakeLists.txt
+++ b/lib/SILOptimizer/Transforms/CMakeLists.txt
@@ -14,6 +14,7 @@ set(TRANSFORMS_SOURCES
   Transforms/FunctionSignatureOpts.cpp
   Transforms/GenericSpecializer.cpp
   Transforms/MergeCondFail.cpp
+  Transforms/MarkUninitializedFixup.cpp
   Transforms/OwnershipModelEliminator.cpp
   Transforms/PerformanceInliner.cpp
   Transforms/RedundantLoadElimination.cpp

--- a/lib/SILOptimizer/Transforms/MarkUninitializedFixup.cpp
+++ b/lib/SILOptimizer/Transforms/MarkUninitializedFixup.cpp
@@ -1,0 +1,146 @@
+//===--- MarkUninitializedFixup.cpp ---------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#define DEBUG_TYPE "sil-ownership-model-eliminator"
+#include "swift/SIL/SILBuilder.h"
+#include "swift/SIL/SILFunction.h"
+#include "swift/SIL/SILVisitor.h"
+#include "swift/SILOptimizer/PassManager/Transforms.h"
+
+using namespace swift;
+
+//===----------------------------------------------------------------------===//
+//                           Top Level Entry Point
+//===----------------------------------------------------------------------===//
+
+static SILInstruction *
+getInitialProjectBox(MarkUninitializedInst *MUI,
+                     ArrayRef<ProjectBoxInst *> Projections) {
+  assert(!Projections.empty());
+  if (Projections.size() == 1) {
+    auto *PBI = Projections[0];
+    assert(PBI->getParent() == MUI->getParent());
+    return PBI;
+  }
+
+  // Otherwise, we want to select the earliest project box. There should
+  // only be one.
+  ProjectBoxInst *PBI = Projections[0];
+
+  // Otherwise, we need to find the one that is closest to the
+  // mark_uninitialized. It should be in the same block.
+  for (auto *I : makeArrayRef(Projections).slice(1)) {
+    // If the new instruction is in a different block than the
+    // mark_uninitialized, it can not be a good solution, so skip it.
+    if (I->getParent() != MUI->getParent()) {
+      continue;
+    }
+
+    // If PBI is not in the same block as the MUI, but I is, we picked a
+    // bad initial PBI, set PBI to I.
+    if (PBI->getParent() != MUI->getParent()) {
+      // Otherwise, I is a better candidate than PBI so set PBI to I.
+      PBI = I;
+      continue;
+    }
+
+    // Otherwise, we have that PBI and I are both in the same block. See
+    // which one is first.
+    auto *BB = PBI->getParent();
+    if (BB->end() != std::find_if(PBI->getIterator(), BB->end(),
+                                  [&I](const SILInstruction &InnerI) -> bool {
+                                    return I == &InnerI;
+                                  })) {
+      continue;
+    }
+
+    PBI = I;
+  }
+
+  assert(PBI->getParent() == MUI->getParent());
+  return PBI;
+}
+
+namespace {
+
+struct MarkUninitializedFixup : SILModuleTransform {
+  void run() override {
+    bool MadeChange = false;
+
+    for (auto &F : *getModule()) {
+      for (auto &BB : F) {
+        for (auto II = BB.begin(), IE = BB.end(); II != IE;) {
+          // Grab our given instruction and advance the iterator. This is
+          // important since we may be destroying the given instruction.
+          auto *MUI = dyn_cast<MarkUninitializedInst>(&*II);
+          ++II;
+
+          // If we do not have a mark_uninitialized or we have a
+          // mark_uninitialized of an alloc_box, continue. These are not
+          // interesting to us.
+          if (!MUI)
+            continue;
+
+          auto *Box = dyn_cast<AllocBoxInst>(MUI->getOperand());
+          if (!Box)
+            continue;
+
+          // We expect there to be in most cases exactly one project_box. That
+          // being said, it is not impossible for there to be multiple. In such
+          // a case, we assume that the correct project_box is the one that is
+          // nearest to the mark_uninitialized in the same block. This preserves
+          // the existing behavior.
+          llvm::TinyPtrVector<ProjectBoxInst *> Projections;
+          for (auto *Op : MUI->getUses()) {
+            if (auto *PBI = dyn_cast<ProjectBoxInst>(Op->getUser())) {
+              Projections.push_back(PBI);
+            }
+          }
+          assert(!Projections.empty() && "SILGen should never emit a "
+                                         "mark_uninitialized by itself");
+
+          // First replace all uses of the mark_uninitialized with the box.
+          MUI->replaceAllUsesWith(Box);
+
+          // That means now our project box now has the alloc_box as its
+          // operand. Grab that project_box.
+          SILInstruction *PBI = getInitialProjectBox(MUI, Projections);
+
+          // Then create the new mark_uninitialized and force all uses of the
+          // project_box to go through the new mark_uninitialized.
+          SILBuilder B(std::next(PBI->getIterator()));
+          SILValue Undef = SILUndef::get(PBI->getType(), PBI->getModule());
+          auto *NewMUI = B.createMarkUninitialized(PBI->getLoc(), Undef,
+                                                   MUI->getKind());
+          PBI->replaceAllUsesWith(NewMUI);
+          NewMUI->setOperand(PBI);
+
+          // Finally, remove the old mark_uninitialized.
+          MUI->eraseFromParent();
+          MadeChange = true;
+        }
+      }
+
+      if (MadeChange) {
+        auto InvalidKind =
+            SILAnalysis::InvalidationKind::BranchesAndInstructions;
+        invalidateAnalysis(&F, InvalidKind);
+      }
+    }
+  }
+};
+
+} // end anonymous namespace
+
+SILTransform *swift::createMarkUninitializedFixup() {
+  return new MarkUninitializedFixup();
+}

--- a/test/SILGen/access_marker_gen.swift
+++ b/test/SILGen/access_marker_gen.swift
@@ -7,23 +7,23 @@ public struct S {
 
 // CHECK-LABEL: sil hidden [noinline] @_T017access_marker_gen5initSAA1SVs9AnyObject_pSgF : $@convention(thin) (@owned Optional<AnyObject>) -> @owned S {
 // CHECK: bb0(%0 : $Optional<AnyObject>):
-// CHECK: %[[BOX:.*]] = alloc_box ${ var S }, var, name "s"
-// CHECK: %[[ADDRS:.*]] = project_box %[[BOX]] : ${ var S }, 0
-// CHECK: %[[UNINIT:.*]] = mark_uninitialized [var] %[[ADDRS]] : $*S
+// CHECK: [[BOX:%.*]] = alloc_box ${ var S }, var, name "s"
+// CHECK: [[MARKED_BOX:%.*]] = mark_uninitialized [var] [[BOX]] : ${ var S }
+// CHECK: [[ADDR:%.*]] = project_box [[MARKED_BOX]] : ${ var S }, 0
 // CHECK: cond_br %{{.*}}, bb1, bb2
 // CHECK: bb1:
-// CHECK: %[[ACCESS1:.*]] = begin_access [modify] [unknown] %[[UNINIT]] : $*S
-// CHECK: assign %{{.*}} to %[[ACCESS1]] : $*S
-// CHECK: end_access %[[ACCESS1]] : $*S
+// CHECK: [[ACCESS1:%.*]] = begin_access [modify] [unknown] [[ADDR]] : $*S
+// CHECK: assign %{{.*}} to [[ACCESS1]] : $*S
+// CHECK: end_access [[ACCESS1]] : $*S
 // CHECK: bb2:
-// CHECK: %[[ACCESS2:.*]] = begin_access [modify] [unknown] %[[UNINIT]] : $*S
-// CHECK: assign %{{.*}} to %[[ACCESS2]] : $*S
-// CHECK: end_access %[[ACCESS2]] : $*S
+// CHECK: [[ACCESS2:%.*]] = begin_access [modify] [unknown] [[ADDR]] : $*S
+// CHECK: assign %{{.*}} to [[ACCESS2]] : $*S
+// CHECK: end_access [[ACCESS2]] : $*S
 // CHECK: bb3:
-// CHECK: %[[ACCESS3:.*]] = begin_access [read] [unknown] %[[UNINIT]] : $*S
-// CHECK: %[[RET:.*]] = load [copy] %[[ACCESS3]] : $*S
-// CHECK: end_access %[[ACCESS3]] : $*S
-// CHECK: return %[[RET]] : $S
+// CHECK: [[ACCESS3:%.*]] = begin_access [read] [unknown] [[ADDR]] : $*S
+// CHECK: [[RET:%.*]] = load [copy] [[ACCESS3]] : $*S
+// CHECK: end_access [[ACCESS3]] : $*S
+// CHECK: return [[RET]] : $S
 // CHECK-LABEL: } // end sil function '_T017access_marker_gen5initSAA1SVs9AnyObject_pSgF'
 @inline(never)
 func initS(_ o: AnyObject?) -> S {

--- a/test/SILGen/closures.swift
+++ b/test/SILGen/closures.swift
@@ -310,20 +310,20 @@ class SelfCapturedInInit : Base {
   //
   // First create our initial value for self.
   // CHECK:   [[SELF_BOX:%.*]] = alloc_box ${ var SelfCapturedInInit }, let, name "self"
-  // CHECK:   [[PB_SELF_BOX:%.*]] = project_box [[SELF_BOX]]
-  // CHECK:   [[UNINIT_SELF:%.*]] = mark_uninitialized [derivedself] [[PB_SELF_BOX]]
-  // CHECK:   store [[SELF]] to [init] [[UNINIT_SELF]]
+  // CHECK:   [[UNINIT_SELF:%.*]] = mark_uninitialized [derivedself] [[SELF_BOX]]
+  // CHECK:   [[PB_SELF_BOX:%.*]] = project_box [[UNINIT_SELF]]
+  // CHECK:   store [[SELF]] to [init] [[PB_SELF_BOX]]
   //
   // Then perform the super init sequence.
-  // CHECK:   [[TAKEN_SELF:%.*]] = load [take] [[UNINIT_SELF]]
+  // CHECK:   [[TAKEN_SELF:%.*]] = load [take] [[PB_SELF_BOX]]
   // CHECK:   [[UPCAST_TAKEN_SELF:%.*]] = upcast [[TAKEN_SELF]]
   // CHECK:   [[NEW_SELF:%.*]] = apply {{.*}}([[UPCAST_TAKEN_SELF]]) : $@convention(method) (@owned Base) -> @owned Base
   // CHECK:   [[DOWNCAST_NEW_SELF:%.*]] = unchecked_ref_cast [[NEW_SELF]] : $Base to $SelfCapturedInInit
-  // CHECK:   store [[DOWNCAST_NEW_SELF]] to [init] [[UNINIT_SELF]]
+  // CHECK:   store [[DOWNCAST_NEW_SELF]] to [init] [[PB_SELF_BOX]]
   //
   // Finally put self in the closure.
-  // CHECK:   [[BORROWED_SELF:%.*]] = load_borrow [[UNINIT_SELF]]
-  // CHECK:   [[COPIED_SELF:%.*]] = load [copy] [[UNINIT_SELF]]
+  // CHECK:   [[BORROWED_SELF:%.*]] = load_borrow [[PB_SELF_BOX]]
+  // CHECK:   [[COPIED_SELF:%.*]] = load [copy] [[PB_SELF_BOX]]
   // CHECK:   [[FOO_VALUE:%.*]] = partial_apply {{%.*}}([[COPIED_SELF]]) : $@convention(thin) (@owned SelfCapturedInInit) -> @owned SelfCapturedInInit
   // CHECK:   [[FOO_LOCATION:%.*]] = ref_element_addr [[BORROWED_SELF]]
   // CHECK:   assign [[FOO_VALUE]] to [[FOO_LOCATION]]

--- a/test/SILGen/complete_object_init.swift
+++ b/test/SILGen/complete_object_init.swift
@@ -13,20 +13,19 @@ class A {
 // CHECK-LABEL: sil hidden @_T020complete_object_init1AC{{[_0-9a-zA-Z]*}}fc : $@convention(method) (@owned A) -> @owned A
 // CHECK: bb0([[SELF_PARAM:%[0-9]+]] : $A):
 // CHECK:   [[SELF_BOX:%[0-9]+]] = alloc_box ${ var A }
-// CHECK:   [[PB:%.*]] = project_box [[SELF_BOX]]
-// CHECK:   [[SELF:%[0-9]+]] = mark_uninitialized [delegatingself] [[PB]] : $*A
-// CHECK:   store [[SELF_PARAM]] to [init] [[SELF]] : $*A
-// CHECK:   [[SELFP:%[0-9]+]] = load [take] [[SELF]] : $*A
+// CHECK:   [[UNINIT_SELF:%[0-9]+]] = mark_uninitialized [delegatingself] [[SELF_BOX]] : ${ var A }
+// CHECK:   [[PB:%.*]] = project_box [[UNINIT_SELF]]
+// CHECK:   store [[SELF_PARAM]] to [init] [[PB]] : $*A
+// CHECK:   [[SELFP:%[0-9]+]] = load [take] [[PB]] : $*A
 // CHECK:   [[INIT:%[0-9]+]] = class_method [[SELFP]] : $A, #A.init!initializer.1 : (A.Type) -> (X) -> A, $@convention(method) (X, @owned A) -> @owned A
 // CHECK:   [[X_INIT:%[0-9]+]] = function_ref @_T020complete_object_init1XV{{[_0-9a-zA-Z]*}}fC : $@convention(method) (@thin X.Type) -> X
 // CHECK:   [[X_META:%[0-9]+]] = metatype $@thin X.Type
 // CHECK:   [[X:%[0-9]+]] = apply [[X_INIT]]([[X_META]]) : $@convention(method) (@thin X.Type) -> X
 // CHECK:   [[INIT_RESULT:%[0-9]+]] = apply [[INIT]]([[X]], [[SELFP]]) : $@convention(method) (X, @owned A) -> @owned A
-// CHECK:   store [[INIT_RESULT]] to [init] [[SELF]] : $*A
-// CHECK:   [[RESULT:%[0-9]+]] = load [copy] [[SELF]] : $*A
-// CHECK:   destroy_value [[SELF_BOX]] : ${ var A }
+// CHECK:   store [[INIT_RESULT]] to [init] [[PB]] : $*A
+// CHECK:   [[RESULT:%[0-9]+]] = load [copy] [[PB]] : $*A
+// CHECK:   destroy_value [[UNINIT_SELF]] : ${ var A }
 // CHECK:   return [[RESULT]] : $A
-
   convenience init() {
     self.init(x: X())
   }

--- a/test/SILGen/decls.swift
+++ b/test/SILGen/decls.swift
@@ -31,20 +31,20 @@ func MRV() -> (Int, Float, (), Double) {}
 // CHECK-LABEL: sil hidden @_T05decls14tuple_patternsyyF
 func tuple_patterns() {
   var (a, b) : (Int, Float)
-  // CHECK: [[AADDR1:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK: [[PBA:%.*]] = project_box [[AADDR1]]
-  // CHECK: [[AADDR:%[0-9]+]] = mark_uninitialized [var] [[PBA]]
-  // CHECK: [[BADDR1:%[0-9]+]] = alloc_box ${ var Float }
-  // CHECK: [[PBB:%.*]] = project_box [[BADDR1]]
-  // CHECK: [[BADDR:%[0-9]+]] = mark_uninitialized [var] [[PBB]]
+  // CHECK: [[ABOX:%[0-9]+]] = alloc_box ${ var Int }
+  // CHECK: [[AADDR:%[0-9]+]] = mark_uninitialized [var] [[ABOX]]
+  // CHECK: [[PBA:%.*]] = project_box [[AADDR]]
+  // CHECK: [[BBOX:%[0-9]+]] = alloc_box ${ var Float }
+  // CHECK: [[BADDR:%[0-9]+]] = mark_uninitialized [var] [[BBOX]]
+  // CHECK: [[PBB:%.*]] = project_box [[BADDR]]
 
   var (c, d) = (a, b)
   // CHECK: [[CADDR:%[0-9]+]] = alloc_box ${ var Int }
   // CHECK: [[PBC:%.*]] = project_box [[CADDR]]
   // CHECK: [[DADDR:%[0-9]+]] = alloc_box ${ var Float }
   // CHECK: [[PBD:%.*]] = project_box [[DADDR]]
-  // CHECK: copy_addr [[AADDR]] to [initialization] [[PBC]]
-  // CHECK: copy_addr [[BADDR]] to [initialization] [[PBD]]
+  // CHECK: copy_addr [[PBA]] to [initialization] [[PBC]]
+  // CHECK: copy_addr [[PBB]] to [initialization] [[PBD]]
 
   // CHECK: [[EADDR:%[0-9]+]] = alloc_box ${ var Int }
   // CHECK: [[PBE:%.*]] = project_box [[EADDR]]
@@ -65,8 +65,8 @@ func tuple_patterns() {
   // CHECK: [[IADDR:%[0-9]+]] = alloc_box ${ var Int }
   // CHECK: [[PBI:%.*]] = project_box [[IADDR]]
   // CHECK-NOT: alloc_box ${ var Float }
-  // CHECK: copy_addr [[AADDR]] to [initialization] [[PBI]]
-  // CHECK: [[B:%[0-9]+]] = load [trivial] [[BADDR]]
+  // CHECK: copy_addr [[PBA]] to [initialization] [[PBI]]
+  // CHECK: [[B:%[0-9]+]] = load [trivial] [[PBB]]
   // CHECK-NOT: store [[B]]
   var (i,_) = (a, b)
 

--- a/test/SILGen/default_constructor.swift
+++ b/test/SILGen/default_constructor.swift
@@ -30,13 +30,14 @@ struct D {
 // CHECK-LABEL: sil hidden @_T019default_constructor1DV{{[_0-9a-zA-Z]*}}fC : $@convention(method) (@thin D.Type) -> D
 // CHECK: [[THISBOX:%[0-9]+]] = alloc_box ${ var D }
 // CHECK: [[THIS:%[0-9]+]] = mark_uninit
+// CHECK: [[PB_THIS:%.*]] = project_box [[THIS]]
 // CHECK: [[INIT:%[0-9]+]] = function_ref @_T019default_constructor1DV1iSivfi
 // CHECK: [[RESULT:%[0-9]+]] = apply [[INIT]]()
 // CHECK: [[INTVAL:%[0-9]+]] = tuple_extract [[RESULT]] : $(Int, Double), 0
 // CHECK: [[FLOATVAL:%[0-9]+]] = tuple_extract [[RESULT]] : $(Int, Double), 1
-// CHECK: [[IADDR:%[0-9]+]] = struct_element_addr [[THIS]] : $*D, #D.i
+// CHECK: [[IADDR:%[0-9]+]] = struct_element_addr [[PB_THIS]] : $*D, #D.i
 // CHECK: assign [[INTVAL]] to [[IADDR]]
-// CHECK: [[JADDR:%[0-9]+]] = struct_element_addr [[THIS]] : $*D, #D.j
+// CHECK: [[JADDR:%[0-9]+]] = struct_element_addr [[PB_THIS]] : $*D, #D.j
 // CHECK: assign [[FLOATVAL]] to [[JADDR]]
 
 class E {
@@ -67,20 +68,19 @@ class F : E { }
 // CHECK-LABEL: sil hidden @_T019default_constructor1FCACycfc : $@convention(method) (@owned F) -> @owned F
 // CHECK: bb0([[ORIGSELF:%[0-9]+]] : $F)
 // CHECK-NEXT: [[SELF_BOX:%[0-9]+]] = alloc_box ${ var F }
-// CHECK-NEXT: project_box [[SELF_BOX]]
-// CHECK-NEXT: [[SELF:%[0-9]+]] = mark_uninitialized [derivedself]
-// CHECK-NEXT: store [[ORIGSELF]] to [init] [[SELF]] : $*F
-// CHECK-NEXT: [[SELFP:%[0-9]+]] = load [take] [[SELF]] : $*F
+// CHECK-NEXT: [[SELF:%[0-9]+]] = mark_uninitialized [derivedself] [[SELF_BOX]]
+// CHECK-NEXT: [[PB:%.*]] = project_box [[SELF]]
+// CHECK-NEXT: store [[ORIGSELF]] to [init] [[PB]] : $*F
+// CHECK-NEXT: [[SELFP:%[0-9]+]] = load [take] [[PB]] : $*F
 // CHECK-NEXT: [[E:%[0-9]]] = upcast [[SELFP]] : $F to $E
 // CHECK: [[E_CTOR:%[0-9]+]] = function_ref @_T019default_constructor1ECACycfc : $@convention(method) (@owned E) -> @owned E
 // CHECK-NEXT: [[ESELF:%[0-9]]] = apply [[E_CTOR]]([[E]]) : $@convention(method) (@owned E) -> @owned E
 
 // CHECK-NEXT: [[ESELFW:%[0-9]+]] = unchecked_ref_cast [[ESELF]] : $E to $F
-// CHECK-NEXT: store [[ESELFW]] to [init] [[SELF]] : $*F
-// CHECK-NEXT: [[SELFP:%[0-9]+]] = load [copy] [[SELF]] : $*F
-// CHECK-NEXT: destroy_value [[SELF_BOX]] : ${ var F }
+// CHECK-NEXT: store [[ESELFW]] to [init] [[PB]] : $*F
+// CHECK-NEXT: [[SELFP:%[0-9]+]] = load [copy] [[PB]] : $*F
+// CHECK-NEXT: destroy_value [[SELF]] : ${ var F }
 // CHECK-NEXT: return [[SELFP]] : $F
-
 
 // <rdar://problem/19780343> Default constructor for a struct with optional doesn't compile
 

--- a/test/SILGen/errors.swift
+++ b/test/SILGen/errors.swift
@@ -502,15 +502,15 @@ class BaseThrowingInit : HasThrowingInit {
 }
 // CHECK: sil hidden @_T06errors16BaseThrowingInit{{.*}}c : $@convention(method) (Int, Int, @owned BaseThrowingInit) -> (@owned BaseThrowingInit, @error Error)
 // CHECK:      [[BOX:%.*]] = alloc_box ${ var BaseThrowingInit }
-// CHECK:      [[PB:%.*]] = project_box [[BOX]]
-// CHECK:      [[MARKED_BOX:%.*]] = mark_uninitialized [derivedself] [[PB]]
+// CHECK:      [[MARKED_BOX:%.*]] = mark_uninitialized [derivedself] [[BOX]]
+// CHECK:      [[PB:%.*]] = project_box [[MARKED_BOX]]
 //   Initialize subField.
-// CHECK:      [[T0:%.*]] = load_borrow [[MARKED_BOX]]
+// CHECK:      [[T0:%.*]] = load_borrow [[PB]]
 // CHECK-NEXT: [[T1:%.*]] = ref_element_addr [[T0]] : $BaseThrowingInit, #BaseThrowingInit.subField
 // CHECK-NEXT: assign %1 to [[T1]]
-// CHECK-NEXT: end_borrow [[T0]] from [[MARKED_BOX]]
+// CHECK-NEXT: end_borrow [[T0]] from [[PB]]
 //   Super delegation.
-// CHECK-NEXT: [[T0:%.*]] = load [take] [[MARKED_BOX]]
+// CHECK-NEXT: [[T0:%.*]] = load [take] [[PB]]
 // CHECK-NEXT: [[T2:%.*]] = upcast [[T0]] : $BaseThrowingInit to $HasThrowingInit
 // CHECK: [[T3:%[0-9]+]] = function_ref @_T06errors15HasThrowingInitCACSi5value_tKcfc : $@convention(method) (Int, @owned HasThrowingInit) -> (@owned HasThrowingInit, @error Error)
 // CHECK-NEXT: apply [[T3]](%0, [[T2]])

--- a/test/SILGen/extensions.swift
+++ b/test/SILGen/extensions.swift
@@ -56,24 +56,24 @@ struct Box<T> {
 
 // CHECK-LABEL: sil hidden @_T010extensions3BoxVACyxGx1t_tcfC : $@convention(method) <T> (@in T, @thin Box<T>.Type) -> @out Box<T>
 // CHECK:      [[SELF_BOX:%.*]] = alloc_box $<τ_0_0> { var Box<τ_0_0> } <T>
-// CHECK-NEXT: [[SELF_ADDR:%.*]] = project_box [[SELF_BOX]] : $<τ_0_0> { var Box<τ_0_0> } <T>
-// CHECK:      [[SELF_PTR:%.*]] = mark_uninitialized [rootself] [[SELF_ADDR]] : $*Box<T>
+// CHECK-NEXT: [[UNINIT_SELF_BOX:%.*]] = mark_uninitialized [rootself] [[SELF_BOX]]
+// CHECK-NEXT: [[SELF_ADDR:%.*]] = project_box [[UNINIT_SELF_BOX]] : $<τ_0_0> { var Box<τ_0_0> } <T>
 // CHECK:      [[INIT:%.*]] = function_ref @_T010extensions3BoxV1txSgvfi : $@convention(thin) <τ_0_0> () -> @out Optional<τ_0_0>
 // CHECK-NEXT: [[RESULT:%.*]] = alloc_stack $Optional<T>
 // CHECK-NEXT: apply [[INIT]]<T>([[RESULT]]) : $@convention(thin) <τ_0_0> () -> @out Optional<τ_0_0>
-// CHECK-NEXT: [[T_ADDR:%.*]] = struct_element_addr [[SELF_PTR]] : $*Box<T>, #Box.t
+// CHECK-NEXT: [[T_ADDR:%.*]] = struct_element_addr [[SELF_ADDR]] : $*Box<T>, #Box.t
 // CHECK-NEXT: copy_addr [take] [[RESULT]] to [[T_ADDR]] : $*Optional<T>
 // CHECK-NEXT: dealloc_stack [[RESULT]] : $*Optional<T>
 // CHECK-NEXT: [[RESULT:%.*]] = alloc_stack $Optional<T>
 // CHECK-NEXT: [[RESULT_ADDR:%.*]] = init_enum_data_addr [[RESULT]] : $*Optional<T>, #Optional.some!enumelt.1
 // CHECK-NEXT: copy_addr %1 to [initialization] %14 : $*T
 // CHECK-NEXT: inject_enum_addr [[RESULT]] : $*Optional<T>, #Optional.some!enumelt.1
-// CHECK-NEXT: [[T_ADDR:%.*]] = struct_element_addr [[SELF_PTR]] : $*Box<T>, #Box.t
+// CHECK-NEXT: [[T_ADDR:%.*]] = struct_element_addr [[SELF_ADDR]] : $*Box<T>, #Box.t
 // CHECK-NEXT: copy_addr [take] [[RESULT]] to [[T_ADDR:%.*]] : $*Optional<T>
 // CHECK-NEXT: dealloc_stack [[RESULT]] : $*Optional<T>
-// CHECK-NEXT: copy_addr [[SELF_PTR]] to [initialization] %0 : $*Box<T>
+// CHECK-NEXT: copy_addr [[SELF_ADDR]] to [initialization] %0 : $*Box<T>
 // CHECK-NEXT: destroy_addr %1 : $*T
-// CHECK-NEXT: destroy_value [[SELF_BOX]] : $<τ_0_0> { var Box<τ_0_0> } <T>
+// CHECK-NEXT: destroy_value [[UNINIT_SELF_BOX]] : $<τ_0_0> { var Box<τ_0_0> } <T>
 // CHECK-NEXT: [[RESULT:%.*]] = tuple ()
 // CHECK-NEXT: return [[RESULT]] : $()
 

--- a/test/SILGen/foreign_errors.swift
+++ b/test/SILGen/foreign_errors.swift
@@ -193,16 +193,16 @@ class VeryErrorProne : ErrorProne {
 // CHECK-LABEL:    sil hidden @_T014foreign_errors14VeryErrorProneCACs9AnyObject_pSg7withTwo_tKcfc
 // CHECK:    bb0([[ARG1:%.*]] : $Optional<AnyObject>, [[ARG2:%.*]] : $VeryErrorProne):
 // CHECK:      [[BOX:%.*]] = alloc_box ${ var VeryErrorProne }
-// CHECK:      [[PB:%.*]] = project_box [[BOX]]
-// CHECK:      [[MARKED_BOX:%.*]] = mark_uninitialized [derivedself] [[PB]]
-// CHECK:      store [[ARG2]] to [init] [[MARKED_BOX]]
-// CHECK:      [[T0:%.*]] = load [take] [[MARKED_BOX]]
+// CHECK:      [[MARKED_BOX:%.*]] = mark_uninitialized [derivedself] [[BOX]]
+// CHECK:      [[PB:%.*]] = project_box [[MARKED_BOX]]
+// CHECK:      store [[ARG2]] to [init] [[PB]]
+// CHECK:      [[T0:%.*]] = load [take] [[PB]]
 // CHECK-NEXT: [[T1:%.*]] = upcast [[T0]] : $VeryErrorProne to $ErrorProne
 // CHECK-NEXT: [[T2:%.*]] = super_method [volatile] [[T0]] : $VeryErrorProne, #ErrorProne.init!initializer.1.foreign : (ErrorProne.Type) -> (Any?) throws -> ErrorProne, $@convention(objc_method) (Optional<AnyObject>, Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, @owned ErrorProne) -> @owned Optional<ErrorProne>
 // CHECK:      [[BORROWED_ARG1:%.*]] = begin_borrow [[ARG1]]
 // CHECK:      [[ARG1_COPY:%.*]] = copy_value [[BORROWED_ARG1]]
 // CHECK-NOT:  [[BOX]]{{^[0-9]}}
-// CHECK-NOT:  [[MARKED_BOX]]{{^[0-9]}}
+// CHECK-NOT:  [[PB]]{{^[0-9]}}
 // CHECK:      apply [[T2]]([[ARG1_COPY]], {{%.*}}, [[T1]])
 
 // rdar://21051021

--- a/test/SILGen/guaranteed_self.swift
+++ b/test/SILGen/guaranteed_self.swift
@@ -366,23 +366,23 @@ class D: C {
   // CHECK-LABEL: sil hidden @_T015guaranteed_self1DC{{[_0-9a-zA-Z]*}}fc : $@convention(method) (@owned D) -> @owned D
   // CHECK:       bb0([[SELF:%.*]] : $D):
   // CHECK:         [[SELF_BOX:%.*]] = alloc_box ${ var D }
-  // CHECK-NEXT:    [[PB:%.*]] = project_box [[SELF_BOX]]
-  // CHECK-NEXT:    [[SELF_ADDR:%.*]] = mark_uninitialized [derivedself] [[PB]]
-  // CHECK-NEXT:    store [[SELF]] to [init] [[SELF_ADDR]]
-  // CHECK-NOT:     [[SELF_ADDR]]
-  // CHECK:         [[SELF1:%.*]] = load [take] [[SELF_ADDR]]
+  // CHECK-NEXT:    [[MARKED_SELF_BOX:%.*]] = mark_uninitialized [derivedself] [[SELF_BOX]]
+  // CHECK-NEXT:    [[PB:%.*]] = project_box [[MARKED_SELF_BOX]]
+  // CHECK-NEXT:    store [[SELF]] to [init] [[PB]]
+  // CHECK-NOT:     [[PB]]
+  // CHECK:         [[SELF1:%.*]] = load [take] [[PB]]
   // CHECK-NEXT:    [[SUPER1:%.*]] = upcast [[SELF1]]
-  // CHECK-NOT:     [[SELF_ADDR]]
+  // CHECK-NOT:     [[PB]]
   // CHECK:         [[SUPER2:%.*]] = apply {{.*}}([[SUPER1]])
   // CHECK-NEXT:    [[SELF2:%.*]] = unchecked_ref_cast [[SUPER2]]
-  // CHECK-NEXT:    store [[SELF2]] to [init] [[SELF_ADDR]]
-  // CHECK-NOT:     [[SELF_ADDR]]
+  // CHECK-NEXT:    store [[SELF2]] to [init] [[PB]]
+  // CHECK-NOT:     [[PB]]
   // CHECK-NOT:     [[SELF1]]
   // CHECK-NOT:     [[SUPER1]]
   // CHECK-NOT:     [[SELF2]]
   // CHECK-NOT:     [[SUPER2]]
-  // CHECK:         [[SELF_FINAL:%.*]] = load [copy] [[SELF_ADDR]]
-  // CHECK-NEXT:    destroy_value [[SELF_BOX]]
+  // CHECK:         [[SELF_FINAL:%.*]] = load [copy] [[PB]]
+  // CHECK-NEXT:    destroy_value [[MARKED_SELF_BOX]]
   // CHECK-NEXT:    return [[SELF_FINAL]]
   required init() {
     super.init()

--- a/test/SILGen/init_ref_delegation.swift
+++ b/test/SILGen/init_ref_delegation.swift
@@ -8,9 +8,8 @@ struct S {
   init() {
     // CHECK: bb0([[SELF_META:%[0-9]+]] : $@thin S.Type):
     // CHECK-NEXT:   [[SELF_BOX:%[0-9]+]] = alloc_box ${ var S }
-    // CHECK-NEXT:   [[PB:%.*]] = project_box [[SELF_BOX]]
-    // CHECK-NEXT:   [[SELF:%[0-9]+]] = mark_uninitialized [delegatingself] [[PB]] : $*S
-    
+    // CHECK-NEXT:   [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
+    // CHECK-NEXT:   [[PB:%.*]] = project_box [[MARKED_SELF_BOX]]
     // CHECK:   [[S_DELEG_INIT:%[0-9]+]] = function_ref @_T019init_ref_delegation1SV{{[_0-9a-zA-Z]*}}fC : $@convention(method) (X, @thin S.Type) -> S
     
     // CHECK:   [[X_CTOR:%[0-9]+]] = function_ref @_T019init_ref_delegation1XV{{[_0-9a-zA-Z]*}}fC : $@convention(method) (@thin X.Type) -> X
@@ -18,9 +17,9 @@ struct S {
     // CHECK-NEXT:   [[X:%[0-9]+]] = apply [[X_CTOR]]([[X_META]]) : $@convention(method) (@thin X.Type) -> X
     // CHECK-NEXT:   [[REPLACEMENT_SELF:%[0-9]+]] = apply [[S_DELEG_INIT]]([[X]], [[SELF_META]]) : $@convention(method) (X, @thin S.Type) -> S
     self.init(x: X())
-    // CHECK-NEXT:   assign [[REPLACEMENT_SELF]] to [[SELF]] : $*S
-    // CHECK-NEXT:   [[SELF_BOX1:%[0-9]+]] = load [trivial] [[SELF]] : $*S
-    // CHECK-NEXT:   destroy_value [[SELF_BOX]] : ${ var S }
+    // CHECK-NEXT:   assign [[REPLACEMENT_SELF]] to [[PB]] : $*S
+    // CHECK-NEXT:   [[SELF_BOX1:%[0-9]+]] = load [trivial] [[PB]] : $*S
+    // CHECK-NEXT:   destroy_value [[MARKED_SELF_BOX]] : ${ var S }
     // CHECK-NEXT:   return [[SELF_BOX1]] : $S
   }
 
@@ -36,8 +35,8 @@ enum E {
   init() {
     // CHECK: bb0([[E_META:%[0-9]+]] : $@thin E.Type):
     // CHECK:   [[E_BOX:%[0-9]+]] = alloc_box ${ var E }
-    // CHECK:   [[PB:%.*]] = project_box [[E_BOX]]
-    // CHECK:   [[E_SELF:%[0-9]+]] = mark_uninitialized [delegatingself] [[PB]] : $*E
+    // CHECK:   [[MARKED_E_BOX:%[0-9]+]] = mark_uninitialized [delegatingself] [[E_BOX]]
+    // CHECK:   [[PB:%.*]] = project_box [[MARKED_E_BOX]]
 
     // CHECK:   [[X_INIT:%[0-9]+]] = function_ref @_T019init_ref_delegation1EO{{[_0-9a-zA-Z]*}}fC : $@convention(method) (X, @thin E.Type) -> E
 
@@ -45,10 +44,10 @@ enum E {
     // CHECK:   [[X_META:%[0-9]+]] = metatype $@thin X.Type
     // CHECK:   [[X:%[0-9]+]] = apply [[E_DELEG_INIT]]([[X_META]]) : $@convention(method) (@thin X.Type) -> X
     // CHECK:   [[S:%[0-9]+]] = apply [[X_INIT]]([[X]], [[E_META]]) : $@convention(method) (X, @thin E.Type) -> E
-    // CHECK:   assign [[S:%[0-9]+]] to [[E_SELF]] : $*E
-    // CHECK:   [[E_BOX1:%[0-9]+]] = load [trivial] [[E_SELF]] : $*E
+    // CHECK:   assign [[S:%[0-9]+]] to [[PB]] : $*E
+    // CHECK:   [[E_BOX1:%[0-9]+]] = load [trivial] [[PB]] : $*E
     self.init(x: X())
-    // CHECK:   destroy_value [[E_BOX]] : ${ var E }
+    // CHECK:   destroy_value [[MARKED_E_BOX]] : ${ var E }
     // CHECK:   return [[E_BOX1:%[0-9]+]] : $E
   }
 
@@ -61,9 +60,8 @@ struct S2 {
   init() {
     // CHECK: bb0([[S2_META:%[0-9]+]] : $@thin S2.Type):
     // CHECK:   [[SELF_BOX:%[0-9]+]] = alloc_box ${ var S2 }
-    // CHECK:   [[PB:%.*]] = project_box [[SELF_BOX]]
-    // CHECK:   [[SELF:%[0-9]+]] = mark_uninitialized [delegatingself] [[PB]] : $*S2
-
+    // CHECK:   [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
+    // CHECK:   [[PB:%.*]] = project_box [[MARKED_SELF_BOX]]
     // CHECK:   [[S2_DELEG_INIT:%[0-9]+]] = function_ref @_T019init_ref_delegation2S2V{{[_0-9a-zA-Z]*}}fC : $@convention(method) <τ_0_0> (@in τ_0_0, @thin S2.Type) -> S2
 
     // CHECK:   [[X_INIT:%[0-9]+]] = function_ref @_T019init_ref_delegation1XV{{[_0-9a-zA-Z]*}}fC : $@convention(method) (@thin X.Type) -> X
@@ -73,10 +71,10 @@ struct S2 {
     // CHECK:   store [[X]] to [trivial] [[X_BOX]] : $*X
     // CHECK:   [[SELF_BOX1:%[0-9]+]] = apply [[S2_DELEG_INIT]]<X>([[X_BOX]], [[S2_META]]) : $@convention(method) <τ_0_0> (@in τ_0_0, @thin S2.Type) -> S2
     // CHECK:   dealloc_stack [[X_BOX]] : $*X
-    // CHECK:   assign [[SELF_BOX1]] to [[SELF]] : $*S2
-    // CHECK:   [[SELF_BOX4:%[0-9]+]] = load [trivial] [[SELF]] : $*S2
+    // CHECK:   assign [[SELF_BOX1]] to [[PB]] : $*S2
+    // CHECK:   [[SELF_BOX4:%[0-9]+]] = load [trivial] [[PB]] : $*S2
     self.init(t: X())
-    // CHECK:   destroy_value [[SELF_BOX]] : ${ var S2 }
+    // CHECK:   destroy_value [[MARKED_SELF_BOX]] : ${ var S2 }
     // CHECK:   return [[SELF_BOX4]] : $S2
   }
 
@@ -92,16 +90,17 @@ class C1 {
   convenience init(x: X) {
     // CHECK: bb0([[X:%[0-9]+]] : $X, [[ORIG_SELF:%[0-9]+]] : $C1):
     // CHECK:   [[SELF_BOX:%[0-9]+]] = alloc_box ${ var C1 }
-    // CHECK:   [[PB:%.*]] = project_box [[SELF_BOX]]
-    // CHECK:   [[SELF:%[0-9]+]] = mark_uninitialized [delegatingself] [[PB]] : $*C1
-    // CHECK:   store [[ORIG_SELF]] to [init] [[SELF]] : $*C1
-    // CHECK:   [[SELF_FROM_BOX:%[0-9]+]] = load [take] [[SELF]] : $*C1
+    // CHECK:   [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
+    // CHECK:   [[PB:%.*]] = project_box [[MARKED_SELF_BOX]]
+
+    // CHECK:   store [[ORIG_SELF]] to [init] [[PB]] : $*C1
+    // CHECK:   [[SELF_FROM_BOX:%[0-9]+]] = load [take] [[PB]] : $*C1
 
     // CHECK:   [[DELEG_INIT:%[0-9]+]] = class_method [[SELF_FROM_BOX]] : $C1, #C1.init!initializer.1 : (C1.Type) -> (X, X) -> C1, $@convention(method) (X, X, @owned C1) -> @owned C1
     // CHECK:   [[SELFP:%[0-9]+]] = apply [[DELEG_INIT]]([[X]], [[X]], [[SELF_FROM_BOX]]) : $@convention(method) (X, X, @owned C1) -> @owned C1
-    // CHECK:   store [[SELFP]] to [init] [[SELF]] : $*C1
-    // CHECK:   [[SELFP:%[0-9]+]] = load [copy] [[SELF]] : $*C1
-    // CHECK:   destroy_value [[SELF_BOX]] : ${ var C1 }
+    // CHECK:   store [[SELFP]] to [init] [[PB]] : $*C1
+    // CHECK:   [[SELFP:%[0-9]+]] = load [copy] [[PB]] : $*C1
+    // CHECK:   destroy_value [[MARKED_SELF_BOX]] : ${ var C1 }
     // CHECK:   return [[SELFP]] : $C1
     self.init(x1: x, x2: x)
   }
@@ -116,16 +115,16 @@ class C1 {
   convenience init(x: X) {
     // CHECK: bb0([[X:%[0-9]+]] : $X, [[ORIG_SELF:%[0-9]+]] : $C2):
     // CHECK:   [[SELF_BOX:%[0-9]+]] = alloc_box ${ var C2 }
-    // CHECK:   [[PB:%.*]] = project_box [[SELF_BOX]]
-    // CHECK:   [[UNINIT_SELF:%[0-9]+]] = mark_uninitialized [delegatingself] [[PB]] : $*C2
-    // CHECK:   store [[ORIG_SELF]] to [init] [[UNINIT_SELF]] : $*C2
-    // CHECK:   [[SELF:%[0-9]+]] = load [take] [[UNINIT_SELF]] : $*C2
+    // CHECK:   [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
+    // CHECK:   [[PB_SELF:%.*]] = project_box [[MARKED_SELF_BOX]]
+    // CHECK:   store [[ORIG_SELF]] to [init] [[PB_SELF]] : $*C2
+    // CHECK:   [[SELF:%[0-9]+]] = load [take] [[PB_SELF]] : $*C2
 
     // CHECK:   [[DELEG_INIT:%[0-9]+]] = class_method [[SELF]] : $C2, #C2.init!initializer.1 : (C2.Type) -> (X, X) -> C2, $@convention(method) (X, X, @owned C2) -> @owned C2
     // CHECK:   [[REPLACE_SELF:%[0-9]+]] = apply [[DELEG_INIT]]([[X]], [[X]], [[SELF]]) : $@convention(method) (X, X, @owned C2) -> @owned C2
-    // CHECK:   store [[REPLACE_SELF]] to [init] [[UNINIT_SELF]] : $*C2
-    // CHECK:   [[VAR_15:%[0-9]+]] = load [copy] [[UNINIT_SELF]] : $*C2
-    // CHECK:   destroy_value [[SELF_BOX]] : ${ var C2 }
+    // CHECK:   store [[REPLACE_SELF]] to [init] [[PB_SELF]] : $*C2
+    // CHECK:   [[VAR_15:%[0-9]+]] = load [copy] [[PB_SELF]] : $*C2
+    // CHECK:   destroy_value [[MARKED_SELF_BOX]] : ${ var C2 }
     // CHECK:   return [[VAR_15]] : $C2
     self.init(x1: x, x2: x)
     // CHECK-NOT: sil hidden @_T019init_ref_delegation2C2C{{[_0-9a-zA-Z]*}}fcTo : $@convention(objc_method) (X, @owned C2) -> @owned C2 {

--- a/test/SILGen/initializers.swift
+++ b/test/SILGen/initializers.swift
@@ -361,12 +361,12 @@ class FailableBaseClass {
   // CHECK-LABEL: sil hidden @_T021failable_initializers17FailableBaseClassCACSgyt19failAfterDelegation_tcfc : $@convention(method) (@owned FailableBaseClass) -> @owned Optional<FailableBaseClass> {
   // CHECK: bb0([[OLD_SELF:%.*]] : $FailableBaseClass):
   // CHECK:   [[SELF_BOX:%.*]] = alloc_box ${ var FailableBaseClass }, let, name "self"
-  // CHECK:   [[PB_BOX:%.*]] = project_box [[SELF_BOX]]
-  // CHECK:   [[MUI:%.*]] = mark_uninitialized [delegatingself] [[PB_BOX]]
-  // CHECK:   store [[OLD_SELF]] to [init] [[MUI]]
-  // CHECK:   [[TAKE_SELF:%.*]] = load [take] [[MUI]]
+  // CHECK:   [[MARKED_SELF_BOX:%.*]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
+  // CHECK:   [[PB_BOX:%.*]] = project_box [[MARKED_SELF_BOX]]
+  // CHECK:   store [[OLD_SELF]] to [init] [[PB_BOX]]
+  // CHECK:   [[TAKE_SELF:%.*]] = load [take] [[PB_BOX]]
   // CHECK:   [[NEW_SELF:%.*]] = apply {{.*}}([[TAKE_SELF]]) : $@convention(method) (@owned FailableBaseClass) -> @owned FailableBaseClass
-  // CHECK:   destroy_value [[SELF_BOX]]
+  // CHECK:   destroy_value [[MARKED_SELF_BOX]]
   // CHECK:   [[RESULT:%.*]] = enum $Optional<FailableBaseClass>, #Optional.none!enumelt
   // CHECK:   br bb2([[RESULT]] : $Optional<FailableBaseClass>)
   // CHECK: bb2([[RESULT:%.*]] : $Optional<FailableBaseClass>):
@@ -382,10 +382,10 @@ class FailableBaseClass {
   // CHECK-LABEL: sil hidden @_T021failable_initializers17FailableBaseClassCACSgyt20failDuringDelegation_tcfc : $@convention(method) (@owned FailableBaseClass) -> @owned Optional<FailableBaseClass> {
   // CHECK: bb0([[OLD_SELF:%.*]] : $FailableBaseClass):
   // CHECK:   [[SELF_BOX:%.*]] = alloc_box ${ var FailableBaseClass }, let, name "self"
-  // CHECK:   [[PB_BOX:%.*]] = project_box [[SELF_BOX]]
-  // CHECK:   [[MUI:%.*]] = mark_uninitialized [delegatingself] [[PB_BOX]]
-  // CHECK:   store [[OLD_SELF]] to [init] [[MUI]]
-  // CHECK:   [[TAKE_SELF:%.*]] = load [take] [[MUI]]
+  // CHECK:   [[MARKED_SELF_BOX:%.*]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
+  // CHECK:   [[PB_BOX:%.*]] = project_box [[MARKED_SELF_BOX]]
+  // CHECK:   store [[OLD_SELF]] to [init] [[PB_BOX]]
+  // CHECK:   [[TAKE_SELF:%.*]] = load [take] [[PB_BOX]]
   // CHECK:   [[NEW_SELF:%.*]] = apply {{.*}}([[TAKE_SELF]]) : $@convention(method) (@owned FailableBaseClass) -> @owned Optional<FailableBaseClass>
   // CHECK:   cond_br {{.*}}, [[SUCC_BB:bb[0-9]+]], [[FAIL_BB:bb[0-9]+]]
   //
@@ -395,14 +395,14 @@ class FailableBaseClass {
   //
   // CHECK: [[SUCC_BB]]:
   // CHECK:   [[UNWRAPPED_NEW_SELF:%.*]] = unchecked_enum_data [[NEW_SELF]] : $Optional<FailableBaseClass>, #Optional.some!enumelt.1
-  // CHECK:   store [[UNWRAPPED_NEW_SELF]] to [init] [[MUI]]
-  // CHECK:   [[RESULT:%.*]] = load [copy] [[MUI]]
+  // CHECK:   store [[UNWRAPPED_NEW_SELF]] to [init] [[PB_BOX]]
+  // CHECK:   [[RESULT:%.*]] = load [copy] [[PB_BOX]]
   // CHECK:   [[WRAPPED_RESULT:%.*]] = enum $Optional<FailableBaseClass>, #Optional.some!enumelt.1, [[RESULT]]
-  // CHECK:   destroy_value [[SELF_BOX]]
+  // CHECK:   destroy_value [[MARKED_SELF_BOX]]
   // CHECK:   br [[EPILOG_BB:bb[0-9]+]]([[WRAPPED_RESULT]]
   //
   // CHECK: [[FAIL_EPILOG_BB]]:
-  // CHECK:   destroy_value [[SELF_BOX]]
+  // CHECK:   destroy_value [[MARKED_SELF_BOX]]
   // CHECK:   [[WRAPPED_RESULT:%.*]] = enum $Optional<FailableBaseClass>, #Optional.none!enumelt
   // CHECK:   br [[EPILOG_BB]]([[WRAPPED_RESULT]]
   //
@@ -417,10 +417,10 @@ class FailableBaseClass {
   // CHECK-LABEL: sil hidden @_T021failable_initializers17FailableBaseClassCSQyACGyt21failDuringDelegation2_tcfc : $@convention(method) (@owned FailableBaseClass) -> @owned Optional<FailableBaseClass> {
   // CHECK: bb0([[OLD_SELF:%.*]] : $FailableBaseClass):
   // CHECK:   [[SELF_BOX:%.*]] = alloc_box ${ var FailableBaseClass }, let, name "self"
-  // CHECK:   [[PB_BOX:%.*]] = project_box [[SELF_BOX]]
-  // CHECK:   [[MUI:%.*]] = mark_uninitialized [delegatingself] [[PB_BOX]]
-  // CHECK:   store [[OLD_SELF]] to [init] [[MUI]]
-  // CHECK-NEXT:   [[TAKE_SELF:%.*]] = load [take] [[MUI]]
+  // CHECK:   [[MARKED_SELF_BOX:%.*]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
+  // CHECK:   [[PB_BOX:%.*]] = project_box [[MARKED_SELF_BOX]]
+  // CHECK:   store [[OLD_SELF]] to [init] [[PB_BOX]]
+  // CHECK-NEXT:   [[TAKE_SELF:%.*]] = load [take] [[PB_BOX]]
   // CHECK-NOT: [[OLD_SELF]]
   // CHECK-NOT: copy_value
   // CHECK:   [[NEW_SELF:%.*]] = apply {{.*}}([[TAKE_SELF]]) : $@convention(method) (@owned FailableBaseClass) -> @owned Optional<FailableBaseClass>
@@ -430,10 +430,10 @@ class FailableBaseClass {
   // CHECK:   unreachable
   //
   // CHECK: [[SUCC_BB]]([[RESULT:%.*]] : $FailableBaseClass):
-  // CHECK:   store [[RESULT]] to [init] [[MUI]]
-  // CHECK:   [[RESULT:%.*]] = load [copy] [[MUI]]
+  // CHECK:   store [[RESULT]] to [init] [[PB_BOX]]
+  // CHECK:   [[RESULT:%.*]] = load [copy] [[PB_BOX]]
   // CHECK:   [[WRAPPED_RESULT:%.*]] = enum $Optional<FailableBaseClass>, #Optional.some!enumelt.1, [[RESULT]] : $FailableBaseClass
-  // CHECK:   destroy_value [[SELF_BOX]]
+  // CHECK:   destroy_value [[MARKED_SELF_BOX]]
   // CHECK:   br [[EPILOG_BB:bb[0-9]+]]([[WRAPPED_RESULT]]
   //
   // CHECK: [[EPILOG_BB]]([[WRAPPED_RESULT:%.*]] : $Optional<FailableBaseClass>):
@@ -467,13 +467,13 @@ class FailableDerivedClass : FailableBaseClass {
   // CHECK-LABEL: sil hidden @_T021failable_initializers20FailableDerivedClassCACSgyt27derivedFailBeforeDelegation_tcfc : $@convention(method) (@owned FailableDerivedClass) -> @owned Optional<FailableDerivedClass> {
   // CHECK: bb0([[OLD_SELF:%.*]] : $FailableDerivedClass):
   // CHECK:   [[SELF_BOX:%.*]] = alloc_box ${ var FailableDerivedClass }, let, name "self"
-  // CHECK:   [[PB_BOX:%.*]] = project_box [[SELF_BOX]]
-  // CHECK:   [[MUI:%.*]] = mark_uninitialized [derivedself] [[PB_BOX]]
-  // CHECK:   store [[OLD_SELF]] to [init] [[MUI]]
+  // CHECK:   [[MARKED_SELF_BOX:%.*]] = mark_uninitialized [derivedself] [[SELF_BOX]]
+  // CHECK:   [[PB_BOX:%.*]] = project_box [[MARKED_SELF_BOX]]
+  // CHECK:   store [[OLD_SELF]] to [init] [[PB_BOX]]
   // CHECK-NEXT: br bb1
   //
   // CHECK: bb1:
-  // CHECK-NEXT: destroy_value [[SELF_BOX]]
+  // CHECK-NEXT: destroy_value [[MARKED_SELF_BOX]]
   // CHECK-NEXT: [[RESULT:%.*]] = enum $Optional<FailableDerivedClass>, #Optional.none!enumelt
   // CHECK-NEXT: br bb2([[RESULT]]
   //
@@ -488,19 +488,19 @@ class FailableDerivedClass : FailableBaseClass {
   init?(derivedFailDuringDelegation: ()) {
     // First initialize the lvalue for self.
     // CHECK:   [[SELF_BOX:%.*]] = alloc_box ${ var FailableDerivedClass }, let, name "self"
-    // CHECK:   [[PB_BOX:%.*]] = project_box [[SELF_BOX]]
-    // CHECK:   [[MUI:%.*]] = mark_uninitialized [derivedself] [[PB_BOX]]
-    // CHECK:   store [[OLD_SELF]] to [init] [[MUI]]
+    // CHECK:   [[MARKED_SELF_BOX:%.*]] = mark_uninitialized [derivedself] [[SELF_BOX]]
+    // CHECK:   [[PB_BOX:%.*]] = project_box [[MARKED_SELF_BOX]]
+    // CHECK:   store [[OLD_SELF]] to [init] [[PB_BOX]]
     //
     // Then assign canary to other member using a borrow.
-    // CHECK:   [[BORROWED_SELF:%.*]] = load_borrow [[MUI]]
+    // CHECK:   [[BORROWED_SELF:%.*]] = load_borrow [[PB_BOX]]
     // CHECK:   [[CANARY_VALUE:%.*]] = apply
     // CHECK:   [[CANARY_GEP:%.*]] = ref_element_addr [[BORROWED_SELF]]
     // CHECK:   assign [[CANARY_VALUE]] to [[CANARY_GEP]]
     self.otherMember = Canary()
 
     // Finally, begin the super init sequence.
-    // CHECK:   [[LOADED_SELF:%.*]] = load [take] [[MUI]]
+    // CHECK:   [[LOADED_SELF:%.*]] = load [take] [[PB_BOX]]
     // CHECK:   [[UPCAST_SELF:%.*]] = upcast [[LOADED_SELF]]
     // CHECK:   [[OPT_NEW_SELF:%.*]] = apply {{.*}}([[UPCAST_SELF]]) : $@convention(method) (@owned FailableBaseClass) -> @owned Optional<FailableBaseClass>
     // CHECK:   [[IS_NIL:%.*]] = select_enum [[OPT_NEW_SELF]]
@@ -510,14 +510,14 @@ class FailableDerivedClass : FailableBaseClass {
     // CHECK: [[SUCC_BB]]:
     // CHECK:   [[NEW_SELF:%.*]] = unchecked_enum_data [[OPT_NEW_SELF]]
     // CHECK:   [[DOWNCAST_NEW_SELF:%.*]] = unchecked_ref_cast [[NEW_SELF]]
-    // CHECK:   store [[DOWNCAST_NEW_SELF]] to [init] [[MUI]]
-    // CHECK:   [[RESULT:%.*]] = load [copy] [[MUI]]
+    // CHECK:   store [[DOWNCAST_NEW_SELF]] to [init] [[PB_BOX]]
+    // CHECK:   [[RESULT:%.*]] = load [copy] [[PB_BOX]]
     // CHECK:   [[WRAPPED_RESULT:%.*]] = enum $Optional<FailableDerivedClass>, #Optional.some!enumelt.1, [[RESULT]]
-    // CHECK:   destroy_value [[SELF_BOX]]
+    // CHECK:   destroy_value [[MARKED_SELF_BOX]]
     // CHECK:   br [[EPILOG_BB:bb[0-9]+]]([[WRAPPED_RESULT]]
     //
     // CHECK: [[FAIL_BB]]:
-    // CHECK:   destroy_value [[SELF_BOX]]
+    // CHECK:   destroy_value [[MARKED_SELF_BOX]]
     super.init(failBeforeFullInitialization: ())
   }
 
@@ -626,30 +626,30 @@ class ThrowDerivedClass : ThrowBaseClass {
   // CHECK-LABEL: sil hidden @_T021failable_initializers17ThrowDerivedClassCACSi29failBeforeOrDuringDelegation2_tKcfc
   // CHECK: bb0({{.*}}, [[OLD_SELF:%.*]] : $ThrowDerivedClass):
   // CHECK:   [[SELF_BOX:%.*]] = alloc_box ${ var ThrowDerivedClass }, let, name "self"
-  // CHECK:   [[PB_BOX:%.*]] = project_box [[SELF_BOX]]
-  // CHECK:   [[MUI:%.*]] = mark_uninitialized [delegatingself] [[PB_BOX]]
-  // CHECK:   store [[OLD_SELF]] to [init] [[MUI]]
-  // CHECK:   [[MOVE_ONLY_SELF:%.*]] = load [take] [[MUI]]
+  // CHECK:   [[MARKED_SELF_BOX:%.*]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
+  // CHECK:   [[PB_BOX:%.*]] = project_box [[MARKED_SELF_BOX]]
+  // CHECK:   store [[OLD_SELF]] to [init] [[PB_BOX]]
+  // CHECK:   [[MOVE_ONLY_SELF:%.*]] = load [take] [[PB_BOX]]
   // CHECK:   try_apply {{.*}}({{.*}}) : $@convention(thin) (Int) -> (Int, @error Error), normal [[SUCC_BB1:bb[0-9]+]], error [[ERROR_BB1:bb[0-9]+]]
   //
   // CHECK: [[SUCC_BB1]](
   // CHECK:   try_apply {{.*}}({{.*}}, [[MOVE_ONLY_SELF]]) : $@convention(method) (Int, @owned ThrowDerivedClass) -> (@owned ThrowDerivedClass, @error Error), normal [[SUCC_BB2:bb[0-9]+]], error [[ERROR_BB2:bb[0-9]+]]
   //
   // CHECK: [[SUCC_BB2]]([[NEW_SELF:%.*]] : $ThrowDerivedClass):
-  // CHECK-NEXT: store [[NEW_SELF]] to [init] [[MUI]]
-  // CHECK-NEXT: [[RESULT:%.*]] = load [copy] [[MUI]]
-  // CHECK-NEXT: destroy_value [[SELF_BOX]]
+  // CHECK-NEXT: store [[NEW_SELF]] to [init] [[PB_BOX]]
+  // CHECK-NEXT: [[RESULT:%.*]] = load [copy] [[PB_BOX]]
+  // CHECK-NEXT: destroy_value [[MARKED_SELF_BOX]]
   // CHECK-NEXT: return [[RESULT]]
   //
   // CHECK: [[ERROR_BB1]]([[ERROR:%.*]] : $Error):
-  // CHECK-NEXT: store [[MOVE_ONLY_SELF]] to [init] [[MUI]]
+  // CHECK-NEXT: store [[MOVE_ONLY_SELF]] to [init] [[PB_BOX]]
   // CHECK-NEXT: br [[THROWING_BB:bb[0-9]+]]([[ERROR]]
   //
   // CHECK: [[ERROR_BB2]]([[ERROR:%.*]] : $Error):
   // CHECK-NEXT: br [[THROWING_BB]]([[ERROR]]
   //
   // CHECK: [[THROWING_BB]]([[ERROR:%.*]] : $Error):
-  // CHECK-NEXT: destroy_value [[SELF_BOX]]
+  // CHECK-NEXT: destroy_value [[MARKED_SELF_BOX]]
   // CHECK-NEXT: throw [[ERROR]]
   convenience init(failBeforeOrDuringDelegation2: Int) throws {
     try self.init(failBeforeDelegation: unwrap(failBeforeOrDuringDelegation2))
@@ -663,21 +663,21 @@ class ThrowDerivedClass : ThrowBaseClass {
   // CHECK-LABEL: sil hidden @_T021failable_initializers17ThrowDerivedClassCACSi27failDuringOrAfterDelegation_tKcfc : $@convention(method) (Int, @owned ThrowDerivedClass) -> (@owned ThrowDerivedClass, @error Error) {
   // CHECK: bb0({{.*}}, [[OLD_SELF:%.*]] : $ThrowDerivedClass):
   // CHECK:   [[SELF_BOX:%.*]] = alloc_box ${ var ThrowDerivedClass }, let, name "self"
-  // CHECK:   [[PB_BOX:%.*]] = project_box [[SELF_BOX]]
-  // CHECK:   [[MUI:%.*]] = mark_uninitialized [delegatingself] [[PB_BOX]]
-  // CHECK:   store [[OLD_SELF]] to [init] [[MUI]]
-  // CHECK:   [[MOVE_ONLY_SELF:%.*]] = load [take] [[MUI]]
+  // CHECK:   [[MARKED_SELF_BOX:%.*]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
+  // CHECK:   [[PB_BOX:%.*]] = project_box [[MARKED_SELF_BOX]]
+  // CHECK:   store [[OLD_SELF]] to [init] [[PB_BOX]]
+  // CHECK:   [[MOVE_ONLY_SELF:%.*]] = load [take] [[PB_BOX]]
   // CHECK:   try_apply {{.*}}([[MOVE_ONLY_SELF]]) : $@convention(method) (@owned ThrowDerivedClass) -> (@owned ThrowDerivedClass, @error Error), normal [[SUCC_BB1:bb[0-9]+]], error [[ERROR_BB1:bb[0-9]+]]
   //
   // CHECK: [[SUCC_BB1]]([[NEW_SELF:%.*]] : $ThrowDerivedClass):
-  // CHECK-NEXT:   store [[NEW_SELF]] to [init] [[MUI]]
+  // CHECK-NEXT:   store [[NEW_SELF]] to [init] [[PB_BOX]]
   // CHECK-NEXT:   // function_ref
   // CHECK-NEXT:   function_ref @
   // CHECK-NEXT:   try_apply {{.*}}({{.*}}) : $@convention(thin) (Int) -> (Int, @error Error), normal [[SUCC_BB2:bb[0-9]+]], error [[ERROR_BB2:bb[0-9]+]]
   //
   // CHECK: [[SUCC_BB2]](
-  // CHECK-NEXT: [[RESULT:%.*]] = load [copy] [[MUI]]
-  // CHECK-NEXT: destroy_value [[SELF_BOX]]
+  // CHECK-NEXT: [[RESULT:%.*]] = load [copy] [[PB_BOX]]
+  // CHECK-NEXT: destroy_value [[MARKED_SELF_BOX]]
   // CHECK-NEXT: return [[RESULT]]
   //
   // CHECK: [[ERROR_BB1]]([[ERROR:%.*]] : $Error):
@@ -687,7 +687,7 @@ class ThrowDerivedClass : ThrowBaseClass {
   // CHECK-NEXT: br [[THROWING_BB]]([[ERROR]]
   //
   // CHECK: [[THROWING_BB]]([[ERROR:%.*]] : $Error):
-  // CHECK-NEXT: destroy_value [[SELF_BOX]]
+  // CHECK-NEXT: destroy_value [[MARKED_SELF_BOX]]
   // CHECK-NEXT: throw [[ERROR]]
   convenience init(failDuringOrAfterDelegation: Int) throws {
     try self.init()

--- a/test/SILGen/newtype.swift
+++ b/test/SILGen/newtype.swift
@@ -18,13 +18,13 @@ func createErrorDomain(str: String) -> ErrorDomain {
 // CHECK-RAW-LABEL: sil shared [transparent] [serializable] @_T0SC11ErrorDomainVABSS8rawValue_tcfC
 // CHECK-RAW: bb0([[STR:%[0-9]+]] : $String,
 // CHECK-RAW: [[SELF_BOX:%[0-9]+]] = alloc_box ${ var ErrorDomain }, var, name "self"
-// CHECK-RAW: [[SELF:%[0-9]+]] = project_box [[SELF_BOX]]
-// CHECK-RAW: [[UNINIT_SELF:%[0-9]+]] = mark_uninitialized [rootself] [[SELF]]
+// CHECK-RAW: [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [rootself] [[SELF_BOX]]
+// CHECK-RAW: [[PB_BOX:%[0-9]+]] = project_box [[MARKED_SELF_BOX]]
 // CHECK-RAW: [[BRIDGE_FN:%[0-9]+]] = function_ref @{{.*}}_bridgeToObjectiveC
 // CHECK-RAW: [[BORROWED_STR:%.*]] = begin_borrow [[STR]]
 // CHECK-RAW: [[BRIDGED:%[0-9]+]] = apply [[BRIDGE_FN]]([[BORROWED_STR]])
 // CHECK-RAW: end_borrow [[BORROWED_STR]] from [[STR]]
-// CHECK-RAW: [[RAWVALUE_ADDR:%[0-9]+]] = struct_element_addr [[UNINIT_SELF]]
+// CHECK-RAW: [[RAWVALUE_ADDR:%[0-9]+]] = struct_element_addr [[PB_BOX]]
 // CHECK-RAW: assign [[BRIDGED]] to [[RAWVALUE_ADDR]]
 
 func getRawValue(ed: ErrorDomain) -> String {

--- a/test/SILGen/objc_init_ref_delegation.swift
+++ b/test/SILGen/objc_init_ref_delegation.swift
@@ -9,14 +9,14 @@ extension Gizmo {
   convenience init(int i: Int) {
     // CHECK: bb0([[I:%[0-9]+]] : $Int, [[ORIG_SELF:%[0-9]+]] : $Gizmo):
     // CHECK:   [[SELF_BOX:%[0-9]+]] = alloc_box ${ var Gizmo }
-    // CHECK:   [[PB:%.*]] = project_box [[SELF_BOX]]
-    // CHECK:   [[SELFMUI:%[0-9]+]] = mark_uninitialized [delegatingself] [[PB]] : $*Gizmo
-    // CHECK:   store [[ORIG_SELF]] to [init] [[SELFMUI]] : $*Gizmo
-    // CHECK:   [[SELF:%[0-9]+]] = load [take] [[SELFMUI]] : $*Gizmo
+    // CHECK:   [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
+    // CHECK:   [[PB_BOX:%.*]] = project_box [[MARKED_SELF_BOX]]
+    // CHECK:   store [[ORIG_SELF]] to [init] [[PB_BOX]] : $*Gizmo
+    // CHECK:   [[SELF:%[0-9]+]] = load [take] [[PB_BOX]] : $*Gizmo
     // CHECK:   [[INIT_DELEG:%[0-9]+]] = class_method [volatile] [[SELF]] : $Gizmo, #Gizmo.init!initializer.1.foreign : (Gizmo.Type) -> (Int) -> Gizmo!, $@convention(objc_method) (Int, @owned Gizmo) -> @owned Optional<Gizmo>
     // CHECK:   [[SELF_RET:%[0-9]+]] = apply [[INIT_DELEG]]([[I]], [[SELF]]) : $@convention(objc_method) (Int, @owned Gizmo) -> @owned Optional<Gizmo>
-    // CHECK:   [[SELF4:%.*]] = load [copy] [[SELFMUI]]
-    // CHECK:   destroy_value [[SELF_BOX:%[0-9]+]] : ${ var Gizmo }
+    // CHECK:   [[SELF4:%.*]] = load [copy] [[PB_BOX]]
+    // CHECK:   destroy_value [[MARKED_SELF_BOX]]
     // CHECK:   return [[SELF4]] : $Gizmo
     self.init(bellsOn:i)
   }

--- a/test/SILGen/objc_thunks.swift
+++ b/test/SILGen/objc_thunks.swift
@@ -301,8 +301,8 @@ class Hoozit : Gizmo {
   // Constructor.
   // CHECK-LABEL: sil hidden @_T011objc_thunks6HoozitCACSi7bellsOn_tcfc : $@convention(method) (Int, @owned Hoozit) -> @owned Hoozit {
   // CHECK: [[SELF_BOX:%[0-9]+]] = alloc_box ${ var Hoozit }
-  // CHECK: [[PB:%.*]] = project_box [[SELF_BOX]]
-  // CHECK: [[SELFMUI:%[0-9]+]] = mark_uninitialized [derivedself] [[PB]]
+  // CHECK: [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [derivedself] [[SELF_BOX]]
+  // CHECK: [[PB_BOX:%.*]] = project_box [[MARKED_SELF_BOX]]
   // CHECK: [[GIZMO:%[0-9]+]] = upcast [[SELF:%[0-9]+]] : $Hoozit to $Gizmo
   // CHECK: [[SUPERMETHOD:%[0-9]+]] = super_method [volatile] [[SELF]] : $Hoozit, #Gizmo.init!initializer.1.foreign : (Gizmo.Type) -> (Int) -> Gizmo!, $@convention(objc_method) (Int, @owned Gizmo) -> @owned Optional<Gizmo>
   // CHECK-NEXT: [[SELF_REPLACED:%[0-9]+]] = apply [[SUPERMETHOD]](%0, [[X:%[0-9]+]]) : $@convention(objc_method) (Int, @owned Gizmo) -> @owned Optional<Gizmo>
@@ -409,13 +409,13 @@ extension Hoozit {
   // CHECK-LABEL: sil hidden @_T011objc_thunks6HoozitCACSd6double_tcfc : $@convention(method) (Double, @owned Hoozit) -> @owned Hoozit
   convenience init(double d: Double) { 
     // CHECK: [[SELF_BOX:%[0-9]+]] = alloc_box ${ var Hoozit }
-    // CHECK: [[PB:%.*]] = project_box [[SELF_BOX]]
-    // CHECK: [[SELFMUI:%[0-9]+]] = mark_uninitialized [delegatingself] [[PB]]
+    // CHECK: [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
+    // CHECK: [[PB_BOX:%.*]] = project_box [[MARKED_SELF_BOX]]
     // CHECK: [[X_BOX:%[0-9]+]] = alloc_box ${ var X }
     var x = X()
     // CHECK: [[CTOR:%[0-9]+]] = class_method [volatile] [[SELF:%[0-9]+]] : $Hoozit, #Hoozit.init!initializer.1.foreign : (Hoozit.Type) -> (Int) -> Hoozit, $@convention(objc_method) (Int, @owned Hoozit) -> @owned Hoozit
     // CHECK: [[NEW_SELF:%[0-9]+]] = apply [[CTOR]]
-    // CHECK: store [[NEW_SELF]] to [init] [[SELFMUI]] : $*Hoozit
+    // CHECK: store [[NEW_SELF]] to [init] [[PB_BOX]] : $*Hoozit
     // CHECK: [[NONNULL:%[0-9]+]] = is_nonnull [[NEW_SELF]] : $Hoozit
     // CHECK-NEXT: cond_br [[NONNULL]], [[NONNULL_BB:bb[0-9]+]], [[NULL_BB:bb[0-9]+]]
     // CHECK: [[NULL_BB]]:

--- a/test/SILGen/properties.swift
+++ b/test/SILGen/properties.swift
@@ -11,8 +11,8 @@ func getInt() -> Int { return zero }
 func physical_tuple_lvalue(_ c: Int) {
   var x : (Int, Int)
   // CHECK: [[BOX:%[0-9]+]] = alloc_box ${ var (Int, Int) }
-  // CHECK: [[XADDR1:%.*]] = project_box [[BOX]]
-  // CHECK: [[XADDR:%[0-9]+]] = mark_uninitialized [var] [[XADDR1]]
+  // CHECK: [[MARKED_BOX:%[0-9]+]] = mark_uninitialized [var] [[BOX]]
+  // CHECK: [[XADDR:%.*]] = project_box [[MARKED_BOX]]
   x.1 = c
   // CHECK: [[X_1:%[0-9]+]] = tuple_element_addr [[XADDR]] : {{.*}}, 1
   // CHECK: assign %0 to [[X_1]]
@@ -556,9 +556,10 @@ struct DidSetWillSetTests: ForceAccessors {
   // CHECK-LABEL: sil hidden @_T010properties010DidSetWillC5TestsV{{[_0-9a-zA-Z]*}}fC
   // CHECK: bb0(%0 : $Int, %1 : $@thin DidSetWillSetTests.Type):
   // CHECK:        [[SELF:%.*]] = mark_uninitialized [rootself]
-  // CHECK:        [[P1:%.*]] = struct_element_addr [[SELF]] : $*DidSetWillSetTests, #DidSetWillSetTests.a
+  // CHECK:        [[PB_SELF:%.*]] = project_box [[SELF]]
+  // CHECK:        [[P1:%.*]] = struct_element_addr [[PB_SELF]] : $*DidSetWillSetTests, #DidSetWillSetTests.a
   // CHECK-NEXT:   assign %0 to [[P1]]
-  // CHECK:        [[P2:%.*]] = struct_element_addr [[SELF]] : $*DidSetWillSetTests, #DidSetWillSetTests.a
+  // CHECK:        [[P2:%.*]] = struct_element_addr [[PB_SELF]] : $*DidSetWillSetTests, #DidSetWillSetTests.a
   // CHECK-NEXT:   assign %0 to [[P2]]
 }
 
@@ -924,10 +925,11 @@ class r19254812Derived: r19254812Base{
   
 // Accessing the "pi" property should not copy_value/release self.
 // CHECK-LABEL: sil hidden @_T010properties16r19254812DerivedC{{[_0-9a-zA-Z]*}}fc
-// CHECK: [[SELFMUI:%[0-9]+]] = mark_uninitialized [derivedself] 
+// CHECK: [[MARKED_SELF_BOX:%.*]] = mark_uninitialized [derivedself]
+// CHECK: [[PB_BOX:%.*]] = project_box [[MARKED_SELF_BOX]]
 
 // Initialization of the pi field: no copy_values/releases.
-// CHECK:  [[SELF:%[0-9]+]] = load_borrow [[SELFMUI]] : $*r19254812Derived
+// CHECK:  [[SELF:%[0-9]+]] = load_borrow [[PB_BOX]] : $*r19254812Derived
 // CHECK-NEXT:  [[PIPTR:%[0-9]+]] = ref_element_addr [[SELF]] : $r19254812Derived, #r19254812Derived.pi
 // CHECK-NEXT:  assign {{.*}} to [[PIPTR]] : $*Double
 
@@ -935,7 +937,7 @@ class r19254812Derived: r19254812Base{
 // CHECK-NOT: copy_value
 
 // Load of the pi field: no copy_values/releases.
-// CHECK:  [[SELF:%[0-9]+]] = load_borrow [[SELFMUI]] : $*r19254812Derived
+// CHECK:  [[SELF:%[0-9]+]] = load_borrow [[PB_BOX]] : $*r19254812Derived
 // CHECK-NEXT:  [[PIPTR:%[0-9]+]] = ref_element_addr [[SELF]] : $r19254812Derived, #r19254812Derived.pi
 // CHECK-NEXT:  {{.*}} = load [trivial] [[PIPTR]] : $*Double
 // CHECK: return

--- a/test/SILGen/property_behavior_init.swift
+++ b/test/SILGen/property_behavior_init.swift
@@ -27,9 +27,10 @@ struct Foo {
   // CHECK-LABEL: sil hidden @_T022property_behavior_init3FooV{{[_0-9a-zA-Z]*}}fC
   // CHECK:       bb0([[X:%.*]] : $Int,
   init(x: Int) {
-    // CHECK: [[UNINIT_SELF:%.*]] = mark_uninitialized [rootself]
-    // CHECK: [[UNINIT_STORAGE:%.*]] = struct_element_addr [[UNINIT_SELF]]
-    // CHECK: [[UNINIT_BEHAVIOR:%.*]] = mark_uninitialized_behavior {{.*}}<Foo>([[UNINIT_STORAGE]]) : {{.*}}, {{%.*}}([[UNINIT_SELF]])
+    // CHECK: [[MARKED_SELF_BOX:%.*]] = mark_uninitialized [rootself]
+    // CHECK: [[PB_BOX:%.*]] = project_box [[MARKED_SELF_BOX]]
+    // CHECK: [[UNINIT_STORAGE:%.*]] = struct_element_addr [[PB_BOX]]
+    // CHECK: [[UNINIT_BEHAVIOR:%.*]] = mark_uninitialized_behavior {{.*}}<Foo>([[UNINIT_STORAGE]]) : {{.*}}, {{%.*}}([[PB_BOX]])
 
     // Pure assignments undergo DI analysis so assign to the marking proxy.
 
@@ -40,21 +41,21 @@ struct Foo {
 
     // Reads or inouts use the accessors normally.
 
-    // CHECK: [[SELF:%.*]] = load [trivial] [[UNINIT_SELF]]
+    // CHECK: [[SELF:%.*]] = load [trivial] [[PB_BOX]]
     // CHECK: [[GETTER:%.*]] = function_ref @_T022property_behavior_init3FooV1xSifg
     // CHECK: apply [[GETTER]]([[SELF]])
     _ = self.x
 
     // CHECK: [[WHACK:%.*]] = function_ref @_T022property_behavior_init5whackyxzlF
     // CHECK: [[INOUT:%.*]] = alloc_stack
-    // CHECK: [[SELF:%.*]] = load [trivial] [[UNINIT_SELF]]
+    // CHECK: [[SELF:%.*]] = load [trivial] [[PB_BOX]]
     // CHECK: [[GETTER:%.*]] = function_ref @_T022property_behavior_init3FooV1xSifg
     // CHECK: [[VALUE:%.*]] = apply [[GETTER]]([[SELF]])
     // CHECK: store [[VALUE]] to [trivial] [[INOUT]]
     // CHECK: apply [[WHACK]]<Int>([[INOUT]])
     // CHECK: [[VALUE:%.*]] = load [trivial] [[INOUT]]
     // CHECK: [[SETTER:%.*]] = function_ref @_T022property_behavior_init3FooV1xSifs
-    // CHECK: apply [[SETTER]]([[VALUE]], [[UNINIT_SELF]])
+    // CHECK: apply [[SETTER]]([[VALUE]], [[PB_BOX]])
     whack(&self.x)
   }
 }

--- a/test/SILGen/protocol_extensions.swift
+++ b/test/SILGen/protocol_extensions.swift
@@ -773,15 +773,15 @@ extension ProtoDelegatesToObjC where Self : ObjCInitClass {
   // CHECK: bb0([[STR:%[0-9]+]] : $String, [[SELF_META:%[0-9]+]] : $@thick Self.Type):
   init(string: String) {
     // CHECK:   [[SELF_BOX:%[0-9]+]] = alloc_box $<τ_0_0 where τ_0_0 : ObjCInitClass, τ_0_0 : ProtoDelegatesToObjC> { var τ_0_0 } <Self>
-    // CHECK:   [[PB:%.*]] = project_box [[SELF_BOX]]
-    // CHECK:   [[SELF:%[0-9]+]] = mark_uninitialized [delegatingself] [[PB]] : $*Self
+    // CHECK:   [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
+    // CHECK:   [[PB_SELF_BOX:%.*]] = project_box [[MARKED_SELF_BOX]]
     // CHECK:   [[SELF_META_OBJC:%[0-9]+]] = thick_to_objc_metatype [[SELF_META]] : $@thick Self.Type to $@objc_metatype Self.Type
     // CHECK:   [[SELF_ALLOC:%[0-9]+]] = alloc_ref_dynamic [objc] [[SELF_META_OBJC]] : $@objc_metatype Self.Type, $Self
     // CHECK:   [[SELF_ALLOC_C:%[0-9]+]] = upcast [[SELF_ALLOC]] : $Self to $ObjCInitClass
     // CHECK:   [[OBJC_INIT:%[0-9]+]] = class_method [[SELF_ALLOC_C]] : $ObjCInitClass, #ObjCInitClass.init!initializer.1 : (ObjCInitClass.Type) -> () -> ObjCInitClass, $@convention(method) (@owned ObjCInitClass) -> @owned ObjCInitClass
     // CHECK:   [[SELF_RESULT:%[0-9]+]] = apply [[OBJC_INIT]]([[SELF_ALLOC_C]]) : $@convention(method) (@owned ObjCInitClass) -> @owned ObjCInitClass
     // CHECK:   [[SELF_RESULT_AS_SELF:%[0-9]+]] = unchecked_ref_cast [[SELF_RESULT]] : $ObjCInitClass to $Self
-    // CHECK:   assign [[SELF_RESULT_AS_SELF]] to [[SELF]] : $*Self
+    // CHECK:   assign [[SELF_RESULT_AS_SELF]] to [[PB_SELF_BOX]] : $*Self
     self.init()
   }
 }
@@ -799,13 +799,13 @@ extension ProtoDelegatesToRequired where Self : RequiredInitClass {
   // CHECK: bb0([[STR:%[0-9]+]] : $String, [[SELF_META:%[0-9]+]] : $@thick Self.Type):
   init(string: String) {
   // CHECK:   [[SELF_BOX:%[0-9]+]] = alloc_box $<τ_0_0 where τ_0_0 : RequiredInitClass, τ_0_0 : ProtoDelegatesToRequired> { var τ_0_0 } <Self>
-  // CHECK:   [[PB:%.*]] = project_box [[SELF_BOX]]
-  // CHECK:   [[SELF:%[0-9]+]] = mark_uninitialized [delegatingself] [[PB]] : $*Self
+  // CHECK:   [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
+  // CHECK:   [[PB_SELF_BOX:%.*]] = project_box [[MARKED_SELF_BOX]]
   // CHECK:   [[SELF_META_AS_CLASS_META:%[0-9]+]] = upcast [[SELF_META]] : $@thick Self.Type to $@thick RequiredInitClass.Type
   // CHECK:   [[INIT:%[0-9]+]] = class_method [[SELF_META_AS_CLASS_META]] : $@thick RequiredInitClass.Type, #RequiredInitClass.init!allocator.1 : (RequiredInitClass.Type) -> () -> RequiredInitClass, $@convention(method) (@thick RequiredInitClass.Type) -> @owned RequiredInitClass
   // CHECK:   [[SELF_RESULT:%[0-9]+]] = apply [[INIT]]([[SELF_META_AS_CLASS_META]]) : $@convention(method) (@thick RequiredInitClass.Type) -> @owned RequiredInitClass
   // CHECK:   [[SELF_RESULT_AS_SELF:%[0-9]+]] = unchecked_ref_cast [[SELF_RESULT]] : $RequiredInitClass to $Self
-  // CHECK:   assign [[SELF_RESULT_AS_SELF]] to [[SELF]] : $*Self
+  // CHECK:   assign [[SELF_RESULT_AS_SELF]] to [[PB_SELF_BOX]] : $*Self
     self.init()
   }
 }

--- a/test/SILGen/super_init_refcounting.swift
+++ b/test/SILGen/super_init_refcounting.swift
@@ -9,18 +9,18 @@ class Foo {
 class Bar: Foo {
   // CHECK-LABEL: sil hidden @_T022super_init_refcounting3BarC{{[_0-9a-zA-Z]*}}fc
   // CHECK: bb0([[INPUT_SELF:%.*]] : $Bar):
-  // CHECK:         [[SELF_VAR:%.*]] = alloc_box ${ var Bar }
-  // CHECK:         [[PB:%.*]] = project_box [[SELF_VAR]]
-  // CHECK:         [[SELF_MUI:%.*]] =  mark_uninitialized [derivedself] [[PB]]
-  // CHECK:         store [[INPUT_SELF]] to [init] [[SELF_MUI]]
-  // CHECK:         [[ORIG_SELF:%.*]] = load [take] [[SELF_MUI]]
+  // CHECK:         [[SELF_BOX:%.*]] = alloc_box ${ var Bar }
+  // CHECK:         [[MARKED_SELF_BOX:%.*]] =  mark_uninitialized [derivedself] [[SELF_BOX]]
+  // CHECK:         [[PB_SELF_BOX:%.*]] = project_box [[MARKED_SELF_BOX]]
+  // CHECK:         store [[INPUT_SELF]] to [init] [[PB_SELF_BOX]]
+  // CHECK:         [[ORIG_SELF:%.*]] = load [take] [[PB_SELF_BOX]]
   // CHECK-NOT:     copy_value [[ORIG_SELF]]
   // CHECK:         [[ORIG_SELF_UP:%.*]] = upcast [[ORIG_SELF]]
   // CHECK-NOT:     copy_value [[ORIG_SELF_UP]]
   // CHECK:         [[SUPER_INIT:%[0-9]+]] = function_ref @_T022super_init_refcounting3FooCACycfc : $@convention(method) (@owned Foo) -> @owned Foo
   // CHECK:         [[NEW_SELF:%.*]] = apply [[SUPER_INIT]]([[ORIG_SELF_UP]])
   // CHECK:         [[NEW_SELF_DOWN:%.*]] = unchecked_ref_cast [[NEW_SELF]]
-  // CHECK:         store [[NEW_SELF_DOWN]] to [init] [[SELF_MUI]]
+  // CHECK:         store [[NEW_SELF_DOWN]] to [init] [[PB_SELF_BOX]]
   override init() {
     super.init()
   }
@@ -28,14 +28,14 @@ class Bar: Foo {
 
 extension Foo {
   // CHECK-LABEL: sil hidden @_T022super_init_refcounting3FooC{{[_0-9a-zA-Z]*}}fc
-  // CHECK:         [[SELF_VAR:%.*]] = alloc_box ${ var Foo }
-  // CHECK:         [[PB:%.*]] = project_box [[SELF_VAR]]
-  // CHECK:         [[SELF_MUI:%.*]] =  mark_uninitialized [delegatingself] [[PB]]
-  // CHECK:         [[ORIG_SELF:%.*]] = load [take] [[SELF_MUI]]
+  // CHECK:         [[SELF_BOX:%.*]] = alloc_box ${ var Foo }
+  // CHECK:         [[MARKED_SELF_BOX:%.*]] =  mark_uninitialized [delegatingself] [[SELF_BOX]]
+  // CHECK:         [[PB_SELF_BOX:%.*]] = project_box [[MARKED_SELF_BOX]]
+  // CHECK:         [[ORIG_SELF:%.*]] = load [take] [[PB_SELF_BOX]]
   // CHECK-NOT:     copy_value [[ORIG_SELF]]
   // CHECK:         [[SUPER_INIT:%.*]] = class_method
   // CHECK:         [[NEW_SELF:%.*]] = apply [[SUPER_INIT]]([[ORIG_SELF]])
-  // CHECK:         store [[NEW_SELF]] to [init] [[SELF_MUI]]
+  // CHECK:         store [[NEW_SELF]] to [init] [[PB_SELF_BOX]]
   convenience init(x: Int) {
     self.init()
   }
@@ -75,13 +75,13 @@ class Good: Foo {
 
   // CHECK-LABEL: sil hidden @_T022super_init_refcounting4GoodC{{[_0-9a-zA-Z]*}}fc
   // CHECK:         [[SELF_BOX:%.*]] = alloc_box ${ var Good }
-  // CHECK:         [[PB:%.*]] = project_box [[SELF_BOX]]
-  // CHECK:         [[SELF:%.*]] = mark_uninitialized [derivedself] [[PB]]
-  // CHECK:         store %0 to [init] [[SELF]]
-  // CHECK:         [[SELF_OBJ:%.*]] = load_borrow [[SELF]]
+  // CHECK:         [[MARKED_SELF_BOX:%.*]] = mark_uninitialized [derivedself] [[SELF_BOX]]
+  // CHECK:         [[PB_SELF_BOX:%.*]] = project_box [[MARKED_SELF_BOX]]
+  // CHECK:         store %0 to [init] [[PB_SELF_BOX]]
+  // CHECK:         [[SELF_OBJ:%.*]] = load_borrow [[PB_SELF_BOX]]
   // CHECK:         [[X_ADDR:%.*]] = ref_element_addr [[SELF_OBJ]] : $Good, #Good.x
   // CHECK:         assign {{.*}} to [[X_ADDR]] : $*Int
-  // CHECK:         [[SELF_OBJ:%.*]] = load [take] [[SELF]] : $*Good
+  // CHECK:         [[SELF_OBJ:%.*]] = load [take] [[PB_SELF_BOX]] : $*Good
   // CHECK:         [[SUPER_OBJ:%.*]] = upcast [[SELF_OBJ]] : $Good to $Foo
   // CHECK:         [[SUPER_INIT:%.*]] = function_ref @_T022super_init_refcounting3FooCACSicfc : $@convention(method) (Int, @owned Foo) -> @owned Foo
   // CHECK:         [[BORROWED_SUPER:%.*]] = begin_borrow [[SUPER_OBJ]]

--- a/test/SILGen/unowned.swift
+++ b/test/SILGen/unowned.swift
@@ -42,8 +42,8 @@ func test0(c c: C) {
 
   var a: A
   // CHECK:   [[A1:%.*]] = alloc_box ${ var A }, var, name "a"
-  // CHECK:   [[PBA:%.*]] = project_box [[A1]]
-  // CHECK:   [[A:%.*]] = mark_uninitialized [var] [[PBA]]
+  // CHECK:   [[MARKED_A1:%.*]] = mark_uninitialized [var] [[A1]]
+  // CHECK:   [[PBA:%.*]] = project_box [[MARKED_A1]]
 
   unowned var x = c
   // CHECK:   [[X:%.*]] = alloc_box ${ var @sil_unowned C }
@@ -59,7 +59,7 @@ func test0(c c: C) {
   a.x = c
   // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
   // CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
-  // CHECK:   [[T1:%.*]] = struct_element_addr [[A]] : $*A, #A.x
+  // CHECK:   [[T1:%.*]] = struct_element_addr [[PBA]] : $*A, #A.x
   // CHECK:   [[T2:%.*]] = ref_to_unowned [[ARG_COPY]] : $C
   // CHECK:   unowned_retain [[T2]] : $@sil_unowned C
   // CHECK:   assign [[T2]] to [[T1]] : $*@sil_unowned C
@@ -70,13 +70,13 @@ func test0(c c: C) {
   // CHECK:   [[T2:%.*]] = load [take] [[PBX]] : $*@sil_unowned C     
   // CHECK:   strong_retain_unowned  [[T2]] : $@sil_unowned C  
   // CHECK:   [[T3:%.*]] = unowned_to_ref [[T2]] : $@sil_unowned C to $C
-  // CHECK:   [[XP:%.*]] = struct_element_addr [[A]] : $*A, #A.x
+  // CHECK:   [[XP:%.*]] = struct_element_addr [[PBA]] : $*A, #A.x
   // CHECK:   [[T4:%.*]] = ref_to_unowned [[T3]] : $C to $@sil_unowned C
   // CHECK:   unowned_retain [[T4]] : $@sil_unowned C  
   // CHECK:   assign [[T4]] to [[XP]] : $*@sil_unowned C
   // CHECK:   destroy_value [[T3]] : $C
   // CHECK:   destroy_value [[X]]
-  // CHECK:   destroy_value [[A1]]
+  // CHECK:   destroy_value [[MARKED_A1]]
   // CHECK:   destroy_value [[ARG]]
 }
 // CHECK: } // end sil function '_T07unowned5test0yAA1CC1c_tF'

--- a/test/SILGen/weak.swift
+++ b/test/SILGen/weak.swift
@@ -19,8 +19,8 @@ func test0(c c: C) {
 
   var a: A
 // CHECK:      [[A1:%.*]] = alloc_box ${ var A }
-// CHECK-NEXT: [[PBA:%.*]] = project_box [[A1]]
-// CHECK:      [[A:%.*]] = mark_uninitialized [var] [[PBA]]
+// CHECK:      [[MARKED_A1:%.*]] = mark_uninitialized [var] [[A1]]
+// CHECK-NEXT: [[PBA:%.*]] = project_box [[MARKED_A1]]
 
   weak var x = c
 // CHECK:      [[X:%.*]] = alloc_box ${ var @sil_weak Optional<C> }, var, name "x"
@@ -37,7 +37,7 @@ func test0(c c: C) {
 // CHECK-NEXT: [[OPTVAL:%.*]] = enum $Optional<C>, #Optional.some!enumelt.1, [[TMP]] : $C
 
 //   Drill to a.x
-// CHECK-NEXT: [[A_X:%.*]] = struct_element_addr [[A]] : $*A, #A.x
+// CHECK-NEXT: [[A_X:%.*]] = struct_element_addr [[PBA]] : $*A, #A.x
 
 //   Store to a.x.
 // CHECK-NEXT: store_weak [[OPTVAL]] to [[A_X]] : $*@sil_weak Optional<C>

--- a/test/SILOptimizer/allocbox_to_stack.sil
+++ b/test/SILOptimizer/allocbox_to_stack.sil
@@ -68,15 +68,15 @@ bb0:
 sil @multi_strong_release : $() -> Int {
 bb0:
   %1 = alloc_box ${ var Int }
-  %1a = project_box %1 : ${ var Int }, 0
-  %2 = mark_uninitialized [rootself] %1a : $*Int
+  %1a = mark_uninitialized [rootself] %1 : ${ var Int }
+  %2 = project_box %1a : ${ var Int }, 0
   %3 = load %2 : $*Int
-  %x = strong_retain %1 : ${ var Int }
-  %y = strong_release %1 : ${ var Int }
+  %x = strong_retain %1a : ${ var Int }
+  %y = strong_release %1a : ${ var Int }
   %b = br bb1
 bb1:
 
-  %4 = strong_release %1 : ${ var Int }
+  %4 = strong_release %1a : ${ var Int }
   %5 = return %3 : $Int
 
 // CHECK: %0 = alloc_stack
@@ -318,9 +318,9 @@ extension Int : My_Incrementable { }
 sil @test_mui : $@convention(thin) (Builtin.Int1) -> () {
 bb0(%0 : $Builtin.Int1):
   %2 = alloc_box ${ var SomeClass }
-  %2a = project_box %2 : ${ var SomeClass }, 0
+  %2a = mark_uninitialized [var] %2 : ${ var SomeClass }
+  %3 = project_box %2a : ${ var SomeClass }, 0
   // CHECK: [[STACK:%[0-9]+]] = alloc_stack
-  %3 = mark_uninitialized [var] %2a : $*SomeClass
   // CHECK: [[MUI:%[0-9]+]] = mark_uninitialized
   cond_br %0, bb1, bb3
 
@@ -335,7 +335,7 @@ bb1:
   strong_retain %12 : $SomeClass
   %14 = apply %11(%12) : $@convention(thin) (@owned SomeClass) -> ()
 
-  strong_release %2 : ${ var SomeClass }
+  strong_release %2a : ${ var SomeClass }
   // CHECK: destroy_addr [[MUI]]
   // CHECK-NEXT: dealloc_stack [[STACK]]
   br bb2
@@ -347,7 +347,7 @@ bb2:
   return %17 : $()
 
 bb3:
-  strong_release %2 : ${ var SomeClass }
+  strong_release %2a : ${ var SomeClass }
   // CHECK: destroy_addr [[MUI]]
   // CHECK-NEXT: dealloc_stack [[STACK]]
   br bb2
@@ -715,8 +715,8 @@ sil hidden @try_apply_during_chaining_init : $@convention(method) (Int, @owned T
 // %1                                             // user: %7
 bb0(%0 : $Int, %1 : $ThrowDerivedClass):
   %2 = alloc_box ${ var ThrowDerivedClass }, let, name "self"
-  %3 = project_box %2 : ${ var ThrowDerivedClass }, 0
-  %4 = mark_uninitialized [delegatingself] %3 : $*ThrowDerivedClass
+  %3 = mark_uninitialized [delegatingself] %2 : ${ var ThrowDerivedClass }
+  %4 = project_box %3 : ${ var ThrowDerivedClass }, 0
   store %1 to %4 : $*ThrowDerivedClass
   %8 = load %4 : $*ThrowDerivedClass
   %9 = function_ref @fake_throwing_init : $@convention(method) (Int, @owned ThrowDerivedClass) -> (@owned ThrowDerivedClass, @error Error)
@@ -732,7 +732,7 @@ bb2(%14 : $ThrowDerivedClass):                    // Preds: bb1
   store %14 to %4 : $*ThrowDerivedClass
   %16 = load %4 : $*ThrowDerivedClass
   strong_retain %16 : $ThrowDerivedClass
-  strong_release %2 : ${ var ThrowDerivedClass }
+  strong_release %3 : ${ var ThrowDerivedClass }
   return %16 : $ThrowDerivedClass
 
 // %20                                            // user: %22
@@ -746,7 +746,7 @@ bb4(%23 : $Error):                                // Preds: bb1
 
 // %25                                            // user: %27
 bb5(%25 : $Error):                                // Preds: bb4 bb3
-  strong_release %2 : ${ var ThrowDerivedClass }
+  strong_release %3 : ${ var ThrowDerivedClass }
   throw %25 : $Error
 }
 
@@ -1029,4 +1029,3 @@ bb3:
   unreachable
 
 }
-

--- a/test/SILOptimizer/allocbox_to_stack_ownership.sil
+++ b/test/SILOptimizer/allocbox_to_stack_ownership.sil
@@ -69,11 +69,11 @@ bb0:
 sil @multi_destroy_value : $@convention(thin) () -> Int {
 bb0:
   %1 = alloc_box ${ var Int }
-  %1a = project_box %1 : ${ var Int }, 0
-  %2 = mark_uninitialized [rootself] %1a : $*Int
+  %1a = mark_uninitialized [rootself] %1 : ${ var Int }
+  %2 = project_box %1a : ${ var Int }, 0
   %3 = load [trivial] %2 : $*Int
-  %x = copy_value %1 : ${ var Int }
-  destroy_value %1 : ${ var Int }
+  %x = copy_value %1a : ${ var Int }
+  destroy_value %1a : ${ var Int }
   br bb1
 
 bb1:
@@ -314,9 +314,9 @@ extension Int : My_Incrementable { }
 sil @test_mui : $@convention(thin) (Builtin.Int1) -> () {
 bb0(%0 : @trivial $Builtin.Int1):
   %2 = alloc_box ${ var SomeClass }
-  %2a = project_box %2 : ${ var SomeClass }, 0
+  %2a = mark_uninitialized [var] %2 : ${ var SomeClass }
+  %3 = project_box %2a : ${ var SomeClass }, 0
   // CHECK: [[STACK:%[0-9]+]] = alloc_stack
-  %3 = mark_uninitialized [var] %2a : $*SomeClass
   // CHECK: [[MUI:%[0-9]+]] = mark_uninitialized
   cond_br %0, bb1, bb3
 
@@ -330,7 +330,7 @@ bb1:
   %12 = load [copy] %3 : $*SomeClass
   %14 = apply %11(%12) : $@convention(thin) (@owned SomeClass) -> ()
 
-  destroy_value %2 : ${ var SomeClass }
+  destroy_value %2a : ${ var SomeClass }
   // CHECK: destroy_addr [[MUI]]
   // CHECK-NEXT: dealloc_stack [[STACK]]
   br bb2
@@ -342,7 +342,7 @@ bb2:
   return %17 : $()
 
 bb3:
-  destroy_value %2 : ${ var SomeClass }
+  destroy_value %2a : ${ var SomeClass }
   // CHECK: destroy_addr [[MUI]]
   // CHECK-NEXT: dealloc_stack [[STACK]]
   br bb2
@@ -711,8 +711,8 @@ sil hidden @try_apply_during_chaining_init : $@convention(method) (Int, @owned T
 // %1                                             // user: %7
 bb0(%0 : @trivial $Int, %1 : @owned $ThrowDerivedClass):
   %2 = alloc_box ${ var ThrowDerivedClass }, let, name "self"
-  %3 = project_box %2 : ${ var ThrowDerivedClass }, 0
-  %4 = mark_uninitialized [delegatingself] %3 : $*ThrowDerivedClass
+  %3 = mark_uninitialized [delegatingself] %2 : ${ var ThrowDerivedClass }
+  %4 = project_box %3 : ${ var ThrowDerivedClass }, 0
   store %1 to [init] %4 : $*ThrowDerivedClass
   %8 = load [take] %4 : $*ThrowDerivedClass
   %9 = function_ref @fake_throwing_init : $@convention(method) (Int, @owned ThrowDerivedClass) -> (@owned ThrowDerivedClass, @error Error)
@@ -727,7 +727,7 @@ bb1(%12 : @trivial $Int):                                  // Preds: bb0
 bb2(%14 : @owned $ThrowDerivedClass):                    // Preds: bb1
   store %14 to [init] %4 : $*ThrowDerivedClass
   %16 = load [copy] %4 : $*ThrowDerivedClass
-  destroy_value %2 : ${ var ThrowDerivedClass }
+  destroy_value %3 : ${ var ThrowDerivedClass }
   return %16 : $ThrowDerivedClass
 
 // %20                                            // user: %22
@@ -741,7 +741,7 @@ bb4(%23 : @owned $Error):                                // Preds: bb1
 
 // %25                                            // user: %27
 bb5(%25 : @owned $Error):                                // Preds: bb4 bb3
-  destroy_value %2 : ${ var ThrowDerivedClass }
+  destroy_value %3 : ${ var ThrowDerivedClass }
   throw %25 : $Error
 }
 

--- a/test/SILOptimizer/capture_promotion_ownership.sil
+++ b/test/SILOptimizer/capture_promotion_ownership.sil
@@ -34,8 +34,10 @@ sil @dummy_func : $@convention(thin) (Int, Int, Int) -> Int
 sil @test_capture_promotion : $@convention(thin) () -> @owned @callee_owned () -> Int {
 bb0:
   // CHECK: [[BOX1:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <Foo>
+  // CHECK: [[MARKED_BOX1:%.*]] = mark_uninitialized [var] [[BOX1]]
   %1 = alloc_box $<τ_0_0> { var τ_0_0 } <Foo>
-  %1a = project_box %1 : $<τ_0_0> { var τ_0_0 } <Foo>, 0
+  %1ab = mark_uninitialized [var] %1 : $<τ_0_0> { var τ_0_0 } <Foo>
+  %1a = project_box %1ab : $<τ_0_0> { var τ_0_0 } <Foo>, 0
   %2 = function_ref @foo_allocating_init : $@convention(thin) (@thick Foo.Type) -> @owned Foo
   %3 = metatype $@thick Foo.Type
   %4 = apply %2(%3) : $@convention(thin) (@thick Foo.Type) -> @owned Foo
@@ -58,7 +60,7 @@ bb0:
   %15 = apply %12(%14, %13) : $@convention(thin) (Builtin.Word, @thin Int.Type) -> Int
   store %15 to [trivial] %11a : $*Int
 
-// CHECK: [[BOX1_COPY:%.*]] = copy_value [[BOX1]]
+// CHECK: [[BOX1_COPY:%.*]] = copy_value [[MARKED_BOX1]]
 // CHECK: [[BOX1_COPY_PB:%.*]] = project_box [[BOX1_COPY]]
 // CHECK: [[BOX2_COPY:%.*]] = copy_value [[BOX2]]
 // CHECK: [[BOX2_COPY_PB:%.*]] = project_box [[BOX2_COPY]]
@@ -87,14 +89,14 @@ bb0:
 // CHECK-NEXT: {{.*}} = partial_apply [[CLOSURE_PROMOTE]]([[LOADFOO]], [[LOADBAZ]], [[LOADINT]])
 
   %17 = function_ref @closure0 : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Foo>, @owned <τ_0_0> { var τ_0_0 } <Baz>, @owned <τ_0_0> { var τ_0_0 } <Int>) -> Int
-  %18 = copy_value %1 : $<τ_0_0> { var τ_0_0 } <Foo>
+  %18 = copy_value %1ab : $<τ_0_0> { var τ_0_0 } <Foo>
   %19 = copy_value %6 : $<τ_0_0> { var τ_0_0 } <Baz>
   %20 = copy_value %11 : $<τ_0_0> { var τ_0_0 } <Int>
   %21 = partial_apply %17(%18, %19, %20) : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Foo>, @owned <τ_0_0> { var τ_0_0 } <Baz>, @owned <τ_0_0> { var τ_0_0 } <Int>) -> Int
 
   destroy_value %11 : $<τ_0_0> { var τ_0_0 } <Int>
   destroy_value %6 : $<τ_0_0> { var τ_0_0 } <Baz>
-  destroy_value %1 : $<τ_0_0> { var τ_0_0 } <Foo>
+  destroy_value %1ab : $<τ_0_0> { var τ_0_0 } <Foo>
 
   return %21 : $@callee_owned () -> Int
 }

--- a/test/SILOptimizer/mark_uninitialized_fixup.sil
+++ b/test/SILOptimizer/mark_uninitialized_fixup.sil
@@ -1,0 +1,82 @@
+// RUN: %target-sil-opt -enable-sil-ownership -mark-uninitialized-fixup %s | %FileCheck %s
+
+sil_stage raw
+
+import Builtin
+
+// CHECK-LABEL: sil @single_bb_single_proj_case : $@convention(thin) () -> () {
+// CHECK: [[BOX:%.*]] = alloc_box ${ var Builtin.Int32 }
+// CHECK: [[PB:%.*]] = project_box [[BOX]]
+// CHECK: mark_uninitialized [rootself] [[PB]]
+sil @single_bb_single_proj_case : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_box ${ var Builtin.Int32 }
+  %1 = mark_uninitialized [rootself] %0 : ${ var Builtin.Int32 }
+  %2 = project_box %1 : ${ var Builtin.Int32 }, 0
+  destroy_value %1 : ${ var Builtin.Int32 }
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil @single_bb_multiple_proj_case : $@convention(thin) () -> () {
+// CHECK: [[BOX:%.*]] = alloc_box ${ var Builtin.Int32 }
+// CHECK: [[PB:%.*]] = project_box [[BOX]]
+// CHECK: mark_uninitialized [rootself] [[PB]]
+// CHECK: project_box [[BOX]]
+sil @single_bb_multiple_proj_case : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_box ${ var Builtin.Int32 }
+  %1 = mark_uninitialized [rootself] %0 : ${ var Builtin.Int32 }
+  %2 = project_box %1 : ${ var Builtin.Int32 }, 0
+  %3 = project_box %1 : ${ var Builtin.Int32 }, 0
+  destroy_value %1 : ${ var Builtin.Int32 }
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+
+// CHECK-LABEL: sil @multiple_bb_case : $@convention(thin) () -> () {
+// CHECK:   [[BOX:%.*]] = alloc_box ${ var Builtin.Int32 }
+// CHECK:   [[PB:%.*]] = project_box [[BOX]]
+// CHECK:   mark_uninitialized [rootself] [[PB]]
+// CHECK:   br [[NEXT_BB:bb[0-9]+]]
+//
+// CHECK: [[NEXT_BB]]:
+// CHECK:   project_box [[BOX]]
+sil @multiple_bb_case : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_box ${ var Builtin.Int32 }
+  %1 = mark_uninitialized [rootself] %0 : ${ var Builtin.Int32 }
+  %2 = project_box %1 : ${ var Builtin.Int32 }, 0
+  br bb1
+
+bb1:
+  %3 = project_box %1 : ${ var Builtin.Int32 }, 0
+  destroy_value %1 : ${ var Builtin.Int32 }
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+struct Bool {
+  var _value: Builtin.Int1
+}
+
+// CHECK-LABEL: sil @test_rauw_uses_of_project_box : $@convention(thin) (Builtin.Int1, @thin Bool.Type) -> Bool {
+// CHECK: [[BOX:%.*]] = alloc_box ${ var Bool }
+// CHECK: [[PB:%.*]] = project_box [[BOX]]
+// CHECK: [[MUI:%.*]] = mark_uninitialized [rootself] [[PB]]
+// CHECK: struct_element_addr [[MUI]]
+// CHECK: load [trivial] [[MUI]]
+// CHECK: destroy_value [[BOX]]
+sil @test_rauw_uses_of_project_box : $@convention(thin) (Builtin.Int1, @thin Bool.Type) -> Bool {
+bb0(%0 : @trivial $Builtin.Int1, %1 : @trivial $@thin Bool.Type):
+  %2 = alloc_box ${ var Bool }, var, name "self"
+  %3 = mark_uninitialized [rootself] %2 : ${ var Bool }
+  %4 = project_box %3 : ${ var Bool }, 0
+  debug_value %0 : $Builtin.Int1, let, name "v", argno 1
+  %6 = struct_element_addr %4 : $*Bool, #Bool._value
+  assign %0 to %6 : $*Builtin.Int1
+  %8 = load [trivial] %4 : $*Bool
+  destroy_value %3 : ${ var Bool }
+  return %8 : $Bool
+}


### PR DESCRIPTION
[semantic-sil] Update capture promotion for moving mark_uninitialized onto alloc_box instead of project_box and move the fixup pass behind it.

rdar://31521023
