### PR TITLE
[runtime] Fix assignment of Any with mismatched types.

### DIFF
--- a/stdlib/public/runtime/ExistentialMetadataImpl.h
+++ b/stdlib/public/runtime/ExistentialMetadataImpl.h
@@ -232,6 +232,7 @@ struct LLVM_LIBRARY_VISIBILITY OpaqueExistentialBoxBase
         // Move dest value asside so we can destroy it later.
         destType->vw_initializeWithTake(opaqueTmpBuffer, destValue);
 
+        src->copyTypeInto(dest, args...);
         if (srcVwt->isValueInline()) {
           // Inline src value.
 
@@ -252,6 +253,7 @@ struct LLVM_LIBRARY_VISIBILITY OpaqueExistentialBoxBase
         auto *destRef =
             *reinterpret_cast<HeapObject **>(dest->getBuffer(args...));
 
+        src->copyTypeInto(dest, args...);
         if (srcVwt->isValueInline()) {
 
           // initWithCopy.
@@ -329,6 +331,8 @@ struct LLVM_LIBRARY_VISIBILITY OpaqueExistentialBoxBase
 
         // Move dest value asside.
         destType->vw_initializeWithTake(opaqueTmpBuffer, destValue);
+
+        src->copyTypeInto(dest, args...);
         if (srcVwt->isValueInline()) {
           // Inline src value.
 
@@ -349,6 +353,7 @@ struct LLVM_LIBRARY_VISIBILITY OpaqueExistentialBoxBase
         auto *destRef =
             *reinterpret_cast<HeapObject **>(dest->getBuffer(args...));
 
+        src->copyTypeInto(dest, args...);
         if (srcVwt->isValueInline()) {
           // initWithCopy.
 


### PR DESCRIPTION
The COW existential implementation sets the existential box's
new value but fails to set the box's new type. Hijinks ensue
when the new value is later used as if it were of the old type.

rdar://31955457