### PR TITLE
[4.0] Let Character literals, which fit into 64 bits, be folded into a single integer constant.

### DIFF
--- a/stdlib/public/core/CTypes.swift
+++ b/stdlib/public/core/CTypes.swift
@@ -206,6 +206,8 @@ extension CVaListPointer : CustomDebugStringConvertible {
   }
 }
 
+@_versioned
+@_inlineable
 func _memcpy(
   dest destination: UnsafeMutableRawPointer,
   src: UnsafeMutableRawPointer,

--- a/stdlib/public/core/Character.swift
+++ b/stdlib/public/core/Character.swift
@@ -104,6 +104,9 @@ public struct Character :
         UTF32.self, input: CollectionOfOne(UInt32(value))))
   }
 
+  // Inlining ensures that the whole constructor can be folded away to a single
+  // integer constant in case of small character literals.
+  @inline(__always)
   @effects(readonly)
   public init(
     _builtinExtendedGraphemeClusterLiteral start: Builtin.RawPointer,
@@ -195,6 +198,7 @@ public struct Character :
 
   /// Creates a Character from a String that is already known to require the
   /// large representation.
+  @_versioned
   internal init(_largeRepresentationString s: String) {
     if let native = s._core.nativeBuffer,
        native.start == s._core._baseAddress! {

--- a/test/SILOptimizer/character_literals.swift
+++ b/test/SILOptimizer/character_literals.swift
@@ -1,0 +1,32 @@
+// RUN: %target-swift-frontend -parse-as-library -O -emit-ir  %s | %FileCheck %s
+// REQUIRES: swift_stdlib_no_asserts,optimized_stdlib,CPU=x86_64
+
+// This is an end-to-end test to ensure that the optimizer generates
+// a simple literal for character literals.
+
+// CHECK-LABEL: define {{.*}}charArray
+// CHECK-NOT: {{^}}[^ ]
+// CHECK:       store i64 9223372036854775649, i64*
+// CHECK-NOT: {{^}}[^ ]
+// CHECK:       store i64 9223372036854775650, i64*
+// CHECK-NOT: {{^}}[^ ]
+// CHECK:       store i64 9223372036854775651, i64*
+// CHECK-NOT: {{^}}[^ ]
+// CHECK:       store i64 9223372036854775652, i64*
+// CHECK-NOT: {{^}}[^ ]
+// CHECK:       ret
+public func charArray(_ i: Int) -> [Character] {
+  return [ "a", "b", "c", "d" ]
+}
+
+// CHECK-LABEL: define {{.*}}singleChar
+// CHECK: ret {{.*}} 9223372036854775649
+public func singleChar() -> Character {
+  return "a"
+}
+
+// CHECK-LABEL: define {{.*}}singleNonAsciiChar
+// CHECK: ret {{.*}} 9223372036848850918
+public func singleNonAsciiChar() -> Character {
+  return "日"
+}


### PR DESCRIPTION
Explanation: Let Character literals that fit into 64 bits, be folded into a single integer constant.
It makes character literals much faster (3x improvement for the CharacterLiteralsSmall benchmark)
And it removes _a lot_ of redundant code (~80% for the CharacterLiteralsSmall benchmark)

Scope: An optimization improvement

Issue: rdar://problem/22481219

Risk: Low. Except changing inlining decisions, there is no other change in the compiler or library.

Testing: There is a test case in this PR for swift CI