### PR TITLE
Fix spurious 'unreachable' warning with failable initializers

### DIFF
--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -286,7 +286,7 @@ void SILGenFunction::emitValueConstructor(ConstructorDecl *ctor) {
 
       // Inject the self value into an optional if the constructor is failable.
       if (ctor->getFailability() != OTK_None) {
-        selfValue = B.createEnum(ctor, selfValue,
+        selfValue = B.createEnum(cleanupLoc, selfValue,
                                  getASTContext().getOptionalSomeDecl(),
                                  getLoweredLoadableType(resultType));
       }
@@ -306,7 +306,8 @@ void SILGenFunction::emitValueConstructor(ConstructorDecl *ctor) {
       // If this is a failable initializer, project out the payload.
       case OTK_Optional:
       case OTK_ImplicitlyUnwrappedOptional:
-        returnAddress = B.createInitEnumDataAddr(ctor, completeReturnAddress,
+        returnAddress = B.createInitEnumDataAddr(cleanupLoc,
+                                                 completeReturnAddress,
                                        getASTContext().getOptionalSomeDecl(),
                                                  selfLV->getType());
         break;
@@ -320,7 +321,7 @@ void SILGenFunction::emitValueConstructor(ConstructorDecl *ctor) {
       // Inject the enum tag if the result is optional because of failability.
       if (ctor->getFailability() != OTK_None) {
         // Inject the 'Some' tag.
-        B.createInjectEnumAddr(ctor, completeReturnAddress,
+        B.createInjectEnumAddr(cleanupLoc, completeReturnAddress,
                                getASTContext().getOptionalSomeDecl());
       }
     }

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -1257,8 +1257,6 @@ void FunctionSignaturePartialSpecializer::addRequirements(
 /// Add requirements from the caller's signature.
 void FunctionSignaturePartialSpecializer::addCallerRequirements() {
   for (auto CallerArchetype : UsedCallerArchetypes) {
-    auto CallerGenericParam =
-      CallerGenericEnv->mapTypeOutOfContext(CallerArchetype);
     // Add requirements for this caller generic parameter and its dependent
     // types.
     SmallVector<Requirement, 4> CollectedReqs;
@@ -1269,7 +1267,7 @@ void FunctionSignaturePartialSpecializer::addCallerRequirements() {
             for (auto Req : CollectedReqs) {
               Req.dump();
             }
-            CallerInterfaceToSpecializedInterfaceMap.dump();
+            CallerInterfaceToSpecializedInterfaceMap.dump(llvm::dbgs());
            );
       addRequirements(CollectedReqs, CallerInterfaceToSpecializedInterfaceMap);
     }
@@ -1446,7 +1444,6 @@ void ReabstractionInfo::performPartialSpecializationPreparation(
     SILFunction *Caller, SILFunction *Callee,
     ArrayRef<Substitution> ParamSubs) {
   SILModule &M = Callee->getModule();
-  auto &Ctx = M.getASTContext();
 
   // Caller is the SILFunction containing the apply instruction.
   CanGenericSignature CallerGenericSig;

--- a/test/SILOptimizer/unreachable_code.swift
+++ b/test/SILOptimizer/unreachable_code.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil %s -o /dev/null -verify
+// RUN: %target-swift-frontend -emit-sil -primary-file %s -o /dev/null -verify
 func ifFalse() -> Int {
   if false { // expected-note {{always evaluates to false}}
     return 0 // expected-warning {{will never be executed}}
@@ -350,7 +350,7 @@ func testGuard(_ a : Int) {
   }
 }
 
-public func testFailingCast(_ s:String) -> Int {
+func testFailingCast(_ s:String) -> Int {
    // There should be no notes or warnings about a call to a noreturn function, because we do not expose
    // how casts are lowered.
    return s as! Int // expected-warning {{cast from 'String' to unrelated type 'Int' always fails}}
@@ -419,14 +419,30 @@ while true {
 
 
 // SR-1010 - rdar://25278336 - Spurious "will never be executed" warnings when building standard library
-public struct SR1010<T> {
+struct SR1010<T> {
   var a : T
 }
 
 extension SR1010 {
   @available(*, unavailable, message: "use the 'enumerated()' method on the sequence")
-  public init(_ base: Int) {
+  init(_ base: Int) {
     fatalError("unavailable function can't be called")
   }
 }
 
+// More spurious 'will never be executed' warnings
+struct FailingStruct {
+  init?(x: ()) {
+    fatalError("gotcha")
+  }
+}
+
+class FailingClass {
+  init?(x: ()) {
+    fatalError("gotcha")
+  }
+
+  convenience init?(y: ()) {
+    fatalError("gotcha")
+  }
+}


### PR DESCRIPTION
Fixes <https://bugs.swift.org/browse/SR-4673>.