### PR TITLE
Runtime support for the NSArchiver class attributes.

### DIFF
--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -1217,6 +1217,14 @@ FUNCTION(GetKeyPath, swift_getKeyPath, C_CC,
          ARGS(Int8PtrTy, Int8PtrTy),
          ATTRS(NoUnwind))
 
+// func _registerClassNameForArchiving(_ nameOrNull: UnsafePointer<CChar>?,
+//                                     _ c: AnyClass)
+FUNCTION(RegisterClassNameForArchiving, swift_registerClassNameForArchiving,
+         SwiftCC,
+         RETURNS(VoidTy),
+         ARGS(Int8PtrTy, TypeMetadataPtrTy),
+         ATTRS(NoUnwind))
+
 #if SWIFT_OBJC_INTEROP || !defined(SWIFT_RUNTIME_GENERATE_GLOBAL_SYMBOLS)
 
 // Put here all definitions of runtime functions which are:

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -960,6 +960,9 @@ void IRGenModule::emitClassDecl(ClassDecl *D) {
   emitClassMetadata(*this, D,
                     classTI.getLayout(*this, selfType),
                     classTI.getClassLayout(*this, selfType));
+
+  IRGen.addClassForArchiveNameRegistration(D);
+
   emitNestedTypeDecls(D->getMembers());
   emitFieldMetadataRecord(D);
 }

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -41,9 +41,11 @@
 #include "llvm/IR/Module.h"
 #include "llvm/IR/TypeBuilder.h"
 #include "llvm/IR/Value.h"
+#include "llvm/IR/InlineAsm.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/ConvertUTF.h"
 #include "llvm/Support/Path.h"
+#include "llvm/Transforms/Utils/ModuleUtils.h"
 
 #include "ConstantBuilder.h"
 #include "Explosion.h"
@@ -940,6 +942,56 @@ void IRGenerator::emitLazyDefinitions() {
       IGM->emitSILFunction(f);
     }
   }
+}
+
+void IRGenerator::emitNSArchiveClassNameRegistration() {
+  if (ClassesForArchiveNameRegistration.empty())
+    return;
+
+  // Emit the register function in the primary module.
+  IRGenModule *IGM = getPrimaryIGM();
+
+  llvm::Function *RegisterFn = llvm::Function::Create(
+                                llvm::FunctionType::get(IGM->VoidTy, false),
+                                llvm::GlobalValue::InternalLinkage,
+                                "_swift_register_class_names_for_archives");
+  IRGenFunction RegisterIGF(*IGM, RegisterFn);
+  RegisterFn->setAttributes(IGM->constructInitialAttributes());
+  IGM->Module.getFunctionList().push_back(RegisterFn);
+  RegisterFn->setCallingConv(IGM->DefaultCC);
+
+  for (ClassDecl *CD : ClassesForArchiveNameRegistration) {
+    Type Ty = CD->getDeclaredType();
+    llvm::Value *MetaData = RegisterIGF.emitTypeMetadataRef(getAsCanType(Ty));
+    if (auto *LegacyAttr = CD->getAttrs().
+          getAttribute<NSKeyedArchiveLegacyAttr>()) {
+      // Register the name for the class in the NSKeyed(Un)Archiver.
+      llvm::Value *NameStr = IGM->getAddrOfGlobalString(LegacyAttr->Name);
+      RegisterIGF.Builder.CreateCall(IGM->getRegisterClassNameForArchivingFn(),
+                                     {NameStr, MetaData});
+    } else {
+      assert(CD->getAttrs().hasAttribute<StaticInitializeObjCMetadataAttr>());
+
+      // In this case we don't add a name mapping, but just get the metadata
+      // to make sure that the class is registered. But: we need to add a use
+      // (empty inline asm instruction) for the metadata. Otherwise
+      // llvm would optimize the metadata accessor call away because it's
+      // defined as "readnone".
+      llvm::FunctionType *asmFnTy =
+        llvm::FunctionType::get(IGM->VoidTy, {MetaData->getType()},
+                                false /* = isVarArg */);
+      llvm::InlineAsm *inlineAsm =
+        llvm::InlineAsm::get(asmFnTy, "", "r", true /* = SideEffects */);
+      RegisterIGF.Builder.CreateCall(inlineAsm, MetaData);
+    }
+  }
+  RegisterIGF.Builder.CreateRetVoid();
+
+  // Add the registration function as a static initializer. We use a priority
+  // slightly lower than used for C++ global constructors, so that the code is
+  // executed before C++ global constructors (in case someone uses archives
+  // from a C++ global constructor).
+  llvm::appendToGlobalCtors(IGM->Module, RegisterFn, 60000, nullptr);
 }
 
 /// Emit symbols for eliminated dead methods, which can still be referenced

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -715,6 +715,7 @@ static std::unique_ptr<llvm::Module> performIRGeneration(IRGenOptions &Opts,
       IGM.emitTypeMetadataRecords();
       IGM.emitBuiltinReflectionMetadata();
       IGM.emitReflectionMetadataVersion();
+      irgen.emitNSArchiveClassNameRegistration();
     }
 
     // Emit symbols for eliminated dead methods.
