### PR TITLE
SIL: Don't DFE functions referenced from KeyPath patterns.

### DIFF
--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -1599,6 +1599,9 @@ public:
                                    getter, setter, indices, ty);
   }
   
+  void incrementRefCounts() const;
+  void decrementRefCounts() const;
+  
   void Profile(llvm::FoldingSetNodeID &ID);
 };
 
@@ -1696,6 +1699,7 @@ class KeyPathInst final
   
 public:
   KeyPathPattern *getPattern() const;
+  bool hasPattern() const { return (bool)Pattern; }
 
   ArrayRef<Operand> getAllOperands() const {
     // TODO: Subscript keypaths will have operands.
@@ -1711,6 +1715,8 @@ public:
   static bool classof(const ValueBase *V) {
     return V->getKind() == ValueKind::KeyPathInst;
   }
+  
+  void dropReferencedPattern();
   
   ~KeyPathInst();
 };

--- a/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
+++ b/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
@@ -192,6 +192,46 @@ protected:
 
   }
   
+  /// Marks the declarations referenced by a key path pattern as alive if they
+  /// aren't yet.
+  void ensureKeyPathComponentsAreAlive(KeyPathPattern *KP) {
+    for (auto &component : KP->getComponents()) {
+      switch (component.getKind()) {
+      case KeyPathPatternComponent::Kind::SettableProperty:
+        ensureAlive(component.getComputedPropertySetter());
+        LLVM_FALLTHROUGH;
+      case KeyPathPatternComponent::Kind::GettableProperty: {
+        ensureAlive(component.getComputedPropertyGetter());
+        auto id = component.getComputedPropertyId();
+        switch (id.getKind()) {
+        case KeyPathPatternComponent::ComputedPropertyId::DeclRef: {
+          auto decl = cast<AbstractFunctionDecl>(id.getDeclRef().getDecl());
+          if (auto clas = dyn_cast<ClassDecl>(decl->getDeclContext())) {
+            ensureAliveClassMethod(getMethodInfo(decl, /*witness*/ false),
+                                   dyn_cast<FuncDecl>(decl),
+                                   clas);
+          } else if (auto proto =
+                       dyn_cast<ProtocolDecl>(decl->getDeclContext())) {
+            ensureAliveProtocolMethod(getMethodInfo(decl, /*witness*/ true));
+          } else {
+            llvm_unreachable("key path keyed by a non-class, non-protocol method");
+          }
+          break;
+        }
+        case KeyPathPatternComponent::ComputedPropertyId::Function:
+          ensureAlive(id.getFunction());
+          break;
+        case KeyPathPatternComponent::ComputedPropertyId::Property:
+          break;
+        }
+        continue;
+      }
+      case KeyPathPatternComponent::Kind::StoredProperty:
+        continue;
+      }
+    }
+  }
+  
   /// Marks a function as alive if it is not alive yet.
   void ensureAlive(SILFunction *F) {
     if (!isAlive(F))
@@ -313,6 +353,8 @@ protected:
           ensureAliveClassMethod(mi, dyn_cast<FuncDecl>(funcDecl), MethodCl);
         } else if (auto *FRI = dyn_cast<FunctionRefInst>(&I)) {
           ensureAlive(FRI->getReferencedFunction());
+        } else if (auto *KPI = dyn_cast<KeyPathInst>(&I)) {
+          ensureKeyPathComponentsAreAlive(KPI->getPattern());
         }
       }
     }

--- a/test/stdlib/KeyPath.swift
+++ b/test/stdlib/KeyPath.swift
@@ -4,9 +4,6 @@
 // REQUIRES: executable_test
 // REQUIRES: PTRSIZE=64
 
-// Disabled for now
-// REQUIRES: rdar31776015
-
 import StdlibUnittest
 
 var keyPath = TestSuite("key paths")

--- a/test/stdlib/KeyPathImplementation.swift
+++ b/test/stdlib/KeyPathImplementation.swift
@@ -4,10 +4,6 @@
 // REQUIRES: executable_test
 // REQUIRES: PTRSIZE=64
 
-// Disabled for now
-// REQUIRES: rdar31776015
-
-
 import StdlibUnittest
 
 var keyPathImpl = TestSuite("key path implementation")

--- a/test/stdlib/KeyPathObjC.swift
+++ b/test/stdlib/KeyPathObjC.swift
@@ -5,9 +5,6 @@
 // REQUIRES: PTRSIZE=64
 // REQUIRES: objc_interop
 
-// Disabled for now
-// REQUIRES: rdar31776015
-
 import StdlibUnittest
 import Foundation
 


### PR DESCRIPTION
Fixes rdar://problem/31776015.