### PR TITLE
[semantic-sil] Update OME for having mark_uninitialized on the alloc_box instead of project_box.

### DIFF
--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -80,9 +80,9 @@ static void addMandatoryOptPipeline(SILPassPipelinePlan &P,
   P.addDiagnoseStaticExclusivity();
   P.addCapturePromotion();
   P.addAllocBoxToStack();
-  P.addMarkUninitializedFixup();
   P.addNoReturnFolding();
   P.addOwnershipModelEliminator();
+  P.addMarkUninitializedFixup();
   P.addDefiniteInitialization();
 
   P.addAccessEnforcementSelection();

--- a/lib/SILOptimizer/Transforms/OwnershipModelEliminator.cpp
+++ b/lib/SILOptimizer/Transforms/OwnershipModelEliminator.cpp
@@ -79,7 +79,6 @@ struct OwnershipModelEliminatorVisitor
   bool visitUnmanagedAutoreleaseValueInst(UnmanagedAutoreleaseValueInst *UAVI);
   bool visitCheckedCastBranchInst(CheckedCastBranchInst *CBI);
   bool visitSwitchEnumInst(SwitchEnumInst *SWI);
-  bool visitProjectBoxInst(ProjectBoxInst *PBI);
 };
 
 } // end anonymous namespace
@@ -244,67 +243,6 @@ bool OwnershipModelEliminatorVisitor::visitSwitchEnumInst(
     return false;
   DefaultBlock->getArgument(0)->replaceAllUsesWith(SWEI->getOperand());
   DefaultBlock->eraseArgument(0);
-  return true;
-}
-
-// Since we are threading through copies, we may have situations like:
-//
-// let x = alloc_box $Foo
-// let y = project_box x
-// let z = mark_uninitialized y
-// ... use z ...
-//
-// let y2 = project_box x
-//
-// let x2 = copy_value x
-// let y3 = project_box y
-//
-// We need to move project_box like y2 and y3 to go through z so that DI can
-// reason about them.
-//
-// Once DI is updated for ownership, this can go away.
-bool OwnershipModelEliminatorVisitor::visitProjectBoxInst(ProjectBoxInst *PBI) {
-  // First if our operand is already a mark_uninitialized, then we do not need
-  // to do anything.
-  auto *Use = PBI->getSingleUse();
-  if (Use && isa<MarkUninitializedInst>(Use->getUser())) {
-    return false;
-  }
-
-  // Otherwise, lets try to find the alloc_box.
-  SILValue BoxValue = PBI->getOperand();
-  while (auto *CVI = dyn_cast<CopyValueInst>(BoxValue)) {
-    BoxValue = CVI->getOperand();
-  }
-
-  // We were unable to find the alloc_box. This must be an indirect enum box
-  // pattern.
-  auto *ABI = dyn_cast<AllocBoxInst>(BoxValue);
-  if (!ABI)
-    return false;
-
-  // See if we can find (mark_uninitialized (project_box))
-  SILValue MUI;
-  for (auto *Use : ABI->getUses()) {
-    auto *BoxProjection = dyn_cast<ProjectBoxInst>(Use->getUser());
-    if (!BoxProjection)
-      continue;
-    auto *Op = BoxProjection->getSingleUse();
-    if (!Op || !isa<MarkUninitializedInst>(Op->getUser()))
-      continue;
-    MUI = SILValue(Op->getUser());
-    break;
-  }
-
-  // If we did not find a mark uninitialized inst, then this is not the pattern
-  // that we are looking for.
-  if (!MUI)
-    return false;
-
-  // Ok, we found it. Replace all uses of this project box with the
-  // mark_uninitialized and then erase it.
-  PBI->replaceAllUsesWith(MUI);
-  PBI->eraseFromParent();
   return true;
 }
 

--- a/test/SILOptimizer/ownership_model_eliminator.sil
+++ b/test/SILOptimizer/ownership_model_eliminator.sil
@@ -229,32 +229,3 @@ bb3:
   %9999 = tuple()
   return %9999 : $()
 }
-
-// CHECK-LABEL: sil @mark_uninitialized_project_box : $@convention(thin) () -> () {
-// CHECK: [[BOX:%.*]] = alloc_box
-// CHECK: [[PB_BOX:%.*]] = project_box [[BOX]]
-// CHECK: [[MUI:%.*]] = mark_uninitialized [var] [[PB_BOX]]
-// CHECK: store {{%.*}} to [[MUI]]
-// CHECK: load [[MUI]]
-// CHECK: load [[MUI]]
-// CHECK: strong_release [[BOX]]
-// CHECK: } // end sil function 'mark_uninitialized_project_box'
-sil @mark_uninitialized_project_box : $@convention(thin) () -> () {
-bb0:
-  %0 = alloc_box $<τ_0_0> { var τ_0_0 } <Builtin.Int32>
-  %1 = project_box %0 : $<τ_0_0> { var τ_0_0 } <Builtin.Int32>, 0
-  %2 = mark_uninitialized [var] %1 : $*Builtin.Int32
-  %3 = integer_literal $Builtin.Int32, 0
-  store %3 to [trivial] %2 : $*Builtin.Int32
-
-  %4 = project_box %0 : $<τ_0_0> { var τ_0_0 } <Builtin.Int32>, 0
-  %5 = load [trivial] %4 : $*Builtin.Int32
-
-  %6 = copy_value %0 : $<τ_0_0> { var τ_0_0 } <Builtin.Int32>
-  %7 = project_box %0 : $<τ_0_0> { var τ_0_0 } <Builtin.Int32>, 0
-  %8 = load [trivial] %7 : $*Builtin.Int32
-  destroy_value %6 : $<τ_0_0> { var τ_0_0 } <Builtin.Int32>
-  destroy_value %0 : $<τ_0_0> { var τ_0_0 } <Builtin.Int32>
-  %9999 = tuple()
-  return %9999 : $()
-}


### PR DESCRIPTION
[semantic-sil] Update OME for having mark_uninitialized on the alloc_box instead of project_box.

This consists of just removing support from OME for ensuring that all uses of a
box go through the project_box that has as its user a mark_uninitialized. Since
the lowering of mark_uninitialized onto the relevant project_box is done by
MarkUninitializedFixup pass, I can just rip out the hacks from the OME!

rdar://31521023

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
