### PR TITLE
[QoI] Improve diagnostics for unresolved member with incorrect arguments

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -7205,7 +7205,8 @@ bool FailureDiagnosis::visitUnresolvedMemberExpr(UnresolvedMemberExpr *E) {
     candidateInfo.suggestPotentialOverloads(E->getNameLoc().getBaseNameLoc());
     return true;
   }
-  
+
+  auto *argExpr = E->getArgument();
   auto candidateArgTy = candidateInfo[0].getArgumentType();
 
   // Depending on how we matched, produce tailored diagnostics.
@@ -7226,8 +7227,8 @@ bool FailureDiagnosis::visitUnresolvedMemberExpr(UnresolvedMemberExpr *E) {
 
     // If we have an exact match, then we must have an argument list, check it.
     if (candidateArgTy) {
-      assert(E->getArgument() && "Exact match without argument?");
-      if (!typeCheckArgumentChildIndependently(E->getArgument(), candidateArgTy,
+      assert(argExpr && "Exact match without argument?");
+      if (!typeCheckArgumentChildIndependently(argExpr, candidateArgTy,
                                                candidateInfo))
         return true;
     }
@@ -7256,71 +7257,50 @@ bool FailureDiagnosis::visitUnresolvedMemberExpr(UnresolvedMemberExpr *E) {
   case CC_Inaccessible:
     // Diagnose some simple and common errors.
     return candidateInfo.diagnoseSimpleErrors(E);
-      
-  case CC_ArgumentLabelMismatch: { // Argument labels are not correct.
-    auto argExpr = typeCheckArgumentChildIndependently(E->getArgument(),
-                                                       candidateArgTy,
-                                                       candidateInfo);
-    if (!argExpr) return true;
 
-    // Construct the actual expected argument labels that our candidate
-    // expected.
-    assert(candidateArgTy &&
-           "Candidate must expect an argument to have a label mismatch");
-    SmallVector<Identifier, 2> argLabelsScratch;
-    auto arguments = decomposeArgType(candidateArgTy,
-                                      candidateInfo[0].getArgumentLabels(
-                                        argLabelsScratch));
-    
-    // TODO: This is probably wrong for varargs, e.g. calling "print" with the
-    // wrong label.
-    SmallVector<Identifier, 4> expectedNames;
-    for (auto &arg : arguments)
-      expectedNames.push_back(arg.Label);
-
-    return diagnoseArgumentLabelError(CS->TC, argExpr, expectedNames,
-                                      /*isSubscript*/false);
-  }
-    
-  case CC_GeneralMismatch:        // Something else is wrong.
-  case CC_ArgumentCountMismatch:  // This candidate has wrong # arguments.
+  case CC_ArgumentLabelMismatch:
+  case CC_ArgumentCountMismatch: {
     // If we have no argument, the candidates must have expected one.
-    if (!E->getArgument()) {
+    if (!argExpr) {
       if (!candidateArgTy)
         return false; // Candidate must be incorrect for some other reason.
-      
+
       // Pick one of the arguments that are expected as an exemplar.
       if (candidateArgTy->isVoid()) {
         // If this member is () -> T, suggest adding parentheses.
         diagnose(E->getNameLoc(), diag::expected_parens_in_contextual_member,
                  E->getName())
-          .fixItInsertAfter(E->getEndLoc(), "()");
+            .fixItInsertAfter(E->getEndLoc(), "()");
       } else {
         diagnose(E->getNameLoc(), diag::expected_argument_in_contextual_member,
                  E->getName(), candidateArgTy);
       }
       return true;
     }
-     
+
+    assert(argExpr && candidateArgTy && "Exact match without an argument?");
+    return diagnoseSingleCandidateFailures(candidateInfo, E, argExpr,
+                                           E->getArgumentLabels());
+  }
+
+  case CC_GeneralMismatch: { // Something else is wrong.
     // If an argument value was specified, but this member expects no arguments,
     // then we fail with a nice error message.
     if (!candidateArgTy) {
-      if (E->getArgument()->getType()->isVoid()) {
+      if (argExpr->getType()->isVoid()) {
         diagnose(E->getNameLoc(), diag::unexpected_parens_in_contextual_member,
                  E->getName())
-          .fixItRemove(E->getArgument()->getSourceRange());
+            .fixItRemove(E->getArgument()->getSourceRange());
       } else {
-        diagnose(E->getNameLoc(), diag::unexpected_argument_in_contextual_member,
-                 E->getName())
-          .highlight(E->getArgument()->getSourceRange());
+        diagnose(E->getNameLoc(),
+                 diag::unexpected_argument_in_contextual_member, E->getName())
+            .highlight(E->getArgument()->getSourceRange());
       }
       return true;
     }
 
-    assert(E->getArgument() && candidateArgTy &&
-           "Exact match without an argument?");
-    return !typeCheckArgumentChildIndependently(E->getArgument(), candidateArgTy,
-                                                candidateInfo);
+    return false;
+  }
   }
 
   llvm_unreachable("all cases should be handled");

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -429,7 +429,7 @@ let _: [Color] = [1,2].map { _ in .Unknown("") }// expected-error {{missing argu
 let _: (Int) -> (Int, Color) = { ($0, .Unknown("")) } // expected-error {{missing argument label 'description:' in call}} {{48-48=description: }}
 let _: Color = .Unknown("") // expected-error {{missing argument label 'description:' in call}} {{25-25=description: }}
 let _: Color = .Unknown // expected-error {{member 'Unknown' expects argument of type '(description: String)'}}
-let _: Color = .Unknown(42) // expected-error {{cannot convert value of type 'Int' to expected argument type 'String'}}
+let _: Color = .Unknown(42) // expected-error {{missing argument label 'description:' in call}}
 let _ : Color = .rainbow(42)  // expected-error {{argument passed to call that takes no arguments}}
 
 let _ : (Int, Float) = (42.0, 12)  // expected-error {{cannot convert value of type 'Double' to specified type 'Int'}}
@@ -441,10 +441,11 @@ let _: Color = .overload(1.0)  // expected-error {{ambiguous reference to member
 // expected-note @-1 {{overloads for 'overload' exist with these partially matching parameter lists: (a: Int), (b: Int)}}
 let _: Color = .overload(1)  // expected-error {{ambiguous reference to member 'overload'}}
 // expected-note @-1 {{overloads for 'overload' exist with these partially matching parameter lists: (a: Int), (b: Int)}}
-let _: Color = .frob(1.0, &i) // expected-error {{cannot convert value of type 'Double' to expected argument type 'Int'}}
-let _: Color = .frob(1, i)  // expected-error {{passing value of type 'Int' to an inout parameter requires explicit '&'}}
+let _: Color = .frob(1.0, &i) // expected-error {{missing argument label 'b:' in call}}
+let _: Color = .frob(1.0, b: &i) // expected-error {{cannot convert value of type 'Double' to expected argument type 'Int'}}
+let _: Color = .frob(1, i)  // expected-error {{missing argument label 'b:' in call}}
 let _: Color = .frob(1, b: i)  // expected-error {{passing value of type 'Int' to an inout parameter requires explicit '&'}}
-let _: Color = .frob(1, &d) // expected-error {{cannot convert value of type 'Double' to expected argument type 'Int'}}
+let _: Color = .frob(1, &d) // expected-error {{missing argument label 'b:' in call}}
 let _: Color = .frob(1, b: &d) // expected-error {{cannot convert value of type 'Double' to expected argument type 'Int'}}
 var someColor : Color = .red // expected-error {{enum type 'Color' has no case 'red'; did you mean 'Red'}}
 someColor = .red  // expected-error {{enum type 'Color' has no case 'red'; did you mean 'Red'}}

--- a/test/Constraints/diagnostics_swift4.swift
+++ b/test/Constraints/diagnostics_swift4.swift
@@ -26,3 +26,13 @@ class C2_2505: P_2505 {
 
 let c_2505 = C_2505(arg: [C2_2505()]) // expected-error {{argument labels '(arg:)' do not match any available overloads}} expected-note {{overloads for 'C_2505' exist}}
 
+// rdar://problem/31898542 - Swift 4: 'type of expression is ambiguous without more context' errors, without a fixit
+
+enum R31898542<T> {
+  case success(T) // expected-note {{'success' declared here}}
+  case failure
+}
+
+func foo() -> R31898542<()> {
+  return .success() // expected-error {{missing argument for parameter #1 in call}} {{19-19=<#T#>}}
+}


### PR DESCRIPTION
`FailureDiagnosis::visitUnresolvedMemberExpr` tries to use the same logic
as `diagnoseSingleCandidateFailures` so instead of doing that let's remove
some of the special handling and use `diagnoseSingleCandidateFailures`
directly instead, which improves label diagnostics and handles more erroneous
cases as well.

Resolves: rdar://problem/31898542

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
