### PR TITLE
Small SILSuccessor Cleanups

### DIFF
--- a/include/swift/SIL/SILBasicBlock.h
+++ b/include/swift/SIL/SILBasicBlock.h
@@ -286,7 +286,7 @@ public:
     return makeTransformRange(getSuccessors(), F);
   }
 
-  using pred_iterator = SILSuccessorIterator;
+  using pred_iterator = SILSuccessor::pred_iterator;
 
   bool pred_empty() const { return PredList == nullptr; }
   pred_iterator pred_begin() const { return pred_iterator(PredList); }

--- a/include/swift/SIL/SILSuccessor.h
+++ b/include/swift/SIL/SILSuccessor.h
@@ -34,8 +34,6 @@ class TermInst;
 /// predecessors. This is done by using an ilist that is embedded into
 /// SILSuccessors.
 class SILSuccessor {
-  friend class SILSuccessorIterator;
-
   /// The terminator instruction that contains this SILSuccessor.
   TermInst *ContainingInst = nullptr;
   
@@ -78,41 +76,40 @@ public:
   // Do not copy or move these.
   SILSuccessor(const SILSuccessor &) = delete;
   SILSuccessor(SILSuccessor &&) = delete;
+
+  /// This is an iterator for walking the predecessor list of a SILBasicBlock.
+  class pred_iterator {
+    SILSuccessor *Cur;
+
+  public:
+    using difference_type = std::ptrdiff_t;
+    using value_type = SILBasicBlock *;
+    using pointer = SILBasicBlock **;
+    using reference = SILBasicBlock *&;
+    using iterator_category = std::forward_iterator_tag;
+
+    pred_iterator(SILSuccessor *Cur = 0) : Cur(Cur) {}
+
+    bool operator==(pred_iterator I2) const { return Cur == I2.Cur; }
+    bool operator!=(pred_iterator I2) const { return Cur != I2.Cur; }
+
+    pred_iterator &operator++() {
+      assert(Cur && "Trying to advance past end");
+      Cur = Cur->Next;
+      return *this;
+    }
+
+    pred_iterator operator++(int) {
+      pred_iterator copy = *this;
+      ++*this;
+      return copy;
+    }
+
+    SILSuccessor *getSuccessorRef() const { return Cur; }
+    SILBasicBlock *operator*();
+    const SILBasicBlock *operator*() const;
+  };
 };
-  
-/// SILSuccessorIterator - This is an iterator for walking the successor list of
-/// a SILBasicBlock.
-class SILSuccessorIterator {
-  SILSuccessor *Cur;
-public:
-  using difference_type = std::ptrdiff_t;
-  using value_type = SILBasicBlock *;
-  using pointer = SILBasicBlock **;
-  using reference = SILBasicBlock *&;
-  using iterator_category = std::forward_iterator_tag;
-  
-  SILSuccessorIterator(SILSuccessor *Cur = 0) : Cur(Cur) {}
-  
-  bool operator==(SILSuccessorIterator I2) const { return Cur == I2.Cur; }
-  bool operator!=(SILSuccessorIterator I2) const { return Cur != I2.Cur; }
-
-  SILSuccessorIterator &operator++() {
-    assert(Cur && "Trying to advance past end");
-    Cur = Cur->Next;
-    return *this;
-  }
-
-  SILSuccessorIterator operator++(int) {
-    SILSuccessorIterator copy = *this;
-    ++*this;
-    return copy;
-  }
-
-  SILSuccessor *getSuccessorRef() const { return Cur; }
-  SILBasicBlock *operator*();
-  const SILBasicBlock *operator*() const;
-};
-  
 
 } // end swift namespace
 

--- a/include/swift/SIL/SILSuccessor.h
+++ b/include/swift/SIL/SILSuccessor.h
@@ -18,26 +18,42 @@
 #include <iterator>
 
 namespace swift {
+
 class SILBasicBlock;
 class TermInst;
 
-/// SILSuccessor - This represents a reference to a SILBasicBlock in a
-/// terminator instruction, forming a list of TermInst references to
-/// BasicBlocks.  This forms the predecessor list, ensuring that it is always
-/// kept up to date.
+/// \brief An edge in the control flow graph.
+///
+/// A SILSuccessor is stored in the terminator instruction of the tail block of
+/// the CFG edge. Internally it has a back reference to the terminator that
+/// contains it (ContainingInst). It also contains the SuccessorBlock that is
+/// the "head" of the CFG edge. This makes it very simple to iterate over the
+/// successors of a specific block.
+///
+/// SILSuccessor also enables given a "head" edge the ability to iterate over
+/// predecessors. This is done by using an ilist that is embedded into
+/// SILSuccessors.
 class SILSuccessor {
   friend class SILSuccessorIterator;
-  /// ContainingInst - This is the Terminator instruction that contains this
-  /// successor.
+
+  /// The terminator instruction that contains this SILSuccessor.
   TermInst *ContainingInst = nullptr;
   
-  /// SuccessorBlock - If non-null, this is the BasicBlock that the terminator
-  /// branches to.
+  /// If non-null, this is the BasicBlock that the terminator branches to.
   SILBasicBlock *SuccessorBlock = nullptr;
-  
-  /// This is the prev and next terminator reference to SuccessorBlock, or
-  /// null if SuccessorBlock is null.
-  SILSuccessor **Prev = nullptr, *Next = nullptr;
+
+  /// A pointer to the SILSuccessor that represents the previous SILSuccessor in the
+  /// predecessor list for SuccessorBlock.
+  ///
+  /// Must be nullptr if SuccessorBlock is.
+  SILSuccessor **Prev = nullptr;
+
+  /// A pointer to the SILSuccessor that represents the next SILSuccessor in the
+  /// predecessor list for SuccessorBlock.
+  ///
+  /// Must be nullptr if SuccessorBlock is.
+  SILSuccessor *Next = nullptr;
+
 public:
   SILSuccessor() {}
 

--- a/lib/SIL/SILSuccessor.cpp
+++ b/lib/SIL/SILSuccessor.cpp
@@ -38,14 +38,14 @@ void SILSuccessor::operator=(SILBasicBlock *BB) {
   SuccessorBlock = BB;
 }
 
-// Dereferencing the SuccIterator returns the predecessor's SILBasicBlock.
-SILBasicBlock *SILSuccessorIterator::operator*() {
+// Dereferencing the pred_iterator returns the predecessor's SILBasicBlock.
+SILBasicBlock *SILSuccessor::pred_iterator::operator*() {
   assert(Cur && "Can't deference end (or default constructed) iterator");
   return Cur->ContainingInst->getParent();
 }
 
-// Dereferencing the SuccIterator returns the predecessor's SILBasicBlock.
-const SILBasicBlock *SILSuccessorIterator::operator*() const {
+// Dereferencing the pred_iterator returns the predecessor's SILBasicBlock.
+const SILBasicBlock *SILSuccessor::pred_iterator::operator*() const {
   assert(Cur && "Can't deference end (or default constructed) iterator");
   return Cur->ContainingInst->getParent();
 }


### PR DESCRIPTION
This PR contains two small patches. The first adds comments to SILSuccessor. The second renames SILSuccessorIterator to SILSuccessor::pred_iterator. This fits with the actual usage of the iterator.