### PR TITLE
Remove interpolated strings from benchmark CheckResults

### DIFF
--- a/benchmark/single-source/Ackermann.swift
+++ b/benchmark/single-source/Ackermann.swift
@@ -42,6 +42,5 @@ public func run_Ackermann(_ N: Int) {
       break
     }
   }
-  CheckResults(result == ref_result[n],
-      "IncorrectResults in Ackermann: \(result) != \(ref_result[n]).")
+  CheckResults(result == ref_result[n])
 }

--- a/benchmark/single-source/ArrayLiteral.swift
+++ b/benchmark/single-source/ArrayLiteral.swift
@@ -40,7 +40,7 @@ public func run_ArrayValueProp(_ N: Int) {
     res += addLiteralArray()
     res -= addLiteralArray()
   }
-  CheckResults(res == 123, "Wrong result in ArrayValueProp 123 != \(res)")
+  CheckResults(res == 123)
 }
 
 
@@ -81,7 +81,7 @@ public func run_ArrayValueProp2(_ N: Int) {
     res += addLiteralArray2()
     res -= addLiteralArray2()
   }
-  CheckResults(res == 123, "Wrong result in ArrayValueProp 123 != \(res)")
+  CheckResults(res == 123)
 }
 
 @inline(never)
@@ -91,7 +91,7 @@ public func run_ArrayValueProp3(_ N: Int) {
     res += addLiteralArray3()
     res -= addLiteralArray3()
   }
-  CheckResults(res == 123, "Wrong result in ArrayValueProp 123 != \(res)")
+  CheckResults(res == 123)
 }
 
 @inline(never)
@@ -101,5 +101,5 @@ public func run_ArrayValueProp4(_ N: Int) {
     res += addLiteralArray4()
     res -= addLiteralArray4()
   }
-  CheckResults(res == 123, "Wrong result in ArrayValueProp 123 != \(res)")
+  CheckResults(res == 123)
 }

--- a/benchmark/single-source/ArraySubscript.swift
+++ b/benchmark/single-source/ArraySubscript.swift
@@ -34,6 +34,5 @@ public func run_ArraySubscript(_ N: Int) {
     arrays[i][bound(i)] =
       max(arrays[i-1][bound(i-1)], arrays[i][bound(i)])
   }
-  CheckResults(arrays[0][0] <= arrays[numArrays-1][bound(numArrays-1)],
-               "Incorrect results in QuickSort.")
+  CheckResults(arrays[0][0] <= arrays[numArrays-1][bound(numArrays-1)])
 }

--- a/benchmark/single-source/BitCount.swift
+++ b/benchmark/single-source/BitCount.swift
@@ -33,8 +33,8 @@ func countBitSet(_ num: Int) -> Int {
 public func run_BitCount(_ N: Int) {
   for _ in 1...100*N {
     // Check some results.
-    CheckResults(countBitSet(1) == 1, "Incorrect results in BitCount.")
-    CheckResults(countBitSet(2) == 1, "Incorrect results in BitCount.")
-    CheckResults(countBitSet(2457) == 6, "Incorrect results in BitCount.")
+    CheckResults(countBitSet(1) == 1)
+    CheckResults(countBitSet(2) == 1)
+    CheckResults(countBitSet(2457) == 6)
   }
 }

--- a/benchmark/single-source/ByteSwap.swift
+++ b/benchmark/single-source/ByteSwap.swift
@@ -42,8 +42,8 @@ func byteswap_logn(_ a: UInt64) -> UInt64 {
 public func run_ByteSwap(_ N: Int) {
   for _ in 1...100*N {
     // Check some results.
-    CheckResults(byteswap_logn(byteswap_n(2457)) == 2457, "Incorrect results in ByteSwap.")
-    CheckResults(byteswap_logn(byteswap_n(9129)) == 9129, "Incorrect results in ByteSwap.")
-    CheckResults(byteswap_logn(byteswap_n(3333)) == 3333, "Incorrect results in ByteSwap.")
+    CheckResults(byteswap_logn(byteswap_n(2457)) == 2457)
+    CheckResults(byteswap_logn(byteswap_n(9129)) == 9129)
+    CheckResults(byteswap_logn(byteswap_n(3333)) == 3333)
   }
 }

--- a/benchmark/single-source/CString.swift
+++ b/benchmark/single-source/CString.swift
@@ -36,7 +36,7 @@ public func run_CStringLongAscii(_ N: Int) {
     // static string to c -> from c to String -> implicit conversion
     res &= strlen(ascii.withCString(String.init(cString:)))
   }
-  CheckResults(res == 0, "IncorrectResults in run_CStringLongAscii: \(res) != \(refResult)")
+  CheckResults(res == 0)
 }
 
 @inline(never)
@@ -46,7 +46,7 @@ public func run_CStringLongNonAscii(_ N: Int) {
   for _ in 1...N*500 {
     res &= strlen(japanese.withCString(String.init(cString:)))
   }
-  CheckResults(res == 0, "IncorrectResults in run_CStringLongAscii: \(res) != \(refResult)")
+  CheckResults(res == 0)
 }
 
 
@@ -84,6 +84,6 @@ public func run_CStringShortAscii(_ N: Int) {
     }
     res = res & DoOneIter(strings)
   }
-  assert(res == reference, "IncorrectResults in StrToInt: \(res) != \(reference)")
+  assert(res == reference)
 }
 

--- a/benchmark/single-source/Calculator.swift
+++ b/benchmark/single-source/Calculator.swift
@@ -36,6 +36,6 @@ public func run_Calculator(_ N: Int) {
   for _ in 1...N*5000 {
       c += my_atoi_impl("10")
   }
-  CheckResults(c == 0, "IncorrectResults in run_Calculator")
+  CheckResults(c == 0)
 }
 

--- a/benchmark/single-source/DeadArray.swift
+++ b/benchmark/single-source/DeadArray.swift
@@ -35,5 +35,5 @@ public func run_DeadArray(_ N: Int) {
     Count = 0
     runLoop(0, var2: 0)
   }
-  CheckResults(Count == 100_000, "Incorrect number of calls in loop")
+  CheckResults(Count == 100_000)
 }

--- a/benchmark/single-source/DictTest.swift
+++ b/benchmark/single-source/DictTest.swift
@@ -122,8 +122,7 @@ public func run_Dictionary(scale: Int) {
       Dict[word] = true
     }
   }
-  CheckResults(Dict.count == 270,
-               "IncorrectResults in DictTest: \(Dict.count) != 270.")
+  CheckResults(Dict.count == 270)
 
   // Check performance of searching in the dictionary:
   // Fill the dictionary with words from the first half of the text
@@ -142,8 +141,7 @@ public func run_Dictionary(scale: Int) {
       }
     }
   }
-  CheckResults(count == N*541,
-               "IncorrectResults in DictTest: \(count) != \(N*541).")
+  CheckResults(count == N*541)
 }
 
 class Box<T : Hashable> : Hashable {
@@ -272,8 +270,7 @@ public func run_DictionaryOfObjects(scale: Int) {
       Dict[Box(word)] = Box(true)
     }
   }
-  CheckResults(Dict.count == 270,
-               "IncorrectResults in DictTest: \(Dict.count) != 270.")
+  CheckResults(Dict.count == 270)
 
   // Check performance of searching in the dictionary:
   // Fill the dictionary with words from the first half of the text
@@ -292,6 +289,5 @@ public func run_DictionaryOfObjects(scale: Int) {
       }
     }
   }
-  CheckResults(count == N*541,
-               "IncorrectResults in DictTestAllObjects: \(count) != \(N*541).")
+  CheckResults(count == N*541)
 }

--- a/benchmark/single-source/DictTest2.swift
+++ b/benchmark/single-source/DictTest2.swift
@@ -34,7 +34,7 @@ public func run_Dictionary2(_ N: Int) {
       break
     }
   }
-  CheckResults(res == ref_result, "Incorrect results in Dictionary2: \(res) != \(ref_result)")
+  CheckResults(res == ref_result)
 }
 
 class Box<T : Hashable> : Hashable {
@@ -75,5 +75,5 @@ public func run_Dictionary2OfObjects(_ N: Int) {
       break
     }
   }
