### PR TITLE
Swift 3 compatibility versions of String.init for Signed/UnsignedInt

### DIFF
--- a/stdlib/public/core/StringLegacy.swift
+++ b/stdlib/public/core/StringLegacy.swift
@@ -285,6 +285,45 @@ extension String {
   ///
   /// Numerals greater than 9 are represented as Roman letters. These letters
   /// start with `"A"` if `uppercase` is `true`; otherwise, with `"a"`.
+  /// 
+  ///     let v = 999_999
+  ///     print(String(v, radix: 2))
+  ///     // Prints "11110100001000111111"
+  ///
+  ///     print(String(v, radix: 16))
+  ///     // Prints "f423f"
+  ///     print(String(v, radix: 16, uppercase: true))
+  ///     // Prints "F423F"
+  ///
+  /// - Parameters:
+  ///   - value: The value to convert to a string.
+  ///   - radix: The base to use for the string representation. `radix` must be
+  ///     at least 2 and at most 36. The default is 10.
+  ///   - uppercase: Pass `true` to use uppercase letters to represent numerals
+  ///     greater than 9, or `false` to use lowercase letters. The default is
+  ///     `false`.
+  // FIXME(integers): tiebreaker between T : FixedWidthInteger and other obsoleted
+  @available(swift, obsoleted: 4)
+  public init<T : FixedWidthInteger>(
+    _ value: T, radix: Int = 10, uppercase: Bool = false
+  ) where T : SignedInteger {
+    _precondition(radix > 1, "Radix must be greater than 1")
+    self = _int64ToString(
+      Int64(value), radix: Int64(radix), uppercase: uppercase)
+  }
+  
+  /// Creates a string representing the given value in base 10, or some other
+  /// specified base.
+  ///
+  /// The following example converts the maximal `Int` value to a string and
+  /// prints its length:
+  ///
+  ///     let max = String(Int.max)
+  ///     print("\(max) has \(max.utf16.count) digits.")
+  ///     // Prints "9223372036854775807 has 19 digits."
+  ///
+  /// Numerals greater than 9 are represented as Roman letters. These letters
+  /// start with `"A"` if `uppercase` is `true`; otherwise, with `"a"`.
   ///
   ///     let v: UInt = 999_999
   ///     print(String(v, radix: 2))
@@ -309,6 +348,82 @@ extension String {
     _precondition(radix > 1, "Radix must be greater than 1")
     self = _uint64ToString(
       UInt64(value), radix: Int64(radix), uppercase: uppercase)
+  }
+  
+  /// Creates a string representing the given value in base 10, or some other
+  /// specified base.
+  ///
+  /// The following example converts the maximal `Int` value to a string and
+  /// prints its length:
+  ///
+  ///     let max = String(Int.max)
+  ///     print("\(max) has \(max.utf16.count) digits.")
+  ///     // Prints "9223372036854775807 has 19 digits."
+  ///
+  /// Numerals greater than 9 are represented as Roman letters. These letters
+  /// start with `"A"` if `uppercase` is `true`; otherwise, with `"a"`.
+  /// 
+  ///     let v = 999_999
+  ///     print(String(v, radix: 2))
+  ///     // Prints "11110100001000111111"
+  ///
+  ///     print(String(v, radix: 16))
+  ///     // Prints "f423f"
+  ///     print(String(v, radix: 16, uppercase: true))
+  ///     // Prints "F423F"
+  ///
+  /// - Parameters:
+  ///   - value: The value to convert to a string.
+  ///   - radix: The base to use for the string representation. `radix` must be
+  ///     at least 2 and at most 36. The default is 10.
+  ///   - uppercase: Pass `true` to use uppercase letters to represent numerals
+  ///     greater than 9, or `false` to use lowercase letters. The default is
+  ///     `false`.
+  @available(swift, obsoleted: 4, message: "Please use the version for FixedWidthInteger instead.")
+  public init<T : _SignedInteger>(
+    _ value: T, radix: Int = 10, uppercase: Bool = false
+  ) {
+    _precondition(radix > 1, "Radix must be greater than 1")
+    self = _int64ToString(
+      value.toIntMax(), radix: Int64(radix), uppercase: uppercase)
+  }
+  
+  /// Creates a string representing the given value in base 10, or some other
+  /// specified base.
+  ///
+  /// The following example converts the maximal `Int` value to a string and
+  /// prints its length:
+  ///
+  ///     let max = String(Int.max)
+  ///     print("\(max) has \(max.utf16.count) digits.")
+  ///     // Prints "9223372036854775807 has 19 digits."
+  ///
+  /// Numerals greater than 9 are represented as Roman letters. These letters
+  /// start with `"A"` if `uppercase` is `true`; otherwise, with `"a"`.
+  ///
+  ///     let v: UInt = 999_999
+  ///     print(String(v, radix: 2))
+  ///     // Prints "11110100001000111111"
+  ///
+  ///     print(String(v, radix: 16))
+  ///     // Prints "f423f"
+  ///     print(String(v, radix: 16, uppercase: true))
+  ///     // Prints "F423F"
+  ///
+  /// - Parameters:
+  ///   - value: The value to convert to a string.
+  ///   - radix: The base to use for the string representation. `radix` must be
+  ///     at least 2 and at most 36. The default is 10.
+  ///   - uppercase: Pass `true` to use uppercase letters to represent numerals
+  ///     greater than 9, or `false` to use lowercase letters. The default is
+  ///     `false`.
+  @available(swift, obsoleted: 4, message: "Please use the version for FixedWidthInteger instead.")
+  public init<T : UnsignedInteger>(
+    _ value: T, radix: Int = 10, uppercase: Bool = false
+  ) {
+    _precondition(radix > 1, "Radix must be greater than 1")
+    self = _uint64ToString(
+      value.toUIntMax(), radix: Int64(radix), uppercase: uppercase)
   }
 }
 


### PR DESCRIPTION
rdar://problem/31727219