### PR TITLE
[generic-specializer] Final parts of the partial specialization implementation

### DIFF
--- a/include/swift/SILOptimizer/Utils/Generics.h
+++ b/include/swift/SILOptimizer/Utils/Generics.h
@@ -131,7 +131,7 @@ class ReabstractionInfo {
 
   ReabstractionInfo() {}
 public:
-  /// Constructs the ReabstractionInfo for generic function \p Orig with
+  /// Constructs the ReabstractionInfo for generic function \p Callee with
   /// substitutions \p ParamSubs.
   /// If specialization is not possible getSpecializedType() will return an
   /// invalid type.
@@ -139,10 +139,10 @@ public:
                     SubstitutionList ParamSubs,
                     bool ConvertIndirectToDirect = true);
 
-  /// Constructs the ReabstractionInfo for generic function \p Orig with
+  /// Constructs the ReabstractionInfo for generic function \p Callee with
   /// additional requirements. Requirements may contain new layout,
   /// conformances or same concrete type requirements.
-  ReabstractionInfo(SILFunction *Orig, ArrayRef<Requirement> Requirements);
+  ReabstractionInfo(SILFunction *Callee, ArrayRef<Requirement> Requirements);
 
   /// Returns true if the \p ParamIdx'th (non-result) formal parameter is
   /// converted from indirect to direct.

