### PR TITLE
Foundation Encoders

### DIFF
--- a/stdlib/public/SDK/Foundation/CMakeLists.txt
+++ b/stdlib/public/SDK/Foundation/CMakeLists.txt
@@ -6,6 +6,7 @@ add_swift_library(swiftFoundation ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SD
   Boxing.swift
   Calendar.swift
   CharacterSet.swift
+  Codable.swift
   Data.swift
   DataThunks.m
   Date.swift
@@ -17,6 +18,7 @@ add_swift_library(swiftFoundation ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SD
   Foundation.swift
   IndexPath.swift
   IndexSet.swift
+  JSONEncoder.swift
   Locale.swift
   Measurement.swift
   Notification.swift
@@ -41,6 +43,7 @@ add_swift_library(swiftFoundation ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SD
   NSURL.swift
   NSValue.swift.gyb
   PersonNameComponents.swift
+  PlistEncoder.swift
   ReferenceConvertible.swift
   String.swift
   TimeZone.swift

--- a/stdlib/public/SDK/Foundation/Codable.swift
+++ b/stdlib/public/SDK/Foundation/Codable.swift
@@ -30,34 +30,6 @@ extension Data : Codable {
     private enum CodingKeys : Int, CodingKey {
         case length
         case bytes
-
-        // TODO: Remove these when derived conformance is merged.
-        var stringValue: String {
-            switch self {
-            case .length: return "length"
-            case .bytes: return "bytes"
-            }
-        }
-
-        init?(stringValue: String) {
-            switch stringValue {
-            case "length": self = .length
-            case "bytes": self = .bytes
-            default: return nil
-            }
-        }
-
-        var intValue: Int? {
-            return self.rawValue
-        }
-
-        init?(intValue: Int) {
-            switch intValue {
-            case 0: self = .length
-            case 1: self = .bytes
-            default: return nil
-            }
-        }
     }
 
     public init(from decoder: Decoder) throws {

--- a/stdlib/public/SDK/Foundation/Codable.swift
+++ b/stdlib/public/SDK/Foundation/Codable.swift
@@ -1,0 +1,200 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+//===----------------------------------------------------------------------===//
+// Codable Extensions
+//===----------------------------------------------------------------------===//
+
+extension Date : Codable {
+    public init(from decoder: Decoder) throws {
+        let timestamp = try decoder.singleValueContainer().decode(Double.self)
+        self.init(timeIntervalSince1970: timestamp)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(self.timeIntervalSince1970)
+    }
+}
+
+extension Data : Codable {
+    private enum CodingKeys : Int, CodingKey {
+        case length
+        case bytes
+
+        // TODO: Remove these when derived conformance is merged.
+        var stringValue: String {
+            switch self {
+            case .length: return "length"
+            case .bytes: return "bytes"
+            }
+        }
+
+        init?(stringValue: String) {
+            switch stringValue {
+            case "length": self = .length
+            case "bytes": self = .bytes
+            default: return nil
+            }
+        }
+
+        var intValue: Int? {
+            return self.rawValue
+        }
+
+        init?(intValue: Int) {
+            switch intValue {
+            case 0: self = .length
+            case 1: self = .bytes
+            default: return nil
+            }
+        }
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let length = try container.decode(Int.self, forKey: .length)
+        guard length >= 0 else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath,
+                                                                    debugDescription: "Cannot decode a Data of negative length \(length)."))
+        }
+
+        var bytesContainer = try container.nestedUnkeyedContainer(forKey: .bytes)
+
+        self.init(capacity: length)
+        for i in 0 ..< length {
+            let byte = try bytesContainer.decode(UInt8.self)
+            self[i] = byte
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.count, forKey: .length)
+
+        var bytesContainer = container.nestedUnkeyedContainer(forKey: .bytes)
+
+        // Since enumerateBytes does not rethrow, we need to catch the error, stow it away, and rethrow if we stopped.
+        var caughtError: Error? = nil
+        self.enumerateBytes { (buffer: UnsafeBufferPointer<UInt8>, byteIndex: Data.Index, stop: inout Bool) in
+            do {
+                for byte in buffer {
+                    try bytesContainer.encode(byte)
+                }
+            } catch {
+                caughtError = error
+                stop = true
+            }
+        }
+
+        if let error = caughtError {
+            throw error
+        }
+    }
+}
+
+//===----------------------------------------------------------------------===//
+// Errors
+//===----------------------------------------------------------------------===//
+
+// Adding the following extensions to EncodingError and DecodingError allows them to bridge to NSErrors implicitly.
+
+fileprivate let NSCodingPathErrorKey = "NSCodingPath"
+fileprivate let NSDebugDescriptionErrorKey = "NSDebugDescription"
+
+extension EncodingError : CustomNSError {
+    public static var errorDomain: String = NSCocoaErrorDomain
+
+    public var errorCode: Int {
+        switch self {
+        case .invalidValue(_, _): return CocoaError.coderInvalidValue.rawValue
+        }
+    }
+
+    public var errorUserInfo: [String : Any] {
+        let context: Context
+        switch self {
+        case .invalidValue(_, let c): context = c
+        }
+
+        return [NSCodingPathErrorKey: context.codingPath,
+                NSDebugDescriptionErrorKey: context.debugDescription]
+    }
+}
+
+extension DecodingError : CustomNSError {
+    public static var errorDomain: String = NSCocoaErrorDomain
+
+    public var errorCode: Int {
+        switch self {
+        case .valueNotFound(_, _): fallthrough
+        case .keyNotFound(_, _):
+            return CocoaError._coderValueNotFound.rawValue
+
+        case .typeMismatch(_, _): fallthrough
+        case .dataCorrupted(_):
+            return CocoaError._coderReadCorrupt.rawValue
+        }
+    }
+
+    public var errorUserInfo: [String : Any]? {
+        let context: Context
+        switch self {
+        case .typeMismatch(_, let c): context = c
+        case .valueNotFound(_, let c): context = c
+        case .keyNotFound(_, let c): context = c
+        case .dataCorrupted(let c): context = c
+        }
+
+        return [NSCodingPathErrorKey: context.codingPath,
+                NSDebugDescriptionErrorKey: context.debugDescription]
+    }
+}
+
+//===----------------------------------------------------------------------===//
+// Error Utilities
+//===----------------------------------------------------------------------===//
+
+internal extension DecodingError {
+    /// Returns a `.typeMismatch` error describing the expected type.
+    ///
+    /// - parameter path: The path of `CodingKey`s taken to decode a value of this type.
+    /// - parameter expectation: The type expected to be encountered.
+    /// - parameter reality: The value that was encountered instead of the expected type.
+    /// - returns: A `DecodingError` with the appropriate path and debug description.
+    internal static func _typeMismatch(at path: [CodingKey?], expectation: Any.Type, reality: Any) -> DecodingError {
+        let description = "Expected to decode \(expectation) but found \(_typeDescription(of: reality)) instead."
+        return .typeMismatch(expectation, Context(codingPath: path, debugDescription: description))
+    }
+
+    /// Returns a description of the type of `value` appropriate for an error message.
+    ///
+    /// - parameter value: The value whose type to describe.
+    /// - returns: A string describing `value`.
+    /// - precondition: `value` is one of the types below.
+    fileprivate static func _typeDescription(of value: Any) -> String {
+        if value is NSNull {
+            return "a null value"
+        } else if value is NSNumber /* FIXME: If swift-corelibs-foundation isn't updated to use NSNumber, this check will be necessary: || value is Int || value is Double */ {
+            return "a number"
+        } else if value is String {
+            return "a string/data"
+        } else if value is [Any] {
+            return "an array"
+        } else if value is [String : Any] {
+            return "a dictionary"
+        } else {
+            // This should never happen -- we somehow have a non-JSON type here.
+            preconditionFailure("Invalid storage type \(type(of: value)).")
+        }
+    }
+}

--- a/stdlib/public/SDK/Foundation/Codable.swift
+++ b/stdlib/public/SDK/Foundation/Codable.swift
@@ -59,9 +59,7 @@ extension Data : Codable {
         var caughtError: Error? = nil
         self.enumerateBytes { (buffer: UnsafeBufferPointer<UInt8>, byteIndex: Data.Index, stop: inout Bool) in
             do {
-                for byte in buffer {
-                    try bytesContainer.encode(byte)
-                }
+                try bytesContainer.encode(contentsOf: buffer)
             } catch {
                 caughtError = error
                 stop = true

--- a/stdlib/public/SDK/Foundation/Codable.swift
+++ b/stdlib/public/SDK/Foundation/Codable.swift
@@ -17,12 +17,12 @@
 extension Date : Codable {
     public init(from decoder: Decoder) throws {
         let timestamp = try decoder.singleValueContainer().decode(Double.self)
-        self.init(timeIntervalSince1970: timestamp)
+        self.init(timeIntervalSinceReferenceDate: timestamp)
     }
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
-        try container.encode(self.timeIntervalSince1970)
+        try container.encode(self.timeIntervalSinceReferenceDate)
     }
 }
 

--- a/stdlib/public/SDK/Foundation/JSONEncoder.swift
+++ b/stdlib/public/SDK/Foundation/JSONEncoder.swift
@@ -1,0 +1,1846 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+//===----------------------------------------------------------------------===//
+// JSON Encoder
+//===----------------------------------------------------------------------===//
+
+/// `JSONEncoder` facilitates the encoding of `Encodable` values into JSON.
+open class JSONEncoder {
+    // MARK: Options
+
+    /// The formatting of the output JSON data.
+    public enum OutputFormatting {
+        /// Produce JSON compacted by removing whitespace. This is the default formatting.
+        case compact
+
+        /// Produce human-readable JSON with indented output.
+        case prettyPrinted
+    }
+
+    /// The strategy to use for encoding `Date` values.
+    public enum DateEncodingStrategy {
+        /// Defer to `Date` for choosing an encoding. This is the default strategy.
+        case deferredToDate
+
+        /// Encode the `Date` as a UNIX timestamp (as a JSON number).
+        case secondsSince1970
+
+        /// Encode the `Date` as UNIX millisecond timestamp (as a JSON number).
+        case millisecondsSince1970
+
+        /// Encode the `Date` as an ISO-8601-formatted string (in RFC 3339 format).
+        @available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
+        case iso8601
+
+        /// Encode the `Date` as a string formatted by the given formatter.
+        case formatted(DateFormatter)
+
+        /// Encode the `Date` as a custom value encoded by the given closure.
+        ///
+        /// If the closure fails to encode a value into the given encoder, the encoder will encode an empty automatic container in its place.
+        case custom((Date, Encoder) throws -> Void)
+    }
+
+    /// The strategy to use for encoding `Data` values.
+    public enum DataEncodingStrategy {
+        /// Encoded the `Data` as a Base64-encoded string. This is the default strategy.
+        case base64Encode
+
+        /// Encode the `Data` as a custom value encoded by the given closure.
+        ///
+        /// If the closure fails to encode a value into the given encoder, the encoder will encode an empty automatic container in its place.
+        case custom((Data, Encoder) throws -> Void)
+    }
+
+    /// The strategy to use for non-JSON-conforming floating-point values (IEEE 754 infinity and NaN).
+    public enum NonConformingFloatEncodingStrategy {
+        /// Throw upon encountering non-conforming values. This is the default strategy.
+        case `throw`
+
+        /// Encode the values using the given representation strings.
+        case convertToString(positiveInfinity: String, negativeInfinity: String, nan: String)
+    }
+
+    /// The output format to produce. Defaults to `.compact`.
+    open var outputFormatting: OutputFormatting = .compact
+
+    /// The strategy to use in encoding dates. Defaults to `.deferredToDate`.
+    open var dateEncodingStrategy: DateEncodingStrategy = .deferredToDate
+
+    /// The strategy to use in encoding binary data. Defaults to `.base64Encode`.
+    open var dataEncodingStrategy: DataEncodingStrategy = .base64Encode
+
+    /// The strategy to use in encoding non-conforming numbers. Defaults to `.throw`.
+    open var nonConformingFloatEncodingStrategy: NonConformingFloatEncodingStrategy = .throw
+
+    /// Contextual user-provided information for use during encoding.
+    open var userInfo: [CodingUserInfoKey : Any] = [:]
+
+    /// Options set on the top-level encoder to pass down the encoding hierarchy.
+    fileprivate struct _Options {
+        let dateEncodingStrategy: DateEncodingStrategy
+        let dataEncodingStrategy: DataEncodingStrategy
+        let nonConformingFloatEncodingStrategy: NonConformingFloatEncodingStrategy
+        let userInfo: [CodingUserInfoKey : Any]
+    }
+
+    /// The options set on the top-level encoder.
+    fileprivate var options: _Options {
+        return _Options(dateEncodingStrategy: dateEncodingStrategy,
+                        dataEncodingStrategy: dataEncodingStrategy,
+                        nonConformingFloatEncodingStrategy: nonConformingFloatEncodingStrategy,
+                        userInfo: userInfo)
+    }
+
+    // MARK: - Constructing a JSON Encoder
+
+    /// Initializes `self` with default strategies.
+    public init() {}
+
+    // MARK: - Encoding Values
+
+    /// Encodes the given top-level value and returns its JSON representation.
+    ///
+    /// - parameter value: The value to encode.
+    /// - returns: A new `Data` value containing the encoded JSON data.
+    /// - throws: `EncodingError.invalidValue` if a non-comforming floating-point value is encountered during encoding, and the encoding strategy is `.throw`.
+    /// - throws: An error if any value throws an error during encoding.
+    open func encode<T : Encodable>(_ value: T) throws -> Data {
+        let encoder = _JSONEncoder(options: self.options)
+        try value.encode(to: encoder)
+
+        guard encoder.storage.count > 0 else {
+            throw EncodingError.invalidValue(value, EncodingError.Context(codingPath: [], debugDescription: "Top-level \(T.self) did not encode any values."))
+        }
+
+        let topLevel = encoder.storage.popContainer()
+        if topLevel is NSNull {
+            throw EncodingError.invalidValue(value, EncodingError.Context(codingPath: [], debugDescription: "Top-level \(T.self) encoded as null JSON fragment."))
+        } else if topLevel is NSNumber {
+            throw EncodingError.invalidValue(value, EncodingError.Context(codingPath: [], debugDescription: "Top-level \(T.self) encoded as number JSON fragment."))
+        } else if topLevel is NSString {
+            throw EncodingError.invalidValue(value, EncodingError.Context(codingPath: [], debugDescription: "Top-level \(T.self) encoded as string JSON fragment."))
+        }
+
+        return try JSONSerialization.data(withJSONObject: topLevel, options: outputFormatting == .prettyPrinted ? .prettyPrinted : [])
+    }
+}
+
+// MARK: - _JSONEncoder
+
+fileprivate class _JSONEncoder : Encoder {
+    // MARK: Properties
+
+    /// The encoder's storage.
+    var storage: _JSONEncodingStorage
+
+    /// Options set on the top-level encoder.
+    let options: JSONEncoder._Options
+
+    /// The path to the current point in encoding.
+    var codingPath: [CodingKey?] = []
+
+    /// Contextual user-provided information for use during encoding.
+    var userInfo: [CodingUserInfoKey : Any] {
+        return self.options.userInfo
+    }
+
+    // MARK: - Initialization
+
+    /// Initializes `self` with the given top-level encoder options.
+    init(options: JSONEncoder._Options) {
+        self.options = options
+        self.storage = _JSONEncodingStorage()
+    }
+
+    // MARK: - Coding Path Actions
+
+    /// Performs the given closure with the given key pushed onto the end of the current coding path.
+    ///
+    /// - parameter key: The key to push. May be nil for unkeyed containers.
+    /// - parameter work: The work to perform with the key in the path.
+    func with(pushedKey key: CodingKey?, _ work: () throws -> ()) rethrows {
+        self.codingPath.append(key)
+        try work()
+        self.codingPath.removeLast()
+    }
+
+    /// Asserts that a new container can be requested at this coding path.
+    /// `preconditionFailure()`s if one cannot be requested.
+    func assertCanRequestNewContainer() {
+        // Every time a new value gets encoded, the key it's encoded for is pushed onto the coding path (even if it's a nil key from an unkeyed container).
+        // At the same time, every time a container is requested, a new value gets pushed onto the storage stack.
+        // If there are more values on the storage stack than on the coding path, it means the value is requesting more than one container, which violates the precondition.
+
+        // This means that anytime something that can request a new container goes onto the stack, we MUST push a key onto the coding path.
+        // Things which will not request containers do not need to have the coding path extended for them (but it doesn't matter if it is, because they will not reach here).
+        guard self.storage.count == self.codingPath.count else {
+            let previousContainerType: String
+            if self.storage.containers.last is NSDictionary {
+                previousContainerType = "keyed"
+            } else if self.storage.containers.last is NSArray {
+                previousContainerType = "unkeyed"
+            } else {
+                previousContainerType = "single value"
+            }
+
+            preconditionFailure("Attempt to encode with new container when already encoded with \(previousContainerType) container.")
+        }
+    }
+
+    // MARK: - Encoder Methods
+    func container<Key>(keyedBy: Key.Type) -> KeyedEncodingContainer<Key> {
+        assertCanRequestNewContainer()
+        let container = self.storage.pushKeyedContainer()
+        let wrapper = _JSONKeyedEncodingContainer<Key>(referencing: self, wrapping: container)
+        return KeyedEncodingContainer(wrapper)
+    }
+
+    func unkeyedContainer() -> UnkeyedEncodingContainer {
+        assertCanRequestNewContainer()
+        let container = self.storage.pushUnkeyedContainer()
+        return _JSONUnkeyedEncodingContainer(referencing: self, wrapping: container)
+    }
+
+    func singleValueContainer() -> SingleValueEncodingContainer {
+        assertCanRequestNewContainer()
+        return self
+    }
+}
+
+// MARK: - Encoding Storage and Containers
+
+fileprivate struct _JSONEncodingStorage {
+    // MARK: Properties
+
+    /// The container stack.
+    /// Elements may be any one of the JSON types (NSNull, NSNumber, NSString, NSArray, NSDictionary).
+    private(set) var containers: [NSObject] = []
+
+    // MARK: - Initialization
+
+    /// Initializes `self` with no containers.
+    init() {}
+
+    // MARK: - Modifying the Stack
+
+    var count: Int {
+        return self.containers.count
+    }
+
+    mutating func pushKeyedContainer() -> NSMutableDictionary {
+        let dictionary = NSMutableDictionary()
+        self.containers.append(dictionary)
+        return dictionary
+    }
+
+    mutating func pushUnkeyedContainer() -> NSMutableArray {
+        let array = NSMutableArray()
+        self.containers.append(array)
+        return array
+    }
+
+    mutating func push(container: NSObject) {
+        self.containers.append(container)
+    }
+
+    mutating func popContainer() -> NSObject {
+        precondition(self.containers.count > 0, "Empty container stack.")
+        return self.containers.popLast()!
+    }
+}
+
+// MARK: - Encoding Containers
+
+fileprivate struct _JSONKeyedEncodingContainer<K : CodingKey> : KeyedEncodingContainerProtocol {
+    typealias Key = K
+
+    // MARK: Properties
+
+    /// A reference to the encoder we're writing to.
+    let encoder: _JSONEncoder
+
+    /// A reference to the container we're writing to.
+    let container: NSMutableDictionary
+
+    // MARK: - Initialization
+
+    /// Initializes `self` with the given references.
+    init(referencing encoder: _JSONEncoder, wrapping container: NSMutableDictionary) {
+        self.encoder = encoder
+        self.container = container
+    }
+
+    // MARK: - KeyedEncodingContainerProtocol Methods
+
+    var codingPath: [CodingKey?] {
+        return self.encoder.codingPath
+    }
+
+    mutating func encode(_ value: Bool?, forKey key: Key)   throws { self.container[key.stringValue] = self.encoder.box(value) }
+    mutating func encode(_ value: Int?, forKey key: Key)    throws { self.container[key.stringValue] = self.encoder.box(value) }
+    mutating func encode(_ value: Int8?, forKey key: Key)   throws { self.container[key.stringValue] = self.encoder.box(value) }
+    mutating func encode(_ value: Int16?, forKey key: Key)  throws { self.container[key.stringValue] = self.encoder.box(value) }
+    mutating func encode(_ value: Int32?, forKey key: Key)  throws { self.container[key.stringValue] = self.encoder.box(value) }
+    mutating func encode(_ value: Int64?, forKey key: Key)  throws { self.container[key.stringValue] = self.encoder.box(value) }
+    mutating func encode(_ value: UInt?, forKey key: Key)   throws { self.container[key.stringValue] = self.encoder.box(value) }
+    mutating func encode(_ value: UInt8?, forKey key: Key)  throws { self.container[key.stringValue] = self.encoder.box(value) }
+    mutating func encode(_ value: UInt16?, forKey key: Key) throws { self.container[key.stringValue] = self.encoder.box(value) }
+    mutating func encode(_ value: UInt32?, forKey key: Key) throws { self.container[key.stringValue] = self.encoder.box(value) }
+    mutating func encode(_ value: UInt64?, forKey key: Key) throws { self.container[key.stringValue] = self.encoder.box(value) }
+    mutating func encode(_ value: String?, forKey key: Key) throws { self.container[key.stringValue] = self.encoder.box(value) }
+
+    mutating func encode(_ value: Float?, forKey key: Key)  throws {
+        // Since the float may be invalid and throw, the coding path needs to contain this key.
+        try self.encoder.with(pushedKey: key) {
+            self.container[key.stringValue] = try self.encoder.box(value)
+        }
+    }
+
+    mutating func encode(_ value: Double?, forKey key: Key) throws {
+        // Since the double may be invalid and throw, the coding path needs to contain this key.
+        try self.encoder.with(pushedKey: key) {
+            self.container[key.stringValue] = try self.encoder.box(value)
+        }
+    }
+
+    mutating func encode<T : Encodable>(_ value: T?, forKey key: Key) throws {
+        try self.encoder.with(pushedKey: key) {
+            self.container[key.stringValue] = try self.encoder.box(value)
+        }
+    }
+
+    mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type, forKey key: Key) -> KeyedEncodingContainer<NestedKey> {
+        let container = self.encoder.storage.pushKeyedContainer()
+        self.container[key.stringValue] = container
+        let wrapper = _JSONKeyedEncodingContainer<NestedKey>(referencing: self.encoder, wrapping: container)
+        return KeyedEncodingContainer(wrapper)
+    }
+
+    mutating func nestedUnkeyedContainer(forKey key: Key) -> UnkeyedEncodingContainer {
+        let container = self.encoder.storage.pushUnkeyedContainer()
+        self.container[key.stringValue] = container
+        return _JSONUnkeyedEncodingContainer(referencing: self.encoder, wrapping: container)
+    }
+
+    mutating func superEncoder() -> Encoder {
+        return _JSONReferencingEncoder(referencing: self.encoder, wrapping: self.container, key: "super")
+    }
+
+    mutating func superEncoder(forKey key: Key) -> Encoder {
+        return _JSONReferencingEncoder(referencing: self.encoder, wrapping: self.container, key: key.stringValue)
+    }
+}
+
+fileprivate struct _JSONUnkeyedEncodingContainer : UnkeyedEncodingContainer {
+    // MARK: Properties
+
+    /// A reference to the encoder we're writing to.
+    let encoder: _JSONEncoder
+
+    /// A reference to the container we're writing to.
+    let container: NSMutableArray
+
+    // MARK: - Initialization
+
+    /// Initializes `self` with the given references.
+    init(referencing encoder: _JSONEncoder, wrapping container: NSMutableArray) {
+        self.encoder = encoder
+        self.container = container
+    }
+
+    // MARK: - UnkeyedEncodingContainer Methods
+
+    var codingPath: [CodingKey?] {
+        return self.encoder.codingPath
+    }
+
+    mutating func encode(_ value: Bool?)   throws { self.container.add(self.encoder.box(value)) }
+    mutating func encode(_ value: Int?)    throws { self.container.add(self.encoder.box(value)) }
+    mutating func encode(_ value: Int8?)   throws { self.container.add(self.encoder.box(value)) }
+    mutating func encode(_ value: Int16?)  throws { self.container.add(self.encoder.box(value)) }
+    mutating func encode(_ value: Int32?)  throws { self.container.add(self.encoder.box(value)) }
+    mutating func encode(_ value: Int64?)  throws { self.container.add(self.encoder.box(value)) }
+    mutating func encode(_ value: UInt?)   throws { self.container.add(self.encoder.box(value)) }
+    mutating func encode(_ value: UInt8?)  throws { self.container.add(self.encoder.box(value)) }
+    mutating func encode(_ value: UInt16?) throws { self.container.add(self.encoder.box(value)) }
+    mutating func encode(_ value: UInt32?) throws { self.container.add(self.encoder.box(value)) }
+    mutating func encode(_ value: UInt64?) throws { self.container.add(self.encoder.box(value)) }
+    mutating func encode(_ value: String?) throws { self.container.add(self.encoder.box(value)) }
+
+    mutating func encode(_ value: Float?)  throws {
+        // Since the float may be invalid and throw, the coding path needs to contain this key.
+        try self.encoder.with(pushedKey: nil) {
+            self.container.add(try self.encoder.box(value))
+        }
+    }
+
+    mutating func encode(_ value: Double?) throws {
+        // Since the double may be invalid and throw, the coding path needs to contain this key.
+        try self.encoder.with(pushedKey: nil) {
+            self.container.add(try self.encoder.box(value))
+        }
+    }
+
+    mutating func encode<T : Encodable>(_ value: T?) throws {
+        try self.encoder.with(pushedKey: nil) {
+            self.container.add(try self.encoder.box(value))
+        }
+    }
+
+    mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type) -> KeyedEncodingContainer<NestedKey> {
+        let container = self.encoder.storage.pushKeyedContainer()
+        self.container.add(container)
+        let wrapper = _JSONKeyedEncodingContainer<NestedKey>(referencing: self.encoder, wrapping: container)
+        return KeyedEncodingContainer(wrapper)
+    }
+
+    mutating func nestedUnkeyedContainer() -> UnkeyedEncodingContainer {
+        let container = self.encoder.storage.pushUnkeyedContainer()
+        self.container.add(container)
+        return _JSONUnkeyedEncodingContainer(referencing: self.encoder, wrapping: container)
+    }
+
+    mutating func superEncoder() -> Encoder {
+        return _JSONReferencingEncoder(referencing: self.encoder, wrapping: self.container, at: self.container.count)
+    }
+}
+
+extension _JSONEncoder : SingleValueEncodingContainer {
+    // MARK: Utility
+
+    /// Asserts that a single value can be encoded at the current coding path (i.e. that one has not already been encoded through this container).
+    /// `preconditionFailure()`s if one cannot be encoded.
+    ///
+    /// This is similar to assertCanRequestNewContainer above.
+    func assertCanEncodeSingleValue() {
+        guard self.storage.count == self.codingPath.count else {
+            let previousContainerType: String
+            if self.storage.containers.last is NSDictionary {
+                previousContainerType = "keyed"
+            } else if self.storage.containers.last is NSArray {
+                previousContainerType = "unkeyed"
+            } else {
+                preconditionFailure("Attempt to encode multiple values in a single value container.")
+            }
+
+            preconditionFailure("Attempt to encode with new container when already encoded with \(previousContainerType) container.")
+        }
+    }
+
+    // MARK: - SingleValueEncodingContainer Methods
+
+    func encode(_ value: Bool) throws {
+        assertCanEncodeSingleValue()
+        self.storage.push(container: box(value))
+    }
+
+    func encode(_ value: Int) throws {
+        assertCanEncodeSingleValue()
+        self.storage.push(container: box(value))
+    }
+
+    func encode(_ value: Int8) throws {
+        assertCanEncodeSingleValue()
+        self.storage.push(container: box(value))
+    }
+
+    func encode(_ value: Int16) throws {
+        assertCanEncodeSingleValue()
+        self.storage.push(container: box(value))
+    }
+
+    func encode(_ value: Int32) throws {
+        assertCanEncodeSingleValue()
+        self.storage.push(container: box(value))
+    }
+
+    func encode(_ value: Int64) throws {
+        assertCanEncodeSingleValue()
+        self.storage.push(container: box(value))
+    }
+
+    func encode(_ value: UInt) throws {
+        assertCanEncodeSingleValue()
+        self.storage.push(container: box(value))
+    }
+
+    func encode(_ value: UInt8) throws {
+        assertCanEncodeSingleValue()
+        self.storage.push(container: box(value))
+    }
+
+    func encode(_ value: UInt16) throws {
+        assertCanEncodeSingleValue()
+        self.storage.push(container: box(value))
+    }
+
+    func encode(_ value: UInt32) throws {
+        assertCanEncodeSingleValue()
+        self.storage.push(container: box(value))
+    }
+
+    func encode(_ value: UInt64) throws {
+        assertCanEncodeSingleValue()
+        self.storage.push(container: box(value))
+    }
+
+    func encode(_ value: String) throws {
+        assertCanEncodeSingleValue()
+        self.storage.push(container: box(value))
+    }
+
+    func encode(_ value: Float) throws {
+        assertCanEncodeSingleValue()
+        try self.storage.push(container: box(value))
+    }
+
+    func encode(_ value: Double) throws {
+        assertCanEncodeSingleValue()
+        try self.storage.push(container: box(value))
+    }
+}
+
+// MARK: - Concrete Value Representations
+
+extension _JSONEncoder {
+    /// Returns the given value boxed in a container appropriate for pushing onto the container stack.
+    fileprivate func box(_ value: Bool?)   -> NSObject { return value == nil ? NSNull() : NSNumber(value: value!) }
+    fileprivate func box(_ value: Int?)    -> NSObject { return value == nil ? NSNull() : NSNumber(value: value!) }
+    fileprivate func box(_ value: Int8?)   -> NSObject { return value == nil ? NSNull() : NSNumber(value: value!) }
+    fileprivate func box(_ value: Int16?)  -> NSObject { return value == nil ? NSNull() : NSNumber(value: value!) }
+    fileprivate func box(_ value: Int32?)  -> NSObject { return value == nil ? NSNull() : NSNumber(value: value!) }
+    fileprivate func box(_ value: Int64?)  -> NSObject { return value == nil ? NSNull() : NSNumber(value: value!) }
+    fileprivate func box(_ value: UInt?)   -> NSObject { return value == nil ? NSNull() : NSNumber(value: value!) }
+    fileprivate func box(_ value: UInt8?)  -> NSObject { return value == nil ? NSNull() : NSNumber(value: value!) }
+    fileprivate func box(_ value: UInt16?) -> NSObject { return value == nil ? NSNull() : NSNumber(value: value!) }
+    fileprivate func box(_ value: UInt32?) -> NSObject { return value == nil ? NSNull() : NSNumber(value: value!) }
+    fileprivate func box(_ value: UInt64?) -> NSObject { return value == nil ? NSNull() : NSNumber(value: value!) }
+    fileprivate func box(_ value: String?) -> NSObject { return value == nil ? NSNull() : NSString(string: value!) }
+
+    fileprivate func box(_ float: Float?) throws -> NSObject {
+        guard let float = float else {
+            return NSNull()
+        }
+
+        guard !float.isInfinite && !float.isNaN else {
+            guard case let .convertToString(positiveInfinity: posInfString,
+                                            negativeInfinity: negInfString,
+                                            nan: nanString) = self.options.nonConformingFloatEncodingStrategy else {
+                throw EncodingError._invalidFloatingPointValue(float, at: codingPath)
+            }
+
+            if float == Float.infinity {
+                return NSString(string: posInfString)
+            } else if float == -Float.infinity {
+                return NSString(string: negInfString)
+            } else {
+                return NSString(string: nanString)
+            }
+        }
+
+        return NSNumber(value: float)
+    }
+
+    fileprivate func box(_ double: Double?) throws -> NSObject {
+        guard let double = double else {
+            return NSNull()
+        }
+
+        guard !double.isInfinite && !double.isNaN else {
+            guard case let .convertToString(positiveInfinity: posInfString,
+                                            negativeInfinity: negInfString,
+                                            nan: nanString) = self.options.nonConformingFloatEncodingStrategy else {
+                throw EncodingError._invalidFloatingPointValue(double, at: codingPath)
+            }
+
+            if double == Double.infinity {
+                return NSString(string: posInfString)
+            } else if double == -Double.infinity {
+                return NSString(string: negInfString)
+            } else {
+                return NSString(string: nanString)
+            }
+        }
+
+        return NSNumber(value: double)
+    }
+
+    fileprivate func box(_ date: Date?) throws -> NSObject {
+        guard let date = date else {
+            return NSNull()
+        }
+
+        switch self.options.dateEncodingStrategy {
+        case .deferredToDate:
+            // Must be called with a surrounding with(pushedKey:) call.
+            try date.encode(to: self)
+            return self.storage.popContainer()
+
+        case .secondsSince1970:
+            return NSNumber(value: date.timeIntervalSince1970)
+
+        case .millisecondsSince1970:
+            return NSNumber(value: 1000.0 * date.timeIntervalSince1970)
+
+        case .iso8601:
+            if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
+                return NSString(string: _iso8601Formatter.string(from: date))
+            } else {
+                fatalError("ISO8601DateFormatter is unavailable on this platform.")
+            }
+
+        case .formatted(let formatter):
+            return NSString(string: formatter.string(from: date))
+
+        case .custom(let closure):
+            let depth = self.storage.count
+            try closure(date, self)
+
+            guard self.storage.count > depth else {
+                // The closure didn't encode anything. Return the default keyed container.
+                return NSDictionary()
+            }
+
+            // We can pop because the closure encoded something.
+            return self.storage.popContainer()
+        }
+    }
+
+    fileprivate func box(_ data: Data?) throws -> NSObject {
+        guard let data = data else {
+            return NSNull()
+        }
+
+        switch self.options.dataEncodingStrategy {
+        case .base64Encode:
+            return NSString(string: data.base64EncodedString())
+
+        case .custom(let closure):
+            let depth = self.storage.count
+            try closure(data, self)
+
+            guard self.storage.count > depth else {
+                // The closure didn't encode anything. Return the default keyed container.
+                return NSDictionary()
+            }
+
+            // We can pop because the closure encoded something.
+            return self.storage.popContainer()
+        }
+    }
+
+    fileprivate func box<T : Encodable>(_ value: T?) throws -> NSObject {
+        guard let value = value else {
+            return NSNull()
+        }
+
+        if T.self == Date.self {
+            // Respect Date encoding strategy
+            return try self.box((value as! Date))
+        } else if T.self == Data.self {
+            // Respect Data encoding strategy
+            return try self.box((value as! Data))
+        }
+
+        // The value should request a container from the _JSONEncoder.
+        let topContainer = self.storage.containers.last
+        try value.encode(to: self)
+
+        // The top container should be a new container.
+        guard self.storage.containers.last! !== topContainer else {
+            // If the value didn't request a container at all, encode the default container instead.
+            return NSDictionary()
+        }
+
+        return self.storage.popContainer()
+    }
+}
+
+// MARK: - _JSONReferencingEncoder
+
+/// _JSONReferencingEncoder is a special subclass of _JSONEncoder which has its own storage, but references the contents of a different encoder.
+/// It's used in superEncoder(), which returns a new encoder for encoding a superclass -- the lifetime of the encoder should not escape the scope it's created in, but it doesn't necessarily know when it's done being used (to write to the original container).
+fileprivate class _JSONReferencingEncoder : _JSONEncoder {
+    // MARK: Reference types.
+
+    /// The type of container we're referencing.
+    enum Reference {
+        /// Referencing a specific index in an array container.
+        case array(NSMutableArray, Int)
+
+        /// Referencing a specific key in a dictionary container.
+        case dictionary(NSMutableDictionary, String)
+    }
+
+    // MARK: - Properties
+
+    /// The encoder we're referencing.
+    let encoder: _JSONEncoder
+
+    /// The container reference itself.
+    let reference: Reference
+
+    // MARK: - Initialization
+
+    /// Initializes `self` by referencing the given array container in the given encoder.
+    init(referencing encoder: _JSONEncoder, wrapping array: NSMutableArray, at index: Int) {
+        self.encoder = encoder
+        self.reference = .array(array, index)
+        super.init(options: encoder.options)
+    }
+
+    /// Initializes `self` by referencing the given dictionary container in the given encoder.
+    init(referencing encoder: _JSONEncoder, wrapping dictionary: NSMutableDictionary, key: String) {
+        self.encoder = encoder
+        self.reference = .dictionary(dictionary, key)
+        super.init(options: encoder.options)
+    }
+
+
+    // MARK: - Deinitialization
+
+    // Finalizes `self` by writing the contents of our storage to the referenced encoder's storage.
+    deinit {
+        // TODO: Ensure self.storage.count == 1, otherwise something went wrong.
+        let value = self.storage.popContainer()
+        switch self.reference {
+        case .array(let array, let index):
+            array.insert(value, at: index)
+
+        case .dictionary(let dictionary, let key):
+            dictionary[NSString(string: key)] = value
+        }
+    }
+}
+
+//===----------------------------------------------------------------------===//
+// JSON Decoder
+//===----------------------------------------------------------------------===//
+
+/// `JSONDecoder` facilitates the decoding of JSON into semantic `Decodable` types.
+open class JSONDecoder {
+    // MARK: Options
+
+    /// The strategy to use for decoding `Date` values.
+    public enum DateDecodingStrategy {
+        /// Defer to `Date` for decoding. This is the default strategy.
+        case deferredToDate
+
+        /// Decode the `Date` as a UNIX timestamp from a JSON number.
+        case secondsSince1970
+
+        /// Decode the `Date` as UNIX millisecond timestamp from a JSON number.
+        case millisecondsSince1970
+
+        /// Decode the `Date` as an ISO-8601-formatted string (in RFC 3339 format).
+        @available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
+        case iso8601
+
+        /// Decode the `Date` as a string parsed by the given formatter.
+        case formatted(DateFormatter)
+
+        /// Decode the `Date` as a custom value decoded by the given closure.
+        case custom((_ decoder: Decoder) throws -> Date)
+    }
+
+    /// The strategy to use for decoding `Data` values.
+    public enum DataDecodingStrategy {
+        /// Decode the `Data` from a Base64-encoded string. This is the default strategy.
+        case base64Decode
+
+        /// Decode the `Data` as a custom value decoded by the given closure.
+        case custom((_ decoder: Decoder) throws -> Data)
+    }
+
+    /// The strategy to use for non-JSON-conforming floating-point values (IEEE 754 infinity and NaN).
+    public enum NonConformingFloatDecodingStrategy {
+        /// Throw upon encountering non-conforming values. This is the default strategy.
+        case `throw`
+
+        /// Decode the values from the given representation strings.
+        case convertFromString(positiveInfinity: String, negativeInfinity: String, nan: String)
+    }
+
+    /// The strategy to use in decoding dates. Defaults to `.deferredToDate`.
+    open var dateDecodingStrategy: DateDecodingStrategy = .deferredToDate
+
+    /// The strategy to use in decoding binary data. Defaults to `.base64Decode`.
+    open var dataDecodingStrategy: DataDecodingStrategy = .base64Decode
+
+    /// The strategy to use in decoding non-conforming numbers. Defaults to `.throw`.
+    open var nonConformingFloatDecodingStrategy: NonConformingFloatDecodingStrategy = .throw
+
+    /// Contextual user-provided information for use during decoding.
+    open var userInfo: [CodingUserInfoKey : Any] = [:]
+
+    /// Options set on the top-level encoder to pass down the decoding hierarchy.
+    fileprivate struct _Options {
+        let dateDecodingStrategy: DateDecodingStrategy
+        let dataDecodingStrategy: DataDecodingStrategy
+        let nonConformingFloatDecodingStrategy: NonConformingFloatDecodingStrategy
+        let userInfo: [CodingUserInfoKey : Any]
+    }
+
+    /// The options set on the top-level decoder.
+    fileprivate var options: _Options {
+        return _Options(dateDecodingStrategy: dateDecodingStrategy,
+                        dataDecodingStrategy: dataDecodingStrategy,
+                        nonConformingFloatDecodingStrategy: nonConformingFloatDecodingStrategy,
+                        userInfo: userInfo)
+    }
+
+    // MARK: - Constructing a JSON Decoder
+
+    /// Initializes `self` with default strategies.
+    public init() {}
+
+    // MARK: - Decoding Values
+
+    /// Decodes a top-level value of the given type from the given JSON representation.
+    ///
+    /// - parameter type: The type of the value to decode.
+    /// - parameter data: The data to decode from.
+    /// - returns: A value of the requested type.
+    /// - throws: `DecodingError.dataCorrupted` if values requested from the payload are corrupted, or if the given data is not valid JSON.
+    /// - throws: An error if any value throws an error during decoding.
+    open func decode<T : Decodable>(_ type: T.Type, from data: Data) throws -> T {
+        let topLevel = try JSONSerialization.jsonObject(with: data)
+        let decoder = _JSONDecoder(referencing: topLevel, options: self.options)
+        return try T(from: decoder)
+    }
+}
+
+// MARK: - _JSONDecoder
+
+fileprivate class _JSONDecoder : Decoder {
+    // MARK: Properties
+
+    /// The decoder's storage.
+    var storage: _JSONDecodingStorage
+
+    /// Options set on the top-level decoder.
+    let options: JSONDecoder._Options
+
+    /// The path to the current point in encoding.
+    var codingPath: [CodingKey?] = []
+
+    /// Contextual user-provided information for use during encoding.
+    var userInfo: [CodingUserInfoKey : Any] {
+        return self.options.userInfo
+    }
+
+    // MARK: - Initialization
+
+    /// Initializes `self` with the given top-level container and options.
+    init(referencing container: Any, options: JSONDecoder._Options) {
+        self.storage = _JSONDecodingStorage()
+        self.storage.push(container: container)
+        self.options = options
+    }
+
+    // MARK: - Coding Path Actions
+
+    /// Performs the given closure with the given key pushed onto the end of the current coding path.
+    ///
+    /// - parameter key: The key to push. May be nil for unkeyed containers.
+    /// - parameter work: The work to perform with the key in the path.
+    func with<T>(pushedKey key: CodingKey?, _ work: () throws -> T) rethrows -> T {
+        self.codingPath.append(key)
+        let ret: T = try work()
+        self.codingPath.removeLast()
+        return ret
+    }
+
+    // MARK: - Decoder Methods
+
+    func container<Key>(keyedBy type: Key.Type) throws -> KeyedDecodingContainer<Key> {
+        guard !(self.storage.topContainer is NSNull) else {
+            throw DecodingError.valueNotFound(KeyedDecodingContainer<Key>.self,
+                                              DecodingError.Context(codingPath: self.codingPath,
+                                                                    debugDescription: "Cannot get keyed decoding container -- found null value instead."))
+        }
+
+        guard let container = self.storage.topContainer as? [String : Any] else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: [String : Any].self, reality: self.storage.topContainer)
+        }
+
+        let wrapper = _JSONKeyedDecodingContainer<Key>(referencing: self, wrapping: container)
+        return KeyedDecodingContainer(wrapper)
+    }
+
+    func unkeyedContainer() throws -> UnkeyedDecodingContainer {
+        guard !(self.storage.topContainer is NSNull) else {
+            throw DecodingError.valueNotFound(UnkeyedDecodingContainer.self,
+                                              DecodingError.Context(codingPath: self.codingPath,
+                                                                    debugDescription: "Cannot get unkeyed decoding container -- found null value instead."))
+        }
+
+        guard let container = self.storage.topContainer as? [Any] else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: [Any].self, reality: self.storage.topContainer)
+        }
+
+        let wrapper = _JSONUnkeyedDecodingContainer(referencing: self, wrapping: container)
+        return wrapper
+    }
+
+    func singleValueContainer() throws -> SingleValueDecodingContainer {
+        guard !(self.storage.topContainer is NSNull) else {
+            throw DecodingError.valueNotFound(SingleValueDecodingContainer.self,
+                                              DecodingError.Context(codingPath: self.codingPath,
+                                                                    debugDescription: "Cannot get single value decoding container -- found null value instead."))
+        }
+
+        guard !(self.storage.topContainer is [String : Any]) else {
+            throw DecodingError.typeMismatch(SingleValueDecodingContainer.self,
+                                             DecodingError.Context(codingPath: self.codingPath,
+                                                                   debugDescription: "Cannot get single value decoding container -- found keyed container instead."))
+        }
+
+        guard !(self.storage.topContainer is [Any]) else {
+            throw DecodingError.typeMismatch(SingleValueDecodingContainer.self,
+                                             DecodingError.Context(codingPath: self.codingPath,
+                                                                   debugDescription: "Cannot get single value decoding container -- found unkeyed container instead."))
+        }
+
+        return self
+    }
+}
+
+// MARK: - Decoding Storage
+
+fileprivate struct _JSONDecodingStorage {
+    // MARK: Properties
+
+    /// The container stack.
+    /// Elements may be any one of the JSON types (NSNull, NSNumber, String, Array, [String : Any]).
+    private(set) var containers: [Any] = []
+
+    // MARK: - Initialization
+
+    /// Initializes `self` with no containers.
+    init() {}
+
+    // MARK: - Modifying the Stack
+
+    var count: Int {
+        return self.containers.count
+    }
+
+    var topContainer: Any {
+        precondition(self.containers.count > 0, "Empty container stack.")
+        return self.containers.last!
+    }
+
+    mutating func push(container: Any) {
+        self.containers.append(container)
+    }
+
+    mutating func popContainer() {
+        precondition(self.containers.count > 0, "Empty container stack.")
+        self.containers.removeLast()
+    }
+}
+
+// MARK: Decoding Containers
+
+fileprivate struct _JSONKeyedDecodingContainer<K : CodingKey> : KeyedDecodingContainerProtocol {
+    typealias Key = K
+
+    // MARK: Properties
+
+    /// A reference to the decoder we're reading from.
+    let decoder: _JSONDecoder
+
+    /// A reference to the container we're reading from.
+    let container: [String : Any]
+
+    // MARK: - Initialization
+
+    /// Initializes `self` by referencing the given decoder and container.
+    init(referencing decoder: _JSONDecoder, wrapping container: [String : Any]) {
+        self.decoder = decoder
+        self.container = container
+    }
+
+    // MARK: - KeyedDecodingContainerProtocol Methods
+
+    var codingPath: [CodingKey?] {
+        return self.decoder.codingPath
+    }
+
+    var allKeys: [Key] {
+        return self.container.keys.flatMap { Key(stringValue: $0) }
+    }
+
+    func contains(_ key: Key) -> Bool {
+        return self.container[key.stringValue] != nil
+    }
+
+    func decodeIfPresent(_ type: Bool.Type, forKey key: Key) throws -> Bool? {
+        return try self.decoder.with(pushedKey: key) {
+            return try self.decoder.unbox(self.container[key.stringValue], as: Bool.self)
+        }
+    }
+
+    func decodeIfPresent(_ type: Int.Type, forKey key: Key) throws -> Int? {
+        return try self.decoder.with(pushedKey: key) {
+            return try self.decoder.unbox(self.container[key.stringValue], as: Int.self)
+        }
+    }
+
+    func decodeIfPresent(_ type: Int8.Type, forKey key: Key) throws -> Int8? {
+        return try self.decoder.with(pushedKey: key) {
+            return try self.decoder.unbox(self.container[key.stringValue], as: Int8.self)
+        }
+    }
+
+    func decodeIfPresent(_ type: Int16.Type, forKey key: Key) throws -> Int16? {
+        return try self.decoder.with(pushedKey: key) {
+            return try self.decoder.unbox(self.container[key.stringValue], as: Int16.self)
+        }
+    }
+
+    func decodeIfPresent(_ type: Int32.Type, forKey key: Key) throws -> Int32? {
+        return try self.decoder.with(pushedKey: key) {
+            return try self.decoder.unbox(self.container[key.stringValue], as: Int32.self)
+        }
+    }
+
+    func decodeIfPresent(_ type: Int64.Type, forKey key: Key) throws -> Int64? {
+        return try self.decoder.with(pushedKey: key) {
+            return try self.decoder.unbox(self.container[key.stringValue], as: Int64.self)
+        }
+    }
+
+    func decodeIfPresent(_ type: UInt.Type, forKey key: Key) throws -> UInt? {
+        return try self.decoder.with(pushedKey: key) {
+            return try self.decoder.unbox(self.container[key.stringValue], as: UInt.self)
+        }
+    }
+
+    func decodeIfPresent(_ type: UInt8.Type, forKey key: Key) throws -> UInt8? {
+        return try self.decoder.with(pushedKey: key) {
+            return try self.decoder.unbox(self.container[key.stringValue], as: UInt8.self)
+        }
+    }
+
+    func decodeIfPresent(_ type: UInt16.Type, forKey key: Key) throws -> UInt16? {
+        return try self.decoder.with(pushedKey: key) {
+            return try self.decoder.unbox(self.container[key.stringValue], as: UInt16.self)
+        }
+    }
+
+    func decodeIfPresent(_ type: UInt32.Type, forKey key: Key) throws -> UInt32? {
+        return try self.decoder.with(pushedKey: key) {
+            return try self.decoder.unbox(self.container[key.stringValue], as: UInt32.self)
+        }
+    }
+
+    func decodeIfPresent(_ type: UInt64.Type, forKey key: Key) throws -> UInt64? {
+        return try self.decoder.with(pushedKey: key) {
+            return try self.decoder.unbox(self.container[key.stringValue], as: UInt64.self)
+        }
+    }
+
+    func decodeIfPresent(_ type: Float.Type, forKey key: Key) throws -> Float? {
+        return try self.decoder.with(pushedKey: key) {
+            return try self.decoder.unbox(self.container[key.stringValue], as: Float.self)
+        }
+    }
+
+    func decodeIfPresent(_ type: Double.Type, forKey key: Key) throws -> Double? {
+        return try self.decoder.with(pushedKey: key) {
+            return try self.decoder.unbox(self.container[key.stringValue], as: Double.self)
+        }
+    }
+
+    func decodeIfPresent(_ type: String.Type, forKey key: Key) throws -> String? {
+        return try self.decoder.with(pushedKey: key) {
+            return try self.decoder.unbox(self.container[key.stringValue], as: String.self)
+        }
+    }
+
+    func decodeIfPresent(_ type: Data.Type, forKey key: Key) throws -> Data? {
+        return try self.decoder.with(pushedKey: key) {
+            return try self.decoder.unbox(self.container[key.stringValue], as: Data.self)
+        }
+    }
+
+    func decodeIfPresent<T : Decodable>(_ type: T.Type, forKey key: Key) throws -> T? {
+        return try self.decoder.with(pushedKey: key) {
+            return try self.decoder.unbox(self.container[key.stringValue], as: T.self)
+        }
+    }
+
+    func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type, forKey key: Key) throws -> KeyedDecodingContainer<NestedKey> {
+        return try self.decoder.with(pushedKey: key) {
+            guard let value = self.container[key.stringValue] else {
+                throw DecodingError.keyNotFound(key,
+                                                DecodingError.Context(codingPath: self.codingPath,
+                                                                      debugDescription: "Cannot get \(KeyedDecodingContainer<NestedKey>.self) -- no value found for key \"\(key.stringValue)\""))
+            }
+
+            guard let container = value as? [String : Any] else {
+                throw DecodingError._typeMismatch(at: self.codingPath, expectation: [String : Any].self, reality: value)
+            }
+
+            let wrapper = _JSONKeyedDecodingContainer<NestedKey>(referencing: self.decoder, wrapping: container)
+            return KeyedDecodingContainer(wrapper)
+        }
+    }
+
+    func nestedUnkeyedContainer(forKey key: Key) throws -> UnkeyedDecodingContainer {
+        return try self.decoder.with(pushedKey: key) {
+            guard let value = self.container[key.stringValue] else {
+                throw DecodingError.keyNotFound(key,
+                                                DecodingError.Context(codingPath: self.codingPath,
+                                                                      debugDescription: "Cannot get UnkeyedDecodingContainer -- no value found for key \"\(key.stringValue)\""))
+            }
+
+            guard let container = value as? [Any] else {
+                throw DecodingError._typeMismatch(at: self.codingPath, expectation: [Any].self, reality: value)
+            }
+
+            return _JSONUnkeyedDecodingContainer(referencing: self.decoder, wrapping: container)
+        }
+    }
+
+    func _superDecoder(forKey key: CodingKey) throws -> Decoder {
+        return try self.decoder.with(pushedKey: key) {
+            guard let value = self.container[key.stringValue] else {
+                throw DecodingError.keyNotFound(key,
+                                                DecodingError.Context(codingPath: self.codingPath,
+                                                                      debugDescription: "Cannot get superDecoder() -- no value found for key \"\(key.stringValue)\""))
+            }
+
+            return _JSONDecoder(referencing: value, options: self.decoder.options)
+        }
+    }
+
+    func superDecoder() throws -> Decoder {
+        return try _superDecoder(forKey: _JSONDecodingSuperKey())
+    }
+
+    func superDecoder(forKey key: Key) throws -> Decoder {
+        return try _superDecoder(forKey: key)
+    }
+}
+
+fileprivate struct _JSONDecodingSuperKey : CodingKey {
+    init() {}
+
+    var stringValue: String { return "super" }
+    init?(stringValue: String) {
+        guard stringValue == "super" else { return nil }
+    }
+
+    var intValue: Int? { return nil }
+    init?(intValue: Int) {
+        return nil
+    }
+}
+
+fileprivate struct _JSONUnkeyedDecodingContainer : UnkeyedDecodingContainer {
+    // MARK: Properties
+
+    /// A reference to the decoder we're reading from.
+    let decoder: _JSONDecoder
+
+    /// A reference to the container we're reading from.
+    let container: [Any]
+
+    /// The index of the element we're about to decode.
+    var currentIndex: Int
+
+    // MARK: - Initialization
+
+    /// Initializes `self` by referencing the given decoder and container.
+    init(referencing decoder: _JSONDecoder, wrapping container: [Any]) {
+        self.decoder = decoder
+        self.container = container
+        self.currentIndex = 0
+    }
+
+    // MARK: - UnkeyedDecodingContainer Methods
+
+    var codingPath: [CodingKey?] {
+        return self.decoder.codingPath
+    }
+
+    var count: Int? {
+        return self.container.count
+    }
+
+    var isAtEnd: Bool {
+        return self.currentIndex >= self.count!
+    }
+
+    mutating func decodeIfPresent(_ type: Bool.Type) throws -> Bool? {
+        guard !self.isAtEnd else { return nil }
+
+        return try self.decoder.with(pushedKey: nil) {
+            let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: Bool.self)
+            self.currentIndex += 1
+            return decoded
+        }
+    }
+
+    mutating func decodeIfPresent(_ type: Int.Type) throws -> Int? {
+        guard !self.isAtEnd else { return nil }
+
+        return try self.decoder.with(pushedKey: nil) {
+            let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: Int.self)
+            self.currentIndex += 1
+            return decoded
+        }
+    }
+
+    mutating func decodeIfPresent(_ type: Int8.Type) throws -> Int8? {
+        guard !self.isAtEnd else { return nil }
+
+        return try self.decoder.with(pushedKey: nil) {
+            let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: Int8.self)
+            self.currentIndex += 1
+            return decoded
+        }
+    }
+
+    mutating func decodeIfPresent(_ type: Int16.Type) throws -> Int16? {
+        guard !self.isAtEnd else { return nil }
+
+        return try self.decoder.with(pushedKey: nil) {
+            let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: Int16.self)
+            self.currentIndex += 1
+            return decoded
+        }
+    }
+
+    mutating func decodeIfPresent(_ type: Int32.Type) throws -> Int32? {
+        guard !self.isAtEnd else { return nil }
+
+        return try self.decoder.with(pushedKey: nil) {
+            let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: Int32.self)
+            self.currentIndex += 1
+            return decoded
+        }
+    }
+
+    mutating func decodeIfPresent(_ type: Int64.Type) throws -> Int64? {
+        guard !self.isAtEnd else { return nil }
+
+        return try self.decoder.with(pushedKey: nil) {
+            let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: Int64.self)
+            self.currentIndex += 1
+            return decoded
+        }
+    }
+
+    mutating func decodeIfPresent(_ type: UInt.Type) throws -> UInt? {
+        guard !self.isAtEnd else { return nil }
+
+        return try self.decoder.with(pushedKey: nil) {
+            let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: UInt.self)
+            self.currentIndex += 1
+            return decoded
+        }
+    }
+
+    mutating func decodeIfPresent(_ type: UInt8.Type) throws -> UInt8? {
+        guard !self.isAtEnd else { return nil }
+
+        return try self.decoder.with(pushedKey: nil) {
+            let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: UInt8.self)
+            self.currentIndex += 1
+            return decoded
+        }
+    }
+
+    mutating func decodeIfPresent(_ type: UInt16.Type) throws -> UInt16? {
+        guard !self.isAtEnd else { return nil }
+
+        return try self.decoder.with(pushedKey: nil) {
+            let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: UInt16.self)
+            self.currentIndex += 1
+            return decoded
+        }
+    }
+
+    mutating func decodeIfPresent(_ type: UInt32.Type) throws -> UInt32? {
+        guard !self.isAtEnd else { return nil }
+
+        return try self.decoder.with(pushedKey: nil) {
+            let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: UInt32.self)
+            self.currentIndex += 1
+            return decoded
+        }
+    }
+
+    mutating func decodeIfPresent(_ type: UInt64.Type) throws -> UInt64? {
+        guard !self.isAtEnd else { return nil }
+
+        return try self.decoder.with(pushedKey: nil) {
+            let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: UInt64.self)
+            self.currentIndex += 1
+            return decoded
+        }
+    }
+
+    mutating func decodeIfPresent(_ type: Float.Type) throws -> Float? {
+        guard !self.isAtEnd else { return nil }
+
+        return try self.decoder.with(pushedKey: nil) {
+            let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: Float.self)
+            self.currentIndex += 1
+            return decoded
+        }
+    }
+
+    mutating func decodeIfPresent(_ type: Double.Type) throws -> Double? {
+        guard !self.isAtEnd else { return nil }
+
+        return try self.decoder.with(pushedKey: nil) {
+            let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: Double.self)
+            self.currentIndex += 1
+            return decoded
+        }
+    }
+
+    mutating func decodeIfPresent(_ type: String.Type) throws -> String? {
+        guard !self.isAtEnd else { return nil }
+
+        return try self.decoder.with(pushedKey: nil) {
+            let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: String.self)
+            self.currentIndex += 1
+            return decoded
+        }
+    }
+
+    mutating func decodeIfPresent(_ type: Data.Type) throws -> Data? {
+        guard !self.isAtEnd else { return nil }
+
+        return try self.decoder.with(pushedKey: nil) {
+            let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: Data.self)
+            self.currentIndex += 1
+            return decoded
+        }
+    }
+
+    mutating func decodeIfPresent<T : Decodable>(_ type: T.Type) throws -> T? {
+        guard !self.isAtEnd else { return nil }
+
+        return try self.decoder.with(pushedKey: nil) {
+            let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: T.self)
+            self.currentIndex += 1
+            return decoded
+        }
+    }
+
+    mutating func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type) throws -> KeyedDecodingContainer<NestedKey> {
+        return try self.decoder.with(pushedKey: nil) {
+            guard !self.isAtEnd else {
+                throw DecodingError.valueNotFound(KeyedDecodingContainer<NestedKey>.self,
+                                                  DecodingError.Context(codingPath: self.codingPath,
+                                                                        debugDescription: "Cannot get nested keyed container -- unkeyed container is at end."))
+            }
+
+            let value = self.container[self.currentIndex]
+            guard !(value is NSNull) else {
+                throw DecodingError.valueNotFound(KeyedDecodingContainer<NestedKey>.self,
+                                                  DecodingError.Context(codingPath: self.codingPath,
+                                                                        debugDescription: "Cannot get keyed decoding container -- found null value instead."))
+            }
+
+            guard let container = value as? [String : Any] else {
+                throw DecodingError._typeMismatch(at: self.codingPath, expectation: [String : Any].self, reality: value)
+            }
+
+            self.currentIndex += 1
+            let wrapper = _JSONKeyedDecodingContainer<NestedKey>(referencing: self.decoder, wrapping: container)
+            return KeyedDecodingContainer(wrapper)
+        }
+    }
+
+    mutating func nestedUnkeyedContainer() throws -> UnkeyedDecodingContainer {
+        return try self.decoder.with(pushedKey: nil) {
+            guard !self.isAtEnd else {
+                throw DecodingError.valueNotFound(UnkeyedDecodingContainer.self,
+                                                  DecodingError.Context(codingPath: self.codingPath,
+                                                                        debugDescription: "Cannot get nested keyed container -- unkeyed container is at end."))
+            }
+
+            let value = self.container[self.currentIndex]
+            guard !(value is NSNull) else {
+                throw DecodingError.valueNotFound(UnkeyedDecodingContainer.self,
+                                                  DecodingError.Context(codingPath: self.codingPath,
+                                                                        debugDescription: "Cannot get keyed decoding container -- found null value instead."))
+            }
+
+            guard let container = value as? [Any] else {
+                throw DecodingError._typeMismatch(at: self.codingPath, expectation: [Any].self, reality: value)
+            }
+
+            self.currentIndex += 1
+            return _JSONUnkeyedDecodingContainer(referencing: self.decoder, wrapping: container)
+        }
+    }
+
+    mutating func superDecoder() throws -> Decoder {
+        return try self.decoder.with(pushedKey: nil) {
+            guard !self.isAtEnd else {
+                throw DecodingError.valueNotFound(Decoder.self,
+                                                  DecodingError.Context(codingPath: self.codingPath,
+                                                                        debugDescription: "Cannot get superDecoder() -- unkeyed container is at end."))
+            }
+
+            let value = self.container[self.currentIndex]
+            guard !(value is NSNull) else {
+                throw DecodingError.valueNotFound(Decoder.self,
+                                                  DecodingError.Context(codingPath: self.codingPath,
+                                                                        debugDescription: "Cannot get superDecoder() -- found null value instead."))
+            }
+
+            self.currentIndex += 1
+            return _JSONDecoder(referencing: value, options: self.decoder.options)
+        }
+    }
+}
+
+extension _JSONDecoder : SingleValueDecodingContainer {
+    // MARK: SingleValueDecodingContainer Methods
+
+    // These all unwrap the result, since we couldn't have gotten a single value container if the topContainer was null.
+    func decode(_ type: Bool.Type)   throws -> Bool   { return try self.unbox(self.storage.topContainer, as: Bool.self)! }
+    func decode(_ type: Int.Type)    throws -> Int    { return try self.unbox(self.storage.topContainer, as: Int.self)! }
+    func decode(_ type: Int8.Type)   throws -> Int8   { return try self.unbox(self.storage.topContainer, as: Int8.self)! }
+    func decode(_ type: Int16.Type)  throws -> Int16  { return try self.unbox(self.storage.topContainer, as: Int16.self)! }
+    func decode(_ type: Int32.Type)  throws -> Int32  { return try self.unbox(self.storage.topContainer, as: Int32.self)! }
+    func decode(_ type: Int64.Type)  throws -> Int64  { return try self.unbox(self.storage.topContainer, as: Int64.self)! }
+    func decode(_ type: UInt.Type)   throws -> UInt   { return try self.unbox(self.storage.topContainer, as: UInt.self)! }
+    func decode(_ type: UInt8.Type)  throws -> UInt8  { return try self.unbox(self.storage.topContainer, as: UInt8.self)! }
+    func decode(_ type: UInt16.Type) throws -> UInt16 { return try self.unbox(self.storage.topContainer, as: UInt16.self)! }
+    func decode(_ type: UInt32.Type) throws -> UInt32 { return try self.unbox(self.storage.topContainer, as: UInt32.self)! }
+    func decode(_ type: UInt64.Type) throws -> UInt64 { return try self.unbox(self.storage.topContainer, as: UInt64.self)! }
+    func decode(_ type: Float.Type)  throws -> Float  { return try self.unbox(self.storage.topContainer, as: Float.self)! }
+    func decode(_ type: Double.Type) throws -> Double { return try self.unbox(self.storage.topContainer, as: Double.self)! }
+    func decode(_ type: String.Type) throws -> String { return try self.unbox(self.storage.topContainer, as: String.self)! }
+    func decode(_ type: Data.Type)   throws -> Data   { return try self.unbox(self.storage.topContainer, as: Data.self)! }
+}
+
+// MARK: - Concrete Value Representations
+
+extension _JSONDecoder {
+    /// Returns the given value unboxed from a container.
+    fileprivate func unbox(_ value: Any?, as type: Bool.Type) throws -> Bool? {
+        guard let value = value else { return nil }
+        guard !(value is NSNull) else { return nil }
+
+        if let number = value as? NSNumber {
+            // TODO: Add a flag to coerce non-boolean numbers into Bools?
+            if number === kCFBooleanTrue as NSNumber {
+                return true
+            } else if number === kCFBooleanFalse as NSNumber {
+                return false
+            }
+
+        /* FIXME: If swift-corelibs-foundation doesn't change to use NSNumber, this code path will need to be included and tested:
+        } else if let bool = value as? Bool {
+            return bool
+        */
+
+        }
+
+        throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+    }
+
+    fileprivate func unbox(_ value: Any?, as type: Int.Type) throws -> Int? {
+        guard let value = value else { return nil }
+        guard !(value is NSNull) else { return nil }
+
+        guard let number = value as? NSNumber else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+        }
+
+        let int = number.intValue
+        guard NSNumber(value: int) == number else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Parsed JSON number <\(number)> does not fit in \(type)."))
+        }
+
+        return int
+    }
+
+    fileprivate func unbox(_ value: Any?, as type: Int8.Type) throws -> Int8? {
+        guard let value = value else { return nil }
+        guard !(value is NSNull) else { return nil }
+
+        guard let number = value as? NSNumber else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+        }
+
+        let int8 = number.int8Value
+        guard NSNumber(value: int8) == number else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Parsed JSON number <\(number)> does not fit in \(type)."))
+        }
+
+        return int8
+    }
+
+    fileprivate func unbox(_ value: Any?, as type: Int16.Type) throws -> Int16? {
+        guard let value = value else { return nil }
+        guard !(value is NSNull) else { return nil }
+
+        guard let number = value as? NSNumber else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+        }
+
+        let int16 = number.int16Value
+        guard NSNumber(value: int16) == number else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Parsed JSON number <\(number)> does not fit in \(type)."))
+        }
+
+        return int16
+    }
+
+    fileprivate func unbox(_ value: Any?, as type: Int32.Type) throws -> Int32? {
+        guard let value = value else { return nil }
+        guard !(value is NSNull) else { return nil }
+
+        guard let number = value as? NSNumber else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+        }
+
+        let int32 = number.int32Value
+        guard NSNumber(value: int32) == number else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Parsed JSON number <\(number)> does not fit in \(type)."))
+        }
+
+        return int32
+    }
+
+    fileprivate func unbox(_ value: Any?, as type: Int64.Type) throws -> Int64? {
+        guard let value = value else { return nil }
+        guard !(value is NSNull) else { return nil }
+
+        guard let number = value as? NSNumber else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+        }
+
+        let int64 = number.int64Value
+        guard NSNumber(value: int64) == number else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Parsed JSON number <\(number)> does not fit in \(type)."))
+        }
+
+        return int64
+    }
+
+    fileprivate func unbox(_ value: Any?, as type: UInt.Type) throws -> UInt? {
+        guard let value = value else { return nil }
+        guard !(value is NSNull) else { return nil }
+
+        guard let number = value as? NSNumber else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+        }
+
+        let uint = number.uintValue
+        guard NSNumber(value: uint) == number else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Parsed JSON number <\(number)> does not fit in \(type)."))
+        }
+
+        return uint
+    }
+
+    fileprivate func unbox(_ value: Any?, as type: UInt8.Type) throws -> UInt8? {
+        guard let value = value else { return nil }
+        guard !(value is NSNull) else { return nil }
+
+        guard let number = value as? NSNumber else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+        }
+
+        let uint8 = number.uint8Value
+        guard NSNumber(value: uint8) == number else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Parsed JSON number <\(number)> does not fit in \(type)."))
+        }
+
+        return uint8
+    }
+
+    fileprivate func unbox(_ value: Any?, as type: UInt16.Type) throws -> UInt16? {
+        guard let value = value else { return nil }
+        guard !(value is NSNull) else { return nil }
+
+        guard let number = value as? NSNumber else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+        }
+
+        let uint16 = number.uint16Value
+        guard NSNumber(value: uint16) == number else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Parsed JSON number <\(number)> does not fit in \(type)."))
+        }
+
+        return uint16
+    }
+
+    fileprivate func unbox(_ value: Any?, as type: UInt32.Type) throws -> UInt32? {
+        guard let value = value else { return nil }
+        guard !(value is NSNull) else { return nil }
+
+        guard let number = value as? NSNumber else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+        }
+
+        let uint32 = number.uint32Value
+        guard NSNumber(value: uint32) == number else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Parsed JSON number <\(number)> does not fit in \(type)."))
+        }
+
+        return uint32
+    }
+
+    fileprivate func unbox(_ value: Any?, as type: UInt64.Type) throws -> UInt64? {
+        guard let value = value else { return nil }
+        guard !(value is NSNull) else { return nil }
+
+        guard let number = value as? NSNumber else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+        }
+
+        let uint64 = number.uint64Value
+        guard NSNumber(value: uint64) == number else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Parsed JSON number <\(number)> does not fit in \(type)."))
+        }
+
+        return uint64
+    }
+
+    fileprivate func unbox(_ value: Any?, as type: Float.Type) throws -> Float? {
+        guard let value = value else { return nil }
+        guard !(value is NSNull) else { return nil }
+
+        if let number = value as? NSNumber {
+            // We are willing to return a Float by losing precision:
+            // * If the original value was integral,
+            //   * and the integral value was > Float.greatestFiniteMagnitude, we will fail
+            //   * and the integral value was <= Float.greatestFiniteMagnitude, we are willing to lose precision past 2^24
+            // * If it was a Float, you will get back the precise value
+            // * If it was a Double or Decimal, you will get back the nearest approximation if it will fit
+            let double = number.doubleValue
+            guard abs(double) <= Double(Float.greatestFiniteMagnitude) else {
+                throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Parsed JSON number \(number) does not fit in \(type)."))
+            }
+
+            return Float(double)
+
+        /* FIXME: If swift-corelibs-foundation doesn't change to use NSNumber, this code path will need to be included and tested:
+        } else if let double = value as? Double {
+            if abs(double) <= Double(Float.max) {
+                return Float(double)
+            }
+
+            overflow = true
+        } else if let int = value as? Int {
+            if let float = Float(exactly: int) {
+                return float
+            }
+
+            overflow = true
+        */
+
+        } else if let string = value as? String,
+            case .convertFromString(let posInfString, let negInfString, let nanString) = self.options.nonConformingFloatDecodingStrategy {
+            if string == posInfString {
+                return Float.infinity
+            } else if string == negInfString {
+                return -Float.infinity
+            } else if string == nanString {
+                return Float.nan
+            }
+        }
+
+        throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+    }
+
+    func unbox(_ value: Any?, as type: Double.Type) throws -> Double? {
+        guard let value = value else { return nil }
+        guard !(value is NSNull) else { return nil }
+
+        if let number = value as? NSNumber {
+            // We are always willing to return the number as a Double:
+            // * If the original value was integral, it is guaranteed to fit in a Double; we are willing to lose precision past 2^53 if you encoded a UInt64 but requested a Double
+            // * If it was a Float or Double, you will get back the precise value
+            // * If it was Decimal, you will get back the nearest approximation
+            return number.doubleValue
+
+        /* FIXME: If swift-corelibs-foundation doesn't change to use NSNumber, this code path will need to be included and tested:
+        } else if let double = value as? Double {
+            return double
+        } else if let int = value as? Int {
+            if let double = Double(exactly: int) {
+                return double
+            }
+
+            overflow = true
+        */
+
+        } else if let string = value as? String,
+            case .convertFromString(let posInfString, let negInfString, let nanString) = self.options.nonConformingFloatDecodingStrategy {
+            if string == posInfString {
+                return Double.infinity
+            } else if string == negInfString {
+                return -Double.infinity
+            } else if string == nanString {
+                return Double.nan
+            }
+        }
+
+        throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+    }
+
+    func unbox(_ value: Any?, as type: String.Type) throws -> String? {
+        guard let value = value else { return nil }
+        guard !(value is NSNull) else { return nil }
+
+        guard let string = value as? String else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+        }
+
+        return string
+    }
+
+    func unbox(_ value: Any?, as type: Date.Type) throws -> Date? {
+        guard let value = value else { return nil }
+        guard !(value is NSNull) else { return nil }
+
+        switch self.options.dateDecodingStrategy {
+        case .deferredToDate:
+            self.storage.push(container: value)
+            let date = try Date(from: self)
+            self.storage.popContainer()
+            return date
+
+        case .secondsSince1970:
+            let double = try self.unbox(value, as: Double.self)!
+            return Date(timeIntervalSince1970: double)
+
+        case .millisecondsSince1970:
+            let double = try self.unbox(value, as: Double.self)!
+            return Date(timeIntervalSince1970: double / 1000.0)
+
+        case .iso8601:
+            if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
+                let string = try self.unbox(value, as: String.self)!
+                guard let date = _iso8601Formatter.date(from: string) else {
+                    throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Expected date string to be ISO8601-formatted."))
+                }
+
+                return date
+            } else {
+                fatalError("ISO8601DateFormatter is unavailable on this platform.")
+            }
+
+        case .formatted(let formatter):
+            let string = try self.unbox(value, as: String.self)!
+            guard let date = formatter.date(from: string) else {
+                throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Date string does not match format expected by formatter."))
+            }
+
+            return date
+
+        case .custom(let closure):
+            self.storage.push(container: value)
+            let date = try closure(self)
+            self.storage.popContainer()
+            return date
+        }
+    }
+
+    func unbox(_ value: Any?, as type: Data.Type) throws -> Data? {
+        guard let value = value else { return nil }
+        guard !(value is NSNull) else { return nil }
+
+        switch self.options.dataDecodingStrategy {
+        case .base64Decode:
+            guard let string = value as? String else {
+                throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+            }
+
+            guard let data = Data(base64Encoded: string) else {
+                throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Encountered Data is not valid Base64."))
+            }
+
+            return data
+
+        case .custom(let closure):
+            self.storage.push(container: value)
+            let data = try closure(self)
+            self.storage.popContainer()
+            return data
+        }
+    }
+
+    func unbox<T : Decodable>(_ value: Any?, as type: T.Type) throws -> T? {
+        guard let value = value else { return nil }
+        guard !(value is NSNull) else { return nil }
+
+        let decoded: T
+        if T.self == Date.self {
+            decoded = (try self.unbox(value, as: Date.self) as! T)
+        } else if T.self == Data.self {
+            decoded = (try self.unbox(value, as: Data.self) as! T)
+        } else {
+            self.storage.push(container: value)
+            decoded = try T(from: self)
+            self.storage.popContainer()
+        }
+
+        return decoded
+    }
+}
+
+//===----------------------------------------------------------------------===//
+// Shared ISO8601 Date Formatter
+//===----------------------------------------------------------------------===//
+
+// NOTE: This value is implicitly lazy and _must_ be lazy. We're compiled against the latest SDK (w/ ISO8601DateFormatter), but linked against whichever Foundation the user has. ISO8601DateFormatter might not exist, so we better not hit this code path on an older OS.
+@available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
+fileprivate var _iso8601Formatter: ISO8601DateFormatter = {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = .withInternetDateTime
+    return formatter
+}()
+
+//===----------------------------------------------------------------------===//
+// Error Utilities
+//===----------------------------------------------------------------------===//
+
+fileprivate extension EncodingError {
+    /// Returns a `.invalidValue` error describing the given invalid floating-point value.
+    ///
+    ///
+    /// - parameter value: The value that was invalid to encode.
+    /// - parameter path: The path of `CodingKey`s taken to encode this value.
+    /// - returns: An `EncodingError` with the appropriate path and debug description.
+    fileprivate static func _invalidFloatingPointValue<T : FloatingPoint>(_ value: T, at codingPath: [CodingKey?]) -> EncodingError {
+        let valueDescription: String
+        if value == T.infinity {
+            valueDescription = "\(T.self).infinity"
+        } else if value == -T.infinity {
+            valueDescription = "-\(T.self).infinity"
+        } else {
+            valueDescription = "\(T.self).nan"
+        }
+
+        let debugDescription = "Unable to encode \(valueDescription) directly in JSON. Use JSONEncoder.NonConformingFloatEncodingStrategy.convertToString to specify how the value should be encoded."
+        return .invalidValue(value, EncodingError.Context(codingPath: codingPath, debugDescription: debugDescription))
+    }
+}

