### PR TITLE
[SILOpt] Specialized functions are never public.

### DIFF
--- a/test/SILOptimizer/cast_folding_objc_no_foundation.swift
+++ b/test/SILOptimizer/cast_folding_objc_no_foundation.swift
@@ -7,7 +7,7 @@
 
 struct PlainStruct {}
 
-// CHECK-LABEL: sil hidden [noinline] @_T031cast_folding_objc_no_foundation23testAnyObjectToArrayIntSbs0gH0_pFTf4g_n
+// CHECK-LABEL: sil shared [noinline] @_T031cast_folding_objc_no_foundation23testAnyObjectToArrayIntSbs0gH0_pFTf4g_n
 // CHECK: bb0(%0 : $AnyObject):
 // CHECK: [[SOURCE:%.*]] = alloc_stack $AnyObject
 // CHECK: [[TARGET:%.*]] = alloc_stack $Array<Int>
@@ -17,7 +17,7 @@ func testAnyObjectToArrayInt(_ a: AnyObject) -> Bool {
   return a is [Int]
 }
 
-// CHECK-LABEL: sil hidden [noinline] @_T031cast_folding_objc_no_foundation26testAnyObjectToArrayStringSbs0gH0_pFTf4g_n
+// CHECK-LABEL: sil shared [noinline] @_T031cast_folding_objc_no_foundation26testAnyObjectToArrayStringSbs0gH0_pFTf4g_n
 // CHECK: bb0(%0 : $AnyObject):
 // CHECK: [[SOURCE:%.*]] = alloc_stack $AnyObject
 // CHECK: [[TARGET:%.*]] = alloc_stack $Array<String>
@@ -27,7 +27,7 @@ func testAnyObjectToArrayString(_ a: AnyObject) -> Bool {
   return a is [String]
 }
 
-// CHECK-LABEL: sil hidden [noinline] @_T031cast_folding_objc_no_foundation30testAnyObjectToArrayNotBridged{{.*}}
+// CHECK-LABEL: sil shared [noinline] @_T031cast_folding_objc_no_foundation30testAnyObjectToArrayNotBridged{{.*}}
 // CHECK: bb0(%0 : $AnyObject):
 // CHECK: [[SOURCE:%.*]] = alloc_stack $AnyObject
 // CHECK: [[TARGET:%.*]] = alloc_stack $Array<PlainStruct>
@@ -37,7 +37,7 @@ func testAnyObjectToArrayNotBridged(_ a: AnyObject) -> Bool {
   return a is [PlainStruct]
 }
 
-// CHECK-LABEL: sil hidden [noinline] @_T031cast_folding_objc_no_foundation25testAnyObjectToDictionarySbs0gH0_pFTf4g_n
+// CHECK-LABEL: sil shared [noinline] @_T031cast_folding_objc_no_foundation25testAnyObjectToDictionarySbs0gH0_pFTf4g_n
 // CHECK: bb0(%0 : $AnyObject):
 // CHECK: [[SOURCE:%.*]] = alloc_stack $AnyObject
 // CHECK: [[TARGET:%.*]] = alloc_stack $Dictionary<Int, String>
@@ -47,7 +47,7 @@ func testAnyObjectToDictionary(_ a: AnyObject) -> Bool {
   return a is [Int: String]
 }
 
-// CHECK-LABEL: sil hidden [noinline] @_T031cast_folding_objc_no_foundation21testAnyObjectToStringSbs0gH0_pFTf4g_n
+// CHECK-LABEL: sil shared [noinline] @_T031cast_folding_objc_no_foundation21testAnyObjectToStringSbs0gH0_pFTf4g_n
 // CHECK: bb0(%0 : $AnyObject):
 // CHECK: [[SOURCE:%.*]] = alloc_stack $AnyObject
 // CHECK: [[TARGET:%.*]] = alloc_stack $String

--- a/test/SILOptimizer/deadargsignatureopt.sil
+++ b/test/SILOptimizer/deadargsignatureopt.sil
@@ -83,10 +83,10 @@ bb0:
   return %2 : $@callee_owned (Int32, Int32) -> Bool
 }
 
