### PR TITLE
 Fix some LValue type checking issues exposed by key paths.

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1425,22 +1425,17 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
         if (typeVarOccursInType(typeVar1, type2))
           return formUnsolvedResult();
 
-        // Equal constraints allow mixed LValue/RValue bindings.
+        // Equal constraints allow mixed LValue/RValue bindings, but
+        // if we bind a type to a type variable that can bind to
+        // LValues as part of simplifying the Equal constraint we may
+        // later block a binding of the opposite "LValue-ness" to the
+        // same type variable that happens as part of simplifying
+        // another constraint.
         if (kind == ConstraintKind::Equal) {
-          // If we could bind an LValue to the type variable, but the
-          // type that is already bound is not an LValue, defer
-          // simplifying the constraint since we may come along at a
-          // later time and attempt to bind the LValue type to this
-          // type variable.
-          if (typeVar1->getImpl().canBindToLValue()) {
-            if (!type2->isLValueType()) {
-              return formUnsolvedResult();
-            }
-          } else {
-            // If the type variable does not allow LValue bindings,
-            // get the RValue type.
-            type2 = type2->getRValueType();
-          }
+          if (typeVar1->getImpl().canBindToLValue())
+            return formUnsolvedResult();
+
+          type2 = type2->getRValueType();
         }
 
         // If the left-hand type variable cannot bind to an lvalue,
@@ -1480,22 +1475,17 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
       if (typeVarOccursInType(typeVar2, type1))
         return formUnsolvedResult();
 
-      // Equal constraints allow mixed LValue/RValue bindings.
+      // Equal constraints allow mixed LValue/RValue bindings, but
+      // if we bind a type to a type variable that can bind to
+      // LValues as part of simplifying the Equal constraint we may
+      // later block a binding of the opposite "LValue-ness" to the
+      // same type variable that happens as part of simplifying
+      // another constraint.
       if (kind == ConstraintKind::Equal) {
-        // If we could bind an LValue to the type variable, but the
-        // type that is already bound is not an LValue, defer
-        // simplifying the constraint since we may come along at a
-        // later time and attempt to bind the LValue type to this
-        // type variable.
-        if (typeVar2->getImpl().canBindToLValue()) {
-          if (!type1->isLValueType()) {
-            return formUnsolvedResult();
-          }
-        } else {
-          // If the type variable does not allow LValue bindings,
-          // get the RValue type.
-          type1 = type1->getRValueType();
-        }
+        if (typeVar2->getImpl().canBindToLValue())
+          return formUnsolvedResult();
+
+        type1 = type1->getRValueType();
       }
 
       if (!typeVar2->getImpl().canBindToLValue() &&

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -17,6 +17,7 @@ struct A: Hashable {
 
   var property: Prop
   var optProperty: Prop?
+  let optLetProperty: Prop?
 
   subscript(sub: Sub) -> A { get { return self } set { } }
 
@@ -88,9 +89,7 @@ func testKeyPath(sub: Sub, optSub: OptSub, x: Int) {
   let _: ReferenceWritableKeyPath<A, Prop> = \.property
 
   // FIXME crash let _: PartialKeyPath<A> = \[sub]
-  // FIXME should resolve: expected-error@+1{{}}
   let _: KeyPath<A, A> = \.[sub]
-  // FIXME should resolve: expected-error@+1{{}}
   let _: WritableKeyPath<A, A> = \.[sub]
   // expected-error@+1{{ambiguous}} (need to improve diagnostic)
   let _: ReferenceWritableKeyPath<A, A> = \.[sub]
@@ -109,8 +108,8 @@ func testKeyPath(sub: Sub, optSub: OptSub, x: Int) {
   // expected-error@+1{{cannot convert}}
   let _: ReferenceWritableKeyPath<A, A?> = \.optProperty?[sub]
 
-  // FIXME should resolve: expected-error@+1{{}}
   let _: KeyPath<A, Prop> = \.optProperty!
+  let _: KeyPath<A, Prop> = \.optLetProperty!
   let _: KeyPath<A, Prop?> = \.property[optSub]?.optProperty!
   let _: KeyPath<A, A?> = \.property[optSub]?.optProperty![sub]
 

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -111,8 +111,8 @@ func testKeyPath(sub: Sub, optSub: OptSub, x: Int) {
 
   // FIXME should resolve: expected-error@+1{{}}
   let _: KeyPath<A, Prop> = \.optProperty!
-  // FIXME should resolve: expected-error@+1{{}}
-  let _: KeyPath<A, Prop?> = \.property[optSub]?.optProperty![sub]
+  let _: KeyPath<A, Prop?> = \.property[optSub]?.optProperty!
+  let _: KeyPath<A, A?> = \.property[optSub]?.optProperty![sub]
 
   // FIXME crash let _: PartialKeyPath<C<A>> = \.value
   let _: KeyPath<C<A>, A> = \.value


### PR DESCRIPTION
We had an inconsistency in the handling of ConstraintKind::Equal in that we would take
      $T1 Equal $T2
where $T2 was previously bound to a type, and bind the RValue type of $T2's type to $T1.

This can cause problems if we later attempt to bind the LValue version of that type to $T1, which happens as a result of simplifying other constraints.

Instead, defer binding types in Equal constraint where the unbound type variable can be bound to an LValue.