### PR TITLE
[indexer] Don't index closure params.

### DIFF
--- a/lib/Index/IndexSymbol.cpp
+++ b/lib/Index/IndexSymbol.cpp
@@ -232,5 +232,6 @@ SymbolSubKind index::getSubKindForAccessor(AccessorKind AK) {
 
 bool index::isLocalSymbol(const swift::Decl *D) {
   return D->getDeclContext()->getLocalContext() &&
-    (!isa<ParamDecl>(D) || cast<ParamDecl>(D)->getArgumentNameLoc().isValid());
+    (!isa<ParamDecl>(D) || cast<ParamDecl>(D)->getArgumentNameLoc().isValid() ||
+     D->getDeclContext()->getContextKind() == DeclContextKind::AbstractClosureExpr);
 }

--- a/test/Index/roles.swift
+++ b/test/Index/roles.swift
@@ -74,6 +74,10 @@ func aCalledFunction(a: Int, b: inout Int) {
   // CHECK-NEXT: RelCont | function/Swift | aCalledFunction(a:b:) | s:14swift_ide_test15aCalledFunctionySi1a_Siz1btF
   // CHECK: [[@LINE-3]]:7 | param/Swift | a | s:{{.*}} | Ref,Read,RelCont | rel: 1
   // CHECK-NEXT: RelCont | function/Swift | aCalledFunction(a:b:) | s:14swift_ide_test15aCalledFunctionySi1a_Siz1btF
+
+  _ = { ignored in ignored + 1}
+  // CHECK-NOT: [[@LINE-1]]:9 {{.*}} | ignored | {{.*}}
+
 }
 
 aCalledFunction(a: 1, b: &z)


### PR DESCRIPTION
<!-- What's in this pull request? -->
Closure params were incorrectly being indexed. They can only be referenced locally, so don't index them.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves rdar://problem/31905371.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->