### PR TITLE
Add a test case for non-ascii module names.

### DIFF
--- a/test/stdlib/UnicodeMetadata.swift
+++ b/test/stdlib/UnicodeMetadata.swift
@@ -1,0 +1,13 @@
+// RUN: %target-build-swift -module-name="日本語01" %s -o %t.out
+// RUN: %target-run %t.out | %FileCheck %s
+// REQUIRES: executable_test
+
+
+class myClass { }
+
+// Check that the runtime doesn't crash when generating the class name with
+// a non-ascii module name.
+let array = [ myClass() ]
+
+// CHECK: [日本語01.myClass]
+print(array)


### PR DESCRIPTION
With the old remangler this test crashed at runtime when trying to create the mangled name for a class with a non-ascii module name.

rdar://problem/31875699
