### PR TITLE
Better diagnostics for multi-line string literals

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -132,8 +132,6 @@ ERROR(lex_illegal_multiline_string_start,none,
       "multi-line string literal content must begin on a new line", ())
 ERROR(lex_illegal_multiline_string_end,none,
       "multi-line string literal content must not be on the delimiter's line", ())
-ERROR(lex_ambiguous_string_indent,none,
-      "invalid mix of multi-line string literal indentation", ())
 ERROR(lex_insufficient_string_indent,none,
       "string literal content is insufficiently indented", ())
 ERROR(lex_unexpected_tab_in_string_indent,none,

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -132,13 +132,13 @@ ERROR(lex_illegal_multiline_string_start,none,
       "multi-line string literal content must begin on a new line", ())
 ERROR(lex_illegal_multiline_string_end,none,
       "multi-line string literal closing delimiter must begin on a new line", ())
-ERROR(lex_inconsistent_string_indent,none,
+ERROR(lex_multiline_string_indent_inconsistent,none,
       "%select{unexpected space in|unexpected tab in|insufficient}2 indentation of "
       "%select{line|next %1 lines}0 in multi-line string literal", 
       (bool, unsigned, unsigned))
-NOTE(note_indentation_should_match_here,none,
+NOTE(lex_multiline_string_indent_should_match_here,none,
       "should match %select{space|tab}0 here", (unsigned))
-NOTE(note_change_current_line_indentation,none,
+NOTE(lex_multiline_string_indent_change_line,none,
       "change indentation of %select{this line|these lines}0 to match closing delimiter", (bool))
 
 ERROR(lex_invalid_character,none,

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -140,6 +140,8 @@ ERROR(lex_unexpected_tab_in_string_indent,none,
       "string literal content is indented with a tab where a space is expected", ())
 ERROR(lex_unexpected_space_in_string_indent,none,
       "string literal content is indented with a space where a tab is expected", ())
+NOTE(note_change_current_line_indentation,none,
+      "change indentation to match last line", ())
 
 ERROR(lex_invalid_character,none,
        "invalid character in source file", ())

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -133,7 +133,7 @@ ERROR(lex_illegal_multiline_string_start,none,
 ERROR(lex_illegal_multiline_string_end,none,
       "multi-line string literal closing delimiter must begin on a new line", ())
 ERROR(lex_inconsistent_string_indent,none,
-      "unexpected %select{space in|tab in|end of}2 indentation of "
+      "%select{unexpected space in|unexpected tab in|insufficient}2 indentation of "
       "%select{line|next %1 lines}0 in multi-line string literal", 
       (bool, unsigned, unsigned))
 NOTE(note_indentation_should_match_here,none,

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -134,7 +134,12 @@ ERROR(lex_illegal_multiline_string_end,none,
       "invalid end of multi-line string literal", ())
 ERROR(lex_ambiguous_string_indent,none,
       "invalid mix of multi-line string literal indentation", ())
-
+ERROR(lex_insufficient_string_indent,none,
+      "string literal content is insufficiently indented", ())
+ERROR(lex_unexpected_tab_in_string_indent,none,
+      "string literal content is indented with a tab where a space is expected", ())
+ERROR(lex_unexpected_space_in_string_indent,none,
+      "string literal content is indented with a space where a tab is expected", ())
 
 ERROR(lex_invalid_character,none,
        "invalid character in source file", ())

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -129,7 +129,7 @@ ERROR(lex_invalid_unicode_scalar,none,
 ERROR(lex_unicode_escape_braces,none,
       "expected hexadecimal code in braces after unicode escape", ())
 ERROR(lex_illegal_multiline_string_start,none,
-      "invalid start of multi-line string literal", ())
+      "multi-line string literal content must begin on a new line", ())
 ERROR(lex_illegal_multiline_string_end,none,
       "invalid end of multi-line string literal", ())
 ERROR(lex_ambiguous_string_indent,none,

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -131,7 +131,7 @@ ERROR(lex_unicode_escape_braces,none,
 ERROR(lex_illegal_multiline_string_start,none,
       "multi-line string literal content must begin on a new line", ())
 ERROR(lex_illegal_multiline_string_end,none,
-      "invalid end of multi-line string literal", ())
+      "multi-line string literal content must not be on the delimiter's line", ())
 ERROR(lex_ambiguous_string_indent,none,
       "invalid mix of multi-line string literal indentation", ())
 ERROR(lex_insufficient_string_indent,none,

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -133,15 +133,13 @@ ERROR(lex_illegal_multiline_string_start,none,
 ERROR(lex_illegal_multiline_string_end,none,
       "multi-line string literal closing delimiter must begin on a new line", ())
 ERROR(lex_inconsistent_string_indent,none,
-      "line does not start with same indentation as closing delimiter of multi-line string literal", ())
-NOTE(note_insufficient_string_indent,none,
-      "unexpectedly found non-indentation character here", ())
-NOTE(note_unexpected_char_in_string_indent,none,
-      "unexpected %select{space|tab}0 in indentation here", (bool))
-NOTE(note_matching_indentation_char_here,none,
-      "should match %select{space|tab}0 in same position before closing delimiter", (bool))
+      "unexpected %select{space in|tab in|end of}2 indentation of "
+      "%select{line|next %1 lines}0 in multi-line string literal", 
+      (bool, unsigned, unsigned))
+NOTE(note_indentation_should_match_here,none,
+      "should match %select{space|tab}0 here", (unsigned))
 NOTE(note_change_current_line_indentation,none,
-      "change indentation of this line to match closing delimiter", ())
+      "change indentation of %select{this line|these lines}0 to match closing delimiter", (bool))
 
 ERROR(lex_invalid_character,none,
        "invalid character in source file", ())

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -131,17 +131,17 @@ ERROR(lex_unicode_escape_braces,none,
 ERROR(lex_illegal_multiline_string_start,none,
       "multi-line string literal content must begin on a new line", ())
 ERROR(lex_illegal_multiline_string_end,none,
-      "multi-line string literal content must not be on the delimiter's line", ())
-ERROR(lex_insufficient_string_indent,none,
-      "string literal content is insufficiently indented", ())
-ERROR(lex_unexpected_tab_in_string_indent,none,
-      "string literal content is indented with a tab where a space is expected", ())
-ERROR(lex_unexpected_space_in_string_indent,none,
-      "string literal content is indented with a space where a tab is expected", ())
+      "multi-line string literal closing delimiter must begin on a new line", ())
+ERROR(lex_inconsistent_string_indent,none,
+      "line does not start with same indentation as closing delimiter of multi-line string literal", ())
+NOTE(note_insufficient_string_indent,none,
+      "unexpectedly found non-indentation character here", ())
+NOTE(note_unexpected_char_in_string_indent,none,
+      "unexpected %select{space|tab}0 in indentation here", (bool))
+NOTE(note_matching_indentation_char_here,none,
+      "should match %select{space|tab}0 in same position before closing delimiter", (bool))
 NOTE(note_change_current_line_indentation,none,
-      "change indentation to match last line", ())
-NOTE(note_change_last_line_indentation,none,
-      "change last line's indentation to match this line", ())
+      "change indentation of this line to match closing delimiter", ())
 
 ERROR(lex_invalid_character,none,
        "invalid character in source file", ())

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -142,6 +142,8 @@ ERROR(lex_unexpected_space_in_string_indent,none,
       "string literal content is indented with a space where a tab is expected", ())
 NOTE(note_change_current_line_indentation,none,
       "change indentation to match last line", ())
+NOTE(note_change_last_line_indentation,none,
+      "change last line's indentation to match this line", ())
 
 ERROR(lex_invalid_character,none,
        "invalid character in source file", ())

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -1392,7 +1392,7 @@ static size_t commonPrefixLength(StringRef shorter, const char * longer) {
 // FIXME: StringRef has a method like this; we should probably make LinePtr a 
 // StringRef so we can use it.
 static size_t firstNotOf(const char * haystack, const char * needles, size_t offset = 0) {
-  return strpbrk(haystack + offset, needles) - haystack;
+  return strspn(haystack + offset, needles) + offset;
 }
 
 static void diagnoseInvalidMultilineIndents(DiagnosticEngine *Diags, 

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -1412,6 +1412,8 @@ static void diagnoseInvalidMultilineIndents(
     return;
   }
   
+  assert(LineStarts.size() > 0);
+  
   auto getLoc = [&](size_t offset) -> SourceLoc {
     return Lexer::getSourceLoc((const char *)Bytes.bytes_begin() + offset);
   };
@@ -1427,21 +1429,23 @@ static void diagnoseInvalidMultilineIndents(
   };
   
   Diags->diagnose(getLoc(LineStarts[0] + MistakeOffset),
-                  diag::lex_inconsistent_string_indent,
+                  diag::lex_multiline_string_indent_inconsistent,
                   LineStarts.size() != 1, LineStarts.size(),
                   classify(Bytes[LineStarts[0] + MistakeOffset]));
   
   Diags->diagnose(IndentLoc.getAdvancedLoc(MistakeOffset), 
-                  diag::note_indentation_should_match_here, 
+                  diag::lex_multiline_string_indent_should_match_here, 
                   classify(ExpectedIndent[MistakeOffset]));
   
   auto fix = Diags->diagnose(getLoc(LineStarts[0] + MistakeOffset),
-                             diag::note_change_current_line_indentation,
+                             diag::lex_multiline_string_indent_change_line,
                              LineStarts.size() != 1);
   
   assert(MistakeOffset <= ActualIndent.size());
-  assert(ExpectedIndent.substr(0, MistakeOffset) == ActualIndent.substr(0, MistakeOffset));
-  for(auto line : LineStarts) {    
+  assert(ExpectedIndent.substr(0, MistakeOffset) == 
+         ActualIndent.substr(0, MistakeOffset));
+  
+  for(auto line : LineStarts) {
     fix.fixItReplaceChars(getLoc(line + MistakeOffset), 
                           getLoc(line + ActualIndent.size()),
                           ExpectedIndent.substr(MistakeOffset));

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -1479,7 +1479,8 @@ void Lexer::lexStringLiteral() {
     MultilineString = true;
     CurPtr += 2;
     if (*CurPtr != '\n' && *CurPtr != '\r')
-      diagnose(CurPtr, diag::lex_illegal_multiline_string_start);
+      diagnose(CurPtr, diag::lex_illegal_multiline_string_start)
+        .fixItInsert(Lexer::getSourceLoc(CurPtr), "\n");
   }
 
   while (true) {

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -1370,9 +1370,12 @@ getMultilineTrailingIndent(const Token &Str, DiagnosticEngine *Diags) {
       return std::make_tuple(string, range);
     }
     default:
-      if (Diags)
-        Diags->diagnose(Lexer::getSourceLoc(start),
-                        diag::lex_illegal_multiline_string_end);
+        if (Diags) {
+          auto loc = Lexer::getSourceLoc(start + 1);
+          Diags->diagnose(loc, diag::lex_illegal_multiline_string_end)
+            // FIXME: Should try to suggest indentation.
+            .fixItInsert(loc, "\n");
+        }
       return std::make_tuple("", CharSourceRange(Lexer::getSourceLoc(end - 1), 0));
     }
   }

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -1406,6 +1406,18 @@ static void diagnoseInvalidMultilineIndents(DiagnosticEngine *Diags,
   }
   
   Diags->diagnose(Lexer::getSourceLoc(LinePtr), error);
+  
+  size_t allIndentationOffset;
+  // Scan past any remaining indentation in the line, which we will assume is 
+  // incorrect.
+  // FIXME: It'd be better to examine surrounding lines to see how they're indented, 
+  // and then leave enough whitespace on this line to match them.
+  for(allIndentationOffset = mistakeOffset; LinePtr[allIndentationOffset] == ' ' || LinePtr[allIndentationOffset] == '\t'; allIndentationOffset++)
+  /* do nothing */;
+  
+  // Suggest fixing this by replacing with the expected whitespace.
+  Diags->diagnose(Lexer::getSourceLoc(LinePtr), diag::note_change_current_line_indentation)
+    .fixItReplaceChars(Lexer::getSourceLoc(LinePtr), Lexer::getSourceLoc(LinePtr + allIndentationOffset), ExpectedIndentation);
 }
 
 /// validateMultilineIndents:

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -29,6 +29,8 @@
 // FIXME: Figure out if this can be migrated to LLVM.
 #include "clang/Basic/CharInfo.h"
 
+#include <limits>
+
 using namespace swift;
 
 // clang::isIdentifierHead and clang::isIdentifierBody are deliberately not in
@@ -1464,7 +1466,7 @@ static void validateMultilineIndents(const Token &Str,
   
   // The offset into the previous line where it experienced its first indentation 
   // error, or Indent.size() if every character matched.
-  size_t lastMistakeOffset = SIZE_T_MAX;
+  size_t lastMistakeOffset = std::numeric_limits<size_t>::max();
   // Offsets for each consecutive previous line with its first error at 
   // lastMatchLength.
   SmallVector<size_t, 4> linesWithLastMistakeOffset = {};

--- a/test/Parse/multiline_errors.swift
+++ b/test/Parse/multiline_errors.swift
@@ -68,7 +68,7 @@ _ = """Fourteen
 // newline currently required before closing """
 _ = """
     Fourteen
-    Pi""" // expected-error@-0{{invalid end of multi-line string literal}}
+    Pi""" // expected-error@-0{{multi-line string literal content must not be on the delimiter's line}} {{7-7=\n}}
 
 // newline currently required after opening """
 _ = """""" // expected-error@-0{{multi-line string literal content must begin on a new line}} {{8-8=\n}}

--- a/test/Parse/multiline_errors.swift
+++ b/test/Parse/multiline_errors.swift
@@ -63,7 +63,7 @@ _ = """
 // newline currently required after opening """
 _ = """Fourteen
     Pi
-    """ // expected-error@-2{{invalid start of multi-line string literal}}
+    """ // expected-error@-2{{multi-line string literal content must begin on a new line}} {{8-8=\n}}
 
 // newline currently required before closing """
 _ = """
@@ -71,7 +71,7 @@ _ = """
     Pi""" // expected-error@-0{{invalid end of multi-line string literal}}
 
 // newline currently required after opening """
-_ = """""" // expected-error@-0{{invalid start of multi-line string literal}}
+_ = """""" // expected-error@-0{{multi-line string literal content must begin on a new line}} {{8-8=\n}}
 
 // newline currently required after opening """
-_ = """ """ // expected-error@-0{{invalid start of multi-line string literal}}
+_ = """ """ // expected-error@-0{{multi-line string literal content must begin on a new line}} {{8-8=\n}}

--- a/test/Parse/multiline_errors.swift
+++ b/test/Parse/multiline_errors.swift
@@ -49,7 +49,7 @@ _ = """
 	Thirteen 2
   Xi 2
 	""" // expected-error@-1{{string literal content is indented with a space where a tab is expected}}
-      // expected-note@-2{{change indentation to match last line}} {{1-2=	}}
+      // expected-note@-2{{change indentation to match last line}} {{1-3=	}}
       // expected-note@-2{{change last line's indentation to match this line}} {{1-3=  }}
 
 // multiple spaces are not the same as a tab for de-indentation

--- a/test/Parse/multiline_errors.swift
+++ b/test/Parse/multiline_errors.swift
@@ -8,64 +8,57 @@ import Swift
 _ = """
     Eleven
   Mu
-    """ // expected-error@-1{{line does not start with same indentation as closing delimiter of multi-line string literal}}
-        // expected-note@-2{{unexpectedly found non-indentation character here}}
-        // expected-note@-2{{should match space in same position before closing delimiter}}
-        // expected-note@-4{{change indentation of this line to match closing delimiter}} {{1-3=    }}
+    """ // expected-error@-1{{unexpected end of indentation of line in multi-line string literal}}
+        // expected-note@-1{{should match space here}}
+        // expected-note@-3{{change indentation of this line to match closing delimiter}} {{3-3=  }}
 
 // expecting at least 4 columns of leading indentation
 _ = """
     Eleven
    Mu
-    """ // expected-error@-1{{line does not start with same indentation as closing delimiter of multi-line string literal}}
-        // expected-note@-2{{unexpectedly found non-indentation character here}}
-        // expected-note@-2{{should match space in same position before closing delimiter}}
-        // expected-note@-4{{change indentation of this line to match closing delimiter}} {{1-4=    }}
+    """ // expected-error@-1{{unexpected end of indentation of line in multi-line string literal}}
+        // expected-note@-1{{should match space here}}
+        // expected-note@-3{{change indentation of this line to match closing delimiter}} {{4-4= }}
 
 // \t is not the same as an actual tab for de-indentation
 _ = """
 	Twelve
 \tNu
-	""" // expected-error@-1{{line does not start with same indentation as closing delimiter of multi-line string literal}}
-      // expected-note@-2{{unexpectedly found non-indentation character here}}
-      // expected-note@-2{{should match tab in same position before closing delimiter}}
-      // expected-note@-4{{change indentation of this line to match closing delimiter}} {{1-1=	}}
+	""" // expected-error@-1{{unexpected end of indentation of line in multi-line string literal}}
+      // expected-note@-1{{should match tab here}}
+      // expected-note@-3{{change indentation of this line to match closing delimiter}} {{1-1=	}}
 
 // a tab is not the same as multiple spaces for de-indentation
 _ = """
   Thirteen
 	Xi
-  """ // expected-error@-1{{line does not start with same indentation as closing delimiter of multi-line string literal}}
-      // expected-note@-2{{unexpected tab in indentation here}}
-      // expected-note@-2{{should match space in same position before closing delimiter}}
-      // expected-note@-4{{change indentation of this line to match closing delimiter}} {{1-2=  }}
+  """ // expected-error@-1{{unexpected tab in indentation of line in multi-line string literal}}
+      // expected-note@-1{{should match space here}}
+      // expected-note@-3{{change indentation of this line to match closing delimiter}} {{1-2=  }}
 
 // a tab is not the same as multiple spaces for de-indentation
 _ = """
     Fourteen
   	Pi
-    """ // expected-error@-1{{line does not start with same indentation as closing delimiter of multi-line string literal}}
-        // expected-note@-2{{unexpected tab in indentation here}}
-        // expected-note@-2{{should match space in same position before closing delimiter}}
-        // expected-note@-4{{change indentation of this line to match closing delimiter}} {{1-4=    }}
+    """ // expected-error@-1{{unexpected tab in indentation of line in multi-line string literal}}
+        // expected-note@-1{{should match space here}}
+        // expected-note@-3{{change indentation of this line to match closing delimiter}} {{3-4=  }}
 
 // multiple spaces are not the same as a tab for de-indentation
 _ = """
 	Thirteen 2
   Xi 2
-	""" // expected-error@-1{{line does not start with same indentation as closing delimiter of multi-line string literal}}
-      // expected-note@-2{{unexpected space in indentation here}}
-      // expected-note@-2{{should match tab in same position before closing delimiter}}
-      // expected-note@-4{{change indentation of this line to match closing delimiter}} {{1-3=	}}
+	""" // expected-error@-1{{unexpected space in indentation of line in multi-line string literal}}
+      // expected-note@-1{{should match tab here}}
+      // expected-note@-3{{change indentation of this line to match closing delimiter}} {{1-3=	}}
 
 // multiple spaces are not the same as a tab for de-indentation
 _ = """
 		Fourteen 2
 	  Pi 2
-		""" // expected-error@-1{{line does not start with same indentation as closing delimiter of multi-line string literal}}
-        // expected-note@-2{{unexpected space in indentation here}}
-        // expected-note@-2{{should match tab in same position before closing delimiter}}
-        // expected-note@-4{{change indentation of this line to match closing delimiter}} {{1-4=		}}
+		""" // expected-error@-1{{unexpected space in indentation of line in multi-line string literal}}
+        // expected-note@-1{{should match tab here}}
+        // expected-note@-3{{change indentation of this line to match closing delimiter}} {{2-4=	}}
 
 // newline currently required after opening """
 _ = """Fourteen
@@ -82,3 +75,34 @@ _ = """""" // expected-error@-0{{multi-line string literal content must begin on
 
 // newline currently required after opening """
 _ = """ """ // expected-error@-0{{multi-line string literal content must begin on a new line}} {{8-8=\n}}
+
+// two lines should get only one error
+_ = """
+    Hello,
+        World!
+	"""     // expected-error@-2{{unexpected space in indentation of next 2 lines in multi-line string literal}}
+          // expected-note@-1{{should match tab here}}
+          // expected-note@-4{{change indentation of these lines to match closing delimiter}} {{1-5=	}} {{1-5=	}}
+
+  _ = """
+Zero A
+Zero B
+	One A
+	One B
+  Two A
+  Two B
+Three A
+Three B
+		Four A
+		Four B
+			Five A
+			Five B
+		"""   // expected-error@-12{{unexpected end of indentation of next 2 lines in multi-line string literal}}
+          // expected-note@-1{{should match tab here}}
+          // expected-note@-14{{change indentation of these lines to match closing delimiter}} {{1-1=		}} {{1-1=		}}
+          // expected-error@-13{{unexpected end of indentation of next 2 lines in multi-line string literal}}
+          // expected-note@-4{{should match tab here}}
+          // expected-note@-15{{change indentation of these lines to match closing delimiter}} {{2-2=	}} {{2-2=	}}
+          // expected-error@-14{{unexpected space in indentation of next 4 lines in multi-line string literal}}
+          // expected-note@-7{{should match tab here}}
+          // expected-note@-16{{change indentation of these lines to match closing delimiter}} {{1-1=		}} {{1-1=		}} {{1-1=		}} {{1-1=		}}

--- a/test/Parse/multiline_errors.swift
+++ b/test/Parse/multiline_errors.swift
@@ -4,35 +4,61 @@ import Swift
 
 // ===---------- Multiline --------===
 
+// expecting at least 4 columns of leading indentation
 _ = """
     Eleven
   Mu
-    """ // expected-error@-1{{invalid mix of multi-line string literal indentation}}
-// expecting at least 4 columns of leading indentation
+    """ // expected-error@-1{{string literal content is insufficiently indented}}
+        // expected-note@-2{{change indentation to match last line}} {{1-3=    }}
+        // expected-note@-2{{change last line's indentation to match this line}} {{1-5=  }}
 
+// expecting at least 4 columns of leading indentation
 _ = """
     Eleven
    Mu
-    """ // expected-error@-1{{invalid mix of multi-line string literal indentation}}
-// expecting at least 4 columns of leading indentation
+    """ // expected-error@-1{{string literal content is insufficiently indented}}
+        // expected-note@-2{{change indentation to match last line}} {{1-4=    }}
+        // expected-note@-2{{change last line's indentation to match this line}} {{1-5=   }}
 
+// \t is not the same as an actual tab for de-indentation
 _ = """
 	Twelve
 \tNu
-	""" // expected-error@-1{{invalid mix of multi-line string literal indentation}}
-// \t is not the same as an actual tab for de-indentation
+	""" // expected-error@-1{{string literal content is insufficiently indented}}
+      // expected-note@-2{{change indentation to match last line}} {{1-1=	}}
+      // expected-note@-2{{change last line's indentation to match this line}} {{1-2=}}
 
+// a tab is not the same as multiple spaces for de-indentation
 _ = """
   Thirteen
 	Xi
-  """ // expected-error@-1{{invalid mix of multi-line string literal indentation}}
-// a tab is not the same as multiple spaces for de-indentation
+  """ // expected-error@-1{{string literal content is indented with a tab where a space is expected}}
+      // expected-note@-2{{change indentation to match last line}} {{1-2=  }}
+      // expected-note@-2{{change last line's indentation to match this line}} {{1-3=	}}
 
+// a tab is not the same as multiple spaces for de-indentation
 _ = """
     Fourteen
   	Pi
-    """ // expected-error@-1{{invalid mix of multi-line string literal indentation}}
-// a tab is not the same as multiple spaces for de-indentation
+    """ // expected-error@-1{{string literal content is indented with a tab where a space is expected}}
+        // expected-note@-2{{change indentation to match last line}} {{1-4=    }}
+        // expected-note@-2{{change last line's indentation to match this line}} {{1-5=  	}}
+
+// multiple spaces are not the same as a tab for de-indentation
+_ = """
+	Thirteen 2
+  Xi 2
+	""" // expected-error@-1{{string literal content is indented with a space where a tab is expected}}
+      // expected-note@-2{{change indentation to match last line}} {{1-2=	}}
+      // expected-note@-2{{change last line's indentation to match this line}} {{1-3=  }}
+
+// multiple spaces are not the same as a tab for de-indentation
+_ = """
+		Fourteen 2
+	  Pi 2
+		""" // expected-error@-1{{string literal content is indented with a space where a tab is expected}}
+        // expected-note@-2{{change indentation to match last line}} {{1-4=		}}
+        // expected-note@-2{{change last line's indentation to match this line}} {{1-5=	  }}
 
 _ = """Fourteen
     Pi

--- a/test/Parse/multiline_errors.swift
+++ b/test/Parse/multiline_errors.swift
@@ -8,57 +8,64 @@ import Swift
 _ = """
     Eleven
   Mu
-    """ // expected-error@-1{{string literal content is insufficiently indented}}
-        // expected-note@-2{{change indentation to match last line}} {{1-3=    }}
-        // expected-note@-2{{change last line's indentation to match this line}} {{1-5=  }}
+    """ // expected-error@-1{{line does not start with same indentation as closing delimiter of multi-line string literal}}
+        // expected-note@-2{{unexpectedly found non-indentation character here}}
+        // expected-note@-2{{should match space in same position before closing delimiter}}
+        // expected-note@-4{{change indentation of this line to match closing delimiter}} {{1-3=    }}
 
 // expecting at least 4 columns of leading indentation
 _ = """
     Eleven
    Mu
-    """ // expected-error@-1{{string literal content is insufficiently indented}}
-        // expected-note@-2{{change indentation to match last line}} {{1-4=    }}
-        // expected-note@-2{{change last line's indentation to match this line}} {{1-5=   }}
+    """ // expected-error@-1{{line does not start with same indentation as closing delimiter of multi-line string literal}}
+        // expected-note@-2{{unexpectedly found non-indentation character here}}
+        // expected-note@-2{{should match space in same position before closing delimiter}}
+        // expected-note@-4{{change indentation of this line to match closing delimiter}} {{1-4=    }}
 
 // \t is not the same as an actual tab for de-indentation
 _ = """
 	Twelve
 \tNu
-	""" // expected-error@-1{{string literal content is insufficiently indented}}
-      // expected-note@-2{{change indentation to match last line}} {{1-1=	}}
-      // expected-note@-2{{change last line's indentation to match this line}} {{1-2=}}
+	""" // expected-error@-1{{line does not start with same indentation as closing delimiter of multi-line string literal}}
+      // expected-note@-2{{unexpectedly found non-indentation character here}}
+      // expected-note@-2{{should match tab in same position before closing delimiter}}
+      // expected-note@-4{{change indentation of this line to match closing delimiter}} {{1-1=	}}
 
 // a tab is not the same as multiple spaces for de-indentation
 _ = """
   Thirteen
 	Xi
-  """ // expected-error@-1{{string literal content is indented with a tab where a space is expected}}
-      // expected-note@-2{{change indentation to match last line}} {{1-2=  }}
-      // expected-note@-2{{change last line's indentation to match this line}} {{1-3=	}}
+  """ // expected-error@-1{{line does not start with same indentation as closing delimiter of multi-line string literal}}
+      // expected-note@-2{{unexpected tab in indentation here}}
+      // expected-note@-2{{should match space in same position before closing delimiter}}
+      // expected-note@-4{{change indentation of this line to match closing delimiter}} {{1-2=  }}
 
 // a tab is not the same as multiple spaces for de-indentation
 _ = """
     Fourteen
   	Pi
-    """ // expected-error@-1{{string literal content is indented with a tab where a space is expected}}
-        // expected-note@-2{{change indentation to match last line}} {{1-4=    }}
-        // expected-note@-2{{change last line's indentation to match this line}} {{1-5=  	}}
+    """ // expected-error@-1{{line does not start with same indentation as closing delimiter of multi-line string literal}}
+        // expected-note@-2{{unexpected tab in indentation here}}
+        // expected-note@-2{{should match space in same position before closing delimiter}}
+        // expected-note@-4{{change indentation of this line to match closing delimiter}} {{1-4=    }}
 
 // multiple spaces are not the same as a tab for de-indentation
 _ = """
 	Thirteen 2
   Xi 2
-	""" // expected-error@-1{{string literal content is indented with a space where a tab is expected}}
-      // expected-note@-2{{change indentation to match last line}} {{1-3=	}}
-      // expected-note@-2{{change last line's indentation to match this line}} {{1-2=  }}
+	""" // expected-error@-1{{line does not start with same indentation as closing delimiter of multi-line string literal}}
+      // expected-note@-2{{unexpected space in indentation here}}
+      // expected-note@-2{{should match tab in same position before closing delimiter}}
+      // expected-note@-4{{change indentation of this line to match closing delimiter}} {{1-3=	}}
 
 // multiple spaces are not the same as a tab for de-indentation
 _ = """
 		Fourteen 2
 	  Pi 2
-		""" // expected-error@-1{{string literal content is indented with a space where a tab is expected}}
-        // expected-note@-2{{change indentation to match last line}} {{1-4=		}}
-        // expected-note@-2{{change last line's indentation to match this line}} {{1-3=	  }}
+		""" // expected-error@-1{{line does not start with same indentation as closing delimiter of multi-line string literal}}
+        // expected-note@-2{{unexpected space in indentation here}}
+        // expected-note@-2{{should match tab in same position before closing delimiter}}
+        // expected-note@-4{{change indentation of this line to match closing delimiter}} {{1-4=		}}
 
 // newline currently required after opening """
 _ = """Fourteen
@@ -68,7 +75,7 @@ _ = """Fourteen
 // newline currently required before closing """
 _ = """
     Fourteen
-    Pi""" // expected-error@-0{{multi-line string literal content must not be on the delimiter's line}} {{7-7=\n}}
+    Pi""" // expected-error@-0{{multi-line string literal closing delimiter must begin on a new line}} {{7-7=\n}}
 
 // newline currently required after opening """
 _ = """""" // expected-error@-0{{multi-line string literal content must begin on a new line}} {{8-8=\n}}

--- a/test/Parse/multiline_errors.swift
+++ b/test/Parse/multiline_errors.swift
@@ -60,18 +60,18 @@ _ = """
         // expected-note@-2{{change indentation to match last line}} {{1-4=		}}
         // expected-note@-2{{change last line's indentation to match this line}} {{1-3=	  }}
 
+// newline currently required after opening """
 _ = """Fourteen
     Pi
     """ // expected-error@-2{{invalid start of multi-line string literal}}
-// newline currently required after opening """
 
+// newline currently required before closing """
 _ = """
     Fourteen
     Pi""" // expected-error@-0{{invalid end of multi-line string literal}}
-// newline currently required before closing """
 
+// newline currently required after opening """
 _ = """""" // expected-error@-0{{invalid start of multi-line string literal}}
-// newline currently required after opening """
 
-_ = """ """ // expected-error@-0{{invalid start of multi-line string literal}}
 // newline currently required after opening """
+_ = """ """ // expected-error@-0{{invalid start of multi-line string literal}}

--- a/test/Parse/multiline_errors.swift
+++ b/test/Parse/multiline_errors.swift
@@ -50,7 +50,7 @@ _ = """
   Xi 2
 	""" // expected-error@-1{{string literal content is indented with a space where a tab is expected}}
       // expected-note@-2{{change indentation to match last line}} {{1-3=	}}
-      // expected-note@-2{{change last line's indentation to match this line}} {{1-3=  }}
+      // expected-note@-2{{change last line's indentation to match this line}} {{1-2=  }}
 
 // multiple spaces are not the same as a tab for de-indentation
 _ = """
@@ -58,7 +58,7 @@ _ = """
 	  Pi 2
 		""" // expected-error@-1{{string literal content is indented with a space where a tab is expected}}
         // expected-note@-2{{change indentation to match last line}} {{1-4=		}}
-        // expected-note@-2{{change last line's indentation to match this line}} {{1-5=	  }}
+        // expected-note@-2{{change last line's indentation to match this line}} {{1-3=	  }}
 
 _ = """Fourteen
     Pi

--- a/test/Parse/multiline_errors.swift
+++ b/test/Parse/multiline_errors.swift
@@ -8,7 +8,7 @@ import Swift
 _ = """
     Eleven
   Mu
-    """ // expected-error@-1{{unexpected end of indentation of line in multi-line string literal}}
+    """ // expected-error@-1{{insufficient indentation of line in multi-line string literal}}
         // expected-note@-1{{should match space here}}
         // expected-note@-3{{change indentation of this line to match closing delimiter}} {{3-3=  }}
 
@@ -16,7 +16,7 @@ _ = """
 _ = """
     Eleven
    Mu
-    """ // expected-error@-1{{unexpected end of indentation of line in multi-line string literal}}
+    """ // expected-error@-1{{insufficient indentation of line in multi-line string literal}}
         // expected-note@-1{{should match space here}}
         // expected-note@-3{{change indentation of this line to match closing delimiter}} {{4-4= }}
 
@@ -24,7 +24,7 @@ _ = """
 _ = """
 	Twelve
 \tNu
-	""" // expected-error@-1{{unexpected end of indentation of line in multi-line string literal}}
+	""" // expected-error@-1{{insufficient indentation of line in multi-line string literal}}
       // expected-note@-1{{should match tab here}}
       // expected-note@-3{{change indentation of this line to match closing delimiter}} {{1-1=	}}
 
@@ -97,10 +97,10 @@ Three B
 		Four B
 			Five A
 			Five B
-		"""   // expected-error@-12{{unexpected end of indentation of next 2 lines in multi-line string literal}}
+		"""   // expected-error@-12{{insufficient indentation of next 2 lines in multi-line string literal}}
           // expected-note@-1{{should match tab here}}
           // expected-note@-14{{change indentation of these lines to match closing delimiter}} {{1-1=		}} {{1-1=		}}
-          // expected-error@-13{{unexpected end of indentation of next 2 lines in multi-line string literal}}
+          // expected-error@-13{{insufficient indentation of next 2 lines in multi-line string literal}}
           // expected-note@-4{{should match tab here}}
           // expected-note@-15{{change indentation of these lines to match closing delimiter}} {{2-2=	}} {{2-2=	}}
           // expected-error@-14{{unexpected space in indentation of next 4 lines in multi-line string literal}}


### PR DESCRIPTION
Improves the error messages emitted when a multiline string literal has a whitespace error. Incorrect indentation uses one of these three messages:

* "string literal content is insufficiently indented"
* "string literal content is indented with a tab where a space is expected"
* "string literal content is indented with a space where a tab is expected"

All three of these errors also include two fix-its:

* "change indentation to match last line"
* "change last line's indentation to match this line"

Finally, missing newlines after the opening delimiter or before the closing delimiter are indicated with:

* "multi-line string literal content must begin on a new line"
* "multi-line string literal content must not be on the delimiter's line"

Both of these also include fix-its to add newlines.

I was not able to build a toolchain and test this in Xcode, so I'm not totally sure this will give the experience we hope for. But I think this is the right direction.

Resolves [SR-4701](https://bugs.swift.org/browse/SR-4701).

@milseman @johnno1962 