### PR TITLE
SE-0169: Add support for shared private

### DIFF
--- a/include/swift/AST/AccessScope.h
+++ b/include/swift/AST/AccessScope.h
@@ -30,6 +30,12 @@ public:
 
   static AccessScope getPublic() { return AccessScope(nullptr); }
 
+  /// Perform the shared private access check. Private scope is shared between 
+  /// the declaration and all of the extensions of that type inside the file.
+  /// This will return false in Swift 3 mode because private is not shared
+  /// between types.
+  static bool checkSharedPrivateAccess(const DeclContext *useDC, const DeclContext *sourceDC);
+
   /// Returns nullptr if access scope is public.
   const DeclContext *getDeclContext() const { return Value.getPointer(); }
 
@@ -48,7 +54,8 @@ public:
   /// \see DeclContext::isChildContextOf
   bool isChildOf(AccessScope AS) const {
     if (!isPublic() && !AS.isPublic())
-      return getDeclContext()->isChildContextOf(AS.getDeclContext());
+      return (getDeclContext()->isChildContextOf(AS.getDeclContext()) ||
+        checkSharedPrivateAccess(getDeclContext(), AS.getDeclContext()));
     if (isPublic() && AS.isPublic())
       return false;
     return AS.isPublic();

--- a/include/swift/AST/AccessScope.h
+++ b/include/swift/AST/AccessScope.h
@@ -30,11 +30,10 @@ public:
 
   static AccessScope getPublic() { return AccessScope(nullptr); }
 
-  /// Perform the shared private access check. Private scope is shared between 
-  /// the declaration and all of the extensions of that type inside the file.
-  /// This will return false in Swift 3 mode because private is not shared
-  /// between types.
-  static bool checkSharedPrivateAccess(const DeclContext *useDC, const DeclContext *sourceDC);
+  /// Check if private access is allowed. This is a lexical scope check in Swift
+  /// 3 mode. In Swift 4 mode, declarations and extensions of the same type will
+  /// also allow access.
+  static bool allowsPrivateAccess(const DeclContext *useDC, const DeclContext *sourceDC);
 
   /// Returns nullptr if access scope is public.
   const DeclContext *getDeclContext() const { return Value.getPointer(); }
@@ -54,8 +53,7 @@ public:
   /// \see DeclContext::isChildContextOf
   bool isChildOf(AccessScope AS) const {
     if (!isPublic() && !AS.isPublic())
-      return (getDeclContext()->isChildContextOf(AS.getDeclContext()) ||
-        checkSharedPrivateAccess(getDeclContext(), AS.getDeclContext()));
+      return allowsPrivateAccess(getDeclContext(), AS.getDeclContext());
     if (isPublic() && AS.isPublic())
       return false;
     return AS.isPublic();

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -993,7 +993,7 @@ getSharedPrivateDeclContext(const DeclContext *DC, const SourceFile *useSF) {
       lastExtension = ED;
 
   // If there's no last extension, return the supplied context.
-  return lastExtension ?: DC;
+  return lastExtension ? lastExtension : DC;
 }
 
 bool AccessScope::checkSharedPrivateAccess(const DeclContext *useDC, const DeclContext *sourceDC) {

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1262,7 +1262,9 @@ static bool checkAccessibility(const DeclContext *useDC,
   assert(sourceDC && "ValueDecl being accessed must have a valid DeclContext");
   switch (access) {
   case Accessibility::Private:
-    return useDC == sourceDC || useDC->isChildContextOf(sourceDC);
+    return (useDC == sourceDC ||
+      useDC->isChildContextOf(sourceDC) ||
+      AccessScope::checkSharedPrivateAccess(useDC, sourceDC));
   case Accessibility::FilePrivate:
     return useDC->getModuleScopeContext() == sourceDC->getModuleScopeContext();
   case Accessibility::Internal: {

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1263,8 +1263,7 @@ static bool checkAccessibility(const DeclContext *useDC,
   switch (access) {
   case Accessibility::Private:
     return (useDC == sourceDC ||
-      useDC->isChildContextOf(sourceDC) ||
-      AccessScope::checkSharedPrivateAccess(useDC, sourceDC));
+      AccessScope::allowsPrivateAccess(useDC, sourceDC));
   case Accessibility::FilePrivate:
     return useDC->getModuleScopeContext() == sourceDC->getModuleScopeContext();
   case Accessibility::Internal: {

--- a/test/Compatibility/accessibility_private.swift
+++ b/test/Compatibility/accessibility_private.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -swift-version 4
+// RUN: %target-typecheck-verify-swift -swift-version 3
 
 class Container {
   private func foo() {} // expected-note * {{declared here}}
@@ -15,8 +15,8 @@ class Container {
     _ = self.bar
     self.bar = 5
 
-    privateExtensionMethod()
-    self.privateExtensionMethod()
+    privateExtensionMethod() // expected-error {{'privateExtensionMethod' is inaccessible due to 'private' protection level}}
+    self.privateExtensionMethod() // expected-error {{'privateExtensionMethod' is inaccessible due to 'private' protection level}}
 
     _ = PrivateInner()
     _ = Container.PrivateInner()
@@ -27,14 +27,14 @@ class Container {
       obj.foo()
       _ = obj.bar
       obj.bar = 5
-      obj.privateExtensionMethod()
+      obj.privateExtensionMethod() // expected-error {{'privateExtensionMethod' is inaccessible due to 'private' protection level}}
 
       _ = PrivateInner()
       _ = Container.PrivateInner()
     }
 
     var inner: PrivateInner? // expected-error {{property must be declared private because its type uses a private type}}
-    var innerQualified: Container.PrivateInner? // expected-error {{property must be declared private because its type uses a private type}} expected-note {{declared here}}
+    var innerQualified: Container.PrivateInner? // expected-error {{property must be declared private because its type uses a private type}}
   }
 
   var inner: PrivateInner? // expected-error {{property must be declared private because its type uses a private type}}
@@ -54,42 +54,42 @@ extension Container {
   private func privateExtensionMethod() {} // expected-note * {{declared here}}
 
   func extensionTest() {
-    foo()
-    self.foo()
+    foo() // expected-error {{'foo' is inaccessible due to 'private' protection level}}
+    self.foo() // expected-error {{'foo' is inaccessible due to 'private' protection level}}
 
-    _ = bar
-    bar = 5
-    _ = self.bar
-    self.bar = 5
+    _ = bar // expected-error {{'bar' is inaccessible due to 'private' protection level}}
+    bar = 5 // expected-error {{'bar' is inaccessible due to 'private' protection level}}
+    _ = self.bar // expected-error {{'bar' is inaccessible due to 'private' protection level}}
+    self.bar = 5 // expected-error {{'bar' is inaccessible due to 'private' protection level}}
 
     privateExtensionMethod()
     self.privateExtensionMethod()
 
-    _ = PrivateInner()
-    _ = Container.PrivateInner()
+    _ = PrivateInner() // expected-error {{'PrivateInner' is inaccessible due to 'private' protection level}}
+    _ = Container.PrivateInner() // expected-error {{'PrivateInner' is inaccessible due to 'private' protection level}}
   }
 
   // FIXME: Why do these errors happen twice?
-  var extensionInner: PrivateInner? { return nil } // expected-error {{property must be declared private because its type uses a private type}}
-  var extensionInnerQualified: Container.PrivateInner? { return nil } // expected-error {{property must be declared private because its type uses a private type}}
+  var extensionInner: PrivateInner? { return nil } // expected-error 2 {{'PrivateInner' is inaccessible due to 'private' protection level}}
+  var extensionInnerQualified: Container.PrivateInner? { return nil } // expected-error 2 {{'PrivateInner' is inaccessible due to 'private' protection level}}
 }
 
 extension Container.Inner {
   func extensionTest(obj: Container) {
-    obj.foo()
-    _ = obj.bar
-    obj.bar = 5
-    obj.privateExtensionMethod()
+    obj.foo() // expected-error {{'foo' is inaccessible due to 'private' protection level}}
+    _ = obj.bar // expected-error {{'bar' is inaccessible due to 'private' protection level}}
+    obj.bar = 5 // expected-error {{'bar' is inaccessible due to 'private' protection level}}
+    obj.privateExtensionMethod() // expected-error {{'privateExtensionMethod' is inaccessible due to 'private' protection level}}
 
     // FIXME: Unqualified lookup won't look into Container from here.
     _ = PrivateInner() // expected-error {{use of unresolved identifier 'PrivateInner'}}
-    _ = Container.PrivateInner()
+    _ = Container.PrivateInner() // expected-error {{'PrivateInner' is inaccessible due to 'private' protection level}}
   }
 
   // FIXME: Why do these errors happen twice?
   // FIXME: Unqualified lookup won't look into Container from here.
   var inner: PrivateInner? { return nil } // expected-error 2 {{use of undeclared type 'PrivateInner'}}
-  var innerQualified: Container.PrivateInner? { return nil } // expected-error {{invalid redeclaration of 'innerQualified'}} expected-error {{property must be declared private because its type uses a private type}}
+  var innerQualified: Container.PrivateInner? { return nil } // expected-error 2 {{'PrivateInner' is inaccessible due to 'private' protection level}}
 }
 
 class Sub : Container {
@@ -149,17 +149,17 @@ private class VIPPrivateSetPropSub : VIPPrivateSetPropBase, VeryImportantProto {
 }
 
 extension Container {
-  private typealias ExtensionConflictingType = Int // expected-note {{found candidate with type}} expected-note {{previously declared here}}
+  private typealias ExtensionConflictingType = Int // expected-note * {{declared here}}
 }
 extension Container {
-  private typealias ExtensionConflictingType = Double  // expected-error {{invalid redeclaration of 'ExtensionConflictingType'}} expected-note {{found candidate with type}}
+  private typealias ExtensionConflictingType = Double // expected-note * {{declared here}}
 }
 extension Container {
   func test() {
-    let a: ExtensionConflictingType? = nil
-    let b: Container.ExtensionConflictingType? = nil // expected-error {{ambiguous type name 'ExtensionConflictingType' in 'Container'}}
-    _ = ExtensionConflictingType()
-    _ = Container.ExtensionConflictingType()
+    let a: ExtensionConflictingType? = nil // expected-error {{'ExtensionConflictingType' is inaccessible due to 'private' protection level}}
+    let b: Container.ExtensionConflictingType? = nil // expected-error {{'ExtensionConflictingType' is inaccessible due to 'private' protection level}}
+    _ = ExtensionConflictingType() // expected-error {{'ExtensionConflictingType' is inaccessible due to 'private' protection level}}
+    _ = Container.ExtensionConflictingType() // expected-error {{'ExtensionConflictingType' is inaccessible due to 'private' protection level}}
   }
 }
 

--- a/test/Sema/accessibility_shared_private.swift
+++ b/test/Sema/accessibility_shared_private.swift
@@ -1,0 +1,76 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: %utils/split_file.py -o %t %s
+// RUN: %target-swift-frontend -swift-version 4 -typecheck %t/declarations.swift %t/other_file_extensions.swift -verify
+
+// BEGIN declarations.swift
+struct PrivateMembers  {
+  private var privateCounter: Int = 0 // expected-note 2 {{declared here}}
+  private func privateMethod() {} // expected-note 2 {{declared here}}
+  private struct PrivateInner { // expected-note 3 {{declared here}}
+    private struct Invisible {} // expected-note {{declared here}}
+  }
+}
+extension PrivateMembers {
+  private func usePrivate() { // expected-note 2 {{declared here}}
+    print(privateCounter)
+    privateMethod()
+    _ = PrivateInner()
+    _ = PrivateInner.Invisible() // expected-error {{'Invisible' is inaccessible due to 'private' protection level}}
+  }
+}
+func using(_ obj: PrivateMembers) {
+  print(obj.privateCounter) // expected-error {{'privateCounter' is inaccessible due to 'private' protection level}}
+  obj.privateMethod() // expected-error {{'privateMethod' is inaccessible due to 'private' protection level}}
+  obj.usePrivate() // expected-error {{'usePrivate' is inaccessible due to 'private' protection level}}
+  _ = PrivateMembers.PrivateInner() // expected-error {{'PrivateInner' is inaccessible due to 'private' protection level}}
+  _ = PrivateMembers.PrivateInner.Invisible() // expected-error {{'PrivateInner' is inaccessible due to 'private' protection level}}
+}
+
+struct Outer {
+  private static func privateDeclaration() {}
+  struct Middle {
+    private static func privateDeclaration() {}
+    struct Inner {
+      private static func privateDeclaration() {}
+    }
+  }
+}
+
+extension Outer.Middle.Inner {
+  func useParentDeclarationPrivate() {
+    Outer.privateDeclaration()
+    Outer.Middle.privateDeclaration()
+    Outer.Middle.Inner.privateDeclaration()
+  }
+}
+
+// BEGIN other_file_extensions.swift
+extension PrivateMembers {
+  private func useDeclarationPrivate() {
+    print(privateCounter) // expected-error {{'privateCounter' is inaccessible due to 'private' protection level}}
+    privateMethod() // expected-error {{'privateMethod' is inaccessible due to 'private' protection level}}
+    usePrivate() // expected-error {{'usePrivate' is inaccessible due to 'private' protection level}}
+    _ = PrivateInner() // expected-error {{'PrivateInner' is inaccessible due to 'private' protection level}}
+  }
+}
+
+extension PrivateMembers {
+  private func useExtensionPrivate() {
+    useDeclarationPrivate()
+  }
+}
+
+extension Outer {
+  private struct MiddleExtension {
+    private static func privateDeclaration() {} // expected-note {{declared here}}
+  }
+  private static func outerExtension() {}
+}
+
+extension Outer.Middle.Inner {
+  func useParentExtensionPrivate() {
+    Outer.outerExtension()
+    _ = Outer.MiddleExtension()
+    Outer.MiddleExtension.privateDeclaration() // expected-error {{'privateDeclaration' is inaccessible due to 'private' protection level}}
+  }
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->
This PR implements [SE-0169](https://github.com/apple/swift-evolution/blob/master/proposals/0169-improve-interaction-between-private-declarations-and-extensions.md) and allows the private scope to be shared between types and extensions inside of a file. This follows the approach Jordan spelled out in  [SR-4616](https://bugs.swift.org/browse/SR-4616?focusedCommentId=23934&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-23934). 

The one slight deviation is that I didn't change the way the private `AccessScope` is constructed, but changed the `isChildOf` check to also use the private scope check. Doing both didn't seem to make sense and I believe `isChildOf` needs to use the private scope check.

For testing I added a test `Sema/accessibility_shared_private.swift` with explicit checks for multi-file shared private behavior. I also copied the existing `Sema/accessibility_private.swift` to the Compatibility directory, and updated the test for Swift 4 behavior. I think the test coverage is pretty good, but any ideas for additional testing would be great.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-4616](https://bugs.swift.org/browse/SR-4616).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
