### PR TITLE
[Type checker] Extend redundant-conformance warning to imported types.

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -6101,13 +6101,15 @@ void TypeChecker::checkConformancesInContext(DeclContext *dc,
     auto extendedNominal =
       diag.ExistingDC->getAsNominalTypeOrNominalTypeExtensionContext();
     if (existingModule != dc->getParentModule() &&
-        (existingModule == extendedNominal->getParentModule() ||
+        (existingModule->getName() ==
+           extendedNominal->getParentModule()->getName() ||
          existingModule == diag.Protocol->getParentModule())) {
       // Warn about the conformance.
       diagnose(diag.Loc, diag::redundant_conformance_adhoc,
                dc->getDeclaredInterfaceType(),
                diag.Protocol->getName(),
-               existingModule == extendedNominal->getParentModule(),
+               existingModule->getName() ==
+                 extendedNominal->getParentModule()->getName(),
                existingModule->getName());
 
       // Complain about any declarations in this extension whose names match

--- a/test/Compatibility/range_hashable.swift
+++ b/test/Compatibility/range_hashable.swift
@@ -1,0 +1,9 @@
+// RUN: %target-typecheck-verify-swift -swift-version 3
+
+// REQUIRES: objc_interop
+
+import Foundation
+
+extension NSRange : Hashable { // expected-warning{{conformance of '_NSRange' to protocol 'Hashable' was already stated in the type's module 'Foundation'}}
+  var hashValue: Int { return 0 } // expected-note{{var 'hashValue' will not be used to satisfy the conformance to 'Hashable'}}
+}


### PR DESCRIPTION
Fix a silly gap in my fix for rdar://problem/31104415, where imported
types that gain conformances through their overlays were still getting
errors. Fixes SR-4820 / rdar://problem/32134724.
