### PR TITLE
SILCloner: Map opened types using Type::subst instead of transform.

### DIFF
--- a/include/swift/AST/Type.h
+++ b/include/swift/AST/Type.h
@@ -73,6 +73,15 @@ struct QueryTypeSubstitutionMap {
 };
 
 /// A function object suitable for use as a \c TypeSubstitutionFn that
+/// queries an underlying \c TypeSubstitutionMap, or returns the original type
+/// if no match was found.
+struct QueryTypeSubstitutionMapOrIdentity {
+  const TypeSubstitutionMap &substitutions;
+  
+  Type operator()(SubstitutableType *type) const;
+};
+
+/// A function object suitable for use as a \c TypeSubstitutionFn that
 /// queries an underlying \c SubstitutionMap.
 struct QuerySubstitutionMap {
   const SubstitutionMap &subMap;

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -50,6 +50,16 @@ Type QueryTypeSubstitutionMap::operator()(SubstitutableType *type) const {
   return Type();
 }
 
+Type
+QueryTypeSubstitutionMapOrIdentity::operator()(SubstitutableType *type) const {
+  auto key = type->getCanonicalType()->castTo<SubstitutableType>();
+  auto known = substitutions.find(key);
+  if (known != substitutions.end() && known->second)
+    return known->second;
+  
+  return type;
+}
+
 Type QuerySubstitutionMap::operator()(SubstitutableType *type) const {
   auto key = cast<SubstitutableType>(type->getCanonicalType());
   return subMap.lookupSubstitution(key);


### PR DESCRIPTION
transform doesn't handle conformances properly, so it blows up on SILBoxTypes (and would eventually blow up on BoundGenericTypes if we ever model their arguments properly as substitution lists). Fixes rdar://problem/31941811.
