### PR TITLE
[4.0] Ensure that deserialization recovery doesn't affect vtable layout

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -299,6 +299,9 @@ public:
     OnParam            = 1 << 30,
     OnModule           = 1 << 31,
 
+    // Cannot have any attributes.
+    OnMissingMember = 0,
+
     // More coarse-grained aggregations for use in Attr.def.
     OnOperator = OnInfixOperator|OnPrefixOperator|OnPostfixOperator,
 

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3215,6 +3215,7 @@ class ClassDecl : public NominalTypeDecl {
   unsigned ObjCKind : 3;
 
   unsigned HasMissingDesignatedInitializers : 1;
+  unsigned HasMissingVTableEntries : 1;
 
   friend class IterativeTypeChecker;
 
@@ -3309,6 +3310,16 @@ public:
 
   void setHasMissingDesignatedInitializers(bool newValue = true) {
     HasMissingDesignatedInitializers = newValue;
+  }
+
+  /// Returns true if the class has missing members that require vtable entries.
+  ///
+  /// In this case, the class cannot be subclassed, because we cannot construct
+  /// the vtable for the subclass.
+  bool hasMissingVTableEntries() const;
+
+  void setHasMissingVTableEntries(bool newValue = true) {
+    HasMissingVTableEntries = newValue;
   }
 
   /// Find a method of a class that overrides a given method.

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -140,6 +140,7 @@ enum class DescriptiveDeclKind : uint8_t {
   DidSet,
   EnumElement,
   Module,
+  MissingMember,
 };
 
 /// Keeps track of stage of circularity checking for the given protocol.
@@ -602,6 +603,15 @@ class alignas(1 << DeclAlignInBits) Decl {
   enum { NumIfConfigDeclBits = NumDeclBits + 1 };
   static_assert(NumIfConfigDeclBits <= 32, "fits in an unsigned");
 
+  class MissingMemberDeclBitfields {
+    friend class MissingMemberDecl;
+    unsigned : NumDeclBits;
+
+    unsigned NumberOfVTableEntries : 2;
+  };
+  enum { NumMissingMemberDeclBits = NumDeclBits + 2 };
+  static_assert(NumMissingMemberDeclBits <= 32, "fits in an unsigned");
+
 protected:
   union {
     DeclBitfields DeclBits;
@@ -626,6 +636,7 @@ protected:
     ImportDeclBitfields ImportDeclBits;
     ExtensionDeclBitfields ExtensionDeclBits;
     IfConfigDeclBitfields IfConfigDeclBits;
+    MissingMemberDeclBitfields MissingMemberDeclBits;
     uint32_t OpaqueBits;
   };
 
@@ -6129,6 +6140,55 @@ public:
   
   static bool classof(const Decl *D) {
     return D->getKind() == DeclKind::PostfixOperator;
+  }
+};
+
+/// Represents a hole where a declaration should have been.
+///
+/// Among other things, these are used to keep vtable layout consistent.
+class MissingMemberDecl : public Decl {
+  DeclName Name;
+
+  MissingMemberDecl(DeclContext *DC, DeclName name, unsigned vtableEntries)
+      : Decl(DeclKind::MissingMember, DC), Name(name) {
+    MissingMemberDeclBits.NumberOfVTableEntries = vtableEntries;
+    assert(getNumberOfVTableEntries() == vtableEntries && "not enough bits");
+    setImplicit();
+  }
+public:
+  static MissingMemberDecl *
+  forMethod(ASTContext &ctx, DeclContext *DC, DeclName name,
+            bool hasNormalVTableEntry) {
+    assert(!name || name.isCompoundName());
+    return new (ctx) MissingMemberDecl(DC, name, hasNormalVTableEntry);
+  }
+
+  static MissingMemberDecl *
+  forInitializer(ASTContext &ctx, DeclContext *DC, DeclName name,
+                 bool hasNormalVTableEntry,
+                 bool hasAllocatingVTableEntry) {
+    unsigned entries = hasNormalVTableEntry + hasAllocatingVTableEntry;
+    return new (ctx) MissingMemberDecl(DC, name, entries);
+  }
+
+  DeclName getFullName() const {
+    return Name;
+  }
+
+  unsigned getNumberOfVTableEntries() const {
+    return MissingMemberDeclBits.NumberOfVTableEntries;
+  }
+
+  SourceLoc getLoc() const {
+    return SourceLoc();
+  }
+
+  SourceRange getSourceRange() const {
+    return SourceRange();
+  }
+
+  static bool classof(const Decl *D) {
+    return D->getKind() == DeclKind::MissingMember;
   }
 };
 

--- a/include/swift/AST/DeclNodes.def
+++ b/include/swift/AST/DeclNodes.def
@@ -93,6 +93,7 @@ DECL(EnumCase, Decl)
 CONTEXT_DECL(TopLevelCode, Decl)
 DECL(IfConfig, Decl)
 DECL(PrecedenceGroup, Decl)
+DECL(MissingMember, Decl)
 
 ABSTRACT_DECL(Operator, Decl)
   OPERATOR_DECL(InfixOperator, OperatorDecl)

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1377,6 +1377,10 @@ ERROR(objc_runtime_visible_cannot_conform_to_objc_protocol,none,
 ERROR(protocol_has_missing_requirements,none,
       "type %0 cannot conform to protocol %1 because it has requirements that "
       "cannot be satisfied", (Type, Type))
+ERROR(protocol_has_missing_requirements_versioned,none,
+      "type %0 cannot conform to protocol %1 (compiled with Swift %2) because "
+      "it has requirements that could not be loaded in Swift %3",
+      (Type, Type, clang::VersionTuple, clang::VersionTuple))
 ERROR(requirement_restricts_self,none,
       "%0 requirement %1 cannot add constraint '%2%select{:|:| ==|:}3 %4' on "
       "'Self'",
@@ -1906,6 +1910,14 @@ ERROR(inheritance_from_final_class,none,
 ERROR(inheritance_from_unspecialized_objc_generic_class,none,
       "inheritance from a generic Objective-C class %0 must bind "
       "type parameters of %0 to specific concrete types", (Identifier))
+ERROR(inheritance_from_class_with_missing_vtable_entries,none,
+      "cannot inherit from class %0 because it has overridable members that "
+      "could not be loaded",
+      (Identifier))
+ERROR(inheritance_from_class_with_missing_vtable_entries_versioned,none,
+      "cannot inherit from class %0 (compiled with Swift %1) because it has "
+      "overridable members that could not be loaded in Swift %2",
+      (Identifier, clang::VersionTuple, clang::VersionTuple))
 ERROR(inheritance_from_cf_class,none,
       "cannot inherit from Core Foundation type %0", (Identifier))
 ERROR(inheritance_from_objc_runtime_visible_class,none,

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -238,6 +238,9 @@ struct PrintOptions {
   /// Whether to skip parameter type attributes
   bool SkipParameterTypeAttributes = false;
 
+  /// Whether to skip placeholder members.
+  bool SkipMissingMemberPlaceholders = true;
+
   /// Whether to print a long attribute like '\@available' on a separate line
   /// from the declaration or other attributes.
   bool PrintLongAttrsOnSeparateLines = false;
@@ -489,6 +492,7 @@ struct PrintOptions {
     result.AbstractAccessors = false;
     result.PrintAccessibility = true;
     result.SkipEmptyExtensionDecls = false;
+    result.SkipMissingMemberPlaceholders = false;
     return result;
   }
 

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -221,19 +221,22 @@ enum class TypeTraitResult {
 
 /// Specifies which normally-unsafe type mismatches should be accepted when
 /// checking overrides.
-enum class OverrideMatchMode {
-  /// Only accept overrides that are properly covariant.
-  Strict,
+enum class TypeMatchFlags {
+  /// Allow properly-covariant overrides.
+  AllowOverride = 1 << 0,
   /// Allow a parameter with IUO type to be overridden by a parameter with non-
   /// optional type.
-  AllowNonOptionalForIUOParam,
+  AllowNonOptionalForIUOParam = 1 << 1,
   /// Allow any mismatches of Optional or ImplicitlyUnwrappedOptional at the
   /// top level of a type.
   ///
   /// This includes function parameters and result types as well as tuple
   /// elements, but excludes generic parameters.
-  AllowTopLevelOptionalMismatch
+  AllowTopLevelOptionalMismatch = 1 << 2,
+  /// Allow any ABI-compatible types to be considered matching.
+  AllowABICompatible = 1 << 3,
 };
+using TypeMatchOptions = OptionSet<TypeMatchFlags>;
 
 /// TypeBase - Base class for all types in Swift.
 class alignas(1 << TypeAlignInBits) TypeBase {
@@ -702,10 +705,9 @@ public:
   /// concrete types to form the argument type.
   bool isBindableTo(Type ty);
 
-  /// \brief Determines whether this type is permitted as a method override
-  /// of the \p other.
-  bool canOverride(Type other, OverrideMatchMode matchMode,
-                   LazyResolver *resolver);
+  /// \brief Determines whether this type is similar to \p other as defined by
+  /// \p matchOptions.
+  bool matches(Type other, TypeMatchOptions matchOptions, LazyResolver *resolver);
 
   /// \brief Determines whether this type has a retainable pointer
   /// representation, i.e. whether it is representable as a single,

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -197,8 +197,8 @@ namespace swift {
     /// Whether to attempt to recover from missing cross-references and other
     /// errors when deserializing from a Swift module.
     ///
-    /// This is a staging flag; eventually it will be on by default.
-    bool EnableDeserializationRecovery = false;
+    /// This is a staging flag; eventually it will be removed.
+    bool EnableDeserializationRecovery = true;
 
     /// Should we use \c ASTScope-based resolution for unqualified name lookup?
     bool EnableASTScopeLookup = false;

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -270,9 +270,12 @@ def enable_experimental_keypaths :
   Flag<["-"], "enable-experimental-keypaths">,
   HelpText<"Enable experimental keypaths">;
 
-def enable_experimental_deserialization_recovery :
-  Flag<["-"], "enable-experimental-deserialization-recovery">,
+def enable_deserialization_recovery :
+  Flag<["-"], "enable-deserialization-recovery">,
   HelpText<"Attempt to recover from missing xrefs (etc) in swiftmodules">;
+def disable_deserialization_recovery :
+  Flag<["-"], "disable-deserialization-recovery">,
+  HelpText<"Don't attempt to recover from missing xrefs (etc) in swiftmodules">;
 
 def enable_cow_existentials : Flag<["-"], "enable-cow-existentials">,
   HelpText<"Enable the copy-on-write existential implementation">;

--- a/include/swift/SIL/SILVTableVisitor.h
+++ b/include/swift/SIL/SILVTableVisitor.h
@@ -43,38 +43,33 @@ template <class T> class SILVTableVisitor {
   void maybeAddMethod(FuncDecl *fd) {
     assert(!fd->hasClangNode());
 
-    // Observing accessors and addressors don't get vtable entries.
-    if (fd->isObservingAccessor() ||
-        fd->getAddressorKind() != AddressorKind::NotAddressor)
-      return;
-
-    maybeAddEntry(SILDeclRef(fd, SILDeclRef::Kind::Func));
+    maybeAddEntry(SILDeclRef(fd, SILDeclRef::Kind::Func),
+                  fd->needsNewVTableEntry());
   }
 
   void maybeAddConstructor(ConstructorDecl *cd) {
     assert(!cd->hasClangNode());
 
-    SILDeclRef initRef(cd, SILDeclRef::Kind::Initializer);
-
-    // Stub constructors don't get a vtable entry unless they were synthesized
-    // to override a base class initializer.
-    if (cd->hasStubImplementation() &&
-        !initRef.getNextOverriddenVTableEntry())
-      return;
-
     // Required constructors (or overrides thereof) have their allocating entry
     // point in the vtable.
-    if (cd->isRequired())
-      maybeAddEntry(SILDeclRef(cd, SILDeclRef::Kind::Allocator));
+    if (cd->isRequired()) {
+      bool needsAllocatingEntry = cd->needsNewVTableEntry();
+      if (!needsAllocatingEntry)
+        if (auto *baseCD = cd->getOverriddenDecl())
+          needsAllocatingEntry = !baseCD->isRequired();
+      maybeAddEntry(SILDeclRef(cd, SILDeclRef::Kind::Allocator),
+                    needsAllocatingEntry);
+    }
 
     // All constructors have their initializing constructor in the
     // vtable, which can be used by a convenience initializer.
-    maybeAddEntry(SILDeclRef(cd, SILDeclRef::Kind::Initializer));
+    maybeAddEntry(SILDeclRef(cd, SILDeclRef::Kind::Initializer),
+                  cd->needsNewVTableEntry());
   }
 
-  void maybeAddEntry(SILDeclRef declRef) {
+  void maybeAddEntry(SILDeclRef declRef, bool needsNewEntry) {
     // Introduce a new entry if required.
-    if (Types.requiresNewVTableEntry(declRef))
+    if (needsNewEntry)
       asDerived().addMethod(declRef);
 
     // Update any existing entries that it overrides.

--- a/include/swift/SIL/SILVTableVisitor.h
+++ b/include/swift/SIL/SILVTableVisitor.h
@@ -94,6 +94,8 @@ protected:
         maybeAddMethod(fd);
       else if (auto *cd = dyn_cast<ConstructorDecl>(member))
         maybeAddConstructor(cd);
+      else if (auto *placeholder = dyn_cast<MissingMemberDecl>(member))
+        asDerived().addPlaceholder(placeholder);
     }
   }
 };

--- a/include/swift/SIL/SILWitnessVisitor.h
+++ b/include/swift/SIL/SILWitnessVisitor.h
@@ -143,6 +143,10 @@ public:
     asDerived().addMethod(func);
   }
 
+  void visitMissingMemberDecl(MissingMemberDecl *placeholder) {
+    asDerived().addPlaceholder(placeholder);
+  }
+
   void visitAssociatedTypeDecl(AssociatedTypeDecl *td) {
     // We already visited these in the first pass.
   }

--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -511,8 +511,6 @@ class TypeConverter {
   
   llvm::DenseMap<OverrideKey, SILConstantInfo> ConstantOverrideTypes;
 
-  llvm::DenseMap<SILDeclRef, bool> RequiresVTableEntry;
-
   llvm::DenseMap<AnyFunctionRef, CaptureInfo> LoweredCaptures;
   
   CanAnyFunctionType makeConstantInterfaceType(SILDeclRef constant);
@@ -664,11 +662,6 @@ public:
   /// Returns the SILParameterInfo for the given declaration's `self` parameter.
   /// `constant` must refer to a method.
   SILParameterInfo getConstantSelfParameter(SILDeclRef constant);
-
-  /// Return if this method introduces a new vtable entry. This will be true
-  /// if the method does not override any method of its base class, or if it
-  /// overrides a method but has a more general AST type.
-  bool requiresNewVTableEntry(SILDeclRef method);
 
   /// Return the most derived override which requires a new vtable entry.
   /// If the method does not override anything or no override is vtable
@@ -852,8 +845,6 @@ private:
   CanAnyFunctionType getBridgedFunctionType(AbstractionPattern fnPattern,
                                             CanAnyFunctionType fnType,
                                             AnyFunctionType::ExtInfo extInfo);
-
-  bool requiresNewVTableEntryUncached(SILDeclRef method);
 };
 
 inline const TypeLowering &

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -54,7 +54,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// in source control, you should also update the comment to briefly
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
-const uint16_t VERSION_MINOR = 343; // Last change: new vtable entry flag
+const uint16_t VERSION_MINOR = 344; // Last change: ctor newly required flag
 
 using DeclID = PointerEmbeddedInt<unsigned, 31>;
 using DeclIDField = BCFixed<31>;
@@ -859,6 +859,7 @@ namespace decls_block {
     DeclIDField, // overridden decl
     AccessibilityKindField, // accessibility
     BCFixed<1>,   // requires a new vtable slot
+    BCFixed<1>,   // 'required' but overridden is not (used for recovery)
     BCArray<IdentifierIDField> // argument names
     // Trailed by its generic parameters, if any, followed by the parameter
     // patterns.

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -54,7 +54,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// in source control, you should also update the comment to briefly
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
-const uint16_t VERSION_MINOR = 342; // Last change: keypath instruction
+const uint16_t VERSION_MINOR = 343; // Last change: new vtable entry flag
 
 using DeclID = PointerEmbeddedInt<unsigned, 31>;
 using DeclIDField = BCFixed<31>;
@@ -858,6 +858,7 @@ namespace decls_block {
     TypeIDField, // canonical interface type
     DeclIDField, // overridden decl
     AccessibilityKindField, // accessibility
+    BCFixed<1>,   // requires a new vtable slot
     BCArray<IdentifierIDField> // argument names
     // Trailed by its generic parameters, if any, followed by the parameter
     // patterns.
@@ -916,6 +917,7 @@ namespace decls_block {
     BCFixed<1>,   // name is compound?
     AddressorKindField, // addressor kind
     AccessibilityKindField, // accessibility
+    BCFixed<1>,   // requires a new vtable slot
     BCArray<IdentifierIDField> // name components
     // The record is trailed by:
     // - its _silgen_name, if any

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -120,6 +120,10 @@ class SerializedASTFile final : public LoadedFile {
 public:
   bool isSIB() const { return IsSIB; }
 
+  /// Returns the language version that was used to compile the contents of this
+  /// file.
+  const version::Version &getLanguageVersionBuiltWith() const;
+
   virtual bool isSystemModule() const override;
 
   virtual void lookupValue(ModuleDecl::AccessPathTy accessPath,

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1119,6 +1119,13 @@ namespace {
       printCommon(MD, "module");
       PrintWithColorRAII(OS, ParenthesisColor) << ')';
     }
+
+    void visitMissingMemberDecl(MissingMemberDecl *MMD) {
+      printCommon(MMD, "missing_member_decl ");
+      PrintWithColorRAII(OS, IdentifierColor)
+          << '\"' << MMD->getFullName() << '\"';
+      PrintWithColorRAII(OS, ParenthesisColor) << ')';
+    }
   };
 } // end anonymous namespace
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -1644,6 +1644,9 @@ bool swift::shouldPrint(const Decl *D, PrintOptions &Options) {
       return false;
   }
 
+  if (Options.SkipMissingMemberPlaceholders && isa<MissingMemberDecl>(D))
+    return false;
+
   if (Options.SkipDeinit && isa<DestructorDecl>(D)) {
     return false;
   }
@@ -3221,6 +3224,12 @@ void PrintAST::visitPostfixOperatorDecl(PostfixOperatorDecl *decl) {
 }
 
 void PrintAST::visitModuleDecl(ModuleDecl *decl) { }
+
+void PrintAST::visitMissingMemberDecl(MissingMemberDecl *decl) {
+  Printer << "/* placeholder for ";
+  recordDeclLoc(decl, [&]{ Printer << decl->getFullName(); });
+  Printer << " */";
+}
 
 void PrintAST::visitBraceStmt(BraceStmt *stmt) {
   Printer << "{";

--- a/lib/AST/ASTScope.cpp
+++ b/lib/AST/ASTScope.cpp
@@ -929,6 +929,7 @@ ASTScope *ASTScope::createIfNeeded(const ASTScope *parent, Decl *decl) {
   case DeclKind::Param:
   case DeclKind::EnumElement:
   case DeclKind::IfConfig:
+  case DeclKind::MissingMember:
     // These declarations do not introduce scopes.
     return nullptr;
 

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -253,6 +253,10 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
     return doIt(SD->getElementTypeLoc());
   }
 
+  bool visitMissingMemberDecl(MissingMemberDecl *MMD) {
+    return false;
+  }
+
   bool visitAbstractFunctionDecl(AbstractFunctionDecl *AFD) {
 #ifndef NDEBUG
     PrettyStackTraceDecl debugStack("walking into body of", AFD);

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -132,6 +132,7 @@ DescriptiveDeclKind Decl::getDescriptiveKind() const {
   TRIVIAL_KIND(EnumElement);
   TRIVIAL_KIND(Param);
   TRIVIAL_KIND(Module);
+  TRIVIAL_KIND(MissingMember);
 
    case DeclKind::Enum:
      return cast<EnumDecl>(this)->getGenericParams()
@@ -266,6 +267,7 @@ StringRef Decl::getDescriptiveKindName(DescriptiveDeclKind K) {
   ENTRY(MutableAddressor, "mutableAddress accessor");
   ENTRY(EnumElement, "enum element");
   ENTRY(Module, "module");
+  ENTRY(MissingMember, "missing member placeholder");
   }
 #undef ENTRY
   llvm_unreachable("bad DescriptiveDeclKind");
@@ -735,6 +737,7 @@ ImportKind ImportDecl::getBestImportKind(const ValueDecl *VD) {
   case DeclKind::EnumCase:
   case DeclKind::IfConfig:
   case DeclKind::PrecedenceGroup:
+  case DeclKind::MissingMember:
     llvm_unreachable("not a ValueDecl");
 
   case DeclKind::AssociatedType:
@@ -1370,6 +1373,7 @@ bool ValueDecl::isDefinition() const {
   case DeclKind::PostfixOperator:
   case DeclKind::IfConfig:
   case DeclKind::PrecedenceGroup:
+  case DeclKind::MissingMember:
     assert(!isa<ValueDecl>(this));
     llvm_unreachable("non-value decls shouldn't get here");
 
@@ -1411,6 +1415,7 @@ bool ValueDecl::isInstanceMember() const {
   case DeclKind::PostfixOperator:
   case DeclKind::IfConfig:
   case DeclKind::PrecedenceGroup:
+  case DeclKind::MissingMember:
     llvm_unreachable("Not a ValueDecl");
 
   case DeclKind::Class:

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4604,6 +4604,63 @@ AbstractFunctionDecl *AbstractFunctionDecl::getOverriddenDecl() const {
   return nullptr;
 }
 
+static bool requiresNewVTableEntry(const AbstractFunctionDecl *decl) {
+  assert(isa<FuncDecl>(decl) || isa<ConstructorDecl>(decl));
+
+  // Final members are always be called directly.
+  // Dynamic methods are always accessed by objc_msgSend().
+  if (decl->isFinal() || decl->isDynamic())
+    return false;
+
+  if (auto *fd = dyn_cast<FuncDecl>(decl)) {
+    switch (fd->getAccessorKind()) {
+    case AccessorKind::NotAccessor:
+    case AccessorKind::IsGetter:
+    case AccessorKind::IsSetter:
+      break;
+    case AccessorKind::IsAddressor:
+    case AccessorKind::IsMutableAddressor:
+      return false;
+    case AccessorKind::IsMaterializeForSet:
+      // Special case -- materializeForSet on dynamic storage is not
+      // itself dynamic, but should be treated as such for the
+      // purpose of constructing a vtable.
+      // FIXME: It should probably just be 'final'.
+      if (fd->getAccessorStorageDecl()->isDynamic())
+        return false;
+      break;
+    case AccessorKind::IsWillSet:
+    case AccessorKind::IsDidSet:
+      return false;
+    }
+  }
+
+  auto base = decl->getOverriddenDecl();
+  if (!base || base->hasClangNode())
+    return true;
+
+  // If the method overrides something, we only need a new entry if the
+  // override has a more general AST type. However an abstraction
+  // change is OK; we don't want to add a whole new vtable entry just
+  // because an @in parameter because @owned, or whatever.
+  auto baseInterfaceTy = base->getInterfaceType();
+  auto derivedInterfaceTy = decl->getInterfaceType();
+
+  auto selfInterfaceTy = decl->getDeclContext()->getDeclaredInterfaceType();
+
+  auto overrideInterfaceTy = selfInterfaceTy->adjustSuperclassMemberDeclType(
+      base, decl, baseInterfaceTy);
+
+  return !derivedInterfaceTy->matches(overrideInterfaceTy,
+                                      TypeMatchFlags::AllowABICompatible,
+                                      /*resolver*/nullptr);
+}
+
+void AbstractFunctionDecl::computeNeedsNewVTableEntry() {
+  setNeedsNewVTableEntry(requiresNewVTableEntry(this));
+}
+
+
 FuncDecl *FuncDecl::createImpl(ASTContext &Context,
                                SourceLoc StaticLoc,
                                StaticSpellingKind StaticSpelling,
@@ -4758,7 +4815,7 @@ ConstructorDecl::ConstructorDecl(DeclName Name, SourceLoc ConstructorLoc,
   setParameterLists(SelfDecl, BodyParams);
   
   ConstructorDeclBits.ComputedBodyInitKind = 0;
-  ConstructorDeclBits.HasStubImplementation = 0;
+  this->HasStubImplementation = 0;
   this->InitKind = static_cast<unsigned>(CtorInitializerKind::Designated);
   this->Failability = static_cast<unsigned>(Failability);
 }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2492,6 +2492,7 @@ ClassDecl::ClassDecl(SourceLoc ClassLoc, Identifier Name, SourceLoc NameLoc,
   ClassDeclBits.HasDestructorDecl = 0;
   ObjCKind = 0;
   HasMissingDesignatedInitializers = 0;
+  HasMissingVTableEntries = 0;
 }
 
 DestructorDecl *ClassDecl::getDestructor() {
@@ -2507,6 +2508,11 @@ bool ClassDecl::hasMissingDesignatedInitializers() const {
   (void)mutableThis->lookupDirect(getASTContext().Id_init,
                                   /*ignoreNewExtensions*/true);
   return HasMissingDesignatedInitializers;
+}
+
+bool ClassDecl::hasMissingVTableEntries() const {
+  (void)getMembers();
+  return HasMissingVTableEntries;
 }
 
 bool ClassDecl::inheritsSuperclassInitializers(LazyResolver *resolver) {

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1128,6 +1128,8 @@ public:
       ASD->setSetterAccessibility(access);
     // All imported decls are constructed fully validated.
     D->setValidationStarted();
+    if (auto AFD = dyn_cast<AbstractFunctionDecl>(static_cast<Decl *>(D)))
+      AFD->setNeedsNewVTableEntry(false);
     return D;
   }
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -920,8 +920,11 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.EnableClassResilience |=
     Args.hasArg(OPT_enable_class_resilience);
 
-  Opts.EnableDeserializationRecovery |=
-    Args.hasArg(OPT_enable_experimental_deserialization_recovery);
+  if (auto A = Args.getLastArg(OPT_enable_deserialization_recovery,
+                               OPT_disable_deserialization_recovery)) {
+    Opts.EnableDeserializationRecovery
+      = A->getOption().matches(OPT_enable_deserialization_recovery);
+  }
 
   Opts.DisableAvailabilityChecking |=
       Args.hasArg(OPT_disable_availability_checking);

--- a/lib/FrontendTool/ReferenceDependencies.cpp
+++ b/lib/FrontendTool/ReferenceDependencies.cpp
@@ -254,6 +254,7 @@ bool swift::emitReferenceDependencies(DiagnosticEngine &diags,
     case DeclKind::Constructor:
     case DeclKind::Destructor:
     case DeclKind::EnumElement:
+    case DeclKind::MissingMember:
       llvm_unreachable("cannot appear at the top level of a file");
     }
   }

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -535,6 +535,7 @@ CodeCompletionResult::getCodeCompletionDeclKind(const Decl *D) {
   case DeclKind::EnumCase:
   case DeclKind::TopLevelCode:
   case DeclKind::IfConfig:
+  case DeclKind::MissingMember:
     llvm_unreachable("not expecting such a declaration result");
   case DeclKind::Module:
     return CodeCompletionDeclKind::Module;

--- a/lib/IRGen/ClassMetadataLayout.h
+++ b/lib/IRGen/ClassMetadataLayout.h
@@ -181,6 +181,12 @@ public:
                               ClassDecl *forClass) {
     addPointer();
   }
+  void addPlaceholder(MissingMemberDecl *MMD) {
+    for (auto i : range(MMD->getNumberOfVTableEntries())) {
+      (void)i;
+      addPointer();
+    }
+  }
 
 private:
   // Our layout here assumes that there will never be unclaimed space

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -1505,6 +1505,10 @@ namespace {
       }
     }
 
+    void visitMissingMemberDecl(MissingMemberDecl *placeholder) {
+      llvm_unreachable("should not IRGen classes with missing members");
+    }
+
     void addIVarInitializer() {
       if (auto fn = IGM.getAddrOfIVarInitDestroy(getClass(),
                                                  /*destroy*/ false,

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -166,6 +166,8 @@ public:
   void visitTypeDecl(TypeDecl *type) {
     // We'll visit nested types separately if necessary.
   }
+
+  void visitMissingMemberDecl(MissingMemberDecl *placeholder) {}
   
   void visitFuncDecl(FuncDecl *method) {
     if (!requiresObjCMethodDescriptor(method)) return;
@@ -378,6 +380,8 @@ public:
   void visitTypeDecl(TypeDecl *type) {
     // We'll visit nested types separately if necessary.
   }
+
+  void visitMissingMemberDecl(MissingMemberDecl *placeholder) {}
 
   void visitAbstractFunctionDecl(AbstractFunctionDecl *method) {
     llvm::Constant *name, *imp, *types;
@@ -1673,6 +1677,9 @@ void IRGenModule::emitGlobalDecl(Decl *D) {
   case DeclKind::Destructor:
     llvm_unreachable("there are no global destructor");
 
+  case DeclKind::MissingMember:
+    llvm_unreachable("there are no global member placeholders");
+
   case DeclKind::TypeAlias:
   case DeclKind::GenericTypeParam:
   case DeclKind::AssociatedType:
@@ -2933,6 +2940,7 @@ void IRGenModule::emitNestedTypeDecls(DeclRange members) {
     case DeclKind::Destructor:
     case DeclKind::EnumCase:
     case DeclKind::EnumElement:
+    case DeclKind::MissingMember:
       // Skip non-type members.
       continue;
 

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -3502,6 +3502,10 @@ namespace {
       }
     }
 
+    void addPlaceholder(MissingMemberDecl *) {
+      llvm_unreachable("cannot generate metadata with placeholders in it");
+    }
+
     void addMethodOverride(SILDeclRef baseRef, SILDeclRef declRef) {}
 
     void addGenericArgument(CanType argTy, ClassDecl *forClass) {

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -662,6 +662,13 @@ namespace {
       Entries.push_back(WitnessTableEntry::forFunction(ctor));
     }
 
+    void addPlaceholder(MissingMemberDecl *placeholder) {
+      for (auto i : range(placeholder->getNumberOfVTableEntries())) {
+        (void)i;
+        Entries.push_back(WitnessTableEntry());
+      }
+    }
+
     void addAssociatedType(AssociatedTypeDecl *ty) {
       Entries.push_back(WitnessTableEntry::forAssociatedType(ty));
     }
@@ -1115,6 +1122,10 @@ public:
 
     void addConstructor(ConstructorDecl *requirement) {
       return addMethodFromSILWitnessTable(requirement);
+    }
+
+    void addPlaceholder(MissingMemberDecl *placeholder) {
+      llvm_unreachable("cannot emit a witness table with placeholders in it");
     }
 
     void addAssociatedType(AssociatedTypeDecl *requirement) {

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -1783,14 +1783,15 @@ SILParameterInfo TypeConverter::getConstantSelfParameter(SILDeclRef constant) {
   return ty->getParameters().back();
 }
 
-bool TypeConverter::requiresNewVTableEntry(SILDeclRef method) {
-  auto found = RequiresVTableEntry.find(method);
-  if (found != RequiresVTableEntry.end())
-    return found->second;
-
-  auto result = requiresNewVTableEntryUncached(method);
-  RequiresVTableEntry.insert(std::make_pair(method, result));
-  return result;
+static bool requiresNewVTableEntry(SILDeclRef method) {
+  if (cast<AbstractFunctionDecl>(method.getDecl())->needsNewVTableEntry())
+    return true;
+  if (method.kind == SILDeclRef::Kind::Allocator) {
+    auto *ctor = cast<ConstructorDecl>(method.getDecl());
+    if (ctor->isRequired() && !ctor->getOverriddenDecl()->isRequired())
+      return true;
+  }
+  return false;
 }
 
 // This check duplicates TypeConverter::checkForABIDifferences(),
@@ -1800,128 +1801,8 @@ bool TypeConverter::requiresNewVTableEntry(SILDeclRef method) {
 // @guaranteed or whatever.
 static bool checkASTTypeForABIDifferences(CanType type1,
                                           CanType type2) {
-  // Unwrap optionals, but remember that we did.
-  bool type1WasOptional = false;
-  bool type2WasOptional = false;
-  if (auto object = type1.getAnyOptionalObjectType()) {
-    type1WasOptional = true;
-    type1 = object;
-  }
-  if (auto object = type2.getAnyOptionalObjectType()) {
-    type2WasOptional = true;
-    type2 = object;
-  }
-
-  // Forcing IUOs always requires a new vtable entry.
-  if (type1WasOptional && !type2WasOptional)
-    return true;
-
-  // Except for the above case, we should not be making a value less optional.
-
-  // If we're introducing a level of optionality, only certain types are
-  // ABI-compatible -- check below.
-  bool optionalityChange = (!type1WasOptional && type2WasOptional);
-
-  // If the types are identical and there was no optionality change,
-  // we're done.
-  if (type1 == type2 && !optionalityChange)
-    return false;
-
-  // Classes, class-constrained archetypes, and pure-ObjC existential types
-  // all have single retainable pointer representation; optionality change
-  // is allowed.
-  if ((type1->mayHaveSuperclass() ||
-       type1->isObjCExistentialType()) &&
-      (type2->mayHaveSuperclass() ||
-       type2->isObjCExistentialType()))
-    return false;
-
-  // Class metatypes are ABI-compatible even under optionality change.
-  if (auto metaTy1 = dyn_cast<MetatypeType>(type1)) {
-    if (auto metaTy2 = dyn_cast<MetatypeType>(type2)) {
-      if (metaTy1.getInstanceType().getClassOrBoundGenericClass() &&
-          metaTy2.getInstanceType().getClassOrBoundGenericClass())
-        return false;
-    }
-  }
-
-  if (!optionalityChange) {
-    // Function parameters are ABI compatible if their differences are
-    // trivial.
-    if (auto fnTy1 = dyn_cast<AnyFunctionType>(type1)) {
-      if (auto fnTy2 = dyn_cast<AnyFunctionType>(type2)) {
-        return (
-            checkASTTypeForABIDifferences(fnTy2.getInput(), fnTy1.getInput()) ||
-            checkASTTypeForABIDifferences(fnTy1.getResult(), fnTy2.getResult()));
-      }
-    }
-
-    // Tuple types are ABI-compatible if their elements are.
-    if (auto tuple1 = dyn_cast<TupleType>(type1)) {
-      if (auto tuple2 = dyn_cast<TupleType>(type2)) {
-        if (tuple1->getNumElements() != tuple2->getNumElements())
-          return true;
-
-        for (unsigned i = 0, e = tuple1->getNumElements(); i < e; i++) {
-          if (checkASTTypeForABIDifferences(tuple1.getElementType(i),
-                                            tuple2.getElementType(i)))
-            return true;
-        }
-
-        // Tuple lengths and elements match
-        return false;
-      }
-    }
-  }
-
-  // The types are different, or there was an optionality change resulting
-  // in a change in representation.
-  return true;
-}
-
-bool TypeConverter::requiresNewVTableEntryUncached(SILDeclRef derived) {
-  auto *decl = derived.getDecl();
-
-  // Final members are always be called directly.
-  // Dynamic methods are always accessed by objc_msgSend().
-  if (decl->isFinal() || decl->isDynamic())
-    return false;
-
-  // Special case -- materializeForSet on dynamic storage is not
-  // itself dynamic, but should be treated as such for the
-  // purpose of constructing the vtable.
-  if (auto *fd = dyn_cast<FuncDecl>(decl)) {
-    if (fd->getAccessorKind() == AccessorKind::IsMaterializeForSet &&
-        fd->getAccessorStorageDecl()->isDynamic())
-      return false;
-  }
-
-  // If the method overrides something, we only need a new entry if the
-  // override has a more general AST type. However an abstraction
-  // change is OK; we don't want to add a whole new vtable entry just
-  // because an @in parameter because @owned, or whatever.
-  if (auto base = derived.getNextOverriddenVTableEntry()) {
-    auto baseInfo = getConstantInfo(base);
-    auto derivedInfo = getConstantInfo(derived);
-
-    auto baseInterfaceTy = baseInfo.FormalInterfaceType;
-    auto derivedInterfaceTy = derivedInfo.FormalInterfaceType;
-
-    auto selfInterfaceTy = derivedInterfaceTy.getInput()->getRValueInstanceType();
-
-    auto overrideInterfaceTy =
-        selfInterfaceTy->adjustSuperclassMemberDeclType(
-            base.getDecl(), derived.getDecl(), baseInterfaceTy)
-      ->getCanonicalType();
-
-    if (checkASTTypeForABIDifferences(derivedInterfaceTy, overrideInterfaceTy))
-      return true;
-
-    return false;
-  }
-
-  // We need a new entry.
-  return true;
+  return !type1->matches(type2, TypeMatchFlags::AllowABICompatible,
+                         /*resolver*/nullptr);
 }
 
 SILDeclRef TypeConverter::getOverriddenVTableEntry(SILDeclRef method) {

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -224,6 +224,7 @@ public:
   void visitConstructorDecl(ConstructorDecl *d) {}
   void visitDestructorDecl(DestructorDecl *d) {}
   void visitModuleDecl(ModuleDecl *d) { }
+  void visitMissingMemberDecl(MissingMemberDecl *d) {}
 
   void visitFuncDecl(FuncDecl *fd);
   void visitPatternBindingDecl(PatternBindingDecl *vd);

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -1393,6 +1393,7 @@ void SILGenModule::emitExternalDefinition(Decl *d) {
   case DeclKind::PostfixOperator:
   case DeclKind::PrecedenceGroup:
   case DeclKind::Module:
+  case DeclKind::MissingMember:
     llvm_unreachable("Not a valid external definition for SILGen");
   }
 }

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -203,6 +203,8 @@ public:
     assert(result.second);
     (void) result;
   }
+
+  void addPlaceholder(MissingMemberDecl *) {}
 };
 
 } // end anonymous namespace
@@ -848,6 +850,7 @@ public:
   void visitTypeAliasDecl(TypeAliasDecl *tad) {}
   void visitAbstractTypeParamDecl(AbstractTypeParamDecl *tpd) {}
   void visitModuleDecl(ModuleDecl *md) {}
+  void visitMissingMemberDecl(MissingMemberDecl *) {}
   void visitNominalTypeDecl(NominalTypeDecl *ntd) {
     SILGenType(SGM, ntd).emitType();
   }
@@ -947,6 +950,7 @@ public:
   void visitTypeAliasDecl(TypeAliasDecl *tad) {}
   void visitAbstractTypeParamDecl(AbstractTypeParamDecl *tpd) {}
   void visitModuleDecl(ModuleDecl *md) {}
+  void visitMissingMemberDecl(MissingMemberDecl *) {}
   void visitNominalTypeDecl(NominalTypeDecl *ntd) {
     SILGenType(SGM, ntd).emitType();
   }

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -406,6 +406,10 @@ public:
     super::addConstructor(cd, witness);
   }
 
+  void addPlaceholder(MissingMemberDecl *placeholder) {
+    llvm_unreachable("generating a witness table with placeholders in it");
+  }
+
   void addMethod(SILDeclRef requirementRef,
                  SILDeclRef witnessRef,
                  IsFreeFunctionWitness_t isFree,
@@ -750,6 +754,10 @@ public:
     }
 
     super::addConstructor(cd, witness);
+  }
+
+  void addPlaceholder(MissingMemberDecl *placeholder) {
+    llvm_unreachable("generating a witness table with placeholders in it");
   }
 
   void addMethod(SILDeclRef requirementRef,

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -2149,6 +2149,7 @@ swift::createDesignatedInitOverride(TypeChecker &tc,
   if (kind == DesignatedInitKind::Stub) {
     // Make this a stub implementation.
     createStubBody(tc, ctor);
+    ctor->setNeedsNewVTableEntry(false);
     return ctor;
   }
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1871,6 +1871,7 @@ static void checkAccessibility(TypeChecker &TC, const Decl *D) {
 
   case DeclKind::Param:
   case DeclKind::GenericTypeParam:
+  case DeclKind::MissingMember:
     llvm_unreachable("does not have accessibility");
 
   case DeclKind::IfConfig:
@@ -3867,6 +3868,10 @@ public:
 
   void visitPrecedenceGroupDecl(PrecedenceGroupDecl *PGD) {
     TC.validateDecl(PGD);
+  }
+
+  void visitMissingMemberDecl(MissingMemberDecl *MMD) {
+    llvm_unreachable("should always be type-checked already");
   }
 
   void visitBoundVariable(VarDecl *VD) {
@@ -7026,6 +7031,7 @@ void TypeChecker::validateDecl(ValueDecl *D) {
   case DeclKind::PostfixOperator:
   case DeclKind::PrecedenceGroup:
   case DeclKind::IfConfig:
+  case DeclKind::MissingMember:
     llvm_unreachable("not a value decl");
 
   case DeclKind::Module:
@@ -7465,6 +7471,7 @@ void TypeChecker::validateAccessibility(ValueDecl *D) {
   case DeclKind::PostfixOperator:
   case DeclKind::PrecedenceGroup:
   case DeclKind::IfConfig:
+  case DeclKind::MissingMember:
     llvm_unreachable("not a value decl");
 
   case DeclKind::Module:

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -5722,15 +5722,15 @@ public:
         }
 
         // Failing that, check for subtyping.
-        auto matchMode = OverrideMatchMode::Strict;
+        TypeMatchOptions matchMode = TypeMatchFlags::AllowOverride;
         if (attempt == OverrideCheckingAttempt::MismatchedOptional ||
             attempt == OverrideCheckingAttempt::BaseNameWithMismatchedOptional){
-          matchMode = OverrideMatchMode::AllowTopLevelOptionalMismatch;
+          matchMode |= TypeMatchFlags::AllowTopLevelOptionalMismatch;
         } else if (parentDecl->isObjC()) {
-          matchMode = OverrideMatchMode::AllowNonOptionalForIUOParam;
+          matchMode |= TypeMatchFlags::AllowNonOptionalForIUOParam;
         }
 
-        if (declTy->canOverride(parentDeclTy, matchMode, &TC)) {
+        if (declTy->matches(parentDeclTy, matchMode, &TC)) {
           // If the Objective-C selectors match, always call it exact.
           matches.push_back({parentDecl, objCMatch, parentDeclTy});
           hadExactMatch |= objCMatch;
@@ -5947,9 +5947,9 @@ public:
         auto parentPropertyTy = superclass->adjustSuperclassMemberDeclType(
             matchDecl, decl, matchDecl->getInterfaceType());
         
-        if (!propertyTy->canOverride(parentPropertyTy,
-                                     OverrideMatchMode::Strict,
-                                     &TC)) {
+        if (!propertyTy->matches(parentPropertyTy,
+                                 TypeMatchFlags::AllowOverride,
+                                 &TC)) {
           TC.diagnose(property, diag::override_property_type_mismatch,
                       property->getName(), propertyTy, parentPropertyTy);
           noteFixableMismatchedTypes(TC, decl, matchDecl);

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4537,6 +4537,27 @@ public:
           break;
         }
 
+        if (!isInvalidSuperclass && Super->hasMissingVTableEntries()) {
+          auto *superFile = Super->getModuleScopeContext();
+          if (auto *serialized = dyn_cast<SerializedASTFile>(superFile)) {
+            if (serialized->getLanguageVersionBuiltWith() !=
+                TC.getLangOpts().EffectiveLanguageVersion) {
+              TC.diagnose(CD,
+                          diag::inheritance_from_class_with_missing_vtable_entries_versioned,
+                          Super->getName(),
+                          serialized->getLanguageVersionBuiltWith(),
+                          TC.getLangOpts().EffectiveLanguageVersion);
+              isInvalidSuperclass = true;
+            }
+          }
+          if (!isInvalidSuperclass) {
+            TC.diagnose(
+                CD, diag::inheritance_from_class_with_missing_vtable_entries,
+                Super->getName());
+            isInvalidSuperclass = true;
+          }
+        }
+
         // Require the superclass to be open if this is outside its
         // defining module.  But don't emit another diagnostic if we
         // already complained about the class being inherently

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -38,6 +38,7 @@
 #include "swift/Basic/Defer.h"
 #include "swift/ClangImporter/ClangModule.h"
 #include "swift/Sema/IDETypeChecking.h"
+#include "swift/Serialization/SerializedModuleLoader.h"
 #include "llvm/ADT/ScopedHashTable.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/Support/Compiler.h"
@@ -2021,8 +2022,23 @@ namespace {
     // If the protocol contains missing requirements, it can't be conformed to
     // at all.
     if (Proto->hasMissingRequirements()) {
-      TC.diagnose(ComplainLoc, diag::protocol_has_missing_requirements,
-                  T, Proto->getDeclaredType());
+      bool hasDiagnosed = false;
+      auto *protoFile = Proto->getModuleScopeContext();
+      if (auto *serialized = dyn_cast<SerializedASTFile>(protoFile)) {
+        if (serialized->getLanguageVersionBuiltWith() !=
+            TC.getLangOpts().EffectiveLanguageVersion) {
+          TC.diagnose(ComplainLoc,
+                      diag::protocol_has_missing_requirements_versioned,
+                      T, Proto->getDeclaredType(),
+                      serialized->getLanguageVersionBuiltWith(),
+                      TC.getLangOpts().EffectiveLanguageVersion);
+          hasDiagnosed = true;
+        }
+      }
+      if (!hasDiagnosed) {
+        TC.diagnose(ComplainLoc, diag::protocol_has_missing_requirements,
+                    T, Proto->getDeclaredType());
+      }
       conformance->setInvalid();
       return conformance;
     }

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4458,6 +4458,9 @@ void ModuleFile::loadAllMembers(Decl *container, uint64_t contextData) {
             [&](const DeclDeserializationError &error) {
           if (error.isDesignatedInitializer())
             containingClass->setHasMissingDesignatedInitializers();
+          if (error.needsVTableEntry() || error.needsAllocatingVTableEntry())
+            containingClass->setHasMissingVTableEntries();
+
           if (error.getName().getBaseName() == getContext().Id_init) {
             members.push_back(MissingMemberDecl::forInitializer(
                 getContext(), containingClass, error.getName(),

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -1279,8 +1279,52 @@ ModuleFile::resolveCrossReference(ModuleDecl *baseModule, uint32_t pathLen) {
     return nullptr;
   }
 
+  auto getXRefDeclNameForError = [&]() -> DeclName {
+    DeclName result = pathTrace.getLastName();
+    while (--pathLen) {
+      auto entry = DeclTypeCursor.advance(AF_DontPopBlockAtEnd);
+      if (entry.Kind != llvm::BitstreamEntry::Record)
+        return Identifier();
+
+      unsigned recordID = DeclTypeCursor.readRecord(entry.ID, scratch,
+                                                    &blobData);
+      switch (recordID) {
+      case XREF_TYPE_PATH_PIECE: {
+        IdentifierID IID;
+        XRefTypePathPieceLayout::readRecord(scratch, IID, None);
+        result = getIdentifier(IID);
+        break;
+      }
+      case XREF_VALUE_PATH_PIECE: {
+        IdentifierID IID;
+        XRefValuePathPieceLayout::readRecord(scratch, None, IID, None, None);
+        result = getIdentifier(IID);
+        break;
+      }
+      case XREF_INITIALIZER_PATH_PIECE:
+        result = getContext().Id_init;
+        break;
+
+      case XREF_EXTENSION_PATH_PIECE:
+      case XREF_OPERATOR_OR_ACCESSOR_PATH_PIECE:
+        break;
+
+      case XREF_GENERIC_PARAM_PATH_PIECE:
+        // Can't get the name without deserializing.
+        result = Identifier();
+        break;
+
+      default:
+        // Unknown encoding.
+        return Identifier();
+      }
+    }
+    return result;
+  };
+
   if (values.empty()) {
-    return llvm::make_error<XRefError>("top-level value not found", pathTrace);
+    return llvm::make_error<XRefError>("top-level value not found", pathTrace,
+                                       getXRefDeclNameForError());
   }
 
   // Filters for values discovered in the remaining path pieces.
@@ -1400,7 +1444,8 @@ ModuleFile::resolveCrossReference(ModuleDecl *baseModule, uint32_t pathLen) {
 
       if (values.size() != 1) {
         return llvm::make_error<XRefError>("multiple matching base values",
-                                           pathTrace);
+                                           pathTrace,
+                                           getXRefDeclNameForError());
       }
 
       auto nominal = dyn_cast<NominalTypeDecl>(values.front());
@@ -1408,7 +1453,8 @@ ModuleFile::resolveCrossReference(ModuleDecl *baseModule, uint32_t pathLen) {
 
       if (!nominal) {
         return llvm::make_error<XRefError>("base is not a nominal type",
-                                           pathTrace);
+                                           pathTrace,
+                                           getXRefDeclNameForError());
       }
 
       auto members = nominal->lookupDirect(memberName);
@@ -1498,7 +1544,8 @@ ModuleFile::resolveCrossReference(ModuleDecl *baseModule, uint32_t pathLen) {
     case XREF_GENERIC_PARAM_PATH_PIECE: {
       if (values.size() != 1) {
         return llvm::make_error<XRefError>("multiple matching base values",
-                                           pathTrace);
+                                           pathTrace,
+                                           getXRefDeclNameForError());
       }
 
       uint32_t paramIndex;
@@ -1534,12 +1581,12 @@ ModuleFile::resolveCrossReference(ModuleDecl *baseModule, uint32_t pathLen) {
       if (!paramList) {
         return llvm::make_error<XRefError>(
             "cross-reference to generic param for non-generic type",
-            pathTrace);
+            pathTrace, getXRefDeclNameForError());
       }
       if (paramIndex >= paramList->size()) {
         return llvm::make_error<XRefError>(
             "generic argument index out of bounds",
-            pathTrace);
+            pathTrace, getXRefDeclNameForError());
       }
 
       values.clear();
@@ -1563,7 +1610,8 @@ ModuleFile::resolveCrossReference(ModuleDecl *baseModule, uint32_t pathLen) {
     }
 
     if (values.empty()) {
-      return llvm::make_error<XRefError>("result not found", pathTrace);
+      return llvm::make_error<XRefError>("result not found", pathTrace,
+                                         getXRefDeclNameForError());
     }
 
     // Reset the module filter.
@@ -2043,6 +2091,9 @@ ModuleFile::getDeclChecked(DeclID DID, Optional<DeclContext *> ForcedContext) {
     ctx.Stats->getFrontendCounters().NumDeclsDeserialized++;
 
   // Read the attributes (if any).
+  // This isn't just using DeclAttributes because that would result in the
+  // attributes getting reversed.
+  // FIXME: If we reverse them at serialization time we could get rid of this.
   DeclAttribute *DAttrs = nullptr;
   DeclAttribute **AttrsNext = &DAttrs;
   auto AddAttribute = [&](DeclAttribute *Attr) {
@@ -2520,11 +2571,12 @@ ModuleFile::getDeclChecked(DeclID DID, Optional<DeclContext *> ForcedContext) {
   case decls_block::CONSTRUCTOR_DECL: {
     DeclContextID contextID;
     uint8_t rawFailability;
-    bool isImplicit, isObjC, hasStubImplementation, throws, needsNewVTableEntry;
+    bool isImplicit, isObjC, hasStubImplementation, throws;
     GenericEnvironmentID genericEnvID;
     uint8_t storedInitKind, rawAccessLevel;
     TypeID interfaceID, canonicalTypeID;
     DeclID overriddenID;
+    bool needsNewVTableEntry, firstTimeRequired;
     ArrayRef<uint64_t> argNameIDs;
 
     decls_block::ConstructorLayout::readRecord(scratch, contextID,
@@ -2534,7 +2586,9 @@ ModuleFile::getDeclChecked(DeclID DID, Optional<DeclContext *> ForcedContext) {
                                                genericEnvID, interfaceID,
                                                canonicalTypeID, overriddenID,
                                                rawAccessLevel,
-                                               needsNewVTableEntry, argNameIDs);
+                                               needsNewVTableEntry,
+                                               firstTimeRequired,
+                                               argNameIDs);
 
     // Resolve the name ids.
     SmallVector<Identifier, 2> argNames;
@@ -2545,20 +2599,29 @@ ModuleFile::getDeclChecked(DeclID DID, Optional<DeclContext *> ForcedContext) {
     Optional<swift::CtorInitializerKind> initKind =
         getActualCtorInitializerKind(storedInitKind);
 
-    auto errorKind = DeclDeserializationError::Normal;
+    DeclDeserializationError::Flags errorFlags;
     if (initKind == CtorInitializerKind::Designated)
-      errorKind = DeclDeserializationError::DesignatedInitializer;
+      errorFlags |= DeclDeserializationError::DesignatedInitializer;
+    if (needsNewVTableEntry) {
+      errorFlags |= DeclDeserializationError::NeedsVTableEntry;
+      DeclAttributes attrs;
+      attrs.setRawAttributeChain(DAttrs);
+      if (attrs.hasAttribute<RequiredAttr>())
+        errorFlags |= DeclDeserializationError::NeedsAllocatingVTableEntry;
+    }
+    if (firstTimeRequired)
+      errorFlags |= DeclDeserializationError::NeedsAllocatingVTableEntry;
 
     auto overridden = getDeclChecked(overriddenID);
     if (!overridden) {
       llvm::consumeError(overridden.takeError());
-      return llvm::make_error<OverrideError>(name, errorKind);
+      return llvm::make_error<OverrideError>(name, errorFlags);
     }
 
     auto canonicalType = getTypeChecked(canonicalTypeID);
     if (!canonicalType) {
       return llvm::make_error<TypeError>(
-          name, takeErrorInfo(canonicalType.takeError()), errorKind);
+          name, takeErrorInfo(canonicalType.takeError()), errorFlags);
     }
 
     auto parent = getDeclContext(contextID);
@@ -2780,16 +2843,20 @@ ModuleFile::getDeclChecked(DeclID DID, Optional<DeclContext *> ForcedContext) {
         name = DeclName(names[0]);
     }
 
+    DeclDeserializationError::Flags errorFlags;
+    if (needsNewVTableEntry)
+      errorFlags |= DeclDeserializationError::NeedsVTableEntry;
+
     Expected<Decl *> overridden = getDeclChecked(overriddenID);
     if (!overridden) {
       llvm::consumeError(overridden.takeError());
-      return llvm::make_error<OverrideError>(name);
+      return llvm::make_error<OverrideError>(name, errorFlags);
     }
 
     auto canonicalType = getTypeChecked(canonicalTypeID);
     if (!canonicalType) {
       return llvm::make_error<TypeError>(
-          name, takeErrorInfo(canonicalType.takeError()));
+          name, takeErrorInfo(canonicalType.takeError()), errorFlags);
     }
 
     auto DC = getDeclContext(contextID);
@@ -3699,9 +3766,10 @@ Expected<Type> ModuleFile::getTypeChecked(TypeID TID) {
     auto nominal = dyn_cast<NominalTypeDecl>(nominalOrError.get());
     if (!nominal) {
       XRefTracePath tinyTrace{*nominalOrError.get()->getModuleContext()};
-      tinyTrace.addValue(cast<ValueDecl>(nominalOrError.get())->getName());
+      DeclName fullName = cast<ValueDecl>(nominalOrError.get())->getFullName();
+      tinyTrace.addValue(fullName.getBaseName());
       return llvm::make_error<XRefError>("declaration is not a nominal type",
-                                         tinyTrace);
+                                         tinyTrace, fullName);
     }
     typeOrOffset = NominalType::get(nominal, parentTy.get(), ctx);
 
@@ -4381,17 +4449,25 @@ void ModuleFile::loadAllMembers(Decl *container, uint64_t contextData) {
         fatal(next.takeError());
 
       // Drop the member if it had a problem.
-      // FIXME: If this was a non-final, non-dynamic, non-@objc-overriding
-      // member, it's going to affect the vtable layout, and /every single call/
-      // will be wrong.
+      // FIXME: Handle overridable members in class extensions too, someday.
       if (auto *containingClass = dyn_cast<ClassDecl>(container)) {
-        auto handleMissingDesignatedInit =
-            [containingClass](const DeclDeserializationError &error) {
-          if (error.getKind() != OverrideError::DesignatedInitializer)
-            return;
-          containingClass->setHasMissingDesignatedInitializers();
+        auto handleMissingClassMember =
+            [&](const DeclDeserializationError &error) {
+          if (error.isDesignatedInitializer())
+            containingClass->setHasMissingDesignatedInitializers();
+          if (error.getName().getBaseName() == getContext().Id_init) {
+            members.push_back(MissingMemberDecl::forInitializer(
+                getContext(), containingClass, error.getName(),
+                error.needsVTableEntry(), error.needsAllocatingVTableEntry()));
+          } else if (error.needsVTableEntry()) {
+            members.push_back(MissingMemberDecl::forMethod(
+                getContext(), containingClass, error.getName(),
+                error.needsVTableEntry()));
+          }
+          // FIXME: Handle other kinds of missing members: properties,
+          // subscripts, and methods that don't need vtable entries.
         };
-        llvm::handleAllErrors(next.takeError(), handleMissingDesignatedInit);
+        llvm::handleAllErrors(next.takeError(), handleMissingClassMember);
       } else {
         llvm::consumeError(next.takeError());
       }

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2520,7 +2520,7 @@ ModuleFile::getDeclChecked(DeclID DID, Optional<DeclContext *> ForcedContext) {
   case decls_block::CONSTRUCTOR_DECL: {
     DeclContextID contextID;
     uint8_t rawFailability;
-    bool isImplicit, isObjC, hasStubImplementation, throws;
+    bool isImplicit, isObjC, hasStubImplementation, throws, needsNewVTableEntry;
     GenericEnvironmentID genericEnvID;
     uint8_t storedInitKind, rawAccessLevel;
     TypeID interfaceID, canonicalTypeID;
@@ -2533,7 +2533,8 @@ ModuleFile::getDeclChecked(DeclID DID, Optional<DeclContext *> ForcedContext) {
                                                throws, storedInitKind,
                                                genericEnvID, interfaceID,
                                                canonicalTypeID, overriddenID,
-                                               rawAccessLevel, argNameIDs);
+                                               rawAccessLevel,
+                                               needsNewVTableEntry, argNameIDs);
 
     // Resolve the name ids.
     SmallVector<Identifier, 2> argNames;
@@ -2625,6 +2626,7 @@ ModuleFile::getDeclChecked(DeclID DID, Optional<DeclContext *> ForcedContext) {
       ctor->setInitKind(initKind.getValue());
     if (auto overriddenCtor = cast_or_null<ConstructorDecl>(overridden.get()))
       ctor->setOverriddenDecl(overriddenCtor);
+    ctor->setNeedsNewVTableEntry(needsNewVTableEntry);
     break;
   }
 
@@ -2751,7 +2753,7 @@ ModuleFile::getDeclChecked(DeclID DID, Optional<DeclContext *> ForcedContext) {
     DeclID associatedDeclID;
     DeclID overriddenID;
     DeclID accessorStorageDeclID;
-    bool hasCompoundName;
+    bool hasCompoundName, needsNewVTableEntry;
     ArrayRef<uint64_t> nameIDs;
 
     decls_block::FuncLayout::readRecord(scratch, contextID, isImplicit,
@@ -2762,7 +2764,7 @@ ModuleFile::getDeclChecked(DeclID DID, Optional<DeclContext *> ForcedContext) {
                                         associatedDeclID, overriddenID,
                                         accessorStorageDeclID, hasCompoundName,
                                         rawAddressorKind, rawAccessLevel,
-                                        nameIDs);
+                                        needsNewVTableEntry, nameIDs);
 
     // Resolve the name ids.
     SmallVector<Identifier, 2> names;
@@ -2880,6 +2882,7 @@ ModuleFile::getDeclChecked(DeclID DID, Optional<DeclContext *> ForcedContext) {
       fn->setImplicit();
     fn->setMutating(isMutating);
     fn->setDynamicSelf(hasDynamicSelf);
+    fn->setNeedsNewVTableEntry(needsNewVTableEntry);
     break;
   }
 

--- a/lib/Serialization/DeserializationErrors.h
+++ b/lib/Serialization/DeserializationErrors.h
@@ -50,6 +50,21 @@ class XRefTracePath {
       : kind(K),
         data(llvm::PointerLikeTypeTraits<T>::getAsVoidPointer(value)) {}
 
+    Identifier getAsIdentifier() const {
+      switch (kind) {
+      case Kind::Value:
+      case Kind::Operator:
+        return getDataAs<Identifier>();
+      case Kind::Type:
+      case Kind::OperatorFilter:
+      case Kind::Accessor:
+      case Kind::Extension:
+      case Kind::GenericParam:
+      case Kind::Unknown:
+        return Identifier();
+      }
+    }
+
     void print(raw_ostream &os) const {
       switch (kind) {
       case Kind::Value:
@@ -164,6 +179,15 @@ public:
     path.push_back({ PathPiece::Kind::Unknown, kind });
   }
 
+  Identifier getLastName() const {
+    for (auto &piece : reversed(path)) {
+      Identifier result = piece.getAsIdentifier();
+      if (!result.empty())
+        return result;
+    }
+    return Identifier();
+  }
+
   void removeLast() {
     path.pop_back();
   }
@@ -183,17 +207,30 @@ class DeclDeserializationError : public llvm::ErrorInfoBase {
   void anchor() override;
 
 public:
-  enum Kind {
-    Normal,
-    DesignatedInitializer
+  enum Flag : unsigned {
+    DesignatedInitializer = 1 << 0,
+    NeedsVTableEntry = 1 << 1,
+    NeedsAllocatingVTableEntry = 1 << 2,
   };
+  using Flags = OptionSet<Flag>;
 
 protected:
-  Kind kind = Normal;
+  DeclName name;
+  Flags flags;
 
 public:
-  Kind getKind() const {
-    return kind;
+  DeclName getName() const {
+    return name;
+  }
+
+  bool isDesignatedInitializer() const {
+    return flags.contains(Flag::DesignatedInitializer);
+  }
+  bool needsVTableEntry() const {
+    return flags.contains(Flag::NeedsVTableEntry);
+  }
+  bool needsAllocatingVTableEntry() const {
+    return flags.contains(Flag::NeedsAllocatingVTableEntry);
   }
 
   bool isA(const void *const ClassID) const override {
@@ -212,8 +249,10 @@ class XRefError : public llvm::ErrorInfo<XRefError, DeclDeserializationError> {
   const char *message;
 public:
   template <size_t N>
-  XRefError(const char (&message)[N], XRefTracePath path)
-      : path(path), message(message) {}
+  XRefError(const char (&message)[N], XRefTracePath path, DeclName name)
+      : path(path), message(message) {
+    this->name = name;
+  }
 
   void log(raw_ostream &OS) const override {
     OS << message << "\n";
@@ -232,11 +271,10 @@ private:
   static const char ID;
   void anchor() override;
 
-  DeclName name;
-
 public:
-  explicit OverrideError(DeclName name, Kind kind = Normal) : name(name) {
-    this->kind = kind;
+  explicit OverrideError(DeclName name, Flags flags = {}) {
+    this->name = name;
+    this->flags = flags;
   }
 
   void log(raw_ostream &OS) const override {
@@ -253,13 +291,13 @@ class TypeError : public llvm::ErrorInfo<TypeError, DeclDeserializationError> {
   static const char ID;
   void anchor() override;
 
-  DeclName name;
   std::unique_ptr<ErrorInfoBase> underlyingReason;
 public:
   explicit TypeError(DeclName name, std::unique_ptr<ErrorInfoBase> reason,
-                     Kind kind = Normal)
-      : name(name), underlyingReason(std::move(reason)) {
-    this->kind = kind;
+                     Flags flags = {})
+      : underlyingReason(std::move(reason)) {
+    this->name = name;
+    this->flags = flags;
   }
 
   void log(raw_ostream &OS) const override {

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -1925,3 +1925,7 @@ ClassDecl *SerializedASTFile::getMainClass() const {
   assert(hasEntryPoint());
   return cast_or_null<ClassDecl>(File.getDecl(File.Bits.EntryPointDeclID));
 }
+
+const version::Version &SerializedASTFile::getLanguageVersionBuiltWith() const {
+  return File.CompatibilityVersion;
+}

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2315,6 +2315,8 @@ void Serializer::writeForeignErrorConvention(const ForeignErrorConvention &fec){
 void Serializer::writeDecl(const Decl *D) {
   using namespace decls_block;
 
+  PrettyStackTraceDecl trace("serializing", D);
+
   auto id = DeclAndTypeIDs[D].first;
   assert(id != 0 && "decl or type not referenced properly");
   (void)id;
@@ -2850,6 +2852,7 @@ void Serializer::writeDecl(const Decl *D) {
                            !fn->getFullName().isSimpleName(),
                            rawAddressorKind,
                            rawAccessLevel,
+                           fn->needsNewVTableEntry(),
                            nameComponents);
 
     writeGenericParams(fn->getGenericParams());
@@ -2972,6 +2975,7 @@ void Serializer::writeDecl(const Decl *D) {
                                   addTypeRef(ty->getCanonicalType()),
                                   addDeclRef(ctor->getOverriddenDecl()),
                                   rawAccessLevel,
+                                  ctor->needsNewVTableEntry(),
                                   nameComponents);
 
     writeGenericParams(ctor->getGenericParams());

--- a/lib/Syntax/LegacyASTTransformer.cpp
+++ b/lib/Syntax/LegacyASTTransformer.cpp
@@ -278,6 +278,15 @@ LegacyASTTransformer::visitPostfixOperatorDecl(
   return getUnknownDecl(D);
 }
 
+
+RC<SyntaxData>
+LegacyASTTransformer::visitMissingMemberDecl(
+    MissingMemberDecl *D,
+    const SyntaxData *Parent,
+    const CursorIndex IndexInParent) {
+  return getUnknownDecl(D);
+}
+
 RC<SyntaxData>
 LegacyASTTransformer::visitGenericTypeParamDecl(
     GenericTypeParamDecl *D,

--- a/test/Compatibility/MixAndMatch/witness_change.swift
+++ b/test/Compatibility/MixAndMatch/witness_change.swift
@@ -1,9 +1,9 @@
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-experimental-deserialization-recovery -emit-module -o %t/SomeObjCModule.swiftmodule -module-name SomeObjCModule -I %t -I %S/Inputs -swift-version 3 %S/Inputs/SomeObjCModuleX.swift
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-experimental-deserialization-recovery -emit-module -o %t/SomeSwift3Module.swiftmodule -module-name SomeSwift3Module -I %t -I %S/Inputs -swift-version 3 %s
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-experimental-deserialization-recovery -emit-module -o %t/SomeSwift4Module.swiftmodule -module-name SomeSwift4Module -I %t -I %S/Inputs -swift-version 4 %S/Inputs/witness_change_swift4.swift
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-experimental-deserialization-recovery -c -I %t -I %S/Inputs -swift-version 3 %S/Inputs/witness_change_swift3_leaf.swift
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t/SomeObjCModule.swiftmodule -module-name SomeObjCModule -I %t -I %S/Inputs -swift-version 3 %S/Inputs/SomeObjCModuleX.swift
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t/SomeSwift3Module.swiftmodule -module-name SomeSwift3Module -I %t -I %S/Inputs -swift-version 3 %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t/SomeSwift4Module.swiftmodule -module-name SomeSwift4Module -I %t -I %S/Inputs -swift-version 4 %S/Inputs/witness_change_swift4.swift
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -c -I %t -I %S/Inputs -swift-version 3 %S/Inputs/witness_change_swift3_leaf.swift
 
 // REQUIRES: objc_interop
 

--- a/test/Serialization/Recovery/Inputs/custom-modules/Types.apinotes
+++ b/test/Serialization/Recovery/Inputs/custom-modules/Types.apinotes
@@ -25,6 +25,8 @@ SwiftVersions:
   Typedefs:
   - Name: RenamedTypedef
     SwiftName: Swift3RenamedTypedef
+  - Name: NewlyWrappedTypedef
+    SwiftWrapper: none
   Tags:
   - Name: RenamedStruct
     SwiftName: Swift3RenamedStruct

--- a/test/Serialization/Recovery/Inputs/custom-modules/Types.h
+++ b/test/Serialization/Recovery/Inputs/custom-modules/Types.h
@@ -9,6 +9,7 @@
 @end
 
 typedef int RenamedTypedef;
+typedef int NewlyWrappedTypedef __attribute__((swift_wrapper(struct)));
 
 struct RenamedStruct {
   int value;

--- a/test/Serialization/Recovery/crash-recovery.swift
+++ b/test/Serialization/Recovery/crash-recovery.swift
@@ -1,8 +1,8 @@
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: %target-swift-frontend -emit-module -o %t -module-name Lib -I %S/Inputs/custom-modules -swift-version 3 %s
 
-// RUN: not --crash %target-swift-ide-test -source-filename=x -print-module -module-to-print Lib -I %t -I %S/Inputs/custom-modules -swift-version 3 -Xcc -DBAD 2>&1 | %FileCheck -check-prefix CHECK-CRASH -check-prefix CHECK-CRASH-3 %s
-// RUN: not --crash %target-swift-ide-test -source-filename=x -print-module -module-to-print Lib -I %t -I %S/Inputs/custom-modules -swift-version 4 -Xcc -DBAD 2>&1 | %FileCheck -check-prefix CHECK-CRASH -check-prefix CHECK-CRASH-4 %s
+// RUN: echo 'import Lib; _ = Sub.disappearingMethod' | not --crash %target-swift-frontend -typecheck -I %t -I %S/Inputs/custom-modules -swift-version 3 -disable-deserialization-recovery -Xcc -DBAD - 2>&1 | %FileCheck -check-prefix CHECK-CRASH -check-prefix CHECK-CRASH-3 %s
+// RUN: echo 'import Lib; _ = Sub.disappearingMethod' | not --crash %target-swift-frontend -typecheck -I %t -I %S/Inputs/custom-modules -swift-version 4 -disable-deserialization-recovery -Xcc -DBAD - 2>&1 | %FileCheck -check-prefix CHECK-CRASH -check-prefix CHECK-CRASH-4 %s
 
 // REQUIRES: objc_interop
 

--- a/test/Serialization/Recovery/overrides.swift
+++ b/test/Serialization/Recovery/overrides.swift
@@ -3,9 +3,9 @@
 
 // RUN: %target-swift-ide-test -source-filename=x -print-module -module-to-print Lib -I %t -I %S/Inputs/custom-modules | %FileCheck %s
 
-// RUN: %target-swift-ide-test -source-filename=x -print-module -module-to-print Lib -I %t -I %S/Inputs/custom-modules -Xcc -DBAD -enable-experimental-deserialization-recovery | %FileCheck -check-prefix CHECK-RECOVERY %s
+// RUN: %target-swift-ide-test -source-filename=x -print-module -module-to-print Lib -I %t -I %S/Inputs/custom-modules -Xcc -DBAD | %FileCheck -check-prefix CHECK-RECOVERY %s
 
-// RUN: %target-swift-frontend -typecheck %s -I %t -I %S/Inputs/custom-modules -Xcc -DBAD -enable-experimental-deserialization-recovery -D TEST -verify
+// RUN: %target-swift-frontend -typecheck %s -I %t -I %S/Inputs/custom-modules -Xcc -DBAD -D TEST -verify
 
 // REQUIRES: objc_interop
 

--- a/test/Serialization/Recovery/overrides.swift
+++ b/test/Serialization/Recovery/overrides.swift
@@ -191,6 +191,7 @@ open class D1_DesignatedInitDisappears : DesignatedInitDisappearsBase {
 
 // CHECK-RECOVERY-LABEL: class D1_DesignatedInitDisappears : DesignatedInitDisappearsBase {
 // CHECK-RECOVERY-NEXT: init()
+// CHECK-RECOVERY-NEXT: /* placeholder for init(value:) */
 // CHECK-RECOVERY-NEXT: {{^}$}}
 
 
@@ -203,6 +204,7 @@ open class D2_OnlyDesignatedInitDisappears : OnlyDesignatedInitDisappearsBase {
 // CHECK-NEXT: {{^}$}}
 
 // CHECK-RECOVERY-LABEL: class D2_OnlyDesignatedInitDisappears : OnlyDesignatedInitDisappearsBase {
+// CHECK-RECOVERY-NEXT: /* placeholder for init(value:) */
 // CHECK-RECOVERY-NEXT: {{^}$}}
 
 
@@ -231,6 +233,7 @@ open class D4_UnknownInitDisappears : UnknownInitDisappearsBase {
 
 // CHECK-RECOVERY-LABEL: class D4_UnknownInitDisappears : UnknownInitDisappearsBase {
 // CHECK-RECOVERY-NEXT: init()
+// CHECK-RECOVERY-NEXT: /* placeholder for init(value:) */
 // CHECK-RECOVERY-NEXT: {{^}$}}
 
 
@@ -244,7 +247,68 @@ open class D5_OnlyUnknownInitDisappears : OnlyUnknownInitDisappearsBase {
 // CHECK-NEXT: {{^}$}}
 
 // CHECK-RECOVERY-LABEL: class D5_OnlyUnknownInitDisappears : OnlyUnknownInitDisappearsBase {
+// CHECK-RECOVERY-NEXT: /* placeholder for init(value:) */
 // CHECK-RECOVERY-NEXT: init()
+// CHECK-RECOVERY-NEXT: {{^}$}}
+
+open class D6_UnknownInitDisappearsGrandchild : D4_UnknownInitDisappears {
+  public override init() { fatalError() }
+  public override init(value: Int) { fatalError() }
+}
+
+// CHECK-LABEL: class D6_UnknownInitDisappearsGrandchild : D4_UnknownInitDisappears {
+// CHECK-NEXT: init()
+// CHECK-NEXT: init(value: Int)
+// CHECK-NEXT: {{^}$}}
+
+// CHECK-RECOVERY-LABEL: class D6_UnknownInitDisappearsGrandchild : D4_UnknownInitDisappears {
+// CHECK-RECOVERY-NEXT: init()
+// CHECK-RECOVERY-NEXT: /* placeholder for init(value:) */
+// CHECK-RECOVERY-NEXT: {{^}$}}
+
+open class D7_UnknownInitDisappearsGrandchildRequired : D4_UnknownInitDisappears {
+  public override init() { fatalError() }
+  public required override init(value: Int) { fatalError() }
+}
+
+// CHECK-LABEL: class D7_UnknownInitDisappearsGrandchildRequired : D4_UnknownInitDisappears {
+// CHECK-NEXT: init()
+// CHECK-NEXT: init(value: Int)
+// CHECK-NEXT: {{^}$}}
+
+// CHECK-RECOVERY-LABEL: class D7_UnknownInitDisappearsGrandchildRequired : D4_UnknownInitDisappears {
+// CHECK-RECOVERY-NEXT: init()
+// CHECK-RECOVERY-NEXT: /* placeholder for init(value:) */
+// CHECK-RECOVERY-NEXT: {{^}$}}
+
+open class D8_UnknownInitDisappearsRequired : UnknownInitDisappearsBase {
+  public override init() { fatalError() }
+  public required override init(value: Int) { fatalError() }
+}
+
+// CHECK-LABEL: class D8_UnknownInitDisappearsRequired : UnknownInitDisappearsBase {
+// CHECK-NEXT: init()
+// CHECK-NEXT: init(value: Int)
+// CHECK-NEXT: {{^}$}}
+
+// CHECK-RECOVERY-LABEL: class D8_UnknownInitDisappearsRequired : UnknownInitDisappearsBase {
+// CHECK-RECOVERY-NEXT: init()
+// CHECK-RECOVERY-NEXT: /* placeholder for init(value:) */
+// CHECK-RECOVERY-NEXT: {{^}$}}
+
+open class D9_UnknownInitDisappearsRequiredGrandchild : D8_UnknownInitDisappearsRequired {
+  public override init() { fatalError() }
+  public required init(value: Int) { fatalError() }
+}
+
+// CHECK-LABEL: class D9_UnknownInitDisappearsRequiredGrandchild : D8_UnknownInitDisappearsRequired {
+// CHECK-NEXT: init()
+// CHECK-NEXT: init(value: Int)
+// CHECK-NEXT: {{^}$}}
+
+// CHECK-RECOVERY-LABEL: class D9_UnknownInitDisappearsRequiredGrandchild : D8_UnknownInitDisappearsRequired {
+// CHECK-RECOVERY-NEXT: init()
+// CHECK-RECOVERY-NEXT: /* placeholder for init(value:) */
 // CHECK-RECOVERY-NEXT: {{^}$}}
 
 #endif // TEST

--- a/test/Serialization/Recovery/type-removal-objc.swift
+++ b/test/Serialization/Recovery/type-removal-objc.swift
@@ -3,7 +3,7 @@
 
 // RUN: %target-swift-ide-test -source-filename=x -print-module -module-to-print Lib -I %t -I %S/Inputs/custom-modules | %FileCheck %s
 
-// RUN: %target-swift-ide-test -source-filename=x -print-module -module-to-print Lib -I %t -I %S/Inputs/custom-modules -Xcc -DBAD -enable-experimental-deserialization-recovery > %t.txt
+// RUN: %target-swift-ide-test -source-filename=x -print-module -module-to-print Lib -I %t -I %S/Inputs/custom-modules -Xcc -DBAD > %t.txt
 // RUN: %FileCheck -check-prefix CHECK-RECOVERY %s < %t.txt
 // RUN: %FileCheck -check-prefix CHECK-RECOVERY-NEGATIVE %s < %t.txt
 

--- a/test/Serialization/Recovery/typedefs-in-protocols.swift
+++ b/test/Serialization/Recovery/typedefs-in-protocols.swift
@@ -17,7 +17,7 @@ import Lib
 
 // CHECK-IR-LABEL: define{{.*}} void @_T04main19testWitnessDispatch
 public func testWitnessDispatch(user: Proto) {
-  // The important thing in this CHECK line is the "i64 11", which is the offset
+  // The important thing in this CHECK line is the "i32 11", which is the offset
   // for the witness table slot for 'lastMethod()'. If the layout here
   // changes, please check that offset 11 is still correct.
   // CHECK-IR-NOT: ret
@@ -33,7 +33,7 @@ public func testWitnessDispatch(user: Proto) {
 
 // CHECK-IR-LABEL: define{{.*}} void @_T04main19testGenericDispatch
 public func testGenericDispatch<T: Proto>(user: T) {
-  // The important thing in this CHECK line is the "i64 11", which is the offset
+  // The important thing in this CHECK line is the "i32 11", which is the offset
   // for the witness table slot for 'lastMethod()'. If the layout here
   // changes, please check that offset 11 is still correct.
   // CHECK-IR-NOT: ret

--- a/test/Serialization/Recovery/typedefs-in-protocols.swift
+++ b/test/Serialization/Recovery/typedefs-in-protocols.swift
@@ -3,12 +3,12 @@
 
 // RUN: %target-swift-ide-test -source-filename=x -print-module -module-to-print Lib -I %t -I %S/Inputs/custom-modules | %FileCheck %s
 
-// RUN: %target-swift-ide-test -source-filename=x -print-module -module-to-print Lib -I %t -I %S/Inputs/custom-modules -Xcc -DBAD -enable-experimental-deserialization-recovery | %FileCheck -check-prefix CHECK-RECOVERY %s
+// RUN: %target-swift-ide-test -source-filename=x -print-module -module-to-print Lib -I %t -I %S/Inputs/custom-modules -Xcc -DBAD | %FileCheck -check-prefix CHECK-RECOVERY %s
 
-// RUN: %target-swift-frontend -typecheck -I %t -I %S/Inputs/custom-modules -Xcc -DBAD -DTEST -enable-experimental-deserialization-recovery -DVERIFY %s -verify
+// RUN: %target-swift-frontend -typecheck -I %t -I %S/Inputs/custom-modules -Xcc -DBAD -DTEST -DVERIFY %s -verify
 
 // RUN: %target-swift-frontend -emit-ir -I %t -I %S/Inputs/custom-modules -DTEST %s | %FileCheck -check-prefix CHECK-IR %s
-// RUN: %target-swift-frontend -emit-ir -I %t -I %S/Inputs/custom-modules -Xcc -DBAD -DTEST -enable-experimental-deserialization-recovery %s | %FileCheck -check-prefix CHECK-IR %s
+// RUN: %target-swift-frontend -emit-ir -I %t -I %S/Inputs/custom-modules -Xcc -DBAD -DTEST %s | %FileCheck -check-prefix CHECK-IR %s
 
 #if TEST
 

--- a/test/Serialization/Recovery/typedefs-in-protocols.swift
+++ b/test/Serialization/Recovery/typedefs-in-protocols.swift
@@ -1,0 +1,132 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: %target-swift-frontend -emit-sil -o - -emit-module-path %t/Lib.swiftmodule -module-name Lib -I %S/Inputs/custom-modules -disable-objc-attr-requires-foundation-module %s | %FileCheck -check-prefix CHECK-WITNESS-TABLE %s
+
+// RUN: %target-swift-ide-test -source-filename=x -print-module -module-to-print Lib -I %t -I %S/Inputs/custom-modules | %FileCheck %s
+
+// RUN: %target-swift-ide-test -source-filename=x -print-module -module-to-print Lib -I %t -I %S/Inputs/custom-modules -Xcc -DBAD -enable-experimental-deserialization-recovery | %FileCheck -check-prefix CHECK-RECOVERY %s
+
+// RUN: %target-swift-frontend -typecheck -I %t -I %S/Inputs/custom-modules -Xcc -DBAD -DTEST -enable-experimental-deserialization-recovery -DVERIFY %s -verify
+
+// RUN: %target-swift-frontend -emit-ir -I %t -I %S/Inputs/custom-modules -DTEST %s | %FileCheck -check-prefix CHECK-IR %s
+// RUN: %target-swift-frontend -emit-ir -I %t -I %S/Inputs/custom-modules -Xcc -DBAD -DTEST -enable-experimental-deserialization-recovery %s | %FileCheck -check-prefix CHECK-IR %s
+
+#if TEST
+
+import Typedefs
+import Lib
+
+// CHECK-IR-LABEL: define{{.*}} void @_T04main19testWitnessDispatch
+public func testWitnessDispatch(user: Proto) {
+  // The important thing in this CHECK line is the "i64 11", which is the offset
+  // for the witness table slot for 'lastMethod()'. If the layout here
+  // changes, please check that offset 11 is still correct.
+  // CHECK-IR-NOT: ret
+  // CHECK-IR: [[SLOT:%.+]] = getelementptr inbounds i8*, i8** {{%.+}}, i32 11
+  // CHECK-IR-NOT: ret
+  // CHECK-IR: [[RAW_METHOD:%.+]] = load i8*, i8** [[SLOT]]
+  // CHECK-IR-NOT: ret
+  // CHECK-IR: [[METHOD:%.+]] = bitcast i8* [[RAW_METHOD]] to void (%swift.opaque*, %swift.type*, i8**)*
+  // CHECK-IR-NOT: ret
+  // CHECK-IR: call swiftcc void [[METHOD]](
+  _ = user.lastMethod()
+} // CHECK-IR: ret void
+
+// CHECK-IR-LABEL: define{{.*}} void @_T04main19testGenericDispatch
+public func testGenericDispatch<T: Proto>(user: T) {
+  // The important thing in this CHECK line is the "i64 11", which is the offset
+  // for the witness table slot for 'lastMethod()'. If the layout here
+  // changes, please check that offset 11 is still correct.
+  // CHECK-IR-NOT: ret
+  // CHECK-IR: [[SLOT:%.+]] = getelementptr inbounds i8*, i8** %T.Proto, i32 11
+  // CHECK-IR-NOT: ret
+  // CHECK-IR: [[RAW_METHOD:%.+]] = load i8*, i8** [[SLOT]]
+  // CHECK-IR-NOT: ret
+  // CHECK-IR: [[METHOD:%.+]] = bitcast i8* [[RAW_METHOD]] to void (%swift.opaque*, %swift.type*, i8**)*
+  // CHECK-IR-NOT: ret
+  // CHECK-IR: call swiftcc void [[METHOD]](
+  _ = user.lastMethod()
+} // CHECK-IR: ret void
+
+#if VERIFY
+
+public class TestImpl : Proto {} // expected-error {{type 'TestImpl' cannot conform to protocol 'Proto' because it has requirements that cannot be satisfied}}
+
+#endif // VERIFY
+
+#else // TEST
+
+import Typedefs
+
+// CHECK-LABEL: protocol Proto {
+// CHECK-RECOVERY-LABEL: protocol Proto {
+public protocol Proto {
+  // CHECK: var unwrappedProp: UnwrappedInt? { get set }
+  // CHECK-RECOVERY: var unwrappedProp: Int32?
+  var unwrappedProp: UnwrappedInt? { get set }
+  // CHECK: var wrappedProp: WrappedInt? { get set }
+  // CHECK-RECOVERY: /* placeholder for _ */
+  // CHECK-RECOVERY: /* placeholder for _ */
+  // CHECK-RECOVERY: /* placeholder for _ */
+  var wrappedProp: WrappedInt? { get set }
+
+  // CHECK: func returnsUnwrappedMethod() -> UnwrappedInt
+  // CHECK-RECOVERY: func returnsUnwrappedMethod() -> Int32
+  func returnsUnwrappedMethod() -> UnwrappedInt
+  // CHECK: func returnsWrappedMethod() -> WrappedInt
+  // CHECK-RECOVERY: /* placeholder for returnsWrappedMethod() */
+  func returnsWrappedMethod() -> WrappedInt
+
+  // CHECK: subscript(_: WrappedInt) -> () { get }
+  // CHECK-RECOVERY: /* placeholder for _ */
+  subscript(_: WrappedInt) -> () { get }
+
+  // CHECK: init()
+  // CHECK-RECOVERY: init()
+  init()
+
+  // CHECK: init(wrapped: WrappedInt)
+  // CHECK-RECOVERY: /* placeholder for init(wrapped:) */
+  init(wrapped: WrappedInt)
+
+  func lastMethod()
+}
+// CHECK: {{^}$}}
+// CHECK-RECOVERY: {{^}$}}
+
+// CHECK-LABEL: struct ProtoLibImpl : Proto {
+// CHECK-RECOVERY-LABEL: struct ProtoLibImpl : Proto {
+public struct ProtoLibImpl : Proto {
+  public var unwrappedProp: UnwrappedInt?
+  public var wrappedProp: WrappedInt?
+
+  public func returnsUnwrappedMethod() -> UnwrappedInt { fatalError() }
+  public func returnsWrappedMethod() -> WrappedInt { fatalError() }
+
+  public subscript(_: WrappedInt) -> () { return () }
+
+  public init() {}
+  public init(wrapped: WrappedInt) {}
+
+  public func lastMethod() {}
+}
+// CHECK: {{^}$}}
+// CHECK-RECOVERY: {{^}$}}
+
+// This is mostly to check when changes are necessary for the CHECK-IR lines
+// above.
+// CHECK-WITNESS-TABLE-LABEL: sil_witness_table{{.*}} ProtoLibImpl: Proto module Lib {
+// 0 CHECK-WITNESS-TABLE-NEXT: #Proto.unwrappedProp!getter.1:
+// 1 CHECK-WITNESS-TABLE-NEXT: #Proto.unwrappedProp!setter.1:
+// 2 CHECK-WITNESS-TABLE-NEXT: #Proto.unwrappedProp!materializeForSet.1:
+// 3 CHECK-WITNESS-TABLE-NEXT: #Proto.wrappedProp!getter.1:
+// 4 CHECK-WITNESS-TABLE-NEXT: #Proto.wrappedProp!setter.1:
+// 5 CHECK-WITNESS-TABLE-NEXT: #Proto.wrappedProp!materializeForSet.1:
+// 6 CHECK-WITNESS-TABLE-NEXT: #Proto.returnsUnwrappedMethod!1:
+// 7 CHECK-WITNESS-TABLE-NEXT: #Proto.returnsWrappedMethod!1:
+// 8 CHECK-WITNESS-TABLE-NEXT: #Proto.subscript!getter.1:
+// 9 CHECK-WITNESS-TABLE-NEXT: #Proto.init!allocator.1:
+// 10 CHECK-WITNESS-TABLE-NEXT: #Proto.init!allocator.1:
+// 11 CHECK-WITNESS-TABLE-NEXT: #Proto.lastMethod!1:
+// CHECK-WITNESS-TABLE: }
+
+#endif // TEST

--- a/test/Serialization/Recovery/typedefs.swift
+++ b/test/Serialization/Recovery/typedefs.swift
@@ -33,7 +33,7 @@ public func testVTableBuilding(user: User) {
   // for the vtable slot for 'lastMethod()'. If the layout here
   // changes, please check that offset 24 is still correct.
   // CHECK-IR-NOT: ret
-  // CHECK-IR: getelementptr inbounds void (%T3Lib4UserC*)*, void (%T3Lib4UserC*)** %{{[0-9]+}}, i64 24
+  // CHECK-IR: getelementptr inbounds void (%T3Lib4UserC*)*, void (%T3Lib4UserC*)** %{{[0-9]+}}, {{i64 24|i32 27}}
   _ = user.lastMethod()
 } // CHECK-IR: ret void
 
@@ -119,7 +119,7 @@ open class User {
 // This is mostly to check when changes are necessary for the CHECK-IR lines
 // above.
 // CHECK-VTABLE-LABEL: sil_vtable User {
-// (10 words of normal class metadata)
+// (10 words of normal class metadata on 64-bit platforms, 13 on 32-bit)
 // 10 CHECK-VTABLE-NEXT: #User.unwrappedProp!getter.1:
 // 11 CHECK-VTABLE-NEXT: #User.unwrappedProp!setter.1:
 // 12 CHECK-VTABLE-NEXT: #User.unwrappedProp!materializeForSet.1:

--- a/test/Serialization/Recovery/typedefs.swift
+++ b/test/Serialization/Recovery/typedefs.swift
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: %target-swift-frontend -emit-module -o %t -module-name Lib -I %S/Inputs/custom-modules %s
+// RUN: %target-swift-frontend -emit-sil -o - -emit-module-path %t/Lib.swiftmodule -module-name Lib -I %S/Inputs/custom-modules %s | %FileCheck -check-prefix CHECK-VTABLE %s
 
 // RUN: %target-swift-ide-test -source-filename=x -print-module -module-to-print Lib -I %t -I %S/Inputs/custom-modules | %FileCheck %s
 
@@ -9,6 +9,7 @@
 
 // RUN: %target-swift-frontend -typecheck -I %t -I %S/Inputs/custom-modules -Xcc -DBAD -DTEST -enable-experimental-deserialization-recovery -DVERIFY %s -verify
 // RUN: %target-swift-frontend -emit-silgen -I %t -I %S/Inputs/custom-modules -Xcc -DBAD -DTEST -enable-experimental-deserialization-recovery %s | %FileCheck -check-prefix CHECK-SIL %s
+// RUN: %target-swift-frontend -emit-ir -I %t -I %S/Inputs/custom-modules -Xcc -DBAD -DTEST -enable-experimental-deserialization-recovery %s | %FileCheck -check-prefix CHECK-IR %s
 
 #if TEST
 
@@ -23,6 +24,16 @@ func testSymbols() {
   // CHECK-SIL: function_ref @_T03Lib9usesAssocs5Int32VSgfau
   _ = Lib.usesAssoc
 } // CHECK-SIL: end sil function '_T08typedefs11testSymbolsyyF'
+
+// CHECK-IR-LABEL: define{{.*}} void @_T08typedefs18testVTableBuildingy3Lib4UserC4user_tF
+public func testVTableBuilding(user: User) {
+  // The important thing in this CHECK line is the "i64 23", which is the offset
+  // for the vtable slot for 'lastMethod()'. If the layout here
+  // changes, please check that offset 23 is still correct.
+  // CHECK-IR-NOT: ret
+  // CHECK-IR: getelementptr inbounds void (%T3Lib4UserC*)*, void (%T3Lib4UserC*)** %{{[0-9]+}}, i64 23
+  _ = user.lastMethod()
+} // CHECK-IR: ret void
 
 #if VERIFY
 let _: String = useAssoc(ImportedType.self) // expected-error {{cannot convert call result type '_.Assoc?' to expected type 'String'}}
@@ -64,18 +75,19 @@ open class User {
   // CHECK-RECOVERY: var unwrappedProp: Int32?
   public var unwrappedProp: UnwrappedInt?
   // CHECK: var wrappedProp: WrappedInt?
-  // CHECK-RECOVERY-NEGATIVE-NOT: var wrappedProp:
+  // CHECK-RECOVERY: /* placeholder for _ */
+  // CHECK-RECOVERY: /* placeholder for _ */
   public var wrappedProp: WrappedInt?
 
   // CHECK: func returnsUnwrappedMethod() -> UnwrappedInt
   // CHECK-RECOVERY: func returnsUnwrappedMethod() -> Int32
   public func returnsUnwrappedMethod() -> UnwrappedInt { fatalError() }
   // CHECK: func returnsWrappedMethod() -> WrappedInt
-  // CHECK-RECOVERY-NEGATIVE-NOT: func returnsWrappedMethod(
+  // CHECK-RECOVERY: /* placeholder for returnsWrappedMethod() */
   public func returnsWrappedMethod() -> WrappedInt { fatalError() }
 
   // CHECK: subscript(_: WrappedInt) -> () { get }
-  // CHECK-RECOVERY-NEGATIVE-NOT: subscript(
+  // CHECK-RECOVERY: /* placeholder for _ */
   public subscript(_: WrappedInt) -> () { return () }
 
   // CHECK: init()
@@ -83,15 +95,43 @@ open class User {
   public init() {}
 
   // CHECK: init(wrapped: WrappedInt)
-  // CHECK-RECOVERY-NEGATIVE-NOT: init(wrapped:
+  // CHECK-RECOVERY: /* placeholder for init(wrapped:) */
   public init(wrapped: WrappedInt) {}
 
   // CHECK: convenience init(conveniently: Int)
   // CHECK-RECOVERY: convenience init(conveniently: Int)
   public convenience init(conveniently: Int) { self.init() }
+
+  // CHECK: required init(wrappedRequired: WrappedInt)
+  // CHECK-RECOVERY: /* placeholder for init(wrappedRequired:) */
+  public required init(wrappedRequired: WrappedInt) {}
+
+  public func lastMethod() {}
 }
 // CHECK: {{^}$}}
 // CHECK-RECOVERY: {{^}$}}
+
+// This is mostly to check when changes are necessary for the CHECK-IR lines
+// above.
+// CHECK-VTABLE-LABEL: sil_vtable User {
+// (8 words of normal class metadata)
+// 9 CHECK-VTABLE-NEXT: #User.unwrappedProp!getter.1:
+// 10 CHECK-VTABLE-NEXT: #User.unwrappedProp!setter.1:
+// 11 CHECK-VTABLE-NEXT: #User.unwrappedProp!materializeForSet.1:
+// 12 CHECK-VTABLE-NEXT: #User.wrappedProp!getter.1:
+// 13 CHECK-VTABLE-NEXT: #User.wrappedProp!setter.1:
+// 14 CHECK-VTABLE-NEXT: #User.wrappedProp!materializeForSet.1:
+// 15 CHECK-VTABLE-NEXT: #User.returnsUnwrappedMethod!1:
+// 16 CHECK-VTABLE-NEXT: #User.returnsWrappedMethod!1:
+// 17 CHECK-VTABLE-NEXT: #User.subscript!getter.1:
+// 18 CHECK-VTABLE-NEXT: #User.init!initializer.1:
+// 19 CHECK-VTABLE-NEXT: #User.init!initializer.1:
+// 20 CHECK-VTABLE-NEXT: #User.init!initializer.1:
+// 21 CHECK-VTABLE-NEXT: #User.init!allocator.1:
+// 22 CHECK-VTABLE-NEXT: #User.init!initializer.1:
+// 23 CHECK-VTABLE-NEXT: #User.lastMethod!1:
+// CHECK-VTABLE: }
+
 
 // CHECK-LABEL: class UserConvenience
 // CHECK-RECOVERY-LABEL: class UserConvenience
@@ -101,7 +141,7 @@ open class UserConvenience {
   public init() {}
 
   // CHECK: convenience init(wrapped: WrappedInt)
-  // CHECK-RECOVERY-NEGATIVE-NOT: init(wrapped:
+  // CHECK-RECOVERY: /* placeholder for init(wrapped:) */
   public convenience init(wrapped: WrappedInt) { self.init() }
 
   // CHECK: convenience init(conveniently: Int)
@@ -110,6 +150,22 @@ open class UserConvenience {
 }
 // CHECK: {{^}$}}
 // CHECK-RECOVERY: {{^}$}}
+
+
+// CHECK-LABEL: class UserSub
+// CHECK-RECOVERY-LABEL: class UserSub
+open class UserSub : User {
+  // CHECK: init(wrapped: WrappedInt?)
+  // CHECK-RECOVERY: /* placeholder for init(wrapped:) */
+  public override init(wrapped: WrappedInt?) { super.init() }
+
+  // CHECK: required init(wrappedRequired: WrappedInt?)
+  // CHECK-RECOVERY: /* placeholder for init(wrappedRequired:) */
+  public required init(wrappedRequired: WrappedInt?) { super.init() }
+}
+// CHECK: {{^}$}}
+// CHECK-RECOVERY: {{^}$}}
+
 
 // CHECK-DAG: let x: MysteryTypedef
 // CHECK-RECOVERY-DAG: let x: Int32

--- a/test/Serialization/Recovery/typedefs.swift
+++ b/test/Serialization/Recovery/typedefs.swift
@@ -9,6 +9,8 @@
 
 // RUN: %target-swift-frontend -typecheck -I %t -I %S/Inputs/custom-modules -Xcc -DBAD -DTEST -enable-experimental-deserialization-recovery -DVERIFY %s -verify
 // RUN: %target-swift-frontend -emit-silgen -I %t -I %S/Inputs/custom-modules -Xcc -DBAD -DTEST -enable-experimental-deserialization-recovery %s | %FileCheck -check-prefix CHECK-SIL %s
+
+// RUN: %target-swift-frontend -emit-ir -I %t -I %S/Inputs/custom-modules -DTEST %s | %FileCheck -check-prefix CHECK-IR %s
 // RUN: %target-swift-frontend -emit-ir -I %t -I %S/Inputs/custom-modules -Xcc -DBAD -DTEST -enable-experimental-deserialization-recovery %s | %FileCheck -check-prefix CHECK-IR %s
 
 #if TEST
@@ -27,11 +29,11 @@ func testSymbols() {
 
 // CHECK-IR-LABEL: define{{.*}} void @_T08typedefs18testVTableBuildingy3Lib4UserC4user_tF
 public func testVTableBuilding(user: User) {
-  // The important thing in this CHECK line is the "i64 23", which is the offset
+  // The important thing in this CHECK line is the "i64 24", which is the offset
   // for the vtable slot for 'lastMethod()'. If the layout here
-  // changes, please check that offset 23 is still correct.
+  // changes, please check that offset 24 is still correct.
   // CHECK-IR-NOT: ret
-  // CHECK-IR: getelementptr inbounds void (%T3Lib4UserC*)*, void (%T3Lib4UserC*)** %{{[0-9]+}}, i64 23
+  // CHECK-IR: getelementptr inbounds void (%T3Lib4UserC*)*, void (%T3Lib4UserC*)** %{{[0-9]+}}, i64 24
   _ = user.lastMethod()
 } // CHECK-IR: ret void
 
@@ -77,6 +79,7 @@ open class User {
   // CHECK: var wrappedProp: WrappedInt?
   // CHECK-RECOVERY: /* placeholder for _ */
   // CHECK-RECOVERY: /* placeholder for _ */
+  // CHECK-RECOVERY: /* placeholder for _ */
   public var wrappedProp: WrappedInt?
 
   // CHECK: func returnsUnwrappedMethod() -> UnwrappedInt
@@ -114,22 +117,22 @@ open class User {
 // This is mostly to check when changes are necessary for the CHECK-IR lines
 // above.
 // CHECK-VTABLE-LABEL: sil_vtable User {
-// (8 words of normal class metadata)
-// 9 CHECK-VTABLE-NEXT: #User.unwrappedProp!getter.1:
-// 10 CHECK-VTABLE-NEXT: #User.unwrappedProp!setter.1:
-// 11 CHECK-VTABLE-NEXT: #User.unwrappedProp!materializeForSet.1:
-// 12 CHECK-VTABLE-NEXT: #User.wrappedProp!getter.1:
-// 13 CHECK-VTABLE-NEXT: #User.wrappedProp!setter.1:
-// 14 CHECK-VTABLE-NEXT: #User.wrappedProp!materializeForSet.1:
-// 15 CHECK-VTABLE-NEXT: #User.returnsUnwrappedMethod!1:
-// 16 CHECK-VTABLE-NEXT: #User.returnsWrappedMethod!1:
-// 17 CHECK-VTABLE-NEXT: #User.subscript!getter.1:
-// 18 CHECK-VTABLE-NEXT: #User.init!initializer.1:
+// (10 words of normal class metadata)
+// 10 CHECK-VTABLE-NEXT: #User.unwrappedProp!getter.1:
+// 11 CHECK-VTABLE-NEXT: #User.unwrappedProp!setter.1:
+// 12 CHECK-VTABLE-NEXT: #User.unwrappedProp!materializeForSet.1:
+// 13 CHECK-VTABLE-NEXT: #User.wrappedProp!getter.1:
+// 14 CHECK-VTABLE-NEXT: #User.wrappedProp!setter.1:
+// 15 CHECK-VTABLE-NEXT: #User.wrappedProp!materializeForSet.1:
+// 16 CHECK-VTABLE-NEXT: #User.returnsUnwrappedMethod!1:
+// 17 CHECK-VTABLE-NEXT: #User.returnsWrappedMethod!1:
+// 18 CHECK-VTABLE-NEXT: #User.subscript!getter.1:
 // 19 CHECK-VTABLE-NEXT: #User.init!initializer.1:
 // 20 CHECK-VTABLE-NEXT: #User.init!initializer.1:
-// 21 CHECK-VTABLE-NEXT: #User.init!allocator.1:
-// 22 CHECK-VTABLE-NEXT: #User.init!initializer.1:
-// 23 CHECK-VTABLE-NEXT: #User.lastMethod!1:
+// 21 CHECK-VTABLE-NEXT: #User.init!initializer.1:
+// 22 CHECK-VTABLE-NEXT: #User.init!allocator.1:
+// 23 CHECK-VTABLE-NEXT: #User.init!initializer.1:
+// 24 CHECK-VTABLE-NEXT: #User.lastMethod!1:
 // CHECK-VTABLE: }
 
 

--- a/test/Serialization/Recovery/typedefs.swift
+++ b/test/Serialization/Recovery/typedefs.swift
@@ -3,15 +3,15 @@
 
 // RUN: %target-swift-ide-test -source-filename=x -print-module -module-to-print Lib -I %t -I %S/Inputs/custom-modules | %FileCheck %s
 
-// RUN: %target-swift-ide-test -source-filename=x -print-module -module-to-print Lib -I %t -I %S/Inputs/custom-modules -Xcc -DBAD -enable-experimental-deserialization-recovery > %t.txt
+// RUN: %target-swift-ide-test -source-filename=x -print-module -module-to-print Lib -I %t -I %S/Inputs/custom-modules -Xcc -DBAD > %t.txt
 // RUN: %FileCheck -check-prefix CHECK-RECOVERY %s < %t.txt
 // RUN: %FileCheck -check-prefix CHECK-RECOVERY-NEGATIVE %s < %t.txt
 
-// RUN: %target-swift-frontend -typecheck -I %t -I %S/Inputs/custom-modules -Xcc -DBAD -DTEST -enable-experimental-deserialization-recovery -DVERIFY %s -verify
-// RUN: %target-swift-frontend -emit-silgen -I %t -I %S/Inputs/custom-modules -Xcc -DBAD -DTEST -enable-experimental-deserialization-recovery %s | %FileCheck -check-prefix CHECK-SIL %s
+// RUN: %target-swift-frontend -typecheck -I %t -I %S/Inputs/custom-modules -Xcc -DBAD -DTEST -DVERIFY %s -verify
+// RUN: %target-swift-frontend -emit-silgen -I %t -I %S/Inputs/custom-modules -Xcc -DBAD -DTEST %s | %FileCheck -check-prefix CHECK-SIL %s
 
 // RUN: %target-swift-frontend -emit-ir -I %t -I %S/Inputs/custom-modules -DTEST %s | %FileCheck -check-prefix CHECK-IR %s
-// RUN: %target-swift-frontend -emit-ir -I %t -I %S/Inputs/custom-modules -Xcc -DBAD -DTEST -enable-experimental-deserialization-recovery %s | %FileCheck -check-prefix CHECK-IR %s
+// RUN: %target-swift-frontend -emit-ir -I %t -I %S/Inputs/custom-modules -Xcc -DBAD -DTEST %s | %FileCheck -check-prefix CHECK-IR %s
 
 #if TEST
 

--- a/test/Serialization/Recovery/typedefs.swift
+++ b/test/Serialization/Recovery/typedefs.swift
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: %target-swift-frontend -emit-sil -o - -emit-module-path %t/Lib.swiftmodule -module-name Lib -I %S/Inputs/custom-modules %s | %FileCheck -check-prefix CHECK-VTABLE %s
+// RUN: %target-swift-frontend -emit-sil -o - -emit-module-path %t/Lib.swiftmodule -module-name Lib -I %S/Inputs/custom-modules -disable-objc-attr-requires-foundation-module %s | %FileCheck -check-prefix CHECK-VTABLE %s
 
 // RUN: %target-swift-ide-test -source-filename=x -print-module -module-to-print Lib -I %t -I %S/Inputs/custom-modules | %FileCheck %s
 
@@ -52,17 +52,19 @@ let _ = unwrapped // okay
 _ = usesWrapped(nil) // expected-error {{use of unresolved identifier 'usesWrapped'}}
 _ = usesUnwrapped(nil) // expected-error {{nil is not compatible with expected argument type 'Int32'}}
 
-public class UserSub: User {
+public class UserDynamicSub: UserDynamic {
   override init() {}
 }
 // FIXME: Bad error message; really it's that the convenience init hasn't been
 // inherited.
-_ = UserSub(conveniently: 0) // expected-error {{argument passed to call that takes no arguments}}
+_ = UserDynamicSub(conveniently: 0) // expected-error {{argument passed to call that takes no arguments}}
 
-public class UserConvenienceSub: UserConvenience {
+public class UserDynamicConvenienceSub: UserDynamicConvenience {
   override init() {}
 }
-_ = UserConvenienceSub(conveniently: 0)
+_ = UserDynamicConvenienceSub(conveniently: 0)
+
+public class UserSub : User {} // expected-error {{cannot inherit from class 'User' because it has overridable members that could not be loaded}}
 
 #endif // VERIFY
 
@@ -150,6 +152,42 @@ open class UserConvenience {
   // CHECK: convenience init(conveniently: Int)
   // CHECK-RECOVERY: convenience init(conveniently: Int)
   public convenience init(conveniently: Int) { self.init() }
+}
+// CHECK: {{^}$}}
+// CHECK-RECOVERY: {{^}$}}
+
+// CHECK-LABEL: class UserDynamic
+// CHECK-RECOVERY-LABEL: class UserDynamic
+open class UserDynamic {
+  // CHECK: init()
+  // CHECK-RECOVERY: init()
+  @objc public dynamic init() {}
+
+  // CHECK: init(wrapped: WrappedInt)
+  // CHECK-RECOVERY: /* placeholder for init(wrapped:) */
+  @objc public dynamic init(wrapped: WrappedInt) {}
+
+  // CHECK: convenience init(conveniently: Int)
+  // CHECK-RECOVERY: convenience init(conveniently: Int)
+  @objc public dynamic convenience init(conveniently: Int) { self.init() }
+}
+// CHECK: {{^}$}}
+// CHECK-RECOVERY: {{^}$}}
+
+// CHECK-LABEL: class UserDynamicConvenience
+// CHECK-RECOVERY-LABEL: class UserDynamicConvenience
+open class UserDynamicConvenience {
+  // CHECK: init()
+  // CHECK-RECOVERY: init()
+  @objc public dynamic init() {}
+
+  // CHECK: convenience init(wrapped: WrappedInt)
+  // CHECK-RECOVERY: /* placeholder for init(wrapped:) */
+  @objc public dynamic convenience init(wrapped: WrappedInt) { self.init() }
+
+  // CHECK: convenience init(conveniently: Int)
+  // CHECK-RECOVERY: convenience init(conveniently: Int)
+  @objc public dynamic convenience init(conveniently: Int) { self.init() }
 }
 // CHECK: {{^}$}}
 // CHECK-RECOVERY: {{^}$}}

--- a/test/Serialization/Recovery/types-3-to-4.swift
+++ b/test/Serialization/Recovery/types-3-to-4.swift
@@ -16,6 +16,8 @@ import Lib
 func requiresConformance(_: B_RequiresConformance<B_ConformsToProto>) {}
 func requiresConformance(_: B_RequiresConformance<C_RelyOnConformanceImpl.Assoc>) {}
 
+class Sub: Base {} // okay
+class Impl: Proto {} // expected-error {{type 'Impl' does not conform to protocol 'Proto'}}
 
 #else // TEST
 
@@ -84,6 +86,13 @@ public protocol C_RelyOnConformance {
 
 public class C_RelyOnConformanceImpl: C_RelyOnConformance {
   public typealias Assoc = Swift3RenamedClass
+}
+
+open class Base {
+  public init(wrapped: NewlyWrappedTypedef) {}
+}
+public protocol Proto {
+  func useWrapped(_ wrapped: NewlyWrappedTypedef)
 }
 
 #endif

--- a/test/Serialization/Recovery/types-3-to-4.swift
+++ b/test/Serialization/Recovery/types-3-to-4.swift
@@ -3,9 +3,9 @@
 
 // RUN: %target-swift-ide-test -source-filename=x -print-module -module-to-print Lib -I %t -I %S/Inputs/custom-modules -swift-version 3 | %FileCheck -check-prefix=CHECK-3 %s
 
-// RUN: %target-swift-ide-test -source-filename=x -print-module -module-to-print Lib -I %t -I %S/Inputs/custom-modules -enable-experimental-deserialization-recovery -swift-version 4 | %FileCheck -check-prefix=CHECK-4 %s
+// RUN: %target-swift-ide-test -source-filename=x -print-module -module-to-print Lib -I %t -I %S/Inputs/custom-modules -swift-version 4 | %FileCheck -check-prefix=CHECK-4 %s
 
-// RUN: %target-swift-frontend -typecheck %s -I %t -I %S/Inputs/custom-modules  -swift-version 4 -enable-experimental-deserialization-recovery -D TEST -verify
+// RUN: %target-swift-frontend -typecheck %s -I %t -I %S/Inputs/custom-modules  -swift-version 4 -D TEST -verify
 
 // REQUIRES: objc_interop
 

--- a/test/Serialization/Recovery/types-4-to-3.swift
+++ b/test/Serialization/Recovery/types-4-to-3.swift
@@ -16,6 +16,8 @@ import Lib
 func requiresConformance(_: B_RequiresConformance<B_ConformsToProto>) {}
 func requiresConformance(_: B_RequiresConformance<C_RelyOnConformanceImpl.Assoc>) {}
 
+class Sub: Base {} // expected-error {{cannot inherit from class 'Base' (compiled with Swift 4.0) because it has overridable members that could not be loaded in Swift 3.2}}
+class Impl: Proto {} // expected-error {{type 'Impl' cannot conform to protocol 'Proto' (compiled with Swift 4.0) because it has requirements that could not be loaded in Swift 3.2}}
 
 #else // TEST
 
@@ -60,6 +62,13 @@ public protocol C_RelyOnConformance {
 
 public class C_RelyOnConformanceImpl: C_RelyOnConformance {
   public typealias Assoc = RenamedClass
+}
+
+open class Base {
+  public init(wrapped: NewlyWrappedTypedef) {}
+}
+public protocol Proto {
+  func useWrapped(_ wrapped: NewlyWrappedTypedef)
 }
 
 #endif

--- a/test/Serialization/Recovery/types-4-to-3.swift
+++ b/test/Serialization/Recovery/types-4-to-3.swift
@@ -3,9 +3,9 @@
 
 // RUN: %target-swift-ide-test -source-filename=x -print-module -module-to-print Lib -I %t -I %S/Inputs/custom-modules -swift-version 4 | %FileCheck %s
 
-// RUN: %target-swift-ide-test -source-filename=x -print-module -module-to-print Lib -I %t -I %S/Inputs/custom-modules -enable-experimental-deserialization-recovery -swift-version 3 | %FileCheck %s
+// RUN: %target-swift-ide-test -source-filename=x -print-module -module-to-print Lib -I %t -I %S/Inputs/custom-modules -swift-version 3 | %FileCheck %s
 
-// RUN: %target-swift-frontend -typecheck %s -I %t -I %S/Inputs/custom-modules  -swift-version 3 -enable-experimental-deserialization-recovery -D TEST -verify
+// RUN: %target-swift-frontend -typecheck %s -I %t -I %S/Inputs/custom-modules  -swift-version 3 -D TEST -verify
 
 // REQUIRES: objc_interop
 

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -353,13 +353,6 @@ EnableSwift3ObjCInference("enable-swift3-objc-inference",
     llvm::cl::init(false));
 
 static llvm::cl::opt<bool>
-EnableDeserializationRecovery(
-    "enable-experimental-deserialization-recovery",
-    llvm::cl::desc("Attempt to recover from missing xrefs (etc) in swiftmodules"),
-    llvm::cl::cat(Category),
-    llvm::cl::init(false));
-
-static llvm::cl::opt<bool>
 DisableObjCAttrRequiresFoundationModule(
     "disable-objc-attr-requires-foundation-module",
     llvm::cl::desc("Allow @objc to be used freely"),
@@ -3017,8 +3010,6 @@ int main(int argc, char *argv[]) {
   InitInvok.getLangOptions().EnableSwift3ObjCInference =
     options::EnableSwift3ObjCInference ||
     InitInvok.getLangOptions().isSwiftVersion3();
-  InitInvok.getLangOptions().EnableDeserializationRecovery |=
-    options::EnableDeserializationRecovery;
   InitInvok.getClangImporterOptions().ImportForwardDeclarations |=
     options::ObjCForwardDeclarations;
   InitInvok.getClangImporterOptions().InferImportAsMember |=

--- a/unittests/AST/CMakeLists.txt
+++ b/unittests/AST/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_swift_unittest(SwiftASTTests
-  OverrideTests.cpp
   SourceLocTests.cpp
   TestContext.cpp
+  TypeMatchTests.cpp
   VersionRangeLattice.cpp
 )
 

--- a/unittests/AST/TestContext.h
+++ b/unittests/AST/TestContext.h
@@ -13,6 +13,7 @@
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ASTScope.h"
 #include "swift/AST/DiagnosticEngine.h"
+#include "swift/AST/Module.h"
 #include "swift/Basic/LangOptions.h"
 #include "swift/Basic/SourceManager.h"
 


### PR DESCRIPTION
- Lift the decision of whether a method needs a vtable slot up to AST.
- Add a new MissingMemberDecl and use it to handle non-deserializable class and protocol members.
- Disallow subclassing or protocol adoption when a class/protocol is missing vtable entries.
- Turn on deserialization recovery by default.

Reviewed by @slavapestov (#9309, #9360) and @jckarter (#9451, #9438).
rdar://problem/31878396