### PR TITLE
[AST] Fix use-after-free due to a rogue getPointer().

### DIFF
--- a/lib/AST/ConformanceLookupTable.cpp
+++ b/lib/AST/ConformanceLookupTable.cpp
@@ -809,8 +809,7 @@ ProtocolConformance *ConformanceLookupTable::getConformance(
     ModuleDecl *module = entry->getDeclContext()->getParentModule();
     auto inheritedConformance = module->lookupConformance(superclassTy,
                                                           protocol,
-                                                          resolver)
-                                  .getPointer();
+                                                          resolver);
 
     // Form the inherited conformance.
     conformance = ctx.getInheritedConformance(


### PR DESCRIPTION
ASan found this amusing stack-use-after-scope problem in the AST
that's been around for a long while. It was introduced when
`ModuleDecl::lookupConformance()` changed from returning an

    llvm::PointerIntPair<ProtocolConformance *, 2>

to an

    Optional<ProtocolConformanceRef>

In the former, `getPointer()` grabbed the `ProtocolConformance*`, which
was fine. In the latter, it produced a `ProtocolConformanceRef*`
pointing into a temporary value.

Fixes rdar://problem/31708629.
