### PR TITLE
[Stdlib] For Collections, the SubSequence of a Subsequence is SubSequence

### DIFF
--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -4211,6 +4211,15 @@ static void computeDerivedSameTypeComponents(
     assert(componentOf.count(concrete.archetype) > 0);
     auto &component = components[componentOf[concrete.archetype]];
 
+    // FIXME: Skip self-derived sources. This means our attempts to "stage"
+    // construction of self-derived sources really don't work, because we
+    // discover more information later, so we need a more on-line or
+    // iterative approach.
+    bool derivedViaConcrete;
+    if (concrete.source->isSelfDerivedSource(concrete.archetype,
+                                             derivedViaConcrete))
+      continue;
+
     // If it has a better source than we'd seen before for this component,
     // keep it.
     auto &bestConcreteTypeSource = component.concreteTypeSource;

--- a/stdlib/private/StdlibCollectionUnittest/CheckCollectionType.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/CheckCollectionType.swift.gyb
@@ -480,7 +480,6 @@ internal enum _SubSequenceSubscriptOnRangeMode {
     CollectionWithEquatableElement : %(protocol)s,
     %(subseq_as_collection)s
     C.SubSequence : %(protocol)s,
-    C.SubSequence.SubSequence == C.SubSequence,
     C.Indices : %(protocol)s,
     CollectionWithEquatableElement.Iterator.Element : Equatable
   ''' % locals()

--- a/stdlib/private/StdlibCollectionUnittest/CheckMutableCollectionType.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/CheckMutableCollectionType.swift.gyb
@@ -122,7 +122,6 @@ extension TestSuite {
     collectionIsBidirectional: Bool = false
   ) where
     C.SubSequence : MutableCollection,
-    C.SubSequence.SubSequence == C.SubSequence,
     C.Indices : Collection,
     CollectionWithEquatableElement.Iterator.Element : Equatable,
     CollectionWithComparableElement.Iterator.Element : Comparable {
@@ -785,7 +784,6 @@ self.test("\(testNamePrefix).partition/InvalidOrderings") {
     isFixedLengthCollection: Bool
   ) where
     C.SubSequence : BidirectionalCollection & MutableCollection,
-    C.SubSequence.SubSequence == C.SubSequence,
     C.Indices : BidirectionalCollection,
     CollectionWithEquatableElement.Iterator.Element : Equatable,
     CollectionWithComparableElement.Iterator.Element : Comparable {
@@ -932,7 +930,6 @@ self.test("\(testNamePrefix).partition/DispatchesThrough_withUnsafeMutableBuffer
     isFixedLengthCollection: Bool
   ) where
     C.SubSequence : RandomAccessCollection & MutableCollection,
-    C.SubSequence.SubSequence == C.SubSequence,
     C.Indices : RandomAccessCollection,
     CollectionWithEquatableElement.Iterator.Element : Equatable,
     CollectionWithComparableElement.Iterator.Element : Comparable {

--- a/stdlib/private/StdlibCollectionUnittest/CheckRangeReplaceableCollectionType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckRangeReplaceableCollectionType.swift
@@ -463,7 +463,6 @@ extension TestSuite {
     collectionIsBidirectional: Bool = false
   ) where
     C.SubSequence : Collection,
-    C.SubSequence.SubSequence == C.SubSequence,
     C.Indices : Collection,
     CollectionWithEquatableElement.Iterator.Element : Equatable,
     CollectionWithEquatableElement.SubSequence : Collection {
@@ -1182,7 +1181,6 @@ self.test("\(testNamePrefix).OperatorPlus") {
     outOfBoundsIndexOffset: Int = 1
   ) where
     C.SubSequence : BidirectionalCollection & RangeReplaceableCollection,
-    C.SubSequence.SubSequence == C.SubSequence,
     C.Indices : BidirectionalCollection,
     CollectionWithEquatableElement.Iterator.Element : Equatable {
 
@@ -1305,7 +1303,6 @@ self.test("\(testNamePrefix).removeLast(n: Int)/whereIndexIsBidirectional/remove
     outOfBoundsIndexOffset: Int = 1
   ) where
     C.SubSequence : RandomAccessCollection & RangeReplaceableCollection,
-    C.SubSequence.SubSequence == C.SubSequence,
     C.Indices : RandomAccessCollection,
     CollectionWithEquatableElement.Iterator.Element : Equatable {
 

--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
@@ -367,7 +367,6 @@ public func expect${Mutable}CollectionType<X : ${Mutable}Collection>(
   X.SubSequence : Collection,
 %   end
   // X.SubSequence.Indices == X.Indices, // FIXME(ABI)#3 (Recursive Protocol Constraints): can't have this constraint now.
-  X.SubSequence.SubSequence == X.SubSequence,
   X.Indices : Collection {}
 % end
 
@@ -411,7 +410,6 @@ public func expectCollectionAssociatedTypes<X : Collection>(
   // the 'where' clause, all of these should be required by the protocol.
   X.SubSequence : Collection,
   // X.SubSequence.Indices == X.Indices, // FIXME(ABI)#7 (Recursive Protocol Constraints): can't have this constraint now.
-  X.SubSequence.SubSequence == X.SubSequence,
   X.Indices : Collection {}
 
 /// Check that all associated types of a `BidirectionalCollection` are what we
@@ -428,7 +426,6 @@ public func expectBidirectionalCollectionAssociatedTypes<X : BidirectionalCollec
   // the 'where' clause, all of these should be required by the protocol.
   X.SubSequence : BidirectionalCollection,
   // X.SubSequence.Indices == X.Indices, // FIXME(ABI)#9 (Recursive Protocol Constraints): can't have this constraint now.
-  X.SubSequence.SubSequence == X.SubSequence,
   X.Indices : BidirectionalCollection {}
 
 /// Check that all associated types of a `RandomAccessCollection` are what we
@@ -445,7 +442,6 @@ public func expectRandomAccessCollectionAssociatedTypes<X : RandomAccessCollecti
   // the 'where' clause, all of these should be required by the protocol.
   X.SubSequence : RandomAccessCollection,
   // X.SubSequence.Indices == X.Indices, // FIXME(ABI)#11 (Recursive Protocol Constraints): can't have this constraint now.
-  X.SubSequence.SubSequence == X.SubSequence,
   X.Indices : RandomAccessCollection {}
 
 public struct AssertionResult : CustomStringConvertible {

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -662,14 +662,13 @@ public protocol Collection : _Indexable, Sequence {
   /// collection, the subsequence should also conform to `Collection`.
   associatedtype SubSequence : _IndexableBase, Sequence = Slice<Self>
       where Self.SubSequence.Index == Index,
-            Self.Iterator.Element == Self.SubSequence.Iterator.Element
+            Self.Iterator.Element == Self.SubSequence.Iterator.Element,
+            SubSequence.SubSequence == SubSequence
   // FIXME(ABI)#98 (Recursive Protocol Constraints):
   // FIXME(ABI)#99 (Associated Types with where clauses):
   // associatedtype SubSequence : Collection
   //   where
-  //   ,
   //   SubSequence.Indices == Indices,
-  //   SubSequence.SubSequence == SubSequence
   //
   // (<rdar://problem/20715009> Implement recursive protocol
   // constraints)

--- a/stdlib/public/core/ExistentialCollection.swift.gyb
+++ b/stdlib/public/core/ExistentialCollection.swift.gyb
@@ -430,13 +430,11 @@ internal final class _${Kind}Box<S : ${Kind}> : _Any${Kind}Box<S.Iterator.Elemen
   S.SubSequence : ${Kind},
 %  if Kind == 'Sequence':
   S.SubSequence.Iterator.Element == S.Iterator.Element,
-%end
   S.SubSequence.SubSequence == S.SubSequence
-%   if Kind != 'Sequence':
-  ,
+%  else:
   S.SubSequence.Indices : ${Kind},
   S.Indices : ${Kind}
-%   end
+%  end
 {
   internal typealias Element = S.Iterator.Element
 
@@ -1045,7 +1043,6 @@ public struct ${Self}<Element>
     C.SubSequence : ${SubProtocol},
     C.SubSequence.Iterator.Element == Element,
     C.SubSequence.Indices : ${SubProtocol},
-    C.SubSequence.SubSequence == C.SubSequence,
     C.Indices : ${SubProtocol}
      {
     // Traversal: ${Traversal}

--- a/stdlib/public/core/LazyCollection.swift.gyb
+++ b/stdlib/public/core/LazyCollection.swift.gyb
@@ -163,8 +163,8 @@ extension ${Self} : ${TraversalCollection} {
   ///
   /// - Complexity: O(1)
   @_inlineable
-  public subscript(bounds: Range<Index>) -> ${Self}<${Slice}<Base>> {
-    return ${Slice}(base: _base, bounds: bounds).lazy
+  public subscript(bounds: Range<Index>) -> ${Slice}<${Self}<Base>> {
+    return ${Slice}(base: self, bounds: bounds)
   }
 
   /// A Boolean value indicating whether the collection is empty.

--- a/stdlib/public/core/Mirror.swift
+++ b/stdlib/public/core/Mirror.swift
@@ -220,7 +220,6 @@ public struct Mirror {
     // associated types of Collection.
     C.SubSequence : Collection,
     C.SubSequence.Indices : Collection,
-    C.SubSequence.SubSequence == C.SubSequence,
     C.Indices : Collection {
 
     self.subjectType = Subject.self
@@ -272,7 +271,6 @@ public struct Mirror {
     // FIXME(ABI)#48 (Associated Types with where clauses): these constraints should be applied to
     // associated types of Collection.
     C.SubSequence : Collection,
-    C.SubSequence.SubSequence == C.SubSequence,
     C.Indices : Collection {
 
     self.subjectType = Subject.self


### PR DESCRIPTION
Part of ABI FIXME #99, this gives us some nice consistency that
ensures that slicing a `SubSequence` gives us another `SubSequence`. There
are two source-compatibility implications to this change:

* Collections now need to satisfy this property, which could not be
  expressed in Swift 3. There might be some Collections that don't
  satisfy this property, and will break with the Swift 4 compiler
  *even in Swift 3 compatibility mode*. Case in point...
* The Lazy collection types were formulated as a lazy collection of
  the base slice (e.g., `LazyCollection<ArraySlice<T>>`) rather than as
  a slice of the lazy collection (e.g.,
  `Slice<LazyCollection<Array<T>>`). The former doesn't meet the new
  requirements, so change to the latter.