### PR TITLE
[TSan/Exclusivity] Make test more robust against optimization

### DIFF
--- a/test/Sanitizers/Inputs/tsan-uninstrumented.swift
+++ b/test/Sanitizers/Inputs/tsan-uninstrumented.swift
@@ -60,3 +60,5 @@ public var computedGlobalInUninstrumentedModule2: Int {
   get { return 0 }
   set { }
 }
+
+public func uninstrumentedBlackHole<T>(_ p: T) { }

--- a/test/Sanitizers/tsan-inout.swift
+++ b/test/Sanitizers/tsan-inout.swift
@@ -159,7 +159,7 @@ testRace(name: "InoutAccessToStoredGlobalInUninstrumentedModule",
 // the read from the global is IRGen'd to a memcpy().
 testRace(name: "ReadAndWriteToStoredGlobalInUninstrumentedModule",
         thread: { storedGlobalInUninstrumentedModule2 = 7 },
-        thread: { _ = storedGlobalInUninstrumentedModule2 } )
+        thread: { uninstrumentedBlackHole(storedGlobalInUninstrumentedModule2) } )
 // CHECK-INTERCEPTORS-ACCESSES-LABEL: Running ReadAndWriteToStoredGlobalInUninstrumentedModule
 // CHECK-INTERCEPTORS-ACCESSES: ThreadSanitizer: data race
 // CHECK-INTERCEPTORS-ACCESSES: Location is global


### PR DESCRIPTION
Add a "black hole" uninstrumented function to the test that prevents the
compiler from removing an unused read that needs to be instrumented by
TSan for the test to pass.

This is needed to prevent the optimizer from removing a useless read
when static enforcement of exclusivity is turned on.