### PR TITLE
[Constraint solver] Fix Swift 3 compatibility issue with overloaded o…

### DIFF
--- a/test/Constraints/overload.swift
+++ b/test/Constraints/overload.swift
@@ -209,3 +209,16 @@ func test_f6() {
 	let _: (X1a) -> Void = f6
 	let _: (X1a) -> X6 = X6.init
 }
+
+func curry<LHS, RHS, R>(_ f: @escaping (LHS, RHS) -> R) -> (LHS) -> (RHS) -> R {
+  return { lhs in { rhs in f(lhs, rhs) } }
+}
+
+// We need to have an alternative version of this to ensure that there's an overload disjunction created.
+func curry<F, S, T, R>(_ f: @escaping (F, S, T) -> R) -> (F) -> (S) -> (T) -> R {
+  return { fst in { snd in { thd in f(fst, snd, thd) } } }
+}
+
+// Ensure that we consider these unambiguous
+let _ = curry(+)(1)
+let _ = [0].reduce(0, +)


### PR DESCRIPTION
…perators.

Recent changes to the stdlib resulted in some expressions involving
literals and operators that have both generic and non-generic overloads
to become ambiguous. The ambiguity is due to an old performance hack in
the solver which unfortunately needs to remain in place at the moment to
avoid regressing expression type checker performance.

This commit changes the performance hack a bit in that instead of
stopping visiting the options in a disjunction as soon as we have a
solution involving non-generic operators and come across a constraint
involving generic operators, we instead continue visiting the elements
in the disjunction, but just skip over the generic operators.

Fixes rdar://problem/31695865 and rdar://problem/31698831.
