### PR TITLE
Fix nested types in closure context and non-static operator crash

### DIFF
--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -363,6 +363,9 @@ public:
     return ParentAndKind.getPointer();
   }
 
+  /// Returns the semantic parent for purposes of name lookup.
+  DeclContext *getParentForLookup() const;
+
   /// Return true if this is a child of the specified other decl context.
   bool isChildContextOf(const DeclContext *Other) const {
     if (this == Other) return false;

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -406,6 +406,16 @@ Decl *DeclContext::getInnermostDeclarationDeclContext() {
   return nullptr;
 }
 
+DeclContext *DeclContext::getParentForLookup() const {
+  if (isa<ProtocolDecl>(this) || isa<ExtensionDecl>(this)) {
+    // If we are inside a protocol or an extension, skip directly
+    // to the module scope context, without looking at any (invalid)
+    // outer types.
+    return getModuleScopeContext();
+  }
+  return getParent();
+}
+
 ModuleDecl *DeclContext::getParentModule() const {
   const DeclContext *DC = this;
   while (!DC->isModuleContext())

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -857,7 +857,7 @@ UnqualifiedLookup::UnqualifiedLookup(DeclName Name, DeclContext *DC,
           }
         }
 
-        DC = DC->getParent();
+        DC = DC->getParentForLookup();
       }
 
       if (!isCascadingUse.hasValue())

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4733,35 +4733,24 @@ public:
     // Check for static/final/class when we're in a type.
     auto dc = FD->getDeclContext();
     if (dc->isTypeContext()) {
-      // Within a class, operator functions must be 'static' or 'final'.
-      if (auto classDecl = dc->getAsClassOrClassExtensionContext()) {
-        // For a class, we also need the function or class to be 'final'.
-        if (!classDecl->isFinal() && !FD->isFinal() &&
-            FD->getStaticSpelling() != StaticSpellingKind::KeywordStatic) {
-          if (!FD->isStatic()) {
-            TC.diagnose(FD->getLoc(), diag::nonstatic_operator_in_type,
-                        operatorName,
-                        dc->getDeclaredInterfaceType())
-              .fixItInsert(FD->getAttributeInsertionLoc(/*forModifier=*/true),
-                           "static ");
-
-            FD->setStatic();
-          } else {
-            TC.diagnose(FD->getLoc(), diag::nonfinal_operator_in_class,
-                        operatorName, dc->getDeclaredInterfaceType())
-              .fixItInsert(FD->getAttributeInsertionLoc(/*forModifier=*/true),
-                           "final ");
-            FD->getAttrs().add(new (TC.Context) FinalAttr(/*IsImplicit=*/true));
-          }
-        }
-      } else if (!FD->isStatic()) {
-        // Operator functions must be static.
-        TC.diagnose(FD, diag::nonstatic_operator_in_type,
+      if (!FD->isStatic()) {
+        TC.diagnose(FD->getLoc(), diag::nonstatic_operator_in_type,
                     operatorName,
                     dc->getDeclaredInterfaceType())
           .fixItInsert(FD->getAttributeInsertionLoc(/*forModifier=*/true),
                        "static ");
+
         FD->setStatic();
+      } else if (auto classDecl = dc->getAsClassOrClassExtensionContext()) {
+        // For a class, we also need the function or class to be 'final'.
+        if (!classDecl->isFinal() && !FD->isFinal() &&
+            FD->getStaticSpelling() != StaticSpellingKind::KeywordStatic) {
+          TC.diagnose(FD->getLoc(), diag::nonfinal_operator_in_class,
+                      operatorName, dc->getDeclaredInterfaceType())
+            .fixItInsert(FD->getAttributeInsertionLoc(/*forModifier=*/true),
+                         "final ");
+          FD->getAttrs().add(new (TC.Context) FinalAttr(/*IsImplicit=*/true));
+        }
       }
     } else if (!dc->isModuleScopeContext()) {
       TC.diagnose(FD, diag::operator_in_local_scope);

--- a/test/Constraints/tuple.swift
+++ b/test/Constraints/tuple.swift
@@ -213,3 +213,22 @@ var y = 0
 let _ = (x, (y, 0))
 takesRValue((x, (y, 0)))
 takesAny((x, (y, 0)))
+
+// SR-2600 - Closure cannot infer tuple parameter names
+typealias Closure<A, B> = ((a: A, b: B)) -> String
+
+func invoke<A, B>(a: A, b: B, _ closure: Closure<A,B>) {
+  print(closure((a, b)))
+}
+
+invoke(a: 1, b: "B") { $0.b }
+
+invoke(a: 1, b: "B") { $0.1 }
+
+invoke(a: 1, b: "B") { (c: (a: Int, b: String)) in
+  return c.b
+}
+
+invoke(a: 1, b: "B") { c in
+  return c.b
+}

--- a/test/decl/func/operator.swift
+++ b/test/decl/func/operator.swift
@@ -228,7 +228,7 @@ class C0 {
 }
 
 class C1 {
-  final func %%%(lhs: C1, rhs: C1) -> C1 { return lhs }
+  final func %%%(lhs: C1, rhs: C1) -> C1 { return lhs } // expected-error{{operator '%%%' declared in type 'C1' must be 'static'}}{{3-3=static }}
 }
 
 final class C2 {

--- a/test/decl/nested/protocol.swift
+++ b/test/decl/nested/protocol.swift
@@ -7,7 +7,7 @@ struct OuterGeneric<D> {
   protocol InnerProtocol { // expected-error{{protocol 'InnerProtocol' cannot be nested inside another declaration}}
     associatedtype Rooster
     func flip(_ r: Rooster)
-    func flop(_ t: D)
+    func flop(_ t: D) // expected-error{{use of undeclared type 'D'}}
   }
 }
 
@@ -15,7 +15,7 @@ class OuterGenericClass<T> {
   protocol InnerProtocol { // expected-error{{protocol 'InnerProtocol' cannot be nested inside another declaration}}
     associatedtype Rooster
     func flip(_ r: Rooster)
-    func flop(_ t: T)
+    func flop(_ t: T) // expected-error{{use of undeclared type 'T'}}
   }
 }
 
@@ -25,7 +25,7 @@ protocol OuterProtocol {
   // expected-note@-1 {{did you mean 'InnerProtocol'?}}
     associatedtype Rooster
     func flip(_ r: Rooster)
-    func flop(_ h: Hen)
+    func flop(_ h: Hen) // expected-error{{use of undeclared type 'Hen'}}
   }
 }
 

--- a/test/decl/nested/type_in_function.swift
+++ b/test/decl/nested/type_in_function.swift
@@ -3,6 +3,23 @@
 // Generic class locally defined in non-generic function (rdar://problem/20116710)
 func f3() {
   class B<T> {}
+
+  class C : B<Int> {}
+
+  _ = B<Int>()
+  _ = C()
+}
+
+// Type defined inside a closure (rdar://problem/31803589)
+func hasAClosure() {
+  _ = {
+    enum E<T> { case a(T) }
+
+    let _ = E.a("hi")
+    let _ = E<String>.a("hi")
+    let _: E = .a("hi")
+    let _: E<String> = .a("hi")
+  }
 }
 
 protocol Racoon {

--- a/validation-test/IDE/crashers_2/0010-reference-to-self-in-extension-init.swift
+++ b/validation-test/IDE/crashers_2/0010-reference-to-self-in-extension-init.swift
@@ -1,7 +1,0 @@
-// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-// REQUIRES: asserts
-
-extension Integer { 
-#^A^#
-  extension {
-        var : Self   

--- a/validation-test/IDE/crashers_2_fixed/0010-reference-to-self-in-extension-init.swift
+++ b/validation-test/IDE/crashers_2_fixed/0010-reference-to-self-in-extension-init.swift
@@ -1,0 +1,6 @@
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+
+extension Integer { 
+#^A^#
+  extension {
+        var : Self   

--- a/validation-test/compiler_crashers_2_fixed/0094-rdar30689883.swift
+++ b/validation-test/compiler_crashers_2_fixed/0094-rdar30689883.swift
@@ -1,0 +1,52 @@
+// RUN: not %target-swift-frontend %s -emit-ir
+
+public struct Trie<Key: Hashable, Value> {
+
+    internal var root: TrieNode<Key, Value>
+
+    public init() {
+        self.root = TrieNode<Key, Value>()
+    }
+
+    public mutating func removeValue<C: Collection>(forCollection collection: C) -> Value? where C.Iterator.Element == Key {
+        return self.root.removeValue(forIterator: collection.makeIterator())
+    }
+
+    public mutating func updateValue<C: Collection>(_ value: Value, forCollection collection: C) -> Value? where C.Iterator.Element == Key {
+        return self.root.updateValue(value, forIterator: collection.makeIterator())
+    }
+
+    public func value<C: Collection>(forCollection collection: C) -> Value? where C.Iterator.Element == Key {
+        return self.root.value(forIterator: collection.makeIterator())
+    }
+}
+
+internal struct TrieNode<Key: Hashable, Value> {
+
+    internal let children: Dictionary<Key, TrieNode<Key, Value>>
+
+    internal let value: Value?
+
+    internal init(value: Value?=nil) {
+        self.children = Dictionary<Key, TrieNode<Key, Value>>()
+        self.value = value
+    }
+
+    internal mutating func removeValue<I: IteratorProtocol>(forIterator iterator: inout I) -> Value? where I.Element == Key {
+        return nil
+    }
+
+    internal mutating func updateValue<I: IteratorProtocol>(_ value: Value, forIterator iterator: inout I) -> Value? where I.Element == Key {
+        return nil
+    }
+
+    internal func value<I: IteratorProtocol>(forIterator iterator: inout I) -> Value? where I.Element == Key {
+        guard let key = iterator.next() else {
+            return value
+        }
+
+        return self.children[key]?.value(forIterator: iterator)
+    }
+}
+
+

--- a/validation-test/compiler_crashers_fixed/28701-false-should-have-found-context-by-now.swift
+++ b/validation-test/compiler_crashers_fixed/28701-false-should-have-found-context-by-now.swift
@@ -6,9 +6,5 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-protocol P{typealias a
-struct A{{}func a:a
-{
-}
-struct A{extension{var f=a
+// RUN: not %target-swift-frontend %s -emit-ir
+protocol P{class a}class C:P{protocol A:a

--- a/validation-test/compiler_crashers_fixed/28725-gpdecl-getdepth-generictypeparamdecl-invaliddepth-parameter-hasnt-been-validated.swift
+++ b/validation-test/compiler_crashers_fixed/28725-gpdecl-getdepth-generictypeparamdecl-invaliddepth-parameter-hasnt-been-validated.swift
@@ -6,5 +6,5 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-protocol A{protocol A:A{class a{let c=a}typealias a
+// RUN: not %target-swift-frontend %s -emit-ir
+struct B{let f=a}protocol P{}extension P{extension{func&(U=

--- a/validation-test/compiler_crashers_fixed/28727-objectty-haserror-cannot-have-errortype-wrapped-inside-lvaluetype.swift
+++ b/validation-test/compiler_crashers_fixed/28727-objectty-haserror-cannot-have-errortype-wrapped-inside-lvaluetype.swift
@@ -6,5 +6,5 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-protocol P{class a}class C:P{protocol A:a
+// RUN: not %target-swift-frontend %s -emit-ir
+protocol P}extension P{lazy var f={extension{var f=((self

--- a/validation-test/compiler_crashers_fixed/28729-archetype-bad-generic-context-nesting.swift
+++ b/validation-test/compiler_crashers_fixed/28729-archetype-bad-generic-context-nesting.swift
@@ -6,5 +6,8 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-protocol P}extension P{lazy var f={extension{var f=((self
+// RUN: not %target-swift-frontend %s -emit-ir
+protocol P{
+protocol
+P{typealias a{}struct B{extension{protocol P{
+func a:a

--- a/validation-test/compiler_crashers_fixed/28734-conformingreplacementtype-is-substitutabletype-conformingreplacementtype-is-depe.swift
+++ b/validation-test/compiler_crashers_fixed/28734-conformingreplacementtype-is-substitutabletype-conformingreplacementtype-is-depe.swift
@@ -6,8 +6,9 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-protocol P{
-protocol
-P{typealias a{}struct B{extension{protocol P{
-func a:a
+// RUN: not %target-swift-frontend %s -emit-ir
+protocol P{typealias a
+struct A{{}func a:a
+{
+}
+struct A{extension{var f=a

--- a/validation-test/compiler_crashers_fixed/28735-reftype-hastypeparameter-cannot-have-a-dependent-type-here.swift
+++ b/validation-test/compiler_crashers_fixed/28735-reftype-hastypeparameter-cannot-have-a-dependent-type-here.swift
@@ -5,6 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-protocol A{{}struct A{typealias a:Self
-protocol P{extension{lazy var f=A.a
+// REQUIRES: asserts
+// RUN: not %target-swift-frontend %s -emit-ir
+protocol A{protocol A:A{class a{let c=a}typealias a

--- a/validation-test/compiler_crashers_fixed/28741-anonymous-namespace-verifier-walktodeclpost-swift-decl.swift
+++ b/validation-test/compiler_crashers_fixed/28741-anonymous-namespace-verifier-walktodeclpost-swift-decl.swift
@@ -5,6 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-struct B{let f=a}protocol P{}extension P{extension{func&(U=
+// RUN: not %target-swift-frontend %s -emit-ir
+protocol A{{}struct A{typealias a:Self
+protocol P{extension{lazy var f=A.a


### PR DESCRIPTION
- Fixes <rdar://problem/31803589> and <rdar://problem/31469036>.
- Fixes 8 compiler crashers.
- Adds regression tests for <rdar://problem/rdar30689883> and <https://bugs.swift.org/browse/SR-2600> which are already fixed.
rdar://problem/31104529