### PR TITLE
[strip -ST] Disable runtime stack trace dumping on Darwin when asserts are disabled.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -416,6 +416,7 @@ include(AddSwift)
 include(SwiftConfigureSDK)
 include(SwiftComponents)
 include(SwiftList)
+include(AddSwiftRuntime)
 
 # Configure swift include, install, build components.
 swift_configure_components()
@@ -785,6 +786,17 @@ if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
   set(CMAKE_OSX_DEPLOYMENT_TARGET "")
 endif()
 
+swift_runtime_enable_backtrace_reporting(SWIFT_RUNTIME_ENABLE_BACKTRACE_REPORTING_default)
+set(SWIFT_RUNTIME_ENABLE_BACKTRACE_REPORTING
+    ${SWIFT_RUNTIME_ENABLE_BACKTRACE_REPORTING_default}
+    CACHE BOOL "Enable simple backtrace printing using dladdr")
+set(SWIFT_RUNTIME_DLADDR_ALLOWED
+    ${SWIFT_RUNTIME_ENABLE_BACKTRACE_REPORTING_default}
+    CACHE BOOL "Is dladdr allowed to be used in the code base. Must be TRUE if SWIFT_RUNTIME_ENABLE_BACKTRACE_REPORTING is set to TRUE")
+if ("${SWIFT_RUNTIME_ENABLE_BACKTRACE_REPORTING}" AND NOT "${SWIFT_RUNTIME_DLADDR_ALLOWED}")
+  message(FATAL "Can not enable backtrace reporting without allowing dladdr to be used by the runtime")
+endif()
+
 message(STATUS "Building host Swift tools for ${SWIFT_HOST_VARIANT_SDK} ${SWIFT_HOST_VARIANT_ARCH}")
 message(STATUS "  Build type: ${CMAKE_BUILD_TYPE}")
 message(STATUS "  Assertions: ${LLVM_ENABLE_ASSERTIONS}")
@@ -798,6 +810,8 @@ message(STATUS "")
 
 message(STATUS "Building Swift runtime with:")
 message(STATUS "  Leak Detection Checker Entrypoints: ${SWIFT_RUNTIME_ENABLE_LEAK_CHECKER}")
+message(STATUS "  Backtraces:                         ${SWIFT_RUNTIME_ENABLE_BACKTRACE_REPORTING}")
+message(STATUS "  DLAddr Allowed:                     ${SWIFT_RUNTIME_DLADDR_ALLOWED}")
 message(STATUS "")
 
 #

--- a/cmake/modules/AddSwiftRuntime.cmake
+++ b/cmake/modules/AddSwiftRuntime.cmake
@@ -1,0 +1,52 @@
+#===--- AddSwiftRuntime.cmake --------------------------------------------===#
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https:#swift.org/LICENSE.txt for license information
+# See https:#swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+#===----------------------------------------------------------------------===#
+
+include(SwiftUtils)
+
+function(swift_runtime_enable_backtrace_reporting outvar)
+  precondition(outvar "Must have an outvar set")
+
+  # We do not support backtraces on android...
+  is_sdk_requested(ANDROID swift_build_android)
+  if(${swift_build_android})
+    set(${outvar} FALSE PARENT_SCOPE)
+    return()
+  endif()
+
+  # ... or cygwin
+  if ("${CMAKE_SYSTEM_NAME}" STREQUAL "CYGWIN")
+    set(${outvar} FALSE PARENT_SCOPE)
+    return()
+  endif()
+
+  # ... or win32.
+  if (WIN32)
+    set(${outvar} FALSE PARENT_SCOPE)
+    return()
+  endif()
+
+  # If we are not Darwin, but are cygwin, win32, or android we *do* support
+  # runtime backtraces. This is just preserving the current existing
+  # behavior. Arguably this should be an opt in feature always.
+  if (NOT "${CMAKE_SYSTEM_NAME}" STREQUAL Darwin)
+    set(${outvar} TRUE PARENT_SCOPE)
+    return()
+  endif()
+
+  # Otherwise, we have a Darwin build. Enable runtime backtrace reporting only
+  # when compiler assertions are enabled.
+  if ("${SWIFT_STDLIB_ASSERTIONS}")
+    set(${outvar} TRUE PARENT_SCOPE)
+  else()
+    set(${outvar} FALSE PARENT_SCOPE)
+  endif()
+endfunction()

