### PR TITLE
[stdlib] Minor documentation fixes

### DIFF
--- a/stdlib/public/core/LifetimeManager.swift
+++ b/stdlib/public/core/LifetimeManager.swift
@@ -10,8 +10,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// Evaluate `f()` and return its result, ensuring that `x` is not
-/// destroyed before f returns.
+/// Evaluates a closure while ensuring that the given instance is not destroyed
+/// before the closure returns.
+///
+/// - Parameters:
+///   - x: An instance to preserve until the execution of `body` is completed.
+///   - body: A closure to execute that depends on the lifetime of `x` being
+///     extended.
+/// - Returns: The return value of `body`, if any.
 @_inlineable
 public func withExtendedLifetime<T, Result>(
   _ x: T, _ body: () throws -> Result
@@ -20,8 +26,14 @@ public func withExtendedLifetime<T, Result>(
   return try body()
 }
 
-/// Evaluate `f(x)` and return its result, ensuring that `x` is not
-/// destroyed before f returns.
+/// Evaluates a closure while ensuring that the given instance is not destroyed
+/// before the closure returns.
+///
+/// - Parameters:
+///   - x: An instance to preserve until the execution of `body` is completed.
+///   - body: A closure to execute that depends on the lifetime of `x` being
+///     extended.
+/// - Returns: The return value of `body`, if any.
 @_inlineable
 public func withExtendedLifetime<T, Result>(
   _ x: T, _ body: (T) throws -> Result

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -380,7 +380,7 @@ public protocol Sequence {
   /// Returns an array containing, in order, the elements of the sequence
   /// that satisfy the given predicate.
   ///
-  /// In this example, `filter` is used to include only names shorter than
+  /// In this example, `filter(_:)` is used to include only names shorter than
   /// five characters.
   ///
   ///     let cast = ["Vivien", "Marlon", "Kim", "Karl"]
@@ -391,7 +391,7 @@ public protocol Sequence {
   /// - Parameter isIncluded: A closure that takes an element of the
   ///   sequence as its argument and returns a Boolean value indicating
   ///   whether the element should be included in the returned array.
-  /// - Returns: An array of the elements that `includeElement` allowed.
+  /// - Returns: An array of the elements that `isIncluded` allowed.
   func filter(
     _ isIncluded: (Iterator.Element) throws -> Bool
   ) rethrows -> [Iterator.Element]
@@ -862,7 +862,7 @@ extension Sequence {
   /// Returns an array containing, in order, the elements of the sequence
   /// that satisfy the given predicate.
   ///
-  /// In this example, `filter` is used to include only names shorter than
+  /// In this example, `filter(_:)` is used to include only names shorter than
   /// five characters.
   ///
   ///     let cast = ["Vivien", "Marlon", "Kim", "Karl"]
@@ -873,7 +873,7 @@ extension Sequence {
   /// - Parameter isIncluded: A closure that takes an element of the
   ///   sequence as its argument and returns a Boolean value indicating
   ///   whether the element should be included in the returned array.
-  /// - Returns: An array of the elements that `includeElement` allowed.
+  /// - Returns: An array of the elements that `isIncluded` allowed.
   @_inlineable
   public func filter(
     _ isIncluded: (Iterator.Element) throws -> Bool

--- a/stdlib/public/core/UnsafePointer.swift.gyb
+++ b/stdlib/public/core/UnsafePointer.swift.gyb
@@ -52,8 +52,8 @@
 ///
 %if mutable:
 /// You can use methods like `initialize(to:count:)`, `initialize(from:)`, and
-/// `moveInitializeMemory(from:count)` to initialize the memory referenced by
-/// a pointer with a value or series of values.
+/// `moveInitialize(from:count:)` to initialize the memory referenced by a
+/// pointer with a value or series of values.
 ///
 % end
 /// Initialized Memory

--- a/stdlib/public/core/UnsafeRawPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawPointer.swift.gyb
@@ -52,7 +52,7 @@
 ///
 %if mutable:
 /// You can use methods like `initializeMemory(as:from:)` and
-/// `moveInitializeMemory(as:from:count)` to bind raw memory to a type and
+/// `moveInitializeMemory(as:from:count:)` to bind raw memory to a type and
 /// initialize it with a value or series of values. To bind uninitialized
 /// memory to a type without initializing it, use the `bindMemory(to:count:)`
 /// method. These methods all return typed pointers for further typed access


### PR DESCRIPTION
* Revise `withExtendedLifetime(_:_:)`
* Correct method in UnsafeMutablePointer discussion
* `Sequence.filter(_:)` documentation fixes
