### PR TITLE
Disable an "expression too complex" test for now.

### DIFF
--- a/test/Sema/complex_expressions.swift
+++ b/test/Sema/complex_expressions.swift
@@ -2,7 +2,8 @@
 
 // SR-139:
 // Infinite recursion parsing bitwise operators
-let x = UInt32(0x1FF)&0xFF << 24 | UInt32(0x1FF)&0xFF << 16 | UInt32(0x1FF)&0xFF << 8 | (UInt32(0x1FF)&0xFF);
+// FIXME: SR-4714 tracks re-enabling this
+// let x = UInt32(0x1FF)&0xFF << 24 | UInt32(0x1FF)&0xFF << 16 | UInt32(0x1FF)&0xFF << 8 | (UInt32(0x1FF)&0xFF);
 
 // SR-838:
 // expression test_seconds() was too complex to be solved in reasonable time


### PR DESCRIPTION
I've opened https://bugs.swift.org/browse/SR-4714 to track fixing the
slowness here and/or moving the test into the validation suite.

We're currently not "too complex" here given the current metric, but we
are still extremely slow, adding several minutes to test runs.
