### PR TITLE
[benchmark] Support multiple regular expression filters in Benchmark_Driver

### DIFF
--- a/benchmark/scripts/Benchmark_Driver
+++ b/benchmark/scripts/Benchmark_Driver
@@ -122,9 +122,9 @@ def get_tests(driver_path, args):
     """Return a list of available performance tests"""
     tests = subprocess.check_output([driver_path, '--list']).split()[2:]
     if args.filters:
-        return sorted(list(set([ name
-            for prefix in args.filters
-            for name in tests if name.startswith(prefix) ])))
+        regexes = [re.compile(pattern) for pattern in args.filters]
+        return sorted(list(set([name for pattern in regexes
+                                for name in tests if pattern.match(name)])))
     if not args.benchmarks:
         return tests
     return sorted(list(set(tests).intersection(set(args.benchmarks))))
@@ -352,7 +352,7 @@ def positive_int(value):
 
 def main():
     parser = argparse.ArgumentParser(
-        epilog='Example: ./Benchmark_Driver run -i 5 -f Prefix -f Suffix -f Drop'
+        epilog='Example: ./Benchmark_Driver run -i 5 -f Prefix -f .*Suffix.*'
     )
     subparsers = parser.add_subparsers(
         title='Swift benchmark driver commands',
@@ -366,8 +366,8 @@ def main():
         help='benchmark to run (default: all)', nargs='*', metavar="BENCHMARK")
     benchmarks_group.add_argument(
         '-f', '--filter', dest='filters', action='append',
-        help='run all tests whose name starts with PREFIX, '+
-        'multiple filters are supported', metavar="PREFIX")
+        help='run all tests whose name match regular expression PATTERN, ' +
+        'multiple filters are supported', metavar="PATTERN")
     parent_parser.add_argument(
         '-t', '--tests',
         help='directory containing Benchmark_O{,none,unchecked} ' +

--- a/benchmark/scripts/Benchmark_Driver
+++ b/benchmark/scripts/Benchmark_Driver
@@ -121,8 +121,10 @@ def instrument_test(driver_path, test, num_samples):
 def get_tests(driver_path, args):
     """Return a list of available performance tests"""
     tests = subprocess.check_output([driver_path, '--list']).split()[2:]
-    if args.filter:
-        return filter(lambda name: name.startswith(args.filter), tests)
+    if args.filters:
+        return sorted(list(set([ name
+            for prefix in args.filters
+            for name in tests if name.startswith(prefix) ])))
     if not args.benchmarks:
         return tests
     return sorted(list(set(tests).intersection(set(args.benchmarks))))
@@ -363,7 +365,7 @@ def main():
         default=[],
         help='benchmark to run (default: all)', nargs='*', metavar="BENCHMARK")
     benchmarks_group.add_argument(
-        '-f', '--filter',
+        '-f', '--filter', dest='filters', nargs='*',
         help='run all tests whose name starts with PREFIX', metavar="PREFIX")
     parent_parser.add_argument(
         '-t', '--tests',

--- a/benchmark/scripts/Benchmark_Driver
+++ b/benchmark/scripts/Benchmark_Driver
@@ -352,7 +352,7 @@ def positive_int(value):
 
 def main():
     parser = argparse.ArgumentParser(
-        epilog='Example: ./Benchmark_Driver run -i 5 -f Array'
+        epilog='Example: ./Benchmark_Driver run -i 5 -f Prefix -f Suffix -f Drop'
     )
     subparsers = parser.add_subparsers(
         title='Swift benchmark driver commands',
@@ -365,8 +365,9 @@ def main():
         default=[],
         help='benchmark to run (default: all)', nargs='*', metavar="BENCHMARK")
     benchmarks_group.add_argument(
-        '-f', '--filter', dest='filters', nargs='*',
-        help='run all tests whose name starts with PREFIX', metavar="PREFIX")
+        '-f', '--filter', dest='filters', action='append',
+        help='run all tests whose name starts with PREFIX, '+
+        'multiple filters are supported', metavar="PREFIX")
     parent_parser.add_argument(
         '-t', '--tests',
         help='directory containing Benchmark_O{,none,unchecked} ' +


### PR DESCRIPTION
This is a minor follow-up to #8975 Fix SR-4598 Add option to run subset of benchmarks matching a prefix.

It adds option to specify multiple prefixes and run all tests matching them. For example:
```
 ./Benchmark_Driver run -i 5 -f Prefix Suffix Drop 
```
runs all the benchmarks for the `Sequence` interface.