### PR TITLE
Tweak DiagnosticEngine's 'aka' logic to only kick in for typealiases.

### DIFF
--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -16,6 +16,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/AST/DiagnosticEngine.h"
+#include "swift/AST/ASTContext.h"
 #include "swift/AST/ASTPrinter.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/Module.h"
@@ -313,6 +314,42 @@ static void formatSelectionArgument(StringRef ModifierArguments,
   
 }
 
+static bool isInterestingTypealias(Type type) {
+  auto aliasTy = dyn_cast<NameAliasType>(type.getPointer());
+  if (!aliasTy)
+    return false;
+  if (aliasTy->getDecl() == type->getASTContext().getVoidDecl())
+    return false;
+  if (type->is<BuiltinType>())
+    return false;
+  return true;
+}
+
+/// Decide whether to show the desugared type or not.  We filter out some
+/// cases to avoid too much noise.
+static bool shouldShowAKA(Type type, StringRef typeName) {
+  // Canonical types are already desugared.
+  if (type->isCanonical())
+    return false;
+
+  // Don't show generic type parameters.
+  if (type->hasTypeParameter())
+    return false;
+
+  // Only show 'aka' if there's a typealias involved; other kinds of sugar
+  // are easy enough for people to read on their own.
+  if (!type.findIf(isInterestingTypealias))
+    return false;
+
+  // If they are textually the same, don't show them.  This can happen when
+  // they are actually different types, because they exist in different scopes
+  // (e.g. everyone names their type parameters 'T').
+  if (typeName == type->getCanonicalType()->getString())
+    return false;
+
+  return true;
+}
+
 /// \brief Format a single diagnostic argument and write it to the given
 /// stream.
 static void formatDiagnosticArgument(StringRef Modifier, 
@@ -381,33 +418,7 @@ static void formatDiagnosticArgument(StringRef Modifier,
     auto type = Arg.getAsType()->getWithoutParens();
     std::string typeName = type->getString();
 
-    // Decide whether to show the desugared type or not.  We filter out some
-    // cases to avoid too much noise.
-    bool showAKA = !type->isCanonical();
-
-    // If we're complaining about a function type, don't "aka" just because of
-    // differences in the argument or result types.
-    if (showAKA && type->is<AnyFunctionType>() &&
-        isa<AnyFunctionType>(type.getPointer()))
-      showAKA = false;
-
-    // Don't unwrap intentional sugar types like T? or [T].
-    if (showAKA && (isa<SyntaxSugarType>(type.getPointer()) ||
-                    isa<DictionaryType>(type.getPointer()) ||
-                    type->is<BuiltinType>()))
-      showAKA = false;
-
-    // If they are textually the same, don't show them.  This can happen when
-    // they are actually different types, because they exist in different scopes
-    // (e.g. everyone names their type parameters 'T').
-    if (showAKA && typeName == type->getCanonicalType()->getString())
-      showAKA = false;
-
-    // Don't show generic type parameters.
-    if (showAKA && type->hasTypeParameter())
-      showAKA = false;
-
-    if (showAKA) {
+    if (shouldShowAKA(type, typeName)) {
       llvm::SmallString<256> AkaText;
       llvm::raw_svector_ostream OutAka(AkaText);
       OutAka << type->getCanonicalType();

--- a/test/ClangImporter/cf.swift
+++ b/test/ClangImporter/cf.swift
@@ -132,8 +132,8 @@ func nameCollisions() {
   cf = cfAlias // okay
 
   var otherAlias: MyProblematicAlias?
-  otherAlias = cfAlias // expected-error {{cannot assign value of type 'MyProblematicAliasRef?' to type 'MyProblematicAlias?'}}
-  cfAlias = otherAlias // expected-error {{cannot assign value of type 'MyProblematicAlias?' to type 'MyProblematicAliasRef?'}}
+  otherAlias = cfAlias // expected-error {{cannot assign value of type 'MyProblematicAliasRef?' (aka 'Optional<MyProblematicObjectRef>') to type 'MyProblematicAlias?' (aka 'Optional<Float>')}}
+  cfAlias = otherAlias // expected-error {{cannot assign value of type 'MyProblematicAlias?' (aka 'Optional<Float>') to type 'MyProblematicAliasRef?' (aka 'Optional<MyProblematicObjectRef>')}}
 
   func isOptionalFloat(_: inout Optional<Float>) {}
   isOptionalFloat(&otherAlias) // okay

--- a/test/ClangImporter/cfuncs_parse.swift
+++ b/test/ClangImporter/cfuncs_parse.swift
@@ -16,23 +16,23 @@ func test_cfunc2(_ i: Int) {
 
 func test_cfunc3_a() {
   let b = cfunc3( { (a : Double, b : Double) -> Double in a + b } )
-  _ = b(1.5, 2.5) as Double // expected-error{{value of optional type 'double_bin_op_block?' not unwrapped; did you mean to use '!' or '?'?}}
+  _ = b(1.5, 2.5) as Double // expected-error{{value of optional type 'double_bin_op_block?' (aka 'Optional<(Double, Double) -> Double>') not unwrapped; did you mean to use '!' or '?'?}}
   _ = b!(1.5, 2.5) as Double
-  _ = b as Double// expected-error{{cannot convert value of type 'double_bin_op_block?' to type 'Double' in coercion}}
+  _ = b as Double// expected-error{{cannot convert value of type 'double_bin_op_block?' (aka 'Optional<(Double, Double) -> Double>') to type 'Double' in coercion}}
 }
 
 func test_cfunc3_b() {
   let b = cfunc3( { a, b in a + b } )
-  _ = b(1.5, 2.5) as Double // expected-error{{value of optional type 'double_bin_op_block?' not unwrapped; did you mean to use '!' or '?'?}}
+  _ = b(1.5, 2.5) as Double // expected-error{{value of optional type 'double_bin_op_block?' (aka 'Optional<(Double, Double) -> Double>') not unwrapped; did you mean to use '!' or '?'?}}
   _ = b!(1.5, 2.5) as Double
-  _ = b as Double// expected-error{{cannot convert value of type 'double_bin_op_block?' to type 'Double' in coercion}}
+  _ = b as Double// expected-error{{cannot convert value of type 'double_bin_op_block?' (aka 'Optional<(Double, Double) -> Double>') to type 'Double' in coercion}}
 }
 
 func test_cfunc3_c() {
   let b = cfunc3({ $0 + $1 })
-  _ = b(1.5, 2.5) as Double // expected-error{{value of optional type 'double_bin_op_block?' not unwrapped; did you mean to use '!' or '?'?}}
+  _ = b(1.5, 2.5) as Double // expected-error{{value of optional type 'double_bin_op_block?' (aka 'Optional<(Double, Double) -> Double>') not unwrapped; did you mean to use '!' or '?'?}}
   _ = b!(1.5, 2.5) as Double
-  _ = b as Double// expected-error{{cannot convert value of type 'double_bin_op_block?' to type 'Double' in coercion}}
+  _ = b as Double// expected-error{{cannot convert value of type 'double_bin_op_block?' (aka 'Optional<(Double, Double) -> Double>') to type 'Double' in coercion}}
 }
 
 func test_cfunc3_d() {

--- a/test/ClangImporter/ctypes_parse.swift
+++ b/test/ClangImporter/ctypes_parse.swift
@@ -204,7 +204,7 @@ func testFunctionPointers() {
     = getFunctionPointer2()
 
   useFunctionPointer2(anotherFP)
-  anotherFP = fp // expected-error {{cannot assign value of type 'fptr?' to type '@convention(c) (CInt, CLong, UnsafeMutableRawPointer?) -> Void'}}
+  anotherFP = fp // expected-error {{cannot assign value of type 'fptr?' (aka 'Optional<@convention(c) (Int32) -> Int32>') to type '@convention(c) (CInt, CLong, UnsafeMutableRawPointer?) -> Void' (aka '@convention(c) (Int32, Int, Optional<UnsafeMutableRawPointer>) -> ()')}}
 }
 
 func testStructDefaultInit() {

--- a/test/Compatibility/accessibility_compound.swift
+++ b/test/Compatibility/accessibility_compound.swift
@@ -9,7 +9,7 @@ public struct PublicStruct {
 
 private typealias PrivateAlias = PublicStruct // expected-note * {{type declared here}}
 
-public let a0 = nil as PrivateAlias.Inner? // expected-warning {{constant should not be declared public because its type 'PrivateAlias.Inner?' uses a private type}}
+public let a0 = nil as PrivateAlias.Inner? // expected-warning {{constant should not be declared public because its type 'PrivateAlias.Inner?' (aka 'Optional<PublicStruct.Inner>') uses a private type}}
 public let a: PrivateAlias.Inner? // expected-warning {{constant should not be declared public because its type uses a private type}}
 public let b: PrivateAlias.Internal? // expected-error {{constant cannot be declared public because its type uses an internal type}}
 public let c: Pair<PrivateAlias.Inner, PublicStruct.Internal>? // expected-error {{constant cannot be declared public because its type uses an internal type}}

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -97,7 +97,7 @@ func f8<T:P2>(_ n: T, _ f: @escaping (T) -> T) {}
 f8(3, f4) // expected-error {{in argument type '(Int) -> Int', 'Int' does not conform to expected type 'P2'}}
 typealias Tup = (Int, Double)
 func f9(_ x: Tup) -> Tup { return x }
-f8((1,2.0), f9) // expected-error {{in argument type '(Tup) -> Tup', 'Tup' (aka '(Int, Double)') does not conform to expected type 'P2'}}
+f8((1,2.0), f9) // expected-error {{in argument type '(Tup) -> Tup' (aka '(Int, Double) -> (Int, Double)'), 'Tup' (aka '(Int, Double)') does not conform to expected type 'P2'}}
 
 // <rdar://problem/19658691> QoI: Incorrect diagnostic for calling nonexistent members on literals
 1.doesntExist(0)  // expected-error {{value of type 'Int' has no member 'doesntExist'}}

--- a/test/Constraints/dictionary_literal.swift
+++ b/test/Constraints/dictionary_literal.swift
@@ -74,7 +74,7 @@ func testDefaultExistentials() {
   let _: [String : Any] = ["a" : 1, "b" : 2.5, "c" : "hello"]
   
   let _ = ["a" : 1, "b" : nil, "c" : "hello"]
-  // expected-error@-1{{heterogeneous collection literal could only be inferred to 'Dictionary<String, Any?>' (aka 'Dictionary<String, Optional<Any>>'); add explicit type annotation if this is intentional}}{{46-46= as Dictionary<String, Any?>}}
+  // expected-error@-1{{heterogeneous collection literal could only be inferred to 'Dictionary<String, Any?>'; add explicit type annotation if this is intentional}}{{46-46= as Dictionary<String, Any?>}}
   
   let _: [String : Any?] = ["a" : 1, "b" : nil, "c" : "hello"]
 

--- a/test/Parse/pointer_conversion.swift.gyb
+++ b/test/Parse/pointer_conversion.swift.gyb
@@ -93,7 +93,7 @@ func mutableVoidPointerArguments(_ p: UnsafeMutablePointer<Int>,
   // We don't allow these conversions outside of function arguments.
   var x: UnsafeMutableRawPointer = &i // expected-error{{cannot convert value of type 'inout Int' to specified type 'UnsafeMutableRawPointer'}}
   x = p // expected-error{{cannot assign value of type 'UnsafeMutablePointer<Int>' to type 'UnsafeMutableRawPointer'}}
-  x = &ii // expected-error{{cannot assign value of type 'inout [Int]' (aka 'inout Array<Int>') to type 'UnsafeMutableRawPointer'}}
+  x = &ii // expected-error{{cannot assign value of type 'inout [Int]' to type 'UnsafeMutableRawPointer'}}
   _ = x
 }
 
@@ -128,7 +128,7 @@ func mutableRawPointerArguments(_ p: UnsafeMutablePointer<Int>,
   // We don't allow these conversions outside of function arguments.
   var x: UnsafeMutableRawPointer = &i // expected-error{{cannot convert value of type 'inout Int' to specified type 'UnsafeMutableRawPointer'}}
   x = p // expected-error{{cannot assign value of type 'UnsafeMutablePointer<Int>' to type 'UnsafeMutableRawPointer'}}
-  x = &ii // expected-error{{cannot assign value of type 'inout [Int]' (aka 'inout Array<Int>') to type 'UnsafeMutableRawPointer'}}
+  x = &ii // expected-error{{cannot assign value of type 'inout [Int]' to type 'UnsafeMutableRawPointer'}}
   _ = x
 }
 

--- a/test/Sema/accessibility_compound.swift
+++ b/test/Sema/accessibility_compound.swift
@@ -9,7 +9,7 @@ public struct PublicStruct {
 
 private typealias PrivateAlias = PublicStruct // expected-note * {{type declared here}}
 
-public let a0 = nil as PrivateAlias.Inner? // expected-error {{constant cannot be declared public because its type 'PrivateAlias.Inner?' uses a private type}}
+public let a0 = nil as PrivateAlias.Inner? // expected-error {{constant cannot be declared public because its type 'PrivateAlias.Inner?' (aka 'Optional<PublicStruct.Inner>') uses a private type}}
 public let a: PrivateAlias.Inner? // expected-error {{constant cannot be declared public because its type uses a private type}}
 public let b: PrivateAlias.Internal? // expected-error {{constant cannot be declared public because its type uses a private type}}
 public let c: Pair<PrivateAlias.Inner, PublicStruct.Internal>? // expected-error {{constant cannot be declared public because its type uses a private type}}

--- a/test/Serialization/Recovery/typedefs.swift
+++ b/test/Serialization/Recovery/typedefs.swift
@@ -28,7 +28,7 @@ let _: Bool? = useAssoc(ImportedType.self) // expected-error {{cannot convert va
 let _: Int32? = useAssoc(ImportedType.self)
 
 let _: String = useAssoc(AnotherType.self) // expected-error {{cannot convert call result type '_.Assoc?' to expected type 'String'}}
-let _: Bool? = useAssoc(AnotherType.self) // expected-error {{cannot convert value of type 'AnotherType.Assoc?' to specified type 'Bool?'}}
+let _: Bool? = useAssoc(AnotherType.self) // expected-error {{cannot convert value of type 'AnotherType.Assoc?' (aka 'Optional<Int32>') to specified type 'Bool?'}}
 let _: Int32? = useAssoc(AnotherType.self)
 #endif // VERIFY
 

--- a/test/attr/attr_escaping.swift
+++ b/test/attr/attr_escaping.swift
@@ -155,6 +155,6 @@ class FooClass {
   }
   var computedEscaping : (@escaping ()->Int)->Void {
     get { return stored! }
-    set(newValue) { stored = newValue } // expected-error{{cannot assign value of type '(@escaping () -> Int) -> Void' to type 'Optional<(() -> Int) -> Void>' (aka 'Optional<(() -> Int) -> ()>')}}
+    set(newValue) { stored = newValue } // expected-error{{cannot assign value of type '(@escaping () -> Int) -> Void' to type 'Optional<(() -> Int) -> Void>'}}
   }
 }

--- a/validation-test/SIL/crashers/006-swift-syntaxsugartype-getimplementationtype.sil
+++ b/validation-test/SIL/crashers/006-swift-syntaxsugartype-getimplementationtype.sil
@@ -1,4 +1,0 @@
-// RUN: not --crash %target-sil-opt %s
-// REQUIRES: asserts
-class C
-struct e{weak var x:C

--- a/validation-test/SIL/crashers/041-swift-typebase-getdesugaredtype.sil
+++ b/validation-test/SIL/crashers/041-swift-typebase-getdesugaredtype.sil
@@ -1,3 +1,0 @@
-// RUN: not --crash %target-sil-opt %s
-// REQUIRES: asserts
-class C struct A{weak var e:C

--- a/validation-test/SIL/crashers_fixed/006-swift-syntaxsugartype-getimplementationtype.sil
+++ b/validation-test/SIL/crashers_fixed/006-swift-syntaxsugartype-getimplementationtype.sil
@@ -1,0 +1,3 @@
+// RUN: not %target-sil-opt %s
+class C
+struct e{weak var x:C

--- a/validation-test/SIL/crashers_fixed/041-swift-typebase-getdesugaredtype.sil
+++ b/validation-test/SIL/crashers_fixed/041-swift-typebase-getdesugaredtype.sil
@@ -1,0 +1,2 @@
+// RUN: not %target-sil-opt %s
+class C struct A{weak var e:C


### PR DESCRIPTION
Previously we had more ad hoc logic that tried to decide if it was worth desugaring a type based on its structure. Now we instead look for a typealias that might actually benefit from desugaring, and if we don't find one we won't show the 'aka' note.

(This will be used for #8987.)

Some of the output involving function types gets a lot wordier from this, but I'm not convinced that's the wrong thing to do. The mismatch might be within a type alias!
rdar://problem/31511958