### PR TITLE
[4.0] Collected fixes

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5308,6 +5308,10 @@ public:
 
   /// True if the function is a defer body.
   bool isDeferBody() const;
+
+  /// Perform basic checking to determine whether the @IBAction attribute can
+  /// be applied to this function.
+  bool isPotentialIBActionTarget() const;
 };
   
 /// \brief This represents a 'case' declaration in an 'enum', which may declare

--- a/lib/AST/ConformanceLookupTable.cpp
+++ b/lib/AST/ConformanceLookupTable.cpp
@@ -809,8 +809,7 @@ ProtocolConformance *ConformanceLookupTable::getConformance(
     ModuleDecl *module = entry->getDeclContext()->getParentModule();
     auto inheritedConformance = module->lookupConformance(superclassTy,
                                                           protocol,
-                                                          resolver)
-                                  .getPointer();
+                                                          resolver);
 
     // Form the inherited conformance.
     conformance = ctx.getInheritedConformance(

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5111,6 +5111,12 @@ bool FuncDecl::isDeferBody() const {
   return getName() == getASTContext().getIdentifier("$defer");
 }
 
+bool FuncDecl::isPotentialIBActionTarget() const {
+  return isInstanceMember() &&
+    getDeclContext()->getAsClassOrClassExtensionContext() &&
+    !isAccessor();
+}
+
 Type TypeBase::getSwiftNewtypeUnderlyingType() {
   auto structDecl = getStructOrBoundGenericStruct();
   if (!structDecl)

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3703,9 +3703,12 @@ namespace {
       }
 
       // Handle attributes.
-      if (decl->hasAttr<clang::IBActionAttr>())
+      if (decl->hasAttr<clang::IBActionAttr>() &&
+          isa<FuncDecl>(result) &&
+          cast<FuncDecl>(result)->isPotentialIBActionTarget()) {
         result->getAttrs().add(
             new (Impl.SwiftContext) IBActionAttr(/*IsImplicit=*/false));
+      }
 
       // Check whether there's some special method to import.
       if (!forceClassMethod) {

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -42,8 +42,19 @@ public:
   /// This emits a diagnostic with a fixit to remove the attribute.
   template<typename ...ArgTypes>
   void diagnoseAndRemoveAttr(DeclAttribute *attr, ArgTypes &&...Args) {
-    TC.diagnose(attr->getLocation(), std::forward<ArgTypes>(Args)...)
-      .fixItRemove(attr->getRangeWithAt());
+    assert(!D->hasClangNode() && "Clang imported propagated a bogus attribute");
+    if (!D->hasClangNode()) {
+      SourceLoc loc = attr->getLocation();
+      assert(loc.isValid() && "Diagnosing attribute with invalid location");
+      if (loc.isInvalid()) {
+        loc = D->getLoc();
+      }
+      if (loc.isValid()) {
+        TC.diagnose(loc, std::forward<ArgTypes>(Args)...)
+          .fixItRemove(attr->getRangeWithAt());
+      }
+    }
+
     attr->setInvalid();
   }
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -304,10 +304,8 @@ void AttributeEarlyChecker::visitDynamicAttr(DynamicAttr *attr) {
 void AttributeEarlyChecker::visitIBActionAttr(IBActionAttr *attr) {
   // Only instance methods returning () can be IBActions.
   const FuncDecl *FD = cast<FuncDecl>(D);
-  if (!FD->getDeclContext()->getAsClassOrClassExtensionContext() ||
-      FD->isStatic() || FD->isAccessor())
+  if (!FD->isPotentialIBActionTarget())
     return diagnoseAndRemoveAttr(attr, diag::invalid_ibaction_decl);
-
 }
 
 void AttributeEarlyChecker::visitIBDesignableAttr(IBDesignableAttr *attr) {

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1627,7 +1627,7 @@ void AttributeChecker::visitSpecializeAttr(SpecializeAttr *attr) {
 
   // Form a new generic signature based on the old one.
   GenericSignatureBuilder Builder(D->getASTContext(),
-                           LookUpConformanceInModule(DC->getParentModule()));
+                                  TypeChecker::LookUpConformance(TC, DC));
 
   // First, add the old generic signature.
   Builder.addGenericSignature(genericSig);

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -797,8 +797,7 @@ TypeChecker::validateGenericFuncSignature(AbstractFunctionDecl *func) {
   addGenericParamTypes(gp, allGenericParams);
 
   // Create the generic signature builder.
-  GenericSignatureBuilder builder(Context,
-                           LookUpConformanceInModule(func->getParentModule()));
+  GenericSignatureBuilder builder(Context, LookUpConformance(*this, func));
 
   // Type check the function declaration, treating all generic type
   // parameters as dependent, unresolved.
@@ -1028,8 +1027,7 @@ TypeChecker::validateGenericSubscriptSignature(SubscriptDecl *subscript) {
   addGenericParamTypes(gp, allGenericParams);
 
   // Create the generic signature builder.
-  GenericSignatureBuilder builder(Context,
-                       LookUpConformanceInModule(subscript->getParentModule()));
+  GenericSignatureBuilder builder(Context, LookUpConformance(*this, subscript));
 
   // Type check the function declaration, treating all generic type
   // parameters as dependent, unresolved.
@@ -1148,7 +1146,7 @@ GenericEnvironment *TypeChecker::checkGenericEnvironment(
 
   // Create the generic signature builder.
   ModuleDecl *module = dc->getParentModule();
-  GenericSignatureBuilder builder(Context, LookUpConformanceInModule(module));
+  GenericSignatureBuilder builder(Context, LookUpConformance(*this, dc));
 
   // Type check the generic parameters, treating all generic type
   // parameters as dependent, unresolved.

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -997,12 +997,13 @@ RequirementEnvironment::RequirementEnvironment(
   auto selfType = cast<GenericTypeParamType>(
                             proto->getSelfInterfaceType()->getCanonicalType());
 
-  // Construct a generic signature builder by collecting the constraints from the
-  // requirement and the context of the conformance together, because both
-  // define the capabilities of the requirement.
+  // Construct a generic signature builder by collecting the constraints
+  // from the requirement and the context of the conformance together,
+  // because both define the capabilities of the requirement.
   GenericSignatureBuilder builder(
            ctx,
-           LookUpConformanceInModule(conformanceDC->getParentModule()));
+           TypeChecker::LookUpConformance(tc, conformanceDC));
+
   SmallVector<GenericTypeParamType*, 4> allGenericParams;
 
   // Add the generic signature of the context of the conformance. This includes
@@ -4776,8 +4777,7 @@ void ConformanceChecker::ensureRequirementsAreSatisfied() {
       // FIXME: maybe this should be the conformance's type
       proto->getDeclaredInterfaceType(), reqSig,
       QuerySubstitutionMap{substitutions},
-      LookUpConformanceInModule(
-        Conformance->getDeclContext()->getParentModule()),
+      TypeChecker::LookUpConformance(TC, Conformance->getDeclContext()),
       nullptr,
       ConformanceCheckFlags::Used, &listener);
 
@@ -5266,6 +5266,21 @@ TypeChecker::conformsToProtocol(Type T, ProtocolDecl *Proto, DeclContext *DC,
   auto conformance = conformsToProtocol(T, Proto, DC, options, ComplainLoc);
   return conformance ? ConformsToProtocolResult::success(*conformance)
                      : ConformsToProtocolResult::failure();
+}
+
+Optional<ProtocolConformanceRef>
+TypeChecker::LookUpConformance::operator()(
+                                       CanType dependentType,
+                                       Type conformingReplacementType,
+                                       ProtocolType *conformedProtocol) const {
+  if (conformingReplacementType->isTypeParameter())
+    return ProtocolConformanceRef(conformedProtocol->getDecl());
+
+  return tc.conformsToProtocol(conformingReplacementType,
+                               conformedProtocol->getDecl(),
+                               dc,
+                               (ConformanceCheckFlags::Used|
+                                ConformanceCheckFlags::InExpression));
 }
 
 /// Mark any _ObjectiveCBridgeable conformances in the given type as "used".

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -743,7 +743,7 @@ Type TypeChecker::applyUnboundGenericArguments(
     auto result =
       checkGenericArguments(dc, loc, noteLoc, unboundType, genericSig,
                             QueryTypeSubstitutionMap{subs},
-                            LookUpConformanceInModule{dc->getParentModule()},
+                            LookUpConformance(*this, dc),
                             unsatisfiedDependency);
 
     switch (result) {
@@ -758,7 +758,7 @@ Type TypeChecker::applyUnboundGenericArguments(
 
   // Apply the substitution map to the interface type of the declaration.
   resultType = resultType.subst(QueryTypeSubstitutionMap{subs},
-                                LookUpConformanceInModule(dc->getParentModule()),
+                                LookUpConformance(*this, dc),
                                 SubstFlags::UseErrorType);
 
   if (isa<NominalTypeDecl>(decl)) {

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1814,6 +1814,23 @@ public:
                      ConformanceCheckOptions options, SourceLoc ComplainLoc,
                      UnsatisfiedDependency *unsatisfiedDependency);
 
+  /// Functor class suitable for use as a \c LookupConformanceFn to look up a
+  /// conformance through a particular declaration context using the given
+  /// type checker.
+  class LookUpConformance {
+    TypeChecker &tc;
+    DeclContext *dc;
+
+  public:
+    explicit LookUpConformance(TypeChecker &tc, DeclContext *dc)
+      : tc(tc), dc(dc) { }
+
+    Optional<ProtocolConformanceRef>
+    operator()(CanType dependentType,
+               Type conformingReplacementType,
+               ProtocolType *conformedProtocol) const;
+  };
+
   /// Completely check the given conformance.
   void checkConformance(NormalProtocolConformance *conformance);
 

--- a/test/ClangImporter/Inputs/ibaction.h
+++ b/test/ClangImporter/Inputs/ibaction.h
@@ -1,0 +1,9 @@
+@import ObjectiveC;
+
+@protocol IBActionInProtocol
+-(void) __attribute__((ibaction)) actionMethod:(_Nullable id)param;
+@end
+
+@interface ConformsToIBActionInProtocol : NSObject <IBActionInProtocol>
+@end
+

--- a/test/ClangImporter/objc_ibaction.swift
+++ b/test/ClangImporter/objc_ibaction.swift
@@ -1,0 +1,6 @@
+// RUN: %target-swift-frontend -emit-sil %s -import-objc-header %S/Inputs/ibaction.h -verify
+// REQUIRES: objc_interop
+
+func foo(object: ConformsToIBActionInProtocol) {
+  object.actionMethod(object)
+}

--- a/test/multifile/Inputs/for_each_conformance_crashB.swift
+++ b/test/multifile/Inputs/for_each_conformance_crashB.swift
@@ -1,0 +1,12 @@
+protocol _P { }
+protocol P : _P { }
+
+protocol Q {
+  associatedtype A: P
+
+  func getArray() -> [RequiresP<A>]
+}
+
+struct RequiresP<T: P> { }
+
+struct MyStruct: P { }

--- a/test/multifile/for_each_conformance_crash.swift
+++ b/test/multifile/for_each_conformance_crash.swift
@@ -1,0 +1,7 @@
+// RUN: %target-swift-frontend -emit-ir %S/Inputs/for_each_conformance_crashB.swift -primary-file %s -o -
+
+extension Q where A == MyStruct {
+  func foo() {
+    for _ in getArray() { }
+  }
+}


### PR DESCRIPTION
A collection of varied fixes for the 4.0 branch:

* Mark conformances as "used" when the `GenericSignatureBuilder` needs them. Fixes rdar://problem/31759258
* Don't transfer `ibaction` attributes from Objective-C methods to their Swift counterparts if it doesn't make sense for Swift. Fixes rdar://problem/31776315
* Fix a stack-use-after-scope error in protocol conformance formation. Fixes rdar://problem/31708629
* Tolerate partially-type-checked ASTs, for general sanity with +Asserts builds