### PR TITLE
[Generic environment] Only substitute top-level archetypes.

### DIFF
--- a/lib/AST/GenericEnvironment.cpp
+++ b/lib/AST/GenericEnvironment.cpp
@@ -227,6 +227,10 @@ Type GenericEnvironment::QueryArchetypeToInterfaceSubstitutions::operator()(
   auto archetype = type->getAs<ArchetypeType>();
   if (!archetype) return Type();
 
+  // Only top-level archetypes need to be substituted directly; nested
+  // archetypes will be handled via their root archetypes.
+  if (archetype->getParent()) return Type();
+
   // If not all generic parameters have had their context types recorded,
   // perform a linear search.
   auto genericParams = self->Signature->getGenericParams();

--- a/validation-test/compiler_crashers_2_fixed/0090-sr4617.swift
+++ b/validation-test/compiler_crashers_2_fixed/0090-sr4617.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-frontend -primary-file %s -emit-ir
+
+extension Dictionary  {
+  init<S: Sequence>(grouping elements: S, by keyForValue: (S.Iterator.Element) -> Key)
+  where Array<S.Iterator.Element> == Value
+  {
+    self = [:]
+    for value in elements {
+      var values = self[keyForValue(value)] ?? []
+      values.append(value)
+      self[keyForValue(value)] = values
+    }
+  }
+}


### PR DESCRIPTION
The core substitution routine for the archetypes-to-interface types
substitution was attempting to provide mappings for nested archetypes,
when in fact these archetypes would (1) always be resolvable via their
parent, and (2) could in fact cause infinite recursion, as with the
new test case. Fixes SR-4617 / rdar://problem/31673819.