-  CheckResults(res == ref_result, "Incorrect results in Dictionary2AllObjects: \(res) != \(ref_result)")
+  CheckResults(res == ref_result)
 }

--- a/benchmark/single-source/DictTest3.swift
+++ b/benchmark/single-source/DictTest3.swift
@@ -41,7 +41,7 @@ public func run_Dictionary3(_ N: Int) {
       break
     }
   }
-  CheckResults(res == ref_result, "Incorrect results in Dictionary3: \(res) != \(ref_result)")
+  CheckResults(res == ref_result)
 }
 
 class Box<T : Hashable> : Hashable {
@@ -89,5 +89,5 @@ public func run_Dictionary3OfObjects(_ N: Int) {
       break
     }
   }
-  CheckResults(res == ref_result, "Incorrect results in Dictionary3OfObject: \(res) != \(ref_result)")
+  CheckResults(res == ref_result)
 }

--- a/benchmark/single-source/DictionaryBridge.swift
+++ b/benchmark/single-source/DictionaryBridge.swift
@@ -21,7 +21,7 @@ class Thing : NSObject {
 
   required override init() {
     let c = type(of: self).col()
-    CheckResults(c!.count == 10, "The rules of the universe apply")
+    CheckResults(c!.count == 10)
   }
 
   private class func col() -> [String : AnyObject]? {

--- a/benchmark/single-source/DictionaryRemove.swift
+++ b/benchmark/single-source/DictionaryRemove.swift
@@ -23,8 +23,7 @@ public func run_DictionaryRemove(_ N: Int) {
     for i in 1...size {
         dict[i] = i
     }
-    CheckResults(dict.count == size,
-                 "Incorrect dict count: \(dict.count) != \(size).")
+    CheckResults(dict.count == size)
 
     var tmpDict = dict
     for _ in 1...1000*N {
@@ -38,8 +37,7 @@ public func run_DictionaryRemove(_ N: Int) {
         }
     }
 
-    CheckResults(tmpDict.isEmpty,
-                 "tmpDict should be empty: \(tmpDict.count) != 0.")
+    CheckResults(tmpDict.isEmpty)
 }
 
 class Box<T : Hashable> : Hashable {
@@ -67,8 +65,7 @@ public func run_DictionaryRemoveOfObjects(_ N: Int) {
     for i in 1...size {
         dict[Box(i)] = Box(i)
     }
-    CheckResults(dict.count == size,
-                 "Incorrect dict count: \(dict.count) != \(size).")
+    CheckResults(dict.count == size)
 
     var tmpDict = dict
     for _ in 1...1000*N {
@@ -82,6 +79,5 @@ public func run_DictionaryRemoveOfObjects(_ N: Int) {
         }
     }
 
-    CheckResults(tmpDict.isEmpty,
-                 "tmpDict should be empty: \(tmpDict.count) != 0.")
+    CheckResults(tmpDict.isEmpty)
 }

--- a/benchmark/single-source/DictionarySwap.swift
+++ b/benchmark/single-source/DictionarySwap.swift
@@ -23,8 +23,7 @@ public func run_DictionarySwap(_ N: Int) {
     for i in 1...size {
         dict[i] = i
     }
-    CheckResults(dict.count == size,
-                 "Incorrect dict count: \(dict.count) != \(size).")
+    CheckResults(dict.count == size)
 
     var swapped = false
     for _ in 1...10000*N {
@@ -35,8 +34,7 @@ public func run_DictionarySwap(_ N: Int) {
         }
     }
 
-    CheckResults(swappedCorrectly(swapped, dict[25]!, dict[75]!),
-                 "Dictionary value swap failed")
+    CheckResults(swappedCorrectly(swapped, dict[25]!, dict[75]!))
 }
 
 // Return true if correctly swapped, false otherwise
@@ -70,8 +68,7 @@ public func run_DictionarySwapOfObjects(_ N: Int) {
     for i in 1...size {
         dict[Box(i)] = Box(i)
     }
-    CheckResults(dict.count == size,
-                 "Incorrect dict count: \(dict.count) != \(size).")
+    CheckResults(dict.count == size)
 
     var swapped = false
     for _ in 1...10000*N {
@@ -82,6 +79,5 @@ public func run_DictionarySwapOfObjects(_ N: Int) {
         }
     }
 
-    CheckResults(swappedCorrectly(swapped, dict[Box(25)]!.value, dict[Box(75)]!.value),
-                 "Dictionary value swap failed")
+    CheckResults(swappedCorrectly(swapped, dict[Box(25)]!.value, dict[Box(75)]!.value))
 }

--- a/benchmark/single-source/DropFirst.swift
+++ b/benchmark/single-source/DropFirst.swift
@@ -31,8 +31,7 @@ public func run_DropFirstCountableRange(_ N: Int) {
     for element in s.dropFirst(dropCount) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in DropFirstCountableRange: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -43,8 +42,7 @@ public func run_DropFirstSequence(_ N: Int) {
     for element in s.dropFirst(dropCount) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in DropFirstSequence: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -55,8 +53,7 @@ public func run_DropFirstAnySequence(_ N: Int) {
     for element in s.dropFirst(dropCount) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in DropFirstAnySequence: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -67,8 +64,7 @@ public func run_DropFirstAnySeqCntRange(_ N: Int) {
     for element in s.dropFirst(dropCount) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in DropFirstAnySeqCntRange: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -79,8 +75,7 @@ public func run_DropFirstAnySeqCRangeIter(_ N: Int) {
     for element in s.dropFirst(dropCount) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in DropFirstAnySeqCRangeIter: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -91,8 +86,7 @@ public func run_DropFirstAnyCollection(_ N: Int) {
     for element in s.dropFirst(dropCount) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in DropFirstAnyCollection: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -103,8 +97,7 @@ public func run_DropFirstArray(_ N: Int) {
     for element in s.dropFirst(dropCount) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in DropFirstArray: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -115,8 +108,7 @@ public func run_DropFirstCountableRangeLazy(_ N: Int) {
     for element in s.dropFirst(dropCount) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in DropFirstCountableRangeLazy: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -127,8 +119,7 @@ public func run_DropFirstSequenceLazy(_ N: Int) {
     for element in s.dropFirst(dropCount) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in DropFirstSequenceLazy: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -139,8 +130,7 @@ public func run_DropFirstAnySequenceLazy(_ N: Int) {
     for element in s.dropFirst(dropCount) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in DropFirstAnySequenceLazy: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -151,8 +141,7 @@ public func run_DropFirstAnySeqCntRangeLazy(_ N: Int) {
     for element in s.dropFirst(dropCount) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in DropFirstAnySeqCntRangeLazy: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -163,8 +152,7 @@ public func run_DropFirstAnySeqCRangeIterLazy(_ N: Int) {
     for element in s.dropFirst(dropCount) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in DropFirstAnySeqCRangeIterLazy: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -175,8 +163,7 @@ public func run_DropFirstAnyCollectionLazy(_ N: Int) {
     for element in s.dropFirst(dropCount) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in DropFirstAnyCollectionLazy: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -187,7 +174,6 @@ public func run_DropFirstArrayLazy(_ N: Int) {
     for element in s.dropFirst(dropCount) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in DropFirstArrayLazy: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }

--- a/benchmark/single-source/DropFirst.swift.gyb
+++ b/benchmark/single-source/DropFirst.swift.gyb
@@ -51,8 +51,7 @@ public func run_DropFirst${Name}(_ N: Int) {
     for element in s.dropFirst(dropCount) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in DropFirst${Name}: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 % end

--- a/benchmark/single-source/DropLast.swift
+++ b/benchmark/single-source/DropLast.swift
@@ -31,8 +31,7 @@ public func run_DropLastCountableRange(_ N: Int) {
     for element in s.dropLast(dropCount) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in DropLastCountableRange: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -43,8 +42,7 @@ public func run_DropLastSequence(_ N: Int) {
     for element in s.dropLast(dropCount) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in DropLastSequence: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -55,8 +53,7 @@ public func run_DropLastAnySequence(_ N: Int) {
     for element in s.dropLast(dropCount) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in DropLastAnySequence: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -67,8 +64,7 @@ public func run_DropLastAnySeqCntRange(_ N: Int) {
     for element in s.dropLast(dropCount) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in DropLastAnySeqCntRange: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -79,8 +75,7 @@ public func run_DropLastAnySeqCRangeIter(_ N: Int) {
     for element in s.dropLast(dropCount) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in DropLastAnySeqCRangeIter: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -91,8 +86,7 @@ public func run_DropLastAnyCollection(_ N: Int) {
     for element in s.dropLast(dropCount) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in DropLastAnyCollection: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -103,8 +97,7 @@ public func run_DropLastArray(_ N: Int) {
     for element in s.dropLast(dropCount) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in DropLastArray: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -115,8 +108,7 @@ public func run_DropLastCountableRangeLazy(_ N: Int) {
     for element in s.dropLast(dropCount) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in DropLastCountableRangeLazy: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -127,8 +119,7 @@ public func run_DropLastSequenceLazy(_ N: Int) {
     for element in s.dropLast(dropCount) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in DropLastSequenceLazy: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -139,8 +130,7 @@ public func run_DropLastAnySequenceLazy(_ N: Int) {
     for element in s.dropLast(dropCount) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in DropLastAnySequenceLazy: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -151,8 +141,7 @@ public func run_DropLastAnySeqCntRangeLazy(_ N: Int) {
     for element in s.dropLast(dropCount) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in DropLastAnySeqCntRangeLazy: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -163,8 +152,7 @@ public func run_DropLastAnySeqCRangeIterLazy(_ N: Int) {
     for element in s.dropLast(dropCount) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in DropLastAnySeqCRangeIterLazy: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -175,8 +163,7 @@ public func run_DropLastAnyCollectionLazy(_ N: Int) {
     for element in s.dropLast(dropCount) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in DropLastAnyCollectionLazy: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -187,7 +174,6 @@ public func run_DropLastArrayLazy(_ N: Int) {
     for element in s.dropLast(dropCount) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in DropLastArrayLazy: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }

--- a/benchmark/single-source/DropLast.swift.gyb
+++ b/benchmark/single-source/DropLast.swift.gyb
@@ -51,8 +51,7 @@ public func run_DropLast${Name}(_ N: Int) {
     for element in s.dropLast(dropCount) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in DropLast${Name}: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 % end

--- a/benchmark/single-source/DropWhile.swift
+++ b/benchmark/single-source/DropWhile.swift
@@ -31,8 +31,7 @@ public func run_DropWhileCountableRange(_ N: Int) {
     for element in s.drop(while: {$0 < dropCount} ) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in DropWhileCountableRange: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -43,8 +42,7 @@ public func run_DropWhileSequence(_ N: Int) {
     for element in s.drop(while: {$0 < dropCount} ) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in DropWhileSequence: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -55,8 +53,7 @@ public func run_DropWhileAnySequence(_ N: Int) {
     for element in s.drop(while: {$0 < dropCount} ) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in DropWhileAnySequence: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -67,8 +64,7 @@ public func run_DropWhileAnySeqCntRange(_ N: Int) {
     for element in s.drop(while: {$0 < dropCount} ) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in DropWhileAnySeqCntRange: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -79,8 +75,7 @@ public func run_DropWhileAnySeqCRangeIter(_ N: Int) {
     for element in s.drop(while: {$0 < dropCount} ) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in DropWhileAnySeqCRangeIter: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -91,8 +86,7 @@ public func run_DropWhileAnyCollection(_ N: Int) {
     for element in s.drop(while: {$0 < dropCount} ) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in DropWhileAnyCollection: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -103,8 +97,7 @@ public func run_DropWhileArray(_ N: Int) {
     for element in s.drop(while: {$0 < dropCount} ) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in DropWhileArray: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -115,8 +108,7 @@ public func run_DropWhileCountableRangeLazy(_ N: Int) {
     for element in s.drop(while: {$0 < dropCount} ) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in DropWhileCountableRangeLazy: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -127,8 +119,7 @@ public func run_DropWhileSequenceLazy(_ N: Int) {
     for element in s.drop(while: {$0 < dropCount} ) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in DropWhileSequenceLazy: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -139,8 +130,7 @@ public func run_DropWhileAnySequenceLazy(_ N: Int) {
     for element in s.drop(while: {$0 < dropCount} ) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in DropWhileAnySequenceLazy: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -151,8 +141,7 @@ public func run_DropWhileAnySeqCntRangeLazy(_ N: Int) {
     for element in s.drop(while: {$0 < dropCount} ) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in DropWhileAnySeqCntRangeLazy: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -163,8 +152,7 @@ public func run_DropWhileAnySeqCRangeIterLazy(_ N: Int) {
     for element in s.drop(while: {$0 < dropCount} ) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in DropWhileAnySeqCRangeIterLazy: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -175,8 +163,7 @@ public func run_DropWhileAnyCollectionLazy(_ N: Int) {
     for element in s.drop(while: {$0 < dropCount} ) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in DropWhileAnyCollectionLazy: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -187,7 +174,6 @@ public func run_DropWhileArrayLazy(_ N: Int) {
     for element in s.drop(while: {$0 < dropCount} ) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in DropWhileArrayLazy: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }

--- a/benchmark/single-source/DropWhile.swift.gyb
+++ b/benchmark/single-source/DropWhile.swift.gyb
@@ -51,8 +51,7 @@ public func run_DropWhile${Name}(_ N: Int) {
     for element in s.drop(while: {$0 < dropCount} ) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in DropWhile${Name}: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 % end

--- a/benchmark/single-source/Fibonacci.swift
+++ b/benchmark/single-source/Fibonacci.swift
@@ -38,6 +38,5 @@ public func run_Fibonacci(_ N: Int) {
       break
     }
   }
-  CheckResults(result == ref_result,
-               "Incorrect results in Fibonacci: \(result) != \(ref_result)")
+  CheckResults(result == ref_result)
 }

--- a/benchmark/single-source/Hash.swift
+++ b/benchmark/single-source/Hash.swift
@@ -587,8 +587,7 @@ public func run_HashTest(_ N: Int) {
     let MD = MD5()
     for (K, V) in TestMD5 {
       MD.update(K)
-      CheckResults(MD.digest() == V,
-                   "Incorrect result in Hash: check 1 failed.")
+      CheckResults(MD.digest() == V)
       MD.reset()
     }
 
@@ -609,8 +608,7 @@ public func run_HashTest(_ N: Int) {
     }
     let MD2 = MD5()
     MD2.update(L)
-    CheckResults(MD.digest() == MD2.digest(),
-                 "Incorrect result in Hash: check 2 failed.")
+    CheckResults(MD.digest() == MD2.digest())
 
     // Test the famous MD5 collision from 2009: http://www.mscs.dal.ca/~selinger/md5collision/
     let Src1 : [UInt8] =
@@ -632,10 +630,8 @@ public func run_HashTest(_ N: Int) {
     H2.update(Src2)
     let A1 = H1.digest()
     let A2 = H2.digest()
-    CheckResults(A1 == A2,
-                 "Incorrect result in Hash: check 3 failed.")
-    CheckResults(A1 == "79054025255fb1a26e4bc422aef54eb4",
-                 "Incorrect result in Hash: check 4 failed.")
+    CheckResults(A1 == A2)
+    CheckResults(A1 == "79054025255fb1a26e4bc422aef54eb4")
     H1.reset()
     H2.reset()
 
@@ -643,15 +639,13 @@ public func run_HashTest(_ N: Int) {
     let SH256 = SHA256()
     for (K, V) in TestSHA1 {
       SH.update(K)
-      CheckResults(SH.digest() == V,
-                   "Incorrect result in Hash: check 5 failed.")
+      CheckResults(SH.digest() == V)
       SH.reset()
     }
 
     for (K, V) in TestSHA256 {
       SH256.update(K)
-      CheckResults(SH256.digest() == V,
-                   "Incorrect result in Hash: check 5 failed.")
+      CheckResults(SH256.digest() == V)
       SH256.reset()
     }
 
@@ -672,7 +666,6 @@ public func run_HashTest(_ N: Int) {
     }
     let SH2 = SHA1()
     SH2.update(L)
-    CheckResults(SH.digest() == SH2.digest(),
-                 "Incorrect result in Hash: check 5 failed.")
+    CheckResults(SH.digest() == SH2.digest())
   }
 }

--- a/benchmark/single-source/HashQuadratic.swift
+++ b/benchmark/single-source/HashQuadratic.swift
@@ -27,7 +27,6 @@ public func run_HashQuadratic(_ N: Int) {
             dict2[k] = v
         }
     
-        CheckResults(dict1[size/2] == dict2[size/2],
-            "Incorrect results in HashQuadratic")
+        CheckResults(dict1[size/2] == dict2[size/2])
     }
 }

--- a/benchmark/single-source/Integrate.swift
+++ b/benchmark/single-source/Integrate.swift
@@ -63,6 +63,5 @@ public func run_Integrate(_ N: Int) {
     }
   }
 
-  CheckResults(abs(result - ref_result) < bound,
-               "Incorrect results in Integrate: abs(\(result) - \(ref_result)) > \(bound)")
+  CheckResults(abs(result - ref_result) < bound)
 }

--- a/benchmark/single-source/LazyFilter.swift
+++ b/benchmark/single-source/LazyFilter.swift
@@ -22,7 +22,7 @@ public func run_LazilyFilteredRange(_ N: Int) {
     res += Array(c).count
     res -= Array(c).count
   }
-  CheckResults(res == 123, "Wrong result in LazilyFilteredRange 123 != \(res)")
+  CheckResults(res == 123)
 }
 
 @inline(never)
@@ -33,6 +33,6 @@ public func run_LazilyFilteredArrays(_ N: Int) {
     res += Array(c).count
     res -= Array(c).count
   }
-  CheckResults(res == 123, "Wrong result in LazilyFilteredArray 123 != \(res)")
+  CheckResults(res == 123)
 }
 

--- a/benchmark/single-source/LinkedList.swift
+++ b/benchmark/single-source/LinkedList.swift
@@ -46,6 +46,5 @@ public func run_LinkedList(_ N: Int) {
       break
     }
   }
-  CheckResults(sum == ref_result,
-               "Incorrect results in LinkedList: \(sum) != \(ref_result)")
+  CheckResults(sum == ref_result)
 }

--- a/benchmark/single-source/MapReduce.swift
+++ b/benchmark/single-source/MapReduce.swift
@@ -22,7 +22,7 @@ public func run_MapReduce(_ N: Int) {
     numbers = numbers.map { $0 &+ 5 }
     c += numbers.reduce(0, &+)
   }
-  CheckResults(c != 0, "IncorrectResults in MapReduce")
+  CheckResults(c != 0)
 }
 
 @inline(never)
@@ -34,7 +34,7 @@ public func run_MapReduceAnyCollection(_ N: Int) {
     let mapped = numbers.map { $0 &+ 5 }
     c += mapped.reduce(0, &+)
   }
-  CheckResults(c != 0, "IncorrectResults in MapReduce")
+  CheckResults(c != 0)
 }
 
 @inline(never)
@@ -46,7 +46,7 @@ public func run_MapReduceAnyCollectionShort(_ N: Int) {
     let mapped = numbers.map { $0 &+ 5 }
     c += mapped.reduce(0, &+)
   }
-  CheckResults(c != 0, "IncorrectResults in MapReduce")
+  CheckResults(c != 0)
 }
 
 @inline(never)
@@ -58,7 +58,7 @@ public func run_MapReduceShort(_ N: Int) {
     numbers = numbers.map { $0 &+ 5 }
     c += numbers.reduce(0, &+)
   }
-  CheckResults(c != 0, "IncorrectResults in MapReduce")
+  CheckResults(c != 0)
 }
 
 @inline(never)
@@ -70,7 +70,7 @@ public func run_MapReduceSequence(_ N: Int) {
     let mapped = numbers.map { $0 &+ 5 }
     c += mapped.reduce(0, &+)
   }
-  CheckResults(c != 0, "IncorrectResults in MapReduce")
+  CheckResults(c != 0)
 }
 
 @inline(never)
@@ -82,7 +82,7 @@ public func run_MapReduceLazySequence(_ N: Int) {
     let mapped = numbers.lazy.map { $0 &+ 5 }
     c += mapped.reduce(0, &+)
   }
-  CheckResults(c != 0, "IncorrectResults in MapReduce")
+  CheckResults(c != 0)
 }
 
 @inline(never)
@@ -94,7 +94,7 @@ public func run_MapReduceLazyCollection(_ N: Int) {
     let mapped = numbers.lazy.map { $0 &+ 5 }
     c += mapped.reduce(0, &+)
   }
-  CheckResults(c != 0, "IncorrectResults in MapReduce")
+  CheckResults(c != 0)
 }
 
 @inline(never)
@@ -106,7 +106,7 @@ public func run_MapReduceLazyCollectionShort(_ N: Int) {
     let mapped = numbers.lazy.map { $0 &+ 5 }
     c += mapped.reduce(0, &+)
   }
-  CheckResults(c != 0, "IncorrectResults in MapReduce")
+  CheckResults(c != 0)
 }
 
 @inline(never)
@@ -117,7 +117,7 @@ public func run_MapReduceString(_ N: Int) {
   for _ in 1...N*100 {
     c += s.utf8.map { UInt64($0 &+ 5) }.reduce(0, &+)
   }
-  CheckResults(c != 0, "IncorrectResults in MapReduce")
+  CheckResults(c != 0)
 }
 
 @inline(never)
@@ -128,7 +128,7 @@ public func run_MapReduceShortString(_ N: Int) {
   for _ in 1...N*100 {
     c += s.utf8.map { UInt64($0 &+ 5) }.reduce(0, &+)
   }
-  CheckResults(c != 0, "IncorrectResults in MapReduce")
+  CheckResults(c != 0)
 }
 
 @inline(never)
@@ -141,7 +141,7 @@ public func run_MapReduceClass(_ N: Int) {
     let mapped = numbers.map { $0.intValue &+ 5 }
     c += mapped.reduce(0, &+)
   }
-  CheckResults(c != 0, "IncorrectResults in MapReduce")
+  CheckResults(c != 0)
 #endif
 }
 
@@ -155,7 +155,7 @@ public func run_MapReduceClassShort(_ N: Int) {
     let mapped = numbers.map { $0.intValue &+ 5 }
     c += mapped.reduce(0, &+)
   }
-  CheckResults(c != 0, "IncorrectResults in MapReduce")
+  CheckResults(c != 0)
 #endif
 }
 

--- a/benchmark/single-source/Memset.swift
+++ b/benchmark/single-source/Memset.swift
@@ -26,5 +26,5 @@ public func run_Memset(_ N: Int) {
     memset(&a, 1)
     memset(&a, 0)
   }
-  CheckResults(a[87] == 0, "Incorrect result in Memset.")
+  CheckResults(a[87] == 0)
 }

--- a/benchmark/single-source/MonteCarloE.swift
+++ b/benchmark/single-source/MonteCarloE.swift
@@ -29,10 +29,8 @@ public func run_MonteCarloE(scale: Int) {
   let numEmptyIntervals = intervals.filter{!$0}.count
   // If there are no empty intervals, then obviously the random generator is
   // not 'random' enough.
-  CheckResults(numEmptyIntervals != N,
-               "Incorrect results in MonteCarloE: no empty intervals.")
+  CheckResults(numEmptyIntervals != N)
   let e_estimate = Double(N)/Double(numEmptyIntervals)
   let e = 2.71828
-  CheckResults(abs(e_estimate - e) < 0.1,
-               "Incorrect results in MonteCarloE: e_estimate == \(e_estimate)")
+  CheckResults(abs(e_estimate - e) < 0.1)
 }

--- a/benchmark/single-source/MonteCarloPi.swift
+++ b/benchmark/single-source/MonteCarloPi.swift
@@ -25,6 +25,5 @@ public func run_MonteCarloPi(scale: Int) {
   }
   let pi_estimate: Double = Double(pointsInside)*4.0/Double(N)
   let pi = 3.1415
-  CheckResults(abs(pi_estimate - pi) < 0.1,
-               "Incorrect results in MonteCarloPi: pi_estimate == \(pi_estimate)")
+  CheckResults(abs(pi_estimate - pi) < 0.1)
 }

--- a/benchmark/single-source/NSDictionaryCastToSwift.swift
+++ b/benchmark/single-source/NSDictionaryCastToSwift.swift
@@ -29,8 +29,6 @@ public func run_NSDictionaryCastToSwift(_ N: Int) {
             break
         }
     }
-    CheckResults(swiftDict.isEmpty,
-            "Incorrect result in swiftDict.isEmpty: " +
-            "\(swiftDict.isEmpty) != true\n")
+    CheckResults(swiftDict.isEmpty)
 #endif
 }

--- a/benchmark/single-source/NopDeinit.swift
+++ b/benchmark/single-source/NopDeinit.swift
@@ -30,7 +30,6 @@ public func run_NopDeinit(_ N: Int) {
     let size = 500
     for i in 1...size { arr.append(X(i)) }
     arr.removeAll()
-    CheckResults(arr.count == 0,
-                 "Incorrect results in NopDeinit: \(arr.count) != 0.")
+    CheckResults(arr.count == 0)
   }
 }

--- a/benchmark/single-source/ObjectAllocation.swift
+++ b/benchmark/single-source/ObjectAllocation.swift
@@ -123,13 +123,9 @@ public func run_ObjectAllocation(_ N: Int) {
     ArrayResult = testArray()
   }
 
-  CheckResults(SingleObjectResult == 499500,
-               "Incorrect results in testSingleObject")
-  CheckResults(TreeResult == 90000,
-               "Incorrect results in testTree")
-  CheckResults(ListResult == 48375,
-               "Incorrect results in testList")
-  CheckResults(ArrayResult == 3000,
-               "Incorrect results in testArray")
+  CheckResults(SingleObjectResult == 499500)
+  CheckResults(TreeResult == 90000)
+  CheckResults(ListResult == 48375)
+  CheckResults(ArrayResult == 3000)
 }
 

--- a/benchmark/single-source/ObjectiveCBridging.swift
+++ b/benchmark/single-source/ObjectiveCBridging.swift
@@ -45,7 +45,7 @@ func testObjectiveCBridgeFromNSString() {
       s = n!
     }
   }
-  CheckResults(s != nil && s == "NSString that does not fit in tagged pointer", "Expected results did not match")
+  CheckResults(s != nil && s == "NSString that does not fit in tagged pointer")
 }
 #endif
 
@@ -70,7 +70,7 @@ func testObjectiveCBridgeFromNSStringForced() {
     // Call _forceBridgeFromObjectiveC
     s = forcedCast(nsString)
   }
-  CheckResults(s != nil && s == "NSString that does not fit in tagged pointer", "Expected results did not match")
+  CheckResults(s != nil && s == "NSString that does not fit in tagged pointer")
 }
 #endif
 
@@ -95,7 +95,7 @@ func testObjectiveCBridgeToNSString() {
     // Call _BridgedToObjectiveC
     s = nativeString as NSString
   }
-  CheckResults(s != nil && s == "Native", "Expected results did not match")
+  CheckResults(s != nil && s == "Native")
 }
 #endif
 
@@ -140,7 +140,7 @@ func testObjectiveCBridgeFromNSArrayAnyObject() {
        nativeString = forcedCast(nativeArray[0])
     }
   }
-  CheckResults(nativeString != nil && nativeString! == "NSString that does not fit in tagged pointer", "Expected results did not match")
+  CheckResults(nativeString != nil && nativeString! == "NSString that does not fit in tagged pointer")
 }
 #endif
 
@@ -165,7 +165,7 @@ func testObjectiveCBridgeFromNSArrayAnyObjectForced() {
     let nativeArray : [NSString] = forcedCast(nsArray)
     nativeString = forcedCast(nativeArray[0])
   }
-  CheckResults(nativeString != nil && nativeString! == "NSString that does not fit in tagged pointer", "Expected results did not match")
+  CheckResults(nativeString != nil && nativeString! == "NSString that does not fit in tagged pointer")
 }
 #endif
 
@@ -191,7 +191,7 @@ func testObjectiveCBridgeToNSArray() {
     let nsArray = nativeArray as NSArray
     nsString = nsArray.object(at: 0)
   }
-  CheckResults(nsString != nil && (nsString! as! NSString).isEqual("abcde"), "Expected results did not match")
+  CheckResults(nsString != nil && (nsString! as! NSString).isEqual("abcde"))
 }
 #endif
 
@@ -217,7 +217,7 @@ func testObjectiveCBridgeFromNSArrayAnyObjectToString() {
       nativeString = nativeArray[0]
     }
   }
-  CheckResults(nativeString != nil && nativeString == "NSString that does not fit in tagged pointer", "Expected results did not match")
+  CheckResults(nativeString != nil && nativeString == "NSString that does not fit in tagged pointer")
 }
 #endif
 
@@ -242,7 +242,7 @@ func testObjectiveCBridgeFromNSArrayAnyObjectToStringForced() {
     let nativeArray : [String] = forcedCast(nsArray)
     nativeString = nativeArray[0]
   }
-  CheckResults(nativeString != nil && nativeString == "NSString that does not fit in tagged pointer", "Expected results did not match")
+  CheckResults(nativeString != nil && nativeString == "NSString that does not fit in tagged pointer")
 }
 #endif
 
@@ -297,7 +297,7 @@ func testObjectiveCBridgeFromNSDictionaryAnyObject() {
        nativeInt = forcedCast(nativeDictionary[nsString])
     }
   }
-  CheckResults(nativeInt != nil && nativeInt == 1, "Expected results did not match")
+  CheckResults(nativeInt != nil && nativeInt == 1)
 }
 #endif
 
@@ -324,7 +324,7 @@ func testObjectiveCBridgeFromNSDictionaryAnyObjectForced() {
        nativeInt = forcedCast(nativeDictionary[nsString])
     }
   }
-  CheckResults(nativeInt != nil && nativeInt == 1, "Expected results did not match")
+  CheckResults(nativeInt != nil && nativeInt == 1)
 }
 #endif
 
@@ -352,7 +352,7 @@ func testObjectiveCBridgeToNSDictionary() {
     let nsDict = nativeDictionary as NSDictionary
     nsNumber = nsDict.object(forKey: key)
   }
-  CheckResults(nsNumber != nil && (nsNumber as! Int) == 1, "Expected results did not match")
+  CheckResults(nsNumber != nil && (nsNumber as! Int) == 1)
 }
 #endif
 
@@ -380,7 +380,7 @@ func testObjectiveCBridgeFromNSDictionaryAnyObjectToString() {
        nativeInt = nativeDictionary[nativeString]
     }
   }
-  CheckResults(nativeInt != nil && nativeInt == 1, "Expected results did not match")
+  CheckResults(nativeInt != nil && nativeInt == 1)
 }
 #endif
 
@@ -408,7 +408,7 @@ func testObjectiveCBridgeFromNSDictionaryAnyObjectToStringForced() {
        nativeInt = nativeDictionary[nativeString]
     }
   }
-  CheckResults(nativeInt != nil && nativeInt == 1, "Expected results did not match")
+  CheckResults(nativeInt != nil && nativeInt == 1)
 }
 #endif
 
