### PR TITLE
Warn about NSCoding classes with unstable mangled names

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -277,6 +277,10 @@ DECL_ATTR(NSKeyedArchiveLegacy, NSKeyedArchiveLegacy,
           OnClass | NotSerialized | LongAttribute,
           /*Not serialized */ 68)
 
+SIMPLE_DECL_ATTR(_staticInitializeObjCMetadata, StaticInitializeObjCMetadata,
+                 OnClass | NotSerialized | LongAttribute | UserInaccessible,
+                 /*Not serialized */ 69)
+
 #undef TYPE_ATTR
 #undef DECL_ATTR_ALIAS
 #undef SIMPLE_DECL_ATTR

--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -273,6 +273,10 @@ DECL_ATTR(_implements, Implements,
           | NotSerialized | UserInaccessible,
           /* Not serialized */ 67)
 
+DECL_ATTR(NSKeyedArchiveLegacy, NSKeyedArchiveLegacy,
+          OnClass | NotSerialized | LongAttribute,
+          /*Not serialized */ 68)
+
 #undef TYPE_ATTR
 #undef DECL_ATTR_ALIAS
 #undef SIMPLE_DECL_ATTR

--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -281,6 +281,11 @@ SIMPLE_DECL_ATTR(_staticInitializeObjCMetadata, StaticInitializeObjCMetadata,
                  OnClass | NotSerialized | LongAttribute | UserInaccessible,
                  /*Not serialized */ 69)
 
+SIMPLE_DECL_ATTR(NSKeyedArchiveSubclassesOnly,
+                 NSKeyedArchiveSubclassesOnly,
+                 OnClass | NotSerialized | LongAttribute,
+                 /*Not serialized */ 70)
+
 #undef TYPE_ATTR
 #undef DECL_ATTR_ALIAS
 #undef SIMPLE_DECL_ATTR

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -1158,6 +1158,24 @@ public:
   }
 };
 
