### PR TITLE
[Type checker] Handle 'rethrows' checks for single-parameter functions.

### DIFF
--- a/test/decl/func/rethrows.swift
+++ b/test/decl/func/rethrows.swift
@@ -476,3 +476,10 @@ func throwWhileGettingFoo() throws -> Foo.Type { return Foo.self }
 
 (throwWhileGettingFoo()).foo(Foo())() // expected-error {{can throw}}
 (try throwWhileGettingFoo()).foo(Foo())()
+
+// <rdar://problem/31794932> [Source compatibility] Call to sort(by):) can throw, but is not marked with 'try'
+func doRethrow(fn: (Int, Int) throws -> Int) rethrows { }
+
+func testDoRethrow() {
+  doRethrow(fn:) { (a, b) in return a }
+}


### PR DESCRIPTION
The throw-checking code wasn't properly coping with functions that
take a single, labeled argument, due to the longstanding lie that
pretends that functions take a tuple argument vs. zero or more
separate arguments. Here, the lie manifests as spurious "call can
throw, but is not marked as such" errors.

Fixes rdar://problem/31794932.
