### PR TITLE
[CodeCompletion] Provide basic code completion support for Swift KeyPath. rdar://31768743

### DIFF
--- a/include/swift/IDE/CodeCompletion.h
+++ b/include/swift/IDE/CodeCompletion.h
@@ -503,6 +503,7 @@ enum class CompletionKind {
   ReturnStmtExpr,
   AfterPound,
   GenericParams,
+  SwiftKeyPath,
 };
 
 /// \brief A single code completion result.

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -132,6 +132,7 @@ public:
   bool InPoundIfEnvironment = false;
   bool InSwiftKeyPath = false;
   Expr* SwiftKeyPathRoot = nullptr;
+  SourceLoc SwiftKeyPathSlashLoc = SourceLoc();
 
   LocalContext *CurLocalContext = nullptr;
 

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -131,6 +131,7 @@ public:
   bool InPoundLineEnvironment = false;
   bool InPoundIfEnvironment = false;
   bool InSwiftKeyPath = false;
+  Expr* SwiftKeyPathRoot = nullptr;
 
   LocalContext *CurLocalContext = nullptr;
 

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -5155,8 +5155,13 @@ void CodeCompletionCallbacksImpl::doneParsing() {
   case CompletionKind::SwiftKeyPath: {
     Lookup.setHaveDot(DotLoc);
     Lookup.setIsSwiftKeyPathExpr();
-    Lookup.getValueExprCompletions((*ExprType)->getAs<BoundGenericType>()->
-      getGenericArgs()[1]);
+    if (auto BGT = (*ExprType)->getAs<BoundGenericType>()) {
+      if (BGT->getGenericArgs().size() == 2) {
+        // The second generic type argument of KeyPath<Root, Value> should be
+        // the value we pull code completion results from.
+        Lookup.getValueExprCompletions(BGT->getGenericArgs()[1]);
+      }
+    }
     break;
   }
 

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -5156,10 +5156,11 @@ void CodeCompletionCallbacksImpl::doneParsing() {
     Lookup.setHaveDot(DotLoc);
     Lookup.setIsSwiftKeyPathExpr();
     if (auto BGT = (*ExprType)->getAs<BoundGenericType>()) {
-      if (BGT->getGenericArgs().size() == 2) {
+      auto AllArgs = BGT->getGenericArgs();
+      if (AllArgs.size() == 2) {
         // The second generic type argument of KeyPath<Root, Value> should be
         // the value we pull code completion results from.
-        Lookup.getValueExprCompletions(BGT->getGenericArgs()[1]);
+        Lookup.getValueExprCompletions(AllArgs[1]);
       }
     }
     break;

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -320,7 +320,6 @@ static bool KeyPathFilter(ValueDecl* decl, DeclVisibilityKind) {
 
 static bool SwiftKeyPathFilter(ValueDecl* decl, DeclVisibilityKind) {
   switch(decl->getKind()){
-  case DeclKind::Subscript:
   case DeclKind::Var:
     return true;
   default:

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1140,14 +1140,15 @@ Parser::parseExprPostfixSuffix(ParserResult<Expr> Result, bool isExprBasic,
       // Handle "x.<tab>" for code completion.
       if (Tok.is(tok::code_complete)) {
         if (CodeCompletion && Result.isNonNull()) {
-          if (InSwiftKeyPath)
+          if (InSwiftKeyPath) {
             Result = makeParserResult(
               new (Context) KeyPathExpr(SwiftKeyPathSlashLoc, Result.get(),
                                         nullptr));
-          else if (SwiftKeyPathRoot)
+          } else if (SwiftKeyPathRoot) {
             Result = makeParserResult(
               new (Context) KeyPathExpr(SwiftKeyPathSlashLoc, SwiftKeyPathRoot,
                                         Result.get()));
+          }
           CodeCompletion->completeDotExpr(Result.get(), /*DotLoc=*/TokLoc);
         }
         // Eat the code completion token because we handled it.

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -539,7 +539,7 @@ ParserResult<Expr> Parser::parseExprKeyPath() {
   }
 
   if (startsWithSymbol(Tok, '.')) {
-    llvm::SaveAndRestore<Expr*> S(SwiftKeyPathRoot, rootResult.get());
+    llvm::SaveAndRestore<Expr*> S(SwiftKeyPathRoot, rootResult.getPtrOrNull());
 
     // For uniformity, \.foo is parsed as if it were MAGIC.foo, so we need to
     // make sure the . is there, but parsing the ? in \.? as .? doesn't make

--- a/test/IDE/complete_swift_key_path.swift
+++ b/test/IDE/complete_swift_key_path.swift
@@ -24,6 +24,8 @@ class Person {
 let keyPath1 = \Person.#^PART_1^#
 let keyPath2 = \Person.friends[0].#^PART_2^#
 let keyPath3 = \Person.friends[0].friends[0].friends[0].#^PART_3^#
+
+// FIXME: the optionality keypath should work after our compiler is ready.
 let keyPath4 = \Person.bestFriend?.#^PART_4^#
 let keyPath5 = \Person.friends.[0].friends[0].friends[0].#^PART_5^#
 let keyPath6 = \[Person].[0].#^PART_6^#

--- a/test/IDE/complete_swift_key_path.swift
+++ b/test/IDE/complete_swift_key_path.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PART_1 | %FileCheck %s -check-prefix=PERSON-MEMBER
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PART_2 | %FileCheck %s -check-prefix=PERSON-MEMBER
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PART_3 | %FileCheck %s -check-prefix=PERSON-MEMBER
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PART_4 | %FileCheck %s -check-prefix=PERSON-MEMBER-OPT
+
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PART_5 | %FileCheck %s -check-prefix=PERSON-MEMBER
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PART_6 | %FileCheck %s -check-prefix=PERSON-MEMBER
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PART_7 | %FileCheck %s -check-prefix=PERSON-MEMBER
@@ -41,9 +41,3 @@ func foo1(_ p : Person) {
 // PERSON-MEMBER-NEXT: Decl[InstanceVar]/CurrNominal:      friends[#[Person]#]; name=friends
 // PERSON-MEMBER-NEXT: Decl[InstanceVar]/CurrNominal:      bestFriend[#Person?#]; name=bestFriend 
 // PERSON-MEMBER-NEXT: Decl[Subscript]/CurrNominal:        [{#Int#}][#Int#]; name=[Int]
-
-// PERSON-MEMBER-OPT: Begin completions, 7 items
-// PERSON-MEMBER-OPT-NEXT: Decl[InstanceVar]/CurrNominal/Erase[1]: ?.name[#String#]; name=name
-// PERSON-MEMBER-OPT-NEXT: Decl[InstanceVar]/CurrNominal/Erase[1]: ?.friends[#[Person]#]; name=friends
-// PERSON-MEMBER-OPT-NEXT: Decl[InstanceVar]/CurrNominal/Erase[1]: ?.bestFriend[#Person?#]; name=bestFriend
-// PERSON-MEMBER-OPT-NEXT: Decl[Subscript]/CurrNominal:        [{#Int#}][#Int#]; name=[Int]

--- a/test/IDE/complete_swift_key_path.swift
+++ b/test/IDE/complete_swift_key_path.swift
@@ -5,6 +5,10 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PART_5 | %FileCheck %s -check-prefix=PERSON-MEMBER
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PART_6 | %FileCheck %s -check-prefix=PERSON-MEMBER
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PART_7 | %FileCheck %s -check-prefix=PERSON-MEMBER
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PART_8 | %FileCheck %s -check-prefix=PERSON-MEMBER
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PART_9 | %FileCheck %s -check-prefix=PERSON-MEMBER
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PART_10 | %FileCheck %s -check-prefix=PERSON-MEMBER
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PART_11 | %FileCheck %s -check-prefix=PERSON-MEMBER
 
 class Person {
     var name: String
@@ -14,6 +18,7 @@ class Person {
         self.name = name
     }
     func getName() -> String { return name }
+    subscript(_ index: Int) -> Int { get { return 1} }
 }
 
 let keyPath1 = \Person.#^PART_1^#
@@ -24,12 +29,21 @@ let keyPath5 = \Person.friends.[0].friends[0].friends[0].#^PART_5^#
 let keyPath6 = \[Person].[0].#^PART_6^#
 let keyPath7 = \[Person].[0].friends[0].#^PART_7^#
 
-// PERSON-MEMBER: Begin completions, 3 items
+func foo1(_ p : Person) {
+  _ = p[keyPath:\Person.#^PART_8^#]
+  _ = p[keyPath:\Person.friends[0].#^PART_9^#]
+  _ = p[keyPath:\[Person].[0].#^PART_10^#]
+  _ = p[keyPath:\Person.friends.[0].friends[0].friends[0].#^PART_11^#]
+}
+
+// PERSON-MEMBER: Begin completions, 4 items
 // PERSON-MEMBER-NEXT: Decl[InstanceVar]/CurrNominal:      name[#String#]; name=name
 // PERSON-MEMBER-NEXT: Decl[InstanceVar]/CurrNominal:      friends[#[Person]#]; name=friends
 // PERSON-MEMBER-NEXT: Decl[InstanceVar]/CurrNominal:      bestFriend[#Person?#]; name=bestFriend 
+// PERSON-MEMBER-NEXT: Decl[Subscript]/CurrNominal:        [{#Int#}][#Int#]; name=[Int]
 
-// PERSON-MEMBER-OPT: Begin completions, 6 items
+// PERSON-MEMBER-OPT: Begin completions, 7 items
 // PERSON-MEMBER-OPT-NEXT: Decl[InstanceVar]/CurrNominal/Erase[1]: ?.name[#String#]; name=name
 // PERSON-MEMBER-OPT-NEXT: Decl[InstanceVar]/CurrNominal/Erase[1]: ?.friends[#[Person]#]; name=friends
 // PERSON-MEMBER-OPT-NEXT: Decl[InstanceVar]/CurrNominal/Erase[1]: ?.bestFriend[#Person?#]; name=bestFriend
+// PERSON-MEMBER-OPT-NEXT: Decl[Subscript]/CurrNominal:        [{#Int#}][#Int#]; name=[Int]

--- a/test/IDE/complete_swift_key_path.swift
+++ b/test/IDE/complete_swift_key_path.swift
@@ -1,0 +1,33 @@
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PART_1 | %FileCheck %s -check-prefix=PERSON-MEMBER
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PART_2 | %FileCheck %s -check-prefix=PERSON-MEMBER
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PART_3 | %FileCheck %s -check-prefix=PERSON-MEMBER
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PART_4 | %FileCheck %s -check-prefix=PERSON-MEMBER-OPT
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PART_5 | %FileCheck %s -check-prefix=PERSON-MEMBER
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PART_6 | %FileCheck %s -check-prefix=PERSON-MEMBER
+
+class Person {
+    var name: String
+    var friends: [Person] = []
+    var bestFriend: Person? = nil
+    init(name: String) {
+        self.name = name
+    }
+    func getName() -> String { return name }
+}
+
+let keyPath1 = \Person.#^PART_1^#
+let keyPath2 = \Person.friends[0].#^PART_2^#
+let keyPath3 = \Person.friends[0].friends[0].friends[0].#^PART_3^#
+let keyPath4 = \Person.bestFriend?.#^PART_4^#
+let keyPath5 = \Person.friends.[0].friends[0].friends[0].#^PART_5^#
+let keyPath6 = \Person.friends.[0].friends.[0].friends.[0].#^PART_6^#
+
+// PERSON-MEMBER: Begin completions, 3 items
+// PERSON-MEMBER-NEXT: Decl[InstanceVar]/CurrNominal:      name[#String#]; name=name
+// PERSON-MEMBER-NEXT: Decl[InstanceVar]/CurrNominal:      friends[#[Person]#]; name=friends
+// PERSON-MEMBER-NEXT: Decl[InstanceVar]/CurrNominal:      bestFriend[#Person?#]; name=bestFriend 
+
+// PERSON-MEMBER-OPT: Begin completions, 6 items
+// PERSON-MEMBER-OPT-NEXT: Decl[InstanceVar]/CurrNominal/Erase[1]: ?.name[#String#]; name=name
+// PERSON-MEMBER-OPT-NEXT: Decl[InstanceVar]/CurrNominal/Erase[1]: ?.friends[#[Person]#]; name=friends
+// PERSON-MEMBER-OPT-NEXT: Decl[InstanceVar]/CurrNominal/Erase[1]: ?.bestFriend[#Person?#]; name=bestFriend

--- a/test/IDE/complete_swift_key_path.swift
+++ b/test/IDE/complete_swift_key_path.swift
@@ -4,6 +4,7 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PART_4 | %FileCheck %s -check-prefix=PERSON-MEMBER-OPT
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PART_5 | %FileCheck %s -check-prefix=PERSON-MEMBER
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PART_6 | %FileCheck %s -check-prefix=PERSON-MEMBER
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PART_7 | %FileCheck %s -check-prefix=PERSON-MEMBER
 
 class Person {
     var name: String
@@ -20,7 +21,8 @@ let keyPath2 = \Person.friends[0].#^PART_2^#
 let keyPath3 = \Person.friends[0].friends[0].friends[0].#^PART_3^#
 let keyPath4 = \Person.bestFriend?.#^PART_4^#
 let keyPath5 = \Person.friends.[0].friends[0].friends[0].#^PART_5^#
-let keyPath6 = \Person.friends.[0].friends.[0].friends.[0].#^PART_6^#
+let keyPath6 = \[Person].[0].#^PART_6^#
+let keyPath7 = \[Person].[0].friends[0].#^PART_7^#
 
 // PERSON-MEMBER: Begin completions, 3 items
 // PERSON-MEMBER-NEXT: Decl[InstanceVar]/CurrNominal:      name[#String#]; name=name


### PR DESCRIPTION
This patch starts libIDE support for code completing keyPath expression; after each `.` in key path component, code completion provides type-sensitive member properties and subscripts. This patch doesn't implement code completion for contextual-inferred keyPath root type like `\.property.[0]`.