### PR TITLE
[swiftc (38 vs. 5515)] Add crasher in swift::TypeChecker::substMemberTypeWithBase

### DIFF
--- a/validation-test/compiler_crashers/28743-swift-typechecker-substmembertypewithbase-swift-moduledecl-swift-typedecl-swift-.swift
+++ b/validation-test/compiler_crashers/28743-swift-typechecker-substmembertypewithbase-swift-moduledecl-swift-typedecl-swift-.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol P}extension P{typealias a:Self.a{}func a:Self.a


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeChecker::substMemberTypeWithBase`.

Current number of unresolved compiler crashers: 38 (5515 resolved)

Stack trace:

```
0 0x00000000039d6c48 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x39d6c48)
1 0x00000000039d7386 SignalHandler(int) (/path/to/swift/bin/swift+0x39d7386)
2 0x00007f88e1c0e390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x000000000137952b swift::TypeChecker::substMemberTypeWithBase(swift::ModuleDecl*, swift::TypeDecl*, swift::Type) (/path/to/swift/bin/swift+0x137952b)
4 0x00000000013364d6 swift::CompleteGenericTypeResolver::resolveDependentMemberType(swift::Type, swift::DeclContext*, swift::SourceRange, swift::ComponentIdentTypeRepr*) (/path/to/swift/bin/swift+0x13364d6)
5 0x000000000137aecf resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x137aecf)
6 0x000000000137a8b3 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x137a8b3)
7 0x000000000137bb07 (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0x137bb07)
8 0x000000000137ba0c swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x137ba0c)
9 0x0000000001379fd5 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x1379fd5)
10 0x00000000013378b6 checkGenericFuncSignature(swift::TypeChecker&, swift::GenericSignatureBuilder*, swift::AbstractFunctionDecl*, swift::GenericTypeResolver&) (/path/to/swift/bin/swift+0x13378b6)
11 0x0000000001337460 swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0x1337460)
12 0x000000000131d3f5 (anonymous namespace)::DeclChecker::visitFuncDecl(swift::FuncDecl*) (/path/to/swift/bin/swift+0x131d3f5)
13 0x00000000013096a7 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x13096a7)
14 0x000000000130b438 swift::TypeChecker::validateDecl(swift::ValueDecl*) (/path/to/swift/bin/swift+0x130b438)
15 0x000000000154abbc swift::DeclContext::lookupQualified(swift::Type, swift::DeclName, swift::NLOptions, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&) const (/path/to/swift/bin/swift+0x154abbc)
16 0x000000000133c886 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>)::$_1::operator()() const (/path/to/swift/bin/swift+0x133c886)
17 0x000000000133c737 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>) (/path/to/swift/bin/swift+0x133c737)
18 0x0000000001381c00 diagnoseUnknownType(swift::TypeChecker&, swift::DeclContext*, swift::Type, swift::SourceRange, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::OptionSet<swift::NameLookupFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x1381c00)
19 0x000000000137b307 resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x137b307)
20 0x000000000137a8b3 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x137a8b3)
21 0x000000000137bb07 (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0x137bb07)
22 0x000000000137ba0c swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x137ba0c)
23 0x0000000001379fd5 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x1379fd5)
24 0x000000000130b26a swift::TypeChecker::validateDecl(swift::ValueDecl*) (/path/to/swift/bin/swift+0x130b26a)
25 0x00000000013199bf (anonymous namespace)::DeclChecker::visitTypeAliasDecl(swift::TypeAliasDecl*) (/path/to/swift/bin/swift+0x13199bf)
26 0x000000000130955b (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x130955b)
27 0x000000000131990b (anonymous namespace)::DeclChecker::visitExtensionDecl(swift::ExtensionDecl*) (/path/to/swift/bin/swift+0x131990b)
28 0x000000000130954b (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x130954b)
29 0x0000000001309483 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x1309483)
30 0x0000000001389255 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x1389255)
31 0x0000000000f82cb6 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf82cb6)
32 0x00000000004aa1dd performCompile(std::unique_ptr<swift::CompilerInstance, std::default_delete<swift::CompilerInstance> >&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4aa1dd)
33 0x00000000004a89f5 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a89f5)
34 0x0000000000465567 main (/path/to/swift/bin/swift+0x465567)
35 0x00007f88e011f830 __libc_start_main /build/glibc-9tT8Do/glibc-2.23/csu/../csu/libc-start.c:325:0
36 0x0000000000462c09 _start (/path/to/swift/bin/swift+0x462c09)
```