### PR TITLE
[SourceKit] When cursor points to an external argument name in a function-like decl, we should return the information about the function-like decl instead of being empty. rdar://32018814 (#9356)

### DIFF
--- a/include/swift/AST/SourceEntityWalker.h
+++ b/include/swift/AST/SourceEntityWalker.h
@@ -124,6 +124,19 @@ public:
   virtual bool visitCallArgName(Identifier Name, CharSourceRange Range,
                                 ValueDecl *D);
 
+  /// This method is called for each external argument name in function-like
+  /// declarations like constructor, function and subscript. The function is
+  /// called only when a external argument label is specifically specified,
+  /// like func foo(External Internal: Int) {}.
+  /// If it returns false, the remaining traversal is terminated and returns
+  /// failure.
+  ///
+  /// \param Name the argument name.
+  /// \param StartLoc the source loc of the argument name start.
+  /// \param D the function-like decl.
+  virtual bool visitDeclarationArgumentName(Identifier Name, SourceLoc StartLoc,
+                                            ValueDecl *D);
+
   /// This method is called when a Module is referenced in source.
   virtual bool visitModuleReference(ModuleEntity Mod, CharSourceRange Range);
 

--- a/include/swift/IDE/Utils.h
+++ b/include/swift/IDE/Utils.h
@@ -199,6 +199,8 @@ private:
                           ReferenceMetaData Data) override;
   bool visitCallArgName(Identifier Name, CharSourceRange Range,
                         ValueDecl *D) override;
