### PR TITLE
[Exclusivity] Disable dynamic enforcement in noescape closures.

### DIFF
--- a/lib/SILOptimizer/Mandatory/AccessEnforcementSelection.cpp
+++ b/lib/SILOptimizer/Mandatory/AccessEnforcementSelection.cpp
@@ -375,7 +375,7 @@ struct AccessEnforcementSelection : SILFunctionTransform {
         // escape within the callee, so static enforcement is always sufficient.
         //
         // FIXME: `inout_aliasable` are not currently enforced on the caller
-        // side. Consequenctly, using static enforcement for noescape closures
+        // side. Consequently, using static enforcement for noescape closures
         // may fails to diagnose certain violations.
         setStaticEnforcement(access);
         break;

--- a/test/Interpreter/enforce_exclusive_access.swift
+++ b/test/Interpreter/enforce_exclusive_access.swift
@@ -101,47 +101,62 @@ ExclusiveAccessTestSuite.test("ModifyFollowedByModify") {
   globalX = X() // no-trap
 }
 
-ExclusiveAccessTestSuite.test("ClosureCaptureModifyModify")
-.skip(.custom(
-    { _isFastAssertConfiguration() },
-    reason: "this trap is not guaranteed to happen in -Ounchecked"))
-  .crashOutputMatches("modify/modify access conflict detected on address")
-  .code
-{
-  var x = X()
-  modifyAndPerform(&x) {
-    expectCrashLater()
-    x.i = 12
-  }
-}
+// FIXME: This should be a static diagnostics.
+// Once this radar is fixed, conirm that a it is covered by a static diagnostic
+// (-verify) test in exclusivity_static_diagnostics.sil.
+// <rdar://problem/32061282> Enforce exclusive access in noescape closures.
+//
+//ExclusiveAccessTestSuite.test("ClosureCaptureModifyModify")
+//.skip(.custom(
+//    { _isFastAssertConfiguration() },
+//    reason: "this trap is not guaranteed to happen in -Ounchecked"))
+//  .crashOutputMatches("modify/modify access conflict detected on address")
+//  .code
+//{
+//  var x = X()
+//  modifyAndPerform(&x) {
+//    expectCrashLater()
+//    x.i = 12
+//  }
+//}
 
-ExclusiveAccessTestSuite.test("ClosureCaptureReadModify")
-.skip(.custom(
-    { _isFastAssertConfiguration() },
-    reason: "this trap is not guaranteed to happen in -Ounchecked"))
-  .crashOutputMatches("read/modify access conflict detected on address")
-  .code
-{
-  var x = X()
-  modifyAndPerform(&x) {
-    expectCrashLater()
-    _blackHole(x.i)
-  }
-}
+// FIXME: This should be a static diagnostics.
+// Once this radar is fixed, conirm that a it is covered by a static diagnostic
+// (-verify) test in exclusivity_static_diagnostics.sil.
+// <rdar://problem/32061282> Enforce exclusive access in noescape closures.
+//
+//ExclusiveAccessTestSuite.test("ClosureCaptureReadModify")
+//.skip(.custom(
+//    { _isFastAssertConfiguration() },
+//    reason: "this trap is not guaranteed to happen in -Ounchecked"))
+//  .crashOutputMatches("read/modify access conflict detected on address")
+//  .code
+//{
+//  var x = X()
+//  modifyAndPerform(&x) {
+//    expectCrashLater()
+//    _blackHole(x.i)
+//  }
+//}
 
-ExclusiveAccessTestSuite.test("ClosureCaptureModifyRead")
-.skip(.custom(
-    { _isFastAssertConfiguration() },
-    reason: "this trap is not guaranteed to happen in -Ounchecked"))
-  .crashOutputMatches("modify/read access conflict detected on address")
-  .code
-{
-  var x = X()
-  readAndPerform(&x) {
-    expectCrashLater()
-    x.i = 12
-  }
-}
+// FIXME: This should be a static diagnostics.
+// Once this radar is fixed, conirm that a it is covered by a static diagnostic
+// (-verify) test in exclusivity_static_diagnostics.sil.
+// <rdar://problem/32061282> Enforce exclusive access in noescape closures.
+//
+//ExclusiveAccessTestSuite.test("ClosureCaptureModifyRead")
+//.skip(.custom(
+//    { _isFastAssertConfiguration() },
+//    reason: "this trap is not guaranteed to happen in -Ounchecked"))
+//  .crashOutputMatches("modify/read access conflict detected on address")
+//  .code
+//{
+//  var x = X()
+//  readAndPerform(&x) {
+//    expectCrashLater()
+//    x.i = 12
+//  }
+//}
 
 ExclusiveAccessTestSuite.test("ClosureCaptureReadRead") {
   var x = X()

--- a/test/Interpreter/enforce_exclusive_access.swift
+++ b/test/Interpreter/enforce_exclusive_access.swift
@@ -101,8 +101,8 @@ ExclusiveAccessTestSuite.test("ModifyFollowedByModify") {
   globalX = X() // no-trap
 }
 
-// FIXME: This should be a static diagnostics.
-// Once this radar is fixed, conirm that a it is covered by a static diagnostic
+// FIXME: This should be covered by static diagnostics.
+// Once this radar is fixed, confirm that a it is covered by a static diagnostic
 // (-verify) test in exclusivity_static_diagnostics.sil.
 // <rdar://problem/32061282> Enforce exclusive access in noescape closures.
 //
@@ -120,8 +120,8 @@ ExclusiveAccessTestSuite.test("ModifyFollowedByModify") {
 //  }
 //}
 
-// FIXME: This should be a static diagnostics.
-// Once this radar is fixed, conirm that a it is covered by a static diagnostic
+// FIXME: This should be covered by static diagnostics.
+// Once this radar is fixed, confirm that a it is covered by a static diagnostic
 // (-verify) test in exclusivity_static_diagnostics.sil.
 // <rdar://problem/32061282> Enforce exclusive access in noescape closures.
 //
@@ -139,8 +139,8 @@ ExclusiveAccessTestSuite.test("ModifyFollowedByModify") {
 //  }
 //}
 
-// FIXME: This should be a static diagnostics.
-// Once this radar is fixed, conirm that a it is covered by a static diagnostic
+// FIXME: This should be covered by static diagnostics.
+// Once this radar is fixed, confirm that a it is covered by a static diagnostic
 // (-verify) test in exclusivity_static_diagnostics.sil.
 // <rdar://problem/32061282> Enforce exclusive access in noescape closures.
 //

--- a/test/SILOptimizer/access_enforcement_noescape.swift
+++ b/test/SILOptimizer/access_enforcement_noescape.swift
@@ -1,0 +1,536 @@
+// RUN: %target-swift-frontend -enforce-exclusivity=checked -Onone -emit-sil -parse-as-library %s | %FileCheck %s
+// REQUIRES: asserts
+
+// This tests SILGen and AccessEnforcementSelection as a single set of tests.
+// (Some static/dynamic enforcement selection is done in SILGen, and some is
+// deferred. That may change over time but we want the outcome to be the same).
+//
+// Each FIXME me line is a case that the current implementation misses.
+// The model is currently being refined, so this isn't set in stone.
+//
+// TODO: Ensure that each of these cases is covered by
+// Interpreter/enforce_exclusive_access.swift.
+
+// Helper
+func doOne(_ f: () -> ()) {
+  f()
+}
+
+// Helper
+func doTwo(_: ()->(), _: ()->()) {}
+
+// Helper
+func doOneInout(_: ()->(), _: inout Int) {}
+
+// Helper
+struct Frob {
+  mutating func outerMut() { doOne { innerMut() } }
+  mutating func innerMut() {}
+}
+
+// FIXME: statically prohibit a call to a non-escaping closure
+// parameter using another non-escaping closure parameter as an argument.
+func reentrantNoescape(fn: (() -> ()) -> ()) {
+  fn { fn {} }
+}
+
+// Error: Cannot capture nonescaping closure.
+// func reentrantCapturedNoescape(fn: (() -> ()) -> ()) {
+//   let c = { fn {} }
+//   fn(c)
+// }
+
+// Allow nested mutable access via closures.
+func nestedNoEscape(f: inout Frob) {
+  doOne { f.outerMut() }
+}
+// CHECK-LABEL: sil hidden @_T027access_enforcement_noescape14nestedNoEscapeyAA4FrobVz1f_tF : $@convention(thin) (@inout Frob) -> () {
+// CHECK-NOT: begin_access
+// CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape14nestedNoEscapeyAA4FrobVz1f_tF'
+
+// closure #1 in nestedNoEscape(f:)
+// CHECK-LABEL: sil private @_T027access_enforcement_noescape14nestedNoEscapeyAA4FrobVz1f_tFyycfU_ : $@convention(thin) (@inout_aliasable Frob) -> () {
+// FIXME-CHECK: [[ACCESS:%.*]] = begin_access [modify] [static] %0 : $*Frob
+// CHECK: [[ACCESS:%.*]] = begin_access [modify]
+// CHECK: %{{.*}} = apply %{{.*}}([[ACCESS]]) : $@convention(method) (@inout Frob) -> ()
+// CHECK: end_access [[ACCESS]] : $*Frob
+// CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape14nestedNoEscapeyAA4FrobVz1f_tFyycfU_'
+
+// Allow aliased noescape reads.
+func readRead() {
+  var x = 3
+  // Around the call: [read] [dynamic]
+  // Inside each closure: [read] [static]
+  doTwo({ _ = x }, { _ = x })
+  x = 42
+}
+// CHECK-LABEL: sil hidden @_T027access_enforcement_noescape8readReadyyF : $@convention(thin) () -> () {
+// CHECK: [[ALLOC:%.*]] = alloc_stack $Int, var, name "x"
+// FIXME-CHECK: [[ACCESS:%.*]] = begin_access [read] [dynamic] [[ALLOC]] : $*Int
+// CHECK: apply
+// FIXME-CHECK: end_access [[ACCESS]] 
+// CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape8readReadyyF'
+
+// closure #1 in readRead()
+// CHECK-LABEL: sil private @_T027access_enforcement_noescape8readReadyyFyycfU_ : $@convention(thin) (@inout_aliasable Int) -> () {
+// FIXME-CHECK: [[ACCESS:%.*]] = begin_access [read] [static] %0 : $*Int
+// FIXME-CHECK: end_access [[ACCESS]] 
+// CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape8readReadyyFyycfU_'
+
+// closure #2 in readRead()
+// CHECK-LABEL: sil private @_T027access_enforcement_noescape8readReadyyFyycfU0_ : $@convention(thin) (@inout_aliasable Int) -> () {
+// FIXME-CHECK: [[ACCESS:%.*]] = begin_access [read] [static] %0 : $*Int
+// FIXME-CHECK: end_access [[ACCESS]] 
+// CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape8readReadyyFyycfU0_'
+
+// Allow aliased noescape reads of an `inout` arg.
+func inoutReadRead(x: inout Int) {
+  // Around the call: [read] [static]
+  // Inside each closure: [read] [static]
+  doTwo({ _ = x }, { _ = x })
+}
+// CHECK-LABEL: sil hidden @_T027access_enforcement_noescape09inoutReadE0ySiz1x_tF : $@convention(thin) (@inout Int) -> () {
+// CHECK: [[PA1:%.*]] = partial_apply
+// CHECK: [[PA2:%.*]] = partial_apply
+// FIXME-CHECK: [[ACCESS:%.*]] = begin_access [read] [static] %0 : $*Int
+// CHECK: apply %{{.*}}([[PA1]], [[PA2]])
+// FIXME-CHECK: end_access [[ACCESS]] 
+// CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape09inoutReadE0ySiz1x_tF'
+
+// closure #1 in inoutReadRead(x:)
+// CHECK-LABEL: sil private @_T027access_enforcement_noescape09inoutReadE0ySiz1x_tFyycfU_ : $@convention(thin) (@inout_aliasable Int) -> () {
+// FIXME-CHECK: [[ACCESS:%.*]] = begin_access [read] [static] %0 : $*Int
+// FIXME-CHECK: end_access [[ACCESS]] 
+// CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape09inoutReadE0ySiz1x_tFyycfU_'
+
+// closure #2 in inoutReadRead(x:)
+// CHECK-LABEL: sil private @_T027access_enforcement_noescape09inoutReadE0ySiz1x_tFyycfU0_ : $@convention(thin) (@inout_aliasable Int) -> () {
+// FIXME-CHECK: [[ACCESS:%.*]] = begin_access [read] [static] %0 : $*Int
+// FIXME-CHECK: end_access [[ACCESS]] 
+// CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape09inoutReadE0ySiz1x_tFyycfU0_'
+
+// Allow aliased noescape read + boxed read.
+func readBoxRead() {
+  var x = 3
+  let c = { _ = x }
+  // Around the call: [read] [dynamic]
+  // Inside may-escape closure `c`: [read] [dynamic]
+  // Inside never-escape closure: [read] [static]
+  doTwo(c, { _ = x })
+  x = 42
+}
+// CHECK-LABEL: sil hidden @_T027access_enforcement_noescape11readBoxReadyyF : $@convention(thin) () -> () {
+// CHECK: [[PA1:%.*]] = partial_apply
+// CHECK: [[PA2:%.*]] = partial_apply
+// FIXME-CHECK: [[ACCESS:%.*]] = begin_access [read] [dynamic] %0 : $*Int
+// CHECK: apply %{{.*}}([[PA1]], [[PA2]])
+// FIXME-CHECK: end_access [[ACCESS]] 
+// CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape11readBoxReadyyF'
+
+// closure #1 in readBoxRead()
+// CHECK-LABEL: sil private @_T027access_enforcement_noescape11readBoxReadyyFyycfU_ : $@convention(thin) (@owned { var Int }) -> () {
+// CHECK: [[ADDR:%.*]] = project_box %0 : ${ var Int }, 0
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [dynamic] [[ADDR]] : $*Int
+// CHECK: end_access [[ACCESS]] 
+// CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape11readBoxReadyyFyycfU_'
+
+// closure #2 in readBoxRead()
+// CHECK-LABEL: sil private @_T027access_enforcement_noescape11readBoxReadyyFyycfU0_ : $@convention(thin) (@inout_aliasable Int) -> () {
+// FIXME-CHECK: [[ACCESS:%.*]] = begin_access [read] [static] %0 : $*Int
+// FIXME-CHECK: end_access [[ACCESS]] 
+// CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape11readBoxReadyyFyycfU0_'
+
+// Error: cannout capture inout.
+//
+// func inoutReadReadBox(x: inout Int) {
+//   let c = { _ = x }
+//   doTwo({ _ = x }, c)
+// }
+
+// Allow aliased noescape read + write.
+func readWrite() {
+  var x = 3
+  // Around the call: [modify] [dynamic]
+  // Inside closure 1: [read] [static]
+  // Inside closure 2: [modify] [static]
+  doTwo({ _ = x }, { x = 42 })
+}
+// CHECK-LABEL: sil hidden @_T027access_enforcement_noescape9readWriteyyF : $@convention(thin) () -> () {
+// CHECK: [[PA1:%.*]] = partial_apply
+// CHECK: [[PA2:%.*]] = partial_apply
+// FIXME-CHECK: [[ACCESS:%.*]] = begin_access [modify] [dynamic] %0 : $*Int
+// CHECK: apply %{{.*}}([[PA1]], [[PA2]])
+// FIXME-CHECK: end_access [[ACCESS]] 
+// CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape9readWriteyyF'
+
+// closure #1 in readWrite()
+// CHECK-LABEL: sil private @_T027access_enforcement_noescape9readWriteyyFyycfU_ : $@convention(thin) (@inout_aliasable Int) -> () {
+// FIXME-CHECK: [[ACCESS:%.*]] = begin_access [read] [static] %0 : $*Int
+// FIXME-CHECK: end_access [[ACCESS]] 
+// CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape9readWriteyyFyycfU_'
+
+// closure #2 in readWrite()
+// CHECK-LABEL: sil private @_T027access_enforcement_noescape9readWriteyyFyycfU0_ : $@convention(thin) (@inout_aliasable Int) -> () {
+// FIXME-CHECK: [[ACCESS:%.*]] = begin_access [modify] [static] %0 : $*Int
+// FIXME-CHECK: end_access [[ACCESS]] 
+// CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape9readWriteyyFyycfU0_'
+
+// Allow aliased noescape read + write of an `inout` arg.
+func inoutReadWrite(x: inout Int) {
+  // Around the call: [modify] [static]
+  // Inside closure 1: [read] [static]
+  // Inside closure 2: [modify] [static]
+  doTwo({ _ = x }, { x = 3 })
+}
+
+// CHECK-LABEL: sil hidden @_T027access_enforcement_noescape14inoutReadWriteySiz1x_tF : $@convention(thin) (@inout Int) -> () {
+// CHECK: [[PA1:%.*]] = partial_apply
+// CHECK: [[PA2:%.*]] = partial_apply
+// FIXME-CHECK: [[ACCESS:%.*]] = begin_access [modify] [static] %0 : $*Int
+// CHECK: apply %{{.*}}([[PA1]], [[PA2]])
+// FIXME-CHECK: end_access [[ACCESS]] 
+// CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape14inoutReadWriteySiz1x_tF'
+
+// closure #1 in inoutReadWrite(x:)
+// CHECK-LABEL: sil private @_T027access_enforcement_noescape14inoutReadWriteySiz1x_tFyycfU_ : $@convention(thin) (@inout_aliasable Int) -> () {
+// FIXME-CHECK: [[ACCESS:%.*]] = begin_access [read] [static] %0 : $*Int
+// FIXME-CHECK: end_access [[ACCESS]] 
+// CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape14inoutReadWriteySiz1x_tFyycfU_'
+
+// closure #2 in inoutReadWrite(x:)
+// CHECK-LABEL: sil private @_T027access_enforcement_noescape14inoutReadWriteySiz1x_tFyycfU0_ : $@convention(thin) (@inout_aliasable Int) -> () {
+// FIXME-CHECK: [[ACCESS:%.*]] = begin_access [modify] [static] %0 : $*Int
+// FIXME-CHECK: end_access [[ACCESS]] 
+// CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape14inoutReadWriteySiz1x_tFyycfU0_'
+
+
+// FIXME: Trap on aliased boxed read + noescape write.
+//
+// Note: There's no actual exclusivity danger here, because `c` is
+// passed to a noescape argument and is never itself
+// captured. However, SILGen conservatively assumes that the
+// assignment `let c =` captures the closure. Later we could refine
+// the rules to recognize obviously nonescpaping closures.
+func readBoxWrite() {
+  var x = 3
+  let c = { _ = x }
+  // Around the call: [modify] [dynamic]
+  // Inside may-escape closure `c`: [read] [dynamic]
+  // Inside never-escape closure: [modify] [static]
+  doTwo(c, { x = 42 })
+}
+// CHECK-LABEL: sil hidden @_T027access_enforcement_noescape12readBoxWriteyyF : $@convention(thin) () -> () {
+// CHECK: [[PA1:%.*]] = partial_apply
+// CHECK: [[PA2:%.*]] = partial_apply
+// FIXME-CHECK: [[ACCESS:%.*]] = begin_access [modify] [dynamic] %0 : $*Int
+// CHECK: apply %{{.*}}([[PA1]], [[PA2]])
+// FIXME-CHECK: end_access [[ACCESS]]
+// CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape12readBoxWriteyyF'
+
+// closure #1 in readBoxWrite()
+// CHECK-LABEL: sil private @_T027access_enforcement_noescape12readBoxWriteyyFyycfU_ : $@convention(thin) (@owned { var Int }) -> () {
+// CHECK: [[ADDR:%.*]] = project_box %0 : ${ var Int }, 0
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [dynamic] [[ADDR]] : $*Int
+// CHECK: end_access [[ACCESS]] 
+// CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape12readBoxWriteyyFyycfU_'
+
+// closure #2 in readBoxWrite()
+// CHECK-LABEL: sil private @_T027access_enforcement_noescape12readBoxWriteyyFyycfU0_ : $@convention(thin) (@inout_aliasable Int) -> () {
+// FIXME-CHECK: [[ACCESS:%.*]] = begin_access [modify] [static] %0 : $*Int
+// FIXME-CHECK: end_access [[ACCESS]] 
+// CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape12readBoxWriteyyFyycfU0_'
+
+// Error: cannout capture inout.
+// func inoutReadBoxWrite(x: inout Int) {
+//   let c = { _ = x }
+//    doTwo({ x = 42 }, c)
+// }
+
+// FIXME: Trap on aliased noescape read + boxed write.
+//
+// See the note above.
+func readWriteBox() {
+  var x = 3
+  let c = { x = 42 }
+  // Around the call: [read] [dynamic]
+  // Inside may-escape closure `c`: [modify] [dynamic]
+  // Inside never-escape closure: [read] [static]
+  doTwo({ _ = x }, c)
+}
+
+// CHECK-LABEL: sil hidden @_T027access_enforcement_noescape12readWriteBoxyyF : $@convention(thin) () -> () {
+// CHECK: [[PA1:%.*]] = partial_apply
+// CHECK: [[PA2:%.*]] = partial_apply
+// FIXME-CHECK: [[ACCESS:%.*]] = begin_access [read] [dynamic] %0 : $*Int
+// CHECK: apply %{{.*}}([[PA2]], [[PA1]])
+// FIXME-CHECK: end_access [[ACCESS]]
+// CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape12readWriteBoxyyF'
+
+// closure #1 in readWriteBox()
+// CHECK-LABEL: sil private @_T027access_enforcement_noescape12readWriteBoxyyFyycfU_ : $@convention(thin) (@owned { var Int }) -> () {
+// CHECK: [[ADDR:%.*]] = project_box %0 : ${ var Int }, 0
+// CHECK: [[ACCESS:%.*]] = begin_access [modify] [dynamic] [[ADDR]] : $*Int
+// CHECK: end_access [[ACCESS]] 
+// CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape12readWriteBoxyyFyycfU_'
+
+// closure #2 in readWriteBox()
+// CHECK-LABEL: sil private @_T027access_enforcement_noescape12readWriteBoxyyFyycfU0_ : $@convention(thin) (@inout_aliasable Int) -> () {
+// FIXME-CHECK: [[ACCESS:%.*]] = begin_access [read] [static] %0 : $*Int
+// FIXME-CHECK: end_access [[ACCESS]] 
+// CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape12readWriteBoxyyFyycfU0_'
+
+// Error: cannout capture inout.
+// func inoutReadWriteBox(x: inout Int) {
+//   let c = { x = 42 }
+//   doTwo({ _ = x }, c)
+// }
+
+// Error on noescape read + write inout.
+func readWriteInout() {
+  var x = 3
+  // Around the call: [read] [dynamic]
+  // Around the call: [modify] [static] // Error
+  // Inside closure: [modify] [static]
+  doOneInout({ _ = x }, &x)
+}
+
+// CHECK-LABEL: sil hidden @_T027access_enforcement_noescape14readWriteInoutyyF : $@convention(thin) () -> () {
+// CHECK: [[PA1:%.*]] = partial_apply
+// FIXME-CHECK: [[ACCESS:%.*]] = begin_access [read] [dynamic] %0 : $*Int
+// FIXME-CHECK: [[ACCESS2:%.*]] = begin_access [modify] [static] %0 : $*Int
+// FIXME-CHECK: apply %{{.*}}([[PA1]], [[ACCESS2]])
+// FIXME-CHECK: end_access [[ACCESS2]]
+// FIXME-CHECK: end_access [[ACCESS]]
+// CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape14readWriteInoutyyF'
+
+// closure #1 in readWriteInout()
+// CHECK-LABEL: sil private @_T027access_enforcement_noescape14readWriteInoutyyFyycfU_ : $@convention(thin) (@inout_aliasable Int) -> () {
+// FIXME-CHECK: [[ACCESS:%.*]] = begin_access [modify] [static] %0 : $*Int
+// FIXME-CHECK: end_access [[ACCESS]] 
+// CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape14readWriteInoutyyFyycfU_'
+
+// Error on noescape read + write inout of an inout.
+func inoutReadWriteInout(x: inout Int) {
+  // Around the call: [read] [static]
+  // Around the call: [modify] [static] // Error
+  // Inside closure: [modify] [static]
+  doOneInout({ _ = x }, &x)
+}
+
+// CHECK-LABEL: sil hidden @_T027access_enforcement_noescape19inoutReadWriteInoutySiz1x_tF : $@convention(thin) (@inout Int) -> () {
+// CHECK: [[PA1:%.*]] = partial_apply
+// FIXME-CHECK: [[ACCESS:%.*]] = begin_access [read] [static] %0 : $*Int
+// FIXME-CHECK: [[ACCESS2:%.*]] = begin_access [modify] [static] %0 : $*Int
+// FIXME-CHECK: apply %{{.*}}([[PA1]], [[ACCESS2]])
+// FIXME-CHECK: end_access [[ACCESS2]]
+// FIXME-CHECK: end_access [[ACCESS]]
+// CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape19inoutReadWriteInoutySiz1x_tF'
+
+// closure #1 in inoutReadWriteInout(x:)
+// CHECK-LABEL: sil private @_T027access_enforcement_noescape19inoutReadWriteInoutySiz1x_tFyycfU_ : $@convention(thin) (@inout_aliasable Int) -> () {
+// FIXME-CHECK: [[ACCESS:%.*]] = begin_access [modify] [static] %0 : $*Int
+// FIXME-CHECK: end_access [[ACCESS]] 
+// CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape19inoutReadWriteInoutySiz1x_tFyycfU_'
+
+// Error: cannout capture inout.
+func readBoxWriteInout() {
+  var x = 3
+  let c = { _ = x }
+  // Around the call: [modify] [dynamic]
+  // Inside closure: [read] [dynamic]
+  doOneInout(c, &x)
+}
+
+// CHECK-LABEL: sil hidden @_T027access_enforcement_noescape17readBoxWriteInoutyyF : $@convention(thin) () -> () {
+// CHECK: [[PA1:%.*]] = partial_apply
+// FIXME-CHECK: [[ACCESS:%.*]] = begin_access [modify] [dynamic] %0 : $*Int
+// FIXME-CHECK: apply %{{.*}}([[PA1]], [[ACCESS]])
+// FIXME-CHECK: end_access [[ACCESS]]
+// CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape17readBoxWriteInoutyyF'
+
+// closure #1 in readBoxWriteInout()
+// CHECK-LABEL: sil private @_T027access_enforcement_noescape17readBoxWriteInoutyyFyycfU_ : $@convention(thin) (@owned { var Int }) -> () {
+// CHECK: [[ADDR:%.*]] = project_box %0 : ${ var Int }, 0
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [dynamic] [[ADDR]] : $*Int
+// CHECK: end_access [[ACCESS]] 
+// CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape17readBoxWriteInoutyyFyycfU_'
+
+// Error: inout cannot be captured.
+// func inoutReadBoxWriteInout(x: inout Int) {
+//   let c = { _ = x }
+//   doOneInout(c, &x)
+// }
+
+// Allow aliased noescape write + write.
+func writeWrite() {
+  var x = 3
+  // Around the call: [modify] [dynamic]
+  // Inside closure 1: [modify] [static]
+  // Inside closure 2: [modify] [static]
+  doTwo({ x = 42 }, { x = 87 })
+  _ = x
+}
+
+// CHECK-LABEL: sil hidden @_T027access_enforcement_noescape10writeWriteyyF : $@convention(thin) () -> () {
+// CHECK: [[PA1:%.*]] = partial_apply
+// CHECK: [[PA2:%.*]] = partial_apply
+// FIXME-CHECK: [[ACCESS:%.*]] = begin_access [modify] [dynamic] %0 : $*Int
+// FIXME-CHECK: apply %{{.*}}([[PA1]], [[PA2]])
+// FIXME-CHECK: end_access [[ACCESS]]
+// CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape10writeWriteyyF'
+
+// closure #1 in writeWrite()
+// CHECK-LABEL: sil private @_T027access_enforcement_noescape10writeWriteyyFyycfU_ : $@convention(thin) (@inout_aliasable Int) -> () {
+// FIXME-CHECK: [[ACCESS:%.*]] = begin_access [modify] [static] %0 : $*Int
+// FIXME-CHECK: end_access [[ACCESS]] 
+// CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape10writeWriteyyFyycfU_'
+
+// closure #2 in writeWrite()
+// CHECK-LABEL: sil private @_T027access_enforcement_noescape10writeWriteyyFyycfU0_ : $@convention(thin) (@inout_aliasable Int) -> () {
+// FIXME-CHECK: [[ACCESS:%.*]] = begin_access [modify] [static] %0 : $*Int
+// FIXME-CHECK: end_access [[ACCESS]] 
+// CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape10writeWriteyyFyycfU0_'
+
+  
+// Allow aliased noescape write + write of an `inout` arg.
+func inoutWriteWrite(x: inout Int) {
+  // Around the call: [modify] [static]
+  // Inside closure 1: [modify] [static]
+  // Inside closure 2: [modify] [static]
+  doTwo({ x = 42}, { x = 87 })
+}
+
+// CHECK-LABEL: sil hidden @_T027access_enforcement_noescape010inoutWriteE0ySiz1x_tF : $@convention(thin) (@inout Int) -> () {
+// CHECK: [[PA1:%.*]] = partial_apply
+// CHECK: [[PA2:%.*]] = partial_apply
+// FIXME-CHECK: [[ACCESS:%.*]] = begin_access [modify] [static] %0 : $*Int
+// FIXME-CHECK: apply %{{.*}}([[PA1]], [[PA2]])
+// FIXME-CHECK: end_access [[ACCESS]]
+// CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape010inoutWriteE0ySiz1x_tF'
+
+// closure #1 in inoutWriteWrite(x:)
+// CHECK-LABEL: sil private @_T027access_enforcement_noescape010inoutWriteE0ySiz1x_tFyycfU_ : $@convention(thin) (@inout_aliasable Int) -> () {
+// FIXME-CHECK: [[ACCESS:%.*]] = begin_access [modify] [static] %0 : $*Int
+// FIXME-CHECK: end_access [[ACCESS]] 
+// CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape010inoutWriteE0ySiz1x_tFyycfU_'
+
+// closure #2 in inoutWriteWrite(x:)
+// CHECK-LABEL: sil private @_T027access_enforcement_noescape010inoutWriteE0ySiz1x_tFyycfU0_ : $@convention(thin) (@inout_aliasable Int) -> () {
+// FIXME-CHECK: [[ACCESS:%.*]] = begin_access [modify] [static] %0 : $*Int
+// FIXME-CHECK: end_access [[ACCESS]] 
+// CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape010inoutWriteE0ySiz1x_tFyycfU0_'
+
+// FIXME: Trap on aliased boxed write + noescape write.
+//
+// See the note above.
+func writeWriteBox() {
+  var x = 3
+  let c = { x = 87 }
+  // Around the call: [modify] [dynamic]
+  // Inside may-escape closure `c`: [modify] [dynamic]
+  // Inside never-escape closure: [modify] [static]
+  doTwo({ x = 42 }, c)
+  _ = x
+}
+
+// CHECK-LABEL: sil hidden @_T027access_enforcement_noescape13writeWriteBoxyyF : $@convention(thin) () -> () {
+// CHECK: [[PA1:%.*]] = partial_apply
+// CHECK: [[PA2:%.*]] = partial_apply
+// FIXME-CHECK: [[ACCESS:%.*]] = begin_access [modify] [dynamic] %0 : $*Int
+// FIXME-CHECK: apply %{{.*}}([[PA1]], [[PA2]])
+// FIXME-CHECK: end_access [[ACCESS]]
+// CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape13writeWriteBoxyyF'
+
+// closure #1 in writeWriteBox()
+// CHECK-LABEL: sil private @_T027access_enforcement_noescape13writeWriteBoxyyFyycfU_ : $@convention(thin) (@owned { var Int }) -> () {
+// CHECK: [[ADDR:%.*]] = project_box %0 : ${ var Int }, 0
+// CHECK: [[ACCESS:%.*]] = begin_access [modify] [dynamic] [[ADDR]] : $*Int
+// CHECK: end_access [[ACCESS]] 
+// CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape13writeWriteBoxyyFyycfU_'
+
+// closure #2 in writeWriteBox()
+// CHECK-LABEL: sil private @_T027access_enforcement_noescape13writeWriteBoxyyFyycfU0_ : $@convention(thin) (@inout_aliasable Int) -> () {
+// FIXME-CHECK: [[ACCESS:%.*]] = begin_access [modify] [static] %0 : $*Int
+// FIXME-CHECK: end_access [[ACCESS]] 
+// CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape13writeWriteBoxyyFyycfU0_'
+
+// Error: inout cannot be captured.
+// func inoutWriteWriteBox(x: inout Int) {
+//   let c = { x = 87 }
+//   doTwo({ x = 42 }, c)
+// }
+
+/// Error on noescape write + write inout.
+func writeWriteInout() {
+  var x = 3
+  // Around the call: [modify] [dynamic]
+  // Around the call: [modify] [static] // Error
+  // Inside closure: [modify] [static]
+  doOneInout({ x = 42 }, &x)
+}
+
+// CHECK-LABEL: sil hidden @_T027access_enforcement_noescape15writeWriteInoutyyF : $@convention(thin) () -> () {
+// CHECK: [[PA1:%.*]] = partial_apply
+// FIXME-CHECK: [[ACCESS:%.*]] = begin_access [modify] [dynamic] %0 : $*Int
+// FIXME-CHECK: [[ACCESS2:%.*]] = begin_access [modify] [static] %0 : $*Int
+// FIXME-CHECK: apply %{{.*}}([[PA1]], [[ACCESS2]])
+// FIXME-CHECK: end_access [[ACCESS]]
+// CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape15writeWriteInoutyyF'
+
+// closure #1 in writeWriteInout()
+// CHECK-LABEL: sil private @_T027access_enforcement_noescape15writeWriteInoutyyFyycfU_ : $@convention(thin) (@inout_aliasable Int) -> () {
+// FIXME-CHECK: [[ACCESS:%.*]] = begin_access [modify] [static] %0 : $*Int
+// FIXME-CHECK: end_access [[ACCESS]] 
+// CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape15writeWriteInoutyyFyycfU_'
+
+// Error on noescape write + write inout.
+func inoutWriteWriteInout(x: inout Int) {
+  // Around the call: [modify] [static]
+  // Around the call: [modify] [static] // Error
+  // Inside closure: [modify] [static]
+  doOneInout({ x = 42 }, &x)
+}
+
+// inoutWriteWriteInout(x:)
+// CHECK-LABEL: sil hidden @_T027access_enforcement_noescape010inoutWriteE5InoutySiz1x_tF : $@convention(thin) (@inout Int) -> () {
+// CHECK: [[PA1:%.*]] = partial_apply
+// FIXME-CHECK: [[ACCESS:%.*]] = begin_access [modify] [static] %0 : $*Int
+// FIXME-CHECK: [[ACCESS2:%.*]] = begin_access [modify] [static] %0 : $*Int
+// FIXME-CHECK: apply %{{.*}}([[PA1]], [[ACCESS2]])
+// FIXME-CHECK: end_access [[ACCESS]]
+// CHECK-LABEL: // end sil function '_T027access_enforcement_noescape010inoutWriteE5InoutySiz1x_tF'
+
+// closure #1 in inoutWriteWriteInout(x:)
+// CHECK-LABEL: sil private @_T027access_enforcement_noescape010inoutWriteE5InoutySiz1x_tFyycfU_ : $@convention(thin) (@inout_aliasable Int) -> () {
+// FIXME-CHECK: [[ACCESS:%.*]] = begin_access [modify] [static] %0 : $*Int
+// FIXME-CHECK: end_access [[ACCESS]] 
+// CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape010inoutWriteE5InoutySiz1x_tFyycfU_'
+
+// Trap on boxed write + write inout.
+func writeBoxWriteInout() {
+  var x = 3
+  let c = { x = 42 }
+  // Around the call: [modify] [dynamic]
+  // Inside closure: [modify] [dynamic]
+  doOneInout(c, &x)
+}
+
+// CHECK-LABEL: sil hidden @_T027access_enforcement_noescape18writeBoxWriteInoutyyF : $@convention(thin) () -> () {
+// CHECK: [[PA1:%.*]] = partial_apply
+// FIXME-CHECK: [[ACCESS:%.*]] = begin_access [modify] [dynamic] %0 : $*Int
+// FIXME-CHECK: apply %{{.*}}([[PA1]], [[ACCESS]])
+// FIXME-CHECK: end_access [[ACCESS]]
+// CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape18writeBoxWriteInoutyyF'
+
+// closure #1 in writeBoxWriteInout()
+// CHECK-LABEL: sil private @_T027access_enforcement_noescape18writeBoxWriteInoutyyFyycfU_ : $@convention(thin) (@owned { var Int }) -> () {
+// CHECK: [[ADDR:%.*]] = project_box %0 : ${ var Int }, 0
+// FIXME-CHECK: [[ACCESS:%.*]] = begin_access [modify] [dynamic] [[ADDR]] : $*Int
+// FIXME-CHECK: end_access [[ACCESS]]
+// CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape18writeBoxWriteInoutyyFyycfU_'
+
+// Error: Cannot capture inout
+// func inoutWriteBoxWriteInout(x: inout Int) {
+//   let c = { x = 42 }
+//   doOneInout(c, &x)
+// }

--- a/test/SILOptimizer/access_enforcement_noescape.swift
+++ b/test/SILOptimizer/access_enforcement_noescape.swift
@@ -5,7 +5,7 @@
 // (Some static/dynamic enforcement selection is done in SILGen, and some is
 // deferred. That may change over time but we want the outcome to be the same).
 //
-// Each FIXME me line is a case that the current implementation misses.
+// Each FIXME line is a case that the current implementation misses.
 // The model is currently being refined, so this isn't set in stone.
 //
 // TODO: Ensure that each of these cases is covered by
@@ -73,12 +73,14 @@ func readRead() {
 
 // closure #1 in readRead()
 // CHECK-LABEL: sil private @_T027access_enforcement_noescape8readReadyyFyycfU_ : $@convention(thin) (@inout_aliasable Int) -> () {
+// CHECK-NOT: [[ACCESS:%.*]] = begin_access [read] [dynamic]
 // FIXME-CHECK: [[ACCESS:%.*]] = begin_access [read] [static] %0 : $*Int
 // FIXME-CHECK: end_access [[ACCESS]] 
 // CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape8readReadyyFyycfU_'
 
 // closure #2 in readRead()
 // CHECK-LABEL: sil private @_T027access_enforcement_noescape8readReadyyFyycfU0_ : $@convention(thin) (@inout_aliasable Int) -> () {
+// CHECK-NOT: [[ACCESS:%.*]] = begin_access [read] [dynamic]
 // FIXME-CHECK: [[ACCESS:%.*]] = begin_access [read] [static] %0 : $*Int
 // FIXME-CHECK: end_access [[ACCESS]] 
 // CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape8readReadyyFyycfU0_'
@@ -99,12 +101,14 @@ func inoutReadRead(x: inout Int) {
 
 // closure #1 in inoutReadRead(x:)
 // CHECK-LABEL: sil private @_T027access_enforcement_noescape09inoutReadE0ySiz1x_tFyycfU_ : $@convention(thin) (@inout_aliasable Int) -> () {
+// CHECK-NOT: [[ACCESS:%.*]] = begin_access [read] [dynamic]
 // FIXME-CHECK: [[ACCESS:%.*]] = begin_access [read] [static] %0 : $*Int
 // FIXME-CHECK: end_access [[ACCESS]] 
 // CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape09inoutReadE0ySiz1x_tFyycfU_'
 
 // closure #2 in inoutReadRead(x:)
 // CHECK-LABEL: sil private @_T027access_enforcement_noescape09inoutReadE0ySiz1x_tFyycfU0_ : $@convention(thin) (@inout_aliasable Int) -> () {
+// CHECK-NOT: [[ACCESS:%.*]] = begin_access [read] [dynamic]
 // FIXME-CHECK: [[ACCESS:%.*]] = begin_access [read] [static] %0 : $*Int
 // FIXME-CHECK: end_access [[ACCESS]] 
 // CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape09inoutReadE0ySiz1x_tFyycfU0_'
@@ -136,6 +140,7 @@ func readBoxRead() {
 
 // closure #2 in readBoxRead()
 // CHECK-LABEL: sil private @_T027access_enforcement_noescape11readBoxReadyyFyycfU0_ : $@convention(thin) (@inout_aliasable Int) -> () {
+// CHECK-NOT: [[ACCESS:%.*]] = begin_access [read] [dynamic]
 // FIXME-CHECK: [[ACCESS:%.*]] = begin_access [read] [static] %0 : $*Int
 // FIXME-CHECK: end_access [[ACCESS]] 
 // CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape11readBoxReadyyFyycfU0_'
@@ -165,12 +170,14 @@ func readWrite() {
 
 // closure #1 in readWrite()
 // CHECK-LABEL: sil private @_T027access_enforcement_noescape9readWriteyyFyycfU_ : $@convention(thin) (@inout_aliasable Int) -> () {
+// CHECK-NOT: [[ACCESS:%.*]] = begin_access [read] [dynamic]
 // FIXME-CHECK: [[ACCESS:%.*]] = begin_access [read] [static] %0 : $*Int
 // FIXME-CHECK: end_access [[ACCESS]] 
 // CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape9readWriteyyFyycfU_'
 
 // closure #2 in readWrite()
 // CHECK-LABEL: sil private @_T027access_enforcement_noescape9readWriteyyFyycfU0_ : $@convention(thin) (@inout_aliasable Int) -> () {
+// CHECK-NOT: [[ACCESS:%.*]] = begin_access [modify] [dynamic]
 // FIXME-CHECK: [[ACCESS:%.*]] = begin_access [modify] [static] %0 : $*Int
 // FIXME-CHECK: end_access [[ACCESS]] 
 // CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape9readWriteyyFyycfU0_'
@@ -193,12 +200,14 @@ func inoutReadWrite(x: inout Int) {
 
 // closure #1 in inoutReadWrite(x:)
 // CHECK-LABEL: sil private @_T027access_enforcement_noescape14inoutReadWriteySiz1x_tFyycfU_ : $@convention(thin) (@inout_aliasable Int) -> () {
+// CHECK-NOT: [[ACCESS:%.*]] = begin_access [read] [dynamic]
 // FIXME-CHECK: [[ACCESS:%.*]] = begin_access [read] [static] %0 : $*Int
 // FIXME-CHECK: end_access [[ACCESS]] 
 // CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape14inoutReadWriteySiz1x_tFyycfU_'
 
 // closure #2 in inoutReadWrite(x:)
 // CHECK-LABEL: sil private @_T027access_enforcement_noescape14inoutReadWriteySiz1x_tFyycfU0_ : $@convention(thin) (@inout_aliasable Int) -> () {
+// CHECK-NOT: [[ACCESS:%.*]] = begin_access [modify] [dynamic]
 // FIXME-CHECK: [[ACCESS:%.*]] = begin_access [modify] [static] %0 : $*Int
 // FIXME-CHECK: end_access [[ACCESS]] 
 // CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape14inoutReadWriteySiz1x_tFyycfU0_'
@@ -236,6 +245,7 @@ func readBoxWrite() {
 
 // closure #2 in readBoxWrite()
 // CHECK-LABEL: sil private @_T027access_enforcement_noescape12readBoxWriteyyFyycfU0_ : $@convention(thin) (@inout_aliasable Int) -> () {
+// CHECK-NOT: [[ACCESS:%.*]] = begin_access [modify] [dynamic]
 // FIXME-CHECK: [[ACCESS:%.*]] = begin_access [modify] [static] %0 : $*Int
 // FIXME-CHECK: end_access [[ACCESS]] 
 // CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape12readBoxWriteyyFyycfU0_'
@@ -275,6 +285,7 @@ func readWriteBox() {
 
 // closure #2 in readWriteBox()
 // CHECK-LABEL: sil private @_T027access_enforcement_noescape12readWriteBoxyyFyycfU0_ : $@convention(thin) (@inout_aliasable Int) -> () {
+// CHECK-NOT: [[ACCESS:%.*]] = begin_access [read] [dynamic]
 // FIXME-CHECK: [[ACCESS:%.*]] = begin_access [read] [static] %0 : $*Int
 // FIXME-CHECK: end_access [[ACCESS]] 
 // CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape12readWriteBoxyyFyycfU0_'
@@ -305,7 +316,8 @@ func readWriteInout() {
 
 // closure #1 in readWriteInout()
 // CHECK-LABEL: sil private @_T027access_enforcement_noescape14readWriteInoutyyFyycfU_ : $@convention(thin) (@inout_aliasable Int) -> () {
-// FIXME-CHECK: [[ACCESS:%.*]] = begin_access [modify] [static] %0 : $*Int
+// CHECK-NOT: [[ACCESS:%.*]] = begin_access [read] [dynamic]
+// FIXME-CHECK: [[ACCESS:%.*]] = begin_access [read] [static] %0 : $*Int
 // FIXME-CHECK: end_access [[ACCESS]] 
 // CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape14readWriteInoutyyFyycfU_'
 
@@ -328,7 +340,8 @@ func inoutReadWriteInout(x: inout Int) {
 
 // closure #1 in inoutReadWriteInout(x:)
 // CHECK-LABEL: sil private @_T027access_enforcement_noescape19inoutReadWriteInoutySiz1x_tFyycfU_ : $@convention(thin) (@inout_aliasable Int) -> () {
-// FIXME-CHECK: [[ACCESS:%.*]] = begin_access [modify] [static] %0 : $*Int
+// CHECK-NOT: [[ACCESS:%.*]] = begin_access [read] [dynamic]
+// FIXME-CHECK: [[ACCESS:%.*]] = begin_access [read] [static] %0 : $*Int
 // FIXME-CHECK: end_access [[ACCESS]] 
 // CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape19inoutReadWriteInoutySiz1x_tFyycfU_'
 
@@ -381,12 +394,14 @@ func writeWrite() {
 
 // closure #1 in writeWrite()
 // CHECK-LABEL: sil private @_T027access_enforcement_noescape10writeWriteyyFyycfU_ : $@convention(thin) (@inout_aliasable Int) -> () {
+// CHECK-NOT: [[ACCESS:%.*]] = begin_access [modify] [dynamic]
 // FIXME-CHECK: [[ACCESS:%.*]] = begin_access [modify] [static] %0 : $*Int
 // FIXME-CHECK: end_access [[ACCESS]] 
 // CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape10writeWriteyyFyycfU_'
 
 // closure #2 in writeWrite()
 // CHECK-LABEL: sil private @_T027access_enforcement_noescape10writeWriteyyFyycfU0_ : $@convention(thin) (@inout_aliasable Int) -> () {
+// CHECK-NOT: [[ACCESS:%.*]] = begin_access [modify] [dynamic]
 // FIXME-CHECK: [[ACCESS:%.*]] = begin_access [modify] [static] %0 : $*Int
 // FIXME-CHECK: end_access [[ACCESS]] 
 // CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape10writeWriteyyFyycfU0_'
@@ -410,12 +425,14 @@ func inoutWriteWrite(x: inout Int) {
 
 // closure #1 in inoutWriteWrite(x:)
 // CHECK-LABEL: sil private @_T027access_enforcement_noescape010inoutWriteE0ySiz1x_tFyycfU_ : $@convention(thin) (@inout_aliasable Int) -> () {
+// CHECK-NOT: [[ACCESS:%.*]] = begin_access [modify] [dynamic]
 // FIXME-CHECK: [[ACCESS:%.*]] = begin_access [modify] [static] %0 : $*Int
 // FIXME-CHECK: end_access [[ACCESS]] 
 // CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape010inoutWriteE0ySiz1x_tFyycfU_'
 
 // closure #2 in inoutWriteWrite(x:)
 // CHECK-LABEL: sil private @_T027access_enforcement_noescape010inoutWriteE0ySiz1x_tFyycfU0_ : $@convention(thin) (@inout_aliasable Int) -> () {
+// CHECK-NOT: [[ACCESS:%.*]] = begin_access [modify] [dynamic]
 // FIXME-CHECK: [[ACCESS:%.*]] = begin_access [modify] [static] %0 : $*Int
 // FIXME-CHECK: end_access [[ACCESS]] 
 // CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape010inoutWriteE0ySiz1x_tFyycfU0_'
@@ -450,6 +467,7 @@ func writeWriteBox() {
 
 // closure #2 in writeWriteBox()
 // CHECK-LABEL: sil private @_T027access_enforcement_noescape13writeWriteBoxyyFyycfU0_ : $@convention(thin) (@inout_aliasable Int) -> () {
+// CHECK-NOT: [[ACCESS:%.*]] = begin_access [modify] [dynamic]
 // FIXME-CHECK: [[ACCESS:%.*]] = begin_access [modify] [static] %0 : $*Int
 // FIXME-CHECK: end_access [[ACCESS]] 
 // CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape13writeWriteBoxyyFyycfU0_'
@@ -479,6 +497,7 @@ func writeWriteInout() {
 
 // closure #1 in writeWriteInout()
 // CHECK-LABEL: sil private @_T027access_enforcement_noescape15writeWriteInoutyyFyycfU_ : $@convention(thin) (@inout_aliasable Int) -> () {
+// CHECK-NOT: [[ACCESS:%.*]] = begin_access [modify] [dynamic]
 // FIXME-CHECK: [[ACCESS:%.*]] = begin_access [modify] [static] %0 : $*Int
 // FIXME-CHECK: end_access [[ACCESS]] 
 // CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape15writeWriteInoutyyFyycfU_'
@@ -502,6 +521,7 @@ func inoutWriteWriteInout(x: inout Int) {
 
 // closure #1 in inoutWriteWriteInout(x:)
 // CHECK-LABEL: sil private @_T027access_enforcement_noescape010inoutWriteE5InoutySiz1x_tFyycfU_ : $@convention(thin) (@inout_aliasable Int) -> () {
+// CHECK-NOT: [[ACCESS:%.*]] = begin_access [modify] [dynamic]
 // FIXME-CHECK: [[ACCESS:%.*]] = begin_access [modify] [static] %0 : $*Int
 // FIXME-CHECK: end_access [[ACCESS]] 
 // CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape010inoutWriteE5InoutySiz1x_tFyycfU_'
@@ -525,8 +545,8 @@ func writeBoxWriteInout() {
 // closure #1 in writeBoxWriteInout()
 // CHECK-LABEL: sil private @_T027access_enforcement_noescape18writeBoxWriteInoutyyFyycfU_ : $@convention(thin) (@owned { var Int }) -> () {
 // CHECK: [[ADDR:%.*]] = project_box %0 : ${ var Int }, 0
-// FIXME-CHECK: [[ACCESS:%.*]] = begin_access [modify] [dynamic] [[ADDR]] : $*Int
-// FIXME-CHECK: end_access [[ACCESS]]
+// CHECK: [[ACCESS:%.*]] = begin_access [modify] [dynamic] [[ADDR]] : $*Int
+// CHECK: end_access [[ACCESS]]
 // CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape18writeBoxWriteInoutyyFyycfU_'
 
 // Error: Cannot capture inout

--- a/test/SILOptimizer/access_enforcement_selection.sil
+++ b/test/SILOptimizer/access_enforcement_selection.sil
@@ -68,7 +68,7 @@ sil hidden @markFuncEscape : $@convention(thin) () -> () {
 sil @takesInoutAndClosure : $@convention(thin) (@inout Builtin.Int64, @owned @callee_owned () -> ()) -> ()
 sil @closureCapturingByStorageAddress : $@convention(thin) (@inout_aliasable Builtin.Int64) -> ()
 
-// Test dynamic enforcement of box addresses that escape via closure
+// Test static enforcement of box addresses that escape via closure
 // partial_applys.
 // application.
 // CHECK-LABEL: sil hidden @escapeAsArgumentToPartialApply : $@convention(thin) () -> () {
@@ -78,7 +78,7 @@ sil @closureCapturingByStorageAddress : $@convention(thin) (@inout_aliasable Bui
 // CHECK:  [[FUNC:%.*]] = function_ref @takesInoutAndClosure : $@convention(thin) (@inout Builtin.Int64, @owned @callee_owned () -> ()) -> ()
 // CHECK:  [[CLOSURE:%.*]] = function_ref @closureCapturingByStorageAddress : $@convention(thin) (@inout_aliasable Builtin.Int64) -> ()
 // CHECK:  [[PA:%.*]] = partial_apply [[CLOSURE]]([[ADR]]) : $@convention(thin) (@inout_aliasable Builtin.Int64) -> ()
-// CHECK:  [[MODIFY:%.*]] = begin_access [modify] [dynamic] [[ADR]] : $*Builtin.Int64
+// CHECK:  [[MODIFY:%.*]] = begin_access [modify] [static] [[ADR]] : $*Builtin.Int64
 // CHECK:  %{{.*}} = apply [[FUNC]]([[MODIFY]], [[PA]]) : $@convention(thin) (@inout Builtin.Int64, @owned @callee_owned () -> ()) -> ()
 // CHECK:  end_access [[MODIFY]] : $*Builtin.Int64
 // CHECK:  destroy_value [[BOX]] : ${ var Builtin.Int64 }

--- a/test/SILOptimizer/access_enforcement_selection.swift
+++ b/test/SILOptimizer/access_enforcement_selection.swift
@@ -29,14 +29,10 @@ public func captureStack() -> Int {
 // Dynamic access for `return x`. Since the closure is non-escaping, using
 // dynamic enforcement here is more conservative than it needs to be -- static
 // is sufficient here.
-// CHECK: Dynamic Access: %{{.*}} = begin_access [read] [dynamic] %{{.*}} : $*Int
+// CHECK: Static Access: %{{.*}} = begin_access [read] [static] %{{.*}} : $*Int
 
-// The access inside the closure is dynamic, until we have the logic necessary to
-// prove that no other closures are passed to `takeClosure` that may write to
-// `x`.
-//
 // CHECK-LABEL: Access Enforcement Selection in _T028access_enforcement_selection12captureStackSiyFSiycfU_
-// CHECK: Dynamic Access: %{{.*}} = begin_access [read] [dynamic] %{{.*}} : $*Int
+// CHECK: Static Access: %{{.*}} = begin_access [read] [static] %{{.*}} : $*Int
 
 
 // Generate an alloc_stack that does not escape into a closure.
@@ -60,15 +56,13 @@ public func captureStackWithInoutInProgress() -> Int {
   return x
 }
 // CHECK-LABEL: Access Enforcement Selection in _T028access_enforcement_selection31captureStackWithInoutInProgressSiyF
-// Dynamic access for `&x`. This must be dynamic so that we catch the conflict
-// in the closure.
-// CHECK-DAG: Dynamic Access: %{{.*}} = begin_access [modify] [dynamic] %{{.*}} : $*Int
-// Dynamic access for `return x`. This is more conservative than it needs
-// to be; it can be static.
-// CHECK-DAG: Dynamic Access: %{{.*}} = begin_access [read] [dynamic] %{{.*}} : $*Int
+// Static access for `&x`.
+// CHECK-DAG: Static Access: %{{.*}} = begin_access [modify] [static] %{{.*}} : $*Int
+// Static access for `return x`.
+// CHECK-DAG: Static Access: %{{.*}} = begin_access [read] [static] %{{.*}} : $*Int
 //
 // CHECK-LABEL: Access Enforcement Selection in _T028access_enforcement_selection31captureStackWithInoutInProgressSiyFSiycfU_
-// CHECK: Dynamic Access: %{{.*}} = begin_access [read] [dynamic] %{{.*}} : $*Int
+// CHECK: Static Access: %{{.*}} = begin_access [read] [static] %{{.*}} : $*Int
 
 // Generate an alloc_box that escapes into a closure.
 public func captureBox() -> Int {
@@ -90,17 +84,15 @@ public func recaptureStack() -> Int {
 }
 // CHECK-LABEL: Access Enforcement Selection in _T028access_enforcement_selection14recaptureStackSiyF
 //
-// Dynamic access for `return x`. This is more conservative than it needs
-// to be; static is sufficient.
-// CHECK: Dynamic Access:   %{{.*}} = begin_access [read] [dynamic] %{{.*}} : $*Int
+// Static access for `return x`.
+// CHECK: Static Access:   %{{.*}} = begin_access [read] [static] %{{.*}} : $*Int
 
 // CHECK-LABEL: Access Enforcement Selection in _T028access_enforcement_selection14recaptureStackSiyFSiycfU_
 //
-// The first [modify] access inside the closure must be dynamic. It enforces the
+// The first [modify] access inside the closure is static. It enforces the
 // @inout argument.
-// CHECK: Dynamic Access: %{{.*}} = begin_access [modify] [dynamic] %{{.*}} : $*Int
+// CHECK: Static Access: %{{.*}} = begin_access [modify] [static] %{{.*}} : $*Int
 //
-// The second [read] access is only dynamic because the analysis isn't strong
-// enough to prove otherwise. Same as `captureStack` above.
+// The second [read] access is static. Same as `captureStack` above.
 //
-// CHECK: Dynamic Access: %{{.*}} = begin_access [read] [dynamic] %{{.*}} : $*Int
+// CHECK: Static Access: %{{.*}} = begin_access [read] [static] %{{.*}} : $*Int


### PR DESCRIPTION
---
CCC
---
Explanation: Fully checking the exclusivity model requires enabling dynamic checks. We can't allow false positives, especially in a common case like mutation with a noescape closure. Instead we claim that these checks are currently incomplete for accesses within noescape closure. In the near future, once the lagnuage proposal is fully accepted, we will implement static checking of noescape closures. Static checking these cases is far superior for many reasons in addition to avoiding false positives.

Scope: Only affects -enforce-exclusivity=checked, which is purely opt-in.

Radar: <rdar://problem/32119357> [Exclusivity] Disable dynamic enforcement in noescape closures.

Risk: Some code that violates the exclusivity model will pass without failure until static enforcement is enabled. This engenders a false sense of security.

Testing: All applications that have already been tested with enforcement need to be retested.