--- a/stdlib/public/SDK/Foundation/NSError.swift
+++ b/stdlib/public/SDK/Foundation/NSError.swift
@@ -836,12 +836,24 @@ extension CocoaError.Code {
 
   @available(OSX, introduced: 10.11) @available(iOS, introduced: 9.0)
   public static var coderReadCorrupt: CocoaError.Code {
+    return _coderReadCorrupt
+  }
+
+  internal static var _coderReadCorrupt: CocoaError.Code {
     return CocoaError.Code(rawValue: 4864)
   }
 
   @available(OSX, introduced: 10.11) @available(iOS, introduced: 9.0)
   public static var coderValueNotFound: CocoaError.Code {
+    return _coderValueNotFound
+  }
+
+  internal static var _coderValueNotFound: CocoaError.Code {
     return CocoaError.Code(rawValue: 4865)
+  }
+
+  public static var coderInvalidValue: CocoaError.Code {
+    return CocoaError.Code(rawValue: 4866)
   }
 }
 
@@ -1275,12 +1287,24 @@ extension CocoaError {
 
   @available(OSX, introduced: 10.11) @available(iOS, introduced: 9.0)
   public static var coderReadCorrupt: CocoaError.Code {
+    return _coderReadCorrupt
+  }
+
+  public static var _coderReadCorrupt: CocoaError.Code {
     return CocoaError.Code(rawValue: 4864)
   }
 
   @available(OSX, introduced: 10.11) @available(iOS, introduced: 9.0)
   public static var coderValueNotFound: CocoaError.Code {
+    return _coderValueNotFound
+  }
+
+  internal static var _coderValueNotFound: CocoaError.Code {
     return CocoaError.Code(rawValue: 4865)
+  }
+
+  public static var coderInvalidValue: CocoaError.Code {
+    return CocoaError.Code(rawValue: 4866)
   }
 }
 

