### PR TITLE
[Serialization] Drop decls whose types can't be deserialized.

### DIFF
--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -44,7 +44,7 @@ const unsigned char MODULE_DOC_SIGNATURE[] = { 0xE2, 0x9C, 0xA8, 0x07 };
 
 /// Serialized module format major version number.
 ///
-/// Always 0 for Swift 1.x - 3.x.
+/// Always 0 for Swift 1.x - 4.x.
 const uint16_t VERSION_MAJOR = 0;
 
 /// Serialized module format minor version number.
@@ -54,7 +54,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// in source control, you should also update the comment to briefly
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
-const uint16_t VERSION_MINOR = 338; // Last change: OPERAND_WITH_ATTR format.
+const uint16_t VERSION_MINOR = 339; // Last change: member canonical types
 
 using DeclID = PointerEmbeddedInt<unsigned, 31>;
 using DeclIDField = BCFixed<31>;
@@ -858,7 +858,8 @@ namespace decls_block {
     BCFixed<1>,  // throws?
     CtorInitializerKindField,  // initializer kind
     GenericEnvironmentIDField, // generic environment
-    TypeIDField, // type (interface)
+    TypeIDField, // interface type
+    TypeIDField, // canonical interface type
     DeclIDField, // overridden decl
     AccessibilityKindField, // accessibility
     BCArray<IdentifierIDField> // argument names
@@ -877,6 +878,7 @@ namespace decls_block {
     BCFixed<1>,   // HasNonPatternBindingInit?
     StorageKindField,   // StorageKind
     TypeIDField,  // interface type
+    TypeIDField,  // canonical interface type
     DeclIDField,  // getter
     DeclIDField,  // setter
     DeclIDField,  // materializeForSet
@@ -911,6 +913,7 @@ namespace decls_block {
     BCVBR<5>,     // number of parameter patterns
     GenericEnvironmentIDField, // generic environment
     TypeIDField,  // interface type
+    TypeIDField,  // canonical interface type
     DeclIDField,  // operator decl
     DeclIDField,  // overridden function
     DeclIDField,  // AccessorStorageDecl
@@ -982,6 +985,7 @@ namespace decls_block {
     StorageKindField,   // StorageKind
     GenericEnvironmentIDField, // generic environment
     TypeIDField, // interface type
+    TypeIDField,  // canonical interface type
     DeclIDField, // getter
     DeclIDField, // setter
     DeclIDField, // materializeForSet

--- a/lib/Serialization/DeserializationErrors.h
+++ b/lib/Serialization/DeserializationErrors.h
@@ -1,0 +1,254 @@
+//===--- DeserializationErrors.h - Problems in deserialization --*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SERIALIZATION_DESERIALIZATIONERRORS_H
+#define SWIFT_SERIALIZATION_DESERIALIZATIONERRORS_H
+
+#include "swift/AST/Identifier.h"
+#include "swift/AST/Module.h"
+#include "swift/Serialization/ModuleFormat.h"
+#include "llvm/Support/Error.h"
+
+namespace swift {
+namespace serialization {
+
+class XRefTracePath {
+  class PathPiece {
+  public:
+    enum class Kind {
+      Value,
+      Type,
+      Operator,
+      OperatorFilter,
+      Accessor,
+      Extension,
+      GenericParam,
+      Unknown
+    };
+
+  private:
+    Kind kind;
+    void *data;
+
+    template <typename T>
+    T getDataAs() const {
+      return llvm::PointerLikeTypeTraits<T>::getFromVoidPointer(data);
+    }
+
+  public:
+    template <typename T>
+    PathPiece(Kind K, T value)
+      : kind(K),
+        data(llvm::PointerLikeTypeTraits<T>::getAsVoidPointer(value)) {}
+
+    void print(raw_ostream &os) const {
+      switch (kind) {
+      case Kind::Value:
+        os << getDataAs<Identifier>();
+        break;
+      case Kind::Type:
+        os << "with type " << getDataAs<Type>();
+        break;
+      case Kind::Extension:
+        if (getDataAs<ModuleDecl *>()) {
+          os << "in an extension in module '"
+             << getDataAs<ModuleDecl *>()->getName()
+             << "'";
+        } else {
+          os << "in an extension in any module";
+        }
+        break;
+      case Kind::Operator:
+        os << "operator " << getDataAs<Identifier>();
+        break;
+      case Kind::OperatorFilter:
+        switch (getDataAs<uintptr_t>()) {
+        case Infix:
+          os << "(infix)";
+          break;
+        case Prefix:
+          os << "(prefix)";
+          break;
+        case Postfix:
+          os << "(postfix)";
+          break;
+        default:
+          os << "(unknown operator filter)";
+          break;
+        }
+        break;
+      case Kind::Accessor:
+        switch (getDataAs<uintptr_t>()) {
+        case Getter:
+          os << "(getter)";
+          break;
+        case Setter:
+          os << "(setter)";
+          break;
+        case MaterializeForSet:
+          os << "(materializeForSet)";
+          break;
+        case Addressor:
+          os << "(addressor)";
+          break;
+        case MutableAddressor:
+          os << "(mutableAddressor)";
+          break;
+        case WillSet:
+          os << "(willSet)";
+          break;
+        case DidSet:
+          os << "(didSet)";
+          break;
+        default:
+          os << "(unknown accessor kind)";
+          break;
+        }
+        break;
+      case Kind::GenericParam:
+        os << "generic param #" << getDataAs<uintptr_t>();
+        break;
+      case Kind::Unknown:
+        os << "unknown xref kind " << getDataAs<uintptr_t>();
+        break;
+      }
+    }
+  };
+
+  ModuleDecl &baseM;
+  SmallVector<PathPiece, 8> path;
+
+public:
+  explicit XRefTracePath(ModuleDecl &M) : baseM(M) {}
+
+  void addValue(Identifier name) {
+    path.push_back({ PathPiece::Kind::Value, name });
+  }
+
+  void addType(Type ty) {
+    path.push_back({ PathPiece::Kind::Type, ty });
+  }
+
+  void addOperator(Identifier name) {
+    path.push_back({ PathPiece::Kind::Operator, name });
+  }
+
+  void addOperatorFilter(uint8_t fixity) {
+    path.push_back({ PathPiece::Kind::OperatorFilter,
+                     static_cast<uintptr_t>(fixity) });
+  }
+
+  void addAccessor(uint8_t kind) {
+    path.push_back({ PathPiece::Kind::Accessor,
+                     static_cast<uintptr_t>(kind) });
+  }
+
+  void addExtension(ModuleDecl *M) {
+    path.push_back({ PathPiece::Kind::Extension, M });
+  }
+
+  void addGenericParam(uintptr_t index) {
+    path.push_back({ PathPiece::Kind::GenericParam, index });
+  }
+
+  void addUnknown(uintptr_t kind) {
+    path.push_back({ PathPiece::Kind::Unknown, kind });
+  }
+
+  void removeLast() {
+    path.pop_back();
+  }
+
+  void print(raw_ostream &os, StringRef leading = "") const {
+    os << "Cross-reference to module '" << baseM.getName() << "'\n";
+    for (auto &piece : path) {
+      os << leading << "... ";
+      piece.print(os);
+      os << "\n";
+    }
+  }
+};
+
+class DeclDeserializationError : public llvm::ErrorInfoBase {
+  static const char ID;
+  void anchor() override;
+
+public:
+  enum Kind {
+    Normal,
+    DesignatedInitializer
+  };
+
+protected:
+  Kind kind = Normal;
+
+public:
+  Kind getKind() const {
+    return kind;
+  }
+
+  bool isA(const void *const ClassID) const override {
+    return ClassID == classID() || ErrorInfoBase::isA(ClassID);
+  }
+
+  static const void *classID() { return &ID; }
+};
+
+class XRefError : public llvm::ErrorInfo<XRefError, DeclDeserializationError> {
+  friend ErrorInfo;
+  static const char ID;
+  void anchor() override;
+
+  XRefTracePath path;
+  const char *message;
+public:
+  template <size_t N>
+  XRefError(const char (&message)[N], XRefTracePath path)
+      : path(path), message(message) {}
+
+  void log(raw_ostream &OS) const override {
+    OS << message << "\n";
+    path.print(OS);
+  }
+
+  std::error_code convertToErrorCode() const override {
+    return llvm::inconvertibleErrorCode();
+  }
+};
+
+class OverrideError : public llvm::ErrorInfo<OverrideError,
+                                             DeclDeserializationError> {
+private:
+  friend ErrorInfo;
+  static const char ID;
+  void anchor() override;
+
+  DeclName name;
+
+public:
+  explicit OverrideError(DeclName name, Kind kind = Normal) : name(name) {
+    this->kind = kind;
+  }
+
+  void log(raw_ostream &OS) const override {
+    OS << "could not find '" << name << "' in parent class";
+  }
+
+  std::error_code convertToErrorCode() const override {
+    return llvm::inconvertibleErrorCode();
+  }
+};
+
+} // end namespace serialization
+} // end namespace swift
+
+#endif

--- a/lib/Serialization/DeserializationErrors.h
+++ b/lib/Serialization/DeserializationErrors.h
@@ -256,8 +256,11 @@ class TypeError : public llvm::ErrorInfo<TypeError, DeclDeserializationError> {
   DeclName name;
   std::unique_ptr<ErrorInfoBase> underlyingReason;
 public:
-  explicit TypeError(DeclName name, std::unique_ptr<ErrorInfoBase> reason)
-      : name(name), underlyingReason(std::move(reason)) {}
+  explicit TypeError(DeclName name, std::unique_ptr<ErrorInfoBase> reason,
+                     Kind kind = Normal)
+      : name(name), underlyingReason(std::move(reason)) {
+    this->kind = kind;
+  }
 
   void log(raw_ostream &OS) const override {
     OS << "could not deserialize type for '" << name << "'";

--- a/lib/Serialization/DeserializationErrors.h
+++ b/lib/Serialization/DeserializationErrors.h
@@ -248,6 +248,30 @@ public:
   }
 };
 
+class TypeError : public llvm::ErrorInfo<TypeError, DeclDeserializationError> {
+  friend ErrorInfo;
+  static const char ID;
+  void anchor() override;
+
+  DeclName name;
+  std::unique_ptr<ErrorInfoBase> underlyingReason;
+public:
+  explicit TypeError(DeclName name, std::unique_ptr<ErrorInfoBase> reason)
+      : name(name), underlyingReason(std::move(reason)) {}
+
+  void log(raw_ostream &OS) const override {
+    OS << "could not deserialize type for '" << name << "'";
+    if (underlyingReason) {
+      OS << ": ";
+      underlyingReason->log(OS);
+    }
+  }
+
+  std::error_code convertToErrorCode() const override {
+    return llvm::inconvertibleErrorCode();
+  }
+};
+
 } // end namespace serialization
 } // end namespace swift
 

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/Serialization/ModuleFile.h"
+#include "DeserializationErrors.h"
 #include "swift/Serialization/ModuleFormat.h"
 #include "swift/Subsystems.h"
 #include "swift/AST/ASTContext.h"
@@ -31,6 +32,7 @@
 using namespace swift;
 using namespace swift::serialization;
 using namespace llvm::support;
+using llvm::Expected;
 
 static bool checkModuleSignature(llvm::BitstreamCursor &cursor) {
   for (unsigned char byte : MODULE_SIGNATURE)
@@ -1310,17 +1312,17 @@ void ModuleFile::lookupValue(DeclName name,
     // serialized.
     auto iter = TopLevelDecls->find(name.getBaseName());
     if (iter != TopLevelDecls->end()) {
-      if (name.isSimpleName()) {
-        for (auto item : *iter) {
-          auto VD = cast<ValueDecl>(getDecl(item.second));
+      for (auto item : *iter) {
+        Expected<Decl *> declOrError = getDeclChecked(item.second);
+        if (!declOrError) {
+          if (!getContext().LangOpts.EnableDeserializationRecovery)
+            fatal(declOrError.takeError());
+          llvm::consumeError(declOrError.takeError());
+          continue;
+        }
+        auto VD = cast<ValueDecl>(declOrError.get());
+        if (name.isSimpleName() || VD->getFullName().matchesRef(name))
           results.push_back(VD);
-        }
-      } else {
-        for (auto item : *iter) {
-          auto VD = cast<ValueDecl>(getDecl(item.second));
-          if (VD->getFullName().matchesRef(name))
-            results.push_back(VD);
-        }
       }
     }
   }
@@ -1503,21 +1505,32 @@ void ModuleFile::lookupVisibleDecls(ModuleDecl::AccessPathTy accessPath,
   if (!TopLevelDecls)
     return;
 
+  auto tryImport = [this, &consumer](DeclID ID) {
+    Expected<Decl *> declOrError = getDeclChecked(ID);
+    if (!declOrError) {
+      if (!getContext().LangOpts.EnableDeserializationRecovery)
+        fatal(declOrError.takeError());
+      llvm::consumeError(declOrError.takeError());
+      return;
+    }
+    consumer.foundDecl(cast<ValueDecl>(declOrError.get()),
+                       DeclVisibilityKind::VisibleAtTopLevel);
+  };
+
   if (!accessPath.empty()) {
     auto iter = TopLevelDecls->find(accessPath.front().first);
     if (iter == TopLevelDecls->end())
       return;
 
     for (auto item : *iter)
-      consumer.foundDecl(cast<ValueDecl>(getDecl(item.second)),
-                         DeclVisibilityKind::VisibleAtTopLevel);
+      tryImport(item.second);
+
     return;
   }
 
   for (auto entry : TopLevelDecls->data()) {
     for (auto item : entry)
-      consumer.foundDecl(cast<ValueDecl>(getDecl(item.second)),
-                         DeclVisibilityKind::VisibleAtTopLevel);
+      tryImport(item.second);
   }
 }
 
@@ -1711,8 +1724,16 @@ void ModuleFile::getTopLevelDecls(SmallVectorImpl<Decl *> &results) {
 
   if (TopLevelDecls) {
     for (auto entry : TopLevelDecls->data()) {
-      for (auto item : entry)
-        results.push_back(getDecl(item.second));
+      for (auto item : entry) {
+        Expected<Decl *> declOrError = getDeclChecked(item.second);
+        if (!declOrError) {
+          if (!getContext().LangOpts.EnableDeserializationRecovery)
+            fatal(declOrError.takeError());
+          llvm::consumeError(declOrError.takeError());
+          continue;
+        }
+        results.push_back(declOrError.get());
+      }
     }
   }
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2761,6 +2761,7 @@ void Serializer::writeDecl(const Decl *D) {
     if (var->isSettable(nullptr))
       rawSetterAccessLevel =
         getRawStableAccessibility(var->getSetterAccessibility());
+    Type ty = var->getInterfaceType();
 
     unsigned abbrCode = DeclTypeAbbrCodes[VarLayout::Code];
     VarLayout::emitRecord(Out, ScratchRecord, abbrCode,
@@ -2772,7 +2773,8 @@ void Serializer::writeDecl(const Decl *D) {
                           var->isLet(),
                           var->hasNonPatternBindingInit(),
                           (unsigned) accessors.Kind,
-                          addTypeRef(var->getInterfaceType()),
+                          addTypeRef(ty),
+                          addTypeRef(ty->getCanonicalType()),
                           addDeclRef(accessors.Get),
                           addDeclRef(accessors.Set),
                           addDeclRef(accessors.MaterializeForSet),
@@ -2824,6 +2826,7 @@ void Serializer::writeDecl(const Decl *D) {
       getRawStableAccessibility(fn->getFormalAccess());
     uint8_t rawAddressorKind =
       getRawStableAddressorKind(fn->getAddressorKind());
+    Type ty = fn->getInterfaceType();
 
     FuncLayout::emitRecord(Out, ScratchRecord, abbrCode,
                            contextID,
@@ -2838,7 +2841,8 @@ void Serializer::writeDecl(const Decl *D) {
                            fn->getParameterLists().size(),
                            addGenericEnvironmentRef(
                                                   fn->getGenericEnvironment()),
-                           addTypeRef(fn->getInterfaceType()),
+                           addTypeRef(ty),
+                           addTypeRef(ty->getCanonicalType()),
                            addDeclRef(fn->getOperatorDecl()),
                            addDeclRef(fn->getOverriddenDecl()),
                            addDeclRef(fn->getAccessorStorageDecl()),
@@ -2906,6 +2910,7 @@ void Serializer::writeDecl(const Decl *D) {
     if (subscript->isSettable())
       rawSetterAccessLevel =
         getRawStableAccessibility(subscript->getSetterAccessibility());
+    Type ty = subscript->getInterfaceType();
 
     unsigned abbrCode = DeclTypeAbbrCodes[SubscriptLayout::Code];
     SubscriptLayout::emitRecord(Out, ScratchRecord, abbrCode,
@@ -2915,7 +2920,8 @@ void Serializer::writeDecl(const Decl *D) {
                                 (unsigned) accessors.Kind,
                                 addGenericEnvironmentRef(
                                             subscript->getGenericEnvironment()),
-                                addTypeRef(subscript->getInterfaceType()),
+                                addTypeRef(ty),
+                                addTypeRef(ty->getCanonicalType()),
                                 addDeclRef(accessors.Get),
                                 addDeclRef(accessors.Set),
                                 addDeclRef(accessors.MaterializeForSet),
@@ -2946,6 +2952,7 @@ void Serializer::writeDecl(const Decl *D) {
 
     uint8_t rawAccessLevel =
       getRawStableAccessibility(ctor->getFormalAccess());
+    Type ty = ctor->getInterfaceType();
 
     unsigned abbrCode = DeclTypeAbbrCodes[ConstructorLayout::Code];
     ConstructorLayout::emitRecord(Out, ScratchRecord, abbrCode,
@@ -2960,7 +2967,8 @@ void Serializer::writeDecl(const Decl *D) {
                                     ctor->getInitKind()),
                                   addGenericEnvironmentRef(
                                                  ctor->getGenericEnvironment()),
-                                  addTypeRef(ctor->getInterfaceType()),
+                                  addTypeRef(ty),
+                                  addTypeRef(ty->getCanonicalType()),
                                   addDeclRef(ctor->getOverriddenDecl()),
                                   rawAccessLevel,
                                   nameComponents);

--- a/test/Serialization/Recovery/Inputs/custom-modules/TypeRemovalObjC.h
+++ b/test/Serialization/Recovery/Inputs/custom-modules/TypeRemovalObjC.h
@@ -1,0 +1,18 @@
+@protocol AProto
+@end
+
+#if !BAD
+__attribute__((objc_root_class))
+@interface Base
+- (instancetype)init;
+@end
+
+@interface Generic<T>: Base
+@end
+
+@protocol SomeProto
+@end
+#endif
+
+@protocol ZProto
+@end

--- a/test/Serialization/Recovery/Inputs/custom-modules/Typedefs.h
+++ b/test/Serialization/Recovery/Inputs/custom-modules/Typedefs.h
@@ -9,3 +9,11 @@ struct ImportedType {
 };
 
 typedef MysteryTypedef ImportedTypeAssoc __attribute__((swift_name("ImportedType.Assoc")));
+
+#if !BAD
+typedef int WrappedInt __attribute__((swift_wrapper(struct)));
+typedef int UnwrappedInt;
+#else
+typedef int WrappedInt;
+typedef int UnwrappedInt __attribute__((swift_wrapper(struct)));
+#endif

--- a/test/Serialization/Recovery/Inputs/custom-modules/module.modulemap
+++ b/test/Serialization/Recovery/Inputs/custom-modules/module.modulemap
@@ -1,3 +1,4 @@
 module Overrides { header "Overrides.h" }
 module Typedefs { header "Typedefs.h" }
+module TypeRemovalObjC { header "TypeRemovalObjC.h" }
 module Types { header "Types.h" }

--- a/test/Serialization/Recovery/overrides.swift
+++ b/test/Serialization/Recovery/overrides.swift
@@ -74,6 +74,11 @@ public class A_Sub: Base {
   public override var disappearingProperty: Int { return 0 }
 }
 
+public class A_Sub2: A_Sub {
+  public override func disappearingMethod() {}
+}
+
+
 // CHECK-LABEL: class A_Sub : Base {
 // CHECK-NEXT: func disappearingMethod()
 // CHECK-NEXT: func nullabilityChangeMethod() -> Any?
@@ -83,7 +88,16 @@ public class A_Sub: Base {
 // CHECK-NEXT: init()
 // CHECK-NEXT: {{^}$}}
 
+// CHECK-LABEL: class A_Sub2 : A_Sub {
+// CHECK-NEXT: func disappearingMethod()
+// CHECK-NEXT: init()
+// CHECK-NEXT: {{^}$}}
+
 // CHECK-RECOVERY-LABEL: class A_Sub : Base {
+// CHECK-RECOVERY-NEXT: init()
+// CHECK-RECOVERY-NEXT: {{^}$}}
+
+// CHECK-RECOVERY-LABEL: class A_Sub2 : A_Sub {
 // CHECK-RECOVERY-NEXT: init()
 // CHECK-RECOVERY-NEXT: {{^}$}}
 

--- a/test/Serialization/Recovery/type-removal-objc.swift
+++ b/test/Serialization/Recovery/type-removal-objc.swift
@@ -1,0 +1,45 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: %target-swift-frontend -emit-module -o %t -module-name Lib -I %S/Inputs/custom-modules %s
+
+// RUN: %target-swift-ide-test -source-filename=x -print-module -module-to-print Lib -I %t -I %S/Inputs/custom-modules | %FileCheck %s
+
+// RUN: %target-swift-ide-test -source-filename=x -print-module -module-to-print Lib -I %t -I %S/Inputs/custom-modules -Xcc -DBAD -enable-experimental-deserialization-recovery > %t.txt
+// RUN: %FileCheck -check-prefix CHECK-RECOVERY %s < %t.txt
+// RUN: %FileCheck -check-prefix CHECK-RECOVERY-NEGATIVE %s < %t.txt
+
+// REQUIRES: objc_interop
+
+import TypeRemovalObjC
+
+// CHECK-DAG: let simple: AnyObject?
+// CHECK-RECOVERY-DAG: let simple: AnyObject?
+public let simple: AnyObject? = nil
+
+// CHECK-DAG: let someObject: Base?
+// CHECK-RECOVERY-NEGATIVE-NOT: let someObject:
+public let someObject: Base? = nil
+// CHECK-DAG: let someGenericObject: Generic<AnyObject>?
+// CHECK-RECOVERY-NEGATIVE-NOT: let someGenericObject:
+public let someGenericObject: Generic<AnyObject>? = nil
+// CHECK-DAG: let someProtoValue: SomeProto?
+// CHECK-RECOVERY-NEGATIVE-NOT: let someProtoValue:
+public let someProtoValue: SomeProto? = nil
+// CHECK-DAG: let someProtoType: SomeProto.Type?
+// CHECK-RECOVERY-NEGATIVE-NOT: let someProtoType:
+public let someProtoType: SomeProto.Type? = nil
+// CHECK-DAG: let someProtoCompositionValue: (AProto & SomeProto)?
+// CHECK-RECOVERY-NEGATIVE-NOT: let someProtoCompositionValue:
+public let someProtoCompositionValue: (AProto & SomeProto)? = nil
+// CHECK-DAG: let someProtoCompositionValue2: (SomeProto & ZProto)?
+// CHECK-RECOVERY-NEGATIVE-NOT: let someProtoCompositionValue2:
+public let someProtoCompositionValue2: (SomeProto & ZProto)? = nil
+
+// CHECK-DAG: unowned var someUnownedObject: @sil_unowned Base
+// CHECK-RECOVERY-NEGATIVE-NOT: var someUnownedObject:
+public unowned var someUnownedObject: Base = Base()
+// CHECK-DAG: unowned(unsafe) var someUnownedUnsafeObject: @sil_unmanaged Base
+// CHECK-RECOVERY-NEGATIVE-NOT: var someUnownedUnsafeObject:
+public unowned(unsafe) var someUnownedUnsafeObject: Base = Base()
+// CHECK-DAG: weak var someWeakObject: @sil_weak Base
+// CHECK-RECOVERY-NEGATIVE-NOT: var someWeakObject:
+public weak var someWeakObject: Base? = nil

--- a/test/Serialization/Recovery/typedefs.swift
+++ b/test/Serialization/Recovery/typedefs.swift
@@ -36,6 +36,9 @@ let _: Int32? = useAssoc(AnotherType.self)
 let _ = wrapped // expected-error {{use of unresolved identifier 'wrapped'}}
 let _ = unwrapped // okay
 
+_ = usesWrapped(nil) // expected-error {{use of unresolved identifier 'usesWrapped'}}
+_ = usesUnwrapped(nil) // expected-error {{nil is not compatible with expected argument type 'Int32'}}
+
 #endif // VERIFY
 
 #else // TEST
@@ -123,5 +126,20 @@ public var normalFirst: Int?, wrappedSecond: WrappedInt?
 // CHECK-RECOVERY-NEGATIVE-NOT: var wrappedThird:
 // CHECK-RECOVERY-NEGATIVE-NOT: var wrappedFourth:
 public var wrappedThird, wrappedFourth: WrappedInt?
+
+// CHECK-DAG: func usesWrapped(_ wrapped: WrappedInt)
+// CHECK-RECOVERY-NEGATIVE-NOT: func usesWrapped(
+public func usesWrapped(_ wrapped: WrappedInt) {}
+// CHECK-DAG: func usesUnwrapped(_ unwrapped: UnwrappedInt)
+// CHECK-RECOVERY-DAG: func usesUnwrapped(_ unwrapped: Int32)
+public func usesUnwrapped(_ unwrapped: UnwrappedInt) {}
+
+// CHECK-DAG: func returnsWrapped() -> WrappedInt
+// CHECK-RECOVERY-NEGATIVE-NOT: func returnsWrapped(
+public func returnsWrapped() -> WrappedInt { fatalError() }
+
+// CHECK-DAG: func returnsWrappedGeneric<T>(_: T.Type) -> WrappedInt
+// CHECK-RECOVERY-NEGATIVE-NOT: func returnsWrappedGeneric
+public func returnsWrappedGeneric<T>(_: T.Type) -> WrappedInt { fatalError() }
 
 #endif // TEST

--- a/test/Serialization/Recovery/typedefs.swift
+++ b/test/Serialization/Recovery/typedefs.swift
@@ -35,6 +35,7 @@ let _: Int32? = useAssoc(AnotherType.self)
 
 let _ = wrapped // expected-error {{use of unresolved identifier 'wrapped'}}
 let _ = unwrapped // okay
+
 #endif // VERIFY
 
 #else // TEST
@@ -71,5 +72,56 @@ public let wrapped = WrappedInt(0)
 // CHECK-DAG: let unwrapped: UnwrappedInt
 // CHECK-RECOVERY-DAG: let unwrapped: Int32
 public let unwrapped: UnwrappedInt = 0
+
+// CHECK-DAG: let wrappedMetatype: WrappedInt.Type
+// CHECK-RECOVERY-NEGATIVE-NOT: let wrappedMetatype:
+public let wrappedMetatype = WrappedInt.self
+// CHECK-DAG: let wrappedOptional: WrappedInt?
+// CHECK-RECOVERY-NEGATIVE-NOT: let wrappedOptional:
+public let wrappedOptional: WrappedInt? = nil
+// CHECK-DAG: let wrappedIUO: WrappedInt!
+// CHECK-RECOVERY-NEGATIVE-NOT: let wrappedIUO:
+public let wrappedIUO: WrappedInt! = nil
+// CHECK-DAG: let wrappedArray: [WrappedInt]
+// CHECK-RECOVERY-NEGATIVE-NOT: let wrappedArray:
+public let wrappedArray: [WrappedInt] = []
+// CHECK-DAG: let wrappedDictionary: [Int : WrappedInt]
+// CHECK-RECOVERY-NEGATIVE-NOT: let wrappedDictionary:
+public let wrappedDictionary: [Int: WrappedInt] = [:]
+// CHECK-DAG: let wrappedTuple: (WrappedInt, Int)?
+// CHECK-RECOVERY-NEGATIVE-NOT: let wrappedTuple:
+public let wrappedTuple: (WrappedInt, Int)? = nil
+// CHECK-DAG: let wrappedTuple2: (Int, WrappedInt)?
+// CHECK-RECOVERY-NEGATIVE-NOT: let wrappedTuple2:
+public let wrappedTuple2: (Int, WrappedInt)? = nil
+// CHECK-DAG: let wrappedClosure: ((WrappedInt) -> Void)?
+// CHECK-RECOVERY-NEGATIVE-NOT: let wrappedClosure:
+public let wrappedClosure: ((WrappedInt) -> Void)? = nil
+// CHECK-DAG: let wrappedClosure2: (() -> WrappedInt)?
+// CHECK-RECOVERY-NEGATIVE-NOT: let wrappedClosure2:
+public let wrappedClosure2: (() -> WrappedInt)? = nil
+// CHECK-DAG: let wrappedClosure3: ((Int, WrappedInt) -> Void)?
+// CHECK-RECOVERY-NEGATIVE-NOT: let wrappedClosure3:
+public let wrappedClosure3: ((Int, WrappedInt) -> Void)? = nil
+// CHECK-DAG: let wrappedClosureInout: ((inout WrappedInt) -> Void)?
+// CHECK-RECOVERY-NEGATIVE-NOT: let wrappedClosureInout:
+public let wrappedClosureInout: ((inout WrappedInt) -> Void)? = nil
+
+
+// CHECK-DAG: var wrappedFirst: WrappedInt?
+// CHECK-DAG: var normalSecond: Int?
+// CHECK-RECOVERY-NEGATIVE-NOT: var wrappedFirst:
+// CHECK-RECOVERY-DAG: var normalSecond: Int?
+public var wrappedFirst: WrappedInt?, normalSecond: Int?
+// CHECK-DAG: var normalFirst: Int?
+// CHECK-DAG: var wrappedSecond: WrappedInt?
+// CHECK-RECOVERY-DAG: var normalFirst: Int?
+// CHECK-RECOVERY-NEGATIVE-NOT: var wrappedSecond:
+public var normalFirst: Int?, wrappedSecond: WrappedInt?
+// CHECK-DAG: var wrappedThird: WrappedInt?
+// CHECK-DAG: var wrappedFourth: WrappedInt?
+// CHECK-RECOVERY-NEGATIVE-NOT: var wrappedThird:
+// CHECK-RECOVERY-NEGATIVE-NOT: var wrappedFourth:
+public var wrappedThird, wrappedFourth: WrappedInt?
 
 #endif // TEST


### PR DESCRIPTION
This shouldn't be common—renames are far more likely, and those we can track—but occurs when the swift_wrapper attribute (the implementation of NS_STRING_ENUM) is active in Swift 4 but not in Swift 3.

Note that this only checks the canonical interface type of the declaration, because the non-canonical type may contain references to the declaration's generic parameters.