### PR TITLE
IRGen: Use link_once instead of external for private decls

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1388,8 +1388,12 @@ getIRLinkage(const UniversalLinkageInfo &info, SILLinkage linkage,
   case SILLinkage::Private:
     // In case of multiple llvm modules (in multi-threaded compilation) all
     // private decls must be visible from other files.
+    // We use LinkOnceODR instead of External here because private lazy protocol
+    // witness table accessors could be emitted by two different IGMs during
+    // IRGen into different object files and the linker would complain about
+    // duplicate symbols.
     if (info.HasMultipleIGMs)
-      return RESULT(External, Hidden, Default);
+      return RESULT(LinkOnceODR, Hidden, Default);
     return RESULT(Internal, Default, Default);
 
   case SILLinkage::PublicExternal: {


### PR DESCRIPTION
We can get duplicate symbols for accessors IRGen creates per IGM instance e.g
for lazy protocol witness table accessors.

(A better but more risky fix is to hoist the caching of the accessors to
IRGenerator so that we only generate them once per module to begin with)

Yes I owe a test case here ...

rdar://31988578