### PR TITLE
[Type checker] Downgrade some "redundant conformance" errors to warnings.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1542,6 +1542,13 @@ WARNING(witness_unavailable,none,
 
 ERROR(redundant_conformance,none,
       "redundant conformance of %0 to protocol %1", (Type, DeclName))
+WARNING(redundant_conformance_adhoc,none,
+        "conformance of %0 to protocol %1 was already stated in "
+        "%select{the protocol's|the type's}2 module %3",
+        (Type, DeclName, bool, Identifier))
+NOTE(redundant_conformance_witness_ignored,none,
+     "%0 %1 will not be used to satisfy the conformance to %2",
+     (DescriptiveDeclKind, DeclName, DeclName))
 
 // "Near matches"
 WARNING(optional_req_near_match,none,

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -1128,6 +1128,11 @@ static void filterValues(Type expectedTy, ModuleDecl *expectedModule,
 
   auto newEnd = std::remove_if(values.begin(), values.end(),
                                [=](ValueDecl *value) {
+    // Ignore anything that was parsed (vs. deserialized), because a serialized
+    // module cannot refer to it.
+    if (value->getDeclContext()->getParentSourceFile())
+      return true;
+
     if (isType != isa<TypeDecl>(value))
       return true;
     if (!value->hasInterfaceType())

--- a/test/Compatibility/string_collection.swift
+++ b/test/Compatibility/string_collection.swift
@@ -1,0 +1,15 @@
+// RUN: %target-typecheck-verify-swift -swift-version 3
+
+extension String : Collection { // expected-warning{{conformance of 'String' to protocol 'Collection' was already stated in the type's module 'Swift'}}
+  subscript (i: Index) -> String { // expected-note{{subscript 'subscript' will not be used to satisfy the conformance to 'Collection'}}
+    get { return self }
+    set { }
+  }
+
+  var isEmpty: Bool { return false } // expected-note{{var 'isEmpty' will not be used to satisfy the conformance to 'Collection'}}
+
+}
+
+func testStringOps(s: String) {
+  _ = s.isEmpty
+}

--- a/test/Sema/enum_post_hoc_raw_representable_with_raw_type.swift
+++ b/test/Sema/enum_post_hoc_raw_representable_with_raw_type.swift
@@ -5,5 +5,5 @@
 
 import enum_with_raw_type
 
-// expected-error@+1{{redundant conformance of 'Foo' to protocol 'RawRepresentable'}}
+// expected-warning@+1{{conformance of 'Foo' to protocol 'RawRepresentable' was already stated in the type's module 'enum_with_raw_type'}}
 extension Foo: RawRepresentable {}

--- a/test/decl/protocol/conforms/Inputs/redundant_conformance_A.swift
+++ b/test/decl/protocol/conforms/Inputs/redundant_conformance_A.swift
@@ -1,0 +1,14 @@
+public protocol P1 {
+  associatedtype A
+
+  func f() -> A
+}
+
+public struct ConformsToP : P1 {
+  public func f() -> Int { return 0 }
+}
+
+public struct OtherConformsToP {
+  public func f() -> Int { return 0 }
+}
+

--- a/test/decl/protocol/conforms/Inputs/redundant_conformance_B.swift
+++ b/test/decl/protocol/conforms/Inputs/redundant_conformance_B.swift
@@ -1,0 +1,14 @@
+import redundant_conformance_A
+
+public protocol P2 {
+  associatedtype A
+
+  func f() -> A
+}
+
+extension OtherConformsToP: P1 {
+}
+
+extension ConformsToP: P2 {
+  public func f() -> Int { return 0 }
+}

--- a/test/decl/protocol/conforms/placement.swift
+++ b/test/decl/protocol/conforms/placement.swift
@@ -189,31 +189,31 @@ enum MFSynthesizedEnum2 : Int { case none = 0 }
 // ===========================================================================
 // Tests with conformances in imported modules
 // ===========================================================================
-extension MMExplicit1 : MMP1 { } // expected-error{{redundant conformance of 'MMExplicit1' to protocol 'MMP1'}}
+extension MMExplicit1 : MMP1 { } // expected-warning{{conformance of 'MMExplicit1' to protocol 'MMP1' was already stated in the type's module 'placement_module_A'}}
 
-extension MMExplicit1 : MMP2a { } // expected-error{{redundant conformance of 'MMExplicit1' to protocol 'MMP2a'}}
-extension MMExplicit1 : MMP3a { } // expected-error{{redundant conformance of 'MMExplicit1' to protocol 'MMP3a'}}
+extension MMExplicit1 : MMP2a { } // expected-warning{{MMExplicit1' to protocol 'MMP2a' was already stated in the type's module 'placement_module_A}}
+extension MMExplicit1 : MMP3a { } // expected-warning{{conformance of 'MMExplicit1' to protocol 'MMP3a' was already stated in the type's module 'placement_module_A'}}
 
 extension MMExplicit1 : MMP3b { } // okay
 
-extension MMSuper1 : MMP1 { } // expected-error{{redundant conformance of 'MMSuper1' to protocol 'MMP1'}}
-extension MMSuper1 : MMP2a { } // expected-error{{redundant conformance of 'MMSuper1' to protocol 'MMP2a'}}
+extension MMSuper1 : MMP1 { } // expected-warning{{conformance of 'MMSuper1' to protocol 'MMP1' was already stated in the type's module 'placement_module_A'}}
+extension MMSuper1 : MMP2a { } // expected-warning{{conformance of 'MMSuper1' to protocol 'MMP2a' was already stated in the type's module 'placement_module_A'}}
 extension MMSuper1 : MMP3b { } // okay
 
-extension MMSub1 : AnyObject { } // expected-error{{redundant conformance of 'MMSub1' to protocol 'AnyObject'}}
+extension MMSub1 : AnyObject { } // expected-warning{{conformance of 'MMSub1' to protocol 'AnyObject' was already stated in the type's module 'placement_module_A'}}
 
-extension MMSub2 : MMP1 { } // expected-error{{redundant conformance of 'MMSub2' to protocol 'MMP1'}}
-extension MMSub2 : MMP2a { } // expected-error{{redundant conformance of 'MMSub2' to protocol 'MMP2a'}}
+extension MMSub2 : MMP1 { } // expected-warning{{conformance of 'MMSub2' to protocol 'MMP1' was already stated in the type's module 'placement_module_A'}}
+extension MMSub2 : MMP2a { } // expected-warning{{conformance of 'MMSub2' to protocol 'MMP2a' was already stated in the type's module 'placement_module_A'}}
 extension MMSub2 : MMP3b { } // okay
 
 extension MMSub2 : MMAnyObjectRefinement { } // okay
 
-extension MMSub3 : MMP1 { } // expected-error{{redundant conformance of 'MMSub3' to protocol 'MMP1'}}
-extension MMSub3 : MMP2a { } // expected-error{{redundant conformance of 'MMSub3' to protocol 'MMP2a'}}
+extension MMSub3 : MMP1 { } // expected-warning{{conformance of 'MMSub3' to protocol 'MMP1' was already stated in the type's module 'placement_module_A'}}
+extension MMSub3 : MMP2a { } // expected-warning{{conformance of 'MMSub3' to protocol 'MMP2a' was already stated in the type's module 'placement_module_A'}}
 extension MMSub3 : MMP3b { } // okay
-extension MMSub3 : AnyObject { } // expected-error{{redundant conformance of 'MMSub3' to protocol 'AnyObject'}}
+extension MMSub3 : AnyObject { } // expected-warning{{conformance of 'MMSub3' to protocol 'AnyObject' was already stated in the type's module 'placement_module_A'}}
 
-extension MMSub4 : MMP1 { } // expected-error{{redundant conformance of 'MMSub4' to protocol 'MMP1'}}
-extension MMSub4 : MMP2a { } // expected-error{{redundant conformance of 'MMSub4' to protocol 'MMP2a'}}
+extension MMSub4 : MMP1 { } // expected-warning{{conformance of 'MMSub4' to protocol 'MMP1' was already stated in the type's module 'placement_module_B'}}
+extension MMSub4 : MMP2a { } // expected-warning{{conformance of 'MMSub4' to protocol 'MMP2a' was already stated in the type's module 'placement_module_B'}}
 extension MMSub4 : MMP3b { } // okay
 extension MMSub4 : AnyObjectRefinement { } // okay

--- a/test/decl/protocol/conforms/redundant_conformance.swift
+++ b/test/decl/protocol/conforms/redundant_conformance.swift
@@ -1,0 +1,32 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+
+// RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/redundant_conformance_A.swift
+// RUN: %target-swift-frontend -emit-module -o %t -I %t %S/Inputs/redundant_conformance_B.swift
+// RUN: %target-typecheck-verify-swift -I %t %s
+
+import redundant_conformance_A
+import redundant_conformance_B
+
+extension ConformsToP
+  : P1 { // expected-warning{{conformance of 'ConformsToP' to protocol 'P1' was already stated in the type's module 'redundant_conformance_A'}}
+  typealias A = Double // expected-note{{type alias 'A' will not be used to satisfy the conformance to 'P1'}}
+
+  func f() -> Double { return 0.0 } // expected-note{{instance method 'f()' will not be used to satisfy the conformance to 'P1'}}
+       // expected-note@-1{{found this candidate}}
+}
+
+extension ConformsToP
+  : P2 { // expected-warning{{conformance of 'ConformsToP' to protocol 'P2' was already stated in the protocol's module 'redundant_conformance_B'}}
+}
+
+extension OtherConformsToP : P1 { // expected-error{{redundant conformance of 'OtherConformsToP' to protocol 'P1'}}
+  func f() -> Int { return 0 }
+}
+
+func testConformsToP(cp1: ConformsToP, ocp1: OtherConformsToP) {
+  // Note:
+  let _ = cp1.f()  // expected-error{{ambiguous use of 'f()'}}
+
+  let _ = ocp1.f() // okay: picks "our" OtherConformsToP.f()
+}


### PR DESCRIPTION
When an extension introduces a conformance that already exists, the
type checker will reject the conformance and then ignore it. In cases
where the original conformance is in the same module as the type or
protocol (but the new, redundant conformance is in some other module),
downgrade this error to a warning. This helps with library-evolution
cases where a library omitted a particular conformance for one of its
own types/protocols in a previous version, then introduces it in a new
version.

The specific driver for this is the conformance of String to
Collection, which affects source compatibility. Fixes
rdar://problem/31104415.