### PR TITLE
SIL: KeyPathInst has to have side effects, since it retains.

### DIFF
--- a/include/swift/SIL/SILNodes.def
+++ b/include/swift/SIL/SILNodes.def
@@ -251,7 +251,9 @@ ABSTRACT_VALUE(SILInstruction, ValueBase)
   INST(InitBlockStorageHeaderInst, SILInstruction, init_block_storage_header, None, DoesNotRelease)
 
   // Key paths
-  INST(KeyPathInst, SILInstruction, keypath, None, DoesNotRelease)
+  // TODO: The only "side effect" is potentially retaining the returned key path
+  // object; is there a more specific effect?
+  INST(KeyPathInst, SILInstruction, keypath, MayHaveSideEffects, DoesNotRelease)
 
   // Conversions
   ABSTRACT_VALUE(ConversionInst, SILInstruction)


### PR DESCRIPTION
Fixes rdar://problem/31975279.
