### PR TITLE
qualify some names with their namespace (NFC)

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -96,7 +96,7 @@ void *TypeBase::operator new(size_t bytes, const ASTContext &ctx,
   return ctx.Allocate(bytes, alignment, arena);
 }
 
-bool CanType::isActuallyCanonicalOrNull() const {
+bool swift::CanType::isActuallyCanonicalOrNull() const {
   return getPointer() == nullptr ||
          getPointer() == llvm::DenseMapInfo<TypeBase *>::getTombstoneKey() ||
          getPointer()->isCanonical();

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -2099,7 +2099,7 @@ void SILGlobalVariable::print(llvm::raw_ostream &OS, bool Verbose) const {
   OS << "\n\n";
 }
 
-void SILGlobalVariable::dump(bool Verbose) const {
+void swift::SILGlobalVariable::dump(bool Verbose) const {
   print(llvm::errs(), Verbose);
 }
 


### PR DESCRIPTION
When building with GCC 5.7 on Linux, these functions are not decorated
correctly, resulting in link failures due to unresolved symbols.
Specify the fully qualified name to ensure that we get the decoration
correct.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
