### PR TITLE
[ClangImporter] Always import types under their Swift 4 name.

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -436,8 +436,11 @@ class alignas(1 << DeclAlignInBits) Decl {
   class TypeAliasDeclBitfields {
     friend class TypeAliasDecl;
     unsigned : NumGenericTypeDeclBits;
+
+    /// Whether the typealias forwards perfectly to its underlying type.
+    unsigned IsCompatibilityAlias : 1;
   };
-  enum { NumTypeAliasDeclBits = NumGenericTypeDeclBits };
+  enum { NumTypeAliasDeclBits = NumGenericTypeDeclBits + 1 };
   static_assert(NumTypeAliasDeclBits <= 32, "fits in an unsigned");
 
   class NominalTypeDeclBitFields {
@@ -2440,6 +2443,14 @@ public:
 
   /// For generic typealiases, return the unbound generic type.
   UnboundGenericType *getUnboundGenericType() const;
+
+  bool isCompatibilityAlias() const {
+    return TypeAliasDeclBits.IsCompatibilityAlias;
+  }
+
+  void markAsCompatibilityAlias(bool newValue = true) {
+    TypeAliasDeclBits.IsCompatibilityAlias = newValue;
+  }
 
   static bool classof(const Decl *D) {
     return D->getKind() == DeclKind::TypeAlias;

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2282,7 +2282,9 @@ TypeAliasDecl::TypeAliasDecl(SourceLoc TypeAliasLoc, SourceLoc EqualLoc,
                              Identifier Name, SourceLoc NameLoc,
                              GenericParamList *GenericParams, DeclContext *DC)
   : GenericTypeDecl(DeclKind::TypeAlias, DC, Name, NameLoc, {}, GenericParams),
-    TypeAliasLoc(TypeAliasLoc), EqualLoc(EqualLoc) {}
+    TypeAliasLoc(TypeAliasLoc), EqualLoc(EqualLoc) {
+  TypeAliasDeclBits.IsCompatibilityAlias = false;
+}
 
 SourceRange TypeAliasDecl::getSourceRange() const {
   if (UnderlyingTy.hasLocation())

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -322,6 +322,8 @@ static bool isInterestingTypealias(Type type) {
     return false;
   if (type->is<BuiltinType>())
     return false;
+  if (aliasTy->getDecl()->isCompatibilityAlias())
+    return isInterestingTypealias(aliasTy->getSinglyDesugaredType());
   return true;
 }
 

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2953,7 +2953,7 @@ void ClangImporter::Implementation::lookupValue(
           auto alternateNamedDecl =
               cast_or_null<ValueDecl>(importDeclReal(recentClangDecl,
                                                      nameVersion));
-          if (!alternateNamedDecl)
+          if (!alternateNamedDecl || alternateNamedDecl == decl)
             return;
           assert(alternateNamedDecl->getFullName().matchesRef(name) &&
                  "importFullName behaved differently from importDecl");

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2063,8 +2063,12 @@ namespace {
     void markAsVariant(Decl *decl, ImportedName correctSwiftName) {
       // Types always import using the latest version. Make sure all names up
       // to that version are considered available.
-      if (isa<TypeDecl>(decl) && getVersion() >= getActiveSwiftVersion())
-        return;
+      if (isa<TypeDecl>(decl)) {
+        cast<TypeAliasDecl>(decl)->markAsCompatibilityAlias();
+
+        if (getVersion() >= getActiveSwiftVersion())
+          return;
+      }
 
       // TODO: some versions should be deprecated instead of unavailable
 

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -1893,28 +1893,54 @@ namespace {
     /// Note: Use this rather than calling Impl.importFullName directly!
     ImportedName importFullName(const clang::NamedDecl *D,
                                 Optional<ImportedName> &correctSwiftName) {
-      if (isActiveSwiftVersion()) {
-        // Just import the current Swift name.
-        correctSwiftName = None;
-        return Impl.importFullName(D, getVersion());
+      ImportNameVersion canonicalVersion = getActiveSwiftVersion();
+      if (isa<clang::TypeDecl>(D) || isa<clang::ObjCContainerDecl>(D)) {
+        canonicalVersion = ImportNameVersion::ForTypes;
+      }
+      correctSwiftName = None;
+
+      // First, import based on the Swift name of the canonical declaration:
+      // the latest version for types and the current version for non-type
+      // values. If that fails, we won't do anything.
+      auto canonicalName = Impl.importFullName(D, canonicalVersion);
+      if (!canonicalName)
+        return ImportedName();
+
+      if (getVersion() == canonicalVersion) {
+        // Make sure we don't try to import the same type twice as canonical.
+        if (canonicalVersion != getActiveSwiftVersion()) {
+          auto activeName = Impl.importFullName(D, getActiveSwiftVersion());
+          if (activeName &&
+              activeName.getDeclName() == canonicalName.getDeclName()) {
+            return ImportedName();
+          }
+        }
+
+        return canonicalName;
       }
 
       // Special handling when we import using the older Swift name.
       //
-      // First, import based on the current Swift name. If that fails, we won't
-      // do anything.
-      correctSwiftName = Impl.importFullName(D, getActiveSwiftVersion());
-      if (!*correctSwiftName)
-        return {};
-
       // Import using the alternate Swift name. If that fails, or if it's
       // identical to the active Swift name, we won't introduce an alternate
       // Swift name stub declaration.
       auto alternateName = Impl.importFullName(D, getVersion());
-      if (!alternateName || alternateName.getDeclName() == correctSwiftName->getDeclName())
+      if (!alternateName)
         return ImportedName();
 
-      // Okay, return the alternate Swift name.
+      if (alternateName.getDeclName() == canonicalName.getDeclName()) {
+        if (getVersion() == getActiveSwiftVersion()) {
+          assert(canonicalVersion != getActiveSwiftVersion());
+          return alternateName;
+        }
+        return ImportedName();
+      }
+
+      // Always use the active version as the preferred name, even if the
+      // canonical name is a different version.
+      correctSwiftName = Impl.importFullName(D, getActiveSwiftVersion());
+      assert(correctSwiftName);
+
       return alternateName;
     }
 
@@ -2035,6 +2061,11 @@ namespace {
     /// Mark the given declaration as an older Swift version variant of the
     /// current name.
     void markAsVariant(Decl *decl, ImportedName correctSwiftName) {
+      // Types always import using the latest version. Make sure all names up
+      // to that version are considered available.
+      if (isa<TypeDecl>(decl) && getVersion() >= getActiveSwiftVersion())
+        return;
+
       // TODO: some versions should be deprecated instead of unavailable
 
       ASTContext &ctx = decl->getASTContext();
@@ -3853,7 +3884,7 @@ namespace {
         return nullptr;
 
       // Find the Swift class being extended.
-      auto objcClass = cast_or_null<ClassDecl>(
+      auto objcClass = castIgnoringCompatibilityAlias<ClassDecl>(
           Impl.importDecl(decl->getClassInterface(), getActiveSwiftVersion()));
       if (!objcClass)
         return nullptr;
@@ -4669,7 +4700,7 @@ SwiftDeclConverter::importCFClassType(const clang::TypedefNameDecl *decl,
     if (auto attr = record->getAttr<clang::ObjCBridgeAttr>()) {
       // Record the Objective-C class to which this CF type is toll-free
       // bridged.
-      if (ClassDecl *objcClass = dyn_cast_or_null<ClassDecl>(
+      if (ClassDecl *objcClass = dynCastIgnoringCompatibilityAlias<ClassDecl>(
               Impl.importDeclByName(attr->getBridgedType()->getName()))) {
         theClass->getAttrs().add(new (Impl.SwiftContext)
                                      ObjCBridgedAttr(objcClass));
@@ -4679,7 +4710,7 @@ SwiftDeclConverter::importCFClassType(const clang::TypedefNameDecl *decl,
     if (auto attr = record->getAttr<clang::ObjCBridgeMutableAttr>()) {
       // Record the Objective-C class to which this CF type is toll-free
       // bridged.
-      if (ClassDecl *objcClass = dyn_cast_or_null<ClassDecl>(
+      if (ClassDecl *objcClass = dynCastIgnoringCompatibilityAlias<ClassDecl>(
               Impl.importDeclByName(attr->getBridgedType()->getName()))) {
         theClass->getAttrs().add(new (Impl.SwiftContext)
                                      ObjCBridgedAttr(objcClass));
@@ -4696,7 +4727,11 @@ Decl *SwiftDeclConverter::importCompatibilityTypeAlias(
     ImportedName correctSwiftName) {
   // Import the referenced declaration. If it doesn't come in as a type,
   // we don't care.
-  auto importedDecl = Impl.importDecl(decl, getActiveSwiftVersion());
+  Decl *importedDecl = nullptr;
+  if (getVersion() >= getActiveSwiftVersion())
+    importedDecl = Impl.importDecl(decl, ImportNameVersion::ForTypes);
+  if (!importedDecl)
+    importedDecl = Impl.importDecl(decl, getActiveSwiftVersion());
   auto typeDecl = dyn_cast_or_null<TypeDecl>(importedDecl);
   if (!typeDecl)
     return nullptr;
@@ -6193,7 +6228,7 @@ void SwiftDeclConverter::importObjCProtocols(
 
   for (auto cp = clangProtocols.begin(), cpEnd = clangProtocols.end();
        cp != cpEnd; ++cp) {
-    if (auto proto = cast_or_null<ProtocolDecl>(
+    if (auto proto = castIgnoringCompatibilityAlias<ProtocolDecl>(
             Impl.importDecl(*cp, getActiveSwiftVersion()))) {
       addProtocols(proto, protocols, knownProtocols);
       inheritedTypes.push_back(TypeLoc::withoutLoc(proto->getDeclaredType()));
@@ -6275,7 +6310,7 @@ Optional<GenericParamList *> SwiftDeclConverter::importObjCGenericParams(
         inherited.push_back(TypeLoc::withoutLoc(superclassType));
       }
       for (clang::ObjCProtocolDecl *clangProto : clangBound->quals()) {
-        ProtocolDecl *proto = cast_or_null<ProtocolDecl>(
+        ProtocolDecl *proto = castIgnoringCompatibilityAlias<ProtocolDecl>(
             Impl.importDecl(clangProto, getActiveSwiftVersion()));
         if (!proto) {
           return None;
@@ -6915,7 +6950,7 @@ ClangImporter::Implementation::importDeclImpl(const clang::NamedDecl *ClangDecl,
 
       if (hasMissingRequiredMember) {
         // Mark the protocol as having missing requirements.
-        if (auto proto = cast_or_null<ProtocolDecl>(
+        if (auto proto = castIgnoringCompatibilityAlias<ProtocolDecl>(
                 importDecl(clangProto, CurrentVersion))) {
           proto->setHasMissingRequirements(true);
         }
@@ -6929,7 +6964,7 @@ ClangImporter::Implementation::importDeclImpl(const clang::NamedDecl *ClangDecl,
         // Only allow this to affect declarations in the same top-level module
         // as the original class.
         if (getClangModuleForDecl(theClass) == getClangModuleForDecl(method)) {
-          if (auto swiftClass = cast_or_null<ClassDecl>(
+          if (auto swiftClass = castIgnoringCompatibilityAlias<ClassDecl>(
                   importDecl(theClass, CurrentVersion))) {
             swiftClass->setHasMissingDesignatedInitializers();
           }

--- a/lib/ClangImporter/ImportName.h
+++ b/lib/ClangImporter/ImportName.h
@@ -54,7 +54,14 @@ enum class ImportNameVersion : unsigned {
   Swift4,
 
   /// A placeholder for the latest version, to be used in loops and such.
-  LAST_VERSION = Swift4
+  LAST_VERSION = Swift4,
+
+  /// The version which should be used for importing types, which need to have
+  /// one canonical definition.
+  ///
+  /// FIXME: Is this supposed to be the /newest/ version, or a canonical
+  /// version that lasts forever as part of the ABI?
+  ForTypes = Swift4
 };
 
 static inline ImportNameVersion &operator++(ImportNameVersion &value) {

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -576,7 +576,7 @@ namespace {
         genericEnv = ext->getGenericEnvironment();
       } else if (auto *interface =
           dyn_cast<clang::ObjCInterfaceDecl>(typeParamContext)) {
-        auto cls = cast_or_null<ClassDecl>(
+        auto cls = castIgnoringCompatibilityAlias<ClassDecl>(
             Impl.importDecl(interface, Impl.CurrentVersion));
         if (!cls)
           return ImportResult();
@@ -853,7 +853,7 @@ namespace {
       // If this object pointer refers to an Objective-C class (possibly
       // qualified),
       if (auto objcClass = type->getInterfaceDecl()) {
-        auto imported = cast_or_null<ClassDecl>(
+        auto imported = castIgnoringCompatibilityAlias<ClassDecl>(
             Impl.importDecl(objcClass, Impl.CurrentVersion));
         if (!imported)
           return nullptr;
@@ -1038,7 +1038,7 @@ namespace {
 
         for (auto cp = type->qual_begin(), cpEnd = type->qual_end();
              cp != cpEnd; ++cp) {
-          auto proto = cast_or_null<ProtocolDecl>(
+          auto proto = castIgnoringCompatibilityAlias<ProtocolDecl>(
             Impl.importDecl(*cp, Impl.CurrentVersion));
           if (!proto)
             return Type();
@@ -2432,7 +2432,8 @@ static Type getNamedProtocolType(ClangImporter::Implementation &impl,
   for (auto decl : lookupResult) {
     if (auto swiftDecl =
             impl.importDecl(decl->getUnderlyingDecl(), impl.CurrentVersion)) {
-      if (auto protoDecl = dyn_cast<ProtocolDecl>(swiftDecl)) {
+      if (auto protoDecl =
+              dynCastIgnoringCompatibilityAlias<ProtocolDecl>(swiftDecl)) {
         return protoDecl->getDeclaredType();
       }
     }

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -3829,6 +3829,13 @@ Expected<Type> ModuleFile::getTypeChecked(TypeID TID) {
       }
     }
 
+    // Look through compatibility aliases that are now unavailable.
+    if (alias->getAttrs().isUnavailable(ctx) &&
+        alias->isCompatibilityAlias()) {
+      typeOrOffset = alias->getUnderlyingTypeLoc().getType();
+      break;
+    }
+
     typeOrOffset = alias->getDeclaredInterfaceType();
     break;
   }

--- a/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/APINotesFrameworkTest.apinotes
+++ b/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/APINotesFrameworkTest.apinotes
@@ -103,3 +103,7 @@ SwiftVersions:
         SwiftName: ImportantCStruct
       - Name: InnerInSwift4
         SwiftName: InnerInSwift4
+    Typedefs:
+      - Name: SomeCAlias
+        SwiftName: ImportantCAlias
+

--- a/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/Types.h
+++ b/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/Types.h
@@ -4,4 +4,6 @@ struct __attribute__((swift_name("VeryImportantCStruct"))) SomeCStruct {
     int field;
 };
 
+typedef int __attribute__((swift_name("VeryImportantCAlias"))) SomeCAlias;
+
 #pragma clang assume_nonnull end

--- a/test/APINotes/versioned-test-mangling.swift
+++ b/test/APINotes/versioned-test-mangling.swift
@@ -1,0 +1,15 @@
+// RUN: rm -rf %t && mkdir -p %t
+
+// Use fake mangled names here with the name of the imported module.
+// swift-ide-test isn't testing the full demangling algorithm.
+
+// RUN: %target-swift-ide-test -F %S/Inputs/custom-frameworks -print-ast-typechecked -source-filename %s -swift-version 3 -find-mangled _T0So16ImportantCStructa | %FileCheck -check-prefix=CHECK-TOP-ALIAS %s
+// RUN: %target-swift-ide-test -F %S/Inputs/custom-frameworks -print-ast-typechecked -source-filename %s -swift-version 4 -find-mangled _T0So16ImportantCStructa | %FileCheck -check-prefix=CHECK-TOP-ALIAS %s
+
+// RUN: %target-swift-ide-test -F %S/Inputs/custom-frameworks -print-ast-typechecked -source-filename %s -swift-version 3 -find-mangled _T0So13InnerInSwift4a | %FileCheck -check-prefix=CHECK-NESTED-ALIAS %s
+// RUN: %target-swift-ide-test -F %S/Inputs/custom-frameworks -print-ast-typechecked -source-filename %s -swift-version 4 -find-mangled _T0So13InnerInSwift4a | %FileCheck -check-prefix=CHECK-NESTED-ALIAS %s
+
+import APINotesFrameworkTest
+
+// CHECK-TOP-ALIAS: typealias ImportantCStruct = VeryImportantCStruct
+// CHECK-NESTED-ALIAS: typealias InnerInSwift4 = Outer.Inner

--- a/test/APINotes/versioned.swift
+++ b/test/APINotes/versioned.swift
@@ -68,6 +68,22 @@ func testRenamedTopLevelDiags() {
   _ = Outer.Inner()
   // CHECK-DIAGS-3-NOT: versioned.swift:[[@LINE-1]]:
 }
+
+func testAKA(structValue: ImportantCStruct, aliasValue: ImportantCAlias) {
+  let _: Int = structValue
+  // CHECK-DIAGS-3: versioned.swift:[[@LINE-1]]:16: error: cannot convert value of type 'ImportantCStruct' to specified type 'Int'
+
+  let _: Int = aliasValue
+  // CHECK-DIAGS-3: versioned.swift:[[@LINE-1]]:16: error: cannot convert value of type 'ImportantCAlias' (aka 'Int32') to specified type 'Int'
+
+  let optStructValue: Optional = structValue
+  let _: Int = optStructValue
+  // CHECK-DIAGS-3: versioned.swift:[[@LINE-1]]:16: error: cannot convert value of type 'Optional<ImportantCStruct>' to specified type 'Int'
+
+  let optAliasValue: Optional = aliasValue
+  let _: Int = optAliasValue
+  // CHECK-DIAGS-3: versioned.swift:[[@LINE-1]]:16: error: cannot convert value of type 'Optional<ImportantCAlias>' (aka 'Optional<Int32>') to specified type 'Int'
+}
 #endif
 
 #if !swift(>=4)

--- a/test/IDE/import_as_member.swift
+++ b/test/IDE/import_as_member.swift
@@ -68,9 +68,8 @@
 // PRINT-APINOTES-3-NEXT:   init(oldLabel _: Int32)
 // PRINT-APINOTES-3-NEXT:   @available(swift, introduced: 4, renamed: "Struct1.init(oldLabel:)")
 // PRINT-APINOTES-3-NEXT:   init(newLabel _: Int32)
-// PRINT-APINOTES-3-NEXT:   typealias OldApiNoteType = Double
-// PRINT-APINOTES-3-NEXT:   @available(swift, introduced: 4, renamed: "Struct1.OldApiNoteType")
-// PRINT-APINOTES-3-NEXT:   typealias NewApiNoteType = Struct1.OldApiNoteType
+// PRINT-APINOTES-3-NEXT:   typealias OldApiNoteType = Struct1.NewApiNoteType
+// PRINT-APINOTES-3-NEXT:   typealias NewApiNoteType = Double
 // PRINT-APINOTES-3-NEXT: }
 // PRINT-APINOTES-3-NOT: @available
 // PRINT-APINOTES-3:     var IAMStruct1APINoteVarInSwift4: Double

--- a/test/Serialization/Recovery/Inputs/custom-modules/Types.apinotes
+++ b/test/Serialization/Recovery/Inputs/custom-modules/Types.apinotes
@@ -1,0 +1,35 @@
+Name: Types
+Classes:
+- Name: RenamedClass
+  SwiftName: RenamedClass
+- Name: RenamedGenericClass
+  SwiftName: RenamedGenericClass
+Typedefs:
+- Name: RenamedTypedef
+  SwiftName: RenamedTypedef
+Tags:
+- Name: RenamedStruct
+  SwiftName: RenamedStruct
+- Name: RenamedEnum
+  SwiftName: RenamedEnum
+Protocols:
+- Name: RenamedProtocol
+  SwiftName: RenamedProtocol
+SwiftVersions:
+- Version: 3
+  Classes:
+  - Name: RenamedClass
+    SwiftName: Swift3RenamedClass
+  - Name: RenamedGenericClass
+    SwiftName: Swift3RenamedGenericClass
+  Typedefs:
+  - Name: RenamedTypedef
+    SwiftName: Swift3RenamedTypedef
+  Tags:
+  - Name: RenamedStruct
+    SwiftName: Swift3RenamedStruct
+  - Name: RenamedEnum
+    SwiftName: Swift3RenamedEnum
+  Protocols:
+  - Name: RenamedProtocol
+    SwiftName: Swift3RenamedProtocol

--- a/test/Serialization/Recovery/Inputs/custom-modules/Types.h
+++ b/test/Serialization/Recovery/Inputs/custom-modules/Types.h
@@ -1,0 +1,27 @@
+@interface Object
+- (nonnull instancetype)init;
+@end
+
+@interface RenamedClass : Object
+@end
+
+@interface RenamedGenericClass<Element> : Object
+@end
+
+typedef int RenamedTypedef;
+
+struct RenamedStruct {
+  int value;
+};
+
+#define CF_ENUM(_type, _name) enum _name : _type _name; enum _name : _type
+
+typedef CF_ENUM(long, RenamedEnum) {
+  RenamedEnumA
+};
+
+@protocol RenamedProtocol
+@end
+
+@interface RenamedClass (RenamedProtocol) <RenamedProtocol>
+@end

--- a/test/Serialization/Recovery/Inputs/custom-modules/module.modulemap
+++ b/test/Serialization/Recovery/Inputs/custom-modules/module.modulemap
@@ -1,2 +1,3 @@
 module Overrides { header "Overrides.h" }
 module Typedefs { header "Typedefs.h" }
+module Types { header "Types.h" }

--- a/test/Serialization/Recovery/types-3-to-4.swift
+++ b/test/Serialization/Recovery/types-3-to-4.swift
@@ -1,0 +1,89 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: %target-swift-frontend -emit-module -o %t -module-name Lib -I %S/Inputs/custom-modules -swift-version 3 %s
+
+// RUN: %target-swift-ide-test -source-filename=x -print-module -module-to-print Lib -I %t -I %S/Inputs/custom-modules -swift-version 3 | %FileCheck -check-prefix=CHECK-3 %s
+
+// RUN: %target-swift-ide-test -source-filename=x -print-module -module-to-print Lib -I %t -I %S/Inputs/custom-modules -enable-experimental-deserialization-recovery -swift-version 4 | %FileCheck -check-prefix=CHECK-4 %s
+
+// RUN: %target-swift-frontend -typecheck %s -I %t -I %S/Inputs/custom-modules  -swift-version 4 -enable-experimental-deserialization-recovery -D TEST -verify
+
+// REQUIRES: objc_interop
+
+#if TEST
+
+import Lib
+
+func requiresConformance(_: B_RequiresConformance<B_ConformsToProto>) {}
+func requiresConformance(_: B_RequiresConformance<C_RelyOnConformanceImpl.Assoc>) {}
+
+
+#else // TEST
+
+import Types
+
+// Please use prefixes to keep the printed parts of this file in alphabetical
+// order.
+
+public func A_renameAllTheThings(
+  a: Swift3RenamedClass?,
+  b: Swift3RenamedGenericClass<AnyObject>?,
+  c: Swift3RenamedTypedef,
+  d: Swift3RenamedStruct,
+  e: Swift3RenamedEnum,
+  f: Swift3RenamedProtocol
+) {}
+
+// CHECK-4-LABEL: func A_renameAllTheThings(
+// CHECK-4-SAME: a: RenamedClass?
+// CHECK-4-SAME: b: RenamedGenericClass<AnyObject>?
+// CHECK-4-SAME: c: RenamedTypedef
+// CHECK-4-SAME: d: RenamedStruct
+// CHECK-4-SAME: e: RenamedEnum
+// CHECK-4-SAME: f: RenamedProtocol
+// CHECK-4-SAME: )
+
+
+// CHECK-3-LABEL: func A_renameAllTheThings(
+// CHECK-3-SAME: a: Swift3RenamedClass?
+
+// FIXME: An issue not specific to the importer where generic typealiases are
+// not preserved when provided arguments.
+// CHECK-3-SAME: b: RenamedGenericClass<AnyObject>?
+
+// CHECK-3-SAME: c: Swift3RenamedTypedef
+// CHECK-3-SAME: d: Swift3RenamedStruct
+// CHECK-3-SAME: e: Swift3RenamedEnum
+// CHECK-3-SAME: f: Swift3RenamedProtocol
+// CHECK-3-SAME: )
+
+
+public func A_renameGeneric<T: Swift3RenamedProtocol>(obj: T) {}
+
+// CHECK-4-LABEL: func A_renameGeneric<T>(
+// CHECK-4-SAME: where T : RenamedProtocol
+
+// FIXME: Preserve sugar in requirements.
+// CHECK-3-LABEL: func A_renameGeneric<T>(
+// CHECK-3-SAME: where T : RenamedProtocol
+
+public class B_ConformsToProto: Swift3RenamedProtocol {}
+
+// CHECK-4-LABEL: class B_ConformsToProto : RenamedProtocol
+// CHECK-3-LABEL: class B_ConformsToProto : Swift3RenamedProtocol
+
+public struct B_RequiresConformance<T: Swift3RenamedProtocol> {}
+
+// CHECK-4-LABEL: struct B_RequiresConformance<T> where T : RenamedProtocol
+
+// FIXME: Preserve sugar in requirements.
+// CHECK-3-LABEL: struct B_RequiresConformance<T> where T : RenamedProtocol
+
+public protocol C_RelyOnConformance {
+  associatedtype Assoc: Swift3RenamedProtocol
+}
+
+public class C_RelyOnConformanceImpl: C_RelyOnConformance {
+  public typealias Assoc = Swift3RenamedClass
+}
+
+#endif

--- a/test/Serialization/Recovery/types-4-to-3.swift
+++ b/test/Serialization/Recovery/types-4-to-3.swift
@@ -1,0 +1,65 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: %target-swift-frontend -emit-module -o %t -module-name Lib -I %S/Inputs/custom-modules -swift-version 4 %s
+
+// RUN: %target-swift-ide-test -source-filename=x -print-module -module-to-print Lib -I %t -I %S/Inputs/custom-modules -swift-version 4 | %FileCheck %s
+
+// RUN: %target-swift-ide-test -source-filename=x -print-module -module-to-print Lib -I %t -I %S/Inputs/custom-modules -enable-experimental-deserialization-recovery -swift-version 3 | %FileCheck %s
+
+// RUN: %target-swift-frontend -typecheck %s -I %t -I %S/Inputs/custom-modules  -swift-version 3 -enable-experimental-deserialization-recovery -D TEST -verify
+
+// REQUIRES: objc_interop
+
+#if TEST
+
+import Lib
+
+func requiresConformance(_: B_RequiresConformance<B_ConformsToProto>) {}
+func requiresConformance(_: B_RequiresConformance<C_RelyOnConformanceImpl.Assoc>) {}
+
+
+#else // TEST
+
+import Types
+
+// Please use prefixes to keep the printed parts of this file in alphabetical
+// order.
+
+public func A_renameAllTheThings(
+  a: RenamedClass?,
+  b: RenamedGenericClass<AnyObject>?,
+  c: RenamedTypedef,
+  d: RenamedStruct,
+  e: RenamedEnum,
+  f: RenamedProtocol
+) {}
+
+// CHECK-LABEL: func A_renameAllTheThings(
+// CHECK-SAME: a: RenamedClass?
+// CHECK-SAME: b: RenamedGenericClass<AnyObject>?
+// CHECK-SAME: c: RenamedTypedef
+// CHECK-SAME: d: RenamedStruct
+// CHECK-SAME: e: RenamedEnum
+// CHECK-SAME: f: RenamedProtocol
+// CHECK-SAME: )
+
+
+public func A_renameGeneric<T: RenamedProtocol>(obj: T) {}
+
+// CHECK-LABEL: func A_renameGeneric<T>(
+// CHECK-SAME: where T : RenamedProtocol
+
+public class B_ConformsToProto: RenamedProtocol {}
+// CHECK-LABEL: class B_ConformsToProto : RenamedProtocol
+
+public struct B_RequiresConformance<T: RenamedProtocol> {}
+// CHECK-LABEL: struct B_RequiresConformance<T> where T : RenamedProtocol
+
+public protocol C_RelyOnConformance {
+  associatedtype Assoc: RenamedProtocol
+}
+
+public class C_RelyOnConformanceImpl: C_RelyOnConformance {
+  public typealias Assoc = RenamedClass
+}
+
+#endif

--- a/test/decl/typealias/typealias.swift
+++ b/test/decl/typealias/typealias.swift
@@ -35,3 +35,36 @@ struct Hair<Style> {
 typealias FunnyHair = Hair<Color>
 
 var f: FunnyHair
+
+// Class inheritance through a typealias.
+class BaseClass {}
+typealias BaseAlias = BaseClass
+class SubClass : BaseAlias {}
+let _: BaseClass = SubClass()
+let _: BaseAlias = SubClass()
+
+func generic<T: BaseAlias>(_: T) {}
+generic(SubClass())
+extension BaseAlias {}
+
+class GenericBaseClass<T: AnyObject> {}
+typealias GenericBaseAlias = GenericBaseClass
+class ConcreteSubClass : GenericBaseAlias<BaseClass> {}
+let _: GenericBaseClass<BaseClass> = ConcreteSubClass()
+let _: GenericBaseAlias<BaseClass> = ConcreteSubClass()
+
+func generic<T: GenericBaseAlias<BaseClass>>(_: T) {}
+generic(ConcreteSubClass())
+extension GenericBaseAlias {
+  func doSomething(with: T) {}
+}
+
+// Protocol adoption through a typealias.
+protocol SomeProto {}
+typealias SomeProtoAlias = SomeProto
+class SomeProtoImpl : SomeProtoAlias {}
+let _: SomeProto = SomeProtoImpl()
+let _: SomeProtoAlias = SomeProtoImpl()
+
+func generic<T: SomeProtoAlias>(_: T) {}
+generic(SomeProtoImpl())


### PR DESCRIPTION
This means all cross-module references and all mangled names will consistently use the Swift 4 name (the canonical type), no special handling required.

The main thing we lose here is that the Swift 4 names of imported types become usable in Swift 3 mode without any diagnostics, similar to how most language features introduced in Swift 4 are available in Swift 3 mode. It also implies that the Swift 4 name will show up in demangled names.

rdar://problem/31616162 rdar://problem/31848862

(This PR also slurps in some improvements to swift-ide-test that I should really break out separately.)