### PR TITLE
Add a testcase for the debug info generated for 'Bool'.

### DIFF
--- a/test/DebugInfo/bool.swift
+++ b/test/DebugInfo/bool.swift
@@ -1,9 +1,14 @@
 // RUN: %target-swift-frontend %s -emit-ir -gdwarf-types -o - | %FileCheck %s
+// RUN: %target-swift-frontend %s -emit-ir -g -o - \
+// RUN:   | %FileCheck %s --check-prefix=CHECK_G
 
 func markUsed<T>(_ t: T) {}
 
 // Int1 uses 1 bit, but is aligned at 8 bits.
 // CHECK: !DIBasicType(name: "_T0Bi1_D", size: 1, encoding: DW_ATE_unsigned)
+// Bool has a fixed layout with a storage size of 1 byte and 7 "spare" bits.
+// CHECK_G: !DICompositeType(tag: DW_TAG_structure_type, name: "Bool",
+// CHECK_G-SAME:             size: 8
 func main() {
   var t = true
   var f = false


### PR DESCRIPTION
rdar://problem/29605924
