### PR TITLE
[swiftc (38 vs. 5515)] Add crasher in swift::Type::subst

### DIFF
--- a/validation-test/compiler_crashers/28742-swift-type-subst-llvm-function-ref-swift-type-swift-substitutabletype-llvm-funct.swift
+++ b/validation-test/compiler_crashers/28742-swift-type-subst-llvm-function-ref-swift-type-swift-substitutabletype-llvm-funct.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol P{{}typealias a:=A.a:struct A:P


### PR DESCRIPTION
Add test case for crash triggered in `swift::Type::subst`.

Current number of unresolved compiler crashers: 38 (5515 resolved)

Stack trace:

```
0 0x000000000398ef48 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x398ef48)
1 0x000000000398f686 SignalHandler(int) (/path/to/swift/bin/swift+0x398f686)
2 0x00007f68e66e4390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00000000015320c6 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::OptionSet<swift::SubstFlags, unsigned int>) const (/path/to/swift/bin/swift+0x15320c6)
4 0x000000000133b375 (anonymous namespace)::ConformanceChecker::resolveTypeWitnesses()::$_42::operator()(unsigned int) const (/path/to/swift/bin/swift+0x133b375)
5 0x000000000131e2d2 (anonymous namespace)::ConformanceChecker::resolveTypeWitnesses() (/path/to/swift/bin/swift+0x131e2d2)
6 0x000000000131db9b swift::TypeChecker::resolveTypeWitness(swift::NormalProtocolConformance const*, swift::AssociatedTypeDecl*) (/path/to/swift/bin/swift+0x131db9b)
7 0x000000000151df1e swift::NormalProtocolConformance::getTypeWitnessAndDecl(swift::AssociatedTypeDecl*, swift::LazyResolver*) const (/path/to/swift/bin/swift+0x151df1e)
8 0x000000000151db06 swift::ProtocolConformance::getTypeWitnessAndDecl(swift::AssociatedTypeDecl*, swift::LazyResolver*) const (/path/to/swift/bin/swift+0x151db06)
9 0x000000000130e6f4 swift::TypeChecker::lookupMemberType(swift::DeclContext*, swift::Type, swift::Identifier, swift::OptionSet<swift::NameLookupFlags, unsigned int>) (/path/to/swift/bin/swift+0x130e6f4)
10 0x000000000134b25c resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x134b25c)
11 0x000000000134aa53 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x134aa53)
12 0x000000000134bb6b (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0x134bb6b)
13 0x000000000134ba6c swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x134ba6c)
14 0x000000000134a16a swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x134a16a)
15 0x00000000012dc6b6 swift::TypeChecker::validateDecl(swift::ValueDecl*) (/path/to/swift/bin/swift+0x12dc6b6)
16 0x00000000012dab87 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x12dab87)
17 0x00000000012ec41b (anonymous namespace)::DeclChecker::visitProtocolDecl(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0x12ec41b)
18 0x00000000012daba7 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x12daba7)
19 0x00000000012da9a3 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x12da9a3)
20 0x0000000001358bc5 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x1358bc5)
21 0x0000000000f69ab6 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf69ab6)
22 0x00000000004a870e swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a870e)
23 0x0000000000465347 main (/path/to/swift/bin/swift+0x465347)
24 0x00007f68e4bf5830 __libc_start_main /build/glibc-9tT8Do/glibc-2.23/csu/../csu/libc-start.c:325:0
25 0x00000000004629e9 _start (/path/to/swift/bin/swift+0x4629e9)
```