### PR TITLE
[Migrator] Add `Swift.` prefix to type(of:) expressions in Swift 3

### DIFF
--- a/test/Migrator/prefix_typeof_expr.swift
+++ b/test/Migrator/prefix_typeof_expr.swift
@@ -1,0 +1,27 @@
+// rdar://problem/32025974
+// XFAIL: linux
+// RUN: rm -rf %t && mkdir -p %t && %target-swift-frontend -c -update-code -primary-file %s -emit-migrated-file-path %t/prefix_typeof_expr.swift.result -emit-remap-file-path %t/member.swift.remap -o /dev/null
+// RUN: diff -u %S/prefix_typeof_expr.swift.expected %t/prefix_typeof_expr.swift.result
+
+class HasTypeVar {
+  var type: Int {
+    precondition(true, "\(type(of: self)) should never be asked for its type")
+    _ = Swift.type(of: 1) // Don't add another prefix to this one
+    return 1
+  }
+}
+
+class HasTypeMethod {
+  func type<T>(of: T) -> Int {
+    _ = type(of: 1)
+    _ = Swift.type(of: 1) // Don't add another prefix to this one
+    return 1
+  }
+}
+
+func type<T>(of: T) -> Int {
+  return 1
+}
+
+_ = type(of: 1)
+_ = Swift.type(of: 1) // Don't add another prefix to this one

--- a/test/Migrator/prefix_typeof_expr.swift.expected
+++ b/test/Migrator/prefix_typeof_expr.swift.expected
@@ -1,0 +1,27 @@
+// rdar://problem/32025974
+// XFAIL: linux
+// RUN: rm -rf %t && mkdir -p %t && %target-swift-frontend -c -update-code -primary-file %s -emit-migrated-file-path %t/prefix_typeof_expr.swift.result -emit-remap-file-path %t/member.swift.remap -o /dev/null
+// RUN: diff -u %S/prefix_typeof_expr.swift.expected %t/prefix_typeof_expr.swift.result
+
+class HasTypeVar {
+  var type: Int {
+    precondition(true, "\(Swift.type(of: self)) should never be asked for its type")
+    _ = Swift.type(of: 1) // Don't add another prefix to this one
+    return 1
+  }
+}
+
+class HasTypeMethod {
+  func type<T>(of: T) -> Int {
+    _ = Swift.type(of: 1)
+    _ = Swift.type(of: 1) // Don't add another prefix to this one
+    return 1
+  }
+}
+
+func type<T>(of: T) -> Int {
+  return 1
+}
+
+_ = Swift.type(of: 1)
+_ = Swift.type(of: 1) // Don't add another prefix to this one

--- a/test/Migrator/tuple-arguments.swift
+++ b/test/Migrator/tuple-arguments.swift
@@ -1,4 +1,4 @@
-// FIXME: Figure out why this is not working on linux
+// rdar://problem/32025974
 // XFAIL: linux
 
 // RUN: %target-swift-frontend -typecheck %s -swift-version 3

--- a/test/Migrator/tuple-arguments.swift.expected
+++ b/test/Migrator/tuple-arguments.swift.expected
@@ -1,4 +1,4 @@
-// FIXME: Figure out why this is not working on linux
+// rdar://problem/32025974
 // XFAIL: linux
 
 // RUN: %target-swift-frontend -typecheck %s -swift-version 3


### PR DESCRIPTION
This changed to be resolved by overload resolution in Swift 4, and so
can suddenly be shadowed by similarly named properties and functions
that are visible at the expression's location. When in Swift 3 mode, if
there is a visible declaration named "type", add the `Swift.` prefix to
disambiguate in Swift 4 mode.

rdar://problem/31997321