### PR TITLE
[NFC] Remove ClangImporter tests' dependence on IDE's tests

### DIFF
--- a/test/ClangImporter/Inputs/custom-modules/ImportAsMember.apinotes
+++ b/test/ClangImporter/Inputs/custom-modules/ImportAsMember.apinotes
@@ -1,0 +1,29 @@
+Name: ImportAsMember
+Globals:
+- Name: IAMStruct1APINoteVar
+  SwiftName: Struct1.newApiNoteVar
+- Name: IAMStruct1APINoteVarInSwift4
+  SwiftName: Struct1.apiNoteVarInSwift4
+Functions:
+- Name: IAMStruct1APINoteFunction
+  SwiftName: "Struct1.newApiNoteMethod()"
+- Name: IAMStruct1APINoteCreateFunction
+  SwiftName: "Struct1.init(newLabel:)"
+Typedefs:
+- Name: IAMStruct1APINoteType
+  SwiftName: Struct1.NewApiNoteType
+SwiftVersions:
+- Version: 3
+  Globals:
+  - Name: IAMStruct1APINoteVar
+    SwiftName: Struct1.oldApiNoteVar
+  - Name: IAMStruct1APINoteVarInSwift4
+    SwiftName: IAMStruct1APINoteVarInSwift4
+  Functions:
+  - Name: IAMStruct1APINoteFunction
+    SwiftName: "Struct1.oldApiNoteMethod()"
+  - Name: IAMStruct1APINoteCreateFunction
+    SwiftName: "Struct1.init(oldLabel:)"
+  Typedefs:
+  - Name: IAMStruct1APINoteType
+    SwiftName: Struct1.OldApiNoteType

--- a/test/ClangImporter/Inputs/custom-modules/ImportAsMember.h
+++ b/test/ClangImporter/Inputs/custom-modules/ImportAsMember.h
@@ -1,0 +1,60 @@
+#ifndef IMPORT_AS_MEMBER_H
+#define IMPORT_AS_MEMBER_H
+
+struct __attribute__((swift_name("Struct1"))) IAMStruct1 {
+  double x, y, z;
+};
+
+extern double IAMStruct1GlobalVar
+    __attribute__((swift_name("Struct1.globalVar")));
+
+extern struct IAMStruct1 IAMStruct1CreateSimple(double value)
+    __attribute__((swift_name("Struct1.init(value:)")));
+
+extern struct IAMStruct1 IAMStruct1CreateSpecialLabel(void)
+    __attribute__((swift_name("Struct1.init(specialLabel:)")));
+
+extern struct IAMStruct1 IAMStruct1Invert(struct IAMStruct1 s)
+    __attribute__((swift_name("Struct1.inverted(self:)")));
+
+extern void IAMStruct1InvertInPlace(struct IAMStruct1 *s)
+    __attribute__((swift_name("Struct1.invert(self:)")));
+
+extern struct IAMStruct1 IAMStruct1Rotate(const struct IAMStruct1 *s,
+                                          double radians)
+    __attribute__((swift_name("Struct1.translate(self:radians:)")));
+
+extern struct IAMStruct1 IAMStruct1Scale(struct IAMStruct1 s,
+                                         double radians)
+    __attribute__((swift_name("Struct1.scale(self:_:)")));
+
+extern double IAMStruct1GetRadius(const struct IAMStruct1 *s)
+    __attribute__((swift_name("getter:Struct1.radius(self:)")));
+
+extern void IAMStruct1SetRadius(struct IAMStruct1 s, double radius)
+    __attribute__((swift_name("setter:Struct1.radius(self:_:)")));
+
+extern double IAMStruct1GetAltitude(struct IAMStruct1 s)
+    __attribute__((swift_name("getter:Struct1.altitude(self:)")));
+
+extern void IAMStruct1SetAltitude(struct IAMStruct1 *s, double altitude)
+    __attribute__((swift_name("setter:Struct1.altitude(self:_:)")));
+
+extern double IAMStruct1GetMagnitude(struct IAMStruct1 s)
+    __attribute__((swift_name("getter:Struct1.magnitude(self:)")));
+
+extern int IAMStruct1StaticMethod(void)
+    __attribute__((swift_name("Struct1.staticMethod()")));
+extern int IAMStruct1StaticGetProperty(void)
+    __attribute__((swift_name("getter:Struct1.property()")));
+extern int IAMStruct1StaticSetProperty(int i)
+    __attribute__((swift_name("setter:Struct1.property(i:)")));
+extern int IAMStruct1StaticGetOnlyProperty(void)
+    __attribute__((swift_name("getter:Struct1.getOnlyProperty()")));
+
+extern void IAMStruct1SelfComesLast(double x, struct IAMStruct1 s)
+    __attribute__((swift_name("Struct1.selfComesLast(x:self:)")));
+extern void IAMStruct1SelfComesThird(int a, float b, struct IAMStruct1 s, double x)
+    __attribute__((swift_name("Struct1.selfComesThird(a:b:self:x:)")));
+
+#endif // IMPORT_AS_MEMBER_H

