### PR TITLE
[Migrator] Add Substring -> String conversion fix-it tests

### DIFF
--- a/test/Migrator/Inputs/string_to_substring_conversion.swift
+++ b/test/Migrator/Inputs/string_to_substring_conversion.swift
@@ -1,0 +1,46 @@
+let s = "foo"
+let ss = s[s.startIndex..<s.endIndex]
+
+// CTP_ReturnStmt
+func returnStringButWantedSubstring() -> Substring {
+  return s
+}
+
+// CTP_DefaultParameter
+// Never do this.
+func defaultArgIsSubstring(ss: Substring = s) {}
+
+// CTP_CalleeResult
+func returnString() -> String {
+  return s
+}
+let s2: Substring = returnString()
+
+// CTP_CallArgument
+func takeString(s: String) {}
+func takeSubstring(ss: Substring) {}
+
+takeSubstring(ss)
+takeSubstring(s)
+
+// CTP_ClosureResult
+[1,2,3].map { (x: Int) -> Substring in
+  return s
+}
+
+// CTP_ArrayElement
+let a: [Substring] = [ s ]
+
+// CTP_DictionaryKey
+// CTP_DictionaryValue
+let d: [Substring : Substring] = [
+  "CTP_DictionaryValue" : s,
+  s : "CTP_DictionaryKey",
+]
+
+// CTP_CoerceOperand
+let s3: Substring = s as Substring
+
+// CTP_AssignSource
+let s4: Substring = s
+

--- a/test/Migrator/Inputs/substring_to_string_conversion.swift
+++ b/test/Migrator/Inputs/substring_to_string_conversion.swift
@@ -1,0 +1,46 @@
+let s = "foo"
+let ss = s[s.startIndex..<s.endIndex]
+
+// CTP_ReturnStmt
+
+func returnSubstringButWantedString() -> String {
+  return ss
+}
+
+// CTP_DefaultParameter
+
+// Never do this.
+func defaultArgIsString(s: String = ss) {}
+
+// CTP_CalleeResult
+func returnSubstring() -> Substring {
+  return ss
+}
+let s2: String = returnSubstring()
+
+// CTP_CallArgument
+func takeString(_ s: String) {}
+
+takeString(s)
+takeString(ss)
+
+// CTP_ClosureResult
+[1,2,3].map { (x: Int) -> String in
+  return ss
+}
+
+// CTP_ArrayElement
+let a: [String] = [ ss ]
+
+// CTP_DictionaryKey
+// CTP_DictionaryValue
+let d: [String : String] = [
+  "CTP_DictionaryValue" : ss,
+  ss : "CTP_DictionaryKey",
+]
+
+// CTP_CoerceOperand
+let s3: String = ss as String
+
+// CTP_AssignSource
+let s4: String = ss

--- a/test/Migrator/string_to_substring_conversion.swift
+++ b/test/Migrator/string_to_substring_conversion.swift
@@ -1,0 +1,3 @@
+// RUN: rm -rf %t && mkdir -p %t && %target-swift-frontend -c -update-code -primary-file %S/Inputs/string_to_substring_conversion.swift -emit-migrated-file-path %t/string_to_substring_conversion.swift.result -swift-version 4
+// RUN: diff -u %S/string_conversion.swift.expected %t/string_to_substring_conversion.swift.result
+// XFAIL: *

--- a/test/Migrator/string_to_substring_conversion.swift.expected
+++ b/test/Migrator/string_to_substring_conversion.swift.expected
@@ -1,0 +1,46 @@
+let s = "foo"
+let ss = s[s.startIndex..<s.endIndex]
+
+// CTP_ReturnStmt
+func returnStringButWantedSubstring() -> Substring {
+  return s[]
+}
+
+// CTP_DefaultParameter
+// Never do this.
+func defaultArgIsSubstring(ss: Substring = s[]) {}
+
+// CTP_CalleeResult
+func returnString() -> String {
+  return s[]
+}
+let s2: Substring = returnString()[]
+
+// CTP_CallArgument
+func takeString(s: String) {}
+func takeSubstring(ss: Substring) {}
+
+takeSubstring(ss)
+takeSubstring(s[])
+
+// CTP_ClosureResult
+[1,2,3].map { (x: Int) -> Substring in
+  return s[]
+}
+
+// CTP_ArrayElement
+let a: [Substring] = [ s[] ]
+
+// CTP_DictionaryKey
+// CTP_DictionaryValue
+let d: [Substring : Substring] = [
+  "CTP_DictionaryValue" : s[],
+  s[] : "CTP_DictionaryKey",
+]
+
+// CTP_CoerceOperand
+let s3: Substring = s[] as Substring
+
+// CTP_AssignSource
+let s4: Substring = s[]
+

--- a/test/Migrator/substring_to_string_conversion.swift
+++ b/test/Migrator/substring_to_string_conversion.swift
@@ -1,0 +1,3 @@
+// RUN: rm -rf %t && mkdir -p %t && %target-swift-frontend -c -update-code -primary-file %S/Inputs/substring_to_string_conversion.swift -emit-migrated-file-path %t/substring_to_string_conversion.swift.result -swift-version 4
+// RUN: diff -u %S/substring_to_string_conversion.swift.expected %t/substring_to_string_conversion.swift.result
+// XFAIL: *

--- a/test/Migrator/substring_to_string_conversion.swift.expected
+++ b/test/Migrator/substring_to_string_conversion.swift.expected
@@ -1,0 +1,47 @@
+let s = "foo"
+let ss = s[s.startIndex..<s.endIndex]
+
+// CTP_ReturnStmt
+
+func returnSubstringButWantedString() -> String {
+  return String(ss)
+}
+
+// CTP_DefaultParameter
+
+// Never do this.
+func defaultArgIsString(s: String = String(ss)) {}
+
+// CTP_CalleeResult
+func returnSubstring() -> Substring {
+  return String(ss)
+}
+let s2: String = String(returnSubstring())
+
+// CTP_CallArgument
+func takeString(s: String) {}
+func takeSubstring(ss: Substring) {}
+
+takeString(string)
+takeString(String(substring))
+
+// CTP_ClosureResult
+[1,2,3].map { (x: Int) -> String in
+  return String(ss)
+}
+
+// CTP_ArrayElement
+let a: [String] = [ String(ss) ]
+
+// CTP_DictionaryKey
+// CTP_DictionaryValue
+let d: [String : String] = [
+  "CTP_DictionaryValue" : String(ss),
+  String(ss) : "CTP_DictionaryKey",
+]
+
+// CTP_CoerceOperand
+let s3: String = String(ss) as String
+
+// CTP_AssignSource
+let s4: String = String(ss)


### PR DESCRIPTION
There is no implicit conversion between String and Substring, so
the migrator can offer fix-its to convert between the two by wrapping
in String.init or adding the void subscript [] accordingly. This
commit just adds the tests for migration for the time being.

rdar://problem/30928902