### PR TITLE
[WIP] Mangle imported declarations using their C names

### DIFF
--- a/include/swift/AST/ASTPrinter.h
+++ b/include/swift/AST/ASTPrinter.h
@@ -178,6 +178,13 @@ public:
 
   ASTPrinter &operator<<(DeclName name);
 
+  // Special case for 'char', but not arbitrary things that convert to 'char'.
+  template <typename T>
+  typename std::enable_if<std::is_same<T, char>::value, ASTPrinter &>::type
+  operator<<(T c) {
+    return *this << StringRef(&c, 1);
+  }
+
   void printKeyword(StringRef name) {
     callPrintNamePre(PrintNameContext::Keyword);
     *this << name;

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -342,6 +342,19 @@ struct PrintOptions {
 
   bool PrintAsMember = false;
 
+  /// \see ShouldQualifyNestedDeclarations
+  enum class QualifyNestedDeclarations {
+    Never,
+    TypesOnly,
+    Always
+  };
+
+  /// Controls when a nested declaration's name should be printed qualified with
+  /// its enclosing context, if it's being printed on its own (rather than as
+  /// part of the context).
+  QualifyNestedDeclarations ShouldQualifyNestedDeclarations =
+      QualifyNestedDeclarations::Never;
+
   /// \brief If this is not \c nullptr then functions (including accessors and
   /// constructors) will be printed with a body that is determined by this
   /// function.
@@ -386,6 +399,8 @@ struct PrintOptions {
     result.PrintOverrideKeyword = false;
     result.AccessibilityFilter = Accessibility::Public;
     result.PrintIfConfig = false;
+    result.ShouldQualifyNestedDeclarations =
+        QualifyNestedDeclarations::TypesOnly;
     return result;
   }
 
@@ -400,6 +415,8 @@ struct PrintOptions {
     result.ExcludeAttrList.push_back(DAK_DiscardableResult);
     result.EmptyLineBetweenMembers = true;
     result.ElevateDocCommentFromConformance = true;
+    result.ShouldQualifyNestedDeclarations =
+        QualifyNestedDeclarations::Always;
     return result;
   }
 
@@ -486,6 +503,7 @@ struct PrintOptions {
     PO.ExcludeAttrList.push_back(DAK_Available);
     PO.SkipPrivateStdlibDecls = true;
     PO.ExplodeEnumCaseDecls = true;
+    PO.ShouldQualifyNestedDeclarations = QualifyNestedDeclarations::TypesOnly;
     return PO;
   }
 };

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -56,8 +56,20 @@ class IRGenOptions;
 class LazyResolver;
 class ModuleDecl;
 class NominalTypeDecl;
+class TypeDecl;
 class VisibleDeclConsumer;
 enum class SelectorSplitKind;
+
+/// Represents the different namespaces for types in C.
+///
+/// A simplified version of clang::Sema::LookupKind.
+enum class ClangTypeKind {
+  Typedef,
+  ObjCClass = Typedef,
+  /// Structs, enums, and unions.
+  Tag,
+  ObjCProtocol,
+};
 
 /// \brief Class that imports Clang modules into Swift, mapping directly
 /// from Clang ASTs over to Swift ASTs.
@@ -135,6 +147,14 @@ public:
   ///
   /// \param name The name we're searching for.
   void lookupValue(DeclName name, VisibleDeclConsumer &consumer);
+
+  /// Look up a type declaration by its Clang name.
+  ///
+  /// Note that this method does no filtering. If it finds the type in a loaded
+  /// module, it returns it. This is intended for use in reflection / debugging
+  /// contexts where access is not a problem.
+  void lookupTypeDecl(StringRef clangName, ClangTypeKind kind,
+                      llvm::function_ref<void(TypeDecl*)> receiver);
 
   /// Look for textually included declarations from the bridging header.
   ///

--- a/include/swift/Demangling/Demangler.h
+++ b/include/swift/Demangling/Demangler.h
@@ -403,7 +403,7 @@ private:
   NodePointer popModule();
   NodePointer popContext();
   NodePointer popTypeAndGetChild();
-  NodePointer popTypeAndGetNominal();
+  NodePointer popTypeAndGetAnyGeneric();
   NodePointer demangleBuiltinType();
   NodePointer demangleAnyGenericType(Node::Kind kind);
   NodePointer demangleExtensionContext();

--- a/include/swift/Reflection/TypeRef.h
+++ b/include/swift/Reflection/TypeRef.h
@@ -224,6 +224,7 @@ public:
   bool isStruct() const;
   bool isEnum() const;
   bool isClass() const;
+  bool isAlias() const;
 
   const TypeRef *getParent() const {
     return Parent;

--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -57,7 +57,9 @@ class TypeDecoder {
       return decodeMangledType(Node->getChild(0));
     case NodeKind::Class:
     case NodeKind::Enum:
-    case NodeKind::Structure: {
+    case NodeKind::Structure:
+    case NodeKind::TypeAlias: // This can show up for imported Clang decls.
+    {
       BuiltNominalTypeDecl typeDecl = BuiltNominalTypeDecl();
       BuiltType parent = BuiltType();
       if (!decodeMangledNominalType(Node, typeDecl, parent))

--- a/include/swift/Strings.h
+++ b/include/swift/Strings.h
@@ -39,9 +39,9 @@ namespace swift {
   static const char LLDB_EXPRESSIONS_MODULE_NAME_PREFIX[] = "__lldb_expr_";
 
   /// The name of the fake module used to hold imported Objective-C things.
-  static const char MANGLING_MODULE_OBJC[] = "__ObjC";
-  /// The name of the fake module used to hold imported C things.
-  static const char MANGLING_MODULE_C[] = "__C";
+  static const char MANGLING_MODULE_OBJC[] = "__C";
+  /// The name of the fake module used to hold synthesized ClangImporter things.
+  static const char MANGLING_MODULE_CLANG_IMPORTER[] = "__C_Synthesized";
 } // end namespace swift
 
 #endif // SWIFT_STRINGS_H

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -1022,8 +1022,7 @@ void ASTMangler::appendImplFunctionType(SILFunctionType *fn) {
 /// Mangle the context of the given declaration as a <context.
 /// This is the top-level entrypoint for mangling <context>.
 void ASTMangler::appendContextOf(const ValueDecl *decl) {
-  // Declarations provided provided by a C module have a special context
-  // mangling.
+  // Declarations imported from C have a special context mangling.
   //   known-context ::= 'So'
   //
   // Also handle top-level imported declarations that don't have corresponding
@@ -1038,6 +1037,12 @@ void ASTMangler::appendContextOf(const ValueDecl *decl) {
       return appendOperator("SC");
     }
   }
+
+  // Nested types imported from C should also get use the special "So" context.
+  if (isa<TypeDecl>(decl))
+    if (auto *clangDecl = decl->getClangDecl())
+      if (clangDecl->getDeclContext()->isTranslationUnit())
+        return appendOperator("So");
 
   // Just mangle the decl's DC.
   appendContext(decl->getDeclContext());
@@ -1267,28 +1272,53 @@ void ASTMangler::appendAnyGenericType(const GenericTypeDecl *decl) {
     return;
 
   appendContextOf(decl);
-  appendDeclName(decl);
 
-  switch (decl->getKind()) {
-  default:
-    llvm_unreachable("not a nominal type");
+  // Always use Clang names for imported Clang declarations.
+  auto *clangDecl = dyn_cast_or_null<clang::TypeDecl>(decl->getClangDecl());
+  if (clangDecl && !clangDecl->getName().empty()) {
+    appendIdentifier(clangDecl->getName());
+    // The important distinctions to maintain here are Objective-C's various
+    // namespaces: protocols, tags (struct/enum/union), and unqualified names.
+    // We continue to mangle "class" the standard Swift way because it feels
+    // weird to call that an alias, but they're really in the same namespace.
+    if (isa<clang::ObjCInterfaceDecl>(clangDecl)) {
+      appendOperator("C");
+    } else if (isa<clang::ObjCProtocolDecl>(clangDecl)) {
+      appendOperator("P");
+    } else if (isa<clang::TagDecl>(clangDecl)) {
+      // Note: This includes enums, but that's okay. A Clang enum is not always
+      // imported as a Swift enum.
+      appendOperator("V");
+    } else if (isa<clang::TypedefNameDecl>(clangDecl)) {
+      appendOperator("a");
+    } else {
+      llvm_unreachable("unknown imported Clang type");
+    }
+  } else {
+    appendDeclName(decl);
 
-  case DeclKind::TypeAlias:
-    appendOperator("a");
-    break;
-  case DeclKind::Protocol:
-    appendOperator("P");
-    break;
-  case DeclKind::Class:
-    appendOperator("C");
-    break;
-  case DeclKind::Enum:
-    appendOperator("O");
-    break;
-  case DeclKind::Struct:
-    appendOperator("V");
-    break;
+    switch (decl->getKind()) {
+    default:
+      llvm_unreachable("not a nominal type");
+
+    case DeclKind::TypeAlias:
+      appendOperator("a");
+      break;
+    case DeclKind::Protocol:
+      appendOperator("P");
+      break;
+    case DeclKind::Class:
+      appendOperator("C");
+      break;
+    case DeclKind::Enum:
+      appendOperator("O");
+      break;
+    case DeclKind::Struct:
+      appendOperator("V");
+      break;
+    }
   }
+
   addSubstitution(key.getPointer());
 }
 

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -1022,28 +1022,21 @@ void ASTMangler::appendImplFunctionType(SILFunctionType *fn) {
 /// Mangle the context of the given declaration as a <context.
 /// This is the top-level entrypoint for mangling <context>.
 void ASTMangler::appendContextOf(const ValueDecl *decl) {
-  auto clangDecl = decl->getClangDecl();
-
-  // Classes and protocols implemented in Objective-C have a special context
+  // Declarations provided provided by a C module have a special context
   // mangling.
   //   known-context ::= 'So'
-  if (isa<ClassDecl>(decl) && clangDecl) {
-    assert(isa<clang::ObjCInterfaceDecl>(clangDecl) ||
-           isa<clang::TypedefDecl>(clangDecl));
-    return appendOperator("So");
-  }
-  
-  if (isa<ProtocolDecl>(decl) && clangDecl) {
-    assert(isa<clang::ObjCProtocolDecl>(clangDecl));
-    return appendOperator("So");
-  }
-
-  // Declarations provided by a C module have a special context mangling.
+  //
+  // Also handle top-level imported declarations that don't have corresponding
+  // Clang decls. Check getKind() directly to avoid a layering dependency.
   //   known-context ::= 'SC'
-  // Do a dance to avoid a layering dependency.
   if (auto file = dyn_cast<FileUnit>(decl->getDeclContext())) {
-    if (file->getKind() == FileUnitKind::ClangModule)
+    if (file->getKind() == FileUnitKind::ClangModule) {
+      // FIXME: Import-as-member Clang decls should appear under 'So' as well,
+      // rather than under their current parent.
+      if (decl->getClangDecl())
+        return appendOperator("So");
       return appendOperator("SC");
+    }
   }
 
   // Just mangle the decl's DC.
@@ -1241,7 +1234,7 @@ void ASTMangler::appendModule(const ModuleDecl *module) {
   StringRef ModName = module->getName().str();
   if (ModName == MANGLING_MODULE_OBJC)
     return appendOperator("So");
-  if (ModName == MANGLING_MODULE_C)
+  if (ModName == MANGLING_MODULE_CLANG_IMPORTER)
     return appendOperator("SC");
 
   appendIdentifier(ModName);

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -884,8 +884,11 @@ void NominalTypeDecl::prepareConformanceTable() const {
 
   // If this type declaration was not parsed from source code or introduced
   // via the Clang importer, don't add any synthesized conformances.
-  if (!getParentSourceFile() && !hasClangNode())
+  auto *file = cast<FileUnit>(getModuleScopeContext());
+  if (file->getKind() != FileUnitKind::Source &&
+      file->getKind() != FileUnitKind::ClangModule) {
     return;
+  }
 
   // Add any synthesized conformances.
   if (isa<ClassDecl>(this)) {

--- a/lib/AST/USRGeneration.cpp
+++ b/lib/AST/USRGeneration.cpp
@@ -164,15 +164,12 @@ bool ide::printDeclUSR(const ValueDecl *D, raw_ostream &OS) {
       //     static var errSecond: MyError.Code { get }
       // }
       //
-      // The clang enum and enum constants are associated with both the
-      // struct/nested enum, and the static vars/enum cases.
+      // The clang enum constants are associated with both the static vars and
+      // the enum cases.
       // But we want unique USRs for the above symbols, so use the clang USR
-      // for the enum and enum cases, and the Swift USR for the struct and vars.
+      // for the enum cases, and the Swift USR for the vars.
       //
-      if (isa<clang::EnumDecl>(ClangD)) {
-        if (ClangD->hasAttr<clang::NSErrorDomainAttr>() && isa<StructDecl>(D))
-          return ClangNode();
-      } else if (auto *ClangEnumConst = dyn_cast<clang::EnumConstantDecl>(ClangD)) {
+      if (auto *ClangEnumConst = dyn_cast<clang::EnumConstantDecl>(ClangD)) {
         if (auto *ClangEnum = dyn_cast<clang::EnumDecl>(ClangEnumConst->getDeclContext())) {
           if (ClangEnum->hasAttr<clang::NSErrorDomainAttr>() && isa<VarDecl>(D))
             return ClangNode();

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -505,7 +505,7 @@ NodePointer Demangler::demangleStandardSubstitution() {
     case 'o':
       return createNode(Node::Kind::Module, MANGLING_MODULE_OBJC);
     case 'C':
-      return createNode(Node::Kind::Module, MANGLING_MODULE_C);
+      return createNode(Node::Kind::Module, MANGLING_MODULE_CLANG_IMPORTER);
     case 'g': {
       NodePointer OptionalTy =
         createType(createWithChildren(Node::Kind::BoundGenericEnum,

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -62,12 +62,13 @@ static bool isContext(Node::Kind kind) {
   }
 }
 
-static bool isNominal(Node::Kind kind) {
+static bool isAnyGeneric(Node::Kind kind) {
   switch (kind) {
     case Node::Kind::Structure:
     case Node::Kind::Class:
     case Node::Kind::Enum:
     case Node::Kind::Protocol:
+    case Node::Kind::TypeAlias:
       return true;
     default:
       return false;
@@ -683,9 +684,9 @@ NodePointer Demangler::popTypeAndGetChild() {
   return Ty->getFirstChild();
 }
 
-NodePointer Demangler::popTypeAndGetNominal() {
+NodePointer Demangler::popTypeAndGetAnyGeneric() {
   NodePointer Child = popTypeAndGetChild();
-  if (Child && isNominal(Child->getKind()))
+  if (Child && isAnyGeneric(Child->getKind()))
     return Child;
   return nullptr;
 }
@@ -770,7 +771,7 @@ NodePointer Demangler::demangleAnyGenericType(Node::Kind kind) {
 NodePointer Demangler::demangleExtensionContext() {
   NodePointer GenSig = popNode(Node::Kind::DependentGenericSignature);
   NodePointer Module = popModule();
-  NodePointer Type = popTypeAndGetNominal();
+  NodePointer Type = popTypeAndGetAnyGeneric();
   NodePointer Ext = createWithChildren(Node::Kind::Extension, Module, Type);
   if (GenSig)
     Ext = addChild(Ext, GenSig);
@@ -874,7 +875,7 @@ NodePointer Demangler::demangleBoundGenericType() {
     if (!popNode(Node::Kind::FirstElementMarker))
       return nullptr;
   }
-  NodePointer Nominal = popTypeAndGetNominal();
+  NodePointer Nominal = popTypeAndGetAnyGeneric();
   NodePointer NTy = createType(demangleBoundGenericArgs(Nominal, TypeListList, 0));
   addSubstitution(NTy);
   return NTy;
@@ -1064,7 +1065,7 @@ NodePointer Demangler::demangleMetatype() {
                              popProtocolConformance());
     case 'C': {
       NodePointer Ty = popNode(Node::Kind::Type);
-      if (!Ty || !isNominal(Ty->getChild(0)->getKind()))
+      if (!Ty || !isAnyGeneric(Ty->getChild(0)->getKind()))
         return nullptr;
       return createWithChild(Node::Kind::ReflectionMetadataSuperclassDescriptor,
                              Ty->getChild(0));

--- a/lib/Demangling/OldDemangler.cpp
+++ b/lib/Demangling/OldDemangler.cpp
@@ -863,7 +863,8 @@ private:
     if (Mangled.nextIf('o'))
       return Factory.createNode(Node::Kind::Module, MANGLING_MODULE_OBJC);
     if (Mangled.nextIf('C'))
-      return Factory.createNode(Node::Kind::Module, MANGLING_MODULE_C);
+      return Factory.createNode(Node::Kind::Module,
+                                MANGLING_MODULE_CLANG_IMPORTER);
     if (Mangled.nextIf('a'))
       return createSwiftType(Node::Kind::Structure, "Array");
     if (Mangled.nextIf('b'))

--- a/lib/Demangling/Remangler.cpp
+++ b/lib/Demangling/Remangler.cpp
@@ -1290,7 +1290,7 @@ void Remangler::mangleModule(Node *node) {
     Buffer << 's';
   } else if (node->getText() == MANGLING_MODULE_OBJC) {
     Buffer << "So";
-  } else if (node->getText() == MANGLING_MODULE_C) {
+  } else if (node->getText() == MANGLING_MODULE_CLANG_IMPORTER) {
     Buffer << "SC";
   } else {
     mangleIdentifier(node);

--- a/lib/IDE/CommentConversion.cpp
+++ b/lib/IDE/CommentConversion.cpp
@@ -344,6 +344,8 @@ void CommentToXMLConverter::visitDocComment(const DocComment *DC) {
     PO.PrintDocumentationComments = false;
     PO.TypeDefinitions = false;
     PO.VarInitializers = false;
+    PO.ShouldQualifyNestedDeclarations =
+        PrintOptions::QualifyNestedDeclarations::TypesOnly;
 
     OS << "<Declaration>";
     llvm::SmallString<32> DeclSS;

--- a/lib/IDE/TypeReconstruction.cpp
+++ b/lib/IDE/TypeReconstruction.cpp
@@ -100,7 +100,7 @@ public:
     assert(!module_name.empty());
     static ConstString g_ObjectiveCModule(MANGLING_MODULE_OBJC);
     static ConstString g_BuiltinModule("Builtin");
-    static ConstString g_CModule(MANGLING_MODULE_C);
+    static ConstString g_CModule(MANGLING_MODULE_CLANG_IMPORTER);
     if (allow_crawler) {
       if (module_name == g_ObjectiveCModule || module_name == g_CModule)
         return DeclsLookupSource(&ast, module_name);

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -2143,7 +2143,7 @@ getTypeEntityInfo(IRGenModule &IGM, CanType conformingType) {
     }
   } else {
     // Metadata for Clang types should be uniqued like foreign classes.
-    if (nom->hasClangNode()) {
+    if (isa<ClangModuleUnit>(nom->getModuleScopeContext())) {
       typeKind = TypeMetadataRecordKind::NonuniqueDirectType;
       entity = LinkEntity::forForeignTypeMetadataCandidate(conformingType);
       defaultTy = IGM.TypeMetadataStructTy;
@@ -2662,9 +2662,8 @@ ConstantReference IRGenModule::getAddrOfTypeMetadata(CanType concreteType,
               "foreign candidate");
     defaultVarTy = TypeMetadataStructTy;
     adjustmentIndex = 0;
-  } else if (concreteType->getAnyNominal()) {
-    auto nom = concreteType->getNominalOrBoundGenericNominal();
-    assert((!nom || !nom->hasClangNode())
+  } else if (auto nom = concreteType->getAnyNominal()) {
+    assert(!isa<ClangModuleUnit>(nom->getModuleScopeContext())
            && "metadata for foreign type should be emitted as "
               "foreign candidate");
     (void)nom;

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -22,6 +22,7 @@
 #include "swift/AST/IRGenOptions.h"
 #include "swift/AST/SubstitutionMap.h"
 #include "swift/AST/Types.h"
+#include "swift/ClangImporter/ClangModule.h"
 #include "swift/IRGen/Linking.h"
 #include "swift/Runtime/Metadata.h"
 #include "swift/SIL/FormalLinkage.h"
@@ -442,7 +443,7 @@ bool irgen::isTypeMetadataAccessTrivial(IRGenModule &IGM, CanType type) {
     auto nominalType = cast<NominalType>(type);
 
     // Imported type metadata always requires an accessor.
-    if (nominalType->getDecl()->hasClangNode())
+    if (isa<ClangModuleUnit>(nominalType->getDecl()->getModuleScopeContext()))
       return false;
 
     // Metadata with a non-trivial parent node always requires an accessor.
@@ -1310,7 +1311,8 @@ static llvm::Value *emitTypeMetadataAccessFunctionBody(IRGenFunction &IGF,
     return emitDirectTypeMetadataRef(IGF, type);
 
   if (typeDecl->isGenericContext() &&
-      !(isa<ClassDecl>(typeDecl) && typeDecl->hasClangNode())) {
+      !(isa<ClassDecl>(typeDecl) &&
+        isa<ClangModuleUnit>(typeDecl->getModuleScopeContext()))) {
     // This is a metadata accessor for a fully substituted generic type.
     return emitDirectTypeMetadataRef(IGF, type);
   }
@@ -1341,7 +1343,7 @@ static llvm::Value *emitTypeMetadataAccessFunctionBody(IRGenFunction &IGF,
     }
 
   // Imported value types require foreign metadata uniquing.
-  } else if (typeDecl->hasClangNode()) {
+  } else if (isa<ClangModuleUnit>(typeDecl->getModuleScopeContext())) {
     return emitForeignTypeMetadataRef(IGF, type);
   }
 
@@ -5437,7 +5439,7 @@ IRGenModule::getAddrOfForeignTypeMetadataCandidate(CanType type) {
     addressPoint = builder.getOffsetOfAddressPoint();
   } else if (auto structType = dyn_cast<StructType>(type)) {
     auto structDecl = structType->getDecl();
-    assert(structDecl->hasClangNode());
+    assert(isa<ClangModuleUnit>(structDecl->getModuleScopeContext()));
     
     ForeignStructMetadataBuilder builder(*this, structDecl, init);
     builder.layout();

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -33,6 +33,7 @@
 #include "swift/AST/Decl.h"
 #include "swift/AST/IRGenOptions.h"
 #include "swift/AST/SubstitutionMap.h"
+#include "swift/ClangImporter/ClangModule.h"
 #include "swift/IRGen/Linking.h"
 #include "swift/SIL/SILDeclRef.h"
 #include "swift/SIL/SILModule.h"
@@ -1734,7 +1735,7 @@ void IRGenModule::emitSILWitnessTable(SILWitnessTable *wt) {
     if (ClassDecl *clas = dyn_cast<ClassDecl>(Nominal)) {
       if (clas->isForeign())
         getAddrOfForeignTypeMetadataCandidate(conformingType);
-    } else if (Nominal->hasClangNode()) {
+    } else if (isa<ClangModuleUnit>(Nominal->getModuleScopeContext())) {
       getAddrOfForeignTypeMetadataCandidate(conformingType);
     }
   }

--- a/lib/Migrator/CMakeLists.txt
+++ b/lib/Migrator/CMakeLists.txt
@@ -27,7 +27,7 @@ endforeach()
 list(APPEND outputs "${output_dir}")
 
 add_custom_target("symlink_migrator_data"
-    DEPENDS "${outputs}"
+    DEPENDS "${output_dir}" "${outputs}"
     COMMENT "Symlinking migrator data to ${output_dir}")
 
 swift_install_in_component(compiler

--- a/lib/RemoteAST/CMakeLists.txt
+++ b/lib/RemoteAST/CMakeLists.txt
@@ -1,5 +1,19 @@
+if(XCODE)
+  file(GLOB_RECURSE REMOTE_LIB_HEADERS
+    ${SWIFT_SOURCE_DIR}/include/swift/Remote/*.h
+    ${SWIFT_SOURCE_DIR}/include/swift/Remote/*.def)
+
+  set_source_files_properties(${REMOTE_LIB_HEADERS}
+    PROPERTIES
+    HEADER_FILE_ONLY true)
+  source_group("libRemote Headers" FILES ${REMOTE_LIB_HEADERS})
+else()
+  set(REMOTE_LIB_HEADERS)
+endif()
+
 add_swift_library(swiftRemoteAST STATIC
   RemoteAST.cpp
   InProcessMemoryReader.cpp
+  ${REMOTE_LIB_HEADERS}
   LINK_LIBRARIES
     swiftSema swiftIRGen)

--- a/lib/RemoteAST/RemoteAST.cpp
+++ b/lib/RemoteAST/RemoteAST.cpp
@@ -25,6 +25,7 @@
 #include "swift/AST/Types.h"
 #include "swift/Basic/Mangler.h"
 #include "swift/ClangImporter/ClangImporter.h"
+#include "llvm/ADT/StringSwitch.h"
 
 // TODO: Develop a proper interface for this.
 #include "swift/AST/IRGenOptions.h"
@@ -375,7 +376,8 @@ public:
   Type createObjCClassType(StringRef name) {
     Identifier ident = Ctx.getIdentifier(name);
     auto typeDecl =
-      findForeignNominalTypeDecl(ident, Demangle::Node::Kind::Class);
+        findForeignNominalTypeDecl(ident, ForeignModuleKind::Imported,
+                                   Demangle::Node::Kind::Class);
     if (!typeDecl) return Type();
     return createNominalType(typeDecl, /*parent*/ Type());
   }
@@ -418,13 +420,21 @@ private:
   DeclContext *findDeclContext(const Demangle::NodePointer &node);
   ModuleDecl *findModule(const Demangle::NodePointer &node);
   Demangle::NodePointer findModuleNode(const Demangle::NodePointer &node);
-  bool isForeignModule(const Demangle::NodePointer &node);
+
+  enum class ForeignModuleKind {
+    Imported,
+    SynthesizedByImporter
+  };
+
+  Optional<ForeignModuleKind>
+  getForeignModuleKind(const Demangle::NodePointer &node);
 
   NominalTypeDecl *findNominalTypeDecl(DeclContext *dc,
                                        Identifier name,
                                        Identifier privateDiscriminator,
                                        Demangle::Node::Kind kind);
   NominalTypeDecl *findForeignNominalTypeDecl(Identifier name,
+                                              ForeignModuleKind lookupKind,
                                               Demangle::Node::Kind kind);
 
   Type checkTypeRepr(TypeRepr *repr) {
@@ -514,15 +524,19 @@ RemoteASTTypeBuilder::findModuleNode(const Demangle::NodePointer &node) {
   return findModuleNode(child->getFirstChild());
 }
 
-bool RemoteASTTypeBuilder::isForeignModule(const Demangle::NodePointer &node) {
+Optional<RemoteASTTypeBuilder::ForeignModuleKind>
+RemoteASTTypeBuilder::getForeignModuleKind(const Demangle::NodePointer &node) {
   if (node->getKind() == Demangle::Node::Kind::DeclContext)
-    return isForeignModule(node->getFirstChild());
+    return getForeignModuleKind(node->getFirstChild());
 
   if (node->getKind() != Demangle::Node::Kind::Module)
-    return false;
+    return None;
 
-  return (node->getText() == MANGLING_MODULE_OBJC ||
-          node->getText() == MANGLING_MODULE_CLANG_IMPORTER);
+  return llvm::StringSwitch<Optional<ForeignModuleKind>>(node->getText())
+      .Case(MANGLING_MODULE_OBJC, ForeignModuleKind::Imported)
+      .Case(MANGLING_MODULE_CLANG_IMPORTER,
+            ForeignModuleKind::SynthesizedByImporter)
+      .Default(None);
 }
 
 DeclContext *
@@ -538,7 +552,8 @@ RemoteASTTypeBuilder::findDeclContext(const Demangle::NodePointer &node) {
   case Demangle::Node::Kind::Class:
   case Demangle::Node::Kind::Enum:
   case Demangle::Node::Kind::Protocol:
-  case Demangle::Node::Kind::Structure: {
+  case Demangle::Node::Kind::Structure:
+  case Demangle::Node::Kind::TypeAlias: {
     const auto &declNameNode = node->getChild(1);
 
     // Handle local declarations.
@@ -576,12 +591,13 @@ RemoteASTTypeBuilder::findDeclContext(const Demangle::NodePointer &node) {
     DeclContext *dc = findDeclContext(node->getChild(0));
     if (!dc) {
       // Do some backup logic for foreign type declarations.
-      if (privateDiscriminator.empty() &&
-          isForeignModule(node->getChild(0))) {
-        return findForeignNominalTypeDecl(name, node->getKind());
-      } else {
-        return nullptr;
+      if (privateDiscriminator.empty()) {
+        if (auto foreignModuleKind = getForeignModuleKind(node->getChild(0))) {
+          return findForeignNominalTypeDecl(name, foreignModuleKind.getValue(),
+                                            node->getKind());
+        }
       }
+      return nullptr;
     }
 
     return findNominalTypeDecl(dc, name, privateDiscriminator, node->getKind());
@@ -628,6 +644,7 @@ RemoteASTTypeBuilder::findNominalTypeDecl(DeclContext *dc,
 
 NominalTypeDecl *
 RemoteASTTypeBuilder::findForeignNominalTypeDecl(Identifier name,
+                                                 ForeignModuleKind foreignKind,
                                                  Demangle::Node::Kind kind) {
   // Check to see if we have an importer loaded.
   auto importer = static_cast<ClangImporter *>(Ctx.getClangModuleLoader());
@@ -643,11 +660,9 @@ RemoteASTTypeBuilder::findForeignNominalTypeDecl(Identifier name,
 
     void foundDecl(ValueDecl *decl, DeclVisibilityKind reason) override {
       if (HadError) return;
-      auto typeDecl = getAcceptableNominalTypeCandidate(decl, ExpectedKind);
-      if (!typeDecl) return;
-      if (typeDecl == Result) return;
+      if (decl == Result) return;
       if (!Result) {
-        Result = typeDecl;
+        Result = cast<NominalTypeDecl>(decl);
       } else {
         HadError = true;
         Result = nullptr;
@@ -655,7 +670,36 @@ RemoteASTTypeBuilder::findForeignNominalTypeDecl(Identifier name,
     }
   } consumer(kind);
 
-  importer->lookupValue(name, consumer);
+  switch (foreignKind) {
+  case ForeignModuleKind::SynthesizedByImporter:
+    importer->lookupValue(name, consumer);
+    if (consumer.Result)
+      consumer.Result = getAcceptableNominalTypeCandidate(consumer.Result,kind);
+    break;
+  case ForeignModuleKind::Imported: {
+    ClangTypeKind lookupKind;
+    switch (kind) {
+    case Demangle::Node::Kind::Protocol:
+      lookupKind = ClangTypeKind::ObjCProtocol;
+      break;
+    case Demangle::Node::Kind::Class:
+      lookupKind = ClangTypeKind::ObjCClass;
+      break;
+    case Demangle::Node::Kind::TypeAlias:
+      lookupKind = ClangTypeKind::Typedef;
+      break;
+    case Demangle::Node::Kind::Structure:
+    case Demangle::Node::Kind::Enum:
+      lookupKind = ClangTypeKind::Tag;
+      break;
+    default:
+      return nullptr;
+    }
+    importer->lookupTypeDecl(name.str(), lookupKind, [&](TypeDecl *found) {
+      consumer.foundDecl(found, DeclVisibilityKind::VisibleAtTopLevel);
+    });
+  }
+  }
 
   return consumer.Result;
 }

--- a/lib/RemoteAST/RemoteAST.cpp
+++ b/lib/RemoteAST/RemoteAST.cpp
@@ -16,6 +16,7 @@
 
 #include "swift/RemoteAST/RemoteAST.h"
 #include "swift/Remote/MetadataReader.h"
+#include "swift/Strings.h"
 #include "swift/Subsystems.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/Decl.h"
@@ -520,7 +521,8 @@ bool RemoteASTTypeBuilder::isForeignModule(const Demangle::NodePointer &node) {
   if (node->getKind() != Demangle::Node::Kind::Module)
     return false;
 
-  return (node->getText() == "__ObjC");
+  return (node->getText() == MANGLING_MODULE_OBJC ||
+          node->getText() == MANGLING_MODULE_CLANG_IMPORTER);
 }
 
 DeclContext *

--- a/lib/SIL/SILFunction.cpp
+++ b/lib/SIL/SILFunction.cpp
@@ -16,6 +16,7 @@
 #include "swift/SIL/SILInstruction.h"
 #include "swift/SIL/SILArgument.h"
 #include "swift/SIL/CFG.h"
+#include "swift/SIL/PrettyStackTrace.h"
 #include "swift/AST/GenericEnvironment.h"
 #include "llvm/ADT/Optional.h"
 #include "llvm/Support/CommandLine.h"
@@ -64,6 +65,7 @@ SILFunction *SILFunction::create(
   llvm::StringMapEntry<SILFunction*> *entry = nullptr;
   if (!name.empty()) {
     entry = &*M.FunctionTable.insert(std::make_pair(name, nullptr)).first;
+    PrettyStackTraceSILFunction trace("creating", entry->getValue());
     assert(!entry->getValue() && "function already exists");
     name = entry->getKey();
   }

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -25,6 +25,7 @@
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/Basic/Defer.h"
+#include "swift/ClangImporter/ClangModule.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringExtras.h"
 using namespace swift;
@@ -242,11 +243,9 @@ bool needsToBeRegisteredAsExternalDecl(AbstractStorageDecl *storage) {
   if (storage->hasClangNode())
     return true;
 
-  // ...or it was synthesized into an imported type.
-  auto nominal = dyn_cast<NominalTypeDecl>(storage->getDeclContext());
-  if (!nominal)
-    return false;
-  return nominal->hasClangNode();
+  // ...or it was synthesized into an imported context.
+  const DeclContext *dc = storage->getDeclContext();
+  return isa<ClangModuleUnit>(dc->getModuleScopeContext());
 }
 
 /// Mark the accessor as transparent if we can.

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -17,6 +17,7 @@
 #include "swift/AST/Pattern.h"
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/Types.h"
+#include "swift/ClangImporter/ClangModule.h"
 #include "DerivedConformances.h"
 
 using namespace swift;
@@ -148,7 +149,7 @@ FuncDecl *DerivedConformance::declareDerivedPropertyGetter(TypeChecker &tc,
   // If the enum was not imported, the derived conformance is either from the
   // enum itself or an extension, in which case we will emit the declaration
   // normally.
-  if (parentDecl->hasClangNode())
+  if (isa<ClangModuleUnit>(parentDC->getModuleScopeContext()))
     tc.Context.addExternalDecl(getterDecl);
 
   return getterDecl;

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -35,6 +35,7 @@
 #include "swift/AST/TypeMatcher.h"
 #include "swift/AST/TypeWalker.h"
 #include "swift/Basic/Defer.h"
+#include "swift/ClangImporter/ClangModule.h"
 #include "swift/Sema/IDETypeChecking.h"
 #include "llvm/ADT/ScopedHashTable.h"
 #include "llvm/ADT/SmallString.h"
@@ -5727,12 +5728,13 @@ static void diagnosePotentialWitness(TypeChecker &tc,
 
 void TypeChecker::checkConformancesInContext(DeclContext *dc,
                                              IterableDeclContext *idc) {
+  // For anything imported from Clang, lazily check conformances.
+  if (isa<ClangModuleUnit>(dc->getModuleScopeContext()))
+    return;
+
   // Determine the accessibility of this conformance.
   Accessibility defaultAccessibility;
   if (auto ext = dyn_cast<ExtensionDecl>(dc)) {
-    // For anything with a Clang node, lazily check conformances.
-    if (ext->hasClangNode()) return;
-
     Type extendedTy = ext->getExtendedType();
     if (!extendedTy)
       return;
@@ -5741,11 +5743,7 @@ void TypeChecker::checkConformancesInContext(DeclContext *dc,
       return;
     defaultAccessibility = nominal->getFormalAccess();
   } else {
-    // For anything with a Clang node, lazily check conformances.
-    auto nominal = cast<NominalTypeDecl>(dc);
-    if (nominal->hasClangNode()) return;
-
-    defaultAccessibility = nominal->getFormalAccess();
+    defaultAccessibility = cast<NominalTypeDecl>(dc)->getFormalAccess();
   }
 
   ReferencedNameTracker *tracker = nullptr;

--- a/stdlib/public/Reflection/TypeRef.cpp
+++ b/stdlib/public/Reflection/TypeRef.cpp
@@ -72,6 +72,8 @@ public:
       printHeader("enum");
     else if (N->isClass())
       printHeader("class");
+    else if (N->isAlias())
+      printHeader("alias");
     else
       printHeader("nominal");
     auto demangled = Demangle::demangleTypeAsString(N->getMangledName());
@@ -417,6 +419,16 @@ bool isClass(Demangle::NodePointer Node) {
       return false;
   }
 }
+bool isAlias(Demangle::NodePointer Node) {
+  switch (Node->getKind()) {
+    case Demangle::Node::Kind::Type:
+      return isAlias(Node->getChild(0));
+    case Demangle::Node::Kind::TypeAlias:
+      return true;
+    default:
+      return false;
+  }
+}
 } // end anonymous namespace
 
 bool NominalTypeTrait::isStruct() const {
@@ -425,18 +437,22 @@ bool NominalTypeTrait::isStruct() const {
   return ::isStruct(Demangled);
 }
 
-
 bool NominalTypeTrait::isEnum() const {
   Demangle::Demangler Dem;
   Demangle::NodePointer Demangled = Dem.demangleType(MangledName);
   return ::isEnum(Demangled);
 }
 
-
 bool NominalTypeTrait::isClass() const {
   Demangle::Demangler Dem;
   Demangle::NodePointer Demangled = Dem.demangleType(MangledName);
   return ::isClass(Demangled);
+}
+
+bool NominalTypeTrait::isAlias() const {
+  Demangle::Demangler Dem;
+  Demangle::NodePointer Demangled = Dem.demangleType(MangledName);
+  return ::isAlias(Demangled);
 }
 
 /// Visitor class to set the WasAbstract flag of any MetatypeTypeRefs

--- a/stdlib/public/runtime/Demangle.cpp
+++ b/stdlib/public/runtime/Demangle.cpp
@@ -131,9 +131,7 @@ swift::_swift_buildDemanglingForMetadata(const Metadata *type,
     auto objcWrapper = static_cast<const ObjCClassWrapperMetadata *>(type);
     const char *className = class_getName((Class)objcWrapper->Class);
     
-    // ObjC classes mangle as being in the magic "__ObjC" module.
-    auto module = Dem.createNode(Node::Kind::Module, "__ObjC");
-    
+    auto module = Dem.createNode(Node::Kind::Module, MANGLING_MODULE_OBJC);
     auto node = Dem.createNode(Node::Kind::Class);
     node->addChild(module, Dem);
     node->addChild(Dem.createNode(Node::Kind::Identifier,

--- a/stdlib/public/runtime/ErrorObject.mm
+++ b/stdlib/public/runtime/ErrorObject.mm
@@ -248,7 +248,7 @@ static const WitnessTable *getNSErrorConformanceToError() {
   // Swift source.
 
   auto TheWitnessTable = SWIFT_LAZY_CONSTANT(dlsym(RTLD_DEFAULT,
-               MANGLE_AS_STRING(MANGLE_SYM(So7CFErrorCs5Error10FoundationWP))));
+      MANGLE_AS_STRING(MANGLE_SYM(So10CFErrorRefas5Error10FoundationWP))));
   assert(TheWitnessTable &&
          "Foundation overlay not loaded, or 'CFError : Error' conformance "
          "not available");

--- a/test/ClangImporter/ctypes_ir.swift
+++ b/test/ClangImporter/ctypes_ir.swift
@@ -27,7 +27,7 @@ func testStructWithFlexibleArray(_ s : StructWithFlexibleArray) {
 }
 
 // Make sure flexible array struct member isn't represented in IR function signature as i0 (or at all). rdar://problem/18510461
-// CHECK-LABEL: define hidden swiftcc void @_T09ctypes_ir27testStructWithFlexibleArrayySC0defG0VF(i32)
+// CHECK-LABEL: define hidden swiftcc void @_T09ctypes_ir27testStructWithFlexibleArrayySo0defG0VF(i32)
 
 typealias EightUp = (Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8)
 

--- a/test/ClangImporter/enum-error.swift
+++ b/test/ClangImporter/enum-error.swift
@@ -8,7 +8,8 @@
 // RUN: %target-swift-frontend -DCATCHAS -emit-sil %s -import-objc-header %S/Inputs/enum-error.h | %FileCheck %s -check-prefix=CATCHAS
 // RUN: %target-swift-frontend -DGENERICONLY -emit-sil %s -import-objc-header %S/Inputs/enum-error.h | %FileCheck %s -check-prefix=GENERICONLY
 
-// RUN: %target-swift-frontend -emit-sil %s -import-objc-header %S/Inputs/enum-error.h -verify
+// RUN: not %target-swift-frontend -DEXHAUSTIVE -emit-sil %s -import-objc-header %S/Inputs/enum-error.h 2>&1 | %FileCheck %s -check-prefix=EXHAUSTIVE
+// RUN: %target-swift-frontend -typecheck %s -import-objc-header %S/Inputs/enum-error.h -DERRORS -verify
 
 // RUN: echo '#include "enum-error.h"' > %t.m
 // RUN: %target-swift-ide-test -source-filename %s -print-header -header-to-print %S/Inputs/enum-error.h -import-objc-header %S/Inputs/enum-error.h -print-regular-comments --cc-args %target-cc-options -fsyntax-only %t.m -I %S/Inputs > %t.txt
@@ -76,13 +77,13 @@ func testError() {
   }
   let _ : TestError = dyncast(testErrorNSError)
 
-#else
+#elseif EXHAUSTIVE
 // CHECK: sil_witness_table shared [serialized] TestError: _BridgedStoredNSError module __ObjC
   let terr = getErr()
   switch (terr) { case .TENone, .TEOne, .TETwo: break } // ok
 
   switch (terr) { case .TENone, .TEOne: break }
-    // expected-error@-1 {{switch must be exhaustive, consider adding missing cases}}
+  // EXHAUSTIVE: [[@LINE-1]]:{{.+}}: error: switch must be exhaustive, consider adding missing cases
 
   let _ = TestError.Code(rawValue: 2)!
 
@@ -95,20 +96,19 @@ func testError() {
 
 }
 
-// HEADER: struct TestError : _BridgedStoredNSError {
-// HEADER:   let _nsError: NSError
-// HEADER:   init(_nsError: NSError)
-// HEADER:   static var _nsErrorDomain: String { get }
-// HEADER:   enum Code : Int32, _ErrorCodeProtocol {
-// HEADER:     init?(rawValue: Int32)
-// HEADER:     var rawValue: Int32 { get }
-// HEADER:     typealias _ErrorType = TestError
-// HEADER:     case TENone
-// HEADER:     case TEOne
-// HEADER:     case TETwo
-// HEADER:   }
-// HEADER:   static var TENone: TestError.Code { get }
-// HEADER:   static var TEOne: TestError.Code { get }
-// HEADER:   static var TETwo: TestError.Code { get }
+#if ERRORS
+class ObjCTest {
+  @objc func foo() -> TestError {} // expected-error {{method cannot be marked @objc because its result type cannot be represented in Objective-C}} expected-note {{Swift structs cannot be represented in Objective-C}}
+  @objc func bar() -> TestError.Code {} // okay
+}
+#endif
+
+// HEADER: enum Code : Int32, _ErrorCodeProtocol {
+// HEADER:   init?(rawValue: Int32)
+// HEADER:   var rawValue: Int32 { get }
+// HEADER:   typealias _ErrorType = TestError
+// HEADER:   case TENone
+// HEADER:   case TEOne
+// HEADER:   case TETwo
 // HEADER: }
 // HEADER: func getErr() -> TestError.Code

--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -25,7 +25,7 @@ _TtGSqSS_ ---> Swift.String?
 _TtGSQSS_ ---> Swift.String!
 _TtGVs10DictionarySSSi_ ---> [Swift.String : Swift.Int]
 _TtVs7CString ---> Swift.CString
-_TtCSo8NSObject ---> __ObjC.NSObject
+_TtCSo8NSObject ---> __C.NSObject
 _TtO6Monads6Either ---> Monads.Either
 _TtbSiSu ---> @convention(block) (Swift.Int) -> Swift.UInt
 _TtcSiSu ---> @convention(c) (Swift.Int) -> Swift.UInt
@@ -78,11 +78,11 @@ _TF3foog3barSi ---> foo.bar.getter : Swift.Int
 _TF3foos3barSi ---> foo.bar.setter : Swift.Int
 _TFC3foo3bar3basfT3zimCS_3zim_T_ ---> foo.bar.bas(zim: foo.zim) -> ()
 _TToFC3foo3bar3basfT3zimCS_3zim_T_ ---> {T:_TFC3foo3bar3basfT3zimCS_3zim_T_,C} @objc foo.bar.bas(zim: foo.zim) -> ()
-_TTOFSC3fooFTSdSd_Sd ---> {T:_TFSC3fooFTSdSd_Sd} @nonobjc __C.foo(Swift.Double, Swift.Double) -> Swift.Double
+_TTOFSC3fooFTSdSd_Sd ---> {T:_TFSC3fooFTSdSd_Sd} @nonobjc __C_Synthesized.foo(Swift.Double, Swift.Double) -> Swift.Double
 _T03foo3barC3basyAA3zimCAE_tFTo ---> {T:_T03foo3barC3basyAA3zimCAE_tF,C} @objc foo.bar.bas(zim: foo.zim) -> ()
-_T0SC3fooS2d_SdtFTO ---> {T:_T0SC3fooS2d_SdtF} @nonobjc __C.foo(Swift.Double, Swift.Double) -> Swift.Double
+_T0SC3fooS2d_SdtFTO ---> {T:_T0SC3fooS2d_SdtF} @nonobjc __C_Synthesized.foo(Swift.Double, Swift.Double) -> Swift.Double
 _S3foo3barC3basyAA3zimCAE_tFTo ---> {T:_S3foo3barC3basyAA3zimCAE_tF,C} @objc foo.bar.bas(zim: foo.zim) -> ()
-_SSC3fooS2d_SdtFTO ---> {T:_SSC3fooS2d_SdtF} @nonobjc __C.foo(Swift.Double, Swift.Double) -> Swift.Double
+_SSC3fooS2d_SdtFTO ---> {T:_SSC3fooS2d_SdtF} @nonobjc __C_Synthesized.foo(Swift.Double, Swift.Double) -> Swift.Double
 _TTDFC3foo3bar3basfT3zimCS_3zim_T_ ---> dynamic foo.bar.bas(zim: foo.zim) -> ()
 _TFC3foo3bar3basfT3zimCS_3zim_T_ ---> foo.bar.bas(zim: foo.zim) -> ()
 _TF3foooi1pFTCS_3barVS_3bas_OS_3zim ---> foo.+ infix(foo.bar, foo.bas) -> foo.zim
@@ -120,7 +120,7 @@ _TWGC3foo3barS_8barrableS_ ---> generic protocol witness table for foo.bar : foo
 _TWIC3foo3barS_8barrableS_ ---> {C} instantiation function for generic protocol witness table for foo.bar : foo.barrable in foo
 _TWtC3foo3barS_8barrableS_4fred ---> {C} associated type metadata accessor for fred in foo.bar : foo.barrable in foo
 _TWTC3foo3barS_8barrableS_4fredS_6thomas ---> {C} associated type witness table accessor for fred : foo.thomas in foo.bar : foo.barrable in foo
-_TFSCg5greenVSC5Color ---> __C.green.getter : __C.Color
+_TFSCg5greenVSC5Color ---> __C_Synthesized.green.getter : __C_Synthesized.Color
 _TIF1t1fFT1iSi1sSS_T_A_ ---> default argument 0 of t.f(i: Swift.Int, s: Swift.String) -> ()
 _TIF1t1fFT1iSi1sSS_T_A0_ ---> default argument 1 of t.f(i: Swift.Int, s: Swift.String) -> ()
 _TFSqcfT_GSqx_ ---> Swift.Optional.init() -> A?
@@ -169,8 +169,8 @@ _TFCF5types1gFT1bSb_T_L0_10Collection3zimfT_T_ ---> zim() -> () in Collection #2
 _TFF17capture_promotion22test_capture_promotionFT_FT_SiU_FT_Si_promote0 ---> closure #1 () -> Swift.Int in capture_promotion.test_capture_promotion() -> () -> Swift.Int with unmangled suffix "_promote0"
 _TFIVs8_Processi10_argumentsGSaSS_U_FT_GSaSS_ ---> _arguments : [Swift.String] in variable initialization expression of Swift._Process with unmangled suffix "U_FT_GSaSS_"
 _TFIvVs8_Process10_argumentsGSaSS_iU_FT_GSaSS_ ---> closure #1 () -> [Swift.String] in variable initialization expression of Swift._Process._arguments : [Swift.String]
-_TFCSo1AE ---> __ObjC.A.__ivar_destroyer
-_TFCSo1Ae ---> __ObjC.A.__ivar_initializer
+_TFCSo1AE ---> __C.A.__ivar_destroyer
+_TFCSo1Ae ---> __C.A.__ivar_initializer
 _TTWC13call_protocol1CS_1PS_FS1_3foofT_Si ---> protocol witness for call_protocol.P.foo() -> Swift.Int in conformance call_protocol.C : call_protocol.P in call_protocol
 _T013call_protocol1CCAA1PA2aDP3fooSiyFTW ---> {T:} protocol witness for call_protocol.P.foo() -> Swift.Int in conformance call_protocol.C : call_protocol.P in call_protocol
 _TFC12dynamic_self1X1ffT_DS0_ ---> dynamic_self.X.f() -> Self
@@ -249,5 +249,5 @@ _T0s10DictionaryV3t17E6Index2V1loiSbAEyxq__G_AGtFZ ---> static (extension in t17
 _T08mangling14varargsVsArrayySaySiG3arrd_SS1ntF ---> mangling.varargsVsArray(arr: Swift.Int..., n: Swift.String) -> ()
 _T08mangling14varargsVsArrayySaySiG3arrd_tF ---> mangling.varargsVsArray(arr: Swift.Int...) -> ()
 _T0s13_UnicodeViewsVss22RandomAccessCollectionRzs0A8EncodingR_11SubSequence_5IndexQZAFRtzsAcERpzAE_AEQZAIRSs15UnsignedInteger8Iterator_7ElementRPzAE_AlMQZANRS13EncodedScalar_AlMQY_AORSr0_lE13CharacterViewVyxq__G ---> (extension in Swift):Swift._UnicodeViews<A, B><A, B where A: Swift.RandomAccessCollection, B: Swift.UnicodeEncoding, A.Index == A.SubSequence.Index, A.SubSequence: Swift.RandomAccessCollection, A.SubSequence == A.SubSequence.SubSequence, A.Iterator.Element: Swift.UnsignedInteger, A.Iterator.Element == A.SubSequence.Iterator.Element, A.SubSequence.Iterator.Element == B.EncodedScalar.Iterator.Element>.CharacterView
-_T010Foundation11MeasurementV12SimulatorKitSo9UnitAngleCRszlE11OrientationO2eeoiSbAcDEAGOyAF_G_AKtFZ ---> static (extension in SimulatorKit):Foundation.Measurement<A where A == __ObjC.UnitAngle>.Orientation.== infix((extension in SimulatorKit):Foundation.Measurement<__ObjC.UnitAngle>.Orientation, (extension in SimulatorKit):Foundation.Measurement<__ObjC.UnitAngle>.Orientation) -> Swift.Bool
+_T010Foundation11MeasurementV12SimulatorKitSo9UnitAngleCRszlE11OrientationO2eeoiSbAcDEAGOyAF_G_AKtFZ ---> static (extension in SimulatorKit):Foundation.Measurement<A where A == __C.UnitAngle>.Orientation.== infix((extension in SimulatorKit):Foundation.Measurement<__C.UnitAngle>.Orientation, (extension in SimulatorKit):Foundation.Measurement<__C.UnitAngle>.Orientation) -> Swift.Bool
 _T04main1_yyF ---> main._() -> ()

--- a/test/IRGen/abitypes.swift
+++ b/test/IRGen/abitypes.swift
@@ -22,20 +22,20 @@ class Foo {
   // x86_64-macosx: define hidden { <2 x float>, <2 x float> } @_T08abitypes3FooC3bar{{[_0-9a-zA-Z]*}}FTo(i8*, i8*) unnamed_addr {{.*}} {
   // x86_64-ios: define hidden swiftcc { i64, i64 } @_T08abitypes3FooC3bar{{[_0-9a-zA-Z]*}}F(%T8abitypes3FooC* swiftself) {{.*}} {
   // x86_64-ios: define hidden { <2 x float>, <2 x float> } @_T08abitypes3FooC3bar{{[_0-9a-zA-Z]*}}FTo(i8*, i8*) unnamed_addr {{.*}} {
-  // i386-ios: define hidden swiftcc void @_T08abitypes3FooC3bar{{[_0-9a-zA-Z]*}}F(%TSC6MyRectV* noalias nocapture sret, %T8abitypes3FooC* swiftself) {{.*}} {
-  // i386-ios: define hidden void @_T08abitypes3FooC3bar{{[_0-9a-zA-Z]*}}FTo(%TSC6MyRectV* noalias nocapture sret, i8*, i8*) unnamed_addr {{.*}} {
+  // i386-ios: define hidden swiftcc void @_T08abitypes3FooC3bar{{[_0-9a-zA-Z]*}}F(%TSo6MyRectV* noalias nocapture sret, %T8abitypes3FooC* swiftself) {{.*}} {
+  // i386-ios: define hidden void @_T08abitypes3FooC3bar{{[_0-9a-zA-Z]*}}FTo(%TSo6MyRectV* noalias nocapture sret, i8*, i8*) unnamed_addr {{.*}} {
   // armv7-ios: define hidden swiftcc { float, float, float, float } @_T08abitypes3FooC3bar{{[_0-9a-zA-Z]*}}F(%T8abitypes3FooC* swiftself) {{.*}} {
-  // armv7-ios: define hidden void @_T08abitypes3FooC3bar{{[_0-9a-zA-Z]*}}FTo(%TSC6MyRectV* noalias nocapture sret, i8*, i8*) unnamed_addr {{.*}} {
+  // armv7-ios: define hidden void @_T08abitypes3FooC3bar{{[_0-9a-zA-Z]*}}FTo(%TSo6MyRectV* noalias nocapture sret, i8*, i8*) unnamed_addr {{.*}} {
   // armv7s-ios: define hidden swiftcc { float, float, float, float } @_T08abitypes3FooC3bar{{[_0-9a-zA-Z]*}}F(%T8abitypes3FooC* swiftself) {{.*}} {
-  // armv7s-ios: define hidden void @_T08abitypes3FooC3bar{{[_0-9a-zA-Z]*}}FTo(%TSC6MyRectV* noalias nocapture sret, i8*, i8*) unnamed_addr {{.*}} {
+  // armv7s-ios: define hidden void @_T08abitypes3FooC3bar{{[_0-9a-zA-Z]*}}FTo(%TSo6MyRectV* noalias nocapture sret, i8*, i8*) unnamed_addr {{.*}} {
   // arm64-ios: define hidden swiftcc { i64, i64 } @_T08abitypes3FooC3bar{{[_0-9a-zA-Z]*}}F(%T8abitypes3FooC* swiftself) {{.*}} {
   // arm64-ios: define hidden [[ARM64_MYRECT]] @_T08abitypes3FooC3bar{{[_0-9a-zA-Z]*}}FTo(i8*, i8*) unnamed_addr {{.*}} {
   // x86_64-tvos: define hidden swiftcc { i64, i64 } @_T08abitypes3FooC3bar{{[_0-9a-zA-Z]*}}F(%T8abitypes3FooC* swiftself) {{.*}} {
   // x86_64-tvos: define hidden { <2 x float>, <2 x float> } @_T08abitypes3FooC3bar{{[_0-9a-zA-Z]*}}FTo(i8*, i8*) unnamed_addr {{.*}} {
   // arm64-tvos: define hidden swiftcc { i64, i64 }  @_T08abitypes3FooC3bar{{[_0-9a-zA-Z]*}}F(%T8abitypes3FooC* swiftself) {{.*}} {
   // arm64-tvos: define hidden [[ARM64_MYRECT]] @_T08abitypes3FooC3bar{{[_0-9a-zA-Z]*}}FTo(i8*, i8*) unnamed_addr {{.*}} {
-  // i386-watchos: define hidden swiftcc void @_T08abitypes3FooC3bar{{[_0-9a-zA-Z]*}}F(%TSC6MyRectV* noalias nocapture sret, %T8abitypes3FooC* swiftself) {{.*}} {
-  // i386-watchos: define hidden void @_T08abitypes3FooC3bar{{[_0-9a-zA-Z]*}}FTo(%TSC6MyRectV* noalias nocapture sret, i8*, i8*) unnamed_addr {{.*}} {
+  // i386-watchos: define hidden swiftcc void @_T08abitypes3FooC3bar{{[_0-9a-zA-Z]*}}F(%TSo6MyRectV* noalias nocapture sret, %T8abitypes3FooC* swiftself) {{.*}} {
+  // i386-watchos: define hidden void @_T08abitypes3FooC3bar{{[_0-9a-zA-Z]*}}FTo(%TSo6MyRectV* noalias nocapture sret, i8*, i8*) unnamed_addr {{.*}} {
   // armv7k-watchos: define hidden swiftcc { float, float, float, float } @_T08abitypes3FooC3bar{{[_0-9a-zA-Z]*}}F(%T8abitypes3FooC* swiftself) {{.*}} {
   // armv7k-watchos: define hidden [[ARMV7K_MYRECT]] @_T08abitypes3FooC3bar{{[_0-9a-zA-Z]*}}FTo(i8*, i8*) unnamed_addr {{.*}} {
   dynamic func bar() -> MyRect {
@@ -44,7 +44,7 @@ class Foo {
 
 
   // x86_64-macosx: define hidden swiftcc double @_T08abitypes3FooC14getXFromNSRect{{[_0-9a-zA-Z]*}}F(double, double, double, double, %T8abitypes3FooC* swiftself) {{.*}} {
-  // x86_64-macosx: define hidden double @_T08abitypes3FooC14getXFromNSRect{{[_0-9a-zA-Z]*}}FTo(i8*, i8*, %TSC6CGRectV* byval align 8) unnamed_addr {{.*}} {
+  // x86_64-macosx: define hidden double @_T08abitypes3FooC14getXFromNSRect{{[_0-9a-zA-Z]*}}FTo(i8*, i8*, %TSo6CGRectV* byval align 8) unnamed_addr {{.*}} {
   // armv7-ios: define hidden swiftcc double @_T08abitypes3FooC14getXFromNSRect{{[_0-9a-zA-Z]*}}F(float, float, float, float, %T8abitypes3FooC* swiftself) {{.*}} {
   // armv7-ios: define hidden double @_T08abitypes3FooC14getXFromNSRect{{[_0-9a-zA-Z]*}}FTo(i8*, i8*, [4 x i32]) unnamed_addr {{.*}} {
   // armv7s-ios: define hidden swiftcc double @_T08abitypes3FooC14getXFromNSRect{{[_0-9a-zA-Z]*}}F(float, float, float, float, %T8abitypes3FooC* swiftself) {{.*}} {
@@ -107,7 +107,7 @@ class Foo {
   }
 
   // Ensure that MyRect is passed as an indirect-byval on x86_64 because we run out of registers for direct arguments
-  // x86_64-macosx: define hidden float @_T08abitypes3FooC25getXFromRectIndirectByVal{{[_0-9a-zA-Z]*}}FTo(i8*, i8*, float, float, float, float, float, float, float, %TSC6MyRectV* byval align 4) unnamed_addr {{.*}} {
+  // x86_64-macosx: define hidden float @_T08abitypes3FooC25getXFromRectIndirectByVal{{[_0-9a-zA-Z]*}}FTo(i8*, i8*, float, float, float, float, float, float, float, %TSo6MyRectV* byval align 4) unnamed_addr {{.*}} {
   dynamic func getXFromRectIndirectByVal(_: Float, second _: Float, 
                                        third _: Float, fourth _: Float,
                                        fifth _: Float, sixth _: Float,
@@ -168,7 +168,7 @@ class Foo {
   }
 
   // x86_64-macosx: define hidden swiftcc { double, double, double } @_T08abitypes3FooC3baz{{[_0-9a-zA-Z]*}}F(%T8abitypes3FooC* swiftself) {{.*}} {
-  // x86_64-macosx: define hidden void @_T08abitypes3FooC3baz{{[_0-9a-zA-Z]*}}FTo(%TSC4TrioV* noalias nocapture sret, i8*, i8*) unnamed_addr {{.*}} {
+  // x86_64-macosx: define hidden void @_T08abitypes3FooC3baz{{[_0-9a-zA-Z]*}}FTo(%TSo4TrioV* noalias nocapture sret, i8*, i8*) unnamed_addr {{.*}} {
   dynamic func baz() -> Trio {
     return Trio(i: 1.0, j: 2.0, k: 3.0)
   }
@@ -176,7 +176,7 @@ class Foo {
   // x86_64-macosx:      define hidden swiftcc double @_T08abitypes3FooC4bazc{{[_0-9a-zA-Z]*}}F(%TSo13StructReturnsC*, %T8abitypes3FooC* swiftself) {{.*}} {
   // x86_64-macosx:      load i8*, i8** @"\01L_selector(newTrio)", align 8
   // x86_64-macosx:      [[CAST:%[0-9]+]] = bitcast {{%.*}}* %0
-  // x86_64-macosx:      call void bitcast (void ()* @objc_msgSend_stret to void (%TSC4TrioV*, [[OPAQUE:.*]]*, i8*)*)
+  // x86_64-macosx:      call void bitcast (void ()* @objc_msgSend_stret to void (%TSo4TrioV*, [[OPAQUE:.*]]*, i8*)*)
   func bazc(_ p: StructReturns) -> Double {
     return p.newTrio().j
   }
@@ -510,10 +510,10 @@ class Foo {
   }
 
   // arm64-ios: define hidden swiftcc { i64, i64, i64, i64 } @_T08abitypes3FooC14callJustReturn{{[_0-9a-zA-Z]*}}F(%TSo13StructReturnsC*, i64, i64, i64, i64, %T8abitypes3FooC* swiftself) {{.*}} {
-  // arm64-ios: define hidden void @_T08abitypes3FooC14callJustReturn{{[_0-9a-zA-Z]*}}FTo(%TSC9BigStructV* noalias nocapture sret, i8*, i8*, [[OPAQUE:.*]]*, %TSC9BigStructV*) unnamed_addr {{.*}} {
+  // arm64-ios: define hidden void @_T08abitypes3FooC14callJustReturn{{[_0-9a-zA-Z]*}}FTo(%TSo9BigStructV* noalias nocapture sret, i8*, i8*, [[OPAQUE:.*]]*, %TSo9BigStructV*) unnamed_addr {{.*}} {
   //
   // arm64-tvos: define hidden swiftcc { i64, i64, i64, i64 } @_T08abitypes3FooC14callJustReturn{{[_0-9a-zA-Z]*}}F(%TSo13StructReturnsC*, i64, i64, i64, i64, %T8abitypes3FooC* swiftself) {{.*}} {
-  // arm64-tvos: define hidden void @_T08abitypes3FooC14callJustReturn{{[_0-9a-zA-Z]*}}FTo(%TSC9BigStructV* noalias nocapture sret, i8*, i8*, [[OPAQUE:.*]]*, %TSC9BigStructV*) unnamed_addr {{.*}} {
+  // arm64-tvos: define hidden void @_T08abitypes3FooC14callJustReturn{{[_0-9a-zA-Z]*}}FTo(%TSo9BigStructV* noalias nocapture sret, i8*, i8*, [[OPAQUE:.*]]*, %TSo9BigStructV*) unnamed_addr {{.*}} {
   dynamic func callJustReturn(_ r: StructReturns, with v: BigStruct) -> BigStruct {
     return r.justReturn(v)
   }
@@ -530,11 +530,11 @@ class Foo {
 // armv7k-watchos: define internal %struct.One @makeOne(float %f, float %s)
 
 // rdar://17631440 - Expand direct arguments that are coerced to aggregates.
-// x86_64-macosx: define{{( protected)?}} swiftcc float @_T08abitypes13testInlineAggSfSC6MyRectVF(i64, i64) {{.*}} {
-// x86_64-macosx: [[COERCED:%.*]] = alloca %TSC6MyRectV, align 8
+// x86_64-macosx: define{{( protected)?}} swiftcc float @_T08abitypes13testInlineAggSfSo6MyRectVF(i64, i64) {{.*}} {
+// x86_64-macosx: [[COERCED:%.*]] = alloca %TSo6MyRectV, align 8
 // x86_64-macosx: store i64 %
 // x86_64-macosx: store i64 %
-// x86_64-macosx: [[CAST:%.*]] = bitcast %TSC6MyRectV* [[COERCED]] to { <2 x float>, <2 x float> }*
+// x86_64-macosx: [[CAST:%.*]] = bitcast %TSo6MyRectV* [[COERCED]] to { <2 x float>, <2 x float> }*
 // x86_64-macosx: [[T0:%.*]] = getelementptr inbounds { <2 x float>, <2 x float> }, { <2 x float>, <2 x float> }* [[CAST]], i32 0, i32 0
 // x86_64-macosx: [[FIRST_HALF:%.*]] = load <2 x float>, <2 x float>* [[T0]], align 8
 // x86_64-macosx: [[T0:%.*]] = getelementptr inbounds { <2 x float>, <2 x float> }, { <2 x float>, <2 x float> }* [[CAST]], i32 0, i32 1
@@ -548,8 +548,8 @@ public func testInlineAgg(_ rect: MyRect) -> Float {
 // We need to allocate enough memory on the stack to hold the argument value we load.
 // arm64-ios: define swiftcc void @_T08abitypes14testBOOLStructyyF()
 // arm64-ios:  [[COERCED:%.*]] = alloca i64
-// arm64-ios:  [[STRUCTPTR:%.*]] = bitcast i64* [[COERCED]] to %TSC14FiveByteStructV
-// arm64-ios:  [[PTR0:%.*]] = getelementptr inbounds %TSC14FiveByteStructV, %TSC14FiveByteStructV* [[STRUCTPTR]], {{i.*}} 0, {{i.*}} 0
+// arm64-ios:  [[STRUCTPTR:%.*]] = bitcast i64* [[COERCED]] to %TSo14FiveByteStructV
+// arm64-ios:  [[PTR0:%.*]] = getelementptr inbounds %TSo14FiveByteStructV, %TSo14FiveByteStructV* [[STRUCTPTR]], {{i.*}} 0, {{i.*}} 0
 // arm64-ios:  [[PTR1:%.*]] = getelementptr inbounds %T10ObjectiveC8ObjCBoolV, %T10ObjectiveC8ObjCBoolV* [[PTR0]], {{i.*}} 0, {{i.*}} 0
 // arm64-ios:  [[PTR2:%.*]] = getelementptr inbounds %TSb, %TSb* [[PTR1]], {{i.*}} 0, {{i.*}} 0
 // arm64-ios:  store i1 false, i1* [[PTR2]], align 8

--- a/test/IRGen/c_layout.sil
+++ b/test/IRGen/c_layout.sil
@@ -7,13 +7,13 @@ import Swift
 
 // TODO: Provide tests for other architectures
 
-// CHECK-x86_64: %TSC11BitfieldOneV = type <{ %Ts6UInt32V, %TSC6NestedV, [4 x i8], [4 x i8], %TSf, [1 x i8], [7 x i8], %Ts6UInt64V, %Ts6UInt32V, [4 x i8] }>
-// CHECK-x86_64: %TSC6NestedV = type <{ %TSf, [3 x i8], [1 x i8] }>
+// CHECK-x86_64: %TSo11BitfieldOneV = type <{ %Ts6UInt32V, %TSo6NestedV, [4 x i8], [4 x i8], %TSf, [1 x i8], [7 x i8], %Ts6UInt64V, %Ts6UInt32V, [4 x i8] }>
+// CHECK-x86_64: %TSo6NestedV = type <{ %TSf, [3 x i8], [1 x i8] }>
 
-// CHECK-x86_64: %TSC26BitfieldSeparatorReferenceV = type [[BITFIELD_SEP_TYPE:<{ %Ts5UInt8V, \[3 x i8\], %Ts5UInt8V }>]]
-// CHECK-x86_64: %TSC25BitfieldSeparatorSameNameV = type [[BITFIELD_SEP_TYPE]]
-// CHECK-x86_64: %TSC36BitfieldSeparatorDifferentNameStructV = type [[BITFIELD_SEP_TYPE]]
-// CHECK-x86_64: %TSC21BitfieldSeparatorAnonV = type [[BITFIELD_SEP_TYPE]]
+// CHECK-x86_64: %TSo26BitfieldSeparatorReferenceV = type [[BITFIELD_SEP_TYPE:<{ %Ts5UInt8V, \[3 x i8\], %Ts5UInt8V }>]]
+// CHECK-x86_64: %TSo25BitfieldSeparatorSameNameV = type [[BITFIELD_SEP_TYPE]]
+// CHECK-x86_64: %TSo36BitfieldSeparatorDifferentNameStructV = type [[BITFIELD_SEP_TYPE]]
+// CHECK-x86_64: %TSo21BitfieldSeparatorAnonV = type [[BITFIELD_SEP_TYPE]]
 
 sil public_external @createBitfieldOne : $@convention(c) () -> BitfieldOne
 sil public_external @consumeBitfieldOne : $@convention(c) (BitfieldOne) -> ()
@@ -28,68 +28,68 @@ bb0:
   return %r : $()
 }
 // CHECK-x86_64: define{{( protected)?}} swiftcc void @test0()
-// CHECK-x86_64:   [[RESULT:%.*]] = alloca %TSC11BitfieldOneV, align 8
-// CHECK-x86_64:   [[ARG:%.*]] = alloca %TSC11BitfieldOneV, align 8
+// CHECK-x86_64:   [[RESULT:%.*]] = alloca %TSo11BitfieldOneV, align 8
+// CHECK-x86_64:   [[ARG:%.*]] = alloca %TSo11BitfieldOneV, align 8
 //   Make the first call and pull all the values out of the indirect result.
-// CHECK-x86_64:   call void @createBitfieldOne(%TSC11BitfieldOneV* noalias nocapture sret [[RESULT]])
-// CHECK-x86_64:   [[ADDR_A:%.*]] = getelementptr inbounds %TSC11BitfieldOneV, %TSC11BitfieldOneV* [[RESULT]], i32 0, i32 0
+// CHECK-x86_64:   call void @createBitfieldOne(%TSo11BitfieldOneV* noalias nocapture sret [[RESULT]])
+// CHECK-x86_64:   [[ADDR_A:%.*]] = getelementptr inbounds %TSo11BitfieldOneV, %TSo11BitfieldOneV* [[RESULT]], i32 0, i32 0
 // CHECK-x86_64:   [[ADDR_A_V:%.*]] = getelementptr inbounds %Ts6UInt32V, %Ts6UInt32V* [[ADDR_A]], i32 0, i32 0
 // CHECK-x86_64:   [[A:%.*]] = load i32, i32* [[ADDR_A_V]], align 8
-// CHECK-x86_64:   [[ADDR_B:%.*]] = getelementptr inbounds %TSC11BitfieldOneV, %TSC11BitfieldOneV* [[RESULT]], i32 0, i32 1
-// CHECK-x86_64:   [[ADDR_B_X:%.*]] = getelementptr inbounds %TSC6NestedV, %TSC6NestedV* [[ADDR_B]], i32 0, i32 0
+// CHECK-x86_64:   [[ADDR_B:%.*]] = getelementptr inbounds %TSo11BitfieldOneV, %TSo11BitfieldOneV* [[RESULT]], i32 0, i32 1
+// CHECK-x86_64:   [[ADDR_B_X:%.*]] = getelementptr inbounds %TSo6NestedV, %TSo6NestedV* [[ADDR_B]], i32 0, i32 0
 // CHECK-x86_64:   [[ADDR_B_X_V:%.*]] = getelementptr inbounds %TSf, %TSf* [[ADDR_B_X]], i32 0, i32 0
 // CHECK-x86_64:   [[B_X:%.*]] = load float, float* [[ADDR_B_X_V]], align 4
-// CHECK-x86_64:   [[ADDR_B_YZ:%.*]] = getelementptr inbounds %TSC6NestedV, %TSC6NestedV* [[ADDR_B]], i32 0, i32 1
+// CHECK-x86_64:   [[ADDR_B_YZ:%.*]] = getelementptr inbounds %TSo6NestedV, %TSo6NestedV* [[ADDR_B]], i32 0, i32 1
 // CHECK-x86_64:   [[ADDR_B_YZ_1:%.*]] = bitcast [3 x i8]* [[ADDR_B_YZ]] to i24*
 // CHECK-x86_64:   [[B_YZ:%.*]] = load i24, i24* [[ADDR_B_YZ_1]], align 4
-// CHECK-x86_64:   [[ADDR_CDE:%.*]] = getelementptr inbounds %TSC11BitfieldOneV, %TSC11BitfieldOneV* [[RESULT]], i32 0, i32 2
+// CHECK-x86_64:   [[ADDR_CDE:%.*]] = getelementptr inbounds %TSo11BitfieldOneV, %TSo11BitfieldOneV* [[RESULT]], i32 0, i32 2
 // CHECK-x86_64:   [[ADDR_CDE_1:%.*]] = bitcast [4 x i8]* [[ADDR_CDE]] to i32*
 // CHECK-x86_64:   [[CDE:%.*]] = load i32, i32* [[ADDR_CDE_1]], align 4
-// CHECK-x86_64:   [[ADDR_FGH:%.*]] = getelementptr inbounds %TSC11BitfieldOneV, %TSC11BitfieldOneV* [[RESULT]], i32 0, i32 3
+// CHECK-x86_64:   [[ADDR_FGH:%.*]] = getelementptr inbounds %TSo11BitfieldOneV, %TSo11BitfieldOneV* [[RESULT]], i32 0, i32 3
 // CHECK-x86_64:   [[ADDR_FGH_1:%.*]] = bitcast [4 x i8]* [[ADDR_FGH]] to i32*
 // CHECK-x86_64:   [[FGH:%.*]] = load i32, i32* [[ADDR_FGH_1]], align 8
-// CHECK-x86_64:   [[ADDR_I:%.*]] = getelementptr inbounds %TSC11BitfieldOneV, %TSC11BitfieldOneV* [[RESULT]], i32 0, i32 4
+// CHECK-x86_64:   [[ADDR_I:%.*]] = getelementptr inbounds %TSo11BitfieldOneV, %TSo11BitfieldOneV* [[RESULT]], i32 0, i32 4
 // CHECK-x86_64:   [[ADDR_I_V:%.*]] = getelementptr inbounds %TSf, %TSf* [[ADDR_I]], i32 0, i32 0
 // CHECK-x86_64:   [[I:%.*]] = load float, float* [[ADDR_I_V]], align 4
-// CHECK-x86_64:   [[ADDR_JK:%.*]] = getelementptr inbounds %TSC11BitfieldOneV, %TSC11BitfieldOneV* [[RESULT]], i32 0, i32 5
+// CHECK-x86_64:   [[ADDR_JK:%.*]] = getelementptr inbounds %TSo11BitfieldOneV, %TSo11BitfieldOneV* [[RESULT]], i32 0, i32 5
 // CHECK-x86_64:   [[ADDR_JK_1:%.*]] = bitcast [1 x i8]* [[ADDR_JK]] to i8*
 // CHECK-x86_64:   [[JK:%.*]] = load i8, i8* [[ADDR_JK_1]], align 8
-// CHECK-x86_64:   [[ADDR_L:%.*]] = getelementptr inbounds %TSC11BitfieldOneV, %TSC11BitfieldOneV* [[RESULT]], i32 0, i32 7
+// CHECK-x86_64:   [[ADDR_L:%.*]] = getelementptr inbounds %TSo11BitfieldOneV, %TSo11BitfieldOneV* [[RESULT]], i32 0, i32 7
 // CHECK-x86_64:   [[ADDR_L_V:%.*]] = getelementptr inbounds %Ts6UInt64V, %Ts6UInt64V* [[ADDR_L]], i32 0, i32 0
 // CHECK-x86_64:   [[L:%.*]] = load i64, i64* [[ADDR_L_V]], align 8
-// CHECK-x86_64:   [[ADDR_M:%.*]] = getelementptr inbounds %TSC11BitfieldOneV, %TSC11BitfieldOneV* [[RESULT]], i32 0, i32 8
+// CHECK-x86_64:   [[ADDR_M:%.*]] = getelementptr inbounds %TSo11BitfieldOneV, %TSo11BitfieldOneV* [[RESULT]], i32 0, i32 8
 // CHECK-x86_64:   [[ADDR_M_V:%.*]] = getelementptr inbounds %Ts6UInt32V, %Ts6UInt32V* [[ADDR_M]], i32 0, i32 0
 // CHECK-x86_64:   [[M:%.*]] = load i32, i32* [[ADDR_M_V]], align 8
 //   Put all of the values into the indirect argument and make the second call.
-// CHECK-x86_64:   [[ADDR_A:%.*]] = getelementptr inbounds %TSC11BitfieldOneV, %TSC11BitfieldOneV* [[ARG]], i32 0, i32 0
+// CHECK-x86_64:   [[ADDR_A:%.*]] = getelementptr inbounds %TSo11BitfieldOneV, %TSo11BitfieldOneV* [[ARG]], i32 0, i32 0
 // CHECK-x86_64:   [[ADDR_A_V:%.*]] = getelementptr inbounds %Ts6UInt32V, %Ts6UInt32V* [[ADDR_A]], i32 0, i32 0
 // CHECK-x86_64:   store i32 [[A]], i32* [[ADDR_A_V]], align 8
-// CHECK-x86_64:   [[ADDR_B:%.*]] = getelementptr inbounds %TSC11BitfieldOneV, %TSC11BitfieldOneV* [[ARG]], i32 0, i32 1
-// CHECK-x86_64:   [[ADDR_B_X:%.*]] = getelementptr inbounds %TSC6NestedV, %TSC6NestedV* [[ADDR_B]], i32 0, i32 0
+// CHECK-x86_64:   [[ADDR_B:%.*]] = getelementptr inbounds %TSo11BitfieldOneV, %TSo11BitfieldOneV* [[ARG]], i32 0, i32 1
+// CHECK-x86_64:   [[ADDR_B_X:%.*]] = getelementptr inbounds %TSo6NestedV, %TSo6NestedV* [[ADDR_B]], i32 0, i32 0
 // CHECK-x86_64:   [[ADDR_B_X_V:%.*]] = getelementptr inbounds %TSf, %TSf* [[ADDR_B_X]], i32 0, i32 0
 // CHECK-x86_64:   store float [[B_X]], float* [[ADDR_B_X_V]], align 4
-// CHECK-x86_64:   [[ADDR_B_YZ:%.*]] = getelementptr inbounds %TSC6NestedV, %TSC6NestedV* [[ADDR_B]], i32 0, i32 1
+// CHECK-x86_64:   [[ADDR_B_YZ:%.*]] = getelementptr inbounds %TSo6NestedV, %TSo6NestedV* [[ADDR_B]], i32 0, i32 1
 // CHECK-x86_64:   [[ADDR_B_YZ_1:%.*]] = bitcast [3 x i8]* [[ADDR_B_YZ]] to i24*
 // CHECK-x86_64:   store i24 [[B_YZ]], i24* [[ADDR_B_YZ_1]], align 4
-// CHECK-x86_64:   [[ADDR_CDE:%.*]] = getelementptr inbounds %TSC11BitfieldOneV, %TSC11BitfieldOneV* [[ARG]], i32 0, i32 2
+// CHECK-x86_64:   [[ADDR_CDE:%.*]] = getelementptr inbounds %TSo11BitfieldOneV, %TSo11BitfieldOneV* [[ARG]], i32 0, i32 2
 // CHECK-x86_64:   [[ADDR_CDE_1:%.*]] = bitcast [4 x i8]* [[ADDR_CDE]] to i32*
 // CHECK-x86_64:   store i32 [[CDE]], i32* [[ADDR_CDE_1]], align 4
-// CHECK-x86_64:   [[ADDR_FGH:%.*]] = getelementptr inbounds %TSC11BitfieldOneV, %TSC11BitfieldOneV* [[ARG]], i32 0, i32 3
+// CHECK-x86_64:   [[ADDR_FGH:%.*]] = getelementptr inbounds %TSo11BitfieldOneV, %TSo11BitfieldOneV* [[ARG]], i32 0, i32 3
 // CHECK-x86_64:   [[ADDR_FGH_1:%.*]] = bitcast [4 x i8]* [[ADDR_FGH]] to i32*
 // CHECK-x86_64:   store i32 [[FGH]], i32* [[ADDR_FGH_1]], align 8
-// CHECK-x86_64:   [[ADDR_I:%.*]] = getelementptr inbounds %TSC11BitfieldOneV, %TSC11BitfieldOneV* [[ARG]], i32 0, i32 4
+// CHECK-x86_64:   [[ADDR_I:%.*]] = getelementptr inbounds %TSo11BitfieldOneV, %TSo11BitfieldOneV* [[ARG]], i32 0, i32 4
 // CHECK-x86_64:   [[ADDR_I_V:%.*]] = getelementptr inbounds %TSf, %TSf* [[ADDR_I]], i32 0, i32 0
 // CHECK-x86_64:   store float [[I]], float* [[ADDR_I_V]], align 4
-// CHECK-x86_64:   [[ADDR_JK:%.*]] = getelementptr inbounds %TSC11BitfieldOneV, %TSC11BitfieldOneV* [[ARG]], i32 0, i32 5
+// CHECK-x86_64:   [[ADDR_JK:%.*]] = getelementptr inbounds %TSo11BitfieldOneV, %TSo11BitfieldOneV* [[ARG]], i32 0, i32 5
 // CHECK-x86_64:   [[ADDR_JK_1:%.*]] = bitcast [1 x i8]* [[ADDR_JK]] to i8*
 // CHECK-x86_64:   store i8 [[JK]], i8* [[ADDR_JK_1]], align 8
-// CHECK-x86_64:   [[ADDR_L:%.*]] = getelementptr inbounds %TSC11BitfieldOneV, %TSC11BitfieldOneV* [[ARG]], i32 0, i32 7
+// CHECK-x86_64:   [[ADDR_L:%.*]] = getelementptr inbounds %TSo11BitfieldOneV, %TSo11BitfieldOneV* [[ARG]], i32 0, i32 7
 // CHECK-x86_64:   [[ADDR_L_V:%.*]] = getelementptr inbounds %Ts6UInt64V, %Ts6UInt64V* [[ADDR_L]], i32 0, i32 0
 // CHECK-x86_64:   store i64 [[L]], i64* [[ADDR_L_V]], align 8
-// CHECK-x86_64:   [[ADDR_M:%.*]] = getelementptr inbounds %TSC11BitfieldOneV, %TSC11BitfieldOneV* [[ARG]], i32 0, i32 8
+// CHECK-x86_64:   [[ADDR_M:%.*]] = getelementptr inbounds %TSo11BitfieldOneV, %TSo11BitfieldOneV* [[ARG]], i32 0, i32 8
 // CHECK-x86_64:   [[ADDR_M_V:%.*]] = getelementptr inbounds %Ts6UInt32V, %Ts6UInt32V* [[ADDR_M]], i32 0, i32 0
 // CHECK-x86_64:   store i32 [[M]], i32* [[ADDR_M_V]], align 8
-// CHECK-x86_64:   call void @consumeBitfieldOne(%TSC11BitfieldOneV* byval align 8 [[ARG]])
+// CHECK-x86_64:   call void @consumeBitfieldOne(%TSo11BitfieldOneV* byval align 8 [[ARG]])
 // CHECK-x86_64:   ret void
 
 
@@ -304,7 +304,7 @@ entry(%b : $@convention(block) (CChar) -> CChar, %c : $CChar):
 }
 
 // CHECK-x86_64-LABEL: define{{( protected)?}} swiftcc void @testBitfieldInBlock
-// CHECK-x86_64:         call void {{%.*}}(%TSC11BitfieldOneV* noalias nocapture sret {{%.*}}, %objc_block* {{%.*}}, %TSC11BitfieldOneV* byval align 8 {{%.*}})
+// CHECK-x86_64:         call void {{%.*}}(%TSo11BitfieldOneV* noalias nocapture sret {{%.*}}, %objc_block* {{%.*}}, %TSo11BitfieldOneV* byval align 8 {{%.*}})
 sil @testBitfieldInBlock : $@convention(thin) (@owned @convention(block) (BitfieldOne) -> BitfieldOne, BitfieldOne) -> BitfieldOne  {
 entry(%b : $@convention(block) (BitfieldOne) -> BitfieldOne, %x : $BitfieldOne):
   %r = apply %b(%x) : $@convention(block) (BitfieldOne) -> BitfieldOne

--- a/test/IRGen/cf.sil
+++ b/test/IRGen/cf.sil
@@ -4,14 +4,14 @@
 // REQUIRES: objc_interop
 
 // CHECK: [[TYPE:%swift.type]] = type
-// CHECK: [[REFRIGERATOR:%TSo14CCRefrigeratorC]] = type
+// CHECK: [[REFRIGERATOR:%TSo17CCRefrigeratorRefa]] = type
 // CHECK: [[OBJC:%objc_object]] = type
 
-// CHECK: [[REFRIGERATOR_NAME:@.*]] = private unnamed_addr constant [20 x i8] c"So14CCRefrigeratorC\00"
+// CHECK: [[REFRIGERATOR_NAME:@.*]] = private unnamed_addr constant [23 x i8] c"So17CCRefrigeratorRefa\00"
 
-// CHECK-32: @_T0So14CCRefrigeratorCN = linkonce_odr hidden global <{ {{.*}} }> <{ i8* getelementptr inbounds ([20 x i8], [20 x i8]* [[REFRIGERATOR_NAME]], i32 0, i32 0), [[TYPE]]* null, i32 0, i8** @_T0BOWV, i32 16, [[TYPE]]* null, i8* null, i8* null, i8* null }>
+// CHECK-32: @_T0So17CCRefrigeratorRefaN = linkonce_odr hidden global <{ {{.*}} }> <{ i8* getelementptr inbounds ([23 x i8], [23 x i8]* [[REFRIGERATOR_NAME]], i32 0, i32 0), [[TYPE]]* null, i32 0, i8** @_T0BOWV, i32 16, [[TYPE]]* null, i8* null, i8* null, i8* null }>
 
-// CHECK-64: @_T0So14CCRefrigeratorCN = linkonce_odr hidden global <{ {{.*}} }> <{ i8* getelementptr inbounds ([20 x i8], [20 x i8]* [[REFRIGERATOR_NAME]], i64 0, i64 0), [[TYPE]]* null, i64 0, i8** @_T0BOWV, i64 16, [[TYPE]]* null, i8* null, i8* null, i8* null }>
+// CHECK-64: @_T0So17CCRefrigeratorRefaN = linkonce_odr hidden global <{ {{.*}} }> <{ i8* getelementptr inbounds ([23 x i8], [23 x i8]* [[REFRIGERATOR_NAME]], i64 0, i64 0), [[TYPE]]* null, i64 0, i8** @_T0BOWV, i64 16, [[TYPE]]* null, i8* null, i8* null, i8* null }>
 
 sil_stage canonical
 
@@ -30,10 +30,10 @@ bb0(%0 : $CCRefrigerator):
 
 // CHECK:    define{{( protected)?}} swiftcc void @call_generic([[REFRIGERATOR]]*) {{.*}} {
 // CHECK:      [[T0:%.*]] = bitcast [[REFRIGERATOR]]* %0 to [[OBJC]]*
-// CHECK-NEXT: [[T1:%.*]] = call [[TYPE]]* @_T0So14CCRefrigeratorCMa()
+// CHECK-NEXT: [[T1:%.*]] = call [[TYPE]]* @_T0So17CCRefrigeratorRefaMa()
 // CHECK-NEXT: call swiftcc void @generic_function([[OBJC]]* [[T0]], [[TYPE]]* [[T1]])
 // CHECK-NEXT: ret void
 
-// CHECK:    define linkonce_odr hidden [[TYPE]]* @_T0So14CCRefrigeratorCMa()
-// CHECK-32:    call [[TYPE]]* @swift_getForeignTypeMetadata([[TYPE]]* bitcast (i8* getelementptr inbounds (i8, i8* bitcast ({{.*}}* @_T0So14CCRefrigeratorCN to i8*), i32 16) to [[TYPE]]*))
-// CHECK-64:    call [[TYPE]]* @swift_getForeignTypeMetadata([[TYPE]]* bitcast (i8* getelementptr inbounds (i8, i8* bitcast ({{.*}}* @_T0So14CCRefrigeratorCN to i8*), i64 32) to [[TYPE]]*))
+// CHECK:    define linkonce_odr hidden [[TYPE]]* @_T0So17CCRefrigeratorRefaMa()
+// CHECK-32:    call [[TYPE]]* @swift_getForeignTypeMetadata([[TYPE]]* bitcast (i8* getelementptr inbounds (i8, i8* bitcast ({{.*}}* @_T0So17CCRefrigeratorRefaN to i8*), i32 16) to [[TYPE]]*))
+// CHECK-64:    call [[TYPE]]* @swift_getForeignTypeMetadata([[TYPE]]* bitcast (i8* getelementptr inbounds (i8, i8* bitcast ({{.*}}* @_T0So17CCRefrigeratorRefaN to i8*), i64 32) to [[TYPE]]*))

--- a/test/IRGen/foreign_types.sil
+++ b/test/IRGen/foreign_types.sil
@@ -3,12 +3,12 @@
 sil_stage canonical
 import c_layout
 
-// CHECK-LABEL: @_T0SC14HasNestedUnionV18__Unnamed_struct_sVN = linkonce_odr hidden global
+// CHECK-LABEL: @_T0So14HasNestedUnionV18__Unnamed_struct_sVN = linkonce_odr hidden global
 // CHECK-SAME:  void (%swift.type*)* @initialize_metadata___Unnamed_struct_s,
 // CHECK-SAME:  i8* getelementptr inbounds
 // CHECK-SAME:  %swift.type* null,
 // CHECK-SAME:  [[INT:i[0-9]+]] 1,
-// CHECK-SAME:  @_T0SC14HasNestedUnionV18__Unnamed_struct_sVWV
+// CHECK-SAME:  @_T0So14HasNestedUnionV18__Unnamed_struct_sVWV
 // CHECK-SAME:  [[INT]] 1,
 // CHECK-SAME:  [[INT]] sub ({{.*}}),
 // CHECK-SAME:  %swift.type* null,
@@ -24,7 +24,7 @@ bb0:
 }
 
 // CHECK-LABEL: define private void @initialize_metadata___Unnamed_struct_s
-// CHECK:       [[PARENT:%.*]] = call %swift.type* @_T0SC14HasNestedUnionVMa()
+// CHECK:       [[PARENT:%.*]] = call %swift.type* @_T0So14HasNestedUnionVMa()
 // CHECK-NEXT:  [[T0:%.]] = bitcast %swift.type* %0 to %swift.type**
 // CHECK-NEXT:  [[T1:%.]] = getelementptr inbounds %swift.type*, %swift.type** [[T0]], [[INT]] 2
 // CHECK-NEXT:  store %swift.type* [[PARENT]], %swift.type** [[T1]],

--- a/test/IRGen/newtype.swift
+++ b/test/IRGen/newtype.swift
@@ -10,15 +10,15 @@ import Newtype
 // REQUIRES: objc_interop
 
 // Witness table for synthesized ClosedEnums : _ObjectiveCBridgeable.
-// CHECK: @_T0So10ClosedEnumVs21_ObjectiveCBridgeable7NewtypeWP = linkonce_odr
+// CHECK: @_T0So13SNTClosedEnumas21_ObjectiveCBridgeable7NewtypeWP = linkonce_odr
 
-// CHECK-LABEL: define swiftcc %TSo8NSStringC* @_T07newtype14getErrorDomainSo0cD0VyF()
+// CHECK-LABEL: define swiftcc %TSo8NSStringC* @_T07newtype14getErrorDomainSo08SNTErrorD0ayF()
 public func getErrorDomain() -> ErrorDomain {
-  // CHECK: load %TSo8NSStringC*, %TSo8NSStringC** getelementptr inbounds (%TSo11ErrorDomainV, %TSo11ErrorDomainV* {{.*}}@SNTErrOne
+  // CHECK: load %TSo8NSStringC*, %TSo8NSStringC** getelementptr inbounds (%TSo14SNTErrorDomaina, %TSo14SNTErrorDomaina* {{.*}}@SNTErrOne
   return .one
 }
 
-// CHECK-LABEL: _T07newtype6getFooSo14NSNotificationC4NameVyF
+// CHECK-LABEL: _T07newtype6getFooSo18NSNotificationNameayF
 public func getFoo() -> NSNotification.Name {
   return NSNotification.Name.Foo
   // CHECK: load {{.*}} @FooNotification
@@ -40,7 +40,7 @@ public func getGlobalNotification(_ x: Int) -> String {
 // CHECK: ret
 }
 
-// CHECK-LABEL: _T07newtype17getCFNewTypeValueSo0cD0VSb6useVar_tF
+// CHECK-LABEL: _T07newtype17getCFNewTypeValueSo0cD0aSb6useVar_tF
 public func getCFNewTypeValue(useVar: Bool) -> CFNewType {
   if (useVar) {
     return CFNewType.MyCFNewTypeValue
@@ -52,7 +52,7 @@ public func getCFNewTypeValue(useVar: Bool) -> CFNewType {
   // CHECK: ret
 }
 
-// CHECK-LABEL: _T07newtype21getUnmanagedCFNewTypes0C0VySo8CFStringCGSb6useVar_tF
+// CHECK-LABEL: _T07newtype21getUnmanagedCFNewTypes0C0VySo11CFStringRefaGSb6useVar_tF
 public func getUnmanagedCFNewType(useVar: Bool) -> Unmanaged<CFString> {
   if (useVar) {
     return CFNewType.MyCFNewTypeValueUnaudited
@@ -133,26 +133,26 @@ public func anchor() -> Bool {
 }
 
 class ObjCTest {
-  // CHECK-LABEL: define hidden %0* @_T07newtype8ObjCTestC19optionalPassThroughSo11ErrorDomainVSgAGFTo
+  // CHECK-LABEL: define hidden %0* @_T07newtype8ObjCTestC19optionalPassThroughSo14SNTErrorDomainaSgAGFTo
   // CHECK: [[CASTED:%.+]] = ptrtoint %0* %2 to i{{32|64}}
-  // CHECK: [[RESULT:%.+]] = call swiftcc i{{32|64}} @_T07newtype8ObjCTestC19optionalPassThroughSo11ErrorDomainVSgAGF(i{{32|64}} [[CASTED]], %T7newtype8ObjCTestC* swiftself {{%.+}})
+  // CHECK: [[RESULT:%.+]] = call swiftcc i{{32|64}} @_T07newtype8ObjCTestC19optionalPassThroughSo14SNTErrorDomainaSgAGF(i{{32|64}} [[CASTED]], %T7newtype8ObjCTestC* swiftself {{%.+}})
   // CHECK: [[OPAQUE_RESULT:%.+]] = inttoptr i{{32|64}} [[RESULT]] to %0*
   // CHECK: ret %0* [[OPAQUE_RESULT]]
   // CHECK: {{^}$}}
 
-  // OPT-LABEL: define hidden %0* @_T07newtype8ObjCTestC19optionalPassThroughSo11ErrorDomainVSgAGFTo
+  // OPT-LABEL: define hidden %0* @_T07newtype8ObjCTestC19optionalPassThroughSo14SNTErrorDomainaSgAGFTo
   // OPT: ret %0* %2
   // OPT: {{^}$}}
   @objc func optionalPassThrough(_ ed: ErrorDomain?) -> ErrorDomain? {
     return ed
   }
 
-  // CHECK-LABEL: define hidden i32 @_T07newtype8ObjCTestC18integerPassThroughSo5MyIntVAFFTo
-  // CHECK: [[RESULT:%.+]] = call swiftcc i32 @_T07newtype8ObjCTestC18integerPassThroughSo5MyIntVAFF(i32 %2, %T7newtype8ObjCTestC* swiftself {{%.+}})
+  // CHECK-LABEL: define hidden i32 @_T07newtype8ObjCTestC18integerPassThroughSo5MyIntaAFFTo
+  // CHECK: [[RESULT:%.+]] = call swiftcc i32 @_T07newtype8ObjCTestC18integerPassThroughSo5MyIntaAFF(i32 %2, %T7newtype8ObjCTestC* swiftself {{%.+}})
   // CHECK: ret i32 [[RESULT]]
   // CHECK: {{^}$}}
 
-  // OPT-LABEL: define hidden i32 @_T07newtype8ObjCTestC18integerPassThroughSo5MyIntVAFFTo
+  // OPT-LABEL: define hidden i32 @_T07newtype8ObjCTestC18integerPassThroughSo5MyIntaAFFTo
   // OPT: ret i32 %2
   // OPT: {{^}$}}
   @objc func integerPassThrough(_ num: MyInt) -> MyInt {

--- a/test/IRGen/newtype.swift
+++ b/test/IRGen/newtype.swift
@@ -10,11 +10,11 @@ import Newtype
 // REQUIRES: objc_interop
 
 // Witness table for synthesized ClosedEnums : _ObjectiveCBridgeable.
-// CHECK: @_T0SC10ClosedEnumVs21_ObjectiveCBridgeable7NewtypeWP = linkonce_odr
+// CHECK: @_T0So10ClosedEnumVs21_ObjectiveCBridgeable7NewtypeWP = linkonce_odr
 
-// CHECK-LABEL: define swiftcc %TSo8NSStringC* @_T07newtype14getErrorDomainSC0cD0VyF()
+// CHECK-LABEL: define swiftcc %TSo8NSStringC* @_T07newtype14getErrorDomainSo0cD0VyF()
 public func getErrorDomain() -> ErrorDomain {
-  // CHECK: load %TSo8NSStringC*, %TSo8NSStringC** getelementptr inbounds (%TSC11ErrorDomainV, %TSC11ErrorDomainV* {{.*}}@SNTErrOne
+  // CHECK: load %TSo8NSStringC*, %TSo8NSStringC** getelementptr inbounds (%TSo11ErrorDomainV, %TSo11ErrorDomainV* {{.*}}@SNTErrOne
   return .one
 }
 
@@ -40,7 +40,7 @@ public func getGlobalNotification(_ x: Int) -> String {
 // CHECK: ret
 }
 
-// CHECK-LABEL: _T07newtype17getCFNewTypeValueSC0cD0VSb6useVar_tF
+// CHECK-LABEL: _T07newtype17getCFNewTypeValueSo0cD0VSb6useVar_tF
 public func getCFNewTypeValue(useVar: Bool) -> CFNewType {
   if (useVar) {
     return CFNewType.MyCFNewTypeValue
@@ -133,26 +133,26 @@ public func anchor() -> Bool {
 }
 
 class ObjCTest {
-  // CHECK-LABEL: define hidden %0* @_T07newtype8ObjCTestC19optionalPassThroughSC11ErrorDomainVSgAGFTo
+  // CHECK-LABEL: define hidden %0* @_T07newtype8ObjCTestC19optionalPassThroughSo11ErrorDomainVSgAGFTo
   // CHECK: [[CASTED:%.+]] = ptrtoint %0* %2 to i{{32|64}}
-  // CHECK: [[RESULT:%.+]] = call swiftcc i{{32|64}} @_T07newtype8ObjCTestC19optionalPassThroughSC11ErrorDomainVSgAGF(i{{32|64}} [[CASTED]], %T7newtype8ObjCTestC* swiftself {{%.+}})
+  // CHECK: [[RESULT:%.+]] = call swiftcc i{{32|64}} @_T07newtype8ObjCTestC19optionalPassThroughSo11ErrorDomainVSgAGF(i{{32|64}} [[CASTED]], %T7newtype8ObjCTestC* swiftself {{%.+}})
   // CHECK: [[OPAQUE_RESULT:%.+]] = inttoptr i{{32|64}} [[RESULT]] to %0*
   // CHECK: ret %0* [[OPAQUE_RESULT]]
   // CHECK: {{^}$}}
 
-  // OPT-LABEL: define hidden %0* @_T07newtype8ObjCTestC19optionalPassThroughSC11ErrorDomainVSgAGFTo
+  // OPT-LABEL: define hidden %0* @_T07newtype8ObjCTestC19optionalPassThroughSo11ErrorDomainVSgAGFTo
   // OPT: ret %0* %2
   // OPT: {{^}$}}
   @objc func optionalPassThrough(_ ed: ErrorDomain?) -> ErrorDomain? {
     return ed
   }
 
-  // CHECK-LABEL: define hidden i32 @_T07newtype8ObjCTestC18integerPassThroughSC5MyIntVAFFTo
-  // CHECK: [[RESULT:%.+]] = call swiftcc i32 @_T07newtype8ObjCTestC18integerPassThroughSC5MyIntVAFF(i32 %2, %T7newtype8ObjCTestC* swiftself {{%.+}})
+  // CHECK-LABEL: define hidden i32 @_T07newtype8ObjCTestC18integerPassThroughSo5MyIntVAFFTo
+  // CHECK: [[RESULT:%.+]] = call swiftcc i32 @_T07newtype8ObjCTestC18integerPassThroughSo5MyIntVAFF(i32 %2, %T7newtype8ObjCTestC* swiftself {{%.+}})
   // CHECK: ret i32 [[RESULT]]
   // CHECK: {{^}$}}
 
-  // OPT-LABEL: define hidden i32 @_T07newtype8ObjCTestC18integerPassThroughSC5MyIntVAFFTo
+  // OPT-LABEL: define hidden i32 @_T07newtype8ObjCTestC18integerPassThroughSo5MyIntVAFFTo
   // OPT: ret i32 %2
   // OPT: {{^}$}}
   @objc func integerPassThrough(_ num: MyInt) -> MyInt {

--- a/test/IRGen/objc.swift
+++ b/test/IRGen/objc.swift
@@ -15,14 +15,14 @@ import gizmo
 // CHECK: [[OBJC:%objc_object]] = type
 // CHECK: [[ID:%T4objc2idV]] = type <{ %Ts9AnyObjectP }>
 // CHECK: [[GIZMO:%TSo5GizmoC]] = type
-// CHECK: [[RECT:%TSC4RectV]] = type
+// CHECK: [[RECT:%TSo4RectV]] = type
 // CHECK: [[FLOAT:%TSf]] = type
 
 // CHECK: @"\01L_selector_data(bar)" = private global [4 x i8] c"bar\00", section "__TEXT,__objc_methname,cstring_literals", align 1
 // CHECK: @"\01L_selector(bar)" = private externally_initialized global i8* getelementptr inbounds ([4 x i8], [4 x i8]* @"\01L_selector_data(bar)", i64 0, i64 0), section "__DATA,__objc_selrefs,literal_pointers,no_dead_strip", align 8
 
-// CHECK: @_T0SC4RectVMn = linkonce_odr hidden constant
-// CHECK: @_T0SC4RectVN = linkonce_odr hidden global
+// CHECK: @_T0So4RectVMn = linkonce_odr hidden constant
+// CHECK: @_T0So4RectVN = linkonce_odr hidden global
 
 // CHECK: @"\01L_selector_data(acquiesce)"
 // CHECK-NOT: @"\01L_selector_data(disharmonize)"
@@ -124,8 +124,8 @@ func test10(_ g: Gizmo, r: Rect) {
 // Force the emission of the Rect metadata.
 func test11_helper<T>(_ t: T) {}
 // NSRect's metadata needs to be uniqued at runtime using getForeignTypeMetadata.
-// CHECK-LABEL: define hidden swiftcc void @_T04objc6test11ySC4RectVF
-// CHECK:         call %swift.type* @swift_getForeignTypeMetadata({{.*}} @_T0SC4RectVN
+// CHECK-LABEL: define hidden swiftcc void @_T04objc6test11ySo4RectVF
+// CHECK:         call %swift.type* @swift_getForeignTypeMetadata({{.*}} @_T0So4RectVN
 func test11(_ r: Rect) { test11_helper(r) }
 
 class WeakObjC {

--- a/test/IRGen/objc_class_export.swift
+++ b/test/IRGen/objc_class_export.swift
@@ -10,9 +10,9 @@
 // CHECK: [[FOO:%T17objc_class_export3FooC]] = type <{ [[REF]], %TSi }>
 // CHECK: [[INT:%TSi]] = type <{ i64 }>
 // CHECK: [[DOUBLE:%TSd]] = type <{ double }>
-// CHECK: [[NSRECT:%TSC6NSRectV]] = type <{ %TSC7NSPointV, %TSC6NSSizeV }>
-// CHECK: [[NSPOINT:%TSC7NSPointV]] = type <{ %TSd, %TSd }>
-// CHECK: [[NSSIZE:%TSC6NSSizeV]] = type <{ %TSd, %TSd }>
+// CHECK: [[NSRECT:%TSo6NSRectV]] = type <{ %TSo7NSPointV, %TSo6NSSizeV }>
+// CHECK: [[NSPOINT:%TSo7NSPointV]] = type <{ %TSd, %TSd }>
+// CHECK: [[NSSIZE:%TSo6NSSizeV]] = type <{ %TSd, %TSd }>
 // CHECK: [[OBJC:%objc_object]] = type opaque
 
 // CHECK: @"OBJC_METACLASS_$__TtC17objc_class_export3Foo" = hidden global %objc_class {
@@ -58,7 +58,7 @@
 // CHECK:   %swift.opaque* null,
 // CHECK:   i64 add (i64 ptrtoint ({{.*}}* @_DATA__TtC17objc_class_export3Foo to i64), i64 1),
 // CHECK:   [[FOO]]* (%swift.type*)* @_T017objc_class_export3FooC6createACyFZ,
-// CHECK:   void (double, double, double, double, [[FOO]]*)* @_T017objc_class_export3FooC10drawInRectySC6NSRectV5dirty_tF
+// CHECK:   void (double, double, double, double, [[FOO]]*)* @_T017objc_class_export3FooC10drawInRectySo6NSRectV5dirty_tF
 // CHECK: }>, section "__DATA,__objc_data, regular"
 // -- TODO: The OBJC_CLASS symbol should reflect the qualified runtime name of
 //    Foo.
@@ -82,25 +82,25 @@ struct BigStructWithNativeObjects {
 
   @objc func drawInRect(dirty dirty: NSRect) {
   }
-  // CHECK: define internal void @_T017objc_class_export3FooC10drawInRectySC6NSRectV5dirty_tFTo([[OPAQUE:%.*]]*, i8*, [[NSRECT]]* byval align 8) unnamed_addr {{.*}} {
+  // CHECK: define internal void @_T017objc_class_export3FooC10drawInRectySo6NSRectV5dirty_tFTo([[OPAQUE:%.*]]*, i8*, [[NSRECT]]* byval align 8) unnamed_addr {{.*}} {
   // CHECK:   [[CAST:%[a-zA-Z0-9]+]] = bitcast [[OPAQUE]]* %0 to [[FOO]]*
-  // CHECK:   call swiftcc void @_T017objc_class_export3FooC10drawInRectySC6NSRectV5dirty_tF(double {{.*}}, double {{.*}}, double {{.*}}, double {{.*}}, [[FOO]]* swiftself [[CAST]])
+  // CHECK:   call swiftcc void @_T017objc_class_export3FooC10drawInRectySo6NSRectV5dirty_tF(double {{.*}}, double {{.*}}, double {{.*}}, double {{.*}}, [[FOO]]* swiftself [[CAST]])
   // CHECK: }
 
   @objc func bounds() -> NSRect {
     return NSRect(origin: NSPoint(x: 0, y: 0), 
                   size: NSSize(width: 0, height: 0))
   }
-  // CHECK: define internal void @_T017objc_class_export3FooC6boundsSC6NSRectVyFTo([[NSRECT]]* noalias nocapture sret, [[OPAQUE4:%.*]]*, i8*) unnamed_addr {{.*}} {
+  // CHECK: define internal void @_T017objc_class_export3FooC6boundsSo6NSRectVyFTo([[NSRECT]]* noalias nocapture sret, [[OPAQUE4:%.*]]*, i8*) unnamed_addr {{.*}} {
   // CHECK:   [[CAST:%[a-zA-Z0-9]+]] = bitcast [[OPAQUE4]]* %1 to [[FOO]]*
-  // CHECK:   call swiftcc { double, double, double, double } @_T017objc_class_export3FooC6boundsSC6NSRectVyF([[FOO]]* swiftself [[CAST]])
+  // CHECK:   call swiftcc { double, double, double, double } @_T017objc_class_export3FooC6boundsSo6NSRectVyF([[FOO]]* swiftself [[CAST]])
 
   @objc func convertRectToBacking(r r: NSRect) -> NSRect {
     return r
   }
-  // CHECK: define internal void @_T017objc_class_export3FooC20convertRectToBackingSC6NSRectVAF1r_tFTo([[NSRECT]]* noalias nocapture sret, [[OPAQUE5:%.*]]*, i8*, [[NSRECT]]* byval align 8) unnamed_addr {{.*}} {
+  // CHECK: define internal void @_T017objc_class_export3FooC20convertRectToBackingSo6NSRectVAF1r_tFTo([[NSRECT]]* noalias nocapture sret, [[OPAQUE5:%.*]]*, i8*, [[NSRECT]]* byval align 8) unnamed_addr {{.*}} {
   // CHECK:   [[CAST:%[a-zA-Z0-9]+]] = bitcast [[OPAQUE5]]* %1 to [[FOO]]*
-  // CHECK:   call swiftcc { double, double, double, double } @_T017objc_class_export3FooC20convertRectToBackingSC6NSRectVAF1r_tF(double {{.*}}, double {{.*}}, double {{.*}}, double {{.*}}, [[FOO]]* swiftself [[CAST]])
+  // CHECK:   call swiftcc { double, double, double, double } @_T017objc_class_export3FooC20convertRectToBackingSo6NSRectVAF1r_tF(double {{.*}}, double {{.*}}, double {{.*}}, double {{.*}}, [[FOO]]* swiftself [[CAST]])
 
   func doStuffToSwiftSlice(f f: [Int]) {
   }

--- a/test/IRGen/objc_generic_class_metadata.sil
+++ b/test/IRGen/objc_generic_class_metadata.sil
@@ -71,7 +71,7 @@ entry(%0: $Subclass):
   unreachable
 }
 
-sil @_T027objc_generic_class_metadata8SubclassCSQyACGs10DictionaryVySC13GenericOptionVypGSg7options_tcfcTo : $@convention(objc_method) (@owned Subclass, @owned NSDictionary) -> @owned Subclass {
+sil @_T027objc_generic_class_metadata8SubclassCSQyACGs10DictionaryVySo13GenericOptionVypGSg7options_tcfcTo : $@convention(objc_method) (@owned Subclass, @owned NSDictionary) -> @owned Subclass {
 entry(%0: $Subclass, %1: $NSDictionary):
   unreachable
 }

--- a/test/IRGen/objc_generic_class_metadata.sil
+++ b/test/IRGen/objc_generic_class_metadata.sil
@@ -71,7 +71,7 @@ entry(%0: $Subclass):
   unreachable
 }
 
-sil @_T027objc_generic_class_metadata8SubclassCSQyACGs10DictionaryVySo13GenericOptionVypGSg7options_tcfcTo : $@convention(objc_method) (@owned Subclass, @owned NSDictionary) -> @owned Subclass {
+sil @_T027objc_generic_class_metadata8SubclassCSQyACGs10DictionaryVySo13GenericOptionaypGSg7options_tcfcTo : $@convention(objc_method) (@owned Subclass, @owned NSDictionary) -> @owned Subclass {
 entry(%0: $Subclass, %1: $NSDictionary):
   unreachable
 }

--- a/test/IRGen/objc_ns_enum.swift
+++ b/test/IRGen/objc_ns_enum.swift
@@ -8,71 +8,71 @@
 import Foundation
 import gizmo
 
-// CHECK: @_T0SC16NSRuncingOptionsOWV = linkonce_odr hidden constant
-// CHECK: @_T0SC16NSRuncingOptionsOMn = linkonce_odr hidden constant
-// CHECK: @_T0SC16NSRuncingOptionsON = linkonce_odr hidden global
-// CHECK: @_T0SC28NeverActuallyMentionedByNameOs9Equatable5gizmoWP = linkonce_odr hidden constant
+// CHECK: @_T0So16NSRuncingOptionsOWV = linkonce_odr hidden constant
+// CHECK: @_T0So16NSRuncingOptionsOMn = linkonce_odr hidden constant
+// CHECK: @_T0So16NSRuncingOptionsON = linkonce_odr hidden global
+// CHECK: @_T0So28NeverActuallyMentionedByNameOs9Equatable5gizmoWP = linkonce_odr hidden constant
 
 // CHECK-LABEL: define{{( protected)?}} i32 @main
-// CHECK:         call %swift.type* @_T0SC16NSRuncingOptionsOMa()
+// CHECK:         call %swift.type* @_T0So16NSRuncingOptionsOMa()
 
-// CHECK: define hidden swiftcc i16 @_T012objc_ns_enum09imported_C9_inject_aSC16NSRuncingOptionsOyF()
+// CHECK: define hidden swiftcc i16 @_T012objc_ns_enum09imported_C9_inject_aSo16NSRuncingOptionsOyF()
 // CHECK:   ret i16 123
 func imported_enum_inject_a() -> NSRuncingOptions {
   return .mince
 }
 
-// CHECK: define hidden swiftcc i16 @_T012objc_ns_enum09imported_C9_inject_bSC16NSRuncingOptionsOyF()
+// CHECK: define hidden swiftcc i16 @_T012objc_ns_enum09imported_C9_inject_bSo16NSRuncingOptionsOyF()
 // CHECK:   ret i16 4567
 func imported_enum_inject_b() -> NSRuncingOptions {
   return .quinceSliced
 }
 
-// CHECK: define hidden swiftcc i16 @_T012objc_ns_enum09imported_C9_inject_cSC16NSRuncingOptionsOyF()
+// CHECK: define hidden swiftcc i16 @_T012objc_ns_enum09imported_C9_inject_cSo16NSRuncingOptionsOyF()
 // CHECK:   ret i16 5678
 func imported_enum_inject_c() -> NSRuncingOptions {
   return .quinceJulienned
 }
 
-// CHECK: define hidden swiftcc i16 @_T012objc_ns_enum09imported_C9_inject_dSC16NSRuncingOptionsOyF()
+// CHECK: define hidden swiftcc i16 @_T012objc_ns_enum09imported_C9_inject_dSo16NSRuncingOptionsOyF()
 // CHECK:   ret i16 6789
 func imported_enum_inject_d() -> NSRuncingOptions {
   return .quinceDiced
 }
 
-// CHECK: define hidden swiftcc i32 @_T012objc_ns_enum09imported_C17_inject_radixed_aSC16NSRadixedOptionsOyF() {{.*}} {
+// CHECK: define hidden swiftcc i32 @_T012objc_ns_enum09imported_C17_inject_radixed_aSo16NSRadixedOptionsOyF() {{.*}} {
 // -- octal 0755
 // CHECK:   ret i32 493
 func imported_enum_inject_radixed_a() -> NSRadixedOptions {
   return .octal
 }
 
-// CHECK: define hidden swiftcc i32 @_T012objc_ns_enum09imported_C17_inject_radixed_bSC16NSRadixedOptionsOyF() {{.*}} {
+// CHECK: define hidden swiftcc i32 @_T012objc_ns_enum09imported_C17_inject_radixed_bSo16NSRadixedOptionsOyF() {{.*}} {
 // -- hex 0xFFFF
 // CHECK:   ret i32 65535
 func imported_enum_inject_radixed_b() -> NSRadixedOptions {
   return .hex
 }
 
-// CHECK: define hidden swiftcc i32 @_T012objc_ns_enum09imported_C18_inject_negative_aSC17NSNegativeOptionsOyF() {{.*}} {
+// CHECK: define hidden swiftcc i32 @_T012objc_ns_enum09imported_C18_inject_negative_aSo17NSNegativeOptionsOyF() {{.*}} {
 // CHECK:   ret i32 -1
 func imported_enum_inject_negative_a() -> NSNegativeOptions {
   return .foo
 }
 
-// CHECK: define hidden swiftcc i32 @_T012objc_ns_enum09imported_C18_inject_negative_bSC17NSNegativeOptionsOyF() {{.*}} {
+// CHECK: define hidden swiftcc i32 @_T012objc_ns_enum09imported_C18_inject_negative_bSo17NSNegativeOptionsOyF() {{.*}} {
 // CHECK:   ret i32 -2147483648
 func imported_enum_inject_negative_b() -> NSNegativeOptions {
   return .bar
 }
 
-// CHECK: define hidden swiftcc i32 @_T012objc_ns_enum09imported_C27_inject_negative_unsigned_aSC25NSNegativeUnsignedOptionsOyF() {{.*}} {
+// CHECK: define hidden swiftcc i32 @_T012objc_ns_enum09imported_C27_inject_negative_unsigned_aSo25NSNegativeUnsignedOptionsOyF() {{.*}} {
 // CHECK:   ret i32 -1
 func imported_enum_inject_negative_unsigned_a() -> NSNegativeUnsignedOptions {
   return .foo
 }
 
-// CHECK: define hidden swiftcc i32 @_T012objc_ns_enum09imported_C27_inject_negative_unsigned_bSC25NSNegativeUnsignedOptionsOyF() {{.*}} {
+// CHECK: define hidden swiftcc i32 @_T012objc_ns_enum09imported_C27_inject_negative_unsigned_bSo25NSNegativeUnsignedOptionsOyF() {{.*}} {
 // CHECK:   ret i32 -2147483648
 func imported_enum_inject_negative_unsigned_b() -> NSNegativeUnsignedOptions {
   return .bar
@@ -85,8 +85,8 @@ func test_enum_without_name_Equatable(_ obj: TestThatEnumType) -> Bool {
 func use_metadata<T>(_ t:T){}
 use_metadata(NSRuncingOptions.mince)
 
-// CHECK-LABEL: define linkonce_odr hidden %swift.type* @_T0SC16NSRuncingOptionsOMa()
-// CHECK:         call %swift.type* @swift_getForeignTypeMetadata({{.*}} @_T0SC16NSRuncingOptionsON {{.*}}) [[NOUNWIND_READNONE:#[0-9]+]]
+// CHECK-LABEL: define linkonce_odr hidden %swift.type* @_T0So16NSRuncingOptionsOMa()
+// CHECK:         call %swift.type* @swift_getForeignTypeMetadata({{.*}} @_T0So16NSRuncingOptionsON {{.*}}) [[NOUNWIND_READNONE:#[0-9]+]]
 
 @objc enum ExportedToObjC: Int {
   case Foo = -1, Bar, Bas

--- a/test/IRGen/objc_ns_enum.swift
+++ b/test/IRGen/objc_ns_enum.swift
@@ -8,71 +8,71 @@
 import Foundation
 import gizmo
 
-// CHECK: @_T0So16NSRuncingOptionsOWV = linkonce_odr hidden constant
-// CHECK: @_T0So16NSRuncingOptionsOMn = linkonce_odr hidden constant
-// CHECK: @_T0So16NSRuncingOptionsON = linkonce_odr hidden global
-// CHECK: @_T0So28NeverActuallyMentionedByNameOs9Equatable5gizmoWP = linkonce_odr hidden constant
+// CHECK: @_T0So16NSRuncingOptionsVWV = linkonce_odr hidden constant
+// CHECK: @_T0So16NSRuncingOptionsVMn = linkonce_odr hidden constant
+// CHECK: @_T0So16NSRuncingOptionsVN = linkonce_odr hidden global
+// CHECK: @_T0So28NeverActuallyMentionedByNameVs9Equatable5gizmoWP = linkonce_odr hidden constant
 
 // CHECK-LABEL: define{{( protected)?}} i32 @main
-// CHECK:         call %swift.type* @_T0So16NSRuncingOptionsOMa()
+// CHECK:         call %swift.type* @_T0So16NSRuncingOptionsVMa()
 
-// CHECK: define hidden swiftcc i16 @_T012objc_ns_enum09imported_C9_inject_aSo16NSRuncingOptionsOyF()
+// CHECK: define hidden swiftcc i16 @_T012objc_ns_enum09imported_C9_inject_aSo16NSRuncingOptionsVyF()
 // CHECK:   ret i16 123
 func imported_enum_inject_a() -> NSRuncingOptions {
   return .mince
 }
 
-// CHECK: define hidden swiftcc i16 @_T012objc_ns_enum09imported_C9_inject_bSo16NSRuncingOptionsOyF()
+// CHECK: define hidden swiftcc i16 @_T012objc_ns_enum09imported_C9_inject_bSo16NSRuncingOptionsVyF()
 // CHECK:   ret i16 4567
 func imported_enum_inject_b() -> NSRuncingOptions {
   return .quinceSliced
 }
 
-// CHECK: define hidden swiftcc i16 @_T012objc_ns_enum09imported_C9_inject_cSo16NSRuncingOptionsOyF()
+// CHECK: define hidden swiftcc i16 @_T012objc_ns_enum09imported_C9_inject_cSo16NSRuncingOptionsVyF()
 // CHECK:   ret i16 5678
 func imported_enum_inject_c() -> NSRuncingOptions {
   return .quinceJulienned
 }
 
-// CHECK: define hidden swiftcc i16 @_T012objc_ns_enum09imported_C9_inject_dSo16NSRuncingOptionsOyF()
+// CHECK: define hidden swiftcc i16 @_T012objc_ns_enum09imported_C9_inject_dSo16NSRuncingOptionsVyF()
 // CHECK:   ret i16 6789
 func imported_enum_inject_d() -> NSRuncingOptions {
   return .quinceDiced
 }
 
-// CHECK: define hidden swiftcc i32 @_T012objc_ns_enum09imported_C17_inject_radixed_aSo16NSRadixedOptionsOyF() {{.*}} {
+// CHECK: define hidden swiftcc i32 @_T012objc_ns_enum09imported_C17_inject_radixed_aSo16NSRadixedOptionsVyF() {{.*}} {
 // -- octal 0755
 // CHECK:   ret i32 493
 func imported_enum_inject_radixed_a() -> NSRadixedOptions {
   return .octal
 }
 
-// CHECK: define hidden swiftcc i32 @_T012objc_ns_enum09imported_C17_inject_radixed_bSo16NSRadixedOptionsOyF() {{.*}} {
+// CHECK: define hidden swiftcc i32 @_T012objc_ns_enum09imported_C17_inject_radixed_bSo16NSRadixedOptionsVyF() {{.*}} {
 // -- hex 0xFFFF
 // CHECK:   ret i32 65535
 func imported_enum_inject_radixed_b() -> NSRadixedOptions {
   return .hex
 }
 
-// CHECK: define hidden swiftcc i32 @_T012objc_ns_enum09imported_C18_inject_negative_aSo17NSNegativeOptionsOyF() {{.*}} {
+// CHECK: define hidden swiftcc i32 @_T012objc_ns_enum09imported_C18_inject_negative_aSo17NSNegativeOptionsVyF() {{.*}} {
 // CHECK:   ret i32 -1
 func imported_enum_inject_negative_a() -> NSNegativeOptions {
   return .foo
 }
 
-// CHECK: define hidden swiftcc i32 @_T012objc_ns_enum09imported_C18_inject_negative_bSo17NSNegativeOptionsOyF() {{.*}} {
+// CHECK: define hidden swiftcc i32 @_T012objc_ns_enum09imported_C18_inject_negative_bSo17NSNegativeOptionsVyF() {{.*}} {
 // CHECK:   ret i32 -2147483648
 func imported_enum_inject_negative_b() -> NSNegativeOptions {
   return .bar
 }
 
-// CHECK: define hidden swiftcc i32 @_T012objc_ns_enum09imported_C27_inject_negative_unsigned_aSo25NSNegativeUnsignedOptionsOyF() {{.*}} {
+// CHECK: define hidden swiftcc i32 @_T012objc_ns_enum09imported_C27_inject_negative_unsigned_aSo25NSNegativeUnsignedOptionsVyF() {{.*}} {
 // CHECK:   ret i32 -1
 func imported_enum_inject_negative_unsigned_a() -> NSNegativeUnsignedOptions {
   return .foo
 }
 
-// CHECK: define hidden swiftcc i32 @_T012objc_ns_enum09imported_C27_inject_negative_unsigned_bSo25NSNegativeUnsignedOptionsOyF() {{.*}} {
+// CHECK: define hidden swiftcc i32 @_T012objc_ns_enum09imported_C27_inject_negative_unsigned_bSo25NSNegativeUnsignedOptionsVyF() {{.*}} {
 // CHECK:   ret i32 -2147483648
 func imported_enum_inject_negative_unsigned_b() -> NSNegativeUnsignedOptions {
   return .bar
@@ -85,8 +85,8 @@ func test_enum_without_name_Equatable(_ obj: TestThatEnumType) -> Bool {
 func use_metadata<T>(_ t:T){}
 use_metadata(NSRuncingOptions.mince)
 
-// CHECK-LABEL: define linkonce_odr hidden %swift.type* @_T0So16NSRuncingOptionsOMa()
-// CHECK:         call %swift.type* @swift_getForeignTypeMetadata({{.*}} @_T0So16NSRuncingOptionsON {{.*}}) [[NOUNWIND_READNONE:#[0-9]+]]
+// CHECK-LABEL: define linkonce_odr hidden %swift.type* @_T0So16NSRuncingOptionsVMa()
+// CHECK:         call %swift.type* @swift_getForeignTypeMetadata({{.*}} @_T0So16NSRuncingOptionsVN {{.*}}) [[NOUNWIND_READNONE:#[0-9]+]]
 
 @objc enum ExportedToObjC: Int {
   case Foo = -1, Bar, Bas

--- a/test/IRGen/objc_structs.swift
+++ b/test/IRGen/objc_structs.swift
@@ -9,7 +9,7 @@ import Foundation
 import gizmo
 
 // CHECK: [[GIZMO:%TSo5GizmoC]] = type opaque
-// CHECK: [[NSRECT:%TSC6NSRectV]] = type <{ [[NSPOINT:%TSC7NSPointV]], [[NSSIZE:%TSC6NSSizeV]] }>
+// CHECK: [[NSRECT:%TSo6NSRectV]] = type <{ [[NSPOINT:%TSo7NSPointV]], [[NSSIZE:%TSo6NSSizeV]] }>
 // CHECK: [[NSPOINT]] = type <{ [[DOUBLE:%TSd]], [[DOUBLE]] }>
 // CHECK: [[DOUBLE]] = type <{ double }>
 // CHECK: [[NSSIZE]] = type <{ [[DOUBLE]], [[DOUBLE]] }>
@@ -61,7 +61,7 @@ func convertRectFromBase(_ v: NSView, r: NSRect) -> NSRect {
 }
 // CHECK: }
 
-// CHECK: define hidden swiftcc { {{.*}}*, {{.*}}*, {{.*}}*, {{.*}}* } @_T012objc_structs20useStructOfNSStringsSC0deF0VADF({{.*}}*, {{.*}}*, {{.*}}*, {{.*}}*)
+// CHECK: define hidden swiftcc { {{.*}}*, {{.*}}*, {{.*}}*, {{.*}}* } @_T012objc_structs20useStructOfNSStringsSo0deF0VADF({{.*}}*, {{.*}}*, {{.*}}*, {{.*}}*)
 // CHECK:   call void @useStructOfNSStringsInObjC(%struct.StructOfNSStrings* noalias nocapture sret {{%.*}}, %struct.StructOfNSStrings* byval align 8 {{%.*}})
 func useStructOfNSStrings(_ s: StructOfNSStrings) -> StructOfNSStrings {
   return useStructOfNSStringsInObjC(s)

--- a/test/IRGen/objc_super.swift
+++ b/test/IRGen/objc_super.swift
@@ -14,7 +14,7 @@ import gizmo
 // CHECK: [[SUPER:%objc_super]] = type
 // CHECK: [[OBJC:%objc_object]] = type
 // CHECK: [[GIZMO:%TSo5GizmoC]] = type
-// CHECK: [[NSRECT:%TSC6NSRectV]] = type
+// CHECK: [[NSRECT:%TSo6NSRectV]] = type
 
 class Hoozit : Gizmo {
   // CHECK: define hidden swiftcc void @_T010objc_super6HoozitC4frobyyF([[HOOZIT]]* swiftself) {{.*}} {
@@ -37,7 +37,7 @@ class Hoozit : Gizmo {
   }
   // CHECK: }
 
-  // CHECK: define hidden swiftcc { double, double, double, double } @_T010objc_super6HoozitC5frameSC6NSRectVyF(%T10objc_super6HoozitC* swiftself) {{.*}} {
+  // CHECK: define hidden swiftcc { double, double, double, double } @_T010objc_super6HoozitC5frameSo6NSRectVyF(%T10objc_super6HoozitC* swiftself) {{.*}} {
   override func frame() -> NSRect {
     // CHECK: [[T0:%.*]] = call [[TYPE]]* @_T010objc_super6HoozitCMa()
     // CHECK: [[T1:%.*]] = bitcast [[TYPE]]* [[T0]] to [[CLASS]]*

--- a/test/IRGen/partial_apply_objc.sil
+++ b/test/IRGen/partial_apply_objc.sil
@@ -37,7 +37,7 @@ bb0(%0 : $Int, %1 : $ObjCClass):
   %v = tuple()
   return %v : $()
 }
-sil @_T018partial_apply_objc9ObjCClassC7method2ySC6NSRectV1r_tFTo : $@convention(objc_method) (NSRect, ObjCClass) -> () {
+sil @_T018partial_apply_objc9ObjCClassC7method2ySo6NSRectV1r_tFTo : $@convention(objc_method) (NSRect, ObjCClass) -> () {
 bb0(%0 : $NSRect, %1 : $ObjCClass):
   %v = tuple()
   return %v : $()
@@ -122,9 +122,9 @@ entry(%c : $ObjCClass):
 // CHECK:  ret { i8*, %swift.refcounted* } [[CLOSURE]]
 // CHECK:}
 // CHECK: define internal swiftcc void [[OBJC_PARTIAL_APPLY_STUB2]](double, double, double, double, %swift.refcounted*
-// CHECK:  [[TMP:%.*]] = alloca %TSC6NSRectV
-// CHECK:  [[ORIGIN:%.*]] = getelementptr inbounds %TSC6NSRectV, %TSC6NSRectV* [[TMP]]
-// CHECK:  [[ORIGINX:%.*]] = getelementptr inbounds %TSC7NSPointV, %TSC7NSPointV* [[ORIGIN]]
+// CHECK:  [[TMP:%.*]] = alloca %TSo6NSRectV
+// CHECK:  [[ORIGIN:%.*]] = getelementptr inbounds %TSo6NSRectV, %TSo6NSRectV* [[TMP]]
+// CHECK:  [[ORIGINX:%.*]] = getelementptr inbounds %TSo7NSPointV, %TSo7NSPointV* [[ORIGIN]]
 // CHECK:  [[ORIGINXVAL:%*]] = getelementptr inbounds %TSd, %TSd* [[ORIGINX]]
 // CHECK:  store double %0, double* [[ORIGINXVAL]]
 sil @objc_partial_apply_indirect_sil_argument : $@convention(thin) ObjCClass -> @callee_owned NSRect -> () {

--- a/test/IRGen/protocol_conformance_records_objc.swift
+++ b/test/IRGen/protocol_conformance_records_objc.swift
@@ -18,9 +18,9 @@ public protocol Runcible {
 // -- protocol descriptor
 // CHECK:           [[RUNCIBLE:%swift.protocol\* @_T033protocol_conformance_records_objc8RuncibleMp]]
 // -- type metadata
-// CHECK:           @_T0SC6NSRectVN
+// CHECK:           @_T0So6NSRectVN
 // -- witness table
-// CHECK:           @_T0SC6NSRectV33protocol_conformance_records_objc8RuncibleACWP
+// CHECK:           @_T0So6NSRectV33protocol_conformance_records_objc8RuncibleACWP
 // -- flags 0x02: nonunique direct metadata
 // CHECK:           i32 2 },
 extension NSRect: Runcible {

--- a/test/IRGen/reflection_metadata_imported.swift
+++ b/test/IRGen/reflection_metadata_imported.swift
@@ -5,9 +5,9 @@ import c_layout
 // CHECK-DAG: @__swift_reflection_version = linkonce_odr hidden constant i16 {{[0-9]+}}
 
 // CHECK-DAG: @_T028reflection_metadata_imported15HasImportedTypeVMF = internal constant {{.*}}swift3_fieldmd
-// CHECK-DAG: @_T0SC1AVMB = linkonce_odr hidden constant {{.*}}swift3_builtin
-// CHECK-DAG: @_T0SC11CrappyColorVMB = linkonce_odr hidden constant {{.*}}swift3_builtin
-// CHECK-DAG: @_T0SC11CrappyColorVs16RawRepresentable8c_layoutMA = linkonce_odr hidden constant {{.*}}swift3_assocty
+// CHECK-DAG: @_T0So1AVMB = linkonce_odr hidden constant {{.*}}swift3_builtin
+// CHECK-DAG: @_T0So11CrappyColorVMB = linkonce_odr hidden constant {{.*}}swift3_builtin
+// CHECK-DAG: @_T0So11CrappyColorVs16RawRepresentable8c_layoutMA = linkonce_odr hidden constant {{.*}}swift3_assocty
 
 struct HasImportedType {
   let a: A

--- a/test/Reflection/typeref_decoding_objc.swift
+++ b/test/Reflection/typeref_decoding_objc.swift
@@ -10,34 +10,34 @@
 // CHECK: =======
 // CHECK: TypesToReflect.OC
 // CHECK: -----------------
-// CHECK: nsObject: __ObjC.NSObject
-// CHECK: (class __ObjC.NSObject)
+// CHECK: nsObject: __C.NSObject
+// CHECK: (class __C.NSObject)
 
-// CHECK: nsString: __ObjC.NSString
-// CHECK: (class __ObjC.NSString)
+// CHECK: nsString: __C.NSString
+// CHECK: (class __C.NSString)
 
-// CHECK: cfString: __ObjC.CFString
-// CHECK: (class __ObjC.CFString)
+// CHECK: cfString: __C.CFString
+// CHECK: (class __C.CFString)
 
 // CHECK: aBlock: @convention(block) () -> ()
 // CHECK: (function convention=block
 // CHECK:   (tuple))
 
-// CHECK: ocnss: TypesToReflect.GenericOC<__ObjC.NSString>
+// CHECK: ocnss: TypesToReflect.GenericOC<__C.NSString>
 // CHECK: (bound_generic_class TypesToReflect.GenericOC
-// CHECK:   (class __ObjC.NSString))
+// CHECK:   (class __C.NSString))
 
-// CHECK: occfs: TypesToReflect.GenericOC<__ObjC.CFString>
+// CHECK: occfs: TypesToReflect.GenericOC<__C.CFString>
 // CHECK: (bound_generic_class TypesToReflect.GenericOC
-// CHECK:   (class __ObjC.CFString))
+// CHECK:   (class __C.CFString))
 
 // CHECK: TypesToReflect.GenericOC
 // CHECK: ------------------------
 
 // CHECK: TypesToReflect.HasObjCClasses
 // CHECK: -----------------------------
-// CHECK: url: __ObjC.NSURL
-// CHECK: (class __ObjC.NSURL)
+// CHECK: url: __C.NSURL
+// CHECK: (class __C.NSURL)
 
 // CHECK: integer: Swift.Int
 // CHECK: (struct Swift.Int)
@@ -48,12 +48,12 @@
 // CHECK: TypesToReflect.OP
 // CHECK: -----------------
 
-// CHECK: __ObjC.Bundle
-// CHECK: ---------------
-// CHECK: __ObjC.NSURL
+// CHECK: __C.Bundle
+// CHECK: ----------
+// CHECK: __C.NSURL
+// CHECK: ---------
+// CHECK: __C.NSCoding
 // CHECK: ------------
-// CHECK: __ObjC.NSCoding
-// CHECK: ---------------
 
 // CHECK: ASSOCIATED TYPES:
 // CHECK: =================
@@ -77,6 +77,6 @@
 // CHECK-NEXT: ====================
 
 // CHECK:      - Capture types:
-// CHECK-NEXT: (class __ObjC.Bundle)
-// CHECK-NEXT: (protocol __ObjC.NSCoding)
+// CHECK-NEXT: (class __C.Bundle)
+// CHECK-NEXT: (protocol __C.NSCoding)
 // CHECK-NEXT: - Metadata sources:

--- a/test/Reflection/typeref_decoding_objc.swift
+++ b/test/Reflection/typeref_decoding_objc.swift
@@ -16,8 +16,8 @@
 // CHECK: nsString: __C.NSString
 // CHECK: (class __C.NSString)
 
-// CHECK: cfString: __C.CFString
-// CHECK: (class __C.CFString)
+// CHECK: cfString: __C.CFStringRef
+// CHECK: (alias __C.CFStringRef)
 
 // CHECK: aBlock: @convention(block) () -> ()
 // CHECK: (function convention=block
@@ -27,9 +27,9 @@
 // CHECK: (bound_generic_class TypesToReflect.GenericOC
 // CHECK:   (class __C.NSString))
 
-// CHECK: occfs: TypesToReflect.GenericOC<__C.CFString>
+// CHECK: occfs: TypesToReflect.GenericOC<__C.CFStringRef>
 // CHECK: (bound_generic_class TypesToReflect.GenericOC
-// CHECK:   (class __C.CFString))
+// CHECK:   (alias __C.CFStringRef))
 
 // CHECK: TypesToReflect.GenericOC
 // CHECK: ------------------------

--- a/test/RemoteAST/Inputs/custom-modules/ErrorEnums.h
+++ b/test/RemoteAST/Inputs/custom-modules/ErrorEnums.h
@@ -1,0 +1,26 @@
+@import Foundation;
+
+NSString * const MyErrorDomain;
+typedef NS_ENUM(int, MyError) {
+  MyErrorGood,
+  MyErrorBad,
+} __attribute__((ns_error_domain(MyErrorDomain)));
+
+NSString * const MyRenamedErrorDomain;
+typedef NS_ENUM(int, MyRenamedError) {
+  MyRenamedErrorGood,
+  MyRenamedErrorBad,
+} __attribute__((ns_error_domain(MyRenamedErrorDomain))) __attribute__((swift_name("RenamedError")));
+
+
+struct Wrapper {
+  int unrelatedValue;
+};
+
+// Not actually an error enum, since those can't be import-as-member'd right 
+// now, but it can still hang with us.
+typedef NS_ENUM(int, MyMemberEnum) {
+  MyMemberEnumA,
+  MyMemberEnumB,
+} __attribute__((swift_name("Wrapper.MemberEnum")));
+

--- a/test/RemoteAST/Inputs/custom-modules/module.modulemap
+++ b/test/RemoteAST/Inputs/custom-modules/module.modulemap
@@ -1,0 +1,1 @@
+module ErrorEnums { header "ErrorEnums.h" }

--- a/test/RemoteAST/foreign_types.swift
+++ b/test/RemoteAST/foreign_types.swift
@@ -1,12 +1,29 @@
-// RUN: %target-swift-remoteast-test -sdk %S/../IRGen/Inputs %s | %FileCheck %s
+// RUN: %target-swift-remoteast-test-with-sdk -I %S/../ClangImporter/Inputs/custom-modules -I %S/Inputs/custom-modules %s | %FileCheck %s
 
 // REQUIRES: swift-remoteast-test
 // REQUIRES: objc_interop
 
+import Foundation
 import CoreCooling
+import ErrorEnums
 
 @_silgen_name("printMetadataType")
 func printType(_: Any.Type)
 
 printType(CCRefrigerator.self)
 // CHECK: found type: CCRefrigerator
+
+printType(MyError.self)
+// CHECK: found type: MyError{{$}}
+
+printType(MyError.Code.self)
+// CHECK: found type: MyError.Code{{$}}
+
+printType(RenamedError.self)
+// CHECK: found type: RenamedError{{$}}
+
+printType(RenamedError.Code.self)
+// CHECK: found type: RenamedError.Code{{$}}
+
+printType(Wrapper.MemberEnum.self)
+// CHECK: found type: Wrapper.MemberEnum{{$}}

--- a/test/SILGen/c_materializeForSet_linkage.swift
+++ b/test/SILGen/c_materializeForSet_linkage.swift
@@ -16,8 +16,8 @@ extension NSReferencePoint: Pointable {}
 // Make sure synthesized materializeForSet and its callbacks have shared linkage
 // for properties imported from Clang
 
-// CHECK-LABEL: sil shared [transparent] [serializable] @_T0SC7NSPointV1xSffm
-// CHECK-LABEL: sil shared [transparent] [serializable] @_T0SC7NSPointV1ySffm
+// CHECK-LABEL: sil shared [transparent] [serializable] @_T0So7NSPointV1xSffm
+// CHECK-LABEL: sil shared [transparent] [serializable] @_T0So7NSPointV1ySffm
 
 // CHECK-LABEL: sil shared [serializable] @_T0So16NSReferencePointC1xSffmytfU_
 // CHECK-LABEL: sil shared [serializable] @_T0So16NSReferencePointC1xSffm

--- a/test/SILGen/cf.swift
+++ b/test/SILGen/cf.swift
@@ -65,10 +65,10 @@ protocol Impedance {
 
 extension CCImpedance: Impedance {}
 
-// CHECK-LABEL: sil private [transparent] [thunk] @_T0SC11CCImpedanceV2cf9ImpedanceA2cDP4real9ComponentQzfgTW
-// CHECK-LABEL: sil shared [transparent] [serializable] @_T0SC11CCImpedanceV4realSdfg
-// CHECK-LABEL: sil private [transparent] [thunk] @_T0SC11CCImpedanceV2cf9ImpedanceA2cDP4imag9ComponentQzfgTW
-// CHECK-LABEL: sil shared [transparent] [serializable] @_T0SC11CCImpedanceV4imagSdfg
+// CHECK-LABEL: sil private [transparent] [thunk] @_T0So11CCImpedanceV2cf9ImpedanceA2cDP4real9ComponentQzfgTW
+// CHECK-LABEL: sil shared [transparent] [serializable] @_T0So11CCImpedanceV4realSdfg
+// CHECK-LABEL: sil private [transparent] [thunk] @_T0So11CCImpedanceV2cf9ImpedanceA2cDP4imag9ComponentQzfgTW
+// CHECK-LABEL: sil shared [transparent] [serializable] @_T0So11CCImpedanceV4imagSdfg
 
 class MyMagnetism : CCMagnetismModel {
   // CHECK-LABEL: sil hidden [thunk] @_T02cf11MyMagnetismC15getRefrigerator{{[_0-9a-zA-Z]*}}FTo : $@convention(objc_method) (MyMagnetism) -> @autoreleased CCRefrigerator

--- a/test/SILGen/cf_members.swift
+++ b/test/SILGen/cf_members.swift
@@ -36,7 +36,7 @@ public func foo(_ x: Double) {
   // CHECK: apply [[FN]]([[X]])
   z = makeMetatype().init(value: x)
 
-  // CHECK: [[THUNK:%.*]] = function_ref @_T0So7Struct1VABSd5value_tcfCTcTO
+  // CHECK: [[THUNK:%.*]] = function_ref @_T0So10IAMStruct1VABSd5value_tcfCTcTO
   // CHECK: [[SELF_META:%.*]] = metatype $@thin Struct1.Type
   // CHECK: [[A:%.*]] = apply [[THUNK]]([[SELF_META]])
   // CHECK: [[BORROWED_A:%.*]] = begin_borrow [[A]]
@@ -60,7 +60,7 @@ public func foo(_ x: Double) {
   // CHECK: apply [[FN]]([[ZTMP]], [[X]])
   z = z.translate(radians: x)
 
-  // CHECK: [[THUNK:%.*]] = function_ref [[THUNK_NAME:@_T0So7Struct1V9translateABSd7radians_tFTcTO]]
+  // CHECK: [[THUNK:%.*]] = function_ref [[THUNK_NAME:@_T0So10IAMStruct1V9translateABSd7radians_tFTcTO]]
   // CHECK: [[ZVAL:%.*]] = load [trivial] [[Z]]
   // CHECK: [[C:%.*]] = apply [[THUNK]]([[ZVAL]])
   // CHECK: [[BORROWED_C:%.*]] = begin_borrow [[C]]
@@ -86,7 +86,7 @@ public func foo(_ x: Double) {
   // CHECK: apply [[FN]]([[ZVAL]], [[X]])
   z = z.scale(x)
 
-  // CHECK: [[THUNK:%.*]] = function_ref @_T0So7Struct1V5scaleABSdFTcTO
+  // CHECK: [[THUNK:%.*]] = function_ref @_T0So10IAMStruct1V5scaleABSdFTcTO
   // CHECK: [[ZVAL:%.*]] = load [trivial] [[Z]]
   // CHECK: [[F:%.*]] = apply [[THUNK]]([[ZVAL]])
   // CHECK: [[BORROWED_F:%.*]] = begin_borrow [[F]]
@@ -95,7 +95,7 @@ public func foo(_ x: Double) {
   // CHECK: apply [[F_COPY]]([[X]])
   // CHECK: end_borrow [[BORROWED_F]] from [[F]]
   z = f(x)
-  // CHECK: [[THUNK:%.*]] = function_ref @_T0So7Struct1V5scaleABSdFTcTO
+  // CHECK: [[THUNK:%.*]] = function_ref @_T0So10IAMStruct1V5scaleABSdFTcTO
   // CHECK: thin_to_thick_function [[THUNK]]
   let g = Struct1.scale
   // CHECK: [[ZVAL:%.*]] = load [trivial] [[Z]]
@@ -132,7 +132,7 @@ public func foo(_ x: Double) {
   // CHECK: [[FN:%.*]] = function_ref @IAMStruct1StaticMethod
   // CHECK: apply [[FN]]()
   var y = Struct1.staticMethod()
-  // CHECK: [[THUNK:%.*]] = function_ref @_T0So7Struct1V12staticMethods5Int32VyFZTcTO
+  // CHECK: [[THUNK:%.*]] = function_ref @_T0So10IAMStruct1V12staticMethods5Int32VyFZTcTO
   // CHECK: [[SELF:%.*]] = metatype
   // CHECK: [[I:%.*]] = apply [[THUNK]]([[SELF]])
   // CHECK: [[BORROWED_I:%.*]] = begin_borrow [[I]]
@@ -202,37 +202,37 @@ public func foo(_ x: Double) {
 }
 // CHECK: } // end sil function '_T010cf_members3foo{{[_0-9a-zA-Z]*}}F'
 
-// CHECK-LABEL: sil shared [serializable] [thunk] @_T0So7Struct1VABSd5value_tcfCTO
+// CHECK-LABEL: sil shared [serializable] [thunk] @_T0So10IAMStruct1VABSd5value_tcfCTO
 // CHECK:       bb0([[X:%.*]] : $Double, [[SELF:%.*]] : $@thin Struct1.Type):
 // CHECK:         [[CFUNC:%.*]] = function_ref @IAMStruct1CreateSimple
 // CHECK:         [[RET:%.*]] = apply [[CFUNC]]([[X]])
 // CHECK:         return [[RET]]
 
-// CHECK-LABEL: sil shared [serializable] [thunk] @_T0So7Struct1V9translateABSd7radians_tFTO
+// CHECK-LABEL: sil shared [serializable] [thunk] @_T0So10IAMStruct1V9translateABSd7radians_tFTO
 // CHECK:       bb0([[X:%.*]] : $Double, [[SELF:%.*]] : $Struct1):
 // CHECK:         store [[SELF]] to [trivial] [[TMP:%.*]] :
 // CHECK:         [[CFUNC:%.*]] = function_ref @IAMStruct1Rotate
 // CHECK:         [[RET:%.*]] = apply [[CFUNC]]([[TMP]], [[X]])
 // CHECK:         return [[RET]]
 
-// CHECK-LABEL: sil shared [serializable] [thunk] @_T0So7Struct1V5scaleABSdFTO
+// CHECK-LABEL: sil shared [serializable] [thunk] @_T0So10IAMStruct1V5scaleABSdFTO
 // CHECK:       bb0([[X:%.*]] : $Double, [[SELF:%.*]] : $Struct1):
 // CHECK:         [[CFUNC:%.*]] = function_ref @IAMStruct1Scale
 // CHECK:         [[RET:%.*]] = apply [[CFUNC]]([[SELF]], [[X]])
 // CHECK:         return [[RET]]
 
-// CHECK-LABEL: sil shared [serializable] [thunk] @_T0So7Struct1V12staticMethods5Int32VyFZTO
+// CHECK-LABEL: sil shared [serializable] [thunk] @_T0So10IAMStruct1V12staticMethods5Int32VyFZTO
 // CHECK:       bb0([[SELF:%.*]] : $@thin Struct1.Type):
 // CHECK:         [[CFUNC:%.*]] = function_ref @IAMStruct1StaticMethod
 // CHECK:         [[RET:%.*]] = apply [[CFUNC]]()
 // CHECK:         return [[RET]]
 
-// CHECK-LABEL: sil shared [serializable] [thunk] @_T0So7Struct1V13selfComesLastySd1x_tFTO
+// CHECK-LABEL: sil shared [serializable] [thunk] @_T0So10IAMStruct1V13selfComesLastySd1x_tFTO
 // CHECK:       bb0([[X:%.*]] : $Double, [[SELF:%.*]] : $Struct1):
 // CHECK:         [[CFUNC:%.*]] = function_ref @IAMStruct1SelfComesLast
 // CHECK:         apply [[CFUNC]]([[X]], [[SELF]])
 
-// CHECK-LABEL: sil shared [serializable] [thunk] @_T0So7Struct1V14selfComesThirdys5Int32V1a_Sf1bSd1xtFTO
+// CHECK-LABEL: sil shared [serializable] [thunk] @_T0So10IAMStruct1V14selfComesThirdys5Int32V1a_Sf1bSd1xtFTO
 // CHECK:       bb0([[X:%.*]] : $Int32, [[Y:%.*]] : $Float, [[Z:%.*]] : $Double, [[SELF:%.*]] : $Struct1):
 // CHECK:         [[CFUNC:%.*]] = function_ref @IAMStruct1SelfComesThird
 // CHECK:         apply [[CFUNC]]([[X]], [[Y]], [[SELF]], [[Z]])

--- a/test/SILGen/cf_members.swift
+++ b/test/SILGen/cf_members.swift
@@ -36,7 +36,7 @@ public func foo(_ x: Double) {
   // CHECK: apply [[FN]]([[X]])
   z = makeMetatype().init(value: x)
 
-  // CHECK: [[THUNK:%.*]] = function_ref @_T0SC7Struct1VABSd5value_tcfCTcTO
+  // CHECK: [[THUNK:%.*]] = function_ref @_T0So7Struct1VABSd5value_tcfCTcTO
   // CHECK: [[SELF_META:%.*]] = metatype $@thin Struct1.Type
   // CHECK: [[A:%.*]] = apply [[THUNK]]([[SELF_META]])
   // CHECK: [[BORROWED_A:%.*]] = begin_borrow [[A]]
@@ -60,7 +60,7 @@ public func foo(_ x: Double) {
   // CHECK: apply [[FN]]([[ZTMP]], [[X]])
   z = z.translate(radians: x)
 
-  // CHECK: [[THUNK:%.*]] = function_ref [[THUNK_NAME:@_T0SC7Struct1V9translateABSd7radians_tFTcTO]]
+  // CHECK: [[THUNK:%.*]] = function_ref [[THUNK_NAME:@_T0So7Struct1V9translateABSd7radians_tFTcTO]]
   // CHECK: [[ZVAL:%.*]] = load [trivial] [[Z]]
   // CHECK: [[C:%.*]] = apply [[THUNK]]([[ZVAL]])
   // CHECK: [[BORROWED_C:%.*]] = begin_borrow [[C]]
@@ -86,7 +86,7 @@ public func foo(_ x: Double) {
   // CHECK: apply [[FN]]([[ZVAL]], [[X]])
   z = z.scale(x)
 
-  // CHECK: [[THUNK:%.*]] = function_ref @_T0SC7Struct1V5scaleABSdFTcTO
+  // CHECK: [[THUNK:%.*]] = function_ref @_T0So7Struct1V5scaleABSdFTcTO
   // CHECK: [[ZVAL:%.*]] = load [trivial] [[Z]]
   // CHECK: [[F:%.*]] = apply [[THUNK]]([[ZVAL]])
   // CHECK: [[BORROWED_F:%.*]] = begin_borrow [[F]]
@@ -95,7 +95,7 @@ public func foo(_ x: Double) {
   // CHECK: apply [[F_COPY]]([[X]])
   // CHECK: end_borrow [[BORROWED_F]] from [[F]]
   z = f(x)
-  // CHECK: [[THUNK:%.*]] = function_ref @_T0SC7Struct1V5scaleABSdFTcTO
+  // CHECK: [[THUNK:%.*]] = function_ref @_T0So7Struct1V5scaleABSdFTcTO
   // CHECK: thin_to_thick_function [[THUNK]]
   let g = Struct1.scale
   // CHECK: [[ZVAL:%.*]] = load [trivial] [[Z]]
@@ -132,7 +132,7 @@ public func foo(_ x: Double) {
   // CHECK: [[FN:%.*]] = function_ref @IAMStruct1StaticMethod
   // CHECK: apply [[FN]]()
   var y = Struct1.staticMethod()
-  // CHECK: [[THUNK:%.*]] = function_ref @_T0SC7Struct1V12staticMethods5Int32VyFZTcTO
+  // CHECK: [[THUNK:%.*]] = function_ref @_T0So7Struct1V12staticMethods5Int32VyFZTcTO
   // CHECK: [[SELF:%.*]] = metatype
   // CHECK: [[I:%.*]] = apply [[THUNK]]([[SELF]])
   // CHECK: [[BORROWED_I:%.*]] = begin_borrow [[I]]
@@ -202,37 +202,37 @@ public func foo(_ x: Double) {
 }
 // CHECK: } // end sil function '_T010cf_members3foo{{[_0-9a-zA-Z]*}}F'
 
-// CHECK-LABEL: sil shared [serializable] [thunk] @_T0SC7Struct1VABSd5value_tcfCTO
+// CHECK-LABEL: sil shared [serializable] [thunk] @_T0So7Struct1VABSd5value_tcfCTO
 // CHECK:       bb0([[X:%.*]] : $Double, [[SELF:%.*]] : $@thin Struct1.Type):
 // CHECK:         [[CFUNC:%.*]] = function_ref @IAMStruct1CreateSimple
 // CHECK:         [[RET:%.*]] = apply [[CFUNC]]([[X]])
 // CHECK:         return [[RET]]
 
-// CHECK-LABEL: sil shared [serializable] [thunk] @_T0SC7Struct1V9translateABSd7radians_tFTO
+// CHECK-LABEL: sil shared [serializable] [thunk] @_T0So7Struct1V9translateABSd7radians_tFTO
 // CHECK:       bb0([[X:%.*]] : $Double, [[SELF:%.*]] : $Struct1):
 // CHECK:         store [[SELF]] to [trivial] [[TMP:%.*]] :
 // CHECK:         [[CFUNC:%.*]] = function_ref @IAMStruct1Rotate
 // CHECK:         [[RET:%.*]] = apply [[CFUNC]]([[TMP]], [[X]])
 // CHECK:         return [[RET]]
 
-// CHECK-LABEL: sil shared [serializable] [thunk] @_T0SC7Struct1V5scaleABSdFTO
+// CHECK-LABEL: sil shared [serializable] [thunk] @_T0So7Struct1V5scaleABSdFTO
 // CHECK:       bb0([[X:%.*]] : $Double, [[SELF:%.*]] : $Struct1):
 // CHECK:         [[CFUNC:%.*]] = function_ref @IAMStruct1Scale
 // CHECK:         [[RET:%.*]] = apply [[CFUNC]]([[SELF]], [[X]])
 // CHECK:         return [[RET]]
 
-// CHECK-LABEL: sil shared [serializable] [thunk] @_T0SC7Struct1V12staticMethods5Int32VyFZTO
+// CHECK-LABEL: sil shared [serializable] [thunk] @_T0So7Struct1V12staticMethods5Int32VyFZTO
 // CHECK:       bb0([[SELF:%.*]] : $@thin Struct1.Type):
 // CHECK:         [[CFUNC:%.*]] = function_ref @IAMStruct1StaticMethod
 // CHECK:         [[RET:%.*]] = apply [[CFUNC]]()
 // CHECK:         return [[RET]]
 
-// CHECK-LABEL: sil shared [serializable] [thunk] @_T0SC7Struct1V13selfComesLastySd1x_tFTO
+// CHECK-LABEL: sil shared [serializable] [thunk] @_T0So7Struct1V13selfComesLastySd1x_tFTO
 // CHECK:       bb0([[X:%.*]] : $Double, [[SELF:%.*]] : $Struct1):
 // CHECK:         [[CFUNC:%.*]] = function_ref @IAMStruct1SelfComesLast
 // CHECK:         apply [[CFUNC]]([[X]], [[SELF]])
 
-// CHECK-LABEL: sil shared [serializable] [thunk] @_T0SC7Struct1V14selfComesThirdys5Int32V1a_Sf1bSd1xtFTO
+// CHECK-LABEL: sil shared [serializable] [thunk] @_T0So7Struct1V14selfComesThirdys5Int32V1a_Sf1bSd1xtFTO
 // CHECK:       bb0([[X:%.*]] : $Int32, [[Y:%.*]] : $Float, [[Z:%.*]] : $Double, [[SELF:%.*]] : $Struct1):
 // CHECK:         [[CFUNC:%.*]] = function_ref @IAMStruct1SelfComesThird
 // CHECK:         apply [[CFUNC]]([[X]], [[Y]], [[SELF]], [[Z]])

--- a/test/SILGen/external_definitions.swift
+++ b/test/SILGen/external_definitions.swift
@@ -19,7 +19,7 @@ hasNoPrototype()
 // CHECK:   [[NSANSE_RESULT:%.*]] = apply [[NSANSE]]([[ANSIBLE]])
 // CHECK:   destroy_value [[ANSIBLE]] : $Optional<Ansible>
 // -- Referencing unapplied C function goes through a thunk
-// CHECK:   [[NSANSE:%.*]] = function_ref @_T0SC6NSAnseSQySo7AnsibleCGADFTO : $@convention(thin) (@owned Optional<Ansible>) -> @owned Optional<Ansible>
+// CHECK:   [[NSANSE:%.*]] = function_ref @_T0So6NSAnseSQySo7AnsibleCGADFTO : $@convention(thin) (@owned Optional<Ansible>) -> @owned Optional<Ansible>
 // -- Referencing unprototyped C function passes no parameters
 // CHECK:   [[NOPROTO:%.*]] = function_ref @hasNoPrototype : $@convention(c) () -> ()
 // CHECK:   apply [[NOPROTO]]()
@@ -32,7 +32,7 @@ hasNoPrototype()
 // CHECK-LABEL: sil shared [serializable] @_T0So8NSObjectC{{[_0-9a-zA-Z]*}}fC : $@convention(method) (@thick NSObject.Type) -> @owned NSObject
 
 // -- Native Swift thunk for NSAnse
-// CHECK: sil shared [serialized] [thunk] @_T0SC6NSAnseSQySo7AnsibleCGADFTO : $@convention(thin) (@owned Optional<Ansible>) -> @owned Optional<Ansible> {
+// CHECK: sil shared [serialized] [thunk] @_T0So6NSAnseSQySo7AnsibleCGADFTO : $@convention(thin) (@owned Optional<Ansible>) -> @owned Optional<Ansible> {
 // CHECK: bb0(%0 : $Optional<Ansible>):
 // CHECK:   %1 = function_ref @NSAnse : $@convention(c) (Optional<Ansible>) -> @autoreleased Optional<Ansible>
 // CHECK:   %2 = apply %1(%0) : $@convention(c) (Optional<Ansible>) -> @autoreleased Optional<Ansible>

--- a/test/SILGen/imported_struct_array_field.swift
+++ b/test/SILGen/imported_struct_array_field.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -emit-silgen -import-objc-header %S/Inputs/array_typedef.h %s | %FileCheck %s
 
-// CHECK-LABEL: sil shared [transparent] [serializable] @_T0SC4NameV{{[_0-9a-zA-Z]*}}fC : $@convention(method) (UInt8, UInt8, UInt8, UInt8, @thin Name.Type) -> Name
+// CHECK-LABEL: sil shared [transparent] [serializable] @_T0So4NameV{{[_0-9a-zA-Z]*}}fC : $@convention(method) (UInt8, UInt8, UInt8, UInt8, @thin Name.Type) -> Name
 func useImportedArrayTypedefInit() -> Name {
   return Name(name: (0, 0, 0, 0))
 }

--- a/test/SILGen/mangling.swift
+++ b/test/SILGen/mangling.swift
@@ -81,9 +81,7 @@ func single_protocol_composition(x x: protocol<Foo>) {} // expected-warning {{'p
 func uses_objc_class_and_protocol(o o: NSObject, p: NSAnsing) {}
 
 // Clang-imported structs get mangled using their Clang module name.
-// FIXME: Temporarily mangles everything into the virtual module __C__
-// <rdar://problem/14221244>
-// CHECK-LABEL: sil hidden @_T08mangling17uses_clang_structySC6NSRectV1r_tF
+// CHECK-LABEL: sil hidden @_T08mangling17uses_clang_structySo6NSRectV1r_tF
 func uses_clang_struct(r r: NSRect) {}
 
 // CHECK-LABEL: sil hidden @_T08mangling14uses_optionalsScSgSiSg1x_tF

--- a/test/SILGen/newtype.swift
+++ b/test/SILGen/newtype.swift
@@ -15,7 +15,7 @@ func createErrorDomain(str: String) -> ErrorDomain {
   return ErrorDomain(rawValue: str)
 }
 
-// CHECK-RAW-LABEL: sil shared [transparent] [serializable] @_T0So11ErrorDomainVABSS8rawValue_tcfC
+// CHECK-RAW-LABEL: sil shared [transparent] [serializable] @_T0So14SNTErrorDomainaABSS8rawValue_tcfC
 // CHECK-RAW: bb0([[STR:%[0-9]+]] : $String,
 // CHECK-RAW: [[SELF_BOX:%[0-9]+]] = alloc_box ${ var ErrorDomain }, var, name "self"
 // CHECK-RAW: [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [rootself] [[SELF_BOX]]
@@ -31,7 +31,7 @@ func getRawValue(ed: ErrorDomain) -> String {
   return ed.rawValue
 }
 
-// CHECK-RAW-LABEL: sil shared [serializable] @_T0So11ErrorDomainV8rawValueSSfg
+// CHECK-RAW-LABEL: sil shared [serializable] @_T0So14SNTErrorDomaina8rawValueSSfg
 // CHECK-RAW: bb0([[SELF:%[0-9]+]] : $ErrorDomain):
 // CHECK-RAW: [[FORCE_BRIDGE:%[0-9]+]] = function_ref @_forceBridgeFromObjectiveC_bridgeable
 // CHECK-RAW: [[STRING_RESULT_ADDR:%[0-9]+]] = alloc_stack $String
@@ -43,14 +43,14 @@ func getRawValue(ed: ErrorDomain) -> String {
 // CHECK-RAW: return [[STRING_RESULT]]
 
 class ObjCTest {
-  // CHECK-RAW-LABEL: sil hidden @_T07newtype8ObjCTestC19optionalPassThroughSo11ErrorDomainVSgAGF : $@convention(method) (@owned Optional<ErrorDomain>, @guaranteed ObjCTest) -> @owned Optional<ErrorDomain> {
-  // CHECK-RAW: sil hidden [thunk] @_T07newtype8ObjCTestC19optionalPassThroughSo11ErrorDomainVSgAGFTo : $@convention(objc_method) (Optional<ErrorDomain>, ObjCTest) -> Optional<ErrorDomain> {
+  // CHECK-RAW-LABEL: sil hidden @_T07newtype8ObjCTestC19optionalPassThroughSo14SNTErrorDomainaSgAGF : $@convention(method) (@owned Optional<ErrorDomain>, @guaranteed ObjCTest) -> @owned Optional<ErrorDomain> {
+  // CHECK-RAW: sil hidden [thunk] @_T07newtype8ObjCTestC19optionalPassThroughSo14SNTErrorDomainaSgAGFTo : $@convention(objc_method) (Optional<ErrorDomain>, ObjCTest) -> Optional<ErrorDomain> {
   @objc func optionalPassThrough(_ ed: ErrorDomain?) -> ErrorDomain? {
     return ed
   }  
 
-  // CHECK-RAW-LABEL: sil hidden @_T07newtype8ObjCTestC18integerPassThroughSo5MyIntVAFF : $@convention(method) (MyInt, @guaranteed ObjCTest) -> MyInt {
-  // CHECK-RAW: sil hidden [thunk] @_T07newtype8ObjCTestC18integerPassThroughSo5MyIntVAFFTo : $@convention(objc_method) (MyInt, ObjCTest) -> MyInt {
+  // CHECK-RAW-LABEL: sil hidden @_T07newtype8ObjCTestC18integerPassThroughSo5MyIntaAFF : $@convention(method) (MyInt, @guaranteed ObjCTest) -> MyInt {
+  // CHECK-RAW: sil hidden [thunk] @_T07newtype8ObjCTestC18integerPassThroughSo5MyIntaAFFTo : $@convention(objc_method) (MyInt, ObjCTest) -> MyInt {
   @objc func integerPassThrough(_ ed: MyInt) -> MyInt {
     return ed
   }  

--- a/test/SILGen/newtype.swift
+++ b/test/SILGen/newtype.swift
@@ -15,7 +15,7 @@ func createErrorDomain(str: String) -> ErrorDomain {
   return ErrorDomain(rawValue: str)
 }
 
-// CHECK-RAW-LABEL: sil shared [transparent] [serializable] @_T0SC11ErrorDomainVABSS8rawValue_tcfC
+// CHECK-RAW-LABEL: sil shared [transparent] [serializable] @_T0So11ErrorDomainVABSS8rawValue_tcfC
 // CHECK-RAW: bb0([[STR:%[0-9]+]] : $String,
 // CHECK-RAW: [[SELF_BOX:%[0-9]+]] = alloc_box ${ var ErrorDomain }, var, name "self"
 // CHECK-RAW: [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [rootself] [[SELF_BOX]]
@@ -31,7 +31,7 @@ func getRawValue(ed: ErrorDomain) -> String {
   return ed.rawValue
 }
 
-// CHECK-RAW-LABEL: sil shared [serializable] @_T0SC11ErrorDomainV8rawValueSSfg
+// CHECK-RAW-LABEL: sil shared [serializable] @_T0So11ErrorDomainV8rawValueSSfg
 // CHECK-RAW: bb0([[SELF:%[0-9]+]] : $ErrorDomain):
 // CHECK-RAW: [[FORCE_BRIDGE:%[0-9]+]] = function_ref @_forceBridgeFromObjectiveC_bridgeable
 // CHECK-RAW: [[STRING_RESULT_ADDR:%[0-9]+]] = alloc_stack $String
@@ -43,14 +43,14 @@ func getRawValue(ed: ErrorDomain) -> String {
 // CHECK-RAW: return [[STRING_RESULT]]
 
 class ObjCTest {
-  // CHECK-RAW-LABEL: sil hidden @_T07newtype8ObjCTestC19optionalPassThroughSC11ErrorDomainVSgAGF : $@convention(method) (@owned Optional<ErrorDomain>, @guaranteed ObjCTest) -> @owned Optional<ErrorDomain> {
-  // CHECK-RAW: sil hidden [thunk] @_T07newtype8ObjCTestC19optionalPassThroughSC11ErrorDomainVSgAGFTo : $@convention(objc_method) (Optional<ErrorDomain>, ObjCTest) -> Optional<ErrorDomain> {
+  // CHECK-RAW-LABEL: sil hidden @_T07newtype8ObjCTestC19optionalPassThroughSo11ErrorDomainVSgAGF : $@convention(method) (@owned Optional<ErrorDomain>, @guaranteed ObjCTest) -> @owned Optional<ErrorDomain> {
+  // CHECK-RAW: sil hidden [thunk] @_T07newtype8ObjCTestC19optionalPassThroughSo11ErrorDomainVSgAGFTo : $@convention(objc_method) (Optional<ErrorDomain>, ObjCTest) -> Optional<ErrorDomain> {
   @objc func optionalPassThrough(_ ed: ErrorDomain?) -> ErrorDomain? {
     return ed
   }  
 
-  // CHECK-RAW-LABEL: sil hidden @_T07newtype8ObjCTestC18integerPassThroughSC5MyIntVAFF : $@convention(method) (MyInt, @guaranteed ObjCTest) -> MyInt {
-  // CHECK-RAW: sil hidden [thunk] @_T07newtype8ObjCTestC18integerPassThroughSC5MyIntVAFFTo : $@convention(objc_method) (MyInt, ObjCTest) -> MyInt {
+  // CHECK-RAW-LABEL: sil hidden @_T07newtype8ObjCTestC18integerPassThroughSo5MyIntVAFF : $@convention(method) (MyInt, @guaranteed ObjCTest) -> MyInt {
+  // CHECK-RAW: sil hidden [thunk] @_T07newtype8ObjCTestC18integerPassThroughSo5MyIntVAFFTo : $@convention(objc_method) (MyInt, ObjCTest) -> MyInt {
   @objc func integerPassThrough(_ ed: MyInt) -> MyInt {
     return ed
   }  

--- a/test/SILGen/objc_bridging.swift
+++ b/test/SILGen/objc_bridging.swift
@@ -533,7 +533,7 @@ func applyStringBlock(_ f: @convention(block) (String) -> String, x: String) -> 
 
 // CHECK-LABEL: sil hidden @_T013objc_bridging15bridgeCFunction{{.*}}F
 func bridgeCFunction() -> (String!) -> (String!) {
-  // CHECK: [[THUNK:%.*]] = function_ref @_T0SC18NSStringFromStringSQySSGABFTO : $@convention(thin) (@owned Optional<String>) -> @owned Optional<String>
+  // CHECK: [[THUNK:%.*]] = function_ref @_T0So18NSStringFromStringSQySSGABFTO : $@convention(thin) (@owned Optional<String>) -> @owned Optional<String>
   // CHECK: [[THICK:%.*]] = thin_to_thick_function [[THUNK]]
   // CHECK: return [[THICK]]
   return NSStringFromString

--- a/test/SILGen/objc_bridging_any.swift
+++ b/test/SILGen/objc_bridging_any.swift
@@ -743,5 +743,5 @@ class AnyHashableClass : NSObject {
 
 // CHECK-LABEL: sil_witness_table shared [serialized] GenericOption: Hashable module objc_generics {
 // CHECK-NEXT: base_protocol Equatable: GenericOption: Equatable module objc_generics
-// CHECK-NEXT: method #Hashable.hashValue!getter.1: {{.*}} : @_T0So13GenericOptionVs8Hashable13objc_genericssACP9hashValueSifgTW
+// CHECK-NEXT: method #Hashable.hashValue!getter.1: {{.*}} : @_T0So13GenericOptionas8Hashable13objc_genericssACP9hashValueSifgTW
 // CHECK-NEXT: }

--- a/test/SILGen/objc_bridging_any.swift
+++ b/test/SILGen/objc_bridging_any.swift
@@ -743,5 +743,5 @@ class AnyHashableClass : NSObject {
 
 // CHECK-LABEL: sil_witness_table shared [serialized] GenericOption: Hashable module objc_generics {
 // CHECK-NEXT: base_protocol Equatable: GenericOption: Equatable module objc_generics
-// CHECK-NEXT: method #Hashable.hashValue!getter.1: {{.*}} : @_T0SC13GenericOptionVs8Hashable13objc_genericssACP9hashValueSifgTW
+// CHECK-NEXT: method #Hashable.hashValue!getter.1: {{.*}} : @_T0So13GenericOptionVs8Hashable13objc_genericssACP9hashValueSifgTW
 // CHECK-NEXT: }

--- a/test/SILGen/objc_enum.swift
+++ b/test/SILGen/objc_enum.swift
@@ -7,15 +7,15 @@
 import gizmo
 
 
-// CHECK-DAG: sil shared [serializable] @_T0So16NSRuncingOptionsO{{[_0-9a-zA-Z]*}}fC
-// CHECK-DAG: sil shared [serializable] @_T0So16NSRuncingOptionsO8rawValueSifg
-// CHECK-DAG: sil shared [serializable] @_T0So16NSRuncingOptionsO9hashValueSifg
+// CHECK-DAG: sil shared [serializable] @_T0So16NSRuncingOptionsV{{[_0-9a-zA-Z]*}}fC
+// CHECK-DAG: sil shared [serializable] @_T0So16NSRuncingOptionsV8rawValueSifg
+// CHECK-DAG: sil shared [serializable] @_T0So16NSRuncingOptionsV9hashValueSifg
 
 // Non-payload enum ctors don't need to be instantiated at all.
-// NEGATIVE-NOT: sil shared [transparent] @_T0So16NSRuncingOptionsO5MinceAbBmF
-// NEGATIVE-NOT: sil shared [transparent] @_T0So16NSRuncingOptionsO12QuinceSlicedAbBmF
-// NEGATIVE-NOT: sil shared [transparent] @_T0So16NSRuncingOptionsO15QuinceJuliennedAbBmF
-// NEGATIVE-NOT: sil shared [transparent] @_T0So16NSRuncingOptionsO11QuinceDicedAbBmF
+// NEGATIVE-NOT: sil shared [transparent] @_T0So16NSRuncingOptionsV5MinceAbBmF
+// NEGATIVE-NOT: sil shared [transparent] @_T0So16NSRuncingOptionsV12QuinceSlicedAbBmF
+// NEGATIVE-NOT: sil shared [transparent] @_T0So16NSRuncingOptionsV15QuinceJuliennedAbBmF
+// NEGATIVE-NOT: sil shared [transparent] @_T0So16NSRuncingOptionsV11QuinceDicedAbBmF
 
 var runcing: NSRuncingOptions = .mince
 
@@ -45,7 +45,7 @@ _ = NSFungingMask.toTheMax
 // CHECK-DAG: sil_witness_table shared [serialized] NSRuncingOptions: Hashable module gizmo
 // CHECK-DAG: sil_witness_table shared [serialized] NSFungingMask: RawRepresentable module gizmo
 
-// CHECK-DAG: sil shared [transparent] [serialized] [thunk] @_T0So16NSRuncingOptionsOs16RawRepresentable5gizmosACP{{[_0-9a-zA-Z]*}}fCTW
+// CHECK-DAG: sil shared [transparent] [serialized] [thunk] @_T0So16NSRuncingOptionsVs16RawRepresentable5gizmosACP{{[_0-9a-zA-Z]*}}fCTW
 
 // Extension conformances get linkage according to the protocol's accessibility, as normal.
 // CHECK-DAG: sil_witness_table hidden NSRuncingOptions: Bub module objc_enum

--- a/test/SILGen/objc_enum.swift
+++ b/test/SILGen/objc_enum.swift
@@ -7,15 +7,15 @@
 import gizmo
 
 
-// CHECK-DAG: sil shared [serializable] @_T0SC16NSRuncingOptionsO{{[_0-9a-zA-Z]*}}fC
-// CHECK-DAG: sil shared [serializable] @_T0SC16NSRuncingOptionsO8rawValueSifg
-// CHECK-DAG: sil shared [serializable] @_T0SC16NSRuncingOptionsO9hashValueSifg
+// CHECK-DAG: sil shared [serializable] @_T0So16NSRuncingOptionsO{{[_0-9a-zA-Z]*}}fC
+// CHECK-DAG: sil shared [serializable] @_T0So16NSRuncingOptionsO8rawValueSifg
+// CHECK-DAG: sil shared [serializable] @_T0So16NSRuncingOptionsO9hashValueSifg
 
 // Non-payload enum ctors don't need to be instantiated at all.
-// NEGATIVE-NOT: sil shared [transparent] @_T0SC16NSRuncingOptionsO5MinceAbBmF
-// NEGATIVE-NOT: sil shared [transparent] @_T0SC16NSRuncingOptionsO12QuinceSlicedAbBmF
-// NEGATIVE-NOT: sil shared [transparent] @_T0SC16NSRuncingOptionsO15QuinceJuliennedAbBmF
-// NEGATIVE-NOT: sil shared [transparent] @_T0SC16NSRuncingOptionsO11QuinceDicedAbBmF
+// NEGATIVE-NOT: sil shared [transparent] @_T0So16NSRuncingOptionsO5MinceAbBmF
+// NEGATIVE-NOT: sil shared [transparent] @_T0So16NSRuncingOptionsO12QuinceSlicedAbBmF
+// NEGATIVE-NOT: sil shared [transparent] @_T0So16NSRuncingOptionsO15QuinceJuliennedAbBmF
+// NEGATIVE-NOT: sil shared [transparent] @_T0So16NSRuncingOptionsO11QuinceDicedAbBmF
 
 var runcing: NSRuncingOptions = .mince
 
@@ -45,7 +45,7 @@ _ = NSFungingMask.toTheMax
 // CHECK-DAG: sil_witness_table shared [serialized] NSRuncingOptions: Hashable module gizmo
 // CHECK-DAG: sil_witness_table shared [serialized] NSFungingMask: RawRepresentable module gizmo
 
-// CHECK-DAG: sil shared [transparent] [serialized] [thunk] @_T0SC16NSRuncingOptionsOs16RawRepresentable5gizmosACP{{[_0-9a-zA-Z]*}}fCTW
+// CHECK-DAG: sil shared [transparent] [serialized] [thunk] @_T0So16NSRuncingOptionsOs16RawRepresentable5gizmosACP{{[_0-9a-zA-Z]*}}fCTW
 
 // Extension conformances get linkage according to the protocol's accessibility, as normal.
 // CHECK-DAG: sil_witness_table hidden NSRuncingOptions: Bub module objc_enum

--- a/test/SILGen/objc_imported_generic.swift
+++ b/test/SILGen/objc_imported_generic.swift
@@ -128,7 +128,7 @@ func configureWithoutOptions() {
 // foreign to native thunk for init(options:), uses GenericOption : Hashable
 // conformance
 
-// CHECK-LABEL: sil shared [serializable] [thunk] @_T0So12GenericClassCSQyAByxGGs10DictionaryVySo0A6OptionVypGSg7options_tcfcTO : $@convention(method) <T where T : AnyObject> (@owned Optional<Dictionary<GenericOption, Any>>, @owned GenericClass<T>) -> @owned Optional<GenericClass<T>>
+// CHECK-LABEL: sil shared [serializable] [thunk] @_T0So12GenericClassCSQyAByxGGs10DictionaryVySo0A6OptionaypGSg7options_tcfcTO : $@convention(method) <T where T : AnyObject> (@owned Optional<Dictionary<GenericOption, Any>>, @owned GenericClass<T>) -> @owned Optional<GenericClass<T>>
 // CHECK: [[FN:%.*]] = function_ref @_T0s10DictionaryV10FoundationE19_bridgeToObjectiveCSo12NSDictionaryCyF : $@convention(method) <τ_0_0, τ_0_1 where τ_0_0 : Hashable> (@guaranteed Dictionary<τ_0_0, τ_0_1>) -> @owned NSDictionary
 // CHECK: apply [[FN]]<GenericOption, Any>({{.*}}) : $@convention(method) <τ_0_0, τ_0_1 where τ_0_0 : Hashable> (@guaranteed Dictionary<τ_0_0, τ_0_1>) -> @owned NSDictionary
 // CHECK: return
@@ -141,5 +141,5 @@ func configureWithoutOptions() {
 // Make sure we emitted the witness table for the above conformance
 
 // CHECK-LABEL: sil_witness_table shared [serialized] GenericOption: Hashable module objc_generics {
-// CHECK: method #Hashable.hashValue!getter.1: {{.*}}: @_T0So13GenericOptionVs8Hashable13objc_genericssACP9hashValueSifgTW
+// CHECK: method #Hashable.hashValue!getter.1: {{.*}}: @_T0So13GenericOptionas8Hashable13objc_genericssACP9hashValueSifgTW
 // CHECK: }

--- a/test/SILGen/objc_imported_generic.swift
+++ b/test/SILGen/objc_imported_generic.swift
@@ -128,7 +128,7 @@ func configureWithoutOptions() {
 // foreign to native thunk for init(options:), uses GenericOption : Hashable
 // conformance
 
-// CHECK-LABEL: sil shared [serializable] [thunk] @_T0So12GenericClassCSQyAByxGGs10DictionaryVySC0A6OptionVypGSg7options_tcfcTO : $@convention(method) <T where T : AnyObject> (@owned Optional<Dictionary<GenericOption, Any>>, @owned GenericClass<T>) -> @owned Optional<GenericClass<T>>
+// CHECK-LABEL: sil shared [serializable] [thunk] @_T0So12GenericClassCSQyAByxGGs10DictionaryVySo0A6OptionVypGSg7options_tcfcTO : $@convention(method) <T where T : AnyObject> (@owned Optional<Dictionary<GenericOption, Any>>, @owned GenericClass<T>) -> @owned Optional<GenericClass<T>>
 // CHECK: [[FN:%.*]] = function_ref @_T0s10DictionaryV10FoundationE19_bridgeToObjectiveCSo12NSDictionaryCyF : $@convention(method) <τ_0_0, τ_0_1 where τ_0_0 : Hashable> (@guaranteed Dictionary<τ_0_0, τ_0_1>) -> @owned NSDictionary
 // CHECK: apply [[FN]]<GenericOption, Any>({{.*}}) : $@convention(method) <τ_0_0, τ_0_1 where τ_0_0 : Hashable> (@guaranteed Dictionary<τ_0_0, τ_0_1>) -> @owned NSDictionary
 // CHECK: return
@@ -141,5 +141,5 @@ func configureWithoutOptions() {
 // Make sure we emitted the witness table for the above conformance
 
 // CHECK-LABEL: sil_witness_table shared [serialized] GenericOption: Hashable module objc_generics {
-// CHECK: method #Hashable.hashValue!getter.1: {{.*}}: @_T0SC13GenericOptionVs8Hashable13objc_genericssACP9hashValueSifgTW
+// CHECK: method #Hashable.hashValue!getter.1: {{.*}}: @_T0So13GenericOptionVs8Hashable13objc_genericssACP9hashValueSifgTW
 // CHECK: }

--- a/test/SILOptimizer/bridged_casts_folding.swift
+++ b/test/SILOptimizer/bridged_casts_folding.swift
@@ -782,22 +782,22 @@ print("Swift to NS sets: End")
 
 // Check optimizations of casts from String to CFString
 
-// CHECK-LABEL: sil [noinline] @_T021bridged_casts_folding29testForcedCastSwiftToCFStringSo0I0CyF
+// CHECK-LABEL: sil [noinline] @_T021bridged_casts_folding29testForcedCastSwiftToCFStringSo0I3RefayF
 // CHECK-NOT: unconditional_checked
 // CHECK: function_ref @{{.*}}_bridgeToObjectiveC
 // CHECK: unchecked_ref_cast{{.*}}: $NSString to $CFString
-// CHECK: end{{.*}}_T021bridged_casts_folding29testForcedCastSwiftToCFStringSo0I0CyF
+// CHECK: end{{.*}}_T021bridged_casts_folding29testForcedCastSwiftToCFStringSo0I3RefayF
 @inline(never)
 public func testForcedCastSwiftToCFString() -> CFString {
   let o: CFString = forcedCast(swiftString)
   return o
 }
 
-// CHECK-LABEL: sil [noinline] @_T021bridged_casts_folding27testCondCastSwiftToCFStringSo0I0CSgyF
+// CHECK-LABEL: sil [noinline] @_T021bridged_casts_folding27testCondCastSwiftToCFStringSo0I3RefaSgyF
 // CHECK-NOT: unconditional_checked
 // CHECK: function_ref @{{.*}}_bridgeToObjectiveC
 // CHECK: unchecked_ref_cast{{.*}}: $NSString to $CFString
-// CHECK: end{{.*}}_T021bridged_casts_folding27testCondCastSwiftToCFStringSo0I0CSgyF
+// CHECK: end{{.*}}_T021bridged_casts_folding27testCondCastSwiftToCFStringSo0I3RefaSgyF
 @inline(never)
 public func testCondCastSwiftToCFString() -> CFString? {
   let o: CFString? = condCast(swiftString)
@@ -806,22 +806,22 @@ public func testCondCastSwiftToCFString() -> CFString? {
 
 // Check optimizations of casts from Int to CFNumber
 
-// CHECK-LABEL: sil [noinline] @_T021bridged_casts_folding32testForcedCastSwiftIntToCFNumberSo0J0CyF
+// CHECK-LABEL: sil [noinline] @_T021bridged_casts_folding32testForcedCastSwiftIntToCFNumberSo0J3RefayF
 // CHECK-NOT: unconditional_checked
 // CHECK: function_ref @{{.*}}_bridgeToObjectiveC
 // CHECK: unchecked_ref_cast{{.*}}: $NSNumber to $CFNumber
-// CHECK: end{{.*}}_T021bridged_casts_folding32testForcedCastSwiftIntToCFNumberSo0J0CyF
+// CHECK: end{{.*}}_T021bridged_casts_folding32testForcedCastSwiftIntToCFNumberSo0J3RefayF
 @inline(never)
 public func testForcedCastSwiftIntToCFNumber() -> CFNumber {
   let o: CFNumber = forcedCast(swiftIntNumber)
   return o
 }
 
-// CHECK-LABEL: sil [noinline] @_T021bridged_casts_folding30testCondCastSwiftIntToCFNumberSo0J0CSgyF
+// CHECK-LABEL: sil [noinline] @_T021bridged_casts_folding30testCondCastSwiftIntToCFNumberSo0J3RefaSgyF
 // CHECK-NOT: unconditional_checked
 // CHECK: function_ref @{{.*}}_bridgeToObjectiveC
 // CHECK: unchecked_ref_cast{{.*}}: $NSNumber to $CFNumber
-// CHECK: end{{.*}}_T021bridged_casts_folding30testCondCastSwiftIntToCFNumberSo0J0CSgyF
+// CHECK: end{{.*}}_T021bridged_casts_folding30testCondCastSwiftIntToCFNumberSo0J3RefaSgyF
 @inline(never)
 public func testCondCastSwiftIntToCFNumber() -> CFNumber? {
   let o: CFNumber? = condCast(swiftIntNumber)
@@ -830,22 +830,22 @@ public func testCondCastSwiftIntToCFNumber() -> CFNumber? {
 
 // Check optimization of casts from Swift Array to CFArray
 
-// CHECK-LABEL: sil [noinline] @_T021bridged_casts_folding31testForcedCastSwiftToCFArrayIntSo0I0CyF
+// CHECK-LABEL: sil [noinline] @_T021bridged_casts_folding31testForcedCastSwiftToCFArrayIntSo0I3RefayF
 // CHECK-NOT: unconditional_checked
 // CHECK: function_ref @{{.*}}_bridgeToObjectiveC
 // CHECK: unchecked_ref_cast{{.*}}: $NSArray to $CFArray
-// CHECK: end{{.*}}_T021bridged_casts_folding31testForcedCastSwiftToCFArrayIntSo0I0CyF
+// CHECK: end{{.*}}_T021bridged_casts_folding31testForcedCastSwiftToCFArrayIntSo0I3RefayF
 @inline(never)
 public func testForcedCastSwiftToCFArrayInt() -> CFArray {
   let arr: CFArray = forcedCast(arrInt)
   return arr
 }
 
-// CHECK-LABEL: sil [noinline] @_T021bridged_casts_folding29testCondCastSwiftToCFArrayIntSo0I0CSgyF
+// CHECK-LABEL: sil [noinline] @_T021bridged_casts_folding29testCondCastSwiftToCFArrayIntSo0I3RefaSgyF
 // CHECK-NOT: unconditional_checked
 // CHECK: function_ref @{{.*}}_bridgeToObjectiveC
 // CHECK: unchecked_ref_cast{{.*}}: $NSArray to $CFArray
-// CHECK: end{{.*}}_T021bridged_casts_folding29testCondCastSwiftToCFArrayIntSo0I0CSgyF
+// CHECK: end{{.*}}_T021bridged_casts_folding29testCondCastSwiftToCFArrayIntSo0I3RefaSgyF
 @inline(never)
 public func testCondCastSwiftToCFArrayInt() -> CFArray? {
   let arrOpt: CFArray? = condCast(arrInt)
@@ -854,22 +854,22 @@ public func testCondCastSwiftToCFArrayInt() -> CFArray? {
 
 // Check optimization of casts from Swift Dict to CFDictionary
 
-// CHECK-LABEL: sil [noinline] @_T021bridged_casts_folding30testForcedCastSwiftToCFDictIntSo12CFDictionaryCyF
+// CHECK-LABEL: sil [noinline] @_T021bridged_casts_folding30testForcedCastSwiftToCFDictIntSo15CFDictionaryRefayF
 // CHECK-NOT: unconditional_checked
 // CHECK: function_ref @{{.*}}_bridgeToObjectiveC
 // CHECK: unchecked_ref_cast{{.*}}: $NSDictionary to $CFDictionary
-// CHECK: end{{.*}}_T021bridged_casts_folding30testForcedCastSwiftToCFDictIntSo12CFDictionaryCyF
+// CHECK: end{{.*}}_T021bridged_casts_folding30testForcedCastSwiftToCFDictIntSo15CFDictionaryRefayF
 @inline(never)
 public func testForcedCastSwiftToCFDictInt() -> CFDictionary {
   let dict: CFDictionary = forcedCast(dictInt)
   return dict
 }
 
-// CHECK-LABEL: sil [noinline] @_T021bridged_casts_folding28testCondCastSwiftToCFDictIntSo12CFDictionaryCSgyF
+// CHECK-LABEL: sil [noinline] @_T021bridged_casts_folding28testCondCastSwiftToCFDictIntSo15CFDictionaryRefaSgyF
 // CHECK-NOT: unconditional_checked
 // CHECK: function_ref @{{.*}}_bridgeToObjectiveC
 // CHECK: unchecked_ref_cast{{.*}}: $NSDictionary to $CFDictionary
-// CHECK: end{{.*}}_T021bridged_casts_folding28testCondCastSwiftToCFDictIntSo12CFDictionaryCSgyF
+// CHECK: end{{.*}}_T021bridged_casts_folding28testCondCastSwiftToCFDictIntSo15CFDictionaryRefaSgyF
 @inline(never)
 public func testCondCastSwiftToCFDictInt() -> CFDictionary? {
   let dictOpt: CFDictionary? = condCast(dictInt)
@@ -878,22 +878,22 @@ public func testCondCastSwiftToCFDictInt() -> CFDictionary? {
 
 // Check optimization of casts from Swift Set to CFSet
 
-// CHECK-LABEL: sil [noinline] @_T021bridged_casts_folding29testForcedCastSwiftToCFSetIntSo0I0CyF
+// CHECK-LABEL: sil [noinline] @_T021bridged_casts_folding29testForcedCastSwiftToCFSetIntSo0I3RefayF
 // CHECK-NOT: unconditional_checked
 // CHECK: function_ref @{{.*}}_bridgeToObjectiveC
 // CHECK: unchecked_ref_cast{{.*}}: $NSSet to $CFSet
-// CHECK: end{{.*}}_T021bridged_casts_folding29testForcedCastSwiftToCFSetIntSo0I0CyF
+// CHECK: end{{.*}}_T021bridged_casts_folding29testForcedCastSwiftToCFSetIntSo0I3RefayF
 @inline(never)
 public func testForcedCastSwiftToCFSetInt() -> CFSet {
   let set: CFSet = forcedCast(setInt)
   return set
 }
 
-// CHECK-LABEL: sil [noinline] @_T021bridged_casts_folding27testCondCastSwiftToCFSetIntSo0I0CSgyF
+// CHECK-LABEL: sil [noinline] @_T021bridged_casts_folding27testCondCastSwiftToCFSetIntSo0I3RefaSgyF
 // CHECK-NOT: unconditional_checked
 // CHECK: function_ref @{{.*}}_bridgeToObjectiveC
 // CHECK: unchecked_ref_cast{{.*}}: $NSSet to $CFSet
-// CHECK: end{{.*}}_T021bridged_casts_folding27testCondCastSwiftToCFSetIntSo0I0CSgyF
+// CHECK: end{{.*}}_T021bridged_casts_folding27testCondCastSwiftToCFSetIntSo0I3RefaSgyF
 @inline(never)
 public func testCondCastSwiftToCFSetInt() -> CFSet? {
   let setOpt: CFSet? = condCast(setInt)

--- a/test/SILOptimizer/predictable_memopt_unreferenceable_storage.swift
+++ b/test/SILOptimizer/predictable_memopt_unreferenceable_storage.swift
@@ -14,7 +14,7 @@ struct T {
         self.s = s
     }
 }
-// CHECK-LABEL: sil hidden @_T042predictable_memopt_unreferenceable_storage1TVACSC19StructWithBitfieldsV1v_AA1SV1stcfC
+// CHECK-LABEL: sil hidden @_T042predictable_memopt_unreferenceable_storage1TVACSo19StructWithBitfieldsV1v_AA1SV1stcfC
 // CHECK:       bb0(%0 : $StructWithBitfields, %1 : $S, %2 : $@thin T.Type):
 // CHECK:         [[RESULT:%.*]] = struct $T (%0 : $StructWithBitfields, %1 : $S)
 // CHECK:         return [[RESULT]]

--- a/test/Serialization/sil-imported-enums.swift
+++ b/test/Serialization/sil-imported-enums.swift
@@ -14,7 +14,7 @@
 import Foundation
 import UsesImportedEnums
 
-// CHECK-LABEL: sil hidden @_T04main4testSbSo13NSRuncingModeO1e_tF
+// CHECK-LABEL: sil hidden @_T04main4testSbSo13NSRuncingModeV1e_tF
 func test(e: NSRuncingMode) -> Bool {
   // CHECK-NOT: return
   // CHECK: _T0s2eeoiSbx_xts16RawRepresentableRzs9Equatable0B5ValueRpzlF

--- a/test/Serialization/sil-imported-enums.swift
+++ b/test/Serialization/sil-imported-enums.swift
@@ -14,7 +14,7 @@
 import Foundation
 import UsesImportedEnums
 
-// CHECK-LABEL: sil hidden @_T04main4testSbSC13NSRuncingModeO1e_tF
+// CHECK-LABEL: sil hidden @_T04main4testSbSo13NSRuncingModeO1e_tF
 func test(e: NSRuncingMode) -> Bool {
   // CHECK-NOT: return
   // CHECK: _T0s2eeoiSbx_xts16RawRepresentableRzs9Equatable0B5ValueRpzlF

--- a/test/SourceKit/DocSupport/doc_clang_module.swift.response
+++ b/test/SourceKit/DocSupport/doc_clang_module.swift.response
@@ -2155,7 +2155,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
   {
     key.kind: source.lang.swift.ref.typealias,
     key.name: "Element",
-    key.usr: "s:SC17FooRuncingOptionsV7Elementa",
+    key.usr: "s:So17FooRuncingOptionsV7Elementa",
     key.offset: 2859,
     key.length: 7
   },
@@ -5237,7 +5237,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
       {
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(_:)",
-        key.usr: "s:SC8FooEnum1VABs6UInt32Vcfc",
+        key.usr: "s:So8FooEnum1VABs6UInt32Vcfc",
         key.offset: 89,
         key.length: 24,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>rawValue</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:s6UInt32V\">UInt32</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
@@ -5254,7 +5254,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
       {
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(rawValue:)",
-        key.usr: "s:SC8FooEnum1VABs6UInt32V8rawValue_tcfc",
+        key.usr: "s:So8FooEnum1VABs6UInt32V8rawValue_tcfc",
         key.offset: 119,
         key.length: 31,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>rawValue</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:s6UInt32V\">UInt32</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
@@ -5278,7 +5278,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
       {
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "rawValue",
-        key.usr: "s:SC8FooEnum1V8rawValues6UInt32Vv",
+        key.usr: "s:So8FooEnum1V8rawValues6UInt32Vv",
         key.offset: 156,
         key.length: 20,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>rawValue</decl.name>: <decl.var.type><ref.struct usr=\"s:s6UInt32V\">UInt32</ref.struct></decl.var.type></decl.var.instance>",
@@ -5350,7 +5350,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
       {
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(_:)",
-        key.usr: "s:SC8FooEnum2VABs6UInt32Vcfc",
+        key.usr: "s:So8FooEnum2VABs6UInt32Vcfc",
         key.offset: 326,
         key.length: 24,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>rawValue</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:s6UInt32V\">UInt32</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
@@ -5367,7 +5367,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
       {
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(rawValue:)",
-        key.usr: "s:SC8FooEnum2VABs6UInt32V8rawValue_tcfc",
+        key.usr: "s:So8FooEnum2VABs6UInt32V8rawValue_tcfc",
         key.offset: 356,
         key.length: 31,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>rawValue</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:s6UInt32V\">UInt32</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
@@ -5391,7 +5391,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
       {
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "rawValue",
-        key.usr: "s:SC8FooEnum2V8rawValues6UInt32Vv",
+        key.usr: "s:So8FooEnum2V8rawValues6UInt32Vv",
         key.offset: 393,
         key.length: 20,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>rawValue</decl.name>: <decl.var.type><ref.struct usr=\"s:s6UInt32V\">UInt32</ref.struct></decl.var.type></decl.var.instance>",
@@ -5470,7 +5470,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
       {
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(_:)",
-        key.usr: "s:SC8FooEnum3VABs6UInt32Vcfc",
+        key.usr: "s:So8FooEnum3VABs6UInt32Vcfc",
         key.offset: 595,
         key.length: 24,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>rawValue</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:s6UInt32V\">UInt32</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
@@ -5487,7 +5487,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
       {
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(rawValue:)",
-        key.usr: "s:SC8FooEnum3VABs6UInt32V8rawValue_tcfc",
+        key.usr: "s:So8FooEnum3VABs6UInt32V8rawValue_tcfc",
         key.offset: 625,
         key.length: 31,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>rawValue</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:s6UInt32V\">UInt32</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
@@ -5511,7 +5511,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
       {
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "rawValue",
-        key.usr: "s:SC8FooEnum3V8rawValues6UInt32Vv",
+        key.usr: "s:So8FooEnum3V8rawValues6UInt32Vv",
         key.offset: 662,
         key.length: 20,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>rawValue</decl.name>: <decl.var.type><ref.struct usr=\"s:s6UInt32V\">UInt32</ref.struct></decl.var.type></decl.var.instance>",
@@ -5628,7 +5628,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
       {
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(rawValue:)",
-        key.usr: "s:SC17FooRuncingOptionsVABSi8rawValue_tcfc",
+        key.usr: "s:So17FooRuncingOptionsVABSi8rawValue_tcfc",
         key.offset: 967,
         key.length: 28,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>rawValue</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
@@ -6259,7 +6259,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.doc.full_as_xml: "<Function><Name>init(_:)</Name><USR>s:s10SetAlgebraPsExqd__cs8SequenceRd__8Iterator_7ElementQYd__AERtzlufc</USR><Declaration>convenience init&lt;S&gt;(_ sequence: S) where S : Sequence, Self.Element == S.Iterator.Element</Declaration><Abstract><Para>Creates a new set from a finite sequence of items.</Para></Abstract><Parameters><Parameter><Name>sequence</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>The elements to use as members of the new set.</Para></Discussion></Parameter></Parameters><Discussion><Para>Use this initializer to create a new set from an existing sequence, like an array or a range:</Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let validIndices = Set(0..<7).subtracting([2, 4, 5])]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(validIndices)]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// Prints \"[6, 0, 1, 3]\"]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered></CodeListing></Discussion></Function>",
         key.offset: 2786,
         key.length: 102,
-        key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>convenience</syntaxtype.keyword> <syntaxtype.keyword>init</syntaxtype.keyword>&lt;S&gt;(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>sequence</decl.var.parameter.name>: <decl.var.parameter.type>S</decl.var.parameter.type></decl.var.parameter>) <syntaxtype.keyword>where</syntaxtype.keyword> <decl.generic_type_requirement>S : <ref.protocol usr=\"s:s8SequenceP\">Sequence</ref.protocol></decl.generic_type_requirement>, <decl.generic_type_requirement><ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct>.<ref.typealias usr=\"s:SC17FooRuncingOptionsV7Elementa\">Element</ref.typealias> == S.Iterator.Element</decl.generic_type_requirement></decl.function.constructor>",
+        key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>convenience</syntaxtype.keyword> <syntaxtype.keyword>init</syntaxtype.keyword>&lt;S&gt;(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>sequence</decl.var.parameter.name>: <decl.var.parameter.type>S</decl.var.parameter.type></decl.var.parameter>) <syntaxtype.keyword>where</syntaxtype.keyword> <decl.generic_type_requirement>S : <ref.protocol usr=\"s:s8SequenceP\">Sequence</ref.protocol></decl.generic_type_requirement>, <decl.generic_type_requirement><ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct>.<ref.typealias usr=\"s:So17FooRuncingOptionsV7Elementa\">Element</ref.typealias> == S.Iterator.Element</decl.generic_type_requirement></decl.function.constructor>",
         key.entities: [
           {
             key.kind: source.lang.swift.decl.var.local,
@@ -6461,7 +6461,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
       {
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init()",
-        key.usr: "s:SC10FooStruct1VABycfc",
+        key.usr: "s:So10FooStruct1VABycfc",
         key.offset: 3482,
         key.length: 6,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>()</decl.function.constructor>"
@@ -6469,7 +6469,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
       {
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(x:y:)",
-        key.usr: "s:SC10FooStruct1VABs5Int32V1x_Sd1ytcfc",
+        key.usr: "s:So10FooStruct1VABs5Int32V1x_Sd1ytcfc",
         key.offset: 3494,
         key.length: 29,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>x</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>y</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:Sd\">Double</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
@@ -6544,7 +6544,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
       {
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init()",
-        key.usr: "s:SC10FooStruct2VABycfc",
+        key.usr: "s:So10FooStruct2VABycfc",
         key.offset: 3651,
         key.length: 6,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>()</decl.function.constructor>"
@@ -6552,7 +6552,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
       {
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(x:y:)",
-        key.usr: "s:SC10FooStruct2VABs5Int32V1x_Sd1ytcfc",
+        key.usr: "s:So10FooStruct2VABs5Int32V1x_Sd1ytcfc",
         key.offset: 3663,
         key.length: 29,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>x</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>y</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:Sd\">Double</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
@@ -6610,7 +6610,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
       {
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init()",
-        key.usr: "s:SC17FooStructTypedef2VABycfc",
+        key.usr: "s:So17FooStructTypedef2VABycfc",
         key.offset: 3805,
         key.length: 6,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>()</decl.function.constructor>"
@@ -6618,7 +6618,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
       {
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(x:y:)",
-        key.usr: "s:SC17FooStructTypedef2VABs5Int32V1x_Sd1ytcfc",
+        key.usr: "s:So17FooStructTypedef2VABs5Int32V1x_Sd1ytcfc",
         key.offset: 3817,
         key.length: 29,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>x</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>y</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:Sd\">Double</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
@@ -7375,7 +7375,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
       {
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init()",
-        key.usr: "s:SC15_InternalStructVABycfc",
+        key.usr: "s:So15_InternalStructVABycfc",
         key.offset: 6254,
         key.length: 6,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>()</decl.function.constructor>"
@@ -7383,7 +7383,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
       {
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(x:)",
-        key.usr: "s:SC15_InternalStructVABs5Int32V1x_tcfc",
+        key.usr: "s:So15_InternalStructVABs5Int32V1x_tcfc",
         key.offset: 6266,
         key.length: 16,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>x</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
@@ -7995,7 +7995,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
       {
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(_:)",
-        key.usr: "s:SC11FooSubEnum1VABs6UInt32Vcfc",
+        key.usr: "s:So11FooSubEnum1VABs6UInt32Vcfc",
         key.offset: 7852,
         key.length: 24,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>rawValue</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:s6UInt32V\">UInt32</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
@@ -8012,7 +8012,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
       {
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(rawValue:)",
-        key.usr: "s:SC11FooSubEnum1VABs6UInt32V8rawValue_tcfc",
+        key.usr: "s:So11FooSubEnum1VABs6UInt32V8rawValue_tcfc",
         key.offset: 7882,
         key.length: 31,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>rawValue</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:s6UInt32V\">UInt32</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
@@ -8036,7 +8036,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
       {
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "rawValue",
-        key.usr: "s:SC11FooSubEnum1V8rawValues6UInt32Vv",
+        key.usr: "s:So11FooSubEnum1V8rawValues6UInt32Vv",
         key.offset: 7919,
         key.length: 20,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>rawValue</decl.name>: <decl.var.type><ref.struct usr=\"s:s6UInt32V\">UInt32</ref.struct></decl.var.type></decl.var.instance>",

--- a/test/SourceKit/DocSupport/doc_error_domain.swift
+++ b/test/SourceKit/DocSupport/doc_error_domain.swift
@@ -13,7 +13,7 @@
 
 // CHECK:         key.kind: source.lang.swift.decl.struct,
 // CHECK-NEXT:    key.name: "MyError",
-// CHECK-NEXT:    key.usr: "s:SC7MyErrorV",
+// CHECK-NEXT:    key.usr: "s:So7MyErrorV",
 // CHECK-NEXT:    This is my cool error code.
 
 // CHECK:             key.kind: source.lang.swift.decl.enum,
@@ -28,5 +28,5 @@
 
 // CHECK:             key.kind: source.lang.swift.decl.var.static,
 // CHECK-NEXT:        key.name: "errFirst",
-// CHECK-NEXT:        key.usr: "s:SC7MyErrorV8errFirstAB4CodeOvZ",
+// CHECK-NEXT:        key.usr: "s:So7MyErrorV8errFirstAB4CodeOvZ",
 // CHECK-NEXT:        This is first error.

--- a/test/SourceKit/DocSupport/doc_error_domain.swift
+++ b/test/SourceKit/DocSupport/doc_error_domain.swift
@@ -13,8 +13,8 @@
 
 // CHECK:         key.kind: source.lang.swift.decl.struct,
 // CHECK-NEXT:    key.name: "MyError",
-// CHECK-NEXT:    key.usr: "s:So7MyErrorV",
-// CHECK-NEXT:    This is my cool error code.
+// CHECK-NEXT:    key.usr: "s:SC7MyErrorV",
+// CHECK-NOT:     This is my cool error code.
 
 // CHECK:             key.kind: source.lang.swift.decl.enum,
 // CHECK-NEXT:        key.name: "Code",
@@ -28,5 +28,5 @@
 
 // CHECK:             key.kind: source.lang.swift.decl.var.static,
 // CHECK-NEXT:        key.name: "errFirst",
-// CHECK-NEXT:        key.usr: "s:So7MyErrorV8errFirstAB4CodeOvZ",
+// CHECK-NEXT:        key.usr: "s:SC7MyErrorV8errFirstAB4CodeOvZ",
 // CHECK-NEXT:        This is first error.

--- a/test/SourceKit/DocSupport/doc_error_domain.swift
+++ b/test/SourceKit/DocSupport/doc_error_domain.swift
@@ -28,5 +28,5 @@
 
 // CHECK:             key.kind: source.lang.swift.decl.var.static,
 // CHECK-NEXT:        key.name: "errFirst",
-// CHECK-NEXT:        key.usr: "s:SC7MyErrorV8errFirstAB4CodeOvZ",
+// CHECK-NEXT:        key.usr: "s:SC7MyErrorV8errFirstSo0aB4CodeVvZ",
 // CHECK-NEXT:        This is first error.

--- a/test/SourceKit/DocSupport/doc_source_file.swift.response
+++ b/test/SourceKit/DocSupport/doc_source_file.swift.response
@@ -2598,7 +2598,7 @@
         key.usr: "s:8__main__2S1V7Elementa",
         key.offset: 1835,
         key.length: 20,
-        key.fully_annotated_decl: "<decl.typealias><syntaxtype.keyword>typealias</syntaxtype.keyword> <decl.name>Element</decl.name> = <ref.struct usr=\"s:Si\">Int</ref.struct></decl.typealias>",
+        key.fully_annotated_decl: "<decl.typealias><syntaxtype.keyword>typealias</syntaxtype.keyword> <ref.struct usr=\"s:8__main__2S1V\">S1</ref.struct>.<decl.name>Element</decl.name> = <ref.struct usr=\"s:Si\">Int</ref.struct></decl.typealias>",
         key.conforms: [
           {
             key.kind: source.lang.swift.ref.protocol,

--- a/test/SourceKit/DocSupport/doc_swift_module.swift.response
+++ b/test/SourceKit/DocSupport/doc_swift_module.swift.response
@@ -1159,7 +1159,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
         key.usr: "s:4cake2C1C7Elementa",
         key.offset: 24,
         key.length: 23,
-        key.fully_annotated_decl: "<decl.typealias><syntaxtype.keyword>typealias</syntaxtype.keyword> <decl.name>Element</decl.name> = <ref.struct usr=\"s:Si\">Int</ref.struct></decl.typealias>",
+        key.fully_annotated_decl: "<decl.typealias><syntaxtype.keyword>typealias</syntaxtype.keyword> <ref.class usr=\"s:4cake2C1C\">C1</ref.class>.<decl.name>Element</decl.name> = <ref.struct usr=\"s:Si\">Int</ref.struct></decl.typealias>",
         key.conforms: [
           {
             key.kind: source.lang.swift.ref.protocol,
@@ -1701,7 +1701,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
         key.usr: "s:4cake2S1V2SEO",
         key.offset: 1089,
         key.length: 63,
-        key.fully_annotated_decl: "<decl.enum><syntaxtype.keyword>enum</syntaxtype.keyword> <decl.name>SE</decl.name></decl.enum>",
+        key.fully_annotated_decl: "<decl.enum><syntaxtype.keyword>enum</syntaxtype.keyword> <ref.struct usr=\"s:4cake2S1V\">S1</ref.struct>.<decl.name>SE</decl.name></decl.enum>",
         key.entities: [
           {
             key.kind: source.lang.swift.decl.enumelement,
@@ -1778,7 +1778,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
         key.usr: "s:4cake2S2V1Ta",
         key.offset: 1238,
         key.length: 21,
-        key.fully_annotated_decl: "<decl.typealias><syntaxtype.keyword>typealias</syntaxtype.keyword> <decl.name>T</decl.name> = <ref.struct usr=\"s:4cake2S2V\">S2</ref.struct></decl.typealias>",
+        key.fully_annotated_decl: "<decl.typealias><syntaxtype.keyword>typealias</syntaxtype.keyword> <ref.struct usr=\"s:4cake2S2V\">S2</ref.struct>.<decl.name>T</decl.name> = <ref.struct usr=\"s:4cake2S2V\">S2</ref.struct></decl.typealias>",
         key.conforms: [
           {
             key.kind: source.lang.swift.ref.protocol,

--- a/test/stdlib/Reflection_objc.swift
+++ b/test/stdlib/Reflection_objc.swift
@@ -63,7 +63,7 @@ print("ObjC quick look objects:")
 // CHECK-LABEL: ObjC enums:
 print("ObjC enums:")
 
-// CHECK-NEXT: We cannot reflect ComparisonResult yet
+// CHECK-NEXT: We cannot reflect NSComparisonResult yet
 print("We cannot reflect \(ComparisonResult.orderedAscending) yet")
 
 // Don't crash when introspecting framework types such as NSURL.

--- a/test/stdlib/RuntimeObjC.swift
+++ b/test/stdlib/RuntimeObjC.swift
@@ -363,7 +363,7 @@ Runtime.test("Generic class ObjC runtime names") {
 
   expectEqual("_T01a12GenericClassCySo7CFArrayCGD",
               NSStringFromClass(GenericClass<CFArray>.self))
-  expectEqual("_T01a12GenericClassCySC7DecimalVGD",
+  expectEqual("_T01a12GenericClassCySo7DecimalVGD",
               NSStringFromClass(GenericClass<Decimal>.self))
   expectEqual("_T01a12GenericClassCySo8NSObjectCGD",
               NSStringFromClass(GenericClass<NSObject>.self))
@@ -751,8 +751,8 @@ Reflection.test("Unmanaged/not-nil") {
   dump(optionalURL, to: &output)
 
   let expected =
-    "▿ Optional(Swift.Unmanaged<__ObjC.CFURL>(_value: http://llvm.org/))\n" +
-    "  ▿ some: Swift.Unmanaged<__ObjC.CFURL>\n" +
+    "▿ Optional(Swift.Unmanaged<__C.CFURL>(_value: http://llvm.org/))\n" +
+    "  ▿ some: Swift.Unmanaged<__C.CFURL>\n" +
     "    - _value: http://llvm.org/ #0\n" +
     "      - super: NSObject\n"
 

--- a/test/stdlib/RuntimeObjC.swift
+++ b/test/stdlib/RuntimeObjC.swift
@@ -361,7 +361,7 @@ Runtime.test("Generic class ObjC runtime names") {
   expectEqual("_T01a12GenericClassCyAA9ProtocolA_AA0C1BpmGD",
               NSStringFromClass(GenericClass<(ProtocolB & ProtocolA).Protocol>.self))
 
-  expectEqual("_T01a12GenericClassCySo7CFArrayCGD",
+  expectEqual("_T01a12GenericClassCySo10CFArrayRefaGD",
               NSStringFromClass(GenericClass<CFArray>.self))
   expectEqual("_T01a12GenericClassCySo7DecimalVGD",
               NSStringFromClass(GenericClass<Decimal>.self))
@@ -751,8 +751,8 @@ Reflection.test("Unmanaged/not-nil") {
   dump(optionalURL, to: &output)
 
   let expected =
-    "▿ Optional(Swift.Unmanaged<__C.CFURL>(_value: http://llvm.org/))\n" +
-    "  ▿ some: Swift.Unmanaged<__C.CFURL>\n" +
+    "▿ Optional(Swift.Unmanaged<__C.CFURLRef>(_value: http://llvm.org/))\n" +
+    "  ▿ some: Swift.Unmanaged<__C.CFURLRef>\n" +
     "    - _value: http://llvm.org/ #0\n" +
     "      - super: NSObject\n"
 


### PR DESCRIPTION
This makes them consistent no matter what shenanigans are pulled by the importer, particularly NS_ENUM vs. NS_OPTIONS and NS_SWIFT_NAME.

The 'NSErrorDomain' API note *nearly* works with this, but the synthesized error struct is still mangled as a Swift declaration, which means it's not rename-stable. Fortunately, these are rare to appear at API boundaries.

The one place where this still falls down is NS_STRING_ENUM: when this is applied, a typedef is imported as a unique struct, but without it it's just a typealias for the underlying type. I don't have a solution for this yet.

This PR pulls in #8849 and a number of other little cleanups; the important part is the last two commits. It still needs more tests, and may not even be the direction we want to go.

rdar://problem/31616162