### PR TITLE
SILPrinter: make the printing of debug info optional.

### DIFF
--- a/include/swift/SIL/SILPrintContext.h
+++ b/include/swift/SIL/SILPrintContext.h
@@ -69,10 +69,18 @@ protected:
   /// Sort all kind of tables to ease diffing.
   bool SortedSIL;
 
+  /// Print debug locations and scopes.
+  bool DebugInfo;
+
 public:
+  /// Constructor with default values for options.
+  ///
+  /// DebugInfo will be set according to the -sil-print-debuginfo option.
   SILPrintContext(llvm::raw_ostream &OS, bool Verbose = false,
-                  bool SortedSIL = false) :
-        OutStream(OS), Verbose(Verbose), SortedSIL(SortedSIL) { }
+                  bool SortedSIL = false);
+
+  SILPrintContext(llvm::raw_ostream &OS, bool Verbose,
+                  bool SortedSIL, bool DebugInfo);
 
   virtual ~SILPrintContext();
 
@@ -89,6 +97,9 @@ public:
   
   /// Returns true if verbose SIL should be printed.
   bool printVerbose() const { return Verbose; }
+
+  /// Returns true if debug locations and scopes should be printed.
+  bool printDebugInfo() const { return DebugInfo; }
 
   SILPrintContext::ID getID(const SILBasicBlock *Block);
 

--- a/test/ClangImporter/macro_literals.swift
+++ b/test/ClangImporter/macro_literals.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-sil %s | %FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -Xllvm -sil-print-debuginfo -emit-sil %s | %FileCheck %s
 
 import macros
 

--- a/test/ClangImporter/serialization-sil.swift
+++ b/test/ClangImporter/serialization-sil.swift
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: %target-swift-frontend -emit-module-path %t/Test.swiftmodule -emit-sil -o /dev/null -module-name Test %s -sdk "" -import-objc-header %S/Inputs/serialization-sil.h
-// RUN: %target-sil-func-extractor %t/Test.swiftmodule -func=_T04Test16testPartialApplyySoAA_pF -o - | %FileCheck %s
+// RUN: %target-sil-func-extractor %t/Test.swiftmodule -sil-print-debuginfo  -func=_T04Test16testPartialApplyySoAA_pF -o - | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/DebugInfo/conditional-assign.swift
+++ b/test/DebugInfo/conditional-assign.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend %s -emit-sil -g -o - | %FileCheck  %s
+// RUN: %target-swift-frontend %s -Xllvm -sil-print-debuginfo -emit-sil -g -o - | %FileCheck  %s
 public protocol DelegateA {}
 public protocol DelegateB {}
 public protocol WithDelegate

--- a/test/DebugInfo/gsil.swift
+++ b/test/DebugInfo/gsil.swift
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: %target-swift-frontend %s -O -gsil -emit-ir -o %t/out.ir
+// RUN: %target-swift-frontend %s -O -gsil -Xllvm -sil-print-debuginfo -emit-ir -o %t/out.ir
 // RUN: %FileCheck %s < %t/out.ir
 // RUN: %FileCheck %s --check-prefix=CHECK_OUT_SIL < %t/out.ir.gsil_0.sil
 

--- a/test/SIL/Parser/sil_scope.sil
+++ b/test/SIL/Parser/sil_scope.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil %s | %FileCheck %s
+// RUN: %target-sil-opt -sil-print-debuginfo -assume-parsing-unqualified-ownership-sil %s | %FileCheck %s
 
 // CHECK: sil_scope 1 { loc "foo.sil":12:34 parent @foo : $@convention(thin) () -> () }
           sil_scope 1 { loc "foo.sil":12:34 parent @foo : $@convention(thin) () -> () }

--- a/test/SIL/Parser/sil_scope_inline_fn.sil
+++ b/test/SIL/Parser/sil_scope_inline_fn.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -O %s | %FileCheck %s
+// RUN: %target-sil-opt -sil-print-debuginfo -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -O %s | %FileCheck %s
 
 sil_scope 1 { loc "foo.sil":3:4 parent @foo : $@convention(thin) () -> () }
 sil_scope 2 { loc "foo.sil":3:4 parent 1 }

