### PR TITLE
[swiftc (39 vs. 5515)] Add crasher in swift::GenericEnvironment::mapTypeOutOfContext

### DIFF
--- a/validation-test/compiler_crashers/28744-swift-genericenvironment-maptypeoutofcontext-swift-genericenvironment-swift-type.swift
+++ b/validation-test/compiler_crashers/28744-swift-genericenvironment-maptypeoutofcontext-swift-genericenvironment-swift-type.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol P extension P{var f=A.a}extension P{struct A{func a:Self


### PR DESCRIPTION
Add test case for crash triggered in `swift::GenericEnvironment::mapTypeOutOfContext`.

Current number of unresolved compiler crashers: 39 (5515 resolved)

Stack trace:

```
0 0x00000000039d6c48 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x39d6c48)
1 0x00000000039d7386 SignalHandler(int) (/path/to/swift/bin/swift+0x39d7386)
2 0x00007f89796d7390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x000000000150311b swift::GenericEnvironment::mapTypeOutOfContext(swift::GenericEnvironment*, swift::Type) (/path/to/swift/bin/swift+0x150311b)
4 0x00000000013411c2 swift::TypeChecker::coercePatternToType(swift::Pattern*&, swift::DeclContext*, swift::Type, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, swift::TypeLoc) (/path/to/swift/bin/swift+0x13411c2)
5 0x00000000012fdd64 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*, bool)::BindingListener::appliedSolution(swift::constraints::Solution&, swift::Expr*) (/path/to/swift/bin/swift+0x12fdd64)
6 0x00000000012f3999 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x12f3999)
7 0x00000000012f78f1 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*, bool) (/path/to/swift/bin/swift+0x12f78f1)
8 0x00000000012f7ab6 swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int, bool) (/path/to/swift/bin/swift+0x12f7ab6)
9 0x000000000130f0e8 validatePatternBindingEntries(swift::TypeChecker&, swift::PatternBindingDecl*) (/path/to/swift/bin/swift+0x130f0e8)
10 0x00000000013095c4 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x13095c4)
11 0x000000000131990b (anonymous namespace)::DeclChecker::visitExtensionDecl(swift::ExtensionDecl*) (/path/to/swift/bin/swift+0x131990b)
12 0x000000000130954b (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x130954b)
13 0x0000000001309483 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x1309483)
14 0x0000000001389255 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x1389255)
15 0x0000000000f82cb6 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf82cb6)
16 0x00000000004aa1dd performCompile(std::unique_ptr<swift::CompilerInstance, std::default_delete<swift::CompilerInstance> >&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4aa1dd)
17 0x00000000004a89f5 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a89f5)
18 0x0000000000465567 main (/path/to/swift/bin/swift+0x465567)
19 0x00007f8977be8830 __libc_start_main /build/glibc-9tT8Do/glibc-2.23/csu/../csu/libc-start.c:325:0
20 0x0000000000462c09 _start (/path/to/swift/bin/swift+0x462c09)
```