### PR TITLE
[Parser] Add fix-it for missing type errors

### DIFF
--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -196,7 +196,12 @@ ParserResult<TypeRepr> Parser::parseTypeSimple(Diag<> MessageID,
     }
     LLVM_FALLTHROUGH;
   default:
-    diagnose(Tok, MessageID);
+    auto diag = diagnose(Tok, MessageID);
+    // If the next token is closing or separating, the type was likely forgotten
+    if (Tok.isAny(tok::r_paren, tok::r_brace, tok::r_square, tok::arrow,
+                  tok::equal, tok::comma, tok::semi)) {
+      diag.fixItInsert(getEndOfPreviousLoc(), " <#type#>");
+    }
     if (Tok.isKeyword() && !Tok.isAtStartOfLine()) {
       ty = makeParserErrorResult(new (Context) ErrorTypeRepr(Tok.getLoc()));
       consumeToken();

--- a/test/Parse/recovery.swift
+++ b/test/Parse/recovery.swift
@@ -297,7 +297,7 @@ _ = foobar // OK.
 //===--- Recovery for parse errors in types.
 
 struct ErrorTypeInVarDecl1 {
-  var v1 : // expected-error {{expected type}}
+  var v1 : // expected-error {{expected type}} {{11-11= <#type#>}}
 }
 
 struct ErrorTypeInVarDecl2 {
@@ -311,7 +311,7 @@ struct ErrorTypeInVarDecl3 {
 }
 
 struct ErrorTypeInVarDecl4 {
-  var v1 : Int<, // expected-error {{expected type}}
+  var v1 : Int<, // expected-error {{expected type}} {{16-16= <#type#>}}
   var v2 : Int
 }
 

--- a/test/decl/func/functions.swift
+++ b/test/decl/func/functions.swift
@@ -71,20 +71,20 @@ func g_recover_missing_tuple_paren(_ b: Int) {
 
 //===--- Parse errors.
 
-func parseError1a(_ a: ) {} // expected-error {{expected parameter type following ':'}}
+func parseError1a(_ a: ) {} // expected-error {{expected parameter type following ':'}} {{23-23= <#type#>}}
 
-func parseError1b(_ a: // expected-error {{expected parameter type following ':'}}
+func parseError1b(_ a: // expected-error {{expected parameter type following ':'}} {{23-23= <#type#>}}
                   ) {}
 
-func parseError2(_ a: Int, b: ) {} // expected-error {{expected parameter type following ':'}}
+func parseError2(_ a: Int, b: ) {} // expected-error {{expected parameter type following ':'}} {{30-30= <#type#>}}
 
-func parseError3(_ a: unknown_type, b: ) {} // expected-error {{use of undeclared type 'unknown_type'}}  expected-error {{expected parameter type following ':'}}
+func parseError3(_ a: unknown_type, b: ) {} // expected-error {{use of undeclared type 'unknown_type'}}  expected-error {{expected parameter type following ':'}} {{39-39= <#type#>}}
 
 func parseError4(_ a: , b: ) {} // expected-error 2{{expected parameter type following ':'}}
 
 func parseError5(_ a: b: ) {} // expected-error {{use of undeclared type 'b'}}  expected-error {{expected ',' separator}} {{24-24=,}} expected-error {{expected parameter name followed by ':'}}
 
-func parseError6(_ a: unknown_type, b: ) {} // expected-error {{use of undeclared type 'unknown_type'}}  expected-error {{expected parameter type following ':'}}
+func parseError6(_ a: unknown_type, b: ) {} // expected-error {{use of undeclared type 'unknown_type'}}  expected-error {{expected parameter type following ':'}} {{39-39= <#type#>}}
 
 func parseError7(_ a: Int, goo b: unknown_type) {} // expected-error {{use of undeclared type 'unknown_type'}}
 

--- a/test/decl/protocol/protocols.swift
+++ b/test/decl/protocol/protocols.swift
@@ -27,7 +27,7 @@ protocol Test2 {
   associatedtype mytype
   associatedtype mybadtype = Int
 
-  associatedtype V : Test = // expected-error {{expected type in associated type declaration}}
+  associatedtype V : Test = // expected-error {{expected type in associated type declaration}} {{28-28= <#type#>}}
 }
 
 func test1() {

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -236,7 +236,7 @@ func test_as_1() {
 }
 func test_as_2() {
   let x: Int = 1
-  x as [] // expected-error {{expected element type}}
+  x as [] // expected-error {{expected element type}} {{9-9= <#type#>}}
 }
 
 func test_lambda() {


### PR DESCRIPTION
Resolves [SR-4785](https://bugs.swift.org/browse/SR-4785).

We can't reliably decide in the parser if a type was forgotten or a wrong spelling was meant to be a type (e.g. `let x: class MyClass`). This patch applies a heuristic that the parameter was most likely forgotten if the next character is a closing bracket or a semantic separator (arrow, equal, comma, semicolon).
This catches the most common cases of function parameters and variable declarations that are immediately initialised.