### PR TITLE
SIL: Kill off uncurryLevel even more

### DIFF
--- a/include/swift/Reflection/TypeRef.h
+++ b/include/swift/Reflection/TypeRef.h
@@ -396,10 +396,6 @@ public:
     FIND_OR_CREATE_TYPEREF(A, ProtocolTypeRef, MangledName);
   }
 
-  bool isAnyObject() const {
-    return MangledName == "s9AnyObject_p";
-  }
-
   bool isError() const {
     return MangledName == "s5Error_p";
   }

--- a/include/swift/Reflection/TypeRefBuilder.h
+++ b/include/swift/Reflection/TypeRefBuilder.h
@@ -312,9 +312,6 @@ public:
                     const TypeRef *Protocol);
 
   const TypeRef *
-  lookupSuperclass(const std::string &MangledTypeName);
-
-  const TypeRef *
   lookupSuperclass(const TypeRef *TR);
 
   /// Load unsubstituted field types for a nominal type.

--- a/include/swift/SIL/SILDeclRef.h
+++ b/include/swift/SIL/SILDeclRef.h
@@ -66,6 +66,8 @@ bool requiresForeignEntryPoint(ValueDecl *vd);
 /// True if the entry point is natively foreign.
 bool requiresForeignToNativeThunk(ValueDecl *vd);
 
