### PR TITLE
Add a new MissingMemberDecl and use it to handle non-deserializable class members

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -299,6 +299,9 @@ public:
     OnParam            = 1 << 30,
     OnModule           = 1 << 31,
 
+    // Cannot have any attributes.
+    OnVTablePlaceholder = 0,
+
     // More coarse-grained aggregations for use in Attr.def.
     OnOperator = OnInfixOperator|OnPrefixOperator|OnPostfixOperator,
 

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -300,7 +300,7 @@ public:
     OnModule           = 1 << 31,
 
     // Cannot have any attributes.
-    OnVTablePlaceholder = 0,
+    OnMissingMember = 0,
 
     // More coarse-grained aggregations for use in Attr.def.
     OnOperator = OnInfixOperator|OnPrefixOperator|OnPostfixOperator,

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -140,6 +140,7 @@ enum class DescriptiveDeclKind : uint8_t {
   DidSet,
   EnumElement,
   Module,
+  VTablePlaceholder,
 };
 
 /// Keeps track of stage of circularity checking for the given protocol.
@@ -6129,6 +6130,31 @@ public:
   
   static bool classof(const Decl *D) {
     return D->getKind() == DeclKind::PostfixOperator;
+  }
+};
+
+class VTablePlaceholderDecl : public Decl {
+  DeclName Name;
+public:
+  VTablePlaceholderDecl(DeclContext *DC, DeclName name)
+      : Decl(DeclKind::VTablePlaceholder, DC), Name(name) {
+    setImplicit();
+  }
+
+  DeclName getFullName() const {
+    return Name;
+  }
+
+  SourceLoc getLoc() const {
+    return SourceLoc();
+  }
+
+  SourceRange getSourceRange() const {
+    return SourceRange();
+  }
+
+  static bool classof(const Decl *D) {
+    return D->getKind() == DeclKind::VTablePlaceholder;
   }
 };
 

--- a/include/swift/AST/DeclNodes.def
+++ b/include/swift/AST/DeclNodes.def
@@ -93,7 +93,7 @@ DECL(EnumCase, Decl)
 CONTEXT_DECL(TopLevelCode, Decl)
 DECL(IfConfig, Decl)
 DECL(PrecedenceGroup, Decl)
-DECL(VTablePlaceholder, Decl)
+DECL(MissingMember, Decl)
 
 ABSTRACT_DECL(Operator, Decl)
   OPERATOR_DECL(InfixOperator, OperatorDecl)

--- a/include/swift/AST/DeclNodes.def
+++ b/include/swift/AST/DeclNodes.def
@@ -93,6 +93,7 @@ DECL(EnumCase, Decl)
 CONTEXT_DECL(TopLevelCode, Decl)
 DECL(IfConfig, Decl)
 DECL(PrecedenceGroup, Decl)
+DECL(VTablePlaceholder, Decl)
 
 ABSTRACT_DECL(Operator, Decl)
   OPERATOR_DECL(InfixOperator, OperatorDecl)

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -238,6 +238,9 @@ struct PrintOptions {
   /// Whether to skip parameter type attributes
   bool SkipParameterTypeAttributes = false;
 
+  /// Whether to skip vtable placeholder members.
+  bool SkipVTablePlaceholders = true;
+
   /// Whether to print a long attribute like '\@available' on a separate line
   /// from the declaration or other attributes.
   bool PrintLongAttrsOnSeparateLines = false;
@@ -489,6 +492,7 @@ struct PrintOptions {
     result.AbstractAccessors = false;
     result.PrintAccessibility = true;
     result.SkipEmptyExtensionDecls = false;
+    result.SkipVTablePlaceholders = false;
     return result;
   }
 

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -238,8 +238,8 @@ struct PrintOptions {
   /// Whether to skip parameter type attributes
   bool SkipParameterTypeAttributes = false;
 
-  /// Whether to skip vtable placeholder members.
-  bool SkipVTablePlaceholders = true;
+  /// Whether to skip placeholder members.
+  bool SkipMissingMemberPlaceholders = true;
 
   /// Whether to print a long attribute like '\@available' on a separate line
   /// from the declaration or other attributes.
@@ -492,7 +492,7 @@ struct PrintOptions {
     result.AbstractAccessors = false;
     result.PrintAccessibility = true;
     result.SkipEmptyExtensionDecls = false;
-    result.SkipVTablePlaceholders = false;
+    result.SkipMissingMemberPlaceholders = false;
     return result;
   }
 

--- a/include/swift/SIL/SILVTableVisitor.h
+++ b/include/swift/SIL/SILVTableVisitor.h
@@ -94,6 +94,8 @@ protected:
         maybeAddMethod(fd);
       else if (auto *cd = dyn_cast<ConstructorDecl>(member))
         maybeAddConstructor(cd);
+      else if (auto *placeholder = dyn_cast<MissingMemberDecl>(member))
+        asDerived().addPlaceholder(placeholder);
     }
   }
 };

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -54,7 +54,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// in source control, you should also update the comment to briefly
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
-const uint16_t VERSION_MINOR = 343; // Last change: new vtable entry flag
+const uint16_t VERSION_MINOR = 344; // Last change: ctor newly required flag
 
 using DeclID = PointerEmbeddedInt<unsigned, 31>;
 using DeclIDField = BCFixed<31>;
@@ -859,6 +859,7 @@ namespace decls_block {
     DeclIDField, // overridden decl
     AccessibilityKindField, // accessibility
     BCFixed<1>,   // requires a new vtable slot
+    BCFixed<1>,   // 'required' but overridden is not (used for recovery)
     BCArray<IdentifierIDField> // argument names
     // Trailed by its generic parameters, if any, followed by the parameter
     // patterns.

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1111,10 +1111,10 @@ namespace {
       PrintWithColorRAII(OS, ParenthesisColor) << ')';
     }
 
-    void visitVTablePlaceholderDecl(VTablePlaceholderDecl *VTPD) {
-      printCommon(VTPD, "vtable_placeholder_decl ");
+    void visitMissingMemberDecl(MissingMemberDecl *MMD) {
+      printCommon(MMD, "missing_member_decl ");
       PrintWithColorRAII(OS, IdentifierColor)
-          << '\"' << VTPD->getFullName() << '\"';
+          << '\"' << MMD->getFullName() << '\"';
       PrintWithColorRAII(OS, ParenthesisColor) << ')';
     }
   };

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1110,6 +1110,13 @@ namespace {
       printCommon(MD, "module");
       PrintWithColorRAII(OS, ParenthesisColor) << ')';
     }
+
+    void visitVTablePlaceholderDecl(VTablePlaceholderDecl *VTPD) {
+      printCommon(VTPD, "vtable_placeholder_decl ");
+      PrintWithColorRAII(OS, IdentifierColor)
+          << '\"' << VTPD->getFullName() << '\"';
+      PrintWithColorRAII(OS, ParenthesisColor) << ')';
+    }
   };
 } // end anonymous namespace
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3214,6 +3214,7 @@ void PrintAST::visitPostfixOperatorDecl(PostfixOperatorDecl *decl) {
 }
 
 void PrintAST::visitModuleDecl(ModuleDecl *decl) { }
