### PR TITLE
[runtime] Enhance output from dynamic exclusivity violations. Print current stacktrace and the symbolicated frame of the previous conflicting access.

### DIFF
--- a/include/swift/Runtime/Debug.h
+++ b/include/swift/Runtime/Debug.h
@@ -124,6 +124,16 @@ void swift_abortRetainOverflow();
 LLVM_ATTRIBUTE_NORETURN LLVM_ATTRIBUTE_NOINLINE
 void swift_abortRetainUnowned(const void *object);
 
+/// This function dumps one line of a stack trace. It is assumed that \p framePC
+/// is the address of the stack frame at index \p index. If \p shortOutput is
+/// true, this functions prints only the name of the symbol and offset, ignores
+/// \p index argument and omits the newline.
+void dumpStackTraceEntry(unsigned index, void *framePC,
+                         bool shortOutput = false);
+
+LLVM_ATTRIBUTE_NOINLINE
+void printCurrentBacktrace(unsigned framesToSkip = 1);
+
 // namespace swift
 }
 

--- a/include/swift/Runtime/Exclusivity.h
+++ b/include/swift/Runtime/Exclusivity.h
@@ -19,6 +19,8 @@
 
 #include <cstdint>
 
+#include "swift/Runtime/Config.h"
+
 namespace swift {
 
 enum class ExclusivityFlags : uintptr_t;

--- a/stdlib/public/runtime/Errors.cpp
+++ b/stdlib/public/runtime/Errors.cpp
@@ -58,8 +58,6 @@ enum: uint32_t {
 
 using namespace swift;
 
-#if SWIFT_SUPPORTS_BACKTRACE_REPORTING
-
 static bool getSymbolNameAddr(llvm::StringRef libraryName, SymbolInfo syminfo,
                               std::string &symbolName, uintptr_t &addrOut) {
 
@@ -98,9 +96,9 @@ static bool getSymbolNameAddr(llvm::StringRef libraryName, SymbolInfo syminfo,
   return true;
 }
 
-/// This function dumps one line of a stack trace. It is assumed that \p address
-/// is the address of the stack frame at index \p index.
-static void dumpStackTraceEntry(unsigned index, void *framePC) {
+void swift::dumpStackTraceEntry(unsigned index, void *framePC,
+                                bool shortOutput) {
+#if SWIFT_SUPPORTS_BACKTRACE_REPORTING
   SymbolInfo syminfo;
 
   // 0 is failure for lookupSymbol
@@ -120,6 +118,14 @@ static void dumpStackTraceEntry(unsigned index, void *framePC) {
   uintptr_t symbolAddr = uintptr_t(framePC);
   bool foundSymbol =
       getSymbolNameAddr(libraryName, syminfo, symbolName, symbolAddr);
+  ptrdiff_t offset = 0;
+  if (foundSymbol) {
+    offset = ptrdiff_t(uintptr_t(framePC) - symbolAddr);
+  } else {
+    offset = ptrdiff_t(uintptr_t(framePC) - uintptr_t(syminfo.baseAddress));
+    symbolAddr = uintptr_t(framePC);
+    symbolName = "<unavailable>";
+  }
 
   // We do not use %p here for our pointers since the format is implementation
   // defined. This makes it logically impossible to check the output. Forcing
@@ -128,20 +134,38 @@ static void dumpStackTraceEntry(unsigned index, void *framePC) {
   // from the base address of where the image containing framePC is mapped.
   // This gives enough info to reconstruct identical debugging target after
   // this process terminates.
-  if (foundSymbol) {
-    static const char *backtraceEntryFormat = "%-4u %-34s 0x%0.16lx %s + %td\n";
-    fprintf(stderr, backtraceEntryFormat, index, libraryName.data(), symbolAddr,
-            symbolName.c_str(), ptrdiff_t(uintptr_t(framePC) - symbolAddr));
+  if (shortOutput) {
+    fprintf(stderr, "%s`%s + %td", libraryName.data(), symbolName.c_str(),
+            offset);
   } else {
-    static const char *backtraceEntryFormat = "%-4u %-34s 0x%0.16lx "
-                                              "<unavailable> + %td\n";
-    fprintf(stderr, backtraceEntryFormat, index, libraryName.data(),
-            uintptr_t(framePC),
-            ptrdiff_t(uintptr_t(framePC) - uintptr_t(syminfo.baseAddress)));
+    constexpr const char *format = "%-4u %-34s 0x%0.16lx %s + %td\n";
+    fprintf(stderr, format, index, libraryName.data(), symbolAddr,
+            symbolName.c_str(), offset);
   }
+#else
+  if (shortOutput) {
+    fprintf(stderr, "<unavailable>");
+  } else {
+    constexpr const char *format = "%-4u 0x%0.16lx\n";
+    fprintf(stderr, format, index, framePC);
+  }
+#endif
 }
 
+LLVM_ATTRIBUTE_NOINLINE
+void swift::printCurrentBacktrace(unsigned framesToSkip) {
+#if SWIFT_SUPPORTS_BACKTRACE_REPORTING
+  constexpr unsigned maxSupportedStackDepth = 128;
+  void *addrs[maxSupportedStackDepth];
+
+  int symbolCount = backtrace(addrs, maxSupportedStackDepth);
+  for (int i = framesToSkip; i < symbolCount; ++i) {
+    dumpStackTraceEntry(i - framesToSkip, addrs[i]);
+  }
+#else
+  fprintf(stderr, "<backtrace unavailable>\n");
 #endif
+}
 
 #ifdef SWIFT_HAVE_CRASHREPORTERCLIENT
 #include <malloc/malloc.h>
@@ -210,13 +234,7 @@ reportNow(uint32_t flags, const char *message)
 #if SWIFT_SUPPORTS_BACKTRACE_REPORTING
   if (flags & FatalErrorFlags::ReportBacktrace) {
     fputs("Current stack trace:\n", stderr);
-    constexpr unsigned maxSupportedStackDepth = 128;
-    void *addrs[maxSupportedStackDepth];
-
-    int symbolCount = backtrace(addrs, maxSupportedStackDepth);
-    for (int i = 0; i < symbolCount; ++i) {
-      dumpStackTraceEntry(i, addrs[i]);
-    }
+    printCurrentBacktrace();
   }
 #endif
 }

--- a/test/Interpreter/enforce_exclusive_access.swift
+++ b/test/Interpreter/enforce_exclusive_access.swift
@@ -47,7 +47,8 @@ ExclusiveAccessTestSuite.test("ModifyInsideRead")
   .skip(.custom(
     { _isFastAssertConfiguration() },
     reason: "this trap is not guaranteed to happen in -Ounchecked"))
-  .crashOutputMatches("read/modify access conflict detected on address")
+  .crashOutputMatches("Previous access (a read) started at")
+  .crashOutputMatches("Current access (a modification) started at")
   .code
 {
   readAndPerform(&globalX) {
@@ -60,7 +61,8 @@ ExclusiveAccessTestSuite.test("ReadInsideModify")
   .skip(.custom(
     { _isFastAssertConfiguration() },
     reason: "this trap is not guaranteed to happen in -Ounchecked"))
-  .crashOutputMatches("modify/read access conflict detected on address")
+  .crashOutputMatches("Previous access (a modification) started at")
+  .crashOutputMatches("Current access (a read) started at")
   .code
 {
   modifyAndPerform(&globalX) {
@@ -74,7 +76,8 @@ ExclusiveAccessTestSuite.test("ModifyInsideModify")
   .skip(.custom(
     { _isFastAssertConfiguration() },
     reason: "this trap is not guaranteed to happen in -Ounchecked"))
-  .crashOutputMatches("modify/modify access conflict detected on address")
+  .crashOutputMatches("Previous access (a modification) started at")
+  .crashOutputMatches("Current access (a modification) started at")
   .code
 {
   modifyAndPerform(&globalX) {
@@ -110,7 +113,8 @@ ExclusiveAccessTestSuite.test("ModifyFollowedByModify") {
 //.skip(.custom(
 //    { _isFastAssertConfiguration() },
 //    reason: "this trap is not guaranteed to happen in -Ounchecked"))
-//  .crashOutputMatches("modify/modify access conflict detected on address")
+//  .crashOutputMatches("Previous access (a modification) started at")
+//  .crashOutputMatches("Current access (a modification) started at")
 //  .code
 //{
 //  var x = X()
@@ -129,7 +133,8 @@ ExclusiveAccessTestSuite.test("ModifyFollowedByModify") {
 //.skip(.custom(
 //    { _isFastAssertConfiguration() },
 //    reason: "this trap is not guaranteed to happen in -Ounchecked"))
-//  .crashOutputMatches("modify/read access conflict detected on address")
+//  .crashOutputMatches("Previous access (a read) started at")
+//  .crashOutputMatches("Current access (a modification) started at")
 //  .code
 //{
 //  var x = X()
@@ -148,7 +153,8 @@ ExclusiveAccessTestSuite.test("ModifyFollowedByModify") {
 //.skip(.custom(
 //    { _isFastAssertConfiguration() },
 //    reason: "this trap is not guaranteed to happen in -Ounchecked"))
-//  .crashOutputMatches("read/modify access conflict detected on address")
+//  .crashOutputMatches("Previous access (a modification) started at")
+//  .crashOutputMatches("Current access (a read) started at")
 //  .code
 //{
 //  var x = X()

--- a/test/Interpreter/enforce_exclusive_access_backtrace.swift
+++ b/test/Interpreter/enforce_exclusive_access_backtrace.swift
@@ -1,0 +1,33 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: %target-build-swift -swift-version 3 %s -o %t/a.out -enforce-exclusivity=checked -Onone
+//
+// RUN: %target-run %t/a.out 2>&1 | %FileCheck %s
+// REQUIRES: executable_test
+// REQUIRES: OS=macosx
+
+import StdlibUnittest
+import SwiftPrivatePthreadExtras
+import Foundation
+
+struct X {
+  var i = 7
+}
+
+func readAndPerform<T>(_ _: UnsafePointer<T>, closure: () ->()) {
+  closure()
+}
+
+var globalX = X()
+withUnsafePointer(to: &globalX) { _ = fputs(String(format: "globalX: 0x%lx\n", Int(bitPattern: $0)), stderr) }
+// CHECK: globalX: [[ADDR:0x.*]]
+
+readAndPerform(&globalX) {
+  globalX = X()
+  // CHECK: Simultaneous accesses to [[ADDR]], but modification requires exclusive access.
+  // CHECK: Previous access (a read) started at a.out`main + {{.*}} (0x{{.*}}).
+  // CHECK: Current access (a modification) started at:
+  // CHECK: a.out {{.*}} closure
+  // CHECK: a.out {{.*}} readAndPerform
+  // CHECK: a.out {{.*}} main
+}

--- a/unittests/runtime/CMakeLists.txt
+++ b/unittests/runtime/CMakeLists.txt
@@ -32,6 +32,7 @@ if(("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "${SWIFT_PRIMARY_VARIANT_SDK}") AND
   endif()
 
   add_swift_unittest(SwiftRuntimeTests
+    Exclusivity.cpp
     Metadata.cpp
     Mutex.cpp
     Enum.cpp

--- a/unittests/runtime/Exclusivity.cpp
+++ b/unittests/runtime/Exclusivity.cpp
@@ -1,0 +1,56 @@
+//===--- Exclusivity.cpp --------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Runtime/Exclusivity.h"
+#include "swift/Runtime/Metadata.h"
+#include "gtest/gtest.h"
+
+using namespace swift;
+
+TEST(TextExclusivity, testNullPC) {
+  ValueBuffer scratch, scratch2;
+  long var;
+  swift_beginAccess(&var, &scratch,
+                    ExclusivityFlags::WarningOnly | ExclusivityFlags::Read,
+                    /*pc=*/0);
+  swift_beginAccess(&var, &scratch2,
+                    ExclusivityFlags::WarningOnly | ExclusivityFlags::Modify,
+                    /*pc=*/0);
+  swift_endAccess(&scratch2);
+  swift_endAccess(&scratch);
+}
+
+TEST(TextExclusivity, testPCOne) {
+  ValueBuffer scratch, scratch2;
+  long var;
+  swift_beginAccess(&var, &scratch,
+                    ExclusivityFlags::WarningOnly | ExclusivityFlags::Read,
+                    /*pc=*/(void *)1);
+  swift_beginAccess(&var, &scratch2,
+                    ExclusivityFlags::WarningOnly | ExclusivityFlags::Modify,
+                    /*pc=*/(void *)1);
+  swift_endAccess(&scratch2);
+  swift_endAccess(&scratch);
+}
+
+TEST(TextExclusivity, testBogusPC) {
+  ValueBuffer scratch, scratch2;
+  long var;
+  swift_beginAccess(&var, &scratch,
+                    ExclusivityFlags::WarningOnly | ExclusivityFlags::Read,
+                    /*pc=*/(void *)0xdeadbeefdeadbeefULL);
+  swift_beginAccess(&var, &scratch2,
+                    ExclusivityFlags::WarningOnly | ExclusivityFlags::Modify,
+                    /*pc=*/(void *)0xdeadbeefdeadbeefULL);
+  swift_endAccess(&scratch2);
+  swift_endAccess(&scratch);
+}


### PR DESCRIPTION
Enhance output from dynamic exclusivity violations. Print current stacktrace and the symbolicated frame of the previous conflicting access.  This is what the output looks like with this patch:

```
Simultaneous accesses to 0x108b516d8, but modification requires exclusive access.
Previous access (a read) started at enforce_exclusive_access2`main + 64 (0x108b4e100).
Current access (a modification) started at:
0    enforce_exclusive_access2          0x0000000108b4e220 closure #1 in  + 46
1    enforce_exclusive_access2          0x0000000108b4e1d0 readAndPerform<A>(_:closure:) + 52
2    enforce_exclusive_access2          0x0000000108b4e0c0 main + 114
3    libdyld.dylib                      0x00007fffcbce3768 start + 1
```
