### PR TITLE
Emit error in Swift 4 mode for final protocol extensions

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -186,7 +186,8 @@ public:
     // 'final' only makes sense in the context of a class declaration.
     // Reject it on global functions, protocols, structs, enums, etc.
     if (!D->getDeclContext()->getAsClassOrClassExtensionContext()) {
-      if (D->getDeclContext()->getAsProtocolExtensionContext())
+      if (TC.Context.isSwiftVersion3() && 
+          D->getDeclContext()->getAsProtocolExtensionContext())
         TC.diagnose(attr->getLocation(), 
           diag::protocol_extension_cannot_be_final)
           .fixItRemove(attr->getRange());

--- a/test/Compatibility/attr_final_protocol_extension.swift
+++ b/test/Compatibility/attr_final_protocol_extension.swift
@@ -1,0 +1,8 @@
+// RUN: %target-typecheck-verify-swift -swift-version 3
+// Generate a swift 3 compatible warning if final is specified in an extension
+
+protocol P {}
+
+extension P {
+  final func inExtension() {} // expected-warning{{functions in a protocol extension do not need to be marked with 'final'}} {{3-9=}}
+}

--- a/test/attr/attr_final_protocol_extension.swift
+++ b/test/attr/attr_final_protocol_extension.swift
@@ -1,0 +1,7 @@
+// RUN: %target-typecheck-verify-swift -swift-version 4
+
+protocol P {}
+
+extension P {
+  final func inExtension() {} // expected-error {{only classes and class members may be marked with 'final'}} {{3-9=}}
+}


### PR DESCRIPTION
This is an update to #8010 that should resolve [SR-1762](https://bugs.swift.org/browse/SR-1762). The change makes the final protocol extension warning only occur in Swift 3 mode, otherwise the usual `final` error message is generated.

I tried to take in the feedback from the other PR that tests in `test/Compatibility` must cover the complete functionality of the original. I made a separate test `test/attr/attr_final_protocol_extension.swift` and copied it into `test/Compatibility` to check the Swift 3 code path. It also seemed valid to copy over all of `test/attr/attr_final.swift` into `test/Compatibility`, but I chose to just do a subset since only a small slice of behavior changes. Glad to do anything that makes more sense here.

Brian
