### PR TITLE
Custom Reverse[RandomAccess]Collection.Iterator

### DIFF
--- a/stdlib/public/core/Reverse.swift
+++ b/stdlib/public/core/Reverse.swift
@@ -156,9 +156,35 @@ public struct ReversedCollection<
 
   public typealias IndexDistance = Base.IndexDistance
 
-  /// A type that provides the sequence's iteration interface and
-  /// encapsulates its iteration state.
-  public typealias Iterator = IndexingIterator<ReversedCollection>
+  @_fixed_layout
+  public struct Iterator : IteratorProtocol, Sequence {
+    @_inlineable
+    @inline(__always)
+    public /// @testable
+    init(elements: Base, endPosition: Base.Index) {
+      self._elements = elements
+      self._position = endPosition
+    }
+    
+    @_inlineable
+    @inline(__always)
+    public mutating func next() -> Base.Iterator.Element? {
+      guard _fastPath(_position != _elements.startIndex) else { return nil }
+      _position = _elements.index(before: _position)
+      return _elements[_position]
+    }
+    
+    @_versioned
+    internal let _elements: Base
+    @_versioned
+    internal var _position: Base.Index
+  }
+
+  @_inlineable
+  @inline(__always)
+  public func makeIterator() -> Iterator {
+    return Iterator(elements: _base, endPosition: _base.endIndex)
+  }
 
   @_inlineable
   public var startIndex: Index {


### PR DESCRIPTION
In local tests this has accounted for some major speedups by helping the optimizer eliminate ARC traffic

@airspeedswift this is technically a source compatibility break, though I doubt anyone is depending on the associated iterator type.  We've had it on our list for a while to give all these `Sequence`s their own `Iterator` type, FWIW