### PR TITLE
[swift 4] Better diagnostics for multi-line string literals (#9148)

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -129,12 +129,17 @@ ERROR(lex_invalid_unicode_scalar,none,
 ERROR(lex_unicode_escape_braces,none,
       "expected hexadecimal code in braces after unicode escape", ())
 ERROR(lex_illegal_multiline_string_start,none,
-      "invalid start of multi-line string literal", ())
+      "multi-line string literal content must begin on a new line", ())
 ERROR(lex_illegal_multiline_string_end,none,
-      "invalid end of multi-line string literal", ())
-ERROR(lex_ambiguous_string_indent,none,
-      "invalid mix of multi-line string literal indentation", ())
-
+      "multi-line string literal closing delimiter must begin on a new line", ())
+ERROR(lex_multiline_string_indent_inconsistent,none,
+      "%select{unexpected space in|unexpected tab in|insufficient}2 indentation of "
+      "%select{line|next %1 lines}0 in multi-line string literal", 
+      (bool, unsigned, unsigned))
+NOTE(lex_multiline_string_indent_should_match_here,none,
+      "should match %select{space|tab}0 here", (unsigned))
+NOTE(lex_multiline_string_indent_change_line,none,
+      "change indentation of %select{this line|these lines}0 to match closing delimiter", (bool))
 
 ERROR(lex_invalid_character,none,
        "invalid character in source file", ())

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -29,6 +29,8 @@
 // FIXME: Figure out if this can be migrated to LLVM.
 #include "clang/Basic/CharInfo.h"
 
+#include <limits>
+
 using namespace swift;
 
 // clang::isIdentifierHead and clang::isIdentifierBody are deliberately not in
@@ -1347,53 +1349,172 @@ static StringRef getStringLiteralContent(const Token &Str) {
   return Bytes;
 }
 
+static size_t commonPrefixLength(StringRef shorter, StringRef longer) {
+  size_t offset = 0;
+  while(offset < shorter.size() && offset < longer.size() && shorter[offset] == longer[offset]) {
+    offset++;
+  }
+  
+  return offset;
+}
+
 /// getMultilineTrailingIndent:
 /// Determine trailing indent to be used for multiline literal indent stripping.
