### PR TITLE
stdlib: make a few structs @_fixed_layout to fix the resilience build.

### DIFF
--- a/stdlib/public/core/Character.swift
+++ b/stdlib/public/core/Character.swift
@@ -60,6 +60,7 @@
 /// [glossary]: http://www.unicode.org/glossary/
 /// [clusters]: http://www.unicode.org/glossary/#extended_grapheme_cluster
 /// [scalars]: http://www.unicode.org/glossary/#unicode_scalar_value
+@_fixed_layout
 public struct Character :
   _ExpressibleByBuiltinExtendedGraphemeClusterLiteral,
   ExpressibleByExtendedGraphemeClusterLiteral, Hashable {

--- a/stdlib/public/core/UTF8.swift
+++ b/stdlib/public/core/UTF8.swift
@@ -85,6 +85,7 @@ extension _Unicode.UTF8 : UnicodeEncoding {
       _bitCount: 32)
   }
   
+  @_fixed_layout
   public struct ForwardParser {
     public typealias _Buffer = _UIntBuffer<UInt32, UInt8>
     @inline(__always)
@@ -93,6 +94,7 @@ extension _Unicode.UTF8 : UnicodeEncoding {
     public var _buffer: _Buffer
   }
   
+  @_fixed_layout
   public struct ReverseParser {
     public typealias _Buffer = _UIntBuffer<UInt32, UInt8>
     @inline(__always)

--- a/stdlib/public/core/UnicodeParser.swift
+++ b/stdlib/public/core/UnicodeParser.swift
@@ -66,6 +66,7 @@ extension UnicodeParser {
 }
 
 extension _Unicode {
+  @_fixed_layout
   public struct ParsingIterator<
     CodeUnitIterator : IteratorProtocol, 
     Parser: UnicodeParser


### PR DESCRIPTION
This is a follow-up fix for making struct constructors inline(__always) in
155db0a4bd698ba17697acea76bfe7ad7676d88b: Let Character literals, which fit into 64 bits, be folded into a single integer constant.
and
d8f1caf4a694fe76d2f33c0dca2539626d723684: Inline all the new low-level bits

If we decide that this structs should not have fixed layout we must re-evaluate the performance difference of not being able to inline
the struct constructors.
