### PR TITLE
Revert "Add reproducibility tests for -emit-module, -emit-sib, -emit-sibgen, -emit-sil and -emit-tbd"

### DIFF
--- a/test/reproducible-builds/swiftc-emit-module.swift
+++ b/test/reproducible-builds/swiftc-emit-module.swift
@@ -1,6 +1,0 @@
-// RUN: rm -rf %t && mkdir -p %t
-// RUN: %target-build-swift -O -g -module-name foo -emit-module %s -o %t/run-1.module
-// RUN: %target-build-swift -O -g -module-name foo -emit-module %s -o %t/run-2.module
-// RUN: cmp %t/run-1.module %t/run-2.module
-// RUN: cmp %t/run-1.swiftdoc %t/run-2.swiftdoc
-print("foo")

--- a/test/reproducible-builds/swiftc-emit-sib.swift
+++ b/test/reproducible-builds/swiftc-emit-sib.swift
@@ -1,5 +1,0 @@
-// RUN: rm -rf %t && mkdir -p %t
-// RUN: %target-build-swift -O -g -module-name foo -emit-sib %s -o %t/run-1.sib
-// RUN: %target-build-swift -O -g -module-name foo -emit-sib %s -o %t/run-2.sib
-// RUN: cmp %t/run-1.sib %t/run-2.sib
-print("foo")

--- a/test/reproducible-builds/swiftc-emit-sibgen.swift
+++ b/test/reproducible-builds/swiftc-emit-sibgen.swift
@@ -1,5 +1,0 @@
-// RUN: rm -rf %t && mkdir -p %t
-// RUN: %target-build-swift -O -g -module-name foo -emit-sibgen %s -o %t/run-1.sibgen
-// RUN: %target-build-swift -O -g -module-name foo -emit-sibgen %s -o %t/run-2.sibgen
-// RUN: cmp %t/run-1.sibgen %t/run-2.sibgen
-print("foo")

--- a/test/reproducible-builds/swiftc-emit-sil.swift
+++ b/test/reproducible-builds/swiftc-emit-sil.swift
@@ -1,5 +1,0 @@
-// RUN: rm -rf %t && mkdir -p %t
-// RUN: %target-build-swift -O -g -module-name foo -emit-sil %s -o %t/run-1.sil
-// RUN: %target-build-swift -O -g -module-name foo -emit-sil %s -o %t/run-2.sil
-// RUN: diff -u %t/run-1.sil %t/run-2.sil
-print("foo")

--- a/test/reproducible-builds/swiftc-emit-tbd.swift
+++ b/test/reproducible-builds/swiftc-emit-tbd.swift
@@ -1,5 +1,0 @@
-// RUN: rm -rf %t && mkdir -p %t
-// RUN: %target-build-swift -O -g -module-name foo -emit-tbd %s -o %t/run-1.tbd
-// RUN: %target-build-swift -O -g -module-name foo -emit-tbd %s -o %t/run-2.tbd
-// RUN: diff -u %t/run-1.tbd %t/run-2.tbd
-print("foo")


### PR DESCRIPTION
This causes failures on the bots because of use list order differences (AFAICT)

Reverts apple/swift#9067