### PR TITLE
Revert "[test] Temporarily disable test stdlib/Mirror.swift on armv7s."

### DIFF
--- a/test/stdlib/Mirror.swift
+++ b/test/stdlib/Mirror.swift
@@ -22,10 +22,6 @@
 // RUN: %target-run %t/Mirror
 // REQUIRES: executable_test
 
-// FIXME: rdar://30332105 LLVM miscompile of vector instructions
-//   in optimized build of Mirrors.LabeledStructure
-// UNSUPPORTED: CPU=armv7s
-
 import StdlibUnittest
 
 


### PR DESCRIPTION
This reverts commit 9681fbc59d4545e4d5281c110212559928baaa9b.

This was a workaround for an LLVM bug that is now fixed.
