### PR TITLE
[Exclusivity] Enable static memory access enforcement markers.

### DIFF
--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -150,12 +150,6 @@ public:
   /// Emit checks to trap at run time when the law of exclusivity is violated.
   bool EnforceExclusivityDynamic = false;
 
-  /// Returns true when either static or dynamic exclusivity enforcement
-  /// is enabled.
-  bool isAnyExclusivityEnforcementEnabled() {
-    return EnforceExclusivityStatic || EnforceExclusivityDynamic;
-  }
-
   /// Enable the mandatory semantic arc optimizer.
   bool EnableMandatorySemanticARCOpts = false;
 

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -1275,8 +1275,7 @@ public:
     require(BAI->getType().isAddress(),
             "begin_access operand must have address type");
 
-    // Any kind of access marker can be used in the raw stage if either kind
-    // of enforcement is enabled globally.
+    // Any kind of access marker can be used in the raw stage.
     // After the raw stage, only dynamic access markers can be used, and
     // only if dynamic enforcement is enabled globally.
     // Eventually, we should allow access markers to persist in SIL, and
@@ -1284,23 +1283,20 @@ public:
     // passes first.
     switch (BAI->getEnforcement()) {
     case SILAccessEnforcement::Unknown:
-      require(F.getModule().getOptions().isAnyExclusivityEnforcementEnabled()
-              && BAI->getModule().getStage() == SILStage::Raw,
+      require(BAI->getModule().getStage() == SILStage::Raw,
               "access must have known enforcement outside raw stage");
       break;
 
     case SILAccessEnforcement::Static:
     case SILAccessEnforcement::Unsafe:
-      require(F.getModule().getOptions().isAnyExclusivityEnforcementEnabled()
-              && BAI->getModule().getStage() == SILStage::Raw,
+      require(BAI->getModule().getStage() == SILStage::Raw,
               "non-dynamic enforcement is currently disallowed outside "
               "raw stage");
       break;
 
     case SILAccessEnforcement::Dynamic:
-      require(F.getModule().getOptions().EnforceExclusivityDynamic ||
-              (F.getModule().getOptions().EnforceExclusivityStatic &&
-               BAI->getModule().getStage() == SILStage::Raw),
+      require(F.getModule().getOptions().EnforceExclusivityDynamic
+              || BAI->getModule().getStage() == SILStage::Raw,
               "dynamic access enforcement is only allowed after raw stage when "
               "globally enabled");
       break;

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -135,9 +135,7 @@ static bool shouldUseUnsafeEnforcement(VarDecl *var) {
 
 Optional<SILAccessEnforcement>
 SILGenFunction::getStaticEnforcement(VarDecl *var) {
-  if (getOptions().EnforceExclusivityStatic)
-    return SILAccessEnforcement::Static;
-  return None;
+  return SILAccessEnforcement::Static;
 }
 
 Optional<SILAccessEnforcement>
@@ -152,10 +150,7 @@ SILGenFunction::getDynamicEnforcement(VarDecl *var) {
 
 Optional<SILAccessEnforcement>
 SILGenFunction::getUnknownEnforcement(VarDecl *var) {
-  if (getOptions().EnforceExclusivityStatic ||
-      getOptions().EnforceExclusivityDynamic)
-    return SILAccessEnforcement::Unknown;
-  return None;
+  return SILAccessEnforcement::Unknown;
 }
 
 /// SILGenLValue - An ASTVisitor for building logical lvalues.

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -2895,7 +2895,6 @@ void SILGenFunction::emitAssignLValueToLValue(SILLocation loc, LValue &&src,
   // because it causes the formal accesses to the source and destination to
   // overlap.
   bool peepholeConflict =
-      getOptions().isAnyExclusivityEnforcementEnabled() &&
       !src.isObviouslyNonConflicting(dest, AccessKind::Read, AccessKind::Write);
 
   if (peepholeConflict || !src.isPhysical() || !dest.isPhysical()) {

--- a/lib/SILOptimizer/Mandatory/AccessMarkerElimination.cpp
+++ b/lib/SILOptimizer/Mandatory/AccessMarkerElimination.cpp
@@ -35,8 +35,6 @@ struct AccessMarkerElimination : SILModuleTransform {
     // Don't bother doing anything unless some kind of exclusivity
     // enforcement is enabled.
     auto &M = *getModule();
-    if (!M.getOptions().isAnyExclusivityEnforcementEnabled())
-      return;
 
     bool removedAny = false;
 

--- a/test/SILGen/address_only_types.swift
+++ b/test/SILGen/address_only_types.swift
@@ -161,7 +161,8 @@ func address_only_assignment_from_temp(_ dest: inout Unloadable) {
   // CHECK: bb0([[DEST:%[0-9]+]] : $*Unloadable):
   dest = some_address_only_function_1()
   // CHECK: [[TEMP:%[0-9]+]] = alloc_stack $Unloadable
-  // CHECK: copy_addr [take] [[TEMP]] to %0 :
+  // CHECK: %[[ACCESS:.*]] = begin_access [modify] [unknown] %0 :
+  // CHECK: copy_addr [take] [[TEMP]] to %[[ACCESS]] :
   // CHECK-NOT: destroy_addr [[TEMP]]
   // CHECK: dealloc_stack [[TEMP]]
 }
@@ -174,8 +175,11 @@ func address_only_assignment_from_lv(_ dest: inout Unloadable, v: Unloadable) {
   // CHECK: [[PBOX:%[0-9]+]] = project_box [[VBOX]]
   // CHECK: copy_addr [[VARG]] to [initialization] [[PBOX]] : $*Unloadable
   dest = v
-  // FIXME: emit into?
-  // CHECK: copy_addr [[PBOX]] to %0 :
+  // CHECK: [[READBOX:%.*]] = begin_access [read] [unknown] [[PBOX]] :
+  // CHECK: [[TEMP:%[0-9]+]] = alloc_stack $Unloadable
+  // CHECK: copy_addr [[READBOX]] to [initialization] [[TEMP]] :
+  // CHECK: [[RET:%.*]] = begin_access [modify] [unknown] %0 :
+  // CHECK: copy_addr [take] [[TEMP]] to [[RET]] :
   // CHECK: destroy_value [[VBOX]]
 }
 
@@ -216,7 +220,8 @@ func address_only_var() -> Unloadable {
   // CHECK: [[XPB:%.*]] = project_box [[XBOX]]
   // CHECK: apply {{%.*}}([[XPB]])
   return x
-  // CHECK: copy_addr [[XPB]] to [initialization] [[RET]]
+  // CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[XPB]] :
+  // CHECK: copy_addr [[ACCESS]] to [initialization] %0
   // CHECK: destroy_value [[XBOX]]
   // CHECK: return
 }

--- a/test/SILGen/addressors.swift
+++ b/test/SILGen/addressors.swift
@@ -178,8 +178,9 @@ struct D : Subscriptable {
 // SILGEN:   debug_value [[VALUE]] : $Int32
 // SILGEN:   debug_value [[I]] : $Int32
 // SILGEN:   debug_value_addr [[SELF]]
+// SILGEN:   [[ACCESS:%.*]] = begin_access [modify] [unknown] [[SELF]] : $*D   // users: %12, %8
 // SILGEN:   [[T0:%.*]] = function_ref @_T010addressors1DV9subscripts5Int32VAFcfau{{.*}}
-// SILGEN:   [[PTR:%.*]] = apply [[T0]]([[I]], [[SELF]])
+// SILGEN:   [[PTR:%.*]] = apply [[T0]]([[I]], [[ACCESS]])
 // SILGEN:   [[T0:%.*]] = struct_extract [[PTR]] : $UnsafeMutablePointer<Int32>,
 // SILGEN:   [[ADDR:%.*]] = pointer_to_address [[T0]] : $Builtin.RawPointer to [strict] $*Int32
 // SILGEN:   assign [[VALUE]] to [[ADDR]] : $*Int32

--- a/test/SILGen/borrow.swift
+++ b/test/SILGen/borrow.swift
@@ -17,7 +17,8 @@ func useD(_ d: D) {}
 // CHECK:   [[BOX:%.*]] = alloc_box ${ var C }, var, name "c"
 // CHECK:   [[PB_BOX:%.*]] = project_box [[BOX]]
 // CHECK:   [[FUNC:%.*]] = function_ref @_T06borrow4useD{{.*}} : $@convention(thin) (@owned D) -> ()
-// CHECK:   [[CLASS:%.*]] = load [copy] [[PB_BOX]]
+// CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[PB_BOX]] : $*C
+// CHECK:   [[CLASS:%.*]] = load [copy] [[ACCESS]]
 // CHECK:   [[BORROWED_CLASS:%.*]] = begin_borrow [[CLASS]]
 // CHECK:   [[OFFSET:%.*]] = ref_element_addr [[BORROWED_CLASS]]
 // CHECK:   [[LOADED_VALUE:%.*]] = load [copy] [[OFFSET]]

--- a/test/SILGen/boxed_existentials.swift
+++ b/test/SILGen/boxed_existentials.swift
@@ -84,7 +84,8 @@ func test_property_of_lvalue(_ x: Error) -> String {
 // CHECK:         [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
 // CHECK:         [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]] : $Error
 // CHECK:         store [[ARG_COPY]] to [init] [[PVAR]]
-// CHECK:         [[VALUE_BOX:%.*]] = load [copy] [[PVAR]]
+// CHECK:         [[ACCESS:%.*]] = begin_access [read] [unknown] [[PVAR]] : $*Error
+// CHECK:         [[VALUE_BOX:%.*]] = load [copy] [[ACCESS]]
 // CHECK:         [[VALUE:%.*]] = open_existential_box [[VALUE_BOX]] : $Error to $*[[VALUE_TYPE:@opened\(.*\) Error]]
 // CHECK:         [[COPY:%.*]] = alloc_stack $[[VALUE_TYPE]]
 // CHECK:         copy_addr [[VALUE]] to [initialization] [[COPY]]
@@ -150,7 +151,8 @@ func test_open_existential_semantics(_ guaranteed: Error,
   // GUARANTEED-NOT: destroy_value [[ARG0]]
   guaranteed.extensionMethod()
 
-  // CHECK: [[IMMEDIATE:%.*]] = load [copy] [[PB]]
+  // CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[PB]] : $*Error
+  // CHECK: [[IMMEDIATE:%.*]] = load [copy] [[ACCESS]]
   // -- need a copy_value to guarantee
   // CHECK: [[VALUE:%.*]] = open_existential_box [[IMMEDIATE]]
   // CHECK: [[METHOD:%.*]] = function_ref
@@ -161,7 +163,8 @@ func test_open_existential_semantics(_ guaranteed: Error,
   //    out.
   // CHECK: destroy_value [[IMMEDIATE]]
 
-  // GUARANTEED: [[IMMEDIATE:%.*]] = load [copy] [[PB]]
+  // GUARANTEED: [[ACCESS:%.*]] = begin_access [read] [unknown] [[PB]] : $*Error
+  // GUARANTEED: [[IMMEDIATE:%.*]] = load [copy] [[ACCESS]]
   // -- need a copy_value to guarantee
   // GUARANTEED: [[VALUE:%.*]] = open_existential_box [[IMMEDIATE]]
   // GUARANTEED: [[METHOD:%.*]] = function_ref
@@ -203,7 +206,8 @@ func erasure_to_any(_ guaranteed: Error, _ immediate: Error) -> Any {
     // CHECK-NOT: destroy_value [[GUAR]]
     return guaranteed
   } else if true {
-    // CHECK:     [[IMMEDIATE:%.*]] = load [copy] [[PB]]
+    // CHECK:     [[ACCESS:%.*]] = begin_access [read] [unknown] [[PB]]
+    // CHECK:     [[IMMEDIATE:%.*]] = load [copy] [[ACCESS]]
     // CHECK:     [[FROM_VALUE:%.*]] = open_existential_box [[IMMEDIATE]]
     // CHECK:     [[TO_VALUE:%.*]] = init_existential_addr [[OUT]]
     // CHECK:     copy_addr [[FROM_VALUE]] to [initialization] [[TO_VALUE]]

--- a/test/SILGen/builtins.swift
+++ b/test/SILGen/builtins.swift
@@ -670,7 +670,8 @@ func pinUnpin(_ object : Builtin.NativeObject) {
 // NativeObject
 // CHECK-LABEL: sil hidden @_T08builtins8isUnique{{[_0-9a-zA-Z]*}}F
 // CHECK: bb0(%0 : $*Optional<Builtin.NativeObject>):
-// CHECK: [[BUILTIN:%.*]] = is_unique %0 : $*Optional<Builtin.NativeObject>
+// CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] %0 : $*Optional<Builtin.NativeObject>
+// CHECK: [[BUILTIN:%.*]] = is_unique [[WRITE]] : $*Optional<Builtin.NativeObject>
 // CHECK: return
 func isUnique(_ ref: inout Builtin.NativeObject?) -> Bool {
   return _getBool(Builtin.isUnique(&ref))
@@ -679,7 +680,8 @@ func isUnique(_ ref: inout Builtin.NativeObject?) -> Bool {
 // NativeObject nonNull
 // CHECK-LABEL: sil hidden @_T08builtins8isUnique{{[_0-9a-zA-Z]*}}F
 // CHECK: bb0(%0 : $*Builtin.NativeObject):
-// CHECK: [[BUILTIN:%.*]] = is_unique %0 : $*Builtin.NativeObject
+// CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] %0
+// CHECK: [[BUILTIN:%.*]] = is_unique [[WRITE]] : $*Builtin.NativeObject
 // CHECK: return
 func isUnique(_ ref: inout Builtin.NativeObject) -> Bool {
   return _getBool(Builtin.isUnique(&ref))
@@ -688,7 +690,8 @@ func isUnique(_ ref: inout Builtin.NativeObject) -> Bool {
 // NativeObject pinned
 // CHECK-LABEL: sil hidden @_T08builtins16isUniqueOrPinned{{[_0-9a-zA-Z]*}}F
 // CHECK: bb0(%0 : $*Optional<Builtin.NativeObject>):
-// CHECK: [[BUILTIN:%.*]] = is_unique_or_pinned %0 : $*Optional<Builtin.NativeObject>
+// CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] %0
+// CHECK: [[BUILTIN:%.*]] = is_unique_or_pinned [[WRITE]] : $*Optional<Builtin.NativeObject>
 // CHECK: return
 func isUniqueOrPinned(_ ref: inout Builtin.NativeObject?) -> Bool {
   return _getBool(Builtin.isUniqueOrPinned(&ref))
@@ -697,7 +700,8 @@ func isUniqueOrPinned(_ ref: inout Builtin.NativeObject?) -> Bool {
 // NativeObject pinned nonNull
 // CHECK-LABEL: sil hidden @_T08builtins16isUniqueOrPinned{{[_0-9a-zA-Z]*}}F
 // CHECK: bb0(%0 : $*Builtin.NativeObject):
-// CHECK: [[BUILTIN:%.*]] = is_unique_or_pinned %0 : $*Builtin.NativeObject
+// CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] %0
+// CHECK: [[BUILTIN:%.*]] = is_unique_or_pinned [[WRITE]] : $*Builtin.NativeObject
 // CHECK: return
 func isUniqueOrPinned(_ ref: inout Builtin.NativeObject) -> Bool {
   return _getBool(Builtin.isUniqueOrPinned(&ref))
@@ -706,7 +710,8 @@ func isUniqueOrPinned(_ ref: inout Builtin.NativeObject) -> Bool {
 // UnknownObject (ObjC)
 // CHECK-LABEL: sil hidden @_T08builtins8isUnique{{[_0-9a-zA-Z]*}}F
 // CHECK: bb0(%0 : $*Optional<Builtin.UnknownObject>):
-// CHECK: [[BUILTIN:%.*]] = is_unique %0 : $*Optional<Builtin.UnknownObject>
+// CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] %0
+// CHECK: [[BUILTIN:%.*]] = is_unique [[WRITE]] : $*Optional<Builtin.UnknownObject>
 // CHECK: return
 func isUnique(_ ref: inout Builtin.UnknownObject?) -> Bool {
   return _getBool(Builtin.isUnique(&ref))
@@ -715,7 +720,8 @@ func isUnique(_ ref: inout Builtin.UnknownObject?) -> Bool {
 // UnknownObject (ObjC) nonNull
 // CHECK-LABEL: sil hidden @_T08builtins8isUnique{{[_0-9a-zA-Z]*}}F
 // CHECK: bb0(%0 : $*Builtin.UnknownObject):
-// CHECK: [[BUILTIN:%.*]] = is_unique %0 : $*Builtin.UnknownObject
+// CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] %0
+// CHECK: [[BUILTIN:%.*]] = is_unique [[WRITE]] : $*Builtin.UnknownObject
 // CHECK: return
 func isUnique(_ ref: inout Builtin.UnknownObject) -> Bool {
   return _getBool(Builtin.isUnique(&ref))
@@ -724,7 +730,8 @@ func isUnique(_ ref: inout Builtin.UnknownObject) -> Bool {
 // UnknownObject (ObjC) pinned nonNull
 // CHECK-LABEL: sil hidden @_T08builtins16isUniqueOrPinned{{[_0-9a-zA-Z]*}}F
 // CHECK: bb0(%0 : $*Builtin.UnknownObject):
-// CHECK: [[BUILTIN:%.*]] = is_unique_or_pinned %0 : $*Builtin.UnknownObject
+// CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] %0
+// CHECK: [[BUILTIN:%.*]] = is_unique_or_pinned [[WRITE]] : $*Builtin.UnknownObject
 // CHECK: return
 func isUniqueOrPinned(_ ref: inout Builtin.UnknownObject) -> Bool {
   return _getBool(Builtin.isUniqueOrPinned(&ref))
@@ -733,7 +740,8 @@ func isUniqueOrPinned(_ ref: inout Builtin.UnknownObject) -> Bool {
 // BridgeObject nonNull
 // CHECK-LABEL: sil hidden @_T08builtins8isUnique{{[_0-9a-zA-Z]*}}F
 // CHECK: bb0(%0 : $*Builtin.BridgeObject):
-// CHECK: [[BUILTIN:%.*]] = is_unique %0 : $*Builtin.BridgeObject
+// CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] %0
+// CHECK: [[BUILTIN:%.*]] = is_unique [[WRITE]] : $*Builtin.BridgeObject
 // CHECK: return
 func isUnique(_ ref: inout Builtin.BridgeObject) -> Bool {
   return _getBool(Builtin.isUnique(&ref))
@@ -742,7 +750,8 @@ func isUnique(_ ref: inout Builtin.BridgeObject) -> Bool {
 // BridgeObject pinned nonNull
 // CHECK-LABEL: sil hidden @_T08builtins16isUniqueOrPinned{{[_0-9a-zA-Z]*}}F
 // CHECK: bb0(%0 : $*Builtin.BridgeObject):
-// CHECK: [[BUILTIN:%.*]] = is_unique_or_pinned %0 : $*Builtin.BridgeObject
+// CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] %0
+// CHECK: [[BUILTIN:%.*]] = is_unique_or_pinned [[WRITE]] : $*Builtin.BridgeObject
 // CHECK: return
 func isUniqueOrPinned(_ ref: inout Builtin.BridgeObject) -> Bool {
   return _getBool(Builtin.isUniqueOrPinned(&ref))
@@ -751,7 +760,8 @@ func isUniqueOrPinned(_ ref: inout Builtin.BridgeObject) -> Bool {
 // BridgeObject nonNull native
 // CHECK-LABEL: sil hidden @_T08builtins15isUnique_native{{[_0-9a-zA-Z]*}}F
 // CHECK: bb0(%0 : $*Builtin.BridgeObject):
-// CHECK: [[CAST:%.*]] = unchecked_addr_cast %0 : $*Builtin.BridgeObject to $*Builtin.NativeObject
+// CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] %0
+// CHECK: [[CAST:%.*]] = unchecked_addr_cast [[WRITE]] : $*Builtin.BridgeObject to $*Builtin.NativeObject
 // CHECK: return
 func isUnique_native(_ ref: inout Builtin.BridgeObject) -> Bool {
   return _getBool(Builtin.isUnique_native(&ref))
@@ -760,7 +770,8 @@ func isUnique_native(_ ref: inout Builtin.BridgeObject) -> Bool {
 // BridgeObject pinned nonNull native
 // CHECK-LABEL: sil hidden @_T08builtins23isUniqueOrPinned_native{{[_0-9a-zA-Z]*}}F
 // CHECK: bb0(%0 : $*Builtin.BridgeObject):
-// CHECK: [[CAST:%.*]] = unchecked_addr_cast %0 : $*Builtin.BridgeObject to $*Builtin.NativeObject
+// CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] %0
+// CHECK: [[CAST:%.*]] = unchecked_addr_cast [[WRITE]] : $*Builtin.BridgeObject to $*Builtin.NativeObject
 // CHECK: [[BUILTIN:%.*]] = is_unique_or_pinned [[CAST]] : $*Builtin.NativeObject
 // CHECK: return
 func isUniqueOrPinned_native(_ ref: inout Builtin.BridgeObject) -> Bool {

--- a/test/SILGen/cf_members.swift
+++ b/test/SILGen/cf_members.swift
@@ -51,17 +51,20 @@ public func foo(_ x: Double) {
   // z = b(x)
 
   // CHECK: [[FN:%.*]] = function_ref @IAMStruct1InvertInPlace
-  // CHECK: apply [[FN]]([[Z]])
+  // CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] [[Z]] : $*Struct1
+  // CHECK: apply [[FN]]([[WRITE]])
   z.invert()
 
   // CHECK: [[FN:%.*]] = function_ref @IAMStruct1Rotate : $@convention(c) (@in Struct1, Double) -> Struct1
-  // CHECK: [[ZVAL:%.*]] = load [trivial] [[Z]]
+  // CHECK: [[WRITE:%.*]] = begin_access [read] [unknown] [[Z]] : $*Struct1
+  // CHECK: [[ZVAL:%.*]] = load [trivial] [[WRITE]]
   // CHECK: store [[ZVAL]] to [trivial] [[ZTMP:%.*]] :
   // CHECK: apply [[FN]]([[ZTMP]], [[X]])
   z = z.translate(radians: x)
 
   // CHECK: [[THUNK:%.*]] = function_ref [[THUNK_NAME:@_T0SC7Struct1V9translateABSd7radians_tFTcTO]]
-  // CHECK: [[ZVAL:%.*]] = load [trivial] [[Z]]
+  // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[Z]] : $*Struct1
+  // CHECK: [[ZVAL:%.*]] = load [trivial] [[READ]]
   // CHECK: [[C:%.*]] = apply [[THUNK]]([[ZVAL]])
   // CHECK: [[BORROWED_C:%.*]] = begin_borrow [[C]]
   // CHECK: [[C_COPY:%.*]] = copy_value [[BORROWED_C]]
@@ -82,12 +85,14 @@ public func foo(_ x: Double) {
   // z = e(z, x)
 
   // CHECK: [[FN:%.*]] = function_ref @IAMStruct1Scale
-  // CHECK: [[ZVAL:%.*]] = load [trivial] [[Z]]
+  // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[Z]] : $*Struct1
+  // CHECK: [[ZVAL:%.*]] = load [trivial] [[READ]]
   // CHECK: apply [[FN]]([[ZVAL]], [[X]])
   z = z.scale(x)
 
   // CHECK: [[THUNK:%.*]] = function_ref @_T0SC7Struct1V5scaleABSdFTcTO
-  // CHECK: [[ZVAL:%.*]] = load [trivial] [[Z]]
+  // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[Z]] : $*Struct1
+  // CHECK: [[ZVAL:%.*]] = load [trivial] [[READ]]
   // CHECK: [[F:%.*]] = apply [[THUNK]]([[ZVAL]])
   // CHECK: [[BORROWED_F:%.*]] = begin_borrow [[F]]
   // CHECK: [[F_COPY:%.*]] = copy_value [[BORROWED_F]]
@@ -98,7 +103,8 @@ public func foo(_ x: Double) {
   // CHECK: [[THUNK:%.*]] = function_ref @_T0SC7Struct1V5scaleABSdFTcTO
   // CHECK: thin_to_thick_function [[THUNK]]
   let g = Struct1.scale
-  // CHECK: [[ZVAL:%.*]] = load [trivial] [[Z]]
+  // CHECK:  [[READ:%.*]] = begin_access [read] [unknown] [[Z]] : $*Struct1
+  // CHECK: [[ZVAL:%.*]] = load [trivial] [[READ]]
   z = g(z)(x)
 
   // TODO: If we implement SE-0042, this should directly reference the
@@ -106,25 +112,30 @@ public func foo(_ x: Double) {
   // let h: @convention(c) (Struct1, Double) -> Struct1 = Struct1.scale
   // z = h(z, x)
 
-  // CHECK: [[ZVAL:%.*]] = load [trivial] [[Z]]
+  // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[Z]] : $*Struct1
+  // CHECK: [[ZVAL:%.*]] = load [trivial] [[READ]]
   // CHECK: store [[ZVAL]] to [trivial] [[ZTMP:%.*]] :
   // CHECK: [[GET:%.*]] = function_ref @IAMStruct1GetRadius : $@convention(c) (@in Struct1) -> Double
   // CHECK: apply [[GET]]([[ZTMP]])
   _ = z.radius
-  // CHECK: [[ZVAL:%.*]] = load [trivial] [[Z]]
+  // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[Z]] : $*Struct1
+  // CHECK: [[ZVAL:%.*]] = load [trivial] [[READ]]
   // CHECK: [[SET:%.*]] = function_ref @IAMStruct1SetRadius : $@convention(c) (Struct1, Double) -> ()
   // CHECK: apply [[SET]]([[ZVAL]], [[X]])
   z.radius = x
 
-  // CHECK: [[ZVAL:%.*]] = load [trivial] [[Z]]
+  // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[Z]] : $*Struct1
+  // CHECK: [[ZVAL:%.*]] = load [trivial] [[READ]]
   // CHECK: [[GET:%.*]] = function_ref @IAMStruct1GetAltitude : $@convention(c) (Struct1) -> Double
   // CHECK: apply [[GET]]([[ZVAL]])
   _ = z.altitude
+  // CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] [[Z]] : $*Struct1
   // CHECK: [[SET:%.*]] = function_ref @IAMStruct1SetAltitude : $@convention(c) (@inout Struct1, Double) -> ()
-  // CHECK: apply [[SET]]([[Z]], [[X]])
+  // CHECK: apply [[SET]]([[WRITE]], [[X]])
   z.altitude = x
   
-  // CHECK: [[ZVAL:%.*]] = load [trivial] [[Z]]
+  // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[Z]] : $*Struct1
+  // CHECK: [[ZVAL:%.*]] = load [trivial] [[READ]]
   // CHECK: [[GET:%.*]] = function_ref @IAMStruct1GetMagnitude : $@convention(c) (Struct1) -> Double
   // CHECK: apply [[GET]]([[ZVAL]])
   _ = z.magnitude
@@ -173,7 +184,8 @@ public func foo(_ x: Double) {
   _ = makeMetatype().getOnlyProperty
 
   // CHECK: [[FN:%.*]] = function_ref @IAMStruct1SelfComesLast : $@convention(c) (Double, Struct1) -> ()
-  // CHECK: [[ZVAL:%.*]] = load [trivial] [[Z]]
+  // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[Z]] : $*Struct1
+  // CHECK: [[ZVAL:%.*]] = load [trivial] [[READ]]
   // CHECK: apply [[FN]]([[X]], [[ZVAL]])
   z.selfComesLast(x: x)
   let k: (Double) -> () = z.selfComesLast(x:)
@@ -186,7 +198,8 @@ public func foo(_ x: Double) {
   // m(z, x)
 
   // CHECK: [[FN:%.*]] = function_ref @IAMStruct1SelfComesThird : $@convention(c) (Int32, Float, Struct1, Double) -> ()
-  // CHECK: [[ZVAL:%.*]] = load [trivial] [[Z]]
+  // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[Z]] : $*Struct1
+  // CHECK: [[ZVAL:%.*]] = load [trivial] [[READ]]
   // CHECK: apply [[FN]]({{.*}}, {{.*}}, [[ZVAL]], [[X]])
   z.selfComesThird(a: y, b: 0, x: x)
   let n: (Int32, Float, Double) -> () = z.selfComesThird(a:b:x:)

--- a/test/SILGen/class_bound_protocols.swift
+++ b/test/SILGen/class_bound_protocols.swift
@@ -32,7 +32,8 @@ func class_bound_generic<T : ClassBound>(x: T) -> T {
   // CHECK:   [[X_COPY:%.*]] = copy_value [[BORROWED_X]]
   // CHECK:   store [[X_COPY]] to [init] [[PB]]
   return x
-  // CHECK:   [[X1:%.*]] = load [copy] [[PB]]
+  // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PB]] : $*T
+  // CHECK:   [[X1:%.*]] = load [copy] [[READ]]
   // CHECK:   destroy_value [[X_ADDR]]
   // CHECK:   destroy_value [[X]]
   // CHECK:   return [[X1]]
@@ -49,7 +50,8 @@ func class_bound_generic_2<T : ClassBound & NotClassBound>(x: T) -> T {
   // CHECK:   store [[X_COPY]] to [init] [[PB]]
   // CHECK:   end_borrow [[BORROWED_X]] from [[X]]
   return x
-  // CHECK:   [[X1:%.*]] = load [copy] [[PB]]
+  // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PB]] : $*T
+  // CHECK:   [[X1:%.*]] = load [copy] [[READ]]
   // CHECK:   return [[X1]]
 }
 
@@ -64,7 +66,8 @@ func class_bound_protocol(x: ClassBound) -> ClassBound {
   // CHECK:   store [[X_COPY]] to [init] [[PB]]
   // CHECK:   end_borrow [[BORROWED_X]] from [[X]]
   return x
-  // CHECK:   [[X1:%.*]] = load [copy] [[PB]]
+  // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PB]] : $*ClassBound
+  // CHECK:   [[X1:%.*]] = load [copy] [[READ]]
   // CHECK:   return [[X1]]
 }
 
@@ -80,7 +83,8 @@ func class_bound_protocol_composition(x: ClassBound & NotClassBound)
   // CHECK:   store [[X_COPY]] to [init] [[PB]]
   // CHECK:   end_borrow [[BORROWED_X]] from [[X]]
   return x
-  // CHECK:   [[X1:%.*]] = load [copy] [[PB]]
+  // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PB]] : $*ClassBound & NotClassBound
+  // CHECK:   [[X1:%.*]] = load [copy] [[READ]]
   // CHECK:   return [[X1]]
 }
 
@@ -131,7 +135,8 @@ func class_bound_method(x: ClassBound) {
   // CHECK: [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
   // CHECK: store [[ARG_COPY]] to [init] [[XBOX_PB]]
   // CHECK: end_borrow [[BORROWED_ARG]] from [[ARG]]
-  // CHECK: [[X:%.*]] = load [copy] [[XBOX_PB]] : $*ClassBound
+  // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[XBOX_PB]] : $*ClassBound
+  // CHECK: [[X:%.*]] = load [copy] [[READ]] : $*ClassBound
   // CHECK: [[PROJ:%.*]] = open_existential_ref [[X]] : $ClassBound to $[[OPENED:@opened(.*) ClassBound]]
   // CHECK: [[METHOD:%.*]] = witness_method $[[OPENED]], #ClassBound.classBoundMethod!1
   // CHECK: apply [[METHOD]]<[[OPENED]]>([[PROJ]])

--- a/test/SILGen/closures.swift
+++ b/test/SILGen/closures.swift
@@ -51,7 +51,8 @@ func read_only_capture(_ x: Int) -> Int {
 // CHECK: sil private @[[CAP_NAME]]
 // CHECK: bb0([[XBOX:%[0-9]+]] : ${ var Int }):
 // CHECK: [[XADDR:%[0-9]+]] = project_box [[XBOX]]
-// CHECK: [[X:%[0-9]+]] = load [trivial] [[XADDR]]
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[XADDR]] : $*Int
+// CHECK: [[X:%[0-9]+]] = load [trivial] [[ACCESS]]
 // CHECK: destroy_value [[XBOX]]
 // CHECK: return [[X]]
 // } // end sil function '[[CAP_NAME]]'
@@ -66,7 +67,8 @@ func write_to_capture(_ x: Int) -> Int {
   // CHECK:   store [[X]] to [trivial] [[XBOX_PB]]
   // CHECK:   [[X2BOX:%[0-9]+]] = alloc_box ${ var Int }
   // CHECK:   [[X2BOX_PB:%.*]] = project_box [[X2BOX]]
-  // CHECK:   copy_addr [[XBOX_PB]] to [initialization] [[X2BOX_PB]]
+  // CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[XBOX_PB]] : $*Int
+  // CHECK:   copy_addr [[ACCESS]] to [initialization] [[X2BOX_PB]]
   // CHECK:   [[X2BOX_COPY:%.*]] = copy_value [[X2BOX]]
   // SEMANTIC ARC TODO: This next mark_function_escape should be on a projection from X2BOX_COPY.
   // CHECK:   mark_function_escape [[X2BOX_PB]]
@@ -82,7 +84,8 @@ func write_to_capture(_ x: Int) -> Int {
   // SEMANTIC ARC TODO: This should load from X2BOX_COPY project. There is an
   // issue here where after a copy_value, we need to reassign a projection in
   // some way.
-  // CHECK:   [[RET:%[0-9]+]] = load [trivial] [[X2BOX_PB]]
+  // CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[X2BOX_PB]] : $*Int
+  // CHECK:   [[RET:%[0-9]+]] = load [trivial] [[ACCESS]]
   // CHECK:   destroy_value [[X2BOX]]
   // CHECK:   destroy_value [[XBOX]]
   // CHECK:   return [[RET]]
@@ -93,7 +96,8 @@ func write_to_capture(_ x: Int) -> Int {
 // CHECK: sil private @[[SCRIB_NAME]]
 // CHECK: bb0([[XBOX:%[0-9]+]] : ${ var Int }):
 // CHECK:   [[XADDR:%[0-9]+]] = project_box [[XBOX]]
-// CHECK:   copy_addr {{%[0-9]+}} to [[XADDR]]
+// CHECK:   [[ACCESS:%.*]] = begin_access [modify] [unknown] [[XADDR]] : $*Int
+// CHECK:   assign {{%[0-9]+}} to [[ACCESS]]
 // CHECK:   destroy_value [[XBOX]]
 // CHECK:   return
 // CHECK: } // end sil function '[[SCRIB_NAME]]'
@@ -170,7 +174,8 @@ func anon_read_only_capture(_ x: Int) -> Int {
 }
 // CHECK: sil private @[[CLOSURE_NAME]]
 // CHECK: bb0([[XADDR:%[0-9]+]] : $*Int):
-// CHECK: [[X:%[0-9]+]] = load [trivial] [[XADDR]]
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[XADDR]] : $*Int
+// CHECK: [[X:%[0-9]+]] = load [trivial] [[ACCESS]]
 // CHECK: return [[X]]
 
 // CHECK-LABEL: sil hidden @_T08closures21small_closure_capture{{[_0-9a-zA-Z]*}}F
@@ -191,7 +196,8 @@ func small_closure_capture(_ x: Int) -> Int {
 }
 // CHECK: sil private @[[CLOSURE_NAME]]
 // CHECK: bb0([[XADDR:%[0-9]+]] : $*Int):
-// CHECK: [[X:%[0-9]+]] = load [trivial] [[XADDR]]
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[XADDR]] : $*Int
+// CHECK: [[X:%[0-9]+]] = load [trivial] [[ACCESS]]
 // CHECK: return [[X]]
 
 

--- a/test/SILGen/copy_lvalue_peepholes.swift
+++ b/test/SILGen/copy_lvalue_peepholes.swift
@@ -12,19 +12,11 @@ func getInt() -> Int { return zero }
 // CHECK:   [[PBX:%.*]] = project_box [[X]]
 // CHECK:   [[Y:%.*]] = alloc_box ${ var Builtin.Int64 }
 // CHECK:   [[PBY:%.*]] = project_box [[Y]]
-// CHECK:   copy_addr [[PBX]] to [initialization] [[PBY]] : $*Builtin.Int64
+// CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PBX]]
+// CHECK:   copy_addr [[READ]] to [initialization] [[PBY]] : $*Builtin.Int64
 func init_var_from_lvalue(x: Int) {
   var x = x
   var y = x
-}
-
-// CHECK-LABEL: sil hidden @_T021copy_lvalue_peepholes016assign_var_from_B0{{[_0-9a-zA-Z]*}}F
-// CHECK:   [[Y:%.*]] = alloc_box ${ var Builtin.Int64 }
-// CHECK:   [[PBY:%.*]] = project_box [[Y]]
-// CHECK:   copy_addr [[PBY]] to %0
-func assign_var_from_lvalue(x: inout Int, y: Int) {
-  var y = y
-  x = y
 }
 
 // -- Peephole doesn't apply to computed lvalues
@@ -47,7 +39,8 @@ func init_var_from_computed_lvalue() {
 // CHECK-LABEL: sil hidden @_T021copy_lvalue_peepholes021assign_computed_from_B0{{[_0-9a-zA-Z]*}}F
 // CHECK:   [[Y:%.*]] = alloc_box
 // CHECK:   [[PBY:%.*]] = project_box [[Y]]
-// CHECK:   [[Y_VAL:%.*]] = load [trivial] [[PBY]]
+// CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PBY]]
+// CHECK:   [[Y_VAL:%.*]] = load [trivial] [[READ]]
 // CHECK:   [[SETTER:%.*]] = function_ref @_T021copy_lvalue_peepholes8computedBi64_fs
 // CHECK:   apply [[SETTER]]([[Y_VAL]])
 func assign_computed_from_lvalue(y: Int) {
@@ -56,7 +49,8 @@ func assign_computed_from_lvalue(y: Int) {
 }
 
 // CHECK-LABEL: sil hidden @_T021copy_lvalue_peepholes24assign_var_from_computed{{[_0-9a-zA-Z]*}}F
-// CHECK:   assign {{%.*}} to %0
+// CHECK:   [[WRITE:%.*]] = begin_access [modify] [unknown] %0
+// CHECK:   assign {{%.*}} to [[WRITE]]
 func assign_var_from_computed(x: inout Int) {
   x = computed
 }

--- a/test/SILGen/decls.swift
+++ b/test/SILGen/decls.swift
@@ -43,9 +43,10 @@ func tuple_patterns() {
   // CHECK: [[PBC:%.*]] = project_box [[CADDR]]
   // CHECK: [[DADDR:%[0-9]+]] = alloc_box ${ var Float }
   // CHECK: [[PBD:%.*]] = project_box [[DADDR]]
-  // CHECK: copy_addr [[PBA]] to [initialization] [[PBC]]
-  // CHECK: copy_addr [[PBB]] to [initialization] [[PBD]]
-
+  // CHECK: [[READA:%.*]] = begin_access [read] [unknown] [[PBA]] : $*Int
+  // CHECK: copy_addr [[READA]] to [initialization] [[PBC]]
+  // CHECK: [[READB:%.*]] = begin_access [read] [unknown] [[PBB]] : $*Float
+  // CHECK: copy_addr [[READB]] to [initialization] [[PBD]]
   // CHECK: [[EADDR:%[0-9]+]] = alloc_box ${ var Int }
   // CHECK: [[PBE:%.*]] = project_box [[EADDR]]
   // CHECK: [[FADDR:%[0-9]+]] = alloc_box ${ var Float }
@@ -65,8 +66,10 @@ func tuple_patterns() {
   // CHECK: [[IADDR:%[0-9]+]] = alloc_box ${ var Int }
   // CHECK: [[PBI:%.*]] = project_box [[IADDR]]
   // CHECK-NOT: alloc_box ${ var Float }
-  // CHECK: copy_addr [[PBA]] to [initialization] [[PBI]]
-  // CHECK: [[B:%[0-9]+]] = load [trivial] [[PBB]]
+  // CHECK: [[READA:%.*]] = begin_access [read] [unknown] [[PBA]] : $*Int
+  // CHECK: copy_addr [[READA]] to [initialization] [[PBI]]
+  // CHECK: [[READB:%.*]] = begin_access [read] [unknown] [[PBB]] : $*Float
+  // CHECK: [[B:%[0-9]+]] = load [trivial] [[READB]]
   // CHECK-NOT: store [[B]]
   var (i,_) = (a, b)
 
@@ -133,7 +136,9 @@ func store_to_global(x: Int) {
   // CHECK: [[ACCESSOR:%[0-9]+]] = function_ref @_T05decls6globalSifau
   // CHECK: [[PTR:%[0-9]+]] = apply [[ACCESSOR]]()
   // CHECK: [[ADDR:%[0-9]+]] = pointer_to_address [[PTR]]
-  // CHECK: copy_addr [[PBX]] to [[ADDR]]
+  // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[PBX]] : $*Int
+  // CHECK: [[COPY:%.*]] = load [trivial] [[READ]] : $*Int
+  // CHECK: assign [[COPY]] to [[ADDR]] : $*Int
   // CHECK: return
 }
 

--- a/test/SILGen/dynamic_lookup.swift
+++ b/test/SILGen/dynamic_lookup.swift
@@ -61,7 +61,9 @@ func direct_to_static_method(_ obj: AnyObject) {
   // CHECK: [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
   // CHECK: store [[ARG_COPY]] to [init] [[PBOBJ]] : $*AnyObject
   // CHECK: end_borrow [[BORROWED_ARG]] from [[ARG]]
-  // CHECK-NEXT: [[OBJCOPY:%[0-9]+]] = load_borrow [[PBOBJ]] : $*AnyObject
+  // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[PBOBJ]]
+  // CHECK-NEXT: [[OBJCOPY:%[0-9]+]] = load_borrow [[READ]] : $*AnyObject
+  // CHECK: end_access [[READ]]
   // CHECK-NEXT: [[OBJMETA:%[0-9]+]] = existential_metatype $@thick AnyObject.Type, [[OBJCOPY]] : $AnyObject
   // CHECK-NEXT: [[OPENMETA:%[0-9]+]] = open_existential_metatype [[OBJMETA]] : $@thick AnyObject.Type to $@thick (@opened([[UUID:".*"]]) AnyObject).Type
   // CHECK-NEXT: [[METHOD:%[0-9]+]] = dynamic_method [volatile] [[OPENMETA]] : $@thick (@opened([[UUID]]) AnyObject).Type, #X.staticF!1.foreign : (X.Type) -> () -> (), $@convention(objc_method) (@thick (@opened([[UUID]]) AnyObject).Type) -> ()
@@ -84,7 +86,8 @@ func opt_to_class(_ obj: AnyObject) {
   // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
   // CHECK:   [[OPTBOX:%[0-9]+]] = alloc_box ${ var Optional<@callee_owned () -> ()> }
   // CHECK:   [[PBOPT:%.*]] = project_box [[OPTBOX]]
-  // CHECK:   [[EXISTVAL:%[0-9]+]] = load [copy] [[PBOBJ]] : $*AnyObject
+  // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PBOBJ]]
+  // CHECK:   [[EXISTVAL:%[0-9]+]] = load [copy] [[READ]] : $*AnyObject
   // CHECK:   [[OBJ_SELF:%[0-9]*]] = open_existential_ref [[EXISTVAL]]
   // CHECK:   [[OPT_TMP:%.*]] = alloc_stack $Optional<@callee_owned () -> ()>
   // CHECK:   dynamic_method_br [[OBJ_SELF]] : $@opened({{.*}}) AnyObject, #X.f!1.foreign, [[HASBB:[a-zA-z0-9]+]], [[NOBB:[a-zA-z0-9]+]]
@@ -137,7 +140,8 @@ func opt_to_static_method(_ obj: AnyObject) {
   // CHECK:   end_borrow [[BORROWED_OBJ]] from [[OBJ]]
   // CHECK:   [[OPTBOX:%[0-9]+]] = alloc_box ${ var Optional<@callee_owned () -> ()> }
   // CHECK:   [[PBO:%.*]] = project_box [[OPTBOX]]
-  // CHECK:   [[OBJCOPY:%[0-9]+]] = load_borrow [[PBOBJ]] : $*AnyObject
+  // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PBOBJ]]
+  // CHECK:   [[OBJCOPY:%[0-9]+]] = load_borrow [[READ]] : $*AnyObject
   // CHECK:   [[OBJMETA:%[0-9]+]] = existential_metatype $@thick AnyObject.Type, [[OBJCOPY]] : $AnyObject
   // CHECK:   [[OPENMETA:%[0-9]+]] = open_existential_metatype [[OBJMETA]] : $@thick AnyObject.Type to $@thick (@opened
   // CHECK:   [[OBJCMETA:%[0-9]+]] = thick_to_objc_metatype [[OPENMETA]]
@@ -158,7 +162,8 @@ func opt_to_property(_ obj: AnyObject) {
   // CHECK:   end_borrow [[BORROWED_OBJ]] from [[OBJ]]
   // CHECK:   [[INT_BOX:%[0-9]+]] = alloc_box ${ var Int }
   // CHECK:   project_box [[INT_BOX]]
-  // CHECK:   [[OBJ:%[0-9]+]] = load [copy] [[PBOBJ]] : $*AnyObject
+  // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PBOBJ]]
+  // CHECK:   [[OBJ:%[0-9]+]] = load [copy] [[READ]] : $*AnyObject
   // CHECK:   [[RAWOBJ_SELF:%[0-9]+]] = open_existential_ref [[OBJ]] : $AnyObject
   // CHECK:   [[OPTTEMP:%.*]] = alloc_stack $Optional<Int>
   // CHECK:   dynamic_method_br [[RAWOBJ_SELF]] : $@opened({{.*}}) AnyObject, #X.value!getter.1.foreign, bb1, bb2
@@ -191,9 +196,11 @@ func direct_to_subscript(_ obj: AnyObject, i: Int) {
   // CHECK:   store [[I]] to [trivial] [[PBI]] : $*Int
   // CHECK:   alloc_box ${ var Int }
   // CHECK:   project_box
-  // CHECK:   [[OBJ:%[0-9]+]] = load [copy] [[PBOBJ]] : $*AnyObject
+  // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PBOBJ]]
+  // CHECK:   [[OBJ:%[0-9]+]] = load [copy] [[READ]] : $*AnyObject
   // CHECK:   [[OBJ_REF:%[0-9]+]] = open_existential_ref [[OBJ]] : $AnyObject to $@opened({{.*}}) AnyObject
-  // CHECK:   [[I:%[0-9]+]] = load [trivial] [[PBI]] : $*Int
+  // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PBI]]
+  // CHECK:   [[I:%[0-9]+]] = load [trivial] [[READ]] : $*Int
   // CHECK:   [[OPTTEMP:%.*]] = alloc_stack $Optional<Int>
   // CHECK:   dynamic_method_br [[OBJ_REF]] : $@opened({{.*}}) AnyObject, #X.subscript!getter.1.foreign, bb1, bb2
 
@@ -223,9 +230,11 @@ func opt_to_subscript(_ obj: AnyObject, i: Int) {
   // CHECK:   [[I_BOX:%[0-9]+]] = alloc_box ${ var Int }
   // CHECK:   [[PBI:%.*]] = project_box [[I_BOX]]
   // CHECK:   store [[I]] to [trivial] [[PBI]] : $*Int
-  // CHECK:   [[OBJ:%[0-9]+]] = load [copy] [[PBOBJ]] : $*AnyObject
+  // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PBOBJ]]
+  // CHECK:   [[OBJ:%[0-9]+]] = load [copy] [[READ]] : $*AnyObject
   // CHECK:   [[OBJ_REF:%[0-9]+]] = open_existential_ref [[OBJ]] : $AnyObject to $@opened({{.*}}) AnyObject
-  // CHECK:   [[I:%[0-9]+]] = load [trivial] [[PBI]] : $*Int
+  // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PBI]]
+  // CHECK:   [[I:%[0-9]+]] = load [trivial] [[READ]] : $*Int
   // CHECK:   [[OPTTEMP:%.*]] = alloc_stack $Optional<Int>
   // CHECK:   dynamic_method_br [[OBJ_REF]] : $@opened({{.*}}) AnyObject, #X.subscript!getter.1.foreign, bb1, bb2
 
@@ -250,7 +259,8 @@ func downcast(_ obj: AnyObject) -> X {
   // CHECK:   [[OBJ_COPY:%.*]] = copy_value [[BORROWED_OBJ]]
   // CHECK:   store [[OBJ_COPY]] to [init] [[PBOBJ]] : $*AnyObject
   // CHECK:   end_borrow [[BORROWED_OBJ]] from [[OBJ]]
-  // CHECK:   [[OBJ:%[0-9]+]] = load [copy] [[PBOBJ]] : $*AnyObject
+  // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PBOBJ]]
+  // CHECK:   [[OBJ:%[0-9]+]] = load [copy] [[READ]] : $*AnyObject
   // CHECK:   [[X:%[0-9]+]] = unconditional_checked_cast [[OBJ]] : $AnyObject to $X
   // CHECK:   destroy_value [[OBJ_BOX]] : ${ var AnyObject }
   // CHECK:   destroy_value %0

--- a/test/SILGen/errors.swift
+++ b/test/SILGen/errors.swift
@@ -613,21 +613,23 @@ func supportStructure(_ b: inout Bridge, name: String) throws {
 // CHECK:      [[SUPPORT:%.*]] = function_ref @_T06errors5PylonV7supportyyKF
 // CHECK-NEXT: [[BORROWED_ARG2:%.*]] = begin_borrow [[ARG2]]
 // CHECK-NEXT: [[INDEX_COPY_1:%.*]] = copy_value [[BORROWED_ARG2]] : $String
+// CHECK-NEXT: [[WRITE:%.*]] = begin_access [modify] [unknown] [[ARG1]] : $*Bridge
 // CHECK-NEXT: [[INDEX_COPY_2:%.*]] = copy_value [[INDEX_COPY_1]] : $String
 // CHECK-NEXT: [[TEMP:%.*]] = alloc_stack $Pylon
-// CHECK-NEXT: [[BASE:%.*]] = load_borrow [[ARG1]] : $*Bridge
+// CHECK-NEXT: [[BASE:%.*]] = load_borrow [[WRITE]] : $*Bridge
 // CHECK-NEXT: // function_ref
 // CHECK-NEXT: [[GETTER:%.*]] = function_ref @_T06errors6BridgeV9subscriptAA5PylonVSScfg :
 // CHECK-NEXT: [[T0:%.*]] = apply [[GETTER]]([[INDEX_COPY_1]], [[BASE]])
 // CHECK-NEXT: store [[T0]] to [init] [[TEMP]]
-// CHECK-NEXT: end_borrow [[BASE]] from [[ARG1]]
+// CHECK-NEXT: end_borrow [[BASE]] from [[WRITE]]
 // CHECK-NEXT: try_apply [[SUPPORT]]([[TEMP]]) : {{.*}}, normal [[BB_NORMAL:bb[0-9]+]], error [[BB_ERROR:bb[0-9]+]]
 
 // CHECK:    [[BB_NORMAL]]
 // CHECK-NEXT: [[T0:%.*]] = load [take] [[TEMP]]
 // CHECK-NEXT: // function_ref
 // CHECK-NEXT: [[SETTER:%.*]] = function_ref @_T06errors6BridgeV9subscriptAA5PylonVSScfs :
-// CHECK-NEXT: apply [[SETTER]]([[T0]], [[INDEX_COPY_2]], [[ARG1]])
+// CHECK-NEXT: apply [[SETTER]]([[T0]], [[INDEX_COPY_2]], [[WRITE]])
+// CHECK-NEXT: end_access [[WRITE]]
 // CHECK-NEXT: dealloc_stack [[TEMP]]
 // CHECK-NEXT: end_borrow [[BORROWED_INDEX]] from [[INDEX]]
 // CHECK-NEXT: destroy_value [[INDEX]] : $String
@@ -641,11 +643,12 @@ func supportStructure(_ b: inout Bridge, name: String) throws {
 // CHECK-NEXT: [[INDEX_COPY_2_COPY:%.*]] = copy_value [[INDEX_COPY_2]]
 // CHECK-NEXT: // function_ref
 // CHECK-NEXT: [[SETTER:%.*]] = function_ref @_T06errors6BridgeV9subscriptAA5PylonVSScfs :
-// CHECK-NEXT: apply [[SETTER]]([[T0]], [[INDEX_COPY_2_COPY]], [[ARG1]])
+// CHECK-NEXT: apply [[SETTER]]([[T0]], [[INDEX_COPY_2_COPY]], [[WRITE]])
 // CHECK-NEXT: destroy_addr [[TEMP]]
 // CHECK-NEXT: dealloc_stack [[TEMP]]
 // ==> SEMANTIC ARC TODO: INDEX_COPY_2 on the next line should be INDEX_COPY_2_COPY
 // CHECK-NEXT: destroy_value [[INDEX_COPY_2]] : $String
+// CHECK-NEXT: end_access [[WRITE]]
 // CHECK-NEXT: end_borrow [[BORROWED_INDEX]] from [[INDEX]]
 // CHECK-NEXT: destroy_value [[INDEX]] : $String
 // CHECK-NEXT: throw [[ERROR]]
@@ -666,9 +669,10 @@ func supportStructure(_ b: inout OwnedBridge, name: String) throws {
 // CHECK:      [[SUPPORT:%.*]] = function_ref @_T06errors5PylonV7supportyyKF
 // CHECK:      [[BORROWED_ARG2:%.*]] = begin_borrow [[ARG2]]
 // CHECK:      [[ARG2_COPY:%.*]] = copy_value [[BORROWED_ARG2]] : $String
+// CHECK:      [[WRITE:%.*]] = begin_access [modify] [unknown] %0 : $*OwnedBridge
 // CHECK-NEXT: // function_ref
 // CHECK-NEXT: [[ADDRESSOR:%.*]] = function_ref @_T06errors11OwnedBridgeV9subscriptAA5PylonVSScfaO :
-// CHECK-NEXT: [[T0:%.*]] = apply [[ADDRESSOR]]([[ARG2_COPY]], [[ARG1]])
+// CHECK-NEXT: [[T0:%.*]] = apply [[ADDRESSOR]]([[ARG2_COPY]], [[WRITE]])
 // CHECK-NEXT: [[BORROWED_T0:%.*]] = begin_borrow [[T0]]
 // CHECK-NEXT: [[T1:%.*]] = tuple_extract [[BORROWED_T0]] : {{.*}}, 0
 // CHECK-NEXT: [[BORROWED_OWNER:%.*]] = tuple_extract [[BORROWED_T0]] : {{.*}}, 1
@@ -680,6 +684,7 @@ func supportStructure(_ b: inout OwnedBridge, name: String) throws {
 // CHECK-NEXT: [[T5:%.*]] = mark_dependence [[T4]] : $*Pylon on [[OWNER]]
 // CHECK-NEXT: try_apply [[SUPPORT]]([[T5]]) : {{.*}}, normal [[BB_NORMAL:bb[0-9]+]], error [[BB_ERROR:bb[0-9]+]]
 // CHECK:    [[BB_NORMAL]]
+// CHECK-NEXT: end_access [[WRITE]]
 // CHECK-NEXT: destroy_value [[OWNER]] : $Builtin.UnknownObject
 // CHECK-NEXT: end_borrow [[BORROWED_ARG2]] from [[ARG2]]
 // CHECK-NEXT: destroy_value [[ARG2]] : $String
@@ -687,6 +692,7 @@ func supportStructure(_ b: inout OwnedBridge, name: String) throws {
 // CHECK-NEXT: return
 // CHECK:    [[BB_ERROR]]([[ERROR:%.*]] : $Error):
 // CHECK-NEXT: destroy_value [[OWNER]] : $Builtin.UnknownObject
+// CHECK-NEXT: end_access [[WRITE]]
 // CHECK-NEXT: end_borrow [[BORROWED_ARG2]] from [[ARG2]]
 // CHECK-NEXT: destroy_value [[ARG2]] : $String
 // CHECK-NEXT: throw [[ERROR]]
@@ -707,9 +713,10 @@ func supportStructure(_ b: inout PinnedBridge, name: String) throws {
 // CHECK:        [[SUPPORT:%.*]] = function_ref @_T06errors5PylonV7supportyyKF
 // CHECK:        [[BORROWED_ARG2:%.*]] = begin_borrow [[ARG2]]
 // CHECK:        [[ARG2_COPY:%.*]] = copy_value [[BORROWED_ARG2]] : $String
+// CHECK-NEXT:   [[WRITE:%.*]] = begin_access [modify] [unknown] [[ARG1]] : $*PinnedBridge
 // CHECK-NEXT:   // function_ref
 // CHECK-NEXT:   [[ADDRESSOR:%.*]] = function_ref @_T06errors12PinnedBridgeV9subscriptAA5PylonVSScfaP :
-// CHECK-NEXT:   [[T0:%.*]] = apply [[ADDRESSOR]]([[ARG2_COPY]], [[ARG1]])
+// CHECK-NEXT:   [[T0:%.*]] = apply [[ADDRESSOR]]([[ARG2_COPY]], [[WRITE]])
 // CHECK-NEXT:   [[BORROWED_T0:%.*]] = begin_borrow [[T0]]
 // CHECK-NEXT:   [[T1:%.*]] = tuple_extract [[BORROWED_T0]] : {{.*}}, 0
 // CHECK-NEXT:   [[BORROWED_OWNER:%.*]] = tuple_extract [[BORROWED_T0]] : {{.*}}, 1
@@ -722,6 +729,7 @@ func supportStructure(_ b: inout PinnedBridge, name: String) throws {
 // CHECK-NEXT:   try_apply [[SUPPORT]]([[T5]]) : {{.*}}, normal [[BB_NORMAL:bb[0-9]+]], error [[BB_ERROR:bb[0-9]+]]
 // CHECK:      [[BB_NORMAL]]
 // CHECK-NEXT:   strong_unpin [[OWNER]] : $Optional<Builtin.NativeObject>
+// CHECK-NEXT:   end_access [[WRITE]]
 // CHECK-NEXT:   end_borrow [[BORROWED_ARG2]] from [[ARG2]]
 // CHECK-NEXT:   destroy_value [[ARG2]] : $String
 // CHECK-NEXT:   tuple ()
@@ -730,6 +738,7 @@ func supportStructure(_ b: inout PinnedBridge, name: String) throws {
 // CHECK-NEXT:   [[OWNER_COPY:%.*]] = copy_value [[OWNER]]
 // CHECK-NEXT:   strong_unpin [[OWNER_COPY]] : $Optional<Builtin.NativeObject>
 // CHECK-NEXT:   destroy_value [[OWNER]]
+// CHECK-NEXT:   end_access [[WRITE]]
 // CHECK-NEXT:   end_borrow [[BORROWED_ARG2]] from [[ARG2]]
 // CHECK-NEXT:   destroy_value [[ARG2]] : $String
 // CHECK-NEXT:   throw [[ERROR]]

--- a/test/SILGen/expressions.swift
+++ b/test/SILGen/expressions.swift
@@ -338,12 +338,15 @@ func archetype_member_ref<T : Runcible>(_ x: T) {
   var x = x
   x.free_method()
   // CHECK: witness_method $T, #Runcible.free_method!1
+  // CHECK-NEXT: [[READ:%.*]] = begin_access [read] [unknown] [[X:%.*]]
   // CHECK-NEXT: [[TEMP:%.*]] = alloc_stack $T
-  // CHECK-NEXT: copy_addr [[X:%.*]] to [initialization] [[TEMP]]
+  // CHECK-NEXT: copy_addr [[READ]] to [initialization] [[TEMP]]
+  // CHECK-NEXT: end_access [[READ]]
   // CHECK-NEXT: apply
   // CHECK-NEXT: destroy_addr [[TEMP]]
   var u = x.associated_method()
   // CHECK: witness_method $T, #Runcible.associated_method!1
+  // CHECK-NEXT: [[WRITE:%.*]] = begin_access [modify] [unknown]
   // CHECK-NEXT: apply
   T.static_method()
   // CHECK: witness_method $T, #Runcible.static_method!1
@@ -435,11 +438,13 @@ func tuple_element(_ x: (Int, Float)) {
   // CHECK: [[PB:%.*]] = project_box [[XADDR]]
 
   int(x.0)
-  // CHECK: tuple_element_addr [[PB]] : {{.*}}, 0
+  // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[PB]]
+  // CHECK: tuple_element_addr [[READ]] : {{.*}}, 0
   // CHECK: apply
 
   float(x.1)
-  // CHECK: tuple_element_addr [[PB]] : {{.*}}, 1
+  // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[PB]]
+  // CHECK: tuple_element_addr [[READ]] : {{.*}}, 1
   // CHECK: apply
 
   int(tuple().0)
@@ -480,21 +485,26 @@ func if_expr(_ a: Bool, b: Bool, x: Int, y: Int, z: Int) -> Int {
     : b
     ? y
     : z
-  // CHECK:   [[A:%[0-9]+]] = load [trivial] [[PBA]]
+  // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PBA]]
+  // CHECK:   [[A:%[0-9]+]] = load [trivial] [[READ]]
   // CHECK:   [[ACOND:%[0-9]+]] = apply {{.*}}([[A]])
   // CHECK:   cond_br [[ACOND]], [[IF_A:bb[0-9]+]], [[ELSE_A:bb[0-9]+]]
   // CHECK: [[IF_A]]:
-  // CHECK:   [[XVAL:%[0-9]+]] = load [trivial] [[PBX]]
+  // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PBX]]
+  // CHECK:   [[XVAL:%[0-9]+]] = load [trivial] [[READ]]
   // CHECK:   br [[CONT_A:bb[0-9]+]]([[XVAL]] : $Int)
   // CHECK: [[ELSE_A]]:
-  // CHECK:   [[B:%[0-9]+]] = load [trivial] [[PBB]]
+  // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PBB]]
+  // CHECK:   [[B:%[0-9]+]] = load [trivial] [[READ]]
   // CHECK:   [[BCOND:%[0-9]+]] = apply {{.*}}([[B]])
   // CHECK:   cond_br [[BCOND]], [[IF_B:bb[0-9]+]], [[ELSE_B:bb[0-9]+]]
   // CHECK: [[IF_B]]:
-  // CHECK:   [[YVAL:%[0-9]+]] = load [trivial] [[PBY]]
+  // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PBY]]
+  // CHECK:   [[YVAL:%[0-9]+]] = load [trivial] [[READ]]
   // CHECK:   br [[CONT_B:bb[0-9]+]]([[YVAL]] : $Int)
   // CHECK: [[ELSE_B]]:
-  // CHECK:   [[ZVAL:%[0-9]+]] = load [trivial] [[PBZ]]
+  // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PBZ]]
+  // CHECK:   [[ZVAL:%[0-9]+]] = load [trivial] [[READ]]
   // CHECK:   br [[CONT_B:bb[0-9]+]]([[ZVAL]] : $Int)
   // CHECK: [[CONT_B]]([[B_RES:%[0-9]+]] : $Int):
   // CHECK:   br [[CONT_A:bb[0-9]+]]([[B_RES]] : $Int)

--- a/test/SILGen/extensions.swift
+++ b/test/SILGen/extensions.swift
@@ -68,8 +68,10 @@ struct Box<T> {
 // CHECK-NEXT: [[RESULT_ADDR:%.*]] = init_enum_data_addr [[RESULT]] : $*Optional<T>, #Optional.some!enumelt.1
 // CHECK-NEXT: copy_addr %1 to [initialization] %14 : $*T
 // CHECK-NEXT: inject_enum_addr [[RESULT]] : $*Optional<T>, #Optional.some!enumelt.1
-// CHECK-NEXT: [[T_ADDR:%.*]] = struct_element_addr [[SELF_ADDR]] : $*Box<T>, #Box.t
+// CHECK-NEXT: [[WRITE:%.*]] = begin_access [modify] [unknown] [[SELF_ADDR]] : $*Box<T>
+// CHECK-NEXT: [[T_ADDR:%.*]] = struct_element_addr [[WRITE]] : $*Box<T>, #Box.t
 // CHECK-NEXT: copy_addr [take] [[RESULT]] to [[T_ADDR:%.*]] : $*Optional<T>
+// CHECK-NEXT: end_access [[WRITE]]
 // CHECK-NEXT: dealloc_stack [[RESULT]] : $*Optional<T>
 // CHECK-NEXT: copy_addr [[SELF_ADDR]] to [initialization] %0 : $*Box<T>
 // CHECK-NEXT: destroy_addr %1 : $*T

--- a/test/SILGen/foreach.swift
+++ b/test/SILGen/foreach.swift
@@ -119,7 +119,8 @@ func trivialStructBreak(_ xx: [Int]) {
 // CHECK: [[LOOP_DEST]]:
 // CHECK:   [[FUNC_REF:%.*]] = function_ref @_T0s16IndexingIteratorV4next8_ElementQzSgyF : $@convention(method)
 // CHECK:   [[GET_ELT_STACK:%.*]] = alloc_stack $Optional<Int>
-// CHECK:   apply [[FUNC_REF]]<[Int]>([[GET_ELT_STACK]], [[PROJECT_ITERATOR_BOX]])
+// CHECK:   [[WRITE:%.*]] = begin_access [modify] [unknown] [[PROJECT_ITERATOR_BOX]] : $*IndexingIterator<Array<Int>>
+// CHECK:   apply [[FUNC_REF]]<[Int]>([[GET_ELT_STACK]], [[WRITE]])
 // CHECK:   [[IND_VAR:%.*]] = load [trivial] [[GET_ELT_STACK]]
 // CHECK:   switch_enum [[IND_VAR]] : $Optional<Int>, case #Optional.some!enumelt.1: [[SOME_BB:bb[0-9]+]], case #Optional.none!enumelt: [[NONE_BB:bb[0-9]+]]
 //
@@ -223,7 +224,8 @@ func existentialBreak(_ xx: [P]) {
 //
 // CHECK: [[LOOP_DEST]]:
 // CHECK:   [[FUNC_REF:%.*]] = function_ref @_T0s16IndexingIteratorV4next8_ElementQzSgyF : $@convention(method)
-// CHECK:   apply [[FUNC_REF]]<[P]>([[ELT_STACK]], [[PROJECT_ITERATOR_BOX]])
+// CHECK:   [[WRITE:%.*]] = begin_access [modify] [unknown] [[PROJECT_ITERATOR_BOX]] : $*IndexingIterator<Array<P>> // users: %16, %15
+// CHECK:   apply [[FUNC_REF]]<[P]>([[ELT_STACK]], [[WRITE]])
 // CHECK:   switch_enum_addr [[ELT_STACK]] : $*Optional<P>, case #Optional.some!enumelt.1: [[SOME_BB:bb[0-9]+]], case #Optional.none!enumelt: [[NONE_BB:bb[0-9]+]]
 //
 // CHECK: [[NONE_BB]]:
@@ -387,7 +389,8 @@ func genericStructBreak<T>(_ xx: [GenericStruct<T>]) {
 //
 // CHECK: [[LOOP_DEST]]:
 // CHECK:   [[FUNC_REF:%.*]] = function_ref @_T0s16IndexingIteratorV4next8_ElementQzSgyF : $@convention(method)
-// CHECK:   apply [[FUNC_REF]]<[GenericStruct<T>]>([[ELT_STACK]], [[PROJECT_ITERATOR_BOX]])
+// CHECK:   [[WRITE:%.*]] = begin_access [modify] [unknown] [[PROJECT_ITERATOR_BOX]] : $*IndexingIterator<Array<GenericStruct<T>>>
+// CHECK:   apply [[FUNC_REF]]<[GenericStruct<T>]>([[ELT_STACK]], [[WRITE]])
 // CHECK:   switch_enum_addr [[ELT_STACK]] : $*Optional<GenericStruct<T>>, case #Optional.some!enumelt.1: [[SOME_BB:bb[0-9]+]], case #Optional.none!enumelt: [[NONE_BB:bb[0-9]+]]
 //
 // CHECK: [[NONE_BB]]:
@@ -496,7 +499,8 @@ func genericCollectionBreak<T : Collection>(_ xx: T) {
 //
 // CHECK: [[LOOP_DEST]]:
 // CHECK:   [[GET_NEXT_FUNC:%.*]] = witness_method $T.Iterator, #IteratorProtocol.next!1 : <Self where Self : IteratorProtocol> (inout Self) -> () -> Self.Element? : $@convention(witness_method) <τ_0_0 where τ_0_0 : IteratorProtocol> (@inout τ_0_0) -> @out Optional<τ_0_0.Element>
-// CHECK:   apply [[GET_NEXT_FUNC]]<T.Iterator>([[ELT_STACK]], [[PROJECT_ITERATOR_BOX]])
+// CHECK:   [[WRITE:%.*]] = begin_access [modify] [unknown] [[PROJECT_ITERATOR_BOX]] : $*T.Iterator
+// CHECK:   apply [[GET_NEXT_FUNC]]<T.Iterator>([[ELT_STACK]], [[WRITE]])
 // CHECK:   switch_enum_addr [[ELT_STACK]] : $*Optional<T._Element>, case #Optional.some!enumelt.1: [[SOME_BB:bb[0-9]+]], case #Optional.none!enumelt: [[NONE_BB:bb[0-9]+]]
 //
 // CHECK: [[NONE_BB]]:

--- a/test/SILGen/functions.swift
+++ b/test/SILGen/functions.swift
@@ -110,8 +110,10 @@ func calls(_ i:Int, j:Int, k:Int) {
   // CHECK: [[KADDR:%.*]] = project_box [[KBOX]]
 
   // CHECK: [[FUNC:%[0-9]+]] = function_ref @_T09functions19standalone_function{{[_0-9a-zA-Z]*}}F : $@convention(thin) (Builtin.Int64, Builtin.Int64) -> Builtin.Int64
-  // CHECK: [[I:%[0-9]+]] = load [trivial] [[IADDR]]
-  // CHECK: [[J:%[0-9]+]] = load [trivial] [[JADDR]]
+  // CHECK: [[READI:%.*]] = begin_access [read] [unknown] [[IADDR]]
+  // CHECK: [[I:%[0-9]+]] = load [trivial] [[READI]]
+  // CHECK: [[READJ:%.*]] = begin_access [read] [unknown] [[JADDR]]
+  // CHECK: [[J:%[0-9]+]] = load [trivial] [[READJ]]
   // CHECK: apply [[FUNC]]([[I]], [[J]])
   standalone_function(i, j)
 
@@ -120,8 +122,10 @@ func calls(_ i:Int, j:Int, k:Int) {
   // CHECK: [[ST_ADDR:%.*]] = alloc_box ${ var SomeStruct }
   // CHECK: [[CTOR:%.*]] = function_ref @_T09functions10SomeStructV{{[_0-9a-zA-Z]*}}fC : $@convention(method) (Builtin.Int64, Builtin.Int64, @thin SomeStruct.Type) -> SomeStruct
   // CHECK: [[METATYPE:%.*]] = metatype $@thin SomeStruct.Type
-  // CHECK: [[I:%.*]] = load [trivial] [[IADDR]]
-  // CHECK: [[J:%.*]] = load [trivial] [[JADDR]]
+  // CHECK: [[READI:%.*]] = begin_access [read] [unknown] [[IADDR]]
+  // CHECK: [[I:%.*]] = load [trivial] [[READI]]
+  // CHECK: [[READJ:%.*]] = begin_access [read] [unknown] [[JADDR]]
+  // CHECK: [[J:%.*]] = load [trivial] [[READJ]]
   // CHECK: apply [[CTOR]]([[I]], [[J]], [[METATYPE]]) : $@convention(method) (Builtin.Int64, Builtin.Int64, @thin SomeStruct.Type) -> SomeStruct
   var st = SomeStruct(x: i, y: j)
 
@@ -138,14 +142,18 @@ func calls(_ i:Int, j:Int, k:Int) {
   // CHECK: [[CADDR:%.*]] = project_box [[CBOX]]
   // CHECK: [[FUNC:%[0-9]+]] = function_ref @_T09functions9SomeClassC{{[_0-9a-zA-Z]*}}fC : $@convention(method) (Builtin.Int64, Builtin.Int64, @thick SomeClass.Type) -> @owned SomeClass
   // CHECK: [[META:%[0-9]+]] = metatype $@thick SomeClass.Type
-  // CHECK: [[I:%[0-9]+]] = load [trivial] [[IADDR]]
-  // CHECK: [[J:%[0-9]+]] = load [trivial] [[JADDR]]
+  // CHECK: [[READI:%.*]] = begin_access [read] [unknown] [[IADDR]]
+  // CHECK: [[I:%[0-9]+]] = load [trivial] [[READI]]
+  // CHECK: [[READJ:%.*]] = begin_access [read] [unknown] [[JADDR]]
+  // CHECK: [[J:%[0-9]+]] = load [trivial] [[READJ]]
   // CHECK: [[C:%[0-9]+]] = apply [[FUNC]]([[I]], [[J]], [[META]])
   var c = SomeClass(x: i, y: j)
 
-  // CHECK: [[C:%[0-9]+]] = load [copy] [[CADDR]]
+  // CHECK: [[READC:%.*]] = begin_access [read] [unknown] [[CADDR]]
+  // CHECK: [[C:%[0-9]+]] = load [copy] [[READC]]
   // CHECK: [[METHOD:%[0-9]+]] = class_method [[C]] : {{.*}}, #SomeClass.method!1
-  // CHECK: [[I:%[0-9]+]] = load [trivial] [[IADDR]]
+  // CHECK: [[READI:%.*]] = begin_access [read] [unknown] [[IADDR]]
+  // CHECK: [[I:%[0-9]+]] = load [trivial] [[READI]]
   // CHECK: apply [[METHOD]]([[I]], [[C]])
   // CHECK: destroy_value [[C]]
   c.method(i)
@@ -156,50 +164,64 @@ func calls(_ i:Int, j:Int, k:Int) {
   var cm1 = SomeClass.method(c)
   cm1(i)
 
-  // CHECK: [[C:%[0-9]+]] = load [copy] [[CADDR]]
+  // CHECK: [[READC:%.*]] = begin_access [read] [unknown] [[CADDR]]
+  // CHECK: [[C:%[0-9]+]] = load [copy] [[READC]]
   // CHECK: [[METHOD:%[0-9]+]] = class_method [[C]] : {{.*}}, #SomeClass.method!1
-  // CHECK: [[I:%[0-9]+]] = load [trivial] [[IADDR]]
+  // CHECK: [[READI:%.*]] = begin_access [read] [unknown] [[IADDR]]
+  // CHECK: [[I:%[0-9]+]] = load [trivial] [[READI]]
   // CHECK: apply [[METHOD]]([[I]], [[C]])
   // CHECK: destroy_value [[C]]
   SomeClass.method(c)(i)
 
   // -- Curry the Type onto static method argument lists.
   
-  // CHECK: [[C:%[0-9]+]] = load_borrow [[CADDR]]
+  // CHECK: [[READC:%.*]] = begin_access [read] [unknown] [[CADDR]]
+  // CHECK: [[C:%[0-9]+]] = load_borrow [[READC]]
   // CHECK: [[META:%.*]] = value_metatype $@thick SomeClass.Type, [[C]]
   // CHECK: [[METHOD:%[0-9]+]] = class_method [[META]] : {{.*}}, #SomeClass.static_method!1
-  // CHECK: [[I:%[0-9]+]] = load [trivial] [[IADDR]]
+  // CHECK: [[READI:%.*]] = begin_access [read] [unknown] [[IADDR]]
+  // CHECK: [[I:%[0-9]+]] = load [trivial] [[READI]]
   // CHECK: apply [[METHOD]]([[I]], [[META]])
   type(of: c).static_method(i)
 
   // -- Curry property accesses.
 
   // -- FIXME: class_method-ify class getters.
-  // CHECK: [[C:%[0-9]+]] = load [copy] [[CADDR]]
+  // CHECK: [[READC:%.*]] = begin_access [read] [unknown] [[CADDR]]
+  // CHECK: [[C:%[0-9]+]] = load [copy] [[READC]]
   // CHECK: [[GETTER:%[0-9]+]] = class_method {{.*}} : $SomeClass, #SomeClass.someProperty!getter.1
   // CHECK: apply [[GETTER]]([[C]])
   // CHECK: destroy_value [[C]]
   i = c.someProperty
 
-  // CHECK: [[C:%[0-9]+]] = load [copy] [[CADDR]]
-  // CHECK: [[I:%[0-9]+]] = load [trivial] [[IADDR]]
+  // CHECK: [[READC:%.*]] = begin_access [read] [unknown] [[CADDR]]
+  // CHECK: [[C:%[0-9]+]] = load [copy] [[READC]]
+  // CHECK: [[READI:%.*]] = begin_access [read] [unknown] [[IADDR]]
+  // CHECK: [[I:%[0-9]+]] = load [trivial] [[READI]]
   // CHECK: [[SETTER:%[0-9]+]] = class_method [[C]] : $SomeClass, #SomeClass.someProperty!setter.1 : (SomeClass) -> (Builtin.Int64) -> ()
   // CHECK: apply [[SETTER]]([[I]], [[C]])
   // CHECK: destroy_value [[C]]
   c.someProperty = i
 
-  // CHECK: [[C:%[0-9]+]] = load [copy] [[CADDR]]
-  // CHECK: [[J:%[0-9]+]] = load [trivial] [[JADDR]]
-  // CHECK: [[K:%[0-9]+]] = load [trivial] [[KADDR]]
+  // CHECK: [[READC:%.*]] = begin_access [read] [unknown] [[CADDR]]
+  // CHECK: [[C:%[0-9]+]] = load [copy] [[READC]]
+  // CHECK: [[READJ:%.*]] = begin_access [read] [unknown] [[JADDR]]
+  // CHECK: [[J:%[0-9]+]] = load [trivial] [[READJ]]
+  // CHECK: [[READK:%.*]] = begin_access [read] [unknown] [[KADDR]]
+  // CHECK: [[K:%[0-9]+]] = load [trivial] [[READK]]
   // CHECK: [[GETTER:%[0-9]+]] = class_method [[C]] : $SomeClass, #SomeClass.subscript!getter.1 : (SomeClass) -> (Builtin.Int64, Builtin.Int64) -> Builtin.Int64, $@convention(method) (Builtin.Int64, Builtin.Int64, @guaranteed SomeClass) -> Builtin.Int64
   // CHECK: apply [[GETTER]]([[J]], [[K]], [[C]])
   // CHECK: destroy_value [[C]]
   i = c[j, k]
 
-  // CHECK: [[C:%[0-9]+]] = load [copy] [[CADDR]]
-  // CHECK: [[I:%[0-9]+]] = load [trivial] [[IADDR]]
-  // CHECK: [[J:%[0-9]+]] = load [trivial] [[JADDR]]
-  // CHECK: [[K:%[0-9]+]] = load [trivial] [[KADDR]]
+  // CHECK: [[READC:%.*]] = begin_access [read] [unknown] [[CADDR]]
+  // CHECK: [[C:%[0-9]+]] = load [copy] [[READC]]
+  // CHECK: [[READI:%.*]] = begin_access [read] [unknown] [[IADDR]]
+  // CHECK: [[I:%[0-9]+]] = load [trivial] [[READI]]
+  // CHECK: [[READJ:%.*]] = begin_access [read] [unknown] [[JADDR]]
+  // CHECK: [[J:%[0-9]+]] = load [trivial] [[READJ]]
+  // CHECK: [[READK:%.*]] = begin_access [read] [unknown] [[KADDR]]
+  // CHECK: [[K:%[0-9]+]] = load [trivial] [[READK]]
   // CHECK: [[SETTER:%[0-9]+]] = class_method [[C]] : $SomeClass, #SomeClass.subscript!setter.1 : (SomeClass) -> (Builtin.Int64, Builtin.Int64, Builtin.Int64) -> (), $@convention(method) (Builtin.Int64, Builtin.Int64, Builtin.Int64, @guaranteed SomeClass) -> ()
   // CHECK: apply [[SETTER]]([[K]], [[I]], [[J]], [[C]])
   // CHECK: destroy_value [[C]]
@@ -212,11 +234,13 @@ func calls(_ i:Int, j:Int, k:Int) {
   // CHECK: [[PADDR:%.*]] = project_box [[PBOX]]
   var p : SomeProtocol = ConformsToSomeProtocol()
 
+  // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[PADDR]]
   // CHECK: [[TEMP:%.*]] = alloc_stack $SomeProtocol
-  // CHECK: copy_addr [[PADDR]] to [initialization] [[TEMP]]
+  // CHECK: copy_addr [[READ]] to [initialization] [[TEMP]]
   // CHECK: [[PVALUE:%[0-9]+]] = open_existential_addr immutable_access [[TEMP]] : $*SomeProtocol to $*[[OPENED:@opened(.*) SomeProtocol]]
   // CHECK: [[PMETHOD:%[0-9]+]] = witness_method $[[OPENED]], #SomeProtocol.method!1
-  // CHECK: [[I:%[0-9]+]] = load [trivial] [[IADDR]]
+  // CHECK: [[READI:%.*]] = begin_access [read] [unknown] [[IADDR]]
+  // CHECK: [[I:%[0-9]+]] = load [trivial] [[READI]]
   // CHECK: apply [[PMETHOD]]<[[OPENED]]>([[I]], [[PVALUE]])
   // CHECK: destroy_addr [[TEMP]]
   // CHECK: dealloc_stack [[TEMP]]
@@ -224,7 +248,8 @@ func calls(_ i:Int, j:Int, k:Int) {
 
   // CHECK: [[PVALUE:%[0-9]+]] = open_existential_addr immutable_access [[PADDR:%.*]] : $*SomeProtocol to $*[[OPENED:@opened(.*) SomeProtocol]]
   // CHECK: [[PMETHOD:%[0-9]+]] = witness_method $[[OPENED]], #SomeProtocol.method!1
-  // CHECK: [[I:%[0-9]+]] = load [trivial] [[IADDR]]
+  // CHECK: [[READI:%.*]] = begin_access [read] [unknown] [[IADDR]]
+  // CHECK: [[I:%[0-9]+]] = load [trivial] [[READI]]
   // CHECK: apply [[PMETHOD]]<[[OPENED]]>([[I]], [[PVALUE]])
   var sp : SomeProtocol = ConformsToSomeProtocol()
   sp.method(i)
@@ -244,7 +269,8 @@ func calls(_ i:Int, j:Int, k:Int) {
   // CHECK: apply [[CTOR_GEN]]<Builtin.Int64>([[META]])
   var g = SomeGeneric<Builtin.Int64>()
 
-  // CHECK: [[G:%[0-9]+]] = load [copy] [[GADDR]]
+  // CHECK: [[READG:%.*]] = begin_access [read] [unknown] [[GADDR]]
+  // CHECK: [[G:%[0-9]+]] = load [copy] [[READG]]
   // CHECK: [[METHOD_GEN:%[0-9]+]] = class_method [[G]] : {{.*}}, #SomeGeneric.method!1
   // CHECK: [[TMPR:%.*]] = alloc_stack $Builtin.Int64
   // CHECK: [[TMPI:%.*]] = alloc_stack $Builtin.Int64
@@ -252,7 +278,8 @@ func calls(_ i:Int, j:Int, k:Int) {
   // CHECK: destroy_value [[G]]
   g.method(i)
 
-  // CHECK: [[G:%[0-9]+]] = load [copy] [[GADDR]]
+  // CHECK: [[READG:%.*]] = begin_access [read] [unknown] [[GADDR]]
+  // CHECK: [[G:%[0-9]+]] = load [copy] [[READG]]
   // CHECK: [[METHOD_GEN:%[0-9]+]] = class_method [[G]] : {{.*}}, #SomeGeneric.generic!1
   // CHECK: [[TMPR:%.*]] = alloc_stack $Builtin.Int64
   // CHECK: [[TMPJ:%.*]] = alloc_stack $Builtin.Int64
@@ -260,7 +287,8 @@ func calls(_ i:Int, j:Int, k:Int) {
   // CHECK: destroy_value [[G]]
   g.generic(j)
 
-  // CHECK: [[C:%[0-9]+]] = load [copy] [[CADDR]]
+  // CHECK: [[READC:%.*]] = begin_access [read] [unknown] [[CADDR]]
+  // CHECK: [[C:%[0-9]+]] = load [copy] [[READC]]
   // CHECK: [[METHOD_GEN:%[0-9]+]] = class_method [[C]] : {{.*}}, #SomeClass.generic!1
   // CHECK: [[TMPR:%.*]] = alloc_stack $Builtin.Int64
   // CHECK: [[TMPK:%.*]] = alloc_stack $Builtin.Int64
@@ -287,25 +315,32 @@ func calls(_ i:Int, j:Int, k:Int) {
   // CHECK: [[FUNC_THICK:%[0-9]+]] = thin_to_thick_function [[FUNC_THIN]]
   // CHECK: store [[FUNC_THICK]] to [init] [[FADDR]]
   var f = standalone_function
-  // CHECK: [[F:%[0-9]+]] = load [copy] [[FADDR]]
-  // CHECK: [[I:%[0-9]+]] = load [trivial] [[IADDR]]
-  // CHECK: [[J:%[0-9]+]] = load [trivial] [[JADDR]]
+  // CHECK: [[READF:%.*]] = begin_access [read] [unknown] [[FADDR]]
+  // CHECK: [[F:%[0-9]+]] = load [copy] [[READF]]
+  // CHECK: [[READI:%.*]] = begin_access [read] [unknown] [[IADDR]]
+  // CHECK: [[I:%[0-9]+]] = load [trivial] [[READI]]
+  // CHECK: [[READJ:%.*]] = begin_access [read] [unknown] [[JADDR]]
+  // CHECK: [[J:%[0-9]+]] = load [trivial] [[READJ]]
   // CHECK: apply [[F]]([[I]], [[J]])
   f(i, j)
 
   // CHECK: [[HOF:%[0-9]+]] = function_ref @_T09functions21higher_order_function{{[_0-9a-zA-Z]*}}F : $@convention(thin) {{.*}}
   // CHECK: [[FUNC_THIN:%[0-9]+]] = function_ref @_T09functions19standalone_function{{[_0-9a-zA-Z]*}}F : $@convention(thin) (Builtin.Int64, Builtin.Int64) -> Builtin.Int64
   // CHECK: [[FUNC_THICK:%[0-9]+]] = thin_to_thick_function [[FUNC_THIN]]
-  // CHECK: [[I:%[0-9]+]] = load [trivial] [[IADDR]]
-  // CHECK: [[J:%[0-9]+]] = load [trivial] [[JADDR]]
+  // CHECK: [[READI:%.*]] = begin_access [read] [unknown] [[IADDR]]
+  // CHECK: [[I:%[0-9]+]] = load [trivial] [[READI]]
+  // CHECK: [[READJ:%.*]] = begin_access [read] [unknown] [[JADDR]]
+  // CHECK: [[J:%[0-9]+]] = load [trivial] [[READJ]]
   // CHECK: apply [[HOF]]([[FUNC_THICK]], [[I]], [[J]])
   higher_order_function(standalone_function, i, j)
 
   // CHECK: [[HOF2:%[0-9]+]] = function_ref @_T09functions22higher_order_function2{{[_0-9a-zA-Z]*}}F : $@convention(thin) {{.*}}
   // CHECK: [[FUNC_THIN:%[0-9]+]] = function_ref @_T09functions19standalone_function{{[_0-9a-zA-Z]*}}F : $@convention(thin) (Builtin.Int64, Builtin.Int64) -> Builtin.Int64
   // CHECK: [[FUNC_THICK:%.*]] = thin_to_thick_function [[FUNC_THIN]]
-  // CHECK: [[I:%[0-9]+]] = load [trivial] [[IADDR]]
-  // CHECK: [[J:%[0-9]+]] = load [trivial] [[JADDR]]
+  // CHECK: [[READI:%.*]] = begin_access [read] [unknown] [[IADDR]]
+  // CHECK: [[I:%[0-9]+]] = load [trivial] [[READI]]
+  // CHECK: [[READJ:%.*]] = begin_access [read] [unknown] [[JADDR]]
+  // CHECK: [[J:%[0-9]+]] = load [trivial] [[READJ]]
   // CHECK: apply [[HOF2]]([[FUNC_THICK]], [[I]], [[J]])
   higher_order_function2(standalone_function, i, j)
 }

--- a/test/SILGen/guaranteed_self.swift
+++ b/test/SILGen/guaranteed_self.swift
@@ -495,7 +495,9 @@ class LetFieldClass {
   // CHECK-NEXT: [[KRAKEN2:%.*]] = load [copy] [[KRAKEN_ADDR]]
   // CHECK-NEXT: store [[KRAKEN2]] to [init] [[PB]]
   // CHECK: [[DESTROY_SHIP_FUN:%.*]] = function_ref @_T015guaranteed_self11destroyShipyAA6KrakenCF : $@convention(thin) (@owned Kraken) -> ()
-  // CHECK-NEXT: [[KRAKEN_COPY:%.*]] = load [copy] [[PB]]
+  // CHECK-NEXT: [[READ:%.*]] = begin_access [read] [unknown] [[PB]] : $*Kraken
+  // CHECK-NEXT: [[KRAKEN_COPY:%.*]] = load [copy] [[READ]]
+  // CHECK-NEXT: end_access [[READ]] : $*Kraken
   // CHECK-NEXT: apply [[DESTROY_SHIP_FUN]]([[KRAKEN_COPY]])
   // CHECK-NEXT: destroy_value [[KRAKEN_BOX]]
   // CHECK-NEXT: destroy_value [[KRAKEN]]
@@ -529,7 +531,9 @@ class LetFieldClass {
   // CHECK-NEXT: [[KRAKEN2:%.*]] = apply [[KRAKEN_GETTER_FUN]]([[CLS]])
   // CHECK-NEXT: store [[KRAKEN2]] to [init] [[PB]]
   // CHECK: [[DESTROY_SHIP_FUN:%.*]] = function_ref @_T015guaranteed_self11destroyShipyAA6KrakenCF : $@convention(thin) (@owned Kraken) -> ()
-  // CHECK-NEXT: [[KRAKEN_COPY:%.*]] = load [copy] [[PB]]
+  // CHECK-NEXT: [[WRITE:%.*]] = begin_access [read] [unknown] [[PB]] : $*Kraken
+  // CHECK-NEXT: [[KRAKEN_COPY:%.*]] = load [copy] [[WRITE]]
+  // CHECK-NEXT: end_access [[WRITE]] : $*Kraken
   // CHECK-NEXT: apply [[DESTROY_SHIP_FUN]]([[KRAKEN_COPY]])
   // CHECK-NEXT: destroy_value [[KRAKEN_BOX]]
   // CHECK-NEXT: destroy_value [[KRAKEN]]

--- a/test/SILGen/if_expr.swift
+++ b/test/SILGen/if_expr.swift
@@ -41,10 +41,12 @@ func addr_only_ternary_1(x: Bool) -> AddressOnly {
 
   // CHECK:   cond_br {{%.*}}, [[TRUE:bb[0-9]+]], [[FALSE:bb[0-9]+]]
   // CHECK: [[TRUE]]:
-  // CHECK:   copy_addr [[PBa]] to [initialization] [[RET]]
+  // CHECK:   [[READa:%.*]] = begin_access [read] [unknown] [[PBa]]
+  // CHECK:   copy_addr [[READa]] to [initialization] [[RET]]
   // CHECK:   br [[CONT:bb[0-9]+]]
   // CHECK: [[FALSE]]:
-  // CHECK:   copy_addr [[PBb]] to [initialization] [[RET]]
+  // CHECK:   [[READb:%.*]] = begin_access [read] [unknown] [[PBb]]
+  // CHECK:   copy_addr [[READb]] to [initialization] [[RET]]
   // CHECK:   br [[CONT]]
   return x ? a : b
 }

--- a/test/SILGen/implicitly_unwrapped_optional.swift
+++ b/test/SILGen/implicitly_unwrapped_optional.swift
@@ -12,23 +12,24 @@ func foo(f f: (() -> ())!) {
 // CHECK:   [[T0_COPY:%.*]] = copy_value [[BORROWED_T0]]
 // CHECK:   store [[T0_COPY]] to [init] [[PF]]
 // CHECK:   end_borrow [[BORROWED_T0]] from [[T0]]
-// CHECK:   [[T1:%.*]] = select_enum_addr [[PF]]
-// CHECK:   cond_br [[T1]], bb1, bb3
+// CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PF]] : $*Optional<@callee_owned () -> ()>
+// CHECK:   [[T1:%.*]] = select_enum_addr [[READ]]
+// CHECK:   cond_br [[T1]], bb2, bb1
 //   If it does, project and load the value out of the implicitly unwrapped
 //   optional...
-// CHECK:    bb1:
-// CHECK-NEXT: [[FN0_ADDR:%.*]] = unchecked_take_enum_data_addr [[PF]]
+// CHECK:    bb2:
+// CHECK-NEXT: [[FN0_ADDR:%.*]] = unchecked_take_enum_data_addr [[READ]]
 // CHECK-NEXT: [[FN0:%.*]] = load [copy] [[FN0_ADDR]]
 //   .... then call it
 // CHECK:   apply [[FN0]]() : $@callee_owned () -> ()
-// CHECK:   br bb2
-// CHECK: bb2(
+// CHECK:   br bb3
+// CHECK: bb3(
 // CHECK:   destroy_value [[F]]
 // CHECK:   destroy_value [[T0]]
 // CHECK:   return
-// CHECK: bb3:
+// CHECK: bb4:
 // CHECK:   enum $Optional<()>, #Optional.none!enumelt
-// CHECK:   br bb2
+// CHECK:   br bb3
 //   The rest of this is tested in optional.swift
 // } // end sil function '{{.*}}foo{{.*}}'
 

--- a/test/SILGen/let_decls.swift
+++ b/test/SILGen/let_decls.swift
@@ -246,14 +246,16 @@ func test_weird_property(_ v : WeirdPropertyTest, i : Int) -> Int {
   // CHECK: store %0 to [trivial] [[PB]]
 
   // The setter isn't mutating, so we need to load the box.
-  // CHECK: [[VVAL:%[0-9]+]] = load [trivial] [[PB]]
+  // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[PB]]
+  // CHECK: [[VVAL:%[0-9]+]] = load [trivial] [[READ]]
   // CHECK: [[SETFN:%[0-9]+]] = function_ref @_T09let_decls17WeirdPropertyTestV1pSifs
   // CHECK: apply [[SETFN]](%1, [[VVAL]])
   v.p = i
   
   // The getter is mutating, so it takes the box address.
+  // CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] [[PB]]
   // CHECK: [[GETFN:%[0-9]+]] = function_ref @_T09let_decls17WeirdPropertyTestV1pSifg
-  // CHECK-NEXT: [[RES:%[0-9]+]] = apply [[GETFN]]([[PB]])
+  // CHECK-NEXT: [[RES:%[0-9]+]] = apply [[GETFN]]([[WRITE]])
   // CHECK: return [[RES]]
   return v.p
 }
@@ -478,7 +480,8 @@ struct LetPropertyStruct {
 // CHECK:  [[ABOX:%[0-9]+]] = alloc_box ${ var LetPropertyStruct }
 // CHECK:  [[A:%[0-9]+]] = project_box [[ABOX]]
 // CHECK:   store %0 to [trivial] [[A]] : $*LetPropertyStruct
-// CHECK:   [[STRUCT:%[0-9]+]] = load [trivial] [[A]] : $*LetPropertyStruct
+// CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[A]]
+// CHECK:   [[STRUCT:%[0-9]+]] = load [trivial] [[READ]] : $*LetPropertyStruct
 // CHECK:   [[PROP:%[0-9]+]] = struct_extract [[STRUCT]] : $LetPropertyStruct, #LetPropertyStruct.lp
 // CHECK:   destroy_value [[ABOX]] : ${ var LetPropertyStruct }
 // CHECK:   return [[PROP]] : $Int

--- a/test/SILGen/lifetime.swift
+++ b/test/SILGen/lifetime.swift
@@ -189,7 +189,8 @@ func reftype_call_arg() {
 // CHECK:   store [[A1_COPY]] to [init] [[PB]]
 // CHECK:   end_borrow [[BORROWED_A1]] from [[A1]]
 // CHECK:   [[RFWA:%[0-9]+]] = function_ref @_T08lifetime21reftype_func_with_arg{{[_0-9a-zA-Z]*}}F
-// CHECK:   [[A2:%[0-9]+]] = load [copy] [[PB]]
+// CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PB]]
+// CHECK:   [[A2:%[0-9]+]] = load [copy] [[READ]]
 // CHECK:   [[RESULT:%.*]] = apply [[RFWA]]([[A2]])
 // CHECK:   destroy_value [[RESULT]]
 // CHECK:   destroy_value [[AADDR]]
@@ -368,13 +369,15 @@ func logical_lvalue_lifetime(_ r: RefWithProp, _ i: Int, _ v: Val) {
 
   // -- Reference types need to be copy_valued as property method args.
   r.int_prop = i
-  // CHECK: [[R1:%[0-9]+]] = load [copy] [[PR]]
+  // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PR]]
+  // CHECK: [[R1:%[0-9]+]] = load [copy] [[READ]]
   // CHECK: [[SETTER_METHOD:%[0-9]+]] = class_method {{.*}} : $RefWithProp, #RefWithProp.int_prop!setter.1 : (RefWithProp) -> (Int) -> (), $@convention(method) (Int, @guaranteed RefWithProp) -> ()
   // CHECK: apply [[SETTER_METHOD]]({{.*}}, [[R1]])
   // CHECK: destroy_value [[R1]]
 
   r.aleph_prop.b = v
-  // CHECK: [[R2:%[0-9]+]] = load [copy] [[PR]]
+  // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[PR]]
+  // CHECK: [[R2:%[0-9]+]] = load [copy] [[READ]]
   // CHECK: [[STORAGE:%.*]] = alloc_stack $Builtin.UnsafeValueBuffer
   // CHECK: [[ALEPH_PROP_TEMP:%[0-9]+]] = alloc_stack $Aleph
   // CHECK: [[BORROWED_R2:%.*]] = begin_borrow [[R2]]
@@ -503,8 +506,10 @@ class Foo<T> {
     // -- Then initialize #Foo.x using the earlier stored value of CHI to THIS_Z.
     x = chi
     // CHECK:   [[BORROWED_THIS:%.*]] = begin_borrow [[THIS]]
+    // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PCHI]]
+    // CHECK:   [[X:%.*]] = load [trivial] [[READ]]
     // CHECK:   [[THIS_X:%[0-9]+]] = ref_element_addr [[BORROWED_THIS]] : {{.*}}, #Foo.x
-    // CHECK:   copy_addr [[PCHI]] to [[THIS_X]]
+    // CHECK:   assign [[X]] to [[THIS_X]]
     // CHECK:   end_borrow [[BORROWED_THIS]] from [[THIS]]
 
     // -- cleanup chi
@@ -663,7 +668,8 @@ struct Bar {
     // CHECK: [[PB_BOX:%.*]] = project_box [[MARKED_SELF_BOX]]
 
     x = bar()
-    // CHECK: [[SELF_X:%[0-9]+]] = struct_element_addr [[PB_BOX]] : $*Bar, #Bar.x
+    // CHECK:   [[WRITE:%.*]] = begin_access [modify] [unknown] [[PB_BOX]]
+    // CHECK: [[SELF_X:%[0-9]+]] = struct_element_addr [[WRITE]] : $*Bar, #Bar.x
     // CHECK: assign {{.*}} to [[SELF_X]]
 
     // -- load and return this
@@ -690,11 +696,13 @@ struct Bas<T> {
     // CHECK: [[PB_BOX:%.*]] = project_box [[MARKED_SELF_BOX]]
 
     x = bar()
-    // CHECK: [[SELF_X:%[0-9]+]] = struct_element_addr [[PB_BOX]] : $*Bas<T>, #Bas.x
+    // CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] [[PB_BOX]]
+    // CHECK: [[SELF_X:%[0-9]+]] = struct_element_addr [[WRITE]] : $*Bas<T>, #Bas.x
     // CHECK: assign {{.*}} to [[SELF_X]]
 
     y = yy
-    // CHECK: [[SELF_Y:%[0-9]+]] = struct_element_addr [[PB_BOX]] : $*Bas<T>, #Bas.y
+    // CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] [[PB_BOX]]
+    // CHECK: [[SELF_Y:%[0-9]+]] = struct_element_addr [[WRITE]] : $*Bas<T>, #Bas.y
     // CHECK: copy_addr {{.*}} to [[SELF_Y]]
     // CHECK: destroy_value
 
@@ -730,7 +738,8 @@ class D : B {
     // CHECK: [[THIS1:%[0-9]+]] = load [take] [[PB_BOX]]
     // CHECK: [[THIS1_SUP:%[0-9]+]] = upcast [[THIS1]] : ${{.*}} to $B
     // CHECK: [[SUPER_CTOR:%[0-9]+]] = function_ref @_T08lifetime1BCACSi1y_tcfc : $@convention(method) (Int, @owned B) -> @owned B
-    // CHECK: [[Y:%[0-9]+]] = load [trivial] [[PY]]
+    // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[PY]]
+    // CHECK: [[Y:%[0-9]+]] = load [trivial] [[READ]]
     // CHECK: [[THIS2_SUP:%[0-9]+]] = apply [[SUPER_CTOR]]([[Y]], [[THIS1_SUP]])
     // CHECK: [[THIS2:%[0-9]+]] = unchecked_ref_cast [[THIS2_SUP]] : $B to $D
     // CHECK: [[THIS1:%[0-9]+]] = load [copy] [[PB_BOX]]
@@ -746,7 +755,8 @@ func downcast(_ b: B) {
   // CHECK: [[BADDR:%[0-9]+]] = alloc_box ${ var B }
   // CHECK: [[PB:%[0-9]+]] = project_box [[BADDR]]
   (b as! D).foo()
-  // CHECK: [[B:%[0-9]+]] = load [copy] [[PB]]
+  // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[PB]]
+  // CHECK: [[B:%[0-9]+]] = load [copy] [[READ]]
   // CHECK: [[D:%[0-9]+]] = unconditional_checked_cast [[B]] : {{.*}} to $D
   // CHECK: apply {{.*}}([[D]])
   // CHECK-NOT: destroy_value [[B]]

--- a/test/SILGen/materializeForSet.swift
+++ b/test/SILGen/materializeForSet.swift
@@ -302,9 +302,10 @@ func improveWizard(_ wizard: inout Wizard) {
 }
 // CHECK-LABEL: sil hidden @_T017materializeForSet13improveWizardyAA0E0VzF
 // CHECK:       [[IMPROVE:%.*]] = function_ref @_T017materializeForSet7improveySizF :
+// CHECK-NEXT:  [[WRITE:%.*]] = begin_access [modify] [unknown] %0 : $*Wizard
 // CHECK-NEXT:  [[TEMP:%.*]] = alloc_stack $Int
 //   Call the getter and materialize the result in the temporary.
-// CHECK-NEXT:  [[T0:%.*]] = load [trivial] [[WIZARD:.*]] : $*Wizard
+// CHECK-NEXT:  [[T0:%.*]] = load [trivial] [[WRITE:.*]] : $*Wizard
 // CHECK-NEXT:  function_ref
 // CHECK-NEXT:  [[GETTER:%.*]] = function_ref @_T017materializeForSet5MagicPAAE5hocusSifg
 // CHECK-NEXT:  [[WTEMP:%.*]] = alloc_stack $Wizard
@@ -317,7 +318,8 @@ func improveWizard(_ wizard: inout Wizard) {
 // CHECK-NEXT:  [[T0:%.*]] = load [trivial] [[TEMP]]
 // CHECK-NEXT:  function_ref
 // CHECK-NEXT:  [[SETTER:%.*]] = function_ref @_T017materializeForSet5MagicPAAE5hocusSifs
-// CHECK-NEXT:  apply [[SETTER]]<Wizard>([[T0]], [[WIZARD]])
+// CHECK-NEXT:  apply [[SETTER]]<Wizard>([[T0]], [[WRITE]])
+// CHECK-NEXT:  end_access [[WRITE]] : $*Wizard
 // CHECK-NEXT:  dealloc_stack [[TEMP]]
 
 protocol Totalled {

--- a/test/SILGen/metatype_abstraction.swift
+++ b/test/SILGen/metatype_abstraction.swift
@@ -54,7 +54,8 @@ func genericMetatypeFromGenericMetatype<T>(_ x: GenericMetatype<T>)-> T.Type {
 // CHECK-LABEL: sil hidden @_T0s026dynamicMetatypeFromGenericB0s1CCms0dB0VyACGF
 // CHECK:         [[XBOX:%[0-9]+]] = alloc_box ${ var GenericMetatype<C> }
 // CHECK:         [[PX:%[0-9]+]] = project_box [[XBOX]]
-// CHECK:         [[ADDR:%.*]] = struct_element_addr [[PX]] : $*GenericMetatype<C>, #GenericMetatype.value
+// CHECK:         [[READ:%.*]] = begin_access [read] [unknown] [[PX]] : $*GenericMetatype<C>
+// CHECK:         [[ADDR:%.*]] = struct_element_addr [[READ]] : $*GenericMetatype<C>, #GenericMetatype.value
 // CHECK:         [[META:%.*]] = load [trivial] [[ADDR]] : $*@thick C.Type
 // CHECK:         return [[META]] : $@thick C.Type
 // CHECK:       }
@@ -90,7 +91,8 @@ func dynamicMetatypeToGeneric(_ x: C.Type) {
 // CHECK-LABEL: sil hidden @_T0s024dynamicMetatypeToGenericB0ys1CCmF
 // CHECK:         [[XBOX:%[0-9]+]] = alloc_box ${ var @thick C.Type }
 // CHECK:         [[PX:%[0-9]+]] = project_box [[XBOX]]
-// CHECK:         [[META:%.*]] = load [trivial] [[PX]] : $*@thick C.Type
+// CHECK:         [[READ:%.*]] = begin_access [read] [unknown] [[PX]] : $*@thick C.Type
+// CHECK:         [[META:%.*]] = load [trivial] [[READ]] : $*@thick C.Type
 // CHECK:         apply {{%.*}}<C>([[META]]) : $@convention(thin) <τ_0_0> (@thick τ_0_0.Type) -> ()
 func dynamicMetatypeToGenericMetatype(_ x: C.Type) {
   var x = x

--- a/test/SILGen/newtype.swift
+++ b/test/SILGen/newtype.swift
@@ -24,7 +24,8 @@ func createErrorDomain(str: String) -> ErrorDomain {
 // CHECK-RAW: [[BORROWED_STR:%.*]] = begin_borrow [[STR]]
 // CHECK-RAW: [[BRIDGED:%[0-9]+]] = apply [[BRIDGE_FN]]([[BORROWED_STR]])
 // CHECK-RAW: end_borrow [[BORROWED_STR]] from [[STR]]
-// CHECK-RAW: [[RAWVALUE_ADDR:%[0-9]+]] = struct_element_addr [[PB_BOX]]
+// CHECK-RAW: [[WRITE:%.*]] = begin_access [modify] [unknown] [[PB_BOX]]
+// CHECK-RAW: [[RAWVALUE_ADDR:%[0-9]+]] = struct_element_addr [[WRITE]]
 // CHECK-RAW: assign [[BRIDGED]] to [[RAWVALUE_ADDR]]
 
 func getRawValue(ed: ErrorDomain) -> String {

--- a/test/SILGen/objc_ownership_conventions.swift
+++ b/test/SILGen/objc_ownership_conventions.swift
@@ -43,7 +43,8 @@ func test5(_ g: Gizmo) {
   // CHECK:   [[CLASS:%.*]] = metatype $@thick Gizmo.Type
   // CHECK:   [[METHOD:%.*]] = class_method [volatile] [[CLASS]] : {{.*}}, #Gizmo.inspect!1.foreign
   // CHECK:   [[OBJC_CLASS:%[0-9]+]] = thick_to_objc_metatype [[CLASS]] : $@thick Gizmo.Type to $@objc_metatype Gizmo.Type
-  // CHECK:   [[V:%.*]] = load [copy] [[GIZMO_BOX_PB]]
+  // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[GIZMO_BOX_PB]] : $*Gizmo
+  // CHECK:   [[V:%.*]] = load [copy] [[READ]]
   // CHECK:   [[G:%.*]] = enum $Optional<Gizmo>, #Optional.some!enumelt.1, [[V]]
   // CHECK:   apply [[METHOD]]([[G]], [[OBJC_CLASS]])
   // CHECK:   destroy_value [[G]]
@@ -67,7 +68,8 @@ func test6(_ g: Gizmo) {
   // CHECK:   [[CLASS:%.*]] = metatype $@thick Gizmo.Type
   // CHECK:   [[METHOD:%.*]] = class_method [volatile] [[CLASS]] : {{.*}}, #Gizmo.consume!1.foreign
   // CHECK:   [[OBJC_CLASS:%.*]] = thick_to_objc_metatype [[CLASS]] : $@thick Gizmo.Type to $@objc_metatype Gizmo.Type
-  // CHECK:   [[V:%.*]] = load [copy] [[GIZMO_BOX_PB]]
+  // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[GIZMO_BOX_PB]] : $*Gizmo
+  // CHECK:   [[V:%.*]] = load [copy] [[READ]]
   // CHECK:   [[G:%.*]] = enum $Optional<Gizmo>, #Optional.some!enumelt.1, [[V]]
   // CHECK:   apply [[METHOD]]([[G]], [[OBJC_CLASS]])
   // CHECK-NOT:  destroy_value [[G]]
@@ -90,7 +92,8 @@ func test7(_ g: Gizmo) {
   // CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
   // CHECK:   store [[ARG_COPY]] to [init] [[GIZMO_BOX_PB]]
   // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
-  // CHECK:   [[G:%.*]] = load [copy] [[GIZMO_BOX_PB]]
+  // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[GIZMO_BOX_PB]] : $*Gizmo
+  // CHECK:   [[G:%.*]] = load [copy] [[READ]]
   // CHECK:   [[METHOD:%.*]] = class_method [volatile] [[G]] : {{.*}}, #Gizmo.fork!1.foreign
   // CHECK:   apply [[METHOD]]([[G]])
   // CHECK-NOT:  destroy_value [[G]]

--- a/test/SILGen/objc_protocols.swift
+++ b/test/SILGen/objc_protocols.swift
@@ -271,7 +271,8 @@ func testInitializableExistential(_ im: Initializable.Type, i: Int) -> Initializ
   // CHECK:   [[I2:%[0-9]+]] = apply [[INIT_WITNESS]]<@opened([[N]]) Initializable>([[I]], [[I2_COPY]]) : $@convention(objc_method) <τ_0_0 where τ_0_0 : Initializable> (Int, @owned τ_0_0) -> @owned τ_0_0
   // CHECK:   [[I2_EXIST_CONTAINER:%[0-9]+]] = init_existential_ref [[I2]] : $@opened([[N]]) Initializable : $@opened([[N]]) Initializable, $Initializable
   // CHECK:   store [[I2_EXIST_CONTAINER]] to [init] [[PB]] : $*Initializable
-  // CHECK:   [[I2:%[0-9]+]] = load [copy] [[PB]] : $*Initializable
+  // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PB]] : $*Initializable
+  // CHECK:   [[I2:%[0-9]+]] = load [copy] [[READ]] : $*Initializable
   // CHECK:   destroy_value [[I2_BOX]] : ${ var Initializable }
   // CHECK:   return [[I2]] : $Initializable
   var i2 = im.init(int: i)

--- a/test/SILGen/opaque_values_silgen.swift
+++ b/test/SILGen/opaque_values_silgen.swift
@@ -185,7 +185,8 @@ public func s020_______callVarArg() {
 // CHECK: bb0([[ARG0:%.*]] : $*T, [[ARG1:%.*]] : $T):
 // CHECK:   [[BORROWED_ARG1:%.*]] = begin_borrow [[ARG1]]
 // CHECK:   [[CPY:%.*]] = copy_value [[BORROWED_ARG1]] : $T
-// CHECK:   assign [[CPY]] to [[ARG0]] : $*T
+// CHECK:   [[READ:%.*]] = begin_access [modify] [unknown] [[ARG0]] : $*T
+// CHECK:   assign [[CPY]] to [[READ]] : $*T
 // CHECK:   end_borrow [[BORROWED_ARG1]] from [[ARG1]]
 // CHECK:   destroy_value [[ARG1]] : $T
 // CHECK:   return %{{.*}} : $()
@@ -528,7 +529,8 @@ func s230______condFromAny(_ x: Any) {
 // CHECK:   [[COPY_ARG:%.*]] = copy_value [[BORROWED_ARG]]
 // CHECK:   store [[COPY_ARG]] to [init] [[PROJ_BOX]]
 // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
-// CHECK:   [[LOAD_BOX:%.*]] = load [copy] [[PROJ_BOX]]
+// CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PROJ_BOX]] : $*Error
+// CHECK:   [[LOAD_BOX:%.*]] = load [copy] [[READ]]
 // CHECK:   [[OPAQUE_ARG:%.*]] = open_existential_box [[LOAD_BOX]] : $Error to $*@opened({{.*}}) Error
 // CHECK:   [[LOAD_OPAQUE:%.*]] = load [copy] [[OPAQUE_ARG]]
 // CHECK:   [[ALLOC_OPEN:%.*]] = alloc_stack $@opened({{.*}}) Error
@@ -735,10 +737,12 @@ func s340_______captureBox() {
 // CHECK:   [[APPLY_FOR_BRANCH:%.*]] = apply %{{.*}}([[ARG]]) : $@convention(method) (Bool) -> Builtin.Int1
 // CHECK:   cond_br [[APPLY_FOR_BRANCH]], bb2, bb1
 // CHECK: bb1:
-// CHECK:   [[RETVAL1:%.*]] = load [copy] [[PROJ_BOX]] : $*EmptyP
+// CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PROJ_BOX]] : $*EmptyP
+// CHECK:   [[RETVAL1:%.*]] = load [copy] [[READ]] : $*EmptyP
 // CHECK:   br bb3([[RETVAL1]] : $EmptyP)
 // CHECK: bb2:
-// CHECK:   [[RETVAL2:%.*]] = load [copy] [[PROJ_BOX]] : $*EmptyP
+// CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PROJ_BOX]] : $*EmptyP
+// CHECK:   [[RETVAL2:%.*]] = load [copy] [[READ]] : $*EmptyP
 // CHECK:   br bb3([[RETVAL2]] : $EmptyP)
 // CHECK: bb3([[RETVAL:%.*]] : $EmptyP):
 // CHECK:   destroy_value [[ALLOC_OF_BOX]]
@@ -1052,11 +1056,12 @@ func s999_____condTFromAny<T>(_ x: Any, _ y: T) {
 // ---
 // CHECK-LABEL: sil @_T0s10DictionaryV20opaque_values_silgenE22inoutAccessOfSubscriptyq_3key_tF : $@convention(method) <Key, Value where Key : Hashable> (@in Value, @inout Dictionary<Key, Value>) -> () {
 // CHECK: bb0([[ARG0:%.*]] : $Value, [[ARG1:%.*]] : $*Dictionary<Key, Value>):
+// CHECK:   [[WRITE:%.*]] = begin_access [modify] [unknown] [[ARG1]] : $*Dictionary<Key, Value>
 // CHECK:   [[OPTIONAL_ALLOC:%.*]] = alloc_stack $Optional<Value>
 // CHECK:   switch_enum_addr [[OPTIONAL_ALLOC]] : $*Optional<Value>, case #Optional.some!enumelt.1: bb2, case #Optional.none!enumelt: bb1
 // CHECK: bb2:
 // CHECK:   [[OPTIONAL_LOAD:%.*]] = load [take] [[OPTIONAL_ALLOC]] : $*Optional<Value>
-// CHECK:   apply {{.*}}<Key, Value>([[OPTIONAL_LOAD]], {{.*}}, [[ARG1]]) : $@convention(method) <τ_0_0, τ_0_1 where τ_0_0 : Hashable> (@in Optional<τ_0_1>, @in τ_0_1, @inout Dictionary<τ_0_0, τ_0_1>) -> ()
+// CHECK:   apply {{.*}}<Key, Value>([[OPTIONAL_LOAD]], {{.*}}, [[WRITE]]) : $@convention(method) <τ_0_0, τ_0_1 where τ_0_0 : Hashable> (@in Optional<τ_0_1>, @in τ_0_1, @inout Dictionary<τ_0_0, τ_0_1>) -> ()
 // CHECK:   return %{{.*}} : $()
 // CHECK-LABEL: } // end sil function '_T0s10DictionaryV20opaque_values_silgenE22inoutAccessOfSubscriptyq_3key_tF'
 

--- a/test/SILGen/optional.swift
+++ b/test/SILGen/optional.swift
@@ -45,20 +45,22 @@ func testAddrOnlyCallResult<T>(_ f: (() -> T)?) {
 // CHECK-NEXT: [[X:%.*]] = alloc_box $<τ_0_0> { var Optional<τ_0_0> } <T>, var, name "x"
 // CHECK-NEXT: [[PBX:%.*]] = project_box [[X]]
 // CHECK-NEXT: [[TEMP:%.*]] = init_enum_data_addr [[PBX]]
+// CHECK-NEXT: [[READ:%.*]] = begin_access [read] [unknown] [[PBF]]
 //   Check whether 'f' holds a value.
-// CHECK:      [[T1:%.*]] = select_enum_addr [[PBF]]
-// CHECK-NEXT: cond_br [[T1]], bb1, bb3
+// CHECK:      [[T1:%.*]] = select_enum_addr [[READ]]
+// CHECK-NEXT: cond_br [[T1]], bb2, bb1
 //   If so, pull out the value...
-// CHECK:    bb1:
-// CHECK-NEXT: [[T1:%.*]] = unchecked_take_enum_data_addr [[PBF]]
+// CHECK:    bb2:
+// CHECK-NEXT: [[T1:%.*]] = unchecked_take_enum_data_addr [[READ]]
 // CHECK-NEXT: [[T0:%.*]] = load [copy] [[T1]]
+// CHECK-NEXT: end_access [[READ]]
 //   ...evaluate the rest of the suffix...
 // CHECK-NEXT: apply [[T0]]([[TEMP]])
 //   ...and coerce to T?
 // CHECK-NEXT: inject_enum_addr [[PBX]] {{.*}}some
-// CHECK-NEXT: br bb2
+// CHECK-NEXT: br bb3
 //   Continuation block.
-// CHECK:    bb2
+// CHECK:    bb3
 // CHECK-NEXT: destroy_value [[X]]
 // CHECK-NEXT: destroy_value [[F]]
 // CHECK-NEXT: destroy_value %0
@@ -66,9 +68,9 @@ func testAddrOnlyCallResult<T>(_ f: (() -> T)?) {
 // CHECK-NEXT: return [[T0]] : $()
 
 //   Nothing block.
-// CHECK:    bb3:
+// CHECK:    bb4:
 // CHECK-NEXT: inject_enum_addr [[PBX]] {{.*}}none
-// CHECK-NEXT: br bb2
+// CHECK-NEXT: br bb3
 
 
 // <rdar://problem/15180622>

--- a/test/SILGen/optional_lvalue.swift
+++ b/test/SILGen/optional_lvalue.swift
@@ -1,18 +1,20 @@
 // RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s
 
 // CHECK-LABEL: sil hidden @_T015optional_lvalue07assign_a1_B0ySiSgz_SitF
+// CHECK:         [[WRITE:%.*]] = begin_access [modify] [unknown] %0 : $*Optional<Int>
 // CHECK:         [[PRECOND:%.*]] = function_ref @_T0s30_diagnoseUnexpectedNilOptional{{[_0-9a-zA-Z]*}}F
 // CHECK:         apply [[PRECOND]](
-// CHECK:         [[PAYLOAD:%.*]] = unchecked_take_enum_data_addr %0 : $*Optional<Int>, #Optional.some!enumelt.1
+// CHECK:         [[PAYLOAD:%.*]] = unchecked_take_enum_data_addr [[WRITE]] : $*Optional<Int>, #Optional.some!enumelt.1
 // CHECK:         assign {{%.*}} to [[PAYLOAD]]
 func assign_optional_lvalue(_ x: inout Int?, _ y: Int) {
   x! = y
 }
 
 // CHECK-LABEL: sil hidden @_T015optional_lvalue011assign_iuo_B0ySQySiGz_SitF
+// CHECK:         [[WRITE:%.*]] = begin_access [modify] [unknown] %0 : $*Optional<Int>
 // CHECK:         [[PRECOND:%.*]] = function_ref @_T0s30_diagnoseUnexpectedNilOptional{{[_0-9a-zA-Z]*}}F
 // CHECK:         apply [[PRECOND]](
-// CHECK:         [[PAYLOAD:%.*]] = unchecked_take_enum_data_addr %0 : $*Optional<Int>, #Optional.some!enumelt.1
+// CHECK:         [[PAYLOAD:%.*]] = unchecked_take_enum_data_addr [[WRITE]] : $*Optional<Int>, #Optional.some!enumelt.1
 // CHECK:         assign {{%.*}} to [[PAYLOAD]]
 func assign_iuo_lvalue(_ x: inout Int!, _ y: Int) {
   x! = y
@@ -28,7 +30,8 @@ struct S {
 }
 
 // CHECK-LABEL: sil hidden @_T015optional_lvalue011assign_iuo_B9_implicitySQyAA1SVGz_SitF
-// CHECK:         [[SOME:%.*]] = unchecked_take_enum_data_addr %0
+// CHECK:         [[WRITE:%.*]] = begin_access [modify] [unknown] %0 : $*Optional<S>
+// CHECK:         [[SOME:%.*]] = unchecked_take_enum_data_addr [[WRITE]]
 // CHECK:         [[X:%.*]] = struct_element_addr [[SOME]]
 func assign_iuo_lvalue_implicit(_ s: inout S!, _ y: Int) {
   s.x = y

--- a/test/SILGen/pointer_conversion.swift
+++ b/test/SILGen/pointer_conversion.swift
@@ -138,7 +138,8 @@ func inoutToPointer() {
   // CHECK: [[PB:%.*]] = project_box [[INT]]
   takesMutablePointer(&int)
   // CHECK: [[TAKES_MUTABLE:%.*]] = function_ref @_T018pointer_conversion19takesMutablePointer{{[_0-9a-zA-Z]*}}F
-  // CHECK: [[POINTER:%.*]] = address_to_pointer [[PB]]
+  // CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] [[PB]]
+  // CHECK: [[POINTER:%.*]] = address_to_pointer [[WRITE]]
   // CHECK: [[CONVERT:%.*]] = function_ref @_T0s30_convertInOutToPointerArgument{{[_0-9a-zA-Z]*}}F
   // CHECK: apply [[CONVERT]]<UnsafeMutablePointer<Int>>({{%.*}}, [[POINTER]])
   // CHECK: apply [[TAKES_MUTABLE]]
@@ -159,7 +160,8 @@ func inoutToPointer() {
 
   takesMutableRawPointer(&int)
   // CHECK: [[TAKES_MUTABLE:%.*]] = function_ref @_T018pointer_conversion22takesMutableRawPointer{{[_0-9a-zA-Z]*}}F
-  // CHECK: [[POINTER:%.*]] = address_to_pointer [[PB]]
+  // CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] [[PB]]
+  // CHECK: [[POINTER:%.*]] = address_to_pointer [[WRITE]]
   // CHECK: [[CONVERT:%.*]] = function_ref @_T0s30_convertInOutToPointerArgument{{[_0-9a-zA-Z]*}}F
   // CHECK: apply [[CONVERT]]<UnsafeMutableRawPointer>({{%.*}}, [[POINTER]])
   // CHECK: apply [[TAKES_MUTABLE]]
@@ -188,7 +190,8 @@ func classInoutToPointer() {
   // CHECK: [[PB:%.*]] = project_box [[VAR]]
   takesPlusOnePointer(&c)
   // CHECK: [[TAKES_PLUS_ONE:%.*]] = function_ref @_T018pointer_conversion19takesPlusOnePointer{{[_0-9a-zA-Z]*}}F
-  // CHECK: [[POINTER:%.*]] = address_to_pointer [[PB]]
+  // CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] [[PB]]
+  // CHECK: [[POINTER:%.*]] = address_to_pointer [[WRITE]]
   // CHECK: [[CONVERT:%.*]] = function_ref @_T0s30_convertInOutToPointerArgument{{[_0-9a-zA-Z]*}}F
   // CHECK: apply [[CONVERT]]<UnsafeMutablePointer<C>>({{%.*}}, [[POINTER]])
   // CHECK: apply [[TAKES_PLUS_ONE]]

--- a/test/SILGen/properties.swift
+++ b/test/SILGen/properties.swift
@@ -14,7 +14,8 @@ func physical_tuple_lvalue(_ c: Int) {
   // CHECK: [[MARKED_BOX:%[0-9]+]] = mark_uninitialized [var] [[BOX]]
   // CHECK: [[XADDR:%.*]] = project_box [[MARKED_BOX]]
   x.1 = c
-  // CHECK: [[X_1:%[0-9]+]] = tuple_element_addr [[XADDR]] : {{.*}}, 1
+  // CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] [[XADDR]]
+  // CHECK: [[X_1:%[0-9]+]] = tuple_element_addr [[WRITE]] : {{.*}}, 1
   // CHECK: assign %0 to [[X_1]]
 }
 
@@ -32,10 +33,14 @@ func physical_tuple_rvalue() -> Int {
 // CHECK-LABEL: sil hidden @_T010properties16tuple_assignment{{[_0-9a-zA-Z]*}}F
 func tuple_assignment(_ a: inout Int, b: inout Int) {
   // CHECK: bb0([[A_ADDR:%[0-9]+]] : $*Int, [[B_ADDR:%[0-9]+]] : $*Int):
-  // CHECK: [[B:%[0-9]+]] = load [trivial] [[B_ADDR]]
-  // CHECK: [[A:%[0-9]+]] = load [trivial] [[A_ADDR]]
-  // CHECK: assign [[B]] to [[A_ADDR]]
-  // CHECK: assign [[A]] to [[B_ADDR]]
+  // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[B_ADDR]]
+  // CHECK: [[B:%[0-9]+]] = load [trivial] [[READ]]
+  // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[A_ADDR]]
+  // CHECK: [[A:%[0-9]+]] = load [trivial] [[READ]]
+  // CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] [[A_ADDR]]
+  // CHECK: assign [[B]] to [[WRITE]]
+  // CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] [[B_ADDR]]
+  // CHECK: assign [[A]] to [[WRITE]]
   (a, b) = (b, a)
 }
 
@@ -46,8 +51,10 @@ func tuple_assignment_2(_ a: inout Int, b: inout Int, xy: (Int, Int)) {
   // CHECK: [[XY2:%[0-9]+]] = tuple ([[X]] : $Int, [[Y]] : $Int)
   // CHECK: [[X:%[0-9]+]] = tuple_extract [[XY2]] : {{.*}}, 0
   // CHECK: [[Y:%[0-9]+]] = tuple_extract [[XY2]] : {{.*}}, 1
-  // CHECK: assign [[X]] to [[A_ADDR]]
-  // CHECK: assign [[Y]] to [[B_ADDR]]
+  // CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] [[A_ADDR]]
+  // CHECK: assign [[X]] to [[WRITE]]
+  // CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] [[B_ADDR]]
+  // CHECK: assign [[Y]] to [[WRITE]]
 }
 
 class Ref {
@@ -92,7 +99,9 @@ func physical_struct_lvalue(_ c: Int) {
   var v : Val
   // CHECK: [[VADDR:%[0-9]+]] = alloc_box ${ var Val }
   v.y = c
-  // CHECK: assign %0 to [[X_1]]
+  // CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown]
+  // CHECK: [[YADDR:%.*]] = struct_element_addr [[WRITE]]
+  // CHECK: assign %0 to [[YADDR]]
 }
 
 // CHECK-LABEL: sil hidden @_T010properties21physical_class_lvalue{{[_0-9a-zA-Z]*}}F : $@convention(thin) (@owned Ref, Int) -> ()
@@ -170,8 +179,9 @@ func logical_struct_get() -> Int {
 func logical_struct_set(_ value: inout Val, z: Int) {
   // CHECK: bb0([[VAL:%[0-9]+]] : $*Val, [[Z:%[0-9]+]] : $Int):
   value.z = z
+  // CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] [[VAL]]
   // CHECK: [[Z_SET_METHOD:%[0-9]+]] = function_ref @_T010properties3ValV1z{{[_0-9a-zA-Z]*}}fs
-  // CHECK: apply [[Z_SET_METHOD]]([[Z]], [[VAL]])
+  // CHECK: apply [[Z_SET_METHOD]]([[Z]], [[WRITE]])
   // CHECK: return
 }
 
@@ -179,7 +189,8 @@ func logical_struct_set(_ value: inout Val, z: Int) {
 func logical_struct_in_tuple_set(_ value: inout (Int, Val), z: Int) {
   // CHECK: bb0([[VAL:%[0-9]+]] : $*(Int, Val), [[Z:%[0-9]+]] : $Int):
   value.1.z = z
-  // CHECK: [[VAL_1:%[0-9]+]] = tuple_element_addr [[VAL]] : {{.*}}, 1
+  // CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] [[VAL]]
+  // CHECK: [[VAL_1:%[0-9]+]] = tuple_element_addr [[WRITE]] : {{.*}}, 1
   // CHECK: [[Z_SET_METHOD:%[0-9]+]] = function_ref @_T010properties3ValV1z{{[_0-9a-zA-Z]*}}fs
   // CHECK: apply [[Z_SET_METHOD]]([[Z]], [[VAL_1]])
   // CHECK: return
@@ -190,7 +201,8 @@ func logical_struct_in_reftype_set(_ value: inout Val, z1: Int) {
   // CHECK: bb0([[VAL:%[0-9]+]] : $*Val, [[Z1:%[0-9]+]] : $Int):
   value.ref.val_prop.z_tuple.1 = z1
   // -- val.ref
-  // CHECK: [[VAL_REF_ADDR:%[0-9]+]] = struct_element_addr [[VAL]] : $*Val, #Val.ref
+  // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[VAL]]
+  // CHECK: [[VAL_REF_ADDR:%[0-9]+]] = struct_element_addr [[WRITE]] : $*Val, #Val.ref
   // CHECK: [[VAL_REF:%[0-9]+]] = load [copy] [[VAL_REF_ADDR]]
   // -- getters and setters
   // -- val.ref.val_prop
@@ -252,8 +264,9 @@ func reftype_rvalue_set(_ value: Val) {
 func tuple_in_logical_struct_set(_ value: inout Val, z1: Int) {
   // CHECK: bb0([[VAL:%[0-9]+]] : $*Val, [[Z1:%[0-9]+]] : $Int):
   value.z_tuple.1 = z1
+  // CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] [[VAL]]
   // CHECK: [[Z_TUPLE_MATERIALIZED:%[0-9]+]] = alloc_stack $(Int, Int)
-  // CHECK: [[VAL1:%[0-9]+]] = load_borrow [[VAL]]
+  // CHECK: [[VAL1:%[0-9]+]] = load_borrow [[WRITE]]
   // CHECK: [[Z_GET_METHOD:%[0-9]+]] = function_ref @_T010properties3ValV7z_tupleSi_Sitfg
   // CHECK: [[A0:%.*]] = tuple_element_addr [[Z_TUPLE_MATERIALIZED]] : {{.*}}, 0
   // CHECK: [[A1:%.*]] = tuple_element_addr [[Z_TUPLE_MATERIALIZED]] : {{.*}}, 1
@@ -262,12 +275,12 @@ func tuple_in_logical_struct_set(_ value: inout Val, z1: Int) {
   // CHECK: [[T1:%.*]] = tuple_extract [[Z_TUPLE]] : {{.*}}, 1
   // CHECK: store [[T0]] to [trivial] [[A0]]
   // CHECK: store [[T1]] to [trivial] [[A1]]
-  // CHECK: end_borrow [[VAL1]] from [[VAL]]
+  // CHECK: end_borrow [[VAL1]] from [[WRITE]]
   // CHECK: [[Z_TUPLE_1:%[0-9]+]] = tuple_element_addr [[Z_TUPLE_MATERIALIZED]] : {{.*}}, 1
   // CHECK: assign [[Z1]] to [[Z_TUPLE_1]]
   // CHECK: [[Z_TUPLE_MODIFIED:%[0-9]+]] = load [trivial] [[Z_TUPLE_MATERIALIZED]]
   // CHECK: [[Z_SET_METHOD:%[0-9]+]] = function_ref @_T010properties3ValV7z_tupleSi_Sitfs
-  // CHECK: apply [[Z_SET_METHOD]]({{%[0-9]+, %[0-9]+}}, [[VAL]])
+  // CHECK: apply [[Z_SET_METHOD]]({{%[0-9]+, %[0-9]+}}, [[WRITE]])
   // CHECK: dealloc_stack [[Z_TUPLE_MATERIALIZED]]
   // CHECK: return
 }
@@ -339,7 +352,8 @@ func physical_inout(_ x: Int) {
   // CHECK: [[PB:%.*]] = project_box [[XADDR]]
   inout_arg(&x)
   // CHECK: [[INOUT_ARG:%[0-9]+]] = function_ref @_T010properties9inout_arg{{[_0-9a-zA-Z]*}}F
-  // CHECK: apply [[INOUT_ARG]]([[PB]])
+  // CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] [[PB]]
+  // CHECK: apply [[INOUT_ARG]]([[WRITE]])
 }
 
 
@@ -365,8 +379,9 @@ func val_subscript_set(_ v: Val, i: Int, x: Float) {
   v[i] = x
   // CHECK: [[VADDR:%[0-9]+]] = alloc_box ${ var Val }
   // CHECK: [[PB:%.*]] = project_box [[VADDR]]
+  // CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] [[PB]]
   // CHECK: [[SUBSCRIPT_SET_METHOD:%[0-9]+]] = function_ref @_T010properties3ValV9subscript{{[_0-9a-zA-Z]*}}fs
-  // CHECK: apply [[SUBSCRIPT_SET_METHOD]]([[X]], [[I]], [[PB]])
+  // CHECK: apply [[SUBSCRIPT_SET_METHOD]]([[X]], [[I]], [[WRITE]])
 }
 
 struct Generic<T> {
@@ -482,8 +497,10 @@ struct DidSetWillSetTests: ForceAccessors {
 
       // CHECK-NEXT: // function_ref properties.takeInt
       // CHECK-NEXT: [[TAKEINTFN:%.*]] = function_ref @_T010properties7takeInt{{[_0-9a-zA-Z]*}}F
-      // CHECK-NEXT: [[FIELDPTR:%.*]] = struct_element_addr %1 : $*DidSetWillSetTests, #DidSetWillSetTests.a
+      // CHECK: [[READ:%.*]] = begin_access [read] [unknown] %1
+      // CHECK-NEXT: [[FIELDPTR:%.*]] = struct_element_addr [[READ]] : $*DidSetWillSetTests, #DidSetWillSetTests.a
       // CHECK-NEXT: [[A:%.*]] = load [trivial] [[FIELDPTR]] : $*Int
+      // CHECK-NEXT: end_access [[READ]]
       // CHECK-NEXT: apply [[TAKEINTFN]]([[A]]) : $@convention(thin) (Int) -> ()
 
       takeInt(newA)
@@ -504,8 +521,10 @@ struct DidSetWillSetTests: ForceAccessors {
 
       // CHECK-NEXT: // function_ref properties.takeInt(Swift.Int) -> ()
       // CHECK-NEXT: [[TAKEINTFN:%.*]] = function_ref @_T010properties7takeInt{{[_0-9a-zA-Z]*}}F
-      // CHECK-NEXT: [[AADDR:%.*]] = struct_element_addr %1 : $*DidSetWillSetTests, #DidSetWillSetTests.a
+      // CHECK: [[READ:%.*]] = begin_access [read] [unknown] %1
+      // CHECK-NEXT: [[AADDR:%.*]] = struct_element_addr [[READ]] : $*DidSetWillSetTests, #DidSetWillSetTests.a
       // CHECK-NEXT: [[A:%.*]] = load [trivial] [[AADDR]] : $*Int
+      // CHECK-NEXT: end_access [[READ]]
       // CHECK-NEXT: apply [[TAKEINTFN]]([[A]]) : $@convention(thin) (Int) -> ()
 
       a = zero  // reassign, but don't infinite loop.
@@ -514,8 +533,10 @@ struct DidSetWillSetTests: ForceAccessors {
       // CHECK-NEXT: [[ZEROFN:%.*]] = function_ref @_T010properties4zero{{[_0-9a-zA-Z]*}}fau
       // CHECK-NEXT: [[ZERORAW:%.*]] = apply [[ZEROFN]]() : $@convention(thin) () -> Builtin.RawPointer
       // CHECK-NEXT: [[ZEROADDR:%.*]] = pointer_to_address [[ZERORAW]] : $Builtin.RawPointer to [strict] $*Int
-      // CHECK-NEXT: [[AADDR:%.*]] = struct_element_addr %1 : $*DidSetWillSetTests, #DidSetWillSetTests.a
-      // CHECK-NEXT: copy_addr [[ZEROADDR]] to [[AADDR]] : $*Int
+      // CHECK-NEXT: [[ZERO:%.*]] = load [trivial] [[ZEROADDR]]
+      // CHECK-NEXT: [[WRITE:%.*]] = begin_access [modify] [unknown] %1
+      // CHECK-NEXT: [[AADDR:%.*]] = struct_element_addr [[WRITE]] : $*DidSetWillSetTests, #DidSetWillSetTests.a
+      // CHECK-NEXT: assign [[ZERO]] to [[AADDR]]
     }
   }
 
@@ -540,26 +561,35 @@ struct DidSetWillSetTests: ForceAccessors {
   // CHECK-NEXT: debug_value %0
   // CHECK-NEXT: debug_value_addr %1
 
-  // CHECK-NEXT: [[AADDR:%.*]] = struct_element_addr %1 : $*DidSetWillSetTests, #DidSetWillSetTests.a
+  // CHECK-NEXT: [[READ:%.*]] = begin_access [read] [unknown] %1
+  // CHECK-NEXT: [[AADDR:%.*]] = struct_element_addr [[READ]] : $*DidSetWillSetTests, #DidSetWillSetTests.a
   // CHECK-NEXT: [[OLDVAL:%.*]] = load [trivial] [[AADDR]] : $*Int
+  // CHECK-NEXT: end_access [[READ]]
   // CHECK-NEXT: debug_value [[OLDVAL]] : $Int, let, name "tmp"
 
   // CHECK-NEXT: // function_ref {{.*}}.DidSetWillSetTests.a.willset : Swift.Int
   // CHECK-NEXT: [[WILLSETFN:%.*]] = function_ref @_T010properties010DidSetWillC5TestsV1a{{[_0-9a-zA-Z]*}}fw
-  // CHECK-NEXT:  apply [[WILLSETFN]](%0, %1) : $@convention(method) (Int, @inout DidSetWillSetTests) -> ()
-  // CHECK-NEXT: [[AADDR:%.*]] = struct_element_addr %1 : $*DidSetWillSetTests, #DidSetWillSetTests.a
+  // CHECK-NEXT: [[WRITE:%.*]] = begin_access [modify] [unknown] %1
+  // CHECK-NEXT:  apply [[WILLSETFN]](%0, [[WRITE]]) : $@convention(method) (Int, @inout DidSetWillSetTests) -> ()
+  // CHECK-NEXT: end_access [[WRITE]]
+  // CHECK-NEXT: [[WRITE:%.*]] = begin_access [modify] [unknown] %1
+  // CHECK-NEXT: [[AADDR:%.*]] = struct_element_addr [[WRITE]] : $*DidSetWillSetTests, #DidSetWillSetTests.a
   // CHECK-NEXT: assign %0 to [[AADDR]] : $*Int
+  // CHECK-NEXT: end_access [[WRITE]]
   // CHECK-NEXT: // function_ref {{.*}}.DidSetWillSetTests.a.didset : Swift.Int
   // CHECK-NEXT: [[DIDSETFN:%.*]] = function_ref @_T010properties010DidSetWillC5TestsV1a{{[_0-9a-zA-Z]*}}fW : $@convention(method) (Int, @inout DidSetWillSetTests) -> ()
-  // CHECK-NEXT: apply [[DIDSETFN]]([[OLDVAL]], %1) : $@convention(method) (Int, @inout DidSetWillSetTests) -> ()
+  // CHECK-NEXT: [[WRITE:%.*]] = begin_access [modify] [unknown] %1
+  // CHECK-NEXT: apply [[DIDSETFN]]([[OLDVAL]], [[WRITE]]) : $@convention(method) (Int, @inout DidSetWillSetTests) -> ()
 
   // CHECK-LABEL: sil hidden @_T010properties010DidSetWillC5TestsV{{[_0-9a-zA-Z]*}}fC
   // CHECK: bb0(%0 : $Int, %1 : $@thin DidSetWillSetTests.Type):
   // CHECK:        [[SELF:%.*]] = mark_uninitialized [rootself]
   // CHECK:        [[PB_SELF:%.*]] = project_box [[SELF]]
-  // CHECK:        [[P1:%.*]] = struct_element_addr [[PB_SELF]] : $*DidSetWillSetTests, #DidSetWillSetTests.a
+  // CHECK:        [[WRITE:%.*]] = begin_access [modify] [unknown] [[PB_SELF]]
+  // CHECK:        [[P1:%.*]] = struct_element_addr [[WRITE]] : $*DidSetWillSetTests, #DidSetWillSetTests.a
   // CHECK-NEXT:   assign %0 to [[P1]]
-  // CHECK:        [[P2:%.*]] = struct_element_addr [[PB_SELF]] : $*DidSetWillSetTests, #DidSetWillSetTests.a
+  // CHECK:        [[WRITE:%.*]] = begin_access [modify] [unknown] [[PB_SELF]]
+  // CHECK:        [[P2:%.*]] = struct_element_addr [[WRITE]] : $*DidSetWillSetTests, #DidSetWillSetTests.a
   // CHECK-NEXT:   assign %0 to [[P2]]
 }
 
@@ -687,18 +717,22 @@ func propertyWithDidSetTakingOldValue() {
 // CHECK-NEXT:  debug_value [[ARG1]] : $Int, let, name "newValue", argno 1
 // CHECK-NEXT:  [[ARG2_PB:%.*]] = project_box [[ARG2]]
 // CHECK-NEXT:  debug_value_addr [[ARG2_PB]] : $*Int, var, name "p", argno 2
-// CHECK-NEXT:  [[ARG2_PB_VAL:%.*]] = load [trivial] [[ARG2_PB]] : $*Int
+// CHECK-NEXT:  [[READ:%.*]] = begin_access [read] [unknown] [[ARG2_PB]]
+// CHECK-NEXT:  [[ARG2_PB_VAL:%.*]] = load [trivial] [[READ]] : $*Int
+// CHECK-NEXT:  end_access [[READ]]
 // CHECK-NEXT:  debug_value [[ARG2_PB_VAL]] : $Int
-// CHECK-NEXT:  assign [[ARG1]] to [[ARG2_PB]] : $*Int
+// CHECK-NEXT:  [[WRITE:%.*]] = begin_access [modify] [unknown] [[ARG2_PB]]
+// CHECK-NEXT:  assign [[ARG1]] to [[WRITE]] : $*Int
+// CHECK-NEXT:  end_access [[WRITE]]
 // CHECK-NEXT:  [[ARG2_COPY:%.*]] = copy_value [[ARG2]] : ${ var Int }
 // SEMANTIC ARC TODO: Another case where we need to put the mark_function_escape on a new projection after a copy.
 // CHECK-NEXT:  mark_function_escape [[ARG2_PB]]
 // CHECK-NEXT:  // function_ref
 // CHECK-NEXT:  [[FUNC:%.*]] = function_ref @_T010properties32propertyWithDidSetTakingOldValueyyF1pL_SifW : $@convention(thin) (Int, @owned { var Int }) -> ()
-// CHECK-NEXT:  %11 = apply [[FUNC]]([[ARG2_PB_VAL]], [[ARG2_COPY]]) : $@convention(thin) (Int, @owned { var Int }) -> ()
+// CHECK-NEXT:  %{{.*}} = apply [[FUNC]]([[ARG2_PB_VAL]], [[ARG2_COPY]]) : $@convention(thin) (Int, @owned { var Int }) -> ()
 // CHECK-NEXT:  destroy_value [[ARG2]] : ${ var Int }
-// CHECK-NEXT:  %13 = tuple ()
-// CHECK-NEXT:  return %13 : $()
+// CHECK-NEXT:  %{{.*}} = tuple ()
+// CHECK-NEXT:  return %{{.*}} : $()
 // CHECK-NEXT:} // end sil function '_T010properties32propertyWithDidSetTakingOldValue{{[_0-9a-zA-Z]*}}'
 
 
@@ -1036,7 +1070,8 @@ struct MutatingGetterStruct {
   // CHECK: [[X:%.*]] = alloc_box ${ var MutatingGetterStruct }, var, name "x"
   // CHECK-NEXT: [[PB:%.*]] = project_box [[X]]
   // CHECK: store {{.*}} to [trivial] [[PB]] : $*MutatingGetterStruct
-  // CHECK: apply {{%.*}}([[PB]]) : $@convention(method) (@inout MutatingGetterStruct) -> Int
+  // CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] [[PB]]
+  // CHECK: apply {{%.*}}([[WRITE]]) : $@convention(method) (@inout MutatingGetterStruct) -> Int
   static func test() {
     var x = MutatingGetterStruct()
     _ = x.write

--- a/test/SILGen/property_abstraction.swift
+++ b/test/SILGen/property_abstraction.swift
@@ -45,7 +45,8 @@ func inOutFunc(_ f: inout ((Int) -> Int)) { }
 // CHECK:   store [[ARG_COPY]] to [init] [[XBOX_PB]]
 // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
 // CHECK:   [[INOUTFUNC:%.*]] = function_ref @_T020property_abstraction9inOutFunc{{[_0-9a-zA-Z]*}}F
-// CHECK:   [[F_ADDR:%.*]] = struct_element_addr [[XBOX_PB]] : $*Foo<Int, Int>, #Foo.f
+// CHECK:   [[WRITE:%.*]] = begin_access [modify] [unknown] [[XBOX_PB]] : $*Foo<Int, Int>
+// CHECK:   [[F_ADDR:%.*]] = struct_element_addr [[WRITE]] : $*Foo<Int, Int>, #Foo.f
 // CHECK:   [[F_SUBST_MAT:%.*]] = alloc_stack
 // CHECK:   [[F_ORIG:%.*]] = load [copy] [[F_ADDR]]
 // CHECK:   [[REABSTRACT_FN:%.*]] = function_ref @_T0{{.*}}TR :
@@ -141,7 +142,8 @@ func setBuilder<F: Factory where F.Product == MyClass>(_ factory: inout F) {
 // CHECK: bb0(%0 : $*F):
 // CHECK:   [[F0:%.*]] = function_ref @_T020property_abstraction10setBuilder{{[_0-9a-zA-Z]*}} : $@convention(thin) () -> @owned MyClass
 // CHECK:   [[F1:%.*]] = thin_to_thick_function [[F0]]
+// CHECK:   [[WRITE:%.*]] = begin_access [modify] [unknown] %0 : $*F
 // CHECK:   [[SETTER:%.*]] = witness_method $F, #Factory.builder!setter.1
 // CHECK:   [[REABSTRACTOR:%.*]] = function_ref @_T0{{.*}}TR :
 // CHECK:   [[F2:%.*]] = partial_apply [[REABSTRACTOR]]([[F1]])
-// CHECK:   apply [[SETTER]]<F>([[F2]], %0)
+// CHECK:   apply [[SETTER]]<F>([[F2]], [[WRITE]])

--- a/test/SILGen/property_behavior_init.swift
+++ b/test/SILGen/property_behavior_init.swift
@@ -41,21 +41,23 @@ struct Foo {
 
     // Reads or inouts use the accessors normally.
 
-    // CHECK: [[SELF:%.*]] = load [trivial] [[PB_BOX]]
+    // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[PB_BOX]]
+    // CHECK: [[SELF:%.*]] = load [trivial] [[READ]]
     // CHECK: [[GETTER:%.*]] = function_ref @_T022property_behavior_init3FooV1xSifg
     // CHECK: apply [[GETTER]]([[SELF]])
     _ = self.x
 
     // CHECK: [[WHACK:%.*]] = function_ref @_T022property_behavior_init5whackyxzlF
+    // CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] [[PB_BOX]]
     // CHECK: [[INOUT:%.*]] = alloc_stack
-    // CHECK: [[SELF:%.*]] = load [trivial] [[PB_BOX]]
+    // CHECK: [[SELF:%.*]] = load [trivial] [[WRITE]]
     // CHECK: [[GETTER:%.*]] = function_ref @_T022property_behavior_init3FooV1xSifg
     // CHECK: [[VALUE:%.*]] = apply [[GETTER]]([[SELF]])
     // CHECK: store [[VALUE]] to [trivial] [[INOUT]]
     // CHECK: apply [[WHACK]]<Int>([[INOUT]])
     // CHECK: [[VALUE:%.*]] = load [trivial] [[INOUT]]
     // CHECK: [[SETTER:%.*]] = function_ref @_T022property_behavior_init3FooV1xSifs
-    // CHECK: apply [[SETTER]]([[VALUE]], [[PB_BOX]])
+    // CHECK: apply [[SETTER]]([[VALUE]], [[WRITE]])
     whack(&self.x)
   }
 }

--- a/test/SILGen/protocol_class_refinement.swift
+++ b/test/SILGen/protocol_class_refinement.swift
@@ -31,7 +31,8 @@ func getObjectUID<T: ObjectUID>(x: T) -> (Int, Int, Int, Int) {
   // CHECK: [[XBOX:%.*]] = alloc_box $<τ_0_0 where τ_0_0 : ObjectUID> { var τ_0_0 } <T>
   // CHECK: [[PB:%.*]] = project_box [[XBOX]]
   // -- call x.uid()
-  // CHECK: [[X:%.*]] = load [copy] [[PB]]
+  // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[PB]] : $*T
+  // CHECK: [[X:%.*]] = load [copy] [[READ]]
   // CHECK: [[X_TMP:%.*]] = alloc_stack
   // CHECK: store [[X]] to [init] [[X_TMP]]
   // CHECK: [[GET_UID:%.*]] = witness_method $T, #UID.uid!1
@@ -39,12 +40,14 @@ func getObjectUID<T: ObjectUID>(x: T) -> (Int, Int, Int, Int) {
   // CHECK: [[X2:%.*]] = load [take] [[X_TMP]]
   // CHECK: destroy_value [[X2]]
   // -- call set x.clsid
+  // CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] [[PB]] : $*T
   // CHECK: [[SET_CLSID:%.*]] = witness_method $T, #UID.clsid!setter.1
-  // CHECK: apply [[SET_CLSID]]<T>([[UID]], [[PB]])
+  // CHECK: apply [[SET_CLSID]]<T>([[UID]], [[WRITE]])
   x.clsid = x.uid()
 
   // -- call x.uid()
-  // CHECK: [[X:%.*]] = load [copy] [[PB]]
+  // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[PB]] : $*T
+  // CHECK: [[X:%.*]] = load [copy] [[READ]]
   // CHECK: [[X_TMP:%.*]] = alloc_stack
   // CHECK: store [[X]] to [init] [[X_TMP]]
   // CHECK: [[GET_UID:%.*]] = witness_method $T, #UID.uid!1
@@ -52,8 +55,9 @@ func getObjectUID<T: ObjectUID>(x: T) -> (Int, Int, Int, Int) {
   // CHECK: [[X2:%.*]] = load [take] [[X_TMP]]
   // CHECK: destroy_value [[X2]]
   // -- call nextCLSID from protocol ext
+  // CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] [[PB]] : $*T
   // CHECK: [[SET_NEXTCLSID:%.*]] = function_ref @_T025protocol_class_refinement3UIDPAAE9nextCLSIDSifs
-  // CHECK: apply [[SET_NEXTCLSID]]<T>([[UID]], [[PB]])
+  // CHECK: apply [[SET_NEXTCLSID]]<T>([[UID]], [[WRITE]])
   x.nextCLSID = x.uid()
 
   // -- call x.uid()
@@ -79,7 +83,8 @@ func getBaseObjectUID<T: UID where T: Base>(x: T) -> (Int, Int, Int) {
   // CHECK: [[XBOX:%.*]] = alloc_box $<τ_0_0 where τ_0_0 : Base, τ_0_0 : UID> { var τ_0_0 } <T>
   // CHECK: [[PB:%.*]] = project_box [[XBOX]]
   // -- call x.uid()
-  // CHECK: [[X:%.*]] = load [copy] [[PB]]
+  // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[PB]] : $*T
+  // CHECK: [[X:%.*]] = load [copy] [[READ]]
   // CHECK: [[X_TMP:%.*]] = alloc_stack
   // CHECK: store [[X]] to [init] [[X_TMP]]
   // CHECK: [[GET_UID:%.*]] = witness_method $T, #UID.uid!1
@@ -87,12 +92,14 @@ func getBaseObjectUID<T: UID where T: Base>(x: T) -> (Int, Int, Int) {
   // CHECK: [[X2:%.*]] = load [take] [[X_TMP]]
   // CHECK: destroy_value [[X2]]
   // -- call set x.clsid
+  // CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] [[PB]] : $*T
   // CHECK: [[SET_CLSID:%.*]] = witness_method $T, #UID.clsid!setter.1
-  // CHECK: apply [[SET_CLSID]]<T>([[UID]], [[PB]])
+  // CHECK: apply [[SET_CLSID]]<T>([[UID]], [[WRITE]])
   x.clsid = x.uid()
 
   // -- call x.uid()
-  // CHECK: [[X:%.*]] = load [copy] [[PB]]
+  // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[PB]] : $*T
+  // CHECK: [[X:%.*]] = load [copy] [[READ]]
   // CHECK: [[X_TMP:%.*]] = alloc_stack
   // CHECK: store [[X]] to [init] [[X_TMP]]
   // CHECK: [[GET_UID:%.*]] = witness_method $T, #UID.uid!1
@@ -100,8 +107,9 @@ func getBaseObjectUID<T: UID where T: Base>(x: T) -> (Int, Int, Int) {
   // CHECK: [[X2:%.*]] = load [take] [[X_TMP]]
   // CHECK: destroy_value [[X2]]
   // -- call nextCLSID from protocol ext
+  // CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] [[PB]] : $*T
   // CHECK: [[SET_NEXTCLSID:%.*]] = function_ref @_T025protocol_class_refinement3UIDPAAE9nextCLSIDSifs
-  // CHECK: apply [[SET_NEXTCLSID]]<T>([[UID]], [[PB]])
+  // CHECK: apply [[SET_NEXTCLSID]]<T>([[UID]], [[WRITE]])
   x.nextCLSID = x.uid()
   return (x.iid, x.clsid, x.nextCLSID)
 }

--- a/test/SILGen/protocol_optional.swift
+++ b/test/SILGen/protocol_optional.swift
@@ -20,7 +20,8 @@ func optionalMethodGeneric<T : P1>(t t : T) {
   // CHECK:   end_borrow [[T_BORROW]] from [[T]]
   // CHECK:   [[OPT_BOX:%[0-9]+]] = alloc_box ${ var Optional<@callee_owned (Int) -> ()> }
   // CHECK:   project_box [[OPT_BOX]]
-  // CHECK:   [[T:%[0-9]+]] = load [copy] [[PT]] : $*T
+  // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PT]] : $*T
+  // CHECK:   [[T:%[0-9]+]] = load [copy] [[READ]] : $*T
   // CHECK:   alloc_stack $Optional<@callee_owned (Int) -> ()>
   // CHECK:   dynamic_method_br [[T]] : $T, #P1.method!1.foreign
   var methodRef = t.method
@@ -39,7 +40,8 @@ func optionalPropertyGeneric<T : P1>(t t : T) {
   // CHECK:   end_borrow [[T_BORROW]] from [[T]]
   // CHECK:   [[OPT_BOX:%[0-9]+]] = alloc_box ${ var Optional<Int> }
   // CHECK:   project_box [[OPT_BOX]]
-  // CHECK:   [[T:%[0-9]+]] = load [copy] [[PT]] : $*T
+  // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PT]] : $*T
+  // CHECK:   [[T:%[0-9]+]] = load [copy] [[READ]] : $*T
   // CHECK:   alloc_stack $Optional<Int>
   // CHECK:   dynamic_method_br [[T]] : $T, #P1.prop!getter.1.foreign
   var propertyRef = t.prop
@@ -58,7 +60,8 @@ func optionalSubscriptGeneric<T : P1>(t t : T) {
   // CHECK:   end_borrow [[T_BORROW]] from [[T]]
   // CHECK:   [[OPT_BOX:%[0-9]+]] = alloc_box ${ var Optional<Int> }
   // CHECK:   project_box [[OPT_BOX]]
-  // CHECK:   [[T:%[0-9]+]] = load [copy] [[PT]] : $*T
+  // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PT]] : $*T
+  // CHECK:   [[T:%[0-9]+]] = load [copy] [[READ]] : $*T
   // CHECK:   [[INTCONV:%[0-9]+]] = function_ref @_T0S2i{{[_0-9a-zA-Z]*}}fC
   // CHECK:   [[INT64:%[0-9]+]] = metatype $@thin Int.Type
   // CHECK:   [[FIVELIT:%[0-9]+]] = integer_literal $Builtin.Int2048, 5

--- a/test/SILGen/reabstract_lvalue.swift
+++ b/test/SILGen/reabstract_lvalue.swift
@@ -18,8 +18,9 @@ func reabstractFunctionInOut() {
   // CHECK: [[THICK_ARG:%.*]] = thin_to_thick_function [[ARG]]
   // CHECK: store [[THICK_ARG:%.*]] to [init] [[PB]]
   // CHECK: [[FUNC:%.*]] = function_ref @_T017reabstract_lvalue19consumeGenericInOut{{[_0-9a-zA-Z]*}}F
+  // CHECK:  [[WRITE:%.*]] = begin_access [modify] [unknown] [[PB]] : $*@callee_owned (Int) -> Double
   // CHECK: [[ABSTRACTED_BOX:%.*]] = alloc_stack $@callee_owned (@in Int) -> @out Double
-  // CHECK: [[THICK_ARG:%.*]] = load [copy] [[PB]]
+  // CHECK: [[THICK_ARG:%.*]] = load [copy] [[WRITE]]
   // CHECK: [[THUNK1:%.*]] = function_ref @_T0SiSdIxyd_SiSdIxir_TR
   // CHECK: [[ABSTRACTED_ARG:%.*]] = partial_apply [[THUNK1]]([[THICK_ARG]])
   // CHECK: store [[ABSTRACTED_ARG]] to [init] [[ABSTRACTED_BOX]]

--- a/test/SILGen/statements.swift
+++ b/test/SILGen/statements.swift
@@ -166,6 +166,7 @@ func for_loops2() {
   // rdar://problem/19316670
   // CHECK: [[NEXT:%[0-9]+]] = function_ref @_T0s16IndexingIteratorV4next{{[_0-9a-zA-Z]*}}F
   // CHECK-NEXT: alloc_stack $Optional<MyClass>
+  // CHECK-NEXT: [[WRITE:%.*]] = begin_access [modify] [unknown]
   // CHECK-NEXT: apply [[NEXT]]<[MyClass]>
   // CHECK: class_method [[OBJ:%[0-9]+]] : $MyClass, #MyClass.foo!1
   let objects = [MyClass(), MyClass() ]

--- a/test/SILGen/struct_resilience.swift
+++ b/test/SILGen/struct_resilience.swift
@@ -19,8 +19,9 @@ func functionWithResilientTypes(_ s: Size, f: (Size) -> Size) -> Size {
 // CHECK:         copy_addr %1 to [initialization] [[SIZE_BOX:%.*]] : $*Size
 // CHECK:         [[FN:%.*]] = function_ref @_T016resilient_struct4SizeV1wSifg : $@convention(method) (@in_guaranteed Size) -> Int
 // CHECK:         [[RESULT:%.*]] = apply [[FN]]([[SIZE_BOX]])
+// CHECK:         [[WRITE:%.*]] = begin_access [modify] [unknown] [[OTHER_SIZE_BOX]] : $*Size
 // CHECK:         [[FN:%.*]] = function_ref @_T016resilient_struct4SizeV1wSifs : $@convention(method) (Int, @inout Size) -> ()
-// CHECK:         apply [[FN]]([[RESULT]], [[OTHER_SIZE_BOX]])
+// CHECK:         apply [[FN]]([[RESULT]], [[WRITE]])
   s2.w = s.w
 
 // CHECK:         copy_addr %1 to [initialization] [[SIZE_BOX:%.*]] : $*Size
@@ -139,7 +140,8 @@ public func functionWithMyResilientTypes(_ s: MySize, f: (MySize) -> MySize) -> 
 
 // CHECK:         [[SRC_ADDR:%.*]] = struct_element_addr %1 : $*MySize, #MySize.w
 // CHECK:         [[SRC:%.*]] = load [trivial] [[SRC_ADDR]] : $*Int
-// CHECK:         [[DEST_ADDR:%.*]] = struct_element_addr [[SIZE_BOX]] : $*MySize, #MySize.w
+// CHECK:         [[WRITE:%.*]] = begin_access [modify] [unknown] [[SIZE_BOX]] : $*MySize
+// CHECK:         [[DEST_ADDR:%.*]] = struct_element_addr [[WRITE]] : $*MySize, #MySize.w
 // CHECK:         assign [[SRC]] to [[DEST_ADDR]] : $*Int
   s2.w = s.w
 

--- a/test/SILGen/switch_var.swift
+++ b/test/SILGen/switch_var.swift
@@ -51,7 +51,8 @@ func test_var_1() {
   // CHECK-NOT: br bb
   case var x:
   // CHECK:   function_ref @_T010switch_var1aySi1x_tF
-  // CHECK:   load [trivial] [[X]]
+  // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[X]]
+  // CHECK:   load [trivial] [[READ]]
   // CHECK:   destroy_value [[XADDR]]
   // CHECK:   br [[CONT:bb[0-9]+]]
     a(x: x)
@@ -68,13 +69,15 @@ func test_var_2() {
   // CHECK:   [[XADDR:%.*]] = alloc_box ${ var Int }
   // CHECK:   [[X:%.*]] = project_box [[XADDR]]
   // CHECK:   function_ref @_T010switch_var6runcedSbSi1x_tF
-  // CHECK:   load [trivial] [[X]]
+  // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[X]]
+  // CHECK:   load [trivial] [[READ]]
   // CHECK:   cond_br {{%.*}}, [[CASE1:bb[0-9]+]], [[NO_CASE1:bb[0-9]+]]
   // -- TODO: Clean up these empty waypoint bbs.
   case var x where runced(x: x):
   // CHECK: [[CASE1]]:
   // CHECK:   function_ref @_T010switch_var1aySi1x_tF
-  // CHECK:   load [trivial] [[X]]
+  // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[X]]
+  // CHECK:   load [trivial] [[READ]]
   // CHECK:   destroy_value [[XADDR]]
   // CHECK:   br [[CONT:bb[0-9]+]]
     a(x: x)
@@ -82,12 +85,14 @@ func test_var_2() {
   // CHECK:   [[YADDR:%.*]] = alloc_box ${ var Int }
   // CHECK:   [[Y:%.*]] = project_box [[YADDR]]
   // CHECK:   function_ref @_T010switch_var6fungedSbSi1x_tF
-  // CHECK:   load [trivial] [[Y]]
+  // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[Y]]
+  // CHECK:   load [trivial] [[READ]]
   // CHECK:   cond_br {{%.*}}, [[CASE2:bb[0-9]+]], [[NO_CASE2:bb[0-9]+]]
   case var y where funged(x: y):
   // CHECK: [[CASE2]]:
   // CHECK:   function_ref @_T010switch_var1bySi1x_tF
-  // CHECK:   load [trivial] [[Y]]
+  // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[Y]]
+  // CHECK:   load [trivial] [[READ]]
   // CHECK:   destroy_value [[YADDR]]
   // CHECK:   br [[CONT]]
     b(x: y)
@@ -98,7 +103,8 @@ func test_var_2() {
   // CHECK:   [[ZADDR:%.*]] = alloc_box ${ var Int }
   // CHECK:   [[Z:%.*]] = project_box [[ZADDR]]
   // CHECK:   function_ref @_T010switch_var1cySi1x_tF
-  // CHECK:   load [trivial] [[Z]]
+  // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[Z]]
+  // CHECK:   load [trivial] [[READ]]
   // CHECK:   destroy_value [[ZADDR]]
   // CHECK:   br [[CONT]]
     c(x: z)
@@ -116,29 +122,37 @@ func test_var_3() {
   // CHECK:   [[XADDR:%.*]] = alloc_box ${ var (Int, Int) }
   // CHECK:   [[X:%.*]] = project_box [[XADDR]]
   // CHECK:   function_ref @_T010switch_var6runcedSbSi1x_tF
-  // CHECK:   tuple_element_addr [[X]] : {{.*}}, 0
+  // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[X]]
+  // CHECK:   tuple_element_addr [[READ]] : {{.*}}, 0
   // CHECK:   cond_br {{%.*}}, [[CASE1:bb[0-9]+]], [[NO_CASE1:bb[0-9]+]]
   case var x where runced(x: x.0):
   // CHECK: [[CASE1]]:
   // CHECK:   function_ref @_T010switch_var2aaySi_Sit1x_tF
-  // CHECK:   load [trivial] [[X]]
+  // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[X]]
+  // CHECK:   load [trivial] [[READ]]
   // CHECK:   destroy_value [[XADDR]]
   // CHECK:   br [[CONT:bb[0-9]+]]
     aa(x: x)
   // CHECK: [[NO_CASE1]]:
+  // CHECK:   br [[NO_CASE1_TARGET:bb[0-9]+]]
+
+  // CHECK: [[NO_CASE1_TARGET]]:
   // CHECK:   [[YADDR:%.*]] = alloc_box ${ var Int }
   // CHECK:   [[Y:%.*]] = project_box [[YADDR]]
-  // CHECK:   [[Z:%.*]] = alloc_box ${ var Int }
+  // CHECK:   [[ZADDR:%.*]] = alloc_box ${ var Int }
   // CHECK:   [[Z:%.*]] = project_box [[ZADDR]]
   // CHECK:   function_ref @_T010switch_var6fungedSbSi1x_tF
-  // CHECK:   load [trivial] [[Y]]
+  // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[Y]]
+  // CHECK:   load [trivial] [[READ]]
   // CHECK:   cond_br {{%.*}}, [[CASE2:bb[0-9]+]], [[NO_CASE2:bb[0-9]+]]
   case (var y, var z) where funged(x: y):
   // CHECK: [[CASE2]]:
   // CHECK:   function_ref @_T010switch_var1aySi1x_tF
-  // CHECK:   load [trivial] [[Y]]
+  // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[Y]]
+  // CHECK:   load [trivial] [[READ]]
   // CHECK:   function_ref @_T010switch_var1bySi1x_tF
-  // CHECK:   load [trivial] [[Z]]
+  // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[Z]]
+  // CHECK:   load [trivial] [[READ]]
   // CHECK:   destroy_value [[ZADDR]]
   // CHECK:   destroy_value [[YADDR]]
   // CHECK:   br [[CONT]]
@@ -148,12 +162,14 @@ func test_var_3() {
   // CHECK:   [[WADDR:%.*]] = alloc_box ${ var (Int, Int) }
   // CHECK:   [[W:%.*]] = project_box [[WADDR]]
   // CHECK:   function_ref @_T010switch_var5ansedSbSi1x_tF
-  // CHECK:   tuple_element_addr [[W]] : {{.*}}, 0
+  // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[W]]
+  // CHECK:   tuple_element_addr [[READ]] : {{.*}}, 0
   // CHECK:   cond_br {{%.*}}, [[CASE3:bb[0-9]+]], [[NO_CASE3:bb[0-9]+]]
   case var w where ansed(x: w.0):
   // CHECK: [[CASE3]]:
   // CHECK:   function_ref @_T010switch_var2bbySi_Sit1x_tF
-  // CHECK:   load [trivial] [[W]]
+  // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[W]]
+  // CHECK:   load [trivial] [[READ]]
   // CHECK:   br [[CONT]]
     bb(x: w)
   // CHECK: [[NO_CASE3]]:
@@ -164,7 +180,8 @@ func test_var_3() {
   // CHECK:   [[VADDR:%.*]] = alloc_box ${ var (Int, Int) } 
   // CHECK:   [[V:%.*]] = project_box [[VADDR]]
   // CHECK:   function_ref @_T010switch_var2ccySi_Sit1x_tF
-  // CHECK:   load [trivial] [[V]]
+  // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[V]]
+  // CHECK:   load [trivial] [[READ]]
   // CHECK:   destroy_value [[VADDR]]
   // CHECK:   br [[CONT]]
     cc(x: v)
@@ -198,7 +215,8 @@ func test_var_4(p p: P) {
   // CHECK:   [[X:%.*]] = project_box [[XADDR]]
   // CHECK:   store [[PAIR_1]] to [trivial] [[X]]
   // CHECK:   function_ref @_T010switch_var6runcedSbSi1x_tF
-  // CHECK:   load [trivial] [[X]]
+  // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[X]]
+  // CHECK:   load [trivial] [[READ]]
   // CHECK:   cond_br {{%.*}}, [[CASE1:bb[0-9]+]], [[NO_CASE1:bb[0-9]+]]
   case (is X, var x) where runced(x: x):
   // CHECK: [[CASE1]]:
@@ -228,13 +246,15 @@ func test_var_4(p p: P) {
   // CHECK:   [[Y:%.*]] = project_box [[YADDR]]
   // CHECK:   store [[PAIR_1]] to [trivial] [[Y]]
   // CHECK:   function_ref @_T010switch_var6fungedSbSi1x_tF
-  // CHECK:   load [trivial] [[Y]]
+  // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[Y]]
+  // CHECK:   load [trivial] [[READ]]
   // CHECK:   cond_br {{%.*}}, [[CASE2:bb[0-9]+]], [[NO_CASE2:bb[0-9]+]]
 
   case (is Y, var y) where funged(x: y):
   // CHECK: [[CASE2]]:
   // CHECK:   function_ref @_T010switch_var1bySi1x_tF
-  // CHECK:   load [trivial] [[Y]]
+  // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[Y]]
+  // CHECK:   load [trivial] [[READ]]
   // CHECK:   destroy_value [[YADDR]]
   // CHECK:   dealloc_stack [[TMP]]
   // CHECK:   destroy_addr [[PAIR_0]] : $*P
@@ -254,12 +274,14 @@ func test_var_4(p p: P) {
   // CHECK:   [[ZADDR:%.*]] = alloc_box ${ var (P, Int) }
   // CHECK:   [[Z:%.*]] = project_box [[ZADDR]]
   // CHECK:   function_ref @_T010switch_var5ansedSbSi1x_tF
-  // CHECK:   tuple_element_addr [[Z]] : {{.*}}, 1
+  // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[Z]]
+  // CHECK:   tuple_element_addr [[READ]] : {{.*}}, 1
   // CHECK:   cond_br {{%.*}}, [[CASE3:bb[0-9]+]], [[DFLT_NO_CASE3:bb[0-9]+]]
   case var z where ansed(x: z.1):
   // CHECK: [[CASE3]]:
   // CHECK:   function_ref @_T010switch_var1cySi1x_tF
-  // CHECK:   tuple_element_addr [[Z]] : {{.*}}, 1
+  // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[Z]]
+  // CHECK:   tuple_element_addr [[READ]] : {{.*}}, 1
   // CHECK:   destroy_value [[ZADDR]]
   // CHECK-NEXT: dealloc_stack [[PAIR]]
   // CHECK:   br [[CONT]]
@@ -274,7 +296,8 @@ func test_var_4(p p: P) {
   // CHECK:   [[WADDR:%.*]] = alloc_box ${ var Int }
   // CHECK:   [[W:%.*]] = project_box [[WADDR]]
   // CHECK:   function_ref @_T010switch_var1dySi1x_tF
-  // CHECK:   load [trivial] [[W]]
+  // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[W]]
+  // CHECK:   load [trivial] [[READ]]
   // CHECK:   destroy_value [[WADDR]]
   // CHECK:   destroy_addr [[PAIR_0]] : $*P
   // CHECK:   dealloc_stack [[PAIR]]
@@ -464,7 +487,8 @@ func test_mixed_let_var() {
   case var x where runced():
   // CHECK: [[CASE1]]:
   // CHECK:   [[A:%.*]] = function_ref @_T010switch_var1aySS1x_tF
-  // CHECK:   [[X:%.*]] = load [copy] [[PBOX]]
+  // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PBOX]]
+  // CHECK:   [[X:%.*]] = load [copy] [[READ]]
   // CHECK:   apply [[A]]([[X]])
   // CHECK:   destroy_value [[BOX]]
   // CHECK:   br [[CONT:bb[0-9]+]]
@@ -698,7 +722,8 @@ func test_multiple_patterns5() {
     // CHECK:   [[CASE_BODY]]([[BODY_X:%.*]] : $Int):
     // CHECK:     store [[BODY_X]] to [trivial] [[BOX_X:%.*]] : $*Int
     // CHECK:     [[FUNC_AAA:%.*]] = function_ref @_T010switch_var3aaaySiz1x_tF
-    // CHECK:     apply [[FUNC_AAA]]([[BOX_X]])
+    // CHECK:     [[WRITE:%.*]] = begin_access [modify] [unknown] [[BOX_X]]
+    // CHECK:     apply [[FUNC_AAA]]([[WRITE]])
     aaa(x: &x)
   }
 }

--- a/test/SILGen/tuples.swift
+++ b/test/SILGen/tuples.swift
@@ -47,10 +47,12 @@ func testShuffleOpaque() {
   // CHECK-NEXT: [[T0:%.*]] = function_ref @_T06tuples7make_xySi1x_AA1P_p1ytyF
   // CHECK-NEXT: [[TEMP:%.*]] = alloc_stack $P
   // CHECK-NEXT: [[T1:%.*]] = apply [[T0]]([[TEMP]])
-  // CHECK-NEXT: [[PAIR_0:%.*]] = tuple_element_addr [[PBPAIR]] : $*(y: P, x: Int), 0
+  // CHECK-NEXT: [[WRITE:%.*]] = begin_access [modify] [unknown] [[PBPAIR]] : $*(y: P, x: Int)
+  // CHECK-NEXT: [[PAIR_0:%.*]] = tuple_element_addr [[WRITE]] : $*(y: P, x: Int), 0
   // CHECK-NEXT: copy_addr [take] [[TEMP]] to [[PAIR_0]]
-  // CHECK-NEXT: [[PAIR_1:%.*]] = tuple_element_addr [[PBPAIR]] : $*(y: P, x: Int), 1
+  // CHECK-NEXT: [[PAIR_1:%.*]] = tuple_element_addr [[WRITE]] : $*(y: P, x: Int), 1
   // CHECK-NEXT: assign [[T1]] to [[PAIR_1]]
+  // CHECK-NEXT: end_access [[WRITE]] : $*(y: P, x: Int)
   // CHECK-NEXT: dealloc_stack [[TEMP]]
   pair = make_xy()
 }
@@ -92,10 +94,12 @@ func testShuffleTuple() {
   // CHECK-NEXT: [[T0:%.*]] = function_ref @_T06tuples6make_pAA1P_pyF 
   // CHECK-NEXT: [[TEMP:%.*]] = alloc_stack $P
   // CHECK-NEXT: apply [[T0]]([[TEMP]])
-  // CHECK-NEXT: [[PAIR_0:%.*]] = tuple_element_addr [[PBPAIR]] : $*(y: P, x: Int), 0
+  // CHECK-NEXT: [[WRITE:%.*]] = begin_access [modify] [unknown] [[PBPAIR]] : $*(y: P, x: Int)
+  // CHECK-NEXT: [[PAIR_0:%.*]] = tuple_element_addr [[WRITE]] : $*(y: P, x: Int), 0
   // CHECK-NEXT: copy_addr [take] [[TEMP]] to [[PAIR_0]]
-  // CHECK-NEXT: [[PAIR_1:%.*]] = tuple_element_addr [[PBPAIR]] : $*(y: P, x: Int), 1
+  // CHECK-NEXT: [[PAIR_1:%.*]] = tuple_element_addr [[WRITE]] : $*(y: P, x: Int), 1
   // CHECK-NEXT: assign [[INT]] to [[PAIR_1]]
+  // CHECK-NEXT: end_access [[WRITE]] : $*(y: P, x: Int)
   // CHECK-NEXT: dealloc_stack [[TEMP]]
   pair = (x: make_int(), y: make_p())
 }

--- a/test/SILGen/types.swift
+++ b/test/SILGen/types.swift
@@ -26,10 +26,13 @@ struct S {
     var x = x
     // CHECK: bb0([[X:%[0-9]+]] : $Int, [[THIS:%[0-9]+]] : $*S):
     member = x
-    // CHECK: [[XADDR:%[0-9]+]] = alloc_box ${ var Int }
-    // CHECK: [[X:%[0-9]+]] = project_box [[XADDR]]
-    // CHECK: [[MEMBER:%[0-9]+]] = struct_element_addr [[THIS]] : $*S, #S.member
-    // CHECK: copy_addr [[X]] to [[MEMBER]]
+    // CHECK: [[XBOX:%[0-9]+]] = alloc_box ${ var Int }
+    // CHECK: [[XADDR:%[0-9]+]] = project_box [[XBOX]]
+    // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[XADDR]] : $*Int
+    // CHECK: [[X:%.*]] = load [trivial] [[READ]] : $*Int
+    // CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] [[THIS]] : $*S
+    // CHECK: [[MEMBER:%[0-9]+]] = struct_element_addr [[WRITE]] : $*S, #S.member
+    // CHECK: assign [[X]] to [[MEMBER]] : $*Int
   }
 
   class SC {

--- a/test/SILGen/unowned.swift
+++ b/test/SILGen/unowned.swift
@@ -59,7 +59,8 @@ func test0(c c: C) {
   a.x = c
   // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
   // CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
-  // CHECK:   [[T1:%.*]] = struct_element_addr [[PBA]] : $*A, #A.x
+  // CHECK:   [[WRITE:%.*]] = begin_access [modify] [unknown] [[PBA]]
+  // CHECK:   [[T1:%.*]] = struct_element_addr [[WRITE]] : $*A, #A.x
   // CHECK:   [[T2:%.*]] = ref_to_unowned [[ARG_COPY]] : $C
   // CHECK:   unowned_retain [[T2]] : $@sil_unowned C
   // CHECK:   assign [[T2]] to [[T1]] : $*@sil_unowned C
@@ -67,10 +68,12 @@ func test0(c c: C) {
   // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
 
   a.x = x
-  // CHECK:   [[T2:%.*]] = load [take] [[PBX]] : $*@sil_unowned C     
+  // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PBX]]
+  // CHECK:   [[T2:%.*]] = load [take] [[READ]] : $*@sil_unowned C     
   // CHECK:   strong_retain_unowned  [[T2]] : $@sil_unowned C  
   // CHECK:   [[T3:%.*]] = unowned_to_ref [[T2]] : $@sil_unowned C to $C
-  // CHECK:   [[XP:%.*]] = struct_element_addr [[PBA]] : $*A, #A.x
+  // CHECK:   [[WRITE:%.*]] = begin_access [modify] [unknown] [[PBA]]
+  // CHECK:   [[XP:%.*]] = struct_element_addr [[WRITE]] : $*A, #A.x
   // CHECK:   [[T4:%.*]] = ref_to_unowned [[T3]] : $C to $@sil_unowned C
   // CHECK:   unowned_retain [[T4]] : $@sil_unowned C  
   // CHECK:   assign [[T4]] to [[XP]] : $*@sil_unowned C

--- a/test/SILGen/weak.swift
+++ b/test/SILGen/weak.swift
@@ -26,18 +26,23 @@ func test0(c c: C) {
 // CHECK:      [[X:%.*]] = alloc_box ${ var @sil_weak Optional<C> }, var, name "x"
 // CHECK-NEXT: [[PBX:%.*]] = project_box [[X]]
 //   Implicit conversion
-// CHECK-NEXT: [[TMP:%.*]] = load [copy] [[PBC]] : $*C
+// CHECK-NEXT: [[READ:%.*]] = begin_access [read] [unknown] [[PBC]]
+// CHECK-NEXT: [[TMP:%.*]] = load [copy] [[READ]] : $*C
+// CHECK-NEXT: end_access [[READ]]
 // CHECK-NEXT: [[OPTVAL:%.*]] = enum $Optional<C>, #Optional.some!enumelt.1, [[TMP]] : $C
 // CHECK-NEXT: store_weak [[OPTVAL]] to [initialization] [[PBX]] : $*@sil_weak Optional<C>
 // CHECK-NEXT: destroy_value [[OPTVAL]] : $Optional<C>
 
   a.x = c
 //   Implicit conversion
-// CHECK-NEXT: [[TMP:%.*]] = load [copy] [[PBC]] : $*C
+// CHECK-NEXT: [[READ:%.*]] = begin_access [read] [unknown] [[PBC]]
+// CHECK-NEXT: [[TMP:%.*]] = load [copy] [[READ]] : $*C
+// CHECK-NEXT:  end_access [[READ]]
 // CHECK-NEXT: [[OPTVAL:%.*]] = enum $Optional<C>, #Optional.some!enumelt.1, [[TMP]] : $C
 
 //   Drill to a.x
-// CHECK-NEXT: [[A_X:%.*]] = struct_element_addr [[PBA]] : $*A, #A.x
+// CHECK-NEXT: [[WRITE:%.*]] = begin_access [modify] [unknown] [[PBA]]
+// CHECK-NEXT: [[A_X:%.*]] = struct_element_addr [[WRITE]] : $*A, #A.x
 
 //   Store to a.x.
 // CHECK-NEXT: store_weak [[OPTVAL]] to [[A_X]] : $*@sil_weak Optional<C>
@@ -50,9 +55,10 @@ func test0(c c: C) {
 // CHECK: bb0(%0 : ${ var @sil_weak Optional<C> }):
 // CHECK-NEXT:  %1 = project_box %0
 // CHECK-NEXT:  debug_value_addr %1 : $*@sil_weak Optional<C>, var, name "bC", argno 1
-// CHECK-NEXT:  %3 = alloc_stack $Optional<C>
-// CHECK-NEXT:  %4 = load_weak %1 : $*@sil_weak Optional<C>
-// CHECK-NEXT:  store %4 to [init] %3 : $*Optional<C>
+// CHECK-NEXT:  [[READ:%.*]] = begin_access [read] [unknown] %1
+// CHECK-NEXT:  [[STK:%.*]] = alloc_stack $Optional<C>
+// CHECK-NEXT:  [[VAL:%.*]] = load_weak [[READ]] : $*@sil_weak Optional<C>
+// CHECK-NEXT:  store [[VAL]] to [init] [[STK]] : $*Optional<C>
 func testClosureOverWeak() {
   weak var bC = C()
   takeClosure { bC!.f() }


### PR DESCRIPTION
This adds support for static enforcement. Now the diagnostics can be enabled with an option without otherwise affecting compilation.

I've already recovered performance lost by disabling the SILGen peephole.
Enabling the markers doesn't have other significant performance or compile time impact.