--- a/include/swift/SILOptimizer/Utils/Generics.h
+++ b/include/swift/SILOptimizer/Utils/Generics.h
@@ -94,8 +94,8 @@ class ReabstractionInfo {
   // callee archetypes.
   SubstitutionList ClonerParamSubs;
 
-  // Reference to the original generic non-specialized function.
-  SILFunction *OriginalF;
+  // Reference to the original generic non-specialized callee function.
+  SILFunction *Callee;
 
   // The apply site which invokes the generic function.
   ApplySite Apply;
@@ -218,7 +218,7 @@ public:
   CanSILFunctionType createSpecializedType(CanSILFunctionType SubstFTy,
                                            SILModule &M) const;
 
-  SILFunction *getNonSpecializedFunction() const { return OriginalF; }
+  SILFunction *getNonSpecializedFunction() const { return Callee; }
 
   /// Map type into a context of the specialized function.
   Type mapTypeIntoContext(Type type) const;
@@ -226,7 +226,7 @@ public:
   /// Map SIL type into a context of the specialized function.
   SILType mapTypeIntoContext(SILType type) const;
 
-  SILModule &getModule() const { return OriginalF->getModule(); }
+  SILModule &getModule() const { return Callee->getModule(); }
 
   /// Returns true if generic specialization is possible.
   bool canBeSpecialized() const;

--- a/include/swift/SILOptimizer/Utils/Generics.h
+++ b/include/swift/SILOptimizer/Utils/Generics.h
@@ -27,6 +27,8 @@
 
 namespace swift {
 
+class FunctionSignaturePartialSpecializer;
+
 /// Tries to specialize an \p Apply of a generic function. It can be a full
 /// apply site or a partial apply.
 /// Replaced and now dead instructions are returned in \p DeadApplies.
@@ -119,11 +121,13 @@ class ReabstractionInfo {
   void createSubstitutedAndSpecializedTypes();
   bool prepareAndCheck(ApplySite Apply, SILFunction *Callee,
                        SubstitutionList ParamSubs);
-  void specializeConcreteAndGenericSubstitutions(ApplySite Apply,
-                                                 SILFunction *Callee,
-                                                 SubstitutionList ParamSubs);
-  void specializeConcreteSubstitutions(ApplySite Apply, SILFunction *Callee,
-                                       SubstitutionList ParamSubs);
+  void performFullSpecializationPreparation(SILFunction *Callee,
+                                            SubstitutionList ParamSubs);
+  void performPartialSpecializationPreparation(SILFunction *Caller,
+                                               SILFunction *Callee,
+                                               SubstitutionList ParamSubs);
+  void finishPartialSpecializationPreparation(
+      FunctionSignaturePartialSpecializer &FSPS);
 
   ReabstractionInfo() {}
 public:

--- a/include/swift/SILOptimizer/Utils/Generics.h
+++ b/include/swift/SILOptimizer/Utils/Generics.h
@@ -73,19 +73,16 @@ class ReabstractionInfo {
   /// It is nullptr if the specialization is not polymorphic.
   GenericSignature *SpecializedGenericSig;
 
-  // Set of the substitutions used by the caller's apply instruction before
+  // Set of substitutions from callee's invocation before
   // any transformations performed by the generic specializer.
   //
-  // Maps caller's generic parameters to caller's archetypes.
-  SubstitutionList OriginalParamSubs;
+  // Maps callee's generic parameters to caller's archetypes.
+  SubstitutionList CalleeParamSubs;
 
-  // Set of substitutions to be used by the caller's apply when it calls a
-  // specialized function.
+  // Set of substitutions to be used to invoke a specialized function.
   //
-  // Maps caller's generic parameters to caller's archetypes.
-  //
-  // FIXME: How is this different from OriginalParamSubs? Right now both
-  // are identical.
+  // Maps generic parameters of the specialized callee function to caller's
+  // archetypes.
   SubstitutionList CallerParamSubs;
 
   // Replaces archetypes of the original callee with archetypes
@@ -213,8 +210,8 @@ public:
     return ClonerParamSubs;
   }
 
-  SubstitutionList getOriginalParamSubstitutions() const {
-    return OriginalParamSubs;
+  SubstitutionList getCalleeParamSubstitutions() const {
+    return CalleeParamSubs;
   }
 
   /// Create a specialized function type for a specific substituted type \p

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -36,21 +36,21 @@ llvm::cl::opt<bool> SupportGenericSubstitutions(
 
 static bool OptimizeGenericSubstitutions = false;
 
-// Max depth of a type which can be processed by the generic
-// specializer.
-// E.g. the depth of Array<Array<Array<T>>> is 3.
-// No specializations will be produced, if any of generic parameters contains
-// a bound generic type with the depth higher than this threshold
+/// Max depth of a type which can be processed by the generic
+/// specializer.
+/// E.g. the depth of Array<Array<Array<T>>> is 3.
+/// No specializations will be produced, if any of generic parameters contains
+/// a bound generic type with the depth higher than this threshold
 static const unsigned TypeDepthThreshold = 50;
-// Set the width threshold rather high, because some projects uses very wide
-// tuples to model fixed size arrays.
+/// Set the width threshold rather high, because some projects uses very wide
+/// tuples to model fixed size arrays.
 static const unsigned TypeWidthThreshold = 2000;
 
-// Compute the width and the depth of a type.
-// We compute both, because some pathological test-cases result in very
-// wide types and some others result in very deep types. It is important
-// to bail as soon as we hit the threshold on any of both dimensions to
-// prevent compiler hangs and crashes.
+/// Compute the width and the depth of a type.
+/// We compute both, because some pathological test-cases result in very
+/// wide types and some others result in very deep types. It is important
+/// to bail as soon as we hit the threshold on any of both dimensions to
+/// prevent compiler hangs and crashes.
 static std::pair<unsigned, unsigned> getTypeDepthAndWidth(Type t) {
   unsigned Depth = 0;
   unsigned Width = 0;
@@ -529,8 +529,8 @@ ReabstractionInfo::createSubstitutedType(SILFunction *OrigF,
   return NewFnTy;
 }
 
-// Convert the substituted function type into a specialized function type based
-// on the ReabstractionInfo.
+/// Convert the substituted function type into a specialized function type based
+/// on the ReabstractionInfo.
 CanSILFunctionType ReabstractionInfo::
 createSpecializedType(CanSILFunctionType SubstFTy, SILModule &M) const {
   llvm::SmallVector<SILResultInfo, 8> SpecializedResults;
@@ -586,8 +586,8 @@ getGenericEnvironmentAndSignature(GenericSignatureBuilder &Builder,
   return std::make_pair(GenericEnv, GenericSig);
 }
 
-// Create a new generic signature from an existing one by adding
-// additional requirements.
+/// Create a new generic signature from an existing one by adding
+/// additional requirements.
 std::pair<GenericEnvironment *, GenericSignature *>
 getGenericEnvironmentAndSignatureWithRequirements(
     GenericSignature *OrigGenSig, GenericEnvironment *OrigGenericEnv,
@@ -858,34 +858,34 @@ namespace swift {
 
 /// A helper class for creating partially specialized function signatures.
 class FunctionSignaturePartialSpecializer {
-  // Maps caller's generic parameters to generic parameters of the specialized
-  // function.
+  /// Maps caller's generic parameters to generic parameters of the specialized
+  /// function.
   llvm::DenseMap<SubstitutableType *, Type>
       CallerInterfaceToSpecializedInterfaceMapping;
 
-  // Maps callee's generic parameters to generic parameters of the specialized
-  // function.
+  /// Maps callee's generic parameters to generic parameters of the specialized
+  /// function.
   llvm::DenseMap<SubstitutableType *, Type>
       CalleeInterfaceToSpecializedInterfaceMapping;
 
-  // Maps the generic parameters of the specialized function to the caller's
-  // contextual types.
+  /// Maps the generic parameters of the specialized function to the caller's
+  /// contextual types.
   llvm::DenseMap<SubstitutableType *, Type>
       SpecializedInterfaceToCallerArchetypeMapping;
 
-  // A SubstitutionMap for re-mapping caller's interface types
-  // to interface types of the specialized function.
+  /// A SubstitutionMap for re-mapping caller's interface types
+  /// to interface types of the specialized function.
   SubstitutionMap CallerInterfaceToSpecializedInterfaceMap;
 
-  // Maps callee's interface types to caller's contextual types.
-  // It is computed from the original SubstitutionList.
+  /// Maps callee's interface types to caller's contextual types.
+  /// It is computed from the original SubstitutionList.
   SubstitutionMap CalleeInterfaceToCallerArchetypeMap;
 
-  // Maps callee's interface types to specialized functions interface types.
+  /// Maps callee's interface types to specialized functions interface types.
   SubstitutionMap CalleeInterfaceToSpecializedInterfaceMap;
 
-  // Maps the generic parameters of the specialized function to the caller's
-  // contextual types.
+  /// Maps the generic parameters of the specialized function to the caller's
+  /// contextual types.
   SubstitutionMap SpecializedInterfaceToCallerArchetypeMap;
 
   GenericSignature *CallerGenericSig;
@@ -901,18 +901,18 @@ class FunctionSignaturePartialSpecializer {
   ModuleDecl *SM;
   ASTContext &Ctx;
 
-  // This is a builder for a new partially specialized generic signature.
+  /// This is a builder for a new partially specialized generic signature.
   GenericSignatureBuilder Builder;
 
-  // Set of newly created generic type parameters.
+  /// Set of newly created generic type parameters.
   SmallVector<GenericTypeParamType*, 4> AllGenericParams;
 
-  // Archetypes used in the substitutions of an apply instructions.
-  // These are the contextual archetypes of the caller function, which
-  // invokes a generic function that is being specialized.
+  /// Archetypes used in the substitutions of an apply instructions.
+  /// These are the contextual archetypes of the caller function, which
+  /// invokes a generic function that is being specialized.
   llvm::SmallSetVector<ArchetypeType *, 2> UsedCallerArchetypes;
 
-  // Number of created generic parameters so far.
+  /// Number of created generic parameters so far.
   unsigned GPIdx = 0;
 
   void createGenericParamsForUsedCallerArchetypes();
@@ -940,7 +940,7 @@ class FunctionSignaturePartialSpecializer {
   /// specialized. Ignore all others.
   void collectUsedCallerArchetypes(SubstitutionList ParamSubs);
 
-  // Create a new generic parameter.
+  /// Create a new generic parameter.
   GenericTypeParamType *createGenericParam();
 
 public:
@@ -960,8 +960,8 @@ public:
       CalleeGenericSig->getSubstitutionMap(ParamSubs);
   }
 
-  // This constructor is used by when processing @_specialize.
-  // In this case, the caller and the callee are the same function.
+  /// This constructor is used by when processing @_specialize.
+  /// In this case, the caller and the callee are the same function.
   FunctionSignaturePartialSpecializer(SILModule &M,
                                       GenericSignature *CalleeGenericSig,
                                       GenericEnvironment *CalleeGenericEnv,
@@ -1245,14 +1245,14 @@ void FunctionSignaturePartialSpecializer::
   }
 }
 
-// Add requirements from a given list of requirements to the
-// GenericSignatureBuilder. Re-map them using the provided SubstitutionMap.
+/// Add requirements from a given list of requirements to the
+/// GenericSignatureBuilder. Re-map them using the provided SubstitutionMap.
 void FunctionSignaturePartialSpecializer::addRequirements(
     ArrayRef<Requirement> Reqs, SubstitutionMap &SubsMap) {
   remapRequirements(Reqs, SubsMap, Builder, SM);
 }
 
-// Add requirements from the caller signature.
+/// Add requirements from the caller's signature.
 void FunctionSignaturePartialSpecializer::addCallerRequirements() {
   for (auto CallerArchetype : UsedCallerArchetypes) {
     auto CallerGenericParam =
@@ -1274,7 +1274,7 @@ void FunctionSignaturePartialSpecializer::addCallerRequirements() {
   }
 }
 
-// Add requirements from the callee signature.
+/// Add requirements from the callee's signature.
 void FunctionSignaturePartialSpecializer::addCalleeRequirements() {
   if (CalleeGenericSig)
     addRequirements(CalleeGenericSig->getRequirements(),
@@ -1345,7 +1345,7 @@ void FunctionSignaturePartialSpecializer::computeCallerInterfaceSubs(
         CallerInterfaceSubs.dump(llvm::dbgs()));
 }
 
-// Fast-path for the case when generic substitutions are not supported.
+/// Fast-path for the case when generic substitutions are not supported.
 void FunctionSignaturePartialSpecializer::
     createSpecializedGenericSignatureWithNonGenericSubs() {
   // Simply create a set of same-type requirements based on concrete
@@ -1414,32 +1414,32 @@ void FunctionSignaturePartialSpecializer::createSpecializedGenericSignature(
   }
 }
 
-// Builds a new generic and function signatures for a partial specialization.
-// Allows for partial specializations even if substitutions contain
-// type parameters.
-//
-// The new generic signature has the following generic parameters:
-// - For each substitution with a concrete type CT as a replacement for a
-// generic type T, it introduces a generic parameter T' and a
-// requirement T' == CT
-// - For all other substitutions that are considered for partial specialization,
-// it collects first the archetypes used in the replacements. Then for each such
-// archetype A a new generic parameter T' introduced.
-// - If there is a substitution for type T and this substitution is excluded
-// from partial specialization (e.g. because it is impossible or would result
-// in a less efficient code), then a new generic parameter T' is introduced,
-// which does not get any additional, more specific requirements based on the
-// substitutions.
-//
-// After all generic parameters are added according to the rules above,
-// the requirements of the callee's signature are re-mapped by re-formulating
-// them in terms of the newly introduced generic parameters. In case a remapped
-// requirement does not contain any generic types, it can be omitted, because
-// it is fulfilled already.
-//
-// If any of the generic parameters were introduced for caller's archetypes,
-// their requirements from the caller's signature are re-mapped by
-// re-formulating them in terms of the newly introduced generic parameters.
+/// Builds a new generic and function signatures for a partial specialization.
+/// Allows for partial specializations even if substitutions contain
+/// type parameters.
+///
+/// The new generic signature has the following generic parameters:
+/// - For each substitution with a concrete type CT as a replacement for a
+/// generic type T, it introduces a generic parameter T' and a
+/// requirement T' == CT
+/// - For all other substitutions that are considered for partial specialization,
+/// it collects first the archetypes used in the replacements. Then for each such
+/// archetype A a new generic parameter T' introduced.
+/// - If there is a substitution for type T and this substitution is excluded
+/// from partial specialization (e.g. because it is impossible or would result
+/// in a less efficient code), then a new generic parameter T' is introduced,
+/// which does not get any additional, more specific requirements based on the
+/// substitutions.
+///
+/// After all generic parameters are added according to the rules above,
+/// the requirements of the callee's signature are re-mapped by re-formulating
+/// them in terms of the newly introduced generic parameters. In case a remapped
+/// requirement does not contain any generic types, it can be omitted, because
+/// it is fulfilled already.
+///
+/// If any of the generic parameters were introduced for caller's archetypes,
+/// their requirements from the caller's signature are re-mapped by
+/// re-formulating them in terms of the newly introduced generic parameters.
 void ReabstractionInfo::performPartialSpecializationPreparation(
     SILFunction *Caller, SILFunction *Callee,
     ArrayRef<Substitution> ParamSubs) {
@@ -1546,7 +1546,7 @@ checkSpecializationRequirements(ArrayRef<Requirement> Requirements) {
   }
 }
 
-// This constructor is used when processing @_specialize.
+/// This constructor is used when processing @_specialize.
 ReabstractionInfo::ReabstractionInfo(SILFunction *Callee,
                                      ArrayRef<Requirement> Requirements) {
   if (shouldNotSpecializeCallee(Callee))
@@ -1600,7 +1600,7 @@ GenericFuncSpecializer::GenericFuncSpecializer(SILFunction *GenericFunc,
   DEBUG(llvm::dbgs() << "    Specialized function " << ClonedName << '\n');
 }
 
-// Return an existing specialization if one exists.
+/// Return an existing specialization if one exists.
 SILFunction *GenericFuncSpecializer::lookupSpecialization() {
   if (SILFunction *SpecializedF = M.lookUpFunction(ClonedName)) {
     if (ReInfo.getSpecializedType() != SpecializedF->getLoweredFunctionType()) {
@@ -1621,7 +1621,7 @@ SILFunction *GenericFuncSpecializer::lookupSpecialization() {
   return nullptr;
 }
 
-// Forward decl for prespecialization support.
+/// Forward decl for prespecialization support.
 static bool linkSpecialization(SILModule &M, SILFunction *F);
 
 void ReabstractionInfo::verify() const {
@@ -1631,7 +1631,7 @@ void ReabstractionInfo::verify() const {
           getSpecializedType()->isPolymorphic()));
 }
 
-// Create a new specialized function if possible, and cache it.
+/// Create a new specialized function if possible, and cache it.
 SILFunction *GenericFuncSpecializer::tryCreateSpecialization() {
   // Do not create any new specializations at Onone.
   if (M.getOptions().Optimization <= SILOptions::SILOptMode::None)
@@ -1676,7 +1676,7 @@ static void fixUsedVoidType(SILValue VoidVal, SILLocation Loc,
   VoidVal->replaceAllUsesWith(NewVoidVal);
 }
 
-// Prepare call arguments. Perform re-abstraction if required.
+/// Prepare call arguments. Perform re-abstraction if required.
 static void prepareCallArguments(ApplySite AI, SILBuilder &Builder,
                                  const ReabstractionInfo &ReInfo,
                                  SmallVectorImpl<SILValue> &Arguments,
@@ -1731,8 +1731,8 @@ getCalleeSubstFunctionType(SILValue Callee, SubstitutionList Subs) {
   return CanFnTy->substGenericArgs(*Callee->getModule(), Subs);
 }
 
-// Create a new apply based on an old one, but with a different
-// function being applied.
+/// Create a new apply based on an old one, but with a different
+/// function being applied.
 static ApplySite replaceWithSpecializedCallee(ApplySite AI,
                                               SILValue Callee,
                                               SILBuilder &Builder,
@@ -1811,8 +1811,8 @@ static ApplySite replaceWithSpecializedCallee(ApplySite AI,
   llvm_unreachable("unhandled kind of apply");
 }
 
-// Create a new apply based on an old one, but with a different
-// function being applied.
+/// Create a new apply based on an old one, but with a different
+/// function being applied.
 ApplySite swift::
 replaceWithSpecializedFunction(ApplySite AI, SILFunction *NewF,
                                const ReabstractionInfo &ReInfo) {
@@ -1922,7 +1922,7 @@ SILFunction *ReabstractionThunkGenerator::createThunk() {
   return Thunk;
 }
 
-// Create a call to a reabstraction thunk. Return the call's direct result.
+/// Create a call to a reabstraction thunk. Return the call's direct result.
 SILValue ReabstractionThunkGenerator::createReabstractionThunkApply(
     SILBuilder &Builder) {
   SILFunction *Thunk = &Builder.getFunction();
@@ -1953,12 +1953,12 @@ SILValue ReabstractionThunkGenerator::createReabstractionThunkApply(
   return ReturnValue;
 }
 
-// Create SIL arguments for a reabstraction thunk with lowered addresses. This
-// may involve replacing indirect arguments with loads and stores. Return the
-// SILArgument for the address of an indirect result, or nullptr.
-//
-// FIXME: Remove this if we don't need to create reabstraction thunks after
-// address lowering.
+/// Create SIL arguments for a reabstraction thunk with lowered addresses. This
+/// may involve replacing indirect arguments with loads and stores. Return the
+/// SILArgument for the address of an indirect result, or nullptr.
+///
+/// FIXME: Remove this if we don't need to create reabstraction thunks after
+/// address lowering.
 SILArgument *ReabstractionThunkGenerator::convertReabstractionThunkArguments(
     SILBuilder &Builder) {
   SILFunction *Thunk = &Builder.getFunction();
@@ -2243,8 +2243,8 @@ static bool linkSpecialization(SILModule &M, SILFunction *F) {
   return false;
 }
 
-// The whitelist of classes and functions from the stdlib,
-// whose specializations we want to preserve.
+/// The whitelist of classes and functions from the stdlib,
+/// whose specializations we want to preserve.
 static const char *const WhitelistedSpecializations[] = {
     "Array",
     "_ArrayBuffer",

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -1906,11 +1906,11 @@ void swift::trySpecializeApplyOfGeneric(
     ApplySite Apply, DeadInstructionSet &DeadApplies,
     llvm::SmallVectorImpl<SILFunction *> &NewFunctions) {
   assert(Apply.hasSubstitutions() && "Expected an apply with substitutions!");
-
-  auto *F = Apply.getInstruction()->getFunction();
+  auto *F = Apply.getFunction();
   auto *RefF = cast<FunctionRefInst>(Apply.getCallee())->getReferencedFunction();
 
-  DEBUG(llvm::dbgs() << "\n\n*** ApplyInst:\n";
+  DEBUG(llvm::dbgs() << "\n\n*** ApplyInst in function " << F->getName()
+                     << ":\n";
         Apply.getInstruction()->dumpInContext());
 
   // If the caller is fragile but the callee is not, bail out.

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -271,8 +271,14 @@ bool ReabstractionInfo::prepareAndCheck(ApplySite Apply, SILFunction *Callee,
   if (HasUnboundGenericParams) {
     // Bail if we cannot specialize generic substitutions, but all substitutions
     // were generic.
-    if (!HasConcreteGenericParams && !SpecializeGenericSubstitutions)
+    if (!HasConcreteGenericParams && !SupportGenericSubstitutions) {
+      DEBUG(llvm::dbgs() << "    Partial specialization is not supported if "
+                            "all substitutions are generic.\n");
+      DEBUG(for (auto Sub : ParamSubs) {
+          Sub.dump();
+        });
       return false;
+    }
 
     if (!HasNonArchetypeGenericParams && !HasConcreteGenericParams) {
       DEBUG(llvm::dbgs() << "    Partial specialization is not supported if "

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -601,36 +601,6 @@ getSignatureWithRequirements(GenericSignature *OrigGenSig,
   return getGenericEnvironmentAndSignature(Builder, M);
 }
 
-/// Perform some sanity checks for the requirements
-static void
-checkSpecializationRequirements(ArrayRef<Requirement> Requirements) {
-  for (auto &Req : Requirements) {
-    if (Req.getKind() == RequirementKind::SameType) {
-      auto FirstType = Req.getFirstType();
-      auto SecondType = Req.getSecondType();
-      assert(FirstType && SecondType);
-      assert(!FirstType->hasArchetype());
-      assert(!SecondType->hasArchetype());
-
-      // Only one of the types should be concrete.
-      assert(FirstType->hasTypeParameter() != SecondType->hasTypeParameter() &&
-             "Only concrete type same-type requirements are supported by "
-             "generic specialization");
-
-      (void) FirstType;
-      (void) SecondType;
-
-      continue;
-    }
-
-    if (Req.getKind() == RequirementKind::Layout) {
-      continue;
-    }
-
-    llvm_unreachable("Unknown type of requirement in generic specialization");
-  }
-}
-
 ReabstractionInfo::ReabstractionInfo(SILFunction *OrigF,
                                      ArrayRef<Requirement> Requirements) {
   if (shouldNotSpecializeCallee(OrigF))
@@ -1439,6 +1409,36 @@ void ReabstractionInfo::specializeConcreteAndGenericSubstitutions(
     if (getSubstitutedType()->isPolymorphic())
       DEBUG(llvm::dbgs() << "Created new specialized type: " << SpecializedType
                          << "\n");
+  }
+}
+
+/// Perform some sanity checks for the requirements provided in @_specialize.
+static void
+checkSpecializationRequirements(ArrayRef<Requirement> Requirements) {
+  for (auto &Req : Requirements) {
+    if (Req.getKind() == RequirementKind::SameType) {
+      auto FirstType = Req.getFirstType();
+      auto SecondType = Req.getSecondType();
+      assert(FirstType && SecondType);
+      assert(!FirstType->hasArchetype());
+      assert(!SecondType->hasArchetype());
+
+      // Only one of the types should be concrete.
+      assert(FirstType->hasTypeParameter() != SecondType->hasTypeParameter() &&
+             "Only concrete type same-type requirements are supported by "
+             "generic specialization");
+
+      (void) FirstType;
+      (void) SecondType;
+
+      continue;
+    }
+
+    if (Req.getKind() == RequirementKind::Layout) {
+      continue;
+    }
+
+    llvm_unreachable("Unknown type of requirement in generic specialization");
   }
 }
 

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -199,7 +199,7 @@ bool ReabstractionInfo::prepareAndCheck(ApplySite Apply, SILFunction *Callee,
   auto CalleeGenericSig = Callee->getLoweredFunctionType()->getGenericSignature();
   auto CalleeGenericEnv = Callee->getGenericEnvironment();
 
-  OriginalF = Callee;
+  this->Callee = Callee;
   this->Apply = Apply;
 
   SubstitutionMap InterfaceSubs;
@@ -426,13 +426,13 @@ bool ReabstractionInfo::isPartialSpecialization() const {
 }
 
 void ReabstractionInfo::createSubstitutedAndSpecializedTypes() {
-  auto &M = OriginalF->getModule();
+  auto &M = Callee->getModule();
 
   // Find out how the function type looks like after applying the provided
   // substitutions.
   if (!SubstitutedType) {
-    SubstitutedType = createSubstitutedType(
-        OriginalF, CallerInterfaceSubs, HasUnboundGenericParams);
+    SubstitutedType = createSubstitutedType(Callee, CallerInterfaceSubs,
+                                            HasUnboundGenericParams);
   }
   assert(!SubstitutedType->hasArchetype() &&
          "Substituted function type should not contain archetypes");
@@ -695,7 +695,7 @@ void ReabstractionInfo::specializeConcreteSubstitutions(
   SILModule &M = Callee->getModule();
   auto &Ctx = M.getASTContext();
 
-  OriginalF = Callee;
+  this->Callee = Callee;
 
   auto OrigGenericSig = Callee->getLoweredFunctionType()->getGenericSignature();
   auto OrigGenericEnv = Callee->getGenericEnvironment();

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -572,17 +572,6 @@ getGenericEnvironmentAndSignature(GenericSignatureBuilder &Builder,
   auto *GenericSig =
       Builder.getGenericSignature()->getCanonicalSignature().getPointer();
   auto *GenericEnv = GenericSig->createGenericEnvironment(*M.getSwiftModule());
-
-  // FIXME: This is a workaround for the signature minimization bug.
-  GenericSignatureBuilder TmpBuilder(
-      M.getASTContext(), LookUpConformanceInModule(M.getSwiftModule()));
-  TmpBuilder.addGenericSignature(GenericSig);
-  TmpBuilder.finalize(SourceLoc(), GenericSig->getGenericParams(),
-                      /*allowConcreteGenericParams=*/true);
-  GenericSig =
-      TmpBuilder.getGenericSignature()->getCanonicalSignature().getPointer();
-  GenericEnv = GenericSig->createGenericEnvironment(*M.getSwiftModule());
-
   assert(!GenericSig || GenericEnv);
   return std::make_pair(GenericEnv, GenericSig);
 }


### PR DESCRIPTION
- Introduced a new helper class FunctionSignaturePartialSpecializer which provides most of the functionality required for producing a specialized generic signature based on the provided substitutions or requirements. The class consists of many small functions, which should make it easier to understand the code.

- Added a full support for partial specialization of generic parameters with generic substitutions (use flag `-Xllvm -sil-partial-specialization-with-generic-substitutions` to enable it)
- Removed the simpler version of the partial specializer which could partially specialize only generic parameters with non-generic substitutions. It is not needed anymore, because we can handle any substations now when performing the partial specialization.

- The functionality used by the EagerSpecializer to implement the partial specializations required by @_specialize is expressed in terms of FunctionSignaturePartialSpecializer as well. The code implementing it is much smaller now.

Partial specialization of generic parameters with generic substitutions is fully functional, but it is disabled by default, because it needs some tweaks when it comes to compile times and size of produced code. These issues will be addressed in the subsequent commits.

Partial specialization of generic parameters with concrete substitutions continues to be enabled by default. It was enabled by default a couple of weeks ago.