### PR TITLE
Foundation Overlay: AffineTransform.rotate(byRadians:) is wrong

### DIFF
--- a/stdlib/public/SDK/Foundation/AffineTransform.swift
+++ b/stdlib/public/SDK/Foundation/AffineTransform.swift
@@ -170,11 +170,8 @@ public struct AffineTransform : ReferenceConvertible, Hashable, CustomStringConv
         
         let sine = CGFloat(sin(α))
         let cosine = CGFloat(cos(α))
-
-        m11 = cosine
-        m12 = sine
-        m21 = -sine
-        m22 = cosine
+        
+        append(AffineTransform(m11: cosine, m12: sine, m21: -sine, m22: cosine, tX: 0, tY: 0))
     }
     
     /**

--- a/test/stdlib/TestAffineTransform.swift
+++ b/test/stdlib/TestAffineTransform.swift
@@ -183,6 +183,10 @@ class TestAffineTransform : TestAffineTransformSuper {
         var reflectAboutOrigin = AffineTransform.identity
         reflectAboutOrigin.rotate(byRadians: .pi)
         checkPointTransformation(reflectAboutOrigin, point: point, expectedPoint: NSPoint(x: CGFloat(-10.0), y: CGFloat(-10.0)))
+        
+        var scaleThenRotate = AffineTransform(scale: 2)
+        scaleThenRotate.rotate(byRadians: .pi / 2)
+        checkPointTransformation(scaleThenRotate, point: point, expectedPoint: NSPoint(x: CGFloat(-20.0), y: CGFloat(20.0)))
     }
     
     func test_Inversion() {


### PR DESCRIPTION
Currently, `AffineTransform.rotate(byRadians:)` simply assigns the sines and cosines to
the transformation matrix, throwing away information about the current scale, rotation, etc.

This patch performs a proper rotation by concatenating the rotation matrix. This matches the behavior of `NSAffineTransform`.

Resolves [SR-3941](https://bugs.swift.org/browse/SR-3941).
