### PR TITLE
Fix SR-4659 Benchmark logs should be tied to tested tree version

### DIFF
--- a/benchmark/scripts/Benchmark_Driver
+++ b/benchmark/scripts/Benchmark_Driver
@@ -130,6 +130,14 @@ def get_current_git_branch(git_repo_path):
          '--abbrev-ref', 'HEAD'], stderr=subprocess.STDOUT).strip()
 
 
+def get_git_head_ID(git_repo_path):
+    """Return the short identifier for the HEAD commit of the repo
+        `git_repo_path`"""
+    return subprocess.check_output(
+        ['git', '-C', git_repo_path, 'rev-parse',
+         '--short', 'HEAD'], stderr=subprocess.STDOUT).strip()
+
+
 def log_results(log_directory, driver, formatted_output, swift_repo=None):
     """Log `formatted_output` to a branch specific directory in
     `log_directory`
@@ -138,6 +146,10 @@ def log_results(log_directory, driver, formatted_output, swift_repo=None):
         branch = get_current_git_branch(swift_repo)
     except (OSError, subprocess.CalledProcessError):
         branch = None
+    try:
+        head_ID = '-' + get_git_head_ID(swift_repo)
+    except (OSError, subprocess.CalledProcessError):
+        head_ID = ''
     timestamp = time.strftime("%Y%m%d%H%M%S", time.localtime())
     if branch:
         output_directory = os.path.join(log_directory, branch)
@@ -149,7 +161,7 @@ def log_results(log_directory, driver, formatted_output, swift_repo=None):
     except OSError:
         pass
     log_file = os.path.join(output_directory,
-                            driver_name + '-' + timestamp + '.log')
+                            driver_name + '-' + timestamp + head_ID + '.log')
     print('Logging results to: %s' % log_file)
     with open(log_file, 'w') as f:
         f.write(formatted_output)


### PR DESCRIPTION

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-4659](https://bugs.swift.org/browse/SR-4659).

Broken out of #8793.

@gottesmm Please review.