### PR TITLE
Lift case redundancy checks into Sema

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3610,6 +3610,8 @@ ERROR(non_exhaustive_switch,none,
       "%select{:|?}0 %2", (bool, bool, StringRef))
 NOTE(missing_particular_case,none,
      "missing case: '%0'", (StringRef))
+WARNING(redundant_particular_case,none,
+        "case is already handled by previous patterns; consider removing it",())
 
 #ifndef DIAG_NO_UNDEF
 # if defined(DIAG)

--- a/test/Constraints/patterns.swift
+++ b/test/Constraints/patterns.swift
@@ -158,8 +158,8 @@ case let x???: print(x, terminator: "")
 case let x??: print(x as Any, terminator: "")
 case let x?: print(x as Any, terminator: "")
 case 4???: break
-case nil??: break
-case nil?: break
+case nil??: break // expected-warning {{case is already handled by previous patterns; consider removing it}}
+case nil?: break // expected-warning {{case is already handled by previous patterns; consider removing it}}
 default: break
 }
 

--- a/test/Parse/matching_patterns.swift
+++ b/test/Parse/matching_patterns.swift
@@ -28,17 +28,20 @@ case square(9):
 // 'var' and 'let' patterns.
 case var a:
   a = 1
-case let a:
+case let a: // expected-warning {{case is already handled by previous patterns; consider removing it}}
   a = 1         // expected-error {{cannot assign}}
 case var var a: // expected-error {{'var' cannot appear nested inside another 'var' or 'let' pattern}}
+                // expected-warning@-1 {{case is already handled by previous patterns; consider removing it}}
   a += 1
 case var let a: // expected-error {{'let' cannot appear nested inside another 'var' or 'let' pattern}}
+                // expected-warning@-1 {{case is already handled by previous patterns; consider removing it}}
   print(a, terminator: "")
 case var (var b): // expected-error {{'var' cannot appear nested inside another 'var'}}
+                  // expected-warning@-1 {{case is already handled by previous patterns; consider removing it}}
   b += 1
 
 // 'Any' pattern.
-case _:
+case _: // expected-warning {{case is already handled by previous patterns; consider removing it}}
   ()
 
 // patterns are resolved in expression-only positions are errors.
@@ -49,7 +52,7 @@ case 1 + (_): // expected-error{{'_' can only appear in a pattern or on the left
 switch (x,x) {
 case (var a, var a): // expected-error {{definition conflicts with previous value}} expected-note {{previous definition of 'a' is here}} expected-warning {{variable 'a' was never used; consider replacing with '_' or removing it}} expected-warning {{variable 'a' was never used; consider replacing with '_' or removing it}}
   fallthrough
-case _:
+case _: // expected-warning {{case is already handled by previous patterns; consider removing it}}
   ()
 }
 
@@ -153,10 +156,10 @@ struct ContainsEnum {
     // expected-note@-1 {{missing case: '.Mere(_)'}}
     // expected-note@-2 {{missing case: '.Twain(_, _)'}}
     case ContainsEnum.Possible<Int>.Naught,
-         ContainsEnum.Possible.Naught,
-         Possible<Int>.Naught,
-         Possible.Naught,
-         .Naught:
+         ContainsEnum.Possible.Naught, // expected-warning {{case is already handled by previous patterns; consider removing it}}
+         Possible<Int>.Naught, // expected-warning {{case is already handled by previous patterns; consider removing it}}
+         Possible.Naught, // expected-warning {{case is already handled by previous patterns; consider removing it}}
+         .Naught: // expected-warning {{case is already handled by previous patterns; consider removing it}}
       ()
     }
   }
@@ -167,7 +170,7 @@ func nonmemberAccessesMemberType(_ n: ContainsEnum.Possible<Int>) {
   // expected-note@-1 {{missing case: '.Mere(_)'}}
   // expected-note@-2 {{missing case: '.Twain(_, _)'}}
   case ContainsEnum.Possible<Int>.Naught,
-       .Naught:
+       .Naught: // expected-warning {{case is already handled by previous patterns; consider removing it}}
     ()
   }
 }
@@ -176,15 +179,15 @@ var m : ImportedEnum = .Simple
 
 switch m {
 case imported_enums.ImportedEnum.Simple,
-     ImportedEnum.Simple,
-     .Simple:
+     ImportedEnum.Simple, // expected-warning {{case is already handled by previous patterns; consider removing it}}
+     .Simple: // expected-warning {{case is already handled by previous patterns; consider removing it}}
   ()
 case imported_enums.ImportedEnum.Compound,
-     imported_enums.ImportedEnum.Compound(_),
-     ImportedEnum.Compound,
-     ImportedEnum.Compound(_),
-     .Compound,
-     .Compound(_):
+     imported_enums.ImportedEnum.Compound(_), // expected-warning {{case is already handled by previous patterns; consider removing it}}
+     ImportedEnum.Compound, // expected-warning {{case is already handled by previous patterns; consider removing it}}
+     ImportedEnum.Compound(_), // expected-warning {{case is already handled by previous patterns; consider removing it}}
+     .Compound, // expected-warning {{case is already handled by previous patterns; consider removing it}}
+     .Compound(_): // expected-warning {{case is already handled by previous patterns; consider removing it}}
   ()
 }
 
