### PR TITLE
[GSB] Add RequirementSource::isProtocolRequirement() to check both protocol-requirement kinds.

### DIFF
--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -869,7 +869,7 @@ public:
            "RequirementSource kind/storageKind mismatch");
 
     storage.type = type.getPointer();
-    if (kind == ProtocolRequirement)
+    if (isProtocolRequirement())
       getTrailingObjects<ProtocolDecl *>()[0] = protocol;
     if (hasTrailingWrittenRequirementLoc)
       getTrailingObjects<WrittenRequirementLoc>()[0] = writtenReqLoc;
@@ -978,6 +978,11 @@ public:
   PotentialArchetype *visitPotentialArchetypesAlongPath(
            llvm::function_ref<bool(PotentialArchetype *,
                                    const RequirementSource *)> visitor) const;
+
+  /// Whether this source is a requirement in a protocol.
+  bool isProtocolRequirement() const {
+    return kind == ProtocolRequirement || kind == InferredProtocolRequirement;
+  }
 
   /// Whether the requirement is inferred or derived from an inferred
   /// requirement.

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -823,8 +823,7 @@ ConformanceAccessPath GenericSignature::getConformanceAccessPath(
   buildPath = [&](GenericSignature *sig, const RequirementSource *source,
                   ProtocolDecl *conformingProto, Type rootType) {
     // Each protocol requirement is a step along the path.
-    if (source->kind == RequirementSource::ProtocolRequirement ||
-        source->kind == RequirementSource::InferredProtocolRequirement) {
+    if (source->isProtocolRequirement()) {
       // Follow the rest of the path to derive the conformance into which
       // this particular protocol requirement step would look.
       auto inProtocol = source->getProtocolDecl();

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -613,7 +613,7 @@ ProtocolDecl *RequirementSource::getProtocolDecl() const {
     return nullptr;
 
   case StorageKind::StoredType:
-    if (kind == ProtocolRequirement)
+    if (isProtocolRequirement())
       return getTrailingObjects<ProtocolDecl *>()[0];
     return nullptr;
 
@@ -637,7 +637,7 @@ SourceLoc RequirementSource::getLoc() const {
   // for a particular requirement, rather than turning on/off location info.
   // Locations that fall into this category should be advisory, emitted via
   // notes rather than as the normal location.
-  if (kind == ProtocolRequirement && parent &&
+  if (isProtocolRequirement() && parent &&
       parent->kind != RequirementSignatureSelf)
     return parent->getLoc();
 
@@ -668,8 +668,7 @@ SourceLoc RequirementSource::getLoc() const {
 static unsigned sourcePathLength(const RequirementSource *source) {
   unsigned count = 0;
   for (; source; source = source->parent) {
-    if (source->kind == RequirementSource::ProtocolRequirement ||
-        source->kind == RequirementSource::InferredProtocolRequirement)
+    if (source->isProtocolRequirement())
       ++count;
   }
   return count;


### PR DESCRIPTION
It’s too easy to forget to check both `ProtocolRequirement` and `InferredProtocolRequirement`, so abstract the check into a method.

