### PR TITLE
[SILGen] Only emit Builtin.swift3ImplicitObjCEntrypoint() calls in Swift 4

### DIFF
--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -1043,8 +1043,13 @@ void SILGenFunction::emitNativeToForeignThunk(SILDeclRef thunk) {
     }
 
     if (auto attr = decl->getAttrs().getAttribute<ObjCAttr>()) {
+      // If @objc was inferred based on the Swift 3 @objc inference rules, but
+      // we aren't compiling in Swift 3 compatibility mode, emit a call to
+      // Builtin.swift3ImplicitObjCEntrypoint() to enable runtime logging of
+      // the uses of such entrypoints.
       if (attr->isSwift3Inferred() &&
-          !decl->getAttrs().hasAttribute<DynamicAttr>()) {
+          !decl->getAttrs().hasAttribute<DynamicAttr>() &&
+          !getASTContext().LangOpts.isSwiftVersion3()) {
         B.createBuiltin(loc, getASTContext().getIdentifier("swift3ImplicitObjCEntrypoint"),
             getModule().Types.getEmptyTupleType(), { }, { });
       }

--- a/test/IRGen/objc_deprecated_objc_thunks.swift
+++ b/test/IRGen/objc_deprecated_objc_thunks.swift
@@ -1,4 +1,6 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -emit-ir -disable-objc-attr-requires-foundation-module | %FileCheck %s
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -emit-ir -disable-objc-attr-requires-foundation-module -enable-swift3-objc-inference -swift-version 4 | %FileCheck -check-prefix CHECK-SWIFT4 %s
+
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -emit-ir -disable-objc-attr-requires-foundation-module -swift-version 3 | %FileCheck -check-prefix CHECK-SWIFT3 %s
 
 // REQUIRES: CPU=x86_64
 // REQUIRES: objc_interop
@@ -9,7 +11,11 @@ class ObjCSubclass : NSObject {
   func foo() { }
 }
 
-// CHECK-LABEL: define hidden void @_T0016objc_deprecated_A7_thunks12ObjCSubclassC3fooyyFTo(%0*, i8*)
-// CHECK: entry:
-// CHECK: [[SELF:%[0-9]+]] = bitcast %0* %0 to %objc_object*
-// CHECK-NEXT: call void @swift_objc_swift3ImplicitObjCEntrypoint(%objc_object* [[SELF]], i8* %1)
+// CHECK-SWIFT4-LABEL: define hidden void @_T0016objc_deprecated_A7_thunks12ObjCSubclassC3fooyyFTo(%0*, i8*)
+// CHECK-SWIFT4: entry:
+// CHECK-SWIFT4: [[SELF:%[0-9]+]] = bitcast %0* %0 to %objc_object*
+// CHECK-SWIFT4-NEXT: call void @swift_objc_swift3ImplicitObjCEntrypoint(%objc_object* [[SELF]], i8* %1)
+
+// CHECK-SWIFT3-LABEL: define hidden void @_T0016objc_deprecated_A7_thunks12ObjCSubclassC3fooyyFTo(%0*, i8*)
+// CHECK-SWIFT3: entry:
+// CHECK-SWIFT3-NOT: call void @swift_objc_swift3ImplicitObjCEntrypoint(%objc_object* [[SELF]], i8* %1)

--- a/test/Interpreter/SDK/objc_swift3_deprecated_objc_inference.swift
+++ b/test/Interpreter/SDK/objc_swift3_deprecated_objc_inference.swift
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t  &&  mkdir -p %t
-// RUN: %target-build-swift %s -o %t/a.out
+// RUN: %target-build-swift -swift-version 4 -Xfrontend -enable-swift3-objc-inference %s -o %t/a.out
 // RUN: %target-run %t/a.out 2>&1 | %FileCheck %s -check-prefix=CHECK_NOTHING
 // RUN: env SWIFT_DEBUG_IMPLICIT_OBJC_ENTRYPOINT=0 SIMCTL_CHILD_SWIFT_DEBUG_IMPLICIT_OBJC_ENTRYPOINT=0 %target-run %t/a.out 2>&1 | %FileCheck %s -check-prefix=CHECK_NOTHING
 

--- a/test/SILGen/objc_deprecated_objc_thunks.swift
+++ b/test/SILGen/objc_deprecated_objc_thunks.swift
@@ -1,43 +1,47 @@
-// RUN: %target-swift-frontend -sdk %S/Inputs %s -I %S/Inputs -enable-source-import -emit-silgen -enable-swift3-objc-inference | %FileCheck %s
+// RUN: %target-swift-frontend -sdk %S/Inputs %s -I %S/Inputs -enable-source-import -emit-silgen -enable-swift3-objc-inference -swift-version 4 | %FileCheck -check-prefix CHECK-SWIFT4 %s
+
+// RUN: %target-swift-frontend -sdk %S/Inputs %s -I %S/Inputs -enable-source-import -emit-silgen -swift-version 3 | %FileCheck -check-prefix CHECK-SWIFT3 %s
 
 // REQUIRES: objc_interop
 
 import Foundation
 
 class ObjCSubclass : NSObject {
-  // CHECK-LABEL: sil hidden [thunk] @_T0016objc_deprecated_A7_thunks12ObjCSubclassCACyt7nothing_tcfcTo : $@convention(objc_method) (@owned ObjCSubclass) -> @owned ObjCSubclass {
-  // CHECK: bb0(%0 : $ObjCSubclass):
-  // CHECK-NEXT: builtin "swift3ImplicitObjCEntrypoint"() : $()
+  // CHECK-SWIFT4-LABEL: sil hidden [thunk] @_T0016objc_deprecated_A7_thunks12ObjCSubclassCACyt7nothing_tcfcTo : $@convention(objc_method) (@owned ObjCSubclass) -> @owned ObjCSubclass {
+  // CHECK-SWIFT4: bb0(%0 : $ObjCSubclass):
+  // CHECK-SWIFT4-NEXT: builtin "swift3ImplicitObjCEntrypoint"() : $()
   init(nothing: ()) { super.init() }
   
-  // CHECK-LABEL: sil hidden [thunk] @_T0016objc_deprecated_A7_thunks12ObjCSubclassC3fooyyFTo : $@convention(objc_method) (ObjCSubclass) -> ()
-  // CHECK: bb0(%0 : $ObjCSubclass):
-  // CHECK-NEXT: builtin "swift3ImplicitObjCEntrypoint"() : $()
+  // CHECK-SWIFT4-LABEL: sil hidden [thunk] @_T0016objc_deprecated_A7_thunks12ObjCSubclassC3fooyyFTo : $@convention(objc_method) (ObjCSubclass) -> ()
+  // CHECK-SWIFT4: bb0(%0 : $ObjCSubclass):
+  // CHECK-SWIFT4-NEXT: builtin "swift3ImplicitObjCEntrypoint"() : $()
   func foo() { }
 
-  // CHECK-LABEL: sil hidden [thunk] @_T0016objc_deprecated_A7_thunks12ObjCSubclassC3barSo8NSObjectCSgfgTo : $@convention(objc_method) (ObjCSubclass) -> @autoreleased Optional<NSObject>
-  // CHECK: bb0(%0 : $ObjCSubclass):
-  // CHECK-NEXT: builtin "swift3ImplicitObjCEntrypoint"() : $()
+  // CHECK-SWIFT4-LABEL: sil hidden [thunk] @_T0016objc_deprecated_A7_thunks12ObjCSubclassC3barSo8NSObjectCSgfgTo : $@convention(objc_method) (ObjCSubclass) -> @autoreleased Optional<NSObject>
+  // CHECK-SWIFT4: bb0(%0 : $ObjCSubclass):
+  // CHECK-SWIFT4-NEXT: builtin "swift3ImplicitObjCEntrypoint"() : $()
 
-  // CHECK-LABEL: sil hidden [thunk] @_T0016objc_deprecated_A7_thunks12ObjCSubclassC3barSo8NSObjectCSgfsTo : $@convention(objc_method) (Optional<NSObject>, ObjCSubclass) -> () {
-  // CHECK: %0 : $Optional<NSObject>, %1 : $ObjCSubclass
-  // CHECK-NEXT: builtin "swift3ImplicitObjCEntrypoint"() : $()
+  // CHECK-SWIFT4-LABEL: sil hidden [thunk] @_T0016objc_deprecated_A7_thunks12ObjCSubclassC3barSo8NSObjectCSgfsTo : $@convention(objc_method) (Optional<NSObject>, ObjCSubclass) -> () {
+  // CHECK-SWIFT4: %0 : $Optional<NSObject>, %1 : $ObjCSubclass
+  // CHECK-SWIFT4-NEXT: builtin "swift3ImplicitObjCEntrypoint"() : $()
   var bar: NSObject? = nil
 
-  // CHECK-LABEL: sil hidden [thunk] @_T0016objc_deprecated_A7_thunks12ObjCSubclassC9subscriptyXlSicfgTo : $@convention(objc_method) (Int, ObjCSubclass) -> @autoreleased AnyObject 
-  // CHECK: bb0(%0 : $Int, %1 : $ObjCSubclass):
-  // CHECK-NEXT: builtin "swift3ImplicitObjCEntrypoint"() : $()
+  // CHECK-SWIFT4-LABEL: sil hidden [thunk] @_T0016objc_deprecated_A7_thunks12ObjCSubclassC9subscriptyXlSicfgTo : $@convention(objc_method) (Int, ObjCSubclass) -> @autoreleased AnyObject 
+  // CHECK-SWIFT4: bb0(%0 : $Int, %1 : $ObjCSubclass):
+  // CHECK-SWIFT4-NEXT: builtin "swift3ImplicitObjCEntrypoint"() : $()
 
-  // CHECK-LABEL: sil hidden [thunk] @_T0016objc_deprecated_A7_thunks12ObjCSubclassC9subscriptyXlSicfsTo : $@convention(objc_method) (AnyObject, Int, ObjCSubclass) ->
-  // CHECK: bb0(%0 : $AnyObject, %1 : $Int, %2 : $ObjCSubclass):
-  // CHECK-NEXT: builtin "swift3ImplicitObjCEntrypoint"() : $()
+  // CHECK-SWIFT4-LABEL: sil hidden [thunk] @_T0016objc_deprecated_A7_thunks12ObjCSubclassC9subscriptyXlSicfsTo : $@convention(objc_method) (AnyObject, Int, ObjCSubclass) ->
+  // CHECK-SWIFT4: bb0(%0 : $AnyObject, %1 : $Int, %2 : $ObjCSubclass):
+  // CHECK-SWIFT4-NEXT: builtin "swift3ImplicitObjCEntrypoint"() : $()
   subscript (i: Int) -> AnyObject { get { return self } set { } } 
 }
 
 extension ObjCSubclass {
-	// CHECK-LABEL: sil hidden [thunk] @_T0016objc_deprecated_A7_thunks12ObjCSubclassC13falsePositiveyyFTo : $@convention(objc_method) (ObjCSubclass) -> ()
-  // CHECK: bb0(%0 : $ObjCSubclass):
-  // CHECK-NOT: builtin "swift3ImplicitObjCEntrypoint"() : $()
-	// CHECK: return
+	// CHECK-SWIFT4-LABEL: sil hidden [thunk] @_T0016objc_deprecated_A7_thunks12ObjCSubclassC13falsePositiveyyFTo : $@convention(objc_method) (ObjCSubclass) -> ()
+  // CHECK-SWIFT4: bb0(%0 : $ObjCSubclass):
+  // CHECK-SWIFT4-NOT: builtin "swift3ImplicitObjCEntrypoint"() : $()
+	// CHECK-SWIFT4: return
   func falsePositive() { }
 }
+
+// CHECK-SWIFT3-NOT: builtin "swift3ImplicitObjCEntrypoint"() : $()

--- a/validation-test/compiler_crashers_2_fixed/0095-rdar30154791.swift
+++ b/validation-test/compiler_crashers_2_fixed/0095-rdar30154791.swift
@@ -1,0 +1,35 @@
+// RUN: not %target-swift-frontend %s -typecheck
+
+struct X<T> {}
+struct Y<T> {}
+
+protocol P {
+  associatedtype T = X<U>
+  associatedtype U
+
+  func foo() -> T
+}
+
+protocol Q: P {
+  func bar() -> T
+  func bas() -> U
+}
+
+extension P {
+  func foo() -> X<U> { fatalError() }
+}
+
+extension Q {
+  func foo() -> Y<U> { fatalError() }
+  func bar() -> Y<U> { fatalError() }
+}
+
+struct S {}
+
+extension S {
+  func bas() -> Int {}
+}
+extension S: Q {}
+
+let x: Y = S().foo()
+


### PR DESCRIPTION
Only emit calls to `Builtin.swift3ImplicitObjCEntrypoint()` when we are
in Swift 4 mode with `-enable-swift3-objc-inference`, which is a
transitional state in which one is debugging the use of the
deprecated `@objc` entrypoints. Fixes rdar://problem/32122408.
