### PR TITLE
Weaken the circularity re-delay assertion when errors have been emitted.

### DIFF
--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -578,10 +578,14 @@ static void typeCheckFunctionsAndExternalDecls(TypeChecker &TC) {
   // Now that all types have been finalized, run any delayed
   // circularity checks.
   // This has been written carefully to fail safe + finitely if
-  // for some reason a type gets re-delayed.
+  // for some reason a type gets re-delayed in a non-assertions
+  // build in an otherwise successful build.
+  // Types can be redelayed in a failing build because we won't
+  // type-check required declarations from different files.
   for (size_t i = 0, e = TC.DelayedCircularityChecks.size(); i != e; ++i) {
     TC.checkDeclCircularity(TC.DelayedCircularityChecks[i]);
-    assert(e == TC.DelayedCircularityChecks.size() &&
+    assert((e == TC.DelayedCircularityChecks.size() ||
+            TC.Context.hadError()) &&
            "circularity checking for type was re-delayed!");
   }
   TC.DelayedCircularityChecks.clear();

--- a/test/Sema/Inputs/circularity_multifile_error_helper.swift
+++ b/test/Sema/Inputs/circularity_multifile_error_helper.swift
@@ -1,0 +1,5 @@
+struct External {
+  var member: Something
+}
+
+struct OtherExternal {}

--- a/test/Sema/circularity_multifile_error.swift
+++ b/test/Sema/circularity_multifile_error.swift
@@ -1,0 +1,11 @@
+// RUN: %target-swift-frontend -emit-silgen -verify -primary-file %s %S/Inputs/circularity_multifile_error_helper.swift
+
+// SR-4594
+
+struct A {
+  var b: AnUndefinedType // expected-error {{use of undeclared type 'AnUndefinedType'}}
+}
+
+struct B {
+  var a : External
+}


### PR DESCRIPTION
We don't finalize declarations when there's been an error, which means
we might never assign types to the stored properties/cases of a nominal
type from another file, which means that circularity checking for types
using those types be re-delayed.

Resolves [SR-4594](https://bugs.swift.org/browse/SR-4594).
rdar://problem/31627630