### PR TITLE
[GSB] Start inferring same-type requirements from inherited type declarations

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -7427,6 +7427,40 @@ void TypeChecker::validateDeclForNameLookup(ValueDecl *D) {
     validateAccessibility(assocType);
     break;
   }
+  case DeclKind::TypeAlias: {
+    auto typealias = cast<TypeAliasDecl>(D);
+    if (typealias->getUnderlyingTypeLoc().getType())
+      return;
+
+    // Perform earlier validation of typealiases in protocols.
+    if (auto proto = dyn_cast<ProtocolDecl>(dc)) {
+      if (!typealias->getGenericParams()) {
+        ProtocolRequirementTypeResolver resolver(proto);
+        TypeResolutionOptions options;
+
+        if (typealias->isBeingValidated()) return;
+
+        typealias->setIsBeingValidated();
+        SWIFT_DEFER { typealias->setIsBeingValidated(false); };
+
+        validateAccessibility(typealias);
+        if (typealias->getFormalAccess() <= Accessibility::FilePrivate)
+          options |= TR_KnownNonCascadingDependency;
+
+        if (validateType(typealias->getUnderlyingTypeLoc(),
+                         typealias, options, &resolver)) {
+          typealias->setInvalid();
+          typealias->getUnderlyingTypeLoc().setInvalidType(Context);
+        }
+
+        typealias->setUnderlyingType(
+                                typealias->getUnderlyingTypeLoc().getType());
+
+        return;
+      }
+    }
+    LLVM_FALLTHROUGH;
+  }
 
   default:
     validateDecl(D);

--- a/test/Generics/protocol_type_aliases.swift
+++ b/test/Generics/protocol_type_aliases.swift
@@ -62,7 +62,7 @@ protocol Q3: P3 {
 protocol P3_1 {
     typealias T = Float // expected-error{{typealias 'T' requires types 'P3.T' (aka 'Int') and 'Float' to be the same}}
 }
-protocol Q3_1: P3, P3_1 {}
+protocol Q3_1: P3, P3_1 {} // expected-error{{generic signature requires types 'Float'}}
 
 // FIXME: these shouldn't be necessary to trigger the errors above, but are, due to
 // the 'recursive decl validation' FIXME in GenericSignatureBuilder.cpp.

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -91,7 +91,7 @@ func inferSuperclassRequirement2<T : Canidae>(_ v: U<T>) {}
 // ----------------------------------------------------------------------------
 
 protocol P3 {
-  associatedtype P3Assoc : P2
+  associatedtype P3Assoc : P2  // expected-note{{declared here}}
 }
 
 protocol P4 {
@@ -388,4 +388,19 @@ protocol P27a {
 protocol P27b {
   associatedtype A
   associatedtype B where A == X26<B>
+}
+
+// ----------------------------------------------------------------------------
+// Inference of associated type relationships within a protocol hierarchy
+// ----------------------------------------------------------------------------
+
+struct X28 : P2 {
+  func p1() { }
+}
+
+// CHECK-LABEL: .P28@
+// CHECK-NEXT: Requirement signature: <Self where Self : P3, Self.P3Assoc == X28>
+// CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0 : P3, τ_0_0.P3Assoc == X28>
+protocol P28: P3 {
+  typealias P3Assoc = X28   // expected-warning{{typealias overriding associated type}}
 }


### PR DESCRIPTION
Infer same-type requirements among same-named associated
types/typealiases within inherited protocols. This is more staging; it
doesn't really have teeth until we stop wiring together these types as
part of lookup.
