### PR TITLE
[Foundation] Improve String bridge performance by implementing SPIs to access character buffers directly

### DIFF
--- a/stdlib/public/SDK/Foundation/CMakeLists.txt
+++ b/stdlib/public/SDK/Foundation/CMakeLists.txt
@@ -24,6 +24,7 @@ add_swift_library(swiftFoundation ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SD
   Notification.swift
   NSArray.swift
   NSCoder.swift
+  NSContiguousString.swift
   NSDate.swift
   NSDictionary.swift
   NSError.swift

--- a/stdlib/public/SDK/Foundation/NSContiguousString.swift
+++ b/stdlib/public/SDK/Foundation/NSContiguousString.swift
@@ -1,0 +1,60 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_exported import Foundation // Clang module
+
+extension _NSContiguousString {
+    @objc(copyWithZone:)
+    func copy(with zone: NSZone? = nil) -> Any {
+        // Since this string is immutable we can just return ourselves.
+        return self
+    }
+    
+    @objc
+    var fastestEncoding: UInt {
+        return _core.elementWidth == 1 ? String.Encoding.ascii.rawValue : String.Encoding.utf16.rawValue
+    }
+    
+    @objc
+    var smallestEncoding: UInt {
+        return _core.elementWidth == 1 ? String.Encoding.ascii.rawValue : String.Encoding.utf16.rawValue
+    }
+    
+    /// The following methods are purely optimizations as special dispensation from
+    /// Foundation. Relying on these methods to exist, return sane results and/or being
+    /// used in production code is strictly not supported. They may change behavior in
+    /// future releases and are purely SPI for authorized consumers.
+    @objc(_fastCharacterContents)
+    func _fastCharacterContents() -> UnsafeRawPointer? {
+        return _core.elementWidth == 2 ? UnsafeRawPointer(_core.startUTF16) : nil
+    }
+    
+    @objc(_fastCStringContents:)
+    func _fastCStringContents(_ nullTerminationRequired: Bool) -> UnsafeRawPointer? {
+        guard _core.isASCII else {
+            return nil
+        }
+        guard nullTerminationRequired else {
+            return UnsafeRawPointer(_core.startASCII)
+        }
+        let cnt = _core.count
+        guard cnt != 0 else { 
+            return nil
+        }
+        // This depends on the underlying buffer either being a slice or a null terminated buffer 
+        // because it will read off the end of the slice by one byte...
+        guard _core.startASCII[cnt] == 0 else {
+            return nil
+        }
+        return UnsafeRawPointer(_core.startASCII)
+    }
+}

--- a/stdlib/public/core/StringBridge.swift
+++ b/stdlib/public/core/StringBridge.swift
@@ -250,11 +250,6 @@ public final class _NSContiguousString : _SwiftNativeNSString {
     }
   }
 
-  @objc
-  func _fastCharacterContents() -> UnsafeMutablePointer<UInt16>? {
-    return _core.elementWidth == 2 ? _core.startUTF16 : nil
-  }
-
   //
   // Implement sub-slicing without adding layers of wrapping
   //

--- a/test/stdlib/Inputs/FoundationBridge/FoundationBridge.h
+++ b/test/stdlib/Inputs/FoundationBridge/FoundationBridge.h
@@ -20,6 +20,11 @@ typedef NS_ENUM(NSInteger, ObjectBehaviorAction) {
     ObjectBehaviorActionMutableCopy
 };
 
+typedef NS_OPTIONS(NSInteger, ObjectBehaviorEqualityOptions) {
+    ObjectBehaviorEqualityOptionsCopy = 1 << 0,
+    ObjectBehaviorEqualityOptionsRawPointerCompare = 1 << 1,
+};
+
 // NOTE: this class is NOT meant to be used in threaded contexts.
 @interface ObjectBehaviorVerifier : NSObject
 @property (readonly) BOOL wasRetained;
