### PR TITLE
[Driver/ClangImporter] Changes for the driver to recognize -pch-output-dir and propagate to the frontend invocations

### DIFF
--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -242,8 +242,7 @@ public:
   ///
   /// \sa clang::GeneratePCHAction
   bool emitBridgingPCH(StringRef headerPath,
-                       StringRef outputPCHPath,
-                       clang::DiagnosticConsumer *Diags = nullptr);
+                       StringRef outputPCHPath);
 
   /// Returns true if a clang CompilerInstance can successfully read in a PCH,
   /// assuming it exists, with the current options. This can be used to find out

--- a/include/swift/ClangImporter/ClangImporterOptions.h
+++ b/include/swift/ClangImporter/ClangImporterOptions.h
@@ -44,6 +44,9 @@ public:
   /// header, place it in this directory.
   std::string PrecompiledHeaderOutputDir;
 
+  /// Disable validating the persistent PCH.
+  bool PCHDisableValidation = false;
+
   /// \see Mode
   enum class Modes : uint8_t {
     /// Set up Clang for importing modules into Swift and generating IR from

--- a/include/swift/Driver/Action.h
+++ b/include/swift/Driver/Action.h
@@ -282,10 +282,16 @@ public:
 };
   
 class GeneratePCHJobAction : public JobAction {
+  std::string PersistentPCHDir;
+
   virtual void anchor();
 public:
-  explicit GeneratePCHJobAction(Action *Input)
-    : JobAction(Action::GeneratePCHJob, Input, types::TY_PCH) {}
+  GeneratePCHJobAction(Action *Input, StringRef persistentPCHDir)
+    : JobAction(Action::GeneratePCHJob, Input, types::TY_PCH),
+      PersistentPCHDir(persistentPCHDir) {}
+
+  bool isPersistentPCH() const { return !PersistentPCHDir.empty(); }
+  StringRef getPersistentPCHDir() const { return PersistentPCHDir; }
 
   static bool classof(const Action *A) {
     return A->getKind() == Action::GeneratePCHJob;

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -247,6 +247,9 @@ def emit_verbose_sil : Flag<["-"], "emit-verbose-sil">,
 def emit_pch : Flag<["-"], "emit-pch">,
   HelpText<"Emit PCH for imported Objective-C header file">, ModeOpt;
 
+def pch_disable_validation : Flag<["-"], "pch-disable-validation">,
+  HelpText<"Disable validating the persistent PCH">;
+
 def enable_sil_ownership : Flag<["-"], "enable-sil-ownership">,
   HelpText<"Enable the SIL Ownership Model">;
 

--- a/lib/ClangImporter/ClangDiagnosticConsumer.cpp
+++ b/lib/ClangImporter/ClangDiagnosticConsumer.cpp
@@ -29,9 +29,10 @@ namespace {
                                   StringRef)> callback;
 
   public:
-    ClangDiagRenderer(const clang::ASTContext &ctx, decltype(callback) fn)
-       : DiagnosticNoteRenderer(ctx.getLangOpts(),
-                                &ctx.getDiagnostics().getDiagnosticOptions()),
+    ClangDiagRenderer(const clang::LangOptions &langOpts,
+                      clang::DiagnosticOptions *diagOpts,
+                      decltype(callback) fn)
+       : DiagnosticNoteRenderer(langOpts, diagOpts),
          callback(fn) {}
 
   private:
@@ -224,7 +225,9 @@ void ClangDiagnosticConsumer::HandleDiagnostic(
 
   } else {
     assert(clangDiag.hasSourceManager());
-    ClangDiagRenderer renderer(ImporterImpl.getClangASTContext(), emitDiag);
+    auto clangCI = ImporterImpl.getClangInstance();
+    ClangDiagRenderer renderer(clangCI->getLangOpts(),
+                               &clangCI->getDiagnosticOpts(), emitDiag);
     renderer.emitDiagnostic(clangDiag.getLocation(), clangDiagLevel, message,
                             clangDiag.getRanges(), clangDiag.getFixItHints(),
                             &clangDiag.getSourceManager());

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -1757,9 +1757,10 @@ static StringRef getOutputFilename(Compilation &C,
   // use the -o arg) even though, based on ownership considerations within the
   // driver, it is stored as a "top level" JobAction.
   if (auto *PCHAct = dyn_cast<GeneratePCHJobAction>(JA)) {
-    // For a persistent PCH use the PCH output directory as the -o arg.
+    // For a persistent PCH we don't use an output, the frontend determines
+    // the filename to use for the PCH.
     if (PCHAct->isPersistentPCH())
-      return PCHAct->getPersistentPCHDir();
+      return StringRef();
     AtTopLevel = false;
   }
 

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -1326,7 +1326,12 @@ void Driver::buildActions(const ToolChain &TC,
         auto Ty = TC.lookupTypeForExtension(llvm::sys::path::extension(Value));
         if (Ty == types::TY_ObjCHeader) {
           std::unique_ptr<Action> HeaderInput(new InputAction(*A, Ty));
-          PCH = new GeneratePCHJobAction(HeaderInput.release());
+          StringRef PersistentPCHDir;
+          if (const Arg *A = Args.getLastArg(options::OPT_pch_output_dir)) {
+            PersistentPCHDir = A->getValue();
+          }
+          PCH = new GeneratePCHJobAction(HeaderInput.release(),
+                                         PersistentPCHDir);
           Actions.push_back(PCH);
         }
       }
@@ -1751,7 +1756,10 @@ static StringRef getOutputFilename(Compilation &C,
   // FIXME: Treat GeneratePCHJobAction as non-top-level (to get tempfile and not
   // use the -o arg) even though, based on ownership considerations within the
   // driver, it is stored as a "top level" JobAction.
-  if (isa<GeneratePCHJobAction>(JA)) {
+  if (auto *PCHAct = dyn_cast<GeneratePCHJobAction>(JA)) {
+    // For a persistent PCH use the PCH output directory as the -o arg.
+    if (PCHAct->isPersistentPCH())
+      return PCHAct->getPersistentPCHDir();
     AtTopLevel = false;
   }
 

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -823,7 +823,7 @@ ToolChain::constructInvocation(const GeneratePCHJobAction &job,
     Arguments.push_back("-emit-pch");
     Arguments.push_back("-pch-output-dir");
     Arguments.push_back(
-      context.Args.MakeArgString(context.Output.getPrimaryOutputFilename()));
+      context.Args.MakeArgString(job.getPersistentPCHDir()));
   } else {
     Arguments.push_back("-emit-pch");
     Arguments.push_back("-o");

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -335,16 +335,33 @@ ToolChain::constructInvocation(const CompileJobAction &job,
   // of any input PCH to the current action if one is present.
   if (context.Args.hasArgNoClaim(options::OPT_import_objc_header)) {
     bool ForwardAsIs = true;
-    for (auto *IJ : context.Inputs) {
-      if (!IJ->getOutput().getAnyOutputForType(types::TY_PCH).empty()) {
-        Arguments.push_back("-import-objc-header");
-        addInputsOfType(Arguments, context.Inputs, types::TY_PCH);
-        ForwardAsIs = false;
-        break;
+    bool bridgingPCHIsEnabled =
+        context.Args.hasFlag(options::OPT_enable_bridging_pch,
+                             options::OPT_disable_bridging_pch,
+                             true);
+    bool usePersistentPCH = bridgingPCHIsEnabled &&
+        context.Args.hasArg(options::OPT_pch_output_dir);
+    if (!usePersistentPCH) {
+      for (auto *IJ : context.Inputs) {
+        if (!IJ->getOutput().getAnyOutputForType(types::TY_PCH).empty()) {
+          Arguments.push_back("-import-objc-header");
+          addInputsOfType(Arguments, context.Inputs, types::TY_PCH);
+          ForwardAsIs = false;
+          break;
+        }
       }
     }
     if (ForwardAsIs) {
       context.Args.AddLastArg(Arguments, options::OPT_import_objc_header);
+    }
+    if (usePersistentPCH) {
+      context.Args.AddLastArg(Arguments, options::OPT_pch_output_dir);
+      if (context.OI.CompilerMode == OutputInfo::Mode::StandardCompile) {
+        // In the 'multiple invocations for each file' mode we don't need to
+        // validate the PCH every time, it has been validated with the initial
+        // -emit-pch invocation.
+        Arguments.push_back("-pch-disable-validation");
+      }
     }
   }
 
@@ -802,10 +819,17 @@ ToolChain::constructInvocation(const GeneratePCHJobAction &job,
 
   addInputsOfType(Arguments, context.InputActions, types::TY_ObjCHeader);
 
-  Arguments.push_back("-emit-pch");
-  Arguments.push_back("-o");
-  Arguments.push_back(
-    context.Args.MakeArgString(context.Output.getPrimaryOutputFilename()));
+  if (job.isPersistentPCH()) {
+    Arguments.push_back("-emit-pch");
+    Arguments.push_back("-pch-output-dir");
+    Arguments.push_back(
+      context.Args.MakeArgString(context.Output.getPrimaryOutputFilename()));
+  } else {
+    Arguments.push_back("-emit-pch");
+    Arguments.push_back("-o");
+    Arguments.push_back(
+      context.Args.MakeArgString(context.Output.getPrimaryOutputFilename()));
+  }
 
   return {SWIFT_EXECUTABLE_NAME, Arguments};
 }

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1129,6 +1129,7 @@ static bool ParseClangImporterArgs(ClangImporterOptions &Opts,
 
   if (const Arg *A = Args.getLastArg(OPT_pch_output_dir)) {
     Opts.PrecompiledHeaderOutputDir = A->getValue();
+    Opts.PCHDisableValidation |= Args.hasArg(OPT_pch_disable_validation);
   }
 
   return false;

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -459,6 +459,15 @@ static bool performCompile(CompilerInstance &Instance,
   if (Action == FrontendOptions::EmitPCH) {
     auto clangImporter = static_cast<ClangImporter *>(
       Instance.getASTContext().getClangModuleLoader());
+    auto &ImporterOpts = Invocation.getClangImporterOptions();
+    auto &PCHOutDir = ImporterOpts.PrecompiledHeaderOutputDir;
+    if (!PCHOutDir.empty()) {
+      ImporterOpts.BridgingHeader = Invocation.getInputFilenames()[0];
+      // Create or validate a persistent PCH.
+      auto SwiftPCHHash = Invocation.getPCHHash();
+      auto PCH = clangImporter->getOrCreatePCH(ImporterOpts, SwiftPCHHash);
+      return !PCH.hasValue();
+    }
     return clangImporter->emitBridgingPCH(
       Invocation.getInputFilenames()[0],
       opts.getSingleOutputFilename());

--- a/test/ClangImporter/MixedSource/import-mixed-framework-with-forward.swift
+++ b/test/ClangImporter/MixedSource/import-mixed-framework-with-forward.swift
@@ -7,6 +7,7 @@
 
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-pch -F %t %S/Inputs/import-mixed-framework-with-forward.h -o %t/bridge.pch
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -F %t -import-objc-header %t/bridge.pch %s -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -F %t -import-objc-header %S/Inputs/import-mixed-framework-with-forward.h -pch-output-dir %t/pch %s -verify
 
 
 // REQUIRES: objc_interop

--- a/test/ClangImporter/diags-with-many-imports.swift
+++ b/test/ClangImporter/diags-with-many-imports.swift
@@ -1,6 +1,7 @@
 // RUN: not %target-swift-frontend -typecheck %s -I %S/Inputs/many-imports -import-objc-header %S/Inputs/many-imports/obsoleted.h 2>&1 | %FileCheck %s
 // RUN: %target-swift-frontend -emit-pch %S/Inputs/many-imports/obsoleted.h -o %t.pch
 // RUN: not %target-swift-frontend -typecheck %s -I %S/Inputs/many-imports -import-objc-header %t.pch 2>&1 | %FileCheck %s
+// RUN: not %target-swift-frontend -typecheck %s -I %S/Inputs/many-imports -import-objc-header %S/Inputs/many-imports/obsoleted.h -pch-output-dir %t/pch 2>&1 | %FileCheck %s
 
 import Module1
 import Module2

--- a/test/ClangImporter/objc_redeclared_properties_incompatible.swift
+++ b/test/ClangImporter/objc_redeclared_properties_incompatible.swift
@@ -5,6 +5,7 @@
 
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-pch -F %S/Inputs/frameworks -o %t.pch %t.h
 // RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -F %S/Inputs/frameworks -import-objc-header %t.pch %s 2>&1 | %FileCheck -check-prefix=CHECK -check-prefix=CHECK-PRIVATE %s
+// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -F %S/Inputs/frameworks -import-objc-header %t.h -pch-output-dir %t/pch %s 2>&1 | %FileCheck -check-prefix=CHECK -check-prefix=CHECK-PRIVATE %s
 
 // REQUIRES: objc_interop
 

--- a/test/ClangImporter/pch-bridging-header-deps.swift
+++ b/test/ClangImporter/pch-bridging-header-deps.swift
@@ -10,6 +10,11 @@
 // RUN: %FileCheck --check-prefix CHECK-SWIFTDEPS %s < %t.swiftdeps
 // RUN: %FileCheck --check-prefix CHECK-SWIFTDEPS2 %s < %t.swiftdeps
 
+// RUN: %target-swift-frontend -module-name test -c -emit-dependencies-path %t.persistent.d -emit-reference-dependencies-path %t.persistent.swiftdeps -primary-file %s %s -import-objc-header %S/Inputs/chained-unit-test-bridging-header-to-pch.h -pch-output-dir %t/pch
+// RUN: %FileCheck --check-prefix CHECK-DEPS %s < %t.persistent.d
+// RUN: %FileCheck --check-prefix CHECK-SWIFTDEPS %s < %t.persistent.swiftdeps
+// RUN: %FileCheck --check-prefix CHECK-SWIFTDEPS2 %s < %t.persistent.swiftdeps
+
 print(app_function(1))
 
 // CHECK-DEPS: pch-bridging-header-deps.o : {{.*}}SOURCE_DIR/test/ClangImporter/Inputs/app-bridging-header-to-pch.h {{.*}}SOURCE_DIR/test/ClangImporter/Inputs/chained-unit-test-bridging-header-to-pch.h

--- a/test/ClangImporter/pch-bridging-header-serialized-diagnostics.swift
+++ b/test/ClangImporter/pch-bridging-header-serialized-diagnostics.swift
@@ -8,5 +8,14 @@
 // RUN: not %target-swift-frontend -emit-pch %S/Inputs/bad-bridging-header.h -o %t.pch -serialize-diagnostics -serialize-diagnostics-path %t.dia 2>&1 | %FileCheck -check-prefix=CHECK-DIAG %s
 // RUN: c-index-test -read-diagnostics %t.dia > %t.deserialized_diagnostics.txt 2>&1
 // RUN: %FileCheck -check-prefix=CHECK-DIAG -input-file=%t.deserialized_diagnostics.txt %s
+
+// RUN: not %target-swift-frontend -emit-pch %S/Inputs/bad-bridging-header.h -pch-output-dir %t/pch -serialize-diagnostics -serialize-diagnostics-path %t.dia2 2>&1 | %FileCheck -check-prefix=CHECK-DIAG %s
+// RUN: c-index-test -read-diagnostics %t.dia2 > %t.deserialized_diagnostics.txt2 2>&1
+// RUN: %FileCheck -check-prefix=CHECK-DIAG -input-file=%t.deserialized_diagnostics.txt2 %s
+
+// RUN: not %target-swift-frontend -import-objc-header %S/Inputs/bad-bridging-header.h -pch-output-dir %t/pch -typecheck %s -serialize-diagnostics -serialize-diagnostics-path %t.dia3 2>&1 | %FileCheck -check-prefix=CHECK-DIAG %s
+// RUN: c-index-test -read-diagnostics %t.dia3 > %t.deserialized_diagnostics.txt3 2>&1
+// RUN: %FileCheck -check-prefix=CHECK-DIAG -input-file=%t.deserialized_diagnostics.txt3 %s
+
 // CHECK-DIAG: bad-bridging-header.h:1:10: error: 'this-header-does-not-exist.h' file not found
 // CHECK-DIAG: failed to emit precompiled header

--- a/test/ClangImporter/pch-bridging-header.swift
+++ b/test/ClangImporter/pch-bridging-header.swift
@@ -20,6 +20,31 @@
 // RUN: env TMPDIR=%t/tmp/ %target-swiftc_driver -parse %s -import-objc-header %S/Inputs/sdk-bridging-header.h
 // RUN: not ls %t/tmp/*.pch >/dev/null 2>&1
 
+// Test -emit-pch invocation but with a persistent PCH
+// RUN: %target-swift-frontend -emit-pch -pch-output-dir %t/pch %S/Inputs/sdk-bridging-header.h
+// RUN: %target-swift-frontend -parse -verify %s -import-objc-header %S/Inputs/sdk-bridging-header.h -pch-output-dir %t/pch -pch-disable-validation
+// RUN: ls %t/pch/*.pch >/dev/null 2>&1
+
+// Test implicit use of persistent PCH
+// RUN: %target-swift-frontend -parse -verify %s -import-objc-header %S/Inputs/sdk-bridging-header.h -pch-output-dir %t/pch2
+// RUN: ls %t/pch2/*.pch >/dev/null 2>&1
+
+// RUN: touch %t/header.with.dot.h
+// RUN: touch %t/test.swift
+// RUN: %target-swift-frontend -typecheck %t/test.swift -import-objc-header %t/header.with.dot.h -pch-output-dir %t/pch_with_dot -module-cache-path %t/mcp1
+// RUN: %target-swift-frontend -typecheck %t/test.swift -import-objc-header %t/header.with.dot.h -pch-output-dir %t/pch_with_dot -module-cache-path %t/mcp2
+// RUN: ls %t/pch_with_dot/*swift*clang*.pch | count 2
+
+// Test the driver-automated version using persistent PCH
+// RUN: %target-swiftc_driver -parse -save-temps %s -import-objc-header %S/Inputs/sdk-bridging-header.h -pch-output-dir %t/pch3
+// RUN: ls %t/pch3/*.pch >/dev/null 2>&1
+// RUN: llvm-objdump -raw-clang-ast %t/pch3/*.pch | llvm-bcanalyzer -dump | %FileCheck %s -check-prefix=PERSISTENT
+// PERSISTENT: ORIGINAL_FILE{{.*}}Inputs/sdk-bridging-header.h
+
+// Test that -pch-disable-validation works in that it won't implicitely create a PCH
+// RUN: not %target-swift-frontend -typecheck %s -import-objc-header %S/Inputs/sdk-bridging-header.h -pch-output-dir %t/no-pch -pch-disable-validation 2>&1 | %FileCheck %s -check-prefix=NO-VALIDATION
+// NO-VALIDATION: PCH file {{.*}} not found
+
 import Foundation
 
 let not = MyPredicate.not()

--- a/test/Driver/bridging-pch.swift
+++ b/test/Driver/bridging-pch.swift
@@ -17,3 +17,22 @@
 
 // RUN: echo "{\"\": {\"swift-dependencies\": \"master.swiftdeps\"}}" > %t.json
 // RUN: %swiftc_driver -typecheck -incremental -enable-bridging-pch -output-file-map %t.json -import-objc-header %S/Inputs/bridging-header.h %s
+
+// Test persistent PCH
+
+// RUN: %swiftc_driver -typecheck -driver-print-actions -import-objc-header %S/Inputs/bridging-header.h -pch-output-dir %t/pch %s 2>&1 | %FileCheck %s -check-prefix=YESPCHACT
+// RUN: %swiftc_driver -typecheck -disable-bridging-pch -driver-print-actions -import-objc-header %S/Inputs/bridging-header.h -pch-output-dir %t/pch %s 2>&1 | %FileCheck %s -check-prefix=NOPCHACT
+
+// RUN: %swiftc_driver -typecheck -driver-print-jobs -import-objc-header %S/Inputs/bridging-header.h -pch-output-dir %t/pch -disable-bridging-pch %s 2>&1 | %FileCheck %s -check-prefix=PERSISTENT-DISABLED-YESPCHJOB
+// RUN: %swiftc_driver -typecheck -driver-print-jobs -import-objc-header %S/Inputs/bridging-header.h -pch-output-dir %t/pch -whole-module-optimization -disable-bridging-pch %s 2>&1 | %FileCheck %s -check-prefix=PERSISTENT-DISABLED-YESPCHJOB
+// PERSISTENT-DISABLED-YESPCHJOB-NOT: -pch-output-dir
+
+// RUN: %swiftc_driver -typecheck -driver-print-jobs -import-objc-header %S/Inputs/bridging-header.h -pch-output-dir %t/pch %s 2>&1 | %FileCheck %s -check-prefix=PERSISTENT-YESPCHJOB
+// PERSISTENT-YESPCHJOB: {{.*}}swift -frontend {{.*}} -emit-pch -pch-output-dir {{.*}}/pch
+// PERSISTENT-YESPCHJOB: {{.*}}swift -frontend {{.*}} -import-objc-header {{.*}}bridging-header.h -pch-output-dir {{.*}}/pch -pch-disable-validation
+
+// RUN: %swiftc_driver -typecheck -driver-print-jobs -import-objc-header %S/Inputs/bridging-header.h -pch-output-dir %t/pch -whole-module-optimization %s 2>&1 | %FileCheck %s -check-prefix=PERSISTENT-WMO-YESPCHJOB --implicit-check-not pch-disable-validation
+// PERSISTENT-WMO-YESPCHJOB: {{.*}}swift -frontend {{.*}} -import-objc-header {{.*}}bridging-header.h -pch-output-dir {{.*}}/pch
+
+// RUN: %swiftc_driver -typecheck -disable-bridging-pch  -driver-print-jobs -import-objc-header %S/Inputs/bridging-header.h -pch-output-dir %t/pch %s 2>&1 | %FileCheck %s -check-prefix=NOPCHJOB
+// RUN: %swiftc_driver -typecheck -incremental -enable-bridging-pch -output-file-map %t.json -import-objc-header %S/Inputs/bridging-header.h -pch-output-dir %t/pch %s

--- a/test/IDE/complete_with_header_import.swift
+++ b/test/IDE/complete_with_header_import.swift
@@ -10,6 +10,13 @@
 // RUN: echo '// new stuff' >> %t/header.h
 // RUN: %target-swift-ide-test -code-completion -pch-output-dir %t/pch -source-filename %s -code-completion-token=TOP -import-objc-header %t/header.h | %FileCheck %s -check-prefix=CHECK-TOP
 
+// Check that code-completion functions if there is an error in the header.
+// FIXME: Nothing from the bridging header gets imported if there is an error, we should be more resilient.
+// RUN: cp %S/Inputs/header.h %t/header-with-error.h
+// RUN: echo '#error error in header' >> %t/header-with-error.h
+// RUN: %target-swift-ide-test -code-completion -pch-output-dir %t/pch -source-filename %s -code-completion-token=TOP -import-objc-header %t/header-with-error.h | %FileCheck %s -check-prefix=CHECK-WITH-ERROR
+// CHECK-WITH-ERROR: Decl[FreeFunction]{{.*}} foo()
+
 // REQUIRES: objc_interop
 
 func foo() {


### PR DESCRIPTION
For the multiple-files mode -emit-pch is still invoked in separate frontend invocation but with using a persistent PCH.
Subsequent frontend invocations use the persistent PCH but they don't need to validate it.

For all-files mode (e.g. WMO) the frontend invocation uses a persistent PCH that it also validates.
