### PR TITLE
[stdlib/resilience] Mark FixedWidthInteger.bitwidth as inlinable

### DIFF
--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -2172,6 +2172,7 @@ extension FixedWidthInteger {
   @available(swift, deprecated: 3.1, obsoleted: 4.0, message: "Use 0")
   public static var allZeros: Self { return 0 }
 
+  @_inlineable
   public var bitWidth: Int { return Self.bitWidth }
 
 }


### PR DESCRIPTION
Fixes test/IRGen/enum_derived.swift test case in resilient mode.

rdar://31757974