+void PrintAST::visitVTablePlaceholderDecl(VTablePlaceholderDecl *decl) {}
 
 void PrintAST::visitBraceStmt(BraceStmt *stmt) {
   Printer << "{";

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -1644,7 +1644,7 @@ bool swift::shouldPrint(const Decl *D, PrintOptions &Options) {
       return false;
   }
 
-  if (Options.SkipVTablePlaceholders && isa<VTablePlaceholderDecl>(D))
+  if (Options.SkipMissingMemberPlaceholders && isa<MissingMemberDecl>(D))
     return false;
 
   if (Options.SkipDeinit && isa<DestructorDecl>(D)) {
@@ -3218,7 +3218,7 @@ void PrintAST::visitPostfixOperatorDecl(PostfixOperatorDecl *decl) {
 
 void PrintAST::visitModuleDecl(ModuleDecl *decl) { }
 
-void PrintAST::visitVTablePlaceholderDecl(VTablePlaceholderDecl *decl) {
+void PrintAST::visitMissingMemberDecl(MissingMemberDecl *decl) {
   Printer << "/* placeholder for ";
   recordDeclLoc(decl, [&]{ Printer << decl->getFullName(); });
   Printer << " */";

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -1644,6 +1644,9 @@ bool swift::shouldPrint(const Decl *D, PrintOptions &Options) {
       return false;
   }
 
+  if (Options.SkipVTablePlaceholders && isa<VTablePlaceholderDecl>(D))
+    return false;
+
   if (Options.SkipDeinit && isa<DestructorDecl>(D)) {
     return false;
   }
@@ -3214,7 +3217,12 @@ void PrintAST::visitPostfixOperatorDecl(PostfixOperatorDecl *decl) {
 }
 
 void PrintAST::visitModuleDecl(ModuleDecl *decl) { }
-void PrintAST::visitVTablePlaceholderDecl(VTablePlaceholderDecl *decl) {}
+
+void PrintAST::visitVTablePlaceholderDecl(VTablePlaceholderDecl *decl) {
+  Printer << "/* placeholder for ";
+  recordDeclLoc(decl, [&]{ Printer << decl->getFullName(); });
+  Printer << " */";
+}
 
 void PrintAST::visitBraceStmt(BraceStmt *stmt) {
   Printer << "{";

--- a/lib/AST/ASTScope.cpp
+++ b/lib/AST/ASTScope.cpp
@@ -929,7 +929,7 @@ ASTScope *ASTScope::createIfNeeded(const ASTScope *parent, Decl *decl) {
   case DeclKind::Param:
   case DeclKind::EnumElement:
   case DeclKind::IfConfig:
-  case DeclKind::VTablePlaceholder:
+  case DeclKind::MissingMember:
     // These declarations do not introduce scopes.
     return nullptr;
 

--- a/lib/AST/ASTScope.cpp
+++ b/lib/AST/ASTScope.cpp
@@ -929,6 +929,7 @@ ASTScope *ASTScope::createIfNeeded(const ASTScope *parent, Decl *decl) {
   case DeclKind::Param:
   case DeclKind::EnumElement:
   case DeclKind::IfConfig:
+  case DeclKind::VTablePlaceholder:
     // These declarations do not introduce scopes.
     return nullptr;
 

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -260,6 +260,10 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
     return doIt(SD->getElementTypeLoc());
   }
 
+  bool visitVTablePlaceholderDecl(VTablePlaceholderDecl *ID) {
+    return false;
+  }
+
   bool visitAbstractFunctionDecl(AbstractFunctionDecl *AFD) {
 #ifndef NDEBUG
     PrettyStackTraceDecl debugStack("walking into body of", AFD);

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -260,7 +260,7 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
     return doIt(SD->getElementTypeLoc());
   }
 
-  bool visitVTablePlaceholderDecl(VTablePlaceholderDecl *ID) {
+  bool visitMissingMemberDecl(MissingMemberDecl *MMD) {
     return false;
   }
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -133,7 +133,7 @@ DescriptiveDeclKind Decl::getDescriptiveKind() const {
   TRIVIAL_KIND(EnumElement);
   TRIVIAL_KIND(Param);
   TRIVIAL_KIND(Module);
-  TRIVIAL_KIND(VTablePlaceholder);
+  TRIVIAL_KIND(MissingMember);
 
    case DeclKind::Enum:
      return cast<EnumDecl>(this)->getGenericParams()
@@ -268,7 +268,7 @@ StringRef Decl::getDescriptiveKindName(DescriptiveDeclKind K) {
   ENTRY(MutableAddressor, "mutableAddress accessor");
   ENTRY(EnumElement, "enum element");
   ENTRY(Module, "module");
-  ENTRY(VTablePlaceholder, "vtable placeholder");
+  ENTRY(MissingMember, "missing member placeholder");
   }
 #undef ENTRY
   llvm_unreachable("bad DescriptiveDeclKind");
@@ -738,7 +738,7 @@ ImportKind ImportDecl::getBestImportKind(const ValueDecl *VD) {
   case DeclKind::EnumCase:
   case DeclKind::IfConfig:
   case DeclKind::PrecedenceGroup:
-  case DeclKind::VTablePlaceholder:
+  case DeclKind::MissingMember:
     llvm_unreachable("not a ValueDecl");
 
   case DeclKind::AssociatedType:
@@ -1374,7 +1374,7 @@ bool ValueDecl::isDefinition() const {
   case DeclKind::PostfixOperator:
   case DeclKind::IfConfig:
   case DeclKind::PrecedenceGroup:
-  case DeclKind::VTablePlaceholder:
+  case DeclKind::MissingMember:
     assert(!isa<ValueDecl>(this));
     llvm_unreachable("non-value decls shouldn't get here");
 
@@ -1416,7 +1416,7 @@ bool ValueDecl::isInstanceMember() const {
   case DeclKind::PostfixOperator:
   case DeclKind::IfConfig:
   case DeclKind::PrecedenceGroup:
-  case DeclKind::VTablePlaceholder:
+  case DeclKind::MissingMember:
     llvm_unreachable("Not a ValueDecl");
 
   case DeclKind::Class:

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -133,6 +133,7 @@ DescriptiveDeclKind Decl::getDescriptiveKind() const {
   TRIVIAL_KIND(EnumElement);
   TRIVIAL_KIND(Param);
   TRIVIAL_KIND(Module);
+  TRIVIAL_KIND(VTablePlaceholder);
 
    case DeclKind::Enum:
      return cast<EnumDecl>(this)->getGenericParams()
@@ -267,6 +268,7 @@ StringRef Decl::getDescriptiveKindName(DescriptiveDeclKind K) {
   ENTRY(MutableAddressor, "mutableAddress accessor");
   ENTRY(EnumElement, "enum element");
   ENTRY(Module, "module");
+  ENTRY(VTablePlaceholder, "vtable placeholder");
   }
 #undef ENTRY
   llvm_unreachable("bad DescriptiveDeclKind");
@@ -736,6 +738,7 @@ ImportKind ImportDecl::getBestImportKind(const ValueDecl *VD) {
   case DeclKind::EnumCase:
   case DeclKind::IfConfig:
   case DeclKind::PrecedenceGroup:
+  case DeclKind::VTablePlaceholder:
     llvm_unreachable("not a ValueDecl");
 
   case DeclKind::AssociatedType:
@@ -1371,6 +1374,7 @@ bool ValueDecl::isDefinition() const {
   case DeclKind::PostfixOperator:
   case DeclKind::IfConfig:
   case DeclKind::PrecedenceGroup:
+  case DeclKind::VTablePlaceholder:
     assert(!isa<ValueDecl>(this));
     llvm_unreachable("non-value decls shouldn't get here");
 
@@ -1412,6 +1416,7 @@ bool ValueDecl::isInstanceMember() const {
   case DeclKind::PostfixOperator:
   case DeclKind::IfConfig:
   case DeclKind::PrecedenceGroup:
+  case DeclKind::VTablePlaceholder:
     llvm_unreachable("Not a ValueDecl");
 
   case DeclKind::Class:

--- a/lib/FrontendTool/ReferenceDependencies.cpp
+++ b/lib/FrontendTool/ReferenceDependencies.cpp
@@ -254,6 +254,7 @@ bool swift::emitReferenceDependencies(DiagnosticEngine &diags,
     case DeclKind::Constructor:
     case DeclKind::Destructor:
     case DeclKind::EnumElement:
+    case DeclKind::VTablePlaceholder:
       llvm_unreachable("cannot appear at the top level of a file");
     }
   }

--- a/lib/FrontendTool/ReferenceDependencies.cpp
+++ b/lib/FrontendTool/ReferenceDependencies.cpp
@@ -254,7 +254,7 @@ bool swift::emitReferenceDependencies(DiagnosticEngine &diags,
     case DeclKind::Constructor:
     case DeclKind::Destructor:
     case DeclKind::EnumElement:
-    case DeclKind::VTablePlaceholder:
+    case DeclKind::MissingMember:
       llvm_unreachable("cannot appear at the top level of a file");
     }
   }

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -535,6 +535,7 @@ CodeCompletionResult::getCodeCompletionDeclKind(const Decl *D) {
   case DeclKind::EnumCase:
   case DeclKind::TopLevelCode:
   case DeclKind::IfConfig:
+  case DeclKind::VTablePlaceholder:
     llvm_unreachable("not expecting such a declaration result");
   case DeclKind::Module:
     return CodeCompletionDeclKind::Module;

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -535,7 +535,7 @@ CodeCompletionResult::getCodeCompletionDeclKind(const Decl *D) {
   case DeclKind::EnumCase:
   case DeclKind::TopLevelCode:
   case DeclKind::IfConfig:
-  case DeclKind::VTablePlaceholder:
+  case DeclKind::MissingMember:
     llvm_unreachable("not expecting such a declaration result");
   case DeclKind::Module:
     return CodeCompletionDeclKind::Module;

--- a/lib/IRGen/ClassMetadataLayout.h
+++ b/lib/IRGen/ClassMetadataLayout.h
@@ -181,6 +181,12 @@ public:
                               ClassDecl *forClass) {
     addPointer();
   }
+  void addPlaceholder(MissingMemberDecl *MMD) {
+    for (auto i : range(MMD->getNumberOfVTableEntries())) {
+      (void)i;
+      addPointer();
+    }
+  }
 
 private:
   // Our layout here assumes that there will never be unclaimed space

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -1491,9 +1491,8 @@ namespace {
       }
     }
 
-    void visitVTablePlaceholderDecl(VTablePlaceholderDecl *placeholder) {
-      // FIXME
-      IGM.fatal_unimplemented(SourceLoc(), "vtable placeholder");
+    void visitMissingMemberDecl(MissingMemberDecl *placeholder) {
+      llvm_unreachable("should not IRGen classes with missing members");
     }
 
     void addIVarInitializer() {

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -1491,6 +1491,11 @@ namespace {
       }
     }
 
+    void visitVTablePlaceholderDecl(VTablePlaceholderDecl *placeholder) {
+      // FIXME
+      IGM.fatal_unimplemented(SourceLoc(), "vtable placeholder");
+    }
+
     void addIVarInitializer() {
       if (auto fn = IGM.getAddrOfIVarInitDestroy(getClass(),
                                                  /*destroy*/ false,

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -166,6 +166,8 @@ public:
   void visitTypeDecl(TypeDecl *type) {
     // We'll visit nested types separately if necessary.
   }
+
+  void visitVTablePlaceholderDecl(VTablePlaceholderDecl *placeholder) {}
   
   void visitFuncDecl(FuncDecl *method) {
     if (!requiresObjCMethodDescriptor(method)) return;
@@ -378,6 +380,8 @@ public:
   void visitTypeDecl(TypeDecl *type) {
     // We'll visit nested types separately if necessary.
   }
+
+  void visitVTablePlaceholderDecl(VTablePlaceholderDecl *placeholder) {}
 
   void visitAbstractFunctionDecl(AbstractFunctionDecl *method) {
     llvm::Constant *name, *imp, *types;
@@ -1668,6 +1672,9 @@ void IRGenModule::emitGlobalDecl(Decl *D) {
   case DeclKind::Destructor:
     llvm_unreachable("there are no global destructor");
 
+  case DeclKind::VTablePlaceholder:
+    llvm_unreachable("there are no global vtable placeholders");
+
   case DeclKind::TypeAlias:
   case DeclKind::GenericTypeParam:
   case DeclKind::AssociatedType:
@@ -2927,6 +2934,7 @@ void IRGenModule::emitNestedTypeDecls(DeclRange members) {
     case DeclKind::Destructor:
     case DeclKind::EnumCase:
     case DeclKind::EnumElement:
+    case DeclKind::VTablePlaceholder:
       // Skip non-type members.
       continue;
 

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -167,7 +167,7 @@ public:
     // We'll visit nested types separately if necessary.
   }
 
-  void visitVTablePlaceholderDecl(VTablePlaceholderDecl *placeholder) {}
+  void visitMissingMemberDecl(MissingMemberDecl *placeholder) {}
   
   void visitFuncDecl(FuncDecl *method) {
     if (!requiresObjCMethodDescriptor(method)) return;
@@ -381,7 +381,7 @@ public:
     // We'll visit nested types separately if necessary.
   }
 
-  void visitVTablePlaceholderDecl(VTablePlaceholderDecl *placeholder) {}
+  void visitMissingMemberDecl(MissingMemberDecl *placeholder) {}
 
   void visitAbstractFunctionDecl(AbstractFunctionDecl *method) {
     llvm::Constant *name, *imp, *types;
@@ -1672,8 +1672,8 @@ void IRGenModule::emitGlobalDecl(Decl *D) {
   case DeclKind::Destructor:
     llvm_unreachable("there are no global destructor");
 
-  case DeclKind::VTablePlaceholder:
-    llvm_unreachable("there are no global vtable placeholders");
+  case DeclKind::MissingMember:
+    llvm_unreachable("there are no global member placeholders");
 
   case DeclKind::TypeAlias:
   case DeclKind::GenericTypeParam:
@@ -2934,7 +2934,7 @@ void IRGenModule::emitNestedTypeDecls(DeclRange members) {
     case DeclKind::Destructor:
     case DeclKind::EnumCase:
     case DeclKind::EnumElement:
-    case DeclKind::VTablePlaceholder:
+    case DeclKind::MissingMember:
       // Skip non-type members.
       continue;
 

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -3502,6 +3502,10 @@ namespace {
       }
     }
 
+    void addPlaceholder(MissingMemberDecl *) {
+      llvm_unreachable("cannot generate metadata with placeholders in it");
+    }
+
     void addMethodOverride(SILDeclRef baseRef, SILDeclRef declRef) {}
 
     void addGenericArgument(CanType argTy, ClassDecl *forClass) {

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -224,7 +224,7 @@ public:
   void visitConstructorDecl(ConstructorDecl *d) {}
   void visitDestructorDecl(DestructorDecl *d) {}
   void visitModuleDecl(ModuleDecl *d) { }
-  void visitVTablePlaceholderDecl(VTablePlaceholderDecl *d) {}
+  void visitMissingMemberDecl(MissingMemberDecl *d) {}
 
   void visitFuncDecl(FuncDecl *fd);
   void visitPatternBindingDecl(PatternBindingDecl *vd);

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -224,6 +224,7 @@ public:
   void visitConstructorDecl(ConstructorDecl *d) {}
   void visitDestructorDecl(DestructorDecl *d) {}
   void visitModuleDecl(ModuleDecl *d) { }
+  void visitVTablePlaceholderDecl(VTablePlaceholderDecl *d) {}
 
   void visitFuncDecl(FuncDecl *fd);
   void visitPatternBindingDecl(PatternBindingDecl *vd);

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -1393,7 +1393,7 @@ void SILGenModule::emitExternalDefinition(Decl *d) {
   case DeclKind::PostfixOperator:
   case DeclKind::PrecedenceGroup:
   case DeclKind::Module:
-  case DeclKind::VTablePlaceholder:
+  case DeclKind::MissingMember:
     llvm_unreachable("Not a valid external definition for SILGen");
   }
 }

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -1393,6 +1393,7 @@ void SILGenModule::emitExternalDefinition(Decl *d) {
   case DeclKind::PostfixOperator:
   case DeclKind::PrecedenceGroup:
   case DeclKind::Module:
+  case DeclKind::VTablePlaceholder:
     llvm_unreachable("Not a valid external definition for SILGen");
   }
 }

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -823,6 +823,7 @@ public:
   void visitTypeAliasDecl(TypeAliasDecl *tad) {}
   void visitAbstractTypeParamDecl(AbstractTypeParamDecl *tpd) {}
   void visitModuleDecl(ModuleDecl *md) {}
+  void visitVTablePlaceholderDecl(VTablePlaceholderDecl *) {}
   void visitNominalTypeDecl(NominalTypeDecl *ntd) {
     SILGenType(SGM, ntd).emitType();
   }
@@ -922,6 +923,7 @@ public:
   void visitTypeAliasDecl(TypeAliasDecl *tad) {}
   void visitAbstractTypeParamDecl(AbstractTypeParamDecl *tpd) {}
   void visitModuleDecl(ModuleDecl *md) {}
+  void visitVTablePlaceholderDecl(VTablePlaceholderDecl *) {}
   void visitNominalTypeDecl(NominalTypeDecl *ntd) {
     SILGenType(SGM, ntd).emitType();
   }

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -203,6 +203,8 @@ public:
     assert(result.second);
     (void) result;
   }
+
+  void addPlaceholder(MissingMemberDecl *) {}
 };
 
 } // end anonymous namespace
@@ -823,7 +825,7 @@ public:
   void visitTypeAliasDecl(TypeAliasDecl *tad) {}
   void visitAbstractTypeParamDecl(AbstractTypeParamDecl *tpd) {}
   void visitModuleDecl(ModuleDecl *md) {}
-  void visitVTablePlaceholderDecl(VTablePlaceholderDecl *) {}
+  void visitMissingMemberDecl(MissingMemberDecl *) {}
   void visitNominalTypeDecl(NominalTypeDecl *ntd) {
     SILGenType(SGM, ntd).emitType();
   }
@@ -923,7 +925,7 @@ public:
   void visitTypeAliasDecl(TypeAliasDecl *tad) {}
   void visitAbstractTypeParamDecl(AbstractTypeParamDecl *tpd) {}
   void visitModuleDecl(ModuleDecl *md) {}
-  void visitVTablePlaceholderDecl(VTablePlaceholderDecl *) {}
+  void visitMissingMemberDecl(MissingMemberDecl *) {}
   void visitNominalTypeDecl(NominalTypeDecl *ntd) {
     SILGenType(SGM, ntd).emitType();
   }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1921,6 +1921,7 @@ static void checkAccessibility(TypeChecker &TC, const Decl *D) {
 
   case DeclKind::Param:
   case DeclKind::GenericTypeParam:
+  case DeclKind::VTablePlaceholder:
     llvm_unreachable("does not have accessibility");
 
   case DeclKind::IfConfig:
@@ -3917,6 +3918,10 @@ public:
 
   void visitPrecedenceGroupDecl(PrecedenceGroupDecl *PGD) {
     TC.validateDecl(PGD);
+  }
+
+  void visitVTablePlaceholderDecl(VTablePlaceholderDecl *VTPD) {
+    llvm_unreachable("should always be type-checked already");
   }
 
   void visitBoundVariable(VarDecl *VD) {
@@ -7065,6 +7070,7 @@ void TypeChecker::validateDecl(ValueDecl *D) {
   case DeclKind::PostfixOperator:
   case DeclKind::PrecedenceGroup:
   case DeclKind::IfConfig:
+  case DeclKind::VTablePlaceholder:
     llvm_unreachable("not a value decl");
 
   case DeclKind::Module:
@@ -7504,6 +7510,7 @@ void TypeChecker::validateAccessibility(ValueDecl *D) {
   case DeclKind::PostfixOperator:
   case DeclKind::PrecedenceGroup:
   case DeclKind::IfConfig:
+  case DeclKind::VTablePlaceholder:
     llvm_unreachable("not a value decl");
 
   case DeclKind::Module:

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1921,7 +1921,7 @@ static void checkAccessibility(TypeChecker &TC, const Decl *D) {
 
   case DeclKind::Param:
   case DeclKind::GenericTypeParam:
-  case DeclKind::VTablePlaceholder:
+  case DeclKind::MissingMember:
     llvm_unreachable("does not have accessibility");
 
   case DeclKind::IfConfig:
@@ -3920,7 +3920,7 @@ public:
     TC.validateDecl(PGD);
   }
 
-  void visitVTablePlaceholderDecl(VTablePlaceholderDecl *VTPD) {
+  void visitMissingMemberDecl(MissingMemberDecl *MMD) {
     llvm_unreachable("should always be type-checked already");
   }
 
@@ -7070,7 +7070,7 @@ void TypeChecker::validateDecl(ValueDecl *D) {
   case DeclKind::PostfixOperator:
   case DeclKind::PrecedenceGroup:
   case DeclKind::IfConfig:
-  case DeclKind::VTablePlaceholder:
+  case DeclKind::MissingMember:
     llvm_unreachable("not a value decl");
 
   case DeclKind::Module:
@@ -7510,7 +7510,7 @@ void TypeChecker::validateAccessibility(ValueDecl *D) {
   case DeclKind::PostfixOperator:
   case DeclKind::PrecedenceGroup:
   case DeclKind::IfConfig:
-  case DeclKind::VTablePlaceholder:
+  case DeclKind::MissingMember:
     llvm_unreachable("not a value decl");
 
   case DeclKind::Module:

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2520,11 +2520,12 @@ ModuleFile::getDeclChecked(DeclID DID, Optional<DeclContext *> ForcedContext) {
   case decls_block::CONSTRUCTOR_DECL: {
     DeclContextID contextID;
     uint8_t rawFailability;
-    bool isImplicit, isObjC, hasStubImplementation, throws, needsNewVTableEntry;
+    bool isImplicit, isObjC, hasStubImplementation, throws;
     GenericEnvironmentID genericEnvID;
     uint8_t storedInitKind, rawAccessLevel;
     TypeID interfaceID, canonicalTypeID;
     DeclID overriddenID;
+    bool needsNewVTableEntry, firstTimeRequired;
     ArrayRef<uint64_t> argNameIDs;
 
     decls_block::ConstructorLayout::readRecord(scratch, contextID,
@@ -2534,7 +2535,9 @@ ModuleFile::getDeclChecked(DeclID DID, Optional<DeclContext *> ForcedContext) {
                                                genericEnvID, interfaceID,
                                                canonicalTypeID, overriddenID,
                                                rawAccessLevel,
-                                               needsNewVTableEntry, argNameIDs);
+                                               needsNewVTableEntry,
+                                               firstTimeRequired,
+                                               argNameIDs);
 
     // Resolve the name ids.
     SmallVector<Identifier, 2> argNames;

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -1279,8 +1279,52 @@ ModuleFile::resolveCrossReference(ModuleDecl *baseModule, uint32_t pathLen) {
     return nullptr;
   }
 
+  auto getXRefDeclNameForError = [&]() -> DeclName {
+    DeclName result = pathTrace.getLastName();
+    while (--pathLen) {
+      auto entry = DeclTypeCursor.advance(AF_DontPopBlockAtEnd);
+      if (entry.Kind != llvm::BitstreamEntry::Record)
+        return Identifier();
+
+      unsigned recordID = DeclTypeCursor.readRecord(entry.ID, scratch,
+                                                    &blobData);
+      switch (recordID) {
+      case XREF_TYPE_PATH_PIECE: {
+        IdentifierID IID;
+        XRefTypePathPieceLayout::readRecord(scratch, IID, None);
+        result = getIdentifier(IID);
+        break;
+      }
+      case XREF_VALUE_PATH_PIECE: {
+        IdentifierID IID;
+        XRefValuePathPieceLayout::readRecord(scratch, None, IID, None, None);
+        result = getIdentifier(IID);
+        break;
+      }
+      case XREF_INITIALIZER_PATH_PIECE:
+        result = getContext().Id_init;
+        break;
+
+      case XREF_EXTENSION_PATH_PIECE:
+      case XREF_OPERATOR_OR_ACCESSOR_PATH_PIECE:
+        break;
+
+      case XREF_GENERIC_PARAM_PATH_PIECE:
+        // Can't get the name without deserializing.
+        result = Identifier();
+        break;
+
+      default:
+        // Unknown encoding.
+        return Identifier();
+      }
+    }
+    return result;
+  };
+
   if (values.empty()) {
-    return llvm::make_error<XRefError>("top-level value not found", pathTrace);
+    return llvm::make_error<XRefError>("top-level value not found", pathTrace,
+                                       getXRefDeclNameForError());
   }
 
   // Filters for values discovered in the remaining path pieces.
@@ -1400,7 +1444,8 @@ ModuleFile::resolveCrossReference(ModuleDecl *baseModule, uint32_t pathLen) {
 
       if (values.size() != 1) {
         return llvm::make_error<XRefError>("multiple matching base values",
-                                           pathTrace);
+                                           pathTrace,
+                                           getXRefDeclNameForError());
       }
 
       auto nominal = dyn_cast<NominalTypeDecl>(values.front());
@@ -1408,7 +1453,8 @@ ModuleFile::resolveCrossReference(ModuleDecl *baseModule, uint32_t pathLen) {
 
       if (!nominal) {
         return llvm::make_error<XRefError>("base is not a nominal type",
-                                           pathTrace);
+                                           pathTrace,
+                                           getXRefDeclNameForError());
       }
 
       auto members = nominal->lookupDirect(memberName);
@@ -1498,7 +1544,8 @@ ModuleFile::resolveCrossReference(ModuleDecl *baseModule, uint32_t pathLen) {
     case XREF_GENERIC_PARAM_PATH_PIECE: {
       if (values.size() != 1) {
         return llvm::make_error<XRefError>("multiple matching base values",
-                                           pathTrace);
+                                           pathTrace,
+                                           getXRefDeclNameForError());
       }
 
       uint32_t paramIndex;
@@ -1534,12 +1581,12 @@ ModuleFile::resolveCrossReference(ModuleDecl *baseModule, uint32_t pathLen) {
       if (!paramList) {
         return llvm::make_error<XRefError>(
             "cross-reference to generic param for non-generic type",
-            pathTrace);
+            pathTrace, getXRefDeclNameForError());
       }
       if (paramIndex >= paramList->size()) {
         return llvm::make_error<XRefError>(
             "generic argument index out of bounds",
-            pathTrace);
+            pathTrace, getXRefDeclNameForError());
       }
 
       values.clear();
@@ -1563,7 +1610,8 @@ ModuleFile::resolveCrossReference(ModuleDecl *baseModule, uint32_t pathLen) {
     }
 
     if (values.empty()) {
-      return llvm::make_error<XRefError>("result not found", pathTrace);
+      return llvm::make_error<XRefError>("result not found", pathTrace,
+                                         getXRefDeclNameForError());
     }
 
     // Reset the module filter.
@@ -2043,6 +2091,9 @@ ModuleFile::getDeclChecked(DeclID DID, Optional<DeclContext *> ForcedContext) {
     ctx.Stats->getFrontendCounters().NumDeclsDeserialized++;
 
   // Read the attributes (if any).
+  // This isn't just using DeclAttributes because that would result in the
+  // attributes getting reversed.
+  // FIXME: If we reverse them at serialization time we could get rid of this.
   DeclAttribute *DAttrs = nullptr;
   DeclAttribute **AttrsNext = &DAttrs;
   auto AddAttribute = [&](DeclAttribute *Attr) {
@@ -2548,20 +2599,29 @@ ModuleFile::getDeclChecked(DeclID DID, Optional<DeclContext *> ForcedContext) {
     Optional<swift::CtorInitializerKind> initKind =
         getActualCtorInitializerKind(storedInitKind);
 
-    auto errorKind = DeclDeserializationError::Normal;
+    DeclDeserializationError::Flags errorFlags;
     if (initKind == CtorInitializerKind::Designated)
-      errorKind = DeclDeserializationError::DesignatedInitializer;
+      errorFlags |= DeclDeserializationError::DesignatedInitializer;
+    if (needsNewVTableEntry) {
+      errorFlags |= DeclDeserializationError::NeedsVTableEntry;
+      DeclAttributes attrs;
+      attrs.setRawAttributeChain(DAttrs);
+      if (attrs.hasAttribute<RequiredAttr>())
+        errorFlags |= DeclDeserializationError::NeedsAllocatingVTableEntry;
+    }
+    if (firstTimeRequired)
+      errorFlags |= DeclDeserializationError::NeedsAllocatingVTableEntry;
 
     auto overridden = getDeclChecked(overriddenID);
     if (!overridden) {
       llvm::consumeError(overridden.takeError());
-      return llvm::make_error<OverrideError>(name, errorKind);
+      return llvm::make_error<OverrideError>(name, errorFlags);
     }
 
     auto canonicalType = getTypeChecked(canonicalTypeID);
     if (!canonicalType) {
       return llvm::make_error<TypeError>(
-          name, takeErrorInfo(canonicalType.takeError()), errorKind);
+          name, takeErrorInfo(canonicalType.takeError()), errorFlags);
     }
 
     auto parent = getDeclContext(contextID);
@@ -2783,16 +2843,20 @@ ModuleFile::getDeclChecked(DeclID DID, Optional<DeclContext *> ForcedContext) {
         name = DeclName(names[0]);
     }
 
+    DeclDeserializationError::Flags errorFlags;
+    if (needsNewVTableEntry)
+      errorFlags |= DeclDeserializationError::NeedsVTableEntry;
+
     Expected<Decl *> overridden = getDeclChecked(overriddenID);
     if (!overridden) {
       llvm::consumeError(overridden.takeError());
-      return llvm::make_error<OverrideError>(name);
+      return llvm::make_error<OverrideError>(name, errorFlags);
     }
 
     auto canonicalType = getTypeChecked(canonicalTypeID);
     if (!canonicalType) {
       return llvm::make_error<TypeError>(
-          name, takeErrorInfo(canonicalType.takeError()));
+          name, takeErrorInfo(canonicalType.takeError()), errorFlags);
     }
 
     auto DC = getDeclContext(contextID);
@@ -3702,9 +3766,10 @@ Expected<Type> ModuleFile::getTypeChecked(TypeID TID) {
     auto nominal = dyn_cast<NominalTypeDecl>(nominalOrError.get());
     if (!nominal) {
       XRefTracePath tinyTrace{*nominalOrError.get()->getModuleContext()};
-      tinyTrace.addValue(cast<ValueDecl>(nominalOrError.get())->getName());
+      DeclName fullName = cast<ValueDecl>(nominalOrError.get())->getFullName();
+      tinyTrace.addValue(fullName.getBaseName());
       return llvm::make_error<XRefError>("declaration is not a nominal type",
-                                         tinyTrace);
+                                         tinyTrace, fullName);
     }
     typeOrOffset = NominalType::get(nominal, parentTy.get(), ctx);
 
@@ -4384,15 +4449,24 @@ void ModuleFile::loadAllMembers(Decl *container, uint64_t contextData) {
         fatal(next.takeError());
 
       // Drop the member if it had a problem.
-      // FIXME: If this was a non-final, non-dynamic, non-@objc-overriding
-      // member, it's going to affect the vtable layout, and /every single call/
-      // will be wrong.
+      // FIXME: Handle overridable members in class extensions too, someday.
       if (auto *containingClass = dyn_cast<ClassDecl>(container)) {
         auto handleMissingDesignatedInit =
-            [containingClass](const DeclDeserializationError &error) {
-          if (error.getKind() != OverrideError::DesignatedInitializer)
-            return;
-          containingClass->setHasMissingDesignatedInitializers();
+            [&](const DeclDeserializationError &error) {
+          if (error.isDesignatedInitializer())
+            containingClass->setHasMissingDesignatedInitializers();
+          if (error.needsAllocatingVTableEntry()) {
+            auto placeholder =
+                new (getContext()) VTablePlaceholderDecl(containingClass,
+                                                         error.getName());
+            members.push_back(placeholder);
+          }
+          if (error.needsVTableEntry()) {
+            auto placeholder =
+                new (getContext()) VTablePlaceholderDecl(containingClass,
+                                                         error.getName());
+            members.push_back(placeholder);
+          }
         };
         llvm::handleAllErrors(next.takeError(), handleMissingDesignatedInit);
       } else {

--- a/lib/Serialization/DeserializationErrors.h
+++ b/lib/Serialization/DeserializationErrors.h
@@ -50,6 +50,21 @@ class XRefTracePath {
       : kind(K),
         data(llvm::PointerLikeTypeTraits<T>::getAsVoidPointer(value)) {}
 
+    Identifier getAsIdentifier() const {
+      switch (kind) {
+      case Kind::Value:
+      case Kind::Operator:
+        return getDataAs<Identifier>();
+      case Kind::Type:
+      case Kind::OperatorFilter:
+      case Kind::Accessor:
+      case Kind::Extension:
+      case Kind::GenericParam:
+      case Kind::Unknown:
+        return Identifier();
+      }
+    }
+
     void print(raw_ostream &os) const {
       switch (kind) {
       case Kind::Value:
@@ -164,6 +179,15 @@ public:
     path.push_back({ PathPiece::Kind::Unknown, kind });
   }
 
+  Identifier getLastName() const {
+    for (auto &piece : reversed(path)) {
+      Identifier result = piece.getAsIdentifier();
+      if (!result.empty())
+        return result;
+    }
+    return Identifier();
+  }
+
   void removeLast() {
     path.pop_back();
   }
@@ -183,17 +207,30 @@ class DeclDeserializationError : public llvm::ErrorInfoBase {
   void anchor() override;
 
 public:
-  enum Kind {
-    Normal,
-    DesignatedInitializer
+  enum Flag : unsigned {
+    DesignatedInitializer = 1 << 0,
+    NeedsVTableEntry = 1 << 1,
+    NeedsAllocatingVTableEntry = 1 << 2,
   };
+  using Flags = OptionSet<Flag>;
 
 protected:
-  Kind kind = Normal;
+  DeclName name;
+  Flags flags;
 
 public:
-  Kind getKind() const {
-    return kind;
+  DeclName getName() const {
+    return name;
+  }
+
+  bool isDesignatedInitializer() const {
+    return flags.contains(Flag::DesignatedInitializer);
+  }
+  bool needsVTableEntry() const {
+    return flags.contains(Flag::NeedsVTableEntry);
+  }
+  bool needsAllocatingVTableEntry() const {
+    return flags.contains(Flag::NeedsAllocatingVTableEntry);
   }
 
   bool isA(const void *const ClassID) const override {
@@ -212,8 +249,10 @@ class XRefError : public llvm::ErrorInfo<XRefError, DeclDeserializationError> {
   const char *message;
 public:
   template <size_t N>
-  XRefError(const char (&message)[N], XRefTracePath path)
-      : path(path), message(message) {}
+  XRefError(const char (&message)[N], XRefTracePath path, DeclName name)
+      : path(path), message(message) {
+    this->name = name;
+  }
 
   void log(raw_ostream &OS) const override {
     OS << message << "\n";
@@ -232,11 +271,10 @@ private:
   static const char ID;
   void anchor() override;
 
-  DeclName name;
-
 public:
-  explicit OverrideError(DeclName name, Kind kind = Normal) : name(name) {
-    this->kind = kind;
+  explicit OverrideError(DeclName name, Flags flags = {}) {
+    this->name = name;
+    this->flags = flags;
   }
 
   void log(raw_ostream &OS) const override {
@@ -253,13 +291,13 @@ class TypeError : public llvm::ErrorInfo<TypeError, DeclDeserializationError> {
   static const char ID;
   void anchor() override;
 
-  DeclName name;
   std::unique_ptr<ErrorInfoBase> underlyingReason;
 public:
   explicit TypeError(DeclName name, std::unique_ptr<ErrorInfoBase> reason,
-                     Kind kind = Normal)
-      : name(name), underlyingReason(std::move(reason)) {
-    this->kind = kind;
+                     Flags flags = {})
+      : underlyingReason(std::move(reason)) {
+    this->name = name;
+    this->flags = flags;
   }
 
   void log(raw_ostream &OS) const override {

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2958,6 +2958,11 @@ void Serializer::writeDecl(const Decl *D) {
       getRawStableAccessibility(ctor->getFormalAccess());
     Type ty = ctor->getInterfaceType();
 
+    bool firstTimeRequired = ctor->isRequired();
+    if (auto *overridden = ctor->getOverriddenDecl())
+      if (firstTimeRequired && overridden->isRequired())
+        firstTimeRequired = false;
+
     unsigned abbrCode = DeclTypeAbbrCodes[ConstructorLayout::Code];
     ConstructorLayout::emitRecord(Out, ScratchRecord, abbrCode,
                                   contextID,
@@ -2976,6 +2981,7 @@ void Serializer::writeDecl(const Decl *D) {
                                   addDeclRef(ctor->getOverriddenDecl()),
                                   rawAccessLevel,
                                   ctor->needsNewVTableEntry(),
+                                  firstTimeRequired,
                                   nameComponents);
 
     writeGenericParams(ctor->getGenericParams());

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1526,6 +1526,9 @@ static bool shouldSerializeMember(Decl *D) {
   case DeclKind::PrecedenceGroup:
     llvm_unreachable("decl should never be a member");
 
+  case DeclKind::VTablePlaceholder:
+    llvm_unreachable("should never need to reserialize a vtable placeholder");
+
   case DeclKind::IfConfig:
     return false;
 
@@ -2504,6 +2507,9 @@ void Serializer::writeDecl(const Decl *D) {
                                       relations);
     break;
   }
+
+  case DeclKind::VTablePlaceholder:
+    llvm_unreachable("vtable placeholders shouldn't be serialized");
 
   case DeclKind::InfixOperator: {
     auto op = cast<InfixOperatorDecl>(D);

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1526,8 +1526,8 @@ static bool shouldSerializeMember(Decl *D) {
   case DeclKind::PrecedenceGroup:
     llvm_unreachable("decl should never be a member");
 
-  case DeclKind::VTablePlaceholder:
-    llvm_unreachable("should never need to reserialize a vtable placeholder");
+  case DeclKind::MissingMember:
+    llvm_unreachable("should never need to reserialize a member placeholder");
 
   case DeclKind::IfConfig:
     return false;
@@ -2508,8 +2508,8 @@ void Serializer::writeDecl(const Decl *D) {
     break;
   }
 
-  case DeclKind::VTablePlaceholder:
-    llvm_unreachable("vtable placeholders shouldn't be serialized");
+  case DeclKind::MissingMember:
+    llvm_unreachable("member placeholders shouldn't be serialized");
 
   case DeclKind::InfixOperator: {
     auto op = cast<InfixOperatorDecl>(D);

--- a/lib/Syntax/LegacyASTTransformer.cpp
+++ b/lib/Syntax/LegacyASTTransformer.cpp
@@ -280,8 +280,8 @@ LegacyASTTransformer::visitPostfixOperatorDecl(
 
 
 RC<SyntaxData>
-LegacyASTTransformer::visitVTablePlaceholderDecl(
-    VTablePlaceholderDecl *D,
+LegacyASTTransformer::visitMissingMemberDecl(
+    MissingMemberDecl *D,
     const SyntaxData *Parent,
     const CursorIndex IndexInParent) {
   return getUnknownDecl(D);

--- a/lib/Syntax/LegacyASTTransformer.cpp
+++ b/lib/Syntax/LegacyASTTransformer.cpp
@@ -278,6 +278,15 @@ LegacyASTTransformer::visitPostfixOperatorDecl(
   return getUnknownDecl(D);
 }
 
+
+RC<SyntaxData>
+LegacyASTTransformer::visitVTablePlaceholderDecl(
+    VTablePlaceholderDecl *D,
+    const SyntaxData *Parent,
+    const CursorIndex IndexInParent) {
+  return getUnknownDecl(D);
+}
+
 RC<SyntaxData>
 LegacyASTTransformer::visitGenericTypeParamDecl(
     GenericTypeParamDecl *D,

--- a/test/Serialization/Recovery/overrides.swift
+++ b/test/Serialization/Recovery/overrides.swift
@@ -294,7 +294,6 @@ open class D8_UnknownInitDisappearsRequired : UnknownInitDisappearsBase {
 // CHECK-RECOVERY-LABEL: class D8_UnknownInitDisappearsRequired : UnknownInitDisappearsBase {
 // CHECK-RECOVERY-NEXT: init()
 // CHECK-RECOVERY-NEXT: /* placeholder for init(value:) */
-// CHECK-RECOVERY-NEXT: /* placeholder for init(value:) */
 // CHECK-RECOVERY-NEXT: {{^}$}}
 
 open class D9_UnknownInitDisappearsRequiredGrandchild : D8_UnknownInitDisappearsRequired {

--- a/test/Serialization/Recovery/overrides.swift
+++ b/test/Serialization/Recovery/overrides.swift
@@ -191,6 +191,7 @@ open class D1_DesignatedInitDisappears : DesignatedInitDisappearsBase {
 
 // CHECK-RECOVERY-LABEL: class D1_DesignatedInitDisappears : DesignatedInitDisappearsBase {
 // CHECK-RECOVERY-NEXT: init()
+// CHECK-RECOVERY-NEXT: /* placeholder for init(value:) */
 // CHECK-RECOVERY-NEXT: {{^}$}}
 
 
@@ -203,6 +204,7 @@ open class D2_OnlyDesignatedInitDisappears : OnlyDesignatedInitDisappearsBase {
 // CHECK-NEXT: {{^}$}}
 
 // CHECK-RECOVERY-LABEL: class D2_OnlyDesignatedInitDisappears : OnlyDesignatedInitDisappearsBase {
+// CHECK-RECOVERY-NEXT: /* placeholder for init(value:) */
 // CHECK-RECOVERY-NEXT: {{^}$}}
 
 
@@ -231,6 +233,7 @@ open class D4_UnknownInitDisappears : UnknownInitDisappearsBase {
 
 // CHECK-RECOVERY-LABEL: class D4_UnknownInitDisappears : UnknownInitDisappearsBase {
 // CHECK-RECOVERY-NEXT: init()
+// CHECK-RECOVERY-NEXT: /* placeholder for init(value:) */
 // CHECK-RECOVERY-NEXT: {{^}$}}
 
 
@@ -244,7 +247,69 @@ open class D5_OnlyUnknownInitDisappears : OnlyUnknownInitDisappearsBase {
 // CHECK-NEXT: {{^}$}}
 
 // CHECK-RECOVERY-LABEL: class D5_OnlyUnknownInitDisappears : OnlyUnknownInitDisappearsBase {
+// CHECK-RECOVERY-NEXT: /* placeholder for init(value:) */
 // CHECK-RECOVERY-NEXT: init()
+// CHECK-RECOVERY-NEXT: {{^}$}}
+
+open class D6_UnknownInitDisappearsGrandchild : D4_UnknownInitDisappears {
+  public override init() { fatalError() }
+  public override init(value: Int) { fatalError() }
+}
+
+// CHECK-LABEL: class D6_UnknownInitDisappearsGrandchild : D4_UnknownInitDisappears {
+// CHECK-NEXT: init()
+// CHECK-NEXT: init(value: Int)
+// CHECK-NEXT: {{^}$}}
+
+// CHECK-RECOVERY-LABEL: class D6_UnknownInitDisappearsGrandchild : D4_UnknownInitDisappears {
+// CHECK-RECOVERY-NEXT: init()
+// CHECK-RECOVERY-NEXT: /* placeholder for init(value:) */
+// CHECK-RECOVERY-NEXT: {{^}$}}
+
+open class D7_UnknownInitDisappearsGrandchildRequired : D4_UnknownInitDisappears {
+  public override init() { fatalError() }
+  public required override init(value: Int) { fatalError() }
+}
+
+// CHECK-LABEL: class D7_UnknownInitDisappearsGrandchildRequired : D4_UnknownInitDisappears {
+// CHECK-NEXT: init()
+// CHECK-NEXT: init(value: Int)
+// CHECK-NEXT: {{^}$}}
+
+// CHECK-RECOVERY-LABEL: class D7_UnknownInitDisappearsGrandchildRequired : D4_UnknownInitDisappears {
+// CHECK-RECOVERY-NEXT: init()
+// CHECK-RECOVERY-NEXT: /* placeholder for init(value:) */
+// CHECK-RECOVERY-NEXT: {{^}$}}
+
+open class D8_UnknownInitDisappearsRequired : UnknownInitDisappearsBase {
+  public override init() { fatalError() }
+  public required override init(value: Int) { fatalError() }
+}
+
+// CHECK-LABEL: class D8_UnknownInitDisappearsRequired : UnknownInitDisappearsBase {
+// CHECK-NEXT: init()
+// CHECK-NEXT: init(value: Int)
+// CHECK-NEXT: {{^}$}}
+
+// CHECK-RECOVERY-LABEL: class D8_UnknownInitDisappearsRequired : UnknownInitDisappearsBase {
+// CHECK-RECOVERY-NEXT: init()
+// CHECK-RECOVERY-NEXT: /* placeholder for init(value:) */
+// CHECK-RECOVERY-NEXT: /* placeholder for init(value:) */
+// CHECK-RECOVERY-NEXT: {{^}$}}
+
+open class D9_UnknownInitDisappearsRequiredGrandchild : D8_UnknownInitDisappearsRequired {
+  public override init() { fatalError() }
+  public required init(value: Int) { fatalError() }
+}
+
+// CHECK-LABEL: class D9_UnknownInitDisappearsRequiredGrandchild : D8_UnknownInitDisappearsRequired {
+// CHECK-NEXT: init()
+// CHECK-NEXT: init(value: Int)
+// CHECK-NEXT: {{^}$}}
+
+// CHECK-RECOVERY-LABEL: class D9_UnknownInitDisappearsRequiredGrandchild : D8_UnknownInitDisappearsRequired {
+// CHECK-RECOVERY-NEXT: init()
+// CHECK-RECOVERY-NEXT: /* placeholder for init(value:) */
 // CHECK-RECOVERY-NEXT: {{^}$}}
 
 #endif // TEST

--- a/test/Serialization/Recovery/typedefs.swift
+++ b/test/Serialization/Recovery/typedefs.swift
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: %target-swift-frontend -emit-module -o %t -module-name Lib -I %S/Inputs/custom-modules %s
+// RUN: %target-swift-frontend -emit-sil -o - -emit-module-path %t/Lib.swiftmodule -module-name Lib -I %S/Inputs/custom-modules %s | %FileCheck -check-prefix CHECK-VTABLE %s
 
 // RUN: %target-swift-ide-test -source-filename=x -print-module -module-to-print Lib -I %t -I %S/Inputs/custom-modules | %FileCheck %s
 
@@ -9,6 +9,7 @@
 
 // RUN: %target-swift-frontend -typecheck -I %t -I %S/Inputs/custom-modules -Xcc -DBAD -DTEST -enable-experimental-deserialization-recovery -DVERIFY %s -verify
 // RUN: %target-swift-frontend -emit-silgen -I %t -I %S/Inputs/custom-modules -Xcc -DBAD -DTEST -enable-experimental-deserialization-recovery %s | %FileCheck -check-prefix CHECK-SIL %s
+// RUN: %target-swift-frontend -emit-ir -I %t -I %S/Inputs/custom-modules -Xcc -DBAD -DTEST -enable-experimental-deserialization-recovery %s | %FileCheck -check-prefix CHECK-IR %s
 
 #if TEST
 
@@ -23,6 +24,16 @@ func testSymbols() {
   // CHECK-SIL: function_ref @_T03Lib9usesAssocs5Int32VSgfau
   _ = Lib.usesAssoc
 } // CHECK-SIL: end sil function '_T08typedefs11testSymbolsyyF'
+
+// CHECK-IR-LABEL: define{{.*}} void @_T08typedefs18testVTableBuildingy3Lib4UserC4user_tF
+public func testVTableBuilding(user: User) {
+  // The important thing in this CHECK line is the "i64 23", which is the offset
+  // for the vtable slot for 'lastMethod()'. If the layout here
+  // changes, please check that offset 23 is still correct.
+  // CHECK-IR-NOT: ret
+  // CHECK-IR: getelementptr inbounds void (%T3Lib4UserC*)*, void (%T3Lib4UserC*)** %{{[0-9]+}}, i64 23
+  _ = user.lastMethod()
+} // CHECK-IR: ret void
 
 #if VERIFY
 let _: String = useAssoc(ImportedType.self) // expected-error {{cannot convert call result type '_.Assoc?' to expected type 'String'}}
@@ -93,11 +104,33 @@ open class User {
 
   // CHECK: required init(wrappedRequired: WrappedInt)
   // CHECK-RECOVERY: /* placeholder for init(wrappedRequired:) */
-  // CHECK-RECOVERY: /* placeholder for init(wrappedRequired:) */
   public required init(wrappedRequired: WrappedInt) {}
+
+  public func lastMethod() {}
 }
 // CHECK: {{^}$}}
 // CHECK-RECOVERY: {{^}$}}
+
+// This is mostly to check when changes are necessary for the CHECK-IR lines
+// above.
+// CHECK-VTABLE-LABEL: sil_vtable User {
+// (8 words of normal class metadata)
+// 9 CHECK-VTABLE-NEXT: #User.unwrappedProp!getter.1:
+// 10 CHECK-VTABLE-NEXT: #User.unwrappedProp!setter.1:
+// 11 CHECK-VTABLE-NEXT: #User.unwrappedProp!materializeForSet.1:
+// 12 CHECK-VTABLE-NEXT: #User.wrappedProp!getter.1:
+// 13 CHECK-VTABLE-NEXT: #User.wrappedProp!setter.1:
+// 14 CHECK-VTABLE-NEXT: #User.wrappedProp!materializeForSet.1:
+// 15 CHECK-VTABLE-NEXT: #User.returnsUnwrappedMethod!1:
+// 16 CHECK-VTABLE-NEXT: #User.returnsWrappedMethod!1:
+// 17 CHECK-VTABLE-NEXT: #User.subscript!getter.1:
+// 18 CHECK-VTABLE-NEXT: #User.init!initializer.1:
+// 19 CHECK-VTABLE-NEXT: #User.init!initializer.1:
+// 20 CHECK-VTABLE-NEXT: #User.init!initializer.1:
+// 21 CHECK-VTABLE-NEXT: #User.init!allocator.1:
+// 22 CHECK-VTABLE-NEXT: #User.init!initializer.1:
+// 23 CHECK-VTABLE-NEXT: #User.lastMethod!1:
+// CHECK-VTABLE: }
 
 
 // CHECK-LABEL: class UserConvenience

--- a/test/Serialization/Recovery/typedefs.swift
+++ b/test/Serialization/Recovery/typedefs.swift
@@ -128,7 +128,6 @@ open class UserSub : User {
 
   // CHECK: required init(wrappedRequired: WrappedInt?)
   // CHECK-RECOVERY: /* placeholder for init(wrappedRequired:) */
-  // CHECK-RECOVERY: /* placeholder for init(wrappedRequired:) */
   public required init(wrappedRequired: WrappedInt?) { super.init() }
 }
 // CHECK: {{^}$}}

--- a/test/Serialization/Recovery/typedefs.swift
+++ b/test/Serialization/Recovery/typedefs.swift
@@ -64,18 +64,19 @@ open class User {
   // CHECK-RECOVERY: var unwrappedProp: Int32?
   public var unwrappedProp: UnwrappedInt?
   // CHECK: var wrappedProp: WrappedInt?
-  // CHECK-RECOVERY-NEGATIVE-NOT: var wrappedProp:
+  // CHECK-RECOVERY: /* placeholder for _ */
+  // CHECK-RECOVERY: /* placeholder for _ */
   public var wrappedProp: WrappedInt?
 
   // CHECK: func returnsUnwrappedMethod() -> UnwrappedInt
   // CHECK-RECOVERY: func returnsUnwrappedMethod() -> Int32
   public func returnsUnwrappedMethod() -> UnwrappedInt { fatalError() }
   // CHECK: func returnsWrappedMethod() -> WrappedInt
-  // CHECK-RECOVERY-NEGATIVE-NOT: func returnsWrappedMethod(
+  // CHECK-RECOVERY: /* placeholder for returnsWrappedMethod() */
   public func returnsWrappedMethod() -> WrappedInt { fatalError() }
 
   // CHECK: subscript(_: WrappedInt) -> () { get }
-  // CHECK-RECOVERY-NEGATIVE-NOT: subscript(
+  // CHECK-RECOVERY: /* placeholder for _ */
   public subscript(_: WrappedInt) -> () { return () }
 
   // CHECK: init()
@@ -83,15 +84,21 @@ open class User {
   public init() {}
 
   // CHECK: init(wrapped: WrappedInt)
-  // CHECK-RECOVERY-NEGATIVE-NOT: init(wrapped:
+  // CHECK-RECOVERY: /* placeholder for init(wrapped:) */
   public init(wrapped: WrappedInt) {}
 
   // CHECK: convenience init(conveniently: Int)
   // CHECK-RECOVERY: convenience init(conveniently: Int)
   public convenience init(conveniently: Int) { self.init() }
+
+  // CHECK: required init(wrappedRequired: WrappedInt)
+  // CHECK-RECOVERY: /* placeholder for init(wrappedRequired:) */
+  // CHECK-RECOVERY: /* placeholder for init(wrappedRequired:) */
+  public required init(wrappedRequired: WrappedInt) {}
 }
 // CHECK: {{^}$}}
 // CHECK-RECOVERY: {{^}$}}
+
 
 // CHECK-LABEL: class UserConvenience
 // CHECK-RECOVERY-LABEL: class UserConvenience
@@ -101,7 +108,7 @@ open class UserConvenience {
   public init() {}
 
   // CHECK: convenience init(wrapped: WrappedInt)
-  // CHECK-RECOVERY-NEGATIVE-NOT: init(wrapped:
+  // CHECK-RECOVERY: /* placeholder for init(wrapped:) */
   public convenience init(wrapped: WrappedInt) { self.init() }
 
   // CHECK: convenience init(conveniently: Int)
@@ -110,6 +117,23 @@ open class UserConvenience {
 }
 // CHECK: {{^}$}}
 // CHECK-RECOVERY: {{^}$}}
+
+
+// CHECK-LABEL: class UserSub
+// CHECK-RECOVERY-LABEL: class UserSub
+open class UserSub : User {
+  // CHECK: init(wrapped: WrappedInt?)
+  // CHECK-RECOVERY: /* placeholder for init(wrapped:) */
+  public override init(wrapped: WrappedInt?) { super.init() }
+
+  // CHECK: required init(wrappedRequired: WrappedInt?)
+  // CHECK-RECOVERY: /* placeholder for init(wrappedRequired:) */
+  // CHECK-RECOVERY: /* placeholder for init(wrappedRequired:) */
+  public required init(wrappedRequired: WrappedInt?) { super.init() }
+}
+// CHECK: {{^}$}}
+// CHECK-RECOVERY: {{^}$}}
+
 
 // CHECK-DAG: let x: MysteryTypedef
 // CHECK-RECOVERY-DAG: let x: Int32


### PR DESCRIPTION
Since our vtables are generated from the AST by the client (see #9309), dropping class members when there are deserialization errors (see #8933) can cause vtables to lose entries. Since vtable dispatch is done by constant, compile-time offsets today, this would lead to miscompiled code. Our solution is a new VTablePlaceholderDecl that occupies a spot in the ClassDecl, which SIL can use to leave a blank space in the vtable.

TODO:
- [x] Actually hook this up to the vtable emitter.
- [ ] Disable subclassing when there are missing vtable entries. (This is a symptom of our current vtable emission, which needs to directly reference symbols that appear in base class vtables.)
- [ ] Handle protocols as well.

(remaining items to be handled in follow-up PRs)

rdar://problem/31878396