### PR TITLE
[4.0] [Constraint solver] Look through lvalue types when establish nil-convertibility

### DIFF
--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1182,7 +1182,8 @@ static PotentialBindings getPotentialBindings(ConstraintSystem &cs,
         // produce an optional of that type as a potential binding. We
         // overwrite the binding in place because the non-optional type
         // will fail to type-check against the nil-literal conformance.
-        auto nominalBindingDecl = binding.BindingType->getAnyNominal();
+        auto nominalBindingDecl =
+          binding.BindingType->getRValueType()->getAnyNominal();
         bool conformsToExprByNilLiteral = false;
         if (nominalBindingDecl) {
           SmallVector<ProtocolConformance *, 2> conformances;

--- a/test/Constraints/optional.swift
+++ b/test/Constraints/optional.swift
@@ -245,3 +245,17 @@ class C2 {
         return p1 ?? p2?.prop
     }
 }
+
+
+// rdar://problem/31779785
+class X { }
+
+class Bar {
+  let xOpt: X?
+  let b: Bool
+
+  init() {
+    let result = b ? nil : xOpt
+    let _: Int = result // expected-error{{cannot convert value of type 'X?' to specified type 'Int'}}
+  }
+}


### PR DESCRIPTION
When determining whether our inference of an optional type should add
a layer of optionality, look through lvalue types.
Fixes rdar://problem/31779785.
