### PR TITLE
[NOT FOR MERGE] A less naive implementation of utf8.underestimatedCount

### DIFF
--- a/stdlib/public/core/StringUTF8.swift
+++ b/stdlib/public/core/StringUTF8.swift
@@ -173,6 +173,8 @@ extension String {
     internal let _startIndex: Index
     internal let _endIndex: Index
 
+    internal let _isSlice: Bool
+
     init(_ _core: _StringCore) {
       self._core = _core
       self._endIndex = Index(_coreIndex: _core.endIndex, Index._emptyBuffer)
@@ -182,12 +184,18 @@ extension String {
       } else {
         self._startIndex = self._endIndex
       }
+      self._isSlice = false
     }
 
     init(_ _core: _StringCore, _ s: Index, _ e: Index) {
       self._core = _core
       self._startIndex = s
       self._endIndex = e
+      self._isSlice = true
+    }
+
+    public var underestimatedCount: Int {
+      return self._isSlice ? count : _core.count
     }
 
     /// A position in a string's `UTF8View` instance.


### PR DESCRIPTION
Since `UTF8View` is it's own slice, simple returning `_core.count` is not good enough. Let's see what this less naive implementation offers in terms of performance.