### PR TITLE
Disable a failing test: TestCharacterSet.test_moreSetOperations

### DIFF
--- a/test/stdlib/TestCharacterSet.swift
+++ b/test/stdlib/TestCharacterSet.swift
@@ -283,6 +283,8 @@ class TestCharacterSet : TestCharacterSetSuper {
         // fix that corrected this behavior.
         // TODO: figure out why the simulator is claiming this as a failure.
         // https://bugs.swift.org/browse/SR-4457
+
+        /* Disabled now: rdar://problem/31746923
         #if os(macOS)
             if #available(OSX 10.12.4, iOS 10.3, watchOS 3.2, tvOS 10.2, *) {
                 let abcSet = CharacterSet(charactersIn: "abc")
@@ -297,6 +299,7 @@ class TestCharacterSet : TestCharacterSetSuper {
                 expectFalse(abcSet.isStrictSuperset(of:abcdSet))
             }
         #endif
+        */
     }
 }
 


### PR DESCRIPTION
We have disable this test on master because it is flaky. Do the same on swift-4.0-branch.

rdar://problem/31746923
(cherry picked from commit 43ecc02397560f8a1966b6e4781dbd87b8d76f3a)