--- a/test/SIL/Parser/sillocation.sil
+++ b/test/SIL/Parser/sillocation.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil %s | %FileCheck %s
+// RUN: %target-sil-opt -sil-print-debuginfo -assume-parsing-unqualified-ownership-sil %s | %FileCheck %s
 
 sil @foo : $@convention(thin) () -> () {
 bb0:

--- a/test/SIL/unimplemented_initializer.swift
+++ b/test/SIL/unimplemented_initializer.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -sdk %S/../SILGen/Inputs -I %S/../SILGen/Inputs -enable-source-import -primary-file %s -emit-sil -emit-verbose-sil | %FileCheck %s -check-prefix=CHECK-DEBUG
-// RUN: %target-swift-frontend -sdk %S/../SILGen/Inputs -I %S/../SILGen/Inputs -enable-source-import -primary-file %s -emit-sil -emit-verbose-sil -O | %FileCheck %s -check-prefix=CHECK-RELEASE
+// RUN: %target-swift-frontend -sdk %S/../SILGen/Inputs -I %S/../SILGen/Inputs -Xllvm -sil-print-debuginfo -enable-source-import -primary-file %s -emit-sil -emit-verbose-sil | %FileCheck %s -check-prefix=CHECK-DEBUG
+// RUN: %target-swift-frontend -sdk %S/../SILGen/Inputs -I %S/../SILGen/Inputs -Xllvm -sil-print-debuginfo -enable-source-import -primary-file %s -emit-sil -emit-verbose-sil -O | %FileCheck %s -check-prefix=CHECK-RELEASE
 
 // XFAIL: linux
 

--- a/test/SILGen/auto_generated_super_init_call.swift
+++ b/test/SILGen/auto_generated_super_init_call.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -sil-print-debuginfo -emit-silgen %s | %FileCheck %s
 
 // Test that we emit a call to super.init at the end of the initializer, when none has been previously added.
 

--- a/test/SILGen/errors.swift
+++ b/test/SILGen/errors.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -parse-stdlib -emit-silgen -verify -primary-file %s %S/Inputs/errors_other.swift | %FileCheck %s
+// RUN: %target-swift-frontend -parse-stdlib -emit-silgen -Xllvm -sil-print-debuginfo -verify -primary-file %s %S/Inputs/errors_other.swift | %FileCheck %s
 
 import Swift
 

--- a/test/SILGen/indirect_enum.swift
+++ b/test/SILGen/indirect_enum.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -sil-print-debuginfo -emit-silgen %s | %FileCheck %s
 
 indirect enum TreeA<T> {
   case Nil

--- a/test/SILGen/objc_bridged_results.swift
+++ b/test/SILGen/objc_bridged_results.swift
@@ -1,7 +1,7 @@
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: %build-silgen-test-overlays
 
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -emit-silgen %s -import-objc-header %S/Inputs/objc_bridged_results.h | %FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -emit-silgen %s -Xllvm -sil-print-debuginfo -import-objc-header %S/Inputs/objc_bridged_results.h | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/SILGen/objc_bridging_any.swift
+++ b/test/SILGen/objc_bridging_any.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -Xllvm -sil-print-debuginfo -emit-silgen %s | %FileCheck %s
 // REQUIRES: objc_interop
 
 import Foundation

--- a/test/SILGen/objc_thunks.swift
+++ b/test/SILGen/objc_thunks.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -emit-silgen -emit-verbose-sil | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -Xllvm -sil-print-debuginfo -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -emit-silgen -emit-verbose-sil | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/SILGen/sil_locations.swift
+++ b/test/SILGen/sil_locations.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen -emit-verbose-sil %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -Xllvm -sil-print-debuginfo -emit-verbose-sil %s | %FileCheck %s
 
 // FIXME: Not sure if this an ideal source info for the branch - 
 // it points to if, not the last instruction in the block.

--- a/test/SILGen/sil_locations_top_level.swift
+++ b/test/SILGen/sil_locations_top_level.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -emit-silgen -emit-verbose-sil %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -Xllvm -sil-print-debuginfo -emit-silgen -emit-verbose-sil %s | %FileCheck %s
 
 // Test top-level/module locations.
 class TopLevelObjectTy {

--- a/test/SILGen/source_location.swift
+++ b/test/SILGen/source_location.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -Xllvm -sil-print-debuginfo -emit-silgen %s | %FileCheck %s
 
 func printSourceLocation(file: String = #file, line: Int = #line) {}
 

--- a/test/SILOptimizer/allocbox_to_stack.sil
+++ b/test/SILOptimizer/allocbox_to_stack.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -allocbox-to-stack | %FileCheck %s
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -sil-print-debuginfo -enable-sil-verify-all %s -allocbox-to-stack | %FileCheck %s
 
 import Builtin
 

--- a/test/SILOptimizer/basic-callee-printer.sil
+++ b/test/SILOptimizer/basic-callee-printer.sil
@@ -1,5 +1,5 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -basic-callee-printer -o /dev/null | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-NOWMO %s
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -wmo -basic-callee-printer -o /dev/null | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-WMO %s
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -sil-print-debuginfo -enable-sil-verify-all %s -basic-callee-printer -o /dev/null | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-NOWMO %s
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -sil-print-debuginfo -enable-sil-verify-all %s -wmo -basic-callee-printer -o /dev/null | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-WMO %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/conditionforwarding.sil
+++ b/test/SILOptimizer/conditionforwarding.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -condition-forwarding | %FileCheck %s
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -sil-print-debuginfo -enable-sil-verify-all %s -condition-forwarding | %FileCheck %s
 
 import Builtin
 import Swift

--- a/test/SILOptimizer/dead_array_elim.sil
+++ b/test/SILOptimizer/dead_array_elim.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -deadobject-elim %s | %FileCheck %s
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -sil-print-debuginfo -enable-sil-verify-all -deadobject-elim %s | %FileCheck %s
 
 // Linux doesn't have the same symbol name for _ArrayBuffer.
 // XFAIL: linux

--- a/test/SILOptimizer/sil_locations.sil
+++ b/test/SILOptimizer/sil_locations.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -mandatory-inlining -emit-verbose-sil %s | %FileCheck %s
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -sil-print-debuginfo -enable-sil-verify-all -mandatory-inlining -emit-verbose-sil %s | %FileCheck %s
 
 import Builtin
 import Swift

--- a/test/SILOptimizer/specialize_apply_conf.swift
+++ b/test/SILOptimizer/specialize_apply_conf.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -O -sil-inline-threshold 0 -emit-sil -primary-file %s | %FileCheck %s
+// RUN: %target-swift-frontend -O -sil-inline-threshold 0 -Xllvm -sil-print-debuginfo -emit-sil -primary-file %s | %FileCheck %s
 
 // We can't deserialize apply_inst with subst lists. When radar://14443304
 // is fixed then we should convert this test to a SIL test.


### PR DESCRIPTION
With the option -sil-print-debuginfo the printing of debug locations and scopes can be enabled.

I made the default for the option “false”, because in 99% of the time I don’t need the debug info in the printed SIL and I prefer better readability.
