### PR TITLE
[Migrator] Fix optional types not being updated correctly in some cases

### DIFF
--- a/test/Migrator/API.json
+++ b/test/Migrator/API.json
@@ -207,12 +207,12 @@
   {
     "DiffItemKind": "CommonDiffItem",
     "NodeKind": "Function",
-    "NodeAnnotation": "UnwrapOptional",
-    "ChildIndex": "0",
+    "NodeAnnotation": "TypeRewritten",
+    "ChildIndex": "0:0",
     "LeftUsr": "s:6CitiesAAC7buderimABSgyF",
     "LeftComment": "",
     "RightUsr": "",
-    "RightComment": "",
+    "RightComment": "Cities & ExtraCities",
     "ModuleName": "Cities"
   },
   {
@@ -389,6 +389,28 @@
     "LeftComment": "",
     "RightUsr": "",
     "RightComment": "setZooLocationNew(newX:newY:newZ:)",
+    "ModuleName": "Cities"
+  },
+  {
+    "DiffItemKind": "CommonDiffItem",
+    "NodeKind": "Function",
+    "NodeAnnotation": "TypeRewritten",
+    "ChildIndex": "1:0",
+    "LeftUsr": "s:6CitiesAAC8maroochyySiSg1x_AD1ytF",
+    "LeftComment": "Int",
+    "RightUsr": "",
+    "RightComment": "(Int) -> Int",
+    "ModuleName": "Cities"
+  },
+  {
+    "DiffItemKind": "CommonDiffItem",
+    "NodeKind": "Function",
+    "NodeAnnotation": "TypeRewritten",
+    "ChildIndex": "2:0",
+    "LeftUsr": "s:6CitiesAAC8maroochyySiSg1x_AD1ytF",
+    "LeftComment": "Int",
+    "RightUsr": "",
+    "RightComment": "(Int) -> Int",
     "ModuleName": "Cities"
   }
 ]

--- a/test/Migrator/Inputs/cities.swift
+++ b/test/Migrator/Inputs/cities.swift
@@ -8,6 +8,7 @@ open class Cities {
   open func yandina(x: [[String : Cities]]!) {}
   open func buderim() -> Cities? { return Cities(x: 1) }
   open func noosa() -> [[String : Cities]?] { return [] }
+  open func maroochy(x: Int?, y: Int?) {}
 }
 
 public protocol ExtraCities {

--- a/test/Migrator/wrap_optional.swift
+++ b/test/Migrator/wrap_optional.swift
@@ -12,13 +12,14 @@ class MyCities : Cities {
   override func mooloolaba(x: Cities, y: Cities?) {}
   override func toowoomba(x: [Cities], y: [Cities]?) {}
   override func mareeba(x: [String : Cities?], y: [String : Cities]?) {}
+  override func maroochy(x: (Int)?, y: Int?) {}
 }
 
 class MySubCities : MyCities {}
 
 class MySubSubCities : MySubCities {
   override func yandina(x: [[String : Cities]]!) {}
-  override func buderim() -> Cities? { return Cities(x: 1) }
+  override func buderim() -> Cities? { return nil }
   override func noosa() -> [[String : Cities]?] { return [] }
 }
 

--- a/test/Migrator/wrap_optional.swift.expected
+++ b/test/Migrator/wrap_optional.swift.expected
@@ -12,13 +12,14 @@ class MyCities : Cities {
   override func newMooloolaba(newX x: Cities?, newY y: Cities) {}
   override func toowoomba(x: [Cities?], y: [Cities?]) {}
   override func mareeba(x: [String? : Cities], y: [Int : Cities]) {}
+  override func maroochy(x: ((Int) -> Int)?, y: ((Int) -> Int)?) {}
 }
 
 class MySubCities : MyCities {}
 
 class MySubSubCities : MySubCities {
   override func yandina(x: [[Int : Cities]]?) {}
-  override func buderim() -> Cities { return Cities(x: 1) }
+  override func buderim() -> (Cities & ExtraCities)? { return nil }
   override func noosa() -> [[Int : Cities]] { return [] }
 }
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
If the replacement type was a function type or protocol-constrained type (e.g.  `Class & Proto`) and the existing type had a postfix `?` or `!`, we weren't wrapping the replacement in parens. This would result in an incorrect/ambiguous new type. This patch wraps the replacement in parens if it contains an `&` or `->` and the existing type has a trailing `?` or `!`.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves rdar://problem/32082269.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->