### PR TITLE
[Type checker] Fix rethrow checking with a single argument label harder.

### DIFF
--- a/lib/Sema/TypeCheckError.cpp
+++ b/lib/Sema/TypeCheckError.cpp
@@ -665,9 +665,9 @@ private:
   Classification classifyRethrowsArgument(Expr *arg, Type paramType) {
     arg = arg->getValueProvidingExpr();
 
-    // If the parameter was a tuple, try to look through the various
-    // tuple operations.
-    if (auto paramTupleType = paramType->getAs<TupleType>()) {
+    // If the parameter was structurally a tuple, try to look through the
+    // various tuple operations.
+    if (auto paramTupleType = dyn_cast<TupleType>(paramType.getPointer())) {
       if (auto tuple = dyn_cast<TupleExpr>(arg)) {
         return classifyTupleRethrowsArgument(tuple, paramTupleType);
       } else if (auto shuffle = dyn_cast<TupleShuffleExpr>(arg)) {
@@ -675,8 +675,7 @@ private:
       }
 
       int scalarElt = paramTupleType->getElementForScalarInit();
-      if (scalarElt < 0 ||
-          !paramTupleType->getElementType(scalarElt)->isEqual(arg->getType())) {
+      if (scalarElt < 0) {
         // Otherwise, we're passing an opaque tuple expression, and we
         // should treat it as contributing to 'rethrows' if the original
         // parameter type included a throwing function type.

--- a/test/decl/func/rethrows.swift
+++ b/test/decl/func/rethrows.swift
@@ -480,6 +480,11 @@ func throwWhileGettingFoo() throws -> Foo.Type { return Foo.self }
 // <rdar://problem/31794932> [Source compatibility] Call to sort(by):) can throw, but is not marked with 'try'
 func doRethrow(fn: (Int, Int) throws -> Int) rethrows { }
 
+struct DoRethrowGeneric<T> {
+  func method(fn: (T, T) throws -> T) rethrows { }
+}
+
 func testDoRethrow() {
   doRethrow(fn:) { (a, b) in return a }
+  DoRethrowGeneric<Int>().method(fn:) { (a, b) in return a }
 }


### PR DESCRIPTION
My original fix for rdar://problem/31794932 didn't work for generic
functions because it was checking in the unsubstituted interface
type. Check structurally instead. Fixes rdar://problem/31794932.

