### PR TITLE
Changelog updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,21 @@ CHANGELOG
 Swift 4.0
 ---------
 
+* [SE-0142][]
+
+  Protocols and associated types can now contain `where` clauses that
+  provide additional restrictions on associated types. For example:
+
+    ```swift
+    protocol StringRepresentable: RawRepresentable
+    where RawValue == String { }
+
+    protocol RawStringWrapper {
+      associatedtype Wrapped: RawRepresentable
+        where Wrapper.RawValue == String
+    }
+    ```
+
 * [SE-0160][]
 
   In Swift 4 mode, a declaration is inferred to be `@objc` where it is required for semantic consistency of the programming model. Specifically, it is inferred when:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,32 @@ CHANGELOG
 Swift 4.0
 ---------
 
+* [SE-0160][]
+
+  In Swift 4 mode, a declaration is inferred to be `@objc` where it is required for semantic consistency of the programming model. Specifically, it is inferred when:
+
+    * The declaration is an override of an `@objc` declaration
+    * The declaration satisfies a requirement in an `@objc` protocol
+    * The declaration has one of the following attributes: `@IBAction`, `@IBOutlet`, `@IBInspectable`, `@GKInspectable`, or `@NSManaged`
+
+  Additionally, in Swift 4 mode, `dynamic` declarations that don't
+  have `@objc` inferred based on the rules above will need to be
+  explicitly marked `@objc`.
+
+  Swift 3 compatibility mode retains the more-permissive Swift 3
+  rules for inference of `@objc` within subclasses of
+  `NSObject`. However, the compiler will emit warnings about places
+  where the Objective-C entry points for these inference cases are
+  used, e.g., in a `#selector` or `#keyPath` expression, via
+  messaging through `AnyObject`, or direct uses in Objective-C code
+  within a mixed project. The warnings can be silenced by adding an
+  explicit `@objc`. Uses of these entrypoints that are not
+  statically visible to the compiler can be diagnosed at runtime by
+  setting the environment variable
+  `SWIFT_DEBUG_IMPLICIT_OBJC_ENTRYPOINT` to a value between 1 and 3
+  and testing the application. See the [migration discussion in
+  SE-0160](https://github.com/apple/swift-evolution/blob/master/proposals/0160-objc-inference.md#minimal-migration-workflow).
+
 * [SE-0138](https://github.com/apple/swift-evolution/blob/master/proposals/0138-unsaferawbufferpointer.md#amendment-to-normalize-the-slice-type):
 
   Slicing a raw buffer no longer results in the same raw buffer


### PR DESCRIPTION
Add changelog entries for two implemented proposals

* [SE-0160](https://github.com/apple/swift-evolution/blob/master/proposals/0160-objc-inference.md): Limiting `@objc` inference
* [SE-0142](https://github.com/apple/swift-evolution/blob/master/proposals/0142-associated-types-constraints.md): Permit `where` clauses to constraint associated types.

Addresses rdar://problem/31776483.