### PR TITLE
[Associated type inference] Check solutions against full requirement signature

### DIFF
--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -145,13 +145,15 @@ public:
 
   /// Retrieve the type witness for the given associated type.
   Type getTypeWitness(AssociatedTypeDecl *assocType,
-                      LazyResolver *resolver) const;
+                      LazyResolver *resolver,
+                      SubstOptions options = None) const;
 
   /// Retrieve the type witness and type decl (if one exists)
   /// for the given associated type.
   std::pair<Type, TypeDecl *>
   getTypeWitnessAndDecl(AssociatedTypeDecl *assocType,
-                        LazyResolver *resolver) const;
+                        LazyResolver *resolver,
+                        SubstOptions options = None) const;
 
   /// Apply the given function object to each type witness within this
   /// protocol conformance.
@@ -399,7 +401,8 @@ public:
   /// for the given associated type.
   std::pair<Type, TypeDecl *>
   getTypeWitnessAndDecl(AssociatedTypeDecl *assocType,
-                        LazyResolver *resolver) const;
+                        LazyResolver *resolver,
+                        SubstOptions options = None) const;
 
   /// Determine whether the protocol conformance has a type witness for the
   /// given associated type.
@@ -568,7 +571,8 @@ public:
   /// for the given associated type.
   std::pair<Type, TypeDecl *>
   getTypeWitnessAndDecl(AssociatedTypeDecl *assocType,
-                        LazyResolver *resolver) const;
+                        LazyResolver *resolver,
+                        SubstOptions options = None) const;
 
   /// Given that the requirement signature of the protocol directly states
   /// that the given dependent type must conform to the given protocol,
@@ -662,8 +666,10 @@ public:
   /// for the given associated type.
   std::pair<Type, TypeDecl *>
   getTypeWitnessAndDecl(AssociatedTypeDecl *assocType,
-                        LazyResolver *resolver) const {
-    return InheritedConformance->getTypeWitnessAndDecl(assocType, resolver);
+                        LazyResolver *resolver,
+                        SubstOptions options = None) const {
+    return InheritedConformance->getTypeWitnessAndDecl(assocType, resolver,
+                                                       options);
   }
 
   /// Given that the requirement signature of the protocol directly states

--- a/include/swift/AST/Type.h
+++ b/include/swift/AST/Type.h
@@ -165,7 +165,26 @@ enum class SubstFlags {
 };
 
 /// Options for performing substitutions into a type.
