### PR TITLE
[SE-0160] Make deprecated @objc inference warnings opt-in.

### DIFF
--- a/cmake/modules/SwiftSource.cmake
+++ b/cmake/modules/SwiftSource.cmake
@@ -278,7 +278,7 @@ function(_compile_swift_files
   endif()
 
   if (SWIFTFILE_IS_STDLIB_CORE OR SWIFTFILE_IS_SDK_OVERLAY)
-    list(APPEND swift_flags "-warn-swift3-objc-inference")
+    list(APPEND swift_flags "-warn-swift3-objc-inference-complete")
   endif()
 
   list(APPEND swift_flags ${SWIFT_EXPERIMENTAL_EXTRA_FLAGS})

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -46,6 +46,19 @@ namespace swift {
   };
   enum { NumPlatformConditionKind = 4 };
 
+  /// Describes which Swift 3 Objective-C inference warnings should be
+  /// emitted.
+  enum class Swift3ObjCInferenceWarnings {
+    /// No warnings; this is the default.
+    None,
+    /// "Minimal" warnings driven by uses of declarations that make use of
+    /// the Objective-C entry point directly.
+    Minimal,
+    /// "Complete" warnings that add "@objc" for every entry point that
+    /// Swift 3 would have inferred as "@objc" but Swift 4 will not.
+    Complete,
+  };
+
   /// \brief A collection of options that affect the language dialect and
   /// provide compiler debugging facilities.
   class LangOptions {
@@ -212,7 +225,8 @@ namespace swift {
 
     /// Warn about cases where Swift 3 would infer @objc but later versions
     /// of Swift do not.
-    bool WarnSwift3ObjCInference = false;
+    Swift3ObjCInferenceWarnings WarnSwift3ObjCInference =
+      Swift3ObjCInferenceWarnings::None;
     
     /// Enable keypaths.
     bool EnableExperimentalKeyPaths = false;

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -285,9 +285,19 @@ def continue_building_after_errors : Flag<["-"], "continue-building-after-errors
   Flags<[FrontendOption, DoesNotAffectIncrementalBuild]>,
   HelpText<"Continue building, even after errors are encountered">;
 
-def warn_swift3_objc_inference : Flag<["-"], "warn-swift3-objc-inference">,
+def warn_swift3_objc_inference_complete :
+  Flag<["-"], "warn-swift3-objc-inference-complete">,
   Flags<[FrontendOption, DoesNotAffectIncrementalBuild]>,
-  HelpText<"Warn about deprecated @objc inference in Swift 3">;
+  HelpText<"Warn about deprecated @objc inference in Swift 3 for every declaration that will no longer be inferred as @objc in Swift 4">;
+
+def warn_swift3_objc_inference_minimal :
+  Flag<["-"], "warn-swift3-objc-inference-minimal">,
+  Flags<[FrontendOption, DoesNotAffectIncrementalBuild]>,
+  HelpText<"Warn about deprecated @objc inference in Swift 3 based on direct uses of the Objective-C entrypoint">;
+
+def warn_swift3_objc_inference : Flag<["-"], "warn-swift3-objc-inference">,
+  Alias<warn_swift3_objc_inference_complete>,
+  Flags<[FrontendOption, DoesNotAffectIncrementalBuild, HelpHidden]>;
 
 // Platform options.
 def enable_app_extension : Flag<["-"], "application-extension">,

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1011,12 +1011,22 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   }
 
   Opts.EnableAppExtensionRestrictions |= Args.hasArg(OPT_enable_app_extension);
-  Opts.WarnSwift3ObjCInference |= Args.hasArg(OPT_warn_swift3_objc_inference);
 
   Opts.EnableSwift3ObjCInference =
     Args.hasFlag(OPT_enable_swift3_objc_inference,
                  OPT_disable_swift3_objc_inference,
                  Opts.isSwiftVersion3());
+
+  if (Opts.EnableSwift3ObjCInference) {
+    if (const Arg *A = Args.getLastArg(
+                                   OPT_warn_swift3_objc_inference_minimal,
+                                   OPT_warn_swift3_objc_inference_complete)) {
+      if (A->getOption().getID() == OPT_warn_swift3_objc_inference_minimal)
+        Opts.WarnSwift3ObjCInference = Swift3ObjCInferenceWarnings::Minimal;
+      else
+        Opts.WarnSwift3ObjCInference = Swift3ObjCInferenceWarnings::Complete;
+    }
+  }
 
   llvm::Triple Target = Opts.Target;
   StringRef TargetArg;

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -949,7 +949,8 @@ namespace {
         // complain.
         if (auto attr = member->getAttrs().getAttribute<ObjCAttr>()) {
           if (attr->isSwift3Inferred() &&
-              !tc.Context.LangOpts.WarnSwift3ObjCInference) {
+              tc.Context.LangOpts.WarnSwift3ObjCInference
+                == Swift3ObjCInferenceWarnings::Minimal) {
             tc.diagnose(memberLoc,
                         diag::expr_dynamic_lookup_swift3_objc_inference,
                         member->getDescriptiveKind(),
@@ -3954,7 +3955,8 @@ namespace {
         // If this attribute was inferred based on deprecated Swift 3 rules,
         // complain.
         if (attr->isSwift3Inferred() &&
-            !tc.Context.LangOpts.WarnSwift3ObjCInference) {
+            tc.Context.LangOpts.WarnSwift3ObjCInference
+              == Swift3ObjCInferenceWarnings::Minimal) {
           tc.diagnose(E->getLoc(), diag::expr_selector_swift3_objc_inference,
                       foundDecl->getDescriptiveKind(), foundDecl->getFullName(),
                       foundDecl->getDeclContext()

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2416,7 +2416,9 @@ static Optional<ObjCReason> shouldMarkAsObjC(TypeChecker &TC,
     if (TC.Context.LangOpts.EnableSwift3ObjCInference) {
       // If we've been asked to warn about deprecated @objc inference, do so
       // now.
-      if (TC.Context.LangOpts.WarnSwift3ObjCInference && !isAccessor) {
+      if (TC.Context.LangOpts.WarnSwift3ObjCInference !=
+            Swift3ObjCInferenceWarnings::None &&
+          !isAccessor) {
         TC.diagnose(VD, diag::objc_inference_swift3_dynamic)
           .highlight(attr->getLocation())
           .fixItInsert(VD->getAttributeInsertionLoc(/*forModifier=*/false),
@@ -2845,7 +2847,8 @@ void swift::markAsObjC(TypeChecker &TC, ValueDecl *D,
     // If we've been asked to unconditionally warn about these deprecated
     // @objc inference rules, do so now. However, we don't warn about
     // accessors---just the main storage declarations.
-    if (TC.Context.LangOpts.WarnSwift3ObjCInference &&
+    if (TC.Context.LangOpts.WarnSwift3ObjCInference ==
+          Swift3ObjCInferenceWarnings::Complete &&
         !(isa<FuncDecl>(D) && cast<FuncDecl>(D)->isGetterOrSetter())) {
       TC.diagnose(D, diag::objc_inference_swift3_objc_derived);
       TC.diagnose(D, diag::objc_inference_swift3_addobjc)
@@ -6136,7 +6139,8 @@ public:
 
       // When warning about all deprecated @objc inference rules,
       // we only need to do this check if we have implicit 'dynamic'.
-      if (TC.Context.LangOpts.WarnSwift3ObjCInference) {
+      if (TC.Context.LangOpts.WarnSwift3ObjCInference !=
+            Swift3ObjCInferenceWarnings::None) {
         if (auto dynamicAttr = Base->getAttrs().getAttribute<DynamicAttr>())
           if (!dynamicAttr->isImplicit()) return;
       }

--- a/lib/Sema/TypeCheckExprObjC.cpp
+++ b/lib/Sema/TypeCheckExprObjC.cpp
@@ -333,7 +333,8 @@ Optional<Type> TypeChecker::checkObjCKeyPathExpr(DeclContext *dc,
         // If this attribute was inferred based on deprecated Swift 3 rules,
         // complain.
         if (attr->isSwift3Inferred() &&
-            !Context.LangOpts.WarnSwift3ObjCInference) {
+            Context.LangOpts.WarnSwift3ObjCInference ==
+              Swift3ObjCInferenceWarnings::Minimal) {
           diagnose(componentNameLoc, diag::expr_keypath_swift3_objc_inference,
                    var->getFullName(),
                    var->getDeclContext()

--- a/test/attr/attr_objc_swift3_deprecated.swift
+++ b/test/attr/attr_objc_swift3_deprecated.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -disable-objc-attr-requires-foundation-module -typecheck -verify %s -swift-version 3 -warn-swift3-objc-inference
+// RUN: %target-swift-frontend -disable-objc-attr-requires-foundation-module -typecheck -verify %s -swift-version 3 -warn-swift3-objc-inference-complete
 // REQUIRES: objc_interop
 
 import Foundation

--- a/test/attr/attr_objc_swift3_deprecated_uses.swift
+++ b/test/attr/attr_objc_swift3_deprecated_uses.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -disable-objc-attr-requires-foundation-module -typecheck -verify %s -swift-version 3
+// RUN: %target-swift-frontend -disable-objc-attr-requires-foundation-module -typecheck -verify %s -swift-version 3 -warn-swift3-objc-inference-minimal
 // REQUIRES: objc_interop
 
 import Foundation
@@ -30,9 +30,9 @@ class ObjCSubclass : NSObject {
 }
 
 class DynamicMembers {
-  dynamic func foo() { }
+  dynamic func foo() { } // expected-warning{{inference of '@objc' for 'dynamic' members is deprecated}}{{3-3=@objc }}
   
-  dynamic var bar: NSObject? = nil
+  dynamic var bar: NSObject? = nil // expected-warning{{inference of '@objc' for 'dynamic' members is deprecated}}{{3-3=@objc }}
 
   func overridableFunc() { }
   var overridableVar: NSObject? = nil


### PR DESCRIPTION
The warnings about deprecated @objc inference in Swift 3 mode can be a
bit annoying; and are mostly relevant to the migration workflow. Make
the warning emission a three-state switch:

* None (the default): don't warn about these issues.
* Minimal (`-warn-swift3-objc-inference-minimal`): warn about direct
  uses of Objective-C entrypoints and provide `@objc` Fix-Its for them.
* Complete (`-warn-swift3-objc-inference-complete`): warn about all
  cases where Swift 3 infers `@objc` but Swift 4 will not.

Fixes rdar://problem/31922278.