@@ -464,7 +464,7 @@ func testObjectiveCBridgeFromNSSetAnyObject() {
        result = nativeSet.contains(nsString)
     }
   }
-  CheckResults(result != nil && result!, "Expected results did not match")
+  CheckResults(result != nil && result!)
 }
 #endif
 
@@ -491,7 +491,7 @@ func testObjectiveCBridgeFromNSSetAnyObjectForced() {
        result = nativeSet.contains(nsString)
     }
   }
-  CheckResults(result != nil && result!, "Expected results did not match")
+  CheckResults(result != nil && result!)
 }
 #endif
 
@@ -518,7 +518,7 @@ func testObjectiveCBridgeToNSSet() {
     let nsDict = nativeSet as NSSet
     nsString = nsDict.member(key)
   }
-  CheckResults(nsString != nil && (nsString as! String) == "abcde1", "Expected results did not match")
+  CheckResults(nsString != nil && (nsString as! String) == "abcde1")
 }
 #endif
 
@@ -546,7 +546,7 @@ func testObjectiveCBridgeFromNSSetAnyObjectToString() {
        result = nativeSet.contains(nativeString)
     }
   }
-  CheckResults(result != nil && result!, "Expected results did not match")
+  CheckResults(result != nil && result!)
 }
 #endif
 
