### PR TITLE
Improve multi-file enum diagnostics

### DIFF
--- a/test/FixCode/Inputs/fixits-enum-multifile.swift
+++ b/test/FixCode/Inputs/fixits-enum-multifile.swift
@@ -1,0 +1,6 @@
+enum EMulti {
+  case e1
+  case e2
+  case e3(Bool)
+}
+

--- a/test/FixCode/fixits-empty-switch-multifile.swift
+++ b/test/FixCode/fixits-empty-switch-multifile.swift
@@ -1,0 +1,7 @@
+// RUN: not %swift -typecheck -target %target-triple %s %S/Inputs/fixits-enum-multifile.swift -emit-fixits-path %t.remap -I %S/Inputs -diagnostics-editor-mode
+// RUN: c-arcmt-test %t.remap | arcmt-test -verify-transformed-files %s.result
+
+func foo1(_ e: EMulti) {
+  switch e {
+  }
+}

--- a/test/FixCode/fixits-empty-switch-multifile.swift.result
+++ b/test/FixCode/fixits-empty-switch-multifile.swift.result
@@ -1,0 +1,10 @@
+// RUN: not %swift -typecheck -target %target-triple %s %S/Inputs/fixits-enum-multifile.swift -emit-fixits-path %t.remap -I %S/Inputs -diagnostics-editor-mode
+// RUN: c-arcmt-test %t.remap | arcmt-test -verify-transformed-files %s.result
+
+func foo1(_ e: EMulti) {
+  switch e {
+  case .e1: <#code#>
+case .e2: <#code#>
+case .e3(_): <#code#>
+}
+}

--- a/test/NameBinding/reference-dependencies.swift
+++ b/test/NameBinding/reference-dependencies.swift
@@ -215,6 +215,8 @@ func lookUpManyTopLevelNames() {
   switch getOtherFileEnum() {
   case .Value:
     break
+  default:
+    break
   }
 
   _ = .Value as OtherFileEnumWrapper.Enum

--- a/validation-test/Driver/Dependencies/rdar25405605.swift
+++ b/validation-test/Driver/Dependencies/rdar25405605.swift
@@ -58,7 +58,7 @@
 
 // RUN: cp %S/Inputs/rdar25405605/helper-3.swift %t/helper.swift
 // RUN: touch -t 201401240007 %t/helper.swift
-// RUN: cd %t && %target-build-swift -c -incremental -output-file-map %S/Inputs/rdar25405605/output.json -parse-as-library ./main.swift ./helper.swift -parseable-output -j1 -module-name main 2>&1 | %FileCheck -check-prefix=CHECK-3 %s
+// RUN: cd %t && not %target-build-swift -c -incremental -output-file-map %S/Inputs/rdar25405605/output.json -parse-as-library ./main.swift ./helper.swift -parseable-output -j1 -module-name main 2>&1 | %FileCheck -check-prefix=CHECK-3 %s
 
 // CHECK-3-NOT: warning
 // CHECK-3: {{^{$}}


### PR DESCRIPTION
Given a setup where one file declares an enum and the other switches on it, decomposition fails because it can't get any useful interface types out of the AST.  Version 1 of this patch adds a short hack that just throws in the enum case constructor heads into the space and reports that back to the user because it's better than nothing, but there's got to be a better way to do this.

@slavapestov?