### PR TITLE
Sema: Remove TR_NonEnumInheritanceClauseOuterLayer [4.0]

### DIFF
--- a/lib/Sema/ITCDecl.cpp
+++ b/lib/Sema/ITCDecl.cpp
@@ -61,10 +61,6 @@ decomposeInheritedClauseDecl(
         }
       }
     }
-
-    if (!isa<EnumDecl>(typeDecl)) {
-      options |= TR_NonEnumInheritanceClauseOuterLayer;
-    }
   } else {
     auto ext = decl.get<ExtensionDecl *>();
     inheritanceClause = ext->getInherited();
@@ -258,8 +254,6 @@ void IterativeTypeChecker::processInheritedProtocols(
     // FIXME: We'd prefer to keep what the user wrote here.
     if (inherited.getType()->isExistentialType()) {
       auto layout = inherited.getType()->getExistentialLayout();
-      assert(!layout.superclass && "Need to redo inheritance clause "
-             "typechecking");
       for (auto inheritedProtocolTy: layout.getProtocols()) {
         auto *inheritedProtocol = inheritedProtocolTy->getDecl();
 

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -667,9 +667,8 @@ Type TypeChecker::applyGenericArguments(Type type, TypeDecl *decl,
   for (auto tyR : genericArgs)
     args.push_back(tyR);
 
-  auto argumentOptions = options - TR_NonEnumInheritanceClauseOuterLayer;
   auto result = applyUnboundGenericArguments(unboundType, genericDecl, loc,
-                                             dc, args, argumentOptions,
+                                             dc, args, options,
                                              resolver, unsatisfiedDependency);
   if (!result)
     return result;
@@ -1271,20 +1270,6 @@ resolveTopLevelIdentTypeComponent(TypeChecker &TC, DeclContext *DC,
       return type;
 
     auto hasError = type->hasError();
-    if (options & TR_NonEnumInheritanceClauseOuterLayer) {
-      auto protocolOrClass =
-          hasError ? (isa<ProtocolDecl>(typeDecl) || isa<ClassDecl>(typeDecl))
-                   : (type->is<ProtocolType>() || type->is<ClassType>());
-      if (!protocolOrClass) {
-        auto diagnosedType = hasError ? typeDecl->getDeclaredInterfaceType() : type;
-        if (diagnosedType && /*FIXME:*/!hasError) {
-          TC.diagnose(comp->getIdLoc(),
-                      diag::inheritance_from_non_protocol_or_class,
-                      diagnosedType);
-          return ErrorType::get(diagnosedType);
-        }
-      }
-    }
 
     if (hasError)
       return type;
@@ -1534,16 +1519,6 @@ static Type resolveNestedIdentTypeComponent(
     }
   }
 
-  if (options & TR_NonEnumInheritanceClauseOuterLayer) {
-    auto protocolOrClass =
-        memberType->is<ProtocolType>() || memberType->is<ClassType>();
-    if (!protocolOrClass) {
-      TC.diagnose(comp->getIdLoc(),
-                  diag::inheritance_from_non_protocol_or_class, memberType);
-      return ErrorType::get(memberType);
-    }
-  }
-
   // If there are generic arguments, apply them now.
   if (auto genComp = dyn_cast<GenericIdentTypeRepr>(comp)) {
     memberType = TC.applyGenericArguments(
@@ -1590,9 +1565,8 @@ static Type resolveIdentTypeComponent(
 
   // All remaining components use qualified lookup.
 
-  auto parentOptions = options - TR_NonEnumInheritanceClauseOuterLayer;
   // Resolve the parent type.
-  Type parentTy = resolveIdentTypeComponent(TC, DC, parentComps, parentOptions,
+  Type parentTy = resolveIdentTypeComponent(TC, DC, parentComps, options,
                                             diagnoseErrors, resolver,
                                             unsatisfiedDependency);
   if (!parentTy || parentTy->hasError()) return parentTy;

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -484,13 +484,8 @@ enum TypeResolutionFlags : unsigned {
   /// Whether we are checking the outermost type of a computed property setter's newValue
   TR_ImmediateSetterNewValue = 0x1000000,
 
-  /// Whether we are checking the outermost layer of types in an inheritance
-  /// clause on something other than an enum (i.e. V, but not U or W, in class
-  /// T: U.V<W>)
-  TR_NonEnumInheritanceClauseOuterLayer = 0x2000000,
-
   /// Whether we are checking the underlying type of a typealias.
-  TR_TypeAliasUnderlyingType = 0x4000000,
+  TR_TypeAliasUnderlyingType = 0x2000000,
 };
 
 /// Option set describing how type resolution should work.

--- a/test/decl/protocol/protocols.swift
+++ b/test/decl/protocol/protocols.swift
@@ -38,7 +38,9 @@ func test1() {
   v1.creator = "Me"                   // expected-error {{cannot assign to property: 'creator' is a get-only property}}
 }
 
-protocol Bogus : Int {} // expected-error{{inheritance from non-protocol, non-class type 'Int'}}
+protocol Bogus : Int {}
+// expected-error@-1{{inheritance from non-protocol type 'Int'}}
+// expected-error@-2{{type 'Self' constrained to non-protocol type 'Int'}}
 
 // Explicit conformance checks (successful).
 
@@ -73,6 +75,25 @@ enum NotPrintableO : Any, CustomStringConvertible {} // expected-error{{type 'No
 
 struct NotFormattedPrintable : FormattedPrintable { // expected-error{{type 'NotFormattedPrintable' does not conform to protocol 'CustomStringConvertible'}}
   func print(format: TestFormat) {} // expected-note{{candidate has non-matching type '(TestFormat) -> ()'}}
+}
+
+// Protocol compositions in inheritance clauses
+protocol Left {
+  func l() // expected-note {{protocol requires function 'l()' with type '() -> ()'; do you want to add a stub?}}
+}
+protocol Right {
+  func r() // expected-note {{protocol requires function 'r()' with type '() -> ()'; do you want to add a stub?}}
+}
+typealias Both = Left & Right
+
+protocol Up : Both {
+  func u()
+}
+
+struct DoesNotConform : Up {
+  // expected-error@-1 {{type 'DoesNotConform' does not conform to protocol 'Left'}}
+  // expected-error@-2 {{type 'DoesNotConform' does not conform to protocol 'Right'}}
+  func u() {}
 }
 
 // Circular protocols

--- a/test/type/subclass_composition.swift
+++ b/test/type/subclass_composition.swift
@@ -450,7 +450,7 @@ func conformsTo<T1 : P2, T2 : Base<Int> & P2>(
 protocol ProtoConstraintsSelfToClass where Self : Base<Int> {}
 
 protocol ProtoRefinesClass : Base<Int> {} // FIXME expected-error {{}}
-protocol ProtoRefinesClassAndProtocolAlias : BaseIntAndP2 {} // FIXME expected-error {{}}
+protocol ProtoRefinesClassAndProtocolAlias : BaseIntAndP2 {}
 protocol ProtoRefinesClassAndProtocolDirect : Base<Int> & P2 {} // FIXME expected-error 2 {{}}
 protocol ProtoRefinesClassAndProtocolExpanded : Base<Int>, P2 {} // FIXME expected-error {{}}
 
@@ -459,7 +459,9 @@ class ClassConformsToClassProtocolBad1 : ProtoConstraintsSelfToClass {}
 // expected-note@-2 {{requirement specified as 'Self' : 'Base<Int>' [with Self = ClassConformsToClassProtocolBad1]}}
 class ClassConformsToClassProtocolGood1 : Derived, ProtoConstraintsSelfToClass {}
 
-class ClassConformsToClassProtocolBad2 : ProtoRefinesClass {} // FIXME
+class ClassConformsToClassProtocolBad2 : ProtoRefinesClass {}
+// expected-error@-1 {{'ProtoRefinesClass' requires that 'ClassConformsToClassProtocolBad2' inherit from 'Base<Int>'}}
+// expected-note@-2 {{requirement specified as 'Self' : 'Base<Int>' [with Self = ClassConformsToClassProtocolBad2]}}
 class ClassConformsToClassProtocolGood2 : Derived, ProtoRefinesClass {}
 
 // Subclass existentials inside inheritance clauses
@@ -494,7 +496,6 @@ class CompositionInClassInheritanceClauseDirect : Base<Int> & P2 {
 
 protocol CompositionInAssociatedTypeInheritanceClause {
   associatedtype A : BaseIntAndP2
-  // FIXME expected-error@-1 {{}}
 }
 
 // Members of metatypes and existential metatypes


### PR DESCRIPTION
* Description: This fixes a source compatibility issue uncovered by the ProcedureKit project in the source compatibility test suite. We were incorrectly rejecting protocols that inherit from typealiases containing protocol compositions. This was not tested, but it worked in 3.1 and people now rely on this behavior.

* Origination: The regression was introduced with the associated type where clause, where some defensive checks against malformed inheritance clauses were introduced. It appears that these defensive checks are no longer necessary.

* Risk: Low, at worst we will crash on an invalid inheritance clause where we used to diagnose, but it appears that none of our compiler crasher tests regressed from this.

* Tested: New test added to cover the case used in ProcedureKit.

* Bug: https://bugs.swift.org/browse/SR-4855

* Reviewed by: Huon Wilson, Doug Gregor.