### PR TITLE
[AST] Eliminate IfConfigStmt

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -44,6 +44,7 @@ namespace swift {
   class GenericEnvironment;
   class ArchetypeType;
   class ASTContext;
+  struct ASTNode;
   class ASTPrinter;
   class ASTWalker;
   class ConstructorDecl;
@@ -2023,34 +2024,33 @@ public:
   }
 };
 
-/// IfConfigDecl - This class represents the declaration-side representation of
-/// #if/#else/#endif blocks. Active and inactive block members are stored
-/// separately, with the intention being that active members will be handed
-/// back to the enclosing declaration.
+/// IfConfigDecl - This class represents #if/#else/#endif blocks.
+/// Active and inactive block members are stored separately, with the intention
+/// being that active members will be handed back to the enclosing context.
 class IfConfigDecl : public Decl {
   /// An array of clauses controlling each of the #if/#elseif/#else conditions.
   /// The array is ASTContext allocated.
-  ArrayRef<IfConfigClause<Decl *>> Clauses;
+  ArrayRef<IfConfigClause> Clauses;
   SourceLoc EndLoc;
 public:
   
-  IfConfigDecl(DeclContext *Parent, ArrayRef<IfConfigClause<Decl *>> Clauses,
+  IfConfigDecl(DeclContext *Parent, ArrayRef<IfConfigClause> Clauses,
                SourceLoc EndLoc, bool HadMissingEnd)
     : Decl(DeclKind::IfConfig, Parent), Clauses(Clauses), EndLoc(EndLoc)
   {
     IfConfigDeclBits.HadMissingEnd = HadMissingEnd;
   }
 
-  ArrayRef<IfConfigClause<Decl *>> getClauses() const { return Clauses; }
+  ArrayRef<IfConfigClause> getClauses() const { return Clauses; }
 
   /// Return the active clause, or null if there is no active one.
-  const IfConfigClause<Decl *> *getActiveClause() const {
+  const IfConfigClause *getActiveClause() const {
     for (auto &Clause : Clauses)
       if (Clause.isActive) return &Clause;
     return nullptr;
   }
 
-  const ArrayRef<Decl*> getActiveMembers() const {
+  const ArrayRef<ASTNode> getActiveClauseElements() const {
     if (auto *Clause = getActiveClause())
       return Clause->Elements;
     return {};

--- a/include/swift/AST/IfConfigClause.h
+++ b/include/swift/AST/IfConfigClause.h
@@ -22,11 +22,11 @@
 namespace swift {
   class Expr;
   class SourceLoc;
+  struct ASTNode;
 
 /// This represents one part of a #if block.  If the condition field is
 /// non-null, then this represents a #if or a #elseif, otherwise it represents
 /// an #else block.
-template <typename ElemTy>
 struct IfConfigClause {
   /// The location of the #if, #elseif, or #else keyword.
   SourceLoc Loc;
@@ -36,13 +36,13 @@ struct IfConfigClause {
   Expr *Cond;
   
   /// Elements inside the clause
-  ArrayRef<ElemTy> Elements;
+  ArrayRef<ASTNode> Elements;
 
   /// True if this is the active clause of the #if block.
   bool isActive;
 
-  IfConfigClause<ElemTy>(SourceLoc Loc, Expr *Cond,
-                         ArrayRef<ElemTy> Elements, bool isActive)
+  IfConfigClause(SourceLoc Loc, Expr *Cond,
+                 ArrayRef<ASTNode> Elements, bool isActive)
     : Loc(Loc), Cond(Cond), Elements(Elements), isActive(isActive) {
   }
 };

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -279,7 +279,7 @@ struct PrintOptions {
   /// Print all decls that have at least this level of access.
   Accessibility AccessibilityFilter = Accessibility::Private;
 
-  /// Print IfConfigDecls and IfConfigStmts.
+  /// Print IfConfigDecls.
   bool PrintIfConfig = true;
 
   /// Whether we are printing for sil.

--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -655,46 +655,6 @@ public:
   static bool classof(const Stmt *S) { return S->getKind() == StmtKind::Guard; }
 };
 
-/// IfConfigStmt - This class models the statement-side representation of
-/// #if/#else/#endif blocks.
-class IfConfigStmt : public Stmt {
-  /// An array of clauses controlling each of the #if/#elseif/#else conditions.
-  /// The array is ASTContext allocated.
-  ArrayRef<IfConfigClause<ASTNode>> Clauses;
-  SourceLoc EndLoc;
-  bool HadMissingEnd;
-
-public:
-  IfConfigStmt(ArrayRef<IfConfigClause<ASTNode>> Clauses, SourceLoc EndLoc,
-               bool HadMissingEnd)
-  : Stmt(StmtKind::IfConfig, /*implicit=*/false),
-    Clauses(Clauses), EndLoc(EndLoc), HadMissingEnd(HadMissingEnd) {}
-  
-  SourceLoc getIfLoc() const { return Clauses[0].Loc; }
-
-  SourceLoc getStartLoc() const { return getIfLoc(); }
-  SourceLoc getEndLoc() const { return EndLoc; }
-
-  bool hadMissingEnd() const { return HadMissingEnd; }
-  
-  const ArrayRef<IfConfigClause<ASTNode>> &getClauses() const {
-    return Clauses;
-  }
-
-  ArrayRef<ASTNode> getActiveClauseElements() const {
-    for (auto &Clause : Clauses)
-      if (Clause.isActive)
-        return Clause.Elements;
-    return ArrayRef<ASTNode>();
-  }
-
-  // Implement isa/cast/dyncast/etc.
-  static bool classof(const Stmt *S) {
-    return S->getKind() == StmtKind::IfConfig;
-  }
-};
-
-  
 /// WhileStmt - while statement. After type-checking, the condition is of
 /// type Builtin.Int1.
 class WhileStmt : public LabeledConditionalStmt {

--- a/include/swift/AST/StmtNodes.def
+++ b/include/swift/AST/StmtNodes.def
@@ -61,7 +61,6 @@ STMT(Catch, Stmt)
 STMT(Break, Stmt)
 STMT(Continue, Stmt)
 STMT(Fallthrough, Stmt)
-STMT(IfConfig, Stmt)
 STMT(Fail, Stmt)
 STMT(Throw, Stmt)
 

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -716,9 +716,10 @@ public:
   ParserResult<TypeDecl> parseDeclAssociatedType(ParseDeclOptions Flags,
                                                  DeclAttributes &Attributes);
   
-  ParserResult<IfConfigDecl> parseDeclIfConfig(ParseDeclOptions Flags);
-  ParserResult<IfConfigDecl> parseStmtIfConfig(BraceItemListKind Kind
-                                                 = BraceItemListKind::Brace);
+  /// Parse a #if ... #endif directive.
+  /// Delegate callback function to parse elements in the blocks.
+  ParserResult<IfConfigDecl> parseIfConfig(
+    llvm::function_ref<void(SmallVectorImpl<ASTNode> &, bool)> parseElements);
 
   /// Parse a #line/#sourceLocation directive.
   /// 'isLine = true' indicates parsing #line instead of #sourcelocation

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -717,6 +717,9 @@ public:
                                                  DeclAttributes &Attributes);
   
   ParserResult<IfConfigDecl> parseDeclIfConfig(ParseDeclOptions Flags);
+  ParserResult<IfConfigDecl> parseStmtIfConfig(BraceItemListKind Kind
+                                                 = BraceItemListKind::Brace);
+
   /// Parse a #line/#sourceLocation directive.
   /// 'isLine = true' indicates parsing #line instead of #sourcelocation
   ParserStatus parseLineDirective(bool isLine = false);
@@ -1277,8 +1280,6 @@ public:
   ParserResult<PoundAvailableInfo> parseStmtConditionPoundAvailable();
   ParserResult<Stmt> parseStmtIf(LabeledStmtInfo LabelInfo);
   ParserResult<Stmt> parseStmtGuard();
-  ParserResult<Stmt> parseStmtIfConfig(BraceItemListKind Kind
-                                        = BraceItemListKind::Brace);
   ParserResult<Stmt> parseStmtWhile(LabeledStmtInfo LabelInfo);
   ParserResult<Stmt> parseStmtRepeat(LabeledStmtInfo LabelInfo);
   ParserResult<Stmt> parseStmtDo(LabeledStmtInfo LabelInfo);

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1030,33 +1030,41 @@ namespace {
       }
       PrintWithColorRAII(OS, ParenthesisColor) << ')';
     }
+    
+    void printASTNodes(const ArrayRef<ASTNode> &Elements, StringRef Name) {
+      OS.indent(Indent);
+      PrintWithColorRAII(OS, ParenthesisColor) << "(";
+      PrintWithColorRAII(OS, ASTNodeColor) << Name;
+      for (auto Elt : Elements) {
+        OS << '\n';
+        if (auto *SubExpr = Elt.dyn_cast<Expr*>())
+          printRec(SubExpr);
+        else if (auto *SubStmt = Elt.dyn_cast<Stmt*>())
+          printRec(SubStmt);
+        else
+          printRec(Elt.get<Decl*>());
+      }
+      PrintWithColorRAII(OS, ParenthesisColor) << ')';
+    }
 
     void visitIfConfigDecl(IfConfigDecl *ICD) {
-      OS.indent(Indent);
-      PrintWithColorRAII(OS, ParenthesisColor) << '(';
-      OS << "#if_decl\n";
+      printCommon(ICD, "if_config_decl");
       Indent += 2;
       for (auto &Clause : ICD->getClauses()) {
+        OS << '\n';
+        OS.indent(Indent);
+        PrintWithColorRAII(OS, StmtColor) << (Clause.Cond ? "#if:" : "#else:");
+        if (Clause.isActive)
+          PrintWithColorRAII(OS, DeclModifierColor) << " active";
         if (Clause.Cond) {
-          PrintWithColorRAII(OS, ParenthesisColor) << '(';
-          OS << "#if:";
-          if (Clause.isActive) OS << " active";
           OS << "\n";
           printRec(Clause.Cond);
-        } else {
-          OS << '\n';
-          PrintWithColorRAII(OS, ParenthesisColor) << '(';
-          OS << "#else:";
-          if (Clause.isActive) OS << " active";
-          OS << "\n";
         }
 
-        for (auto D : Clause.Elements) {
-          OS << '\n';
-          printRec(D);
-        }
-
-        PrintWithColorRAII(OS, ParenthesisColor) << ')';
+        OS << '\n';
+        Indent += 2;
+        printASTNodes(Clause.Elements, "elements");
+        Indent -= 2;
       }
 
       Indent -= 2;
@@ -1413,35 +1421,6 @@ public:
       printRec(elt);
     OS << '\n';
     printRec(S->getBody());
-    PrintWithColorRAII(OS, ParenthesisColor) << ')';
-  }
-
-  void visitIfConfigStmt(IfConfigStmt *S) {
-    printCommon(S, "#if_stmt");
-    Indent += 2;
-    for (auto &Clause : S->getClauses()) {
-      OS << '\n';
-      OS.indent(Indent);
-      if (Clause.Cond) {
-        PrintWithColorRAII(OS, ParenthesisColor) << '(';
-        PrintWithColorRAII(OS, StmtColor) << "#if:";
-        if (Clause.isActive)
-          PrintWithColorRAII(OS, DeclModifierColor) << " active";
-        OS << '\n';
-        printRec(Clause.Cond);
-      } else {
-        PrintWithColorRAII(OS, StmtColor) << "#else";
-        if (Clause.isActive)
-          PrintWithColorRAII(OS, DeclModifierColor) << " active";
-      }
-
-      OS << '\n';
-      Indent += 2;
-      printASTNodes(Clause.Elements, "elements");
-      Indent -= 2;
-    }
-
-    Indent -= 2;
     PrintWithColorRAII(OS, ParenthesisColor) << ')';
   }
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2365,18 +2365,15 @@ void PrintAST::visitIfConfigDecl(IfConfigDecl *ICD) {
 
   for (auto &Clause : ICD->getClauses()) {
     if (&Clause == &*ICD->getClauses().begin())
-      Printer << tok::pound_if << " "; // FIXME: print condition
+      Printer << tok::pound_if << " /* condition */"; // FIXME: print condition
     else if (Clause.Cond)
-      Printer << tok::pound_elseif << ""; // FIXME: print condition
+      Printer << tok::pound_elseif << " /* condition */"; // FIXME: print condition
     else
       Printer << tok::pound_else;
+    printASTNodes(Clause.Elements);
     Printer.printNewline();
-    if (printASTNodes(Clause.Elements)) {
-      Printer.printNewline();
-      indent();
-    }
+    indent();
   }
-  Printer.printNewline();
   Printer << tok::pound_endif;
 }
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2360,7 +2360,24 @@ void PrintAST::visitTopLevelCodeDecl(TopLevelCodeDecl *decl) {
 }
 
 void PrintAST::visitIfConfigDecl(IfConfigDecl *ICD) {
-  // FIXME: Pretty print #if decls
+  if (!Options.PrintIfConfig)
+    return;
+
+  for (auto &Clause : ICD->getClauses()) {
+    if (&Clause == &*ICD->getClauses().begin())
+      Printer << tok::pound_if << " "; // FIXME: print condition
+    else if (Clause.Cond)
+      Printer << tok::pound_elseif << ""; // FIXME: print condition
+    else
+      Printer << tok::pound_else;
+    Printer.printNewline();
+    if (printASTNodes(Clause.Elements)) {
+      Printer.printNewline();
+      indent();
+    }
+  }
+  Printer.printNewline();
+  Printer << tok::pound_endif;
 }
 
 void PrintAST::visitTypeAliasDecl(TypeAliasDecl *decl) {
@@ -3265,27 +3282,6 @@ void PrintAST::visitGuardStmt(GuardStmt *stmt) {
   // FIXME: print condition
   Printer << " ";
   visit(stmt->getBody());
-}
-
-void PrintAST::visitIfConfigStmt(IfConfigStmt *stmt) {
-  if (!Options.PrintIfConfig)
-    return;
-
-  for (auto &Clause : stmt->getClauses()) {
-    if (&Clause == &*stmt->getClauses().begin())
-      Printer << tok::pound_if << " "; // FIXME: print condition
-    else if (Clause.Cond)
-      Printer << tok::pound_elseif << ""; // FIXME: print condition
-    else
-      Printer << tok::pound_else;
-    Printer.printNewline();
-    if (printASTNodes(Clause.Elements)) {
-      Printer.printNewline();
-      indent();
-    }
-  }
-  Printer.printNewline();
-  Printer << tok::pound_endif;
 }
 
 void PrintAST::visitWhileStmt(WhileStmt *stmt) {

--- a/lib/AST/ASTScope.cpp
+++ b/lib/AST/ASTScope.cpp
@@ -188,22 +188,9 @@ static bool hasAccessors(AbstractStorageDecl *asd) {
   llvm_unreachable("Unhandled ContinuationKind in switch.");
 }
 
-/// Determine whether this is a top-level code declaration that isn't just
-/// wrapping an #if.
+/// Determine whether this is a top-level code declaration.
 static bool isRealTopLevelCodeDecl(Decl *decl) {
-  auto topLevelCode = dyn_cast<TopLevelCodeDecl>(decl);
-  if (!topLevelCode) return false;
-
-  // Drop top-level statements containing just an IfConfigStmt.
-  // FIXME: The modeling of IfConfig is weird.
-  auto braceStmt = topLevelCode->getBody();
-  auto elements = braceStmt->getElements();
-  if (elements.size() == 1 &&
-      elements[0].is<Stmt *>() &&
-      isa<IfConfigStmt>(elements[0].get<Stmt *>()))
-    return false;
-
-  return true;
+  return isa<TopLevelCodeDecl>(decl);
 }
 
 void ASTScope::expand() const {
@@ -1153,7 +1140,6 @@ ASTScope *ASTScope::createIfNeeded(const ASTScope *parent, Stmt *stmt) {
   case StmtKind::Break:
   case StmtKind::Continue:
   case StmtKind::Fallthrough:
-  case StmtKind::IfConfig:
   case StmtKind::Fail:
   case StmtKind::Throw:
     // Nothing to do for these statements.

--- a/lib/AST/ASTScope.cpp
+++ b/lib/AST/ASTScope.cpp
@@ -188,11 +188,6 @@ static bool hasAccessors(AbstractStorageDecl *asd) {
   llvm_unreachable("Unhandled ContinuationKind in switch.");
 }
 
-/// Determine whether this is a top-level code declaration.
-static bool isRealTopLevelCodeDecl(Decl *decl) {
-  return isa<TopLevelCodeDecl>(decl);
-}
-
 void ASTScope::expand() const {
   assert(!isExpanded() && "Already expanded the children of this node");
   ASTContext &ctx = getASTContext();
@@ -300,7 +295,7 @@ void ASTScope::expand() const {
 
         // If the declaration is a top-level code declaration, turn the source
         // file into a continuation. We're done.
-        if (isRealTopLevelCodeDecl(decl)) {
+        if (isa<TopLevelCodeDecl>(decl)) {
           addActiveContinuation(this);
           break;
         }
@@ -937,7 +932,6 @@ ASTScope *ASTScope::createIfNeeded(const ASTScope *parent, Decl *decl) {
   }
 
   case DeclKind::TopLevelCode:
-    if (!isRealTopLevelCodeDecl(decl)) return nullptr;
     return new (ctx) ASTScope(parent, cast<TopLevelCodeDecl>(decl));
 
   case DeclKind::Protocol:

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -2917,23 +2917,23 @@ public:
                         [&]{ S->print(Out); });
     }
 
-    void checkSourceRanges(IfConfigStmt *S) {
-      checkSourceRangesBase(S);
+    void checkSourceRanges(IfConfigDecl *ICD) {
+      checkSourceRangesBase(ICD);
 
-      SourceLoc Location = S->getStartLoc();
-      for (auto &Clause : S->getClauses()) {
+      SourceLoc Location = ICD->getStartLoc();
+      for (auto &Clause : ICD->getClauses()) {
         // Clause start, note that the first clause start location is the
         // same as that of the whole statement
-        if (Location == S->getStartLoc()) {
+        if (Location == ICD->getStartLoc()) {
           if (Location != Clause.Loc) {
-            Out << "bad start location of IfConfigStmt first clause\n";
-            S->print(Out);
+            Out << "bad start location of IfConfigDecl first clause\n";
+            ICD->print(Out);
             abort();
           }
         } else {
           if (!Ctx.SourceMgr.isBeforeInBuffer(Location, Clause.Loc)) {
-            Out << "bad start location of IfConfigStmt clause\n";
-            S->print(Out);
+            Out << "bad start location of IfConfigDecl clause\n";
+            ICD->print(Out);
             abort();
           }
         }
@@ -2943,8 +2943,8 @@ public:
         Expr *Cond = Clause.Cond;
         if (Cond) {
           if (!Ctx.SourceMgr.isBeforeInBuffer(Location, Cond->getStartLoc())) {
-            Out << "invalid IfConfigStmt clause condition start location\n";
-            S->print(Out);
+            Out << "invalid IfConfigDecl clause condition start location\n";
+            ICD->print(Out);
             abort();
           }
           Location = Cond->getEndLoc();
@@ -2959,8 +2959,8 @@ public:
           }
           
           if (!Ctx.SourceMgr.isBeforeInBuffer(StoredLoc, StartLocation)) {
-            Out << "invalid IfConfigStmt clause element start location\n";
-            S->print(Out);
+            Out << "invalid IfConfigDecl clause element start location\n";
+            ICD->print(Out);
             abort();
           }
           
@@ -2972,9 +2972,9 @@ public:
         }
       }
 
-      if (Ctx.SourceMgr.isBeforeInBuffer(S->getEndLoc(), Location)) {
-        Out << "invalid IfConfigStmt end location\n";
-        S->print(Out);
+      if (Ctx.SourceMgr.isBeforeInBuffer(ICD->getEndLoc(), Location)) {
+        Out << "invalid IfConfigDecl end location\n";
+        ICD->print(Out);
         abort();
       }
     }

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -177,7 +177,7 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
   }
 
   bool visitIfConfigDecl(IfConfigDecl *ICD) {
-    // By default, just visit the declarations that are actually
+    // By default, just visit the elements that are actually
     // injected into the enclosing context.
     return false;
   }
@@ -1286,14 +1286,6 @@ Stmt *Traversal::visitGuardStmt(GuardStmt *US) {
   else
     return nullptr;
   return US;
-}
-
-
-Stmt *Traversal::visitIfConfigStmt(IfConfigStmt *ICS) {
-  // Active members are attached to the enclosing declaration, so there's no
-  // need to walk anything within.
-  
-  return ICS;
 }
 
 Stmt *Traversal::visitDoStmt(DoStmt *DS) {

--- a/lib/AST/NameLookupImpl.h
+++ b/lib/AST/NameLookupImpl.h
@@ -151,10 +151,6 @@ private:
     visit(S->getBody());
   }
 
-  void visitIfConfigStmt(IfConfigStmt * S) {
-    // Active members are attached to the enclosing declaration, so there's no
-    // need to walk anything within.
-  }
   void visitWhileStmt(WhileStmt *S) {
     if (!isReferencePointInRange(S->getSourceRange()))
       return;

--- a/lib/AST/SourceEntityWalker.cpp
+++ b/lib/AST/SourceEntityWalker.cpp
@@ -141,6 +141,15 @@ bool SemaAnnotator::walkToDeclPre(Decl *D) {
     if (Loc.isValid())
       NameLen = PrecD->getName().getLength();
 
+  } else if (auto *ICD = dyn_cast<IfConfigDecl>(D)) {
+    if (SEWalker.shouldWalkInactiveConfigRegion()) {
+      for (auto Clause : ICD->getClauses()) {
+        for (auto Member : Clause.Elements) {
+          Member.walk(*this);
+        }
+      }
+      return false;
+    }
   } else {
     return true;
   }
@@ -198,17 +207,6 @@ bool SemaAnnotator::walkToDeclPost(Decl *D) {
 std::pair<bool, Stmt *> SemaAnnotator::walkToStmtPre(Stmt *S) {
   bool TraverseChildren = SEWalker.walkToStmtPre(S);
   if (TraverseChildren) {
-    if (SEWalker.shouldWalkInactiveConfigRegion()) {
-      if (auto *ICS = dyn_cast<IfConfigStmt>(S)) {
-        TraverseChildren = false;
-        for (auto Clause : ICS->getClauses()) {
-          for (auto Member : Clause.Elements) {
-            Member.walk(*this);
-          }
-        }
-      }
-    }
-
     if (auto *DeferS = dyn_cast<DeferStmt>(S)) {
       if (auto *FD = DeferS->getTempDecl()) {
         auto *RetS = FD->getBody()->walk(*this);

--- a/lib/IDE/Formatting.cpp
+++ b/lib/IDE/Formatting.cpp
@@ -652,7 +652,7 @@ class FormatWalker : public SourceEntityWalker {
   /// Sometimes, target is a part of "parent", for instance, "#else" is a part
   /// of an ifconfigstmt, so that ifconfigstmt is not really the parent of "#else".
   bool isTargetPartOf(swift::ASTWalker::ParentTy Parent) {
-    if (auto Conf = dyn_cast_or_null<IfConfigStmt>(Parent.getAsStmt())) {
+    if (auto Conf = dyn_cast_or_null<IfConfigDecl>(Parent.getAsDecl())) {
       for (auto Clause : Conf->getClauses()) {
         if (Clause.Loc == TargetLocation)
           return true;

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2106,6 +2106,8 @@ Parser::parseDecl(ParseDeclOptions Flags,
       Handler(ICD);
       // Copy the active members into the entries list.
       for (auto activeMember : ICD->getActiveMembers()) {
+        if (isa<IfConfigDecl>(activeMember))
+          continue;
         Handler(activeMember);
       }
     }

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2105,10 +2105,12 @@ Parser::parseDecl(ParseDeclOptions Flags,
       // The IfConfigDecl is ahead of its members in source order.
       Handler(ICD);
       // Copy the active members into the entries list.
-      for (auto activeMember : ICD->getActiveMembers()) {
-        if (isa<IfConfigDecl>(activeMember))
+      for (auto activeMember : ICD->getActiveClauseElements()) {
+        auto *D = activeMember.get<Decl*>();
+        if (isa<IfConfigDecl>(D))
+          // Don't hoist nested '#if'.
           continue;
-        Handler(activeMember);
+        Handler(D);
       }
     }
     return IfConfigResult;

--- a/lib/Parse/ParseIfConfig.cpp
+++ b/lib/Parse/ParseIfConfig.cpp
@@ -549,21 +549,20 @@ static bool isVersionIfConfigCondition(Expr *Condition) {
 
 } // end anonymous namespace
 
-/// Parse and populate a list of #if/#elseif/#else/#endif clauses.
+/// Parse and populate a #if ... #endif directive.
 /// Delegate callback function to parse elements in the blocks.
-template <unsigned N>
-static ParserStatus parseIfConfig(
-    Parser &P, SmallVectorImpl<IfConfigClause> &Clauses,
-    SourceLoc &EndLoc, bool HadMissingEnd,
+ParserResult<IfConfigDecl> Parser::parseIfConfig(
     llvm::function_ref<void(SmallVectorImpl<ASTNode> &, bool)> parseElements) {
+
+  SmallVector<IfConfigClause, 4> Clauses;
   Parser::StructureMarkerRAII ParsingDecl(
-      P, P.Tok.getLoc(), Parser::StructureMarkerKind::IfConfig);
+      *this, Tok.getLoc(), Parser::StructureMarkerKind::IfConfig);
 
   bool foundActive = false;
   bool isVersionCondition = false;
   while (1) {
-    bool isElse = P.Tok.is(tok::pound_else);
-    SourceLoc ClauseLoc = P.consumeToken();
+    bool isElse = Tok.is(tok::pound_else);
+    SourceLoc ClauseLoc = consumeToken();
     Expr *Condition = nullptr;
     bool isActive = false;
 
@@ -571,107 +570,53 @@ static ParserStatus parseIfConfig(
     if (isElse) {
       isActive = !foundActive;
     } else {
-      llvm::SaveAndRestore<bool> S(P.InPoundIfEnvironment, true);
-      ParserResult<Expr> Result = P.parseExprSequence(diag::expected_expr,
+      llvm::SaveAndRestore<bool> S(InPoundIfEnvironment, true);
+      ParserResult<Expr> Result = parseExprSequence(diag::expected_expr,
                                                       /*isBasic*/true,
                                                       /*isForDirective*/true);
       if (Result.isNull())
         return makeParserError();
       Condition = Result.get();
-      if (validateIfConfigCondition(Condition, P.Context, P.Diags)) {
+      if (validateIfConfigCondition(Condition, Context, Diags)) {
         // Error in the condition;
         isActive = false;
         isVersionCondition = false;
       } else if (!foundActive) {
         // Evaludate the condition only if we haven't found any active one.
-        isActive = evaluateIfConfigCondition(Condition, P.Context);
+        isActive = evaluateIfConfigCondition(Condition, Context);
         isVersionCondition = isVersionIfConfigCondition(Condition);
       }
     }
 
     foundActive |= isActive;
 
-    if (!P.Tok.isAtStartOfLine() && P.Tok.isNot(tok::eof)) {
-      P.diagnose(P.Tok.getLoc(),
-                 diag::extra_tokens_conditional_compilation_directive);
+    if (!Tok.isAtStartOfLine() && Tok.isNot(tok::eof)) {
+      diagnose(Tok.getLoc(),
+               diag::extra_tokens_conditional_compilation_directive);
     }
 
     // Parse elements
-    SmallVector<ASTNode, N> Elements;
+    SmallVector<ASTNode, 16> Elements;
     if (isActive || !isVersionCondition) {
       parseElements(Elements, isActive);
     } else {
-      DiagnosticTransaction DT(P.Diags);
-      P.skipUntilConditionalBlockClose();
+      DiagnosticTransaction DT(Diags);
+      skipUntilConditionalBlockClose();
       DT.abort();
     }
 
     Clauses.emplace_back(ClauseLoc, Condition,
-                         P.Context.AllocateCopy(Elements), isActive);
+                         Context.AllocateCopy(Elements), isActive);
 
-    if (P.Tok.isNot(tok::pound_elseif, tok::pound_else))
+    if (Tok.isNot(tok::pound_elseif, tok::pound_else))
       break;
 
     if (isElse)
-      P.diagnose(P.Tok, diag::expected_close_after_else_directive);
+      diagnose(Tok, diag::expected_close_after_else_directive);
   }
 
-  HadMissingEnd = P.parseEndIfDirective(EndLoc);
-  return makeParserSuccess();
-}
-
-/// Parse #if ... #endif in declarations position.
-ParserResult<IfConfigDecl> Parser::parseDeclIfConfig(ParseDeclOptions Flags) {
-  SmallVector<IfConfigClause, 4> Clauses;
   SourceLoc EndLoc;
-  bool HadMissingEnd = false;
-  auto Status = parseIfConfig<8>(
-      *this, Clauses, EndLoc, HadMissingEnd,
-      [&](SmallVectorImpl<ASTNode> &Decls, bool IsActive) {
-    Optional<Scope> scope;
-    if (!IsActive)
-      scope.emplace(this, getScopeInfo().getCurrentScope()->getKind(),
-                    /*inactiveConfigBlock=*/true);
-
-    ParserStatus Status;
-    bool PreviousHadSemi = true;
-    while (Tok.isNot(tok::pound_else, tok::pound_endif, tok::pound_elseif,
-                      tok::eof)) {
-      if (Tok.is(tok::r_brace)) {
-        diagnose(Tok.getLoc(),
-                  diag::unexpected_rbrace_in_conditional_compilation_block);
-        // If we see '}', following declarations don't look like belong to
-        // the current decl context; skip them.
-        skipUntilConditionalBlockClose();
-        break;
-      }
-      Status |= parseDeclItem(PreviousHadSemi, Flags,
-                              [&](Decl *D) {Decls.emplace_back(D);});
-    }
-  });
-  if (Status.isError())
-    return makeParserErrorResult<IfConfigDecl>();
-
-  IfConfigDecl *ICD = new (Context) IfConfigDecl(CurDeclContext,
-                                                 Context.AllocateCopy(Clauses),
-                                                 EndLoc, HadMissingEnd);
-  return makeParserResult(ICD);
-}
-
-/// Parse #if ... #endif in statements position.
-ParserResult<IfConfigDecl> Parser::parseStmtIfConfig(BraceItemListKind Kind) {
-  SmallVector<IfConfigClause, 4> Clauses;
-  SourceLoc EndLoc;
-  bool HadMissingEnd = false;
-  auto Status = parseIfConfig<16>(
-      *this, Clauses, EndLoc, HadMissingEnd,
-      [&](SmallVectorImpl<ASTNode> &Elements, bool IsActive) {
-    parseBraceItems(Elements, Kind, IsActive
-                      ? BraceItemListKind::ActiveConditionalBlock
-                      : BraceItemListKind::InactiveConditionalBlock);
-  });
-  if (Status.isError())
-    return makeParserErrorResult<IfConfigDecl>();
+  bool HadMissingEnd = parseEndIfDirective(EndLoc);
 
   auto *ICD = new (Context) IfConfigDecl(CurDeclContext,
                                          Context.AllocateCopy(Clauses),

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -293,7 +293,12 @@ ParserStatus Parser::parseBraceItems(SmallVectorImpl<ASTNode> &Entries,
         Entries.push_back(D);
       TmpDecls.clear();
     } else if (Tok.is(tok::pound_if)) {
-      auto IfConfigResult = parseStmtIfConfig(Kind);
+      auto IfConfigResult = parseIfConfig(
+        [&](SmallVectorImpl<ASTNode> &Elements, bool IsActive) {
+          parseBraceItems(Elements, Kind, IsActive
+                            ? BraceItemListKind::ActiveConditionalBlock
+                            : BraceItemListKind::InactiveConditionalBlock);
+        });
       
       if (IfConfigResult.isParseError()) {
         NeedParseErrorRecovery = true;

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -324,6 +324,8 @@ ParserStatus Parser::parseBraceItems(SmallVectorImpl<ASTNode> &Entries,
 
       IfConfigStmt *ICS = cast<IfConfigStmt>(Result.get<Stmt*>());
       for (auto &Entry : ICS->getActiveClauseElements()) {
+        if (Entry.is<Stmt*>() && isa<IfConfigStmt>(Entry.get<Stmt*>()))
+          continue;
         Entries.push_back(Entry);
         if (Entry.is<Decl*>()) {
           Entry.get<Decl*>()->setEscapedFromIfConfig(true);

--- a/lib/SILGen/SILGenStmt.cpp
+++ b/lib/SILGen/SILGenStmt.cpp
@@ -200,8 +200,8 @@ void StmtEmitter::visitBraceStmt(BraceStmt *S) {
   
   for (auto &ESD : S->getElements()) {
     
-    if (auto S = ESD.dyn_cast<Stmt*>())
-      if (isa<IfConfigStmt>(S))
+    if (auto D = ESD.dyn_cast<Decl*>())
+      if (isa<IfConfigDecl>(D))
         continue;
     
     // If we ever reach an unreachable point, stop emitting statements and issue
@@ -539,12 +539,6 @@ void StmtEmitter::visitGuardStmt(GuardStmt *S) {
   // Emit the condition bindings, branching to the bodyBB if they fail.  Since
   // we didn't push a scope, the bound variables are live after this statement.
   SGF.emitStmtCondition(S->getCond(), bodyBB, S);
-}
-
-
-void StmtEmitter::visitIfConfigStmt(IfConfigStmt *S) {
-  // Active members are attached to the enclosing declaration, so there's no
-  // need to walk anything within.
 }
 
 void StmtEmitter::visitWhileStmt(WhileStmt *S) {

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -1975,6 +1975,11 @@ public:
     if (isa<TypeDecl>(D))
       return false;
       
+    // The body of #if clauses are not walked into, we need custom processing
+    // for them.
+    if (auto *ICD = dyn_cast<IfConfigDecl>(D))
+      handleIfConfig(ICD);
+      
     // If this is a VarDecl, then add it to our list of things to track.
     if (auto *vd = dyn_cast<VarDecl>(D))
       if (shouldTrackVarDecl(vd)) {
@@ -2045,15 +2050,10 @@ public:
   std::pair<bool, Expr *> walkToExprPre(Expr *E) override;
 
   /// handle #if directives.
-  void handleIfConfig(IfConfigStmt *ICS);
+  void handleIfConfig(IfConfigDecl *ICD);
 
   /// Custom handling for statements.
   std::pair<bool, Stmt *> walkToStmtPre(Stmt *S) override {
-    // The body of #if statements are not walked into, we need custom processing
-    // for them.
-    if (auto *ICS = dyn_cast<IfConfigStmt>(S))
-      handleIfConfig(ICS);
-      
     // Keep track of an association between vardecls and the StmtCondition that
     // they are bound in for IfStmt, GuardStmt, WhileStmt, etc.
     if (auto LCS = dyn_cast<LabeledConditionalStmt>(S)) {
@@ -2396,7 +2396,7 @@ std::pair<bool, Expr *> VarDeclUsageChecker::walkToExprPre(Expr *E) {
 /// handle #if directives.  All of the active clauses are already walked by the
 /// AST walker, but we also want to handle the inactive ones to avoid false
 /// positives.
-void VarDeclUsageChecker::handleIfConfig(IfConfigStmt *ICS) {
+void VarDeclUsageChecker::handleIfConfig(IfConfigDecl *ICD) {
   struct ConservativeDeclMarker : public ASTWalker {
     VarDeclUsageChecker &VDUC;
     ConservativeDeclMarker(VarDeclUsageChecker &VDUC) : VDUC(VDUC) {}
@@ -2411,7 +2411,7 @@ void VarDeclUsageChecker::handleIfConfig(IfConfigStmt *ICS) {
     }
   };
 
-  for (auto &clause : ICS->getClauses()) {
+  for (auto &clause : ICD->getClauses()) {
     // Active clauses are handled by the normal AST walk.
     if (clause.isActive) continue;
 

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -512,14 +512,6 @@ public:
     return GS;
   }
 
-  Stmt *visitIfConfigStmt(IfConfigStmt *ICS) {
-    
-    // Active members are attached to the enclosing declaration, so there's no
-    // need to walk anything within.
-    
-    return ICS;
-  }
-
   Stmt *visitDoStmt(DoStmt *DS) {
     AddLabeledStmt loopNest(*this, DS);
     Stmt *S = DS->getBody();

--- a/lib/Syntax/LegacyASTTransformer.cpp
+++ b/lib/Syntax/LegacyASTTransformer.cpp
@@ -599,13 +599,6 @@ LegacyASTTransformer::visitFallthroughStmt(FallthroughStmt *S,
 }
 
 RC<SyntaxData>
-LegacyASTTransformer::visitIfConfigStmt(IfConfigStmt *S,
-                                        const SyntaxData *Parent,
-                                        const CursorIndex IndexInParent) {
-  return getUnknownStmt(S);
-}
-
-RC<SyntaxData>
 LegacyASTTransformer::visitFailStmt(FailStmt *S,
                                     const SyntaxData *Parent,
                                     const CursorIndex IndexInParent) {

--- a/test/IDE/print_ast_non_typechecked.swift
+++ b/test/IDE/print_ast_non_typechecked.swift
@@ -4,3 +4,24 @@ class C {
 
 // RUN: %target-swift-ide-test -print-ast-not-typechecked -source-filename %s | %FileCheck %s -check-prefix=CHECK1
 // CHECK1: func foo(s: Int)
+
+#if BAR
+func bar() {}
+#elseif BAZ
+func baz() {}
+#else
+func qux() {}
+#endif
+
+// CHECK1: {{^}}#if /* condition */
+// CHECK1: {{^}}  func bar() {
+// CHECK1: {{^}}  }
+// CHECK1: {{^}}#elseif /* condition */
+// CHECK1: {{^}}  func baz() {
+// CHECK1: {{^}}  }
+// CHECK1: {{^}}#else
+// CHECK1: {{^}}  func qux() {
+// CHECK1: {{^}}  }
+// CHECK1: {{^}}#endif
+// CHECK1: {{^}}func qux() {
+// CHECK1: {{^}}}

--- a/test/IDE/print_source_file_interface_1.swift.result
+++ b/test/IDE/print_source_file_interface_1.swift.result
@@ -3,8 +3,6 @@
 
 // More blah blah.
 
-
-
 import Swift
 
 internal class FooDisabled {

--- a/test/Parse/ConditionalCompilation/pound-if-top-level-4.swift
+++ b/test/Parse/ConditionalCompilation/pound-if-top-level-4.swift
@@ -1,0 +1,21 @@
+// RUN: %target-typecheck-verify-swift
+
+// https://bugs.swift.org/browse/SR-4426
+// '#if' in top-level code that contains only decls should not disturb forward reference.
+
+typealias A = B
+
+#if false
+func foo() {}
+#endif
+
+struct B {}
+
+// If '#if' contains active non-decls, we don't support forward reference.
+typealias C = D // expected-error {{use of undeclared type 'D'}}
+
+#if true
+print("ok")
+#endif
+
+struct D {}

--- a/test/Parse/ConditionalCompilation/stmt_in_type.swift
+++ b/test/Parse/ConditionalCompilation/stmt_in_type.swift
@@ -1,0 +1,13 @@
+// RUN: %target-typecheck-verify-swift -D FOO
+
+// Test case for statements in #if block in types.
+
+func foo() {}
+
+struct S1 { // expected-note 2 {{in declaration of 'S1'}}
+#if FOO
+  return 1; // expected-error {{expected declaration}}
+#elseif BAR
+  foo(); // expected-error {{expected declaration}}
+#endif
+}

--- a/test/Parse/ConditionalCompilation/toplevel_parseaslibrary.swift
+++ b/test/Parse/ConditionalCompilation/toplevel_parseaslibrary.swift
@@ -1,0 +1,11 @@
+// RUN: %target-typecheck-verify-swift -parse-as-library -D FOO
+
+// '-parse-as-library' doesn't allow exprssions nor statements in #if blocks.
+
+func foo() {}
+
+#if FOO
+  foo() // expected-error {{expressions are not allowed at the top level}}
+#else
+  if true { foo() } // expected-error {{statements are not allowed at the top level}}
+#endif


### PR DESCRIPTION
~~**NOTE: This conflicts with #7955 , I will rebase this PR when it's merged.**~~ landed

Resolves: [SR-4426](https://bugs.swift.org/browse/SR-4426)

`#if` in statements position doesn't have to be `Stmt`.
Modeling it as `IfConfigDecl` simplify the code and AST.

* Make `IfConfigDecl` be able to hold `ASTNode` elements
* Parse `#if` as `IfConfigDecl`
* Stop enclosing toplevel `#if` into `TopLevelCodeDecl`.
* ~New methods on `IfConfigDecl` for retrieving active elements as `Decl`s. This replaces `IfConfigDecl::getActiveMembers()`.~
* Eliminate `IfConfigStmt`

```swift
#if true
  #if true
  func foo() {}
  #endif
#else
  func bar() {}
#endif
```
is now dumped as:
```
(source_file
  (if_config_decl
    #if: active
      (boolean_literal_expr type='<null>' value=true)
      (elements
        (if_config_decl
          #if: active
            (boolean_literal_expr type='<null>' value=true)
            (elements
              (func_decl "foo()" ...)))
        (func_decl "foo()" ...))
    #else:
      (elements
        (func_decl "bar()" ...)))
  (func_decl "foo()" ...))
```