### PR TITLE
[migrator] Add test for objc inference changes (fixit migration)

### DIFF
--- a/test/Migrator/objc_inference.swift
+++ b/test/Migrator/objc_inference.swift
@@ -1,0 +1,37 @@
+// RUN: rm -rf %t && mkdir -p %t && %target-swift-frontend -update-code -warn-swift3-objc-inference -primary-file %s -emit-migrated-file-path %t/migrated_objc_inference.swift -o %t/objc_inference.remap
+// RUN: not diff -u %s %t/migrated_objc_inference.swift > %t/objc_inference.diff
+// RUN: %FileCheck %s < %t/objc_inference.diff
+// REQUIRES: objc_interop
+
+import Foundation
+
+class MyClass : NSObject {
+  var property : NSObject? = nil
+  // CHECK: +  @objc var property : NSObject? = nil
+
+  dynamic var member : Int { return 2 }
+  // CHECK: +  @objc dynamic var member : Int { return 2 }
+
+  func foo() {}
+  // CHECK: +  @objc func foo() {}
+
+  func baz() {}
+  // CHECK: +  @objc func baz() {}
+}
+
+extension MyClass {
+  func bar() {}
+  // CHECK: +  @objc func bar() {}
+}
+
+class MySubClass : MyClass {
+  override func foo() {}
+  override func bar() {}
+}
+
+func test(object: AnyObject, mine: MyClass) {
+  _ = #selector(MyClass.foo)
+  _ = #selector(getter: MyClass.member)
+  _ = #keyPath(MyClass.property)
+  _ = object.baz?()
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->
Migrator tests for `@objc` inference changes in https://github.com/apple/swift-evolution/blob/master/proposals/0160-objc-inference.md

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->