### PR TITLE
[swift-4.0-branch][stdlib] Bounds check in String subscript fast path

### DIFF
--- a/stdlib/public/core/StringCharacterView.swift
+++ b/stdlib/public/core/StringCharacterView.swift
@@ -445,7 +445,14 @@ extension String.CharacterView : BidirectionalCollection {
       let relativeOffset = i._base._position - _coreOffset
       if _core.isASCII {
         let asciiBuffer = _core.asciiBuffer._unsafelyUnwrappedUnchecked
-        return Character(UnicodeScalar(asciiBuffer[relativeOffset]))
+        // Bounds checks in an UnsafeBufferPointer (asciiBuffer) are only
+        // performed in Debug mode, so they need to be duplicated here.
+        // Falling back to the non-optimal behavior in the case they don't
+        // pass.
+        if relativeOffset >= asciiBuffer.startIndex &&
+          relativeOffset < asciiBuffer.endIndex {
+          return Character(UnicodeScalar(asciiBuffer[relativeOffset]))
+        }
       } else if _core._baseAddress != nil {
         let cu = _core._nthContiguous(relativeOffset)
         // Only constructible if sub-surrogate

--- a/validation-test/stdlib/String.swift
+++ b/validation-test/stdlib/String.swift
@@ -192,9 +192,7 @@ StringTests.test("ForeignIndexes/UnexpectedCrash")
   expectEqual("a", acceptor[donor.startIndex])
 }
 
-StringTests.test("ForeignIndexes/subscript(Index)/OutOfBoundsTrap")
-  .skip(.always("<rdar://problem/31992473>"))
-  .code {
+StringTests.test("ForeignIndexes/subscript(Index)/OutOfBoundsTrap") {
   let donor = "abcdef"
   let acceptor = "uvw"
 


### PR DESCRIPTION
UnsafeBufferPoiunter subscript used in the fast path only checks bounds
in Debug mode, therefore extra checks are needed.

Addresses: <rdar://problem/31992473>

* Explanation: Introduced fastPath did not implement necessary bounds checks in release mode
* Scope of Issue: Without the fix, access past the end of string does not trap in certain circumstances
* Risk: Minimal
* Reviewed By: Michael Ilseman
* Testing: Automated test suite
* Directions for QA: N/A
* Radar: <rdar://problem/32026958>