### PR TITLE
swift-stdlib-tool is not a shell script and can be stripped

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -3207,7 +3207,6 @@ for host in "${ALL_HOSTS[@]}"; do
             # Exclude shell scripts.
             (cd "${INSTALL_SYMROOT}" &&
              find ./"${TOOLCHAIN_PREFIX}" -perm -0111 -type f -print | \
-               grep -v swift-stdlib-tool | \
                grep -v crashlog.py | \
                grep -v symbolication.py | \
                xargs -n 1 -P ${BUILD_JOBS} $(xcrun_find_tool dsymutil))


### PR DESCRIPTION
Before Swift 3.1, we installed the swift-stdlib-tool-substitute script
in place of Xcode's swift-stdlib-tool. This check was added to the build
script (76e99159c1) to avoid trying to strip that file. Now that
swift-stdlib-tool is part of open-source Swift, the -substitute script is
gone and there is no need for this check.