### PR TITLE
[4.0] Support key paths on 32-bit platforms.

### DIFF
--- a/include/swift/ABI/HeapObject.h
+++ b/include/swift/ABI/HeapObject.h
@@ -1,0 +1,22 @@
+//===--- HeapObject.h - ABI constants for heap objects -----------*- C++ *-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  Constants used in the layout of heap objects.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __SWIFT_ABI_HEAPOBJECT_H__
+#define __SWIFT_ABI_HEAPOBJECT_H__
+
+#include "../../../stdlib/public/SwiftShims/HeapObject.h"
+
+#endif // __SWIFT_ABI_HEAPOBJECT_H__

--- a/stdlib/public/SwiftShims/GlobalObjects.h
+++ b/stdlib/public/SwiftShims/GlobalObjects.h
@@ -89,6 +89,14 @@ SWIFT_RUNTIME_STDLIB_INTERFACE
 __swift_uint64_t _swift_stdlib_HashingDetail_fixedSeedOverride;
 
 #ifdef __cplusplus
+
+static_assert(std::is_pod<_SwiftEmptyArrayStorage>::value,
+              "empty array type should be POD");
+static_assert(std::is_pod<_SwiftEmptyDictionaryStorage>::value,
+              "empty dictionary type should be POD");
+static_assert(std::is_pod<_SwiftEmptySetStorage>::value,
+              "empty set type should be POD");
+
 }} // extern "C", namespace swift
 #endif
 

--- a/stdlib/public/SwiftShims/HeapObject.h
+++ b/stdlib/public/SwiftShims/HeapObject.h
@@ -14,6 +14,10 @@
 
 #include "RefCount.h"
 
+#define SWIFT_ABI_HEAP_OBJECT_HEADER_SIZE_64 16
+// TODO: Should be 8
+#define SWIFT_ABI_HEAP_OBJECT_HEADER_SIZE_32 12
+
 #ifdef __cplusplus
 #include <type_traits>
 #include "swift/Basic/type_traits.h"
@@ -69,9 +73,17 @@ static_assert(swift::IsTriviallyConstructible<HeapObject>::value,
               "HeapObject must be trivially initializable");
 static_assert(std::is_trivially_destructible<HeapObject>::value,
               "HeapObject must be trivially destructible");
+
 // FIXME: small header for 32-bit
 //static_assert(sizeof(HeapObject) == 2*sizeof(void*),
 //              "HeapObject must be two pointers long");
+//
+static_assert(sizeof(HeapObject) ==
+  (sizeof(void*) == 8 ? SWIFT_ABI_HEAP_OBJECT_HEADER_SIZE_64 :
+   sizeof(void*) == 4 ? SWIFT_ABI_HEAP_OBJECT_HEADER_SIZE_32 :
+   0 && "unexpected pointer size"),
+  "HeapObject must match ABI heap object header size");
+
 static_assert(alignof(HeapObject) == alignof(void*),
               "HeapObject must be pointer-aligned");
 

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -1414,7 +1414,8 @@ public func _appendingKeyPaths<
 }
 
 // The distance in bytes from the address point of a KeyPath object to its
