### PR TITLE
[Type checker] Warn about classes conforming to AnyObject in Swift 3 mode

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1909,7 +1909,8 @@ ERROR(inheritance_from_cf_class,none,
 ERROR(inheritance_from_objc_runtime_visible_class,none,
       "cannot inherit from class %0 because it is only visible via the "
       "Objective-C runtime", (Identifier))
-
+WARNING(class_inherits_anyobject,none,
+        "conformance of class %0 to 'AnyObject' is redundant", (Type))
 
 // Enums
 ERROR(enum_case_access,none,

--- a/test/Compatibility/anyobject.swift
+++ b/test/Compatibility/anyobject.swift
@@ -1,0 +1,10 @@
+// RUN: %target-typecheck-verify-swift -swift-version 3
+
+protocol P { }
+protocol Q { }
+
+class Foo: AnyObject { } // expected-warning{{conformance of class 'Foo' to 'AnyObject' is redundant}}{{10-21=}}
+
+class Bar: AnyObject, P { } // expected-warning{{conformance of class 'Bar' to 'AnyObject' is redundant}}{{12-23=}}
+
+class Wibble: Bar, AnyObject, Q { } // expected-warning{{conformance of class 'Wibble' to 'AnyObject' is redundant}}{{18-29=}}

--- a/test/decl/protocol/conforms/placement.swift
+++ b/test/decl/protocol/conforms/placement.swift
@@ -106,7 +106,7 @@ extension ExplicitSub1 : P1 { } // expected-error{{redundant conformance of 'Exp
 // ---------------------------------------------------------------------------
 // Suppression of synthesized conformances
 // ---------------------------------------------------------------------------
-class SynthesizedClass1 : AnyObject { } // expected-error{{inheritance from non-protocol, non-class type 'AnyObject'}}
+class SynthesizedClass1 : AnyObject { } // expected-warning{{conformance of class 'SynthesizedClass1' to 'AnyObject' is redundant}}
 
 class SynthesizedClass2 { }
 extension SynthesizedClass2 : AnyObject { } // expected-error{{inheritance from non-protocol type 'AnyObject'}}
@@ -116,7 +116,7 @@ class SynthesizedClass3 : AnyObjectRefinement { }
 class SynthesizedClass4 { }
 extension SynthesizedClass4 : AnyObjectRefinement { }
 
-class SynthesizedSubClass1 : SynthesizedClass1, AnyObject { } // expected-error{{inheritance from non-protocol, non-class type 'AnyObject'}}
+class SynthesizedSubClass1 : SynthesizedClass1, AnyObject { } // expected-warning{{conformance of class 'SynthesizedSubClass1' to 'AnyObject' is redundant}}
 
 class SynthesizedSubClass2 : SynthesizedClass2 { }
 extension SynthesizedSubClass2 : AnyObject { } // expected-error{{inheritance from non-protocol type 'AnyObject'}}


### PR DESCRIPTION
Swift 3 allowed a class to explicitly conform to `AnyObject`, although
it was meaningless. Recent `AnyObject`-related changes started rejecting
such conformances as ill-formed; allow them with a warning + Fix-It in
Swift 3 compatibility mode.
