### PR TITLE
[swiftc (40 vs. 5515)] Add crasher in swift::Expr::walk(...)

### DIFF
--- a/validation-test/compiler_crashers/28745-ty-getnominalorboundgenericnominal-ty-is-dynamicselftype-ty-isexistentialtype-ty.swift
+++ b/validation-test/compiler_crashers/28745-ty-getnominalorboundgenericnominal-ty-is-dynamicselftype-ty-isexistentialtype-ty.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+&{LazyFilterIndex{


### PR DESCRIPTION
Add test case for crash triggered in `swift::Expr::walk(...)`.

Current number of unresolved compiler crashers: 40 (5515 resolved)

/cc @DougGregor - just wanted to let you know that this crasher caused an assertion failure for the assertion `ty->getNominalOrBoundGenericNominal() || ty->is<DynamicSelfType>() || ty->isExistentialType() || ty->is<ArchetypeType>()` added on 2014-02-25 by you in commit 6a532e05c :-)

Assertion failure in [`lib/Sema/CSApply.cpp (line 6984)`](https://github.com/apple/swift/blob/4806e2841fbc8802d7f5c6312ceeecf7e2c37dce/lib/Sema/CSApply.cpp#L6984):

```
Assertion `ty->getNominalOrBoundGenericNominal() || ty->is<DynamicSelfType>() || ty->isExistentialType() || ty->is<ArchetypeType>()' failed.

When executing: swift::Expr *(anonymous namespace)::ExprRewriter::finishApply(swift::ApplyExpr *, swift::Type, swift::constraints::ConstraintLocatorBuilder)
```

Assertion context:

```c++
      .fixItInsert(apply->getArg()->getStartLoc(), ".init");
  }

  // If we're "constructing" a tuple type, it's simply a conversion.
  if (auto tupleTy = ty->getAs<TupleType>()) {
    // FIXME: Need an AST to represent this properly.
    return coerceToType(apply->getArg(), tupleTy, locator);
  }

  // We're constructing a value of nominal type. Look for the constructor or
  // enum element to use.
```
Stack trace:

```
0 0x00000000039d6c48 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x39d6c48)
1 0x00000000039d7386 SignalHandler(int) (/path/to/swift/bin/swift+0x39d7386)
2 0x00007fad538d6390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007fad51dfc428 gsignal /build/glibc-9tT8Do/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007fad51dfe02a abort /build/glibc-9tT8Do/glibc-2.23/stdlib/abort.c:91:0
5 0x00007fad51df4bd7 __assert_fail_base /build/glibc-9tT8Do/glibc-2.23/assert/assert.c:92:0
6 0x00007fad51df4c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x000000000139637d (/path/to/swift/bin/swift+0x139637d)
8 0x00000000013acaa3 (anonymous namespace)::ExprRewriter::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0x13acaa3)
9 0x0000000001391c74 (anonymous namespace)::ExprRewriter::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0x1391c74)
10 0x0000000001397441 (anonymous namespace)::ExprWalker::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0x1397441)
11 0x00000000014bdc5c swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x14bdc5c)
12 0x0000000001396bde (anonymous namespace)::ExprWalker::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x1396bde)
13 0x00000000014bdc0b swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x14bdc0b)
14 0x000000000138ec0f swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) (/path/to/swift/bin/swift+0x138ec0f)
15 0x00000000012f38f0 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x12f38f0)
16 0x00000000013bddd6 (anonymous namespace)::FailureDiagnosis::typeCheckChildIndependently(swift::Expr*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<TCCFlags, unsigned int>, swift::ExprTypeCheckListener*, bool) (/path/to/swift/bin/swift+0x13bddd6)
17 0x00000000013baa1e swift::ASTVisitor<(anonymous namespace)::FailureDiagnosis, bool, void, void, void, void, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x13baa1e)
18 0x00000000013b246a swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) (/path/to/swift/bin/swift+0x13b246a)
19 0x00000000013b91a2 swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) (/path/to/swift/bin/swift+0x13b91a2)
20 0x00000000012efe48 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0x12efe48)
21 0x00000000012f3866 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x12f3866)
22 0x0000000001373ee5 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x1373ee5)
23 0x00000000013736f6 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0x13736f6)
24 0x00000000013892d0 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x13892d0)
25 0x0000000000f82cb6 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf82cb6)
26 0x00000000004aa1dd performCompile(std::unique_ptr<swift::CompilerInstance, std::default_delete<swift::CompilerInstance> >&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4aa1dd)
27 0x00000000004a89f5 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a89f5)
28 0x0000000000465567 main (/path/to/swift/bin/swift+0x465567)
29 0x00007fad51de7830 __libc_start_main /build/glibc-9tT8Do/glibc-2.23/csu/../csu/libc-start.c:325:0
30 0x0000000000462c09 _start (/path/to/swift/bin/swift+0x462c09)
```