### PR TITLE
Fix for SR-4683

### DIFF
--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -1693,14 +1693,19 @@ void ASTMangler::appendDeclType(const ValueDecl *decl, bool isFunctionMangling) 
                                      requirements, requirementsBuf);
  
   if (AnyFunctionType *FuncTy = type->getAs<AnyFunctionType>()) {
-    bool forceSingleParam = false;
+
+    const ParameterList *Params = nullptr;
     if (const auto *FDecl = dyn_cast<AbstractFunctionDecl>(decl)) {
       unsigned PListIdx = isMethodDecl(decl) ? 1 : 0;
       if (PListIdx < FDecl->getNumParameterLists()) {
-        const ParameterList *Params = FDecl->getParameterList(PListIdx);
-        forceSingleParam = (Params->size() == 1);
+        Params = FDecl->getParameterList(PListIdx);
       }
+    } else if (const auto *SDecl = dyn_cast<SubscriptDecl>(decl)) {
+        Params = SDecl->getIndices();
     }
+    bool forceSingleParam = Params && (Params->size() == 1);
+          
+
     if (isFunctionMangling) {
       appendFunctionSignature(FuncTy, forceSingleParam);
     } else {

--- a/test/SILGen/arguments_as_tuple_overloads.swift
+++ b/test/SILGen/arguments_as_tuple_overloads.swift
@@ -1,6 +1,7 @@
 // RUN: %target-swift-frontend -parse-as-library -module-name=test -emit-silgen -primary-file %s | %FileCheck %s
 
-// Check if we mangle the following constructors and functions correctly.
+// Check if we mangle the following constructors, functions, and
+// subscripts correctly.
 
 public struct Pair {
   // CHECK: sil @_T04test4PairVACSi_SitcfC :
@@ -17,6 +18,16 @@ public struct Pair {
 
   // CHECK: sil @_T04test4PairVAAySi_Sit_tF :
   public func test(_ t: (Int, Int)) {
+  }
+
+  // CHECK: sil @_T04test4PairV9subscriptS2i_Sitcfg :
+  public subscript(_:Int, _:Int) -> Int {
+      get { return 0 }
+  }
+
+  // CHECK: sil @_T04test4PairV9subscriptS2i_Sit_tcfg :
+  public subscript(_:(Int, Int)) -> Int {
+      get { return 0 }
   }
 }
 

--- a/test/SILGen/constrained_extensions.swift
+++ b/test/SILGen/constrained_extensions.swift
@@ -48,7 +48,7 @@ extension Array where Element == Int {
     return e!
   }
 
-  // CHECK-LABEL: sil @_T0Sa22constrained_extensionsSiRszlE9subscriptSiycfg : $@convention(method) (@guaranteed Array<Int>) -> Int
+  // CHECK-LABEL: sil @_T0Sa22constrained_extensionsSiRszlE9subscriptSiyt_tcfg : $@convention(method) (@guaranteed Array<Int>) -> Int
   public subscript(i: ()) -> Element {
     return self[0]
   }
@@ -119,7 +119,7 @@ extension Dictionary where Key == Int {
     return Dictionary(x: ()).instanceMethod()
   }
 
-  // CHECK-LABEL: sil @_T0s10DictionaryV22constrained_extensionsSiRszr0_lE9subscriptq_ycfg : $@convention(method) <Key, Value where Key == Int> (@guaranteed Dictionary<Int, Value>) -> @out Value
+  // CHECK-LABEL: sil @_T0s10DictionaryV22constrained_extensionsSiRszr0_lE9subscriptq_yt_tcfg : $@convention(method) <Key, Value where Key == Int> (@guaranteed Dictionary<Int, Value>) -> @out Value
   public subscript(i: ()) -> Value {
     return self[0]!
   }
@@ -153,10 +153,10 @@ extension GenericClass where Y == () {
     set {}
   }
 
-  // CHECK-LABEL: sil @_T022constrained_extensions12GenericClassCAAytRs_r0_lE9subscriptxycfg : $@convention(method) <X, Y where Y == ()> (@guaranteed GenericClass<X, ()>) -> @out X
-  // CHECK-LABEL: sil @_T022constrained_extensions12GenericClassCAAytRs_r0_lE9subscriptxycfs : $@convention(method) <X, Y where Y == ()> (@in X, @guaranteed GenericClass<X, ()>) -> ()
-  // CHECK-LABEL: sil [transparent] [serialized] @_T022constrained_extensions12GenericClassCAAytRs_r0_lE9subscriptxycfmytfU_ : $@convention(method) <X, Y where Y == ()> (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout GenericClass<X, ()>, @thick GenericClass<X, ()>.Type) -> ()
-  // CHECK-LABEL: sil [transparent] [serialized] @_T022constrained_extensions12GenericClassCAAytRs_r0_lE9subscriptxycfm : $@convention(method) <X, Y where Y == ()> (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @guaranteed GenericClass<X, ()>) -> (Builtin.RawPointer, Optional<Builtin.RawPointer>)
+  // CHECK-LABEL: sil @_T022constrained_extensions12GenericClassCAAytRs_r0_lE9subscriptxyt_tcfg : $@convention(method) <X, Y where Y == ()> (@guaranteed GenericClass<X, ()>) -> @out X
+  // CHECK-LABEL: sil @_T022constrained_extensions12GenericClassCAAytRs_r0_lE9subscriptxyt_tcfs : $@convention(method) <X, Y where Y == ()> (@in X, @guaranteed GenericClass<X, ()>) -> ()
+  // CHECK-LABEL: sil [transparent] [serialized] @_T022constrained_extensions12GenericClassCAAytRs_r0_lE9subscriptxyt_tcfmytfU_ : $@convention(method) <X, Y where Y == ()> (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout GenericClass<X, ()>, @thick GenericClass<X, ()>.Type) -> ()
+  // CHECK-LABEL: sil [transparent] [serialized] @_T022constrained_extensions12GenericClassCAAytRs_r0_lE9subscriptxyt_tcfm : $@convention(method) <X, Y where Y == ()> (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @guaranteed GenericClass<X, ()>) -> (Builtin.RawPointer, Optional<Builtin.RawPointer>)
   public subscript(_: Y) -> X {
     get { while true {} }
     set {}


### PR DESCRIPTION
Consists of adding another case (subscripts) to the code in ASTMangler.cpp, added in 11f66f8ce39b95c62191a6291780b2316b5863bd, that fixed SR-1795.

Resolves [SR-4683](https://bugs.swift.org/browse/SR-4683).

@swift-ci Please smoke test and merge