### PR TITLE
More runtime support for subclass existentials

### DIFF
--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -404,7 +404,8 @@ class ExistentialTypeFlags {
   enum : int_type {
     NumWitnessTablesMask  = 0x00FFFFFFU,
     ClassConstraintMask   = 0x80000000U,
-    SpecialProtocolMask   = 0x7F000000U,
+    HasSuperclassMask     = 0x40000000U,
+    SpecialProtocolMask   = 0x3F000000U,
     SpecialProtocolShift  = 24U,
   };
   int_type Data;
@@ -421,6 +422,11 @@ public:
                                   | (bool(c) ? ClassConstraintMask : 0));
   }
   constexpr ExistentialTypeFlags
+  withHasSuperclass(bool hasSuperclass) const {
+    return ExistentialTypeFlags((Data & ~HasSuperclassMask)
+                                  | (hasSuperclass ? HasSuperclassMask : 0));
+  }
+  constexpr ExistentialTypeFlags
   withSpecialProtocol(SpecialProtocol sp) const {
     return ExistentialTypeFlags((Data & ~SpecialProtocolMask)
                                   | (int_type(sp) << SpecialProtocolShift));
@@ -433,7 +439,11 @@ public:
   ProtocolClassConstraint getClassConstraint() const {
     return ProtocolClassConstraint(bool(Data & ClassConstraintMask));
   }
-  
+
+  bool hasSuperclassConstraint() const {
+    return bool(Data & HasSuperclassMask);
+  }
+
   /// Return whether this existential type represents an uncomposed special
   /// protocol.
   SpecialProtocol getSpecialProtocol() const {

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -2445,9 +2445,16 @@ struct TargetExistentialTypeMetadata : public TargetMetadata<Runtime> {
     return Flags.getClassConstraint() == ProtocolClassConstraint::Class;
   }
 
-  const Metadata *getSuperclassConstraint() const {
-    // FIXME
-    return nullptr;
+  const TargetMetadata<Runtime> *getSuperclassConstraint() const {
+    if (!Flags.hasSuperclassConstraint())
+      return nullptr;
+
+    // Get a pointer to tail-allocated storage for this metadata record.
+    auto Pointer = reinterpret_cast<
+      ConstTargetMetadataPointer<Runtime, TargetMetadata> const *>(this + 1);
+
+    // The superclass immediately follows the list of protocol descriptors.
+    return Pointer[Protocols.NumProtocols];
   }
 
   static bool classof(const TargetMetadata<Runtime> *metadata) {

--- a/lib/IRGen/GenCast.cpp
+++ b/lib/IRGen/GenCast.cpp
@@ -291,21 +291,34 @@ llvm::Value *irgen::emitReferenceToObjCProtocol(IRGenFunction &IGF,
 /// Emit a helper function to look up \c numProtocols witness tables given
 /// a value and a type metadata reference.
 ///
-/// The function's input type is (value, metadataValue, protocol...)
+/// If \p checkClassConstraint is true, we must emit an explicit check that the
+/// instance is a class.
+///
+/// If \p checkSuperclassConstraint is true, we are given an additional parameter
+/// with a superclass type in it, and must emit a check that the instance is a
+/// subclass of the given class.
+///
+/// The function's input type is (value, metadataValue, superclass?, protocol...)
 /// The function's output type is (value, witnessTable...)
 ///
 /// The value is NULL if the cast failed.
-static llvm::Function *emitExistentialScalarCastFn(IRGenModule &IGM,
-                                                   unsigned numProtocols,
-                                                   CheckedCastMode mode,
-                                                   bool checkClassConstraint) {
+static llvm::Function *
+emitExistentialScalarCastFn(IRGenModule &IGM,
+                            unsigned numProtocols,
+                            CheckedCastMode mode,
+                            bool checkClassConstraint,
+                            bool checkSuperclassConstraint) {
+  assert(!checkSuperclassConstraint || checkClassConstraint);
+
   // Build the function name.
   llvm::SmallString<32> name;
   {
     llvm::raw_svector_ostream os(name);
     os << "dynamic_cast_existential_";
     os << numProtocols;
-    if (checkClassConstraint)
+    if (checkSuperclassConstraint)
+      os << "_superclass";
+    else if (checkClassConstraint)
       os << "_class";
     switch (mode) {
     case CheckedCastMode::Unconditional:
@@ -329,6 +342,8 @@ static llvm::Function *emitExistentialScalarCastFn(IRGenModule &IGM,
   argTys.push_back(IGM.Int8PtrTy);
   argTys.push_back(IGM.TypeMetadataPtrTy);
   returnTys.push_back(IGM.Int8PtrTy);
+  if (checkSuperclassConstraint)
+    argTys.push_back(IGM.TypeMetadataPtrTy);
   for (unsigned i = 0; i < numProtocols; ++i) {
     argTys.push_back(IGM.ProtocolDescriptorPtrTy);
     returnTys.push_back(IGM.WitnessTablePtrTy);
@@ -355,7 +370,26 @@ static llvm::Function *emitExistentialScalarCastFn(IRGenModule &IGM,
   rets.add(value);
 
   // Check the class constraint if necessary.
-  if (checkClassConstraint) {
+  if (checkSuperclassConstraint) {
+    auto superclassMetadata = args.claimNext();
+    auto castFn = IGF.IGM.getDynamicCastMetatypeFn();
+    auto castResult = IGF.Builder.CreateCall(castFn, {ref,
+                                                      superclassMetadata});
+
+    auto cc = cast<llvm::Function>(castFn)->getCallingConv();
+
+    // FIXME: Eventually, we may want to throw.
+    castResult->setCallingConv(cc);
+    castResult->setDoesNotThrow();
+
+    auto isClass = IGF.Builder.CreateICmpNE(
+        castResult,
+        llvm::ConstantPointerNull::get(IGF.IGM.TypeMetadataPtrTy));
+
+    auto contBB = IGF.createBasicBlock("cont");
+    IGF.Builder.CreateCondBr(isClass, contBB, failBB);
+    IGF.Builder.emitBlock(contBB);
+  } else if (checkClassConstraint) {
     auto isClass = IGF.Builder.CreateCall(IGM.getIsClassTypeFn(), ref);
     auto contBB = IGF.createBasicBlock("cont");
     IGF.Builder.CreateCondBr(isClass, contBB, failBB);
@@ -374,7 +408,7 @@ static llvm::Function *emitExistentialScalarCastFn(IRGenModule &IGM,
     IGF.Builder.emitBlock(contBB);
     rets.add(witness);
   }
-  
+
   // If we succeeded, return the witnesses.
   IGF.emitScalarReturn(returnTy, rets);
   
@@ -472,11 +506,15 @@ void irgen::emitScalarExistentialDowncast(IRGenFunction &IGF,
                                   CheckedCastMode mode,
                                   Optional<MetatypeRepresentation> metatypeKind,
                                   Explosion &ex) {
-  auto instanceType = destType.getSwiftRValueType();
-  while (auto metatypeType = dyn_cast<ExistentialMetatypeType>(instanceType))
-    instanceType = metatypeType.getInstanceType();
+  auto srcInstanceType = srcType.getSwiftRValueType();
+  auto destInstanceType = destType.getSwiftRValueType();
+  while (auto metatypeType = dyn_cast<ExistentialMetatypeType>(
+           destInstanceType)) {
+    destInstanceType = metatypeType.getInstanceType();
+    srcInstanceType = cast<AnyMetatypeType>(srcInstanceType).getInstanceType();
+  }
 
-  auto layout = instanceType.getExistentialLayout();
+  auto layout = destInstanceType.getExistentialLayout();
 
   // Look up witness tables for the protocols that need them and get
   // references to the ObjC Protocol* values for the objc protocols.
@@ -486,7 +524,7 @@ void irgen::emitScalarExistentialDowncast(IRGenFunction &IGF,
   bool hasClassConstraint = layout.requiresClass;
   bool hasClassConstraintByProtocol = false;
 
-  assert(!layout.superclass && "Subclass existentials not supported yet");
+  bool hasSuperclassConstraint = bool(layout.superclass);
 
   for (auto protoTy : layout.getProtocols()) {
     auto *protoDecl = protoTy->getDecl();
@@ -532,10 +570,34 @@ void irgen::emitScalarExistentialDowncast(IRGenFunction &IGF,
     auto schema = IGF.getTypeInfo(destType).getSchema();
     resultType = schema[0].getScalarType();
   }
-  // We only need to check the class constraint for metatype casts where
-  // no protocol conformance indirectly requires the constraint for us.
-  bool checkClassConstraint =
-    (bool)metatypeKind && hasClassConstraint && !hasClassConstraintByProtocol;
+
+  // The source of a scalar cast is statically known to be a class or a
+  // metatype, so we only have to check the class constraint in two cases:
+  //
+  // 1) The destination type has an explicit superclass constraint that is
+  //    more derived than what the source type is known to be.
+  //
+  // 2) We are casting between metatypes, in which case the source might
+  //    be a non-class metatype.
+  bool checkClassConstraint = false;
+  if ((bool)metatypeKind &&
+      hasClassConstraint &&
+      !hasClassConstraintByProtocol &&
+      !srcInstanceType->mayHaveSuperclass())
+    checkClassConstraint = true;
+
+  // If the source has an equal or more derived superclass constraint than
+  // the destination, we can elide the superclass check.
+  //
+  // Note that destInstanceType is always an existential type, so calling
+  // getSuperclass() returns the superclass constraint of the existential,
+  // not the superclass of some concrete class.
+  bool checkSuperclassConstraint =
+    hasSuperclassConstraint &&
+    !destInstanceType->getSuperclass()->isExactSuperclassOf(srcInstanceType);
+
+  if (checkSuperclassConstraint)
+    checkClassConstraint = true;
 
   llvm::Value *resultValue = value;
 
@@ -671,8 +733,11 @@ void irgen::emitScalarExistentialDowncast(IRGenFunction &IGF,
   }
 
   // Look up witness tables for the protocols that need them.
-  auto fn = emitExistentialScalarCastFn(IGF.IGM, witnessTableProtos.size(),
-                                        mode, checkClassConstraint);
+  auto fn = emitExistentialScalarCastFn(IGF.IGM,
+                                        witnessTableProtos.size(),
+                                        mode,
+                                        checkClassConstraint,
+                                        checkSuperclassConstraint);
 
   llvm::SmallVector<llvm::Value *, 4> args;
 
@@ -681,6 +746,10 @@ void irgen::emitScalarExistentialDowncast(IRGenFunction &IGF,
   args.push_back(resultValue);
 
   args.push_back(metadataValue);
+
+  if (checkSuperclassConstraint)
+    args.push_back(IGF.emitTypeMetadataRef(CanType(layout.superclass)));
+
   for (auto proto : witnessTableProtos)
     args.push_back(proto);
 

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -1531,8 +1531,9 @@ llvm::StructType *IRGenModule::createNominalType(CanType type) {
   assert(type.getNominalOrBoundGenericNominal());
 
   // We share type infos for different instantiations of a generic type
-  // when the archetypes have the same exemplars.  Mangling the archetypes
-  // in this case can be very misleading, so we just mangle the base name.
+  // when the archetypes have the same exemplars.  We cannot mangle
+  // archetypes, and the mangling does not have to be unique, so we just
+  // mangle the unbound generic form of the type.
   if (type->hasArchetype())
     type = type.getNominalOrBoundGenericNominal()->getDeclaredType()
                                                  ->getCanonicalType();

--- a/lib/IRGen/IRGenMangler.cpp
+++ b/lib/IRGen/IRGenMangler.cpp
@@ -94,7 +94,18 @@ mangleProtocolForLLVMTypeName(ProtocolCompositionType *type) {
         appendOperator("_");
     }
     if (layout.superclass) {
-      appendType(layout.superclass);
+      auto superclassTy = layout.superclass;
+
+      // We share type infos for different instantiations of a generic type
+      // when the archetypes have the same exemplars.  We cannot mangle
+      // archetypes, and the mangling does not have to be unique, so we just
+      // mangle the unbound generic form of the type.
+      if (superclassTy->hasArchetype()) {
+        superclassTy = superclassTy->getClassOrBoundGenericClass()
+          ->getDeclaredType();
+      }
+
+      appendType(CanType(superclassTy));
       appendOperator("Xc");
     } else if (layout.getLayoutConstraint()) {
       appendOperator("Xl");

--- a/test/IRGen/metatype_casts.sil
+++ b/test/IRGen/metatype_casts.sil
@@ -88,13 +88,24 @@ end:
 }
 
 // CHECK-LABEL: define{{( protected)?}} swiftcc %swift.type* @checked_cast_to_anyobject_type
-// CHECK:         [[METATYPE:%.*]] = call %swift.type* @_T014metatype_casts9SomeClassCMa()
-// CHECK:         [[T0:%.*]] = bitcast %swift.type* [[METATYPE]] to i8*
-// CHECK:         [[CAST:%.*]] = call { i8* } @dynamic_cast_existential_0_class_unconditional(i8* [[T0]], %swift.type* [[METATYPE]])
+// CHECK:         [[T0:%.*]] = bitcast %swift.type* %0 to i8*
+// CHECK:         [[CAST:%.*]] = call { i8* } @dynamic_cast_existential_0_class_unconditional(i8* [[T0]], %swift.type* %0)
 // CHECK:         [[RESULT0:%.*]] = extractvalue { i8* } [[CAST]], 0
 // CHECK:         [[RESULT:%.*]] = bitcast i8* [[RESULT0]] to %swift.type*
 // CHECK:         ret %swift.type* [[RESULT]]
-sil @checked_cast_to_anyobject_type : $@convention(thin) () -> @thick AnyObject.Type {
+sil @checked_cast_to_anyobject_type : $@convention(thin) (@thick Any.Type) -> @thick AnyObject.Type {
+entry(%0 : $@thick Any.Type):
+  %2 = unconditional_checked_cast %0 : $@thick Any.Type to $@thick AnyObject.Type
+  return %2 : $@thick AnyObject.Type
+}
+
+// Trivial case -- we know the source is a class metatype, so there's nothing
+// to check.
+
+// CHECK-LABEL: define{{( protected)?}} swiftcc %swift.type* @checked_cast_class_to_anyobject_type
+// CHECK:         [[METATYPE:%.*]] = call %swift.type* @_T014metatype_casts9SomeClassCMa()
+// CHECK:         ret %swift.type* [[METATYPE]]
+sil @checked_cast_class_to_anyobject_type : $@convention(thin) () -> @thick AnyObject.Type {
 entry:
   %1 = metatype $@thick SomeClass.Type
   %2 = unconditional_checked_cast %1 : $@thick SomeClass.Type to $@thick AnyObject.Type

--- a/test/IRGen/subclass_existentials.sil
+++ b/test/IRGen/subclass_existentials.sil
@@ -6,9 +6,14 @@ import Builtin
 import Swift
 
 class C {}
+class G<T> {}
+
 protocol P {}
 
 class D : C, P {}
+class E<T> : G<T>, P {}
+
+protocol R {}
 
 // Make sure we use native reference counting when the existential has a Swift
 // class bound.
@@ -61,11 +66,152 @@ bb0:
   return %4 : $()
 }
 
+// CHECK-LABEL: define{{( protected)?}} swiftcc { %T21subclass_existentials1CC*, i8** } @eraseToExistential(%T21subclass_existentials1DC*)
+// CHECK:       [[INSTANCE:%.*]] = bitcast %T21subclass_existentials1DC* %0 to %T21subclass_existentials1CC*
+// CHECK-NEXT:  [[RESULT1:%.*]] = insertvalue { %T21subclass_existentials1CC*, i8** } undef, %T21subclass_existentials1CC* [[INSTANCE]], 0
+// CHECK-NEXT:  [[RESULT2:%.*]] = insertvalue { %T21subclass_existentials1CC*, i8** } [[RESULT1]], i8** @_T021subclass_existentials1DCAA1PAAWP, 1
+// CHECK-NEXT:  ret { %T21subclass_existentials1CC*, i8** } [[RESULT2]]
 sil @eraseToExistential : $@convention(thin) (@owned D) -> @owned C & P {
 bb0(%0 : $D):
   %2 = init_existential_ref %0 : $D : $D, $C & P
   return %2 : $C & P
 }
 
+// CHECK-LABEL: define{{( protected)?}} swiftcc { %T21subclass_existentials1GC*, i8** } @eraseToExistentialWithGeneric(%T21subclass_existentials1EC*)
+// CHECK:       [[INSTANCE:%.*]] = bitcast %T21subclass_existentials1EC* %0 to %T21subclass_existentials1GC*
+// CHECK-NEXT:  [[RESULT1:%.*]] = insertvalue { %T21subclass_existentials1GC*, i8** } undef, %T21subclass_existentials1GC* [[INSTANCE]], 0
+// CHECK-NEXT:  [[RESULT2:%.*]] = insertvalue { %T21subclass_existentials1GC*, i8** } [[RESULT1]], i8** @_T021subclass_existentials1ECyxGAA1PAAlWP, 1
+// CHECK-NEXT:  ret { %T21subclass_existentials1GC*, i8** } [[RESULT2]]
+sil @eraseToExistentialWithGeneric : $@convention(thin) <τ_0_0> (@owned E<τ_0_0>) -> @owned G<τ_0_0> & P {
+bb0(%0 : $E<τ_0_0>):
+  %2 = init_existential_ref %0 : $E<τ_0_0> : $E<τ_0_0>, $G<τ_0_0> & P
+  return %2 : $G<τ_0_0> & P
+}
+
+// CHECK-LABEL: define{{( protected)?}} swiftcc void @checkExistentialDowncast(%T21subclass_existentials1CC*, %T21subclass_existentials1CC*, i8**)
+sil @checkExistentialDowncast : $@convention(thin) (@owned C, @owned C & P) -> () {
+bb0(%0 : $C, %1 : $C & P):
+
+// CHECK:       [[METATYPE_PTR:%.*]] = bitcast %T21subclass_existentials1CC* %0 to %swift.type**
+// CHECK-NEXT:  [[METATYPE:%.*]] = load %swift.type*, %swift.type** [[METATYPE_PTR]], align 8
+// CHECK-NEXT:  [[VALUE:%.*]] = bitcast %T21subclass_existentials1CC* %0 to i8*
+// CHECK-NEXT:  [[SUPERCLASS:%.*]] = call %swift.type* @_T021subclass_existentials1DCMa()
+// CHECK-NEXT:  [[RESULT:%.*]] = call { i8*, i8** } @dynamic_cast_existential_1_superclass_unconditional(i8* [[VALUE]], %swift.type* [[METATYPE]], %swift.type* [[SUPERCLASS]], %swift.protocol* @_T021subclass_existentials1RMp)
+// CHECK-NEXT:  [[VALUE_ADDR:%.*]] = extractvalue { i8*, i8** } [[RESULT]], 0
+// CHECK-NEXT:  [[VALUE:%.*]] = bitcast i8* [[VALUE_ADDR]] to %T21subclass_existentials1DC*
+// CHECK-NEXT:  [[WTABLE:%.*]] = extractvalue { i8*, i8** } [[RESULT]], 1
+  %2 = unconditional_checked_cast %0 : $C to $D & R
+
+// CHECK-NEXT:  call void bitcast (void (%swift.refcounted*)* @swift_rt_swift_release to void (%T21subclass_existentials1DC*)*)(%T21subclass_existentials1DC* [[VALUE]])
+  destroy_value %2 : $D & R
+
+// CHECK-NEXT:  [[VALUE:%.*]] = bitcast %T21subclass_existentials1CC* %1 to i8*
+// CHECK-NEXT:  [[CLASS_ADDR:%.*]] = bitcast %swift.type* [[SUPERCLASS]] to i8*
+// CHECK-NEXT:  [[RESULT:%.*]] = call i8* @swift_dynamicCastClassUnconditional(i8* [[VALUE]], i8* [[CLASS_ADDR]])
+// CHECK-NEXT:  [[VALUE:%.*]] = bitcast i8* [[RESULT]] to %T21subclass_existentials1DC*
+  %3 = unconditional_checked_cast %1 : $C & P to $D
+
+// CHECK-NEXT:  call void bitcast (void (%swift.refcounted*)* @swift_rt_swift_release to void (%T21subclass_existentials1DC*)*)(%T21subclass_existentials1DC* [[VALUE]])
+  destroy_value %3 : $D
+
+// CHECK-NEXT:  ret void
+  %result = tuple ()
+  return %result : $()
+}
+
+// CHECK-LABEL: define private { i8*, i8** } @dynamic_cast_existential_1_superclass_unconditional(i8*, %swift.type*, %swift.type*, %swift.protocol*)
+// CHECK:     entry:
+// CHECK-NEXT:  [[RESULT:%.*]] = call %swift.type* @swift_dynamicCastMetatype(%swift.type* %1, %swift.type* %2)
+// CHECK-NEXT:  [[IS_SUBCLASS:%.*]] = icmp ne %swift.type* [[RESULT]], null
+// CHECK-NEXT:  br i1 [[IS_SUBCLASS]], label %cont, label %fail
+
+// CHECK:     cont:
+// CHECK-NEXT:  [[WTABLE:%.*]] = call i8** @swift_conformsToProtocol(%swift.type* %1, %swift.protocol* %3)
+// CHECK-NEXT:  [[IS_NOT_CONFORMING:%.*]] = icmp eq i8** [[WTABLE]], null
+// CHECK-NEXT:  br i1 [[IS_NOT_CONFORMING]], label %fail, label %cont1
+
+// CHECK:     cont1:
+// CHECK-NEXT:  [[RESULT1:%.*]] = insertvalue { i8*, i8** } undef, i8* %0, 0
+// CHECK-NEXT:  [[RESULT2:%.*]] = insertvalue { i8*, i8** } [[RESULT1]], i8** [[WTABLE]], 1
+// CHECK-NEXT:  ret { i8*, i8** } [[RESULT2]]
+
+// CHECK:     fail:
+// CHECK-NEXT:  call void @llvm.trap()
+// CHECK-NEXT:  unreachable
+
+// CHECK-LABEL: define{{( protected)?}} swiftcc void @checkExistentialSameClassDowncast(%T21subclass_existentials1CC*)
+sil @checkExistentialSameClassDowncast : $@convention(thin) (@owned C) -> () {
+bb0(%0 : $C):
+
+// CHECK:       [[METATYPE_PTR:%.*]] = bitcast %T21subclass_existentials1CC* %0 to %swift.type**
+// CHECK-NEXT:  [[METATYPE:%.*]] = load %swift.type*, %swift.type** [[METATYPE_PTR]], align 8
+// CHECK-NEXT:  [[VALUE:%.*]] = bitcast %T21subclass_existentials1CC* %0 to i8*
+// CHECK-NEXT:  [[RESULT:%.*]] = call { i8*, i8** } @dynamic_cast_existential_1_unconditional(i8* [[VALUE]], %swift.type* [[METATYPE]], %swift.protocol* @_T021subclass_existentials1PMp)
+// CHECK-NEXT:  [[VALUE_ADDR:%.*]] = extractvalue { i8*, i8** } [[RESULT]], 0
+// CHECK-NEXT:  [[VALUE:%.*]] = bitcast i8* [[VALUE_ADDR]] to %T21subclass_existentials1CC*
+// CHECK-NEXT:  [[WTABLE:%.*]] = extractvalue { i8*, i8** } [[RESULT]], 1
+  %2 = unconditional_checked_cast %0 : $C to $C & P
+
+// CHECK-NEXT:  call void bitcast (void (%swift.refcounted*)* @swift_rt_swift_release to void (%T21subclass_existentials1CC*)*)(%T21subclass_existentials1CC* [[VALUE]])
+  destroy_value %2 : $C & P
+
+// CHECK-NEXT:  ret void
+  %result = tuple ()
+  return %result : $()
+}
+
+// CHECK-LABEL: define private { i8*, i8** } @dynamic_cast_existential_1_unconditional(i8*, %swift.type*, %swift.protocol*)
+// CHECK:     entry:
+// CHECK-NEXT:  [[WTABLE:%.*]] = call i8** @swift_conformsToProtocol(%swift.type* %1, %swift.protocol* %2)
+// CHECK-NEXT:  [[IS_NOT_CONFORMING:%.*]] = icmp eq i8** [[WTABLE]], null
+// CHECK-NEXT:  br i1 [[IS_NOT_CONFORMING]], label %fail, label %cont
+
+// CHECK:     cont:
+// CHECK-NEXT:  [[RESULT1:%.*]] = insertvalue { i8*, i8** } undef, i8* %0, 0
+// CHECK-NEXT:  [[RESULT2:%.*]] = insertvalue { i8*, i8** } [[RESULT1]], i8** [[WTABLE]], 1
+// CHECK-NEXT:  ret { i8*, i8** } [[RESULT2]]
+
+// CHECK:     fail:
+// CHECK-NEXT:  call void @llvm.trap()
+// CHECK-NEXT:  unreachable
+
+// CHECK-LABEL: define{{( protected)?}} swiftcc void @checkExistentialMetatypeDowncast(%swift.type*, %swift.type*, i8**)
+sil @checkExistentialMetatypeDowncast : $@convention(thin) (@owned @thick C.Type, @owned @thick (C & P).Type) -> () {
+bb0(%0 : $@thick C.Type, %1 : $@thick (C & P).Type):
+
+// CHECK:       [[METATYPE:%.*]] = bitcast %swift.type* %0 to i8*
+// CHECK-NEXT:  [[SUPERCLASS:%.*]] = call %swift.type* @_T021subclass_existentials1DCMa()
+// CHECK-NEXT:  [[RESULT:%.*]] = call { i8*, i8** } @dynamic_cast_existential_1_superclass_unconditional(i8* [[METATYPE]], %swift.type* %0, %swift.type* [[SUPERCLASS]], %swift.protocol* @_T021subclass_existentials1RMp)
+// CHECK-NEXT:  [[VALUE_ADDR:%.*]] = extractvalue { i8*, i8** } [[RESULT]], 0
+// CHECK-NEXT:  [[VALUE:%.*]] = bitcast i8* [[VALUE_ADDR]] to %swift.type*
+// CHECK-NEXT:  [[WTABLE:%.*]] = extractvalue { i8*, i8** } [[RESULT]], 1
+  %2 = unconditional_checked_cast %0 : $@thick C.Type to $@thick (D & R).Type
+
+// CHECK-NEXT:  [[RESULT:%.*]] = call %swift.type* @swift_dynamicCastMetatypeUnconditional(%swift.type* %1, %swift.type* [[SUPERCLASS]])
+  %3 = unconditional_checked_cast %1 : $@thick (C & P).Type to $@thick D.Type
+
+// CHECK-NEXT:  ret void
+  %result = tuple ()
+  return %result : $()
+}
+
+// CHECK-LABEL: define{{( protected)?}} swiftcc void @checkExistentialSameClassMetatypeDowncast(%swift.type*)
+sil @checkExistentialSameClassMetatypeDowncast : $@convention(thin) (@owned @thick C.Type) -> () {
+bb0(%0 : $@thick C.Type):
+
+// CHECK:       [[METATYPE:%.*]] = bitcast %swift.type* %0 to i8*
+// CHECK-NEXT:  [[RESULT:%.*]] = call { i8*, i8** } @dynamic_cast_existential_1_unconditional(i8* [[METATYPE]], %swift.type* %0, %swift.protocol* @_T021subclass_existentials1PMp)
+// CHECK-NEXT:  [[VALUE_ADDR:%.*]] = extractvalue { i8*, i8** } [[RESULT]], 0
+// CHECK-NEXT:  [[VALUE:%.*]] = bitcast i8* [[VALUE_ADDR]] to %swift.type*
+// CHECK-NEXT:  [[WTABLE:%.*]] = extractvalue { i8*, i8** } [[RESULT]], 1
+  %2 = unconditional_checked_cast %0 : $@thick C.Type to $@thick (C & P).Type
+
+// CHECK-NEXT:  ret void
+  %result = tuple ()
+  return %result : $()
+}
+
 sil_vtable C {}
 sil_vtable D {}
+sil_vtable G {}
+sil_vtable E {}

--- a/test/Reflection/capture_descriptors.sil
+++ b/test/Reflection/capture_descriptors.sil
@@ -241,3 +241,27 @@ bb0(%thin: $@convention(thin) () -> (), %c: $@convention(c) () -> (), %block: $@
 // CHECK-NEXT: (function convention=thin
 // CHECK-NEXT:   (tuple))
 // CHECK-NEXT: - Metadata sources:
+
+// Capturing opened existentials
+//
+// Not supported yet -- make sure we bail out instead of crashing.
+//
+// FIXME: Eventually, we should emit a useful capture descriptor
+// for this case.
+
+sil @existential_callee : $@convention(thin) <τ_0_0 where τ_0_0 : P> () -> @out P {
+bb0(%0 : $*P):
+  unreachable
+}
+
+
+sil @existential_caller : $@convention(thin) (@in P) -> () {
+bb0(%0 : $*P):
+  %payload = open_existential_addr immutable_access %0 : $*P to $*@opened("2D7A8F84-2973-11E7-838D-34363BD08DA0") P
+  %f = function_ref @existential_callee : $@convention(thin) <τ_0_0 where τ_0_0 : P> () -> @out P
+  %result = partial_apply %f<@opened("2D7A8F84-2973-11E7-838D-34363BD08DA0") P>() : $@convention(thin) <τ_0_0 where τ_0_0 : P> () -> @out P
+  destroy_value %result : $@callee_owned () -> @out P
+  destroy_addr %0 : $*P
+  %tuple = tuple ()
+  return %tuple : $()
+}

--- a/test/SILGen/function_conversion.swift
+++ b/test/SILGen/function_conversion.swift
@@ -1,4 +1,5 @@
-// RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -primary-file %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir -primary-file %s
 
 // Check SILGen against various FunctionConversionExprs emitted by Sema.
 

--- a/test/SILGen/partial_apply_protocol.swift
+++ b/test/SILGen/partial_apply_protocol.swift
@@ -1,4 +1,5 @@
-// RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -primary-file %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir -primary-file %s
 
 protocol Clonable {
   func clone() -> Self

--- a/test/SILGen/subclass_existentials.swift
+++ b/test/SILGen/subclass_existentials.swift
@@ -1,20 +1,42 @@
-// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -emit-silgen -parse-as-library -enable-experimental-subclass-existentials %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -emit-silgen -parse-as-library -enable-experimental-subclass-existentials -primary-file %s -verify | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir -parse-as-library -enable-experimental-subclass-existentials -primary-file %s
+
+// Note: we pass -verify above to ensure there are no spurious
+// compiler warnings relating to casts.
 
 protocol Q {}
 
 class Base<T> : Q {
-  func classSelfReturn() -> Self {}
-  static func classSelfReturn() -> Self {}
+  required init(classInit: ()) {}
+  func classSelfReturn() -> Self {
+    return self
+  }
+  static func classSelfReturn() -> Self {
+    return self.init(classInit: ())
+  }
 }
 
 protocol P {
+  init(protocolInit: ())
   func protocolSelfReturn() -> Self
   static func protocolSelfReturn() -> Self
 }
 
 class Derived : Base<Int>, P {
-  func protocolSelfReturn() -> Self {}
-  static func protocolSelfReturn() -> Self {}
+  required init(protocolInit: ()) {
+    super.init(classInit: ())
+  }
+
+  required init(classInit: ()) {
+    super.init(classInit: ())
+  }
+
+  func protocolSelfReturn() -> Self {
+    return self
+  }
+  static func protocolSelfReturn() -> Self {
+    return self.init(classInit: ())
+  }
 }
 
 protocol R {}
@@ -128,7 +150,23 @@ func methodCalls(
   // CHECK: end_borrow [[BORROW]] from %0 : $Base<Int> & P
   let _: Base<Int> & P = baseAndP.protocolSelfReturn()
 
+  // CHECK: [[METATYPE:%.*]] = open_existential_metatype %1 : $@thick (Base<Int> & P).Type to $@thick (@opened("{{.*}}") (Base<Int> & P)).Type
+  // CHECK: [[METHOD:%.*]] = function_ref @_T021subclass_existentials4BaseC15classSelfReturnACyxGXDyFZ : $@convention(method) <τ_0_0> (@thick Base<τ_0_0>.Type) -> @owned Base<τ_0_0>
+  // CHECK: [[METATYPE_REF:%.*]] = upcast [[METATYPE]] : $@thick (@opened("{{.*}}") (Base<Int> & P)).Type to $@thick Base<Int>.Type
+  // CHECK: [[RESULT_REF2:%.*]] = apply [[METHOD]]<Int>([[METATYPE_REF]])
+  // CHECK: [[RESULT_REF:%.*]] = unchecked_ref_cast [[RESULT_REF2]] : $Base<Int> to $@opened("{{.*}}") (Base<Int> & P)
+  // CHECK: [[RESULT:%.*]] = init_existential_ref [[RESULT_REF]] : $@opened("{{.*}}") (Base<Int> & P) : $@opened("{{.*}}") (Base<Int> & P), $Base<Int> & P
+  // CHECK: destroy_value [[RESULT]]
   let _: Base<Int> & P = baseAndPType.classSelfReturn()
+
+  // CHECK: [[METATYPE:%.*]] = open_existential_metatype %1 : $@thick (Base<Int> & P).Type to $@thick (@opened("{{.*}}") (Base<Int> & P)).Type
+  // CHECK: [[METHOD:%.*]] = witness_method $@opened("{{.*}}") (Base<Int> & P), #P.protocolSelfReturn!1 : <Self where Self : P> (Self.Type) -> () -> @dynamic_self Self, [[METATYPE]] : $@thick (@opened("{{.*}}") (Base<Int> & P)).Type : $@convention(witness_method) <τ_0_0 where τ_0_0 : P> (@thick τ_0_0.Type) -> @out τ_0_0
+  // CHECK: [[RESULT:%.*]] = alloc_stack $@opened("{{.*}}") (Base<Int> & P)
+  // CHECK: apply [[METHOD]]<@opened("{{.*}}") (Base<Int> & P)>(%37, %35) : $@convention(witness_method) <τ_0_0 where τ_0_0 : P> (@thick τ_0_0.Type) -> @out τ_0_0
+  // CHECK: [[RESULT_REF:%.*]] = load [take] [[RESULT]] : $*@opened("{{.*}}") (Base<Int> & P)
+  // CHECK: [[RESULT_VALUE:%.*]] = init_existential_ref [[RESULT_REF]] : $@opened("{{.*}}") (Base<Int> & P) : $@opened("{{.*}}") (Base<Int> & P), $Base<Int> & P
+  // CHECK: destroy_value [[RESULT_VALUE]]
+  // CHECK: dealloc_stack [[RESULT]]
   let _: Base<Int> & P = baseAndPType.protocolSelfReturn()
 
   // Partial applications
@@ -137,10 +175,15 @@ func methodCalls(
 
   let _: () -> (Base<Int> & P) = baseAndPType.classSelfReturn
   let _: () -> (Base<Int> & P) = baseAndPType.protocolSelfReturn
+
+  let _: () -> (Base<Int> & P) = baseAndPType.init(classInit:)
+  let _: () -> (Base<Int> & P) = baseAndPType.init(protocolInit:)
+
+  // CHECK:      return
+  // CHECK-NEXT: }
 }
 
 // CHECK-LABEL: sil hidden @_T021subclass_existentials19functionConversionsyAA1P_AA4BaseCySiGXcyc07returnsE4AndP_AaC_AFXcXpyc0feG5PTypeAA7DerivedCyc0fI0AJmyc0fI4TypeAA1R_AJXcyc0fiG1RAaM_AJXcXpyc0fiG5RTypetF : $@convention(thin) (@owned @callee_owned () -> @owned Base<Int> & P, @owned @callee_owned () -> @thick (Base<Int> & P).Type, @owned @callee_owned () -> @owned Derived, @owned @callee_owned () -> @thick Derived.Type, @owned @callee_owned () -> @owned Derived & R, @owned @callee_owned () -> @thick (Derived & R).Type) -> () {
-
 func functionConversions(
   returnsBaseAndP: @escaping () -> (Base<Int> & P),
   returnsBaseAndPType: @escaping () -> (Base<Int> & P).Type,
@@ -166,4 +209,259 @@ func functionConversions(
 
   let _: () -> P = returnsDerivedAndR
   let _: () -> P.Type = returnsDerivedAndRType
+
+  // CHECK:      return %
+  // CHECK-NEXT: }
+}
+
+// CHECK-LABEL: sil hidden @_T021subclass_existentials9downcastsyAA1P_AA4BaseCySiGXc8baseAndP_AA7DerivedC7derivedAaC_AFXcXp0eF5PTypeAIm0H4TypetF : $@convention(thin) (@owned Base<Int> & P, @owned Derived, @thick (Base<Int> & P).Type, @thick Derived.Type) -> () {
+func downcasts(
+  baseAndP: Base<Int> & P,
+  derived: Derived,
+  baseAndPType: (Base<Int> & P).Type,
+  derivedType: Derived.Type) {
+
+  // CHECK:      [[BORROWED:%.*]] = begin_borrow %0 : $Base<Int> & P
+  // CHECK-NEXT: [[COPIED:%.*]] = copy_value [[BORROWED]] : $Base<Int> & P
+  // CHECK-NEXT: checked_cast_br [[COPIED]] : $Base<Int> & P to $Derived
+  let _ = baseAndP as? Derived
+
+  // CHECK:      [[BORROWED:%.*]] = begin_borrow %0 : $Base<Int> & P
+  // CHECK-NEXT: [[COPIED:%.*]] = copy_value [[BORROWED]] : $Base<Int> & P
+  // CHECK-NEXT: unconditional_checked_cast [[COPIED]] : $Base<Int> & P to $Derived
+  let _ = baseAndP as! Derived
+
+  // CHECK:      [[BORROWED:%.*]] = begin_borrow %0 : $Base<Int> & P
+  // CHECK-NEXT: [[COPIED:%.*]] = copy_value [[BORROWED]] : $Base<Int> & P
+  // CHECK-NEXT: checked_cast_br [[COPIED]] : $Base<Int> & P to $Derived & R
+  let _ = baseAndP as? (Derived & R)
+
+  // CHECK:      [[BORROWED:%.*]] = begin_borrow %0 : $Base<Int> & P
+  // CHECK-NEXT: [[COPIED:%.*]] = copy_value [[BORROWED]] : $Base<Int> & P
+  // CHECK-NEXT: unconditional_checked_cast [[COPIED]] : $Base<Int> & P to $Derived & R
+  let _ = baseAndP as! (Derived & R)
+
+  // CHECK:      checked_cast_br %3 : $@thick Derived.Type to $@thick (Derived & R).Type
+  let _ = derivedType as? (Derived & R).Type
+
+  // CHECK:      unconditional_checked_cast %3 : $@thick Derived.Type to $@thick (Derived & R).Type
+  let _ = derivedType as! (Derived & R).Type
+
+  // CHECK:      checked_cast_br %2 : $@thick (Base<Int> & P).Type to $@thick Derived.Type
+  let _ = baseAndPType as? Derived.Type
+
+  // CHECK:      unconditional_checked_cast %2 : $@thick (Base<Int> & P).Type to $@thick Derived.Type
+  let _ = baseAndPType as! Derived.Type
+
+  // CHECK:      checked_cast_br %2 : $@thick (Base<Int> & P).Type to $@thick (Derived & R).Type
+  let _ = baseAndPType as? (Derived & R).Type
+
+  // CHECK:      unconditional_checked_cast %2 : $@thick (Base<Int> & P).Type to $@thick (Derived & R).Type
+  let _ = baseAndPType as! (Derived & R).Type
+
+  // CHECK:      return
+  // CHECK-NEXT: }
+}
+
+// CHECK-LABEL: sil hidden @_T021subclass_existentials16archetypeUpcastsyq_9baseTAndP_q0_0E7IntAndPq1_7derivedtAA4BaseCyxGRb_AA1PR_AGySiGRb0_AaIR0_AA7DerivedCRb1_r2_lF : $@convention(thin) <T, BaseTAndP, BaseIntAndP, DerivedT where BaseTAndP : Base<T>, BaseTAndP : P, BaseIntAndP : Base<Int>, BaseIntAndP : P, DerivedT : Derived> (@owned BaseTAndP, @owned BaseIntAndP, @owned DerivedT) -> () {
+func archetypeUpcasts<T,
+                      BaseTAndP : Base<T> & P,
+                      BaseIntAndP : Base<Int> & P,
+                      DerivedT : Derived>(
+  baseTAndP: BaseTAndP,
+  baseIntAndP : BaseIntAndP,
+  derived : DerivedT) {
+
+  // CHECK:      [[BORROWED:%.*]] = begin_borrow %0 : $BaseTAndP
+  // CHECK-NEXT: [[COPIED:%.*]] = copy_value [[BORROWED]] : $BaseTAndP
+  // CHECK-NEXT: init_existential_ref [[COPIED]] : $BaseTAndP : $BaseTAndP, $Base<T> & P
+  let _: Base<T> & P = baseTAndP
+
+  // CHECK:      [[BORROWED:%.*]] = begin_borrow %1 : $BaseIntAndP
+  // CHECK-NEXT: [[COPIED:%.*]] = copy_value [[BORROWED]] : $BaseIntAndP
+  // CHECK-NEXT: init_existential_ref [[COPIED]] : $BaseIntAndP : $BaseIntAndP, $Base<Int> & P
+  let _: Base<Int> & P = baseIntAndP
+
+  // CHECK:      [[BORROWED:%.*]] = begin_borrow %2 : $DerivedT
+  // CHECK-NEXT: [[COPIED:%.*]] = copy_value [[BORROWED]] : $DerivedT
+  // CHECK-NEXT: init_existential_ref [[COPIED]] : $DerivedT : $DerivedT, $Base<Int> & P
+  let _: Base<Int> & P = derived
+
+  // CHECK:      return
+  // CHECK-NEXT: }
+}
+
+// CHECK-LABEL: sil hidden @_T021subclass_existentials18archetypeDowncastsyx1s_q_1tq0_2ptq1_5baseTq2_0F3Intq3_0f6TAndP_C0q4_0fg5AndP_C0q5_08derived_C0AA1R_AA7DerivedCXc0ji2R_C0AA1P_AA4BaseCyq_GXc0fH10P_concreteAaO_AQySiGXc0fgi2P_M0tAaOR0_ARRb1_ATRb2_ARRb3_AaOR3_ATRb4_AaOR4_AMRb5_r6_lF : $@convention(thin) <S, T, PT, BaseT, BaseInt, BaseTAndP, BaseIntAndP, DerivedT where PT : P, BaseT : Base<T>, BaseInt : Base<Int>, BaseTAndP : Base<T>, BaseTAndP : P, BaseIntAndP : Base<Int>, BaseIntAndP : P, DerivedT : Derived> (@in S, @in T, @in PT, @owned BaseT, @owned BaseInt, @owned BaseTAndP, @owned BaseIntAndP, @owned DerivedT, @owned Derived & R, @owned Base<T> & P, @owned Base<Int> & P) -> () {
+func archetypeDowncasts<S,
+                        T,
+                        PT : P,
+                        BaseT : Base<T>,
+                        BaseInt : Base<Int>,
+                        BaseTAndP : Base<T> & P,
+                        BaseIntAndP : Base<Int> & P,
+                        DerivedT : Derived>(
+  s: S,
+  t: T,
+  pt: PT,
+  baseT : BaseT,
+  baseInt : BaseInt,
+
+  baseTAndP_archetype: BaseTAndP,
+  baseIntAndP_archetype : BaseIntAndP,
+  derived_archetype : DerivedT,
+  derivedAndR_archetype : Derived & R,
+
+  baseTAndP_concrete: Base<T> & P,
+  baseIntAndP_concrete: Base<Int> & P) {
+
+  // CHECK:      [[COPY:%.*]] = alloc_stack $S
+  // CHECK-NEXT: copy_addr %0 to [initialization] [[COPY]] : $*S
+  // CHECK-NEXT: [[RESULT:%.*]] = alloc_stack $Base<T> & P
+  // CHECK-NEXT: checked_cast_addr_br take_always S in [[COPY]] : $*S to Base<T> & P in [[RESULT]] : $*Base<T> & P
+  let _ = s as? (Base<T> & P)
+
+  // CHECK:      [[COPY:%.*]] = alloc_stack $S
+  // CHECK-NEXT: copy_addr %0 to [initialization] [[COPY]] : $*S
+  // CHECK-NEXT: [[RESULT:%.*]] = alloc_stack $Base<T> & P
+  // CHECK-NEXT: unconditional_checked_cast_addr take_always S in [[COPY]] : $*S to Base<T> & P in [[RESULT]] : $*Base<T> & P
+  let _ = s as! (Base<T> & P)
+
+  // CHECK:      [[COPY:%.*]] = alloc_stack $S
+  // CHECK-NEXT: copy_addr %0 to [initialization] [[COPY]] : $*S
+  // CHECK-NEXT: [[RESULT:%.*]] = alloc_stack $Base<Int> & P
+  // CHECK-NEXT: checked_cast_addr_br take_always S in [[COPY]] : $*S to Base<Int> & P in [[RESULT]] : $*Base<Int> & P
+  let _ = s as? (Base<Int> & P)
+
+  // CHECK:      [[COPY:%.*]] = alloc_stack $S
+  // CHECK-NEXT: copy_addr %0 to [initialization] [[COPY]] : $*S
+  // CHECK-NEXT: [[RESULT:%.*]] = alloc_stack $Base<Int> & P
+  // CHECK-NEXT: unconditional_checked_cast_addr take_always S in [[COPY]] : $*S to Base<Int> & P in [[RESULT]] : $*Base<Int> & P
+  let _ = s as! (Base<Int> & P)
+
+  // CHECK:      [[BORROWED:%.*]] = begin_borrow %5 : $BaseTAndP
+  // CHECK-NEXT: [[COPIED:%.*]] = copy_value [[BORROWED]] : $BaseTAndP
+  // CHECK-NEXT: checked_cast_br [[COPIED]] : $BaseTAndP to $Derived & R
+  let _ = baseTAndP_archetype as? (Derived & R)
+
+  // CHECK:      [[BORROWED:%.*]] = begin_borrow %5 : $BaseTAndP
+  // CHECK-NEXT: [[COPIED:%.*]] = copy_value [[BORROWED]] : $BaseTAndP
+  // CHECK-NEXT: unconditional_checked_cast [[COPIED]] : $BaseTAndP to $Derived & R
+  let _ = baseTAndP_archetype as! (Derived & R)
+
+  // CHECK:      [[BORROWED:%.*]] = begin_borrow %9 : $Base<T> & P
+  // CHECK-NEXT: [[COPIED:%.*]] = copy_value [[BORROWED]] : $Base<T> & P
+  // CHECK-NEXT: [[COPY:%.*]] = alloc_stack $Base<T> & P
+  // CHECK-NEXT: store [[COPIED]] to [init] [[COPY]] : $*Base<T> & P
+  // CHECK-NEXT: [[RESULT:%.*]] = alloc_stack $Optional<S>
+  // CHECK-NEXT: [[PAYLOAD:%.*]] = init_enum_data_addr [[RESULT]] : $*Optional<S>, #Optional.some
+  // CHECK-NEXT: checked_cast_addr_br take_always Base<T> & P in [[COPY]] : $*Base<T> & P to S in [[PAYLOAD]] : $*S
+  let _ = baseTAndP_concrete as? S
+
+  // CHECK:      [[COPY:%.*]] = alloc_stack $Base<T> & P
+  // CHECK-NEXT: [[BORROWED:%.*]] = begin_borrow %9 : $Base<T> & P
+  // CHECK-NEXT: [[COPIED:%.*]] = copy_value [[BORROWED]] : $Base<T> & P
+  // CHECK-NEXT: store [[COPIED]] to [init] [[COPY]] : $*Base<T> & P
+  // CHECK-NEXT: [[RESULT:%.*]] = alloc_stack $S
+  // CHECK-NEXT: unconditional_checked_cast_addr take_always Base<T> & P in [[COPY]] : $*Base<T> & P to S in [[RESULT]] : $*S
+  let _ = baseTAndP_concrete as! S
+
+  // CHECK:      [[BORROWED:%.*]] = begin_borrow %9 : $Base<T> & P
+  // CHECK-NEXT: [[COPIED:%.*]] = copy_value [[BORROWED]] : $Base<T> & P
+  // CHECK-NEXT: checked_cast_br [[COPIED]] : $Base<T> & P to $BaseT
+  let _ = baseTAndP_concrete as? BaseT
+
+  // CHECK:      [[BORROWED:%.*]] = begin_borrow %9 : $Base<T> & P
+  // CHECK-NEXT: [[COPIED:%.*]] = copy_value [[BORROWED]] : $Base<T> & P
+  // CHECK-NEXT: unconditional_checked_cast [[COPIED]] : $Base<T> & P to $BaseT
+  let _ = baseTAndP_concrete as! BaseT
+
+  // CHECK:      [[BORROWED:%.*]] = begin_borrow %9 : $Base<T> & P
+  // CHECK-NEXT: [[COPIED:%.*]] = copy_value [[BORROWED]] : $Base<T> & P
+  // CHECK-NEXT: checked_cast_br [[COPIED]] : $Base<T> & P to $BaseInt
+  let _ = baseTAndP_concrete as? BaseInt
+
+  // CHECK:      [[BORROWED:%.*]] = begin_borrow %9 : $Base<T> & P
+  // CHECK-NEXT: [[COPIED:%.*]] = copy_value [[BORROWED]] : $Base<T> & P
+  // CHECK-NEXT: unconditional_checked_cast [[COPIED]] : $Base<T> & P to $BaseInt
+  let _ = baseTAndP_concrete as! BaseInt
+
+  // CHECK:      [[BORROWED:%.*]] = begin_borrow %9 : $Base<T> & P
+  // CHECK-NEXT: [[COPIED:%.*]] = copy_value [[BORROWED]] : $Base<T> & P
+  // CHECK-NEXT: checked_cast_br [[COPIED]] : $Base<T> & P to $BaseTAndP
+  let _ = baseTAndP_concrete as? BaseTAndP
+
+  // CHECK:      [[BORROWED:%.*]] = begin_borrow %9 : $Base<T> & P
+  // CHECK-NEXT: [[COPIED:%.*]] = copy_value [[BORROWED]] : $Base<T> & P
+  // CHECK-NEXT: unconditional_checked_cast [[COPIED]] : $Base<T> & P to $BaseTAndP
+  let _ = baseTAndP_concrete as! BaseTAndP
+
+  // CHECK:      [[BORROWED:%.*]] = begin_borrow %6 : $BaseIntAndP
+  // CHECK-NEXT: [[COPIED:%.*]] = copy_value [[BORROWED]] : $BaseIntAndP
+  // CHECK-NEXT: checked_cast_br [[COPIED]] : $BaseIntAndP to $Derived & R
+  let _ = baseIntAndP_archetype as? (Derived & R)
+
+  // CHECK:      [[BORROWED:%.*]] = begin_borrow %6 : $BaseIntAndP
+  // CHECK-NEXT: [[COPIED:%.*]] = copy_value [[BORROWED]] : $BaseIntAndP
+  // CHECK-NEXT: unconditional_checked_cast [[COPIED]] : $BaseIntAndP to $Derived & R
+  let _ = baseIntAndP_archetype as! (Derived & R)
+
+  // CHECK:      [[BORROWED:%.*]] = begin_borrow %10 : $Base<Int> & P
+  // CHECK-NEXT: [[COPIED:%.*]] = copy_value [[BORROWED]] : $Base<Int> & P
+  // CHECK-NEXT: [[COPY:%.*]] = alloc_stack $Base<Int> & P
+  // CHECK-NEXT: store [[COPIED]] to [init] [[COPY]] : $*Base<Int> & P
+  // CHECK-NEXT: [[RESULT:%.*]] = alloc_stack $Optional<S>
+  // CHECK-NEXT: [[PAYLOAD:%.*]] = init_enum_data_addr [[RESULT]] : $*Optional<S>, #Optional.some
+  // CHECK-NEXT: checked_cast_addr_br take_always Base<Int> & P in [[COPY]] : $*Base<Int> & P to S in [[PAYLOAD]] : $*S
+  let _ = baseIntAndP_concrete as? S
+
+  // CHECK:      [[COPY:%.*]] = alloc_stack $Base<Int> & P
+  // CHECK-NEXT: [[BORROWED:%.*]] = begin_borrow %10 : $Base<Int> & P
+  // CHECK-NEXT: [[COPIED:%.*]] = copy_value [[BORROWED]] : $Base<Int> & P
+  // CHECK-NEXT: store [[COPIED]] to [init] [[COPY]] : $*Base<Int> & P
+  // CHECK-NEXT: [[RESULT:%.*]] = alloc_stack $S
+  // CHECK-NEXT: unconditional_checked_cast_addr take_always Base<Int> & P in [[COPY]] : $*Base<Int> & P to S in [[RESULT]] : $*S
+  let _ = baseIntAndP_concrete as! S
+
+  // CHECK:      [[BORROWED:%.*]] = begin_borrow %10 : $Base<Int> & P
+  // CHECK-NEXT: [[COPIED:%.*]] = copy_value [[BORROWED]] : $Base<Int> & P
+  // CHECK-NEXT: checked_cast_br [[COPIED]] : $Base<Int> & P to $DerivedT
+  let _ = baseIntAndP_concrete as? DerivedT
+
+  // CHECK:      [[BORROWED:%.*]] = begin_borrow %10 : $Base<Int> & P
+  // CHECK-NEXT: [[COPIED:%.*]] = copy_value [[BORROWED]] : $Base<Int> & P
+  // CHECK-NEXT: unconditional_checked_cast [[COPIED]] : $Base<Int> & P to $DerivedT
+  let _ = baseIntAndP_concrete as! DerivedT
+
+  // CHECK:      [[BORROWED:%.*]] = begin_borrow %10 : $Base<Int> & P
+  // CHECK-NEXT: [[COPIED:%.*]] = copy_value [[BORROWED]] : $Base<Int> & P
+  // CHECK-NEXT: checked_cast_br [[COPIED]] : $Base<Int> & P to $BaseT
+  let _ = baseIntAndP_concrete as? BaseT
+
+  // CHECK:      [[BORROWED:%.*]] = begin_borrow %10 : $Base<Int> & P
+  // CHECK-NEXT: [[COPIED:%.*]] = copy_value [[BORROWED]] : $Base<Int> & P
+  // CHECK-NEXT: unconditional_checked_cast [[COPIED]] : $Base<Int> & P to $BaseT
+  let _ = baseIntAndP_concrete as! BaseT
+
+  // CHECK:      [[BORROWED:%.*]] = begin_borrow %10 : $Base<Int> & P
+  // CHECK-NEXT: [[COPIED:%.*]] = copy_value [[BORROWED]] : $Base<Int> & P
+  // CHECK-NEXT: checked_cast_br [[COPIED]] : $Base<Int> & P to $BaseInt
+  let _ = baseIntAndP_concrete as? BaseInt
+
+  // CHECK:      [[BORROWED:%.*]] = begin_borrow %10 : $Base<Int> & P
+  // CHECK-NEXT: [[COPIED:%.*]] = copy_value [[BORROWED]] : $Base<Int> & P
+  // CHECK-NEXT: unconditional_checked_cast [[COPIED]] : $Base<Int> & P to $BaseInt
+  let _ = baseIntAndP_concrete as! BaseInt
+
+  // CHECK:      [[BORROWED:%.*]] = begin_borrow %10 : $Base<Int> & P
+  // CHECK-NEXT: [[COPIED:%.*]] = copy_value [[BORROWED]] : $Base<Int> & P
+  // CHECK-NEXT: checked_cast_br [[COPIED]] : $Base<Int> & P to $BaseTAndP
+  let _ = baseIntAndP_concrete as? BaseTAndP
+
+  // CHECK:      [[BORROWED:%.*]] = begin_borrow %10 : $Base<Int> & P
+  // CHECK-NEXT: [[COPIED:%.*]] = copy_value [[BORROWED]] : $Base<Int> & P
+  // CHECK-NEXT: unconditional_checked_cast [[COPIED]] : $Base<Int> & P to $BaseTAndP
+  let _ = baseIntAndP_concrete as! BaseTAndP
+
+  // CHECK:      return
+  // CHECK-NEXT: }
 }

--- a/test/type/subclass_composition.swift
+++ b/test/type/subclass_composition.swift
@@ -335,9 +335,25 @@ func metatypeSubtyping(
   let _: Derived.Type = derivedAndAnyObject
   let _: BaseAndP2<Int>.Type = baseIntAndP2AndAnyObject
 
+  let _ = baseIntAndP2 as Base<Int>.Type
+  let _ = baseIntAndP2AndAnyObject as Base<Int>.Type
+  let _ = derivedAndAnyObject as Derived.Type
+  let _ = baseIntAndP2AndAnyObject as BaseAndP2<Int>.Type
+
+  let _ = baseIntAndP2 as? Base<Int>.Type // expected-warning {{always succeeds}}
+  let _ = baseIntAndP2AndAnyObject as? Base<Int>.Type // expected-warning {{always succeeds}}
+  let _ = derivedAndAnyObject as? Derived.Type // expected-warning {{always succeeds}}
+  let _ = baseIntAndP2AndAnyObject as? BaseAndP2<Int>.Type // expected-warning {{always succeeds}}
+
   // Upcast
   let _: BaseAndP2<Int>.Type = derived
   let _: BaseAndP2<Int>.Type = derivedAndAnyObject
+
+  let _ = derived as BaseAndP2<Int>.Type
+  let _ = derivedAndAnyObject as BaseAndP2<Int>.Type
+
+  let _ = derived as? BaseAndP2<Int>.Type // expected-warning {{always succeeds}}
+  let _ = derivedAndAnyObject as? BaseAndP2<Int>.Type // expected-warning {{always succeeds}}
 
   // Erasing superclass constraint
   let _: P2.Type = baseIntAndP2
@@ -345,6 +361,18 @@ func metatypeSubtyping(
   let _: P2.Type = derivedAndAnyObject
   let _: (P2 & AnyObject).Type = derived
   let _: (P2 & AnyObject).Type = derivedAndAnyObject
+
+  let _ = baseIntAndP2 as P2.Type
+  let _ = derived as P2.Type
+  let _ = derivedAndAnyObject as P2.Type
+  let _ = derived as (P2 & AnyObject).Type
+  let _ = derivedAndAnyObject as (P2 & AnyObject).Type
+
+  let _ = baseIntAndP2 as? P2.Type // expected-warning {{always succeeds}}
+  let _ = derived as? P2.Type // expected-warning {{always succeeds}}
+  let _ = derivedAndAnyObject as? P2.Type // expected-warning {{always succeeds}}
+  let _ = derived as? (P2 & AnyObject).Type // expected-warning {{always succeeds}}
+  let _ = derivedAndAnyObject as? (P2 & AnyObject).Type // expected-warning {{always succeeds}}
 
   // Initializers
   let _: Base<Int> & P2 = baseIntAndP2.init(classInit: ())

--- a/test/type/subclass_composition.swift
+++ b/test/type/subclass_composition.swift
@@ -71,6 +71,16 @@ func basicDiagnostics(
   // Valid typealias case
   _: OtherAndP2 & P3) {}
 
+// A composition containing only a single class is actually identical to
+// the class type itself.
+struct Box<T : Base<Int>> {}
+
+func takesBox(_: Box<Base<Int>>) {}
+
+func passesBox(_ b: Box<Base<Int> & Base<Int>>) {
+  takesBox(b)
+}
+
 // Test that subtyping behaves as you would expect.
 func basicSubtyping(
   base: Base<Int>,

--- a/test/type/subclass_composition_objc.swift
+++ b/test/type/subclass_composition_objc.swift
@@ -58,3 +58,12 @@ func testSelfConformance(cp: ObjCClass & StaticObjCProtocol) {
   // expected-note@-2 {{expected an argument list of type '(T)'}}
 
 }
+
+func testMetatypeSelfConformance(m1: (ObjCClass & ObjCProtocol).Protocol,
+                                 m2: (ObjCClass & StaticObjCProtocol).Protocol) {
+  _ = m1 as (ObjCClass & ObjCProtocol).Type
+  _ = m1 as? (ObjCClass & ObjCProtocol).Type // expected-warning {{always succeeds}}
+
+  _ = m2 as (ObjCClass & StaticObjCProtocol).Type // expected-error {{'(ObjCClass & StaticObjCProtocol).Protocol' is not convertible to '(ObjCClass & StaticObjCProtocol).Type'; did you mean to use 'as!' to force downcast?}}
+  _ = m2 as? (ObjCClass & StaticObjCProtocol).Type // FIXME should 'always fail'
+}

--- a/unittests/runtime/Metadata.cpp
+++ b/unittests/runtime/Metadata.cpp
@@ -402,6 +402,8 @@ TEST(MetadataTest, getExistentialMetadata) {
       EXPECT_EQ(0U, any->Protocols.NumProtocols);
       EXPECT_EQ(SpecialProtocol::None,
                 any->Flags.getSpecialProtocol());
+      EXPECT_EQ(nullptr,
+                any->getSuperclassConstraint());
       return any;
     });
 
@@ -420,6 +422,8 @@ TEST(MetadataTest, getExistentialMetadata) {
       EXPECT_EQ(&ProtocolA, a->Protocols[0]);
       EXPECT_EQ(SpecialProtocol::None,
                 a->Flags.getSpecialProtocol());
+      EXPECT_EQ(nullptr,
+                a->getSuperclassConstraint());
       return a;
     });
 
@@ -439,6 +443,8 @@ TEST(MetadataTest, getExistentialMetadata) {
       EXPECT_EQ(&ProtocolB, b->Protocols[0]);
       EXPECT_EQ(SpecialProtocol::None,
                 b->Flags.getSpecialProtocol());
+      EXPECT_EQ(nullptr,
+                b->getSuperclassConstraint());
       return b;
     });
 
@@ -472,8 +478,8 @@ TEST(MetadataTest, getExistentialMetadata) {
         || (ab->Protocols[0]==&ProtocolB && ab->Protocols[1]==&ProtocolA));
       EXPECT_EQ(SpecialProtocol::None,
                 ab->Flags.getSpecialProtocol());
-      EXPECT_EQ(SpecialProtocol::None,
-                ba->Flags.getSpecialProtocol());
+      EXPECT_EQ(nullptr,
+                ab->getSuperclassConstraint());
       return ab;
     });
 
@@ -494,6 +500,8 @@ TEST(MetadataTest, getExistentialMetadata) {
       EXPECT_EQ(SpecialProtocol::None,
                 classConstrained->Flags.getSpecialProtocol());
       EXPECT_EQ(&ProtocolClassConstrained, classConstrained->Protocols[0]);
+      EXPECT_EQ(nullptr,
+                classConstrained->getSuperclassConstraint());
       return classConstrained;
     });
 
@@ -514,6 +522,8 @@ TEST(MetadataTest, getExistentialMetadata) {
       EXPECT_EQ(SpecialProtocol::None,
                 noWitnessTable->Flags.getSpecialProtocol());
       EXPECT_EQ(&ProtocolNoWitnessTable, noWitnessTable->Protocols[0]);
+      EXPECT_EQ(nullptr,
+                noWitnessTable->getSuperclassConstraint());
       return noWitnessTable;
     });
 
@@ -536,6 +546,8 @@ TEST(MetadataTest, getExistentialMetadata) {
       EXPECT_EQ(3U, mixedWitnessTable->Protocols.NumProtocols);
       EXPECT_EQ(SpecialProtocol::None,
                 mixedWitnessTable->Flags.getSpecialProtocol());
+      EXPECT_EQ(nullptr,
+                mixedWitnessTable->getSuperclassConstraint());
       return mixedWitnessTable;
     });
   
@@ -561,6 +573,8 @@ TEST(MetadataTest, getExistentialMetadata) {
                 special->Flags.getSpecialProtocol());
       EXPECT_EQ(ExpectedErrorValueWitnesses,
                 special->getValueWitnesses());
+      EXPECT_EQ(nullptr,
+                special->getSuperclassConstraint());
       return special;
     });
 
@@ -582,6 +596,8 @@ TEST(MetadataTest, getExistentialMetadata) {
                 special->Flags.getSpecialProtocol());
       EXPECT_NE(ExpectedErrorValueWitnesses,
                 special->getValueWitnesses());
+      EXPECT_EQ(nullptr,
+                special->getSuperclassConstraint());
       return special;
     });
 }
@@ -710,6 +726,8 @@ TEST(MetadataTest, getExistentialTypeMetadata_opaque) {
       EXPECT_EQ(alignof(void*), ex1->getValueWitnesses()->getAlignment());
       EXPECT_FALSE(ex1->getValueWitnesses()->isPOD());
       EXPECT_FALSE(ex1->getValueWitnesses()->isBitwiseTakable());
+      EXPECT_EQ(nullptr,
+                ex1->getSuperclassConstraint());
       return ex1;
     });
 
@@ -726,6 +744,8 @@ TEST(MetadataTest, getExistentialTypeMetadata_opaque) {
       EXPECT_EQ(alignof(void*), ex2->getValueWitnesses()->getAlignment());
       EXPECT_FALSE(ex2->getValueWitnesses()->isPOD());
       EXPECT_FALSE(ex2->getValueWitnesses()->isBitwiseTakable());
+      EXPECT_EQ(nullptr,
+                ex2->getSuperclassConstraint());
       return ex2;
     });
 
@@ -742,6 +762,8 @@ TEST(MetadataTest, getExistentialTypeMetadata_opaque) {
       EXPECT_EQ(alignof(void*), ex3->getValueWitnesses()->getAlignment());
       EXPECT_FALSE(ex3->getValueWitnesses()->isPOD());
       EXPECT_FALSE(ex3->getValueWitnesses()->isBitwiseTakable());
+      EXPECT_EQ(nullptr,
+                ex3->getSuperclassConstraint());
       return ex3;
     });
 }
@@ -760,6 +782,8 @@ TEST(MetadataTest, getExistentialTypeMetadata_class) {
       EXPECT_EQ(alignof(void*), ex1->getValueWitnesses()->getAlignment());
       EXPECT_FALSE(ex1->getValueWitnesses()->isPOD());
       EXPECT_TRUE(ex1->getValueWitnesses()->isBitwiseTakable());
+      EXPECT_EQ(nullptr,
+                ex1->getSuperclassConstraint());
       return ex1;
     });
 
@@ -776,6 +800,8 @@ TEST(MetadataTest, getExistentialTypeMetadata_class) {
       EXPECT_EQ(alignof(void*), ex2->getValueWitnesses()->getAlignment());
       EXPECT_FALSE(ex2->getValueWitnesses()->isPOD());
       EXPECT_TRUE(ex2->getValueWitnesses()->isBitwiseTakable());
+      EXPECT_EQ(nullptr,
+                ex2->getSuperclassConstraint());
       return ex2;
     });
 
@@ -792,7 +818,58 @@ TEST(MetadataTest, getExistentialTypeMetadata_class) {
       EXPECT_EQ(alignof(void*), ex3->getValueWitnesses()->getAlignment());
       EXPECT_FALSE(ex3->getValueWitnesses()->isPOD());
       EXPECT_TRUE(ex3->getValueWitnesses()->isBitwiseTakable());
+      EXPECT_EQ(nullptr,
+                ex3->getSuperclassConstraint());
       return ex3;
+    });
+}
+
+TEST(MetadataTest, getExistentialTypeMetadata_subclass) {
+  RaceTest_ExpectEqual<const ExistentialTypeMetadata *>(
+    [&]() -> const ExistentialTypeMetadata * {
+      const ProtocolDescriptor *protoList1[] = {
+        &OpaqueProto1
+      };
+      auto ex1 = swift_getExistentialTypeMetadata(ProtocolClassConstraint::Class,
+                                                  /*superclass=*/&MetadataTest2,
+                                                  1, protoList1);
+      EXPECT_EQ(MetadataKind::Existential, ex1->getKind());
+      EXPECT_EQ(2 * sizeof(void*), ex1->getValueWitnesses()->getSize());
+      EXPECT_EQ(alignof(void*), ex1->getValueWitnesses()->getAlignment());
+      EXPECT_FALSE(ex1->getValueWitnesses()->isPOD());
+      EXPECT_TRUE(ex1->getValueWitnesses()->isBitwiseTakable());
+      EXPECT_EQ(ProtocolClassConstraint::Class,
+                ex1->Flags.getClassConstraint());
+      EXPECT_EQ(1U, ex1->Protocols.NumProtocols);
+      EXPECT_EQ(&OpaqueProto1, ex1->Protocols[0]);
+      EXPECT_EQ(&MetadataTest2, ex1->getSuperclassConstraint());
+      return ex1;
+    });
+
+
+  RaceTest_ExpectEqual<const ExistentialTypeMetadata *>(
+    [&]() -> const ExistentialTypeMetadata * {
+      const ProtocolDescriptor *protoList2[] = {
+        &OpaqueProto1,
+        &ClassProto1
+      };
+      auto ex2 = swift_getExistentialTypeMetadata(ProtocolClassConstraint::Class,
+                                                  /*superclass=*/&MetadataTest2,
+                                                  2, protoList2);
+      EXPECT_EQ(MetadataKind::Existential, ex2->getKind());
+      EXPECT_EQ(3 * sizeof(void*), ex2->getValueWitnesses()->getSize());
+      EXPECT_EQ(alignof(void*), ex2->getValueWitnesses()->getAlignment());
+      EXPECT_FALSE(ex2->getValueWitnesses()->isPOD());
+      EXPECT_TRUE(ex2->getValueWitnesses()->isBitwiseTakable());
+      EXPECT_EQ(ProtocolClassConstraint::Class,
+                ex2->Flags.getClassConstraint());
+      EXPECT_EQ(2U, ex2->Protocols.NumProtocols);
+      EXPECT_TRUE((ex2->Protocols[0] == &OpaqueProto1 &&
+                   ex2->Protocols[1] == &ClassProto1) ||
+                  (ex2->Protocols[0] == &ClassProto1 &&
+                   ex2->Protocols[1] == &OpaqueProto1));
+      EXPECT_EQ(&MetadataTest2, ex2->getSuperclassConstraint());
+      return ex2;
     });
 }
 


### PR DESCRIPTION
Builds upon https://github.com/apple/swift/pull/8876 and https://github.com/apple/swift/pull/8788.

- Runtime metadata instantiation for subclass existentials
- Scalar downcasts
- More tests, mainly casts

Next up: dynamic casts.