### PR TITLE
[stdlib] Fix for initFromArray test on big endian

### DIFF
--- a/test/stdlib/UnsafeRawBufferPointer.swift
+++ b/test/stdlib/UnsafeRawBufferPointer.swift
@@ -66,7 +66,11 @@ UnsafeRawBufferPointerTestSuite.test("initFromArray") {
   array1.withUnsafeBytes { bytes1 in
     expectEqual(bytes1.count, 16)
     for (i, b) in bytes1.enumerated() {
-      if i % 4 == 0 {
+      var num = i
+#if _endian(big)
+      num = num + 1
+#endif
+      if num % 4 == 0 {
         expectEqual(Int(b), i / 4)
       }
       else {


### PR DESCRIPTION
<!-- What's in this pull request? -->
Account for byte order in initFromArray test.  This will allow the test to pass on s390x
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
