### PR TITLE
[gardening] Remove redundant repetition of type names (DRY): RepeatedTypeName foo = dyn_cast<RepeatedTypeName>(bar)

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -1271,7 +1271,7 @@ public:
   template <typename ATTR>
   ATTR *getAttribute(bool AllowInvalid = false) {
     for (auto Attr : *this)
-      if (ATTR *SpecificAttr = dyn_cast<ATTR>(Attr))
+      if (auto *SpecificAttr = dyn_cast<ATTR>(Attr))
         if (SpecificAttr->isValid() || AllowInvalid)
           return SpecificAttr;
     return nullptr;

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -4587,9 +4587,9 @@ inline TupleTypeElt::TupleTypeElt(Type ty, Identifier name, bool isVariadic,
 
 inline Type TupleTypeElt::getVarargBaseTy(Type VarArgT) {
   TypeBase *T = VarArgT.getPointer();
-  if (ArraySliceType *AT = dyn_cast<ArraySliceType>(T))
+  if (auto *AT = dyn_cast<ArraySliceType>(T))
     return AT->getBaseType();
-  if (BoundGenericType *BGT = dyn_cast<BoundGenericType>(T)) {
+  if (auto *BGT = dyn_cast<BoundGenericType>(T)) {
     // It's the stdlib Array<T>.
     return BGT->getGenericArgs()[0];
   }

--- a/include/swift/SIL/PatternMatch.h
+++ b/include/swift/SIL/PatternMatch.h
@@ -77,7 +77,7 @@ struct bind_ty {
 
   template<typename ITy>
   bool match(ITy *V) {
-    if (Class *CV = dyn_cast<Class>(V)) {
+    if (auto *CV = dyn_cast<Class>(V)) {
       VR = CV;
       return true;
     }

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -349,7 +349,7 @@ SILCloner<ImplClass>::remapValue(SILValue Value) {
   if (VI != ValueMap.end())
     return VI->second;
 
-  if (SILInstruction* I = dyn_cast<SILInstruction>(Value)) {
+  if (auto *I = dyn_cast<SILInstruction>(Value)) {
     auto II = InstructionMap.find(I);
     if (II != InstructionMap.end())
       return SILValue(II->second);
@@ -357,7 +357,7 @@ SILCloner<ImplClass>::remapValue(SILValue Value) {
   }
 
   // If we have undef, just remap the type.
-  if (SILUndef *U = dyn_cast<SILUndef>(Value)) {
+  if (auto *U = dyn_cast<SILUndef>(Value)) {
     auto type = getOpType(U->getType());
     ValueBase *undef =
       (type == U->getType() ? U : SILUndef::get(type, Builder.getModule()));

--- a/include/swift/SIL/TypeSubstCloner.h
+++ b/include/swift/SIL/TypeSubstCloner.h
@@ -113,7 +113,7 @@ protected:
     Builder.setCurrentDebugScope(super::getOpScope(Inst->getDebugScope()));
     SILValue CalleeVal = Inst->getCallee();
     if (!Inlining) {
-      FunctionRefInst *FRI = dyn_cast<FunctionRefInst>(CalleeVal);
+      auto *FRI = dyn_cast<FunctionRefInst>(CalleeVal);
       if (FRI && FRI->getReferencedFunction() == Inst->getFunction() &&
           Inst->getSubstitutions() == this->ApplySubs) {
         FRI = Builder.createFunctionRef(getOpLocation(Inst->getLoc()),
@@ -147,7 +147,7 @@ protected:
     Builder.setCurrentDebugScope(super::getOpScope(Inst->getDebugScope()));
     SmallVector<Substitution, 16> TempSubstList;
     if (!Inlining) {
-      FunctionRefInst *FRI = dyn_cast<FunctionRefInst>(CalleeVal);
+      auto *FRI = dyn_cast<FunctionRefInst>(CalleeVal);
       if (FRI && FRI->getReferencedFunction() == Inst->getFunction()) {
         auto LoweredFnTy = Builder.getFunction().getLoweredFunctionType();
         auto GenSig = LoweredFnTy->getGenericSignature();

--- a/include/swift/SILOptimizer/Analysis/EpilogueARCAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/EpilogueARCAnalysis.h
@@ -161,7 +161,7 @@ public:
       return true;
     // Handle self-recursion. A self-recursion can be considered a +1 on the
     // current argument.
-    if (ApplyInst *AI = dyn_cast<ApplyInst>(II))
+    if (auto *AI = dyn_cast<ApplyInst>(II))
      if (AI->getCalleeFunction() == II->getParent()->getParent())
        return true;
     return false;
@@ -192,7 +192,7 @@ public:
     // We are checking for retain. If this is a self-recursion. call
     // to the function (which returns an owned value) can be treated as
     // the retain instruction.
-    if (ApplyInst *AI = dyn_cast<ApplyInst>(II))
+    if (auto *AI = dyn_cast<ApplyInst>(II))
      if (AI->getCalleeFunction() == II->getParent()->getParent())
        return true;
     // Check whether this is a retain instruction and the argument it

--- a/include/swift/SILOptimizer/PassManager/PassManager.h
+++ b/include/swift/SILOptimizer/PassManager/PassManager.h
@@ -118,7 +118,7 @@ public:
   template<typename T>
   T *getAnalysis() {
     for (SILAnalysis *A : Analysis)
-      if (T *R = llvm::dyn_cast<T>(A))
+      if (auto *R = llvm::dyn_cast<T>(A))
         return R;
 
     llvm_unreachable("Unable to find analysis for requested type.");

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -641,7 +641,7 @@ static VarDecl *getPointeeProperty(VarDecl *&cache,
   if (results.size() != 1) return nullptr;
 
   // The property must have type T.
-  VarDecl *property = dyn_cast<VarDecl>(results[0]);
+  auto *property = dyn_cast<VarDecl>(results[0]);
   if (!property) return nullptr;
   if (!property->getInterfaceType()->isEqual(sig->getGenericParams()[0]))
     return nullptr;
@@ -873,7 +873,7 @@ FuncDecl *ASTContext::getEqualIntDecl() const {
   // Find the overload for Int.
   for (ValueDecl *vd : equalFuncs) {
     // All "==" decls should be functions, but who knows...
-    FuncDecl *funcDecl = dyn_cast<FuncDecl>(vd);
+    auto *funcDecl = dyn_cast<FuncDecl>(vd);
     if (!funcDecl)
       continue;
 

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -699,9 +699,9 @@ namespace {
 
       OS << ' ';
       printDeclName(VD);
-      if (AbstractFunctionDecl *AFD = dyn_cast<AbstractFunctionDecl>(VD))
+      if (auto *AFD = dyn_cast<AbstractFunctionDecl>(VD))
         printGenericParameters(OS, AFD->getGenericParams());
-      if (GenericTypeDecl *GTD = dyn_cast<GenericTypeDecl>(VD))
+      if (auto *GTD = dyn_cast<GenericTypeDecl>(VD))
         printGenericParameters(OS, GTD->getGenericParams());
 
       if (auto *var = dyn_cast<VarDecl>(VD)) {
@@ -1365,9 +1365,9 @@ public:
     PrintWithColorRAII(OS, ASTNodeColor) << Name;
     for (auto Elt : Elements) {
       OS << '\n';
-      if (Expr *SubExpr = Elt.dyn_cast<Expr*>())
+      if (auto *SubExpr = Elt.dyn_cast<Expr*>())
         printRec(SubExpr);
-      else if (Stmt *SubStmt = Elt.dyn_cast<Stmt*>())
+      else if (auto *SubStmt = Elt.dyn_cast<Stmt*>())
         printRec(SubStmt);
       else
         printRec(Elt.get<Decl*>());

--- a/lib/AST/ASTNode.cpp
+++ b/lib/AST/ASTNode.cpp
@@ -23,11 +23,11 @@
 using namespace swift;
 
 SourceRange ASTNode::getSourceRange() const {
-  if (const Expr *E = this->dyn_cast<Expr*>())
+  if (const auto *E = this->dyn_cast<Expr*>())
     return E->getSourceRange();
-  if (const Stmt *S = this->dyn_cast<Stmt*>())
+  if (const auto *S = this->dyn_cast<Stmt*>())
     return S->getSourceRange();
-  if (const Decl *D = this->dyn_cast<Decl*>())
+  if (const auto *D = this->dyn_cast<Decl*>())
     return D->getSourceRange();
   llvm_unreachable("unsupported AST node");
 }
@@ -43,12 +43,12 @@ SourceLoc ASTNode::getEndLoc() const {
 }
 
 DeclContext *ASTNode::getAsDeclContext() const {
-  if (Expr *E = this->dyn_cast<Expr*>()) {
+  if (auto *E = this->dyn_cast<Expr*>()) {
     if (isa<AbstractClosureExpr>(E))
       return static_cast<AbstractClosureExpr*>(E);
   } else if (is<Stmt*>()) {
     return nullptr;
-  } else if (Decl *D = this->dyn_cast<Decl*>()) {
+  } else if (auto *D = this->dyn_cast<Decl*>()) {
     if (isa<DeclContext>(D))
       return cast<DeclContext>(D);
   } else if (getOpaqueValue())
@@ -57,31 +57,31 @@ DeclContext *ASTNode::getAsDeclContext() const {
 }
 
 bool ASTNode::isImplicit() const {
-  if (const Expr *E = this->dyn_cast<Expr*>())
+  if (const auto *E = this->dyn_cast<Expr*>())
     return E->isImplicit();
-  if (const Stmt *S = this->dyn_cast<Stmt*>())
+  if (const auto *S = this->dyn_cast<Stmt*>())
     return S->isImplicit();
-  if (const Decl *D = this->dyn_cast<Decl*>())
+  if (const auto *D = this->dyn_cast<Decl*>())
     return D->isImplicit();
   llvm_unreachable("unsupported AST node");
 }
 
 void ASTNode::walk(ASTWalker &Walker) {
-  if (Expr *E = this->dyn_cast<Expr*>())
+  if (auto *E = this->dyn_cast<Expr*>())
     E->walk(Walker);
-  else if (Stmt *S = this->dyn_cast<Stmt*>())
+  else if (auto *S = this->dyn_cast<Stmt*>())
     S->walk(Walker);
-  else if (Decl *D = this->dyn_cast<Decl*>())
+  else if (auto *D = this->dyn_cast<Decl*>())
     D->walk(Walker);
   else
     llvm_unreachable("unsupported AST node");
 }
 void ASTNode::walk(SourceEntityWalker &Walker) {
-  if (Expr *E = this->dyn_cast<Expr*>())
+  if (auto *E = this->dyn_cast<Expr*>())
     Walker.walk(E);
-  else if (Stmt *S = this->dyn_cast<Stmt*>())
+  else if (auto *S = this->dyn_cast<Stmt*>())
     Walker.walk(S);
-  else if (Decl *D = this->dyn_cast<Decl*>())
+  else if (auto *D = this->dyn_cast<Decl*>())
     Walker.walk(D);
   else
     llvm_unreachable("unsupported AST node");

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -56,7 +56,7 @@ struct SynthesizedExtensionAnalyzer::Implementation {
   static bool isMemberFavored(const NominalTypeDecl* Target, const Decl* D) {
     DeclContext* DC = Target->getInnermostDeclContext();
     Type BaseTy = Target->getDeclaredTypeInContext();
-    const FuncDecl *FD = dyn_cast<FuncDecl>(D);
+    const auto *FD = dyn_cast<FuncDecl>(D);
     if (!FD)
       return true;
     ResolvedMemberResult Result = resolveValueMember(*DC, BaseTy,
@@ -1627,7 +1627,7 @@ static bool shouldPrintAsFavorable(const Decl *D, PrintOptions &Options) {
     return true;
   NominalTypeDecl *Target = Options.TransformContext->getNominal();
   Type BaseTy = Target->getDeclaredTypeInContext();
-  const FuncDecl *FD = dyn_cast<FuncDecl>(D);
+  const auto *FD = dyn_cast<FuncDecl>(D);
   if (!FD)
     return true;
   ResolvedMemberResult Result = resolveValueMember(*Target->getDeclContext(),

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -366,7 +366,7 @@ public:
     /// Helper template for dispatching post-visitation.
     template <class T> T dispatchVisitPost(T node) {
       // Verify source ranges if the AST node was parsed from source.
-      SourceFile *SF = M.dyn_cast<SourceFile *>();
+      auto *SF = M.dyn_cast<SourceFile *>();
       if (SF) {
         // If we are inside an implicit BraceStmt, don't verify source
         // locations.  LLDB creates implicit BraceStmts which contain a mix of
@@ -817,7 +817,7 @@ public:
     void verifyChecked(ReturnStmt *S) {
       auto func = Functions.back();
       Type resultType;
-      if (FuncDecl *FD = dyn_cast<FuncDecl>(func)) {
+      if (auto *FD = dyn_cast<FuncDecl>(func)) {
         resultType = FD->getResultInterfaceType();
         resultType = FD->mapTypeIntoContext(resultType);
       } else if (auto closure = dyn_cast<AbstractClosureExpr>(func)) {
@@ -905,7 +905,7 @@ public:
     }
 
     Type checkAssignDest(Expr *Dest) {
-      if (TupleExpr *TE = dyn_cast<TupleExpr>(Dest)) {
+      if (auto *TE = dyn_cast<TupleExpr>(Dest)) {
         SmallVector<TupleTypeElt, 4> lhsTupleTypes;
         for (unsigned i = 0; i != TE->getNumElements(); ++i) {
           Type SubType = checkAssignDest(TE->getElement(i));
@@ -1523,7 +1523,7 @@ public:
       // a computed property or if the base is a protocol or existential.
       if (auto *baseIOT = E->getBase()->getType()->getAs<InOutType>()) {
         if (!baseIOT->getObjectType()->is<ArchetypeType>()) {
-          VarDecl *VD = dyn_cast<VarDecl>(E->getMember().getDecl());
+          auto *VD = dyn_cast<VarDecl>(E->getMember().getDecl());
           if (!VD || !VD->hasAccessorFunctions()) {
             Out << "member_ref_expr on value of inout type\n";
             E->dump(Out);
@@ -2154,7 +2154,7 @@ public:
       if (normal->isLazilyResolved()) return;
 
       // Translate the owning declaration into a DeclContext.
-      NominalTypeDecl *nominal = dyn_cast<NominalTypeDecl>(decl);
+      auto *nominal = dyn_cast<NominalTypeDecl>(decl);
       DeclContext *conformingDC;
       if (nominal) {
         conformingDC = nominal;

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -1198,7 +1198,7 @@ Stmt *Traversal::visitThrowStmt(ThrowStmt *TS) {
 
 Stmt *Traversal::visitBraceStmt(BraceStmt *BS) {
   for (auto &Elem : BS->getElements()) {
-    if (Expr *SubExpr = Elem.dyn_cast<Expr*>()) {
+    if (auto *SubExpr = Elem.dyn_cast<Expr*>()) {
       if (Expr *E2 = doIt(SubExpr))
         Elem = E2;
       else
@@ -1206,7 +1206,7 @@ Stmt *Traversal::visitBraceStmt(BraceStmt *BS) {
       continue;
     }
 
-    if (Stmt *S = Elem.dyn_cast<Stmt*>()) {
+    if (auto *S = Elem.dyn_cast<Stmt*>()) {
       if (Stmt *S2 = doIt(S))
         Elem = S2;
       else

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -377,7 +377,7 @@ bool AbstractFunctionDecl::isTransparent() const {
 
   // If this is an accessor, check if the transparent attribute was set
   // on the value decl.
-  if (const FuncDecl *FD = dyn_cast<FuncDecl>(this)) {
+  if (const auto *FD = dyn_cast<FuncDecl>(this)) {
     if (auto *ASD = FD->getAccessorStorageDecl())
       return ASD->isTransparent();
   }
@@ -2699,7 +2699,7 @@ AbstractFunctionDecl *
 ClassDecl::findOverridingDecl(const AbstractFunctionDecl *Method) const {
   auto Members = getMembers();
   for (auto M : Members) {
-    AbstractFunctionDecl *CurMethod = dyn_cast<AbstractFunctionDecl>(M);
+    auto *CurMethod = dyn_cast<AbstractFunctionDecl>(M);
     if (!CurMethod)
       continue;
     if (CurMethod->isOverridingDecl(Method)) {
@@ -2726,7 +2726,7 @@ ClassDecl::findImplementingMethod(const AbstractFunctionDecl *Method) const {
   while (C) {
     auto Members = C->getMembers();
     for (auto M : Members) {
-      AbstractFunctionDecl *CurMethod = dyn_cast<AbstractFunctionDecl>(M);
+      auto *CurMethod = dyn_cast<AbstractFunctionDecl>(M);
       if (!CurMethod)
         continue;
       if (Method == CurMethod)
@@ -4138,9 +4138,9 @@ SourceRange ParamDecl::getSourceRange() const {
 
 Type ParamDecl::getVarargBaseTy(Type VarArgT) {
   TypeBase *T = VarArgT.getPointer();
-  if (ArraySliceType *AT = dyn_cast<ArraySliceType>(T))
+  if (auto *AT = dyn_cast<ArraySliceType>(T))
     return AT->getBaseType();
-  if (BoundGenericType *BGT = dyn_cast<BoundGenericType>(T)) {
+  if (auto *BGT = dyn_cast<BoundGenericType>(T)) {
     // It's the stdlib Array<T>.
     return BGT->getGenericArgs()[0];
   }

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -175,10 +175,10 @@ SourceLoc Expr::getLoc() const {
 }
 
 Expr *Expr::getSemanticsProvidingExpr() {
-  if (IdentityExpr *IE = dyn_cast<IdentityExpr>(this))
+  if (auto *IE = dyn_cast<IdentityExpr>(this))
     return IE->getSubExpr()->getSemanticsProvidingExpr();
 
-  if (TryExpr *TE = dyn_cast<TryExpr>(this))
+  if (auto *TE = dyn_cast<TryExpr>(this))
     return TE->getSubExpr()->getSemanticsProvidingExpr();
 
   return this;
@@ -1491,7 +1491,7 @@ DictionaryExpr *DictionaryExpr::create(ASTContext &C, SourceLoc LBracketLoc,
 }
 
 static ValueDecl *getCalledValue(Expr *E) {
-  if (DeclRefExpr *DRE = dyn_cast<DeclRefExpr>(E))
+  if (auto *DRE = dyn_cast<DeclRefExpr>(E))
     return DRE->getDecl();
 
   Expr *E2 = E->getValueProvidingExpr();

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -1750,8 +1750,8 @@ PotentialArchetype *PotentialArchetype::updateNestedTypeForConformance(
 PotentialArchetype *PotentialArchetype::updateNestedTypeForConformance(
                       PointerUnion<AssociatedTypeDecl *, TypeAliasDecl *> type,
                       NestedTypeUpdate kind) {
-  AssociatedTypeDecl *assocType = type.dyn_cast<AssociatedTypeDecl *>();
-  TypeAliasDecl *typealias = type.dyn_cast<TypeAliasDecl *>();
+  auto *assocType = type.dyn_cast<AssociatedTypeDecl *>();
+  auto *typealias = type.dyn_cast<TypeAliasDecl *>();
   if (!assocType && !typealias)
     return nullptr;
 
@@ -2888,7 +2888,7 @@ ConstraintResult GenericSignatureBuilder::addTypeRequirement(
   if (!constraintType->isExistentialType() &&
       !constraintType->getClassOrBoundGenericClass()) {
     if (source.getLoc().isValid() && !constraintType->hasError()) {
-      Type subjectType = subject.dyn_cast<Type>();
+      auto subjectType = subject.dyn_cast<Type>();
       if (!subjectType)
         subjectType = subject.get<PotentialArchetype *>()
                         ->getDependentType(Impl->GenericParams,

--- a/lib/AST/LookupVisibleDecls.cpp
+++ b/lib/AST/LookupVisibleDecls.cpp
@@ -568,7 +568,7 @@ static void lookupVisibleMemberDeclsImpl(
     lookupDeclsFromProtocolsBeingConformedTo(BaseTy, Consumer, LS, CurrDC,
                                              Reason, TypeResolver, Visited);
     // If we have a class type, look into its superclass.
-    ClassDecl *CurClass = dyn_cast<ClassDecl>(CurNominal);
+    auto *CurClass = dyn_cast<ClassDecl>(CurNominal);
 
     if (CurClass && CurClass->hasSuperclass()) {
       assert(BaseTy.getPointer() != CurClass->getSuperclass().getPointer() &&

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -181,23 +181,23 @@ template<typename Range>
 void SourceLookupCache::doPopulateCache(Range decls,
                                         bool onlyOperators) {
   for (Decl *D : decls) {
-    if (ValueDecl *VD = dyn_cast<ValueDecl>(D))
+    if (auto *VD = dyn_cast<ValueDecl>(D))
       if (onlyOperators ? VD->isOperator() : VD->hasName()) {
         // Cache the value under both its compound name and its full name.
         TopLevelValues.add(VD);
       }
-    if (NominalTypeDecl *NTD = dyn_cast<NominalTypeDecl>(D))
+    if (auto *NTD = dyn_cast<NominalTypeDecl>(D))
       doPopulateCache(NTD->getMembers(), true);
-    if (ExtensionDecl *ED = dyn_cast<ExtensionDecl>(D))
+    if (auto *ED = dyn_cast<ExtensionDecl>(D))
       doPopulateCache(ED->getMembers(), true);
   }
 }
 
 void SourceLookupCache::populateMemberCache(const SourceFile &SF) {
   for (const Decl *D : SF.Decls) {
-    if (const NominalTypeDecl *NTD = dyn_cast<NominalTypeDecl>(D)) {
+    if (const auto *NTD = dyn_cast<NominalTypeDecl>(D)) {
       addToMemberCache(NTD->getMembers());
-    } else if (const ExtensionDecl *ED = dyn_cast<ExtensionDecl>(D)) {
+    } else if (const auto *ED = dyn_cast<ExtensionDecl>(D)) {
       addToMemberCache(ED->getMembers());
     }
   }

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -719,14 +719,14 @@ UnqualifiedLookup::UnqualifiedLookup(DeclName Name, DeclContext *DC,
           }
           if (!isCascadingUse.hasValue())
             isCascadingUse = ACE->isCascadingContextForLookup(false);
-        } else if (ExtensionDecl *ED = dyn_cast<ExtensionDecl>(DC)) {
+        } else if (auto *ED = dyn_cast<ExtensionDecl>(DC)) {
           ExtendedType = ED->getSelfTypeInContext();
 
           BaseDecl = ED->getAsNominalTypeOrNominalTypeExtensionContext();
           MetaBaseDecl = BaseDecl;
           if (!isCascadingUse.hasValue())
             isCascadingUse = ED->isCascadingContextForLookup(false);
-        } else if (NominalTypeDecl *ND = dyn_cast<NominalTypeDecl>(DC)) {
+        } else if (auto *ND = dyn_cast<NominalTypeDecl>(DC)) {
           ExtendedType = ND->getDeclaredType();
           BaseDecl = ND;
           MetaBaseDecl = BaseDecl;

--- a/lib/AST/NameLookupImpl.h
+++ b/lib/AST/NameLookupImpl.h
@@ -101,7 +101,7 @@ public:
 
   void checkSourceFile(const SourceFile &SF) {
     for (Decl *D : SF.Decls)
-      if (TopLevelCodeDecl *TLCD = dyn_cast<TopLevelCodeDecl>(D))
+      if (auto *TLCD = dyn_cast<TopLevelCodeDecl>(D))
         visitBraceStmt(TLCD->getBody(), /*isTopLevel=*/true);
   }
 
@@ -174,7 +174,7 @@ private:
       return;
     visit(S->getBody());
     for (Decl *D : S->getInitializerVarDecls()) {
-      if (ValueDecl *VD = dyn_cast<ValueDecl>(D))
+      if (auto *VD = dyn_cast<ValueDecl>(D))
         checkValueDecl(VD, DeclVisibilityKind::LocalVariable);
     }
   }
@@ -196,12 +196,12 @@ private:
     }
 
     for (auto elem : S->getElements()) {
-      if (Stmt *S = elem.dyn_cast<Stmt*>())
+      if (auto *S = elem.dyn_cast<Stmt*>())
         visit(S);
     }
     for (auto elem : S->getElements()) {
-      if (Decl *D = elem.dyn_cast<Decl*>()) {
-        if (ValueDecl *VD = dyn_cast<ValueDecl>(D))
+      if (auto *D = elem.dyn_cast<Decl*>()) {
+        if (auto *VD = dyn_cast<ValueDecl>(D))
           checkValueDecl(VD, DeclVisibilityKind::LocalVariable);
       }
     }

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3936,7 +3936,7 @@ bool Type::isPrivateStdlibType(bool whitelistProtocols) const {
     return false;
 
   // A 'public' typealias can have an 'internal' type.
-  if (NameAliasType *NAT = dyn_cast<NameAliasType>(Ty.getPointer()))
+  if (auto *NAT = dyn_cast<NameAliasType>(Ty.getPointer()))
     return NAT->getDecl()->isPrivateStdlibDecl(whitelistProtocols);
 
   if (auto Paren = dyn_cast<ParenType>(Ty.getPointer()))

--- a/lib/AST/USRGeneration.cpp
+++ b/lib/AST/USRGeneration.cpp
@@ -149,13 +149,13 @@ static bool shouldUseObjCUSR(const Decl *D) {
                  isa<TypeDecl>(D))) // nested types aren't supported
     return false;
 
-  if (const ValueDecl *VD = dyn_cast<ValueDecl>(D)) {
+  if (const auto *VD = dyn_cast<ValueDecl>(D)) {
     if (isa<EnumElementDecl>(VD))
       return true;
     return objc_translation::isVisibleToObjC(VD, Accessibility::Internal);
   }
 
-  if (const ExtensionDecl *ED = dyn_cast<ExtensionDecl>(D)) {
+  if (const auto *ED = dyn_cast<ExtensionDecl>(D)) {
     if (auto ExtendedType = ED->getExtendedType()) {
       auto baseClass = ExtendedType->getClassOrBoundGenericClass();
       return baseClass && shouldUseObjCUSR(baseClass) && !baseClass->isForeign();

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -2255,7 +2255,7 @@ static unsigned printActions(const Action *A,
   llvm::raw_string_ostream os(str);
 
   os << Action::getClassName(A->getKind()) << ", ";
-  if (const InputAction *IA = dyn_cast<InputAction>(A)) {
+  if (const auto *IA = dyn_cast<InputAction>(A)) {
     os << "\"" << IA->getInputArg().getValue() << "\"";
   } else {
     os << "{";

--- a/lib/Driver/Job.cpp
+++ b/lib/Driver/Job.cpp
@@ -117,7 +117,7 @@ void Job::printSummary(raw_ostream &os) const {
   SmallVector<std::string, 4> Inputs;
 
   for (const Action *A : getSource().getInputs())
-    if (const InputAction *IA = dyn_cast<InputAction>(A))
+    if (const auto *IA = dyn_cast<InputAction>(A))
       Inputs.push_back(IA->getInputArg().getValue());
 
   for (const Job *J : getInputs())

--- a/lib/Driver/OutputFileMap.cpp
+++ b/lib/Driver/OutputFileMap.cpp
@@ -105,7 +105,7 @@ bool OutputFileMap::parse(std::unique_ptr<llvm::MemoryBuffer> Buffer) {
   if (!Root)
     return true;
 
-  llvm::yaml::MappingNode *Map = dyn_cast<llvm::yaml::MappingNode>(Root);
+  auto *Map = dyn_cast<llvm::yaml::MappingNode>(Root);
   if (!Map)
     return true;
 
@@ -119,7 +119,7 @@ bool OutputFileMap::parse(std::unique_ptr<llvm::MemoryBuffer> Buffer) {
     if (!Value)
       return true;
 
-    llvm::yaml::ScalarNode *InputPath = dyn_cast<llvm::yaml::ScalarNode>(Key);
+    auto *InputPath = dyn_cast<llvm::yaml::ScalarNode>(Key);
     if (!InputPath)
       return true;
 
@@ -134,11 +134,11 @@ bool OutputFileMap::parse(std::unique_ptr<llvm::MemoryBuffer> Buffer) {
       llvm::yaml::Node *Key = OutputPair.getKey();
       llvm::yaml::Node *Value = OutputPair.getValue();
 
-      llvm::yaml::ScalarNode *KindNode = dyn_cast<llvm::yaml::ScalarNode>(Key);
+      auto *KindNode = dyn_cast<llvm::yaml::ScalarNode>(Key);
       if (!KindNode)
         return true;
 
-      llvm::yaml::ScalarNode *Path = dyn_cast<llvm::yaml::ScalarNode>(Value);
+      auto *Path = dyn_cast<llvm::yaml::ScalarNode>(Value);
       if (!Path)
         return true;
 

--- a/lib/Driver/ParseableOutput.cpp
+++ b/lib/Driver/ParseableOutput.cpp
@@ -109,7 +109,7 @@ public:
     wrapper.flush();
 
     for (const Action *A : Cmd.getSource().getInputs()) {
-      if (const InputAction *IA = dyn_cast<InputAction>(A))
+      if (const auto *IA = dyn_cast<InputAction>(A))
         Inputs.push_back(CommandInput(IA->getInputArg().getValue()));
     }
 

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -975,7 +975,7 @@ static bool dumpAPI(ModuleDecl *Mod, StringRef OutDir) {
   }
 
   for (auto *FU : Mod->getFiles()) {
-    if (SourceFile *SF = dyn_cast<SourceFile>(FU))
+    if (auto *SF = dyn_cast<SourceFile>(FU))
       if (dumpFile(SF))
         return true;
   }

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -4250,7 +4250,7 @@ public:
   void foundDecl(ValueDecl *D, DeclVisibilityKind Reason) override {
     if (Reason == DeclVisibilityKind::MemberOfCurrentNominal) {
       if (isa<TypeAliasDecl>(D)) {
-        ValueDecl *VD = dyn_cast<ValueDecl>(D);
+        auto *VD = dyn_cast<ValueDecl>(D);
         SatisfiedAssociatedTypes.insert(VD->getName().str());
       }
       return;

--- a/lib/IDE/IDETypeChecking.cpp
+++ b/lib/IDE/IDETypeChecking.cpp
@@ -25,7 +25,7 @@ collectDefaultImplementationForProtocolMembers(ProtocolDecl *PD,
   DeclContext *DC = PD->getInnermostDeclContext();
   auto HandleMembers = [&](DeclRange Members) {
     for (Decl *D : Members) {
-      ValueDecl *VD = dyn_cast<ValueDecl>(D);
+      auto *VD = dyn_cast<ValueDecl>(D);
 
       // Skip non-value decl.
       if (!VD)
@@ -51,6 +51,6 @@ collectDefaultImplementationForProtocolMembers(ProtocolDecl *PD,
 
   // Collect the default implementations for the members in the inherited
   // protocols.
-  for (auto* IP : PD->getInheritedProtocols())
+  for (auto *IP : PD->getInheritedProtocols())
     HandleMembers(IP->getMembers());
 }

--- a/lib/IDE/SwiftSourceDocInfo.cpp
+++ b/lib/IDE/SwiftSourceDocInfo.cpp
@@ -130,7 +130,7 @@ bool SemaLocResolver::walkToDeclPre(Decl *D, CharSourceRange Range) {
   if (isa<ExtensionDecl>(D))
     return true;
 
-  if (ValueDecl *VD = dyn_cast<ValueDecl>(D))
+  if (auto *VD = dyn_cast<ValueDecl>(D))
     return !tryResolve(VD, /*CtorTyRef=*/nullptr, /*ExtTyRef=*/nullptr,
                        Range.getStart(), /*IsRef=*/false);
 
@@ -930,7 +930,7 @@ void swift::ide::getLocationInfo(const ValueDecl *VD,
 std::vector<CharSourceRange> swift::ide::
 getCallArgLabelRanges(SourceManager &SM, Expr *Arg, LabelRangeEndAt EndKind) {
   std::vector<CharSourceRange> Ranges;
-  if (TupleExpr *TE = dyn_cast<TupleExpr>(Arg)) {
+  if (auto *TE = dyn_cast<TupleExpr>(Arg)) {
     size_t ElemIndex = 0;
     for (Expr *Elem : TE->getElements()) {
       SourceLoc LabelStart(Elem->getStartLoc());
@@ -946,7 +946,7 @@ getCallArgLabelRanges(SourceManager &SM, Expr *Arg, LabelRangeEndAt EndKind) {
       Ranges.push_back(CharSourceRange(SM, LabelStart, LabelEnd));
       ++ElemIndex;
     }
-  } else if (ParenExpr *PE = dyn_cast<ParenExpr>(Arg)) {
+  } else if (auto *PE = dyn_cast<ParenExpr>(Arg)) {
     if (PE->getSubExpr())
       Ranges.push_back(CharSourceRange(PE->getSubExpr()->getStartLoc(), 0));
   }

--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -716,9 +716,9 @@ std::pair<bool, Stmt *> ModelASTWalker::walkToStmtPre(Stmt *S) {
         return { false, nullptr };
 
       for (auto &Element : Clause.Elements) {
-        if (Expr *E = Element.dyn_cast<Expr*>()) {
+        if (auto *E = Element.dyn_cast<Expr*>()) {
           E->walk(*this);
-        } else if (Stmt *S = Element.dyn_cast<Stmt*>()) {
+        } else if (auto *S = Element.dyn_cast<Stmt*>()) {
           S->walk(*this);
         } else {
           Element.get<Decl*>()->walk(*this);
@@ -761,7 +761,7 @@ bool ModelASTWalker::walkToDeclPre(Decl *D) {
     return false;
 
   if (auto *AFD = dyn_cast<AbstractFunctionDecl>(D)) {
-    FuncDecl *FD = dyn_cast<FuncDecl>(AFD);
+    auto *FD = dyn_cast<FuncDecl>(AFD);
     if (FD && FD->isAccessor()) {
       // Pass context sensitive keyword token.
       SourceLoc SL = FD->getFuncLoc();

--- a/lib/IDE/TypeReconstruction.cpp
+++ b/lib/IDE/TypeReconstruction.cpp
@@ -669,7 +669,7 @@ static TypeBase *FixCallingConv(Decl *in_decl, TypeBase *in_type) {
   if (!in_decl)
     return in_type;
 
-  AnyFunctionType *func_type = dyn_cast<AnyFunctionType>(in_type);
+  auto *func_type = dyn_cast<AnyFunctionType>(in_type);
   if (func_type) {
     DeclContext *decl_context = in_decl->getDeclContext();
     if (decl_context && decl_context->isTypeContext()) {

--- a/lib/IRGen/GenBuiltin.cpp
+++ b/lib/IRGen/GenBuiltin.cpp
@@ -333,7 +333,7 @@ if (Builtin.ID == BuiltinValueKind::id) { \
       llvm::Instruction *I = static_cast<llvm::Instruction *>(v);
       if (I->getParent() == IGF.Builder.GetInsertBlock()) {
         llvm::LLVMContext &ctx = IGF.IGM.Module.getContext();
-        llvm::IntegerType *intType = dyn_cast<llvm::IntegerType>(v->getType());
+        auto *intType = dyn_cast<llvm::IntegerType>(v->getType());
         llvm::Metadata *rangeElems[] = {
           llvm::ConstantAsMetadata::get(llvm::ConstantInt::get(intType, 0)),
           llvm::ConstantAsMetadata::get(

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -1230,7 +1230,7 @@ void irgen::extractScalarResults(IRGenFunction &IGF, llvm::Type *bodyType,
   if (bodyType != callType)
     returned = IGF.coerceValue(returned, bodyType, IGF.IGM.DataLayout);
 
-  if (llvm::StructType *structType = dyn_cast<llvm::StructType>(bodyType))
+  if (auto *structType = dyn_cast<llvm::StructType>(bodyType))
     for (unsigned i = 0, e = structType->getNumElements(); i != e; ++i)
       out.add(IGF.Builder.CreateExtractValue(returned, i));
   else

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -2214,7 +2214,7 @@ bool irgen::doesClassMetadataRequireDynamicInitialization(IRGenModule &IGM,
 bool irgen::doesConformanceReferenceNominalTypeDescriptor(IRGenModule &IGM,
                                                        CanType conformingType) {
   NominalTypeDecl *nom = conformingType->getAnyNominal();
-  ClassDecl *clas = dyn_cast<ClassDecl>(nom);
+  auto *clas = dyn_cast<ClassDecl>(nom);
   if (nom->isGenericContext() && (!clas || !clas->usesObjCGenericsModel()))
     return true;
 

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -564,7 +564,7 @@ void IRGenModule::emitRuntimeRegistration() {
     for (SILFunction &SF : getSILModule()) {
       if (SF.hasLocation()) {
         if (Decl* D = SF.getLocation().getAsASTNode<Decl>()) {
-          if (FuncDecl *FD = dyn_cast<FuncDecl>(D)) {
+          if (auto *FD = dyn_cast<FuncDecl>(D)) {
             if (FD->getAttrs().hasAttribute<LLDBDebuggerFunctionAttr>()) {
               EntryPoint = &SF;
               break;
@@ -3422,7 +3422,7 @@ IRGenModule::getAddrOfAssociatedTypeWitnessTableAccessFunction(
 static llvm::Function *shouldDefineHelper(IRGenModule &IGM,
                                           llvm::Constant *fn,
                                           bool setIsNoInline) {
-  llvm::Function *def = dyn_cast<llvm::Function>(fn);
+  auto *def = dyn_cast<llvm::Function>(fn);
   if (!def) return nullptr;
   if (!def->empty()) return nullptr;
 

--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -506,7 +506,7 @@ const TypeInfo *TypeConverter::convertBlockStorageType(SILBlockStorageType *T) {
   auto &capture = IGM.getTypeInfoForLowered(T->getCaptureType());
   
   // TODO: Support dynamic-sized captures.
-  const FixedTypeInfo *fixedCapture = dyn_cast<FixedTypeInfo>(&capture);
+  const auto *fixedCapture = dyn_cast<FixedTypeInfo>(&capture);
   llvm::Type *fixedCaptureTy;
   // The block header is pointer aligned. The capture may be worse aligned.
   Alignment align = IGM.getPointerAlignment();

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -779,7 +779,7 @@ namespace {
 
       auto resultMetadata = extractAndMarkResultType(type);
       
-      CanTupleType inputTuple = dyn_cast<TupleType>(type.getInput());
+      auto inputTuple = dyn_cast<TupleType>(type.getInput());
 
       size_t numArguments = 1;
 

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -1738,7 +1738,7 @@ void IRGenModule::emitSILWitnessTable(SILWitnessTable *wt) {
   if (!doesConformanceReferenceNominalTypeDescriptor(*this, conformingType)) {
     // Trigger the lazy emission of the foreign type metadata.
     NominalTypeDecl *Nominal = conformingType->getAnyNominal();
-    if (ClassDecl *clas = dyn_cast<ClassDecl>(Nominal)) {
+    if (auto *clas = dyn_cast<ClassDecl>(Nominal)) {
       if (clas->isForeign())
         getAddrOfForeignTypeMetadataCandidate(conformingType);
     } else if (isa<ClangModuleUnit>(Nominal->getModuleScopeContext())) {

--- a/lib/IRGen/GenValueWitness.cpp
+++ b/lib/IRGen/GenValueWitness.cpp
@@ -1634,7 +1634,7 @@ Address TypeInfo::indexArray(IRGenFunction &IGF, Address base,
   // The stride of a Swift type may not match its LLVM size. If we know we have
   // a fixed stride different from our size, or we have a dynamic size,
   // do a byte-level GEP with the proper stride.
-  const FixedTypeInfo *fixedTI = dyn_cast<FixedTypeInfo>(this);
+  const auto *fixedTI = dyn_cast<FixedTypeInfo>(this);
 
   llvm::Value *destValue = nullptr;
   Size stride(1);

--- a/lib/IRGen/IRBuilder.h
+++ b/lib/IRGen/IRBuilder.h
@@ -134,7 +134,7 @@ public:
     void insert(llvm::Instruction *I) {
       assert(isValid() && "inserting at invalid location!");
       assert(I->getParent() == nullptr);
-      if (llvm::BasicBlock *block = After.dyn_cast<llvm::BasicBlock*>()) {
+      if (auto *block = After.dyn_cast<llvm::BasicBlock*>()) {
         block->getInstList().push_front(I);
       } else {
         llvm::Instruction *afterInsn = After.get<llvm::Instruction*>();

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -876,7 +876,7 @@ static void performParallelIRGeneration(IRGenOptions &Opts,
   irgen.emitGlobalTopLevel();
   
   for (auto *File : M->getFiles()) {
-    if (SourceFile *SF = dyn_cast<SourceFile>(File)) {
+    if (auto *SF = dyn_cast<SourceFile>(File)) {
       IRGenModule *IGM = irgen.getGenModule(SF);
       IGM->emitSourceFile(*SF, 0);
     } else {

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -1737,7 +1737,7 @@ IRGenDebugInfoImpl::emitFunction(const SILDebugScope *DS, llvm::Function *Fn,
 
   // Some IRGen-generated helper functions don't have a corresponding
   // SIL function, hence the dyn_cast.
-  SILFunction *SILFn = DS ? DS->Parent.dyn_cast<SILFunction *>() : nullptr;
+  auto *SILFn = DS ? DS->Parent.dyn_cast<SILFunction *>() : nullptr;
   StringRef LinkageName;
   if (Fn)
     LinkageName = Fn->getName();

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -2797,7 +2797,7 @@ mapTriviallyToInt(IRGenSILFunction &IGF, const EnumImplStrategy &EIS, SelectEnum
     return nullptr;
   
   llvm::Type *type = schema[0].getScalarType();
-  llvm::IntegerType *resultType = dyn_cast<llvm::IntegerType>(type);
+  auto *resultType = dyn_cast<llvm::IntegerType>(type);
   if (!resultType)
     return nullptr;
   
@@ -2813,7 +2813,7 @@ mapTriviallyToInt(IRGenSILFunction &IGF, const EnumImplStrategy &EIS, SelectEnum
     if (index < 0)
       return nullptr;
     
-    IntegerLiteralInst *intLit = dyn_cast<IntegerLiteralInst>(casePair.second);
+    auto *intLit = dyn_cast<IntegerLiteralInst>(casePair.second);
     if (!intLit)
       return nullptr;
     

--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -435,7 +435,7 @@ static bool modifiableApply(ApplySite applySite, irgen::IRGenModule &Mod) {
   auto callee = applySite.getCallee();
   if (isa<ProjectBlockStorageInst>(callee)) {
     return false;
-  } else if (LoadInst *instr = dyn_cast<LoadInst>(callee)) {
+  } else if (auto *instr = dyn_cast<LoadInst>(callee)) {
     auto loadedSrcValue = instr->getOperand();
     if (isa<ProjectBlockStorageInst>(loadedSrcValue)) {
       return false;
@@ -673,31 +673,31 @@ void LoadableStorageAllocation::replaceLoadWithCopyAddr(
       break;
     }
     case ValueKind::RetainValueInst: {
-      RetainValueInst *insToInsert = dyn_cast<RetainValueInst>(userIns);
+      auto *insToInsert = dyn_cast<RetainValueInst>(userIns);
       assert(insToInsert && "Unexpected cast failure");
       pass.retainInstsToMod.push_back(insToInsert);
       break;
     }
     case ValueKind::ReleaseValueInst: {
-      ReleaseValueInst *insToInsert = dyn_cast<ReleaseValueInst>(userIns);
+      auto *insToInsert = dyn_cast<ReleaseValueInst>(userIns);
       assert(insToInsert && "Unexpected cast failure");
       pass.releaseInstsToMod.push_back(insToInsert);
       break;
     }
     case ValueKind::StoreInst: {
-      StoreInst *insToInsert = dyn_cast<StoreInst>(userIns);
+      auto *insToInsert = dyn_cast<StoreInst>(userIns);
       assert(insToInsert && "Unexpected cast failure");
       pass.storeInstsToMod.push_back(insToInsert);
       break;
     }
     case ValueKind::DebugValueInst: {
-      DebugValueInst *insToInsert = dyn_cast<DebugValueInst>(userIns);
+      auto *insToInsert = dyn_cast<DebugValueInst>(userIns);
       assert(insToInsert && "Unexpected cast failure");
       pass.debugInstsToMod.push_back(insToInsert);
       break;
     }
     case ValueKind::StructExtractInst: {
-      StructExtractInst *instToInsert = dyn_cast<StructExtractInst>(userIns);
+      auto *instToInsert = dyn_cast<StructExtractInst>(userIns);
       if (std::find(pass.structExtractInstsToMod.begin(),
                     pass.structExtractInstsToMod.end(),
                     instToInsert) == pass.structExtractInstsToMod.end()) {
@@ -706,7 +706,7 @@ void LoadableStorageAllocation::replaceLoadWithCopyAddr(
       break;
     }
     case ValueKind::SwitchEnumInst: {
-      SwitchEnumInst *instToInsert = dyn_cast<SwitchEnumInst>(userIns);
+      auto *instToInsert = dyn_cast<SwitchEnumInst>(userIns);
       if (std::find(pass.switchEnumInstsToMod.begin(),
                     pass.switchEnumInstsToMod.end(),
                     instToInsert) == pass.switchEnumInstsToMod.end()) {
@@ -815,41 +815,41 @@ void LoadableStorageAllocation::replaceLoadWithCopyAddrForModifiable(
       break;
     }
     case ValueKind::RetainValueInst: {
-      RetainValueInst *insToInsert = dyn_cast<RetainValueInst>(userIns);
+      auto *insToInsert = dyn_cast<RetainValueInst>(userIns);
       assert(insToInsert && "Unexpected cast failure");
       pass.retainInstsToMod.push_back(insToInsert);
       usersToMod.push_back(user);
       break;
     }
     case ValueKind::ReleaseValueInst: {
-      ReleaseValueInst *insToInsert = dyn_cast<ReleaseValueInst>(userIns);
+      auto *insToInsert = dyn_cast<ReleaseValueInst>(userIns);
       assert(insToInsert && "Unexpected cast failure");
       pass.releaseInstsToMod.push_back(insToInsert);
       usersToMod.push_back(user);
       break;
     }
     case ValueKind::StoreInst: {
-      StoreInst *insToInsert = dyn_cast<StoreInst>(userIns);
+      auto *insToInsert = dyn_cast<StoreInst>(userIns);
       assert(insToInsert && "Unexpected cast failure");
       pass.storeInstsToMod.push_back(insToInsert);
       usersToMod.push_back(user);
       break;
     }
     case ValueKind::DebugValueInst: {
-      DebugValueInst *insToInsert = dyn_cast<DebugValueInst>(userIns);
+      auto *insToInsert = dyn_cast<DebugValueInst>(userIns);
       assert(insToInsert && "Unexpected cast failure");
       pass.debugInstsToMod.push_back(insToInsert);
       usersToMod.push_back(user);
       break;
     }
     case ValueKind::StructExtractInst: {
-      StructExtractInst *instToInsert = dyn_cast<StructExtractInst>(userIns);
+      auto *instToInsert = dyn_cast<StructExtractInst>(userIns);
       pass.structExtractInstsToMod.push_back(instToInsert);
       usersToMod.push_back(user);
       break;
     }
     case ValueKind::SwitchEnumInst: {
-      SwitchEnumInst *instToInsert = dyn_cast<SwitchEnumInst>(userIns);
+      auto *instToInsert = dyn_cast<SwitchEnumInst>(userIns);
       pass.switchEnumInstsToMod.push_back(instToInsert);
       usersToMod.push_back(user);
       break;
@@ -1066,7 +1066,7 @@ static void setInstrUsers(StructLoweringState &pass, AllocStackInst *allocInstr,
       if (modifiableApply(site, pass.Mod)) {
         userOp->set(allocInstr);
       }
-    } else if (StoreInst *storeUser = dyn_cast<StoreInst>(user)) {
+    } else if (auto *storeUser = dyn_cast<StoreInst>(user)) {
       // Optimization: replace with copy_addr to reduce code size
       assert(std::find(pass.storeInstsToMod.begin(), pass.storeInstsToMod.end(),
                        storeUser) == pass.storeInstsToMod.end() &&
@@ -1114,7 +1114,7 @@ static void allocateAndSetForArgumentOperand(StructLoweringState &pass,
                                              SILValue value,
                                              SILInstruction *applyInst) {
   assert(value->getType().isObject());
-  SILArgument *arg = dyn_cast<SILArgument>(value);
+  auto *arg = dyn_cast<SILArgument>(value);
   assert(arg && "non-instr operand must be an argmuent");
 
   SILBuilder allocBuilder(pass.F->begin()->begin());
@@ -1303,7 +1303,7 @@ static void rewriteFunction(StructLoweringState &pass,
           // Get its storage location as a new operand
           if (!currOperandInstr) {
             allocateAndSetForArgumentOperand(pass, currOperand, applyInst);
-          } else if (LoadInst *load = dyn_cast<LoadInst>(currOperandInstr)) {
+          } else if (auto *load = dyn_cast<LoadInst>(currOperandInstr)) {
             if (allUsesAreReplaceable(load, pass.Mod)) {
               allocator.replaceLoadWithCopyAddr(load);
             } else {
@@ -1399,34 +1399,34 @@ static void rewriteFunction(StructLoweringState &pass,
     SILInstruction *newInstr = nullptr;
     switch (instr->getKind()) {
     case ValueKind::StructExtractInst: {
-      StructExtractInst *convInstr = dyn_cast<StructExtractInst>(instr);
+      auto *convInstr = dyn_cast<StructExtractInst>(instr);
       newInstr = resultTyBuilder.createStructExtract(
           Loc, convInstr->getOperand(), convInstr->getField(),
           newSILType.getObjectType());
       break;
     }
     case ValueKind::StructElementAddrInst: {
-      StructElementAddrInst *convInstr = dyn_cast<StructElementAddrInst>(instr);
+      auto *convInstr = dyn_cast<StructElementAddrInst>(instr);
       newInstr = resultTyBuilder.createStructElementAddr(
           Loc, convInstr->getOperand(), convInstr->getField(),
           newSILType.getAddressType());
       break;
     }
     case ValueKind::RefTailAddrInst: {
-      RefTailAddrInst *convInstr = dyn_cast<RefTailAddrInst>(instr);
+      auto *convInstr = dyn_cast<RefTailAddrInst>(instr);
       newInstr = resultTyBuilder.createRefTailAddr(Loc, convInstr->getOperand(),
                                                    newSILType.getAddressType());
       break;
     }
     case ValueKind::RefElementAddrInst: {
-      RefElementAddrInst *convInstr = dyn_cast<RefElementAddrInst>(instr);
+      auto *convInstr = dyn_cast<RefElementAddrInst>(instr);
       newInstr = resultTyBuilder.createRefElementAddr(
           Loc, convInstr->getOperand(), convInstr->getField(),
           newSILType.getAddressType());
       break;
     }
     case ValueKind::EnumInst: {
-      EnumInst *convInstr = dyn_cast<EnumInst>(instr);
+      auto *convInstr = dyn_cast<EnumInst>(instr);
       SILValue operand =
           convInstr->hasOperand() ? convInstr->getOperand() : SILValue();
       newInstr = resultTyBuilder.createEnum(
@@ -1472,7 +1472,7 @@ static void rewriteFunction(StructLoweringState &pass,
       break;
     }
     case ValueKind::DynamicMethodInst: {
-      DynamicMethodInst *DMI = dyn_cast<DynamicMethodInst>(instr);
+      auto *DMI = dyn_cast<DynamicMethodInst>(instr);
       assert(DMI && "ValueKind is Witness Method but dyn_cast failed");
       SILValue selfValue = instr->getOperand(0);
       newInstr = methodBuilder.createDynamicMethod(loc, selfValue, member,
@@ -1480,7 +1480,7 @@ static void rewriteFunction(StructLoweringState &pass,
       break;
     }
     case ValueKind::WitnessMethodInst: {
-      WitnessMethodInst *WMI = dyn_cast<WitnessMethodInst>(instr);
+      auto *WMI = dyn_cast<WitnessMethodInst>(instr);
       assert(WMI && "ValueKind is Witness Method but dyn_cast failed");
       newInstr = methodBuilder.createWitnessMethod(
           loc, WMI->getLookupType(), WMI->getConformance(), member, newSILType,
@@ -1640,7 +1640,7 @@ void LoadableByAddress::recreateSingleApply(SILInstruction *applyInst) {
   SILInstruction *newApply = nullptr;
   switch (applyInst->getKind()) {
   case ValueKind::ApplyInst: {
-    ApplyInst *castedApply = dyn_cast<ApplyInst>(applyInst);
+    auto *castedApply = dyn_cast<ApplyInst>(applyInst);
     assert(castedApply && "ValueKind is ApplyInst but cast to it failed");
     newApply = applyBuilder.createApply(castedApply->getLoc(), callee,
                                         newSubType, resultType, newSubs,
@@ -1649,7 +1649,7 @@ void LoadableByAddress::recreateSingleApply(SILInstruction *applyInst) {
     break;
   }
   case ValueKind::TryApplyInst: {
-    TryApplyInst *castedApply = dyn_cast<TryApplyInst>(applyInst);
+    auto *castedApply = dyn_cast<TryApplyInst>(applyInst);
     assert(castedApply && "ValueKind is TryApplyInst but cast to it failed");
     newApply = applyBuilder.createTryApply(
         castedApply->getLoc(), callee, newSubType, newSubs, callArgs,
@@ -1658,7 +1658,7 @@ void LoadableByAddress::recreateSingleApply(SILInstruction *applyInst) {
     break;
   }
   case ValueKind::PartialApplyInst: {
-    PartialApplyInst *castedApply = dyn_cast<PartialApplyInst>(applyInst);
+    auto *castedApply = dyn_cast<PartialApplyInst>(applyInst);
     assert(castedApply &&
            "ValueKind is PartialApplyInst but cast to it failed");
     // Change the type of the Closure
@@ -1772,7 +1772,7 @@ void LoadableByAddress::recreateConvInstrs() {
       break;
     }
     case ValueKind::ConvertFunctionInst: {
-      ConvertFunctionInst *instr = dyn_cast<ConvertFunctionInst>(convInstr);
+      auto *instr = dyn_cast<ConvertFunctionInst>(convInstr);
       assert(instr && "Unexpected conversion instruction");
       newInstr = convBuilder.createConvertFunction(
           instr->getLoc(), instr->getOperand(), newType);

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -105,14 +105,14 @@ public:
   }
 
   StringRef getFilename() const {
-    if (SourceFile *SF = SFOrMod.dyn_cast<SourceFile *>())
+    if (auto *SF = SFOrMod.dyn_cast<SourceFile *>())
       return SF->getFilename();
     return SFOrMod.get<ModuleDecl *>()->getModuleFilename();
   }
 
   void
   getImportedModules(SmallVectorImpl<ModuleDecl::ImportedModule> &Modules) const {
-    if (SourceFile *SF = SFOrMod.dyn_cast<SourceFile *>()) {
+    if (auto *SF = SFOrMod.dyn_cast<SourceFile *>()) {
       SF->getImportedModules(Modules, ModuleDecl::ImportFilter::All);
     } else {
       SFOrMod.get<ModuleDecl *>()->getImportedModules(Modules,
@@ -256,14 +256,14 @@ private:
     // Do not handle unavailable decls.
     if (AvailableAttr::isUnavailable(D))
       return false;
-    if (FuncDecl *FD = dyn_cast<FuncDecl>(D)) {
+    if (auto *FD = dyn_cast<FuncDecl>(D)) {
       if (FD->isAccessor() && getParentDecl() != FD->getAccessorStorageDecl())
         return false; // already handled as part of the var decl.
     }
-    if (ValueDecl *VD = dyn_cast<ValueDecl>(D)) {
+    if (auto *VD = dyn_cast<ValueDecl>(D)) {
       if (!report(VD))
         return false;
-      if (SubscriptDecl *SD = dyn_cast<SubscriptDecl>(VD)) {
+      if (auto *SD = dyn_cast<SubscriptDecl>(VD)) {
         // Avoid indexing the indices, only walk the getter/setter.
         if (SD->getGetter())
           if (SourceEntityWalker::walk(cast<Decl>(SD->getGetter())))
@@ -283,7 +283,7 @@ private:
         return false; // already walked what we needed.
       }
     }
-    if (ExtensionDecl *ED = dyn_cast<ExtensionDecl>(D))
+    if (auto *ED = dyn_cast<ExtensionDecl>(D))
       return reportExtension(ED);
     return true;
   }
@@ -973,7 +973,7 @@ bool IndexSwiftASTWalker::reportRef(ValueDecl *D, SourceLoc Loc,
     return true;
 
   // Report the accessors that were utilized.
-  if (AbstractStorageDecl *ASD = dyn_cast<AbstractStorageDecl>(D)) {
+  if (auto *ASD = dyn_cast<AbstractStorageDecl>(D)) {
     bool UsesGetter = Info.roles & (SymbolRoleSet)SymbolRole::Read;
     bool UsesSetter = Info.roles & (SymbolRoleSet)SymbolRole::Write;
 

--- a/lib/LLVMPasses/LLVMARCOpts.cpp
+++ b/lib/LLVMPasses/LLVMARCOpts.cpp
@@ -548,7 +548,7 @@ static DtorKind analyzeDestructor(Value *P) {
   // We have to have a known heap metadata value, reject dynamically computed
   // ones, or places
   // Also, make sure we have a definitive initializer for the global.
-  GlobalVariable *GV = dyn_cast<GlobalVariable>(P->stripPointerCasts());
+  auto *GV = dyn_cast<GlobalVariable>(P->stripPointerCasts());
   if (GV == nullptr || !GV->hasDefinitiveInitializer())
     return DtorKind::Unknown;
 
@@ -559,7 +559,7 @@ static DtorKind analyzeDestructor(Value *P) {
   // FIXME: Would like to abstract the dtor slot (#0) out from this to somewhere
   // unified.
   enum { DTorSlotOfHeapMetadata = 0 };
-  Function *DtorFn =dyn_cast<Function>(CS->getOperand(DTorSlotOfHeapMetadata));
+  auto *DtorFn = dyn_cast<Function>(CS->getOperand(DTorSlotOfHeapMetadata));
   if (DtorFn == nullptr || DtorFn->isInterposable() ||
       DtorFn->hasExternalLinkage())
     return DtorKind::Unknown;
@@ -635,12 +635,12 @@ static DtorKind analyzeDestructor(Value *P) {
         if (!I.mayHaveSideEffects()) continue;
 
         // store, memcpy, memmove *to* the object can be dropped.
-        if (StoreInst *SI = dyn_cast<StoreInst>(&I)) {
+        if (auto *SI = dyn_cast<StoreInst>(&I)) {
           if (SI->getPointerOperand()->stripInBoundsOffsets() == ThisObject)
             continue;
         }
 
-        if (MemIntrinsic *MI = dyn_cast<MemIntrinsic>(&I)) {
+        if (auto *MI = dyn_cast<MemIntrinsic>(&I)) {
           if (MI->getDest()->stripInBoundsOffsets() == ThisObject)
             continue;
         }
@@ -753,7 +753,7 @@ static bool performStoreOnlyObjectElimination(CallInst &Allocation,
       // object is being stored *to*, not itself being stored (which would be an
       // escape point).  Since stores themselves don't have any uses, we can
       // short-cut the classification scheme above.
-      if (StoreInst *SI = dyn_cast<StoreInst>(User)) {
+      if (auto *SI = dyn_cast<StoreInst>(User)) {
         // If this is a store *to* the object, we can zap it.
         if (UI.getUse().getOperandNo() == StoreInst::getPointerOperandIndex()) {
           InvolvedInstructions.insert(SI);
@@ -762,7 +762,7 @@ static bool performStoreOnlyObjectElimination(CallInst &Allocation,
         // Otherwise, using the object as a source (or size) is an escape.
         return false;
       }
-      if (MemIntrinsic *MI = dyn_cast<MemIntrinsic>(User)) {
+      if (auto *MI = dyn_cast<MemIntrinsic>(User)) {
         // If this is a memset/memcpy/memmove *to* the object, we can zap it.
         if (UI.getUse().getOperandNo() == 0) {
           InvolvedInstructions.insert(MI);

--- a/lib/LLVMPasses/LLVMMergeFunctions.cpp
+++ b/lib/LLVMPasses/LLVMMergeFunctions.cpp
@@ -125,7 +125,7 @@ cmpOperandsIgnoringConsts(const Instruction *L, const Instruction *R,
   if (!isEligibleForConstantSharing(L))
     return Res;
 
-  if (const CallInst *CL = dyn_cast<CallInst>(L)) {
+  if (const auto *CL = dyn_cast<CallInst>(L)) {
     if (CL->isInlineAsm())
       return Res;
     if (Function *CalleeL = CL->getCalledFunction()) {
@@ -672,7 +672,7 @@ void SwiftMergeFunctions::updateUnhandledCalleeCount(FunctionEntry *FE,
   // Iterate over all functions of FE's equivalence class.
   do {
     for (Use &U : FE->F->uses()) {
-      if (Instruction *I = dyn_cast<Instruction>(U.getUser())) {
+      if (auto *I = dyn_cast<Instruction>(U.getUser())) {
         FunctionEntry *CallerFE = getEntry(I->getFunction());
         if (CallerFE && CallerFE->TreeIter != FnTree.end()) {
           // Accumulate the count in the first entry of the equivalence class.
@@ -788,7 +788,7 @@ bool SwiftMergeFunctions::constsDiffer(const FunctionInfos &FInfos,
 
   for (const FunctionInfo &FI : FInfos) {
     Value *Op = FI.CurrentInst->getOperand(OpIdx);
-    if (Constant *C = dyn_cast<Constant>(Op)) {
+    if (auto *C = dyn_cast<Constant>(Op)) {
       if (!CommonConst) {
         CommonConst = C;
       } else if (C != CommonConst) {
@@ -896,7 +896,7 @@ void SwiftMergeFunctions::mergeWithParams(const FunctionInfos &FInfos,
 
     // Collect all functions which are referenced by any parameter.
     for (Value *V : PI.Values) {
-      if (Function *F = dyn_cast<Function>(V))
+      if (auto *F = dyn_cast<Function>(V))
         SelfReferencingFunctions.insert(F);
     }
   }
@@ -1026,7 +1026,7 @@ bool SwiftMergeFunctions::replaceDirectCallers(Function *Old, Function *New,
   SmallVector<CallInst *, 8> Callers;
   
   for (Use &U : Old->uses()) {
-    Instruction *I = dyn_cast<Instruction>(U.getUser());
+    auto *I = dyn_cast<Instruction>(U.getUser());
     if (!I) {
       AllReplaced = false;
       continue;
@@ -1035,7 +1035,7 @@ bool SwiftMergeFunctions::replaceDirectCallers(Function *Old, Function *New,
     if (FE)
       removeEquivalenceClassFromTree(FE);
     
-    CallInst *CI = dyn_cast<CallInst>(I);
+    auto *CI = dyn_cast<CallInst>(I);
     if (!CI || CI->getCalledValue() != Old) {
       AllReplaced = false;
       continue;

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -146,7 +146,7 @@ namespace {
         return false;
       if (!P.CurDeclContext)
         return false;
-      FuncDecl *func_decl = dyn_cast<FuncDecl>(P.CurDeclContext);
+      auto *func_decl = dyn_cast<FuncDecl>(P.CurDeclContext);
       if (!func_decl)
         return false;
         
@@ -251,7 +251,7 @@ bool Parser::parseTopLevel() {
 
   // Add newly parsed decls to the module.
   for (auto Item : Items)
-    if (Decl *D = Item.dyn_cast<Decl*>())
+    if (auto *D = Item.dyn_cast<Decl*>())
       SF.Decls.push_back(D);
 
   // Note that the source file is fully parsed and verify it.
@@ -3962,9 +3962,9 @@ VarDecl *Parser::parseDeclVarGetSet(Pattern *pattern,
   VarDecl *PrimaryVar = nullptr;
   {
     Pattern *PrimaryPattern = pattern;
-    if (TypedPattern *Typed = dyn_cast<TypedPattern>(PrimaryPattern))
+    if (auto *Typed = dyn_cast<TypedPattern>(PrimaryPattern))
       PrimaryPattern = Typed->getSubPattern();
-    if (NamedPattern *Named = dyn_cast<NamedPattern>(PrimaryPattern)) {
+    if (auto *Named = dyn_cast<NamedPattern>(PrimaryPattern)) {
       PrimaryVar = Named->getDecl();
     }
   }
@@ -3977,7 +3977,7 @@ VarDecl *Parser::parseDeclVarGetSet(Pattern *pattern,
   }
 
   TypeLoc TyLoc;
-  if (TypedPattern *TP = dyn_cast<TypedPattern>(pattern)) {
+  if (auto *TP = dyn_cast<TypedPattern>(pattern)) {
     TyLoc = TP->getTypeLoc();
   } else if (!PrimaryVar) {
     TyLoc = TypeLoc::withoutLoc(ErrorType::get(Context));
@@ -4530,7 +4530,7 @@ Parser::parseDeclVar(ParseDeclOptions Flags,
     addPatternVariablesToScope(pattern);
     
     // Propagate back types for simple patterns, like "var A, B : T".
-    if (TypedPattern *TP = dyn_cast<TypedPattern>(pattern)) {
+    if (auto *TP = dyn_cast<TypedPattern>(pattern)) {
       if (isa<NamedPattern>(TP->getSubPattern()) && PatternInit == nullptr) {
         for (unsigned i = PBDEntries.size() - 1; i != 0; --i) {
           Pattern *PrevPat = PBDEntries[i-1].getPattern();

--- a/lib/Parse/ParseSIL.cpp
+++ b/lib/Parse/ParseSIL.cpp
@@ -4955,7 +4955,7 @@ bool Parser::parseSILVTable() {
     return true;
   }
 
-  ClassDecl *theClass = dyn_cast<ClassDecl>(VD);
+  auto *theClass = dyn_cast<ClassDecl>(VD);
   if (!theClass) {
     diagnose(Loc, diag::sil_vtable_class_not_found, Name);
     return true;
@@ -5020,7 +5020,7 @@ static ProtocolDecl *parseProtocolDecl(Parser &P, SILParser &SP) {
     P.diagnose(DeclLoc, diag::sil_witness_protocol_not_found, DeclName);
     return nullptr;
   }
-  ProtocolDecl *proto = dyn_cast<ProtocolDecl>(VD);
+  auto *proto = dyn_cast<ProtocolDecl>(VD);
   if (!proto)
     P.diagnose(DeclLoc, diag::sil_witness_protocol_not_found, DeclName);
   return proto;

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -394,11 +394,11 @@ ParserStatus Parser::parseBraceItems(SmallVectorImpl<ASTNode> &Entries,
 
     if (!NeedParseErrorRecovery && Tok.is(tok::semi)) {
       PreviousHadSemi = true;
-      if (Expr *E = Result.dyn_cast<Expr*>())
+      if (auto *E = Result.dyn_cast<Expr*>())
         E->TrailingSemiLoc = consumeToken(tok::semi);
-      else if (Stmt *S = Result.dyn_cast<Stmt*>())
+      else if (auto *S = Result.dyn_cast<Stmt*>())
         S->TrailingSemiLoc = consumeToken(tok::semi);
-      else if (Decl *D = Result.dyn_cast<Decl*>())
+      else if (auto *D = Result.dyn_cast<Decl*>())
         D->TrailingSemiLoc = consumeToken(tok::semi);
       else
         assert(!Result && "Unsupported AST node");

--- a/lib/SIL/Projection.cpp
+++ b/lib/SIL/Projection.cpp
@@ -803,7 +803,7 @@ SILValue Projection::getOperandForAggregate(SILInstruction *I) const {
     case ProjectionKind::Index:
       break;
     case ProjectionKind::Enum:
-      if (EnumInst *EI = dyn_cast<EnumInst>(I)) {
+      if (auto *EI = dyn_cast<EnumInst>(I)) {
         if (EI->getElement() == getEnumElementDecl(I->getType())) {
           assert(EI->hasOperand() && "expected data operand");
           return EI->getOperand();

--- a/lib/SIL/SILDeclRef.cpp
+++ b/lib/SIL/SILDeclRef.cpp
@@ -297,21 +297,21 @@ SILDeclRef::SILDeclRef(SILDeclRef::Loc baseLoc,
  : isDirectReference(0), defaultArgIndex(0)
 {
   unsigned naturalUncurryLevel;
-  if (ValueDecl *vd = baseLoc.dyn_cast<ValueDecl*>()) {
-    if (FuncDecl *fd = dyn_cast<FuncDecl>(vd)) {
+  if (auto *vd = baseLoc.dyn_cast<ValueDecl*>()) {
+    if (auto *fd = dyn_cast<FuncDecl>(vd)) {
       // Map FuncDecls directly to Func SILDeclRefs.
       loc = fd;
       kind = Kind::Func;
       naturalUncurryLevel = getFuncNaturalUncurryLevel(fd);
     }
     // Map ConstructorDecls to the Allocator SILDeclRef of the constructor.
-    else if (ConstructorDecl *cd = dyn_cast<ConstructorDecl>(vd)) {
+    else if (auto *cd = dyn_cast<ConstructorDecl>(vd)) {
       loc = cd;
       kind = Kind::Allocator;
       naturalUncurryLevel = 1;
     }
     // Map EnumElementDecls to the EnumElement SILDeclRef of the element.
-    else if (EnumElementDecl *ed = dyn_cast<EnumElementDecl>(vd)) {
+    else if (auto *ed = dyn_cast<EnumElementDecl>(vd)) {
       loc = ed;
       kind = Kind::EnumElement;
       naturalUncurryLevel = ed->getArgumentInterfaceType() ? 1 : 0;

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -128,7 +128,7 @@ static CanType getKnownType(Optional<CanType> &cacheSlot, ASTContext &C,
       if (decls.size() != 1)
         return CanType();
 
-      const TypeDecl *typeDecl = dyn_cast<TypeDecl>(decls.front());
+      const auto *typeDecl = dyn_cast<TypeDecl>(decls.front());
       if (!typeDecl)
         return CanType();
 
@@ -521,7 +521,7 @@ enum class ConventionsKind : uint8_t {
       }
 
       // Okay, handle 'self'.
-      if (CanTupleType substTupleType = dyn_cast<TupleType>(substType)) {
+      if (auto substTupleType = dyn_cast<TupleType>(substType)) {
         unsigned numEltTypes = substTupleType.getElementTypes().size();
         assert(numEltTypes > 0);
 
@@ -1398,7 +1398,7 @@ getSILFunctionTypeForClangDecl(SILModule &M, const clang::Decl *clangDecl,
 
 /// Try to find a clang method declaration for the given function.
 static const clang::Decl *findClangMethod(ValueDecl *method) {
-  if (FuncDecl *methodFn = dyn_cast<FuncDecl>(method)) {
+  if (auto *methodFn = dyn_cast<FuncDecl>(method)) {
     if (auto *decl = methodFn->getClangDecl())
       return decl;
 
@@ -1406,7 +1406,7 @@ static const clang::Decl *findClangMethod(ValueDecl *method) {
       return findClangMethod(overridden);
   }
 
-  if (ConstructorDecl *constructor = dyn_cast<ConstructorDecl>(method)) {
+  if (auto *constructor = dyn_cast<ConstructorDecl>(method)) {
     if (auto *decl = constructor->getClangDecl())
       return decl;
   }

--- a/lib/SIL/SILType.cpp
+++ b/lib/SIL/SILType.cpp
@@ -159,7 +159,7 @@ static bool canUnsafeCastTuple(SILType fromType, CanTupleType fromTupleTy,
     return true;
   }
   // Otherwise, flatten one level of tuple elements on each side.
-  CanTupleType toTupleTy = dyn_cast<TupleType>(toType.getSwiftRValueType());
+  auto toTupleTy = dyn_cast<TupleType>(toType.getSwiftRValueType());
   if (!toTupleTy)
     return false;
 

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -751,15 +751,15 @@ public:
     SILBasicBlock *SBB = AI->getParent();
     bool Allocated = true;
     for (auto Inst = AI->getIterator(), E = SBB->end(); Inst != E; ++Inst) {
-      if (LoadInst *LI = dyn_cast<LoadInst>(Inst))
+      if (auto *LI = dyn_cast<LoadInst>(Inst))
         if (LI->getOperand() == AI)
           require(Allocated, "AllocStack used by Load outside its lifetime");
 
-      if (StoreInst *SI = dyn_cast<StoreInst>(Inst))
+      if (auto *SI = dyn_cast<StoreInst>(Inst))
         if (SI->getDest() == AI)
           require(Allocated, "AllocStack used by Store outside its lifetime");
 
-      if (DeallocStackInst *DSI = dyn_cast<DeallocStackInst>(Inst))
+      if (auto *DSI = dyn_cast<DeallocStackInst>(Inst))
         if (DSI->getOperand() == AI)
           Allocated = false;
     }

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -88,7 +88,7 @@ static bool hasSingletonMetatype(CanType instanceType) {
 
 CaptureKind TypeConverter::getDeclCaptureKind(CapturedValue capture) {
   auto decl = capture.getDecl();
-  if (VarDecl *var = dyn_cast<VarDecl>(decl)) {
+  if (auto *var = dyn_cast<VarDecl>(decl)) {
     switch (var->getStorageKind()) {
     case VarDecl::StoredWithTrivialAccessors:
       llvm_unreachable("stored local variable with trivial accessors?");
@@ -1911,7 +1911,7 @@ TypeConverter::getFunctionInterfaceTypeWithCaptures(CanAnyFunctionType funcType,
 }
 
 CanAnyFunctionType TypeConverter::makeConstantInterfaceType(SILDeclRef c) {
-  ValueDecl *vd = c.loc.dyn_cast<ValueDecl *>();
+  auto *vd = c.loc.dyn_cast<ValueDecl *>();
 
   switch (c.kind) {
   case SILDeclRef::Kind::Func: {
@@ -1988,7 +1988,7 @@ CanAnyFunctionType TypeConverter::makeConstantInterfaceType(SILDeclRef c) {
 /// Get the generic environment for an entity.
 GenericEnvironment *
 TypeConverter::getConstantGenericEnvironment(SILDeclRef c) {
-  ValueDecl *vd = c.loc.dyn_cast<ValueDecl *>();
+  auto *vd = c.loc.dyn_cast<ValueDecl *>();
   
   /// Get the function generic params, including outer params.
   switch (c.kind) {

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -812,7 +812,7 @@ static bool requiresIVarInitialization(SILGenModule &SGM, ClassDecl *cd) {
 
 bool SILGenModule::hasNonTrivialIVars(ClassDecl *cd) {
   for (Decl *member : cd->getMembers()) {
-    VarDecl *vd = dyn_cast<VarDecl>(member);
+    auto *vd = dyn_cast<VarDecl>(member);
     if (!vd || !vd->hasStorage()) continue;
 
     const TypeLowering &ti = Types.getTypeLowering(vd->getType());
@@ -1171,10 +1171,10 @@ void SILGenModule::visitTopLevelCodeDecl(TopLevelCodeDecl *td) {
  
   for (auto &ESD : td->getBody()->getElements()) {
     if (!TopLevelSGF->B.hasValidInsertionPoint()) {
-      if (Stmt *S = ESD.dyn_cast<Stmt*>()) {
+      if (auto *S = ESD.dyn_cast<Stmt*>()) {
         if (S->isImplicit())
           continue;
-      } else if (Expr *E = ESD.dyn_cast<Expr*>()) {
+      } else if (auto *E = ESD.dyn_cast<Expr*>()) {
         if (E->isImplicit())
           continue;
       }
@@ -1184,9 +1184,9 @@ void SILGenModule::visitTopLevelCodeDecl(TopLevelCodeDecl *td) {
       return;
     }
 
-    if (Stmt *S = ESD.dyn_cast<Stmt*>()) {
+    if (auto *S = ESD.dyn_cast<Stmt*>()) {
       TopLevelSGF->emitStmt(S);
-    } else if (Expr *E = ESD.dyn_cast<Expr*>()) {
+    } else if (auto *E = ESD.dyn_cast<Expr*>()) {
       TopLevelSGF->emitIgnoredExpr(E);
     } else {
       TopLevelSGF->visit(ESD.get<Decl*>());

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -53,7 +53,7 @@ static RValue emitImplicitValueConstructorArg(SILGenFunction &gen,
   auto type = DC->mapTypeIntoContext(interfaceType)->getCanonicalType();
 
   // Restructure tuple arguments.
-  if (CanTupleType tupleTy = dyn_cast<TupleType>(interfaceType)) {
+  if (auto tupleTy = dyn_cast<TupleType>(interfaceType)) {
     RValue tuple(type);
     for (auto fieldType : tupleTy.getElementTypes())
       tuple.addElement(emitImplicitValueConstructorArg(gen, loc, fieldType, DC));

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -1955,7 +1955,7 @@ ResultPlanner::planTupleIntoIndirectResult(AbstractionPattern innerOrigType,
   // outerOrigType can be a tuple if we're doing something like
   // injecting into an optional tuple.
 
-  CanTupleType outerSubstTupleType = dyn_cast<TupleType>(outerSubstType);
+  auto outerSubstTupleType = dyn_cast<TupleType>(outerSubstType);
 
   // If the outer type is not a tuple, it must be optional.
   if (!outerSubstTupleType) {
@@ -2054,7 +2054,7 @@ ResultPlanner::planTupleIntoDirectResult(AbstractionPattern innerOrigType,
                                          SILResultInfo outerResult) {
   assert(innerOrigType.isTuple());
 
-  CanTupleType outerSubstTupleType = dyn_cast<TupleType>(outerSubstType);
+  auto outerSubstTupleType = dyn_cast<TupleType>(outerSubstType);
 
   // If the outer type is not a tuple, it must be optional or we are under
   // opaque value mode
@@ -2265,7 +2265,7 @@ void ResultPlanner::planTupleFromDirectResult(AbstractionPattern innerOrigType,
                                               SILResultInfo innerResult) {
 
   assert(!innerOrigType.isTuple());
-  CanTupleType outerSubstTupleType = dyn_cast<TupleType>(outerSubstType);
+  auto outerSubstTupleType = dyn_cast<TupleType>(outerSubstType);
 
   assert(outerSubstTupleType && "Outer type must be a tuple");
   assert(innerSubstType->getNumElements() ==

--- a/lib/SILGen/SILGenProfiling.cpp
+++ b/lib/SILGen/SILGenProfiling.cpp
@@ -715,11 +715,11 @@ void SILGenProfiling::assignRegionCounters(Decl *Root) {
 }
 
 static SILLocation getLocation(ASTNode Node) {
-  if (Expr *E = Node.dyn_cast<Expr *>())
+  if (auto *E = Node.dyn_cast<Expr *>())
     return E;
-  else if (Stmt *S = Node.dyn_cast<Stmt *>())
+  else if (auto *S = Node.dyn_cast<Stmt *>())
     return S;
-  else if (Decl *D = Node.dyn_cast<Decl *>())
+  else if (auto *D = Node.dyn_cast<Decl *>())
     return D;
   else
     llvm_unreachable("unsupported ASTNode");

--- a/lib/SILGen/SILGenStmt.cpp
+++ b/lib/SILGen/SILGenStmt.cpp
@@ -209,9 +209,9 @@ void StmtEmitter::visitBraceStmt(BraceStmt *S) {
     if (!SGF.B.hasValidInsertionPoint()) {
       // If this is an implicit statement or expression, just skip over it,
       // don't emit a diagnostic here.
-      if (Stmt *S = ESD.dyn_cast<Stmt*>()) {
+      if (auto *S = ESD.dyn_cast<Stmt*>()) {
         if (S->isImplicit()) continue;
-      } else if (Expr *E = ESD.dyn_cast<Expr*>()) {
+      } else if (auto *E = ESD.dyn_cast<Expr*>()) {
         if (E->isImplicit()) continue;
       }
       
@@ -226,7 +226,7 @@ void StmtEmitter::visitBraceStmt(BraceStmt *S) {
     }
 
     // Process children.
-    if (Stmt *S = ESD.dyn_cast<Stmt*>()) {
+    if (auto *S = ESD.dyn_cast<Stmt*>()) {
       visit(S);
       if (isa<ReturnStmt>(S))
         StmtType = ReturnStmtType;
@@ -236,7 +236,7 @@ void StmtEmitter::visitBraceStmt(BraceStmt *S) {
         StmtType = ContinueStmtType;
       if (isa<ThrowStmt>(S))
         StmtType = ThrowStmtType;
-    } else if (Expr *E = ESD.dyn_cast<Expr*>()) {
+    } else if (auto *E = ESD.dyn_cast<Expr*>()) {
       SGF.emitIgnoredExpr(E);
     } else {
       SGF.visit(ESD.get<Decl*>());

--- a/lib/SILOptimizer/Analysis/ARCAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/ARCAnalysis.cpp
@@ -515,7 +515,7 @@ ConsumedResultToEpilogueRetainMatcher::
 findMatchingRetainsInBasicBlock(SILBasicBlock *BB, SILValue V) {
   for (auto II = BB->rbegin(), IE = BB->rend(); II != IE; ++II) {
     // Handle self-recursion.
-    if (ApplyInst *AI = dyn_cast<ApplyInst>(&*II))
+    if (auto *AI = dyn_cast<ApplyInst>(&*II))
       if (AI->getCalleeFunction() == BB->getParent()) 
         return std::make_pair(FindRetainKind::Recursion, AI);
     
@@ -557,7 +557,7 @@ findMatchingRetains(SILBasicBlock *BB) {
   // return value.
   SILValue RV = SILValue();
   for (auto II = BB->rbegin(), IE = BB->rend(); II != IE; ++II) {
-    if (ReturnInst *RI = dyn_cast<ReturnInst>(&*II)) {
+    if (auto *RI = dyn_cast<ReturnInst>(&*II)) {
       RV = RI->getOperand();
       break;
     }

--- a/lib/SILOptimizer/Analysis/AliasAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/AliasAnalysis.cpp
@@ -748,7 +748,7 @@ bool swift::isLetPointer(SILValue V) {
 
 
   // Check if a parent of a tuple is a "let"
-  if (TupleElementAddrInst *TEA = dyn_cast<TupleElementAddrInst>(V))
+  if (auto *TEA = dyn_cast<TupleElementAddrInst>(V))
     return isLetPointer(TEA->getOperand());
 
   return false;

--- a/lib/SILOptimizer/Analysis/SimplifyInstruction.cpp
+++ b/lib/SILOptimizer/Analysis/SimplifyInstruction.cpp
@@ -131,13 +131,13 @@ SILValue InstSimplifier::visitTupleInst(TupleInst *TI) {
 
 SILValue InstSimplifier::visitTupleExtractInst(TupleExtractInst *TEI) {
   // tuple_extract(tuple(x, y), 0) -> x
-  if (TupleInst *TheTuple = dyn_cast<TupleInst>(TEI->getOperand()))
+  if (auto *TheTuple = dyn_cast<TupleInst>(TEI->getOperand()))
     return TheTuple->getElement(TEI->getFieldNo());
 
   // tuple_extract(apply([add|sub|...]overflow(x,y)),  0) -> x
   // tuple_extract(apply(checked_trunc(ext(x))), 0) -> x
   if (TEI->getFieldNo() == 0)
-    if (BuiltinInst *BI = dyn_cast<BuiltinInst>(TEI->getOperand()))
+    if (auto *BI = dyn_cast<BuiltinInst>(TEI->getOperand()))
       return simplifyOverflowBuiltin(BI);
 
   return SILValue();
@@ -145,7 +145,7 @@ SILValue InstSimplifier::visitTupleExtractInst(TupleExtractInst *TEI) {
 
 SILValue InstSimplifier::visitStructExtractInst(StructExtractInst *SEI) {
   // struct_extract(struct(x, y), x) -> x
-  if (StructInst *Struct = dyn_cast<StructInst>(SEI->getOperand()))
+  if (auto *Struct = dyn_cast<StructInst>(SEI->getOperand()))
     return Struct->getFieldValue(SEI->getField());
 
   return SILValue();
@@ -155,7 +155,7 @@ SILValue
 InstSimplifier::
 visitUncheckedEnumDataInst(UncheckedEnumDataInst *UEDI) {
   // (unchecked_enum_data (enum payload)) -> payload
-  if (EnumInst *EI = dyn_cast<EnumInst>(UEDI->getOperand())) {
+  if (auto *EI = dyn_cast<EnumInst>(UEDI->getOperand())) {
     if (EI->getElement() != UEDI->getElement())
       return SILValue();
 
@@ -570,8 +570,8 @@ static SILValue simplifyBinaryWithOverflow(BuiltinInst *BI,
   const SILValue &Op1 = Args[0];
   const SILValue &Op2 = Args[1];
 
-  IntegerLiteralInst *IntOp1 = dyn_cast<IntegerLiteralInst>(Op1);
-  IntegerLiteralInst *IntOp2 = dyn_cast<IntegerLiteralInst>(Op2);
+  auto *IntOp1 = dyn_cast<IntegerLiteralInst>(Op1);
+  auto *IntOp2 = dyn_cast<IntegerLiteralInst>(Op2);
 
   // If both ops are not constants, we cannot do anything.
   // FIXME: Add cases where we can do something, eg, (x - x) -> 0

--- a/lib/SILOptimizer/Analysis/ValueTracking.cpp
+++ b/lib/SILOptimizer/Analysis/ValueTracking.cpp
@@ -148,7 +148,7 @@ IsZeroKind swift::isZeroValue(SILValue Value) {
     if (T->getFieldNo() != 0)
       return IsZeroKind::Unknown;
 
-    BuiltinInst *BI = dyn_cast<BuiltinInst>(T->getOperand());
+    auto *BI = dyn_cast<BuiltinInst>(T->getOperand());
     if (!BI)
       return IsZeroKind::Unknown;
 

--- a/lib/SILOptimizer/IPO/CapturePromotion.cpp
+++ b/lib/SILOptimizer/IPO/CapturePromotion.cpp
@@ -534,7 +534,7 @@ ClosureCloner::visitStrongReleaseInst(StrongReleaseInst *Inst) {
       Inst->getFunction()->hasUnqualifiedOwnership() &&
       "Should not see strong release in a function with qualified ownership");
   SILValue Operand = Inst->getOperand();
-  if (SILArgument *A = dyn_cast<SILArgument>(Operand)) {
+  if (auto *A = dyn_cast<SILArgument>(Operand)) {
     auto I = BoxArgumentMap.find(A);
     if (I != BoxArgumentMap.end()) {
       // Releases of the box arguments get replaced with ReleaseValue of the new
@@ -556,7 +556,7 @@ ClosureCloner::visitStrongReleaseInst(StrongReleaseInst *Inst) {
 /// normally.
 void ClosureCloner::visitDestroyValueInst(DestroyValueInst *Inst) {
   SILValue Operand = Inst->getOperand();
-  if (SILArgument *A = dyn_cast<SILArgument>(Operand)) {
+  if (auto *A = dyn_cast<SILArgument>(Operand)) {
     auto I = BoxArgumentMap.find(A);
     if (I != BoxArgumentMap.end()) {
       // Releases of the box arguments get replaced with an end_borrow,

--- a/lib/SILOptimizer/IPO/CapturePropagation.cpp
+++ b/lib/SILOptimizer/IPO/CapturePropagation.cpp
@@ -379,7 +379,7 @@ static SILFunction *getSpecializedWithDeadParams(
           return nullptr;
       }
 
-      if (TryApplyInst *TAI = dyn_cast<TryApplyInst>(&I)) {
+      if (auto *TAI = dyn_cast<TryApplyInst>(&I)) {
         // Check the normal and throw blocks of the try_apply.
         if (onlyContainsReturnOrThrowOfArg(TAI->getNormalBB()) &&
             onlyContainsReturnOrThrowOfArg(TAI->getErrorBB()))
@@ -488,7 +488,7 @@ void CapturePropagation::run() {
     while (I != BB.end()) {
       SILInstruction *Inst = &*I;
       ++I;
-      if (PartialApplyInst *PAI = dyn_cast<PartialApplyInst>(Inst))
+      if (auto *PAI = dyn_cast<PartialApplyInst>(Inst))
         HasChanged |= optimizePartialApply(PAI);
     }
   }

--- a/lib/SILOptimizer/IPO/GlobalOpt.cpp
+++ b/lib/SILOptimizer/IPO/GlobalOpt.cpp
@@ -176,7 +176,7 @@ static void removeToken(SILValue Op) {
       ATPI->eraseFromParent();
   }
 
-  if (GlobalAddrInst *GAI = dyn_cast<GlobalAddrInst>(Op)) {
+  if (auto *GAI = dyn_cast<GlobalAddrInst>(Op)) {
     auto *Global = GAI->getReferencedGlobal();
     // If "global_addr token" is used more than one time, bail.
     if (!(GAI->use_empty() || GAI->hasOneUse()))
@@ -256,7 +256,7 @@ static SILFunction *genGetterFromInit(StoreInst *Store,
       I.eraseFromParent();
       continue;
     }
-    if (StoreInst *SI = dyn_cast<StoreInst>(&I)) {
+    if (auto *SI = dyn_cast<StoreInst>(&I)) {
       Val = SI->getSrc();
       SILBuilderWithScope B(SI);
       B.createReturn(SI->getLoc(), Val);
@@ -348,11 +348,11 @@ bool SILGlobalOpt::isInLoop(SILBasicBlock *CurBB) {
 /// Returns true if the block \p BB is terminated with a cond_br based on an
 /// availability check.
 static bool isAvailabilityCheck(SILBasicBlock *BB) {
-  CondBranchInst *CBR = dyn_cast<CondBranchInst>(BB->getTerminator());
+  auto *CBR = dyn_cast<CondBranchInst>(BB->getTerminator());
   if (!CBR)
     return false;
   
-  ApplyInst *AI = dyn_cast<ApplyInst>(CBR->getCondition());
+  auto *AI = dyn_cast<ApplyInst>(CBR->getCondition());
   if (!AI)
     return false;
 
@@ -511,13 +511,13 @@ static SILFunction *genGetterFromInit(SILFunction *InitF, VarDecl *varDecl) {
       continue;
     }
 
-    if (StoreInst *SI = dyn_cast<StoreInst>(&I)) {
+    if (auto *SI = dyn_cast<StoreInst>(&I)) {
       Val = SI->getSrc();
       Store = SI;
       continue;
     }
 
-    if (ReturnInst *RI = dyn_cast<ReturnInst>(&I)) {
+    if (auto *RI = dyn_cast<ReturnInst>(&I)) {
       SILBuilderWithScope B(RI);
       B.createReturn(RI->getLoc(), Val);
       eraseUsesOfInstruction(RI);
@@ -542,7 +542,7 @@ static SILFunction *findInitializer(SILModule *Module, SILFunction *AddrF,
   SILBasicBlock *BB = &AddrF->front();
   for (auto &I : *BB) {
     // Find the builtin "once" call.
-    if (BuiltinInst *BI = dyn_cast<BuiltinInst>(&I)) {
+    if (auto *BI = dyn_cast<BuiltinInst>(&I)) {
       const BuiltinInfo &Builtin = Module->getBuiltinInfo(BI->getName());
       if (Builtin.ID != BuiltinValueKind::Once)
         continue;
@@ -895,12 +895,12 @@ bool SILGlobalOpt::run() {
     for (auto &BB : F) {
       bool IsCold = ColdBlocks.isCold(&BB);
       for (auto &I : BB)
-        if (BuiltinInst *BI = dyn_cast<BuiltinInst>(&I)) {
+        if (auto *BI = dyn_cast<BuiltinInst>(&I)) {
           collectOnceCall(BI);
-        } else if (ApplyInst *AI = dyn_cast<ApplyInst>(&I)) {
+        } else if (auto *AI = dyn_cast<ApplyInst>(&I)) {
           if (!IsCold)
             collectGlobalInitCall(AI);
-        } else if (GlobalAddrInst *GAI = dyn_cast<GlobalAddrInst>(&I)) {
+        } else if (auto *GAI = dyn_cast<GlobalAddrInst>(&I)) {
             collectGlobalAccess(GAI);
         }
     }

--- a/lib/SILOptimizer/IPO/GlobalPropertyOpt.cpp
+++ b/lib/SILOptimizer/IPO/GlobalPropertyOpt.cpp
@@ -286,7 +286,7 @@ bool GlobalPropertyOpt::canAddressEscape(SILValue V, bool acceptStore) {
 
 /// Scan an instruction and build dependencies for it.
 void GlobalPropertyOpt::scanInstruction(swift::SILInstruction *Inst) {
-  if (ApplyInst *AI = dyn_cast<ApplyInst>(Inst)) {
+  if (auto *AI = dyn_cast<ApplyInst>(Inst)) {
     ArraySemanticsCall semCall(AI);
     switch (semCall.getKind()) {
       case ArrayCallKind::kArrayInit:
@@ -305,7 +305,7 @@ void GlobalPropertyOpt::scanInstruction(swift::SILInstruction *Inst) {
       default:
         break;
     }
-  } else if (LoadInst *LI = dyn_cast<LoadInst>(Inst)) {
+  } else if (auto *LI = dyn_cast<LoadInst>(Inst)) {
     if (isArrayType(LI->getType())) {
       // Add a dependency from the value at the address to the loaded value.
       SILValue loadAddr = LI->getOperand();
@@ -313,7 +313,7 @@ void GlobalPropertyOpt::scanInstruction(swift::SILInstruction *Inst) {
       addDependency(getAddrEntry(loadAddr), getValueEntry(LI));
       return;
     }
-  } else if (StoreInst *SI = dyn_cast<StoreInst>(Inst)) {
+  } else if (auto *SI = dyn_cast<StoreInst>(Inst)) {
     SILValue src = SI->getSrc();
     if (isArrayType(src->getType())) {
       // Add a dependency from the operand to the value at the store-address.
@@ -332,21 +332,21 @@ void GlobalPropertyOpt::scanInstruction(swift::SILInstruction *Inst) {
       }
       return;
     }
-  } else if (StructExtractInst *SEI = dyn_cast<StructExtractInst>(Inst)) {
+  } else if (auto *SEI = dyn_cast<StructExtractInst>(Inst)) {
     if (isArrayType(SEI->getType())) {
       // Add a dependency from the field to the extracted value.
       VarDecl *Field = SEI->getField();
       addDependency(getFieldEntry(Field), getValueEntry(SEI));
       return;
     }
-  } else if (TupleExtractInst *TEI = dyn_cast<TupleExtractInst>(Inst)) {
+  } else if (auto *TEI = dyn_cast<TupleExtractInst>(Inst)) {
     if (isArrayType(TEI->getType())) {
       // Add a dependency from the tuple itself to the extracted element.
       SILValue tuple = TEI->getOperand();
       addDependency(getValueEntry(tuple), getValueEntry(TEI));
       return;
     }
-  } else if (TupleInst *TI = dyn_cast<TupleInst>(Inst)) {
+  } else if (auto *TI = dyn_cast<TupleInst>(Inst)) {
     if (isTupleWithArray(TI->getType().getSwiftRValueType())) {
       // Add dependencies from array elements to the tuple itself.
       for (Operand &Op : TI->getAllOperands()) {
@@ -357,7 +357,7 @@ void GlobalPropertyOpt::scanInstruction(swift::SILInstruction *Inst) {
       }
       return;
     }
-  } else if (StructInst *SI = dyn_cast<StructInst>(Inst)) {
+  } else if (auto *SI = dyn_cast<StructInst>(Inst)) {
     // Add dependencies from the array operands to the struct array-fields.
     StructDecl *S = SI->getStructDecl();
     NominalTypeDecl::StoredPropertyRange Range = S->getStoredProperties();
@@ -404,9 +404,9 @@ void GlobalPropertyOpt::scanInstructions() {
             hasPreds = true;
             auto *Term = Pred->getTerminator();
             SILValue PredArg;
-            if (BranchInst *BI = dyn_cast<BranchInst>(Term)) {
+            if (auto *BI = dyn_cast<BranchInst>(Term)) {
               PredArg = BI->getArg(argIdx);
-            } else if (CondBranchInst *CBI = dyn_cast<CondBranchInst>(Term)) {
+            } else if (auto *CBI = dyn_cast<CondBranchInst>(Term)) {
               PredArg = CBI->getArgForDestBB(&BB, BBArg);
             }
             if (PredArg) {

--- a/lib/SILOptimizer/LoopTransforms/ArrayBoundsCheckOpts.cpp
+++ b/lib/SILOptimizer/LoopTransforms/ArrayBoundsCheckOpts.cpp
@@ -620,7 +620,7 @@ static SILValue getZeroToCountArray(SILValue Start, SILValue End) {
 /// loop is only executed if "Start < End".
 static bool isLessThanCheck(SILValue Start, SILValue End,
                             CondBranchInst *CondBr, SILBasicBlock *Preheader) {
-  BuiltinInst *BI = dyn_cast<BuiltinInst>(CondBr->getCondition());
+  auto *BI = dyn_cast<BuiltinInst>(CondBr->getCondition());
   if (!BI)
     return false;
 

--- a/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
+++ b/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
@@ -423,7 +423,7 @@ protected:
 /// store to the local's address. checkSafeArrayAddressUses will check that the
 /// store is a simple initialization outside the loop.
 bool COWArrayOpt::checkUniqueArrayContainer(SILValue ArrayContainer) {
-  if (SILArgument *Arg = dyn_cast<SILArgument>(ArrayContainer)) {
+  if (auto *Arg = dyn_cast<SILArgument>(ArrayContainer)) {
     // Check that the argument is passed as an inout type. This means there are
     // no aliases accessible within this function scope.
     auto Params = Function->getLoweredFunctionType()->getParameters();
@@ -1262,7 +1262,7 @@ bool COWArrayOpt::hoistInLoopWithOnlyNonArrayValueMutatingOperations() {
       }
       // A store is only safe if it is to an array element and the element type
       // is trivial.
-      if (StoreInst *SI = dyn_cast<StoreInst>(Inst)) {
+      if (auto *SI = dyn_cast<StoreInst>(Inst)) {
         if (!isArrayEltStore(SI) ||
             !SI->getSrc()->getType().isTrivial(Module)) {
           DEBUG(llvm::dbgs()

--- a/lib/SILOptimizer/LoopTransforms/LICM.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LICM.cpp
@@ -127,9 +127,9 @@ static bool hasLoopInvariantOperands(SILInstruction *I, SILLoop *L) {
 /// Check if an address does not depend on other values in a basic block.
 static SILInstruction *addressIndependent(SILValue Addr) {
   Addr = stripCasts(Addr);
-  if (GlobalAddrInst *SGAI = dyn_cast<GlobalAddrInst>(Addr))
+  if (auto *SGAI = dyn_cast<GlobalAddrInst>(Addr))
     return SGAI;
-  if (StructElementAddrInst *SEAI = dyn_cast<StructElementAddrInst>(Addr))
+  if (auto *SEAI = dyn_cast<StructElementAddrInst>(Addr))
     return addressIndependent(SEAI->getOperand());
   return nullptr;
 }

--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -562,7 +562,7 @@ void OpaqueStorageAllocation::allocateForValue(SILValue value,
     // TODO: Handle block arguments.
     // TODO: Handle subobjects with a single composition, and other non-mutating
     // uses such as @in arguments.
-    if (SILInstruction *def = dyn_cast<SILInstruction>(value)) {
+    if (auto *def = dyn_cast<SILInstruction>(value)) {
       Operand *useOper = *value->use_begin();
       if (canProjectFrom(def, useOper->getUser())) {
         storage.setComposedOperand(useOper);

--- a/lib/SILOptimizer/Mandatory/DataflowDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/DataflowDiagnostics.cpp
@@ -102,7 +102,7 @@ static void diagnoseStaticReports(const SILInstruction *I,
 
       // Report diagnostic if the first argument has been folded to '1'.
       OperandValueArrayRef Args = BI->getArguments();
-      IntegerLiteralInst *V = dyn_cast<IntegerLiteralInst>(Args[0]);
+      auto *V = dyn_cast<IntegerLiteralInst>(Args[0]);
       if (!V || V->getValue() != 1)
         return;
 

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -890,10 +890,10 @@ void LifetimeChecker::handleLoadUse(unsigned UseID) {
   // If this is an OpenExistentialAddrInst in preparation for applying
   // a witness method, analyze its use to make sure, that no mutation of
   // lvalue let constants occurs.
-  auto* OEAI = dyn_cast<OpenExistentialAddrInst>(LoadInst);
+  auto *OEAI = dyn_cast<OpenExistentialAddrInst>(LoadInst);
   if (OEAI != nullptr && TheMemory.isElementLetProperty(Use.FirstElement)) {
     for (auto OEAUse : OEAI->getUses()) {
-      auto* AI = dyn_cast<ApplyInst>(OEAUse->getUser());
+      auto *AI = dyn_cast<ApplyInst>(OEAUse->getUser());
 
       if (AI == nullptr)
         // User is not an ApplyInst

--- a/lib/SILOptimizer/Mandatory/DiagnoseUnreachable.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseUnreachable.cpp
@@ -190,9 +190,9 @@ static bool constantFoldTerminator(SILBasicBlock &BB,
   TermInst *TI = BB.getTerminator();
 
   // Process conditional branches with constant conditions.
-  if (CondBranchInst *CBI = dyn_cast<CondBranchInst>(TI)) {
+  if (auto *CBI = dyn_cast<CondBranchInst>(TI)) {
     SILValue V = CBI->getCondition();
-    SILInstruction *CondI = dyn_cast<SILInstruction>(V);
+    auto *CondI = dyn_cast<SILInstruction>(V);
     SILLocation Loc = CBI->getLoc();
 
     if (IntegerLiteralInst *ConstCond =
@@ -249,8 +249,8 @@ static bool constantFoldTerminator(SILBasicBlock &BB,
   //                            case #Bool.false!unionelt: bb2
   // =>
   //   br bb2
-  if (SwitchEnumInst *SUI = dyn_cast<SwitchEnumInst>(TI)) {
-    if (EnumInst *TheEnum = dyn_cast<EnumInst>(SUI->getOperand())) {
+  if (auto *SUI = dyn_cast<SwitchEnumInst>(TI)) {
+    if (auto *TheEnum = dyn_cast<EnumInst>(SUI->getOperand())) {
       const EnumElementDecl *TheEnumElem = TheEnum->getElement();
       SILBasicBlock *TheSuccessorBlock = nullptr;
       int ReachableBlockIdx = -1;
@@ -334,7 +334,7 @@ static bool constantFoldTerminator(SILBasicBlock &BB,
   //   switch_value %1 : $Builtin.Int64, case 1: bb1, case 2: bb2
   // =>
   //   br bb2
-  if (SwitchValueInst *SUI = dyn_cast<SwitchValueInst>(TI)) {
+  if (auto *SUI = dyn_cast<SwitchValueInst>(TI)) {
     if (IntegerLiteralInst *SwitchVal =
           dyn_cast<IntegerLiteralInst>(SUI->getOperand())) {
       SILBasicBlock *TheSuccessorBlock = nullptr;

--- a/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
@@ -221,7 +221,7 @@ getCalleeFunction(FullApplySite AI, bool &IsThick,
     FullArgs.push_back(Arg);
   SILValue CalleeValue = AI.getCallee();
 
-  if (LoadInst *LI = dyn_cast<LoadInst>(CalleeValue)) {
+  if (auto *LI = dyn_cast<LoadInst>(CalleeValue)) {
     // Conservatively only see through alloc_box; we assume this pass is run
     // immediately after SILGen
     auto *PBI = dyn_cast<ProjectBoxInst>(LI->getOperand());
@@ -282,7 +282,7 @@ getCalleeFunction(FullApplySite AI, bool &IsThick,
     IsThick = true;
   }
 
-  FunctionRefInst *FRI = dyn_cast<FunctionRefInst>(CalleeValue);
+  auto *FRI = dyn_cast<FunctionRefInst>(CalleeValue);
 
   if (!FRI)
     return nullptr;

--- a/lib/SILOptimizer/SILCombiner/SILCombine.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombine.cpp
@@ -294,7 +294,7 @@ SILInstruction *SILCombiner::eraseInstFromFunction(SILInstruction &I,
   // use counts.
   if (I.getNumOperands() < 8 && AddOperandsToWorklist) {
     for (auto &OpI : I.getAllOperands()) {
-      if (SILInstruction *Op = llvm::dyn_cast<SILInstruction>(&*OpI.get())) {
+      if (auto *Op = llvm::dyn_cast<SILInstruction>(&*OpI.get())) {
         DEBUG(llvm::dbgs() << "SC: add op " << *Op <<
               " from erased inst to worklist\n");
         Worklist.add(Op);

--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -399,7 +399,7 @@ SILCombiner::optimizeApplyOfConvertFunctionInst(FullApplySite AI,
                                                 ConvertFunctionInst *CFI) {
   // We only handle simplification of static function references. If we don't
   // have one, bail.
-  FunctionRefInst *FRI = dyn_cast<FunctionRefInst>(CFI->getOperand());
+  auto *FRI = dyn_cast<FunctionRefInst>(CFI->getOperand());
   if (!FRI)
     return nullptr;
 

--- a/lib/SILOptimizer/SILCombiner/SILCombinerBuiltinVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerBuiltinVisitors.cpp
@@ -245,7 +245,7 @@ static IndexRawPointerInst *
 matchSizeOfMultiplication(SILValue I, MetatypeInst *RequiredType,
                           BuiltinInst *&TruncOrBitCast, SILValue &Ptr,
                           SILValue &Distance) {
-  IndexRawPointerInst *Res = dyn_cast<IndexRawPointerInst>(I);
+  auto *Res = dyn_cast<IndexRawPointerInst>(I);
   if (!Res)
     return nullptr;
 

--- a/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
@@ -179,7 +179,7 @@ SILInstruction *SILCombiner::visitSwitchValueInst(SwitchValueInst *SVI) {
   SILBasicBlock *TrueBB = nullptr;
   for (unsigned Idx = 0, Num = SVI->getNumCases(); Idx < Num; ++Idx) {
     auto Case = SVI->getCase(Idx);
-    IntegerLiteralInst *CaseVal = dyn_cast<IntegerLiteralInst>(Case.first);
+    auto *CaseVal = dyn_cast<IntegerLiteralInst>(Case.first);
     if (!CaseVal)
       return nullptr;
     SILBasicBlock *DestBB = Case.second;
@@ -606,7 +606,7 @@ SILInstruction *SILCombiner::visitRetainValueInst(RetainValueInst *RVI) {
 
     // ...and the predecessor instruction is a release_value on the same value
     // as our retain_value...
-    if (ReleaseValueInst *Release = dyn_cast<ReleaseValueInst>(&*Pred))
+    if (auto *Release = dyn_cast<ReleaseValueInst>(&*Pred))
       // Remove them...
       if (Release->getOperand() == RVI->getOperand()) {
         eraseInstFromFunction(*Release);
@@ -694,7 +694,7 @@ SILInstruction *SILCombiner::visitStrongRetainInst(StrongRetainInst *SRI) {
 
     // ...and the predecessor instruction is a strong_release on the same value
     // as our strong_retain...
-    if (StrongReleaseInst *Release = dyn_cast<StrongReleaseInst>(&*Pred))
+    if (auto *Release = dyn_cast<StrongReleaseInst>(&*Pred))
       // Remove them...
       if (Release->getOperand() == SRI->getOperand()) {
         eraseInstFromFunction(*Release);
@@ -908,8 +908,8 @@ SILCombiner::visitInjectEnumAddrInst(InjectEnumAddrInst *IEAI) {
   if (!hasOneNonDebugUse(DataAddrInst))
     return nullptr;
 
-  StoreInst *SI = dyn_cast<StoreInst>(getSingleNonDebugUser(DataAddrInst));
-  ApplyInst *AI = dyn_cast<ApplyInst>(getSingleNonDebugUser(DataAddrInst));
+  auto *SI = dyn_cast<StoreInst>(getSingleNonDebugUser(DataAddrInst));
+  auto *AI = dyn_cast<ApplyInst>(getSingleNonDebugUser(DataAddrInst));
   if (!SI && !AI) {
     return nullptr;
   }
@@ -1346,7 +1346,7 @@ visitAllocRefDynamicInst(AllocRefDynamicInst *ARDI) {
     MDVal = UC->getOperand();
 
   SILInstruction *NewInst = nullptr;
-  if (MetatypeInst *MI = dyn_cast<MetatypeInst>(MDVal)) {
+  if (auto *MI = dyn_cast<MetatypeInst>(MDVal)) {
     auto &Mod = ARDI->getModule();
     auto SILInstanceTy = MI->getType().getMetatypeInstanceType(Mod);
 

--- a/lib/SILOptimizer/Transforms/ARCCodeMotion.cpp
+++ b/lib/SILOptimizer/Transforms/ARCCodeMotion.cpp
@@ -819,7 +819,7 @@ void ReleaseCodeMotionContext::computeCodeMotionGenKillSet() {
 
     // Handle SILArgument, SILArgument can invalidate.
     for (unsigned i = 0; i < RCRootVault.size(); ++i) {
-      SILArgument *A = dyn_cast<SILArgument>(RCRootVault[i]);
+      auto *A = dyn_cast<SILArgument>(RCRootVault[i]);
       if (!A || A->getParent() != BB)
         continue;
       InterestBlock = true;
@@ -986,7 +986,7 @@ void ReleaseCodeMotionContext::computeCodeMotionInsertPoints() {
     for (unsigned i = 0; i < RCRootVault.size(); ++i) {
       if (!S->BBSetOut[i]) 
         continue;
-      SILArgument *A = dyn_cast<SILArgument>(RCRootVault[i]);
+      auto *A = dyn_cast<SILArgument>(RCRootVault[i]);
       if (!A || A->getParent() != BB)
         continue;
       InsertPoints[RCRootVault[i]].push_back(&*BB->begin());

--- a/lib/SILOptimizer/Transforms/ConditionForwarding.cpp
+++ b/lib/SILOptimizer/Transforms/ConditionForwarding.cpp
@@ -149,7 +149,7 @@ static bool hasNoRelevantSideEffects(SILBasicBlock *BB) {
 bool ConditionForwarding::tryOptimize(SwitchEnumInst *SEI) {
   // The switch_enum argument (an Enum) must be a block argument at the merging
   // point of the condition's destinations.
-  SILArgument *Arg = dyn_cast<SILArgument>(SEI->getOperand());
+  auto *Arg = dyn_cast<SILArgument>(SEI->getOperand());
   if (!Arg)
     return false;
 

--- a/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
@@ -107,7 +107,7 @@ class DCE : public SILFunctionTransform {
 
     SILFunction *F = getFunction();
 
-    auto* DA = PM->getAnalysis<PostDominanceAnalysis>();
+    auto *DA = PM->getAnalysis<PostDominanceAnalysis>();
     PDT = DA->get(F);
 
     // If we have a function that consists of nothing but a

--- a/lib/SILOptimizer/Transforms/DeadStoreElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadStoreElimination.cpp
@@ -110,7 +110,7 @@ static llvm::SmallVector<SILInstruction *, 1>
 findDeallocStackInst(AllocStackInst *ASI) {
   llvm::SmallVector<SILInstruction *, 1> DSIs;
   for (auto UI = ASI->use_begin(), E = ASI->use_end(); UI != E; ++UI) {
-    if (DeallocStackInst *D = dyn_cast<DeallocStackInst>(UI->getUser())) {
+    if (auto *D = dyn_cast<DeallocStackInst>(UI->getUser())) {
       DSIs.push_back(D);
     }   
   }

--- a/lib/SILOptimizer/Transforms/MergeCondFail.cpp
+++ b/lib/SILOptimizer/Transforms/MergeCondFail.cpp
@@ -54,7 +54,7 @@ public:
       for (auto InstIt = BB.begin(), End = BB.end(); InstIt != End;) {
         auto *CurInst = &*InstIt;
         ++InstIt;
-        CondFailInst *CFI = dyn_cast<CondFailInst>(CurInst);
+        auto *CFI = dyn_cast<CondFailInst>(CurInst);
 
         // Stop merging at side-effects or reads from memory.
         if (!CFI && (CurInst->mayHaveSideEffects() ||

--- a/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
+++ b/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
@@ -809,7 +809,7 @@ void SILPerformanceInliner::visitColdBlocks(
   DominanceOrder domOrder(Root, DT);
   while (SILBasicBlock *block = domOrder.getNext()) {
     for (SILInstruction &I : *block) {
-      ApplyInst *AI = dyn_cast<ApplyInst>(&I);
+      auto *AI = dyn_cast<ApplyInst>(&I);
       if (!AI)
         continue;
 

--- a/lib/SILOptimizer/Transforms/RedundantLoadElimination.cpp
+++ b/lib/SILOptimizer/Transforms/RedundantLoadElimination.cpp
@@ -101,7 +101,7 @@ STATISTIC(NumForwardedLoads, "Number of loads forwarded");
 /// Return the deallocate stack instructions corresponding to the given
 /// AllocStackInst.
 static SILInstruction *findAllocStackInst(SILInstruction *I) {
-  if (DeallocStackInst *DSI = dyn_cast<DeallocStackInst>(I))
+  if (auto *DSI = dyn_cast<DeallocStackInst>(I))
     return dyn_cast<SILInstruction>(DSI->getOperand());
   return nullptr;
 }

--- a/lib/SILOptimizer/Transforms/RedundantOverflowCheckRemoval.cpp
+++ b/lib/SILOptimizer/Transforms/RedundantOverflowCheckRemoval.cpp
@@ -209,8 +209,8 @@ public:
       return true;
 
     // Evaluate literal integers.
-    IntegerLiteralInst *AI = dyn_cast<IntegerLiteralInst>(A);
-    IntegerLiteralInst *BI = dyn_cast<IntegerLiteralInst>(B);
+    auto *AI = dyn_cast<IntegerLiteralInst>(A);
+    auto *BI = dyn_cast<IntegerLiteralInst>(B);
     if (AI && BI) {
       APInt Ap = AI->getValue();
       APInt Bp = BI->getValue();
@@ -232,7 +232,7 @@ public:
 
   /// Return True if we can deduct that \p N is always positive (N > 0).
   static bool isKnownPositive(SILValue N) {
-    if (IntegerLiteralInst *NI = dyn_cast<IntegerLiteralInst>(N))
+    if (auto *NI = dyn_cast<IntegerLiteralInst>(N))
       return NI->getValue().isStrictlyPositive();
     return false;
   }
@@ -241,8 +241,8 @@ public:
   /// absolute value of \p B. In other words, check if \p A known to be closer
   /// to zero.
   static bool isKnownAbsLess(SILValue A, SILValue B) {
-    IntegerLiteralInst *AI = dyn_cast<IntegerLiteralInst>(A);
-    IntegerLiteralInst *BI = dyn_cast<IntegerLiteralInst>(B);
+    auto *AI = dyn_cast<IntegerLiteralInst>(A);
+    auto *BI = dyn_cast<IntegerLiteralInst>(B);
 
     if (AI && BI)
       return AI->getValue().abs().ult(BI->getValue().abs());
@@ -295,8 +295,8 @@ public:
         if (F.Relationship == ValueRelation::SLT) {
           SILValue A = BI->getOperand(0);
           SILValue B = BI->getOperand(1);
-          IntegerLiteralInst *AI = dyn_cast<IntegerLiteralInst>(A);
-          IntegerLiteralInst *BI = dyn_cast<IntegerLiteralInst>(B);
+          auto *AI = dyn_cast<IntegerLiteralInst>(A);
+          auto *BI = dyn_cast<IntegerLiteralInst>(B);
           if (L == A && BI && BI->getValue().getSExtValue() == 1)
             return true;
           if (L == B && AI && AI->getValue().getSExtValue() == 1)
@@ -324,8 +324,8 @@ public:
         if (F.Relationship == ValueRelation::ULT) {
           SILValue A = BI->getOperand(0);
           SILValue B = BI->getOperand(1);
-          IntegerLiteralInst *AI = dyn_cast<IntegerLiteralInst>(A);
-          IntegerLiteralInst *BI = dyn_cast<IntegerLiteralInst>(B);
+          auto *AI = dyn_cast<IntegerLiteralInst>(A);
+          auto *BI = dyn_cast<IntegerLiteralInst>(B);
           if (L == A && BI && BI->getValue().getZExtValue() == 1)
             return true;
           if (L == B && AI && AI->getValue().getZExtValue() == 1)
@@ -430,7 +430,7 @@ public:
         if (F.Relationship == ValueRelation::ULT) {
           SILValue A = BI->getOperand(0);
           SILValue B = BI->getOperand(1);
-          IntegerLiteralInst *BI = dyn_cast<IntegerLiteralInst>(B);
+          auto *BI = dyn_cast<IntegerLiteralInst>(B);
           if (R == A && BI && BI->getValue().getZExtValue() == 1)
             return true;
         }
@@ -488,7 +488,7 @@ public:
         if (F.Relationship == ValueRelation::SLT) {
           SILValue A = BI->getOperand(0);
           SILValue B = BI->getOperand(1);
-          IntegerLiteralInst *BI = dyn_cast<IntegerLiteralInst>(B);
+          auto *BI = dyn_cast<IntegerLiteralInst>(B);
           if (R == A && BI && BI->getValue().getSExtValue() == 1)
             return true;
         }

--- a/lib/SILOptimizer/Transforms/ReleaseDevirtualizer.cpp
+++ b/lib/SILOptimizer/Transforms/ReleaseDevirtualizer.cpp
@@ -113,7 +113,7 @@ devirtualizeReleaseOfObject(SILInstruction *ReleaseInst,
     return false;
 
   // Is the dealloc_ref paired with an alloc_ref?
-  AllocRefInst *ARI = dyn_cast<AllocRefInst>(DeallocInst->getOperand());
+  auto *ARI = dyn_cast<AllocRefInst>(DeallocInst->getOperand());
   if (!ARI)
     return false;
 

--- a/lib/SILOptimizer/Transforms/SILCleanup.cpp
+++ b/lib/SILOptimizer/Transforms/SILCleanup.cpp
@@ -37,7 +37,7 @@ static void cleanFunction(SILFunction &Fn) {
       ++I;
 
       // Remove calls to Builtin.staticReport().
-      if (BuiltinInst *BI = dyn_cast<BuiltinInst>(Inst)) {
+      if (auto *BI = dyn_cast<BuiltinInst>(Inst)) {
         const BuiltinInfo &B = BI->getBuiltinInfo();
         if (B.ID == BuiltinValueKind::StaticReport) {
           // The call to the builtin should get removed before we reach

--- a/lib/SILOptimizer/Transforms/SILCodeMotion.cpp
+++ b/lib/SILOptimizer/Transforms/SILCodeMotion.cpp
@@ -123,7 +123,7 @@ static bool hoistSILArgumentReleaseInst(SILBasicBlock *BB) {
     return false;
 
   // Make sure it is a release on a SILArgument of the current basic block..
-  SILArgument *SA = dyn_cast<SILArgument>(Head->getOperand(0));
+  auto *SA = dyn_cast<SILArgument>(Head->getOperand(0));
   if (!SA || SA->getParent() != BB)
     return false;
 
@@ -203,7 +203,7 @@ enum OperandRelation {
 static SILValue findValueShallowRoot(const SILValue &In) {
   // If this is a basic block argument with a single caller
   // then we know exactly which value is passed to the argument.
-  if (SILArgument *Arg = dyn_cast<SILArgument>(In)) {
+  if (auto *Arg = dyn_cast<SILArgument>(In)) {
     SILBasicBlock *Parent = Arg->getParent();
     SILBasicBlock *Pred = Parent->getSinglePredecessorBlock();
     if (!Pred) return In;
@@ -309,15 +309,15 @@ cheaperToPassOperandsAsArguments(SILInstruction *First,
   // This will further enable to sink strong_retain_unowned instructions,
   // which provides more opportunities for the unowned-optimization in
   // LLVMARCOpts.
-  UnownedToRefInst *UTORI1 = dyn_cast<UnownedToRefInst>(First);
-  UnownedToRefInst *UTORI2 = dyn_cast<UnownedToRefInst>(Second);
+  auto *UTORI1 = dyn_cast<UnownedToRefInst>(First);
+  auto *UTORI2 = dyn_cast<UnownedToRefInst>(Second);
   if (UTORI1 && UTORI2) {
     return 0;
   }
 
   // TODO: Add more cases than Struct
-  StructInst *FirstStruct = dyn_cast<StructInst>(First);
-  StructInst *SecondStruct = dyn_cast<StructInst>(Second);
+  auto *FirstStruct = dyn_cast<StructInst>(First);
+  auto *SecondStruct = dyn_cast<StructInst>(Second);
 
   if (!FirstStruct || !SecondStruct)
     return None;
@@ -408,7 +408,7 @@ static bool sinkArgument(SILBasicBlock *BB, unsigned ArgNum) {
   SILBasicBlock *FirstPred = *BB->pred_begin();
   TermInst *FirstTerm = FirstPred->getTerminator();
   auto FirstPredArg = FirstTerm->getOperand(ArgNum);
-  SILInstruction *FSI = dyn_cast<SILInstruction>(FirstPredArg);
+  auto *FSI = dyn_cast<SILInstruction>(FirstPredArg);
 
   // The list of identical instructions.
   SmallVector<SILValue, 8> Clones;
@@ -443,7 +443,7 @@ static bool sinkArgument(SILBasicBlock *BB, unsigned ArgNum) {
 
     // Find the Nth argument passed to BB.
     SILValue Arg = TI->getOperand(ArgNum);
-    SILInstruction *SI = dyn_cast<SILInstruction>(Arg);
+    auto *SI = dyn_cast<SILInstruction>(Arg);
     if (!SI || !hasOneNonDebugUse(SI))
       return false;
     if (SI->isIdenticalTo(FSI)) {
@@ -495,7 +495,7 @@ static bool sinkArgument(SILBasicBlock *BB, unsigned ArgNum) {
       assert((isa<BranchInst>(TI) || isa<CondBranchInst>(TI)) &&
              "Branch instruction required");
 
-      SILInstruction *CloneInst = dyn_cast<SILInstruction>(*CloneIt);
+      auto *CloneInst = dyn_cast<SILInstruction>(*CloneIt);
       TI->setOperand(ArgNum, CloneInst->getOperand(*DifferentOperandIndex));
       // Now delete the clone as we only needed it operand.
       if (CloneInst != FSI)
@@ -1078,7 +1078,7 @@ void BBEnumTagDataflowState::handlePredSwitchEnum(SwitchEnumInst *S) {
 
 void BBEnumTagDataflowState::handlePredCondSelectEnum(CondBranchInst *CondBr) {
 
-  SelectEnumInst *EITI = dyn_cast<SelectEnumInst>(CondBr->getCondition());
+  auto *EITI = dyn_cast<SelectEnumInst>(CondBr->getCondition());
   if (!EITI)
     return;
 

--- a/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
+++ b/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
@@ -89,7 +89,7 @@ public:
       : ASI(Asi), DSI(nullptr), DT(Di), DomTreeLevels(DomTreeLevels), B(B) {
     // Scan the users in search of a deallocation instruction.
     for (auto UI = ASI->use_begin(), E = ASI->use_end(); UI != E; ++UI)
-      if (DeallocStackInst *D = dyn_cast<DeallocStackInst>(UI->getUser())) {
+      if (auto *D = dyn_cast<DeallocStackInst>(UI->getUser())) {
         // Don't record multiple dealloc instructions.
         if (DSI) {
           DSI = nullptr;
@@ -216,7 +216,7 @@ static bool isCaptured(AllocStackInst *ASI, bool &inSingleBlock) {
       continue;
 
     // We can store into an AllocStack (but not the pointer).
-    if (StoreInst *SI = dyn_cast<StoreInst>(II))
+    if (auto *SI = dyn_cast<StoreInst>(II))
       if (SI->getDest() == ASI)
         continue;
 
@@ -248,7 +248,7 @@ bool MemoryToRegisters::isWriteOnlyAllocation(AllocStackInst *ASI) {
     SILInstruction *II = UI->getUser();
 
     // It is okay to store into this AllocStack.
-    if (StoreInst *SI = dyn_cast<StoreInst>(II))
+    if (auto *SI = dyn_cast<StoreInst>(II))
       if (!isa<AllocStackInst>(SI->getSrc()))
         continue;
 
@@ -297,7 +297,7 @@ static bool isLoadFromStack(SILInstruction *I, AllocStackInst *ASI) {
 
 /// Collects all load instructions which (transitively) use \p I as address.
 static void collectLoads(SILInstruction *I, SmallVectorImpl<LoadInst *> &Loads) {
-  if (LoadInst *load = dyn_cast<LoadInst>(I)) {
+  if (auto *load = dyn_cast<LoadInst>(I)) {
     Loads.push_back(load);
     return;
   }
@@ -385,7 +385,7 @@ StackAllocationPromoter::promoteAllocationInBlock(SILBasicBlock *BB) {
 
     // Remove stores and record the value that we are saving as the running
     // value.
-    if (StoreInst *SI = dyn_cast<StoreInst>(Inst)) {
+    if (auto *SI = dyn_cast<StoreInst>(Inst)) {
       if (SI->getDest() != ASI)
         continue;
 
@@ -422,7 +422,7 @@ StackAllocationPromoter::promoteAllocationInBlock(SILBasicBlock *BB) {
     }
 
     // Stop on deallocation.
-    if (DeallocStackInst *DSI = dyn_cast<DeallocStackInst>(Inst)) {
+    if (auto *DSI = dyn_cast<DeallocStackInst>(Inst)) {
       if (DSI->getOperand() == ASI)
         break;
     }
@@ -464,7 +464,7 @@ void MemoryToRegisters::removeSingleBlockAllocation(AllocStackInst *ASI) {
 
     // Remove stores and record the value that we are saving as the running
     // value.
-    if (StoreInst *SI = dyn_cast<StoreInst>(Inst)) {
+    if (auto *SI = dyn_cast<StoreInst>(Inst)) {
       if (SI->getDest() == ASI) {
         RunningVal = SI->getSrc();
         Inst->eraseFromParent();
@@ -497,7 +497,7 @@ void MemoryToRegisters::removeSingleBlockAllocation(AllocStackInst *ASI) {
     }
 
     // Remove deallocation.
-    if (DeallocStackInst *DSI = dyn_cast<DeallocStackInst>(Inst)) {
+    if (auto *DSI = dyn_cast<DeallocStackInst>(Inst)) {
       if (DSI->getOperand() == ASI) {
         Inst->eraseFromParent();
         NumInstRemoved++;
@@ -828,7 +828,7 @@ bool MemoryToRegisters::run() {
     auto I = BB.begin(), E = BB.end();
     while (I != E) {
       SILInstruction *Inst = &*I;
-      AllocStackInst *ASI = dyn_cast<AllocStackInst>(Inst);
+      auto *ASI = dyn_cast<AllocStackInst>(Inst);
       if (!ASI) {
         ++I;
         continue;

--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -799,7 +799,7 @@ getEnumCaseRecursive(SILValue Val, SILBasicBlock *UsedInBB, int RecursionDepth,
       if (!isa<BranchInst>(TI) && !isa<CondBranchInst>(TI))
         return nullptr;
 
-      SILArgument *IncomingArg = dyn_cast<SILArgument>(IncomingVal);
+      auto *IncomingArg = dyn_cast<SILArgument>(IncomingVal);
       if (IncomingArg && HandledArgs.count(IncomingArg) != 0)
         continue;
 
@@ -868,12 +868,12 @@ static bool couldSimplifyEnumUsers(SILArgument *BBArg, int Budget) {
     if (isa<EnumInst>(User))
       return true;
 
-    if (SwitchValueInst *SWI = dyn_cast<SwitchValueInst>(User)) {
+    if (auto *SWI = dyn_cast<SwitchValueInst>(User)) {
       if (SWI->getOperand() == BBArg)
         return true;
     }
 
-    if (BranchInst *BI = dyn_cast<BranchInst>(User)) {
+    if (auto *BI = dyn_cast<BranchInst>(User)) {
       if (BudgetForBranch > Budget) {
         BudgetForBranch = Budget;
         for (SILInstruction &I : *BB) {
@@ -1073,7 +1073,7 @@ static SILBasicBlock *getTrampolineDest(SILBasicBlock *SBB) {
   if (!onlyHasTerminatorAndDebugInsts(SBB))
     return nullptr;
 
-  BranchInst *BI = dyn_cast<BranchInst>(SBB->getTerminator());
+  auto *BI = dyn_cast<BranchInst>(SBB->getTerminator());
   if (!BI)
     return nullptr;
 
@@ -1111,7 +1111,7 @@ static BranchInst *getTrampolineWithoutBBArgsTerminator(SILBasicBlock *SBB) {
   if (!onlyHasTerminatorAndDebugInsts(SBB))
     return nullptr;
 
-  BranchInst *BI = dyn_cast<BranchInst>(SBB->getTerminator());
+  auto *BI = dyn_cast<BranchInst>(SBB->getTerminator());
   if (!BI)
     return nullptr;
 
@@ -1343,7 +1343,7 @@ static SILValue invertExpectAndApplyTo(SILBuilder &Builder,
   if (BI->getIntrinsicInfo().ID != llvm::Intrinsic::expect)
     return V;
   auto Args = BI->getArguments();
-  IntegerLiteralInst *IL = dyn_cast<IntegerLiteralInst>(Args[1]);
+  auto *IL = dyn_cast<IntegerLiteralInst>(Args[1]);
   if (!IL)
     return V;
   SILValue NegatedExpectedValue = Builder.createIntegerLiteral(
@@ -2144,7 +2144,7 @@ static bool tryMoveCondFailToPreds(SILBasicBlock *BB) {
     return false;
   
   // Check if the condition is a single-used argument in the current block.
-  SILArgument *condArg = dyn_cast<SILArgument>(cond);
+  auto *condArg = dyn_cast<SILArgument>(cond);
   if (!condArg || !condArg->hasOneUse())
     return false;
   
@@ -2270,7 +2270,7 @@ bool SimplifyCFG::canonicalizeSwitchEnums() {
   for (auto &BB : Fn) {
     TermInst *TI = BB.getTerminator();
   
-    SwitchEnumInstBase *SWI = dyn_cast<SwitchEnumInstBase>(TI);
+    auto *SWI = dyn_cast<SwitchEnumInstBase>(TI);
     if (!SWI)
       continue;
     
@@ -3257,7 +3257,7 @@ bool simplifyToSelectValue(SILBasicBlock *MergeBlock, unsigned ArgNum,
         EnumInst *PrevResult =
             dyn_cast<EnumInst>(CaseLiteralsToResultMap[CaseInfo.Literal]);
         assert(PrevResult && "Prev. case result is not an EnumInst");
-        EnumInst *CurrResult = dyn_cast<EnumInst>(CaseInfo.Result);
+        auto *CurrResult = dyn_cast<EnumInst>(CaseInfo.Result);
         assert(CurrResult && "Curr. case result is not an EnumInst");
         if (PrevResult->getElement() != CurrResult->getElement()) {
           // result value does not match - bail

--- a/lib/SILOptimizer/Utils/CFG.cpp
+++ b/lib/SILOptimizer/Utils/CFG.cpp
@@ -31,7 +31,7 @@ TermInst *swift::addNewEdgeValueToBranch(TermInst *Branch, SILBasicBlock *Dest,
   SILBuilderWithScope Builder(Branch);
   TermInst *NewBr = nullptr;
 
-  if (CondBranchInst *CBI = dyn_cast<CondBranchInst>(Branch)) {
+  if (auto *CBI = dyn_cast<CondBranchInst>(Branch)) {
     SmallVector<SILValue, 8> TrueArgs;
     SmallVector<SILValue, 8> FalseArgs;
 
@@ -53,7 +53,7 @@ TermInst *swift::addNewEdgeValueToBranch(TermInst *Branch, SILBasicBlock *Dest,
     NewBr = Builder.createCondBranch(CBI->getLoc(), CBI->getCondition(),
                                     CBI->getTrueBB(), TrueArgs,
                                     CBI->getFalseBB(), FalseArgs);
-  } else if (BranchInst *BI = dyn_cast<BranchInst>(Branch)) {
+  } else if (auto *BI = dyn_cast<BranchInst>(Branch)) {
     SmallVector<SILValue, 8> Args;
 
     for (auto A : BI->getArgs())
@@ -88,7 +88,7 @@ TermInst *swift::changeEdgeValue(TermInst *Branch, SILBasicBlock *Dest,
                                  size_t Idx, SILValue Val) {
   SILBuilderWithScope Builder(Branch);
 
-  if (CondBranchInst *CBI = dyn_cast<CondBranchInst>(Branch)) {
+  if (auto *CBI = dyn_cast<CondBranchInst>(Branch)) {
     SmallVector<SILValue, 8> TrueArgs;
     SmallVector<SILValue, 8> FalseArgs;
 
@@ -128,7 +128,7 @@ TermInst *swift::changeEdgeValue(TermInst *Branch, SILBasicBlock *Dest,
     return CBI;
   }
 
-  if (BranchInst *BI = dyn_cast<BranchInst>(Branch)) {
+  if (auto *BI = dyn_cast<BranchInst>(Branch)) {
     SmallVector<SILValue, 8> Args;
 
     assert(Idx < BI->getNumArgs() && "Not enough edges");

--- a/lib/SILOptimizer/Utils/CheckedCastBrJumpThreading.cpp
+++ b/lib/SILOptimizer/Utils/CheckedCastBrJumpThreading.cpp
@@ -229,7 +229,7 @@ void CheckedCastBrJumpThreading::Edit::modifyCFGForUnknownPreds() {
   // for method chaining code like obj.method1().method2().etc()
   auto *CCBI = cast<CheckedCastBranchInst>(CCBBlock->getTerminator());
   SILInstruction *Inst = &*CCBI->getFailureBB()->begin();
-  if (ClassMethodInst *CMI = dyn_cast<ClassMethodInst>(Inst)) {
+  if (auto *CMI = dyn_cast<ClassMethodInst>(Inst)) {
     if (CMI->getOperand() == stripClassCasts(CCBI->getOperand())) {
       // Replace checked_cast_br by branch to FailureBB.
       SILBuilder(CCBI->getParent()).createBranch(CCBI->getLoc(),

--- a/lib/SILOptimizer/Utils/Local.cpp
+++ b/lib/SILOptimizer/Utils/Local.cpp
@@ -180,7 +180,7 @@ recursivelyDeleteTriviallyDeadInstructions(ArrayRef<SILInstruction *> IA,
 
         // If the operand is an instruction that is only used by the instruction
         // being deleted, delete it.
-        if (SILInstruction *OpValInst = dyn_cast<SILInstruction>(OpVal))
+        if (auto *OpValInst = dyn_cast<SILInstruction>(OpVal))
           if (!DeadInsts.count(OpValInst) &&
               isInstructionTriviallyDead(OpValInst))
             NextInsts.insert(OpValInst);
@@ -369,7 +369,7 @@ TermInst *swift::addArgumentToBranch(SILValue Val, SILBasicBlock *Dest,
                                      TermInst *Branch) {
   SILBuilderWithScope Builder(Branch);
 
-  if (CondBranchInst *CBI = dyn_cast<CondBranchInst>(Branch)) {
+  if (auto *CBI = dyn_cast<CondBranchInst>(Branch)) {
     SmallVector<SILValue, 8> TrueArgs;
     SmallVector<SILValue, 8> FalseArgs;
 
@@ -392,7 +392,7 @@ TermInst *swift::addArgumentToBranch(SILValue Val, SILBasicBlock *Dest,
                                     CBI->getFalseBB(), FalseArgs);
   }
 
-  if (BranchInst *BI = dyn_cast<BranchInst>(Branch)) {
+  if (auto *BI = dyn_cast<BranchInst>(Branch)) {
     SmallVector<SILValue, 8> Args;
 
     for (auto A : BI->getArgs())

--- a/lib/SILOptimizer/Utils/SILInliner.cpp
+++ b/lib/SILOptimizer/Utils/SILInliner.cpp
@@ -109,7 +109,7 @@ bool SILInliner::inlineFunction(FullApplySite AI, ArrayRef<SILValue> Args) {
   // If we're inlining into a normal apply and the callee's entry
   // block ends in a return, then we can avoid a split.
   if (auto nonTryAI = dyn_cast<ApplyInst>(AI)) {
-    if (ReturnInst *RI = dyn_cast<ReturnInst>(CalleeEntryBB->getTerminator())) {
+    if (auto *RI = dyn_cast<ReturnInst>(CalleeEntryBB->getTerminator())) {
       // Replace all uses of the apply instruction with the operands of the
       // return instruction, appropriately mapped.
       nonTryAI->replaceAllUsesWith(remapValue(RI->getOperand()));
@@ -149,7 +149,7 @@ bool SILInliner::inlineFunction(FullApplySite AI, ArrayRef<SILValue> Args) {
 
     // Modify return terminators to branch to the return-to BB, rather than
     // trying to clone the ReturnInst.
-    if (ReturnInst *RI = dyn_cast<ReturnInst>(BI->first->getTerminator())) {
+    if (auto *RI = dyn_cast<ReturnInst>(BI->first->getTerminator())) {
       auto thrownValue = remapValue(RI->getOperand());
       getBuilder().createBranch(Loc.getValue(), ReturnToBB,
                                 thrownValue);
@@ -158,7 +158,7 @@ bool SILInliner::inlineFunction(FullApplySite AI, ArrayRef<SILValue> Args) {
 
     // Modify throw terminators to branch to the error-return BB, rather than
     // trying to clone the ThrowInst.
-    if (ThrowInst *TI = dyn_cast<ThrowInst>(BI->first->getTerminator())) {
+    if (auto *TI = dyn_cast<ThrowInst>(BI->first->getTerminator())) {
       if (auto *A = dyn_cast<ApplyInst>(AI)) {
         (void)A;
         assert(A->isNonThrowing() &&

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -4628,7 +4628,7 @@ Expr *ExprRewriter::coerceTupleToTuple(Expr *expr, TupleType *fromTuple,
 
   // Capture the tuple expression, if there is one.
   Expr *innerExpr = lookThroughIdentityExprs(expr);
-  TupleExpr *fromTupleExpr = dyn_cast<TupleExpr>(innerExpr);
+  auto *fromTupleExpr = dyn_cast<TupleExpr>(innerExpr);
 
   /// Check each of the tuple elements in the destination.
   bool hasVariadic = false;
@@ -4700,7 +4700,7 @@ Expr *ExprRewriter::coerceTupleToTuple(Expr *expr, TupleType *fromTuple,
                                             fromTuple, toTuple);
       if (typeFromPattern) {
         std::vector<std::pair<SourceLoc, std::string>> locInsertPairs;
-        TuplePattern *tupleP = dyn_cast<TuplePattern>(typeFromPattern.getValue());
+        auto *tupleP = dyn_cast<TuplePattern>(typeFromPattern.getValue());
         if (tupleP && shouldApplyAddingLabelFixit(tupleP, toTuple, fromTuple,
                                                   locInsertPairs)) {
           for (auto &Pair : locInsertPairs) {
@@ -5321,8 +5321,8 @@ Expr *ExprRewriter::coerceCallArguments(
   (void)failed;
 
   // We should either have parentheses or a tuple.
-  TupleExpr *argTuple = dyn_cast<TupleExpr>(arg);
-  ParenExpr *argParen = dyn_cast<ParenExpr>(arg);
+  auto *argTuple = dyn_cast<TupleExpr>(arg);
+  auto *argParen = dyn_cast<ParenExpr>(arg);
   // FIXME: Eventually, we want to enforce that we have either argTuple or
   // argParen here.
 
@@ -7774,7 +7774,7 @@ Solution::convertBooleanTypeToBuiltinI1(Expr *expr, ConstraintLocator *locator) 
     tc.diagnose(expr->getLoc(), diag::broken_bool);
     return nullptr;
   }
-  FuncDecl *builtinMethod = dyn_cast<FuncDecl>(members[0].Decl);
+  auto *builtinMethod = dyn_cast<FuncDecl>(members[0].Decl);
   if (!builtinMethod) {
     tc.diagnose(expr->getLoc(), diag::broken_bool);
     return nullptr;

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -3850,12 +3850,12 @@ static bool tryIntegerCastFixIts(InFlightDiagnostic &diag,
     return false;
 
   auto getInnerCastedExpr = [&]() -> Expr* {
-    CallExpr *CE = dyn_cast<CallExpr>(expr);
+    auto *CE = dyn_cast<CallExpr>(expr);
     if (!CE)
       return nullptr;
     if (!isa<ConstructorRefCallExpr>(CE->getFn()))
       return nullptr;
-    ParenExpr *parenE = dyn_cast<ParenExpr>(CE->getArg());
+    auto *parenE = dyn_cast<ParenExpr>(CE->getArg());
     if (!parenE)
       return nullptr;
     return parenE->getSubExpr();
@@ -4980,7 +4980,7 @@ static bool diagnoseSingleCandidateFailures(CalleeCandidateInfo &CCI,
     auto rawTy = isRawRepresentable(resTy, CCI.CS);
     if (rawTy && arg.Ty && resTy->isEqual(arg.Ty)) {
       auto getInnerExpr = [](Expr *E) -> Expr* {
-        ParenExpr *parenE = dyn_cast<ParenExpr>(E);
+        auto *parenE = dyn_cast<ParenExpr>(E);
         if (!parenE)
           return nullptr;
         return parenE->getSubExpr();

--- a/lib/Sema/InstrumenterSupport.cpp
+++ b/lib/Sema/InstrumenterSupport.cpp
@@ -61,7 +61,7 @@ public:
     return {true, E};
   }
   bool walkToDeclPre(Decl *D) override {
-    if (ValueDecl *VD = dyn_cast<ValueDecl>(D)) {
+    if (auto *VD = dyn_cast<ValueDecl>(D)) {
       if (!VD->hasInterfaceType() || VD->getInterfaceType()->hasError()) {
         error = true;
         return false;

--- a/lib/Sema/InstrumenterSupport.h
+++ b/lib/Sema/InstrumenterSupport.h
@@ -59,7 +59,7 @@ protected:
       }
     }
     std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
-      if (ClosureExpr *CE = dyn_cast<ClosureExpr>(E)) {
+      if (auto *CE = dyn_cast<ClosureExpr>(E)) {
         BraceStmt *B = CE->getBody();
         if (B) {
           BraceStmt *NB = I.transformBraceStmt(B);

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -2011,7 +2011,7 @@ public:
         if (node.is<Decl *>()) {
           // Flag all variables in a PatternBindingDecl
           Decl *D = node.get<Decl *>();
-          PatternBindingDecl *PBD = dyn_cast<PatternBindingDecl>(D);
+          auto *PBD = dyn_cast<PatternBindingDecl>(D);
           if (!PBD) continue;
           for (PatternBindingEntry PBE : PBD->getPatternList()) {
             PBE.getPattern()->forEachVariable([&](VarDecl *VD) {
@@ -2021,7 +2021,7 @@ public:
         } else if (node.is<Stmt *>()) {
           // Flag all variables in guard statements
           Stmt *S = node.get<Stmt *>();
-          GuardStmt *GS = dyn_cast<GuardStmt>(S);
+          auto *GS = dyn_cast<GuardStmt>(S);
           if (!GS) continue;
           for (StmtConditionElement SCE : GS->getCond()) {
             if (auto pattern = SCE.getPatternOrNull()) {
@@ -2594,7 +2594,7 @@ static void checkCStyleForLoop(TypeChecker &TC, const ForStmt *FS) {
   if (!loopVarDecl || loopVarDecl->getNumPatternEntries() != 1)
     return;
 
-  VarDecl *loopVar = dyn_cast<VarDecl>(initializers[1]);
+  auto *loopVar = dyn_cast<VarDecl>(initializers[1]);
   Expr *startValue = loopVarDecl->getInit(0);
   OperatorKind OpKind;
   Expr *endValue = endConditionValueForConvertingCStyleForLoop(FS, loopVar, OpKind);
@@ -2926,7 +2926,7 @@ public:
     : TC(tc), DC(dc), SelectorTy(selectorTy) { }
 
   std::pair<bool, Expr *> walkToExprPre(Expr *expr) override {
-    StringLiteralExpr *stringLiteral = dyn_cast<StringLiteralExpr>(expr);
+    auto *stringLiteral = dyn_cast<StringLiteralExpr>(expr);
     bool fromStringLiteral = false;
     bool hadParens = false;
     if (stringLiteral) {

--- a/lib/Sema/NameBinding.cpp
+++ b/lib/Sema/NameBinding.cpp
@@ -326,7 +326,7 @@ void swift::performNameBinding(SourceFile &SF, unsigned StartElem) {
   // Do a prepass over the declarations to find and load the imported modules
   // and map operator decls.
   for (auto D : llvm::makeArrayRef(SF.Decls).slice(StartElem)) {
-    if (ImportDecl *ID = dyn_cast<ImportDecl>(D)) {
+    if (auto *ID = dyn_cast<ImportDecl>(D)) {
       Binder.addImport(ImportedModules, ID);
     } else if (auto *OD = dyn_cast<PrefixOperatorDecl>(D)) {
       insertOperatorDecl(Binder, SF.PrefixOperators, OD);

--- a/lib/Sema/PCMacro.cpp
+++ b/lib/Sema/PCMacro.cpp
@@ -126,12 +126,12 @@ public:
                                             // See the elseif.swift test.
       Stmt *NES = transformStmt(ES);
       if (ElseLoc.isValid()) {
-        if (BraceStmt *BS = dyn_cast<BraceStmt>(NES)) {
+        if (auto *BS = dyn_cast<BraceStmt>(NES)) {
           BraceStmt *NBS = prependLoggerCall(BS, ElseLoc);
           if (NBS != ES) {
             IS->setElseStmt(NBS);
           }
-        } else if (IfStmt *EIS = dyn_cast<IfStmt>(NES)) {
+        } else if (auto *EIS = dyn_cast<IfStmt>(NES)) {
           // FIXME: here we should use the old range to show a better highlight
           // (including the previous else)
           if (EIS != ES) {
@@ -300,7 +300,7 @@ public:
   Decl *transformDecl(Decl *D) {
     if (D->isImplicit())
       return D;
-    if (FuncDecl *FD = dyn_cast<FuncDecl>(D)) {
+    if (auto *FD = dyn_cast<FuncDecl>(D)) {
       if (BraceStmt *B = FD->getBody()) {
         BraceStmt *NB = transformBraceStmt(B);
         // Since it would look strange going straight to the first line in a
@@ -341,7 +341,7 @@ public:
 
     for (size_t EI = 0; EI != Elements.size(); ++EI) {
       swift::ASTNode &Element = Elements[EI];
-      if (Expr *E = Element.dyn_cast<Expr *>()) {
+      if (auto *E = Element.dyn_cast<Expr *>()) {
         E->walk(CF);
 
         Added<Stmt *> LogBefore = buildLoggerCall(E->getSourceRange(), true);
@@ -353,9 +353,9 @@ public:
           Elements.insert(Elements.begin() + (EI + 2), *LogAfter);
           EI += 2;
         }
-      } else if (Stmt *S = Element.dyn_cast<Stmt *>()) {
+      } else if (auto *S = Element.dyn_cast<Stmt *>()) {
         S->walk(CF);
-        if (ReturnStmt *RS = dyn_cast<ReturnStmt>(S)) {
+        if (auto *RS = dyn_cast<ReturnStmt>(S)) {
           if (RS->hasResult()) {
             std::pair<PatternBindingDecl *, VarDecl *> PV =
                 buildPatternAndVariable(RS->getResult());
@@ -392,7 +392,7 @@ public:
               EI += 2;
             }
           }
-        } else if (ContinueStmt *CS = dyn_cast<ContinueStmt>(S)) {
+        } else if (auto *CS = dyn_cast<ContinueStmt>(S)) {
           Added<Stmt *> LogBefore = buildLoggerCall(CS->getSourceRange(), true);
           Added<Stmt *> LogAfter = buildLoggerCall(CS->getSourceRange(), false);
           if (*LogBefore && *LogAfter) {
@@ -402,7 +402,7 @@ public:
             EI += 2;
           }
 
-        } else if (BreakStmt *BS = dyn_cast<BreakStmt>(S)) {
+        } else if (auto *BS = dyn_cast<BreakStmt>(S)) {
           Added<Stmt *> LogBefore = buildLoggerCall(BS->getSourceRange(), true);
           Added<Stmt *> LogAfter = buildLoggerCall(BS->getSourceRange(), false);
           if (*LogBefore && *LogAfter) {
@@ -412,7 +412,7 @@ public:
             EI += 2;
           }
 
-        } else if (FallthroughStmt *FS = dyn_cast<FallthroughStmt>(S)) {
+        } else if (auto *FS = dyn_cast<FallthroughStmt>(S)) {
           Added<Stmt *> LogBefore = buildLoggerCall(FS->getSourceRange(), true);
           Added<Stmt *> LogAfter = buildLoggerCall(FS->getSourceRange(), false);
           if (*LogBefore && *LogAfter) {
@@ -428,7 +428,7 @@ public:
             Elements[EI] = NS;
           }
         }
-      } else if (Decl *D = Element.dyn_cast<Decl *>()) {
+      } else if (auto *D = Element.dyn_cast<Decl *>()) {
         D->walk(CF);
         if (auto *PBD = dyn_cast<PatternBindingDecl>(D)) {
           // FIXME: Should iterate all var decls
@@ -684,7 +684,7 @@ void swift::performPCMacro(SourceFile &SF, TopLevelContext &TLC) {
     ExpressionFinder(TopLevelContext &TLC) : TLC(TLC) {}
 
     bool walkToDeclPre(Decl *D) override {
-      if (AbstractFunctionDecl *FD = dyn_cast<AbstractFunctionDecl>(D)) {
+      if (auto *FD = dyn_cast<AbstractFunctionDecl>(D)) {
         if (!FD->isImplicit()) {
           if (FD->getBody()) {
             ASTContext &ctx = FD->getASTContext();
@@ -698,7 +698,7 @@ void swift::performPCMacro(SourceFile &SF, TopLevelContext &TLC) {
             return false;
           }
         }
-      } else if (TopLevelCodeDecl *TLCD = dyn_cast<TopLevelCodeDecl>(D)) {
+      } else if (auto *TLCD = dyn_cast<TopLevelCodeDecl>(D)) {
         if (!TLCD->isImplicit()) {
           if (BraceStmt *Body = TLCD->getBody()) {
             ASTContext &ctx = static_cast<Decl *>(TLCD)->getASTContext();

--- a/lib/Sema/PlaygroundTransform.cpp
+++ b/lib/Sema/PlaygroundTransform.cpp
@@ -273,7 +273,7 @@ public:
   Decl *transformDecl(Decl *D) {
     if (D->isImplicit())
       return D;
-    if (FuncDecl *FD = dyn_cast<FuncDecl>(D)) {
+    if (auto *FD = dyn_cast<FuncDecl>(D)) {
       if (BraceStmt *B = FD->getBody()) {
         TargetKindSetter TKS(BracePairs, BracePair::TargetKinds::Return);
         BraceStmt *NB = transformBraceStmt(B);
@@ -376,9 +376,9 @@ public:
 
     for (size_t EI = 0; EI != Elements.size(); ++EI) {
       swift::ASTNode &Element = Elements[EI];
-      if (Expr *E = Element.dyn_cast<Expr *>()) {
+      if (auto *E = Element.dyn_cast<Expr *>()) {
         E->walk(CF);
-        if (AssignExpr *AE = dyn_cast<AssignExpr>(E)) {
+        if (auto *AE = dyn_cast<AssignExpr>(E)) {
           if (auto *MRE = dyn_cast<MemberRefExpr>(AE->getDest())) {
             // an assignment to a property of an object counts as a mutation of
             // that object
@@ -422,9 +422,9 @@ public:
               EI += 3;
             }
           }
-        } else if (ApplyExpr *AE = dyn_cast<ApplyExpr>(E)) {
+        } else if (auto *AE = dyn_cast<ApplyExpr>(E)) {
           bool Handled = false;
-          if (DeclRefExpr *DRE = dyn_cast<DeclRefExpr>(AE->getFn())) {
+          if (auto *DRE = dyn_cast<DeclRefExpr>(AE->getFn())) {
             auto *FnD = dyn_cast<AbstractFunctionDecl>(DRE->getDecl());
             if (FnD && FnD->getModuleContext() == Context.TheStdlibModule) {
               StringRef FnName = FnD->getNameStr();
@@ -520,9 +520,9 @@ public:
             }
           }
         }
-      } else if (Stmt *S = Element.dyn_cast<Stmt *>()) {
+      } else if (auto *S = Element.dyn_cast<Stmt *>()) {
         S->walk(CF);
-        if (ReturnStmt *RS = dyn_cast<ReturnStmt>(S)) {
+        if (auto *RS = dyn_cast<ReturnStmt>(S)) {
           if (RS->hasResult()) {
             std::pair<PatternBindingDecl *, VarDecl *> PV =
                 buildPatternAndVariable(RS->getResult());
@@ -559,7 +559,7 @@ public:
             Elements[EI] = NS;
           }
         }
-      } else if (Decl *D = Element.dyn_cast<Decl *>()) {
+      } else if (auto *D = Element.dyn_cast<Decl *>()) {
         D->walk(CF);
         if (auto *PBD = dyn_cast<PatternBindingDecl>(D)) {
           if (VarDecl *VD = PBD->getSingleVar()) {
@@ -612,7 +612,7 @@ public:
   }
 
   Added<Stmt *> logDeclOrMemberRef(Added<Expr *> RE) {
-    if (DeclRefExpr *DRE = dyn_cast<DeclRefExpr>(*RE)) {
+    if (auto *DRE = dyn_cast<DeclRefExpr>(*RE)) {
       VarDecl *VD = cast<VarDecl>(DRE->getDecl());
 
       if (isa<ConstructorDecl>(TypeCheckDC) &&
@@ -626,7 +626,7 @@ public:
                                     true, // implicit
                                     AccessSemantics::Ordinary, Type()),
           DRE->getSourceRange(), VD->getName().str().str().c_str());
-    } else if (MemberRefExpr *MRE = dyn_cast<MemberRefExpr>(*RE)) {
+    } else if (auto *MRE = dyn_cast<MemberRefExpr>(*RE)) {
       Expr *B = MRE->getBase();
       ConcreteDeclRef M = MRE->getMember();
 
@@ -648,7 +648,7 @@ public:
   std::pair<PatternBindingDecl *, VarDecl *>
   maybeFixupPrintArgument(ApplyExpr *Print) {
     Expr *ArgTuple = Print->getArg();
-    if (ParenExpr *PE = dyn_cast<ParenExpr>(ArgTuple)) {
+    if (auto *PE = dyn_cast<ParenExpr>(ArgTuple)) {
       std::pair<PatternBindingDecl *, VarDecl *> PV =
           buildPatternAndVariable(PE->getSubExpr());
       PE->setSubExpr(new (Context) DeclRefExpr(
@@ -656,7 +656,7 @@ public:
           true, // implicit
           AccessSemantics::Ordinary, PE->getSubExpr()->getType()));
       return PV;
-    } else if (TupleExpr *TE = dyn_cast<TupleExpr>(ArgTuple)) {
+    } else if (auto *TE = dyn_cast<TupleExpr>(ArgTuple)) {
       if (TE->getNumElements() == 0) {
         return std::make_pair(nullptr, nullptr);
       } else {
@@ -902,7 +902,7 @@ void swift::performPlaygroundTransform(SourceFile &SF, bool HighPerformance) {
     ExpressionFinder(bool HP) : HighPerformance(HP) {}
 
     bool walkToDeclPre(Decl *D) override {
-      if (AbstractFunctionDecl *FD = dyn_cast<AbstractFunctionDecl>(D)) {
+      if (auto *FD = dyn_cast<AbstractFunctionDecl>(D)) {
         if (!FD->isImplicit()) {
           if (BraceStmt *Body = FD->getBody()) {
             ASTContext &ctx = FD->getASTContext();
@@ -915,7 +915,7 @@ void swift::performPlaygroundTransform(SourceFile &SF, bool HighPerformance) {
             return false;
           }
         }
-      } else if (TopLevelCodeDecl *TLCD = dyn_cast<TopLevelCodeDecl>(D)) {
+      } else if (auto *TLCD = dyn_cast<TopLevelCodeDecl>(D)) {
         if (!TLCD->isImplicit()) {
           if (BraceStmt *Body = TLCD->getBody()) {
             ASTContext &ctx = static_cast<Decl *>(TLCD)->getASTContext();

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -376,7 +376,7 @@ private:
       }
     }
 
-    BraceStmt *ParentBrace = dyn_cast<BraceStmt>(Parent.getAsStmt());
+    auto *ParentBrace = dyn_cast<BraceStmt>(Parent.getAsStmt());
     assert(ParentBrace && "Expected parent of GuardStmt to be BraceStmt");
     if (!FallthroughRange.hasValue())
       return;

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1157,7 +1157,7 @@ TypeExpr *PreCheckExpression::simplifyTypeExpr(Expr *E) {
     if (AE->getElements().size() != 1)
       return nullptr;
 
-    TypeExpr *TyExpr = dyn_cast<TypeExpr>(AE->getElement(0));
+    auto *TyExpr = dyn_cast<TypeExpr>(AE->getElement(0));
     if (!TyExpr)
       return nullptr;
 
@@ -1177,11 +1177,11 @@ TypeExpr *PreCheckExpression::simplifyTypeExpr(Expr *E) {
     TypeRepr *keyTypeRepr, *valueTypeRepr;
     
     if (auto EltTuple = dyn_cast<TupleExpr>(DE->getElement(0))) {
-      TypeExpr *KeyTyExpr = dyn_cast<TypeExpr>(EltTuple->getElement(0));
+      auto *KeyTyExpr = dyn_cast<TypeExpr>(EltTuple->getElement(0));
       if (!KeyTyExpr)
         return nullptr;
 
-      TypeExpr *ValueTyExpr = dyn_cast<TypeExpr>(EltTuple->getElement(1));
+      auto *ValueTyExpr = dyn_cast<TypeExpr>(EltTuple->getElement(1));
       if (!ValueTyExpr)
         return nullptr;
      
@@ -2291,7 +2291,7 @@ bool TypeChecker::typeCheckForEachBinding(DeclContext *dc, ForEachStmt *stmt) {
 /// \brief Compute the rvalue type of the given expression, which is the
 /// destination of an assignment statement.
 Type ConstraintSystem::computeAssignDestType(Expr *dest, SourceLoc equalLoc) {
-  if (TupleExpr *TE = dyn_cast<TupleExpr>(dest)) {
+  if (auto *TE = dyn_cast<TupleExpr>(dest)) {
     auto &ctx = getASTContext();
     SmallVector<TupleTypeElt, 4> destTupleTypes;
     for (unsigned i = 0; i != TE->getNumElements(); ++i) {

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -5067,7 +5067,7 @@ public:
 
       Optional<ObjCReason> isObjC = shouldMarkAsObjC(TC, FD);
 
-      ProtocolDecl *protocolContext = dyn_cast<ProtocolDecl>(
+      auto *protocolContext = dyn_cast<ProtocolDecl>(
           FD->getDeclContext());
       if (protocolContext && FD->isAccessor()) {
         if (isObjC)

--- a/lib/Sema/TypeCheckExpr.cpp
+++ b/lib/Sema/TypeCheckExpr.cpp
@@ -167,12 +167,12 @@ TypeChecker::lookupPrecedenceGroupForInfixOperator(DeclContext *DC, Expr *E) {
                                      castExpr->getAsLoc());
   }
 
-  if (DeclRefExpr *DRE = dyn_cast<DeclRefExpr>(E)) {
+  if (auto *DRE = dyn_cast<DeclRefExpr>(E)) {
     Identifier name = DRE->getDecl()->getName();
     return lookupPrecedenceGroupForOperator(*this, DC, name, DRE->getLoc());
   }
 
-  if (OverloadedDeclRefExpr *OO = dyn_cast<OverloadedDeclRefExpr>(E)) {
+  if (auto *OO = dyn_cast<OverloadedDeclRefExpr>(E)) {
     Identifier name = OO->getDecls()[0]->getName();
     return lookupPrecedenceGroupForOperator(*this, DC, name, OO->getLoc());
   }
@@ -207,7 +207,7 @@ static Expr *makeBinOp(TypeChecker &TC, Expr *Op, Expr *LHS, Expr *RHS,
     return nullptr;
 
   // If the left-hand-side is a 'try', hoist it up.
-  AnyTryExpr *tryEval = dyn_cast<AnyTryExpr>(LHS);
+  auto *tryEval = dyn_cast<AnyTryExpr>(LHS);
   if (tryEval) {
     LHS = tryEval->getSubExpr();
   }

--- a/lib/Sema/TypeCheckREPL.cpp
+++ b/lib/Sema/TypeCheckREPL.cpp
@@ -440,17 +440,17 @@ void TypeChecker::processREPLTopLevel(SourceFile &SF, TopLevelContext &TLC,
   for (Decl *D : NewDecls) {
     SF.Decls.push_back(D);
 
-    TopLevelCodeDecl *TLCD = dyn_cast<TopLevelCodeDecl>(D);
+    auto *TLCD = dyn_cast<TopLevelCodeDecl>(D);
     if (!TLCD || TLCD->getBody()->getElements().empty())
       continue;
 
     auto Entry = TLCD->getBody()->getElement(0);
 
     // Check to see if the TLCD has an expression that we have to transform.
-    if (Expr *E = Entry.dyn_cast<Expr*>())
+    if (auto *E = Entry.dyn_cast<Expr*>())
       RC.processREPLTopLevelExpr(E);
-    else if (Decl *D = Entry.dyn_cast<Decl*>())
-      if (PatternBindingDecl *PBD = dyn_cast<PatternBindingDecl>(D))
+    else if (auto *D = Entry.dyn_cast<Decl*>())
+      if (auto *PBD = dyn_cast<PatternBindingDecl>(D))
         RC.processREPLTopLevelPatternBinding(PBD);
   }
 

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -243,21 +243,21 @@ static void tryDiagnoseUnnecessaryCastOverOptionSet(ASTContext &Ctx,
         NTD->lookupConformance(module, optionSetType, conformances)))
     return;
 
-  CallExpr *CE = dyn_cast<CallExpr>(E);
+  auto *CE = dyn_cast<CallExpr>(E);
   if (!CE)
     return;
   if (!isa<ConstructorRefCallExpr>(CE->getFn()))
     return;
-  ParenExpr *ParenE = dyn_cast<ParenExpr>(CE->getArg());
+  auto *ParenE = dyn_cast<ParenExpr>(CE->getArg());
   if (!ParenE)
     return;
-  MemberRefExpr *ME = dyn_cast<MemberRefExpr>(ParenE->getSubExpr());
+  auto *ME = dyn_cast<MemberRefExpr>(ParenE->getSubExpr());
   if (!ME)
     return;
   ValueDecl *VD = ME->getMember().getDecl();
   if (!VD || VD->getName() != Ctx.Id_rawValue)
     return;
-  MemberRefExpr *BME = dyn_cast<MemberRefExpr>(ME->getBase());
+  auto *BME = dyn_cast<MemberRefExpr>(ME->getBase());
   if (!BME)
     return;
   if (!BME->getType()->isEqual(ResultType))
@@ -1197,11 +1197,11 @@ void TypeChecker::checkIgnoredExpr(Expr *E) {
     // constructor calls during CSApply / ExprRewriter::convertLiteral.
     if (call->isImplicit()) {
       Expr *arg = call->getArg();
-      if (TupleExpr *TE = dyn_cast<TupleExpr>(arg))
+      if (auto *TE = dyn_cast<TupleExpr>(arg))
         if (TE->getNumElements() == 1)
           arg = TE->getElement(0);
 
-      if (LiteralExpr *LE = dyn_cast<LiteralExpr>(arg)) {
+      if (auto *LE = dyn_cast<LiteralExpr>(arg)) {
         diagnoseIgnoredLiteral(*this, LE);
         return;
       }
@@ -1245,7 +1245,7 @@ void TypeChecker::checkIgnoredExpr(Expr *E) {
 Stmt *StmtChecker::visitBraceStmt(BraceStmt *BS) {
   const SourceManager &SM = TC.Context.SourceMgr;
   for (auto &elem : BS->getElements()) {
-    if (Expr *SubExpr = elem.dyn_cast<Expr*>()) {
+    if (auto *SubExpr = elem.dyn_cast<Expr*>()) {
       SourceLoc Loc = SubExpr->getStartLoc();
       if (EndTypeCheckLoc.isValid() &&
           (Loc == EndTypeCheckLoc || SM.isBeforeInBuffer(EndTypeCheckLoc, Loc)))
@@ -1280,7 +1280,7 @@ Stmt *StmtChecker::visitBraceStmt(BraceStmt *BS) {
       continue;
     }
 
-    if (Stmt *SubStmt = elem.dyn_cast<Stmt*>()) {
+    if (auto *SubStmt = elem.dyn_cast<Stmt*>()) {
       SourceLoc Loc = SubStmt->getStartLoc();
       if (EndTypeCheckLoc.isValid() &&
           (Loc == EndTypeCheckLoc || SM.isBeforeInBuffer(EndTypeCheckLoc, Loc)))
@@ -1530,7 +1530,7 @@ bool TypeChecker::typeCheckConstructorBodyUntil(ConstructorDecl *ctor,
   if (nominalDecl == nullptr)
     return HadError;
 
-  ClassDecl *ClassD = dyn_cast<ClassDecl>(nominalDecl);
+  auto *ClassD = dyn_cast<ClassDecl>(nominalDecl);
   bool wantSuperInitCall = false;
   if (ClassD) {
     bool isDelegating = false;

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2161,7 +2161,7 @@ Type TypeResolver::resolveAttributedType(TypeAttributes &attrs,
     }
 
   // Function attributes require a syntactic function type.
-  FunctionTypeRepr *fnRepr = dyn_cast<FunctionTypeRepr>(repr);
+  auto *fnRepr = dyn_cast<FunctionTypeRepr>(repr);
 
   if (hasFunctionAttr && fnRepr && (options & TR_SILType)) {
     SILFunctionType::Representation rep;

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -708,7 +708,7 @@ void swift::performTypeChecking(SourceFile &SF, TopLevelContext &TLC,
 
     bool hasTopLevelCode = false;
     for (auto D : llvm::makeArrayRef(SF.Decls).slice(StartElem)) {
-      if (TopLevelCodeDecl *TLCD = dyn_cast<TopLevelCodeDecl>(D)) {
+      if (auto *TLCD = dyn_cast<TopLevelCodeDecl>(D)) {
         hasTopLevelCode = true;
         // Immediately perform global name-binding etc.
         TC.typeCheckTopLevelCodeDecl(TLCD);

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3849,7 +3849,7 @@ class YamlGroupInputParser {
 
   bool parseRoot(FileNameToGroupNameMap &Map, llvm::yaml::Node *Root,
                  StringRef ParentName) {
-    llvm::yaml::MappingNode *MapNode = dyn_cast<llvm::yaml::MappingNode>(Root);
+    auto *MapNode = dyn_cast<llvm::yaml::MappingNode>(Root);
     if (!MapNode) {
       return true;
     }
@@ -3923,7 +3923,7 @@ public:
 
     // The format is a map of ("group0" : ["file1", "file2"]), meaning all
     // symbols from file1 and file2 belong to "group0".
-    llvm::yaml::MappingNode *Map = dyn_cast<llvm::yaml::MappingNode>(Root);
+    auto *Map = dyn_cast<llvm::yaml::MappingNode>(Root);
     if (!Map) {
       return true;
     }

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -202,7 +202,7 @@ void TBDGenVisitor::visitAbstractFunctionDecl(AbstractFunctionDecl *AFD) {
     paramLists = paramLists.slice(1);
   for (auto *paramList : paramLists) {
     for (auto *param : *paramList) {
-      if (auto defaultArg = param->getDefaultValue())
+      if (param->getDefaultValue())
         addSymbol(SILDeclRef::getDefaultArgGenerator(AFD, index));
       index++;
     }

--- a/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
+++ b/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
@@ -952,7 +952,7 @@ static void sortRecursive(const Options &options, Group *group,
   auto &contents = group->contents;
   double best = -1.0;
   for (auto &item : contents) {
-    if (Group *g = dyn_cast<Group>(item.get())) {
+    if (auto *g = dyn_cast<Group>(item.get())) {
       sortRecursive(options, g, hasExpectedTypes);
     } else {
       Result *r = cast<Result>(item.get());
@@ -1047,7 +1047,7 @@ void CodeCompletionOrganizer::Impl::groupStemsRecursive(
 
   auto start = worklist.begin();
   while (start != worklist.end()) {
-    if (Group *g = dyn_cast<Group>(start->get())) {
+    if (auto *g = dyn_cast<Group>(start->get())) {
       groupStemsRecursive(g, recurseIntoNewGroups, getStem);
       newContents.push_back(std::move(*start));
       ++start;

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -108,12 +108,12 @@ class AnnotatingPrinter : public StreamPrinter {
   DefaultImplementMap *DefaultMapToUse = nullptr;
 
   void initDefaultMapToUse(const Decl *D) {
-    const ExtensionDecl *ED = dyn_cast<ExtensionDecl>(D);
+    const auto *ED = dyn_cast<ExtensionDecl>(D);
     if (!ED)
       return;
     if (ED->getExtendedType()) {
       if (auto NTD = ED->getExtendedType()->getAnyNominal()) {
-        if (ProtocolDecl *PD = dyn_cast<ProtocolDecl>(NTD)) {
+        if (auto *PD = dyn_cast<ProtocolDecl>(NTD)) {
           auto Pair = AllDefaultMaps.insert({PD, DefaultImplementMap()});
           DefaultMapToUse = &Pair.first->getSecond();
           if (Pair.second) {
@@ -134,7 +134,7 @@ class AnnotatingPrinter : public StreamPrinter {
   ValueDecl *getDefaultImplementation(const Decl *D) {
     if (!DefaultMapToUse)
       return nullptr;
-    ValueDecl *VD = const_cast<ValueDecl*>(dyn_cast<ValueDecl>(D));
+    auto *VD = const_cast<ValueDecl*>(dyn_cast<ValueDecl>(D));
     auto Found = DefaultMapToUse->find(VD);
     if (Found != DefaultMapToUse->end()) {
       return Found->second;
@@ -324,7 +324,7 @@ static bool initDocEntityInfo(const Decl *D, const Decl *SynthesizedTarget,
 
   if (Info.Kind.isInvalid())
     return true;
-  if (const ValueDecl *VD = dyn_cast<ValueDecl>(D)) {
+  if (const auto *VD = dyn_cast<ValueDecl>(D)) {
     llvm::raw_svector_ostream NameOS(Info.Name);
     SwiftLangSupport::printDisplayName(VD, NameOS);
     {
@@ -409,7 +409,7 @@ static bool initDocEntityInfo(const Decl *D, const Decl *SynthesizedTarget,
     // We report sub-module information only for top-level decls.
     case DeclContextKind::Module:
     case DeclContextKind::FileUnit: {
-      if (auto* CD = D->getClangDecl()) {
+      if (auto *CD = D->getClangDecl()) {
         if (auto *M = CD->getImportedOwningModule()) {
           const clang::Module *Root = M->getTopLevelModule();
 
@@ -517,7 +517,7 @@ static void reportRelated(ASTContext &Ctx,
                           DocInfoConsumer &Consumer) {
   if (!D || isa<ParamDecl>(D))
     return;
-  if (const ExtensionDecl *ED = dyn_cast<ExtensionDecl>(D)) {
+  if (const auto *ED = dyn_cast<ExtensionDecl>(D)) {
     if (SynthesizedTarget) {
       passExtends((ValueDecl*)SynthesizedTarget, Consumer);
     } else if (Type T = ED->getExtendedType()) {
@@ -543,7 +543,7 @@ static void reportRelated(ASTContext &Ctx,
 
     // Otherwise, report the inheritance of the type alias itself.
     passInheritsAndConformancesForValueDecl(TAD, Consumer);
-  } else if (const TypeDecl *TD = dyn_cast<TypeDecl>(D)) {
+  } else if (const auto *TD = dyn_cast<TypeDecl>(D)) {
     passInherits(TD->getInherited(), Consumer);
     passConforms(TD->getSatisfiedProtocolRequirements(/*Sorted=*/true),
                  Consumer);

--- a/tools/swift-api-digester/swift-api-digester.cpp
+++ b/tools/swift-api-digester/swift-api-digester.cpp
@@ -954,7 +954,7 @@ static StringRef getTypeName(SDKContext &Ctx, Type Ty) {
   if (Ty->isVoid()) {
     return Ctx.buffer("Void");
   }
-  if (NameAliasType *NAT = dyn_cast<NameAliasType>(Ty.getPointer())) {
+  if (auto *NAT = dyn_cast<NameAliasType>(Ty.getPointer())) {
     return NAT->getDecl()->getNameStr();
   }
   if (Ty->getAnyNominal()) {
@@ -2471,7 +2471,7 @@ class DiffItemEmitter : public SDKNodeVisitor {
   }
 
   void visit(NodePtr Node) override {
-    SDKNodeDecl *Parent = dyn_cast<SDKNodeDecl>(Node);
+    auto *Parent = dyn_cast<SDKNodeDecl>(Node);
     if (!Parent) {
       if (auto TN = dyn_cast<SDKNodeType>(Node)) {
         Parent = TN->getClosestParentDecl();

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -1240,7 +1240,7 @@ private:
   bool walkToDeclPre(Decl *D, CharSourceRange Range) override {
     if (Range.getByteLength() == 0)
       return true;
-    if (ValueDecl *VD = dyn_cast<ValueDecl>(D))
+    if (auto *VD = dyn_cast<ValueDecl>(D))
       annotateSourceEntity({ Range, VD, nullptr, /*IsRef=*/false});
     return true;
   }
@@ -1626,7 +1626,7 @@ public:
     if (isa<ProtocolDecl>(D)) {
       InProtocol = true;
       DefaultImplementationMap.clear();
-      ProtocolDecl *PD = const_cast<ProtocolDecl*>(dyn_cast<ProtocolDecl>(D));
+      auto *PD = const_cast<ProtocolDecl*>(dyn_cast<ProtocolDecl>(D));
       collectDefaultImplementationForProtocolMembers(PD,
                                                      DefaultImplementationMap);
     }
@@ -2497,7 +2497,7 @@ public:
 
 private:
   bool walkToDeclPre(Decl *D, CharSourceRange Range) override {
-    if (ValueDecl *VD = dyn_cast<ValueDecl>(D))
+    if (auto *VD = dyn_cast<ValueDecl>(D))
       printUSR(VD, Range.getStart());
     return true;
   }


### PR DESCRIPTION
The DRY `auto` version is by far the dominant form already used in the repo, so this PR merely brings the relatively few remaining exceptional cases (redundant repetition form) in line with the dominant form (`auto` form).

See the [C++ Core Guidelines](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#es11-use-auto-to-avoid-redundant-repetition-of-type-names) for a general discussion on why to use `auto` to avoid redundant repetition of type names.

See 503774e5a7041e2aa9b2eadae3a4065a0c202b59 for a similar cleanup which standardized usage of `auto` in `if-dyncast` pattern locally.