### PR TITLE
ASTContext: Add CGFloat as a trivial representable kind even if we loaded CoreGraphics later

### DIFF
--- a/test/Interpreter/late_import_cgfloat.swift
+++ b/test/Interpreter/late_import_cgfloat.swift
@@ -1,0 +1,14 @@
+// RUN: %target-repl-run-simple-swift | %FileCheck %s
+
+// REQUIRES: swift_repl
+
+// This used to crash.
+
+let str = ""
+import Foundation
+let pt = CGPoint(x: 1.0, y: 2.0)
+// CHECK: pt : CGPoint = (1.0, 2.0)
+
+import simd
+let f = float2(x: 1.0, y: 2.0)
+// CHECK: f : float2 = float2(1.0, 2.0)


### PR DESCRIPTION
Add CGFloat as a trivial type even after the one-time initialization of the ForeignRepresentableCache.

This allows

  let str = ""
  import Foundation
  let pt = CGPoint(x: 1.0, y: 2.0)

to work.

Before we would populate the cache the first time on the first line "let str =
..." and because the CoreGraphics module was not loaded we would not add CGFloat
as a trivial type. When we come to query for CGFloat on the third line we would
return NSNumber instead of CGFloat as a type and that would crash IRGen.

rdar://31610342

