### PR TITLE
[ClangImporter] If enum_extensibility was removed, it's not an enum.

### DIFF
--- a/lib/ClangImporter/ImportEnumInfo.cpp
+++ b/lib/ClangImporter/ImportEnumInfo.cpp
@@ -60,6 +60,18 @@ void EnumInfo::classifyEnum(ASTContext &ctx, const clang::EnumDecl *decl,
     return;
   }
 
+  // If API notes have /removed/ a FlagEnum or EnumExtensibility attribute,
+  // then we don't need to check the macros.
+  for (auto *attr : decl->specific_attrs<clang::SwiftVersionedAttr>()) {
+    if (!attr->getVersion().empty())
+      continue;
+    if (isa<clang::FlagEnumAttr>(attr->getAttrToAdd()) ||
+        isa<clang::EnumExtensibilityAttr>(attr->getAttrToAdd())) {
+      kind = EnumKind::Unknown;
+      return;
+    }
+  }
+
   // Was the enum declared using *_ENUM or *_OPTIONS?
   // FIXME: Stop using these once flag_enum and enum_extensibility
   // have been adopted everywhere, or at least relegate them to Swift 3 mode

--- a/test/ClangImporter/enum.swift
+++ b/test/ClangImporter/enum.swift
@@ -11,6 +11,7 @@
 
 import Foundation
 import user_objc
+import enums_using_attributes
 
 // NS_ENUM
 var mince = NSRuncingMode.mince
@@ -149,6 +150,7 @@ var topLevelCaseName = RuncingMince // expected-error{{}}
 #endif
 
 let _: EnumViaAttribute = .first
+let _: CFEnumWithAttr = .first
 
 // NS_OPTIONS
 var withMince: NSRuncingOptions = .enableMince
@@ -196,6 +198,7 @@ let objcFlags: objc_flags = [.taggedPointer, .swiftRefcount]
 
 let optionsWithSwiftName: NSOptionsAlsoGetSwiftName = .Case
 let optionsViaAttribute: OptionsViaAttribute = [.first, .second]
+let optionsViaAttribute2: CFOptionsWithAttr = [.first]
 
 // <rdar://problem/25168818> Don't import None members in NS_OPTIONS types
 #if !IRGEN
@@ -211,3 +214,10 @@ _ = EmptySet3.None
 // Just use this type, making sure that its case alias doesn't cause problems.
 // rdar://problem/30401506
 _ = EnumWithAwkwardDeprecations.normalCase1
+
+#if !IRGEN
+let _: UnknownEnumThanksToAPINotes = .first // expected-error {{has no member 'first'}}
+let _: UnknownOptionsThanksToAPINotes = .first // expected-error {{has no member 'first'}}
+#endif
+let _ = UnknownEnumThanksToAPINotesFirst
+let _ = UnknownOptionsThanksToAPINotesFirst

--- a/test/Inputs/clang-importer-sdk/usr/include/enums_using_attributes.apinotes
+++ b/test/Inputs/clang-importer-sdk/usr/include/enums_using_attributes.apinotes
@@ -1,0 +1,6 @@
+Name: enums_using_attributes
+Tags:
+- Name: UnknownEnumThanksToAPINotes
+  EnumKind: none
+- Name: UnknownOptionsThanksToAPINotes
+  EnumKind: none

--- a/test/Inputs/clang-importer-sdk/usr/include/enums_using_attributes.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/enums_using_attributes.h
@@ -1,0 +1,18 @@
+#define CF_ENUM(_type, _name) enum _name : _type _name; \
+  enum __attribute__((enum_extensibility(open))) _name : _type
+#define CF_OPTIONS(_type, _name) enum _name : _type _name; \
+  enum __attribute__((enum_extensibility(open), flag_enum)) _name : _type
+
+typedef CF_ENUM(int, CFEnumWithAttr) {
+  CFEnumWithAttrFirst = 1,
+};
+typedef CF_ENUM(int, UnknownEnumThanksToAPINotes) {
+  UnknownEnumThanksToAPINotesFirst = 1,
+};
+
+typedef CF_OPTIONS(int, CFOptionsWithAttr) {
+  CFOptionsWithAttrFirst = 1,
+};
+typedef CF_OPTIONS(int, UnknownOptionsThanksToAPINotes) {
+  UnknownOptionsThanksToAPINotesFirst = 1,
+};

--- a/test/Inputs/clang-importer-sdk/usr/include/module.map
+++ b/test/Inputs/clang-importer-sdk/usr/include/module.map
@@ -98,6 +98,10 @@ module objc_structs {
   export *
 }
 
+module enums_using_attributes {
+  header "enums_using_attributes.h"
+}
+
 module errors {
   header "errors.h"
   export *


### PR DESCRIPTION
(and similar for flag_enum)

This commit prepares the importer for a world in which NS_ENUM and NS_OPTIONS have adopted the new Clang attributes `enum_extensibility` and `flag_enum`, but API notes are used to reverse the effect. Without this there would be no transition path for adopting the standard Cocoa macros, which have applied unconditionally up to now.

rdar://problem/18744821