### PR TITLE
Re-instate "Improve disjunction selection"

### DIFF
--- a/validation-test/Sema/type_checker_perf/generic_operators.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/generic_operators.swift.gyb
@@ -1,0 +1,20 @@
+// RUN: %scale-test --begin 1 --end 5 --step 1 --select incrementScopeCounter %s --polynomial-threshold=2.3
+// REQUIRES: OS=macosx
+// REQUIRES: asserts
+
+infix operator +|+ : AdditionPrecedence
+
+func +|+ <T: FloatingPoint>(lhs: T, rhs: T) -> T {
+  return lhs
+}
+
+func +|+ <T: SignedInteger>(lhs: T, rhs: T) -> T {
+  return lhs
+}
+
+func test(i: Int, j: Int, k: Int, l: Int) -> Int {
+  return i +|+ j +|+ k +|+ l
+%for i in range(1, N):
+         +|+ i +|+ j +|+ k +|+ l
+%end
+}

--- a/validation-test/stdlib/Data.swift
+++ b/validation-test/stdlib/Data.swift
@@ -28,7 +28,10 @@ DataTestSuite.test("Data.Iterator semantics") {
       ptr[i] = UInt8(i % 23)
     }
   }
-  checkSequence((0..<65535).lazy.map({ UInt8($0 % 23) }), data)
+  // SR-4724: Should not need to be split out but if it is not it
+  // is considered ambiguous.
+  let temp = (0..<65535).lazy.map({ UInt8($0 % 23) })
+  checkSequence(temp, data)
 }
 
 DataTestSuite.test("associated types") {

--- a/validation-test/stdlib/Set.swift
+++ b/validation-test/stdlib/Set.swift
@@ -203,7 +203,10 @@ func getBridgedVerbatimSet(_ members: [Int] = [1010, 2020, 3030])
 /// Get a Set<NSObject> (Set<TestObjCKeyTy>) backed by native storage
 func getNativeBridgedVerbatimSet(_ members: [Int] = [1010, 2020, 3030]) ->
   Set<NSObject> {
-  let result: Set<NSObject> = Set(members.map({ TestObjCKeyTy($0) }))
+  // SR-4724: Should not need to be split out but if it is not it
+  // is considered ambiguous.
+  let temp = members.map({ TestObjCKeyTy($0) })
+  let result: Set<NSObject> = Set(temp)
   expectTrue(isNativeSet(result))
   return result
 }


### PR DESCRIPTION
Thie reinstates 3c5b393e0c07c222950e626e5c4553358e22365d, which was
backed out due to it exposing an ambiguous expression in a recent stdlib
commit.
rdar://problem/31853575