### PR TITLE
[cursor-info] Add a way to opt out of automatic request cancellation

### DIFF
--- a/test/SourceKit/CursorInfo/cursor_no_cancel.swift
+++ b/test/SourceKit/CursorInfo/cursor_no_cancel.swift
@@ -1,0 +1,46 @@
+func myFunc() {
+  _ = 1
+}
+
+// Perform 8 concurrent cursor infos, which is often enough to cause
+// contention.  We disable printing the requests to minimize delay.
+
+// RUN: %sourcekitd-test \
+// RUN:      -async -dont-print-request -cancel-on-subsequent-request=0 -req=cursor -pos=1:6 %s -- %s \
+// RUN:   == -async -dont-print-request -cancel-on-subsequent-request=0 -req=cursor -pos=1:6 %s -- %s \
+// RUN:   == -async -dont-print-request -cancel-on-subsequent-request=0 -req=cursor -pos=1:6 %s -- %s \
+// RUN:   == -async -dont-print-request -cancel-on-subsequent-request=0 -req=cursor -pos=1:6 %s -- %s \
+// RUN:   == -async -dont-print-request -cancel-on-subsequent-request=0 -req=cursor -pos=1:6 %s -- %s \
+// RUN:   == -async -dont-print-request -cancel-on-subsequent-request=0 -req=cursor -pos=1:6 %s -- %s \
+// RUN:   == -async -dont-print-request -cancel-on-subsequent-request=0 -req=cursor -pos=1:6 %s -- %s \
+// RUN:   == -async -dont-print-request -cancel-on-subsequent-request=0 -req=cursor -pos=1:6 %s -- %s 2>&1 \
+// RUN:   | %FileCheck %s -implicit-check-not='Request Cancel'
+
+// CHECK: source.lang.swift.decl.function.free
+// CHECK: source.lang.swift.decl.function.free
+// CHECK: source.lang.swift.decl.function.free
+// CHECK: source.lang.swift.decl.function.free
+// CHECK: source.lang.swift.decl.function.free
+// CHECK: source.lang.swift.decl.function.free
+// CHECK: source.lang.swift.decl.function.free
+// CHECK: source.lang.swift.decl.function.free
+
+// RUN: %sourcekitd-test \
+// RUN:      -async -dont-print-request -cancel-on-subsequent-request=0 -req=range -pos=2:3 -length=5 %s -- %s \
+// RUN:   == -async -dont-print-request -cancel-on-subsequent-request=0 -req=range -pos=2:3 -length=5 %s -- %s \
+// RUN:   == -async -dont-print-request -cancel-on-subsequent-request=0 -req=range -pos=2:3 -length=5 %s -- %s \
+// RUN:   == -async -dont-print-request -cancel-on-subsequent-request=0 -req=range -pos=2:3 -length=5 %s -- %s \
+// RUN:   == -async -dont-print-request -cancel-on-subsequent-request=0 -req=range -pos=2:3 -length=5 %s -- %s \
+// RUN:   == -async -dont-print-request -cancel-on-subsequent-request=0 -req=range -pos=2:3 -length=5 %s -- %s \
+// RUN:   == -async -dont-print-request -cancel-on-subsequent-request=0 -req=range -pos=2:3 -length=5 %s -- %s \
+// RUN:   == -async -dont-print-request -cancel-on-subsequent-request=0 -req=range -pos=2:3 -length=5 %s -- %s 2>&1 \
+// RUN:   | %FileCheck %s -check-prefix=RANGE -implicit-check-not='Request Cancel'
+
+// RANGE: source.lang.swift.range.singleexpression
+// RANGE: source.lang.swift.range.singleexpression
+// RANGE: source.lang.swift.range.singleexpression
+// RANGE: source.lang.swift.range.singleexpression
+// RANGE: source.lang.swift.range.singleexpression
+// RANGE: source.lang.swift.range.singleexpression
+// RANGE: source.lang.swift.range.singleexpression
+// RANGE: source.lang.swift.range.singleexpression

