### PR TITLE
[Parse] [Sema] [SR-3174] Ignore local variables in selector

### DIFF
--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -94,7 +94,8 @@ public:
                     SourceLoc Loc = SourceLoc(),
                     bool IsTypeLookup = false,
                     bool AllowProtocolMembers = false,
-                    bool IgnoreAccessControl = false);
+                    bool IgnoreAccessControl = false,
+                    bool IgnoreLocalVariables = false);
 
   SmallVector<UnqualifiedLookupResult, 4> Results;
 

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -707,6 +707,11 @@ ParserResult<Expr> Parser::parseExprSelector() {
     selectorContext = ObjCSelectorContext::MethodSelector;
   }
 
+  // Ignore DisabledVars in Selector.
+  SmallVector<VarDecl *, 4> Vars;
+  llvm::SaveAndRestore<decltype(DisabledVars)>
+  RestoreCurVars(DisabledVars, Vars);
+
   // Parse the subexpression.
   CodeCompletionCallbacks::InObjCSelectorExprRAII
     InObjCSelectorExpr(CodeCompletion, selectorContext);

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -818,11 +818,13 @@ namespace {
       // For method selectors with unresolved sub-expressions,
       // resolve the expression but ignore local variables to allow
       // conflicting method names
-      if (auto selector = dyn_cast<ObjCSelectorExpr>(expr)) {
-        if (selector->isMethodSelector()) {
-          if (auto unresolved = dyn_cast<UnresolvedDeclRefExpr>(selector->getSubExpr())) {
-            TC.checkForForbiddenPrefix(unresolved);
-            return finish(true, TC.resolveDeclRefExpr(unresolved, DC, /*ignoreLocalVariables=*/true));
+      if (!TC.getLangOpts().isSwiftVersion3()) { 
+        if (auto selector = dyn_cast<ObjCSelectorExpr>(expr)) {
+          if (selector->isMethodSelector()) {
+            if (auto unresolved = dyn_cast<UnresolvedDeclRefExpr>(selector->getSubExpr())) {
+              TC.checkForForbiddenPrefix(unresolved);
+              return finish(true, TC.resolveDeclRefExpr(unresolved, DC, /*ignoreLocalVariables=*/true));
+            }
           }
         }
       }

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -815,6 +815,9 @@ namespace {
         return finish(true, TC.resolveDeclRefExpr(unresolved, DC));
       }
 
+      // For method selectors with unresolved sub-expressions,
+      // resolve the expression but ignore local variables to allow
+      // conflicting method names
       if (auto selector = dyn_cast<ObjCSelectorExpr>(expr)) {
         if (selector->isMethodSelector()) {
           if (auto unresolved = dyn_cast<UnresolvedDeclRefExpr>(selector->getSubExpr())) {

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -178,7 +178,8 @@ LookupResult TypeChecker::lookupUnqualified(DeclContext *dc, DeclName name,
       loc,
       /*IsTypeLookup=*/false,
       options.contains(NameLookupFlags::ProtocolMembers),
-      options.contains(NameLookupFlags::IgnoreAccessibility));
+      options.contains(NameLookupFlags::IgnoreAccessibility),
+      options.contains(NameLookupFlags::IgnoreLocalVariables));
 
   LookupResult result;
   LookupResultBuilder builder(*this, result, dc, options,
@@ -203,7 +204,6 @@ LookupResult TypeChecker::lookupUnqualified(DeclContext *dc, DeclName name,
       }
       assert(foundInType && "bogus base declaration?");
     }
-
     builder.add(found.getValueDecl(), found.getBaseDecl(), foundInType);
   }
   return result;

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -253,6 +253,8 @@ enum class NameLookupFlags {
   /// Whether to ignore access control for this lookup, allowing inaccessible
   /// results to be returned.
   IgnoreAccessibility = 0x10,
+  // Whether to ignore local variables for this lookup
+  IgnoreLocalVariables = 0x20,
 };
 
 /// A set of options that control name lookup.
@@ -913,7 +915,7 @@ public:
   /// Bind an UnresolvedDeclRefExpr by performing name lookup and
   /// returning the resultant expression.  Context is the DeclContext used
   /// for the lookup.
-  Expr *resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE, DeclContext *Context);
+  Expr *resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE, DeclContext *Context, bool ignoreLocalVariables = false);
 
   /// \brief Validate the given type.
   ///

--- a/test/expr/unary/selector/selector.swift
+++ b/test/expr/unary/selector/selector.swift
@@ -148,6 +148,7 @@ default:
 }
 
 // SR-3174
+// REQUIRES: SWIFT_VERSION=4
 
 class D {
   func test() {

--- a/test/expr/unary/selector/selector.swift
+++ b/test/expr/unary/selector/selector.swift
@@ -149,12 +149,19 @@ default:
 
 // SR-3174
 
-class Hello {
+class D {
   func test() {
     let cancel = #selector(cancel) // expected-warning {{initialization of immutable value 'cancel' was never used; consider replacing with assignment to '_' or removing it}}
   }
 
-  func cancel() { }
+  @objc func cancel() { }
+}
+
+class E {
+  let d = D()
+  func test() {
+    let cancel = #selector(d.cancel) // expected-warning {{initialization of immutable value 'cancel' was never used; consider replacing with assignment to '_' or removing it}} 
+  }
 }
 
 func testVariableWithinItsOwnInitialValue() {

--- a/test/expr/unary/selector/selector.swift
+++ b/test/expr/unary/selector/selector.swift
@@ -164,8 +164,14 @@ class E {
   }
 }
 
-func testVariableWithinItsOwnInitialValue() {
-    let cancel = #selector(cancel) // expected-warning {{initialization of immutable value 'cancel' was never used; consider replacing with assignment to '_' or removing it}}
+class F: D {
+  override func test() {
+    let cancel = #selector(cancel) // expected-warning {{initialization of immutable value 'cancel' was never used; consider replacing with assignment to '_' or removing it}} 
+  }
 }
 
-func cancel() {}
+func testVariableWithinItsOwnInitialValue() {
+    let doSomething = #selector(doSomething) // expected-warning {{initialization of immutable value 'doSomething' was never used; consider replacing with assignment to '_' or removing it}}
+}
+
+func doSomething() {}

--- a/test/expr/unary/selector/selector.swift
+++ b/test/expr/unary/selector/selector.swift
@@ -146,3 +146,19 @@ case #selector(SR1827.bar)?:
 default:
   break
 }
+
+// SR-3174
+
+class Hello {
+  func test() {
+    let cancel = #selector(cancel) // expected-warning {{initialization of immutable value 'cancel' was never used; consider replacing with assignment to '_' or removing it}}
+  }
+
+  func cancel() { }
+}
+
+func testVariableWithinItsOwnInitialValue() {
+    let cancel = #selector(cancel) // expected-warning {{initialization of immutable value 'cancel' was never used; consider replacing with assignment to '_' or removing it}}
+}
+
+func cancel() {}


### PR DESCRIPTION
<!-- What's in this pull request? -->
Declaring a variable and assigning a selector that refers to a method with the same name as the variable is currently not possible. The compiler will complain with an error message.

``` swift
func foo() {
  let bar = #selector(bar) // Error: Variable used within its own initial value
}

func bar() { }
```

However, the compiler should realise that not the variable, but instead, the method `bar()` was meant to be used. A local variable can't even be a selector.

> The subexpression of the #selector expression must be a reference to an objc method. [SE-0022](https://github.com/apple/swift-evolution/blob/master/proposals/0022-objc-selectors.md#detailed-design)

Again, the compiler will complain with an appropriate error message.

``` swift 
func foo() {
  let t = { 
    print("Swift is awesome!")
  }
  let bar = #selector(t) // Error: Argument of '#selector' cannot refer to variable 't'
}
```

This pull request changes this behaviour and allows the usage of the same name in a selector.

``` swift
func foo() {
  let bar = #selector(bar) // All good, no error anymore
}

func bar() { }
```

The compiler does this now in two steps: Firstly, the parser ignores the `DisabledVars` property if a selector is currently being parsed. In addition, while the type checker walks the AST and stumbles across an `ObjCSelectorExpr`, it ignores local variables when trying to resolve an `UnresolvedDeclRefExpr`.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-3174](https://bugs.swift.org/browse/SR-3174).

Can you take a look at it, @DougGregor or @jrose-apple? 🙏
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->