### PR TITLE
-Onone support for access markers, fixes to SIL passes, options and pipeline config.

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -58,6 +58,9 @@ ERROR(error_unsupported_opt_for_target, none,
 ERROR(error_argument_not_allowed_with, none,
   "argument '%0' is not allowed with '%1'", (StringRef, StringRef))
 
+WARNING(warning_argument_not_supported_with_optimization, none,
+  "argument '%0' is not supported with optimization", (StringRef))
+
 ERROR(error_option_requires_sanitizer, none,
   "option '%0' requires a sanitizer to be enabled. Use -sanitize= to enable a"
   " sanitizer", (StringRef))

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1237,6 +1237,12 @@ void parseExclusivityEnforcementOptions(const llvm::opt::Arg *A,
     Diags.diagnose(SourceLoc(), diag::error_unsupported_option_argument,
         A->getOption().getPrefixedName(), A->getValue());
   }
+  if (Opts.Optimization > SILOptions::SILOptMode::None
+      && Opts.EnforceExclusivityDynamic) {
+    Diags.diagnose(SourceLoc(),
+                   diag::warning_argument_not_supported_with_optimization,
+                   A->getOption().getPrefixedName() + A->getValue());
+  }
 }
 
 static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,

--- a/lib/SILOptimizer/Mandatory/AccessEnforcementSelection.cpp
+++ b/lib/SILOptimizer/Mandatory/AccessEnforcementSelection.cpp
@@ -12,7 +12,9 @@
 ///
 /// This pass eliminates 'unknown' access enforcement by selecting either
 /// static or dynamic enforcement.
-/// 
+///
+/// FIXME: handle boxes used by copy_value when neither copy is captured.
+///
 //===----------------------------------------------------------------------===//
 
 #define DEBUG_TYPE "access-enforcement-selection"
@@ -110,6 +112,8 @@ void SelectEnforcement::run() {
   updateAccesses();
 }
 