--- a/stdlib/public/SDK/Foundation/PlistEncoder.swift
+++ b/stdlib/public/SDK/Foundation/PlistEncoder.swift
@@ -1,0 +1,1482 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+//===----------------------------------------------------------------------===//
+// Plist Encoder
+//===----------------------------------------------------------------------===//
+
+/// `PropertyListEncoder` facilitates the encoding of `Encodable` values into property lists.
+open class PropertyListEncoder {
+
+    // MARK: - Options
+
+    /// The output format to write the property list data in. Defaults to `.binary`.
+    open var outputFormat: PropertyListSerialization.PropertyListFormat = .binary
+
+    /// Contextual user-provided information for use during encoding.
+    open var userInfo: [CodingUserInfoKey : Any] = [:]
+
+    /// Options set on the top-level encoder to pass down the encoding hierarchy.
+    fileprivate struct _Options {
+        let outputFormat: PropertyListSerialization.PropertyListFormat
+        let userInfo: [CodingUserInfoKey : Any]
+    }
+
+    /// The options set on the top-level encoder.
+    fileprivate var options: _Options {
+        return _Options(outputFormat: outputFormat, userInfo: userInfo)
+    }
+
+    // MARK: - Constructing a Property List Encoder
+
+    /// Initializes `self` with default strategies.
+    public init() {}
+
+    // MARK: - Encoding Values
+
+    /// Encodes the given top-level value and returns its property list representation.
+    ///
+    /// - parameter value: The value to encode.
+    /// - returns: A new `Data` value containing the encoded property list data.
+    /// - throws: `EncodingError.invalidValue` if a non-comforming floating-point value is encountered during encoding, and the encoding strategy is `.throw`.
+    /// - throws: An error if any value throws an error during encoding.
+    open func encode<Value : Encodable>(_ value: Value) throws -> Data {
+        let encoder = _PlistEncoder(options: self.options)
+        try value.encode(to: encoder)
+
+        guard encoder.storage.count > 0 else {
+            throw EncodingError.invalidValue(value,
+                                             EncodingError.Context(codingPath: [],
+                                                                   debugDescription: "Top-level \(Value.self) did not encode any values."))
+        }
+
+        let topLevel = encoder.storage.popContainer()
+        if topLevel is NSNumber {
+            throw EncodingError.invalidValue(value,
+                                             EncodingError.Context(codingPath: [],
+                                                                   debugDescription: "Top-level \(Value.self) encoded as number property list fragment."))
+        } else if topLevel is NSString {
+            throw EncodingError.invalidValue(value,
+                                             EncodingError.Context(codingPath: [],
+                                                                   debugDescription: "Top-level \(Value.self) encoded as string property list fragment."))
+        } else if topLevel is NSDate {
+            throw EncodingError.invalidValue(value,
+                                             EncodingError.Context(codingPath: [],
+                                                                   debugDescription: "Top-level \(Value.self) encoded as date property list fragment."))
+        }
+
+        return try PropertyListSerialization.data(fromPropertyList: topLevel, format: self.outputFormat, options: 0)
+    }
+}
+
+// MARK: - _PlistEncoder
+
+fileprivate class _PlistEncoder : Encoder {
+    // MARK: Properties
+
+    /// The encoder's storage.
+    var storage: _PlistEncodingStorage
+
+    /// Options set on the top-level encoder.
+    let options: PropertyListEncoder._Options
+
+    /// The path to the current point in encoding.
+    var codingPath: [CodingKey?] = []
+
+    /// Contextual user-provided information for use during encoding.
+    var userInfo: [CodingUserInfoKey : Any] {
+        return self.options.userInfo
+    }
+
+    // MARK: - Initialization
+
+    /// Initializes `self` with the given top-level encoder options.
+    init(options: PropertyListEncoder._Options) {
+        self.options = options
+        self.storage = _PlistEncodingStorage()
+    }
+
+    // MARK: - Coding Path Actions
+
+    /// Performs the given closure with the given key pushed onto the end of the current coding path.
+    ///
+    /// - parameter key: The key to push. May be nil for unkeyed containers.
+    /// - parameter work: The work to perform with the key in the path.
+    func with(pushedKey key: CodingKey?, _ work: () throws -> ()) rethrows {
+        self.codingPath.append(key)
+        try work()
+        self.codingPath.removeLast()
+    }
+
+    /// Asserts that a new container can be requested at this coding path.
+    /// `preconditionFailure()`s if one cannot be requested.
+    func assertCanRequestNewContainer() {
+        // Every time a new value gets encoded, the key it's encoded for is pushed onto the coding path (even if it's a nil key from an unkeyed container).
+        // At the same time, every time a container is requested, a new value gets pushed onto the storage stack.
+        // If there are more values on the storage stack than on the coding path, it means the value is requesting more than one container, which violates the precondition.
+
+        // This means that anytime something that can request a new container goes onto the stack, we MUST push a key onto the coding path.
+        // Things which will not request containers do not need to have the coding path extended for them (but it doesn't matter if it is, because they will not reach here).
+        guard self.storage.count == self.codingPath.count else {
+            let previousContainerType: String
+            if self.storage.containers.last is NSDictionary {
+                previousContainerType = "keyed"
+            } else if self.storage.containers.last is NSArray {
+                previousContainerType = "unkeyed"
+            } else {
+                previousContainerType = "single value"
+            }
+
+            preconditionFailure("Attempt to encode with new container when already encoded with \(previousContainerType) container.")
+        }
+    }
+
+    // MARK: - Encoder Methods
+    func container<Key>(keyedBy: Key.Type) -> KeyedEncodingContainer<Key> {
+        assertCanRequestNewContainer()
+        let container = self.storage.pushKeyedContainer()
+        let wrapper = _PlistKeyedEncodingContainer<Key>(referencing: self, wrapping: container)
+        return KeyedEncodingContainer(wrapper)
+    }
+
+    func unkeyedContainer() -> UnkeyedEncodingContainer {
+        assertCanRequestNewContainer()
+        let container = self.storage.pushUnkeyedContainer()
+        return _PlistUnkeyedEncodingContainer(referencing: self, wrapping: container)
+    }
+
+    func singleValueContainer() -> SingleValueEncodingContainer {
+        assertCanRequestNewContainer()
+        return self
+    }
+}
+
+// MARK: - Encoding Storage and Containers
+
+fileprivate struct _PlistEncodingStorage {
+    // MARK: Properties
+
+    /// The container stack.
+    /// Elements may be any one of the plist types (NSNumber, NSString, NSDate, NSArray, NSDictionary).
+    private(set) var containers: [NSObject] = []
+
+    // MARK: - Initialization
+
+    /// Initializes `self` with no containers.
+    init() {}
+
+    // MARK: - Modifying the Stack
+
+    var count: Int {
+        return self.containers.count
+    }
+
+    mutating func pushKeyedContainer() -> NSMutableDictionary {
+        let dictionary = NSMutableDictionary()
+        self.containers.append(dictionary)
+        return dictionary
+    }
+
+    mutating func pushUnkeyedContainer() -> NSMutableArray {
+        let array = NSMutableArray()
+        self.containers.append(array)
+        return array
+    }
+
+    mutating func push(container: NSObject) {
+        self.containers.append(container)
+    }
+
+    mutating func popContainer() -> NSObject {
+        precondition(self.containers.count > 0, "Empty container stack.")
+        return self.containers.popLast()!
+    }
+}
+
+// MARK: - Encoding Containers
+
+fileprivate struct _PlistKeyedEncodingContainer<K : CodingKey> : KeyedEncodingContainerProtocol {
+    typealias Key = K
+
+    // MARK: Properties
+
+    /// A reference to the encoder we're writing to.
+    let encoder: _PlistEncoder
+
+    /// A reference to the container we're writing to.
+    let container: NSMutableDictionary
+
+    // MARK: - Initialization
+
+    /// Initializes `self` with the given references.
+    init(referencing encoder: _PlistEncoder, wrapping container: NSMutableDictionary) {
+        self.encoder = encoder
+        self.container = container
+    }
+
+    // MARK: - KeyedEncodingContainerProtocol Methods
+
+    var codingPath: [CodingKey?] {
+        return self.encoder.codingPath
+    }
+
+    mutating func encode(_ value: Bool?, forKey key: Key)   throws { self.container[key.stringValue] = self.encoder.box(value) }
+    mutating func encode(_ value: Int?, forKey key: Key)    throws { self.container[key.stringValue] = self.encoder.box(value) }
+    mutating func encode(_ value: Int8?, forKey key: Key)   throws { self.container[key.stringValue] = self.encoder.box(value) }
+    mutating func encode(_ value: Int16?, forKey key: Key)  throws { self.container[key.stringValue] = self.encoder.box(value) }
+    mutating func encode(_ value: Int32?, forKey key: Key)  throws { self.container[key.stringValue] = self.encoder.box(value) }
+    mutating func encode(_ value: Int64?, forKey key: Key)  throws { self.container[key.stringValue] = self.encoder.box(value) }
+    mutating func encode(_ value: UInt?, forKey key: Key)   throws { self.container[key.stringValue] = self.encoder.box(value) }
+    mutating func encode(_ value: UInt8?, forKey key: Key)  throws { self.container[key.stringValue] = self.encoder.box(value) }
+    mutating func encode(_ value: UInt16?, forKey key: Key) throws { self.container[key.stringValue] = self.encoder.box(value) }
+    mutating func encode(_ value: UInt32?, forKey key: Key) throws { self.container[key.stringValue] = self.encoder.box(value) }
+    mutating func encode(_ value: UInt64?, forKey key: Key) throws { self.container[key.stringValue] = self.encoder.box(value) }
+    mutating func encode(_ value: String?, forKey key: Key) throws { self.container[key.stringValue] = self.encoder.box(value) }
+    mutating func encode(_ value: Float?, forKey key: Key)  throws { self.container[key.stringValue] = self.encoder.box(value) }
+    mutating func encode(_ value: Double?, forKey key: Key) throws { self.container[key.stringValue] = self.encoder.box(value) }
+
+    mutating func encode<T : Encodable>(_ value: T?, forKey key: Key) throws {
+        try self.encoder.with(pushedKey: key) {
+            self.container[key.stringValue] = try self.encoder.box(value)
+        }
+    }
+
+    mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type, forKey key: Key) -> KeyedEncodingContainer<NestedKey> {
+        let container = self.encoder.storage.pushKeyedContainer()
+        self.container[key.stringValue] = container
+        let wrapper = _PlistKeyedEncodingContainer<NestedKey>(referencing: self.encoder, wrapping: container)
+        return KeyedEncodingContainer(wrapper)
+    }
+
+    mutating func nestedUnkeyedContainer(forKey key: Key) -> UnkeyedEncodingContainer {
+        let container = self.encoder.storage.pushUnkeyedContainer()
+        self.container[key.stringValue] = container
+        return _PlistUnkeyedEncodingContainer(referencing: self.encoder, wrapping: container)
+    }
+
+    mutating func superEncoder() -> Encoder {
+        return _PlistReferencingEncoder(referencing: self.encoder, wrapping: self.container, key: "super")
+    }
+
+    mutating func superEncoder(forKey key: Key) -> Encoder {
+        return _PlistReferencingEncoder(referencing: self.encoder, wrapping: self.container, key: key.stringValue)
+    }
+}
+
+fileprivate struct _PlistUnkeyedEncodingContainer : UnkeyedEncodingContainer {
+    // MARK: Properties
+
+    /// A reference to the encoder we're writing to.
+    let encoder: _PlistEncoder
+
+    /// A reference to the container we're writing to.
+    let container: NSMutableArray
+
+    // MARK: - Initialization
+
+    /// Initializes `self` with the given references.
+    init(referencing encoder: _PlistEncoder, wrapping container: NSMutableArray) {
+        self.encoder = encoder
+        self.container = container
+    }
+
+    // MARK: - UnkeyedEncodingContainer Methods
+
+    var codingPath: [CodingKey?] {
+        return self.encoder.codingPath
+    }
+
+    mutating func encode(_ value: Bool?)   throws { self.container.add(self.encoder.box(value)) }
+    mutating func encode(_ value: Int?)    throws { self.container.add(self.encoder.box(value)) }
+    mutating func encode(_ value: Int8?)   throws { self.container.add(self.encoder.box(value)) }
+    mutating func encode(_ value: Int16?)  throws { self.container.add(self.encoder.box(value)) }
+    mutating func encode(_ value: Int32?)  throws { self.container.add(self.encoder.box(value)) }
+    mutating func encode(_ value: Int64?)  throws { self.container.add(self.encoder.box(value)) }
+    mutating func encode(_ value: UInt?)   throws { self.container.add(self.encoder.box(value)) }
+    mutating func encode(_ value: UInt8?)  throws { self.container.add(self.encoder.box(value)) }
+    mutating func encode(_ value: UInt16?) throws { self.container.add(self.encoder.box(value)) }
+    mutating func encode(_ value: UInt32?) throws { self.container.add(self.encoder.box(value)) }
+    mutating func encode(_ value: UInt64?) throws { self.container.add(self.encoder.box(value)) }
+    mutating func encode(_ value: Float?)  throws { self.container.add(self.encoder.box(value)) }
+    mutating func encode(_ value: Double?) throws { self.container.add(self.encoder.box(value)) }
+    mutating func encode(_ value: String?) throws { self.container.add(self.encoder.box(value)) }
+
+    mutating func encode<T : Encodable>(_ value: T?) throws {
+        try self.encoder.with(pushedKey: nil) {
+            self.container.add(try self.encoder.box(value))
+        }
+    }
+
+    mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type) -> KeyedEncodingContainer<NestedKey> {
+        let container = self.encoder.storage.pushKeyedContainer()
+        self.container.add(container)
+        let wrapper = _PlistKeyedEncodingContainer<NestedKey>(referencing: self.encoder, wrapping: container)
+        return KeyedEncodingContainer(wrapper)
+    }
+
+    mutating func nestedUnkeyedContainer() -> UnkeyedEncodingContainer {
+        let container = self.encoder.storage.pushUnkeyedContainer()
+        self.container.add(container)
+        return _PlistUnkeyedEncodingContainer(referencing: self.encoder, wrapping: container)
+    }
+
+    mutating func superEncoder() -> Encoder {
+        return _PlistReferencingEncoder(referencing: self.encoder, wrapping: self.container, at: self.container.count)
+    }
+}
+
+extension _PlistEncoder : SingleValueEncodingContainer {
+    // MARK: Utility
+
+    /// Asserts that a single value can be encoded at the current coding path (i.e. that one has not already been encoded through this container).
+    /// `preconditionFailure()`s if one cannot be encoded.
+    ///
+    /// This is similar to assertCanRequestNewContainer above.
+    func assertCanEncodeSingleValue() {
+        guard self.storage.count == self.codingPath.count else {
+            let previousContainerType: String
+            if self.storage.containers.last is NSDictionary {
+                previousContainerType = "keyed"
+            } else if self.storage.containers.last is NSArray {
+                previousContainerType = "unkeyed"
+            } else {
+                preconditionFailure("Attempt to encode multiple values in a single value container.")
+            }
+
+            preconditionFailure("Attempt to encode with new container when already encoded with \(previousContainerType) container.")
+        }
+    }
+
+    // MARK: - SingleValueEncodingContainer Methods
+
+    func encode(_ value: Bool) throws {
+        assertCanEncodeSingleValue()
+        self.storage.push(container: box(value))
+    }
+
+    func encode(_ value: Int) throws {
+        assertCanEncodeSingleValue()
+        self.storage.push(container: box(value))
+    }
+
+    func encode(_ value: Int8) throws {
+        assertCanEncodeSingleValue()
+        self.storage.push(container: box(value))
+    }
+
+    func encode(_ value: Int16) throws {
+        assertCanEncodeSingleValue()
+        self.storage.push(container: box(value))
+    }
+
+    func encode(_ value: Int32) throws {
+        assertCanEncodeSingleValue()
+        self.storage.push(container: box(value))
+    }
+
+    func encode(_ value: Int64) throws {
+        assertCanEncodeSingleValue()
+        self.storage.push(container: box(value))
+    }
+
+    func encode(_ value: UInt) throws {
+        assertCanEncodeSingleValue()
+        self.storage.push(container: box(value))
+    }
+
+    func encode(_ value: UInt8) throws {
+        assertCanEncodeSingleValue()
+        self.storage.push(container: box(value))
+    }
+
+    func encode(_ value: UInt16) throws {
+        assertCanEncodeSingleValue()
+        self.storage.push(container: box(value))
+    }
+
+    func encode(_ value: UInt32) throws {
+        assertCanEncodeSingleValue()
+        self.storage.push(container: box(value))
+    }
+
+    func encode(_ value: UInt64) throws {
+        assertCanEncodeSingleValue()
+        self.storage.push(container: box(value))
+    }
+
+    func encode(_ value: String) throws {
+        assertCanEncodeSingleValue()
+        self.storage.push(container: box(value))
+    }
+
+    func encode(_ value: Float) throws {
+        assertCanEncodeSingleValue()
+        self.storage.push(container: box(value))
+    }
+
+    func encode(_ value: Double) throws {
+        assertCanEncodeSingleValue()
+        self.storage.push(container: box(value))
+    }
+}
+
+// MARK: - Concrete Value Representations
+
+extension _PlistEncoder {
+
+    /// Returns the given value boxed in a container appropriate for pushing onto the container stack.
+    fileprivate func box(_ value: Bool?)   -> NSObject { return value == nil ? _plistNullNSString : NSNumber(value: value!) }
+    fileprivate func box(_ value: Int?)    -> NSObject { return value == nil ? _plistNullNSString : NSNumber(value: value!) }
+    fileprivate func box(_ value: Int8?)   -> NSObject { return value == nil ? _plistNullNSString : NSNumber(value: value!) }
+    fileprivate func box(_ value: Int16?)  -> NSObject { return value == nil ? _plistNullNSString : NSNumber(value: value!) }
+    fileprivate func box(_ value: Int32?)  -> NSObject { return value == nil ? _plistNullNSString : NSNumber(value: value!) }
+    fileprivate func box(_ value: Int64?)  -> NSObject { return value == nil ? _plistNullNSString : NSNumber(value: value!) }
+    fileprivate func box(_ value: UInt?)   -> NSObject { return value == nil ? _plistNullNSString : NSNumber(value: value!) }
+    fileprivate func box(_ value: UInt8?)  -> NSObject { return value == nil ? _plistNullNSString : NSNumber(value: value!) }
+    fileprivate func box(_ value: UInt16?) -> NSObject { return value == nil ? _plistNullNSString : NSNumber(value: value!) }
+    fileprivate func box(_ value: UInt32?) -> NSObject { return value == nil ? _plistNullNSString : NSNumber(value: value!) }
+    fileprivate func box(_ value: UInt64?) -> NSObject { return value == nil ? _plistNullNSString : NSNumber(value: value!) }
+    fileprivate func box(_ value: Float?)  -> NSObject { return value == nil ? _plistNullNSString : NSNumber(value: value!) }
+    fileprivate func box(_ value: Double?) -> NSObject { return value == nil ? _plistNullNSString : NSNumber(value: value!) }
+    fileprivate func box(_ value: String?) -> NSObject { return value == nil ? _plistNullNSString : NSString(string: value!) }
+    fileprivate func box(_ value: Data?)   -> NSObject { return value == nil ? _plistNullNSString : NSData(data: value!) }
+
+    fileprivate func box<T : Encodable>(_ value: T?) throws -> NSObject {
+        guard let value = value else {
+            return _plistNullNSString
+        }
+
+        if T.self == Date.self {
+            // PropertyListSerialization handles Date directly.
+            return NSDate(timeIntervalSinceReferenceDate: (value as! Date).timeIntervalSinceReferenceDate)
+        } else if T.self == Data.self {
+            // PropertyListSerialization handles Data directly.
+            return NSData(data: (value as! Data))
+        }
+
+        // The value should request a container from the _PlistEncoder.
+        let currentTopContainer = self.storage.containers.last
+        try value.encode(to: self)
+
+        // The top container should be a new container.
+        guard self.storage.containers.last! !== currentTopContainer else {
+            // If the value didn't request a container at all, encode the default container instead.
+            return NSDictionary()
+        }
+
+        return self.storage.popContainer()
+    }
+}
+
+// MARK: - _PlistReferencingEncoder
+
+/// _PlistReferencingEncoder is a special subclass of _PlistEncoder which has its own storage, but references the contents of a different encoder.
+/// It's used in superEncoder(), which returns a new encoder for encoding a superclass -- the lifetime of the encoder should not escape the scope it's created in, but it doesn't necessarily know when it's done being used (to write to the original container).
+fileprivate class _PlistReferencingEncoder : _PlistEncoder {
+    // MARK: Reference types.
+
+    /// The type of container we're referencing.
+    enum Reference {
+        /// Referencing a specific index in an array container.
+        case array(NSMutableArray, Int)
+
+        /// Referencing a specific key in a dictionary container.
+        case dictionary(NSMutableDictionary, String)
+    }
+
+    // MARK: - Properties
+
+    /// The encoder we're referencing.
+    let encoder: _PlistEncoder
+
+    /// The container reference itself.
+    let reference: Reference
+
+    // MARK: - Initialization
+
+    /// Initializes `self` by referencing the given array container in the given encoder.
+    init(referencing encoder: _PlistEncoder, wrapping array: NSMutableArray, at index: Int) {
+        self.encoder = encoder
+        self.reference = .array(array, index)
+        super.init(options: encoder.options)
+    }
+
+    /// Initializes `self` by referencing the given dictionary container in the given encoder.
+    init(referencing encoder: _PlistEncoder, wrapping dictionary: NSMutableDictionary, key: String) {
+        self.encoder = encoder
+        self.reference = .dictionary(dictionary, key)
+        super.init(options: encoder.options)
+    }
+
+
+    // MARK: - Deinitialization
+
+    // Finalizes `self` by writing the contents of our storage to the referenced encoder's storage.
+    deinit {
+        // TODO: Ensure self.storage.count == 1, otherwise something went wrong.
+        let value = self.storage.popContainer()
+        switch self.reference {
+        case .array(let array, let index):
+            array.insert(value, at: index)
+
+        case .dictionary(let dictionary, let key):
+            dictionary[NSString(string: key)] = value
+        }
+    }
+}
+
+//===----------------------------------------------------------------------===//
+// Plist Decoder
+//===----------------------------------------------------------------------===//
+
+/// `PropertyListDecoder` facilitates the decoding of property list values into semantic `Decodable` types.
+open class PropertyListDecoder {
+    // MARK: Options
+
+    /// Contextual user-provided information for use during decoding.
+    open var userInfo: [CodingUserInfoKey : Any] = [:]
+
+    /// Options set on the top-level encoder to pass down the decoding hierarchy.
+    fileprivate struct _Options {
+        let userInfo: [CodingUserInfoKey : Any]
+    }
+
+    /// The options set on the top-level decoder.
+    fileprivate var options: _Options {
+        return _Options(userInfo: userInfo)
+    }
+
+    // MARK: - Constructing a Property List Decoder
+
+    /// Initializes `self` with default strategies.
+    public init() {}
+
+    // MARK: - Decoding Values
+
+    /// Decodes a top-level value of the given type from the given property list representation.
+    ///
+    /// - parameter type: The type of the value to decode.
+    /// - parameter data: The data to decode from.
+    /// - returns: A value of the requested type.
+    /// - throws: `DecodingError.dataCorrupted` if values requested from the payload are corrupted, or if the given data is not a valid property list.
+    /// - throws: An error if any value throws an error during decoding.
+    open func decode<T : Decodable>(_ type: T.Type, from data: Data) throws -> T {
+        var format: PropertyListSerialization.PropertyListFormat = .binary
+        return try decode(T.self, from: data, format: &format)
+    }
+
+    /// Decodes a top-level value of the given type from the given property list representation.
+    ///
+    /// - parameter type: The type of the value to decode.
+    /// - parameter data: The data to decode from.
+    /// - parameter format: The parsed property list format.
+    /// - returns: A value of the requested type along with the detected format of the property list.
+    /// - throws: `DecodingError.dataCorrupted` if values requested from the payload are corrupted, or if the given data is not a valid property list.
+    /// - throws: An error if any value throws an error during decoding.
+    open func decode<T : Decodable>(_ type: T.Type, from data: Data, format: inout PropertyListSerialization.PropertyListFormat) throws -> T {
+        let topLevel = try PropertyListSerialization.propertyList(from: data, options: [], format: &format)
+        let decoder = _PlistDecoder(referencing: topLevel, options: self.options)
+        return try T(from: decoder)
+    }
+}
+
+// MARK: - _PlistDecoder
+
+fileprivate class _PlistDecoder : Decoder {
+    // MARK: Properties
+
+    /// The decoder's storage.
+    var storage: _PlistDecodingStorage
+
+    /// Options set on the top-level decoder.
+    let options: PropertyListDecoder._Options
+
+    /// The path to the current point in encoding.
+    var codingPath: [CodingKey?] = []
+
+    /// Contextual user-provided information for use during encoding.
+    var userInfo: [CodingUserInfoKey : Any] {
+        return self.options.userInfo
+    }
+
+    // MARK: - Initialization
+
+    /// Initializes `self` with the given top-level container and options.
+    init(referencing container: Any, options: PropertyListDecoder._Options) {
+        self.storage = _PlistDecodingStorage()
+        self.storage.push(container: container)
+        self.options = options
+    }
+
+    // MARK: - Coding Path Actions
+
+    /// Performs the given closure with the given key pushed onto the end of the current coding path.
+    ///
+    /// - parameter key: The key to push. May be nil for unkeyed containers.
+    /// - parameter work: The work to perform with the key in the path.
+    func with<T>(pushedKey key: CodingKey?, _ work: () throws -> T) rethrows -> T {
+        self.codingPath.append(key)
+        let ret: T = try work()
+        self.codingPath.removeLast()
+        return ret
+    }
+
+    // MARK: - Decoder Methods
+
+    func container<Key>(keyedBy type: Key.Type) throws -> KeyedDecodingContainer<Key> {
+        guard !(self.storage.topContainer is NSNull) else {
+            throw DecodingError.valueNotFound(KeyedDecodingContainer<Key>.self,
+                                              DecodingError.Context(codingPath: self.codingPath,
+                                                      debugDescription: "Cannot get keyed decoding container -- found null value instead."))
+        }
+
+        guard let container = self.storage.topContainer as? [String : Any] else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: [String : Any].self, reality: self.storage.topContainer)
+        }
+
+        let wrapper = _PlistKeyedDecodingContainer<Key>(referencing: self, wrapping: container)
+        return KeyedDecodingContainer(wrapper)
+    }
+
+    func unkeyedContainer() throws -> UnkeyedDecodingContainer {
+        guard !(self.storage.topContainer is NSNull) else {
+            throw DecodingError.valueNotFound(UnkeyedDecodingContainer.self,
+                                              DecodingError.Context(codingPath: self.codingPath,
+                                                      debugDescription: "Cannot get unkeyed decoding container -- found null value instead."))
+        }
+
+        guard let container = self.storage.topContainer as? [Any] else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: [Any].self, reality: self.storage.topContainer)
+        }
+
+        let wrapper = _PlistUnkeyedDecodingContainer(referencing: self, wrapping: container)
+        return wrapper
+    }
+
+    func singleValueContainer() throws -> SingleValueDecodingContainer {
+        guard !(self.storage.topContainer is NSNull) else {
+            throw DecodingError.valueNotFound(SingleValueDecodingContainer.self,
+                                              DecodingError.Context(codingPath: self.codingPath,
+                                                      debugDescription: "Cannot get single value decoding container -- found null value instead."))
+        }
+
+        guard !(self.storage.topContainer is [String : Any]) else {
+            throw DecodingError.typeMismatch(SingleValueDecodingContainer.self,
+                                             DecodingError.Context(codingPath: self.codingPath,
+                                                     debugDescription: "Cannot get single value decoding container -- found keyed container instead."))
+        }
+
+        guard !(self.storage.topContainer is [Any]) else {
+            throw DecodingError.typeMismatch(SingleValueDecodingContainer.self,
+                                             DecodingError.Context(codingPath: self.codingPath,
+                                                     debugDescription: "Cannot get single value decoding container -- found unkeyed container instead."))
+        }
+
+        return self
+    }
+}
+
+// MARK: - Decoding Storage
+
+fileprivate struct _PlistDecodingStorage {
+    // MARK: Properties
+
+    /// The container stack.
+    /// Elements may be any one of the plist types (NSNumber, Date, String, Array, [String : Any]).
+    private(set) var containers: [Any] = []
+
+    // MARK: - Initialization
+
+    /// Initializes `self` with no containers.
+    init() {}
+
+    // MARK: - Modifying the Stack
+
+    var count: Int {
+        return self.containers.count
+    }
+
+    var topContainer: Any {
+        precondition(self.containers.count > 0, "Empty container stack.")
+        return self.containers.last!
+    }
+
+    mutating func push(container: Any) {
+        self.containers.append(container)
+    }
+
+    mutating func popContainer() {
+        precondition(self.containers.count > 0, "Empty container stack.")
+        self.containers.removeLast()
+    }
+}
+
+// MARK: Decoding Containers
+
+fileprivate struct _PlistKeyedDecodingContainer<K : CodingKey> : KeyedDecodingContainerProtocol {
+    typealias Key = K
+
+    // MARK: Properties
+
+    /// A reference to the decoder we're reading from.
+    let decoder: _PlistDecoder
+
+    /// A reference to the container we're reading from.
+    let container: [String : Any]
+
+    // MARK: - Initialization
+
+    /// Initializes `self` by referencing the given decoder and container.
+    init(referencing decoder: _PlistDecoder, wrapping container: [String : Any]) {
+        self.decoder = decoder
+        self.container = container
+    }
+
+    // MARK: - KeyedDecodingContainerProtocol Methods
+
+    var codingPath: [CodingKey?] {
+        return self.decoder.codingPath
+    }
+
+    var allKeys: [Key] {
+        return self.container.keys.flatMap { Key(stringValue: $0) }
+    }
+
+    func contains(_ key: Key) -> Bool {
+        return self.container[key.stringValue] != nil
+    }
+
+    func decodeIfPresent(_ type: Bool.Type, forKey key: Key) throws -> Bool? {
+        return try self.decoder.with(pushedKey: key) {
+            return try self.decoder.unbox(self.container[key.stringValue], as: Bool.self)
+        }
+    }
+
+    func decodeIfPresent(_ type: Int.Type, forKey key: Key) throws -> Int? {
+        return try self.decoder.with(pushedKey: key) {
+            return try self.decoder.unbox(self.container[key.stringValue], as: Int.self)
+        }
+    }
+
+    func decodeIfPresent(_ type: Int8.Type, forKey key: Key) throws -> Int8? {
+        return try self.decoder.with(pushedKey: key) {
+            return try self.decoder.unbox(self.container[key.stringValue], as: Int8.self)
+        }
+    }
+
+    func decodeIfPresent(_ type: Int16.Type, forKey key: Key) throws -> Int16? {
+        return try self.decoder.with(pushedKey: key) {
+            return try self.decoder.unbox(self.container[key.stringValue], as: Int16.self)
+        }
+    }
+
+    func decodeIfPresent(_ type: Int32.Type, forKey key: Key) throws -> Int32? {
+        return try self.decoder.with(pushedKey: key) {
+            return try self.decoder.unbox(self.container[key.stringValue], as: Int32.self)
+        }
+    }
+
+    func decodeIfPresent(_ type: Int64.Type, forKey key: Key) throws -> Int64? {
+        return try self.decoder.with(pushedKey: key) {
+            return try self.decoder.unbox(self.container[key.stringValue], as: Int64.self)
+        }
+    }
+
+    func decodeIfPresent(_ type: UInt.Type, forKey key: Key) throws -> UInt? {
+        return try self.decoder.with(pushedKey: key) {
+            return try self.decoder.unbox(self.container[key.stringValue], as: UInt.self)
+        }
+    }
+
+    func decodeIfPresent(_ type: UInt8.Type, forKey key: Key) throws -> UInt8? {
+        return try self.decoder.with(pushedKey: key) {
+            return try self.decoder.unbox(self.container[key.stringValue], as: UInt8.self)
+        }
+    }
+
+    func decodeIfPresent(_ type: UInt16.Type, forKey key: Key) throws -> UInt16? {
+        return try self.decoder.with(pushedKey: key) {
+            return try self.decoder.unbox(self.container[key.stringValue], as: UInt16.self)
+        }
+    }
+
+    func decodeIfPresent(_ type: UInt32.Type, forKey key: Key) throws -> UInt32? {
+        return try self.decoder.with(pushedKey: key) {
+            return try self.decoder.unbox(self.container[key.stringValue], as: UInt32.self)
+        }
+    }
+
+    func decodeIfPresent(_ type: UInt64.Type, forKey key: Key) throws -> UInt64? {
+        return try self.decoder.with(pushedKey: key) {
+            return try self.decoder.unbox(self.container[key.stringValue], as: UInt64.self)
+        }
+    }
+
+    func decodeIfPresent(_ type: Float.Type, forKey key: Key) throws -> Float? {
+        return try self.decoder.with(pushedKey: key) {
+            return try self.decoder.unbox(self.container[key.stringValue], as: Float.self)
+        }
+    }
+
+    func decodeIfPresent(_ type: Double.Type, forKey key: Key) throws -> Double? {
+        return try self.decoder.with(pushedKey: key) {
+            return try self.decoder.unbox(self.container[key.stringValue], as: Double.self)
+        }
+    }
+
+    func decodeIfPresent(_ type: String.Type, forKey key: Key) throws -> String? {
+        return try self.decoder.with(pushedKey: key) {
+            return try self.decoder.unbox(self.container[key.stringValue], as: String.self)
+        }
+    }
+
+    func decodeIfPresent(_ type: Data.Type, forKey key: Key) throws -> Data? {
+        return try self.decoder.with(pushedKey: key) {
+            return try self.decoder.unbox(self.container[key.stringValue], as: Data.self)
+        }
+    }
+
+    func decodeIfPresent<T : Decodable>(_ type: T.Type, forKey key: Key) throws -> T? {
+        return try self.decoder.with(pushedKey: key) {
+            return try self.decoder.unbox(self.container[key.stringValue], as: T.self)
+        }
+    }
+
+    func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type, forKey key: Key) throws -> KeyedDecodingContainer<NestedKey> {
+        return try self.decoder.with(pushedKey: key) {
+            guard let value = self.container[key.stringValue] else {
+                throw DecodingError.valueNotFound(KeyedDecodingContainer<NestedKey>.self,
+                                                  DecodingError.Context(codingPath: self.codingPath,
+                                                          debugDescription: "Cannot get nested keyed container -- no value found for key \"\(key.stringValue)\""))
+            }
+
+            guard let container = value as? [String : Any] else {
+                throw DecodingError._typeMismatch(at: self.codingPath, expectation: [String : Any].self, reality: value)
+            }
+
+            let wrapper = _PlistKeyedDecodingContainer<NestedKey>(referencing: self.decoder, wrapping: container)
+            return KeyedDecodingContainer(wrapper)
+        }
+    }
+
+    func nestedUnkeyedContainer(forKey key: Key) throws -> UnkeyedDecodingContainer {
+        return try self.decoder.with(pushedKey: key) {
+            guard let value = self.container[key.stringValue] else {
+                throw DecodingError.valueNotFound(UnkeyedDecodingContainer.self,
+                                                  DecodingError.Context(codingPath: self.codingPath,
+                                                          debugDescription: "Cannot get nested unkeyed container -- no value found for key \"\(key.stringValue)\""))
+            }
+
+            guard let container = value as? [Any] else {
+                throw DecodingError._typeMismatch(at: self.codingPath, expectation: [Any].self, reality: value)
+            }
+
+            return _PlistUnkeyedDecodingContainer(referencing: self.decoder, wrapping: container)
+        }
+    }
+
+    func _superDecoder(forKey key: CodingKey) throws -> Decoder {
+        return try self.decoder.with(pushedKey: key) {
+            guard let value = self.container[key.stringValue] else {
+                throw DecodingError.valueNotFound(Decoder.self,
+                                                  DecodingError.Context(codingPath: self.codingPath,
+                                                          debugDescription: "Cannot get superDecoder() -- no value found for key \"\(key.stringValue)\""))
+            }
+
+            return _PlistDecoder(referencing: value, options: self.decoder.options)
+        }
+    }
+
+    func superDecoder() throws -> Decoder {
+        return try _superDecoder(forKey: _PlistDecodingSuperKey())
+    }
+
+    func superDecoder(forKey key: Key) throws -> Decoder {
+        return try _superDecoder(forKey: key)
+    }
+}
+
+fileprivate struct _PlistDecodingSuperKey : CodingKey {
+    init() {}
+
+    var stringValue: String { return "super" }
+    init?(stringValue: String) {
+        guard stringValue == "super" else { return nil }
+    }
+
+    var intValue: Int? { return nil }
+    init?(intValue: Int) {
+        return nil
+    }
+}
+
+fileprivate struct _PlistUnkeyedDecodingContainer : UnkeyedDecodingContainer {
+    // MARK: Properties
+
+    /// A reference to the decoder we're reading from.
+    let decoder: _PlistDecoder
+
+    /// A reference to the container we're reading from.
+    let container: [Any]
+
+    /// The index of the element we're about to decode.
+    var currentIndex: Int
+
+    // MARK: - Initialization
+
+    /// Initializes `self` by referencing the given decoder and container.
+    init(referencing decoder: _PlistDecoder, wrapping container: [Any]) {
+        self.decoder = decoder
+        self.container = container
+        self.currentIndex = 0
+    }
+
+    // MARK: - UnkeyedDecodingContainer Methods
+
+    var codingPath: [CodingKey?] {
+        return self.decoder.codingPath
+    }
+
+    var count: Int? {
+        return self.container.count
+    }
+
+    var isAtEnd: Bool {
+        return self.currentIndex >= self.count!
+    }
+
+    mutating func decodeIfPresent(_ type: Bool.Type) throws -> Bool? {
+        guard !self.isAtEnd else { return nil }
+
+        return try self.decoder.with(pushedKey: nil) {
+            let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: Bool.self)
+            self.currentIndex += 1
+            return decoded
+        }
+    }
+
+    mutating func decodeIfPresent(_ type: Int.Type) throws -> Int? {
+        guard !self.isAtEnd else { return nil }
+
+        return try self.decoder.with(pushedKey: nil) {
+            let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: Int.self)
+            self.currentIndex += 1
+            return decoded
+        }
+    }
+
+    mutating func decodeIfPresent(_ type: Int8.Type) throws -> Int8? {
+        guard !self.isAtEnd else { return nil }
+
+        return try self.decoder.with(pushedKey: nil) {
+            let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: Int8.self)
+            self.currentIndex += 1
+            return decoded
+        }
+    }
+
+    mutating func decodeIfPresent(_ type: Int16.Type) throws -> Int16? {
+        guard !self.isAtEnd else { return nil }
+
+        return try self.decoder.with(pushedKey: nil) {
+            let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: Int16.self)
+            self.currentIndex += 1
+            return decoded
+        }
+    }
+
+    mutating func decodeIfPresent(_ type: Int32.Type) throws -> Int32? {
+        guard !self.isAtEnd else { return nil }
+
+        return try self.decoder.with(pushedKey: nil) {
+            let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: Int32.self)
+            self.currentIndex += 1
+            return decoded
+        }
+    }
+
+    mutating func decodeIfPresent(_ type: Int64.Type) throws -> Int64? {
+        guard !self.isAtEnd else { return nil }
+
+        return try self.decoder.with(pushedKey: nil) {
+            let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: Int64.self)
+            self.currentIndex += 1
+            return decoded
+        }
+    }
+
+    mutating func decodeIfPresent(_ type: UInt.Type) throws -> UInt? {
+        guard !self.isAtEnd else { return nil }
+
+        return try self.decoder.with(pushedKey: nil) {
+            let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: UInt.self)
+            self.currentIndex += 1
+            return decoded
+        }
+    }
+
+    mutating func decodeIfPresent(_ type: UInt8.Type) throws -> UInt8? {
+        guard !self.isAtEnd else { return nil }
+
+        return try self.decoder.with(pushedKey: nil) {
+            let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: UInt8.self)
+            self.currentIndex += 1
+            return decoded
+        }
+    }
+
+    mutating func decodeIfPresent(_ type: UInt16.Type) throws -> UInt16? {
+        guard !self.isAtEnd else { return nil }
+
+        return try self.decoder.with(pushedKey: nil) {
+            let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: UInt16.self)
+            self.currentIndex += 1
+            return decoded
+        }
+    }
+
+    mutating func decodeIfPresent(_ type: UInt32.Type) throws -> UInt32? {
+        guard !self.isAtEnd else { return nil }
+
+        return try self.decoder.with(pushedKey: nil) {
+            let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: UInt32.self)
+            self.currentIndex += 1
+            return decoded
+        }
+    }
+
+    mutating func decodeIfPresent(_ type: UInt64.Type) throws -> UInt64? {
+        guard !self.isAtEnd else { return nil }
+
+        return try self.decoder.with(pushedKey: nil) {
+            let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: UInt64.self)
+            self.currentIndex += 1
+            return decoded
+        }
+    }
+
+    mutating func decodeIfPresent(_ type: Float.Type) throws -> Float? {
+        guard !self.isAtEnd else { return nil }
+
+        return try self.decoder.with(pushedKey: nil) {
+            let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: Float.self)
+            self.currentIndex += 1
+            return decoded
+        }
+    }
+
+    mutating func decodeIfPresent(_ type: Double.Type) throws -> Double? {
+        guard !self.isAtEnd else { return nil }
+
+        return try self.decoder.with(pushedKey: nil) {
+            let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: Double.self)
+            self.currentIndex += 1
+            return decoded
+        }
+    }
+
+    mutating func decodeIfPresent(_ type: String.Type) throws -> String? {
+        guard !self.isAtEnd else { return nil }
+
+        return try self.decoder.with(pushedKey: nil) {
+            let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: String.self)
+            self.currentIndex += 1
+            return decoded
+        }
+    }
+
+    mutating func decodeIfPresent(_ type: Data.Type) throws -> Data? {
+        guard !self.isAtEnd else { return nil }
+
+        return try self.decoder.with(pushedKey: nil) {
+            let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: Data.self)
+            self.currentIndex += 1
+            return decoded
+        }
+    }
+
+    mutating func decodeIfPresent<T : Decodable>(_ type: T.Type) throws -> T? {
+        guard !self.isAtEnd else { return nil }
+
+        return try self.decoder.with(pushedKey: nil) {
+            let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: T.self)
+            self.currentIndex += 1
+            return decoded
+        }
+    }
+
+    mutating func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type) throws -> KeyedDecodingContainer<NestedKey> {
+        return try self.decoder.with(pushedKey: nil) {
+            guard !self.isAtEnd else {
+                throw DecodingError.valueNotFound(KeyedDecodingContainer<NestedKey>.self,
+                                                  DecodingError.Context(codingPath: self.codingPath,
+                                                          debugDescription: "Cannot get nested keyed container -- unkeyed container is at end."))
+            }
+
+            let value = self.container[self.currentIndex]
+            guard !(value is NSNull) else {
+                throw DecodingError.valueNotFound(KeyedDecodingContainer<NestedKey>.self,
+                                                  DecodingError.Context(codingPath: self.codingPath,
+                                                          debugDescription: "Cannot get keyed decoding container -- found null value instead."))
+            }
+
+            guard let container = value as? [String : Any] else {
+                throw DecodingError._typeMismatch(at: self.codingPath, expectation: [String : Any].self, reality: value)
+            }
+
+            self.currentIndex += 1
+            let wrapper = _PlistKeyedDecodingContainer<NestedKey>(referencing: self.decoder, wrapping: container)
+            return KeyedDecodingContainer(wrapper)
+        }
+    }
+
+    mutating func nestedUnkeyedContainer() throws -> UnkeyedDecodingContainer {
+        return try self.decoder.with(pushedKey: nil) {
+            guard !self.isAtEnd else {
+                throw DecodingError.valueNotFound(UnkeyedDecodingContainer.self,
+                                                  DecodingError.Context(codingPath: self.codingPath,
+                                                          debugDescription: "Cannot get nested unkeyed container -- unkeyed container is at end."))
+            }
+
+            let value = self.container[self.currentIndex]
+            guard !(value is NSNull) else {
+                throw DecodingError.valueNotFound(UnkeyedDecodingContainer.self,
+                                                  DecodingError.Context(codingPath: self.codingPath,
+                                                          debugDescription: "Cannot get keyed decoding container -- found null value instead."))
+            }
+
+            guard let container = value as? [Any] else {
+                throw DecodingError._typeMismatch(at: self.codingPath, expectation: [Any].self, reality: value)
+            }
+
+            self.currentIndex += 1
+            return _PlistUnkeyedDecodingContainer(referencing: self.decoder, wrapping: container)
+        }
+    }
+
+    mutating func superDecoder() throws -> Decoder {
+        return try self.decoder.with(pushedKey: nil) {
+            guard !self.isAtEnd else {
+                throw DecodingError.valueNotFound(Decoder.self, DecodingError.Context(codingPath: self.codingPath,
+                                                                        debugDescription: "Cannot get superDecoder() -- unkeyed container is at end."))
+            }
+
+            let value = self.container[self.currentIndex]
+            guard !(value is NSNull) else {
+                throw DecodingError.valueNotFound(Decoder.self,
+                                                  DecodingError.Context(codingPath: self.codingPath,
+                                                          debugDescription: "Cannot get superDecoder() -- found null value instead."))
+            }
+
+            self.currentIndex += 1
+            return _PlistDecoder(referencing: value, options: self.decoder.options)
+        }
+    }
+}
+
+extension _PlistDecoder : SingleValueDecodingContainer {
+    // MARK: SingleValueDecodingContainer Methods
+
+    // These all unwrap the result, since we couldn't have gotten a single value container if the topContainer was null.
+    func decode(_ type: Bool.Type)   throws -> Bool   { return try self.unbox(self.storage.topContainer, as: Bool.self)! }
+    func decode(_ type: Int.Type)    throws -> Int    { return try self.unbox(self.storage.topContainer, as: Int.self)! }
+    func decode(_ type: Int8.Type)   throws -> Int8   { return try self.unbox(self.storage.topContainer, as: Int8.self)! }
+    func decode(_ type: Int16.Type)  throws -> Int16  { return try self.unbox(self.storage.topContainer, as: Int16.self)! }
+    func decode(_ type: Int32.Type)  throws -> Int32  { return try self.unbox(self.storage.topContainer, as: Int32.self)! }
+    func decode(_ type: Int64.Type)  throws -> Int64  { return try self.unbox(self.storage.topContainer, as: Int64.self)! }
+    func decode(_ type: UInt.Type)   throws -> UInt   { return try self.unbox(self.storage.topContainer, as: UInt.self)! }
+    func decode(_ type: UInt8.Type)  throws -> UInt8  { return try self.unbox(self.storage.topContainer, as: UInt8.self)! }
+    func decode(_ type: UInt16.Type) throws -> UInt16 { return try self.unbox(self.storage.topContainer, as: UInt16.self)! }
+    func decode(_ type: UInt32.Type) throws -> UInt32 { return try self.unbox(self.storage.topContainer, as: UInt32.self)! }
+    func decode(_ type: UInt64.Type) throws -> UInt64 { return try self.unbox(self.storage.topContainer, as: UInt64.self)! }
+    func decode(_ type: Float.Type)  throws -> Float  { return try self.unbox(self.storage.topContainer, as: Float.self)! }
+    func decode(_ type: Double.Type) throws -> Double { return try self.unbox(self.storage.topContainer, as: Double.self)! }
+    func decode(_ type: String.Type) throws -> String { return try self.unbox(self.storage.topContainer, as: String.self)! }
+    func decode(_ type: Data.Type)   throws -> Data   { return try self.unbox(self.storage.topContainer, as: Data.self)! }
+}
+
+// MARK: - Concrete Value Representations
+
+extension _PlistDecoder {
+    /// Returns the given value unboxed from a container.
+    fileprivate func unbox(_ value: Any?, as type: Bool.Type) throws -> Bool? {
+        guard let value = value else { return nil }
+        if let string = value as? String, string == _plistNull { return nil }
+
+        if let number = value as? NSNumber {
+            // TODO: Add a flag to coerce non-boolean numbers into Bools?
+            if number === kCFBooleanTrue as NSNumber {
+                return true
+            } else if number === kCFBooleanFalse as NSNumber {
+                return false
+            }
+
+        /* FIXME: If swift-corelibs-foundation doesn't change to use NSNumber, this code path will need to be included and tested:
+        } else if let bool = value as? Bool {
+            return bool
+        */
+
+        }
+
+        throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+    }
+
+    fileprivate func unbox(_ value: Any?, as type: Int.Type) throws -> Int? {
+        guard let value = value else { return nil }
+        if let string = value as? String, string == _plistNull { return nil }
+
+        guard let number = value as? NSNumber else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+        }
+
+        let int = number.intValue
+        guard NSNumber(value: int) == number else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Parsed property list number <\(number)> does not fit in \(type)."))
+        }
+
+        return int
+    }
+
+    fileprivate func unbox(_ value: Any?, as type: Int8.Type) throws -> Int8? {
+        guard let value = value else { return nil }
+        if let string = value as? String, string == _plistNull { return nil }
+
+        guard let number = value as? NSNumber else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+        }
+
+        let int8 = number.int8Value
+        guard NSNumber(value: int8) == number else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Parsed property list number <\(number)> does not fit in \(type)."))
+        }
+
+        return int8
+    }
+
+    fileprivate func unbox(_ value: Any?, as type: Int16.Type) throws -> Int16? {
+        guard let value = value else { return nil }
+        if let string = value as? String, string == _plistNull { return nil }
+
+        guard let number = value as? NSNumber else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+        }
+
+        let int16 = number.int16Value
+        guard NSNumber(value: int16) == number else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Parsed property list number <\(number)> does not fit in \(type)."))
+        }
+
+        return int16
+    }
+
+    fileprivate func unbox(_ value: Any?, as type: Int32.Type) throws -> Int32? {
+        guard let value = value else { return nil }
+        if let string = value as? String, string == _plistNull { return nil }
+
+        guard let number = value as? NSNumber else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+        }
+
+        let int32 = number.int32Value
+        guard NSNumber(value: int32) == number else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Parsed property list number <\(number)> does not fit in \(type)."))
+        }
+
+        return int32
+    }
+
+    fileprivate func unbox(_ value: Any?, as type: Int64.Type) throws -> Int64? {
+        guard let value = value else { return nil }
+        if let string = value as? String, string == _plistNull { return nil }
+
+        guard let number = value as? NSNumber else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+        }
+
+        let int64 = number.int64Value
+        guard NSNumber(value: int64) == number else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Parsed property list number <\(number)> does not fit in \(type)."))
+        }
+
+        return int64
+    }
+
+    fileprivate func unbox(_ value: Any?, as type: UInt.Type) throws -> UInt? {
+        guard let value = value else { return nil }
+        if let string = value as? String, string == _plistNull { return nil }
+
+        guard let number = value as? NSNumber else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+        }
+
+        let uint = number.uintValue
+        guard NSNumber(value: uint) == number else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Parsed property list number <\(number)> does not fit in \(type)."))
+        }
+
+        return uint
+    }
+
+    fileprivate func unbox(_ value: Any?, as type: UInt8.Type) throws -> UInt8? {
+        guard let value = value else { return nil }
+        if let string = value as? String, string == _plistNull { return nil }
+
+        guard let number = value as? NSNumber else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+        }
+
+        let uint8 = number.uint8Value
+        guard NSNumber(value: uint8) == number else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Parsed property list number <\(number)> does not fit in \(type)."))
+        }
+
+        return uint8
+    }
+
+    fileprivate func unbox(_ value: Any?, as type: UInt16.Type) throws -> UInt16? {
+        guard let value = value else { return nil }
+        if let string = value as? String, string == _plistNull { return nil }
+
+        guard let number = value as? NSNumber else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+        }
+
+        let uint16 = number.uint16Value
+        guard NSNumber(value: uint16) == number else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Parsed property list number <\(number)> does not fit in \(type)."))
+        }
+
+        return uint16
+    }
+
+    fileprivate func unbox(_ value: Any?, as type: UInt32.Type) throws -> UInt32? {
+        guard let value = value else { return nil }
+        if let string = value as? String, string == _plistNull { return nil }
+
+        guard let number = value as? NSNumber else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+        }
+
+        let uint32 = number.uint32Value
+        guard NSNumber(value: uint32) == number else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Parsed property list number <\(number)> does not fit in \(type)."))
+        }
+
+        return uint32
+    }
+
+    fileprivate func unbox(_ value: Any?, as type: UInt64.Type) throws -> UInt64? {
+        guard let value = value else { return nil }
+        if let string = value as? String, string == _plistNull { return nil }
+
+        guard let number = value as? NSNumber else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+        }
+
+        let uint64 = number.uint64Value
+        guard NSNumber(value: uint64) == number else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Parsed property list number <\(number)> does not fit in \(type)."))
+        }
+
+        return uint64
+    }
+
+    fileprivate func unbox(_ value: Any?, as type: Float.Type) throws -> Float? {
+        guard let value = value else { return nil }
+        if let string = value as? String, string == _plistNull { return nil }
+
+        guard let number = value as? NSNumber else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+        }
+
+        let float = number.floatValue
+        guard NSNumber(value: float) == number else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Parsed property list number <\(number)> does not fit in \(type)."))
+        }
+
+        return float
+    }
+
+    func unbox(_ value: Any?, as type: Double.Type) throws -> Double? {
+        guard let value = value else { return nil }
+        if let string = value as? String, string == _plistNull { return nil }
+
+        guard let number = value as? NSNumber else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+        }
+
+        let double = number.doubleValue
+        guard NSNumber(value: double) == number else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Parsed property list number <\(number)> does not fit in \(type)."))
+        }
+
+        return double
+    }
+
+    func unbox(_ value: Any?, as type: String.Type) throws -> String? {
+        guard let value = value else { return nil }
+
+        guard let string = value as? String else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+        }
+
+        return string == _plistNull ? nil : string
+    }
+
+    func unbox(_ value: Any?, as type: Date.Type) throws -> Date? {
+        guard let value = value else { return nil }
+        if let string = value as? String, string == _plistNull { return nil }
+
+        guard let date = value as? Date else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+        }
+
+        return date
+    }
+
+    func unbox(_ value: Any?, as type: Data.Type) throws -> Data? {
+        guard let value = value else { return nil }
+        if let string = value as? String, string == _plistNull { return nil }
+
+        guard let data = value as? Data else {
+            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+        }
+
+        return data
+    }
+
+    func unbox<T : Decodable>(_ value: Any?, as type: T.Type) throws -> T? {
+        guard let value = value else { return nil }
+        if let string = value as? String, string == _plistNull { return nil }
+
+        let decoded: T
+        if T.self == Date.self {
+            decoded = (try self.unbox(value, as: Date.self) as! T)
+        } else if T.self == Data.self {
+            decoded = (try self.unbox(value, as: Data.self) as! T)
+        } else {
+            self.storage.push(container: value)
+            decoded = try T(from: self)
+            self.storage.popContainer()
+        }
+
+        return decoded
+    }
+}
+
+//===----------------------------------------------------------------------===//
+// Shared Plist Null Representation
+//===----------------------------------------------------------------------===//
+
+// Since plists do not support null values by default, we will encode them as "$null".
+fileprivate let _plistNull = "$null"
+fileprivate let _plistNullNSString = NSString(string: _plistNull)

