### PR TITLE
[test] Add regression test for cursor-info crasher in rdar://problem/31758709

### DIFF
--- a/test/SourceKit/CursorInfo/rdar_31758709.swift
+++ b/test/SourceKit/CursorInfo/rdar_31758709.swift
@@ -1,0 +1,10 @@
+// Checks that we don't crash
+// RUN: %sourcekitd-test -req=cursor -pos=8:19 %s -- %s | %FileCheck %s
+// CHECK: source.lang.swift.ref.class
+
+class ImageSet {
+  class StandImageSet {}
+  func foo() {
+    /*here:*/StandImageSet()
+  }
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->
Adds a regression test for a cursor-info crasher that's already been fixed.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves rdar://problem/31758709

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->