### PR TITLE
ClangImporter: Fix bug where members of renamed types were dropped [4.0]

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -7296,7 +7296,7 @@ DeclContext *ClangImporter::Implementation::importDeclContextImpl(
   if (!swiftDecl)
     return nullptr;
 
-  if (auto nominal = dyn_cast<NominalTypeDecl>(swiftDecl))
+  if (auto nominal = dynCastIgnoringCompatibilityAlias<NominalTypeDecl>(swiftDecl))
     return nominal;
   if (auto extension = dyn_cast<ExtensionDecl>(swiftDecl))
     return extension;

--- a/test/APINotes/versioned.swift
+++ b/test/APINotes/versioned.swift
@@ -60,12 +60,16 @@ func testRenamedTopLevelDiags() {
   // CHECK-DIAGS-3-NOTE: versioned.swift:[[@LINE-1]]:
 
   // CHECK-DIAGS-3-NOT: versioned.swift:[[@LINE+1]]:
-  _ = InnerInSwift4()
-  // CHECK-DIAGS-4: versioned.swift:[[@LINE-1]]:7: error: 'InnerInSwift4' has been renamed to 'Outer.Inner'
+  let s = InnerInSwift4()
+  // CHECK-DIAGS-4: versioned.swift:[[@LINE-1]]:11: error: 'InnerInSwift4' has been renamed to 'Outer.Inner'
   // CHECK-DIAGS-4: note: 'InnerInSwift4' was obsoleted in Swift 4
+  _ = s.value
+  // CHECK-DIAGS-4-NOT: versioned.swift:[[@LINE-1]]:
 
   // CHECK-DIAGS-4-NOT: versioned.swift:[[@LINE+1]]:
-  _ = Outer.Inner()
+  let t = Outer.Inner()
+  // CHECK-DIAGS-3-NOT: versioned.swift:[[@LINE-1]]:
+  _ = s.value
   // CHECK-DIAGS-3-NOT: versioned.swift:[[@LINE-1]]:
 }
 


### PR DESCRIPTION
* Description: Fixes a regression from a recent change to the ClangImporter where types were always imported as their Swift 4 name, with a compatibility alias in Swift 3 mode. Such types did not appear to have any members in Swift 3 mode, breaking code which had not yet been migrated.

* Scope of the issue: Affects anyone using an imported type from Swift 3 code, where the type got renamed in Swift 4 mode.

* Origination: Introduced in master recently.

* Risk: Low, we already do the "look through compatibility typealias" thing in a few places.

* Tested: New test case added to ensure that members of renamed types are visible from Swift.

* Radars: <rdar://problem/31911531>, <rdar://problem/32042522>, and probably <rdar://problem/31976966>.

* Reviewed by: Jordan Rose