### PR TITLE
Fix IRGenSIL to always look through DynamicallyEnforcedAddress.

### DIFF
--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -274,11 +274,6 @@ public:
     return kind == Kind::BoxWithAddress;
   }
   
-  Address getAddress() const {
-    assert(kind == Kind::Address && "not an allocated address");
-    return address.getAddress();
-  }
-
   StackAddress getStackAddress() const {
     assert(kind == Kind::Address && "not an allocated address");
     return address;
@@ -300,6 +295,17 @@ public:
   const DynamicallyEnforcedAddress &getDynamicallyEnforcedAddress() const {
     assert(kind == Kind::DynamicallyEnforcedAddress);
     return dynamicallyEnforcedAddress;
+  }
+
+  Address getAnyAddress() const {
+    if (kind == LoweredValue::Kind::Address) {
+      return address.getAddress();
+    } else if (kind == LoweredValue::Kind::ContainedAddress) {
+      return getAddressInContainer();
+    } else {
+      assert(kind == LoweredValue::Kind::DynamicallyEnforcedAddress);
+      return getDynamicallyEnforcedAddress().Addr;
+    }
   }
   
   void getExplosion(IRGenFunction &IGF, Explosion &ex) const;
@@ -559,15 +565,7 @@ public:
   /// Get the Address of a SIL value of address type, which must have been
   /// lowered.
   Address getLoweredAddress(SILValue v) {
-    auto &&lv = getLoweredValue(v);
-    if (lv.kind == LoweredValue::Kind::Address) {
-      return lv.getAddress();
-    } else if (lv.kind == LoweredValue::Kind::ContainedAddress) {
-      return lv.getAddressInContainer();
-    } else {
-      assert(lv.kind == LoweredValue::Kind::DynamicallyEnforcedAddress);
-      return lv.getDynamicallyEnforcedAddress().Addr;
-    }
+    return getLoweredValue(v).getAnyAddress();
   }
 
   StackAddress getLoweredStackAddress(SILValue v) {
@@ -2623,14 +2621,13 @@ static void addIncomingSILArgumentsToPHINodes(IRGenSILFunction &IGF,
                                               OperandValueArrayRef args) {
   unsigned phiIndex = 0;
   for (SILValue arg : args) {
-    const LoweredValue &lv = IGF.getLoweredValue(arg);
-  
-    if (lv.isAddress()) {
-      addIncomingAddressToPHINodes(IGF, lbb, phiIndex, lv.getAddress());
+    if (arg->getType().isAddress()) {
+      addIncomingAddressToPHINodes(IGF, lbb, phiIndex,
+                                   IGF.getLoweredAddress(arg));
       continue;
     }
     
-    Explosion argValue = lv.getExplosion(IGF);
+    Explosion argValue = IGF.getLoweredExplosion(arg);
     addIncomingExplosionToPHINodes(IGF, lbb, phiIndex, argValue);
   }
 }
@@ -4647,16 +4644,18 @@ void IRGenSILFunction::visitIsNonnullInst(swift::IsNonnullInst *i) {
   // Get the value we're testing, which may be a function, an address or an
   // instance pointer.
   llvm::Value *val;
-  const LoweredValue &lv = getLoweredValue(i->getOperand());
-  
-  if (i->getOperand()->getType().is<SILFunctionType>()) {
-    Explosion values = lv.getExplosion(*this);
-    val = values.claimNext();   // Function pointer.
-    values.claimNext();         // Ignore the data pointer.
-  } else if (lv.isAddress()) {
-    val = lv.getAddress().getAddress();
+
+  SILValue operand = i->getOperand();
+  auto type = operand->getType();
+  if (type.isAddress()) {
+    val = getLoweredAddress(operand).getAddress();
+  } else if (auto fnType = type.getAs<SILFunctionType>()) {
+    Explosion values = getLoweredExplosion(operand);
+    val = values.claimNext();    // Function pointer.
+    if (fnType->getRepresentation() == SILFunctionTypeRepresentation::Thick)
+      (void) values.claimNext(); // Ignore the data pointer.
   } else {
-    Explosion values = lv.getExplosion(*this);
+    Explosion values = getLoweredExplosion(operand);
     val = values.claimNext();
   }
   
@@ -5049,7 +5048,7 @@ void IRGenSILFunction::visitCopyAddrInst(swift::CopyAddrInst *i) {
       setAllocatedAddressForBuffer(i->getDest(), addr);
     }
   } else {
-    Address dest = loweredDest.getAddress();
+    Address dest = loweredDest.getAnyAddress();
     
     if (i->isInitializationOfDest()) {
       if (i->isTakeOfSrc()) {

--- a/test/IRGen/access_markers.sil
+++ b/test/IRGen/access_markers.sil
@@ -5,6 +5,7 @@ import Swift
 
 class A {
   @sil_stored var property: Int { get set }
+  @sil_stored var exProperty: Any { get set }
   deinit
   init()
 }
@@ -74,6 +75,21 @@ bb0(%0 : $A):
 
   dealloc_stack %1 : $*Builtin.UnsafeValueBuffer
 
+  %20 = tuple ()
+  return %20 : $()
+}
+
+// rdar://31964550
+// Just check that this doesn't crash.
+sil @testCopyAddr : $(@guaranteed A) -> () {
+bb0(%0 : $A):
+  %1 = alloc_stack $Any
+  %2 = ref_element_addr %0 : $A, #A.exProperty
+  %3 = begin_access [dynamic] [read] %2 : $*Any
+  copy_addr %2 to [initialization] %1 : $*Any
+  end_access %3 : $*Any
+  destroy_addr %1 : $*Any
+  dealloc_stack %1 : $*Any
   %20 = tuple ()
   return %20 : $()
 }


### PR DESCRIPTION
Fixes rdar://31964550.

Swift 4.0 version of #9237.
