### PR TITLE
SILGen/IRGen/KeyPaths: Components for ObjC properties need to be identified by selector.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,23 @@ CHANGELOG
 Swift 4.0
 ---------
 
+* [SE-0161][] is partially implemented. Swift now natively supports key path
+  objects for properties. Similar to KVC key path strings in Cocoa, key path
+  objects allow a property to be referenced independently of accessing it
+  from a value:
+
+    ```swift
+    struct Point {
+      var x, y: Double
+    }
+    let x = \Point.x
+    let y = \Point.y
+
+    let p = Point(x: 3, y: 4)
+    p[keyPath: x] // gives 3
+    p[keyPath: y] // gives 4
+    ```
+
 * Core Foundation types implicitly conform to Hashable (and Equatable), using
   CFHash and CFEqual as the implementation. This change applies even to "Swift
   3 mode", so if you were previously adding this conformance yourself, use

--- a/include/swift/ABI/KeyPath.h
+++ b/include/swift/ABI/KeyPath.h
@@ -164,10 +164,17 @@ public:
   };
   
   enum ComputedPropertyIDKind {
-    Getter,
+    Pointer,
     StoredPropertyOffset,
     VTableOffset,
   };
+  
+  constexpr static uint32_t
+  getResolutionStrategy(ComputedPropertyIDKind idKind) {
+    return idKind == Pointer ? _SwiftKeyPathComponentHeader_ComputedIDUnresolvedIndirectPointer
+         : idKind == StoredPropertyOffset ? _SwiftKeyPathComponentHeader_ComputedIDUnresolvedFieldOffset
+         : (assert("no resolution strategy implemented" && false), 0);
+  }
   
   constexpr static KeyPathComponentHeader
   forComputedProperty(ComputedPropertyKind kind,
@@ -186,7 +193,8 @@ public:
       | (idKind == VTableOffset
            ? _SwiftKeyPathComponentHeader_ComputedIDByVTableOffsetFlag : 0)
       | (hasArguments ? _SwiftKeyPathComponentHeader_ComputedHasArgumentsFlag : 0)
-      | (resolvedID ? 0 : _SwiftKeyPathComponentHeader_ComputedUnresolvedIDFlag));
+      | (resolvedID ? _SwiftKeyPathComponentHeader_ComputedIDResolved
+                    : getResolutionStrategy(idKind)));
   }
   
   constexpr uint32_t getData() const { return Data; }

--- a/lib/IRGen/GenObjC.cpp
+++ b/lib/IRGen/GenObjC.cpp
@@ -581,6 +581,11 @@ namespace {
   };
 } // end anonymous namespace
 
