### PR TITLE
Referencing encoders should use parent codingPath

### DIFF
--- a/stdlib/public/SDK/Foundation/JSONEncoder.swift
+++ b/stdlib/public/SDK/Foundation/JSONEncoder.swift
@@ -148,7 +148,7 @@ fileprivate class _JSONEncoder : Encoder {
     let options: JSONEncoder._Options
 
     /// The path to the current point in encoding.
-    var codingPath: [CodingKey?] = []
+    var codingPath: [CodingKey?]
 
     /// Contextual user-provided information for use during encoding.
     var userInfo: [CodingUserInfoKey : Any] {
@@ -158,9 +158,10 @@ fileprivate class _JSONEncoder : Encoder {
     // MARK: - Initialization
 
     /// Initializes `self` with the given top-level encoder options.
-    init(options: JSONEncoder._Options) {
+    init(options: JSONEncoder._Options, codingPath: [CodingKey?] = []) {
         self.options = options
         self.storage = _JSONEncodingStorage()
+        self.codingPath = codingPath
     }
 
     // MARK: - Coding Path Actions
@@ -697,14 +698,14 @@ fileprivate class _JSONReferencingEncoder : _JSONEncoder {
     init(referencing encoder: _JSONEncoder, wrapping array: NSMutableArray, at index: Int) {
         self.encoder = encoder
         self.reference = .array(array, index)
-        super.init(options: encoder.options)
+        super.init(options: encoder.options, codingPath: encoder.codingPath)
     }
 
     /// Initializes `self` by referencing the given dictionary container in the given encoder.
     init(referencing encoder: _JSONEncoder, wrapping dictionary: NSMutableDictionary, key: String) {
         self.encoder = encoder
         self.reference = .dictionary(dictionary, key)
-        super.init(options: encoder.options)
+        super.init(options: encoder.options, codingPath: encoder.codingPath)
     }
 
 

--- a/stdlib/public/SDK/Foundation/JSONEncoder.swift
+++ b/stdlib/public/SDK/Foundation/JSONEncoder.swift
@@ -708,6 +708,24 @@ fileprivate class _JSONReferencingEncoder : _JSONEncoder {
         super.init(options: encoder.options, codingPath: encoder.codingPath)
     }
 
+    // MARK: - Overridden Implementations
+
+    /// Asserts that we can add a new container at this coding path. See _JSONEncoder.assertCanRequestNewContainer for the logic behind this.
+    /// This differs from super's implementation only in the condition: we need to account for the fact that we copied our reference's coding path, but not its list of containers, so the counts are mismatched.
+    override func assertCanRequestNewContainer() {
+        guard self.storage.count == self.codingPath.count - self.encoder.codingPath.count else {
+            let previousContainerType: String
+            if self.storage.containers.last is NSDictionary {
+                previousContainerType = "keyed"
+            } else if self.storage.containers.last is NSArray {
+                previousContainerType = "unkeyed"
+            } else {
+                previousContainerType = "single value"
+            }
+
+            preconditionFailure("Attempt to encode with new container when already encoded with \(previousContainerType) container.")
+        }
+    }
 
     // MARK: - Deinitialization
 

--- a/stdlib/public/SDK/Foundation/PlistEncoder.swift
+++ b/stdlib/public/SDK/Foundation/PlistEncoder.swift
@@ -90,7 +90,7 @@ fileprivate class _PlistEncoder : Encoder {
     let options: PropertyListEncoder._Options
 
     /// The path to the current point in encoding.
-    var codingPath: [CodingKey?] = []
+    var codingPath: [CodingKey?]
 
     /// Contextual user-provided information for use during encoding.
     var userInfo: [CodingUserInfoKey : Any] {
@@ -100,9 +100,10 @@ fileprivate class _PlistEncoder : Encoder {
     // MARK: - Initialization
 
     /// Initializes `self` with the given top-level encoder options.
-    init(options: PropertyListEncoder._Options) {
+    init(options: PropertyListEncoder._Options, codingPath: [CodingKey?] = []) {
         self.options = options
         self.storage = _PlistEncodingStorage()
+        self.codingPath = codingPath
     }
 
     // MARK: - Coding Path Actions
@@ -507,14 +508,14 @@ fileprivate class _PlistReferencingEncoder : _PlistEncoder {
     init(referencing encoder: _PlistEncoder, wrapping array: NSMutableArray, at index: Int) {
         self.encoder = encoder
         self.reference = .array(array, index)
-        super.init(options: encoder.options)
+        super.init(options: encoder.options, codingPath: encoder.codingPath)
     }
 
     /// Initializes `self` by referencing the given dictionary container in the given encoder.
     init(referencing encoder: _PlistEncoder, wrapping dictionary: NSMutableDictionary, key: String) {
         self.encoder = encoder
         self.reference = .dictionary(dictionary, key)
-        super.init(options: encoder.options)
+        super.init(options: encoder.options, codingPath: encoder.codingPath)
     }
 
 

--- a/stdlib/public/SDK/Foundation/PlistEncoder.swift
+++ b/stdlib/public/SDK/Foundation/PlistEncoder.swift
@@ -518,6 +518,24 @@ fileprivate class _PlistReferencingEncoder : _PlistEncoder {
         super.init(options: encoder.options, codingPath: encoder.codingPath)
     }
 
+    // MARK: - Overridden Implementations
+
+    /// Asserts that we can add a new container at this coding path. See _PlistEncoder.assertCanRequestNewContainer for the logic behind this.
+    /// This differs from super's implementation only in the condition: we need to account for the fact that we copied our reference's coding path, but not its list of containers, so the counts are mismatched.
+    override func assertCanRequestNewContainer() {
+        guard self.storage.count == self.codingPath.count - self.encoder.codingPath.count else {
+            let previousContainerType: String
+            if self.storage.containers.last is NSDictionary {
+                previousContainerType = "keyed"
+            } else if self.storage.containers.last is NSArray {
+                previousContainerType = "unkeyed"
+            } else {
+                previousContainerType = "single value"
+            }
+
+            preconditionFailure("Attempt to encode with new container when already encoded with \(previousContainerType) container.")
+        }
+    }
 
     // MARK: - Deinitialization
 


### PR DESCRIPTION
**What's in this pull request?**
If you were to ask for a `superEncoder()` before, the encoder you got had a `codingPath` of `[]`, which is not correct.
Resolves [SR-4788](https://bugs.swift.org/browse/SR-4788).

Cherry-pick of https://github.com/apple/swift/pull/9230

rdar://problem/31965830