### PR TITLE
Update reflection on 4.0 to match code in master

### DIFF
--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -410,8 +410,8 @@ class ExistentialTypeFlags {
   };
   int_type Data;
 
-  constexpr ExistentialTypeFlags(int_type Data) : Data(Data) {}
 public:
+  constexpr ExistentialTypeFlags(int_type Data) : Data(Data) {}
   constexpr ExistentialTypeFlags() : Data(0) {}
   constexpr ExistentialTypeFlags withNumWitnessTables(unsigned numTables) const {
     return ExistentialTypeFlags((Data & ~NumWitnessTablesMask) | numTables);

--- a/include/swift/Reflection/Records.h
+++ b/include/swift/Reflection/Records.h
@@ -19,7 +19,7 @@
 
 #include "swift/Basic/RelativePointer.h"
 
-const uint16_t SWIFT_REFLECTION_METADATA_VERSION = 2; // use new mangling
+const uint16_t SWIFT_REFLECTION_METADATA_VERSION = 3; // superclass field
 
 namespace swift {
 namespace reflection {
@@ -145,6 +145,7 @@ class FieldDescriptor {
   }
 
   const RelativeDirectPointer<const char> MangledTypeName;
+  const RelativeDirectPointer<const char> Superclass;
 
 public:
   FieldDescriptor() = delete;
@@ -189,6 +190,14 @@ public:
 
   std::string getMangledTypeName() const {
     return MangledTypeName.get();
+  }
+
+  bool hasSuperclass() const {
+    return Superclass;
+  }
+
+  std::string getSuperclass() const {
+    return Superclass.get();
   }
 };
 

--- a/include/swift/Reflection/ReflectionContext.h
+++ b/include/swift/Reflection/ReflectionContext.h
@@ -376,6 +376,11 @@ private:
     // solve the problem.
     while (!CaptureTypes.empty()) {
       const TypeRef *OrigCaptureTR = CaptureTypes[0];
+
+      // If we failed to demangle the capture type, we cannot proceed.
+      if (OrigCaptureTR == nullptr)
+        return nullptr;
+
       const TypeRef *SubstCaptureTR = nullptr;
 
       // If we have enough substitutions to make this captured value's

--- a/include/swift/Reflection/TypeRef.h
+++ b/include/swift/Reflection/TypeRef.h
@@ -421,28 +421,39 @@ public:
 };
 
 class ProtocolCompositionTypeRef final : public TypeRef {
-  std::vector<const TypeRef *> Protocols;
+  std::vector<const TypeRef *> Members;
+  bool HasExplicitAnyObject;
 
-  static TypeRefID Profile(const std::vector<const TypeRef *> &Protocols) {
+  static TypeRefID Profile(const std::vector<const TypeRef *> &Members,
+                           bool HasExplicitAnyObject) {
     TypeRefID ID;
-    for (auto Protocol : Protocols) {
-      ID.addPointer(Protocol);
+    ID.addInteger((uint32_t)HasExplicitAnyObject);
+    for (auto Member : Members) {
+      ID.addPointer(Member);
     }
     return ID;
   }
 
 public:
-  ProtocolCompositionTypeRef(std::vector<const TypeRef *> Protocols)
-    : TypeRef(TypeRefKind::ProtocolComposition), Protocols(Protocols) {}
+  ProtocolCompositionTypeRef(std::vector<const TypeRef *> Members,
+                            bool HasExplicitAnyObject)
+    : TypeRef(TypeRefKind::ProtocolComposition),
+      Members(Members), HasExplicitAnyObject(HasExplicitAnyObject) {}
 
   template <typename Allocator>
   static const ProtocolCompositionTypeRef *
-  create(Allocator &A, std::vector<const TypeRef *> Protocols) {
-    FIND_OR_CREATE_TYPEREF(A, ProtocolCompositionTypeRef, Protocols);\
+  create(Allocator &A, std::vector<const TypeRef *> Members,
+        bool HasExplicitAnyObject) {
+    FIND_OR_CREATE_TYPEREF(A, ProtocolCompositionTypeRef, Members,
+                           HasExplicitAnyObject);
   }
 
-  const std::vector<const TypeRef *> &getProtocols() const {
-    return Protocols;
+  const std::vector<const TypeRef *> &getMembers() const {
+    return Members;
+  }
+
+  bool hasExplicitAnyObject() const {
+    return HasExplicitAnyObject;
   }
 
   static bool classof(const TypeRef *TR) {

--- a/include/swift/Reflection/TypeRefBuilder.h
+++ b/include/swift/Reflection/TypeRefBuilder.h
@@ -210,6 +210,7 @@ public:
 
   const ProtocolTypeRef *createProtocolType(const std::string &mangledName,
                                             const std::string &moduleName,
+                                            const std::string &privateDiscriminator,
                                             const std::string &name) {
     return ProtocolTypeRef::create(*this, mangledName);
   }

--- a/include/swift/Reflection/TypeRefBuilder.h
+++ b/include/swift/Reflection/TypeRefBuilder.h
@@ -215,12 +215,16 @@ public:
   }
 
   const ProtocolCompositionTypeRef *
-  createProtocolCompositionType(const std::vector<const TypeRef*> &protocols) {
-    for (auto protocol : protocols) {
-      if (!isa<ProtocolTypeRef>(protocol))
+  createProtocolCompositionType(const std::vector<const TypeRef*> &members,
+                                bool hasExplicitAnyObject) {
+    for (auto member : members) {
+      if (!isa<ProtocolTypeRef>(member) &&
+          !isa<NominalTypeRef>(member) &&
+          !isa<BoundGenericTypeRef>(member))
         return nullptr;
     }
-    return ProtocolCompositionTypeRef::create(*this, protocols);
+    return ProtocolCompositionTypeRef::create(*this, members,
+                                              hasExplicitAnyObject);
   }
 
   const ExistentialMetatypeTypeRef *

--- a/include/swift/Reflection/TypeRefBuilder.h
+++ b/include/swift/Reflection/TypeRefBuilder.h
@@ -134,6 +134,8 @@ public:
   TypeRefBuilder &operator=(const TypeRefBuilder &other) = delete;
 
 private:
+  Demangle::Demangler Dem;
+
   /// Makes sure dynamically allocated TypeRefs stick around for the life of
   /// this TypeRefBuilder and are automatically released.
   std::vector<std::unique_ptr<const TypeRef>> TypeRefPool;

--- a/include/swift/Reflection/TypeRefBuilder.h
+++ b/include/swift/Reflection/TypeRefBuilder.h
@@ -314,8 +314,8 @@ public:
   const FieldDescriptor *getFieldTypeInfo(const TypeRef *TR);
 
   /// Get the parsed and substituted field types for a nominal type.
-  std::vector<FieldTypeInfo>
-  getFieldTypeRefs(const TypeRef *TR, const FieldDescriptor *FD);
+  bool getFieldTypeRefs(const TypeRef *TR, const FieldDescriptor *FD,
+                        std::vector<FieldTypeInfo> &Fields);
 
   /// Get the primitive type lowering for a builtin type.
   const BuiltinTypeDescriptor *getBuiltinTypeInfo(const TypeRef *TR);

--- a/lib/RemoteAST/RemoteAST.cpp
+++ b/lib/RemoteAST/RemoteAST.cpp
@@ -318,14 +318,15 @@ public:
     return decl->getDeclaredType();
   }
 
-  Type createProtocolCompositionType(ArrayRef<Type> protocols) {
-    for (auto protocol : protocols) {
-      if (!protocol->is<ProtocolType>())
+  Type createProtocolCompositionType(ArrayRef<Type> members,
+                                     bool hasExplicitAnyObject) {
+    for (auto member : members) {
+      if (!member->isExistentialType() &&
+          !member->getClassOrBoundGenericClass())
         return Type();
     }
-    return ProtocolCompositionType::get(Ctx, protocols,
-                                        // FIXME
-                                        /*HasExplicitAnyObject=*/false);
+
+    return ProtocolCompositionType::get(Ctx, members, hasExplicitAnyObject);
   }
 
   Type createExistentialMetatypeType(Type instance) {

--- a/lib/RemoteAST/RemoteAST.cpp
+++ b/lib/RemoteAST/RemoteAST.cpp
@@ -306,12 +306,16 @@ public:
 
   Type createProtocolType(StringRef mangledName,
                           StringRef moduleName,
-                          StringRef protocolName) {
+                          StringRef privateDiscriminator,
+                          StringRef name) {
     auto module = Ctx.getModuleByName(moduleName);
     if (!module) return Type();
 
-    Identifier name = Ctx.getIdentifier(protocolName);
-    auto decl = findNominalTypeDecl(module, name, Identifier(),
+    auto decl = findNominalTypeDecl(module,
+                                    Ctx.getIdentifier(name),
+                                    (privateDiscriminator.empty()
+                                     ? Identifier()
+                                     : Ctx.getIdentifier(privateDiscriminator)),
                                     Demangle::Node::Kind::Protocol);
     if (!decl) return Type();
 

--- a/stdlib/public/Reflection/TypeLowering.cpp
+++ b/stdlib/public/Reflection/TypeLowering.cpp
@@ -206,13 +206,19 @@ BuiltinTypeInfo::BuiltinTypeInfo(const BuiltinTypeDescriptor *descriptor)
 /// Utility class for building values that contain witness tables.
 class ExistentialTypeInfoBuilder {
   TypeConverter &TC;
-  ExistentialTypeRepresentation Representation;
   std::vector<const ProtocolTypeRef *> Protocols;
+  ExistentialTypeRepresentation Representation;
+  ReferenceCounting Refcounting;
   bool ObjC;
   unsigned WitnessTableCount;
   bool Invalid;
 
   bool isSingleError() const {
+    // If we changed representation, it means we added a
+    // superclass constraint or an AnyObject member.
+    if (Representation != ExistentialTypeRepresentation::Opaque)
+      return false;
+
     if (Protocols.size() != 1)
       return false;
 
@@ -231,13 +237,6 @@ class ExistentialTypeInfoBuilder {
     }
 
     for (auto *P : Protocols) {
-      // FIXME: AnyObject should go away
-      if (P->isAnyObject()) {
-        Representation = ExistentialTypeRepresentation::Class;
-        // No extra witness table for AnyObject
-        continue;
-      }
-
       const FieldDescriptor *FD = TC.getBuilder().getFieldTypeInfo(P);
       if (FD == nullptr) {
         DEBUG(std::cerr << "No field descriptor: "; P->dump())
@@ -271,15 +270,76 @@ class ExistentialTypeInfoBuilder {
 public:
   ExistentialTypeInfoBuilder(TypeConverter &TC)
     : TC(TC), Representation(ExistentialTypeRepresentation::Opaque),
-      ObjC(false), WitnessTableCount(0), Invalid(false) {}
+      Refcounting(ReferenceCounting::Unknown),
+      ObjC(false), WitnessTableCount(0),
+      Invalid(false) {}
 
-  void addProtocol(const TypeRef *TR) {
-    if (auto *P = dyn_cast<const ProtocolTypeRef>(TR)) {
-      Protocols.push_back(P);
-    } else {
-      DEBUG(std::cerr << "Not a protocol: "; TR->dump())
-      Invalid = true;
+  void addProtocol(const ProtocolTypeRef *P) {
+    // FIXME: AnyObject should go away
+    if (P->isAnyObject()) {
+      Representation = ExistentialTypeRepresentation::Class;
+      // No extra witness table for AnyObject
+      return;
     }
+
+    Protocols.push_back(P);
+  }
+
+  void addProtocolComposition(const ProtocolCompositionTypeRef *PC) {
+    for (auto *T : PC->getMembers()) {
+      if (auto *P = dyn_cast<ProtocolTypeRef>(T)) {
+        addProtocol(P);
+        continue;
+      }
+
+      if (auto *PC = dyn_cast<ProtocolCompositionTypeRef>(T)) {
+        addProtocolComposition(PC);
+        continue;
+      }
+
+      // Anything else should either be a superclass constraint, or
+      // we have an invalid typeref.
+      if (!isa<NominalTypeRef>(T) &&
+          !isa<BoundGenericTypeRef>(T)) {
+        DEBUG(std::cerr << "Bad existential member: "; T->dump())
+        Invalid = true;
+        continue;
+      }
+      auto *FD = TC.getBuilder().getFieldTypeInfo(T);
+      if (FD == nullptr) {
+        DEBUG(std::cerr << "No field descriptor: "; T->dump())
+        Invalid = true;
+        continue;
+      }
+
+      // We have a valid superclass constraint. It only affects
+      // lowering by class-constraining the entire existential.
+      switch (FD->Kind) {
+      case FieldDescriptorKind::Class:
+        Refcounting = ReferenceCounting::Native;
+        LLVM_FALLTHROUGH;
+
+      case FieldDescriptorKind::ObjCClass:
+        addAnyObject();
+        break;
+
+      default:
+        DEBUG(std::cerr << "Bad existential member: "; T->dump())
+        Invalid = true;
+        continue;
+      }
+    }
+
+    if (PC->hasExplicitAnyObject())
+      addAnyObject();
+  }
+
+  void addAnyObject() {
+    Representation = ExistentialTypeRepresentation::Class;
+  }
+
+  void markInvalid() {
+    Invalid = true;
   }
 
   const TypeInfo *build() {
@@ -295,7 +355,7 @@ public:
       }
 
       return TC.getReferenceTypeInfo(ReferenceKind::Strong,
-                                     ReferenceCounting::Unknown);
+                                     Refcounting);
     }
 
     RecordKind Kind;
@@ -317,7 +377,10 @@ public:
     case ExistentialTypeRepresentation::Class:
       // Class existentials consist of a single retainable pointer
       // followed by witness tables.
-      builder.addField("object", TC.getUnknownObjectTypeRef());
+      if (Refcounting == ReferenceCounting::Unknown)
+        builder.addField("object", TC.getUnknownObjectTypeRef());
+      else
+        builder.addField("object", TC.getNativeObjectTypeRef());
       break;
     case ExistentialTypeRepresentation::Opaque: {
       auto *TI = TC.getTypeInfo(TC.getRawPointerTypeRef());
@@ -1097,8 +1160,7 @@ public:
   const TypeInfo *
   visitProtocolCompositionTypeRef(const ProtocolCompositionTypeRef *PC) {
     ExistentialTypeInfoBuilder builder(TC);
-    for (auto *P : PC->getProtocols())
-      builder.addProtocol(P);
+    builder.addProtocolComposition(PC);
     return builder.build();
   }
 
@@ -1124,8 +1186,7 @@ public:
     if (auto *P = dyn_cast<ProtocolTypeRef>(TR)) {
       builder.addProtocol(P);
     } else if (auto *PC = dyn_cast<ProtocolCompositionTypeRef>(TR)) {
-      for (auto *P : PC->getProtocols())
-        builder.addProtocol(P);
+      builder.addProtocolComposition(PC);
     } else {
       DEBUG(std::cerr << "Invalid existential metatype: "; EM->dump());
       return nullptr;

--- a/stdlib/public/Reflection/TypeRef.cpp
+++ b/stdlib/public/Reflection/TypeRef.cpp
@@ -140,8 +140,10 @@ public:
 
   void visitProtocolCompositionTypeRef(const ProtocolCompositionTypeRef *PC) {
     printHeader("protocol_composition");
-    for (auto protocol : PC->getProtocols())
-      printRec(protocol);
+    if (PC->hasExplicitAnyObject())
+      OS << " any_object";
+    for (auto member : PC->getMembers())
+      printRec(member);
     OS << ')';
   }
 
@@ -266,8 +268,8 @@ struct TypeRefIsConcrete
 
   bool
   visitProtocolCompositionTypeRef(const ProtocolCompositionTypeRef *PC) {
-    for (auto Protocol : PC->getProtocols())
-      if (!visit(Protocol))
+    for (auto Member : PC->getMembers())
+      if (!visit(Member))
         return false;
     return true;
   }

--- a/stdlib/public/Reflection/TypeRef.cpp
+++ b/stdlib/public/Reflection/TypeRef.cpp
@@ -255,7 +255,6 @@ struct TypeRefIsConcrete
   }
 
   bool visitFunctionTypeRef(const FunctionTypeRef *F) {
-    std::vector<TypeRef *> SubstitutedArguments;
     for (auto Argument : F->getArguments())
       if (!visit(Argument))
         return false;

--- a/stdlib/public/Reflection/TypeRefBuilder.cpp
+++ b/stdlib/public/Reflection/TypeRefBuilder.cpp
@@ -124,15 +124,16 @@ TypeRefBuilder::getFieldTypeInfo(const TypeRef *TR) {
   return nullptr;
 }
 
-std::vector<FieldTypeInfo>
-TypeRefBuilder::getFieldTypeRefs(const TypeRef *TR, const FieldDescriptor *FD) {
+
+bool TypeRefBuilder::getFieldTypeRefs(const TypeRef *TR,
+                                      const FieldDescriptor *FD,
+                                      std::vector<FieldTypeInfo> &Fields) {
   if (FD == nullptr)
-    return {};
+    return false;
 
   auto Subs = TR->getSubstMap();
 
   Demangle::Demangler Dem;
-  std::vector<FieldTypeInfo> Fields;
   for (auto &Field : *FD) {
     auto FieldName = Field.getFieldName();
 
@@ -145,7 +146,7 @@ TypeRefBuilder::getFieldTypeRefs(const TypeRef *TR, const FieldDescriptor *FD) {
     auto Demangled = Dem.demangleType(Field.getMangledTypeName());
     auto Unsubstituted = swift::remote::decodeMangledType(*this, Demangled);
     if (!Unsubstituted)
-      return {};
+      return false;
 
     auto Substituted = Unsubstituted->subst(*this, Subs);
 
@@ -156,7 +157,7 @@ TypeRefBuilder::getFieldTypeRefs(const TypeRef *TR, const FieldDescriptor *FD) {
 
     Fields.push_back(FieldTypeInfo::forField(FieldName, Substituted));
   }
-  return Fields;
+  return true;
 }
 
 const BuiltinTypeDescriptor *

--- a/stdlib/public/Reflection/TypeRefBuilder.cpp
+++ b/stdlib/public/Reflection/TypeRefBuilder.cpp
@@ -49,7 +49,6 @@ lookupTypeWitness(const std::string &MangledTypeName,
         continue;
 
       std::string ProtocolMangledName(AssocTyDescriptor.ProtocolTypeName);
-      Demangle::Demangler Dem;
       auto DemangledProto = Dem.demangleType(ProtocolMangledName);
       auto TR = swift::remote::decodeMangledType(*this, DemangledProto);
 
@@ -86,7 +85,6 @@ lookupSuperclass(const TypeRef *TR) {
   if (FD == nullptr)
     return nullptr;
 
-  Demangle::Demangler Dem;
   auto Demangled = Dem.demangleType(FD->getSuperclass());
   auto Unsubstituted = swift::remote::decodeMangledType(*this, Demangled);
   if (!Unsubstituted)
@@ -131,7 +129,6 @@ bool TypeRefBuilder::getFieldTypeRefs(const TypeRef *TR,
 
   auto Subs = TR->getSubstMap();
 
-  Demangle::Demangler Dem;
   for (auto &Field : *FD) {
     auto FieldName = Field.getFieldName();
 
@@ -207,7 +204,6 @@ ClosureContextInfo
 TypeRefBuilder::getClosureContextInfo(const CaptureDescriptor &CD) {
   ClosureContextInfo Info;
 
-  Demangle::Demangler Dem;
   for (auto i = CD.capture_begin(), e = CD.capture_end(); i != e; ++i) {
     const TypeRef *TR = nullptr;
     if (i->hasMangledTypeName()) {
@@ -250,7 +246,6 @@ TypeRefBuilder::dumpTypeRef(const std::string &MangledName,
   auto TypeName = Demangle::demangleTypeAsString(MangledName);
   OS << TypeName << '\n';
 
-  Demangle::Demangler Dem;
   auto DemangleTree = Dem.demangleType(MangledName);
   auto TR = swift::remote::decodeMangledType(*this, DemangleTree);
   if (!TR) {

--- a/stdlib/public/runtime/Demangle.cpp
+++ b/stdlib/public/runtime/Demangle.cpp
@@ -149,43 +149,16 @@ swift::_swift_buildDemanglingForMetadata(const Metadata *type,
   }
   case MetadataKind::Existential: {
     auto exis = static_cast<const ExistentialTypeMetadata *>(type);
-    NodePointer proto_list;
     
     std::vector<const ProtocolDescriptor *> protocols;
     protocols.reserve(exis->Protocols.NumProtocols);
     for (unsigned i = 0, e = exis->Protocols.NumProtocols; i < e; ++i)
       protocols.push_back(exis->Protocols[i]);
 
-    if (exis->getSuperclassConstraint()) {
-      // If there is a superclass constraint, we mangle it specially.
-      proto_list = Dem.createNode(Node::Kind::ProtocolListWithClass);
-    } else if (exis->isClassBounded()) {
-      // Check if the class constraint is implied by any of our
-      // protocols.
-      bool requiresClassImplicit = false;
-
-      for (auto *protocol : protocols) {
-        if (protocol->Flags.getClassConstraint()
-            == ProtocolClassConstraint::Class)
-          requiresClassImplicit = true;
-      }
-
-      // If it was implied, we don't do anything special.
-      if (requiresClassImplicit)
-        proto_list = Dem.createNode(Node::Kind::ProtocolList);
-      // If the existential type has an explicit AnyObject constraint,
-      // we must mangle it as such.
-      else
-        proto_list = Dem.createNode(Node::Kind::ProtocolListWithAnyObject);
-    } else {
-      // Just a simple composition of protocols.
-      proto_list = Dem.createNode(Node::Kind::ProtocolList);
-    }
-
-    NodePointer type_list = Dem.createNode(Node::Kind::TypeList);
-
+    auto type_list = Dem.createNode(Node::Kind::TypeList);
+    auto proto_list = Dem.createNode(Node::Kind::ProtocolList);
     proto_list->addChild(type_list, Dem);
-    
+
     // Sort the protocols by their mangled names.
     // The ordering in the existential type metadata is by metadata pointer,
     // which isn't necessarily stable across invocations.
@@ -226,11 +199,39 @@ swift::_swift_buildDemanglingForMetadata(const Metadata *type,
       type_list->addChild(protocolNode, Dem);
     }
 
-    if (auto *superclass = exis->getSuperclassConstraint()) {
+    if (auto superclass = exis->getSuperclassConstraint()) {
+      // If there is a superclass constraint, we mangle it specially.
+      auto result = Dem.createNode(Node::Kind::ProtocolListWithClass);
       auto superclassNode = _swift_buildDemanglingForMetadata(superclass, Dem);
-      proto_list->addChild(superclassNode, Dem);
+
+      result->addChild(proto_list, Dem);
+      result->addChild(superclassNode, Dem);
+      return result;
     }
 
+    if (exis->isClassBounded()) {
+      // Check if the class constraint is implied by any of our
+      // protocols.
+      bool requiresClassImplicit = false;
+
+      for (auto *protocol : protocols) {
+        if (protocol->Flags.getClassConstraint()
+            == ProtocolClassConstraint::Class)
+          requiresClassImplicit = true;
+      }
+
+      // If it was implied, we don't do anything special.
+      if (requiresClassImplicit)
+        return proto_list;
+
+      // If the existential type has an explicit AnyObject constraint,
+      // we must mangle it as such.
+      auto result = Dem.createNode(Node::Kind::ProtocolListWithAnyObject);
+      result->addChild(proto_list, Dem);
+      return result;
+    }
+
+    // Just a simple composition of protocols.
     return proto_list;
   }
   case MetadataKind::ExistentialMetatype: {

--- a/test/Reflection/Inputs/Protocols.swift
+++ b/test/Reflection/Inputs/Protocols.swift
@@ -19,3 +19,9 @@ public protocol P4 {
 public protocol ClassBoundP: class {
   associatedtype Inner
 }
+
+fileprivate protocol FileprivateProtocol {}
+
+public struct HasFileprivateProtocol {
+  fileprivate let x: FileprivateProtocol
+}

--- a/test/Reflection/Inputs/TypeLowering.swift
+++ b/test/Reflection/Inputs/TypeLowering.swift
@@ -113,6 +113,8 @@ public struct ExistentialStruct {
   
   public weak var weakAnyObject: AnyObject?
   public weak var weakAnyClassBoundProto: CP1?
+
+  public let classConstrainedP1: C & P1
 }
 
 public struct MetadataHolder<T, U> {

--- a/test/Reflection/typeref_decoding.swift
+++ b/test/Reflection/typeref_decoding.swift
@@ -579,6 +579,14 @@
 // CHECK: TypesToReflect.ClassBoundP
 // CHECK: --------------------------
 
+// CHECK: TypesToReflect.(FileprivateProtocol in _{{[0-9A-F]+}})
+// CHECK: -------------------------------------------------------------------------
+
+// CHECK: TypesToReflect.HasFileprivateProtocol
+// CHECK: -------------------------------------
+// CHECK: x: TypesToReflect.(FileprivateProtocol in _{{[0-9A-F]+}})
+// CHECK: (protocol TypesToReflect.(FileprivateProtocol in _{{[0-9A-F]+}}))
+
 // CHECK: ASSOCIATED TYPES:
 // CHECK: =================
 // CHECK: - TypesToReflect.C1 : TypesToReflect.ClassBoundP

--- a/test/Reflection/typeref_lowering.swift
+++ b/test/Reflection/typeref_lowering.swift
@@ -514,7 +514,7 @@
 
 12TypeLowering17ExistentialStructV
 // CHECK-64:      (struct TypeLowering.ExistentialStruct)
-// CHECK-64-NEXT: (struct size=448 alignment=8 stride=448 num_extra_inhabitants=0
+// CHECK-64-NEXT: (struct size=464 alignment=8 stride=464 num_extra_inhabitants=0
 // CHECK-64-NEXT:   (field name=any offset=0
 // CHECK-64-NEXT:     (opaque_existential size=32 alignment=8 stride=32 num_extra_inhabitants=0
 // CHECK-64-NEXT:       (field name=metadata offset=24
@@ -636,10 +636,16 @@
 // CHECK-64-NEXT:       (field name=object offset=0
 // CHECK-64-NEXT:         (reference kind=weak refcounting=unknown))
 // CHECK-64-NEXT:       (field name=wtable offset=8
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1))))
+// CHECK-64-NEXT:   (field name=classConstrainedP1 offset=448
+// CHECK-64-NEXT:     (class_existential size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI]]
+// CHECK-64-NEXT:       (field name=object offset=0
+// CHECK-64-NEXT:         (reference kind=strong refcounting=native))
+// CHECK-64-NEXT:       (field name=wtable offset=8
 // CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1)))))
 
 // CHECK-32: (struct TypeLowering.ExistentialStruct)
-// CHECK-32-NEXT: (struct size=224 alignment=4 stride=224 num_extra_inhabitants=0
+// CHECK-32-NEXT: (struct size=232 alignment=4 stride=232 num_extra_inhabitants=0
 // CHECK-32-NEXT:   (field name=any offset=0
 // CHECK-32-NEXT:     (opaque_existential size=16 alignment=4 stride=16 num_extra_inhabitants=0
 // CHECK-32-NEXT:       (field name=metadata offset=12
@@ -760,6 +766,12 @@
 // CHECK-32-NEXT:     (class_existential size=8 alignment=4 stride=8 num_extra_inhabitants=4096
 // CHECK-32-NEXT:       (field name=object offset=0
 // CHECK-32-NEXT:         (reference kind=weak refcounting=unknown))
+// CHECK-32-NEXT:       (field name=wtable offset=4
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1))))
+// CHECK-32-NEXT:   (field name=classConstrainedP1 offset=224
+// CHECK-32-NEXT:     (class_existential size=8 alignment=4 stride=8 num_extra_inhabitants=4096
+// CHECK-32-NEXT:       (field name=object offset=0
+// CHECK-32-NEXT:         (reference kind=strong refcounting=native))
 // CHECK-32-NEXT:       (field name=wtable offset=4
 // CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1)))))
 

--- a/unittests/Reflection/TypeRef.cpp
+++ b/unittests/Reflection/TypeRef.cpp
@@ -166,10 +166,10 @@ TEST(TypeRefTest, UniqueProtocolTypeRef) {
   EXPECT_NE(P2, P3);
   EXPECT_NE(P3, P4);
 
-  auto PC1 = Builder.createProtocolCompositionType({P1, P2});
-  auto PC2 = Builder.createProtocolCompositionType({P1, P2});
-  auto PC3 = Builder.createProtocolCompositionType({P1, P2, P2});
-  auto Any = Builder.createProtocolCompositionType({});
+  auto PC1 = Builder.createProtocolCompositionType({P1, P2}, false);
+  auto PC2 = Builder.createProtocolCompositionType({P1, P2}, false);
+  auto PC3 = Builder.createProtocolCompositionType({P1, P2, P2}, false);
+  auto Any = Builder.createProtocolCompositionType({}, false);
 
   EXPECT_EQ(PC1, PC2);
   EXPECT_NE(PC2, PC3);

--- a/unittests/Reflection/TypeRef.cpp
+++ b/unittests/Reflection/TypeRef.cpp
@@ -156,10 +156,10 @@ TEST(TypeRefTest, UniqueFunctionTypeRef) {
 TEST(TypeRefTest, UniqueProtocolTypeRef) {
   TypeRefBuilder Builder;
 
-  auto P1 = Builder.createProtocolType(ABC, Module, Protocol);
-  auto P2 = Builder.createProtocolType(ABC, Module, Protocol);
-  auto P3 = Builder.createProtocolType(ABCD, Module, Shmrotocol);
-  auto P4 = Builder.createProtocolType(XYZ, Shmodule, Protocol);
+  auto P1 = Builder.createProtocolType(ABC, Module, "", Protocol);
+  auto P2 = Builder.createProtocolType(ABC, Module, "", Protocol);
+  auto P3 = Builder.createProtocolType(ABCD, Module, "", Shmrotocol);
+  auto P4 = Builder.createProtocolType(XYZ, Shmodule, "", Protocol);
 
   EXPECT_EQ(P1, P2);
   EXPECT_NE(P2, P3);
@@ -220,8 +220,8 @@ TEST(TypeRefTest, UniqueDependentMemberTypeRef) {
 
   auto N1 = Builder.createNominalType(ABC, nullptr);
   auto N2 = Builder.createNominalType(XYZ, nullptr);
-  auto P1 = Builder.createProtocolType(ABC, Module, Protocol);
-  auto P2 = Builder.createProtocolType(ABCD, Shmodule, Protocol);
+  auto P1 = Builder.createProtocolType(ABC, Module, "", Protocol);
+  auto P2 = Builder.createProtocolType(ABCD, Shmodule, "", Protocol);
 
   auto DM1 = Builder.createDependentMemberType("Index", N1, P1);
   auto DM2 = Builder.createDependentMemberType("Index", N1, P1);

--- a/validation-test/Reflection/reflect_existential.swift
+++ b/validation-test/Reflection/reflect_existential.swift
@@ -1,0 +1,174 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_existential
+// RUN: %target-run %target-swift-reflection-test %t/reflect_existential 2>&1 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+// REQUIRES: objc_interop
+// REQUIRES: executable_test
+
+import SwiftReflectionTest
+
+class TestGeneric<T> {
+  var t: T
+
+  init(_ t: T) {
+    self.t = t
+  }
+}
+
+protocol P {}
+protocol CP : class {}
+class C : CP {}
+class D : C, P {}
+
+reflect(object: TestGeneric(D() as Any))
+
+// CHECK-64: Type reference:
+// CHECK-64: (bound_generic_class reflect_existential.TestGeneric
+// CHECK-64:   (protocol_composition))
+
+// CHECK-64: Type info:
+// CHECK-64: (class_instance size=48 alignment=8 stride=48 num_extra_inhabitants=0
+// CHECK-64:   (field name=t offset=16
+// CHECK-64:     (opaque_existential size=32 alignment=8 stride=32 num_extra_inhabitants=0
+// CHECK-64:       (field name=metadata offset=24
+// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647)))))
+
+// CHECK-32: Type reference:
+// CHECK-32: (bound_generic_class reflect_existential.TestGeneric
+// CHECK-32:   (protocol_composition))
+
+// CHECK-32: Type info:
+// CHECK-32: (class_instance size=28 alignment=4 stride=28 num_extra_inhabitants=0
+// CHECK-32:   (field name=t offset=12
+// CHECK-32:     (opaque_existential size=16 alignment=4 stride=16 num_extra_inhabitants=0
+// CHECK-32:       (field name=metadata offset=12
+// CHECK-32:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096)))))
+
+reflect(object: TestGeneric(D() as P))
+
+// CHECK-64: Type reference:
+// CHECK-64: (bound_generic_class reflect_existential.TestGeneric
+// CHECK-64:   (protocol_composition
+// CHECK-64:     (protocol reflect_existential.P)))
+
+// CHECK-64: Type info:
+// CHECK-64: (class_instance size=56 alignment=8 stride=56 num_extra_inhabitants=0
+// CHECK-64:   (field name=t offset=16
+// CHECK-64:     (opaque_existential size=40 alignment=8 stride=40 num_extra_inhabitants=0
+// CHECK-64:       (field name=metadata offset=24
+// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647))
+// CHECK-64:       (field name=wtable offset=32
+// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1)))))
+
+// CHECK-32: Type reference:
+// CHECK-32: (bound_generic_class reflect_existential.TestGeneric
+// CHECK-32:   (protocol_composition
+// CHECK-32:     (protocol reflect_existential.P)))
+
+// CHECK-32: Type info:
+// CHECK-32: (class_instance size=32 alignment=4 stride=32 num_extra_inhabitants=0
+// CHECK-32:   (field name=t offset=12
+// CHECK-32:     (opaque_existential size=20 alignment=4 stride=20 num_extra_inhabitants=0
+// CHECK-32:       (field name=metadata offset=12
+// CHECK-32:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096))
+// CHECK-32:       (field name=wtable offset=16
+// CHECK-32:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1)))))
+
+reflect(object: TestGeneric(D() as (P & AnyObject)))
+
+// CHECK-64: Type reference:
+// CHECK-64: (bound_generic_class reflect_existential.TestGeneric
+// CHECK-64:   (protocol_composition any_object
+// CHECK-64:     (protocol reflect_existential.P)
+// CHECK-64:     (protocol Swift.AnyObject)))
+
+// CHECK-64: Type info:
+// CHECK-64: (class_instance size=32 alignment=8 stride=32 num_extra_inhabitants=0
+// CHECK-64:   (field name=t offset=16
+// CHECK-64:     (class_existential size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647
+// CHECK-64:       (field name=object offset=0
+// CHECK-64:         (reference kind=strong refcounting=unknown))
+// CHECK-64:       (field name=wtable offset=8
+// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1)))))
+
+// CHECK-32: Type reference:
+// CHECK-32: (bound_generic_class reflect_existential.TestGeneric
+// CHECK-32:   (protocol_composition any_object
+// CHECK-32:     (protocol reflect_existential.P)
+// CHECK-32:     (protocol Swift.AnyObject)))
+
+// CHECK-32: Type info:
+// CHECK-32: (class_instance size=20 alignment=4 stride=20 num_extra_inhabitants=0
+// CHECK-32:   (field name=t offset=12
+// CHECK-32:     (class_existential size=8 alignment=4 stride=8 num_extra_inhabitants=4096
+// CHECK-32:       (field name=object offset=0
+// CHECK-32:         (reference kind=strong refcounting=unknown))
+// CHECK-32:       (field name=wtable offset=4
+// CHECK-32:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1)))))
+
+reflect(object: TestGeneric(D() as CP))
+
+// CHECK-64: Type reference:
+// CHECK-64: (bound_generic_class reflect_existential.TestGeneric
+// CHECK-64:   (protocol_composition any_object
+// CHECK-64:     (protocol reflect_existential.CP)))
+
+// CHECK-64: Type info:
+// CHECK-64: (class_instance size=32 alignment=8 stride=32 num_extra_inhabitants=0
+// CHECK-64:   (field name=t offset=16
+// CHECK-64:     (class_existential size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647
+// CHECK-64:       (field name=object offset=0
+// CHECK-64:         (reference kind=strong refcounting=unknown))
+// CHECK-64:       (field name=wtable offset=8
+// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1)))))
+
+// CHECK-32: Type reference:
+// CHECK-32: (bound_generic_class reflect_existential.TestGeneric
+// CHECK-32:   (protocol_composition any_object
+// CHECK-32:     (protocol reflect_existential.CP)))
+
+// CHECK-32: Type info:
+// CHECK-32: (class_instance size=20 alignment=4 stride=20 num_extra_inhabitants=0
+// CHECK-32:   (field name=t offset=12
+// CHECK-32:     (class_existential size=8 alignment=4 stride=8 num_extra_inhabitants=4096
+// CHECK-32:       (field name=object offset=0
+// CHECK-32:         (reference kind=strong refcounting=unknown))
+// CHECK-32:       (field name=wtable offset=4
+// CHECK-32:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1)))))
+
+reflect(object: TestGeneric(D() as (C & P)))
+
+// CHECK-64: Type reference:
+// CHECK-64: (bound_generic_class reflect_existential.TestGeneric
+// CHECK-64:   (protocol_composition any_object
+// CHECK-64:     (class reflect_existential.C)
+// CHECK-64:     (protocol reflect_existential.P)))
+
+// CHECK-64: Type info:
+// CHECK-64: (class_instance size=32 alignment=8 stride=32 num_extra_inhabitants=0
+// CHECK-64:   (field name=t offset=16
+// CHECK-64:     (class_existential size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647
+// CHECK-64:       (field name=object offset=0
+// CHECK-64:         (reference kind=strong refcounting=native))
+// CHECK-64:       (field name=wtable offset=8
+// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1)))))
+
+// CHECK-32: Type reference:
+// CHECK-32: (bound_generic_class reflect_existential.TestGeneric
+// CHECK-32:   (protocol_composition any_object
+// CHECK-32:     (class reflect_existential.C)
+// CHECK-32:     (protocol reflect_existential.P)))
+
+// CHECK-32: Type info:
+// CHECK-32: (class_instance size=20 alignment=4 stride=20 num_extra_inhabitants=0
+// CHECK-32:   (field name=t offset=12
+// CHECK-32:     (class_existential size=8 alignment=4 stride=8 num_extra_inhabitants=4096
+// CHECK-32:       (field name=object offset=0
+// CHECK-32:         (reference kind=strong refcounting=native))
+// CHECK-32:       (field name=wtable offset=4
+// CHECK-32:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1)))))
+
+doneReflecting()
+
+// CHECK-64: Done.
+
+// CHECK-32: Done.


### PR DESCRIPTION
* Description:
  * This is a series of patches which improve remote reflection:
    * Format version 3 brings a new way of recording the superclass of a class directly, instead of a fake "super" associated type on an AnyObject conformance.
    * Support for subclass existentials, which are enabled by default in the 4.0 branch.
    * Fixes for <rdar://problem/31661662>, <rdar://problem/31668126>, <rdar://problem/30398155> and <rdar://problem/31961386>, which are some of the top crashes we've been seeing here.
    * To make the above changes work, I had to cherry pick a couple of the mangling-related patches from the AnyObject removal, because they fixed some problems with subclass existential mangling also, in particular getting a mangled name from runtime metadata for a subclass existential type, and printing such a mangling as a human-readable string. While the AnyObject removal was intimately connected to subclass existentials, note that these changes do not introduce the new primitive AnyObject type; this continues to be a protocol in the 4.0 branch.

* Scope of the issue: the top crashes have been coming up a lot, and subclass existential support in reflection is important because this is a new feature we just introduced.

* Origination: The crash with private protocols was introduced by the RemoteAST work done in Swift 3.1, so it is a regression from Swift 3.0 to 3.1. The support for subclass existentials is needed because subclass existentials were introduced in 4.0.

* Risk: Very low risk for anything other than reflection. Medium risk for reflection since there is a lot of new code; I would have liked to get it in two days ago, but was hitting CI issues and I'm hoping it should not be a problem to get it in now.

* Tested: New tests added for the new features and bug fixes.

* Reviewed by: @bitjammer and @rjmccall