### PR TITLE
[Exclusivity] Add a small number of static end-to-end tests.

### DIFF
--- a/test/SILOptimizer/exclusivity_static_diagnostics.swift
+++ b/test/SILOptimizer/exclusivity_static_diagnostics.swift
@@ -2,7 +2,7 @@
 
 import Swift
 
-func takesTwoInouts(_ p1: inout Int, _ p2: inout Int) { }
+func takesTwoInouts<T>(_ p1: inout T, _ p2: inout T) { }
 
 func simpleInoutDiagnostic() {
   var i = 7
@@ -19,4 +19,38 @@ func swapNoSuppression(_ i: Int, _ j: Int) {
   // expected-warning@+2{{modification requires exclusive access}}
   // expected-note@+1{{conflicting modification requires exclusive access}}
   swap(&a[i], &a[j]) // no-warning
+}
+
+class SomeClass { }
+
+struct StructWithMutatingMethodThatTakesSelfInout {
+  var f = SomeClass()
+  mutating func mutate(_ other: inout StructWithMutatingMethodThatTakesSelfInout) { }
+  mutating func mutate(_ other: inout SomeClass) { }
+
+  mutating func callMutatingMethodThatTakesSelfInout() {
+    // expected-warning@+2{{modification requires exclusive access}}
+    // expected-note@+1{{conflicting modification requires exclusive access}}
+    mutate(&self)
+  }
+
+  mutating func callMutatingMethodThatTakesSelfStoredPropInout() {
+    // expected-warning@+2{{modification requires exclusive access}}
+    // expected-note@+1{{conflicting modification requires exclusive access}}
+    mutate(&self.f)
+  }
+}
+
+var global1 = StructWithMutatingMethodThatTakesSelfInout()
+func callMutatingMethodThatTakesGlobalStoredPropInout() {
+  // expected-warning@+2{{modification requires exclusive access}}
+  // expected-note@+1{{conflicting modification requires exclusive access}}
+  global1.mutate(&global1.f)
+}
+
+func violationWithGenericType<T>(_ p: T) {
+  var local = p
+  // expected-warning@+2{{modification requires exclusive access}}
+  // expected-note@+1{{conflicting modification requires exclusive access}}
+  takesTwoInouts(&local, &local)
 }


### PR DESCRIPTION
These encode the most common forms of violation we expect to detect statically.

This is a test-only change.