### PR TITLE
Swift 4.0: overlays: Update dependencies and amend the script to add headers.

### DIFF
--- a/stdlib/public/SDK/CloudKit/CMakeLists.txt
+++ b/stdlib/public/SDK/CloudKit/CMakeLists.txt
@@ -8,18 +8,10 @@ add_swift_library(swiftCloudKit ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
   TARGET_SDKS OSX IOS IOS_SIMULATOR TVOS TVOS_SIMULATOR WATCHOS WATCHOS_SIMULATOR
 
-  # The dependency on the 'os' module only appears in particular Apple-internal
-  # configurations, but it causes no harm to specify it unconditionally.
-  # The ./utils/find-overlay-dependencies.sh tool only touches the
-  # OSX|IOS|TVOS|WATCHOS lines, so the standalone "os" lines remain.
-  SWIFT_MODULE_DEPENDS_OSX Darwin Contacts CoreGraphics CoreLocation Dispatch Foundation IOKit ObjectiveC # auto-updated
-    os
-  SWIFT_MODULE_DEPENDS_IOS Darwin Contacts CoreLocation Dispatch Foundation ObjectiveC # auto-updated
-    os
-  SWIFT_MODULE_DEPENDS_TVOS Darwin CoreLocation Dispatch Foundation ObjectiveC # auto-updated
-    os
-  SWIFT_MODULE_DEPENDS_WATCHOS Darwin CoreLocation Dispatch Foundation ObjectiveC # auto-updated
-    os
+  SWIFT_MODULE_DEPENDS_OSX Darwin CoreGraphics CoreLocation Dispatch Foundation IOKit ObjectiveC os XPC # auto-updated
+  SWIFT_MODULE_DEPENDS_IOS Darwin CoreGraphics CoreLocation Dispatch Foundation ObjectiveC os # auto-updated
+  SWIFT_MODULE_DEPENDS_TVOS Darwin CoreGraphics CoreLocation Dispatch Foundation ObjectiveC os # auto-updated
+  SWIFT_MODULE_DEPENDS_WATCHOS Darwin CoreGraphics CoreLocation Dispatch Foundation ObjectiveC os # auto-updated
   FRAMEWORK_DEPENDS_WEAK CloudKit
 
   DEPLOYMENT_VERSION_OSX ${SWIFTLIB_DEPLOYMENT_VERSION_CLOUDKIT_OSX}

--- a/stdlib/public/SDK/Contacts/CMakeLists.txt
+++ b/stdlib/public/SDK/Contacts/CMakeLists.txt
@@ -8,8 +8,8 @@ add_swift_library(swiftContacts ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
   TARGET_SDKS OSX IOS IOS_SIMULATOR WATCHOS WATCHOS_SIMULATOR
   SWIFT_MODULE_DEPENDS_OSX Darwin CoreGraphics Dispatch Foundation IOKit ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_IOS Darwin Dispatch Foundation ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_WATCHOS Darwin Dispatch Foundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_IOS Darwin CoreGraphics Dispatch Foundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_WATCHOS Darwin CoreGraphics Dispatch Foundation ObjectiveC # auto-updated
   FRAMEWORK_DEPENDS_WEAK Contacts
 
   DEPLOYMENT_VERSION_OSX ${SWIFTLIB_DEPLOYMENT_VERSION_CONTACTS_OSX}

--- a/stdlib/public/SDK/CoreData/CMakeLists.txt
+++ b/stdlib/public/SDK/CoreData/CMakeLists.txt
@@ -9,9 +9,9 @@ add_swift_library(swiftCoreData ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_
   SWIFT_COMPILE_FLAGS "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}"
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
   SWIFT_MODULE_DEPENDS_OSX Darwin CoreGraphics Dispatch Foundation IOKit ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_IOS Darwin Dispatch Foundation ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_TVOS Darwin Dispatch Foundation ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_WATCHOS Darwin Dispatch Foundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_IOS Darwin CoreGraphics Dispatch Foundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_TVOS Darwin CoreGraphics Dispatch Foundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_WATCHOS Darwin CoreGraphics Dispatch Foundation ObjectiveC # auto-updated
   FRAMEWORK_DEPENDS CoreData
 
   DEPLOYMENT_VERSION_OSX ${SWIFTLIB_DEPLOYMENT_VERSION_COREDATA_OSX}

--- a/stdlib/public/SDK/CoreLocation/CMakeLists.txt
+++ b/stdlib/public/SDK/CoreLocation/CMakeLists.txt
@@ -8,9 +8,9 @@ add_swift_library(swiftCoreLocation ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_
   SWIFT_COMPILE_FLAGS "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}"
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
   SWIFT_MODULE_DEPENDS_OSX Darwin CoreGraphics Dispatch Foundation IOKit ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_IOS Darwin Dispatch Foundation ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_TVOS Darwin Dispatch Foundation ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_WATCHOS Darwin Dispatch Foundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_IOS Darwin CoreGraphics Dispatch Foundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_TVOS Darwin CoreGraphics Dispatch Foundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_WATCHOS Darwin CoreGraphics Dispatch Foundation ObjectiveC # auto-updated
   FRAMEWORK_DEPENDS CoreLocation
 
   DEPLOYMENT_VERSION_OSX ${SWIFTLIB_DEPLOYMENT_VERSION_CORELOCATION_OSX}

--- a/stdlib/public/SDK/Foundation/CMakeLists.txt
+++ b/stdlib/public/SDK/Foundation/CMakeLists.txt
@@ -56,16 +56,9 @@ add_swift_library(swiftFoundation ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SD
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
 
   SWIFT_MODULE_DEPENDS_OSX Darwin CoreGraphics Dispatch IOKit ObjectiveC # auto-updated
-  # CoreGraphics is used by the overlay but not by the Foundation
-  # framework, so we need to add it as a dependency.
-  # The ./utils/find-overlay-dependencies.sh tool only touches the
-  # OSX|IOS|TVOS|WATCHOS lines, so the standalone CoreGraphics lines remain.
-  SWIFT_MODULE_DEPENDS_IOS Darwin Dispatch ObjectiveC # auto-updated
-    CoreGraphics
-  SWIFT_MODULE_DEPENDS_TVOS Darwin Dispatch ObjectiveC # auto-updated
-    CoreGraphics
-  SWIFT_MODULE_DEPENDS_WATCHOS Darwin Dispatch ObjectiveC # auto-updated
-    CoreGraphics
+  SWIFT_MODULE_DEPENDS_IOS Darwin CoreGraphics Dispatch ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_TVOS Darwin CoreGraphics Dispatch ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_WATCHOS Darwin CoreGraphics Dispatch ObjectiveC # auto-updated
   FRAMEWORK_DEPENDS Foundation
 
   DEPLOYMENT_VERSION_OSX ${SWIFTLIB_DEPLOYMENT_VERSION_FOUNDATION_OSX}

--- a/stdlib/public/SDK/GLKit/CMakeLists.txt
+++ b/stdlib/public/SDK/GLKit/CMakeLists.txt
@@ -8,7 +8,7 @@ add_swift_library(swiftGLKit ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVE
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
   TARGET_SDKS OSX IOS IOS_SIMULATOR TVOS TVOS_SIMULATOR
   SWIFT_MODULE_DEPENDS_OSX Darwin AppKit CoreData CoreGraphics CoreImage Dispatch Foundation IOKit ObjectiveC QuartzCore simd XPC # auto-updated
-  SWIFT_MODULE_DEPENDS_IOS Darwin CoreGraphics CoreImage Dispatch Foundation ObjectiveC QuartzCore simd UIKit # auto-updated
+  SWIFT_MODULE_DEPENDS_IOS Darwin CoreGraphics CoreImage Dispatch Foundation ObjectiveC os QuartzCore simd UIKit # auto-updated
   SWIFT_MODULE_DEPENDS_TVOS Darwin CoreGraphics CoreImage Dispatch Foundation ObjectiveC QuartzCore simd UIKit # auto-updated
   FRAMEWORK_DEPENDS GLKit
 

--- a/stdlib/public/SDK/GameplayKit/CMakeLists.txt
+++ b/stdlib/public/SDK/GameplayKit/CMakeLists.txt
@@ -8,7 +8,7 @@ add_swift_library(swiftGameplayKit ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_S
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
   TARGET_SDKS OSX IOS IOS_SIMULATOR TVOS TVOS_SIMULATOR
   SWIFT_MODULE_DEPENDS_OSX Darwin AppKit CoreData CoreGraphics CoreImage Dispatch Foundation GLKit IOKit ObjectiveC QuartzCore SceneKit simd SpriteKit XPC # auto-updated
-  SWIFT_MODULE_DEPENDS_IOS Darwin CoreGraphics CoreImage Dispatch Foundation GLKit ObjectiveC QuartzCore SceneKit simd SpriteKit UIKit # auto-updated
+  SWIFT_MODULE_DEPENDS_IOS Darwin CoreAudio CoreGraphics CoreImage CoreMedia Dispatch Foundation GLKit ObjectiveC os QuartzCore SceneKit simd SpriteKit UIKit # auto-updated
   SWIFT_MODULE_DEPENDS_TVOS Darwin CoreGraphics CoreImage Dispatch Foundation GLKit ObjectiveC QuartzCore SceneKit simd SpriteKit UIKit # auto-updated
   FRAMEWORK_DEPENDS_WEAK GameplayKit
 

--- a/stdlib/public/SDK/HomeKit/CMakeLists.txt
+++ b/stdlib/public/SDK/HomeKit/CMakeLists.txt
@@ -7,7 +7,7 @@ add_swift_library(swiftHomeKit ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_O
   SWIFT_COMPILE_FLAGS "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}"
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
   TARGET_SDKS IOS IOS_SIMULATOR TVOS TVOS_SIMULATOR WATCHOS WATCHOS_SIMULATOR
-  SWIFT_MODULE_DEPENDS_IOS Darwin CoreGraphics CoreImage Dispatch Foundation ObjectiveC QuartzCore UIKit # auto-updated
+  SWIFT_MODULE_DEPENDS_IOS Darwin CoreGraphics CoreImage Dispatch Foundation ObjectiveC os QuartzCore UIKit # auto-updated
   SWIFT_MODULE_DEPENDS_TVOS Darwin CoreGraphics CoreImage Dispatch Foundation ObjectiveC QuartzCore UIKit # auto-updated
   SWIFT_MODULE_DEPENDS_WATCHOS Darwin CoreGraphics Dispatch Foundation ObjectiveC # auto-updated
     UIKit # required in some configurations but not found by tool

--- a/stdlib/public/SDK/Intents/CMakeLists.txt
+++ b/stdlib/public/SDK/Intents/CMakeLists.txt
@@ -23,8 +23,8 @@ add_swift_library(swiftIntents ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_O
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
   TARGET_SDKS OSX IOS IOS_SIMULATOR WATCHOS WATCHOS_SIMULATOR
   SWIFT_MODULE_DEPENDS_OSX Darwin CoreGraphics CoreLocation Dispatch Foundation IOKit ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_IOS Darwin CoreLocation Dispatch Foundation ObjectiveC # auto-updated
-  SWIFT_MODULE_DEPENDS_WATCHOS Darwin CoreLocation Dispatch Foundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_IOS Darwin CoreGraphics CoreLocation Dispatch Foundation ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_WATCHOS Darwin CoreGraphics CoreLocation Dispatch Foundation ObjectiveC # auto-updated
   FRAMEWORK_DEPENDS_WEAK Intents
 
   DEPLOYMENT_VERSION_OSX ${SWIFTLIB_DEPLOYMENT_VERSION_INTENTS_OSX}

--- a/stdlib/public/SDK/MapKit/CMakeLists.txt
+++ b/stdlib/public/SDK/MapKit/CMakeLists.txt
@@ -7,7 +7,7 @@ add_swift_library(swiftMapKit ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OV
   SWIFT_COMPILE_FLAGS "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}"
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
   SWIFT_MODULE_DEPENDS_OSX Darwin AppKit CoreData CoreGraphics CoreImage CoreLocation Dispatch Foundation IOKit ObjectiveC QuartzCore XPC # auto-updated
-  SWIFT_MODULE_DEPENDS_IOS Darwin CoreGraphics CoreImage CoreLocation Dispatch Foundation ObjectiveC QuartzCore UIKit # auto-updated
+  SWIFT_MODULE_DEPENDS_IOS Darwin CoreGraphics CoreImage CoreLocation Dispatch Foundation ObjectiveC os QuartzCore UIKit # auto-updated
   SWIFT_MODULE_DEPENDS_TVOS Darwin CoreGraphics CoreImage CoreLocation Dispatch Foundation ObjectiveC QuartzCore UIKit # auto-updated
   SWIFT_MODULE_DEPENDS_WATCHOS Darwin CoreGraphics CoreLocation Dispatch Foundation ObjectiveC # auto-updated
     UIKit # required in some configurations but not found by tool

--- a/stdlib/public/SDK/Photos/CMakeLists.txt
+++ b/stdlib/public/SDK/Photos/CMakeLists.txt
@@ -7,8 +7,8 @@ add_swift_library(swiftPhotos ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OV
   SWIFT_COMPILE_FLAGS "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}"
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
   TARGET_SDKS IOS IOS_SIMULATOR TVOS TVOS_SIMULATOR
-  SWIFT_MODULE_DEPENDS_IOS Darwin AVFoundation CoreAudio CoreGraphics CoreImage CoreLocation CoreMedia Dispatch Foundation ObjectiveC QuartzCore simd UIKit # auto-updated
-  SWIFT_MODULE_DEPENDS_TVOS Darwin AVFoundation CoreAudio CoreGraphics CoreImage CoreLocation CoreMedia Dispatch Foundation ObjectiveC QuartzCore simd UIKit # auto-updated
+  SWIFT_MODULE_DEPENDS_IOS Darwin AVFoundation CoreAudio CoreData CoreGraphics CoreImage CoreLocation CoreMedia Dispatch Foundation ObjectiveC os QuartzCore simd UIKit # auto-updated
+  SWIFT_MODULE_DEPENDS_TVOS Darwin AVFoundation CoreAudio CoreData CoreGraphics CoreImage CoreLocation CoreMedia Dispatch Foundation ObjectiveC QuartzCore simd UIKit # auto-updated
   FRAMEWORK_DEPENDS Photos
 
   DEPLOYMENT_VERSION_IOS ${SWIFTLIB_DEPLOYMENT_VERSION_PHOTOS_IOS}

--- a/stdlib/public/SDK/SceneKit/CMakeLists.txt
+++ b/stdlib/public/SDK/SceneKit/CMakeLists.txt
@@ -8,9 +8,9 @@ add_swift_library(swiftSceneKit ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
   TARGET_SDKS OSX IOS IOS_SIMULATOR TVOS TVOS_SIMULATOR WATCHOS WATCHOS_SIMULATOR
   SWIFT_MODULE_DEPENDS_OSX Darwin AppKit CoreData CoreGraphics CoreImage Dispatch Foundation GLKit IOKit ObjectiveC QuartzCore simd XPC # auto-updated
-  SWIFT_MODULE_DEPENDS_IOS Darwin CoreGraphics CoreImage Dispatch Foundation GLKit ObjectiveC QuartzCore simd UIKit # auto-updated
+  SWIFT_MODULE_DEPENDS_IOS Darwin CoreAudio CoreGraphics CoreImage CoreMedia Dispatch Foundation GLKit ObjectiveC os QuartzCore simd UIKit # auto-updated
   SWIFT_MODULE_DEPENDS_TVOS Darwin CoreGraphics CoreImage Dispatch Foundation GLKit ObjectiveC QuartzCore simd UIKit # auto-updated
-  SWIFT_MODULE_DEPENDS_WATCHOS Darwin CoreGraphics Dispatch Foundation ObjectiveC simd # auto-updated
+  SWIFT_MODULE_DEPENDS_WATCHOS Darwin CoreGraphics Dispatch Foundation ObjectiveC simd UIKit # auto-updated
     UIKit # required in some configurations but not found by tool
   FRAMEWORK_DEPENDS_WEAK SceneKit
 

--- a/stdlib/public/SDK/SpriteKit/CMakeLists.txt
+++ b/stdlib/public/SDK/SpriteKit/CMakeLists.txt
@@ -9,7 +9,7 @@ add_swift_library(swiftSpriteKit ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
   TARGET_SDKS OSX IOS IOS_SIMULATOR TVOS TVOS_SIMULATOR WATCHOS WATCHOS_SIMULATOR
   SWIFT_MODULE_DEPENDS_OSX Darwin AppKit CoreData CoreGraphics CoreImage Dispatch Foundation GLKit IOKit ObjectiveC QuartzCore simd XPC # auto-updated
-  SWIFT_MODULE_DEPENDS_IOS Darwin CoreGraphics CoreImage Dispatch Foundation GLKit ObjectiveC QuartzCore simd UIKit # auto-updated
+  SWIFT_MODULE_DEPENDS_IOS Darwin CoreGraphics CoreImage Dispatch Foundation GLKit ObjectiveC os QuartzCore simd UIKit # auto-updated
   SWIFT_MODULE_DEPENDS_TVOS Darwin CoreGraphics CoreImage Dispatch Foundation GLKit ObjectiveC QuartzCore simd UIKit # auto-updated
   SWIFT_MODULE_DEPENDS_WATCHOS Darwin CoreGraphics Dispatch Foundation ObjectiveC simd UIKit # auto-updated
   FRAMEWORK_DEPENDS SpriteKit

--- a/stdlib/public/SDK/UIKit/CMakeLists.txt
+++ b/stdlib/public/SDK/UIKit/CMakeLists.txt
@@ -9,7 +9,7 @@ add_swift_library(swiftUIKit ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVE
   SWIFT_COMPILE_FLAGS "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}"
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
   TARGET_SDKS IOS IOS_SIMULATOR TVOS TVOS_SIMULATOR WATCHOS WATCHOS_SIMULATOR
-  SWIFT_MODULE_DEPENDS_IOS Darwin CoreGraphics CoreImage Dispatch Foundation ObjectiveC QuartzCore # auto-updated
+  SWIFT_MODULE_DEPENDS_IOS Darwin CoreGraphics CoreImage Dispatch Foundation ObjectiveC os QuartzCore # auto-updated
   SWIFT_MODULE_DEPENDS_TVOS Darwin CoreGraphics CoreImage Dispatch Foundation ObjectiveC QuartzCore # auto-updated
   SWIFT_MODULE_DEPENDS_WATCHOS Darwin CoreGraphics Dispatch Foundation ObjectiveC # auto-updated
   SWIFT_COMPILE_FLAGS_WATCHOS -Xfrontend -disable-autolink-framework -Xfrontend CoreText

--- a/stdlib/public/SDK/WatchKit/CMakeLists.txt
+++ b/stdlib/public/SDK/WatchKit/CMakeLists.txt
@@ -7,8 +7,8 @@ add_swift_library(swiftWatchKit ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_
   SWIFT_COMPILE_FLAGS "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}"
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
   TARGET_SDKS IOS IOS_SIMULATOR WATCHOS WATCHOS_SIMULATOR
-  SWIFT_MODULE_DEPENDS_IOS Darwin CoreGraphics CoreImage CoreLocation Dispatch Foundation MapKit ObjectiveC QuartzCore UIKit # auto-updated
-  SWIFT_MODULE_DEPENDS_WATCHOS Darwin CoreGraphics CoreLocation Dispatch Foundation HomeKit MapKit ObjectiveC SceneKit simd UIKit # auto-updated
+  SWIFT_MODULE_DEPENDS_IOS Darwin CoreGraphics CoreImage CoreLocation Dispatch Foundation MapKit ObjectiveC os QuartzCore UIKit # auto-updated
+  SWIFT_MODULE_DEPENDS_WATCHOS Darwin CoreGraphics CoreLocation Dispatch Foundation ObjectiveC SceneKit simd UIKit # auto-updated
   FRAMEWORK_DEPENDS_WEAK WatchKit
   SWIFT_COMPILE_FLAGS_WATCHOS -Xfrontend -disable-autolink-framework -Xfrontend CoreText
 

--- a/stdlib/public/SDK/os/CMakeLists.txt
+++ b/stdlib/public/SDK/os/CMakeLists.txt
@@ -10,11 +10,11 @@ add_swift_library(swiftos ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLA
   SWIFT_COMPILE_FLAGS "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}"
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
   SWIFT_MODULE_DEPENDS_OSX Darwin Dispatch ObjectiveC XPC # auto-updated
-  SWIFT_MODULE_DEPENDS_IOS Darwin ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_IOS Darwin Dispatch ObjectiveC # auto-updated
     Dispatch # required in some configurations but not found by tool
-  SWIFT_MODULE_DEPENDS_TVOS Darwin ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_TVOS Darwin Dispatch ObjectiveC # auto-updated
     Dispatch # required in some configurations but not found by tool
-  SWIFT_MODULE_DEPENDS_WATCHOS Darwin ObjectiveC # auto-updated
+  SWIFT_MODULE_DEPENDS_WATCHOS Darwin Dispatch ObjectiveC # auto-updated
     Dispatch # required in some configurations but not found by tool
 
   DEPLOYMENT_VERSION_OSX ${SWIFTLIB_DEPLOYMENT_VERSION_OS_OSX}

--- a/utils/find-overlay-dependencies.sh
+++ b/utils/find-overlay-dependencies.sh
@@ -56,6 +56,8 @@ SDKS[iphoneos]="arm64"
 SDKS[appletvos]="arm64"
 SDKS[watchos]="armv7k"
 
+SDKS_ORDERED=(macosx iphoneos appletvos watchos)
+
 typeset -A CMAKE_DEPENDS_NAME
 CMAKE_DEPENDS_NAME[macosx]="SWIFT_MODULE_DEPENDS_OSX"
 CMAKE_DEPENDS_NAME[iphoneos]="SWIFT_MODULE_DEPENDS_IOS"
@@ -63,10 +65,11 @@ CMAKE_DEPENDS_NAME[appletvos]="SWIFT_MODULE_DEPENDS_TVOS"
 CMAKE_DEPENDS_NAME[watchos]="SWIFT_MODULE_DEPENDS_WATCHOS"
 
 echo $1
-for sdk in ${(k)SDKS}; do
+for sdk in $SDKS_ORDERED; do
+  sdkfull="${sdk}${SUFFIX}"
   arch=$SDKS[$sdk]
-  printf "%s:\n\t" "$sdk"
-  deps=$(echo "@import $1;" | xcrun -sdk $sdk clang -arch $arch -x objective-c - -M -fmodules 2>/dev/null)
+  printf "%s:\n\t" "$sdkfull"
+  deps=$(echo "@import $1;" | xcrun -sdk "${sdkfull}" clang -arch $arch -x objective-c -F $(xcrun -show-sdk-path -sdk "${sdkfull}")/System/Library/PrivateFrameworks - -M -fmodules 2>/dev/null)
   if [[ $? != 0 ]]; then
     # Clear the cmake file of this unsupported platform and loop
     echo "unsupported"
@@ -85,6 +88,10 @@ for sdk in ${(k)SDKS}; do
         egrep -q "\b$overlay\b") &&
         DEPENDS_ON+=${CUSTOM_NAMED_MODULES[$overlay]-$overlay}
   done
+
+  if [[ $sdk != macosx* ]]; then
+    DEPENDS_ON=("${(@)DEPENDS_ON:#XPC}")
+  fi
   echo "$DEPENDS_ON"
   if [[ $UPDATE_CMAKE == 1 ]]; then
     sed -i "" -E -e "s/^([ \t]*$CMAKE_DEPENDS_NAME[$sdk]).*$/\1 $DEPENDS_ON # auto-updated/" "$CMAKE_PATH"


### PR DESCRIPTION

• Explanation: The overlay dependencies for the new SDKs need updating.
• Scope of Issue: The overlay dependency lists are incomplete and the build breaks on UIKit not having the os overlay compiled yet.
• Origination: SDKs changed.
• Risk: Low
• Reviewed By: Jacob Mizrazi
• Testing: Swift CI

rdar://problem/32029879

