### PR TITLE
swift-api-digester: avoid reporting moved constructors. rdar://31694119

### DIFF
--- a/test/api-digester/Inputs/cake1.swift
+++ b/test/api-digester/Inputs/cake1.swift
@@ -14,3 +14,7 @@ public class C1 {
   public var CIIns2 : C1?
   public func foo3(a : Void?) {}
 }
+
+public struct Somestruct2 {
+  public static func foo1() {}
+}

--- a/test/api-digester/Inputs/cake2.swift
+++ b/test/api-digester/Inputs/cake2.swift
@@ -14,3 +14,7 @@ public class C1 {
   public weak var CIIns2 : C1?
   public func foo3(a : ()?) {}
 }
+
+public struct NSSomestruct2 {
+  public static func foo1() {}
+}

--- a/test/api-digester/Outputs/Cake.txt
+++ b/test/api-digester/Outputs/Cake.txt
@@ -4,10 +4,12 @@
 /* Moved Decls */
 
 /* Renamed Decls */
+Struct Somestruct2 has been renamed to Struct NSSomestruct2
 Func S1.foo5(x:y:) has been renamed to Func S1.foo5(x:y:z:)
 
 /* Type Changes */
 Constructor S1.init(_:) has parameter 0 type change from Int to Double
+Constructor Somestruct2.init() has return type change from Somestruct2 to NSSomestruct2
 Func C1.foo2(_:) has parameter 0 type change from Int to () -> ()
 
 /* Decl Attribute changes */

--- a/tools/swift-api-digester/swift-api-digester.cpp
+++ b/tools/swift-api-digester/swift-api-digester.cpp
@@ -2756,10 +2756,11 @@ void DiagnosisEmitter::handle(const SDKNodeDecl *Node, NodeAnnotation Anno) {
   switch(Anno) {
   case NodeAnnotation::Removed: {
     if (auto *Added = findAddedDecl(Node)) {
-      MovedDecls.Diags.emplace_back(Node->getDeclKind(),
-                                    Added->getDeclKind(),
-                                    Node->getFullyQualifiedName(),
-                                    Added->getFullyQualifiedName());
+      if (Node->getDeclKind() != DeclKind::Constructor)
+        MovedDecls.Diags.emplace_back(Node->getDeclKind(),
+                                      Added->getDeclKind(),
+                                      Node->getFullyQualifiedName(),
+                                      Added->getFullyQualifiedName());
     } else {
       RemovedDecls.Diags.emplace_back(Node->getDeclKind(),
                                       Node->getFullyQualifiedName(),


### PR DESCRIPTION
They don't make more sense than renamed decls.