### PR TITLE
Merge pull request #9393 from shajrawi/arg_param_mismatch

### DIFF
--- a/test/IRGen/big_types_corner_cases.swift
+++ b/test/IRGen/big_types_corner_cases.swift
@@ -12,6 +12,32 @@ public struct BigStruct {
   var i8 : Int32 = 8
 }
 
+func takeClosure(execute block: () -> Void) {
+}
+
+class OptionalInoutFuncType {
+  private var lp :  BigStruct?
+  private var _handler : ((BigStruct?, Error?) -> ())?
+
+  func execute(_ error: Error?) {
+    var p : BigStruct?
+    var handler: ((BigStruct?, Error?) -> ())?
+    
+    takeClosure {
+      p = self.lp
+      handler = self._handler
+      self._handler = nil
+    }
+
+    handler?(p, error)
+  }
+}
+
+// CHECK-LABEL: define{{( protected)?}} internal swiftcc void @_T022big_types_corner_cases21OptionalInoutFuncTypeC7executeys5Error_pSgFyycfU_(%T22big_types_corner_cases9BigStructVSg* nocapture dereferenceable({{.*}}), %T22big_types_corner_cases21OptionalInoutFuncTypeC*, %T22big_types_corner_cases9BigStructVSgs5Error_pSgIxcx_Sg* nocapture dereferenceable({{.*}})
+// CHECK: call void @_T0SqWy
+// CHECK: call void @_T0SqWe
+// CHECK: ret void
+
 public func f1_returns_BigType(_ x: BigStruct) -> BigStruct {
   return x
 }


### PR DESCRIPTION
radar rdar://problem/32027045 
cherry-pick of PR  https://github.com/apple/swift/pull/9393 into Swift 4.0 branch

• Explanation: Fixes an issue in the large loadable types module pass: given an inout optional function type argument, for which the function signature has changed, we mistakenly treated it the transformed type as an object type instead of address type
• Scope of Issue: This is a Mandatory pass. Can affect any user of Swift 4.0 if their code contains this pattern.
• Risk: Low
• Reviewed By: Arnold Schwaighofer
• Testing: test case from radar now compile and verify correctly, PR testing on Master branch
• Directions for QE: Compile the test case attached to rdar://problem/32027045 , make sure -sil-verify-all is set for extra testing / sanity check.