### PR TITLE
[Exclusivity] Use dynamic enforcement on boxes whose projections escape

### DIFF
--- a/test/SILOptimizer/access_enforcement_selection.sil
+++ b/test/SILOptimizer/access_enforcement_selection.sil
@@ -64,6 +64,41 @@ sil hidden @markFuncEscape : $@convention(thin) () -> () {
   %99 = return %98 : $()
 }
 
+
+sil @takesInoutAndClosure : $@convention(thin) (@inout Builtin.Int64, @owned @callee_owned () -> ()) -> ()
+sil @closureCapturingByStorageAddress : $@convention(thin) (@inout_aliasable Builtin.Int64) -> ()
+
+// Test dynamic enforcement of box addresses that escape via closure
+// partial_applys.
+// application.
+// CHECK-LABEL: sil hidden @escapeAsArgumentToPartialApply : $@convention(thin) () -> () {
+// CHECK: bb0:
+// CHECK:  [[BOX:%.*]] = alloc_box ${ var Builtin.Int64 }, var, name "x"
+// CHECK:  [[ADR:%.*]] = project_box [[BOX]] : ${ var Builtin.Int64 }, 0
+// CHECK:  [[FUNC:%.*]] = function_ref @takesInoutAndClosure : $@convention(thin) (@inout Builtin.Int64, @owned @callee_owned () -> ()) -> ()
+// CHECK:  [[CLOSURE:%.*]] = function_ref @closureCapturingByStorageAddress : $@convention(thin) (@inout_aliasable Builtin.Int64) -> ()
+// CHECK:  [[PA:%.*]] = partial_apply [[CLOSURE]]([[ADR]]) : $@convention(thin) (@inout_aliasable Builtin.Int64) -> ()
+// CHECK:  [[MODIFY:%.*]] = begin_access [modify] [dynamic] [[ADR]] : $*Builtin.Int64
+// CHECK:  %{{.*}} = apply [[FUNC]]([[MODIFY]], [[PA]]) : $@convention(thin) (@inout Builtin.Int64, @owned @callee_owned () -> ()) -> ()
+// CHECK:  end_access [[MODIFY]] : $*Builtin.Int64
+// CHECK:  destroy_value [[BOX]] : ${ var Builtin.Int64 }
+// CHECK:  return %{{.*}} : $()
+// CHECK-LABEL:} // end sil function 'escapeAsArgumentToPartialApply'
+sil hidden @escapeAsArgumentToPartialApply : $@convention(thin) () -> () {
+  %2 = alloc_box ${ var Builtin.Int64 }, var, name "x"
+  %3 = project_box %2 : ${ var Builtin.Int64 }, 0
+  %4 = function_ref @takesInoutAndClosure : $@convention(thin) (@inout Builtin.Int64, @owned @callee_owned () -> ()) -> ()
+  %5 = function_ref @closureCapturingByStorageAddress : $@convention(thin) (@inout_aliasable Builtin.Int64) -> ()
+  %6 = partial_apply %5(%3) : $@convention(thin) (@inout_aliasable Builtin.Int64) -> ()
+  %7 = begin_access [modify] [unknown] %3 : $*Builtin.Int64
+  %8 = apply %4(%7, %6) : $@convention(thin) (@inout Builtin.Int64, @owned @callee_owned () -> ()) -> ()
+  end_access %7 : $*Builtin.Int64
+  destroy_value %2 : ${ var Builtin.Int64 }
+  %9 = tuple ()
+  %10 = return %9 : $()
+}
+
+
 // Test static enforcement of copied boxes.
 // FIXME: Oops... We make this dynamic.
 //

