### PR TITLE
[stdlib] Provide Swift 3 compatible Dict.keys/values

### DIFF
--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -2012,12 +2012,12 @@ public struct Dictionary<Key : Hashable, Value> :
   @_inlineable
   @available(swift, introduced: 4.0)
   public func filter(
-    _ isIncluded: (Key, Value) throws -> Bool
+    _ isIncluded: (Element) throws -> Bool
   ) rethrows -> [Key: Value] {
     var result = Dictionary()
-    for (key, value) in self {
-      if try isIncluded(key, value) {
-        result[key] = value
+    for el in self {
+      if try isIncluded(el) {
+        result[el.key] = el.value
       }
     }
     return result

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -2291,6 +2291,26 @@ public struct Dictionary<Key : Hashable, Value> :
   // API itself.
   //
 
+  //
+  // Collection conformance
+  //
+  
+  /// A Boolean value that indicates whether the dictionary is empty.
+  ///
+  /// Dictionaries are empty when created with an initializer or an empty
+  /// dictionary literal.
+  ///
+  ///     var frequencies: [String: Int] = [:]
+  ///     print(frequencies.isEmpty)
+  ///     // Prints "true"
+  public var isEmpty: Bool {
+    return count == 0
+  }
+}
+
+// Maintain old `keys` and `values` types in Swift 3 mode.
+
+extension Dictionary {
   /// A collection containing just the keys of the dictionary.
   ///
   /// When iterated over, keys appear in this collection in the same order as
@@ -2307,6 +2327,50 @@ public struct Dictionary<Key : Hashable, Value> :
   ///     // Prints "BR"
   ///     // Prints "JP"
   ///     // Prints "GH"
+  @available(swift, obsoleted: 4.0)
+  public var keys: LazyMapCollection<[Key: Value], Key> {
+    return self.lazy.map { $0.key }
+  }
+  
+  /// A collection containing just the values of the dictionary.
+  ///
+  /// When iterated over, values appear in this collection in the same order as
+  /// they occur in the dictionary's key-value pairs.
+  ///
+  ///     let countryCodes = ["BR": "Brazil", "GH": "Ghana", "JP": "Japan"]
+  ///     print(countryCodes)
+  ///     // Prints "["BR": "Brazil", "JP": "Japan", "GH": "Ghana"]"
+  ///
+  ///     for v in countryCodes.values {
+  ///         print(v)
+  ///     }
+  ///     // Prints "Brazil"
+  ///     // Prints "Japan"
+  ///     // Prints "Ghana"
+  @available(swift, obsoleted: 4.0)
+  public var values: LazyMapCollection<[Key: Value], Value> {
+    return self.lazy.map { $0.value }
+  }
+}
+
+extension Dictionary {
+  /// A collection containing just the keys of the dictionary.
+  ///
+  /// When iterated over, keys appear in this collection in the same order as
+  /// they occur in the dictionary's key-value pairs. Each key in the keys
+  /// collection has a unique value.
+  ///
+  ///     let countryCodes = ["BR": "Brazil", "GH": "Ghana", "JP": "Japan"]
+  ///     print(countryCodes)
+  ///     // Prints "["BR": "Brazil", "JP": "Japan", "GH": "Ghana"]"
+  ///
+  ///     for k in countryCodes.keys {
+  ///         print(k)
+  ///     }
+  ///     // Prints "BR"
+  ///     // Prints "JP"
+  ///     // Prints "GH"
+  @available(swift, introduced: 4.0)
   public var keys: Keys {
     return Keys(self)
   }
@@ -2326,6 +2390,7 @@ public struct Dictionary<Key : Hashable, Value> :
   ///     // Prints "Brazil"
   ///     // Prints "Japan"
   ///     // Prints "Ghana"
+  @available(swift, introduced: 4.0)
   public var values: Values {
     get {
       return Values(self)
@@ -2333,22 +2398,6 @@ public struct Dictionary<Key : Hashable, Value> :
     set {
       self = Dictionary(_variantBuffer: newValue._variantBuffer)
     }
-  }
-
-  //
-  // Collection conformance
-  //
-
-  /// A Boolean value that indicates whether the dictionary is empty.
-  ///
-  /// Dictionaries are empty when created with an initializer or an empty
-  /// dictionary literal.
-  ///
-  ///     var frequencies: [String: Int] = [:]
-  ///     print(frequencies.isEmpty)
-  ///     // Prints "true"
-  public var isEmpty: Bool {
-    return count == 0
   }
 
   /// A view of a dictionary's keys.

--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -1180,10 +1180,12 @@ DictionaryTestSuite.test("COW.Fast.ValuesAccessDoesNotReallocate") {
   assert(d1.values[i] == 1010)
   assert(d1[i] == (10, 1010))
   
+#if swift(>=4.0)
   d2.values[i] += 1
   assert(d2.values[i] == 1011)
   assert(d2[10]! == 1011)
   assert(identity1 != d2._rawIdentifier())
+#endif
   
   assert(d1[10]! == 1010)
   assert(identity1 == d1._rawIdentifier())
@@ -1242,8 +1244,10 @@ DictionaryTestSuite.test("COW.Fast.KeysAccessDoesNotReallocate") {
     // keys.index(of:) - O(1) bucket + linear search
     MinimalHashableValue.timesEqualEqualWasCalled = 0
     let l = d2.keys.index(of: lastKey)!
+#if swift(>=4.0)
     expectLE(MinimalHashableValue.timesEqualEqualWasCalled, 4)
-    
+#endif
+
     expectEqual(j, k)
     expectEqual(k, l)
   }

--- a/validation-test/stdlib/HashedCollectionFilter3.swift
+++ b/validation-test/stdlib/HashedCollectionFilter3.swift
@@ -17,5 +17,19 @@ FilterTestSuite.test("Set.filter(_:) -> [Element]") {
   expectTrue(f is [Int])
 }
 
+FilterTestSuite.test("Dictionary.keys -> LazyMapCollection") {
+  let d = [10: 1010, 20: 1020, 30: 1030, 40: 1040]
+  // .keys should produce a LazyMapCollection in Swift 3
+  let f: Any = d.keys
+  expectEqual(4, f.count)
+}
+
+FilterTestSuite.test("Dictionary.values -> LazyMapCollection") {
+  let d = [10: 1010, 20: 1020, 30: 1030, 40: 1040]
+  // .values should produce a LazyMapCollection in Swift 3
+  let f: Any = d.values
+  expectEqual(4, f.count)
+}
+
 runAllTests()
 

--- a/validation-test/stdlib/HashedCollectionFilter3.swift
+++ b/validation-test/stdlib/HashedCollectionFilter3.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-stdlib-swift
+// RUN: %target-run-stdlib-swift -swift-version 3
 // REQUIRES: executable_test
 
 import StdlibUnittest
@@ -21,14 +21,16 @@ FilterTestSuite.test("Dictionary.keys -> LazyMapCollection") {
   let d = [10: 1010, 20: 1020, 30: 1030, 40: 1040]
   // .keys should produce a LazyMapCollection in Swift 3
   let f: Any = d.keys
-  expectEqual(4, f.count)
+  let g = f as! LazyMapCollection<[Int: Int], Int>
+  expectEqual(4, g.count)
 }
 
 FilterTestSuite.test("Dictionary.values -> LazyMapCollection") {
   let d = [10: 1010, 20: 1020, 30: 1030, 40: 1040]
   // .values should produce a LazyMapCollection in Swift 3
   let f: Any = d.values
-  expectEqual(4, f.count)
+  let g = f as! LazyMapCollection<[Int: Int], Int>
+  expectEqual(4, g.count)
 }
 
 runAllTests()

--- a/validation-test/stdlib/HashedCollectionFilter4.swift
+++ b/validation-test/stdlib/HashedCollectionFilter4.swift
@@ -37,5 +37,19 @@ FilterTestSuite.test("Set.filter(_:) -> [Element] available") {
   expectEqual(2, f.count)
 }
 
+FilterTestSuite.test("Dictionary.keys -> Keys") {
+  let d = [10: 1010, 20: 1020, 30: 1030, 40: 1040]
+  // .keys should produce a Dictionary.Keys in Swift 4
+  let f: Any = d.keys
+  expectTrue(f is Dictionary<Int, Int>.Keys)
+}
+
+FilterTestSuite.test("Dictionary.values -> Values") {
+  let d = [10: 1010, 20: 1020, 30: 1030, 40: 1040]
+  // .values should produce a Dictionary.Values in Swift 4
+  let f: Any = d.values
+  expectTrue(f is Dictionary<Int, Int>.Values)
+}
+
 runAllTests()
 

--- a/validation-test/stdlib/HashedCollectionFilter4.swift
+++ b/validation-test/stdlib/HashedCollectionFilter4.swift
@@ -10,14 +10,14 @@ FilterTestSuite.test("Dictionary.filter(_:) -> [Key: Value]")
 {
   let d = [10: 1010, 20: 1020, 30: 1030, 40: 1040]
   // filter(_:) should produce a dictionary in Swift 4
-  let f: Any = d.filter { (k, v) in k > 20 }
+  let f: Any = d.filter { $0.key > 20 }
   expectTrue(f is [Int: Int])
 }
 
 FilterTestSuite.test("Dictionary.filter(_:) -> [(Key, Value)] available") {
   let d = [10: 1010, 20: 1020, 30: 1030, 40: 1040]
   // The Array-returning version from Sequence should still be accessible
-  let f: [(Int, Int)] = d.filter { (k, v) in k > 20 }
+  let f: [(Int, Int)] = d.filter { $0.key > 20 }
   expectEqual(2, f.count)
 }
 
@@ -37,14 +37,18 @@ FilterTestSuite.test("Set.filter(_:) -> [Element] available") {
   expectEqual(2, f.count)
 }
 
-FilterTestSuite.test("Dictionary.keys -> Keys") {
+FilterTestSuite.test("Dictionary.keys -> Keys")
+  .xfail(.always("Not actually running under Swift 4")).code
+{
   let d = [10: 1010, 20: 1020, 30: 1030, 40: 1040]
   // .keys should produce a Dictionary.Keys in Swift 4
   let f: Any = d.keys
   expectTrue(f is Dictionary<Int, Int>.Keys)
 }
 
-FilterTestSuite.test("Dictionary.values -> Values") {
+FilterTestSuite.test("Dictionary.values -> Values")
+  .xfail(.always("Not actually running under Swift 4")).code
+{
   let d = [10: 1010, 20: 1020, 30: 1030, 40: 1040]
   // .values should produce a Dictionary.Values in Swift 4
   let f: Any = d.values


### PR DESCRIPTION
This also includes a change to the new `Dictionary.filter(_:)` method so that its closure argument correctly matches the one on `Sequence`.