### PR TITLE
Remove AnyObject protocol once and for all

### DIFF
--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -226,10 +226,8 @@ enum class SpecialProtocol: uint8_t {
   ///
   /// This must be 0 for ABI compatibility with Objective-C protocol_t records.
   None = 0,
-  /// The AnyObject protocol.
-  AnyObject = 1,
   /// The Error protocol.
-  Error = 2,
+  Error = 1,
 };
 
 /// Identifiers for protocol method dispatch strategies.
@@ -244,10 +242,6 @@ enum class ProtocolDispatchStrategy: uint8_t {
   /// To invoke methods of this protocol, a pointer to a protocol witness table
   /// corresponding to the protocol conformance must be available.
   Swift = 1,
-  
-  /// The protocol guarantees that it has no methods to dispatch. It requires
-  /// neither Objective-C metadata nor a witness table.
-  Empty = 2,
 };
 
 /// Flags in a generic nominal type descriptor.
@@ -375,7 +369,6 @@ public:
   static bool needsWitnessTable(ProtocolDispatchStrategy strategy) {
     switch (strategy) {
     case ProtocolDispatchStrategy::ObjC:
-    case ProtocolDispatchStrategy::Empty:
       return false;
     case ProtocolDispatchStrategy::Swift:
       return true;

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1301,8 +1301,6 @@ ERROR(extension_protocol_inheritance,none,
 ERROR(extension_protocol_via_typealias,none,
       "protocol %0 in the module being compiled cannot be extended via a "
       "type alias", (Type))
-ERROR(extension_anyobject,none,
-      "'AnyObject' protocol cannot be extended", ())
 ERROR(objc_generic_extension_using_type_parameter,none,
       "extension of a generic Objective-C class cannot access the class's "
       "generic parameters at runtime", ())

--- a/include/swift/AST/ExistentialLayout.h
+++ b/include/swift/AST/ExistentialLayout.h
@@ -28,8 +28,7 @@ namespace swift {
 
 struct ExistentialLayout {
   ExistentialLayout() {
-    requiresClass = false;
-    requiresClassImplied = false;
+    hasExplicitAnyObject = false;
     containsNonObjCProtocol = false;
     singleProtocol = nullptr;
   }
@@ -40,13 +39,8 @@ struct ExistentialLayout {
   /// The superclass constraint, if any.
   Type superclass;
 
-  /// Whether the existential requires a class, either via an explicit
-  /// '& AnyObject' member or because of a superclass or protocol constraint.
-  bool requiresClass : 1;
-
-  /// Whether the class constraint was implied by another constraint and therefore
-  /// does not need to be stated explicitly.
-  bool requiresClassImplied : 1;
+  /// Whether the existential contains an explicit '& AnyObject' constraint.
+  bool hasExplicitAnyObject : 1;
 
   /// Whether any protocol members are non-@objc.
   bool containsNonObjCProtocol : 1;
@@ -55,8 +49,15 @@ struct ExistentialLayout {
 
   bool isObjC() const {
     // FIXME: Does the superclass have to be @objc?
-    return requiresClass && !containsNonObjCProtocol;
+    return ((superclass ||
+             hasExplicitAnyObject ||
+             getProtocols().size() > 0)
+            && !containsNonObjCProtocol);
   }
+
+  /// Whether the existential requires a class, either via an explicit
+  /// '& AnyObject' member or because of a superclass or protocol constraint.
+  bool requiresClass() const;
 
   // Does this existential contain the Error protocol?
   bool isExistentialWithError(ASTContext &ctx) const;

--- a/include/swift/AST/KnownProtocols.def
+++ b/include/swift/AST/KnownProtocols.def
@@ -50,7 +50,6 @@
 
 PROTOCOL(Sequence)
 PROTOCOL(IteratorProtocol)
-PROTOCOL(AnyObject)
 PROTOCOL(RawRepresentable)
 PROTOCOL(Equatable)
 PROTOCOL(Hashable)

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -682,18 +682,6 @@ CanType ASTContext::getAnyObjectType() const {
     return Impl.AnyObjectType;
   }
 
-  // Go find 'AnyObject' in the Swift module.
-  //
-  // FIXME: This is going away.
-  SmallVector<ValueDecl *, 1> results;
-  lookupInSwiftModule("AnyObject", results);
-  for (auto result : results) {
-    if (auto proto = dyn_cast<ProtocolDecl>(result)) {
-      Impl.AnyObjectType = proto->getDeclaredType()->getCanonicalType();
-      return Impl.AnyObjectType;
-    }
-  }
-
   Impl.AnyObjectType = CanType(
     ProtocolCompositionType::get(
       *this, {}, /*HasExplicitAnyObject=*/true));

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -680,7 +680,7 @@ void ASTMangler::appendType(Type type) {
       if (layout.superclass) {
         appendType(layout.superclass);
         return appendOperator("Xc");
-      } else if (layout.requiresClass & !layout.requiresClassImplied) {
+      } else if (layout.hasExplicitAnyObject) {
         return appendOperator("Xl");
       }
       return appendOperator("p");

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2048,11 +2048,6 @@ void PrintAST::printInherited(const Decl *decl,
   if (inherited.empty() && superclass.isNull() && !explicitClass) {
     if (protos.empty())
       return;
-    // If only conforms to AnyObject protocol, nothing to print.
-    if (protos.size() == 1) {
-      if (protos.front()->isSpecificProtocol(KnownProtocolKind::AnyObject))
-        return;
-    }
   }
 
   if (inherited.empty()) {
@@ -2076,8 +2071,6 @@ void PrintAST::printInherited(const Decl *decl,
 
     for (auto Proto : protos) {
       if (!shouldPrint(Proto))
-        continue;
-      if (Proto->isSpecificProtocol(KnownProtocolKind::AnyObject))
         continue;
       if (auto Enum = dyn_cast<EnumDecl>(decl)) {
         // Conformance to RawRepresentable is implied by having a raw type.

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2919,9 +2919,6 @@ bool ProtocolDecl::existentialConformsToSelfSlow() {
   ProtocolDeclBits.ExistentialConformsToSelfValid = true;
   ProtocolDeclBits.ExistentialConformsToSelf = true;
 
-  if (isSpecificProtocol(KnownProtocolKind::AnyObject))
-    return true;
-
   if (!isObjC()) {
     ProtocolDeclBits.ExistentialConformsToSelf = false;
     return false;

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -322,8 +322,19 @@ static bool isInterestingTypealias(Type type) {
     return false;
   if (type->is<BuiltinType>())
     return false;
+
+  auto underlyingTy = aliasTy->getDecl()->getUnderlyingTypeLoc().getType();
+
+  // A typealias that directly points at Builtin.AnyObject is not
+  // 'interesting', since it is in fact the AnyObject typealias in
+  // the standard library.
+  if (underlyingTy->isAnyObject() &&
+      isa<ProtocolCompositionType>(underlyingTy.getPointer()))
+    return false;
+
   if (aliasTy->getDecl()->isCompatibilityAlias())
-    return isInterestingTypealias(aliasTy->getSinglyDesugaredType());
+    return isInterestingTypealias(underlyingTy);
+
   return true;
 }
 

--- a/lib/AST/LayoutConstraint.cpp
+++ b/lib/AST/LayoutConstraint.cpp
@@ -60,7 +60,7 @@ StringRef LayoutConstraintInfo::getName(LayoutConstraintKind Kind) {
   case LayoutConstraintKind::UnknownLayout:
     return "_UnknownLayout";
   case LayoutConstraintKind::Class:
-    return "_Class";
+    return "AnyObject";
   case LayoutConstraintKind::NativeClass:
     return "_NativeClass";
   case LayoutConstraintKind::RefCountedObject:

--- a/lib/AST/LookupVisibleDecls.cpp
+++ b/lib/AST/LookupVisibleDecls.cpp
@@ -471,11 +471,6 @@ static void lookupVisibleProtocolMemberDecls(
     Type BaseTy, ProtocolType *PT, VisibleDeclConsumer &Consumer,
     const DeclContext *CurrDC, LookupState LS, DeclVisibilityKind Reason,
     LazyResolver *TypeResolver, VisitedSet &Visited) {
-  if (PT->getDecl()->isSpecificProtocol(KnownProtocolKind::AnyObject)) {
-    // Handle AnyObject in a special way.
-    doDynamicLookup(Consumer, CurrDC, LS, TypeResolver);
-    return;
-  }
   if (!Visited.insert(PT->getDecl()).second)
     return;
 
@@ -524,6 +519,12 @@ static void lookupVisibleMemberDeclsImpl(
     MT->getModule()->lookupVisibleDecls(ModuleDecl::AccessPathTy(),
                                         FilteringConsumer,
                                         NLKind::QualifiedLookup);
+    return;
+  }
+
+  // If the base is AnyObject, we are doing dynamic lookup.
+  if (BaseTy->isAnyObject()) {
+    doDynamicLookup(Consumer, CurrDC, LS, TypeResolver);
     return;
   }
 

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -587,14 +587,6 @@ ModuleDecl::lookupConformance(Type type, ProtocolDecl *protocol,
       }
     }
 
-    // FIXME: This will go away soon.
-    if (protocol->isSpecificProtocol(KnownProtocolKind::AnyObject)) {
-      if (archetype->requiresClass())
-        return ProtocolConformanceRef(protocol);
-
-      return None;
-    }
-
     for (auto ap : archetype->getConformsTo()) {
       if (ap == protocol || ap->inheritsFrom(protocol))
         return ProtocolConformanceRef(protocol);
@@ -620,12 +612,6 @@ ModuleDecl::lookupConformance(Type type, ProtocolDecl *protocol,
     // @objc protocols.
     if (!layout.isObjC())
       return None;
-
-    // Special-case AnyObject, which may not be in the list of conformances.
-    //
-    // FIXME: This is going away soon.
-    if (protocol->isSpecificProtocol(KnownProtocolKind::AnyObject))
-      return ProtocolConformanceRef(protocol);
 
     // If the existential is class-constrained, the class might conform
     // concretely.

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1389,17 +1389,6 @@ bool DeclContext::lookupQualified(Type type,
   if (auto nominal = type->getAnyNominal()) {
     visited.insert(nominal);
     stack.push_back(nominal);
-    
-    // If we want dynamic lookup and we're searching in the
-    // AnyObject protocol, note this for later.
-    //
-    // FIXME: This will go away soon.
-    if (options & NL_DynamicLookup) {
-      if (auto proto = dyn_cast<ProtocolDecl>(nominal)) {
-        if (proto->isSpecificProtocol(KnownProtocolKind::AnyObject))
-          wantLookupInAllClasses = true;
-      }
-    }
   }
   // Handle archetypes
   else if (auto archetypeTy = type->getAs<ArchetypeType>()) {

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -122,44 +122,11 @@ ProtocolConformanceRef::subst(Type origType,
 
   auto *proto = getRequirement();
 
-  // If the original type was an archetype, check the conformance map.
-  if (origType->is<SubstitutableType>()
-      || origType->is<DependentMemberType>()) {
-    if (auto result = conformances(origType->getCanonicalType(),
-                                   substType,
-                                   proto->getDeclaredType())) {
-      return *result;
-    }
-  }
-
-  // If that didn't find anything, we can still synthesize AnyObject
-  // conformances from thin air.  FIXME: this is going away soon.
-  if (proto->isSpecificProtocol(KnownProtocolKind::AnyObject)) {
-    if (substType->isExistentialType())
-      return *this;
-
-    ClassDecl *classDecl = nullptr;
-    auto archetype = substType->getAs<ArchetypeType>();
-
-    if (archetype) {
-      if (archetype->getSuperclass())
-        classDecl = archetype->getSuperclass()->getClassOrBoundGenericClass();
-
-      // A class-constrained archetype without a superclass constraint
-      // conforms to AnyObject abstractly.
-      if (!classDecl && archetype->requiresClass())
-        return ProtocolConformanceRef(proto);
-    } else {
-      classDecl = substType->getClassOrBoundGenericClass();
-    }
-
-    assert(classDecl);
-
-    // Create a concrete conformance based on the conforming class.
-    SmallVector<ProtocolConformance *, 1> lookupResults;
-    classDecl->lookupConformance(classDecl->getParentModule(), proto,
-                                 lookupResults);
-    return ProtocolConformanceRef(lookupResults.front());
+  // Check the conformance map.
+  if (auto result = conformances(origType->getCanonicalType(),
+                                 substType,
+                                 proto->getDeclaredType())) {
+    return *result;
   }
 
   llvm_unreachable("Invalid conformance substitution");
@@ -886,13 +853,7 @@ void NominalTypeDecl::prepareConformanceTable() const {
   }
 
   // Add any synthesized conformances.
-  if (isa<ClassDecl>(this)) {
-    // FIXME: This is going away soon.
-    if (auto anyObject = getASTContext().getProtocol(
-                           KnownProtocolKind::AnyObject)) {
-      ConformanceTable->addSynthesizedConformance(mutableThis, anyObject);
-    }
-  } else if (auto theEnum = dyn_cast<EnumDecl>(mutableThis)) {
+  if (auto theEnum = dyn_cast<EnumDecl>(mutableThis)) {
     if (theEnum->hasCases() && theEnum->hasOnlyCasesWithoutAssociatedValues()) {
       // Simple enumerations conform to Equatable.
       if (auto equatable = ctx.getProtocol(KnownProtocolKind::Equatable)) {

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -194,13 +194,6 @@ SubstitutionMap::lookupConformance(CanType type, ProtocolDecl *proto) const {
   auto genericSig = getGenericSignature();
   auto &mod = *proto->getModuleContext();
 
-  // HACK: Deal with AnyObject conformances, which get magically dropped in
-  // frustrating ways.
-  // FIXME: This hack dies with AnyObject-as-a-protocol.
-  if (proto->isSpecificProtocol(KnownProtocolKind::AnyObject) &&
-      genericSig->requiresClass(type, mod))
-    return ProtocolConformanceRef(proto);
-
   // If the type doesn't conform to this protocol, fail.
   if (!genericSig->conformsToProtocol(type, proto, mod))
     return None;
@@ -458,9 +451,8 @@ void SubstitutionMap::verify() const {
       // AnyObject or an @objc protocol.
       if (citer->isAbstract() && replacement->isExistentialType()) {
         auto *proto = citer->getRequirement();
-        assert((proto->isSpecificProtocol(KnownProtocolKind::AnyObject) ||
-                proto->isObjC()) &&
-               "an existential type can conform only to AnyObject or an "
+        assert(proto->isObjC() &&
+               "an existential type can conform only to an "
                "@objc-protocol");
         continue;
       }

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -229,9 +229,7 @@ ExistentialLayout::ExistentialLayout(ProtocolType *type) {
   auto *protoDecl = type->getDecl();
 
   hasExplicitAnyObject = false;
-  containsNonObjCProtocol =
-    !(protoDecl->isSpecificProtocol(KnownProtocolKind::AnyObject) ||
-      protoDecl->isObjC());
+  containsNonObjCProtocol = !protoDecl->isObjC();
 
   singleProtocol = type;
 }
@@ -251,9 +249,7 @@ ExistentialLayout::ExistentialLayout(ProtocolCompositionType *type) {
 
   for (auto member : members) {
     auto *protoDecl = member->castTo<ProtocolType>()->getDecl();
-    containsNonObjCProtocol |=
-      !(protoDecl->isSpecificProtocol(KnownProtocolKind::AnyObject) ||
-        protoDecl->isObjC());
+    containsNonObjCProtocol |= !protoDecl->isObjC();
   }
 
   singleProtocol = nullptr;
@@ -289,14 +285,7 @@ bool ExistentialLayout::requiresClass() const {
 }
 
 bool ExistentialLayout::isAnyObject() const {
-  // New implementation
-  auto protocols = getProtocols();
-  if (hasExplicitAnyObject && !superclass && protocols.empty())
-    return true;
-
-  // Old implementation -- FIXME: remove this
-  return protocols.size() == 1 &&
-    protocols[0]->getDecl()->isSpecificProtocol(KnownProtocolKind::AnyObject);
+  return (hasExplicitAnyObject && !superclass && getProtocols().empty());
 }
 
 bool TypeBase::isObjCExistentialType() {

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -889,16 +889,20 @@ Type TypeBase::getRValueInstanceType() {
 
 /// \brief Collect the protocols in the existential type T into the given
 /// vector.
-static void addProtocols(Type T, SmallVectorImpl<ProtocolDecl *> &Protocols,
-                         Type &Superclass) {
+static void addProtocols(Type T,
+                         SmallVectorImpl<ProtocolDecl *> &Protocols,
+                         Type &Superclass,
+                         bool &HasExplicitAnyObject) {
   if (auto Proto = T->getAs<ProtocolType>()) {
     Protocols.push_back(Proto->getDecl());
     return;
   }
 
   if (auto PC = T->getAs<ProtocolCompositionType>()) {
+    if (PC->hasExplicitAnyObject())
+      HasExplicitAnyObject = true;
     for (auto P : PC->getMembers())
-      addProtocols(P, Protocols, Superclass);
+      addProtocols(P, Protocols, Superclass, HasExplicitAnyObject);
     return;
   }
 
@@ -2780,11 +2784,15 @@ Type ProtocolCompositionType::get(const ASTContext &C,
   Type Superclass;
   SmallVector<ProtocolDecl *, 4> Protocols;
   for (Type t : Members) {
-    addProtocols(t, Protocols, Superclass);
+    addProtocols(t, Protocols, Superclass, HasExplicitAnyObject);
   }
   
   // Minimize the set of protocols composed together.
   ProtocolType::canonicalizeProtocols(Protocols);
+
+  // The presence of a superclass constraint makes AnyObject redundant.
+  if (Superclass)
+    HasExplicitAnyObject = false;
 
   // If one protocol remains with no further constraints, its nominal
   // type is the canonical type.
@@ -2803,8 +2811,7 @@ Type ProtocolCompositionType::get(const ASTContext &C,
                  });
 
   // TODO: Canonicalize away HasExplicitAnyObject if it is implied
-  // by one of our member protocols or the presence of a superclass
-  // constraint.
+  // by one of our member protocols.
   return build(C, CanTypes, HasExplicitAnyObject);
 }
 

--- a/lib/AST/USRGeneration.cpp
+++ b/lib/AST/USRGeneration.cpp
@@ -150,11 +150,6 @@ static bool shouldUseObjCUSR(const Decl *D) {
     return false;
 
   if (const ValueDecl *VD = dyn_cast<ValueDecl>(D)) {
-    if (auto *PD = dyn_cast<ProtocolDecl>(D))
-      if (auto known = PD->getKnownProtocolKind())
-        if (known == KnownProtocolKind::AnyObject)
-          return false;
-
     if (isa<EnumElementDecl>(VD))
       return true;
     return objc_translation::isVisibleToObjC(VD, Accessibility::Internal);

--- a/lib/IRGen/GenCast.cpp
+++ b/lib/IRGen/GenCast.cpp
@@ -533,15 +533,6 @@ void irgen::emitScalarExistentialDowncast(IRGenFunction &IGF,
     // to check for it independent of protocol witnesses.
     if (protoDecl->requiresClass()) {
       assert(hasClassConstraint);
-
-      if (protoDecl->getKnownProtocolKind()
-          && *protoDecl->getKnownProtocolKind() == KnownProtocolKind::AnyObject) {
-        // AnyObject only requires that the type be a class.
-        continue;
-      }
-      
-      // If this protocol is class-constrained but not AnyObject, checking its
-      // conformance will check the class constraint too.
       hasClassConstraintByProtocol = true;
     }
 

--- a/lib/IRGen/GenCast.cpp
+++ b/lib/IRGen/GenCast.cpp
@@ -521,7 +521,7 @@ void irgen::emitScalarExistentialDowncast(IRGenFunction &IGF,
   SmallVector<llvm::Value*, 4> objcProtos;
   SmallVector<llvm::Value*, 4> witnessTableProtos;
 
-  bool hasClassConstraint = layout.requiresClass;
+  bool hasClassConstraint = layout.requiresClass();
   bool hasClassConstraintByProtocol = false;
 
   bool hasSuperclassConstraint = bool(layout.superclass);

--- a/lib/IRGen/GenClangType.cpp
+++ b/lib/IRGen/GenClangType.cpp
@@ -350,10 +350,6 @@ clang::CanQualType GenClangType::visitTupleType(CanTupleType type) {
 clang::CanQualType GenClangType::visitProtocolType(CanProtocolType type) {
   auto proto = type->getDecl();
 
-  // AnyObject -> id.
-  if (proto->isSpecificProtocol(KnownProtocolKind::AnyObject))
-    return getClangIdType(getClangASTContext());
-
   // Single protocol -> id<Proto>
   if (proto->isObjC()) {
     auto &clangCtx = getClangASTContext();
@@ -606,6 +602,10 @@ clang::CanQualType GenClangType::visitProtocolCompositionType(
   SmallVector<const clang::ObjCProtocolDecl *, 4> Protocols;
   auto layout = type.getExistentialLayout();
   assert(layout.isObjC() && "Cannot represent opaque existential in Clang");
+
+  // AnyObject -> id.
+  if (layout.isAnyObject())
+    return getClangIdType(getClangASTContext());
 
   auto superclassTy = clangCtx.ObjCBuiltinIdTy;
   if (layout.superclass) {

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -1123,10 +1123,6 @@ namespace {
       for (ProtocolDecl *p : theProtocol->getInheritedProtocols()) {
         if (!p->isObjC())
           continue;
-        // Don't emit the magic AnyObject conformance.
-        if (auto known = p->getKnownProtocolKind())
-          if (*known == KnownProtocolKind::AnyObject)
-            continue;
         Protocols.push_back(p);
       }
 
@@ -1146,11 +1142,6 @@ namespace {
       }
 
       for (ProtocolDecl *proto : protocols) {
-        // Don't emit the magic AnyObject conformance.
-        if (auto known = proto->getKnownProtocolKind())
-          if (*known == KnownProtocolKind::AnyObject)
-            continue;
-
         Protocols.push_back(proto);
       }
     }

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -742,11 +742,6 @@ hasExplicitProtocolConformance(NominalTypeDecl *decl) {
     if (P->isObjC())
       continue;
 
-    // neither does AnyObject
-    if (P->getKnownProtocolKind().hasValue() &&
-        *P->getKnownProtocolKind() == KnownProtocolKind::AnyObject)
-      continue;
-
     return true;
   }
 

--- a/lib/IRGen/GenExistential.cpp
+++ b/lib/IRGen/GenExistential.cpp
@@ -1418,7 +1418,7 @@ static const TypeInfo *createExistentialTypeInfo(IRGenModule &IGM, CanType T) {
 
   // If the existential is class, lower it to a class
   // existential representation.
-  if (layout.requiresClass) {
+  if (layout.requiresClass()) {
     // If we're not using the Objective-C runtime, we can use the
     // native reference counting entry points.
     ReferenceCounting refcounting = getReferenceCountingForType(IGM, T);

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -951,7 +951,7 @@ namespace {
       // Note: ProtocolClassConstraint::Class is 0, ::Any is 1.
       auto classConstraint =
         llvm::ConstantInt::get(IGF.IGM.Int1Ty,
-                               !layout.requiresClass);
+                               !layout.requiresClass());
       llvm::Value *superclassConstraint =
         llvm::ConstantPointerNull::get(IGF.IGM.TypeMetadataPtrTy);
       if (layout.superclass) {

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -5497,8 +5497,6 @@ SpecialProtocol irgen::getSpecialProtocolID(ProtocolDecl *P) {
   if (!known)
     return SpecialProtocol::None;
   switch (*known) {
-  case KnownProtocolKind::AnyObject:
-    return SpecialProtocol::AnyObject;
   case KnownProtocolKind::Error:
     return SpecialProtocol::Error;
     

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -993,11 +993,6 @@ void IRGenModule::emitFieldMetadataRecord(const NominalTypeDecl *Decl) {
   FieldTypeMetadataBuilder builder(*this, Decl);
   builder.emit();
 
-  // So that -parse-stdlib tests don't need to define an AnyObject
-  // protocol (which will go away one day anyway).
-  if (!Context.getProtocol(KnownProtocolKind::AnyObject))
-    return;
-
   // If this is a class declaration with a superclass, record the
   // superclass as a special associated type named 'super' on the
   // 'AnyObject' protocol.

--- a/lib/Parse/ParseSIL.cpp
+++ b/lib/Parse/ParseSIL.cpp
@@ -1538,7 +1538,7 @@ collectExistentialConformances(Parser &P, CanType conformingType, SourceLoc loc,
                                CanType protocolType) {
   auto layout = protocolType.getExistentialLayout();
 
-  if (layout.requiresClass) {
+  if (layout.requiresClass()) {
     if (!conformingType->mayHaveSuperclass() &&
         !conformingType->isObjCExistentialType()) {
       P.diagnose(loc, diag::sil_not_class, conformingType);

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -53,8 +53,7 @@ static bool isNSObjectOrAnyHashable(ASTContext &ctx, Type type) {
            classDecl->getModuleContext()->getName() == ctx.Id_ObjectiveC;
   }
   if (auto nomDecl = type->getAnyNominal()) {
-    return nomDecl->getName() == ctx.getIdentifier("AnyHashable") &&
-      nomDecl->getModuleContext() == ctx.getStdlibModule();
+    return nomDecl == ctx.getAnyHashableDecl();
   }
 
   return false;
@@ -1996,7 +1995,8 @@ public:
 
     if (otherModule == &M)
       return false;
-    if (otherModule->isStdlibModule())
+    if (otherModule->isStdlibModule() ||
+        otherModule->isBuiltinModule())
       return true;
     // Don't need a module for SIMD types in C.
     if (otherModule->getName() == M.getASTContext().Id_simd)

--- a/lib/SIL/SILType.cpp
+++ b/lib/SIL/SILType.cpp
@@ -506,7 +506,7 @@ SILType::getPreferredExistentialRepresentation(SILModule &M,
 
   // A class-constrained protocol composition can adopt the conforming
   // class reference directly.
-  if (layout.requiresClass)
+  if (layout.requiresClass())
     return ExistentialRepresentation::Class;
   
   // Otherwise, we need to use a fixed-sized buffer.
@@ -539,7 +539,7 @@ SILType::canUseExistentialRepresentation(SILModule &M,
     
     // A class-constrained composition uses ClassReference representation;
     // otherwise, we use a fixed-sized buffer.
-    if (layout.requiresClass)
+    if (layout.requiresClass())
       return repr == ExistentialRepresentation::Class;
 
     return repr == ExistentialRepresentation::Opaque;

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -2707,10 +2707,10 @@ public:
             "init_existential instruction must have the "
             "right number of conformances");
 
-    if (layout.requiresClass) {
+    if (layout.requiresClass()) {
       require(concreteType->mayHaveSuperclass() ||
               (concreteType.isExistentialType() &&
-               concreteType.getExistentialLayout().requiresClass),
+               concreteType.getExistentialLayout().requiresClass()),
               "init_existential of class existential with non-class type");
     }
 

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -2109,16 +2109,8 @@ void TypeConverter::popGenericContext(CanGenericSignature sig) {
 
 ProtocolDispatchStrategy
 TypeConverter::getProtocolDispatchStrategy(ProtocolDecl *P) {
-  // AnyObject has no requirements (other than the object being a class), so
-  // needs no method dispatch.
-  if (auto known = P->getKnownProtocolKind()) {
-    if (*known == KnownProtocolKind::AnyObject)
-      return ProtocolDispatchStrategy::Empty;
-  }
-  
-  // Otherwise, ObjC protocols use ObjC method dispatch, and Swift protocols
+  // ObjC protocols use ObjC method dispatch, and Swift protocols
   // use witness tables.
-  
   if (P->isObjC())
     return ProtocolDispatchStrategy::ObjC;
   

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -3227,21 +3227,9 @@ private:
           emittedArg = ManagedValue(opened, emittedArg.getCleanup());
         }
         
-        // Erase to AnyObject.
-        auto conformance = SGF.SGM.SwiftModule->lookupConformance(
-          emittedArgTy,
-          SGF.getASTContext().getProtocol(KnownProtocolKind::AnyObject),
-          nullptr);
-        assert(conformance &&
-               "no AnyObject conformance for class?!");
-        
-        ArrayRef<ProtocolConformanceRef> conformances(*conformance);
-        auto ctxConformances = SGF.getASTContext().AllocateCopy(conformances);
-        
         auto erased = SGF.B.createInitExistentialRef(loc,
                          SILType::getPrimitiveObjectType(getAnyObjectType()),
-                         emittedArgTy, emittedArg.getValue(),
-                         ctxConformances);
+                         emittedArgTy, emittedArg.getValue(), {});
         emittedArg = ManagedValue(erased, emittedArg.getCleanup());
       }
       

--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -642,21 +642,13 @@ ManagedValue SILGenFunction::emitExistentialErasure(
   
     // If the concrete value is a pseudogeneric archetype, first erase it to
     // its upper bound.
-    auto anyObjectProto = getASTContext()
-      .getProtocol(KnownProtocolKind::AnyObject);
     auto anyObjectTy = getASTContext().getAnyObjectType();
     auto eraseToAnyObject =
     [&, concreteFormalType, F](SGFContext C) -> ManagedValue {
       auto concreteValue = F(SGFContext());
-      auto anyObjectConformance = SGM.SwiftModule
-        ->lookupConformance(concreteFormalType, anyObjectProto, nullptr);
-      ProtocolConformanceRef buf[] = {
-        *anyObjectConformance,
-      };
-
       return B.createInitExistentialRef(
           loc, SILType::getPrimitiveObjectType(anyObjectTy), concreteFormalType,
-          concreteValue, getASTContext().AllocateCopy(buf));
+          concreteValue, {});
     };
     
     auto concreteTLPtr = &concreteTL;

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -478,11 +478,6 @@ void SILGenFunction::emitArtificialTopLevel(ClassDecl *mainClass) {
         ->getCanonicalType();
     CanType mainClassMetaty = CanMetatypeType::get(mainClassTy,
                                                    MetatypeRepresentation::ObjC);
-    ProtocolDecl *anyObjectProtocol =
-      ctx.getProtocol(KnownProtocolKind::AnyObject);
-    auto mainClassAnyObjectConformance = ProtocolConformanceRef(
-      *SGM.M.getSwiftModule()->lookupConformance(mainClassTy, anyObjectProtocol,
-                                                nullptr));
     CanType anyObjectTy = ctx.getAnyObjectType();
     CanType anyObjectMetaTy = CanExistentialMetatypeType::get(anyObjectTy,
                                                   MetatypeRepresentation::ObjC);
@@ -507,9 +502,7 @@ void SILGenFunction::emitArtificialTopLevel(ClassDecl *mainClass) {
     SILValue metaTy = B.createMetatype(mainClass,
                              SILType::getPrimitiveObjectType(mainClassMetaty));
     metaTy = B.createInitExistentialMetatype(mainClass, metaTy,
-                          SILType::getPrimitiveObjectType(anyObjectMetaTy),
-                          ctx.AllocateCopy(
-                            llvm::makeArrayRef(mainClassAnyObjectConformance)));
+                          SILType::getPrimitiveObjectType(anyObjectMetaTy), {});
     SILValue optName = B.createApply(mainClass,
                                NSStringFromClass,
                                NSStringFromClass->getType(),

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -4283,9 +4283,6 @@ bool FailureDiagnosis::diagnoseContextualConversionError() {
     tryRawRepresentableFixIts(diag, CS, exprType, contextualType,
                               KnownProtocolKind::ExpressibleByStringLiteral,
                               expr) ||
-    tryRawRepresentableFixIts(diag, CS, exprType, contextualType,
-                              KnownProtocolKind::AnyObject,
-                              expr) ||
     tryIntegerCastFixIts(diag, CS, exprType, contextualType, expr) ||
     addTypeCoerceFixit(diag, CS, exprType, contextualType, expr);
     break;

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -3426,13 +3426,13 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
 
     bool toRequiresClass;
     if (toType->isExistentialType())
-      toRequiresClass = toType->getExistentialLayout().requiresClass;
+      toRequiresClass = toType->getExistentialLayout().requiresClass();
     else
       toRequiresClass = toType->mayHaveSuperclass();
 
     bool fromRequiresClass;
     if (fromType->isExistentialType())
-      fromRequiresClass = fromType->getExistentialLayout().requiresClass;
+      fromRequiresClass = fromType->getExistentialLayout().requiresClass();
     else
       fromRequiresClass = fromType->mayHaveSuperclass();
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -7692,15 +7692,6 @@ void TypeChecker::validateExtension(ExtensionDecl *ext) {
 
     ext->getExtendedTypeLoc().setType(extendedType);
     ext->setGenericEnvironment(env);
-
-    // Speculatively ban extension of AnyObject; it won't be a
-    // protocol forever, and we don't want to allow code that we know
-    // we'll break later.
-    if (proto->getDecl()->isSpecificProtocol(
-          KnownProtocolKind::AnyObject)) {
-      diagnose(ext, diag::extension_anyobject)
-        .highlight(ext->getExtendedTypeLoc().getSourceRange());
-    }
     return;
   }
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5210,7 +5210,7 @@ Optional<ProtocolConformanceRef> TypeChecker::containsProtocol(
     // AnyObject.
     //
     // FIXME: This check is moving elsewhere soon.
-    if (layout.requiresClass &&
+    if (layout.requiresClass() &&
         Proto->isSpecificProtocol(KnownProtocolKind::AnyObject)) {
       return ProtocolConformanceRef(Proto);
     }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1993,8 +1993,7 @@ namespace {
     }
 
     // Foreign classes cannot conform to objc protocols.
-    if (Proto->isObjC() &&
-        !Proto->isSpecificProtocol(KnownProtocolKind::AnyObject)) {
+    if (Proto->isObjC()) {
       if (auto clas = canT->getClassOrBoundGenericClass()) {
         Optional<decltype(diag::cf_class_cannot_conform_to_objc_protocol)>
         diagKind;
@@ -5206,16 +5205,7 @@ Optional<ProtocolConformanceRef> TypeChecker::containsProtocol(
   if (T->isExistentialType()) {
     auto layout = T->getExistentialLayout();
 
-    // First, any class-constrained existential semantically contains
-    // AnyObject.
-    //
-    // FIXME: This check is moving elsewhere soon.
-    if (layout.requiresClass() &&
-        Proto->isSpecificProtocol(KnownProtocolKind::AnyObject)) {
-      return ProtocolConformanceRef(Proto);
-    }
-
-    // Next, if we have a superclass constraint, the class may conform
+    // First, if we have a superclass constraint, the class may conform
     // concretely.
     if (layout.superclass) {
       if (auto result = conformsToProtocol(layout.superclass, Proto,
@@ -5224,7 +5214,7 @@ Optional<ProtocolConformanceRef> TypeChecker::containsProtocol(
       }
     }
 
-    // Finally, check if the existential contains the protocol in question.
+    // Next, check if the existential contains the protocol in question.
     for (auto P : layout.getProtocols()) {
       auto *PD = P->getDecl();
       // If we found the protocol we're looking for, return an abstract

--- a/stdlib/public/core/Policy.swift
+++ b/stdlib/public/core/Policy.swift
@@ -250,22 +250,12 @@ public typealias _MaxBuiltinFloatType = Builtin.FPIEEE64
 ///     // Prints "The value of 'obj' is 100"
 ///
 /// - SeeAlso: `AnyClass`
-@objc
-public protocol AnyObject : class {}
 #else
 /// The protocol to which all classes implicitly conform.
 ///
 /// - SeeAlso: `AnyClass`
-public protocol AnyObject : class {}
 #endif
-// Implementation note: the `AnyObject` protocol *must* not have any method or
-// property requirements.
-
-// FIXME: AnyObject should have an alternate version for non-objc without
-// the @objc attribute, but AnyObject needs to be not be an address-only
-// type to be able to be the target of castToNativeObject and an empty
-// non-objc protocol appears not to be. There needs to be another way to make
-// this the right kind of object.
+public typealias AnyObject = Builtin.AnyObject
 
 /// The protocol to which all class types implicitly conform.
 ///

--- a/stdlib/public/runtime/Demangle.cpp
+++ b/stdlib/public/runtime/Demangle.cpp
@@ -149,43 +149,16 @@ swift::_swift_buildDemanglingForMetadata(const Metadata *type,
   }
   case MetadataKind::Existential: {
     auto exis = static_cast<const ExistentialTypeMetadata *>(type);
-    NodePointer proto_list;
     
     std::vector<const ProtocolDescriptor *> protocols;
     protocols.reserve(exis->Protocols.NumProtocols);
     for (unsigned i = 0, e = exis->Protocols.NumProtocols; i < e; ++i)
       protocols.push_back(exis->Protocols[i]);
 
-    if (exis->getSuperclassConstraint()) {
-      // If there is a superclass constraint, we mangle it specially.
-      proto_list = Dem.createNode(Node::Kind::ProtocolListWithClass);
-    } else if (exis->isClassBounded()) {
-      // Check if the class constraint is implied by any of our
-      // protocols.
-      bool requiresClassImplicit = false;
-
-      for (auto *protocol : protocols) {
-        if (protocol->Flags.getClassConstraint()
-            == ProtocolClassConstraint::Class)
-          requiresClassImplicit = true;
-      }
-
-      // If it was implied, we don't do anything special.
-      if (requiresClassImplicit)
-        proto_list = Dem.createNode(Node::Kind::ProtocolList);
-      // If the existential type has an explicit AnyObject constraint,
-      // we must mangle it as such.
-      else
-        proto_list = Dem.createNode(Node::Kind::ProtocolListWithAnyObject);
-    } else {
-      // Just a simple composition of protocols.
-      proto_list = Dem.createNode(Node::Kind::ProtocolList);
-    }
-
-    NodePointer type_list = Dem.createNode(Node::Kind::TypeList);
-
+    auto type_list = Dem.createNode(Node::Kind::TypeList);
+    auto proto_list = Dem.createNode(Node::Kind::ProtocolList);
     proto_list->addChild(type_list, Dem);
-    
+
     // Sort the protocols by their mangled names.
     // The ordering in the existential type metadata is by metadata pointer,
     // which isn't necessarily stable across invocations.
@@ -226,11 +199,39 @@ swift::_swift_buildDemanglingForMetadata(const Metadata *type,
       type_list->addChild(protocolNode, Dem);
     }
 
-    if (auto *superclass = exis->getSuperclassConstraint()) {
+    if (auto superclass = exis->getSuperclassConstraint()) {
+      // If there is a superclass constraint, we mangle it specially.
+      auto result = Dem.createNode(Node::Kind::ProtocolListWithClass);
       auto superclassNode = _swift_buildDemanglingForMetadata(superclass, Dem);
-      proto_list->addChild(superclassNode, Dem);
+
+      result->addChild(proto_list, Dem);
+      result->addChild(superclassNode, Dem);
+      return result;
     }
 
+    if (exis->isClassBounded()) {
+      // Check if the class constraint is implied by any of our
+      // protocols.
+      bool requiresClassImplicit = false;
+
+      for (auto *protocol : protocols) {
+        if (protocol->Flags.getClassConstraint()
+            == ProtocolClassConstraint::Class)
+          requiresClassImplicit = true;
+      }
+
+      // If it was implied, we don't do anything special.
+      if (requiresClassImplicit)
+        return proto_list;
+
+      // If the existential type has an explicit AnyObject constraint,
+      // we must mangle it as such.
+      auto result = Dem.createNode(Node::Kind::ProtocolListWithAnyObject);
+      result->addChild(proto_list, Dem);
+      return result;
+    }
+
+    // Just a simple composition of protocols.
     return proto_list;
   }
   case MetadataKind::ExistentialMetatype: {

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -2282,7 +2282,6 @@ getExistentialValueWitnesses(ProtocolClassConstraint classConstraint,
 #endif
       
   // Other existentials use standard representation.
-  case SpecialProtocol::AnyObject:
   case SpecialProtocol::None:
     break;
   }
@@ -2305,7 +2304,6 @@ ExistentialTypeMetadata::getRepresentation() const {
   switch (Flags.getSpecialProtocol()) {
   case SpecialProtocol::Error:
     return ExistentialTypeRepresentation::Error;
-  case SpecialProtocol::AnyObject:
   case SpecialProtocol::None:
     break;
   }
@@ -2520,24 +2518,6 @@ ExistentialCacheEntry::ExistentialCacheEntry(Key key) {
     if (p->Flags.needsWitnessTable())
       ++numWitnessTables;
   }
-
-#ifndef NDEBUG
-  // Verify the class constraint.
-  {
-    auto classConstraint = ProtocolClassConstraint::Any;
-
-    if (key.SuperclassConstraint)
-      classConstraint = ProtocolClassConstraint::Class;
-    else {
-      for (auto p : make_range(key.Protocols, key.Protocols + key.NumProtocols)) {
-        if (p->Flags.getClassConstraint() == ProtocolClassConstraint::Class)
-          classConstraint = ProtocolClassConstraint::Class;
-      }
-    }
-    
-    assert(classConstraint == key.ClassConstraint);
-  }
-#endif
 
   // Get the special protocol kind for an uncomposed protocol existential.
   // Protocol compositions are currently never special.

--- a/stdlib/public/runtime/SwiftValue.mm
+++ b/stdlib/public/runtime/SwiftValue.mm
@@ -229,19 +229,7 @@ swift::findSwiftValueConformances(const ExistentialTypeMetadata *existentialType
   for (size_t i = 0, e = protocols.NumProtocols; i != e; ++i) {
     auto protocol = protocols[i];
 
-    // _SwiftValue does conform to AnyObject.
-    switch (protocol->Flags.getSpecialProtocol()) {
-    case SpecialProtocol::AnyObject:
-      continue;
-
-    case SpecialProtocol::Error:
-      return false;
-
-    case SpecialProtocol::None:
-      break;
-    }
-
-    // Otherwise, it only conforms to ObjC protocols.  We specifically
+    // _SwiftValue only conforms to ObjC protocols.  We specifically
     // don't want to say that _SwiftValue conforms to the Swift protocols
     // that NSObject conforms to because that would create a situation
     // where arguably an arbitrary type would conform to those protocols

--- a/test/ClangImporter/serialization-sil.swift
+++ b/test/ClangImporter/serialization-sil.swift
@@ -13,7 +13,7 @@ public func testPartialApply(_ obj: Test) {
     // CHECK: [[CURRIED1_FALSE]]:
     // CHECK: [[CURRIED1_TRUE]]([[CURRIED1_METHOD:%.+]] : $@convention(objc_method) (@opened([[CURRIED1_EXISTENTIAL]]) Test) -> @autoreleased AnyObject):
     // CHECK: [[CURRIED1_PARTIAL:%.+]] = partial_apply [[CURRIED1_METHOD]]([[CURRIED1_OBJ]]) : $@convention(objc_method) (@opened([[CURRIED1_EXISTENTIAL]]) Test) -> @autoreleased AnyObject
-    // CHECK: [[CURRIED1_THUNK:%.+]] = function_ref @_T0s9AnyObject_pIxo_ypIxr_TR : $@convention(thin) (@owned @callee_owned () -> @owned AnyObject) -> @out Any
+    // CHECK: [[CURRIED1_THUNK:%.+]] = function_ref @_T0yXlIxo_ypIxr_TR : $@convention(thin) (@owned @callee_owned () -> @owned AnyObject) -> @out Any
     // CHECK: = partial_apply [[CURRIED1_THUNK]]([[CURRIED1_PARTIAL]])
     curried1()
   }

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -237,7 +237,7 @@ String().asdf  // expected-error {{value of type 'String' has no member 'asdf'}}
 // <rdar://problem/21553065> Spurious diagnostic: '_' can only appear in a pattern or on the left side of an assignment
 protocol r21553065Protocol {}
 class r21553065Class<T : AnyObject> {}
-_ = r21553065Class<r21553065Protocol>()  // expected-error {{type 'r21553065Protocol' does not conform to protocol 'AnyObject'}}
+_ = r21553065Class<r21553065Protocol>()  // expected-error {{'r21553065Protocol' is not convertible to 'AnyObject'}}
 
 // Type variables not getting erased with nested closures
 struct Toe {

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -299,11 +299,11 @@ func testFixIts() {
   _ = FullyGeneric<Any>()
 
   _ = AnyClassBound() // expected-error {{generic parameter 'Foo' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{20-20=<AnyObject>}}
-  _ = AnyClassBound<Any>() // expected-error {{type 'Any' does not conform to protocol 'AnyObject'}}
+  _ = AnyClassBound<Any>() // expected-error {{'Any' is not convertible to 'AnyObject'}}
   _ = AnyClassBound<AnyObject>()
 
   _ = AnyClassBound2() // expected-error {{generic parameter 'Foo' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{21-21=<AnyObject>}}
-  _ = AnyClassBound2<Any>() // expected-error {{type 'Any' does not conform to protocol 'AnyObject'}}
+  _ = AnyClassBound2<Any>() // expected-error {{'Any' is not convertible to 'AnyObject'}}
   _ = AnyClassBound2<AnyObject>()
 
   _ = ProtoBound() // expected-error {{generic parameter 'Foo' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{17-17=<<#Foo: SubProto#>>}}
@@ -324,8 +324,8 @@ func testFixIts() {
   _ = ProtosBound2() // expected-error {{generic parameter 'Foo' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{19-19=<<#Foo: NSCopyish & SubProto#>>}}
   _ = ProtosBound3() // expected-error {{generic parameter 'Foo' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{19-19=<<#Foo: NSCopyish & SubProto#>>}}
 
-  _ = AnyClassAndProtoBound() // expected-error {{generic parameter 'Foo' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{28-28=<<#Foo: AnyObject & SubProto#>>}}
-  _ = AnyClassAndProtoBound2() // expected-error {{generic parameter 'Foo' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{29-29=<<#Foo: AnyObject & SubProto#>>}}
+  _ = AnyClassAndProtoBound() // expected-error {{generic parameter 'Foo' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{28-28=<<#Foo: SubProto & AnyObject#>>}}
+  _ = AnyClassAndProtoBound2() // expected-error {{generic parameter 'Foo' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{29-29=<<#Foo: SubProto & AnyObject#>>}}
 
   _ = ClassAndProtoBound() // expected-error {{generic parameter 'Foo' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{25-25=<<#Foo: X & SubProto#>>}}
 

--- a/test/IDE/annotation.swift
+++ b/test/IDE/annotation.swift
@@ -225,7 +225,7 @@ class Observers {
 }
 
 class C9 {}
-// CHECK: func <Func>test6</Func>(_ <Param>o</Param>: <iProtocol@>AnyObject</iProtocol>) {
+// CHECK: func <Func>test6</Func>(_ <Param>o</Param>: <iTypeAlias@>AnyObject</iTypeAlias>) {
 func test6(_ o: AnyObject) {
   // CHECK: let <Var>x</Var> = <Param@[[@LINE-1]]:14>o</Param> as! <Class@[[@LINE-3]]:7>C9</Class>
   let x = o as! C9

--- a/test/IDE/reconstruct_type_from_mangled_name.swift
+++ b/test/IDE/reconstruct_type_from_mangled_name.swift
@@ -191,10 +191,9 @@ func foo2(p: P1 & P2) {
   foo2(p: p)
 }
 
-// CHECK: func foo3(p: AnyObject & P1)
+// CHECK: func foo3(p: P1 & AnyObject)
 func foo3(p: P1 & AnyObject) {
-// CHECK: decl: let p: AnyObject & P1
-// CHECK: dref: {{(@objc )?}}protocol AnyObject
+// CHECK: decl: let p: P1 & AnyObject
   foo3(p: p)
 }
 
@@ -205,7 +204,7 @@ func foo4(p: P1 & P2 & Myclass1) {
 }
 
 func genericFunction<T : AnyObject>(t: T) {
-// CHECK: decl: FAILURE for 'T' usr=s:14swift_ide_test15genericFunctionyx1t_ts9AnyObjectRzlF1TL_xmfp
+// CHECK: decl: FAILURE for 'T' usr=s:14swift_ide_test15genericFunctionyx1t_tRlzClF1TL_xmfp
   genericFunction(t: t)
 }
 

--- a/test/IRGen/generic_class_anyobject.swift
+++ b/test/IRGen/generic_class_anyobject.swift
@@ -5,6 +5,6 @@
 
 func foo<T: AnyObject>(_ x: T) -> T { return x }
 
-// CHECK-LABEL: define hidden swiftcc %objc_object* @_T023generic_class_anyobject3bars9AnyObject_psAC_pF(%objc_object*)
+// CHECK-LABEL: define hidden swiftcc %objc_object* @_T023generic_class_anyobject3baryXlyXlF(%objc_object*)
 // CHECK:         call swiftcc %objc_object* @_T023generic_class_anyobject3foo{{[_0-9a-zA-Z]*}}F
 func bar(_ x: AnyObject) -> AnyObject { return foo(x) }

--- a/test/IRGen/objc.swift
+++ b/test/IRGen/objc.swift
@@ -13,7 +13,7 @@ import gizmo
 // CHECK: [[MYBLAMMO:%T4objc8MyBlammoC]] = type
 // CHECK: [[TEST2:%T4objc5Test2C]] = type
 // CHECK: [[OBJC:%objc_object]] = type
-// CHECK: [[ID:%T4objc2idV]] = type <{ %Ts9AnyObjectP }>
+// CHECK: [[ID:%T4objc2idV]] = type <{ %AnyObject }>
 // CHECK: [[GIZMO:%TSo5GizmoC]] = type
 // CHECK: [[RECT:%TSo4RectV]] = type
 // CHECK: [[FLOAT:%TSf]] = type

--- a/test/IRGen/objc_generic_protocol_conformance.swift
+++ b/test/IRGen/objc_generic_protocol_conformance.swift
@@ -9,5 +9,5 @@ protocol P {
 
 extension Foo: P {}
 
-// SIL-LABEL: sil private [transparent] [thunk] @_T0So3FooCyxG33objc_generic_protocol_conformance1PADs9AnyObjectRzlAdEP3fooyyFTW {{.*}} @pseudogeneric
-// IR-LABEL: define internal swiftcc void @_T0So3FooCyxG33objc_generic_protocol_conformance1PADs9AnyObjectRzlAdEP3fooyyFTW(%TSo3FooC** noalias nocapture swiftself dereferenceable({{4|8}}), %swift.type*{{( %Self)?}}, i8**{{( %SelfWitnessTable)?}})
+// SIL-LABEL: sil private [transparent] [thunk] @_T0So3FooCyxG33objc_generic_protocol_conformance1PADRlzClAdEP3fooyyFTW {{.*}} @pseudogeneric
+// IR-LABEL: define internal swiftcc void @_T0So3FooCyxG33objc_generic_protocol_conformance1PADRlzClAdEP3fooyyFTW(%TSo3FooC** noalias nocapture swiftself dereferenceable({{4|8}}), %swift.type*{{( %Self)?}}, i8**{{( %SelfWitnessTable)?}})

--- a/test/IRGen/objc_methods.swift
+++ b/test/IRGen/objc_methods.swift
@@ -50,7 +50,7 @@ class Foo: Fooable {
 // CHECK:   }, {
 // CHECK:     i8* getelementptr inbounds ([8 x i8], [8 x i8]* @"\01L_selector_data(garply:)", i64 0, i64 0),
 // CHECK:     i8* getelementptr inbounds ([11 x i8], [11 x i8]* [[GARPLY_SIGNATURE]], i64 0, i64 0),
-// CHECK:     i8* bitcast (void (i8*, i8*, i8*)* @_T012objc_methods3FooC6garplyys9AnyObject_pSgFTo to i8*)
+// CHECK:     i8* bitcast (void (i8*, i8*, i8*)* @_T012objc_methods3FooC6garplyyyXlSgFTo to i8*)
 // CHECK:   }, {
 // CHECK:     i8* getelementptr inbounds ([7 x i8], [7 x i8]* @"\01L_selector_data(block:)", i64 0, i64 0),
 // CHECK:     i8* getelementptr inbounds ([12 x i8], [12 x i8]* [[BLOCK_SIGNATURE_TRAD]], i64 0, i64 0),

--- a/test/IRGen/objc_pointers.swift
+++ b/test/IRGen/objc_pointers.swift
@@ -14,7 +14,7 @@ import Foundation
                               z: UnsafePointer<Int>,
                               w: AutoreleasingUnsafeMutablePointer<Foo?>) {}
 
-  // CHECK: define internal void @_T013objc_pointers3FooC24pointerMetatypeArgumentsys33AutoreleasingUnsafeMutablePointerVys9AnyObject_pXpG1x_AFysAG_pXpSgG1ytFTo(%0*, i8*, i8**, i8**)
+  // CHECK: define internal void @_T013objc_pointers3FooC24pointerMetatypeArgumentsys33AutoreleasingUnsafeMutablePointerVyyXlXpG1x_AFyyXlXpSgG1ytFTo(%0*, i8*, i8**, i8**)
   @objc func pointerMetatypeArguments(x: AutoreleasingUnsafeMutablePointer<AnyClass>,
                                       y: AutoreleasingUnsafeMutablePointer<AnyClass?>) {}
 }

--- a/test/IRGen/special_protocols.sil
+++ b/test/IRGen/special_protocols.sil
@@ -1,17 +1,9 @@
 // RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -emit-ir -parse-stdlib -module-name Swift | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
 
-public protocol AnyObject: class {}
-// CHECK-LABEL: @_T0s9AnyObjectMp = {{(protected )?}}constant %swift.protocol {
-// --                 0x0000_0049: special protocol 01, class, empty, swift
-// CHECK:         i32 73,
-// CHECK:         i16 0,
-// CHECK:         i16 0,
-// CHECK:         i32 0 }
-
 public protocol Error {}
 // CHECK-LABEL: @_T0s5ErrorMp = {{(protected )?}}constant %swift.protocol {
 // --                 0x0000_0087: special protocol 02, non-class, witness, swift
-// CHECK:         i32 135,
+// CHECK:         i32 72,
 // CHECK:         i16 0,
 // CHECK:         i16 0,
 // CHECK:         i32 0 }

--- a/test/Interpreter/subclass_existentials.swift
+++ b/test/Interpreter/subclass_existentials.swift
@@ -154,10 +154,11 @@ SubclassExistentialsTestSuite.test("Metadata instantiation") {
   expectTrue(((Base<Int>) & P & Q).self == (P & (Base<Int>) & Q).self)
   expectTrue((P & Q & (Base<Int>)).self == (Q & (Base<Int>) & P).self)
 
-  // For now...
-  expectFalse((P & Q).self == (P & Q & AnyObject).self)
-  expectFalse((P & Q).self == (Q & P & AnyObject).self)
-  expectFalse(((Base<Int>) & Q).self == (Q & (Base<Int>) & AnyObject).self)
+  expectTrue((P & Q).self == (P & Q & AnyObject).self)
+  expectTrue((P & Q).self == (Q & P & AnyObject).self)
+  expectTrue(((Base<Int>) & Q).self == (Q & (Base<Int>) & AnyObject).self)
+
+  expectFalse((R & AnyObject).self == R.self)
 }
 
 SubclassExistentialsTestSuite.test("Metadata to string") {

--- a/test/SILGen/access_marker_gen.swift
+++ b/test/SILGen/access_marker_gen.swift
@@ -7,7 +7,7 @@ public struct S {
   var o: AnyObject?
 }
 
-// CHECK-LABEL: sil hidden [noinline] @_T017access_marker_gen5initSAA1SVs9AnyObject_pSgF : $@convention(thin) (@owned Optional<AnyObject>) -> @owned S {
+// CHECK-LABEL: sil hidden [noinline] @_T017access_marker_gen5initSAA1SVyXlSgF : $@convention(thin) (@owned Optional<AnyObject>) -> @owned S {
 // CHECK: bb0(%0 : $Optional<AnyObject>):
 // CHECK: [[BOX:%.*]] = alloc_box ${ var S }, var, name "s"
 // CHECK: [[MARKED_BOX:%.*]] = mark_uninitialized [var] [[BOX]] : ${ var S }
@@ -26,7 +26,7 @@ public struct S {
 // CHECK: [[RET:%.*]] = load [copy] [[ACCESS3]] : $*S
 // CHECK: end_access [[ACCESS3]] : $*S
 // CHECK: return [[RET]] : $S
-// CHECK-LABEL: } // end sil function '_T017access_marker_gen5initSAA1SVs9AnyObject_pSgF'
+// CHECK-LABEL: } // end sil function '_T017access_marker_gen5initSAA1SVyXlSgF'
 @inline(never)
 func initS(_ o: AnyObject?) -> S {
   var s: S
@@ -65,7 +65,7 @@ func readGlobal() -> AnyObject? {
   return global.o
 }
 
-// CHECK-LABEL: sil hidden @_T017access_marker_gen10readGlobals9AnyObject_pSgyF
+// CHECK-LABEL: sil hidden @_T017access_marker_gen10readGlobalyXlSgyF
 // CHECK:         [[ADDRESSOR:%.*]] = function_ref @_T017access_marker_gen6globalAA1SVfau :
 // CHECK-NEXT:    [[T0:%.*]] = apply [[ADDRESSOR]]()
 // CHECK-NEXT:    [[T1:%.*]] = pointer_to_address [[T0]] : $Builtin.RawPointer to [strict] $*S

--- a/test/SILGen/builtins.swift
+++ b/test/SILGen/builtins.swift
@@ -792,7 +792,7 @@ func refcast_generic_any<T>(_ o: T) -> AnyObject {
   return Builtin.castReference(o)
 }
 
-// CHECK-LABEL: sil hidden @_T08builtins17refcast_class_anys9AnyObject_pAA1ACF :
+// CHECK-LABEL: sil hidden @_T08builtins17refcast_class_anyyXlAA1ACF :
 // CHECK: bb0([[ARG:%.*]] : $A):
 // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
 // CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
@@ -800,7 +800,7 @@ func refcast_generic_any<T>(_ o: T) -> AnyObject {
 // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
 // CHECK:   destroy_value [[ARG]]
 // CHECK:   return [[ARG_COPY_CASTED]]
-// CHECK: } // end sil function '_T08builtins17refcast_class_anys9AnyObject_pAA1ACF'
+// CHECK: } // end sil function '_T08builtins17refcast_class_anyyXlAA1ACF'
 func refcast_class_any(_ o: A) -> AnyObject {
   return Builtin.castReference(o)
 }
@@ -811,7 +811,7 @@ func refcast_punknown_any(_ o: PUnknown) -> AnyObject {
   return Builtin.castReference(o)
 }
 
-// CHECK-LABEL: sil hidden @_T08builtins18refcast_pclass_anys9AnyObject_pAA6PClass_pF :
+// CHECK-LABEL: sil hidden @_T08builtins18refcast_pclass_anyyXlAA6PClass_pF :
 // CHECK: bb0([[ARG:%.*]] : $PClass):
 // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
 // CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
@@ -819,7 +819,7 @@ func refcast_punknown_any(_ o: PUnknown) -> AnyObject {
 // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
 // CHECK:   destroy_value [[ARG]]
 // CHECK:   return [[ARG_COPY_CAST]]
-// CHECK: } // end sil function '_T08builtins18refcast_pclass_anys9AnyObject_pAA6PClass_pF'
+// CHECK: } // end sil function '_T08builtins18refcast_pclass_anyyXlAA6PClass_pF'
 func refcast_pclass_any(_ o: PClass) -> AnyObject {
   return Builtin.castReference(o)
 }

--- a/test/SILGen/dynamic.swift
+++ b/test/SILGen/dynamic.swift
@@ -70,8 +70,8 @@ protocol Proto {
 // CHECK-LABEL: sil hidden [thunk] @_T07dynamic3FooC10objcMethod{{[_0-9a-zA-Z]*}}FTo
 // CHECK-LABEL: sil hidden [transparent] [thunk] @_T07dynamic3FooC8objcPropSifgTo
 // CHECK-LABEL: sil hidden [transparent] [thunk] @_T07dynamic3FooC8objcPropSifsTo
-// CHECK-LABEL: sil hidden [thunk] @_T07dynamic3FooC9subscriptSis9AnyObject_p4objc_tcfgTo
-// CHECK-LABEL: sil hidden [thunk] @_T07dynamic3FooC9subscriptSis9AnyObject_p4objc_tcfsTo
+// CHECK-LABEL: sil hidden [thunk] @_T07dynamic3FooC9subscriptSiyXl4objc_tcfgTo
+// CHECK-LABEL: sil hidden [thunk] @_T07dynamic3FooC9subscriptSiyXl4objc_tcfsTo
 
 // TODO: dynamic initializing ctor must be objc dispatched
 // CHECK-LABEL: sil hidden @_T07dynamic3{{[_0-9a-zA-Z]*}}fC
@@ -107,9 +107,9 @@ protocol Proto {
 // CHECK:         class_method {{%.*}} : $Foo, #Foo.objcProp!getter.1 :
 // CHECK-LABEL: sil private [transparent] [thunk] @_T07dynamic3FooCAA5ProtoA2aDP8objcPropSifsTW
 // CHECK:         class_method {{%.*}} : $Foo, #Foo.objcProp!setter.1 :
-// CHECK-LABEL: sil private [transparent] [thunk] @_T07dynamic3FooCAA5ProtoA2aDP9subscriptSis9AnyObject_p4objc_tcfgTW
+// CHECK-LABEL: sil private [transparent] [thunk] @_T07dynamic3FooCAA5ProtoA2aDP9subscriptSiyXl4objc_tcfgTW
 // CHECK:         class_method {{%.*}} : $Foo, #Foo.subscript!getter.1 :
-// CHECK-LABEL: sil private [transparent] [thunk] @_T07dynamic3FooCAA5ProtoA2aDP9subscriptSis9AnyObject_p4objc_tcfsTW
+// CHECK-LABEL: sil private [transparent] [thunk] @_T07dynamic3FooCAA5ProtoA2aDP9subscriptSiyXl4objc_tcfsTW
 // CHECK:         class_method {{%.*}} : $Foo, #Foo.subscript!setter.1 :
 
 // Dynamic witnesses use objc dispatch:
@@ -194,11 +194,11 @@ class Subclass: Foo {
 
   override subscript(objc objc: AnyObject) -> Int {
     get { return super[objc: objc] }
-    // CHECK-LABEL: sil hidden @_T07dynamic8SubclassC9subscriptSis9AnyObject_p4objc_tcfg
-    // CHECK:         function_ref @_T07dynamic3FooC9subscriptSis9AnyObject_p4objc_tcfg : $@convention(method) (@owned AnyObject, @guaranteed Foo) -> Int
+    // CHECK-LABEL: sil hidden @_T07dynamic8SubclassC9subscriptSiyXl4objc_tcfg
+    // CHECK:         function_ref @_T07dynamic3FooC9subscriptSiyXl4objc_tcfg : $@convention(method) (@owned AnyObject, @guaranteed Foo) -> Int
     set { super[objc: objc] = newValue }
-    // CHECK-LABEL: sil hidden @_T07dynamic8SubclassC9subscriptSis9AnyObject_p4objc_tcfs
-    // CHECK:         function_ref @_T07dynamic3FooC9subscriptSis9AnyObject_p4objc_tcfs : $@convention(method) (Int, @owned AnyObject, @guaranteed Foo) -> ()
+    // CHECK-LABEL: sil hidden @_T07dynamic8SubclassC9subscriptSiyXl4objc_tcfs
+    // CHECK:         function_ref @_T07dynamic3FooC9subscriptSiyXl4objc_tcfs : $@convention(method) (Int, @owned AnyObject, @guaranteed Foo) -> ()
   }
 
   // Dynamic methods are super-dispatched by objc_msgSend
@@ -496,8 +496,8 @@ public class ConcreteDerived : GenericBase<Int> {
 // CHECK-NEXT:   #Foo.objcProp!getter.1: {{.*}} :    _T07dynamic3FooC8objcPropSifg  // dynamic.Foo.objcProp.getter : Swift.Int
 // CHECK-NEXT:   #Foo.objcProp!setter.1: {{.*}} :    _T07dynamic3FooC8objcPropSifs  // dynamic.Foo.objcProp.setter : Swift.Int
 // CHECK-NEXT:   #Foo.objcProp!materializeForSet.1
-// CHECK-NEXT:   #Foo.subscript!getter.1: {{.*}} : _T07dynamic3FooC9subscriptSis9AnyObject_p4objc_tcfg // dynamic.Foo.subscript.getter : (objc: Swift.AnyObject) -> Swift.Int
-// CHECK-NEXT:   #Foo.subscript!setter.1: {{.*}} : _T07dynamic3FooC9subscriptSis9AnyObject_p4objc_tcfs // dynamic.Foo.subscript.setter : (objc: Swift.AnyObject) -> Swift.Int
+// CHECK-NEXT:   #Foo.subscript!getter.1: {{.*}} : _T07dynamic3FooC9subscriptSiyXl4objc_tcfg // dynamic.Foo.subscript.getter : (objc: Swift.AnyObject) -> Swift.Int
+// CHECK-NEXT:   #Foo.subscript!setter.1: {{.*}} : _T07dynamic3FooC9subscriptSiyXl4objc_tcfs // dynamic.Foo.subscript.setter : (objc: Swift.AnyObject) -> Swift.Int
 // CHECK-NEXT:   #Foo.subscript!materializeForSet
 // CHECK-NEXT:   #Foo.overriddenByDynamic!1: {{.*}} : _T07dynamic3FooC19overriddenByDynamic{{[_0-9a-zA-Z]*}}
 // CHECK-NEXT:   #Foo.deinit!deallocator: {{.*}}

--- a/test/SILGen/dynamic_lookup_throws.swift
+++ b/test/SILGen/dynamic_lookup_throws.swift
@@ -11,7 +11,7 @@ class Blub : NSObject {
    func blub() throws {}
 }
 
-// CHECK-LABEL: sil hidden @_T021dynamic_lookup_throws8testBlubys9AnyObject_p1a_tKF : $@convention(thin) (@owned AnyObject) -> @error Error
+// CHECK-LABEL: sil hidden @_T021dynamic_lookup_throws8testBlubyyXl1a_tKF : $@convention(thin) (@owned AnyObject) -> @error Error
 // CHECK: bb0([[ARG:%.*]] : $AnyObject):
 func testBlub(a: AnyObject) throws {
   // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]

--- a/test/SILGen/dynamic_self.swift
+++ b/test/SILGen/dynamic_self.swift
@@ -111,7 +111,7 @@ func testExistentialDispatchClass(cp: CP) {
   @objc func method() -> Self { return self }
 }
 
-// CHECK-LABEL: sil hidden @_T012dynamic_self21testAnyObjectDispatchys0dE0_p1o_tF : $@convention(thin) (@owned AnyObject) -> () {
+// CHECK-LABEL: sil hidden @_T012dynamic_self21testAnyObjectDispatchyyXl1o_tF : $@convention(thin) (@owned AnyObject) -> () {
 func testAnyObjectDispatch(o: AnyObject) {
   // CHECK: dynamic_method_br [[O_OBJ:%[0-9]+]] : $@opened({{.*}}) AnyObject, #ObjC.method!1.foreign, bb1, bb2
 
@@ -120,7 +120,7 @@ func testAnyObjectDispatch(o: AnyObject) {
   // CHECK:   [[VAR_9:%[0-9]+]] = partial_apply [[METHOD]]([[O_OBJ_COPY]]) : $@convention(objc_method) (@opened({{.*}}) AnyObject) -> @autoreleased AnyObject
   var _ = o.method
 }
-// CHECK: } // end sil function '_T012dynamic_self21testAnyObjectDispatchys0dE0_p1o_tF'
+// CHECK: } // end sil function '_T012dynamic_self21testAnyObjectDispatchyyXl1o_tF'
 
 
 // <rdar://problem/16270889> Dispatch through ObjC metatypes.

--- a/test/SILGen/foreign_errors.swift
+++ b/test/SILGen/foreign_errors.swift
@@ -190,7 +190,7 @@ class VeryErrorProne : ErrorProne {
 // on than is being tested here, we should consider adding FileCheck tests for
 // it.
 
-// CHECK-LABEL:    sil hidden @_T014foreign_errors14VeryErrorProneCACs9AnyObject_pSg7withTwo_tKcfc
+// CHECK-LABEL:    sil hidden @_T014foreign_errors14VeryErrorProneCACyXlSg7withTwo_tKcfc
 // CHECK:    bb0([[ARG1:%.*]] : $Optional<AnyObject>, [[ARG2:%.*]] : $VeryErrorProne):
 // CHECK:      [[BOX:%.*]] = alloc_box ${ var VeryErrorProne }
 // CHECK:      [[MARKED_BOX:%.*]] = mark_uninitialized [derivedself] [[BOX]]

--- a/test/SILGen/function_conversion_objc.swift
+++ b/test/SILGen/function_conversion_objc.swift
@@ -8,12 +8,12 @@ import Foundation
 
 // CHECK-LABEL: sil hidden @_T024function_conversion_objc20convMetatypeToObjectySo8NSObjectCmADcF
 func convMetatypeToObject(_ f: @escaping (NSObject) -> NSObject.Type) {
-// CHECK:         function_ref @_T0So8NSObjectCABXMTIxxd_ABs9AnyObject_pIxxo_TR
+// CHECK:         function_ref @_T0So8NSObjectCABXMTIxxd_AByXlIxxo_TR
 // CHECK:         partial_apply
   let _: (NSObject) -> AnyObject = f
 }
 
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0So8NSObjectCABXMTIxxd_ABs9AnyObject_pIxxo_TR : $@convention(thin) (@owned NSObject, @owned @callee_owned (@owned NSObject) -> @thick NSObject.Type) -> @owned AnyObject {
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0So8NSObjectCABXMTIxxd_AByXlIxxo_TR : $@convention(thin) (@owned NSObject, @owned @callee_owned (@owned NSObject) -> @thick NSObject.Type) -> @owned AnyObject {
 // CHECK:         apply %1(%0)
 // CHECK:         thick_to_objc_metatype {{.*}} : $@thick NSObject.Type to $@objc_metatype NSObject.Type
 // CHECK:         objc_metatype_to_object {{.*}} : $@objc_metatype NSObject.Type to $AnyObject
@@ -23,12 +23,12 @@ func convMetatypeToObject(_ f: @escaping (NSObject) -> NSObject.Type) {
 
 // CHECK-LABEL: sil hidden @_T024function_conversion_objc31convExistentialMetatypeToObjectyAA9NSBurrito_pXpAaC_pcF
 func convExistentialMetatypeToObject(_ f: @escaping (NSBurrito) -> NSBurrito.Type) {
-// CHECK:         function_ref @_T024function_conversion_objc9NSBurrito_pAaB_pXmTIxxd_AaB_ps9AnyObject_pIxxo_TR
+// CHECK:         function_ref @_T024function_conversion_objc9NSBurrito_pAaB_pXmTIxxd_AaB_pyXlIxxo_TR
 // CHECK:         partial_apply
   let _: (NSBurrito) -> AnyObject = f
 }
 
-// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T024function_conversion_objc9NSBurrito_pAaB_pXmTIxxd_AaB_ps9AnyObject_pIxxo_TR : $@convention(thin) (@owned NSBurrito, @owned @callee_owned (@owned NSBurrito) -> @thick NSBurrito.Type) -> @owned AnyObject
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T024function_conversion_objc9NSBurrito_pAaB_pXmTIxxd_AaB_pyXlIxxo_TR : $@convention(thin) (@owned NSBurrito, @owned @callee_owned (@owned NSBurrito) -> @thick NSBurrito.Type) -> @owned AnyObject
 // CHECK:         apply %1(%0)
 // CHECK:         thick_to_objc_metatype {{.*}} : $@thick NSBurrito.Type to $@objc_metatype NSBurrito.Type
 // CHECK:         objc_existential_metatype_to_object {{.*}} : $@objc_metatype NSBurrito.Type to $AnyObject

--- a/test/SILGen/generic_casts.swift
+++ b/test/SILGen/generic_casts.swift
@@ -216,7 +216,7 @@ func class_existential_is_class(_ p: ClassBound) -> Bool {
   // CHECK: checked_cast_br {{%.*}} to $C
 }
 
-// CHECK-LABEL: sil hidden @_T013generic_casts27optional_anyobject_to_classAA1CCSgs9AnyObject_pSgF 
+// CHECK-LABEL: sil hidden @_T013generic_casts27optional_anyobject_to_classAA1CCSgyXlSgF 
 // CHECK:         checked_cast_br {{%.*}} : $AnyObject to $C
 func optional_anyobject_to_class(_ p: AnyObject?) -> C? {
   return p as? C

--- a/test/SILGen/metatype_object_conversion.swift
+++ b/test/SILGen/metatype_object_conversion.swift
@@ -10,7 +10,7 @@ protocol CP : class {}
 
 @objc protocol OP {}
 
-// CHECK-LABEL: sil hidden @_T026metatype_object_conversion0A8ToObjects03AnyE0_pAA1CCmF 
+// CHECK-LABEL: sil hidden @_T026metatype_object_conversion0A8ToObjectyXlAA1CCmF 
 func metatypeToObject(_ x: C.Type) -> AnyObject {
   // CHECK: bb0([[THICK:%.*]] : $@thick C.Type):
   // CHECK:   [[OBJC:%.*]] = thick_to_objc_metatype [[THICK]]
@@ -19,7 +19,7 @@ func metatypeToObject(_ x: C.Type) -> AnyObject {
   return x
 }
 
-// CHECK-LABEL: sil hidden @_T026metatype_object_conversion27existentialMetatypeToObjects03AnyG0_pAA2CP_pXpF
+// CHECK-LABEL: sil hidden @_T026metatype_object_conversion27existentialMetatypeToObjectyXlAA2CP_pXpF
 func existentialMetatypeToObject(_ x: CP.Type) -> AnyObject {
   // CHECK: bb0([[THICK:%.*]] : $@thick CP.Type):
   // CHECK:   [[OBJC:%.*]] = thick_to_objc_metatype [[THICK]]

--- a/test/SILGen/objc_attr_NSManaged_multi.swift
+++ b/test/SILGen/objc_attr_NSManaged_multi.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-// CHECK-LABEL: sil hidden @_T025objc_attr_NSManaged_multi9testMultis9AnyObject_pAA10SwiftGizmoCF : $@convention(thin) (@owned SwiftGizmo) -> @owned AnyObject {
+// CHECK-LABEL: sil hidden @_T025objc_attr_NSManaged_multi9testMultiyXlAA10SwiftGizmoCF : $@convention(thin) (@owned SwiftGizmo) -> @owned AnyObject {
 // CHECK: bb0([[ARG:%.*]] : $SwiftGizmo):
 // CHECK: [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
 // CHECK: = class_method [volatile] [[BORROWED_ARG]] : $SwiftGizmo, #SwiftGizmo.kvc!1.foreign : (SwiftGizmo) -> () -> (), $@convention(objc_method) (SwiftGizmo) -> ()

--- a/test/SILGen/objc_bridging.swift
+++ b/test/SILGen/objc_bridging.swift
@@ -467,7 +467,7 @@ class Bas : NSObject {
     super.init()
   }
 
-  // CHECK-LABEL: sil hidden [thunk] @_T013objc_bridging3BasC8arrayArgySays9AnyObject_pGFTo : $@convention(objc_method) (NSArray, Bas) -> ()
+  // CHECK-LABEL: sil hidden [thunk] @_T013objc_bridging3BasC8arrayArgySayyXlGFTo : $@convention(objc_method) (NSArray, Bas) -> ()
   // CHECK: bb0([[NSARRAY:%[0-9]+]] : $NSArray, [[SELF:%[0-9]+]] : $Bas):
   // CHECK:   [[NSARRAY_COPY:%.*]] = copy_value [[NSARRAY]] : $NSArray
   // CHECK:   [[SELF_COPY:%.*]] = copy_value [[SELF]] : $Bas
@@ -476,18 +476,18 @@ class Bas : NSObject {
   // CHECK:   [[ARRAY_META:%[0-9]+]] = metatype $@thin Array<AnyObject>.Type
   // CHECK:   [[ARRAY:%[0-9]+]] = apply [[CONV_FN]]<AnyObject>([[OPT_NSARRAY]], [[ARRAY_META]])
   // CHECK:   [[BORROWED_SELF_COPY:%.*]] = begin_borrow [[SELF_COPY]]
-  // CHECK:   [[SWIFT_FN:%[0-9]+]] = function_ref @_T013objc_bridging3BasC8arrayArgySays9AnyObject_pGF : $@convention(method) (@owned Array<AnyObject>, @guaranteed Bas) -> ()
+  // CHECK:   [[SWIFT_FN:%[0-9]+]] = function_ref @_T013objc_bridging3BasC8arrayArgySayyXlGF : $@convention(method) (@owned Array<AnyObject>, @guaranteed Bas) -> ()
   // CHECK:   [[RESULT:%[0-9]+]] = apply [[SWIFT_FN]]([[ARRAY]], [[BORROWED_SELF_COPY]]) : $@convention(method) (@owned Array<AnyObject>, @guaranteed Bas) -> ()
   // CHECK:   end_borrow [[BORROWED_SELF_COPY]] from [[SELF_COPY]]
   // CHECK:   destroy_value [[SELF_COPY]] : $Bas
   // CHECK:   return [[RESULT]] : $()
   func arrayArg(_ array: [AnyObject]) { }
   
-  // CHECK-LABEL: sil hidden [thunk] @_T013objc_bridging3BasC11arrayResultSays9AnyObject_pGyFTo : $@convention(objc_method) (Bas) -> @autoreleased NSArray
+  // CHECK-LABEL: sil hidden [thunk] @_T013objc_bridging3BasC11arrayResultSayyXlGyFTo : $@convention(objc_method) (Bas) -> @autoreleased NSArray
   // CHECK: bb0([[SELF:%[0-9]+]] : $Bas):
   // CHECK:   [[SELF_COPY:%.*]] = copy_value [[SELF]] : $Bas
   // CHECK:   [[BORROWED_SELF_COPY:%.*]] = begin_borrow [[SELF_COPY]]
-  // CHECK:   [[SWIFT_FN:%[0-9]+]] = function_ref @_T013objc_bridging3BasC11arrayResultSays9AnyObject_pGyF : $@convention(method) (@guaranteed Bas) -> @owned Array<AnyObject>
+  // CHECK:   [[SWIFT_FN:%[0-9]+]] = function_ref @_T013objc_bridging3BasC11arrayResultSayyXlGyF : $@convention(method) (@guaranteed Bas) -> @owned Array<AnyObject>
   // CHECK:   [[ARRAY:%[0-9]+]] = apply [[SWIFT_FN]]([[BORROWED_SELF_COPY]]) : $@convention(method) (@guaranteed Bas) -> @owned Array<AnyObject>
   // CHECK:   end_borrow [[BORROWED_SELF_COPY]] from [[SELF_COPY]]
   // CHECK:   destroy_value [[SELF_COPY]]
@@ -548,9 +548,9 @@ func forceNSArrayMembers() -> (NSArray, NSArray) {
 // arguments lifetime-extends the bridged pointer for the right duration.
 // <rdar://problem/16738050>
 
-// CHECK-LABEL: sil shared [serializable] @_T0So7NSArrayCABSQySPys9AnyObject_pSgGG7objects_s5Int32V5counttcfC
+// CHECK-LABEL: sil shared [serializable] @_T0So7NSArrayCABSQySPyyXlSgGG7objects_s5Int32V5counttcfC
 // CHECK:         [[SELF:%.*]] = alloc_ref_dynamic
-// CHECK:         [[METHOD:%.*]] = function_ref @_T0So7NSArrayCABSQySPys9AnyObject_pSgGG7objects_s5Int32V5counttcfcTO
+// CHECK:         [[METHOD:%.*]] = function_ref @_T0So7NSArrayCABSQySPyyXlSgGG7objects_s5Int32V5counttcfcTO
 // CHECK:         [[RESULT:%.*]] = apply [[METHOD]]
 // CHECK:         return [[RESULT]]
 

--- a/test/SILGen/objc_bridging_any.swift
+++ b/test/SILGen/objc_bridging_any.swift
@@ -139,7 +139,7 @@ func passingToId<T: CP, U>(receiver: NSIdLover,
   // CHECK:   [[ERROR_BOX:%[0-9]+]] = open_existential_box [[ERROR_COPY]] : $Error to $*@opened([[ERROR_ARCHETYPE:"[^"]*"]]) Error
   // CHECK:   [[ERROR_STACK:%[0-9]+]] = alloc_stack $@opened([[ERROR_ARCHETYPE]]) Error
   // CHECK:   copy_addr [[ERROR_BOX]] to [initialization] [[ERROR_STACK]] : $*@opened([[ERROR_ARCHETYPE]]) Error
-  // CHECK:   [[BRIDGE_FUNCTION:%[0-9]+]] = function_ref @_T0s27_bridgeAnythingToObjectiveCs9AnyObject_pxlF
+  // CHECK:   [[BRIDGE_FUNCTION:%[0-9]+]] = function_ref @_T0s27_bridgeAnythingToObjectiveCyXlxlF
   // CHECK:   [[BRIDGED_ERROR:%[0-9]+]] = apply [[BRIDGE_FUNCTION]]<@opened([[ERROR_ARCHETYPE]]) Error>([[ERROR_STACK]])
   // CHECK:   dealloc_stack [[ERROR_STACK]] : $*@opened([[ERROR_ARCHETYPE]]) Error
   // CHECK:   destroy_value [[ERROR_COPY]] : $Error
@@ -182,7 +182,7 @@ func passingToId<T: CP, U>(receiver: NSIdLover,
   // CHECK:   [[METHOD:%.*]] = class_method [volatile] [[BORROWED_SELF]] : $NSIdLover,
   // CHECK:   [[BORROWED_OPT_STRING:%.*]] = begin_borrow [[OPT_STRING]]
   // CHECK:   [[OPT_STRING_COPY:%.*]] = copy_value [[BORROWED_OPT_STRING]]
-  // CHECK:   [[BRIDGE_OPTIONAL:%.*]] = function_ref @_T0Sq19_bridgeToObjectiveCs9AnyObject_pyF
+  // CHECK:   [[BRIDGE_OPTIONAL:%.*]] = function_ref @_T0Sq19_bridgeToObjectiveCyXlyF
   // CHECK:   [[TMP:%.*]] = alloc_stack $Optional<String>
   // CHECK:   store [[OPT_STRING_COPY]] to [init] [[TMP]]
   // CHECK:   [[ANYOBJECT:%.*]] = apply [[BRIDGE_OPTIONAL]]<String>([[TMP]])
@@ -195,7 +195,7 @@ func passingToId<T: CP, U>(receiver: NSIdLover,
   // CHECK:   [[METHOD:%.*]] = class_method [volatile] [[BORROWED_SELF]] : $NSIdLover,
   // CHECK:   [[BORROWED_OPT_NSSTRING:%.*]] = begin_borrow [[OPT_NSSTRING]]
   // CHECK:   [[OPT_NSSTRING_COPY:%.*]] = copy_value [[BORROWED_OPT_NSSTRING]]
-  // CHECK:   [[BRIDGE_OPTIONAL:%.*]] = function_ref @_T0Sq19_bridgeToObjectiveCs9AnyObject_pyF
+  // CHECK:   [[BRIDGE_OPTIONAL:%.*]] = function_ref @_T0Sq19_bridgeToObjectiveCyXlyF
   // CHECK:   [[TMP:%.*]] = alloc_stack $Optional<NSString>
   // CHECK:   store [[OPT_NSSTRING_COPY]] to [init] [[TMP]]
   // CHECK:   [[ANYOBJECT:%.*]] = apply [[BRIDGE_OPTIONAL]]<NSString>([[TMP]])
@@ -208,7 +208,7 @@ func passingToId<T: CP, U>(receiver: NSIdLover,
   // CHECK:   [[METHOD:%.*]] = class_method [volatile] [[BORROWED_SELF]] : $NSIdLover,
   // CHECK:   [[TMP:%.*]] = alloc_stack $Optional<Any>
   // CHECK:   copy_addr [[OPT_ANY]] to [initialization] [[TMP]]
-  // CHECK:   [[BRIDGE_OPTIONAL:%.*]] = function_ref @_T0Sq19_bridgeToObjectiveCs9AnyObject_pyF
+  // CHECK:   [[BRIDGE_OPTIONAL:%.*]] = function_ref @_T0Sq19_bridgeToObjectiveCyXlyF
   // CHECK:   [[ANYOBJECT:%.*]] = apply [[BRIDGE_OPTIONAL]]<Any>([[TMP]])
   // CHECK:   apply [[METHOD]]([[ANYOBJECT]], [[BORROWED_SELF]])
   // CHECK:   end_borrow [[BORROWED_SELF]] from [[SELF]]
@@ -383,7 +383,7 @@ func passingToNullableId<T: CP, U>(receiver: NSIdLover,
   // CHECK-NEXT: [[ERROR_BOX:%[0-9]+]] = open_existential_box [[ERROR_COPY]] : $Error to $*@opened([[ERROR_ARCHETYPE:"[^"]*"]]) Error
   // CHECK-NEXT: [[ERROR_STACK:%[0-9]+]] = alloc_stack $@opened([[ERROR_ARCHETYPE]]) Error
   // CHECK-NEXT: copy_addr [[ERROR_BOX]] to [initialization] [[ERROR_STACK]] : $*@opened([[ERROR_ARCHETYPE]]) Error
-  // CHECK: [[BRIDGE_FUNCTION:%[0-9]+]] = function_ref @_T0s27_bridgeAnythingToObjectiveCs9AnyObject_pxlF
+  // CHECK: [[BRIDGE_FUNCTION:%[0-9]+]] = function_ref @_T0s27_bridgeAnythingToObjectiveCyXlxlF
   // CHECK-NEXT: [[BRIDGED_ERROR:%[0-9]+]] = apply [[BRIDGE_FUNCTION]]<@opened([[ERROR_ARCHETYPE]]) Error>([[ERROR_STACK]])
   // CHECK-NEXT: [[BRIDGED_ERROR_OPT:%[0-9]+]] = enum $Optional<AnyObject>, #Optional.some!enumelt.1, [[BRIDGED_ERROR]] : $AnyObject
   // CHECK-NEXT: dealloc_stack [[ERROR_STACK]] : $*@opened([[ERROR_ARCHETYPE]]) Error
@@ -545,7 +545,7 @@ class SwiftIdLover : NSObject, Anyable {
   // CHECK:    bb0([[BLOCK:%.*]] : $@convention(block) (AnyObject) -> (), [[SELF:%.*]] : $SwiftIdLover):
   // CHECK-NEXT:  [[BLOCK_COPY:%.*]] = copy_block [[BLOCK]]
   // CHECK-NEXT:  [[SELF_COPY:%.*]] = copy_value [[SELF]]
-  // CHECK:       [[THUNK_FN:%.*]] = function_ref @_T0s9AnyObject_pIyBy_ypIxi_TR
+  // CHECK:       [[THUNK_FN:%.*]] = function_ref @_T0yXlIyBy_ypIxi_TR
   // CHECK-NEXT:  [[THUNK:%.*]] = partial_apply [[THUNK_FN]]([[BLOCK_COPY]])
   // CHECK:       [[BORROWED_SELF_COPY:%.*]] = begin_borrow [[SELF_COPY]]
   // CHECK-NEXT:  // function_ref
@@ -555,7 +555,7 @@ class SwiftIdLover : NSObject, Anyable {
   // CHECK-NEXT:  destroy_value [[SELF_COPY]]
   // CHECK-NEXT:  return [[RESULT]]
 
-  // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0s9AnyObject_pIyBy_ypIxi_TR
+  // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0yXlIyBy_ypIxi_TR
   // CHECK:     bb0([[ANY:%.*]] : $*Any, [[BLOCK:%.*]] : $@convention(block) (AnyObject) -> ()):
   // CHECK-NEXT:  [[OPENED_ANY:%.*]] = open_existential_addr immutable_access [[ANY]] : $*Any to $*[[OPENED_TYPE:@opened.*Any]],
 	// CHECK:   [[TMP:%.*]] = alloc_stack
@@ -587,14 +587,14 @@ class SwiftIdLover : NSObject, Anyable {
   // CHECK-NEXT:  [[BLOCK_STORAGE:%.*]] = alloc_stack $@block_storage @callee_owned (@in Any) -> ()
   // CHECK-NEXT:  [[BLOCK_STORAGE_ADDR:%.*]] = project_block_storage [[BLOCK_STORAGE]]
   // CHECK-NEXT:  store [[RESULT:%.*]] to [init] [[BLOCK_STORAGE_ADDR]]
-  // CHECK:       [[THUNK_FN:%.*]] = function_ref @_T0ypIxi_s9AnyObject_pIyBy_TR
+  // CHECK:       [[THUNK_FN:%.*]] = function_ref @_T0ypIxi_yXlIyBy_TR
   // CHECK-NEXT:  [[BLOCK_HEADER:%.*]] = init_block_storage_header [[BLOCK_STORAGE]] : $*@block_storage @callee_owned (@in Any) -> (), invoke [[THUNK_FN]]
   // CHECK-NEXT:  [[BLOCK:%.*]] = copy_block [[BLOCK_HEADER]]
   // CHECK-NEXT:  dealloc_stack [[BLOCK_STORAGE]]
   // CHECK-NEXT:  destroy_value [[RESULT]]
   // CHECK-NEXT:  return [[BLOCK]]
 
-  // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0ypIxi_s9AnyObject_pIyBy_TR : $@convention(c) (@inout_aliasable @block_storage @callee_owned (@in Any) -> (), AnyObject) -> ()
+  // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0ypIxi_yXlIyBy_TR : $@convention(c) (@inout_aliasable @block_storage @callee_owned (@in Any) -> (), AnyObject) -> ()
   // CHECK:     bb0([[BLOCK_STORAGE:%.*]] : $*@block_storage @callee_owned (@in Any) -> (), [[ANY:%.*]] : $AnyObject):
   // CHECK-NEXT:  [[BLOCK_STORAGE_ADDR:%.*]] = project_block_storage [[BLOCK_STORAGE]]
   // CHECK-NEXT:  [[FUNCTION:%.*]] = load [copy] [[BLOCK_STORAGE_ADDR]]
@@ -620,7 +620,7 @@ class SwiftIdLover : NSObject, Anyable {
   // CHECK-NEXT:  [[BLOCK_COPY:%.*]] = copy_block [[BLOCK]]
   // CHECK-NEXT:  [[ANY_COPY:%.*]] = copy_value [[ANY]]
   // CHECK-NEXT:  // function_ref
-  // CHECK-NEXT:  [[THUNK_FN:%.*]] = function_ref @_T0s9AnyObject_pIyBa_ypIxr_TR
+  // CHECK-NEXT:  [[THUNK_FN:%.*]] = function_ref @_T0yXlIyBa_ypIxr_TR
   // CHECK-NEXT:  [[THUNK:%.*]] = partial_apply [[THUNK_FN]]([[BLOCK_COPY]])
   // CHECK-NEXT:  [[BORROWED_ANY_COPY:%.*]] = begin_borrow [[ANY_COPY]]
   // CHECK-NEXT:  // function_ref
@@ -630,7 +630,7 @@ class SwiftIdLover : NSObject, Anyable {
   // CHECK-NEXT:  destroy_value [[ANY_COPY]]
   // CHECK-NEXT:  return [[RESULT]]
 
-  // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0s9AnyObject_pIyBa_ypIxr_TR : $@convention(thin) (@owned @convention(block) () -> @autoreleased AnyObject) -> @out Any
+  // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0yXlIyBa_ypIxr_TR : $@convention(thin) (@owned @convention(block) () -> @autoreleased AnyObject) -> @out Any
   // CHECK:     bb0([[ANY_ADDR:%.*]] : $*Any, [[BLOCK:%.*]] : $@convention(block) () -> @autoreleased AnyObject):
   // CHECK-NEXT:  [[BRIDGED:%.*]] = apply [[BLOCK]]()
   // CHECK-NEXT:  [[OPTIONAL:%.*]] = unchecked_ref_cast [[BRIDGED]]
@@ -665,14 +665,14 @@ class SwiftIdLover : NSObject, Anyable {
   // CHECK-NEXT:  [[BLOCK_STORAGE_ADDR:%.*]] = project_block_storage [[BLOCK_STORAGE]]
   // CHECK-NEXT:  store [[FUNCTION]] to [init] [[BLOCK_STORAGE_ADDR]]
   // CHECK-NEXT:  // function_ref
-  // CHECK-NEXT:  [[THUNK_FN:%.*]] = function_ref @_T0ypIxr_s9AnyObject_pIyBa_TR
+  // CHECK-NEXT:  [[THUNK_FN:%.*]] = function_ref @_T0ypIxr_yXlIyBa_TR
   // CHECK-NEXT:  [[BLOCK_HEADER:%.*]] = init_block_storage_header [[BLOCK_STORAGE]] : $*@block_storage @callee_owned () -> @out Any, invoke [[THUNK_FN]]
   // CHECK-NEXT:  [[BLOCK:%.*]] = copy_block [[BLOCK_HEADER]]
   // CHECK-NEXT:  dealloc_stack [[BLOCK_STORAGE]]
   // CHECK-NEXT:  destroy_value [[FUNCTION]]
   // CHECK-NEXT:  return [[BLOCK]]
 
-  // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0ypIxr_s9AnyObject_pIyBa_TR : $@convention(c) (@inout_aliasable @block_storage @callee_owned () -> @out Any) -> @autoreleased AnyObject
+  // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0ypIxr_yXlIyBa_TR : $@convention(c) (@inout_aliasable @block_storage @callee_owned () -> @out Any) -> @autoreleased AnyObject
   // CHECK:     bb0(%0 : $*@block_storage @callee_owned () -> @out Any):
   // CHECK-NEXT:  [[BLOCK_STORAGE_ADDR:%.*]] = project_block_storage %0
   // CHECK-NEXT:  [[FUNCTION:%.*]] = load [copy] [[BLOCK_STORAGE_ADDR]]
@@ -694,7 +694,7 @@ class SwiftIdLover : NSObject, Anyable {
   @objc func methodReturningBlockReturningAny() -> (() -> Any) {}
 
   @objc func methodReturningBlockReturningOptionalAny() -> (() -> Any?) {}
-  // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0ypSgIxr_s9AnyObject_pSgIyBa_TR
+  // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0ypSgIxr_yXlSgIyBa_TR
   // CHECK: function_ref @_T0s27_bridgeAnythingToObjectiveC{{.*}}F
 
   override init() { super.init() }

--- a/test/SILGen/objc_currying.swift
+++ b/test/SILGen/objc_currying.swift
@@ -126,7 +126,7 @@ func curry_returnsInnerPointer(_ x: CurryTest) -> () -> UnsafeMutableRawPointer!
 // CHECK:   return [[RES]]
 // CHECK: } // end sil function '[[THUNK_RETURNSINNERPOINTER_2]]'
 
-// CHECK-LABEL: sil hidden @_T013objc_currying19curry_pod_AnyObjectS2ics0eF0_pF : $@convention(thin) (@owned AnyObject) -> @owned @callee_owned (Int) -> Int
+// CHECK-LABEL: sil hidden @_T013objc_currying19curry_pod_AnyObjectS2icyXlF : $@convention(thin) (@owned AnyObject) -> @owned @callee_owned (Int) -> Int
 // CHECK: bb0([[ANY:%.*]] : $AnyObject):
 // CHECK:   [[BORROWED_ANY:%.*]] = begin_borrow [[ANY]]
 // CHECK:   [[OPENED_ANY:%.*]] = open_existential_ref [[BORROWED_ANY]]
@@ -135,13 +135,13 @@ func curry_returnsInnerPointer(_ x: CurryTest) -> () -> UnsafeMutableRawPointer!
 // CHECK:   [[HAS_METHOD]]([[METHOD:%.*]] : $@convention(objc_method) (Int, @opened({{.*}}) AnyObject) -> Int):
 // CHECK:   [[OPENED_ANY_COPY_2:%.*]] = copy_value [[OPENED_ANY_COPY]]
 // CHECK:   partial_apply [[METHOD]]([[OPENED_ANY_COPY_2]])
-// CHECK: } // end sil function '_T013objc_currying19curry_pod_AnyObjectS2ics0eF0_pF'
+// CHECK: } // end sil function '_T013objc_currying19curry_pod_AnyObjectS2icyXlF'
 func curry_pod_AnyObject(_ x: AnyObject) -> (Int) -> Int {
   return x.pod!
 }
 
 // normalOwnership requires a thunk to bring the method to Swift conventions
-// CHECK-LABEL: sil hidden @_T013objc_currying31curry_normalOwnership_AnyObjectSQySo9CurryTestCGAEcs0fG0_pF : $@convention(thin) (@owned AnyObject) -> @owned @callee_owned (@owned Optional<CurryTest>) -> @owned Optional<CurryTest> {
+// CHECK-LABEL: sil hidden @_T013objc_currying31curry_normalOwnership_AnyObjectSQySo9CurryTestCGAEcyXlF : $@convention(thin) (@owned AnyObject) -> @owned @callee_owned (@owned Optional<CurryTest>) -> @owned Optional<CurryTest> {
 // CHECK: bb0([[ANY:%.*]] : $AnyObject):
 // CHECK:   [[BORROWED_ANY:%.*]] = begin_borrow [[ANY]]
 // CHECK:   [[OPENED_ANY:%.*]] = open_existential_ref [[BORROWED_ANY]]
@@ -152,14 +152,14 @@ func curry_pod_AnyObject(_ x: AnyObject) -> (Int) -> Int {
 // CHECK:   [[PA:%.*]] = partial_apply [[METHOD]]([[OPENED_ANY_COPY_2]])
 // CHECK:   [[THUNK:%.*]] = function_ref @_T0So9CurryTestCSgACIxyo_A2CIxxo_TR
 // CHECK:   partial_apply [[THUNK]]([[PA]])
-// CHECK: } // end sil function '_T013objc_currying31curry_normalOwnership_AnyObjectSQySo9CurryTestCGAEcs0fG0_pF'
+// CHECK: } // end sil function '_T013objc_currying31curry_normalOwnership_AnyObjectSQySo9CurryTestCGAEcyXlF'
 func curry_normalOwnership_AnyObject(_ x: AnyObject) -> (CurryTest!) -> CurryTest! {
   return x.normalOwnership!
 }
 
 // weirdOwnership is NS_RETURNS_RETAINED and NS_CONSUMES_SELF so already
 // follows Swift conventions
-// CHECK-LABEL: sil hidden @_T013objc_currying30curry_weirdOwnership_AnyObjectSQySo9CurryTestCGAEcs0fG0_pF : $@convention(thin) (@owned AnyObject) -> @owned @callee_owned (@owned Optional<CurryTest>) -> @owned Optional<CurryTest>
+// CHECK-LABEL: sil hidden @_T013objc_currying30curry_weirdOwnership_AnyObjectSQySo9CurryTestCGAEcyXlF : $@convention(thin) (@owned AnyObject) -> @owned @callee_owned (@owned Optional<CurryTest>) -> @owned Optional<CurryTest>
 // CHECK: bb0([[ANY:%.*]] : $AnyObject):
 // CHECK:   [[BORROWED_ANY:%.*]] = begin_borrow [[ANY]]
 // CHECK:   [[OPENED_ANY:%.*]] = open_existential_ref [[BORROWED_ANY]]
@@ -168,13 +168,13 @@ func curry_normalOwnership_AnyObject(_ x: AnyObject) -> (CurryTest!) -> CurryTes
 // CHECK: bb1([[METHOD:%.*]] : $@convention(objc_method) (@owned Optional<CurryTest>, @owned @opened({{.*}}) AnyObject) -> @owned Optional<CurryTest>):
 // CHECK:   [[OPENED_ANY_COPY_2:%.*]] = copy_value [[OPENED_ANY_COPY]]
 // CHECK:   partial_apply [[METHOD]]([[OPENED_ANY_COPY_2]])
-// CHECK: } // end sil function '_T013objc_currying30curry_weirdOwnership_AnyObjectSQySo9CurryTestCGAEcs0fG0_pF'
+// CHECK: } // end sil function '_T013objc_currying30curry_weirdOwnership_AnyObjectSQySo9CurryTestCGAEcyXlF'
 func curry_weirdOwnership_AnyObject(_ x: AnyObject) -> (CurryTest!) -> CurryTest! {
   return x.weirdOwnership!
 }
 
 // bridged requires a thunk to handle bridging conversions
-// CHECK-LABEL: sil hidden @_T013objc_currying23curry_bridged_AnyObjectSQySSGACcs0eF0_pF : $@convention(thin) (@owned AnyObject) -> @owned @callee_owned (@owned Optional<String>) -> @owned Optional<String>
+// CHECK-LABEL: sil hidden @_T013objc_currying23curry_bridged_AnyObjectSQySSGACcyXlF : $@convention(thin) (@owned AnyObject) -> @owned @callee_owned (@owned Optional<String>) -> @owned Optional<String>
 // CHECK: bb0([[ANY:%.*]] : $AnyObject):
 // CHECK:    [[BORROWED_ANY:%.*]] = begin_borrow [[ANY]]
 // CHECK:   [[OPENED_ANY:%.*]] = open_existential_ref [[BORROWED_ANY]]
@@ -185,14 +185,14 @@ func curry_weirdOwnership_AnyObject(_ x: AnyObject) -> (CurryTest!) -> CurryTest
 // CHECK:   [[PA:%.*]] = partial_apply [[METHOD]]([[OPENED_ANY_COPY_2]])
 // CHECK:   [[THUNK:%.*]] = function_ref @_T0So8NSStringCSgACIxyo_SSSgADIxxo_TR
 // CHECK:   partial_apply [[THUNK]]([[PA]])
-// CHECK: } // end sil function '_T013objc_currying23curry_bridged_AnyObjectSQySSGACcs0eF0_pF'
+// CHECK: } // end sil function '_T013objc_currying23curry_bridged_AnyObjectSQySSGACcyXlF'
 func curry_bridged_AnyObject(_ x: AnyObject) -> (String!) -> String! {
   return x.bridged!
 }
 
 // check that we substitute Self = AnyObject correctly for Self-returning
 // methods
-// CHECK-LABEL: sil hidden @_T013objc_currying27curry_returnsSelf_AnyObjectSQys0fG0_pGycsAC_pF : $@convention(thin) (@owned AnyObject) -> @owned @callee_owned () -> @owned Optional<AnyObject> {
+// CHECK-LABEL: sil hidden @_T013objc_currying27curry_returnsSelf_AnyObjectSQyyXlGycyXlF : $@convention(thin) (@owned AnyObject) -> @owned @callee_owned () -> @owned Optional<AnyObject> {
 // CHECK: bb0([[ANY:%.*]] : $AnyObject):
 // CHECK:   [[BORROWED_ANY:%.*]] = begin_borrow [[ANY]]
 // CHECK:   [[OPENED_ANY:%.*]] = open_existential_ref [[BORROWED_ANY]]
@@ -201,12 +201,12 @@ func curry_bridged_AnyObject(_ x: AnyObject) -> (String!) -> String! {
 // CHECK: [[HAS_METHOD]]([[METHOD:%.*]] : $@convention(objc_method) (@opened({{.*}}) AnyObject) -> @autoreleased Optional<AnyObject>):
 // CHECK:   [[OPENED_ANY_COPY_2:%.*]] = copy_value [[OPENED_ANY_COPY]]
 // CHECK:   [[PA:%.*]] = partial_apply [[METHOD]]([[OPENED_ANY_COPY_2]])
-// CHECK: } // end sil function '_T013objc_currying27curry_returnsSelf_AnyObjectSQys0fG0_pGycsAC_pF'
+// CHECK: } // end sil function '_T013objc_currying27curry_returnsSelf_AnyObjectSQyyXlGycyXlF'
 func curry_returnsSelf_AnyObject(_ x: AnyObject) -> () -> AnyObject! {
   return x.returnsSelf!
 }
 
-// CHECK-LABEL: sil hidden @_T013objc_currying35curry_returnsInnerPointer_AnyObjectSQySvGycs0gH0_pF : $@convention(thin) (@owned AnyObject) -> @owned @callee_owned () -> Optional<UnsafeMutableRawPointer> {
+// CHECK-LABEL: sil hidden @_T013objc_currying35curry_returnsInnerPointer_AnyObjectSQySvGycyXlF : $@convention(thin) (@owned AnyObject) -> @owned @callee_owned () -> Optional<UnsafeMutableRawPointer> {
 // CHECK: bb0([[ANY:%.*]] : $AnyObject):
 // CHECK:   [[BORROWED_ANY:%.*]] = begin_borrow [[ANY]]
 // CHECK:   [[OPENED_ANY:%.*]] = open_existential_ref [[BORROWED_ANY]]
@@ -215,7 +215,7 @@ func curry_returnsSelf_AnyObject(_ x: AnyObject) -> () -> AnyObject! {
 // CHECK: [[HAS_METHOD]]([[METHOD:%.*]] : $@convention(objc_method) (@opened({{.*}}) AnyObject) -> @unowned_inner_pointer Optional<UnsafeMutableRawPointer>):
 // CHECK:   [[OPENED_ANY_COPY_2:%.*]] = copy_value [[OPENED_ANY_COPY]]
 // CHECK:   [[PA:%.*]] = partial_apply [[METHOD]]([[OPENED_ANY_COPY_2]])
-// CHECK: } // end sil function '_T013objc_currying35curry_returnsInnerPointer_AnyObjectSQySvGycs0gH0_pF'
+// CHECK: } // end sil function '_T013objc_currying35curry_returnsInnerPointer_AnyObjectSQySvGycyXlF'
 
 func curry_returnsInnerPointer_AnyObject(_ x: AnyObject) -> () -> UnsafeMutableRawPointer! {
   return x.returnsInnerPointer!

--- a/test/SILGen/objc_deprecated_objc_thunks.swift
+++ b/test/SILGen/objc_deprecated_objc_thunks.swift
@@ -24,11 +24,11 @@ class ObjCSubclass : NSObject {
   // CHECK-NEXT: builtin "swift3ImplicitObjCEntrypoint"() : $()
   var bar: NSObject? = nil
 
-  // CHECK-LABEL: sil hidden [thunk] @_T0016objc_deprecated_A7_thunks12ObjCSubclassC9subscripts9AnyObject_pSicfgTo : $@convention(objc_method) (Int, ObjCSubclass) -> @autoreleased AnyObject 
+  // CHECK-LABEL: sil hidden [thunk] @_T0016objc_deprecated_A7_thunks12ObjCSubclassC9subscriptyXlSicfgTo : $@convention(objc_method) (Int, ObjCSubclass) -> @autoreleased AnyObject 
   // CHECK: bb0(%0 : $Int, %1 : $ObjCSubclass):
   // CHECK-NEXT: builtin "swift3ImplicitObjCEntrypoint"() : $()
 
-  // CHECK-LABEL: sil hidden [thunk] @_T0016objc_deprecated_A7_thunks12ObjCSubclassC9subscripts9AnyObject_pSicfsTo : $@convention(objc_method) (AnyObject, Int, ObjCSubclass) ->
+  // CHECK-LABEL: sil hidden [thunk] @_T0016objc_deprecated_A7_thunks12ObjCSubclassC9subscriptyXlSicfsTo : $@convention(objc_method) (AnyObject, Int, ObjCSubclass) ->
   // CHECK: bb0(%0 : $AnyObject, %1 : $Int, %2 : $ObjCSubclass):
   // CHECK-NEXT: builtin "swift3ImplicitObjCEntrypoint"() : $()
   subscript (i: Int) -> AnyObject { get { return self } set { } } 

--- a/test/SILGen/objc_imported_generic.swift
+++ b/test/SILGen/objc_imported_generic.swift
@@ -24,39 +24,39 @@ public func genericMethodOnAnyObjectChained(o: AnyObject, b: Bool) -> AnyObject?
   return o.thing?()
 }
 
-// CHECK-LABEL: sil @_T021objc_imported_generic0C24MethodOnAnyObjectChaineds0fG0_pSgsAC_p1o_Sb1btF
+// CHECK-LABEL: sil @_T021objc_imported_generic0C24MethodOnAnyObjectChainedyXlSgyXl1o_Sb1btF
 // CHECK: bb0([[ANY:%.*]] : $AnyObject, [[BOOL:%.*]] : $Bool):
 // CHECK:   [[BORROWED_ANY:%.*]] = begin_borrow [[ANY]]
 // CHECK:   [[OPENED_ANY:%.*]] = open_existential_ref [[BORROWED_ANY]]
 // CHECK:   [[OPENED_ANY_COPY:%.*]] = copy_value [[OPENED_ANY]]
 // CHECK:   dynamic_method_br [[OPENED_ANY_COPY]] : $@opened([[TAG:.*]]) AnyObject, #GenericClass.thing!1.foreign, bb1
 // CHECK:   bb1({{%.*}} : $@convention(objc_method) @pseudogeneric (@opened([[TAG]]) AnyObject) -> @autoreleased Optional<AnyObject>):
-// CHECK: } // end sil function '_T021objc_imported_generic0C24MethodOnAnyObjectChaineds0fG0_pSgsAC_p1o_Sb1btF'
+// CHECK: } // end sil function '_T021objc_imported_generic0C24MethodOnAnyObjectChainedyXlSgyXl1o_Sb1btF'
 
 public func genericSubscriptOnAnyObject(o: AnyObject, b: Bool) -> AnyObject? {
   return o[0 as UInt16]
 }
 
-// CHECK-LABEL: sil @_T021objc_imported_generic0C20SubscriptOnAnyObjects0fG0_pSgsAC_p1o_Sb1btF
+// CHECK-LABEL: sil @_T021objc_imported_generic0C20SubscriptOnAnyObjectyXlSgyXl1o_Sb1btF
 // CHECK: bb0([[ANY:%.*]]
 // CHCEK:   [[OPENED_ANY:%.*]] = open_existential_ref [[ANY]]
 // CHECK:   [[OPENED_ANY_COPY:%.*]] = copy_value [[OPENED_ANY]]
 // CHECK:   dynamic_method_br [[OPENED_ANY_COPY]] : $@opened([[TAG:.*]]) AnyObject, #GenericClass.subscript!getter.1.foreign, bb1
 // CHECK:   bb1({{%.*}} : $@convention(objc_method) @pseudogeneric (UInt16, @opened([[TAG]]) AnyObject) -> @autoreleased AnyObject):
-// CHECK: } // end sil function '_T021objc_imported_generic0C20SubscriptOnAnyObjects0fG0_pSgsAC_p1o_Sb1btF'
+// CHECK: } // end sil function '_T021objc_imported_generic0C20SubscriptOnAnyObjectyXlSgyXl1o_Sb1btF'
 
 public func genericPropertyOnAnyObject(o: AnyObject, b: Bool) -> AnyObject?? {
   return o.propertyThing
 }
 
-// CHECK-LABEL: sil @_T021objc_imported_generic0C19PropertyOnAnyObjects0fG0_pSgSgsAC_p1o_Sb1btF
+// CHECK-LABEL: sil @_T021objc_imported_generic0C19PropertyOnAnyObjectyXlSgSgyXl1o_Sb1btF
 // CHECK: bb0([[ANY:%.*]] : $AnyObject, [[BOOL:%.*]] : $Bool):
 // CHECK:   [[BORROWED_ANY:%.*]] = begin_borrow [[ANY]]
 // CHECK:   [[OPENED_ANY:%.*]] = open_existential_ref [[BORROWED_ANY]]
 // CHECK:   [[OPENED_ANY_COPY:%.*]] = copy_value [[OPENED_ANY]]
 // CHECK:   dynamic_method_br [[OPENED_ANY_COPY]] : $@opened([[TAG:.*]]) AnyObject, #GenericClass.propertyThing!getter.1.foreign, bb1
 // CHECK:   bb1({{%.*}} : $@convention(objc_method) @pseudogeneric (@opened([[TAG]]) AnyObject) -> @autoreleased Optional<AnyObject>):
-// CHECK: } // end sil function '_T021objc_imported_generic0C19PropertyOnAnyObjects0fG0_pSgSgsAC_p1o_Sb1btF'
+// CHECK: } // end sil function '_T021objc_imported_generic0C19PropertyOnAnyObjectyXlSgSgyXl1o_Sb1btF'
 
 public protocol ThingHolder {
   associatedtype Thing
@@ -89,9 +89,9 @@ public func genericBlockBridging<T: Ansible>(x: GenericClass<T>) {
 }
 
 // CHECK-LABEL: sil @_T021objc_imported_generic0C13BlockBridging{{[_0-9a-zA-Z]*}}F
-// CHECK:         [[BLOCK_TO_FUNC:%.*]] = function_ref @_T0xxIyBya_xxIxxo_s9AnyObjectRz21objc_imported_generic7AnsibleRzlTR
+// CHECK:         [[BLOCK_TO_FUNC:%.*]] = function_ref @_T0xxIyBya_xxIxxo_RlzC21objc_imported_generic7AnsibleRzlTR
 // CHECK:         partial_apply [[BLOCK_TO_FUNC]]<T>
-// CHECK:         [[FUNC_TO_BLOCK:%.*]] = function_ref @_T0xxIxxo_xxIyBya_s9AnyObjectRz21objc_imported_generic7AnsibleRzlTR
+// CHECK:         [[FUNC_TO_BLOCK:%.*]] = function_ref @_T0xxIxxo_xxIyBya_RlzC21objc_imported_generic7AnsibleRzlTR
 // CHECK:         init_block_storage_header {{.*}} invoke [[FUNC_TO_BLOCK]]<T>
 
 // CHECK-LABEL: sil @_T021objc_imported_generic20arraysOfGenericParam{{[_0-9a-zA-Z]*}}F
@@ -106,7 +106,7 @@ public func arraysOfGenericParam<T: AnyObject>(y: Array<T>) {
   x.propertyArrayOfThings = y
 }
 
-// CHECK-LABEL: sil private @_T021objc_imported_generic0C4Funcyxms9AnyObjectRzlFyycfU_ : $@convention(thin) <V where V : AnyObject> () -> () {
+// CHECK-LABEL: sil private @_T021objc_imported_generic0C4FuncyxmRlzClFyycfU_ : $@convention(thin) <V where V : AnyObject> () -> () {
 // CHECK:  [[INIT:%.*]] = function_ref @_T0So12GenericClassCAByxGycfC : $@convention(method) <τ_0_0 where τ_0_0 : AnyObject> (@thick GenericClass<τ_0_0>.Type) -> @owned GenericClass<τ_0_0>
 // CHECK:  [[META:%.*]] = metatype $@thick GenericClass<V>.Type
 // CHECK:  apply [[INIT]]<V>([[META]])

--- a/test/SILGen/objc_properties.swift
+++ b/test/SILGen/objc_properties.swift
@@ -155,30 +155,30 @@ class Singleton : NSObject {
 }
 
 class HasUnmanaged : NSObject {
-  // CHECK-LABEL: sil hidden [thunk] @_T015objc_properties12HasUnmanagedC3refs0D0Vys9AnyObject_pGSgfgTo
+  // CHECK-LABEL: sil hidden [thunk] @_T015objc_properties12HasUnmanagedC3refs0D0VyyXlGSgfgTo
   // CHECK: bb0([[CLS:%.*]] : $HasUnmanaged):
   // CHECK:     [[CLS_COPY:%.*]] = copy_value [[CLS]]
   // CHECK:     [[BORROWED_CLS_COPY:%.*]] = begin_borrow [[CLS_COPY]]
-  // CHECK:     [[NATIVE:%.+]] = function_ref @_T015objc_properties12HasUnmanagedC3refs0D0Vys9AnyObject_pGSgfg
+  // CHECK:     [[NATIVE:%.+]] = function_ref @_T015objc_properties12HasUnmanagedC3refs0D0VyyXlGSgfg
   // CHECK:     [[RESULT:%.+]] = apply [[NATIVE]]([[BORROWED_CLS_COPY]])
   // CHECK:     end_borrow [[BORROWED_CLS_COPY]] from [[CLS_COPY]]
   // CHECK-NOT: {{(retain|release)}}
   // CHECK:     destroy_value [[CLS_COPY]] : $HasUnmanaged
   // CHECK-NOT: {{(retain|release)}}
   // CHECK:     return [[RESULT]] : $Optional<Unmanaged<AnyObject>>
-  // CHECK: } // end sil function '_T015objc_properties12HasUnmanagedC3refs0D0Vys9AnyObject_pGSgfgTo'
+  // CHECK: } // end sil function '_T015objc_properties12HasUnmanagedC3refs0D0VyyXlGSgfgTo'
 
-  // CHECK-LABEL: sil hidden [thunk] @_T015objc_properties12HasUnmanagedC3refs0D0Vys9AnyObject_pGSgfsTo
+  // CHECK-LABEL: sil hidden [thunk] @_T015objc_properties12HasUnmanagedC3refs0D0VyyXlGSgfsTo
   // CHECK: bb0([[NEW_VALUE:%.*]] : $Optional<Unmanaged<AnyObject>>, [[SELF:%.*]] : $HasUnmanaged):
   // CHECK-NEXT: [[SELF_COPY:%.*]] = copy_value [[SELF]] : $HasUnmanaged
   // CHECK-NEXT: [[BORROWED_SELF_COPY:%.*]] = begin_borrow [[SELF_COPY]]
   // CHECK-NEXT: // function_ref
-  // CHECK-NEXT: [[NATIVE:%.+]] = function_ref @_T015objc_properties12HasUnmanagedC3refs0D0Vys9AnyObject_pGSgfs
+  // CHECK-NEXT: [[NATIVE:%.+]] = function_ref @_T015objc_properties12HasUnmanagedC3refs0D0VyyXlGSgfs
   // CHECK-NEXT: [[RESULT:%.*]] = apply [[NATIVE]]([[NEW_VALUE]], [[BORROWED_SELF_COPY]])
   // CHECK-NEXT: end_borrow [[BORROWED_SELF_COPY]] from [[SELF_COPY]]
   // CHECK-NEXT: destroy_value [[SELF_COPY]] : $HasUnmanaged
   // CHECK-NEXT: return [[RESULT:%.*]]
-  // CHECK: } // end sil function '_T015objc_properties12HasUnmanagedC3refs0D0Vys9AnyObject_pGSgfsTo'
+  // CHECK: } // end sil function '_T015objc_properties12HasUnmanagedC3refs0D0VyyXlGSgfsTo'
   @objc var ref: Unmanaged<AnyObject>?
 }
 

--- a/test/SILGen/opaque_values_silgen.swift
+++ b/test/SILGen/opaque_values_silgen.swift
@@ -253,7 +253,7 @@ public func s060__callMultiResult(i: Int) -> (Int, (Int, Int)) {
 // SILGen, prepareArchetypeCallee. Materialize a
 // non-class-constrainted self from a class-constrained archetype.
 // ---
-// CHECK-LABEL: sil hidden @_T020opaque_values_silgen21s070__materializeSelfyx1t_ts9AnyObjectRzAA3FooRzlF : $@convention(thin) <T where T : AnyObject, T : Foo> (@owned T) -> () {
+// CHECK-LABEL: sil hidden @_T020opaque_values_silgen21s070__materializeSelfyx1t_tRlzCAA3FooRzlF : $@convention(thin) <T where T : AnyObject, T : Foo> (@owned T) -> () {
 // CHECK: bb0([[ARG:%.*]] : $T):
 // CHECK: [[WITNESS_METHOD:%.*]] = witness_method $T, #Foo.foo!1 : <Self where Self : Foo> (Self) -> () -> () : $@convention(witness_method) <τ_0_0 where τ_0_0 : Foo> (@in_guaranteed τ_0_0) -> ()
 // CHECK: [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
@@ -261,7 +261,7 @@ public func s060__callMultiResult(i: Int) -> (Int, (Int, Int)) {
 // CHECK: end_borrow [[BORROWED_ARG]] from [[ARG]]
 // CHECK: destroy_value [[ARG]] : $T
 // CHECK: return %{{[0-9]+}} : $()
-// CHECK-LABEL: } // end sil function '_T020opaque_values_silgen21s070__materializeSelfyx1t_ts9AnyObjectRzAA3FooRzlF'
+// CHECK-LABEL: } // end sil function '_T020opaque_values_silgen21s070__materializeSelfyx1t_tRlzCAA3FooRzlF'
 func s070__materializeSelf<T: Foo>(t: T) where T: AnyObject {
   t.foo()
 }

--- a/test/SILGen/optional-cast.swift
+++ b/test/SILGen/optional-cast.swift
@@ -163,7 +163,7 @@ func bar(_ y : A????) {
 }
 
 
-// CHECK-LABEL: sil hidden @_T04main3bazys9AnyObject_pSgF : $@convention(thin) (@owned Optional<AnyObject>) -> () {
+// CHECK-LABEL: sil hidden @_T04main3bazyyXlSgF : $@convention(thin) (@owned Optional<AnyObject>) -> () {
 // CHECK:       bb0([[ARG:%.*]] : $Optional<AnyObject>):
 // CHECK:         [[X:%.*]] = alloc_box ${ var Optional<B> }, var, name "x"
 // CHECK-NEXT:    [[PB:%.*]] = project_box [[X]]
@@ -178,7 +178,7 @@ func bar(_ y : A????) {
 // CHECK:         store [[CASTED_VALUE]] to [init] [[X_VALUE]]
 // CHECK:       [[NOT_B]]([[ORIGINAL_VALUE:%.*]] : $AnyObject):
 // CHECK:         destroy_value [[ORIGINAL_VALUE]]
-// CHECK: } // end sil function '_T04main3bazys9AnyObject_pSgF'
+// CHECK: } // end sil function '_T04main3bazyyXlSgF'
 func baz(_ y : AnyObject?) {
   var x = (y as? B)
 }

--- a/test/SILGen/pointer_conversion.swift
+++ b/test/SILGen/pointer_conversion.swift
@@ -290,7 +290,7 @@ func optArrayToOptPointer(array: [Int]?) {
   // CHECK:   cond_br [[T0]], [[SOME_BB:bb[0-9]+]], [[NONE_BB:bb[0-9]+]]
   // CHECK: [[SOME_BB]]:
   // CHECK:   [[SOME_VALUE:%.*]] = unchecked_enum_data [[COPY]]
-  // CHECK:   [[CONVERT:%.*]] = function_ref @_T0s35_convertConstArrayToPointerArguments9AnyObject_pSg_q_tSayxGs01_E0R_r0_lF
+  // CHECK:   [[CONVERT:%.*]] = function_ref @_T0s35_convertConstArrayToPointerArgumentyXlSg_q_tSayxGs01_E0R_r0_lF
   // CHECK:   [[TEMP:%.*]] = alloc_stack $UnsafePointer<Int>
   // CHECK:   [[OWNER:%.*]] = apply [[CONVERT]]<Int, UnsafePointer<Int>>([[TEMP:%.*]], [[SOME_VALUE]])
   // CHECK:   [[PTR:%.*]] = load [trivial] [[TEMP]]
@@ -329,7 +329,7 @@ func optOptArrayToOptOptPointer(array: [Int]??) {
   // CHECK:   br [[SOME_NONE_BB2:bb[0-9]+]]
   // CHECK: [[SOME_SOME_BB]]:
   // CHECK:   [[SOME_SOME_VALUE:%.*]] = unchecked_enum_data [[SOME_VALUE]]
-  // CHECK:   [[CONVERT:%.*]] = function_ref @_T0s35_convertConstArrayToPointerArguments9AnyObject_pSg_q_tSayxGs01_E0R_r0_lF
+  // CHECK:   [[CONVERT:%.*]] = function_ref @_T0s35_convertConstArrayToPointerArgumentyXlSg_q_tSayxGs01_E0R_r0_lF
   // CHECK:   [[TEMP:%.*]] = alloc_stack $UnsafePointer<Int>
   // CHECK:   [[OWNER:%.*]] = apply [[CONVERT]]<Int, UnsafePointer<Int>>([[TEMP:%.*]], [[SOME_SOME_VALUE]])
   // CHECK:   [[PTR:%.*]] = load [trivial] [[TEMP]]
@@ -369,7 +369,7 @@ func optStringToOptPointer(string: String?) {
   // CHECK:   cond_br [[T0]], [[SOME_BB:bb[0-9]+]], [[NONE_BB:bb[0-9]+]]
   // CHECK: [[SOME_BB]]:
   // CHECK:   [[SOME_VALUE:%.*]] = unchecked_enum_data [[COPY]]
-  // CHECK:   [[CONVERT:%.*]] = function_ref @_T0s40_convertConstStringToUTF8PointerArguments9AnyObject_pSg_xtSSs01_F0RzlF
+  // CHECK:   [[CONVERT:%.*]] = function_ref @_T0s40_convertConstStringToUTF8PointerArgumentyXlSg_xtSSs01_F0RzlF
   // CHECK:   [[TEMP:%.*]] = alloc_stack $UnsafeRawPointer
   // CHECK:   [[OWNER:%.*]] = apply [[CONVERT]]<UnsafeRawPointer>([[TEMP:%.*]], [[SOME_VALUE]])
   // CHECK:   [[PTR:%.*]] = load [trivial] [[TEMP]]
@@ -409,7 +409,7 @@ func optOptStringToOptOptPointer(string: String??) {
   // CHECK:   br [[SOME_NONE_BB2:bb[0-9]+]]
   // CHECK: [[SOME_SOME_BB]]:
   // CHECK:   [[SOME_SOME_VALUE:%.*]] = unchecked_enum_data [[SOME_VALUE]]
-  // CHECK:   [[CONVERT:%.*]] = function_ref @_T0s40_convertConstStringToUTF8PointerArguments9AnyObject_pSg_xtSSs01_F0RzlF
+  // CHECK:   [[CONVERT:%.*]] = function_ref @_T0s40_convertConstStringToUTF8PointerArgumentyXlSg_xtSSs01_F0RzlF
   // CHECK:   [[TEMP:%.*]] = alloc_stack $UnsafeRawPointer
   // CHECK:   [[OWNER:%.*]] = apply [[CONVERT]]<UnsafeRawPointer>([[TEMP:%.*]], [[SOME_SOME_VALUE]])
   // CHECK:   [[PTR:%.*]] = load [trivial] [[TEMP]]

--- a/test/SILGen/switch.swift
+++ b/test/SILGen/switch.swift
@@ -524,7 +524,7 @@ func test_isa_class_1(x: B) {
 }
 // CHECK: } // end sil function '_T06switch16test_isa_class_1yAA1BC1x_tF'
 
-// CHECK-LABEL: sil hidden @_T06switch16test_isa_class_2s9AnyObject_pAA1BC1x_tF : $@convention(thin)
+// CHECK-LABEL: sil hidden @_T06switch16test_isa_class_2yXlAA1BC1x_tF : $@convention(thin)
 func test_isa_class_2(x: B) -> AnyObject {
   // CHECK: bb0([[X:%.*]] : $B):
   // CHECK:   [[BORROWED_X:%.*]] = begin_borrow [[X]]
@@ -639,7 +639,7 @@ func test_isa_class_2(x: B) -> AnyObject {
   // CHECK:   destroy_value [[X]]
   // CHECK:   return [[T0]]
 }
-// CHECK: } // end sil function '_T06switch16test_isa_class_2s9AnyObject_pAA1BC1x_tF'
+// CHECK: } // end sil function '_T06switch16test_isa_class_2yXlAA1BC1x_tF'
 
 enum MaybePair {
   case Neither

--- a/test/SILGen/vtable_thunks_reabstraction_final.swift
+++ b/test/SILGen/vtable_thunks_reabstraction_final.swift
@@ -30,7 +30,7 @@ class GenericSub<U: AnyObject>: GenericSuper<U>, Barrable {
   }
 }
 
-// CHECK-LABEL: sil private [transparent] [thunk] @_T033vtable_thunks_reabstraction_final10GenericSubCyxGAA8BarrableAAs9AnyObjectRzlAaEP3foo3BarQzSgAJFTW
+// CHECK-LABEL: sil private [transparent] [thunk] @_T033vtable_thunks_reabstraction_final10GenericSubCyxGAA8BarrableAARlzClAaEP3foo3BarQzSgAIFTW
 // CHECK:         class_method {{%.*}} : $GenericSub<τ_0_0>, #GenericSub.foo!1 {{.*}}, $@convention(method) <τ_0_0 where τ_0_0 : AnyObject> (@in τ_0_0, @guaranteed GenericSub<τ_0_0>) -> @out Optional<τ_0_0>
 
 class C {}

--- a/test/SILOptimizer/access_marker_mandatory.swift
+++ b/test/SILOptimizer/access_marker_mandatory.swift
@@ -5,7 +5,7 @@ public struct S {
   var o: AnyObject
 }
 
-// CHECK-LABEL: sil [noinline] @_T023access_marker_mandatory5initSAA1SVSi_s9AnyObject_ptF : $@convention(thin) (Int, @owned AnyObject) -> @owned S {
+// CHECK-LABEL: sil [noinline] @_T023access_marker_mandatory5initSAA1SVSi_yXltF : $@convention(thin) (Int, @owned AnyObject) -> @owned S {
 // CHECK: bb0(%0 : $Int, %1 : $AnyObject):
 // CHECK: [[STK:%.*]] = alloc_stack $S, var, name "s"
 // CHECK: cond_br %{{.*}}, bb1, bb2
@@ -24,7 +24,7 @@ public struct S {
 // CHECK: destroy_addr [[STK]]
 // CHECK: dealloc_stack [[STK]]
 // CHECK: return [[RET]] : $S
-// CHECK-LABEL: } // end sil function '_T023access_marker_mandatory5initSAA1SVSi_s9AnyObject_ptF'
+// CHECK-LABEL: } // end sil function '_T023access_marker_mandatory5initSAA1SVSi_yXltF'
 @inline(never)
 public func initS(_ x: Int, _ o: AnyObject) -> S {
   var s: S
@@ -39,10 +39,10 @@ public func initS(_ x: Int, _ o: AnyObject) -> S {
 @inline(never)
 func takeS(_ s: S) {}
 
-// CHECK-LABEL: sil @_T023access_marker_mandatory14modifyAndReadSys9AnyObject_p1o_tF : $@convention(thin) (@owned AnyObject) -> () {
+// CHECK-LABEL: sil @_T023access_marker_mandatory14modifyAndReadSyyXl1o_tF : $@convention(thin) (@owned AnyObject) -> () {
 // CHECK: bb0(%0 : $AnyObject):
 // CHECK: [[STK:%.*]] = alloc_stack $S, var, name "s"
-// CHECK: [[FINIT:%.*]] = function_ref @_T023access_marker_mandatory5initSAA1SVSi_s9AnyObject_ptF : $@convention(thin) (Int, @owned AnyObject) -> @owned S
+// CHECK: [[FINIT:%.*]] = function_ref @_T023access_marker_mandatory5initSAA1SVSi_yXltF : $@convention(thin) (Int, @owned AnyObject) -> @owned S
 // CHECK: [[INITS:%.*]] = apply [[FINIT]](%{{.*}}, %0) : $@convention(thin) (Int, @owned AnyObject) -> @owned S
 // CHECK: store [[INITS]] to [[STK]] : $*S
 // CHECK: [[WRITE:%.*]] = begin_access [modify] [static] [[STK]] : $*S
@@ -53,7 +53,7 @@ func takeS(_ s: S) {}
 // CHECK: [[READ:%.*]] = begin_access [read] [static] [[STK]] : $*S
 // CHECK: end_access [[READ]]
 // CHECK: apply [[FTAKE]](%{{.*}}) : $@convention(thin) (@owned S) -> ()
-// CHECK-LABEL: } // end sil function '_T023access_marker_mandatory14modifyAndReadSys9AnyObject_p1o_tF'
+// CHECK-LABEL: } // end sil function '_T023access_marker_mandatory14modifyAndReadSyyXl1o_tF'
 public func modifyAndReadS(o: AnyObject) {
   var s = initS(3, o)
   s.i = 42

--- a/test/SILOptimizer/arcsequenceopts_rcidentityanalysis.sil
+++ b/test/SILOptimizer/arcsequenceopts_rcidentityanalysis.sil
@@ -38,7 +38,7 @@ public enum FakeOptional<T> {
   case some(T)
 }
 
-public protocol AnyObject : class {}
+public typealias AnyObject = Builtin.AnyObject
 
 class C {
   init()

--- a/test/SILOptimizer/cast_folding_objc.swift
+++ b/test/SILOptimizer/cast_folding_objc.swift
@@ -52,7 +52,7 @@ func test0() -> Bool {
 // the compiler does not statically know if this object
 // is NSNumber can be converted into Int.
 
-// CHECK-LABEL: sil [noinline] @_T017cast_folding_objc35testMayBeBridgedCastFromObjCtoSwiftSis9AnyObject_pF
+// CHECK-LABEL: sil [noinline] @_T017cast_folding_objc35testMayBeBridgedCastFromObjCtoSwiftSiyXlF
 // CHECK: unconditional_checked_cast_addr
 // CHECK: return
 @inline(never)
@@ -64,7 +64,7 @@ public func testMayBeBridgedCastFromObjCtoSwift(_ o: AnyObject) -> Int {
 // the compiler does not statically know if this object
 // is NSString can be converted into String.
 
-// CHECK-LABEL: sil [noinline] @_T017cast_folding_objc41testConditionalBridgedCastFromObjCtoSwiftSSSgs9AnyObject_pF
+// CHECK-LABEL: sil [noinline] @_T017cast_folding_objc41testConditionalBridgedCastFromObjCtoSwiftSSSgyXlF
 // CHECK: unconditional_checked_cast_addr
 // CHECK: return
 @inline(never)

--- a/test/SILOptimizer/cast_folding_objc_no_foundation.swift
+++ b/test/SILOptimizer/cast_folding_objc_no_foundation.swift
@@ -7,7 +7,7 @@
 
 struct PlainStruct {}
 
-// CHECK-LABEL: sil shared [noinline] @_T031cast_folding_objc_no_foundation23testAnyObjectToArrayIntSbs0gH0_pFTf4g_n
+// CHECK-LABEL: sil shared [noinline] @_T031cast_folding_objc_no_foundation23testAnyObjectToArrayIntSbyXlFTf4g_n
 // CHECK: bb0(%0 : $AnyObject):
 // CHECK: [[SOURCE:%.*]] = alloc_stack $AnyObject
 // CHECK: [[TARGET:%.*]] = alloc_stack $Array<Int>
@@ -17,7 +17,7 @@ func testAnyObjectToArrayInt(_ a: AnyObject) -> Bool {
   return a is [Int]
 }
 
-// CHECK-LABEL: sil shared [noinline] @_T031cast_folding_objc_no_foundation26testAnyObjectToArrayStringSbs0gH0_pFTf4g_n
+// CHECK-LABEL: sil shared [noinline] @_T031cast_folding_objc_no_foundation26testAnyObjectToArrayStringSbyXlFTf4g_n
 // CHECK: bb0(%0 : $AnyObject):
 // CHECK: [[SOURCE:%.*]] = alloc_stack $AnyObject
 // CHECK: [[TARGET:%.*]] = alloc_stack $Array<String>
@@ -37,7 +37,7 @@ func testAnyObjectToArrayNotBridged(_ a: AnyObject) -> Bool {
   return a is [PlainStruct]
 }
 
-// CHECK-LABEL: sil shared [noinline] @_T031cast_folding_objc_no_foundation25testAnyObjectToDictionarySbs0gH0_pFTf4g_n
+// CHECK-LABEL: sil shared [noinline] @_T031cast_folding_objc_no_foundation25testAnyObjectToDictionarySbyXlFTf4g_n
 // CHECK: bb0(%0 : $AnyObject):
 // CHECK: [[SOURCE:%.*]] = alloc_stack $AnyObject
 // CHECK: [[TARGET:%.*]] = alloc_stack $Dictionary<Int, String>
@@ -47,7 +47,7 @@ func testAnyObjectToDictionary(_ a: AnyObject) -> Bool {
   return a is [Int: String]
 }
 
-// CHECK-LABEL: sil shared [noinline] @_T031cast_folding_objc_no_foundation21testAnyObjectToStringSbs0gH0_pFTf4g_n
+// CHECK-LABEL: sil shared [noinline] @_T031cast_folding_objc_no_foundation21testAnyObjectToStringSbyXlFTf4g_n
 // CHECK: bb0(%0 : $AnyObject):
 // CHECK: [[SOURCE:%.*]] = alloc_stack $AnyObject
 // CHECK: [[TARGET:%.*]] = alloc_stack $String

--- a/test/SILOptimizer/devirt_jump_thread.sil
+++ b/test/SILOptimizer/devirt_jump_thread.sil
@@ -442,6 +442,5 @@ sil [transparent] [serialized] @_TFSb21_getBuiltinLogicValuefSbFT_Bi1_ : $@conve
 
 sil [serialized] @_TZFsoi3eeeFTGSqPs9AnyObject__GSqPS____Sb : $@convention(thin) (@owned Optional<AnyObject>, @owned Optional<AnyObject>) -> Bool
 
-sil_witness_table C: AnyObject module main
 
 

--- a/test/SILOptimizer/specialize_anyobject.swift
+++ b/test/SILOptimizer/specialize_anyobject.swift
@@ -17,6 +17,6 @@ struct S<A: PB> {
 
 // CHECK-LABEL: sil hidden @_T020specialize_anyobject6callit{{[_0-9a-zA-Z]*}}F
 func callit(s: S<CB>) {
-  // CHECK: function_ref @_T0s3eeeoiSbs9AnyObject_pSg_ACtF : $@convention(thin) (@owned Optional<AnyObject>, @owned Optional<AnyObject>) -> Bool
+  // CHECK: function_ref @_T0s3eeeoiSbyXlSg_ABtF : $@convention(thin) (@owned Optional<AnyObject>, @owned Optional<AnyObject>) -> Bool
   s.crash()
 }

--- a/test/SILOptimizer/specialize_checked_cast_branch.swift
+++ b/test/SILOptimizer/specialize_checked_cast_branch.swift
@@ -325,17 +325,17 @@ func ExistentialToArchetypeCast<T>(o : AnyObject, t : T) -> T {
   _preconditionFailure("??? Profit?")
 }
 
-// CHECK-LABEL: sil shared @_T030specialize_checked_cast_branch26ExistentialToArchetypeCastxs9AnyObject_p1o_x1ttlFAA1CC_Tg5Tf4nd_n : $@convention(thin) (@owned AnyObject) -> @owned C
+// CHECK-LABEL: sil shared @_T030specialize_checked_cast_branch26ExistentialToArchetypeCastxyXl1o_x1ttlFAA1CC_Tg5Tf4nd_n : $@convention(thin) (@owned AnyObject) -> @owned C
 // CHECK: bb0
 // CHECK:  checked_cast_br %0 : $AnyObject to $C
 // CHECK: bb1
 
-// CHECK-LABEL: sil shared @_T030specialize_checked_cast_branch26ExistentialToArchetypeCastxs9AnyObject_p1o_x1ttlFAA8NotUInt8V_Tg5Tf4gd_n : $@convention(thin) (@guaranteed AnyObject) -> NotUInt8
+// CHECK-LABEL: sil shared @_T030specialize_checked_cast_branch26ExistentialToArchetypeCastxyXl1o_x1ttlFAA8NotUInt8V_Tg5Tf4gd_n : $@convention(thin) (@guaranteed AnyObject) -> NotUInt8
 // CHECK: bb0
 // CHECK:  checked_cast_addr_br take_always AnyObject in {{%.*}} : $*AnyObject to NotUInt8 in {{%.*}} : $*NotUInt8,
 // CHECK: bb1
 
-// CHECK-LABEL: sil shared @_T030specialize_checked_cast_branch26ExistentialToArchetypeCastxs9AnyObject_p1o_x1ttlFsAC_p_Tg5Tf4nd_n : $@convention(thin) (@owned AnyObject) -> @owned AnyObject
+// CHECK-LABEL: sil shared @_T030specialize_checked_cast_branch26ExistentialToArchetypeCastxyXl1o_x1ttlFyXl_Tg5Tf4nd_n : $@convention(thin) (@owned AnyObject) -> @owned AnyObject
 // CHECK: bb0
 // CHECK-NOT: checked_cast_br %
 // CHECK: return %0 : $AnyObject

--- a/test/SILOptimizer/specialize_unconditional_checked_cast.swift
+++ b/test/SILOptimizer/specialize_unconditional_checked_cast.swift
@@ -353,7 +353,7 @@ public func ExistentialToArchetype<T>(o o : AnyObject, t : T) -> T {
 // CHECK: return
 
 // AnyObject -> AnyObject
-// CHECK-LABEL: sil shared [noinline] @_T037specialize_unconditional_checked_cast22ExistentialToArchetype{{[_0-9a-zA-Z]*}}AnyObject{{.*}}Tg5 : $@convention(thin) (@owned AnyObject, @owned AnyObject) -> @owned AnyObject {
+// CHECK-LABEL: sil shared [noinline] @_T037specialize_unconditional_checked_cast22ExistentialToArchetype{{[_0-9a-zA-Z]*}}yXl{{.*}}Tg5 : $@convention(thin) (@owned AnyObject, @owned AnyObject) -> @owned AnyObject {
 // CHECK: bb0(%0 : $AnyObject, %1 : $AnyObject):
 // CHECK: strong_release %1
 // CHECK: return %0

--- a/test/SourceKit/DocSupport/doc_clang_module.swift.response
+++ b/test/SourceKit/DocSupport/doc_clang_module.swift.response
@@ -4465,9 +4465,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.length: 10
   },
   {
-    key.kind: source.lang.swift.ref.protocol,
-    key.name: "AnyObject",
-    key.usr: "s:s9AnyObjectP",
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
     key.offset: 6668,
     key.length: 9
   },
@@ -4487,9 +4485,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.length: 16
   },
   {
-    key.kind: source.lang.swift.ref.protocol,
-    key.name: "AnyObject",
-    key.usr: "s:s9AnyObjectP",
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
     key.offset: 6722,
     key.length: 9
   },
@@ -4554,9 +4550,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.length: 7
   },
   {
-    key.kind: source.lang.swift.ref.protocol,
-    key.name: "AnyObject",
-    key.usr: "s:s9AnyObjectP",
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
     key.offset: 6831,
     key.length: 9
   },
@@ -7541,7 +7535,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "c:objc(cs)FooClassPropertyOwnership(py)assignable",
         key.offset: 6636,
         key.length: 42,
-        key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>unowned(unsafe)</syntaxtype.keyword> <syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>assignable</decl.name>: <decl.var.type><ref.protocol usr=\"s:s9AnyObjectP\">AnyObject</ref.protocol>!</decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
+        key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>unowned(unsafe)</syntaxtype.keyword> <syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>assignable</decl.name>: <decl.var.type>AnyObject!</decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
       },
       {
         key.kind: source.lang.swift.decl.var.instance,
@@ -7549,7 +7543,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "c:objc(cs)FooClassPropertyOwnership(py)unsafeAssignable",
         key.offset: 6684,
         key.length: 48,
-        key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>unowned(unsafe)</syntaxtype.keyword> <syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>unsafeAssignable</decl.name>: <decl.var.type><ref.protocol usr=\"s:s9AnyObjectP\">AnyObject</ref.protocol>!</decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
+        key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>unowned(unsafe)</syntaxtype.keyword> <syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>unsafeAssignable</decl.name>: <decl.var.type>AnyObject!</decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
       },
       {
         key.kind: source.lang.swift.decl.var.instance,
@@ -7581,7 +7575,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "c:objc(cs)FooClassPropertyOwnership(py)weakRef",
         key.offset: 6813,
         key.length: 28,
-        key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>weak</syntaxtype.keyword> <syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>weakRef</decl.name>: <decl.var.type><ref.protocol usr=\"s:s9AnyObjectP\">AnyObject</ref.protocol>!</decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
+        key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>weak</syntaxtype.keyword> <syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>weakRef</decl.name>: <decl.var.type>AnyObject!</decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
       },
       {
         key.kind: source.lang.swift.decl.var.instance,

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift.response
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift.response
@@ -4072,24 +4072,6 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.length: 12
   },
   {
-    key.kind: source.lang.swift.ref.protocol,
-    key.offset: 5904,
-    key.length: 9,
-    key.is_system: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.protocol,
-    key.offset: 5963,
-    key.length: 9,
-    key.is_system: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.protocol,
-    key.offset: 6092,
-    key.length: 9,
-    key.is_system: 1
-  },
-  {
     key.kind: source.lang.swift.ref.struct,
     key.offset: 6125,
     key.length: 5,

--- a/test/decl/ext/protocol.swift
+++ b/test/decl/ext/protocol.swift
@@ -928,7 +928,7 @@ extension BadProto4 { } // expected-error{{protocol 'BadProto3' in the module be
 typealias RawRepresentableAlias = RawRepresentable
 extension RawRepresentableAlias { } // okay
 
-extension AnyObject { } // expected-error{{'AnyObject' protocol cannot be extended}}
+extension AnyObject { } // expected-error{{non-nominal type 'AnyObject' cannot be extended}}
 
 // Members of protocol extensions cannot be overridden.
 // rdar://problem/21075287

--- a/test/decl/nested/protocol.swift
+++ b/test/decl/nested/protocol.swift
@@ -64,7 +64,15 @@ enum OuterEnum {
   case C(C) // expected-error{{invalid redeclaration of 'C'}}
 }
 
-class OuterClass<T> {
+class OuterClass {
   protocol InnerProtocol : OuterClass { }
-  // expected-error@-1{{protocol 'InnerProtocol' cannot be nested inside another declaration}}
+  // expected-error@-1{{non-class type 'InnerProtocol' cannot inherit from class 'OuterClass'}}
+  // expected-error@-2{{protocol 'InnerProtocol' cannot be nested inside another declaration}}
+}
+
+class OtherGenericClass<T> {
+  // FIXME: The diagnostic is misleading -- OuterClass is in fact a class type
+  protocol InnerProtocol : OtherGenericClass { }
+  // expected-error@-1{{inheritance from non-protocol, non-class type 'OtherGenericClass<T>'}}
+  // expected-error@-2{{protocol 'InnerProtocol' cannot be nested inside another declaration}}
 }

--- a/test/type/subclass_composition.swift
+++ b/test/type/subclass_composition.swift
@@ -51,13 +51,13 @@ struct Unrelated {}
 // FIXME: Not implemented yet.
 //
 
-func alreadyConforms<T>(_: Base<T>) {}
-func alreadyConforms<T>(_: Base<T> & P1) {}
-func alreadyConforms<T>(_: Base<T> & AnyObject) {}
-func alreadyConforms<T>(_: Base<T> & P1 & AnyObject) {}
+func alreadyConforms<T>(_: Base<T>) {} // expected-note {{'alreadyConforms' previously declared here}}
+func alreadyConforms<T>(_: Base<T> & P1) {} // expected-note {{'alreadyConforms' previously declared here}}
+func alreadyConforms<T>(_: Base<T> & AnyObject) {} // expected-error {{invalid redeclaration of 'alreadyConforms'}}
+func alreadyConforms<T>(_: Base<T> & P1 & AnyObject) {} // expected-error {{invalid redeclaration of 'alreadyConforms'}}
 
-func alreadyConforms(_: P3) {}
-func alreadyConforms(_: P3 & AnyObject) {}
+func alreadyConforms(_: P3) {} // expected-note {{'alreadyConforms' previously declared here}}
+func alreadyConforms(_: P3 & AnyObject) {} // expected-error {{invalid redeclaration of 'alreadyConforms'}}
 
 // SE-0156 stipulates that a composition can contain multiple classes, as long
 // as they are all the same.

--- a/validation-test/compiler_crashers_2/0091-rdar30168645.swift
+++ b/validation-test/compiler_crashers_2/0091-rdar30168645.swift
@@ -1,5 +1,0 @@
-// RUN: not --crash %target-swift-frontend -emit-ir -primary-file %s
-
-class Base<T: AnyObject> {}
-
-class Derived: Base<Derived> {}

--- a/validation-test/compiler_crashers_2_fixed/0091-rdar30168645.swift
+++ b/validation-test/compiler_crashers_2_fixed/0091-rdar30168645.swift
@@ -1,0 +1,5 @@
+// RUN: %target-swift-frontend -emit-ir -primary-file %s
+
+class Base<T: AnyObject> {}
+
+class Derived: Base<Derived> {}


### PR DESCRIPTION
@DougGregor told me that SE-0156 is not really done until the AnyObject protocol is gone. So here you go.

I'm going to debug and land https://github.com/apple/swift/pull/9096 first; this PR only contains one additional patch on top of that one.