### PR TITLE
[QoI] Properly diagnose closure parameter distructuring after SE-0110

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1066,6 +1066,8 @@ ERROR(anon_closure_arg_in_closure_with_args,none,
 ERROR(anon_closure_arg_in_closure_with_args_typo,none,
       "anonymous closure arguments cannot be used inside a closure that has "
       "explicit arguments; did you mean '%0'?", (StringRef))
+ERROR(anon_closure_tuple_param_destructuring,none,
+      "closure tuple parameter does not support destructuring", ())
 ERROR(expected_closure_parameter_name,none,
       "expected the name of a closure parameter", ())
 ERROR(expected_capture_specifier,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2830,6 +2830,11 @@ ERROR(closure_argument_list_tuple,none,
 ERROR(closure_argument_list_missing,none,
       "contextual type for closure argument list expects %0 argument%s0, "
       "which cannot be implicitly ignored", (unsigned))
+ERROR(closure_tuple_parameter_destructuring,none,
+      "closure tuple parameter %0 does not support destructuring", (Type))
+ERROR(closure_tuple_parameter_destructuring_implicit,none,
+      "closure tuple parameter %0 does not support destructuring "
+      "with implicit parameters", (Type))
 
 ERROR(tuple_pattern_length_mismatch,none,
       "tuple pattern has the wrong length for tuple type %0", (Type))

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -266,10 +266,18 @@ Parser::parseParameterClause(SourceLoc &leftParenLoc,
         status |= type;
         param.Type = type.getPtrOrNull();
 
-        // Unnamed parameters must be written as "_: Type".
+        // If this is a closure declaration, what is going
+        // on is most likely argument destructuring, we are going
+        // to diagnose that after all of the parameters are parsed.
         if (param.Type) {
-          diagnose(typeStartLoc, diag::parameter_unnamed)
-            .fixItInsert(typeStartLoc, "_: ");
+          // Mark current parameter as invalid so it is possible
+          // to diagnose it as destructuring of the closure parameter list.
+          param.isInvalid = true;
+          if (!isClosure) {
+            // Unnamed parameters must be written as "_: Type".
+            diagnose(typeStartLoc, diag::parameter_unnamed)
+                .fixItInsert(typeStartLoc, "_: ");
+          }
         }
       } else {
         // Otherwise, we're not sure what is going on, but this doesn't smell

--- a/test/decl/func/functions.swift
+++ b/test/decl/func/functions.swift
@@ -104,7 +104,7 @@ _ = nullaryClosure(0)
 // parameter labels, and they are thus not in scope in the body of the function.
 // expected-error@+1{{unnamed parameters must be written}} {{27-27=_: }}
 func destructureArgument( (result: Int, error: Bool) ) -> Int {
-  return result  // expected-error {{use of unresolved identifier 'result'}}
+  return result
 }
 
 // The former is the same as this:

--- a/validation-test/IDE/crashers_2/0013-unmapped-dependent-type-2.swift
+++ b/validation-test/IDE/crashers_2/0013-unmapped-dependent-type-2.swift
@@ -1,6 +1,0 @@
-// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-// REQUIRES: asserts
-
-func a<b>(() -> b) -> b {
-  a {}#^A^#
-}

--- a/validation-test/IDE/crashers_2_fixed/0013-unmapped-dependent-type-2.swift
+++ b/validation-test/IDE/crashers_2_fixed/0013-unmapped-dependent-type-2.swift
@@ -1,0 +1,5 @@
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+
+func a<b>(() -> b) -> b {
+  a {}#^A^#
+}

--- a/validation-test/compiler_crashers_fixed/28723-unreachable-executed-at-swift-lib-sema-csdiag-cpp-4012.swift
+++ b/validation-test/compiler_crashers_fixed/28723-unreachable-executed-at-swift-lib-sema-csdiag-cpp-4012.swift
@@ -5,6 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 func t(UInt=__FUNCTION__
 func&t(


### PR DESCRIPTION
Swift 3 supported limited argument destructuring when it comes to
declaring (trailing) closures. Such behavior has been changed by
SE-0110. This patch aims to provide better error message as well
as fix-it (if structure of the expected and actual arguments matches)
to make the migration easier and disambiguate some of the common
mistakes.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-4738](https://bugs.swift.org/browse/SR-4738).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->