### PR TITLE
Better fix for handling Equal constraints in matchTypes.

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1425,22 +1425,17 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
         if (typeVarOccursInType(typeVar1, type2))
           return formUnsolvedResult();
 
-        // Equal constraints allow mixed LValue/RValue bindings.
+        // Equal constraints allow mixed LValue/RValue bindings, but
+        // if we bind a type to a type variable that can bind to
+        // LValues as part of simplifying the Equal constraint we may
+        // later block a binding of the opposite "LValue-ness" to the
+        // same type variable that happens as part of simplifying
+        // another constraint.
         if (kind == ConstraintKind::Equal) {
-          // If we could bind an LValue to the type variable, but the
-          // type that is already bound is not an LValue, defer
-          // simplifying the constraint since we may come along at a
-          // later time and attempt to bind the LValue type to this
-          // type variable.
-          if (typeVar1->getImpl().canBindToLValue()) {
-            if (!type2->isLValueType()) {
-              return formUnsolvedResult();
-            }
-          } else {
-            // If the type variable does not allow LValue bindings,
-            // get the RValue type.
-            type2 = type2->getRValueType();
-          }
+          if (typeVar1->getImpl().canBindToLValue())
+            return formUnsolvedResult();
+
+          type2 = type2->getRValueType();
         }
 
         // If the left-hand type variable cannot bind to an lvalue,
@@ -1480,22 +1475,17 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
       if (typeVarOccursInType(typeVar2, type1))
         return formUnsolvedResult();
 
-      // Equal constraints allow mixed LValue/RValue bindings.
+      // Equal constraints allow mixed LValue/RValue bindings, but
+      // if we bind a type to a type variable that can bind to
+      // LValues as part of simplifying the Equal constraint we may
+      // later block a binding of the opposite "LValue-ness" to the
+      // same type variable that happens as part of simplifying
+      // another constraint.
       if (kind == ConstraintKind::Equal) {
-        // If we could bind an LValue to the type variable, but the
-        // type that is already bound is not an LValue, defer
-        // simplifying the constraint since we may come along at a
-        // later time and attempt to bind the LValue type to this
-        // type variable.
-        if (typeVar2->getImpl().canBindToLValue()) {
-          if (!type1->isLValueType()) {
-            return formUnsolvedResult();
-          }
-        } else {
-          // If the type variable does not allow LValue bindings,
-          // get the RValue type.
-          type1 = type1->getRValueType();
-        }
+        if (typeVar2->getImpl().canBindToLValue())
+          return formUnsolvedResult();
+
+        type1 = type1->getRValueType();
       }
 
       if (!typeVar2->getImpl().canBindToLValue() &&


### PR DESCRIPTION
The fix committed in 15fb957f09f5d51c2738e236203daf677c14bd51 still
allows for the possibility that we can bind one type as part of
processing the Equal constraint and then later come along and attempt to
bind the LValue version of that type as part of processing another
constraint.

Ideally we would not bind any types as part of handling Equal, but
attempting to do that resulted in some significant regressions in
diagnostics which will need to be investigated at a later date.

I don't have a test case for this as it was discovered by thought
process, not testing, and constructing a test case isn't really feasible
because it relies on a lot of specifics about the order in which things
happen to be processed the constraint solver.
