### PR TITLE
[Constraint solver] Shore up "common return type" optimization.

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5035,12 +5035,6 @@ class FuncDecl final : public AbstractFunctionDecl,
 
   TypeLoc FnRetType;
 
-  /// If this declaration is part of an overload set, determine if we've
-  /// searched for a common overload amongst all overloads, or if we've found
-  /// one.
-  unsigned HaveSearchedForCommonOverloadReturnType : 1;
-  unsigned HaveFoundCommonOverloadReturnType : 1;
-
   /// Whether we are statically dispatched even if overridable
   unsigned ForcedStaticDispatch : 1;
 
@@ -5081,8 +5075,6 @@ class FuncDecl final : public AbstractFunctionDecl,
     Mutating = false;
     HasDynamicSelf = false;
     ForcedStaticDispatch = false;
-    HaveSearchedForCommonOverloadReturnType = false;
-    HaveFoundCommonOverloadReturnType = false;
   }
 
   static FuncDecl *createImpl(ASTContext &Context, SourceLoc StaticLoc,
@@ -5155,20 +5147,6 @@ public:
     return getParameterLists()[i];
   }
   
-
-  bool getHaveSearchedForCommonOverloadReturnType() {
-    return HaveSearchedForCommonOverloadReturnType;
-  }
-  void setHaveSearchedForCommonOverloadReturnType(bool b = true) {
-    HaveSearchedForCommonOverloadReturnType = b;
-  }
-  bool getHaveFoundCommonOverloadReturnType() {
-    return HaveFoundCommonOverloadReturnType;
-  }
-  void setHaveFoundCommonOverloadReturnType(bool b = true) {
-    HaveFoundCommonOverloadReturnType = b;
-  }
-
   /// \returns true if this is non-mutating due to applying a 'mutating'
   /// attribute. For example a "mutating set" accessor.
   bool isExplicitNonMutating() const;

--- a/validation-test/compiler_crashers_fixed/28614-args-size-fnref-getnumargumentsforfullapply-partial-application-was-throwing.swift
+++ b/validation-test/compiler_crashers_fixed/28614-args-size-fnref-getnumargumentsforfullapply-partial-application-was-throwing.swift
@@ -5,6 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 // REQUIRES: asserts
 func a{guard let[]=(a||()A


### PR DESCRIPTION
The "common return type" optimization that occurs at
constraint-generation time was overly complicated and wrong in a
couple of places. Fix up these issues:

* Don't cache information about this optimization in the decls
  themselves; it ignores visibility as well as invalidation that
  occurs in script mode and playgrounds. Just do the the work again
* Don't map type into context; we can bail out when there are type
  parameters present
* Skip the "self" parameters of operators in types (since this only
  ever occurs for operators).

Longer term, this optimization should move into the solver itself. But
for now, at least it's cleaner/more correct.
