### PR TITLE
Adopt to upstream changes.

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -1437,24 +1437,32 @@ llvm::DIType *IRGenDebugInfo::createType(DebugTypeInfo DbgTy,
     auto IdTy = DBuilder.createForwardDecl(
       llvm::dwarf::DW_TAG_structure_type, MangledName, Scope, File, 0,
         llvm::dwarf::DW_LANG_ObjC, 0, 0);
-    return DBuilder.createPointerType(IdTy, PtrSize, 0, MangledName);
+    return DBuilder.createPointerType(IdTy, PtrSize, 0,
+                                      /* DWARFAddressSpace */ None,
+                                      MangledName);
   }
 
   case TypeKind::BuiltinNativeObject: {
     unsigned PtrSize = CI.getTargetInfo().getPointerWidth(0);
-    auto PTy = DBuilder.createPointerType(nullptr, PtrSize, 0, MangledName);
+    auto PTy = DBuilder.createPointerType(nullptr, PtrSize, 0,
+                                          /* DWARFAddressSpace */ None,
+                                          MangledName);
     return DBuilder.createObjectPointerType(PTy);
   }
 
   case TypeKind::BuiltinBridgeObject: {
     unsigned PtrSize = CI.getTargetInfo().getPointerWidth(0);
-    auto PTy = DBuilder.createPointerType(nullptr, PtrSize, 0, MangledName);
+    auto PTy = DBuilder.createPointerType(nullptr, PtrSize, 0,
+                                          /* DWARFAddressSpace */ None,
+                                          MangledName);
     return DBuilder.createObjectPointerType(PTy);
   }
 
   case TypeKind::BuiltinRawPointer: {
     unsigned PtrSize = CI.getTargetInfo().getPointerWidth(0);
-    return DBuilder.createPointerType(nullptr, PtrSize, 0, MangledName);
+    return DBuilder.createPointerType(nullptr, PtrSize, 0,
+                                      /* DWARFAddressSpace */ None,
+                                      MangledName);
   }
 
   case TypeKind::DynamicSelf: {


### PR DESCRIPTION
This function has a new argument to specify a DWARFAddressSpace value.
There is a default value but since it was not added as the last argument,
Swift needs to update calls that specify the optional pointer type name
argument.

(cherry picked from commit 21ddc5c0870f449e0f545f9b1a8c032ce9a24158)
(cherry picked from commit 915cda6a05cf7c7eddbb79af14a023914cb9cea9)

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
