### PR TITLE
[sil-open-archetypes-tracker] Add type dependent operands to more instructions

### DIFF
--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -677,8 +677,8 @@ public:
 
   ConvertFunctionInst *createConvertFunction(SILLocation Loc, SILValue Op,
                                              SILType Ty) {
-    return insert(new (F.getModule())
-                      ConvertFunctionInst(getSILDebugLocation(Loc), Op, Ty));
+    return insert(ConvertFunctionInst::create(getSILDebugLocation(Loc), Op, Ty,
+                                              F, OpenedArchetypes));
   }
 
   ThinFunctionToPointerInst *
@@ -689,13 +689,13 @@ public:
 
   PointerToThinFunctionInst *
   createPointerToThinFunction(SILLocation Loc, SILValue Op, SILType Ty) {
-    return insert(new (F.getModule()) PointerToThinFunctionInst(
-        getSILDebugLocation(Loc), Op, Ty));
+    return insert(PointerToThinFunctionInst::create(
+        getSILDebugLocation(Loc), Op, Ty, F, OpenedArchetypes));
   }
 
   UpcastInst *createUpcast(SILLocation Loc, SILValue Op, SILType Ty) {
-    return insert(new (F.getModule())
-                      UpcastInst(getSILDebugLocation(Loc), Op, Ty));
+    return insert(UpcastInst::create(getSILDebugLocation(Loc), Op, Ty, F,
+                                     OpenedArchetypes));
   }
 
   AddressToPointerInst *createAddressToPointer(SILLocation Loc, SILValue Op,
@@ -782,8 +782,8 @@ public:
 
   ThinToThickFunctionInst *createThinToThickFunction(SILLocation Loc,
                                                      SILValue Op, SILType Ty) {
-    return insert(new (F.getModule()) ThinToThickFunctionInst(
-        getSILDebugLocation(Loc), Op, Ty));
+    return insert(ThinToThickFunctionInst::create(getSILDebugLocation(Loc), Op,
+                                                  Ty, F, OpenedArchetypes));
   }
 
   ThickToObjCMetatypeInst *createThickToObjCMetatype(SILLocation Loc,

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -2972,13 +2972,20 @@ public:
 
 /// ConvertFunctionInst - Change the type of a function value without
 /// affecting how it will codegen.
-class ConvertFunctionInst
-  : public UnaryInstructionBase<ValueKind::ConvertFunctionInst, ConversionInst>
-{
+class ConvertFunctionInst final
+    : public UnaryInstructionWithTypeDependentOperandsBase<
+          ValueKind::ConvertFunctionInst, ConvertFunctionInst, ConversionInst,
+          /* HAS_RESULT */ true> {
   friend SILBuilder;
 
-  ConvertFunctionInst(SILDebugLocation DebugLoc, SILValue Operand, SILType Ty)
-      : UnaryInstructionBase(DebugLoc, Operand, Ty) {}
+  ConvertFunctionInst(SILDebugLocation DebugLoc, SILValue Operand,
+                      ArrayRef<SILValue> TypeDependentOperands, SILType Ty)
+      : UnaryInstructionWithTypeDependentOperandsBase(
+            DebugLoc, Operand, TypeDependentOperands, Ty) {}
+
+  static ConvertFunctionInst *
+  create(SILDebugLocation DebugLoc, SILValue Operand, SILType Ty,
+         SILFunction &F, SILOpenedArchetypesState &OpenedArchetypes);
 };
 
 /// ThinFunctionToPointerInst - Convert a thin function pointer to a
@@ -2996,25 +3003,39 @@ class ThinFunctionToPointerInst
 
 /// PointerToThinFunctionInst - Convert a Builtin.RawPointer to a thin
 /// function pointer.
-class PointerToThinFunctionInst
-  : public UnaryInstructionBase<ValueKind::PointerToThinFunctionInst,
-                                ConversionInst>
-{
+class PointerToThinFunctionInst final
+    : public UnaryInstructionWithTypeDependentOperandsBase<
+          ValueKind::PointerToThinFunctionInst, PointerToThinFunctionInst,
+          ConversionInst, /* HAS_RESULT */ true> {
   friend SILBuilder;
 
   PointerToThinFunctionInst(SILDebugLocation DebugLoc, SILValue operand,
+                            ArrayRef<SILValue> TypeDependentOperands,
                             SILType ty)
-      : UnaryInstructionBase(DebugLoc, operand, ty) {}
+      : UnaryInstructionWithTypeDependentOperandsBase(
+            DebugLoc, operand, TypeDependentOperands, ty) {}
+
+  static PointerToThinFunctionInst *
+  create(SILDebugLocation DebugLoc, SILValue Operand, SILType Ty,
+         SILFunction &F, SILOpenedArchetypesState &OpenedArchetypes);
 };
 
 /// UpcastInst - Perform a conversion of a class instance to a supertype.
-class UpcastInst
-  : public UnaryInstructionBase<ValueKind::UpcastInst, ConversionInst>
+class UpcastInst final : public UnaryInstructionWithTypeDependentOperandsBase<
+                             ValueKind::UpcastInst, UpcastInst, ConversionInst,
+                             /* HAS_RESULT */ true>
+
 {
   friend SILBuilder;
 
-  UpcastInst(SILDebugLocation DebugLoc, SILValue Operand, SILType Ty)
-      : UnaryInstructionBase(DebugLoc, Operand, Ty) {}
+  UpcastInst(SILDebugLocation DebugLoc, SILValue Operand,
+             ArrayRef<SILValue> TypeDependentOperands, SILType Ty)
+      : UnaryInstructionWithTypeDependentOperandsBase(
+            DebugLoc, Operand, TypeDependentOperands, Ty) {}
+
+  static UpcastInst *
+  create(SILDebugLocation DebugLoc, SILValue Operand, SILType Ty,
+         SILFunction &F, SILOpenedArchetypesState &OpenedArchetypes);
 };
 
 /// AddressToPointerInst - Convert a SIL address to a Builtin.RawPointer value.
@@ -3294,15 +3315,20 @@ class UnmanagedToRefInst
 
 /// ThinToThickFunctionInst - Given a thin function reference, adds a null
 /// context to convert the value to a thick function type.
-class ThinToThickFunctionInst
-  : public UnaryInstructionBase<ValueKind::ThinToThickFunctionInst,
-                                ConversionInst>
-{
+class ThinToThickFunctionInst final
+    : public UnaryInstructionWithTypeDependentOperandsBase<
+          ValueKind::ThinToThickFunctionInst, ThinToThickFunctionInst,
+          ConversionInst, /* HAS_RESULT */ true> {
   friend SILBuilder;
 
   ThinToThickFunctionInst(SILDebugLocation DebugLoc, SILValue Operand,
-                          SILType Ty)
-      : UnaryInstructionBase(DebugLoc, Operand, Ty) {}
+                          ArrayRef<SILValue> TypeDependentOperands, SILType Ty)
+      : UnaryInstructionWithTypeDependentOperandsBase(
+            DebugLoc, Operand, TypeDependentOperands, Ty) {}
+
+  static ThinToThickFunctionInst *
+  create(SILDebugLocation DebugLoc, SILValue Operand, SILType Ty,
+         SILFunction &F, SILOpenedArchetypesState &OpenedArchetypes);
 
 public:
   /// Return the callee of the thin_to_thick_function.

--- a/lib/SIL/SILInstructions.cpp
+++ b/lib/SIL/SILInstructions.cpp
@@ -1906,6 +1906,65 @@ MetatypeInst *MetatypeInst::create(SILDebugLocation Loc, SILType Ty,
   return ::new (Buffer) MetatypeInst(Loc, Ty, TypeDependentOperands);
 }
 
+UpcastInst *UpcastInst::create(SILDebugLocation DebugLoc, SILValue Operand,
+                               SILType Ty, SILFunction &F,
+                               SILOpenedArchetypesState &OpenedArchetypes) {
+  SILModule &Mod = F.getModule();
+  SmallVector<SILValue, 8> TypeDependentOperands;
+  collectTypeDependentOperands(TypeDependentOperands, OpenedArchetypes, F,
+                               Ty.getSwiftRValueType());
+  unsigned size =
+    totalSizeToAlloc<swift::Operand>(1 + TypeDependentOperands.size());
+  void *Buffer = Mod.allocateInst(size, alignof(UpcastInst));
+  return ::new (Buffer) UpcastInst(DebugLoc, Operand,
+                                   TypeDependentOperands, Ty);
+}
+
+ThinToThickFunctionInst *
+ThinToThickFunctionInst::create(SILDebugLocation DebugLoc, SILValue Operand,
+                                SILType Ty, SILFunction &F,
+                                SILOpenedArchetypesState &OpenedArchetypes) {
+  SILModule &Mod = F.getModule();
+  SmallVector<SILValue, 8> TypeDependentOperands;
+  collectTypeDependentOperands(TypeDependentOperands, OpenedArchetypes, F,
+                               Ty.getSwiftRValueType());
+  unsigned size =
+    totalSizeToAlloc<swift::Operand>(1 + TypeDependentOperands.size());
+  void *Buffer = Mod.allocateInst(size, alignof(ThinToThickFunctionInst));
+  return ::new (Buffer) ThinToThickFunctionInst(DebugLoc, Operand,
+                                                TypeDependentOperands, Ty);
+}
+
+PointerToThinFunctionInst *
+PointerToThinFunctionInst::create(SILDebugLocation DebugLoc, SILValue Operand,
+                                  SILType Ty, SILFunction &F,
+                                  SILOpenedArchetypesState &OpenedArchetypes) {
+  SILModule &Mod = F.getModule();
+  SmallVector<SILValue, 8> TypeDependentOperands;
+  collectTypeDependentOperands(TypeDependentOperands, OpenedArchetypes, F,
+                               Ty.getSwiftRValueType());
+  unsigned size =
+    totalSizeToAlloc<swift::Operand>(1 + TypeDependentOperands.size());
+  void *Buffer = Mod.allocateInst(size, alignof(PointerToThinFunctionInst));
+  return ::new (Buffer) PointerToThinFunctionInst(DebugLoc, Operand,
+                                                  TypeDependentOperands, Ty);
+}
+
+ConvertFunctionInst *
+ConvertFunctionInst::create(SILDebugLocation DebugLoc, SILValue Operand,
+                            SILType Ty, SILFunction &F,
+                            SILOpenedArchetypesState &OpenedArchetypes) {
+  SILModule &Mod = F.getModule();
+  SmallVector<SILValue, 8> TypeDependentOperands;
+  collectTypeDependentOperands(TypeDependentOperands, OpenedArchetypes, F,
+                               Ty.getSwiftRValueType());
+  unsigned size =
+    totalSizeToAlloc<swift::Operand>(1 + TypeDependentOperands.size());
+  void *Buffer = Mod.allocateInst(size, alignof(ConvertFunctionInst));
+  return ::new (Buffer) ConvertFunctionInst(DebugLoc, Operand,
+                                            TypeDependentOperands, Ty);
+}
+
 bool KeyPathPatternComponent::isComputedSettablePropertyMutating() const {
   switch (getKind()) {
   case Kind::StoredProperty:

--- a/test/Interpreter/subclass_existentials.swift
+++ b/test/Interpreter/subclass_existentials.swift
@@ -15,9 +15,6 @@
 // RUN: %target-build-swift %s -o %t/a.out
 // RUN: %target-run %t/a.out
 // REQUIRES: executable_test
-//
-// XFAIL: swift_test_mode_optimize
-// XFAIL: swift_test_mode_optimize_unchecked
 
 import StdlibUnittest
 


### PR DESCRIPTION
The following instructions were enhanced with type dependent operands:
- convert_function
- pointer_to_thin_function
- upcast_inst
- thin_to_thick_function

Fixes rdar://31879356
