### PR TITLE
[migrator] Add objc inference warning to the new migrator fixit whitelist

### DIFF
--- a/include/swift/Migrator/FixitFilter.h
+++ b/include/swift/Migrator/FixitFilter.h
@@ -101,7 +101,8 @@ struct FixitFilter {
         Info.ID == diag::deprecated_protocol_composition_single.ID ||
         Info.ID == diag::deprecated_any_composition.ID ||
         Info.ID == diag::deprecated_operator_body.ID ||
-        Info.ID == diag::unbound_generic_parameter_explicit_fix.ID)
+        Info.ID == diag::unbound_generic_parameter_explicit_fix.ID ||
+        Info.ID == diag::objc_inference_swift3_addobjc.ID)
       return true;
 
     return false;


### PR DESCRIPTION
<!-- What's in this pull request? -->
Fixes test failure in test/Migrator/objc_inference.swift

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->