### PR TITLE
[Type checker] Handle 'rethrows' checks for single-parameter functions.

### DIFF
--- a/test/decl/func/rethrows.swift
+++ b/test/decl/func/rethrows.swift
@@ -476,3 +476,10 @@ func throwWhileGettingFoo() throws -> Foo.Type { return Foo.self }
 
 (throwWhileGettingFoo()).foo(Foo())() // expected-error {{can throw}}
 (try throwWhileGettingFoo()).foo(Foo())()
+
+// <rdar://problem/31794932> [Source compatibility] Call to sort(by):) can throw, but is not marked with 'try'
+func doRethrow(fn: (Int, Int) throws -> Int) rethrows { }
+
+func testDoRethrow() {
+  doRethrow(fn:) { (a, b) in return a }
+}

--- a/unittests/runtime/Metadata.cpp
+++ b/unittests/runtime/Metadata.cpp
@@ -443,16 +443,19 @@ TEST(MetadataTest, getExistentialMetadata) {
     });
 
   // protocol compositions are order-invariant
-  const ProtocolDescriptor *protoList4[] = {
-    &ProtocolA,
-    &ProtocolB
-  };
-  const ProtocolDescriptor *protoList5[] = {
-    &ProtocolB,
-    &ProtocolA
-  };
   RaceTest_ExpectEqual<const ExistentialTypeMetadata *>(
     [&]() -> const ExistentialTypeMetadata * {
+
+      const ProtocolDescriptor *protoList4[] = {
+        &ProtocolA,
+        &ProtocolB
+      };
+
+      const ProtocolDescriptor *protoList5[] = {
+        &ProtocolB,
+        &ProtocolA
+      };
+
       auto ab = swift_getExistentialTypeMetadata(ProtocolClassConstraint::Any,
                                                 /*superclass=*/nullptr,
                                                 2, protoList4);
@@ -514,13 +517,14 @@ TEST(MetadataTest, getExistentialMetadata) {
       return noWitnessTable;
     });
 
-  const ProtocolDescriptor *protoList8[] = {
-    &ProtocolNoWitnessTable,
-    &ProtocolA,
-    &ProtocolB
-  };
   RaceTest_ExpectEqual<const ExistentialTypeMetadata *>(
     [&]() -> const ExistentialTypeMetadata * {
+      const ProtocolDescriptor *protoList8[] = {
+        &ProtocolNoWitnessTable,
+        &ProtocolA,
+        &ProtocolB
+      };
+
       auto mixedWitnessTable
         = swift_getExistentialTypeMetadata(ProtocolClassConstraint::Class,
                                            /*superclass=*/nullptr,
@@ -560,12 +564,13 @@ TEST(MetadataTest, getExistentialMetadata) {
       return special;
     });
 
-  const ProtocolDescriptor *protoList10[] = {
-    &ProtocolError,
-    &ProtocolA
-  };
   RaceTest_ExpectEqual<const ExistentialTypeMetadata *>(
     [&]() -> const ExistentialTypeMetadata * {
+      const ProtocolDescriptor *protoList10[] = {
+        &ProtocolError,
+        &ProtocolA
+      };
+
       auto special
         = swift_getExistentialTypeMetadata(ProtocolClassConstraint::Any,
                                            /*superclass=*/nullptr,


### PR DESCRIPTION
The throw-checking code wasn't properly coping with functions that
take a single, labeled argument, due to the longstanding lie that
pretends that functions take a tuple argument vs. zero or more
separate arguments. Here, the lie manifests as spurious "call can
throw, but is not marked as such" errors.

Fixes rdar://problem/31794932.