### PR TITLE
[stdlib] String initializers

### DIFF
--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -21,11 +21,6 @@ public protocol StringProtocol
   Hashable
   where Iterator.Element == Character {
 
-  // this should be just <T : StringProtocol>
-  init<
-    T : LosslessStringConvertible & Sequence
-  >(_ other: T) where T.Iterator.Element == Character
-
   associatedtype UTF8Index
   var utf8: String.UTF8View { get }
   associatedtype UTF16Index
@@ -81,14 +76,6 @@ public protocol StringProtocol
     encoding: Encoding.Type,
     _ body: (UnsafePointer<Encoding.CodeUnit>) throws -> Result
   ) rethrows -> Result
-}
-
-extension StringProtocol {
-  public init<
-    T : LosslessStringConvertible & Sequence
-  >(_ other: T) where T.Iterator.Element == Character {
-    self.init(other.description.characters)
-  }
 }
 
 /// Call body with a pointer to zero-terminated sequence of

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -78,6 +78,12 @@ public protocol StringProtocol
   ) rethrows -> Result
 }
 
+extension StringProtocol /* : LosslessStringConvertible */ {
+  public init?(_ description: String) {
+    self.init(description.characters)
+  }
+}
+
 /// Call body with a pointer to zero-terminated sequence of
 /// `TargetEncoding.CodeUnit` representing the same string as `source`, when
 /// `source` is interpreted as being encoded with `SourceEncoding`.
@@ -1020,12 +1026,6 @@ extension String {
 extension String : CustomStringConvertible {
   public var description: String {
     return self
-  }
-}
-
-extension String : LosslessStringConvertible {
-  public init?(_ description: String) {
-    self = description
   }
 }
 

--- a/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
+++ b/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
@@ -41,11 +41,8 @@ extension String : StringProtocol {
   // - init<S>(_ characters: S) where S : Sequence, S.Iterator.Element == Character
   // Cannot simply do init(_: String) as that would itself be ambiguous with
   // init?(_ description: String)
-  public init<
-    T : LosslessStringConvertible & Sequence
-  >(_ other: T)
-  where T.Iterator.Element == Character {
-    self = other.description
+  public init<T : StringProtocol>(_ other: T) {
+    self.init(other.characters)
   }
 
   /// The position of the first character in a nonempty string.

--- a/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
+++ b/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
@@ -41,8 +41,8 @@ extension String : StringProtocol {
   // - init<S>(_ characters: S) where S : Sequence, S.Iterator.Element == Character
   // Cannot simply do init(_: String) as that would itself be ambiguous with
   // init?(_ description: String)
-  public init<T : StringProtocol>(_ other: T) {
-    self.init(other.characters)
+  public init(_ other: String) {
+    self.init(other._core)
   }
 
   /// The position of the first character in a nonempty string.

--- a/test/stdlib/StringAPI.swift
+++ b/test/stdlib/StringAPI.swift
@@ -362,8 +362,11 @@ StringTests.test("CompareStringsWithUnpairedSurrogates")
 }
 
 StringTests.test("String.init(_:String)") {
-  let _: String = String("" as String) // should compile without ambiguities
+  var s = String("")
+  expectType(String.self, &s)
+  var _ = String("") as String? // should also compile, but not be the default
 }
+
 
 StringTests.test("[String].joined() -> String") {
   let s = ["hello", "world"].joined()


### PR DESCRIPTION
- Reming the unnecessary initializer form the `StringProtocol`
- Moving things around to make `String("")` return a non-optional `String` by default, while keeping conformance to`LosslessStringConvertible` with it's failing initializer from `String`.