### PR TITLE
[4.0] Runtime: swift_getExistentialTypeMetadata should trust the compiler's ordering of protocols in compositions.

### DIFF
--- a/stdlib/public/runtime/Demangle.cpp
+++ b/stdlib/public/runtime/Demangle.cpp
@@ -160,13 +160,19 @@ swift::_swift_buildDemanglingForMetadata(const Metadata *type,
     proto_list->addChild(type_list, Dem);
 
     // Sort the protocols by their mangled names.
-    // The ordering in the existential type metadata is by metadata pointer,
-    // which isn't necessarily stable across invocations.
+    // This shouldn't strictly be necessary, since the compiler will invoke the
+    // runtime getExistentialTypeMetadata entry point with the protocol
+    // descriptors in canonical order, but we got this ordering wrong in 3.x
+    // (because protocols in the Swift module mangle as `s10identifier` instead
+    // of `10Identifier10identifier`, leading to different-from-alphabetical
+    // order) and don't want to risk disturbing the mangled runtime names
+    // of classes in 4.0.
     std::sort(protocols.begin(), protocols.end(),
           [](const ProtocolDescriptor *a, const ProtocolDescriptor *b) -> bool {
             return strcmp(a->Name, b->Name) < 0;
           });
     
+
     for (auto *protocol : protocols) {
       // The protocol name is mangled as a type symbol, with the _Tt prefix.
       StringRef ProtoName(protocol->Name);

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -2503,8 +2503,9 @@ swift::swift_getExistentialTypeMetadata(ProtocolClassConstraint classConstraint,
                                         const ProtocolDescriptor **protocols)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
 
-  // Sort the protocol set.
-  std::sort(protocols, protocols + numProtocols);
+  // We entrust that the compiler emitting the call to
+  // swift_getExistentialTypeMetadata always sorts the `protocols` array using
+  // a globally stable ordering that's consistent across modules.
 
   ExistentialCacheEntry::Key key = {
     superclassConstraint, classConstraint, numProtocols, protocols

--- a/unittests/runtime/Metadata.cpp
+++ b/unittests/runtime/Metadata.cpp
@@ -448,41 +448,6 @@ TEST(MetadataTest, getExistentialMetadata) {
       return b;
     });
 
-  // protocol compositions are order-invariant
-  RaceTest_ExpectEqual<const ExistentialTypeMetadata *>(
-    [&]() -> const ExistentialTypeMetadata * {
-
-      const ProtocolDescriptor *protoList4[] = {
-        &ProtocolA,
-        &ProtocolB
-      };
-
-      const ProtocolDescriptor *protoList5[] = {
-        &ProtocolB,
-        &ProtocolA
-      };
-
-      auto ab = swift_getExistentialTypeMetadata(ProtocolClassConstraint::Any,
-                                                /*superclass=*/nullptr,
-                                                2, protoList4);
-      auto ba = swift_getExistentialTypeMetadata(ProtocolClassConstraint::Any,
-                                                /*superclass=*/nullptr,
-                                                2, protoList5);
-      EXPECT_EQ(ab, ba);
-      EXPECT_EQ(MetadataKind::Existential, ab->getKind());
-      EXPECT_EQ(2U, ab->Flags.getNumWitnessTables());
-      EXPECT_EQ(ProtocolClassConstraint::Any, ab->Flags.getClassConstraint());
-      EXPECT_EQ(2U, ab->Protocols.NumProtocols);
-      EXPECT_TRUE(
-           (ab->Protocols[0]==&ProtocolA && ab->Protocols[1]==&ProtocolB)
-        || (ab->Protocols[0]==&ProtocolB && ab->Protocols[1]==&ProtocolA));
-      EXPECT_EQ(SpecialProtocol::None,
-                ab->Flags.getSpecialProtocol());
-      EXPECT_EQ(nullptr,
-                ab->getSuperclassConstraint());
-      return ab;
-    });
-
   const ProtocolDescriptor *protoList6[] = {
     &ProtocolClassConstrained,
   };
@@ -864,10 +829,8 @@ TEST(MetadataTest, getExistentialTypeMetadata_subclass) {
       EXPECT_EQ(ProtocolClassConstraint::Class,
                 ex2->Flags.getClassConstraint());
       EXPECT_EQ(2U, ex2->Protocols.NumProtocols);
-      EXPECT_TRUE((ex2->Protocols[0] == &OpaqueProto1 &&
-                   ex2->Protocols[1] == &ClassProto1) ||
-                  (ex2->Protocols[0] == &ClassProto1 &&
-                   ex2->Protocols[1] == &OpaqueProto1));
+      EXPECT_TRUE(ex2->Protocols[0] == &OpaqueProto1 &&
+                  ex2->Protocols[1] == &ClassProto1);
       EXPECT_EQ(&MetadataTest2, ex2->getSuperclassConstraint());
       return ex2;
     });

--- a/validation-test/Reflection/reflect_existential.swift
+++ b/validation-test/Reflection/reflect_existential.swift
@@ -78,8 +78,8 @@ reflect(object: TestGeneric(D() as (P & AnyObject)))
 // CHECK-64: Type reference:
 // CHECK-64: (bound_generic_class reflect_existential.TestGeneric
 // CHECK-64:   (protocol_composition any_object
-// CHECK-64:     (protocol reflect_existential.P)
-// CHECK-64:     (protocol Swift.AnyObject)))
+// CHECK-64:     (protocol Swift.AnyObject)
+// CHECK-64:     (protocol reflect_existential.P)))
 
 // CHECK-64: Type info:
 // CHECK-64: (class_instance size=32 alignment=8 stride=32 num_extra_inhabitants=0
@@ -93,8 +93,8 @@ reflect(object: TestGeneric(D() as (P & AnyObject)))
 // CHECK-32: Type reference:
 // CHECK-32: (bound_generic_class reflect_existential.TestGeneric
 // CHECK-32:   (protocol_composition any_object
-// CHECK-32:     (protocol reflect_existential.P)
-// CHECK-32:     (protocol Swift.AnyObject)))
+// CHECK-32:     (protocol Swift.AnyObject)
+// CHECK-32:     (protocol reflect_existential.P)))
 
 // CHECK-32: Type info:
 // CHECK-32: (class_instance size=20 alignment=4 stride=20 num_extra_inhabitants=0


### PR DESCRIPTION
Explanation: The compiler pre-canonicalizes protocol composition types by minimizing constraints and sorting the remaining protocols by module + name, which ought to be globally stable within a program (assuming there aren't multiple modules with the same name, in which case we'll have bigger problems…). The compiler also statically lays out existential types according to its conception of the canonical composition ordering, so the runtime's own attempts to form a stable ordering lead to layout inconsistencies between runtime and compile-time layout, leading to crashes.

Scope: Dynamic casts or generic code involving protocol compositions can misbehave at runtime in arbitrary ways.

Issue: SR-4477, rdar://problem/31404278

Risk: Low

Testing: Swift CI, test case from Jira