### PR TITLE
[PrintAsObjC] Don't use take an ArrayRef into temporary storage.

### DIFF
--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -558,8 +558,8 @@ private:
     auto paramLists = AFD->getParameterLists();
     assert(paramLists.size() == 2 && "not an ObjC-compatible method");
 
-    ArrayRef<Identifier> selectorPieces
-      = AFD->getObjCSelector().getSelectorPieces();
+    auto selector = AFD->getObjCSelector();
+    ArrayRef<Identifier> selectorPieces = selector.getSelectorPieces();
     
     const auto &params = paramLists[1]->getArray();
     unsigned paramIndex = 0;


### PR DESCRIPTION
`ObjCSelector::getSelectorPieces()` can return a pointer to `*this`, so
don't use it on a temporary. Fixes an ASan-detected
stack-use-after-scope, rdar://problem/31837593.