-// CHECK-LABEL: sil @_T012one_arg_deadTf4nnd_n
+// CHECK-LABEL: sil shared @_T012one_arg_deadTf4nnd_n
 // CHECK: builtin
 // CHECK: return
 
-// CHECK-LABEL: sil @_T013two_args_deadTf4nnd_n
+// CHECK-LABEL: sil shared @_T013two_args_deadTf4nnd_n
 // CHECK: builtin
 // CHECK: return

--- a/test/SILOptimizer/devirt_covariant_return.swift
+++ b/test/SILOptimizer/devirt_covariant_return.swift
@@ -179,12 +179,13 @@ final class C2:C {
 // Check that the Optional return value from doSomething
 // gets properly unwrapped into a Payload object and then further
 // devirtualized.
-// CHECK-LABEL: sil hidden @_T023devirt_covariant_return7driver1s5Int32VAA2C1CFTf4d_n
+// CHECK-LABEL: sil shared [noinline] @_T023devirt_covariant_return7driver1s5Int32VAA2C1CFTf4d_n
 // CHECK: integer_literal $Builtin.Int32, 2
 // CHECK: struct $Int32 (%{{.*}} : $Builtin.Int32)
 // CHECK-NOT: class_method
 // CHECK-NOT: function_ref
 // CHECK: return
+@inline(never)
 func driver1(_ c: C1) -> Int32 {
   return c.doSomething().getValue()
 }
@@ -192,13 +193,14 @@ func driver1(_ c: C1) -> Int32 {
 // Check that the Optional return value from doSomething
 // gets properly unwrapped into a Payload object and then further
 // devirtualized.
-// CHECK-LABEL: sil hidden @_T023devirt_covariant_return7driver3s5Int32VAA1CCFTf4g_n
+// CHECK-LABEL: sil shared [noinline] @_T023devirt_covariant_return7driver3s5Int32VAA1CCFTf4g_n
 // CHECK: bb{{[0-9]+}}(%{{[0-9]+}} : $C2):
 // CHECK-NOT: bb{{.*}}:
 // check that for C2, we convert the non-optional result into an optional and then cast.
 // CHECK: enum $Optional
 // CHECK-NEXT: upcast
 // CHECK: return
+@inline(never)
 func driver3(_ c: C) -> Int32 {
   return c.doSomething()!.getValue()
 }
@@ -232,7 +234,7 @@ public class D2: D1 {
 
 // Check that the boo call gets properly devirtualized and that
 // that D2.foo() is inlined thanks to this.
-// CHECK-LABEL: sil hidden @_T023devirt_covariant_return7driver2s5Int32VAA2D2CFTf4g_n
+// CHECK-LABEL: sil shared [noinline] @_T023devirt_covariant_return7driver2s5Int32VAA2D2CFTf4g_n
 // CHECK-NOT: class_method
 // CHECK: checked_cast_br [exact] %{{.*}} : $D1 to $D2
 // CHECK: bb2
@@ -242,6 +244,7 @@ public class D2: D1 {
 // CHECK: bb3
 // CHECK: class_method
 // CHECK: }
+@inline(never)
 func driver2(_ d: D2) -> Int32 {
   return d.boo()
 }
@@ -276,12 +279,13 @@ class EEE : CCC {
 
 // Check that c.foo() is devirtualized, because the optimizer can handle the casting the return type
 // correctly, i.e. it can cast (BBB, BBB) into (AAA, AAA)
-// CHECK-LABEL: sil hidden @_T023devirt_covariant_return37testDevirtOfMethodReturningTupleTypesAA2AAC_ADtAA3CCCC_AA2BBC1btFTf4gg_n
+// CHECK-LABEL: sil shared [noinline] @_T023devirt_covariant_return37testDevirtOfMethodReturningTupleTypesAA2AAC_ADtAA3CCCC_AA2BBC1btFTf4gg_n
 // CHECK: checked_cast_br [exact] %{{.*}} : $CCC to $CCC
 // CHECK: checked_cast_br [exact] %{{.*}} : $CCC to $DDD
 // CHECK: checked_cast_br [exact] %{{.*}} : $CCC to $EEE
 // CHECK: class_method
 // CHECK: }
+@inline(never)
 func testDevirtOfMethodReturningTupleTypes(_ c: CCC, b: BB) -> (AA, AA) {
   return c.foo(b)
 }
@@ -315,12 +319,13 @@ class DDDD : CCCC {
 
 // Check devirtualization of methods with optional results, where
 // optional results need to be casted.
-// CHECK-LABEL: sil @{{.*}}testOverridingMethodWithOptionalResult
+// CHECK-LABEL: sil shared [noinline] @{{.*}}testOverridingMethodWithOptionalResult
 // CHECK: checked_cast_br [exact] %{{.*}} : $F to $F
 // CHECK: checked_cast_br [exact] %{{.*}} : $F to $G
 // CHECK: switch_enum
 // CHECK: checked_cast_br [exact] %{{.*}} : $F to $H
 // CHECK: switch_enum
+@inline(never)
 public func testOverridingMethodWithOptionalResult(_ f: F) -> (F?, Int)? {
   return f.foo()
 }

--- a/test/SILOptimizer/devirt_default_case.swift
+++ b/test/SILOptimizer/devirt_default_case.swift
@@ -132,7 +132,7 @@ class Base4 {
 func foo(_ a: A3) -> Int {
 // Check that call to A3.f() can be devirtualized.
 //
-// CHECK-NORMAL: sil{{( hidden)?}} [noinline] @_T019devirt_default_case3fooSiAA2A3CFTf4g_n
+// CHECK-NORMAL: sil{{( shared)?}} [noinline] @_T019devirt_default_case3fooSiAA2A3CFTf4g_n
 // CHECK-NORMAL: function_ref @_T019devirt_default_case2B3C1fSiyFTf4d_n
 // CHECK-NORMAL: function_ref @_T019devirt_default_case2A3C1fSiyFTf4d_n
 // CHECK-NORMAL-NOT: class_method
@@ -168,7 +168,7 @@ class D6 : C6 {
 func check_static_class_devirt(_ c: C6) -> Int { 
 // Check that C.bar() and D.bar() are devirtualized.
 //
-// CHECK-LABEL: sil{{( hidden)?}} [noinline] @_T019devirt_default_case019check_static_class_A0SiAA2C6CFTf4g_n
+// CHECK-LABEL: sil shared [noinline] @_T019devirt_default_case019check_static_class_A0SiAA2C6CFTf4g_n
 // CHECK: checked_cast_br [exact] %0 : $C6 to $C6
 // CHECK: checked_cast_br [exact] %0 : $C6 to $D6
 // CHECK: class_method

--- a/test/SILOptimizer/devirt_protocol_method_invocations.swift
+++ b/test/SILOptimizer/devirt_protocol_method_invocations.swift
@@ -68,7 +68,7 @@ public func test_devirt_protocol_extension_method_invocation_with_self_return_ty
 // be propagated from init_existential_addr into witness_method and 
 // apply instructions.
 
-// CHECK-LABEL: sil [noinline] @_T034devirt_protocol_method_invocations05test_a1_b1_C11_invocationSiAA1CCFTf4g_n
+// CHECK-LABEL: sil shared [noinline] @_T034devirt_protocol_method_invocations05test_a1_b1_C11_invocationSiAA1CCFTf4g_n
 // CHECK-NOT: witness_method
 // CHECK: checked_cast
 // CHECK-NOT: checked_cast
@@ -99,7 +99,7 @@ public func test_devirt_protocol_method_invocation(_ c: C) -> Int {
 // In fact, the call is expected to be inlined and then constant-folded
 // into a single integer constant.
 
-// CHECK-LABEL: sil [noinline] @_T034devirt_protocol_method_invocations05test_a1_b11_extension_C11_invocations5Int32VAA1CCFTf4d_n
+// CHECK-LABEL: sil shared [noinline] @_T034devirt_protocol_method_invocations05test_a1_b11_extension_C11_invocations5Int32VAA1CCFTf4d_n
 // CHECK-NOT: checked_cast
 // CHECK-NOT: open_existential
 // CHECK-NOT: witness_method
@@ -204,10 +204,11 @@ public final class V {
 }
 
 // Check that all witness_method invocations are devirtualized.
-// CHECK-LABEL: sil @_T034devirt_protocol_method_invocations44testPropagationOfConcreteTypeIntoExistentialyAA1VC1v_s5Int32V1xtFTf4gd_n
+// CHECK-LABEL: sil shared [noinline] @_T034devirt_protocol_method_invocations44testPropagationOfConcreteTypeIntoExistentialyAA1VC1v_s5Int32V1xtFTf4gd_n
 // CHECK-NOT: witness_method
 // CHECK-NOT: class_method
 // CHECK: return
+@inline(never)
 public func testPropagationOfConcreteTypeIntoExistential(v: V, x: Int32) {
   let y = v.a.plus()
   defer {

--- a/test/SILOptimizer/devirt_unbound_generic.swift
+++ b/test/SILOptimizer/devirt_unbound_generic.swift
@@ -55,7 +55,7 @@ public func testDevirt<T>(_ c: CC<T>) -> T? {
 
 // Check that the instance method Derived<T>.foo can be devirtualized, because Derived.foo is an internal function,
 // Derived has no subclasses and it is a WMO compilation.
-// CHECK-LABEL: sil hidden [noinline] @_T022devirt_unbound_generic5test2yAA7DerivedCyxGlF{{.*}}
+// CHECK-LABEL: sil shared [noinline] @_T022devirt_unbound_generic5test2yAA7DerivedCyxGlF{{.*}}
 // CHECK-NOT: class_method
 // CHECK-NOT: witness_method
 // CHECK-NOT: apply
@@ -72,7 +72,7 @@ public func doTest2<T>(_ t:T) {
 
 // Check that the class method Derived<T>.boo can be devirtualized, because Derived.boo is an internal function,
 // Derived has no subclasses and it is a WMO compilation.
-// CHECK: sil hidden [noinline] @_T022devirt_unbound_generic5test3yAA7DerivedCyxGlF{{.*}}
+// CHECK: sil shared [noinline] @_T022devirt_unbound_generic5test3yAA7DerivedCyxGlF{{.*}}
 // CHECK-NOT: class_method
 // CHECK-NOT: witness_method
 // CHECK-NOT: apply

--- a/test/SILOptimizer/functionsigopts.sil
+++ b/test/SILOptimizer/functionsigopts.sil
@@ -1701,19 +1701,19 @@ bb0(%0 : $*T):
   return %r : $()
 }
 
-// CHECK-LABEL: sil @_T036exploded_release_to_guaranteed_paramTf4gX_n
+// CHECK-LABEL: sil shared @_T036exploded_release_to_guaranteed_paramTf4gX_n
 // CHECK: bb0([[INPUT_ARG0:%[0-9]+]] : $Int):
 // CHECK-NOT: strong_release
 // CHECK: return
 
-// CHECK-LABEL: sil @_T025single_owned_return_valueTf4n_g : $@convention(thin) (@owned boo) -> boo
+// CHECK-LABEL: sil shared @_T025single_owned_return_valueTf4n_g : $@convention(thin) (@owned boo) -> boo
 // CHECK: bb0([[INPUT_ARG0:%[0-9]+]] : $boo):
 // CHECK-NOT: retain_value
 // CHECK: return
 
 // There should not be a single retain in this function.
 //
-// CHECK-LABEL: sil @_T045single_owned_return_value_with_self_recursionTf4n_g : $@convention(thin) (@owned boo) -> boo
+// CHECK-LABEL: sil shared @_T045single_owned_return_value_with_self_recursionTf4n_g : $@convention(thin) (@owned boo) -> boo
 // CHECK: bb0
 // CHECK-NOT: retain_value
 // CHECK: return
@@ -1776,26 +1776,26 @@ bb0(%0 : $*T):
 // CHECK:  return
 
 // Check that an owned-to-guaranteed has happened.
-// CHECK-LABEL: sil hidden [noinline] @_T027generic_owned_to_guaranteedTf4g_n : $@convention(thin) <T where T : KlassFoo> (@guaranteed T) -> Int64
-// CHECK-NOT: release_value 
+// CHECK-LABEL: sil shared [noinline] @_T027generic_owned_to_guaranteedTf4g_n : $@convention(thin) <T where T : KlassFoo> (@guaranteed T) -> Int64
+// CHECK-NOT: release_value
 // CHECK-NOT: strong_release 
 // CHECK-NOT: destroy_addr 
 // CHECK: end sil function '_T027generic_owned_to_guaranteedTf4g_n'
 
 // Check that an owned-to-guaranteed has happened.
-// CHECK-LABEL: sil @_T034generic_owned_to_guaranteed_callerTf4g_n : $@convention(thin) <T where T : KlassFoo> (@guaranteed T) -> Int64
-// Call the specialized function. It should have a guaranteed param now. 
+// CHECK-LABEL: sil shared @_T034generic_owned_to_guaranteed_callerTf4g_n : $@convention(thin) <T where T : KlassFoo> (@guaranteed T) -> Int64
+// Call the specialized function. It should have a guaranteed param now.
 // CHECK: function_ref @_T027generic_owned_to_guaranteedTf4g_n : $@convention(thin) <τ_0_0 where τ_0_0 : KlassFoo> (@guaranteed τ_0_0) -> Int64
 // CHECK: apply
 // CHECK: end sil function '_T034generic_owned_to_guaranteed_callerTf4g_n'
 
 // Check that a in-to-guaranteed has happened.
-// CHECK-LABEL: sil hidden [noinline] @_T024generic_in_to_guaranteedTf4g_n : $@convention(thin) <T where T : P> (@in_guaranteed T) -> Int64
+// CHECK-LABEL: sil shared [noinline] @_T024generic_in_to_guaranteedTf4g_n : $@convention(thin) <T where T : P> (@in_guaranteed T) -> Int64
 // CHECK-NOT: destroy_addr
 // CHECK: end sil function '_T024generic_in_to_guaranteedTf4g_n'
 
 // Check that a in-to-guaranteed has happened.
-// CHECK-LABEL: sil @_T031generic_in_to_guaranteed_callerTf4g_n : $@convention(thin) <T where T : P> (@in_guaranteed T) -> Int64
+// CHECK-LABEL: sil shared @_T031generic_in_to_guaranteed_callerTf4g_n : $@convention(thin) <T where T : P> (@in_guaranteed T) -> Int64
 // Call the specialized function. It should have a guaranteed param now. 
 // CHECK: function_ref @_T024generic_in_to_guaranteedTf4g_n : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> Int64
 // CHECK: apply

--- a/test/SILOptimizer/functionsigopts_self.swift
+++ b/test/SILOptimizer/functionsigopts_self.swift
@@ -21,7 +21,7 @@ extension C {
 }
 // The integer argument is truly dead, but the C.Type metadata argument may not be removed.
 // function signature specialization <Arg[0] = Dead> of static functionsigopts_self.C.factory (functionsigopts_self.C.Type)(Swift.Int) -> Self
-// CHECK-LABEL: sil hidden @_T020functionsigopts_self1CC7factory{{[_0-9a-zA-Z]*}}FZTf4dn_n : $@convention(method) (@thick C.Type) -> @owned C
+// CHECK-LABEL: sil shared @_T020functionsigopts_self1CC7factory{{[_0-9a-zA-Z]*}}FZTf4dn_n : $@convention(method) (@thick C.Type) -> @owned C
 // CHECK: bb0(%0 : $@thick C.Type):
 // CHECK: function_ref functionsigopts_self.gen<A>() -> A
 // CHECK: apply %{{[0-9]+}}<@dynamic_self C>

--- a/test/SILOptimizer/specialization_of_stdlib_binary_only.swift
+++ b/test/SILOptimizer/specialization_of_stdlib_binary_only.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -O -parse-stdlib -parse-as-library -emit-sil %s | %FileCheck %s
+// RUN: %target-swift-frontend -sil-serialize-all -O -parse-stdlib -parse-as-library -emit-sil %s | %FileCheck %s
 
 // Make sure specialization of stdlib_binary_only functions are not marked
 // shared. Marking them shared would make their visibility hidden. Because


### PR DESCRIPTION
Specializations are implementation details, and thus shouldn't be
public, even if they are specializing a public function. Without this
downgrade, the ABI of a module depends on random internal code
(could change inlining decisions etc.), as well as swiftc's optimiser.
