### PR TITLE
[4.0] [Substitution map] Hack: look at inherited conformances in lookupConformance

### DIFF
--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -107,6 +107,13 @@ SubstitutionMap::lookupConformance(CanType type, ProtocolDecl *proto) const {
           return conformance;
       }
 
+      // FIXME: Hack to deal with substitution maps created with incorrect
+      // conformances. This better go away soon or I'll be sad.
+      for (auto conformance : known->second) {
+        if (conformance.getRequirement()->inheritsFrom(proto))
+          return conformance.getInherited(proto);
+      }
+
       return None;
     };
 


### PR DESCRIPTION
This hack is papering over a bug elsewhere that is adding the wrong
conformances to a substitution map, but it fixes rdar://problem/31815540.
