### PR TITLE
[Exclusivity] Improve static enforcement diagnostics

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -87,11 +87,17 @@ NOTE(previous_inout_alias,none,
 // This is temporarily a warning during staging to make it easier to evaluate.
 // The intent is to change it to an error before turning it on by default.
 WARNING(exclusivity_access_required,none,
+        "simultaneous accesses to %0 %1; "
+        "%select{initialization|read|modification|deinitialization}2 requires "
+        "exclusive access", (DescriptiveDeclKind, Identifier, unsigned))
+
+WARNING(exclusivity_access_required_unknown_decl,none,
+        "simultaneous accesses; "
         "%select{initialization|read|modification|deinitialization}0 requires "
-        "%select{exclusive|shared}1 access", (unsigned, unsigned))
+        "exclusive access", (unsigned))
+
 NOTE(exclusivity_conflicting_access,none,
-     "conflicting %select{initialization|read|modification|deinitialization}0 "
-     "requires %select{exclusive|shared}1 access", (unsigned, unsigned))
+     "conflicting access is here", ())
 
 ERROR(unsupported_c_function_pointer_conversion,none,
       "C function pointer signature %0 is not compatible with expected type %1",

--- a/test/SILOptimizer/exclusivity_static_diagnostics.sil
+++ b/test/SILOptimizer/exclusivity_static_diagnostics.sil
@@ -38,8 +38,8 @@ bb0(%0 : $Int):
   %3 = project_box %2 : ${ var Int }, 0
   store %0 to [trivial] %3 : $*Int
   %4 = function_ref @takesTwoInouts : $@convention(thin) (@inout Int, @inout Int) -> ()
-  %5 = begin_access [modify] [unknown] %3 : $*Int  // expected-note {{conflicting modification requires exclusive access}}
-  %6 = begin_access [modify] [unknown] %3 : $*Int  // expected-warning {{modification requires exclusive access}}
+  %5 = begin_access [modify] [unknown] %3 : $*Int  // expected-warning {{simultaneous accesses; modification requires exclusive access}}
+  %6 = begin_access [modify] [unknown] %3 : $*Int  // expected-note {{conflicting access is here}}
   %7 = apply %4(%5, %6) : $@convention(thin) (@inout Int, @inout Int) -> ()
   end_access %6 : $*Int
   end_access %5: $*Int
@@ -55,9 +55,9 @@ bb0(%0 : $Int):
   %3 = project_box %2 : ${ var Int }, 0
   store %0 to [trivial] %3 : $*Int
   %4 = function_ref @takesTwoInouts : $@convention(thin) (@inout Int, @inout Int) -> ()
-  %5 = begin_access [modify] [unknown] %3 : $*Int  // expected-note {{conflicting modification requires exclusive access}}
+  %5 = begin_access [modify] [unknown] %3 : $*Int  // expected-warning {{simultaneous accesses; modification requires exclusive access}}
   %6 = begin_access [modify] [unknown] %5 : $*Int
-  %7 = begin_access [modify] [unknown] %3 : $*Int  // expected-warning {{modification requires exclusive access}}
+  %7 = begin_access [modify] [unknown] %3 : $*Int  // expected-note {{conflicting access is here}}
   %8 = apply %4(%5, %6) : $@convention(thin) (@inout Int, @inout Int) -> ()
   end_access %7 : $*Int
   end_access %6 : $*Int
@@ -147,8 +147,8 @@ bb0(%0 : $Int, %1 : $Builtin.Int1):
   br bb1
 bb1:
   // Make sure we don't diagnose twice.
-  %4 = begin_access [modify] [unknown] %3 : $*Int // expected-note {{conflicting modification requires exclusive access}}
-  %5 = begin_access [modify] [unknown] %3 : $*Int // expected-warning {{modification requires exclusive access}}
+  %4 = begin_access [modify] [unknown] %3 : $*Int // expected-warning {{simultaneous accesses; modification requires exclusive access}}
+  %5 = begin_access [modify] [unknown] %3 : $*Int // expected-note {{conflicting access is here}}
   end_access %5: $*Int
   end_access %4: $*Int
   cond_br %1, bb1, bb2
@@ -198,8 +198,8 @@ bb0(%0 : $Int):
   %1 = alloc_box ${ var Int }
   %2 = project_box %1 : ${ var Int }, 0
   store %0 to [trivial] %2 : $*Int
-  %4 = begin_access [read] [unknown] %2 : $*Int // expected-note {{conflicting read requires shared access}}
-  %5 = begin_access [modify] [unknown] %2 : $*Int // expected-warning {{modification requires exclusive access}}
+  %4 = begin_access [read] [unknown] %2 : $*Int // expected-note {{conflicting access is here}}
+  %5 = begin_access [modify] [unknown] %2 : $*Int // expected-warning {{simultaneous accesses; modification requires exclusive access}}
   end_access %5 : $*Int
   end_access %4: $*Int
   destroy_value %1 : ${ var Int }
@@ -213,8 +213,8 @@ bb0(%0 : $Int):
   %1 = alloc_box ${ var Int }
   %2 = project_box %1 : ${ var Int }, 0
   store %0 to [trivial] %2 : $*Int
-  %4 = begin_access [modify] [unknown] %2 : $*Int // expected-note {{conflicting modification requires exclusive access}}
-  %5 = begin_access [read] [unknown] %2 : $*Int // expected-warning {{read requires shared access}}
+  %4 = begin_access [modify] [unknown] %2 : $*Int // expected-warning {{simultaneous accesses; modification requires exclusive access}}
+  %5 = begin_access [read] [unknown] %2 : $*Int // expected-note {{conflicting access is here}}
   end_access %5 : $*Int
   end_access %4: $*Int
   destroy_value %1 : ${ var Int }
@@ -232,11 +232,11 @@ sil hidden @classStoredProperty : $@convention(thin) (ClassWithStoredProperty) -
 bb0(%0 : $ClassWithStoredProperty):
   %1 = ref_element_addr %0 : $ClassWithStoredProperty, #ClassWithStoredProperty.f
 
-  // expected-note@+1{{conflicting modification requires exclusive access}}
+  // expected-warning@+1{{simultaneous accesses to var 'f'; modification requires exclusive access}}
   %2 = begin_access [modify] [dynamic] %1 : $*Int
   %3 = ref_element_addr %0 : $ClassWithStoredProperty, #ClassWithStoredProperty.f
 
-  // expected-warning@+1{{modification requires exclusive access}}
+  // expected-note@+1{{conflicting access is here}}
   %4 = begin_access [modify] [dynamic] %3 : $*Int
   end_access %4 : $*Int
   end_access %2 : $*Int
@@ -252,11 +252,11 @@ bb0(%0 : $ClassWithStoredProperty):
   %2 = begin_borrow %0 : $ClassWithStoredProperty
   %3 = ref_element_addr %1 : $ClassWithStoredProperty, #ClassWithStoredProperty.f
 
-  // expected-note@+1{{conflicting modification requires exclusive access}}
+  // expected-warning@+1{{simultaneous accesses to var 'f'; modification requires exclusive access}}
   %4 = begin_access [modify] [dynamic] %3 : $*Int
   %5 = ref_element_addr %2 : $ClassWithStoredProperty, #ClassWithStoredProperty.f
 
-  // expected-warning@+1{{modification requires exclusive access}}
+  // expected-note@+1{{conflicting access is here}}
   %6 = begin_access [modify] [dynamic] %5 : $*Int
   end_access %6 : $*Int
   end_access %4 : $*Int
@@ -279,8 +279,8 @@ bb0(%0 : $Int):
   store %0 to [trivial] %3 : $*Int
   %4 = copy_value %2 : ${ var Int }
   %5 = project_box %4 : ${ var Int }, 0
-  %6 = begin_access [modify] [unknown] %3 : $*Int  // expected-note {{conflicting modification requires exclusive access}}
-  %7 = begin_access [modify] [unknown] %5 : $*Int  // expected-warning {{modification requires exclusive access}}
+  %6 = begin_access [modify] [unknown] %3 : $*Int  // expected-warning {{simultaneous accesses; modification requires exclusive access}}
+  %7 = begin_access [modify] [unknown] %5 : $*Int  // expected-note {{conflicting access is here}}
   end_access %7 : $*Int
   end_access %6: $*Int
   destroy_value %2 : ${ var Int }
@@ -297,8 +297,8 @@ bb0(%0 : $Int):
   %3 = project_box %2 : ${ var Int }, 0
   store %0 to [trivial] %3 : $*Int
   %4 = project_box %2 : ${ var Int }, 0
-  %5 = begin_access [modify] [unknown] %3 : $*Int  // expected-note {{conflicting modification requires exclusive access}}
-  %6 = begin_access [modify] [unknown] %4 : $*Int  // expected-warning {{modification requires exclusive access}}
+  %5 = begin_access [modify] [unknown] %3 : $*Int  // expected-warning {{simultaneous accesses; modification requires exclusive access}}
+  %6 = begin_access [modify] [unknown] %4 : $*Int  // expected-note {{conflicting access is here}}
   end_access %6 : $*Int
   end_access %5: $*Int
   destroy_value %2 : ${ var Int }
@@ -315,8 +315,8 @@ sil hidden @modifySameGlobal : $@convention(thin) (Int) -> () {
 bb0(%0 : $Int):
   %1 = global_addr @global1 :$*Int
   %2 = global_addr @global1 :$*Int
-  %3 = begin_access [modify] [unknown] %1 : $*Int  // expected-note {{conflicting modification requires exclusive access}}
-  %4 = begin_access [modify] [unknown] %2 : $*Int  // expected-warning {{modification requires exclusive access}}
+  %3 = begin_access [modify] [unknown] %1 : $*Int  // expected-warning {{simultaneous accesses; modification requires exclusive access}}
+  %4 = begin_access [modify] [unknown] %2 : $*Int  // expected-note {{conflicting access is here}}
   end_access %4 : $*Int
   end_access %3: $*Int
   %5 = tuple ()
@@ -347,8 +347,8 @@ bb0(%0 : $Int):
   %3 = project_box %2 : ${ var Int }, 0
   store %0 to [trivial] %3 : $*Int
   %4 = function_ref @takesTwoInouts : $@convention(thin) (@inout Int, @inout Int) -> ()
-  %5 = begin_access [read] [unknown] %3 : $*Int  // expected-note {{conflicting read requires shared access}}
-  %6 = begin_access [modify] [unknown] %3 : $*Int  // expected-warning {{modification requires exclusive access}}
+  %5 = begin_access [read] [unknown] %3 : $*Int  // expected-note {{conflicting access is here}}
+  %6 = begin_access [modify] [unknown] %3 : $*Int  // expected-warning {{simultaneous accesses; modification requires exclusive access}}
   %7 = begin_access [read] [unknown] %3 : $*Int // no-error
   %8 = apply %4(%5, %6) : $@convention(thin) (@inout Int, @inout Int) -> ()
   end_access %7 : $*Int
@@ -368,8 +368,8 @@ bb0(%0 : $Int):
   %3 = project_box %2 : ${ var Int }, 0
   store %0 to [trivial] %3 : $*Int
   %4 = function_ref @takesTwoInouts : $@convention(thin) (@inout Int, @inout Int) -> ()
-  %5 = begin_access [modify] [unknown] %3 : $*Int  // expected-note {{conflicting modification requires exclusive access}}
-  %6 = begin_access [modify] [unknown] %3 : $*Int  // expected-warning {{modification requires exclusive access}}
+  %5 = begin_access [modify] [unknown] %3 : $*Int  // expected-warning {{simultaneous accesses; modification requires exclusive access}}
+  %6 = begin_access [modify] [unknown] %3 : $*Int  // expected-note {{conflicting access is here}}
   %7 = begin_access [modify] [unknown] %3 : $*Int  // no-error
   %8 = apply %4(%5, %6) : $@convention(thin) (@inout Int, @inout Int) -> ()
   end_access %7 : $*Int
@@ -392,8 +392,8 @@ bb0(%0 : $Int):
   %4 = function_ref @takesTwoInouts : $@convention(thin) (@inout Int, @inout Int) -> ()
   %5 = begin_access [modify] [unknown] %3 : $*Int  // no-note
   end_access %5 : $*Int
-  %6 = begin_access [modify] [unknown] %3 : $*Int  // expected-note {{conflicting modification requires exclusive access}}
-  %7 = begin_access [modify] [unknown] %3 : $*Int  // expected-warning {{modification requires exclusive access}}
+  %6 = begin_access [modify] [unknown] %3 : $*Int  // expected-warning {{simultaneous accesses; modification requires exclusive access}}
+  %7 = begin_access [modify] [unknown] %3 : $*Int  // expected-note {{conflicting access is here}}
   %8 = apply %4(%5, %6) : $@convention(thin) (@inout Int, @inout Int) -> ()
   end_access %7 : $*Int
   end_access %6: $*Int

--- a/test/SILOptimizer/exclusivity_static_diagnostics.swift
+++ b/test/SILOptimizer/exclusivity_static_diagnostics.swift
@@ -7,17 +7,22 @@ func takesTwoInouts<T>(_ p1: inout T, _ p2: inout T) { }
 func simpleInoutDiagnostic() {
   var i = 7
 
-  // expected-warning@+2{{modification requires exclusive access}}
-  // expected-note@+1{{conflicting modification requires exclusive access}}
+  // expected-warning@+2{{simultaneous accesses to var 'i'; modification requires exclusive access}}
+  // expected-note@+1{{conflicting access is here}}
   takesTwoInouts(&i, &i)
 }
 
+func inoutOnInoutParameter(p: inout Int) {
+  // expected-warning@+2{{simultaneous accesses to parameter 'p'; modification requires exclusive access}}
+  // expected-note@+1{{conflicting access is here}}
+  takesTwoInouts(&p, &p)
+}
 
 func swapNoSuppression(_ i: Int, _ j: Int) {
   var a: [Int] = [1, 2, 3]
 
-  // expected-warning@+2{{modification requires exclusive access}}
-  // expected-note@+1{{conflicting modification requires exclusive access}}
+  // expected-warning@+2{{simultaneous accesses to var 'a'; modification requires exclusive access}}
+  // expected-note@+1{{conflicting access is here}}
   swap(&a[i], &a[j]) // no-warning
 }
 
@@ -29,23 +34,23 @@ struct StructWithMutatingMethodThatTakesSelfInout {
   mutating func mutate(_ other: inout SomeClass) { }
 
   mutating func callMutatingMethodThatTakesSelfInout() {
-    // expected-warning@+2{{modification requires exclusive access}}
-    // expected-note@+1{{conflicting modification requires exclusive access}}
+    // expected-warning@+2{{simultaneous accesses to parameter 'self'; modification requires exclusive access}}
+    // expected-note@+1{{conflicting access is here}}
     mutate(&self)
   }
 
   mutating func callMutatingMethodThatTakesSelfStoredPropInout() {
-    // expected-warning@+2{{modification requires exclusive access}}
-    // expected-note@+1{{conflicting modification requires exclusive access}}
+    // expected-warning@+2{{simultaneous accesses to parameter 'self'; modification requires exclusive access}}
+    // expected-note@+1{{conflicting access is here}}
     mutate(&self.f)
   }
 }
 
-var global1 = StructWithMutatingMethodThatTakesSelfInout()
+var globalStruct1 = StructWithMutatingMethodThatTakesSelfInout()
 func callMutatingMethodThatTakesGlobalStoredPropInout() {
-  // expected-warning@+2{{modification requires exclusive access}}
-  // expected-note@+1{{conflicting modification requires exclusive access}}
-  global1.mutate(&global1.f)
+  // expected-warning@+2{{simultaneous accesses to var 'globalStruct1'; modification requires exclusive access}}
+  // expected-note@+1{{conflicting access is here}}
+  globalStruct1.mutate(&globalStruct1.f)
 }
 
 class ClassWithFinalStoredProp {
@@ -55,21 +60,21 @@ class ClassWithFinalStoredProp {
   func callMutatingMethodThatTakesClassStoredPropInout() {
     s1.mutate(&s2.f) // no-warning
 
-    // expected-warning@+2{{modification requires exclusive access}}
-    // expected-note@+1{{conflicting modification requires exclusive access}}
+    // expected-warning@+2{{simultaneous accesses to var 's1'; modification requires exclusive access}}
+    // expected-note@+1{{conflicting access is here}}
     s1.mutate(&s1.f)
 
     let local1 = self
 
-    // expected-warning@+2{{modification requires exclusive access}}
-    // expected-note@+1{{conflicting modification requires exclusive access}}
+    // expected-warning@+2{{simultaneous accesses to var 's1'; modification requires exclusive access}}
+    // expected-note@+1{{conflicting access is here}}
     local1.s1.mutate(&local1.s1.f)
   }
 }
 
 func violationWithGenericType<T>(_ p: T) {
   var local = p
-  // expected-warning@+2{{modification requires exclusive access}}
-  // expected-note@+1{{conflicting modification requires exclusive access}}
+  // expected-warning@+2{{simultaneous accesses to var 'local'; modification requires exclusive access}}
+  // expected-note@+1{{conflicting access is here}}
   takesTwoInouts(&local, &local)
 }

--- a/test/SILOptimizer/exclusivity_suppress_swap.swift
+++ b/test/SILOptimizer/exclusivity_suppress_swap.swift
@@ -9,8 +9,8 @@ func swapSuppression(_ i: Int, _ j: Int) {
 
   swap(&a[i], &a[j]) // no-warning
 
-  // expected-warning@+2{{modification requires exclusive access}}
-  // expected-note@+1{{conflicting modification requires exclusive access}}
+  // expected-warning@+2{{simultaneous accesses to var 'a'; modification requires exclusive access}}
+  // expected-note@+1{{conflicting access is here}}
   takesTwoInouts(&a[i], &a[j])
 }
 
@@ -20,8 +20,8 @@ func missedSwapSuppression(_ i: Int, _ j: Int) {
   // We don't suppress when swap() is used as a value
   let mySwap: (inout Int, inout Int) -> () = swap
 
-  // expected-warning@+2{{modification requires exclusive access}}
-  // expected-note@+1{{conflicting modification requires exclusive access}}
+  // expected-warning@+2{{simultaneous accesses to var 'a'; modification requires exclusive access}}
+  // expected-note@+1{{conflicting access is here}}
   mySwap(&a[i], &a[j])
 }
 
@@ -33,7 +33,7 @@ func dontSuppressUserSwap(_ i: Int, _ j: Int) {
     return (p1, p2) = (p2, p1)
   }
 
-  // expected-warning@+2{{modification requires exclusive access}}
-  // expected-note@+1{{conflicting modification requires exclusive access}}
+  // expected-warning@+2{{simultaneous accesses to var 'a'; modification requires exclusive access}}
+  // expected-note@+1{{conflicting access is here}}
   swap(&a[i], &a[j])
 }


### PR DESCRIPTION
Static diagnostics now refer to the identifier for the variable requiring
exclusive diagnostics. Additionally, when two accesses conflict we now always
emit the main diagnostic on the first modifying access and the note on either
the second modifying access or the read.

The diagnostics also now highlight the source range for the expression
beginning the access.