### PR TITLE
Fixes a bug in large loadable types wherein only the callee type of Apply is changed

### DIFF
--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -472,6 +472,19 @@ void LargeValueVisitor::visitApply(ApplySite applySite) {
   if (!isLargeLoadableType(genEnv, currType, pass.Mod) &&
       (currType != newType)) {
     pass.applies.push_back(applySite.getInstruction());
+    return;
+  }
+  // Check callee - need new generic env:
+  SILFunctionType *origSILFunctionType = applySite.getSubstCalleeType();
+  GenericEnvironment *genEnvCallee = nullptr;
+  if (origSILFunctionType->isPolymorphic()) {
+    genEnvCallee = getGenericEnvironment(
+        applySite.getModule(), CanSILFunctionType(origSILFunctionType));
+  }
+  SILFunctionType *newSILFunctionType =
+      getNewSILFunctionTypePtr(genEnvCallee, origSILFunctionType, pass.Mod);
+  if (origSILFunctionType != newSILFunctionType) {
+    pass.applies.push_back(applySite.getInstruction());
   }
 }
 

--- a/test/IRGen/big_types_corner_cases.swift
+++ b/test/IRGen/big_types_corner_cases.swift
@@ -31,3 +31,25 @@ public func f3_uses_f2() {
 // CHECK: call swiftcc { i8*, %swift.refcounted* } @_T022big_types_corner_cases13f2_returns_f1AA9BigStructVADcyF()
 // CHECK: call swiftcc void %16(%T22big_types_corner_cases9BigStructV* noalias nocapture sret %call.aggresult1, %T22big_types_corner_cases9BigStructV* noalias nocapture dereferenceable
 // CHECK: ret void
+
+public struct MyStruct {
+  public let a: Int
+  public let b: String?
+ }
+
+typealias UploadFunction = ((MyStruct, Int?) -> Void) -> Void
+func takesUploader(_ u: UploadFunction) { }
+
+class Foo {
+  func blam() {
+    takesUploader(self.myMethod) // crash compiling this
+  }
+
+  func myMethod(_ callback: (MyStruct, Int) -> Void) -> Void { }
+}
+
+// CHECK-LABEL: define{{( protected)?}} linkonce_odr hidden swiftcc { i8*, %swift.refcounted* } @_T022big_types_corner_cases3FooC8myMethodyyAA8MyStructV_SitcFTc(%T22big_types_corner_cases3FooC*)
+// CHECK: getelementptr inbounds %T22big_types_corner_cases3FooC, %T22big_types_corner_cases3FooC*
+// CHECK: getelementptr inbounds void (i8*, %swift.refcounted*, %T22big_types_corner_cases3FooC*)*, void (i8*, %swift.refcounted*, %T22big_types_corner_cases3FooC*)**
+// CHECK: call noalias %swift.refcounted* @swift_rt_swift_allocObject(%swift.type* getelementptr inbounds (%swift.full_boxmetadata, %swift.full_boxmetadata*
+// CHECK: ret { i8*, %swift.refcounted* }


### PR DESCRIPTION
Radar rdar://problem/31991715

Fixes a corner-case in large loadable types: An apply instruction wherein neither the parameters nor the return type is changed *BUT* The callee signature is changed (a method inside a class) - need to re-create the Apply instruction in that case.