### PR TITLE
Update the TBI test to be conditional on the arm64 code generator instead of targeting arm64.

### DIFF
--- a/test/Misc/tbi.swift
+++ b/test/Misc/tbi.swift
@@ -6,8 +6,7 @@
 // RUN:     -O -S %s -parse-as-library -parse-stdlib -module-name Swift | \
 // RUN:   %FileCheck --check-prefix=NO_TBI %s
 
-// REQUIRES: CPU=arm64
-// REQUIRES: OS=ios
+// REQUIRES: CODEGENERATOR=AArch64
 
 // Verify that TBI is on by default in Swift on targets that support it. For our
 // purposes this means iOS8.0 or later.


### PR DESCRIPTION
Update the TBI test to be conditional on the arm64 code generator instead of targeting arm64.

This ensures that we run the test during normal PR testing and hopefully ensures
I never have to fix this test again = ).

rdar://24370377