--- a/test/SILOptimizer/access_enforcement_selection.swift
+++ b/test/SILOptimizer/access_enforcement_selection.swift
@@ -12,6 +12,11 @@ public func takesInout(_ i: inout Int) {
 // Helper taking a basic, no-escape closure.
 func takeClosure(_: ()->Int) {}
 
+// Helper taking a basic, no-escape closure.
+func takeClosureAndInout(_: inout Int, _: ()->Int) {}
+
+// Helper taking an escaping closure.
+func takeEscapingClosure(_: @escaping ()->Int) {}
 
 // Generate an alloc_stack that escapes into a closure.
 public func captureStack() -> Int {
@@ -21,8 +26,10 @@ public func captureStack() -> Int {
   return x
 }
 // CHECK-LABEL: Access Enforcement Selection in _T028access_enforcement_selection12captureStackSiyF
-// Static access for `return x`.
-// CHECK: Static Access: %{{.*}} = begin_access [read] [static] %{{.*}} : $*Int
+// Dynamic access for `return x`. Since the closure is non-escaping, using
+// dynamic enforcement here is more conservative than it needs to be -- static
+// is sufficient here.
+// CHECK: Dynamic Access: %{{.*}} = begin_access [read] [dynamic] %{{.*}} : $*Int
 
 // The access inside the closure is dynamic, until we have the logic necessary to
 // prove that no other closures are passed to `takeClosure` that may write to
@@ -30,6 +37,49 @@ public func captureStack() -> Int {
 //
 // CHECK-LABEL: Access Enforcement Selection in _T028access_enforcement_selection12captureStackSiyFSiycfU_
 // CHECK: Dynamic Access: %{{.*}} = begin_access [read] [dynamic] %{{.*}} : $*Int
+
+
+// Generate an alloc_stack that does not escape into a closure.
+public func nocaptureStack() -> Int {
+  var x = 3
+  takeClosure { return 5 }
+  return x
+}
+// CHECK-LABEL: Access Enforcement Selection in _T028access_enforcement_selection14nocaptureStackSiyF
+// Static access for `return x`.
+// CHECK: Static Access: %{{.*}} = begin_access [read] [static] %{{.*}} : $*Int
+//
+// CHECK-LABEL: Access Enforcement Selection in _T028access_enforcement_selection14nocaptureStackSiyFSiycfU_
+
+// Generate an alloc_stack that escapes into a closure while an access is
+// in progress.
+public func captureStackWithInoutInProgress() -> Int {
+  // Use a `var` so `x` isn't treated as a literal.
+  var x = 3
+  takeClosureAndInout(&x) { return x }
+  return x
+}
+// CHECK-LABEL: Access Enforcement Selection in _T028access_enforcement_selection31captureStackWithInoutInProgressSiyF
+// Dynamic access for `&x`. This must be dynamic so that we catch the conflict
+// in the closure.
+// CHECK-DAG: Dynamic Access: %{{.*}} = begin_access [modify] [dynamic] %{{.*}} : $*Int
+// Dynamic access for `return x`. This is more conservative than it needs
+// to be; it can be static.
+// CHECK-DAG: Dynamic Access: %{{.*}} = begin_access [read] [dynamic] %{{.*}} : $*Int
+//
+// CHECK-LABEL: Access Enforcement Selection in _T028access_enforcement_selection31captureStackWithInoutInProgressSiyFSiycfU_
+// CHECK: Dynamic Access: %{{.*}} = begin_access [read] [dynamic] %{{.*}} : $*Int
+
+// Generate an alloc_box that escapes into a closure.
+public func captureBox() -> Int {
+  var x = 3
+  takeEscapingClosure { x = 4; return x }
+  return x
+}
+// CHECK-LABEL: Access Enforcement Selection in _T028access_enforcement_selection10captureBoxSiyF
+// Dynamic access for `return x`.
+// CHECK: Dynamic Access: %{{.*}} = begin_access [read] [dynamic] %{{.*}} : $*Int
+// CHECK-LABEL: _T028access_enforcement_selection10captureBoxSiyFSiycfU_
 
 // Generate a closure in which the @inout_aliasing argument
 // escapes to an @inout function `bar`.
@@ -40,8 +90,9 @@ public func recaptureStack() -> Int {
 }
 // CHECK-LABEL: Access Enforcement Selection in _T028access_enforcement_selection14recaptureStackSiyF
 //
-// Static access for `return x`.
-// CHECK: Static Access:   %{{.*}} = begin_access [read] [static] %{{.*}} : $*Int
+// Dynamic access for `return x`. This is more conservative than it needs
+// to be; static is sufficient.
+// CHECK: Dynamic Access:   %{{.*}} = begin_access [read] [dynamic] %{{.*}} : $*Int
 
 // CHECK-LABEL: Access Enforcement Selection in _T028access_enforcement_selection14recaptureStackSiyFSiycfU_
 //


### PR DESCRIPTION
In AccessEnforcementSelection, treat passing a projection from a box to
a partial_apply as an escape to force using dynamic enforcement on the box.

This will now correctly use dynamic enforcement on variables that are taken
as inout and also captured by storage address in a closure:

  var x = ...

  x.mutatingMethod { ... use x ...}

but does pessimize some of our existing enforcement into dynamic since
access enforcement selection.

Ideally we would distinguish between escaping via an nonescaping closures
(which can only conflict with accesses that are in progress) and
escaping via escaping closures (which can conflict for any reachable code
after the escape)