--- a/test/ClangImporter/Inputs/custom-modules/Newtype.h
+++ b/test/ClangImporter/Inputs/custom-modules/Newtype.h
@@ -1,4 +1,104 @@
 @import Foundation;
+@import CoreFoundation;
 
-typedef NSString *__nonnull SNTErrorDomain __attribute((swift_newtype(struct)));
-typedef NSInteger MyInt __attribute((swift_newtype(struct)));
+typedef NSString *__nonnull SNTErrorDomain __attribute((swift_newtype(struct)))
+__attribute((swift_name("ErrorDomain")));
+
+extern void SNTErrorDomainProcess(SNTErrorDomain d)
+    __attribute((swift_name("ErrorDomain.process(self:)")));
+
+typedef struct {} Food;
+
+extern const SNTErrorDomain SNTErrOne
+    __attribute((swift_name("ErrorDomain.one")));
+extern const SNTErrorDomain SNTErrTwo;
+extern const SNTErrorDomain SNTErrorDomainThree;
+extern const SNTErrorDomain SNTFourErrorDomain;
+extern const SNTErrorDomain SNTFive
+    __attribute((swift_name("stillAMember")));
+extern const SNTErrorDomain SNTElsewhere
+    __attribute((swift_name("Food.err")));
+
+typedef NSString *__nullable SNTClosedEnum __attribute((swift_newtype(enum)))
+__attribute((swift_name("ClosedEnum")));
+
+extern const SNTClosedEnum SNTFirstClosedEntryEnum;
+extern const SNTClosedEnum SNTSecondEntry;
+extern const SNTClosedEnum SNTClosedEnumThirdEntry;
+
+typedef NSString * IUONewtype __attribute((swift_newtype(struct)));
+
+typedef float MyFloat __attribute((swift_newtype(struct)));
+extern const MyFloat globalFloat;
+extern const MyFloat kPI;
+extern const MyFloat kVersion;
+
+typedef int MyInt __attribute((swift_newtype(struct)));
+extern const MyInt kMyIntZero;
+extern const MyInt kMyIntOne;
+extern const int kRawInt;
+extern void takesMyInt(MyInt);
+
+typedef NSString * NSURLResourceKey __attribute((swift_newtype(struct)));
+extern NSURLResourceKey const NSURLIsRegularFileKey;
+extern NSURLResourceKey const NSURLIsDirectoryKey;
+extern NSURLResourceKey const NSURLLocalizedNameKey;
+
+// Special case: Notifications
+extern const NSString *FooNotification;
+extern const NSString *kBarNotification;
+extern const NSString *NSWibbleNotification;
+
+// But not just 'Notification'
+extern const NSString *kNotification;
+extern const NSString *Notification;
+
+// Nor when explicitly swift_name-ed
+extern const NSString *kSNNotification
+    __attribute((swift_name("swiftNamedNotification")));
+
+// Test CFStringRef
+typedef CFStringRef CFNewType __attribute((swift_newtype(struct)));
+
+// CF audited
+_Pragma("clang arc_cf_code_audited begin")
+extern const CFNewType MyCFNewTypeValue;
+extern CFNewType FooAudited(void);
+_Pragma("clang arc_cf_code_audited end")
+extern const CFNewType MyCFNewTypeValueUnauditedButConst;
+
+// un-audited CFStringRef
+extern CFNewType MyCFNewTypeValueUnaudited;
+extern CFNewType FooUnaudited(void);
+
+// Tests to show identical calling convention / binary representation for
+// new_type and non-new_type
+typedef CFStringRef MyABINewType __attribute((swift_newtype(struct)));
+typedef CFStringRef MyABIOldType;
+_Pragma("clang arc_cf_code_audited begin")
+extern const MyABINewType kMyABINewTypeGlobal;
+extern const MyABIOldType kMyABIOldTypeGlobal;
+extern MyABINewType getMyABINewType(void);
+extern MyABIOldType getMyABIOldType(void);
+extern void takeMyABINewType(MyABINewType);
+extern void takeMyABIOldType(MyABIOldType);
+
+extern void takeMyABINewTypeNonNull(__nonnull MyABINewType);
+extern void takeMyABIOldTypeNonNull(__nonnull MyABIOldType);
+_Pragma("clang arc_cf_code_audited end")
+
+typedef NSString *MyABINewTypeNS __attribute((swift_newtype(struct)));
+typedef NSString *MyABIOldTypeNS;
+extern MyABINewTypeNS getMyABINewTypeNS(void);
+extern MyABIOldTypeNS getMyABIOldTypeNS(void);
+extern void takeMyABINewTypeNonNullNS(__nonnull MyABINewTypeNS);
+extern void takeMyABIOldTypeNonNullNS(__nonnull MyABIOldTypeNS);
+
+// Nested types
+typedef struct {int i;} NSSomeContext;
+
+typedef NSString *NSSomeContextName __attribute((swift_newtype(struct)))
+__attribute((swift_name("NSSomeContext.Name")));
+
+extern const NSSomeContextName NSMyContextName;
+

