### PR TITLE
[index] Bring back unnamed parameter indexing

### DIFF
--- a/lib/AST/USRGeneration.cpp
+++ b/lib/AST/USRGeneration.cpp
@@ -141,7 +141,7 @@ static bool ShouldUseObjCUSR(const Decl *D) {
 }
 
 bool ide::printDeclUSR(const ValueDecl *D, raw_ostream &OS) {
-  if (!D->hasName() &&
+  if (!D->hasName() && !isa<ParamDecl>(D) &&
       (!isa<FuncDecl>(D) ||
        cast<FuncDecl>(D)->getAccessorKind() == AccessorKind::NotAccessor))
     return true; // Ignore.

--- a/test/Index/kinds.swift
+++ b/test/Index/kinds.swift
@@ -51,8 +51,8 @@ class AClass {
   // CHECK-NEXT: RelChild | instance-method/Swift | instanceMethod(a:b:_:d:_:) | s:14swift_ide_test6AClassC14instanceMethodySi1a_Si1bS2i1dSitF
   // CHECK: [[@LINE-5]]:33 | param(local)/Swift | b | s:{{.*}} | Def,RelChild | rel: 1
   // CHECK: [[@LINE-6]]:43 | param(local)/Swift | c | s:{{.*}} | Def,RelChild | rel: 1
-  // CHECK-NOT: {{^}}[[@LINE-7]]:53 |
-  // CHECK-NOT: {{^}}[[@LINE-8]]:61 |
+  // CHECK: [[@LINE-7]]:53 | param(local)/Swift | _ | s:{{.*}} | Def,RelChild | rel: 1
+  // CHECK: [[@LINE-8]]:61 | param/Swift | _ | s:{{.*}} | Def,RelChild | rel: 1
 
     _ = a
     // CHECK: [[@LINE-1]]:9 | param/Swift | a | s:{{.*}} | Ref,Read,RelCont | rel: 1


### PR DESCRIPTION
This was disabled in 5c80f1edafd9 but should be working. This allows the
indexer to see the full set of parameters even when some are unnamed.