### PR TITLE
Add a targeted test for inout-to-pointer conversions in the context o…

### DIFF
--- a/test/Sema/diag_type_conversion.swift
+++ b/test/Sema/diag_type_conversion.swift
@@ -48,3 +48,21 @@ func foo13(a : [AnyHashable : Any]) {}
 func foo14(b : [NSObject : AnyObject]) {
   foo13(a : b)
 }
+
+
+// Add a minimal test for inout-to-pointer conversion involving a
+// generic function with a protocol constraint of Equatable.
+infix operator =*= : ComparisonPrecedence
+func =*= <T : Equatable>(lhs: T, rhs: T) -> Bool {
+ return lhs == rhs
+}
+func =*= <T : Equatable>(lhs: T?, rhs: T?) -> Bool {
+ return lhs == rhs
+}
+
+class C {}
+
+var o = C()
+var p: UnsafeMutablePointer<C>? = nil
+
+_ = p =*= &o


### PR DESCRIPTION
…f generic functions.

I was experimenting with type checker changes that resulted in breaking
code like this and we did not have a test in place to catch the problem.
