### PR TITLE
Let Character literals, which fit into 64 bits, be folded into a single integer constant.

### DIFF
--- a/benchmark/single-source/CharacterLiteralsSmall.swift
+++ b/benchmark/single-source/CharacterLiteralsSmall.swift
@@ -55,15 +55,20 @@ func makeCharacter_UTF8Length8() -> Character {
   return "\u{00a9}\u{0300}\u{0301}\u{0302}"
 }
 
+@inline(never)
+func makeLiterals() {
+  blackHole(makeCharacter_UTF8Length1())
+  blackHole(makeCharacter_UTF8Length2())
+  blackHole(makeCharacter_UTF8Length3())
+  blackHole(makeCharacter_UTF8Length4())
+  blackHole(makeCharacter_UTF8Length5())
+  blackHole(makeCharacter_UTF8Length6())
+  blackHole(makeCharacter_UTF8Length7())
+  blackHole(makeCharacter_UTF8Length8())
+}
+
 public func run_CharacterLiteralsSmall(_ N: Int) {
   for _ in 0...10000 * N {
-    _ = makeCharacter_UTF8Length1()
-    _ = makeCharacter_UTF8Length2()
-    _ = makeCharacter_UTF8Length3()
-    _ = makeCharacter_UTF8Length4()
-    _ = makeCharacter_UTF8Length5()
-    _ = makeCharacter_UTF8Length6()
-    _ = makeCharacter_UTF8Length7()
-    _ = makeCharacter_UTF8Length8()
+    makeLiterals()
   }
 }

--- a/benchmark/utils/TestsUtils.swift
+++ b/benchmark/utils/TestsUtils.swift
@@ -66,3 +66,9 @@ struct MyStruct : SomeProtocol {
 }
 public func someProtocolFactory() -> SomeProtocol { return MyStruct() }
 
+// Just consume the argument.
+// It's important that this function is in a another module than the tests
+// which are using it.
+public func blackHole<T>(_ x: T) {
+}
+

--- a/stdlib/public/core/CTypes.swift
+++ b/stdlib/public/core/CTypes.swift
@@ -206,6 +206,8 @@ extension CVaListPointer : CustomDebugStringConvertible {
   }
 }
 
+@_versioned
+@_inlineable
 func _memcpy(
   dest destination: UnsafeMutableRawPointer,
   src: UnsafeMutableRawPointer,

--- a/stdlib/public/core/Character.swift
+++ b/stdlib/public/core/Character.swift
@@ -104,6 +104,9 @@ public struct Character :
         UTF32.self, input: CollectionOfOne(UInt32(value))))
   }
 
+  // Inlining ensures that the whole constructor can be folded away to a single
+  // integer constant in case of small character literals.
+  @inline(__always)
   @effects(readonly)
   public init(
     _builtinExtendedGraphemeClusterLiteral start: Builtin.RawPointer,
@@ -195,6 +198,7 @@ public struct Character :
 
   /// Creates a Character from a String that is already known to require the
   /// large representation.
+  @_versioned
   internal init(_largeRepresentationString s: String) {
     if let native = s._core.nativeBuffer,
        native.start == s._core._baseAddress! {

--- a/test/SILOptimizer/character_literals.swift
+++ b/test/SILOptimizer/character_literals.swift
@@ -1,0 +1,32 @@
+// RUN: %target-swift-frontend -parse-as-library -O -emit-ir  %s | %FileCheck %s
+// REQUIRES: swift_stdlib_no_asserts,optimized_stdlib,CPU=x86_64
+
+// This is an end-to-end test to ensure that the optimizer generates
+// a simple literal for character literals.
+
+// CHECK-LABEL: define {{.*}}charArray
+// CHECK-NOT: {{^}}[^ ]
+// CHECK:       store i64 9223372036854775649, i64*
+// CHECK-NOT: {{^}}[^ ]
+// CHECK:       store i64 9223372036854775650, i64*
+// CHECK-NOT: {{^}}[^ ]
+// CHECK:       store i64 9223372036854775651, i64*
+// CHECK-NOT: {{^}}[^ ]
+// CHECK:       store i64 9223372036854775652, i64*
+// CHECK-NOT: {{^}}[^ ]
+// CHECK:       ret
+public func charArray(_ i: Int) -> [Character] {
+  return [ "a", "b", "c", "d" ]
+}
+
+// CHECK-LABEL: define {{.*}}singleChar
+// CHECK: ret {{.*}} 9223372036854775649
+public func singleChar() -> Character {
+  return "a"
+}
+
+// CHECK-LABEL: define {{.*}}singleNonAsciiChar
+// CHECK: ret {{.*}} 9223372036848850918
+public func singleNonAsciiChar() -> Character {
+  return "日"
+}


### PR DESCRIPTION
This is done by ensuring that the corresponding Character constructor is inlined. llvm will do the constant folding.
Also add a test which checks this.

It makes character literals much faster (3x improvement for the CharacterLiteralsSmall benchmark)
And it removes _a lot_ of redundant code (~80% for the CharacterLiteralsSmall benchmark)

rdar://problem/22481219