### PR TITLE
[Stdlib] Remove a return statement after a fatalError().

### DIFF
--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -1570,7 +1570,6 @@ extension BinaryInteger {
   public init?<T : FloatingPoint>(exactly source: T) {
     // FIXME(integers): implement
     fatalError()
-    return nil
   }
 
   @_transparent


### PR DESCRIPTION
Eliminates a warning about unreachable code because, you know, it's
unreachable code. Fixes rdar://problem/31766069.
