### PR TITLE
Remove the ZExt attribute for the MakeBoxUnique runtime function.

### DIFF
--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -61,7 +61,7 @@ FUNCTION(MakeBoxUnique,
          DefaultCC,
          RETURNS(RefCountedPtrTy, OpaquePtrTy),
          ARGS(OpaquePtrTy, TypeMetadataPtrTy, SizeTy),
-         ATTRS(NoUnwind, ZExt))
+         ATTRS(NoUnwind))
 
 FUNCTION(DeallocBox, swift_deallocBox, DefaultCC,
          RETURNS(VoidTy),


### PR DESCRIPTION
The IR verifier in recent versions of LLVM (used with the master-next branch)
complains about a ZExt attribute used with a non-integer type, and it does
not make sense to zero-extend the return value of MakeBoxUnique, which is
a pair of pointers.