### PR TITLE
Sema: Allow nested typealiases to reference protocols with associated type or Self requirements [4.0]

### DIFF
--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -4139,13 +4139,8 @@ void TypeChecker::checkUnsupportedProtocolType(Decl *decl) {
   if (!decl || decl->isInvalid())
     return;
 
-  // Global type aliases are okay.
-  if (isa<TypeAliasDecl>(decl) &&
-      decl->getDeclContext()->isModuleScopeContext())
-    return;
-
-  // Non-typealias type declarations are okay.
-  if (isa<TypeDecl>(decl) && !isa<TypeAliasDecl>(decl))
+  // Type declarations are okay.
+  if (isa<TypeDecl>(decl))
     return;
 
   // Extensions are okay.

--- a/test/type/protocol_types.swift
+++ b/test/type/protocol_types.swift
@@ -23,27 +23,32 @@ func refinementErasure(_ p: Pub) {
 typealias Compo = HasSelfRequirements & Bar
 
 struct CompoAssocType {
-  typealias Compo = HasSelfRequirements & Bar // expected-error{{protocol 'HasSelfRequirements' can only be used as a generic constraint}}
+  typealias Compo = HasSelfRequirements & Bar
 }
 
 func useAsRequirement<T: HasSelfRequirements>(_ x: T) { }
 func useCompoAsRequirement<T: HasSelfRequirements & Bar>(_ x: T) { }
 func useCompoAliasAsRequirement<T: Compo>(_ x: T) { }
+func useNestedCompoAliasAsRequirement<T: CompoAssocType.Compo>(_ x: T) { }
 
 func useAsWhereRequirement<T>(_ x: T) where T: HasSelfRequirements {}
 func useCompoAsWhereRequirement<T>(_ x: T) where T: HasSelfRequirements & Bar {}
 func useCompoAliasAsWhereRequirement<T>(_ x: T) where T: Compo {}
+func useNestedCompoAliasAsWhereRequirement<T>(_ x: T) where T: CompoAssocType.Compo {}
 
 func useAsType(_ x: HasSelfRequirements) { } // expected-error{{protocol 'HasSelfRequirements' can only be used as a generic constraint}}
 func useCompoAsType(_ x: HasSelfRequirements & Bar) { } // expected-error{{protocol 'HasSelfRequirements' can only be used as a generic constraint}}
 func useCompoAliasAsType(_ x: Compo) { } // expected-error{{protocol 'HasSelfRequirements' can only be used as a generic constraint}}
+func useNestedCompoAliasAsType(_ x: CompoAssocType.Compo) { } // expected-error{{protocol 'HasSelfRequirements' can only be used as a generic constraint}}
 
 struct TypeRequirement<T: HasSelfRequirements> {}
 struct CompoTypeRequirement<T: HasSelfRequirements & Bar> {}
 struct CompoAliasTypeRequirement<T: Compo> {}
+struct NestedCompoAliasTypeRequirement<T: CompoAssocType.Compo> {}
 
 struct CompoTypeWhereRequirement<T> where T: HasSelfRequirements & Bar {}
 struct CompoAliasTypeWhereRequirement<T> where T: Compo {}
+struct NestedCompoAliasTypeWhereRequirement<T> where T: CompoAssocType.Compo {}
 
 struct Struct1<T> { }
 struct Struct2<T : Pub & Bar> { }


### PR DESCRIPTION
* Description: Lift an artificial restriction on what protocol types may appear in the underlying type of a typealias nested inside of another type.

* Scope of the issue: This is a request from the standard library team for the new String implementation in 4.0.

* Origination: Restriction has always been there.

* Risk: Very low. First this is a very narrow change. Second, we have two levels of checks: first, we prohibit a protocol containing associated types or Self requirements from being used as a type in a few places, and second, we prohibit such member access on an existential base. Even if the first check is totally busted, the second will catch the invalid member usage (and is necessary because members with Self requirements can appear in extensions).

* Tested: New test added to exercise the loosened restriction.

* Radar: <rdar://problem/32122591>

* Reviewed by: Doug Gregor