### PR TITLE
[Migrator] Don't pick up missing argument type placeholder fix-its

### DIFF
--- a/include/swift/Migrator/FixitFilter.h
+++ b/include/swift/Migrator/FixitFilter.h
@@ -77,6 +77,19 @@ struct FixitFilter {
       return false;
     }
 
+    // With SE-110, the migrator may get a recommendation to add a Void
+    // placeholder in the call to f in:
+    // func foo(f: (Void) -> ()) {
+    //   f()
+    // }
+    // Here, f was () -> () in Swift 3 but now (()) -> () in Swift 4. Adding a
+    // type placeholder in the f() call isn't helpful for migration, although
+    // this particular fix-it should be to fix the f parameter's type.
+    if (Info.ID == diag::missing_argument_named.ID ||
+        Info.ID == diag::missing_argument_positional.ID) {
+      return false;
+    }
+
     if (Kind == DiagnosticKind::Error)
       return true;
 

--- a/test/Migrator/Inputs/ignore_type_placeholder.swift
+++ b/test/Migrator/Inputs/ignore_type_placeholder.swift
@@ -1,0 +1,3 @@
+func foo(f: (Void) -> ()) {
+  f()
+}

--- a/test/Migrator/ignore_type_placeholder.swift
+++ b/test/Migrator/ignore_type_placeholder.swift
@@ -1,0 +1,3 @@
+// RUN: rm -rf %t && mkdir -p %t && %target-swift-frontend -c -primary-file %S/Inputs/ignore_type_placeholder.swift -emit-migrated-file-path %t/ignore_type_placeholder.swift.result -emit-remap-file-path %t/ignore_type_placeholder.swift.remap
+// RUN: %FileCheck %s < %t/ignore_type_placeholder.swift.result
+// CHECK-NOT: f(<#Void#>)


### PR DESCRIPTION
With SE-110, the migrator may get a recommendation to add a Void
placeholder in the call to f in:
func foo(f: (Void) -> ()) {
  f()
}
Here, f was () -> () in Swift 3 but now (()) -> () in Swift 4. Adding a
type placeholder in the f() call isn't helpful for migration, although
this particular fix-it should be to fix the f parameter's type.

rdar://problem/31895432
