### PR TITLE
[Type checker] Warn about unavailable witnesses used to satisfy a requirement

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1533,6 +1533,10 @@ NOTE(declared_protocol_conformance_here,none,
      "%0 implicitly conforms to protocol %2}1 here",
      (Type, unsigned, DeclName, DeclName))
 
+WARNING(witness_unavailable,none,
+        "unavailable %0 %1 was used to satisfy a requirement of protocol %2",
+        (DescriptiveDeclKind, DeclName, DeclName))
+
 ERROR(redundant_conformance,none,
       "redundant conformance of %0 to protocol %1", (Type, DeclName))
 

--- a/test/decl/protocol/req/unavailable.swift
+++ b/test/decl/protocol/req/unavailable.swift
@@ -23,3 +23,13 @@ class Bar : NonObjCProto { // expected-error {{type 'Bar' does not conform to pr
   func good() {}
 }
 
+
+// Warn about unavailable witnesses.
+protocol P {
+  func foo(bar: Foo) // expected-note{{requirement 'foo(bar:)' declared here}}
+}
+
+struct ConformsToP : P {
+  @available(*, unavailable)
+  func foo(bar: Foo) { } // expected-warning{{unavailable instance method 'foo(bar:)' was used to satisfy a requirement of protocol 'P'}}
+}


### PR DESCRIPTION
Fixes rdar://problem/30933490 in the most conservative way, by warning when an unavailable witness is used to satisfy a requirement. Anything more (error in Swift 4 mode, changing the preference rules) would be require an evolution discussion that I don't want to open right now.