### PR TITLE
[stdlib] Backward compatibility fix for a flatMap on [String]

### DIFF
--- a/stdlib/public/core/SequenceAlgorithms.swift.gyb
+++ b/stdlib/public/core/SequenceAlgorithms.swift.gyb
@@ -721,6 +721,16 @@ extension Sequence {
   public func flatMap<ElementOfResult>(
     _ transform: (${GElement}) throws -> ElementOfResult?
   ) rethrows -> [ElementOfResult] {
+    return try _flatMap(transform)
+  }
+
+  // The implementation of flatMap accepting a closure with an optional result.
+  // Factored out into a separate functions in order to be used in multiple
+  // overloads.
+  @inline(__always)
+  public func _flatMap<ElementOfResult>(
+    _ transform: (${GElement}) throws -> ElementOfResult?
+  ) rethrows -> [ElementOfResult] {
     var result: [ElementOfResult] = []
     for element in self {
       if let newElement = try transform(element) {

--- a/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
+++ b/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
@@ -383,10 +383,18 @@ extension String {
   }
 }
 
-extension Sequence where Iterator.Element == String {
-  // This overload is only here to make code like:
-  //   ["hello"].flatMap { $0 }
-  // return an array of strings without any type context in Swift 3 mode.
+//===----------------------------------------------------------------------===//
+// The following overloads of flatMap are carefully crafted to allow the code
+// like the following:
+//   ["hello"].flatMap { $0 }
+// return an array of strings without any type context in Swift 3 mode, at the
+// same time allowing the following code snippet to compile:
+//   [0, 1].flatMap { x in
+//     if String(x) == "foo" { return "bar" } else { return nil }
+//   }
+// Note that the second overload is delcared on a more specific protocol.
+// See: test/stdlib/StringFlatMap.swift for tests.
+extension Sequence {
   @available(swift, obsoleted: 4)
   public func flatMap(
     _ transform: (Iterator.Element) throws -> String
@@ -394,6 +402,15 @@ extension Sequence where Iterator.Element == String {
     return try map(transform)
   }
 }
+
+extension Collection {
+  public func flatMap(
+    _ transform: (Iterator.Element) throws -> String?
+  ) rethrows -> [String] {
+    return try _flatMap(transform)
+  }
+}
+//===----------------------------------------------------------------------===//
 
 extension String {
   @available(*, unavailable, message: "Operator '+' cannot be used to append a String to a sequence of strings")

--- a/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
+++ b/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
@@ -383,6 +383,18 @@ extension String {
   }
 }
 
+extension Sequence where Iterator.Element == String {
+  // This overload is only here to make code like:
+  //   ["hello"].flatMap { $0 }
+  // return an array of strings without any type context in Swift 3 mode.
+  @available(swift, obsoleted: 4)
+  public func flatMap(
+    _ transform: (Iterator.Element) throws -> String
+  ) rethrows -> [String] {
+    return try map(transform)
+  }
+}
+
 extension String {
   @available(*, unavailable, message: "Operator '+' cannot be used to append a String to a sequence of strings")
   public static func + <S : Sequence>(lhs: S, rhs: String) -> Never

--- a/test/stdlib/StringFlatMap.swift
+++ b/test/stdlib/StringFlatMap.swift
@@ -1,0 +1,32 @@
+// RUN: rm -rf %t ; mkdir -p %t
+// RUN: %target-build-swift %s -o %t/a.out3 -swift-version 3 && %target-run %t/a.out3
+// RUN: %target-build-swift %s -o %t/a.out4 -swift-version 4 && %target-run %t/a.out4
+
+import StdlibUnittest
+
+#if swift(>=4)
+
+public typealias ExpectedResultType = [Character]
+
+#else
+
+public typealias ExpectedResultType = [String]
+
+#endif
+
+var Tests = TestSuite("StringFlatMap")
+
+Tests.test("DefaultReturnType") {
+  var result = ["hello", "world"].flatMap { $0 }
+  expectType(ExpectedResultType.self, &result)
+}
+
+Tests.test("ExplicitTypeContext") {
+  expectEqualSequence(["hello", "world"],
+    ["hello", "world"].flatMap { $0 } as [String])
+  expectEqualSequence("helloworld".characters,
+    ["hello", "world"].flatMap { $0 } as [Character])
+}
+
+
+runAllTests()

--- a/test/stdlib/StringFlatMap.swift
+++ b/test/stdlib/StringFlatMap.swift
@@ -28,5 +28,15 @@ Tests.test("ExplicitTypeContext") {
     ["hello", "world"].flatMap { $0 } as [Character])
 }
 
+Tests.test("inference") {
+  let result = [1, 2].flatMap { x in
+    if String(x) == "foo" {
+      return "bar"
+    } else {
+      return nil
+    }
+  }
+  expectEqualSequence([], result)
+}
 
 runAllTests()


### PR DESCRIPTION
Since `String` started to conform to `Collection`, the `flatMap` with a
sequence returning closure is now a better match than the one that
relies on the optional promotion in this code:

```swift
[""].flatMap { $0 }
```

which results in the default type of this expression changing from
`[String]` to `[Character]`.

Restoring the old behavior in Swift 3 mode by adding a very explicit
overload.

Fixes: <rdar://problem/32024978>