### PR TITLE
Implement \ syntax for Swift key paths.

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1176,6 +1176,8 @@ ERROR(expr_keypath_expected_property_or_type,PointsToFirstBadToken,
       "expected property or type name within '#keyPath(...)'", ())
 ERROR(expr_keypath_expected_rparen,PointsToFirstBadToken,
       "expected ')' to complete '#keyPath' expression", ())
+ERROR(expr_keypath_expected_expr,none,
+      "expected expression path in Swift key path",())
 
 // Selector expressions.
 ERROR(expr_selector_expected_lparen,PointsToFirstBadToken,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -441,6 +441,10 @@ ERROR(expr_unsupported_objc_key_path_compound_name,none,
       "compound name", ())
 ERROR(expr_keypath_no_keypath_type,none,
       "broken standard library: no 'KeyPath' type found", ())
+ERROR(expr_swift_keypath_invalid_component,none,
+      "invalid component of Swift key path", ())
+ERROR(expr_swift_keypath_not_starting_with_type,none,
+      "a Swift key path must begin with a type", ())
 
 // Selector expressions.
 ERROR(expr_selector_no_objc_runtime,none,

--- a/include/swift/AST/ExprNodes.def
+++ b/include/swift/AST/ExprNodes.def
@@ -168,6 +168,7 @@ UNCHECKED_EXPR(UnresolvedPattern, Expr)
 EXPR(EditorPlaceholder, Expr)
 EXPR(ObjCSelector, Expr)
 EXPR(KeyPath, Expr)
+UNCHECKED_EXPR(KeyPathDot, Expr)
 
 #undef EXPR_RANGE
 #undef LITERAL_EXPR

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -130,6 +130,7 @@ public:
 
   bool InPoundLineEnvironment = false;
   bool InPoundIfEnvironment = false;
+  bool InSwiftKeyPath = false;
 
   LocalContext *CurLocalContext = nullptr;
 
@@ -1143,6 +1144,7 @@ public:
                                               bool isExprBasic);
   ParserResult<Expr> parseExprPostfixSuffix(ParserResult<Expr> inner,
                                             bool isExprBasic,
+                                            bool periodHasKeyPathBehaviour,
                                             bool &hasBindOptional);
   ParserResult<Expr> parseExprPostfix(Diag<> ID, bool isExprBasic);
   ParserResult<Expr> parseExprUnary(Diag<> ID, bool isExprBasic);

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -517,16 +517,16 @@ public:
   /// Add a camel-cased option if it is different than the first option.
   void diagnoseConsecutiveIDs(StringRef First, SourceLoc FirstLoc,
                               StringRef DeclKindName);
-     
-  /// \brief Check whether the current token starts with '<'.
-  bool startsWithLess(Token Tok) {
-    return Tok.isAnyOperator() && Tok.getText()[0] == '<';
+
+  bool startsWithSymbol(Token Tok, char symbol) {
+    return (Tok.isAnyOperator() || Tok.isPunctuation()) &&
+           Tok.getText()[0] == symbol;
   }
+  /// \brief Check whether the current token starts with '<'.
+  bool startsWithLess(Token Tok) { return startsWithSymbol(Tok, '<'); }
 
   /// \brief Check whether the current token starts with '>'.
-  bool startsWithGreater(Token Tok) {
-    return Tok.isAnyOperator() && Tok.getText()[0] == '>';
-  }
+  bool startsWithGreater(Token Tok) { return startsWithSymbol(Tok, '>'); }
 
   /// \brief Consume the starting '<' of the current token, which may either
   /// be a complete '<' token or some kind of operator token starting with '<',

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1141,6 +1141,9 @@ public:
                                        bool isForConditionalDirective = false);
   ParserResult<Expr> parseExprSequenceElement(Diag<> ID,
                                               bool isExprBasic);
+  ParserResult<Expr> parseExprPostfixSuffix(ParserResult<Expr> inner,
+                                            bool isExprBasic,
+                                            bool &hasBindOptional);
   ParserResult<Expr> parseExprPostfix(Diag<> ID, bool isExprBasic);
   ParserResult<Expr> parseExprUnary(Diag<> ID, bool isExprBasic);
   ParserResult<Expr> parseExprKeyPathObjC();

--- a/include/swift/Syntax/TokenKinds.def
+++ b/include/swift/Syntax/TokenKinds.def
@@ -174,6 +174,8 @@ PUNCTUATOR(arrow,         "->")
 
 PUNCTUATOR(backtick,      "`")
 
+PUNCTUATOR(backslash, "\\")
+
 PUNCTUATOR(exclaim_postfix, "!") // if left-bound
 
 PUNCTUATOR(question_postfix, "?") // if left-bound
@@ -193,7 +195,6 @@ POUND_KEYWORD(else)
 POUND_KEYWORD(elseif)
 POUND_KEYWORD(endif)
 POUND_KEYWORD(keyPath)
-POUND_KEYWORD(keyPath2) // TODO
 POUND_KEYWORD(line)
 POUND_KEYWORD(sourceLocation)
 POUND_KEYWORD(selector)

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2467,6 +2467,25 @@ public:
       OS << '\n';
       printRec(stringLiteral);
     }
