### PR TITLE
Don't leak writeback path components

### DIFF
--- a/lib/SILGen/LValue.h
+++ b/lib/SILGen/LValue.h
@@ -506,6 +506,7 @@ struct LLVM_LIBRARY_VISIBILITY ExclusiveBorrowFormalAccess : FormalAccess {
 
   void finishImpl(SILGenFunction &SGF) override {
     performWriteback(SGF, /*isFinal*/ true);
+    component.reset();
   }
 };
 


### PR DESCRIPTION
The problem here is really that DiverseStack isn't supposed to handle non-trivial types; this
is a targeted fix.

This change affects only an internal detail of SILGen; it does not alter the generated code.  It is low-risk because of that and because it is well-exercised by regression tests.  No other testing is required other than to observe that the leak disappears.

Fixes rdar://32083241.

The master version of this PR, #9471, was reviewed by @jckarter.