### PR TITLE
Fix an issue that was uncovered by the linux fix: resolves verifier bug in 32-bit code

### DIFF
--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -417,7 +417,11 @@ void LargeValueVisitor::visitApply(ApplySite applySite) {
     SILValue currOperand = operand.get();
     SILType silType = currOperand->getType();
     SILType newSilType = getNewSILType(genEnv, silType, pass.Mod);
-    if (silType != newSilType) {
+    if (silType != newSilType ||
+        std::find(pass.largeLoadableArgs.begin(), pass.largeLoadableArgs.end(),
+                  currOperand) != pass.largeLoadableArgs.end() ||
+        std::find(pass.funcSigArgs.begin(), pass.funcSigArgs.end(),
+                  currOperand) != pass.funcSigArgs.end()) {
       pass.applies.push_back(applySite.getInstruction());
       return;
     }


### PR DESCRIPTION
This PR uncovered a problem on mac 32-bit targets https://github.com/apple/swift/pull/9165

It only shows up in a full build when trying to verify all SIL on 32-bit targets

This PR tries to resolve that issue: we fixed the substituted function type, but, the old deceleration does not make sense (because we changed the ABI) - don't verify against it if the SIL stage is lowered