### PR TITLE
AST: Don't print satisfied protocol requirements when dumping Decls

### DIFF
--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -998,15 +998,6 @@ namespace {
         OS << "_for=" << ASD->getFullName();
       }
 
-      for (auto VD: FD->getSatisfiedProtocolRequirements()) {
-        OS << '\n';
-        OS.indent(Indent+2);
-        PrintWithColorRAII(OS, ParenthesisColor) << '(';
-        OS << "conformance ";
-        VD->dumpRef(OS);
-        PrintWithColorRAII(OS, ParenthesisColor) << ')';
-      }
-
       printAbstractFunctionDecl(FD);
 
       PrintWithColorRAII(OS, ParenthesisColor) << ')';


### PR DESCRIPTION
This can trigger recursive conformance checking, which can change
how associated type inference behaves due to ordering issues, as
well as cause crashes.

Dumping should be idempotent.