### PR TITLE
Change REQUIRES arguments to work with recent LLVM versions

### DIFF
--- a/test/stdlib/KeyPath.swift
+++ b/test/stdlib/KeyPath.swift
@@ -5,7 +5,7 @@
 // REQUIRES: PTRSIZE=64
 
 // Disabled for now
-// REQUIRES: rdar://problem/31776015
+// REQUIRES: rdar31776015
 
 import StdlibUnittest
 

--- a/test/stdlib/KeyPathImplementation.swift
+++ b/test/stdlib/KeyPathImplementation.swift
@@ -5,7 +5,7 @@
 // REQUIRES: PTRSIZE=64
 
 // Disabled for now
-// REQUIRES: rdar://problem/31776015
+// REQUIRES: rdar31776015
 
 
 import StdlibUnittest

--- a/test/stdlib/KeyPathObjC.swift
+++ b/test/stdlib/KeyPathObjC.swift
@@ -6,7 +6,7 @@
 // REQUIRES: objc_interop
 
 // Disabled for now
-// REQUIRES: rdar://problem/31776015
+// REQUIRES: rdar31776015
 
 import StdlibUnittest
 import Foundation

--- a/validation-test/SIL/verify_all_overlays.sil
+++ b/validation-test/SIL/verify_all_overlays.sil
@@ -2,6 +2,6 @@
 
 // CHECK-NOT: Unknown
 
-// REQUIRES: rdar://problem/31683781
+// REQUIRES: rdar31683781
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test


### PR DESCRIPTION
With more recent versions of LLVM (e.g., used with master-next) the
argument of REQUIRES is parsed as an expression. Do not use "rdar"
URLS for these since it confuses lit.