### PR TITLE
[index] Mark indexed methods as 'dynamic' when appropriate

### DIFF
--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -712,6 +712,24 @@ bool IndexSwiftASTWalker::reportRelatedTypeRef(const TypeLoc &Ty, SymbolRoleSet 
   return true;
 }
 
+static bool isDynamicVarAccessorOrFunc(ValueDecl *D, SymbolInfo symInfo) {
+  if (auto NTD = D->getDeclContext()->getAsNominalTypeOrNominalTypeExtensionContext()) {
+    bool isClassOrProtocol = isa<ClassDecl>(NTD) || isa<ProtocolDecl>(NTD);
+    bool isInternalAccessor =
+      symInfo.SubKind == SymbolSubKind::SwiftAccessorWillSet ||
+      symInfo.SubKind == SymbolSubKind::SwiftAccessorDidSet ||
+      symInfo.SubKind == SymbolSubKind::SwiftAccessorAddressor ||
+      symInfo.SubKind == SymbolSubKind::SwiftAccessorMutableAddressor;
+    if (isClassOrProtocol &&
+        symInfo.Kind != SymbolKind::StaticMethod &&
+        !isInternalAccessor &&
+        !D->isFinal()) {
+      return true;
+    }
+  }
+  return false;
+}
+
 bool IndexSwiftASTWalker::reportPseudoAccessor(AbstractStorageDecl *D,
                                                AccessorKind AccKind, bool IsRef,
                                                SourceLoc Loc) {
@@ -736,6 +754,9 @@ bool IndexSwiftASTWalker::reportPseudoAccessor(AbstractStorageDecl *D,
     Info.symInfo.SubKind = getSubKindForAccessor(AccKind);
     Info.roles |= (SymbolRoleSet)SymbolRole::Implicit;
     Info.group = "";
+    if (isDynamicVarAccessorOrFunc(D, Info.symInfo)) {
+      Info.roles |= (SymbolRoleSet)SymbolRole::Dynamic;
+    }
     return false;
   };
 
@@ -983,6 +1004,10 @@ bool IndexSwiftASTWalker::initFuncDeclIndexSymbol(FuncDecl *D,
   if (initIndexSymbol(D, D->getLoc(), /*IsRef=*/false, Info))
     return true;
 
+  if (isDynamicVarAccessorOrFunc(D, Info.symInfo)) {
+    Info.roles |= (SymbolRoleSet)SymbolRole::Dynamic;
+  }
+
   if (D->getAttrs().hasAttribute<IBActionAttr>()) {
     // Relate with type of the first parameter using RelationIBTypeOf.
     if (D->getParameterLists().size() >= 2) {
@@ -1012,7 +1037,7 @@ static bool isSuperRefExpr(Expr *E) {
 }
 
 static bool isDynamicCall(Expr *BaseE, ValueDecl *D) {
-  // The call is 'dynamic' if the method is not of a struct and the
+  // The call is 'dynamic' if the method is not of a struct/enum and the
   // receiver is not 'super'. Note that if the receiver is 'super' that
   // does not mean that the call is statically determined (an extension
   // method may have injected itself in the super hierarchy).
@@ -1021,7 +1046,7 @@ static bool isDynamicCall(Expr *BaseE, ValueDecl *D) {
   auto TyD = getNominalParent(D);
   if (!TyD)
     return false;
-  if (isa<StructDecl>(TyD))
+  if (isa<StructDecl>(TyD) || isa<EnumDecl>(TyD))
     return false;
   if (isSuperRefExpr(BaseE))
     return false;

--- a/test/Index/index_system_module.swift
+++ b/test/Index/index_system_module.swift
@@ -8,10 +8,10 @@
 // CHECK: class/Swift | SubCls | [[SUBCLS_USR:.*]] | Def | rel: 0
 // CHECK: class/Swift | BaseCls | [[BASECLS_USR:.*]] | Ref,RelBase | rel: 1
 // CHECK-NEXT: RelBase | class/Swift | SubCls | [[SUBCLS_USR]]
-// CHECK: instance-method/Swift | theMeth() | [[SUBCLSMETH_USR:.*]] | Def,RelChild,RelOver | rel: 2
+// CHECK: instance-method/Swift | theMeth() | [[SUBCLSMETH_USR:.*]] | Def,Dyn,RelChild,RelOver | rel: 2
 // CHECK-NEXT: RelOver | instance-method/Swift | theMeth() | [[BASECLSMETH_USR:.*]]
 // CHECK-NEXT: RelChild | class/Swift | SubCls | [[SUBCLS_USR]]
 // CHECK: class/Swift | BaseCls | [[BASECLS_USR]] | Def | rel: 0
-// CHECK: instance-method/Swift | theMeth() | [[BASECLSMETH_USR]] | Def,RelChild | rel: 1
+// CHECK: instance-method/Swift | theMeth() | [[BASECLSMETH_USR]] | Def,Dyn,RelChild | rel: 1
 // CHECK-NEXT: RelChild | class/Swift | BaseCls | [[BASECLS_USR]]
 // CHECK: function/Swift | some_func() | [[SOMEFUNC_USR:.*]] | Def | rel: 0

--- a/test/Index/kinds.swift
+++ b/test/Index/kinds.swift
@@ -45,7 +45,7 @@ class AClass {
 
   // InstanceMethod + Parameters
   func instanceMethod(a: Int, b b: Int, _ c: Int, d _: Int, _: Int) {
-  // CHECK: [[@LINE-1]]:8 | instance-method/Swift | instanceMethod(a:b:_:d:_:) | s:14swift_ide_test6AClassC14instanceMethodySi1a_Si1bS2i1dSitF | Def,RelChild | rel: 1
+  // CHECK: [[@LINE-1]]:8 | instance-method/Swift | instanceMethod(a:b:_:d:_:) | s:14swift_ide_test6AClassC14instanceMethodySi1a_Si1bS2i1dSitF | Def,Dyn,RelChild | rel: 1
   // CHECK-NEXT: RelChild | class/Swift | AClass | s:14swift_ide_test6AClassC
   // CHECK: [[@LINE-3]]:23 | param/Swift | a | s:14swift_ide_test6AClassC14instanceMethodySi1a_Si1bS2i1dSitFAEL_Siv | Def,RelChild | rel: 1
   // CHECK-NEXT: RelChild | instance-method/Swift | instanceMethod(a:b:_:d:_:) | s:14swift_ide_test6AClassC14instanceMethodySi1a_Si1bS2i1dSitF
@@ -64,7 +64,7 @@ class AClass {
 
   // ClassMethod
   class func classMethod() {}
-  // CHECK: [[@LINE-1]]:14 | class-method/Swift | classMethod() | s:14swift_ide_test6AClassC11classMethodyyFZ | Def,RelChild | rel: 1
+  // CHECK: [[@LINE-1]]:14 | class-method/Swift | classMethod() | s:14swift_ide_test6AClassC11classMethodyyFZ | Def,Dyn,RelChild | rel: 1
   // CHECK-NEXT: RelChild | class/Swift | AClass | s:14swift_ide_test6AClassC
 
   // StaticMethod
@@ -79,7 +79,7 @@ class AClass {
 
     // Accessor + AccessorGetter
     get {
-      // CHECK: [[@LINE-1]]:5 | instance-method/acc-get/Swift | getter:instanceProperty | s:14swift_ide_test6AClassC16instancePropertySifg | Def,RelChild,RelAcc | rel: 1
+      // CHECK: [[@LINE-1]]:5 | instance-method/acc-get/Swift | getter:instanceProperty | s:14swift_ide_test6AClassC16instancePropertySifg | Def,Dyn,RelChild,RelAcc | rel: 1
       // CHECK-NEXT: RelChild,RelAcc | instance-property/Swift | instanceProperty | s:14swift_ide_test6AClassC16instancePropertySiv
 
       return 1
@@ -87,7 +87,7 @@ class AClass {
 
     // Accessor + AccessorSetter
     set {}
-    // CHECK: [[@LINE-1]]:5 | instance-method/acc-set/Swift | setter:instanceProperty | s:14swift_ide_test6AClassC16instancePropertySifs | Def,RelChild,RelAcc | rel: 1
+    // CHECK: [[@LINE-1]]:5 | instance-method/acc-set/Swift | setter:instanceProperty | s:14swift_ide_test6AClassC16instancePropertySifs | Def,Dyn,RelChild,RelAcc | rel: 1
     // CHECK-NEXT: RelChild,RelAcc | instance-property/Swift | instanceProperty | s:14swift_ide_test6AClassC16instancePropertySiv
   }
 
@@ -194,7 +194,7 @@ class MyTestCase : XCTestCase {
 // CHECK: [[@LINE-1]]:7 | class(test)/Swift | MyTestCase |
   func callit() {}
   func testMe() {
-  // CHECK: [[@LINE-1]]:8 | instance-method(test)/Swift | testMe() | [[MyTestCase_testMe_USR:.*]] | Def,RelChild
+  // CHECK: [[@LINE-1]]:8 | instance-method(test)/Swift | testMe() | [[MyTestCase_testMe_USR:.*]] | Def,Dyn,RelChild
     callit()
     // CHECK: [[@LINE-1]]:5 | instance-method/Swift | callit() | s:14swift_ide_test10MyTestCaseC6callityyF | Ref,Call,Dyn,RelRec,RelCall,RelCont | rel: 2
     // CHECK-NEXT: RelCall,RelCont | instance-method(test)/Swift | testMe() | [[MyTestCase_testMe_USR]]
@@ -227,7 +227,7 @@ class AttrAnnots {
   @IBOutlet var iboutletString: AnyObject?
   // CHECK: [[@LINE-1]]:17 | instance-property(IB)/Swift | iboutletString |
   @IBAction func someibaction(o: TargetForIBAction) {}
-  // CHECK: [[@LINE-1]]:18 | instance-method(IB)/Swift | someibaction(o:) | {{.*}} | Def,RelChild,RelIBType | rel: 2
+  // CHECK: [[@LINE-1]]:18 | instance-method(IB)/Swift | someibaction(o:) | {{.*}} | Def,Dyn,RelChild,RelIBType | rel: 2
   // CHECK-NEXT: RelIBType | class/Swift | TargetForIBAction | [[TargetForIBAction_USR]]
   @GKInspectable var gkString = "gk"
   // CHECK: [[@LINE-1]]:22 | instance-property(GKI)/Swift | gkString |

--- a/test/Index/roles.swift
+++ b/test/Index/roles.swift
@@ -138,14 +138,14 @@ class AClass {
 // CHECK: [[@LINE-1]]:7 | class/Swift | AClass | [[AClass_USR:.*]] | Def | rel: 0
   var y: AStruct
   // CHECK: [[@LINE-1]]:7 | instance-property/Swift | y | [[AClass_y_USR:.*]] | Def,RelChild | rel: 1
-  // CHECK: [[@LINE-2]]:7 | instance-method/acc-get/Swift | getter:y | [[AClass_y_get_USR:.*]] | Def,Impl,RelChild,RelAcc | rel: 1
+  // CHECK: [[@LINE-2]]:7 | instance-method/acc-get/Swift | getter:y | [[AClass_y_get_USR:.*]] | Def,Dyn,Impl,RelChild,RelAcc | rel: 1
   // CHECK-NEXT:   RelChild,RelAcc | instance-property/Swift | y | [[AClass_y_USR]]
-  // CHECK: [[@LINE-4]]:7 | instance-method/acc-set/Swift | setter:y | [[AClass_y_set_USR:.*]] | Def,Impl,RelChild,RelAcc | rel: 1
+  // CHECK: [[@LINE-4]]:7 | instance-method/acc-set/Swift | setter:y | [[AClass_y_set_USR:.*]] | Def,Dyn,Impl,RelChild,RelAcc | rel: 1
   // CHECK-NEXT:   RelChild,RelAcc | instance-property/Swift | y | [[AClass_y_USR]]
   var z: [Int]
   var computed_p: Int { return 0 }
   // CHECK: [[@LINE-1]]:7 | instance-property/Swift | computed_p | [[AClass_computed_p_USR:.*]] | Def,RelChild | rel: 1
-  // CHECK: [[@LINE-2]]:23 | instance-method/acc-get/Swift | getter:computed_p | [[AClass_computed_p_get_USR:.*]] | Def,RelChild,RelAcc | rel: 1
+  // CHECK: [[@LINE-2]]:23 | instance-method/acc-get/Swift | getter:computed_p | [[AClass_computed_p_get_USR:.*]] | Def,Dyn,RelChild,RelAcc | rel: 1
   // CHECK-NEXT:   RelChild,RelAcc | instance-property/Swift | computed_p | [[AClass_computed_p_USR]]
   // CHECK-NOT: acc-set/Swift | setter:computed_p |
   init(x: Int) {
@@ -155,12 +155,12 @@ class AClass {
   subscript(index: Int) -> Int {
   // CHECK: [[@LINE-1]]:3 | instance-property/subscript/Swift | subscript(_:) | [[AClass_subscript_USR:.*]] | Def,RelChild | rel: 1
     get { return z[0] }
-    // CHECK: [[@LINE-1]]:5 | instance-method/acc-get/Swift | getter:subscript(_:) | [[AClass_subscript_get_USR:.*]] | Def,RelChild,RelAcc | rel: 1
+    // CHECK: [[@LINE-1]]:5 | instance-method/acc-get/Swift | getter:subscript(_:) | [[AClass_subscript_get_USR:.*]] | Def,Dyn,RelChild,RelAcc | rel: 1
     set { z[0] = newValue }
-    // CHECK: [[@LINE-1]]:5 | instance-method/acc-set/Swift | setter:subscript(_:) | [[AClass_subscript_set_USR:.*]] | Def,RelChild,RelAcc | rel: 1
+    // CHECK: [[@LINE-1]]:5 | instance-method/acc-set/Swift | setter:subscript(_:) | [[AClass_subscript_set_USR:.*]] | Def,Dyn,RelChild,RelAcc | rel: 1
   }
   func foo() -> Int { return z[0] }
-  // CHECK: [[@LINE-1]]:8 | instance-method/Swift | foo() | [[AClass_foo_USR:.*]] | Def,RelChild | rel: 1
+  // CHECK: [[@LINE-1]]:8 | instance-method/Swift | foo() | [[AClass_foo_USR:.*]] | Def,Dyn,RelChild | rel: 1
 }
 
 let _ = AClass.foo
@@ -176,7 +176,7 @@ let _ = AClass(x: 1)[1] = 2
 
 extension AClass {
   func test_property_refs1() -> AStruct {
-    // CHECK: [[@LINE-1]]:8 | instance-method/Swift | test_property_refs1() | [[test_property_refs1_USR:.*]] | Def,RelChild | rel: 1
+    // CHECK: [[@LINE-1]]:8 | instance-method/Swift | test_property_refs1() | [[test_property_refs1_USR:.*]] | Def,Dyn,RelChild | rel: 1
     _ = y
     // CHECK: [[@LINE-1]]:9 | instance-property/Swift | y | [[AClass_y_USR]] | Ref,Read,RelCont | rel: 1
     // CHECK: [[@LINE-2]]:9 | instance-method/acc-get/Swift | getter:y | [[AClass_y_get_USR]] | Ref,Call,Dyn,Impl,RelRec,RelCall,RelCont | rel: 2
@@ -191,7 +191,7 @@ extension AClass {
   }
 
   func test_property_refs2() -> Int {
-    // CHECK: [[@LINE-1]]:8 | instance-method/Swift | test_property_refs2() | [[test_property_refs2_USR:.*]] | Def,RelChild | rel: 1
+    // CHECK: [[@LINE-1]]:8 | instance-method/Swift | test_property_refs2() | [[test_property_refs2_USR:.*]] | Def,Dyn,RelChild | rel: 1
     _ = computed_p
     // CHECK: [[@LINE-1]]:9 | instance-property/Swift | computed_p | [[AClass_computed_p_USR]] | Ref,Read,RelCont | rel: 1
     // CHECK: [[@LINE-2]]:9 | instance-method/acc-get/Swift | getter:computed_p | [[AClass_computed_p_get_USR]] | Ref,Call,Dyn,Impl,RelRec,RelCall,RelCont | rel: 2
@@ -213,6 +213,8 @@ protocol X {
 
   var reqProp: Int { get }
   // CHECK: [[@LINE-1]]:7 | instance-property/Swift | reqProp | [[reqProp_USR:.*]] | Def,RelChild | rel: 1
+  // CHECK: [[@LINE-2]]:22 | instance-method/acc-get/Swift | getter:reqProp | {{.*}} | Def,Dyn,RelChild,RelAcc | rel: 1
+  // CHECK-NEXT  RelChild,RelAcc | instance-property/Swift | reqProp_USR | [[reqProp_USR]]
 }
 
 class ImplementsX : X {
@@ -240,7 +242,7 @@ protocol AProtocol {
   // CHECK: [[@LINE-3]]:22 | protocol/Swift | X | [[X_USR]] | Ref | rel: 0
 
   func foo() -> Int
-  // CHECK: [[@LINE-1]]:8 | instance-method/Swift | foo() | s:14swift_ide_test9AProtocolP3fooSiyF | Def,RelChild | rel: 1
+  // CHECK: [[@LINE-1]]:8 | instance-method/Swift | foo() | s:14swift_ide_test9AProtocolP3fooSiyF | Def,Dyn,RelChild | rel: 1
   // CHECK-NEXT: RelChild | protocol/Swift | AProtocol | s:14swift_ide_test9AProtocolP
 }
 
@@ -254,7 +256,7 @@ class ASubClass : AClass, AProtocol {
   typealias T = ImplementsX
 
   override func foo() -> Int {
-    // CHECK: [[@LINE-1]]:17 | instance-method/Swift | foo() | s:14swift_ide_test9ASubClassC3fooSiyF | Def,RelChild,RelOver | rel: 3
+    // CHECK: [[@LINE-1]]:17 | instance-method/Swift | foo() | s:14swift_ide_test9ASubClassC3fooSiyF | Def,Dyn,RelChild,RelOver | rel: 3
     // CHECK-NEXT: RelOver | instance-method/Swift | foo() | [[AClass_foo_USR]]
     // CHECK-NEXT: RelOver | instance-method/Swift | foo() | s:14swift_ide_test9AProtocolP3fooSiyF
     // CHECK-NEXT: RelChild | class/Swift | ASubClass | s:14swift_ide_test9ASubClassC
@@ -269,7 +271,7 @@ extension AClass {
   // CHECK-NEXT: RelExt | extension/ext-class/Swift | AClass | [[EXT_ACLASS_USR]]
 
   func bar() -> Int { return 2 }
-  // CHECK: [[@LINE-1]]:8 | instance-method/Swift | bar() | s:14swift_ide_test6AClassC3barSiyF | Def,RelChild | rel: 1
+  // CHECK: [[@LINE-1]]:8 | instance-method/Swift | bar() | s:14swift_ide_test6AClassC3barSiyF | Def,Dyn,RelChild | rel: 1
   // CHECK-NEXT: RelChild | extension/ext-class/Swift | AClass | [[EXT_ACLASS_USR]]
 }
 
@@ -399,27 +401,55 @@ protocol ProtDerived : ProtRoot {
 
 extension ProtDerived {
   func fooCommon() {}
-  // CHECK: [[@LINE-1]]:8 | instance-method/Swift | fooCommon() | s:14swift_ide_test11ProtDerivedPAAE9fooCommonyyF | Def,RelChild,RelOver | rel: 3
+  // CHECK: [[@LINE-1]]:8 | instance-method/Swift | fooCommon() | s:14swift_ide_test11ProtDerivedPAAE9fooCommonyyF | Def,Dyn,RelChild,RelOver | rel: 3
   // CHECK-NEXT: RelOver | instance-method/Swift | fooCommon() | s:14swift_ide_test11ProtDerivedP9fooCommonyyF
   // CHECK-NEXT: RelOver | instance-method/Swift | fooCommon() | s:14swift_ide_test8ProtRootP9fooCommonyyF
 
   func foo1() {}
-  // CHECK: [[@LINE-1]]:8 | instance-method/Swift | foo1() | s:14swift_ide_test11ProtDerivedPAAE4foo1yyF | Def,RelChild,RelOver | rel: 2
+  // CHECK: [[@LINE-1]]:8 | instance-method/Swift | foo1() | s:14swift_ide_test11ProtDerivedPAAE4foo1yyF | Def,Dyn,RelChild,RelOver | rel: 2
   // CHECK-NEXT: RelOver | instance-method/Swift | foo1() | s:14swift_ide_test8ProtRootP4foo1yyF
 
   func bar1() {}
-  // CHECK: [[@LINE-1]]:8 | instance-method/Swift | bar1() | s:14swift_ide_test11ProtDerivedPAAE4bar1yyF | Def,RelChild,RelOver | rel: 2
+  // CHECK: [[@LINE-1]]:8 | instance-method/Swift | bar1() | s:14swift_ide_test11ProtDerivedPAAE4bar1yyF | Def,Dyn,RelChild,RelOver | rel: 2
   // CHECK-NEXT: RelOver | instance-method/Swift | bar1() | s:14swift_ide_test11ProtDerivedP4bar1yyF
 
   func foo3(a : Int) {}
-  // CHECK: [[@LINE-1]]:8 | instance-method/Swift | foo3(a:) | s:14swift_ide_test11ProtDerivedPAAE4foo3ySi1a_tF | Def,RelChild,RelOver | rel: 2
+  // CHECK: [[@LINE-1]]:8 | instance-method/Swift | foo3(a:) | s:14swift_ide_test11ProtDerivedPAAE4foo3ySi1a_tF | Def,Dyn,RelChild,RelOver | rel: 2
   // CHECK-NEXT: RelOver | instance-method/Swift | foo3(a:) | s:14swift_ide_test8ProtRootP4foo3ySi1a_tF
 
   func foo3(a : String) {}
-  // CHECK: [[@LINE-1]]:8 | instance-method/Swift | foo3(a:) | s:14swift_ide_test11ProtDerivedPAAE4foo3ySS1a_tF | Def,RelChild,RelOver | rel: 2
+  // CHECK: [[@LINE-1]]:8 | instance-method/Swift | foo3(a:) | s:14swift_ide_test11ProtDerivedPAAE4foo3ySS1a_tF | Def,Dyn,RelChild,RelOver | rel: 2
   // CHECK-NEXT: RelOver | instance-method/Swift | foo3(a:) | s:14swift_ide_test8ProtRootP4foo3ySS1a_tF
 
   func bar3(_ : Int) {}
-  // CHECK: [[@LINE-1]]:8 | instance-method/Swift | bar3(_:) | s:14swift_ide_test11ProtDerivedPAAE4bar3ySiF | Def,RelChild,RelOver | rel: 2
+  // CHECK: [[@LINE-1]]:8 | instance-method/Swift | bar3(_:) | s:14swift_ide_test11ProtDerivedPAAE4bar3ySiF | Def,Dyn,RelChild,RelOver | rel: 2
   // CHECK-NEXT: RelOver | instance-method/Swift | bar3(_:) | s:14swift_ide_test11ProtDerivedP4bar3ySiF
+}
+
+enum MyEnum {
+  init() {}
+  func enum_func() {}
+  // CHECK: [[@LINE-1]]:8 | instance-method/Swift | enum_func() | [[MyEnum_enum_func_USR:.*]] | Def,RelChild | rel: 1
+}
+
+MyEnum().enum_func()
+// CHECK: [[@LINE-1]]:10 | instance-method/Swift | enum_func() | [[MyEnum_enum_func_USR]] | Ref,Call,RelRec | rel: 1
+
+class ClassWithFinals {
+  final var prop : Int { get { return 0} }
+  // CHECK: [[@LINE-1]]:26 | instance-method/acc-get/Swift | {{.*}} | Def,RelChild,RelAcc | rel: 1
+  final var prop2 = 0
+  // CHECK: [[@LINE-1]]:13 | instance-method/acc-get/Swift | {{.*}} | Def,Impl,RelChild,RelAcc | rel: 1
+  // CHECK: [[@LINE-2]]:13 | instance-method/acc-set/Swift | {{.*}} | Def,Impl,RelChild,RelAcc | rel: 1
+  final func foo() {}
+  // CHECK: [[@LINE-1]]:14 | instance-method/Swift | {{.*}} | Def,RelChild | rel: 1
+}
+final class FinalClass {
+  var prop : Int { get { return 0} }
+  // CHECK: [[@LINE-1]]:20 | instance-method/acc-get/Swift | {{.*}} | Def,RelChild,RelAcc | rel: 1
+  var prop2 = 0
+  // CHECK: [[@LINE-1]]:7 | instance-method/acc-get/Swift | {{.*}} | Def,Impl,RelChild,RelAcc | rel: 1
+  // CHECK: [[@LINE-2]]:7 | instance-method/acc-set/Swift | {{.*}} | Def,Impl,RelChild,RelAcc | rel: 1
+  func foo() {}
+  // CHECK: [[@LINE-1]]:8 | instance-method/Swift | {{.*}} | Def,RelChild | rel: 1
 }

--- a/test/SourceKit/Indexing/Inputs/cycle-depend/A.response
+++ b/test/SourceKit/Indexing/Inputs/cycle-depend/A.response
@@ -58,11 +58,13 @@
           key.entities: [
             {
               key.kind: source.lang.swift.decl.function.accessor.getter,
-              key.usr: "s:1AAAC1x1BADCfg"
+              key.usr: "s:1AAAC1x1BADCfg",
+              key.is_dynamic: 1
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.setter,
-              key.usr: "s:1AAAC1x1BADCfs"
+              key.usr: "s:1AAAC1x1BADCfs",
+              key.is_dynamic: 1
             }
           ]
         }

--- a/test/SourceKit/Indexing/Inputs/implicit-vis/a.index.response
+++ b/test/SourceKit/Indexing/Inputs/implicit-vis/a.index.response
@@ -28,13 +28,15 @@
               key.kind: source.lang.swift.decl.function.accessor.getter,
               key.usr: "s:12implicit_vis1AC1bAA1BCfg",
               key.line: 2,
-              key.column: 6
+              key.column: 6,
+              key.is_dynamic: 1
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.setter,
               key.usr: "s:12implicit_vis1AC1bAA1BCfs",
               key.line: 2,
-              key.column: 6
+              key.column: 6,
+              key.is_dynamic: 1
             }
           ]
         },

--- a/test/SourceKit/Indexing/Inputs/implicit-vis/b.index.response
+++ b/test/SourceKit/Indexing/Inputs/implicit-vis/b.index.response
@@ -28,13 +28,15 @@
               key.kind: source.lang.swift.decl.function.accessor.getter,
               key.usr: "s:12implicit_vis1BC1aAA1ACfg",
               key.line: 2,
-              key.column: 6
+              key.column: 6,
+              key.is_dynamic: 1
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.setter,
               key.usr: "s:12implicit_vis1BC1aAA1ACfs",
               key.line: 2,
-              key.column: 6
+              key.column: 6,
+              key.is_dynamic: 1
             }
           ]
         },

--- a/test/SourceKit/Indexing/Inputs/test_module.index.response
+++ b/test/SourceKit/Indexing/Inputs/test_module.index.response
@@ -28,12 +28,14 @@
             {
               key.kind: source.lang.swift.decl.function.accessor.getter,
               key.name: "getter:value",
-              key.usr: "s:11test_module16ComputedPropertyC5valueSifg"
+              key.usr: "s:11test_module16ComputedPropertyC5valueSifg",
+              key.is_dynamic: 1
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.setter,
               key.name: "setter:value",
-              key.usr: "s:11test_module16ComputedPropertyC5valueSifs"
+              key.usr: "s:11test_module16ComputedPropertyC5valueSifs",
+              key.is_dynamic: 1
             }
           ]
         }
@@ -68,11 +70,13 @@
           key.entities: [
             {
               key.kind: source.lang.swift.decl.function.accessor.getter,
-              key.usr: "s:11test_module7TwoIntsC1xSifg"
+              key.usr: "s:11test_module7TwoIntsC1xSifg",
+              key.is_dynamic: 1
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.setter,
-              key.usr: "s:11test_module7TwoIntsC1xSifs"
+              key.usr: "s:11test_module7TwoIntsC1xSifs",
+              key.is_dynamic: 1
             }
           ]
         },
@@ -83,11 +87,13 @@
           key.entities: [
             {
               key.kind: source.lang.swift.decl.function.accessor.getter,
-              key.usr: "s:11test_module7TwoIntsC1ySifg"
+              key.usr: "s:11test_module7TwoIntsC1ySifg",
+              key.is_dynamic: 1
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.setter,
-              key.usr: "s:11test_module7TwoIntsC1ySifs"
+              key.usr: "s:11test_module7TwoIntsC1ySifs",
+              key.is_dynamic: 1
             }
           ]
         },

--- a/test/SourceKit/Indexing/index_constructors.swift.response
+++ b/test/SourceKit/Indexing/index_constructors.swift.response
@@ -44,13 +44,15 @@
               key.kind: source.lang.swift.decl.function.accessor.getter,
               key.usr: "s:18index_constructors11HorseObjectC4nameXefg",
               key.line: 7,
-              key.column: 7
+              key.column: 7,
+              key.is_dynamic: 1
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.setter,
               key.usr: "s:18index_constructors11HorseObjectC4nameXefs",
               key.line: 7,
-              key.column: 7
+              key.column: 7,
+              key.is_dynamic: 1
             }
           ]
         },
@@ -60,6 +62,7 @@
           key.usr: "s:18index_constructors11HorseObjectC4flipyyF",
           key.line: 9,
           key.column: 21,
+          key.is_dynamic: 1,
           key.attributes: [
             {
               key.attribute: source.decl.attribute.objc

--- a/test/SourceKit/Indexing/index_is_test_candidate_objc.swift.response
+++ b/test/SourceKit/Indexing/index_is_test_candidate_objc.swift.response
@@ -69,6 +69,7 @@
           key.usr: "s:28index_is_test_candidate_objc14MyPrivateClass33_32FED72643814BE1A523406CD2E729AALLC0c47_startsWithTest_takesNoParams_returnsVoid_andIsG0yyF",
           key.line: 16,
           key.column: 8,
+          key.is_dynamic: 1,
           key.is_test_candidate: 1
         }
       ],
@@ -102,7 +103,8 @@
           key.name: "doesNotStartWithTest()",
           key.usr: "s:28index_is_test_candidate_objc7MyClassC20doesNotStartWithTestyyF",
           key.line: 20,
-          key.column: 8
+          key.column: 8,
+          key.is_dynamic: 1
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
@@ -110,6 +112,7 @@
           key.usr: "s:28index_is_test_candidate_objc7MyClassC0C30_startsWithTest_butTakesAParamySi5param_tF",
           key.line: 21,
           key.column: 8,
+          key.is_dynamic: 1,
           key.entities: [
             {
               key.kind: source.lang.swift.ref.struct,
@@ -126,6 +129,7 @@
           key.usr: "s:28index_is_test_candidate_objc7MyClassC0C50_startsWithTest_andTakesNoParams_butReturnsNonVoidSiyF",
           key.line: 22,
           key.column: 8,
+          key.is_dynamic: 1,
           key.entities: [
             {
               key.kind: source.lang.swift.ref.struct,
@@ -142,6 +146,7 @@
           key.usr: "s:28index_is_test_candidate_objc7MyClassC0C54_startsWithTest_takesNoParams_returnsVoid_andIsPrivate33_32FED72643814BE1A523406CD2E729AALLyyF",
           key.line: 23,
           key.column: 16,
+          key.is_dynamic: 1,
           key.is_test_candidate: 1
         },
         {
@@ -150,6 +155,7 @@
           key.usr: "s:28index_is_test_candidate_objc7MyClassC0C41_startsWithTest_takesNoParams_returnsVoidyyF",
           key.line: 24,
           key.column: 8,
+          key.is_dynamic: 1,
           key.is_test_candidate: 1
         },
         {
@@ -158,6 +164,7 @@
           key.usr: "s:28index_is_test_candidate_objc7MyClassC0C51_startsWithTest_takesNoParams_returnsVoid_andThrowsyyKF",
           key.line: 25,
           key.column: 8,
+          key.is_dynamic: 1,
           key.is_test_candidate: 1
         }
       ],

--- a/test/SourceKit/Indexing/sr_3815.swift.response
+++ b/test/SourceKit/Indexing/sr_3815.swift.response
@@ -38,7 +38,8 @@
           key.name: "f()",
           key.usr: "s:7sr_38151PP1fyyF",
           key.line: 6,
-          key.column: 8
+          key.column: 8,
+          key.is_dynamic: 1
         }
       ]
     },


### PR DESCRIPTION
'dynamic' for indexing purposes means the method is overridable.
rdar://problem/28329047