+    if (!E->isObjC()) {
+      OS << "\n";
+      if (auto root = E->getParsedRoot()) {
+        printRec(root);
+      } else {
+        OS.indent(Indent + 2) << "<<null>>";
+      }
+      OS << "\n";
+      if (auto path = E->getParsedPath()) {
+        printRec(path);
+      } else {
+        OS.indent(Indent + 2) << "<<null>>";
+      }
+    }
+    OS << ")";
+  }
+
+  void visitKeyPathDotExpr(KeyPathDotExpr *E) {
+    printCommon(E, "key_path_dot_expr");
     OS << ")";
   }
 };

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -510,6 +510,7 @@ ConcreteDeclRef Expr::getReferencedDecl() const {
   NO_REFERENCE(EditorPlaceholder);
   NO_REFERENCE(ObjCSelector);
   NO_REFERENCE(KeyPath);
+  NO_REFERENCE(KeyPathDot);
 
 #undef SIMPLE_REFERENCE
 #undef NO_REFERENCE
@@ -796,6 +797,7 @@ bool Expr::canAppendCallParentheses() const {
   case ExprKind::Assign:
   case ExprKind::UnresolvedPattern:
   case ExprKind::EditorPlaceholder:
+  case ExprKind::KeyPathDot:
     return false;
   }
 
@@ -2003,23 +2005,17 @@ ArchetypeType *OpenExistentialExpr::getOpenedArchetype() const {
   return type->castTo<ArchetypeType>();
 }
 
-KeyPathExpr::KeyPathExpr(ASTContext &C,
-                         SourceLoc keywordLoc, SourceLoc lParenLoc,
-                         TypeRepr *root,
-                         ArrayRef<Component> components,
-                         SourceLoc rParenLoc,
-                         bool isObjC,
-                         bool isImplicit)
-  : Expr(ExprKind::KeyPath, isImplicit),
-    KeywordLoc(keywordLoc), LParenLoc(lParenLoc), RParenLoc(rParenLoc),
-    RootType(root),
-    Components(C.AllocateUninitialized<Component>(components.size()))
-{
+KeyPathExpr::KeyPathExpr(ASTContext &C, SourceLoc keywordLoc,
+                         SourceLoc lParenLoc, ArrayRef<Component> components,
+                         SourceLoc rParenLoc, bool isImplicit)
+    : Expr(ExprKind::KeyPath, isImplicit), StartLoc(keywordLoc),
+      LParenLoc(lParenLoc), EndLoc(rParenLoc),
+      Components(C.AllocateUninitialized<Component>(components.size())) {
   // Copy components into the AST context.
   std::uninitialized_copy(components.begin(), components.end(),
                           Components.begin());
-  
-  KeyPathExprBits.IsObjC = isObjC;
+
+  KeyPathExprBits.IsObjC = true;
 }
 
 void

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -1936,6 +1936,8 @@ Restart:
   case ',': return formToken(tok::comma, TokStart);
   case ';': return formToken(tok::semi, TokStart);
   case ':': return formToken(tok::colon, TokStart);
+  case '\\':
+    return formToken(tok::backslash, TokStart);
 
   case '#':
     return lexHash();

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1133,6 +1133,231 @@ static bool canParseTypeOf(Parser &P) {
   return true;
 }
 
+ParserResult<Expr> Parser::parseExprPostfixSuffix(ParserResult<Expr> Result,
+                                                  bool isExprBasic,
+                                                  bool &hasBindOptional) {
+  hasBindOptional = false;
+
+  // Handle suffix expressions.
+  while (1) {
+    // FIXME: Better recovery.
+    if (Result.isNull())
+      return Result;
+
+    // Check for a .foo suffix.
+    SourceLoc TokLoc = Tok.getLoc();
+    if (consumeIf(tok::period) || consumeIf(tok::period_prefix)) {
+
+      // Handle "x.42" - a tuple index.
+      if (Tok.is(tok::integer_literal)) {
+        DeclName name = Context.getIdentifier(Tok.getText());
+        SourceLoc nameLoc = consumeToken(tok::integer_literal);
+
+        // Don't allow '.<integer literal>' following a numeric literal
+        // expression (unless in #if env, for 1.2.3.4 version numbers)
+        if (!InPoundIfEnvironment && Result.isNonNull() &&
+            isa<NumberLiteralExpr>(Result.get())) {
+          diagnose(nameLoc, diag::numeric_literal_numeric_member)
+              .highlight(Result.get()->getSourceRange());
+          continue;
+        }
+
+        Result = makeParserResult(new (Context) UnresolvedDotExpr(
+            Result.get(), TokLoc, name, DeclNameLoc(nameLoc),
+            /*Implicit=*/false));
+        continue;
+      }
+
+      // Handle "x.self" expr.
+      if (Tok.is(tok::kw_self)) {
+        Result = makeParserResult(
+            new (Context) DotSelfExpr(Result.get(), TokLoc, consumeToken()));
+        continue;
+      }
+
+      // Handle the deprecated 'x.dynamicType' and migrate it to `type(of: x)`
+      if (Tok.getText() == "dynamicType") {
+        auto range = Result.get()->getSourceRange();
+        auto dynamicTypeExprRange = SourceRange(TokLoc, Tok.getLoc());
+        diagnose(TokLoc, diag::expr_dynamictype_deprecated)
+            .highlight(dynamicTypeExprRange)
+            .fixItReplace(dynamicTypeExprRange, ")")
+            .fixItInsert(range.Start, "type(of: ");
+
+        // fallthrough to an UnresolvedDotExpr.
+      }
+
+      // If we have '.<keyword><code_complete>', try to recover by creating
+      // an identifier with the same spelling as the keyword.
+      if (Tok.isKeyword() && peekToken().is(tok::code_complete)) {
+        Identifier Name = Context.getIdentifier(Tok.getText());
+        Result = makeParserResult(new (Context) UnresolvedDotExpr(
+            Result.get(), TokLoc, Name, DeclNameLoc(Tok.getLoc()),
+            /*Implicit=*/false));
+        consumeToken();
+        // Fall into the next code completion handler.
+      }
+
+      // Handle "x.<tab>" for code completion.
+      if (Tok.is(tok::code_complete)) {
+        if (CodeCompletion && Result.isNonNull())
+          CodeCompletion->completeDotExpr(Result.get(), /*DotLoc=*/TokLoc);
+        // Eat the code completion token because we handled it.
+        consumeToken(tok::code_complete);
+        Result.setHasCodeCompletion();
+        return Result;
+      }
+
+      DeclNameLoc NameLoc;
+      DeclName Name = parseUnqualifiedDeclName(/*afterDot=*/true, NameLoc,
+                                               diag::expected_member_name);
+      if (!Name)
+        return nullptr;
+
+      Result = makeParserResult(
+          new (Context) UnresolvedDotExpr(Result.get(), TokLoc, Name, NameLoc,
+                                          /*Implicit=*/false));
+
+      if (canParseAsGenericArgumentList()) {
+        SmallVector<TypeRepr *, 8> args;
+        SourceLoc LAngleLoc, RAngleLoc;
+        if (parseGenericArguments(args, LAngleLoc, RAngleLoc)) {
+          diagnose(LAngleLoc, diag::while_parsing_as_left_angle_bracket);
+        }
+
+        SmallVector<TypeLoc, 8> locArgs;
+        for (auto ty : args)
+          locArgs.push_back(ty);
+        Result = makeParserResult(new (Context) UnresolvedSpecializeExpr(
+            Result.get(), LAngleLoc, Context.AllocateCopy(locArgs), RAngleLoc));
+      }
+
+      continue;
+    }
+
+    // If there is an expr-call-suffix, parse it and form a call.
+    if (Tok.isFollowingLParen()) {
+      Result = parseExprCallSuffix(Result, isExprBasic);
+      continue;
+    }
+
+    // NOTE: l_square_lit is for migrating the old object literal syntax.
+    // Eventually this block can be removed.
+    if (Tok.is(tok::l_square_lit) && !Tok.isAtStartOfLine() &&
+        isCollectionLiteralStartingWithLSquareLit()) {
+      assert(Tok.getLength() == 1);
+      Tok.setKind(tok::l_square);
+    }
+
+    // Check for a [expr] suffix.
+    // Note that this cannot be the start of a new line.
+    if (Tok.isFollowingLSquare()) {
+      SourceLoc lSquareLoc, rSquareLoc;
+      SmallVector<Expr *, 2> indexArgs;
+      SmallVector<Identifier, 2> indexArgLabels;
+      SmallVector<SourceLoc, 2> indexArgLabelLocs;
+      Expr *trailingClosure;
+
+      ParserStatus status = parseExprList(
+          tok::l_square, tok::r_square,
+          /*isPostfix=*/true, isExprBasic, lSquareLoc, indexArgs,
+          indexArgLabels, indexArgLabelLocs, rSquareLoc, trailingClosure);
+      if (status.hasCodeCompletion())
+        return makeParserCodeCompletionResult<Expr>();
+      if (status.isError() || Result.isNull())
+        return nullptr;
+      Result = makeParserResult(SubscriptExpr::create(
+          Context, Result.get(), lSquareLoc, indexArgs, indexArgLabels,
+          indexArgLabelLocs, rSquareLoc, trailingClosure, ConcreteDeclRef(),
+          /*implicit=*/false));
+      continue;
+    }
+
+    // Check for a trailing closure, if allowed.
+    if (Tok.is(tok::l_brace) && isValidTrailingClosure(isExprBasic, *this)) {
+      // FIXME: if Result has a trailing closure, break out.
+
+      // Stop after literal expressions, which may never have trailing closures.
+      const auto *callee = Result.get();
+      if (isa<LiteralExpr>(callee) || isa<CollectionExpr>(callee) ||
+          isa<TupleExpr>(callee))
+        break;
+
+      ParserResult<Expr> closure =
+          parseTrailingClosure(callee->getSourceRange());
+      if (closure.isNull())
+        return nullptr;
+
+      // Trailing closure implicitly forms a call.
+      Result = makeParserResult(
+          ParserStatus(closure),
+          CallExpr::create(Context, Result.get(), SourceLoc(), {}, {}, {},
+                           SourceLoc(), closure.get(), /*implicit=*/false));
+
+      if (Result.hasCodeCompletion())
+        return Result;
+
+      // We only allow a single trailing closure on a call.  This could be
+      // generalized in the future, but needs further design.
+      if (Tok.is(tok::l_brace))
+        break;
+      continue;
+    }
+
+    // Check for a ? suffix.
+    if (consumeIf(tok::question_postfix)) {
+      Result = makeParserResult(
+          new (Context) BindOptionalExpr(Result.get(), TokLoc, /*depth*/ 0));
+      hasBindOptional = true;
+      continue;
+    }
+
+    // Check for a ! suffix.
+    if (consumeIf(tok::exclaim_postfix)) {
+      Result =
+          makeParserResult(new (Context) ForceValueExpr(Result.get(), TokLoc));
+      continue;
+    }
+
+    // Check for a postfix-operator suffix.
+    if (Tok.is(tok::oper_postfix)) {
+      Expr *oper = parseExprOperator();
+      Result =
+          makeParserResult(new (Context) PostfixUnaryExpr(oper, Result.get()));
+      continue;
+    }
+
+    if (Tok.is(tok::code_complete)) {
+      if (Tok.isAtStartOfLine()) {
+        // Postfix expression is located on a different line than the code
+        // completion token, and thus they are not related.
+        return Result;
+      }
+
+      if (CodeCompletion && Result.isNonNull()) {
+        bool hasSpace = Tok.getLoc() != getEndOfPreviousLoc();
+        CodeCompletion->completePostfixExpr(Result.get(), hasSpace);
+      }
+      // Eat the code completion token because we handled it.
+      consumeToken(tok::code_complete);
+      return makeParserCodeCompletionResult<Expr>();
+    }
+
+    // If we end up with an unknown token on this line, return an ErrorExpr
+    // covering the range of the token.
+    if (!Tok.isAtStartOfLine() && consumeIf(tok::unknown)) {
+      Result = makeParserResult(new (Context)
+                                    ErrorExpr(Result.get()->getSourceRange()));
+      continue;
+    }
+
+    // Otherwise, we don't know what this token is, it must end the expression.
+    break;
+  }
+
+  return Result;
+}
+
 /// parseExprPostfix
 ///
 ///   expr-literal:
@@ -1571,229 +1796,9 @@ ParserResult<Expr> Parser::parseExprPostfix(Diag<> ID, bool isExprBasic) {
     return Result;
 
   bool hasBindOptional = false;
-    
-  // Handle suffix expressions.
-  while (1) {
-    // FIXME: Better recovery.
-    if (Result.isNull())
-      return Result;
-    
-    // Check for a .foo suffix.
-    SourceLoc TokLoc = Tok.getLoc();
-    if (consumeIf(tok::period) || consumeIf(tok::period_prefix)) {
-
-      // Handle "x.42" - a tuple index.
-      if (Tok.is(tok::integer_literal)) {
-        DeclName name = Context.getIdentifier(Tok.getText());
-        SourceLoc nameLoc = consumeToken(tok::integer_literal);
-        
-        // Don't allow '.<integer literal>' following a numeric literal
-        // expression (unless in #if env, for 1.2.3.4 version numbers)
-        if (!InPoundIfEnvironment &&
-            Result.isNonNull() && isa<NumberLiteralExpr>(Result.get())) {
-          diagnose(nameLoc, diag::numeric_literal_numeric_member)
-            .highlight(Result.get()->getSourceRange());
-          continue;
-        }
-        
-        Result = makeParserResult(
-            new (Context) UnresolvedDotExpr(Result.get(), TokLoc, name,
-                                            DeclNameLoc(nameLoc),
-                                            /*Implicit=*/false));
-        continue;
-      }
-
-      // Handle "x.self" expr.
-      if (Tok.is(tok::kw_self)) {
-        Result = makeParserResult(
-          new (Context) DotSelfExpr(Result.get(), TokLoc, consumeToken()));
-        continue;
-      }
-
-      // Handle the deprecated 'x.dynamicType' and migrate it to `type(of: x)`
-      if (Tok.getText() == "dynamicType") {
-        auto range = Result.get()->getSourceRange();
-        auto dynamicTypeExprRange = SourceRange(TokLoc, Tok.getLoc());
-        diagnose(TokLoc, diag::expr_dynamictype_deprecated)
-          .highlight(dynamicTypeExprRange)
-          .fixItReplace(dynamicTypeExprRange, ")")
-          .fixItInsert(range.Start, "type(of: ");
-
-        // fallthrough to an UnresolvedDotExpr.
-      }
-           
-      // If we have '.<keyword><code_complete>', try to recover by creating
-      // an identifier with the same spelling as the keyword.
-      if (Tok.isKeyword() && peekToken().is(tok::code_complete)) {
-        Identifier Name = Context.getIdentifier(Tok.getText());
-        Result = makeParserResult(
-            new (Context) UnresolvedDotExpr(Result.get(), TokLoc,
-                                            Name, DeclNameLoc(Tok.getLoc()),
-                                            /*Implicit=*/false));
-        consumeToken();
-        // Fall into the next code completion handler.
-      }
-
-      // Handle "x.<tab>" for code completion.
-      if (Tok.is(tok::code_complete)) {
-        if (CodeCompletion && Result.isNonNull())
-          CodeCompletion->completeDotExpr(Result.get(), /*DotLoc=*/TokLoc);
-        // Eat the code completion token because we handled it.
-        consumeToken(tok::code_complete);
-        Result.setHasCodeCompletion();
-        return Result;
-      }
-
-      DeclNameLoc NameLoc;
-      DeclName Name = parseUnqualifiedDeclName(/*afterDot=*/true,
-                                               NameLoc,
-                                               diag::expected_member_name);
-      if (!Name) return nullptr;
-    
-      Result = makeParserResult(
-                 new (Context) UnresolvedDotExpr(Result.get(), TokLoc, Name,
-                                                 NameLoc,
-                                                 /*Implicit=*/false));
-        
-      if (canParseAsGenericArgumentList()) {
-        SmallVector<TypeRepr*, 8> args;
-        SourceLoc LAngleLoc, RAngleLoc;
-        if (parseGenericArguments(args, LAngleLoc, RAngleLoc)) {
-          diagnose(LAngleLoc, diag::while_parsing_as_left_angle_bracket);
-        }
-
-        SmallVector<TypeLoc, 8> locArgs;
-        for (auto ty : args)
-          locArgs.push_back(ty);
-        Result = makeParserResult(new (Context) UnresolvedSpecializeExpr(
-                   Result.get(), LAngleLoc, Context.AllocateCopy(locArgs),
-                   RAngleLoc));
-      }
-
-      continue;
-    }
-
-    // If there is an expr-call-suffix, parse it and form a call.
-    if (Tok.isFollowingLParen()) {
-      Result = parseExprCallSuffix(Result, isExprBasic);
-      continue;
-    }
-    
-    // NOTE: l_square_lit is for migrating the old object literal syntax.
-    // Eventually this block can be removed.
-    if (Tok.is(tok::l_square_lit) && !Tok.isAtStartOfLine() &&
-        isCollectionLiteralStartingWithLSquareLit()) {
-      assert(Tok.getLength() == 1);
-      Tok.setKind(tok::l_square);
-    }
-
-    // Check for a [expr] suffix.
-    // Note that this cannot be the start of a new line.
-    if (Tok.isFollowingLSquare()) {
-      SourceLoc lSquareLoc, rSquareLoc;
-      SmallVector<Expr *, 2> indexArgs;
-      SmallVector<Identifier, 2> indexArgLabels;
-      SmallVector<SourceLoc, 2> indexArgLabelLocs;
-      Expr *trailingClosure;
-      
-      ParserStatus status = parseExprList(tok::l_square, tok::r_square,
-                                          /*isPostfix=*/true, isExprBasic,
-                                          lSquareLoc, indexArgs, indexArgLabels,
-                                          indexArgLabelLocs,
-                                          rSquareLoc,
-                                          trailingClosure);
-      if (status.hasCodeCompletion())
-        return makeParserCodeCompletionResult<Expr>();
-      if (status.isError() || Result.isNull())
-        return nullptr;
-      Result = makeParserResult(
-        SubscriptExpr::create(Context, Result.get(), lSquareLoc, indexArgs,
-                              indexArgLabels, indexArgLabelLocs, rSquareLoc,
-                              trailingClosure, ConcreteDeclRef(),
-                              /*implicit=*/false));
-      continue;
-    }
-
-    // Check for a trailing closure, if allowed.
-    if (Tok.is(tok::l_brace) && isValidTrailingClosure(isExprBasic, *this)) {
-      // FIXME: if Result has a trailing closure, break out.
-
-      // Stop after literal expressions, which may never have trailing closures.
-      const auto *callee = Result.get();
-      if (isa<LiteralExpr>(callee) || isa<CollectionExpr>(callee) ||
-          isa<TupleExpr>(callee))
-        break;
-
-      ParserResult<Expr> closure =
-        parseTrailingClosure(callee->getSourceRange());
-      if (closure.isNull()) return nullptr;
-
-      // Trailing closure implicitly forms a call.
-      Result = makeParserResult(
-                 ParserStatus(closure),
-                 CallExpr::create(Context, Result.get(), SourceLoc(),
-                                  { }, { }, { }, SourceLoc(),
-                                  closure.get(), /*implicit=*/false));
-
-      if (Result.hasCodeCompletion())
-        return Result;
-
-      // We only allow a single trailing closure on a call.  This could be
-      // generalized in the future, but needs further design.
-      if (Tok.is(tok::l_brace)) break;
-      continue;
-    }
-
-    // Check for a ? suffix.
-    if (consumeIf(tok::question_postfix)) {
-      Result = makeParserResult(
-          new (Context) BindOptionalExpr(Result.get(), TokLoc, /*depth*/ 0));
-      hasBindOptional = true;
-      continue;
-    }
-
-    // Check for a ! suffix.
-    if (consumeIf(tok::exclaim_postfix)) {
-      Result = makeParserResult(new (Context) ForceValueExpr(Result.get(), 
-                                                             TokLoc));
-      continue;
-    }
-
-    // Check for a postfix-operator suffix.
-    if (Tok.is(tok::oper_postfix)) {
-      Expr *oper = parseExprOperator();
-      Result = makeParserResult(
-          new (Context) PostfixUnaryExpr(oper, Result.get()));
-      continue;
-    }
-
-    if (Tok.is(tok::code_complete)) {
-      if (Tok.isAtStartOfLine()) {
-        // Postfix expression is located on a different line than the code
-        // completion token, and thus they are not related.
-        return Result;
-      }
-
-      if (CodeCompletion && Result.isNonNull()) {
-        bool hasSpace = Tok.getLoc() != getEndOfPreviousLoc();
-        CodeCompletion->completePostfixExpr(Result.get(), hasSpace);
-      }
-      // Eat the code completion token because we handled it.
-      consumeToken(tok::code_complete);
-      return makeParserCodeCompletionResult<Expr>();
-    }
-    
-    // If we end up with an unknown token on this line, return an ErrorExpr
-    // covering the range of the token.
-    if (!Tok.isAtStartOfLine() && consumeIf(tok::unknown)) {
-      Result = makeParserResult(
-                      new (Context) ErrorExpr(Result.get()->getSourceRange()));
-      continue;
-    }
-    
-    // Otherwise, we don't know what this token is, it must end the expression.
-    break;
-  }
+  Result = parseExprPostfixSuffix(Result, isExprBasic, hasBindOptional);
+  if (Result.isParseError() || Result.hasCodeCompletion())
+    return Result;
 
   // If we had a ? suffix expression, bind the entire postfix chain
   // within an OptionalEvaluationExpr.

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -4159,6 +4159,10 @@ namespace {
       return E;
     }
 
+    Expr *visitKeyPathDotExpr(KeyPathDotExpr *E) {
+      llvm_unreachable("found KeyPathDotExpr in CSApply");
+    }
+
     /// Interface for ExprWalker
     void walkToExprPre(Expr *expr) {
       ExprStack.push_back(expr);

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2932,6 +2932,10 @@ namespace {
       }
       return kpTy;
     }
+
+    Type visitKeyPathDotExpr(KeyPathDotExpr *E) {
+      llvm_unreachable("found KeyPathDotExpr in CSGen");
+    }
   };
 
   /// \brief AST walker that "sanitizes" an expression for the

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -946,6 +946,11 @@ namespace {
       if (auto *simplified = simplifyTypeExpr(expr))
         return simplified;
 
+      if (auto KPE = dyn_cast<KeyPathExpr>(expr)) {
+        resolveKeyPathExpr(KPE);
+        return KPE;
+      }
+
       return expr;
     }
 
@@ -958,6 +963,9 @@ namespace {
     /// as expressions due to the parser not knowing which identifiers are
     /// type names.
     TypeExpr *simplifyTypeExpr(Expr *E);
+
+    /// Simplify a key path expression into a canonical form.
+    void resolveKeyPathExpr(KeyPathExpr *KPE);
   };
 } // end anonymous namespace
 
@@ -1302,6 +1310,103 @@ TypeExpr *PreCheckExpression::simplifyTypeExpr(Expr *E) {
   return nullptr;
 }
 
+void PreCheckExpression::resolveKeyPathExpr(KeyPathExpr *KPE) {
+  if (KPE->isObjC())
+    return;
+
+  TypeRepr *rootType = nullptr;
+  SmallVector<KeyPathExpr::Component, 4> components;
+
+  // Pre-order visit of a sequence foo.bar[0]?.baz, which means that the
+  // components are pushed in reverse order.
+
+  auto traversePath = [&](Expr *expr, bool isInParsedPath,
+                          bool emitErrors = true) {
+    Expr *outermostExpr = expr;
+    while (1) {
+      // Base cases: we've reached the top.
+      if (auto TE = dyn_cast<TypeExpr>(expr)) {
+        assert(!isInParsedPath);
+        rootType = TE->getTypeRepr();
+        return;
+      } else if (isa<KeyPathDotExpr>(expr)) {
+        assert(isInParsedPath);
+        // Nothing here: the type is either the root, or is inferred.
+        return;
+      }
+
+      // Recurring cases:
+      if (auto UDE = dyn_cast<UnresolvedDotExpr>(expr)) {
+        // .foo
+        components.push_back(KeyPathExpr::Component::forUnresolvedProperty(
+            UDE->getName(), UDE->getLoc()));
+
+        expr = UDE->getBase();
+      } else if (auto SE = dyn_cast<SubscriptExpr>(expr)) {
+        // .[0] or just plain [0]
+        components.push_back(
+            KeyPathExpr::Component::forUnresolvedSubscriptWithPrebuiltIndexExpr(
+                SE->getIndex(), SE->getLoc()));
+
+        expr = SE->getBase();
+      } else if (auto BOE = dyn_cast<BindOptionalExpr>(expr)) {
+        // .? or ?
+        components.push_back(KeyPathExpr::Component::forUnresolvedOptionalChain(
+            BOE->getQuestionLoc()));
+
+        expr = BOE->getSubExpr();
+      } else if (auto FVE = dyn_cast<ForceValueExpr>(expr)) {
+        // .! or !
+        components.push_back(KeyPathExpr::Component::forUnresolvedOptionalForce(
+            FVE->getExclaimLoc()));
+
+        expr = FVE->getSubExpr();
+      } else if (auto OEE = dyn_cast<OptionalEvaluationExpr>(expr)) {
+        // Do nothing: this is implied to exist as the last expression, by the
+        // BindOptionalExprs, but is irrelevant to the components.
+        assert(OEE == outermostExpr);
+        expr = OEE->getSubExpr();
+      } else {
+        if (emitErrors)
+          TC.diagnose(expr->getLoc(),
+                      diag::expr_swift_keypath_invalid_component);
+        return;
+      }
+    }
+  };
+
+  auto root = KPE->getParsedRoot();
+  auto path = KPE->getParsedPath();
+
+  if (path) {
+    traversePath(path, /*isInParsedPath=*/true);
+
+    // This path looks like \Foo.Bar.[0].baz, which means Foo.Bar has to be a
+    // type.
+    if (root) {
+      if (auto TE = dyn_cast<TypeExpr>(root)) {
+        rootType = TE->getTypeRepr();
+      } else {
+        // FIXME: Probably better to catch this case earlier and force-eval as
+        // TypeExpr.
+        TC.diagnose(root->getLoc(),
+                    diag::expr_swift_keypath_not_starting_with_type);
+
+        // Traverse this path for recovery purposes: it may be a typo like
+        // \Foo.property.[0].
+        traversePath(root, /*isInParsedPath=*/false,
+                     /*emitErrors=*/false);
+      }
+    }
+  } else {
+    traversePath(root, /*isInParsedPath=*/false);
+  }
+
+  std::reverse(components.begin(), components.end());
+
+  KPE->setRootType(rootType);
+  KPE->resolveComponents(TC.Context, components);
+}
 
 /// \brief Clean up the given ill-formed expression, removing any references
 /// to type variables and setting error types on erroneous expression nodes.

--- a/lib/Syntax/LegacyASTTransformer.cpp
+++ b/lib/Syntax/LegacyASTTransformer.cpp
@@ -1263,6 +1263,13 @@ LegacyASTTransformer::visitKeyPathExpr(KeyPathExpr *E,
   return getUnknownExpr(E);
 }
 
+RC<SyntaxData>
+LegacyASTTransformer::visitKeyPathDotExpr(KeyPathDotExpr *E,
+                                          const SyntaxData *Parent,
+                                          const CursorIndex IndexInParent) {
+  return getUnknownExpr(E);
+}
+
 RC<TokenSyntax>
 syntax::findTokenSyntax(tok ExpectedKind,
                         OwnedString ExpectedText,

--- a/test/Parse/invalid.swift
+++ b/test/Parse/invalid.swift
@@ -1,12 +1,5 @@
 // RUN: %target-typecheck-verify-swift
 
-func foo(_ a: Int) {
-  // expected-error @+1 {{invalid character in source file}} {{8-9= }}
-  foo(<\a\>) // expected-error {{invalid character in source file}} {{10-11= }}
-  // expected-error @-1 {{'<' is not a prefix unary operator}}
-  // expected-error @-2 {{'>' is not a postfix unary operator}}
-}
-
 // rdar://15946844
 func test1(inout var x : Int) {}  // expected-error {{parameter may not have multiple 'inout', 'var', or 'let' specifiers}} {{18-22=}}
 // expected-error @-1 {{'inout' before a parameter name is not allowed, place it before the parameter type instead}} {{12-17=}} {{26-26=inout }}

--- a/test/SILGen/keypaths.swift
+++ b/test/SILGen/keypaths.swift
@@ -31,19 +31,19 @@ protocol P {
 // CHECK-LABEL: sil hidden @{{.*}}storedProperties
 func storedProperties<T>(_: T) {
   // CHECK: keypath $WritableKeyPath<S<T>, T>, <τ_0_0> (root $S<τ_0_0>; stored_property #S.x : $τ_0_0) <T>
-  _ = #keyPath2(S<T>, .x)
+  _ = \S<T>.x
   // CHECK: keypath $KeyPath<S<T>, String>, <τ_0_0> (root $S<τ_0_0>; stored_property #S.y : $String) <T>
-  _ = #keyPath2(S<T>, .y)
+  _ = \S<T>.y
   // CHECK: keypath $ReferenceWritableKeyPath<S<T>, T>, <τ_0_0> (root $S<τ_0_0>; stored_property #S.z : $C<τ_0_0>; stored_property #C.x : $τ_0_0) <T>
-  _ = #keyPath2(S<T>, .z.x)
+  _ = \S<T>.z.x
   // CHECK: keypath $ReferenceWritableKeyPath<C<T>, T>, <τ_0_0> (root $C<τ_0_0>; stored_property #C.x : $τ_0_0) <T>
-  _ = #keyPath2(C<T>, .x)
+  _ = \C<T>.x
   // CHECK: keypath $KeyPath<C<T>, String>, <τ_0_0> (root $C<τ_0_0>; stored_property #C.y : $String) <T>
-  _ = #keyPath2(C<T>, .y)
+  _ = \C<T>.y
   // CHECK: keypath $ReferenceWritableKeyPath<C<T>, T>, <τ_0_0> (root $C<τ_0_0>; stored_property #C.z : $S<τ_0_0>; stored_property #S.x : $τ_0_0) <T>
-  _ = #keyPath2(C<T>, .z.x)
+  _ = \C<T>.z.x
   // CHECK: keypath $KeyPath<C<T>, String>, <τ_0_0> (root $C<τ_0_0>; stored_property #C.z : $S<τ_0_0>; stored_property #S.z : $C<τ_0_0>; stored_property #C.y : $String) <T>
-  _ = #keyPath2(C<T>, .z.z.y)
+  _ = \C<T>.z.z.y
 }
 
 // CHECK-LABEL: sil hidden @{{.*}}computedProperties
@@ -55,7 +55,7 @@ func computedProperties<T: P>(_: T) {
   // CHECK-SAME:   getter @_T08keypaths1CC8nonfinalAA1SVyxGvTK : $@convention(thin) <τ_0_0> (@in C<τ_0_0>, @thick C<τ_0_0>.Type) -> @out S<τ_0_0>,
   // CHECK-SAME:   setter @_T08keypaths1CC8nonfinalAA1SVyxGvTk : $@convention(thin) <τ_0_0> (@in S<τ_0_0>, @in C<τ_0_0>, @thick C<τ_0_0>.Type) -> ()
   // CHECK-SAME: ) <T>
-  _ = #keyPath2(C<T>, .nonfinal)
+  _ = \C<T>.nonfinal
 
   // CHECK: keypath $KeyPath<C<T>, S<T>>, <τ_0_0 where τ_0_0 : P> (
   // CHECK-SAME: root $C<τ_0_0>;
@@ -63,7 +63,7 @@ func computedProperties<T: P>(_: T) {
   // CHECK-SAME:   id #C.computed!getter.1 : <T> (C<T>) -> () -> S<T>,
   // CHECK-SAME:   getter @_T08keypaths1CC8computedAA1SVyxGvTK : $@convention(thin) <τ_0_0> (@in C<τ_0_0>, @thick C<τ_0_0>.Type) -> @out S<τ_0_0>
   // CHECK-SAME: ) <T>
-  _ = #keyPath2(C<T>, .computed)
+  _ = \C<T>.computed
 
   // CHECK: keypath $ReferenceWritableKeyPath<C<T>, S<T>>, <τ_0_0 where τ_0_0 : P> (
   // CHECK-SAME: root $C<τ_0_0>;
@@ -72,14 +72,14 @@ func computedProperties<T: P>(_: T) {
   // CHECK-SAME:   getter @_T08keypaths1CC8observedAA1SVyxGvTK : $@convention(thin) <τ_0_0> (@in C<τ_0_0>, @thick C<τ_0_0>.Type) -> @out S<τ_0_0>,
   // CHECK-SAME:   setter @_T08keypaths1CC8observedAA1SVyxGvTk : $@convention(thin) <τ_0_0> (@in S<τ_0_0>, @in C<τ_0_0>, @thick C<τ_0_0>.Type) -> ()
   // CHECK-SAME: ) <T>
-  _ = #keyPath2(C<T>, .observed)
+  _ = \C<T>.observed
 
-  _ = #keyPath2(C<T>, .nonfinal.x)
-  _ = #keyPath2(C<T>, .computed.x)
-  _ = #keyPath2(C<T>, .observed.x)
-  _ = #keyPath2(C<T>, .z.computed)
-  _ = #keyPath2(C<T>, .z.observed)
-  _ = #keyPath2(C<T>, .observed.x)
+  _ = \C<T>.nonfinal.x
+  _ = \C<T>.computed.x
+  _ = \C<T>.observed.x
+  _ = \C<T>.z.computed
+  _ = \C<T>.z.observed
+  _ = \C<T>.observed.x
 
   // CHECK: keypath $ReferenceWritableKeyPath<C<T>, () -> ()>, <τ_0_0 where τ_0_0 : P> (
   // CHECK-SAME: root $C<τ_0_0>;
@@ -88,14 +88,14 @@ func computedProperties<T: P>(_: T) {
   // CHECK-SAME:   getter @_T08keypaths1CC12reabstractedyycvTK : $@convention(thin) <τ_0_0> (@in C<τ_0_0>, @thick C<τ_0_0>.Type) -> @out @callee_owned (@in ()) -> @out (),
   // CHECK-SAME:   setter @_T08keypaths1CC12reabstractedyycvTk : $@convention(thin) <τ_0_0> (@in @callee_owned (@in ()) -> @out (), @in C<τ_0_0>, @thick C<τ_0_0>.Type) -> ()
   // CHECK-SAME: ) <T>
-  _ = #keyPath2(C<T>, .reabstracted)
+  _ = \C<T>.reabstracted
 
   // CHECK: keypath $KeyPath<S<T>, C<T>>, <τ_0_0 where τ_0_0 : P> (
   // CHECK-SAME: root $S<τ_0_0>; gettable_property $C<τ_0_0>,
   // CHECK-SAME: id @_T08keypaths1SV8computedAA1CCyxGfg : $@convention(method) <τ_0_0> (@in_guaranteed S<τ_0_0>) -> @owned C<τ_0_0>,
   // CHECK-SAME:   getter @_T08keypaths1SV8computedAA1CCyxGvTK : $@convention(thin) <τ_0_0> (@in S<τ_0_0>, @thick S<τ_0_0>.Type) -> @out C<τ_0_0>
   // CHECK-SAME: ) <T>
-  _ = #keyPath2(S<T>, .computed)
+  _ = \S<T>.computed
 
   // CHECK: keypath $WritableKeyPath<S<T>, C<T>>, <τ_0_0 where τ_0_0 : P> (
   // CHECK-SAME: root $S<τ_0_0>;
@@ -104,12 +104,12 @@ func computedProperties<T: P>(_: T) {
   // CHECK-SAME:   getter @_T08keypaths1SV8observedAA1CCyxGvTK : $@convention(thin) <τ_0_0> (@in S<τ_0_0>, @thick S<τ_0_0>.Type) -> @out C<τ_0_0>,
   // CHECK-SAME:   setter @_T08keypaths1SV8observedAA1CCyxGvTk : $@convention(thin) <τ_0_0> (@in C<τ_0_0>, @inout S<τ_0_0>, @thick S<τ_0_0>.Type) -> ()
   // CHECK-SAME: ) <T>
-  _ = #keyPath2(S<T>, .observed)
-  _ = #keyPath2(S<T>, .z.nonfinal)
-  _ = #keyPath2(S<T>, .z.computed)
-  _ = #keyPath2(S<T>, .z.observed)
-  _ = #keyPath2(S<T>, .computed.x)
-  _ = #keyPath2(S<T>, .computed.y)
+  _ = \S<T>.observed
+  _ = \S<T>.z.nonfinal
+  _ = \S<T>.z.computed
+  _ = \S<T>.z.observed
+  _ = \S<T>.computed.x
+  _ = \S<T>.computed.y
   // CHECK: keypath $WritableKeyPath<S<T>, () -> ()>, <τ_0_0 where τ_0_0 : P> (
   // CHECK-SAME:  root $S<τ_0_0>;
   // CHECK-SAME:  settable_property $() -> (),
@@ -117,7 +117,7 @@ func computedProperties<T: P>(_: T) {
   // CHECK-SAME:    getter @_T08keypaths1SV12reabstractedyycvTK : $@convention(thin) <τ_0_0> (@in S<τ_0_0>, @thick S<τ_0_0>.Type) -> @out @callee_owned (@in ()) -> @out (),
   // CHECK-SAME:    setter @_T08keypaths1SV12reabstractedyycvTk : $@convention(thin) <τ_0_0> (@in @callee_owned (@in ()) -> @out (), @inout S<τ_0_0>, @thick S<τ_0_0>.Type) -> ()
   // CHECK-SAME: ) <T>
-  _ = #keyPath2(S<T>, .reabstracted)
+  _ = \S<T>.reabstracted
 
   // CHECK: keypath $KeyPath<T, Int>, <τ_0_0 where τ_0_0 : P> (
   // CHECK-SAME: root $τ_0_0;
@@ -125,7 +125,7 @@ func computedProperties<T: P>(_: T) {
   // CHECK-SAME:   id #P.x!getter.1 : <Self where Self : P> (Self) -> () -> Int,
   // CHECK-SAME:   getter @_T08keypaths1PP1xSivTK : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in τ_0_0) -> @out Int
   // CHECK-SAME: ) <T>
-  _ = #keyPath2(T, .x)
+  _ = \T.x
   // CHECK: keypath $WritableKeyPath<T, String>, <τ_0_0 where τ_0_0 : P> (
   // CHECK-SAME: root $τ_0_0;
   // CHECK-SAME: settable_property $String,
@@ -133,5 +133,5 @@ func computedProperties<T: P>(_: T) {
   // CHECK-SAME:   getter @_T08keypaths1PP1ySSvTK : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in τ_0_0) -> @out String,
   // CHECK-SAME:   setter @_T08keypaths1PP1ySSvTk : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in String, @inout τ_0_0) -> ()
   // CHECK-SAME: ) <T>
-  _ = #keyPath2(T, .y)
+  _ = \T.y
 }

--- a/test/SILGen/keypaths_objc.swift
+++ b/test/SILGen/keypaths_objc.swift
@@ -25,21 +25,21 @@ class Bar: NSObject {
 // CHECK-LABEL: sil hidden @_T013keypaths_objc0B8KeypathsyyF
 func objcKeypaths() {
   // CHECK: keypath $WritableKeyPath<NonObjC, Int>, (root
-  _ = #keyPath2(NonObjC, .x)
+  _ = \NonObjC.x
   // CHECK: keypath $WritableKeyPath<NonObjC, NSObject>, (root
-  _ = #keyPath2(NonObjC, .y)
+  _ = \NonObjC.y
   // CHECK: keypath $KeyPath<Foo, Int>, (objc "int"
-  _ = #keyPath2(Foo, .int)
+  _ = \Foo.int
   // CHECK: keypath $KeyPath<Foo, Bar>, (objc "bar"
-  _ = #keyPath2(Foo, .bar)
+  _ = \Foo.bar
   // CHECK: keypath $KeyPath<Foo, Foo>, (objc "bar.foo"
-  _ = #keyPath2(Foo, .bar.foo)
+  _ = \Foo.bar.foo
   // CHECK: keypath $KeyPath<Foo, Bar>, (objc "bar.foo.bar"
-  _ = #keyPath2(Foo, .bar.foo.bar)
+  _ = \Foo.bar.foo.bar
   // CHECK: keypath $KeyPath<Foo, NonObjC>, (root
-  _ = #keyPath2(Foo, .nonobjc)
+  _ = \Foo.nonobjc
   // CHECK: keypath $KeyPath<Foo, NSObject>, (root
-  _ = #keyPath2(Foo, .bar.foo.nonobjc.y)
+  _ = \Foo.bar.foo.nonobjc.y
   // CHECK: keypath $KeyPath<Foo, Bar>, (objc "thisIsADifferentName"
-  _ = #keyPath2(Foo, .differentName)
+  _ = \Foo.differentName
 }

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -39,97 +39,97 @@ struct Exactly<T> {}
 func expect<T>(_ x: inout T, toHaveType _: Exactly<T>.Type) {}
 
 func testKeyPath(sub: Sub, optSub: OptSub, x: Int) {
-  var a = #keyPath2(A, .property)
+  var a = \A.property
   expect(&a, toHaveType: Exactly<WritableKeyPath<A, Prop>>.self)
 
-  var b = #keyPath2(A, [sub])
+  var b = \A.[sub]
   expect(&b, toHaveType: Exactly<WritableKeyPath<A, A>>.self)
 
-  var c = #keyPath2(A, [sub].property)
+  var c = \A.[sub].property
   expect(&c, toHaveType: Exactly<WritableKeyPath<A, Prop>>.self)
 
-  var d = #keyPath2(A, .optProperty?)
+  var d = \A.optProperty?
   expect(&d, toHaveType: Exactly<KeyPath<A, Prop?>>.self)
 
-  var e = #keyPath2(A, .optProperty?[sub])
+  var e = \A.optProperty?[sub]
   expect(&e, toHaveType: Exactly<KeyPath<A, A?>>.self)
 
-  var f = #keyPath2(A, .optProperty!)
+  var f = \A.optProperty!
   expect(&f, toHaveType: Exactly<WritableKeyPath<A, Prop>>.self)
 
-  var g = #keyPath2(A, .property[optSub]?.optProperty![sub])
+  var g = \A.property[optSub]?.optProperty![sub]
   expect(&g, toHaveType: Exactly<KeyPath<A, A?>>.self)
 
-  var h = #keyPath2([A], .property)
+  var h = \[A].property
   expect(&h, toHaveType: Exactly<KeyPath<[A], Prop>>.self)
 
-  var i = #keyPath2([A], .property.nonMutatingProperty)
+  var i = \[A].property.nonMutatingProperty
   expect(&i, toHaveType: Exactly<ReferenceWritableKeyPath<[A], B>>.self)
 
-  var j = #keyPath2([A], [x])
+  var j = \[A].[x]
   expect(&j, toHaveType: Exactly<WritableKeyPath<[A], A>>.self)
 
-  var k = #keyPath2([A: B], [A()])
+  var k = \[A: B].[A()]
   expect(&k, toHaveType: Exactly<WritableKeyPath<[A: B], B?>>.self)
 
-  var l = #keyPath2(C<A>, .value)
+  var l = \C<A>.value
   expect(&l, toHaveType: Exactly<WritableKeyPath<C<A>, A>>.self)
 
   // expected-error@+1{{generic parameter 'T' could not be inferred}}
-  _ = #keyPath2(C, .value)
+  _ = \C.value
 
   // expected-error@+1{{}}
-  _ = #keyPath2(() -> (), .noMember)
+  _ = \(() -> ()).noMember
 
-  // FIXME crash let _: PartialKeyPath<A> = #keyPath2(.property)
-  let _: KeyPath<A, Prop> = #keyPath2(.property)
-  let _: WritableKeyPath<A, Prop> = #keyPath2(.property)
+  // FIXME crash let _: PartialKeyPath<A> = \.property
+  let _: KeyPath<A, Prop> = \.property
+  let _: WritableKeyPath<A, Prop> = \.property
   // expected-error@+1{{ambiguous}} (need to improve diagnostic)
-  let _: ReferenceWritableKeyPath<A, Prop> = #keyPath2(.property)
+  let _: ReferenceWritableKeyPath<A, Prop> = \.property
 
-  // FIXME crash let _: PartialKeyPath<A> = #keyPath2([sub])
+  // FIXME crash let _: PartialKeyPath<A> = \[sub]
   // FIXME should resolve: expected-error@+1{{}}
-  let _: KeyPath<A, A> = #keyPath2([sub])
+  let _: KeyPath<A, A> = \.[sub]
   // FIXME should resolve: expected-error@+1{{}}
-  let _: WritableKeyPath<A, A> = #keyPath2([sub])
+  let _: WritableKeyPath<A, A> = \.[sub]
   // expected-error@+1{{ambiguous}} (need to improve diagnostic)
-  let _: ReferenceWritableKeyPath<A, A> = #keyPath2([sub])
+  let _: ReferenceWritableKeyPath<A, A> = \.[sub]
 
-  // FIXME crash let _: PartialKeyPath<A> = #keyPath2(.optProperty?)
-  let _: KeyPath<A, Prop?> = #keyPath2(.optProperty?)
+  // FIXME crash let _: PartialKeyPath<A> = \.optProperty?
+  let _: KeyPath<A, Prop?> = \.optProperty?
   // expected-error@+1{{cannot convert}}
-  let _: WritableKeyPath<A, Prop?> = #keyPath2(.optProperty?)
+  let _: WritableKeyPath<A, Prop?> = \.optProperty?
   // expected-error@+1{{cannot convert}}
-  let _: ReferenceWritableKeyPath<A, Prop?> = #keyPath2(.optProperty?)
+  let _: ReferenceWritableKeyPath<A, Prop?> = \.optProperty?
 
-  // FIXME crash let _: PartialKeyPath<A> = #keyPath2(.optProperty?[sub])
-  let _: KeyPath<A, A?> = #keyPath2(.optProperty?[sub])
+  // FIXME crash let _: PartialKeyPath<A> = \.optProperty?[sub]
+  let _: KeyPath<A, A?> = \.optProperty?[sub]
   // expected-error@+1{{cannot convert}}
-  let _: WritableKeyPath<A, A?> = #keyPath2(.optProperty?[sub])
+  let _: WritableKeyPath<A, A?> = \.optProperty?[sub]
   // expected-error@+1{{cannot convert}}
-  let _: ReferenceWritableKeyPath<A, A?> = #keyPath2(.optProperty?[sub])
+  let _: ReferenceWritableKeyPath<A, A?> = \.optProperty?[sub]
 
   // FIXME should resolve: expected-error@+1{{}}
-  let _: KeyPath<A, Prop> = #keyPath2(.optProperty!)
+  let _: KeyPath<A, Prop> = \.optProperty!
   // FIXME should resolve: expected-error@+1{{}}
-  let _: KeyPath<A, Prop?> = #keyPath2(.property[optSub]?.optProperty![sub])
+  let _: KeyPath<A, Prop?> = \.property[optSub]?.optProperty![sub]
 
-  // FIXME crash let _: PartialKeyPath<C<A>> = #keyPath2(.value)
-  let _: KeyPath<C<A>, A> = #keyPath2(.value)
-  let _: WritableKeyPath<C<A>, A> = #keyPath2(.value)
+  // FIXME crash let _: PartialKeyPath<C<A>> = \.value
+  let _: KeyPath<C<A>, A> = \.value
+  let _: WritableKeyPath<C<A>, A> = \.value
   // expected-error@+1{{ambiguous}} (need to improve diagnostic)
-  let _: ReferenceWritableKeyPath<C<A>, A> = #keyPath2(.value)
+  let _: ReferenceWritableKeyPath<C<A>, A> = \.value
 
-  // FIXME crash let _: PartialKeyPath<C<A>> = #keyPath2(C, .value)
-  let _: KeyPath<C<A>, A> = #keyPath2(C, .value)
-  let _: WritableKeyPath<C<A>, A> = #keyPath2(C, .value)
+  // FIXME crash let _: PartialKeyPath<C<A>> = \C, .value
+  let _: KeyPath<C<A>, A> = \C.value
+  let _: WritableKeyPath<C<A>, A> = \C.value
   // expected-error@+1{{cannot convert}}
-  let _: ReferenceWritableKeyPath<C<A>, A> = #keyPath2(C, .value)
+  let _: ReferenceWritableKeyPath<C<A>, A> = \C.value
 
-  // FIXME crash let _: PartialKeyPath<Prop> = #keyPath2(.nonMutatingProperty)
-  let _: KeyPath<Prop, B> = #keyPath2(.nonMutatingProperty)
-  let _: WritableKeyPath<Prop, B> = #keyPath2(.nonMutatingProperty)
-  let _: ReferenceWritableKeyPath<Prop, B> = #keyPath2(.nonMutatingProperty)
+  // FIXME crash let _: PartialKeyPath<Prop> = \.nonMutatingProperty
+  let _: KeyPath<Prop, B> = \.nonMutatingProperty
+  let _: WritableKeyPath<Prop, B> = \.nonMutatingProperty
+  let _: ReferenceWritableKeyPath<Prop, B> = \.nonMutatingProperty
 }
 
 struct Z { }
@@ -196,35 +196,35 @@ func testKeyPathSubscriptTuple(readonly: (Z,Z), writable: inout (Z,Z),
 
 func testSyntaxErrors() { // expected-note{{}}
   // TODO: recovery
-  _ = #keyPath2(.  ; // expected-error{{expected property or type name}}
-  _ = #keyPath2(.a ;
-  _ = #keyPath2([a ;
-  _ = #keyPath2([a];
-  _ = #keyPath2(?  ;
-  _ = #keyPath2(!  ;
-  _ = #keyPath2(.  ;
-  _ = #keyPath2(.a ;
-  _ = #keyPath2([a ;
-  _ = #keyPath2([a,;
-  _ = #keyPath2([a:;
-  _ = #keyPath2([a];
-  _ = #keyPath2(.a?;
-  _ = #keyPath2(.a!;
-  _ = #keyPath2(A     ;
-  _ = #keyPath2(A,    ;
-  _ = #keyPath2(A<    ;
-  _ = #keyPath2(A, .  ;
-  _ = #keyPath2(A, .a ;
-  _ = #keyPath2(A, [a ;
-  _ = #keyPath2(A, [a];
-  _ = #keyPath2(A, ?  ;
-  _ = #keyPath2(A, !  ;
-  _ = #keyPath2(A, .  ;
-  _ = #keyPath2(A, .a ;
-  _ = #keyPath2(A, [a ;
-  _ = #keyPath2(A, [a,;
-  _ = #keyPath2(A, [a:;
-  _ = #keyPath2(A, [a];
-  _ = #keyPath2(A, .a?;
-  _ = #keyPath2(A, .a!;
+  _ = \.  ; // expected-error{{expected member name following '.'}}
+  _ = \.a ;
+  _ = \[a ;
+  _ = \[a];
+  _ = \?  ;
+  _ = \!  ;
+  _ = \.  ; // expected-error{{expected member name following '.'}}
+  _ = \.a ;
+  _ = \[a ;
+  _ = \[a,;
+  _ = \[a:;
+  _ = \[a];
+  _ = \.a?;
+  _ = \.a!;
+  _ = \A     ;
+  _ = \A,    ;
+  _ = \A<    ;
+  _ = \A.  ; // expected-error{{expected member name following '.'}}
+  _ = \A.a ;
+  _ = \A[a ;
+  _ = \A[a];
+  _ = \A?  ;
+  _ = \A!  ;
+  _ = \A.  ; // expected-error{{expected member name following '.'}}
+  _ = \A.a ;
+  _ = \A[a ;
+  _ = \A[a,;
+  _ = \A[a:;
+  _ = \A[a];
+  _ = \A.a?;
+  _ = \A.a!;
 } // expected-error@+1{{}}

--- a/test/stdlib/KeyPath.swift
+++ b/test/stdlib/KeyPath.swift
@@ -78,24 +78,24 @@ struct ComputedB {
 
 keyPath.test("key path in-place instantiation") {
   for _ in 1...2 {
-    let s_x = (#keyPath2(S<Int>, .x) as AnyKeyPath) as! WritableKeyPath<S<Int>, Int>
-    let s_y = (#keyPath2(S<Int>, .y) as AnyKeyPath) as! WritableKeyPath<S<Int>, LifetimeTracked?>
-    let s_z = (#keyPath2(S<Int>, .z) as AnyKeyPath) as! WritableKeyPath<S<Int>, Int>
-    let s_p = (#keyPath2(S<Int>, .p) as AnyKeyPath) as! WritableKeyPath<S<Int>, Point>
-    let s_p_x = (#keyPath2(S<Int>, .p.x) as AnyKeyPath) as! WritableKeyPath<S<Int>, Double>
-    let s_p_y = (#keyPath2(S<Int>, .p.y) as AnyKeyPath) as! WritableKeyPath<S<Int>, Double>
-    let s_c = (#keyPath2(S<Int>, .c) as AnyKeyPath) as! WritableKeyPath<S<Int>, C<Int>>
-    let s_c_x = (#keyPath2(S<Int>, .c.x) as AnyKeyPath) as! ReferenceWritableKeyPath<S<Int>, Int>
+    let s_x = (\S<Int>.x as AnyKeyPath) as! WritableKeyPath<S<Int>, Int>
+    let s_y = (\S<Int>.y as AnyKeyPath) as! WritableKeyPath<S<Int>, LifetimeTracked?>
+    let s_z = (\S<Int>.z as AnyKeyPath) as! WritableKeyPath<S<Int>, Int>
+    let s_p = (\S<Int>.p as AnyKeyPath) as! WritableKeyPath<S<Int>, Point>
+    let s_p_x = (\S<Int>.p.x as AnyKeyPath) as! WritableKeyPath<S<Int>, Double>
+    let s_p_y = (\S<Int>.p.y as AnyKeyPath) as! WritableKeyPath<S<Int>, Double>
+    let s_c = (\S<Int>.c as AnyKeyPath) as! WritableKeyPath<S<Int>, C<Int>>
+    let s_c_x = (\S<Int>.c.x as AnyKeyPath) as! ReferenceWritableKeyPath<S<Int>, Int>
 
-    let c_x = (#keyPath2(C<Int>, .x) as AnyKeyPath) as! ReferenceWritableKeyPath<C<Int>, Int>
+    let c_x = (\C<Int>.x as AnyKeyPath) as! ReferenceWritableKeyPath<C<Int>, Int>
     let s_c_x_2 = s_c.appending(path: c_x)
 
     expectEqual(s_c_x, s_c_x_2)
     expectEqual(s_c_x_2, s_c_x)
     expectEqual(s_c_x.hashValue, s_c_x_2.hashValue)
 
-    let point_x = (#keyPath2(Point, .x) as AnyKeyPath) as! WritableKeyPath<Point, Double>
-    let point_y = (#keyPath2(Point, .y) as AnyKeyPath) as! WritableKeyPath<Point, Double>
+    let point_x = (\Point.x as AnyKeyPath) as! WritableKeyPath<Point, Double>
+    let point_y = (\Point.y as AnyKeyPath) as! WritableKeyPath<Point, Double>
 
     let s_p_x_2 = s_p.appending(path: point_x)
     let s_p_y_2 = s_p.appending(path: point_y)
@@ -107,19 +107,19 @@ keyPath.test("key path in-place instantiation") {
     expectEqual(s_p_y_2, s_p_y)
     expectEqual(s_p_y_2.hashValue, s_p_y.hashValue)
 
-    let ca_readOnly = (#keyPath2(ComputedA, .readOnly) as AnyKeyPath) as! KeyPath<ComputedA, ComputedB>
-    let ca_nonmutating = (#keyPath2(ComputedA, .nonmutating) as AnyKeyPath) as! ReferenceWritableKeyPath<ComputedA, ComputedB>
-    let ca_reabstracted = (#keyPath2(ComputedA, .reabstracted) as AnyKeyPath) as! ReferenceWritableKeyPath<ComputedA, () -> ()>
+    let ca_readOnly = (\ComputedA.readOnly as AnyKeyPath) as! KeyPath<ComputedA, ComputedB>
+    let ca_nonmutating = (\ComputedA.nonmutating as AnyKeyPath) as! ReferenceWritableKeyPath<ComputedA, ComputedB>
+    let ca_reabstracted = (\ComputedA.reabstracted as AnyKeyPath) as! ReferenceWritableKeyPath<ComputedA, () -> ()>
 
-    let cb_readOnly = (#keyPath2(ComputedB, .readOnly) as AnyKeyPath) as! KeyPath<ComputedB, ComputedA>
-    let cb_mutating = (#keyPath2(ComputedB, .mutating) as AnyKeyPath) as! WritableKeyPath<ComputedB, ComputedA>
-    let cb_nonmutating = (#keyPath2(ComputedB, .nonmutating) as AnyKeyPath) as! ReferenceWritableKeyPath<ComputedB, ComputedA>
-    let cb_reabstracted = (#keyPath2(ComputedB, .reabstracted) as AnyKeyPath) as! WritableKeyPath<ComputedB, () -> ()>
+    let cb_readOnly = (\ComputedB.readOnly as AnyKeyPath) as! KeyPath<ComputedB, ComputedA>
+    let cb_mutating = (\ComputedB.mutating as AnyKeyPath) as! WritableKeyPath<ComputedB, ComputedA>
+    let cb_nonmutating = (\ComputedB.nonmutating as AnyKeyPath) as! ReferenceWritableKeyPath<ComputedB, ComputedA>
+    let cb_reabstracted = (\ComputedB.reabstracted as AnyKeyPath) as! WritableKeyPath<ComputedB, () -> ()>
   
-    let ca_readOnly_mutating = (#keyPath2(ComputedA, .readOnly.mutating) as AnyKeyPath) as! KeyPath<ComputedA, ComputedA>
-    let cb_mutating_readOnly = (#keyPath2(ComputedB, .mutating.readOnly) as AnyKeyPath) as! KeyPath<ComputedB, ComputedB>
-    let ca_readOnly_nonmutating = (#keyPath2(ComputedA, .readOnly.nonmutating) as AnyKeyPath) as! ReferenceWritableKeyPath<ComputedA, ComputedA>
-    let cb_readOnly_reabstracted = (#keyPath2(ComputedB, .readOnly.reabstracted) as AnyKeyPath) as! ReferenceWritableKeyPath<ComputedB, () -> ()>
+    let ca_readOnly_mutating = (\ComputedA.readOnly.mutating as AnyKeyPath) as! KeyPath<ComputedA, ComputedA>
+    let cb_mutating_readOnly = (\ComputedB.mutating.readOnly as AnyKeyPath) as! KeyPath<ComputedB, ComputedB>
+    let ca_readOnly_nonmutating = (\ComputedA.readOnly.nonmutating as AnyKeyPath) as! ReferenceWritableKeyPath<ComputedA, ComputedA>
+    let cb_readOnly_reabstracted = (\ComputedB.readOnly.reabstracted as AnyKeyPath) as! ReferenceWritableKeyPath<ComputedB, () -> ()>
 
     let ca_readOnly_mutating2 = ca_readOnly.appending(path: cb_mutating)
     expectEqual(ca_readOnly_mutating, ca_readOnly_mutating2)
@@ -150,24 +150,24 @@ keyPath.test("key path in-place instantiation") {
 keyPath.test("key path generic instantiation") {
   func testWithGenericParam<T: Equatable>(_: T.Type) -> ReferenceWritableKeyPath<S<T>, Int> {
     for i in 1...2 {
-      let s_x = (#keyPath2(S<T>, .x) as AnyKeyPath) as! WritableKeyPath<S<T>, Int>
-      let s_y = (#keyPath2(S<T>, .y) as AnyKeyPath) as! WritableKeyPath<S<T>, LifetimeTracked?>
-      let s_z = (#keyPath2(S<T>, .z) as AnyKeyPath) as! WritableKeyPath<S<T>, T>
-      let s_p = (#keyPath2(S<T>, .p) as AnyKeyPath) as! WritableKeyPath<S<T>, Point>
-      let s_p_x = (#keyPath2(S<T>, .p.x) as AnyKeyPath) as! WritableKeyPath<S<T>, Double>
-      let s_p_y = (#keyPath2(S<T>, .p.y) as AnyKeyPath) as! WritableKeyPath<S<T>, Double>
-      let s_c = (#keyPath2(S<T>, .c) as AnyKeyPath) as! WritableKeyPath<S<T>, C<T>>
-      let s_c_x = (#keyPath2(S<T>, .c.x) as AnyKeyPath) as! ReferenceWritableKeyPath<S<T>, Int>
+      let s_x = (\S<T>.x as AnyKeyPath) as! WritableKeyPath<S<T>, Int>
+      let s_y = (\S<T>.y as AnyKeyPath) as! WritableKeyPath<S<T>, LifetimeTracked?>
+      let s_z = (\S<T>.z as AnyKeyPath) as! WritableKeyPath<S<T>, T>
+      let s_p = (\S<T>.p as AnyKeyPath) as! WritableKeyPath<S<T>, Point>
+      let s_p_x = (\S<T>.p.x as AnyKeyPath) as! WritableKeyPath<S<T>, Double>
+      let s_p_y = (\S<T>.p.y as AnyKeyPath) as! WritableKeyPath<S<T>, Double>
+      let s_c = (\S<T>.c as AnyKeyPath) as! WritableKeyPath<S<T>, C<T>>
+      let s_c_x = (\S<T>.c.x as AnyKeyPath) as! ReferenceWritableKeyPath<S<T>, Int>
 
-      let c_x = (#keyPath2(C<T>, .x) as AnyKeyPath) as! ReferenceWritableKeyPath<C<T>, Int>
+      let c_x = (\C<T>.x as AnyKeyPath) as! ReferenceWritableKeyPath<C<T>, Int>
       let s_c_x_2 = s_c.appending(path: c_x)
 
       expectEqual(s_c_x, s_c_x_2)
       expectEqual(s_c_x_2, s_c_x)
       expectEqual(s_c_x.hashValue, s_c_x_2.hashValue)
 
-      let point_x = (#keyPath2(Point, .x) as AnyKeyPath) as! WritableKeyPath<Point, Double>
-      let point_y = (#keyPath2(Point, .y) as AnyKeyPath) as! WritableKeyPath<Point, Double>
+      let point_x = (\Point.x as AnyKeyPath) as! WritableKeyPath<Point, Double>
+      let point_y = (\Point.y as AnyKeyPath) as! WritableKeyPath<Point, Double>
 
       let s_p_x_2 = s_p.appending(path: point_x)
       let s_p_y_2 = s_p.appending(path: point_y)
@@ -184,15 +184,15 @@ keyPath.test("key path generic instantiation") {
     fatalError()
   }
   let s_c_x_int = testWithGenericParam(Int.self)
-  let s_c_x_int2 = #keyPath2(S<Int>, .c.x)
+  let s_c_x_int2 = \S<Int>.c.x
   expectEqual(s_c_x_int, s_c_x_int2)
 
   let s_c_x_string = testWithGenericParam(String.self)
-  let s_c_x_string2 = #keyPath2(S<String>, .c.x)
+  let s_c_x_string2 = \S<String>.c.x
   expectEqual(s_c_x_string, s_c_x_string2)
 
   let s_c_x_lt = testWithGenericParam(LifetimeTracked.self)
-  let s_c_x_lt2 = #keyPath2(S<LifetimeTracked>, .c.x)
+  let s_c_x_lt2 = \S<LifetimeTracked>.c.x
   expectEqual(s_c_x_lt, s_c_x_lt2)
 }
 

--- a/test/stdlib/KeyPathObjC.swift
+++ b/test/stdlib/KeyPathObjC.swift
@@ -33,22 +33,22 @@ class Bar: NSObject {
 var testKVCStrings = TestSuite("KVC strings")
 
 testKVCStrings.test("KVC strings") {
-  expectEqual((#keyPath2(NonObjC, .x))._kvcKeyPathString, nil)
-  expectEqual((#keyPath2(NonObjC, .y))._kvcKeyPathString, nil)
-  expectEqual((#keyPath2(Foo, .int))._kvcKeyPathString, "int")
-  expectEqual((#keyPath2(Foo, .bar))._kvcKeyPathString, "bar")
-  expectEqual((#keyPath2(Foo, .bar.foo))._kvcKeyPathString, "bar.foo")
-  expectEqual((#keyPath2(Foo, .bar.foo.bar))._kvcKeyPathString, "bar.foo.bar")
-  expectEqual((#keyPath2(Foo, .nonobjc))._kvcKeyPathString, nil)
-  expectEqual((#keyPath2(Foo, .bar.foo.nonobjc.y))._kvcKeyPathString, nil)
-  expectEqual((#keyPath2(Foo, .differentName))._kvcKeyPathString, "thisIsADifferentName")
-  expectEqual((#keyPath2(Bar, .foo))._kvcKeyPathString, "foo")
+  expectEqual((\NonObjC.x)._kvcKeyPathString, nil)
+  expectEqual((\NonObjC.y)._kvcKeyPathString, nil)
+  expectEqual((\Foo.int)._kvcKeyPathString, "int")
+  expectEqual((\Foo.bar)._kvcKeyPathString, "bar")
+  expectEqual((\Foo.bar.foo)._kvcKeyPathString, "bar.foo")
+  expectEqual((\Foo.bar.foo.bar)._kvcKeyPathString, "bar.foo.bar")
+  expectEqual((\Foo.nonobjc)._kvcKeyPathString, nil)
+  expectEqual((\Foo.bar.foo.nonobjc.y)._kvcKeyPathString, nil)
+  expectEqual((\Foo.differentName)._kvcKeyPathString, "thisIsADifferentName")
+  expectEqual((\Bar.foo)._kvcKeyPathString, "foo")
 
-  let foo_bar = #keyPath2(Foo, .bar)
-  let foo_nonobjc = #keyPath2(Foo, .nonobjc)
-  let bar_foo = #keyPath2(Bar, .foo)
+  let foo_bar = \Foo.bar
+  let foo_nonobjc = \Foo.nonobjc
+  let bar_foo = \Bar.foo
 
-  let nonobjc_y = #keyPath2(NonObjC, .y)
+  let nonobjc_y = \NonObjC.y
 
   do {
     let foo_bar_foo = foo_bar.appending(path: bar_foo)


### PR DESCRIPTION
This introduces a few unfortunate things because the syntax is awkward.
In particular, the period and following token in \.[a], \.? and \.! are
token sequences that don't appear anywhere else in Swift, and so need
special handling. This is somewhat compounded by \foo.bar.baz possibly
being \(foo).bar.baz or \(foo.bar).baz (parens around the type), and,
furthermore, needing to distinguish \Foo?.bar from \Foo.?bar.

rdar://problem/31724243