--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -23,6 +23,22 @@ if(SWIFT_RUNTIME_ENABLE_COW_EXISTENTIALS)
     "-DSWIFT_RUNTIME_ENABLE_COW_EXISTENTIALS=1")
 endif()
 
+if(SWIFT_RUNTIME_ENABLE_BACKTRACE_REPORTING)
+  list(APPEND swift_runtime_compile_flags
+    "-DSWIFT_RUNTIME_ENABLE_BACKTRACE_REPORTING=1")
+else()
+  list(APPEND swift_runtime_compile_flags
+    "-DSWIFT_RUNTIME_ENABLE_BACKTRACE_REPORTING=0")
+endif()
+
+if(SWIFT_RUNTIME_DLADDR_ALLOWED)
+  list(APPEND swift_runtime_compile_flags
+    "-DSWIFT_RUNTIME_DLADDR_ALLOW=1")
+else()
+  list(APPEND swift_runtime_compile_flags
+    "-DSWIFT_RUNTIME_DLADDR_ALLOW=0")
+endif()
+
 set(section_magic_compile_flags ${swift_runtime_compile_flags})
 
 list(APPEND swift_runtime_compile_flags
@@ -93,13 +109,18 @@ if(SWIFT_BUILD_STATIC_STDLIB AND "${sdk}" STREQUAL "LINUX")
   string(TOLOWER "${sdk}" lowercase_sdk)
 
   # These two libraries are only used with the static swiftcore
-  add_library(swiftImageInspectionStatic STATIC
-              ImageInspectionStatic.cpp
-              StaticBinaryELF.cpp)
+  add_swift_library(swiftImageInspectionStatic STATIC
+    ImageInspectionStatic.cpp
+    StaticBinaryELF.cpp
+    C_COMPILE_FLAGS ${swift_runtime_library_compile_flags}
+    LINK_FLAGS ${swift_runtime_linker_flags})
   set_target_properties(swiftImageInspectionStatic PROPERTIES
     ARCHIVE_OUTPUT_DIRECTORY "${SWIFTSTATICLIB_DIR}/${lowercase_sdk}")
 
-  add_library(swiftImageInspectionShared STATIC ImageInspectionELF.cpp)
+  add_swift_library(swiftImageInspectionShared STATIC
+    ImageInspectionELF.cpp
+    C_COMPILE_FLAGS ${swift_runtime_library_compile_flags}
+    LINK_FLAGS ${swift_runtime_linker_flags})
   set_target_properties(swiftImageInspectionShared PROPERTIES
     ARCHIVE_OUTPUT_DIRECTORY "${SWIFTSTATICLIB_DIR}/${lowercase_sdk}")
 

--- a/stdlib/public/runtime/Errors.cpp
+++ b/stdlib/public/runtime/Errors.cpp
@@ -14,12 +14,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if defined(__CYGWIN__) || defined(__ANDROID__) || defined(_WIN32)
-#  define SWIFT_SUPPORTS_BACKTRACE_REPORTING 0
-#else
-#  define SWIFT_SUPPORTS_BACKTRACE_REPORTING 1
-#endif
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -40,7 +34,11 @@
 #include <cxxabi.h>
 #endif
 
-#if SWIFT_SUPPORTS_BACKTRACE_REPORTING
+#ifndef SWIFT_RUNTIME_ENABLE_BACKTRACE_REPORTING
+#error "SWIFT_RUNTIME_ENABLE_BACKTRACE_REPORTING must be defined"
+#endif
+
+#if SWIFT_RUNTIME_ENABLE_BACKTRACE_REPORTING
 // execinfo.h is not available on Android. Checks in this file ensure that
 // fatalError behaves as expected, but without stack traces.
 #include <execinfo.h>
@@ -58,7 +56,7 @@ enum: uint32_t {
 
 using namespace swift;
 
-#if SWIFT_SUPPORTS_BACKTRACE_REPORTING
+#if SWIFT_RUNTIME_ENABLE_BACKTRACE_REPORTING
 
 static bool getSymbolNameAddr(llvm::StringRef libraryName, SymbolInfo syminfo,
                               std::string &symbolName, uintptr_t &addrOut) {
@@ -207,7 +205,7 @@ reportNow(uint32_t flags, const char *message)
 #ifdef __APPLE__
   asl_log(nullptr, nullptr, ASL_LEVEL_ERR, "%s", message);
 #endif
-#if SWIFT_SUPPORTS_BACKTRACE_REPORTING
+#if SWIFT_RUNTIME_ENABLE_BACKTRACE_REPORTING
   if (flags & FatalErrorFlags::ReportBacktrace) {
     fputs("Current stack trace:\n", stderr);
     constexpr unsigned maxSupportedStackDepth = 128;

--- a/stdlib/public/runtime/ImageInspectionELF.cpp
+++ b/stdlib/public/runtime/ImageInspectionELF.cpp
@@ -27,6 +27,10 @@
 #include <link.h>
 #include <string.h>
 
+#ifndef SWIFT_RUNTIME_DLADDR_ALLOW
+#error "SWIFT_RUNTIME_DLADDR_ALLOW must be defined!"
+#endif
+
 using namespace swift;
 
 /// The symbol name in the image that identifies the beginning of the
@@ -158,6 +162,7 @@ void swift_addNewDSOImage(const void *addr) {
 }
 
 int swift::lookupSymbol(const void *address, SymbolInfo *info) {
+#if SWIFT_RUNTIME_DLADDR_ALLOW
   Dl_info dlinfo;
   if (dladdr(address, &dlinfo) == 0) {
     return 0;
@@ -168,6 +173,9 @@ int swift::lookupSymbol(const void *address, SymbolInfo *info) {
   info->symbolName = dlinfo.dli_sname;
   info->symbolAddress = dlinfo.dli_saddr;
   return 1;
+#else
+  return 0;
+#endif
 }
 
 #endif // defined(__ELF__) || defined(__ANDROID__)

--- a/stdlib/public/runtime/ImageInspectionMachO.cpp
+++ b/stdlib/public/runtime/ImageInspectionMachO.cpp
@@ -26,6 +26,10 @@
 #include <assert.h>
 #include <dlfcn.h>
 
+#ifndef SWIFT_RUNTIME_DLADDR_ALLOW
+#error "SWIFT_RUNTIME_DLADDR_ALLOW must be defined"
+#endif
+
 using namespace swift;
 
 namespace {
@@ -74,6 +78,7 @@ void swift::initializeTypeMetadataRecordLookup() {
 }
 
 int swift::lookupSymbol(const void *address, SymbolInfo *info) {
+#if SWIFT_RUNTIME_DLADDR_ALLOW
   Dl_info dlinfo;
   if (dladdr(address, &dlinfo) == 0) {
     return 0;
@@ -84,6 +89,9 @@ int swift::lookupSymbol(const void *address, SymbolInfo *info) {
   info->symbolName = dlinfo.dli_sname;
   info->symbolAddress = dlinfo.dli_saddr;
   return 1;
+#else
+  return 0;
+#endif
 }
 
 #endif // defined(__APPLE__) && defined(__MACH__)

--- a/stdlib/public/runtime/ImageInspectionWin32.cpp
+++ b/stdlib/public/runtime/ImageInspectionWin32.cpp
@@ -33,6 +33,10 @@
 #include <dlfcn.h>
 #endif
 
+#ifndef SWIFT_RUNTIME_DLADDR_ALLOW
+#error "SWIFT_RUNTIME_DLADDR_ALLOW must be defined!"
+#endif
+
 using namespace swift;
 
 /// PE section name for the section that contains protocol conformance records.
@@ -219,7 +223,7 @@ void swift::initializeTypeMetadataRecordLookup() {
 
 
 int swift::lookupSymbol(const void *address, SymbolInfo *info) {
-#if defined(__CYGWIN__)
+#if defined(__CYGWIN__) || SWIFT_RUNTIME_DLADDR_ALLOW
   Dl_info dlinfo;
   if (dladdr(address, &dlinfo) == 0) {
     return 0;

--- a/test/Runtime/crash_with_backtrace.swift
+++ b/test/Runtime/crash_with_backtrace.swift
@@ -8,11 +8,15 @@
 // UNSUPPORTED: OS=ios
 // UNSUPPORTED: OS=tvos
 
+// REQUIRES: runtime-dladdr-backtraces
 // REQUIRES: executable_test
 
 // Backtraces are not emitted when optimizations are enabled. This test can not
 // run when optimizations are enabled.
 // REQUIRES: swift_test_mode_optimize_none
+
+// This file just causes a crash in the runtime to check whether or not a stack
+// trace is produced from the runtime.
 
 func main() {
   let x = UnsafePointer<Int>(bitPattern: 0)!

--- a/test/Runtime/crash_without_backtrace.swift
+++ b/test/Runtime/crash_without_backtrace.swift
@@ -1,0 +1,22 @@
+// RUN: rm -rf %t
+// RUN: mkdir %t
+// RUN: %target-build-swift %s -o %t/out
+// RUN: not --crash %t/out 2>&1 | %FileCheck %s
+
+// UNSUPPORTED: OS=watchos
+// UNSUPPORTED: OS=ios
+// UNSUPPORTED: OS=tvos
+// UNSUPPORTED: runtime-dladdr-backtraces
+
+// This file just causes a crash in the runtime to check whether or not a stack
+// trace is produced from the runtime.
+
+// CHECK-NOT: Current stack trace:
+
+import Swift
+
+func foo() -> Int {
+  return UnsafePointer<Int>(bitPattern: 0)!.pointee
+}
+
+foo()

--- a/test/Runtime/crash_without_backtrace_optimized.swift
+++ b/test/Runtime/crash_without_backtrace_optimized.swift
@@ -1,0 +1,24 @@
+// RUN: rm -rf %t
+// RUN: mkdir %t
+// RUN: %target-build-swift -O %s -o %t/out
+// RUN: not --crash %t/out 2>&1 | %FileCheck %s
+
+// UNSUPPORTED: OS=watchos
+// UNSUPPORTED: OS=ios
+// UNSUPPORTED: OS=tvos
+
+// This file just causes a crash in the runtime to check whether or not a stack
+// trace is produced from the runtime.
+//
+// It checks that no matter what when we compile with optimization, we do not
+// emit backtraces.
+
+// CHECK-NOT: Current stack trace:
+
+import Swift
+
+func foo() -> Int {
+  return UnsafePointer<Int>(bitPattern: 0)!.pointee
+}
+
+foo()

--- a/test/Runtime/linux-fatal-backtrace.swift
+++ b/test/Runtime/linux-fatal-backtrace.swift
@@ -5,6 +5,7 @@
 // REQUIRES: executable_test
 // REQUIRES: OS=linux-gnu
 // REQUIRES: lldb
+// REQUIRES: runtime-dladdr-backtraces
 
 // Backtraces are not emitted when optimizations are enabled. This test can not
 // run when optimizations are enabled.

--- a/test/lit.site.cfg.in
+++ b/test/lit.site.cfg.in
@@ -83,6 +83,11 @@ if "@CMAKE_GENERATOR@" == "Xcode":
 
 config.available_features.add("CMAKE_GENERATOR=@CMAKE_GENERATOR@")
 
+if "@SWIFT_RUNTIME_ENABLE_BACKTRACE_REPORTING@" == "TRUE":
+    config.available_features.add('runtime-dladdr-backtraces')
+if "@SWIFT_RUNTIME_DLADDR_ALLOWED@" == "TRUE":
+    config.available_features.add('runtime-dladdr')
+
 if "@SWIFT_ENABLE_SOURCEKIT_TESTS@" == "TRUE":
     config.available_features.add('sourcekit')
 

--- a/unittests/runtime/CMakeLists.txt
+++ b/unittests/runtime/CMakeLists.txt
@@ -1,9 +1,9 @@
 if(("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "${SWIFT_PRIMARY_VARIANT_SDK}") AND
    ("${SWIFT_HOST_VARIANT_ARCH}" STREQUAL "${SWIFT_PRIMARY_VARIANT_ARCH}"))
 
+  set(swift_runtime_test_extra_libraries)
   if(SWIFT_BUILD_STATIC_STDLIB AND "${SWIFT_HOST_VARIANT_SDK}" STREQUAL "LINUX")
-    set(swift_runtime_test_extra_sources
-      "${CMAKE_CURRENT_SOURCE_DIR}/../../stdlib/public/runtime/ImageInspectionELF.cpp")
+    list(APPEND swift_runtime_test_extra_libraries swiftImageInspectionShared)
   endif()
 
   add_subdirectory(LongTests)
@@ -43,13 +43,13 @@ if(("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "${SWIFT_PRIMARY_VARIANT_SDK}") AND
     # from the swiftCore dylib, so we need to link to both the runtime archive
     # and the stdlib.
     $<TARGET_OBJECTS:swiftRuntime${SWIFT_PRIMARY_VARIANT_SUFFIX}>
-    ${swift_runtime_test_extra_sources}
     )
 
   # FIXME: cross-compile for all variants.
   target_link_libraries(SwiftRuntimeTests
     swiftCore${SWIFT_PRIMARY_VARIANT_SUFFIX}
     ${PLATFORM_TARGET_LINK_LIBRARIES}
+    ${swift_runtime_test_extra_libraries}
     )
 endif()
 

--- a/unittests/runtime/LongTests/CMakeLists.txt
+++ b/unittests/runtime/LongTests/CMakeLists.txt
@@ -36,13 +36,13 @@ if(("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "${SWIFT_PRIMARY_VARIANT_SDK}") AND
     # from the swiftCore dylib, so we need to link to both the runtime archive
     # and the stdlib.
     $<TARGET_OBJECTS:swiftRuntime${SWIFT_PRIMARY_VARIANT_SUFFIX}>
-    ${swift_runtime_test_extra_sources}
     )
 
   # FIXME: cross-compile for all variants.
   target_link_libraries(SwiftRuntimeLongTests
     swiftCore${SWIFT_PRIMARY_VARIANT_SUFFIX}
     ${PLATFORM_TARGET_LINK_LIBRARIES}
+    ${swift_runtime_test_extra_libraries}
     )
 endif()
 

--- a/validation-test/BuildSystem/RuntimeBacktraces/object-files-do-not-reference-dladdr.test-sh
+++ b/validation-test/BuildSystem/RuntimeBacktraces/object-files-do-not-reference-dladdr.test-sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# This test makes sure that our object files do not reference any of the black
+# listed symbols.
+
+set -e
+set -u
+
+# REQUIRES: OS=macosx
+# UNSUPPORTED: runtime-dladdr
+# RUN: %s %swift_obj_root
+
+BLACKLIST=( dladdr )
+
+FOUND_VIOLATION=0
+for f in $(find $1/stdlib -iname '*.o' -type f); do
+    for t in "${BLACKLIST[@]}"; do
+        if nm -u "${f}" | grep -q "${t}"; then
+            echo "${f} reference black listed symbol: ${t}!"
+            if [[ "${FOUND_VIOLATION}" -eq 0 ]]; then
+                FOUND_VIOLATION=1
+            fi
+        fi
+    done
+done
+
+if [[ "${FOUND_VIOLATION}" -eq 1 ]]; then
+    echo "Error!"
+    exit 1
+fi
+echo "Did not find any blacklisted symbols!"
+
+set +u
+set +e

--- a/validation-test/lit.site.cfg.in
+++ b/validation-test/lit.site.cfg.in
@@ -83,6 +83,11 @@ if "@CMAKE_GENERATOR@" == "Xcode":
 
 config.available_features.add("CMAKE_GENERATOR=@CMAKE_GENERATOR@")
 
+if "@SWIFT_RUNTIME_ENABLE_BACKTRACE_REPORTING@" == "TRUE":
+    config.available_features.add('runtime-dladdr-backtraces')
+if "@SWIFT_RUNTIME_DLADDR_ALLOWED@" == "TRUE":
+    config.available_features.add('runtime-dladdr')
+
 # Let the main config do the real work.
 config.test_exec_root = os.path.dirname(os.path.realpath(__file__))
 lit_config.load_config(config, "@SWIFT_SOURCE_DIR@/validation-test/lit.cfg")


### PR DESCRIPTION
[strip -ST] Disable runtime stack trace dumping on Darwin when asserts are disabled.

This commit disables runtime stack trace dumping via dladdr on Darwin when
stdlib asserts are disabled.

This stack trace dumping was added as a way to improve the ability to debug the
compiler for compiler developers. This is all well and good but having such a
feature always enabled prevents us from reducing the size of the swift standard
library by eliminating the swift nlist.

rdar://31372220