### PR TITLE
[ClangImporter] For ClangImporter::canReadPCH() do a ReadAST invocation to verify if the PCH is up-to-date or not

### DIFF
--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -308,10 +308,12 @@ public:
 
   Optional<std::string>
   getOrCreatePCH(const ClangImporterOptions &ImporterOptions,
-                 const std::string &SwiftPCHHash);
+                 StringRef SwiftPCHHash);
   Optional<std::string>
+  /// \param isExplicit true if the PCH filename was passed directly
+  /// with -import-objc-header option.
   getPCHFilename(const ClangImporterOptions &ImporterOptions,
-                 const std::string &SwiftPCHHash);
+                 StringRef SwiftPCHHash, bool &isExplicit);
 };
 
 ImportDecl *createImportDecl(ASTContext &Ctx, DeclContext *DC, ClangNode ClangN,

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -724,18 +724,15 @@ bool ClangImporter::canReadPCH(StringRef PCHFilename) {
   auto clangDiags = CompilerInstance::createDiagnostics(
                                               new clang::DiagnosticOptions());
   clang::SourceManager clangSrcMgr(*clangDiags, CI.getFileManager());
-  clang::HeaderSearch headerInfo(CI.getHeaderSearchOptsPtr(),
-                          clangSrcMgr,
-                          *clangDiags,
-                          CI.getLangOpts(),
-                          /*Target=*/nullptr);
-  headerInfo.setModuleCachePath(CI.getSpecificModuleCachePath());
+  auto FID = clangSrcMgr.createFileID(
+                        llvm::make_unique<ZeroFilledMemoryBuffer>(1, "<main>"));
+  clangSrcMgr.setMainFileID(FID);
   clang::Preprocessor PP(CI.getInvocation().getPreprocessorOptsPtr(),
                          *clangDiags,
                          CI.getLangOpts(),
                          clangSrcMgr,
                          CI.getPCMCache(),
-                         headerInfo, CI,
+                         CI.getPreprocessor().getHeaderSearchInfo(), CI,
                          /*IILookup=*/nullptr,
                          /*OwnsHeaderSearch=*/false);
   PP.Initialize(CI.getTarget());

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -711,13 +711,65 @@ addCommonInvocationArguments(std::vector<std::string> &invocationArgStrs,
 }
 
 bool ClangImporter::canReadPCH(StringRef PCHFilename) {
-  return clang::ASTReader::isAcceptableASTFile(PCHFilename,
-    Impl.Instance->getFileManager(),
-    Impl.Instance->getPCHContainerReader(),
-    Impl.Instance->getLangOpts(),
-    Impl.Instance->getTargetOpts(),
-    Impl.Instance->getPreprocessorOpts(),
-    Impl.Instance->getSpecificModuleCachePath());
+  if (!llvm::sys::fs::exists(PCHFilename))
+    return false;
+
+  // FIXME: The following attempts to do an initial ReadAST invocation to verify
+  // the PCH, without affecting the existing CompilerInstance.
+  // Look into combining creating the ASTReader along with verification + update
+  // if necesary, so that we can create and use one ASTReader in the common case
+  // when there is no need for update.
+
+  CompilerInstance &CI = *Impl.Instance;
+  auto clangDiags = CompilerInstance::createDiagnostics(
+                                              new clang::DiagnosticOptions());
+  clang::SourceManager clangSrcMgr(*clangDiags, CI.getFileManager());
+  clang::HeaderSearch headerInfo(CI.getHeaderSearchOptsPtr(),
+                          clangSrcMgr,
+                          *clangDiags,
+                          CI.getLangOpts(),
+                          /*Target=*/nullptr);
+  headerInfo.setModuleCachePath(CI.getSpecificModuleCachePath());
+  clang::Preprocessor PP(CI.getInvocation().getPreprocessorOptsPtr(),
+                         *clangDiags,
+                         CI.getLangOpts(),
+                         clangSrcMgr,
+                         CI.getPCMCache(),
+                         headerInfo, CI,
+                         /*IILookup=*/nullptr,
+                         /*OwnsHeaderSearch=*/false);
+  PP.Initialize(CI.getTarget());
+  clang::ASTContext ctx(CI.getLangOpts(), clangSrcMgr,
+                        PP.getIdentifierTable(), PP.getSelectorTable(),
+                        PP.getBuiltinInfo());
+
+  std::unique_ptr<clang::ASTReader> Reader(new clang::ASTReader(
+      PP, ctx, CI.getPCHContainerReader(),
+      CI.getFrontendOpts().ModuleFileExtensions,
+      CI.getHeaderSearchOpts().Sysroot,
+      /*DisableValidation*/ false,
+      /*AllowPCHWithCompilerErrors*/ false,
+      /*AllowConfigurationMismatch*/ false,
+      /*ValidateSystemInputs*/ true));
+  ctx.InitBuiltinTypes(CI.getTarget());
+
+  auto result = Reader->ReadAST(PCHFilename,
+                  clang::serialization::MK_PCH,
+                  clang::SourceLocation(),
+                  clang::ASTReader::ARR_None);
+  switch (result) {
+  case clang::ASTReader::Success:
+    return true;
+  case clang::ASTReader::Failure:
+  case clang::ASTReader::Missing:
+  case clang::ASTReader::OutOfDate:
+  case clang::ASTReader::VersionMismatch:
+    return false;
+  case clang::ASTReader::ConfigurationMismatch:
+  case clang::ASTReader::HadErrors:
+    assert(0 && "unexpected ASTReader failure for PCH validation");
+    return false;
+  }
 }
 
 Optional<std::string>
@@ -761,6 +813,13 @@ ClangImporter::getOrCreatePCH(const ClangImporterOptions &ImporterOptions,
       llvm::errs(),
       &Impl.Instance->getDiagnosticOpts()
     };
+    StringRef parentDir = llvm::sys::path::parent_path(PCHFilename.getValue());
+    std::error_code EC = llvm::sys::fs::create_directories(parentDir);
+    if (EC) {
+      llvm::errs() << "failed to create directory '" << parentDir << "': "
+        << EC.message();
+      return None;
+    }
     auto FailedToEmit = emitBridgingPCH(ImporterOptions.BridgingHeader,
                                         PCHFilename.getValue(),
                                         Diags);

--- a/test/IDE/complete_with_header_import.swift
+++ b/test/IDE/complete_with_header_import.swift
@@ -4,6 +4,11 @@
 // RUN: %target-swift-ide-test -code-completion -pch-output-dir %t -source-filename %s -code-completion-token=TOP -import-objc-header %S/Inputs/header.h | %FileCheck %s -check-prefix=CHECK-TOP
 // RUN: %target-swift-ide-test -code-completion -pch-output-dir %t -source-filename %s -code-completion-token=TYPE -import-objc-header %S/Inputs/header.h | %FileCheck %s -check-prefix=CHECK-TYPE
 // RUN: stat %t/*.pch
+// RUN: cp %S/Inputs/header.h %t
+// RUN: %target-swift-ide-test -code-completion -pch-output-dir %t/pch -source-filename %s -code-completion-token=TOP -import-objc-header %t/header.h | %FileCheck %s -check-prefix=CHECK-TOP
+// RUN: stat %t/pch/*.pch
+// RUN: echo '// new stuff' >> %t/header.h
+// RUN: %target-swift-ide-test -code-completion -pch-output-dir %t/pch -source-filename %s -code-completion-token=TOP -import-objc-header %t/header.h | %FileCheck %s -check-prefix=CHECK-TOP
 
 // REQUIRES: objc_interop
 


### PR DESCRIPTION
isAcceptableASTFile() was only doing a configuration check and did not do a full check, e.g. if the dependencies are out-of-date.
