### PR TITLE
Add subclass existential support to type reconstruction

### DIFF
--- a/lib/AST/USRGeneration.cpp
+++ b/lib/AST/USRGeneration.cpp
@@ -113,19 +113,24 @@ static bool printObjCUSR(const ValueDecl *D, raw_ostream &OS) {
   return printObjCUSRFragment(D, ObjCName.second.getString(Buf), OS);
 }
 
-static bool ShouldUseObjCUSR(const Decl *D) {
+static bool shouldUseObjCUSR(const Decl *D) {
   // Only the subscript getter/setter are visible to ObjC rather than the
   // subscript itself
   if (isa<SubscriptDecl>(D))
     return false;
 
   auto Parent = D->getDeclContext()->getInnermostDeclarationDeclContext();
-  if (Parent && (!ShouldUseObjCUSR(Parent) || // parent should be visible too
+  if (Parent && (!shouldUseObjCUSR(Parent) || // parent should be visible too
                  !D->getDeclContext()->isTypeContext() || // no local decls
                  isa<TypeDecl>(D))) // nested types aren't supported
     return false;
 
   if (const ValueDecl *VD = dyn_cast<ValueDecl>(D)) {
+    if (auto *PD = dyn_cast<ProtocolDecl>(D))
+      if (auto known = PD->getKnownProtocolKind())
+        if (known == KnownProtocolKind::AnyObject)
+          return false;
+
     if (isa<EnumElementDecl>(VD))
       return true;
     return objc_translation::isVisibleToObjC(VD, Accessibility::Internal);
@@ -134,7 +139,7 @@ static bool ShouldUseObjCUSR(const Decl *D) {
   if (const ExtensionDecl *ED = dyn_cast<ExtensionDecl>(D)) {
     if (auto ExtendedType = ED->getExtendedType()) {
       auto baseClass = ExtendedType->getClassOrBoundGenericClass();
-      return baseClass && ShouldUseObjCUSR(baseClass) && !baseClass->isForeign();
+      return baseClass && shouldUseObjCUSR(baseClass) && !baseClass->isForeign();
     }
   }
   return false;
@@ -202,7 +207,7 @@ bool ide::printDeclUSR(const ValueDecl *D, raw_ostream &OS) {
     return Ignore;
   }
 
-  if (ShouldUseObjCUSR(D)) {
+  if (shouldUseObjCUSR(D)) {
     return printObjCUSR(D, OS);
   }
 
@@ -238,7 +243,7 @@ bool ide::printAccessorUSR(const AbstractStorageDecl *D, AccessorKind AccKind,
   // addressor.
 
   AbstractStorageDecl *SD = const_cast<AbstractStorageDecl*>(D);
-  if (ShouldUseObjCUSR(SD)) {
+  if (shouldUseObjCUSR(SD)) {
     return printObjCUSRForAccessor(SD, AccKind, OS);
   }
 

--- a/lib/IDE/TypeReconstruction.cpp
+++ b/lib/IDE/TypeReconstruction.cpp
@@ -2138,7 +2138,9 @@ Decl *ide::getDeclFromMangledSymbolName(ASTContext &context,
   Demangle::Context DemangleCtx;
   auto node = DemangleCtx.demangleSymbolAsNode(mangledName);
   VisitNodeResult result;
-  VisitNode(&context, node, result);
+
+  if (node)
+    VisitNode(&context, node, result);
   error = result._error;
   if (error.empty() && result._decls.size() == 1) {
     return result._decls.front();
@@ -2157,7 +2159,8 @@ Type ide::getTypeFromMangledTypename(ASTContext &Ctx,
   auto node = DemangleCtx.demangleTypeAsNode(mangledName);
   VisitNodeResult result;
 
-  VisitNode(&Ctx, node, result);
+  if (node)
+    VisitNode(&Ctx, node, result);
   error = result._error;
   if (error.empty() && result._types.size() == 1) {
     return result._types.front().getPointer();
@@ -2176,7 +2179,8 @@ Type ide::getTypeFromMangledSymbolname(ASTContext &Ctx,
   auto node = DemangleCtx.demangleSymbolAsNode(mangledName);
   VisitNodeResult result;
 
-  VisitNode(&Ctx, node, result);
+  if (node)
+    VisitNode(&Ctx, node, result);
   error = result._error;
   if (error.empty() && result._types.size() == 1) {
     return result._types.front().getPointer();

--- a/lib/IDE/TypeReconstruction.cpp
+++ b/lib/IDE/TypeReconstruction.cpp
@@ -1621,6 +1621,32 @@ static void VisitNodeNominal(
   }
 }
 
+static void VisitNodeTypeAlias(
+    ASTContext *ast,
+    Demangle::NodePointer cur_node, VisitNodeResult &result) {
+  Type parent_type;
+
+  Demangle::Node::iterator child_end = cur_node->end();
+  for (Demangle::Node::iterator child_pos = cur_node->begin();
+       child_pos != child_end; ++child_pos) {
+    auto child = *child_pos;
+    switch(child->getKind()) {
+    case Demangle::Node::Kind::Identifier:
+      VisitNodeIdentifier(ast, cur_node, child, result);
+      break;
+    case Demangle::Node::Kind::LocalDeclName:
+      VisitNodeLocalDeclName(ast, cur_node, child, result);
+      break;
+    case Demangle::Node::Kind::PrivateDeclName:
+      VisitNodePrivateDeclName(ast, cur_node, child, result);
+      break;
+    default:
+      VisitNode(ast, child, result);
+      break;
+    }
+  }
+}
+
 static void VisitNodeInOut(
     ASTContext *ast,
     Demangle::NodePointer cur_node, VisitNodeResult &result) {
@@ -1972,9 +1998,12 @@ static void VisitNode(
     VisitNodeNominal(ast, node, result);
     break;
 
+  case Demangle::Node::Kind::TypeAlias:
+    VisitNodeTypeAlias(ast, node, result);
+    break;
+
   case Demangle::Node::Kind::Global:
   case Demangle::Node::Kind::Static:
-  case Demangle::Node::Kind::TypeAlias:
   case Demangle::Node::Kind::Type:
   case Demangle::Node::Kind::TypeMangling:
   case Demangle::Node::Kind::ReturnType:

--- a/test/IDE/reconstruct_type_from_mangled_name.swift
+++ b/test/IDE/reconstruct_type_from_mangled_name.swift
@@ -86,6 +86,40 @@ class Myclass2 {
   }
 }
 
+// CHECK: decl: enum MyEnum
+enum MyEnum {
+// FIXME
+// CHECK: decl:   for 'ravioli'
+  case ravioli
+// CHECK: decl:   for 'pasta'
+  case pasta
+
+// CHECK: decl: func method() -> Int
+  func method() -> Int { return 0 }
+
+// CHECK: decl: func compare(_ other: MyEnum) -> Int
+  func compare(_ other: MyEnum) -> Int {
+    // CHECK: decl: let other: MyEnum
+    return 0
+  }
+
+// CHECK: decl: mutating func mutatingMethod()
+  mutating func mutatingMethod() {}
+}
+
+// CHECK: decl: func f2()
+func f2() {
+// CHECK: type: (MyEnum.Type) -> MyEnum
+  var e = MyEnum.pasta
+
+// CHECK: type: (MyEnum) -> () -> Int
+  e.method()
+// CHECK: (MyEnum) -> (MyEnum) -> Int
+  e.compare(e)
+// CHECK: (@lvalue MyEnum) -> () -> ()
+  e.mutatingMethod()
+}
+
 struct MyGenStruct1<T, U: ExpressibleByStringLiteral, V: Sequence> {
 // CHECK: decl: struct MyGenStruct1<T, U, V> where U : ExpressibleByStringLiteral, V : Sequence
 // FIXME: why are these references to the base type?
@@ -109,6 +143,11 @@ struct MyGenStruct1<T, U: ExpressibleByStringLiteral, V: Sequence> {
     _ = z
 // CHECK: type: V
   }
+
+  // CHECK: decl: func takesT(_ t: T)
+  func takesT(_ t: T) {
+    // CHECK: decl: let t: T
+  }
 }
 
 let genstruct1 = MyGenStruct1<Int, String, [Float]>(x: 1, y: "", z: [1.0])
@@ -129,10 +168,101 @@ func test001() {
 // CHECK: type: String
   _ = genstruct2.z
 // CHECK: type: Dictionary<Int, Int>
+
+  genstruct2.takesT(123)
 }
 
+// CHECK: decl: protocol P1
 protocol P1 {}
-func foo1(p : P1) {}
-// CHECK: decl: protocol P1  for 'P1' usr=s:14swift_ide_test2P1P
-// CHECK: decl: func foo1(p: P1)  for 'foo1' usr=s:14swift_ide_test4foo1yAA2P1_p1p_tF
-// CHECK: decl: let p: P1 for 'p' usr=s:14swift_ide_test4foo1yAA2P1_p1p_tFADL_AaC_pv
+
+// CHECK: decl: func foo1(p: P1)
+func foo1(p: P1) {
+// CHECK: decl: let p: P1
+// CHECK: type: (P1) -> ()
+  foo1(p: p)
+}
+
+// CHECK: decl: protocol P2
+protocol P2 {}
+
+// CHECK: decl: func foo2(p: P1 & P2)
+func foo2(p: P1 & P2) {
+// CHECK: decl: let p: P1 & P2
+  foo2(p: p)
+}
+
+// CHECK: func foo3(p: AnyObject & P1)
+func foo3(p: P1 & AnyObject) {
+// CHECK: decl: let p: AnyObject & P1
+// CHECK: dref: FAILURE for 'AnyObject'
+  foo3(p: p)
+}
+
+// CHECK: func foo4(p: Myclass1 & P1 & P2)
+func foo4(p: P1 & P2 & Myclass1) {
+// CHECK: decl: let p: Myclass1 & P1 & P2
+  foo4(p: p)
+}
+
+func genericFunction<T : AnyObject>(t: T) {
+// CHECK: decl: FAILURE for 'T' usr=s:14swift_ide_test15genericFunctionyx1t_ts9AnyObjectRzlF1TL_xmfp
+  genericFunction(t: t)
+}
+
+// CHECK: decl: func takesInOut(fn: (inout Int) -> ())
+// CHECK: decl: let fn: (inout Int) -> () for 'fn'
+func takesInOut(fn: (inout Int) -> ()) {}
+
+struct Outer {
+  struct Inner {
+    let x: Int
+  }
+
+  struct GenericInner<T> {
+    // CHECK: decl: FAILURE for 'T' usr=s:14swift_ide_test5OuterV12GenericInnerV1Txmfp
+    let t: T
+  }
+}
+
+struct GenericOuter<T> {
+  // CHECK: decl: FAILURE for 'T' usr=s:14swift_ide_test12GenericOuterV1Txmfp
+  struct Inner {
+    let t: T
+    let x: Int
+  }
+
+  struct GenericInner<U> {
+    // CHECK: decl: FAILURE for 'U' usr=s:14swift_ide_test12GenericOuterV0D5InnerV1Uqd__mfp
+    let t: T
+    let u: U
+  }
+}
+
+// CHECK: decl: func takesGeneric(_ t: Outer.GenericInner<Int>)
+func takesGeneric(_ t: Outer.GenericInner<Int>) {
+  takesGeneric(t)
+}
+
+// CHECK: decl: func takesGeneric(_ t: GenericOuter<Int>.Inner)
+func takesGeneric(_ t: GenericOuter<Int>.Inner) {
+  takesGeneric(t)
+}
+
+// CHECK: decl: func takesGeneric(_ t: GenericOuter<Int>.GenericInner<String>)
+func takesGeneric(_ t: GenericOuter<Int>.GenericInner<String>) {
+  takesGeneric(t)
+}
+
+func hasLocalDecls() {
+  func localFunction() {}
+
+  // FIXME
+  // CHECK: decl: FAILURE for 'LocalType'
+  struct LocalType {}
+}
+
+fileprivate struct VeryPrivateData {}
+
+// FIXME
+// CHECK: decl: FAILURE for 'privateFunction'
+fileprivate func privateFunction(_ d: VeryPrivateData) {}

--- a/test/IDE/reconstruct_type_from_mangled_name.swift
+++ b/test/IDE/reconstruct_type_from_mangled_name.swift
@@ -259,6 +259,12 @@ func hasLocalDecls() {
   // FIXME
   // CHECK: decl: FAILURE for 'LocalType'
   struct LocalType {}
+
+  // CHECK: decl: FAILURE for 'LocalAlias'
+  typealias LocalAlias = LocalType
+
+  // CHECK: dref: FAILURE for 'LocalType'
+  let x: LocalAlias = LocalType()
 }
 
 fileprivate struct VeryPrivateData {}

--- a/test/IDE/reconstruct_type_from_mangled_name.swift
+++ b/test/IDE/reconstruct_type_from_mangled_name.swift
@@ -194,7 +194,7 @@ func foo2(p: P1 & P2) {
 // CHECK: func foo3(p: AnyObject & P1)
 func foo3(p: P1 & AnyObject) {
 // CHECK: decl: let p: AnyObject & P1
-// CHECK: dref: FAILURE for 'AnyObject'
+// CHECK: dref: {{(@objc )?}}protocol AnyObject
   foo3(p: p)
 }
 

--- a/test/SourceKit/DocSupport/doc_clang_module.swift.response
+++ b/test/SourceKit/DocSupport/doc_clang_module.swift.response
@@ -4467,7 +4467,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "AnyObject",
-    key.usr: "c:objc(pl)AnyObject",
+    key.usr: "s:s9AnyObjectP",
     key.offset: 6668,
     key.length: 9
   },
@@ -4489,7 +4489,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "AnyObject",
-    key.usr: "c:objc(pl)AnyObject",
+    key.usr: "s:s9AnyObjectP",
     key.offset: 6722,
     key.length: 9
   },
@@ -4556,7 +4556,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "AnyObject",
-    key.usr: "c:objc(pl)AnyObject",
+    key.usr: "s:s9AnyObjectP",
     key.offset: 6831,
     key.length: 9
   },
@@ -7511,7 +7511,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "c:objc(cs)FooClassPropertyOwnership(py)assignable",
         key.offset: 6636,
         key.length: 42,
-        key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>unowned(unsafe)</syntaxtype.keyword> <syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>assignable</decl.name>: <decl.var.type><ref.protocol usr=\"c:objc(pl)AnyObject\">AnyObject</ref.protocol>!</decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
+        key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>unowned(unsafe)</syntaxtype.keyword> <syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>assignable</decl.name>: <decl.var.type><ref.protocol usr=\"s:s9AnyObjectP\">AnyObject</ref.protocol>!</decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
       },
       {
         key.kind: source.lang.swift.decl.var.instance,
@@ -7519,7 +7519,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "c:objc(cs)FooClassPropertyOwnership(py)unsafeAssignable",
         key.offset: 6684,
         key.length: 48,
-        key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>unowned(unsafe)</syntaxtype.keyword> <syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>unsafeAssignable</decl.name>: <decl.var.type><ref.protocol usr=\"c:objc(pl)AnyObject\">AnyObject</ref.protocol>!</decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
+        key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>unowned(unsafe)</syntaxtype.keyword> <syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>unsafeAssignable</decl.name>: <decl.var.type><ref.protocol usr=\"s:s9AnyObjectP\">AnyObject</ref.protocol>!</decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
       },
       {
         key.kind: source.lang.swift.decl.var.instance,
@@ -7551,7 +7551,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "c:objc(cs)FooClassPropertyOwnership(py)weakRef",
         key.offset: 6813,
         key.length: 28,
-        key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>weak</syntaxtype.keyword> <syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>weakRef</decl.name>: <decl.var.type><ref.protocol usr=\"c:objc(pl)AnyObject\">AnyObject</ref.protocol>!</decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
+        key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>weak</syntaxtype.keyword> <syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>weakRef</decl.name>: <decl.var.type><ref.protocol usr=\"s:s9AnyObjectP\">AnyObject</ref.protocol>!</decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
       },
       {
         key.kind: source.lang.swift.decl.var.instance,

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -2638,6 +2638,8 @@ static int doReconstructType(const CompilerInvocation &InitInvok,
   CompilerInvocation Invocation(InitInvok);
   Invocation.addInputFilename(SourceFilename);
   Invocation.getLangOptions().DisableAvailabilityChecking = false;
+  // This is temporary
+  Invocation.getLangOptions().EnableExperimentalSubclassExistentials = true;
 
   CompilerInstance CI;
 


### PR DESCRIPTION
... and nested generics, while I'm here.

TypeReconstruction is a piece of code used by lldb and SourceKit to realize AST types and decls from mangled strings. Longer-term this should be replaced by or merged with RemoteAST, but we're not ready for that yet.

Note that the new tests are all in one patch at the end, because I couldn't be bothered teasing them apart.

Fixes <rdar://problem/31748935> together with the lldb PR.