### PR TITLE
[swift-4.0-branch] IRGen: Use link_once instead of external for private decls

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1393,8 +1393,12 @@ getIRLinkage(const UniversalLinkageInfo &info, SILLinkage linkage,
   case SILLinkage::Private:
     // In case of multiple llvm modules (in multi-threaded compilation) all
     // private decls must be visible from other files.
+    // We use LinkOnceODR instead of External here because private lazy protocol
+    // witness table accessors could be emitted by two different IGMs during
+    // IRGen into different object files and the linker would complain about
+    // duplicate symbols.
     if (info.HasMultipleIGMs)
-      return RESULT(External, Hidden, Default);
+      return RESULT(LinkOnceODR, Hidden, Default);
     return RESULT(Internal, Default, Default);
 
   case SILLinkage::PublicExternal: {


### PR DESCRIPTION
• Explanation: We can get duplicate symbols for accessors IRGen creates per IGM instance e.g
for lazy protocol witness table accessors. This results in linkage errors.

* Scope: This can happen on wmo compilation when private protocols are use. 

* Risk: Low, changing the linkage from external to linkonce_odr should not cause issues.

*Reviewed: Erik

* Testing this has been verified on the breaking software.

rdar://31988578
