### PR TITLE
Short circuit subspace check with empty subjects

### DIFF
--- a/lib/Sema/TypeCheckSwitchStmt.cpp
+++ b/lib/Sema/TypeCheckSwitchStmt.cpp
@@ -251,8 +251,23 @@ namespace {
 
           // Special Case: A constructor pattern may include the head but not
           // the payload patterns.  In that case the space is covered.
+          // This also acts to short-circuit comparisons with payload-less
+          // constructors.
           if (other.getSpaces().empty()) {
             return true;
+          }
+
+          // If 'this' constructor pattern has no payload and the other space
+          // does, then 'this' covers more of the space only if the other
+          // constructor isn't the explicit form.
+          //
+          // .case <= .case(_, _, _, ...)
+          if (this->getSpaces().empty()) {
+            return std::accumulate(other.getSpaces().begin(),
+                                   other.getSpaces().end(),
+                                   true, [](bool acc, const Space sp){
+              return acc && sp.getKind() == SpaceKind::Type;
+            });
           }
 
           // H(a1, ..., an) <= H(b1, ..., bn) iff a1 <= b1 && ... && an <= bn

--- a/test/Sema/exhaustive_switch.swift
+++ b/test/Sema/exhaustive_switch.swift
@@ -1,4 +1,5 @@
 // RUN: %target-typecheck-verify-swift
+
 func foo(a: Int?, b: Int?) -> Int {
   switch (a, b) {
   case (.none, _): return 1
@@ -284,5 +285,27 @@ func switcheroo(a: XX, b: XX) -> Int {
   default:
     print("never hits this:", a, b)
     return 13
+  }
+}
+
+enum PatternCasts {
+  case one(Any)
+  case two
+}
+
+func checkPatternCasts() {
+  // Pattern casts with this structure shouldn't warn about duplicate cases.
+  let x: PatternCasts = .one("One")
+  switch x {
+  case .one(let s as String): print(s)
+  case .one: break
+  case .two: break
+  }
+
+  // But should warn here.
+  switch x {
+  case .one(_): print(s)
+  case .one: break // expected-warning {{case is already handled by previous patterns; consider removing it}}
+  case .two: break
   }
 }


### PR DESCRIPTION
This is the flip side of #9449.  Refutable patterns followed by patterns that do not explicitly match a payload were passing through the `isSubspace` check.  Short-circuit when this happens to correctly identify this kind of structure.