### PR TITLE
[migrator] Don't walk into user-specified type aliases when applying API type changes

### DIFF
--- a/test/Migrator/wrap_optional.swift
+++ b/test/Migrator/wrap_optional.swift
@@ -33,3 +33,21 @@ class MyExtraCities : ExtraCities {
   func blibli(x: (String?, String) -> String!) {}
   func currimundi(x: (Int, (Int, Int))!) {}
 }
+
+typealias IntAnd<T> = (Int, T)
+class Outer {
+  typealias Inner = (String?, String) -> String!
+}
+
+class MyExtraCitiesWithAliases : ExtraCities {
+  func blibli(x: Outer.Inner) {}
+  func currimundi(x: (Int, IntAnd<Int>)!) {}
+}
+
+typealias OptString = String?
+typealias ImplicitlyUnwrapped<T> = T!
+
+class MyExtraCitiesWithMoreAliases : ExtraCities {
+  func blibli(x: (OptString, String) -> String!) {}
+  func currimundi(x: ImplicitlyUnwrapped<(Int, (Int, Int))>) {}
+}

--- a/test/Migrator/wrap_optional.swift.expected
+++ b/test/Migrator/wrap_optional.swift.expected
@@ -33,3 +33,21 @@ class MyExtraCities : ExtraCities {
   func blibli(x: ((String, String) -> String?)?) {}
   func currimundi(x: (Int, (Int?, Int))?) {}
 }
+
+typealias IntAnd<T> = (Int, T)
+class Outer {
+  typealias Inner = (String?, String) -> String!
+}
+
+class MyExtraCitiesWithAliases : ExtraCities {
+  func blibli(x: Outer.Inner?) {}
+  func currimundi(x: (Int, IntAnd<Int>)?) {}
+}
+
+typealias OptString = String?
+typealias ImplicitlyUnwrapped<T> = T!
+
+class MyExtraCitiesWithMoreAliases : ExtraCities {
+  func blibli(x: ((OptString, String) -> String?)?) {}
+  func currimundi(x: ImplicitlyUnwrapped<(Int, (Int, Int))>) {}
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->
When migrating an override of an API with type changes, an assertion would trigger in some cases when a typealias was used as a param or return type. For example, if `func foo(x: (Int, Int))` became `func foo(x: (Int, Int?))`, when we saw an override of it we'd try to walk into its first param's TypeRepr and add a `?` after that TypeRepr's second 'child' TypeRepr. If the override was something like `func foo(x: IntPair)`, however, where `IntPair` is a typealias, we'd hit an assertion because the first param's TypeRepr was expected to have at least 2 children.

This patch updates the migrator to handle these by not applying any changes 'inside' type aliases.

rdar://problem/31766010
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->