### PR TITLE
[test] Cleanup a test relying on USRs that didn't need to

### DIFF
--- a/test/SourceKit/CodeComplete/complete_moduleimportdepth.swift
+++ b/test/SourceKit/CodeComplete/complete_moduleimportdepth.swift
@@ -42,8 +42,8 @@ func test() {
 // CHECK-NEXT:   key.context: source.codecompletion.context.othermodule,
 // CHECK-NEXT:   key.moduleimportdepth: 1,
 // CHECK-NEXT:   key.num_bytes_to_erase: 0,
-// CHECK:        key.associated_usrs: "s:s3absxxs13FloatingPointRz9MagnitudeQzRszlF",
-// CHECK-NEXT:   key.modulename: "Swift"
+// CHECK-NOT:    key.modulename
+// CHECK:        key.modulename: "Swift"
 // CHECK-NEXT: },
 
 // FooHelper.FooHelperExplicit == 1
@@ -54,8 +54,8 @@ func test() {
 // CHECK-NEXT:   key.context: source.codecompletion.context.othermodule,
 // CHECK-NEXT:   key.moduleimportdepth: 1,
 // CHECK-NEXT:   key.num_bytes_to_erase: 0,
-// CHECK:   key.associated_usrs: "c:@F@fooHelperExplicitFrameworkFunc1",
-// CHECK-NEXT:   key.modulename: "FooHelper.FooHelperExplicit"
+// CHECK-NOT:    key.modulename
+// CHECK:        key.modulename: "FooHelper.FooHelperExplicit"
 // CHECK-NEXT: },
 
 // ImportsImportsFoo == 1
@@ -66,8 +66,8 @@ func test() {
 // CHECK-NEXT:   key.context: source.codecompletion.context.othermodule,
 // CHECK-NEXT:   key.moduleimportdepth: 1,
 // CHECK-NEXT:   key.num_bytes_to_erase: 0,
-// CHECK:   key.associated_usrs: "c:@F@importsImportsFoo",
-// CHECK-NEXT:   key.modulename: "ImportsImportsFoo"
+// CHECK-NOT:    key.modulename
+// CHECK:        key.modulename: "ImportsImportsFoo"
 // CHECK-NEXT: },
 
 // Bar == 2
@@ -78,8 +78,8 @@ func test() {
 // CHECK-NEXT:   key.context: source.codecompletion.context.othermodule,
 // CHECK-NEXT:   key.moduleimportdepth: 2,
 // CHECK-NEXT:   key.num_bytes_to_erase: 0,
-// CHECK:   key.associated_usrs: "c:objc(cs)BarForwardDeclaredClass",
-// CHECK-NEXT:   key.modulename: "Bar"
+// CHECK-NOT:    key.modulename
+// CHECK:        key.modulename: "Bar"
 // CHECK-NEXT: },
 
 // ImportsFoo == 2
@@ -90,8 +90,8 @@ func test() {
 // CHECK-NEXT:   key.context: source.codecompletion.context.othermodule,
 // CHECK-NEXT:   key.moduleimportdepth: 2,
 // CHECK-NEXT:   key.num_bytes_to_erase: 0,
-// CHECK:   key.associated_usrs: "c:@F@importsFoo",
-// CHECK-NEXT:   key.modulename: "ImportsFoo"
+// CHECK-NOT:    key.modulename
+// CHECK:        key.modulename: "ImportsFoo"
 // CHECK-NEXT: },
 
 // Foo == FooSub == 3
@@ -102,8 +102,8 @@ func test() {
 // CHECK-NEXT:   key.context: source.codecompletion.context.othermodule,
 // CHECK-NEXT:   key.moduleimportdepth: 3,
 // CHECK-NEXT:   key.num_bytes_to_erase: 0,
-// CHECK:   key.associated_usrs: "c:objc(cs)FooClassBase",
-// CHECK-NEXT:   key.modulename: "Foo"
+// CHECK-NOT:    key.modulename
+// CHECK:        key.modulename: "Foo"
 // CHECK-NEXT: },
 
 // CHECK-LABEL:  key.name: "FooSubEnum1",
@@ -113,8 +113,8 @@ func test() {
 // CHECK-NEXT:   key.context: source.codecompletion.context.othermodule,
 // CHECK-NEXT:   key.moduleimportdepth: 3,
 // CHECK-NEXT:   key.num_bytes_to_erase: 0,
-// CHECK:   key.associated_usrs: "c:@E@FooSubEnum1",
-// CHECK-NEXT:   key.modulename: "Foo.FooSub"
+// CHECK-NOT:    key.modulename
+// CHECK:        key.modulename: "Foo.FooSub"
 // CHECK-NEXT: },
 
 // FooHelper == 4
@@ -127,6 +127,6 @@ func test() {
 // xCHECK-NEXT:   key.context: source.codecompletion.context.othermodule,
 // xCHECK-NEXT:   key.moduleimportdepth: 4,
 // xCHECK-NEXT:   key.num_bytes_to_erase: 0,
-// xCHECK:   key.associated_usrs: "c:FooHelper.h@Ea@FooHelperUnnamedEnumeratorA2",
-// xCHECK-NEXT:   key.modulename: "FooHelper"
+// xCHECK-NOT:    key.modulename
+// xCHECK:        key.modulename: "FooHelper"
 // xCHECK-NEXT: },


### PR DESCRIPTION
We don't care what the USRs are here, we were just using them to avoid
results slipping in between the start of the structure and the module
name.  This patch does that in a way that doesn't use the USR.