-static StringRef getMultilineTrailingIndent(const Token &Str,
-                                            DiagnosticEngine *Diags) {
+static std::tuple<StringRef, SourceLoc>
+getMultilineTrailingIndent(const Token &Str, DiagnosticEngine *Diags) {
   StringRef Bytes = getStringLiteralContent(Str);
   const char *begin = Bytes.begin(), *end = Bytes.end(), *start = end;
+  bool sawNonWhitespace = false;
 
   // Work back from the end to find whitespace to strip.
-  while (start > begin) {
+  while (!sawNonWhitespace && start > begin) {
     switch (*--start) {
     case ' ':
     case '\t':
       continue;
     case '\n':
-    case '\r':
-      return StringRef(start+1, end-(start+1));
+    case '\r': {
+      auto bytes = start + 1;
+      auto length = end-(start+1);
+      
+      auto bytesLoc = Lexer::getSourceLoc(bytes);
+      auto string = StringRef(bytes, length);
+      
+      return std::make_tuple(string, bytesLoc);
+    }
     default:
-      if (Diags)
-        Diags->diagnose(Lexer::getSourceLoc(start),
-                        diag::lex_illegal_multiline_string_end);
-      return "";
+      sawNonWhitespace = true;
     }
   }
+  
+  if (sawNonWhitespace && Diags) {
+    auto loc = Lexer::getSourceLoc(start + 1);
+    Diags->diagnose(loc, diag::lex_illegal_multiline_string_end)
+    // FIXME: Should try to suggest indentation.
+      .fixItInsert(loc, "\n");
+  }
 
-  return "";
+  return std::make_tuple("", Lexer::getSourceLoc(end - 1));
+}
+
+/// diagnoseInvalidMultilineIndents:
+/// Emit errors for a group of multiline indents with the same MistakeOffset.
+/// Note: Does not emit an error if MistakeOffset does not lie within 
+/// ExpectedIndent.
+static void diagnoseInvalidMultilineIndents(
+                                            DiagnosticEngine *Diags, 
+                                            StringRef ExpectedIndent,
+                                            SourceLoc IndentLoc,
+                                            StringRef Bytes,
+                                            SmallVector<size_t, 4> LineStarts,
+                                            size_t MistakeOffset,
+                                            StringRef ActualIndent) {
+  if (MistakeOffset >= ExpectedIndent.size()) {
+    // These lines were valid; there's nothing to correct.
+    return;
+  }
+  
+  assert(LineStarts.size() > 0);
+  
+  auto getLoc = [&](size_t offset) -> SourceLoc {
+    return Lexer::getSourceLoc((const char *)Bytes.bytes_begin() + offset);
+  };
+  auto classify = [&](unsigned char ch) -> unsigned {
+    switch (ch) {
+    case ' ':
+      return 0;
+    case '\t':
+      return 1;
+    default:
+      return 2;
+    }
+  };
+  
+  Diags->diagnose(getLoc(LineStarts[0] + MistakeOffset),
+                  diag::lex_multiline_string_indent_inconsistent,
+                  LineStarts.size() != 1, LineStarts.size(),
+                  classify(Bytes[LineStarts[0] + MistakeOffset]));
+  
+  Diags->diagnose(IndentLoc.getAdvancedLoc(MistakeOffset), 
+                  diag::lex_multiline_string_indent_should_match_here, 
+                  classify(ExpectedIndent[MistakeOffset]));
+  
+  auto fix = Diags->diagnose(getLoc(LineStarts[0] + MistakeOffset),
+                             diag::lex_multiline_string_indent_change_line,
+                             LineStarts.size() != 1);
+  
+  assert(MistakeOffset <= ActualIndent.size());
+  assert(ExpectedIndent.substr(0, MistakeOffset) == 
+         ActualIndent.substr(0, MistakeOffset));
+  
+  for(auto line : LineStarts) {
+    fix.fixItReplaceChars(getLoc(line + MistakeOffset), 
+                          getLoc(line + ActualIndent.size()),
+                          ExpectedIndent.substr(MistakeOffset));
+  }
 }
 
 /// validateMultilineIndents:
 /// Diagnose contents of string literal that have inconsistent indentation.
 static void validateMultilineIndents(const Token &Str,
                                      DiagnosticEngine *Diags) {
-  StringRef Indent = getMultilineTrailingIndent(Str, Diags);
+  StringRef Indent;
+  SourceLoc IndentStartLoc;
+  std::tie(Indent, IndentStartLoc) = getMultilineTrailingIndent(Str, Diags);
   if (Indent.empty())
     return;
-
+  
+  // The offset into the previous line where it experienced its first indentation 
+  // error, or Indent.size() if every character matched.
+  size_t lastMistakeOffset = std::numeric_limits<size_t>::max();
+  // Offsets for each consecutive previous line with its first error at 
+  // lastMatchLength.
+  SmallVector<size_t, 4> linesWithLastMistakeOffset = {};
+  // Prefix of indentation that's present on all lines in linesWithLastMatchLength.
+  StringRef commonIndentation = "";
+  
   StringRef Bytes = getStringLiteralContent(Str);
-  const char *BytesPtr = Bytes.begin();
-  size_t pos = 0;
-  while ((pos = Bytes.find('\n', pos)) != StringRef::npos) {
+  for (size_t pos = Bytes.find('\n'); pos != StringRef::npos; pos = Bytes.find('\n', pos + 1)) {
     size_t nextpos = pos + 1;
-    if (BytesPtr[nextpos] != '\n' && BytesPtr[nextpos] != '\r') {
-      if (Bytes.substr(nextpos, Indent.size()) != Indent)
-        Diags->diagnose(Lexer::getSourceLoc(BytesPtr + nextpos),
-                        diag::lex_ambiguous_string_indent);
+    auto restOfBytes = Bytes.substr(nextpos);
+    
+    // Ignore blank lines.
+    if (restOfBytes[0] == '\n' || restOfBytes[0] == '\r') {
+      continue;
     }
-    pos = nextpos;
+    
+    // Where is the first difference?
+    auto errorOffset = commonPrefixLength(Indent, restOfBytes);
+    
+    // Are we starting a new run?
+    if (errorOffset != lastMistakeOffset) {
+      // Diagnose problems in the just-finished run of lines.
+      diagnoseInvalidMultilineIndents(Diags, Indent, IndentStartLoc, Bytes, 
+                                      linesWithLastMistakeOffset, lastMistakeOffset, 
+                                      commonIndentation);
+      
+      // Set up for a new run.
+      lastMistakeOffset = errorOffset;
+      linesWithLastMistakeOffset = {};
+      
+      // To begin with, all whitespace is part of the common indentation.
+      auto prefixLength = restOfBytes.find_first_not_of(" \t");
+      commonIndentation = restOfBytes.substr(0, prefixLength);
+    }
+    else {
+      // We're continuing the run, so include this line in the common prefix.
+      auto prefixLength = commonPrefixLength(commonIndentation, restOfBytes);
+      commonIndentation = commonIndentation.substr(0, prefixLength);
+    }
+    
+    // Either way, add this line to the run.
+    linesWithLastMistakeOffset.push_back(nextpos);
   }
+  
+  // Handle the last run.
+  diagnoseInvalidMultilineIndents(Diags, Indent, IndentStartLoc, Bytes, 
+                                  linesWithLastMistakeOffset, lastMistakeOffset, 
+                                  commonIndentation);
 }
 
 /// lexStringLiteral:
@@ -1412,7 +1533,8 @@ void Lexer::lexStringLiteral() {
     MultilineString = true;
     CurPtr += 2;
     if (*CurPtr != '\n' && *CurPtr != '\r')
-      diagnose(CurPtr, diag::lex_illegal_multiline_string_start);
+      diagnose(CurPtr, diag::lex_illegal_multiline_string_start)
+        .fixItInsert(Lexer::getSourceLoc(CurPtr), "\n");
   }
 
   while (true) {
@@ -1757,7 +1879,8 @@ void Lexer::getStringLiteralSegments(
   bool MultilineString = Str.IsMultilineString(), IsFirstSegment = true;
   unsigned IndentToStrip = 0;
   if (MultilineString)
-      IndentToStrip = getMultilineTrailingIndent(Str, /*Diags=*/nullptr).size();
+    IndentToStrip = 
+      std::get<0>(getMultilineTrailingIndent(Str, /*Diags=*/nullptr)).size();
 
   // Note that it is always safe to read one over the end of "Bytes" because
   // we know that there is a terminating " character.  Use BytesPtr to avoid a

--- a/test/Parse/multiline_errors.swift
+++ b/test/Parse/multiline_errors.swift
@@ -4,48 +4,105 @@ import Swift
 
 // ===---------- Multiline --------===
 
+// expecting at least 4 columns of leading indentation
 _ = """
     Eleven
   Mu
-    """ // expected-error@-1{{invalid mix of multi-line string literal indentation}}
-// expecting at least 4 columns of leading indentation
+    """ // expected-error@-1{{insufficient indentation of line in multi-line string literal}}
+        // expected-note@-1{{should match space here}}
+        // expected-note@-3{{change indentation of this line to match closing delimiter}} {{3-3=  }}
 
+// expecting at least 4 columns of leading indentation
 _ = """
     Eleven
    Mu
-    """ // expected-error@-1{{invalid mix of multi-line string literal indentation}}
-// expecting at least 4 columns of leading indentation
+    """ // expected-error@-1{{insufficient indentation of line in multi-line string literal}}
+        // expected-note@-1{{should match space here}}
+        // expected-note@-3{{change indentation of this line to match closing delimiter}} {{4-4= }}
 
+// \t is not the same as an actual tab for de-indentation
 _ = """
 	Twelve
 \tNu
-	""" // expected-error@-1{{invalid mix of multi-line string literal indentation}}
-// \t is not the same as an actual tab for de-indentation
+	""" // expected-error@-1{{insufficient indentation of line in multi-line string literal}}
+      // expected-note@-1{{should match tab here}}
+      // expected-note@-3{{change indentation of this line to match closing delimiter}} {{1-1=	}}
 
+// a tab is not the same as multiple spaces for de-indentation
 _ = """
   Thirteen
 	Xi
-  """ // expected-error@-1{{invalid mix of multi-line string literal indentation}}
-// a tab is not the same as multiple spaces for de-indentation
+  """ // expected-error@-1{{unexpected tab in indentation of line in multi-line string literal}}
+      // expected-note@-1{{should match space here}}
+      // expected-note@-3{{change indentation of this line to match closing delimiter}} {{1-2=  }}
 
+// a tab is not the same as multiple spaces for de-indentation
 _ = """
     Fourteen
   	Pi
-    """ // expected-error@-1{{invalid mix of multi-line string literal indentation}}
-// a tab is not the same as multiple spaces for de-indentation
+    """ // expected-error@-1{{unexpected tab in indentation of line in multi-line string literal}}
+        // expected-note@-1{{should match space here}}
+        // expected-note@-3{{change indentation of this line to match closing delimiter}} {{3-4=  }}
 
+// multiple spaces are not the same as a tab for de-indentation
+_ = """
+	Thirteen 2
+  Xi 2
+	""" // expected-error@-1{{unexpected space in indentation of line in multi-line string literal}}
+      // expected-note@-1{{should match tab here}}
+      // expected-note@-3{{change indentation of this line to match closing delimiter}} {{1-3=	}}
+
+// multiple spaces are not the same as a tab for de-indentation
+_ = """
+		Fourteen 2
+	  Pi 2
+		""" // expected-error@-1{{unexpected space in indentation of line in multi-line string literal}}
+        // expected-note@-1{{should match tab here}}
+        // expected-note@-3{{change indentation of this line to match closing delimiter}} {{2-4=	}}
+
+// newline currently required after opening """
 _ = """Fourteen
     Pi
-    """ // expected-error@-2{{invalid start of multi-line string literal}}
-// newline currently required after opening """
+    """ // expected-error@-2{{multi-line string literal content must begin on a new line}} {{8-8=\n}}
 
+// newline currently required before closing """
 _ = """
     Fourteen
-    Pi""" // expected-error@-0{{invalid end of multi-line string literal}}
-// newline currently required before closing """
+    Pi""" // expected-error@-0{{multi-line string literal closing delimiter must begin on a new line}} {{7-7=\n}}
 
-_ = """""" // expected-error@-0{{invalid start of multi-line string literal}}
 // newline currently required after opening """
+_ = """""" // expected-error@-0{{multi-line string literal content must begin on a new line}} {{8-8=\n}}
 
-_ = """ """ // expected-error@-0{{invalid start of multi-line string literal}}
 // newline currently required after opening """
+_ = """ """ // expected-error@-0{{multi-line string literal content must begin on a new line}} {{8-8=\n}}
+
+// two lines should get only one error
+_ = """
+    Hello,
+        World!
+	"""     // expected-error@-2{{unexpected space in indentation of next 2 lines in multi-line string literal}}
+          // expected-note@-1{{should match tab here}}
+          // expected-note@-4{{change indentation of these lines to match closing delimiter}} {{1-5=	}} {{1-5=	}}
+
+  _ = """
+Zero A
+Zero B
+	One A
+	One B
+  Two A
+  Two B
+Three A
+Three B
+		Four A
+		Four B
+			Five A
+			Five B
+		"""   // expected-error@-12{{insufficient indentation of next 2 lines in multi-line string literal}}
+          // expected-note@-1{{should match tab here}}
+          // expected-note@-14{{change indentation of these lines to match closing delimiter}} {{1-1=		}} {{1-1=		}}
+          // expected-error@-13{{insufficient indentation of next 2 lines in multi-line string literal}}
+          // expected-note@-4{{should match tab here}}
+          // expected-note@-15{{change indentation of these lines to match closing delimiter}} {{2-2=	}} {{2-2=	}}
+          // expected-error@-14{{unexpected space in indentation of next 4 lines in multi-line string literal}}
+          // expected-note@-7{{should match tab here}}
+          // expected-note@-16{{change indentation of these lines to match closing delimiter}} {{1-1=		}} {{1-1=		}} {{1-1=		}} {{1-1=		}}


### PR DESCRIPTION
This is a cherry-pick of https://github.com/apple/swift/pull/9148.

* Explanation: Improve diagnostics for multi line string literals
* Scope: Limited, affects reporting of diagnostics regarding multi line string literals
* Radar/SR: rdar://problem/31870223, https://bugs.swift.org/browse/SR-4701
* Risk: Low
* Testing: Normal PR testing is sufficient

<!-- What's in this pull request? -->
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
