### PR TITLE
Performance improvements for new integers

### DIFF
--- a/lib/SILOptimizer/Mandatory/ConstantPropagation.cpp
+++ b/lib/SILOptimizer/Mandatory/ConstantPropagation.cpp
@@ -232,6 +232,7 @@ static SILInstruction *constantFoldCompare(BuiltinInst *BI,
     return B.createIntegerLiteral(BI->getLoc(), BI->getType(), Res);
   }
 
+  // Comparisons of an unsigned value with 0.
   SILValue Other;
   auto MatchNonNegative =
       m_BuiltinInst(BuiltinValueKind::AssumeNonNegative, m_ValueBase());
@@ -257,6 +258,132 @@ static SILInstruction *constantFoldCompare(BuiltinInst *BI,
                                           MatchNonNegative)))) {
     SILBuilderWithScope B(BI);
     return B.createIntegerLiteral(BI->getLoc(), BI->getType(), APInt(1, 1));
+  }
+
+  // Comparisons with Int.Max.
+  IntegerLiteralInst *IntMax;
+
+  // Check signed comparisons.
+  if (match(BI,
+            m_CombineOr(
+                // Int.max < x
+                m_BuiltinInst(BuiltinValueKind::ICMP_SLT,
+                              m_IntegerLiteralInst(IntMax), m_SILValue(Other)),
+                // x > Int.max
+                m_BuiltinInst(BuiltinValueKind::ICMP_SGT, m_SILValue(Other),
+                              m_IntegerLiteralInst(IntMax)))) &&
+      IntMax->getValue().isMaxSignedValue()) {
+    // Any signed number should be <= then IntMax.
+    SILBuilderWithScope B(BI);
+    return B.createIntegerLiteral(BI->getLoc(), BI->getType(), APInt());
+  }
+
+  if (match(BI,
+            m_CombineOr(
+                m_BuiltinInst(BuiltinValueKind::ICMP_SGE,
+                              m_IntegerLiteralInst(IntMax), m_SILValue(Other)),
+                m_BuiltinInst(BuiltinValueKind::ICMP_SLE, m_SILValue(Other),
+                              m_IntegerLiteralInst(IntMax)))) &&
+      IntMax->getValue().isMaxSignedValue()) {
+    // Any signed number should be <= then IntMax.
+    SILBuilderWithScope B(BI);
+    return B.createIntegerLiteral(BI->getLoc(), BI->getType(), APInt(1, 1));
+  }
+
+  // For any x of the same size as Int.max and n>=1 , (x>>n) is always <= Int.max,
+  // that is (x>>n) <= Int.max and Int.max >= (x>>n) are true.
+  if (match(BI,
+            m_CombineOr(
+                // Int.max >= x
+                m_BuiltinInst(BuiltinValueKind::ICMP_UGE,
+                              m_IntegerLiteralInst(IntMax), m_SILValue(Other)),
+                // x <= Int.max
+                m_BuiltinInst(BuiltinValueKind::ICMP_ULE, m_SILValue(Other),
+                              m_IntegerLiteralInst(IntMax)),
+                // Int.max >= x
+                m_BuiltinInst(BuiltinValueKind::ICMP_SGE,
+                              m_IntegerLiteralInst(IntMax), m_SILValue(Other)),
+                // x <= Int.max
+                m_BuiltinInst(BuiltinValueKind::ICMP_SLE, m_SILValue(Other),
+                              m_IntegerLiteralInst(IntMax)))) &&
+      IntMax->getValue().isMaxSignedValue()) {
+    // Check if other is a result of a logical shift right by a strictly
+    // positive number of bits.
+    IntegerLiteralInst *ShiftCount;
+    if (match(Other, m_BuiltinInst(BuiltinValueKind::LShr, m_ValueBase(),
+                                   m_IntegerLiteralInst(ShiftCount))) &&
+        ShiftCount->getValue().isStrictlyPositive()) {
+      SILBuilderWithScope B(BI);
+      return B.createIntegerLiteral(BI->getLoc(), BI->getType(), APInt(1, 1));
+    }
+  }
+
+  // At the same time (x>>n) > Int.max and  Int.max < (x>>n) is false.
+  if (match(BI,
+            m_CombineOr(
+                // Int.max < x
+                m_BuiltinInst(BuiltinValueKind::ICMP_ULT,
+                              m_IntegerLiteralInst(IntMax), m_SILValue(Other)),
+                // x > Int.max
+                m_BuiltinInst(BuiltinValueKind::ICMP_UGT, m_SILValue(Other),
+                              m_IntegerLiteralInst(IntMax)),
+                // Int.max < x
+                m_BuiltinInst(BuiltinValueKind::ICMP_SLT,
+                              m_IntegerLiteralInst(IntMax), m_SILValue(Other)),
+                // x > Int.max
+                m_BuiltinInst(BuiltinValueKind::ICMP_SGT, m_SILValue(Other),
+                              m_IntegerLiteralInst(IntMax)))) &&
+      IntMax->getValue().isMaxSignedValue()) {
+    // Check if other is a result of a logical shift right by a strictly
+    // positive number of bits.
+    IntegerLiteralInst *ShiftCount;
+    if (match(Other, m_BuiltinInst(BuiltinValueKind::LShr, m_ValueBase(),
+                                   m_IntegerLiteralInst(ShiftCount))) &&
+        ShiftCount->getValue().isStrictlyPositive()) {
+      SILBuilderWithScope B(BI);
+      return B.createIntegerLiteral(BI->getLoc(), BI->getType(), APInt());
+    }
+  }
+
+  // Fold x < 0 into false, if x is known to be a result of an unsigned
+  // operation with overflow checks enabled.
+  BuiltinInst *BIOp;
+  if (match(BI, m_BuiltinInst(BuiltinValueKind::ICMP_SLT,
+                              m_TupleExtractInst(m_BuiltinInst(BIOp), 0),
+                              m_Zero()))) {
+    // Check if Other is a result of an unsigned operation with overflow.
+    switch (BIOp->getBuiltinInfo().ID) {
+    default:
+      break;
+    case BuiltinValueKind::UAddOver:
+    case BuiltinValueKind::USubOver:
+    case BuiltinValueKind::UMulOver:
+      // Was it an operation with an overflow check?
+      if (match(BIOp->getOperand(2), m_One())) {
+        SILBuilderWithScope B(BI);
+        return B.createIntegerLiteral(BI->getLoc(), BI->getType(), APInt());
+      }
+    }
+  }
+
+  // Fold x >= 0 into true, if x is known to be a result of an unsigned
+  // operation with overflow checks enabled.
+  if (match(BI, m_BuiltinInst(BuiltinValueKind::ICMP_SGE,
+                              m_TupleExtractInst(m_BuiltinInst(BIOp), 0),
+                              m_Zero()))) {
+    // Check if Other is a result of an unsigned operation with overflow.
+    switch (BIOp->getBuiltinInfo().ID) {
+    default:
+      break;
+    case BuiltinValueKind::UAddOver:
+    case BuiltinValueKind::USubOver:
+    case BuiltinValueKind::UMulOver:
+      // Was it an operation with an overflow check?
+      if (match(BIOp->getOperand(2), m_One())) {
+        SILBuilderWithScope B(BI);
+        return B.createIntegerLiteral(BI->getLoc(), BI->getType(), APInt(1, 1));
+      }
+    }
   }
 
   return nullptr;

