### PR TITLE
[WIP] [Constraint solver] While simplifying constraints, test protocol conf…

### DIFF
--- a/lib/Sema/CSPropagate.cpp
+++ b/lib/Sema/CSPropagate.cpp
@@ -99,6 +99,8 @@ void ConstraintSystem::collectNeighboringBindOverloadDisjunctions(
 // Simplify any active constraints, returning true on success, false
 // on failure.
 bool ConstraintSystem::simplifyForConstraintPropagation() {
+  SmallVector<Constraint *, 4> conformsToConstraints;
+
   while (!ActiveConstraints.empty()) {
     auto *constraint = &ActiveConstraints.front();
     ActiveConstraints.pop_front();
@@ -106,6 +108,9 @@ bool ConstraintSystem::simplifyForConstraintPropagation() {
     assert(constraint->isActive()
            && "Expected constraints to be active?");
     assert(!constraint->isDisabled() && "Unexpected disabled constraint!");
+
+    if (constraint->getKind() == ConstraintKind::ConformsTo)
+      conformsToConstraints.push_back(constraint);
 
     bool failed = false;
 
@@ -131,7 +136,7 @@ bool ConstraintSystem::simplifyForConstraintPropagation() {
       return false;
   }
 
-  return true;
+  return areProtocolConformancesConsistent(conformsToConstraints);
 }
 
 bool ConstraintSystem::areBindPairConsistent(Constraint *first,

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -326,13 +326,87 @@ enumerateDirectSupertypes(TypeChecker &tc, Type type) {
   return result;
 }
 
+bool ConstraintSystem::areProtocolConformancesConsistent(
+    SmallVectorImpl<Constraint *> &conformsToConstraints) {
+  // Examine the other constraints related to ecah of our ConformsTo
+  // constraints. If any fails, return false.
+  for (auto *conformsTo : conformsToConstraints) {
+    if (auto *conformingType =
+            conformsTo->getFirstType()->getAs<TypeVariableType>()) {
+      if (getFixedType(conformingType))
+        continue;
+
+      if (!conformsTo->getSecondType()->getAs<ProtocolType>())
+        continue;
+
+      SmallVector<Constraint *, 4> associated;
+      getConstraintGraph().gatherConstraints(
+          conformingType, associated,
+          ConstraintGraph::GatheringKind::EquivalenceClass);
+
+      // For now we're only looking at argument conversions that are
+      // set up by applies. We'll test the source type of the
+      // conversion against the conformance.
+      for (auto *argumentConstraint : associated) {
+        auto kind = argumentConstraint->getKind();
+        switch (kind) {
+        case ConstraintKind::ArgumentConversion:
+        case ConstraintKind::ArgumentTupleConversion:
+        case ConstraintKind::OperatorArgumentTupleConversion:
+        case ConstraintKind::OperatorArgumentConversion:
+          break;
+        default:
+          continue;
+        }
+
+        auto *convertedTo =
+            argumentConstraint->getSecondType()->getAs<TypeVariableType>();
+        if (!convertedTo || convertedTo != conformingType)
+          continue;
+
+        auto convertedTy = argumentConstraint->getFirstType();
+        if (auto *convertedTyvar = convertedTy->getAs<TypeVariableType>())
+          if (auto fixedTy = getFixedType(convertedTyvar))
+            convertedTy = fixedTy;
+
+        // Only test known types.
+        if (convertedTy->is<TypeVariableType>())
+          continue;
+
+        // We allow inout's to coerce to pointer types, and deal with
+        // that through disjunctions in the solver. We cannot easily
+        // handle that here, so we'll make the safe assumption that
+        // these conform and move on to the next constraint.
+        if (convertedTy->is<InOutType>())
+          continue;
+
+        auto ty = convertedTy->getRValueObjectType();
+
+        auto result = simplifyConformsToConstraint(
+            ty, conformsTo->getSecondType(), conformsTo->getKind(),
+            conformsTo->getLocator(), None);
+
+        if (result == SolutionKind::Error)
+          return false;
+      }
+    }
+  }
+
+  return true;
+}
+
 bool ConstraintSystem::simplify(bool ContinueAfterFailures) {
+  SmallVector<Constraint *, 4> conformsToConstraints;
+
   // While we have a constraint in the worklist, process it.
   while (!ActiveConstraints.empty()) {
     // Grab the next constraint from the worklist.
     auto *constraint = &ActiveConstraints.front();
     ActiveConstraints.pop_front();
     assert(constraint->isActive() && "Worklist constraint is not active?");
+
+    if (constraint->getKind() == ConstraintKind::ConformsTo)
+      conformsToConstraints.push_back(constraint);
 
     // Simplify this constraint.
     switch (simplifyConstraint(*constraint)) {
@@ -383,7 +457,7 @@ bool ConstraintSystem::simplify(bool ContinueAfterFailures) {
     }
   }
 
-  return false;
+  return !areProtocolConformancesConsistent(conformsToConstraints);
 }
 
 namespace {

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2361,6 +2361,14 @@ private:
   /// \param expr The expression to find reductions for.
   void shrink(Expr *expr);
 
+  /// \brief For each ConformsTo constraint passed in, see if the
+  /// other constraints related to the type we're testing conformance
+  /// to make sense with that conformance. If any conformance fails,
+  /// return false. Otherwise, return true. We use this to attempt to
+  /// fail earlier for generic functions.
+  bool areProtocolConformancesConsistent(
+      SmallVectorImpl<Constraint *> &conformsToConstraints);
+
   bool simplifyForConstraintPropagation();
   void collectNeighboringBindOverloadDisjunctions(
       llvm::SetVector<Constraint *> &neighbors);

--- a/test/Constraints/bridging.swift
+++ b/test/Constraints/bridging.swift
@@ -241,9 +241,11 @@ func rdar19770981(_ s: String, ns: NSString) {
   f(ns) // expected-error{{'NSString' is not implicitly convertible to 'String'; did you mean to use 'as' to explicitly convert?}}{{7-7= as String}}
   f(ns as String)
   // 'as' has higher precedence than '>' so no parens are necessary with the fixit:
-  s > ns // expected-error{{'NSString' is not implicitly convertible to 'String'; did you mean to use 'as' to explicitly convert?}}{{9-9= as String}}
+  s > ns // expected-error{{binary operator '>' cannot be applied to operands of type 'String' and 'NSString'}}
+  // expected-note@-1{{expected an argument list of type '(Self, Self)'}}
   _ = s > ns as String
-  ns > s // expected-error{{'NSString' is not implicitly convertible to 'String'; did you mean to use 'as' to explicitly convert?}}{{5-5= as String}}
+  ns > s // expected-error{{binary operator '>' cannot be applied to operands of type 'NSString' and 'String'}}
+  // expected-note@-1{{expected an argument list of type '(Self, Self)'}}
   _ = ns as String > s
 
   // 'as' has lower precedence than '+' so add parens with the fixit:

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -443,3 +443,21 @@ func sr3525_3<T>(t: SR_3525<T>) {
 class testStdlibType {
   let _: Array // expected-error {{reference to generic type 'Array' requires arguments in <...>}} {{15-15=<Any>}}
 }
+
+infix operator =*= : ComparisonPrecedence
+func =*= <T : Equatable>(lhs: T, rhs: T) -> Bool {
+  return lhs == rhs
+}
+func =*= <T : Equatable>(lhs: T?, rhs: T?) -> Bool {
+  return lhs == rhs
+}
+
+class C {}
+
+var ac = C()
+var umpc: UnsafeMutablePointer<C>? = nil
+
+// Ensure that we can typecheck this, and do not accidentially fail
+// because the inout C does not conform to Equatable (we coerce the
+// inout to the UnsafeMutablePointer type here.
+_ = umpc =*= &ac

--- a/test/stdlib/StringDiagnostics.swift
+++ b/test/stdlib/StringDiagnostics.swift
@@ -48,16 +48,22 @@ func testAmbiguousStringComparisons(s: String) {
   let a1 = s as NSString == nsString
   let a2 = s as NSString != nsString
   let a3 = s < nsString // expected-error{{'NSString' is not implicitly convertible to 'String'; did you mean to use 'as' to explicitly convert?}} {{24-24= as String}}
-  let a4 = s <= nsString // expected-error{{'NSString' is not implicitly convertible to 'String'; did you mean to use 'as' to explicitly convert?}} {{25-25= as String}}
-  let a5 = s >= nsString // expected-error{{'NSString' is not implicitly convertible to 'String'; did you mean to use 'as' to explicitly convert?}} {{25-25= as String}}
-  let a6 = s > nsString // expected-error{{'NSString' is not implicitly convertible to 'String'; did you mean to use 'as' to explicitly convert?}} {{24-24= as String}}
+  let a4 = s <= nsString // expected-error{{binary operator '<=' cannot be applied to operands of type 'String' and 'NSString'}}
+  // expected-note@-1{{expected an argument list of type '(Self, Self)'}}
+  let a5 = s >= nsString // expected-error{{binary operator '>=' cannot be applied to operands of type 'String' and 'NSString'}}
+  // expected-note@-1{{expected an argument list of type '(Self, Self)'}}
+  let a6 = s > nsString // expected-error{{binary operator '>' cannot be applied to operands of type 'String' and 'NSString'}}
+  // expected-note@-1{{expected an argument list of type '(Self, Self)'}}
   // now the other way
   let a7 = nsString == s as NSString
   let a8 = nsString != s as NSString
   let a9 = nsString < s // expected-error{{'NSString' is not implicitly convertible to 'String'; did you mean to use 'as' to explicitly convert?}} {{20-20= as String}}
-  let a10 = nsString <= s // expected-error{{'NSString' is not implicitly convertible to 'String'; did you mean to use 'as' to explicitly convert?}} {{21-21= as String}}
-  let a11 = nsString >= s // expected-error{{'NSString' is not implicitly convertible to 'String'; did you mean to use 'as' to explicitly convert?}} {{21-21= as String}}
-  let a12 = nsString > s // expected-error{{'NSString' is not implicitly convertible to 'String'; did you mean to use 'as' to explicitly convert?}} {{21-21= as String}}
+  let a10 = nsString <= s // expected-error{{binary operator '<=' cannot be applied to operands of type 'NSString' and 'String'}}
+  // expected-note@-1{{expected an argument list of type '(Self, Self)'}}
+  let a11 = nsString >= s // expected-error{{binary operator '>=' cannot be applied to operands of type 'NSString' and 'String'}}
+  // expected-note@-1{{expected an argument list of type '(Self, Self)'}}
+  let a12 = nsString > s // expected-error{{binary operator '>' cannot be applied to operands of type 'NSString' and 'String'}}
+  // expected-note@-1{{expected an argument list of type '(Self, Self)'}}
 }
 
 func acceptsSequence<S : Sequence>(_ sequence: S) {}

--- a/validation-test/Sema/type_checker_perf/generic_conformance.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/generic_conformance.swift.gyb
@@ -1,0 +1,20 @@
+// RUN: %scale-test --begin 1 --end 5 --step 1 --select incrementScopeCounter %s --polynomial-threshold=2.1
+// REQUIRES: OS=macosx
+// REQUIRES: asserts
+
+infix operator +|+ : AdditionPrecedence
+
+func +|+ <T: FloatingPoint>(lhs: T, rhs: T) -> T {
+  return lhs
+}
+
+func +|+ <T: SignedInteger>(lhs: T, rhs: T) -> T {
+  return lhs
+}
+
+func test(i: Int, j: Int, k: Int, l: Int) -> Int {
+  return i +|+ j +|+ k +|+ l
+%for i in range(1, N):
+         +|+ i +|+ j +|+ k +|+ l
+%end
+}


### PR DESCRIPTION
…ormance of arguments.

When we simplify bindings and function applications, we generate
independent constraints for protocol conformance and argument
conversion. What we previously did not do is examine these constraints
together to see if they make any sense.

This commit collects the protocol conformance constraints while
simplifying these independent constraints, and then tests these against
the argument conversion constraints for arguments to see if the
arguments could possibly conform to the protocols.

The end result is eliminating some of the exponential behavior observed
the type checker.