--- a/tools/SourceKit/docs/Protocol.md
+++ b/tools/SourceKit/docs/Protocol.md
@@ -635,6 +635,10 @@ To gather documentation, SourceKit must be given either the name of a module (ke
     [opt] <key.compilerargs>: [string*] // Array of zero or more strings for the compiler arguments,
                                         // e.g ["-sdk", "/path/to/sdk"]. If key.sourcefile is provided,
                                         // these must include the path to that file.
+    [opt] <key.cancel_on_subsequent_request>: (int64) // Whether this request should be canceled if a
+                                        // new cursor-info request is made that uses the same AST.
+                                        // This behaviour is a workaround for not having first-class
+                                        // cancelation. For backwards compatibility, the default is 1.
 }
 ```
 

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -475,6 +475,7 @@ public:
 
   virtual void getCursorInfo(StringRef Filename, unsigned Offset,
                              unsigned Length, bool Actionables,
+                             bool CancelOnSubsequentRequest,
                              ArrayRef<const char *> Args,
                           std::function<void(const CursorInfo &)> Receiver) = 0;
 
@@ -485,16 +486,19 @@ public:
                 std::function<void(const NameTranslatingInfo &)> Receiver) = 0;
 
   virtual void getRangeInfo(StringRef Filename, unsigned Offset, unsigned Length,
+                            bool CancelOnSubsequentRequest,
                             ArrayRef<const char *> Args,
                             std::function<void(const RangeInfo&)> Receiver) = 0;
 
   virtual void
   getCursorInfoFromUSR(StringRef Filename, StringRef USR,
+                       bool CancelOnSubsequentRequest,
                        ArrayRef<const char *> Args,
                        std::function<void(const CursorInfo &)> Receiver) = 0;
 
   virtual void findRelatedIdentifiersInFile(StringRef Filename,
                                             unsigned Offset,
+                                            bool CancelOnSubsequentRequest,
                                             ArrayRef<const char *> Args,
                    std::function<void(const RelatedIdentsInfo &)> Receiver) = 0;
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -389,6 +389,7 @@ public:
 
   void getCursorInfo(StringRef Filename, unsigned Offset,
                      unsigned Length, bool Actionables,
+                     bool CancelOnSubsequentRequest,
                      ArrayRef<const char *> Args,
                      std::function<void(const CursorInfo &)> Receiver) override;
 
@@ -398,14 +399,16 @@ public:
                    std::function<void(const NameTranslatingInfo &)> Receiver) override;
 
   void getRangeInfo(StringRef Filename, unsigned Offset, unsigned Length,
-                    ArrayRef<const char *> Args,
+                    bool CancelOnSubsequentRequest, ArrayRef<const char *> Args,
                     std::function<void(const RangeInfo&)> Receiver) override;
 
   void getCursorInfoFromUSR(
-      StringRef Filename, StringRef USR, ArrayRef<const char *> Args,
+      StringRef Filename, StringRef USR, bool CancelOnSubsequentRequest,
+      ArrayRef<const char *> Args,
       std::function<void(const CursorInfo &)> Receiver) override;
 
   void findRelatedIdentifiersInFile(StringRef Filename, unsigned Offset,
+                                    bool CancelOnSubsequentRequest,
                                     ArrayRef<const char *> Args,
               std::function<void(const RelatedIdentsInfo &)> Receiver) override;
 

--- a/tools/SourceKit/tools/sourcekitd-test/Options.td
+++ b/tools/SourceKit/tools/sourcekitd-test/Options.td
@@ -106,6 +106,11 @@ def objc_name : Separate<["-"], "objc-name">,
 def objc_selector : Separate<["-"], "objc-selector">,
   HelpText<"Objective-C selector name to translate from">;
 
+def cancel_on_subsequent_request : Separate<["-"], "cancel-on-subsequent-request">,
+  HelpText<"Whether to cancel if there is a subsequent request using the same AST">;
+def cancel_on_subsequent_request_EQ : Joined<["-"], "cancel-on-subsequent-request=">,
+  Alias<cancel_on_subsequent_request>;
+
 def help : Flag<["-", "--"], "help">,
   HelpText<"Display available options">;
 

--- a/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
@@ -292,6 +292,15 @@ bool TestOptions::parseArgs(llvm::ArrayRef<const char *> Args) {
       ObjCSelector = InputArg->getValue();
       break;
 
+    case OPT_cancel_on_subsequent_request:
+      unsigned Cancel;
+      if (StringRef(InputArg->getValue()).getAsInteger(10, Cancel)) {
+        llvm::errs() << "error: expected integer for 'cancel-on-subsequent-request'\n";
+        return true;
+      }
+      CancelOnSubsequentRequest = Cancel;
+      break;
+
     case OPT_UNKNOWN:
       llvm::errs() << "error: unknown argument: "
                    << InputArg->getAsString(ParsedArgs) << '\n'

--- a/tools/SourceKit/tools/sourcekitd-test/TestOptions.h
+++ b/tools/SourceKit/tools/sourcekitd-test/TestOptions.h
@@ -90,6 +90,7 @@ struct TestOptions {
   bool SynthesizedExtensions = false;
   bool CollectActionables = false;
   bool isAsyncRequest = false;
+  llvm::Optional<bool> CancelOnSubsequentRequest;
   bool parseArgs(llvm::ArrayRef<const char *> Args);
   void printHelp(bool ShowHidden) const;
 };

--- a/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
@@ -141,6 +141,7 @@ static sourcekitd_uid_t KeyArgNames;
 static sourcekitd_uid_t KeySelectorPieces;
 static sourcekitd_uid_t KeyNameKind;
 static sourcekitd_uid_t KeySwiftVersion;
+static sourcekitd_uid_t KeyCancelOnSubsequentRequest;
 
 static sourcekitd_uid_t RequestProtocolVersion;
 static sourcekitd_uid_t RequestDemangle;
@@ -273,6 +274,7 @@ static int skt_main(int argc, const char **argv) {
   KeyNameKind = sourcekitd_uid_get_from_cstr("key.namekind");
 
   KeySwiftVersion = sourcekitd_uid_get_from_cstr("key.swift_version");
+  KeyCancelOnSubsequentRequest = sourcekitd_uid_get_from_cstr("key.cancel_on_subsequent_request");
 
   SemaDiagnosticStage = sourcekitd_uid_get_from_cstr("source.diagnostic.stage.swift.sema");
 
@@ -827,6 +829,10 @@ static int handleTestInvocation(ArrayRef<const char *> Args,
   if (!Opts.HeaderPath.empty()) {
     sourcekitd_request_dictionary_set_string(Req, KeyFilePath,
                                              Opts.HeaderPath.c_str());
+  }
+  if (Opts.CancelOnSubsequentRequest.hasValue()) {
+    sourcekitd_request_dictionary_set_int64(Req, KeyCancelOnSubsequentRequest,
+                                            *Opts.CancelOnSubsequentRequest);
   }
 
   if (Opts.SwiftVersion.hasValue()) {

--- a/tools/SourceKit/tools/sourcekitd/lib/API/DictionaryKeys.h
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/DictionaryKeys.h
@@ -125,6 +125,7 @@ extern SourceKit::UIdent KeyContainerTypeUsr;
 extern SourceKit::UIdent KeyModuleGroups;
 
 extern SourceKit::UIdent KeyRangeContent;
+extern SourceKit::UIdent KeyCancelOnSubsequentRequest;
 
 extern SourceKit::UIdent KeyBaseName;
 extern SourceKit::UIdent KeyArgNames;

--- a/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-Common.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-Common.cpp
@@ -124,6 +124,7 @@ UIdent sourcekitd::KeyUnpopular("key.unpopular");
 UIdent sourcekitd::KeyHide("key.hide");
 UIdent sourcekitd::KeySimplified("key.simplified");
 UIdent sourcekitd::KeyRangeContent("key.rangecontent");
+UIdent sourcekitd::KeyCancelOnSubsequentRequest("key.cancel_on_subsequent_request");
 
 UIdent sourcekitd::KeyIsDeprecated("key.is_deprecated");
 UIdent sourcekitd::KeyIsUnavailable("key.is_unavailable");

--- a/unittests/SourceKit/SwiftLang/CursorInfoTest.cpp
+++ b/unittests/SourceKit/SwiftLang/CursorInfoTest.cpp
@@ -134,7 +134,7 @@ public:
     Semaphore sema(0);
 
     TestCursorInfo TestInfo;
-    getLang().getCursorInfo(DocName, Offset, 0, false, Args,
+    getLang().getCursorInfo(DocName, Offset, 0, false, false, Args,
       [&](const CursorInfo &Info) {
         TestInfo.Name = Info.Name;
         TestInfo.Typename = Info.TypeName;


### PR DESCRIPTION
The OncePerASTToken machinery lets us automatically cancel "stale"
requests after a new one comes in.  This avoid wasting time processing
requests that have been superceded, which is common for cursor-info, but
sometimes you really want to get results even later, so this commit adds
a way to opt out of the cancellation.

Incidentally, disable cancellation of name translation, which doesn't
really make sense and no one should be relying on that.

rdar://problem/31905379
