### PR TITLE
Sema: Try harder to preserve ParenType sugar when when performing upcasts [4.0]

### DIFF
--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3266,6 +3266,12 @@ Type TypeChecker::substMemberTypeWithBase(ModuleDecl *module,
 }
 
 Type TypeChecker::getSuperClassOf(Type type) {
+  if (auto *parenTy = dyn_cast<ParenType>(type.getPointer())) {
+    auto superclassTy = getSuperClassOf(parenTy->getUnderlyingType());
+    if (!superclassTy)
+      return Type();
+    return ParenType::get(Context, superclassTy);
+  }
   return type->getSuperclass();
 }
 

--- a/test/Constraints/function_conversion.swift
+++ b/test/Constraints/function_conversion.swift
@@ -1,0 +1,23 @@
+// RUN: %target-typecheck-verify-swift -swift-version 3
+// RUN: %target-typecheck-verify-swift -swift-version 4
+
+// rdar://problem/31969605
+
+class Base {}
+class Derived : Base {}
+
+protocol Refined {}
+protocol Proto : Refined {}
+extension Base : Refined {}
+
+func baseFn(_: Base) {}
+
+func superclassConversion(fn: @escaping (Base) -> ()) {
+  let _: (Derived) -> () = fn
+}
+
+func existentialConversion(fn: @escaping (Refined) -> ()) {
+  let _: (Proto) -> () = fn
+  let _: (Base) -> () = fn
+  let _: (Derived) -> () = fn
+}


### PR DESCRIPTION
This fixes a case where we would allow a function conversion
in Swift 3 mode, but not in Swift 4. We were incorrectly stripping
off ParenTypes, which was OK in Swift 3, but with the implementation
of SE-0110 this resulted in a type mismatch.

Fixes <rdar://problem/31969605>.