### PR TITLE
Revert "Enable SourceKit tests if building SourceKit"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -381,9 +381,6 @@ endif()
 option(SWIFT_BUILD_SOURCEKIT
     "Build SourceKit"
     ${SWIFT_BUILD_SOURCEKIT_default})
-option(SWIFT_ENABLE_SOURCEKIT_TESTS
-    "Enable running SourceKit tests"
-    ${SWIFT_BUILD_SOURCEKIT_default})
 
 #
 # Assume a new enough ar to generate the index at construction time. This avoids

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -128,7 +128,6 @@ normalize_boolean_spelling(LLVM_ENABLE_ASSERTIONS)
 normalize_boolean_spelling(SWIFT_STDLIB_ASSERTIONS)
 normalize_boolean_spelling(SWIFT_AST_VERIFIER)
 normalize_boolean_spelling(SWIFT_ASAN_BUILD)
-normalize_boolean_spelling(SWIFT_ENABLE_SOURCEKIT_TESTS)
 is_build_type_optimized("${SWIFT_STDLIB_BUILD_TYPE}" SWIFT_OPTIMIZED)
 
 set(profdata_merge_worker

--- a/test/SourceKit/CodeComplete/complete_moduleimportdepth.swift
+++ b/test/SourceKit/CodeComplete/complete_moduleimportdepth.swift
@@ -6,7 +6,6 @@ func test() {
 }
 
 // XFAIL: broken_std_regex
-// REQUIRES: objc_interop
 // RUN: %complete-test -hide-none -group=none -tok=A %s -raw -- -I %S/Inputs -F %S/../Inputs/libIDE-mock-sdk > %t
 // RUN: %FileCheck %s < %t
 

--- a/test/SourceKit/CodeComplete/complete_sort_order.swift
+++ b/test/SourceKit/CodeComplete/complete_sort_order.swift
@@ -7,7 +7,7 @@ func test() {
 
 }
 
-// XFAIL: broken_std_regex, linux
+// XFAIL: broken_std_regex
 // RUN: %sourcekitd-test -req=complete -req-opts=hidelowpriority=0 -pos=7:1 %s -- %s > %t.orig
 // RUN: %FileCheck -check-prefix=NAME %s < %t.orig
 // Make sure the order is as below, foo(Int) should come before foo(String).

--- a/test/SourceKit/CursorInfo/cursor_info.swift
+++ b/test/SourceKit/CursorInfo/cursor_info.swift
@@ -214,7 +214,6 @@ struct HasLocalizationKey {}
 /// - LocalizationKey: ABC
 func hasLocalizationKey2() {}
 
-// REQUIRES: objc_interop
 // RUN: rm -rf %t.tmp
 // RUN: mkdir -p %t.tmp
 // RUN: %swiftc_driver -emit-module -o %t.tmp/FooSwiftModule.swiftmodule %S/Inputs/FooSwiftModule.swift

--- a/test/SourceKit/CursorInfo/cursor_stdlib.swift
+++ b/test/SourceKit/CursorInfo/cursor_stdlib.swift
@@ -21,7 +21,6 @@ func foo2(_ a : inout [S1]) {
 import Swift
 func foo3(a: Float, b: Bool) {}
 
-// REQUIRES: objc_interop
 // RUN: %sourcekitd-test -req=cursor -pos=3:18 %s -- %s %mcp_opt %clang-importer-sdk | %FileCheck -check-prefix=CHECK-OVERLAY %s
 // CHECK-OVERLAY:      source.lang.swift.ref.var.global
 // CHECK-OVERLAY-NEXT: NSUTF8StringEncoding

--- a/test/SourceKit/CursorInfo/cursor_usr.swift
+++ b/test/SourceKit/CursorInfo/cursor_usr.swift
@@ -8,7 +8,6 @@ struct S1 {}
 
 func foo(x: FooStruct1) -> S1 {}
 
-// REQUIRES: objc_interop
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
 // RUN: %swiftc_driver -emit-module -o %t/FooSwiftModule.swiftmodule %S/Inputs/FooSwiftModule.swift

--- a/test/SourceKit/DocumentStructure/structure.swift
+++ b/test/SourceKit/DocumentStructure/structure.swift
@@ -6,3 +6,4 @@
 
 // RUN: %sourcekitd-test -req=structure %S/../Inputs/placeholders.swift | %sed_clean > %t.placeholders.response
 // RUN: diff -u %s.placeholders.response %t.placeholders.response
+

--- a/test/SourceKit/Indexing/index_is_test_candidate.swift.response
+++ b/test/SourceKit/Indexing/index_is_test_candidate.swift.response
@@ -36,7 +36,7 @@
     {
       key.kind: source.lang.swift.decl.class,
       key.name: "XCTestCase",
-      key.usr: "s:23index_is_test_candidate10XCTestCaseC",
+      key.usr: "s:C28index_is_test_candidate_objc10XCTestCase",
       key.line: 15,
       key.column: 7
     },
@@ -50,7 +50,7 @@
         {
           key.kind: source.lang.swift.ref.class,
           key.name: "XCTestCase",
-          key.usr: "s:23index_is_test_candidate10XCTestCaseC",
+          key.usr: "s:C28index_is_test_candidate_objc10XCTestCase",
           key.line: 16,
           key.column: 32
         }
@@ -59,7 +59,7 @@
         {
           key.kind: source.lang.swift.ref.class,
           key.name: "XCTestCase",
-          key.usr: "s:23index_is_test_candidate10XCTestCaseC",
+          key.usr: "s:C28index_is_test_candidate_objc10XCTestCase",
           key.line: 16,
           key.column: 32
         },
@@ -68,11 +68,9 @@
           key.name: "test_startsWithTest_takesNoParams_returnsVoid_butIsPrivate()",
           key.usr: "s:23index_is_test_candidate14MyPrivateClass33_E06F4E7BC5F577AB6E2EC6D3ECA1C8B9LLC0c47_startsWithTest_takesNoParams_returnsVoid_butIsF0yyF",
           key.line: 17,
-          key.column: 8,
-          key.is_dynamic: 1
+          key.column: 8
         }
-      ],
-      key.is_test_candidate: 1
+      ]
     },
     {
       key.kind: source.lang.swift.decl.class,
@@ -84,7 +82,7 @@
         {
           key.kind: source.lang.swift.ref.class,
           key.name: "XCTestCase",
-          key.usr: "s:23index_is_test_candidate10XCTestCaseC",
+          key.usr: "s:C28index_is_test_candidate_objc10XCTestCase",
           key.line: 20,
           key.column: 24
         }
@@ -93,7 +91,7 @@
         {
           key.kind: source.lang.swift.ref.class,
           key.name: "XCTestCase",
-          key.usr: "s:23index_is_test_candidate10XCTestCaseC",
+          key.usr: "s:C28index_is_test_candidate_objc10XCTestCase",
           key.line: 20,
           key.column: 24
         },
@@ -102,8 +100,7 @@
           key.name: "doesNotStartWithTest()",
           key.usr: "s:23index_is_test_candidate7MyClassC20doesNotStartWithTestyyF",
           key.line: 21,
-          key.column: 8,
-          key.is_dynamic: 1
+          key.column: 8
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
@@ -111,7 +108,6 @@
           key.usr: "s:23index_is_test_candidate7MyClassC0C30_startsWithTest_butTakesAParamySi5param_tF",
           key.line: 22,
           key.column: 8,
-          key.is_dynamic: 1,
           key.entities: [
             {
               key.kind: source.lang.swift.ref.struct,
@@ -128,7 +124,6 @@
           key.usr: "s:23index_is_test_candidate7MyClassC0C50_startsWithTest_andTakesNoParams_butReturnsNonVoidSiyF",
           key.line: 23,
           key.column: 8,
-          key.is_dynamic: 1,
           key.entities: [
             {
               key.kind: source.lang.swift.ref.struct,
@@ -144,8 +139,7 @@
           key.name: "test_startsWithTest_takesNoParams_andReturnsVoid_butIsPrivate()",
           key.usr: "s:23index_is_test_candidate7MyClassC0C57_startsWithTest_takesNoParams_andReturnsVoid_butIsPrivate33_E06F4E7BC5F577AB6E2EC6D3ECA1C8B9LLyyF",
           key.line: 24,
-          key.column: 16,
-          key.is_dynamic: 1
+          key.column: 16
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
@@ -153,7 +147,6 @@
           key.usr: "s:23index_is_test_candidate7MyClassC0C41_startsWithTest_takesNoParams_returnsVoidyyF",
           key.line: 25,
           key.column: 8,
-          key.is_dynamic: 1,
           key.is_test_candidate: 1
         },
         {
@@ -162,11 +155,9 @@
           key.usr: "s:23index_is_test_candidate7MyClassC0C51_startsWithTest_takesNoParams_returnsVoid_andThrowsyyKF",
           key.line: 26,
           key.column: 8,
-          key.is_dynamic: 1,
           key.is_test_candidate: 1
         }
-      ],
-      key.is_test_candidate: 1
+      ]
     }
   ]
 }

