### PR TITLE
[Migrator] Set language version to 4 for the fix-it passes

### DIFF
--- a/lib/Migrator/Migrator.cpp
+++ b/lib/Migrator/Migrator.cpp
@@ -96,6 +96,7 @@ Migrator::performAFixItMigration() {
   CompilerInvocation Invocation { StartInvocation };
   Invocation.clearInputs();
   Invocation.addInputBuffer(InputBuffer.get());
+  Invocation.getLangOptions().EffectiveLanguageVersion = { 4, 0, 0 };
 
   CompilerInstance Instance;
   if (Instance.setup(Invocation)) {


### PR DESCRIPTION
When running the fix-it passes, we should explicitly set the effective
language version to 4, since passing language version 3 may be the
default at first.

rdar://problem/31854159