### PR TITLE
[Frontend] -frontend -emit-loaded-module-trace.

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -106,6 +106,8 @@ ERROR(error_mode_cannot_emit_dependencies,none,
   "this mode does not support emitting dependency files", ())
 ERROR(error_mode_cannot_emit_header,none,
   "this mode does not support emitting Objective-C headers", ())
+ERROR(error_mode_cannot_emit_loaded_module_trace,none,
+  "this mode does not support emitting the loaded module trace", ())
 ERROR(error_mode_cannot_emit_module,none,
   "this mode does not support emitting modules", ())
 ERROR(error_mode_cannot_emit_module_doc,none,

--- a/include/swift/Basic/JSONSerialization.h
+++ b/include/swift/Basic/JSONSerialization.h
@@ -445,6 +445,16 @@ private:
   void indent();
 };
 
+template <typename T> struct ArrayTraits<std::vector<T>> {
+  static size_t size(Output &out, std::vector<T> &seq) { return seq.size(); }
+
+  static T &element(Output &out, std::vector<T> &seq, size_t index) {
+    if (index >= seq.size())
+      seq.resize(index + 1);
+    return seq[index];
+  }
+};
+
 template<>
 struct ScalarTraits<bool> {
   static void output(const bool &, llvm::raw_ostream &);

--- a/include/swift/Driver/Compilation.h
+++ b/include/swift/Driver/Compilation.h
@@ -146,6 +146,10 @@ private:
   /// detail than ShowIncrementalBuildDecisions.
   bool ShowJobLifecycle = false;
 
+  /// When true, some frontend job has requested permission to pass
+  /// -emit-loaded-module-trace, so no other job needs to do it.
+  bool PassedEmitLoadedModuleTraceToFrontendJob = false;
+
   static const Job *unwrap(const std::unique_ptr<const Job> &p) {
     return p.get();
   }
@@ -231,6 +235,22 @@ public:
   /// \returns result code for the Compilation's Jobs; 0 indicates success and
   /// -2 indicates that one of the Compilation's Jobs crashed during execution
   int performJobs();
+
+  /// Returns whether the callee is permitted to pass -emit-loaded-module-trace
+  /// to a frontend job.
+  ///
+  /// This only returns true once, because only one job should pass that
+  /// argument.
+  bool requestPermissionForFrontendToEmitLoadedModuleTrace() {
+    if (PassedEmitLoadedModuleTraceToFrontendJob)
+      // Someone else has already done it!
+      return false;
+    else {
+      // We're the first and only (to execute this path).
+      PassedEmitLoadedModuleTraceToFrontendJob = true;
+      return true;
+    }
+  }
 
 private:
   /// \brief Perform all jobs.

--- a/include/swift/Driver/Types.def
+++ b/include/swift/Driver/Types.def
@@ -59,6 +59,7 @@ TYPE("swift-dependencies", SwiftDeps,       "swiftdeps",       "")
 TYPE("remap",           Remapping,          "remap",           "")
 TYPE("imported-modules", ImportedModules,   "importedmodules", "")
 TYPE("tbd",             TBD,                "tbd",             "")
+TYPE("module-trace",    ModuleTrace,        "trace.json",      "")
 
 // Misc types
 TYPE("pcm",             ClangModuleFile,    "pcm",             "")

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -116,6 +116,9 @@ public:
   /// The path to which we should output fixits as source edits.
   std::string FixitsOutputPath;
 
+  /// The path to which we should output a loaded module trace file.
+  std::string LoadedModuleTracePath;
+
   /// Arguments which should be passed in immediate mode.
   std::vector<std::string> ImmediateArgv;
 

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -199,6 +199,16 @@ def emit_dependencies : Flag<["-"], "emit-dependencies">,
   Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>,
   HelpText<"Emit basic Make-compatible dependencies files">;
 
+def emit_loaded_module_trace : Flag<["-"], "emit-loaded-module-trace">,
+  Flags<[FrontendOption, NoInteractiveOption]>,
+  HelpText<"Emit a JSON file containing information about what modules were loaded">;
+def emit_loaded_module_trace_path : Separate<["-"], "emit-loaded-module-trace-path">,
+  Flags<[FrontendOption, NoInteractiveOption]>,
+  HelpText<"Emit the loaded module trace JSON to <path>">,
+  MetaVarName<"<path>">;
+def emit_loaded_module_trace_path_EQ : Joined<["-"], "emit-loaded-module-trace-path=">,
+  Flags<[FrontendOption, NoInteractiveOption]>, Alias<emit_loaded_module_trace_path>;
+
 def serialize_diagnostics : Flag<["-"], "serialize-diagnostics">,
   Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>,
   HelpText<"Serialize diagnostics in a binary format">;

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -1421,6 +1421,7 @@ void Driver::buildActions(const ToolChain &TC,
       case types::TY_PCH:
       case types::TY_ImportedModules:
       case types::TY_TBD:
+      case types::TY_ModuleTrace:
         // We could in theory handle assembly or LLVM input, but let's not.
         // FIXME: What about LTO?
         Diags.diagnose(SourceLoc(), diag::error_unexpected_input_file,
@@ -2071,6 +2072,10 @@ Job *Driver::buildJobsForAction(Compilation &C, const JobAction *JA,
     // Choose the dependencies file output path.
     if (C.getArgs().hasArg(options::OPT_emit_dependencies)) {
       addAuxiliaryOutput(C, *Output, types::TY_Dependencies, OI, OutputMap);
+    }
+    if (C.getArgs().hasArg(options::OPT_emit_loaded_module_trace,
+                           options::OPT_emit_loaded_module_trace_path)) {
+      addAuxiliaryOutput(C, *Output, types::TY_ModuleTrace, OI, OutputMap);
     }
     if (C.getIncrementalBuildEnabled()) {
       addAuxiliaryOutput(C, *Output, types::TY_SwiftDeps, OI, OutputMap);

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -1686,6 +1686,36 @@ void Driver::buildJobs(const ActionList &Actions, const OutputInfo &OI,
   }
 }
 
+static Optional<StringRef> getOutputFilenameFromPathArgOrAsTopLevel(
+    const OutputInfo &OI, const llvm::opt::DerivedArgList &Args,
+    llvm::opt::OptSpecifier PathArg, types::ID ExpectedOutputType,
+    bool TreatAsTopLevelOutput, StringRef ext, llvm::SmallString<128> &Buffer) {
+  if (const Arg *A = Args.getLastArg(PathArg))
+    return StringRef(A->getValue());
+
+  if (TreatAsTopLevelOutput) {
+    if (const Arg *A = Args.getLastArg(options::OPT_o)) {
+      if (OI.CompilerOutputType == ExpectedOutputType)
+        return StringRef(A->getValue());
+
+      // Otherwise, put the file next to the top-level output.
+      Buffer = A->getValue();
+      llvm::sys::path::remove_filename(Buffer);
+      llvm::sys::path::append(Buffer, OI.ModuleName);
+      llvm::sys::path::replace_extension(Buffer, ext);
+      return Buffer.str();
+    }
+
+    // A top-level output wasn't specified, so just output to
+    // <ModuleName>.<ext>.
+    Buffer = OI.ModuleName;
+    llvm::sys::path::replace_extension(Buffer, ext);
+    return Buffer.str();
+  }
+
+  return None;
+}
+
 static StringRef getOutputFilename(Compilation &C,
                                    const JobAction *JA,
                                    const OutputInfo &OI,
@@ -1708,29 +1738,14 @@ static StringRef getOutputFilename(Compilation &C,
 
   // Process Action-specific output-specifying options next,
   // since we didn't find anything applicable in the OutputMap.
+
   if (isa<MergeModuleJobAction>(JA)) {
-    if (const Arg *A = Args.getLastArg(options::OPT_emit_module_path))
-      return A->getValue();
-
-    if (OI.ShouldTreatModuleAsTopLevelOutput) {
-      if (const Arg *A = Args.getLastArg(options::OPT_o)) {
-        if (OI.CompilerOutputType == types::TY_SwiftModuleFile)
-          return A->getValue();
-
-        // Otherwise, put the module next to the top-level output.
-        Buffer = A->getValue();
-        llvm::sys::path::remove_filename(Buffer);
-        llvm::sys::path::append(Buffer, OI.ModuleName);
-        llvm::sys::path::replace_extension(Buffer, SERIALIZED_MODULE_EXTENSION);
-        return Buffer.str();
-      }
-
-      // A top-level output wasn't specified, so just output to
-      // <ModuleName>.swiftmodule.
-      Buffer = OI.ModuleName;
-      llvm::sys::path::replace_extension(Buffer, SERIALIZED_MODULE_EXTENSION);
-      return Buffer.str();
-    }
+    auto optFilename = getOutputFilenameFromPathArgOrAsTopLevel(
+        OI, Args, options::OPT_emit_module_path, types::TY_SwiftModuleFile,
+        OI.ShouldTreatModuleAsTopLevelOutput, SERIALIZED_MODULE_EXTENSION,
+        Buffer);
+    if (optFilename)
+      return *optFilename;
   }
 
   // dSYM actions are never treated as top-level.
@@ -2073,12 +2088,24 @@ Job *Driver::buildJobsForAction(Compilation &C, const JobAction *JA,
     if (C.getArgs().hasArg(options::OPT_emit_dependencies)) {
       addAuxiliaryOutput(C, *Output, types::TY_Dependencies, OI, OutputMap);
     }
-    if (C.getArgs().hasArg(options::OPT_emit_loaded_module_trace,
-                           options::OPT_emit_loaded_module_trace_path)) {
-      addAuxiliaryOutput(C, *Output, types::TY_ModuleTrace, OI, OutputMap);
-    }
     if (C.getIncrementalBuildEnabled()) {
       addAuxiliaryOutput(C, *Output, types::TY_SwiftDeps, OI, OutputMap);
+    }
+
+    // The loaded-module-trace is the same for all compile jobs: all `import`
+    // statements are processed, even ones from non-primary files. Thus, only
+    // one of those jobs needs to emit the file, and we can get it to write
+    // straight to the desired final location.
+    if (C.getArgs().hasArg(options::OPT_emit_loaded_module_trace,
+                           options::OPT_emit_loaded_module_trace_path) &&
+        C.requestPermissionForFrontendToEmitLoadedModuleTrace()) {
+      // By treating this as a top-level output, the return value always exists.
+      auto filename = getOutputFilenameFromPathArgOrAsTopLevel(
+          OI, C.getArgs(), options::OPT_emit_loaded_module_trace_path,
+          types::TY_ModuleTrace,
+          /*TreatAsTopLevelOutput=*/true, "trace.json", Buf);
+
+      Output->setAdditionalOutputForType(types::TY_ModuleTrace, *filename);
     }
   }
 

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -249,6 +249,7 @@ ToolChain::constructInvocation(const CompileJobAction &job,
     case types::TY_ObjCHeader:
     case types::TY_Image:
     case types::TY_SwiftDeps:
+    case types::TY_ModuleTrace:
       llvm_unreachable("Output type can never be primary output.");
     case types::TY_INVALID:
       llvm_unreachable("Invalid type ID");
@@ -381,6 +382,13 @@ ToolChain::constructInvocation(const CompileJobAction &job,
     Arguments.push_back(ReferenceDependenciesPath.c_str());
   }
 
+  const std::string &LoadedModuleTracePath =
+      context.Output.getAdditionalOutputForType(types::TY_ModuleTrace);
+  if (!LoadedModuleTracePath.empty()) {
+    Arguments.push_back("-emit-loaded-module-trace-path");
+    Arguments.push_back(LoadedModuleTracePath.c_str());
+  }
+
   const std::string &FixitsPath =
     context.Output.getAdditionalOutputForType(types::TY_Remapping);
   if (!FixitsPath.empty()) {
@@ -511,6 +519,7 @@ ToolChain::constructInvocation(const BackendJobAction &job,
     case types::TY_Image:
     case types::TY_SwiftDeps:
     case types::TY_Remapping:
+    case types::TY_ModuleTrace:
       llvm_unreachable("Output type can never be primary output.");
     case types::TY_INVALID:
       llvm_unreachable("Invalid type ID");

--- a/lib/Driver/Types.cpp
+++ b/lib/Driver/Types.cpp
@@ -76,6 +76,7 @@ bool types::isTextual(ID Id) {
   case types::TY_AutolinkFile:
   case types::TY_ImportedModules:
   case types::TY_TBD:
+  case types::TY_ModuleTrace:
     return true;
   case types::TY_Image:
   case types::TY_Object:
@@ -127,6 +128,7 @@ bool types::isAfterLLVM(ID Id) {
   case types::TY_SwiftDeps:
   case types::TY_Nothing:
   case types::TY_Remapping:
+  case types::TY_ModuleTrace:
     return false;
   case types::TY_INVALID:
     llvm_unreachable("Invalid type ID.");
@@ -163,6 +165,7 @@ bool types::isPartOfSwiftCompilation(ID Id) {
   case types::TY_SwiftDeps:
   case types::TY_Nothing:
   case types::TY_Remapping:
+  case types::TY_ModuleTrace:
     return false;
   case types::TY_INVALID:
     llvm_unreachable("Invalid type ID.");

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -676,6 +676,10 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
                           OPT_emit_objc_header,
                           OPT_emit_objc_header_path,
                           "h", false);
+  determineOutputFilename(Opts.LoadedModuleTracePath,
+                          OPT_emit_loaded_module_trace,
+                          OPT_emit_loaded_module_trace_path,
+                          "trace.json", false);
 
   if (const Arg *A = Args.getLastArg(OPT_emit_fixits_path)) {
     Opts.FixitsOutputPath = A->getValue();
@@ -751,6 +755,39 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
     case FrontendOptions::Parse:
     case FrontendOptions::Typecheck:
     case FrontendOptions::EmitModuleOnly:
+    case FrontendOptions::EmitSILGen:
+    case FrontendOptions::EmitSIL:
+    case FrontendOptions::EmitSIBGen:
+    case FrontendOptions::EmitSIB:
+    case FrontendOptions::EmitIR:
+    case FrontendOptions::EmitBC:
+    case FrontendOptions::EmitAssembly:
+    case FrontendOptions::EmitObject:
+    case FrontendOptions::EmitImportedModules:
+    case FrontendOptions::EmitTBD:
+      break;
+    }
+  }
+
+  if (!Opts.LoadedModuleTracePath.empty()) {
+    switch (Opts.RequestedAction) {
+    case FrontendOptions::NoneAction:
+    case FrontendOptions::Parse:
+    case FrontendOptions::DumpParse:
+    case FrontendOptions::DumpInterfaceHash:
+    case FrontendOptions::DumpAST:
+    case FrontendOptions::PrintAST:
+    case FrontendOptions::DumpScopeMaps:
+    case FrontendOptions::DumpTypeRefinementContexts:
+    case FrontendOptions::Immediate:
+    case FrontendOptions::REPL:
+    case FrontendOptions::UpdateCode:
+      Diags.diagnose(SourceLoc(),
+                     diag::error_mode_cannot_emit_loaded_module_trace);
+      return true;
+    case FrontendOptions::Typecheck:
+    case FrontendOptions::EmitModuleOnly:
+    case FrontendOptions::EmitPCH:
     case FrontendOptions::EmitSILGen:
     case FrontendOptions::EmitSIL:
     case FrontendOptions::EmitSIBGen:

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -25,6 +25,7 @@
 #include "ReferenceDependencies.h"
 #include "TBD.h"
 
+#include "swift/Strings.h"
 #include "swift/Subsystems.h"
 #include "swift/AST/ASTScope.h"
 #include "swift/AST/DiagnosticsFrontend.h"
@@ -36,10 +37,12 @@
 #include "swift/Basic/Dwarf.h"
 #include "swift/Basic/Edit.h"
 #include "swift/Basic/FileSystem.h"
+#include "swift/Basic/JSONSerialization.h"
 #include "swift/Basic/LLVMContext.h"
 #include "swift/Basic/SourceManager.h"
 #include "swift/Basic/Statistic.h"
 #include "swift/Basic/Timer.h"
+#include "swift/Basic/UUID.h"
 #include "swift/Frontend/DiagnosticVerifier.h"
 #include "swift/Frontend/Frontend.h"
 #include "swift/Frontend/PrintingDiagnosticConsumer.h"
@@ -54,6 +57,7 @@
 // FIXME: We're just using CompilerInstance::createOutputFile.
 // This API should be sunk down to LLVM.
 #include "clang/Frontend/CompilerInstance.h"
+#include "clang/APINotes/Types.h"
 
 #include "llvm/ADT/Statistic.h"
 #include "llvm/IR/LLVMContext.h"
@@ -70,6 +74,12 @@
 
 #include <memory>
 #include <unordered_set>
+
+#if !defined(_MSC_VER) && !defined(__MINGW32__)
+#include <unistd.h>
+#else
+#include <io.h>
+#endif
 
 using namespace swift;
 
@@ -130,6 +140,78 @@ static bool emitMakeDependencies(DiagnosticEngine &diags,
   });
 
   return false;
+}
+
+namespace {
+struct LoadedModuleTraceFormat {
+  std::string Name;
+  std::string Arch;
+  std::vector<std::string> SwiftModules;
+};
+}
+
+namespace swift {
+namespace json {
+template <> struct ObjectTraits<LoadedModuleTraceFormat> {
+  static void mapping(Output &out, LoadedModuleTraceFormat &contents) {
+    out.mapRequired("name", contents.Name);
+    out.mapRequired("arch", contents.Arch);
+    out.mapRequired("swiftmodules", contents.SwiftModules);
+  }
+};
+}
+}
+
+static bool emitLoadedModuleTrace(ASTContext &ctxt,
+                                  DependencyTracker &depTracker,
+                                  const FrontendOptions &opts) {
+  std::error_code EC;
+  llvm::raw_fd_ostream out(opts.LoadedModuleTracePath, EC,
+                           llvm::sys::fs::F_None);
+
+  if (out.has_error() || EC) {
+    ctxt.Diags.diagnose(SourceLoc(), diag::error_opening_output,
+                        opts.LoadedModuleTracePath, EC.message());
+    out.clear_error();
+    return true;
+  }
+
+  llvm::SmallVector<std::string, 16> swiftModules;
+
+  // Canonicalise all the paths by opening them.
+  for (auto &dep : depTracker.getDependencies()) {
+    llvm::SmallString<256> buffer;
+    StringRef realPath;
+    int FD;
+    // FIXME: appropriate error handling
+    if (llvm::sys::fs::openFileForRead(dep, FD, &buffer)) {
+      // Couldn't open the file now, so let's just assume the old path was
+      // canonical (enough).
+      realPath = dep;
+    } else {
+      realPath = buffer.str();
+      // Not much we can do about failing to close.
+      (void)close(FD);
+    }
+
+    // Decide if this is a swiftmodule based on the extension of the raw
+    // dependency path, as the true file may have a different one.
+    auto ext = llvm::sys::path::extension(dep);
+    if (ext.startswith(".") &&
+        ext.drop_front() == SERIALIZED_MODULE_EXTENSION) {
+      swiftModules.push_back(realPath);
+    }
+  }
+
+  LoadedModuleTraceFormat trace = {
+      /*name=*/opts.ModuleName,
+      /*arch=*/ctxt.LangOpts.Target.getArchName(),
+      /*swiftmodules=*/reversePathSortedFilenames(swiftModules)};
+
+  json::Output jsonOutput(out, /*PrettyPrint=*/false);
+  json::jsonize(jsonOutput, trace, /*Required=*/true);
+
+  return true;
 }
 
 /// Writes SIL out to the given file.
@@ -538,6 +620,10 @@ static bool performCompile(std::unique_ptr<CompilerInstance> &Instance,
   if (shouldTrackReferences)
     emitReferenceDependencies(Context.Diags, Instance->getPrimarySourceFile(),
                               *Instance->getDependencyTracker(), opts);
+
+  if (!opts.LoadedModuleTracePath.empty())
+    (void)emitLoadedModuleTrace(Context, *Instance->getDependencyTracker(),
+                                opts);
 
   if (Context.hadError())
     return true;
@@ -1081,7 +1167,8 @@ int swift::performFrontend(ArrayRef<const char *> Args,
 
   DependencyTracker depTracker;
   if (!Invocation.getFrontendOptions().DependenciesFilePath.empty() ||
-      !Invocation.getFrontendOptions().ReferenceDependenciesFilePath.empty()) {
+      !Invocation.getFrontendOptions().ReferenceDependenciesFilePath.empty() ||
+      !Invocation.getFrontendOptions().LoadedModuleTracePath.empty()) {
     Instance->setDependencyTracker(&depTracker);
   }
 

--- a/test/Driver/Inputs/loaded_module_trace_empty.swift
+++ b/test/Driver/Inputs/loaded_module_trace_empty.swift
@@ -1,0 +1,1 @@
+// Don't need anything here, just for the module to exist.

--- a/test/Driver/Inputs/loaded_module_trace_header.h
+++ b/test/Driver/Inputs/loaded_module_trace_header.h
@@ -1,0 +1,1 @@
+#include "loaded_module_trace_header2.h"

--- a/test/Driver/Inputs/loaded_module_trace_header2.h
+++ b/test/Driver/Inputs/loaded_module_trace_header2.h
@@ -1,0 +1,1 @@
+@import Foundation;

--- a/test/Driver/Inputs/loaded_module_trace_imports_module.swift
+++ b/test/Driver/Inputs/loaded_module_trace_imports_module.swift
@@ -1,0 +1,1 @@
+import Module

--- a/test/Driver/loaded_module_trace.swift
+++ b/test/Driver/loaded_module_trace.swift
@@ -1,0 +1,15 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: %target-build-swift -emit-module -module-name Module %S/Inputs/loaded_module_trace_empty.swift -o %t/Module.swiftmodule
+// RUN: %target-swift-frontend -c %s -emit-loaded-module-trace -emit-loaded-module-trace-path - -I %t | %FileCheck %s
+
+// CHECK: {
+// CHECK: "name":"loaded_module_trace"
+// CHECK: "arch":"{{[^"]*}}"
+// CHECK: "swiftmodules":[
+// CHECK: "{{[^"]*}}/Module.swiftmodule"
+// CHECK: "{{[^"]*}}/Swift.swiftmodule"
+// CHECK: "{{[^"]*}}/SwiftOnoneSupport.swiftmodule"
+// CHECK: ]
+// CHECK: }
+
+import Module

--- a/test/Driver/loaded_module_trace.swift
+++ b/test/Driver/loaded_module_trace.swift
@@ -1,16 +1,22 @@
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: %target-build-swift -emit-module -module-name Module %S/Inputs/loaded_module_trace_empty.swift -o %t/Module.swiftmodule
+// RUN: %target-build-swift -emit-module -module-name Module2 %S/Inputs/loaded_module_trace_imports_module.swift -o %t/Module2.swiftmodule -I %t
 // RUN: %target-build-swift %s -emit-loaded-module-trace -o %t/loaded_module_trace -I %t
-// RUN: %FileCheck %s < %t/loaded_module_trace.trace.json
+// RUN: %FileCheck -check-prefix=CHECK %s < %t/loaded_module_trace.trace.json
+// RUN: %FileCheck -check-prefix=CHECK-CONFIRM-ONELINE %s < %t/loaded_module_trace.trace.json
 
 // CHECK: {
 // CHECK: "name":"loaded_module_trace"
 // CHECK: "arch":"{{[^"]*}}"
 // CHECK: "swiftmodules":[
-// CHECK: "{{[^"]*}}/Module.swiftmodule"
+// CHECK: "{{[^"]*}}/Module2.swiftmodule"
 // CHECK: "{{[^"]*}}/Swift.swiftmodule"
 // CHECK: "{{[^"]*}}/SwiftOnoneSupport.swiftmodule"
 // CHECK: ]
 // CHECK: }
 
-import Module
+// Make sure it's all on a single line.
+// CHECK-CONFIRM-ONELINE: {"name":{{.*}}]}
+
+// 'Module2' imports 'Module', so we're also checking we don't get transitive dependencies.
+import Module2

--- a/test/Driver/loaded_module_trace.swift
+++ b/test/Driver/loaded_module_trace.swift
@@ -1,6 +1,7 @@
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: %target-build-swift -emit-module -module-name Module %S/Inputs/loaded_module_trace_empty.swift -o %t/Module.swiftmodule
-// RUN: %target-swift-frontend -c %s -emit-loaded-module-trace -emit-loaded-module-trace-path - -I %t | %FileCheck %s
+// RUN: %target-build-swift %s -emit-loaded-module-trace -o %t/loaded_module_trace -I %t
+// RUN: %FileCheck %s < %t/loaded_module_trace.trace.json
 
 // CHECK: {
 // CHECK: "name":"loaded_module_trace"

--- a/test/Driver/loaded_module_trace_append.swift
+++ b/test/Driver/loaded_module_trace_append.swift
@@ -1,0 +1,6 @@
+// RUN: env SWIFT_LOADED_MODULE_TRACE_PATH=%t %target-build-swift -module-name loaded_module_trace_append %s -o- > /dev/null
+// RUN: env SWIFT_LOADED_MODULE_TRACE_PATH=%t %target-build-swift -module-name loaded_module_trace_append2 %s -o- > /dev/null
+// RUN: %FileCheck %s < %t
+
+// CHECK: {"name":"loaded_module_trace_append",{{.*}}]}
+// CHECK-NEXT: {"name":"loaded_module_trace_append2",{{.*}}]}

--- a/test/Driver/loaded_module_trace_env.swift
+++ b/test/Driver/loaded_module_trace_env.swift
@@ -1,0 +1,12 @@
+// RUN: env SWIFT_LOADED_MODULE_TRACE_PATH=%t %target-build-swift -module-name loaded_module_trace_env %s -o- > /dev/null
+// RUN: %FileCheck %s < %t
+
+// CHECK: {
+// CHECK: "name":"loaded_module_trace_env"
+// CHECK: "arch":"{{[^"]*}}"
+// CHECK: "swiftmodules":[
+// CHECK: "{{[^"]*}}/Swift.swiftmodule"
+// CHECK: "{{[^"]*}}/SwiftOnoneSupport.swiftmodule"
+// CHECK: ]
+// CHECK: "apinotes":[]
+// CHECK: }

--- a/test/Driver/loaded_module_trace_env.swift
+++ b/test/Driver/loaded_module_trace_env.swift
@@ -8,5 +8,4 @@
 // CHECK: "{{[^"]*}}/Swift.swiftmodule"
 // CHECK: "{{[^"]*}}/SwiftOnoneSupport.swiftmodule"
 // CHECK: ]
-// CHECK: "apinotes":[]
 // CHECK: }

--- a/test/Driver/loaded_module_trace_foundation.swift
+++ b/test/Driver/loaded_module_trace_foundation.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -c %s -emit-loaded-module-trace -emit-loaded-module-trace-path - | %FileCheck %s
+// RUN: %target-build-swift -o %t -module-name loaded_module_trace_foundation %s -emit-loaded-module-trace -emit-loaded-module-trace-path - 2>&1 | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/Driver/loaded_module_trace_foundation.swift
+++ b/test/Driver/loaded_module_trace_foundation.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-frontend -c %s -emit-loaded-module-trace -emit-loaded-module-trace-path - | %FileCheck %s
+
+// REQUIRES: objc_interop
+
+// CHECK: {
+// CHECK: "name":"loaded_module_trace_foundation"
+// CHECK: "arch":"{{[^"]*}}"
+// CHECK: "swiftmodules":[
+// CHECK: "{{[^"]*}}/ObjectiveC.swiftmodule"
+// CHECK: "{{[^"]*}}/Dispatch.swiftmodule"
+// CHECK: "{{[^"]*}}/Darwin.swiftmodule"
+// CHECK: "{{[^"]*}}/Foundation.swiftmodule"
+// CHECK: "{{[^"]*}}/Swift.swiftmodule"
+// CHECK: "{{[^"]*}}/IOKit.swiftmodule"
+// CHECK: "{{[^"]*}}/SwiftOnoneSupport.swiftmodule"
+// CHECK: ]
+// CHECK: }
+
+import Foundation

--- a/test/Driver/loaded_module_trace_header.swift
+++ b/test/Driver/loaded_module_trace_header.swift
@@ -1,0 +1,18 @@
+// RUN: env SWIFT_LOADED_MODULE_TRACE_PATH=%t %target-build-swift -module-name loaded_module_trace_header %s -o- -import-objc-header %S/Inputs/loaded_module_trace_header.h > /dev/null
+// RUN: %FileCheck %s < %t
+
+// REQUIRES: objc_interop
+
+// CHECK: {
+// CHECK: "name":"loaded_module_trace_header"
+// CHECK: "arch":"{{[^"]*}}"
+// CHECK: "swiftmodules":[
+// CHECK: "{{[^"]*}}/ObjectiveC.swiftmodule"
+// CHECK: "{{[^"]*}}/Dispatch.swiftmodule"
+// CHECK: "{{[^"]*}}/Darwin.swiftmodule"
+// CHECK: "{{[^"]*}}/Foundation.swiftmodule"
+// CHECK: "{{[^"]*}}/Swift.swiftmodule"
+// CHECK: "{{[^"]*}}/IOKit.swiftmodule"
+// CHECK: "{{[^"]*}}/SwiftOnoneSupport.swiftmodule"
+// CHECK: ]
+// CHECK: }

--- a/test/Driver/loaded_module_trace_multifile.swift
+++ b/test/Driver/loaded_module_trace_multifile.swift
@@ -1,0 +1,20 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: %target-build-swift -emit-module -module-name Module %S/Inputs/loaded_module_trace_empty.swift -o %t/Module.swiftmodule
+// RUN: %target-build-swift -emit-module -module-name Module2 %S/Inputs/loaded_module_trace_empty.swift -o %t/Module2.swiftmodule
+// RUN: %target-build-swift %s %S/Inputs/loaded_module_trace_imports_module.swift -emit-loaded-module-trace-path %t/multifile.trace.json -emit-library -o %t/loaded_module_trace_multifile -I %t
+// RUN: %FileCheck %s < %t/multifile.trace.json
+
+// This file only imports Module2, but the other file imports Module: hopefully they both appear!
+
+// CHECK: {
+// CHECK: "name":"loaded_module_trace_multifile"
+// CHECK: "arch":"{{[^"]*}}"
+// CHECK: "swiftmodules":[
+// CHECK: "{{[^"]*}}/Module2.swiftmodule"
+// CHECK: "{{[^"]*}}/Module.swiftmodule"
+// CHECK: "{{[^"]*}}/Swift.swiftmodule"
+// CHECK: "{{[^"]*}}/SwiftOnoneSupport.swiftmodule"
+// CHECK: ]
+// CHECK: }
+
+import Module2


### PR DESCRIPTION
The -frontend jobs can output a JSON file summarizing the
swiftmodules (etc.) they load during compilation.
