### PR TITLE
[swiftc (34 vs. 5523)] Add crasher in swift::TypeBase::getContextSubstitutions

### DIFF
--- a/validation-test/compiler_crashers/28747-swift-typebase-getcontextsubstitutions-swift-declcontext-const-swift-genericenvi.swift
+++ b/validation-test/compiler_crashers/28747-swift-typebase-getcontextsubstitutions-swift-declcontext-const-swift-genericenvi.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+{protocol P{protocol A:P{}class a{class C:A.a


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeBase::getContextSubstitutions`.

Current number of unresolved compiler crashers: 34 (5523 resolved)

Stack trace:

```
0 0x00000000039d6c48 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x39d6c48)
1 0x00000000039d7386 SignalHandler(int) (/path/to/swift/bin/swift+0x39d7386)
2 0x00007fce365d6390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x000000000156b4cb swift::TypeBase::getContextSubstitutions(swift::DeclContext const*, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x156b4cb)
4 0x00000000015670c0 swift::TypeBase::getContextSubstitutionMap(swift::ModuleDecl*, swift::DeclContext const*, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x15670c0)
5 0x00000000013ece07 swift::createDesignatedInitOverride(swift::TypeChecker&, swift::ClassDecl*, swift::ConstructorDecl*, swift::DesignatedInitKind) (/path/to/swift/bin/swift+0x13ece07)
6 0x0000000001310f29 swift::TypeChecker::addImplicitConstructors(swift::NominalTypeDecl*) (/path/to/swift/bin/swift+0x1310f29)
7 0x000000000131a025 (anonymous namespace)::DeclChecker::visitClassDecl(swift::ClassDecl*) (/path/to/swift/bin/swift+0x131a025)
8 0x000000000130957b (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x130957b)
9 0x000000000131a06b (anonymous namespace)::DeclChecker::visitClassDecl(swift::ClassDecl*) (/path/to/swift/bin/swift+0x131a06b)
10 0x000000000130957b (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x130957b)
11 0x000000000131af2b (anonymous namespace)::DeclChecker::visitProtocolDecl(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0x131af2b)
12 0x0000000001309687 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x1309687)
13 0x0000000001309483 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x1309483)
14 0x0000000001373e86 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x1373e86)
15 0x000000000137353b swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) (/path/to/swift/bin/swift+0x137353b)
16 0x000000000138edac swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) (/path/to/swift/bin/swift+0x138edac)
17 0x00000000012f38f0 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x12f38f0)
18 0x0000000001373ee5 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x1373ee5)
19 0x00000000013736f6 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0x13736f6)
20 0x00000000013892d0 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x13892d0)
21 0x0000000000f82cb6 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf82cb6)
22 0x00000000004aa1dd performCompile(std::unique_ptr<swift::CompilerInstance, std::default_delete<swift::CompilerInstance> >&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4aa1dd)
23 0x00000000004a89f5 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a89f5)
24 0x0000000000465567 main (/path/to/swift/bin/swift+0x465567)
25 0x00007fce34ae7830 __libc_start_main /build/glibc-9tT8Do/glibc-2.23/csu/../csu/libc-start.c:325:0
26 0x0000000000462c09 _start (/path/to/swift/bin/swift+0x462c09)
```