@@ -30,6 +35,9 @@ typedef NS_ENUM(NSInteger, ObjectBehaviorAction) {
 - (void)enumerate:(void (^)(ObjectBehaviorAction))block;
 - (void)reset;
 - (void)dump;
+
++ (BOOL)verifyEqualityOfObject:(NSObject *)left withObject:(NSObject *)right options:(ObjectBehaviorEqualityOptions)options;
+
 @end
 
 #pragma mark - NSData verification

--- a/test/stdlib/Inputs/FoundationBridge/FoundationBridge.m
+++ b/test/stdlib/Inputs/FoundationBridge/FoundationBridge.m
@@ -74,6 +74,54 @@
     }];
 }
 
+
++ (BOOL)verifyEqualityOfObject:(NSObject *)left
+                    withObject:(NSObject *)right
+                       options:(ObjectBehaviorEqualityOptions)options {
+    if (options & ObjectBehaviorEqualityOptionsCopy) {
+        NSObject *leftCopy = [left copy];
+        NSObject *leftCopyWithZone = [(id<NSCopying>)left copyWithZone:nil];
+        NSObject *rightCopy = [right copy];
+        NSObject *rightCopyWithZone = [(id<NSCopying>)right copyWithZone:nil];
+        options = options & (~(ObjectBehaviorEqualityOptionsCopy));
+        BOOL res = [self verifyEqualityOfObject:left
+                                     withObject:leftCopy
+                                        options:options] &&
+               [self verifyEqualityOfObject:left
+                                 withObject:leftCopyWithZone
+                                    options:options] &&
+               [self verifyEqualityOfObject:leftCopy
+                                 withObject:rightCopy
+                                    options:options] &&
+               [self verifyEqualityOfObject:leftCopy
+                                 withObject:rightCopyWithZone
+                                    options:options] &&
+               [self verifyEqualityOfObject:leftCopyWithZone
+                                 withObject:rightCopy
+                                    options:options] &&
+               [self verifyEqualityOfObject:leftCopyWithZone
+                                 withObject:rightCopy
+                                    options:options] &&
+               [self verifyEqualityOfObject:leftCopyWithZone
+                                 withObject:rightCopyWithZone
+                                    options:options] &&
+               [self verifyEqualityOfObject:rightCopy
+                                 withObject:rightCopyWithZone
+                                    options:options];
+        [leftCopy release];
+        [rightCopy release];
+        [leftCopyWithZone release];
+        [rightCopyWithZone release];
+        return res;
+    }
+    if (options &ObjectBehaviorEqualityOptionsRawPointerCompare) {
+        if (left != right) {
+            return NO;
+        }
+    }
+    return [left isEqual:right] && [right isEqual:left];
+}
+
 @end
 
 

