### PR TITLE
[Clang importer] Look through typealiases when importing members of swift_wrappers

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -7361,7 +7361,8 @@ ClangImporter::Implementation::importDeclContextOf(
     auto importedDecl = importDecl(context.getTypedefName(), CurrentVersion);
     if (!importedDecl) return nullptr;
 
-    importedDC = dyn_cast_or_null<DeclContext>(importedDecl);
+    // Dig out the imported DeclContext.
+    importedDC = dynCastIgnoringCompatibilityAlias<NominalTypeDecl>(importedDecl);
     break;
   }
 

--- a/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/APINotesFrameworkTest.apinotes
+++ b/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/APINotesFrameworkTest.apinotes
@@ -106,4 +106,5 @@ SwiftVersions:
     Typedefs:
       - Name: SomeCAlias
         SwiftName: ImportantCAlias
-
+      - Name: EnclosingStructIdentifier
+        SwiftName: EnclosingStructIdentifier

--- a/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/APINotesFrameworkTest.h
+++ b/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/APINotesFrameworkTest.h
@@ -26,3 +26,4 @@ __attribute__((objc_root_class))
 #import <APINotesFrameworkTest/Properties.h>
 #import <APINotesFrameworkTest/Protocols.h>
 #import <APINotesFrameworkTest/Types.h>
+#import <APINotesFrameworkTest/SwiftWrapper.h>

--- a/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/SwiftWrapper.h
+++ b/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/SwiftWrapper.h
@@ -1,0 +1,6 @@
+typedef _Bool EnclosingStructIdentifier
+  __attribute__((swift_wrapper(struct))) __attribute__((swift_name("EnclosingStruct.Identifier")));
+
+struct EnclosingStruct { };
+
+extern const EnclosingStructIdentifier EnclosingStructIdentifierMember;

--- a/test/APINotes/versioned.swift
+++ b/test/APINotes/versioned.swift
@@ -84,9 +84,11 @@ func testAKA(structValue: ImportantCStruct, aliasValue: ImportantCAlias) {
   let _: Int = optAliasValue
   // CHECK-DIAGS-3: versioned.swift:[[@LINE-1]]:16: error: cannot convert value of type 'Optional<ImportantCAlias>' (aka 'Optional<Int32>') to specified type 'Int'
 }
+
 #endif
 
 #if !swift(>=4)
+
 func useSwift3Name(_: ImportantCStruct) {}
 // CHECK-SILGEN-3: sil hidden @_T09versioned13useSwift3NameySo20VeryImportantCStructVF
 
@@ -97,3 +99,17 @@ func useNewlyNested(_: InnerInSwift4) {}
 func useSwift4Name(_: VeryImportantCStruct) {}
 // CHECK-SILGEN: sil hidden @_T09versioned13useSwift4NameySo20VeryImportantCStructVF
 
+
+
+#if swift(>=4)
+func testSwiftWrapperInSwift4() {
+  _ = EnclosingStruct.Identifier.member
+  let _: EnclosingStruct.Identifier = .member
+}
+
+#else
+func testSwiftWrapperInSwift3() {
+  _ = EnclosingStruct.Identifier.member
+  let _: EnclosingStruct.Identifier = .member
+}
+#endif


### PR DESCRIPTION
When a swift_wrapper'd type is renamed from Swift 3 -> 4, we create a
typealias for it. We need to look through that typealias when
deserializing members of that type, e.g., global variables of the
swift_wrapper'd type.

(cherry picked from commit 5934a865661e3585e35e59bb44427b8a95648476)

Fixes rdar://problem/31939047.