### PR TITLE
[capture-promotion] Loosen an assert.

### DIFF
--- a/lib/SILOptimizer/IPO/CapturePromotion.cpp
+++ b/lib/SILOptimizer/IPO/CapturePromotion.cpp
@@ -636,8 +636,8 @@ void ClosureCloner::visitLoadBorrowInst(LoadBorrowInst *LI) {
     // the loads get mapped to uses of the new object type argument.
     //
     // We assume that the value is already guaranteed.
-    assert(Val.getOwnershipKind() == ValueOwnershipKind::Guaranteed
-           && "Expected argument value to be guaranteed");
+    assert(Val.getOwnershipKind().isTrivialOr(ValueOwnershipKind::Guaranteed) &&
+           "Expected argument value to be guaranteed");
     ValueMap.insert(std::make_pair(LI, Val));
     return;
   }
@@ -678,8 +678,8 @@ void ClosureCloner::visitLoadInst(LoadInst *LI) {
     // struct_extract of the new passed in value. The value should be borrowed
     // already.
     SILBuilderWithPostProcess<ClosureCloner, 1> B(this, LI);
-    assert(B.getFunction().hasUnqualifiedOwnership()
-           || Val.getOwnershipKind() == ValueOwnershipKind::Guaranteed);
+    assert(B.getFunction().hasUnqualifiedOwnership() ||
+           Val.getOwnershipKind().isTrivialOr(ValueOwnershipKind::Guaranteed));
     SILValue V =
         B.emitStructExtract(LI->getLoc(), Val, SEAI->getField(), LI->getType());
     ValueMap.insert(std::make_pair(LI, V));

--- a/test/SILOptimizer/capture_promotion_ownership.sil
+++ b/test/SILOptimizer/capture_promotion_ownership.sil
@@ -31,7 +31,7 @@ sil @baz_init : $@convention(thin) (@thin Baz.Type) -> @owned Baz
 sil @dummy_func : $@convention(thin) (Int, Int, Int) -> Int
 
 // CHECK-LABEL: sil @test_capture_promotion
-sil @test_capture_promotion : $@convention(thin) () -> @owned @callee_owned () -> Int {
+sil @test_capture_promotion : $@convention(thin) () -> @owned @callee_owned () -> (Int, Builtin.Int64) {
 bb0:
   // CHECK: [[BOX1:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <Foo>
   // CHECK: [[MARKED_BOX1:%.*]] = mark_uninitialized [var] [[BOX1]]
@@ -88,17 +88,17 @@ bb0:
 // previously used to capture and pass the variable by reference
 // CHECK-NEXT: {{.*}} = partial_apply [[CLOSURE_PROMOTE]]([[LOADFOO]], [[LOADBAZ]], [[LOADINT]])
 
-  %17 = function_ref @closure0 : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Foo>, @owned <τ_0_0> { var τ_0_0 } <Baz>, @owned <τ_0_0> { var τ_0_0 } <Int>) -> Int
+  %17 = function_ref @closure0 : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Foo>, @owned <τ_0_0> { var τ_0_0 } <Baz>, @owned <τ_0_0> { var τ_0_0 } <Int>) -> (Int, Builtin.Int64)
   %18 = copy_value %1ab : $<τ_0_0> { var τ_0_0 } <Foo>
   %19 = copy_value %6 : $<τ_0_0> { var τ_0_0 } <Baz>
   %20 = copy_value %11 : $<τ_0_0> { var τ_0_0 } <Int>
-  %21 = partial_apply %17(%18, %19, %20) : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Foo>, @owned <τ_0_0> { var τ_0_0 } <Baz>, @owned <τ_0_0> { var τ_0_0 } <Int>) -> Int
+  %21 = partial_apply %17(%18, %19, %20) : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Foo>, @owned <τ_0_0> { var τ_0_0 } <Baz>, @owned <τ_0_0> { var τ_0_0 } <Int>) -> (Int, Builtin.Int64)
 
   destroy_value %11 : $<τ_0_0> { var τ_0_0 } <Int>
   destroy_value %6 : $<τ_0_0> { var τ_0_0 } <Baz>
   destroy_value %1ab : $<τ_0_0> { var τ_0_0 } <Foo>
 
-  return %21 : $@callee_owned () -> Int
+  return %21 : $@callee_owned () -> (Int, Builtin.Int64)
 }
 
 // CHECK-LABEL: sil @test_capture_promotion_indirect
@@ -163,7 +163,7 @@ bb0:
   return %21 : $@callee_owned () -> @out Int
 }
 
