### PR TITLE
[Serialization] Handle UnboundGenericTypes of generic typealiases.

### DIFF
--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4425,7 +4425,7 @@ Expected<Type> ModuleFile::getTypeChecked(TypeID TID) {
     decls_block::UnboundGenericTypeLayout::readRecord(scratch,
                                                       genericID, parentID);
 
-    auto genericDecl = cast<NominalTypeDecl>(getDecl(genericID));
+    auto genericDecl = cast<GenericTypeDecl>(getDecl(genericID));
     typeOrOffset = UnboundGenericType::get(genericDecl, getType(parentID), ctx);
     break;
   }

--- a/test/Serialization/Inputs/alias.swift
+++ b/test/Serialization/Inputs/alias.swift
@@ -31,3 +31,6 @@ public protocol ProtoWrapper {}
 extension ProtoWrapper {
   public typealias Boolean = Bool
 }
+
+public struct Outer { public typealias G<T> = T }
+public typealias GG = Outer.G

--- a/test/Serialization/typealias.swift
+++ b/test/Serialization/typealias.swift
@@ -52,3 +52,5 @@ print("\(dyadic((named.b, i))) \(dyadic(both))\n", terminator: "")
 func check(_: BaseAlias) {
 }
 
+let x: GG<Int> = 0
+


### PR DESCRIPTION
Simple latent asserts-only bug, rescused from #8737. Thanks to Slava for the test case.