--- a/test/ClangImporter/Inputs/custom-modules/module.map
+++ b/test/ClangImporter/Inputs/custom-modules/module.map
@@ -77,6 +77,14 @@ module Newtype {
   header "Newtype.h"
 }
 
+module ImportAsMember {
+  export *
+
+  module A {
+    header "ImportAsMember.h"
+  }
+}
+
 module ObjCIRExtras {
   header "ObjCIRExtras.h"
   export *

--- a/test/ClangImporter/objc_parse.swift
+++ b/test/ClangImporter/objc_parse.swift
@@ -624,8 +624,8 @@ func testNSUInteger(_ obj: NSUIntegerTests, uint: UInt, int: Int) {
 }
 
 class NewtypeUser {
-  @objc func stringNewtype(a: SNTErrorDomain) {}
-  @objc func stringNewtypeOptional(a: SNTErrorDomain?) {}
+  @objc func stringNewtype(a: SNTErrorDomain) {} // expected-error {{'SNTErrorDomain' has been renamed to 'ErrorDomain'}}{{31-45=ErrorDomain}}
+  @objc func stringNewtypeOptional(a: SNTErrorDomain?) {} // expected-error {{'SNTErrorDomain' has been renamed to 'ErrorDomain'}}{{39-53=ErrorDomain}}
   @objc func intNewtype(a: MyInt) {}
   @objc func intNewtypeOptional(a: MyInt?) {} // expected-error {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
 }

--- a/test/ClangImporter/swift2_warnings.swift
+++ b/test/ClangImporter/swift2_warnings.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk -I %S/../IDE/Inputs/custom-modules) -emit-sil -I %S/Inputs/custom-modules %s -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-sil -I %S/Inputs/custom-modules %s -verify
 
 // REQUIRES: objc_interop
 


### PR DESCRIPTION
Caught while testing the space engine.  If this import is present in the module map it causes the import in `swift2_warnings` to fail with a conflict between the IDE tests and the clang importer tests.   I took the header that seemed more complete (the IDE tests), but let me know if I should do the opposite and take the other header.