### PR TITLE
[stdlib] New overload for joined()

### DIFF
--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -566,6 +566,11 @@ extension Sequence where Iterator.Element == String {
   ///   in this sequence. The default separator is an empty string.
   /// - Returns: A single, concatenated string.
   public func joined(separator: String = "") -> String {
+    return _joined(separator: separator)
+  }
+
+  @inline(__always)
+  internal func _joined(separator: String = "") -> String {
     var result = ""
 
     // FIXME(performance): this code assumes UTF-16 in-memory representation.
@@ -604,6 +609,30 @@ extension Sequence where Iterator.Element == String {
     }
 
     return result
+  }
+}
+
+
+// This overload is necessary because String now conforms to
+// BidirectionalCollection, and there are other `joined` overloads that are
+// considered more specific. See Flatten.swift.gyb.
+extension BidirectionalCollection where Iterator.Element == String {
+  /// Returns a new string by concatenating the elements of the sequence,
+  /// adding the given separator between each element.
+  ///
+  /// The following example shows how an array of strings can be joined to a
+  /// single, comma-separated string:
+  ///
+  ///     let cast = ["Vivien", "Marlon", "Kim", "Karl"]
+  ///     let list = cast.joined(separator: ", ")
+  ///     print(list)
+  ///     // Prints "Vivien, Marlon, Kim, Karl"
+  ///
+  /// - Parameter separator: A string to insert between each of the elements
+  ///   in this sequence. The default separator is an empty string.
+  /// - Returns: A single, concatenated string.
+  public func joined(separator: String = "") -> String {
+    return _joined(separator: separator)
   }
 }
 

--- a/test/stdlib/StringAPI.swift
+++ b/test/stdlib/StringAPI.swift
@@ -365,6 +365,11 @@ StringTests.test("String.init(_:String)") {
   let _: String = String("" as String) // should compile without ambiguities
 }
 
+StringTests.test("[String].joined() -> String") {
+  let s = ["hello", "world"].joined()
+  _ = s == "" // should compile without error
+}
+
 var CStringTests = TestSuite("CStringTests")
 
 func getNullUTF8() -> UnsafeMutablePointer<UInt8>? {


### PR DESCRIPTION
Now that `String` conforms to the `BidirectionalCollection` protocol, in
the expression `let x = [""].joined()` the best matching overload for
`joined` is no longer the one returning `String`.

Fixes: <rdar://problem/31899440>