### PR TITLE
[Benchmark] Speed up compilation time; add String benchmarks

### DIFF
--- a/benchmark/scripts/generate_harness/generate_harness.py
+++ b/benchmark/scripts/generate_harness/generate_harness.py
@@ -39,7 +39,21 @@ template_map = {
     'CMakeLists.txt_template': os.path.join(output_dir, 'CMakeLists.txt'),
     'main.swift_template': os.path.join(output_dir, 'utils/main.swift')
 }
-ignored_run_funcs = ["Ackermann", "Fibonacci"]
+
+### The test suites. Currently, "other" and "string"
+other_tests = ["Ackermann", "Fibonacci"]
+string_tests = [
+    "StringWalkASCIIScalars",
+    "StringWalkASCIICharacters",
+    "StringWalkUnicodeScalars",
+    "StringWalkUnicodeCharacters",
+    "StringWalkASCIIScalarsBackwards",
+    "StringWalkASCIICharactersBackwards",
+    "StringWalkUnicodeScalarsBackwards",
+    "StringWalkUnicodeCharactersBackwards",
+]
+
+ignored_run_funcs = other_tests + string_tests
 
 template_loader = jinja2.FileSystemLoader(searchpath="/")
 template_env = jinja2.Environment(loader=template_loader, trim_blocks=True,
@@ -115,5 +129,7 @@ if __name__ == '__main__':
             template.render(tests=tests,
                             multisource_benches=multisource_benches,
                             imports=imports,
-                            run_funcs=run_funcs)
+                            run_funcs=run_funcs,
+                            string_tests=string_tests,
+                            other_tests=other_tests)
         )

--- a/benchmark/scripts/generate_harness/generate_harness.py
+++ b/benchmark/scripts/generate_harness/generate_harness.py
@@ -40,7 +40,7 @@ template_map = {
     'main.swift_template': os.path.join(output_dir, 'utils/main.swift')
 }
 
