### PR TITLE
[test] Fix SourceKit test harder against unnecessary USRs

### DIFF
--- a/test/SourceKit/CodeComplete/complete_moduleimportdepth.swift
+++ b/test/SourceKit/CodeComplete/complete_moduleimportdepth.swift
@@ -18,8 +18,8 @@ func test() {
 // CHECK-NEXT:   key.context: source.codecompletion.context.othermodule,
 // CHECK-NEXT:   key.moduleimportdepth: 1,
 // CHECK-NEXT:   key.num_bytes_to_erase: 0,
-// CHECK:        key.associated_usrs: "s:s3absxxs13SignedNumericRz9Magnitudes0C0PQzRszlF",
-// CHECK-NEXT:   key.modulename: "Swift"
+// CHECK-NOT:    key.modulename
+// CHECK:        key.modulename: "Swift"
 // CHECK-NEXT: },
 
 // CHECK-LABEL:  key.name: "abs(:)",
@@ -30,8 +30,8 @@ func test() {
 // CHECK-NEXT:   key.context: source.codecompletion.context.othermodule,
 // CHECK-NEXT:   key.moduleimportdepth: 1,
 // CHECK-NEXT:   key.num_bytes_to_erase: 0,
-// CHECK:        key.associated_usrs: "s:s3absxxs10ComparableRzs13SignedNumericRzlF",
-// CHECK-NEXT:   key.modulename: "Swift"
+// CHECK-NOT:    key.modulename
+// CHECK:        key.modulename: "Swift"
 // CHECK-NEXT: },
 
 // CHECK-LABEL:  key.name: "abs(:)",


### PR DESCRIPTION
This time make sure I actually got *all* the associated_usrs, d'oh.