@@ -574,7 +574,7 @@ func testObjectiveCBridgeFromNSSetAnyObjectToStringForced() {
        result = nativeSet.contains(nativeString)
     }
   }
-  CheckResults(result != nil && result!, "Expected results did not match")
+  CheckResults(result != nil && result!)
 }
 #endif
 

--- a/benchmark/single-source/ObjectiveCBridgingStubs.swift
+++ b/benchmark/single-source/ObjectiveCBridgingStubs.swift
@@ -24,7 +24,7 @@ func testObjectiveCBridgeStubFromNSString() {
    for _ in 0 ..< 10_000 {
      str = b.testToString()
    }
-   CheckResults(str != "" && str == "Default string value no tagged pointer", "Wrong value returned")
+   CheckResults(str != "" && str == "Default string value no tagged pointer")
 }
 #endif
 
@@ -71,7 +71,7 @@ func testObjectiveCBridgeStubFromArrayOfNSString() {
      arr = b.testToArrayOfStrings()
      str = arr[0]
    }
-   CheckResults(str != "" && str == "Default string value no tagged pointer", "Wrong value returned")
+   CheckResults(str != "" && str == "Default string value no tagged pointer")
 }
 #endif
 

--- a/benchmark/single-source/ObjectiveCNoBridgingStubs.swift
+++ b/benchmark/single-source/ObjectiveCNoBridgingStubs.swift
@@ -29,7 +29,7 @@ func testObjectiveCBridgeStubFromNSStringRef() {
   for _ in 0 ..< 10_000 {
     nsString = b.testToString()
   }
-  CheckResults(nsString.isEqual(to: "Default string value no tagged pointer" as NSString), "Wrong value returned")
+  CheckResults(nsString.isEqual(to: "Default string value no tagged pointer" as NSString))
 }
 #endif
 

