### PR TITLE
IRGen: Use LLVM -Os mode to compile swift

### DIFF
--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -154,7 +154,8 @@ void swift::performLLVMOptimizations(IRGenOptions &Opts, llvm::Module *Module,
   PassManagerBuilderWrapper PMBuilder(Opts);
 
   if (Opts.Optimize && !Opts.DisableLLVMOptzns) {
-    PMBuilder.OptLevel = 3;
+    PMBuilder.OptLevel = 2; // -Os
+    PMBuilder.SizeLevel = 1; // -Os
     PMBuilder.Inliner = llvm::createFunctionInliningPass(200);
     PMBuilder.SLPVectorize = true;
     PMBuilder.LoopVectorize = true;
@@ -480,7 +481,7 @@ swift::createTargetMachine(IRGenOptions &Opts, ASTContext &Ctx) {
     return nullptr;
   }
 
-  CodeGenOpt::Level OptLevel = Opts.Optimize ? CodeGenOpt::Aggressive
+  CodeGenOpt::Level OptLevel = Opts.Optimize ? CodeGenOpt::Default // -Os
                                              : CodeGenOpt::None;
 
   // Set up TargetOptions and create the target features string.


### PR DESCRIPTION
We don't want LLVM aggresively inlining llvm.memcpy instructions and similar
aggressive optimizations to save code size.

For example the X86 target sets max stores per memset to 16 and max stores per
memcpy to 8 (vs 4).

Loop optimizations are also a lot more aggressive.

rdar://31691017