### PR TITLE
Reflection: Fix crash when reflecting existential with fileprivate protocol member

### DIFF
--- a/include/swift/Reflection/TypeRefBuilder.h
+++ b/include/swift/Reflection/TypeRefBuilder.h
@@ -210,6 +210,7 @@ public:
 
   const ProtocolTypeRef *createProtocolType(const std::string &mangledName,
                                             const std::string &moduleName,
+                                            const std::string &privateDiscriminator,
                                             const std::string &name) {
     return ProtocolTypeRef::create(*this, mangledName);
   }

--- a/lib/RemoteAST/RemoteAST.cpp
+++ b/lib/RemoteAST/RemoteAST.cpp
@@ -305,12 +305,14 @@ public:
 
   Type createProtocolType(StringRef mangledName,
                           StringRef moduleName,
-                          StringRef protocolName) {
+                          StringRef privateDiscriminator,
+                          StringRef name) {
     auto module = Ctx.getModuleByName(moduleName);
     if (!module) return Type();
 
-    Identifier name = Ctx.getIdentifier(protocolName);
-    auto decl = findNominalTypeDecl(module, name, Identifier(),
+    auto decl = findNominalTypeDecl(module,
+                                    Ctx.getIdentifier(privateDiscriminator),
+                                    Ctx.getIdentifier(name),
                                     Demangle::Node::Kind::Protocol);
     if (!decl) return Type();
 

--- a/test/Reflection/Inputs/Protocols.swift
+++ b/test/Reflection/Inputs/Protocols.swift
@@ -19,3 +19,9 @@ public protocol P4 {
 public protocol ClassBoundP: class {
   associatedtype Inner
 }
+
+fileprivate protocol FileprivateProtocol {}
+
+public struct HasFileprivateProtocol {
+  fileprivate let x: FileprivateProtocol
+}

--- a/test/Reflection/typeref_decoding.swift
+++ b/test/Reflection/typeref_decoding.swift
@@ -579,6 +579,14 @@
 // CHECK: TypesToReflect.ClassBoundP
 // CHECK: --------------------------
 
+// CHECK: TypesToReflect.(FileprivateProtocol in _{{[0-9A-F]+}})
+// CHECK: -------------------------------------------------------------------------
+
+// CHECK: TypesToReflect.HasFileprivateProtocol
+// CHECK: -------------------------------------
+// CHECK: x: TypesToReflect.(FileprivateProtocol in _{{[0-9A-F]+}})
+// CHECK: (protocol TypesToReflect.(FileprivateProtocol in _{{[0-9A-F]+}}))
+
 // CHECK: ASSOCIATED TYPES:
 // CHECK: =================
 // CHECK: - TypesToReflect.C1 : TypesToReflect.ClassBoundP

--- a/unittests/Reflection/TypeRef.cpp
+++ b/unittests/Reflection/TypeRef.cpp
@@ -156,10 +156,10 @@ TEST(TypeRefTest, UniqueFunctionTypeRef) {
 TEST(TypeRefTest, UniqueProtocolTypeRef) {
   TypeRefBuilder Builder;
 
-  auto P1 = Builder.createProtocolType(ABC, Module, Protocol);
-  auto P2 = Builder.createProtocolType(ABC, Module, Protocol);
-  auto P3 = Builder.createProtocolType(ABCD, Module, Shmrotocol);
-  auto P4 = Builder.createProtocolType(XYZ, Shmodule, Protocol);
+  auto P1 = Builder.createProtocolType(ABC, Module, "", Protocol);
+  auto P2 = Builder.createProtocolType(ABC, Module, "", Protocol);
+  auto P3 = Builder.createProtocolType(ABCD, Module, "", Shmrotocol);
+  auto P4 = Builder.createProtocolType(XYZ, Shmodule, "", Protocol);
 
   EXPECT_EQ(P1, P2);
   EXPECT_NE(P2, P3);
@@ -220,8 +220,8 @@ TEST(TypeRefTest, UniqueDependentMemberTypeRef) {
 
   auto N1 = Builder.createNominalType(ABC, nullptr);
   auto N2 = Builder.createNominalType(XYZ, nullptr);
-  auto P1 = Builder.createProtocolType(ABC, Module, Protocol);
-  auto P2 = Builder.createProtocolType(ABCD, Shmodule, Protocol);
+  auto P1 = Builder.createProtocolType(ABC, Module, "", Protocol);
+  auto P2 = Builder.createProtocolType(ABCD, Shmodule, "", Protocol);
 
   auto DM1 = Builder.createDependentMemberType("Index", N1, P1);
   auto DM2 = Builder.createDependentMemberType("Index", N1, P1);


### PR DESCRIPTION
Fixes <rdar://problem/31661662>, <rdar://problem/31668126>,
and probably many other crashes with the same backtrace.