@@ -206,22 +209,22 @@ case .Payload(name: 0):
 case let .Payload(x):
   acceptInt(x)
   acceptString("\(x)")
-case let .Payload(name: x):
+case let .Payload(name: x): // expected-warning {{case is already handled by previous patterns; consider removing it}}
   acceptInt(x)
   acceptString("\(x)")
-case let .Payload((name: x)):
+case let .Payload((name: x)): // expected-warning {{case is already handled by previous patterns; consider removing it}}
   acceptInt(x)
   acceptString("\(x)")
-case .Payload(let (name: x)):
+case .Payload(let (name: x)): // expected-warning {{case is already handled by previous patterns; consider removing it}}
   acceptInt(x)
   acceptString("\(x)")
-case .Payload(let (name: x)):
+case .Payload(let (name: x)): // expected-warning {{case is already handled by previous patterns; consider removing it}}
   acceptInt(x)
   acceptString("\(x)")
-case .Payload(let x):
+case .Payload(let x): // expected-warning {{case is already handled by previous patterns; consider removing it}}
   acceptInt(x)
   acceptString("\(x)")
-case .Payload((let x)):
+case .Payload((let x)): // expected-warning {{case is already handled by previous patterns; consider removing it}}
   acceptInt(x)
   acceptString("\(x)")
 }
@@ -302,7 +305,7 @@ switch op2 {
 case nil: break
 case _?: break
 case (1?)?: break
-case (_?)?: break
+case (_?)?: break // expected-warning {{case is already handled by previous patterns; consider removing it}}
 }
 
 

--- a/test/Parse/switch.swift
+++ b/test/Parse/switch.swift
@@ -221,7 +221,7 @@ case (1, var b): // expected-warning {{variable 'b' was never used; consider rep
 case (1, let b): // let bindings expected-warning {{immutable value 'b' was never used; consider replacing with '_' or removing it}}
   ()
 
-case (_, 2), (let a, _): // expected-error {{'a' must be bound in every pattern}}
+case (_, 2), (let a, _): // expected-error {{'a' must be bound in every pattern}} expected-warning {{case is already handled by previous patterns; consider removing it}}
   ()
 
 // OK
@@ -229,9 +229,13 @@ case (_, 2), (1, _):
   ()
   
 case (_, var a), (_, var a): // expected-warning {{variable 'a' was never used; consider replacing with '_' or removing it}}
+  // expected-warning@-1 {{case is already handled by previous patterns; consider removing it}}
+  // expected-warning@-2 {{case is already handled by previous patterns; consider removing it}}
   ()
   
 case (var a, var b), (var b, var a): // expected-warning {{variable 'a' was never used; consider replacing with '_' or removing it}} expected-warning {{variable 'b' was never used; consider replacing with '_' or removing it}}
+  // expected-warning@-1 {{case is already handled by previous patterns; consider removing it}}
+  // expected-warning@-2 {{case is already handled by previous patterns; consider removing it}}
   ()
 
 case (_, 2): // expected-error {{'case' label in a 'switch' should have at least one executable statement}} {{13-13= break}}

--- a/test/SILGen/unreachable_code.swift
+++ b/test/SILGen/unreachable_code.swift
@@ -68,6 +68,7 @@ func testUnreachableCase1(a : Tree) {
     _ = Leaf
     return
   case .Branch(_):  // expected-warning {{case will never be executed}}
+  // expected-warning@-1 {{case is already handled by previous patterns; consider removing it}}
     return
   }
 }
@@ -77,7 +78,7 @@ func testUnreachableCase2(a : Tree) {
   case let Leaf:
     _ = Leaf
     fallthrough
-  case .Branch(_):
+  case .Branch(_): // expected-warning {{case is already handled by previous patterns; consider removing it}}
     return
   }
 }
@@ -87,6 +88,7 @@ func testUnreachableCase3(a : Tree) {
   case _:
     break
   case .Branch(_):  // expected-warning {{case will never be executed}}
+  // expected-warning@-1 {{case is already handled by previous patterns; consider removing it}}
     return
   }
 }

--- a/test/Sema/exhaustive_switch.swift
+++ b/test/Sema/exhaustive_switch.swift
@@ -232,29 +232,27 @@ func f(a: X, b: X) {
   }
 }
 
