### PR TITLE
SILGen: The foreign-to-native thunk for an @objc protocol member should use a native convention.

### DIFF
--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -1686,8 +1686,13 @@ TypeConverter::getDeclRefRepresentation(SILDeclRef c) {
   // available. There's no great way to do this.
 
   // Protocol witnesses are called using the witness calling convention.
-  if (auto proto = dyn_cast<ProtocolDecl>(c.getDecl()->getDeclContext()))
+  if (auto proto = dyn_cast<ProtocolDecl>(c.getDecl()->getDeclContext())) {
+    // Use the regular method convention for foreign-to-native thunks.
+    if (c.isForeignToNativeThunk())
+      return SILFunctionTypeRepresentation::Method;
+    assert(!c.isNativeToForeignThunk() && "shouldn't be possible");
     return getProtocolWitnessRepresentation(proto);
+  }
 
   switch (c.kind) {
     case SILDeclRef::Kind::GlobalAccessor:

--- a/test/SILGen/objc_protocol_native_thunk.swift
+++ b/test/SILGen/objc_protocol_native_thunk.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-silgen %s | %FileCheck %s
+// REQUIRES: objc_interop
+
+import Foundation
+
+@objc protocol P {
+  func p(_: String)
+}
+@objc class C: NSObject {
+  func c(_: String) {}
+}
+
+// CHECK-LABEL: sil shared [serializable] [thunk] @_T0{{.*}}1P{{.*}}1p{{.*}} : $@convention(method) <Self where Self : P> (@owned String, @guaranteed Self) -> ()
+func foo(x: Bool, y: C & P) -> (String) -> () {
+  return x ? y.c : y.p
+}


### PR DESCRIPTION
Fixes rdar://problem/31922123.
