### PR TITLE
DO NOT MERGE: speculatively change semantics of _fastPath

### DIFF
--- a/stdlib/public/core/Builtin.swift
+++ b/stdlib/public/core/Builtin.swift
@@ -274,14 +274,14 @@ internal func _branchHint(_ actual: Bool, expected: Bool) -> Bool {
 @_transparent
 @_semantics("fastpath")
 public func _fastPath(_ x: Bool) -> Bool {
-  return _branchHint(x, expected: true)
+  return Bool(Builtin.int_expect_Int1(x._value, true._value))
 }
 
 /// Optimizer hint that `x` is expected to be `false`.
 @_transparent
 @_semantics("slowpath")
 public func _slowPath(_ x: Bool) -> Bool {
-  return _branchHint(x, expected: false)
+  return Bool(Builtin.int_expect_Int1(x._value, false._value))
 }
 
 /// Optimizer hint that the code where this function is called is on the fast

--- a/stdlib/public/core/Builtin.swift
+++ b/stdlib/public/core/Builtin.swift
@@ -272,16 +272,16 @@ internal func _branchHint(_ actual: Bool, expected: Bool) -> Bool {
 
 /// Optimizer hint that `x` is expected to be `true`.
 @_transparent
-@_semantics("fastpath")
+// @_semantics("fastpath")
 public func _fastPath(_ x: Bool) -> Bool {
-  return Bool(Builtin.int_expect_Int1(x._value, true._value))
+  return x //Bool(Builtin.int_expect_Int1(x._value, true._value))
 }
 
 /// Optimizer hint that `x` is expected to be `false`.
 @_transparent
-@_semantics("slowpath")
+// @_semantics("slowpath")
 public func _slowPath(_ x: Bool) -> Bool {
-  return Bool(Builtin.int_expect_Int1(x._value, false._value))
+  return x //Bool(Builtin.int_expect_Int1(x._value, false._value))
 }
 
 /// Optimizer hint that the code where this function is called is on the fast


### PR DESCRIPTION
<!-- What's in this pull request? -->
_fastPath has the unfortunate side effect of blowing AC all over the rest of the code. Let's combat code cooling by trying a benchmark run where we have its semantics merely be builtin_expect.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