-### The test suites. Currently, "other" and "string"
+# The test suites. Currently, "other" and "string"
 other_tests = ["Ackermann", "Fibonacci"]
 string_tests = [
     "StringWalkASCIIScalars",

--- a/benchmark/scripts/generate_harness/main.swift_template
+++ b/benchmark/scripts/generate_harness/main.swift_template
@@ -24,17 +24,40 @@ import DriverUtils
 import {{ import }}
 {% endfor %}
 
-precommitTests = [
+@inline(__always)
+private func addPrecommitTest(
+  _ name: String, _ function: @escaping (Int) -> ()
+) {
+  precommitTests[name] = function
+}
+@inline(__always)
+private func addStringTest(
+  _ name: String, _ function: @escaping (Int) -> ()
+) {
+  stringTests[name] = function
+}
+@inline(__always)
+private func addOtherTest(
+  _ name: String, _ function: @escaping (Int) -> ()
+) {
+  otherTests[name] = function
+}
+
+// The main test suite: precommit tests
 {% for run_func in run_funcs %}
-  "{{ run_func[0] }}": run_{{ run_func[1] }},
+addPrecommitTest("{{ run_func[0] }}", run_{{ run_func[1] }})
 {% endfor %}
-]
 
-otherTests = [
-  "Ackermann": run_Ackermann,
-  "Fibonacci": run_Fibonacci,
-]
+// Other tests
+{% for test_name in other_tests %}
+addOtherTest("{{ test_name }}", run_{{ test_name }})
+{% endfor %}
 
+// String tests, an extended benchmark suite exercising finer-granularity
+// behavior of our Strings.
+{% for test_name in string_tests %}
+addStringTest("{{ test_name }}", run_{{ test_name }})
+{% endfor %}
 
 main()
 

--- a/benchmark/single-source/DropFirst.swift
+++ b/benchmark/single-source/DropFirst.swift
@@ -1,4 +1,4 @@
-//===--- DropFirst.swift --------------------------------------------------===//
+//===--- DropFirst.swift --------------------------------------*- swift -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/benchmark/single-source/DropLast.swift
+++ b/benchmark/single-source/DropLast.swift
@@ -1,4 +1,4 @@
-//===--- DropLast.swift ---------------------------------------------------===//
+//===--- DropLast.swift ---------------------------------------*- swift -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/benchmark/single-source/DropWhile.swift
+++ b/benchmark/single-source/DropWhile.swift
@@ -1,4 +1,4 @@
-//===--- DropWhile.swift --------------------------------------------------===//
+//===--- DropWhile.swift --------------------------------------*- swift -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/benchmark/single-source/Prefix.swift
+++ b/benchmark/single-source/Prefix.swift
@@ -1,4 +1,4 @@
-//===--- Prefix.swift -----------------------------------------------------===//
+//===--- Prefix.swift -----------------------------------------*- swift -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/benchmark/single-source/PrefixWhile.swift
+++ b/benchmark/single-source/PrefixWhile.swift
@@ -1,4 +1,4 @@
-//===--- PrefixWhile.swift ------------------------------------------------===//
+//===--- PrefixWhile.swift ------------------------------------*- swift -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/benchmark/single-source/StringWalk.swift
+++ b/benchmark/single-source/StringWalk.swift
@@ -22,17 +22,100 @@ import TestsUtils
 
 var count: Int = 0
 
-@inline(never) func countChars(_ s: String) {
-  for _ in s.unicodeScalars {
+@inline(never) func countScalars(_ s: String.UnicodeScalarView) {
+  for _ in s {
+    count += 1
+  }
+}
+@inline(never) func countCharacters(_ s: String.CharacterView) {
+  for _ in s {
+    count += 1
+  }
+}
+@inline(never) func countScalars_rev(
+	_ s: ReversedCollection<String.UnicodeScalarView>
+) {
+  for _ in s {
+    count += 1
+  }
+}
+@inline(never) func countCharacters_rev(
+	_ s: ReversedCollection<String.CharacterView>
+) {
+  for _ in s {
     count += 1
   }
 }
 
+let asciiString =
+  "siebenhundertsiebenundsiebzigtausendsiebenhundertsiebenundsiebzig"
+let winter = "🏂☃❅❆❄︎⛄️❄️"
+let utf16String =
+  winter + "the quick brown fox" + String(winter.characters.reversed())
+
+// Pre-commit benchmark: simple scalar walk
 @inline(never)
 public func run_StringWalk(_ N: Int) {
-  let s = "siebenhundertsiebenundsiebzigtausendsiebenhundertsiebenundsiebzig"
+	return run_StringWalkASCIIScalars(N)
+}
 
-  for _ in 1...50000*N {
-    countChars(s)
+// Extended String benchmarks:
+let baseMultiplier = 50_000
+let scalarsMultiplier = baseMultiplier
+let charactersMultiplier = baseMultiplier / 5
+
+@inline(never)
+public func run_StringWalkASCIIScalars(_ N: Int) {
+  for _ in 1...scalarsMultiplier*N {
+    countScalars(asciiString.unicodeScalars)
+  }
+}
+
+@inline(never)
+public func run_StringWalkASCIICharacters(_ N: Int) {
+  for _ in 1...charactersMultiplier*N {
+    countCharacters(asciiString.characters)
+  }
+}
+
+@inline(never)
+public func run_StringWalkUnicodeScalars(_ N: Int) {
+  for _ in 1...scalarsMultiplier*N {
+    countScalars(utf16String.unicodeScalars)
+  }
+}
+
+@inline(never)
+public func run_StringWalkUnicodeCharacters(_ N: Int) {
+  for _ in 1...charactersMultiplier*N {
+    countCharacters(utf16String.characters)
+  }
+}
+
+@inline(never)
+public func run_StringWalkASCIIScalarsBackwards(_ N: Int) {
+  for _ in 1...scalarsMultiplier*N {
+    countScalars_rev(asciiString.unicodeScalars.reversed())
+  }
+}
+
+@inline(never)
+public func run_StringWalkASCIICharactersBackwards(_ N: Int) {
+  for _ in 1...charactersMultiplier*N {
+    countCharacters_rev(asciiString.characters.reversed())
+  }
+}
+
+@inline(never)
+public func run_StringWalkUnicodeScalarsBackwards(_ N: Int) {
+  for _ in 1...scalarsMultiplier*N {
+    countScalars_rev(utf16String.unicodeScalars.reversed())
+  }
+}
+
+@inline(never)
+public func run_StringWalkUnicodeCharactersBackwards(_ N: Int) {
+  for _ in 1...charactersMultiplier*N {
+    countCharacters_rev(utf16String.characters.reversed())
   }
 }

--- a/benchmark/single-source/Suffix.swift
+++ b/benchmark/single-source/Suffix.swift
@@ -1,4 +1,4 @@
-//===--- Suffix.swift -----------------------------------------------------===//
+//===--- Suffix.swift -----------------------------------------*- swift -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/benchmark/utils/DriverUtils.swift
+++ b/benchmark/utils/DriverUtils.swift
@@ -64,6 +64,7 @@ struct Test {
 
 public var precommitTests: [String : (Int) -> ()] = [:]
 public var otherTests: [String : (Int) -> ()] = [:]
+public var stringTests: [String : (Int) -> ()] = [:]
 
 enum TestAction {
   case Run
@@ -173,6 +174,10 @@ struct TestConfig {
     }
     for benchName in otherTests.keys.sorted() {
       tests.append(Test(name: benchName, n: i, f: otherTests[benchName]!))
+      i += 1
+    }
+    for benchName in stringTests.keys.sorted() {
+      tests.append(Test(name: benchName, n: i, f: stringTests[benchName]!))
       i += 1
     }
     for i in 0..<tests.count {

--- a/benchmark/utils/main.swift
+++ b/benchmark/utils/main.swift
@@ -119,374 +119,380 @@ import UTF8Decode
 import Walsh
 import XorLoop
 
-precommitTests = [
-  "AngryPhonebook": run_AngryPhonebook,
-  "AnyHashableWithAClass": run_AnyHashableWithAClass,
-  "Array2D": run_Array2D,
-  "ArrayAppend": run_ArrayAppend,
-  "ArrayAppendArrayOfInt": run_ArrayAppendArrayOfInt,
-  "ArrayAppendAscii": run_ArrayAppendAscii,
-  "ArrayAppendFromGeneric": run_ArrayAppendFromGeneric,
-  "ArrayAppendGenericStructs": run_ArrayAppendGenericStructs,
-  "ArrayAppendLatin1": run_ArrayAppendLatin1,
-  "ArrayAppendLazyMap": run_ArrayAppendLazyMap,
-  "ArrayAppendOptionals": run_ArrayAppendOptionals,
-  "ArrayAppendRepeatCol": run_ArrayAppendRepeatCol,
-  "ArrayAppendReserved": run_ArrayAppendReserved,
-  "ArrayAppendSequence": run_ArrayAppendSequence,
-  "ArrayAppendStrings": run_ArrayAppendStrings,
-  "ArrayAppendToFromGeneric": run_ArrayAppendToFromGeneric,
-  "ArrayAppendToGeneric": run_ArrayAppendToGeneric,
-  "ArrayAppendUTF16": run_ArrayAppendUTF16,
-  "ArrayInClass": run_ArrayInClass,
-  "ArrayLiteral": run_ArrayLiteral,
-  "ArrayOfGenericPOD": run_ArrayOfGenericPOD,
-  "ArrayOfGenericRef": run_ArrayOfGenericRef,
-  "ArrayOfPOD": run_ArrayOfPOD,
-  "ArrayOfRef": run_ArrayOfRef,
-  "ArrayPlusEqualArrayOfInt": run_ArrayPlusEqualArrayOfInt,
-  "ArrayPlusEqualFiveElementCollection": run_ArrayPlusEqualFiveElementCollection,
-  "ArrayPlusEqualSingleElementCollection": run_ArrayPlusEqualSingleElementCollection,
-  "ArraySubscript": run_ArraySubscript,
-  "ArrayValueProp": run_ArrayValueProp,
-  "ArrayValueProp2": run_ArrayValueProp2,
-  "ArrayValueProp3": run_ArrayValueProp3,
-  "ArrayValueProp4": run_ArrayValueProp4,
-  "BitCount": run_BitCount,
-  "ByteSwap": run_ByteSwap,
-  "CStringLongAscii": run_CStringLongAscii,
-  "CStringLongNonAscii": run_CStringLongNonAscii,
-  "CStringShortAscii": run_CStringShortAscii,
-  "Calculator": run_Calculator,
-  "CaptureProp": run_CaptureProp,
-  "CharacterLiteralsLarge": run_CharacterLiteralsLarge,
-  "CharacterLiteralsSmall": run_CharacterLiteralsSmall,
-  "Chars": run_Chars,
-  "ClassArrayGetter": run_ClassArrayGetter,
-  "DeadArray": run_DeadArray,
-  "Dictionary": run_Dictionary,
-  "Dictionary2": run_Dictionary2,
-  "Dictionary2OfObjects": run_Dictionary2OfObjects,
-  "Dictionary3": run_Dictionary3,
-  "Dictionary3OfObjects": run_Dictionary3OfObjects,
-  "DictionaryBridge": run_DictionaryBridge,
-  "DictionaryLiteral": run_DictionaryLiteral,
-  "DictionaryOfObjects": run_DictionaryOfObjects,
-  "DictionaryRemove": run_DictionaryRemove,
-  "DictionaryRemoveOfObjects": run_DictionaryRemoveOfObjects,
-  "DictionarySwap": run_DictionarySwap,
-  "DictionarySwapOfObjects": run_DictionarySwapOfObjects,
-  "DropFirstAnyCollection": run_DropFirstAnyCollection,
-  "DropFirstAnyCollectionLazy": run_DropFirstAnyCollectionLazy,
-  "DropFirstAnySeqCRangeIter": run_DropFirstAnySeqCRangeIter,
-  "DropFirstAnySeqCRangeIterLazy": run_DropFirstAnySeqCRangeIterLazy,
-  "DropFirstAnySeqCntRange": run_DropFirstAnySeqCntRange,
-  "DropFirstAnySeqCntRangeLazy": run_DropFirstAnySeqCntRangeLazy,
-  "DropFirstAnySequence": run_DropFirstAnySequence,
-  "DropFirstAnySequenceLazy": run_DropFirstAnySequenceLazy,
-  "DropFirstArray": run_DropFirstArray,
-  "DropFirstArrayLazy": run_DropFirstArrayLazy,
-  "DropFirstCountableRange": run_DropFirstCountableRange,
-  "DropFirstCountableRangeLazy": run_DropFirstCountableRangeLazy,
-  "DropFirstSequence": run_DropFirstSequence,
-  "DropFirstSequenceLazy": run_DropFirstSequenceLazy,
-  "DropLastAnyCollection": run_DropLastAnyCollection,
-  "DropLastAnyCollectionLazy": run_DropLastAnyCollectionLazy,
-  "DropLastAnySeqCRangeIter": run_DropLastAnySeqCRangeIter,
-  "DropLastAnySeqCRangeIterLazy": run_DropLastAnySeqCRangeIterLazy,
-  "DropLastAnySeqCntRange": run_DropLastAnySeqCntRange,
-  "DropLastAnySeqCntRangeLazy": run_DropLastAnySeqCntRangeLazy,
-  "DropLastAnySequence": run_DropLastAnySequence,
-  "DropLastAnySequenceLazy": run_DropLastAnySequenceLazy,
-  "DropLastArray": run_DropLastArray,
-  "DropLastArrayLazy": run_DropLastArrayLazy,
-  "DropLastCountableRange": run_DropLastCountableRange,
-  "DropLastCountableRangeLazy": run_DropLastCountableRangeLazy,
-  "DropLastSequence": run_DropLastSequence,
-  "DropLastSequenceLazy": run_DropLastSequenceLazy,
-  "DropWhileAnyCollection": run_DropWhileAnyCollection,
-  "DropWhileAnyCollectionLazy": run_DropWhileAnyCollectionLazy,
-  "DropWhileAnySeqCRangeIter": run_DropWhileAnySeqCRangeIter,
-  "DropWhileAnySeqCRangeIterLazy": run_DropWhileAnySeqCRangeIterLazy,
-  "DropWhileAnySeqCntRange": run_DropWhileAnySeqCntRange,
-  "DropWhileAnySeqCntRangeLazy": run_DropWhileAnySeqCntRangeLazy,
-  "DropWhileAnySequence": run_DropWhileAnySequence,
-  "DropWhileAnySequenceLazy": run_DropWhileAnySequenceLazy,
-  "DropWhileArray": run_DropWhileArray,
-  "DropWhileArrayLazy": run_DropWhileArrayLazy,
-  "DropWhileCountableRange": run_DropWhileCountableRange,
-  "DropWhileCountableRangeLazy": run_DropWhileCountableRangeLazy,
-  "DropWhileSequence": run_DropWhileSequence,
-  "DropWhileSequenceLazy": run_DropWhileSequenceLazy,
-  "ErrorHandling": run_ErrorHandling,
-  "ExistentialTestArrayConditionalShift_ClassValueBuffer1": run_ExistentialTestArrayConditionalShift_ClassValueBuffer1,
-  "ExistentialTestArrayConditionalShift_ClassValueBuffer2": run_ExistentialTestArrayConditionalShift_ClassValueBuffer2,
-  "ExistentialTestArrayConditionalShift_ClassValueBuffer3": run_ExistentialTestArrayConditionalShift_ClassValueBuffer3,
-  "ExistentialTestArrayConditionalShift_ClassValueBuffer4": run_ExistentialTestArrayConditionalShift_ClassValueBuffer4,
-  "ExistentialTestArrayConditionalShift_IntValueBuffer0": run_ExistentialTestArrayConditionalShift_IntValueBuffer0,
-  "ExistentialTestArrayConditionalShift_IntValueBuffer1": run_ExistentialTestArrayConditionalShift_IntValueBuffer1,
-  "ExistentialTestArrayConditionalShift_IntValueBuffer2": run_ExistentialTestArrayConditionalShift_IntValueBuffer2,
-  "ExistentialTestArrayConditionalShift_IntValueBuffer3": run_ExistentialTestArrayConditionalShift_IntValueBuffer3,
-  "ExistentialTestArrayConditionalShift_IntValueBuffer4": run_ExistentialTestArrayConditionalShift_IntValueBuffer4,
-  "ExistentialTestArrayMutating_ClassValueBuffer1": run_ExistentialTestArrayMutating_ClassValueBuffer1,
-  "ExistentialTestArrayMutating_ClassValueBuffer2": run_ExistentialTestArrayMutating_ClassValueBuffer2,
-  "ExistentialTestArrayMutating_ClassValueBuffer3": run_ExistentialTestArrayMutating_ClassValueBuffer3,
-  "ExistentialTestArrayMutating_ClassValueBuffer4": run_ExistentialTestArrayMutating_ClassValueBuffer4,
-  "ExistentialTestArrayMutating_IntValueBuffer0": run_ExistentialTestArrayMutating_IntValueBuffer0,
-  "ExistentialTestArrayMutating_IntValueBuffer1": run_ExistentialTestArrayMutating_IntValueBuffer1,
-  "ExistentialTestArrayMutating_IntValueBuffer2": run_ExistentialTestArrayMutating_IntValueBuffer2,
-  "ExistentialTestArrayMutating_IntValueBuffer3": run_ExistentialTestArrayMutating_IntValueBuffer3,
-  "ExistentialTestArrayMutating_IntValueBuffer4": run_ExistentialTestArrayMutating_IntValueBuffer4,
-  "ExistentialTestArrayOneMethodCall_ClassValueBuffer1": run_ExistentialTestArrayOneMethodCall_ClassValueBuffer1,
-  "ExistentialTestArrayOneMethodCall_ClassValueBuffer2": run_ExistentialTestArrayOneMethodCall_ClassValueBuffer2,
-  "ExistentialTestArrayOneMethodCall_ClassValueBuffer3": run_ExistentialTestArrayOneMethodCall_ClassValueBuffer3,
-  "ExistentialTestArrayOneMethodCall_ClassValueBuffer4": run_ExistentialTestArrayOneMethodCall_ClassValueBuffer4,
-  "ExistentialTestArrayOneMethodCall_IntValueBuffer0": run_ExistentialTestArrayOneMethodCall_IntValueBuffer0,
-  "ExistentialTestArrayOneMethodCall_IntValueBuffer1": run_ExistentialTestArrayOneMethodCall_IntValueBuffer1,
-  "ExistentialTestArrayOneMethodCall_IntValueBuffer2": run_ExistentialTestArrayOneMethodCall_IntValueBuffer2,
-  "ExistentialTestArrayOneMethodCall_IntValueBuffer3": run_ExistentialTestArrayOneMethodCall_IntValueBuffer3,
-  "ExistentialTestArrayOneMethodCall_IntValueBuffer4": run_ExistentialTestArrayOneMethodCall_IntValueBuffer4,
-  "ExistentialTestArrayShift_ClassValueBuffer1": run_ExistentialTestArrayShift_ClassValueBuffer1,
-  "ExistentialTestArrayShift_ClassValueBuffer2": run_ExistentialTestArrayShift_ClassValueBuffer2,
-  "ExistentialTestArrayShift_ClassValueBuffer3": run_ExistentialTestArrayShift_ClassValueBuffer3,
-  "ExistentialTestArrayShift_ClassValueBuffer4": run_ExistentialTestArrayShift_ClassValueBuffer4,
-  "ExistentialTestArrayShift_IntValueBuffer0": run_ExistentialTestArrayShift_IntValueBuffer0,
-  "ExistentialTestArrayShift_IntValueBuffer1": run_ExistentialTestArrayShift_IntValueBuffer1,
-  "ExistentialTestArrayShift_IntValueBuffer2": run_ExistentialTestArrayShift_IntValueBuffer2,
-  "ExistentialTestArrayShift_IntValueBuffer3": run_ExistentialTestArrayShift_IntValueBuffer3,
-  "ExistentialTestArrayShift_IntValueBuffer4": run_ExistentialTestArrayShift_IntValueBuffer4,
-  "ExistentialTestArrayTwoMethodCalls_ClassValueBuffer1": run_ExistentialTestArrayTwoMethodCalls_ClassValueBuffer1,
-  "ExistentialTestArrayTwoMethodCalls_ClassValueBuffer2": run_ExistentialTestArrayTwoMethodCalls_ClassValueBuffer2,
-  "ExistentialTestArrayTwoMethodCalls_ClassValueBuffer3": run_ExistentialTestArrayTwoMethodCalls_ClassValueBuffer3,
-  "ExistentialTestArrayTwoMethodCalls_ClassValueBuffer4": run_ExistentialTestArrayTwoMethodCalls_ClassValueBuffer4,
-  "ExistentialTestArrayTwoMethodCalls_IntValueBuffer0": run_ExistentialTestArrayTwoMethodCalls_IntValueBuffer0,
-  "ExistentialTestArrayTwoMethodCalls_IntValueBuffer1": run_ExistentialTestArrayTwoMethodCalls_IntValueBuffer1,
-  "ExistentialTestArrayTwoMethodCalls_IntValueBuffer2": run_ExistentialTestArrayTwoMethodCalls_IntValueBuffer2,
-  "ExistentialTestArrayTwoMethodCalls_IntValueBuffer3": run_ExistentialTestArrayTwoMethodCalls_IntValueBuffer3,
-  "ExistentialTestArrayTwoMethodCalls_IntValueBuffer4": run_ExistentialTestArrayTwoMethodCalls_IntValueBuffer4,
-  "ExistentialTestMutatingAndNonMutating_ClassValueBuffer1": run_ExistentialTestMutatingAndNonMutating_ClassValueBuffer1,
-  "ExistentialTestMutatingAndNonMutating_ClassValueBuffer2": run_ExistentialTestMutatingAndNonMutating_ClassValueBuffer2,
-  "ExistentialTestMutatingAndNonMutating_ClassValueBuffer3": run_ExistentialTestMutatingAndNonMutating_ClassValueBuffer3,
-  "ExistentialTestMutatingAndNonMutating_ClassValueBuffer4": run_ExistentialTestMutatingAndNonMutating_ClassValueBuffer4,
-  "ExistentialTestMutatingAndNonMutating_IntValueBuffer0": run_ExistentialTestMutatingAndNonMutating_IntValueBuffer0,
-  "ExistentialTestMutatingAndNonMutating_IntValueBuffer1": run_ExistentialTestMutatingAndNonMutating_IntValueBuffer1,
-  "ExistentialTestMutatingAndNonMutating_IntValueBuffer2": run_ExistentialTestMutatingAndNonMutating_IntValueBuffer2,
-  "ExistentialTestMutatingAndNonMutating_IntValueBuffer3": run_ExistentialTestMutatingAndNonMutating_IntValueBuffer3,
-  "ExistentialTestMutatingAndNonMutating_IntValueBuffer4": run_ExistentialTestMutatingAndNonMutating_IntValueBuffer4,
-  "ExistentialTestMutating_ClassValueBuffer1": run_ExistentialTestMutating_ClassValueBuffer1,
-  "ExistentialTestMutating_ClassValueBuffer2": run_ExistentialTestMutating_ClassValueBuffer2,
-  "ExistentialTestMutating_ClassValueBuffer3": run_ExistentialTestMutating_ClassValueBuffer3,
-  "ExistentialTestMutating_ClassValueBuffer4": run_ExistentialTestMutating_ClassValueBuffer4,
-  "ExistentialTestMutating_IntValueBuffer0": run_ExistentialTestMutating_IntValueBuffer0,
-  "ExistentialTestMutating_IntValueBuffer1": run_ExistentialTestMutating_IntValueBuffer1,
-  "ExistentialTestMutating_IntValueBuffer2": run_ExistentialTestMutating_IntValueBuffer2,
-  "ExistentialTestMutating_IntValueBuffer3": run_ExistentialTestMutating_IntValueBuffer3,
-  "ExistentialTestMutating_IntValueBuffer4": run_ExistentialTestMutating_IntValueBuffer4,
-  "ExistentialTestOneMethodCall_ClassValueBuffer1": run_ExistentialTestOneMethodCall_ClassValueBuffer1,
-  "ExistentialTestOneMethodCall_ClassValueBuffer2": run_ExistentialTestOneMethodCall_ClassValueBuffer2,
-  "ExistentialTestOneMethodCall_ClassValueBuffer3": run_ExistentialTestOneMethodCall_ClassValueBuffer3,
-  "ExistentialTestOneMethodCall_ClassValueBuffer4": run_ExistentialTestOneMethodCall_ClassValueBuffer4,
-  "ExistentialTestOneMethodCall_IntValueBuffer0": run_ExistentialTestOneMethodCall_IntValueBuffer0,
-  "ExistentialTestOneMethodCall_IntValueBuffer1": run_ExistentialTestOneMethodCall_IntValueBuffer1,
-  "ExistentialTestOneMethodCall_IntValueBuffer2": run_ExistentialTestOneMethodCall_IntValueBuffer2,
-  "ExistentialTestOneMethodCall_IntValueBuffer3": run_ExistentialTestOneMethodCall_IntValueBuffer3,
-  "ExistentialTestOneMethodCall_IntValueBuffer4": run_ExistentialTestOneMethodCall_IntValueBuffer4,
-  "ExistentialTestPassExistentialOneMethodCall_ClassValueBuffer1": run_ExistentialTestPassExistentialOneMethodCall_ClassValueBuffer1,
-  "ExistentialTestPassExistentialOneMethodCall_ClassValueBuffer2": run_ExistentialTestPassExistentialOneMethodCall_ClassValueBuffer2,
-  "ExistentialTestPassExistentialOneMethodCall_ClassValueBuffer3": run_ExistentialTestPassExistentialOneMethodCall_ClassValueBuffer3,
-  "ExistentialTestPassExistentialOneMethodCall_ClassValueBuffer4": run_ExistentialTestPassExistentialOneMethodCall_ClassValueBuffer4,
-  "ExistentialTestPassExistentialOneMethodCall_IntValueBuffer0": run_ExistentialTestPassExistentialOneMethodCall_IntValueBuffer0,
-  "ExistentialTestPassExistentialOneMethodCall_IntValueBuffer1": run_ExistentialTestPassExistentialOneMethodCall_IntValueBuffer1,
-  "ExistentialTestPassExistentialOneMethodCall_IntValueBuffer2": run_ExistentialTestPassExistentialOneMethodCall_IntValueBuffer2,
-  "ExistentialTestPassExistentialOneMethodCall_IntValueBuffer3": run_ExistentialTestPassExistentialOneMethodCall_IntValueBuffer3,
-  "ExistentialTestPassExistentialOneMethodCall_IntValueBuffer4": run_ExistentialTestPassExistentialOneMethodCall_IntValueBuffer4,
-  "ExistentialTestPassExistentialTwoMethodCalls_ClassValueBuffer1": run_ExistentialTestPassExistentialTwoMethodCalls_ClassValueBuffer1,
-  "ExistentialTestPassExistentialTwoMethodCalls_ClassValueBuffer2": run_ExistentialTestPassExistentialTwoMethodCalls_ClassValueBuffer2,
-  "ExistentialTestPassExistentialTwoMethodCalls_ClassValueBuffer3": run_ExistentialTestPassExistentialTwoMethodCalls_ClassValueBuffer3,
-  "ExistentialTestPassExistentialTwoMethodCalls_ClassValueBuffer4": run_ExistentialTestPassExistentialTwoMethodCalls_ClassValueBuffer4,
-  "ExistentialTestPassExistentialTwoMethodCalls_IntValueBuffer0": run_ExistentialTestPassExistentialTwoMethodCalls_IntValueBuffer0,
-  "ExistentialTestPassExistentialTwoMethodCalls_IntValueBuffer1": run_ExistentialTestPassExistentialTwoMethodCalls_IntValueBuffer1,
-  "ExistentialTestPassExistentialTwoMethodCalls_IntValueBuffer2": run_ExistentialTestPassExistentialTwoMethodCalls_IntValueBuffer2,
-  "ExistentialTestPassExistentialTwoMethodCalls_IntValueBuffer3": run_ExistentialTestPassExistentialTwoMethodCalls_IntValueBuffer3,
-  "ExistentialTestPassExistentialTwoMethodCalls_IntValueBuffer4": run_ExistentialTestPassExistentialTwoMethodCalls_IntValueBuffer4,
-  "ExistentialTestTwoMethodCalls_ClassValueBuffer1": run_ExistentialTestTwoMethodCalls_ClassValueBuffer1,
-  "ExistentialTestTwoMethodCalls_ClassValueBuffer2": run_ExistentialTestTwoMethodCalls_ClassValueBuffer2,
-  "ExistentialTestTwoMethodCalls_ClassValueBuffer3": run_ExistentialTestTwoMethodCalls_ClassValueBuffer3,
-  "ExistentialTestTwoMethodCalls_ClassValueBuffer4": run_ExistentialTestTwoMethodCalls_ClassValueBuffer4,
-  "ExistentialTestTwoMethodCalls_IntValueBuffer0": run_ExistentialTestTwoMethodCalls_IntValueBuffer0,
-  "ExistentialTestTwoMethodCalls_IntValueBuffer1": run_ExistentialTestTwoMethodCalls_IntValueBuffer1,
-  "ExistentialTestTwoMethodCalls_IntValueBuffer2": run_ExistentialTestTwoMethodCalls_IntValueBuffer2,
-  "ExistentialTestTwoMethodCalls_IntValueBuffer3": run_ExistentialTestTwoMethodCalls_IntValueBuffer3,
-  "ExistentialTestTwoMethodCalls_IntValueBuffer4": run_ExistentialTestTwoMethodCalls_IntValueBuffer4,
-  "GlobalClass": run_GlobalClass,
-  "Hanoi": run_Hanoi,
-  "HashQuadratic": run_HashQuadratic,
-  "HashTest": run_HashTest,
-  "Histogram": run_Histogram,
-  "Integrate": run_Integrate,
-  "IterateData": run_IterateData,
-  "Join": run_Join,
-  "LazilyFilteredArrays": run_LazilyFilteredArrays,
-  "LazilyFilteredRange": run_LazilyFilteredRange,
-  "LinkedList": run_LinkedList,
-  "MapReduce": run_MapReduce,
-  "MapReduceAnyCollection": run_MapReduceAnyCollection,
-  "MapReduceAnyCollectionShort": run_MapReduceAnyCollectionShort,
-  "MapReduceClass": run_MapReduceClass,
-  "MapReduceClassShort": run_MapReduceClassShort,
-  "MapReduceLazyCollection": run_MapReduceLazyCollection,
-  "MapReduceLazyCollectionShort": run_MapReduceLazyCollectionShort,
-  "MapReduceLazySequence": run_MapReduceLazySequence,
-  "MapReduceSequence": run_MapReduceSequence,
-  "MapReduceShort": run_MapReduceShort,
-  "MapReduceShortString": run_MapReduceShortString,
-  "MapReduceString": run_MapReduceString,
-  "Memset": run_Memset,
-  "MonteCarloE": run_MonteCarloE,
-  "MonteCarloPi": run_MonteCarloPi,
-  "NSDictionaryCastToSwift": run_NSDictionaryCastToSwift,
-  "NSError": run_NSError,
-  "NSStringConversion": run_NSStringConversion,
-  "NopDeinit": run_NopDeinit,
-  "ObjectAllocation": run_ObjectAllocation,
-  "ObjectiveCBridgeFromNSArrayAnyObject": run_ObjectiveCBridgeFromNSArrayAnyObject,
-  "ObjectiveCBridgeFromNSArrayAnyObjectForced": run_ObjectiveCBridgeFromNSArrayAnyObjectForced,
-  "ObjectiveCBridgeFromNSArrayAnyObjectToString": run_ObjectiveCBridgeFromNSArrayAnyObjectToString,
-  "ObjectiveCBridgeFromNSArrayAnyObjectToStringForced": run_ObjectiveCBridgeFromNSArrayAnyObjectToStringForced,
-  "ObjectiveCBridgeFromNSDictionaryAnyObject": run_ObjectiveCBridgeFromNSDictionaryAnyObject,
-  "ObjectiveCBridgeFromNSDictionaryAnyObjectForced": run_ObjectiveCBridgeFromNSDictionaryAnyObjectForced,
-  "ObjectiveCBridgeFromNSDictionaryAnyObjectToString": run_ObjectiveCBridgeFromNSDictionaryAnyObjectToString,
-  "ObjectiveCBridgeFromNSDictionaryAnyObjectToStringForced": run_ObjectiveCBridgeFromNSDictionaryAnyObjectToStringForced,
-  "ObjectiveCBridgeFromNSSetAnyObject": run_ObjectiveCBridgeFromNSSetAnyObject,
-  "ObjectiveCBridgeFromNSSetAnyObjectForced": run_ObjectiveCBridgeFromNSSetAnyObjectForced,
-  "ObjectiveCBridgeFromNSSetAnyObjectToString": run_ObjectiveCBridgeFromNSSetAnyObjectToString,
-  "ObjectiveCBridgeFromNSSetAnyObjectToStringForced": run_ObjectiveCBridgeFromNSSetAnyObjectToStringForced,
-  "ObjectiveCBridgeFromNSString": run_ObjectiveCBridgeFromNSString,
-  "ObjectiveCBridgeFromNSStringForced": run_ObjectiveCBridgeFromNSStringForced,
-  "ObjectiveCBridgeStubDataAppend": run_ObjectiveCBridgeStubDataAppend,
-  "ObjectiveCBridgeStubDateAccess": run_ObjectiveCBridgeStubDateAccess,
-  "ObjectiveCBridgeStubDateMutation": run_ObjectiveCBridgeStubDateMutation,
-  "ObjectiveCBridgeStubFromArrayOfNSString": run_ObjectiveCBridgeStubFromArrayOfNSString,
-  "ObjectiveCBridgeStubFromNSDate": run_ObjectiveCBridgeStubFromNSDate,
-  "ObjectiveCBridgeStubFromNSDateRef": run_ObjectiveCBridgeStubFromNSDateRef,
-  "ObjectiveCBridgeStubFromNSString": run_ObjectiveCBridgeStubFromNSString,
-  "ObjectiveCBridgeStubFromNSStringRef": run_ObjectiveCBridgeStubFromNSStringRef,
-  "ObjectiveCBridgeStubNSDataAppend": run_ObjectiveCBridgeStubNSDataAppend,
-  "ObjectiveCBridgeStubNSDateMutationRef": run_ObjectiveCBridgeStubNSDateMutationRef,
-  "ObjectiveCBridgeStubNSDateRefAccess": run_ObjectiveCBridgeStubNSDateRefAccess,
-  "ObjectiveCBridgeStubToArrayOfNSString": run_ObjectiveCBridgeStubToArrayOfNSString,
-  "ObjectiveCBridgeStubToNSDate": run_ObjectiveCBridgeStubToNSDate,
-  "ObjectiveCBridgeStubToNSDateRef": run_ObjectiveCBridgeStubToNSDateRef,
-  "ObjectiveCBridgeStubToNSString": run_ObjectiveCBridgeStubToNSString,
-  "ObjectiveCBridgeStubToNSStringRef": run_ObjectiveCBridgeStubToNSStringRef,
-  "ObjectiveCBridgeStubURLAppendPath": run_ObjectiveCBridgeStubURLAppendPath,
-  "ObjectiveCBridgeStubURLAppendPathRef": run_ObjectiveCBridgeStubURLAppendPathRef,
-  "ObjectiveCBridgeToNSArray": run_ObjectiveCBridgeToNSArray,
-  "ObjectiveCBridgeToNSDictionary": run_ObjectiveCBridgeToNSDictionary,
-  "ObjectiveCBridgeToNSSet": run_ObjectiveCBridgeToNSSet,
-  "ObjectiveCBridgeToNSString": run_ObjectiveCBridgeToNSString,
-  "ObserverClosure": run_ObserverClosure,
-  "ObserverForwarderStruct": run_ObserverForwarderStruct,
-  "ObserverPartiallyAppliedMethod": run_ObserverPartiallyAppliedMethod,
-  "ObserverUnappliedMethod": run_ObserverUnappliedMethod,
-  "OpenClose": run_OpenClose,
-  "Phonebook": run_Phonebook,
-  "PolymorphicCalls": run_PolymorphicCalls,
-  "PopFrontArray": run_PopFrontArray,
-  "PopFrontArrayGeneric": run_PopFrontArrayGeneric,
-  "PopFrontUnsafePointer": run_PopFrontUnsafePointer,
-  "PrefixAnyCollection": run_PrefixAnyCollection,
-  "PrefixAnyCollectionLazy": run_PrefixAnyCollectionLazy,
-  "PrefixAnySeqCRangeIter": run_PrefixAnySeqCRangeIter,
-  "PrefixAnySeqCRangeIterLazy": run_PrefixAnySeqCRangeIterLazy,
-  "PrefixAnySeqCntRange": run_PrefixAnySeqCntRange,
-  "PrefixAnySeqCntRangeLazy": run_PrefixAnySeqCntRangeLazy,
-  "PrefixAnySequence": run_PrefixAnySequence,
-  "PrefixAnySequenceLazy": run_PrefixAnySequenceLazy,
-  "PrefixArray": run_PrefixArray,
-  "PrefixArrayLazy": run_PrefixArrayLazy,
-  "PrefixCountableRange": run_PrefixCountableRange,
-  "PrefixCountableRangeLazy": run_PrefixCountableRangeLazy,
-  "PrefixSequence": run_PrefixSequence,
-  "PrefixSequenceLazy": run_PrefixSequenceLazy,
-  "PrefixWhileAnyCollection": run_PrefixWhileAnyCollection,
-  "PrefixWhileAnyCollectionLazy": run_PrefixWhileAnyCollectionLazy,
-  "PrefixWhileAnySeqCRangeIter": run_PrefixWhileAnySeqCRangeIter,
-  "PrefixWhileAnySeqCRangeIterLazy": run_PrefixWhileAnySeqCRangeIterLazy,
-  "PrefixWhileAnySeqCntRange": run_PrefixWhileAnySeqCntRange,
-  "PrefixWhileAnySeqCntRangeLazy": run_PrefixWhileAnySeqCntRangeLazy,
-  "PrefixWhileAnySequence": run_PrefixWhileAnySequence,
-  "PrefixWhileAnySequenceLazy": run_PrefixWhileAnySequenceLazy,
-  "PrefixWhileArray": run_PrefixWhileArray,
-  "PrefixWhileArrayLazy": run_PrefixWhileArrayLazy,
-  "PrefixWhileCountableRange": run_PrefixWhileCountableRange,
-  "PrefixWhileCountableRangeLazy": run_PrefixWhileCountableRangeLazy,
-  "PrefixWhileSequence": run_PrefixWhileSequence,
-  "PrefixWhileSequenceLazy": run_PrefixWhileSequenceLazy,
-  "Prims": run_Prims,
-  "ProtocolDispatch": run_ProtocolDispatch,
-  "ProtocolDispatch2": run_ProtocolDispatch2,
-  "RC4": run_RC4,
-  "RGBHistogram": run_RGBHistogram,
-  "RGBHistogramOfObjects": run_RGBHistogramOfObjects,
-  "RangeAssignment": run_RangeAssignment,
-  "RecursiveOwnedParameter": run_RecursiveOwnedParameter,
-  "ReversedArray": run_ReversedArray,
-  "ReversedBidirectional": run_ReversedBidirectional,
-  "ReversedDictionary": run_ReversedDictionary,
-  "SetExclusiveOr": run_SetExclusiveOr,
-  "SetExclusiveOr_OfObjects": run_SetExclusiveOr_OfObjects,
-  "SetIntersect": run_SetIntersect,
-  "SetIntersect_OfObjects": run_SetIntersect_OfObjects,
-  "SetIsSubsetOf": run_SetIsSubsetOf,
-  "SetIsSubsetOf_OfObjects": run_SetIsSubsetOf_OfObjects,
-  "SetUnion": run_SetUnion,
-  "SetUnion_OfObjects": run_SetUnion_OfObjects,
-  "SevenBoom": run_SevenBoom,
-  "Sim2DArray": run_Sim2DArray,
-  "SortLettersInPlace": run_SortLettersInPlace,
-  "SortSortedStrings": run_SortSortedStrings,
-  "SortStrings": run_SortStrings,
-  "SortStringsUnicode": run_SortStringsUnicode,
-  "StackPromo": run_StackPromo,
-  "StaticArray": run_StaticArray,
-  "StrComplexWalk": run_StrComplexWalk,
-  "StrToInt": run_StrToInt,
-  "StringAdder": run_StringAdder,
-  "StringBuilder": run_StringBuilder,
-  "StringBuilderLong": run_StringBuilderLong,
-  "StringEdits": run_StringEdits,
-  "StringEqualPointerComparison": run_StringEqualPointerComparison,
-  "StringHasPrefix": run_StringHasPrefix,
-  "StringHasPrefixUnicode": run_StringHasPrefixUnicode,
-  "StringHasSuffix": run_StringHasSuffix,
-  "StringHasSuffixUnicode": run_StringHasSuffixUnicode,
-  "StringInterpolation": run_StringInterpolation,
-  "StringMatch": run_StringMatch,
-  "StringUTF16Builder": run_StringUTF16Builder,
-  "StringWalk": run_StringWalk,
-  "StringWithCString": run_StringWithCString,
-  "SuffixAnyCollection": run_SuffixAnyCollection,
-  "SuffixAnyCollectionLazy": run_SuffixAnyCollectionLazy,
-  "SuffixAnySeqCRangeIter": run_SuffixAnySeqCRangeIter,
-  "SuffixAnySeqCRangeIterLazy": run_SuffixAnySeqCRangeIterLazy,
-  "SuffixAnySeqCntRange": run_SuffixAnySeqCntRange,
-  "SuffixAnySeqCntRangeLazy": run_SuffixAnySeqCntRangeLazy,
-  "SuffixAnySequence": run_SuffixAnySequence,
-  "SuffixAnySequenceLazy": run_SuffixAnySequenceLazy,
-  "SuffixArray": run_SuffixArray,
-  "SuffixArrayLazy": run_SuffixArrayLazy,
-  "SuffixCountableRange": run_SuffixCountableRange,
-  "SuffixCountableRangeLazy": run_SuffixCountableRangeLazy,
-  "SuffixSequence": run_SuffixSequence,
-  "SuffixSequenceLazy": run_SuffixSequenceLazy,
-  "SuperChars": run_SuperChars,
-  "TwoSum": run_TwoSum,
-  "TypeFlood": run_TypeFlood,
-  "UTF8Decode": run_UTF8Decode,
-  "Walsh": run_Walsh,
-  "XorLoop": run_XorLoop,
-]
+@inline(__always)
+private func addPrecommitTest(
+  _ name: String, _ function: @escaping (Int) -> ()
+) {
+  precommitTests[name] = function
+}
+
+addPrecommitTest("AngryPhonebook", run_AngryPhonebook)
+addPrecommitTest("AnyHashableWithAClass", run_AnyHashableWithAClass)
+addPrecommitTest("Array2D", run_Array2D)
+addPrecommitTest("ArrayAppend", run_ArrayAppend)
+addPrecommitTest("ArrayAppendArrayOfInt", run_ArrayAppendArrayOfInt)
+addPrecommitTest("ArrayAppendAscii", run_ArrayAppendAscii)
+addPrecommitTest("ArrayAppendFromGeneric", run_ArrayAppendFromGeneric)
+addPrecommitTest("ArrayAppendGenericStructs", run_ArrayAppendGenericStructs)
+addPrecommitTest("ArrayAppendLatin1", run_ArrayAppendLatin1)
+addPrecommitTest("ArrayAppendLazyMap", run_ArrayAppendLazyMap)
+addPrecommitTest("ArrayAppendOptionals", run_ArrayAppendOptionals)
+addPrecommitTest("ArrayAppendRepeatCol", run_ArrayAppendRepeatCol)
+addPrecommitTest("ArrayAppendReserved", run_ArrayAppendReserved)
+addPrecommitTest("ArrayAppendSequence", run_ArrayAppendSequence)
+addPrecommitTest("ArrayAppendStrings", run_ArrayAppendStrings)
+addPrecommitTest("ArrayAppendToFromGeneric", run_ArrayAppendToFromGeneric)
+addPrecommitTest("ArrayAppendToGeneric", run_ArrayAppendToGeneric)
+addPrecommitTest("ArrayAppendUTF16", run_ArrayAppendUTF16)
+addPrecommitTest("ArrayInClass", run_ArrayInClass)
+addPrecommitTest("ArrayLiteral", run_ArrayLiteral)
+addPrecommitTest("ArrayOfGenericPOD", run_ArrayOfGenericPOD)
+addPrecommitTest("ArrayOfGenericRef", run_ArrayOfGenericRef)
+addPrecommitTest("ArrayOfPOD", run_ArrayOfPOD)
+addPrecommitTest("ArrayOfRef", run_ArrayOfRef)
+addPrecommitTest("ArrayPlusEqualArrayOfInt", run_ArrayPlusEqualArrayOfInt)
+addPrecommitTest("ArrayPlusEqualFiveElementCollection", run_ArrayPlusEqualFiveElementCollection)
+addPrecommitTest("ArrayPlusEqualSingleElementCollection", run_ArrayPlusEqualSingleElementCollection)
+addPrecommitTest("ArraySubscript", run_ArraySubscript)
+addPrecommitTest("ArrayValueProp", run_ArrayValueProp)
+addPrecommitTest("ArrayValueProp2", run_ArrayValueProp2)
+addPrecommitTest("ArrayValueProp3", run_ArrayValueProp3)
+addPrecommitTest("ArrayValueProp4", run_ArrayValueProp4)
+addPrecommitTest("BitCount", run_BitCount)
+addPrecommitTest("ByteSwap", run_ByteSwap)
+addPrecommitTest("CStringLongAscii", run_CStringLongAscii)
+addPrecommitTest("CStringLongNonAscii", run_CStringLongNonAscii)
+addPrecommitTest("CStringShortAscii", run_CStringShortAscii)
+addPrecommitTest("Calculator", run_Calculator)
+addPrecommitTest("CaptureProp", run_CaptureProp)
+addPrecommitTest("CharacterLiteralsLarge", run_CharacterLiteralsLarge)
+addPrecommitTest("CharacterLiteralsSmall", run_CharacterLiteralsSmall)
+addPrecommitTest("Chars", run_Chars)
+addPrecommitTest("ClassArrayGetter", run_ClassArrayGetter)
+addPrecommitTest("DeadArray", run_DeadArray)
+addPrecommitTest("Dictionary", run_Dictionary)
+addPrecommitTest("Dictionary2", run_Dictionary2)
+addPrecommitTest("Dictionary2OfObjects", run_Dictionary2OfObjects)
+addPrecommitTest("Dictionary3", run_Dictionary3)
+addPrecommitTest("Dictionary3OfObjects", run_Dictionary3OfObjects)
+addPrecommitTest("DictionaryBridge", run_DictionaryBridge)
+addPrecommitTest("DictionaryLiteral", run_DictionaryLiteral)
+addPrecommitTest("DictionaryOfObjects", run_DictionaryOfObjects)
+addPrecommitTest("DictionaryRemove", run_DictionaryRemove)
+addPrecommitTest("DictionaryRemoveOfObjects", run_DictionaryRemoveOfObjects)
+addPrecommitTest("DictionarySwap", run_DictionarySwap)
+addPrecommitTest("DictionarySwapOfObjects", run_DictionarySwapOfObjects)
+addPrecommitTest("DropFirstAnyCollection", run_DropFirstAnyCollection)
+addPrecommitTest("DropFirstAnyCollectionLazy", run_DropFirstAnyCollectionLazy)
+addPrecommitTest("DropFirstAnySeqCRangeIter", run_DropFirstAnySeqCRangeIter)
+addPrecommitTest("DropFirstAnySeqCRangeIterLazy", run_DropFirstAnySeqCRangeIterLazy)
+addPrecommitTest("DropFirstAnySeqCntRange", run_DropFirstAnySeqCntRange)
+addPrecommitTest("DropFirstAnySeqCntRangeLazy", run_DropFirstAnySeqCntRangeLazy)
+addPrecommitTest("DropFirstAnySequence", run_DropFirstAnySequence)
+addPrecommitTest("DropFirstAnySequenceLazy", run_DropFirstAnySequenceLazy)
+addPrecommitTest("DropFirstArray", run_DropFirstArray)
+addPrecommitTest("DropFirstArrayLazy", run_DropFirstArrayLazy)
+addPrecommitTest("DropFirstCountableRange", run_DropFirstCountableRange)
+addPrecommitTest("DropFirstCountableRangeLazy", run_DropFirstCountableRangeLazy)
+addPrecommitTest("DropFirstSequence", run_DropFirstSequence)
+addPrecommitTest("DropFirstSequenceLazy", run_DropFirstSequenceLazy)
+addPrecommitTest("DropLastAnyCollection", run_DropLastAnyCollection)
+addPrecommitTest("DropLastAnyCollectionLazy", run_DropLastAnyCollectionLazy)
+addPrecommitTest("DropLastAnySeqCRangeIter", run_DropLastAnySeqCRangeIter)
+addPrecommitTest("DropLastAnySeqCRangeIterLazy", run_DropLastAnySeqCRangeIterLazy)
+addPrecommitTest("DropLastAnySeqCntRange", run_DropLastAnySeqCntRange)
+addPrecommitTest("DropLastAnySeqCntRangeLazy", run_DropLastAnySeqCntRangeLazy)
+addPrecommitTest("DropLastAnySequence", run_DropLastAnySequence)
+addPrecommitTest("DropLastAnySequenceLazy", run_DropLastAnySequenceLazy)
+addPrecommitTest("DropLastArray", run_DropLastArray)
+addPrecommitTest("DropLastArrayLazy", run_DropLastArrayLazy)
+addPrecommitTest("DropLastCountableRange", run_DropLastCountableRange)
+addPrecommitTest("DropLastCountableRangeLazy", run_DropLastCountableRangeLazy)
+addPrecommitTest("DropLastSequence", run_DropLastSequence)
+addPrecommitTest("DropLastSequenceLazy", run_DropLastSequenceLazy)
+addPrecommitTest("DropWhileAnyCollection", run_DropWhileAnyCollection)
+addPrecommitTest("DropWhileAnyCollectionLazy", run_DropWhileAnyCollectionLazy)
+addPrecommitTest("DropWhileAnySeqCRangeIter", run_DropWhileAnySeqCRangeIter)
+addPrecommitTest("DropWhileAnySeqCRangeIterLazy", run_DropWhileAnySeqCRangeIterLazy)
+addPrecommitTest("DropWhileAnySeqCntRange", run_DropWhileAnySeqCntRange)
+addPrecommitTest("DropWhileAnySeqCntRangeLazy", run_DropWhileAnySeqCntRangeLazy)
+addPrecommitTest("DropWhileAnySequence", run_DropWhileAnySequence)
+addPrecommitTest("DropWhileAnySequenceLazy", run_DropWhileAnySequenceLazy)
+addPrecommitTest("DropWhileArray", run_DropWhileArray)
+addPrecommitTest("DropWhileArrayLazy", run_DropWhileArrayLazy)
+addPrecommitTest("DropWhileCountableRange", run_DropWhileCountableRange)
+addPrecommitTest("DropWhileCountableRangeLazy", run_DropWhileCountableRangeLazy)
+addPrecommitTest("DropWhileSequence", run_DropWhileSequence)
+addPrecommitTest("DropWhileSequenceLazy", run_DropWhileSequenceLazy)
+addPrecommitTest("ErrorHandling", run_ErrorHandling)
+addPrecommitTest("ExistentialTestArrayConditionalShift_ClassValueBuffer1", run_ExistentialTestArrayConditionalShift_ClassValueBuffer1)
+addPrecommitTest("ExistentialTestArrayConditionalShift_ClassValueBuffer2", run_ExistentialTestArrayConditionalShift_ClassValueBuffer2)
+addPrecommitTest("ExistentialTestArrayConditionalShift_ClassValueBuffer3", run_ExistentialTestArrayConditionalShift_ClassValueBuffer3)
+addPrecommitTest("ExistentialTestArrayConditionalShift_ClassValueBuffer4", run_ExistentialTestArrayConditionalShift_ClassValueBuffer4)
+addPrecommitTest("ExistentialTestArrayConditionalShift_IntValueBuffer0", run_ExistentialTestArrayConditionalShift_IntValueBuffer0)
+addPrecommitTest("ExistentialTestArrayConditionalShift_IntValueBuffer1", run_ExistentialTestArrayConditionalShift_IntValueBuffer1)
+addPrecommitTest("ExistentialTestArrayConditionalShift_IntValueBuffer2", run_ExistentialTestArrayConditionalShift_IntValueBuffer2)
+addPrecommitTest("ExistentialTestArrayConditionalShift_IntValueBuffer3", run_ExistentialTestArrayConditionalShift_IntValueBuffer3)
+addPrecommitTest("ExistentialTestArrayConditionalShift_IntValueBuffer4", run_ExistentialTestArrayConditionalShift_IntValueBuffer4)
+addPrecommitTest("ExistentialTestArrayMutating_ClassValueBuffer1", run_ExistentialTestArrayMutating_ClassValueBuffer1)
+addPrecommitTest("ExistentialTestArrayMutating_ClassValueBuffer2", run_ExistentialTestArrayMutating_ClassValueBuffer2)
+addPrecommitTest("ExistentialTestArrayMutating_ClassValueBuffer3", run_ExistentialTestArrayMutating_ClassValueBuffer3)
+addPrecommitTest("ExistentialTestArrayMutating_ClassValueBuffer4", run_ExistentialTestArrayMutating_ClassValueBuffer4)
+addPrecommitTest("ExistentialTestArrayMutating_IntValueBuffer0", run_ExistentialTestArrayMutating_IntValueBuffer0)
+addPrecommitTest("ExistentialTestArrayMutating_IntValueBuffer1", run_ExistentialTestArrayMutating_IntValueBuffer1)
+addPrecommitTest("ExistentialTestArrayMutating_IntValueBuffer2", run_ExistentialTestArrayMutating_IntValueBuffer2)
+addPrecommitTest("ExistentialTestArrayMutating_IntValueBuffer3", run_ExistentialTestArrayMutating_IntValueBuffer3)
+addPrecommitTest("ExistentialTestArrayMutating_IntValueBuffer4", run_ExistentialTestArrayMutating_IntValueBuffer4)
+addPrecommitTest("ExistentialTestArrayOneMethodCall_ClassValueBuffer1", run_ExistentialTestArrayOneMethodCall_ClassValueBuffer1)
+addPrecommitTest("ExistentialTestArrayOneMethodCall_ClassValueBuffer2", run_ExistentialTestArrayOneMethodCall_ClassValueBuffer2)
+addPrecommitTest("ExistentialTestArrayOneMethodCall_ClassValueBuffer3", run_ExistentialTestArrayOneMethodCall_ClassValueBuffer3)
+addPrecommitTest("ExistentialTestArrayOneMethodCall_ClassValueBuffer4", run_ExistentialTestArrayOneMethodCall_ClassValueBuffer4)
+addPrecommitTest("ExistentialTestArrayOneMethodCall_IntValueBuffer0", run_ExistentialTestArrayOneMethodCall_IntValueBuffer0)
+addPrecommitTest("ExistentialTestArrayOneMethodCall_IntValueBuffer1", run_ExistentialTestArrayOneMethodCall_IntValueBuffer1)
+addPrecommitTest("ExistentialTestArrayOneMethodCall_IntValueBuffer2", run_ExistentialTestArrayOneMethodCall_IntValueBuffer2)
+addPrecommitTest("ExistentialTestArrayOneMethodCall_IntValueBuffer3", run_ExistentialTestArrayOneMethodCall_IntValueBuffer3)
+addPrecommitTest("ExistentialTestArrayOneMethodCall_IntValueBuffer4", run_ExistentialTestArrayOneMethodCall_IntValueBuffer4)
+addPrecommitTest("ExistentialTestArrayShift_ClassValueBuffer1", run_ExistentialTestArrayShift_ClassValueBuffer1)
+addPrecommitTest("ExistentialTestArrayShift_ClassValueBuffer2", run_ExistentialTestArrayShift_ClassValueBuffer2)
+addPrecommitTest("ExistentialTestArrayShift_ClassValueBuffer3", run_ExistentialTestArrayShift_ClassValueBuffer3)
+addPrecommitTest("ExistentialTestArrayShift_ClassValueBuffer4", run_ExistentialTestArrayShift_ClassValueBuffer4)
+addPrecommitTest("ExistentialTestArrayShift_IntValueBuffer0", run_ExistentialTestArrayShift_IntValueBuffer0)
+addPrecommitTest("ExistentialTestArrayShift_IntValueBuffer1", run_ExistentialTestArrayShift_IntValueBuffer1)
+addPrecommitTest("ExistentialTestArrayShift_IntValueBuffer2", run_ExistentialTestArrayShift_IntValueBuffer2)
+addPrecommitTest("ExistentialTestArrayShift_IntValueBuffer3", run_ExistentialTestArrayShift_IntValueBuffer3)
+addPrecommitTest("ExistentialTestArrayShift_IntValueBuffer4", run_ExistentialTestArrayShift_IntValueBuffer4)
+addPrecommitTest("ExistentialTestArrayTwoMethodCalls_ClassValueBuffer1", run_ExistentialTestArrayTwoMethodCalls_ClassValueBuffer1)
+addPrecommitTest("ExistentialTestArrayTwoMethodCalls_ClassValueBuffer2", run_ExistentialTestArrayTwoMethodCalls_ClassValueBuffer2)
+addPrecommitTest("ExistentialTestArrayTwoMethodCalls_ClassValueBuffer3", run_ExistentialTestArrayTwoMethodCalls_ClassValueBuffer3)
+addPrecommitTest("ExistentialTestArrayTwoMethodCalls_ClassValueBuffer4", run_ExistentialTestArrayTwoMethodCalls_ClassValueBuffer4)
+addPrecommitTest("ExistentialTestArrayTwoMethodCalls_IntValueBuffer0", run_ExistentialTestArrayTwoMethodCalls_IntValueBuffer0)
+addPrecommitTest("ExistentialTestArrayTwoMethodCalls_IntValueBuffer1", run_ExistentialTestArrayTwoMethodCalls_IntValueBuffer1)
+addPrecommitTest("ExistentialTestArrayTwoMethodCalls_IntValueBuffer2", run_ExistentialTestArrayTwoMethodCalls_IntValueBuffer2)
+addPrecommitTest("ExistentialTestArrayTwoMethodCalls_IntValueBuffer3", run_ExistentialTestArrayTwoMethodCalls_IntValueBuffer3)
+addPrecommitTest("ExistentialTestArrayTwoMethodCalls_IntValueBuffer4", run_ExistentialTestArrayTwoMethodCalls_IntValueBuffer4)
+addPrecommitTest("ExistentialTestMutatingAndNonMutating_ClassValueBuffer1", run_ExistentialTestMutatingAndNonMutating_ClassValueBuffer1)
+addPrecommitTest("ExistentialTestMutatingAndNonMutating_ClassValueBuffer2", run_ExistentialTestMutatingAndNonMutating_ClassValueBuffer2)
+addPrecommitTest("ExistentialTestMutatingAndNonMutating_ClassValueBuffer3", run_ExistentialTestMutatingAndNonMutating_ClassValueBuffer3)
+addPrecommitTest("ExistentialTestMutatingAndNonMutating_ClassValueBuffer4", run_ExistentialTestMutatingAndNonMutating_ClassValueBuffer4)
+addPrecommitTest("ExistentialTestMutatingAndNonMutating_IntValueBuffer0", run_ExistentialTestMutatingAndNonMutating_IntValueBuffer0)
+addPrecommitTest("ExistentialTestMutatingAndNonMutating_IntValueBuffer1", run_ExistentialTestMutatingAndNonMutating_IntValueBuffer1)
+addPrecommitTest("ExistentialTestMutatingAndNonMutating_IntValueBuffer2", run_ExistentialTestMutatingAndNonMutating_IntValueBuffer2)
+addPrecommitTest("ExistentialTestMutatingAndNonMutating_IntValueBuffer3", run_ExistentialTestMutatingAndNonMutating_IntValueBuffer3)
+addPrecommitTest("ExistentialTestMutatingAndNonMutating_IntValueBuffer4", run_ExistentialTestMutatingAndNonMutating_IntValueBuffer4)
+addPrecommitTest("ExistentialTestMutating_ClassValueBuffer1", run_ExistentialTestMutating_ClassValueBuffer1)
+addPrecommitTest("ExistentialTestMutating_ClassValueBuffer2", run_ExistentialTestMutating_ClassValueBuffer2)
+addPrecommitTest("ExistentialTestMutating_ClassValueBuffer3", run_ExistentialTestMutating_ClassValueBuffer3)
+addPrecommitTest("ExistentialTestMutating_ClassValueBuffer4", run_ExistentialTestMutating_ClassValueBuffer4)
+addPrecommitTest("ExistentialTestMutating_IntValueBuffer0", run_ExistentialTestMutating_IntValueBuffer0)
+addPrecommitTest("ExistentialTestMutating_IntValueBuffer1", run_ExistentialTestMutating_IntValueBuffer1)
+addPrecommitTest("ExistentialTestMutating_IntValueBuffer2", run_ExistentialTestMutating_IntValueBuffer2)
+addPrecommitTest("ExistentialTestMutating_IntValueBuffer3", run_ExistentialTestMutating_IntValueBuffer3)
+addPrecommitTest("ExistentialTestMutating_IntValueBuffer4", run_ExistentialTestMutating_IntValueBuffer4)
+addPrecommitTest("ExistentialTestOneMethodCall_ClassValueBuffer1", run_ExistentialTestOneMethodCall_ClassValueBuffer1)
+addPrecommitTest("ExistentialTestOneMethodCall_ClassValueBuffer2", run_ExistentialTestOneMethodCall_ClassValueBuffer2)
+addPrecommitTest("ExistentialTestOneMethodCall_ClassValueBuffer3", run_ExistentialTestOneMethodCall_ClassValueBuffer3)
+addPrecommitTest("ExistentialTestOneMethodCall_ClassValueBuffer4", run_ExistentialTestOneMethodCall_ClassValueBuffer4)
+addPrecommitTest("ExistentialTestOneMethodCall_IntValueBuffer0", run_ExistentialTestOneMethodCall_IntValueBuffer0)
+addPrecommitTest("ExistentialTestOneMethodCall_IntValueBuffer1", run_ExistentialTestOneMethodCall_IntValueBuffer1)
+addPrecommitTest("ExistentialTestOneMethodCall_IntValueBuffer2", run_ExistentialTestOneMethodCall_IntValueBuffer2)
+addPrecommitTest("ExistentialTestOneMethodCall_IntValueBuffer3", run_ExistentialTestOneMethodCall_IntValueBuffer3)
+addPrecommitTest("ExistentialTestOneMethodCall_IntValueBuffer4", run_ExistentialTestOneMethodCall_IntValueBuffer4)
+addPrecommitTest("ExistentialTestPassExistentialOneMethodCall_ClassValueBuffer1", run_ExistentialTestPassExistentialOneMethodCall_ClassValueBuffer1)
+addPrecommitTest("ExistentialTestPassExistentialOneMethodCall_ClassValueBuffer2", run_ExistentialTestPassExistentialOneMethodCall_ClassValueBuffer2)
+addPrecommitTest("ExistentialTestPassExistentialOneMethodCall_ClassValueBuffer3", run_ExistentialTestPassExistentialOneMethodCall_ClassValueBuffer3)
+addPrecommitTest("ExistentialTestPassExistentialOneMethodCall_ClassValueBuffer4", run_ExistentialTestPassExistentialOneMethodCall_ClassValueBuffer4)
+addPrecommitTest("ExistentialTestPassExistentialOneMethodCall_IntValueBuffer0", run_ExistentialTestPassExistentialOneMethodCall_IntValueBuffer0)
+addPrecommitTest("ExistentialTestPassExistentialOneMethodCall_IntValueBuffer1", run_ExistentialTestPassExistentialOneMethodCall_IntValueBuffer1)
+addPrecommitTest("ExistentialTestPassExistentialOneMethodCall_IntValueBuffer2", run_ExistentialTestPassExistentialOneMethodCall_IntValueBuffer2)
+addPrecommitTest("ExistentialTestPassExistentialOneMethodCall_IntValueBuffer3", run_ExistentialTestPassExistentialOneMethodCall_IntValueBuffer3)
+addPrecommitTest("ExistentialTestPassExistentialOneMethodCall_IntValueBuffer4", run_ExistentialTestPassExistentialOneMethodCall_IntValueBuffer4)
+addPrecommitTest("ExistentialTestPassExistentialTwoMethodCalls_ClassValueBuffer1", run_ExistentialTestPassExistentialTwoMethodCalls_ClassValueBuffer1)
+addPrecommitTest("ExistentialTestPassExistentialTwoMethodCalls_ClassValueBuffer2", run_ExistentialTestPassExistentialTwoMethodCalls_ClassValueBuffer2)
+addPrecommitTest("ExistentialTestPassExistentialTwoMethodCalls_ClassValueBuffer3", run_ExistentialTestPassExistentialTwoMethodCalls_ClassValueBuffer3)
+addPrecommitTest("ExistentialTestPassExistentialTwoMethodCalls_ClassValueBuffer4", run_ExistentialTestPassExistentialTwoMethodCalls_ClassValueBuffer4)
+addPrecommitTest("ExistentialTestPassExistentialTwoMethodCalls_IntValueBuffer0", run_ExistentialTestPassExistentialTwoMethodCalls_IntValueBuffer0)
+addPrecommitTest("ExistentialTestPassExistentialTwoMethodCalls_IntValueBuffer1", run_ExistentialTestPassExistentialTwoMethodCalls_IntValueBuffer1)
+addPrecommitTest("ExistentialTestPassExistentialTwoMethodCalls_IntValueBuffer2", run_ExistentialTestPassExistentialTwoMethodCalls_IntValueBuffer2)
+addPrecommitTest("ExistentialTestPassExistentialTwoMethodCalls_IntValueBuffer3", run_ExistentialTestPassExistentialTwoMethodCalls_IntValueBuffer3)
+addPrecommitTest("ExistentialTestPassExistentialTwoMethodCalls_IntValueBuffer4", run_ExistentialTestPassExistentialTwoMethodCalls_IntValueBuffer4)
+addPrecommitTest("ExistentialTestTwoMethodCalls_ClassValueBuffer1", run_ExistentialTestTwoMethodCalls_ClassValueBuffer1)
+addPrecommitTest("ExistentialTestTwoMethodCalls_ClassValueBuffer2", run_ExistentialTestTwoMethodCalls_ClassValueBuffer2)
+addPrecommitTest("ExistentialTestTwoMethodCalls_ClassValueBuffer3", run_ExistentialTestTwoMethodCalls_ClassValueBuffer3)
+addPrecommitTest("ExistentialTestTwoMethodCalls_ClassValueBuffer4", run_ExistentialTestTwoMethodCalls_ClassValueBuffer4)
+addPrecommitTest("ExistentialTestTwoMethodCalls_IntValueBuffer0", run_ExistentialTestTwoMethodCalls_IntValueBuffer0)
+addPrecommitTest("ExistentialTestTwoMethodCalls_IntValueBuffer1", run_ExistentialTestTwoMethodCalls_IntValueBuffer1)
+addPrecommitTest("ExistentialTestTwoMethodCalls_IntValueBuffer2", run_ExistentialTestTwoMethodCalls_IntValueBuffer2)
+addPrecommitTest("ExistentialTestTwoMethodCalls_IntValueBuffer3", run_ExistentialTestTwoMethodCalls_IntValueBuffer3)
+addPrecommitTest("ExistentialTestTwoMethodCalls_IntValueBuffer4", run_ExistentialTestTwoMethodCalls_IntValueBuffer4)
+addPrecommitTest("GlobalClass", run_GlobalClass)
+addPrecommitTest("Hanoi", run_Hanoi)
+addPrecommitTest("HashQuadratic", run_HashQuadratic)
+addPrecommitTest("HashTest", run_HashTest)
+addPrecommitTest("Histogram", run_Histogram)
+addPrecommitTest("Integrate", run_Integrate)
+addPrecommitTest("IterateData", run_IterateData)
+addPrecommitTest("Join", run_Join)
+addPrecommitTest("LazilyFilteredArrays", run_LazilyFilteredArrays)
+addPrecommitTest("LazilyFilteredRange", run_LazilyFilteredRange)
+addPrecommitTest("LinkedList", run_LinkedList)
+addPrecommitTest("MapReduce", run_MapReduce)
+addPrecommitTest("MapReduceAnyCollection", run_MapReduceAnyCollection)
+addPrecommitTest("MapReduceAnyCollectionShort", run_MapReduceAnyCollectionShort)
+addPrecommitTest("MapReduceClass", run_MapReduceClass)
+addPrecommitTest("MapReduceClassShort", run_MapReduceClassShort)
+addPrecommitTest("MapReduceLazyCollection", run_MapReduceLazyCollection)
+addPrecommitTest("MapReduceLazyCollectionShort", run_MapReduceLazyCollectionShort)
+addPrecommitTest("MapReduceLazySequence", run_MapReduceLazySequence)
+addPrecommitTest("MapReduceSequence", run_MapReduceSequence)
+addPrecommitTest("MapReduceShort", run_MapReduceShort)
+addPrecommitTest("MapReduceShortString", run_MapReduceShortString)
+addPrecommitTest("MapReduceString", run_MapReduceString)
+addPrecommitTest("Memset", run_Memset)
+addPrecommitTest("MonteCarloE", run_MonteCarloE)
+addPrecommitTest("MonteCarloPi", run_MonteCarloPi)
+addPrecommitTest("NSDictionaryCastToSwift", run_NSDictionaryCastToSwift)
+addPrecommitTest("NSError", run_NSError)
+addPrecommitTest("NSStringConversion", run_NSStringConversion)
+addPrecommitTest("NopDeinit", run_NopDeinit)
+addPrecommitTest("ObjectAllocation", run_ObjectAllocation)
+addPrecommitTest("ObjectiveCBridgeFromNSArrayAnyObject", run_ObjectiveCBridgeFromNSArrayAnyObject)
+addPrecommitTest("ObjectiveCBridgeFromNSArrayAnyObjectForced", run_ObjectiveCBridgeFromNSArrayAnyObjectForced)
+addPrecommitTest("ObjectiveCBridgeFromNSArrayAnyObjectToString", run_ObjectiveCBridgeFromNSArrayAnyObjectToString)
+addPrecommitTest("ObjectiveCBridgeFromNSArrayAnyObjectToStringForced", run_ObjectiveCBridgeFromNSArrayAnyObjectToStringForced)
+addPrecommitTest("ObjectiveCBridgeFromNSDictionaryAnyObject", run_ObjectiveCBridgeFromNSDictionaryAnyObject)
+addPrecommitTest("ObjectiveCBridgeFromNSDictionaryAnyObjectForced", run_ObjectiveCBridgeFromNSDictionaryAnyObjectForced)
+addPrecommitTest("ObjectiveCBridgeFromNSDictionaryAnyObjectToString", run_ObjectiveCBridgeFromNSDictionaryAnyObjectToString)
+addPrecommitTest("ObjectiveCBridgeFromNSDictionaryAnyObjectToStringForced", run_ObjectiveCBridgeFromNSDictionaryAnyObjectToStringForced)
+addPrecommitTest("ObjectiveCBridgeFromNSSetAnyObject", run_ObjectiveCBridgeFromNSSetAnyObject)
+addPrecommitTest("ObjectiveCBridgeFromNSSetAnyObjectForced", run_ObjectiveCBridgeFromNSSetAnyObjectForced)
+addPrecommitTest("ObjectiveCBridgeFromNSSetAnyObjectToString", run_ObjectiveCBridgeFromNSSetAnyObjectToString)
+addPrecommitTest("ObjectiveCBridgeFromNSSetAnyObjectToStringForced", run_ObjectiveCBridgeFromNSSetAnyObjectToStringForced)
+addPrecommitTest("ObjectiveCBridgeFromNSString", run_ObjectiveCBridgeFromNSString)
+addPrecommitTest("ObjectiveCBridgeFromNSStringForced", run_ObjectiveCBridgeFromNSStringForced)
+addPrecommitTest("ObjectiveCBridgeStubDataAppend", run_ObjectiveCBridgeStubDataAppend)
+addPrecommitTest("ObjectiveCBridgeStubDateAccess", run_ObjectiveCBridgeStubDateAccess)
+addPrecommitTest("ObjectiveCBridgeStubDateMutation", run_ObjectiveCBridgeStubDateMutation)
+addPrecommitTest("ObjectiveCBridgeStubFromArrayOfNSString", run_ObjectiveCBridgeStubFromArrayOfNSString)
+addPrecommitTest("ObjectiveCBridgeStubFromNSDate", run_ObjectiveCBridgeStubFromNSDate)
+addPrecommitTest("ObjectiveCBridgeStubFromNSDateRef", run_ObjectiveCBridgeStubFromNSDateRef)
+addPrecommitTest("ObjectiveCBridgeStubFromNSString", run_ObjectiveCBridgeStubFromNSString)
+addPrecommitTest("ObjectiveCBridgeStubFromNSStringRef", run_ObjectiveCBridgeStubFromNSStringRef)
+addPrecommitTest("ObjectiveCBridgeStubNSDataAppend", run_ObjectiveCBridgeStubNSDataAppend)
+addPrecommitTest("ObjectiveCBridgeStubNSDateMutationRef", run_ObjectiveCBridgeStubNSDateMutationRef)
+addPrecommitTest("ObjectiveCBridgeStubNSDateRefAccess", run_ObjectiveCBridgeStubNSDateRefAccess)
+addPrecommitTest("ObjectiveCBridgeStubToArrayOfNSString", run_ObjectiveCBridgeStubToArrayOfNSString)
+addPrecommitTest("ObjectiveCBridgeStubToNSDate", run_ObjectiveCBridgeStubToNSDate)
+addPrecommitTest("ObjectiveCBridgeStubToNSDateRef", run_ObjectiveCBridgeStubToNSDateRef)
+addPrecommitTest("ObjectiveCBridgeStubToNSString", run_ObjectiveCBridgeStubToNSString)
+addPrecommitTest("ObjectiveCBridgeStubToNSStringRef", run_ObjectiveCBridgeStubToNSStringRef)
+addPrecommitTest("ObjectiveCBridgeStubURLAppendPath", run_ObjectiveCBridgeStubURLAppendPath)
+addPrecommitTest("ObjectiveCBridgeStubURLAppendPathRef", run_ObjectiveCBridgeStubURLAppendPathRef)
+addPrecommitTest("ObjectiveCBridgeToNSArray", run_ObjectiveCBridgeToNSArray)
+addPrecommitTest("ObjectiveCBridgeToNSDictionary", run_ObjectiveCBridgeToNSDictionary)
+addPrecommitTest("ObjectiveCBridgeToNSSet", run_ObjectiveCBridgeToNSSet)
+addPrecommitTest("ObjectiveCBridgeToNSString", run_ObjectiveCBridgeToNSString)
+addPrecommitTest("ObserverClosure", run_ObserverClosure)
+addPrecommitTest("ObserverForwarderStruct", run_ObserverForwarderStruct)
+addPrecommitTest("ObserverPartiallyAppliedMethod", run_ObserverPartiallyAppliedMethod)
+addPrecommitTest("ObserverUnappliedMethod", run_ObserverUnappliedMethod)
+addPrecommitTest("OpenClose", run_OpenClose)
+addPrecommitTest("Phonebook", run_Phonebook)
+addPrecommitTest("PolymorphicCalls", run_PolymorphicCalls)
+addPrecommitTest("PopFrontArray", run_PopFrontArray)
+addPrecommitTest("PopFrontArrayGeneric", run_PopFrontArrayGeneric)
+addPrecommitTest("PopFrontUnsafePointer", run_PopFrontUnsafePointer)
+addPrecommitTest("PrefixAnyCollection", run_PrefixAnyCollection)
+addPrecommitTest("PrefixAnyCollectionLazy", run_PrefixAnyCollectionLazy)
+addPrecommitTest("PrefixAnySeqCRangeIter", run_PrefixAnySeqCRangeIter)
+addPrecommitTest("PrefixAnySeqCRangeIterLazy", run_PrefixAnySeqCRangeIterLazy)
+addPrecommitTest("PrefixAnySeqCntRange", run_PrefixAnySeqCntRange)
+addPrecommitTest("PrefixAnySeqCntRangeLazy", run_PrefixAnySeqCntRangeLazy)
+addPrecommitTest("PrefixAnySequence", run_PrefixAnySequence)
+addPrecommitTest("PrefixAnySequenceLazy", run_PrefixAnySequenceLazy)
+addPrecommitTest("PrefixArray", run_PrefixArray)
+addPrecommitTest("PrefixArrayLazy", run_PrefixArrayLazy)
+addPrecommitTest("PrefixCountableRange", run_PrefixCountableRange)
+addPrecommitTest("PrefixCountableRangeLazy", run_PrefixCountableRangeLazy)
+addPrecommitTest("PrefixSequence", run_PrefixSequence)
+addPrecommitTest("PrefixSequenceLazy", run_PrefixSequenceLazy)
+addPrecommitTest("PrefixWhileAnyCollection", run_PrefixWhileAnyCollection)
+addPrecommitTest("PrefixWhileAnyCollectionLazy", run_PrefixWhileAnyCollectionLazy)
+addPrecommitTest("PrefixWhileAnySeqCRangeIter", run_PrefixWhileAnySeqCRangeIter)
+addPrecommitTest("PrefixWhileAnySeqCRangeIterLazy", run_PrefixWhileAnySeqCRangeIterLazy)
+addPrecommitTest("PrefixWhileAnySeqCntRange", run_PrefixWhileAnySeqCntRange)
+addPrecommitTest("PrefixWhileAnySeqCntRangeLazy", run_PrefixWhileAnySeqCntRangeLazy)
+addPrecommitTest("PrefixWhileAnySequence", run_PrefixWhileAnySequence)
+addPrecommitTest("PrefixWhileAnySequenceLazy", run_PrefixWhileAnySequenceLazy)
+addPrecommitTest("PrefixWhileArray", run_PrefixWhileArray)
+addPrecommitTest("PrefixWhileArrayLazy", run_PrefixWhileArrayLazy)
+addPrecommitTest("PrefixWhileCountableRange", run_PrefixWhileCountableRange)
+addPrecommitTest("PrefixWhileCountableRangeLazy", run_PrefixWhileCountableRangeLazy)
+addPrecommitTest("PrefixWhileSequence", run_PrefixWhileSequence)
+addPrecommitTest("PrefixWhileSequenceLazy", run_PrefixWhileSequenceLazy)
+addPrecommitTest("Prims", run_Prims)
+addPrecommitTest("ProtocolDispatch", run_ProtocolDispatch)
+addPrecommitTest("ProtocolDispatch2", run_ProtocolDispatch2)
+addPrecommitTest("RC4", run_RC4)
+addPrecommitTest("RGBHistogram", run_RGBHistogram)
+addPrecommitTest("RGBHistogramOfObjects", run_RGBHistogramOfObjects)
+addPrecommitTest("RangeAssignment", run_RangeAssignment)
+addPrecommitTest("RecursiveOwnedParameter", run_RecursiveOwnedParameter)
+addPrecommitTest("ReversedArray", run_ReversedArray)
+addPrecommitTest("ReversedBidirectional", run_ReversedBidirectional)
+addPrecommitTest("ReversedDictionary", run_ReversedDictionary)
+addPrecommitTest("SetExclusiveOr", run_SetExclusiveOr)
+addPrecommitTest("SetExclusiveOr_OfObjects", run_SetExclusiveOr_OfObjects)
+addPrecommitTest("SetIntersect", run_SetIntersect)
+addPrecommitTest("SetIntersect_OfObjects", run_SetIntersect_OfObjects)
+addPrecommitTest("SetIsSubsetOf", run_SetIsSubsetOf)
+addPrecommitTest("SetIsSubsetOf_OfObjects", run_SetIsSubsetOf_OfObjects)
+addPrecommitTest("SetUnion", run_SetUnion)
+addPrecommitTest("SetUnion_OfObjects", run_SetUnion_OfObjects)
+addPrecommitTest("SevenBoom", run_SevenBoom)
+addPrecommitTest("Sim2DArray", run_Sim2DArray)
+addPrecommitTest("SortLettersInPlace", run_SortLettersInPlace)
+addPrecommitTest("SortSortedStrings", run_SortSortedStrings)
+addPrecommitTest("SortStrings", run_SortStrings)
+addPrecommitTest("SortStringsUnicode", run_SortStringsUnicode)
+addPrecommitTest("StackPromo", run_StackPromo)
+addPrecommitTest("StaticArray", run_StaticArray)
+addPrecommitTest("StrComplexWalk", run_StrComplexWalk)
+addPrecommitTest("StrToInt", run_StrToInt)
+addPrecommitTest("StringAdder", run_StringAdder)
+addPrecommitTest("StringBuilder", run_StringBuilder)
+addPrecommitTest("StringBuilderLong", run_StringBuilderLong)
+addPrecommitTest("StringEdits", run_StringEdits)
+addPrecommitTest("StringEqualPointerComparison", run_StringEqualPointerComparison)
+addPrecommitTest("StringHasPrefix", run_StringHasPrefix)
+addPrecommitTest("StringHasPrefixUnicode", run_StringHasPrefixUnicode)
+addPrecommitTest("StringHasSuffix", run_StringHasSuffix)
+addPrecommitTest("StringHasSuffixUnicode", run_StringHasSuffixUnicode)
+addPrecommitTest("StringInterpolation", run_StringInterpolation)
+addPrecommitTest("StringMatch", run_StringMatch)
+addPrecommitTest("StringUTF16Builder", run_StringUTF16Builder)
+addPrecommitTest("StringWalk", run_StringWalk)
+addPrecommitTest("StringWithCString", run_StringWithCString)
+addPrecommitTest("SuffixAnyCollection", run_SuffixAnyCollection)
+addPrecommitTest("SuffixAnyCollectionLazy", run_SuffixAnyCollectionLazy)
+addPrecommitTest("SuffixAnySeqCRangeIter", run_SuffixAnySeqCRangeIter)
+addPrecommitTest("SuffixAnySeqCRangeIterLazy", run_SuffixAnySeqCRangeIterLazy)
+addPrecommitTest("SuffixAnySeqCntRange", run_SuffixAnySeqCntRange)
+addPrecommitTest("SuffixAnySeqCntRangeLazy", run_SuffixAnySeqCntRangeLazy)
+addPrecommitTest("SuffixAnySequence", run_SuffixAnySequence)
+addPrecommitTest("SuffixAnySequenceLazy", run_SuffixAnySequenceLazy)
+addPrecommitTest("SuffixArray", run_SuffixArray)
+addPrecommitTest("SuffixArrayLazy", run_SuffixArrayLazy)
+addPrecommitTest("SuffixCountableRange", run_SuffixCountableRange)
+addPrecommitTest("SuffixCountableRangeLazy", run_SuffixCountableRangeLazy)
+addPrecommitTest("SuffixSequence", run_SuffixSequence)
+addPrecommitTest("SuffixSequenceLazy", run_SuffixSequenceLazy)
+addPrecommitTest("SuperChars", run_SuperChars)
+addPrecommitTest("TwoSum", run_TwoSum)
+addPrecommitTest("TypeFlood", run_TypeFlood)
+addPrecommitTest("UTF8Decode", run_UTF8Decode)
+addPrecommitTest("Walsh", run_Walsh)
+addPrecommitTest("XorLoop", run_XorLoop)
+
 
 otherTests = [
   "Ackermann": run_Ackermann,

--- a/benchmark/utils/main.swift
+++ b/benchmark/utils/main.swift
@@ -131,7 +131,14 @@ private func addStringTest(
 ) {
   stringTests[name] = function
 }
+@inline(__always)
+private func addOtherTest(
+  _ name: String, _ function: @escaping (Int) -> ()
+) {
+  otherTests[name] = function
+}
 
+// The main test suite: precommit tests
 addPrecommitTest("AngryPhonebook", run_AngryPhonebook)
 addPrecommitTest("AnyHashableWithAClass", run_AnyHashableWithAClass)
 addPrecommitTest("Array2D", run_Array2D)
@@ -499,16 +506,12 @@ addPrecommitTest("UTF8Decode", run_UTF8Decode)
 addPrecommitTest("Walsh", run_Walsh)
 addPrecommitTest("XorLoop", run_XorLoop)
 
-
-otherTests = [
-  "Ackermann": run_Ackermann,
-  "Fibonacci": run_Fibonacci,
-]
+// Other tests
+addOtherTest("Ackermann", run_Ackermann)
+addOtherTest("Fibonacci", run_Fibonacci)
 
 // String tests, an extended benchmark suite exercising finer-granularity
 // behavior of our Strings.
-//
-// Scalar and Character iteration
 addStringTest("StringWalkASCIIScalars", run_StringWalkASCIIScalars)
 addStringTest("StringWalkASCIICharacters", run_StringWalkASCIICharacters)
 addStringTest("StringWalkUnicodeScalars", run_StringWalkUnicodeScalars)

--- a/benchmark/utils/main.swift
+++ b/benchmark/utils/main.swift
@@ -125,6 +125,12 @@ private func addPrecommitTest(
 ) {
   precommitTests[name] = function
 }
+@inline(__always)
+private func addStringTest(
+  _ name: String, _ function: @escaping (Int) -> ()
+) {
+  stringTests[name] = function
+}
 
 addPrecommitTest("AngryPhonebook", run_AngryPhonebook)
 addPrecommitTest("AnyHashableWithAClass", run_AnyHashableWithAClass)
@@ -499,5 +505,17 @@ otherTests = [
   "Fibonacci": run_Fibonacci,
 ]
 
+// String tests, an extended benchmark suite exercising finer-granularity
+// behavior of our Strings.
+//
+// Scalar and Character iteration
+addStringTest("StringWalkASCIIScalars", run_StringWalkASCIIScalars)
+addStringTest("StringWalkASCIICharacters", run_StringWalkASCIICharacters)
+addStringTest("StringWalkUnicodeScalars", run_StringWalkUnicodeScalars)
+addStringTest("StringWalkUnicodeCharacters", run_StringWalkUnicodeCharacters)
+addStringTest("StringWalkASCIIScalarsBackwards", run_StringWalkASCIIScalarsBackwards)
+addStringTest("StringWalkASCIICharactersBackwards", run_StringWalkASCIICharactersBackwards)
+addStringTest("StringWalkUnicodeScalarsBackwards", run_StringWalkUnicodeScalarsBackwards)
+addStringTest("StringWalkUnicodeCharactersBackwards", run_StringWalkUnicodeCharactersBackwards)
 
 main()


### PR DESCRIPTION
<!-- What's in this pull request? -->

This speeds up the compilation time of main.swift in the benchmark suite from taking a minute or two to about a second. NFC.

Starts a String perf test suite called stringTests which is
off-by-default, but allows us to place some lower-level targeted
benchmarking.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->