### PR TITLE
[SR-4231] Add diagnostic (& fix-it) for mixed syntax availability attribute

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1476,6 +1476,9 @@ ERROR(avail_query_argument_and_shorthand_mix_not_allowed, PointsToFirstBadToken,
       "'%0' can't be combined with shorthand specification '%1'",
       (StringRef, StringRef))
 
+NOTE(avail_query_meant_introduced,PointsToFirstBadToken,
+     "did you mean to use '%0, introduced: %1'?", (StringRef, StringRef))
+
 ERROR(avail_query_version_comparison_not_needed,
       none,"version comparison not needed", ())
 

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1472,6 +1472,10 @@ ERROR(avail_query_unrecognized_platform_name,
 ERROR(avail_query_disallowed_operator, PointsToFirstBadToken,
       "'%0' cannot be used in an availability condition", (StringRef))
 
+ERROR(avail_query_argument_and_shorthand_mix_not_allowed, PointsToFirstBadToken,
+      "'%0' can't be combined with shorthand specification '%1'",
+      (StringRef, StringRef))
+
 ERROR(avail_query_version_comparison_not_needed,
       none,"version comparison not needed", ())
 

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -1119,9 +1119,9 @@ Parser::parseAvailabilitySpecList(SmallVectorImpl<AvailabilitySpec *> &Specs) {
               SourceManager.extractText(L->getCharSourceRangeFromSourceRange(
                   SourceManager, Previous->getSourceRange()));
 
-          auto diag = diagnose(
-              Tok, diag::avail_query_argument_and_shorthand_mix_not_allowed,
-              Text, PreviousSpecText);
+          diagnose(Tok,
+                   diag::avail_query_argument_and_shorthand_mix_not_allowed,
+                   Text, PreviousSpecText);
 
           // If this was preceded by a single platform version constraint, we
           // can guess that the intention was to treat it as 'introduced' and
@@ -1137,7 +1137,12 @@ Parser::parseAvailabilitySpecList(SmallVectorImpl<AvailabilitySpec *> &Specs) {
                 PlatformSpec->getPlatformLoc().getAdvancedLoc(
                     PlatformName.size());
 
-            diag.fixItInsert(PlatformNameEndLoc, ", introduced:");
+            StringRef VersionName = PlatformSpec->getVersion().getAsString();
+
+            diagnose(PlatformSpec->getPlatformLoc(),
+                     diag::avail_query_meant_introduced, PlatformName,
+                     VersionName)
+                .fixItInsert(PlatformNameEndLoc, ", introduced:");
           }
 
           Status.setIsParseError();

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -1119,9 +1119,9 @@ Parser::parseAvailabilitySpecList(SmallVectorImpl<AvailabilitySpec *> &Specs) {
               SourceManager.extractText(L->getCharSourceRangeFromSourceRange(
                   SourceManager, Previous->getSourceRange()));
 
-          auto diag = diagnose(Tok,
-                   diag::avail_query_argument_and_shorthand_mix_not_allowed,
-                   Text, PreviousSpecText);
+          auto diag = diagnose(
+              Tok, diag::avail_query_argument_and_shorthand_mix_not_allowed,
+              Text, PreviousSpecText);
 
           // If this was preceded by a single platform version constraint, we
           // can guess that the intention was to treat it as 'introduced' and
@@ -1130,11 +1130,13 @@ Parser::parseAvailabilitySpecList(SmallVectorImpl<AvailabilitySpec *> &Specs) {
               PlatformVersionConstraintAvailabilitySpec::classof(Previous) &&
               Text != "introduced") {
             auto *PlatformSpec =
-            cast<PlatformVersionConstraintAvailabilitySpec>(Previous);
+                cast<PlatformVersionConstraintAvailabilitySpec>(Previous);
 
             auto PlatformName = platformString(PlatformSpec->getPlatform());
             auto PlatformNameEndLoc =
-            PlatformSpec->getPlatformLoc().getAdvancedLoc(PlatformName.size());
+                PlatformSpec->getPlatformLoc().getAdvancedLoc(
+                    PlatformName.size());
+
             diag.fixItInsert(PlatformNameEndLoc, ", introduced:");
           }
 

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -1106,8 +1106,8 @@ Parser::parseAvailabilitySpecList(SmallVectorImpl<AvailabilitySpec *> &Specs) {
       // There is more to parse in this list.
 
       // Before continuing to parse the next specification, we check that it's
-      // also in the shorthand syntax and try to and provide a more specific
-      // diagnostic if that's not the case.
+      // also in the shorthand syntax and provide a more specific diagnostic if
+      // that's not the case.
       if (Tok.isIdentifierOrUnderscore() &&
           !peekToken().isAny(tok::integer_literal, tok::floating_literal)) {
         auto Text = Tok.getText();

--- a/test/Parse/diagnose_availability.swift
+++ b/test/Parse/diagnose_availability.swift
@@ -9,8 +9,9 @@ func availableSince10_6() {}
 func introducedFollowedByDeprecated() {}
 
 @available(OSX 10.0, deprecated: 10.12)
-// expected-error@-1 {{'deprecated' can't be combined with shorthand specification 'OSX 10.0'}} {{15-15=, introduced:}}
-// expected-error@-2 {{expected declaration}} 
+// expected-error@-1 {{'deprecated' can't be combined with shorthand specification 'OSX 10.0'}}
+// expected-note@-2 {{did you mean to use 'OSX, introduced: 10.0'?}} {{15-15=, introduced:}}
+// expected-error@-3 {{expected declaration}}
 func shorthandFollowedByDeprecated() {}
 
 @available(OSX 10.0, introduced: 10.12)

--- a/test/Parse/diagnose_availability.swift
+++ b/test/Parse/diagnose_availability.swift
@@ -6,12 +6,12 @@
 func availableSince10_6() {}
 
 @available(OSX, introduced: 10.0, deprecated: 10.12) // no error
-func introducedFollowedByDepreaction() {}
+func introducedFollowedByDeprecated() {}
 
 @available(OSX 10.0, deprecated: 10.12)
 // expected-error@-1 {{'deprecated' can't be combined with shorthand specification 'OSX 10.0'}} {{15-15=, introduced:}}
 // expected-error@-2 {{expected declaration}} 
-func shorthandFollowedByDepreaction() {}
+func shorthandFollowedByDeprecated() {}
 
 @available(OSX 10.0, introduced: 10.12)
 // expected-error@-1 {{'introduced' can't be combined with shorthand specification 'OSX 10.0'}}
@@ -24,4 +24,4 @@ func availableOnMultiplePlatforms() {}
 @available(iOS 6.0, OSX 10.0, deprecated: 10.12)
 // expected-error@-1 {{'deprecated' can't be combined with shorthand specification 'OSX 10.0'}}
 // expected-error@-2 {{expected declaration}}
-func twoShorthandsFollowedByDepreaction() {}
+func twoShorthandsFollowedByDeprecated() {}

--- a/test/Parse/diagnose_availability.swift
+++ b/test/Parse/diagnose_availability.swift
@@ -1,0 +1,22 @@
+// RUN: %target-typecheck-verify-swift 
+
+// SR-4231: Misleading/wrong error message for malformed @available
+
+@available(OSX 10.6, *) // no error
+func availableSince10_6() {}
+
+@available(OSX, introduced: 10.0, deprecated: 10.12) // no error
+func introducedFollowedByDepreaction() {}
+
+@available(OSX 10.0, deprecated: 10.12)
+// expected-error@-1 {{'deprecated' can't be combined with shorthand specification 'OSX 10.0'}}
+// expected-error@-2 {{expected declaration}}
+func shorthandFollowedByDepreaction() {}
+
+@available(iOS 6.0, OSX 10.8, *) // no error
+func availableOnMultiplePlatforms() {}
+
+@available(iOS 6.0, OSX 10.0, deprecated: 10.12)
+// expected-error@-1 {{'deprecated' can't be combined with shorthand specification 'OSX 10.0'}}
+// expected-error@-2 {{expected declaration}}
+func twoShorthandsFollowedByDepreaction() {}

--- a/test/Parse/diagnose_availability.swift
+++ b/test/Parse/diagnose_availability.swift
@@ -9,9 +9,14 @@ func availableSince10_6() {}
 func introducedFollowedByDepreaction() {}
 
 @available(OSX 10.0, deprecated: 10.12)
-// expected-error@-1 {{'deprecated' can't be combined with shorthand specification 'OSX 10.0'}}
-// expected-error@-2 {{expected declaration}}
+// expected-error@-1 {{'deprecated' can't be combined with shorthand specification 'OSX 10.0'}} {{15-15=, introduced:}}
+// expected-error@-2 {{expected declaration}} 
 func shorthandFollowedByDepreaction() {}
+
+@available(OSX 10.0, introduced: 10.12)
+// expected-error@-1 {{'introduced' can't be combined with shorthand specification 'OSX 10.0'}}
+// expected-error@-2 {{expected declaration}}
+func shorthandFollowedByIntroduced() {}
 
 @available(iOS 6.0, OSX 10.8, *) // no error
 func availableOnMultiplePlatforms() {}


### PR DESCRIPTION
<!-- What's in this pull request? -->
This adds a specific diagnostic when both shorthand and non-shorthand specifications are mixed in the same availability attribute. For example: `@available(OSX 10.0, deprecated: 10.12)`.

Current error:
```
@available(OSX 10.0, deprecated: 10.12)
//                             ^
// error: expected version number
// error: expected declaration
```

New error:
```
@available(OSX 10.0, deprecated: 10.12)
//                   ^
// error: 'deprecated' can't be combined with shorthand specification 'OSX 10.0'
// error: expected declaration
```

If (and only if) there is only a single platform version constraint, that is followed by ‘deprecated’, ‘renamed’, etc. but not ‘introduced’, then it also offers a fix-it to insert `, introduced:` in the platform version constraint, turning:
```
@available(OSX 10.0, deprecated: 10.12)
```
into:
```
@available(OSX, introduced: 10.0, deprecated: 10.12)
// insert:    ^-----------^
```

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-4231](https://bugs.swift.org/browse/SR-4231). 

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->