### PR TITLE
[QoI] Improve diagnostics for calling instance methods on type or in static context

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -2810,7 +2810,8 @@ diagnoseUnviableLookupResults(MemberLookupResult &result, Type baseObjTy,
         }
         assert(TypeDC->isTypeContext() && "Expected type decl context!");
 
-        if (TypeDC->getDeclaredTypeOfContext()->isEqual(instanceTy)) {
+        if (TypeDC->getAsNominalTypeOrNominalTypeExtensionContext() ==
+            instanceTy->getAnyNominal()) {
           if (propertyInitializer)
             CS->TC.diagnose(nameLoc, diag::instance_member_in_initializer,
                             memberName);
@@ -4931,6 +4932,115 @@ static bool diagnoseImplicitSelfErrors(Expr *fnExpr, Expr *argExpr,
   return false;
 }
 
+// It is a somewhat common error to try to access an instance method as a
+// curried member on the type, instead of using an instance, e.g. the user
+// wrote:
+//
+//   Foo.doThing(42, b: 19)
+//
+// instead of:
+//
+//   myFoo.doThing(42, b: 19)
+//
+// Check for this situation and handle it gracefully.
+static bool
+diagnoseInstanceMethodAsCurriedMemberOnType(CalleeCandidateInfo &CCI,
+                                            Expr *fnExpr, Expr *argExpr) {
+  for (auto &candidate : CCI.candidates) {
+    auto argTy = candidate.getArgumentType();
+    if (!argTy)
+      return false;
+
+    auto *decl = candidate.getDecl();
+    if (!decl)
+      return false;
+
+    // If this is an exact match at the level 1 of the parameters, but
+    // there is still something wrong with the expression nevertheless
+    // it might be worth while to check if it's instance method as curried
+    // member of type problem.
+    if (CCI.closeness == CC_ExactMatch &&
+        (decl->isInstanceMember() && candidate.level == 1))
+      continue;
+
+    auto params = decomposeParamType(argTy, decl, candidate.level);
+    // If one of the candidates is an instance method with a single parameter
+    // at the level 0, this might be viable situation for calling instance
+    // method as curried member of type problem.
+    if (params.size() != 1 || !decl->isInstanceMember() || candidate.level > 0)
+      return false;
+  }
+
+  auto &TC = CCI.CS->TC;
+
+  if (auto UDE = dyn_cast<UnresolvedDotExpr>(fnExpr)) {
+    auto baseExpr = UDE->getBase();
+    auto baseType = baseExpr->getType();
+    if (auto *MT = baseType->getAs<MetatypeType>()) {
+      auto DC = CCI.CS->DC;
+      auto instanceType = MT->getInstanceType();
+
+      // If the base is an implicit self type reference, and we're in a
+      // an initializer, then the user wrote something like:
+      //
+      //   class Foo { let val = initFn() }
+      // or
+      //   class Bar { func something(x: Int = initFn()) }
+      //
+      // which runs in type context, not instance context.  Produce a tailored
+      // diagnostic since this comes up and is otherwise non-obvious what is
+      // going on.
+      if (baseExpr->isImplicit() && isa<Initializer>(DC)) {
+        auto *TypeDC = DC->getParent();
+        bool propertyInitializer = true;
+        // If the parent context is not a type context, we expect it
+        // to be a defaulted parameter in a function declaration.
+        if (!TypeDC->isTypeContext()) {
+          assert(TypeDC->getContextKind() ==
+                     DeclContextKind::AbstractFunctionDecl &&
+                 "Expected function decl context for initializer!");
+          TypeDC = TypeDC->getParent();
+          propertyInitializer = false;
+        }
+        assert(TypeDC->isTypeContext() && "Expected type decl context!");
+
+        if (TypeDC->getAsNominalTypeOrNominalTypeExtensionContext() ==
+            instanceType->getAnyNominal()) {
+          if (propertyInitializer)
+            TC.diagnose(UDE->getLoc(), diag::instance_member_in_initializer,
+                        UDE->getName());
+          else
+            TC.diagnose(UDE->getLoc(),
+                        diag::instance_member_in_default_parameter,
+                        UDE->getName());
+          return true;
+        }
+      }
+
+      // If this is a situation like this `self.foo(A())()` and self != A
+      // let's say that `self` is not convertible to A.
+      if (auto nominalType = argExpr->getType()->getAs<NominalType>()) {
+        if (!instanceType->isEqual(nominalType)) {
+          TC.diagnose(argExpr->getStartLoc(), diag::types_not_convertible,
+                      false, nominalType, instanceType);
+          return true;
+        }
+      }
+
+      // Otherwise, complain about use of instance value on type.
+      auto diagnostic = isa<TypeExpr>(baseExpr)
+                            ? diag::instance_member_use_on_type
+                            : diag::could_not_use_instance_member_on_type;
+
+      TC.diagnose(UDE->getLoc(), diagnostic, instanceType, UDE->getName())
+          .highlight(baseExpr->getSourceRange());
+      return true;
+    }
+  }
+
+  return false;
+}
+
 /// Emit a class of diagnostics that we only know how to generate when there is
 /// exactly one candidate we know about.  Return true if an error is emitted.
 static bool diagnoseSingleCandidateFailures(CalleeCandidateInfo &CCI,
@@ -4948,69 +5058,6 @@ static bool diagnoseSingleCandidateFailures(CalleeCandidateInfo &CCI,
 
   auto params = decomposeParamType(argTy, candidate.getDecl(), candidate.level);
   auto args = decomposeArgType(argExpr->getType(), argLabels);
-
-  // It is a somewhat common error to try to access an instance method as a
-  // curried member on the type, instead of using an instance, e.g. the user
-  // wrote:
-  //
-  //   Foo.doThing(42, b: 19)
-  //
-  // instead of:
-  //
-  //   myFoo.doThing(42, b: 19)
-  //
-  // Check for this situation and handle it gracefully.
-  if (params.size() == 1 && candidate.getDecl() &&
-      candidate.getDecl()->isInstanceMember() &&
-      candidate.level == 0) {
-    if (auto UDE = dyn_cast<UnresolvedDotExpr>(fnExpr))
-      if (isa<TypeExpr>(UDE->getBase())) {
-        auto baseType = candidate.getArgumentType();
-        auto DC = CCI.CS->DC;
-
-        // If the base is an implicit self type reference, and we're in a
-        // an initializer, then the user wrote something like:
-        //
-        //   class Foo { let val = initFn() }
-        // or
-        //   class Bar { func something(x: Int = initFn()) }
-        //
-        // which runs in type context, not instance context.  Produce a tailored
-        // diagnostic since this comes up and is otherwise non-obvious what is
-        // going on.
-        if (UDE->getBase()->isImplicit() && isa<Initializer>(DC)) {
-          auto *TypeDC = DC->getParent();
-          bool propertyInitializer = true;
-          // If the parent context is not a type context, we expect it
-          // to be a defaulted parameter in a function declaration.
-          if (!TypeDC->isTypeContext()) {
-            assert(TypeDC->getContextKind() ==
-                       DeclContextKind::AbstractFunctionDecl &&
-                   "Expected function decl context for initializer!");
-            TypeDC = TypeDC->getParent();
-            propertyInitializer = false;
-          }
-          assert(TypeDC->isTypeContext() && "Expected type decl context!");
-
-          if (TypeDC->getDeclaredTypeOfContext()->isEqual(baseType)) {
-            if (propertyInitializer)
-              TC.diagnose(UDE->getLoc(), diag::instance_member_in_initializer,
-                          UDE->getName());
-            else
-              TC.diagnose(UDE->getLoc(),
-                          diag::instance_member_in_default_parameter,
-                          UDE->getName());
-            return true;
-          }
-        }
-
-        // Otherwise, complain about use of instance value on type.
-        TC.diagnose(UDE->getLoc(), diag::instance_member_use_on_type,
-                    baseType, UDE->getName())
-          .highlight(UDE->getBase()->getSourceRange());
-        return true;
-      }
-  }
 
   // Check the case where a raw-representable type is constructed from an
   // argument with the same type:
@@ -5351,6 +5398,9 @@ bool FailureDiagnosis::diagnoseParameterErrors(CalleeCandidateInfo &CCI,
 
   // Try to diagnose errors related to the use of implicit self reference.
   if (diagnoseImplicitSelfErrors(fnExpr, argExpr, CCI, argLabels, CS))
+    return true;
+
+  if (diagnoseInstanceMethodAsCurriedMemberOnType(CCI, fnExpr, argExpr))
     return true;
 
   // Do all the stuff that we only have implemented when there is a single

--- a/test/ClangImporter/objc_parse.swift
+++ b/test/ClangImporter/objc_parse.swift
@@ -340,8 +340,8 @@ func testDynamicSelf(_ queen: Bee, wobbler: NSWobbling) {
   // Instance method on a base class with instancetype result, called on the
   // class itself.
   // FIXME: This should be accepted.
-  // FIXME: The error is lousy, too.
-  let baseClass: ObjCParseExtras.Base.Type = ObjCParseExtras.Base.returnMyself() // expected-error{{missing argument for parameter #1 in call}}
+  let baseClass: ObjCParseExtras.Base.Type = ObjCParseExtras.Base.returnMyself()
+  // expected-error@-1 {{instance member 'returnMyself' cannot be used on type 'Base'}}
 }
 
 func testRepeatedProtocolAdoption(_ w: NSWindow) {

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -940,3 +940,29 @@ func ambiguousCall() -> Float {} // expected-note {{found this candidate}}
 func takesClosure(fn: () -> ()) {}
 
 takesClosure() { ambiguousCall() } // expected-error {{ambiguous use of 'ambiguousCall()'}}
+
+// SR-4692: Useless diagnostics calling non-static method
+
+class SR_4692_a {
+  private static func foo(x: Int, y: Bool) {
+    self.bar(x: x)
+    // expected-error@-1 {{instance member 'bar' cannot be used on type 'SR_4692_a'}}
+  }
+
+  private func bar(x: Int) {
+  }
+}
+
+class SR_4692_b {
+  static func a() {
+    self.f(x: 3, y: true)
+    // expected-error@-1 {{instance member 'f' cannot be used on type 'SR_4692_b'}}
+  }
+
+  private func f(a: Int, b: Bool, c: String) {
+    self.f(x: a, y: b)
+  }
+
+  private func f(x: Int, y: Bool) {
+  }
+}

--- a/test/NameBinding/name_lookup.swift
+++ b/test/NameBinding/name_lookup.swift
@@ -12,7 +12,7 @@ class ThisBase1 {
     set {}
   }
 
-  func baseFunc0() {} // expected-note 2 {{'baseFunc0()' declared here}}
+  func baseFunc0() {}
   func baseFunc1(_ a: Int) {}
 
   subscript(i: Int) -> Double {
@@ -58,7 +58,7 @@ class ThisDerived1 : ThisBase1 {
     set {}
   }
 
-  func derivedFunc0() {}  // expected-note {{'derivedFunc0()' declared here}}
+  func derivedFunc0() {}
   func derivedFunc1(_ a: Int) {}
 
   subscript(i: Double) -> Int {
@@ -222,12 +222,12 @@ class ThisDerived1 : ThisBase1 {
   class func staticTestSelf1() {
     self.baseInstanceVar = 42 // expected-error {{member 'baseInstanceVar' cannot be used on type 'ThisDerived1'}}
     self.baseProp = 42 // expected-error {{member 'baseProp' cannot be used on type 'ThisDerived1'}}
-    self.baseFunc0() // expected-error {{missing argument}}
-    self.baseFunc0(ThisBase1())() // expected-error {{'(ThisBase1) -> () -> ()' is not convertible to '(ThisDerived1) -> () -> ()'}}
+    self.baseFunc0() // expected-error {{instance member 'baseFunc0' cannot be used on type 'ThisDerived1'}}
+    self.baseFunc0(ThisBase1())() // expected-error {{'ThisBase1' is not convertible to 'ThisDerived1'}}
     
     self.baseFunc0(ThisDerived1())()
-    self.baseFunc1(42) // expected-error {{cannot convert value of type 'Int' to expected argument type 'ThisBase1'}}
-    self.baseFunc1(ThisBase1())(42) // expected-error {{'(ThisBase1) -> (Int) -> ()' is not convertible to '(ThisDerived1) -> (Int) -> ()'}}
+    self.baseFunc1(42) // expected-error {{instance member 'baseFunc1' cannot be used on type 'ThisDerived1'}}
+    self.baseFunc1(ThisBase1())(42) // expected-error {{'ThisBase1' is not convertible to 'ThisDerived1'}}
     self.baseFunc1(ThisDerived1())(42)
     self[0] = 42.0 // expected-error {{instance member 'subscript' cannot be used on type 'ThisDerived1'}}
     self.baseStaticVar = 42
@@ -235,7 +235,7 @@ class ThisDerived1 : ThisBase1 {
     self.baseStaticFunc0()
 
     self.baseExtProp = 42 // expected-error {{member 'baseExtProp' cannot be used on type 'ThisDerived1'}}
-    self.baseExtFunc0() // expected-error {{missing argument}}
+    self.baseExtFunc0() // expected-error {{instance member 'baseExtFunc0' cannot be used on type 'ThisDerived1'}}
     self.baseExtStaticVar = 42
     self.baseExtStaticProp = 42 // expected-error {{member 'baseExtStaticProp' cannot be used on type 'ThisDerived1'}}
     self.baseExtStaticFunc0()
@@ -252,15 +252,15 @@ class ThisDerived1 : ThisBase1 {
 
     self.derivedInstanceVar = 42 // expected-error {{member 'derivedInstanceVar' cannot be used on type 'ThisDerived1'}}
     self.derivedProp = 42 // expected-error {{member 'derivedProp' cannot be used on type 'ThisDerived1'}}
-    self.derivedFunc0() // expected-error {{missing argument}}
-    self.derivedFunc0(ThisBase1())() // expected-error {{cannot convert value of type 'ThisBase1' to expected argument type 'ThisDerived1'}}
+    self.derivedFunc0() // expected-error {{instance member 'derivedFunc0' cannot be used on type 'ThisDerived1'}}
+    self.derivedFunc0(ThisBase1())() // expected-error {{'ThisBase1' is not convertible to 'ThisDerived1'}}
     self.derivedFunc0(ThisDerived1())()
     self.derivedStaticVar = 42
     self.derivedStaticProp = 42
     self.derivedStaticFunc0()
 
     self.derivedExtProp = 42 // expected-error {{member 'derivedExtProp' cannot be used on type 'ThisDerived1'}}
-    self.derivedExtFunc0() // expected-error {{missing argument}}
+    self.derivedExtFunc0() // expected-error {{instance member 'derivedExtFunc0' cannot be used on type 'ThisDerived1'}}
     self.derivedExtStaticVar = 42
     self.derivedExtStaticProp = 42 // expected-error {{member 'derivedExtStaticProp' cannot be used on type 'ThisDerived1'}}
     self.derivedExtStaticFunc0()
@@ -291,9 +291,9 @@ class ThisDerived1 : ThisBase1 {
   class func staticTestSuper1() {
     super.baseInstanceVar = 42 // expected-error {{member 'baseInstanceVar' cannot be used on type 'ThisBase1'}}
     super.baseProp = 42 // expected-error {{member 'baseProp' cannot be used on type 'ThisBase1'}}
-    super.baseFunc0() // expected-error {{missing argument}}
+    super.baseFunc0() // expected-error {{instance member 'baseFunc0' cannot be used on type 'ThisBase1'}}
     super.baseFunc0(ThisBase1())()
-    super.baseFunc1(42) // expected-error {{cannot convert value of type 'Int' to expected argument type 'ThisBase1'}}
+    super.baseFunc1(42) // expected-error {{instance member 'baseFunc1' cannot be used on type 'ThisBase1'}}
     super.baseFunc1(ThisBase1())(42)
     super[0] = 42.0 // expected-error {{instance member 'subscript' cannot be used on type 'ThisBase1'}}
     super.baseStaticVar = 42
@@ -301,7 +301,7 @@ class ThisDerived1 : ThisBase1 {
     super.baseStaticFunc0()
 
     super.baseExtProp = 42 // expected-error {{member 'baseExtProp' cannot be used on type 'ThisBase1'}}
-    super.baseExtFunc0() // expected-error {{missing argument}}
+    super.baseExtFunc0() // expected-error {{instance member 'baseExtFunc0' cannot be used on type 'ThisBase1'}}
     super.baseExtStaticVar = 42 
     super.baseExtStaticProp = 42 // expected-error {{member 'baseExtStaticProp' cannot be used on type 'ThisBase1'}}
     super.baseExtStaticFunc0()
@@ -349,7 +349,7 @@ extension ThisBase1 {
     set {}
   }
 
-  func baseExtFunc0() {} // expected-note 2 {{'baseExtFunc0()' declared here}}
+  func baseExtFunc0() {}
 
   var baseExtStaticVar: Int // expected-error {{extensions may not contain stored properties}} // expected-note 2 {{did you mean 'baseExtStaticVar'?}}
 
@@ -381,7 +381,7 @@ extension ThisDerived1 {
     set {}
   }
 
-  func derivedExtFunc0() {} // expected-note {{'derivedExtFunc0()' declared here}}
+  func derivedExtFunc0() {}
 
   var derivedExtStaticVar: Int // expected-error {{extensions may not contain stored properties}}
 
@@ -485,8 +485,23 @@ class Test19935319 {
   func getFoo() -> Int {}
 }
 
+class Test19935319G<T> {
+  let i = getFoo()
+  // expected-error@-1 {{cannot use instance member 'getFoo' within property initializer; property initializers run before 'self' is available}}
+  func getFoo() -> Int { return 42 }
+}
+
 // <rdar://problem/27013358> Crash using instance member as default parameter
 class rdar27013358 {
+  let defaultValue = 1
+  func returnTwo() -> Int {
+    return 2
+  }
+  init(defaulted value: Int = defaultValue) {} // expected-error {{cannot use instance member 'defaultValue' as a default parameter}}
+  init(another value: Int = returnTwo()) {} // expected-error {{cannot use instance member 'returnTwo' as a default parameter}}
+}
+
+class rdar27013358G<T> {
   let defaultValue = 1
   func returnTwo() -> Int {
     return 2


### PR DESCRIPTION
Previously situations like `self.foo(...)` wouldn't be considered as viable
for diagnosing the instance method on type calls, because the base wasn't
TypeExpr, which only accounts for e.g. `X.foo`, instead of validating base
expression itself this patch checks if the _type_ of base expression is
Metatype which is less restrictive.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-4692](https://bugs.swift.org/browse/SR-4692).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->