### PR TITLE
[SR-964] Warn if the implicit setter argument 'newValue' is unused

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3701,10 +3701,10 @@ WARNING(pbd_never_used_stmtcond, none,
         "value %0 was defined but never used; consider replacing "
         "with boolean test",
         (Identifier))
-WARNING(unused_implicit_setter_newvalue, none,
-        "implicit setter argument 'newValue' is never used; consider specifying"
-        " a variable name or using the argument `newValue`",
-        ())
+WARNING(unused_setter_newvalue, none,
+        "setter argument %0 was never used, but the getter was accessed; "
+        "consider using %0 or removing %1",
+        (Identifier, Identifier))
 
 WARNING(pbd_never_used, none,
         "initialization of %select{variable|immutable value}1 %0 was never used"

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3701,6 +3701,10 @@ WARNING(pbd_never_used_stmtcond, none,
         "value %0 was defined but never used; consider replacing "
         "with boolean test",
         (Identifier))
+WARNING(unused_implicit_setter_newvalue, none,
+        "implicit setter argument 'newValue' is never used; consider specifying"
+        " a variable name or using the argument `newValue`",
+        ())
 
 WARNING(pbd_never_used, none,
         "initialization of %select{variable|immutable value}1 %0 was never used"

--- a/test/NameBinding/scope_map_lookup.swift
+++ b/test/NameBinding/scope_map_lookup.swift
@@ -93,6 +93,7 @@ func localComputedProperties() {
       return localProperty // expected-warning{{attempting to access 'localProperty' within its own getter}}
     }
     set {
+      _ = newValue
       print(localProperty)
     }
   }

--- a/test/decl/var/usage.swift
+++ b/test/decl/var/usage.swift
@@ -274,3 +274,23 @@ func sr2421() {
   let x: Int // expected-warning {{immutable value 'x' was never used; consider removing it}}
   x = 42
 }
+
+// Tests fix to SR-964
+func sr964() {
+  var noOpSetter: String {
+    get { return "" }
+    set { } // No warning
+  }
+  var suspiciousSetter: String {
+    get { return "" }
+    set { print(suspiciousSetter) } // expected-warning {{setter argument 'newValue' was never used, but the getter was accessed; consider using 'newValue' or removing 'suspiciousSetter'}}
+  }
+  var namedSuspiciousSetter: String {
+    get { return "" }
+    set(parameter) { print(namedSuspiciousSetter) } // expected-warning {{setter argument 'parameter' was never used, but the getter was accessed; consider using 'parameter' or removing 'namedSuspiciousSetter'}}
+  }
+  var okSetter: String {
+    get { return "" }
+    set { print(newValue) } // No warning
+  }
+}


### PR DESCRIPTION
This PR generates a warning if a setters implicit `newValue` variable is not used. If the variable is used, or if it is explicitly added to the setter (e.g. `set(newValue)`), no warning is generated.  This does not change willSet or didSet, since ignoring the implicit argument in observers is pretty common.

This turns out to create a lot of test churn! Before I run through all of the changes, I wanted to make sure that this is a desired warning, and that the behavior is correct. I think there are relatively few reasons to not use `newValue`, and disabling the warning is very trivial by adding `(newValue)`, or `(ignored)` to the setter. 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-964](https://bugs.swift.org/browse/SR-964).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