-typedef OptionSet<SubstFlags> SubstOptions;
+struct SubstOptions : public OptionSet<SubstFlags> {
+  typedef std::function<Type(const NormalProtocolConformance *,
+                             AssociatedTypeDecl *)>
+    GetTentativeTypeWitness;
+
+  /// Function that retrieves a tentative type witness for a protocol
+  /// conformance with the state \c CheckingTypeWitnesses.
+  GetTentativeTypeWitness getTentativeTypeWitness;
+
+  SubstOptions(llvm::NoneType) : OptionSet(None) { }
+
+  SubstOptions(SubstFlags flags) : OptionSet(flags) { }
+
+  SubstOptions(OptionSet<SubstFlags> options) : OptionSet(options) { }
+
+  SubstOptions(OptionSet<SubstFlags> options,
+              GetTentativeTypeWitness getTentativeTypeWitness)
+    : OptionSet(options),
+      getTentativeTypeWitness(std::move(getTentativeTypeWitness)) { }
+};
 
 inline SubstOptions operator|(SubstFlags lhs, SubstFlags rhs) {
   return SubstOptions(lhs) | rhs;

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -215,13 +215,16 @@ ProtocolConformance::hasTypeWitness(AssociatedTypeDecl *assocType,
 
 std::pair<Type, TypeDecl *>
 ProtocolConformance::getTypeWitnessAndDecl(AssociatedTypeDecl *assocType,
-                                                LazyResolver *resolver) const {
-  CONFORMANCE_SUBCLASS_DISPATCH(getTypeWitnessAndDecl, (assocType, resolver))
+                                           LazyResolver *resolver,
+                                           SubstOptions options) const {
+  CONFORMANCE_SUBCLASS_DISPATCH(getTypeWitnessAndDecl,
+                                (assocType, resolver, options))
 }
 
 Type ProtocolConformance::getTypeWitness(AssociatedTypeDecl *assocType,
-                                         LazyResolver *resolver) const {
-  return getTypeWitnessAndDecl(assocType, resolver).first;
+                                         LazyResolver *resolver,
+                                         SubstOptions options) const {
+  return getTypeWitnessAndDecl(assocType, resolver, options).first;
 }
 
 ValueDecl *ProtocolConformance::getWitnessDecl(ValueDecl *requirement,
@@ -472,22 +475,39 @@ static bool resolveKnownTypeWitness(NormalProtocolConformance *conformance,
 
 std::pair<Type, TypeDecl *>
 NormalProtocolConformance::getTypeWitnessAndDecl(AssociatedTypeDecl *assocType,
-                                                 LazyResolver *resolver) const {
+                                                 LazyResolver *resolver,
+                                                 SubstOptions options) const {
   if (Resolver)
     resolveLazyInfo();
 
+  // Check whether we already have a type witness.
   auto known = TypeWitnesses.find(assocType);
-  if (known == TypeWitnesses.end()) {
-    PrettyStackTraceRequirement trace("resolving", this, assocType);
-    if (!resolveKnownTypeWitness(const_cast<NormalProtocolConformance *>(this),
-                                 assocType)) {
-      assert(resolver && "Unable to resolve type witness");
-      resolver->resolveTypeWitness(this, assocType);
+  if (known != TypeWitnesses.end())
+    return known->second;
+
+  // If this conformance is in a state where it is inferring type witnesses,
+  // check tentative witnesses.
+  if (getState() == ProtocolConformanceState::CheckingTypeWitnesses) {
+    // If there is a tentative-type-witness function, use it.
+    if (options.getTentativeTypeWitness) {
+      if (Type witnessType = options.getTentativeTypeWitness(this, assocType))
+        return { witnessType, nullptr };
     }
-    known = TypeWitnesses.find(assocType);
-    assert(known != TypeWitnesses.end() && "Didn't resolve witness?");
+
+    // Otherwise, we fail; this is the only case in which we can retturn a
+    // null type.
+    return { Type(), nullptr };
   }
 
+  // Otherwise, resolve the type witness.
+  PrettyStackTraceRequirement trace("resolving", this, assocType);
+  if (!resolveKnownTypeWitness(const_cast<NormalProtocolConformance *>(this),
+                               assocType)) {
+    assert(resolver && "Unable to resolve type witness");
+    resolver->resolveTypeWitness(this, assocType);
+  }
+  known = TypeWitnesses.find(assocType);
+  assert(known != TypeWitnesses.end() && "Didn't resolve witness?");
   return known->second;
 }
 
@@ -656,7 +676,8 @@ bool SpecializedProtocolConformance::hasTypeWitness(
 std::pair<Type, TypeDecl *>
 SpecializedProtocolConformance::getTypeWitnessAndDecl(
                       AssociatedTypeDecl *assocType, 
-                      LazyResolver *resolver) const {
+                      LazyResolver *resolver,
+                      SubstOptions options) const {
   // If we've already created this type witness, return it.
   auto known = TypeWitnesses.find(assocType);
   if (known != TypeWitnesses.end()) {
@@ -669,26 +690,41 @@ SpecializedProtocolConformance::getTypeWitnessAndDecl(
   auto substitutionMap =
       genericSig->getSubstitutionMap(GenericSubstitutions);
 
-  auto genericWitnessAndDecl
-    = GenericConformance->getTypeWitnessAndDecl(assocType, resolver);
+  // Local function to determine whether we will end up
+  auto normal = GenericConformance->getRootNormalConformance();
+  auto isTentativeWitness = [&] {
+    if (normal->getState() != ProtocolConformanceState::CheckingTypeWitnesses)
+      return false;
 
-  auto &genericWitness = genericWitnessAndDecl.first;
+    return !normal->hasTypeWitness(assocType, nullptr);
+  };
+
+  auto genericWitnessAndDecl
+    = GenericConformance->getTypeWitnessAndDecl(assocType, resolver, options);
+
+  auto genericWitness = genericWitnessAndDecl.first;
+  if (!genericWitness)
+    return { Type(), nullptr };
+
   auto *typeDecl = genericWitnessAndDecl.second;
 
   // Apply the substitution we computed above
   auto specializedType
-    = genericWitness.subst(substitutionMap);
-  if (!specializedType)
-    specializedType = ErrorType::get(genericWitness);
+    = genericWitness.subst(substitutionMap, options);
+  if (!specializedType) {
+    if (isTentativeWitness())
+      return { Type(), nullptr };
 
-  // If the type witness was unchanged, just copy it directly.
-  if (specializedType.getPointer() == genericWitness.getPointer()) {
-    TypeWitnesses[assocType] = genericWitnessAndDecl;
-    return TypeWitnesses[assocType];
+    specializedType = ErrorType::get(genericWitness);
   }
 
-  TypeWitnesses[assocType] = std::make_pair(specializedType, typeDecl);
-  return TypeWitnesses[assocType];
+  // If we aren't in a case where we used the tentative type witness
+  // information, cache the result.
+  auto specializedWitnessAndDecl = std::make_pair(specializedType, typeDecl);
+  if (!isTentativeWitness() && !specializedType->hasError())
+    TypeWitnesses[assocType] = specializedWitnessAndDecl;
+
+  return specializedWitnessAndDecl;
 }
 
 ProtocolConformanceRef

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2909,17 +2909,11 @@ static Type getMemberForBaseType(LookupConformanceFn lookupConformances,
     if (!conformance) return failed();
     if (!conformance->isConcrete()) return failed();
 
-    // If we have an unsatisfied type witness while we're checking the
-    // conformances we're supposed to skip this conformance's unsatisfied type
-    // witnesses, and we have an unsatisfied type witness, return
-    // "missing".
-    if (conformance->getConcrete()->getRootNormalConformance()->getState()
-          == ProtocolConformanceState::CheckingTypeWitnesses &&
-        !conformance->getConcrete()->hasTypeWitness(assocType, nullptr))
-      return failed();
-
+    // Retrieve the type witness.
     auto witness =
-      conformance->getConcrete()->getTypeWitness(assocType, resolver);
+      conformance->getConcrete()->getTypeWitness(assocType, resolver, options);
+    if (!witness)
+      return failed();
 
     // This is a hacky feature allowing code completion to migrate to
     // using Type::subst() without changing output.

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5453,6 +5453,7 @@ bool TypeChecker::useObjectiveCBridgeableConformancesOfArgs(
   case RequirementCheckResult::UnsatisfiedDependency:
     return true;
   case RequirementCheckResult::Failure:
+  case RequirementCheckResult::SubstitutionFailure:
     return false;
   case RequirementCheckResult::Success: {
     bool anyUnsatisfied = false;

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4012,6 +4012,7 @@ void ConformanceChecker::resolveTypeWitnesses() {
   typedef decltype(typeWitnesses)::ScopeTy TypeWitnessesScope;
   unsigned numTypeWitnesses = 0;
   SmallVector<InferredTypeWitnessesSolution, 4> solutions;
+  SmallVector<InferredTypeWitnessesSolution, 4> nonViableSolutions;
 
   // Information to use for diagnosing failures when we don't have
   // something more specific.
@@ -4194,13 +4195,44 @@ void ConformanceChecker::resolveTypeWitnesses() {
         if (replaced.isNull())
           return true;
         
-        if (checkTypeWitness(TC, DC, assocType, replaced))
-          return true;
-
         known->first = replaced;
       }
     }
 
+    // Check any same-type requirements in the protocol's requirement signature.
+    if (Proto->isRequirementSignatureComputed()) {
+      SubstOptions options(None);
+      options.getTentativeTypeWitness =
+        [&](const NormalProtocolConformance *conformance,
+            AssociatedTypeDecl *assocType) -> Type {
+          if (conformance != Conformance) return Type(0);
+
+          return typeWitnesses.begin(assocType)->first;
+        };
+
+      auto substitutions =
+        SubstitutionMap::getProtocolSubstitutions(
+                                          Proto, Conformance->getType(),
+                                          ProtocolConformanceRef(Conformance));
+
+      auto requirementSig = Proto->getRequirementSignature();
+      auto result =
+        TC.checkGenericArguments(DC, SourceLoc(), SourceLoc(),
+                                 Conformance->getType(), requirementSig,
+                                 QuerySubstitutionMap{substitutions},
+                                 TypeChecker::LookUpConformance(
+                                   TC, Conformance->getDeclContext()),
+                                 nullptr, None, nullptr, options);
+      switch (result) {
+      case RequirementCheckResult::Failure:
+      case RequirementCheckResult::UnsatisfiedDependency:
+        return true;
+
+      case RequirementCheckResult::Success:
+      case RequirementCheckResult::SubstitutionFailure:
+        return false;
+      }
+    }
     return false;
   };
 
@@ -4262,9 +4294,7 @@ void ConformanceChecker::resolveTypeWitnesses() {
       }
 
       /// Check the current set of type witnesses.
-      if (checkCurrentTypeWitnesses()) {
-        return;
-      }
+      bool invalid = checkCurrentTypeWitnesses();
 
       // Determine whether there is already a solution with the same
       // bindings.
@@ -4284,8 +4314,9 @@ void ConformanceChecker::resolveTypeWitnesses() {
           return;
       }
 
-      solutions.push_back(InferredTypeWitnessesSolution());
-      auto &solution = solutions.back();
+      auto &solutionList = invalid ? nonViableSolutions : solutions;
+      solutionList.push_back(InferredTypeWitnessesSolution());
+      auto &solution = solutionList.back();
 
       // Copy the type witnesses.
       for (auto assocType : unresolvedAssocTypes) {
@@ -4477,6 +4508,12 @@ void ConformanceChecker::resolveTypeWitnesses() {
         solutions[0] = std::move(solutions[bestIdx]);
       solutions.erase(solutions.begin() + 1, solutions.end());
     }
+  }
+
+  // If we have no solution, but we did find something that is nonviable,
+  // use the first nonviable one to improve error reporting.
+  if (solutions.empty() && !nonViableSolutions.empty()) {
+    solutions.push_back(std::move(nonViableSolutions.front()));
   }
 
   // If we found a single solution, take it.

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -764,6 +764,7 @@ Type TypeChecker::applyUnboundGenericArguments(
     case RequirementCheckResult::UnsatisfiedDependency:
       return Type();
     case RequirementCheckResult::Failure:
+    case RequirementCheckResult::SubstitutionFailure:
       return ErrorType::get(Context);
     case RequirementCheckResult::Success:
       break;

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -367,7 +367,9 @@ public:
 };
 
 /// The result of `checkGenericRequirement`.
-enum class RequirementCheckResult { Success, Failure, UnsatisfiedDependency };
+enum class RequirementCheckResult {
+  Success, Failure, UnsatisfiedDependency, SubstitutionFailure
+};
 
 class ConformsToProtocolResult {
   Optional<ProtocolConformanceRef> Data;
@@ -1349,7 +1351,8 @@ public:
       LookupConformanceFn conformances,
       UnsatisfiedDependency *unsatisfiedDependency,
       ConformanceCheckOptions conformanceOptions = ConformanceCheckFlags::Used,
-      GenericRequirementsCheckListener *listener = nullptr);
+      GenericRequirementsCheckListener *listener = nullptr,
+      SubstOptions options = None);
 
   /// Resolve the superclass of the given class.
   void resolveSuperclass(ClassDecl *classDecl) override;

--- a/test/Constraints/associated_types.swift
+++ b/test/Constraints/associated_types.swift
@@ -62,8 +62,8 @@ protocol XReqt {}
 protocol YReqt {}
 
 protocol SameTypedDefaultWithReqts {
-    associatedtype X: XReqt // expected-note{{}}
-    associatedtype Y: YReqt // expected-note{{}}
+    associatedtype X: XReqt
+    associatedtype Y: YReqt
     static var x: X { get }
     static var y: Y { get }
 }
@@ -86,7 +86,7 @@ struct UsesSameTypedDefaultWithoutSatisfyingReqts: SameTypedDefaultWithReqts {
 }
 
 protocol SameTypedDefaultBaseWithReqts {
-    associatedtype X: XReqt // expected-note{{}}
+    associatedtype X: XReqt
     static var x: X { get }
 }
 protocol SameTypedDefaultDerivedWithReqts: SameTypedDefaultBaseWithReqts {

--- a/test/Generics/associated_type_where_clause.swift
+++ b/test/Generics/associated_type_where_clause.swift
@@ -157,3 +157,48 @@ protocol P4 {
 protocol P5: P3, P4 {
   associatedtype B where B == A?
 }
+
+// Associated type inference should account for where clauses.
+protocol P6 {
+  associatedtype A
+}
+
+struct X1 { }
+
+struct X2 { }
+
+struct Y1 : P6 {
+  typealias A = X1
+}
+
+struct Y2 : P6 {
+  typealias A = X2
+}
+
+protocol P7 {
+  associatedtype B: P6 // expected-note{{ambiguous inference of associated type 'B': 'Y1' vs. 'Y2'}}
+  associatedtype C: P6 where B.A == C.A
+
+  func getB() -> B
+  func getC() -> C
+}
+
+struct Z1 : P7 {
+  func getB() -> Y1 { return Y1() }
+  func getB() -> Y2 { return Y2() }
+
+  func getC() -> Y1 { return Y1() }
+}
+
+func testZ1(z1: Z1) {
+  let _: Z1.C = Y1()
+}
+
+
+struct Z2 : P7 { // expected-error{{type 'Z2' does not conform to protocol 'P7'}}
+  func getB() -> Y1 { return Y1() } // expected-note{{matching requirement 'getB()' to this declaration inferred associated type to 'Y1'}}
+  func getB() -> Y2 { return Y2() } // expected-note{{matching requirement 'getB()' to this declaration inferred associated type to 'Y2'}}
+
+  func getC() -> Y1 { return Y1() }
+  func getC() -> Y2 { return Y2() }
+}

--- a/test/decl/protocol/conforms/failure.swift
+++ b/test/decl/protocol/conforms/failure.swift
@@ -75,9 +75,9 @@ struct P5Conformer : P5 { // expected-error {{does not conform}}
 
 
 protocol P6Base {
-  associatedtype Foo // expected-note {{protocol requires nested type 'Foo'; do you want to add it?}}
+  associatedtype Foo
   func foo()
-  func bar() -> Foo
+  func bar() -> Foo // expected-note{{protocol requires function 'bar()' with type '() -> P6Conformer.Bar?'; do you want to add a stub?}}
 }
 extension P6Base {
 }
@@ -85,7 +85,7 @@ protocol P6 : P6Base {
   associatedtype Bar // expected-note {{protocol requires nested type 'Bar'}}
 }
 extension P6 {
-  func bar() -> Bar? { return nil }
+  func bar() -> Bar? { return nil } // expected-note{{candidate has non-matching type '<Self> () -> Self.Bar?' [with Foo = P6Conformer.Bar?]}}
 }
 
 struct P6Conformer : P6 { // expected-error 2 {{does not conform}}

--- a/validation-test/compiler_crashers_fixed/28737-genericenv-nullptr-too-much-circularity.swift
+++ b/validation-test/compiler_crashers_fixed/28737-genericenv-nullptr-too-much-circularity.swift
@@ -6,5 +6,5 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 protocol A:a{typealias e}class a:A{typealias e:S


### PR DESCRIPTION
When we have a potential assignment of associated types to type
witnesses during associated type inference, check that set of type
witnesses against the requirements in the requirement signature, so
that we can reject any solutions that fail some of the protocol's
requirements.

This is most of rdar://problem/31830524 --- but gets thwarted by the
inability of associated type inference to work across multiple
protocols.