### PR TITLE
[benchmark] Lower the max memory size of ObejctiveC bridging tests

### DIFF
--- a/benchmark/single-source/ObjectiveCBridgingStubs.swift
+++ b/benchmark/single-source/ObjectiveCBridgingStubs.swift
@@ -31,8 +31,8 @@ func testObjectiveCBridgeStubFromNSString() {
 @inline(never)
 public func run_ObjectiveCBridgeStubFromNSString(_ N: Int) {
 #if _runtime(_ObjC)
-  autoreleasepool {
-    for _ in 0 ..< N {
+  for _ in 0 ..< N {
+    autoreleasepool {
       testObjectiveCBridgeStubFromNSString()
     }
   }
@@ -54,8 +54,8 @@ func testObjectiveCBridgeStubToNSString() {
 @inline(never)
 public func run_ObjectiveCBridgeStubToNSString(_ N: Int) {
 #if _runtime(_ObjC)
-  autoreleasepool {
-    for _ in 0 ..< N {
+  for _ in 0 ..< N {
+    autoreleasepool {
       testObjectiveCBridgeStubToNSString()
     }
   }
@@ -78,8 +78,8 @@ func testObjectiveCBridgeStubFromArrayOfNSString() {
 @inline(never)
 public func run_ObjectiveCBridgeStubFromArrayOfNSString(_ N: Int) {
 #if _runtime(_ObjC)
-  autoreleasepool {
-    for _ in 0 ..< N {
+  for _ in 0 ..< N {
+    autoreleasepool {
       testObjectiveCBridgeStubFromArrayOfNSString()
     }
   }
@@ -100,8 +100,8 @@ func testObjectiveCBridgeStubToArrayOfNSString() {
 @inline(never)
 public func run_ObjectiveCBridgeStubToArrayOfNSString(_ N: Int) {
 #if _runtime(_ObjC)
-  autoreleasepool {
-    for _ in 0 ..< N {
+  for _ in 0 ..< N {
+    autoreleasepool {
       testObjectiveCBridgeStubToArrayOfNSString()
     }
   }
@@ -124,8 +124,8 @@ func testObjectiveCBridgeStubFromNSDate() {
 @inline(never)
 public func run_ObjectiveCBridgeStubFromNSDate(N: Int) {
 #if _runtime(_ObjC)
-  autoreleasepool {
-    for _ in 0 ..< N {
+  for _ in 0 ..< N {
+    autoreleasepool {
       testObjectiveCBridgeStubFromNSDate()
     }
   }
@@ -146,8 +146,8 @@ public func testObjectiveCBridgeStubToNSDate() {
 @inline(never)
 public func run_ObjectiveCBridgeStubToNSDate(N: Int) {
 #if _runtime(_ObjC)
-  autoreleasepool {
-    for _ in 0 ..< N {
+  for _ in 0 ..< N {
+    autoreleasepool {
       testObjectiveCBridgeStubToNSDate()
     }
   }
@@ -168,8 +168,8 @@ func testObjectiveCBridgeStubDateAccess() {
 @inline(never)
 public func run_ObjectiveCBridgeStubDateAccess(N: Int) {
 #if _runtime(_ObjC)
-  autoreleasepool {
-    for _ in 0 ..< N {
+  for _ in 0 ..< N {
+    autoreleasepool {
       testObjectiveCBridgeStubDateAccess()
     }
   }
@@ -189,8 +189,8 @@ func testObjectiveCBridgeStubDateMutation() {
 @inline(never)
 public func run_ObjectiveCBridgeStubDateMutation(N: Int) {
 #if _runtime(_ObjC)
-  autoreleasepool {
-    for _ in 0 ..< N {
+  for _ in 0 ..< N {
+    autoreleasepool {
       testObjectiveCBridgeStubDateMutation()
     }
   }
@@ -213,8 +213,8 @@ func testObjectiveCBridgeStubURLAppendPath() {
 @inline(never)
 public func run_ObjectiveCBridgeStubURLAppendPath(N: Int) {
 #if _runtime(_ObjC)
-  autoreleasepool {
-    for _ in 0 ..< N {
+  for _ in 0 ..< N {
+    autoreleasepool {
       testObjectiveCBridgeStubURLAppendPath()
     }
   }
@@ -238,8 +238,8 @@ func testObjectiveCBridgeStubDataAppend() {
 @inline(never)
 public func run_ObjectiveCBridgeStubDataAppend(N: Int) {
 #if _runtime(_ObjC)
-  autoreleasepool {
-    for _ in 0 ..< N {
+  for _ in 0 ..< N {
+    autoreleasepool {
       testObjectiveCBridgeStubDataAppend()
     }
   }

--- a/benchmark/single-source/ObjectiveCNoBridgingStubs.swift
+++ b/benchmark/single-source/ObjectiveCNoBridgingStubs.swift
@@ -36,8 +36,8 @@ func testObjectiveCBridgeStubFromNSStringRef() {
 @inline(never)
 public func run_ObjectiveCBridgeStubFromNSStringRef(N: Int) {
 #if _runtime(_ObjC)
-  autoreleasepool {
-    for _ in 0 ..< N {
+  for _ in 0 ..< N {
+    autoreleasepool {
       testObjectiveCBridgeStubFromNSStringRef()
     }
   }
@@ -58,8 +58,8 @@ func testObjectiveCBridgeStubToNSStringRef() {
 @inline(never)
 public func run_ObjectiveCBridgeStubToNSStringRef(N: Int) {
 #if _runtime(_ObjC)
-  autoreleasepool {
-    for _ in 0 ..< N {
+  for _ in 0 ..< N {
+    autoreleasepool {
       testObjectiveCBridgeStubToNSStringRef()
     }
   }
@@ -102,8 +102,8 @@ public func testObjectiveCBridgeStubToNSDateRef() {
 @inline(never)
 public func run_ObjectiveCBridgeStubToNSDateRef(N: Int) {
 #if _runtime(_ObjC)
-  autoreleasepool {
-    for _ in 0 ..< N {
+  for _ in 0 ..< N {
+    autoreleasepool {
       testObjectiveCBridgeStubToNSDateRef()
     }
   }
@@ -125,8 +125,8 @@ func testObjectiveCBridgeStubNSDateRefAccess() {
 @inline(never)
 public func run_ObjectiveCBridgeStubNSDateRefAccess(N: Int) {
 #if _runtime(_ObjC)
-  autoreleasepool {
-    for _ in 0 ..< N {
+  for _ in 0 ..< N {
+    autoreleasepool {
       testObjectiveCBridgeStubNSDateRefAccess()
     }
   }
@@ -146,8 +146,8 @@ func testObjectiveCBridgeStubNSDateMutationRef() {
 @inline(never)
 public func run_ObjectiveCBridgeStubNSDateMutationRef(N: Int) {
 #if _runtime(_ObjC)
-  autoreleasepool {
-    for _ in 0 ..< N {
+  for _ in 0 ..< N {
+    autoreleasepool {
       testObjectiveCBridgeStubNSDateMutationRef()
     }
   }
@@ -170,10 +170,10 @@ func testObjectiveCBridgeStubURLAppendPathRef() {
 @inline(never)
 public func run_ObjectiveCBridgeStubURLAppendPathRef(N: Int) {
 #if _runtime(_ObjC)
-  autoreleasepool {
-    for _ in 0 ..< N {
-      testObjectiveCBridgeStubURLAppendPathRef()
-    }
+  for _ in 0 ..< N {
+   autoreleasepool {
+     testObjectiveCBridgeStubURLAppendPathRef()
+   }
   }
 #endif
 }
@@ -195,8 +195,8 @@ func testObjectiveCBridgeStubNSDataAppend() {
 @inline(never)
 public func run_ObjectiveCBridgeStubNSDataAppend(N: Int) {
 #if _runtime(_ObjC)
-  autoreleasepool {
-    for _ in 0 ..< N {
+  for _ in 0 ..< N {
+    autoreleasepool {
       testObjectiveCBridgeStubNSDataAppend()
     }
   }


### PR DESCRIPTION
by moving the autoreleasepool down such that we have less allocations in the pool until it is
empty

rdar://31788785
SR-4666
