### PR TITLE
[stdlib] Disambiguate a subscript operation.

### DIFF
--- a/stdlib/public/core/Substring.swift.gyb
+++ b/stdlib/public/core/Substring.swift.gyb
@@ -310,6 +310,6 @@ extension Substring {
 
   @available(swift, obsoleted: 4)
   public subscript(bounds: ClosedRange<Index>) -> String {
-    return String(self[bounds])
+    return String(self[bounds] as Substring)
   }
 }


### PR DESCRIPTION
This is only flagged by some type checker changes that I have, but it
appears to be a legitimate ambiguity.
