### PR TITLE
[cursor-info] Tweak check to not report parent_loc on locals in body

### DIFF
--- a/test/SourceKit/CursorInfo/cursor_label.swift
+++ b/test/SourceKit/CursorInfo/cursor_label.swift
@@ -5,6 +5,10 @@ class C1 {
   func foo(_ aa : Int) {}
   init(_ cc: Int) {}
   subscript(_ aa : Int)-> Int { get { return 0 } set {}}
+  func foo(label aa : Int, bb: Int) {
+    _ = aa
+    _ = bb
+  }
 }
 let c = C1(cc: 1)
 c.foo(aa : 1)
@@ -15,8 +19,13 @@ c.foo(aa : 1)
 // RUN: %sourcekitd-test -req=cursor -pos=5:15 %s -- %s | %FileCheck %s -check-prefix=CHECK-NONE
 // RUN: %sourcekitd-test -req=cursor -pos=6:11 %s -- %s | %FileCheck %s -check-prefix=CHECK-NONE
 // RUN: %sourcekitd-test -req=cursor -pos=7:16 %s -- %s | %FileCheck %s -check-prefix=CHECK-NONE
+// RUN: %sourcekitd-test -req=cursor -pos=8:18 %s -- %s | %FileCheck %s -check-prefix=CHECK-NONE
+// RUN: %sourcekitd-test -req=cursor -pos=8:28 %s -- %s | %FileCheck %s -check-prefix=CHECK4
+// RUN: %sourcekitd-test -req=cursor -pos=9:9 %s -- %s | %FileCheck %s -check-prefix=CHECK-NONE
+// RUN: %sourcekitd-test -req=cursor -pos=10:9 %s -- %s | %FileCheck %s -check-prefix=CHECK4
 
 // CHECK1: PARENT OFFSET: 13
 // CHECK2: PARENT OFFSET: 37
 // CHECK3: PARENT OFFSET: 56
+// CHECK4: PARENT OFFSET: 229
 // CHECK-NONE-NOT: PARENT OFFSET:

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -621,7 +621,7 @@ getParamParentNameOffset(const ValueDecl *VD, SourceLoc Cursor) {
   if (auto PD = dyn_cast<ParamDecl>(VD)) {
 
     // Avoid returning parent loc for internal-only names.
-    if (PD->getArgumentNameLoc().isValid() && PD->getNameLoc() == Cursor)
+    if (PD->getArgumentNameLoc().isValid() && PD->getArgumentNameLoc() != Cursor)
       return None;
     auto *DC = PD->getDeclContext();
     switch (DC->getContextKind()) {


### PR DESCRIPTION
We were checking only for the specific loc of the declaration of the
param, but that didn't handle references to a local parameter inside the
body.

rdar://problem/32019195