### PR TITLE
[Coverage] Emit a profiler increment in ObjC destructors

### DIFF
--- a/lib/SILGen/SILGenDestructor.cpp
+++ b/lib/SILGen/SILGenDestructor.cpp
@@ -207,6 +207,7 @@ void SILGenFunction::emitObjCDestructor(SILDeclRef dtor) {
   // We won't actually emit the block until we finish with the destructor body.
   prepareEpilog(Type(), false, CleanupLocation::get(loc));
 
+  emitProfilerIncrement(dd->getBody());
   // Emit the destructor body.
   emitStmt(dd->getBody());
 

--- a/test/SILGen/coverage_deinit.swift
+++ b/test/SILGen/coverage_deinit.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -Xllvm -sil-full-demangle -suppress-warnings -profile-generate -profile-coverage-mapping -emit-sorted-sil -emit-sil -module-name coverage_deinit %s | %FileCheck %s
+// REQUIRES: objc_interop
 
 import Foundation
 

--- a/test/SILGen/coverage_deinit.swift
+++ b/test/SILGen/coverage_deinit.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -suppress-warnings -profile-generate -profile-coverage-mapping -emit-sorted-sil -emit-sil -module-name coverage_deinit %s | %FileCheck %s
+
+import Foundation
+
+public class Derived: NSString {
+  // CHECK-LABEL: sil @_T015coverage_deinit7DerivedCfD
+  // CHECK: builtin "int_instrprof_increment"
+  // CHECK-NEXT: super_method {{.*}} : $Derived, #NSString.deinit!deallocator.foreign
+  deinit {
+  }
+}
+
+// CHECK-LABEL: sil_coverage_map "{{.*}}coverage_deinit.swift" _T015coverage_deinit7DerivedCfD
+// CHECK-NEXT: [[@LINE-5]]:10 -> [[@LINE-4]]:4 : 0


### PR DESCRIPTION
The compiler emits profiler increments in destructors for pure-Swift
classes, but not in destructors for classes that inherit from ObjC
classes. Add in increments for the second kind of destructor.

rdar://problem/29139109