### PR TITLE
Un-XFAIL floating point test in resilient mode

### DIFF
--- a/test/stdlib/FloatingPoint.swift.gyb
+++ b/test/stdlib/FloatingPoint.swift.gyb
@@ -3,9 +3,6 @@
 // RUN: %line-directive %t/FloatingPoint.swift -- %target-run %t/a.out
 // REQUIRES: executable_test
 
-// FIXME: https://bugs.swift.org/browse/SR-2808
-// XFAIL: resilient_stdlib
-
 %{
 from gyb_stdlib_unittest_support import TRACE, stackTrace, trace
 }%


### PR DESCRIPTION
Caught by @rudkx by bisecting a failing resilience mode build.

Furthers [SR-2808](https://bugs.swift.org/browse/SR-2808).