-// CHECK-LABEL: sil private @_T08closure0Tf2iii_n : $@convention(thin) (@owned Foo, @owned Baz, Int) -> Int {
+// CHECK-LABEL: sil private @_T08closure0Tf2iii_n : $@convention(thin) (@owned Foo, @owned Baz, Int) -> (Int, Builtin.Int64) {
 // CHECK: bb0([[ORIGINAL_ARG0:%.*]] : @owned $Foo, [[ORIGINAL_ARG1:%.*]] : @owned $Baz, [[ARG2:%.*]] : @trivial $Int):
 // CHECK:   [[ARG0:%.*]] = begin_borrow [[ORIGINAL_ARG0]]
 // CHECK:   [[ARG1:%.*]] = begin_borrow [[ORIGINAL_ARG1]]
@@ -177,6 +177,7 @@ bb0:
 // CHECK:   destroy_value [[ARG0_COPY]]
 
 // CHECK: [[EXTRACT_BAZ_X:%.*]] = struct_extract [[ARG1]] : $Baz, #Baz.x
+// CHECK: [[EXTRACT_INT_VALUE:%.*]] = struct_extract [[ARG2]] : $Int, #Int.value
 // CHECK: [[RETVAL:%.*]] = apply [[DUMMY_FUNC]]([[APPLY_FOO]], [[EXTRACT_BAZ_X]], {{.*}}) : $@convention(thin) (Int, Int, Int) -> Int
 
 // The release of %4 is removed because the Int type is trivial
@@ -190,10 +191,11 @@ bb0:
 // it is a reference type
 // CHECK: end_borrow [[ARG0]] from [[ORIGINAL_ARG0]]
 // CHECK: destroy_value [[ORIGINAL_ARG0]]
-// CHECK: return [[RETVAL]] : $Int
+// CHECK: [[RESULT:%.*]] = tuple ([[RETVAL]] : $Int, [[EXTRACT_INT_VALUE]] : $Builtin.Int64)
+// CHECK: return [[RESULT]] : $(Int, Builtin.Int64)
 // CHECK: } // end sil function '_T08closure0Tf2iii_n'
 
-sil private @closure0 : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Foo>, @owned <τ_0_0> { var τ_0_0 } <Baz>, @owned <τ_0_0> { var τ_0_0 } <Int>) -> Int {
+sil private @closure0 : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Foo>, @owned <τ_0_0> { var τ_0_0 } <Baz>, @owned <τ_0_0> { var τ_0_0 } <Int>) -> (Int, Builtin.Int64) {
 bb0(%0 : @owned $<τ_0_0> { var τ_0_0 } <Foo>, %2 : @owned $<τ_0_0> { var τ_0_0 } <Baz>, %4 : @owned $<τ_0_0> { var τ_0_0 } <Int>):
   %1 = project_box %0 : $<τ_0_0> { var τ_0_0 } <Foo>, 0
   %3 = project_box %2 : $<τ_0_0> { var τ_0_0 } <Baz>, 0
@@ -210,11 +212,14 @@ bb0(%0 : @owned $<τ_0_0> { var τ_0_0 } <Foo>, %2 : @owned $<τ_0_0> { var τ_0
   %12 = struct_element_addr %3 : $*Baz, #Baz.x
   %13 = load [trivial] %12 : $*Int
   %14 = load [trivial] %5 : $*Int
-  %15 = apply %7(%11, %13, %14) : $@convention(thin) (Int, Int, Int) -> Int
+  %15 = struct_element_addr %5 : $*Int, #Int.value
+  %16 = load [trivial] %15 : $*Builtin.Int64
+  %17 = apply %7(%11, %13, %14) : $@convention(thin) (Int, Int, Int) -> Int
   destroy_value %4 : $<τ_0_0> { var τ_0_0 } <Int>
   destroy_value %2 : $<τ_0_0> { var τ_0_0 } <Baz>
   destroy_value %0 : $<τ_0_0> { var τ_0_0 } <Foo>
-  return %15 : $Int
+  %18 = tuple(%17 : $Int, %16 : $Builtin.Int64)
+  return %18 : $(Int, Builtin.Int64)
 }
 
 // The closure in this function is not promotable because it mutates its argument
@@ -302,7 +307,6 @@ bb0(%0 : @owned $<τ_0_0> { var τ_0_0 } <Int>, %2 : @owned $<τ_0_0> { var τ_0
 }
 
 sil [transparent] [serialized] @_T0s1poiSiSi_SitF : $@convention(thin) (Int, Int) -> Int
-
 
 sil private @closure_indirect_result : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Foo>, @owned <τ_0_0> { var τ_0_0 } <Baz>, @owned <τ_0_0> { var τ_0_0 } <Int>) -> @out Int {
 bb0(%0: @trivial $*Int, %1 : @owned $<τ_0_0> { var τ_0_0 } <Foo>, %2 : @owned $<τ_0_0> { var τ_0_0 } <Baz>, %4 : @owned $<τ_0_0> { var τ_0_0 } <Int>):


### PR DESCRIPTION
[capture-promotion] Loosen an assert.

The assert should have been checking for both guaranteed and trivial, not just
guaranteed.

This also uncovered a hole in the testing for capture promotion. I added the
missing test.

<rdar://problem/32027013>