### PR TITLE
[stdlib] De-gyb sorting

### DIFF
--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -111,7 +111,7 @@ set(SWIFTLIB_ESSENTIAL
   ShadowProtocols.swift
   Shims.swift
   Slice.swift.gyb
-  Sort.swift.gyb
+  Sort.swift
   StaticString.swift
   Stride.swift.gyb
   StringCharacterView.swift # ORDER DEPENDENCY: Must precede String.swift

--- a/stdlib/public/core/CollectionAlgorithms.swift.gyb
+++ b/stdlib/public/core/CollectionAlgorithms.swift.gyb
@@ -389,7 +389,7 @@ extension MutableCollection
       return ()
     }
     if didSortUnsafeBuffer == nil {
-      _introSort(&self, subRange: startIndex..<endIndex)
+      _introSort(&self, subRange: startIndex..<endIndex, by: <)
     }
   }
 }

--- a/validation-test/stdlib/Algorithm.swift
+++ b/validation-test/stdlib/Algorithm.swift
@@ -229,7 +229,7 @@ Algorithm.test("sort3/simple")
     [1, 2, 3], [1, 3, 2], [2, 1, 3], [2, 3, 1], [3, 1, 2], [3, 2, 1]
   ]) {
     var input = $0
-    _sort3(&input, 0, 1, 2)
+    _sort3(&input, 0, 1, 2, by: <)
     expectEqual([1, 2, 3], input)
 }
 

--- a/validation-test/stdlib/Sort.swift.gyb
+++ b/validation-test/stdlib/Sort.swift.gyb
@@ -99,7 +99,6 @@ class OffsetCollection : MutableCollection, RandomAccessCollection {
 %   for p in withPredicateValues:
 // workaround for <rdar://problem/18900352> gyb miscompiles nested loops
 %     comparePredicate = "<" if p else ""
-%     commaComparePredicate = ", by: <" if p else ""
 %     name = "lessPredicate" if p else "noPredicate"
 
 Algorithm.test("${t}/sorted/${name}") {
@@ -120,7 +119,7 @@ Algorithm.test("${t}/sorted/${name}") {
   let i1 = 400
   let i2 = 700
   sortedAry2 = ary
-  _introSort(&sortedAry2, subRange: i1..<i2${commaComparePredicate})
+  _introSort(&sortedAry2, subRange: i1..<i2, by: <)
 
   expectEqual(ary[0..<i1], sortedAry2[0..<i1])
   expectSortedCollection(sortedAry2[i1..<i2], ary[i1..<i2])


### PR DESCRIPTION
Rebase of @natecook1000's prior PR #6638. Folds in changes for `swapAt` and `throws`.