+llvm::Constant *IRGenModule::getAddrOfObjCSelectorRef(SILDeclRef method) {
+  assert(method.isForeign);
+  return getAddrOfObjCSelectorRef(Selector(method).str());
+}
+
 static void emitSuperArgument(IRGenFunction &IGF, bool isInstanceMethod,
                               llvm::Value *selfValue,
                               Explosion &selfValues,

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -662,6 +662,7 @@ public:
   llvm::Constant *getAddrOfGlobalConstantString(StringRef utf8);
   llvm::Constant *getAddrOfGlobalUTF16ConstantString(StringRef utf8);
   llvm::Constant *getAddrOfObjCSelectorRef(StringRef selector);
+  llvm::Constant *getAddrOfObjCSelectorRef(SILDeclRef method);
   llvm::Constant *getAddrOfObjCMethodName(StringRef methodName);
   llvm::Constant *getAddrOfObjCProtocolRecord(ProtocolDecl *proto,
                                               ForDefinition_t forDefinition);

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2694,7 +2694,12 @@ getIdForKeyPathComponentComputedProperty(SILGenFunction &SGF,
   }
   case AccessStrategy::DispatchToAccessor: {
     // Identify the property by its vtable or wtable slot.
-    return SILDeclRef(property->getGetter(), SILDeclRef::Kind::Func);
+    // Use the foreign selector if the decl is ObjC-imported, dynamic, or
+    // otherwise requires objc_msgSend for its ABI.
+    return SILDeclRef(property->getGetter(), SILDeclRef::Kind::Func,
+                      ResilienceExpansion::Minimal,
+                      /*curried*/ false,
+                      /*foreign*/ property->requiresForeignGetterAndSetter());
   }
   case AccessStrategy::BehaviorStorage:
     llvm_unreachable("unpossible");

--- a/stdlib/public/SwiftShims/KeyPath.h
+++ b/stdlib/public/SwiftShims/KeyPath.h
@@ -83,8 +83,14 @@ static const __swift_uint32_t _SwiftKeyPathComponentHeader_ComputedIDByVTableOff
   = 0x02000000U;
 static const __swift_uint32_t _SwiftKeyPathComponentHeader_ComputedHasArgumentsFlag
   = 0x01000000U;
-static const __swift_uint32_t _SwiftKeyPathComponentHeader_ComputedUnresolvedIDFlag
+static const __swift_uint32_t _SwiftKeyPathComponentHeader_ComputedIDResolutionMask
+  = 0x0000000FU;
+static const __swift_uint32_t _SwiftKeyPathComponentHeader_ComputedIDResolved
+  = 0x00000000U;
+static const __swift_uint32_t _SwiftKeyPathComponentHeader_ComputedIDUnresolvedFieldOffset
   = 0x00000001U;
+static const __swift_uint32_t _SwiftKeyPathComponentHeader_ComputedIDUnresolvedIndirectPointer
+  = 0x00000002U;
 
 
 #ifdef __cplusplus

--- a/test/IRGen/keypaths_objc.sil
+++ b/test/IRGen/keypaths_objc.sil
@@ -1,0 +1,37 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-ir %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+// REQUIRES: objc_interop
+
+import Swift
+import Foundation
+
+class C: NSObject {
+  dynamic var x: NSString { get }
+  override init()
+}
+
+sil_vtable C {}
+
+sil @x_get : $@convention(thin) (@in C) -> @out NSString
+
+// CHECK: [[KEYPATH_A:@keypath.*]] = private global
+// --             0x2000_0002: computed, get-only, indirect identifier
+// CHECK-SAME: i32 536870914
+// CHECK-SAME: i8** @"\01L_selector(x)"
+
+// CHECK-LABEL: define swiftcc void @objc_only_property()
+sil @objc_only_property : $@convention(thin) () -> () {
+entry:
+  // CHECK: call %swift.refcounted* @swift_getKeyPath({{.*}} [[KEYPATH_A]]
+  %a = keypath $KeyPath<C, NSString>, (objc "x"; root $C; gettable_property $NSString, id #C.x!getter.1.foreign, getter @x_get : $@convention(thin) (@in C) -> @out NSString)
+  unreachable
+}
+
+sil hidden @_T013keypaths_objc1CC1xSo8NSStringCfgTo : $@convention(objc_method) (@guaranteed C) -> NSString {
+entry(%0 : $C):
+  unreachable
+}
+
+sil hidden @_T013keypaths_objc1CCACycfcTo : $@convention(objc_method) (@objc_metatype C.Type) -> @owned C {
+entry(%0 : $@objc_metatype C.Type):
+  unreachable
+}

--- a/test/SILGen/Inputs/keypaths_objc.h
+++ b/test/SILGen/Inputs/keypaths_objc.h
@@ -1,0 +1,7 @@
+@import Foundation;
+
+@interface ObjCFoo
+
+@property(readonly) NSString *_Nonnull objcProp;
+
+@end

--- a/test/SILGen/keypaths_objc.swift
+++ b/test/SILGen/keypaths_objc.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-experimental-keypaths -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-experimental-keypaths -emit-silgen -import-objc-header %S/Inputs/keypaths_objc.h %s | %FileCheck %s
 // REQUIRES: objc_interop
 
 import Foundation
@@ -16,6 +16,8 @@ class Foo: NSObject {
 
   @objc subscript(x: Int) -> Foo { return self }
   @objc subscript(x: Bar) -> Foo { return self }
+
+  dynamic var dyn: String { fatalError() }
 }
 
 class Bar: NSObject {
@@ -42,4 +44,14 @@ func objcKeypaths() {
   _ = \Foo.bar.foo.nonobjc.y
   // CHECK: keypath $KeyPath<Foo, Bar>, (objc "thisIsADifferentName"
   _ = \Foo.differentName
+}
+
+// CHECK-LABEL: sil hidden @_T013keypaths_objc0B18KeypathIdentifiersyyF
+func objcKeypathIdentifiers() {
+  // CHECK: keypath $KeyPath<ObjCFoo, String>, (objc "objcProp"; {{.*}} id #ObjCFoo.objcProp!getter.1.foreign
+  _ = \ObjCFoo.objcProp
+  // CHECK: keypath $KeyPath<Foo, String>, (objc "dyn"; {{.*}} id #Foo.dyn!getter.1.foreign
+  _ = \Foo.dyn
+  // CHECK: keypath $KeyPath<Foo, Int>, (objc "int"; {{.*}} id #Foo.int!getter.1 :
+  _ = \Foo.int
 }

--- a/test/stdlib/KeyPathObjC.swift
+++ b/test/stdlib/KeyPathObjC.swift
@@ -20,6 +20,8 @@ class Foo: NSObject {
 
   @objc subscript(x: Int) -> Foo { return self }
   @objc subscript(x: Bar) -> Foo { return self }
+
+  dynamic var dynamic: Bar { fatalError() }
 }
 
 class Bar: NSObject {
@@ -68,6 +70,14 @@ testKVCStrings.test("KVC strings") {
     let foo_nonobjc_y = foo_nonobjc.appending(path: nonobjc_y)
     expectEqual(foo_nonobjc_y._kvcKeyPathString, nil)
   }
+}
+
+testKVCStrings.test("identification by selector") {
+  let foo_dynamic = \Foo.dynamic
+  let bar_foo = \Bar.foo
+  let foo_dynamic_foo = \Foo.dynamic.foo
+
+  expectEqual(foo_dynamic.appending(path: bar_foo), foo_dynamic_foo)
 }
 
 runAllTests()


### PR DESCRIPTION
A property imported from Objective-C, or marked in Swift with the `dynamic` keyword, doesn't have a vtable slot, so can't be identified that way. Use the ObjC selector as the unique identifier to ascribe equality to such components. Fixes rdar://problem/31768669. (While we're here, throw some more execution tests and a changelog note in.)
