### PR TITLE
[stdlib] XFAIL RangeTraps.CountablePartialRangeFrom in resilient mode

### DIFF
--- a/test/stdlib/RangeTraps.swift
+++ b/test/stdlib/RangeTraps.swift
@@ -17,6 +17,9 @@
 // RUN: %target-run %t/a.out_Debug
 // RUN: %target-run %t/a.out_Release
 // REQUIRES: executable_test
+// CountablePartialRangeFrom fails in resilient mode. <rdar://problem/31909976>
+// XFAIL: resilient_stdlib
+
 
 import StdlibUnittest
 


### PR DESCRIPTION
Here’s the test that’s failing, but is passing on other build configs:

```swift
let range = (Int.max - 1)...
var it = range.makeIterator()
_ = it.next()
expectCrashLater()
_ = it.next()
```

So it failing means in this build  advanced(by: 1) on Int.max, which is what it.next() on a CountablePartialRangeFrom<Int> will be calling, isn’t trapping.