--- a/test/SourceKit/lit.local.cfg
+++ b/test/SourceKit/lit.local.cfg
@@ -1,4 +1,4 @@
-if 'sourcekit' not in config.available_features:
+if 'OS=macosx' not in config.available_features:
     config.unsupported = True
 
 else:

--- a/test/lit.site.cfg.in
+++ b/test/lit.site.cfg.in
@@ -83,9 +83,6 @@ if "@CMAKE_GENERATOR@" == "Xcode":
 
 config.available_features.add("CMAKE_GENERATOR=@CMAKE_GENERATOR@")
 
-if "@SWIFT_ENABLE_SOURCEKIT_TESTS@" == "TRUE":
-    config.available_features.add('sourcekit')
-
 # Let the main config do the real work.
 if config.test_exec_root is None:
     config.test_exec_root = os.path.dirname(os.path.realpath(__file__))

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -762,9 +762,8 @@ private:
 };
 } // end anonymous namespace
 
-static bool makeParserAST(CompilerInstance &CI, StringRef Text,
-                          CompilerInvocation Invocation) {
-  Invocation.clearInputs();
+static bool makeParserAST(CompilerInstance &CI, StringRef Text) {
+  CompilerInvocation Invocation;
   Invocation.setModuleName("main");
   Invocation.setInputKind(InputFileKind::IFK_Swift);
 
@@ -975,7 +974,7 @@ static bool reportModuleDocInfo(CompilerInvocation Invocation,
     return true;
 
   CompilerInstance ParseCI;
-  if (makeParserAST(ParseCI, IFaceInfo.Text, Invocation))
+  if (makeParserAST(ParseCI, IFaceInfo.Text))
     return true;
   addParameterEntities(ParseCI, IFaceInfo);
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftInterfaceGenContext.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftInterfaceGenContext.h
@@ -50,7 +50,6 @@ public:
   static SwiftInterfaceGenContextRef createForSwiftSource(StringRef DocumentName,
                                                           StringRef SourceFileName,
                                                           ASTUnitRef AstUnit,
-                                                          swift::CompilerInvocation Invocation,
                                                           std::string &ErrMsg);
 
   ~SwiftInterfaceGenContext();

--- a/tools/SourceKit/tools/sourcekitd/bin/InProc/CMakeLists.txt
+++ b/tools/SourceKit/tools/sourcekitd/bin/InProc/CMakeLists.txt
@@ -10,21 +10,13 @@ set(sourcekitdInProc_args
 )
 
 if (SOURCEKIT_INSTALLING_INPROC)
-  if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
-    add_sourcekit_framework(sourcekitdInProc
-      ${SOURCEKITD_SOURCE_DIR}/include/sourcekitd/sourcekitd.h
-      ${sourcekitdInProc_args}
-      MODULEMAP module.modulemap
-      INSTALL_IN_COMPONENT sourcekit-inproc
-    )
-    set_property(TARGET sourcekitdInProc APPEND_STRING PROPERTY LINK_FLAGS " -fapplication-extension")
-  else()
-    add_sourcekit_library(sourcekitdInProc
-      ${sourcekitdInProc_args}
-      INSTALL_IN_COMPONENT sourcekit-inproc
-      SHARED
-    )
-  endif()
+  add_sourcekit_framework(sourcekitdInProc
+    ${SOURCEKITD_SOURCE_DIR}/include/sourcekitd/sourcekitd.h
+    ${sourcekitdInProc_args}
+    MODULEMAP module.modulemap
+    INSTALL_IN_COMPONENT sourcekit-inproc
+  )
+  set_property(TARGET sourcekitdInProc APPEND_STRING PROPERTY LINK_FLAGS " -fapplication-extension")
 else()
   add_sourcekit_library(sourcekitdInProc
     ${sourcekitdInProc_args}

--- a/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-InProc.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-InProc.cpp
@@ -14,7 +14,6 @@
 #include "sourcekitd/sourcekitd.h"
 #include "sourcekitd/Internal.h"
 #include "sourcekitd/CodeCompletionResultsArray.h"
-#include "sourcekitd/DocStructureArray.h"
 #include "sourcekitd/DocSupportAnnotationArray.h"
 #include "sourcekitd/TokenAnnotationsArray.h"
 #include "sourcekitd/Logging.h"
@@ -250,10 +249,6 @@ public:
       case CustomBufferKind::TokenAnnotationsArray:
       case CustomBufferKind::DocSupportAnnotationArray:
       case CustomBufferKind::CodeCompletionResultsArray:
-      case CustomBufferKind::DocStructureArray:
-      case CustomBufferKind::InheritedTypesArray:
-      case CustomBufferKind::DocStructureElementArray:
-      case CustomBufferKind::AttributesArray:
         return SOURCEKITD_VARIANT_TYPE_ARRAY;
     }
     llvm::report_fatal_error("sourcekitd object did not resolve to a known type");
@@ -931,18 +926,6 @@ static sourcekitd_variant_t variantFromSKDObject(SKDObjectRef Object) {
           (uintptr_t)DataObject->getDataPtr(), 0 }};
       case CustomBufferKind::CodeCompletionResultsArray:
         return {{ (uintptr_t)getVariantFunctionsForCodeCompletionResultsArray(),
-          (uintptr_t)DataObject->getDataPtr(), 0 }};
-      case CustomBufferKind::DocStructureArray:
-        return {{ (uintptr_t)getVariantFunctionsForDocStructureArray(),
-          (uintptr_t)DataObject->getDataPtr(), ~size_t(0) }};
-      case CustomBufferKind::InheritedTypesArray:
-        return {{ (uintptr_t)getVariantFunctionsForInheritedTypesArray(),
-          (uintptr_t)DataObject->getDataPtr(), 0 }};
-      case CustomBufferKind::DocStructureElementArray:
-        return {{ (uintptr_t)getVariantFunctionsForDocStructureElementArray(),
-          (uintptr_t)DataObject->getDataPtr(), 0 }};
-      case CustomBufferKind::AttributesArray:
-        return {{ (uintptr_t)getVariantFunctionsForAttributesArray(),
           (uintptr_t)DataObject->getDataPtr(), 0 }};
     }
   }

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -153,7 +153,6 @@ KNOWN_SETTINGS=(
     long-test                   "0"              "set to run the long test suite"
     skip-test-benchmarks        ""               "set to skip running Swift Benchmark Suite"
     skip-test-optimized         ""               "set to skip testing the test suite in optimized mode"
-    skip-test-sourcekit         ""               "set to skip testing SourceKit"
     stress-test-sourcekit       ""               "set to run the stress-SourceKit target"
     workspace                   "${HOME}/src"    "source directory containing llvm, clang, swift"
     enable-llvm-assertions      "1"              "set to enable llvm assertions"
@@ -1891,13 +1890,6 @@ for host in "${ALL_HOSTS[@]}"; do
         -DSWIFT_SIL_VERIFY_ALL:BOOL=$(true_false "${SIL_VERIFY_ALL}")
         -DSWIFT_RUNTIME_ENABLE_LEAK_CHECKER:BOOL=$(true_false "${SWIFT_RUNTIME_ENABLE_LEAK_CHECKER}")
     )
-
-    if [[ "${SKIP_TEST_SOURCEKIT}" ]] ; then
-        swift_cmake_options=(
-            "${swift_cmake_options[@]}"
-            -DSWIFT_ENABLE_SOURCEKIT_TESTS:BOOL=FALSE
-        )
-    fi
 
     for product in "${PRODUCTS[@]}"; do
         # Check if we should perform this action.

--- a/validation-test/lit.site.cfg.in
+++ b/validation-test/lit.site.cfg.in
@@ -65,9 +65,6 @@ else:
 if "@SWIFT_OPTIMIZED@" == "TRUE":
     config.available_features.add("optimized_stdlib")
 
-if "@SWIFT_ENABLE_SOURCEKIT_TESTS@" == "TRUE":
-    config.available_features.add('sourcekit')
-
 if "@SWIFT_STDLIB_ENABLE_RESILIENCE@" == "TRUE":
     config.available_features.add("resilient_stdlib")
 


### PR DESCRIPTION
Reverts apple/swift#8485

We have seen some failures on linux that look related to this commit.

One example is here:
https://ci.swift.org/job/oss-swift-incremental-RA-linux-ubuntu-14_04/2239/

Speculatively, reverting to get the bots blue.