### PR TITLE
Various fixes to get master-next building again

### DIFF
--- a/lib/ClangImporter/IAMInference.cpp
+++ b/lib/ClangImporter/IAMInference.cpp
@@ -173,7 +173,7 @@ static clang::Module *getSubmodule(const clang::NamedDecl *decl, clang::Sema &cl
     return m;
   if (auto m = clangSema.getPreprocessor().getCurrentModule())
     return m;
-  if (auto m = clangSema.getPreprocessor().getCurrentSubmodule())
+  if (auto m = clangSema.getPreprocessor().getCurrentLexerSubmodule())
     return m;
 
   return nullptr;

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -497,7 +497,7 @@ static bool moduleIsInferImportAsMember(const clang::NamedDecl *decl,
     submodule = m;
   } else if (auto m = clangSema.getPreprocessor().getCurrentModule()) {
     submodule = m;
-  } else if (auto m = clangSema.getPreprocessor().getCurrentSubmodule()) {
+  } else if (auto m = clangSema.getPreprocessor().getCurrentLexerSubmodule()) {
     submodule = m;
   } else {
     return false;

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -86,8 +86,7 @@ static void addIndirectValueParameterAttributes(IRGenModule &IGM,
   // The parameter must reference dereferenceable memory of the type.
   addDereferenceableAttributeToBuilder(IGM, b, ti);
 
-  auto resultAttrs = llvm::AttributeList::get(IGM.LLVMContext, argIndex + 1, b);
-  attrs = attrs.addAttributes(IGM.LLVMContext, argIndex+1, resultAttrs);
+  attrs = attrs.addAttributes(IGM.LLVMContext, argIndex+1, b);
 }
 
 static void addInoutParameterAttributes(IRGenModule &IGM,
@@ -102,8 +101,7 @@ static void addInoutParameterAttributes(IRGenModule &IGM,
   // The inout must reference dereferenceable memory of the type.
   addDereferenceableAttributeToBuilder(IGM, b, ti);
 
-  auto resultAttrs = llvm::AttributeList::get(IGM.LLVMContext, argIndex + 1, b);
-  attrs = attrs.addAttributes(IGM.LLVMContext, argIndex+1, resultAttrs);
+  attrs = attrs.addAttributes(IGM.LLVMContext, argIndex+1, b);
 }
 
 static llvm::CallingConv::ID getFreestandingConvention(IRGenModule &IGM) {
@@ -134,32 +132,21 @@ llvm::CallingConv::ID irgen::expandCallingConv(IRGenModule &IGM,
 static void addIndirectResultAttributes(IRGenModule &IGM,
                                         llvm::AttributeList &attrs,
                                         unsigned paramIndex, bool allowSRet) {
-  static const llvm::Attribute::AttrKind attrKindsWithSRet[] = {
-    llvm::Attribute::StructRet,
-    llvm::Attribute::NoAlias,
-    llvm::Attribute::NoCapture,
-  };
-  static const llvm::Attribute::AttrKind attrKindsWithoutSRet[] = {
-    llvm::Attribute::NoAlias,
-    llvm::Attribute::NoCapture,
-  };
-  auto resultAttrs = llvm::AttributeList::get(
-      IGM.LLVMContext, paramIndex + 1,
-      (allowSRet ? makeArrayRef(attrKindsWithSRet)
-                 : makeArrayRef(attrKindsWithoutSRet)));
-  attrs = attrs.addAttributes(IGM.LLVMContext, paramIndex + 1, resultAttrs);
+  llvm::AttrBuilder b;
+  b.addAttribute(llvm::Attribute::NoAlias);
+  b.addAttribute(llvm::Attribute::NoCapture);
+  if (allowSRet)
+    b.addAttribute(llvm::Attribute::StructRet);
+  attrs = attrs.addAttributes(IGM.LLVMContext, paramIndex + 1, b);
 }
 
 void IRGenModule::addSwiftSelfAttributes(llvm::AttributeList &attrs,
                                          unsigned argIndex) {
   if (!UseSwiftCC)
     return;
-  static const llvm::Attribute::AttrKind attrKinds[] = {
-    llvm::Attribute::SwiftSelf,
-  };
-  auto argAttrs =
-      llvm::AttributeList::get(this->LLVMContext, argIndex + 1, attrKinds);
-  attrs = attrs.addAttributes(this->LLVMContext, argIndex + 1, argAttrs);
+  llvm::AttrBuilder b;
+  b.addAttribute(llvm::Attribute::SwiftSelf);
+  attrs = attrs.addAttributes(this->LLVMContext, argIndex + 1, b);
 }
 
 void IRGenModule::addSwiftErrorAttributes(llvm::AttributeList &attrs,
@@ -171,12 +158,9 @@ void IRGenModule::addSwiftErrorAttributes(llvm::AttributeList &attrs,
   if (!UseSwiftCC || !this->IsSwiftErrorInRegister)
     return;
 
-  static const llvm::Attribute::AttrKind attrKinds[] = {
-    llvm::Attribute::SwiftError,
-  };
-  auto argAttrs =
-      llvm::AttributeList::get(this->LLVMContext, argIndex + 1, attrKinds);
-  attrs = attrs.addAttributes(this->LLVMContext, argIndex + 1, argAttrs);
+  llvm::AttrBuilder b;
+  b.addAttribute(llvm::Attribute::SwiftError);
+  attrs = attrs.addAttributes(this->LLVMContext, argIndex + 1, b);
 }
 
 void irgen::addByvalArgumentAttributes(IRGenModule &IGM,
@@ -186,10 +170,7 @@ void irgen::addByvalArgumentAttributes(IRGenModule &IGM,
   b.addAttribute(llvm::Attribute::ByVal);
   b.addAttribute(llvm::Attribute::getWithAlignment(IGM.LLVMContext,
                                                    align.getValue()));
-  auto resultAttrs = llvm::AttributeList::get(IGM.LLVMContext, argIndex + 1, b);
-  attrs = attrs.addAttributes(IGM.LLVMContext,
-                              argIndex+1,
-                              resultAttrs);
+  attrs = attrs.addAttributes(IGM.LLVMContext, argIndex+1, b);
 }
 
 void irgen::addExtendAttribute(IRGenModule &IGM, llvm::AttributeList &attrs,
@@ -199,8 +180,7 @@ void irgen::addExtendAttribute(IRGenModule &IGM, llvm::AttributeList &attrs,
     b.addAttribute(llvm::Attribute::SExt);
   else
     b.addAttribute(llvm::Attribute::ZExt);
-  auto resultAttrs = llvm::AttributeList::get(IGM.LLVMContext, index, b);
-  attrs = attrs.addAttributes(IGM.LLVMContext, index, resultAttrs);
+  attrs = attrs.addAttributes(IGM.LLVMContext, index, b);
 }
 
 namespace {

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -86,7 +86,8 @@ static void addIndirectValueParameterAttributes(IRGenModule &IGM,
   // The parameter must reference dereferenceable memory of the type.
   addDereferenceableAttributeToBuilder(IGM, b, ti);
 
-  attrs = attrs.addAttributes(IGM.LLVMContext, argIndex+1, b);
+  attrs = attrs.addAttributes(IGM.LLVMContext,
+                              argIndex + llvm::AttributeList::FirstArgIndex, b);
 }
 
 static void addInoutParameterAttributes(IRGenModule &IGM,
@@ -101,7 +102,8 @@ static void addInoutParameterAttributes(IRGenModule &IGM,
   // The inout must reference dereferenceable memory of the type.
   addDereferenceableAttributeToBuilder(IGM, b, ti);
 
-  attrs = attrs.addAttributes(IGM.LLVMContext, argIndex+1, b);
+  attrs = attrs.addAttributes(IGM.LLVMContext,
+                              argIndex + llvm::AttributeList::FirstArgIndex, b);
 }
 
 static llvm::CallingConv::ID getFreestandingConvention(IRGenModule &IGM) {
@@ -137,7 +139,9 @@ static void addIndirectResultAttributes(IRGenModule &IGM,
   b.addAttribute(llvm::Attribute::NoCapture);
   if (allowSRet)
     b.addAttribute(llvm::Attribute::StructRet);
-  attrs = attrs.addAttributes(IGM.LLVMContext, paramIndex + 1, b);
+  attrs = attrs.addAttributes(IGM.LLVMContext,
+                              paramIndex + llvm::AttributeList::FirstArgIndex,
+                              b);
 }
 
 void IRGenModule::addSwiftSelfAttributes(llvm::AttributeList &attrs,
@@ -146,7 +150,8 @@ void IRGenModule::addSwiftSelfAttributes(llvm::AttributeList &attrs,
     return;
   llvm::AttrBuilder b;
   b.addAttribute(llvm::Attribute::SwiftSelf);
-  attrs = attrs.addAttributes(this->LLVMContext, argIndex + 1, b);
+  attrs = attrs.addAttributes(this->LLVMContext,
+                              argIndex + llvm::AttributeList::FirstArgIndex, b);
 }
 
 void IRGenModule::addSwiftErrorAttributes(llvm::AttributeList &attrs,
@@ -160,7 +165,8 @@ void IRGenModule::addSwiftErrorAttributes(llvm::AttributeList &attrs,
 
   llvm::AttrBuilder b;
   b.addAttribute(llvm::Attribute::SwiftError);
-  attrs = attrs.addAttributes(this->LLVMContext, argIndex + 1, b);
+  attrs = attrs.addAttributes(this->LLVMContext,
+                              argIndex + llvm::AttributeList::FirstArgIndex, b);
 }
 
 void irgen::addByvalArgumentAttributes(IRGenModule &IGM,
@@ -170,7 +176,8 @@ void irgen::addByvalArgumentAttributes(IRGenModule &IGM,
   b.addAttribute(llvm::Attribute::ByVal);
   b.addAttribute(llvm::Attribute::getWithAlignment(IGM.LLVMContext,
                                                    align.getValue()));
-  attrs = attrs.addAttributes(IGM.LLVMContext, argIndex+1, b);
+  attrs = attrs.addAttributes(IGM.LLVMContext,
+                              argIndex + llvm::AttributeList::FirstArgIndex, b);
 }
 
 void irgen::addExtendAttribute(IRGenModule &IGM, llvm::AttributeList &attrs,
@@ -908,7 +915,8 @@ llvm::Type *SignatureExpansion::expandExternalSignatureTypes() {
       bool signExt = paramTys[i]->hasSignedIntegerRepresentation();
       assert((signExt || paramTys[i]->hasUnsignedIntegerRepresentation()) &&
              "Invalid attempt to add extension attribute to argument!");
-      addExtendAttribute(IGM, Attrs, getCurParamIndex()+1, signExt);
+      addExtendAttribute(IGM, Attrs, getCurParamIndex() +
+                         llvm::AttributeList::FirstArgIndex, signExt);
       LLVM_FALLTHROUGH;
     }
     case clang::CodeGen::ABIArgInfo::Direct: {
@@ -1469,7 +1477,8 @@ void CallEmission::setFromCallee() {
     // TODO: Add swift_error attribute.
     assert(LastArgWritten > 0);
     Args[--LastArgWritten] = errorResultSlot.getAddress();
-    addAttribute(LastArgWritten + 1, llvm::Attribute::NoCapture);
+    addAttribute(LastArgWritten + llvm::AttributeList::FirstArgIndex,
+                 llvm::Attribute::NoCapture);
     IGF.IGM.addSwiftErrorAttributes(Attrs, LastArgWritten);
 
     // Fill in the context pointer if necessary.

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -484,7 +484,7 @@ void IRGenModule::emitSourceFile(SourceFile &SF, unsigned StartElem) {
 ///
 /// We use this when Clang code generation might populate the list.
 static void collectGlobalList(IRGenModule &IGM,
-                              SmallVectorImpl<llvm::WeakVH> &list,
+                              SmallVectorImpl<llvm::WeakTrackingVH> &list,
                               StringRef name) {
   if (auto *existing = IGM.Module.getGlobalVariable(name)) {
     auto *globals = cast<llvm::ConstantArray>(existing->getInitializer());
@@ -496,7 +496,7 @@ static void collectGlobalList(IRGenModule &IGM,
   }
 
   std::for_each(list.begin(), list.end(),
-                [](const llvm::WeakVH &global) {
+                [](const llvm::WeakTrackingVH &global) {
     assert(!isa<llvm::GlobalValue>(global) ||
            !cast<llvm::GlobalValue>(global)->isDeclaration() &&
            "all globals in the 'used' list must be definitions");
@@ -507,7 +507,7 @@ static void collectGlobalList(IRGenModule &IGM,
 /// list of values.  Generally these lists are for various LLVM
 /// metadata or runtime purposes.
 static llvm::GlobalVariable *
-emitGlobalList(IRGenModule &IGM, ArrayRef<llvm::WeakVH> handles,
+emitGlobalList(IRGenModule &IGM, ArrayRef<llvm::WeakTrackingVH> handles,
                StringRef name, StringRef section,
                llvm::GlobalValue::LinkageTypes linkage,
                llvm::Type *eltTy,
@@ -648,7 +648,7 @@ void IRGenModule::emitRuntimeRegistration() {
       }
     }
     
-    for (llvm::WeakVH &ObjCClass : ObjCClasses) {
+    for (llvm::WeakTrackingVH &ObjCClass : ObjCClasses) {
       RegIGF.Builder.CreateCall(getInstantiateObjCClassFn(), {ObjCClass});
     }
       

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1514,12 +1514,12 @@ llvm::Function *swift::irgen::createFunction(IRGenModule &IGM,
     IGM.Module.getFunctionList().push_back(fn);
  }
 
-  auto initialAttrs = IGM.constructInitialAttributes();
-  // Merge initialAttrs with attrs.
-  auto updatedAttrs = attrs.addAttributes(
-      IGM.getLLVMContext(), llvm::AttributeList::FunctionIndex, initialAttrs);
-  if (!updatedAttrs.isEmpty())
-    fn->setAttributes(updatedAttrs);
+  if (!attrs.isEmpty())
+    fn->setAttributes(attrs);
+  // Merge initial attributes with attrs.
+  llvm::AttrBuilder b;
+  IGM.constructInitialFnAttributes(b);
+  fn->addAttributes(llvm::AttributeList::FunctionIndex, b);
 
   // Everything externally visible is considered used in Swift.
   // That mostly means we need to be good at not marking things external.

--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -728,11 +728,11 @@ static llvm::Function *emitPartialApplicationForwarder(
   fwd->setCallingConv(
       expandCallingConv(IGM, SILFunctionTypeRepresentation::Thick));
 
-  auto initialAttrs = IGM.constructInitialAttributes();
-  // Merge initialAttrs with outAttrs.
-  auto updatedAttrs = outAttrs.addAttributes(
-      IGM.getLLVMContext(), llvm::AttributeList::FunctionIndex, initialAttrs);
-  fwd->setAttributes(updatedAttrs);
+  fwd->setAttributes(outAttrs);
+  // Merge initial attributes with outAttrs.
+  llvm::AttrBuilder b;
+  IGM.constructInitialFnAttributes(b);
+  fwd->addAttributes(llvm::AttributeList::FunctionIndex, b);
 
   IRGenFunction subIGF(IGM, fwd);
   if (IGM.DebugInfo)

--- a/lib/IRGen/GenObjC.cpp
+++ b/lib/IRGen/GenObjC.cpp
@@ -774,11 +774,11 @@ static llvm::Function *emitObjCPartialApplicationForwarder(IRGenModule &IGM,
   fwd->setCallingConv(
       expandCallingConv(IGM, SILFunctionTypeRepresentation::Thick));
 
-  auto initialAttrs = IGM.constructInitialAttributes();
-  // Merge initialAttrs with attrs.
-  auto updatedAttrs = attrs.addAttributes(
-      IGM.getLLVMContext(), llvm::AttributeList::FunctionIndex, initialAttrs);
-  fwd->setAttributes(updatedAttrs);
+  fwd->setAttributes(attrs);
+  // Merge initial attributes with attrs.
+  llvm::AttrBuilder b;
+  IGM.constructInitialFnAttributes(b);
+  fwd->addAttributes(llvm::AttributeList::FunctionIndex, b);
   
   IRGenFunction subIGF(IGM, fwd);
   if (IGM.DebugInfo)

--- a/lib/IRGen/GenOpaque.cpp
+++ b/lib/IRGen/GenOpaque.cpp
@@ -352,16 +352,12 @@ static void setHelperAttributesForAggResult(llvm::CallInst *call,
   auto attrs = llvm::AttributeList::get(call->getContext(),
                                         llvm::AttributeList::FunctionIndex,
                                         llvm::Attribute::NoUnwind);
-
-  attrs = attrs.addAttribute(call->getContext(), 1, llvm::Attribute::NoAlias);
+  call->setAttributes(attrs);
+  call->addParamAttr(0, llvm::Attribute::NoAlias);
 
   // Only set 'sret' if this is also the formal result.
-  if (isFormalResult) {
-    attrs = attrs.addAttribute(call->getContext(), 1,
-                               llvm::Attribute::StructRet);
-  }
-
-  call->setAttributes(attrs);
+  if (isFormalResult)
+    call->addParamAttr(0, llvm::Attribute::StructRet);
 }
 
 /// Given a call to a helper function, set attributes appropriately.

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -902,6 +902,7 @@ public:
   /// invalid.
   bool finalize();
 
+  void constructInitialFnAttributes(llvm::AttrBuilder &Attrs);
   llvm::AttributeList constructInitialAttributes();
 
   void emitProtocolDecl(ProtocolDecl *D);

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -713,7 +713,7 @@ private:
   /// present in the object file; bitcast to i8*. This is used for
   /// forcing visibility of symbols which may otherwise be optimized
   /// out.
-  SmallVector<llvm::WeakVH, 4> LLVMUsed;
+  SmallVector<llvm::WeakTrackingVH, 4> LLVMUsed;
 
   /// LLVMCompilerUsed - List of global values which are required to be
   /// present in the object file; bitcast to i8*. This is used for
@@ -721,7 +721,7 @@ private:
   /// out.
   ///
   /// Similar to LLVMUsed, but emitted as llvm.compiler.used.
-  SmallVector<llvm::WeakVH, 4> LLVMCompilerUsed;
+  SmallVector<llvm::WeakTrackingVH, 4> LLVMCompilerUsed;
 
   /// Metadata nodes for autolinking info.
   ///
@@ -730,12 +730,12 @@ private:
   SmallVector<llvm::Metadata *, 32> AutolinkEntries;
 
   /// List of Objective-C classes, bitcast to i8*.
-  SmallVector<llvm::WeakVH, 4> ObjCClasses;
+  SmallVector<llvm::WeakTrackingVH, 4> ObjCClasses;
   /// List of Objective-C classes that require nonlazy realization, bitcast to
   /// i8*.
-  SmallVector<llvm::WeakVH, 4> ObjCNonLazyClasses;
+  SmallVector<llvm::WeakTrackingVH, 4> ObjCNonLazyClasses;
   /// List of Objective-C categories, bitcast to i8*.
-  SmallVector<llvm::WeakVH, 4> ObjCCategories;
+  SmallVector<llvm::WeakTrackingVH, 4> ObjCCategories;
   /// List of protocol conformances to generate records for.
   SmallVector<NormalProtocolConformance *, 4> ProtocolConformances;
   /// List of nominal types to generate type metadata records for.
@@ -748,10 +748,10 @@ private:
   /// The interesting global variables relating to an ObjC protocol.
   struct ObjCProtocolPair {
     /// The global variable that contains the protocol record.
-    llvm::WeakVH record;
+    llvm::WeakTrackingVH record;
     /// The global variable that contains the indirect reference to the
     /// protocol record.
-    llvm::WeakVH ref;
+    llvm::WeakTrackingVH ref;
   };
 
   llvm::DenseMap<ProtocolDecl*, ObjCProtocolPair> ObjCProtocols;

--- a/lib/LLVMPasses/LLVMARCOpts.cpp
+++ b/lib/LLVMPasses/LLVMARCOpts.cpp
@@ -651,7 +651,9 @@ static DtorKind analyzeDestructor(Value *P) {
 
       // Okay, the function has some side effects, if it doesn't capture the
       // object argument, at least that is something.
-      return DtorFn->doesNotCapture(0) ? DtorKind::NoEscape : DtorKind::Unknown;
+      return DtorFn->hasAttribute(llvm::AttributeList::ReturnIndex,
+                                  llvm::Attribute::NoCapture) ?
+        DtorKind::NoEscape : DtorKind::Unknown;
     }
   }
 

--- a/lib/LLVMPasses/LLVMMergeFunctions.cpp
+++ b/lib/LLVMPasses/LLVMMergeFunctions.cpp
@@ -367,7 +367,7 @@ private:
 
   /// A work queue of functions that may have been modified and should be
   /// analyzed again.
-  std::vector<WeakVH> Deferred;
+  std::vector<WeakTrackingVH> Deferred;
 
   /// The set of all distinct functions. Use the insert() and remove() methods
   /// to modify it. The map allows efficient lookup and deferring of Functions.
@@ -390,7 +390,7 @@ private:
 
   /// Checks the rules of order relation introduced among functions set.
   /// Returns true, if sanity check has been passed, and false if failed.
-  bool doSanityCheck(std::vector<WeakVH> &Worklist);
+  bool doSanityCheck(std::vector<WeakTrackingVH> &Worklist);
 
   /// Updates the numUnhandledCallees of all user functions of the equivalence
   /// class containing \p FE by \p Delta.
@@ -435,7 +435,7 @@ llvm::ModulePass *swift::createSwiftMergeFunctionsPass() {
   return new SwiftMergeFunctions();
 }
 
-bool SwiftMergeFunctions::doSanityCheck(std::vector<WeakVH> &Worklist) {
+bool SwiftMergeFunctions::doSanityCheck(std::vector<WeakTrackingVH> &Worklist) {
   if (const unsigned Max = NumFunctionsForSanityCheck) {
     unsigned TripleNumber = 0;
     bool Valid = true;
@@ -443,10 +443,12 @@ bool SwiftMergeFunctions::doSanityCheck(std::vector<WeakVH> &Worklist) {
     dbgs() << "MERGEFUNC-SANITY: Started for first " << Max << " functions.\n";
 
     unsigned i = 0;
-    for (std::vector<WeakVH>::iterator I = Worklist.begin(), E = Worklist.end();
+    for (std::vector<WeakTrackingVH>::iterator I = Worklist.begin(),
+                                               E = Worklist.end();
          I != E && i < Max; ++I, ++i) {
       unsigned j = i;
-      for (std::vector<WeakVH>::iterator J = I; J != E && j < Max; ++J, ++j) {
+      for (std::vector<WeakTrackingVH>::iterator J = I; J != E && j < Max;
+           ++J, ++j) {
         Function *F1 = cast<Function>(*I);
         Function *F2 = cast<Function>(*J);
         int Res1 = SwiftFunctionComparator(F1, F2, &GlobalNumbers).
@@ -467,7 +469,7 @@ bool SwiftMergeFunctions::doSanityCheck(std::vector<WeakVH> &Worklist) {
           continue;
 
         unsigned k = j;
-        for (std::vector<WeakVH>::iterator K = J; K != E && k < Max;
+        for (std::vector<WeakTrackingVH>::iterator K = J; K != E && k < Max;
              ++k, ++K, ++TripleNumber) {
           if (K == J)
             continue;
@@ -585,12 +587,12 @@ bool SwiftMergeFunctions::runOnModule(Module &M) {
     // consider merging it. Otherwise it is dropped and never considered again.
     if ((I != S && std::prev(I)->first == I->first) ||
         (std::next(I) != IE && std::next(I)->first == I->first) ) {
-      Deferred.push_back(WeakVH(F));
+      Deferred.push_back(WeakTrackingVH(F));
     }
   }
 
   do {
-    std::vector<WeakVH> Worklist;
+    std::vector<WeakTrackingVH> Worklist;
     Deferred.swap(Worklist);
 
     DEBUG(dbgs() << "======\nbuild tree: worklist-size=" << Worklist.size() <<
@@ -600,7 +602,7 @@ bool SwiftMergeFunctions::runOnModule(Module &M) {
     SmallVector<FunctionEntry *, 8> FuncsToMerge;
 
     // Insert all candidates into the Worklist.
-    for (WeakVH &I : Worklist) {
+    for (WeakTrackingVH &I : Worklist) {
       if (!I)
         continue;
       Function *F = cast<Function>(I);

--- a/lib/LLVMPasses/LLVMMergeFunctions.cpp
+++ b/lib/LLVMPasses/LLVMMergeFunctions.cpp
@@ -600,10 +600,10 @@ bool SwiftMergeFunctions::runOnModule(Module &M) {
     SmallVector<FunctionEntry *, 8> FuncsToMerge;
 
     // Insert all candidates into the Worklist.
-    for (std::vector<WeakVH>::iterator I = Worklist.begin(),
-           E = Worklist.end(); I != E; ++I) {
-      if (!*I) continue;
-      Function *F = cast<Function>(*I);
+    for (WeakVH &I : Worklist) {
+      if (!I)
+        continue;
+      Function *F = cast<Function>(I);
       FunctionEntry *FE = getEntry(F);
       assert(!isInEquivalenceClass(FE));
 


### PR DESCRIPTION
There were several LLVM changes recently that broke Swift's master-next branch. This PR includes fixes for most of them. There is one change that I think should go to master. With those changes, I am able build for macOS and run the tests, but there are still a bunch of unexpected failures.