### PR TITLE
[ClangImporter] Break infinite recursion when failing to import.

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4735,7 +4735,7 @@ Decl *SwiftDeclConverter::importCompatibilityTypeAlias(
   Decl *importedDecl = nullptr;
   if (getVersion() >= getActiveSwiftVersion())
     importedDecl = Impl.importDecl(decl, ImportNameVersion::ForTypes);
-  if (!importedDecl)
+  if (!importedDecl && getVersion() != getActiveSwiftVersion())
     importedDecl = Impl.importDecl(decl, getActiveSwiftVersion());
   auto typeDecl = dyn_cast_or_null<TypeDecl>(importedDecl);
   if (!typeDecl)


### PR DESCRIPTION
Fixes a bug in cb9b9ea7 where a compatibility typealias for a type that's been import-as-member'd can't resolve the member, because we're already in the middle of importing members of the enclosing type.

No tests at the moment because I want to get this in quickly, but also because the real issue is still there: this should import successfully.

rdar://problem/31921746