### PR TITLE
Re-enable Lazy test.

### DIFF
--- a/validation-test/stdlib/Lazy.swift.gyb
+++ b/validation-test/stdlib/Lazy.swift.gyb
@@ -12,9 +12,6 @@
 // RUN: %target-run-simple-swiftgyb
 // REQUIRES: executable_test
 
-// Disabled for now
-// REQUIRES: rdar://problem/31780356
-
 import StdlibUnittest
 import StdlibCollectionUnittest
 


### PR DESCRIPTION
This was fixed by the recent fix for getConformanceAndConcreteType()'s
creation of substitution maps, PR #9053. Fixes rdar://problem/31780356.
