### PR TITLE
Mark conformances as "used" when the GenericSignatureBuilder needs them.

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1629,7 +1629,7 @@ void AttributeChecker::visitSpecializeAttr(SpecializeAttr *attr) {
 
   // Form a new generic signature based on the old one.
   GenericSignatureBuilder Builder(D->getASTContext(),
-                           LookUpConformanceInModule(DC->getParentModule()));
+                                  TypeChecker::LookUpConformance(TC, DC));
 
   // First, add the old generic signature.
   Builder.addGenericSignature(genericSig);

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -797,8 +797,7 @@ TypeChecker::validateGenericFuncSignature(AbstractFunctionDecl *func) {
   addGenericParamTypes(gp, allGenericParams);
 
   // Create the generic signature builder.
-  GenericSignatureBuilder builder(Context,
-                           LookUpConformanceInModule(func->getParentModule()));
+  GenericSignatureBuilder builder(Context, LookUpConformance(*this, func));
 
   // Type check the function declaration, treating all generic type
   // parameters as dependent, unresolved.
@@ -1028,8 +1027,7 @@ TypeChecker::validateGenericSubscriptSignature(SubscriptDecl *subscript) {
   addGenericParamTypes(gp, allGenericParams);
 
   // Create the generic signature builder.
-  GenericSignatureBuilder builder(Context,
-                       LookUpConformanceInModule(subscript->getParentModule()));
+  GenericSignatureBuilder builder(Context, LookUpConformance(*this, subscript));
 
   // Type check the function declaration, treating all generic type
   // parameters as dependent, unresolved.
@@ -1148,7 +1146,7 @@ GenericEnvironment *TypeChecker::checkGenericEnvironment(
 
   // Create the generic signature builder.
   ModuleDecl *module = dc->getParentModule();
-  GenericSignatureBuilder builder(Context, LookUpConformanceInModule(module));
+  GenericSignatureBuilder builder(Context, LookUpConformance(*this, dc));
 
   // Type check the generic parameters, treating all generic type
   // parameters as dependent, unresolved.

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1017,12 +1017,13 @@ RequirementEnvironment::RequirementEnvironment(
   auto selfType = cast<GenericTypeParamType>(
                             proto->getSelfInterfaceType()->getCanonicalType());
 
-  // Construct a generic signature builder by collecting the constraints from the
-  // requirement and the context of the conformance together, because both
-  // define the capabilities of the requirement.
+  // Construct a generic signature builder by collecting the constraints
+  // from the requirement and the context of the conformance together,
+  // because both define the capabilities of the requirement.
   GenericSignatureBuilder builder(
            ctx,
-           LookUpConformanceInModule(conformanceDC->getParentModule()));
+           TypeChecker::LookUpConformance(tc, conformanceDC));
+
   SmallVector<GenericTypeParamType*, 4> allGenericParams;
 
   // Add the generic signature of the context of the conformance. This includes
@@ -4836,8 +4837,7 @@ void ConformanceChecker::ensureRequirementsAreSatisfied() {
       // FIXME: maybe this should be the conformance's type
       proto->getDeclaredInterfaceType(), reqSig,
       QuerySubstitutionMap{substitutions},
-      LookUpConformanceInModule(
-        Conformance->getDeclContext()->getParentModule()),
+      TypeChecker::LookUpConformance(TC, Conformance->getDeclContext()),
       nullptr,
       ConformanceCheckFlags::Used, &listener);
 
@@ -5326,6 +5326,21 @@ TypeChecker::conformsToProtocol(Type T, ProtocolDecl *Proto, DeclContext *DC,
   auto conformance = conformsToProtocol(T, Proto, DC, options, ComplainLoc);
   return conformance ? ConformsToProtocolResult::success(*conformance)
                      : ConformsToProtocolResult::failure();
+}
+
+Optional<ProtocolConformanceRef>
+TypeChecker::LookUpConformance::operator()(
+                                       CanType dependentType,
+                                       Type conformingReplacementType,
+                                       ProtocolType *conformedProtocol) const {
+  if (conformingReplacementType->isTypeParameter())
+    return ProtocolConformanceRef(conformedProtocol->getDecl());
+
+  return tc.conformsToProtocol(conformingReplacementType,
+                               conformedProtocol->getDecl(),
+                               dc,
+                               (ConformanceCheckFlags::Used|
+                                ConformanceCheckFlags::InExpression));
 }
 
 /// Mark any _ObjectiveCBridgeable conformances in the given type as "used".

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -742,7 +742,7 @@ Type TypeChecker::applyUnboundGenericArguments(
     auto result =
       checkGenericArguments(dc, loc, noteLoc, unboundType, genericSig,
                             QueryTypeSubstitutionMap{subs},
-                            LookUpConformanceInModule{dc->getParentModule()},
+                            LookUpConformance(*this, dc),
                             unsatisfiedDependency);
 
     switch (result) {
@@ -757,7 +757,7 @@ Type TypeChecker::applyUnboundGenericArguments(
 
   // Apply the substitution map to the interface type of the declaration.
   resultType = resultType.subst(QueryTypeSubstitutionMap{subs},
-                                LookUpConformanceInModule(dc->getParentModule()),
+                                LookUpConformance(*this, dc),
                                 SubstFlags::UseErrorType);
 
   if (isa<NominalTypeDecl>(decl)) {

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1819,6 +1819,23 @@ public:
                      ConformanceCheckOptions options, SourceLoc ComplainLoc,
                      UnsatisfiedDependency *unsatisfiedDependency);
 
+  /// Functor class suitable for use as a \c LookupConformanceFn to look up a
+  /// conformance through a particular declaration context using the given
+  /// type checker.
+  class LookUpConformance {
+    TypeChecker &tc;
+    DeclContext *dc;
+
+  public:
+    explicit LookUpConformance(TypeChecker &tc, DeclContext *dc)
+      : tc(tc), dc(dc) { }
+
+    Optional<ProtocolConformanceRef>
+    operator()(CanType dependentType,
+               Type conformingReplacementType,
+               ProtocolType *conformedProtocol) const;
+  };
+
   /// Completely check the given conformance.
   void checkConformance(NormalProtocolConformance *conformance);
 

--- a/stdlib/public/core/Filter.swift.gyb
+++ b/stdlib/public/core/Filter.swift.gyb
@@ -97,65 +97,8 @@ public struct LazyFilterSequence<Base : Sequence>
 }
 
 /// The `Index` used for subscripting a `LazyFilterCollection`.
-///
-/// The positions of a `LazyFilterIndex` correspond to those positions
-/// `p` in its underlying collection `c` such that `c[p]`
-/// satisfies the predicate with which the `LazyFilterIndex` was
-/// initialized.
-///
-/// - Note: The performance of advancing a `LazyFilterIndex`
-///   depends on how sparsely the filtering predicate is satisfied,
-///   and may not offer the usual performance given by models of
-///   `Collection`.
-public struct LazyFilterIndex<Base : Collection> {
-
-  /// The position corresponding to `self` in the underlying collection.
-  public let base: Base.Index
-}
-
-extension LazyFilterIndex : Comparable {
-  public static func == (
-    lhs: LazyFilterIndex<Base>,
-    rhs: LazyFilterIndex<Base>
-  ) -> Bool {
-    return lhs.base == rhs.base
-  }
-
-  public static func != (
-    lhs: LazyFilterIndex<Base>,
-    rhs: LazyFilterIndex<Base>
-  ) -> Bool {
-    return lhs.base != rhs.base
-  }
-
-  public static func < (
-    lhs: LazyFilterIndex<Base>,
-    rhs: LazyFilterIndex<Base>
-  ) -> Bool {
-    return lhs.base < rhs.base
-  }
-
-  public static func <= (
-    lhs: LazyFilterIndex<Base>,
-    rhs: LazyFilterIndex<Base>
-  ) -> Bool {
-    return lhs.base <= rhs.base
-  }
-
-  public static func >= (
-    lhs: LazyFilterIndex<Base>,
-    rhs: LazyFilterIndex<Base>
-  ) -> Bool {
-    return lhs.base >= rhs.base
-  }
-
-  public static func > (
-    lhs: LazyFilterIndex<Base>,
-    rhs: LazyFilterIndex<Base>
-  ) -> Bool {
-    return lhs.base > rhs.base
-  }
-}
+@available(swift, deprecated: 3.1, obsoleted: 4.0, message: "Use Base.Index")
+public typealias LazyFilterIndex<Base : Collection> = Base.Index
 
 // FIXME(ABI)#27 (Conditional Conformance): `LazyFilter*Collection` types should be
 // collapsed into one `LazyFilterCollection` using conditional conformances.
@@ -170,20 +113,21 @@ extension LazyFilterIndex : Comparable {
 /// underlying collection that satisfy a predicate.
 ///
 /// - Note: The performance of accessing `startIndex`, `first`, any methods
-///   that depend on `startIndex`, or of advancing a `LazyFilterIndex` depends
+///   that depend on `startIndex`, or of advancing an index depends
 ///   on how sparsely the filtering predicate is satisfied, and may not offer
 ///   the usual performance given by `Collection`. Be aware, therefore, that
 ///   general operations on `LazyFilterCollection` instances may not have the
 ///   documented complexity.
 public struct ${Self}<
   Base : ${collectionForTraversal(Traversal)}
-> : LazyCollectionProtocol, ${collectionForTraversal(Traversal)} {
+> : LazyCollectionProtocol, ${collectionForTraversal(Traversal)}
+{
 
   /// A type that represents a valid position in the collection.
   ///
   /// Valid indices consist of the position of every element and a
   /// "past the end" position that's not valid for use as a subscript.
-  public typealias Index = LazyFilterIndex<Base>
+  public typealias Index = Base.Index
 
   public typealias IndexDistance = Base.IndexDistance
 
@@ -209,7 +153,7 @@ public struct ${Self}<
     while index != _base.endIndex && !_predicate(_base[index]) {
       _base.formIndex(after: &index)
     }
-    return LazyFilterIndex(base: index)
+    return index
   }
 
   /// The collection's "past the end" position---that is, the position one
@@ -218,7 +162,7 @@ public struct ${Self}<
   /// `endIndex` is always reachable from `startIndex` by zero or more
   /// applications of `index(after:)`.
   public var endIndex: Index {
-    return LazyFilterIndex(base: _base.endIndex)
+    return _base.endIndex
   }
 
   // TODO: swift-3-indexing-model - add docs
@@ -230,12 +174,12 @@ public struct ${Self}<
 
   public func formIndex(after i: inout Index) {
     // TODO: swift-3-indexing-model: _failEarlyRangeCheck i?
-    var index = i.base
+    var index = i
     _precondition(index != _base.endIndex, "can't advance past endIndex")
     repeat {
       _base.formIndex(after: &index)
     } while index != _base.endIndex && !_predicate(_base[index])
-    i = LazyFilterIndex(base: index)
+    i = index
   }
 
 %   if Traversal == 'Bidirectional':
@@ -247,12 +191,12 @@ public struct ${Self}<
 
   public func formIndex(before i: inout Index) {
     // TODO: swift-3-indexing-model: _failEarlyRangeCheck i?
-    var index = i.base
+    var index = i
     _precondition(index != _base.startIndex, "can't retreat before startIndex")
     repeat {
       _base.formIndex(before: &index)
     } while !_predicate(_base[index])
-    i = LazyFilterIndex(base: index)
+    i = index
   }
 %   end
 
@@ -261,7 +205,7 @@ public struct ${Self}<
   /// - Precondition: `position` is a valid position in `self` and
   /// `position != endIndex`.
   public subscript(position: Index) -> Base.Iterator.Element {
-    return _base[position.base]
+    return _base[position]
   }
 
   public subscript(bounds: Range<Index>) -> ${Slice}<${Self}<Base>> {

--- a/test/multifile/Inputs/for_each_conformance_crashB.swift
+++ b/test/multifile/Inputs/for_each_conformance_crashB.swift
@@ -1,0 +1,12 @@
+protocol _P { }
+protocol P : _P { }
+
+protocol Q {
+  associatedtype A: P
+
+  func getArray() -> [RequiresP<A>]
+}
+
+struct RequiresP<T: P> { }
+
+struct MyStruct: P { }

--- a/test/multifile/for_each_conformance_crash.swift
+++ b/test/multifile/for_each_conformance_crash.swift
@@ -1,0 +1,7 @@
+// RUN: %target-swift-frontend -emit-ir %S/Inputs/for_each_conformance_crashB.swift -primary-file %s -o -
+
+extension Q where A == MyStruct {
+  func foo() {
+    for _ in getArray() { }
+  }
+}

--- a/test/stdlib/Filter.swift
+++ b/test/stdlib/Filter.swift
@@ -32,12 +32,6 @@ extension LazyFilterSequence where Base : TestProtocol1 {
   }
 }
 
-extension LazyFilterIndex where Base : TestProtocol1 {
-  var _baseIsTestProtocol1: Bool {
-    fatalError("not implemented")
-  }
-}
-
 extension LazyFilterCollection where Base : TestProtocol1 {
   var _baseIsTestProtocol1: Bool {
     fatalError("not implemented")

--- a/validation-test/stdlib/Lazy.swift.gyb
+++ b/validation-test/stdlib/Lazy.swift.gyb
@@ -638,10 +638,10 @@ tests.test("LazySequence/Sequence") {
 }
 
 func expectSequencePassthrough<
-  S : Sequence,
+  S : LazySequenceProtocol,
   Base : Sequence
 >(_ s: S, base: Base, arbitraryElement: S.Iterator.Element, count: Int)
-where S : LazySequenceProtocol, Base : LoggingType,
+where Base : LoggingType,
 Base.Iterator.Element == S.Iterator.Element {
   let baseType = type(of: base)
 
@@ -825,7 +825,7 @@ tests.test("LazyMapCollection/Passthrough") {
   let startIndex = CollectionLog.startIndex.expectIncrement(type(of: base)) {
     mapped.startIndex
   }
-  let endIndex = CollectionLog.endIndex.expectIncrement(type(of: base)) {
+  _ = CollectionLog.endIndex.expectIncrement(type(of: base)) {
     mapped.endIndex
   }
   // Not exactly passthrough, because mapping transforms the result
@@ -1023,9 +1023,7 @@ tests.test("ReversedCollection/Lazy") {
 // Given a couple of sequences backed by FilterGenerator's, check that
 // the first selects even numbers and the second selects odd numbers,
 // both from an underlying sequence of whole numbers.
-func checkFilterIteratorBase<
-  S : Sequence, I : IteratorProtocol
->(_ s1: S, _ s2: S)
+func checkFilterIteratorBase<  S : Sequence, I>(_ s1: S, _ s2: S)
 where S.Iterator == LazyFilterIterator<I>, I.Element == OpaqueValue<Int> {
   var iter1 = s1.makeIterator()
   expectEqual(0, iter1.next()!.value)
@@ -1098,16 +1096,16 @@ tests.test("LazyFilterIndex/base") {
   let evens = base.lazy.filter { $0.value % 2 == 0 }
   let odds = base.lazy.filter { $0.value % 2 != 0 }
 
-  expectEqual(base.startIndex, evens.startIndex.base)
-  expectEqual(base.index(after: base.startIndex), odds.startIndex.base)
+  expectEqual(base.startIndex, evens.startIndex)
+  expectEqual(base.index(after: base.startIndex), odds.startIndex)
 
   expectEqual(
     base.index(after: base.index(after: base.startIndex)),
-    evens.index(after: evens.startIndex).base)
+    evens.index(after: evens.startIndex))
 
   expectEqual(
     base.index(after: base.index(after: base.index(after: base.startIndex))),
-    odds.index(after: odds.startIndex).base)
+    odds.index(after: odds.startIndex))
 }
 
 tests.test("LazyFilterCollection") {


### PR DESCRIPTION
When the type checker forms a `GenericSignatureBuilder` to process
requirements, the GSB may look up concrete conformances. Route such
requests through `TypeChecker::conformsToProtocol()` so they can be
marked as used. This fixes multi-file scenarios where conformances
from another file might be used only in a generic signature in the
primary file, e.g., rdar://problem/31759258.