### PR TITLE
Lift the decision of whether a method needs a vtable slot up to AST.

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -232,7 +232,9 @@ enum class TypeMatchFlags {
   ///
   /// This includes function parameters and result types as well as tuple
   /// elements, but excludes generic parameters.
-  AllowTopLevelOptionalMismatch = 1 << 2
+  AllowTopLevelOptionalMismatch = 1 << 2,
+  /// Allow any ABI-compatible types to be considered matching.
+  AllowABICompatible = 1 << 3,
 };
 using TypeMatchOptions = OptionSet<TypeMatchFlags>;
 

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -221,19 +221,20 @@ enum class TypeTraitResult {
 
 /// Specifies which normally-unsafe type mismatches should be accepted when
 /// checking overrides.
-enum class OverrideMatchMode {
-  /// Only accept overrides that are properly covariant.
-  Strict,
+enum class TypeMatchFlags {
+  /// Allow properly-covariant overrides.
+  AllowOverride = 1 << 0,
   /// Allow a parameter with IUO type to be overridden by a parameter with non-
   /// optional type.
-  AllowNonOptionalForIUOParam,
+  AllowNonOptionalForIUOParam = 1 << 1,
   /// Allow any mismatches of Optional or ImplicitlyUnwrappedOptional at the
   /// top level of a type.
   ///
   /// This includes function parameters and result types as well as tuple
   /// elements, but excludes generic parameters.
-  AllowTopLevelOptionalMismatch
+  AllowTopLevelOptionalMismatch = 1 << 2
 };
+using TypeMatchOptions = OptionSet<TypeMatchFlags>;
 
 /// TypeBase - Base class for all types in Swift.
 class alignas(1 << TypeAlignInBits) TypeBase {
@@ -702,10 +703,9 @@ public:
   /// concrete types to form the argument type.
   bool isBindableTo(Type ty);
 
-  /// \brief Determines whether this type is permitted as a method override
-  /// of the \p other.
-  bool canOverride(Type other, OverrideMatchMode matchMode,
-                   LazyResolver *resolver);
+  /// \brief Determines whether this type is similar to \p other as defined by
+  /// \p matchOptions.
+  bool matches(Type other, TypeMatchOptions matchOptions, LazyResolver *resolver);
 
   /// \brief Determines whether this type has a retainable pointer
   /// representation, i.e. whether it is representable as a single,

--- a/include/swift/SIL/SILVTableVisitor.h
+++ b/include/swift/SIL/SILVTableVisitor.h
@@ -43,38 +43,33 @@ template <class T> class SILVTableVisitor {
   void maybeAddMethod(FuncDecl *fd) {
     assert(!fd->hasClangNode());
 
-    // Observing accessors and addressors don't get vtable entries.
-    if (fd->isObservingAccessor() ||
-        fd->getAddressorKind() != AddressorKind::NotAddressor)
-      return;
-
-    maybeAddEntry(SILDeclRef(fd, SILDeclRef::Kind::Func));
+    maybeAddEntry(SILDeclRef(fd, SILDeclRef::Kind::Func),
+                  fd->needsNewVTableEntry());
   }
 
   void maybeAddConstructor(ConstructorDecl *cd) {
     assert(!cd->hasClangNode());
 
-    SILDeclRef initRef(cd, SILDeclRef::Kind::Initializer);
-
-    // Stub constructors don't get a vtable entry unless they were synthesized
-    // to override a base class initializer.
-    if (cd->hasStubImplementation() &&
-        !initRef.getNextOverriddenVTableEntry())
-      return;
-
     // Required constructors (or overrides thereof) have their allocating entry
     // point in the vtable.
-    if (cd->isRequired())
-      maybeAddEntry(SILDeclRef(cd, SILDeclRef::Kind::Allocator));
+    if (cd->isRequired()) {
+      bool needsAllocatingEntry = cd->needsNewVTableEntry();
+      if (!needsAllocatingEntry)
+        if (auto *baseCD = cd->getOverriddenDecl())
+          needsAllocatingEntry = !baseCD->isRequired();
+      maybeAddEntry(SILDeclRef(cd, SILDeclRef::Kind::Allocator),
+                    needsAllocatingEntry);
+    }
 
     // All constructors have their initializing constructor in the
     // vtable, which can be used by a convenience initializer.
-    maybeAddEntry(SILDeclRef(cd, SILDeclRef::Kind::Initializer));
+    maybeAddEntry(SILDeclRef(cd, SILDeclRef::Kind::Initializer),
+                  cd->needsNewVTableEntry());
   }
 
-  void maybeAddEntry(SILDeclRef declRef) {
+  void maybeAddEntry(SILDeclRef declRef, bool needsNewEntry) {
     // Introduce a new entry if required.
-    if (Types.requiresNewVTableEntry(declRef))
+    if (needsNewEntry)
       asDerived().addMethod(declRef);
 
     // Update any existing entries that it overrides.

--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -511,8 +511,6 @@ class TypeConverter {
   
   llvm::DenseMap<OverrideKey, SILConstantInfo> ConstantOverrideTypes;
 
-  llvm::DenseMap<SILDeclRef, bool> RequiresVTableEntry;
-
   llvm::DenseMap<AnyFunctionRef, CaptureInfo> LoweredCaptures;
   
   CanAnyFunctionType makeConstantInterfaceType(SILDeclRef constant);
@@ -664,11 +662,6 @@ public:
   /// Returns the SILParameterInfo for the given declaration's `self` parameter.
   /// `constant` must refer to a method.
   SILParameterInfo getConstantSelfParameter(SILDeclRef constant);
-
-  /// Return if this method introduces a new vtable entry. This will be true
-  /// if the method does not override any method of its base class, or if it
-  /// overrides a method but has a more general AST type.
-  bool requiresNewVTableEntry(SILDeclRef method);
 
   /// Return the most derived override which requires a new vtable entry.
   /// If the method does not override anything or no override is vtable
@@ -852,8 +845,6 @@ private:
   CanAnyFunctionType getBridgedFunctionType(AbstractionPattern fnPattern,
                                             CanAnyFunctionType fnType,
                                             AnyFunctionType::ExtInfo extInfo);
-
-  bool requiresNewVTableEntryUncached(SILDeclRef method);
 };
 
 inline const TypeLowering &

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -54,7 +54,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// in source control, you should also update the comment to briefly
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
-const uint16_t VERSION_MINOR = 342; // Last change: keypath instruction
+const uint16_t VERSION_MINOR = 343; // Last change: new vtable entry flag
 
 using DeclID = PointerEmbeddedInt<unsigned, 31>;
 using DeclIDField = BCFixed<31>;
@@ -858,6 +858,7 @@ namespace decls_block {
     TypeIDField, // canonical interface type
     DeclIDField, // overridden decl
     AccessibilityKindField, // accessibility
+    BCFixed<1>,   // requires a new vtable slot
     BCArray<IdentifierIDField> // argument names
     // Trailed by its generic parameters, if any, followed by the parameter
     // patterns.
@@ -916,6 +917,7 @@ namespace decls_block {
     BCFixed<1>,   // name is compound?
     AddressorKindField, // addressor kind
     AccessibilityKindField, // accessibility
+    BCFixed<1>,   // requires a new vtable slot
     BCArray<IdentifierIDField> // name components
     // The record is trailed by:
     // - its _silgen_name, if any

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1128,6 +1128,8 @@ public:
       ASD->setSetterAccessibility(access);
     // All imported decls are constructed fully validated.
     D->setValidationStarted();
+    if (auto AFD = dyn_cast<AbstractFunctionDecl>(static_cast<Decl *>(D)))
+      AFD->setNeedsNewVTableEntry(false);
     return D;
   }
 

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -1795,83 +1795,8 @@ bool TypeConverter::requiresNewVTableEntry(SILDeclRef method) {
 // @guaranteed or whatever.
 static bool checkASTTypeForABIDifferences(CanType type1,
                                           CanType type2) {
-  // Unwrap optionals, but remember that we did.
-  bool type1WasOptional = false;
-  bool type2WasOptional = false;
-  if (auto object = type1.getAnyOptionalObjectType()) {
-    type1WasOptional = true;
-    type1 = object;
-  }
-  if (auto object = type2.getAnyOptionalObjectType()) {
-    type2WasOptional = true;
-    type2 = object;
-  }
-
-  // Forcing IUOs always requires a new vtable entry.
-  if (type1WasOptional && !type2WasOptional)
-    return true;
-
-  // Except for the above case, we should not be making a value less optional.
-
-  // If we're introducing a level of optionality, only certain types are
-  // ABI-compatible -- check below.
-  bool optionalityChange = (!type1WasOptional && type2WasOptional);
-
-  // If the types are identical and there was no optionality change,
-  // we're done.
-  if (type1 == type2 && !optionalityChange)
-    return false;
-
-  // Classes, class-constrained archetypes, and pure-ObjC existential types
-  // all have single retainable pointer representation; optionality change
-  // is allowed.
-  if ((type1->mayHaveSuperclass() ||
-       type1->isObjCExistentialType()) &&
-      (type2->mayHaveSuperclass() ||
-       type2->isObjCExistentialType()))
-    return false;
-
-  // Class metatypes are ABI-compatible even under optionality change.
-  if (auto metaTy1 = dyn_cast<MetatypeType>(type1)) {
-    if (auto metaTy2 = dyn_cast<MetatypeType>(type2)) {
-      if (metaTy1.getInstanceType().getClassOrBoundGenericClass() &&
-          metaTy2.getInstanceType().getClassOrBoundGenericClass())
-        return false;
-    }
-  }
-
-  if (!optionalityChange) {
-    // Function parameters are ABI compatible if their differences are
-    // trivial.
-    if (auto fnTy1 = dyn_cast<AnyFunctionType>(type1)) {
-      if (auto fnTy2 = dyn_cast<AnyFunctionType>(type2)) {
-        return (
-            checkASTTypeForABIDifferences(fnTy2.getInput(), fnTy1.getInput()) ||
-            checkASTTypeForABIDifferences(fnTy1.getResult(), fnTy2.getResult()));
-      }
-    }
-
-    // Tuple types are ABI-compatible if their elements are.
-    if (auto tuple1 = dyn_cast<TupleType>(type1)) {
-      if (auto tuple2 = dyn_cast<TupleType>(type2)) {
-        if (tuple1->getNumElements() != tuple2->getNumElements())
-          return true;
-
-        for (unsigned i = 0, e = tuple1->getNumElements(); i < e; i++) {
-          if (checkASTTypeForABIDifferences(tuple1.getElementType(i),
-                                            tuple2.getElementType(i)))
-            return true;
-        }
-
-        // Tuple lengths and elements match
-        return false;
-      }
-    }
-  }
-
-  // The types are different, or there was an optionality change resulting
-  // in a change in representation.
-  return true;
+  return !type1->matches(type2, TypeMatchFlags::AllowABICompatible,
+                         /*resolver*/nullptr);
 }
 
 bool TypeConverter::requiresNewVTableEntryUncached(SILDeclRef derived) {

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -2147,6 +2147,7 @@ swift::createDesignatedInitOverride(TypeChecker &tc,
   if (kind == DesignatedInitKind::Stub) {
     // Make this a stub implementation.
     createStubBody(tc, ctor);
+    ctor->setNeedsNewVTableEntry(false);
     return ctor;
   }
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -5767,15 +5767,15 @@ public:
         }
 
         // Failing that, check for subtyping.
-        auto matchMode = OverrideMatchMode::Strict;
+        TypeMatchOptions matchMode = TypeMatchFlags::AllowOverride;
         if (attempt == OverrideCheckingAttempt::MismatchedOptional ||
             attempt == OverrideCheckingAttempt::BaseNameWithMismatchedOptional){
-          matchMode = OverrideMatchMode::AllowTopLevelOptionalMismatch;
+          matchMode |= TypeMatchFlags::AllowTopLevelOptionalMismatch;
         } else if (parentDecl->isObjC()) {
-          matchMode = OverrideMatchMode::AllowNonOptionalForIUOParam;
+          matchMode |= TypeMatchFlags::AllowNonOptionalForIUOParam;
         }
 
-        if (declTy->canOverride(parentDeclTy, matchMode, &TC)) {
+        if (declTy->matches(parentDeclTy, matchMode, &TC)) {
           // If the Objective-C selectors match, always call it exact.
           matches.push_back({parentDecl, objCMatch, parentDeclTy});
           hadExactMatch |= objCMatch;
@@ -5992,9 +5992,9 @@ public:
         auto parentPropertyTy = superclass->adjustSuperclassMemberDeclType(
             matchDecl, decl, matchDecl->getInterfaceType());
         
-        if (!propertyTy->canOverride(parentPropertyTy,
-                                     OverrideMatchMode::Strict,
-                                     &TC)) {
+        if (!propertyTy->matches(parentPropertyTy,
+                                 TypeMatchFlags::AllowOverride,
+                                 &TC)) {
           TC.diagnose(property, diag::override_property_type_mismatch,
                       property->getName(), propertyTy, parentPropertyTy);
           noteFixableMismatchedTypes(TC, decl, matchDecl);

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2513,7 +2513,7 @@ ModuleFile::getDeclChecked(DeclID DID, Optional<DeclContext *> ForcedContext) {
   case decls_block::CONSTRUCTOR_DECL: {
     DeclContextID contextID;
     uint8_t rawFailability;
-    bool isImplicit, isObjC, hasStubImplementation, throws;
+    bool isImplicit, isObjC, hasStubImplementation, throws, needsNewVTableEntry;
     GenericEnvironmentID genericEnvID;
     uint8_t storedInitKind, rawAccessLevel;
     TypeID interfaceID, canonicalTypeID;
@@ -2526,7 +2526,8 @@ ModuleFile::getDeclChecked(DeclID DID, Optional<DeclContext *> ForcedContext) {
                                                throws, storedInitKind,
                                                genericEnvID, interfaceID,
                                                canonicalTypeID, overriddenID,
-                                               rawAccessLevel, argNameIDs);
+                                               rawAccessLevel,
+                                               needsNewVTableEntry, argNameIDs);
 
     // Resolve the name ids.
     SmallVector<Identifier, 2> argNames;
@@ -2618,6 +2619,7 @@ ModuleFile::getDeclChecked(DeclID DID, Optional<DeclContext *> ForcedContext) {
       ctor->setInitKind(initKind.getValue());
     if (auto overriddenCtor = cast_or_null<ConstructorDecl>(overridden.get()))
       ctor->setOverriddenDecl(overriddenCtor);
+    ctor->setNeedsNewVTableEntry(needsNewVTableEntry);
     break;
   }
 
@@ -2744,7 +2746,7 @@ ModuleFile::getDeclChecked(DeclID DID, Optional<DeclContext *> ForcedContext) {
     DeclID associatedDeclID;
     DeclID overriddenID;
     DeclID accessorStorageDeclID;
-    bool hasCompoundName;
+    bool hasCompoundName, needsNewVTableEntry;
     ArrayRef<uint64_t> nameIDs;
 
     decls_block::FuncLayout::readRecord(scratch, contextID, isImplicit,
@@ -2755,7 +2757,7 @@ ModuleFile::getDeclChecked(DeclID DID, Optional<DeclContext *> ForcedContext) {
                                         associatedDeclID, overriddenID,
                                         accessorStorageDeclID, hasCompoundName,
                                         rawAddressorKind, rawAccessLevel,
-                                        nameIDs);
+                                        needsNewVTableEntry, nameIDs);
 
     // Resolve the name ids.
     SmallVector<Identifier, 2> names;
@@ -2873,6 +2875,7 @@ ModuleFile::getDeclChecked(DeclID DID, Optional<DeclContext *> ForcedContext) {
       fn->setImplicit();
     fn->setMutating(isMutating);
     fn->setDynamicSelf(hasDynamicSelf);
+    fn->setNeedsNewVTableEntry(needsNewVTableEntry);
     break;
   }
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2315,6 +2315,8 @@ void Serializer::writeForeignErrorConvention(const ForeignErrorConvention &fec){
 void Serializer::writeDecl(const Decl *D) {
   using namespace decls_block;
 
+  PrettyStackTraceDecl trace("serializing", D);
+
   auto id = DeclAndTypeIDs[D].first;
   assert(id != 0 && "decl or type not referenced properly");
   (void)id;
@@ -2850,6 +2852,7 @@ void Serializer::writeDecl(const Decl *D) {
                            !fn->getFullName().isSimpleName(),
                            rawAddressorKind,
                            rawAccessLevel,
+                           fn->needsNewVTableEntry(),
                            nameComponents);
 
     writeGenericParams(fn->getGenericParams());
@@ -2972,6 +2975,7 @@ void Serializer::writeDecl(const Decl *D) {
                                   addTypeRef(ty->getCanonicalType()),
                                   addDeclRef(ctor->getOverriddenDecl()),
                                   rawAccessLevel,
+                                  ctor->needsNewVTableEntry(),
                                   nameComponents);
 
     writeGenericParams(ctor->getGenericParams());

--- a/unittests/AST/CMakeLists.txt
+++ b/unittests/AST/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_swift_unittest(SwiftASTTests
-  OverrideTests.cpp
   SourceLocTests.cpp
   TestContext.cpp
+  TypeMatchTests.cpp
   VersionRangeLattice.cpp
 )
 

--- a/unittests/AST/TestContext.h
+++ b/unittests/AST/TestContext.h
@@ -13,6 +13,7 @@
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ASTScope.h"
 #include "swift/AST/DiagnosticEngine.h"
+#include "swift/AST/Module.h"
 #include "swift/Basic/LangOptions.h"
 #include "swift/Basic/SourceManager.h"
 

--- a/unittests/AST/TypeMatchTests.cpp
+++ b/unittests/AST/TypeMatchTests.cpp
@@ -220,6 +220,33 @@ TEST(TypeMatch, IUONearMatch) {
   EXPECT_FALSE(check(optToOpt, baseToBase));
   EXPECT_FALSE(checkIUO(optToOpt, baseToBase));
   EXPECT_TRUE(checkIUOOverride(optToOpt, baseToBase));
+
+  Type tupleOfBase = TupleType::get({baseTy, baseTy}, C.Ctx);
+  Type tupleOfOpt = TupleType::get({optTy, optTy}, C.Ctx);
+
+  Type baseTupleToVoid = FunctionType::get(tupleOfBase,C.Ctx.TheEmptyTupleType);
+  Type optTupleToVoid = FunctionType::get(tupleOfOpt, C.Ctx.TheEmptyTupleType);
+  EXPECT_TRUE(check(baseTupleToVoid, optTupleToVoid));
+  EXPECT_FALSE(checkIUO(baseTupleToVoid, optTupleToVoid));
+  EXPECT_TRUE(checkIUOOverride(baseTupleToVoid, optTupleToVoid));
+  EXPECT_FALSE(check(optTupleToVoid, baseTupleToVoid));
+  EXPECT_TRUE(checkIUO(optTupleToVoid, baseTupleToVoid));
+  EXPECT_TRUE(checkIUOOverride(optTupleToVoid, baseTupleToVoid));
+
+  Type nestedBaseTuple = TupleType::get({C.Ctx.TheEmptyTupleType, tupleOfBase},
+                                        C.Ctx);
+  Type nestedOptTuple = TupleType::get({C.Ctx.TheEmptyTupleType, tupleOfOpt},
+                                        C.Ctx);
+  Type nestedBaseTupleToVoid = FunctionType::get(nestedBaseTuple,
+                                                 C.Ctx.TheEmptyTupleType);
+  Type nestedOptTupleToVoid = FunctionType::get(nestedOptTuple,
+                                                C.Ctx.TheEmptyTupleType);
+  EXPECT_TRUE(check(nestedBaseTupleToVoid, nestedOptTupleToVoid));
+  EXPECT_FALSE(checkIUO(nestedBaseTupleToVoid, nestedOptTupleToVoid));
+  EXPECT_TRUE(checkIUOOverride(nestedBaseTupleToVoid, nestedOptTupleToVoid));
+  EXPECT_FALSE(check(nestedOptTupleToVoid, nestedBaseTupleToVoid));
+  EXPECT_FALSE(checkIUO(nestedOptTupleToVoid, nestedBaseTupleToVoid));
+  EXPECT_FALSE(checkIUOOverride(nestedOptTupleToVoid, nestedBaseTupleToVoid));
 }
 
 TEST(TypeMatch, OptionalMismatch) {

--- a/unittests/AST/TypeMatchTests.cpp
+++ b/unittests/AST/TypeMatchTests.cpp
@@ -1,4 +1,4 @@
-//===--- OverrideTests.cpp - Tests for overriding logic -------------------===//
+//===--- TypeMatchTests.cpp - Tests for TypeBase::matches -----------------===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -12,26 +12,19 @@
 
 #include "TestContext.h"
 #include "swift/AST/ASTContext.h"
-#include "swift/AST/DiagnosticEngine.h"
-#include "swift/AST/Module.h"
-#include "swift/AST/SearchPathOptions.h"
+#include "swift/AST/Decl.h"
 #include "swift/AST/Types.h"
-#include "swift/Basic/LangOptions.h"
-#include "swift/Basic/SourceManager.h"
-#include "swift/Strings.h"
-#include "swift/Subsystems.h"
-#include "llvm/ADT/Triple.h"
-#include "llvm/Support/Host.h"
 #include "gtest/gtest.h"
 
 using namespace swift;
 using namespace swift::unittest;
 
-TEST(Override, IdenticalTypes) {
+TEST(TypeMatch, IdenticalTypes) {
   TestContext C;
 
   auto check = [&C](Type ty) {
-    return ty->canOverride(ty, OverrideMatchMode::Strict, /*resolver*/nullptr);
+    return ty->matches(ty, TypeMatchOptions(), /*resolver*/nullptr) &&
+        ty->matches(ty, TypeMatchFlags::AllowOverride, /*resolver*/nullptr);
   };
 
   EXPECT_TRUE(check(C.Ctx.TheEmptyTupleType));
@@ -53,12 +46,13 @@ TEST(Override, IdenticalTypes) {
   EXPECT_TRUE(check(structToStructFn));
 }
 
-TEST(Override, UnrelatedTypes) {
+TEST(TypeMatch, UnrelatedTypes) {
   TestContext C;
 
   auto check = [&C](Type base, Type derived) {
-    return derived->canOverride(base, OverrideMatchMode::Strict,
-                                /*resolver*/nullptr);
+    return derived->matches(base, TypeMatchOptions(), /*resolver*/nullptr) &&
+        derived->matches(base, TypeMatchFlags::AllowOverride,
+                         /*resolver*/nullptr);
   };
 
   EXPECT_FALSE(check(C.Ctx.TheEmptyTupleType, C.Ctx.TheRawPointerType));
@@ -104,12 +98,13 @@ TEST(Override, UnrelatedTypes) {
   EXPECT_FALSE(check(anotherStructToAnotherStructFn, S2ASFn));
 }
 
-TEST(Override, Classes) {
+TEST(TypeMatch, Classes) {
   TestContext C;
 
   auto check = [&C](Type base, Type derived) {
-    return derived->canOverride(base, OverrideMatchMode::Strict,
-                                /*resolver*/nullptr);
+    return derived->matches(base, TypeMatchFlags::AllowOverride,
+                            /*resolver*/nullptr) &&
+        !derived->matches(base, TypeMatchOptions(), /*resolver*/nullptr);
   };
 
   auto *baseClass = C.makeNominal<ClassDecl>("Base");
@@ -145,12 +140,13 @@ TEST(Override, Classes) {
   EXPECT_FALSE(check(subToSub, baseToBase));
 }
 
-TEST(Override, Optionals) {
+TEST(TypeMatch, Optionals) {
   TestContext C{DeclareOptionalTypes};
 
   auto check = [&C](Type base, Type derived) {
-    return derived->canOverride(base, OverrideMatchMode::Strict,
-                                /*resolver*/nullptr);
+    return derived->matches(base, TypeMatchFlags::AllowOverride,
+                            /*resolver*/nullptr) &&
+        !derived->matches(base, TypeMatchOptions(), /*resolver*/nullptr);
   };
 
   auto *baseClass = C.makeNominal<ClassDecl>("Base");
@@ -176,17 +172,22 @@ TEST(Override, Optionals) {
   EXPECT_FALSE(check(optToOpt, baseToBase));
 }
 
-TEST(Override, IUONearMatch) {
+TEST(TypeMatch, IUONearMatch) {
   TestContext C{DeclareOptionalTypes};
 
   auto check = [&C](Type base, Type derived) {
-    return derived->canOverride(base, OverrideMatchMode::Strict,
-                                /*resolver*/nullptr);
+    return derived->matches(base, TypeMatchFlags::AllowOverride,
+                            /*resolver*/nullptr) &&
+        !derived->matches(base, TypeMatchOptions(), /*resolver*/nullptr);
   };
   auto checkIUO = [&C](Type base, Type derived) {
-    return derived->canOverride(base,
-                                OverrideMatchMode::AllowNonOptionalForIUOParam,
-                                /*resolver*/nullptr);
+    return derived->matches(base, TypeMatchFlags::AllowNonOptionalForIUOParam,
+                            /*resolver*/nullptr);
+  };
+  auto checkIUOOverride = [&C](Type base, Type derived) {
+    TypeMatchOptions matchMode = TypeMatchFlags::AllowOverride;
+    matchMode |= TypeMatchFlags::AllowNonOptionalForIUOParam;
+    return derived->matches(base, matchMode, /*resolver*/nullptr);
   };
 
   auto *baseClass = C.makeNominal<ClassDecl>("Base");
@@ -196,37 +197,47 @@ TEST(Override, IUONearMatch) {
   Type baseToVoid = FunctionType::get(baseTy, C.Ctx.TheEmptyTupleType);
   Type optToVoid = FunctionType::get(optTy, C.Ctx.TheEmptyTupleType);
   EXPECT_TRUE(check(baseToVoid, optToVoid));
-  EXPECT_TRUE(checkIUO(baseToVoid, optToVoid));
+  EXPECT_FALSE(checkIUO(baseToVoid, optToVoid));
+  EXPECT_TRUE(checkIUOOverride(baseToVoid, optToVoid));
   EXPECT_FALSE(check(optToVoid, baseToVoid));
   EXPECT_TRUE(checkIUO(optToVoid, baseToVoid));
+  EXPECT_TRUE(checkIUOOverride(optToVoid, baseToVoid));
 
   Type voidToBase = FunctionType::get(C.Ctx.TheEmptyTupleType, baseTy);
   Type voidToOpt = FunctionType::get(C.Ctx.TheEmptyTupleType, optTy);
   EXPECT_FALSE(check(voidToBase, voidToOpt));
   EXPECT_FALSE(checkIUO(voidToBase, voidToOpt));
+  EXPECT_FALSE(checkIUOOverride(voidToBase, voidToOpt));
   EXPECT_TRUE(check(voidToOpt, voidToBase));
-  EXPECT_TRUE(checkIUO(voidToOpt, voidToBase));
+  EXPECT_FALSE(checkIUO(voidToOpt, voidToBase));
+  EXPECT_TRUE(checkIUOOverride(voidToOpt, voidToBase));
 
   Type baseToBase = FunctionType::get(baseTy, baseTy);
   Type optToOpt = FunctionType::get(optTy, optTy);
   EXPECT_FALSE(check(baseToBase, optToOpt));
   EXPECT_FALSE(checkIUO(baseToBase, optToOpt));
+  EXPECT_FALSE(checkIUOOverride(baseToBase, optToOpt));
   EXPECT_FALSE(check(optToOpt, baseToBase));
-  EXPECT_TRUE(checkIUO(optToOpt, baseToBase));
+  EXPECT_FALSE(checkIUO(optToOpt, baseToBase));
+  EXPECT_TRUE(checkIUOOverride(optToOpt, baseToBase));
 }
 
-TEST(Override, OptionalMismatch) {
+TEST(TypeMatch, OptionalMismatch) {
   TestContext C{DeclareOptionalTypes};
 
   auto check = [&C](Type base, Type derived) {
-    return derived->canOverride(base, OverrideMatchMode::Strict,
-                                /*resolver*/nullptr);
+    return derived->matches(base, TypeMatchFlags::AllowOverride,
+                            /*resolver*/nullptr) &&
+        !derived->matches(base, TypeMatchOptions(), /*resolver*/nullptr);
   };
   auto checkOpt = [&C](Type base, Type derived) {
-    return derived->canOverride(
-        base,
-        OverrideMatchMode::AllowTopLevelOptionalMismatch,
-        /*resolver*/nullptr);
+    return derived->matches(base, TypeMatchFlags::AllowTopLevelOptionalMismatch,
+                            /*resolver*/nullptr);
+  };
+  auto checkOptOverride = [&C](Type base, Type derived) {
+    TypeMatchOptions matchMode = TypeMatchFlags::AllowOverride;
+    matchMode |= TypeMatchFlags::AllowTopLevelOptionalMismatch;
+    return derived->matches(base, matchMode, /*resolver*/nullptr);
   };
 
   auto *baseClass = C.makeNominal<ClassDecl>("Base");
@@ -237,30 +248,62 @@ TEST(Override, OptionalMismatch) {
   Type optToVoid = FunctionType::get(optTy, C.Ctx.TheEmptyTupleType);
   EXPECT_TRUE(check(baseToVoid, optToVoid));
   EXPECT_TRUE(checkOpt(baseToVoid, optToVoid));
+  EXPECT_TRUE(checkOptOverride(baseToVoid, optToVoid));
   EXPECT_FALSE(check(optToVoid, baseToVoid));
   EXPECT_TRUE(checkOpt(optToVoid, baseToVoid));
+  EXPECT_TRUE(checkOptOverride(optToVoid, baseToVoid));
 
   Type voidToBase = FunctionType::get(C.Ctx.TheEmptyTupleType, baseTy);
   Type voidToOpt = FunctionType::get(C.Ctx.TheEmptyTupleType, optTy);
   EXPECT_FALSE(check(voidToBase, voidToOpt));
   EXPECT_TRUE(checkOpt(voidToBase, voidToOpt));
+  EXPECT_TRUE(checkOptOverride(voidToBase, voidToOpt));
   EXPECT_TRUE(check(voidToOpt, voidToBase));
   EXPECT_TRUE(checkOpt(voidToOpt, voidToBase));
+  EXPECT_TRUE(checkOptOverride(voidToOpt, voidToBase));
 
   Type baseToBase = FunctionType::get(baseTy, baseTy);
   Type optToOpt = FunctionType::get(optTy, optTy);
   EXPECT_FALSE(check(baseToBase, optToOpt));
   EXPECT_TRUE(checkOpt(baseToBase, optToOpt));
+  EXPECT_TRUE(checkOptOverride(baseToBase, optToOpt));
   EXPECT_FALSE(check(optToOpt, baseToBase));
   EXPECT_TRUE(checkOpt(optToOpt, baseToBase));
+  EXPECT_TRUE(checkOptOverride(optToOpt, baseToBase));
+
+  auto *subClass = C.makeNominal<ClassDecl>("Sub");
+  subClass->setSuperclass(baseTy);
+  Type subTy = subClass->getDeclaredInterfaceType();
+  Type optSubTy = OptionalType::get(subTy);
+
+  EXPECT_FALSE(check(baseTy, optSubTy));
+  EXPECT_FALSE(checkOpt(baseTy, optSubTy));
+  EXPECT_TRUE(checkOptOverride(baseTy, optSubTy));
+  EXPECT_TRUE(check(optTy, subTy));
+  EXPECT_FALSE(checkOpt(optTy, subTy));
+  EXPECT_TRUE(checkOptOverride(optTy, subTy));
+  EXPECT_TRUE(check(optTy, optSubTy));
+  EXPECT_FALSE(checkOpt(optTy, optSubTy));
+  EXPECT_TRUE(checkOptOverride(optTy, optSubTy));
+
+  EXPECT_FALSE(check(optSubTy, baseTy));
+  EXPECT_FALSE(checkOpt(optSubTy, baseTy));
+  EXPECT_FALSE(checkOptOverride(optSubTy, baseTy));
+  EXPECT_FALSE(check(subTy, optTy));
+  EXPECT_FALSE(checkOpt(subTy, optTy));
+  EXPECT_FALSE(checkOptOverride(subTy, optTy));
+  EXPECT_FALSE(check(optSubTy, optTy));
+  EXPECT_FALSE(checkOpt(optSubTy, optTy));
+  EXPECT_FALSE(checkOptOverride(optSubTy, optTy));
 }
 
-TEST(Override, OptionalMismatchTuples) {
+TEST(TypeMatch, OptionalMismatchTuples) {
   TestContext C{DeclareOptionalTypes};
 
-  auto check = [&C](Type base, Type derived) {
-    return derived->canOverride(base, OverrideMatchMode::Strict,
-                                /*resolver*/nullptr);
+  auto checkOverride = [&C](Type base, Type derived) {
+    return derived->matches(base, TypeMatchFlags::AllowOverride,
+                            /*resolver*/nullptr) &&
+        !derived->matches(base, TypeMatchOptions(), /*resolver*/nullptr);
   };
 
   auto *baseClass = C.makeNominal<ClassDecl>("Base");
@@ -272,27 +315,25 @@ TEST(Override, OptionalMismatchTuples) {
   Type baseOptTuple = TupleType::get({baseTy, optTy}, C.Ctx);
   Type optBaseTuple = TupleType::get({optTy, baseTy}, C.Ctx);
 
-  EXPECT_FALSE(check(baseBaseTuple, optOptTuple));
-  EXPECT_FALSE(check(baseBaseTuple, baseOptTuple));
-  EXPECT_FALSE(check(baseBaseTuple, optBaseTuple));
+  EXPECT_FALSE(checkOverride(baseBaseTuple, optOptTuple));
+  EXPECT_FALSE(checkOverride(baseBaseTuple, baseOptTuple));
+  EXPECT_FALSE(checkOverride(baseBaseTuple, optBaseTuple));
 
-  EXPECT_TRUE(check(optOptTuple, baseBaseTuple));
-  EXPECT_TRUE(check(optOptTuple, baseOptTuple));
-  EXPECT_TRUE(check(optOptTuple, optBaseTuple));
+  EXPECT_TRUE(checkOverride(optOptTuple, baseBaseTuple));
+  EXPECT_TRUE(checkOverride(optOptTuple, baseOptTuple));
+  EXPECT_TRUE(checkOverride(optOptTuple, optBaseTuple));
 
-  EXPECT_TRUE(check(baseOptTuple, baseBaseTuple));
-  EXPECT_FALSE(check(baseOptTuple, optOptTuple));
-  EXPECT_FALSE(check(baseOptTuple, optBaseTuple));
+  EXPECT_TRUE(checkOverride(baseOptTuple, baseBaseTuple));
+  EXPECT_FALSE(checkOverride(baseOptTuple, optOptTuple));
+  EXPECT_FALSE(checkOverride(baseOptTuple, optBaseTuple));
 
-  EXPECT_TRUE(check(optBaseTuple, baseBaseTuple));
-  EXPECT_FALSE(check(optBaseTuple, optOptTuple));
-  EXPECT_FALSE(check(optBaseTuple, baseOptTuple));
+  EXPECT_TRUE(checkOverride(optBaseTuple, baseBaseTuple));
+  EXPECT_FALSE(checkOverride(optBaseTuple, optOptTuple));
+  EXPECT_FALSE(checkOverride(optBaseTuple, baseOptTuple));
 
   auto checkOpt = [&C](Type base, Type derived) {
-    return derived->canOverride(
-        base,
-        OverrideMatchMode::AllowTopLevelOptionalMismatch,
-        /*resolver*/nullptr);
+    return derived->matches(base, TypeMatchFlags::AllowTopLevelOptionalMismatch,
+                            /*resolver*/nullptr);
   };
 
   EXPECT_TRUE(checkOpt(baseBaseTuple, optOptTuple));
@@ -312,31 +353,30 @@ TEST(Override, OptionalMismatchTuples) {
   EXPECT_TRUE(checkOpt(optBaseTuple, baseOptTuple));
 
   Type optOfTuple = OptionalType::get(baseBaseTuple);
-  EXPECT_TRUE(check(optOfTuple, baseBaseTuple));
-  EXPECT_FALSE(check(baseBaseTuple, optOfTuple));
+  EXPECT_TRUE(checkOverride(optOfTuple, baseBaseTuple));
+  EXPECT_FALSE(checkOverride(baseBaseTuple, optOfTuple));
   EXPECT_TRUE(checkOpt(optOfTuple, baseBaseTuple));
   EXPECT_TRUE(checkOpt(baseBaseTuple, optOfTuple));
 }
 
-TEST(Override, OptionalMismatchFunctions) {
+TEST(TypeMatch, OptionalMismatchFunctions) {
   TestContext C{DeclareOptionalTypes};
 
-  auto check = [&C](Type base, Type derived) {
-    return derived->canOverride(base, OverrideMatchMode::Strict,
-                                /*resolver*/nullptr);
+  auto checkOverride = [&C](Type base, Type derived) {
+    return derived->matches(base, TypeMatchFlags::AllowOverride,
+                            /*resolver*/nullptr) &&
+        !derived->matches(base, TypeMatchOptions(), /*resolver*/nullptr);
   };
   auto checkOpt = [&C](Type base, Type derived) {
-    return derived->canOverride(
-        base,
-        OverrideMatchMode::AllowTopLevelOptionalMismatch,
-        /*resolver*/nullptr);
+    return derived->matches(base, TypeMatchFlags::AllowTopLevelOptionalMismatch,
+                            /*resolver*/nullptr);
   };
 
   Type voidToVoid = FunctionType::get(C.Ctx.TheEmptyTupleType,
                                       C.Ctx.TheEmptyTupleType);
   Type optVoidToVoid = OptionalType::get(voidToVoid);
-  EXPECT_TRUE(check(optVoidToVoid, voidToVoid));
+  EXPECT_TRUE(checkOverride(optVoidToVoid, voidToVoid));
   EXPECT_TRUE(checkOpt(optVoidToVoid, voidToVoid));
-  EXPECT_FALSE(check(voidToVoid, optVoidToVoid));
+  EXPECT_FALSE(checkOverride(voidToVoid, optVoidToVoid));
   EXPECT_TRUE(checkOpt(voidToVoid, optVoidToVoid));
 }


### PR DESCRIPTION
This lets us serialize that decision, which means we can conceivably *change* the decision in later versions of the compiler without breaking existing code. More immediately, it's groundwork that will eventually allow us to drop decls from the AST without affecting vtable layout.

First half of \<rdar://problem/31878396\> Deserialization: Dropping members from a class affects the layout of its vtable
