### PR TITLE
[Serialization] Drop typealiases whose underlying types have changed.

### DIFF
--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -473,8 +473,11 @@ public:
   /// Determine whether the witness for the given type requirement
   /// is the default definition.
   bool usesDefaultDefinition(AssociatedTypeDecl *requirement) const {
-    return getTypeWitnessAndDecl(requirement, nullptr)
-        .second->isImplicit();
+    TypeDecl *witnessDecl = getTypeWitnessAndDecl(requirement, nullptr).second;
+    if (witnessDecl)
+      return witnessDecl->isImplicit();
+    // Conservatively assume it does not.
+    return false;
   }
 
   void setLazyLoader(LazyMemberLoader *resolver, uint64_t contextData);

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -54,7 +54,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// in source control, you should also update the comment to briefly
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
-const uint16_t VERSION_MINOR = 335; // Last change: no type in objc method table
+const uint16_t VERSION_MINOR = 336; // Last change: typealias canonical type
 
 using DeclID = PointerEmbeddedInt<unsigned, 31>;
 using DeclIDField = BCFixed<31>;
@@ -571,7 +571,8 @@ namespace decls_block {
 
   using NameAliasTypeLayout = BCRecordLayout<
     NAME_ALIAS_TYPE,
-    DeclIDField // typealias decl
+    DeclIDField, // typealias decl
+    TypeIDField  // canonical type (a fallback)
   >;
 
   using GenericTypeParamTypeLayout = BCRecordLayout<

--- a/lib/Serialization/Serialization.h
+++ b/lib/Serialization/Serialization.h
@@ -405,7 +405,8 @@ public:
   /// The Decl will be scheduled for serialization if necessary.
   ///
   /// \returns The ID for the given Decl in this module.
-  DeclID addDeclRef(const Decl *D, bool forceSerialization = false);
+  DeclID addDeclRef(const Decl *D, bool forceSerialization = false,
+                    bool allowTypeAliasXRef = false);
 
   /// Records the use of the given DeclContext.
   ///

--- a/test/Serialization/Recovery/Inputs/custom-modules/Typedefs.h
+++ b/test/Serialization/Recovery/Inputs/custom-modules/Typedefs.h
@@ -1,0 +1,11 @@
+#if !BAD
+typedef int MysteryTypedef;
+#else
+typedef _Bool MysteryTypedef;
+#endif
+
+struct ImportedType {
+  int value;
+};
+
+typedef MysteryTypedef ImportedTypeAssoc __attribute__((swift_name("ImportedType.Assoc")));

--- a/test/Serialization/Recovery/Inputs/custom-modules/module.modulemap
+++ b/test/Serialization/Recovery/Inputs/custom-modules/module.modulemap
@@ -1,1 +1,2 @@
 module Overrides { header "Overrides.h" }
+module Typedefs { header "Typedefs.h" }

--- a/test/Serialization/Recovery/typedefs.swift
+++ b/test/Serialization/Recovery/typedefs.swift
@@ -1,0 +1,62 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: %target-swift-frontend -emit-module -o %t -module-name Lib -I %S/Inputs/custom-modules %s
+
+// RUN: %target-swift-ide-test -source-filename=x -print-module -module-to-print Lib -I %t -I %S/Inputs/custom-modules | %FileCheck %s
+
+// RUN: %target-swift-ide-test -source-filename=x -print-module -module-to-print Lib -I %t -I %S/Inputs/custom-modules -Xcc -DBAD -enable-experimental-deserialization-recovery | %FileCheck -check-prefix CHECK-RECOVERY %s
+
+// RUN: %target-swift-frontend -typecheck -I %t -I %S/Inputs/custom-modules -Xcc -DBAD -DTEST -enable-experimental-deserialization-recovery -DVERIFY %s -verify
+// RUN: %target-swift-frontend -emit-silgen -I %t -I %S/Inputs/custom-modules -Xcc -DBAD -DTEST -enable-experimental-deserialization-recovery %s | %FileCheck -check-prefix CHECK-SIL %s
+
+#if TEST
+
+import Typedefs
+import Lib
+
+// CHECK-SIL-LABEL: sil hidden @_T08typedefs11testSymbolsyyF
+func testSymbols() {
+  // Check that the symbols are not using 'Bool'.
+  // CHECK-SIL: function_ref @_T03Lib1xs5Int32Vfau
+  _ = Lib.x
+  // CHECK-SIL: function_ref @_T03Lib9usesAssocs5Int32VSgfau
+  _ = Lib.usesAssoc
+} // CHECK-SIL: end sil function '_T08typedefs11testSymbolsyyF'
+
+#if VERIFY
+let _: String = useAssoc(ImportedType.self) // expected-error {{cannot convert call result type '_.Assoc?' to expected type 'String'}}
+let _: Bool? = useAssoc(ImportedType.self) // expected-error {{cannot convert value of type 'Int32?' to specified type 'Bool?'}}
+let _: Int32? = useAssoc(ImportedType.self)
+
+let _: String = useAssoc(AnotherType.self) // expected-error {{cannot convert call result type '_.Assoc?' to expected type 'String'}}
+let _: Bool? = useAssoc(AnotherType.self) // expected-error {{cannot convert value of type 'AnotherType.Assoc?' to specified type 'Bool?'}}
+let _: Int32? = useAssoc(AnotherType.self)
+#endif // VERIFY
+
+#else // TEST
+
+import Typedefs
+
+// CHECK-DAG: let x: MysteryTypedef
+// CHECK-RECOVERY-DAG: let x: Int32
+public let x: MysteryTypedef = 0
+
+public protocol HasAssoc {
+  associatedtype Assoc
+}
+
+extension ImportedType: HasAssoc {}
+
+public struct AnotherType: HasAssoc {
+  public typealias Assoc = MysteryTypedef
+}
+
+public func useAssoc<T: HasAssoc>(_: T.Type) -> T.Assoc? { return nil }
+
+// CHECK-DAG: let usesAssoc: ImportedType.Assoc?
+// CHECK-RECOVERY-DAG: let usesAssoc: Int32?
+public let usesAssoc = useAssoc(ImportedType.self)
+// CHECK-DAG: let usesAssoc2: AnotherType.Assoc?
+// CHECK-RECOVERY-DAG: let usesAssoc2: AnotherType.Assoc?
+public let usesAssoc2 = useAssoc(AnotherType.self)
+
+#endif // TEST


### PR DESCRIPTION
In order to accomplish this, cross-module references to typealiases are now banned except from within conformances and NameAliasTypes, the latter of which records the canonical type to determine if the typealias has changed. For conformances, we don't have a good way to check if the typealias has changed without trying to map it into context, but that's all right—the rest of the compiler can already fall back to the canonical type.