--- a/lib/SILOptimizer/SILCombiner/SILCombinerBuiltinVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerBuiltinVisitors.cpp
@@ -55,8 +55,19 @@ SILInstruction *SILCombiner::optimizeBuiltinCompareEq(BuiltinInst *BI,
   IsZeroKind RHS = isZeroValue(BI->getArguments()[1]);
 
   // Can't handle unknown values.
-  if (LHS == IsZeroKind::Unknown || RHS == IsZeroKind::Unknown)
+  if (LHS == IsZeroKind::Unknown) {
     return nullptr;
+  }
+
+  // Canonicalize i1_const == X to X == i1_const.
+  // Canonicalize i1_const != X to X != i1_const.
+  if (RHS == IsZeroKind::Unknown) {
+    auto *CanonI =
+        Builder.createBuiltin(BI->getLoc(), BI->getName(), BI->getType(), {},
+                              {BI->getArguments()[1], BI->getArguments()[0]});
+    replaceInstUsesWith(*BI, CanonI);
+    return eraseInstFromFunction(*BI);
+  }
 
   // Can't handle non-zero ptr values.
   if (LHS == IsZeroKind::NotZero && RHS == IsZeroKind::NotZero)

--- a/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
@@ -1075,9 +1075,22 @@ SILInstruction *SILCombiner::visitStrongReleaseInst(StrongReleaseInst *SRI) {
 
 SILInstruction *SILCombiner::visitCondBranchInst(CondBranchInst *CBI) {
   // cond_br(xor(x, 1)), t_label, f_label -> cond_br x, f_label, t_label
+  // cond_br(x == 0), t_label, f_label -> cond_br x, f_label, t_label
+  // cond_br(x != 1), t_label, f_label -> cond_br x, f_label, t_label
   SILValue X;
-  if (match(CBI->getCondition(), m_ApplyInst(BuiltinValueKind::Xor,
-                                             m_SILValue(X), m_One()))) {
+  if (match(CBI->getCondition(),
+            m_CombineOr(
+                // xor(x, 1)
+                m_ApplyInst(BuiltinValueKind::Xor, m_SILValue(X), m_One()),
+                // xor(1,x)
+                m_ApplyInst(BuiltinValueKind::Xor, m_One(), m_SILValue(X)),
+                // x == 0
+                m_ApplyInst(BuiltinValueKind::ICMP_EQ, m_SILValue(X), m_Zero()),
+                // x != 1
+                m_ApplyInst(BuiltinValueKind::ICMP_NE, m_SILValue(X),
+                            m_One()))) &&
+      X->getType() ==
+          SILType::getBuiltinIntegerType(1, CBI->getModule().getASTContext())) {
     SmallVector<SILValue, 4> OrigTrueArgs, OrigFalseArgs;
     for (const auto &Op : CBI->getTrueArgs())
       OrigTrueArgs.push_back(Op);

--- a/lib/SILOptimizer/Transforms/RedundantOverflowCheckRemoval.cpp
+++ b/lib/SILOptimizer/Transforms/RedundantOverflowCheckRemoval.cpp
@@ -37,7 +37,7 @@ public:
   RedundantOverflowCheckRemovalPass() {}
 
   /// This enum represents a relationship between two operands.
-  /// The relationship represented by arithmetic operators represent the
+  /// The relationship represented by arithmetic operators represents the
   /// information that the operation did not trap.
   ///
   /// The following code translate (with the correct signedness prefix):
@@ -57,9 +57,11 @@ public:
   /// the function.
   struct Constraint {
     Constraint(SILBasicBlock *BB, SILValue L, SILValue R, ValueRelation Rel) :
-      DominatingBlock(BB), Left(L), Right(R), Relationship(Rel) {}
+      DominatingBlock(BB), Left(L), Right(R), Relationship(Rel) {
+      DEBUG(dump());
+    }
 
-    /// The constraint is valid blocks dominated by this block.
+    /// The constraint is valid in blocks dominated by this block.
     SILBasicBlock *DominatingBlock;
     /// The first operand.
     SILValue Left;
@@ -515,44 +517,150 @@ public:
     return false;
   }
 
-  void registerCondFailFormula(CondFailInst *CFI) {
-    // Extract the arithmetic operation from the condfail.
-    auto *TEI = dyn_cast<TupleExtractInst>(CFI->getOperand());
-    if (!TEI) return;
-    auto *BI = dyn_cast<BuiltinInst>(TEI->getOperand());
-    if (!BI) return;
-
-    // The relationship expressed in the builtin.
+  Optional<ValueRelation> getArithOpRelation(BuiltinInst *BI) {
     ValueRelation Rel;
     switch (BI->getBuiltinInfo().ID) {
-      default: return;
-      case BuiltinValueKind::SAddOver:
-        Rel = ValueRelation::SAdd;
-        break;
-      case BuiltinValueKind::UAddOver:
-        Rel = ValueRelation::UAdd;
-        break;
-      case BuiltinValueKind::SSubOver:
-        Rel = ValueRelation::SSub;
-        break;
-      case BuiltinValueKind::USubOver:
-        Rel = ValueRelation::USub;
-        break;
-      case BuiltinValueKind::SMulOver:
-        Rel = ValueRelation::SMul;
-        break;
-      case BuiltinValueKind::UMulOver:
-        Rel = ValueRelation::UMul;
-        break;
+    default:
+      return None;
+    case BuiltinValueKind::SAddOver:
+      Rel = ValueRelation::SAdd;
+      break;
+    case BuiltinValueKind::UAddOver:
+      Rel = ValueRelation::UAdd;
+      break;
+    case BuiltinValueKind::SSubOver:
+      Rel = ValueRelation::SSub;
+      break;
+    case BuiltinValueKind::USubOver:
+      Rel = ValueRelation::USub;
+      break;
+    case BuiltinValueKind::SMulOver:
+      Rel = ValueRelation::SMul;
+      break;
+    case BuiltinValueKind::UMulOver:
+      Rel = ValueRelation::UMul;
+      break;
+    }
+    return Rel;
+  }
+
+  void addComparisonRelation(BuiltinInst *CMP, SILBasicBlock *TrueBB,
+                             SILBasicBlock *FalseBB) {
+    // The relationship expressed in the builtin.
+    ValueRelation TrueRel;
+    ValueRelation FalseRel;
+    bool Swap = false;
+
+    switch (CMP->getBuiltinInfo().ID) {
+    default:
+      return;
+    case BuiltinValueKind::ICMP_NE: {
+      SILValue Left = CMP->getOperand(0);
+      SILValue Right = CMP->getOperand(1);
+      if (FalseBB)
+        Constraints.push_back(
+            Constraint(FalseBB, Left, Right, ValueRelation::EQ));
+      return;
+    }
+    case BuiltinValueKind::ICMP_EQ: {
+      SILValue Left = CMP->getOperand(0);
+      SILValue Right = CMP->getOperand(1);
+      if (TrueBB)
+        Constraints.push_back(
+            Constraint(TrueBB, Left, Right, ValueRelation::EQ));
+      return;
+    }
+    case BuiltinValueKind::ICMP_SLE:
+      TrueRel = ValueRelation::SLE;
+      FalseRel = ValueRelation::SLT;
+      break;
+    case BuiltinValueKind::ICMP_SLT:
+      TrueRel = ValueRelation::SLT;
+      FalseRel = ValueRelation::SLE;
+      break;
+    case BuiltinValueKind::ICMP_SGE:
+      TrueRel = ValueRelation::SLT;
+      FalseRel = ValueRelation::SLE;
+      Swap = true;
+      break;
+    case BuiltinValueKind::ICMP_SGT:
+      TrueRel = ValueRelation::SLE;
+      FalseRel = ValueRelation::SLT;
+      Swap = true;
+      break;
+    case BuiltinValueKind::ICMP_ULE:
+      TrueRel = ValueRelation::ULE;
+      FalseRel = ValueRelation::ULT;
+      break;
+    case BuiltinValueKind::ICMP_ULT:
+      TrueRel = ValueRelation::ULT;
+      FalseRel = ValueRelation::ULE;
+      break;
+    case BuiltinValueKind::ICMP_UGT:
+      TrueRel = ValueRelation::ULE;
+      FalseRel = ValueRelation::ULT;
+      Swap = true;
+      break;
+    case BuiltinValueKind::ICMP_UGE:
+      TrueRel = ValueRelation::ULT;
+      FalseRel = ValueRelation::ULE;
+      Swap = true;
+      break;
     }
 
-    // Construct and register the constraint.
-    SILBasicBlock *Dom = CFI->getParent();
-    SILValue Left = BI->getOperand(0);
-    SILValue Right = BI->getOperand(1);
-    Constraint F = Constraint(Dom, Left, Right, Rel);
-    Constraints.push_back(F);
+    SILValue Left = CMP->getOperand(0);
+    SILValue Right = CMP->getOperand(1);
+
+    if (Swap)
+      std::swap(Left, Right);
+
+    // Set the constraints for both side of the conditional branch, if
+    // that the condition is dominating the dest block (see comment above).
+    if (TrueBB)  Constraints.push_back(Constraint(TrueBB,  Left, Right, TrueRel));
+    if (FalseBB) Constraints.push_back(Constraint(FalseBB, Right, Left, FalseRel));
   }
+
+  void registerCondFailFormula(CondFailInst *CFI) {
+    // Extract the arithmetic operation from the condfail.
+    if (auto *TEI = dyn_cast<TupleExtractInst>(CFI->getOperand())) {
+      auto *BI = dyn_cast<BuiltinInst>(TEI->getOperand());
+      if (!BI)
+        return;
+
+      // The relationship expressed in the builtin.
+      Optional<ValueRelation> Rel = getArithOpRelation(BI);
+      if (!Rel.hasValue())
+        return;
+
+      // Construct and register the constraint.
+      SILBasicBlock *Dom = CFI->getParent();
+      SILValue Left = BI->getOperand(0);
+      SILValue Right = BI->getOperand(1);
+      Constraint F = Constraint(Dom, Left, Right, *Rel);
+      Constraints.push_back(F);
+    }
+
+    //  Handle patterns like this:
+    //  %cmp_result = builtin "cmp_ult_Int64"
+    //    (%x : $Builtin.Int64, %y : $Builtin.Int64) : $Builtin.Int1
+    //  This cond_fail formula should be registered!
+    //  cond_fail %cmp_result : $Builtin.Int1
+    //  %check_underflow = integer_literal $Builtin.Int1, -1
+    //  At this point we know that x >= y
+    //  %usub_result = builtin "usub_with_overflow_Int64"
+    //    (%x : $Builtin.Int64, %y : $Builtin.Int64, %check_underflow : $Builtin.Int1):
+    //       $(Builtin.Int64, Builtin.Int1)
+    //  %usub_val = tuple_extract %usub_result : $(Builtin.Int64, Builtin.Int1), 0
+    //  We can figure out that x - y will not underflow because of x >= y
+    //  %usub_underflow = tuple_extract %usub_result : $(Builtin.Int64, Builtin.Int1), 1
+    //  cond_fail %usub_underflow : $Builtin.Int1
+    if (auto *CMP = dyn_cast<BuiltinInst>(CFI->getOperand())) {
+      SILBasicBlock *TrueBB = nullptr;
+      SILBasicBlock *FalseBB = CMP->getParent();
+      addComparisonRelation(CMP, TrueBB, FalseBB);
+    }
+  }
+
 
   void registerBranchFormula(CondBranchInst *BI) {
     // Extract the arithmetic operation from the Branch.
@@ -583,68 +691,7 @@ public:
     if (!FalseBB->getSinglePredecessorBlock())
       FalseBB = nullptr;
 
-    // The relationship expressed in the builtin.
-    ValueRelation Rel;
-    bool Swap = false;
-
-    switch (CMP->getBuiltinInfo().ID) {
-      default: return;
-      case BuiltinValueKind::ICMP_NE: {
-        SILValue Left = CMP->getOperand(0);
-        SILValue Right = CMP->getOperand(1);
-        if (FalseBB)
-          Constraints.push_back(Constraint(FalseBB, Left, Right,
-                                     ValueRelation::EQ));
-        return;
-      }
-      case BuiltinValueKind::ICMP_EQ: {
-        SILValue Left = CMP->getOperand(0);
-        SILValue Right = CMP->getOperand(1);
-        if (TrueBB)
-          Constraints.push_back(Constraint(TrueBB, Left, Right,
-                                     ValueRelation::EQ));
-        return;
-      }
-      case BuiltinValueKind::ICMP_SLE:
-        Rel = ValueRelation::SLE;
-        break;
-      case BuiltinValueKind::ICMP_SLT:
-        Rel = ValueRelation::SLT;
-        break;
-      case BuiltinValueKind::ICMP_SGE:
-        Rel = ValueRelation::SLT;
-        Swap = true;
-        break;
-      case BuiltinValueKind::ICMP_SGT:
-        Rel = ValueRelation::SLE;
-        Swap = true;
-        break;
-      case BuiltinValueKind::ICMP_ULE:
-        Rel = ValueRelation::ULE;
-        break;
-      case BuiltinValueKind::ICMP_ULT:
-        Rel = ValueRelation::ULT;
-        break;
-      case BuiltinValueKind::ICMP_UGT:
-        Rel = ValueRelation::ULE;
-        Swap = true;
-        break;
-      case BuiltinValueKind::ICMP_UGE:
-        Rel = ValueRelation::ULT;
-        Swap = true;
-        break;
-    }
-
-    SILValue Left = CMP->getOperand(0);
-    SILValue Right = CMP->getOperand(1);
-
-    if (Swap)
-      std::swap(Left, Right);
-
-    // Set the constraints for both side of the conditional branch, if
-    // that the condition is dominating the dest block (see comment above).
-    if (TrueBB)  Constraints.push_back(Constraint(TrueBB,  Left, Right, Rel));
-    if (FalseBB) Constraints.push_back(Constraint(FalseBB, Right, Left, Rel));
+    addComparisonRelation(CMP, TrueBB, FalseBB );
   }
 
 };

--- a/test/SILOptimizer/constant_propagation.sil
+++ b/test/SILOptimizer/constant_propagation.sil
@@ -225,16 +225,27 @@ bb0(%0 : $Builtin.Int64):
 // CHECK-NEXT: return
 }
 
-sil @testFoldingIntBinaryPredicates : $@convention(thin) () -> () {
-bb0:
+sil @testFoldingIntBinaryPredicates : $@convention(thin) (Builtin.Int32) -> () {
+bb0(%0 : $Builtin.Int32):
   %1 = integer_literal $Builtin.Int1, 1
   %2 = integer_literal $Builtin.Int1, 0
+  // This is Int32.Max
+  %3 = integer_literal $Builtin.Int32, 2147483647 
   %4 = builtin "cmp_eq_Int1"(%1 : $Builtin.Int1, %2 : $Builtin.Int1) : $Builtin.Int1
   %11 = integer_literal $Builtin.Int32, 21
   %12 = integer_literal $Builtin.Int32, 12
   %14 = builtin "cmp_ne_Int32"(%11 : $Builtin.Int32, %12 : $Builtin.Int32) : $Builtin.Int1
   %16 = builtin "cmp_sgt_Int32"(%12 : $Builtin.Int32, %11 : $Builtin.Int32) : $Builtin.Int1
   %17 = builtin "cmp_ult_Int32"(%12 : $Builtin.Int32, %11 : $Builtin.Int32) : $Builtin.Int1
+  // Int32.Max < x
+  %18 = builtin "cmp_slt_Int32"(%3 : $Builtin.Int32, %0 : $Builtin.Int32) : $Builtin.Int1
+  // x > Int32.Max
+  %19 = builtin "cmp_sgt_Int32"(%0 : $Builtin.Int32, %3 : $Builtin.Int32) : $Builtin.Int1
+  // Int32.Max >= x
+  %20 = builtin "cmp_sge_Int32"(%3 : $Builtin.Int32, %0 : $Builtin.Int32) : $Builtin.Int1
+  // x <= Int32.Max
+  %21 = builtin "cmp_sle_Int32"(%0 : $Builtin.Int32, %3 : $Builtin.Int32) : $Builtin.Int1
+
   %5 = tuple ()
   return %5 : $()
 // CHECK-LABEL: sil @testFoldingIntBinaryPredicates
@@ -242,6 +253,10 @@ bb0:
 // CHECK-NEXT: integer_literal $Builtin.Int1, 0
 // CHECK-NEXT: integer_literal $Builtin.Int1, -1
 // CHECK-NEXT: integer_literal $Builtin.Int1, 0
+// CHECK-NEXT: integer_literal $Builtin.Int1, -1
+// CHECK-NEXT: integer_literal $Builtin.Int1, 0
+// CHECK-NEXT: integer_literal $Builtin.Int1, 0
+// CHECK-NEXT: integer_literal $Builtin.Int1, -1
 // CHECK-NEXT: integer_literal $Builtin.Int1, -1
 // CHECK-NEXT: tuple
 // CHECK-NEXT: return
@@ -290,6 +305,115 @@ bb0:
 // CHECK_NEXT: return %2 : $Builtin.Int64
 }
 
+// For any x of the same size as Int.max and n>=1 , (x>>n) is always <= Int.max,
+// that is (x>>n) <= Int.max and Int.max >= (x>>n) are true.
+// At the same time (x>>n) > Int.max and  Int.max < (x>>n) is always false.
+sil @fold_cmp_lshr_with_IntMax : $@convention(thin) (Builtin.Int64) -> Builtin.Int64 {
+bb0(%0 : $Builtin.Int64):
+  %1 = integer_literal $Builtin.Int64, 9223372036854775807 
+  %2 = integer_literal $Builtin.Int64, 1
+  %3 = integer_literal $Builtin.Int64, 3
+  %4 = integer_literal $Builtin.Int64, 0
+  %5 = integer_literal $Builtin.Int64, -2
+
+  // x >> 1
+  %9 = builtin "lshr_Int64"(%0 : $Builtin.Int64, %2 : $Builtin.Int64) : $Builtin.Int64
+
+  %10 = builtin "cmp_sge_Int64"(%1 : $Builtin.Int64, %9 : $Builtin.Int64) : $Builtin.Int1
+  %11 = builtin "cmp_uge_Int64"(%1 : $Builtin.Int64, %9 : $Builtin.Int64) : $Builtin.Int1
+  %12 = builtin "cmp_sle_Int64"(%9 : $Builtin.Int64, %1 : $Builtin.Int64) : $Builtin.Int1
+  %13 = builtin "cmp_ule_Int64"(%9 : $Builtin.Int64, %1 : $Builtin.Int64) : $Builtin.Int1
+
+  %20 = builtin "cmp_slt_Int64"(%1 : $Builtin.Int64, %9 : $Builtin.Int64) : $Builtin.Int1
+  %21 = builtin "cmp_ult_Int64"(%1 : $Builtin.Int64, %9 : $Builtin.Int64) : $Builtin.Int1
+  %22 = builtin "cmp_sgt_Int64"(%9 : $Builtin.Int64, %1 : $Builtin.Int64) : $Builtin.Int1
+  %23 = builtin "cmp_ugt_Int64"(%9 : $Builtin.Int64, %1 : $Builtin.Int64) : $Builtin.Int1
+
+  // x >> 3
+  %29 = builtin "lshr_Int64"(%0 : $Builtin.Int64, %3 : $Builtin.Int64) : $Builtin.Int64
+
+  %30 = builtin "cmp_sge_Int64"(%1 : $Builtin.Int64, %29 : $Builtin.Int64) : $Builtin.Int1
+  %31 = builtin "cmp_uge_Int64"(%1 : $Builtin.Int64, %29 : $Builtin.Int64) : $Builtin.Int1
+  %32 = builtin "cmp_sle_Int64"(%29 : $Builtin.Int64, %1 : $Builtin.Int64) : $Builtin.Int1
+  %33 = builtin "cmp_ule_Int64"(%29 : $Builtin.Int64, %1 : $Builtin.Int64) : $Builtin.Int1
+
+  %40 = builtin "cmp_slt_Int64"(%1 : $Builtin.Int64, %29 : $Builtin.Int64) : $Builtin.Int1
+  %41 = builtin "cmp_ult_Int64"(%1 : $Builtin.Int64, %29 : $Builtin.Int64) : $Builtin.Int1
+  %42 = builtin "cmp_sgt_Int64"(%29 : $Builtin.Int64, %1 : $Builtin.Int64) : $Builtin.Int1
+  %43 = builtin "cmp_ugt_Int64"(%29 : $Builtin.Int64, %1 : $Builtin.Int64) : $Builtin.Int1
+
+  // Check that this peephole does not happen if the shift amount is < 1
+
+  // x >> 0 (i.e. x shifted by something < 1)
+  %59 = builtin "lshr_Int64"(%0 : $Builtin.Int64, %4 : $Builtin.Int64) : $Builtin.Int64
+
+  %60 = builtin "cmp_sge_Int64"(%1 : $Builtin.Int64, %59 : $Builtin.Int64) : $Builtin.Int1
+  %61 = builtin "cmp_uge_Int64"(%1 : $Builtin.Int64, %59 : $Builtin.Int64) : $Builtin.Int1
+  %62 = builtin "cmp_sle_Int64"(%59 : $Builtin.Int64, %1 : $Builtin.Int64) : $Builtin.Int1
+  %63 = builtin "cmp_ule_Int64"(%59 : $Builtin.Int64, %1 : $Builtin.Int64) : $Builtin.Int1
+
+  %70 = builtin "cmp_slt_Int64"(%1 : $Builtin.Int64, %59 : $Builtin.Int64) : $Builtin.Int1
+  %71 = builtin "cmp_ult_Int64"(%1 : $Builtin.Int64, %59 : $Builtin.Int64) : $Builtin.Int1
+  %72 = builtin "cmp_sgt_Int64"(%59 : $Builtin.Int64, %1 : $Builtin.Int64) : $Builtin.Int1
+  %73 = builtin "cmp_ugt_Int64"(%59 : $Builtin.Int64, %1 : $Builtin.Int64) : $Builtin.Int1
+
+  // x >> -2 (i.e. x shifted by something < 1)
+  %79 = builtin "lshr_Int64"(%0 : $Builtin.Int64, %5 : $Builtin.Int64) : $Builtin.Int64
+
+  %80 = builtin "cmp_sge_Int64"(%1 : $Builtin.Int64, %79 : $Builtin.Int64) : $Builtin.Int1
+  %81 = builtin "cmp_uge_Int64"(%1 : $Builtin.Int64, %79 : $Builtin.Int64) : $Builtin.Int1
+  %82 = builtin "cmp_sle_Int64"(%79 : $Builtin.Int64, %1 : $Builtin.Int64) : $Builtin.Int1
+  %83 = builtin "cmp_ule_Int64"(%79 : $Builtin.Int64, %1 : $Builtin.Int64) : $Builtin.Int1
+
+  %90 = builtin "cmp_slt_Int64"(%1 : $Builtin.Int64, %79 : $Builtin.Int64) : $Builtin.Int1
+  %91 = builtin "cmp_ult_Int64"(%1 : $Builtin.Int64, %79 : $Builtin.Int64) : $Builtin.Int1
+  %92 = builtin "cmp_sgt_Int64"(%79 : $Builtin.Int64, %1 : $Builtin.Int64) : $Builtin.Int1
+  %93 = builtin "cmp_ugt_Int64"(%79 : $Builtin.Int64, %1 : $Builtin.Int64) : $Builtin.Int1
+
+  return %4 : $Builtin.Int64
+
+// CHECK-LABEL: sil @fold_cmp_lshr_with_IntMax
+// CHECK: bb0
+// CHECK-NEXT: integer_literal $Builtin.Int64, 9223372036854775807 
+// CHECK-NEXT: integer_literal $Builtin.Int64, 0
+// CHECK-NEXT: integer_literal $Builtin.Int64, -2
+// CHECK-NEXT: integer_literal $Builtin.Int1, -1
+// CHECK-NEXT: integer_literal $Builtin.Int1, -1
+// CHECK-NEXT: integer_literal $Builtin.Int1, -1
+// CHECK-NEXT: integer_literal $Builtin.Int1, -1
+// CHECK-NEXT: integer_literal $Builtin.Int1, 0
+// CHECK-NEXT: integer_literal $Builtin.Int1, 0
+// CHECK-NEXT: integer_literal $Builtin.Int1, 0
+// CHECK-NEXT: integer_literal $Builtin.Int1, 0
+// CHECK-NEXT: integer_literal $Builtin.Int1, -1
+// CHECK-NEXT: integer_literal $Builtin.Int1, -1
+// CHECK-NEXT: integer_literal $Builtin.Int1, -1
+// CHECK-NEXT: integer_literal $Builtin.Int1, -1
+// CHECK-NEXT: integer_literal $Builtin.Int1, 0
+// CHECK-NEXT: integer_literal $Builtin.Int1, 0
+// CHECK-NEXT: integer_literal $Builtin.Int1, 0
+// CHECK-NEXT: integer_literal $Builtin.Int1, 0
+// CHECK-NEXT: builtin "lshr_Int64"(%0 : $Builtin.Int64, %2 : $Builtin.Int64) : $Builtin.Int64
+// CHECK-NEXT: integer_literal $Builtin.Int1, -1
+// CHECK-NEXT: builtin "cmp_uge_Int64"(%1 : $Builtin.Int64, %20 : $Builtin.Int64) : $Builtin.Int1
+// CHECK-NEXT: integer_literal $Builtin.Int1, -1
+// CHECK-NEXT: builtin "cmp_ule_Int64"(%20 : $Builtin.Int64, %1 : $Builtin.Int64) : $Builtin.Int1
+// CHECK-NEXT: integer_literal $Builtin.Int1, 0
+// CHECK-NEXT: builtin "cmp_ult_Int64"(%1 : $Builtin.Int64, %20 : $Builtin.Int64) : $Builtin.Int1
+// CHECK-NEXT: integer_literal $Builtin.Int1, 0
+// CHECK-NEXT: builtin "cmp_ugt_Int64"(%20 : $Builtin.Int64, %1 : $Builtin.Int64) : $Builtin.Int1
+// CHECK-NEXT: builtin "lshr_Int64"(%0 : $Builtin.Int64, %3 : $Builtin.Int64) : $Builtin.Int64
+// CHECK-NEXT: integer_literal $Builtin.Int1, -1
+// CHECK-NEXT: builtin "cmp_uge_Int64"(%1 : $Builtin.Int64, %29 : $Builtin.Int64) : $Builtin.Int1
+// CHECK-NEXT: integer_literal $Builtin.Int1, -1
+// CHECK-NEXT: builtin "cmp_ule_Int64"(%29 : $Builtin.Int64, %1 : $Builtin.Int64) : $Builtin.Int1
+// CHECK-NEXT: integer_literal $Builtin.Int1, 0
+// CHECK-NEXT: builtin "cmp_ult_Int64"(%1 : $Builtin.Int64, %29 : $Builtin.Int64) : $Builtin.Int1
+// CHECK-NEXT: integer_literal $Builtin.Int1, 0
+// CHECK-NEXT: builtin "cmp_ugt_Int64"(%29 : $Builtin.Int64, %1 : $Builtin.Int64) : $Builtin.Int1
+// CHECK-NEXT: return %2 : $Builtin.Int64
+}
+
 // fold_shifts
 sil @fold_shifts : $@convention(thin) () -> Builtin.Int64 {
 bb0:
@@ -314,6 +438,53 @@ bb0:
 // CHECK-NEXT: %4 = integer_literal $Builtin.Int64, 32
 // CHECK-NEXT: return %4 : $Builtin.Int64
 }
+
+// Fold x < 0 into false, if x is known to be a result of an unsigned
+// operation with overflow checks enabled.
+// At the same time x >= 0 is always true under the same conditions.
+sil @fold_unsigned_op_with_overflow_lt_zero : $@convention(thin) (Builtin.Int64, Builtin.Int64) -> Builtin.Int64 {
+bb0(%0 : $Builtin.Int64, %1 : $Builtin.Int64):
+ %zero  = integer_literal $Builtin.Int64, 0
+ %2 = integer_literal $Builtin.Int1, -1
+
+ %uadd_result = builtin "uadd_with_overflow_Int64"(%0 : $Builtin.Int64, %1 : $Builtin.Int64, %2: $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
+ %uadd_with_overflow_result = tuple_extract %uadd_result : $(Builtin.Int64, Builtin.Int1), 0
+ %uadd_overflow = tuple_extract %uadd_result : $(Builtin.Int64, Builtin.Int1), 1
+ cond_fail %uadd_overflow : $Builtin.Int1
+ %compare_slt_uadd_result = builtin "cmp_slt_Int64"(%uadd_with_overflow_result : $Builtin.Int64, %zero : $Builtin.Int64) : $Builtin.Int1
+ %compare_sge_uadd_result = builtin "cmp_sge_Int64"(%uadd_with_overflow_result : $Builtin.Int64, %zero : $Builtin.Int64) : $Builtin.Int1
+
+
+ %usub_result = builtin "usub_with_overflow_Int64"(%0 : $Builtin.Int64, %1 : $Builtin.Int64, %2: $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
+ %usub_with_overflow_result = tuple_extract %usub_result : $(Builtin.Int64, Builtin.Int1), 0
+ %usub_overflow = tuple_extract %usub_result : $(Builtin.Int64, Builtin.Int1), 1
+ cond_fail %uadd_overflow : $Builtin.Int1
+ %compare_slt_usub_result = builtin "cmp_slt_Int64"(%usub_with_overflow_result : $Builtin.Int64, %zero : $Builtin.Int64) : $Builtin.Int1
+ %compare_sge_usub_result = builtin "cmp_sge_Int64"(%usub_with_overflow_result : $Builtin.Int64, %zero : $Builtin.Int64) : $Builtin.Int1
+
+
+ %umul_result = builtin "umul_with_overflow_Int64"(%0 : $Builtin.Int64, %1 : $Builtin.Int64, %2: $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
+ %umul_with_overflow_result = tuple_extract %umul_result : $(Builtin.Int64, Builtin.Int1), 0
+ %umul_overflow = tuple_extract %umul_result : $(Builtin.Int64, Builtin.Int1), 1
+ cond_fail %umul_overflow : $Builtin.Int1
+ %compare_slt_umul_result = builtin "cmp_slt_Int64"(%umul_with_overflow_result : $Builtin.Int64, %zero : $Builtin.Int64) : $Builtin.Int1
+ %compare_sge_umul_result = builtin "cmp_sge_Int64"(%umul_with_overflow_result : $Builtin.Int64, %zero : $Builtin.Int64) : $Builtin.Int1
+
+ return %uadd_with_overflow_result : $Builtin.Int64
+
+// CHECK-LABEL: sil @fold_unsigned_op_with_overflow_lt_zero
+// CHECK: builtin "uadd_with_overflow_Int64"
+// CHECK: integer_literal $Builtin.Int1, 0 
+// CHECK: integer_literal $Builtin.Int1, -1 
+// CHECK: builtin "usub_with_overflow_Int64"
+// CHECK: integer_literal $Builtin.Int1, 0 
+// CHECK: integer_literal $Builtin.Int1, -1 
+// CHECK: builtin "umul_with_overflow_Int64"
+// CHECK: integer_literal $Builtin.Int1, 0 
+// CHECK: integer_literal $Builtin.Int1, -1 
+// CHECK-NEXT: return {{.*}}$Builtin.Int64
+}
+
 
 // fold_float_operations
 sil @fold_float_operations : $@convention(thin) () -> Builtin.FPIEEE64 {

--- a/test/SILOptimizer/cropoverflow.sil
+++ b/test/SILOptimizer/cropoverflow.sil
@@ -743,3 +743,36 @@ bb0(%0 : $Int8):
   %ret = tuple ()
   return %ret : $()
 }
+
+//  Check that the optimization can handle even patterns like this:
+//  %cmp_result = builtin "cmp_ult_Int64"(%x : $Builtin.Int64, %y : $Builtin.Int64) : $Builtin.Int1
+//  This cond_fail formula should be registered!
+//  cond_fail %cmp_result : $Builtin.Int1
+//  At this point we know that x >= y
+//  %usub_result = builtin "usub_with_overflow_Int64"(%x : $Builtin.Int64, %y : $Builtin.Int64, %check_overfow : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
+//  %usub_val = tuple_extract %usub_result : $(Builtin.Int64, Builtin.Int1), 0
+//  We can figure out that x - y will not underflow because of x >= y
+//  %usub_underverflow = tuple_extract %usub_result : $(Builtin.Int64, Builtin.Int1), 1
+//  cond_fail %usub_underflow : $Builtin.Int1
+
+// CHECK-LABEL: sil @cond_fail_of_cmp
+// CHECK: cond_fail
+// Second cond_fail should be removed, because it never fails.
+// CHECK-NOT: cond_fail
+// CHECK: // end sil function 'cond_fail_of_cmp' 
+sil @cond_fail_of_cmp : $@convention(thin) (Builtin.Int64, Builtin.Int64) -> () {
+bb0(%x : $Builtin.Int64, %y: $Builtin.Int64):
+  %cmp_result = builtin "cmp_ult_Int64"(%x : $Builtin.Int64, %y : $Builtin.Int64) : $Builtin.Int1
+  //  This cond_fail formula should be registered!
+  cond_fail %cmp_result : $Builtin.Int1
+  %check_overflow = integer_literal $Builtin.Int1, -1
+  //  At this point we know that x >= y
+  %usub_result = builtin "usub_with_overflow_Int64"(%x : $Builtin.Int64, %y : $Builtin.Int64, %check_overflow : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
+  %usub_val = tuple_extract %usub_result : $(Builtin.Int64, Builtin.Int1), 0
+  //  We can figure out that x - y will not underflow because of x >= y
+  %usub_underflow = tuple_extract %usub_result : $(Builtin.Int64, Builtin.Int1), 1
+  cond_fail %usub_underflow : $Builtin.Int1
+
+  %ret = tuple ()
+  return %ret : $()
+} // end sil function 'cond_fail_of_cmp'

--- a/test/SILOptimizer/sil_combine.sil
+++ b/test/SILOptimizer/sil_combine.sil
@@ -3151,3 +3151,98 @@ bb0(%0 : $Builtin.Int1):
   return %2 : $Builtin.Int1
 }
 
+// cond_br(xor(x, 1)), t_label, f_label -> cond_br x, f_label, t_label
+// CHECK-LABEL: sil @negate_branch_condition_xor1
+// CHECK: bb0
+// CHECK-NEXT: cond_br %0, bb2, bb1
+sil @negate_branch_condition_xor1 : $@convention(thin) (Builtin.Int1) -> Int32 {
+bb0(%0 : $Builtin.Int1):
+  %5 = integer_literal $Builtin.Int1, -1
+  %9 = builtin "xor_Int1"(%0 : $Builtin.Int1, %5 : $Builtin.Int1) : $Builtin.Int1
+  cond_br %9, bb1, bb2                              // id: %10
+
+bb1:                                                // Preds: bb0
+  %1 = integer_literal $Builtin.Int32, 0
+  %2 = struct $Int32 (%1 : $Builtin.Int32)          // user: %12
+  br bb3(%2 : $Int32)                               // id: %12
+
+bb2:                                                // Preds: bb0
+  %3 = integer_literal $Builtin.Int32, 1
+  %4 = struct $Int32 (%3 : $Builtin.Int32)          // user: %12
+  br bb3(%4 : $Int32)                               // id: %15
+
+bb3(%16 : $Int32):                                  // Preds: bb1 bb2
+  return %16 : $Int32                               // id: %17
+}
+
+// cond_br(xor(1, x)), t_label, f_label -> cond_br x, f_label, t_label
+// CHECK-LABEL: sil @negate_branch_condition_xor2
+// CHECK: bb0
+// CHECK-NEXT: cond_br %0, bb2, bb1
+sil @negate_branch_condition_xor2 : $@convention(thin) (Builtin.Int1) -> Int32 {
+bb0(%0 : $Builtin.Int1):
+  %5 = integer_literal $Builtin.Int1, -1
+  %9 = builtin "xor_Int1"(%5 : $Builtin.Int1, %0 : $Builtin.Int1) : $Builtin.Int1
+  cond_br %9, bb1, bb2                              // id: %10
+
+bb1:                                                // Preds: bb0
+  %1 = integer_literal $Builtin.Int32, 0
+  %2 = struct $Int32 (%1 : $Builtin.Int32)          // user: %12
+  br bb3(%2 : $Int32)                               // id: %12
+
+bb2:                                                // Preds: bb0
+  %3 = integer_literal $Builtin.Int32, 1
+  %4 = struct $Int32 (%3 : $Builtin.Int32)          // user: %12
+  br bb3(%4 : $Int32)                               // id: %15
+
+bb3(%16 : $Int32):                                  // Preds: bb1 bb2
+  return %16 : $Int32                               // id: %17
+}
+
+// cond_br(x == 0), t_label, f_label -> cond_br x, f_label, t_label
+// CHECK-LABEL: sil @negate_branch_condition_eq_false
+// CHECK: bb0
+// CHECK-NEXT: cond_br %0, bb2, bb1
+sil @negate_branch_condition_eq_false : $@convention(thin) (Builtin.Int1) -> Int32 {
+bb0(%0 : $Builtin.Int1):
+  %5 = integer_literal $Builtin.Int1, 0
+  %9 = builtin "cmp_eq_Int1"(%0 : $Builtin.Int1, %5 : $Builtin.Int1) : $Builtin.Int1
+  cond_br %9, bb1, bb2                              // id: %10
+
+bb1:                                                // Preds: bb0
+  %1 = integer_literal $Builtin.Int32, 0
+  %2 = struct $Int32 (%1 : $Builtin.Int32)          // user: %12
+  br bb3(%2 : $Int32)                               // id: %12
+
+bb2:                                                // Preds: bb0
+  %3 = integer_literal $Builtin.Int32, 1
+  %4 = struct $Int32 (%3 : $Builtin.Int32)          // user: %12
+  br bb3(%4 : $Int32)                               // id: %15
+
+bb3(%16 : $Int32):                                  // Preds: bb1 bb2
+  return %16 : $Int32                               // id: %17
+}
+
+// cond_br(x != -1), t_label, f_label -> cond_br x, f_label, t_label
+// CHECK-LABEL: sil @negate_branch_condition_ne_true
+// CHECK: bb0
+// CHECK-NEXT: cond_br %0, bb2, bb1
+sil @negate_branch_condition_ne_true : $@convention(thin) (Builtin.Int1) -> Int32 {
+bb0(%0 : $Builtin.Int1):
+  %5 = integer_literal $Builtin.Int1, -1
+  %9 = builtin "cmp_ne_Int1"(%0 : $Builtin.Int1, %5 : $Builtin.Int1) : $Builtin.Int1
+  cond_br %9, bb1, bb2                              // id: %10
+
+bb1:                                                // Preds: bb0
+  %1 = integer_literal $Builtin.Int32, 0
+  %2 = struct $Int32 (%1 : $Builtin.Int32)          // user: %12
+  br bb3(%2 : $Int32)                               // id: %12
+
+bb2:                                                // Preds: bb0
+  %3 = integer_literal $Builtin.Int32, 1
+  %4 = struct $Int32 (%3 : $Builtin.Int32)          // user: %12
+  br bb3(%4 : $Int32)                               // id: %15
+
+bb3(%16 : $Int32):                                  // Preds: bb1 bb2
+  return %16 : $Int32                               // id: %17
+}

--- a/test/SILOptimizer/sil_combine.sil
+++ b/test/SILOptimizer/sil_combine.sil
@@ -3132,3 +3132,22 @@ bb0:
   %3 = tuple ()
   return %3 : $()
 }
+
+// Int1_const == x -> x == Int1_const
+// CHECK-LABEL: sil @canonicalize_bool_eq_checks
+sil @canonicalize_bool_eq_checks : $@convention(thin) (Builtin.Int1) -> Builtin.Int1 {
+bb0(%0 : $Builtin.Int1):
+  %1 = integer_literal $Builtin.Int1, 0
+  %2 = builtin "cmp_eq_Int1"(%1 : $Builtin.Int1, %0 : $Builtin.Int1) : $Builtin.Int1
+  return %2 : $Builtin.Int1
+}
+
+// Int1_const != x -> x != Int1_const
+// CHECK-LABEL: sil @canonicalize_bool_ne_checks
+sil @canonicalize_bool_ne_checks : $@convention(thin) (Builtin.Int1) -> Builtin.Int1 {
+bb0(%0 : $Builtin.Int1):
+  %1 = integer_literal $Builtin.Int1, 0
+  %2 = builtin "cmp_ne_Int1"(%1 : $Builtin.Int1, %0 : $Builtin.Int1) : $Builtin.Int1
+  return %2 : $Builtin.Int1
+}
+


### PR DESCRIPTION
A set of of small peepholes to improve the performance of new integers:
- peepholes for comparisons with Int.Max
- peepholes for some variants of cond_br
- some overflow-check-removal improvements.

Requested by @airspeedswift 