### PR TITLE
[stdlib] Speed up char iteration on ASCII strings.

### DIFF
--- a/stdlib/public/core/StringCharacterView.swift
+++ b/stdlib/public/core/StringCharacterView.swift
@@ -260,6 +260,26 @@ extension String.CharacterView : BidirectionalCollection {
     if start == end {
       return 0
     }
+
+    // Grapheme breaking is much simpler if known ASCII
+    if (_fastPath(_core.isASCII)) {
+      let asciiBuffer = _core.asciiBuffer._unsafelyUnwrappedUnchecked
+      let pos = start._position - _coreOffset
+      let CR: UInt8 = 0x0d
+      let LF: UInt8 = 0x0a
+
+      // With the exception of CR-LF, ASCII graphemes are single-scalar. Check
+      // for that one exception.
+      if _slowPath(
+        asciiBuffer[pos] == CR &&
+        pos+1 < asciiBuffer.endIndex &&
+        asciiBuffer[pos+1] == LF
+      ) {
+        return 2
+      }
+
+      return 1
+    }
     
     let startIndexUTF16 = start._position
     let graphemeClusterBreakProperty =
@@ -301,6 +321,26 @@ extension String.CharacterView : BidirectionalCollection {
     let start = unicodeScalars.startIndex
     if start == end {
       return 0
+    }
+
+    // Grapheme breaking is much simpler if known ASCII
+    if (_fastPath(_core.isASCII)) {
+      let asciiBuffer = _core.asciiBuffer._unsafelyUnwrappedUnchecked
+      let pos = start._position - _coreOffset
+      let CR: UInt8 = 0x0d
+      let LF: UInt8 = 0x0a
+
+      // With the exception of CR-LF, ASCII graphemes are single-scalar. Check
+      // for that one exception.
+      if _slowPath(
+        asciiBuffer[pos] == LF &&
+        pos-1 >= asciiBuffer.startIndex &&
+        asciiBuffer[pos-1] == CR
+      ) {
+        return 2
+      }
+
+      return 1
     }
     
     let endIndexUTF16 = end._position

--- a/stdlib/public/core/StringCharacterView.swift
+++ b/stdlib/public/core/StringCharacterView.swift
@@ -326,7 +326,10 @@ extension String.CharacterView : BidirectionalCollection {
     // Grapheme breaking is much simpler if known ASCII
     if (_fastPath(_core.isASCII)) {
       let asciiBuffer = _core.asciiBuffer._unsafelyUnwrappedUnchecked
-      let pos = start._position - _coreOffset
+      let pos = end._position - _coreOffset - 1
+      _sanityCheck(
+        pos >= asciiBuffer.startIndex,
+        "should of been caught in earlier start-of-scalars check")
       let CR: UInt8 = 0x0d
       let LF: UInt8 = 0x0a
 

--- a/stdlib/public/core/StringCharacterView.swift
+++ b/stdlib/public/core/StringCharacterView.swift
@@ -262,7 +262,8 @@ extension String.CharacterView : BidirectionalCollection {
     }
 
     // Grapheme breaking is much simpler if known ASCII
-    if (_fastPath(_core.isASCII)) {
+    if _core.isASCII {
+      _onFastPath() // Please aggressively inline
       let asciiBuffer = _core.asciiBuffer._unsafelyUnwrappedUnchecked
       let pos = start._position - _coreOffset
       let CR: UInt8 = 0x0d
@@ -324,7 +325,8 @@ extension String.CharacterView : BidirectionalCollection {
     }
 
     // Grapheme breaking is much simpler if known ASCII
-    if (_fastPath(_core.isASCII)) {
+    if _core.isASCII {
+      _onFastPath() // Please aggressively inline
       let asciiBuffer = _core.asciiBuffer._unsafelyUnwrappedUnchecked
       let pos = end._position - _coreOffset - 1
       _sanityCheck(

--- a/test/stdlib/Character.swift
+++ b/test/stdlib/Character.swift
@@ -158,6 +158,13 @@ CharacterTests.test("Hashable") {
   }
 }
 
+CharacterTests.test("CR-LF") {
+  let str = "qwerty\r\n"
+  let str_rev = "\r\nytrewq"
+  expectEqual(str.characters.count, str_rev.characters.count)
+  expectEqualSequence(str.characters.reversed(), str_rev.characters)
+}
+
 /// Test that a given `String` can be transformed into a `Character` and back
 /// without loss of information.
 func checkRoundTripThroughCharacter(_ s: String) {


### PR DESCRIPTION
By doing a fast check for CR-LF, we can speed up forwards and
backwards character iteration on ASCII strings by ~2-3x. This speedup
can be seen in the stringTests suite (previous PR).

It is done as a fast path inside of
_measureExtendedGraphemeClusterForward/Backward, which is never
inlined. Doing the fast path inline would yield even more dramatic
improvements, and might be an area for future exploration, but would
slightly pessimize non-ASCII strings due to code bloat. Additionally,
the current implementation has not been micro-optimized yet. It's
possible that more optimal code would be smaller and have less of an
impact on the general case.

<!-- What's in this pull request? -->
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
