### PR TITLE
Revert "[stdlib] Inline var first default implementation"

### DIFF
--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -1330,15 +1330,12 @@ extension Collection {
   ///     // Prints "10"
   @_inlineable
   public var first: Iterator.Element? {
-    @inline(__always)
-    get {
-      // NB: Accessing `startIndex` may not be O(1) for some lazy collections,
-      // so instead of testing `isEmpty` and then returning the first element,
-      // we'll just rely on the fact that the iterator always yields the
-      // first element first.
-      var i = makeIterator()
-      return i.next()
-    }
+    // NB: Accessing `startIndex` may not be O(1) for some lazy collections,
+    // so instead of testing `isEmpty` and then returning the first element,
+    // we'll just rely on the fact that the iterator always yields the
+    // first element first.
+    var i = makeIterator()
+    return i.next()
   }
   
   // TODO: swift-3-indexing-model - uncomment and replace above ready (or should we still use the iterator one?)


### PR DESCRIPTION
This reverts commit fe38ab15793030183f141cd52f27cfa7621c7513.
It wasn't contributing anything to performance.
