### PR TITLE
[stdlib][WIP perf experiment] Give Array types a custom Iterator

### DIFF
--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -455,6 +455,31 @@ if True:
     raise ValueError('Unhandled case: ' + Self)
 }%
 
+
+@_fixed_layout
+public struct ${Self}Iterator<Element>: IteratorProtocol, Sequence {
+  @_versioned
+  var _buffer: ${Self}<Element>._Buffer
+  @_versioned
+  var _position: Int
+  @_versioned
+  var _end: Int
+  @_inlineable
+  @_versioned
+  init(_elements: ${Self}<Element>) {
+    self._buffer = _elements._buffer
+    _position = _elements.startIndex
+    _end = _elements.endIndex
+  }
+  @_inlineable
+  mutating public func next() -> Element? {
+    guard _position != _end else { return nil }
+    defer { _position += 1 }
+    return _buffer[_position]
+  }
+}
+
+
 ${SelfDocComment}
 @_fixed_layout
 public struct ${Self}<Element>
@@ -464,7 +489,7 @@ public struct ${Self}<Element>
 {
 
   public typealias Index = Int
-  public typealias Iterator = IndexingIterator<${Self}>
+  public typealias Iterator = ${Self}Iterator<Element>
 
 %if Self == 'ArraySlice':
   /// The position of the first element in a nonempty array.
@@ -539,6 +564,10 @@ public struct ${Self}<Element>
     // NOTE: Range checks are not performed here, because it is done later by
     // the subscript function.
     return i - 1
+  }
+  
+  public func makeIterator() -> ${Self}Iterator<Element> {
+    return ${Self}Iterator(_elements: self)
   }
 
   @_inlineable
@@ -1803,7 +1832,7 @@ extension ${Self} {
       }
     }
 
-    var it = IndexingIterator(_elements: self)
+    var it = Iterator(_elements: self)
     it._position = endIndex
     return (it,buffer.index(buffer.startIndex, offsetBy: self.count))
   }

--- a/stdlib/public/core/SliceBuffer.swift
+++ b/stdlib/public/core/SliceBuffer.swift
@@ -286,6 +286,8 @@ internal struct _SliceBuffer<Element>
   ///
   /// - Precondition: `position` is a valid position in `self` and
   ///   `position != endIndex`.
+  @_inlineable
+  @_versioned
   internal subscript(position: Int) -> Element {
     get {
       return getElement(position)

--- a/test/stdlib/Inputs/CommonArrayTests.gyb
+++ b/test/stdlib/Inputs/CommonArrayTests.gyb
@@ -400,7 +400,7 @@ ${Suite}.test("${ArrayType}/AssociatedTypes") {
   typealias CollectionSlice = ArraySlice<OpaqueValue<Int>>
   expectCollectionAssociatedTypes(
     collectionType: Collection.self,
-    iteratorType: IndexingIterator<Collection>.self,
+    iteratorType: ${ArrayType}Iterator<OpaqueValue<Int>>.self,
     subSequenceType: CollectionSlice.self,
     indexType: Int.self,
     indexDistanceType: Int.self,

--- a/validation-test/stdlib/Arrays.swift.gyb
+++ b/validation-test/stdlib/Arrays.swift.gyb
@@ -60,7 +60,7 @@ CopyToNativeArrayBufferTests.test("Collection._copyToContiguousArray()") {
     expectEqual(0, wrapped.timesMakeIteratorCalled.value)
     expectEqual(0, wrapped.timesStartIndexCalled.value)
     let copy = s._copyToContiguousArray()
-    expectEqual(0, wrapped.timesMakeIteratorCalled.value)
+    expectEqual(1, wrapped.timesMakeIteratorCalled.value)
     expectNotEqual(0, wrapped.timesStartIndexCalled.value)
 
     expectEqualSequence(

--- a/validation-test/stdlib/SequenceType.swift.gyb
+++ b/validation-test/stdlib/SequenceType.swift.gyb
@@ -163,7 +163,7 @@ SequenceTypeTests.test("IteratorSequence/IteratorProtocol/empty") {
     let base = data.makeIterator()
     var iter = IteratorSequence(base)
     expectType(
-      IteratorSequence<IndexingIterator<Array<OpaqueValue<Int>>>>.self,
+      IteratorSequence<ArrayIterator<OpaqueValue<Int>>>.self,
       &iter)
     checkIterator(data, iter) { $0.value == $1.value }
   }
@@ -184,7 +184,7 @@ SequenceTypeTests.test("IteratorSequence/IteratorProtocol") {
     let base = data.makeIterator()
     var iter = IteratorSequence(base)
     expectType(
-      IteratorSequence<IndexingIterator<Array<OpaqueValue<Int>>>>.self,
+      IteratorSequence<ArrayIterator<OpaqueValue<Int>>>.self,
       &iter)
     checkIterator(data, iter) { $0.value == $1.value }
   }
@@ -205,7 +205,7 @@ SequenceTypeTests.test("IteratorSequence/Sequence/empty") {
     let base = data.makeIterator()
     var iter = IteratorSequence(base)
     expectType(
-      IteratorSequence<IndexingIterator<Array<OpaqueValue<Int>>>>.self,
+      IteratorSequence<ArrayIterator<OpaqueValue<Int>>>.self,
       &iter)
     checkSequence(data, iter) { $0.value == $1.value }
   }
@@ -226,7 +226,7 @@ SequenceTypeTests.test("IteratorSequence/Sequence") {
     let base = data.makeIterator()
     var iter = IteratorSequence(base)
     expectType(
-      IteratorSequence<IndexingIterator<Array<OpaqueValue<Int>>>>.self,
+      IteratorSequence<ArrayIterator<OpaqueValue<Int>>>.self,
       &iter)
     checkSequence(data, iter) { $0.value == $1.value }
   }


### PR DESCRIPTION
Replacing `IndexingIterator` with a custom iterator for array types that stores the `_buffer`.

Ideally this would be a nested type but that seems to be crashing the compiler.