### PR TITLE
[Parse] Don't tell CodeCompletion nonsense about protocol/AT where clauses.

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -5357,8 +5357,6 @@ parseDeclProtocol(ParseDeclOptions Flags, DeclAttributes &Attributes) {
     Status |= parseInheritance(InheritedProtocols, &classRequirementLoc);
   }
 
-  // Parse a 'where' clause if present. These are not supported, but we will
-  // get better QoI this way.
   TrailingWhereClause *TrailingWhere = nullptr;
   // Parse a 'where' clause if present.
   if (Tok.is(tok::kw_where)) {

--- a/lib/Parse/ParseGeneric.cpp
+++ b/lib/Parse/ParseGeneric.cpp
@@ -385,12 +385,7 @@ ParserStatus Parser::parseProtocolOrAssociatedTypeWhereClause(
     trailingWhere =
         TrailingWhereClause::create(Context, whereLoc, requirements);
   } else if (whereStatus.hasCodeCompletion()) {
-    // FIXME: this is completely (hah) cargo culted.
-    if (CodeCompletion && firstTypeInComplete) {
-      CodeCompletion->completeGenericParams(nullptr);
-    } else {
-      return makeParserCodeCompletionStatus();
-    }
+    return whereStatus;
   }
 
   return ParserStatus();

--- a/test/IDE/complete_crashes.swift
+++ b/test/IDE/complete_crashes.swift
@@ -196,3 +196,9 @@ struct S_RDAR_28991372 {
 
 S_RDAR_28991372(x: #^RDAR_28991372^#, y: <#T##Int#>)
 // RDAR_28991372: Begin completions
+
+// rdar://problem/31981486
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=RDAR_31981486 | %FileCheck %s -check-prefix=RDAR_31981486
+
+protocol P where #^RDAR_31981486^#
+// RDAR_31981486: Begin completions

--- a/validation-test/IDE/crashers_2/0012-protocol-where-clause.swift
+++ b/validation-test/IDE/crashers_2/0012-protocol-where-clause.swift
@@ -1,4 +1,0 @@
-// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-// REQUIRES: asserts
-
-protocol a where #^A^#

--- a/validation-test/IDE/crashers_2_fixed/0012-protocol-where-clause.swift
+++ b/validation-test/IDE/crashers_2_fixed/0012-protocol-where-clause.swift
@@ -1,0 +1,4 @@
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+// REQUIRES: asserts
+
+protocol a where #^A^#


### PR DESCRIPTION
This doesn't give particularly useful information yet (i.e. Self isn't
listed, see rdar://problem/31981641 ), but it does stop the completion
code from just directly crashing.

Fixes rdar://problem/31981486.

(Isn't it great when your own fixme's come back to bite you.)