--- a/benchmark/single-source/OpenClose.swift
+++ b/benchmark/single-source/OpenClose.swift
@@ -32,6 +32,6 @@ public func run_OpenClose(_ N: Int) {
   for _ in 1...N*10000 {
       c += check_state(MyState.Closed)
   }
-  CheckResults(c == 0, "IncorrectResults in run_OpenClose")
+  CheckResults(c == 0)
 }
 

--- a/benchmark/single-source/PopFront.swift
+++ b/benchmark/single-source/PopFront.swift
@@ -27,7 +27,7 @@ public func run_PopFrontArray(_ N: Int) {
         result += a[0]
         a.remove(at: 0)
       }
-      CheckResults(result == arrayCount, "IncorrectResults in StringInterpolation: \(result) != \(arrayCount)")
+      CheckResults(result == arrayCount)
     }
   }
 }
@@ -48,7 +48,7 @@ public func run_PopFrontUnsafePointer(_ N: Int) {
         a.assign(from: a + 1, count: count - 1)
         count -= 1
       }
-      CheckResults(result == arrayCount, "IncorrectResults in StringInterpolation: \(result) != \(arrayCount)")
+      CheckResults(result == arrayCount)
     }
   }
   a.deallocate(capacity: arrayCount)

--- a/benchmark/single-source/PopFrontGeneric.swift
+++ b/benchmark/single-source/PopFrontGeneric.swift
@@ -56,7 +56,7 @@ public func run_PopFrontArrayGeneric(_ N: Int) {
         result += a[0]
         myArrayReplace(&a, 0..<1, EmptyCollection())
       }
