### PR TITLE
[stdlib] Undo Sequence constraint on BinaryInteger.Words

### DIFF
--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -1479,7 +1479,7 @@ public protocol BinaryInteger :
   // FIXME(integers): add doc comments
   // FIXME: Should be `Words : Collection where Words.Iterator.Element == UInt`
   // See <rdar://problem/31798916> for why it isn't.
-  associatedtype Words : Sequence
+  associatedtype Words
   var words: Words { get }
 
   /// The number of bits in the current binary representation of this value.


### PR DESCRIPTION
Because it's not compatible with the planned Sequence.Element changes. Hopefully can go back in once we have recursive constraints.

Sorry @moiseev 