### PR TITLE
[benchmark] SR-4780 Can not run performance tests that are not in precommit suite

### DIFF
--- a/benchmark/scripts/Benchmark_Driver
+++ b/benchmark/scripts/Benchmark_Driver
@@ -120,7 +120,10 @@ def instrument_test(driver_path, test, num_samples):
 
 def get_tests(driver_path, args):
     """Return a list of available performance tests"""
-    tests = subprocess.check_output([driver_path, '--list']).split()[2:]
+    driver = ([driver_path, '--list'])
+    if args.benchmarks or args.filters:
+        driver.append('--run-all')
+    tests = subprocess.check_output(driver).split()[2:]
     if args.filters:
         regexes = [re.compile(pattern) for pattern in args.filters]
         return sorted(list(set([name for pattern in regexes


### PR DESCRIPTION
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-4780](https://bugs.swift.org/browse/SR-4780) Can not run performance tests that are not in precommit suite.

Modified driver to honor command line arguments when listing enabled tests. Fixed interaction between filters (positional arguments) and `--run-all` option.

`Benchmark_Driver` lists available benchmarks with `--run-all` option when benchmarks or filters are specified.
