### PR TITLE
Fix up some CMake things

### DIFF
--- a/lib/Migrator/CMakeLists.txt
+++ b/lib/Migrator/CMakeLists.txt
@@ -27,7 +27,7 @@ endforeach()
 list(APPEND outputs "${output_dir}")
 
 add_custom_target("symlink_migrator_data"
-    DEPENDS "${outputs}"
+    DEPENDS "${output_dir}" "${outputs}"
     COMMENT "Symlinking migrator data to ${output_dir}")
 
 swift_install_in_component(compiler

--- a/lib/RemoteAST/CMakeLists.txt
+++ b/lib/RemoteAST/CMakeLists.txt
@@ -1,5 +1,19 @@
+if(XCODE)
+  file(GLOB_RECURSE REMOTE_LIB_HEADERS
+    ${SWIFT_SOURCE_DIR}/include/swift/Remote/*.h
+    ${SWIFT_SOURCE_DIR}/include/swift/Remote/*.def)
+
+  set_source_files_properties(${REMOTE_LIB_HEADERS}
+    PROPERTIES
+    HEADER_FILE_ONLY true)
+  source_group("libRemote Headers" FILES ${REMOTE_LIB_HEADERS})
+else()
+  set(REMOTE_LIB_HEADERS)
+endif()
+
 add_swift_library(swiftRemoteAST STATIC
   RemoteAST.cpp
   InProcessMemoryReader.cpp
+  ${REMOTE_LIB_HEADERS}
   LINK_LIBRARIES
     swiftSema swiftIRGen)


### PR DESCRIPTION
- When copying Migrator data, don't forget to create the directory we want to symlink into.
- Include the headers in include/swift/Remote/ in the generated Xcode project.