### PR TITLE
Primitive AnyObject fixes

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -21,6 +21,7 @@
 #include "swift/AST/ASTWalker.h"
 #include "swift/AST/DiagnosticEngine.h"
 #include "swift/AST/DiagnosticsSema.h"
+#include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/Expr.h"
 #include "swift/AST/ForeignErrorConvention.h"
 #include "swift/AST/GenericEnvironment.h"
@@ -2842,25 +2843,28 @@ bool ProtocolDecl::inheritsFrom(const ProtocolDecl *super) const {
 }
 
 bool ProtocolDecl::requiresClassSlow() {
-  ProtocolDeclBits.RequiresClass =
-    walkInheritedProtocols([&](ProtocolDecl *proto) {
-      // If the 'requires class' bit is valid, we don't need to search any
-      // further.
-      if (proto->ProtocolDeclBits.RequiresClassValid) {
-        // If this protocol has a class requirement, we're done.
-        if (proto->ProtocolDeclBits.RequiresClass)
-          return TypeWalker::Action::Stop;
+  // Set this first to catch (invalid) circular inheritance.
+  ProtocolDeclBits.RequiresClassValid = true;
 
-        return TypeWalker::Action::SkipChildren;
+  // Quick check: @objc protocols require a class.
+  if (isObjC()) {
+    ProtocolDeclBits.RequiresClass = true;
+    return true;
+  }
+
+  // Otherwise, check if the inheritance clause contains a
+  // class-constrained existential.
+  //
+  // FIXME: Use the requirement signature if available.
+  ProtocolDeclBits.RequiresClass = false;
+  for (auto inherited : getInherited()) {
+    if (auto type = inherited.getType()) {
+      if (type->isExistentialType()) {
+        auto layout = type->getExistentialLayout();
+        ProtocolDeclBits.RequiresClass |= layout.requiresClass;
       }
-
-      // Quick check: @objc indicates that it requires a class.
-      if (proto->getAttrs().hasAttribute<ObjCAttr>() || proto->isObjC())
-        return TypeWalker::Action::Stop;
-
-      // Keep looking.
-      return TypeWalker::Action::Continue;
-    });
+    }
+  }
 
   return ProtocolDeclBits.RequiresClass;
 }

--- a/lib/AST/LookupVisibleDecls.cpp
+++ b/lib/AST/LookupVisibleDecls.cpp
@@ -471,11 +471,6 @@ static void lookupVisibleProtocolMemberDecls(
     Type BaseTy, ProtocolType *PT, VisibleDeclConsumer &Consumer,
     const DeclContext *CurrDC, LookupState LS, DeclVisibilityKind Reason,
     LazyResolver *TypeResolver, VisitedSet &Visited) {
-  if (PT->getDecl()->isSpecificProtocol(KnownProtocolKind::AnyObject)) {
-    // Handle AnyObject in a special way.
-    doDynamicLookup(Consumer, CurrDC, LS, TypeResolver);
-    return;
-  }
   if (!Visited.insert(PT->getDecl()).second)
     return;
 
@@ -524,6 +519,12 @@ static void lookupVisibleMemberDeclsImpl(
     MT->getModule()->lookupVisibleDecls(ModuleDecl::AccessPathTy(),
                                         FilteringConsumer,
                                         NLKind::QualifiedLookup);
+    return;
+  }
+
+  // If the base is AnyObject, we are doing dynamic lookup.
+  if (BaseTy->isAnyObject()) {
+    doDynamicLookup(Consumer, CurrDC, LS, TypeResolver);
     return;
   }
 

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1264,24 +1264,21 @@ resolveTopLevelIdentTypeComponent(TypeChecker &TC, DeclContext *DC,
     if (!type)
       return type;
 
-    auto hasError = type->hasError();
+    if (type->is<ErrorType>())
+      return type;
+
     if (options & TR_NonEnumInheritanceClauseOuterLayer) {
       auto protocolOrClass =
-          hasError ? (isa<ProtocolDecl>(typeDecl) || isa<ClassDecl>(typeDecl))
-                   : (type->is<ProtocolType>() || type->is<ClassType>());
+        (type->is<ProtocolType>() ||
+         type->is<ClassType>() ||
+         type->isAnyObject());
       if (!protocolOrClass) {
-        auto diagnosedType = hasError ? typeDecl->getDeclaredInterfaceType() : type;
-        if (diagnosedType && /*FIXME:*/!hasError) {
-          TC.diagnose(comp->getIdLoc(),
-                      diag::inheritance_from_non_protocol_or_class,
-                      diagnosedType);
-          return ErrorType::get(diagnosedType);
-        }
+        TC.diagnose(comp->getIdLoc(),
+                    diag::inheritance_from_non_protocol_or_class,
+                    type);
+        return ErrorType::get(type);
       }
     }
-
-    if (hasError)
-      return type;
 
     // If this is the first result we found, record it.
     if (current.isNull()) {
@@ -1530,7 +1527,9 @@ static Type resolveNestedIdentTypeComponent(
 
   if (options & TR_NonEnumInheritanceClauseOuterLayer) {
     auto protocolOrClass =
-        memberType->is<ProtocolType>() || memberType->is<ClassType>();
+        memberType->is<ProtocolType>() ||
+        memberType->is<ClassType>() ||
+        memberType->isAnyObject();
     if (!protocolOrClass) {
       TC.diagnose(comp->getIdLoc(),
                   diag::inheritance_from_non_protocol_or_class, memberType);


### PR DESCRIPTION
Now that SE-0156 has landed, it's time to remove protocol AnyObject. This PR just has a few updates to ensure we correctly handle non-protocol AnyObject in a couple of places, enough to build the standard library and overlays with protocol AnyObject removed.

Until protocol AnyObject is actually removed, this is just a no-op.