### PR TITLE
[Migrator] Suggest String <-> Substring conversions

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -231,6 +231,12 @@ namespace swift {
     /// Enable keypaths.
     bool EnableExperimentalKeyPaths = false;
 
+    /// When a conversion from String to Substring fails, emit a fix-it to append
+    /// the void subscript '[]'.
+    /// FIXME: Remove this flag when void subscripts are implemented.
+    /// This is used to guard preemptive testing for the fix-it.
+    bool FixStringToSubstringConversions = false;
+
     /// Sets the target we are building for and updates platform conditions
     /// to match.
     ///

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -408,4 +408,9 @@ HelpText<"Diagnostics will be used in editor">;
 def validate_tbd_against_ir: Flag<["-"], "validate-tbd-against-ir">,
     HelpText<"Compare the symbols in the IR against the TBD file that would be generated.">;
 
+// FIXME: Remove this flag when void subscripts are implemented.
+// This is used to guard preemptive testing for the fix-it.
+def fix_string_substring_conversion: Flag<["-"], "fix-string-substring-conversion">,
+    HelpText<"Emit a fix-it to append '[]' to String expressions when converting to Substring.">;
+
 } // end let Flags = [FrontendOption, NoDriverOption, HelpHidden]

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -884,6 +884,12 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
                           const FrontendOptions &FrontendOpts) {
   using namespace options;
 
+  /// FIXME: Remove this flag when void subscripts are implemented.
+  /// This is used to guard preemptive testing for the fix-it.
+  if (Args.hasArg(OPT_fix_string_substring_conversion)) {
+    Opts.FixStringToSubstringConversions = true;
+  }
+
   if (auto A = Args.getLastArg(OPT_swift_version)) {
     auto vers = version::Version::parseVersionString(
       A->getValue(), SourceLoc(), &Diags);

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -3830,6 +3830,45 @@ static bool tryRawRepresentableFixIts(InFlightDiagnostic &diag,
   return false;
 }
 
+/// Try to add a fix-it when converting between a collection and its slice type,
+/// such as String <-> Substring or (eventually) Array <-> ArraySlice
+static bool trySequenceSubsequenceConversionFixIts(InFlightDiagnostic &diag,
+                                                   ConstraintSystem *CS,
+                                                   Type fromType,
+                                                   Type toType,
+                                                   Expr *expr) {
+  if (CS->TC.Context.getStdlibModule() == nullptr) {
+    return false;
+  }
+  auto String = CS->TC.getStringType(CS->DC);
+  auto Substring = CS->TC.getSubstringType(CS->DC);
+
+  /// FIXME: Remove this flag when void subscripts are implemented.
+  /// Make this unconditional and remove the if statement.
+  if (CS->TC.getLangOpts().FixStringToSubstringConversions) {
+    // String -> Substring conversion
+    // Add '[]' void subscript call to turn the whole String into a Substring
+    if (fromType->getCanonicalType() == String->getCanonicalType()) {
+      if (toType->getCanonicalType() == Substring->getCanonicalType()) {
+        diag.fixItInsertAfter(expr->getEndLoc (), "[]");
+        return true;
+      }
+    }
+  }
+
+  // Substring -> String conversion
+  // Wrap in String.init
+  if (fromType->getCanonicalType() == Substring->getCanonicalType()) {
+    if (toType->getCanonicalType() == String->getCanonicalType()) {
+      diag.fixItInsert(expr->getLoc(), "String(");
+      diag.fixItInsertAfter(expr->getSourceRange().End, ")");
+      return true;
+    }
+  }
+
+  return false;
+}
+
 /// Attempts to add fix-its for these two mistakes:
 ///
 /// - Passing an integer with the right type but which is getting wrapped with a
@@ -4267,6 +4306,13 @@ bool FailureDiagnosis::diagnoseContextualConversionError() {
   InFlightDiagnostic diag = diagnose(expr->getLoc(), diagID,
                                      exprType, contextualType);
   diag.highlight(expr->getSourceRange());
+
+  // Try to convert between a sequence and its subsequence, notably
+  // String <-> Substring.
+  if (trySequenceSubsequenceConversionFixIts(diag, CS, exprType, contextualType,
+                                             expr)) {
+    return true;
+  }
 
   // Attempt to add a fixit for the error.
   switch (CS->getContextualTypePurpose()) {

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -100,6 +100,9 @@ static Type getStdlibType(TypeChecker &TC, Type &cached, DeclContext *dc,
 Type TypeChecker::getStringType(DeclContext *dc) {
   return ::getStdlibType(*this, StringType, dc, "String");
 }
+Type TypeChecker::getSubstringType(DeclContext *dc) {
+  return ::getStdlibType(*this, SubstringType, dc, "Substring");
+}
 Type TypeChecker::getIntType(DeclContext *dc) {
   return ::getStdlibType(*this, IntType, dc, "Int");
 }

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -790,6 +790,7 @@ private:
   Type ImageLiteralType;
   Type FileReferenceLiteralType;
   Type StringType;
+  Type SubstringType;
   Type IntType;
   Type Int8Type;
   Type UInt8Type;
@@ -881,6 +882,7 @@ public:
   Type getOptionalType(SourceLoc loc, Type elementType);
   Type getImplicitlyUnwrappedOptionalType(SourceLoc loc, Type elementType);
   Type getStringType(DeclContext *dc);
+  Type getSubstringType(DeclContext *dc);
   Type getIntType(DeclContext *dc);
   Type getInt8Type(DeclContext *dc);
   Type getUInt8Type(DeclContext *dc);

--- a/test/Migrator/Inputs/string_to_substring_conversion.swift
+++ b/test/Migrator/Inputs/string_to_substring_conversion.swift
@@ -1,46 +1,80 @@
-let s = "foo"
+// RUN: %target-swift-frontend -typecheck -verify fix-string-substring-conversion %s
+
+let s = "Hello"
 let ss = s[s.startIndex..<s.endIndex]
 
-// CTP_ReturnStmt
-func returnStringButWantedSubstring() -> Substring {
-  return s
+// CTP_Initialization
+do {
+  let s1: Substring = { return s }()
+  _ = s1
 }
+
+// CTP_ReturnStmt
+do {
+  func returnsASubstring() -> Substring {
+    return s
+  }
+}
+
+// CTP_ThrowStmt
+// Doesn't really make sense for this fix-it - see case in diagnoseContextualConversionError:
+// The conversion destination of throw is always ErrorType (at the moment)
+// if this ever expands, this should be a specific form like () is for
+// return.
+
+// CTP_EnumCaseRawValue
+// Substrings can't be raw values because they aren't literals.
 
 // CTP_DefaultParameter
-// Never do this.
-func defaultArgIsSubstring(ss: Substring = s) {}
+do {
+  func foo(x: Substring = s) {}
+}
 
 // CTP_CalleeResult
-func returnString() -> String {
-  return s
+do {
+  func getString() -> String { return s }
+  let gottenSubstring: Substring = getString()
+  _ = gottenSubstring
 }
-let s2: Substring = returnString()
 
 // CTP_CallArgument
-func takeString(s: String) {}
-func takeSubstring(ss: Substring) {}
-
-takeSubstring(ss)
-takeSubstring(s)
+do {
+  func takesASubstring(_ ss: Substring) {}
+  takesASubstring(s)
+}
 
 // CTP_ClosureResult
-[1,2,3].map { (x: Int) -> Substring in
-  return s
+do {
+  [s].map { (x: String) -> Substring in x }
 }
 
 // CTP_ArrayElement
-let a: [Substring] = [ s ]
+do {
+  let a: [Substring] = [ s ]
+  _ = a
+}
 
 // CTP_DictionaryKey
+do {
+  let d: [ Substring : Substring ] = [ s : ss ]
+  _ = d
+}
+
 // CTP_DictionaryValue
-let d: [Substring : Substring] = [
-  "CTP_DictionaryValue" : s,
-  s : "CTP_DictionaryKey",
-]
+do {
+  let d: [ Substring : Substring ] = [ ss : s ]
+  _ = d
+}
 
 // CTP_CoerceOperand
-let s3: Substring = s as Substring
+do {
+  let s1: Substring = s as Substring
+  _ = s1
+}
 
 // CTP_AssignSource
-let s4: Substring = s
+do {
+  let s1: Substring = s
+  _ = s1
+}
 

--- a/test/Migrator/Inputs/substring_to_string_conversion.swift
+++ b/test/Migrator/Inputs/substring_to_string_conversion.swift
@@ -1,46 +1,78 @@
-let s = "foo"
+let s = "Hello"
 let ss = s[s.startIndex..<s.endIndex]
 
-// CTP_ReturnStmt
-
-func returnSubstringButWantedString() -> String {
-  return ss
+// CTP_Initialization
+do {
+  let s1: String = { return ss }()
+  _ = s1
 }
+
+// CTP_ReturnStmt
+do {
+  func returnsAString() -> String {
+    return ss
+  }
+}
+
+// CTP_ThrowStmt
+// Doesn't really make sense for this fix-it - see case in diagnoseContextualConversionError:
+// The conversion destination of throw is always ErrorType (at the moment)
+// if this ever expands, this should be a specific form like () is for
+// return.
+
+// CTP_EnumCaseRawValue
+// Substrings can't be raw values because they aren't literals.
 
 // CTP_DefaultParameter
-
-// Never do this.
-func defaultArgIsString(s: String = ss) {}
+do {
+  func foo(x: String = ss) {}
+}
 
 // CTP_CalleeResult
-func returnSubstring() -> Substring {
-  return ss
+do {
+  func getSubstring() -> Substring { return ss }
+  let gottenString : String = getSubstring()
+  _ = gottenString
 }
-let s2: String = returnSubstring()
 
 // CTP_CallArgument
-func takeString(_ s: String) {}
-
-takeString(s)
-takeString(ss)
+do {
+  func takesAString(_ s: String) {}
+  takesAString(ss)
+}
 
 // CTP_ClosureResult
-[1,2,3].map { (x: Int) -> String in
-  return ss
+do {
+  [ss].map { (x: Substring) -> String in x }
 }
 
 // CTP_ArrayElement
-let a: [String] = [ ss ]
+do {
+  let a: [String] = [ ss ]
+  _ = a
+}
 
 // CTP_DictionaryKey
+do {
+  let d: [ String : String ] = [ ss : s ]
+  _ = d
+}
+
 // CTP_DictionaryValue
-let d: [String : String] = [
-  "CTP_DictionaryValue" : ss,
-  ss : "CTP_DictionaryKey",
-]
+do {
+  let d: [ String : String ] = [ s : ss ]
+  _ = d
+}
 
 // CTP_CoerceOperand
-let s3: String = ss as String
+do {
+  let s1: String = ss as String
+  _ = s1
+}
 
 // CTP_AssignSource
-let s4: String = ss
+do {
+  let s1: String = ss
+  _ = s1
+}
+

--- a/test/Migrator/string_to_substring_conversion.swift.expected
+++ b/test/Migrator/string_to_substring_conversion.swift.expected
@@ -1,46 +1,80 @@
-let s = "foo"
+// RUN: %target-swift-frontend -typecheck -verify fix-string-substring-conversion %s
+
+let s = "Hello"
 let ss = s[s.startIndex..<s.endIndex]
 
-// CTP_ReturnStmt
-func returnStringButWantedSubstring() -> Substring {
-  return s[]
+// CTP_Initialization
+do {
+  let s1: Substring = { return s }()[]
+  _ = s1
 }
+
+// CTP_ReturnStmt
+do {
+  func returnsASubstring() -> Substring {
+    return s[]
+  }
+}
+
+// CTP_ThrowStmt
+// Doesn't really make sense for this fix-it - see case in diagnoseContextualConversionError:
+// The conversion destination of throw is always ErrorType (at the moment)
+// if this ever expands, this should be a specific form like () is for
+// return.
+
+// CTP_EnumCaseRawValue
+// Substrings can't be raw values because they aren't literals.
 
 // CTP_DefaultParameter
-// Never do this.
-func defaultArgIsSubstring(ss: Substring = s[]) {}
+do {
+  func foo(x: Substring = s[]) {}
+}
 
 // CTP_CalleeResult
-func returnString() -> String {
-  return s[]
+do {
+  func getString() -> String { return s[] }
+  let gottenSubstring: Substring = getString()[]
+  _ = gottenSubstring
 }
-let s2: Substring = returnString()[]
 
 // CTP_CallArgument
-func takeString(s: String) {}
-func takeSubstring(ss: Substring) {}
-
-takeSubstring(ss)
-takeSubstring(s[])
+do {
+  func takesASubstring(_ ss: Substring) {}
+  takesASubstring(s[])
+}
 
 // CTP_ClosureResult
-[1,2,3].map { (x: Int) -> Substring in
-  return s[]
+do {
+  [s].map { (x: String) -> Substring in x[] }
 }
 
 // CTP_ArrayElement
-let a: [Substring] = [ s[] ]
+do {
+  let a: [Substring] = [ s[] ]
+  _ = a
+}
 
 // CTP_DictionaryKey
+do {
+  let d: [ Substring : Substring ] = [ s[] : ss ]
+  _ = d
+}
+
 // CTP_DictionaryValue
-let d: [Substring : Substring] = [
-  "CTP_DictionaryValue" : s[],
-  s[] : "CTP_DictionaryKey",
-]
+do {
+  let d: [ Substring : Substring ] = [ ss : s[] ]
+  _ = d
+}
 
 // CTP_CoerceOperand
-let s3: Substring = s[] as Substring
+do {
+  let s1: Substring = s[] as Substring
+  _ = s1
+}
 
 // CTP_AssignSource
-let s4: Substring = s[]
+do {
+  let s1: Substring = s[]
+  _ = s1
+}
 

--- a/test/Migrator/substring_to_string_conversion.swift.expected
+++ b/test/Migrator/substring_to_string_conversion.swift.expected
@@ -1,47 +1,78 @@
-let s = "foo"
+let s = "Hello"
 let ss = s[s.startIndex..<s.endIndex]
 
-// CTP_ReturnStmt
-
-func returnSubstringButWantedString() -> String {
-  return String(ss)
+// CTP_Initialization
+do {
+  let s1: String = String({ return ss }())
+  _ = s1
 }
+
+// CTP_ReturnStmt
+do {
+  func returnsAString() -> String {
+    return String(ss)
+  }
+}
+
+// CTP_ThrowStmt
+// Doesn't really make sense for this fix-it - see case in diagnoseContextualConversionError:
+// The conversion destination of throw is always ErrorType (at the moment)
+// if this ever expands, this should be a specific form like () is for
+// return.
+
+// CTP_EnumCaseRawValue
+// Substrings can't be raw values because they aren't literals.
 
 // CTP_DefaultParameter
-
-// Never do this.
-func defaultArgIsString(s: String = String(ss)) {}
+do {
+  func foo(x: String = String(ss)) {}
+}
 
 // CTP_CalleeResult
-func returnSubstring() -> Substring {
-  return String(ss)
+do {
+  func getSubstring() -> Substring { return ss }
+  let gottenString : String = String(getSubstring())
+  _ = gottenString
 }
-let s2: String = String(returnSubstring())
 
 // CTP_CallArgument
-func takeString(s: String) {}
-func takeSubstring(ss: Substring) {}
-
-takeString(string)
-takeString(String(substring))
+do {
+  func takesAString(_ s: String) {}
+  takesAString(String(ss))
+}
 
 // CTP_ClosureResult
-[1,2,3].map { (x: Int) -> String in
-  return String(ss)
+do {
+  [ss].map { (x: Substring) -> String in String(x) }
 }
 
 // CTP_ArrayElement
-let a: [String] = [ String(ss) ]
+do {
+  let a: [String] = [ String(ss) ]
+  _ = a
+}
 
 // CTP_DictionaryKey
+do {
+  let d: [ String : String ] = [ String(ss) : s ]
+  _ = d
+}
+
 // CTP_DictionaryValue
-let d: [String : String] = [
-  "CTP_DictionaryValue" : String(ss),
-  String(ss) : "CTP_DictionaryKey",
-]
+do {
+  let d: [ String : String ] = [ s : String(ss) ]
+  _ = d
+}
 
 // CTP_CoerceOperand
-let s3: String = String(ss) as String
+do {
+  let s1: String = String(ss) as String
+  _ = s1
+}
 
 // CTP_AssignSource
-let s4: String = String(ss)
+do {
+  let s1: String = String(ss)
+  _ = s1
+}
+

--- a/test/Sema/string_to_substring_conversion.swift
+++ b/test/Sema/string_to_substring_conversion.swift
@@ -1,0 +1,80 @@
+// RUN: %target-swift-frontend -typecheck -verify -fix-string-substring-conversion -swift-version 4 %s
+
+let s = "Hello"
+let ss = s[s.startIndex..<s.endIndex]
+
+// CTP_Initialization
+do {
+  let s1: Substring = { return s }() // expected-error {{cannot convert value of type 'String' to specified type 'Substring'}} {{37-37=[]}}
+  _ = s1
+}
+
+// CTP_ReturnStmt
+do {
+  func returnsASubstring() -> Substring {
+    return s // expected-error {{cannot convert return expression of type 'String' to return type 'Substring'}} {{13-13=[]}}
+  }
+}
+
+// CTP_ThrowStmt
+// Doesn't really make sense for this fix-it - see case in diagnoseContextualConversionError:
+// The conversion destination of throw is always ErrorType (at the moment)
+// if this ever expands, this should be a specific form like () is for
+// return.
+
+// CTP_EnumCaseRawValue
+// Substrings can't be raw values because they aren't literals.
+
+// CTP_DefaultParameter
+do {
+  func foo(x: Substring = s) {} // expected-error {{default argument value of type 'String' cannot be converted to type 'Substring'}} {{28-28=[]}}
+}
+
+// CTP_CalleeResult
+do {
+  func getString() -> String { return s }
+  let gottenSubstring: Substring = getString() // expected-error {{cannot convert value of type 'String' to specified type 'Substring'}} {{47-47=[]}}
+  _ = gottenSubstring
+}
+
+// CTP_CallArgument
+do {
+  func takesASubstring(_ ss: Substring) {}
+  takesASubstring(s) // expected-error {{cannot convert value of type 'String' to expected argument type 'Substring'}} {{20-20=[]}}
+}
+
+// CTP_ClosureResult
+do {
+  [s].map { (x: String) -> Substring in x } // expected-error {{cannot convert value of type 'String' to closure result type 'Substring'}} {{42-42=[]}}
+}
+
+// CTP_ArrayElement
+do {
+  let a: [Substring] = [ s ] // expected-error {{cannot convert value of type 'String' to expected element type 'Substring'}} {{27-27=[]}}
+  _ = a
+}
+
+// CTP_DictionaryKey
+do {
+  let d: [ Substring : Substring ] = [ s : ss ] // expected-error {{cannot convert value of type 'String' to expected dictionary key type 'Substring'}} {{41-41=[]}}
+  _ = d
+}
+
+// CTP_DictionaryValue
+do {
+  let d: [ Substring : Substring ] = [ ss : s ] // expected-error {{cannot convert value of type 'String' to expected dictionary value type 'Substring'}} {{46-46=[]}}
+  _ = d
+}
+
+// CTP_CoerceOperand
+do {
+  let s1: Substring = s as Substring // expected-error {{cannot convert value of type 'String' to type 'Substring' in coercion}} {{24-24=[]}}
+  _ = s1
+}
+
+// CTP_AssignSource
+do {
+  let s1: Substring = s // expected-error {{cannot convert value of type 'String' to specified type 'Substring'}} {{24-24=[]}}
+  _ = s1
+}
+

--- a/test/Sema/substring_to_string_conversion.swift
+++ b/test/Sema/substring_to_string_conversion.swift
@@ -1,0 +1,80 @@
+// RUN: %target-swift-frontend -typecheck -verify -swift-version 4 %s
+
+let s = "Hello"
+let ss = s[s.startIndex..<s.endIndex]
+
+// CTP_Initialization
+do {
+  let s1: String = { return ss }() // expected-error {{cannot convert value of type 'Substring' to specified type 'String'}} {{20-20=String(}} {{35-35=)}}
+  _ = s1
+}
+
+// CTP_ReturnStmt
+do {
+  func returnsAString() -> String {
+    return ss // expected-error {{cannot convert return expression of type 'Substring' to return type 'String'}} {{12-12=String(}} {{14-14=)}}
+  }
+}
+
+// CTP_ThrowStmt
+// Doesn't really make sense for this fix-it - see case in diagnoseContextualConversionError:
+// The conversion destination of throw is always ErrorType (at the moment)
+// if this ever expands, this should be a specific form like () is for
+// return.
+
+// CTP_EnumCaseRawValue
+// Substrings can't be raw values because they aren't literals.
+
+// CTP_DefaultParameter
+do {
+  func foo(x: String = ss) {} // expected-error {{default argument value of type 'Substring' cannot be converted to type 'String'}} {{24-24=String(}} {{26-26=)}}
+}
+
+// CTP_CalleeResult
+do {
+  func getSubstring() -> Substring { return ss }
+  let gottenString : String = getSubstring() // expected-error {{cannot convert value of type 'Substring' to specified type 'String'}} {{31-31=String(}} {{45-45=)}}
+  _ = gottenString
+}
+
+// CTP_CallArgument
+do {
+  func takesAString(_ s: String) {}
+  takesAString(ss) // expected-error {{cannot convert value of type 'Substring' to expected argument type 'String'}} {{16-16=String(}} {{18-18=)}}
+}
+
+// CTP_ClosureResult
+do {
+  [ss].map { (x: Substring) -> String in x } // expected-error {{cannot convert value of type 'Substring' to closure result type 'String'}} {{42-42=String(}} {{43-43=)}}
+}
+
+// CTP_ArrayElement
+do {
+  let a: [String] = [ ss ] // expected-error {{cannot convert value of type 'Substring' to expected element type 'String'}} {{23-23=String(}} {{25-25=)}}
+  _ = a
+}
+
+// CTP_DictionaryKey
+do {
+  let d: [ String : String ] = [ ss : s ] // expected-error {{cannot convert value of type 'Substring' to expected dictionary key type 'String'}} {{34-34=String(}} {{36-36=)}}
+  _ = d
+}
+
+// CTP_DictionaryValue
+do {
+  let d: [ String : String ] = [ s : ss ] // expected-error {{cannot convert value of type 'Substring' to expected dictionary value type 'String'}} {{38-38=String(}} {{40-40=)}}
+  _ = d
+}
+
+// CTP_CoerceOperand
+do {
+  let s1: String = ss as String // expected-error {{cannot convert value of type 'Substring' to type 'String' in coercion}} {{20-20=String(}} {{22-22=)}}
+  _ = s1
+}
+
+// CTP_AssignSource
+do {
+  let s1: String = ss // expected-error {{cannot convert value of type 'Substring' to specified type 'String'}} {{20-20=String(}} {{22-22=)}}
+  _ = s1
+}
+


### PR DESCRIPTION
Some APIs that expected a String now expect a Substring and vice
versa. To ease the transition, emit fix-its on conversion errors
between these types that the migrator can pick up.

When converting from Substring -> String, suggest wrapping in
`String.init`.

When converting from String -> Substring, suggest appending the
void subscript `[]`. (This isn't implemented yet so this is
hidden behind a flag).

This can possibly be generalized later when converting between
some sequence and its subsequence, such as Array and ArraySlice,
for example.

rdar://problem/31665649
rdar://problem/31666638