### PR TITLE
[Migrator] Remove unused MigratorOptions in FixitApplyDiagnosticConsumer

### DIFF
--- a/include/swift/Migrator/FixitApplyDiagnosticConsumer.h
+++ b/include/swift/Migrator/FixitApplyDiagnosticConsumer.h
@@ -34,10 +34,6 @@ class FixitApplyDiagnosticConsumer final
   : public DiagnosticConsumer, public FixitFilter {
   clang::RewriteBuffer RewriteBuf;
 
-  /// The Migrator options collected by the Swift CompilerInvocation,
-  /// used to drive decisions about which fix-its to apply.
-  const MigratorOptions &MigratorOpts;
-
   /// The entire text of the input file.
   const StringRef Text;
 
@@ -50,8 +46,7 @@ class FixitApplyDiagnosticConsumer final
   unsigned NumFixitsApplied;
 
 public:
-  FixitApplyDiagnosticConsumer(const MigratorOptions &MigratorOpts,
-                               const StringRef Text,
+  FixitApplyDiagnosticConsumer(const StringRef Text,
                                const StringRef BufferName);
 
   /// Print the resulting text, applying the caught fix-its to the given

--- a/lib/Migrator/FixitApplyDiagnosticConsumer.cpp
+++ b/lib/Migrator/FixitApplyDiagnosticConsumer.cpp
@@ -21,11 +21,9 @@ using namespace swift;
 using namespace swift::migrator;
 
 FixitApplyDiagnosticConsumer::
-FixitApplyDiagnosticConsumer(const MigratorOptions &MigratorOpts,
-                             const StringRef Text,
+FixitApplyDiagnosticConsumer(const StringRef Text,
                              const StringRef BufferName)
-  : MigratorOpts(MigratorOpts),
-    Text(Text), BufferName(BufferName), NumFixitsApplied(0) {
+  : Text(Text), BufferName(BufferName), NumFixitsApplied(0) {
   RewriteBuf.Initialize(Text);
 }
 

--- a/lib/Migrator/Migrator.cpp
+++ b/lib/Migrator/Migrator.cpp
@@ -104,7 +104,6 @@ Migrator::performAFixItMigration() {
   }
 
   FixitApplyDiagnosticConsumer FixitApplyConsumer {
-    getMigratorOptions(),
     InputState->getInputText(),
     getInputFilename(),
   };


### PR DESCRIPTION
This isn't needed right now.