### PR TITLE
[4.0] Update Swift-side tests for Clang providing an unversioned SwiftName.

### DIFF
--- a/lib/IDE/ModuleInterfacePrinting.cpp
+++ b/lib/IDE/ModuleInterfacePrinting.cpp
@@ -450,12 +450,12 @@ void swift::ide::printSubmoduleInterface(
 
   // Sort imported declarations in source order *within a submodule*.
   for (auto &P : ClangDecls) {
-    std::sort(P.second.begin(), P.second.end(),
-              [&](std::pair<Decl *, clang::SourceLocation> LHS,
-                  std::pair<Decl *, clang::SourceLocation> RHS) -> bool {
-                return ClangSourceManager.isBeforeInTranslationUnit(LHS.second,
-                                                                    RHS.second);
-              });
+    std::stable_sort(P.second.begin(), P.second.end(),
+                     [&](std::pair<Decl *, clang::SourceLocation> LHS,
+                         std::pair<Decl *, clang::SourceLocation> RHS) -> bool {
+      return ClangSourceManager.isBeforeInTranslationUnit(LHS.second,
+                                                          RHS.second);
+    });
   }
 
   // Sort Swift declarations so that we print them in a consistent order.

--- a/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/APINotesFrameworkTest.apinotes
+++ b/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/APINotesFrameworkTest.apinotes
@@ -98,11 +98,19 @@ SwiftVersions:
       - Name: acceptDoublePointer
         SwiftName: 'acceptPointer(_:)'
         Nullability: [ O ]
+      - Name: normallyUnchanged
+        SwiftName: normallyUnchangedButChangedInSwift3()
+      - Name: normallyChangedOriginal
+        SwiftName: normallyChangedButSpecialInSwift3()
     Tags:
       - Name: SomeCStruct
         SwiftName: ImportantCStruct
       - Name: InnerInSwift4
         SwiftName: InnerInSwift4
+      - Name: NormallyUnchangedWrapper
+        SwiftName: NormallyUnchangedButChangedInSwift3Wrapper
+      - Name: NormallyChangedOriginalWrapper
+        SwiftName: NormallyChangedButSpecialInSwift3Wrapper
     Typedefs:
       - Name: SomeCAlias
         SwiftName: ImportantCAlias

--- a/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/APINotesFrameworkTest.h
+++ b/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/APINotesFrameworkTest.h
@@ -4,6 +4,9 @@ void acceptDoublePointer(double* _Nonnull ptr) __attribute__((swift_name("accept
 
 void oldAcceptDoublePointer(double* _Nonnull ptr) __attribute__((availability(swift, unavailable, replacement="acceptDoublePointer")));
 
+void normallyUnchanged(void);
+void normallyChangedOriginal(void) __attribute__((swift_name("normallyChanged()")));
+
 #ifdef __OBJC__
 
 __attribute__((objc_root_class))

--- a/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/Types.h
+++ b/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/Types.h
@@ -6,4 +6,11 @@ struct __attribute__((swift_name("VeryImportantCStruct"))) SomeCStruct {
 
 typedef int __attribute__((swift_name("VeryImportantCAlias"))) SomeCAlias;
 
+struct NormallyUnchangedWrapper {
+  int value;
+};
+struct NormallyChangedOriginalWrapper{
+  int value;
+} __attribute__((swift_name("NormallyChangedWrapper")));
+
 #pragma clang assume_nonnull end

--- a/test/APINotes/versioned-objc.swift
+++ b/test/APINotes/versioned-objc.swift
@@ -24,21 +24,21 @@ func testNonGeneric() {
 }
 
 func testRenamedGeneric() {
-  // CHECK-DIAGS-3:[[@LINE+1]]:{{[0-9]+}}: error: 'RenamedGeneric' has been renamed to 'OldRenamedGeneric'
+  // CHECK-DIAGS-3-NOT: 'RenamedGeneric' has been renamed to 'OldRenamedGeneric'
   let _: OldRenamedGeneric<Base> = RenamedGeneric<Base>()
   // CHECK-DIAGS-4:[[@LINE-1]]:{{[0-9]+}}: error: 'OldRenamedGeneric' has been renamed to 'RenamedGeneric'
 
-  // CHECK-DIAGS-3:[[@LINE+1]]:{{[0-9]+}}: error: 'RenamedGeneric' has been renamed to 'OldRenamedGeneric'
+  // CHECK-DIAGS-3-NOT: 'RenamedGeneric' has been renamed to 'OldRenamedGeneric'
   let _: RenamedGeneric<Base> = OldRenamedGeneric<Base>()
   // CHECK-DIAGS-4:[[@LINE-1]]:{{[0-9]+}}: error: 'OldRenamedGeneric' has been renamed to 'RenamedGeneric'
 
   class SwiftClass {}
 
-  // CHECK-DIAGS-3:[[@LINE+1]]:{{[0-9]+}}: error: 'OldRenamedGeneric' requires that 'SwiftClass' inherit from 'Base'
+  // CHECK-DIAGS-3:[[@LINE+1]]:{{[0-9]+}}: error: 'RenamedGeneric' requires that 'SwiftClass' inherit from 'Base'
   let _: OldRenamedGeneric<SwiftClass> = RenamedGeneric<SwiftClass>()
   // CHECK-DIAGS-4:[[@LINE-1]]:{{[0-9]+}}: error: 'RenamedGeneric' requires that 'SwiftClass' inherit from 'Base'
 
-  // CHECK-DIAGS-3:[[@LINE+1]]:{{[0-9]+}}: error: 'OldRenamedGeneric' requires that 'SwiftClass' inherit from 'Base'
+  // CHECK-DIAGS-3:[[@LINE+1]]:{{[0-9]+}}: error: 'RenamedGeneric' requires that 'SwiftClass' inherit from 'Base'
   let _: RenamedGeneric<SwiftClass> = OldRenamedGeneric<SwiftClass>()
   // CHECK-DIAGS-4:[[@LINE-1]]:{{[0-9]+}}: error: 'RenamedGeneric' requires that 'SwiftClass' inherit from 'Base'
 }

--- a/test/APINotes/versioned.swift
+++ b/test/APINotes/versioned.swift
@@ -10,6 +10,42 @@
 // CHECK-SWIFT-4: func accept(_ ptr: UnsafeMutablePointer<Double>)
 // CHECK-SWIFT-3: func acceptPointer(_ ptr: UnsafeMutablePointer<Double>?)
 
+// CHECK-SWIFT-4: func normallyUnchanged()
+// CHECK-SWIFT-4: @available(swift, obsoleted: 4, renamed: "normallyUnchanged()")
+// CHECK-SWIFT-4-NEXT: func normallyUnchangedButChangedInSwift3()
+// CHECK-SWIFT-3: @available(swift, obsoleted: 3, renamed: "normallyUnchangedButChangedInSwift3()")
+// CHECK-SWIFT-3-NEXT: func normallyUnchanged()
+// CHECK-SWIFT-3: func normallyUnchangedButChangedInSwift3()
+
+
+// CHECK-SWIFT-4: func normallyChanged()
+// CHECK-SWIFT-4-NEXT: @available(swift, obsoleted: 4, renamed: "normallyChanged()")
+// CHECK-SWIFT-4-NEXT: func normallyChangedButSpecialInSwift3()
+// CHECK-SWIFT-4-NEXT: @available(swift, obsoleted: 3, renamed: "normallyChanged()")
+// CHECK-SWIFT-4-NEXT: func normallyChangedOriginal()
+// CHECK-SWIFT-3: @available(swift, introduced: 4, renamed: "normallyChangedButSpecialInSwift3()")
+// CHECK-SWIFT-3-NEXT: func normallyChanged()
+// CHECK-SWIFT-3-NEXT: func normallyChangedButSpecialInSwift3()
+// CHECK-SWIFT-3-NEXT: @available(swift, obsoleted: 3, renamed: "normallyChangedButSpecialInSwift3()")
+// CHECK-SWIFT-3-NEXT: func normallyChangedOriginal()
+
+// CHECK-SWIFT-4: @available(swift, obsoleted: 4, renamed: "NormallyUnchangedWrapper")
+// CHECK-SWIFT-4-NEXT: typealias NormallyUnchangedButChangedInSwift3Wrapper = NormallyUnchangedWrapper
+// CHECK-SWIFT-4: struct NormallyUnchangedWrapper {
+// CHECK-SWIFT-3: typealias NormallyUnchangedButChangedInSwift3Wrapper = NormallyUnchangedWrapper
+// CHECK-SWIFT-3-NEXT: struct NormallyUnchangedWrapper {
+
+// CHECK-SWIFT-4: @available(swift, obsoleted: 4, renamed: "NormallyChangedWrapper")
+// CHECK-SWIFT-4-NEXT: typealias NormallyChangedButSpecialInSwift3Wrapper = NormallyChangedWrapper
+// CHECK-SWIFT-4: @available(swift, obsoleted: 3, renamed: "NormallyChangedWrapper")
+// CHECK-SWIFT-4-NEXT: typealias NormallyChangedOriginalWrapper = NormallyChangedWrapper
+// CHECK-SWIFT-4: struct NormallyChangedWrapper {
+// CHECK-SWIFT-3: typealias NormallyChangedButSpecialInSwift3Wrapper = NormallyChangedWrapper
+// CHECK-SWIFT-3-NEXT: @available(swift, obsoleted: 3, renamed: "NormallyChangedButSpecialInSwift3Wrapper")
+// CHECK-SWIFT-3-NEXT: typealias NormallyChangedOriginalWrapper = NormallyChangedButSpecialInSwift3Wrapper
+// CHECK-SWIFT-3-NEXT: struct NormallyChangedWrapper {
+
+
 // RUN: not %target-swift-frontend -typecheck -F %S/Inputs/custom-frameworks -swift-version 4 %s 2>&1 | %FileCheck -check-prefix=CHECK-DIAGS -check-prefix=CHECK-DIAGS-4 %s
 // RUN: not %target-swift-frontend -typecheck -F %S/Inputs/custom-frameworks -swift-version 3 %s 2>&1 | %FileCheck -check-prefix=CHECK-DIAGS -check-prefix=CHECK-DIAGS-3 %s
 

--- a/test/ClangImporter/Inputs/SwiftPrivateAttr.txt
+++ b/test/ClangImporter/Inputs/SwiftPrivateAttr.txt
@@ -107,11 +107,11 @@ struct NSOptions : OptionSet {
   static var __PrivA: NSOptions { get }
   static var B: NSOptions { get }
 }
-@available(swift, obsoleted: 3, renamed: "__PrivCFType")
-typealias __PrivCFTypeRef = __PrivCFType
 class __PrivCFType : _CFObject {
 }
+@available(swift, obsoleted: 3, renamed: "__PrivCFType")
+typealias __PrivCFTypeRef = __PrivCFType
+typealias __PrivCFSub = __PrivCFType
 @available(swift, obsoleted: 3, renamed: "__PrivCFSub")
 typealias __PrivCFSubRef = __PrivCFSub
-typealias __PrivCFSub = __PrivCFType
 typealias __PrivInt = Int32


### PR DESCRIPTION
swift-4.0-branch version of #9414. Must go in when apple/swift-clang#82 does.