### PR TITLE
EscapeAnalysis: handle fix_lifetime instructions

### DIFF
--- a/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
@@ -1354,6 +1354,7 @@ void EscapeAnalysis::analyzeInstruction(SILInstruction *I,
     case ValueKind::ExistentialMetatypeInst:
     case ValueKind::DeallocRefInst:
     case ValueKind::SetDeallocatingInst:
+    case ValueKind::FixLifetimeInst:
       // These instructions don't have any effect on escaping.
       return;
     case ValueKind::StrongReleaseInst:

--- a/test/SILOptimizer/escape_analysis.sil
+++ b/test/SILOptimizer/escape_analysis.sil
@@ -1436,6 +1436,7 @@ bb3(%6: $X):
 // CHECKL:      End
 sil @_T04main1XCfD: $@convention(method) (@owned X) -> () {
 bb0(%0 : $X):
+  fix_lifetime %0 : $X
   %1 = tuple ()
   return %1 : $()
 }

--- a/test/SILOptimizer/stack_promotion_array_literal.swift
+++ b/test/SILOptimizer/stack_promotion_array_literal.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-frontend -parse-as-library -O -module-name=test %s -emit-sil | %FileCheck %s
+// REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
+
+// This is an end-to-end test to check if the array literal in the loop is
+// stack promoted.
+
+// CHECK-LABEL: sil @{{.*}}testit
+// CHECK:  alloc_ref [stack] [tail_elems
+
+public func testit(_ N: Int) {
+  for _ in 0..<N {
+    for _ in 0..<10 {
+       var nums = [Int]()
+       for _ in 0..<40_000 {
+         nums += [1, 2, 3, 4, 5, 6, 7]
+       }
+    }
+  }
+}


### PR DESCRIPTION
This fixes wrong reported escapes of the self reference in destructors.

rdar://problem/31409766

