### PR TITLE
[swift-4.0 branch] [runtime] Fix assignment of Any with mismatched ty…

### DIFF
--- a/stdlib/public/runtime/ExistentialMetadataImpl.h
+++ b/stdlib/public/runtime/ExistentialMetadataImpl.h
@@ -232,6 +232,7 @@ struct LLVM_LIBRARY_VISIBILITY OpaqueExistentialBoxBase
         // Move dest value asside so we can destroy it later.
         destType->vw_initializeWithTake(opaqueTmpBuffer, destValue);
 
+        src->copyTypeInto(dest, args...);
         if (srcVwt->isValueInline()) {
           // Inline src value.
 
@@ -252,6 +253,7 @@ struct LLVM_LIBRARY_VISIBILITY OpaqueExistentialBoxBase
         auto *destRef =
             *reinterpret_cast<HeapObject **>(dest->getBuffer(args...));
 
+        src->copyTypeInto(dest, args...);
         if (srcVwt->isValueInline()) {
 
           // initWithCopy.
@@ -329,6 +331,8 @@ struct LLVM_LIBRARY_VISIBILITY OpaqueExistentialBoxBase
 
         // Move dest value asside.
         destType->vw_initializeWithTake(opaqueTmpBuffer, destValue);
+
+        src->copyTypeInto(dest, args...);
         if (srcVwt->isValueInline()) {
           // Inline src value.
 
@@ -349,6 +353,7 @@ struct LLVM_LIBRARY_VISIBILITY OpaqueExistentialBoxBase
         auto *destRef =
             *reinterpret_cast<HeapObject **>(dest->getBuffer(args...));
 
+        src->copyTypeInto(dest, args...);
         if (srcVwt->isValueInline()) {
           // initWithCopy.
 


### PR DESCRIPTION
…pes.

The COW existential implementation sets the existential box's
new value but fails to set the box's new type. Hijinks ensue
when the new value is later used as if it were of the old type.

rdar://31955457
(cherry picked from commit 2ad2f26024e159dd14f80440fc55ca06eda25510)

• Explanation: The value witness for existential boxes in assignWith(Take/Copy) missed a copy of the  metadata field.

• Scope of Issue:  This causes issues when we assign an existential of one type to an existential of another type because we loose.

    var dict: [String: Any] = ["foo": 0x11111111 as NSNumber]
    print(dict)  // succeeds
    dict["foo"] = 0x22222222
    print(dict)  // crashes

• Origination: This was introduced with COW existential (the original implementation had the copy).

• Risk: Low. By adding the type copy we can only make the code more correct.

• Reviewed By: Arnold (Authored by Greg)
