### PR TITLE
Disallow subclassing when a class is missing vtable entries.

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3215,6 +3215,7 @@ class ClassDecl : public NominalTypeDecl {
   unsigned ObjCKind : 3;
 
   unsigned HasMissingDesignatedInitializers : 1;
+  unsigned HasMissingVTableEntries : 1;
 
   friend class IterativeTypeChecker;
 
@@ -3309,6 +3310,16 @@ public:
 
   void setHasMissingDesignatedInitializers(bool newValue = true) {
     HasMissingDesignatedInitializers = newValue;
+  }
+
+  /// Returns true if the class has missing members that require vtable entries.
+  ///
+  /// In this case, the class cannot be subclassed, because we cannot construct
+  /// the vtable for the subclass.
+  bool hasMissingVTableEntries() const;
+
+  void setHasMissingVTableEntries(bool newValue = true) {
+    HasMissingVTableEntries = newValue;
   }
 
   /// Find a method of a class that overrides a given method.

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1379,6 +1379,10 @@ ERROR(objc_runtime_visible_cannot_conform_to_objc_protocol,none,
 ERROR(protocol_has_missing_requirements,none,
       "type %0 cannot conform to protocol %1 because it has requirements that "
       "cannot be satisfied", (Type, Type))
+ERROR(protocol_has_missing_requirements_versioned,none,
+      "type %0 cannot conform to protocol %1 (compiled with Swift %2) because "
+      "it has requirements that could not be loaded in Swift %3",
+      (Type, Type, clang::VersionTuple, clang::VersionTuple))
 ERROR(requirement_restricts_self,none,
       "%0 requirement %1 cannot add constraint '%2%select{:|:| ==|:}3 %4' on "
       "'Self'",

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1909,9 +1909,13 @@ ERROR(inheritance_from_unspecialized_objc_generic_class,none,
       "inheritance from a generic Objective-C class %0 must bind "
       "type parameters of %0 to specific concrete types", (Identifier))
 ERROR(inheritance_from_class_with_missing_vtable_entries,none,
-      "cannot inherit from class %0 in Swift %1 mode because it has "
-      "overridable members that cannot be loaded",
-      (Identifier, clang::VersionTuple))
+      "cannot inherit from class %0 because it has overridable members that "
+      "could not be loaded",
+      (Identifier))
+ERROR(inheritance_from_class_with_missing_vtable_entries_versioned,none,
+      "cannot inherit from class %0 (compiled with Swift %1) because it has "
+      "overridable members that could not be loaded in Swift %2",
+      (Identifier, clang::VersionTuple, clang::VersionTuple))
 ERROR(inheritance_from_cf_class,none,
       "cannot inherit from Core Foundation type %0", (Identifier))
 ERROR(inheritance_from_objc_runtime_visible_class,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1908,6 +1908,10 @@ ERROR(inheritance_from_final_class,none,
 ERROR(inheritance_from_unspecialized_objc_generic_class,none,
       "inheritance from a generic Objective-C class %0 must bind "
       "type parameters of %0 to specific concrete types", (Identifier))
+ERROR(inheritance_from_class_with_missing_vtable_entries,none,
+      "cannot inherit from class %0 in Swift %1 mode because it has "
+      "overridable members that cannot be loaded",
+      (Identifier, clang::VersionTuple))
 ERROR(inheritance_from_cf_class,none,
       "cannot inherit from Core Foundation type %0", (Identifier))
 ERROR(inheritance_from_objc_runtime_visible_class,none,

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -120,6 +120,10 @@ class SerializedASTFile final : public LoadedFile {
 public:
   bool isSIB() const { return IsSIB; }
 
+  /// Returns the language version that was used to compile the contents of this
+  /// file.
+  const version::Version &getLanguageVersionBuiltWith() const;
+
   virtual bool isSystemModule() const override;
 
   virtual void lookupValue(ModuleDecl::AccessPathTy accessPath,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2493,6 +2493,7 @@ ClassDecl::ClassDecl(SourceLoc ClassLoc, Identifier Name, SourceLoc NameLoc,
   ClassDeclBits.HasDestructorDecl = 0;
   ObjCKind = 0;
   HasMissingDesignatedInitializers = 0;
+  HasMissingVTableEntries = 0;
 }
 
 DestructorDecl *ClassDecl::getDestructor() {
@@ -2508,6 +2509,11 @@ bool ClassDecl::hasMissingDesignatedInitializers() const {
   (void)mutableThis->lookupDirect(getASTContext().Id_init,
                                   /*ignoreNewExtensions*/true);
   return HasMissingDesignatedInitializers;
+}
+
+bool ClassDecl::hasMissingVTableEntries() const {
+  (void)getMembers();
+  return HasMissingVTableEntries;
 }
 
 bool ClassDecl::inheritsSuperclassInitializers(LazyResolver *resolver) {

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4572,6 +4572,14 @@ public:
                       Super->getName());
         }
 
+        if (Super->hasMissingVTableEntries()) {
+          TC.diagnose(CD,
+                      diag::inheritance_from_class_with_missing_vtable_entries,
+                      Super->getName(),
+                      TC.Context.LangOpts.EffectiveLanguageVersion);
+          isInvalidSuperclass = true;
+        }
+
         switch (Super->getForeignClassKind()) {
         case ClassDecl::ForeignKind::Normal:
           break;

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4458,6 +4458,9 @@ void ModuleFile::loadAllMembers(Decl *container, uint64_t contextData) {
             [&](const DeclDeserializationError &error) {
           if (error.isDesignatedInitializer())
             containingClass->setHasMissingDesignatedInitializers();
+          if (error.needsVTableEntry() || error.needsAllocatingVTableEntry())
+            containingClass->setHasMissingVTableEntries();
+
           if (error.getName().getBaseName() == getContext().Id_init) {
             members.push_back(MissingMemberDecl::forInitializer(
                 getContext(), containingClass, error.getName(),

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -1925,3 +1925,7 @@ ClassDecl *SerializedASTFile::getMainClass() const {
   assert(hasEntryPoint());
   return cast_or_null<ClassDecl>(File.getDecl(File.Bits.EntryPointDeclID));
 }
+
+const version::Version &SerializedASTFile::getLanguageVersionBuiltWith() const {
+  return File.CompatibilityVersion;
+}

--- a/test/Serialization/Recovery/Inputs/custom-modules/Types.apinotes
+++ b/test/Serialization/Recovery/Inputs/custom-modules/Types.apinotes
@@ -25,6 +25,8 @@ SwiftVersions:
   Typedefs:
   - Name: RenamedTypedef
     SwiftName: Swift3RenamedTypedef
+  - Name: NewlyWrappedTypedef
+    SwiftWrapper: none
   Tags:
   - Name: RenamedStruct
     SwiftName: Swift3RenamedStruct

--- a/test/Serialization/Recovery/Inputs/custom-modules/Types.h
+++ b/test/Serialization/Recovery/Inputs/custom-modules/Types.h
@@ -9,6 +9,7 @@
 @end
 
 typedef int RenamedTypedef;
+typedef int NewlyWrappedTypedef __attribute__((swift_wrapper(struct)));
 
 struct RenamedStruct {
   int value;

--- a/test/Serialization/Recovery/typedefs.swift
+++ b/test/Serialization/Recovery/typedefs.swift
@@ -64,7 +64,7 @@ public class UserDynamicConvenienceSub: UserDynamicConvenience {
 }
 _ = UserDynamicConvenienceSub(conveniently: 0)
 
-public class UserSub : User {} // expected-error {{cannot inherit from class 'User' in Swift 3.2 mode because it has overridable members that cannot be loaded}}
+public class UserSub : User {} // expected-error {{cannot inherit from class 'User' because it has overridable members that could not be loaded}}
 
 #endif // VERIFY
 

--- a/test/Serialization/Recovery/typedefs.swift
+++ b/test/Serialization/Recovery/typedefs.swift
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: %target-swift-frontend -emit-sil -o - -emit-module-path %t/Lib.swiftmodule -module-name Lib -I %S/Inputs/custom-modules %s | %FileCheck -check-prefix CHECK-VTABLE %s
+// RUN: %target-swift-frontend -emit-sil -o - -emit-module-path %t/Lib.swiftmodule -module-name Lib -I %S/Inputs/custom-modules -disable-objc-attr-requires-foundation-module %s | %FileCheck -check-prefix CHECK-VTABLE %s
 
 // RUN: %target-swift-ide-test -source-filename=x -print-module -module-to-print Lib -I %t -I %S/Inputs/custom-modules | %FileCheck %s
 
@@ -52,17 +52,19 @@ let _ = unwrapped // okay
 _ = usesWrapped(nil) // expected-error {{use of unresolved identifier 'usesWrapped'}}
 _ = usesUnwrapped(nil) // expected-error {{nil is not compatible with expected argument type 'Int32'}}
 
-public class UserSub: User {
+public class UserDynamicSub: UserDynamic {
   override init() {}
 }
 // FIXME: Bad error message; really it's that the convenience init hasn't been
 // inherited.
-_ = UserSub(conveniently: 0) // expected-error {{argument passed to call that takes no arguments}}
+_ = UserDynamicSub(conveniently: 0) // expected-error {{argument passed to call that takes no arguments}}
 
-public class UserConvenienceSub: UserConvenience {
+public class UserDynamicConvenienceSub: UserDynamicConvenience {
   override init() {}
 }
-_ = UserConvenienceSub(conveniently: 0)
+_ = UserDynamicConvenienceSub(conveniently: 0)
+
+public class UserSub : User {} // expected-error {{cannot inherit from class 'User' in Swift 3.2 mode because it has overridable members that cannot be loaded}}
 
 #endif // VERIFY
 
@@ -150,6 +152,42 @@ open class UserConvenience {
   // CHECK: convenience init(conveniently: Int)
   // CHECK-RECOVERY: convenience init(conveniently: Int)
   public convenience init(conveniently: Int) { self.init() }
+}
+// CHECK: {{^}$}}
+// CHECK-RECOVERY: {{^}$}}
+
+// CHECK-LABEL: class UserDynamic
+// CHECK-RECOVERY-LABEL: class UserDynamic
+open class UserDynamic {
+  // CHECK: init()
+  // CHECK-RECOVERY: init()
+  @objc public dynamic init() {}
+
+  // CHECK: init(wrapped: WrappedInt)
+  // CHECK-RECOVERY: /* placeholder for init(wrapped:) */
+  @objc public dynamic init(wrapped: WrappedInt) {}
+
+  // CHECK: convenience init(conveniently: Int)
+  // CHECK-RECOVERY: convenience init(conveniently: Int)
+  @objc public dynamic convenience init(conveniently: Int) { self.init() }
+}
+// CHECK: {{^}$}}
+// CHECK-RECOVERY: {{^}$}}
+
+// CHECK-LABEL: class UserDynamicConvenience
+// CHECK-RECOVERY-LABEL: class UserDynamicConvenience
+open class UserDynamicConvenience {
+  // CHECK: init()
+  // CHECK-RECOVERY: init()
+  @objc public dynamic init() {}
+
+  // CHECK: convenience init(wrapped: WrappedInt)
+  // CHECK-RECOVERY: /* placeholder for init(wrapped:) */
+  @objc public dynamic convenience init(wrapped: WrappedInt) { self.init() }
+
+  // CHECK: convenience init(conveniently: Int)
+  // CHECK-RECOVERY: convenience init(conveniently: Int)
+  @objc public dynamic convenience init(conveniently: Int) { self.init() }
 }
 // CHECK: {{^}$}}
 // CHECK-RECOVERY: {{^}$}}

--- a/test/Serialization/Recovery/types-3-to-4.swift
+++ b/test/Serialization/Recovery/types-3-to-4.swift
@@ -17,6 +17,7 @@ func requiresConformance(_: B_RequiresConformance<B_ConformsToProto>) {}
 func requiresConformance(_: B_RequiresConformance<C_RelyOnConformanceImpl.Assoc>) {}
 
 class Sub: Base {} // okay
+class Impl: Proto {} // expected-error {{type 'Impl' does not conform to protocol 'Proto'}}
 
 #else // TEST
 
@@ -89,6 +90,9 @@ public class C_RelyOnConformanceImpl: C_RelyOnConformance {
 
 open class Base {
   public init(wrapped: NewlyWrappedTypedef) {}
+}
+public protocol Proto {
+  func useWrapped(_ wrapped: NewlyWrappedTypedef)
 }
 
 #endif

--- a/test/Serialization/Recovery/types-3-to-4.swift
+++ b/test/Serialization/Recovery/types-3-to-4.swift
@@ -16,6 +16,7 @@ import Lib
 func requiresConformance(_: B_RequiresConformance<B_ConformsToProto>) {}
 func requiresConformance(_: B_RequiresConformance<C_RelyOnConformanceImpl.Assoc>) {}
 
+class Sub: Base {} // okay
 
 #else // TEST
 
@@ -84,6 +85,10 @@ public protocol C_RelyOnConformance {
 
 public class C_RelyOnConformanceImpl: C_RelyOnConformance {
   public typealias Assoc = Swift3RenamedClass
+}
+
+open class Base {
+  public init(wrapped: NewlyWrappedTypedef) {}
 }
 
 #endif

--- a/test/Serialization/Recovery/types-4-to-3.swift
+++ b/test/Serialization/Recovery/types-4-to-3.swift
@@ -17,6 +17,7 @@ func requiresConformance(_: B_RequiresConformance<B_ConformsToProto>) {}
 func requiresConformance(_: B_RequiresConformance<C_RelyOnConformanceImpl.Assoc>) {}
 
 class Sub: Base {} // expected-error {{cannot inherit from class 'Base' (compiled with Swift 4.0) because it has overridable members that could not be loaded in Swift 3.2}}
+class Impl: Proto {} // expected-error {{type 'Impl' cannot conform to protocol 'Proto' (compiled with Swift 4.0) because it has requirements that could not be loaded in Swift 3.2}}
 
 #else // TEST
 
@@ -65,6 +66,9 @@ public class C_RelyOnConformanceImpl: C_RelyOnConformance {
 
 open class Base {
   public init(wrapped: NewlyWrappedTypedef) {}
+}
+public protocol Proto {
+  func useWrapped(_ wrapped: NewlyWrappedTypedef)
 }
 
 #endif

--- a/test/Serialization/Recovery/types-4-to-3.swift
+++ b/test/Serialization/Recovery/types-4-to-3.swift
@@ -16,6 +16,7 @@ import Lib
 func requiresConformance(_: B_RequiresConformance<B_ConformsToProto>) {}
 func requiresConformance(_: B_RequiresConformance<C_RelyOnConformanceImpl.Assoc>) {}
 
+class Sub: Base {} // expected-error {{cannot inherit from class 'Base' (compiled with Swift 4.0) because it has overridable members that could not be loaded in Swift 3.2}}
 
 #else // TEST
 
@@ -60,6 +61,10 @@ public protocol C_RelyOnConformance {
 
 public class C_RelyOnConformanceImpl: C_RelyOnConformance {
   public typealias Assoc = RenamedClass
+}
+
+open class Base {
+  public init(wrapped: NewlyWrappedTypedef) {}
 }
 
 #endif


### PR DESCRIPTION
Builds on top of #9360—only the last commit is different. This isn't an inherent limitation of the language—in fact, it would be a problem for library evolution if you had to know a superclass's full vtable contents to generate the vtable for a subclass. However, that's exactly where we are today, and that's not going to change for Swift 4.

One small hole in the Swift 3 / Swift 4 story.

More rdar://problem/31878396