+// FIXME: This should cover a superset of AllocBoxToStack's findUnexpectedBoxUse
+// to avoid perturbing codegen. They should be sharing the same analysis.
 void SelectEnforcement::analyzeUsesOfBox(SILInstruction *source) {
   // Collect accesses rooted off of projections.
   for (auto use : source->getUses()) {
@@ -137,7 +141,7 @@ void SelectEnforcement::analyzeUsesOfBox(SILInstruction *source) {
     // Add it to the escapes set.
     Escapes.insert(user);
 
-    // 
+    // Record this point as escaping.
     auto userBB = user->getParent();
     auto &state = StateMap[userBB];
     if (!state.IsInWorklist) {

--- a/lib/SILOptimizer/Mandatory/AccessEnforcementSelection.cpp
+++ b/lib/SILOptimizer/Mandatory/AccessEnforcementSelection.cpp
@@ -80,7 +80,7 @@ public:
   void run();
 
 private:
-  void analyzeUsesOfBox();
+  void analyzeUsesOfBox(SILInstruction *source);
   void analyzeProjection(ProjectBoxInst *projection);
 
   void propagateEscapes();
@@ -101,7 +101,7 @@ private:
 
 void SelectEnforcement::run() {
   // Set up the data-flow problem.
-  analyzeUsesOfBox();
+  analyzeUsesOfBox(Box);
 
   // Run the data-flow problem.
   propagateEscapes();
@@ -110,10 +110,15 @@ void SelectEnforcement::run() {
   updateAccesses();
 }
 
-void SelectEnforcement::analyzeUsesOfBox() {
+void SelectEnforcement::analyzeUsesOfBox(SILInstruction *source) {
   // Collect accesses rooted off of projections.
-  for (auto use : Box->getUses()) {
+  for (auto use : source->getUses()) {
     auto user = use->getUser();
+
+    if (auto MUI = dyn_cast<MarkUninitializedInst>(user)) {
+      analyzeUsesOfBox(MUI);
+      continue;
+    }
 
     if (auto projection = dyn_cast<ProjectBoxInst>(user)) {
       analyzeProjection(projection);
@@ -389,10 +394,14 @@ struct AccessEnforcementSelection : SILFunctionTransform {
   }
 
   void handleAccessToBox(BeginAccessInst *access, ProjectBoxInst *projection) {
+    SILValue source = projection->getOperand();
+    if (auto *MUI = dyn_cast<MarkUninitializedInst>(source))
+      source = MUI->getOperand();
+
     // If we didn't allocate the box, assume that we need to use
     // dynamic enforcement.
     // TODO: use static enforcement in certain provable cases.
-    auto box = dyn_cast<AllocBoxInst>(projection->getOperand());
+    auto box = dyn_cast<AllocBoxInst>(source);
     if (!box) {
       setDynamicEnforcement(access);
       return;

--- a/lib/SILOptimizer/Mandatory/AccessMarkerElimination.cpp
+++ b/lib/SILOptimizer/Mandatory/AccessMarkerElimination.cpp
@@ -28,108 +28,155 @@
 
 using namespace swift;
 
+// This option allows markers to remain in -Onone as a structural SIL property.
+// Regardless of this option, sufficient markers are always emitted to satisfy
+// the current enforcement level. This options simply allows markers to remain
+// for testing and validation.
+//
+// This option only applies to InactiveAccessMarkerElimination. Any occurrence
+// of FullAccessMarkerElimination in the pass pipeline effectively overrides the
+// options and removes all markers.
+//
+// At -Onone, with EnableMarkers, no static markers are removed.
+// With !EnableMarkers:
+// Enforcement | Static               | Dynamic
+// none        | Remove after Diag    | Remove ASAP
+// unchecked   | Remain through IRGen | Remove ASAP
+// checked     | Remain through IRGen | Remain through IRGen
+// dynamic-only| Remove after Diag    | Remain through IRGen
+llvm::cl::opt<bool> EnableAccessMarkers(
+    "sil-access-markers", llvm::cl::init(true),
+    llvm::cl::desc("Enable memory access makers that aren't needed for "
+                   "diagnostics."));
+
 namespace {
 
 struct AccessMarkerElimination : SILModuleTransform {
   virtual bool isFullElimination() = 0;
 
-  void replaceBeginAccessUsers(BeginAccessInst *beginAccess) {
+  bool removedAny = false;
 
-    // Handle all the uses:
-    while (!beginAccess->use_empty()) {
-      Operand *op = *beginAccess->use_begin();
-
-      // Delete any associated end_access instructions.
-      if (auto endAccess = dyn_cast<EndAccessInst>(op->getUser())) {
-        assert(endAccess->use_empty() && "found use of end_access");
-        endAccess->eraseFromParent();
-
-        // Forward all other uses to the original address.
-      } else {
-        op->set(beginAccess->getSource());
-      }
-    }
-  }
-
-  bool shouldPreserveAccess(SILAccessEnforcement enforcement) {
-    auto &M = *getModule();
-    switch (enforcement) {
-    case SILAccessEnforcement::Unknown:
-      return false;
-    case SILAccessEnforcement::Static:
-      // Even though static enforcement is already performed, this flag is
-      // useful to control marker preservation for now.
-      return M.getOptions().EnforceExclusivityStatic;
-    case SILAccessEnforcement::Dynamic:
-      return M.getOptions().EnforceExclusivityDynamic;
-    case SILAccessEnforcement::Unsafe:
-      return false;
-    }
+  SILBasicBlock::iterator eraseInst(SILInstruction *inst) {
+    removedAny = true;
+    return inst->getParent()->erase(inst);
   };
 
-  void run() override {
-    auto &M = *getModule();
+  void replaceBeginAccessUsers(BeginAccessInst *beginAccess);
 
-    bool removedAny = false;
+  // Precondition: !EnableAccessMarkers || isFullElimination()
+  bool shouldPreserveAccess(SILAccessEnforcement enforcement);
 
-    auto eraseInst = [&removedAny](SILInstruction *inst) {
-      removedAny = true;
-      return inst->getParent()->erase(inst);
-    };
+  // Check if the instruction is a marker that should be eliminated. If so,
+  // updated the SIL, short of erasing the marker itself, and return true.
+  bool checkAndEliminateMarker(SILInstruction *inst);
 
-    for (auto &F : M) {
-      // Iterating in reverse eliminates more begin_access users before they
-      // need to be replaced.
-      for (auto &BB : reversed(F)) {
-        // Don't cache the begin iterator since we're reverse iterating.
-        for (auto II = BB.end(); II != BB.begin();) {
-          SILInstruction *inst = &*(--II);
+  // Entry point called by the pass manager.
+  void run() override;
+};
 
-          if (auto beginAccess = dyn_cast<BeginAccessInst>(inst)) {
-            // Leave dynamic accesses in place, but delete all others.
-            if (shouldPreserveAccess(beginAccess->getEnforcement()))
-              continue;
+void AccessMarkerElimination::replaceBeginAccessUsers(
+    BeginAccessInst *beginAccess) {
+  // Handle all the uses:
+  while (!beginAccess->use_empty()) {
+    Operand *op = *beginAccess->use_begin();
 
-            replaceBeginAccessUsers(beginAccess);
-            II = eraseInst(beginAccess);
-            continue;
-          }
+    // Delete any associated end_access instructions.
+    if (auto endAccess = dyn_cast<EndAccessInst>(op->getUser())) {
+      assert(endAccess->use_empty() && "found use of end_access");
+      endAccess->eraseFromParent();
 
-          // end_access instructions will be handled when we process the
-          // begin_access.
-
-          // begin_unpaired_access instructions will be directly removed and
-          // simply replaced with their operand.
-          if (auto BUA = dyn_cast<BeginUnpairedAccessInst>(inst)) {
-            if (shouldPreserveAccess(BUA->getEnforcement()))
-              continue;
-
-            BUA->replaceAllUsesWith(BUA->getSource());
-            II = eraseInst(BUA);
-            continue;
-          }
-          // end_unpaired_access instructions will be directly removed and
-          // simply replaced with their operand.
-          if (auto EUA = dyn_cast<EndUnpairedAccessInst>(inst)) {
-            if (shouldPreserveAccess(EUA->getEnforcement()))
-              continue;
-
-            assert(EUA->use_empty() && "use of end_unpaired_access");
-            II = eraseInst(EUA);
-            continue;
-          }
-        }
-      }
-
-      // Don't invalidate any analyses if we didn't do anything.
-      if (!removedAny)
-        continue;
-
-      auto InvalidKind = SILAnalysis::InvalidationKind::Instructions;
-      invalidateAnalysis(&F, InvalidKind);
+      // Forward all other uses to the original address.
+    } else {
+      op->set(beginAccess->getSource());
     }
   }
-};
+}
+
+// Precondition: !EnableAccessMarkers || isFullElimination()
+bool AccessMarkerElimination::shouldPreserveAccess(
+    SILAccessEnforcement enforcement) {
+  if (isFullElimination())
+    return false;
+
+  auto &M = *getModule();
+  switch (enforcement) {
+  case SILAccessEnforcement::Unknown:
+    return false;
+  case SILAccessEnforcement::Static:
+    // Even though static enforcement is already performed, this flag is
+    // useful to control marker preservation for now.
+    return EnableAccessMarkers || M.getOptions().EnforceExclusivityStatic;
+  case SILAccessEnforcement::Dynamic:
+    // FIXME: when dynamic markers are fully supported, don't strip:
+    // return EnableAccessMarkers || M.getOptions().EnforceExclusivityDynamic;
+    return M.getOptions().EnforceExclusivityDynamic;
+  case SILAccessEnforcement::Unsafe:
+    return false;
+  }
+}
+
+// Check if the instruction is a marker that should be eliminated. If so,
+// updated the SIL, short of erasing the marker itself, and return true.
+bool AccessMarkerElimination::checkAndEliminateMarker(SILInstruction *inst) {
+  if (auto beginAccess = dyn_cast<BeginAccessInst>(inst)) {
+    // Leave dynamic accesses in place, but delete all others.
+    if (shouldPreserveAccess(beginAccess->getEnforcement()))
+      return false;
+
+    replaceBeginAccessUsers(beginAccess);
+    return true;
+  }
+
+  // end_access instructions will be handled when we process the
+  // begin_access.
+
+  // begin_unpaired_access instructions will be directly removed and
+  // simply replaced with their operand.
+  if (auto BUA = dyn_cast<BeginUnpairedAccessInst>(inst)) {
+    if (shouldPreserveAccess(BUA->getEnforcement()))
+      return false;
+
+    BUA->replaceAllUsesWith(BUA->getSource());
+    return true;
+  }
+  // end_unpaired_access instructions will be directly removed and
+  // simply replaced with their operand.
+  if (auto EUA = dyn_cast<EndUnpairedAccessInst>(inst)) {
+    if (shouldPreserveAccess(EUA->getEnforcement()))
+      return false;
+
+    assert(EUA->use_empty() && "use of end_unpaired_access");
+    return true;
+  }
+  return false;
+}
+
+void AccessMarkerElimination::run() {
+  // FIXME: When dynamic markers are fully supported, just skip this pass:
+  //   if (EnableAccessMarkers && !isFullElimination())
+  //     return;
+
+  auto &M = *getModule();
+  for (auto &F : M) {
+    // Iterating in reverse eliminates more begin_access users before they
+    // need to be replaced.
+    for (auto &BB : reversed(F)) {
+      // Don't cache the begin iterator since we're reverse iterating.
+      for (auto II = BB.end(); II != BB.begin();) {
+        SILInstruction *inst = &*(--II);
+        if (checkAndEliminateMarker(inst))
+          II = eraseInst(inst);
+      }
+    }
+
+    // Don't invalidate any analyses if we didn't do anything.
+    if (!removedAny)
+      continue;
+
+    auto InvalidKind = SILAnalysis::InvalidationKind::Instructions;
+    invalidateAnalysis(&F, InvalidKind);
+  }
+}
 
 struct InactiveAccessMarkerElimination : AccessMarkerElimination {
   virtual bool isFullElimination() { return false; }

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -79,13 +79,17 @@ static void addMandatoryOptPipeline(SILPassPipelinePlan &P,
   }
   P.addDiagnoseStaticExclusivity();
   P.addCapturePromotion();
+
+  // Select access kind after capture promotion and before stack promotion.
+  // This guarantees that stack-promotable boxes have [static] enforcement.
+  P.addAccessEnforcementSelection();
+  P.addInactiveAccessMarkerElimination();
+
   P.addAllocBoxToStack();
   P.addNoReturnFolding();
   P.addOwnershipModelEliminator();
   P.addMarkUninitializedFixup();
   P.addDefiniteInitialization();
-  P.addAccessEnforcementSelection();
-  P.addInactiveAccessMarkerElimination();
   P.addMandatoryInlining();
   P.addPredictableMemoryOptimizations();
   P.addDiagnosticConstantPropagation();

--- a/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
+++ b/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
@@ -435,6 +435,7 @@ static void replaceProjectBoxUsers(SILValue HeapBox, SILValue StackBox) {
   while (!Worklist.empty()) {
     auto *Op = Worklist.pop_back_val();
     if (auto *PBI = dyn_cast<ProjectBoxInst>(Op->getUser())) {
+      // This may result in an alloc_stack being used by begin_access [dymaic].
       PBI->replaceAllUsesWith(StackBox);
       continue;
     }

--- a/test/Interpreter/enforce_exclusive_access.swift
+++ b/test/Interpreter/enforce_exclusive_access.swift
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %target-build-swift %s -o %t/a.out -enforce-exclusivity=checked
+// RUN: %target-build-swift %s -o %t/a.out -enforce-exclusivity=checked -Onone
 //
 // RUN: %target-run %t/a.out
 // REQUIRES: executable_test

--- a/test/SILGen/addressors.swift
+++ b/test/SILGen/addressors.swift
@@ -29,7 +29,8 @@ struct A {
 
 // CHECK-LABEL: sil hidden @_T010addressors1AV9subscripts5Int32VAFcfau : $@convention(method) (Int32, @inout A) -> UnsafeMutablePointer<Int32>
 // CHECK: bb0([[INDEX:%.*]] : $Int32, [[SELF:%.*]] : $*A):
-// CHECK:   [[T0:%.*]] = struct_element_addr [[SELF]] : $*A, #A.base
+// CHECK:   [[READ:%.*]] = begin_access [read] [static] [[SELF]] : $*A
+// CHECK:   [[T0:%.*]] = struct_element_addr [[READ]] : $*A, #A.base
 // CHECK:   [[BASE:%.*]] = load [[T0]] : $*UnsafeMutablePointer<Int32>
 // CHECK:   return [[BASE]] : $UnsafeMutablePointer<Int32>
 
@@ -49,8 +50,9 @@ func test0() {
 // CHECK: [[Z:%.*]] = load [[T3]] : $*Int32
   let z = a[10]
 
+// CHECK: [[WRITE:%.*]] = begin_access [modify] [static] [[A]] : $*A
 // CHECK: [[T0:%.*]] = function_ref @_T010addressors1AV9subscripts5Int32VAFcfau :
-// CHECK: [[T1:%.*]] = apply [[T0]]({{%.*}}, [[A]])
+// CHECK: [[T1:%.*]] = apply [[T0]]({{%.*}}, [[WRITE]])
 // CHECK: [[T2:%.*]] = struct_extract [[T1]] : $UnsafeMutablePointer<Int32>, #UnsafeMutablePointer._rawValue
 // CHECK: [[T3:%.*]] = pointer_to_address [[T2]] : $Builtin.RawPointer to [strict] $*Int32
 // CHECK: load
@@ -58,8 +60,9 @@ func test0() {
 // CHECK: store {{%.*}} to [[T3]]
   a[5] += z
 
+// CHECK: [[WRITE:%.*]] = begin_access [modify] [static] [[A]] : $*A
 // CHECK: [[T0:%.*]] = function_ref @_T010addressors1AV9subscripts5Int32VAFcfau :
-// CHECK: [[T1:%.*]] = apply [[T0]]({{%.*}}, [[A]])
+// CHECK: [[T1:%.*]] = apply [[T0]]({{%.*}}, [[WRITE]])
 // CHECK: [[T2:%.*]] = struct_extract [[T1]] : $UnsafeMutablePointer<Int32>, #UnsafeMutablePointer._rawValue
 // CHECK: [[T3:%.*]] = pointer_to_address [[T2]] : $Builtin.RawPointer to [strict] $*Int32
 // CHECK: store {{%.*}} to [[T3]]
@@ -122,8 +125,9 @@ struct B : Subscriptable {
 // CHECK:   [[T0:%.*]] = integer_literal $Builtin.Int32, 0
 // CHECK:   [[INDEX:%.*]] = struct $Int32 ([[T0]] : $Builtin.Int32)
 // CHECK:   [[RHS:%.*]] = integer_literal $Builtin.Int32, 7
+// CHECK:   [[WRITE:%.*]] = begin_access [modify] [static] [[B]] : $*B
 // CHECK:   [[T0:%.*]] = function_ref @_T010addressors1BV9subscripts5Int32VAFcfau
-// CHECK:   [[PTR:%.*]] = apply [[T0]]([[INDEX]], [[B]])
+// CHECK:   [[PTR:%.*]] = apply [[T0]]([[INDEX]], [[WRITE]])
 // CHECK:   [[T0:%.*]] = struct_extract [[PTR]] : $UnsafeMutablePointer<Int32>,
 // CHECK:   [[ADDR:%.*]] = pointer_to_address [[T0]] : $Builtin.RawPointer to [strict] $*Int32
 // Accept either of struct_extract+load or load+struct_element_addr.
@@ -149,14 +153,16 @@ func id_int(_ i: Int32) -> Int32 { return i }
 // CHECK-LABEL: sil hidden @_T010addressors11test_carrays5Int32VAA6CArrayVyA2DcGzF : $@convention(thin) (@inout CArray<(Int32) -> Int32>) -> Int32 {
 // CHECK: bb0([[ARRAY:%.*]] : $*CArray<(Int32) -> Int32>):
 func test_carray(_ array: inout CArray<(Int32) -> Int32>) -> Int32 {
+// CHECK:   [[WRITE:%.*]] = begin_access [modify] [static] [[ARRAY]] : $*CArray<(Int32) -> Int32>
 // CHECK:   [[T0:%.*]] = function_ref @_T010addressors6CArrayV9subscriptxSicfau :
-// CHECK:   [[T1:%.*]] = apply [[T0]]<(Int32) -> Int32>({{%.*}}, [[ARRAY]])
+// CHECK:   [[T1:%.*]] = apply [[T0]]<(Int32) -> Int32>({{%.*}}, [[WRITE]])
 // CHECK:   [[T2:%.*]] = struct_extract [[T1]] : $UnsafeMutablePointer<(Int32) -> Int32>, #UnsafeMutablePointer._rawValue
 // CHECK:   [[T3:%.*]] = pointer_to_address [[T2]] : $Builtin.RawPointer to [strict] $*@callee_owned (@in Int32) -> @out Int32
 // CHECK:   store {{%.*}} to [[T3]] :
   array[0] = id_int
 
-// CHECK:   [[T0:%.*]] = load [[ARRAY]]
+// CHECK:   [[READ:%.*]] = begin_access [read] [static] [[ARRAY]] : $*CArray<(Int32) -> Int32>
+// CHECK:   [[T0:%.*]] = load [[READ]]
 // CHECK:   [[T1:%.*]] = function_ref @_T010addressors6CArrayV9subscriptxSicflu :
 // CHECK:   [[T2:%.*]] = apply [[T1]]<(Int32) -> Int32>({{%.*}}, [[T0]])
 // CHECK:   [[T3:%.*]] = struct_extract [[T2]] : $UnsafePointer<(Int32) -> Int32>, #UnsafePointer._rawValue
@@ -205,22 +211,25 @@ func take_int_inout(_ value: inout Int32) {}
 func test_d(_ array: inout D) -> Int32 {
 // CHECK:   [[T0:%.*]] = function_ref @_T010addressors8make_ints5Int32VyF
 // CHECK:   [[V:%.*]] = apply [[T0]]()
+// CHECK:   [[WRITE:%.*]] = begin_access [modify] [static] [[ARRAY]] : $*D
 // CHECK:   [[T0:%.*]] = function_ref @_T010addressors1DV9subscripts5Int32VAFcfau
-// CHECK:   [[T1:%.*]] = apply [[T0]]({{%.*}}, [[ARRAY]])
+// CHECK:   [[T1:%.*]] = apply [[T0]]({{%.*}}, [[WRITE]])
 // CHECK:   [[T2:%.*]] = struct_extract [[T1]] : $UnsafeMutablePointer<Int32>,
 // CHECK:   [[ADDR:%.*]] = pointer_to_address [[T2]] : $Builtin.RawPointer to [strict] $*Int32
 // CHECK:   store [[V]] to [[ADDR]] : $*Int32
   array[0] = make_int()
 
 // CHECK:   [[FN:%.*]] = function_ref @_T010addressors14take_int_inoutys5Int32VzF
+// CHECK:   [[WRITE:%.*]] = begin_access [modify] [static] [[ARRAY]] : $*D
 // CHECK:   [[T0:%.*]] = function_ref @_T010addressors1DV9subscripts5Int32VAFcfau
-// CHECK:   [[T1:%.*]] = apply [[T0]]({{%.*}}, [[ARRAY]])
+// CHECK:   [[T1:%.*]] = apply [[T0]]({{%.*}}, [[WRITE]])
 // CHECK:   [[T2:%.*]] = struct_extract [[T1]] : $UnsafeMutablePointer<Int32>,
 // CHECK:   [[ADDR:%.*]] = pointer_to_address [[T2]] : $Builtin.RawPointer to [strict] $*Int32
 // CHECK:   apply [[FN]]([[ADDR]])
   take_int_inout(&array[1])
 
-// CHECK:   [[T0:%.*]] = load [[ARRAY]]
+// CHECK:   [[READ:%.*]] = begin_access [read] [static] [[ARRAY]] : $*D
+// CHECK:   [[T0:%.*]] = load [[READ]]
 // CHECK:   [[T1:%.*]] = function_ref @_T010addressors1DV9subscripts5Int32VAFcfg 
 // CHECK:   [[T2:%.*]] = apply [[T1]]({{%.*}}, [[T0]])
 // CHECK:   return [[T2]]

--- a/test/SILGen/unmanaged.swift
+++ b/test/SILGen/unmanaged.swift
@@ -20,10 +20,12 @@ func set(holder holder: inout Holder) {
 // CHECK: bb0([[ADDR:%.*]] : $*Holder):
 // CHECK:        [[T0:%.*]] = function_ref @_T09unmanaged1CC{{[_0-9a-zA-Z]*}}fC
 // CHECK:        [[C:%.*]] = apply [[T0]](
-// CHECK-NEXT:   [[T0:%.*]] = struct_element_addr [[ADDR]] : $*Holder, #Holder.value
+// CHECK-NEXT:   [[WRITE:%.*]] = begin_access [modify] [static] [[ADDR]] : $*Holder
+// CHECK-NEXT:   [[T0:%.*]] = struct_element_addr [[WRITE]] : $*Holder, #Holder.value
 // CHECK-NEXT:   [[T1:%.*]] = ref_to_unmanaged [[C]]
 // CHECK-NEXT:   store [[T1]] to [[T0]]
 // CHECK-NEXT:   strong_release [[C]]
+// CHECK-NEXT:   end_access [[WRITE]] : $*Holder
 // CHECK-NEXT:   tuple ()
 // CHECK-NEXT:   return
 
@@ -33,10 +35,12 @@ func get(holder holder: inout Holder) -> C {
 // CHECK-LABEL:sil hidden @_T09unmanaged3getAA1CCAA6HolderVz6holder_tF : $@convention(thin) (@inout Holder) -> @owned C
 // CHECK: bb0([[ADDR:%.*]] : $*Holder):
 // CHECK-NEXT:   debug_value_addr %0 : $*Holder, var, name "holder", argno 1 
-// CHECK-NEXT:   [[T0:%.*]] = struct_element_addr [[ADDR]] : $*Holder, #Holder.value
+// CHECK-NEXT:   [[READ:%.*]] = begin_access [read] [static] [[ADDR]] : $*Holder
+// CHECK-NEXT:   [[T0:%.*]] = struct_element_addr [[READ]] : $*Holder, #Holder.value
 // CHECK-NEXT:   [[T1:%.*]] = load [[T0]] : $*@sil_unmanaged C
 // CHECK-NEXT:   [[T2:%.*]] = unmanaged_to_ref [[T1]]
 // CHECK-NEXT:   strong_retain [[T2]]
+// CHECK-NEXT:   end_access [[READ]] : $*Holder
 // CHECK-NEXT:   return [[T2]]
 
 func project(fn fn: () -> Holder) -> C {

--- a/test/SILOptimizer/access_enforcement_selection.sil
+++ b/test/SILOptimizer/access_enforcement_selection.sil
@@ -1,0 +1,101 @@
+// RUN: %target-sil-opt -access-enforcement-selection -enforce-exclusivity=checked %s | %FileCheck %s
+
+import Builtin
+import Swift
+
+sil_stage raw
+
+// Test undef begin_access operands.
+// CHECK-LABEL: sil hidden @undefStack : $@convention(thin) (Builtin.Int64) -> Builtin.Int64 {
+// CHECK: bb0(%0 : $Builtin.Int64):
+// CHECK: unreachable
+// CHECK: bb1:
+// CHECK: [[WRITE:%.*]] = begin_access [modify] [static] undef : $*Builtin.Int64
+// CHECK: store %{{.*}} to [trivial] [[WRITE]] : $*Builtin.Int64
+// CHECK: end_access [[WRITE]] : $*Builtin.Int64
+// CHECK: br
+// CHECK: bb2:
+// CHECK: [[READ:%.*]] = begin_access [read] [static] undef : $*Builtin.Int64
+// CHECK: %{{.*}} = load [trivial] [[READ]] : $*Builtin.Int64
+// CHECK: end_access [[READ]] : $*Builtin.Int64
+// CHECK-LABEL: } // end sil function 'undefStack'
+sil hidden @undefStack : $@convention(thin) (Builtin.Int64) -> Builtin.Int64 {
+bb0(%0 : $Builtin.Int64):
+  unreachable
+
+bb1:
+  %23 = integer_literal $Builtin.Int64, 42
+  %25 = begin_access [modify] [unknown] undef : $*Builtin.Int64
+  store %23 to [trivial] %25 : $*Builtin.Int64
+  end_access %25 : $*Builtin.Int64
+  br bb2
+
+bb2:
+  %29 = begin_access [read] [unknown] undef : $*Builtin.Int64
+  %30 = load [trivial] %29 : $*Builtin.Int64
+  end_access %29 : $*Builtin.Int64
+  dealloc_stack undef : $*Builtin.Int64
+  return %30 : $Builtin.Int64
+}
+
+// Test static enforcement selection in the presence of mark_function_escape.
+// This really isn't really a special case, but depends on pass pipeline.
+//
+// CHECK-LABEL: sil hidden @markFuncEscape : $@convention(thin) () -> () {
+// CHECK: bb0:
+// CHECK:  [[BOX:%.*]] = alloc_box ${ var Builtin.Int64 }, var, name "x"
+// CHECK:  [[ADR:%.*]] = project_box [[BOX]] : ${ var Builtin.Int64 }, 0
+// CHECK:  mark_function_escape [[ADR]] : $*Builtin.Int64
+// CHECK:  [[READ:%.*]] = begin_access [read] [static] [[ADR]] : $*Builtin.Int64
+// CHECK:  %{{.*}} = load [trivial] [[READ]] : $*Builtin.Int64
+// CHECK:  end_access [[READ]] : $*Builtin.Int64
+// CHECK:  destroy_value [[BOX]] : ${ var Builtin.Int64 }
+// CHECK:  return %{{.*}} : $()
+// CHECK-LABEL:} // end sil function 'markFuncEscape'
+sil hidden @markFuncEscape : $@convention(thin) () -> () {
+  %2 = alloc_box ${ var Builtin.Int64 }, var, name "x"
+  %3 = project_box %2 : ${ var Builtin.Int64 }, 0
+  mark_function_escape %3 : $*Builtin.Int64
+  %39 = begin_access [read] [unknown] %3 : $*Builtin.Int64
+  %40 = load [trivial] %39 : $*Builtin.Int64
+  end_access %39 : $*Builtin.Int64
+  destroy_value %2 : ${ var Builtin.Int64 }
+  %98 = tuple ()
+  %99 = return %98 : $()
+}
+
+// Test static enforcement of copied boxes.
+// FIXME: Oops... We make this dynamic.
+//
+// CHECK-LABEL: sil hidden @copyBox : $@convention(thin) () -> () {
+// CHECK: bb0:
+// CHECK:  [[BOX:%.*]] = alloc_box ${ var Builtin.Int64 }, var, name "x"
+// CHECK:  [[ADR1:%.*]] = project_box [[BOX]] : ${ var Builtin.Int64 }, 0
+// CHECK:  [[CPY:%.*]] = copy_value [[BOX]] : ${ var Builtin.Int64 }
+// CHECK:  [[ADR2:%.*]] = project_box [[CPY]] : ${ var Builtin.Int64 }, 0
+// CHECK:  [[READ:%.*]] = begin_access [read] [dynamic] [[ADR2]] : $*Builtin.Int64
+// CHECK:  %{{.*}} = load [trivial] [[READ]] : $*Builtin.Int64
+// CHECK:  end_access [[READ]] : $*Builtin.Int64
+// CHECK:  [[READ:%.*]] = begin_access [read] [dynamic] [[ADR1]] : $*Builtin.Int64
+// CHECK:  %{{.*}} = load [trivial] [[READ]] : $*Builtin.Int64
+// CHECK:  end_access [[READ]] : $*Builtin.Int64
+// CHECK:  destroy_value [[CPY]] : ${ var Builtin.Int64 }
+// CHECK:  destroy_value [[BOX]] : ${ var Builtin.Int64 }
+// CHECK:  return %{{.*}} : $()
+// CHECK-LABEL: } // end sil function 'copyBox'
+sil hidden @copyBox : $@convention(thin) () -> () {
+  %2 = alloc_box ${ var Builtin.Int64 }, var, name "x"
+  %3 = project_box %2 : ${ var Builtin.Int64 }, 0
+  %16 = copy_value %2 : ${ var Builtin.Int64 }
+  %17 = project_box %16 : ${ var Builtin.Int64 }, 0
+  %18 = begin_access [read] [unknown] %17 : $*Builtin.Int64
+  %19 = load [trivial] %18 : $*Builtin.Int64
+  end_access %18 : $*Builtin.Int64
+  %39 = begin_access [read] [unknown] %3 : $*Builtin.Int64
+  %40 = load [trivial] %39 : $*Builtin.Int64
+  end_access %39 : $*Builtin.Int64
+  destroy_value %16 : ${ var Builtin.Int64 }
+  destroy_value %2 : ${ var Builtin.Int64 }
+  %98 = tuple ()
+  %99 = return %98 : $()
+}

--- a/test/SILOptimizer/access_enforcement_selection.swift
+++ b/test/SILOptimizer/access_enforcement_selection.swift
@@ -7,7 +7,7 @@ public func takesInout(_ i: inout Int) {
   i = 42
 }
 // CHECK-LABEL: Access Enforcement Selection in _T028access_enforcement_selection10takesInoutySizF
-// CHECK: Static Access: %{{.*}} = begin_access [modify] [static] %0 : $*Int
+// CHECK: Static Access: %{{.*}} = begin_access [modify] [static] %{{.*}} : $*Int
 
 // Helper taking a basic, no-escape closure.
 func takeClosure(_: ()->Int) {}
@@ -22,14 +22,14 @@ public func captureStack() -> Int {
 }
 // CHECK-LABEL: Access Enforcement Selection in _T028access_enforcement_selection12captureStackSiyF
 // Static access for `return x`.
-// CHECK: Static Access: %{{.*}} = begin_access [read] [static] %0 : $*Int
+// CHECK: Static Access: %{{.*}} = begin_access [read] [static] %{{.*}} : $*Int
 
 // The access inside the closure is dynamic, until we have the logic necessary to
 // prove that no other closures are passed to `takeClosure` that may write to
 // `x`.
 //
 // CHECK-LABEL: Access Enforcement Selection in _T028access_enforcement_selection12captureStackSiyFSiycfU_
-// CHECK: Dynamic Access: %{{.*}} = begin_access [read] [dynamic] %0 : $*Int
+// CHECK: Dynamic Access: %{{.*}} = begin_access [read] [dynamic] %{{.*}} : $*Int
 
 // Generate a closure in which the @inout_aliasing argument
 // escapes to an @inout function `bar`.
@@ -41,27 +41,15 @@ public func recaptureStack() -> Int {
 // CHECK-LABEL: Access Enforcement Selection in _T028access_enforcement_selection14recaptureStackSiyF
 //
 // Static access for `return x`.
-// CHECK: Static Access:   %10 = begin_access [read] [static] %0 : $*Int
+// CHECK: Static Access:   %{{.*}} = begin_access [read] [static] %{{.*}} : $*Int
 
 // CHECK-LABEL: Access Enforcement Selection in _T028access_enforcement_selection14recaptureStackSiyFSiycfU_
 //
 // The first [modify] access inside the closure must be dynamic. It enforces the
 // @inout argument.
-// CHECK: Dynamic Access: %{{.*}} = begin_access [modify] [dynamic] %0 : $*Int
+// CHECK: Dynamic Access: %{{.*}} = begin_access [modify] [dynamic] %{{.*}} : $*Int
 //
 // The second [read] access is only dynamic because the analysis isn't strong
 // enough to prove otherwise. Same as `captureStack` above.
 //
-// CHECK: Dynamic Access: %{{.*}} = begin_access [read] [dynamic] %0 : $*Int
-
-public func undefStack(i: Int) -> Int {
-  _preconditionFailure("unreachable")
-  var x = 3
-  if i != 0 {
-    x = 42
-  }
-  return x
-}
-// CHECK-LABEL: Access Enforcement Selection in _T028access_enforcement_selection10undefStackS2i1i_tF
-// CHECK: Static Access:   %{{.*}} = begin_access [modify] [static] undef : $*Int
-// CHECK: Static Access:   %{{.*}} = begin_access [read] [static] undef : $*Int
+// CHECK: Dynamic Access: %{{.*}} = begin_access [read] [dynamic] %{{.*}} : $*Int

--- a/test/SILOptimizer/access_marker_elim.sil
+++ b/test/SILOptimizer/access_marker_elim.sil
@@ -11,7 +11,7 @@ public struct S {
   init(i: Int)
 }
 
-// CHECK-LABEL: sil hidden [noinline] @initS : $@convention(thin) () -> @owned S {
+// CHECK-LABEL: sil hidden [noinline] @f010_initS : $@convention(thin) () -> @owned S {
 // CHECK: bb0:
 // CHECK:  %[[BOX:.*]] = alloc_box ${ var S }, var, name "s"
 // CHECK:  %[[ADDRS:.*]] = project_box %[[BOX]] : ${ var S }, 0
@@ -25,8 +25,8 @@ public struct S {
 // CHECK-NOT: end_access
 // CHECK:  destroy_value %[[BOX]] : ${ var S }
 // CHECK:  return %[[VALS]] : $S
-// CHECK-LABEL: } // end sil function 'initS'
-sil hidden [noinline] @initS : $@convention(thin) () -> @owned S {
+// CHECK-LABEL: } // end sil function 'f010_initS'
+sil hidden [noinline] @f010_initS : $@convention(thin) () -> @owned S {
 bb0:
   %0 = alloc_box ${ var S }, var, name "s"
   %1 = project_box %0 : ${ var S }, 0
@@ -40,4 +40,28 @@ bb0:
   end_access %7 : $*S
   destroy_value %0 : ${ var S }
   return %8 : $S
+}
+
+// Test that box arguments are dynamic.
+// And since inactive elimination currently eliminates all dynamic markers,
+// they are gone from the output.
+//
+// CHECK-LABEL: sil hidden @f020_boxArg : $@convention(thin) (@owned { var Builtin.Int64 }) -> () {
+// CHECK: bb0(%0 : ${ var Builtin.Int64 }):
+// CHECK:  [[ADR:%.*]] = project_box %0 : ${ var Builtin.Int64 }, 0
+// CHECK:  [[VAL:%.*]] = integer_literal $Builtin.Int64, 42
+// CHECK:  store [[VAL]] to [trivial] [[ADR]] : $*Builtin.Int64
+// CHECK:  destroy_value %0 : ${ var Builtin.Int64 }
+// CHECK:  return %{{.*}} : $()
+// CHECK-LABEL: } // end sil function 'f020_boxArg'
+sil hidden @f020_boxArg : $@convention(thin) (@owned { var Builtin.Int64 }) -> () {
+bb0(%0 : ${ var Builtin.Int64 }):
+  %1 = project_box %0 : ${ var Builtin.Int64 }, 0
+  %3 = integer_literal $Builtin.Int64, 42
+  %5 = begin_access [modify] [unknown] %1 : $*Builtin.Int64
+  store %3 to [trivial] %5 : $*Builtin.Int64
+  end_access %5 : $*Builtin.Int64
+  destroy_value %0 : ${ var Builtin.Int64 }
+  %9 = tuple ()
+  return %9 : $()
 }

--- a/test/SILOptimizer/access_marker_mandatory.swift
+++ b/test/SILOptimizer/access_marker_mandatory.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -parse-as-library -Xllvm -sil-full-demangle -emit-sil -enforce-exclusivity=checked %s | %FileCheck %s
+// RUN: %target-swift-frontend -parse-as-library -Xllvm -sil-full-demangle -emit-sil -Onone -enforce-exclusivity=checked %s | %FileCheck %s
 
 public struct S {
   var i: Int
@@ -66,17 +66,17 @@ public func modifyAndReadS(o: AnyObject) {
 // Otherwise, we may try to convert the access to [deinit] which
 // doesn't make sense dynamically.
 //
-// CHECK-LABEL: sil hidden @_T028access_enforcement_selection19captureStackPromoteSiycyF : $@convention(thin) () -> @owned @callee_owned () -> Int {
+// CHECK-LABEL: sil hidden @_T023access_marker_mandatory19captureStackPromoteSiycyF : $@convention(thin) () -> @owned @callee_owned () -> Int {
 // CHECK-LABEL: bb0:
 // CHECK: [[STK:%.*]] = alloc_stack $Int, var, name "x"
 // CHECK: [[WRITE:%.*]] = begin_access [modify] [static] [[STK]] : $*Int
 // CHECK: store %{{.*}} to [[WRITE]] : $*Int
 // CHECK: end_access [[WRITE]] : $*Int
-// CHECK: [[F:%.*]] = function_ref @_T028access_enforcement_selection19captureStackPromoteSiycyFSiycfU_Tf2i_n : $@convention(thin) (Int) -> Int
+// CHECK: [[F:%.*]] = function_ref @_T023access_marker_mandatory19captureStackPromoteSiycyFSiycfU_Tf2i_n : $@convention(thin) (Int) -> Int
 // CHECK: [[C:%.*]] = partial_apply [[F]](%{{.*}}) : $@convention(thin) (Int) -> Int
 // CHECK: dealloc_stack [[STK]] : $*Int
 // CHECK: return [[C]] : $@callee_owned () -> Int
-// CHECK-LABEL: } // end sil function '_T028access_enforcement_selection19captureStackPromoteSiycyF'
+// CHECK-LABEL: } // end sil function '_T023access_marker_mandatory19captureStackPromoteSiycyF'
 func captureStackPromote() -> () -> Int {
   var x = 1
   x = 2

--- a/test/SILOptimizer/access_marker_mandatory.swift
+++ b/test/SILOptimizer/access_marker_mandatory.swift
@@ -59,3 +59,27 @@ public func modifyAndReadS(o: AnyObject) {
   s.i = 42
   takeS(s)
 }
+
+// Test capture promotion followed by stack promotion.
+// Access enforcement selection must run after capture promotion
+// so that we never stack promote something with dynamic access.
+// Otherwise, we may try to convert the access to [deinit] which
+// doesn't make sense dynamically.
+//
+// CHECK-LABEL: sil hidden @_T028access_enforcement_selection19captureStackPromoteSiycyF : $@convention(thin) () -> @owned @callee_owned () -> Int {
+// CHECK-LABEL: bb0:
+// CHECK: [[STK:%.*]] = alloc_stack $Int, var, name "x"
+// CHECK: [[WRITE:%.*]] = begin_access [modify] [static] [[STK]] : $*Int
+// CHECK: store %{{.*}} to [[WRITE]] : $*Int
+// CHECK: end_access [[WRITE]] : $*Int
+// CHECK: [[F:%.*]] = function_ref @_T028access_enforcement_selection19captureStackPromoteSiycyFSiycfU_Tf2i_n : $@convention(thin) (Int) -> Int
+// CHECK: [[C:%.*]] = partial_apply [[F]](%{{.*}}) : $@convention(thin) (Int) -> Int
+// CHECK: dealloc_stack [[STK]] : $*Int
+// CHECK: return [[C]] : $@callee_owned () -> Int
+// CHECK-LABEL: } // end sil function '_T028access_enforcement_selection19captureStackPromoteSiycyF'
+func captureStackPromote() -> () -> Int {
+  var x = 1
+  x = 2
+  let f = { x }
+  return f
+}

--- a/test/SILOptimizer/allocbox_to_stack_ownership.sil
+++ b/test/SILOptimizer/allocbox_to_stack_ownership.sil
@@ -1024,3 +1024,38 @@ bb3:
   unreachable
 }
 
+// Test that
+//  begin_access [read], copy_addr, end_access, destroy_addr
+// is folded into
+//  begin_access [deinit], copy_addr [take], end_access
+//
+// CHECK-LABEL: sil @deinit_access : $@convention(thin) <T> (@in T) -> (@out T, @out T) {
+// CHECK: bb0(%0 : @trivial $*T, %1 : @trivial $*T, %2 : @trivial $*T):
+// CHECK: [[STK:%.*]] = alloc_stack $T, var, name "x"
+// CHECK: copy_addr %2 to [initialization] [[STK]] : $*T
+// CHECK: [[READ:%.*]] = begin_access [read] [static] [[STK]] : $*T
+// CHECK: copy_addr [[READ]] to [initialization] %0 : $*T
+// CHECK: end_access [[READ]] : $*T
+// CHECK: [[READ:%.*]] = begin_access [deinit] [static] [[STK]] : $*T
+// CHECK: copy_addr [take] [[READ]] to [initialization] %1 : $*T
+// CHECK: end_access [[READ]] : $*T
+// CHECK: dealloc_stack [[STK]] : $*T
+// CHECK: destroy_addr %2 : $*T
+// CHECK: return %{{.*}} : $()
+// CHECK-LABEL: } // end sil function 'deinit_access'
+sil @deinit_access : $@convention(thin) <T> (@in T) -> (@out T, @out T) {
+bb0(%0 : @owned $*T, %1 : @owned $*T, %2 : @owned $*T):
+  %4 = alloc_box $<τ_0_0> { var τ_0_0 } <T>, var, name "x"
+  %5 = project_box %4 : $<τ_0_0> { var τ_0_0 } <T>, 0
+  copy_addr %2 to [initialization] %5 : $*T
+  %7 = begin_access [read] [static] %5 : $*T
+  copy_addr %7 to [initialization] %0 : $*T
+  end_access %7 : $*T
+  %10 = begin_access [read] [static] %5 : $*T
+  copy_addr %10 to [initialization] %1 : $*T
+  end_access %10 : $*T
+  destroy_value %4 : $<τ_0_0> { var τ_0_0 } <T>
+  destroy_addr %2 : $*T
+  %15 = tuple ()
+  return %15 : $()
+}

--- a/test/SILOptimizer/definite_init_failable_initializers.swift
+++ b/test/SILOptimizer/definite_init_failable_initializers.swift
@@ -53,8 +53,10 @@ struct FailableStruct {
 // CHECK:       bb0(%0 : $@thin FailableStruct.Type):
 // CHECK-NEXT:    [[SELF_BOX:%.*]] = alloc_stack $FailableStruct
 // CHECK:         [[CANARY:%.*]] = apply
-// CHECK-NEXT:    [[X_ADDR:%.*]] = struct_element_addr [[SELF_BOX]]
+// CHECK-NEXT:    [[WRITE:%.*]] = begin_access [modify] [static] [[SELF_BOX]] : $*FailableStruct
+// CHECK-NEXT:    [[X_ADDR:%.*]] = struct_element_addr [[WRITE]]
 // CHECK-NEXT:    store [[CANARY]] to [[X_ADDR]]
+// CHECK-NEXT:    end_access [[WRITE]] : $*FailableStruct
 // CHECK-NEXT:    br bb1
 // CHECK:       bb1:
 // CHECK-NEXT:    [[X_ADDR:%.*]] = struct_element_addr [[SELF_BOX]]
@@ -73,11 +75,15 @@ struct FailableStruct {
 // CHECK:       bb0
 // CHECK:         [[SELF_BOX:%.*]] = alloc_stack $FailableStruct
 // CHECK:         [[CANARY1:%.*]] = apply
-// CHECK-NEXT:    [[X_ADDR:%.*]] = struct_element_addr [[SELF_BOX]]
+// CHECK-NEXT:    [[WRITE:%.*]] = begin_access [modify] [static] [[SELF_BOX]] : $*FailableStruct
+// CHECK-NEXT:    [[X_ADDR:%.*]] = struct_element_addr [[WRITE]]
 // CHECK-NEXT:    store [[CANARY1]] to [[X_ADDR]]
+// CHECK-NEXT:    end_access [[WRITE]] : $*FailableStruct
 // CHECK:         [[CANARY2:%.*]] = apply
-// CHECK-NEXT:    [[Y_ADDR:%.*]] = struct_element_addr [[SELF_BOX]]
+// CHECK-NEXT:    [[WRITE:%.*]] = begin_access [modify] [static] [[SELF_BOX]] : $*FailableStruct
+// CHECK-NEXT:    [[Y_ADDR:%.*]] = struct_element_addr [[WRITE]]
 // CHECK-NEXT:    store [[CANARY2]] to [[Y_ADDR]]
+// CHECK-NEXT:    end_access [[WRITE]] : $*FailableStruct
 // CHECK-NEXT:    br bb1
 // CHECK:       bb1:
 // CHECK-NEXT:    [[SELF:%.*]] = struct $FailableStruct ([[CANARY1]] : $Canary, [[CANARY2]] : $Canary)
@@ -97,7 +103,9 @@ struct FailableStruct {
 // CHECK:       bb0
 // CHECK:         [[SELF_BOX:%.*]] = alloc_stack $FailableStruct
 // CHECK:         [[CANARY]] = apply
-// CHECK-NEXT:    store [[CANARY]] to [[SELF_BOX]]
+// CHECK-NEXT:    [[WRITE:%.*]] = begin_access [modify] [static] [[SELF_BOX]] : $*FailableStruct
+// CHECK-NEXT:    store [[CANARY]] to [[WRITE]]
+// CHECK-NEXT:    end_access [[WRITE]] : $*FailableStruct
 // CHECK-NEXT:    br bb1
 // CHECK:       bb1:
 // CHECK-NEXT:    release_value [[CANARY]]
@@ -221,8 +229,10 @@ struct FailableAddrOnlyStruct<T : Pachyderm> {
 // CHECK-NEXT:    [[X_BOX:%.*]] = alloc_stack $T
 // CHECK-NEXT:    [[T_TYPE:%.*]] = metatype $@thick T.Type
 // CHECK-NEXT:    apply [[T_INIT_FN]]<T>([[X_BOX]], [[T_TYPE]])
-// CHECK-NEXT:    [[X_ADDR:%.*]] = struct_element_addr [[SELF_BOX]]
+// CHECK-NEXT:    [[WRITE:%.*]] = begin_access [modify] [static] [[SELF_BOX]] : $*FailableAddrOnlyStruct<T>
+// CHECK-NEXT:    [[X_ADDR:%.*]] = struct_element_addr [[WRITE]]
 // CHECK-NEXT:    copy_addr [take] [[X_BOX]] to [initialization] [[X_ADDR]]
+// CHECK-NEXT:    end_access [[WRITE]] : $*FailableAddrOnlyStruct<T>
 // CHECK-NEXT:    dealloc_stack [[X_BOX]]
 // CHECK-NEXT:    br bb1
 // CHECK:       bb1:
@@ -245,15 +255,19 @@ struct FailableAddrOnlyStruct<T : Pachyderm> {
 // CHECK-NEXT:    [[X_BOX:%.*]] = alloc_stack $T
 // CHECK-NEXT:    [[T_TYPE:%.*]] = metatype $@thick T.Type
 // CHECK-NEXT:    apply [[T_INIT_FN]]<T>([[X_BOX]], [[T_TYPE]])
-// CHECK-NEXT:    [[X_ADDR:%.*]] = struct_element_addr [[SELF_BOX]]
+// CHECK-NEXT:    [[WRITE:%.*]] = begin_access [modify] [static] [[SELF_BOX]] : $*FailableAddrOnlyStruct<T>
+// CHECK-NEXT:    [[X_ADDR:%.*]] = struct_element_addr [[WRITE]]
 // CHECK-NEXT:    copy_addr [take] [[X_BOX]] to [initialization] [[X_ADDR]]
+// CHECK-NEXT:    end_access [[WRITE]] : $*FailableAddrOnlyStruct<T>
 // CHECK-NEXT:    dealloc_stack [[X_BOX]]
 // CHECK-NEXT:    [[T_INIT_FN:%.*]] = witness_method $T, #Pachyderm.init!allocator.1
 // CHECK-NEXT:    [[Y_BOX:%.*]] = alloc_stack $T
 // CHECK-NEXT:    [[T_TYPE:%.*]] = metatype $@thick T.Type
 // CHECK-NEXT:    apply [[T_INIT_FN]]<T>([[Y_BOX]], [[T_TYPE]])
-// CHECK-NEXT:    [[Y_ADDR:%.*]] = struct_element_addr [[SELF_BOX]]
+// CHECK-NEXT:    [[WRITE:%.*]] = begin_access [modify] [static] [[SELF_BOX]] : $*FailableAddrOnlyStruct<T>
+// CHECK-NEXT:    [[Y_ADDR:%.*]] = struct_element_addr [[WRITE]]
 // CHECK-NEXT:    copy_addr [take] [[Y_BOX]] to [initialization] [[Y_ADDR]]
+// CHECK-NEXT:    end_access [[WRITE]] : $*FailableAddrOnlyStruct<T>
 // CHECK-NEXT:    dealloc_stack [[Y_BOX]]
 // CHECK-NEXT:    br bb1
 // CHECK:       bb1:
@@ -578,7 +592,9 @@ struct ThrowStruct {
 // CHECK-NEXT:    [[SELF_TYPE:%.*]] = metatype $@thin ThrowStruct.Type
 // CHECK-NEXT:    try_apply [[INIT_FN]]([[SELF_TYPE]])
 // CHECK:       bb1([[NEW_SELF:%.*]] : $ThrowStruct):
-// CHECK-NEXT:    store [[NEW_SELF]] to [[SELF_BOX]]
+// CHECK-NEXT:    [[WRITE:%.*]] = begin_access [modify] [static] [[SELF_BOX]] : $*ThrowStruct
+// CHECK-NEXT:    store [[NEW_SELF]] to [[WRITE]]
+// CHECK-NEXT:    end_access [[WRITE]] : $*ThrowStruct
 // CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    return [[NEW_SELF]]
 // CHECK:       bb2([[ERROR:%.*]] : $Error):
@@ -594,7 +610,9 @@ struct ThrowStruct {
 // CHECK:         [[INIT_FN:%.*]] = function_ref @_T035definite_init_failable_initializers11ThrowStructVACyt6noFail_tcfC
 // CHECK-NEXT:    [[SELF_TYPE:%.*]] = metatype $@thin ThrowStruct.Type
 // CHECK-NEXT:    [[NEW_SELF:%.*]] = apply [[INIT_FN]]([[SELF_TYPE]])
-// CHECK-NEXT:    store [[NEW_SELF]] to [[SELF_BOX]]
+// CHECK-NEXT:    [[WRITE:%.*]] = begin_access [modify] [static] [[SELF_BOX]] : $*ThrowStruct
+// CHECK-NEXT:    store [[NEW_SELF]] to [[WRITE]]
+// CHECK-NEXT:    end_access [[WRITE]] : $*ThrowStruct
 // CHECK:         [[UNWRAP_FN:%.*]] = function_ref @_T035definite_init_failable_initializers6unwrapS2iKF
 // CHECK-NEXT:    try_apply [[UNWRAP_FN]](%0)
 // CHECK:       bb1([[RESULT:%.*]] : $Int):


### PR DESCRIPTION
This enables underlying compiler support for the proposed exclusivity
language feature for testing and evaluation.

Static enforcement:

-Onone: static access markers present through IRGen

-O: all access markers stripped before optimization

-Onone -enforce-exclusivity=unchecked: diagnostics active, no SIL change.

-O -enforce-exclusivity=unchecked: diagnostics active, markers stripped before optimization

Dynamic enforcement:

dynamic markers are only present in SILGen and throughout SIL passes as long as necessary.
i.e. Once a marker is determined to be dynamic, it is stripped if it's inactive.

-Onone -enforce-exclusivity=checked: Runtime diagnostics active. No
changes to the SIL other than the access markers themselves except in
extreme unexpected cases.

-O -enforce-exclusivity=checked: Unsupported. Output a
warning. Dynamic markers will be stripped. Runtime diagnostics will
not be active.