-// buffer header. Includes the size of the Swift heap object header and
+// buffer header. Includes the size of the Swift heap object header and the
+// pointer to the KVC string.
 
 internal var keyPathObjectHeaderSize: Int {
   return MemoryLayout<HeapObject>.size + MemoryLayout<Int>.size
@@ -1437,7 +1438,7 @@ public func swift_getKeyPath(pattern: UnsafeMutableRawPointer,
   //   global object will itself always have the "trivial" bit set, since it
   //   never needs to be destroyed.)
   // - Components may have unresolved forms that require instantiation.
-  // - The component type metadata pointers are unresolved, and instead
+  // - Type metadata pointers are unresolved, and instead
   //   point to accessor functions that instantiate the metadata.
   //
   // The pattern never precomputes the capabilities of the key path (readonly/
@@ -1649,7 +1650,7 @@ internal func _instantiateKeyPathBuffer(
 ) {
   // NB: patternBuffer and destData alias when the pattern is instantiable
   // in-line. Therefore, do not read from patternBuffer after the same position
-  // in destBuffer has been written to.
+  // in destData has been written to.
 
   var patternBuffer = origPatternBuffer
   let destHeaderPtr = origDestData.baseAddress.unsafelyUnwrapped

--- a/test/IRGen/keypaths.sil
+++ b/test/IRGen/keypaths.sil
@@ -1,6 +1,4 @@
 // RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
-// TODO: 32-bit support
-// REQUIRES: PTRSIZE=64
 
 sil_stage canonical
 import Swift
@@ -64,7 +62,7 @@ sil_vtable C {}
 //               -- 0x8000_0018 - instantiable in-line, size 4
 // CHECK-SAME: i32 -2147483644,
 // -- 0x4000_0000 (class) + offset of C.x
-// CHECK-32-SAME: i32 1073741832 }>
+// CHECK-32-SAME: i32 1073741836 }>
 // CHECK-64-SAME: i32 1073741840 }>
 
 // -- %e: C.y
@@ -75,7 +73,7 @@ sil_vtable C {}
 //               -- 0x8000_0018 - instantiable in-line, size 4
 // CHECK-SAME: i32 -2147483644,
 // -- 0x4000_0000 (class) + offset of C.y
-// CHECK-32-SAME: i32 1073741836 }>
+// CHECK-32-SAME: i32 1073741840 }>
 // CHECK-64-SAME: i32 1073741848 }>
 
 // -- %f: C.z
@@ -86,7 +84,7 @@ sil_vtable C {}
 //               -- 0x8000_0018 - instantiable in-line, size 4
 // CHECK-SAME: i32 -2147483644,
 // -- 0x4000_0000 (class) + offset of C.z
-// CHECK-32-SAME: i32 1073741848 }>
+// CHECK-32-SAME: i32 1073741852 }>
 // CHECK-64-SAME: i32 1073741872 }>
 
 // -- %g: S.z.x
@@ -103,7 +101,7 @@ sil_vtable C {}
 // CHECK-64-SAME: i32 32,
 // CHECK: %swift.type* (i8*)*
 // -- 0x4000_0000 (class) + offset of C.x
-// CHECK-32-SAME: i32 1073741832 }>
+// CHECK-32-SAME: i32 1073741836 }>
 // CHECK-64-SAME: i32 1073741840 }>
 
 // -- %h: C.z.x
@@ -116,7 +114,7 @@ sil_vtable C {}
 //                  -- 0x8000_0018 - instantiable in-line, size 16
 // CHECK-64-SAME: i32 -2147483632,
 // -- 0x4000_0000 (class) + offset of C.z
-// CHECK-32-SAME: i32 1073741848,
+// CHECK-32-SAME: i32 1073741852,
 // CHECK-64-SAME: i32 1073741872,
 // CHECK: %swift.type* (i8*)*
 // -- offset of S.x
@@ -130,7 +128,7 @@ sil_vtable C {}
 //              -- 0x8000_0014 - instantiable in-line, size 20
 // CHECK-64-SAME: i32 -2147483628,
 //              -- 0x8000_000c - instantiable in-line, size 12
-// CHECK-32-SAME: i32 -2147483640,
+// CHECK-32-SAME: i32 -2147483636,
 // -- 0x2000_0000 - computed, get-only, identified by function pointer, no args
 // CHECK-SAME: i32 536870912,
 // CHECK-SAME: void ()* @k_id,
@@ -144,7 +142,7 @@ sil_vtable C {}
 //              -- 0x8000_001c - instantiable in-line, size 28
 // CHECK-64-SAME: i32 -2147483620,
 //              -- 0x8000_0010 - instantiable in-line, size 16
-// CHECK-32-SAME: i32 -2147483636,
+// CHECK-32-SAME: i32 -2147483632,
 // -- 0x2a00_0000 - computed, settable, nonmutating, identified by vtable, no args
 // CHECK-SAME: i32 704643072,
 // CHECK-SAME: [[WORD]]
@@ -159,7 +157,7 @@ sil_vtable C {}
 //              -- 0x8000_001c - instantiable in-line, size 28
 // CHECK-64-SAME: i32 -2147483620,
 //              -- 0x8000_0010 - instantiable in-line, size 16
-// CHECK-32-SAME: i32 -2147483636,
+// CHECK-32-SAME: i32 -2147483632,
 // -- 0x3c00_0000 - computed, settable, nonmutating, identified by property offset, no args
 // CHECK-SAME: i32 1006632960,
 // CHECK-SAME: [[WORD]]

--- a/test/SILGen/keypaths.swift
+++ b/test/SILGen/keypaths.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-frontend -enable-experimental-keypaths -emit-silgen %s | %FileCheck %s
-// REQUIRES: PTRSIZE=64
 
 struct S<T> {
   var x: T

--- a/test/stdlib/KeyPath.swift
+++ b/test/stdlib/KeyPath.swift
@@ -2,7 +2,6 @@
 // RUN: %target-build-swift %s -Xfrontend -enable-experimental-keypaths -o %t/a.out
 // RUN: %target-run %t/a.out
 // REQUIRES: executable_test
-// REQUIRES: PTRSIZE=64
 
 import StdlibUnittest
 

--- a/test/stdlib/KeyPathObjC.swift
+++ b/test/stdlib/KeyPathObjC.swift
@@ -2,7 +2,6 @@
 // RUN: %target-build-swift %s -Xfrontend -enable-experimental-keypaths -o %t/a.out
 // RUN: %target-run %t/a.out
 // REQUIRES: executable_test
-// REQUIRES: PTRSIZE=64
 // REQUIRES: objc_interop
 
 import StdlibUnittest


### PR DESCRIPTION
I had optimistically written the code here optimistically hoping #7837 would land in time for me to merge, but that didn't happen, so adjust some things to match the current 12-byte object header size on 32-bit, and introduce some ABI constants for the expected 32- and 64-bit object header sizes we can assert against so that we have some robustness when it eventually changes again. Implements rdar://problem/31768303.
