### PR TITLE
Sema: Fix another SE-0110 issue

### DIFF
--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -196,7 +196,9 @@ void SILGenFunction::emitCaptures(SILLocation loc,
 
     case CaptureKind::Constant: {
       // let declarations.
-      auto Entry = VarLocs[vd];
+      auto found = VarLocs.find(vd);
+      assert(found != VarLocs.end());
+      auto Entry = found->second;
 
       auto *var = cast<VarDecl>(vd);
       auto &tl = getTypeLowering(var->getType()->getReferenceStorageReferent());

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -899,7 +899,8 @@ void TypeChecker::configureInterfaceType(AbstractFunctionDecl *func,
 
     Type selfTy;
     if (i == e-1 && hasSelf) {
-      selfTy = func->computeInterfaceSelfType();
+      selfTy = ParenType::get(Context, func->computeInterfaceSelfType());
+
       // Substitute in our own 'self' parameter.
 
       argTy = selfTy;

--- a/test/Constraints/function_conversion.swift
+++ b/test/Constraints/function_conversion.swift
@@ -21,3 +21,18 @@ func existentialConversion(fn: @escaping (Refined) -> ()) {
   let _: (Base) -> () = fn
   let _: (Derived) -> () = fn
 }
+
+// rdar://problem/31725325
+
+func a<b>(_: [(String, (b) -> () -> Void)]) {}
+func a<b>(_: [(String, (b) -> () throws -> Void)]) {}
+
+class c {
+  func e() {}
+  static var d = [("", e)]
+}
+a(c.d)
+
+func b<T>(_: (T) -> () -> ()) {}
+
+b(c.e)

--- a/test/Constraints/members.swift
+++ b/test/Constraints/members.swift
@@ -7,9 +7,9 @@
 struct X {
   func f0(_ i: Int) -> X { }
 
-  func f1(_ i: Int) { } // expected-note {{found this candidate}}
+  func f1(_ i: Int) { }
 
-  mutating func f1(_ f: Float) { } // expected-note {{found this candidate}}
+  mutating func f1(_ f: Float) { }
 
   func f2<T>(_ x: T) -> T { }
 }
@@ -28,9 +28,7 @@ func g0(_: (inout X) -> (Float) -> ()) {}
 _ = x.f0(i)
 x.f0(i).f1(i)
 
-// FIXME: Is this a bug in Swift 4 mode?
 g0(X.f1)
-// expected-error@-1 {{ambiguous reference to member 'f1'}}
 
 _ = x.f0(x.f2(1))
 _ = x.f0(1).f2(i)


### PR DESCRIPTION
The formal type of methods should be (Type) -> (Args...) -> (),
not Type -> (Args...) -> ().
    
This only matters in Swift 4 mode, where it was preventing the
newly-added test case from type checking.
    
Fixes <rdar://problem/31725325>.