--- a/test/stdlib/TestNSStringBridge.swift
+++ b/test/stdlib/TestNSStringBridge.swift
@@ -1,0 +1,102 @@
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+//
+// RUN: %target-clang %S/Inputs/FoundationBridge/FoundationBridge.m -c -o %t/FoundationBridgeObjC.o -g
+// RUN: %target-build-swift %s -I %S/Inputs/FoundationBridge/ -Xlinker %t/FoundationBridgeObjC.o -o %t/TestNSStringBridge
+
+// RUN: %target-run %t/TestNSStringBridge > %t.txt
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+import Foundation
+import FoundationBridgeObjC
+
+#if FOUNDATION_XCTEST
+    import XCTest
+    class TestNSStringBridgeSuper : XCTestCase { }
+#else
+    import StdlibUnittest
+    class TestNSStringBridgeSuper { }
+#endif
+
+
+// these are just here so that AnyObject picks up the SPI for Foundation fast-path access in ObjC
+class SelectorPlaceholder : NSObject {
+    @objc(_fastCharacterContents)
+    func _fastCharacterContents() -> UnsafeRawPointer? { return nil }
+    @objc(_fastCStringContents:)
+    func _fastCStringContents(_ nullTerminationRequired: Bool) -> UnsafeRawPointer? { return nil }
+}
+
+class TestNSStringBridge : TestNSStringBridgeSuper {
+    func test_bridgeASCII() {
+        let string = "hello world"
+        let fastCharacters = (string as AnyObject)._fastCharacterContents()
+        let fastCStringNullTerm = (string as AnyObject)._fastCStringContents(true)
+        let fastCString = (string as AnyObject)._fastCStringContents(false)
+        expectNil(fastCharacters)
+        expectNotNil(fastCStringNullTerm)
+        expectNotNil(fastCString)
+        expectEqual(string.fastestEncoding, String.Encoding.ascii)
+        expectEqual(string.smallestEncoding, String.Encoding.ascii)
+    }
+
+    func test_bridgeUnicode() {
+        let string = "héllö wørld"
+        let fastCharacters = (string as AnyObject)._fastCharacterContents()
+        let fastCStringNullTerm = (string as AnyObject)._fastCStringContents(true)
+        let fastCString = (string as AnyObject)._fastCStringContents(false)
+        expectNotNil(fastCharacters)
+        expectNil(fastCStringNullTerm)
+        expectNil(fastCString)
+        expectEqual(string.fastestEncoding, String.Encoding.utf16)
+        expectEqual(string.smallestEncoding, String.Encoding.utf16)
+    }
+
+    func test_bridgeSubstring() {
+        let string = "hello world this is a longer string to be sliced"
+        let slice = string[string.index(string.startIndex, offsetBy: 4)..<string.index(string.startIndex, offsetBy: 10)]
+
+        expectNotNil((string as AnyObject)._fastCStringContents(true))
+        expectNotNil((string as AnyObject)._fastCStringContents(false))
+        expectNil((slice as AnyObject)._fastCStringContents(true))
+        expectNotNil((slice as AnyObject)._fastCStringContents(false))
+    }
+
+    func test_emptyBridge() {
+        let string = ""
+        expectNil((string as AnyObject)._fastCStringContents(true))
+        expectNil((string as AnyObject)._fastCStringContents(false))
+    }
+
+    func test_copy() {
+        let string1 = "test"
+        let ns1 = string1 as NSString
+        expectTrue(ObjectBehaviorVerifier.verifyEquality(of: ns1, with: ns1, options: [.copy, .rawPointerCompare]))
+
+        let string2 = "This is a test of strings"
+        let ns2 = string2 as NSString
+        expectTrue(ObjectBehaviorVerifier.verifyEquality(of: ns2, with: ns2, options: [.copy, .rawPointerCompare]))
+
+
+        let string3 = "héllö wørld"
+        let ns3 = string3 as NSString
+        expectTrue(ObjectBehaviorVerifier.verifyEquality(of: ns3, with: ns3, options: [.copy, .rawPointerCompare]))
+    }
+}
+
+#if !FOUNDATION_XCTEST
+var NSStringBridgeTests = TestSuite("TestNSStringBridge")
+NSStringBridgeTests.test("test_bridgeASCII") { TestNSStringBridge().test_bridgeASCII() }
+NSStringBridgeTests.test("test_bridgeUnicode") { TestNSStringBridge().test_bridgeUnicode() }
+NSStringBridgeTests.test("test_copy") { TestNSStringBridge().test_copy() }
+runAllTests()
+#endif


### PR DESCRIPTION
When Swift strings are bridged back into objective-c two distinct methods can be called to get fast-access to the underlying buffers of the strings. These come in two flavors - either eight-bit contents or unicode contents. When the backing of the swift string is represented as a buffer of unicode characters (an element width of 2) the fastest and smallest encoding is unicode (NSUnicodeStringEncoding = 10) and the buffer can be portrayed to obejctive-c directly as a cast of the startUTF16 to a constant unichar pointer. Likewise when the backing is ASCII the buffer can be represented as an eight bit encoding (NSASCIIStringEncoding = 1) and the buffer can be directly accessed as a constant char pointer.

This in normal cases can improve the bridging performance in the upwards of 90% faster access in bridged cases when passing a swift string into objective-c APIs.