### PR TITLE
Enable subclass existentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,70 @@ CHANGELOG
 Swift 4.0
 ---------
 
+* [SE-0156][]
+
+  Protocol composition types can now contain one or more class type terms,
+  forming a class-constrained protocol composition.
+
+  For example:
+
+  ```swift
+  protocol Paintable {
+    func paint()
+  }
+
+  class Canvas {
+    var origin: CGPoint
+  }
+
+  class Wall : Canvas, Paintable {
+    func paint() { ... }
+  }```
+
+  func render(_: Canvas & Paintable) { ... }
+
+  render(Wall())
+  ```
+
+  Note that class-constrained protocol compositions can be written and
+  used in both Swift 3 and Swift 4 mode.
+
+  Generated headers for Swift APIs will map class-constrained protocol
+  compositions to Objective-C protocol-qualified class types in both
+  Swift 3 and Swift 4 mode (for instance, `NSSomeClass & SomeProto &
+  OtherProto` in Swift becomes `NSSomeClass <SomeProto, OtherProto>`
+  in Objective-C).
+
+  Objective-C APIs which use protocol-qualified class types differ in
+  behavior when imported by a module compiled in Swift 3 mode and
+  Swift 4 mode. In Swift 3 mode, these APIs will continue to import as
+  protocol compositions without a class constraint
+  (eg, `SomeProto & OtherProto`).
+
+  In Swift 4 mode, protocol-qualified class types import as
+  class-constrained protocol compositions, for a more faithful mapping
+  of APIs from Objective-C to Swift.
+
+  Note that the current implementation of class-constrained protocol
+  compositions lacks three features outlined in the Swift evolution proposal:
+
+  - In the evolution proposal, a class-constrained is permitted to contain
+    two different classes as long as one is a superclass of the other.
+    The current implementation only allows multiple classes to appear in
+    the composition if they are identical.
+
+  - In the evolution proposal, associated type and class inheritance clauses
+    are generalized to allow class-constrained protocol compositions. The
+    current implementation does not allow this.
+
+  - In the evolution proposal, protocol inheritance clauses are allowed to
+    contain a class, placing a requirement that all conforming types are
+    a subclass of the given class. The current implementation does not
+    allow this.
+
+  These missing aspects of the proposal can be introduced in a future
+  release without breaking source compatibility with existing code.
+
 * [SE-0142][]
 
   Protocols and associated types can now contain `where` clauses that

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -165,9 +165,6 @@ namespace swift {
     /// optimized custom allocator, so that memory debugging tools can be used.
     bool UseMalloc = false;
 
-    /// \brief Enable classes to appear in protocol composition types.
-    bool EnableExperimentalSubclassExistentials = false;
-
     /// \brief Enable experimental property behavior feature.
     bool EnableExperimentalPropertyBehaviors = false;
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -274,10 +274,6 @@ def enable_experimental_deserialization_recovery :
   Flag<["-"], "enable-experimental-deserialization-recovery">,
   HelpText<"Attempt to recover from missing xrefs (etc) in swiftmodules">;
 
-def enable_experimental_subclass_existentials : Flag<["-"],
-  "enable-experimental-subclass-existentials">,
-  HelpText<"Enable classes to appear in protocol composition types">;
-
 def enable_cow_existentials : Flag<["-"], "enable-cow-existentials">,
   HelpText<"Enable the copy-on-write existential implementation">;
 

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -883,10 +883,8 @@ namespace {
             } else {
               SmallVector<Type, 4> memberTypes;
 
-              if (Impl.SwiftContext.LangOpts.EnableExperimentalSubclassExistentials) {
-                if (auto superclassType = typeParam->getSuperclass())
-                  memberTypes.push_back(superclassType);
-              }
+              if (auto superclassType = typeParam->getSuperclass())
+                memberTypes.push_back(superclassType);
 
               for (auto protocolDecl : typeParam->getConformingProtocols())
                 memberTypes.push_back(protocolDecl->getDeclaredType());
@@ -1029,9 +1027,7 @@ namespace {
       // Swift 3 compatibility -- don't import subclass existentials
       if (!type->qual_empty() &&
           (importedType->isAnyObject() ||
-           (!Impl.SwiftContext.isSwiftVersion3() &&
-            Impl.SwiftContext.LangOpts.EnableExperimentalSubclassExistentials))) {
-
+           !Impl.SwiftContext.isSwiftVersion3())) {
         SmallVector<Type, 4> members;
         if (!importedType->isAnyObject())
           members.push_back(importedType);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -910,9 +910,6 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.EnableExperimentalKeyPaths |=
     Args.hasArg(OPT_enable_experimental_keypaths);
 
-  Opts.EnableExperimentalSubclassExistentials |=
-    Args.hasArg(OPT_enable_experimental_subclass_existentials);
-
   Opts.EnableClassResilience |=
     Args.hasArg(OPT_enable_class_resilience);
 

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3100,8 +3100,7 @@ Type TypeResolver::resolveCompositionType(CompositionTypeRepr *repr,
     if (!ty || ty->hasError()) return ty;
 
     auto nominalDecl = ty->getAnyNominal();
-    if (TC.Context.LangOpts.EnableExperimentalSubclassExistentials &&
-        nominalDecl && isa<ClassDecl>(nominalDecl)) {
+    if (nominalDecl && isa<ClassDecl>(nominalDecl)) {
       if (checkSuperclass(tyR->getStartLoc(), ty))
         continue;
 

--- a/stdlib/public/runtime/SwiftValue.h
+++ b/stdlib/public/runtime/SwiftValue.h
@@ -52,10 +52,10 @@ getValueFromSwiftValue(_SwiftValue *v);
 /// or nil if it is not.
 _SwiftValue *getAsSwiftValue(id object);
 
-/// Find conformances for SwiftValue to the given list of protocols.
+/// Find conformances for SwiftValue to the given existential type.
 ///
 /// Returns true if SwiftValue does conform to all the protocols.
-bool findSwiftValueConformances(const ProtocolDescriptorList &protocols,
+bool findSwiftValueConformances(const ExistentialTypeMetadata *existentialType,
                                 const WitnessTable **tablesBuffer);
 
 } // namespace swift

--- a/stdlib/public/runtime/SwiftValue.mm
+++ b/stdlib/public/runtime/SwiftValue.mm
@@ -213,8 +213,14 @@ _SwiftValue *swift::getAsSwiftValue(id object) {
 }
 
 bool
-swift::findSwiftValueConformances(const ProtocolDescriptorList &protocols,
+swift::findSwiftValueConformances(const ExistentialTypeMetadata *existentialType,
                                   const WitnessTable **tablesBuffer) {
+  // _SwiftValue never satisfies a superclass constraint.
+  if (existentialType->getSuperclassConstraint() != nullptr)
+    return false;
+
+  auto &protocols = existentialType->Protocols;
+
   Class cls = nullptr;
 
   // Note that currently we never modify tablesBuffer because

--- a/test/ClangImporter/objc_bridging_generics.swift
+++ b/test/ClangImporter/objc_bridging_generics.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -verify -enable-experimental-subclass-existentials -swift-version 4 %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -verify -swift-version 4 %s
 
 // REQUIRES: objc_interop
 

--- a/test/ClangImporter/objc_bridging_generics_swift3.swift
+++ b/test/ClangImporter/objc_bridging_generics_swift3.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -verify -enable-experimental-subclass-existentials -swift-version 3 %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -verify -swift-version 3 %s
 
 // REQUIRES: objc_interop
 

--- a/test/ClangImporter/subclass_existentials.swift
+++ b/test/ClangImporter/subclass_existentials.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify -o - -primary-file %s -swift-version 4 -enable-experimental-subclass-existentials
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify -o - -primary-file %s -swift-version 4
 
 // REQUIRES: objc_interop
 

--- a/test/ClangImporter/subclass_existentials_ir.swift
+++ b/test/ClangImporter/subclass_existentials_ir.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-ir -o - -primary-file %s -swift-version 4 -enable-experimental-subclass-existentials
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-ir -o - -primary-file %s -swift-version 4
 
 // REQUIRES: objc_interop
 

--- a/test/ClangImporter/subclass_existentials_swift3.swift
+++ b/test/ClangImporter/subclass_existentials_swift3.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify -o - -primary-file %s -enable-experimental-subclass-existentials -swift-version 3
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify -o - -primary-file %s -swift-version 3
 
 // REQUIRES: objc_interop
 

--- a/test/IRGen/objc_type_encoding.swift
+++ b/test/IRGen/objc_type_encoding.swift
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: %build-irgen-test-overlays
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) %s -emit-ir -disable-objc-attr-requires-foundation-module -enable-experimental-subclass-existentials | %FileCheck %s -check-prefix=CHECK-%target-os
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) %s -emit-ir -disable-objc-attr-requires-foundation-module | %FileCheck %s -check-prefix=CHECK-%target-os
 
 // REQUIRES: CPU=x86_64
 // REQUIRES: objc_interop

--- a/test/IRGen/subclass_existentials.sil
+++ b/test/IRGen/subclass_existentials.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -primary-file %s -emit-ir -enable-experimental-subclass-existentials | %FileCheck %s --check-prefix=CHECK-%target-runtime --check-prefix=CHECK
+// RUN: %target-swift-frontend -primary-file %s -emit-ir | %FileCheck %s --check-prefix=CHECK-%target-runtime --check-prefix=CHECK
 
 sil_stage canonical
 

--- a/test/IRGen/type_layout_reference_storage.swift
+++ b/test/IRGen/type_layout_reference_storage.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir -enable-experimental-subclass-existentials %s | %FileCheck %s --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir %s | %FileCheck %s --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK
 
 class C {}
 protocol P: class {}

--- a/test/IRGen/type_layout_reference_storage_objc.swift
+++ b/test/IRGen/type_layout_reference_storage_objc.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-ir %s -enable-experimental-subclass-existentials | %FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-ir %s | %FileCheck %s
 // REQUIRES: objc_interop
 
 import Foundation

--- a/test/Interpreter/subclass_existentials.swift
+++ b/test/Interpreter/subclass_existentials.swift
@@ -444,25 +444,23 @@ SubclassExistentialsTestSuite.test("Failing scalar downcast to subclass existent
   }
 }
 
-// FIXME
-
 SubclassExistentialsTestSuite.test("Failing dynamic downcast to subclass existential") {
   do {
     let baseInt: Base<Int> = Base<Int>(x: 123, y: 321)
 
-    //expectNil(cast(baseInt, to: ((Base<Int>) & P).self))
+    expectNil(cast(baseInt, to: ((Base<Int>) & P).self))
   }
 
   do {
     let r: R = Base<Int>(x: 123, y: 321)
 
-    //expectNil(cast(r, to: ((Base<Int>) & P).self))
+    expectNil(cast(r, to: ((Base<Int>) & P).self))
   }
 
   do {
     let conformsToP = ConformsToP(protocolInit: ())
 
-    //expectNil(cast(conformsToP, to: ((Base<Int>) & P).self))
+    expectNil(cast(conformsToP, to: ((Base<Int>) & P).self))
   }
 }
 

--- a/test/Interpreter/subclass_existentials.swift
+++ b/test/Interpreter/subclass_existentials.swift
@@ -16,6 +16,8 @@
 // RUN: %target-run %t/a.out
 // REQUIRES: executable_test
 //
+// XFAIL: swift_test_mode_optimize
+// XFAIL: swift_test_mode_optimize_unchecked
 
 import StdlibUnittest
 

--- a/test/Interpreter/subclass_existentials.swift
+++ b/test/Interpreter/subclass_existentials.swift
@@ -12,7 +12,7 @@
 //
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %target-build-swift %s -o %t/a.out -Xfrontend -enable-experimental-subclass-existentials
+// RUN: %target-build-swift %s -o %t/a.out
 // RUN: %target-run %t/a.out
 // REQUIRES: executable_test
 //

--- a/test/Interpreter/subclass_existentials.swift
+++ b/test/Interpreter/subclass_existentials.swift
@@ -163,12 +163,10 @@ SubclassExistentialsTestSuite.test("Metadata instantiation") {
 
 // FIXME: Not implemented yet
 
-/*
 SubclassExistentialsTestSuite.test("Metadata to string") {
   expectEqual("Base<Int> & P", String(describing: ((Base<Int>) & P).self))
   expectEqual("Base<Int> & P & Q", String(describing: ((Base<Int>) & P & Q).self))
 }
-*/
 
 SubclassExistentialsTestSuite.test("Call instance methods") {
   do {

--- a/test/Interpreter/subclass_existentials_objc.swift
+++ b/test/Interpreter/subclass_existentials_objc.swift
@@ -1,0 +1,58 @@
+//===--- subclass_existentials.swift --------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: %target-build-swift %s -o %t/a.out -Xfrontend -enable-experimental-subclass-existentials
+// RUN: %target-run %t/a.out
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+//
+
+import StdlibUnittest
+import Foundation
+
+// FIXME: Actually write proper tests here.
+
+func cast<T, U>(_ t: T, to: U.Type) -> U? {
+  return t as? U
+}
+
+protocol CP : class {}
+@objc protocol OP {}
+
+class C {}
+
+class D : C, OP {}
+
+var SubclassExistentialsTestSuite = TestSuite("SubclassExistentials")
+
+SubclassExistentialsTestSuite.test("Metatype self-conformance") {
+  expectFalse(CP.self is AnyObject.Type)
+  expectEqual(OP.self, OP.self as AnyObject.Type)
+
+  expectNil(cast(CP.self, to: AnyObject.Type.self))
+  // FIXME
+  expectNil(cast(OP.self, to: AnyObject.Type.self))
+
+  // FIXME: Sema says 'always true', runtime says false.
+  //
+  // Runtime code had a FIXME in it already, so I think Sema is right.
+  expectFalse(OP.self is AnyObject.Type)
+  expectFalse((C & OP).self is AnyObject.Type)
+  expectFalse((C & OP).self is OP.Type)
+
+  expectTrue(D.self is (C & OP).Type)
+  expectFalse(OP.self is (C & OP).Type)
+}
+
+runAllTests()

--- a/test/Interpreter/subclass_existentials_objc.swift
+++ b/test/Interpreter/subclass_existentials_objc.swift
@@ -12,7 +12,7 @@
 //
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %target-build-swift %s -o %t/a.out -Xfrontend -enable-experimental-subclass-existentials
+// RUN: %target-build-swift %s -o %t/a.out
 // RUN: %target-run %t/a.out
 // REQUIRES: executable_test
 // REQUIRES: objc_interop

--- a/test/PrintAsObjC/protocols.swift
+++ b/test/PrintAsObjC/protocols.swift
@@ -9,8 +9,8 @@
 // RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/Foundation.swift
 // FIXME: END -enable-source-import hackaround
 
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource) -I %t -emit-module -o %t %s -disable-objc-attr-requires-foundation-module -enable-experimental-subclass-existentials
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource) -I %t -parse-as-library %t/protocols.swiftmodule -typecheck -emit-objc-header-path %t/protocols.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module -enable-experimental-subclass-existentials
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource) -I %t -emit-module -o %t %s -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource) -I %t -parse-as-library %t/protocols.swiftmodule -typecheck -emit-objc-header-path %t/protocols.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module
 // RUN: %FileCheck %s < %t/protocols.h
 // RUN: %FileCheck --check-prefix=NEGATIVE %s < %t/protocols.h
 // RUN: %check-in-clang %t/protocols.h

--- a/test/SILGen/subclass_existentials.swift
+++ b/test/SILGen/subclass_existentials.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -emit-silgen -parse-as-library -enable-experimental-subclass-existentials -primary-file %s -verify | %FileCheck %s
-// RUN: %target-swift-frontend -emit-ir -parse-as-library -enable-experimental-subclass-existentials -primary-file %s
+// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -emit-silgen -parse-as-library -primary-file %s -verify | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir -parse-as-library -primary-file %s
 
 // Note: we pass -verify above to ensure there are no spurious
 // compiler warnings relating to casts.

--- a/test/type/subclass_composition.swift
+++ b/test/type/subclass_composition.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-subclass-existentials
+// RUN: %target-typecheck-verify-swift
 
 protocol P1 {
   typealias DependentInConcreteConformance = Self

--- a/test/type/subclass_composition_objc.swift
+++ b/test/type/subclass_composition_objc.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-subclass-existentials -disable-objc-attr-requires-foundation-module
+// RUN: %target-typecheck-verify-swift -disable-objc-attr-requires-foundation-module
 
 @objc class ObjCClass {}
 @objc protocol ObjCProtocol {}

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -2622,8 +2622,6 @@ static int doReconstructType(const CompilerInvocation &InitInvok,
   CompilerInvocation Invocation(InitInvok);
   Invocation.addInputFilename(SourceFilename);
   Invocation.getLangOptions().DisableAvailabilityChecking = false;
-  // This is temporary
-  Invocation.getLangOptions().EnableExperimentalSubclassExistentials = true;
 
   CompilerInstance CI;
 


### PR DESCRIPTION
Good enough for preliminary testing. Work that still remains:

- The execution tests uncovered an unrelated optimizer bug (rdar://problem/31879356)
- The SIL optimizer's devirtualization logic needs some small fixes to be able to devirtualize class methods on a subclass existential
- Reflection, RemoteAST support for subclass existentials
- Ripping out AnyObject
- Class-constrained protocol composition types in associated type inheritance clauses
- Protocols with superclass constraints on the conforming type

Fixes <rdar://problem/23582191> and <https://bugs.swift.org/browse/SR-4296>.