### PR TITLE
[Exclusivity] Temporarily disable an assert in AccessEnforcementSelec…

### DIFF
--- a/lib/SILOptimizer/Mandatory/AccessEnforcementSelection.cpp
+++ b/lib/SILOptimizer/Mandatory/AccessEnforcementSelection.cpp
@@ -382,7 +382,12 @@ struct AccessEnforcementSelection : SILFunctionTransform {
     // dependent BeginAccess).
     //
     // Running before diagnostic constant propagation requires handling 'undef'.
-    assert(isa<AllocStackInst>(address) || isa<SILUndef>(address));
+    //
+    // FIXME: This assert will eventually be important, but for now it's safe to
+    // disable until this problem is resolved:
+    //   <rdar://problem/31797132> [Exclusivity] lldb asserts in
+    //   AccessEnforcementSelector
+    // assert(isa<AllocStackInst>(address) || isa<SILUndef>(address));
     setStaticEnforcement(access);
   }
 


### PR DESCRIPTION
…tor.

This pass doesn't do anything useful downstream yet, so it's safe to temporarily
disable the assert.

Reenable after fixing:
<rdar://problem/31797132> [Exclusivity] lldb asserts in AccessEnforcementSelector