+unsigned getNaturalUncurryLevel(ValueDecl *vd);
+
 enum ForDefinition_t : bool {
   NotForDefinition = false,
   ForDefinition = true
@@ -144,8 +146,6 @@ struct SILDeclRef {
   Loc loc;
   /// The Kind of this SILDeclRef.
   Kind kind : 4;
-  /// The uncurry level of this SILDeclRef.
-  unsigned uncurryLevel : 8;
   /// The required resilience expansion of the declaration.
   unsigned Expansion : 1;
   /// True if the SILDeclRef is a curry thunk.
@@ -158,17 +158,8 @@ struct SILDeclRef {
   /// The default argument index for a default argument getter.
   unsigned defaultArgIndex : 10;
   
-  /// A magic value for SILDeclRef constructors to ask for the natural uncurry
-  /// level of the constant.
-  enum : unsigned { ConstructAtNaturalUncurryLevel = ~0U };
-
-  /// A magic value for SILDeclRef constructors to ask for the best
-  /// available resilience expansion of the constant.
-  static constexpr ResilienceExpansion ConstructAtBestResilienceExpansion
-    = /*TODO*/ ResilienceExpansion::Minimal;
-  
   /// Produces a null SILDeclRef.
-  SILDeclRef() : loc(), kind(Kind::Func), uncurryLevel(0), Expansion(0),
+  SILDeclRef() : loc(), kind(Kind::Func), Expansion(0),
                  isCurried(0), isForeign(0), isDirectReference(0),
                  defaultArgIndex(0) {}
   
@@ -176,10 +167,10 @@ struct SILDeclRef {
   explicit SILDeclRef(ValueDecl *decl, Kind kind,
                       ResilienceExpansion expansion
                         = ResilienceExpansion::Minimal,
-                      unsigned uncurryLevel = ConstructAtNaturalUncurryLevel,
+                      bool isCurried = false,
                       bool isForeign = false);
   
-  /// Produces the 'natural' SILDeclRef for the given ValueDecl or
+  /// Produces a SILDeclRef for the given ValueDecl or
   /// AbstractClosureExpr:
   /// - If 'loc' is a func or closure, this returns a Func SILDeclRef.
   /// - If 'loc' is a ConstructorDecl, this returns the Allocator SILDeclRef
@@ -190,13 +181,15 @@ struct SILDeclRef {
   ///   for the containing ClassDecl.
   /// - If 'loc' is a global VarDecl, this returns its GlobalAccessor
   ///   SILDeclRef.
-  /// If the uncurry level is unspecified or specified as NaturalUncurryLevel,
-  /// then the SILDeclRef for the natural uncurry level of the definition is
-  /// used.
+  ///
+  /// If 'isCurried' is true, the loc must be a method or enum element;
+  /// the SILDeclRef will then refer to a curry thunk with type
+  /// (Self) -> (Args...) -> Result, rather than a direct reference to
+  /// the actual method whose lowered type is (Args..., Self) -> Result.
   explicit SILDeclRef(Loc loc,
                       ResilienceExpansion expansion
                         = ResilienceExpansion::Minimal,
-                      unsigned uncurryLevel = ConstructAtNaturalUncurryLevel,
+                      bool isCurried = false,
                       bool isForeign = false);
 
   /// Produce a SIL constant for a default argument generator.
@@ -284,7 +277,7 @@ struct SILDeclRef {
   llvm::hash_code getHashCode() const {
     return llvm::hash_combine(loc.getOpaqueValue(),
                               static_cast<int>(kind),
-                              Expansion, uncurryLevel,
+                              Expansion, isCurried,
                               isForeign, isDirectReference,
                               defaultArgIndex);
   }
@@ -293,7 +286,7 @@ struct SILDeclRef {
     return loc.getOpaqueValue() == rhs.loc.getOpaqueValue()
       && kind == rhs.kind
       && Expansion == rhs.Expansion
-      && uncurryLevel == rhs.uncurryLevel
+      && isCurried == rhs.isCurried
       && isForeign == rhs.isForeign
       && isDirectReference == rhs.isDirectReference
       && defaultArgIndex == rhs.defaultArgIndex;
@@ -305,26 +298,28 @@ struct SILDeclRef {
   void print(llvm::raw_ostream &os) const;
   void dump() const;
 
+  unsigned getUncurryLevel() const;
+
   ResilienceExpansion getResilienceExpansion() const {
     return ResilienceExpansion(Expansion);
   }
   
   // Returns the SILDeclRef for an entity at a shallower uncurry level.
-  SILDeclRef atUncurryLevel(unsigned level) const {
-    assert(level <= uncurryLevel && "can't safely go to deeper uncurry level");
-    bool willBeCurried = isCurried || level < uncurryLevel;
+  SILDeclRef asCurried(bool curried = true) const {
+    assert(!isCurried && "can't safely go to deeper uncurry level");
     // Curry thunks are never foreign.
-    bool willBeForeign = isForeign && !willBeCurried;
+    bool willBeForeign = isForeign && !curried;
     bool willBeDirect = isDirectReference;
-    return SILDeclRef(loc.getOpaqueValue(), kind, Expansion, level,
-                      willBeCurried, willBeDirect, willBeForeign,
+    return SILDeclRef(loc.getOpaqueValue(), kind, Expansion,
+                      curried, willBeDirect, willBeForeign,
                       defaultArgIndex);
   }
   
   /// Returns the foreign (or native) entry point corresponding to the same
   /// decl.
   SILDeclRef asForeign(bool foreign = true) const {
-    return SILDeclRef(loc.getOpaqueValue(), kind, Expansion, uncurryLevel,
+    assert(!isCurried);
+    return SILDeclRef(loc.getOpaqueValue(), kind, Expansion,
                       isCurried, isDirectReference, foreign, defaultArgIndex);
   }
   
@@ -379,13 +374,13 @@ private:
   explicit SILDeclRef(void *opaqueLoc,
                       Kind kind,
                       unsigned rawExpansion,
-                      unsigned uncurryLevel,
                       bool isCurried,
                       bool isDirectReference,
                       bool isForeign,
                       unsigned defaultArgIndex)
     : loc(Loc::getFromOpaqueValue(opaqueLoc)),
-      kind(kind), uncurryLevel(uncurryLevel), Expansion(rawExpansion),
+      kind(kind),
+      Expansion(rawExpansion),
       isCurried(isCurried),
       isForeign(isForeign), isDirectReference(isDirectReference),
       defaultArgIndex(defaultArgIndex)
@@ -413,18 +408,18 @@ template<> struct DenseMapInfo<swift::SILDeclRef> {
 
   static SILDeclRef getEmptyKey() {
     return SILDeclRef(PointerInfo::getEmptyKey(), Kind::Func,
-                      0, 0, false, false, false, 0);
+                      0, false, false, false, 0);
   }
   static SILDeclRef getTombstoneKey() {
     return SILDeclRef(PointerInfo::getTombstoneKey(), Kind::Func,
-                      0, 0, false, false, false, 0);
+                      0, false, false, false, 0);
   }
   static unsigned getHashValue(swift::SILDeclRef Val) {
     unsigned h1 = PointerInfo::getHashValue(Val.loc.getOpaqueValue());
     unsigned h2 = UnsignedInfo::getHashValue(unsigned(Val.kind));
     unsigned h3 = (Val.kind == Kind::DefaultArgGenerator)
                     ? UnsignedInfo::getHashValue(Val.defaultArgIndex)
-                    : UnsignedInfo::getHashValue(Val.uncurryLevel);
+                    : UnsignedInfo::getHashValue(Val.isCurried);
     unsigned h4 = UnsignedInfo::getHashValue(Val.isForeign);
     unsigned h5 = UnsignedInfo::getHashValue(Val.isDirectReference);
     return h1 ^ (h2 << 4) ^ (h3 << 9) ^ (h4 << 7) ^ (h5 << 11);

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -798,10 +798,7 @@ static bool getInstanceSizeByMethod(IRGenFunction &IGF,
   }
 
   // Check whether the SIL module defines it.  (We need a type for it.)
-  SILDeclRef fnRef(fn, SILDeclRef::Kind::Func,
-                   ResilienceExpansion::Minimal,
-                   /*uncurryLevel*/ 1,
-                   /*foreign*/ false);
+  SILDeclRef fnRef(fn, SILDeclRef::Kind::Func);
   SILFunction *silFn = IGF.getSILModule().lookUpFunction(fnRef);
   if (!silFn)
     return false;
@@ -1475,10 +1472,8 @@ namespace {
 
       // We don't have a destructor body, so hunt for the SIL function
       // for it.
-      SILDeclRef dtorRef(destructor, SILDeclRef::Kind::Deallocator,
-                         ResilienceExpansion::Minimal,
-                         SILDeclRef::ConstructAtNaturalUncurryLevel,
-                         /*isForeign=*/true);
+      auto dtorRef = SILDeclRef(destructor, SILDeclRef::Kind::Deallocator)
+        .asForeign();
       if (auto silFn = IGM.getSILModule().lookUpFunction(dtorRef))
         return silFn->isDefinition();
 

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -2811,12 +2811,11 @@ Optional<llvm::Function*> IRGenModule::getAddrOfIVarInitDestroy(
                             bool isDestroyer,
                             bool isForeign,
                             ForDefinition_t forDefinition) {
-  SILDeclRef silRef(cd, 
-                    isDestroyer? SILDeclRef::Kind::IVarDestroyer
-                               : SILDeclRef::Kind::IVarInitializer, 
-                    ResilienceExpansion::Minimal,
-                    SILDeclRef::ConstructAtNaturalUncurryLevel, 
-                    isForeign);
+  auto silRef = SILDeclRef(cd,
+                           isDestroyer
+                           ? SILDeclRef::Kind::IVarDestroyer
+                           : SILDeclRef::Kind::IVarInitializer)
+    .asForeign(isForeign);
 
   // Find the SILFunction for the ivar initializer or destroyer.
   if (auto silFn = getSILModule().lookUpFunction(silRef)) {

--- a/lib/IRGen/GenObjC.cpp
+++ b/lib/IRGen/GenObjC.cpp
@@ -1004,13 +1004,8 @@ static llvm::Constant *getObjCGetterPointer(IRGenModule &IGM,
   if (isa<ProtocolDecl>(property->getDeclContext()))
     return llvm::ConstantPointerNull::get(IGM.Int8PtrTy);
 
-  // FIXME: Explosion level
-  ResilienceExpansion expansion = ResilienceExpansion::Minimal;
-
-  SILDeclRef getter = SILDeclRef(property->getGetter(), SILDeclRef::Kind::Func,
-                                 expansion,
-                                 SILDeclRef::ConstructAtNaturalUncurryLevel,
-                                 /*foreign*/ true);
+  SILDeclRef getter = SILDeclRef(property->getGetter(), SILDeclRef::Kind::Func)
+    .asForeign();
 
   return findSwiftAsObjCThunk(IGM, getter);
 }
@@ -1028,11 +1023,8 @@ static llvm::Constant *getObjCSetterPointer(IRGenModule &IGM,
   assert(property->isSettable(property->getDeclContext()) &&
          "property is not settable?!");
   
-  ResilienceExpansion expansion = ResilienceExpansion::Minimal;
-  SILDeclRef setter = SILDeclRef(property->getSetter(), SILDeclRef::Kind::Func,
-                                 expansion,
-                                 SILDeclRef::ConstructAtNaturalUncurryLevel,
-                                 /*foreign*/ true);
+  SILDeclRef setter = SILDeclRef(property->getSetter(), SILDeclRef::Kind::Func)
+    .asForeign();
 
   return findSwiftAsObjCThunk(IGM, setter);
 }
@@ -1047,11 +1039,8 @@ static llvm::Constant *getObjCMethodPointer(IRGenModule &IGM,
   if (isa<ProtocolDecl>(method->getDeclContext()))
     return llvm::ConstantPointerNull::get(IGM.Int8PtrTy);
 
-  ResilienceExpansion expansion = ResilienceExpansion::Minimal;
-  SILDeclRef declRef = SILDeclRef(method, SILDeclRef::Kind::Func,
-                                  expansion,
-                                  SILDeclRef::ConstructAtNaturalUncurryLevel,
-                                  /*foreign*/ true);
+  SILDeclRef declRef = SILDeclRef(method, SILDeclRef::Kind::Func)
+    .asForeign();
 
   return findSwiftAsObjCThunk(IGM, declRef);
 }
@@ -1066,11 +1055,8 @@ static llvm::Constant *getObjCMethodPointer(IRGenModule &IGM,
   if (isa<ProtocolDecl>(constructor->getDeclContext()))
     return llvm::ConstantPointerNull::get(IGM.Int8PtrTy);
 
-  ResilienceExpansion expansion = ResilienceExpansion::Minimal;
-  SILDeclRef declRef = SILDeclRef(constructor, SILDeclRef::Kind::Initializer,
-                                  expansion,
-                                  SILDeclRef::ConstructAtNaturalUncurryLevel,
-                                  /*foreign*/ true);
+  SILDeclRef declRef = SILDeclRef(constructor, SILDeclRef::Kind::Initializer)
+    .asForeign();
 
   return findSwiftAsObjCThunk(IGM, declRef);
 }
@@ -1081,11 +1067,8 @@ static llvm::Constant *getObjCMethodPointer(IRGenModule &IGM,
 /// Returns a value of type i8*.
 static llvm::Constant *getObjCMethodPointer(IRGenModule &IGM,
                                             DestructorDecl *destructor) {
-  ResilienceExpansion expansion = ResilienceExpansion::Minimal;
-  SILDeclRef declRef = SILDeclRef(destructor, SILDeclRef::Kind::Deallocator,
-                                  expansion,
-                                  SILDeclRef::ConstructAtNaturalUncurryLevel,
-                                  /*foreign*/ true);
+  SILDeclRef declRef = SILDeclRef(destructor, SILDeclRef::Kind::Deallocator)
+    .asForeign();
 
   return findSwiftAsObjCThunk(IGM, declRef);
 }

--- a/lib/Parse/ParseSIL.cpp
+++ b/lib/Parse/ParseSIL.cpp
@@ -1185,7 +1185,9 @@ bool SILParser::parseSILDeclRef(SILDeclRef &Result,
 
   if (!P.consumeIf(tok::sil_exclamation)) {
     // Construct SILDeclRef.
-    Result = SILDeclRef(VD, Kind, expansion, uncurryLevel, IsObjC);
+    Result = SILDeclRef(VD, Kind, expansion, /*isCurried=*/false, IsObjC);
+    if (uncurryLevel < Result.getUncurryLevel())
+      Result = Result.asCurried();
     return false;
   }
 
@@ -1274,7 +1276,9 @@ bool SILParser::parseSILDeclRef(SILDeclRef &Result,
   } while (P.consumeIf(tok::period));
 
   // Construct SILDeclRef.
-  Result = SILDeclRef(VD, Kind, expansion, uncurryLevel, IsObjC);
+  Result = SILDeclRef(VD, Kind, expansion, /*isCurried=*/false, IsObjC);
+  if (uncurryLevel < Result.getUncurryLevel())
+    Result = Result.asCurried();
   return false;
 }
 

--- a/lib/SIL/SILDeclRef.cpp
+++ b/lib/SIL/SILDeclRef.cpp
@@ -227,14 +227,7 @@ static bool hasLoweredLocalCaptures(AnyFunctionRef AFR,
 
 static unsigned getFuncNaturalUncurryLevel(AnyFunctionRef AFR) {
   assert(AFR.getParameterLists().size() >= 1 && "no arguments for func?!");
-  unsigned Level = AFR.getParameterLists().size() - 1;
-  // Functions with captures have an extra uncurry level for the capture
-  // context.
-  llvm::DenseSet<AnyFunctionRef> visited;
-  visited.insert(AFR);
-  if (hasLoweredLocalCaptures(AFR, visited))
-    Level += 1;
-  return Level;
+  return AFR.getParameterLists().size() - 1;
 }
 
 unsigned swift::getNaturalUncurryLevel(ValueDecl *vd) {

--- a/lib/SIL/SILDeclRef.cpp
+++ b/lib/SIL/SILDeclRef.cpp
@@ -237,84 +237,52 @@ static unsigned getFuncNaturalUncurryLevel(AnyFunctionRef AFR) {
   return Level;
 }
 
-SILDeclRef::SILDeclRef(ValueDecl *vd, SILDeclRef::Kind kind,
-                       ResilienceExpansion expansion,
-                       unsigned atUncurryLevel, bool isForeign)
-  : loc(vd), kind(kind), Expansion(unsigned(expansion)),
-    isForeign(isForeign), isDirectReference(0), defaultArgIndex(0)
-{
-  unsigned naturalUncurryLevel;
-
-  // FIXME: restructure to use a "switch".
+unsigned swift::getNaturalUncurryLevel(ValueDecl *vd) {
   if (auto *func = dyn_cast<FuncDecl>(vd)) {
-    assert(kind == Kind::Func &&
-           "can only create a Func SILDeclRef for a func decl");
-    naturalUncurryLevel = getFuncNaturalUncurryLevel(func);
+    return getFuncNaturalUncurryLevel(func);
   } else if (isa<ConstructorDecl>(vd)) {
-    assert((kind == Kind::Allocator || kind == Kind::Initializer)
-           && "can only create Allocator or Initializer SILDeclRef for ctor");
-    naturalUncurryLevel = 1;
+    return 1;
   } else if (auto *ed = dyn_cast<EnumElementDecl>(vd)) {
-    assert(kind == Kind::EnumElement
-           && "can only create EnumElement SILDeclRef for enum element");
-    naturalUncurryLevel = ed->getArgumentInterfaceType() ? 1 : 0;
+    return ed->getArgumentInterfaceType() ? 1 : 0;
   } else if (isa<DestructorDecl>(vd)) {
-    assert((kind == Kind::Destroyer || kind == Kind::Deallocator)
-           && "can only create destroyer/deallocator SILDeclRef for dtor");
-    naturalUncurryLevel = 0;
+    return 0;
   } else if (isa<ClassDecl>(vd)) {
-    assert((kind == Kind::IVarInitializer || kind == Kind::IVarDestroyer) &&
-           "can only create ivar initializer/destroyer SILDeclRef for class");
-    naturalUncurryLevel = 1;
-  } else if (auto *var = dyn_cast<VarDecl>(vd)) {
-    assert((kind == Kind::GlobalAccessor ||
-            kind == Kind::GlobalGetter ||
-            kind == Kind::StoredPropertyInitializer) &&
-           "can only create GlobalAccessor, GlobalGetter or "
-           "StoredPropertyInitializer SILDeclRef for var");
-
-    naturalUncurryLevel = 0;
-    assert(!var->getDeclContext()->isLocalContext() &&
-           "can't reference local var as global var");
-    assert(var->hasStorage() && "can't reference computed var as global var");
-    (void)var;
+    return 1;
+  } else if (isa<VarDecl>(vd)) {
+    return 0;
   } else {
     llvm_unreachable("Unhandled ValueDecl for SILDeclRef");
   }
-  
-  assert((atUncurryLevel == ConstructAtNaturalUncurryLevel
-          || atUncurryLevel <= naturalUncurryLevel)
-         && "can't emit SILDeclRef below natural uncurry level");
-  uncurryLevel = atUncurryLevel == ConstructAtNaturalUncurryLevel
-    ? naturalUncurryLevel
-    : atUncurryLevel;
-  isCurried = uncurryLevel != naturalUncurryLevel;
 }
+
+SILDeclRef::SILDeclRef(ValueDecl *vd, SILDeclRef::Kind kind,
+                       ResilienceExpansion expansion,
+                       bool isCurried, bool isForeign)
+  : loc(vd), kind(kind), Expansion(unsigned(expansion)),
+    isCurried(isCurried), isForeign(isForeign),
+    isDirectReference(0), defaultArgIndex(0)
+{}
 
 SILDeclRef::SILDeclRef(SILDeclRef::Loc baseLoc,
                        ResilienceExpansion expansion,
-                       unsigned atUncurryLevel, bool asForeign) 
- : isDirectReference(0), defaultArgIndex(0)
+                       bool isCurried, bool asForeign) 
+  : isCurried(isCurried), isDirectReference(0), defaultArgIndex(0)
 {
-  unsigned naturalUncurryLevel;
   if (auto *vd = baseLoc.dyn_cast<ValueDecl*>()) {
     if (auto *fd = dyn_cast<FuncDecl>(vd)) {
       // Map FuncDecls directly to Func SILDeclRefs.
       loc = fd;
       kind = Kind::Func;
-      naturalUncurryLevel = getFuncNaturalUncurryLevel(fd);
     }
     // Map ConstructorDecls to the Allocator SILDeclRef of the constructor.
     else if (auto *cd = dyn_cast<ConstructorDecl>(vd)) {
       loc = cd;
       kind = Kind::Allocator;
-      naturalUncurryLevel = 1;
     }
     // Map EnumElementDecls to the EnumElement SILDeclRef of the element.
     else if (auto *ed = dyn_cast<EnumElementDecl>(vd)) {
       loc = ed;
       kind = Kind::EnumElement;
-      naturalUncurryLevel = ed->getArgumentInterfaceType() ? 1 : 0;
     }
     // VarDecl constants require an explicit kind.
     else if (isa<VarDecl>(vd)) {
@@ -324,7 +292,6 @@ SILDeclRef::SILDeclRef(SILDeclRef::Loc baseLoc,
     else if (auto dtor = dyn_cast<DestructorDecl>(vd)) {
       loc = dtor;
       kind = Kind::Deallocator;
-      naturalUncurryLevel = 0;
     }
     else {
       llvm_unreachable("invalid loc decl for SILDeclRef!");
@@ -334,21 +301,11 @@ SILDeclRef::SILDeclRef(SILDeclRef::Loc baseLoc,
     kind = Kind::Func;
     assert(ACE->getParameterLists().size() >= 1 &&
            "no param patterns for function?!");
-    naturalUncurryLevel = getFuncNaturalUncurryLevel(ACE);
   } else {
     llvm_unreachable("impossible SILDeclRef loc");
   }
 
-  // Set the uncurry level.
-  assert((atUncurryLevel == ConstructAtNaturalUncurryLevel
-          || atUncurryLevel <= naturalUncurryLevel)
-         && "can't emit SILDeclRef below natural uncurry level");
-  uncurryLevel = atUncurryLevel == ConstructAtNaturalUncurryLevel
-    ? naturalUncurryLevel
-    : atUncurryLevel;
   Expansion = (unsigned) expansion;
-  
-  isCurried = uncurryLevel != naturalUncurryLevel;  
   isForeign = asForeign;
 }
 
@@ -794,7 +751,7 @@ SILDeclRef SILDeclRef::getOverridden() const {
   if (!overridden)
     return SILDeclRef();
 
-  return SILDeclRef(overridden, kind, getResilienceExpansion(), uncurryLevel);
+  return SILDeclRef(overridden, kind, getResilienceExpansion(), isCurried);
 }
 
 SILDeclRef SILDeclRef::getNextOverriddenVTableEntry() const {
@@ -877,4 +834,14 @@ SubclassScope SILDeclRef::getSubclassScope() const {
   }
 
   llvm_unreachable("Unhandled Accessibility in switch.");
+}
+
+unsigned SILDeclRef::getUncurryLevel() const {
+  if (isCurried)
+    return 0;
+  if (!hasDecl())
+    return getFuncNaturalUncurryLevel(*getAnyFunctionRef());
+  if (kind == Kind::DefaultArgGenerator)
+    return 0;
+  return getNaturalUncurryLevel(getDecl());
 }

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -1640,9 +1640,10 @@ getUncachedSILFunctionTypeForConstant(SILModule &M,
 CanSILFunctionType TypeConverter::
 getUncachedSILFunctionTypeForConstant(SILDeclRef constant,
                                       CanAnyFunctionType origInterfaceType) {
-  auto origLoweredInterfaceType = getLoweredASTFunctionType(origInterfaceType,
-                                                            constant.uncurryLevel,
-                                                            constant);
+  auto origLoweredInterfaceType =
+    getLoweredASTFunctionType(origInterfaceType,
+                              constant.getUncurryLevel(),
+                              constant);
   return ::getUncachedSILFunctionTypeForConstant(M, constant,
                                                  origLoweredInterfaceType);
 }
@@ -1729,7 +1730,8 @@ SILConstantInfo TypeConverter::getConstantInfo(SILDeclRef constant) {
   // The lowered type is the formal type, but uncurried and with
   // parameters automatically turned into their bridged equivalents.
   auto loweredInterfaceType =
-    getLoweredASTFunctionType(formalInterfaceType, constant.uncurryLevel,
+    getLoweredASTFunctionType(formalInterfaceType,
+                              constant.getUncurryLevel(),
                               constant);
 
   // The SIL type encodes conventions according to the original type.
@@ -1927,7 +1929,7 @@ SILConstantInfo TypeConverter::getConstantOverrideInfo(SILDeclRef derived,
   // Lower the formal AST type.
   auto overrideLoweredInterfaceTy = getLoweredASTFunctionType(
       cast<AnyFunctionType>(overrideInterfaceTy->getCanonicalType()),
-      derived.uncurryLevel, derived);
+      derived.getUncurryLevel(), derived);
 
   if (!checkASTTypeForABIDifferences(derivedInfo.LoweredInterfaceType,
                                      overrideLoweredInterfaceTy)) {

--- a/lib/SIL/SILInstructions.cpp
+++ b/lib/SIL/SILInstructions.cpp
@@ -2106,7 +2106,7 @@ void KeyPathPattern::Profile(llvm::FoldingSetNodeID &ID,
         auto declRef = id.getDeclRef();
         ID.AddPointer(declRef.loc.getOpaqueValue());
         ID.AddInteger((unsigned)declRef.kind);
-        ID.AddInteger(declRef.uncurryLevel);
+        ID.AddInteger(declRef.isCurried);
         ID.AddBoolean(declRef.Expansion);
         ID.AddBoolean(declRef.isCurried);
         ID.AddBoolean(declRef.isForeign);

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -330,6 +330,8 @@ void SILDeclRef::print(raw_ostream &OS) const {
     OS << "!propertyinit";
     break;
   }
+
+  auto uncurryLevel = getUncurryLevel();
   if (uncurryLevel != 0)
     OS << (isDot ? '.' : '!')  << uncurryLevel;
 

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -1876,38 +1876,15 @@ TypeConverter::getFunctionInterfaceTypeWithCaptures(CanAnyFunctionType funcType,
   auto innerExtInfo = AnyFunctionType::ExtInfo(FunctionType::Representation::Thin,
                                                funcType->throws());
 
-  // If we don't have any local captures (including function captures),
-  // there's no context to apply.
-  if (!hasLoweredLocalCaptures(theClosure)) {
-    if (!genericSig)
-      return CanFunctionType::get(funcType.getInput(),
-                                  funcType.getResult(),
-                                  innerExtInfo);
+  if (!genericSig)
+    return CanFunctionType::get(funcType.getInput(),
+                                funcType.getResult(),
+                                innerExtInfo);
     
-    return CanGenericFunctionType::get(genericSig,
-                                       funcType.getInput(),
-                                       funcType.getResult(),
-                                       innerExtInfo);
-  }
-
-  // Strip the generic signature off the inner type; we will add it to the
-  // outer type with captures.
-  funcType = CanFunctionType::get(funcType.getInput(),
-                                  funcType.getResult(),
-                                  innerExtInfo);
-
-  // Add an extra empty tuple level to represent the captures. We'll append the
-  // lowered capture types here.
-  auto extInfo = AnyFunctionType::ExtInfo(FunctionType::Representation::Thin,
-                                          /*throws*/ false);
-
-  if (genericSig) {
-    return CanGenericFunctionType::get(genericSig,
-                                       Context.TheEmptyTupleType, funcType,
-                                       extInfo);
-  }
-  
-  return CanFunctionType::get(Context.TheEmptyTupleType, funcType, extInfo);
+  return CanGenericFunctionType::get(genericSig,
+                                     funcType.getInput(),
+                                     funcType.getResult(),
+                                     innerExtInfo);
 }
 
 CanAnyFunctionType TypeConverter::makeConstantInterfaceType(SILDeclRef c) {

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -852,10 +852,8 @@ void SILGenModule::emitObjCAllocatorDestructor(ClassDecl *cd,
 
   // Emit the ivar initializer, if needed.
   if (requiresIVarInitialization(*this, cd)) {
-    SILDeclRef ivarInitializer(cd, SILDeclRef::Kind::IVarInitializer,
-                               SILDeclRef::ConstructAtBestResilienceExpansion,
-                               SILDeclRef::ConstructAtNaturalUncurryLevel,
-                               /*isForeign=*/true);
+    auto ivarInitializer = SILDeclRef(cd, SILDeclRef::Kind::IVarInitializer)
+      .asForeign();
     SILFunction *f = getFunction(ivarInitializer, ForDefinition);
     preEmitFunction(ivarInitializer, dd, f, dd);
     PrettyStackTraceSILFunction X("silgen emitDestructor ivar initializer", f);
@@ -865,10 +863,8 @@ void SILGenModule::emitObjCAllocatorDestructor(ClassDecl *cd,
 
   // Emit the ivar destroyer, if needed.
   if (hasNonTrivialIVars(cd)) {
-    SILDeclRef ivarDestroyer(cd, SILDeclRef::Kind::IVarDestroyer,
-                             SILDeclRef::ConstructAtBestResilienceExpansion,
-                             SILDeclRef::ConstructAtNaturalUncurryLevel,
-                             /*isForeign=*/true);
+    auto ivarDestroyer = SILDeclRef(cd, SILDeclRef::Kind::IVarDestroyer)
+      .asForeign();
     SILFunction *f = getFunction(ivarDestroyer, ForDefinition);
     preEmitFunction(ivarDestroyer, dd, f, dd);
     PrettyStackTraceSILFunction X("silgen emitDestructor ivar destroyer", f);
@@ -882,10 +878,7 @@ void SILGenModule::emitDestructor(ClassDecl *cd, DestructorDecl *dd) {
   
   // Emit the ivar destroyer, if needed.
   if (requiresIVarDestroyer(cd)) {
-    SILDeclRef ivarDestroyer(cd, SILDeclRef::Kind::IVarDestroyer,
-                             SILDeclRef::ConstructAtBestResilienceExpansion,
-                             SILDeclRef::ConstructAtNaturalUncurryLevel,
-                             /*isForeign=*/false);
+    SILDeclRef ivarDestroyer(cd, SILDeclRef::Kind::IVarDestroyer);
     SILFunction *f = getFunction(ivarDestroyer, ForDefinition);
     preEmitFunction(ivarDestroyer, dd, f, dd);
     PrettyStackTraceSILFunction X("silgen emitDestructor ivar destroyer", f);
@@ -1018,10 +1011,7 @@ void SILGenModule::emitDefaultArgGenerators(SILDeclRef::Loc decl,
 }
 
 void SILGenModule::emitObjCMethodThunk(FuncDecl *method) {
-  SILDeclRef thunk(method,
-                   SILDeclRef::ConstructAtBestResilienceExpansion,
-                   SILDeclRef::ConstructAtNaturalUncurryLevel,
-                   /*isObjC*/ true);
+  auto thunk = SILDeclRef(method).asForeign();
 
   // Don't emit the thunk if it already exists.
   if (hasFunction(thunk))
@@ -1043,10 +1033,8 @@ void SILGenModule::emitObjCPropertyMethodThunks(AbstractStorageDecl *prop) {
   if (!prop->getGetter() || !requiresObjCMethodEntryPoint(prop->getGetter()))
     return;
 
-  SILDeclRef getter(prop->getGetter(), SILDeclRef::Kind::Func,
-                    SILDeclRef::ConstructAtBestResilienceExpansion,
-                    SILDeclRef::ConstructAtNaturalUncurryLevel,
-                    /*isObjC*/ true);
+  auto getter = SILDeclRef(prop->getGetter(), SILDeclRef::Kind::Func)
+    .asForeign();
 
   // Don't emit the thunks if they already exist.
   if (hasFunction(getter))
@@ -1070,10 +1058,8 @@ void SILGenModule::emitObjCPropertyMethodThunks(AbstractStorageDecl *prop) {
     return;
 
   // FIXME: Add proper location.
-  SILDeclRef setter(prop->getSetter(), SILDeclRef::Kind::Func,
-                    SILDeclRef::ConstructAtBestResilienceExpansion,
-                    SILDeclRef::ConstructAtNaturalUncurryLevel,
-                    /*isObjC*/ true);
+  auto setter = SILDeclRef(prop->getSetter(), SILDeclRef::Kind::Func)
+    .asForeign();
 
   SILFunction *f = getFunction(setter, ForDefinition);
   preEmitFunction(setter, prop, f, ThunkBodyLoc);
@@ -1085,11 +1071,8 @@ void SILGenModule::emitObjCPropertyMethodThunks(AbstractStorageDecl *prop) {
 }
 
 void SILGenModule::emitObjCConstructorThunk(ConstructorDecl *constructor) {
-  SILDeclRef thunk(constructor,
-                   SILDeclRef::Kind::Initializer,
-                   SILDeclRef::ConstructAtBestResilienceExpansion,
-                   SILDeclRef::ConstructAtNaturalUncurryLevel,
-                   /*isObjC*/ true);
+  auto thunk = SILDeclRef(constructor, SILDeclRef::Kind::Initializer)
+    .asForeign();
 
   // Don't emit the thunk if it already exists.
   if (hasFunction(thunk))
@@ -1107,11 +1090,8 @@ void SILGenModule::emitObjCConstructorThunk(ConstructorDecl *constructor) {
 }
 
 void SILGenModule::emitObjCDestructorThunk(DestructorDecl *destructor) {
-  SILDeclRef thunk(destructor,
-                   SILDeclRef::Kind::Deallocator,
-                   SILDeclRef::ConstructAtBestResilienceExpansion,
-                   SILDeclRef::ConstructAtNaturalUncurryLevel,
-                   /*isObjC*/ true);
+  auto thunk = SILDeclRef(destructor, SILDeclRef::Kind::Deallocator)
+    .asForeign();
 
   // Don't emit the thunk if it already exists.
   if (hasFunction(thunk))

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -273,9 +273,7 @@ public:
                                 ArrayRef<ParameterList*> paramLists);
 
   /// Emits the curry thunk between two uncurry levels of a function.
-  void emitCurryThunk(ValueDecl *fd,
-                      SILDeclRef entryPoint,
-                      SILDeclRef nextEntryPoint);
+  void emitCurryThunk(SILDeclRef thunk);
   
   /// Emits a thunk from a foreign function to the native Swift convention.
   void emitForeignToNativeThunk(SILDeclRef thunk);

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -486,12 +486,7 @@ void SILGenFunction::emitClassConstructorAllocator(ConstructorDecl *ctor) {
 
   // Call the initializer. Always use the Swift entry point, which will be a
   // bridging thunk if we're calling ObjC.
-  SILDeclRef initConstant =
-    SILDeclRef(ctor,
-               SILDeclRef::Kind::Initializer,
-               SILDeclRef::ConstructAtBestResilienceExpansion,
-               SILDeclRef::ConstructAtNaturalUncurryLevel,
-               /*isObjC=*/false);
+  auto initConstant = SILDeclRef(ctor, SILDeclRef::Kind::Initializer);
 
   ManagedValue initVal;
   SILType initTy;

--- a/lib/SILGen/SILGenDestructor.cpp
+++ b/lib/SILGen/SILGenDestructor.cpp
@@ -228,11 +228,9 @@ void SILGenFunction::emitObjCDestructor(SILDeclRef dtor) {
   assert(superclassTy && "Emitting Objective-C -dealloc without superclass?");
   ClassDecl *superclass = superclassTy->getClassOrBoundGenericClass();
   auto superclassDtorDecl = superclass->getDestructor();
-  SILDeclRef superclassDtor(superclassDtorDecl,
-                            SILDeclRef::Kind::Deallocator,
-                            SILDeclRef::ConstructAtBestResilienceExpansion,
-                            SILDeclRef::ConstructAtNaturalUncurryLevel,
-                            /*isForeign=*/true);
+  auto superclassDtor = SILDeclRef(superclassDtorDecl,
+                                   SILDeclRef::Kind::Deallocator)
+    .asForeign();
   auto superclassDtorType = SGM.getConstantType(superclassDtor);
   SILValue superclassDtorValue = B.createSuperMethod(
                                    cleanupLoc, selfValue, superclassDtor,

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -768,11 +768,7 @@ emitRValueForDecl(SILLocation loc, ConcreteDeclRef declRef, Type ncRefType,
   // If the referenced decl isn't a VarDecl, it should be a constant of some
   // sort.
   SILDeclRef silDeclRef(decl);
-  bool hasLocalCaptures = false;
-  if (auto *fd = dyn_cast<FuncDecl>(decl))
-    hasLocalCaptures = SGM.M.Types.hasLoweredLocalCaptures(fd);
-
-  if (silDeclRef.getUncurryLevel() > 0 && !hasLocalCaptures)
+  if (silDeclRef.getUncurryLevel() > 0)
     silDeclRef = silDeclRef.asCurried();
 
   ManagedValue result = emitClosureValue(loc, silDeclRef, refType,

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -767,18 +767,13 @@ emitRValueForDecl(SILLocation loc, ConcreteDeclRef declRef, Type ncRefType,
   
   // If the referenced decl isn't a VarDecl, it should be a constant of some
   // sort.
-
-  // If the referenced decl is a local func with context, then the SILDeclRef
-  // uncurry level is one deeper (for the context vars).
+  SILDeclRef silDeclRef(decl);
   bool hasLocalCaptures = false;
-  unsigned uncurryLevel = 0;
-  if (auto *fd = dyn_cast<FuncDecl>(decl)) {
+  if (auto *fd = dyn_cast<FuncDecl>(decl))
     hasLocalCaptures = SGM.M.Types.hasLoweredLocalCaptures(fd);
-    if (hasLocalCaptures)
-      ++uncurryLevel;
-  }
 
-  auto silDeclRef = SILDeclRef(decl, ResilienceExpansion::Minimal, uncurryLevel);
+  if (silDeclRef.getUncurryLevel() > 0 && !hasLocalCaptures)
+    silDeclRef = silDeclRef.asCurried();
 
   ManagedValue result = emitClosureValue(loc, silDeclRef, refType,
                                          declRef.getSubstitutions());

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -465,9 +465,7 @@ void SILGenFunction::emitArtificialTopLevel(ClassDecl *mainClass) {
     assert(!results.empty() && "couldn't find UIApplicationMain in UIKit");
     assert(results.size() == 1 && "more than one UIApplicationMain?");
 
-    SILDeclRef mainRef{results.front(), ResilienceExpansion::Minimal,
-                       SILDeclRef::ConstructAtNaturalUncurryLevel,
-                       /*isForeign*/true};
+    auto mainRef = SILDeclRef(results.front()).asForeign();
     auto UIApplicationMainFn = SGM.M.getOrCreateFunction(mainClass, mainRef,
                                                          NotForDefinition);
     auto fnTy = UIApplicationMainFn->getLoweredFunctionType();

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -301,9 +301,6 @@ SILGenFunction::emitClosureValue(SILLocation loc, SILDeclRef constant,
   auto captureInfo = closure.getCaptureInfo();
   auto loweredCaptureInfo = SGM.Types.getLoweredLocalCaptures(closure);
   auto hasCaptures = SGM.Types.hasLoweredLocalCaptures(closure);
-  assert(((constant.uncurryLevel == 1 && hasCaptures) ||
-          (constant.uncurryLevel == 0 && !hasCaptures)) &&
-         "curried local functions not yet supported");
 
   auto constantInfo = getConstantInfo(constant);
   SILValue functionRef = emitGlobalFunctionRef(loc, constant, constantInfo);

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -367,21 +367,6 @@ SILGenFunction::emitClosureValue(SILLocation loc, SILDeclRef constant,
   //  - the original type
   auto origLoweredFormalType =
       AbstractionPattern(constantInfo.LoweredInterfaceType);
-  if (hasCaptures) {
-    // Get the unlowered formal type of the constant, stripping off
-    // the first level of function application, which applies captures.
-    origLoweredFormalType =
-      AbstractionPattern(constantInfo.FormalInterfaceType)
-          .getFunctionResultType();
-
-    // Lower it, being careful to use the right generic signature.
-    origLoweredFormalType =
-      AbstractionPattern(
-          origLoweredFormalType.getGenericSignature(),
-          SGM.Types.getLoweredASTFunctionType(
-              cast<FunctionType>(origLoweredFormalType.getType()),
-              0, constant));
-  }
 
   // - the substituted type
   auto substFormalType = cast<FunctionType>(expectedType);

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -619,8 +619,7 @@ public:
                                   CleanupLocation cleanupLoc);
   /// Generates code for a curry thunk from one uncurry level
   /// of a function to another.
-  void emitCurryThunk(ValueDecl *fd,
-                      SILDeclRef fromLevel, SILDeclRef toLevel);
+  void emitCurryThunk(SILDeclRef thunk);
   /// Generates a thunk from a foreign function to the native Swift convention.
   void emitForeignToNativeThunk(SILDeclRef thunk);
   /// Generates a thunk from a native function to the conventions.

--- a/lib/SILGen/SILGenThunk.cpp
+++ b/lib/SILGen/SILGenThunk.cpp
@@ -73,20 +73,30 @@ SILValue SILGenFunction::emitDynamicMethodRef(SILLocation loc,
 
 static SILValue getNextUncurryLevelRef(SILGenFunction &gen,
                                        SILLocation loc,
-                                       SILDeclRef next,
-                                       bool direct,
+                                       SILDeclRef thunk,
                                        SILValue selfArg,
                                        SubstitutionList curriedSubs) {
-  if (next.isForeign || next.isCurried || !next.hasDecl() || direct)
-    return gen.emitGlobalFunctionRef(loc, next.asForeign(false));
+  auto *vd = thunk.getDecl();
+
+  // Reference the next uncurrying level of the function.
+  SILDeclRef next = SILDeclRef(vd, thunk.kind);
+  assert(!next.isCurried);
+
+  // If the function is natively foreign, reference its foreign entry point.
+  if (requiresForeignToNativeThunk(vd))
+    return gen.emitGlobalFunctionRef(loc, next);
+
+  // If the thunk is a curry thunk for a direct method reference, we are
+  // doing a direct dispatch (eg, a fragile 'super.foo()' call).
+  if (thunk.isDirectReference)
+    return gen.emitGlobalFunctionRef(loc, next);
 
   auto constantInfo = gen.SGM.Types.getConstantInfo(next);
 
-  if (auto *func = dyn_cast<AbstractFunctionDecl>(next.getDecl())) {
-    if (getMethodDispatch(cast<AbstractFunctionDecl>(next.getDecl()))
-          == MethodDispatch::Class) {
+  if (auto *func = dyn_cast<AbstractFunctionDecl>(vd)) {
+    if (getMethodDispatch(func) == MethodDispatch::Class) {
       // Use the dynamic thunk if dynamic.
-      if (next.getDecl()->isDynamic()) {
+      if (vd->isDynamic()) {
         auto dynamicThunk = gen.SGM.getDynamicThunk(next, constantInfo);
         return gen.B.createFunctionRef(loc, dynamicThunk);
       }
@@ -118,10 +128,11 @@ static SILValue getNextUncurryLevelRef(SILGenFunction &gen,
   return gen.emitGlobalFunctionRef(loc, next);
 }
 
-void SILGenFunction::emitCurryThunk(ValueDecl *vd,
-                                    SILDeclRef from, SILDeclRef to) {
+void SILGenFunction::emitCurryThunk(SILDeclRef thunk) {
+  auto *vd = thunk.getDecl();
+
 #ifndef NDEBUG
-  assert(from.uncurryLevel == 0 && to.uncurryLevel == 1
+  assert(thunk.uncurryLevel == 0
          && "currying function at level other than one?!");
 
   if (auto *fd = dyn_cast<AbstractFunctionDecl>(vd)) {
@@ -138,14 +149,14 @@ void SILGenFunction::emitCurryThunk(ValueDecl *vd,
   // Forward substitutions.
   auto subs = F.getForwardingSubstitutions();
 
-  SILValue toFn = getNextUncurryLevelRef(*this, vd, to, from.isDirectReference,
+  SILValue toFn = getNextUncurryLevelRef(*this, vd, thunk,
                                          selfArg, subs);
 
   // FIXME: Using the type from the ConstantInfo instead of looking at
   // getConstantOverrideInfo() for methods looks suspect in the presence
   // of covariant overrides and multiple vtable entries.
   SILFunctionConventions fromConv(
-      SGM.Types.getConstantInfo(from).SILFnType, SGM.M);
+      SGM.Types.getConstantInfo(thunk).SILFnType, SGM.M);
   SILType resultTy = fromConv.getSingleSILResultType();
   resultTy = F.mapTypeIntoContext(resultTy);
   auto substTy = toFn->getType().substGenericArgs(SGM.M,  subs);
@@ -162,20 +173,20 @@ void SILGenFunction::emitCurryThunk(ValueDecl *vd,
   B.createReturn(ImplicitReturnLocation::getImplicitReturnLoc(vd), toClosure);
 }
 
-void SILGenModule::emitCurryThunk(ValueDecl *fd,
-                                  SILDeclRef entryPoint,
-                                  SILDeclRef nextEntryPoint) {
+void SILGenModule::emitCurryThunk(SILDeclRef constant) {
+  assert(constant.uncurryLevel == 0);
+
   // Thunks are always emitted by need, so don't need delayed emission.
-  SILFunction *f = getFunction(entryPoint, ForDefinition);
+  SILFunction *f = getFunction(constant, ForDefinition);
   f->setThunk(IsThunk);
   f->setBare(IsBare);
 
-  preEmitFunction(entryPoint, fd, f, fd);
+  auto *fd = constant.getDecl();
+  preEmitFunction(constant, fd, f, fd);
   PrettyStackTraceSILFunction X("silgen emitCurryThunk", f);
 
-  SILGenFunction(*this, *f)
-    .emitCurryThunk(fd, entryPoint, nextEntryPoint);
-  postEmitFunction(entryPoint, f);
+  SILGenFunction(*this, *f).emitCurryThunk(constant);
+  postEmitFunction(constant, f);
 }
 
 void SILGenModule::emitForeignToNativeThunk(SILDeclRef thunk) {
@@ -224,27 +235,8 @@ SILValue SILGenFunction::emitGlobalFunctionRef(SILLocation loc,
   // If the constant is a thunk we haven't emitted yet, emit it.
   if (!SGM.hasFunction(constant)) {
     if (constant.isCurried) {
-      auto vd = constant.getDecl();
-      // Reference the next uncurrying level of the function.
-      SILDeclRef next = SILDeclRef(vd, constant.kind,
-                                 SILDeclRef::ConstructAtBestResilienceExpansion,
-                                 constant.uncurryLevel + 1);
-      // If the function is fully uncurried and natively foreign, reference its
-      // foreign entry point.
-      if (!next.isCurried) {
-        if (requiresForeignToNativeThunk(vd))
-          next = next.asForeign();
-      }
-      
-      // Preserve whether the curry thunks lead to a direct reference to the
-      // method implementation.
-      next = next.asDirectReference(constant.isDirectReference);
-
-      SGM.emitCurryThunk(vd, constant, next);
-    }
-    // Otherwise, if this is a calling convention thunk we haven't emitted yet,
-    // emit it.
-    else if (constant.isForeignToNativeThunk()) {
+      SGM.emitCurryThunk(constant);
+    } else if (constant.isForeignToNativeThunk()) {
       SGM.emitForeignToNativeThunk(constant);
     } else if (constant.isNativeToForeignThunk()) {
       SGM.emitNativeToForeignThunk(constant);

--- a/lib/SILGen/SILGenThunk.cpp
+++ b/lib/SILGen/SILGenThunk.cpp
@@ -129,17 +129,15 @@ static SILValue getNextUncurryLevelRef(SILGenFunction &gen,
 }
 
 void SILGenFunction::emitCurryThunk(SILDeclRef thunk) {
-  auto *vd = thunk.getDecl();
+  assert(thunk.isCurried);
 
-#ifndef NDEBUG
-  assert(thunk.uncurryLevel == 0
-         && "currying function at level other than one?!");
+  auto *vd = thunk.getDecl();
 
   if (auto *fd = dyn_cast<AbstractFunctionDecl>(vd)) {
     assert(!SGM.M.Types.hasLoweredLocalCaptures(fd) &&
            "methods cannot have captures");
+    (void) fd;
   }
-#endif
 
   auto selfTy = vd->getInterfaceType()->castTo<AnyFunctionType>()
     ->getInput();
@@ -174,7 +172,7 @@ void SILGenFunction::emitCurryThunk(SILDeclRef thunk) {
 }
 
 void SILGenModule::emitCurryThunk(SILDeclRef constant) {
-  assert(constant.uncurryLevel == 0);
+  assert(constant.isCurried);
 
   // Thunks are always emitted by need, so don't need delayed emission.
   SILFunction *f = getFunction(constant, ForDefinition);

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -549,18 +549,6 @@ SILGenModule::emitProtocolWitness(ProtocolConformance *conformance,
                                   IsFreeFunctionWitness_t isFree,
                                   Witness witness) {
   auto requirementInfo = Types.getConstantInfo(requirement);
-  unsigned witnessUncurryLevel = witnessRef.uncurryLevel;
-
-  // If the witness is a free function, consider the self argument
-  // uncurry level.
-  if (isFree)
-    ++witnessUncurryLevel;
-
-  // The SIL witness thunk has the type of the AST-level witness with
-  // witness substitutions applied, at the abstraction level of the
-  // original protocol requirement.
-  assert(requirement.uncurryLevel == witnessUncurryLevel &&
-         "uncurry level of requirement and witness do not match");
 
   GenericEnvironment *genericEnv = nullptr;
 

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -255,12 +255,8 @@ public:
   }
 
   void addConstructor(ConstructorDecl *cd, Witness witness) {
-    SILDeclRef requirementRef(cd, SILDeclRef::Kind::Allocator,
-                              ResilienceExpansion::Minimal);
-
-    SILDeclRef witnessRef(witness.getDecl(), SILDeclRef::Kind::Allocator,
-                          SILDeclRef::ConstructAtBestResilienceExpansion,
-                          requirementRef.uncurryLevel);
+    SILDeclRef requirementRef(cd, SILDeclRef::Kind::Allocator);
+    SILDeclRef witnessRef(witness.getDecl(), SILDeclRef::Kind::Allocator);
 
     asDerived().addMethod(requirementRef, witnessRef, IsNotFreeFunctionWitness,
                           witness);
@@ -283,20 +279,11 @@ public:
 
 private:
   void addMethod(FuncDecl *fd, ValueDecl *witnessDecl, Witness witness) {
-
-    // TODO: multiple resilience expansions?
-    // TODO: multiple uncurry levels?
-    SILDeclRef requirementRef(fd, SILDeclRef::Kind::Func,
-                              ResilienceExpansion::Minimal);
+    SILDeclRef requirementRef(fd, SILDeclRef::Kind::Func);
     // Free function witnesses have an implicit uncurry layer imposed on them by
     // the inserted metatype argument.
     auto isFree = isFreeFunctionWitness(fd, witnessDecl);
-    unsigned witnessUncurryLevel = isFree ? requirementRef.uncurryLevel - 1
-                                          : requirementRef.uncurryLevel;
-
-    SILDeclRef witnessRef(witnessDecl, SILDeclRef::Kind::Func,
-                          SILDeclRef::ConstructAtBestResilienceExpansion,
-                          witnessUncurryLevel);
+    SILDeclRef witnessRef(witnessDecl, SILDeclRef::Kind::Func);
 
     asDerived().addMethod(requirementRef, witnessRef, isFree, witness);
   }

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -698,7 +698,9 @@ static SILDeclRef getSILDeclRef(ModuleFile *MF,
   SILDeclRef DRef(cast<ValueDecl>(MF->getDecl(ListOfValues[NextIdx])),
                   (SILDeclRef::Kind)ListOfValues[NextIdx+1],
                   (ResilienceExpansion)ListOfValues[NextIdx+2],
-                  ListOfValues[NextIdx+3], ListOfValues[NextIdx+4] > 0);
+                  /*isCurried=*/false, ListOfValues[NextIdx+4] > 0);
+  if (ListOfValues[NextIdx+3] < DRef.getUncurryLevel())
+    DRef = DRef.asCurried();
   NextIdx += 5;
   return DRef;
 }

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -468,7 +468,7 @@ static void handleSILDeclRef(Serializer &S, const SILDeclRef &Ref,
   ListOfValues.push_back(S.addDeclRef(Ref.getDecl()));
   ListOfValues.push_back((unsigned)Ref.kind);
   ListOfValues.push_back((unsigned)Ref.getResilienceExpansion());
-  ListOfValues.push_back(Ref.uncurryLevel);
+  ListOfValues.push_back(Ref.getUncurryLevel());
   ListOfValues.push_back(Ref.isForeign);
 }
 

--- a/stdlib/public/Reflection/TypeLowering.cpp
+++ b/stdlib/public/Reflection/TypeLowering.cpp
@@ -275,13 +275,6 @@ public:
       Invalid(false) {}
 
   void addProtocol(const ProtocolTypeRef *P) {
-    // FIXME: AnyObject should go away
-    if (P->isAnyObject()) {
-      Representation = ExistentialTypeRepresentation::Class;
-      // No extra witness table for AnyObject
-      return;
-    }
-
     Protocols.push_back(P);
   }
 

--- a/stdlib/public/Reflection/TypeRefBuilder.cpp
+++ b/stdlib/public/Reflection/TypeRefBuilder.cpp
@@ -72,14 +72,6 @@ lookupTypeWitness(const std::string &MangledTypeName,
 }
 
 const TypeRef * TypeRefBuilder::
-lookupSuperclass(const std::string &MangledTypeName) {
-  // Superclasses are recorded as a special associated type named 'super'
-  // on the 'AnyObject' protocol.
-  return lookupTypeWitness(MangledTypeName, "super",
-                           ProtocolTypeRef::create(*this, "s9AnyObject_p"));
-}
-
-const TypeRef * TypeRefBuilder::
 lookupSuperclass(const TypeRef *TR) {
   auto *FD = getFieldTypeInfo(TR);
   if (FD == nullptr)

--- a/validation-test/SIL/crashers_fixed/014-swift-sildeclref-sildeclref.sil
+++ b/validation-test/SIL/crashers_fixed/014-swift-sildeclref-sildeclref.sil
@@ -1,3 +1,3 @@
-// RUN: not --crash %target-sil-opt %s
+// RUN: not %target-sil-opt %s
 // REQUIRES: asserts
 class C}sil_vtable C{#C


### PR DESCRIPTION
The code deletion from https://github.com/apple/swift/pull/8402 continues. Here I've almost completely ripped out the uncurryLevel concept, in preparation for fixing https://bugs.swift.org/browse/SR-75.