### PR TITLE
[4.0] Treat irrefutable casts as irrefutable patterns.

### DIFF
--- a/lib/Sema/TypeCheckSwitchStmt.cpp
+++ b/lib/Sema/TypeCheckSwitchStmt.cpp
@@ -1071,8 +1071,25 @@ namespace {
         auto *BP = cast<BoolPattern>(item);
         return Space(BP->getValue());
       }
+      case PatternKind::Is: {
+        auto *IP = cast<IsPattern>(item);
+        switch (IP->getCastKind()) {
+        case CheckedCastKind::Coercion:
+        case CheckedCastKind::BridgingCoercion:
+          // These coercions are irrefutable.  Project with the original type
+          // instead of the cast's target type to maintain consistency with the
+          // scrutinee's type.
+          return Space(IP->getType());
+        case CheckedCastKind::Unresolved:
+        case CheckedCastKind::ValueCast:
+        case CheckedCastKind::ArrayDowncast:
+        case CheckedCastKind::DictionaryDowncast:
+        case CheckedCastKind::SetDowncast:
+        case CheckedCastKind::Swift3BridgingDowncast:
+            return Space();
+        }
+      }
       case PatternKind::Typed:
-      case PatternKind::Is:
       case PatternKind::Expr:
         return Space();
       case PatternKind::Var: {

--- a/lib/Sema/TypeCheckSwitchStmt.cpp
+++ b/lib/Sema/TypeCheckSwitchStmt.cpp
@@ -251,8 +251,23 @@ namespace {
 
           // Special Case: A constructor pattern may include the head but not
           // the payload patterns.  In that case the space is covered.
+          // This also acts to short-circuit comparisons with payload-less
+          // constructors.
           if (other.getSpaces().empty()) {
             return true;
+          }
+
+          // If 'this' constructor pattern has no payload and the other space
+          // does, then 'this' covers more of the space only if the other
+          // constructor isn't the explicit form.
+          //
+          // .case <= .case(_, _, _, ...)
+          if (this->getSpaces().empty()) {
+            return std::accumulate(other.getSpaces().begin(),
+                                   other.getSpaces().end(),
+                                   true, [](bool acc, const Space sp){
+              return acc && sp.getKind() == SpaceKind::Type;
+            });
           }
 
           // H(a1, ..., an) <= H(b1, ..., bn) iff a1 <= b1 && ... && an <= bn

--- a/test/Sema/exhaustive_switch.swift
+++ b/test/Sema/exhaustive_switch.swift
@@ -1,4 +1,5 @@
 // RUN: %target-typecheck-verify-swift
+
 func foo(a: Int?, b: Int?) -> Int {
   switch (a, b) {
   case (.none, _): return 1
@@ -284,5 +285,27 @@ func switcheroo(a: XX, b: XX) -> Int {
   default:
     print("never hits this:", a, b)
     return 13
+  }
+}
+
+enum PatternCasts {
+  case one(Any)
+  case two
+}
+
+func checkPatternCasts() {
+  // Pattern casts with this structure shouldn't warn about duplicate cases.
+  let x: PatternCasts = .one("One")
+  switch x {
+  case .one(let s as String): print(s)
+  case .one: break
+  case .two: break
+  }
+
+  // But should warn here.
+  switch x {
+  case .one(_): print(s)
+  case .one: break // expected-warning {{case is already handled by previous patterns; consider removing it}}
+  case .two: break
   }
 }

--- a/test/Sema/exhaustive_switch_objc.swift
+++ b/test/Sema/exhaustive_switch_objc.swift
@@ -1,0 +1,23 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify %s
+// REQUIRES: objc_interop
+
+import Foundation
+
+// Treat irrefutable casts as irrefutable patterns.
+enum Castbah {
+  case shareef(NSInteger)
+  case dont(NSString)
+  case like(Int)
+  case it(Error)
+}
+
+func rock(the c : Castbah) {
+  switch (c, c, c) {
+  case (.shareef(let rock as NSObject), .dont(let the as String), .like(let castbah as Any)):
+    print(rock, the, castbah)
+  case (.it(let e as NSError), _, _):
+    print(e)
+  case let obj as Any:
+    print(obj)
+  }
+}

--- a/test/stmt/statements.swift
+++ b/test/stmt/statements.swift
@@ -384,7 +384,8 @@ func test_is_as_patterns() {
   switch 4 {
   case is Int: break        // expected-warning {{'is' test is always true}}
   case _ as Int: break  // expected-warning {{'as' test is always true}}
-  case _: break
+  // expected-warning@-1 {{case is already handled by previous patterns; consider removing it}}
+  case _: break // expected-warning {{case is already handled by previous patterns; consider removing it}}
   }
 }
 


### PR DESCRIPTION
Explanation: Treat irrefutable casts as irrefutable patterns
Scope: Limited.  Silences what were spurious warnings.
Radar/SR: Reported 
Risk: Low
Testing: Regression tests included in patch

This is a cherry-pick of #9449 and #9464.