+/// Defines the @NSKeyedArchiveLegacyAttr attribute.
+class NSKeyedArchiveLegacyAttr : public DeclAttribute {
+public:
+  NSKeyedArchiveLegacyAttr(StringRef Name, SourceLoc AtLoc, SourceRange Range, bool Implicit)
+    : DeclAttribute(DAK_NSKeyedArchiveLegacy, AtLoc, Range, Implicit),
+      Name(Name) {}
+
+  NSKeyedArchiveLegacyAttr(StringRef Name, bool Implicit)
+    : NSKeyedArchiveLegacyAttr(Name, SourceLoc(), SourceRange(), /*Implicit=*/true) {}
+
+  /// The legacy mangled name.
+  const StringRef Name;
+
+  static bool classof(const DeclAttribute *DA) {
+    return DA->getKind() == DAK_NSKeyedArchiveLegacy;
+  }
+};
+
 /// \brief Attributes that may be applied to declarations.
 class DeclAttributes {
   /// Linked list of declaration attributes.

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1223,6 +1223,9 @@ WARNING(nscoding_unstable_mangled_name_warn,none,
 NOTE(add_nskeyedarchivelegacy_attr,none,
      "add the '@NSKeyedArchiveLegacy' attribute to specify the class name "
      "used for archiving", ())
+ERROR(attr_nskeyedarchivelegacy_generic,none,
+      "@NSKeyedArchiveLegacy attribute cannot be applied to generic class %0",
+      (Type))
 
 // Generic types
 ERROR(unsupported_type_nested_in_generic_function,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1220,11 +1220,14 @@ WARNING(nscoding_unstable_mangled_name_warn,none,
         "%select{private|fileprivate|nested|local|generic}0 class %1 has an "
         "unstable name when archiving via 'NSCoding'",
         (unsigned, Type))
-NOTE(add_nskeyedarchivelegacy_attr,none,
-     "add the '@NSKeyedArchiveLegacy' attribute to specify the class name "
-     "used for archiving", ())
+NOTE(unstable_mangled_name_add_objc,none,
+     "for new classes, add '@objc' to specify a unique, prefixed Objective-C "
+     "runtime name", ())
+NOTE(unstable_mangled_name_add_nskeyedarchivelegacy,none,
+     "for compatibility with existing archives, use '@NSKeyedArchiveLegacy' "
+     "to record the Swift 3 mangled name", ())
 ERROR(attr_nskeyedarchivelegacy_generic,none,
-      "@NSKeyedArchiveLegacy attribute cannot be applied to generic class %0",
+      "'@NSKeyedArchiveLegacy' cannot be applied to generic class %0",
       (Type))
 
 // Generic types

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1212,6 +1212,15 @@ ERROR(pattern_binds_no_variables,none,
       "variables",
       (unsigned))
 
+ERROR(nscoding_unstable_mangled_name,none,
+      "%select{private|fileprivate|nested|generic}0 class %1 has an unstable "
+      "name when archiving via 'NSCoding'",
+      (unsigned, Type))
+WARNING(nscoding_unstable_mangled_name_warn,none,
+        "%select{private|fileprivate|nested|generic}0 class %1 has an unstable "
+        "name when archiving via 'NSCoding'",
+        (unsigned, Type))
+
 
 // Generic types
 ERROR(unsupported_type_nested_in_generic_function,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1213,12 +1213,12 @@ ERROR(pattern_binds_no_variables,none,
       (unsigned))
 
 ERROR(nscoding_unstable_mangled_name,none,
-      "%select{private|fileprivate|nested|generic}0 class %1 has an unstable "
-      "name when archiving via 'NSCoding'",
+      "%select{private|fileprivate|nested|local|generic}0 class %1 has an "
+      "unstable name when archiving via 'NSCoding'",
       (unsigned, Type))
 WARNING(nscoding_unstable_mangled_name_warn,none,
-        "%select{private|fileprivate|nested|generic}0 class %1 has an unstable "
-        "name when archiving via 'NSCoding'",
+        "%select{private|fileprivate|nested|local|generic}0 class %1 has an "
+        "unstable name when archiving via 'NSCoding'",
         (unsigned, Type))
 NOTE(add_nskeyedarchivelegacy_attr,none,
      "add the '@NSKeyedArchiveLegacy' attribute to specify the class name "

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1226,6 +1226,11 @@ NOTE(unstable_mangled_name_add_objc,none,
 NOTE(unstable_mangled_name_add_nskeyedarchivelegacy,none,
      "for compatibility with existing archives, use '@NSKeyedArchiveLegacy' "
      "to record the Swift 3 mangled name", ())
+NOTE(add_nskeyedarchivesubclassesonly_attr,none,
+     "generic classes should not be archived directly; "
+     "add @NSKeyedArchiveSubclassesOnly "
+     "and only archive specific subclasses of this class", (Type))
+
 ERROR(attr_nskeyedarchivelegacy_generic,none,
       "'@NSKeyedArchiveLegacy' cannot be applied to generic class %0",
       (Type))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1220,7 +1220,9 @@ WARNING(nscoding_unstable_mangled_name_warn,none,
         "%select{private|fileprivate|nested|generic}0 class %1 has an unstable "
         "name when archiving via 'NSCoding'",
         (unsigned, Type))
-
+NOTE(add_nskeyedarchivelegacy_attr,none,
+     "add the '@NSKeyedArchiveLegacy' attribute to specify the class name "
+     "used for archiving", ())
 
 // Generic types
 ERROR(unsupported_type_nested_in_generic_function,none,

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -1314,6 +1314,8 @@ namespace decls_block {
   using SynthesizedProtocolDeclAttrLayout
     = BCRecordLayout<SynthesizedProtocol_DECL_ATTR>;
   using ImplementsDeclAttrLayout = BCRecordLayout<Implements_DECL_ATTR>;
+  using NSKeyedArchiveLegacyDeclAttrLayout
+    = BCRecordLayout<NSKeyedArchiveLegacy_DECL_ATTR>;
 
   using InlineDeclAttrLayout = BCRecordLayout<
     Inline_DECL_ATTR,

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -855,6 +855,8 @@ namespace {
 
     void visitClassDecl(ClassDecl *CD) {
       printCommon(CD, "class_decl");
+      if (CD->getAttrs().hasAttribute<StaticInitializeObjCMetadataAttr>())
+        OS << " @_staticInitializeObjCMetadata";
       printInherited(CD->getInherited());
       for (Decl *D : CD->getMembers()) {
         OS << '\n';

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -493,6 +493,15 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
     break;
   }
 
+  case DAK_NSKeyedArchiveLegacy: {
+    Printer.printAttrName("@NSKeyedArchiveLegacy");
+    Printer << "(";
+    auto *attr = cast<NSKeyedArchiveLegacyAttr>(this);
+    Printer << "\"" << attr->Name << "\"";
+    Printer << ")";
+    break;
+  }
+
   case DAK_Count:
     llvm_unreachable("exceed declaration attribute kinds");
 
@@ -609,6 +618,8 @@ StringRef DeclAttribute::getAttrName() const {
     return "_specialize";
   case DAK_Implements:
     return "_implements";
+  case DAK_NSKeyedArchiveLegacy:
+    return "NSKeyedArchiveLegacy";
   }
   llvm_unreachable("bad DeclAttrKind");
 }

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -502,6 +502,10 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
     break;
   }
 
+  case DAK_StaticInitializeObjCMetadata:
+    Printer.printAttrName("@_staticInitializeObjCMetadata");
+    break;
+
   case DAK_Count:
     llvm_unreachable("exceed declaration attribute kinds");
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -743,7 +743,8 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
   }
 
   case DAK_CDecl:
-  case DAK_SILGenName: {
+  case DAK_SILGenName:
+  case DAK_NSKeyedArchiveLegacy: {
     if (!consumeIf(tok::l_paren)) {
       diagnose(Loc, diag::attr_expected_lparen, AttrName,
                DeclAttribute::isDeclModifier(DK));
@@ -785,6 +786,10 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
                                                 AttrRange, /*Implicit=*/false));
       else if (DK == DAK_CDecl)
         Attributes.add(new (Context) CDeclAttr(AsmName.getValue(), AtLoc,
+                                               AttrRange, /*Implicit=*/false));
+      else if (DK == DAK_NSKeyedArchiveLegacy)
+        Attributes.add(new (Context) NSKeyedArchiveLegacyAttr(
+                                               AsmName.getValue(), AtLoc,
                                                AttrRange, /*Implicit=*/false));
       else
         llvm_unreachable("out of sync with switch");

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -97,6 +97,7 @@ public:
   IGNORED_ATTR(ShowInInterface)
   IGNORED_ATTR(DiscardableResult)
   IGNORED_ATTR(Implements)
+  IGNORED_ATTR(NSKeyedArchiveLegacy)
 #undef IGNORED_ATTR
 
   // @noreturn has been replaced with a 'Never' return type.
@@ -766,6 +767,7 @@ public:
     IGNORED_ATTR(WarnUnqualifiedAccess)
     IGNORED_ATTR(ShowInInterface)
     IGNORED_ATTR(ObjCMembers)
+    IGNORED_ATTR(NSKeyedArchiveLegacy)
 #undef IGNORED_ATTR
 
   void visitAvailableAttr(AvailableAttr *attr);

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -29,19 +29,10 @@
 using namespace swift;
 
 namespace {
-/// This visits each attribute on a decl early, before the majority of type
-/// checking has been performed for the decl.  The visitor should return true if
-/// the attribute is invalid and should be marked as such.
-class AttributeEarlyChecker : public AttributeVisitor<AttributeEarlyChecker> {
-  TypeChecker &TC;
-  Decl *D;
-
-public:
-  AttributeEarlyChecker(TypeChecker &TC, Decl *D) : TC(TC), D(D) {}
-
   /// This emits a diagnostic with a fixit to remove the attribute.
   template<typename ...ArgTypes>
-  void diagnoseAndRemoveAttr(DeclAttribute *attr, ArgTypes &&...Args) {
+  void diagnoseAndRemoveAttr(TypeChecker &TC, Decl *D, DeclAttribute *attr,
+                             ArgTypes &&...Args) {
     assert(!D->hasClangNode() && "Clang imported propagated a bogus attribute");
     if (!D->hasClangNode()) {
       SourceLoc loc = attr->getLocation();
@@ -56,6 +47,22 @@ public:
     }
 
     attr->setInvalid();
+  }
+
+/// This visits each attribute on a decl early, before the majority of type
+/// checking has been performed for the decl.  The visitor should return true if
+/// the attribute is invalid and should be marked as such.
+class AttributeEarlyChecker : public AttributeVisitor<AttributeEarlyChecker> {
+  TypeChecker &TC;
+  Decl *D;
+
+public:
+  AttributeEarlyChecker(TypeChecker &TC, Decl *D) : TC(TC), D(D) {}
+
+  /// This emits a diagnostic with a fixit to remove the attribute.
+  template<typename ...ArgTypes>
+  void diagnoseAndRemoveAttr(DeclAttribute *attr, ArgTypes &&...Args) {
+    ::diagnoseAndRemoveAttr(TC, D, attr, std::forward<ArgTypes>(Args)...);
   }
 
   /// Deleting this ensures that all attributes are covered by the visitor
@@ -720,6 +727,12 @@ class AttributeChecker : public AttributeVisitor<AttributeChecker> {
   TypeChecker &TC;
   Decl *D;
 
+  /// This emits a diagnostic with a fixit to remove the attribute.
+  template<typename ...ArgTypes>
+  void diagnoseAndRemoveAttr(DeclAttribute *attr, ArgTypes &&...Args) {
+    ::diagnoseAndRemoveAttr(TC, D, attr, std::forward<ArgTypes>(Args)...);
+  }
+
 public:
   AttributeChecker(TypeChecker &TC, Decl *D) : TC(TC), D(D) {}
 
@@ -767,7 +780,6 @@ public:
     IGNORED_ATTR(WarnUnqualifiedAccess)
     IGNORED_ATTR(ShowInInterface)
     IGNORED_ATTR(ObjCMembers)
-    IGNORED_ATTR(NSKeyedArchiveLegacy)
 #undef IGNORED_ATTR
 
   void visitAvailableAttr(AvailableAttr *attr);
@@ -809,6 +821,7 @@ public:
   
   void visitDiscardableResultAttr(DiscardableResultAttr *attr);
   void visitImplementsAttr(ImplementsAttr *attr);
+  void visitNSKeyedArchiveLegacyAttr(NSKeyedArchiveLegacyAttr *attr);
 };
 } // end anonymous namespace
 
@@ -1939,6 +1952,18 @@ void AttributeChecker::visitImplementsAttr(ImplementsAttr *attr) {
     TC.diagnose(attr->getLocation(),
                 diag::implements_attr_non_protocol_type)
       .highlight(ProtoTypeLoc.getTypeRepr()->getSourceRange());
+  }
+}
+
+void AttributeChecker::visitNSKeyedArchiveLegacyAttr(
+                                              NSKeyedArchiveLegacyAttr *attr) {
+  auto classDecl = dyn_cast<ClassDecl>(D);
+  if (!classDecl) return;
+
+  // Generic classes can't use @NSKeyedArchiveLegacy.
+  if (classDecl->getGenericSignatureOfContext()) {
+    diagnoseAndRemoveAttr(attr, diag::attr_nskeyedarchivelegacy_generic,
+                          classDecl->getDeclaredInterfaceType());
   }
 }
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -106,6 +106,7 @@ public:
   IGNORED_ATTR(Implements)
   IGNORED_ATTR(NSKeyedArchiveLegacy)
   IGNORED_ATTR(StaticInitializeObjCMetadata)
+  IGNORED_ATTR(NSKeyedArchiveSubclassesOnly)
 #undef IGNORED_ATTR
 
   // @noreturn has been replaced with a 'Never' return type.
@@ -782,6 +783,7 @@ public:
     IGNORED_ATTR(ShowInInterface)
     IGNORED_ATTR(ObjCMembers)
     IGNORED_ATTR(StaticInitializeObjCMetadata)
+    IGNORED_ATTR(NSKeyedArchiveSubclassesOnly)
 #undef IGNORED_ATTR
 
   void visitAvailableAttr(AvailableAttr *attr);

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -105,6 +105,7 @@ public:
   IGNORED_ATTR(DiscardableResult)
   IGNORED_ATTR(Implements)
   IGNORED_ATTR(NSKeyedArchiveLegacy)
+  IGNORED_ATTR(StaticInitializeObjCMetadata)
 #undef IGNORED_ATTR
 
   // @noreturn has been replaced with a 'Never' return type.
@@ -780,6 +781,7 @@ public:
     IGNORED_ATTR(WarnUnqualifiedAccess)
     IGNORED_ATTR(ShowInInterface)
     IGNORED_ATTR(ObjCMembers)
+    IGNORED_ATTR(StaticInitializeObjCMetadata)
 #undef IGNORED_ATTR
 
   void visitAvailableAttr(AvailableAttr *attr);

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -6069,6 +6069,7 @@ public:
 
     UNINTERESTING_ATTR(ObjCMembers)
     UNINTERESTING_ATTR(Implements)
+    UNINTERESTING_ATTR(NSKeyedArchiveLegacy)
 
 #undef UNINTERESTING_ATTR
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -6071,6 +6071,7 @@ public:
     UNINTERESTING_ATTR(Implements)
     UNINTERESTING_ATTR(NSKeyedArchiveLegacy)
     UNINTERESTING_ATTR(StaticInitializeObjCMetadata)
+    UNINTERESTING_ATTR(NSKeyedArchiveSubclassesOnly)
 #undef UNINTERESTING_ATTR
 
     void visitAvailableAttr(AvailableAttr *attr) {

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -6070,7 +6070,7 @@ public:
     UNINTERESTING_ATTR(ObjCMembers)
     UNINTERESTING_ATTR(Implements)
     UNINTERESTING_ATTR(NSKeyedArchiveLegacy)
-
+    UNINTERESTING_ATTR(StaticInitializeObjCMetadata)
 #undef UNINTERESTING_ATTR
 
     void visitAvailableAttr(AvailableAttr *attr) {

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5906,10 +5906,13 @@ void TypeChecker::checkConformancesInContext(DeclContext *dc,
         Optional<unsigned> kind;
         bool isFixable = true;
         if (classDecl->getGenericSignature()) {
-          kind = 3;
+          kind = 4;
           isFixable = false;
-        } else if (classDecl->getDeclContext()->isTypeContext()) {
-          kind = 2;
+        } else if (!classDecl->getDeclContext()->isModuleScopeContext()) {
+          if (classDecl->getDeclContext()->isTypeContext())
+            kind = 2;
+          else
+            kind = 3;
         } else {
           switch (classDecl->getFormalAccess()) {
           case Accessibility::FilePrivate:

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5944,10 +5944,15 @@ void TypeChecker::checkConformancesInContext(DeclContext *dc,
                                : diag::nscoding_unstable_mangled_name,
                    *kind, classDecl->TypeDecl::getDeclaredInterfaceType());
           if (isFixable) {
-            diagnose(classDecl, diag::add_nskeyedarchivelegacy_attr)
-              .fixItInsert(
-                classDecl->getAttributeInsertionLoc(/*forModifier=*/false),
-                "@NSKeyedArchiveLegacy(\"<#class archival name#>\")");
+            auto insertionLoc =
+              classDecl->getAttributeInsertionLoc(/*forModifier=*/false);
+            diagnose(classDecl, diag::unstable_mangled_name_add_objc)
+              .fixItInsert(insertionLoc,
+                           "@objc(<#Objective-C class name#>)");
+            diagnose(classDecl,
+                     diag::unstable_mangled_name_add_nskeyedarchivelegacy)
+              .fixItInsert(insertionLoc,
+                           "@NSKeyedArchiveLegacy(\"<#class archival name#>\")");
           }
         }
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5912,7 +5912,8 @@ void TypeChecker::checkConformancesInContext(DeclContext *dc,
           }
         }
 
-        if (kind && !hasExplicitObjCName(classDecl)) {
+        if (kind && !hasExplicitObjCName(classDecl) &&
+            !classDecl->getAttrs().hasAttribute<NSKeyedArchiveLegacyAttr>()) {
           SourceLoc loc;
           if (auto normal = dyn_cast<NormalProtocolConformance>(conformance))
             loc = normal->getLoc();

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5891,8 +5891,10 @@ void TypeChecker::checkConformancesInContext(DeclContext *dc,
         // Note: these 'kind' values are synchronized with
         // diag::nscoding_unstable_mangled_name.
         Optional<unsigned> kind;
+        bool isFixable = true;
         if (classDecl->getGenericSignature()) {
           kind = 3;
+          isFixable = false;
         } else if (classDecl->getDeclContext()->isTypeContext()) {
           kind = 2;
         } else {
@@ -5925,6 +5927,12 @@ void TypeChecker::checkConformancesInContext(DeclContext *dc,
                    emitWarning ? diag::nscoding_unstable_mangled_name_warn
                                : diag::nscoding_unstable_mangled_name,
                    *kind, classDecl->TypeDecl::getDeclaredInterfaceType());
+          if (isFixable) {
+            diagnose(classDecl, diag::add_nskeyedarchivelegacy_attr)
+              .fixItInsert(
+                classDecl->getAttributeInsertionLoc(/*forModifier=*/false),
+                "@NSKeyedArchiveLegacy(\"<#class archival name#>\")");
+          }
         }
       }
     }

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1948,6 +1948,7 @@ void Serializer::writeDeclAttribute(const DeclAttribute *DA) {
   case DAK_SynthesizedProtocol:
   case DAK_Count:
   case DAK_Implements:
+  case DAK_NSKeyedArchiveLegacy:
     llvm_unreachable("cannot serialize attribute");
     return;
 

--- a/test/IDE/complete_decl_attribute.swift
+++ b/test/IDE/complete_decl_attribute.swift
@@ -58,7 +58,7 @@ func method(){}
 @#^KEYWORD3^#
 class C {}
 
-// KEYWORD3:                  Begin completions, 9 items
+// KEYWORD3:                  Begin completions, 10 items
 // KEYWORD3-NEXT:             Keyword/None:                       available[#Class Attribute#]; name=available{{$}}
 // KEYWORD3-NEXT:             Keyword/None:                       objc[#Class Attribute#]; name=objc{{$}}
 // KEYWORD3-NEXT:             Keyword/None:                       IBDesignable[#Class Attribute#]; name=IBDesignable{{$}}
@@ -68,6 +68,7 @@ class C {}
 // KEYWORD3-NEXT:             Keyword/None:                       NSApplicationMain[#Class Attribute#]; name=NSApplicationMain{{$}}
 // KEYWORD3-NEXT:             Keyword/None:                       objc_non_lazy_realization[#Class Attribute#]; name=objc_non_lazy_realization{{$}}
 // KEYWORD3-NEXT:             Keyword/None:                       NSKeyedArchiveLegacy[#Class Attribute#]; name=NSKeyedArchiveLegacy{{$}}
+// KEYWORD3-NEXT:             Keyword/None:                       NSKeyedArchiveSubclassesOnly[#Class Attribute#]; name=NSKeyedArchiveSubclassesOnly{{$}}
 // KEYWORD3-NEXT:             End completions
 
 @#^KEYWORD4^#
@@ -87,7 +88,7 @@ struct S{}
 
 @#^KEYWORD_LAST^#
 
-// KEYWORD_LAST:                  Begin completions, 22 items
+// KEYWORD_LAST:                  Begin completions, 23 items
 // KEYWORD_LAST-NEXT:             Keyword/None:                       available[#Declaration Attribute#]; name=available{{$}}
 // KEYWORD_LAST-NEXT:             Keyword/None:                       objc[#Declaration Attribute#]; name=objc{{$}}
 // KEYWORD_LAST-NEXT:             Keyword/None:                       noreturn[#Declaration Attribute#]; name=noreturn{{$}}
@@ -110,4 +111,5 @@ struct S{}
 // KEYWORD_LAST-NEXT:             Keyword/None:                       discardableResult[#Declaration Attribute#]; name=discardableResult
 // KEYWORD_LAST-NEXT:             Keyword/None:                       GKInspectable[#Declaration Attribute#]; name=GKInspectable{{$}}
 // KEYWORD_LAST-NEXT:             Keyword/None:                       NSKeyedArchiveLegacy[#Declaration Attribute#]; name=NSKeyedArchiveLegacy{{$}}
+// KEYWORD_LAST-NEXT:             Keyword/None:                       NSKeyedArchiveSubclassesOnly[#Declaration Attribute#]; name=NSKeyedArchiveSubclassesOnly{{$}}
 // KEYWORD_LAST-NEXT:             End completions

--- a/test/IDE/complete_decl_attribute.swift
+++ b/test/IDE/complete_decl_attribute.swift
@@ -58,7 +58,7 @@ func method(){}
 @#^KEYWORD3^#
 class C {}
 
-// KEYWORD3:                  Begin completions, 8 items
+// KEYWORD3:                  Begin completions, 9 items
 // KEYWORD3-NEXT:             Keyword/None:                       available[#Class Attribute#]; name=available{{$}}
 // KEYWORD3-NEXT:             Keyword/None:                       objc[#Class Attribute#]; name=objc{{$}}
 // KEYWORD3-NEXT:             Keyword/None:                       IBDesignable[#Class Attribute#]; name=IBDesignable{{$}}
@@ -67,6 +67,7 @@ class C {}
 // KEYWORD3-NEXT:             Keyword/None:                       objcMembers[#Class Attribute#]; name=objcMembers{{$}}
 // KEYWORD3-NEXT:             Keyword/None:                       NSApplicationMain[#Class Attribute#]; name=NSApplicationMain{{$}}
 // KEYWORD3-NEXT:             Keyword/None:                       objc_non_lazy_realization[#Class Attribute#]; name=objc_non_lazy_realization{{$}}
+// KEYWORD3-NEXT:             Keyword/None:                       NSKeyedArchiveLegacy[#Class Attribute#]; name=NSKeyedArchiveLegacy{{$}}
 // KEYWORD3-NEXT:             End completions
 
 @#^KEYWORD4^#
@@ -86,7 +87,7 @@ struct S{}
 
 @#^KEYWORD_LAST^#
 
-// KEYWORD_LAST:                  Begin completions, 21 items
+// KEYWORD_LAST:                  Begin completions, 22 items
 // KEYWORD_LAST-NEXT:             Keyword/None:                       available[#Declaration Attribute#]; name=available{{$}}
 // KEYWORD_LAST-NEXT:             Keyword/None:                       objc[#Declaration Attribute#]; name=objc{{$}}
 // KEYWORD_LAST-NEXT:             Keyword/None:                       noreturn[#Declaration Attribute#]; name=noreturn{{$}}
@@ -108,4 +109,5 @@ struct S{}
 // KEYWORD_LAST-NEXT:             Keyword/None:                       warn_unqualified_access[#Declaration Attribute#]; name=warn_unqualified_access
 // KEYWORD_LAST-NEXT:             Keyword/None:                       discardableResult[#Declaration Attribute#]; name=discardableResult
 // KEYWORD_LAST-NEXT:             Keyword/None:                       GKInspectable[#Declaration Attribute#]; name=GKInspectable{{$}}
+// KEYWORD_LAST-NEXT:             Keyword/None:                       NSKeyedArchiveLegacy[#Declaration Attribute#]; name=NSKeyedArchiveLegacy{{$}}
 // KEYWORD_LAST-NEXT:             End completions

--- a/test/Interpreter/SDK/archiving_generic_swift_class.swift
+++ b/test/Interpreter/SDK/archiving_generic_swift_class.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift -swift-version 3 | %FileCheck %s
+// RUN: %target-run-simple-swift | %FileCheck %s
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
 // UNSUPPORTED: OS=tvos
@@ -210,6 +210,6 @@ if CommandLine.arguments.count < 2 {
 } else if CommandLine.arguments[1] == "-unarchive" {
   unarchive()
 } else {
-  driver()
+  fatalError("invalid commandline argument")
 }
 

--- a/test/Interpreter/SDK/archiving_generic_swift_class.swift
+++ b/test/Interpreter/SDK/archiving_generic_swift_class.swift
@@ -6,6 +6,7 @@
 
 import Foundation
 
+@NSKeyedArchiveSubclassesOnly
 final class Foo<T: NSCoding>: NSObject, NSCoding {
   var one, two: T
 

--- a/test/Interpreter/SDK/archiving_generic_swift_class.swift
+++ b/test/Interpreter/SDK/archiving_generic_swift_class.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift | %FileCheck %s
+// RUN: %target-run-simple-swift -swift-version 3 | %FileCheck %s
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
 // UNSUPPORTED: OS=tvos
@@ -210,6 +210,6 @@ if CommandLine.arguments.count < 2 {
 } else if CommandLine.arguments[1] == "-unarchive" {
   unarchive()
 } else {
-  fatalError("invalid commandline argument")
+  driver()
 }
 

--- a/test/decl/protocol/conforms/nscoding.swift
+++ b/test/decl/protocol/conforms/nscoding.swift
@@ -17,13 +17,15 @@ class CodingA : NSObject, NSCoding {
 // Nested classes
 extension CodingA {
   class NestedA : NSObject, NSCoding { // expected-error{{nested class 'CodingA.NestedA' has an unstable name when archiving via 'NSCoding'}}
-    // expected-note@-1{{add the '@NSKeyedArchiveLegacy' attribute to specify the class name used for archiving}}{{3-3=@NSKeyedArchiveLegacy("<#class archival name#>")}}
+    // expected-note@-1{{for new classes, add '@objc' to specify a unique, prefixed Objective-C runtime name}}{{3-3=@objc(<#Objective-C class name#>)}}
+    // expected-note@-2{{for compatibility with existing archives, use '@NSKeyedArchiveLegacy' to record the Swift 3 mangled name}}{{3-3=@NSKeyedArchiveLegacy("<#class archival name#>")}}
     required init(coder: NSCoder) { }
     func encode(coder: NSCoder) { }
   }
 
   class NestedB : NSObject {
-    // expected-note@-1{{add the '@NSKeyedArchiveLegacy' attribute to specify the class name used for archiving}}{{3-3=@NSKeyedArchiveLegacy("<#class archival name#>")}}
+    // expected-note@-1{{for new classes, add '@objc' to specify a unique, prefixed Objective-C runtime name}}{{3-3=@objc(<#Objective-C class name#>)}}
+    // expected-note@-2{{for compatibility with existing archives, use '@NSKeyedArchiveLegacy' to record the Swift 3 mangled name}}{{3-3=@NSKeyedArchiveLegacy("<#class archival name#>")}}
     required init(coder: NSCoder) { }
     func encode(coder: NSCoder) { }
   }
@@ -62,14 +64,16 @@ extension CodingB {
 
 // Fileprivate classes.
 fileprivate class CodingC : NSObject, NSCoding {    // expected-error{{fileprivate class 'CodingC' has an unstable name when archiving via 'NSCoding'}}
-  // expected-note@-1{{add the '@NSKeyedArchiveLegacy' attribute to specify the class name used for archiving}}{{1-1=@NSKeyedArchiveLegacy("<#class archival name#>")}}
+  // expected-note@-1{{for new classes, add '@objc' to specify a unique, prefixed Objective-C runtime name}}{{1-1=@objc(<#Objective-C class name#>)}}
+  // expected-note@-2{{for compatibility with existing archives, use '@NSKeyedArchiveLegacy' to record the Swift 3 mangled name}}{{1-1=@NSKeyedArchiveLegacy("<#class archival name#>")}}
   required init(coder: NSCoder) { }
   func encode(coder: NSCoder) { }
 }
 
 // Private classes
 private class CodingD : NSObject, NSCoding {       // expected-error{{private class 'CodingD' has an unstable name when archiving via 'NSCoding'}}
-  // expected-note@-1{{add the '@NSKeyedArchiveLegacy' attribute to specify the class name used for archiving}}{{1-1=@NSKeyedArchiveLegacy("<#class archival name#>")}}
+  // expected-note@-1{{for new classes, add '@objc' to specify a unique, prefixed Objective-C runtime name}}{{1-1=@objc(<#Objective-C class name#>)}}
+  // expected-note@-2{{for compatibility with existing archives, use '@NSKeyedArchiveLegacy' to record the Swift 3 mangled name}}{{1-1=@NSKeyedArchiveLegacy("<#class archival name#>")}}
   required init(coder: NSCoder) { }
   func encode(coder: NSCoder) { }
 }
@@ -77,7 +81,8 @@ private class CodingD : NSObject, NSCoding {       // expected-error{{private cl
 // Local classes.
 func someFunction() {
   class LocalCoding : NSObject, NSCoding {       // expected-error{{local class 'LocalCoding' has an unstable name when archiving via 'NSCoding'}}
-  // expected-note@-1{{add the '@NSKeyedArchiveLegacy' attribute to specify the class name used for archiving}}{{3-3=@NSKeyedArchiveLegacy("<#class archival name#>")}}
+  // expected-note@-1{{for new classes, add '@objc' to specify a unique, prefixed Objective-C runtime name}}{{3-3=@objc(<#Objective-C class name#>)}}
+  // expected-note@-2{{for compatibility with existing archives, use '@NSKeyedArchiveLegacy' to record the Swift 3 mangled name}}{{3-3=@NSKeyedArchiveLegacy("<#class archival name#>")}}
   required init(coder: NSCoder) { }
   func encode(coder: NSCoder) { }
 }
@@ -114,11 +119,11 @@ private class CodingG : NSObject, NSCoding {
 @NSKeyedArchiveLegacy("TheCodingG") // expected-error{{@NSKeyedArchiveLegacy may only be used on 'class' declarations}}
 struct Foo { }
 
-@NSKeyedArchiveLegacy("TheCodingG") // expected-error{{@NSKeyedArchiveLegacy attribute cannot be applied to generic class 'Bar<T>'}}
+@NSKeyedArchiveLegacy("TheCodingG") // expected-error{{'@NSKeyedArchiveLegacy' cannot be applied to generic class 'Bar<T>'}}
 class Bar<T> : NSObject { }
 
 extension CodingB {
-  @NSKeyedArchiveLegacy("GenericViaParent") // expected-error{{@NSKeyedArchiveLegacy attribute cannot be applied to generic class 'CodingB<T>.GenericViaParent'}}
+  @NSKeyedArchiveLegacy("GenericViaParent") // expected-error{{'@NSKeyedArchiveLegacy' cannot be applied to generic class 'CodingB<T>.GenericViaParent'}}
   class GenericViaParent : NSObject { }
 }
 

--- a/test/decl/protocol/conforms/nscoding.swift
+++ b/test/decl/protocol/conforms/nscoding.swift
@@ -1,5 +1,8 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -swift-version 4 %s -verify
 
+// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -swift-version 4 %s -dump-ast 2> %t.ast
+// RUN: %FileCheck %s < %t.ast
+
 // REQUIRES: objc_interop
 
 import Foundation
@@ -109,3 +112,9 @@ extension CodingB {
   @NSKeyedArchiveLegacy("GenericViaParent") // expected-error{{@NSKeyedArchiveLegacy attribute cannot be applied to generic class 'CodingB<T>.GenericViaParent'}}
   class GenericViaParent : NSObject { }
 }
+
+// Inference of @_staticInitializeObjCMetadata.
+class SubclassOfCodingE : CodingE<Int> { }
+
+// CHECK: class_decl "NestedA"{{.*}}@_staticInitializeObjCMetadata
+// CHECK: class_decl "SubclassOfCodingE"{{.*}}@_staticInitializeObjCMetadata

--- a/test/decl/protocol/conforms/nscoding.swift
+++ b/test/decl/protocol/conforms/nscoding.swift
@@ -1,0 +1,74 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -swift-version 4 %s -verify
+
+// REQUIRES: objc_interop
+
+import Foundation
+
+// Top-level classes
+class CodingA : NSObject, NSCoding {
+  required init(coder: NSCoder) { }
+  func encode(coder: NSCoder) { }
+  
+}   // okay
+
+// Nested classes
+extension CodingA {
+  class NestedA : NSObject, NSCoding { // expected-error{{nested class 'CodingA.NestedA' has an unstable name when archiving via 'NSCoding'}}
+    required init(coder: NSCoder) { }
+    func encode(coder: NSCoder) { }
+  }
+
+  class NestedB : NSObject {
+    required init(coder: NSCoder) { }
+    func encode(coder: NSCoder) { }
+  }
+
+  @objc(CodingA_NestedC)
+  class NestedC : NSObject, NSCoding {
+    required init(coder: NSCoder) { }
+    func encode(coder: NSCoder) { }
+  }
+
+  @objc(CodingA_NestedD)
+  class NestedD : NSObject {
+    required init(coder: NSCoder) { }
+    func encode(coder: NSCoder) { }
+  }
+}
+
+extension CodingA.NestedB: NSCoding { // expected-error{{nested class 'CodingA.NestedB' has an unstable name when archiving via 'NSCoding'}}
+}
+
+extension CodingA.NestedD: NSCoding { // okay
+}
+
+// Generic classes
+class CodingB<T> : NSObject, NSCoding {   // expected-error{{generic class 'CodingB<T>' has an unstable name when archiving via 'NSCoding'}}
+  required init(coder: NSCoder) { }
+  func encode(coder: NSCoder) { }
+}
+
+extension CodingB {
+  class NestedA : NSObject, NSCoding { // expected-error{{generic class 'CodingB<T>.NestedA' has an unstable name when archiving via 'NSCoding'}}
+    required init(coder: NSCoder) { }
+    func encode(coder: NSCoder) { }
+  }
+}
+
+// Fileprivate classes.
+fileprivate class CodingC : NSObject, NSCoding {    // expected-error{{fileprivate class 'CodingC' has an unstable name when archiving via 'NSCoding'}}
+  required init(coder: NSCoder) { }
+  func encode(coder: NSCoder) { }
+}
+
+// Private classes
+private class CodingD : NSObject, NSCoding {       // expected-error{{private class 'CodingD' has an unstable name when archiving via 'NSCoding'}}
+  required init(coder: NSCoder) { }
+  func encode(coder: NSCoder) { }
+}
+
+// Inherited conformances.
+class CodingE<T> : CodingB<T> {   // expected-error{{generic class 'CodingE<T>' has an unstable name when archiving via 'NSCoding'}}
+  required init(coder: NSCoder) { super.init(coder: coder) }
+  override func encode(coder: NSCoder) { }
+}

--- a/test/decl/protocol/conforms/nscoding.swift
+++ b/test/decl/protocol/conforms/nscoding.swift
@@ -51,12 +51,14 @@ extension CodingA.NestedD: NSCoding { // okay
 
 // Generic classes
 class CodingB<T> : NSObject, NSCoding {   // expected-error{{generic class 'CodingB<T>' has an unstable name when archiving via 'NSCoding'}}
+  // expected-note@-1{{generic classes should not be archived directly}}{{1-1=@NSKeyedArchiveSubclassesOnly}}
   required init(coder: NSCoder) { }
   func encode(coder: NSCoder) { }
 }
 
 extension CodingB {
   class NestedA : NSObject, NSCoding { // expected-error{{generic class 'CodingB<T>.NestedA' has an unstable name when archiving via 'NSCoding'}}
+    // expected-note@-1{{generic classes should not be archived directly}}{{3-3=@NSKeyedArchiveSubclassesOnly}}
     required init(coder: NSCoder) { }
     func encode(coder: NSCoder) { }
   }
@@ -90,6 +92,7 @@ func someFunction() {
 
 // Inherited conformances.
 class CodingE<T> : CodingB<T> {   // expected-error{{generic class 'CodingE<T>' has an unstable name when archiving via 'NSCoding'}}
+    // expected-note@-1{{generic classes should not be archived directly}}{{1-1=@NSKeyedArchiveSubclassesOnly}}
   required init(coder: NSCoder) { super.init(coder: coder) }
   override func encode(coder: NSCoder) { }
 }
@@ -101,6 +104,12 @@ extension CodingA {
     required init(coder: NSCoder) { }
     func encode(coder: NSCoder) { }
   }
+}
+
+@NSKeyedArchiveSubclassesOnly
+class CodingGeneric<T> : NSObject, NSCoding {
+  required init(coder: NSCoder) { }
+  func encode(coder: NSCoder) { }
 }
 
 @NSKeyedArchiveLegacy("TheCodingF")

--- a/test/decl/protocol/conforms/nscoding.swift
+++ b/test/decl/protocol/conforms/nscoding.swift
@@ -72,3 +72,24 @@ class CodingE<T> : CodingB<T> {   // expected-error{{generic class 'CodingE<T>' 
   required init(coder: NSCoder) { super.init(coder: coder) }
   override func encode(coder: NSCoder) { }
 }
+
+// @NSKeyedArchiveLegacy suppressions
+extension CodingA {
+  @NSKeyedArchiveLegacy("TheNestedE")
+  class NestedE : NSObject, NSCoding {
+    required init(coder: NSCoder) { }
+    func encode(coder: NSCoder) { }
+  }
+}
+
+@NSKeyedArchiveLegacy("TheCodingF")
+fileprivate class CodingF : NSObject, NSCoding {
+  required init(coder: NSCoder) { }
+  func encode(coder: NSCoder) { }
+}
+
+@NSKeyedArchiveLegacy("TheCodingG")
+private class CodingG : NSObject, NSCoding {
+  required init(coder: NSCoder) { }
+  func encode(coder: NSCoder) { }
+}

--- a/test/decl/protocol/conforms/nscoding.swift
+++ b/test/decl/protocol/conforms/nscoding.swift
@@ -74,6 +74,15 @@ private class CodingD : NSObject, NSCoding {       // expected-error{{private cl
   func encode(coder: NSCoder) { }
 }
 
+// Local classes.
+func someFunction() {
+  class LocalCoding : NSObject, NSCoding {       // expected-error{{local class 'LocalCoding' has an unstable name when archiving via 'NSCoding'}}
+  // expected-note@-1{{add the '@NSKeyedArchiveLegacy' attribute to specify the class name used for archiving}}{{3-3=@NSKeyedArchiveLegacy("<#class archival name#>")}}
+  required init(coder: NSCoder) { }
+  func encode(coder: NSCoder) { }
+}
+}
+
 // Inherited conformances.
 class CodingE<T> : CodingB<T> {   // expected-error{{generic class 'CodingE<T>' has an unstable name when archiving via 'NSCoding'}}
   required init(coder: NSCoder) { super.init(coder: coder) }

--- a/test/decl/protocol/conforms/nscoding.swift
+++ b/test/decl/protocol/conforms/nscoding.swift
@@ -14,11 +14,13 @@ class CodingA : NSObject, NSCoding {
 // Nested classes
 extension CodingA {
   class NestedA : NSObject, NSCoding { // expected-error{{nested class 'CodingA.NestedA' has an unstable name when archiving via 'NSCoding'}}
+    // expected-note@-1{{add the '@NSKeyedArchiveLegacy' attribute to specify the class name used for archiving}}{{3-3=@NSKeyedArchiveLegacy("<#class archival name#>")}}
     required init(coder: NSCoder) { }
     func encode(coder: NSCoder) { }
   }
 
   class NestedB : NSObject {
+    // expected-note@-1{{add the '@NSKeyedArchiveLegacy' attribute to specify the class name used for archiving}}{{3-3=@NSKeyedArchiveLegacy("<#class archival name#>")}}
     required init(coder: NSCoder) { }
     func encode(coder: NSCoder) { }
   }
@@ -57,12 +59,14 @@ extension CodingB {
 
 // Fileprivate classes.
 fileprivate class CodingC : NSObject, NSCoding {    // expected-error{{fileprivate class 'CodingC' has an unstable name when archiving via 'NSCoding'}}
+  // expected-note@-1{{add the '@NSKeyedArchiveLegacy' attribute to specify the class name used for archiving}}{{1-1=@NSKeyedArchiveLegacy("<#class archival name#>")}}
   required init(coder: NSCoder) { }
   func encode(coder: NSCoder) { }
 }
 
 // Private classes
 private class CodingD : NSObject, NSCoding {       // expected-error{{private class 'CodingD' has an unstable name when archiving via 'NSCoding'}}
+  // expected-note@-1{{add the '@NSKeyedArchiveLegacy' attribute to specify the class name used for archiving}}{{1-1=@NSKeyedArchiveLegacy("<#class archival name#>")}}
   required init(coder: NSCoder) { }
   func encode(coder: NSCoder) { }
 }

--- a/test/decl/protocol/conforms/nscoding.swift
+++ b/test/decl/protocol/conforms/nscoding.swift
@@ -139,5 +139,9 @@ extension CodingB {
 // Inference of @_staticInitializeObjCMetadata.
 class SubclassOfCodingE : CodingE<Int> { }
 
+// CHECK-NOT: class_decl "CodingA"{{.*}}@_staticInitializeObjCMetadata
 // CHECK: class_decl "NestedA"{{.*}}@_staticInitializeObjCMetadata
+// CHECK: class_decl "NestedC"{{.*}}@_staticInitializeObjCMetadata
+// CHECK-NOT: class_decl "NestedE"{{.*}}@_staticInitializeObjCMetadata
+// CHECK-NOT: class_decl "CodingGeneric"{{.*}}@_staticInitializeObjCMetadata
 // CHECK: class_decl "SubclassOfCodingE"{{.*}}@_staticInitializeObjCMetadata

--- a/test/decl/protocol/conforms/nscoding.swift
+++ b/test/decl/protocol/conforms/nscoding.swift
@@ -97,3 +97,15 @@ private class CodingG : NSObject, NSCoding {
   required init(coder: NSCoder) { }
   func encode(coder: NSCoder) { }
 }
+
+// Errors with @NSKeyedArchiveLegacy.
+@NSKeyedArchiveLegacy("TheCodingG") // expected-error{{@NSKeyedArchiveLegacy may only be used on 'class' declarations}}
+struct Foo { }
+
+@NSKeyedArchiveLegacy("TheCodingG") // expected-error{{@NSKeyedArchiveLegacy attribute cannot be applied to generic class 'Bar<T>'}}
+class Bar<T> : NSObject { }
+
+extension CodingB {
+  @NSKeyedArchiveLegacy("GenericViaParent") // expected-error{{@NSKeyedArchiveLegacy attribute cannot be applied to generic class 'CodingB<T>.GenericViaParent'}}
+  class GenericViaParent : NSObject { }
+}


### PR DESCRIPTION
The name mangling changed from Swift 3 to Swift 4, and may get slight
tweaks as we lock down ABI stability. Identify and warn about (in
Swift 3) or error about (in Swift 4) the cases where we don't have
obviously-stable name mangling, e.g.,

* `private`/`fileprivate` classes (whose mangled names involve the file name)
* nested classes (whose mangled names depend on their enclosing type)
* generic classes (whose mangled names involve the type arguments)

For the first two bullets, one can suppress the warning by applying the newly-introduced `NSKeyedArchiveLegacy` attribute and providing the name of the class that was used in existing archives (i.e., the Swift 3 mangled name).