### PR TITLE
[swiftc (34 vs. 5523)] Add crasher in swift::AbstractTypeParamDecl::getSuperclass(...)

### DIFF
--- a/validation-test/compiler_crashers/28748-genericenv-nullptr-too-much-circularity.swift
+++ b/validation-test/compiler_crashers/28748-genericenv-nullptr-too-much-circularity.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol A:a{{}typealias e:a}{}class a:A{typealias e:b


### PR DESCRIPTION
Add test case for crash triggered in `swift::AbstractTypeParamDecl::getSuperclass(...)`.

Current number of unresolved compiler crashers: 34 (5523 resolved)

/cc @slavapestov - just wanted to let you know that this crasher caused an assertion failure for the assertion `genericEnv != nullptr && "Too much circularity"` added on 2017-03-30 by you in commit a79ef97c :-)

Assertion failure in [`lib/AST/Decl.cpp (line 2324)`](https://github.com/apple/swift/blob/f7ff8ce52bd814378e82f3e9374db4465e8c6718/lib/AST/Decl.cpp#L2324):

```
Assertion `genericEnv != nullptr && "Too much circularity"' failed.

When executing: swift::Type swift::AbstractTypeParamDecl::getSuperclass() const
```

Assertion context:

```c++
    GenericContext(DeclContextKind::GenericTypeDecl, DC) {
  setGenericParams(GenericParams);
}

TypeAliasDecl::TypeAliasDecl(SourceLoc TypeAliasLoc, SourceLoc EqualLoc,
                             Identifier Name, SourceLoc NameLoc,
                             GenericParamList *GenericParams, DeclContext *DC)
  : GenericTypeDecl(DeclKind::TypeAlias, DC, Name, NameLoc, {}, GenericParams),
    TypeAliasLoc(TypeAliasLoc), EqualLoc(EqualLoc) {
  TypeAliasDeclBits.IsCompatibilityAlias = false;
}
```
Stack trace:

```
0 0x00000000039d6c48 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x39d6c48)
1 0x00000000039d7386 SignalHandler(int) (/path/to/swift/bin/swift+0x39d7386)
2 0x00007fb3fe8d5390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007fb3fcdfb428 gsignal /build/glibc-9tT8Do/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007fb3fcdfd02a abort /build/glibc-9tT8Do/glibc-2.23/stdlib/abort.c:91:0
5 0x00007fb3fcdf3bd7 __assert_fail_base /build/glibc-9tT8Do/glibc-2.23/assert/assert.c:92:0
6 0x00007fb3fcdf3c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x00000000014e1da6 swift::AbstractTypeParamDecl::getSuperclass() const (/path/to/swift/bin/swift+0x14e1da6)
8 0x000000000136153c checkTypeWitness(swift::TypeChecker&, swift::DeclContext*, swift::AssociatedTypeDecl*, swift::Type) (/path/to/swift/bin/swift+0x136153c)
9 0x000000000135e71e (anonymous namespace)::ConformanceChecker::resolveTypeWitnessViaLookup(swift::AssociatedTypeDecl*) (/path/to/swift/bin/swift+0x135e71e)
10 0x000000000134cb40 swift::TypeChecker::resolveTypeWitness(swift::NormalProtocolConformance const*, swift::AssociatedTypeDecl*) (/path/to/swift/bin/swift+0x134cb40)
11 0x0000000001555a8e swift::NormalProtocolConformance::getTypeWitnessAndDecl(swift::AssociatedTypeDecl*, swift::LazyResolver*) const (/path/to/swift/bin/swift+0x1555a8e)
12 0x0000000001555676 swift::ProtocolConformance::getTypeWitnessAndDecl(swift::AssociatedTypeDecl*, swift::LazyResolver*) const (/path/to/swift/bin/swift+0x1555676)
13 0x000000000151100b maybeAddSameTypeRequirementForNestedType(swift::GenericSignatureBuilder::PotentialArchetype*, swift::GenericSignatureBuilder::RequirementSource const*, swift::GenericSignatureBuilder&) (/path/to/swift/bin/swift+0x151100b)
14 0x0000000001510594 swift::GenericSignatureBuilder::PotentialArchetype::updateNestedTypeForConformance(llvm::PointerUnion<swift::AssociatedTypeDecl*, swift::TypeAliasDecl*>, swift::GenericSignatureBuilder::PotentialArchetype::NestedTypeUpdate) (/path/to/swift/bin/swift+0x1510594)
15 0x0000000001513a4d swift::GenericSignatureBuilder::resolve(llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::FloatingRequirementSource) (/path/to/swift/bin/swift+0x1513a4d)
16 0x0000000001517f15 swift::GenericSignatureBuilder::addTypeRequirement(llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::FloatingRequirementSource, swift::GenericSignatureBuilder::UnresolvedHandlingKind) (/path/to/swift/bin/swift+0x1517f15)
17 0x0000000001529ab1 swift::GenericSignatureBuilder::ConstraintResult llvm::function_ref<swift::GenericSignatureBuilder::ConstraintResult (swift::Type, swift::TypeRepr const*)>::callback_fn<swift::GenericSignatureBuilder::addInheritedRequirements(swift::TypeDecl*, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::RequirementSource const*, swift::ModuleDecl*)::$_26>(long, swift::Type, swift::TypeRepr const*) (/path/to/swift/bin/swift+0x1529ab1)
18 0x00000000015222d7 std::_Function_handler<void (swift::Type, swift::TypeRepr const*), visitInherited(llvm::ArrayRef<swift::TypeLoc>, llvm::function_ref<swift::GenericSignatureBuilder::ConstraintResult (swift::Type, swift::TypeRepr const*)>, llvm::function_ref<swift::GenericSignatureBuilder::ConstraintResult (swift::LayoutConstraint, swift::TypeRepr const*)>)::$_58>::_M_invoke(std::_Any_data const&, swift::Type&&, swift::TypeRepr const*&&) (/path/to/swift/bin/swift+0x15222d7)
19 0x0000000001514419 swift::GenericSignatureBuilder::addInheritedRequirements(swift::TypeDecl*, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::RequirementSource const*, swift::ModuleDecl*) (/path/to/swift/bin/swift+0x1514419)
20 0x00000000015149e4 swift::GenericSignatureBuilder::addConformanceRequirement(swift::GenericSignatureBuilder::PotentialArchetype*, swift::ProtocolDecl*, swift::GenericSignatureBuilder::RequirementSource const*) (/path/to/swift/bin/swift+0x15149e4)
21 0x0000000001518345 swift::GenericSignatureBuilder::addTypeRequirement(llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::FloatingRequirementSource, swift::GenericSignatureBuilder::UnresolvedHandlingKind) (/path/to/swift/bin/swift+0x1518345)
22 0x0000000001529ab1 swift::GenericSignatureBuilder::ConstraintResult llvm::function_ref<swift::GenericSignatureBuilder::ConstraintResult (swift::Type, swift::TypeRepr const*)>::callback_fn<swift::GenericSignatureBuilder::addInheritedRequirements(swift::TypeDecl*, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::RequirementSource const*, swift::ModuleDecl*)::$_26>(long, swift::Type, swift::TypeRepr const*) (/path/to/swift/bin/swift+0x1529ab1)
23 0x00000000015222d7 std::_Function_handler<void (swift::Type, swift::TypeRepr const*), visitInherited(llvm::ArrayRef<swift::TypeLoc>, llvm::function_ref<swift::GenericSignatureBuilder::ConstraintResult (swift::Type, swift::TypeRepr const*)>, llvm::function_ref<swift::GenericSignatureBuilder::ConstraintResult (swift::LayoutConstraint, swift::TypeRepr const*)>)::$_58>::_M_invoke(std::_Any_data const&, swift::Type&&, swift::TypeRepr const*&&) (/path/to/swift/bin/swift+0x15222d7)
24 0x0000000001514419 swift::GenericSignatureBuilder::addInheritedRequirements(swift::TypeDecl*, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::RequirementSource const*, swift::ModuleDecl*) (/path/to/swift/bin/swift+0x1514419)
25 0x00000000015141fe swift::GenericSignatureBuilder::addGenericParameterRequirements(swift::GenericTypeParamDecl*) (/path/to/swift/bin/swift+0x15141fe)
26 0x0000000001336982 swift::TypeChecker::checkGenericParamList(swift::GenericSignatureBuilder*, swift::GenericParamList*, swift::GenericSignature*, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0x1336982)
27 0x0000000001339f8d swift::TypeChecker::checkGenericEnvironment(swift::GenericParamList*, swift::DeclContext*, swift::GenericSignature*, bool, llvm::function_ref<void (swift::GenericSignatureBuilder&)>) (/path/to/swift/bin/swift+0x1339f8d)
28 0x000000000133a3b9 swift::TypeChecker::validateGenericTypeSignature(swift::GenericTypeDecl*) (/path/to/swift/bin/swift+0x133a3b9)
29 0x000000000130b2d3 swift::TypeChecker::validateDecl(swift::ValueDecl*) (/path/to/swift/bin/swift+0x130b2d3)
30 0x000000000131ac13 (anonymous namespace)::DeclChecker::visitProtocolDecl(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0x131ac13)
31 0x0000000001309687 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x1309687)
32 0x0000000001309483 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x1309483)
33 0x0000000001389255 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x1389255)
34 0x0000000000f82cb6 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf82cb6)
35 0x00000000004aa1dd performCompile(std::unique_ptr<swift::CompilerInstance, std::default_delete<swift::CompilerInstance> >&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4aa1dd)
36 0x00000000004a89f5 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a89f5)
37 0x0000000000465567 main (/path/to/swift/bin/swift+0x465567)
38 0x00007fb3fcde6830 __libc_start_main /build/glibc-9tT8Do/glibc-2.23/csu/../csu/libc-start.c:325:0
39 0x0000000000462c09 _start (/path/to/swift/bin/swift+0x462c09)
```