### PR TITLE
Refine parameter type 'inout' diagnostics

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2089,7 +2089,8 @@ ERROR(attr_only_on_parameters,none,
       "%0 may only be used on parameters", (StringRef))
 ERROR(attr_not_on_variadic_parameters,none,
       "%0 may not be used on variadic parameters", (StringRef))
-
+ERROR(attr_not_on_subscript_parameters,none,
+      "%0 may not be used on subscript parameters", (StringRef))
 
 ERROR(override_final,none,
       "%0 overrides a 'final' %1", (DescriptiveDeclKind, DescriptiveDeclKind))

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4184,7 +4184,7 @@ public:
                                      TypeResolutionOptions(),
                                      &resolver);
     isInvalid |= TC.typeCheckParameterList(SD->getIndices(), SD,
-                                           TypeResolutionOptions(),
+                                           TR_SubscriptParameters,
                                            resolver);
 
     if (isInvalid || SD->isInvalid()) {

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -990,7 +990,7 @@ static bool checkGenericSubscriptSignature(TypeChecker &tc,
   auto params = subscript->getIndices();
 
   badType |= tc.typeCheckParameterList(params, subscript,
-                                       TypeResolutionOptions(),
+                                       TR_SubscriptParameters,
                                        resolver);
 
   // Infer requirements from the pattern.

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -766,17 +766,22 @@ static bool validateParameterType(ParamDecl *decl, DeclContext *DC,
     }
     decl->getTypeLoc().setType(Ty);
   }
-  // If the param is not a 'let' and it is not an 'inout'.
-  // It must be a 'var'. Provide helpful diagnostics like a shadow copy
-  // in the function body to fix the 'var' attribute.
-  if (!decl->isLet() &&
-      !decl->isImplicit() &&
-      (Ty.isNull() || !Ty->is<InOutType>()) &&
-      !hadError) {
-    auto func = dyn_cast_or_null<AbstractFunctionDecl>(DC);
-    diagnoseAndMigrateVarParameterToBody(decl, func, TC);
-    decl->setInvalid();
-    hadError = true;
+
+  // If the user did not explicitly write 'let', 'var', or 'inout', we'll let
+  // type inference figure out what went wrong in detail.
+  if (decl->getLetVarInOutLoc().isValid()) {
+    // If the param is not a 'let' and it is not an 'inout'.
+    // It must be a 'var'. Provide helpful diagnostics like a shadow copy
+    // in the function body to fix the 'var' attribute.
+    if (!decl->isLet() &&
+        !decl->isImplicit() &&
+        (Ty.isNull() || !Ty->is<InOutType>()) &&
+        !hadError) {
+      auto func = dyn_cast_or_null<AbstractFunctionDecl>(DC);
+      diagnoseAndMigrateVarParameterToBody(decl, func, TC);
+      decl->setInvalid();
+      hadError = true;
+    }
   }
 
   if (hadError)

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2783,14 +2783,19 @@ bool TypeResolver::resolveSILResults(TypeRepr *repr,
 
 Type TypeResolver::resolveInOutType(InOutTypeRepr *repr,
                                     TypeResolutionOptions options) {
-  // inout is only valid for function parameters.
-  if (!(options & TR_FunctionInput) &&
-      !(options & TR_ImmediateFunctionInput)) {
-    TC.diagnose(repr->getInOutLoc(),
-                (options & TR_VariadicFunctionInput)
-                    ? diag::attr_not_on_variadic_parameters
-                    : diag::attr_only_on_parameters,
-                "'inout'");
+  // inout is only valid for (non-subscript) function parameters.
+  if ((options & TR_SubscriptParameters) ||
+        (!(options & TR_FunctionInput) &&
+         !(options & TR_ImmediateFunctionInput))) {
+    decltype(diag::attr_only_on_parameters) diagID;
+    if (options & TR_SubscriptParameters) {
+      diagID = diag::attr_not_on_subscript_parameters;
+    } else if (options & TR_VariadicFunctionInput) {
+      diagID = diag::attr_not_on_variadic_parameters;
+    } else {
+      diagID = diag::attr_only_on_parameters;
+    }
+    TC.diagnose(repr->getInOutLoc(), diagID, "'inout'");
     repr->setInvalid();
     return ErrorType::get(Context);
   }

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -493,6 +493,9 @@ enum TypeResolutionFlags : unsigned {
 
   /// Whether we are checking the underlying type of a typealias.
   TR_TypeAliasUnderlyingType = 0x4000000,
+
+  /// Whether we are checking the parameter list of a subscript.
+  TR_SubscriptParameters = 0x8000000,
 };
 
 /// Option set describing how type resolution should work.


### PR DESCRIPTION
- Subscripts' parameter lists may not contain inout arguments, but we
were rejecting them at call sites.  Teach the type checker to reject
them during type resolution instead.

- We assumed a syntactic check for inout/var parameters would suffice
given that a parameter unified to an InOutType.  However, closures
passed to function parameters with inout parameters in their parameter
lists can also cause this case to appear, and we would emit a
SourceLoc-less diagnostic.  Instead, do not attempt this recovery path
if the user did not actually write ‘var’ or ‘inout’ on the parameter
type.

Resolves [SR-4751](https://bugs.swift.org/browse/SR-4751), [SR-4214](https://bugs.swift.org/browse/SR-4214), [SR-3644](https://bugs.swift.org/browse/SR-3644), and [SR-2354](https://bugs.swift.org/browse/SR-2354).