+  bool visitDeclarationArgumentName(Identifier Name, SourceLoc StartLoc,
+                                    ValueDecl *D) override;
   bool visitModuleReference(ModuleEntity Mod, CharSourceRange Range) override;
   bool rangeContainsLoc(SourceRange Range) const {
     return getSourceMgr().rangeContainsTokenLoc(Range, LocToResolve);

--- a/lib/AST/SourceEntityWalker.cpp
+++ b/lib/AST/SourceEntityWalker.cpp
@@ -18,6 +18,7 @@
 #include "swift/AST/Expr.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/Pattern.h"
+#include "swift/AST/ParameterList.h"
 #include "swift/AST/Stmt.h"
 #include "swift/AST/TypeRepr.h"
 #include "swift/AST/Types.h"
@@ -97,7 +98,30 @@ bool SemaAnnotator::walkToDeclPre(Decl *D) {
     if (VD->hasName() && !VD->isImplicit())
       NameLen = VD->getName().getLength();
 
-  } else if (ExtensionDecl *ED = dyn_cast<ExtensionDecl>(D)) {
+    auto ReportParamList = [&](ParameterList *PL) {
+      for (auto *PD : *PL) {
+        auto Loc = PD->getArgumentNameLoc();
+        if (Loc.isInvalid())
+          continue;
+        if (!SEWalker.visitDeclarationArgumentName(PD->getArgumentName(), Loc,
+                                                   VD)) {
+          Cancelled = true;
+          return true;
+        }
+      }
+      return false;
+    };
+
+    if (auto AF = dyn_cast<AbstractFunctionDecl>(VD)) {
+      for (auto *PL : AF->getParameterLists())
+        if (ReportParamList(PL))
+          return false;
+    }
+    if (auto SD = dyn_cast<SubscriptDecl>(VD)) {
+      if (ReportParamList(SD->getIndices()))
+        return false;
+    }
+  } else if (auto *ED = dyn_cast<ExtensionDecl>(D)) {
     SourceRange SR = ED->getExtendedTypeLoc().getSourceRange();
     Loc = SR.Start;
     if (Loc.isValid())
@@ -554,6 +578,11 @@ bool SourceEntityWalker::visitSubscriptReference(ValueDecl *D,
 bool SourceEntityWalker::visitCallArgName(Identifier Name,
                                           CharSourceRange Range,
                                           ValueDecl *D) {
+  return true;
+}
+
+bool SourceEntityWalker::
+visitDeclarationArgumentName(Identifier Name, SourceLoc Start, ValueDecl *D) {
   return true;
 }
 

--- a/lib/IDE/SwiftSourceDocInfo.cpp
+++ b/lib/IDE/SwiftSourceDocInfo.cpp
@@ -199,6 +199,13 @@ bool SemaLocResolver::visitCallArgName(Identifier Name, CharSourceRange Range,
   return !Found;
 }
 
+bool SemaLocResolver::
+visitDeclarationArgumentName(Identifier Name, SourceLoc StartLoc, ValueDecl *D) {
+  if (isDone())
+    return false;
+  return !tryResolve(D, nullptr, nullptr, StartLoc, /*IsRef=*/false);
+}
+
 bool SemaLocResolver::visitModuleReference(ModuleEntity Mod,
                                            CharSourceRange Range) {
   if (isDone())

--- a/test/SourceKit/CursorInfo/cursor_label.swift
+++ b/test/SourceKit/CursorInfo/cursor_label.swift
@@ -13,19 +13,54 @@ class C1 {
 let c = C1(cc: 1)
 c.foo(aa : 1)
 
+class C2 {
+  init(cc cc: Int) {}
+  func foo(aa aa : Int) {}
+  subscript(aa aa : Int, bb bb: Int)-> Int { get { return 0 } set {}}
+}
+
 // RUN: %sourcekitd-test -req=cursor -pos=2:9 %s -- %s | %FileCheck %s -check-prefix=CHECK1
 // RUN: %sourcekitd-test -req=cursor -pos=3:13 %s -- %s | %FileCheck %s -check-prefix=CHECK2
 // RUN: %sourcekitd-test -req=cursor -pos=4:24 %s -- %s | %FileCheck %s -check-prefix=CHECK3
-// RUN: %sourcekitd-test -req=cursor -pos=5:15 %s -- %s | %FileCheck %s -check-prefix=CHECK-NONE
-// RUN: %sourcekitd-test -req=cursor -pos=6:11 %s -- %s | %FileCheck %s -check-prefix=CHECK-NONE
-// RUN: %sourcekitd-test -req=cursor -pos=7:16 %s -- %s | %FileCheck %s -check-prefix=CHECK-NONE
-// RUN: %sourcekitd-test -req=cursor -pos=8:18 %s -- %s | %FileCheck %s -check-prefix=CHECK-NONE
+// RUN: %sourcekitd-test -req=cursor -pos=5:15 %s -- %s | %FileCheck %s -check-prefix=CHECK-NO-PARENT-PARAM
+// RUN: %sourcekitd-test -req=cursor -pos=6:11 %s -- %s | %FileCheck %s -check-prefix=CHECK-NO-PARENT-PARAM
+// RUN: %sourcekitd-test -req=cursor -pos=7:16 %s -- %s | %FileCheck %s -check-prefix=CHECK-NO-PARENT-PARAM
+// RUN: %sourcekitd-test -req=cursor -pos=8:18 %s -- %s | %FileCheck %s -check-prefix=CHECK-NO-PARENT-PARAM
 // RUN: %sourcekitd-test -req=cursor -pos=8:28 %s -- %s | %FileCheck %s -check-prefix=CHECK4
-// RUN: %sourcekitd-test -req=cursor -pos=9:9 %s -- %s | %FileCheck %s -check-prefix=CHECK-NONE
-// RUN: %sourcekitd-test -req=cursor -pos=10:9 %s -- %s | %FileCheck %s -check-prefix=CHECK4
+// RUN: %sourcekitd-test -req=cursor -pos=9:9 %s -- %s | %FileCheck %s -check-prefix=CHECK-NO-PARENT-VAR
+// RUN: %sourcekitd-test -req=cursor -pos=10:9 %s -- %s | %FileCheck %s -check-prefix=CHECK5
 
+// CHECK1: source.lang.swift.decl.var.parameter
 // CHECK1: PARENT OFFSET: 13
+
+// CHECK2: source.lang.swift.decl.var.parameter
 // CHECK2: PARENT OFFSET: 37
+
+// CHECK3: source.lang.swift.decl.var.parameter
 // CHECK3: PARENT OFFSET: 56
+
+// CHECK4: source.lang.swift.decl.var.parameter
 // CHECK4: PARENT OFFSET: 229
-// CHECK-NONE-NOT: PARENT OFFSET:
+
+// CHECK5: source.lang.swift.ref.var.local
+// CHECK5: PARENT OFFSET: 229
+
+// CHECK-NO-PARENT-PARAM: source.lang.swift.decl.var.parameter
+// CHECK-NO-PARENT-PARAM-NOT: PARENT OFFSET:
+
+// CHECK-NO-PARENT-VAR: source.lang.swift.ref.var.local
+// CHECK-NO-PARENT-VAR-NOT: PARENT OFFSET:
+
+// RUN: %sourcekitd-test -req=cursor -pos=17:9 %s -- %s | %FileCheck %s -check-prefix=CHECK-CONSTRUCTOR
+// RUN: %sourcekitd-test -req=cursor -pos=18:13 %s -- %s | %FileCheck %s -check-prefix=CHECK-FUNC
+// RUN: %sourcekitd-test -req=cursor -pos=19:14 %s -- %s | %FileCheck %s -check-prefix=CHECK-SUBS
+// RUN: %sourcekitd-test -req=cursor -pos=19:27 %s -- %s | %FileCheck %s -check-prefix=CHECK-SUBS
+
+// CHECK-CONSTRUCTOR: source.lang.swift.decl.function.constructor
+// CHECK-CONSTRUCTOR-NOT: PARENT OFFSET:
+
+// CHECK-FUNC: source.lang.swift.decl.function.method.instance
+// CHECK-FUNC-NOT: PARENT OFFSET:
+
+// CHECK-SUBS: source.lang.swift.decl.function.subscript
+// CHECK-SUBS-NOT: PARENT OFFSET:


### PR DESCRIPTION
Explanation: We are not giving cursor info when cursor points to an external argument label of function-like declarations. This hinders some tooling request from IDE.
Scope: Affects cursor info
Reviewed by: @benlangmuir 
Radar: rdar://32018814
Risk: Low
Testing: Regression tests added.