### PR TITLE
[swiftc (37 vs. 5515)] Add crasher in swift::Decl::walk(...)

### DIFF
--- a/validation-test/compiler_crashers/28741-anonymous-namespace-verifier-walktodeclpost-swift-decl.swift
+++ b/validation-test/compiler_crashers/28741-anonymous-namespace-verifier-walktodeclpost-swift-decl.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol A{{}struct A{typealias a:Self
+protocol P{extension{lazy var f=A.a


### PR DESCRIPTION
Add test case for crash triggered in `swift::Decl::walk(...)`.

Current number of unresolved compiler crashers: 37 (5515 resolved)

Stack trace:

```
0 0x0000000003982358 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3982358)
1 0x0000000003982a96 SignalHandler(int) (/path/to/swift/bin/swift+0x3982a96)
2 0x00007f2efdd71390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007f2efc297428 gsignal /build/glibc-9tT8Do/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f2efc29902a abort /build/glibc-9tT8Do/glibc-2.23/stdlib/abort.c:91:0
5 0x0000000001479f8e (/path/to/swift/bin/swift+0x1479f8e)
6 0x000000000146df6b (anonymous namespace)::Verifier::walkToDeclPost(swift::Decl*) (/path/to/swift/bin/swift+0x146df6b)
7 0x000000000147e26c (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0x147e26c)
8 0x0000000001482337 (anonymous namespace)::Traversal::visit(swift::Pattern*) (/path/to/swift/bin/swift+0x1482337)
9 0x000000000147dd7e (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0x147dd7e)
10 0x000000000147dcfa (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0x147dcfa)
11 0x0000000001483054 (anonymous namespace)::Traversal::visitNominalTypeDecl(swift::NominalTypeDecl*) (/path/to/swift/bin/swift+0x1483054)
12 0x000000000147dba4 (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0x147dba4)
13 0x0000000001483054 (anonymous namespace)::Traversal::visitNominalTypeDecl(swift::NominalTypeDecl*) (/path/to/swift/bin/swift+0x1483054)
14 0x000000000147dba4 (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0x147dba4)
15 0x0000000001483054 (anonymous namespace)::Traversal::visitNominalTypeDecl(swift::NominalTypeDecl*) (/path/to/swift/bin/swift+0x1483054)
16 0x000000000147dba4 (anonymous namespace)::Traversal::doIt(swift::Decl*) (/path/to/swift/bin/swift+0x147dba4)
17 0x000000000147da74 swift::Decl::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x147da74)
18 0x00000000014fa3be swift::SourceFile::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x14fa3be)
19 0x0000000001464335 swift::verify(swift::SourceFile&) (/path/to/swift/bin/swift+0x1464335)
20 0x000000000134d616 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x134d616)
21 0x0000000000fb37a6 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xfb37a6)
22 0x00000000004a999f swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a999f)
23 0x0000000000465287 main (/path/to/swift/bin/swift+0x465287)
24 0x00007f2efc282830 __libc_start_main /build/glibc-9tT8Do/glibc-2.23/csu/../csu/libc-start.c:325:0
25 0x0000000000462929 _start (/path/to/swift/bin/swift+0x462929)
```