### PR TITLE
[NFC][Gardening] Minor cleanup in patterns

### DIFF
--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -78,7 +78,7 @@ static void dumpPattern(const Pattern *p, llvm::raw_ostream &os) {
   }
 
   case PatternKind::OptionalSome:
-    os << ".Some";
+    os << ".some";
     return;
 
   case PatternKind::Bool:
@@ -515,11 +515,6 @@ public:
     return Columns;
   }
 
-  /// Add new columns to the end of the row.
-  void addColumns(ArrayRef<Pattern *> columns) {
-    Columns.append(columns.begin(), columns.end());
-  }
-
   /// Specialize the given column to the given array of new columns.
   ///
   /// Places the new columns using the column-specialization algorithm.
@@ -680,7 +675,7 @@ void ClauseMatrix::print(llvm::raw_ostream &out) const {
       std::string &str = rowStrings.back();
       {
         llvm::raw_string_ostream ss(str);
-        dumpPattern(row[r], ss);
+        dumpPattern(row[c], ss);
         ss.flush();
       }
 


### PR DESCRIPTION
Some things noticed by inspection:

- Old spelling of Optional.some
- pattern dump was using the wrong iterator variable and would crash
- `addColumns` is never used because the row matrix doesn’t expand tuples