-// FIXME: Duplicate case warning is not caught by dataflow diagnostics.
-//func f2(a: X, b: X) {
-//  switch (a, b) {
-//
-//  case (.A, .A): ()
-//  case (.B, .B): ()
-//
-//  case (.A, .B): ()
-//  case (.B, .A): ()
-//
-//  case (_, .Empty): ()
-//  case (.Empty, _): ()
-//
-//  // duplicate cases, but no warning? (comment out the line above and warnings appear!?)
-//  case (.A, .A): ()
-//  case (.B, .B): ()
-//
-//  case (.A, .B): ()
-//  case (.B, .A): ()
-//
-//  default: ()
-//  }
-//}
+func f2(a: X, b: X) {
+  switch (a, b) {
+
+  case (.A, .A): ()
+  case (.B, .B): ()
+
+  case (.A, .B): ()
+  case (.B, .A): ()
+
+  case (_, .Empty): ()
+  case (.Empty, _): ()
+
+  case (.A, .A): () // expected-warning {{case is already handled by previous patterns; consider removing it}}
+  case (.B, .B): () // expected-warning {{case is already handled by previous patterns; consider removing it}}
+
+  case (.A, .B): () // expected-warning {{case is already handled by previous patterns; consider removing it}}
+  case (.B, .A): () // expected-warning {{case is already handled by previous patterns; consider removing it}}
+
+  default: ()
+  }
+}
 
 enum XX : Int {
   case A

--- a/test/expr/postfix/dot/optional_context_member.swift
+++ b/test/expr/postfix/dot/optional_context_member.swift
@@ -12,14 +12,14 @@ func nonOptContext() -> Foo {
   switch () {
   case ():
     return .someVar
-  case ():
+  case (): // expected-warning {{case is already handled by previous patterns; consider removing it}}
     return .someOptVar // expected-error 2 {{value of optional type 'Foo' not unwrapped; did you mean to use '!' or '?'?}} {{23-23=!}}
   // TODO
   //case ():
   //  return .someOptVar!
-  case ():
+  case (): // expected-warning {{case is already handled by previous patterns; consider removing it}}
     return .someFunc()
-  case ():
+  case (): // expected-warning {{case is already handled by previous patterns; consider removing it}}
     return .someOptFunc() // expected-error{{}} {{26-26=!}}
   // TODO
   //case ():
@@ -31,15 +31,15 @@ func optContext() -> Foo? {
   switch () {
   case ():
     return .someVar
-  case ():
+  case (): // expected-warning {{case is already handled by previous patterns; consider removing it}}
     return .someOptVar
-  case ():
+  case (): // expected-warning {{case is already handled by previous patterns; consider removing it}}
     return .someFunc()
-  case ():
+  case (): // expected-warning {{case is already handled by previous patterns; consider removing it}}
     return .someOptFunc()
-  case ():
+  case (): // expected-warning {{case is already handled by previous patterns; consider removing it}}
     return .some(.someVar)
-  case ():
+  case (): // expected-warning {{case is already handled by previous patterns; consider removing it}}
     return .none
   }
 }
@@ -48,15 +48,15 @@ func iuoContext() -> Foo! {
   switch () {
   case ():
     return .someVar
-  case ():
+  case (): // expected-warning {{case is already handled by previous patterns; consider removing it}}
     return .someOptVar
-  case ():
+  case (): // expected-warning {{case is already handled by previous patterns; consider removing it}}
     return .someFunc()
-  case ():
+  case (): // expected-warning {{case is already handled by previous patterns; consider removing it}}
     return .someOptFunc()
-  case ():
+  case (): // expected-warning {{case is already handled by previous patterns; consider removing it}}
     return .some(.someVar)
-  case ():
+  case (): // expected-warning {{case is already handled by previous patterns; consider removing it}}
     return .none
   }
 }

--- a/test/expr/postfix/dot/optional_context_member_enum.swift
+++ b/test/expr/postfix/dot/optional_context_member_enum.swift
@@ -9,7 +9,7 @@ func optEnumContext() -> Bar? {
   switch () {
   case ():
     return .Simple
-  case ():
+  case (): // expected-warning {{case is already handled by previous patterns; consider removing it}}
     return .Complex(0)
   }
 }
@@ -18,7 +18,7 @@ func iuoEnumContext() -> Bar! {
   switch () {
   case ():
     return .Simple
-  case ():
+  case (): // expected-warning {{case is already handled by previous patterns; consider removing it}}
     return .Complex(0)
   }
 }

--- a/test/stmt/statements.swift
+++ b/test/stmt/statements.swift
@@ -257,6 +257,7 @@ func switchWithVarsNotMatchingTypes(_ x: Int, y: Int, z: String) -> Int {
   case (let a, 0, _), (0, let a, _): // OK
     return a
   case (let a, _, _), (_, _, let a): // expected-error {{pattern variable bound to type 'String', expected type 'Int'}}
+  // expected-warning@-1 {{case is already handled by previous patterns; consider removing it}}
     return a
   }
 }


### PR DESCRIPTION
Augments what should be the `unreachable` case dataflow diagnostic in SIL with a syntactic check in Sema.  There is some risk of a double-diagnostic that manifests as warnings that a case is both redundant and will never be executed.  However, there is also a large class of cases that the SIL dataflow diagnostic doesn't detect because it is not strict enough when determining if it has already emitted cleanup blocks exactly once for a particular branch of a decision tree.

Both checks remain because SIL is capable of some checks of decision trees involving where clauses and expressions in patterns whereas Sema always disregards those cases.

This diagnostic is also never emitted for `default`s to encourage their use.  This approach should be revisited when closed/open enums become a thing.