### PR TITLE
Treat irrefutable casts as irrefutable patterns.

### DIFF
--- a/lib/Sema/TypeCheckSwitchStmt.cpp
+++ b/lib/Sema/TypeCheckSwitchStmt.cpp
@@ -1071,8 +1071,25 @@ namespace {
         auto *BP = cast<BoolPattern>(item);
         return Space(BP->getValue());
       }
+      case PatternKind::Is: {
+        auto *IP = cast<IsPattern>(item);
+        switch (IP->getCastKind()) {
+        case CheckedCastKind::Coercion:
+        case CheckedCastKind::BridgingCoercion:
+          // These coercions are irrefutable.  Project with the original type
+          // instead of the cast's target type to maintain consistency with the
+          // scrutinee's type.
+          return Space(IP->getType());
+        case CheckedCastKind::Unresolved:
+        case CheckedCastKind::ValueCast:
+        case CheckedCastKind::ArrayDowncast:
+        case CheckedCastKind::DictionaryDowncast:
+        case CheckedCastKind::SetDowncast:
+        case CheckedCastKind::Swift3BridgingDowncast:
+            return Space();
+        }
+      }
       case PatternKind::Typed:
-      case PatternKind::Is:
       case PatternKind::Expr:
         return Space();
       case PatternKind::Var: {

--- a/test/Sema/exhaustive_switch_objc.swift
+++ b/test/Sema/exhaustive_switch_objc.swift
@@ -1,0 +1,23 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify %s
+// REQUIRES: objc_interop
+
+import Foundation
+
+// Treat irrefutable casts as irrefutable patterns.
+enum Castbah {
+  case shareef(NSInteger)
+  case dont(NSString)
+  case like(Int)
+  case it(Error)
+}
+
+func rock(the c : Castbah) {
+  switch (c, c, c) {
+  case (.shareef(let rock as NSObject), .dont(let the as String), .like(let castbah as Any)):
+    print(rock, the, castbah)
+  case (.it(let e as NSError), _, _):
+    print(e)
+  case let obj as Any:
+    print(obj)
+  }
+}

--- a/test/stmt/statements.swift
+++ b/test/stmt/statements.swift
@@ -384,7 +384,8 @@ func test_is_as_patterns() {
   switch 4 {
   case is Int: break        // expected-warning {{'is' test is always true}}
   case _ as Int: break  // expected-warning {{'as' test is always true}}
-  case _: break
+  // expected-warning@-1 {{case is already handled by previous patterns; consider removing it}}
+  case _: break // expected-warning {{case is already handled by previous patterns; consider removing it}}
   }
 }
 


### PR DESCRIPTION
In response to a post on Swift-dev by @pushkarnk that mentioned a regression in exhaustiveness analysis because irrefutable casts were not treated as irrefutable patterns.  This patch does just that.

