### PR TITLE
Large loadable types: Fixes a bug in Apply's result type

### DIFF
--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -134,10 +134,50 @@ static bool containsLargeLoadable(GenericEnvironment *GenericEnv,
   return false;
 }
 
-// Forward declaration - two functions depend on each other
+// Forward declarations - functions depend on each other
 static SmallVector<SILParameterInfo, 4>
 getNewArgTys(GenericEnvironment *GenericEnv, ArrayRef<SILParameterInfo> params,
              irgen::IRGenModule &Mod);
+static SILType getNewSILType(GenericEnvironment *GenericEnv,
+                             SILType storageType, irgen::IRGenModule &Mod);
+
+static bool newResultsDiffer(GenericEnvironment *GenericEnv,
+                             ArrayRef<SILResultInfo> origResults,
+                             irgen::IRGenModule &Mod) {
+  SmallVector<SILResultInfo, 2> newResults;
+  for (auto result : origResults) {
+    SILType currResultTy = result.getSILStorageType();
+    SILType newSILType = getNewSILType(GenericEnv, currResultTy, Mod);
+    // We (currently) only care about function signatures
+    if (!isLargeLoadableType(GenericEnv, currResultTy, Mod) &&
+        (newSILType != currResultTy)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+static SmallVector<SILResultInfo, 2>
+getNewResults(GenericEnvironment *GenericEnv,
+              ArrayRef<SILResultInfo> origResults, irgen::IRGenModule &Mod) {
+  // Get new SIL Function results - same as old results UNLESS:
+  // Function type results might have a different signature
+  SmallVector<SILResultInfo, 2> newResults;
+  for (auto result : origResults) {
+    SILType currResultTy = result.getSILStorageType();
+    SILType newSILType = getNewSILType(GenericEnv, currResultTy, Mod);
+    // We (currently) only care about function signatures
+    if (!isLargeLoadableType(GenericEnv, currResultTy, Mod) &&
+        (newSILType != currResultTy)) {
+      SILResultInfo newResult(newSILType.getSwiftRValueType(),
+                              result.getConvention());
+      newResults.push_back(newResult);
+    } else {
+      newResults.push_back(result);
+    }
+  }
+  return newResults;
+}
 
 static SILFunctionType *
 getNewSILFunctionTypePtr(GenericEnvironment *GenericEnv,
@@ -146,13 +186,13 @@ getNewSILFunctionTypePtr(GenericEnvironment *GenericEnv,
   assert(modifiableFunction(CanSILFunctionType(currSILFunctionType)));
   SmallVector<SILParameterInfo, 4> newArgTys =
       getNewArgTys(GenericEnv, currSILFunctionType->getParameters(), Mod);
-  SILFunctionType *newSILFunctionType =
-      SILFunctionType::get(currSILFunctionType->getGenericSignature(),
-                           currSILFunctionType->getExtInfo(),
-                           currSILFunctionType->getCalleeConvention(),
-                           newArgTys, currSILFunctionType->getResults(),
-                           currSILFunctionType->getOptionalErrorResult(),
-                           currSILFunctionType->getASTContext());
+  SILFunctionType *newSILFunctionType = SILFunctionType::get(
+      currSILFunctionType->getGenericSignature(),
+      currSILFunctionType->getExtInfo(),
+      currSILFunctionType->getCalleeConvention(), newArgTys,
+      getNewResults(GenericEnv, currSILFunctionType->getResults(), Mod),
+      currSILFunctionType->getOptionalErrorResult(),
+      currSILFunctionType->getASTContext());
   return newSILFunctionType;
 }
 
@@ -426,6 +466,13 @@ void LargeValueVisitor::visitApply(ApplySite applySite) {
       return;
     }
   }
+  SILType currType = applySite.getType();
+  SILType newType = getNewSILType(genEnv, currType, pass.Mod);
+  // We only care about function type results
+  if (!isLargeLoadableType(genEnv, currType, pass.Mod) &&
+      (currType != newType)) {
+    pass.applies.push_back(applySite.getInstruction());
+  }
 }
 
 static bool isMethodInstUnmodifiable(MethodInst *instr) {
@@ -469,6 +516,9 @@ void LargeValueVisitor::visitMethodInst(MethodInst *instr) {
                             pass.Mod)) {
     pass.methodInstsToMod.push_back(instr);
     return;
+  }
+  if (newResultsDiffer(genEnv, currSILFunctionType->getResults(), pass.Mod)) {
+    pass.methodInstsToMod.push_back(instr);
   }
 }
 

--- a/test/IRGen/big_types_corner_cases.swift
+++ b/test/IRGen/big_types_corner_cases.swift
@@ -1,0 +1,33 @@
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -emit-ir | %FileCheck %s
+
+public struct BigStruct {
+  var i0 : Int32 = 0
+  var i1 : Int32 = 1
+  var i2 : Int32 = 2
+  var i3 : Int32 = 3
+  var i4 : Int32 = 4
+  var i5 : Int32 = 5
+  var i6 : Int32 = 6
+  var i7 : Int32 = 7
+  var i8 : Int32 = 8
+}
+
+public func f1_returns_BigType(_ x: BigStruct) -> BigStruct {
+  return x
+}
+
+public func f2_returns_f1() -> (_ x: BigStruct) -> BigStruct {
+  return f1_returns_BigType
+}
+
+public func f3_uses_f2() {
+  let x = BigStruct()
+  let useOfF2 = f2_returns_f1()
+  let _ = useOfF2(x)
+}
+
+// CHECK-LABEL: define{{( protected)?}} swiftcc void @_T022big_types_corner_cases10f3_uses_f2yyF()
+// CHECK: call swiftcc void @_T022big_types_corner_cases9BigStructVACycfC(%T22big_types_corner_cases9BigStructV* noalias nocapture sret
+// CHECK: call swiftcc { i8*, %swift.refcounted* } @_T022big_types_corner_cases13f2_returns_f1AA9BigStructVADcyF()
+// CHECK: call swiftcc void %16(%T22big_types_corner_cases9BigStructV* noalias nocapture sret %call.aggresult1, %T22big_types_corner_cases9BigStructV* noalias nocapture dereferenceable
+// CHECK: ret void


### PR DESCRIPTION
Radar rdar://problem/31956335

Large loadable types: Fixes a bug wherein we did not update an Apply’s result type in case it is a function type - causing an incorrect function signature to be passed on to subsequent Apply instructions