### PR TITLE
Only enable NSCoding-related runtime name warnings with Objective-C interop

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -6001,7 +6001,8 @@ void TypeChecker::checkConformancesInContext(DeclContext *dc,
     // Diagnose @NSCoding on file/fileprivate/nested/generic classes, which
     // have unstable archival names.
     if (auto classDecl = dc->getAsClassOrClassExtensionContext()) {
-      if (isNSCoding(conformance->getProtocol())) {
+      if (Context.LangOpts.EnableObjCInterop &&
+          isNSCoding(conformance->getProtocol())) {
         // Note: these 'kind' values are synchronized with
         // diag::nscoding_unstable_mangled_name.
         Optional<unsigned> kind;


### PR DESCRIPTION
Minor follow-on work for rdar://problem/32118614.