### PR TITLE
[GSB] Warn about redeclarations of associated types from inherited protocols

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1652,6 +1652,13 @@ NOTE(previous_same_type_constraint, none,
      "%select{written here|implied here|inferred from type here}0",
      (unsigned, Type, Type))
 
+WARNING(inherited_associated_type_redecl,none,
+        "redeclaration of associated type %0 from protocol %1 is better "
+        "expressed as a 'where' clause on the protocol", (DeclName, Type))
+WARNING(typealias_override_associated_type,none,
+        "typealias overriding associated type %0 from protocol %1 is better "
+        "expressed as same-type constraint on the protocol", (DeclName, Type))
+
 ERROR(generic_param_access,none,
       "%0 %select{must be declared %select{"
       "%select{private|fileprivate|internal|%error|%error}3|private or fileprivate}4"

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -2348,11 +2348,8 @@ ${operatorComment('&' + x.operator, True)}
 //===----------------------------------------------------------------------===//
 
 /// An integer type that can represent only nonnegative values.
-public protocol UnsignedInteger : BinaryInteger {
-  /// A type that can represent the absolute value of any possible value of the
-  /// conforming type.
-  associatedtype Magnitude : BinaryInteger
-}
+public protocol UnsignedInteger : BinaryInteger
+  where Magnitude : BinaryInteger { }
 
 extension UnsignedInteger {
   /// The magnitude of this value.
@@ -2458,11 +2455,8 @@ extension UnsignedInteger where Self : FixedWidthInteger {
 //===----------------------------------------------------------------------===//
 
 /// An integer type that can represent both positive and negative values.
-public protocol SignedInteger : BinaryInteger, SignedNumeric {
-  /// A type that can represent the absolute value of any possible value of the
-  /// conforming type.
-  associatedtype Magnitude : BinaryInteger
-
+public protocol SignedInteger : BinaryInteger, SignedNumeric
+    where Magnitude : BinaryInteger {
   // These requirements are for the source code compatibility with Swift 3
   static func _maskingAdd(_ lhs: Self, _ rhs: Self) -> Self
   static func _maskingSubtract(_ lhs: Self, _ rhs: Self) -> Self

--- a/test/Constraints/generic_overload.swift
+++ b/test/Constraints/generic_overload.swift
@@ -1,7 +1,7 @@
 // RUN: %target-typecheck-verify-swift
 
-protocol P1 { associatedtype Assoc }
-protocol P2 : P1 { associatedtype Assoc }
+protocol P1 { associatedtype Assoc } // expected-note{{declared here}}
+protocol P2 : P1 { associatedtype Assoc } // expected-warning{{redeclaration of associated type}}
 protocol P3 { }
 
 struct X1 : P1 { typealias Assoc = X3 }

--- a/test/Generics/associated_type_typo.swift
+++ b/test/Generics/associated_type_typo.swift
@@ -60,10 +60,10 @@ func typoFunc3<T : P1>(x: TypoType, y: (T.Assoc) -> ()) { // expected-error{{use
 typealias Element_<S: Sequence> = S.Iterator.Element
 
 public protocol _Indexable1 {
-  associatedtype Slice
+  associatedtype Slice // expected-note{{declared here}}
 }
 public protocol Indexable : _Indexable1 {
-  associatedtype Slice : _Indexable1
+  associatedtype Slice : _Indexable1 // expected-warning{{redeclaration of associated type 'Slice'}}
 }
 
 protocol Pattern {

--- a/test/Generics/associated_type_where_clause.swift
+++ b/test/Generics/associated_type_where_clause.swift
@@ -138,16 +138,16 @@ protocol P {
 
 // Lookup of same-named associated types aren't ambiguous in this context.
 protocol P1 {
-  associatedtype A
+  associatedtype A // expected-note 2{{declared here}}
 }
 
 protocol P2: P1 {
-  associatedtype A
+  associatedtype A // expected-warning{{redeclaration of associated type}}
   associatedtype B where A == B
 }
 
 protocol P3: P1 {
-  associatedtype A
+  associatedtype A // expected-warning{{redeclaration of associated type}}
 }
 
 protocol P4 {

--- a/test/Generics/associated_type_where_clause_hints.swift
+++ b/test/Generics/associated_type_where_clause_hints.swift
@@ -1,0 +1,39 @@
+// RUN: %target-typecheck-verify-swift -typecheck %s -verify
+
+protocol P0 { }
+protocol P0b { }
+
+struct X0 : P0 { }
+
+struct X1 { }
+
+protocol P1 {
+  associatedtype A // expected-note 2{{'A' declared here}}
+}
+
+// A typealias in a subprotocol should be written as a same-type
+// requirement.
+protocol P2 : P1 {
+  typealias A = X1 // expected-warning{{typealias overriding associated type 'A' from protocol 'P1' is better expressed as same-type constraint on the protocol}}{{17-17= where A == X1}}{{3-20=}}
+}
+
+// A redeclaration of an associated type that adds type/layout requirements
+// should be written via a where clause.
+protocol P3a : P1 {
+  associatedtype A: P0, P0b // expected-warning{{redeclaration of associated type 'A' from protocol 'P1' is better expressed as a 'where' clause on the protocol}}{{18-18= where A: P0, A: P0b}}{{3-29=}}
+}
+
+// ... unless it has adds a default type witness
+protocol P3b : P1 {
+  associatedtype A: P0 = X0   // note: no warning
+}
+
+protocol P4: P1 {
+  associatedtype B // expected-note{{'B' declared here}}
+}
+
+protocol P5: P4 where A: P0 {
+  typealias B = X1 // expected-warning{{typealias overriding associated type 'B' from protocol 'P4' is better expressed as same-type constraint on the protocol}}{{28-28=, B == X1}}{{3-20=}}
+}
+
+

--- a/test/Generics/canonicalization.swift
+++ b/test/Generics/canonicalization.swift
@@ -4,11 +4,11 @@
 protocol P0 { }
 
 protocol P {
-  associatedtype A
+  associatedtype A // expected-note{{declared here}}
 }
 
 protocol Q : P {
-  associatedtype A
+  associatedtype A // expected-warning{{redeclaration of associated type 'A' from protocol 'P' is better expressed as a 'where' clause on the protocol}}
 }
 
 func f<T>(t: T) where T : P, T : Q, T.A : P0 { } // expected-note{{'f(t:)' previously declared here}}

--- a/test/Generics/conformance_access_path.swift
+++ b/test/Generics/conformance_access_path.swift
@@ -58,10 +58,11 @@ func testPaths3<V: P5>(_ v: V) {
 
 protocol P6Unordered: P5Unordered { // expected-note{{conformance constraint 'Self.A': 'P0' implied here}}
 	associatedtype A: P0 // expected-warning{{redundant conformance constraint 'Self.A': 'P0'}}
+                       // expected-warning@-1{{redeclaration of associated type 'A'}}
 }
 
 protocol P5Unordered {
-	associatedtype A: P0
+	associatedtype A: P0 // expected-note{{'A' declared here}}
 
 	func getA() -> A
 }

--- a/test/Generics/protocol_requirement_signatures.swift
+++ b/test/Generics/protocol_requirement_signatures.swift
@@ -22,7 +22,7 @@ protocol P3 {}
 // CHECK-NEXT: Requirement signature: <Self where Self.X : P1>
 // CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0.X : P1>
 protocol Q1 {
-    associatedtype X: P1
+    associatedtype X: P1 // expected-note 2{{declared here}}
 }
 
 // inheritance
@@ -36,7 +36,7 @@ protocol Q2: Q1 {}
 // CHECK-NEXT: Requirement signature: <Self where Self : Q1>
 // CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0 : Q1>
 protocol Q3: Q1 {
-    associatedtype X
+    associatedtype X // expected-warning{{redeclaration of associated type 'X'}}
 }
 
 // inheritance adding a new conformance
@@ -44,7 +44,8 @@ protocol Q3: Q1 {
 // CHECK-NEXT: Requirement signature: <Self where Self : Q1, Self.X : P2>
 // CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0 : Q1, τ_0_0.X : P2>
 protocol Q4: Q1 {
-    associatedtype X: P2
+    associatedtype X: P2 // expected-warning{{redeclaration of associated type 'X'}}
+                   // expected-note@-1 2{{'X' declared here}}
 }
 
 // multiple inheritance
@@ -60,6 +61,7 @@ protocol Q5: Q2, Q3, Q4 {}
 protocol Q6: Q2, // expected-note{{conformance constraint 'Self.X': 'P1' implied here}}
              Q3, Q4 {
     associatedtype X: P1 // expected-warning{{redundant conformance constraint 'Self.X': 'P1'}}
+                   // expected-warning@-1{{redeclaration of associated type 'X' from protocol 'Q4' is}}
 }
 
 // multiple inheritance with a new conformance
@@ -67,5 +69,5 @@ protocol Q6: Q2, // expected-note{{conformance constraint 'Self.X': 'P1' implied
 // CHECK-NEXT: Requirement signature: <Self where Self : Q2, Self : Q3, Self : Q4, Self.X : P3>
 // CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0 : Q2, τ_0_0 : Q3, τ_0_0 : Q4, τ_0_0.X : P3>
 protocol Q7: Q2, Q3, Q4 {
-    associatedtype X: P3
+    associatedtype X: P3 // expected-warning{{redeclaration of associated type 'X'}}
 }

--- a/test/Generics/protocol_type_aliases.swift
+++ b/test/Generics/protocol_type_aliases.swift
@@ -6,7 +6,7 @@
 func sameType<T>(_: T.Type, _: T.Type) {}
 
 protocol P {
-    associatedtype A
+    associatedtype A // expected-note{{'A' declared here}}
     typealias X = A
 }
 protocol Q {
@@ -72,7 +72,7 @@ func useTypealias1<T: Q3_1>(_: T, _: T.T) {}
 // Subprotocols can force associated types in their parents to be concrete, and
 // this should be understood for types constrained by the subprotocols.
 protocol Q4: P {
-    typealias A = Int
+    typealias A = Int // expected-warning{{typealias overriding associated type 'A' from protocol 'P'}}
 }
 protocol Q5: P {
     typealias X = Int
@@ -98,13 +98,13 @@ func checkQ5_X<T: Q5>(x: T.Type) { sameType(getP_X(x), Int.self) }
 // Typealiases happen to allow imposing same type requirements between parent
 // protocols
 protocol P6_1 {
-    associatedtype A
+    associatedtype A // expected-note{{'A' declared here}}
 }
 protocol P6_2 {
     associatedtype B
 }
 protocol Q6: P6_1, P6_2 {
-    typealias A = B
+    typealias A = B // expected-warning{{typealias overriding associated type}}
 }
 
 func getP6_1_A<T: P6_1>(_: T.Type) -> T.A.Type { return T.A.self }

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -161,13 +161,13 @@ extension P7 where AssocP6.Element : P6, // expected-note{{conformance constrain
 }
 
 protocol P8 {
-  associatedtype A
-  associatedtype B
+  associatedtype A // expected-note{{'A' declared here}}
+  associatedtype B // expected-note{{'B' declared here}}
 }
 
 protocol P9 : P8 {
-  associatedtype A
-  associatedtype B
+  associatedtype A // expected-warning{{redeclaration of associated type 'A' from protocol 'P8' is better expressed as a 'where' clause on the protocol}}
+  associatedtype B // expected-warning{{redeclaration of associated type 'B' from protocol 'P8' is better expressed as a 'where' clause on the protocol}}
 }
 
 protocol P10 {

--- a/test/IDE/complete_associated_types.swift
+++ b/test/IDE/complete_associated_types.swift
@@ -32,8 +32,8 @@ protocol FooBaseProtocolWithAssociatedTypes {
   associatedtype FooBaseDefaultedTypeB = Int
   associatedtype FooBaseDefaultedTypeC = Int
 
-  associatedtype DeducedTypeCommonA
-  associatedtype DeducedTypeCommonB
+  associatedtype DeducedTypeCommonA // expected-note{{declared here}}
+  associatedtype DeducedTypeCommonB // expected-note{{declared here}}
   associatedtype DeducedTypeCommonC
   associatedtype DeducedTypeCommonD
   func deduceCommonA() -> DeducedTypeCommonA
@@ -57,8 +57,8 @@ protocol FooProtocolWithAssociatedTypes : FooBaseProtocolWithAssociatedTypes {
 
   associatedtype FooBaseDefaultedTypeB = Double
 
-  associatedtype DeducedTypeCommonA
-  associatedtype DeducedTypeCommonB
+  associatedtype DeducedTypeCommonA // expected-warning{{redeclaration of associated type}}
+  associatedtype DeducedTypeCommonB // expected-warning{{redeclaration of associated type}}
   func deduceCommonA() -> DeducedTypeCommonA
   func deduceCommonB() -> DeducedTypeCommonB
 
@@ -79,7 +79,7 @@ protocol BarBaseProtocolWithAssociatedTypes {
   associatedtype DefaultedTypeCommonA = Int
   associatedtype DefaultedTypeCommonC = Int
 
-  associatedtype DeducedTypeCommonA
+  associatedtype DeducedTypeCommonA // expected-note{{'DeducedTypeCommonA' declared here}}
   associatedtype DeducedTypeCommonC
   func deduceCommonA() -> DeducedTypeCommonA
   func deduceCommonC() -> DeducedTypeCommonC
@@ -102,7 +102,7 @@ protocol BarProtocolWithAssociatedTypes : BarBaseProtocolWithAssociatedTypes {
   associatedtype DefaultedTypeCommonA = Int
   associatedtype DefaultedTypeCommonD = Int
 
-  associatedtype DeducedTypeCommonA
+  associatedtype DeducedTypeCommonA // expected-warning{{redeclaration of associated type}}
   associatedtype DeducedTypeCommonD
   func deduceCommonA() -> DeducedTypeCommonA
   func deduceCommonD() -> DeducedTypeCommonD

--- a/test/attr/attr_autoclosure.swift
+++ b/test/attr/attr_autoclosure.swift
@@ -40,10 +40,10 @@ class DerivedClass {
 }
 
 protocol P1 {
-  associatedtype Element
+  associatedtype Element // expected-note{{declared here}}
 }
 protocol P2 : P1 {
-  associatedtype Element
+  associatedtype Element // expected-warning{{redeclaration of associated type 'Element'}}
 }
 
 func overloadedEach<O: P1>(_ source: O, _ closure: @escaping () -> ()) {

--- a/test/attr/attr_noescape.swift
+++ b/test/attr/attr_noescape.swift
@@ -183,10 +183,10 @@ func redundant(_ fn : @noescape  // expected-error @+1 {{@noescape is implied by
 
 
 protocol P1 {
-  associatedtype Element
+  associatedtype Element // expected-note{{declared here}}
 }
 protocol P2 : P1 {
-  associatedtype Element
+  associatedtype Element // expected-warning{{redeclaration of associated type 'Element'}}
 }
 
 func overloadedEach<O: P1, T>(_ source: O, _ transform: @escaping (O.Element) -> (), _: T) {}

--- a/test/attr/attr_override.swift
+++ b/test/attr/attr_override.swift
@@ -423,11 +423,11 @@ protocol SI {}
 protocol CI {}
 
 protocol Sequence {
-  associatedtype I : SI
+  associatedtype I : SI // expected-note{{declared here}}
 }
 
 protocol Collection : Sequence {
-  associatedtype I : CI
+  associatedtype I : CI // expected-warning{{redeclaration of associated type 'I'}}
 }
 
 class Index<F, T> {

--- a/test/decl/protocol/indirectly_recursive_requirement.swift
+++ b/test/decl/protocol/indirectly_recursive_requirement.swift
@@ -5,7 +5,7 @@ protocol Incrementable  {
 }
 
 protocol _ForwardIndex  {
-  associatedtype Distance  = MyInt
+  associatedtype Distance  = MyInt // expected-note{{declared here}}
 }
 
 protocol ForwardIndex : _ForwardIndex {
@@ -19,7 +19,7 @@ protocol BidirectionalIndex : ForwardIndex, _BidirectionalIndex {
 }
 
 protocol _RandomAccessIndex : _BidirectionalIndex {
-  associatedtype Distance
+  associatedtype Distance // expected-warning{{redeclaration of associated type 'Distance}}
 }
 
 protocol RandomAccessIndex 


### PR DESCRIPTION
Introduce a warning about redeclaring the associated types from an
inherited protocol in the protocol being checked:

* If the new declaration is an associated type, note that the
  declaration could be replaced by requirements in the protocol's
  where clause.
* If the new declaration is a typealias, note that it could be
  replaced by a same-type constraint in the protocol's where clause.
