### PR TITLE
Add test for SR-4378

### DIFF
--- a/test/Compatibility/tuple_arguments.swift
+++ b/test/Compatibility/tuple_arguments.swift
@@ -1442,3 +1442,33 @@ func singleElementTupleArgument(completion: ((didAdjust: Bool)) -> Void) {
     completion((didAdjust: true))
 }
 
+
+// SR-4378 -- FIXME -- this should type check, it used to work in Swift 3.0
+
+final public class MutableProperty<Value> {
+    public init(_ initialValue: Value) {}
+}
+
+enum DataSourcePage<T> {
+    case notLoaded
+}
+
+let pages1: MutableProperty<(data: DataSourcePage<Int>, totalCount: Int)> = MutableProperty((
+    // expected-error@-1 {{cannot convert value of type 'MutableProperty<(data: _, totalCount: Int)>' to specified type 'MutableProperty<(data: DataSourcePage<Int>, totalCount: Int)>'}}
+    data: .notLoaded,
+    totalCount: 0
+))
+
+
+let pages2: MutableProperty<(data: DataSourcePage<Int>, totalCount: Int)> = MutableProperty((
+    // expected-error@-1 {{cannot convert value of type 'MutableProperty<(data: DataSourcePage<_>, totalCount: Int)>' to specified type 'MutableProperty<(data: DataSourcePage<Int>, totalCount: Int)>'}}
+    data: DataSourcePage.notLoaded,
+    totalCount: 0
+))
+
+
+let pages3: MutableProperty<(data: DataSourcePage<Int>, totalCount: Int)> = MutableProperty((
+    // expected-error@-1 {{expression type 'MutableProperty<(data: DataSourcePage<Int>, totalCount: Int)>' is ambiguous without more context}}
+    data: DataSourcePage<Int>.notLoaded,
+    totalCount: 0
+))

--- a/test/Constraints/tuple_arguments.swift
+++ b/test/Constraints/tuple_arguments.swift
@@ -1428,3 +1428,30 @@ func singleElementTupleArgument(completion: ((didAdjust: Bool)) -> Void) {
     completion((didAdjust: true))
 }
 
+
+// SR-4378
+
+final public class MutableProperty<Value> {
+    public init(_ initialValue: Value) {}
+}
+
+enum DataSourcePage<T> {
+    case notLoaded
+}
+
+let pages1: MutableProperty<(data: DataSourcePage<Int>, totalCount: Int)> = MutableProperty((
+    data: .notLoaded,
+    totalCount: 0
+))
+
+
+let pages2: MutableProperty<(data: DataSourcePage<Int>, totalCount: Int)> = MutableProperty((
+    data: DataSourcePage.notLoaded,
+    totalCount: 0
+))
+
+
+let pages3: MutableProperty<(data: DataSourcePage<Int>, totalCount: Int)> = MutableProperty((
+    data: DataSourcePage<Int>.notLoaded,
+    totalCount: 0
+))


### PR DESCRIPTION
This snippet type checks in Swift 4 mode, but not in Swift 3.

It used to work in Swift 3.0, so something broke when we
implemented SE-0110 and redid the Swift 3 mode emulation.