### PR TITLE
[AST] Remove unused SubstOptions constructor.

### DIFF
--- a/include/swift/AST/Type.h
+++ b/include/swift/AST/Type.h
@@ -179,11 +179,6 @@ struct SubstOptions : public OptionSet<SubstFlags> {
   SubstOptions(SubstFlags flags) : OptionSet(flags) { }
 
   SubstOptions(OptionSet<SubstFlags> options) : OptionSet(options) { }
-
-  SubstOptions(OptionSet<SubstFlags> options,
-              GetTentativeTypeWitness getTentativeTypeWitness)
-    : OptionSet(options),
-      getTentativeTypeWitness(std::move(getTentativeTypeWitness)) { }
 };
 
 inline SubstOptions operator|(SubstFlags lhs, SubstFlags rhs) {


### PR DESCRIPTION
On some implementations of the C++ Standard Library, trying to
move-construct an std::function will require that the return type be
complete. SubstOptions' GetTentativeTypeWitness function returns Type,
which is defined later in this file, which can trigger the failure.