--- a/stdlib/public/core/Codable.swift
+++ b/stdlib/public/core/Codable.swift
@@ -291,19 +291,20 @@ public struct KeyedEncodingContainer<K : CodingKey> {
     public typealias Key = K
 
     /// The container for the concrete encoder. The type is _*Base so that it's generic on the key type.
-    private var box: _KeyedEncodingContainerBase<Key>
+    @_versioned
+    internal var _box: _KeyedEncodingContainerBase<Key>
 
     /// Initializes `self` with the given container.
     ///
     /// - parameter container: The container to hold.
     public init<Container : KeyedEncodingContainerProtocol>(_ container: Container) where Container.Key == Key {
-        box = _KeyedEncodingContainerBox(container)
+        _box = _KeyedEncodingContainerBox(container)
     }
 
     /// The path of coding keys taken to get to this point in encoding.
     /// A `nil` value indicates an unkeyed container.
     public var codingPath: [CodingKey?] {
-        return box.codingPath
+        return _box.codingPath
     }
 
     /// Encodes the given value for the given key.
@@ -312,7 +313,7 @@ public struct KeyedEncodingContainer<K : CodingKey> {
     /// - parameter key: The key to associate the value with.
     /// - throws: `EncodingError.invalidValue` if the given value is invalid in the current context for this format.
     public mutating func encode(_ value: Bool?, forKey key: Key) throws {
-        try box.encode(value, forKey: key)
+        try _box.encode(value, forKey: key)
     }
 
     /// Encodes the given value for the given key.
@@ -321,7 +322,7 @@ public struct KeyedEncodingContainer<K : CodingKey> {
     /// - parameter key: The key to associate the value with.
     /// - throws: `EncodingError.invalidValue` if the given value is invalid in the current context for this format.
     public mutating func encode(_ value: Int?, forKey key: Key) throws {
-        try box.encode(value, forKey: key)
+        try _box.encode(value, forKey: key)
     }
 
     /// Encodes the given value for the given key.
@@ -330,7 +331,7 @@ public struct KeyedEncodingContainer<K : CodingKey> {
     /// - parameter key: The key to associate the value with.
     /// - throws: `EncodingError.invalidValue` if the given value is invalid in the current context for this format.
     public mutating func encode(_ value: Int8?, forKey key: Key) throws {
-        try box.encode(value, forKey: key)
+        try _box.encode(value, forKey: key)
     }
 
     /// Encodes the given value for the given key.
@@ -339,7 +340,7 @@ public struct KeyedEncodingContainer<K : CodingKey> {
     /// - parameter key: The key to associate the value with.
     /// - throws: `EncodingError.invalidValue` if the given value is invalid in the current context for this format.
     public mutating func encode(_ value: Int16?, forKey key: Key) throws {
-        try box.encode(value, forKey: key)
+        try _box.encode(value, forKey: key)
     }
 
     /// Encodes the given value for the given key.
@@ -348,7 +349,7 @@ public struct KeyedEncodingContainer<K : CodingKey> {
     /// - parameter key: The key to associate the value with.
     /// - throws: `EncodingError.invalidValue` if the given value is invalid in the current context for this format.
     public mutating func encode(_ value: Int32?, forKey key: Key) throws {
-        try box.encode(value, forKey: key)
+        try _box.encode(value, forKey: key)
     }
 
     /// Encodes the given value for the given key.
@@ -357,7 +358,7 @@ public struct KeyedEncodingContainer<K : CodingKey> {
     /// - parameter key: The key to associate the value with.
     /// - throws: `EncodingError.invalidValue` if the given value is invalid in the current context for this format.
     public mutating func encode(_ value: Int64?, forKey key: Key) throws {
-        try box.encode(value, forKey: key)
+        try _box.encode(value, forKey: key)
     }
 
     /// Encodes the given value for the given key.
@@ -366,7 +367,7 @@ public struct KeyedEncodingContainer<K : CodingKey> {
     /// - parameter key: The key to associate the value with.
     /// - throws: `EncodingError.invalidValue` if the given value is invalid in the current context for this format.
     public mutating func encode(_ value: UInt?, forKey key: Key) throws {
-        try box.encode(value, forKey: key)
+        try _box.encode(value, forKey: key)
     }
 
     /// Encodes the given value for the given key.
@@ -375,7 +376,7 @@ public struct KeyedEncodingContainer<K : CodingKey> {
     /// - parameter key: The key to associate the value with.
     /// - throws: `EncodingError.invalidValue` if the given value is invalid in the current context for this format.
     public mutating func encode(_ value: UInt8?, forKey key: Key) throws {
-        try box.encode(value, forKey: key)
+        try _box.encode(value, forKey: key)
     }
 
     /// Encodes the given value for the given key.
@@ -384,7 +385,7 @@ public struct KeyedEncodingContainer<K : CodingKey> {
     /// - parameter key: The key to associate the value with.
     /// - throws: `EncodingError.invalidValue` if the given value is invalid in the current context for this format.
     public mutating func encode(_ value: UInt16?, forKey key: Key) throws {
-        try box.encode(value, forKey: key)
+        try _box.encode(value, forKey: key)
     }
 
     /// Encodes the given value for the given key.
@@ -393,7 +394,7 @@ public struct KeyedEncodingContainer<K : CodingKey> {
     /// - parameter key: The key to associate the value with.
     /// - throws: `EncodingError.invalidValue` if the given value is invalid in the current context for this format.
     public mutating func encode(_ value: UInt32?, forKey key: Key) throws {
-        try box.encode(value, forKey: key)
+        try _box.encode(value, forKey: key)
     }
 
     /// Encodes the given value for the given key.
@@ -402,7 +403,7 @@ public struct KeyedEncodingContainer<K : CodingKey> {
     /// - parameter key: The key to associate the value with.
     /// - throws: `EncodingError.invalidValue` if the given value is invalid in the current context for this format.
     public mutating func encode(_ value: UInt64?, forKey key: Key) throws {
-        try box.encode(value, forKey: key)
+        try _box.encode(value, forKey: key)
     }
 
     /// Encodes the given value for the given key.
@@ -411,7 +412,7 @@ public struct KeyedEncodingContainer<K : CodingKey> {
     /// - parameter key: The key to associate the value with.
     /// - throws: `EncodingError.invalidValue` if the given value is invalid in the current context for this format.
     public mutating func encode(_ value: Float?, forKey key: Key) throws {
-        try box.encode(value, forKey: key)
+        try _box.encode(value, forKey: key)
     }
 
     /// Encodes the given value for the given key.
@@ -420,7 +421,7 @@ public struct KeyedEncodingContainer<K : CodingKey> {
     /// - parameter key: The key to associate the value with.
     /// - throws: `EncodingError.invalidValue` if the given value is invalid in the current context for this format.
     public mutating func encode(_ value: Double?, forKey key: Key) throws {
-        try box.encode(value, forKey: key)
+        try _box.encode(value, forKey: key)
     }
 
     /// Encodes the given value for the given key.
@@ -429,7 +430,7 @@ public struct KeyedEncodingContainer<K : CodingKey> {
     /// - parameter key: The key to associate the value with.
     /// - throws: `EncodingError.invalidValue` if the given value is invalid in the current context for this format.
     public mutating func encode(_ value: String?, forKey key: Key) throws {
-        try box.encode(value, forKey: key)
+        try _box.encode(value, forKey: key)
     }
 
     /// Encodes the given value for the given key.
@@ -438,7 +439,7 @@ public struct KeyedEncodingContainer<K : CodingKey> {
     /// - parameter key: The key to associate the value with.
     /// - throws: `EncodingError.invalidValue` if the given value is invalid in the current context for this format.
     public mutating func encode<T : Encodable>(_ value: T?, forKey key: Key) throws {
-        try box.encode(value, forKey: key)
+        try _box.encode(value, forKey: key)
     }
 
     /// Encodes the given object weakly for the given key.
@@ -449,7 +450,7 @@ public struct KeyedEncodingContainer<K : CodingKey> {
     /// - parameter key: The key to associate the object with.
     /// - throws: `EncodingError.invalidValue` if the given value is invalid in the current context for this format.
     public mutating func encodeWeak<T : AnyObject & Encodable>(_ object: T?, forKey key: Key) throws {
-        try box.encodeWeak(object, forKey: key)
+        try _box.encodeWeak(object, forKey: key)
     }
 
     /// Stores a keyed encoding container for the given key and returns it.
@@ -458,7 +459,7 @@ public struct KeyedEncodingContainer<K : CodingKey> {
     /// - parameter key: The key to encode the container for.
     /// - returns: A new keyed encoding container.
     public mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type, forKey key: Key) -> KeyedEncodingContainer<NestedKey> {
-        return box.nestedContainer(keyedBy: NestedKey.self, forKey: key)
+        return _box.nestedContainer(keyedBy: NestedKey.self, forKey: key)
     }
 
     /// Stores an unkeyed encoding container for the given key and returns it.
@@ -466,7 +467,7 @@ public struct KeyedEncodingContainer<K : CodingKey> {
     /// - parameter key: The key to encode the container for.
     /// - returns: A new unkeyed encoding container.
     public mutating func nestedUnkeyedContainer(forKey key: Key) -> UnkeyedEncodingContainer {
-        return box.nestedUnkeyedContainer(forKey: key)
+        return _box.nestedUnkeyedContainer(forKey: key)
     }
 
     /// Stores a new nested container for the default `super` key and returns a new `Encoder` instance for encoding `super` into that container.
@@ -475,7 +476,7 @@ public struct KeyedEncodingContainer<K : CodingKey> {
     ///
     /// - returns: A new `Encoder` to pass to `super.encode(to:)`.
     public mutating func superEncoder() -> Encoder {
-        return box.superEncoder()
+        return _box.superEncoder()
     }
 
     /// Stores a new nested container for the given key and returns a new `Encoder` instance for encoding `super` into that container.
@@ -483,7 +484,7 @@ public struct KeyedEncodingContainer<K : CodingKey> {
     /// - parameter key: The key to encode `super` for.
     /// - returns: A new `Encoder` to pass to `super.encode(to:)`.
     public mutating func superEncoder(forKey key: Key) -> Encoder {
-        return box.superEncoder(forKey: key)
+        return _box.superEncoder(forKey: key)
     }
 }
 
@@ -849,26 +850,27 @@ public struct KeyedDecodingContainer<K : CodingKey> : KeyedDecodingContainerProt
     public typealias Key = K
 
     /// The container for the concrete decoder. The type is _*Base so that it's generic on the key type.
-    private var box: _KeyedDecodingContainerBase<Key>
+    @_versioned
+    internal var _box: _KeyedDecodingContainerBase<Key>
 
     /// Initializes `self` with the given container.
     ///
     /// - parameter container: The container to hold.
     public init<Container : KeyedDecodingContainerProtocol>(_ container: Container) where Container.Key == Key {
-        box = _KeyedDecodingContainerBox(container)
+        _box = _KeyedDecodingContainerBox(container)
     }
 
     /// The path of coding keys taken to get to this point in decoding.
     /// A `nil` value indicates an unkeyed container.
     public var codingPath: [CodingKey?] {
-        return box.codingPath
+        return _box.codingPath
     }
 
     /// All the keys the `Decoder` has for this container.
     ///
     /// Different keyed containers from the same `Decoder` may return different keys here; it is possible to encode with multiple key types which are not convertible to one another. This should report all keys present which are convertible to the requested type.
     public var allKeys: [Key] {
-        return box.allKeys
+        return _box.allKeys
     }
 
     /// Returns whether the `Decoder` contains a value associated with the given key.
@@ -878,7 +880,7 @@ public struct KeyedDecodingContainer<K : CodingKey> : KeyedDecodingContainerProt
     /// - parameter key: The key to search for.
     /// - returns: Whether the `Decoder` has an entry for the given key.
     public func contains(_ key: Key) -> Bool {
-        return box.contains(key)
+        return _box.contains(key)
     }
 
     /// Decodes a value of the given type for the given key, if present.
@@ -890,7 +892,7 @@ public struct KeyedDecodingContainer<K : CodingKey> : KeyedDecodingContainerProt
     /// - returns: A decoded value of the requested type, or `nil` if the `Decoder` does not have an entry associated with the given key, or if the value is a null value.
     /// - throws: `DecodingError.typeMismatch` if the encountered encoded value is not convertible to the requested type.
     public func decodeIfPresent(_ type: Bool.Type, forKey key: Key) throws -> Bool? {
-        return try box.decodeIfPresent(Bool.self, forKey: key)
+        return try _box.decodeIfPresent(Bool.self, forKey: key)
     }
 
     /// Decodes a value of the given type for the given key, if present.
@@ -902,7 +904,7 @@ public struct KeyedDecodingContainer<K : CodingKey> : KeyedDecodingContainerProt
     /// - returns: A decoded value of the requested type, or `nil` if the `Decoder` does not have an entry associated with the given key, or if the value is a null value.
     /// - throws: `DecodingError.typeMismatch` if the encountered encoded value is not convertible to the requested type.
     public func decodeIfPresent(_ type: Int.Type, forKey key: Key) throws -> Int? {
-        return try box.decodeIfPresent(Int.self, forKey: key)
+        return try _box.decodeIfPresent(Int.self, forKey: key)
     }
 
     /// Decodes a value of the given type for the given key, if present.
@@ -914,7 +916,7 @@ public struct KeyedDecodingContainer<K : CodingKey> : KeyedDecodingContainerProt
     /// - returns: A decoded value of the requested type, or `nil` if the `Decoder` does not have an entry associated with the given key, or if the value is a null value.
     /// - throws: `DecodingError.typeMismatch` if the encountered encoded value is not convertible to the requested type.
     public func decodeIfPresent(_ type: Int8.Type, forKey key: Key) throws -> Int8? {
-        return try box.decodeIfPresent(Int8.self, forKey: key)
+        return try _box.decodeIfPresent(Int8.self, forKey: key)
     }
 
     /// Decodes a value of the given type for the given key, if present.
@@ -926,7 +928,7 @@ public struct KeyedDecodingContainer<K : CodingKey> : KeyedDecodingContainerProt
     /// - returns: A decoded value of the requested type, or `nil` if the `Decoder` does not have an entry associated with the given key, or if the value is a null value.
     /// - throws: `DecodingError.typeMismatch` if the encountered encoded value is not convertible to the requested type.
     public func decodeIfPresent(_ type: Int16.Type, forKey key: Key) throws -> Int16? {
-        return try box.decodeIfPresent(Int16.self, forKey: key)
+        return try _box.decodeIfPresent(Int16.self, forKey: key)
     }
 
     /// Decodes a value of the given type for the given key, if present.
@@ -938,7 +940,7 @@ public struct KeyedDecodingContainer<K : CodingKey> : KeyedDecodingContainerProt
     /// - returns: A decoded value of the requested type, or `nil` if the `Decoder` does not have an entry associated with the given key, or if the value is a null value.
     /// - throws: `DecodingError.typeMismatch` if the encountered encoded value is not convertible to the requested type.
     public func decodeIfPresent(_ type: Int32.Type, forKey key: Key) throws -> Int32? {
-        return try box.decodeIfPresent(Int32.self, forKey: key)
+        return try _box.decodeIfPresent(Int32.self, forKey: key)
     }
 
     /// Decodes a value of the given type for the given key, if present.
@@ -950,7 +952,7 @@ public struct KeyedDecodingContainer<K : CodingKey> : KeyedDecodingContainerProt
     /// - returns: A decoded value of the requested type, or `nil` if the `Decoder` does not have an entry associated with the given key, or if the value is a null value.
     /// - throws: `DecodingError.typeMismatch` if the encountered encoded value is not convertible to the requested type.
     public func decodeIfPresent(_ type: Int64.Type, forKey key: Key) throws -> Int64? {
-        return try box.decodeIfPresent(Int64.self, forKey: key)
+        return try _box.decodeIfPresent(Int64.self, forKey: key)
     }
 
     /// Decodes a value of the given type for the given key, if present.
@@ -962,7 +964,7 @@ public struct KeyedDecodingContainer<K : CodingKey> : KeyedDecodingContainerProt
     /// - returns: A decoded value of the requested type, or `nil` if the `Decoder` does not have an entry associated with the given key, or if the value is a null value.
     /// - throws: `DecodingError.typeMismatch` if the encountered encoded value is not convertible to the requested type.
     public func decodeIfPresent(_ type: UInt.Type, forKey key: Key) throws -> UInt? {
-        return try box.decodeIfPresent(UInt.self, forKey: key)
+        return try _box.decodeIfPresent(UInt.self, forKey: key)
     }
 
     /// Decodes a value of the given type for the given key, if present.
@@ -974,7 +976,7 @@ public struct KeyedDecodingContainer<K : CodingKey> : KeyedDecodingContainerProt
     /// - returns: A decoded value of the requested type, or `nil` if the `Decoder` does not have an entry associated with the given key, or if the value is a null value.
     /// - throws: `DecodingError.typeMismatch` if the encountered encoded value is not convertible to the requested type.
     public func decodeIfPresent(_ type: UInt8.Type, forKey key: Key) throws -> UInt8? {
-        return try box.decodeIfPresent(UInt8.self, forKey: key)
+        return try _box.decodeIfPresent(UInt8.self, forKey: key)
     }
 
     /// Decodes a value of the given type for the given key, if present.
@@ -986,7 +988,7 @@ public struct KeyedDecodingContainer<K : CodingKey> : KeyedDecodingContainerProt
     /// - returns: A decoded value of the requested type, or `nil` if the `Decoder` does not have an entry associated with the given key, or if the value is a null value.
     /// - throws: `DecodingError.typeMismatch` if the encountered encoded value is not convertible to the requested type.
     public func decodeIfPresent(_ type: UInt16.Type, forKey key: Key) throws -> UInt16? {
-        return try box.decodeIfPresent(UInt16.self, forKey: key)
+        return try _box.decodeIfPresent(UInt16.self, forKey: key)
     }
 
     /// Decodes a value of the given type for the given key, if present.
@@ -998,7 +1000,7 @@ public struct KeyedDecodingContainer<K : CodingKey> : KeyedDecodingContainerProt
     /// - returns: A decoded value of the requested type, or `nil` if the `Decoder` does not have an entry associated with the given key, or if the value is a null value.
     /// - throws: `DecodingError.typeMismatch` if the encountered encoded value is not convertible to the requested type.
     public func decodeIfPresent(_ type: UInt32.Type, forKey key: Key) throws -> UInt32? {
-        return try box.decodeIfPresent(UInt32.self, forKey: key)
+        return try _box.decodeIfPresent(UInt32.self, forKey: key)
     }
 
     /// Decodes a value of the given type for the given key, if present.
@@ -1010,7 +1012,7 @@ public struct KeyedDecodingContainer<K : CodingKey> : KeyedDecodingContainerProt
     /// - returns: A decoded value of the requested type, or `nil` if the `Decoder` does not have an entry associated with the given key, or if the value is a null value.
     /// - throws: `DecodingError.typeMismatch` if the encountered encoded value is not convertible to the requested type.
     public func decodeIfPresent(_ type: UInt64.Type, forKey key: Key) throws -> UInt64? {
-        return try box.decodeIfPresent(UInt64.self, forKey: key)
+        return try _box.decodeIfPresent(UInt64.self, forKey: key)
     }
 
     /// Decodes a value of the given type for the given key, if present.
@@ -1022,7 +1024,7 @@ public struct KeyedDecodingContainer<K : CodingKey> : KeyedDecodingContainerProt
     /// - returns: A decoded value of the requested type, or `nil` if the `Decoder` does not have an entry associated with the given key, or if the value is a null value.
     /// - throws: `DecodingError.typeMismatch` if the encountered encoded value is not convertible to the requested type.
     public func decodeIfPresent(_ type: Float.Type, forKey key: Key) throws -> Float? {
-        return try box.decodeIfPresent(Float.self, forKey: key)
+        return try _box.decodeIfPresent(Float.self, forKey: key)
     }
 
     /// Decodes a value of the given type for the given key, if present.
@@ -1034,7 +1036,7 @@ public struct KeyedDecodingContainer<K : CodingKey> : KeyedDecodingContainerProt
     /// - returns: A decoded value of the requested type, or `nil` if the `Decoder` does not have an entry associated with the given key, or if the value is a null value.
     /// - throws: `DecodingError.typeMismatch` if the encountered encoded value is not convertible to the requested type.
     public func decodeIfPresent(_ type: Double.Type, forKey key: Key) throws -> Double? {
-        return try box.decodeIfPresent(Double.self, forKey: key)
+        return try _box.decodeIfPresent(Double.self, forKey: key)
     }
 
     /// Decodes a value of the given type for the given key, if present.
@@ -1046,7 +1048,7 @@ public struct KeyedDecodingContainer<K : CodingKey> : KeyedDecodingContainerProt
     /// - returns: A decoded value of the requested type, or `nil` if the `Decoder` does not have an entry associated with the given key, or if the value is a null value.
     /// - throws: `DecodingError.typeMismatch` if the encountered encoded value is not convertible to the requested type.
     public func decodeIfPresent(_ type: String.Type, forKey key: Key) throws -> String? {
-        return try box.decodeIfPresent(String.self, forKey: key)
+        return try _box.decodeIfPresent(String.self, forKey: key)
     }
 
     /// Decodes a value of the given type for the given key, if present.
@@ -1058,7 +1060,7 @@ public struct KeyedDecodingContainer<K : CodingKey> : KeyedDecodingContainerProt
     /// - returns: A decoded value of the requested type, or `nil` if the `Decoder` does not have an entry associated with the given key, or if the value is a null value.
     /// - throws: `DecodingError.typeMismatch` if the encountered encoded value is not convertible to the requested type.
     public func decodeIfPresent<T : Decodable>(_ type: T.Type, forKey key: Key) throws -> T? {
-        return try box.decodeIfPresent(T.self, forKey: key)
+        return try _box.decodeIfPresent(T.self, forKey: key)
     }
 
     /// Returns the data stored for the given key as represented in a container keyed by the given key type.
@@ -1068,7 +1070,7 @@ public struct KeyedDecodingContainer<K : CodingKey> : KeyedDecodingContainerProt
     /// - returns: A keyed decoding container view into `self`.
     /// - throws: `DecodingError.typeMismatch` if the encountered stored value is not a keyed container.
     public func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type, forKey key: Key) throws -> KeyedDecodingContainer<NestedKey> {
-        return try box.nestedContainer(keyedBy: NestedKey.self, forKey: key)
+        return try _box.nestedContainer(keyedBy: NestedKey.self, forKey: key)
     }
 
     /// Returns the data stored for the given key as represented in an unkeyed container.
@@ -1077,7 +1079,7 @@ public struct KeyedDecodingContainer<K : CodingKey> : KeyedDecodingContainerProt
     /// - returns: An unkeyed decoding container view into `self`.
     /// - throws: `DecodingError.typeMismatch` if the encountered stored value is not an unkeyed container.
     public func nestedUnkeyedContainer(forKey key: Key) throws -> UnkeyedDecodingContainer {
-        return try box.nestedUnkeyedContainer(forKey: key)
+        return try _box.nestedUnkeyedContainer(forKey: key)
     }
 
     /// Returns a `Decoder` instance for decoding `super` from the container associated with the default `super` key.
@@ -1087,7 +1089,7 @@ public struct KeyedDecodingContainer<K : CodingKey> : KeyedDecodingContainerProt
     /// - throws: `DecodingError.keyNotFound` if `self` does not have an entry for the default `super` key.
     /// - throws: `DecodingError.valueNotFound` if `self` has a null entry for the default `super` key.
     public func superDecoder() throws -> Decoder {
-        return try box.superDecoder()
+        return try _box.superDecoder()
     }
 
     /// Returns a `Decoder` instance for decoding `super` from the container associated with the given key.
@@ -1097,7 +1099,7 @@ public struct KeyedDecodingContainer<K : CodingKey> : KeyedDecodingContainerProt
     /// - throws: `DecodingError.keyNotFound` if `self` does not have an entry for the given key.
     /// - throws: `DecodingError.valueNotFound` if `self` has a null entry for the given key.
     public func superDecoder(forKey key: Key) throws -> Decoder {
-        return try box.superDecoder(forKey: key)
+        return try _box.superDecoder(forKey: key)
     }
 }
 
@@ -1922,371 +1924,557 @@ public enum DecodingError : Error {
 // Keyed Encoding Container Implementations
 //===----------------------------------------------------------------------===//
 
-fileprivate class _KeyedEncodingContainerBase<Key : CodingKey> {
+@_fixed_layout
+@_versioned
+internal class _KeyedEncodingContainerBase<Key : CodingKey> {
     // These must all be given a concrete implementation in _*Box.
-    var codingPath: [CodingKey?] {
+    @_inlineable
+    @_versioned
+    internal var codingPath: [CodingKey?] {
         fatalError("_KeyedEncodingContainerBase cannot be used directly.")
     }
 
-    func encode(_ value: Bool?, forKey key: Key) throws {
+    @_inlineable
+    @_versioned
+    internal func encode(_ value: Bool?, forKey key: Key) throws {
         fatalError("_KeyedEncodingContainerBase cannot be used directly.")
     }
 
-    func encode(_ value: Int?, forKey key: Key) throws {
+    @_inlineable
+    @_versioned
+    internal func encode(_ value: Int?, forKey key: Key) throws {
         fatalError("_KeyedEncodingContainerBase cannot be used directly.")
     }
 
-    func encode(_ value: Int8?, forKey key: Key) throws {
+    @_inlineable
+    @_versioned
+    internal func encode(_ value: Int8?, forKey key: Key) throws {
         fatalError("_KeyedEncodingContainerBase cannot be used directly.")
     }
 
-    func encode(_ value: Int16?, forKey key: Key) throws {
+    @_inlineable
+    @_versioned
+    internal func encode(_ value: Int16?, forKey key: Key) throws {
         fatalError("_KeyedEncodingContainerBase cannot be used directly.")
     }
 
-    func encode(_ value: Int32?, forKey key: Key) throws {
+    @_inlineable
+    @_versioned
+    internal func encode(_ value: Int32?, forKey key: Key) throws {
         fatalError("_KeyedEncodingContainerBase cannot be used directly.")
     }
 
-    func encode(_ value: Int64?, forKey key: Key) throws {
+    @_inlineable
+    @_versioned
+    internal func encode(_ value: Int64?, forKey key: Key) throws {
         fatalError("_KeyedEncodingContainerBase cannot be used directly.")
     }
 
-    func encode(_ value: UInt?, forKey key: Key) throws {
+    @_inlineable
+    @_versioned
+    internal func encode(_ value: UInt?, forKey key: Key) throws {
         fatalError("_KeyedEncodingContainerBase cannot be used directly.")
     }
 
-    func encode(_ value: UInt8?, forKey key: Key) throws {
+    @_inlineable
+    @_versioned
+    internal func encode(_ value: UInt8?, forKey key: Key) throws {
         fatalError("_KeyedEncodingContainerBase cannot be used directly.")
     }
 
-    func encode(_ value: UInt16?, forKey key: Key) throws {
+    @_inlineable
+    @_versioned
+    internal func encode(_ value: UInt16?, forKey key: Key) throws {
         fatalError("_KeyedEncodingContainerBase cannot be used directly.")
     }
 
-    func encode(_ value: UInt32?, forKey key: Key) throws {
+    @_inlineable
+    @_versioned
+    internal func encode(_ value: UInt32?, forKey key: Key) throws {
         fatalError("_KeyedEncodingContainerBase cannot be used directly.")
     }
 
-    func encode(_ value: UInt64?, forKey key: Key) throws {
+    @_inlineable
+    @_versioned
+    internal func encode(_ value: UInt64?, forKey key: Key) throws {
         fatalError("_KeyedEncodingContainerBase cannot be used directly.")
     }
 
-    func encode(_ value: Float?, forKey key: Key) throws {
+    @_inlineable
+    @_versioned
+    internal func encode(_ value: Float?, forKey key: Key) throws {
         fatalError("_KeyedEncodingContainerBase cannot be used directly.")
     }
 
-    func encode(_ value: Double?, forKey key: Key) throws {
+    @_inlineable
+    @_versioned
+    internal func encode(_ value: Double?, forKey key: Key) throws {
         fatalError("_KeyedEncodingContainerBase cannot be used directly.")
     }
 
-    func encode(_ value: String?, forKey key: Key) throws {
+    @_inlineable
+    @_versioned
+    internal func encode(_ value: String?, forKey key: Key) throws {
         fatalError("_KeyedEncodingContainerBase cannot be used directly.")
     }
 
-    func encode<T : Encodable>(_ value: T?, forKey key: Key) throws {
+    @_inlineable
+    @_versioned
+    internal func encode<T : Encodable>(_ value: T?, forKey key: Key) throws {
         fatalError("_KeyedEncodingContainerBase cannot be used directly.")
     }
 
-    func encodeWeak<T : AnyObject & Encodable>(_ object: T?, forKey key: Key) throws {
+    @_inlineable
+    @_versioned
+    internal func encodeWeak<T : AnyObject & Encodable>(_ object: T?, forKey key: Key) throws {
         fatalError("_KeyedEncodingContainerBase cannot be used directly.")
     }
 
-    func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type, forKey key: Key) -> KeyedEncodingContainer<NestedKey> {
+    @_inlineable
+    @_versioned
+    internal func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type, forKey key: Key) -> KeyedEncodingContainer<NestedKey> {
         fatalError("_KeyedEncodingContainerBase cannot be used directly.")
     }
 
-    func nestedUnkeyedContainer(forKey key: Key) -> UnkeyedEncodingContainer {
+    @_inlineable
+    @_versioned
+    internal func nestedUnkeyedContainer(forKey key: Key) -> UnkeyedEncodingContainer {
         fatalError("_KeyedEncodingContainerBase cannot be used directly.")
     }
 
-    func superEncoder() -> Encoder {
+    @_inlineable
+    @_versioned
+    internal func superEncoder() -> Encoder {
         fatalError("_KeyedEncodingContainerBase cannot be used directly.")
     }
 
-    func superEncoder(forKey key: Key) -> Encoder {
+    @_inlineable
+    @_versioned
+    internal func superEncoder(forKey key: Key) -> Encoder {
         fatalError("_KeyedEncodingContainerBase cannot be used directly.")
     }
 }
 
-fileprivate final class _KeyedEncodingContainerBox<Concrete : KeyedEncodingContainerProtocol> : _KeyedEncodingContainerBase<Concrete.Key> {
+@_fixed_layout
+@_versioned
+internal final class _KeyedEncodingContainerBox<Concrete : KeyedEncodingContainerProtocol> : _KeyedEncodingContainerBase<Concrete.Key> {
     typealias Key = Concrete.Key
 
-    var concrete: Concrete
+    @_versioned
+    internal var concrete: Concrete
 
-    init(_ container: Concrete) {
+    @_inlineable
+    @_versioned
+    internal init(_ container: Concrete) {
         concrete = container
     }
 
-    override var codingPath: [CodingKey?] {
+    @_inlineable
+    @_versioned
+    override internal var codingPath: [CodingKey?] {
         return concrete.codingPath
     }
 
-    override func encode<T : Encodable>(_ value: T?, forKey key: Key) throws {
+    @_inlineable
+    @_versioned
+    override internal func encode<T : Encodable>(_ value: T?, forKey key: Key) throws {
         try concrete.encode(value, forKey: key)
     }
 
-    override func encode(_ value: Bool?, forKey key: Key) throws {
+    @_inlineable
+    @_versioned
+    override internal func encode(_ value: Bool?, forKey key: Key) throws {
         try concrete.encode(value, forKey: key)
     }
 
-    override func encode(_ value: Int?, forKey key: Key) throws {
+    @_inlineable
+    @_versioned
+    override internal func encode(_ value: Int?, forKey key: Key) throws {
         try concrete.encode(value, forKey: key)
     }
 
-    override func encode(_ value: Int8?, forKey key: Key) throws {
+    @_inlineable
+    @_versioned
+    override internal func encode(_ value: Int8?, forKey key: Key) throws {
         try concrete.encode(value, forKey: key)
     }
 
-    override func encode(_ value: Int16?, forKey key: Key) throws {
+    @_inlineable
+    @_versioned
+    override internal func encode(_ value: Int16?, forKey key: Key) throws {
         try concrete.encode(value, forKey: key)
     }
 
-    override func encode(_ value: Int32?, forKey key: Key) throws {
+    @_inlineable
+    @_versioned
+    override internal func encode(_ value: Int32?, forKey key: Key) throws {
         try concrete.encode(value, forKey: key)
     }
 
-    override func encode(_ value: Int64?, forKey key: Key) throws {
+    @_inlineable
+    @_versioned
+    override internal func encode(_ value: Int64?, forKey key: Key) throws {
         try concrete.encode(value, forKey: key)
     }
 
-    override func encode(_ value: UInt?, forKey key: Key) throws {
+    @_inlineable
+    @_versioned
+    override internal func encode(_ value: UInt?, forKey key: Key) throws {
         try concrete.encode(value, forKey: key)
     }
 
-    override func encode(_ value: UInt8?, forKey key: Key) throws {
+    @_inlineable
+    @_versioned
+    override internal func encode(_ value: UInt8?, forKey key: Key) throws {
         try concrete.encode(value, forKey: key)
     }
 
-    override func encode(_ value: UInt16?, forKey key: Key) throws {
+    @_inlineable
+    @_versioned
+    override internal func encode(_ value: UInt16?, forKey key: Key) throws {
         try concrete.encode(value, forKey: key)
     }
 
-    override func encode(_ value: UInt32?, forKey key: Key) throws {
+    @_inlineable
+    @_versioned
+    override internal func encode(_ value: UInt32?, forKey key: Key) throws {
         try concrete.encode(value, forKey: key)
     }
 
-    override func encode(_ value: UInt64?, forKey key: Key) throws {
+    @_inlineable
+    @_versioned
+    override internal func encode(_ value: UInt64?, forKey key: Key) throws {
         try concrete.encode(value, forKey: key)
     }
 
-    override func encode(_ value: Float?, forKey key: Key) throws {
+    @_inlineable
+    @_versioned
+    override internal func encode(_ value: Float?, forKey key: Key) throws {
         try concrete.encode(value, forKey: key)
     }
 
-    override func encode(_ value: Double?, forKey key: Key) throws {
+    @_inlineable
+    @_versioned
+    override internal func encode(_ value: Double?, forKey key: Key) throws {
         try concrete.encode(value, forKey: key)
     }
 
-    override func encode(_ value: String?, forKey key: Key) throws {
+    @_inlineable
+    @_versioned
+    override internal func encode(_ value: String?, forKey key: Key) throws {
         try concrete.encode(value, forKey: key)
     }
 
-    override func encodeWeak<T : AnyObject & Encodable>(_ object: T?, forKey key: Key) throws {
+    @_inlineable
+    @_versioned
+    override internal func encodeWeak<T : AnyObject & Encodable>(_ object: T?, forKey key: Key) throws {
         try concrete.encodeWeak(object, forKey: key)
     }
 
-    override func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type, forKey key: Key) -> KeyedEncodingContainer<NestedKey> {
+    @_inlineable
+    @_versioned
+    override internal func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type, forKey key: Key) -> KeyedEncodingContainer<NestedKey> {
         return concrete.nestedContainer(keyedBy: NestedKey.self, forKey: key)
     }
 
-    override func nestedUnkeyedContainer(forKey key: Key) -> UnkeyedEncodingContainer {
+    @_inlineable
+    @_versioned
+    override internal func nestedUnkeyedContainer(forKey key: Key) -> UnkeyedEncodingContainer {
         return concrete.nestedUnkeyedContainer(forKey: key)
     }
 
-    override func superEncoder() -> Encoder {
+    @_inlineable
+    @_versioned
+    override internal func superEncoder() -> Encoder {
         return concrete.superEncoder()
     }
 
-    override func superEncoder(forKey key: Key) -> Encoder {
+    @_inlineable
+    @_versioned
+    override internal func superEncoder(forKey key: Key) -> Encoder {
         return concrete.superEncoder(forKey: key)
     }
 }
 
-fileprivate class _KeyedDecodingContainerBase<Key : CodingKey> {
-    var codingPath: [CodingKey?] {
+@_fixed_layout
+@_versioned
+internal class _KeyedDecodingContainerBase<Key : CodingKey> {
+    @_inlineable
+    @_versioned
+    internal var codingPath: [CodingKey?] {
         fatalError("_KeyedDecodingContainerBase cannot be used directly.")
     }
 
-    var allKeys: [Key] {
+    @_inlineable
+    @_versioned
+    internal var allKeys: [Key] {
         fatalError("_KeyedDecodingContainerBase cannot be used directly.")
     }
 
-    func contains(_ key: Key) -> Bool {
+    @_inlineable
+    @_versioned
+    internal func contains(_ key: Key) -> Bool {
         fatalError("_KeyedDecodingContainerBase cannot be used directly.")
     }
 
-    func decodeIfPresent(_ type: Bool.Type, forKey key: Key) throws -> Bool? {
+    @_inlineable
+    @_versioned
+    internal func decodeIfPresent(_ type: Bool.Type, forKey key: Key) throws -> Bool? {
         fatalError("_KeyedDecodingContainerBase cannot be used directly.")
     }
 
-    func decodeIfPresent(_ type: Int.Type, forKey key: Key) throws -> Int? {
+    @_inlineable
+    @_versioned
+    internal func decodeIfPresent(_ type: Int.Type, forKey key: Key) throws -> Int? {
         fatalError("_KeyedDecodingContainerBase cannot be used directly.")
     }
 
-    func decodeIfPresent(_ type: Int8.Type, forKey key: Key) throws -> Int8? {
+    @_inlineable
+    @_versioned
+    internal func decodeIfPresent(_ type: Int8.Type, forKey key: Key) throws -> Int8? {
         fatalError("_KeyedDecodingContainerBase cannot be used directly.")
     }
 
-    func decodeIfPresent(_ type: Int16.Type, forKey key: Key) throws -> Int16? {
+    @_inlineable
+    @_versioned
+    internal func decodeIfPresent(_ type: Int16.Type, forKey key: Key) throws -> Int16? {
         fatalError("_KeyedDecodingContainerBase cannot be used directly.")
     }
 
-    func decodeIfPresent(_ type: Int32.Type, forKey key: Key) throws -> Int32? {
+    @_inlineable
+    @_versioned
+    internal func decodeIfPresent(_ type: Int32.Type, forKey key: Key) throws -> Int32? {
         fatalError("_KeyedDecodingContainerBase cannot be used directly.")
     }
 
-    func decodeIfPresent(_ type: Int64.Type, forKey key: Key) throws -> Int64? {
+    @_inlineable
+    @_versioned
+    internal func decodeIfPresent(_ type: Int64.Type, forKey key: Key) throws -> Int64? {
         fatalError("_KeyedDecodingContainerBase cannot be used directly.")
     }
 
-    func decodeIfPresent(_ type: UInt.Type, forKey key: Key) throws -> UInt? {
+    @_inlineable
+    @_versioned
+    internal func decodeIfPresent(_ type: UInt.Type, forKey key: Key) throws -> UInt? {
         fatalError("_KeyedDecodingContainerBase cannot be used directly.")
     }
 
-    func decodeIfPresent(_ type: UInt8.Type, forKey key: Key) throws -> UInt8? {
+    @_inlineable
+    @_versioned
+    internal func decodeIfPresent(_ type: UInt8.Type, forKey key: Key) throws -> UInt8? {
         fatalError("_KeyedDecodingContainerBase cannot be used directly.")
     }
 
-    func decodeIfPresent(_ type: UInt16.Type, forKey key: Key) throws -> UInt16? {
+    @_inlineable
+    @_versioned
+    internal func decodeIfPresent(_ type: UInt16.Type, forKey key: Key) throws -> UInt16? {
         fatalError("_KeyedDecodingContainerBase cannot be used directly.")
     }
 
-    func decodeIfPresent(_ type: UInt32.Type, forKey key: Key) throws -> UInt32? {
+    @_inlineable
+    @_versioned
+    internal func decodeIfPresent(_ type: UInt32.Type, forKey key: Key) throws -> UInt32? {
         fatalError("_KeyedDecodingContainerBase cannot be used directly.")
     }
 
-    func decodeIfPresent(_ type: UInt64.Type, forKey key: Key) throws -> UInt64? {
+    @_inlineable
+    @_versioned
+    internal func decodeIfPresent(_ type: UInt64.Type, forKey key: Key) throws -> UInt64? {
         fatalError("_KeyedDecodingContainerBase cannot be used directly.")
     }
 
-    func decodeIfPresent(_ type: Float.Type, forKey key: Key) throws -> Float? {
+    @_inlineable
+    @_versioned
+    internal func decodeIfPresent(_ type: Float.Type, forKey key: Key) throws -> Float? {
         fatalError("_KeyedDecodingContainerBase cannot be used directly.")
     }
 
-    func decodeIfPresent(_ type: Double.Type, forKey key: Key) throws -> Double? {
+    @_inlineable
+    @_versioned
+    internal func decodeIfPresent(_ type: Double.Type, forKey key: Key) throws -> Double? {
         fatalError("_KeyedDecodingContainerBase cannot be used directly.")
     }
 
-    func decodeIfPresent(_ type: String.Type, forKey key: Key) throws -> String? {
+    @_inlineable
+    @_versioned
+    internal func decodeIfPresent(_ type: String.Type, forKey key: Key) throws -> String? {
         fatalError("_KeyedDecodingContainerBase cannot be used directly.")
     }
 
-    func decodeIfPresent<T : Decodable>(_ type: T.Type, forKey key: Key) throws -> T? {
+    @_inlineable
+    @_versioned
+    internal func decodeIfPresent<T : Decodable>(_ type: T.Type, forKey key: Key) throws -> T? {
         fatalError("_KeyedDecodingContainerBase cannot be used directly.")
     }
 
-    func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type, forKey key: Key) throws -> KeyedDecodingContainer<NestedKey> {
+    @_inlineable
+    @_versioned
+    internal func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type, forKey key: Key) throws -> KeyedDecodingContainer<NestedKey> {
         fatalError("_KeyedDecodingContainerBase cannot be used directly.")
     }
 
-    func nestedUnkeyedContainer(forKey key: Key) throws -> UnkeyedDecodingContainer {
+    @_inlineable
+    @_versioned
+    internal func nestedUnkeyedContainer(forKey key: Key) throws -> UnkeyedDecodingContainer {
         fatalError("_KeyedDecodingContainerBase cannot be used directly.")
     }
 
-    func superDecoder() throws -> Decoder {
+    @_inlineable
+    @_versioned
+    internal func superDecoder() throws -> Decoder {
         fatalError("_KeyedDecodingContainerBase cannot be used directly.")
     }
 
-    func superDecoder(forKey key: Key) throws -> Decoder {
+    @_inlineable
+    @_versioned
+    internal func superDecoder(forKey key: Key) throws -> Decoder {
         fatalError("_KeyedDecodingContainerBase cannot be used directly.")
     }
 }
 
-fileprivate final class _KeyedDecodingContainerBox<Concrete : KeyedDecodingContainerProtocol> : _KeyedDecodingContainerBase<Concrete.Key> {
+@_fixed_layout
+@_versioned
+internal final class _KeyedDecodingContainerBox<Concrete : KeyedDecodingContainerProtocol> : _KeyedDecodingContainerBase<Concrete.Key> {
     typealias Key = Concrete.Key
 
-    var concrete: Concrete
+    @_versioned
+    internal var concrete: Concrete
 
-    init(_ container: Concrete) {
+    @_inlineable
+    @_versioned
+    internal init(_ container: Concrete) {
         concrete = container
     }
 
+    @_inlineable
+    @_versioned
     override var codingPath: [CodingKey?] {
         return concrete.codingPath
     }
 
+    @_inlineable
+    @_versioned
     override var allKeys: [Key] {
         return concrete.allKeys
     }
 
-    override func contains(_ key: Key) -> Bool {
+    @_inlineable
+    @_versioned
+    override internal func contains(_ key: Key) -> Bool {
         return concrete.contains(key)
     }
 
-    override func decodeIfPresent(_ type: Bool.Type, forKey key: Key) throws -> Bool? {
+    @_inlineable
+    @_versioned
+    override internal func decodeIfPresent(_ type: Bool.Type, forKey key: Key) throws -> Bool? {
         return try concrete.decodeIfPresent(Bool.self, forKey: key)
     }
 
-    override func decodeIfPresent(_ type: Int.Type, forKey key: Key) throws -> Int? {
+    @_inlineable
+    @_versioned
+    override internal func decodeIfPresent(_ type: Int.Type, forKey key: Key) throws -> Int? {
         return try concrete.decodeIfPresent(Int.self, forKey: key)
     }
 
-    override func decodeIfPresent(_ type: Int8.Type, forKey key: Key) throws -> Int8? {
+    @_inlineable
+    @_versioned
+    override internal func decodeIfPresent(_ type: Int8.Type, forKey key: Key) throws -> Int8? {
         return try concrete.decodeIfPresent(Int8.self, forKey: key)
     }
 
-    override func decodeIfPresent(_ type: Int16.Type, forKey key: Key) throws -> Int16? {
+    @_inlineable
+    @_versioned
+    override internal func decodeIfPresent(_ type: Int16.Type, forKey key: Key) throws -> Int16? {
         return try concrete.decodeIfPresent(Int16.self, forKey: key)
     }
 
-    override func decodeIfPresent(_ type: Int32.Type, forKey key: Key) throws -> Int32? {
+    @_inlineable
+    @_versioned
+    override internal func decodeIfPresent(_ type: Int32.Type, forKey key: Key) throws -> Int32? {
         return try concrete.decodeIfPresent(Int32.self, forKey: key)
     }
 
-    override func decodeIfPresent(_ type: Int64.Type, forKey key: Key) throws -> Int64? {
+    @_inlineable
+    @_versioned
+    override internal func decodeIfPresent(_ type: Int64.Type, forKey key: Key) throws -> Int64? {
         return try concrete.decodeIfPresent(Int64.self, forKey: key)
     }
 
-    override func decodeIfPresent(_ type: UInt.Type, forKey key: Key) throws -> UInt? {
+    @_inlineable
+    @_versioned
+    override internal func decodeIfPresent(_ type: UInt.Type, forKey key: Key) throws -> UInt? {
         return try concrete.decodeIfPresent(UInt.self, forKey: key)
     }
 
-    override func decodeIfPresent(_ type: UInt8.Type, forKey key: Key) throws -> UInt8? {
+    @_inlineable
+    @_versioned
+    override internal func decodeIfPresent(_ type: UInt8.Type, forKey key: Key) throws -> UInt8? {
         return try concrete.decodeIfPresent(UInt8.self, forKey: key)
     }
 
-    override func decodeIfPresent(_ type: UInt16.Type, forKey key: Key) throws -> UInt16? {
+    @_inlineable
+    @_versioned
+    override internal func decodeIfPresent(_ type: UInt16.Type, forKey key: Key) throws -> UInt16? {
         return try concrete.decodeIfPresent(UInt16.self, forKey: key)
     }
 
-    override func decodeIfPresent(_ type: UInt32.Type, forKey key: Key) throws -> UInt32? {
+    @_inlineable
+    @_versioned
+    override internal func decodeIfPresent(_ type: UInt32.Type, forKey key: Key) throws -> UInt32? {
         return try concrete.decodeIfPresent(UInt32.self, forKey: key)
     }
 
-    override func decodeIfPresent(_ type: UInt64.Type, forKey key: Key) throws -> UInt64? {
+    @_inlineable
+    @_versioned
+    override internal func decodeIfPresent(_ type: UInt64.Type, forKey key: Key) throws -> UInt64? {
         return try concrete.decodeIfPresent(UInt64.self, forKey: key)
     }
 
-    override func decodeIfPresent(_ type: Float.Type, forKey key: Key) throws -> Float? {
+    @_inlineable
+    @_versioned
+    override internal func decodeIfPresent(_ type: Float.Type, forKey key: Key) throws -> Float? {
         return try concrete.decodeIfPresent(Float.self, forKey: key)
     }
 
-    override func decodeIfPresent(_ type: Double.Type, forKey key: Key) throws -> Double? {
+    @_inlineable
+    @_versioned
+    override internal func decodeIfPresent(_ type: Double.Type, forKey key: Key) throws -> Double? {
         return try concrete.decodeIfPresent(Double.self, forKey: key)
     }
 
-    override func decodeIfPresent(_ type: String.Type, forKey key: Key) throws -> String? {
+    @_inlineable
+    @_versioned
+    override internal func decodeIfPresent(_ type: String.Type, forKey key: Key) throws -> String? {
         return try concrete.decodeIfPresent(String.self, forKey: key)
     }
 
-    override func decodeIfPresent<T : Decodable>(_ type: T.Type, forKey key: Key) throws -> T? {
+    @_inlineable
+    @_versioned
+    override internal func decodeIfPresent<T : Decodable>(_ type: T.Type, forKey key: Key) throws -> T? {
         return try concrete.decodeIfPresent(T.self, forKey: key)
     }
 
-    override func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type, forKey key: Key) throws -> KeyedDecodingContainer<NestedKey> {
+    @_inlineable
+    @_versioned
+    override internal func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type, forKey key: Key) throws -> KeyedDecodingContainer<NestedKey> {
         return try concrete.nestedContainer(keyedBy: NestedKey.self, forKey: key)
     }
 
-    override func nestedUnkeyedContainer(forKey key: Key) throws -> UnkeyedDecodingContainer {
+    @_inlineable
+    @_versioned
+    override internal func nestedUnkeyedContainer(forKey key: Key) throws -> UnkeyedDecodingContainer {
         return try concrete.nestedUnkeyedContainer(forKey: key)
     }
 
-    override func superDecoder() throws -> Decoder {
+    @_inlineable
+    @_versioned
+    override internal func superDecoder() throws -> Decoder {
         return try concrete.superDecoder()
     }
 
-    override func superDecoder(forKey key: Key) throws -> Decoder {
+    @_inlineable
+    @_versioned
+    override internal func superDecoder(forKey key: Key) throws -> Decoder {
         return try concrete.superDecoder(forKey: key)
     }
 }

--- a/test/stdlib/TestJSONEncoder.swift
+++ b/test/stdlib/TestJSONEncoder.swift
@@ -1,0 +1,539 @@
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+import Swift
+import Foundation
+
+// MARK: - Test Suite
+
+#if FOUNDATION_XCTEST
+import XCTest
+class TestJSONEncoderSuper : XCTestCase { }
+#else
+import StdlibUnittest
+class TestJSONEncoderSuper { }
+#endif
+
+class TestJSONEncoder : TestJSONEncoderSuper {
+  // MARK: - Encoding Top-Level Empty Types
+  func testEncodingTopLevelEmptyStruct() {
+    let empty = EmptyStruct()
+    _testRoundTrip(of: empty, expectedJSON: _jsonEmptyDictionary)
+  }
+
+  func testEncodingTopLevelEmptyClass() {
+    let empty = EmptyClass()
+    _testRoundTrip(of: empty, expectedJSON: _jsonEmptyDictionary)
+  }
+
+  // MARK: - Encoding Top-Level Single-Value Types
+  func testEncodingTopLevelSingleValueEnum() {
+    _testEncodeFailure(of: Switch.off)
+    _testEncodeFailure(of: Switch.on)
+  }
+
+  func testEncodingTopLevelSingleValueStruct() {
+    _testEncodeFailure(of: Timestamp(3141592653))
+  }
+
+  func testEncodingTopLevelSingleValueClass() {
+    _testEncodeFailure(of: Counter())
+  }
+
+  // MARK: - Encoding Top-Level Structured Types
+  func testEncodingTopLevelStructuredStruct() {
+    // Address is a struct type with multiple fields.
+    let address = Address.testValue
+    _testRoundTrip(of: address)
+  }
+
+  func testEncodingTopLevelStructuredClass() {
+    // Person is a class with multiple fields.
+    let person = Person.testValue
+    _testRoundTrip(of: person)
+  }
+
+  func testEncodingTopLevelDeepStructuredType() {
+    // Company is a type with fields which are Codable themselves.
+    let company = Company.testValue
+    _testRoundTrip(of: company)
+  }
+
+  // MARK: - Date Strategy Tests
+  func testEncodingDate() {
+    // We can't encode a top-level Date, so it'll be wrapped in an array.
+    _testRoundTrip(of: TopLevelWrapper(Date()))
+  }
+
+  func testEncodingDateSecondsSince1970() {
+    // Cannot encode an arbitrary number of seconds since we've lost precision since 1970.
+    let seconds = 1000.0
+    let expectedJSON = "[1000]".data(using: .utf8)!
+
+    // We can't encode a top-level Date, so it'll be wrapped in an array.
+    _testRoundTrip(of: TopLevelWrapper(Date(timeIntervalSince1970: seconds)),
+                   expectedJSON: expectedJSON,
+                   dateEncodingStrategy: .secondsSince1970,
+                   dateDecodingStrategy: .secondsSince1970)
+  }
+
+  func testEncodingDateMillisecondsSince1970() {
+    // Cannot encode an arbitrary number of seconds since we've lost precision since 1970.
+    let seconds = 1000.0
+    let expectedJSON = "[1000000]".data(using: .utf8)!
+
+    // We can't encode a top-level Date, so it'll be wrapped in an array.
+    _testRoundTrip(of: TopLevelWrapper(Date(timeIntervalSince1970: seconds)),
+                   expectedJSON: expectedJSON,
+                   dateEncodingStrategy: .millisecondsSince1970,
+                   dateDecodingStrategy: .millisecondsSince1970)
+  }
+
+  func testEncodingDateISO8601() {
+    if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
+      let formatter = ISO8601DateFormatter()
+      formatter.formatOptions = .withInternetDateTime
+
+      let timestamp = Date(timeIntervalSince1970: 1000)
+      let expectedJSON = "[\"\(formatter.string(from: timestamp))\"]".data(using: .utf8)!
+
+      // We can't encode a top-level Date, so it'll be wrapped in an array.
+      _testRoundTrip(of: TopLevelWrapper(timestamp),
+                     expectedJSON: expectedJSON,
+                     dateEncodingStrategy: .iso8601,
+                     dateDecodingStrategy: .iso8601)
+    }
+  }
+
+  func testEncodingDateFormatted() {
+    let formatter = DateFormatter()
+    formatter.dateStyle = .full
+    formatter.timeStyle = .full
+
+    let timestamp = Date(timeIntervalSince1970: 1000)
+    let expectedJSON = "[\"\(formatter.string(from: timestamp))\"]".data(using: .utf8)!
+
+    // We can't encode a top-level Date, so it'll be wrapped in an array.
+    _testRoundTrip(of: TopLevelWrapper(timestamp),
+                   expectedJSON: expectedJSON,
+                   dateEncodingStrategy: .formatted(formatter),
+                   dateDecodingStrategy: .formatted(formatter))
+  }
+
+  func testEncodingDateCustom() {
+    let timestamp = Date()
+
+    // We'll encode a number instead of a date.
+    let encode = { (_ data: Date, _ encoder: Encoder) throws -> Void in
+      var container = encoder.singleValueContainer()
+      try container.encode(42)
+    }
+    let decode = { (_: Decoder) throws -> Date in return timestamp }
+
+    // We can't encode a top-level Date, so it'll be wrapped in an array.
+    let expectedJSON = "[42]".data(using: .utf8)!
+    _testRoundTrip(of: TopLevelWrapper(timestamp),
+                   expectedJSON: expectedJSON,
+                   dateEncodingStrategy: .custom(encode),
+                   dateDecodingStrategy: .custom(decode))
+  }
+
+  func testEncodingDateCustomEmpty() {
+    let timestamp = Date()
+
+    // Encoding nothing should encode an empty keyed container ({}).
+    let encode = { (_: Date, _: Encoder) throws -> Void in }
+    let decode = { (_: Decoder) throws -> Date in return timestamp }
+
+    // We can't encode a top-level Date, so it'll be wrapped in an array.
+    let expectedJSON = "[{}]".data(using: .utf8)!
+    _testRoundTrip(of: TopLevelWrapper(timestamp),
+                   expectedJSON: expectedJSON,
+                   dateEncodingStrategy: .custom(encode),
+                   dateDecodingStrategy: .custom(decode))
+  }
+
+  // MARK: - Data Strategy Tests
+  func testEncodingBase64Data() {
+    let data = Data(bytes: [0xDE, 0xAD, 0xBE, 0xEF])
+
+    // We can't encode a top-level Data, so it'll be wrapped in an array.
+    let expectedJSON = "[\"3q2+7w==\"]".data(using: .utf8)!
+    _testRoundTrip(of: TopLevelWrapper(data), expectedJSON: expectedJSON)
+  }
+
+  func testEncodingCustomData() {
+    // We'll encode a number instead of data.
+    let encode = { (_ data: Data, _ encoder: Encoder) throws -> Void in
+      var container = encoder.singleValueContainer()
+      try container.encode(42)
+    }
+    let decode = { (_: Decoder) throws -> Data in return Data() }
+
+    // We can't encode a top-level Data, so it'll be wrapped in an array.
+    let expectedJSON = "[42]".data(using: .utf8)!
+    _testRoundTrip(of: TopLevelWrapper(Data()),
+                   expectedJSON: expectedJSON,
+                   dataEncodingStrategy: .custom(encode),
+                   dataDecodingStrategy: .custom(decode))
+  }
+
+  func testEncodingCustomDataEmpty() {
+    // Encoding nothing should encode an empty keyed container ({}).
+    let encode = { (_: Data, _: Encoder) throws -> Void in }
+    let decode = { (_: Decoder) throws -> Data in return Data() }
+
+    // We can't encode a top-level Data, so it'll be wrapped in an array.
+    let expectedJSON = "[{}]".data(using: .utf8)!
+    _testRoundTrip(of: TopLevelWrapper(Data()),
+                   expectedJSON: expectedJSON,
+                   dataEncodingStrategy: .custom(encode),
+                   dataDecodingStrategy: .custom(decode))
+  }
+
+  // MARK: - Non-Conforming Floating Point Strategy Tests
+  func testEncodingNonConformingFloats() {
+    _testEncodeFailure(of: TopLevelWrapper(Float.infinity))
+    _testEncodeFailure(of: TopLevelWrapper(-Float.infinity))
+    _testEncodeFailure(of: TopLevelWrapper(Float.nan))
+
+    _testEncodeFailure(of: TopLevelWrapper(Double.infinity))
+    _testEncodeFailure(of: TopLevelWrapper(-Double.infinity))
+    _testEncodeFailure(of: TopLevelWrapper(Double.nan))
+  }
+
+  func testEncodingNonConformingFloatStrings() {
+    let encodingStrategy: JSONEncoder.NonConformingFloatEncodingStrategy = .convertToString(positiveInfinity: "INF", negativeInfinity: "-INF", nan: "NaN")
+    let decodingStrategy: JSONDecoder.NonConformingFloatDecodingStrategy = .convertFromString(positiveInfinity: "INF", negativeInfinity: "-INF", nan: "NaN")
+
+
+    _testRoundTrip(of: TopLevelWrapper(Float.infinity),
+                   expectedJSON: "[\"INF\"]".data(using: .utf8)!,
+                   nonConformingFloatEncodingStrategy: encodingStrategy,
+                   nonConformingFloatDecodingStrategy: decodingStrategy)
+    _testRoundTrip(of: TopLevelWrapper(-Float.infinity),
+                   expectedJSON: "[\"-INF\"]".data(using: .utf8)!,
+                   nonConformingFloatEncodingStrategy: encodingStrategy,
+                   nonConformingFloatDecodingStrategy: decodingStrategy)
+
+    // Since Float.nan != Float.nan, we have to use a placeholder that'll encode NaN but actually round-trip.
+    _testRoundTrip(of: TopLevelWrapper(FloatNaNPlaceholder()),
+                   expectedJSON: "[\"NaN\"]".data(using: .utf8)!,
+                   nonConformingFloatEncodingStrategy: encodingStrategy,
+                   nonConformingFloatDecodingStrategy: decodingStrategy)
+
+    _testRoundTrip(of: TopLevelWrapper(Double.infinity),
+                   expectedJSON: "[\"INF\"]".data(using: .utf8)!,
+                   nonConformingFloatEncodingStrategy: encodingStrategy,
+                   nonConformingFloatDecodingStrategy: decodingStrategy)
+    _testRoundTrip(of: TopLevelWrapper(-Double.infinity),
+                   expectedJSON: "[\"-INF\"]".data(using: .utf8)!,
+                   nonConformingFloatEncodingStrategy: encodingStrategy,
+                   nonConformingFloatDecodingStrategy: decodingStrategy)
+
+    // Since Double.nan != Double.nan, we have to use a placeholder that'll encode NaN but actually round-trip.
+    _testRoundTrip(of: TopLevelWrapper(DoubleNaNPlaceholder()),
+                   expectedJSON: "[\"NaN\"]".data(using: .utf8)!,
+                   nonConformingFloatEncodingStrategy: encodingStrategy,
+                   nonConformingFloatDecodingStrategy: decodingStrategy)
+  }
+
+  // MARK: - Helper Functions
+  private var _jsonEmptyDictionary: Data {
+    return "{}".data(using: .utf8)!
+  }
+
+  private func _testEncodeFailure<T : Encodable>(of value: T) {
+    do {
+      let _ = try JSONEncoder().encode(value)
+      expectUnreachable("Encode of top-level \(T.self) was expected to fail.")
+    } catch {}
+  }
+
+  private func _testRoundTrip<T>(of value: T,
+                                 expectedJSON json: Data? = nil,
+                                 dateEncodingStrategy: JSONEncoder.DateEncodingStrategy = .deferredToDate,
+                                 dateDecodingStrategy: JSONDecoder.DateDecodingStrategy = .deferredToDate,
+                                 dataEncodingStrategy: JSONEncoder.DataEncodingStrategy = .base64Encode,
+                                 dataDecodingStrategy: JSONDecoder.DataDecodingStrategy = .base64Decode,
+                                 nonConformingFloatEncodingStrategy: JSONEncoder.NonConformingFloatEncodingStrategy = .throw,
+                                 nonConformingFloatDecodingStrategy: JSONDecoder.NonConformingFloatDecodingStrategy = .throw) where T : Codable, T : Equatable {
+    var payload: Data! = nil
+    do {
+      let encoder = JSONEncoder()
+      encoder.dateEncodingStrategy = dateEncodingStrategy
+      encoder.dataEncodingStrategy = dataEncodingStrategy
+      encoder.nonConformingFloatEncodingStrategy = nonConformingFloatEncodingStrategy
+      payload = try encoder.encode(value)
+    } catch {
+      expectUnreachable("Failed to encode \(T.self) to JSON.")
+    }
+
+    if let expectedJSON = json {
+        expectEqual(expectedJSON, payload, "Produced JSON not identical to expected JSON.")
+    }
+
+    do {
+      let decoder = JSONDecoder()
+      decoder.dateDecodingStrategy = dateDecodingStrategy
+      decoder.dataDecodingStrategy = dataDecodingStrategy
+      decoder.nonConformingFloatDecodingStrategy = nonConformingFloatDecodingStrategy
+      let decoded = try decoder.decode(T.self, from: payload)
+      expectEqual(decoded, value, "\(T.self) did not round-trip to an equal value.")
+    } catch {
+      expectUnreachable("Failed to decode \(T.self) from JSON.")
+    }
+  }
+}
+
+// MARK: - Test Types
+/* FIXME: Import from %S/Inputs/Coding/SharedTypes.swift somehow. */
+
+// MARK: - Empty Types
+fileprivate struct EmptyStruct : Codable, Equatable {
+  static func ==(_ lhs: EmptyStruct, _ rhs: EmptyStruct) -> Bool {
+    return true
+  }
+}
+
+fileprivate class EmptyClass : Codable, Equatable {
+  static func ==(_ lhs: EmptyClass, _ rhs: EmptyClass) -> Bool {
+    return true
+  }
+}
+
+// MARK: - Single-Value Types
+/// A simple on-off switch type that encodes as a single Bool value.
+fileprivate enum Switch : Codable {
+  case off
+  case on
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    switch try container.decode(Bool.self) {
+    case false: self = .off
+    case true:  self = .on
+    }
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    switch self {
+    case .off: try container.encode(false)
+    case .on:  try container.encode(true)
+    }
+  }
+}
+
+/// A simple timestamp type that encodes as a single Double value.
+fileprivate struct Timestamp : Codable {
+  let value: Double
+
+  init(_ value: Double) {
+    self.value = value
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    value = try container.decode(Double.self)
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(self.value)
+  }
+}
+
+/// A simple referential counter type that encodes as a single Int value.
+fileprivate final class Counter : Codable {
+  var count: Int = 0
+
+  init() {}
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    count = try container.decode(Int.self)
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(self.count)
+  }
+}
+
+// MARK: - Structured Types
+/// A simple address type that encodes as a dictionary of values.
+fileprivate struct Address : Codable, Equatable {
+  let street: String
+  let city: String
+  let state: String
+  let zipCode: Int
+  let country: String
+
+  init(street: String, city: String, state: String, zipCode: Int, country: String) {
+    self.street = street
+    self.city = city
+    self.state = state
+    self.zipCode = zipCode
+    self.country = country
+  }
+
+  static func ==(_ lhs: Address, _ rhs: Address) -> Bool {
+    return lhs.street == rhs.street &&
+           lhs.city == rhs.city &&
+           lhs.state == rhs.state &&
+           lhs.zipCode == rhs.zipCode &&
+           lhs.country == rhs.country
+  }
+
+  static var testValue: Address {
+    return Address(street: "1 Infinite Loop",
+                   city: "Cupertino",
+                   state: "CA",
+                   zipCode: 95014,
+                   country: "United States")
+  }
+}
+
+/// A simple person class that encodes as a dictionary of values.
+fileprivate class Person : Codable, Equatable {
+  let name: String
+  let email: String
+
+  init(name: String, email: String) {
+    self.name = name
+    self.email = email
+  }
+
+  static func ==(_ lhs: Person, _ rhs: Person) -> Bool {
+    return lhs.name == rhs.name && lhs.email == rhs.email
+  }
+
+  static var testValue: Person {
+    return Person(name: "Johnny Appleseed", email: "appleseed@apple.com")
+  }
+}
+
+/// A simple company struct which encodes as a dictionary of nested values.
+fileprivate struct Company : Codable, Equatable {
+  let address: Address
+  var employees: [Person]
+
+  init(address: Address, employees: [Person]) {
+    self.address = address
+    self.employees = employees
+  }
+
+  static func ==(_ lhs: Company, _ rhs: Company) -> Bool {
+    return lhs.address == rhs.address && lhs.employees == rhs.employees
+  }
+
+  static var testValue: Company {
+    return Company(address: Address.testValue, employees: [Person.testValue])
+  }
+}
+
+// MARK: - Helper Types
+
+/// Wraps a type T so that it can be encoded at the top level of a payload.
+fileprivate struct TopLevelWrapper<T> : Codable, Equatable where T : Codable, T : Equatable {
+  let value: T
+
+  init(_ value: T) {
+    self.value = value
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.unkeyedContainer()
+    try container.encode(value)
+  }
+
+  init(from decoder: Decoder) throws {
+    var container = try decoder.unkeyedContainer()
+    value = try container.decode(T.self)
+    assert(container.isAtEnd)
+  }
+
+  static func ==(_ lhs: TopLevelWrapper<T>, _ rhs: TopLevelWrapper<T>) -> Bool {
+    return lhs.value == rhs.value
+  }
+}
+
+fileprivate struct FloatNaNPlaceholder : Codable, Equatable {
+  init() {}
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(Float.nan)
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    let float = try container.decode(Float.self)
+    if !float.isNaN {
+      throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Couldn't decode NaN."))
+    }
+  }
+
+  static func ==(_ lhs: FloatNaNPlaceholder, _ rhs: FloatNaNPlaceholder) -> Bool {
+    return true
+  }
+}
+
+fileprivate struct DoubleNaNPlaceholder : Codable, Equatable {
+  init() {}
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(Double.nan)
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    let double = try container.decode(Double.self)
+    if !double.isNaN {
+      throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Couldn't decode NaN."))
+    }
+  }
+
+  static func ==(_ lhs: DoubleNaNPlaceholder, _ rhs: DoubleNaNPlaceholder) -> Bool {
+    return true
+  }
+}
+
+// MARK: - Run Tests
+
+#if !FOUNDATION_XCTEST
+var JSONEncoderTests = TestSuite("TestJSONEncoder")
+JSONEncoderTests.test("testEncodingTopLevelEmptyStruct")        { TestJSONEncoder().testEncodingTopLevelEmptyStruct()       }
+JSONEncoderTests.test("testEncodingTopLevelEmptyClass")         { TestJSONEncoder().testEncodingTopLevelEmptyClass()        }
+JSONEncoderTests.test("testEncodingTopLevelSingleValueEnum")    { TestJSONEncoder().testEncodingTopLevelSingleValueEnum()   }
+JSONEncoderTests.test("testEncodingTopLevelSingleValueStruct")  { TestJSONEncoder().testEncodingTopLevelSingleValueStruct() }
+JSONEncoderTests.test("testEncodingTopLevelSingleValueClass")   { TestJSONEncoder().testEncodingTopLevelSingleValueClass()  }
+JSONEncoderTests.test("testEncodingTopLevelStructuredStruct")   { TestJSONEncoder().testEncodingTopLevelStructuredStruct()  }
+JSONEncoderTests.test("testEncodingTopLevelStructuredClass")    { TestJSONEncoder().testEncodingTopLevelStructuredClass()   }
+JSONEncoderTests.test("testEncodingTopLevelStructuredClass")    { TestJSONEncoder().testEncodingTopLevelStructuredClass()   }
+JSONEncoderTests.test("testEncodingTopLevelDeepStructuredType") { TestJSONEncoder().testEncodingTopLevelDeepStructuredType()}
+JSONEncoderTests.test("testEncodingDate")                       { TestJSONEncoder().testEncodingDate()                      }
+JSONEncoderTests.test("testEncodingDateSecondsSince1970")       { TestJSONEncoder().testEncodingDateSecondsSince1970()      }
+JSONEncoderTests.test("testEncodingDateMillisecondsSince1970")  { TestJSONEncoder().testEncodingDateMillisecondsSince1970() }
+JSONEncoderTests.test("testEncodingDateISO8601")                { TestJSONEncoder().testEncodingDateISO8601()               }
+JSONEncoderTests.test("testEncodingDateFormatted")              { TestJSONEncoder().testEncodingDateFormatted()             }
+JSONEncoderTests.test("testEncodingDateCustom")                 { TestJSONEncoder().testEncodingDateCustom()                }
+JSONEncoderTests.test("testEncodingDateCustomEmpty")            { TestJSONEncoder().testEncodingDateCustomEmpty()           }
+JSONEncoderTests.test("testEncodingBase64Data")                 { TestJSONEncoder().testEncodingBase64Data()                }
+JSONEncoderTests.test("testEncodingCustomData")                 { TestJSONEncoder().testEncodingCustomData()                }
+JSONEncoderTests.test("testEncodingCustomDataEmpty")            { TestJSONEncoder().testEncodingCustomDataEmpty()           }
+JSONEncoderTests.test("testEncodingNonConformingFloats")        { TestJSONEncoder().testEncodingNonConformingFloats()       }
+JSONEncoderTests.test("testEncodingNonConformingFloatStrings")  { TestJSONEncoder().testEncodingNonConformingFloatStrings() }
+runAllTests()
+#endif

--- a/test/stdlib/TestPlistEncoder.swift
+++ b/test/stdlib/TestPlistEncoder.swift
@@ -1,0 +1,289 @@
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+import Swift
+import Foundation
+
+// MARK: - Test Suite
+
+#if FOUNDATION_XCTEST
+import XCTest
+class TestPropertyListEncoderSuper : XCTestCase { }
+#else
+import StdlibUnittest
+class TestPropertyListEncoderSuper { }
+#endif
+
+class TestPropertyListEncoder : TestPropertyListEncoderSuper {
+  // MARK: - Encoding Top-Level Empty Types
+  func testEncodingTopLevelEmptyStruct() {
+    let empty = EmptyStruct()
+    _testRoundTrip(of: empty, in: .binary, expectedPlist: _plistEmptyDictionaryBinary)
+    _testRoundTrip(of: empty, in: .xml, expectedPlist: _plistEmptyDictionaryXML)
+  }
+
+  func testEncodingTopLevelEmptyClass() {
+    let empty = EmptyClass()
+    _testRoundTrip(of: empty, in: .binary, expectedPlist: _plistEmptyDictionaryBinary)
+    _testRoundTrip(of: empty, in: .xml, expectedPlist: _plistEmptyDictionaryXML)
+  }
+
+  // MARK: - Encoding Top-Level Single-Value Types
+  func testEncodingTopLevelSingleValueEnum() {
+    let s1 = Switch.off
+    _testEncodeFailure(of: s1, in: .binary)
+    _testEncodeFailure(of: s1, in: .xml)
+
+    let s2 = Switch.on
+    _testEncodeFailure(of: s2, in: .binary)
+    _testEncodeFailure(of: s2, in: .xml)
+  }
+
+  func testEncodingTopLevelSingleValueStruct() {
+    let t = Timestamp(3141592653)
+    _testEncodeFailure(of: t, in: .binary)
+    _testEncodeFailure(of: t, in: .xml)
+  }
+
+  func testEncodingTopLevelSingleValueClass() {
+    let c = Counter()
+    _testEncodeFailure(of: c, in: .binary)
+    _testEncodeFailure(of: c, in: .xml)
+  }
+
+  // MARK: - Encoding Top-Level Structured Types
+  func testEncodingTopLevelStructuredStruct() {
+    // Address is a struct type with multiple fields.
+    let address = Address.testValue
+    _testRoundTrip(of: address, in: .binary)
+    _testRoundTrip(of: address, in: .xml)
+  }
+
+  func testEncodingTopLevelStructuredClass() {
+    // Person is a class with multiple fields.
+    let person = Person.testValue
+    _testRoundTrip(of: person, in: .binary)
+    _testRoundTrip(of: person, in: .xml)
+  }
+
+  func testEncodingTopLevelDeepStructuredType() {
+    // Company is a type with fields which are Codable themselves.
+    let company = Company.testValue
+    _testRoundTrip(of: company, in: .binary)
+    _testRoundTrip(of: company, in: .xml)
+  }
+
+  // MARK: - Helper Functions
+  private var _plistEmptyDictionaryBinary: Data {
+    return Data(base64Encoded: "YnBsaXN0MDDQCAAAAAAAAAEBAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAJ")!
+  }
+
+  private var _plistEmptyDictionaryXML: Data {
+    return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n<plist version=\"1.0\">\n<dict/>\n</plist>\n".data(using: .utf8)!
+  }
+
+  private func _testEncodeFailure<T : Encodable>(of value: T, in format: PropertyListSerialization.PropertyListFormat) {
+    do {
+      let encoder = PropertyListEncoder()
+      encoder.outputFormat = format
+      let _ = try encoder.encode(value)
+      expectUnreachable("Encode of top-level \(T.self) was expected to fail.")
+    } catch {}
+  }
+
+  private func _testRoundTrip<T>(of value: T, in format: PropertyListSerialization.PropertyListFormat, expectedPlist plist: Data? = nil) where T : Codable, T : Equatable {
+    var payload: Data! = nil
+    do {
+      let encoder = PropertyListEncoder()
+      encoder.outputFormat = format
+      payload = try encoder.encode(value)
+    } catch {
+      expectUnreachable("Failed to encode \(T.self) to plist.")
+    }
+
+    if let expectedPlist = plist {
+      expectEqual(expectedPlist, payload, "Produced plist not identical to expected plist.")
+    }
+
+    do {
+      var decodedFormat: PropertyListSerialization.PropertyListFormat = .xml
+      let decoded = try PropertyListDecoder().decode(T.self, from: payload, format: &decodedFormat)
+      expectEqual(format, decodedFormat, "Encountered plist format differed from requested format.")
+      expectEqual(decoded, value, "\(T.self) did not round-trip to an equal value.")
+    } catch {
+      expectUnreachable("Failed to decode \(T.self) from plist.")
+    }
+  }
+}
+
+// MARK: - Test Types
+/* FIXME: Import from %S/Inputs/Coding/SharedTypes.swift somehow. */
+
+// MARK: - Empty Types
+fileprivate struct EmptyStruct : Codable, Equatable {
+  static func ==(_ lhs: EmptyStruct, _ rhs: EmptyStruct) -> Bool {
+    return true
+  }
+}
+
+fileprivate class EmptyClass : Codable, Equatable {
+  static func ==(_ lhs: EmptyClass, _ rhs: EmptyClass) -> Bool {
+    return true
+  }
+}
+
+// MARK: - Single-Value Types
+/// A simple on-off switch type that encodes as a single Bool value.
+fileprivate enum Switch : Codable {
+  case off
+  case on
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    switch try container.decode(Bool.self) {
+    case false: self = .off
+    case true:  self = .on
+    }
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    switch self {
+    case .off: try container.encode(false)
+    case .on:  try container.encode(true)
+    }
+  }
+}
+
+/// A simple timestamp type that encodes as a single Double value.
+fileprivate struct Timestamp : Codable {
+  let value: Double
+
+  init(_ value: Double) {
+    self.value = value
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    value = try container.decode(Double.self)
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(self.value)
+  }
+}
+
+/// A simple referential counter type that encodes as a single Int value.
+fileprivate final class Counter : Codable {
+  var count: Int = 0
+
+  init() {}
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    count = try container.decode(Int.self)
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(self.count)
+  }
+}
+
+// MARK: - Structured Types
+/// A simple address type that encodes as a dictionary of values.
+fileprivate struct Address : Codable, Equatable {
+  let street: String
+  let city: String
+  let state: String
+  let zipCode: Int
+  let country: String
+
+  init(street: String, city: String, state: String, zipCode: Int, country: String) {
+    self.street = street
+    self.city = city
+    self.state = state
+    self.zipCode = zipCode
+    self.country = country
+  }
+
+  static func ==(_ lhs: Address, _ rhs: Address) -> Bool {
+    return lhs.street == rhs.street &&
+           lhs.city == rhs.city &&
+           lhs.state == rhs.state &&
+           lhs.zipCode == rhs.zipCode &&
+           lhs.country == rhs.country
+  }
+
+  static var testValue: Address {
+    return Address(street: "1 Infinite Loop",
+                   city: "Cupertino",
+                   state: "CA",
+                   zipCode: 95014,
+                   country: "United States")
+  }
+}
+
+/// A simple person class that encodes as a dictionary of values.
+fileprivate class Person : Codable, Equatable {
+  let name: String
+  let email: String
+
+  init(name: String, email: String) {
+    self.name = name
+    self.email = email
+  }
+
+  static func ==(_ lhs: Person, _ rhs: Person) -> Bool {
+    return lhs.name == rhs.name && lhs.email == rhs.email
+  }
+
+  static var testValue: Person {
+    return Person(name: "Johnny Appleseed", email: "appleseed@apple.com")
+  }
+}
+
+/// A simple company struct which encodes as a dictionary of nested values.
+fileprivate struct Company : Codable, Equatable {
+  let address: Address
+  var employees: [Person]
+
+  init(address: Address, employees: [Person]) {
+    self.address = address
+    self.employees = employees
+  }
+
+  static func ==(_ lhs: Company, _ rhs: Company) -> Bool {
+    return lhs.address == rhs.address && lhs.employees == rhs.employees
+  }
+
+  static var testValue: Company {
+    return Company(address: Address.testValue, employees: [Person.testValue])
+  }
+}
+
+// MARK: - Run Tests
+
+#if !FOUNDATION_XCTEST
+var PropertyListEncoderTests = TestSuite("TestPropertyListEncoder")
+PropertyListEncoderTests.test("testEncodingTopLevelEmptyStruct")        { TestPropertyListEncoder().testEncodingTopLevelEmptyStruct()        }
+PropertyListEncoderTests.test("testEncodingTopLevelEmptyClass")         { TestPropertyListEncoder().testEncodingTopLevelEmptyClass()         }
+PropertyListEncoderTests.test("testEncodingTopLevelSingleValueEnum")    { TestPropertyListEncoder().testEncodingTopLevelSingleValueEnum()    }
+PropertyListEncoderTests.test("testEncodingTopLevelSingleValueStruct")  { TestPropertyListEncoder().testEncodingTopLevelSingleValueStruct()  }
+PropertyListEncoderTests.test("testEncodingTopLevelSingleValueClass")   { TestPropertyListEncoder().testEncodingTopLevelSingleValueClass()   }
+PropertyListEncoderTests.test("testEncodingTopLevelStructuredStruct")   { TestPropertyListEncoder().testEncodingTopLevelStructuredStruct()   }
+PropertyListEncoderTests.test("testEncodingTopLevelStructuredClass")    { TestPropertyListEncoder().testEncodingTopLevelStructuredClass()    }
+PropertyListEncoderTests.test("testEncodingTopLevelStructuredClass")    { TestPropertyListEncoder().testEncodingTopLevelStructuredClass()    }
+PropertyListEncoderTests.test("testEncodingTopLevelDeepStructuredType") { TestPropertyListEncoder().testEncodingTopLevelDeepStructuredType() }
+runAllTests()
+#endif


### PR DESCRIPTION
<!-- What's in this pull request? -->
This implements the `JSONEncoder`, `JSONDecoder`, `PropertyListEncoder`, and `PropertyListDecoder` types proposed by [SE-0167](https://github.com/apple/swift-evolution/blob/master/proposals/0167-swift-encoders.md).

This pulls all Foundation-specific work out of #8124 for separate integration.

**This PR depends on #9004 and should NOT be merged until #9004 is complete and merged.**
rdar://problem/30471969
rdar://problem/30472028