### PR TITLE
Fix the hash function for SILDebugScopes to handle the empty scopes

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -70,11 +70,17 @@ class IRGenDebugInfoImpl : public IRGenDebugInfo {
   IRGenModule &IGM;
 
   /// Used for caching SILDebugScopes without inline information.
-  typedef std::pair<const void *, void *> LocalScopeHash;
+  typedef std::pair<const void *, const void *> LocalScopeHash;
   struct LocalScope : public LocalScopeHash {
     LocalScope(const SILDebugScope *DS)
-        : LocalScopeHash(
-              {DS->Loc.getOpaquePointerValue(), DS->Parent.getOpaqueValue()}) {}
+        : LocalScopeHash({DS->Loc.getOpaquePointerValue(),
+                          // If there is no parent SIL function use the scope
+                          // pointer as a unique id instead. This is safe
+                          // because such a function could also never have been
+                          // SIL-inlined.
+                          DS->Parent.getOpaqueValue()
+                              ? DS->Parent.getOpaqueValue()
+                              : DS}) {}
   };
 
   /// Various caches.

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -18,24 +18,24 @@
 #include "IRGenDebugInfo.h"
 #include "GenOpaque.h"
 #include "GenType.h"
+#include "swift/AST/ASTMangler.h"
 #include "swift/AST/Expr.h"
 #include "swift/AST/IRGenOptions.h"
-#include "swift/AST/ASTMangler.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/ModuleLoader.h"
 #include "swift/AST/Pattern.h"
 #include "swift/Basic/Dwarf.h"
 #include "swift/Basic/SourceManager.h"
 #include "swift/Basic/Version.h"
-#include "swift/Demangling/ManglingMacros.h"
 #include "swift/ClangImporter/ClangImporter.h"
+#include "swift/Demangling/ManglingMacros.h"
 #include "swift/SIL/SILArgument.h"
 #include "swift/SIL/SILBasicBlock.h"
 #include "swift/SIL/SILDebugScope.h"
 #include "swift/SIL/SILModule.h"
 #include "clang/AST/ASTContext.h"
-#include "clang/AST/ExternalASTSource.h"
 #include "clang/AST/Decl.h"
+#include "clang/AST/ExternalASTSource.h"
 #include "clang/Basic/Module.h"
 #include "clang/Basic/SourceLocation.h"
 #include "clang/Basic/SourceManager.h"
@@ -43,6 +43,7 @@
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Serialization/ASTReader.h"
 #include "llvm/Config/config.h"
+#include "llvm/IR/DIBuilder.h"
 #include "llvm/IR/DebugInfo.h"
 #include "llvm/IR/Module.h"
 #include "llvm/Support/CommandLine.h"
@@ -56,67 +57,1435 @@
 using namespace swift;
 using namespace irgen;
 
-/// Strdup a raw char array using the bump pointer.
-StringRef IRGenDebugInfo::BumpAllocatedString(const char *Data, size_t Length) {
-  char *Ptr = DebugInfoNames.Allocate<char>(Length+1);
-  memcpy(Ptr, Data, Length);
-  *(Ptr+Length) = 0;
-  return StringRef(Ptr, Length);
-}
+namespace {
+typedef llvm::DenseMap<const llvm::MDString *, llvm::TrackingMDNodeRef>
+    TrackingDIRefMap;
 
-/// Strdup S using the bump pointer.
-StringRef IRGenDebugInfo::BumpAllocatedString(std::string S) {
-  return BumpAllocatedString(S.c_str(), S.length());
-}
+class IRGenDebugInfoImpl : public IRGenDebugInfo {
+  friend class IRGenDebugInfoImpl;
+  const IRGenOptions &Opts;
+  ClangImporter &CI;
+  SourceManager &SM;
+  llvm::DIBuilder DBuilder;
+  IRGenModule &IGM;
 
-/// Strdup StringRef S using the bump pointer.
-StringRef IRGenDebugInfo::BumpAllocatedString(StringRef S) {
-  return BumpAllocatedString(S.data(), S.size());
-}
+  /// Used for caching SILDebugScopes without inline information.
+  typedef std::pair<const void *, void *> LocalScopeHash;
+  struct LocalScope : public LocalScopeHash {
+    LocalScope(const SILDebugScope *DS)
+        : LocalScopeHash(
+              {DS->Loc.getOpaquePointerValue(), DS->Parent.getOpaqueValue()}) {}
+  };
 
-/// Return the size reported by a type.
-static unsigned getSizeInBits(llvm::DIType *Ty) {
-  // Follow derived types until we reach a type that
-  // reports back a size.
-  while (isa<llvm::DIDerivedType>(Ty) && !Ty->getSizeInBits()) {
-    auto *DT = cast<llvm::DIDerivedType>(Ty);
-    Ty = DT->getBaseType().resolve();
-    if (!Ty)
-      return 0;
+  /// Various caches.
+  /// @{
+  llvm::DenseMap<LocalScopeHash, llvm::TrackingMDNodeRef> ScopeCache;
+  llvm::DenseMap<const SILDebugScope *, llvm::TrackingMDNodeRef> InlinedAtCache;
+  llvm::DenseMap<llvm::StringRef, llvm::TrackingMDNodeRef> DIFileCache;
+  llvm::DenseMap<const void *, SILLocation::DebugLoc> DebugLocCache;
+  llvm::DenseMap<TypeBase *, llvm::TrackingMDNodeRef> DITypeCache;
+  llvm::StringMap<llvm::TrackingMDNodeRef> DIModuleCache;
+  TrackingDIRefMap DIRefMap;
+  /// @}
+
+  /// A list of replaceable fwddecls that need to be RAUWed at the end.
+  std::vector<std::pair<TypeBase *, llvm::TrackingMDRef>> ReplaceMap;
+
+  llvm::BumpPtrAllocator DebugInfoNames;
+  StringRef CWDName;                    /// The current working directory.
+  llvm::DICompileUnit *TheCU = nullptr; /// The current compilation unit.
+  llvm::DIFile *MainFile = nullptr;     /// The main file.
+  llvm::DIModule *MainModule = nullptr; /// The current module.
+  llvm::DIScope *EntryPointFn =
+      nullptr;                     /// Scope of SWIFT_ENTRY_POINT_FUNCTION.
+  TypeAliasDecl *MetadataTypeDecl; /// The type decl for swift.type.
+  llvm::DIType *InternalType;      /// Catch-all type for opaque internal types.
+
+  SILLocation::DebugLoc LastDebugLoc; /// The last location that was emitted.
+  const SILDebugScope *LastScope;     /// The scope of that last location.
+  /// The basic block where the location was last changed.
+  llvm::BasicBlock *LastBasicBlock;
+
+  /// Used by pushLoc.
+  SmallVector<std::pair<SILLocation::DebugLoc, const SILDebugScope *>, 8>
+      LocationStack;
+
+public:
+  IRGenDebugInfoImpl(const IRGenOptions &Opts, ClangImporter &CI,
+                     IRGenModule &IGM, llvm::Module &M, SourceFile *SF);
+  void finalize();
+
+  void setCurrentLoc(IRBuilder &Builder, const SILDebugScope *DS,
+                     Optional<SILLocation> Loc = None);
+  void clearLoc(IRBuilder &Builder);
+  void pushLoc();
+  void popLoc();
+  void setArtificialTrapLocation(IRBuilder &Builder,
+                                 const SILDebugScope *Scope);
+  void setEntryPointLoc(IRBuilder &Builder);
+  llvm::DIScope *getEntryPointFn();
+  llvm::DIScope *getOrCreateScope(const SILDebugScope *DS);
+  void emitImport(ImportDecl *D);
+  llvm::DISubprogram *emitFunction(const SILDebugScope *DS, llvm::Function *Fn,
+                                   SILFunctionTypeRepresentation Rep,
+                                   SILType Ty, DeclContext *DeclCtx = nullptr,
+                                   GenericEnvironment *GE = nullptr);
+  llvm::DISubprogram *emitFunction(SILFunction &SILFn, llvm::Function *Fn);
+  void emitArtificialFunction(IRBuilder &Builder, llvm::Function *Fn,
+                              SILType SILTy);
+  void emitVariableDeclaration(IRBuilder &Builder,
+                               ArrayRef<llvm::Value *> Storage,
+                               DebugTypeInfo Ty, const SILDebugScope *DS,
+                               ValueDecl *VarDecl, StringRef Name,
+                               unsigned ArgNo = 0,
+                               IndirectionKind = DirectValue,
+                               ArtificialKind = RealValue);
+  void emitDbgIntrinsic(IRBuilder &Builder, llvm::Value *Storage,
+                        llvm::DILocalVariable *Var, llvm::DIExpression *Expr,
+                        unsigned Line, unsigned Col, llvm::DILocalScope *Scope,
+                        const SILDebugScope *DS);
+  void emitGlobalVariableDeclaration(llvm::GlobalVariable *Storage,
+                                     StringRef Name, StringRef LinkageName,
+                                     DebugTypeInfo DebugType,
+                                     bool IsLocalToUnit,
+                                     Optional<SILLocation> Loc);
+  void emitTypeMetadata(IRGenFunction &IGF, llvm::Value *Metadata,
+                        StringRef Name);
+
+  /// Return the DIBuilder.
+  llvm::DIBuilder &getBuilder() { return DBuilder; }
+
+  /// Decode (and cache) a SourceLoc.
+  SILLocation::DebugLoc decodeSourceLoc(SourceLoc SL);
+
+private:
+  static StringRef getFilenameFromDC(const DeclContext *DC) {
+    if (auto LF = dyn_cast<LoadedFile>(DC))
+      return LF->getFilename();
+    if (auto SF = dyn_cast<SourceFile>(DC))
+      return SF->getFilename();
+    else if (auto M = dyn_cast<ModuleDecl>(DC))
+      return M->getModuleFilename();
+    else
+      return StringRef();
   }
-  return Ty->getSizeInBits();
-}
+
+  SILLocation::DebugLoc getDeserializedLoc(Pattern *) { return {}; }
+  SILLocation::DebugLoc getDeserializedLoc(Expr *) { return {}; }
+  SILLocation::DebugLoc getDeserializedLoc(Stmt *) { return {}; }
+  SILLocation::DebugLoc getDeserializedLoc(Decl *D) {
+    SILLocation::DebugLoc L;
+    const DeclContext *DC = D->getDeclContext()->getModuleScopeContext();
+    StringRef Filename = getFilenameFromDC(DC);
+    if (!Filename.empty())
+      L.Filename = Filename;
+    return L;
+  }
+
+  /// Use the SM to figure out the actual line/column of a SourceLoc.
+  template <typename WithLoc>
+  SILLocation::DebugLoc getDebugLoc(IRGenDebugInfo &DI, WithLoc *S,
+                                    bool End = false) {
+    SILLocation::DebugLoc L;
+    if (S == nullptr)
+      return L;
+
+    SourceLoc Loc = End ? S->getEndLoc() : S->getStartLoc();
+    if (Loc.isInvalid())
+      // This may be a deserialized or clang-imported decl. And modules
+      // don't come with SourceLocs right now. Get at least the name of
+      // the module.
+      return getDeserializedLoc(S);
+
+    return DI.decodeSourceLoc(Loc);
+  }
+
+  SILLocation::DebugLoc getStartLocation(Optional<SILLocation> OptLoc) {
+    if (!OptLoc)
+      return {};
+    return decodeSourceLoc(OptLoc->getStartSourceLoc());
+  }
+
+  SILLocation::DebugLoc decodeDebugLoc(SILLocation Loc) {
+    if (Loc.isDebugInfoLoc())
+      return Loc.getDebugInfoLoc();
+    return decodeSourceLoc(Loc.getDebugSourceLoc());
+  }
+
+  SILLocation::DebugLoc getDebugLocation(Optional<SILLocation> OptLoc) {
+    if (!OptLoc || OptLoc->isInPrologue())
+      return {};
+    return decodeDebugLoc(*OptLoc);
+  }
+
+  /// Strdup a raw char array using the bump pointer.
+  StringRef BumpAllocatedString(const char *Data, size_t Length) {
+    char *Ptr = DebugInfoNames.Allocate<char>(Length + 1);
+    memcpy(Ptr, Data, Length);
+    *(Ptr + Length) = 0;
+    return StringRef(Ptr, Length);
+  }
+
+  /// Strdup S using the bump pointer.
+  StringRef BumpAllocatedString(std::string S) {
+    return BumpAllocatedString(S.c_str(), S.length());
+  }
+
+  /// Strdup StringRef S using the bump pointer.
+  StringRef BumpAllocatedString(StringRef S) {
+    return BumpAllocatedString(S.data(), S.size());
+  }
+
+  /// Return the size reported by a type.
+  static unsigned getSizeInBits(llvm::DIType *Ty) {
+    // Follow derived types until we reach a type that
+    // reports back a size.
+    while (isa<llvm::DIDerivedType>(Ty) && !Ty->getSizeInBits()) {
+      auto *DT = cast<llvm::DIDerivedType>(Ty);
+      Ty = DT->getBaseType().resolve();
+      if (!Ty)
+        return 0;
+    }
+    return Ty->getSizeInBits();
+  }
 
 #ifndef NDEBUG
 
-/// Return the size reported by the variable's type.
-static unsigned getSizeInBits(const llvm::DILocalVariable *Var) {
-  llvm::DIType *Ty = Var->getType().resolve();
-  return getSizeInBits(Ty);
-}
+  /// Return the size reported by the variable's type.
+  static unsigned getSizeInBits(const llvm::DILocalVariable *Var) {
+    llvm::DIType *Ty = Var->getType().resolve();
+    return getSizeInBits(Ty);
+  }
 
 #endif
 
-IRGenDebugInfo::IRGenDebugInfo(const IRGenOptions &Opts,
-                               ClangImporter &CI,
-                               IRGenModule &IGM,
-                               llvm::Module &M,
-                               SourceFile *SF)
-  : Opts(Opts),
-    CI(CI),
-    SM(IGM.Context.SourceMgr),
-    M(M),
-    DBuilder(M),
-    IGM(IGM),
-    MetadataTypeDecl(nullptr),
-    InternalType(nullptr),
-    LastDebugLoc({}),
-    LastScope(nullptr)
-{
-  assert(Opts.DebugInfoKind > IRGenDebugInfoKind::None
-         && "no debug info should be generated");
-  StringRef SourceFileName = SF ? SF->getFilename() :
-                                  StringRef(Opts.MainInputFilename);
+  /// Determine whether this debug scope belongs to an explicit closure.
+  static bool isExplicitClosure(const SILFunction *SILFn) {
+    if (SILFn && SILFn->hasLocation())
+      if (Expr *E = SILFn->getLocation().getAsASTNode<Expr>())
+        if (isa<ClosureExpr>(E))
+          return true;
+    return false;
+  }
+
+  /// Determine whether this location is some kind of closure.
+  static bool isAbstractClosure(const SILLocation &Loc) {
+    if (Expr *E = Loc.getAsASTNode<Expr>())
+      if (isa<AbstractClosureExpr>(E))
+        return true;
+    return false;
+  }
+
+  /// Both the code that is used to set up a closure object and the
+  /// (beginning of) the closure itself has the AbstractClosureExpr as
+  /// location. We are only interested in the latter case and want to
+  /// ignore the setup code.
+  ///
+  /// callWithClosure(
+  ///  { // <-- a breakpoint here should only stop inside of the closure.
+  ///    foo();
+  ///  })
+  ///
+  /// The actual closure has a closure expression as scope.
+  static bool shouldIgnoreAbstractClosure(Optional<SILLocation> Loc,
+                                          const SILDebugScope *DS) {
+    return Loc && isAbstractClosure(*Loc) && DS &&
+           !isAbstractClosure(DS->Loc) && !Loc->is<ImplicitReturnLocation>();
+  }
+
+  llvm::MDNode *createInlinedAt(const SILDebugScope *DS) {
+    auto *CS = DS->InlinedCallSite;
+    if (!CS)
+      return nullptr;
+
+    auto CachedInlinedAt = InlinedAtCache.find(CS);
+    if (CachedInlinedAt != InlinedAtCache.end())
+      return cast<llvm::MDNode>(CachedInlinedAt->second);
+
+    auto L = decodeDebugLoc(CS->Loc);
+    auto Scope = getOrCreateScope(CS->Parent.dyn_cast<const SILDebugScope *>());
+    auto InlinedAt =
+        llvm::DebugLoc::get(L.Line, L.Column, Scope, createInlinedAt(CS));
+    InlinedAtCache.insert(
+        {CS, llvm::TrackingMDNodeRef(InlinedAt.getAsMDNode())});
+    return InlinedAt;
+  }
+
+#ifndef NDEBUG
+  /// Perform a couple of sanity checks on scopes.
+  static bool parentScopesAreSane(const SILDebugScope *DS) {
+    auto *Parent = DS;
+    while ((Parent = Parent->Parent.dyn_cast<const SILDebugScope *>())) {
+      if (!DS->InlinedCallSite)
+        assert(!Parent->InlinedCallSite &&
+               "non-inlined scope has an inlined parent");
+    }
+    return true;
+  }
+
+  bool lineNumberIsSane(IRBuilder &Builder, unsigned Line) {
+    if (IGM.IRGen.Opts.Optimize)
+      return true;
+
+    // Assert monotonically increasing line numbers within the same basic block;
+    llvm::BasicBlock *CurBasicBlock = Builder.GetInsertBlock();
+    if (CurBasicBlock == LastBasicBlock) {
+      return Line >= LastDebugLoc.Line;
+    }
+    LastBasicBlock = CurBasicBlock;
+    return true;
+  }
+#endif
+
+  llvm::DIFile *getOrCreateFile(StringRef Filename) {
+    if (Filename.empty())
+      return MainFile;
+
+    // Look in the cache first.
+    auto CachedFile = DIFileCache.find(Filename);
+    if (CachedFile != DIFileCache.end()) {
+      // Verify that the information still exists.
+      if (llvm::Metadata *V = CachedFile->second)
+        return cast<llvm::DIFile>(V);
+    }
+
+    // Detect the main file.
+    if (MainFile && Filename.endswith(MainFile->getFilename())) {
+      SmallString<256> AbsThisFile, AbsMainFile;
+      AbsThisFile = Filename;
+      llvm::sys::fs::make_absolute(AbsThisFile);
+      llvm::sys::path::append(AbsMainFile, MainFile->getDirectory(),
+                              MainFile->getFilename());
+      if (AbsThisFile == AbsMainFile) {
+        DIFileCache[Filename] = llvm::TrackingMDNodeRef(MainFile);
+        return MainFile;
+      }
+    }
+
+    // Create a new one.
+    StringRef File = llvm::sys::path::filename(Filename);
+    llvm::SmallString<512> Path(Filename);
+    llvm::sys::path::remove_filename(Path);
+    llvm::DIFile *F = DBuilder.createFile(File, Path);
+
+    // Cache it.
+    DIFileCache[Filename] = llvm::TrackingMDNodeRef(F);
+    return F;
+  }
+
+  StringRef getName(const FuncDecl &FD) {
+    // Getters and Setters are anonymous functions, so we forge a name
+    // using its parent declaration.
+    if (FD.isAccessor())
+      if (ValueDecl *VD = FD.getAccessorStorageDecl()) {
+        const char *Kind;
+        switch (FD.getAccessorKind()) {
+        case AccessorKind::NotAccessor:
+          llvm_unreachable("this is an accessor");
+        case AccessorKind::IsGetter:
+          Kind = ".get";
+          break;
+        case AccessorKind::IsSetter:
+          Kind = ".set";
+          break;
+        case AccessorKind::IsWillSet:
+          Kind = ".willset";
+          break;
+        case AccessorKind::IsDidSet:
+          Kind = ".didset";
+          break;
+        case AccessorKind::IsMaterializeForSet:
+          Kind = ".materialize";
+          break;
+        case AccessorKind::IsAddressor:
+          Kind = ".addressor";
+          break;
+        case AccessorKind::IsMutableAddressor:
+          Kind = ".mutableAddressor";
+          break;
+        }
+
+        SmallVector<char, 64> Buf;
+        StringRef Name = (VD->getName().str() + Twine(Kind)).toStringRef(Buf);
+        return BumpAllocatedString(Name);
+      }
+
+    if (FD.hasName())
+      return FD.getName().str();
+
+    return StringRef();
+  }
+
+  StringRef getName(SILLocation L) {
+    if (L.isNull())
+      return StringRef();
+
+    if (FuncDecl *FD = L.getAsASTNode<FuncDecl>())
+      return getName(*FD);
+
+    if (L.isASTNode<ConstructorDecl>())
+      return "init";
+
+    if (L.isASTNode<DestructorDecl>())
+      return "deinit";
+
+    return StringRef();
+  }
+
+  static CanSILFunctionType getFunctionType(SILType SILTy) {
+    if (!SILTy)
+      return CanSILFunctionType();
+
+    auto FnTy = SILTy.getAs<SILFunctionType>();
+    if (!FnTy) {
+      DEBUG(llvm::dbgs() << "Unexpected function type: "; SILTy.dump();
+            llvm::dbgs() << "\n");
+      return CanSILFunctionType();
+    }
+
+    return FnTy;
+  }
+
+  llvm::DIScope *getOrCreateContext(DeclContext *DC) {
+    if (!DC)
+      return TheCU;
+
+    if (isa<FuncDecl>(DC))
+      if (auto *Decl = IGM.getSILModule().lookUpFunction(SILDeclRef(
+              cast<AbstractFunctionDecl>(DC), SILDeclRef::Kind::Func)))
+        return getOrCreateScope(Decl->getDebugScope());
+
+    switch (DC->getContextKind()) {
+    // The interesting cases are already handled above.
+    case DeclContextKind::AbstractFunctionDecl:
+    case DeclContextKind::AbstractClosureExpr:
+
+    // We don't model these in DWARF.
+    case DeclContextKind::SerializedLocal:
+    case DeclContextKind::Initializer:
+    case DeclContextKind::ExtensionDecl:
+    case DeclContextKind::SubscriptDecl:
+    case DeclContextKind::TopLevelCodeDecl:
+      return getOrCreateContext(DC->getParent());
+
+    case DeclContextKind::Module:
+      return getOrCreateModule(
+          {ModuleDecl::AccessPathTy(), cast<ModuleDecl>(DC)});
+    case DeclContextKind::FileUnit:
+      // A module may contain multiple files.
+      return getOrCreateContext(DC->getParent());
+    case DeclContextKind::GenericTypeDecl: {
+      auto *NTD = cast<NominalTypeDecl>(DC);
+      auto *Ty = NTD->getDeclaredType().getPointer();
+      if (auto *DITy = getTypeOrNull(Ty))
+        return DITy;
+
+      // Create a Forward-declared type.
+      auto Loc = getDebugLoc(*this, NTD);
+      auto File = getOrCreateFile(Loc.Filename);
+      auto Line = Loc.Line;
+      auto FwdDecl = DBuilder.createReplaceableCompositeType(
+          llvm::dwarf::DW_TAG_structure_type, NTD->getName().str(),
+          getOrCreateContext(DC->getParent()), File, Line,
+          llvm::dwarf::DW_LANG_Swift, 0, 0);
+      ReplaceMap.emplace_back(
+          std::piecewise_construct, std::make_tuple(Ty),
+          std::make_tuple(static_cast<llvm::Metadata *>(FwdDecl)));
+      return FwdDecl;
+    }
+    }
+    return TheCU;
+  }
+
+  void createParameterType(llvm::SmallVectorImpl<llvm::Metadata *> &Parameters,
+                           SILType type, DeclContext *DeclCtx,
+                           GenericEnvironment *GE) {
+    auto RealType = type.getSwiftRValueType();
+    if (type.isAddress())
+      RealType = CanInOutType::get(RealType);
+    auto DbgTy = DebugTypeInfo::getFromTypeInfo(DeclCtx, GE, RealType,
+                                                IGM.getTypeInfo(type));
+    Parameters.push_back(getOrCreateType(DbgTy));
+  }
+
+  // This is different from SILFunctionType::getAllResultsType() in some subtle
+  // ways.
+  static SILType getResultTypeForDebugInfo(CanSILFunctionType fnTy) {
+    if (fnTy->getNumResults() == 1) {
+      return fnTy->getResults()[0].getSILStorageType();
+    } else if (!fnTy->getNumIndirectFormalResults()) {
+      return fnTy->getDirectFormalResultsType();
+    } else {
+      SmallVector<TupleTypeElt, 4> eltTys;
+      for (auto &result : fnTy->getResults()) {
+        eltTys.push_back(result.getType());
+      }
+      return SILType::getPrimitiveAddressType(
+          CanType(TupleType::get(eltTys, fnTy->getASTContext())));
+    }
+  }
+
+  llvm::DITypeRefArray createParameterTypes(SILType SILTy, DeclContext *DeclCtx,
+                                            GenericEnvironment *GE) {
+    if (!SILTy)
+      return nullptr;
+    return createParameterTypes(SILTy.castTo<SILFunctionType>(), DeclCtx, GE);
+  }
+
+  llvm::DITypeRefArray createParameterTypes(CanSILFunctionType FnTy,
+                                            DeclContext *DeclCtx,
+                                            GenericEnvironment *GE) {
+    SmallVector<llvm::Metadata *, 16> Parameters;
+
+    GenericContextScope scope(IGM, FnTy->getGenericSignature());
+
+    // The function return type is the first element in the list.
+    createParameterType(Parameters, getResultTypeForDebugInfo(FnTy), DeclCtx,
+                        GE);
+
+    // Actually, the input type is either a single type or a tuple
+    // type. We currently represent a function with one n-tuple argument
+    // as an n-ary function.
+    for (auto Param : FnTy->getParameters())
+      createParameterType(Parameters, IGM.silConv.getSILType(Param), DeclCtx,
+                          GE);
+
+    return DBuilder.getOrCreateTypeArray(Parameters);
+  }
+
+  /// FIXME: replace this condition with something more sane.
+  static bool isAllocatingConstructor(SILFunctionTypeRepresentation Rep,
+                                      DeclContext *DeclCtx) {
+    return Rep != SILFunctionTypeRepresentation::Method && DeclCtx &&
+           isa<ConstructorDecl>(DeclCtx);
+  }
+
+  llvm::DIModule *getOrCreateModule(ModuleDecl::ImportedModule M) {
+    StringRef Path = getFilenameFromDC(M.second);
+    if (M.first.empty()) {
+      StringRef Name = M.second->getName().str();
+      return getOrCreateModule(Name, TheCU, Name, Path);
+    }
+
+    unsigned I = 0;
+    SmallString<128> AccessPath;
+    llvm::DIScope *Scope = TheCU;
+    llvm::raw_svector_ostream OS(AccessPath);
+    for (auto elt : M.first) {
+      auto Component = elt.first.str();
+      if (++I > 1)
+        OS << '.';
+      OS << Component;
+      Scope = getOrCreateModule(AccessPath, Scope, Component, Path);
+    }
+    return cast<llvm::DIModule>(Scope);
+  }
+
+  llvm::DIModule *getOrCreateModule(StringRef Key, llvm::DIScope *Parent,
+                                    StringRef Name, StringRef IncludePath) {
+    // Look in the cache first.
+    auto Val = DIModuleCache.find(Key);
+    if (Val != DIModuleCache.end())
+      return cast<llvm::DIModule>(Val->second);
+
+    StringRef ConfigMacros;
+    StringRef Sysroot = IGM.Context.SearchPathOpts.SDKPath;
+    auto M =
+        DBuilder.createModule(Parent, Name, ConfigMacros, IncludePath, Sysroot);
+    DIModuleCache.insert({Key, llvm::TrackingMDNodeRef(M)});
+    return M;
+  }
+
+  llvm::DIModule *
+  getOrCreateModule(clang::ExternalASTSource::ASTSourceDescriptor Desc) {
+    // Handle Clang modules.
+    if (const clang::Module *ClangModule = Desc.getModuleOrNull()) {
+      llvm::DIModule *Parent = nullptr;
+      if (ClangModule->Parent) {
+        clang::ExternalASTSource::ASTSourceDescriptor PM(*ClangModule->Parent);
+        Parent = getOrCreateModule(PM);
+      }
+      return getOrCreateModule(ClangModule->getFullModuleName(), Parent,
+                               Desc.getModuleName(), Desc.getPath());
+    }
+    // Handle PCH.
+    return getOrCreateModule(Desc.getASTFile(), nullptr, Desc.getModuleName(),
+                             Desc.getPath());
+  };
+
+  TypeAliasDecl *getMetadataType() {
+    if (!MetadataTypeDecl) {
+      MetadataTypeDecl = new (IGM.Context) TypeAliasDecl(
+          SourceLoc(), SourceLoc(), IGM.Context.getIdentifier("$swift.type"),
+          SourceLoc(),
+          /*genericparams*/ nullptr, IGM.Context.TheBuiltinModule);
+      MetadataTypeDecl->setUnderlyingType(IGM.Context.TheRawPointerType);
+    }
+    return MetadataTypeDecl;
+  }
+
+  /// Return the DIFile that is the ancestor of Scope.
+  llvm::DIFile *getFile(llvm::DIScope *Scope) {
+    while (!isa<llvm::DIFile>(Scope)) {
+      switch (Scope->getTag()) {
+      case llvm::dwarf::DW_TAG_lexical_block:
+        Scope = cast<llvm::DILexicalBlock>(Scope)->getScope();
+        break;
+      case llvm::dwarf::DW_TAG_subprogram:
+        Scope = cast<llvm::DISubprogram>(Scope)->getFile();
+        break;
+      default:
+        return MainFile;
+      }
+      if (Scope)
+        return MainFile;
+    }
+    return cast<llvm::DIFile>(Scope);
+  }
+
+  static Size getStorageSize(const llvm::DataLayout &DL,
+                             ArrayRef<llvm::Value *> Storage) {
+    unsigned size = 0;
+    for (llvm::Value *Piece : Storage)
+      size += DL.getTypeSizeInBits(Piece->getType());
+    return Size(size);
+  }
+
+  StringRef getMangledName(DebugTypeInfo DbgTy) {
+    if (MetadataTypeDecl && DbgTy.getDecl() == MetadataTypeDecl)
+      return BumpAllocatedString(DbgTy.getDecl()->getName().str());
+
+    Mangle::ASTMangler Mangler;
+    std::string Name = Mangler.mangleTypeForDebugger(
+        DbgTy.getType(), DbgTy.getDeclContext(), DbgTy.getGenericEnvironment());
+    return BumpAllocatedString(Name);
+  }
+
+  llvm::DIDerivedType *createMemberType(DebugTypeInfo DbgTy, StringRef Name,
+                                        unsigned &OffsetInBits,
+                                        llvm::DIScope *Scope,
+                                        llvm::DIFile *File,
+                                        llvm::DINode::DIFlags Flags) {
+    unsigned SizeOfByte = CI.getTargetInfo().getCharWidth();
+    auto *Ty = getOrCreateType(DbgTy);
+    auto *DITy = DBuilder.createMemberType(Scope, Name, File, 0,
+                                           SizeOfByte * DbgTy.size.getValue(),
+                                           0, OffsetInBits, Flags, Ty);
+    OffsetInBits += getSizeInBits(Ty);
+    OffsetInBits =
+        llvm::alignTo(OffsetInBits, SizeOfByte * DbgTy.align.getValue());
+    return DITy;
+  }
+
+  llvm::DINodeArray
+  getTupleElements(TupleType *TupleTy, llvm::DIScope *Scope, llvm::DIFile *File,
+                   llvm::DINode::DIFlags Flags, DeclContext *DeclContext,
+                   GenericEnvironment *GE, unsigned &SizeInBits) {
+    SmallVector<llvm::Metadata *, 16> Elements;
+    unsigned OffsetInBits = 0;
+    auto genericSig = IGM.getSILTypes().getCurGenericContext();
+    for (auto ElemTy : TupleTy->getElementTypes()) {
+      auto &elemTI = IGM.getTypeInfoForUnlowered(
+          AbstractionPattern(genericSig, ElemTy->getCanonicalType()), ElemTy);
+      auto DbgTy =
+          DebugTypeInfo::getFromTypeInfo(DeclContext, GE, ElemTy, elemTI);
+      Elements.push_back(createMemberType(DbgTy, StringRef(), OffsetInBits,
+                                          Scope, File, Flags));
+    }
+    SizeInBits = OffsetInBits;
+    return DBuilder.getOrCreateArray(Elements);
+  }
+
+  llvm::DINodeArray getStructMembers(NominalTypeDecl *D, Type BaseTy,
+                                     llvm::DIScope *Scope, llvm::DIFile *File,
+                                     llvm::DINode::DIFlags Flags,
+                                     unsigned &SizeInBits) {
+    SmallVector<llvm::Metadata *, 16> Elements;
+    unsigned OffsetInBits = 0;
+    for (VarDecl *VD : D->getStoredProperties()) {
+      auto memberTy =
+          BaseTy->getTypeOfMember(IGM.getSwiftModule(), VD, nullptr);
+
+      auto DbgTy = DebugTypeInfo::getFromTypeInfo(
+          VD->getDeclContext(),
+          VD->getDeclContext()->getGenericEnvironmentOfContext(),
+          VD->getInterfaceType(),
+          IGM.getTypeInfoForUnlowered(
+              IGM.getSILTypes().getAbstractionPattern(VD), memberTy));
+      Elements.push_back(createMemberType(DbgTy, VD->getName().str(),
+                                          OffsetInBits, Scope, File, Flags));
+    }
+    if (OffsetInBits > SizeInBits)
+      SizeInBits = OffsetInBits;
+    return DBuilder.getOrCreateArray(Elements);
+  }
+
+  llvm::DICompositeType *
+  createStructType(DebugTypeInfo DbgTy, NominalTypeDecl *Decl, Type BaseTy,
+                   llvm::DIScope *Scope, llvm::DIFile *File, unsigned Line,
+                   unsigned SizeInBits, unsigned AlignInBits,
+                   llvm::DINode::DIFlags Flags, llvm::DIType *DerivedFrom,
+                   unsigned RuntimeLang, StringRef UniqueID) {
+    StringRef Name = Decl->getName().str();
+
+    // Forward declare this first because types may be recursive.
+    auto FwdDecl = llvm::TempDIType(DBuilder.createReplaceableCompositeType(
+        llvm::dwarf::DW_TAG_structure_type, Name, Scope, File, Line,
+        llvm::dwarf::DW_LANG_Swift, SizeInBits, 0, Flags, UniqueID));
+
+#ifndef NDEBUG
+    if (UniqueID.empty())
+      assert(!Name.empty() &&
+             "no mangled name and no human readable name given");
+    else
+      assert((UniqueID.startswith("_T") ||
+              UniqueID.startswith(MANGLING_PREFIX_STR)) &&
+             "UID is not a mangled name");
+#endif
+
+    auto TH = llvm::TrackingMDNodeRef(FwdDecl.get());
+    DITypeCache[DbgTy.getType()] = TH;
+    auto Members =
+        getStructMembers(Decl, BaseTy, Scope, File, Flags, SizeInBits);
+    auto DITy = DBuilder.createStructType(
+        Scope, Name, File, Line, SizeInBits, AlignInBits, Flags, DerivedFrom,
+        Members, RuntimeLang, nullptr, UniqueID);
+    DBuilder.replaceTemporary(std::move(FwdDecl), DITy);
+    return DITy;
+  }
+
+  llvm::DINodeArray getEnumElements(DebugTypeInfo DbgTy, EnumDecl *ED,
+                                    llvm::DIScope *Scope, llvm::DIFile *File,
+                                    llvm::DINode::DIFlags Flags) {
+    SmallVector<llvm::Metadata *, 16> Elements;
+
+    for (auto *ElemDecl : ED->getAllElements()) {
+      // FIXME <rdar://problem/14845818> Support enums.
+      // Swift Enums can be both like DWARF enums and discriminated unions.
+      DebugTypeInfo ElemDbgTy;
+      if (ED->hasRawType())
+        // An enum with a raw type (enum E : Int {}), similar to a
+        // DWARF enum.
+        //
+        // The storage occupied by the enum may be smaller than the
+        // one of the raw type as long as it is large enough to hold
+        // all enum values. Use the raw type for the debug type, but
+        // the storage size from the enum.
+        ElemDbgTy =
+            DebugTypeInfo(ED, DbgTy.getGenericEnvironment(), ED->getRawType(),
+                          DbgTy.StorageType, DbgTy.size, DbgTy.align, true);
+      else if (auto ArgTy = ElemDecl->getArgumentInterfaceType()) {
+        // A discriminated union. This should really be described as a
+        // DW_TAG_variant_type. For now only describing the data.
+        ArgTy = ElemDecl->getParentEnum()->mapTypeIntoContext(ArgTy);
+        auto &TI = IGM.getTypeInfoForUnlowered(ArgTy);
+        ElemDbgTy = DebugTypeInfo::getFromTypeInfo(
+            ElemDecl->getDeclContext(),
+            ElemDecl->getDeclContext()->getGenericEnvironmentOfContext(), ArgTy,
+            TI);
+      } else {
+        // Discriminated union case without argument. Fallback to Int
+        // as the element type; there is no storage here.
+        Type IntTy = IGM.Context.getIntDecl()->getDeclaredType();
+        ElemDbgTy = DebugTypeInfo(
+            ElemDecl->getDeclContext(),
+            ElemDecl->getDeclContext()->getGenericEnvironmentOfContext(), IntTy,
+            DbgTy.StorageType, Size(0), Alignment(1), true);
+      }
+      unsigned Offset = 0;
+      auto MTy = createMemberType(ElemDbgTy, ElemDecl->getName().str(), Offset,
+                                  Scope, File, Flags);
+      Elements.push_back(MTy);
+    }
+    return DBuilder.getOrCreateArray(Elements);
+  }
+
+  llvm::DICompositeType *createEnumType(DebugTypeInfo DbgTy, EnumDecl *Decl,
+                                        StringRef MangledName,
+                                        llvm::DIScope *Scope,
+                                        llvm::DIFile *File, unsigned Line,
+                                        llvm::DINode::DIFlags Flags) {
+    unsigned SizeOfByte = CI.getTargetInfo().getCharWidth();
+    unsigned SizeInBits = DbgTy.size.getValue() * SizeOfByte;
+    // Default, since Swift doesn't allow specifying a custom alignment.
+    unsigned AlignInBits = 0;
+
+    // FIXME: Is DW_TAG_union_type the right thing here?
+    // Consider using a DW_TAG_variant_type instead.
+    auto FwdDecl = llvm::TempDIType(DBuilder.createReplaceableCompositeType(
+        llvm::dwarf::DW_TAG_union_type, MangledName, Scope, File, Line,
+        llvm::dwarf::DW_LANG_Swift, SizeInBits, AlignInBits, Flags,
+        MangledName));
+
+    auto TH = llvm::TrackingMDNodeRef(FwdDecl.get());
+    DITypeCache[DbgTy.getType()] = TH;
+
+    auto DITy = DBuilder.createUnionType(
+        Scope, Decl->getName().str(), File, Line, SizeInBits, AlignInBits,
+        Flags, getEnumElements(DbgTy, Decl, Scope, File, Flags),
+        llvm::dwarf::DW_LANG_Swift, MangledName);
+
+    DBuilder.replaceTemporary(std::move(FwdDecl), DITy);
+    return DITy;
+  }
+
+  llvm::DIType *getOrCreateDesugaredType(Type Ty, DebugTypeInfo DbgTy) {
+    DebugTypeInfo BlandDbgTy(
+        DbgTy.getDeclContext(), DbgTy.getGenericEnvironment(), Ty,
+        DbgTy.StorageType, DbgTy.size, DbgTy.align, DbgTy.DefaultAlignment);
+    return getOrCreateType(BlandDbgTy);
+  }
+
+  uint64_t getSizeOfBasicType(DebugTypeInfo DbgTy) {
+    uint64_t SizeOfByte = CI.getTargetInfo().getCharWidth();
+    uint64_t BitWidth = DbgTy.size.getValue() * SizeOfByte;
+    llvm::Type *StorageType = DbgTy.StorageType
+                                  ? DbgTy.StorageType
+                                  : IGM.DataLayout.getSmallestLegalIntType(
+                                        IGM.getLLVMContext(), BitWidth);
+
+    if (StorageType)
+      return IGM.DataLayout.getTypeSizeInBits(StorageType);
+
+    // This type is too large to fit in a register.
+    assert(BitWidth > IGM.DataLayout.getLargestLegalIntTypeSizeInBits());
+    return BitWidth;
+  }
+
+  llvm::DIType *createPointerSizedStruct(llvm::DIScope *Scope, StringRef Name,
+                                         llvm::DIFile *File, unsigned Line,
+                                         llvm::DINode::DIFlags Flags,
+                                         StringRef MangledName) {
+    if (Opts.DebugInfoKind > IRGenDebugInfoKind::ASTTypes) {
+      auto FwdDecl = DBuilder.createForwardDecl(
+          llvm::dwarf::DW_TAG_structure_type, Name, Scope, File, Line,
+          llvm::dwarf::DW_LANG_Swift, 0, 0);
+      return createPointerSizedStruct(Scope, Name, FwdDecl, File, Line, Flags,
+                                      MangledName);
+    } else {
+      unsigned SizeInBits = CI.getTargetInfo().getPointerWidth(0);
+      return createOpaqueStruct(Scope, Name, File, Line, SizeInBits, 0, Flags,
+                                MangledName);
+    }
+  }
+
+  llvm::DIType *createPointerSizedStruct(llvm::DIScope *Scope, StringRef Name,
+                                         llvm::DIType *PointeeTy,
+                                         llvm::DIFile *File, unsigned Line,
+                                         llvm::DINode::DIFlags Flags,
+                                         StringRef MangledName) {
+    unsigned PtrSize = CI.getTargetInfo().getPointerWidth(0);
+    auto PtrTy = DBuilder.createPointerType(PointeeTy, PtrSize, 0);
+    llvm::Metadata *Elements[] = {DBuilder.createMemberType(
+        Scope, "ptr", File, 0, PtrSize, 0, 0, Flags, PtrTy)};
+    return DBuilder.createStructType(
+        Scope, Name, File, Line, PtrSize, 0, Flags,
+        /* DerivedFrom */ nullptr, DBuilder.getOrCreateArray(Elements),
+        llvm::dwarf::DW_LANG_Swift, nullptr, MangledName);
+  }
+
+  llvm::DIType *
+  createDoublePointerSizedStruct(llvm::DIScope *Scope, StringRef Name,
+                                 llvm::DIType *PointeeTy, llvm::DIFile *File,
+                                 unsigned Line, llvm::DINode::DIFlags Flags,
+                                 StringRef MangledName) {
+    unsigned PtrSize = CI.getTargetInfo().getPointerWidth(0);
+    llvm::Metadata *Elements[] = {
+        DBuilder.createMemberType(
+            Scope, "ptr", File, 0, PtrSize, 0, 0, Flags,
+            DBuilder.createPointerType(PointeeTy, PtrSize, 0)),
+        DBuilder.createMemberType(
+            Scope, "_", File, 0, PtrSize, 0, 0, Flags,
+            DBuilder.createPointerType(nullptr, PtrSize, 0))};
+    return DBuilder.createStructType(
+        Scope, Name, File, Line, 2 * PtrSize, 0, Flags,
+        /* DerivedFrom */ nullptr, DBuilder.getOrCreateArray(Elements),
+        llvm::dwarf::DW_LANG_Swift, nullptr, MangledName);
+  }
+
+  llvm::DIType *createFunctionPointer(DebugTypeInfo DbgTy, llvm::DIScope *Scope,
+                                      unsigned SizeInBits, unsigned AlignInBits,
+                                      llvm::DINode::DIFlags Flags,
+                                      StringRef MangledName) {
+    auto FwdDecl = llvm::TempDINode(DBuilder.createReplaceableCompositeType(
+        llvm::dwarf::DW_TAG_subroutine_type, MangledName, Scope, MainFile, 0,
+        llvm::dwarf::DW_LANG_Swift, SizeInBits, AlignInBits, Flags,
+        MangledName));
+
+    auto TH = llvm::TrackingMDNodeRef(FwdDecl.get());
+    DITypeCache[DbgTy.getType()] = TH;
+
+    CanSILFunctionType FunTy;
+    TypeBase *BaseTy = DbgTy.getType();
+    if (auto *SILFnTy = dyn_cast<SILFunctionType>(BaseTy))
+      FunTy = CanSILFunctionType(SILFnTy);
+    // FIXME: Handling of generic parameters in SIL type lowering is in flux.
+    // DebugInfo doesn't appear to care about the generic context, so just
+    // throw it away before lowering.
+    else if (isa<GenericFunctionType>(BaseTy)) {
+      auto *fTy = cast<AnyFunctionType>(BaseTy);
+      auto *nongenericTy = FunctionType::get(fTy->getInput(), fTy->getResult(),
+                                             fTy->getExtInfo());
+
+      FunTy = IGM.getLoweredType(nongenericTy).castTo<SILFunctionType>();
+    } else
+      FunTy = IGM.getLoweredType(BaseTy).castTo<SILFunctionType>();
+    auto Params = createParameterTypes(FunTy, DbgTy.getDeclContext(),
+                                       DbgTy.getGenericEnvironment());
+
+    auto FnTy = DBuilder.createSubroutineType(Params, Flags);
+    llvm::DIType *DITy;
+    if (FunTy->getRepresentation() == SILFunctionType::Representation::Thick) {
+      if (SizeInBits == 2 * CI.getTargetInfo().getPointerWidth(0))
+        // This is a FunctionPairTy: { i8*, %swift.refcounted* }.
+        DITy = createDoublePointerSizedStruct(Scope, MangledName, FnTy,
+                                              MainFile, 0, Flags, MangledName);
+      else
+        // This is a generic function as noted above.
+        DITy = createOpaqueStruct(Scope, MangledName, MainFile, 0, SizeInBits,
+                                  AlignInBits, Flags, MangledName);
+    } else {
+      assert(SizeInBits == CI.getTargetInfo().getPointerWidth(0));
+      DITy = createPointerSizedStruct(Scope, MangledName, FnTy, MainFile, 0,
+                                      Flags, MangledName);
+    }
+    DBuilder.replaceTemporary(std::move(FwdDecl), DITy);
+    return DITy;
+  }
+
+  llvm::DIType *createTuple(DebugTypeInfo DbgTy, llvm::DIScope *Scope,
+                            unsigned SizeInBits, unsigned AlignInBits,
+                            llvm::DINode::DIFlags Flags,
+                            StringRef MangledName) {
+    TypeBase *BaseTy = DbgTy.getType();
+    auto *TupleTy = BaseTy->castTo<TupleType>();
+    auto FwdDecl = llvm::TempDINode(DBuilder.createReplaceableCompositeType(
+        llvm::dwarf::DW_TAG_structure_type, MangledName, Scope, MainFile, 0,
+        llvm::dwarf::DW_LANG_Swift, SizeInBits, AlignInBits, Flags,
+        MangledName));
+
+    DITypeCache[DbgTy.getType()] = llvm::TrackingMDNodeRef(FwdDecl.get());
+
+    unsigned RealSize;
+    auto Elements = getTupleElements(TupleTy, Scope, MainFile, Flags,
+                                     DbgTy.getDeclContext(),
+                                     DbgTy.getGenericEnvironment(), RealSize);
+    // FIXME: Handle %swift.opaque members and make this into an assertion.
+    if (!RealSize)
+      RealSize = SizeInBits;
+
+    auto DITy = DBuilder.createStructType(
+        Scope, MangledName, MainFile, 0, RealSize, AlignInBits, Flags,
+        nullptr, // DerivedFrom
+        Elements, llvm::dwarf::DW_LANG_Swift, nullptr, MangledName);
+
+    DBuilder.replaceTemporary(std::move(FwdDecl), DITy);
+    return DITy;
+  }
+
+  llvm::DIType *createOpaqueStruct(llvm::DIScope *Scope, StringRef Name,
+                                   llvm::DIFile *File, unsigned Line,
+                                   unsigned SizeInBits, unsigned AlignInBits,
+                                   llvm::DINode::DIFlags Flags,
+                                   StringRef MangledName) {
+    return DBuilder.createStructType(
+        Scope, Name, File, Line, SizeInBits, AlignInBits, Flags,
+        /* DerivedFrom */ nullptr,
+        DBuilder.getOrCreateArray(ArrayRef<llvm::Metadata *>()),
+        llvm::dwarf::DW_LANG_Swift, nullptr, MangledName);
+  }
+
+  llvm::DIType *createType(DebugTypeInfo DbgTy, StringRef MangledName,
+                           llvm::DIScope *Scope, llvm::DIFile *File) {
+    // FIXME: For SizeInBits, clang uses the actual size of the type on
+    // the target machine instead of the storage size that is alloca'd
+    // in the LLVM IR. For all types that are boxed in a struct, we are
+    // emitting the storage size of the struct, but it may be necessary
+    // to emit the (target!) size of the underlying basic type.
+    uint64_t SizeOfByte = CI.getTargetInfo().getCharWidth();
+    uint64_t SizeInBits = DbgTy.size.getValue() * SizeOfByte;
+    unsigned AlignInBits =
+        DbgTy.DefaultAlignment ? 0 : DbgTy.align.getValue() * SizeOfByte;
+    unsigned Encoding = 0;
+    llvm::DINode::DIFlags Flags = llvm::DINode::FlagZero;
+
+    TypeBase *BaseTy = DbgTy.getType();
+
+    if (!BaseTy) {
+      DEBUG(llvm::dbgs() << "Type without TypeBase: "; DbgTy.getType()->dump();
+            llvm::dbgs() << "\n");
+      if (!InternalType) {
+        StringRef Name = "<internal>";
+        InternalType = DBuilder.createForwardDecl(
+            llvm::dwarf::DW_TAG_structure_type, Name, Scope, File,
+            /*Line*/ 0, llvm::dwarf::DW_LANG_Swift, SizeInBits, AlignInBits);
+      }
+      return InternalType;
+    }
+
+    // Here goes!
+    switch (BaseTy->getKind()) {
+    case TypeKind::BuiltinInteger: {
+      Encoding = llvm::dwarf::DW_ATE_unsigned;
+      SizeInBits = getSizeOfBasicType(DbgTy);
+      break;
+    }
+
+    case TypeKind::BuiltinFloat: {
+      auto *FloatTy = BaseTy->castTo<BuiltinFloatType>();
+      // Assuming that the bitwidth and FloatTy->getFPKind() are identical.
+      SizeInBits = FloatTy->getBitWidth();
+      Encoding = llvm::dwarf::DW_ATE_float;
+      break;
+    }
+
+    case TypeKind::BuiltinUnknownObject: {
+      // The builtin opaque Objective-C pointer type. Useful for pushing
+      // an Objective-C type through swift.
+      unsigned PtrSize = CI.getTargetInfo().getPointerWidth(0);
+      auto IdTy = DBuilder.createForwardDecl(llvm::dwarf::DW_TAG_structure_type,
+                                             MangledName, Scope, File, 0,
+                                             llvm::dwarf::DW_LANG_ObjC, 0, 0);
+      return DBuilder.createPointerType(IdTy, PtrSize, 0,
+                                        /* DWARFAddressSpace */ None,
+                                        MangledName);
+    }
+
+    case TypeKind::BuiltinNativeObject: {
+      unsigned PtrSize = CI.getTargetInfo().getPointerWidth(0);
+      auto PTy =
+          DBuilder.createPointerType(nullptr, PtrSize, 0,
+                                     /* DWARFAddressSpace */ None, MangledName);
+      return DBuilder.createObjectPointerType(PTy);
+    }
+
+    case TypeKind::BuiltinBridgeObject: {
+      unsigned PtrSize = CI.getTargetInfo().getPointerWidth(0);
+      auto PTy =
+          DBuilder.createPointerType(nullptr, PtrSize, 0,
+                                     /* DWARFAddressSpace */ None, MangledName);
+      return DBuilder.createObjectPointerType(PTy);
+    }
+
+    case TypeKind::BuiltinRawPointer: {
+      unsigned PtrSize = CI.getTargetInfo().getPointerWidth(0);
+      return DBuilder.createPointerType(nullptr, PtrSize, 0,
+                                        /* DWARFAddressSpace */ None,
+                                        MangledName);
+    }
+
+    case TypeKind::DynamicSelf: {
+      // Self. We don't have a way to represent instancetype in DWARF,
+      // so we emit the static type instead. This is similar to what we
+      // do with instancetype in Objective-C.
+      auto *DynamicSelfTy = BaseTy->castTo<DynamicSelfType>();
+      auto SelfTy =
+          getOrCreateDesugaredType(DynamicSelfTy->getSelfType(), DbgTy);
+      return DBuilder.createTypedef(SelfTy, MangledName, File, 0, File);
+    }
+
+    // Even builtin swift types usually come boxed in a struct.
+    case TypeKind::Struct: {
+      auto *StructTy = BaseTy->castTo<StructType>();
+      auto *Decl = StructTy->getDecl();
+      auto L = getDebugLoc(*this, Decl);
+      if (auto *ClangDecl = Decl->getClangDecl()) {
+        auto ClangSrcLoc = ClangDecl->getLocStart();
+        clang::SourceManager &ClangSM =
+            CI.getClangASTContext().getSourceManager();
+        L.Line = ClangSM.getPresumedLineNumber(ClangSrcLoc);
+        L.Filename = ClangSM.getBufferName(ClangSrcLoc);
+      }
+      auto *File = getOrCreateFile(L.Filename);
+      if (Opts.DebugInfoKind > IRGenDebugInfoKind::ASTTypes)
+        return createStructType(DbgTy, Decl, StructTy, Scope, File, L.Line,
+                                SizeInBits, AlignInBits, Flags,
+                                nullptr, // DerivedFrom
+                                llvm::dwarf::DW_LANG_Swift, MangledName);
+      else
+        return createOpaqueStruct(Scope, Decl->getName().str(), File, L.Line,
+                                  SizeInBits, AlignInBits, Flags, MangledName);
+    }
+
+    case TypeKind::Class: {
+      // Classes are represented as DW_TAG_structure_type. This way the
+      // DW_AT_APPLE_runtime_class(DW_LANG_Swift) attribute can be
+      // used to differentiate them from C++ and ObjC classes.
+      auto *ClassTy = BaseTy->castTo<ClassType>();
+      auto *Decl = ClassTy->getDecl();
+      auto L = getDebugLoc(*this, Decl);
+      if (auto *ClangDecl = Decl->getClangDecl()) {
+        auto ClangSrcLoc = ClangDecl->getLocStart();
+        clang::SourceManager &ClangSM =
+            CI.getClangASTContext().getSourceManager();
+        L.Line = ClangSM.getPresumedLineNumber(ClangSrcLoc);
+        L.Filename = ClangSM.getBufferName(ClangSrcLoc);
+      }
+      assert(SizeInBits == CI.getTargetInfo().getPointerWidth(0));
+      return createPointerSizedStruct(Scope, Decl->getNameStr(),
+                                      getOrCreateFile(L.Filename), L.Line,
+                                      Flags, MangledName);
+    }
+
+    case TypeKind::Protocol: {
+      auto *ProtocolTy = BaseTy->castTo<ProtocolType>();
+      auto *Decl = ProtocolTy->getDecl();
+      // FIXME: (LLVM branch) This should probably be a DW_TAG_interface_type.
+      auto L = getDebugLoc(*this, Decl);
+      auto File = getOrCreateFile(L.Filename);
+      return createOpaqueStruct(Scope, Decl ? Decl->getNameStr() : MangledName,
+                                File, L.Line, SizeInBits, AlignInBits, Flags,
+                                MangledName);
+    }
+
+    case TypeKind::ProtocolComposition: {
+      auto *Decl = DbgTy.getDecl();
+      auto L = getDebugLoc(*this, Decl);
+      auto File = getOrCreateFile(L.Filename);
+
+      // FIXME: emit types
+      // auto ProtocolCompositionTy = BaseTy->castTo<ProtocolCompositionType>();
+      return createOpaqueStruct(Scope, Decl ? Decl->getNameStr() : MangledName,
+                                File, L.Line, SizeInBits, AlignInBits, Flags,
+                                MangledName);
+    }
+
+    case TypeKind::UnboundGeneric: {
+      auto *UnboundTy = BaseTy->castTo<UnboundGenericType>();
+      auto *Decl = UnboundTy->getDecl();
+      auto L = getDebugLoc(*this, Decl);
+      assert(SizeInBits == CI.getTargetInfo().getPointerWidth(0));
+      return createPointerSizedStruct(Scope,
+                                      Decl ? Decl->getNameStr() : MangledName,
+                                      File, L.Line, Flags, MangledName);
+    }
+
+    case TypeKind::BoundGenericStruct: {
+      auto *StructTy = BaseTy->castTo<BoundGenericStructType>();
+      auto *Decl = StructTy->getDecl();
+      auto L = getDebugLoc(*this, Decl);
+      return createOpaqueStruct(Scope, Decl ? Decl->getNameStr() : MangledName,
+                                File, L.Line, SizeInBits, AlignInBits, Flags,
+                                MangledName);
+    }
+
+    case TypeKind::BoundGenericClass: {
+      auto *ClassTy = BaseTy->castTo<BoundGenericClassType>();
+      auto *Decl = ClassTy->getDecl();
+      auto L = getDebugLoc(*this, Decl);
+      // TODO: We may want to peek at Decl->isObjC() and set this
+      // attribute accordingly.
+      assert(SizeInBits == CI.getTargetInfo().getPointerWidth(0));
+      return createPointerSizedStruct(Scope,
+                                      Decl ? Decl->getNameStr() : MangledName,
+                                      File, L.Line, Flags, MangledName);
+    }
+
+    case TypeKind::Tuple: {
+      // Tuples are also represented as structs.
+      if (Opts.DebugInfoKind > IRGenDebugInfoKind::ASTTypes)
+        return createTuple(DbgTy, Scope, SizeInBits, AlignInBits, Flags,
+                           MangledName);
+      else
+        return createOpaqueStruct(Scope, MangledName, MainFile, 0, SizeInBits,
+                                  AlignInBits, Flags, MangledName);
+    }
+
+    case TypeKind::InOut: {
+      // This is an inout type. Naturally we would be emitting them as
+      // DW_TAG_reference_type types, but LLDB can deal better with
+      // pointer-sized struct that has the appropriate mangled name.
+      auto ObjectTy = BaseTy->castTo<InOutType>()->getObjectType();
+      if (Opts.DebugInfoKind > IRGenDebugInfoKind::ASTTypes) {
+        auto DT = getOrCreateDesugaredType(ObjectTy, DbgTy);
+        return createPointerSizedStruct(Scope, MangledName, DT, File, 0, Flags,
+                                        MangledName);
+      } else
+        return createOpaqueStruct(Scope, MangledName, File, 0, SizeInBits,
+                                  AlignInBits, Flags, MangledName);
+    }
+
+    case TypeKind::Archetype: {
+      auto *Archetype = BaseTy->castTo<ArchetypeType>();
+      auto L = getDebugLoc(*this, Archetype->getAssocType());
+      auto Superclass = Archetype->getSuperclass();
+      auto DerivedFrom = Superclass.isNull()
+                             ? nullptr
+                             : getOrCreateDesugaredType(Superclass, DbgTy);
+      auto FwdDecl = llvm::TempDIType(DBuilder.createReplaceableCompositeType(
+          llvm::dwarf::DW_TAG_structure_type, MangledName, Scope, File, L.Line,
+          llvm::dwarf::DW_LANG_Swift, SizeInBits, AlignInBits, Flags,
+          MangledName));
+
+      // Emit the protocols the archetypes conform to.
+      SmallVector<llvm::Metadata *, 4> Protocols;
+      for (auto *ProtocolDecl : Archetype->getConformsTo()) {
+        auto PTy = IGM.getLoweredType(ProtocolDecl->getInterfaceType())
+                       .getSwiftRValueType();
+        auto PDbgTy = DebugTypeInfo::getFromTypeInfo(
+            DbgTy.getDeclContext(), DbgTy.getGenericEnvironment(),
+            ProtocolDecl->getInterfaceType(), IGM.getTypeInfoForLowered(PTy));
+        auto PDITy = getOrCreateType(PDbgTy);
+        Protocols.push_back(
+            DBuilder.createInheritance(FwdDecl.get(), PDITy, 0, Flags));
+      }
+      auto DITy = DBuilder.createStructType(
+          Scope, MangledName, File, L.Line, SizeInBits, AlignInBits, Flags,
+          DerivedFrom, DBuilder.getOrCreateArray(Protocols),
+          llvm::dwarf::DW_LANG_Swift, nullptr, MangledName);
+
+      DBuilder.replaceTemporary(std::move(FwdDecl), DITy);
+      return DITy;
+    }
+
+    case TypeKind::ExistentialMetatype:
+    case TypeKind::Metatype: {
+      // Metatypes are (mostly) singleton type descriptors, often without
+      // storage.
+      Flags |= llvm::DINode::FlagArtificial;
+      auto L = getDebugLoc(*this, DbgTy.getDecl());
+      auto File = getOrCreateFile(L.Filename);
+      return DBuilder.createStructType(
+          Scope, MangledName, File, L.Line, SizeInBits, AlignInBits, Flags,
+          nullptr, nullptr, llvm::dwarf::DW_LANG_Swift, nullptr, MangledName);
+    }
+
+    case TypeKind::SILFunction:
+    case TypeKind::Function:
+    case TypeKind::GenericFunction: {
+      if (Opts.DebugInfoKind > IRGenDebugInfoKind::ASTTypes)
+        return createFunctionPointer(DbgTy, Scope, SizeInBits, AlignInBits,
+                                     Flags, MangledName);
+      else
+        return createOpaqueStruct(Scope, MangledName, MainFile, 0, SizeInBits,
+                                  AlignInBits, Flags, MangledName);
+    }
+
+    case TypeKind::Enum: {
+      auto *EnumTy = BaseTy->castTo<EnumType>();
+      auto *Decl = EnumTy->getDecl();
+      auto L = getDebugLoc(*this, Decl);
+      auto *File = getOrCreateFile(L.Filename);
+      if (Opts.DebugInfoKind > IRGenDebugInfoKind::ASTTypes)
+        return createEnumType(DbgTy, Decl, MangledName, Scope, File, L.Line,
+                              Flags);
+      else
+        return createOpaqueStruct(Scope, Decl->getName().str(), File, L.Line,
+                                  SizeInBits, AlignInBits, Flags, MangledName);
+    }
+
+    case TypeKind::BoundGenericEnum: {
+      auto *EnumTy = BaseTy->castTo<BoundGenericEnumType>();
+      auto *Decl = EnumTy->getDecl();
+      auto L = getDebugLoc(*this, Decl);
+      auto *File = getOrCreateFile(L.Filename);
+      if (Opts.DebugInfoKind > IRGenDebugInfoKind::ASTTypes)
+        return createEnumType(DbgTy, Decl, MangledName, Scope, File, L.Line,
+                              Flags);
+      else
+        return createOpaqueStruct(Scope, Decl->getName().str(), File, L.Line,
+                                  SizeInBits, AlignInBits, Flags, MangledName);
+    }
+
+    case TypeKind::BuiltinVector: {
+      (void)MangledName; // FIXME emit the name somewhere.
+      auto *BuiltinVectorTy = BaseTy->castTo<BuiltinVectorType>();
+      DebugTypeInfo ElemDbgTy(DbgTy.getDeclContext(),
+                              DbgTy.getGenericEnvironment(),
+                              BuiltinVectorTy->getElementType(),
+                              DbgTy.StorageType, DbgTy.size, DbgTy.align, true);
+      auto Subscripts = nullptr;
+      return DBuilder.createVectorType(BuiltinVectorTy->getNumElements(),
+                                       AlignInBits, getOrCreateType(ElemDbgTy),
+                                       Subscripts);
+    }
+
+    // Reference storage types.
+    case TypeKind::UnownedStorage:
+    case TypeKind::UnmanagedStorage:
+    case TypeKind::WeakStorage: {
+      auto *ReferenceTy = cast<ReferenceStorageType>(BaseTy);
+      auto CanTy = ReferenceTy->getReferentType();
+      auto L = getDebugLoc(*this, DbgTy.getDecl());
+      auto File = getOrCreateFile(L.Filename);
+      return DBuilder.createTypedef(getOrCreateDesugaredType(CanTy, DbgTy),
+                                    MangledName, File, L.Line, File);
+    }
+
+    // Sugared types.
+
+    case TypeKind::NameAlias: {
+
+      auto *NameAliasTy = cast<NameAliasType>(BaseTy);
+      auto *Decl = NameAliasTy->getDecl();
+      auto L = getDebugLoc(*this, Decl);
+      auto AliasedTy = NameAliasTy->getSinglyDesugaredType();
+      auto File = getOrCreateFile(L.Filename);
+      // For NameAlias types, the DeclContext for the aliasED type is
+      // in the decl of the alias type.
+      DebugTypeInfo AliasedDbgTy(
+          DbgTy.getDeclContext(), DbgTy.getGenericEnvironment(), AliasedTy,
+          DbgTy.StorageType, DbgTy.size, DbgTy.align, DbgTy.DefaultAlignment);
+      return DBuilder.createTypedef(getOrCreateType(AliasedDbgTy), MangledName,
+                                    File, L.Line, File);
+    }
+
+    case TypeKind::Paren: {
+      auto Ty = cast<ParenType>(BaseTy)->getUnderlyingType();
+      return getOrCreateDesugaredType(Ty, DbgTy);
+    }
+
+    // SyntaxSugarType derivations.
+    case TypeKind::ArraySlice:
+    case TypeKind::Optional:
+    case TypeKind::ImplicitlyUnwrappedOptional: {
+      auto *SyntaxSugarTy = cast<SyntaxSugarType>(BaseTy);
+      auto *CanTy = SyntaxSugarTy->getSinglyDesugaredType();
+      return getOrCreateDesugaredType(CanTy, DbgTy);
+    }
+
+    case TypeKind::Dictionary: {
+      auto *DictionaryTy = cast<DictionaryType>(BaseTy);
+      auto *CanTy = DictionaryTy->getDesugaredType();
+      return getOrCreateDesugaredType(CanTy, DbgTy);
+    }
+
+    case TypeKind::GenericTypeParam: {
+      auto *ParamTy = cast<GenericTypeParamType>(BaseTy);
+      // FIXME: Provide a more meaningful debug type.
+      return DBuilder.createUnspecifiedType(ParamTy->getName().str());
+    }
+    case TypeKind::DependentMember: {
+      auto *MemberTy = cast<DependentMemberType>(BaseTy);
+      // FIXME: Provide a more meaningful debug type.
+      return DBuilder.createUnspecifiedType(MemberTy->getName().str());
+    }
+
+    // The following types exist primarily for internal use by the type
+    // checker.
+    case TypeKind::Error:
+    case TypeKind::Unresolved:
+    case TypeKind::LValue:
+    case TypeKind::TypeVariable:
+    case TypeKind::Module:
+    case TypeKind::SILBlockStorage:
+    case TypeKind::SILBox:
+    case TypeKind::BuiltinUnsafeValueBuffer:
+
+      DEBUG(llvm::errs() << "Unhandled type: "; DbgTy.getType()->dump();
+            llvm::errs() << "\n");
+      MangledName = "<unknown>";
+    }
+    return DBuilder.createBasicType(MangledName, SizeInBits, Encoding);
+  }
+
+  /// Determine if there exists a name mangling for the given type.
+  static bool canMangle(TypeBase *Ty) {
+    switch (Ty->getKind()) {
+    case TypeKind::GenericFunction: // Not yet supported.
+    case TypeKind::SILBlockStorage: // Not supported at all.
+    case TypeKind::SILBox:
+      return false;
+    case TypeKind::InOut: {
+      auto *ObjectTy = Ty->castTo<InOutType>()->getObjectType().getPointer();
+      return canMangle(ObjectTy);
+    }
+    default:
+      return true;
+    }
+  }
+
+  llvm::DIType *getTypeOrNull(TypeBase *Ty) {
+    auto CachedType = DITypeCache.find(Ty);
+    if (CachedType != DITypeCache.end()) {
+      // Verify that the information still exists.
+      if (llvm::Metadata *Val = CachedType->second) {
+        auto DITy = cast<llvm::DIType>(Val);
+        return DITy;
+      }
+    }
+    return nullptr;
+  }
+
+  llvm::DIType *getOrCreateType(DebugTypeInfo DbgTy) {
+    // Is this an empty type?
+    if (DbgTy.isNull())
+      // We can't use the empty type as an index into DenseMap.
+      return createType(DbgTy, "", TheCU, MainFile);
+
+    // Look in the cache first.
+    if (auto *DITy = getTypeOrNull(DbgTy.getType()))
+      return DITy;
+
+    // Second line of defense: Look up the mangled name. TypeBase*'s are
+    // not necessarily unique, but name mangling is too expensive to do
+    // every time.
+    StringRef MangledName;
+    llvm::MDString *UID = nullptr;
+    if (canMangle(DbgTy.getType())) {
+      MangledName = getMangledName(DbgTy);
+      UID = llvm::MDString::get(IGM.getLLVMContext(), MangledName);
+      if (llvm::Metadata *CachedTy = DIRefMap.lookup(UID)) {
+        auto DITy = cast<llvm::DIType>(CachedTy);
+        return DITy;
+      }
+    }
+
+    // Retrieve the context of the type, as opposed to the DeclContext
+    // of the variable.
+    //
+    // FIXME: Builtin and qualified types in LLVM have no parent
+    // scope. TODO: This can be fixed by extending DIBuilder.
+    llvm::DIScope *Scope = nullptr;
+    DeclContext *Context = DbgTy.getType()->getNominalOrBoundGenericNominal();
+    if (Context) {
+      if (auto *D = Context->getAsNominalTypeOrNominalTypeExtensionContext())
+        if (auto *ClangDecl = D->getClangDecl()) {
+          clang::ASTReader &Reader = *CI.getClangInstance().getModuleManager();
+          auto Idx = ClangDecl->getOwningModuleID();
+          if (auto Info = Reader.getSourceDescriptor(Idx))
+            Scope = getOrCreateModule(*Info);
+        }
+      Context = Context->getParent();
+    }
+    if (!Scope)
+      Scope = getOrCreateContext(Context);
+    llvm::DIType *DITy = createType(DbgTy, MangledName, Scope, getFile(Scope));
+
+    // Incrementally build the DIRefMap.
+    if (auto *CTy = dyn_cast<llvm::DICompositeType>(DITy)) {
+#ifndef NDEBUG
+      // Sanity check.
+      if (llvm::Metadata *V = DIRefMap.lookup(UID)) {
+        auto *CachedTy = cast<llvm::DIType>(V);
+        assert(CachedTy == DITy && "conflicting types for one UID");
+      }
+#endif
+      // If this type supports a UID, enter it to the cache.
+      if (auto UID = CTy->getRawIdentifier()) {
+        assert(UID->getString() == MangledName &&
+               "Unique identifier is different from mangled name ");
+        DIRefMap[UID] = llvm::TrackingMDNodeRef(DITy);
+      }
+    }
+
+    // Store it in the cache.
+    DITypeCache.insert({DbgTy.getType(), llvm::TrackingMDNodeRef(DITy)});
+
+    return DITy;
+  }
+};
+
+IRGenDebugInfoImpl::IRGenDebugInfoImpl(const IRGenOptions &Opts,
+                                       ClangImporter &CI, IRGenModule &IGM,
+                                       llvm::Module &M, SourceFile *SF)
+    : Opts(Opts), CI(CI), SM(IGM.Context.SourceMgr), DBuilder(M),
+      IGM(IGM), MetadataTypeDecl(nullptr), InternalType(nullptr),
+      LastDebugLoc({}), LastScope(nullptr) {
+  assert(Opts.DebugInfoKind > IRGenDebugInfoKind::None &&
+         "no debug info should be generated");
+  StringRef SourceFileName =
+      SF ? SF->getFilename() : StringRef(Opts.MainInputFilename);
   StringRef Dir;
   llvm::SmallString<256> AbsMainFile;
   if (SourceFileName.empty())
@@ -128,7 +1497,7 @@ IRGenDebugInfo::IRGenDebugInfo(const IRGenOptions &Opts,
 
   unsigned Lang = llvm::dwarf::DW_LANG_Swift;
   std::string Producer = version::getSwiftFullVersion(
-    IGM.Context.LangOpts.EffectiveLanguageVersion);
+      IGM.Context.LangOpts.EffectiveLanguageVersion);
   bool IsOptimized = Opts.Optimize;
   StringRef Flags = Opts.DWARFDebugFlags;
   unsigned Major, Minor;
@@ -167,157 +1536,27 @@ IRGenDebugInfo::IRGenDebugInfo(const IRGenOptions &Opts,
   DBuilder.createImportedModule(MainFile, MainModule, 1);
 }
 
-static StringRef getFilenameFromDC(const DeclContext *DC) {
-  if (auto LF = dyn_cast<LoadedFile>(DC))
-    return LF->getFilename();
-  if (auto SF = dyn_cast<SourceFile>(DC))
-    return SF->getFilename();
-  else if (auto M = dyn_cast<ModuleDecl>(DC))
-    return M->getModuleFilename();
-  else
-    return StringRef();
-}
+void IRGenDebugInfoImpl::finalize() {
+  assert(LocationStack.empty() && "Mismatch of pushLoc() and popLoc().");
 
-SILLocation::DebugLoc getDeserializedLoc(Pattern *) { return {}; }
-SILLocation::DebugLoc getDeserializedLoc(Expr *) { return {}; }
-SILLocation::DebugLoc getDeserializedLoc(Stmt *) { return {}; }
-SILLocation::DebugLoc getDeserializedLoc(Decl *D) {
-  SILLocation::DebugLoc L;
-  const DeclContext *DC = D->getDeclContext()->getModuleScopeContext();
-  StringRef Filename = getFilenameFromDC(DC);
-  if (!Filename.empty())
-    L.Filename = Filename;
-  return L;
-}
-
-/// Use the SM to figure out the actual line/column of a SourceLoc.
-template <typename WithLoc>
-SILLocation::DebugLoc getDebugLoc(IRGenDebugInfo &DI, WithLoc *S,
-                                  bool End = false) {  
-  SILLocation::DebugLoc L;
-  if (S == nullptr)
-    return L;
-
-  SourceLoc Loc = End ? S->getEndLoc() : S->getStartLoc();
-  if (Loc.isInvalid())
-    // This may be a deserialized or clang-imported decl. And modules
-    // don't come with SourceLocs right now. Get at least the name of
-    // the module.
-    return getDeserializedLoc(S);
-
-  return DI.decodeSourceLoc(Loc);
-}
-
-SILLocation::DebugLoc
-IRGenDebugInfo::getStartLocation(Optional<SILLocation> OptLoc) {
-  if (!OptLoc)
-    return {};
-  return decodeSourceLoc(OptLoc->getStartSourceLoc());
-}
-
-SILLocation::DebugLoc
-IRGenDebugInfo::decodeSourceLoc(SourceLoc SL) {
-  auto &Cached = DebugLocCache[SL.getOpaquePointerValue()];
-  if (Cached.Filename.empty())
-    Cached = SILLocation::decode(SL, SM);
-  return Cached;
-}
-
-SILLocation::DebugLoc
-IRGenDebugInfo::decodeDebugLoc(SILLocation Loc) {
-  if (Loc.isDebugInfoLoc())
-    return Loc.getDebugInfoLoc();
-  return decodeSourceLoc(Loc.getDebugSourceLoc());
-}
-
-SILLocation::DebugLoc
-IRGenDebugInfo::getDebugLocation(Optional<SILLocation> OptLoc) {
-  if (!OptLoc || OptLoc->isInPrologue())
-    return {};
-
-  return decodeDebugLoc(*OptLoc);
-}
-
-
-/// Determine whether this debug scope belongs to an explicit closure.
-static bool isExplicitClosure(const SILFunction *SILFn) {
-  if (SILFn && SILFn->hasLocation())
-    if (Expr *E = SILFn->getLocation().getAsASTNode<Expr>())
-      if (isa<ClosureExpr>(E))
-        return true;
-  return false;
-}
-
-/// Determine whether this location is some kind of closure.
-static bool isAbstractClosure(const SILLocation &Loc) {
-  if (Expr *E = Loc.getAsASTNode<Expr>())
-    if (isa<AbstractClosureExpr>(E))
-      return true;
-  return false;
-}
-
-/// Both the code that is used to set up a closure object and the
-/// (beginning of) the closure itself has the AbstractClosureExpr as
-/// location. We are only interested in the latter case and want to
-/// ignore the setup code.
-///
-/// callWithClosure(
-///  { // <-- a breakpoint here should only stop inside of the closure.
-///    foo();
-///  })
-///
-/// The actual closure has a closure expression as scope.
-static bool shouldIgnoreAbstractClosure(Optional<SILLocation> Loc,
-                                        const SILDebugScope *DS) {
-  return Loc && isAbstractClosure(*Loc) && DS && !isAbstractClosure(DS->Loc) &&
-         !Loc->is<ImplicitReturnLocation>();
-}
-
-llvm::MDNode *IRGenDebugInfo::createInlinedAt(const SILDebugScope *DS) {
-  auto *CS = DS->InlinedCallSite;
-  if (!CS)
-    return nullptr;
-
-  auto CachedInlinedAt = InlinedAtCache.find(CS);
-  if (CachedInlinedAt != InlinedAtCache.end())
-    return cast<llvm::MDNode>(CachedInlinedAt->second);
-
-  auto L = decodeDebugLoc(CS->Loc);
-  auto Scope = getOrCreateScope(CS->Parent.dyn_cast<const SILDebugScope *>());
-  auto InlinedAt =
-      llvm::DebugLoc::get(L.Line, L.Column, Scope, createInlinedAt(CS));
-  InlinedAtCache.insert({CS, llvm::TrackingMDNodeRef(InlinedAt.getAsMDNode())});
-  return InlinedAt;
-}
-
-#ifndef NDEBUG
-/// Perform a couple of sanity checks on scopes.
-static bool parentScopesAreSane(const SILDebugScope *DS) {
-  auto *Parent = DS;
-  while ((Parent = Parent->Parent.dyn_cast<const SILDebugScope *>())) {
-    if (!DS->InlinedCallSite)
-      assert(!Parent->InlinedCallSite &&
-             "non-inlined scope has an inlined parent");
+  // Finalize all replaceable forward declarations.
+  for (auto &Ty : ReplaceMap) {
+    llvm::TempMDNode FwdDecl(cast<llvm::MDNode>(Ty.second));
+    llvm::Metadata *Replacement;
+    if (auto *FullType = getTypeOrNull(Ty.first))
+      Replacement = FullType;
+    else
+      Replacement = Ty.second;
+    DBuilder.replaceTemporary(std::move(FwdDecl),
+                              cast<llvm::MDNode>(Replacement));
   }
-  return true;
+  // Finalize the DIBuilder.
+  DBuilder.finalize();
 }
 
-bool IRGenDebugInfo::lineNumberIsSane(IRBuilder &Builder, unsigned Line) {
-  if (IGM.IRGen.Opts.Optimize)
-    return true;
-
-  // Assert monotonically increasing line numbers within the same basic block;
-  llvm::BasicBlock *CurBasicBlock = Builder.GetInsertBlock();
-  if (CurBasicBlock == LastBasicBlock) {
-    return Line >= LastDebugLoc.Line;
-  }
-  LastBasicBlock = CurBasicBlock;
-  return true;
-}
-#endif
-
-void IRGenDebugInfo::setCurrentLoc(IRBuilder &Builder, const SILDebugScope *DS,
-                                   Optional<SILLocation> Loc) {
+void IRGenDebugInfoImpl::setCurrentLoc(IRBuilder &Builder,
+                                       const SILDebugScope *DS,
+                                       Optional<SILLocation> Loc) {
   assert(DS && "empty scope");
   auto *Scope = getOrCreateScope(DS);
   if (!Scope)
@@ -347,10 +1586,11 @@ void IRGenDebugInfo::setCurrentLoc(IRBuilder &Builder, const SILDebugScope *DS,
     auto File = getOrCreateFile(L.Filename);
     Scope = DBuilder.createLexicalBlockFile(Scope, File);
   }
-  
+
   // FIXME: Enable this assertion.
-  //assert(lineNumberIsSane(Builder, L.Line) &&
-  //       "-Onone, but line numbers are not monotonically increasing within bb");
+  // assert(lineNumberIsSane(Builder, L.Line) &&
+  //       "-Onone, but line numbers are not monotonically increasing within
+  //       bb");
   LastDebugLoc = L;
   LastScope = DS;
 
@@ -361,12 +1601,49 @@ void IRGenDebugInfo::setCurrentLoc(IRBuilder &Builder, const SILDebugScope *DS,
   Builder.SetCurrentDebugLocation(DL);
 }
 
-void IRGenDebugInfo::setEntryPointLoc(IRBuilder &Builder) {
+void IRGenDebugInfoImpl::clearLoc(IRBuilder &Builder) {
+  LastDebugLoc = {};
+  LastScope = nullptr;
+  Builder.SetCurrentDebugLocation(llvm::DebugLoc());
+}
+
+/// Push the current debug location onto a stack and initialize the
+/// IRBuilder to an empty location.
+void IRGenDebugInfoImpl::pushLoc() {
+  LocationStack.push_back(std::make_pair(LastDebugLoc, LastScope));
+  LastDebugLoc = {};
+  LastScope = nullptr;
+}
+
+/// Restore the current debug location from the stack.
+void IRGenDebugInfoImpl::popLoc() {
+  std::tie(LastDebugLoc, LastScope) = LocationStack.pop_back_val();
+}
+
+/// Emit the final line 0 location for the unified trap block at the
+/// end of the function.
+void IRGenDebugInfoImpl::setArtificialTrapLocation(IRBuilder &Builder,
+                                                   const SILDebugScope *Scope) {
+  auto DL = llvm::DebugLoc::get(0, 0, getOrCreateScope(Scope));
+  Builder.SetCurrentDebugLocation(DL);
+}
+
+void IRGenDebugInfoImpl::setEntryPointLoc(IRBuilder &Builder) {
   auto DL = llvm::DebugLoc::get(0, 0, getEntryPointFn(), nullptr);
   Builder.SetCurrentDebugLocation(DL);
 }
 
-llvm::DIScope *IRGenDebugInfo::getOrCreateScope(const SILDebugScope *DS) {
+llvm::DIScope *IRGenDebugInfoImpl::getEntryPointFn() {
+  // Lazily create EntryPointFn.
+  if (!EntryPointFn) {
+    EntryPointFn = DBuilder.createReplaceableCompositeType(
+        llvm::dwarf::DW_TAG_subroutine_type, SWIFT_ENTRY_POINT_FUNCTION,
+        MainFile, MainFile, 0);
+  }
+  return EntryPointFn;
+}
+
+llvm::DIScope *IRGenDebugInfoImpl::getOrCreateScope(const SILDebugScope *DS) {
   if (DS == nullptr)
     return MainFile;
 
@@ -416,226 +1693,38 @@ llvm::DIScope *IRGenDebugInfo::getOrCreateScope(const SILDebugScope *DS) {
   return DScope;
 }
 
-llvm::DIFile *IRGenDebugInfo::getOrCreateFile(StringRef Filename) {
-  if (Filename.empty())
-    return MainFile;
+void IRGenDebugInfoImpl::emitImport(ImportDecl *D) {
+  if (Opts.DebugInfoKind <= IRGenDebugInfoKind::LineTables)
+    return;
 
-  // Look in the cache first.
-  auto CachedFile = DIFileCache.find(Filename);
-  if (CachedFile != DIFileCache.end()) {
-    // Verify that the information still exists.
-    if (llvm::Metadata *V = CachedFile->second)
-      return cast<llvm::DIFile>(V);
+  swift::ModuleDecl *M = IGM.Context.getModule(D->getModulePath());
+  if (!M &&
+      D->getModulePath()[0].first == IGM.Context.TheBuiltinModule->getName())
+    M = IGM.Context.TheBuiltinModule;
+  if (!M) {
+    assert(M && "Could not find module for import decl.");
+    return;
   }
-
-  // Detect the main file.
-  if (MainFile && Filename.endswith(MainFile->getFilename())) {
-    SmallString<256> AbsThisFile, AbsMainFile;
-    AbsThisFile = Filename;
-    llvm::sys::fs::make_absolute(AbsThisFile);
-    llvm::sys::path::append(AbsMainFile, MainFile->getDirectory(),
-                            MainFile->getFilename());
-    if (AbsThisFile == AbsMainFile) {
-      DIFileCache[Filename] = llvm::TrackingMDNodeRef(MainFile);
-      return MainFile;
-    }
-  }
-  
-  // Create a new one.
-  StringRef File = llvm::sys::path::filename(Filename);
-  llvm::SmallString<512> Path(Filename);
-  llvm::sys::path::remove_filename(Path);
-  llvm::DIFile *F = DBuilder.createFile(File, Path);
-
-  // Cache it.
-  DIFileCache[Filename] = llvm::TrackingMDNodeRef(F);
-  return F;
+  auto DIMod = getOrCreateModule({D->getModulePath(), M});
+  auto L = getDebugLoc(*this, D);
+  DBuilder.createImportedModule(getOrCreateFile(L.Filename), DIMod, L.Line);
 }
 
-StringRef IRGenDebugInfo::getName(const FuncDecl &FD) {
-  // Getters and Setters are anonymous functions, so we forge a name
-  // using its parent declaration.
-  if (FD.isAccessor())
-    if (ValueDecl *VD = FD.getAccessorStorageDecl()) {
-      const char *Kind;
-      switch (FD.getAccessorKind()) {
-      case AccessorKind::NotAccessor: llvm_unreachable("this is an accessor");
-      case AccessorKind::IsGetter: Kind = ".get"; break;
-      case AccessorKind::IsSetter: Kind = ".set"; break;
-      case AccessorKind::IsWillSet: Kind = ".willset"; break;
-      case AccessorKind::IsDidSet: Kind = ".didset"; break;
-      case AccessorKind::IsMaterializeForSet: Kind = ".materialize"; break;
-      case AccessorKind::IsAddressor: Kind = ".addressor"; break;
-      case AccessorKind::IsMutableAddressor: Kind = ".mutableAddressor"; break;
-      }
-
-      SmallVector<char, 64> Buf;
-      StringRef Name = (VD->getName().str() + Twine(Kind)).toStringRef(Buf);
-      return BumpAllocatedString(Name);
-    }
-
-  if (FD.hasName())
-    return FD.getName().str();
-
-  return StringRef();
-}
-
-StringRef IRGenDebugInfo::getName(SILLocation L) {
-  if (L.isNull())
-    return StringRef();
-
-  if (FuncDecl *FD = L.getAsASTNode<FuncDecl>())
-    return getName(*FD);
-
-  if (L.isASTNode<ConstructorDecl>())
-    return "init";
-
-  if (L.isASTNode<DestructorDecl>())
-    return "deinit";
-
-  return StringRef();
-}
-
-static CanSILFunctionType getFunctionType(SILType SILTy) {
-  if (!SILTy)
-    return CanSILFunctionType();
-
-  auto FnTy = SILTy.getAs<SILFunctionType>();
-  if (!FnTy) {
-    DEBUG(llvm::dbgs() << "Unexpected function type: "; SILTy.dump();
-          llvm::dbgs() << "\n");
-    return CanSILFunctionType();
-  }
-
-  return FnTy;
-}
-
-llvm::DIScope *IRGenDebugInfo::getEntryPointFn() {
-  // Lazily create EntryPointFn.
-  if (!EntryPointFn) {
-    EntryPointFn = DBuilder.createReplaceableCompositeType(
-      llvm::dwarf::DW_TAG_subroutine_type, SWIFT_ENTRY_POINT_FUNCTION,
-        MainFile, MainFile, 0);
-  }
-  return EntryPointFn;
-}
-
-
-llvm::DIScope *IRGenDebugInfo::getOrCreateContext(DeclContext *DC) {
-  if (!DC)
-    return TheCU;
-
-  if (isa<FuncDecl>(DC))
-    if (auto *Decl = IGM.getSILModule().lookUpFunction(
-          SILDeclRef(cast<AbstractFunctionDecl>(DC), SILDeclRef::Kind::Func)))
-      return getOrCreateScope(Decl->getDebugScope());
-
-  switch (DC->getContextKind()) {
-  // The interesting cases are already handled above.
-  case DeclContextKind::AbstractFunctionDecl:
-  case DeclContextKind::AbstractClosureExpr:
-
-  // We don't model these in DWARF.
-  case DeclContextKind::SerializedLocal:
-  case DeclContextKind::Initializer:
-  case DeclContextKind::ExtensionDecl:
-  case DeclContextKind::SubscriptDecl:
-  case DeclContextKind::TopLevelCodeDecl:
-    return getOrCreateContext(DC->getParent());
-
-  case DeclContextKind::Module:
-    return getOrCreateModule({ModuleDecl::AccessPathTy(), cast<ModuleDecl>(DC)});
-  case DeclContextKind::FileUnit:
-    // A module may contain multiple files.
-    return getOrCreateContext(DC->getParent());
-  case DeclContextKind::GenericTypeDecl: {
-    auto *NTD = cast<NominalTypeDecl>(DC);
-    auto *Ty = NTD->getDeclaredType().getPointer();
-    if (auto *DITy = getTypeOrNull(Ty))
-      return DITy;
-
-    // Create a Forward-declared type.
-    auto Loc = getDebugLoc(*this, NTD);
-    auto File = getOrCreateFile(Loc.Filename);
-    auto Line = Loc.Line;
-    auto FwdDecl = DBuilder.createReplaceableCompositeType(
-        llvm::dwarf::DW_TAG_structure_type, NTD->getName().str(),
-        getOrCreateContext(DC->getParent()), File, Line,
-        llvm::dwarf::DW_LANG_Swift, 0, 0);
-    ReplaceMap.emplace_back(
-        std::piecewise_construct, std::make_tuple(Ty),
-        std::make_tuple(static_cast<llvm::Metadata *>(FwdDecl)));
-    return FwdDecl;
-  }
-  }
-  return TheCU;
-}
-
-void IRGenDebugInfo::createParameterType(
-    llvm::SmallVectorImpl<llvm::Metadata *> &Parameters, SILType type,
-      DeclContext *DeclCtx, GenericEnvironment *GE) {
-  auto RealType = type.getSwiftRValueType();
-  if (type.isAddress())
-    RealType = CanInOutType::get(RealType);
-  auto DbgTy = DebugTypeInfo::getFromTypeInfo(DeclCtx, GE, RealType,
-                                              IGM.getTypeInfo(type));
-  Parameters.push_back(getOrCreateType(DbgTy));
-}
-
-// This is different from SILFunctionType::getAllResultsType() in some subtle
-// ways.
-static SILType getResultTypeForDebugInfo(CanSILFunctionType fnTy) {
-  if (fnTy->getNumResults() == 1) {
-    return fnTy->getResults()[0].getSILStorageType();
-  } else if (!fnTy->getNumIndirectFormalResults()) {
-    return fnTy->getDirectFormalResultsType();
-  } else {
-    SmallVector<TupleTypeElt, 4> eltTys;
-    for (auto &result : fnTy->getResults()) {
-      eltTys.push_back(result.getType());
-    }
-    return SILType::getPrimitiveAddressType(
-      CanType(TupleType::get(eltTys, fnTy->getASTContext())));
-  }
-}
-
-llvm::DITypeRefArray
-IRGenDebugInfo::createParameterTypes(SILType SILTy, DeclContext *DeclCtx,
-                                     GenericEnvironment *GE) {
-  if (!SILTy)
-    return nullptr;
-  return createParameterTypes(SILTy.castTo<SILFunctionType>(), DeclCtx, GE);
-}
-
-llvm::DITypeRefArray IRGenDebugInfo::createParameterTypes(
-    CanSILFunctionType FnTy, DeclContext *DeclCtx, GenericEnvironment *GE) {
-  SmallVector<llvm::Metadata *, 16> Parameters;
-
-  GenericContextScope scope(IGM, FnTy->getGenericSignature());
-
-  // The function return type is the first element in the list.
-  createParameterType(Parameters, getResultTypeForDebugInfo(FnTy), DeclCtx, GE);
-
-  // Actually, the input type is either a single type or a tuple
-  // type. We currently represent a function with one n-tuple argument
-  // as an n-ary function.
-  for (auto Param : FnTy->getParameters())
-    createParameterType(Parameters, IGM.silConv.getSILType(Param), DeclCtx, GE);
-
-  return DBuilder.getOrCreateTypeArray(Parameters);
-}
-
-/// FIXME: replace this condition with something more sane.
-static bool isAllocatingConstructor(SILFunctionTypeRepresentation Rep,
-                                    DeclContext *DeclCtx) {
-  return Rep != SILFunctionTypeRepresentation::Method
-          && DeclCtx && isa<ConstructorDecl>(DeclCtx);
+llvm::DISubprogram *IRGenDebugInfoImpl::emitFunction(SILFunction &SILFn,
+                                                     llvm::Function *Fn) {
+  auto *DS = SILFn.getDebugScope();
+  assert(DS && "SIL function has no debug scope");
+  (void)DS;
+  return emitFunction(SILFn.getDebugScope(), Fn, SILFn.getRepresentation(),
+                      SILFn.getLoweredType(), SILFn.getDeclContext(),
+                      SILFn.getGenericEnvironment());
 }
 
 llvm::DISubprogram *
-IRGenDebugInfo::emitFunction(const SILDebugScope *DS, llvm::Function *Fn,
-                             SILFunctionTypeRepresentation Rep, SILType SILTy,
-                             DeclContext *DeclCtx, GenericEnvironment *GE) {
+IRGenDebugInfoImpl::emitFunction(const SILDebugScope *DS, llvm::Function *Fn,
+                                 SILFunctionTypeRepresentation Rep,
+                                 SILType SILTy, DeclContext *DeclCtx,
+                                 GenericEnvironment *GE) {
   auto Cached = ScopeCache.find(LocalScope(DS));
   if (Cached != ScopeCache.end()) {
     auto SP = cast<llvm::DISubprogram>(Cached->second);
@@ -721,8 +1810,8 @@ IRGenDebugInfo::emitFunction(const SILDebugScope *DS, llvm::Function *Fn,
     ScopeLine = 0;
   }
 
-  if (FnTy && FnTy->getRepresentation()
-        == SILFunctionType::Representation::Block)
+  if (FnTy &&
+      FnTy->getRepresentation() == SILFunctionType::Representation::Block)
     Flags |= llvm::DINode::FlagAppleBlock;
 
   // Get the throws information.
@@ -761,155 +1850,16 @@ IRGenDebugInfo::emitFunction(const SILDebugScope *DS, llvm::Function *Fn,
   return SP;
 }
 
-void IRGenDebugInfo::emitImport(ImportDecl *D) {
-  if (Opts.DebugInfoKind <= IRGenDebugInfoKind::LineTables)
-    return;
-
-  swift::ModuleDecl *M = IGM.Context.getModule(D->getModulePath());
-  if (!M &&
-      D->getModulePath()[0].first == IGM.Context.TheBuiltinModule->getName())
-    M = IGM.Context.TheBuiltinModule;
-  if (!M) {
-    assert(M && "Could not find module for import decl.");
-    return;
-  }
-  auto DIMod = getOrCreateModule({D->getModulePath(), M});
-  auto L = getDebugLoc(*this, D);
-  DBuilder.createImportedModule(getOrCreateFile(L.Filename), DIMod, L.Line);
-}
-
-llvm::DIModule *
-IRGenDebugInfo::getOrCreateModule(ModuleDecl::ImportedModule M) {
-  StringRef Path = getFilenameFromDC(M.second);
-  if (M.first.empty()) {
-    StringRef Name = M.second->getName().str();
-    return getOrCreateModule(Name, TheCU, Name, Path);
-  }
-
-  unsigned I = 0;
-  SmallString<128> AccessPath;
-  llvm::DIScope *Scope = TheCU;
-  llvm::raw_svector_ostream OS(AccessPath);
-  for (auto elt : M.first) {
-    auto Component = elt.first.str();
-    if (++I > 1)
-      OS << '.';
-    OS << Component;
-    Scope = getOrCreateModule(AccessPath, Scope, Component, Path);
-  }
-  return cast<llvm::DIModule>(Scope);
-}
-
-llvm::DIModule *IRGenDebugInfo::getOrCreateModule(StringRef Key,
-                                                  llvm::DIScope *Parent,
-                                                  StringRef Name,
-                                                  StringRef IncludePath) {
-  // Look in the cache first.
-  auto Val = DIModuleCache.find(Key);
-  if (Val != DIModuleCache.end())
-    return cast<llvm::DIModule>(Val->second);
-
-  StringRef ConfigMacros;
-  StringRef Sysroot = IGM.Context.SearchPathOpts.SDKPath;
-  auto M =
-      DBuilder.createModule(Parent, Name, ConfigMacros, IncludePath, Sysroot);
-  DIModuleCache.insert({Key, llvm::TrackingMDNodeRef(M)});
-  return M;
-}
-
-llvm::DIModule *IRGenDebugInfo::getOrCreateModule(
-    clang::ExternalASTSource::ASTSourceDescriptor Desc) {
-  // Handle Clang modules.
-  if (const clang::Module *ClangModule = Desc.getModuleOrNull()) {
-    llvm::DIModule *Parent = nullptr;
-    if (ClangModule->Parent) {
-      clang::ExternalASTSource::ASTSourceDescriptor PM(*ClangModule->Parent);
-      Parent = getOrCreateModule(PM);
-    }
-    return getOrCreateModule(ClangModule->getFullModuleName(), Parent,
-                             Desc.getModuleName(), Desc.getPath());
-  }
-  // Handle PCH.
-  return getOrCreateModule(Desc.getASTFile(), nullptr, Desc.getModuleName(),
-                           Desc.getPath());
-};
-
-llvm::DISubprogram *IRGenDebugInfo::emitFunction(SILFunction &SILFn,
-                                                 llvm::Function *Fn) {
-  auto *DS = SILFn.getDebugScope();
-  assert(DS && "SIL function has no debug scope");
-  (void) DS;
-  return emitFunction(SILFn.getDebugScope(), Fn, SILFn.getRepresentation(),
-                      SILFn.getLoweredType(), SILFn.getDeclContext(),
-                      SILFn.getGenericEnvironment());
-}
-
-void IRGenDebugInfo::emitArtificialFunction(IRBuilder &Builder,
-                                            llvm::Function *Fn, SILType SILTy) {
+void IRGenDebugInfoImpl::emitArtificialFunction(IRBuilder &Builder,
+                                                llvm::Function *Fn,
+                                                SILType SILTy) {
   RegularLocation ALoc = RegularLocation::getAutoGeneratedLocation();
   const SILDebugScope *Scope = new (IGM.getSILModule()) SILDebugScope(ALoc);
   emitFunction(Scope, Fn, SILFunctionTypeRepresentation::Thin, SILTy);
   setCurrentLoc(Builder, Scope);
 }
 
-TypeAliasDecl *IRGenDebugInfo::getMetadataType() {
-  if (!MetadataTypeDecl) {
-    MetadataTypeDecl = new (IGM.Context) TypeAliasDecl(
-        SourceLoc(), SourceLoc(),
-        IGM.Context.getIdentifier("$swift.type"), SourceLoc(),
-        /*genericparams*/nullptr, IGM.Context.TheBuiltinModule);
-    MetadataTypeDecl->setUnderlyingType(IGM.Context.TheRawPointerType);
-  }
-  return MetadataTypeDecl;
-}
-
-void IRGenDebugInfo::emitTypeMetadata(IRGenFunction &IGF,
-                                      llvm::Value *Metadata,
-                                      StringRef Name) {
-  if (Opts.DebugInfoKind <= IRGenDebugInfoKind::LineTables)
-    return;
-
-  auto TName = BumpAllocatedString(("$swift.type." + Name).str());
-  auto DbgTy = DebugTypeInfo::getMetadata(
-      getMetadataType()->getDeclaredInterfaceType().getPointer(),
-      Metadata->getType(), Size(CI.getTargetInfo().getPointerWidth(0)),
-      Alignment(CI.getTargetInfo().getPointerAlign(0)));
-  emitVariableDeclaration(IGF.Builder, Metadata, DbgTy, IGF.getDebugScope(),
-                          nullptr, TName, 0,
-                          // swift.type is already a pointer type,
-                          // having a shadow copy doesn't add another
-                          // layer of indirection.
-                          DirectValue, ArtificialValue);
-}
-
-/// Return the DIFile that is the ancestor of Scope.
-llvm::DIFile *IRGenDebugInfo::getFile(llvm::DIScope *Scope) {
-  while (!isa<llvm::DIFile>(Scope)) {
-    switch (Scope->getTag()) {
-    case llvm::dwarf::DW_TAG_lexical_block:
-      Scope = cast<llvm::DILexicalBlock>(Scope)->getScope();
-      break;
-    case llvm::dwarf::DW_TAG_subprogram:
-      Scope = cast<llvm::DISubprogram>(Scope)->getFile();
-      break;
-    default:
-      return MainFile;
-    }
-    if (Scope)
-      return MainFile;
-  }
-  return cast<llvm::DIFile>(Scope);
-}
-
-static Size
-getStorageSize(const llvm::DataLayout &DL, ArrayRef<llvm::Value *> Storage) {
-  unsigned size = 0;
-  for (llvm::Value *Piece : Storage)
-    size += DL.getTypeSizeInBits(Piece->getType());
-  return Size(size);
-}
-
-void IRGenDebugInfo::emitVariableDeclaration(
+void IRGenDebugInfoImpl::emitVariableDeclaration(
     IRBuilder &Builder, ArrayRef<llvm::Value *> Storage, DebugTypeInfo DbgTy,
     const SILDebugScope *DS, ValueDecl *VarDecl, StringRef Name, unsigned ArgNo,
     IndirectionKind Indirection, ArtificialKind Artificial) {
@@ -925,8 +1875,8 @@ void IRGenDebugInfo::emitVariableDeclaration(
   if (Opts.DebugInfoKind <= IRGenDebugInfoKind::LineTables)
     return;
 
-  // Currently, the DeclContext is needed to mangle archetypes. Bail out if it's
-  // missing.
+  // Currently, the DeclContext is needed to mangle archetypes. Bail out if
+  // it's missing.
   if (DbgTy.Type->hasArchetype() && !DbgTy.DeclCtx)
     return;
 
@@ -957,11 +1907,10 @@ void IRGenDebugInfo::emitVariableDeclaration(
   bool Optimized = false;
   // Create the descriptor for the variable.
   llvm::DILocalVariable *Var =
-      (ArgNo > 0)
-          ? DBuilder.createParameterVariable(Scope, Name, ArgNo, Unit, Line,
-                                             DITy, Optimized, Flags)
-          : DBuilder.createAutoVariable(Scope, Name, Unit, Line, DITy,
-                                        Optimized, Flags);
+      (ArgNo > 0) ? DBuilder.createParameterVariable(
+                        Scope, Name, ArgNo, Unit, Line, DITy, Optimized, Flags)
+                  : DBuilder.createAutoVariable(Scope, Name, Unit, Line, DITy,
+                                                Optimized, Flags);
 
   // Running variables for the current/previous piece.
   bool IsPiece = Storage.size() > 1;
@@ -975,8 +1924,8 @@ void IRGenDebugInfo::emitVariableDeclaration(
     if (Indirection)
       Operands.push_back(llvm::dwarf::DW_OP_deref);
 
-    // There are variables without storage, such as "struct { func foo() {} }".
-    // Emit them as constant 0.
+    // There are variables without storage, such as "struct { func foo() {}
+    // }". Emit them as constant 0.
     if (isa<llvm::UndefValue>(Piece))
       Piece = llvm::ConstantInt::get(IGM.Int64Ty, 0);
 
@@ -991,7 +1940,7 @@ void IRGenDebugInfo::emitVariableDeclaration(
       // Sanity checks.
       assert(SizeInBits && "zero-sized piece");
       assert(SizeInBits < getSizeInBits(Var) && "piece covers entire var");
-      assert(OffsetInBits+SizeInBits <= getSizeInBits(Var) && "pars > totum");
+      assert(OffsetInBits + SizeInBits <= getSizeInBits(Var) && "pars > totum");
 
       // Add the piece DWARF expression.
       Operands.push_back(llvm::dwarf::DW_OP_LLVM_fragment);
@@ -1008,11 +1957,10 @@ void IRGenDebugInfo::emitVariableDeclaration(
                      DBuilder.createExpression(), Line, Loc.Column, Scope, DS);
 }
 
-void IRGenDebugInfo::emitDbgIntrinsic(IRBuilder &Builder, llvm::Value *Storage,
-                                      llvm::DILocalVariable *Var,
-                                      llvm::DIExpression *Expr, unsigned Line,
-                                      unsigned Col, llvm::DILocalScope *Scope,
-                                      const SILDebugScope *DS) {
+void IRGenDebugInfoImpl::emitDbgIntrinsic(
+    IRBuilder &Builder, llvm::Value *Storage, llvm::DILocalVariable *Var,
+    llvm::DIExpression *Expr, unsigned Line, unsigned Col,
+    llvm::DILocalScope *Scope, const SILDebugScope *DS) {
   // Set the location/scope of the intrinsic.
   auto *InlinedAt = createInlinedAt(DS);
   auto DL = llvm::DebugLoc::get(Line, Col, Scope, InlinedAt);
@@ -1021,7 +1969,7 @@ void IRGenDebugInfo::emitDbgIntrinsic(IRBuilder &Builder, llvm::Value *Storage,
   // An alloca may only be described by exactly one dbg.declare.
   if (isa<llvm::AllocaInst>(Storage) && llvm::FindAllocaDbgDeclare(Storage))
     return;
-  
+
   // A dbg.declare is only meaningful if there is a single alloca for
   // the variable that is live throughout the function. With SIL
   // optimizations this is not guaranteed and a variable can end up in
@@ -1036,7 +1984,7 @@ void IRGenDebugInfo::emitDbgIntrinsic(IRBuilder &Builder, llvm::Value *Storage,
     auto InsPt = std::next(I->getIterator());
     auto E = I->getParent()->end();
     while (InsPt != E && isa<llvm::PHINode>(&*InsPt))
-        ++InsPt;
+      ++InsPt;
     if (InsPt != E) {
       DBuilder.insertDbgValueIntrinsic(Storage, 0, Var, Expr, DL, &*InsPt);
       return;
@@ -1047,7 +1995,7 @@ void IRGenDebugInfo::emitDbgIntrinsic(IRBuilder &Builder, llvm::Value *Storage,
   DBuilder.insertDbgValueIntrinsic(Storage, 0, Var, Expr, DL, BB);
 }
 
-void IRGenDebugInfo::emitGlobalVariableDeclaration(
+void IRGenDebugInfoImpl::emitGlobalVariableDeclaration(
     llvm::GlobalVariable *Var, StringRef Name, StringRef LinkageName,
     DebugTypeInfo DbgTy, bool IsLocalToUnit, Optional<SILLocation> Loc) {
   if (Opts.DebugInfoKind <= IRGenDebugInfoKind::LineTables)
@@ -1072,848 +2020,169 @@ void IRGenDebugInfo::emitGlobalVariableDeclaration(
     Var->addDebugInfo(GV);
 }
 
-StringRef IRGenDebugInfo::getMangledName(DebugTypeInfo DbgTy) {
-  if (MetadataTypeDecl && DbgTy.getDecl() == MetadataTypeDecl)
-    return BumpAllocatedString(DbgTy.getDecl()->getName().str());
-  
-  Mangle::ASTMangler Mangler;
-  std::string Name = Mangler.mangleTypeForDebugger(
-      DbgTy.getType(), DbgTy.getDeclContext(), DbgTy.getGenericEnvironment());
-  return BumpAllocatedString(Name);
+void IRGenDebugInfoImpl::emitTypeMetadata(IRGenFunction &IGF,
+                                          llvm::Value *Metadata,
+                                          StringRef Name) {
+  if (Opts.DebugInfoKind <= IRGenDebugInfoKind::LineTables)
+    return;
+
+  auto TName = BumpAllocatedString(("$swift.type." + Name).str());
+  auto DbgTy = DebugTypeInfo::getMetadata(
+      getMetadataType()->getDeclaredInterfaceType().getPointer(),
+      Metadata->getType(), Size(CI.getTargetInfo().getPointerWidth(0)),
+      Alignment(CI.getTargetInfo().getPointerAlign(0)));
+  emitVariableDeclaration(IGF.Builder, Metadata, DbgTy, IGF.getDebugScope(),
+                          nullptr, TName, 0,
+                          // swift.type is already a pointer type,
+                          // having a shadow copy doesn't add another
+                          // layer of indirection.
+                          DirectValue, ArtificialValue);
 }
 
-llvm::DIDerivedType *
-IRGenDebugInfo::createMemberType(DebugTypeInfo DbgTy, StringRef Name,
-                                 unsigned &OffsetInBits, llvm::DIScope *Scope,
-                                 llvm::DIFile *File,
-                                 llvm::DINode::DIFlags Flags) {
-  unsigned SizeOfByte = CI.getTargetInfo().getCharWidth();
-  auto *Ty = getOrCreateType(DbgTy);
-  auto *DITy = DBuilder.createMemberType(Scope, Name, File, 0,
-                                         SizeOfByte * DbgTy.size.getValue(), 0,
-                                         OffsetInBits, Flags, Ty);
-  OffsetInBits += getSizeInBits(Ty);
-  OffsetInBits =
-      llvm::alignTo(OffsetInBits, SizeOfByte * DbgTy.align.getValue());
-  return DITy;
+SILLocation::DebugLoc IRGenDebugInfoImpl::decodeSourceLoc(SourceLoc SL) {
+  auto &Cached = DebugLocCache[SL.getOpaquePointerValue()];
+  if (Cached.Filename.empty())
+    Cached = SILLocation::decode(SL, SM);
+  return Cached;
 }
 
-llvm::DINodeArray IRGenDebugInfo::getTupleElements(
-    TupleType *TupleTy, llvm::DIScope *Scope, llvm::DIFile *File,
-    llvm::DINode::DIFlags Flags, DeclContext *DeclContext,
-    GenericEnvironment *GE, unsigned &SizeInBits) {
-  SmallVector<llvm::Metadata *, 16> Elements;
-  unsigned OffsetInBits = 0;
-  auto genericSig = IGM.getSILTypes().getCurGenericContext();
-  for (auto ElemTy : TupleTy->getElementTypes()) {
-    auto &elemTI = IGM.getTypeInfoForUnlowered(
-        AbstractionPattern(genericSig, ElemTy->getCanonicalType()), ElemTy);
-    auto DbgTy =
-        DebugTypeInfo::getFromTypeInfo(DeclContext, GE, ElemTy, elemTI);
-    Elements.push_back(
-        createMemberType(DbgTy, StringRef(), OffsetInBits, Scope, File, Flags));
-  }
-  SizeInBits = OffsetInBits;
-  return DBuilder.getOrCreateArray(Elements);
+} // anonymous namespace
+
+IRGenDebugInfo *IRGenDebugInfo::createIRGenDebugInfo(const IRGenOptions &Opts,
+                                                     ClangImporter &CI,
+                                                     IRGenModule &IGM,
+                                                     llvm::Module &M,
+                                                     SourceFile *SF) {
+  return new IRGenDebugInfoImpl(Opts, CI, IGM, M, SF);
 }
 
-llvm::DINodeArray IRGenDebugInfo::getStructMembers(
-    NominalTypeDecl *D, Type BaseTy, llvm::DIScope *Scope, llvm::DIFile *File,
-    llvm::DINode::DIFlags Flags, unsigned &SizeInBits) {
-  SmallVector<llvm::Metadata *, 16> Elements;
-  unsigned OffsetInBits = 0;
-  for (VarDecl *VD : D->getStoredProperties()) {
-    auto memberTy =
-        BaseTy->getTypeOfMember(IGM.getSwiftModule(), VD, nullptr);
-
-    auto DbgTy = DebugTypeInfo::getFromTypeInfo(
-        VD->getDeclContext(),
-        VD->getDeclContext()->getGenericEnvironmentOfContext(),
-        VD->getInterfaceType(),
-        IGM.getTypeInfoForUnlowered(IGM.getSILTypes().getAbstractionPattern(VD),
-                                    memberTy));
-    Elements.push_back(createMemberType(DbgTy, VD->getName().str(),
-                                        OffsetInBits, Scope, File, Flags));
-  }
-  if (OffsetInBits > SizeInBits)
-    SizeInBits = OffsetInBits;
-  return DBuilder.getOrCreateArray(Elements);
-}
-
-llvm::DICompositeType *IRGenDebugInfo::createStructType(
-    DebugTypeInfo DbgTy, NominalTypeDecl *Decl, Type BaseTy,
-    llvm::DIScope *Scope, llvm::DIFile *File, unsigned Line,
-    unsigned SizeInBits, unsigned AlignInBits, llvm::DINode::DIFlags Flags,
-    llvm::DIType *DerivedFrom, unsigned RuntimeLang, StringRef UniqueID) {
-  StringRef Name = Decl->getName().str();
-
-  // Forward declare this first because types may be recursive.
-  auto FwdDecl = llvm::TempDIType(
-    DBuilder.createReplaceableCompositeType(
-      llvm::dwarf::DW_TAG_structure_type, Name, Scope, File, Line,
-        llvm::dwarf::DW_LANG_Swift, SizeInBits, 0, Flags, UniqueID));
-
-#ifndef NDEBUG
-  if (UniqueID.empty())
-    assert(!Name.empty() && "no mangled name and no human readable name given");
-  else
-    assert((UniqueID.startswith("_T") ||
-              UniqueID.startswith(MANGLING_PREFIX_STR)) &&
-           "UID is not a mangled name");
-#endif
-
-  auto TH = llvm::TrackingMDNodeRef(FwdDecl.get());
-  DITypeCache[DbgTy.getType()] = TH;
-  auto Members = getStructMembers(Decl, BaseTy, Scope, File, Flags, SizeInBits);
-  auto DITy = DBuilder.createStructType(
-      Scope, Name, File, Line, SizeInBits, AlignInBits, Flags, DerivedFrom,
-      Members, RuntimeLang, nullptr, UniqueID);
-  DBuilder.replaceTemporary(std::move(FwdDecl), DITy);
-  return DITy;
-}
-
-llvm::DINodeArray IRGenDebugInfo::getEnumElements(DebugTypeInfo DbgTy,
-                                                  EnumDecl *ED,
-                                                  llvm::DIScope *Scope,
-                                                  llvm::DIFile *File,
-                                                  llvm::DINode::DIFlags Flags) {
-  SmallVector<llvm::Metadata *, 16> Elements;
-
-  for (auto *ElemDecl : ED->getAllElements()) {
-    // FIXME <rdar://problem/14845818> Support enums.
-    // Swift Enums can be both like DWARF enums and discriminated unions.
-    DebugTypeInfo ElemDbgTy;
-    if (ED->hasRawType())
-      // An enum with a raw type (enum E : Int {}), similar to a
-      // DWARF enum.
-      //
-      // The storage occupied by the enum may be smaller than the
-      // one of the raw type as long as it is large enough to hold
-      // all enum values. Use the raw type for the debug type, but
-      // the storage size from the enum.
-      ElemDbgTy =
-          DebugTypeInfo(ED, DbgTy.getGenericEnvironment(), ED->getRawType(),
-                        DbgTy.StorageType, DbgTy.size, DbgTy.align, true);
-    else if (auto ArgTy = ElemDecl->getArgumentInterfaceType()) {
-      // A discriminated union. This should really be described as a
-      // DW_TAG_variant_type. For now only describing the data.
-      ArgTy = ElemDecl->getParentEnum()->mapTypeIntoContext(ArgTy);
-      auto &TI = IGM.getTypeInfoForUnlowered(ArgTy);
-      ElemDbgTy = DebugTypeInfo::getFromTypeInfo(
-          ElemDecl->getDeclContext(),
-          ElemDecl->getDeclContext()->getGenericEnvironmentOfContext(), ArgTy,
-          TI);
-    } else {
-      // Discriminated union case without argument. Fallback to Int
-      // as the element type; there is no storage here.
-      Type IntTy = IGM.Context.getIntDecl()->getDeclaredType();
-      ElemDbgTy = DebugTypeInfo(
-          ElemDecl->getDeclContext(),
-          ElemDecl->getDeclContext()->getGenericEnvironmentOfContext(), IntTy,
-          DbgTy.StorageType, Size(0), Alignment(1), true);
-    }
-    unsigned Offset = 0;
-    auto MTy = createMemberType(ElemDbgTy, ElemDecl->getName().str(), Offset,
-                                Scope, File, Flags);
-    Elements.push_back(MTy);
-  }
-  return DBuilder.getOrCreateArray(Elements);
-}
-
-llvm::DICompositeType *IRGenDebugInfo::createEnumType(
-    DebugTypeInfo DbgTy, EnumDecl *Decl, StringRef MangledName,
-    llvm::DIScope *Scope, llvm::DIFile *File, unsigned Line,
-    llvm::DINode::DIFlags Flags) {
-  unsigned SizeOfByte = CI.getTargetInfo().getCharWidth();
-  unsigned SizeInBits = DbgTy.size.getValue() * SizeOfByte;
-  // Default, since Swift doesn't allow specifying a custom alignment.
-  unsigned AlignInBits = 0;
-
-  // FIXME: Is DW_TAG_union_type the right thing here?
-  // Consider using a DW_TAG_variant_type instead.
-  auto FwdDecl = llvm::TempDIType(
-    DBuilder.createReplaceableCompositeType(
-      llvm::dwarf::DW_TAG_union_type, MangledName, Scope, File, Line,
-        llvm::dwarf::DW_LANG_Swift, SizeInBits, AlignInBits, Flags,
-        MangledName));
-
-  auto TH = llvm::TrackingMDNodeRef(FwdDecl.get());
-  DITypeCache[DbgTy.getType()] = TH;
-
-  auto DITy = DBuilder.createUnionType(
-      Scope, Decl->getName().str(), File, Line, SizeInBits, AlignInBits, Flags,
-      getEnumElements(DbgTy, Decl, Scope, File, Flags),
-      llvm::dwarf::DW_LANG_Swift, MangledName);
-
-  DBuilder.replaceTemporary(std::move(FwdDecl), DITy);
-  return DITy;
-}
-
-llvm::DIType *IRGenDebugInfo::getOrCreateDesugaredType(Type Ty,
-                                                       DebugTypeInfo DbgTy) {
-  DebugTypeInfo BlandDbgTy(DbgTy.getDeclContext(),
-                           DbgTy.getGenericEnvironment(), Ty, DbgTy.StorageType,
-                           DbgTy.size, DbgTy.align, DbgTy.DefaultAlignment);
-  return getOrCreateType(BlandDbgTy);
-}
-
-uint64_t IRGenDebugInfo::getSizeOfBasicType(DebugTypeInfo DbgTy) {
-  uint64_t SizeOfByte = CI.getTargetInfo().getCharWidth();
-  uint64_t BitWidth = DbgTy.size.getValue() * SizeOfByte;
-  llvm::Type *StorageType = DbgTy.StorageType
-                                ? DbgTy.StorageType
-                                : IGM.DataLayout.getSmallestLegalIntType(
-                                      IGM.getLLVMContext(), BitWidth);
-
-  if (StorageType)
-    return IGM.DataLayout.getTypeSizeInBits(StorageType);
-
-  // This type is too large to fit in a register.
-  assert(BitWidth > IGM.DataLayout.getLargestLegalIntTypeSizeInBits());
-  return BitWidth;
-}
-
-llvm::DIType *IRGenDebugInfo::createPointerSizedStruct(
-    llvm::DIScope *Scope, StringRef Name, llvm::DIFile *File, unsigned Line,
-    llvm::DINode::DIFlags Flags, StringRef MangledName) {
-  if (Opts.DebugInfoKind > IRGenDebugInfoKind::ASTTypes) {
-    auto FwdDecl = DBuilder.createForwardDecl(
-        llvm::dwarf::DW_TAG_structure_type, Name, Scope, File, Line,
-        llvm::dwarf::DW_LANG_Swift, 0, 0);
-    return createPointerSizedStruct(Scope, Name, FwdDecl, File, Line, Flags,
-                                    MangledName);
-  } else {
-    unsigned SizeInBits = CI.getTargetInfo().getPointerWidth(0);
-    return createOpaqueStruct(Scope, Name, File, Line, SizeInBits, 0, Flags,
-                              MangledName);
-  }
-}
-
-llvm::DIType *IRGenDebugInfo::createPointerSizedStruct(
-    llvm::DIScope *Scope, StringRef Name, llvm::DIType *PointeeTy,
-    llvm::DIFile *File, unsigned Line, llvm::DINode::DIFlags Flags,
-    StringRef MangledName) {
-  unsigned PtrSize = CI.getTargetInfo().getPointerWidth(0);
-  auto PtrTy = DBuilder.createPointerType(PointeeTy, PtrSize, 0);
-  llvm::Metadata *Elements[] = {DBuilder.createMemberType(
-      Scope, "ptr", File, 0, PtrSize, 0, 0, Flags, PtrTy)};
-  return DBuilder.createStructType(
-      Scope, Name, File, Line, PtrSize, 0, Flags,
-      /* DerivedFrom */ nullptr, DBuilder.getOrCreateArray(Elements),
-      llvm::dwarf::DW_LANG_Swift, nullptr, MangledName);
-}
-
-llvm::DIType *IRGenDebugInfo::createDoublePointerSizedStruct(
-    llvm::DIScope *Scope, StringRef Name, llvm::DIType *PointeeTy,
-    llvm::DIFile *File, unsigned Line, llvm::DINode::DIFlags Flags,
-    StringRef MangledName) {
-  unsigned PtrSize = CI.getTargetInfo().getPointerWidth(0);
-  llvm::Metadata *Elements[] = {
-      DBuilder.createMemberType(
-          Scope, "ptr", File, 0, PtrSize, 0, 0, Flags,
-          DBuilder.createPointerType(PointeeTy, PtrSize, 0)),
-      DBuilder.createMemberType(
-          Scope, "_", File, 0, PtrSize, 0, 0, Flags,
-          DBuilder.createPointerType(nullptr, PtrSize, 0))};
-  return DBuilder.createStructType(
-      Scope, Name, File, Line, 2*PtrSize, 0, Flags,
-      /* DerivedFrom */ nullptr, DBuilder.getOrCreateArray(Elements),
-      llvm::dwarf::DW_LANG_Swift, nullptr, MangledName);
-}
-
-llvm::DIType *
-IRGenDebugInfo::createFunctionPointer(DebugTypeInfo DbgTy, llvm::DIScope *Scope,
-                                      unsigned SizeInBits, unsigned AlignInBits,
-                                      llvm::DINode::DIFlags Flags,
-                                      StringRef MangledName) {
-  auto FwdDecl = llvm::TempDINode(DBuilder.createReplaceableCompositeType(
-      llvm::dwarf::DW_TAG_subroutine_type, MangledName, Scope, MainFile, 0,
-      llvm::dwarf::DW_LANG_Swift, SizeInBits, AlignInBits, Flags, MangledName));
-
-  auto TH = llvm::TrackingMDNodeRef(FwdDecl.get());
-  DITypeCache[DbgTy.getType()] = TH;
-
-  CanSILFunctionType FunTy;
-  TypeBase *BaseTy = DbgTy.getType();
-  if (auto *SILFnTy = dyn_cast<SILFunctionType>(BaseTy))
-    FunTy = CanSILFunctionType(SILFnTy);
-  // FIXME: Handling of generic parameters in SIL type lowering is in flux.
-  // DebugInfo doesn't appear to care about the generic context, so just
-  // throw it away before lowering.
-  else if (isa<GenericFunctionType>(BaseTy)) {
-    auto *fTy = cast<AnyFunctionType>(BaseTy);
-    auto *nongenericTy =
-        FunctionType::get(fTy->getInput(), fTy->getResult(), fTy->getExtInfo());
-
-    FunTy = IGM.getLoweredType(nongenericTy).castTo<SILFunctionType>();
-  } else
-    FunTy = IGM.getLoweredType(BaseTy).castTo<SILFunctionType>();
-  auto Params = createParameterTypes(FunTy, DbgTy.getDeclContext(),
-                                     DbgTy.getGenericEnvironment());
-
-  auto FnTy = DBuilder.createSubroutineType(Params, Flags);
-  llvm::DIType *DITy;
-  if (FunTy->getRepresentation() == SILFunctionType::Representation::Thick) {
-    if (SizeInBits == 2 * CI.getTargetInfo().getPointerWidth(0))
-      // This is a FunctionPairTy: { i8*, %swift.refcounted* }.
-      DITy = createDoublePointerSizedStruct(Scope, MangledName, FnTy, MainFile,
-                                            0, Flags, MangledName);
-    else
-      // This is a generic function as noted above.
-      DITy = createOpaqueStruct(Scope, MangledName, MainFile, 0, SizeInBits,
-                                AlignInBits, Flags, MangledName);
-  } else {
-    assert(SizeInBits == CI.getTargetInfo().getPointerWidth(0));
-    DITy = createPointerSizedStruct(Scope, MangledName, FnTy, MainFile, 0,
-                                    Flags, MangledName);
-  }
-  DBuilder.replaceTemporary(std::move(FwdDecl), DITy);
-  return DITy;
-}
-
-llvm::DIType *IRGenDebugInfo::createTuple(DebugTypeInfo DbgTy,
-                                          llvm::DIScope *Scope,
-                                          unsigned SizeInBits,
-                                          unsigned AlignInBits,
-                                          llvm::DINode::DIFlags Flags,
-                                          StringRef MangledName) {
-  TypeBase *BaseTy = DbgTy.getType();
-  auto *TupleTy = BaseTy->castTo<TupleType>();
-  auto FwdDecl = llvm::TempDINode(DBuilder.createReplaceableCompositeType(
-      llvm::dwarf::DW_TAG_structure_type, MangledName, Scope, MainFile, 0,
-      llvm::dwarf::DW_LANG_Swift, SizeInBits, AlignInBits, Flags, MangledName));
-
-  DITypeCache[DbgTy.getType()] = llvm::TrackingMDNodeRef(FwdDecl.get());
-
-  unsigned RealSize;
-  auto Elements =
-      getTupleElements(TupleTy, Scope, MainFile, Flags, DbgTy.getDeclContext(),
-                       DbgTy.getGenericEnvironment(), RealSize);
-  // FIXME: Handle %swift.opaque members and make this into an assertion.
-  if (!RealSize)
-    RealSize = SizeInBits;
-
-  auto DITy = DBuilder.createStructType(
-      Scope, MangledName, MainFile, 0, RealSize, AlignInBits, Flags,
-      nullptr, // DerivedFrom
-      Elements, llvm::dwarf::DW_LANG_Swift, nullptr, MangledName);
-
-  DBuilder.replaceTemporary(std::move(FwdDecl), DITy);
-  return DITy;
-}
-
-llvm::DIType *
-IRGenDebugInfo::createOpaqueStruct(llvm::DIScope *Scope, StringRef Name,
-                                   llvm::DIFile *File, unsigned Line,
-                                   unsigned SizeInBits, unsigned AlignInBits,
-                                   llvm::DINode::DIFlags Flags,
-                                   StringRef MangledName) {
-  return DBuilder.createStructType(
-      Scope, Name, File, Line, SizeInBits, AlignInBits, Flags,
-      /* DerivedFrom */ nullptr,
-      DBuilder.getOrCreateArray(ArrayRef<llvm::Metadata *>()),
-      llvm::dwarf::DW_LANG_Swift, nullptr, MangledName);
-}
-
-llvm::DIType *IRGenDebugInfo::createType(DebugTypeInfo DbgTy,
-                                         StringRef MangledName,
-                                         llvm::DIScope *Scope,
-                                         llvm::DIFile *File) {
-  // FIXME: For SizeInBits, clang uses the actual size of the type on
-  // the target machine instead of the storage size that is alloca'd
-  // in the LLVM IR. For all types that are boxed in a struct, we are
-  // emitting the storage size of the struct, but it may be necessary
-  // to emit the (target!) size of the underlying basic type.
-  uint64_t SizeOfByte = CI.getTargetInfo().getCharWidth();
-  uint64_t SizeInBits = DbgTy.size.getValue() * SizeOfByte;
-  unsigned AlignInBits =
-      DbgTy.DefaultAlignment ? 0 : DbgTy.align.getValue() * SizeOfByte;
-  unsigned Encoding = 0;
-  llvm::DINode::DIFlags Flags = llvm::DINode::FlagZero;
-
-  TypeBase *BaseTy = DbgTy.getType();
-
-  if (!BaseTy) {
-    DEBUG(llvm::dbgs() << "Type without TypeBase: "; DbgTy.getType()->dump();
-          llvm::dbgs() << "\n");
-    if (!InternalType) {
-      StringRef Name = "<internal>";
-      InternalType = DBuilder.createForwardDecl(
-          llvm::dwarf::DW_TAG_structure_type, Name, Scope, File,
-          /*Line*/ 0, llvm::dwarf::DW_LANG_Swift, SizeInBits, AlignInBits);
-    }
-    return InternalType;
-  }
-
-  // Here goes!
-  switch (BaseTy->getKind()) {
-  case TypeKind::BuiltinInteger: {
-    Encoding = llvm::dwarf::DW_ATE_unsigned;
-    SizeInBits = getSizeOfBasicType(DbgTy);
-    break;
-  }
-
-  case TypeKind::BuiltinFloat: {
-    auto *FloatTy = BaseTy->castTo<BuiltinFloatType>();
-    // Assuming that the bitwidth and FloatTy->getFPKind() are identical.
-    SizeInBits = FloatTy->getBitWidth();
-    Encoding = llvm::dwarf::DW_ATE_float;
-    break;
-  }
-
-  case TypeKind::BuiltinUnknownObject: {
-    // The builtin opaque Objective-C pointer type. Useful for pushing
-    // an Objective-C type through swift.
-    unsigned PtrSize = CI.getTargetInfo().getPointerWidth(0);
-    auto IdTy = DBuilder.createForwardDecl(
-      llvm::dwarf::DW_TAG_structure_type, MangledName, Scope, File, 0,
-        llvm::dwarf::DW_LANG_ObjC, 0, 0);
-    return DBuilder.createPointerType(IdTy, PtrSize, 0,
-                                      /* DWARFAddressSpace */ None,
-                                      MangledName);
-  }
-
-  case TypeKind::BuiltinNativeObject: {
-    unsigned PtrSize = CI.getTargetInfo().getPointerWidth(0);
-    auto PTy = DBuilder.createPointerType(nullptr, PtrSize, 0,
-                                          /* DWARFAddressSpace */ None,
-                                          MangledName);
-    return DBuilder.createObjectPointerType(PTy);
-  }
-
-  case TypeKind::BuiltinBridgeObject: {
-    unsigned PtrSize = CI.getTargetInfo().getPointerWidth(0);
-    auto PTy = DBuilder.createPointerType(nullptr, PtrSize, 0,
-                                          /* DWARFAddressSpace */ None,
-                                          MangledName);
-    return DBuilder.createObjectPointerType(PTy);
-  }
-
-  case TypeKind::BuiltinRawPointer: {
-    unsigned PtrSize = CI.getTargetInfo().getPointerWidth(0);
-    return DBuilder.createPointerType(nullptr, PtrSize, 0,
-                                      /* DWARFAddressSpace */ None,
-                                      MangledName);
-  }
-
-  case TypeKind::DynamicSelf: {
-    // Self. We don't have a way to represent instancetype in DWARF,
-    // so we emit the static type instead. This is similar to what we
-    // do with instancetype in Objective-C.
-    auto *DynamicSelfTy = BaseTy->castTo<DynamicSelfType>();
-    auto SelfTy = getOrCreateDesugaredType(DynamicSelfTy->getSelfType(), DbgTy);
-    return DBuilder.createTypedef(SelfTy, MangledName, File, 0, File);
-
-  }
-
-  // Even builtin swift types usually come boxed in a struct.
-  case TypeKind::Struct: {
-    auto *StructTy = BaseTy->castTo<StructType>();
-    auto *Decl = StructTy->getDecl();
-    auto L = getDebugLoc(*this, Decl);
-    if (auto *ClangDecl = Decl->getClangDecl()) {
-      auto ClangSrcLoc = ClangDecl->getLocStart();
-      clang::SourceManager &ClangSM =
-          CI.getClangASTContext().getSourceManager();
-      L.Line = ClangSM.getPresumedLineNumber(ClangSrcLoc);
-      L.Filename = ClangSM.getBufferName(ClangSrcLoc);
-    }
-    auto *File = getOrCreateFile(L.Filename);
-    if (Opts.DebugInfoKind > IRGenDebugInfoKind::ASTTypes)
-      return createStructType(DbgTy, Decl, StructTy, Scope, File, L.Line,
-                              SizeInBits, AlignInBits, Flags,
-                              nullptr, // DerivedFrom
-                              llvm::dwarf::DW_LANG_Swift, MangledName);
-    else
-      return createOpaqueStruct(Scope, Decl->getName().str(), File, L.Line,
-                                SizeInBits, AlignInBits, Flags, MangledName);
-  }
-
-  case TypeKind::Class: {
-    // Classes are represented as DW_TAG_structure_type. This way the
-    // DW_AT_APPLE_runtime_class(DW_LANG_Swift) attribute can be
-    // used to differentiate them from C++ and ObjC classes.
-    auto *ClassTy = BaseTy->castTo<ClassType>();
-    auto *Decl = ClassTy->getDecl();
-    auto L = getDebugLoc(*this, Decl);
-    if (auto *ClangDecl = Decl->getClangDecl()) {
-      auto ClangSrcLoc = ClangDecl->getLocStart();
-      clang::SourceManager &ClangSM =
-          CI.getClangASTContext().getSourceManager();
-      L.Line = ClangSM.getPresumedLineNumber(ClangSrcLoc);
-      L.Filename = ClangSM.getBufferName(ClangSrcLoc);
-    }
-    assert(SizeInBits == CI.getTargetInfo().getPointerWidth(0));
-    return createPointerSizedStruct(Scope, Decl->getNameStr(),
-                                    getOrCreateFile(L.Filename), L.Line, Flags,
-                                    MangledName);
-  }
-
-  case TypeKind::Protocol: {
-    auto *ProtocolTy = BaseTy->castTo<ProtocolType>();
-    auto *Decl = ProtocolTy->getDecl();
-    // FIXME: (LLVM branch) This should probably be a DW_TAG_interface_type.
-    auto L = getDebugLoc(*this, Decl);
-    auto File = getOrCreateFile(L.Filename);
-    return createOpaqueStruct(Scope, Decl ? Decl->getNameStr() : MangledName,
-                              File, L.Line, SizeInBits, AlignInBits, Flags,
-                              MangledName);
-  }
-
-  case TypeKind::ProtocolComposition: {
-    auto *Decl = DbgTy.getDecl();
-    auto L = getDebugLoc(*this, Decl);
-    auto File = getOrCreateFile(L.Filename);
-
-    // FIXME: emit types
-    // auto ProtocolCompositionTy = BaseTy->castTo<ProtocolCompositionType>();
-    return createOpaqueStruct(Scope, Decl ? Decl->getNameStr() : MangledName,
-                              File, L.Line, SizeInBits, AlignInBits, Flags,
-                              MangledName);
-  }
-
-  case TypeKind::UnboundGeneric: {
-    auto *UnboundTy = BaseTy->castTo<UnboundGenericType>();
-    auto *Decl = UnboundTy->getDecl();
-    auto L = getDebugLoc(*this, Decl);
-    assert(SizeInBits == CI.getTargetInfo().getPointerWidth(0));
-    return createPointerSizedStruct(Scope,
-                                    Decl ? Decl->getNameStr() : MangledName,
-                                    File, L.Line, Flags, MangledName);
-  }
-
-  case TypeKind::BoundGenericStruct: {
-    auto *StructTy = BaseTy->castTo<BoundGenericStructType>();
-    auto *Decl = StructTy->getDecl();
-    auto L = getDebugLoc(*this, Decl);
-    return createOpaqueStruct(Scope, Decl ? Decl->getNameStr() : MangledName,
-                              File, L.Line, SizeInBits, AlignInBits, Flags,
-                              MangledName);
-  }
-
-  case TypeKind::BoundGenericClass: {
-    auto *ClassTy = BaseTy->castTo<BoundGenericClassType>();
-    auto *Decl = ClassTy->getDecl();
-    auto L = getDebugLoc(*this, Decl);
-    // TODO: We may want to peek at Decl->isObjC() and set this
-    // attribute accordingly.
-    assert(SizeInBits == CI.getTargetInfo().getPointerWidth(0));
-    return createPointerSizedStruct(Scope,
-                                    Decl ? Decl->getNameStr() : MangledName,
-                                    File, L.Line, Flags, MangledName);
-  }
-
-  case TypeKind::Tuple: {
-    // Tuples are also represented as structs.
-    if (Opts.DebugInfoKind > IRGenDebugInfoKind::ASTTypes)
-      return createTuple(DbgTy, Scope, SizeInBits, AlignInBits, Flags,
-                         MangledName);
-    else
-      return createOpaqueStruct(Scope, MangledName, MainFile, 0, SizeInBits,
-                                AlignInBits, Flags, MangledName);
-  }
-
-  case TypeKind::InOut: {
-    // This is an inout type. Naturally we would be emitting them as
-    // DW_TAG_reference_type types, but LLDB can deal better with pointer-sized
-    // struct that has the appropriate mangled name.
-    auto ObjectTy = BaseTy->castTo<InOutType>()->getObjectType();
-    if (Opts.DebugInfoKind > IRGenDebugInfoKind::ASTTypes) {
-      auto DT = getOrCreateDesugaredType(ObjectTy, DbgTy);
-      return createPointerSizedStruct(
-          Scope, MangledName, DT, File, 0, Flags,
-          MangledName);
-    } else
-      return createOpaqueStruct(Scope, MangledName, File, 0, SizeInBits,
-                                AlignInBits, Flags, MangledName);
-  }
-
-  case TypeKind::Archetype: {
-    auto *Archetype = BaseTy->castTo<ArchetypeType>();
-    auto L = getDebugLoc(*this, Archetype->getAssocType());
-    auto Superclass = Archetype->getSuperclass();
-    auto DerivedFrom = Superclass.isNull()
-                           ? nullptr
-                           : getOrCreateDesugaredType(Superclass, DbgTy);
-    auto FwdDecl = llvm::TempDIType(
-      DBuilder.createReplaceableCompositeType(
-        llvm::dwarf::DW_TAG_structure_type, MangledName, Scope, File, L.Line,
-          llvm::dwarf::DW_LANG_Swift, SizeInBits, AlignInBits, Flags,
-          MangledName));
-
-    // Emit the protocols the archetypes conform to.
-    SmallVector<llvm::Metadata *, 4> Protocols;
-    for (auto *ProtocolDecl : Archetype->getConformsTo()) {
-      auto PTy = IGM.getLoweredType(ProtocolDecl->getInterfaceType())
-                     .getSwiftRValueType();
-      auto PDbgTy = DebugTypeInfo::getFromTypeInfo(
-          DbgTy.getDeclContext(), DbgTy.getGenericEnvironment(),
-          ProtocolDecl->getInterfaceType(), IGM.getTypeInfoForLowered(PTy));
-      auto PDITy = getOrCreateType(PDbgTy);
-      Protocols.push_back(DBuilder.createInheritance(FwdDecl.get(),
-                                                     PDITy, 0, Flags));
-    }
-    auto DITy = DBuilder.createStructType(
-        Scope, MangledName, File, L.Line, SizeInBits, AlignInBits, Flags,
-        DerivedFrom, DBuilder.getOrCreateArray(Protocols),
-        llvm::dwarf::DW_LANG_Swift, nullptr,
-        MangledName);
-
-    DBuilder.replaceTemporary(std::move(FwdDecl), DITy);
-    return DITy;
-  }
-
-  case TypeKind::ExistentialMetatype:
-  case TypeKind::Metatype: {
-    // Metatypes are (mostly) singleton type descriptors, often without storage.
-    Flags |= llvm::DINode::FlagArtificial;
-    auto L = getDebugLoc(*this, DbgTy.getDecl());
-    auto File = getOrCreateFile(L.Filename);
-    return DBuilder.createStructType(
-        Scope, MangledName, File, L.Line, SizeInBits, AlignInBits, Flags,
-        nullptr, nullptr, llvm::dwarf::DW_LANG_Swift,
-        nullptr, MangledName);
-  }
-
-  case TypeKind::SILFunction:
-  case TypeKind::Function:
-  case TypeKind::GenericFunction: {
-    if (Opts.DebugInfoKind > IRGenDebugInfoKind::ASTTypes)
-      return createFunctionPointer(DbgTy, Scope, SizeInBits, AlignInBits, Flags,
-                                   MangledName);
-    else
-      return createOpaqueStruct(Scope, MangledName, MainFile, 0, SizeInBits,
-                                AlignInBits, Flags, MangledName);
-  }
-
-  case TypeKind::Enum: {
-    auto *EnumTy = BaseTy->castTo<EnumType>();
-    auto *Decl = EnumTy->getDecl();
-    auto L = getDebugLoc(*this, Decl);
-    auto *File = getOrCreateFile(L.Filename);
-    if (Opts.DebugInfoKind > IRGenDebugInfoKind::ASTTypes)
-      return createEnumType(DbgTy, Decl, MangledName, Scope, File, L.Line,
-                            Flags);
-    else
-      return createOpaqueStruct(Scope, Decl->getName().str(), File, L.Line,
-                                SizeInBits, AlignInBits, Flags, MangledName);
-  }
-
-  case TypeKind::BoundGenericEnum: {
-    auto *EnumTy = BaseTy->castTo<BoundGenericEnumType>();
-    auto *Decl = EnumTy->getDecl();
-    auto L = getDebugLoc(*this, Decl);
-    auto *File = getOrCreateFile(L.Filename);
-    if (Opts.DebugInfoKind > IRGenDebugInfoKind::ASTTypes)
-      return createEnumType(DbgTy, Decl, MangledName, Scope, File, L.Line,
-                            Flags);
-    else
-      return createOpaqueStruct(Scope, Decl->getName().str(), File, L.Line,
-                                SizeInBits, AlignInBits, Flags, MangledName);
-  }
-
-  case TypeKind::BuiltinVector: {
-    (void)MangledName; // FIXME emit the name somewhere.
-    auto *BuiltinVectorTy = BaseTy->castTo<BuiltinVectorType>();
-    DebugTypeInfo ElemDbgTy(DbgTy.getDeclContext(),
-                            DbgTy.getGenericEnvironment(),
-                            BuiltinVectorTy->getElementType(),
-                            DbgTy.StorageType, DbgTy.size, DbgTy.align, true);
-    auto Subscripts = nullptr;
-    return DBuilder.createVectorType(BuiltinVectorTy->getNumElements(),
-                                     AlignInBits, getOrCreateType(ElemDbgTy),
-                                     Subscripts);
-  }
-
-  // Reference storage types.
-  case TypeKind::UnownedStorage:
-  case TypeKind::UnmanagedStorage:
-  case TypeKind::WeakStorage: {
-    auto *ReferenceTy = cast<ReferenceStorageType>(BaseTy);
-    auto CanTy = ReferenceTy->getReferentType();
-    auto L = getDebugLoc(*this, DbgTy.getDecl());
-    auto File = getOrCreateFile(L.Filename);
-    return DBuilder.createTypedef(getOrCreateDesugaredType(CanTy, DbgTy),
-                                  MangledName, File, L.Line, File);
-  }
-
-  // Sugared types.
-
-  case TypeKind::NameAlias: {
-
-    auto *NameAliasTy = cast<NameAliasType>(BaseTy);
-    auto *Decl = NameAliasTy->getDecl();
-    auto L = getDebugLoc(*this, Decl);
-    auto AliasedTy = NameAliasTy->getSinglyDesugaredType();
-    auto File = getOrCreateFile(L.Filename);
-    // For NameAlias types, the DeclContext for the aliasED type is
-    // in the decl of the alias type.
-    DebugTypeInfo AliasedDbgTy(
-        DbgTy.getDeclContext(), DbgTy.getGenericEnvironment(), AliasedTy,
-        DbgTy.StorageType, DbgTy.size, DbgTy.align, DbgTy.DefaultAlignment);
-    return DBuilder.createTypedef(getOrCreateType(AliasedDbgTy), MangledName,
-                                  File, L.Line, File);
-  }
-
-  case TypeKind::Paren: {
-    auto Ty = cast<ParenType>(BaseTy)->getUnderlyingType();
-    return getOrCreateDesugaredType(Ty, DbgTy);
-  }
-
-  // SyntaxSugarType derivations.
-  case TypeKind::ArraySlice:
-  case TypeKind::Optional:
-  case TypeKind::ImplicitlyUnwrappedOptional: {
-    auto *SyntaxSugarTy = cast<SyntaxSugarType>(BaseTy);
-    auto *CanTy = SyntaxSugarTy->getSinglyDesugaredType();
-    return getOrCreateDesugaredType(CanTy, DbgTy);
-  }
-
-  case TypeKind::Dictionary: {
-    auto *DictionaryTy = cast<DictionaryType>(BaseTy);
-    auto *CanTy = DictionaryTy->getDesugaredType();
-    return getOrCreateDesugaredType(CanTy, DbgTy);
-  }
-
-  case TypeKind::GenericTypeParam: {
-    auto *ParamTy = cast<GenericTypeParamType>(BaseTy);
-    // FIXME: Provide a more meaningful debug type.
-    return DBuilder.createUnspecifiedType(ParamTy->getName().str());
-  }
-  case TypeKind::DependentMember: {
-    auto *MemberTy = cast<DependentMemberType>(BaseTy);
-    // FIXME: Provide a more meaningful debug type.
-    return DBuilder.createUnspecifiedType(MemberTy->getName().str());
-  }
-
-  // The following types exist primarily for internal use by the type
-  // checker.
-  case TypeKind::Error:
-  case TypeKind::Unresolved:
-  case TypeKind::LValue:
-  case TypeKind::TypeVariable:
-  case TypeKind::Module:
-  case TypeKind::SILBlockStorage:
-  case TypeKind::SILBox:
-  case TypeKind::BuiltinUnsafeValueBuffer:
-
-    DEBUG(llvm::errs() << "Unhandled type: "; DbgTy.getType()->dump();
-          llvm::errs() << "\n");
-    MangledName = "<unknown>";
-  }
-  return DBuilder.createBasicType(MangledName, SizeInBits, Encoding);
-}
-
-/// Determine if there exists a name mangling for the given type.
-static bool canMangle(TypeBase *Ty) {
-  switch (Ty->getKind()) {
-  case TypeKind::GenericFunction:     // Not yet supported.
-  case TypeKind::SILBlockStorage:     // Not supported at all.
-  case TypeKind::SILBox:
-    return false;
-  case TypeKind::InOut: {
-    auto *ObjectTy = Ty->castTo<InOutType>()->getObjectType().getPointer();
-    return canMangle(ObjectTy);
-  }
-  default:
-    return true;
-  }
-}
-
-llvm::DIType *IRGenDebugInfo::getTypeOrNull(TypeBase *Ty) {
-  auto CachedType = DITypeCache.find(Ty);
-  if (CachedType != DITypeCache.end()) {
-    // Verify that the information still exists.
-    if (llvm::Metadata *Val = CachedType->second) {
-      auto DITy = cast<llvm::DIType>(Val);
-      return DITy;
-    }
-  }
-  return nullptr;
-}
-
-llvm::DIType *IRGenDebugInfo::getOrCreateType(DebugTypeInfo DbgTy) {
-  // Is this an empty type?
-  if (DbgTy.isNull())
-    // We can't use the empty type as an index into DenseMap.
-    return createType(DbgTy, "", TheCU, MainFile);
-
-  // Look in the cache first.
-  if (auto *DITy = getTypeOrNull(DbgTy.getType()))
-    return DITy;
-
-  // Second line of defense: Look up the mangled name. TypeBase*'s are
-  // not necessarily unique, but name mangling is too expensive to do
-  // every time.
-  StringRef MangledName;
-  llvm::MDString *UID = nullptr;
-  if (canMangle(DbgTy.getType())) {
-    MangledName = getMangledName(DbgTy);
-    UID = llvm::MDString::get(IGM.getLLVMContext(), MangledName);
-    if (llvm::Metadata *CachedTy = DIRefMap.lookup(UID)) {
-      auto DITy = cast<llvm::DIType>(CachedTy);
-      return DITy;
-    }
-  }
-
-  // Retrieve the context of the type, as opposed to the DeclContext
-  // of the variable.
-  //
-  // FIXME: Builtin and qualified types in LLVM have no parent
-  // scope. TODO: This can be fixed by extending DIBuilder.
-  llvm::DIScope *Scope = nullptr;
-  DeclContext *Context = DbgTy.getType()->getNominalOrBoundGenericNominal();
-  if (Context) {
-    if (auto *D = Context->getAsNominalTypeOrNominalTypeExtensionContext())
-      if (auto *ClangDecl = D->getClangDecl()) {
-        clang::ASTReader &Reader = *CI.getClangInstance().getModuleManager();
-        auto Idx = ClangDecl->getOwningModuleID();
-        if (auto Info = Reader.getSourceDescriptor(Idx))
-          Scope = getOrCreateModule(*Info);
-      }
-    Context = Context->getParent();
-  }
-  if (!Scope)
-    Scope = getOrCreateContext(Context);
-  llvm::DIType *DITy = createType(DbgTy, MangledName, Scope, getFile(Scope));
-
-  // Incrementally build the DIRefMap.
-  if (auto *CTy = dyn_cast<llvm::DICompositeType>(DITy)) {
-#ifndef NDEBUG
-    // Sanity check.
-    if (llvm::Metadata *V = DIRefMap.lookup(UID)) {
-      auto *CachedTy = cast<llvm::DIType>(V);
-      assert(CachedTy == DITy && "conflicting types for one UID");
-    }
-#endif
-    // If this type supports a UID, enter it to the cache.
-    if (auto UID = CTy->getRawIdentifier()) {
-      assert(UID->getString() == MangledName &&
-             "Unique identifier is different from mangled name ");
-      DIRefMap[UID] = llvm::TrackingMDNodeRef(DITy);
-    }
-  }
-
-  // Store it in the cache.
-  DITypeCache.insert({DbgTy.getType(), llvm::TrackingMDNodeRef(DITy)});
-
-  return DITy;
-}
-
+// Forwarding to the private implementation.
 void IRGenDebugInfo::finalize() {
-  assert(LocationStack.empty() && "Mismatch of pushLoc() and popLoc().");
+  static_cast<IRGenDebugInfoImpl *>(this)->finalize();
+}
 
-  // Finalize all replaceable forward declarations.
-  for (auto &Ty : ReplaceMap) {
-    llvm::TempMDNode FwdDecl(cast<llvm::MDNode>(Ty.second));
-    llvm::Metadata *Replacement;
-    if (auto *FullType = getTypeOrNull(Ty.first))
-      Replacement = FullType;
-    else
-      Replacement = Ty.second;
-    DBuilder.replaceTemporary(std::move(FwdDecl),
-                              cast<llvm::MDNode>(Replacement));
+void IRGenDebugInfo::setCurrentLoc(IRBuilder &Builder, const SILDebugScope *DS,
+                                   Optional<SILLocation> Loc) {
+  static_cast<IRGenDebugInfoImpl *>(this)->setCurrentLoc(Builder, DS, Loc);
+}
+
+void IRGenDebugInfo::clearLoc(IRBuilder &Builder) {
+  static_cast<IRGenDebugInfoImpl *>(this)->clearLoc(Builder);
+}
+
+void IRGenDebugInfo::pushLoc() {
+  static_cast<IRGenDebugInfoImpl *>(this)->pushLoc();
+}
+
+void IRGenDebugInfo::popLoc() {
+  static_cast<IRGenDebugInfoImpl *>(this)->popLoc();
+}
+
+void IRGenDebugInfo::setArtificialTrapLocation(IRBuilder &Builder,
+                                               const SILDebugScope *Scope) {
+  static_cast<IRGenDebugInfoImpl *>(this)->setArtificialTrapLocation(Builder,
+                                                                     Scope);
+}
+
+void IRGenDebugInfo::setEntryPointLoc(IRBuilder &Builder) {
+  static_cast<IRGenDebugInfoImpl *>(this)->setEntryPointLoc(Builder);
+}
+
+llvm::DIScope *IRGenDebugInfo::getEntryPointFn() {
+  return static_cast<IRGenDebugInfoImpl *>(this)->getEntryPointFn();
+}
+
+llvm::DIScope *IRGenDebugInfo::getOrCreateScope(const SILDebugScope *DS) {
+  return static_cast<IRGenDebugInfoImpl *>(this)->getOrCreateScope(DS);
+}
+
+void IRGenDebugInfo::emitImport(ImportDecl *D) {
+  static_cast<IRGenDebugInfoImpl *>(this)->emitImport(D);
+}
+
+llvm::DISubprogram *
+IRGenDebugInfo::emitFunction(const SILDebugScope *DS, llvm::Function *Fn,
+                             SILFunctionTypeRepresentation Rep, SILType Ty,
+                             DeclContext *DeclCtx,
+                             GenericEnvironment *GE) {
+  return static_cast<IRGenDebugInfoImpl *>(this)->emitFunction(DS, Fn, Rep, Ty,
+                                                        DeclCtx);
+}
+
+llvm::DISubprogram *IRGenDebugInfo::emitFunction(SILFunction &SILFn,
+                                                 llvm::Function *Fn) {
+  return static_cast<IRGenDebugInfoImpl *>(this)->emitFunction(SILFn, Fn);
+}
+
+void IRGenDebugInfo::emitArtificialFunction(IRBuilder &Builder,
+                                            llvm::Function *Fn,
+                                            SILType SILTy) {
+  static_cast<IRGenDebugInfoImpl *>(this)->emitArtificialFunction(Builder,
+                                                                  Fn, SILTy);
+}
+
+void IRGenDebugInfo::emitVariableDeclaration(
+    IRBuilder &Builder, ArrayRef<llvm::Value *> Storage, DebugTypeInfo Ty,
+    const SILDebugScope *DS, ValueDecl *VarDecl, StringRef Name,
+    unsigned ArgNo, IndirectionKind Indirection,
+      ArtificialKind Artificial) {
+  static_cast<IRGenDebugInfoImpl *>(this)->emitVariableDeclaration(
+      Builder, Storage, Ty, DS, VarDecl, Name, ArgNo, Indirection, Artificial);
+}
+
+void IRGenDebugInfo::emitDbgIntrinsic(IRBuilder &Builder, llvm::Value *Storage,
+                                      llvm::DILocalVariable *Var,
+                                      llvm::DIExpression *Expr, unsigned Line,
+                                      unsigned Col, llvm::DILocalScope *Scope,
+                                      const SILDebugScope *DS) {
+  static_cast<IRGenDebugInfoImpl *>(this)->emitDbgIntrinsic(
+      Builder, Storage, Var, Expr, Line, Col, Scope, DS);
+}
+
+void IRGenDebugInfo::emitGlobalVariableDeclaration(
+    llvm::GlobalVariable *Storage, StringRef Name, StringRef LinkageName,
+    DebugTypeInfo DebugType, bool IsLocalToUnit, Optional<SILLocation> Loc) {
+  static_cast<IRGenDebugInfoImpl *>(this)->emitGlobalVariableDeclaration(
+      Storage, Name, LinkageName, DebugType, IsLocalToUnit, Loc);
+}
+
+void IRGenDebugInfo::emitTypeMetadata(IRGenFunction &IGF, llvm::Value *Metadata,
+                                      StringRef Name) {
+  static_cast<IRGenDebugInfoImpl *>(this)->emitTypeMetadata(IGF, Metadata,
+                                                            Name);
+}
+
+llvm::DIBuilder &IRGenDebugInfo::getBuilder() {
+  return static_cast<IRGenDebugInfoImpl *>(this)->getBuilder();
+}
+
+SILLocation::DebugLoc IRGenDebugInfo::decodeSourceLoc(SourceLoc SL) {
+  return static_cast<IRGenDebugInfoImpl *>(this)->decodeSourceLoc(SL);
+}
+
+AutoRestoreLocation::AutoRestoreLocation(IRGenDebugInfo *DI, IRBuilder &Builder)
+    : DI(DI), Builder(Builder) {
+  if (DI)
+    SavedLocation = Builder.getCurrentDebugLocation();
+}
+
+/// Autorestore everything back to normal.
+AutoRestoreLocation::~AutoRestoreLocation() {
+  if (DI)
+    Builder.SetCurrentDebugLocation(SavedLocation);
+}
+
+ArtificialLocation::ArtificialLocation(const SILDebugScope *DS,
+                                       IRGenDebugInfo *DI, IRBuilder &Builder)
+    : AutoRestoreLocation(DI, Builder) {
+  if (DI) {
+    auto DL = llvm::DebugLoc::get(0, 0, DI->getOrCreateScope(DS));
+    Builder.SetCurrentDebugLocation(DL);
   }
-  // Finalize the DIBuilder.
-  DBuilder.finalize();
+}
+
+PrologueLocation::PrologueLocation(IRGenDebugInfo *DI, IRBuilder &Builder)
+    : AutoRestoreLocation(DI, Builder) {
+  if (DI)
+    DI->clearLoc(Builder);
 }

--- a/lib/IRGen/IRGenDebugInfo.h
+++ b/lib/IRGen/IRGenDebugInfo.h
@@ -18,34 +18,24 @@
 #define SWIFT_IRGEN_DEBUGINFO_H
 
 #include "DebugTypeInfo.h"
-#include "IRBuilder.h"
 #include "IRGenFunction.h"
-#include "IRGenModule.h"
-#include "clang/AST/ExternalASTSource.h"
-#include "swift/SIL/SILLocation.h"
-#include "llvm/IR/DIBuilder.h"
-#include "llvm/Support/Allocator.h"
 
-#include <set>
+namespace llvm {
+class DIBuilder;
+}
 
 namespace swift {
 
-class ASTContext;
-class AllocStackInst;
 class ClangImporter;
 class IRGenOptions;
-class SILArgument;
-class SILDebugScope;
-class SILModule;
 
 enum class SILFunctionTypeRepresentation : uint8_t;
 
 namespace irgen {
 
+class IRBuilder;
 class IRGenFunction;
-
-typedef llvm::DenseMap<const llvm::MDString *, llvm::TrackingMDNodeRef>
-    TrackingDIRefMap;
+class IRGenModule;
 
 enum IndirectionKind : bool { DirectValue = false, IndirectValue = true };
 enum ArtificialKind : bool { RealValue = false, ArtificialValue = true };
@@ -54,61 +44,11 @@ enum ArtificialKind : bool { RealValue = false, ArtificialValue = true };
 /// LexicalScope, and knows how to translate a \c SILLocation into an
 /// \c llvm::DebugLoc.
 class IRGenDebugInfo {
-  friend class ArtificialLocation;
-  const IRGenOptions &Opts;
-  ClangImporter &CI;
-  SourceManager &SM;
-  llvm::Module &M;
-  llvm::DIBuilder DBuilder;
-  IRGenModule &IGM;
-
-  /// Used for caching SILDebugScopes without inline information.
-  typedef std::pair<const void *, void *> LocalScopeHash;
-  struct LocalScope : public LocalScopeHash {
-    LocalScope(const SILDebugScope *DS)
-        : LocalScopeHash({DS->Loc.getOpaquePointerValue(),
-                          DS->Parent.getOpaqueValue()}) {}
-  };
-
-  /// Various caches.
-  /// @{
-  llvm::DenseMap<LocalScopeHash, llvm::TrackingMDNodeRef> ScopeCache;
-  llvm::DenseMap<const SILDebugScope *, llvm::TrackingMDNodeRef> InlinedAtCache;
-  llvm::DenseMap<llvm::StringRef, llvm::TrackingMDNodeRef> DIFileCache;
-  llvm::DenseMap<const void *, SILLocation::DebugLoc> DebugLocCache;
-  llvm::DenseMap<TypeBase *, llvm::TrackingMDNodeRef> DITypeCache;
-  llvm::StringMap<llvm::TrackingMDNodeRef> DIModuleCache;
-  TrackingDIRefMap DIRefMap;
-  /// @}
-
-  /// A list of replaceable fwddecls that need to be RAUWed at the end.
-  std::vector<std::pair<TypeBase *, llvm::TrackingMDRef>> ReplaceMap;
-
-  llvm::BumpPtrAllocator DebugInfoNames;
-  StringRef CWDName;                    /// The current working directory.
-  llvm::DICompileUnit *TheCU = nullptr; /// The current compilation unit.
-  llvm::DIFile *MainFile = nullptr;     /// The main file.
-  llvm::DIModule *MainModule = nullptr; /// The current module.
-  llvm::DIScope *EntryPointFn =
-      nullptr;                          /// Scope of SWIFT_ENTRY_POINT_FUNCTION.
-  TypeAliasDecl *MetadataTypeDecl;      /// The type decl for swift.type.
-  llvm::DIType *InternalType; /// Catch-all type for opaque internal types.
-
-  SILLocation::DebugLoc LastDebugLoc; /// The last location that was emitted.
-  const SILDebugScope *LastScope;     /// The scope of that last location.
-#ifndef NDEBUG
-  /// The basic block where the location was last changed.
-  llvm::BasicBlock *LastBasicBlock;
-  bool lineNumberIsSane(IRBuilder &Builder, unsigned Line);
-#endif
-
-  /// Used by pushLoc.
-  SmallVector<std::pair<SILLocation::DebugLoc, const SILDebugScope *>, 8>
-      LocationStack;
-
 public:
-  IRGenDebugInfo(const IRGenOptions &Opts, ClangImporter &CI, IRGenModule &IGM,
-                 llvm::Module &M, SourceFile *SF);
+  static IRGenDebugInfo *createIRGenDebugInfo(const IRGenOptions &Opts,
+                                              ClangImporter &CI,
+                                              IRGenModule &IGM, llvm::Module &M,
+                                              SourceFile *SF);
 
   /// Finalize the llvm::DIBuilder owned by this object.
   void finalize();
@@ -118,38 +58,29 @@ public:
   void setCurrentLoc(IRBuilder &Builder, const SILDebugScope *DS,
                      Optional<SILLocation> Loc = None);
 
-  void clearLoc(IRBuilder &Builder) {
-    LastDebugLoc = {};
-    LastScope = nullptr;
-    Builder.SetCurrentDebugLocation(llvm::DebugLoc());
-  }
+  void clearLoc(IRBuilder &Builder);
 
   /// Push the current debug location onto a stack and initialize the
   /// IRBuilder to an empty location.
-  void pushLoc() {
-    LocationStack.push_back(std::make_pair(LastDebugLoc, LastScope));
-    LastDebugLoc = {};
-    LastScope = nullptr;
-  }
+  void pushLoc();
 
   /// Restore the current debug location from the stack.
-  void popLoc() {
-    std::tie(LastDebugLoc, LastScope) = LocationStack.pop_back_val();
-  }
+  void popLoc();
 
   /// Emit the final line 0 location for the unified trap block at the
   /// end of the function.
   void setArtificialTrapLocation(IRBuilder &Builder,
-                                 const SILDebugScope *Scope) {
-    auto DL = llvm::DebugLoc::get(0, 0, getOrCreateScope(Scope));
-    Builder.SetCurrentDebugLocation(DL);
-  }
+                                 const SILDebugScope *Scope);
 
   /// Set the location for SWIFT_ENTRY_POINT_FUNCTION.
   void setEntryPointLoc(IRBuilder &Builder);
 
   /// Return the scope for SWIFT_ENTRY_POINT_FUNCTION.
   llvm::DIScope *getEntryPointFn();
+
+  /// Translate a SILDebugScope into an llvm::DIDescriptor.
+  llvm::DIScope *getOrCreateScope(const SILDebugScope *DS);
+
   
   /// Emit debug info for an import declaration.
   ///
@@ -195,8 +126,8 @@ public:
                                DebugTypeInfo Ty, const SILDebugScope *DS,
                                ValueDecl *VarDecl, StringRef Name,
                                unsigned ArgNo = 0,
-                               IndirectionKind = DirectValue,
-                               ArtificialKind = RealValue);
+                               IndirectionKind Indirection = DirectValue,
+                               ArtificialKind Artificial = RealValue);
 
   /// Emit a dbg.declare or dbg.value intrinsic, depending on Storage.
   void emitDbgIntrinsic(IRBuilder &Builder, llvm::Value *Storage,
@@ -216,161 +147,10 @@ public:
                         StringRef Name);
 
   /// Return the DIBuilder.
-  llvm::DIBuilder &getBuilder() { return DBuilder; }
+  llvm::DIBuilder &getBuilder();
 
   /// Decode (and cache) a SourceLoc.
   SILLocation::DebugLoc decodeSourceLoc(SourceLoc SL);
-private:
-  /// Decode (and cache) a SILLocation.
-  SILLocation::DebugLoc decodeDebugLoc(SILLocation Loc);
-  /// Return the debug location from a SILLocation.
-  SILLocation::DebugLoc getDebugLocation(Optional<SILLocation> OptLoc);
-  /// Return the start of the location's source range.
-  SILLocation::DebugLoc getStartLocation(Optional<SILLocation> OptLoc);
-
-
-  StringRef BumpAllocatedString(const char *Data, size_t Length);
-  StringRef BumpAllocatedString(std::string S);
-  StringRef BumpAllocatedString(StringRef S);
-
-  /// Construct a DIType from a DebugTypeInfo object.
-  ///
-  /// At this point we do not plan to emit full DWARF for all swift
-  /// types, the goal is to emit only the name and provenance of the
-  /// type, where possible. A can import the type definition directly
-  /// from the module/framework/source file the type is specified in.
-  /// For this reason we emit the fully qualified (=mangled) name for
-  /// each type whenever possible.
-  ///
-  /// The ultimate goal is to emit something like a
-  /// DW_TAG_APPLE_ast_ref_type (an external reference) instead of a
-  /// local reference to the type.
-  llvm::DIType *createType(DebugTypeInfo DbgTy, StringRef MangledName,
-                           llvm::DIScope *Scope, llvm::DIFile *File);
-  /// Get a previously created type from the cache.
-  llvm::DIType *getTypeOrNull(TypeBase *Ty);
-  /// Get the DIType corresponding to this DebugTypeInfo from the cache,
-  /// or build a fresh DIType otherwise.  There is the underlying
-  /// assumption that no two types that share the same canonical type
-  /// can have different storage size or alignment.
-  llvm::DIType *getOrCreateType(DebugTypeInfo DbgTy);
-  /// Translate a SILDebugScope into an llvm::DIDescriptor.
-  llvm::DIScope *getOrCreateScope(const SILDebugScope *DS);
-  /// Build the context chain for a given DeclContext.
-  llvm::DIScope *getOrCreateContext(DeclContext *DC);
-
-  /// Construct an LLVM inlined-at location from a SILDebugScope,
-  /// reversing the order in the process.
-  llvm::MDNode *createInlinedAt(const SILDebugScope *CallSite);
-
-  /// Translate filenames into DIFiles.
-  llvm::DIFile *getOrCreateFile(StringRef Filename);
-  /// Return a DIType for Ty reusing any DeclContext found in DbgTy.
-  llvm::DIType *getOrCreateDesugaredType(Type Ty, DebugTypeInfo DbgTy);
-
-  /// Attempt to figure out the unmangled name of a function.
-  StringRef getName(const FuncDecl &FD);
-  /// Attempt to figure out the unmangled name of a function.
-  StringRef getName(SILLocation L);
-  StringRef getMangledName(TypeAliasDecl *Decl);
-  /// Return the mangled name of any nominal type, including the global
-  /// _Tt prefix, which marks the Swift namespace for types in DWARF.
-  StringRef getMangledName(DebugTypeInfo DbgTy);
-  /// Create the array of function parameters for a function type.
-  llvm::DITypeRefArray createParameterTypes(CanSILFunctionType FnTy,
-                                            DeclContext *DeclCtx,
-                                            GenericEnvironment *GE);
-  /// Create the array of function parameters for FnTy. SIL Version.
-  llvm::DITypeRefArray createParameterTypes(SILType SILTy, DeclContext *DeclCtx,
-                                            GenericEnvironment *GE);
-  /// Create a single parameter type and push it.
-  void createParameterType(llvm::SmallVectorImpl<llvm::Metadata *> &Parameters,
-                           SILType CanTy, DeclContext *DeclCtx,
-                           GenericEnvironment *GE);
-  /// Return an array with the DITypes for each of a tuple's elements.
-  llvm::DINodeArray
-  getTupleElements(TupleType *TupleTy, llvm::DIScope *Scope, llvm::DIFile *File,
-                   llvm::DINode::DIFlags Flags, DeclContext *DeclContext,
-                   GenericEnvironment *GE, unsigned &SizeInBits);
-  llvm::DIFile *getFile(llvm::DIScope *Scope);
-  llvm::DIModule *getOrCreateModule(ModuleDecl::ImportedModule M);
-  /// Return a cached module for an access path or create a new one.
-  llvm::DIModule *getOrCreateModule(StringRef Key, llvm::DIScope *Parent,
-                                    StringRef Name, StringRef IncludePath);
-  llvm::DIModule *
-  getOrCreateModule(clang::ExternalASTSource::ASTSourceDescriptor M);
-
-  llvm::DIScope *getModule(StringRef MangledName);
-  /// Return an array with the DITypes for each of a struct's elements.
-  llvm::DINodeArray getStructMembers(NominalTypeDecl *D, Type BaseTy,
-                                     llvm::DIScope *Scope, llvm::DIFile *File,
-                                     llvm::DINode::DIFlags Flags,
-                                     unsigned &SizeInBits);
-  /// Create a temporary forward declaration for a struct and add it to
-  /// the type cache so we can safely build recursive types.
-  llvm::DICompositeType *
-  createStructType(DebugTypeInfo DbgTy, NominalTypeDecl *Decl, Type BaseTy,
-                   llvm::DIScope *Scope, llvm::DIFile *File, unsigned Line,
-                   unsigned SizeInBits, unsigned AlignInBits,
-                   llvm::DINode::DIFlags Flags,
-                   llvm::DIType *DerivedFrom, unsigned RuntimeLang,
-                   StringRef UniqueID);
-
-  /// Create a member of a struct, class, tuple, or enum.
-  llvm::DIDerivedType *createMemberType(DebugTypeInfo DbgTy, StringRef Name,
-                                        unsigned &OffsetInBits,
-                                        llvm::DIScope *Scope,
-                                        llvm::DIFile *File,
-                                        llvm::DINode::DIFlags Flags);
-  /// Return an array with the DITypes for each of an enum's elements.
-  llvm::DINodeArray getEnumElements(DebugTypeInfo DbgTy, EnumDecl *D,
-                                    llvm::DIScope *Scope, llvm::DIFile *File,
-                                    llvm::DINode::DIFlags Flags);
-  /// Create a temporary forward declaration for an enum and add it to
-  /// the type cache so we can safely build recursive types.
-  llvm::DICompositeType *createEnumType(DebugTypeInfo DbgTy, EnumDecl *Decl,
-                                        StringRef MangledName,
-                                        llvm::DIScope *Scope,
-                                        llvm::DIFile *File, unsigned Line,
-                                        llvm::DINode::DIFlags Flags);
-  /// Convenience function that creates a forward declaration for PointeeTy.
-  llvm::DIType *createPointerSizedStruct(llvm::DIScope *Scope, StringRef Name,
-                                         llvm::DIFile *File, unsigned Line,
-                                         llvm::DINode::DIFlags Flags,
-                                         StringRef MangledName);
-  /// Create a pointer-sized struct with a mangled name and a single
-  /// member of PointeeTy.
-  llvm::DIType *createPointerSizedStruct(llvm::DIScope *Scope, StringRef Name,
-                                         llvm::DIType *PointeeTy,
-                                         llvm::DIFile *File, unsigned Line,
-                                         llvm::DINode::DIFlags Flags,
-                                         StringRef MangledName);
-  /// Create a 2*pointer-sized struct with a mangled name and a single
-  /// member of PointeeTy.
-  llvm::DIType *createDoublePointerSizedStruct(
-      llvm::DIScope *Scope, StringRef Name, llvm::DIType *PointeeTy,
-      llvm::DIFile *File, unsigned Line, llvm::DINode::DIFlags Flags,
-      StringRef MangledName);
-
-  /// Create DWARF debug info for a function pointer type.
-  llvm::DIType *createFunctionPointer(DebugTypeInfo DbgTy, llvm::DIScope *Scope,
-                                      unsigned SizeInBits, unsigned AlignInBits,
-                                      llvm::DINode::DIFlags Flags,
-                                      StringRef MangledName);
-
-  /// Create DWARF debug info for a tuple type.
-  llvm::DIType *createTuple(DebugTypeInfo DbgTy, llvm::DIScope *Scope,
-                            unsigned SizeInBits, unsigned AlignInBits,
-                            llvm::DINode::DIFlags Flags, StringRef MangledName);
-
-  /// Create an opaque struct with a mangled name.
-  llvm::DIType *createOpaqueStruct(llvm::DIScope *Scope, StringRef Name,
-                                   llvm::DIFile *File, unsigned Line,
-                                   unsigned SizeInBits, unsigned AlignInBits,
-                                   llvm::DINode::DIFlags Flags,
-                                   StringRef MangledName);
-  uint64_t getSizeOfBasicType(DebugTypeInfo DbgTy);
-  TypeAliasDecl *getMetadataType();
 };
 
 /// An RAII object that autorestores the debug location.
@@ -380,17 +160,9 @@ class AutoRestoreLocation {
   llvm::DebugLoc SavedLocation;
 
 public:
-  AutoRestoreLocation(IRGenDebugInfo *DI, IRBuilder &Builder)
-      : DI(DI), Builder(Builder) {
-    if (DI)
-      SavedLocation = Builder.getCurrentDebugLocation();
-  }
-
+  AutoRestoreLocation(IRGenDebugInfo *DI, IRBuilder &Builder);
   /// Autorestore everything back to normal.
-  ~AutoRestoreLocation() {
-    if (DI)
-      Builder.SetCurrentDebugLocation(SavedLocation);
-  }
+  ~AutoRestoreLocation();
 };
 
 /// An RAII object that temporarily switches to an artificial debug
@@ -404,13 +176,7 @@ class ArtificialLocation : public AutoRestoreLocation {
 public:
   /// Set the current location to line 0, but within scope DS.
   ArtificialLocation(const SILDebugScope *DS, IRGenDebugInfo *DI,
-                     IRBuilder &Builder)
-      : AutoRestoreLocation(DI, Builder) {
-    if (DI) {
-      auto DL = llvm::DebugLoc::get(0, 0, DI->getOrCreateScope(DS));
-      Builder.SetCurrentDebugLocation(DL);
-    }
-  }
+                     IRBuilder &Builder);
 };
 
 /// An RAII object that temporarily switches to an empty
@@ -418,11 +184,7 @@ public:
 class PrologueLocation : public AutoRestoreLocation {
 public:
   /// Set the current location to an empty location.
-  PrologueLocation(IRGenDebugInfo *DI, IRBuilder &Builder)
-      : AutoRestoreLocation(DI, Builder) {
-    if (DI)
-      DI->clearLoc(Builder);
-  }
+  PrologueLocation(IRGenDebugInfo *DI, IRBuilder &Builder);
 };
 
 } // irgen

--- a/lib/IRGen/IRGenDebugInfo.h
+++ b/lib/IRGen/IRGenDebugInfo.h
@@ -21,6 +21,7 @@
 #include "IRBuilder.h"
 #include "IRGenFunction.h"
 #include "IRGenModule.h"
+#include "clang/AST/ExternalASTSource.h"
 #include "swift/SIL/SILLocation.h"
 #include "llvm/IR/DIBuilder.h"
 #include "llvm/Support/Allocator.h"
@@ -296,6 +297,9 @@ private:
   /// Return a cached module for an access path or create a new one.
   llvm::DIModule *getOrCreateModule(StringRef Key, llvm::DIScope *Parent,
                                     StringRef Name, StringRef IncludePath);
+  llvm::DIModule *
+  getOrCreateModule(clang::ExternalASTSource::ASTSourceDescriptor M);
+
   llvm::DIScope *getModule(StringRef MangledName);
   /// Return an array with the DITypes for each of a struct's elements.
   llvm::DINodeArray getStructMembers(NominalTypeDecl *D, Type BaseTy,

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -380,7 +380,8 @@ IRGenModule::IRGenModule(IRGenerator &irgen,
   UseSwiftCC = (SwiftCC == llvm::CallingConv::Swift);
 
   if (IRGen.Opts.DebugInfoKind > IRGenDebugInfoKind::None)
-    DebugInfo = new IRGenDebugInfo(IRGen.Opts, *CI, *this, Module, SF);
+    DebugInfo = IRGenDebugInfo::createIRGenDebugInfo(IRGen.Opts, *CI, *this,
+                                                     Module, SF);
 
   initClangTypeConverter();
 

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -97,8 +97,8 @@ static clang::CodeGenerator *createClangCodeGenerator(ASTContext &Context,
     CGO.setDebugInfo(clang::codegenoptions::DebugInfoKind::DebugLineTablesOnly);
     break;
   case IRGenDebugInfoKind::ASTTypes:
-    // TODO: Enable -gmodules for the clang code generator.
   case IRGenDebugInfoKind::DwarfTypes:
+    CGO.DebugTypeExtRefs = true;
     CGO.setDebugInfo(clang::codegenoptions::DebugInfoKind::FullDebugInfo);
     break;
   }

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -16,6 +16,7 @@
 //===----------------------------------------------------------------------===//
 
 #define DEBUG_TYPE "irgensil"
+#include "llvm/IR/DIBuilder.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/Instructions.h"

--- a/test/DebugInfo/ImportClangSubmodule.swift
+++ b/test/DebugInfo/ImportClangSubmodule.swift
@@ -1,13 +1,12 @@
-// RUN: rm -rf %t && mkdir -p %t
-// REQUIRES: OS=macosx
+// RUN: %target-swift-frontend -emit-ir %s -g -I %S/Inputs -o - | %FileCheck %s
 
-// RUN: %target-swift-frontend -emit-ir %s -g -o - | %FileCheck %s
+// CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "Bar",
+// CHECK-SAME:             scope: ![[SUBMODULE:[0-9]+]]
 
-// CHECK: !DIImportedEntity(
-// CHECK: tag: DW_TAG_imported_module{{.*}}entity: ![[C:.*]], line: [[@LINE+1]])
-import Darwin.C
+// CHECK: ![[SUBMODULE]] = !DIModule(scope: ![[CLANGMODULE:[0-9]+]],
+// CHECK-SAME:                       name: "SubModule",
+// CHECK: ![[CLANGMODULE]] = !DIModule(scope: null, name: "ClangModule",
+// CHECK: !DIImportedEntity({{.*}}, entity: ![[SUBMODULE]], line: [[@LINE+1]])
+import ClangModule.SubModule
 
-let irrational = sqrt(2 as Double)
-
-// CHECK: ![[C]] = !DIModule(scope: ![[Darwin:.*]], name: "C",
-// CHECK: ![[Darwin]] = !DIModule(scope: null, name: "Darwin",
+let bar = Bar()

--- a/test/DebugInfo/Inputs/SubModule.h
+++ b/test/DebugInfo/Inputs/SubModule.h
@@ -1,0 +1,1 @@
+struct Bar {};

--- a/test/DebugInfo/Inputs/module.map
+++ b/test/DebugInfo/Inputs/module.map
@@ -1,3 +1,8 @@
 module ClangModule {
   header "ClangModule.h"
+  export *
+  module SubModule {
+    header "SubModule.h"
+    export *
+  }
 }

--- a/test/DebugInfo/test-foundation.swift
+++ b/test/DebugInfo/test-foundation.swift
@@ -18,8 +18,9 @@ class MyObject : NSObject {
   var MyArr = NSArray()
 // IMPORT-CHECK: filename: "test-foundation.swift"
 // IMPORT-CHECK-DAG: [[FOUNDATION:[0-9]+]] = !DIModule({{.*}} name: "Foundation",{{.*}} includePath:
-// IMPORT-CHECK-DAG: !DICompositeType(tag: DW_TAG_structure_type, name: "NSArray", scope: ![[FOUNDATION]]
-// IMPORT-CHECK-DAG: !DIImportedEntity(tag: DW_TAG_imported_module, {{.*}}entity: ![[FOUNDATION]]
+  // IMPORT-CHECK-DAG: !DICompositeType(tag: DW_TAG_structure_type, name: "NSArray", scope: ![[NSARRAY:[0-9]+]]
+  //  IMPORT-CHECK-DAG: ![[NSARRAY]] = !DIModule(scope: ![[FOUNDATION:[0-9]+]], name: "NSArray"
+  // IMPORT-CHECK-DAG: !DIImportedEntity(tag: DW_TAG_imported_module, {{.*}}entity: ![[FOUNDATION]]
 
   func foo(_ obj: MyObject) {
     return obj.foo(obj)


### PR DESCRIPTION
This PR was created for the fix to <rdar://problem/31926379>.

- Explanation: Swift stores inline information as part of Scopes, LLVM stores it as part of Locations. Commit 5ea2d13f5e0 introduced a DenseMap for caching the non-inlined portion of a scope and it used the scope's parent SILFunction as part of the hash. This caused a collision for LLVM-only artificial helper functions  where the SILFunction is a nullptr. This patch fixes this problem by using the address of the SILDebugScope as a key if the parent function is nullptr.
- Scope: The collision cause LLVM r302469+ to fail verification (I added the verifier check in the light of this problem) and cause corrupted DWARF output that crashes DWARF consumers on older versions of LLVM.
- Radar: rdar://problem/31926379
Risk: Low.
- Testing: Run `dwarfdump --verify` or `symbols` on programs compiled with debug info.

To make cherry-picking conflict free, this PR also includes an NFC refactoring. Let me know if a small but conflicting patch is preferable.