### PR TITLE
[eager-specializer] Fix a bug in eager specialization of throwing functions

### DIFF
--- a/lib/SILOptimizer/IPO/EagerSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/EagerSpecializer.cpp
@@ -248,11 +248,23 @@ emitInvocation(SILBuilder &Builder,
   SILFunctionConventions fnConv(CalleeSILSubstFnTy.castTo<SILFunctionType>(),
                                 Builder.getModule());
 
-  if (!CanSILFuncTy->hasErrorResult()) {
-    return Builder.createApply(
-        CalleeFunc->getLocation(), FuncRefInst, CalleeSILSubstFnTy,
-        fnConv.getSILResultType(), Subs, CallArgs, false);
+  bool isNonThrowing = false;
+  // It it a function whose type claims it is throwing, but
+  // it actually never throws inside its body?
+  if (CanSILFuncTy->hasErrorResult() &&
+      CalleeFunc->findThrowBB() == CalleeFunc->end()) {
+    isNonThrowing = true;
   }
+
+  // Is callee a non-throwing function according to its type
+  // or de-facto?
+  if (!CanSILFuncTy->hasErrorResult() ||
+      CalleeFunc->findThrowBB() == CalleeFunc->end()) {
+    return Builder.createApply(CalleeFunc->getLocation(), FuncRefInst,
+                               CalleeSILSubstFnTy, fnConv.getSILResultType(),
+                               Subs, CallArgs, isNonThrowing);
+  }
+
   return emitApplyWithRethrow(Builder, CalleeFunc->getLocation(),
                               FuncRefInst, CalleeSubstFnTy, Subs,
                               CallArgs,

--- a/test/SILOptimizer/eager_specialize.sil
+++ b/test/SILOptimizer/eager_specialize.sil
@@ -35,7 +35,7 @@ public struct G<Container : HasElt> {
 // CHECK: @_specialize(exported: false, kind: full, where T == S)
 // CHECK: public func getGenericContainer<T>(g: G<T>, e: T.Elt) -> T where T : HasElt, T.Elt : AnElt
 @_specialize(where T == S)
-public func getGenericContainer<T>(g: G<T>, e: T.Elt) -> T where T : HasElt, T.Elt : AnElt
+public func getGenericContainer<T>(g: G<T>, e: T.Elt) -> T where T.Elt : AnElt
 
 enum ArithmeticError : Error {
   case DivByZero
@@ -741,3 +741,103 @@ bb0(%0 : $*Self, %1 : $*Self, %2 : $@thick Self.Type):
 // CHECK-IRGEN-NOT: ret void
 // CHECK-IRGEN:   call {{.*}}elease
 // CHECK-IRGEN:   ret void
+
+////////////////////////////////////////////////////////////////////
+// Check that try_apply instructions are handled correctly by the
+// eager specializer.
+////////////////////////////////////////////////////////////////////
+
+protocol ThrowingP {
+  func action() throws -> Int64
+}
+
+extension Int64 : ThrowingP {
+  public func action() throws -> Int64
+}
+
+class ClassUsingThrowingP {
+  required init()
+  @_specialize(exported: false, kind: full, where T == Int64)
+  public static func f<T>(_: T) throws -> Self where T : ThrowingP
+  @_specialize(exported: false, kind: full, where T == Int64)
+  public static func g<T>(_ t: T) throws -> Int64 where T : ThrowingP
+  deinit
+}
+
+// Int64.action()
+sil @_T0s5Int64V34eager_specialize_throwing_functionE6actionAByKF : $@convention(method) (Int64) -> (Int64, @error Error)
+
+// protocol witness for ThrowingP.action() in conformance Int64
+sil @_T0s5Int64V34eager_specialize_throwing_function9ThrowingPA2cDP6actionAByKFTW : $@convention(witness_method) (@in_guaranteed Int64) -> (Int64, @error Error)
+
+sil @_T034eager_specialize_throwing_function19ClassUsingThrowingPCACycfc : $@convention(method) (@owned ClassUsingThrowingP) -> @owned ClassUsingThrowingP
+
+sil @_T034eager_specialize_throwing_function19ClassUsingThrowingPCfd : $@convention(method) (@guaranteed ClassUsingThrowingP) -> @owned Builtin.NativeObject
+
+// ClassUsingThrowingP.__allocating_init()
+sil @_T034eager_specialize_throwing_function19ClassUsingThrowingPCACycfC : $@convention(method) (@thick ClassUsingThrowingP.Type) -> @owned ClassUsingThrowingP 
+
+// ClassUsingThrowingP.__deallocating_deinit
+sil @_T034eager_specialize_throwing_function19ClassUsingThrowingPCfD : $@convention(method) (@owned ClassUsingThrowingP) -> () 
+
+// f is a function that may throw according to its type, but does not actually do it.
+// Check that this function is properly specialized by the eager specializer.
+// It should dispatch to its specialized version, but use apply [nothrow] to invoke
+// the specialized version.
+
+// CHECK-LABEL: sil @_T034eager_specialize_throwing_function19ClassUsingThrowingPC1fACXDxKAA0G1PRzlFZ : $@convention(method) <T where T : ThrowingP> (@in T, @thick ClassUsingThrowingP.Type) -> (@owned ClassUsingThrowingP, @error Error)
+// CHECK: [[SPECIALIZED:%.*]] = function_ref @_T034eager_specialize_throwing_function19ClassUsingThrowingPC1fACXDxKAA0G1PRzlFZs5Int64V_Tg5 : $@convention(method) (Int64, @thick ClassUsingThrowingP.Type) -> (@owned ClassUsingThrowingP, @error Error)
+// CHECK: apply [nothrow] [[SPECIALIZED]]
+// CHECK: // end sil function '_T034eager_specialize_throwing_function19ClassUsingThrowingPC1fACXDxKAA0G1PRzlFZ'
+// static ClassUsingThrowingP.f<A>(_:)
+sil [_specialize exported: false, kind: full, where T == Int64] @_T034eager_specialize_throwing_function19ClassUsingThrowingPC1fACXDxKAA0G1PRzlFZ : $@convention(method) <T where T : ThrowingP> (@in T, @thick ClassUsingThrowingP.Type) -> (@owned ClassUsingThrowingP, @error Error) {
+bb0(%0 : $*T, %1 : $@thick ClassUsingThrowingP.Type):
+  destroy_addr %0 : $*T
+  %4 = unchecked_trivial_bit_cast %1 : $@thick ClassUsingThrowingP.Type to $@thick @dynamic_self ClassUsingThrowingP.Type
+  // function_ref ClassUsingThrowingP.__allocating_init()
+  %7 = function_ref @_T034eager_specialize_throwing_function19ClassUsingThrowingPCACycfC : $@convention(method) (@thick ClassUsingThrowingP.Type) -> @owned ClassUsingThrowingP
+  %8 = upcast %4 : $@thick @dynamic_self ClassUsingThrowingP.Type to $@thick ClassUsingThrowingP.Type
+  %9 = apply %7(%8) : $@convention(method) (@thick ClassUsingThrowingP.Type) -> @owned ClassUsingThrowingP
+  %10 = unchecked_ref_cast %9 : $ClassUsingThrowingP to $ClassUsingThrowingP
+  return %10 : $ClassUsingThrowingP
+} // end sil function '_T034eager_specialize_throwing_function19ClassUsingThrowingPC1fACXDxKAA0G1PRzlFZ'
+
+// g is a function that may throw according to its type and has a try_apply inisde
+// its body.
+// Check that this function is properly specialized by the eager specializer.
+// It should dispatch to its specialized version and use try_apply to invoke
+// the specialized version.
+
+// CHECK-LABEL: sil @_T034eager_specialize_throwing_function19ClassUsingThrowingPC1gs5Int64VxKAA0G1PRzlFZ : $@convention(method) <T where T : ThrowingP> (@in T, @thick ClassUsingThrowingP.Type) -> (Int64, @error Error)
+// CHECK: [[SPECIALIZED:%.*]] = function_ref @_T034eager_specialize_throwing_function19ClassUsingThrowingPC1gs5Int64VxKAA0G1PRzlFZAF_Tg5 : $@convention(method) (Int64, @thick ClassUsingThrowingP.Type) -> (Int64, @error Error)
+// CHECK: try_apply [[SPECIALIZED]]
+// CHECK: // end sil function '_T034eager_specialize_throwing_function19ClassUsingThrowingPC1gs5Int64VxKAA0G1PRzlFZ'
+
+// static ClassUsingThrowingP.g<A>(_:)
+sil [_specialize exported: false, kind: full, where T == Int64] @_T034eager_specialize_throwing_function19ClassUsingThrowingPC1gs5Int64VxKAA0G1PRzlFZ : $@convention(method) <T where T : ThrowingP> (@in T, @thick ClassUsingThrowingP.Type) -> (Int64, @error Error) {
+bb0(%0 : $*T, %1 : $@thick ClassUsingThrowingP.Type):
+  %5 = witness_method $T, #ThrowingP.action!1 : <Self where Self : ThrowingP> (Self) -> () throws -> Int64 : $@convention(witness_method) <τ_0_0 where τ_0_0 : ThrowingP> (@in_guaranteed τ_0_0) -> (Int64, @error Error)
+  try_apply %5<T>(%0) : $@convention(witness_method) <τ_0_0 where τ_0_0 : ThrowingP> (@in_guaranteed τ_0_0) -> (Int64, @error Error), normal bb1, error bb2
+
+bb1(%7 : $Int64):                                 // Preds: bb0
+  destroy_addr %0 : $*T
+  return %7 : $Int64
+
+bb2(%10 : $Error):                                // Preds: bb0
+  destroy_addr %0 : $*T
+  throw %10 : $Error
+} // end sil function '_T034eager_specialize_throwing_function19ClassUsingThrowingPC1gs5Int64VxKAA0G1PRzlFZ'
+
+sil_vtable ClassUsingThrowingP {
+  #ClassUsingThrowingP.init!allocator.1: (ClassUsingThrowingP.Type) -> () -> ClassUsingThrowingP : _T034eager_specialize_throwing_function19ClassUsingThrowingPCACycfC	// ClassUsingThrowingP.__allocating_init()
+  #ClassUsingThrowingP.init!initializer.1: (ClassUsingThrowingP.Type) -> () -> ClassUsingThrowingP : _T034eager_specialize_throwing_function19ClassUsingThrowingPCACycfc	// ClassUsingThrowingP.init()
+  #ClassUsingThrowingP.deinit!deallocator: _T034eager_specialize_throwing_function19ClassUsingThrowingPCfD	// ClassUsingThrowingP.__deallocating_deinit
+}
+
+sil_witness_table hidden Int64: ThrowingP module eager_specialize_throwing_function {
+  method #ThrowingP.action!1: <Self where Self : ThrowingP> (Self) -> () throws -> Int64 : @_T0s5Int64V34eager_specialize_throwing_function9ThrowingPA2cDP6actionAByKFTW	// protocol witness for ThrowingP.action() in conformance Int64
+}
+
+sil_default_witness_table hidden ThrowingP {
+  no_default
+}


### PR DESCRIPTION
Properly handle the case when a function being specialized may throw according to its type, but does not actually do it in its body.

Fixes rdar://problem/31694581

