### PR TITLE
ClangImporter: Fix bug where members of renamed types were dropped

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -7303,7 +7303,7 @@ DeclContext *ClangImporter::Implementation::importDeclContextImpl(
   if (!swiftDecl)
     return nullptr;
 
-  if (auto nominal = dyn_cast<NominalTypeDecl>(swiftDecl))
+  if (auto nominal = dynCastIgnoringCompatibilityAlias<NominalTypeDecl>(swiftDecl))
     return nominal;
   if (auto extension = dyn_cast<ExtensionDecl>(swiftDecl))
     return extension;

--- a/test/APINotes/versioned.swift
+++ b/test/APINotes/versioned.swift
@@ -60,12 +60,16 @@ func testRenamedTopLevelDiags() {
   // CHECK-DIAGS-3-NOTE: versioned.swift:[[@LINE-1]]:
 
   // CHECK-DIAGS-3-NOT: versioned.swift:[[@LINE+1]]:
-  _ = InnerInSwift4()
-  // CHECK-DIAGS-4: versioned.swift:[[@LINE-1]]:7: error: 'InnerInSwift4' has been renamed to 'Outer.Inner'
+  let s = InnerInSwift4()
+  // CHECK-DIAGS-4: versioned.swift:[[@LINE-1]]:11: error: 'InnerInSwift4' has been renamed to 'Outer.Inner'
   // CHECK-DIAGS-4: note: 'InnerInSwift4' was obsoleted in Swift 4
+  _ = s.value
+  // CHECK-DIAGS-4-NOT: versioned.swift:[[@LINE-1]]:
 
   // CHECK-DIAGS-4-NOT: versioned.swift:[[@LINE+1]]:
-  _ = Outer.Inner()
+  let t = Outer.Inner()
+  // CHECK-DIAGS-3-NOT: versioned.swift:[[@LINE-1]]:
+  _ = s.value
   // CHECK-DIAGS-3-NOT: versioned.swift:[[@LINE-1]]:
 }
 


### PR DESCRIPTION
When "Always import types under their Swift 4 name." was
introduced, we still import members under their Swift 3 names;
this means the member's DeclContext imports as a compatibility
alias.

However, we did not look through the compatibility alias when
mapping the member's Clang DeclContext to a Swift DeclContext,
and as a result, the member was dropped on the floor.

Fixes <rdar://problem/31911531>, <rdar://problem/32042522>,
and probably <rdar://problem/31976966>.