### PR TITLE
Fix Equal constraint handling in matchTypes.

### DIFF
--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -17,6 +17,7 @@ struct A: Hashable {
 
   var property: Prop
   var optProperty: Prop?
+  let optLetProperty: Prop?
 
   subscript(sub: Sub) -> A { get { return self } set { } }
 
@@ -88,9 +89,7 @@ func testKeyPath(sub: Sub, optSub: OptSub, x: Int) {
   let _: ReferenceWritableKeyPath<A, Prop> = \.property
 
   // FIXME crash let _: PartialKeyPath<A> = \[sub]
-  // FIXME should resolve: expected-error@+1{{}}
   let _: KeyPath<A, A> = \.[sub]
-  // FIXME should resolve: expected-error@+1{{}}
   let _: WritableKeyPath<A, A> = \.[sub]
   // expected-error@+1{{ambiguous}} (need to improve diagnostic)
   let _: ReferenceWritableKeyPath<A, A> = \.[sub]
@@ -109,8 +108,8 @@ func testKeyPath(sub: Sub, optSub: OptSub, x: Int) {
   // expected-error@+1{{cannot convert}}
   let _: ReferenceWritableKeyPath<A, A?> = \.optProperty?[sub]
 
-  // FIXME should resolve: expected-error@+1{{}}
   let _: KeyPath<A, Prop> = \.optProperty!
+  let _: KeyPath<A, Prop> = \.optLetProperty!
   let _: KeyPath<A, Prop?> = \.property[optSub]?.optProperty!
   let _: KeyPath<A, A?> = \.property[optSub]?.optProperty![sub]
 

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -111,8 +111,8 @@ func testKeyPath(sub: Sub, optSub: OptSub, x: Int) {
 
   // FIXME should resolve: expected-error@+1{{}}
   let _: KeyPath<A, Prop> = \.optProperty!
-  // FIXME should resolve: expected-error@+1{{}}
-  let _: KeyPath<A, Prop?> = \.property[optSub]?.optProperty![sub]
+  let _: KeyPath<A, Prop?> = \.property[optSub]?.optProperty!
+  let _: KeyPath<A, A?> = \.property[optSub]?.optProperty![sub]
 
   // FIXME crash let _: PartialKeyPath<C<A>> = \.value
   let _: KeyPath<C<A>, A> = \.value


### PR DESCRIPTION
We had an inconsistency in the handling of ConstraintKind::Equal in that
we would take
```
  $T1 Equal $T2
```
where ``$T2`` was previously bound to a type, and bind the RValue type of
``$T2``'s type to ``$T1``.  That does not allow for us to later attempt to bind
the LValue type of that type to ``$T1`` (as might happen in simplifying an
OptionalObject constraint).

Instead, if ``$T1`` can be bound to an LValue and ``$T2`` is not an LValue,
we'll defer simplifying the Equal constraint until after ``$T1`` is bound
through some other type variable binding or constraint simplification.

Fixes rdar://problem/31724272.
