### PR TITLE
[Gardening] SE-0169 PR Feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ CHANGELOG
 
 Swift 4.0
 ---------
+* [SE-0169](https://github.com/apple/swift-evolution/blob/master/proposals/0169-improve-interaction-between-private-declarations-and-extensions.md):
+  In Swift 4 mode, private scope is shared between the declaration and all 
+  extensions of a specific type inside the same file.
 
 * [SE-0138](https://github.com/apple/swift-evolution/blob/master/proposals/0138-unsaferawbufferpointer.md#amendment-to-normalize-the-slice-type):
 

--- a/docs/AccessControl.rst
+++ b/docs/AccessControl.rst
@@ -26,7 +26,8 @@ project--while not accidentally revealing entities to clients of a framework
 module.
 
 .. warning:: This document has not yet been updated for SE-0117, which adds the
-  "open" level of access.
+  "open" level of access, or SE-0169 which shares the private scope between
+  extensions and the declaration inside the same file.
 
 
 .. contents:: :local:

--- a/include/swift/AST/AccessScope.h
+++ b/include/swift/AST/AccessScope.h
@@ -23,7 +23,8 @@ namespace swift {
 /// a particular declaration can be accessed.
 class AccessScope {
   /// The declaration context (if not public) along with a bit saying
-  /// whether this scope is private (or not).
+  /// whether this scope is private (or not). This bit is used to distinguish
+  /// file-level private and fileprivate.
   llvm::PointerIntPair<const DeclContext *, 1, bool> Value;
 public:
   AccessScope(const DeclContext *DC, bool isPrivate = false);

--- a/include/swift/AST/AccessScope.h
+++ b/include/swift/AST/AccessScope.h
@@ -31,11 +31,6 @@ public:
 
   static AccessScope getPublic() { return AccessScope(nullptr); }
 
-  /// Check if private access is allowed. This is a lexical scope check in Swift
-  /// 3 mode. In Swift 4 mode, declarations and extensions of the same type will
-  /// also allow access.
-  static bool allowsAccess(const DeclContext *useDC, const DeclContext *sourceDC);
-
   /// Returns nullptr if access scope is public.
   const DeclContext *getDeclContext() const { return Value.getPointer(); }
 
@@ -52,11 +47,14 @@ public:
   /// Returns true if this is a child scope of the specified other access scope.
   bool isChildOf(AccessScope AS) const {
     if (!isPublic() && !AS.isPublic())
-      return allowsAccess(getDeclContext(), AS.getDeclContext());
+      return getDeclContext()->isAccessibleChildOf(AS.getDeclContext());
     if (isPublic() && AS.isPublic())
       return false;
     return AS.isPublic();
   }
+
+  /// Check if the decl context is equal to or an accessible child of the DC.
+  bool isAccessibleFrom(const DeclContext *DC) const;
 
   /// Returns the associated access level for diagnostic purposes.
   Accessibility accessibilityForDiagnostics() const;

--- a/include/swift/AST/AccessScope.h
+++ b/include/swift/AST/AccessScope.h
@@ -34,7 +34,7 @@ public:
   /// Check if private access is allowed. This is a lexical scope check in Swift
   /// 3 mode. In Swift 4 mode, declarations and extensions of the same type will
   /// also allow access.
-  static bool allowsPrivateAccess(const DeclContext *useDC, const DeclContext *sourceDC);
+  static bool allowsAccess(const DeclContext *useDC, const DeclContext *sourceDC);
 
   /// Returns nullptr if access scope is public.
   const DeclContext *getDeclContext() const { return Value.getPointer(); }
@@ -50,11 +50,9 @@ public:
   bool isFileScope() const;
 
   /// Returns true if this is a child scope of the specified other access scope.
-  ///
-  /// \see DeclContext::isChildContextOf
   bool isChildOf(AccessScope AS) const {
     if (!isPublic() && !AS.isPublic())
-      return allowsPrivateAccess(getDeclContext(), AS.getDeclContext());
+      return allowsAccess(getDeclContext(), AS.getDeclContext());
     if (isPublic() && AS.isPublic())
       return false;
     return AS.isPublic();

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2171,9 +2171,6 @@ public:
   /// features that affect formal access such as \c \@testable are
   /// taken into account.
   ///
-  /// \invariant
-  /// <code>value.isAccessibleFrom(value.getFormalAccessScope())</code>
-  ///
   /// \sa getFormalAccess
   /// \sa isAccessibleFrom
   AccessScope
@@ -4110,6 +4107,18 @@ public:
   }
 
   void overwriteSetterAccessibility(Accessibility accessLevel);
+
+  /// Returns the access level for the setter specified explicitly by the user,
+  /// or provided by default according to language rules.
+  ///
+  /// If \p useDC is provided (the location where the value is being used),
+  /// features that affect formal access such as \c \@testable are taken into
+  /// account.
+  ///
+  /// \sa getFormalAccessScope
+  /// \sa isAccessibleFrom
+  /// \sa isSetterAccessibleFrom
+  Accessibility getFormalSetterAccess(const DeclContext *DC) const;
 
   /// \brief Retrieve the materializeForSet function, if this
   /// declaration has one.

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2157,20 +2157,18 @@ public:
   /// Returns the access level specified explicitly by the user, or provided by
   /// default according to language rules.
   ///
-  /// This is the access used when calculating if access control is being used
-  /// consistently. If \p useDC is provided (the location where the value is
-  /// being used), features that affect formal access such as \c \@testable are
-  /// taken into account.
+  /// If \p useDC is provided (the location where the value is being used), 
+  /// features that affect formal access such as \c \@testable are taken into 
+  /// account.
   ///
   /// \sa getFormalAccessScope
+  /// \sa isAccessibleFrom
   Accessibility getFormalAccess(const DeclContext *useDC = nullptr) const;
 
-  /// Returns the outermost DeclContext from which this declaration can be
-  /// accessed, or null if the declaration is public.
+  /// Returns the AccessScope from which this declaration can be accessed.
   ///
-  /// This is used when calculating if access control is being used
-  /// consistently. If \p useDC is provided (the location where the value is
-  /// being used), features that affect formal access such as \c \@testable are
+  /// If \p useDC is provided (the location where the value is being used), 
+  /// features that affect formal access such as \c \@testable are
   /// taken into account.
   ///
   /// \invariant

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2154,9 +2154,6 @@ public:
     return TypeAndAccess.getInt().hasValue();
   }
 
-  /// \see getFormalAccess
-  Accessibility getFormalAccessImpl(const DeclContext *useDC) const;
-
   /// Returns the access level specified explicitly by the user, or provided by
   /// default according to language rules.
   ///
@@ -2166,14 +2163,7 @@ public:
   /// taken into account.
   ///
   /// \sa getFormalAccessScope
-  Accessibility getFormalAccess(const DeclContext *useDC = nullptr) const {
-    assert(hasAccessibility() && "accessibility not computed yet");
-    Accessibility result = TypeAndAccess.getInt().getValue();
-    if (useDC && (result == Accessibility::Internal ||
-                  result == Accessibility::Public))
-      return getFormalAccessImpl(useDC);
-    return result;
-  }
+  Accessibility getFormalAccess(const DeclContext *useDC = nullptr) const;
 
   /// Returns the outermost DeclContext from which this declaration can be
   /// accessed, or null if the declaration is public.

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2201,14 +2201,6 @@ public:
 
   /// Returns true if this declaration is accessible from the given context.
   ///
-  /// A private declaration is accessible from any DeclContext within the same
-  /// source file.
-  ///
-  /// An internal declaration is accessible from any DeclContext within the same
-  /// module.
-  ///
-  /// A public declaration is accessible everywhere.
-  ///
   /// If \p DC is null, returns true only if this declaration is public.
   bool isAccessibleFrom(const DeclContext *DC) const;
 

--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -19,6 +19,7 @@
 #ifndef SWIFT_DECLCONTEXT_H
 #define SWIFT_DECLCONTEXT_H
 
+#include "swift/AST/AttrKind.h"
 #include "swift/AST/Identifier.h"
 #include "swift/AST/LookupKinds.h"
 #include "swift/AST/ResilienceExpansion.h"
@@ -35,6 +36,7 @@ namespace llvm {
 
 namespace swift {
   class AbstractFunctionDecl;
+  class AccessScope;
   class GenericEnvironment;
   class ASTContext;
   class ASTWalker;
@@ -373,6 +375,27 @@ public:
         return true;
     return false;
   }
+
+  /// Return true if this context is an accessible child of the specified
+  /// \p Other decl context. This will perform an isChildContextOf check, and
+  /// when not in Swift 3 mode, the private scope is extended to include
+  /// declarations and extensions in the same file.
+  ///
+  /// \sa isChildContextOf
+  bool isAccessibleChildOf(const DeclContext *Other) const;
+
+  /// Returns the AccessScope from which the first declaration can be accessed.
+  ///
+  /// If \p useDC is provided (the location where the value is being used),
+  /// features that affect formal access such as \c \@testable are
+  /// taken into account.
+  ///
+  /// \p accessibility specifies the starting access level.
+  /// \p useNominalTypeAccessibility specifies if the nominal type associated
+  /// with extensions should alter the access scope.
+  AccessScope getAccessScope(const DeclContext *useDC,
+                             Accessibility accessibility,
+                             bool useNominalTypeAccessibility = true) const;
 
   /// Returns the module context that contains this context.
   ModuleDecl *getParentModule() const;

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1952,15 +1952,15 @@ Accessibility ValueDecl::getEffectiveAccess() const {
   return effectiveAccess;
 }
 
-Accessibility ValueDecl::getFormalAccessImpl(const DeclContext *useDC) const {
-  assert((getFormalAccess() == Accessibility::Internal ||
-          getFormalAccess() == Accessibility::Public) &&
-         "should be able to fast-path non-internal cases");
-  assert(useDC && "should fast-path non-scoped cases");
-  if (auto *useSF = dyn_cast<SourceFile>(useDC->getModuleScopeContext()))
-    if (useSF->hasTestableImport(getModuleContext()))
-      return getTestableAccess(this);
-  return getFormalAccess();
+Accessibility ValueDecl::getFormalAccess(const DeclContext *useDC) const {
+  assert(hasAccessibility() && "accessibility not computed yet");
+  Accessibility result = TypeAndAccess.getInt().getValue();
+  if (useDC && (result == Accessibility::Internal ||
+                result == Accessibility::Public))
+    if (auto *useSF = dyn_cast<SourceFile>(useDC->getModuleScopeContext()))
+      if (useSF->hasTestableImport(getModuleContext()))
+        return getTestableAccess(this);
+  return result;
 }
 
 AccessScope ValueDecl::getFormalAccessScope(const DeclContext *useDC) const {

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -1000,7 +1000,7 @@ Accessibility AccessScope::accessibilityForDiagnostics() const {
   return Accessibility::Private;
 }
 
-bool AccessScope::allowsPrivateAccess(const DeclContext *useDC, const DeclContext *sourceDC) {
+bool AccessScope::allowsAccess(const DeclContext *useDC, const DeclContext *sourceDC) {
   // Check the lexical scope.
   if (useDC->isChildContextOf(sourceDC))
     return true;

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -975,7 +975,7 @@ getPrivateDeclContext(const DeclContext *DC, const SourceFile *useSF) {
 
 AccessScope::AccessScope(const DeclContext *DC, bool isPrivate)
     : Value(DC, isPrivate) {
-  if (isPrivate) {
+  if (isPrivate && !DC->getASTContext().isSwiftVersion3()) {
     DC = getPrivateDeclContext(DC, DC->getParentSourceFile());
     Value.setPointer(DC);
   }

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1263,7 +1263,7 @@ static bool checkAccessibility(const DeclContext *useDC,
   switch (access) {
   case Accessibility::Private:
     return (useDC == sourceDC ||
-      AccessScope::allowsPrivateAccess(useDC, sourceDC));
+            AccessScope::allowsAccess(useDC, sourceDC));
   case Accessibility::FilePrivate:
     return useDC->getModuleScopeContext() == sourceDC->getModuleScopeContext();
   case Accessibility::Internal: {

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -6575,26 +6575,7 @@ public:
       TC.computeDefaultAccessibility(ED);
       if (auto *AA = ED->getAttrs().getAttribute<AccessibilityAttr>()) {
         const auto access = AA->getAccess();
-        AccessScope desiredAccessScope = AccessScope::getPublic();
-        switch (access) {
-        case Accessibility::Private:
-          assert((ED->isInvalid() ||
-                  ED->getDeclContext()->isModuleScopeContext()) &&
-                 "non-top-level extensions make 'private' != 'fileprivate'");
-          LLVM_FALLTHROUGH;
-        case Accessibility::FilePrivate: {
-          const DeclContext *DC = ED->getModuleScopeContext();
-          bool isPrivate = access == Accessibility::Private;
-          desiredAccessScope = AccessScope(DC, isPrivate);
-          break;
-        }
-        case Accessibility::Internal:
-          desiredAccessScope = AccessScope(ED->getModuleContext());
-          break;
-        case Accessibility::Public:
-        case Accessibility::Open:
-          break;
-        }
+        AccessScope desiredAccessScope = ED->getAccessScope(nullptr, access);
         checkGenericParamAccessibility(TC, ED->getGenericParams(), ED,
                                        desiredAccessScope, access);
       }

--- a/test/Sema/accessibility_private.swift
+++ b/test/Sema/accessibility_private.swift
@@ -69,7 +69,6 @@ extension Container {
     _ = Container.PrivateInner()
   }
 
-  // FIXME: Why do these errors happen twice?
   var extensionInner: PrivateInner? { return nil } // expected-error {{property must be declared private because its type uses a private type}}
   var extensionInnerQualified: Container.PrivateInner? { return nil } // expected-error {{property must be declared private because its type uses a private type}}
 }


### PR DESCRIPTION
This PR addresses some of the feedback from #9098:
- Add SE-0169 to the changelog
- Update old Comments
- Test SE-0169 behavior in single file and WMO mode
- Move `checkAccessibility` to use AccessScopes

The last change of `checkAccessibility` was a bit more of a change than I was hoping for. It turns out that the method for determining the AccessScope is a bit different than what checkAccessibility was doing. Basically `getFormalAccessScope` restricts visibility by the access of the extension's type, and  `checkAccessibility` does not want to do that when performing some protocol conformance checks. I added a `useNominalTypeAccessibility` flag to make the AccessScope creation work in both cases. If this change turns out to be a bad idea, I'm glad to split the commit and keep any of the style changes (`allowsAccess` -> `isAccessibleChildOf`) and revert `checkAccessibility` back to it's original form.

 