### PR TITLE
[Migrator] Make remap file an additional output

### DIFF
--- a/include/swift/Driver/Driver.h
+++ b/include/swift/Driver/Driver.h
@@ -94,7 +94,7 @@ public:
 
   /// Whether the compiler picked the current module name, rather than the user.
   bool ModuleNameIsFallback = false;
-  
+
   /// The number of threads for multi-threaded compilation.
   unsigned numThreads = 0;
 

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -172,8 +172,6 @@ public:
     EmitIR, ///< Emit LLVM IR
     EmitBC, ///< Emit LLVM BC
     EmitObject, ///< Emit object file
-
-    UpdateCode, ///< Update Swift code
   };
 
   /// Indicates the action the user requested that the frontend perform.

--- a/include/swift/Migrator/Migrator.h
+++ b/include/swift/Migrator/Migrator.h
@@ -27,15 +27,18 @@ namespace migrator {
 
 /// Run the migrator on the compiler invocation's input file and emit a
 /// "replacement map" describing the requested changes to the source file.
-bool updateCodeAndEmitRemap(const CompilerInvocation &Invocation);
+bool updateCodeAndEmitRemap(CompilerInstance &Instance,
+                            const CompilerInvocation &Invocation);
 
 class Migrator {
+  CompilerInstance &StartInstance;
   const CompilerInvocation &StartInvocation;
   SourceManager SrcMgr;
   std::vector<RC<MigrationState>> States;
 
 public:
-  Migrator(const CompilerInvocation &StartInvocation);
+  Migrator(CompilerInstance &StartInstance,
+           const CompilerInvocation &StartInvocation);
 
   /// The maximum number of times to run the compiler over the input to get
   /// fix-its. Nullability changes may expose other fix-its in subsequent

--- a/include/swift/Migrator/MigratorOptions.h
+++ b/include/swift/Migrator/MigratorOptions.h
@@ -31,6 +31,11 @@ struct MigratorOptions {
   /// Whether to print each USR we query the api change data store about.
   bool DumpUsr = false;
 
+  /// If non-empty, print a replacement map describing changes to get from
+  /// the first MigrationState's output text to the last MigrationState's
+  /// output text.
+  std::string EmitRemapFilePath = "";
+
   /// If non-empty, print the last MigrationState's output text to the given
   /// file path.
   std::string EmitMigratedFilePath = "";
@@ -40,6 +45,11 @@ struct MigratorOptions {
 
   /// If non-empty, use the api change data serialized to this path.
   std::string APIDigesterDataStorePath = "";
+
+  bool shouldRunMigrator() const {
+    return !(EmitRemapFilePath.empty() && EmitMigratedFilePath.empty() &&
+             DumpMigrationStatesDir.empty());
+  }
 };
 
 } // end namespace swift

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -415,9 +415,19 @@ def line_range : Separate<["-"], "line-range">, Group<code_formatting_Group>,
            "Can only be used with one input file.">, MetaVarName<"<n:n>">;
 
 // Migrator Options
+
+def update_code : Flag<["-"], "update-code">,
+  HelpText<"Update Swift code">,
+  Flags<[FrontendOption, HelpHidden, NoInteractiveOption, DoesNotAffectIncrementalBuild]>;
+
 def disable_migrator_fixits: Flag<["-"], "disable-migrator-fixits">,
   Flags<[FrontendOption, NoInteractiveOption]>,
   HelpText<"Disable the Migrator phase which automatically applies fix-its">;
+
+def emit_remap_file_path: Separate<["-"], "emit-remap-file-path">,
+  Flags<[FrontendOption, NoDriverOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>,
+  HelpText<"Emit the replacement map describing Swift Migrator changes to <path>">,
+  MetaVarName<"<path>">;
 
 def emit_migrated_file_path: Separate<["-"], "emit-migrated-file-path">,
   Flags<[FrontendOption, NoDriverOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>,
@@ -507,10 +517,6 @@ def c : Flag<["-"], "c">, Alias<emit_object>,
   Flags<[FrontendOption, NoInteractiveOption]>, ModeOpt;
 def S: Flag<["-"], "S">, Alias<emit_assembly>,
   Flags<[FrontendOption, NoInteractiveOption]>, ModeOpt;
-
-def update_code : Flag<["-"], "update-code">,
-  HelpText<"Update Swift code">, ModeOpt,
-  Flags<[FrontendOption, HelpHidden, NoInteractiveOption, DoesNotAffectIncrementalBuild]>;
 
 def fixit_all : Flag<["-"], "fixit-all">,
   HelpText<"Apply all fixits from diagnostics without any filtering">,

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -494,8 +494,6 @@ std::unique_ptr<Compilation> Driver::buildCompilation(
     ArgList->hasArg(options::OPT_driver_show_incremental);
   bool ShowJobLifecycle =
     ArgList->hasArg(options::OPT_driver_show_job_lifecycle);
-  bool UpdateCode =
-    ArgList->hasArg(options::OPT_update_code);
 
   bool Incremental = ArgList->hasArg(options::OPT_incremental);
   if (ArgList->hasArg(options::OPT_whole_module_optimization)) {
@@ -671,10 +669,9 @@ std::unique_ptr<Compilation> Driver::buildCompilation(
 
   buildJobs(Actions, OI, OFM.get(), *TC, *C);
 
-  // For updating code we need to go through all the files and pick up changes,
-  // even if they have compiler errors. Also for getting bulk fixits, or for when
-  // users explicitly request to continue building despite errors.
-  if (UpdateCode || ContinueBuildingAfterErrors)
+  // For getting bulk fixits, or for when users explicitly request to continue
+  // building despite errors.
+  if (ContinueBuildingAfterErrors)
     C->setContinueBuildingAfterErrors();
 
   if (ShowIncrementalBuildDecisions || ShowJobLifecycle)
@@ -1124,11 +1121,6 @@ void Driver::buildOutputInfo(const ToolChain &TC, const DerivedArgList &Args,
       // We want the symbols from the whole module, so let's do it in one
       // invocation.
       OI.CompilerMode = OutputInfo::Mode::SingleCompile;
-      break;
-
-    case options::OPT_update_code:
-      OI.CompilerOutputType = types::TY_Remapping;
-      OI.LinkAction = LinkKind::None;
       break;
 
     case options::OPT_parse:
@@ -2063,6 +2055,27 @@ Job *Driver::buildJobsForAction(Compilation &C, const JobAction *JA,
       llvm::sys::path::replace_extension(Path,
                                          SERIALIZED_MODULE_DOC_EXTENSION);
       Output->setAdditionalOutputForType(types::TY_SwiftModuleDocFile, Path);
+      if (isTempFile)
+        C.addTemporaryFile(Path);
+    }
+  }
+
+  if (C.getArgs().hasArg(options::OPT_update_code) &&
+      isa<CompileJobAction>(JA)) {
+    StringRef OFMFixitsOutputPath;
+    if (OutputMap) {
+      auto iter = OutputMap->find(types::TY_Remapping);
+      if (iter != OutputMap->end())
+        OFMFixitsOutputPath = iter->second;
+    }
+    if (!OFMFixitsOutputPath.empty()) {
+      Output->setAdditionalOutputForType(types::ID::TY_Remapping,
+                                         OFMFixitsOutputPath);
+    } else {
+      llvm::SmallString<128> Path(Output->getPrimaryOutputFilenames()[0]);
+      bool isTempFile = C.isTemporaryFile(Path);
+      llvm::sys::path::replace_extension(Path, "remap");
+      Output->setAdditionalOutputForType(types::ID::TY_Remapping, Path);
       if (isTempFile)
         C.addTemporaryFile(Path);
     }

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -402,7 +402,7 @@ ToolChain::constructInvocation(const CompileJobAction &job,
   const std::string &FixitsPath =
     context.Output.getAdditionalOutputForType(types::TY_Remapping);
   if (!FixitsPath.empty()) {
-    Arguments.push_back("-emit-fixits-path");
+    Arguments.push_back("-emit-remap-file-path");
     Arguments.push_back(FixitsPath.c_str());
   }
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -323,8 +323,6 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
       Action = FrontendOptions::REPL;
     } else if (Opt.matches(OPT_interpret)) {
       Action = FrontendOptions::Immediate;
-    } else if (Opt.matches(OPT_update_code)) {
-      Action = FrontendOptions::UpdateCode;
     } else {
       llvm_unreachable("Unhandled mode option");
     }
@@ -562,10 +560,6 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
         Suffix = "importedmodules";
       break;
 
-    case FrontendOptions::UpdateCode:
-      Suffix = REMAP_EXTENSION;
-      break;
-
     case FrontendOptions::EmitTBD:
       if (Opts.OutputFilenames.empty())
         Opts.setSingleOutputFilename("-");
@@ -716,7 +710,6 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
     case FrontendOptions::DumpTypeRefinementContexts:
     case FrontendOptions::Immediate:
     case FrontendOptions::REPL:
-    case FrontendOptions::UpdateCode:
       Diags.diagnose(SourceLoc(), diag::error_mode_cannot_emit_dependencies);
       return true;
     case FrontendOptions::Parse:
@@ -749,7 +742,6 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
     case FrontendOptions::DumpTypeRefinementContexts:
     case FrontendOptions::Immediate:
     case FrontendOptions::REPL:
-    case FrontendOptions::UpdateCode:
       Diags.diagnose(SourceLoc(), diag::error_mode_cannot_emit_header);
       return true;
     case FrontendOptions::Parse:
@@ -781,7 +773,6 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
     case FrontendOptions::DumpTypeRefinementContexts:
     case FrontendOptions::Immediate:
     case FrontendOptions::REPL:
-    case FrontendOptions::UpdateCode:
       Diags.diagnose(SourceLoc(),
                      diag::error_mode_cannot_emit_loaded_module_trace);
       return true;
@@ -818,7 +809,6 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
     case FrontendOptions::EmitSILGen:
     case FrontendOptions::Immediate:
     case FrontendOptions::REPL:
-    case FrontendOptions::UpdateCode:
       if (!Opts.ModuleOutputPath.empty())
         Diags.diagnose(SourceLoc(), diag::error_mode_cannot_emit_module);
       else
@@ -1598,6 +1588,10 @@ bool ParseMigratorArgs(MigratorOptions &Opts, llvm::Triple &Triple,
     Opts.EnableMigratorFixits = false;
   }
 
+  if (auto RemapFilePath = Args.getLastArg(OPT_emit_remap_file_path)) {
+    Opts.EmitRemapFilePath = RemapFilePath->getValue();
+  }
+
   if (auto MigratedFilePath = Args.getLastArg(OPT_emit_migrated_file_path)) {
     Opts.EmitMigratedFilePath = MigratedFilePath->getValue();
   }
@@ -1625,6 +1619,7 @@ bool ParseMigratorArgs(MigratorOptions &Opts, llvm::Triple &Triple,
     if (Supported)
       Opts.APIDigesterDataStorePath = dataPath.str();
   }
+
   return false;
 }
 

--- a/lib/Frontend/FrontendOptions.cpp
+++ b/lib/Frontend/FrontendOptions.cpp
@@ -34,7 +34,6 @@ bool FrontendOptions::actionHasOutput() const {
   case EmitSIBGen:
   case EmitSIB:
   case EmitModuleOnly:
-  case UpdateCode:
     return true;
   case Immediate:
   case REPL:
@@ -67,7 +66,6 @@ bool FrontendOptions::actionIsImmediate() const {
   case EmitSIBGen:
   case EmitSIB:
   case EmitModuleOnly:
-  case UpdateCode:
     return false;
   case Immediate:
   case REPL:

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -460,14 +460,15 @@ static bool performCompile(std::unique_ptr<CompilerInstance> &Instance,
 
   ASTContext &Context = Instance->getASTContext();
 
+  if (!Context.hadError() &&
+      Invocation.getMigratorOptions().shouldRunMigrator()) {
+    migrator::updateCodeAndEmitRemap(*Instance, Invocation);
+  }
+
   if (Action == FrontendOptions::REPL) {
     runREPL(*Instance, ProcessCmdLine(Args.begin(), Args.end()),
             Invocation.getParseStdlib());
     return Context.hadError();
-  }
-
-  if (Action == FrontendOptions::UpdateCode) {
-    return migrator::updateCodeAndEmitRemap(Invocation);
   }
 
   SourceFile *PrimarySourceFile = Instance->getPrimarySourceFile();

--- a/lib/Migrator/Migrator.cpp
+++ b/lib/Migrator/Migrator.cpp
@@ -1,5 +1,4 @@
-//===--- Migrator.cpp -----------------------------------------------------===//
-//
+//===--- Migrator.cpp -----------------------------------------------------===////
 // This source file is part of the Swift.org open source project
 //
 // Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
@@ -26,13 +25,13 @@
 using namespace swift;
 using namespace swift::migrator;
 
-bool migrator::updateCodeAndEmitRemap(const CompilerInvocation &Invocation) {
-  Migrator M { Invocation }; // Provide inputs and configuration
+bool migrator::updateCodeAndEmitRemap(CompilerInstance &Instance,
+                                      const CompilerInvocation &Invocation) {
+  Migrator M { Instance, Invocation }; // Provide inputs and configuration
 
   // Phase 1:
   // Perform any syntactic transformations if requested.
 
-  // TODO
   auto FailedSyntacticPasses = M.performSyntacticPasses();
   if (FailedSyntacticPasses) {
     return true;
@@ -59,8 +58,9 @@ bool migrator::updateCodeAndEmitRemap(const CompilerInvocation &Invocation) {
   return EmitRemapFailed || EmitMigratedFailed || DumpMigrationStatesFailed;
 }
 
-Migrator::Migrator(const CompilerInvocation &StartInvocation)
-  : StartInvocation(StartInvocation) {
+Migrator::Migrator(CompilerInstance &StartInstance,
+                   const CompilerInvocation &StartInvocation)
+  : StartInstance(StartInstance), StartInvocation(StartInvocation) {
 
     auto ErrorOrStartBuffer = llvm::MemoryBuffer::getFile(getInputFilename());
     auto &StartBuffer = ErrorOrStartBuffer.get();
@@ -87,11 +87,10 @@ repeatFixitMigrations(const unsigned Iterations) {
 
 llvm::Optional<RC<MigrationState>>
 Migrator::performAFixItMigration() {
-
   auto InputState = States.back();
   auto InputBuffer =
     llvm::MemoryBuffer::getMemBufferCopy(InputState->getOutputText(),
-                                     getInputFilename());
+                                         getInputFilename());
 
   CompilerInvocation Invocation { StartInvocation };
   Invocation.clearInputs();
@@ -99,7 +98,6 @@ Migrator::performAFixItMigration() {
 
   CompilerInstance Instance;
   if (Instance.setup(Invocation)) {
-    // TODO: Return a state with an error attached?
     return None;
   }
 
@@ -145,30 +143,9 @@ bool Migrator::performSyntacticPasses() {
   clang::LangOptions ClangLangOpts;
   clang::edit::EditedSource Edits { ClangSourceManager, ClangLangOpts };
 
-  // Make a CompilerInstance
-  // Perform Sema
-  // auto SF = CI.getPrimarySourceFile() ?
-
-  CompilerInvocation Invocation { StartInvocation };
-
   auto InputState = States.back();
-  auto TempInputBuffer =
-    llvm::MemoryBuffer::getMemBufferCopy(InputState->getOutputText(),
-                                         getInputFilename());
-  Invocation.clearInputs();
-  Invocation.addInputBuffer(TempInputBuffer.get());
 
-  CompilerInstance Instance;
-  if (Instance.setup(StartInvocation)) {
-    return true;
-  }
-
-  Instance.performSema();
-  if (Instance.getDiags().hasFatalErrorOccurred()) {
-    return true;
-  }
-
-  EditorAdapter Editor { Instance.getSourceMgr(), ClangSourceManager };
+  EditorAdapter Editor { StartInstance.getSourceMgr(), ClangSourceManager };
 
   // const auto SF = Instance.getPrimarySourceFile();
 
@@ -182,7 +159,7 @@ bool Migrator::performSyntacticPasses() {
   // Once it has run, push the edits into Edits above:
   // Edits.commit(YourPass.getEdits());
 
-  SyntacticMigratorPass SPass(Editor, Instance.getPrimarySourceFile(),
+  SyntacticMigratorPass SPass(Editor, StartInstance.getPrimarySourceFile(),
     getMigratorOptions());
   SPass.run();
   Edits.commit(SPass.getEdits());
@@ -194,7 +171,7 @@ bool Migrator::performSyntacticPasses() {
   RewriteBufferEditsReceiver Rewriter {
     ClangSourceManager,
     Editor.getClangFileIDForSwiftBufferID(
-      Instance.getPrimarySourceFile()->getBufferID().getValue()),
+      StartInstance.getPrimarySourceFile()->getBufferID().getValue()),
     InputState->getOutputText()
   };
     

--- a/test/Driver/driver-compile.swift
+++ b/test/Driver/driver-compile.swift
@@ -111,9 +111,8 @@
 // FILELIST: -output-filelist {{[^-]}}
 
 // UPDATE-CODE: DISTINCTIVE-PATH/usr/bin/swift
-// UPDATE-CODE: -frontend
-// UPDATE-CODE: -update-code
-// UPDATE-CODE: -o {{.+}}.remap
+// UPDATE-CODE: -frontend -c
+// UPDATE-CODE: -emit-remap-file-path {{.+}}.remap
 
 // NO-REFERENCE-DEPENDENCIES: bin/swift
 // NO-REFERENCE-DEPENDENCIES-NOT: -emit-reference-dependencies

--- a/test/Migrator/null_migration.swift
+++ b/test/Migrator/null_migration.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t && %swift -update-code -primary-file %s -emit-migrated-file-path %t/migrated_null_migration.swift -o %t/null_migration.remap
+// RUN: rm -rf %t && mkdir -p %t && %target-swift-frontend -c -update-code -primary-file %s -emit-migrated-file-path %t/migrated_null_migration.swift -emit-remap-file-path %t/null_migration.remap
 // RUN: diff -u %s %t/migrated_null_migration.swift
 
 // This file tests that, if all migration passes are no-op,

--- a/test/Migrator/objc_inference.swift
+++ b/test/Migrator/objc_inference.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t && %target-swift-frontend -update-code -warn-swift3-objc-inference -primary-file %s -emit-migrated-file-path %t/migrated_objc_inference.swift -o %t/objc_inference.remap
+// RUN: rm -rf %t && mkdir -p %t && %target-swift-frontend -c -update-code -warn-swift3-objc-inference -primary-file %s -emit-migrated-file-path %t/migrated_objc_inference.swift -emit-remap-file-path %t/migrated_objc_inference.swift.remap
 // RUN: not diff -u %s %t/migrated_objc_inference.swift > %t/objc_inference.diff
 // RUN: %FileCheck %s < %t/objc_inference.diff
 // REQUIRES: objc_interop

--- a/test/migrator/member.swift
+++ b/test/migrator/member.swift
@@ -1,5 +1,5 @@
 // REQUIRES: objc_interop
-// RUN: rm -rf %t && mkdir -p %t && %swift -update-code -primary-file %s  -F %S/mock-sdk -api-diff-data-file %S/API.json -emit-migrated-file-path %t/member.swift.result -o %t/member.swift.remap
+// RUN: rm -rf %t && mkdir -p %t && %target-swift-frontend -c -update-code -primary-file %s -F %S/mock-sdk -api-diff-data-file %S/API.json -emit-migrated-file-path %t/member.swift.result -emit-remap-file-path %t/member.swift.remap
 // RUN: diff -u %S/member.swift.expected %t/member.swift.result
 
 import Bar

--- a/test/migrator/member.swift.expected
+++ b/test/migrator/member.swift.expected
@@ -1,5 +1,5 @@
 // REQUIRES: objc_interop
-// RUN: rm -rf %t && mkdir -p %t && %swift -update-code -primary-file %s  -F %S/mock-sdk -api-diff-data-file %S/API.json -emit-migrated-file-path %t/member.swift.result -o %t/member.swift.remap
+// RUN: rm -rf %t && mkdir -p %t && %target-swift-frontend -c -update-code -primary-file %s -F %S/mock-sdk -api-diff-data-file %S/API.json -emit-migrated-file-path %t/member.swift.result -emit-remap-file-path %t/member.swift.remap
 // RUN: diff -u %S/member.swift.expected %t/member.swift.result
 
 import Bar

--- a/test/migrator/rename-init.swift
+++ b/test/migrator/rename-init.swift
@@ -1,5 +1,5 @@
 // REQUIRES: objc_interop
-// RUN: rm -rf %t && mkdir -p %t && %swift -update-code -primary-file %s  -F %S/mock-sdk -api-diff-data-file %S/API.json -emit-migrated-file-path %t/rename-init.swift.result -o %t/rename-init.swift.remap -disable-migrator-fixits
+// RUN: rm -rf %t && mkdir -p %t && %target-swift-frontend -c -update-code -primary-file %s -F %S/mock-sdk -api-diff-data-file %S/API.json -emit-migrated-file-path %t/rename-init.swift.result -disable-migrator-fixits
 // RUN: diff -u %S/rename-init.swift.expected %t/rename-init.swift.result
 
 import Bar

--- a/test/migrator/rename-init.swift.expected
+++ b/test/migrator/rename-init.swift.expected
@@ -1,5 +1,5 @@
 // REQUIRES: objc_interop
-// RUN: rm -rf %t && mkdir -p %t && %swift -update-code -primary-file %s  -F %S/mock-sdk -api-diff-data-file %S/API.json -emit-migrated-file-path %t/rename-init.swift.result -o %t/rename-init.swift.remap -disable-migrator-fixits
+// RUN: rm -rf %t && mkdir -p %t && %target-swift-frontend -c -update-code -primary-file %s -F %S/mock-sdk -api-diff-data-file %S/API.json -emit-migrated-file-path %t/rename-init.swift.result -disable-migrator-fixits
 // RUN: diff -u %S/rename-init.swift.expected %t/rename-init.swift.result
 
 import Bar

--- a/test/migrator/rename.swift
+++ b/test/migrator/rename.swift
@@ -1,5 +1,5 @@
 // REQUIRES: objc_interop
-// RUN: rm -rf %t && mkdir -p %t && %swift -update-code -primary-file %s  -F %S/mock-sdk -api-diff-data-file %S/API.json -emit-migrated-file-path %t/rename.swift.result -o %t/rename.swift.remap
+// RUN: rm -rf %t && mkdir -p %t && %target-swift-frontend -c -update-code -primary-file %s -F %S/mock-sdk -api-diff-data-file %S/API.json -emit-migrated-file-path %t/rename.swift.result -emit-remap-file-path %t/rename.swift.remap
 // RUN: diff -u %S/rename.swift.expected %t/rename.swift.result
 
 import Bar

--- a/test/migrator/rename.swift.expected
+++ b/test/migrator/rename.swift.expected
@@ -1,5 +1,5 @@
 // REQUIRES: objc_interop
-// RUN: rm -rf %t && mkdir -p %t && %swift -update-code -primary-file %s  -F %S/mock-sdk -api-diff-data-file %S/API.json -emit-migrated-file-path %t/rename.swift.result -o %t/rename.swift.remap
+// RUN: rm -rf %t && mkdir -p %t && %target-swift-frontend -c -update-code -primary-file %s -F %S/mock-sdk -api-diff-data-file %S/API.json -emit-migrated-file-path %t/rename.swift.result -emit-remap-file-path %t/rename.swift.remap
 // RUN: diff -u %S/rename.swift.expected %t/rename.swift.result
 
 import Bar


### PR DESCRIPTION
Instead of making -update-code a separate frontend mode, just make
the remap file, migrated file, and state dump additional outputs
for a standard compile.