### PR TITLE
[sil-combine] Fix a subtle bug in getConformanceAndConcreteType related to handling of inherited conformances

### DIFF
--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -12,6 +12,7 @@
 
 #define DEBUG_TYPE "sil-combine"
 #include "SILCombiner.h"
+#include "swift/AST/SubstitutionMap.h"
 #include "swift/SIL/DynamicCasts.h"
 #include "swift/SIL/PatternMatch.h"
 #include "swift/SIL/SILBuilder.h"
@@ -686,27 +687,39 @@ SILCombiner::createApplyWithConcreteType(FullApplySite AI,
   }
   Args.push_back(NewSelf);
 
+  auto FnTy = AI.getCallee()->getType().castTo<SILFunctionType>();
+  SILType SubstCalleeType = AI.getSubstCalleeSILType();
+  SILType NewSubstCalleeType;
+
   // Form a new set of substitutions where Self is
   // replaced by a concrete type.
   SmallVector<Substitution, 8> Substitutions;
-  for (auto Subst : AI.getSubstitutions()) {
-    auto *A = Subst.getReplacement()->getAs<ArchetypeType>();
-    if (A && A == OpenedArchetype) {
-      auto Conformances = AI.getModule().getASTContext()
-                            .AllocateUninitialized<ProtocolConformanceRef>(1);
-      Conformances[0] = Conformance;
-      Substitution NewSubst(ConcreteType, Conformances);
-      Substitutions.push_back(NewSubst);
-    } else
-      Substitutions.push_back(Subst);
-  }
-
-  SILType SubstCalleeType = AI.getSubstCalleeSILType();
-
-  SILType NewSubstCalleeType;
-
-  auto FnTy = AI.getCallee()->getType().castTo<SILFunctionType>();
   if (FnTy->isPolymorphic()) {
+    auto FnSubsMap =
+        FnTy->getGenericSignature()->getSubstitutionMap(AI.getSubstitutions());
+    auto FinalSubsMap = FnSubsMap.subst(
+        [&](SubstitutableType *type) -> Type {
+          if (type == OpenedArchetype)
+            return ConcreteType;
+          return type;
+        },
+        [&](CanType origTy, Type substTy,
+            ProtocolType *proto) -> Optional<ProtocolConformanceRef> {
+          if (substTy->getCanonicalType() == ConcreteType) {
+            if (proto->getDecl() != Conformance.getRequirement()) {
+              assert(
+                  Conformance.getRequirement()->inheritsFrom(proto->getDecl()));
+              if (Conformance.isAbstract())
+                return ProtocolConformanceRef(proto->getDecl());
+              Conformance = ProtocolConformanceRef(
+                  Conformance.getConcrete()->getInheritedConformance(
+                      proto->getDecl()));
+            }
+            return Conformance;
+          }
+          return ProtocolConformanceRef(proto->getDecl());
+        });
+    FnTy->getGenericSignature()->getSubstitutions(FinalSubsMap, Substitutions);
     // Handle polymorphic functions by properly substituting
     // their parameter types.
     CanSILFunctionType SFT = FnTy->substGenericArgs(

--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -705,17 +705,8 @@ SILCombiner::createApplyWithConcreteType(FullApplySite AI,
         },
         [&](CanType origTy, Type substTy,
             ProtocolType *proto) -> Optional<ProtocolConformanceRef> {
-          if (substTy->getCanonicalType() == ConcreteType) {
-            if (proto->getDecl() != Conformance.getRequirement()) {
-              assert(
-                  Conformance.getRequirement()->inheritsFrom(proto->getDecl()));
-              if (Conformance.isAbstract())
-                return ProtocolConformanceRef(proto->getDecl());
-              Conformance = ProtocolConformanceRef(
-                  Conformance.getConcrete()->getInheritedConformance(
-                      proto->getDecl()));
-            }
-            return Conformance;
+          if (substTy->isEqual(ConcreteType)) {
+            return Conformance.getInherited(proto->getDecl());
           }
           return ProtocolConformanceRef(proto->getDecl());
         });
@@ -807,13 +798,8 @@ getConformanceAndConcreteType(FullApplySite AI,
     if (Requirement->inheritsFrom(Protocol)) {
       // If Requirement != Protocol, then the abstract conformance cannot be used
       // as is and we need to create a proper conformance.
-      return std::make_tuple(
-          Conformance.isAbstract()
-              ? ProtocolConformanceRef(Protocol)
-              : ProtocolConformanceRef(
-                    Conformance.getConcrete()->getInheritedConformance(
-                        Protocol)),
-          ConcreteType, ConcreteTypeDef);
+      return std::make_tuple(Conformance.getInherited(Protocol), ConcreteType,
+                             ConcreteTypeDef);
     }
   }
 

--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -794,10 +794,13 @@ getConformanceAndConcreteType(FullApplySite AI,
     if (Requirement->inheritsFrom(Protocol)) {
       // If Requirement != Protocol, then the abstract conformance cannot be used
       // as is and we need to create a proper conformance.
-      return std::make_tuple(Conformance.isAbstract()
-                                ? ProtocolConformanceRef(Protocol)
-                                : Conformance,
-                            ConcreteType, ConcreteTypeDef);
+      return std::make_tuple(
+          Conformance.isAbstract()
+              ? ProtocolConformanceRef(Protocol)
+              : ProtocolConformanceRef(
+                    Conformance.getConcrete()->getInheritedConformance(
+                        Protocol)),
+          ConcreteType, ConcreteTypeDef);
     }
   }
 

--- a/test/Interpreter/FunctionConversion.swift
+++ b/test/Interpreter/FunctionConversion.swift
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
-// REQUIRES: substitution_map_not_broken
 //
 
 import StdlibUnittest

--- a/test/SILOptimizer/devirt_protocol_method_invocations.swift
+++ b/test/SILOptimizer/devirt_protocol_method_invocations.swift
@@ -1,5 +1,30 @@
 // RUN: %target-swift-frontend -O -emit-sil %s | %FileCheck %s
 
+protocol PPP {
+    func f()
+}
+
+protocol QQQ : PPP {
+}
+
+struct S : QQQ {}
+
+extension QQQ {
+    @_semantics("optimize.sil.never")
+    func f() {}
+}
+
+// Test that all witness_method instructions are devirtualized.
+// This test used to crash the compiler because it uses inherited conformances.
+// CHECK-LABEL: sil @_T034devirt_protocol_method_invocations24testInheritedConformanceyyF : $@convention(thin) () -> ()
+// CHECK-NOT: witness_method
+// CHECK-NOT: class_method
+// CHECK: apply
+// CHECK: // end sil function '_T034devirt_protocol_method_invocations24testInheritedConformanceyyF'
+public func testInheritedConformance() {
+    (S() as QQQ).f()
+}
+
 public protocol Foo { 
   func foo(_ x:Int) -> Int
 }
@@ -49,12 +74,10 @@ public func test_devirt_protocol_extension_method_invocation_with_self_return_ty
   return callGetSelf(c)
 }
 
-// It's not obvious why this isn't completely devirtualized.
 // CHECK: sil @_T034devirt_protocol_method_invocations12test24114020SiyF
-// CHECK:   [[T0:%.*]] = alloc_stack $SimpleBase
-// CHECK:   [[T1:%.*]] = witness_method $SimpleBase, #Base.x!getter.1 
-// CHECK:   [[T2:%.*]] = apply [[T1]]<SimpleBase>([[T0]])
-// CHECK:   return [[T2]]
+// CHECK:   [[T0:%.*]] = integer_literal $Builtin.Int64, 1
+// CHECK:   [[T1:%.*]] = struct $Int ([[T0]] : $Builtin.Int64)
+// CHECK:   return [[T1]]
 
 // CHECK: sil @_T034devirt_protocol_method_invocations14testExMetatypeSiyF
 // CHECK:   [[T0:%.*]] = builtin "sizeof"<Int>


### PR DESCRIPTION
This fixes a couple of tests and some of the compatibility suite projects.
rdar://problem/31815540, rdar://problem/31838976

It is supposed to be a proper fix for a problem addressed by a hack in #9038 