### PR TITLE
API Adjustments in preparation for updating the String proposal

### DIFF
--- a/stdlib/public/core/ASCII.swift
+++ b/stdlib/public/core/ASCII.swift
@@ -37,7 +37,7 @@ extension _Unicode.ASCII : UnicodeEncoding {
   
   @inline(__always)
   @_inlineable
-  public static func encodeIfRepresentable(
+  public static func encode(
     _ source: UnicodeScalar
   ) -> EncodedScalar? {
     guard source.value < (1&<<7) else { return nil }
@@ -45,7 +45,7 @@ extension _Unicode.ASCII : UnicodeEncoding {
   }
 
   @inline(__always)
-  public static func transcodeIfRepresentable<FromEncoding : UnicodeEncoding>(
+  public static func transcode<FromEncoding : UnicodeEncoding>(
     _ content: FromEncoding.EncodedScalar, from _: FromEncoding.Type
   ) -> EncodedScalar? {
     if _fastPath(FromEncoding.self == UTF16.self) {
@@ -58,7 +58,7 @@ extension _Unicode.ASCII : UnicodeEncoding {
       guard (c._storage & 0x80 == 0) else { return nil }
       return EncodedScalar(CodeUnit(c._storage & 0x7f))
     }
-    return encodeIfRepresentable(FromEncoding.decode(content))
+    return encode(FromEncoding.decode(content))
   }
 
   public struct Parser {
@@ -80,7 +80,7 @@ extension _Unicode.ASCII.Parser : UnicodeParser {
     let n = input.next()
     if _fastPath(n != nil), let x = n {
       guard _fastPath(Int8(extendingOrTruncating: x) >= 0)
-      else { return .invalid(length: 1) }
+      else { return .error(length: 1) }
       return .valid(_Unicode.ASCII.EncodedScalar(x))
     }
     return .emptyInput

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -50,7 +50,7 @@ public protocol StringProtocol
   /// - Parameter encoding: describes the encoding in which the code units
   ///   should be interpreted.
   init<C: Collection, Encoding: UnicodeEncoding>(
-    codeUnits: C, encoding: Encoding.Type
+    decoding codeUnits: C, as encoding: Encoding.Type
   )
     where C.Iterator.Element == Encoding.CodeUnit
 
@@ -67,8 +67,8 @@ public protocol StringProtocol
   /// - Parameter encoding: describes the encoding in which the code units
   ///   should be interpreted.
   init<Encoding: UnicodeEncoding>(
-    cString nulTerminatedCodeUnits: UnsafePointer<Encoding.CodeUnit>,
-    encoding: Encoding.Type)
+    decodingCString nulTerminatedCodeUnits: UnsafePointer<Encoding.CodeUnit>,
+    as: Encoding.Type)
     
   /// Invokes the given closure on the contents of the string, represented as a
   /// pointer to a null-terminated sequence of UTF-8 code units.
@@ -78,7 +78,7 @@ public protocol StringProtocol
   /// Invokes the given closure on the contents of the string, represented as a
   /// pointer to a null-terminated sequence of code units in the given encoding.
   func withCString<Result, Encoding: UnicodeEncoding>(
-    encoding: Encoding.Type,
+    encodedAs: Encoding.Type,
     _ body: (UnsafePointer<Encoding.CodeUnit>) throws -> Result
   ) rethrows -> Result
 }
@@ -191,10 +191,10 @@ extension _StringCore {
 
 extension String {
   public init<C: Collection, Encoding: UnicodeEncoding>(
-    codeUnits: C, encoding: Encoding.Type
+    decoding codeUnits: C, as sourceEncoding: Encoding.Type
   ) where C.Iterator.Element == Encoding.CodeUnit {
     let (b,_) = _StringBuffer.fromCodeUnits(
-      codeUnits, encoding: encoding, repairIllFormedSequences: true)
+      codeUnits, encoding: sourceEncoding, repairIllFormedSequences: true)
     self = String(_StringCore(b!))
   }
 
@@ -205,20 +205,20 @@ extension String {
   /// - Parameter encoding: describes the encoding in which the code units
   ///   should be interpreted.
   public init<Encoding: UnicodeEncoding>(
-    cString nulTerminatedCodeUnits: UnsafePointer<Encoding.CodeUnit>,
-    encoding: Encoding.Type) {
+    decodingCString nulTerminatedCodeUnits: UnsafePointer<Encoding.CodeUnit>,
+    as sourceEncoding: Encoding.Type) {
 
     let codeUnits = _SentinelCollection(
       UnsafeBufferPointer(_unboundedStartingAt: nulTerminatedCodeUnits),
       until: _IsZero()
     )
-    self.init(codeUnits: codeUnits, encoding: encoding)
+    self.init(decoding: codeUnits, as: sourceEncoding)
   }
 
   /// Invokes the given closure on the contents of the string, represented as a
   /// pointer to a null-terminated sequence of code units in the given encoding.
   public func withCString<Result, TargetEncoding: UnicodeEncoding>(
-    encoding targetEncoding: TargetEncoding.Type,
+    encodedAs targetEncoding: TargetEncoding.Type,
     _ body: (UnsafePointer<TargetEncoding.CodeUnit>) throws -> Result
   ) rethrows -> Result {
     return try _core._withCSubstring(

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -126,16 +126,16 @@ internal func _withCStringAndLength<
 where Source.Iterator.Element == SourceEncoding.CodeUnit {
   var targetLength = 0 // nul terminator
   var i = source.makeIterator()
-  SourceEncoding.ForwardParser.parse(&i) {
+  SourceEncoding.ForwardParser._parse(&i) {
     targetLength += numericCast(
-      targetEncoding.transcode($0, from: SourceEncoding.self).count)
+      targetEncoding._transcode($0, from: SourceEncoding.self).count)
   }
   var a: [TargetEncoding.CodeUnit] = []
   a.reserveCapacity(targetLength + 1)
   i = source.makeIterator()
-  SourceEncoding.ForwardParser.parse(&i) {
+  SourceEncoding.ForwardParser._parse(&i) {
     a.append(
-      contentsOf: targetEncoding.transcode($0, from: SourceEncoding.self))
+      contentsOf: targetEncoding._transcode($0, from: SourceEncoding.self))
   }
   a.append(0)
   return try body(a, targetLength)

--- a/stdlib/public/core/StringCore.swift
+++ b/stdlib/public/core/StringCore.swift
@@ -381,15 +381,15 @@ public struct _StringCore {
       else {
         // TODO: be sure tests exercise this code path.
         for b in bytes {
-          Encoding.encode(
+          Encoding._encode(
             UnicodeScalar(_unchecked: UInt32(b))).forEach(processCodeUnit)
         }
       }
     }
     else if let content = _unmanagedUTF16 {
       var i = content.makeIterator()
-      _Unicode.UTF16.ForwardParser.parse(&i) {
-        Encoding.transcode($0, from: UTF16.self).forEach(processCodeUnit)
+      _Unicode.UTF16.ForwardParser._parse(&i) {
+        Encoding._transcode($0, from: UTF16.self).forEach(processCodeUnit)
       }
     }
     else if hasCocoaBuffer {

--- a/stdlib/public/core/Substring.swift.gyb
+++ b/stdlib/public/core/Substring.swift.gyb
@@ -103,9 +103,9 @@ public struct Substring : StringProtocol {
 % end
 
   public init<C: Collection, Encoding: UnicodeEncoding>(
-    codeUnits: C, encoding: Encoding.Type
+    decoding codeUnits: C, as sourceEncoding: Encoding.Type
   ) where C.Iterator.Element == Encoding.CodeUnit {
-    self.init(String(codeUnits: codeUnits, encoding: encoding))
+    self.init(String(decoding: codeUnits, as: sourceEncoding))
   }
 
   public init(cString nulTerminatedUTF8: UnsafePointer<CChar>) {
@@ -119,9 +119,11 @@ public struct Substring : StringProtocol {
   /// - Parameter encoding: describes the encoding in which the code units
   ///   should be interpreted.
   public init<Encoding: UnicodeEncoding>(
-    cString nulTerminatedCodeUnits: UnsafePointer<Encoding.CodeUnit>,
-    encoding: Encoding.Type) {
-    self.init(String(cString: nulTerminatedCodeUnits, encoding: encoding))
+    decodingCString nulTerminatedCodeUnits: UnsafePointer<Encoding.CodeUnit>,
+    as targetEncoding: Encoding.Type
+  ) {
+    self.init(
+      String(decodingCString: nulTerminatedCodeUnits, as: targetEncoding))
   }
     
   /// Invokes the given closure on the contents of the string, represented as a
@@ -140,7 +142,7 @@ public struct Substring : StringProtocol {
   /// Invokes the given closure on the contents of the string, represented as a
   /// pointer to a null-terminated sequence of code units in the given encoding.
   public func withCString<Result, TargetEncoding: UnicodeEncoding>(
-    encoding targetEncoding: TargetEncoding.Type,
+    encodedAs targetEncoding: TargetEncoding.Type,
     _ body: (UnsafePointer<TargetEncoding.CodeUnit>) throws -> Result
   ) rethrows -> Result {
     return try _slice._base._core._withCSubstring(

--- a/stdlib/public/core/UTF16.swift
+++ b/stdlib/public/core/UTF16.swift
@@ -37,7 +37,7 @@ extension _Unicode.UTF16 : UnicodeEncoding {
     return UnicodeScalar(_unchecked: value)
   }
 
-  public static func encodeIfRepresentable(
+  public static func encode(
     _ source: UnicodeScalar
   ) -> EncodedScalar? {
     let x = source.value
@@ -52,7 +52,7 @@ extension _Unicode.UTF16 : UnicodeEncoding {
   }
 
   @inline(__always)
-  public static func transcodeIfRepresentable<FromEncoding : UnicodeEncoding>(
+  public static func transcode<FromEncoding : UnicodeEncoding>(
     _ content: FromEncoding.EncodedScalar, from _: FromEncoding.Type
   ) -> EncodedScalar? {
     if _fastPath(FromEncoding.self == UTF8.self) {
@@ -86,12 +86,12 @@ extension _Unicode.UTF16 : UnicodeEncoding {
       s &>>= 8
       r |= s & 0b0__11_1111
       r &= (1 &<< 21) - 1
-      return encodeIfRepresentable(UnicodeScalar(_unchecked: r))
+      return encode(UnicodeScalar(_unchecked: r))
     }
     else if _fastPath(FromEncoding.self == UTF16.self) {
       return unsafeBitCast(content, to: UTF16.EncodedScalar.self)
     }
-    return encodeIfRepresentable(FromEncoding.decode(content))
+    return encode(FromEncoding.decode(content))
   }
   
   public struct ForwardParser {

--- a/stdlib/public/core/UTF32.swift
+++ b/stdlib/public/core/UTF32.swift
@@ -34,7 +34,7 @@ extension _Unicode.UTF32 : UnicodeEncoding {
   }
 
   @inline(__always)
-  public static func encodeIfRepresentable(
+  public static func encode(
     _ source: UnicodeScalar
   ) -> EncodedScalar? {
     return EncodedScalar(source.value)
@@ -60,7 +60,7 @@ extension UTF32.Parser : UnicodeParser {
     if _fastPath(n != nil), let x = n {
       // Check code unit is valid: not surrogate-reserved and within range.
       guard _fastPath((x &>> 11) != 0b1101_1 && x <= 0x10ffff)
-      else { return .invalid(length: 1) }
+      else { return .error(length: 1) }
       
       // x is a valid scalar.
       return .valid(UTF32.EncodedScalar(x))

--- a/stdlib/public/core/UTF8.swift
+++ b/stdlib/public/core/UTF8.swift
@@ -58,7 +58,7 @@ extension _Unicode.UTF8 : UnicodeEncoding {
   
   @inline(__always)
   @_inlineable
-  public static func encodeIfRepresentable(
+  public static func encode(
     _ source: UnicodeScalar
   ) -> EncodedScalar? {
     var c = source.value
@@ -88,7 +88,7 @@ extension _Unicode.UTF8 : UnicodeEncoding {
   }
 
   @inline(__always)
-  public static func transcodeIfRepresentable<FromEncoding : UnicodeEncoding>(
+  public static func transcode<FromEncoding : UnicodeEncoding>(
     _ content: FromEncoding.EncodedScalar, from _: FromEncoding.Type
   ) -> EncodedScalar? {
     if _fastPath(FromEncoding.self == UTF16.self) {
@@ -118,7 +118,7 @@ extension _Unicode.UTF8 : UnicodeEncoding {
     else if _fastPath(FromEncoding.self == UTF8.self) {
       return unsafeBitCast(content, to: UTF8.EncodedScalar.self)
     }
-    return encodeIfRepresentable(FromEncoding.decode(content))
+    return encode(FromEncoding.decode(content))
   }
 
   @_fixed_layout

--- a/stdlib/public/core/UTFEncoding.swift
+++ b/stdlib/public/core/UTFEncoding.swift
@@ -81,7 +81,7 @@ where Encoding.EncodedScalar == _UIntBuffer<UInt32, Encoding.CodeUnit> {
     if _fastPath(isValid) {
       return .valid(encodedScalar)
     }
-    return .invalid(
+    return .error(
       length: Int(scalarBitCount / numericCast(Encoding.CodeUnit.bitWidth)))
   }
 }

--- a/stdlib/public/core/UnicodeEncoding.swift
+++ b/stdlib/public/core/UnicodeEncoding.swift
@@ -18,7 +18,11 @@ public protocol _UnicodeEncoding {
   associatedtype EncodedScalar : BidirectionalCollection
     where EncodedScalar.Iterator.Element == CodeUnit
 
-  /// The replacement character U+FFFD as represented in this encoding
+  /// A unicode scalar value to be used when repairing
+  /// encoding/decoding errors, as represented in this encoding.
+  ///
+  /// If the Unicode replacement character U+FFFD is representable in this
+  /// encoding, `encodedReplacementCharacter` encodes that scalar value.
   static var encodedReplacementCharacter : EncodedScalar { get }
 
   /// Converts from encoded to encoding-independent representation
@@ -30,13 +34,23 @@ public protocol _UnicodeEncoding {
 
   /// Converts a scalar from another encoding's representation, returning
   /// `nil` if the scalar can't be represented in this encoding.
+  ///
+  /// A default implementation of this method will be provided 
+  /// automatically for any conforming type that does not implement one.
   static func transcode<FromEncoding : UnicodeEncoding>(
     _ content: FromEncoding.EncodedScalar, from _: FromEncoding.Type
   ) -> EncodedScalar?
 
+  /// A type that can be used to parse `CodeUnits` into
+  /// `EncodedScalar`s.
   associatedtype ForwardParser : UnicodeParser
-  associatedtype ReverseParser : UnicodeParser
+  // where ForwardParser.Encoding == Self
   
+  /// A type that can be used to parse a reversed sequence of
+  /// `CodeUnits` into `EncodedScalar`s.
+  associatedtype ReverseParser : UnicodeParser
+  // where ReverseParser.Encoding == Self
+
   //===--------------------------------------------------------------------===//
   // FIXME: this requirement shouldn't be here and is mitigated by the default
   // implementation below.  Compiler bugs prevent it from being expressed in an

--- a/stdlib/public/core/UnicodeEncoding.swift
+++ b/stdlib/public/core/UnicodeEncoding.swift
@@ -26,11 +26,11 @@ public protocol _UnicodeEncoding {
 
   /// Converts from encoding-independent to encoded representation, returning
   /// `nil` if the scalar can't be represented in this encoding.
-  static func encodeIfRepresentable(_ content: UnicodeScalar) -> EncodedScalar?
+  static func encode(_ content: UnicodeScalar) -> EncodedScalar?
 
   /// Converts a scalar from another encoding's representation, returning
   /// `nil` if the scalar can't be represented in this encoding.
-  static func transcodeIfRepresentable<FromEncoding : UnicodeEncoding>(
+  static func transcode<FromEncoding : UnicodeEncoding>(
     _ content: FromEncoding.EncodedScalar, from _: FromEncoding.Type
   ) -> EncodedScalar?
 
@@ -55,25 +55,25 @@ public protocol UnicodeEncoding : _UnicodeEncoding
 where ForwardParser.Encoding == Self, ReverseParser.Encoding == Self {}
 
 extension _UnicodeEncoding {
-  public static func transcodeIfRepresentable<FromEncoding : UnicodeEncoding>(
+  public static func transcode<FromEncoding : UnicodeEncoding>(
     _ content: FromEncoding.EncodedScalar, from _: FromEncoding.Type
   ) -> EncodedScalar? {
-    return encodeIfRepresentable(FromEncoding.decode(content))
+    return encode(FromEncoding.decode(content))
   }
 
   /// Converts from encoding-independent to encoded representation, returning
   /// `encodedReplacementCharacter` if the scalar can't be represented in this
   /// encoding.
-  public static func encode(_ content: UnicodeScalar) -> EncodedScalar {
-    return encodeIfRepresentable(content) ?? encodedReplacementCharacter
+  internal static func _encode(_ content: UnicodeScalar) -> EncodedScalar {
+    return encode(content) ?? encodedReplacementCharacter
   }
 
   /// Converts a scalar from another encoding's representation, returning
   /// `encodedReplacementCharacter` if the scalar can't be represented in this
   /// encoding.
-  public static func transcode<FromEncoding : UnicodeEncoding>(
+  internal static func _transcode<FromEncoding : UnicodeEncoding>(
     _ content: FromEncoding.EncodedScalar, from _: FromEncoding.Type
   ) -> EncodedScalar {
-    return encode(FromEncoding.decode(content))
+    return _encode(FromEncoding.decode(content))
   }
 }

--- a/stdlib/public/core/UnicodeParser.swift
+++ b/stdlib/public/core/UnicodeParser.swift
@@ -10,18 +10,31 @@
 //
 //===----------------------------------------------------------------------===//
 extension _Unicode {
+  /// The result of attempting to parse a `T` from some input.
   public enum ParseResult<T> {
+  /// A `T` was parsed successfully
   case valid(T)
+  
+  /// The input was entirely consumed.
   case emptyInput
+  
+  /// An encoding error was detected.
+  ///
+  /// `length` is the number of underlying code units consumed by this
+  /// error (the length of the longest prefix of a valid encoding
+  /// sequence that could be recognized).
   case error(length: Int)
   }
 }
 
-/// Types that separate streams of code units into encoded unicode scalar values
+/// Types that separate streams of code units into encoded Unicode
+/// scalar values.
 public protocol UnicodeParser {
   /// The encoding with which this parser is associated
   associatedtype Encoding : _UnicodeEncoding
 
+  /// Constructs an instance that can be used to begin parsing `CodeUnit`s at
+  /// any Unicode scalar boundary.
   init()
 
   /// Parses a single Unicode scalar value from `input`.

--- a/stdlib/public/core/UnicodeParser.swift
+++ b/stdlib/public/core/UnicodeParser.swift
@@ -13,14 +13,7 @@ extension _Unicode {
   public enum ParseResult<T> {
   case valid(T)
   case emptyInput
-  case invalid(length: Int)
-
-    var isEmpty : Bool {
-      switch self {
-      case .emptyInput: return true
-      default: return false
-      }
-    }
+  case error(length: Int)
   }
 }
 
@@ -39,9 +32,10 @@ public protocol UnicodeParser {
 }
 
 extension UnicodeParser {
+  @_versioned
   @inline(__always)
   @discardableResult
-  public static func parse<I: IteratorProtocol>(
+  internal static func _parse<I: IteratorProtocol>(
     _ input: inout I,
     repairingIllFormedSequences makeRepairs: Bool = true,
     into output: (Encoding.EncodedScalar)->Void
@@ -54,7 +48,7 @@ extension UnicodeParser {
       switch d.parseScalar(from: &input) {
       case let .valid(scalarContent):
         output(scalarContent)
-      case .invalid:
+      case .error:
         if _slowPath(!makeRepairs) { return 1 }
         errorCount += 1
         output(Encoding.encodedReplacementCharacter)
@@ -66,14 +60,14 @@ extension UnicodeParser {
 
   @inline(__always)
   @discardableResult
-  public static func decode<I: IteratorProtocol>(
+  public static func _decode<I: IteratorProtocol>(
     _ input: inout I,
     repairingIllFormedSequences makeRepairs: Bool,
     into output: (UnicodeScalar)->Void
   ) -> Int
   where I.Element == Encoding.CodeUnit
   {
-    return parse(&input, repairingIllFormedSequences: makeRepairs) {
+    return _parse(&input, repairingIllFormedSequences: makeRepairs) {
       output(Encoding.decode($0))
     }
   }
@@ -81,7 +75,8 @@ extension UnicodeParser {
 
 extension _Unicode {
   @_fixed_layout
-  public struct ParsingIterator<
+  public // @testable
+  struct _ParsingIterator<
     CodeUnitIterator : IteratorProtocol, 
     Parser: UnicodeParser
   > where Parser.Encoding.CodeUnit == CodeUnitIterator.Element {
@@ -96,13 +91,13 @@ extension _Unicode {
   }
 }
 
-extension _Unicode.ParsingIterator : IteratorProtocol, Sequence {
+extension _Unicode._ParsingIterator : IteratorProtocol, Sequence {
   @inline(__always)
   @_inlineable
   public mutating func next() -> Parser.Encoding.EncodedScalar? {
     switch parser.parseScalar(from: &codeUnits) {
     case let .valid(scalarContent): return scalarContent
-    case .invalid: return Parser.Encoding.encodedReplacementCharacter
+    case .error: return Parser.Encoding.encodedReplacementCharacter
     case .emptyInput: return nil
     }
   }

--- a/test/Prototypes/UnicodeDecoders.swift
+++ b/test/Prototypes/UnicodeDecoders.swift
@@ -190,7 +190,8 @@ func checkStringProtocol<S : StringProtocol, Encoding: UnicodeEncoding>(
   expectingUTF32 expected: [UInt32]
 ) {
   expectEqualSequence(
-    expected, utf32(s), "\(S.self) init(codeUnits:encoding:)")
+    expected, utf32(S(decoding: utfStr, as: Encoding.self)),
+    "\(S.self) init(decoding:as:)")
 
   if !utfStr.contains(0) {
     if Encoding.self == UTF8.self {
@@ -202,7 +203,7 @@ func checkStringProtocol<S : StringProtocol, Encoding: UnicodeEncoding>(
     
     var ntbs = Array(utfStr); ntbs.append(0)
     expectEqualSequence(
-      expected, utf32(S(cString: ntbs, encoding: Encoding.self)),
+      expected, utf32(S(decodingCString: ntbs, as: Encoding.self)),
       "\(S.self) init(cString:encoding:)"
     )
 
@@ -210,8 +211,8 @@ func checkStringProtocol<S : StringProtocol, Encoding: UnicodeEncoding>(
       expectEqual(s, S(cString: $0), "\(S.self) withCString(_:)")
     }
     
-    s.withCString(encoding: Encoding.self) {
-      expectEqual(s, S(cString: $0, encoding: Encoding.self),
+    s.withCString(encodedAs: Encoding.self) {
+      expectEqual(s, S(decodingCString: $0, as: Encoding.self),
         "\(S.self) withCString(encoding:_:)")
     }
   }
@@ -313,13 +314,15 @@ func checkDecodeUTF<Codec : UnicodeCodec & UnicodeEncoding>(
   
   //===--- String/Substring Construction and C-String interop -------------===//
   do {
-    let s = String(codeUnits: utfStr, encoding: Codec.self)
+    let s = String(decoding: utfStr, as: Codec.self)
     checkStringProtocol(
       s, utfStr, encodedAs: Codec.self, expectingUTF32: expected)
   }
   
   do {
-    let s0 = "\n" + String(codeUnits: utfStr, encoding: Codec.self) + "\n"
+    let s0 = "\n" + String(decoding: utfStr, as: Codec.self) + "\n"
+    let s = s0.dropFirst().dropLast()
+    expectEqualSequence(expected, utf32(s), "Sliced Substring")
     checkStringProtocol(
       s0.dropFirst().dropLast(),
       utfStr, encodedAs: Codec.self, expectingUTF32: expected)


### PR DESCRIPTION
Made the new `StringProtocol` APIs more fluent, and hid the awkwardness of our higher-level Unicode transcoding components by leaving only the essentials exposed publicly/de-underscored.

I'd appreciate feedback on the `StringProtocol` API adjustments in particular, based on an examination of use-sites.  Keep in mind, though, that many of the use-sites we have in the tests are generic, and in practice I normally expect people will be passing explicit concrete encodings (e.g. `UTF8.self`).