@@ -892,6 +893,8 @@ static void performParallelIRGeneration(IRGenOptions &Opts,
   irgen.emitProtocolConformances();
 
   irgen.emitReflectionMetadataVersion();
+
+  irgen.emitNSArchiveClassNameRegistration();
 
   // Emit reflection metadata for builtin and imported types.
   irgen.emitBuiltinReflectionMetadata();

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -222,6 +222,8 @@ private:
   /// The queue of lazy witness tables to emit.
   llvm::SmallVector<SILWitnessTable *, 4> LazyWitnessTables;
 
+  llvm::SmallVector<ClassDecl *, 4> ClassesForArchiveNameRegistration;
+
   /// The order in which all the SIL function definitions should
   /// appear in the translation unit.
   llvm::DenseMap<SILFunction*, unsigned> FunctionOrder;
@@ -296,6 +298,8 @@ public:
   /// Emit a symbol identifying the reflection metadata version.
   void emitReflectionMetadataVersion();
 
+  void emitNSArchiveClassNameRegistration();
+
   /// Checks if the metadata of \p Nominal can be emitted lazily.
   ///
   /// If yes, \p Nominal is added to eligibleLazyMetadata and true is returned.
@@ -333,7 +337,9 @@ public:
                                       {fieldTypes.begin(), fieldTypes.end()},
                                       fn, IGM});
   }
