### PR TITLE
IRGen: Enums - Use memcpy for indirectly primitive copying fixed size types

### DIFF
--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -1314,16 +1314,7 @@ namespace {
     /// Do a primitive copy of the enum from one address to another.
     void emitPrimitiveCopy(IRGenFunction &IGF, Address dest, Address src,
                            SILType T) const {
-      // If the layout is fixed, load and store the fixed-size payload and tag.
-      if (TIK >= Fixed) {
-        EnumPayload payload;
-        llvm::Value *extraTag;
-        std::tie(payload, extraTag)
-          = emitPrimitiveLoadPayloadAndExtraTag(IGF, src);
-        emitPrimitiveStorePayloadAndExtraTag(IGF, dest, payload, extraTag);
-        return;
-      }
-
+      // If the layout is fixed, the size will be a constant.
       // Otherwise, do a memcpy of the dynamic size of the type.
       IGF.Builder.CreateMemCpy(dest.getAddress(), src.getAddress(),
                                TI->getSize(IGF, T),

--- a/test/IRGen/enum.sil
+++ b/test/IRGen/enum.sil
@@ -2647,6 +2647,34 @@ bb4:
   return %9 : $()
 }
 
+struct LargeStruct {
+  var x: Builtin.Int64
+  var x2: Builtin.Int64
+  var x3: Builtin.Int64
+  var x4: Builtin.Int64
+  var x5: Builtin.Int64
+  var x6: Builtin.NativeObject
+}
+
+enum MyOptional {
+  case None
+  case Some(LargeStruct)
+}
+
+// Make sure we use a memcpy for the none branch of the enum copy.
+
+// CHECK-LABEL: define{{.*}} @test_large_optional
+// CHECK: llvm.memcpy
+// CHECK: ret void
+sil @test_large_optional : $@convention(thin) (@in MyOptional) -> () {
+entry(%x : $*MyOptional):
+ %stk = alloc_stack $MyOptional
+ copy_addr %x to [initialization] %stk : $*MyOptional
+ dealloc_stack %stk: $*MyOptional
+ %tuple = tuple ()
+ return %tuple : $()
+}
+
 // -- Fill function for dynamic singleton. The value witness table flags just
 //    get copied over from the element.
 // CHECK: define{{( protected)?}} private %swift.type* @create_generic_metadata_DynamicSingleton(%swift.type_pattern*, i8**) {{.*}} {


### PR DESCRIPTION

There is no value in exploding the schema. Exploding the schema only increases
code size for large enums.

rdar://31685718