-      CheckResults(result == arrayCount, "IncorrectResults in StringInterpolation: \(result) != \(arrayCount)")
+      CheckResults(result == arrayCount)
     }
   }
 }

--- a/benchmark/single-source/Prefix.swift
+++ b/benchmark/single-source/Prefix.swift
@@ -30,8 +30,7 @@ public func run_PrefixCountableRange(_ N: Int) {
     for element in s.prefix(prefixCount) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in PrefixCountableRange: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -42,8 +41,7 @@ public func run_PrefixSequence(_ N: Int) {
     for element in s.prefix(prefixCount) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in PrefixSequence: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -54,8 +52,7 @@ public func run_PrefixAnySequence(_ N: Int) {
     for element in s.prefix(prefixCount) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in PrefixAnySequence: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -66,8 +63,7 @@ public func run_PrefixAnySeqCntRange(_ N: Int) {
     for element in s.prefix(prefixCount) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in PrefixAnySeqCntRange: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -78,8 +74,7 @@ public func run_PrefixAnySeqCRangeIter(_ N: Int) {
     for element in s.prefix(prefixCount) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in PrefixAnySeqCRangeIter: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -90,8 +85,7 @@ public func run_PrefixAnyCollection(_ N: Int) {
     for element in s.prefix(prefixCount) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in PrefixAnyCollection: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -102,8 +96,7 @@ public func run_PrefixArray(_ N: Int) {
     for element in s.prefix(prefixCount) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in PrefixArray: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -114,8 +107,7 @@ public func run_PrefixCountableRangeLazy(_ N: Int) {
     for element in s.prefix(prefixCount) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in PrefixCountableRangeLazy: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -126,8 +118,7 @@ public func run_PrefixSequenceLazy(_ N: Int) {
     for element in s.prefix(prefixCount) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in PrefixSequenceLazy: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -138,8 +129,7 @@ public func run_PrefixAnySequenceLazy(_ N: Int) {
     for element in s.prefix(prefixCount) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in PrefixAnySequenceLazy: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -150,8 +140,7 @@ public func run_PrefixAnySeqCntRangeLazy(_ N: Int) {
     for element in s.prefix(prefixCount) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in PrefixAnySeqCntRangeLazy: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -162,8 +151,7 @@ public func run_PrefixAnySeqCRangeIterLazy(_ N: Int) {
     for element in s.prefix(prefixCount) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in PrefixAnySeqCRangeIterLazy: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -174,8 +162,7 @@ public func run_PrefixAnyCollectionLazy(_ N: Int) {
     for element in s.prefix(prefixCount) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in PrefixAnyCollectionLazy: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -186,7 +173,6 @@ public func run_PrefixArrayLazy(_ N: Int) {
     for element in s.prefix(prefixCount) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in PrefixArrayLazy: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }

--- a/benchmark/single-source/Prefix.swift.gyb
+++ b/benchmark/single-source/Prefix.swift.gyb
@@ -50,8 +50,7 @@ public func run_Prefix${Name}(_ N: Int) {
     for element in s.prefix(prefixCount) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in Prefix${Name}: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 % end

--- a/benchmark/single-source/PrefixWhile.swift
+++ b/benchmark/single-source/PrefixWhile.swift
@@ -30,8 +30,7 @@ public func run_PrefixWhileCountableRange(_ N: Int) {
     for element in s.prefix(while: {$0 < prefixCount} ) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in PrefixWhileCountableRange: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -42,8 +41,7 @@ public func run_PrefixWhileSequence(_ N: Int) {
     for element in s.prefix(while: {$0 < prefixCount} ) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in PrefixWhileSequence: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -54,8 +52,7 @@ public func run_PrefixWhileAnySequence(_ N: Int) {
     for element in s.prefix(while: {$0 < prefixCount} ) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in PrefixWhileAnySequence: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -66,8 +63,7 @@ public func run_PrefixWhileAnySeqCntRange(_ N: Int) {
     for element in s.prefix(while: {$0 < prefixCount} ) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in PrefixWhileAnySeqCntRange: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -78,8 +74,7 @@ public func run_PrefixWhileAnySeqCRangeIter(_ N: Int) {
     for element in s.prefix(while: {$0 < prefixCount} ) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in PrefixWhileAnySeqCRangeIter: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -90,8 +85,7 @@ public func run_PrefixWhileAnyCollection(_ N: Int) {
     for element in s.prefix(while: {$0 < prefixCount} ) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in PrefixWhileAnyCollection: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -102,8 +96,7 @@ public func run_PrefixWhileArray(_ N: Int) {
     for element in s.prefix(while: {$0 < prefixCount} ) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in PrefixWhileArray: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -114,8 +107,7 @@ public func run_PrefixWhileCountableRangeLazy(_ N: Int) {
     for element in s.prefix(while: {$0 < prefixCount} ) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in PrefixWhileCountableRangeLazy: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -126,8 +118,7 @@ public func run_PrefixWhileSequenceLazy(_ N: Int) {
     for element in s.prefix(while: {$0 < prefixCount} ) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in PrefixWhileSequenceLazy: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -138,8 +129,7 @@ public func run_PrefixWhileAnySequenceLazy(_ N: Int) {
     for element in s.prefix(while: {$0 < prefixCount} ) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in PrefixWhileAnySequenceLazy: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -150,8 +140,7 @@ public func run_PrefixWhileAnySeqCntRangeLazy(_ N: Int) {
     for element in s.prefix(while: {$0 < prefixCount} ) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in PrefixWhileAnySeqCntRangeLazy: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -162,8 +151,7 @@ public func run_PrefixWhileAnySeqCRangeIterLazy(_ N: Int) {
     for element in s.prefix(while: {$0 < prefixCount} ) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in PrefixWhileAnySeqCRangeIterLazy: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -174,8 +162,7 @@ public func run_PrefixWhileAnyCollectionLazy(_ N: Int) {
     for element in s.prefix(while: {$0 < prefixCount} ) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in PrefixWhileAnyCollectionLazy: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -186,7 +173,6 @@ public func run_PrefixWhileArrayLazy(_ N: Int) {
     for element in s.prefix(while: {$0 < prefixCount} ) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in PrefixWhileArrayLazy: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }

--- a/benchmark/single-source/PrefixWhile.swift.gyb
+++ b/benchmark/single-source/PrefixWhile.swift.gyb
@@ -50,8 +50,7 @@ public func run_PrefixWhile${Name}(_ N: Int) {
     for element in s.prefix(while: {$0 < prefixCount} ) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in PrefixWhile${Name}: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 % end

--- a/benchmark/single-source/Prims.swift
+++ b/benchmark/single-source/Prims.swift
@@ -751,7 +751,6 @@ public func run_Prims(_ N: Int) {
     for i in 1..<treeEdges.count {
       if let n = treeEdges[i] { cost += map[Edge(start: n, end: i)]! }
     }
-    CheckResults(Int(cost) == 49324,
-                 "Incorrect results in Prims: \(Int(cost)) != 49324.")
+    CheckResults(Int(cost) == 49324)
   }
 }

--- a/benchmark/single-source/ProtocolDispatch2.swift
+++ b/benchmark/single-source/ProtocolDispatch2.swift
@@ -59,6 +59,6 @@ public func run_ProtocolDispatch2(_ N: Int) {
       c += wrapper(i, g1, g2)
     }
   }
-  CheckResults(c == 75000, "IncorrectResults in ProtoDispatch")
+  CheckResults(c == 75000)
 }
 

--- a/benchmark/single-source/RC4.swift
+++ b/benchmark/single-source/RC4.swift
@@ -99,6 +99,6 @@ public func run_RC4(_ N: Int) {
       Enc.encrypt(&LongData)
     }
 
-    CheckResults(LongData == RefResults, "Incorrect result in RC4")
+    CheckResults(LongData == RefResults)
   }
 }

--- a/benchmark/single-source/RGBHistogram.swift
+++ b/benchmark/single-source/RGBHistogram.swift
@@ -27,8 +27,7 @@ public func run_RGBHistogram(_ N: Int) {
             break
         }
     }
-    CheckResults(isCorrectHistogram(histogram),
-                 "Incorrect results in histogram")
+    CheckResults(isCorrectHistogram(histogram))
 }
 
 typealias rrggbb_t = UInt32
@@ -166,8 +165,7 @@ public func run_RGBHistogramOfObjects(_ N: Int) {
             break
         }
     }
-    CheckResults(isCorrectHistogramOfObjects(histogram),
-                 "Incorrect results in histogram")
+    CheckResults(isCorrectHistogramOfObjects(histogram))
 }
 
 

--- a/benchmark/single-source/RangeAssignment.swift
+++ b/benchmark/single-source/RangeAssignment.swift
@@ -22,6 +22,5 @@ public func run_RangeAssignment(_ scale: Int) {
       vector[range] = ArraySlice(vector[range].map { $0 + alfa })
   }
 
-  CheckResults(vector[100] == Double(N),
-    "IncorrectResults in RangeAssignment: \(vector[100]) != \(N).")
+  CheckResults(vector[100] == Double(N))
 }

--- a/benchmark/single-source/RecursiveOwnedParameter.swift
+++ b/benchmark/single-source/RecursiveOwnedParameter.swift
@@ -52,6 +52,5 @@ public func run_RecursiveOwnedParameter(_ N: Int) {
     }
   }
   let refResult = 100*N
-  CheckResults(result == refResult,
-    "IncorrectResults in RecursiveOwnedParameter: \(result) != \(refResult)")
+  CheckResults(result == refResult)
 }

--- a/benchmark/single-source/SetTests.swift
+++ b/benchmark/single-source/SetTests.swift
@@ -34,7 +34,7 @@ public func run_SetIsSubsetOf(_ N: Int) {
     }
   }
 
-  CheckResults(!isSubset, "Incorrect results in SetIsSubsetOf")
+  CheckResults(!isSubset)
 }
 
 @inline(never)
@@ -142,7 +142,7 @@ public func run_SetIsSubsetOf_OfObjects(_ N: Int) {
     }
   }
 
-  CheckResults(!isSubset, "Incorrect results in SetIsSubsetOf")
+  CheckResults(!isSubset)
 }
 
 @inline(never)

--- a/benchmark/single-source/SevenBoom.swift
+++ b/benchmark/single-source/SevenBoom.swift
@@ -31,6 +31,6 @@ public func run_SevenBoom(_ N: Int) {
     catch _ {
     }
   }
-  CheckResults(c == 1, "IncorrectResults in SevenBoom")
+  CheckResults(c == 1)
 }
 

--- a/benchmark/single-source/SortLargeExistentials.swift
+++ b/benchmark/single-source/SortLargeExistentials.swift
@@ -77,7 +77,6 @@ public func run_SortLargeExistentials(_ N: Int) {
     }
 
     // Check whether letters are sorted.
-    CheckResults(letters[0].value <= letters[letters.count/2].value,
-                 "Incorrect results in SortLargeExistentials.")
+    CheckResults(letters[0].value <= letters[letters.count/2].value)
   }
 }

--- a/benchmark/single-source/SortLettersInPlace.swift
+++ b/benchmark/single-source/SortLettersInPlace.swift
@@ -39,8 +39,7 @@ public func run_SortLettersInPlace(_ N: Int) {
     }
 
     // Check whether letters are sorted.
-    CheckResults(letters[0].value <= letters[letters.count/2].value,
-                 "Incorrect results in SortLetterInPlace.")
+    CheckResults(letters[0].value <= letters[letters.count/2].value)
   }
 }
 

--- a/benchmark/single-source/StrComplexWalk.swift
+++ b/benchmark/single-source/StrComplexWalk.swift
@@ -21,7 +21,7 @@ public func run_StrComplexWalk(_ N: Int) {
     for _ in s.unicodeScalars {
       count += 1
     }
-    CheckResults(count == ref_result, "Incorrect results in StrComplexWalk: \(count) != \(ref_result)")
+    CheckResults(count == ref_result)
   }
 }
 

--- a/benchmark/single-source/StrToInt.swift
+++ b/benchmark/single-source/StrToInt.swift
@@ -43,5 +43,5 @@ public func run_StrToInt(_ N: Int) {
   for _ in 1...1000*N {
     res = res & DoOneIter(input)
   }
-  CheckResults(res == ref_result, "IncorrectResults in StrToInt: \(res) != \(ref_result)")
+  CheckResults(res == ref_result)
 }

--- a/benchmark/single-source/StringInterpolation.swift
+++ b/benchmark/single-source/StringInterpolation.swift
@@ -36,7 +36,7 @@ public func run_StringInterpolation(_ N: Int) {
       // with an operation on the native storage type.
       result = result &+ Int(utf16[utf16.index(before: utf16.endIndex)])
     }
-    CheckResults(result == refResult, "IncorrectResults in StringInterpolation: \(result) != \(refResult)")
+    CheckResults(result == refResult)
   }
 }
 

--- a/benchmark/single-source/StringTests.swift
+++ b/benchmark/single-source/StringTests.swift
@@ -19,7 +19,7 @@ public func run_StringHasPrefix(_ N: Int) {
   for _ in 0 ..< N {
     for _ in 0 ..< 100_000 {
       if !testString.hasPrefix(prefix) {
-        CheckResults(false, "prefix check failed")
+        CheckResults(false)
       }
     }
   }
@@ -34,7 +34,7 @@ public func run_StringHasSuffix(_ N: Int) {
   for _ in 0 ..< N {
     for _ in 0 ..< 100_000 {
       if !testString.hasSuffix(suffix) {
-        CheckResults(false, "suffix check failed")
+        CheckResults(false)
       }
     }
   }
@@ -49,7 +49,7 @@ public func run_StringHasPrefixUnicode(_ N: Int) {
   for _ in 0 ..< N {
     for _ in 0 ..< 100_000 {
       if !testString.hasPrefix(prefix) {
-        CheckResults(false, "prefix check failed")
+        CheckResults(false)
       }
     }
   }
@@ -64,7 +64,7 @@ public func run_StringHasSuffixUnicode(_ N: Int) {
   for _ in 0 ..< N {
     for _ in 0 ..< 100_000 {
       if !testString.hasSuffix(suffix) {
-        CheckResults(false, "suffix check failed")
+        CheckResults(false)
       }
     }
   }
@@ -82,7 +82,7 @@ public func run_StringEqualPointerComparison(_ N: Int) {
   for _ in 0 ..< N {
     for _ in 0 ..< 100_000 {
       if !compareEqual(str1, str2) {
-        CheckResults(false, "Strings should be equal")
+        CheckResults(false)
       }
     }
   }

--- a/benchmark/single-source/Suffix.swift
+++ b/benchmark/single-source/Suffix.swift
@@ -30,8 +30,7 @@ public func run_SuffixCountableRange(_ N: Int) {
     for element in s.suffix(suffixCount) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in SuffixCountableRange: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -42,8 +41,7 @@ public func run_SuffixSequence(_ N: Int) {
     for element in s.suffix(suffixCount) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in SuffixSequence: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -54,8 +52,7 @@ public func run_SuffixAnySequence(_ N: Int) {
     for element in s.suffix(suffixCount) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in SuffixAnySequence: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -66,8 +63,7 @@ public func run_SuffixAnySeqCntRange(_ N: Int) {
     for element in s.suffix(suffixCount) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in SuffixAnySeqCntRange: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -78,8 +74,7 @@ public func run_SuffixAnySeqCRangeIter(_ N: Int) {
     for element in s.suffix(suffixCount) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in SuffixAnySeqCRangeIter: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -90,8 +85,7 @@ public func run_SuffixAnyCollection(_ N: Int) {
     for element in s.suffix(suffixCount) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in SuffixAnyCollection: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -102,8 +96,7 @@ public func run_SuffixArray(_ N: Int) {
     for element in s.suffix(suffixCount) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in SuffixArray: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -114,8 +107,7 @@ public func run_SuffixCountableRangeLazy(_ N: Int) {
     for element in s.suffix(suffixCount) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in SuffixCountableRangeLazy: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -126,8 +118,7 @@ public func run_SuffixSequenceLazy(_ N: Int) {
     for element in s.suffix(suffixCount) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in SuffixSequenceLazy: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -138,8 +129,7 @@ public func run_SuffixAnySequenceLazy(_ N: Int) {
     for element in s.suffix(suffixCount) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in SuffixAnySequenceLazy: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -150,8 +140,7 @@ public func run_SuffixAnySeqCntRangeLazy(_ N: Int) {
     for element in s.suffix(suffixCount) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in SuffixAnySeqCntRangeLazy: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -162,8 +151,7 @@ public func run_SuffixAnySeqCRangeIterLazy(_ N: Int) {
     for element in s.suffix(suffixCount) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in SuffixAnySeqCRangeIterLazy: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -174,8 +162,7 @@ public func run_SuffixAnyCollectionLazy(_ N: Int) {
     for element in s.suffix(suffixCount) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in SuffixAnyCollectionLazy: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 @inline(never)
@@ -186,7 +173,6 @@ public func run_SuffixArrayLazy(_ N: Int) {
     for element in s.suffix(suffixCount) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in SuffixArrayLazy: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }

--- a/benchmark/single-source/Suffix.swift.gyb
+++ b/benchmark/single-source/Suffix.swift.gyb
@@ -50,8 +50,7 @@ public func run_Suffix${Name}(_ N: Int) {
     for element in s.suffix(suffixCount) {
       result += element
     }
-    CheckResults(result == sumCount,
-      "IncorrectResults in Suffix${Name}: \(result) != \(sumCount)")
+    CheckResults(result == sumCount)
   }
 }
 % end

--- a/benchmark/single-source/TwoSum.swift
+++ b/benchmark/single-source/TwoSum.swift
@@ -69,11 +69,8 @@ public func run_TwoSum(_ N: Int) {
         }
         Dict[array[n]] = n
       }
-      CheckResults(i1 != nil && i2 != nil,
-                   "Incorrect results in TwoSum: i1 or i2 wasn't found.")
-      CheckResults(Sum == array[i1!] + array[i2!],
-                   "Incorrect results in TwoSum: Sum: \(Sum), " +
-                   "array[i1]: \(array[i1!]), array[i2]: \(array[i2!]).")
+      CheckResults(i1 != nil && i2 != nil)
+      CheckResults(Sum == array[i1!] + array[i2!])
     }
   }
 }

--- a/benchmark/single-source/Walsh.swift
+++ b/benchmark/single-source/Walsh.swift
@@ -62,9 +62,9 @@ func checkCorrectness() {
   InverseWalshTransform(&data)
   for i in 0..<In.count {
     // Check encode.
-    CheckResults(abs(data[i] - In[i]) < 0.0001, "Incorrect results in Walsh.")
+    CheckResults(abs(data[i] - In[i]) < 0.0001)
     // Check decode.
-    CheckResults(abs(mid[i] - Out[i]) < 0.0001, "Incorrect results in Walsh.")
+    CheckResults(abs(mid[i] - Out[i]) < 0.0001)
   }
 }
 

--- a/benchmark/single-source/XorLoop.swift
+++ b/benchmark/single-source/XorLoop.swift
@@ -22,7 +22,6 @@ public func run_XorLoop(_ N: Int) {
       x[i] = x[i] ^ 12345678
     }
     let res = x[10]+x[100]+x[1000]+x[10000]
-    CheckResults(res == ref_result,
-                 "Incorrect results in XorLoop: \(res) != \(ref_result)")
+    CheckResults(res == ref_result)
   }
 }

--- a/benchmark/utils/TestsUtils.swift
+++ b/benchmark/utils/TestsUtils.swift
@@ -72,3 +72,8 @@ public func someProtocolFactory() -> SomeProtocol { return MyStruct() }
 public func blackHole<T>(_ x: T) {
 }
 
+@inline(__always)
+public func CheckResults(_ resultsMatch: Bool) {
+  guard _fastPath(resultsMatch) else { abort() }
+}
+


### PR DESCRIPTION
This call was in many cases skewing the benchmark results.

Note: Intentionally staging this in without removing the old overload initially.
