### PR TITLE
[4.0] [QoI] Properly diagnose closure parameter distructuring after SE-0110

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1064,6 +1064,8 @@ ERROR(anon_closure_arg_in_closure_with_args,none,
 ERROR(anon_closure_arg_in_closure_with_args_typo,none,
       "anonymous closure arguments cannot be used inside a closure that has "
       "explicit arguments; did you mean '%0'?", (StringRef))
+ERROR(anon_closure_tuple_param_destructuring,none,
+      "closure tuple parameter does not support destructuring", ())
 ERROR(expected_closure_parameter_name,none,
       "expected the name of a closure parameter", ())
 ERROR(expected_capture_specifier,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2804,6 +2804,11 @@ ERROR(closure_argument_list_tuple,none,
 ERROR(closure_argument_list_missing,none,
       "contextual type for closure argument list expects %0 argument%s0, "
       "which cannot be implicitly ignored", (unsigned))
+ERROR(closure_tuple_parameter_destructuring,none,
+      "closure tuple parameter %0 does not support destructuring", (Type))
+ERROR(closure_tuple_parameter_destructuring_implicit,none,
+      "closure tuple parameter %0 does not support destructuring "
+      "with implicit parameters", (Type))
 
 ERROR(tuple_pattern_length_mismatch,none,
       "tuple pattern has the wrong length for tuple type %0", (Type))

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -266,10 +266,18 @@ Parser::parseParameterClause(SourceLoc &leftParenLoc,
         status |= type;
         param.Type = type.getPtrOrNull();
 
-        // Unnamed parameters must be written as "_: Type".
+        // If this is a closure declaration, what is going
+        // on is most likely argument destructuring, we are going
+        // to diagnose that after all of the parameters are parsed.
         if (param.Type) {
-          diagnose(typeStartLoc, diag::parameter_unnamed)
-            .fixItInsert(typeStartLoc, "_: ");
+          // Mark current parameter as invalid so it is possible
+          // to diagnose it as destructuring of the closure parameter list.
+          param.isInvalid = true;
+          if (!isClosure) {
+            // Unnamed parameters must be written as "_: Type".
+            diagnose(typeStartLoc, diag::parameter_unnamed)
+                .fixItInsert(typeStartLoc, "_: ");
+          }
         }
       } else {
         // Otherwise, we're not sure what is going on, but this doesn't smell

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -6525,7 +6525,9 @@ bool FailureDiagnosis::visitClosureExpr(ClosureExpr *CE) {
     // in either case, we want to produce nice and clear diagnostics.
     unsigned actualArgCount = params->size();
     unsigned inferredArgCount = 1;
-    if (auto *argTupleTy = inferredArgType->getAs<TupleType>())
+    // Don't try to desugar ParenType which is going to result in incorrect
+    // inferred argument count.
+    if (auto *argTupleTy = dyn_cast<TupleType>(inferredArgType.getPointer()))
       inferredArgCount = argTupleTy->getNumElements();
     
     // If the actual argument count is 1, it can match a tuple as a whole.
@@ -6557,7 +6559,144 @@ bool FailureDiagnosis::visitClosureExpr(ClosureExpr *CE) {
         }
         return true;
       }
-      
+
+      if (inferredArgCount == 1 && actualArgCount > 1) {
+        // Let's see if inferred argument is actually a tuple inside of Paren.
+        if (auto *argTupleTy = inferredArgType->getAs<TupleType>()) {
+          // Looks like the number of closure parameters matches number
+          // of inferred arguments, which means we can we can emit an
+          // error about an attempt to make use of tuple splat or tuple
+          // destructuring and provide a proper fix-it.
+          if (argTupleTy->getNumElements() == actualArgCount) {
+            // In case of implicit parameters e.g. $0, $1 we
+            // can't really provide good fix-it because
+            // structure of parameter type itself is unclear.
+            for (auto *param : params->getArray()) {
+              if (param->isImplicit()) {
+                diagnose(params->getStartLoc(),
+                         diag::closure_tuple_parameter_destructuring_implicit,
+                         argTupleTy);
+                return true;
+              }
+            }
+
+            auto diag = diagnose(params->getStartLoc(),
+                                 diag::closure_tuple_parameter_destructuring,
+                                 argTupleTy);
+            Type actualArgType;
+            if (auto *actualFnType = CE->getType()->getAs<AnyFunctionType>())
+              actualArgType = actualFnType->getInput();
+
+            auto *closureBody = CE->getBody();
+            if (!closureBody)
+              return true;
+
+            auto &sourceMgr = CS->getASTContext().SourceMgr;
+            auto bodyStmts = closureBody->getElements();
+
+            SourceLoc bodyLoc;
+            // If the body is empty let's put the cursor
+            // right after "in", otherwise make it start
+            // location of the first statement in the body.
+            if (bodyStmts.empty())
+              bodyLoc = Lexer::getLocForEndOfToken(sourceMgr, CE->getInLoc());
+            else
+              bodyLoc = bodyStmts.front().getStartLoc();
+
+            SmallString<64> fixIt;
+            llvm::raw_svector_ostream OS(fixIt);
+
+            // If this is multi-line closure we'd have to insert new lines
+            // in the suggested 'let' to keep the structure of the code intact,
+            // otherwise just use ';' to keep everything on the same line.
+            auto inLine = sourceMgr.getLineNumber(CE->getInLoc());
+            auto bodyLine = sourceMgr.getLineNumber(bodyLoc);
+            auto isMultiLineClosure = bodyLine > inLine;
+            auto indent = bodyStmts.empty() ? "" : Lexer::getIndentationForLine(
+                                                       sourceMgr, bodyLoc);
+
+            SmallString<16> parameter;
+            llvm::raw_svector_ostream parameterOS(parameter);
+
+            parameterOS << "(";
+            interleave(params->getArray(),
+                       [&](const ParamDecl *param) {
+                         parameterOS << param->getNameStr();
+                       },
+                       [&] { parameterOS << ", "; });
+            parameterOS << ")";
+
+            // Check if there are any explicit types associated
+            // with parameters, if there are, we'll have to add
+            // type information to the replacement argument.
+            bool explicitTypes = false;
+            for (auto *param : params->getArray()) {
+              if (param->getTypeLoc().getTypeRepr()) {
+                explicitTypes = true;
+                break;
+              }
+            }
+
+            if (isMultiLineClosure)
+              OS << '\n' << indent;
+
+            // Let's form 'let <name> : [<type>]? = arg' expression.
+            OS << "let " << parameterOS.str() << " = arg"
+               << (isMultiLineClosure ? "\n" + indent : "; ");
+
+            SmallString<64> argName;
+            llvm::raw_svector_ostream nameOS(argName);
+            if (explicitTypes) {
+              nameOS << "(arg: " << argTupleTy->getString() << ")";
+            } else {
+              nameOS << "(arg)";
+            }
+
+            if (CE->hasSingleExpressionBody()) {
+              // Let's see if we need to add result type to the argument/fix-it:
+              //  - if the there is a result type associated with the closure;
+              //  - and it's not a void type;
+              //  - and it hasn't been explicitly written.
+              auto resultType = CE->getResultType();
+              auto hasResult = [](Type resultType) -> bool {
+                return resultType && !resultType->isVoid();
+              };
+
+              auto isValidType = [](Type resultType) -> bool {
+                return resultType && !resultType->hasUnresolvedType() &&
+                       !resultType->hasTypeVariable();
+              };
+
+              // If there an expected result type but it hasn't been explictly
+              // provided, let's add it to the argument.
+              if (hasResult(resultType) && !CE->hasExplicitResultType()) {
+                nameOS << " -> ";
+                if (isValidType(resultType))
+                  nameOS << resultType->getString();
+                else
+                  nameOS << "<#Result#>";
+              }
+
+              if (auto stmt = bodyStmts.front().get<Stmt *>()) {
+                // If the body is a single expression with implicit return.
+                if (isa<ReturnStmt>(stmt) && stmt->isImplicit()) {
+                  // And there is non-void expected result type,
+                  // because we add 'let' expression to the body
+                  // we need to make such 'return' explicit.
+                  if (hasResult(resultType))
+                    OS << "return ";
+                }
+              }
+            }
+
+            diag.fixItReplace(params->getSourceRange(), nameOS.str())
+                .fixItInsert(bodyLoc, OS.str());
+
+            return true;
+          }
+        }
+      }
+
       // Okay, the wrong number of arguments was used, complain about that.
       // Before doing so, strip attributes off the function type so that they
       // don't confuse the issue.

--- a/test/decl/func/functions.swift
+++ b/test/decl/func/functions.swift
@@ -104,7 +104,7 @@ _ = nullaryClosure(0)
 // parameter labels, and they are thus not in scope in the body of the function.
 // expected-error@+1{{unnamed parameters must be written}} {{27-27=_: }}
 func destructureArgument( (result: Int, error: Bool) ) -> Int {
-  return result  // expected-error {{use of unresolved identifier 'result'}}
+  return result
 }
 
 // The former is the same as this:

--- a/validation-test/IDE/crashers_2/0013-unmapped-dependent-type-2.swift
+++ b/validation-test/IDE/crashers_2/0013-unmapped-dependent-type-2.swift
@@ -1,6 +1,0 @@
-// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-// REQUIRES: asserts
-
-func a<b>(() -> b) -> b {
-  a {}#^A^#
-}

--- a/validation-test/IDE/crashers_2_fixed/0013-unmapped-dependent-type-2.swift
+++ b/validation-test/IDE/crashers_2_fixed/0013-unmapped-dependent-type-2.swift
@@ -1,0 +1,5 @@
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+
+func a<b>(() -> b) -> b {
+  a {}#^A^#
+}

--- a/validation-test/compiler_crashers_fixed/28723-unreachable-executed-at-swift-lib-sema-csdiag-cpp-4012.swift
+++ b/validation-test/compiler_crashers_fixed/28723-unreachable-executed-at-swift-lib-sema-csdiag-cpp-4012.swift
@@ -5,6 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 func t(UInt=__FUNCTION__
 func&t(


### PR DESCRIPTION
* Description: Swift 3 supported limited argument destructuring when it comes to
declaring (trailing) closures. Such behavior has been changed by
SE-0110. This patch aims to provide better error message as well
as fix-it (if structure of the expected and actual arguments matches)
to make the migration easier and disambiguate some of the common
mistakes.

* Scope of the issue: Affects anyone migrating code from Swift 3 to Swift 4.

* Origin: SE-0110 changed behavior of argument matching, this fix aims to provide proper diagnostic as well as fix-it for closures with tuple parameter splat.

* Risk: Low, this is diagnostic improvements.

* Tested: New test cases added.

* Reviewed by: Jordan Rose, Mark Lacey.

(cherry picked from commit 5adeff065cf6481a9a69a92ff11e395da365a9cc)

Resolves [SR-4738](https://bugs.swift.org/browse/SR-4738).
Resolves [SR-4745](https://bugs.swift.org/browse/SR-4745).
Resolves: rdar://problem/31892961.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
