### PR TITLE
[DO NOT MERGE] Enable exclusivity warning by default

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -87,11 +87,17 @@ NOTE(previous_inout_alias,none,
 // This is temporarily a warning during staging to make it easier to evaluate.
 // The intent is to change it to an error before turning it on by default.
 WARNING(exclusivity_access_required,none,
+        "simultaneous accesses to %0 %1; "
+        "%select{initialization|read|modification|deinitialization}2 requires "
+        "exclusive access", (DescriptiveDeclKind, Identifier, unsigned))
+
+WARNING(exclusivity_access_required_unknown_decl,none,
+        "simultaneous accesses; "
         "%select{initialization|read|modification|deinitialization}0 requires "
-        "%select{exclusive|shared}1 access", (unsigned, unsigned))
+        "exclusive access", (unsigned))
+
 NOTE(exclusivity_conflicting_access,none,
-     "conflicting %select{initialization|read|modification|deinitialization}0 "
-     "requires %select{exclusive|shared}1 access", (unsigned, unsigned))
+     "conflicting access is here", ())
 
 ERROR(unsupported_c_function_pointer_conversion,none,
       "C function pointer signature %0 is not compatible with expected type %1",

--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -141,7 +141,7 @@ public:
   SanitizerKind Sanitize : 2;
 
   /// Emit compile-time diagnostics when the law of exclusivity is violated.
-  bool EnforceExclusivityStatic = false;
+  bool EnforceExclusivityStatic = true;
 
   /// Suppress static diagnostics for violations of exclusive access for calls
   /// to the Standard Library's swap() free function.

--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -143,6 +143,10 @@ public:
   /// Emit compile-time diagnostics when the law of exclusivity is violated.
   bool EnforceExclusivityStatic = false;
 
+  /// Suppress static diagnostics for violations of exclusive access for calls
+  /// to the Standard Library's swap() free function.
+  bool SuppressStaticExclusivitySwap = false;
+
   /// Emit checks to trap at run time when the law of exclusivity is violated.
   bool EnforceExclusivityDynamic = false;
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -256,6 +256,9 @@ def disable_mandatory_semantic_arc_opts : Flag<["-"], "disable-mandatory-semanti
 def assume_parsing_unqualified_ownership_sil : Flag<["-"], "assume-parsing-unqualified-ownership-sil">,
   HelpText<"Assume unqualified SIL ownership when parsing SIL">;
 
+def suppress_static_exclusivity_swap : Flag<["-"], "suppress-static-exclusivity-swap">,
+  HelpText<"Suppress static violations of exclusive access with swap()">;
+
 def enable_sil_opaque_values : Flag<["-"], "enable-sil-opaque-values">,
   HelpText<"Enable SIL Opaque Values">;
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1324,6 +1324,8 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
     |= Args.hasArg(OPT_assume_parsing_unqualified_ownership_sil);
   Opts.EnableMandatorySemanticARCOpts |=
       !Args.hasArg(OPT_disable_mandatory_semantic_arc_opts);
+  Opts.SuppressStaticExclusivitySwap |=
+      Args.hasArg(OPT_suppress_static_exclusivity_swap);
 
   if (Args.hasArg(OPT_debug_on_sil)) {
     // Derive the name of the SIL file for debugging from

--- a/lib/SILOptimizer/Mandatory/DiagnoseStaticExclusivity.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseStaticExclusivity.cpp
@@ -431,7 +431,8 @@ static void checkStaticExclusivity(SILFunction &Fn, PostOrderFunctionInfo *PO) {
       if (auto *AI = dyn_cast<ApplyInst>(&I)) {
         // Suppress for the arguments to the Standard Library's swap()
         // function until we can recommend a safe alternative.
-        if (isCallToStandardLibrarySwap(AI, Fn.getASTContext()))
+        if (Fn.getModule().getOptions().SuppressStaticExclusivitySwap &&
+            isCallToStandardLibrarySwap(AI, Fn.getASTContext()))
           CallsToSuppress.push_back(AI);
       }
 

--- a/test/SILOptimizer/exclusivity_static_diagnostics.sil
+++ b/test/SILOptimizer/exclusivity_static_diagnostics.sil
@@ -245,6 +245,22 @@ bb0(%0 : $Int):
   return %8 : $()
 }
 
+// CHECK-LABEL: sil hidden @lookThroughMarkUninitialized
+sil hidden @lookThroughMarkUninitialized : $@convention(thin) (Int) -> () {
+bb0(%0 : $Int):
+  %1 = alloc_box ${ var Int }
+  %2 = mark_uninitialized [rootself] %1 : ${ var Int }
+  %3 = project_box %2 : ${ var Int }, 0
+  store %0 to [trivial] %3 : $*Int
+  %4 = project_box %2 : ${ var Int }, 0
+  %5 = begin_access [modify] [unknown] %3 : $*Int  // expected-note {{conflicting modification requires exclusive access}}
+  %6 = begin_access [modify] [unknown] %4 : $*Int  // expected-warning {{modification requires exclusive access}}
+  end_access %6 : $*Int
+  end_access %5: $*Int
+  destroy_value %2 : ${ var Int }
+  %7 = tuple ()
+  return %7 : $()
+}
 
 // Treat global as identity for global_addr instruction-
 sil_global hidden @global1 : $Int

--- a/test/SILOptimizer/exclusivity_static_diagnostics.sil
+++ b/test/SILOptimizer/exclusivity_static_diagnostics.sil
@@ -223,6 +223,50 @@ bb0(%0 : $Int):
 }
 
 
+class ClassWithStoredProperty {
+  @sil_stored var f: Int
+  init()
+}
+// CHECK-LABEL: sil hidden @classStoredProperty
+sil hidden @classStoredProperty : $@convention(thin) (ClassWithStoredProperty) -> () {
+bb0(%0 : $ClassWithStoredProperty):
+  %1 = ref_element_addr %0 : $ClassWithStoredProperty, #ClassWithStoredProperty.f
+
+  // expected-note@+1{{conflicting modification requires exclusive access}}
+  %2 = begin_access [modify] [dynamic] %1 : $*Int
+  %3 = ref_element_addr %0 : $ClassWithStoredProperty, #ClassWithStoredProperty.f
+
+  // expected-warning@+1{{modification requires exclusive access}}
+  %4 = begin_access [modify] [dynamic] %3 : $*Int
+  end_access %4 : $*Int
+  end_access %2 : $*Int
+  destroy_value %0 : $ClassWithStoredProperty
+  %5 = tuple ()
+  return %5 : $()
+}
+
+// CHECK-LABEL: sil hidden @lookThroughBeginBorrow
+sil hidden @lookThroughBeginBorrow : $@convention(thin) (ClassWithStoredProperty) -> () {
+bb0(%0 : $ClassWithStoredProperty):
+  %1 = begin_borrow %0 : $ClassWithStoredProperty
+  %2 = begin_borrow %0 : $ClassWithStoredProperty
+  %3 = ref_element_addr %1 : $ClassWithStoredProperty, #ClassWithStoredProperty.f
+
+  // expected-note@+1{{conflicting modification requires exclusive access}}
+  %4 = begin_access [modify] [dynamic] %3 : $*Int
+  %5 = ref_element_addr %2 : $ClassWithStoredProperty, #ClassWithStoredProperty.f
+
+  // expected-warning@+1{{modification requires exclusive access}}
+  %6 = begin_access [modify] [dynamic] %5 : $*Int
+  end_access %6 : $*Int
+  end_access %4 : $*Int
+  end_borrow %2 from %0 : $ClassWithStoredProperty, $ClassWithStoredProperty
+  end_borrow %1 from %0 : $ClassWithStoredProperty, $ClassWithStoredProperty
+  destroy_value %0 : $ClassWithStoredProperty
+  %7 = tuple ()
+  return %7 : $()
+}
+
 // Tests for address identity
 
 // Treat 'alloc_box' as identity for project_box
@@ -295,7 +339,7 @@ bb0(%0 : $Int):
 // Multiple errors accessing the same location
 
 // If we have a sequence of begin read - begin write - begin read accesses make
-// sure the second read doesn't report a confusing read-read conflict.
+// sure the the second read doesn't report a confusing read-read conflict.
 // CHECK-LABEL: sil hidden @readWriteReadConflictingThirdAccess
 sil hidden @readWriteReadConflictingThirdAccess : $@convention(thin) (Int) -> () {
 bb0(%0 : $Int):

--- a/test/SILOptimizer/exclusivity_static_diagnostics.sil
+++ b/test/SILOptimizer/exclusivity_static_diagnostics.sil
@@ -38,8 +38,8 @@ bb0(%0 : $Int):
   %3 = project_box %2 : ${ var Int }, 0
   store %0 to [trivial] %3 : $*Int
   %4 = function_ref @takesTwoInouts : $@convention(thin) (@inout Int, @inout Int) -> ()
-  %5 = begin_access [modify] [unknown] %3 : $*Int  // expected-note {{conflicting modification requires exclusive access}}
-  %6 = begin_access [modify] [unknown] %3 : $*Int  // expected-warning {{modification requires exclusive access}}
+  %5 = begin_access [modify] [unknown] %3 : $*Int  // expected-warning {{simultaneous accesses; modification requires exclusive access}}
+  %6 = begin_access [modify] [unknown] %3 : $*Int  // expected-note {{conflicting access is here}}
   %7 = apply %4(%5, %6) : $@convention(thin) (@inout Int, @inout Int) -> ()
   end_access %6 : $*Int
   end_access %5: $*Int
@@ -55,9 +55,9 @@ bb0(%0 : $Int):
   %3 = project_box %2 : ${ var Int }, 0
   store %0 to [trivial] %3 : $*Int
   %4 = function_ref @takesTwoInouts : $@convention(thin) (@inout Int, @inout Int) -> ()
-  %5 = begin_access [modify] [unknown] %3 : $*Int  // expected-note {{conflicting modification requires exclusive access}}
+  %5 = begin_access [modify] [unknown] %3 : $*Int  // expected-warning {{simultaneous accesses; modification requires exclusive access}}
   %6 = begin_access [modify] [unknown] %5 : $*Int
-  %7 = begin_access [modify] [unknown] %3 : $*Int  // expected-warning {{modification requires exclusive access}}
+  %7 = begin_access [modify] [unknown] %3 : $*Int  // expected-note {{conflicting access is here}}
   %8 = apply %4(%5, %6) : $@convention(thin) (@inout Int, @inout Int) -> ()
   end_access %7 : $*Int
   end_access %6 : $*Int
@@ -147,8 +147,8 @@ bb0(%0 : $Int, %1 : $Builtin.Int1):
   br bb1
 bb1:
   // Make sure we don't diagnose twice.
-  %4 = begin_access [modify] [unknown] %3 : $*Int // expected-note {{conflicting modification requires exclusive access}}
-  %5 = begin_access [modify] [unknown] %3 : $*Int // expected-warning {{modification requires exclusive access}}
+  %4 = begin_access [modify] [unknown] %3 : $*Int // expected-warning {{simultaneous accesses; modification requires exclusive access}}
+  %5 = begin_access [modify] [unknown] %3 : $*Int // expected-note {{conflicting access is here}}
   end_access %5: $*Int
   end_access %4: $*Int
   cond_br %1, bb1, bb2
@@ -198,8 +198,8 @@ bb0(%0 : $Int):
   %1 = alloc_box ${ var Int }
   %2 = project_box %1 : ${ var Int }, 0
   store %0 to [trivial] %2 : $*Int
-  %4 = begin_access [read] [unknown] %2 : $*Int // expected-note {{conflicting read requires shared access}}
-  %5 = begin_access [modify] [unknown] %2 : $*Int // expected-warning {{modification requires exclusive access}}
+  %4 = begin_access [read] [unknown] %2 : $*Int // expected-note {{conflicting access is here}}
+  %5 = begin_access [modify] [unknown] %2 : $*Int // expected-warning {{simultaneous accesses; modification requires exclusive access}}
   end_access %5 : $*Int
   end_access %4: $*Int
   destroy_value %1 : ${ var Int }
@@ -213,8 +213,8 @@ bb0(%0 : $Int):
   %1 = alloc_box ${ var Int }
   %2 = project_box %1 : ${ var Int }, 0
   store %0 to [trivial] %2 : $*Int
-  %4 = begin_access [modify] [unknown] %2 : $*Int // expected-note {{conflicting modification requires exclusive access}}
-  %5 = begin_access [read] [unknown] %2 : $*Int // expected-warning {{read requires shared access}}
+  %4 = begin_access [modify] [unknown] %2 : $*Int // expected-warning {{simultaneous accesses; modification requires exclusive access}}
+  %5 = begin_access [read] [unknown] %2 : $*Int // expected-note {{conflicting access is here}}
   end_access %5 : $*Int
   end_access %4: $*Int
   destroy_value %1 : ${ var Int }
@@ -232,11 +232,11 @@ sil hidden @classStoredProperty : $@convention(thin) (ClassWithStoredProperty) -
 bb0(%0 : $ClassWithStoredProperty):
   %1 = ref_element_addr %0 : $ClassWithStoredProperty, #ClassWithStoredProperty.f
 
-  // expected-note@+1{{conflicting modification requires exclusive access}}
+  // expected-warning@+1{{simultaneous accesses to var 'f'; modification requires exclusive access}}
   %2 = begin_access [modify] [dynamic] %1 : $*Int
   %3 = ref_element_addr %0 : $ClassWithStoredProperty, #ClassWithStoredProperty.f
 
-  // expected-warning@+1{{modification requires exclusive access}}
+  // expected-note@+1{{conflicting access is here}}
   %4 = begin_access [modify] [dynamic] %3 : $*Int
   end_access %4 : $*Int
   end_access %2 : $*Int
@@ -252,11 +252,11 @@ bb0(%0 : $ClassWithStoredProperty):
   %2 = begin_borrow %0 : $ClassWithStoredProperty
   %3 = ref_element_addr %1 : $ClassWithStoredProperty, #ClassWithStoredProperty.f
 
-  // expected-note@+1{{conflicting modification requires exclusive access}}
+  // expected-warning@+1{{simultaneous accesses to var 'f'; modification requires exclusive access}}
   %4 = begin_access [modify] [dynamic] %3 : $*Int
   %5 = ref_element_addr %2 : $ClassWithStoredProperty, #ClassWithStoredProperty.f
 
-  // expected-warning@+1{{modification requires exclusive access}}
+  // expected-note@+1{{conflicting access is here}}
   %6 = begin_access [modify] [dynamic] %5 : $*Int
   end_access %6 : $*Int
   end_access %4 : $*Int
@@ -279,8 +279,8 @@ bb0(%0 : $Int):
   store %0 to [trivial] %3 : $*Int
   %4 = copy_value %2 : ${ var Int }
   %5 = project_box %4 : ${ var Int }, 0
-  %6 = begin_access [modify] [unknown] %3 : $*Int  // expected-note {{conflicting modification requires exclusive access}}
-  %7 = begin_access [modify] [unknown] %5 : $*Int  // expected-warning {{modification requires exclusive access}}
+  %6 = begin_access [modify] [unknown] %3 : $*Int  // expected-warning {{simultaneous accesses; modification requires exclusive access}}
+  %7 = begin_access [modify] [unknown] %5 : $*Int  // expected-note {{conflicting access is here}}
   end_access %7 : $*Int
   end_access %6: $*Int
   destroy_value %2 : ${ var Int }
@@ -297,8 +297,8 @@ bb0(%0 : $Int):
   %3 = project_box %2 : ${ var Int }, 0
   store %0 to [trivial] %3 : $*Int
   %4 = project_box %2 : ${ var Int }, 0
-  %5 = begin_access [modify] [unknown] %3 : $*Int  // expected-note {{conflicting modification requires exclusive access}}
-  %6 = begin_access [modify] [unknown] %4 : $*Int  // expected-warning {{modification requires exclusive access}}
+  %5 = begin_access [modify] [unknown] %3 : $*Int  // expected-warning {{simultaneous accesses; modification requires exclusive access}}
+  %6 = begin_access [modify] [unknown] %4 : $*Int  // expected-note {{conflicting access is here}}
   end_access %6 : $*Int
   end_access %5: $*Int
   destroy_value %2 : ${ var Int }
@@ -315,8 +315,8 @@ sil hidden @modifySameGlobal : $@convention(thin) (Int) -> () {
 bb0(%0 : $Int):
   %1 = global_addr @global1 :$*Int
   %2 = global_addr @global1 :$*Int
-  %3 = begin_access [modify] [unknown] %1 : $*Int  // expected-note {{conflicting modification requires exclusive access}}
-  %4 = begin_access [modify] [unknown] %2 : $*Int  // expected-warning {{modification requires exclusive access}}
+  %3 = begin_access [modify] [unknown] %1 : $*Int  // expected-warning {{simultaneous accesses; modification requires exclusive access}}
+  %4 = begin_access [modify] [unknown] %2 : $*Int  // expected-note {{conflicting access is here}}
   end_access %4 : $*Int
   end_access %3: $*Int
   %5 = tuple ()
@@ -347,8 +347,8 @@ bb0(%0 : $Int):
   %3 = project_box %2 : ${ var Int }, 0
   store %0 to [trivial] %3 : $*Int
   %4 = function_ref @takesTwoInouts : $@convention(thin) (@inout Int, @inout Int) -> ()
-  %5 = begin_access [read] [unknown] %3 : $*Int  // expected-note {{conflicting read requires shared access}}
-  %6 = begin_access [modify] [unknown] %3 : $*Int  // expected-warning {{modification requires exclusive access}}
+  %5 = begin_access [read] [unknown] %3 : $*Int  // expected-note {{conflicting access is here}}
+  %6 = begin_access [modify] [unknown] %3 : $*Int  // expected-warning {{simultaneous accesses; modification requires exclusive access}}
   %7 = begin_access [read] [unknown] %3 : $*Int // no-error
   %8 = apply %4(%5, %6) : $@convention(thin) (@inout Int, @inout Int) -> ()
   end_access %7 : $*Int
@@ -368,8 +368,8 @@ bb0(%0 : $Int):
   %3 = project_box %2 : ${ var Int }, 0
   store %0 to [trivial] %3 : $*Int
   %4 = function_ref @takesTwoInouts : $@convention(thin) (@inout Int, @inout Int) -> ()
-  %5 = begin_access [modify] [unknown] %3 : $*Int  // expected-note {{conflicting modification requires exclusive access}}
-  %6 = begin_access [modify] [unknown] %3 : $*Int  // expected-warning {{modification requires exclusive access}}
+  %5 = begin_access [modify] [unknown] %3 : $*Int  // expected-warning {{simultaneous accesses; modification requires exclusive access}}
+  %6 = begin_access [modify] [unknown] %3 : $*Int  // expected-note {{conflicting access is here}}
   %7 = begin_access [modify] [unknown] %3 : $*Int  // no-error
   %8 = apply %4(%5, %6) : $@convention(thin) (@inout Int, @inout Int) -> ()
   end_access %7 : $*Int
@@ -392,8 +392,8 @@ bb0(%0 : $Int):
   %4 = function_ref @takesTwoInouts : $@convention(thin) (@inout Int, @inout Int) -> ()
   %5 = begin_access [modify] [unknown] %3 : $*Int  // no-note
   end_access %5 : $*Int
-  %6 = begin_access [modify] [unknown] %3 : $*Int  // expected-note {{conflicting modification requires exclusive access}}
-  %7 = begin_access [modify] [unknown] %3 : $*Int  // expected-warning {{modification requires exclusive access}}
+  %6 = begin_access [modify] [unknown] %3 : $*Int  // expected-warning {{simultaneous accesses; modification requires exclusive access}}
+  %7 = begin_access [modify] [unknown] %3 : $*Int  // expected-note {{conflicting access is here}}
   %8 = apply %4(%5, %6) : $@convention(thin) (@inout Int, @inout Int) -> ()
   end_access %7 : $*Int
   end_access %6: $*Int

--- a/test/SILOptimizer/exclusivity_static_diagnostics.swift
+++ b/test/SILOptimizer/exclusivity_static_diagnostics.swift
@@ -2,7 +2,7 @@
 
 import Swift
 
-func takesTwoInouts(_ p1: inout Int, _ p2: inout Int) { }
+func takesTwoInouts<T>(_ p1: inout T, _ p2: inout T) { }
 
 func simpleInoutDiagnostic() {
   var i = 7
@@ -19,4 +19,38 @@ func swapNoSuppression(_ i: Int, _ j: Int) {
   // expected-warning@+2{{modification requires exclusive access}}
   // expected-note@+1{{conflicting modification requires exclusive access}}
   swap(&a[i], &a[j]) // no-warning
+}
+
+class SomeClass { }
+
+struct StructWithMutatingMethodThatTakesSelfInout {
+  var f = SomeClass()
+  mutating func mutate(_ other: inout StructWithMutatingMethodThatTakesSelfInout) { }
+  mutating func mutate(_ other: inout SomeClass) { }
+
+  mutating func callMutatingMethodThatTakesSelfInout() {
+    // expected-warning@+2{{modification requires exclusive access}}
+    // expected-note@+1{{conflicting modification requires exclusive access}}
+    mutate(&self)
+  }
+
+  mutating func callMutatingMethodThatTakesSelfStoredPropInout() {
+    // expected-warning@+2{{modification requires exclusive access}}
+    // expected-note@+1{{conflicting modification requires exclusive access}}
+    mutate(&self.f)
+  }
+}
+
+var global1 = StructWithMutatingMethodThatTakesSelfInout()
+func callMutatingMethodThatTakesGlobalStoredPropInout() {
+  // expected-warning@+2{{modification requires exclusive access}}
+  // expected-note@+1{{conflicting modification requires exclusive access}}
+  global1.mutate(&global1.f)
+}
+
+func violationWithGenericType<T>(_ p: T) {
+  var local = p
+  // expected-warning@+2{{modification requires exclusive access}}
+  // expected-note@+1{{conflicting modification requires exclusive access}}
+  takesTwoInouts(&local, &local)
 }

--- a/test/SILOptimizer/exclusivity_static_diagnostics.swift
+++ b/test/SILOptimizer/exclusivity_static_diagnostics.swift
@@ -48,6 +48,25 @@ func callMutatingMethodThatTakesGlobalStoredPropInout() {
   global1.mutate(&global1.f)
 }
 
+class ClassWithFinalStoredProp {
+  final var s1: StructWithMutatingMethodThatTakesSelfInout = StructWithMutatingMethodThatTakesSelfInout()
+  final var s2: StructWithMutatingMethodThatTakesSelfInout = StructWithMutatingMethodThatTakesSelfInout()
+
+  func callMutatingMethodThatTakesClassStoredPropInout() {
+    s1.mutate(&s2.f) // no-warning
+
+    // expected-warning@+2{{modification requires exclusive access}}
+    // expected-note@+1{{conflicting modification requires exclusive access}}
+    s1.mutate(&s1.f)
+
+    let local1 = self
+
+    // expected-warning@+2{{modification requires exclusive access}}
+    // expected-note@+1{{conflicting modification requires exclusive access}}
+    local1.s1.mutate(&local1.s1.f)
+  }
+}
+
 func violationWithGenericType<T>(_ p: T) {
   var local = p
   // expected-warning@+2{{modification requires exclusive access}}

--- a/test/SILOptimizer/exclusivity_static_diagnostics.swift
+++ b/test/SILOptimizer/exclusivity_static_diagnostics.swift
@@ -7,17 +7,22 @@ func takesTwoInouts<T>(_ p1: inout T, _ p2: inout T) { }
 func simpleInoutDiagnostic() {
   var i = 7
 
-  // expected-warning@+2{{modification requires exclusive access}}
-  // expected-note@+1{{conflicting modification requires exclusive access}}
+  // expected-warning@+2{{simultaneous accesses to var 'i'; modification requires exclusive access}}
+  // expected-note@+1{{conflicting access is here}}
   takesTwoInouts(&i, &i)
 }
 
+func inoutOnInoutParameter(p: inout Int) {
+  // expected-warning@+2{{simultaneous accesses to parameter 'p'; modification requires exclusive access}}
+  // expected-note@+1{{conflicting access is here}}
+  takesTwoInouts(&p, &p)
+}
 
 func swapNoSuppression(_ i: Int, _ j: Int) {
   var a: [Int] = [1, 2, 3]
 
-  // expected-warning@+2{{modification requires exclusive access}}
-  // expected-note@+1{{conflicting modification requires exclusive access}}
+  // expected-warning@+2{{simultaneous accesses to var 'a'; modification requires exclusive access}}
+  // expected-note@+1{{conflicting access is here}}
   swap(&a[i], &a[j]) // no-warning
 }
 
@@ -29,23 +34,23 @@ struct StructWithMutatingMethodThatTakesSelfInout {
   mutating func mutate(_ other: inout SomeClass) { }
 
   mutating func callMutatingMethodThatTakesSelfInout() {
-    // expected-warning@+2{{modification requires exclusive access}}
-    // expected-note@+1{{conflicting modification requires exclusive access}}
+    // expected-warning@+2{{simultaneous accesses to parameter 'self'; modification requires exclusive access}}
+    // expected-note@+1{{conflicting access is here}}
     mutate(&self)
   }
 
   mutating func callMutatingMethodThatTakesSelfStoredPropInout() {
-    // expected-warning@+2{{modification requires exclusive access}}
-    // expected-note@+1{{conflicting modification requires exclusive access}}
+    // expected-warning@+2{{simultaneous accesses to parameter 'self'; modification requires exclusive access}}
+    // expected-note@+1{{conflicting access is here}}
     mutate(&self.f)
   }
 }
 
-var global1 = StructWithMutatingMethodThatTakesSelfInout()
+var globalStruct1 = StructWithMutatingMethodThatTakesSelfInout()
 func callMutatingMethodThatTakesGlobalStoredPropInout() {
-  // expected-warning@+2{{modification requires exclusive access}}
-  // expected-note@+1{{conflicting modification requires exclusive access}}
-  global1.mutate(&global1.f)
+  // expected-warning@+2{{simultaneous accesses to var 'globalStruct1'; modification requires exclusive access}}
+  // expected-note@+1{{conflicting access is here}}
+  globalStruct1.mutate(&globalStruct1.f)
 }
 
 class ClassWithFinalStoredProp {
@@ -55,21 +60,21 @@ class ClassWithFinalStoredProp {
   func callMutatingMethodThatTakesClassStoredPropInout() {
     s1.mutate(&s2.f) // no-warning
 
-    // expected-warning@+2{{modification requires exclusive access}}
-    // expected-note@+1{{conflicting modification requires exclusive access}}
+    // expected-warning@+2{{simultaneous accesses to var 's1'; modification requires exclusive access}}
+    // expected-note@+1{{conflicting access is here}}
     s1.mutate(&s1.f)
 
     let local1 = self
 
-    // expected-warning@+2{{modification requires exclusive access}}
-    // expected-note@+1{{conflicting modification requires exclusive access}}
+    // expected-warning@+2{{simultaneous accesses to var 's1'; modification requires exclusive access}}
+    // expected-note@+1{{conflicting access is here}}
     local1.s1.mutate(&local1.s1.f)
   }
 }
 
 func violationWithGenericType<T>(_ p: T) {
   var local = p
-  // expected-warning@+2{{modification requires exclusive access}}
-  // expected-note@+1{{conflicting modification requires exclusive access}}
+  // expected-warning@+2{{simultaneous accesses to var 'local'; modification requires exclusive access}}
+  // expected-note@+1{{conflicting access is here}}
   takesTwoInouts(&local, &local)
 }

--- a/test/SILOptimizer/exclusivity_static_diagnostics.swift
+++ b/test/SILOptimizer/exclusivity_static_diagnostics.swift
@@ -13,36 +13,10 @@ func simpleInoutDiagnostic() {
 }
 
 
-func swapSuppression(_ i: Int, _ j: Int) {
+func swapNoSuppression(_ i: Int, _ j: Int) {
   var a: [Int] = [1, 2, 3]
 
+  // expected-warning@+2{{modification requires exclusive access}}
+  // expected-note@+1{{conflicting modification requires exclusive access}}
   swap(&a[i], &a[j]) // no-warning
-
-  // expected-warning@+2{{modification requires exclusive access}}
-  // expected-note@+1{{conflicting modification requires exclusive access}}
-  takesTwoInouts(&a[i], &a[j])
-}
-
-func missedSwapSuppression(_ i: Int, _ j: Int) {
-  var a: [Int] = [1, 2, 3]
-
-  // We don't suppress when swap() is used as a value
-  let mySwap: (inout Int, inout Int) -> () = swap
-
-  // expected-warning@+2{{modification requires exclusive access}}
-  // expected-note@+1{{conflicting modification requires exclusive access}}
-  mySwap(&a[i], &a[j])
-}
-
-func dontSuppressUserSwap(_ i: Int, _ j: Int) {
-  var a: [Int] = [1, 2, 3]
-
-  // Don't suppress on user-defined swap.
-  func swap<T>(_ p1: inout T, _ p2: inout T) {
-    return (p1, p2) = (p2, p1)
-  }
-
-  // expected-warning@+2{{modification requires exclusive access}}
-  // expected-note@+1{{conflicting modification requires exclusive access}}
-  swap(&a[i], &a[j])
 }

--- a/test/SILOptimizer/exclusivity_suppress_swap.swift
+++ b/test/SILOptimizer/exclusivity_suppress_swap.swift
@@ -1,0 +1,39 @@
+// RUN: %target-swift-frontend -enforce-exclusivity=checked -suppress-static-exclusivity-swap -emit-sil -primary-file %s -o /dev/null -verify
+
+import Swift
+
+func takesTwoInouts(_ p1: inout Int, _ p2: inout Int) { }
+
+func swapSuppression(_ i: Int, _ j: Int) {
+  var a: [Int] = [1, 2, 3]
+
+  swap(&a[i], &a[j]) // no-warning
+
+  // expected-warning@+2{{modification requires exclusive access}}
+  // expected-note@+1{{conflicting modification requires exclusive access}}
+  takesTwoInouts(&a[i], &a[j])
+}
+
+func missedSwapSuppression(_ i: Int, _ j: Int) {
+  var a: [Int] = [1, 2, 3]
+
+  // We don't suppress when swap() is used as a value
+  let mySwap: (inout Int, inout Int) -> () = swap
+
+  // expected-warning@+2{{modification requires exclusive access}}
+  // expected-note@+1{{conflicting modification requires exclusive access}}
+  mySwap(&a[i], &a[j])
+}
+
+func dontSuppressUserSwap(_ i: Int, _ j: Int) {
+  var a: [Int] = [1, 2, 3]
+
+  // Don't suppress on user-defined swap.
+  func swap<T>(_ p1: inout T, _ p2: inout T) {
+    return (p1, p2) = (p2, p1)
+  }
+
+  // expected-warning@+2{{modification requires exclusive access}}
+  // expected-note@+1{{conflicting modification requires exclusive access}}
+  swap(&a[i], &a[j])
+}

--- a/test/SILOptimizer/exclusivity_suppress_swap.swift
+++ b/test/SILOptimizer/exclusivity_suppress_swap.swift
@@ -9,8 +9,8 @@ func swapSuppression(_ i: Int, _ j: Int) {
 
   swap(&a[i], &a[j]) // no-warning
 
-  // expected-warning@+2{{modification requires exclusive access}}
-  // expected-note@+1{{conflicting modification requires exclusive access}}
+  // expected-warning@+2{{simultaneous accesses to var 'a'; modification requires exclusive access}}
+  // expected-note@+1{{conflicting access is here}}
   takesTwoInouts(&a[i], &a[j])
 }
 
@@ -20,8 +20,8 @@ func missedSwapSuppression(_ i: Int, _ j: Int) {
   // We don't suppress when swap() is used as a value
   let mySwap: (inout Int, inout Int) -> () = swap
 
-  // expected-warning@+2{{modification requires exclusive access}}
-  // expected-note@+1{{conflicting modification requires exclusive access}}
+  // expected-warning@+2{{simultaneous accesses to var 'a'; modification requires exclusive access}}
+  // expected-note@+1{{conflicting access is here}}
   mySwap(&a[i], &a[j])
 }
 
@@ -33,7 +33,7 @@ func dontSuppressUserSwap(_ i: Int, _ j: Int) {
     return (p1, p2) = (p2, p1)
   }
 
-  // expected-warning@+2{{modification requires exclusive access}}
-  // expected-note@+1{{conflicting modification requires exclusive access}}
+  // expected-warning@+2{{simultaneous accesses to var 'a'; modification requires exclusive access}}
+  // expected-note@+1{{conflicting access is here}}
   swap(&a[i], &a[j])
 }

--- a/test/Sanitizers/Inputs/tsan-uninstrumented.swift
+++ b/test/Sanitizers/Inputs/tsan-uninstrumented.swift
@@ -60,3 +60,5 @@ public var computedGlobalInUninstrumentedModule2: Int {
   get { return 0 }
   set { }
 }
+
+public func uninstrumentedBlackHole<T>(_ p: T) { }

--- a/test/Sanitizers/tsan-inout.swift
+++ b/test/Sanitizers/tsan-inout.swift
@@ -159,7 +159,7 @@ testRace(name: "InoutAccessToStoredGlobalInUninstrumentedModule",
 // the read from the global is IRGen'd to a memcpy().
 testRace(name: "ReadAndWriteToStoredGlobalInUninstrumentedModule",
         thread: { storedGlobalInUninstrumentedModule2 = 7 },
-        thread: { _ = storedGlobalInUninstrumentedModule2 } )
+        thread: { uninstrumentedBlackHole(storedGlobalInUninstrumentedModule2) } )
 // CHECK-INTERCEPTORS-ACCESSES-LABEL: Running ReadAndWriteToStoredGlobalInUninstrumentedModule
 // CHECK-INTERCEPTORS-ACCESSES: ThreadSanitizer: data race
 // CHECK-INTERCEPTORS-ACCESSES: Location is global


### PR DESCRIPTION
This PR turns on static checking of exclusivity (as warning) by default. The purpose is for bots to check compatibility