-  
+
+  void addClassForArchiveNameRegistration(ClassDecl *ClassDecl);
+
   unsigned getFunctionOrder(SILFunction *F) {
     auto it = FunctionOrder.find(F);
     assert(it != FunctionOrder.end() &&

--- a/stdlib/public/SDK/Foundation/Foundation.swift
+++ b/stdlib/public/SDK/Foundation/Foundation.swift
@@ -95,3 +95,20 @@ extension CVarArg where Self: _ObjectiveCBridgeable {
     return _encodeBitsAsWords(object)
   }
 }
+
+//===----------------------------------------------------------------------===//
+// Runtime support for NSKeyedArchives
+//===----------------------------------------------------------------------===//
+
+@_silgen_name("swift_registerClassNameForArchiving")
+public func _registerClassNameForArchiving(_ nameForClass: UnsafePointer<CChar>,
+                                           _ classType: AnyClass) {
+  // If it's not possible to create a String from the name, it should abort
+  // and not fail silently.
+  let nameStr = String(utf8String: nameForClass)!
+
+  // Register the class name mapping for archiving and unarchiving.
+  NSKeyedArchiver.setClassName(nameStr, for: classType)
+  NSKeyedUnarchiver.setClass(classType, forClassName: nameStr)
+}
+

--- a/stdlib/public/runtime/RuntimeEntrySymbols.cpp
+++ b/stdlib/public/runtime/RuntimeEntrySymbols.cpp
@@ -36,6 +36,7 @@
 // implementations.
 #define FOR_CONV_DefaultCC(...)
 #define FOR_CONV_C_CC(...)
+#define FOR_CONV_SwiftCC(...)
 // Entry points using the new calling convention require global symbols
 // referring to their implementations.
 #define FOR_CONV_RegisterPreservingCC(x) x

--- a/test/Interpreter/SDK/archive_attributes.swift
+++ b/test/Interpreter/SDK/archive_attributes.swift
@@ -1,0 +1,178 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: %target-build-swift %s -module-name=test -DENCODE -o %t/encode
+// RUN: %target-build-swift %s -module-name=test -o %t/decode
+// RUN: %target-run %t/encode %t/test.arc
+// RUN: %FileCheck -check-prefix=CHECK-ARCHIVE %s < %t/test.arc
+// RUN: %target-run %t/decode %t/test.arc | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+// UNSUPPORTED: OS=tvos
+// UNSUPPORTED: OS=watchos
+
+import Foundation
+
+struct ABC {
+  // CHECK-ARCHIVE-DAG: nested_class_coding
+  @NSKeyedArchiveLegacy("nested_class_coding")
+  class NestedClass : NSObject, NSCoding {
+    var i : Int
+
+    init(_ ii: Int) {
+      i = ii
+    }
+
+    required init(coder aDecoder: NSCoder) {
+      i = aDecoder.decodeInteger(forKey: "i")
+    }
+
+    func encode(with aCoder: NSCoder) {
+      aCoder.encode(i, forKey: "i")
+    }
+  }
+}
+
+// CHECK-ARCHIVE-DAG: private_class_coding
+@NSKeyedArchiveLegacy("private_class_coding")
+private class PrivateClass : NSObject, NSCoding {
+  var pi : Int
+
+  init(_ ii: Int) {
+    pi = ii
+  }
+
+  required init(coder aDecoder: NSCoder) {
+    pi = aDecoder.decodeInteger(forKey: "pi")
+  }
+
+  func encode(with aCoder: NSCoder) {
+    aCoder.encode(pi, forKey: "pi")
+  }
+}
+
+@NSKeyedArchiveSubclassesOnly
+class GenericClass<T> : NSObject, NSCoding {
+  var gi : T? = nil
+
+  override init() {
+  }
+
+  required init(coder aDecoder: NSCoder) {
+  }
+
+  func encode(with aCoder: NSCoder) {
+  }
+}
+
+// CHECK-ARCHIVE-DAG: test.IntClass
+class IntClass : GenericClass<Int> {
+
+  init(ii: Int) {
+    super.init()
+    gi = ii
+  }
+
+  required init(coder aDecoder: NSCoder) {
+    super.init(coder: aDecoder)
+    gi = aDecoder.decodeInteger(forKey: "gi")
+  }
+
+  override func encode(with aCoder: NSCoder) {
+    aCoder.encode(gi!, forKey: "gi")
+  }
+}
+
+// CHECK-ARCHIVE-DAG: double_class_coding
+@NSKeyedArchiveLegacy("double_class_coding")
+class DoubleClass : GenericClass<Double> {
+
+  init(dd: Double) {
+    super.init()
+    gi = dd
+  }
+
+  required init(coder aDecoder: NSCoder) {
+    super.init(coder: aDecoder)
+    gi = aDecoder.decodeDouble(forKey: "gi")
+  }
+
+  override func encode(with aCoder: NSCoder) {
+    aCoder.encode(gi!, forKey: "gi")
+  }
+}
+
+// CHECK-ARCHIVE-DAG: top_level_coding
+@NSKeyedArchiveLegacy("top_level_coding")
+class TopLevel : NSObject, NSCoding {
+  var tli : Int
+
+  var nested: ABC.NestedClass?
+  fileprivate var priv: PrivateClass?
+  var intc : IntClass?
+  var doublec : DoubleClass?
+
+  init(_ ii: Int) {
+    tli = ii
+  }
+
+  required init(coder aDecoder: NSCoder) {
+    tli = aDecoder.decodeInteger(forKey: "tli")
+    nested = aDecoder.decodeObject(forKey: "nested") as? ABC.NestedClass
+    priv = aDecoder.decodeObject(forKey: "priv") as? PrivateClass
+    intc = aDecoder.decodeObject(forKey: "int") as? IntClass
+    doublec = aDecoder.decodeObject(forKey: "double") as? DoubleClass
+  }
+
+  func encode(with aCoder: NSCoder) {
+    aCoder.encode(tli, forKey: "tli")
+    aCoder.encode(nested, forKey: "nested")
+    aCoder.encode(priv, forKey: "priv")
+    aCoder.encode(intc, forKey: "int")
+    aCoder.encode(doublec, forKey: "double")
+  }
+}
+
+func main() {
+
+  let args = CommandLine.arguments
+
+#if ENCODE
+  let c = TopLevel(27)
+  c.nested = ABC.NestedClass(28)
+  c.priv = PrivateClass(29)
+  c.intc = IntClass(ii: 42)
+  c.doublec = DoubleClass(dd: 3.14)
+
+  NSKeyedArchiver.archiveRootObject(c, toFile: args[1])
+#else
+  if let u = NSKeyedUnarchiver.unarchiveObject(withFile: args[1]) {
+    if let x = u as? TopLevel {
+      // CHECK: top-level: 27
+      print("top-level: \(x.tli)")
+      if let n = x.nested {
+        // CHECK: nested: 28
+        print("nested: \(n.i)")
+      }
+      if let p = x.priv {
+        // CHECK: private: 29
+        print("private: \(p.pi)")
+      }
+      if let g = x.intc {
+        // CHECK: int: 42
+        print("int: \(g.gi!)")
+      }
+      if let d = x.doublec {
+        // CHECK: double: 3.14
+        print("double: \(d.gi!)")
+      }
+    } else {
+      print(u)
+    }
+  } else {
+    print("nil")
+  }
+#endif
+}
+
+main()
+


### PR DESCRIPTION
Register class names for NSKeyedArchiver and NSKeyedUnarchiver based on the @NSKeyedArchiveLegacy and @_staticInitializeObjCMetadata class attributes.

@NSKeyedArchiveLegacy registers a class name translation.
@_staticInitializeObjCMetadata just makes sure that the metadata of a class is instantiated.

This registration code is executed as a static initializer, like a C++ global constructor.
