### PR TITLE
[4.0] [QoI] Improve diagnostics for generic subscripts

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -7643,6 +7643,40 @@ FailureDiagnosis::validateContextualType(Type contextualType,
     if (FT->isAutoClosure())
       contextualType = FT->getResult();
 
+  // Since some of the contextual types might be tuples e.g. subscript argument
+  // is a tuple or paren wrapping a tuple, it's required to recursively check
+  // its elements to determine nullability of the contextual type, because it
+  // might contain archetypes.
+  std::function<bool(Type)> shouldNullifyType = [&](Type type) -> bool {
+    switch (type->getDesugaredType()->getKind()) {
+    case TypeKind::Archetype:
+    case TypeKind::Unresolved:
+      return true;
+
+    case TypeKind::BoundGenericEnum:
+    case TypeKind::BoundGenericClass:
+    case TypeKind::BoundGenericStruct:
+    case TypeKind::UnboundGeneric:
+    case TypeKind::GenericFunction:
+    case TypeKind::Metatype:
+      return type->hasUnresolvedType();
+
+    case TypeKind::Tuple: {
+      auto tupleType = type->getAs<TupleType>();
+      for (auto &element : tupleType->getElements()) {
+        if (shouldNullifyType(element.getType()))
+            return true;
+      }
+      break;
+    }
+
+    default:
+      return false;
+    }
+
+    return false;
+  };
+
   bool shouldNullify = false;
   if (auto objectType = contextualType->getLValueOrInOutObjectType()) {
     // Note that simply checking for `objectType->hasUnresolvedType()` is not
@@ -7654,25 +7688,7 @@ FailureDiagnosis::validateContextualType(Type contextualType,
     // sub-expression solver a chance to try and compute type as it sees fit
     // and higher level code would have a chance to check it, which avoids
     // diagnostic messages like `cannot convert (_) -> _ to (Int) -> Void`.
-    switch (objectType->getDesugaredType()->getKind()) {
-    case TypeKind::Archetype:
-    case TypeKind::Unresolved:
-      shouldNullify = true;
-      break;
-
-    case TypeKind::BoundGenericEnum:
-    case TypeKind::BoundGenericClass:
-    case TypeKind::BoundGenericStruct:
-    case TypeKind::UnboundGeneric:
-    case TypeKind::GenericFunction:
-    case TypeKind::Metatype:
-      shouldNullify = objectType->hasUnresolvedType();
-      break;
-
-    default:
-      shouldNullify = false;
-      break;
-    }
+    shouldNullify = shouldNullifyType(objectType);
   }
 
   // If the conversion type contains no info, drop it.

--- a/test/Compatibility/tuple_arguments.swift
+++ b/test/Compatibility/tuple_arguments.swift
@@ -1056,7 +1056,7 @@ struct GenericSubscriptLabeled<T> {
 }
 
 struct GenericSubscriptTwo<T> {
-  subscript(_ x: T, _ y: T) -> Int { get { return 0 } set { } } // expected-note {{'subscript' declared here}}
+  subscript(_ x: T, _ y: T) -> Int { get { return 0 } set { } } // expected-note 3 {{'subscript' declared here}}
 }
 
 struct GenericSubscriptTuple<T> {
@@ -1126,8 +1126,8 @@ do {
 
   var s2 = GenericSubscriptTwo<Double>()
   _ = s2[a, b]
-  _ = s2[(a, b)] // expected-error {{cannot convert value of type '(Double, Double)' to expected argument type '(_, _)'}}
-  _ = s2[d] // expected-error {{cannot convert value of type '(Double, Double)' to expected argument type '(_, _)'}}
+  _ = s2[(a, b)] // expected-error {{missing argument for parameter #2 in call}}
+  _ = s2[d] // expected-error {{missing argument for parameter #2 in call}}
 
   var s3 = GenericSubscriptTuple<Double>()
   _ = s3[a, b] // expected-error {{extra argument in call}}

--- a/test/Constraints/tuple_arguments.swift
+++ b/test/Constraints/tuple_arguments.swift
@@ -1040,7 +1040,7 @@ struct GenericSubscriptLabeled<T> {
 }
 
 struct GenericSubscriptTwo<T> {
-  subscript(_ x: T, _ y: T) -> Int { get { return 0 } set { } } // expected-note {{'subscript' declared here}}
+  subscript(_ x: T, _ y: T) -> Int { get { return 0 } set { } } // expected-note 5 {{'subscript' declared here}}
 }
 
 struct GenericSubscriptLabeledTuple<T> {
@@ -1085,8 +1085,8 @@ do {
 
   let s2 = GenericSubscriptTwo<Double>()
   _ = s2[a, b]
-  _ = s2[(a, b)] // expected-error {{cannot convert value of type '(Double, Double)' to expected argument type '(_, _)'}}
-  _ = s2[d] // expected-error {{cannot convert value of type '(Double, Double)' to expected argument type '(_, _)'}}
+  _ = s2[(a, b)] // expected-error {{missing argument for parameter #2 in call}}
+  _ = s2[d] // expected-error {{missing argument for parameter #2 in call}}
 
   let s3 = GenericSubscriptTuple<Double>()
   _ = s3[a, b] // expected-error {{extra argument in call}}
@@ -1107,8 +1107,8 @@ do {
 
   var s2 = GenericSubscriptTwo<Double>()
   _ = s2[a, b]
-  _ = s2[(a, b)] // expected-error {{cannot convert value of type '(Double, Double)' to expected argument type '(_, _)'}}
-  _ = s2[d] // expected-error {{cannot convert value of type '(Double, Double)' to expected argument type '(_, _)'}}
+  _ = s2[(a, b)] // expected-error {{missing argument for parameter #2 in call}}
+  _ = s2[d] // expected-error {{missing argument for parameter #2 in call}}
 
   var s3 = GenericSubscriptTuple<Double>()
   _ = s3[a, b] // expected-error {{extra argument in call}}


### PR DESCRIPTION
* Description: While diagnosing index expression associated with subscript call
`validateContextualType` didn't look through TupleType to identify
potential nullability of the contextual type related to generic
parameters.

* Scope of the issue: General diagnostic improvements.

* Origination: validateContextualType didn't account for situations when contextual type is a tuple.

* Risk: Low, this is diagnostic improvements.

* Tested: New test cases added.

* Reviewed by: Slava Pestov.

Resolves: rdar://problem/31724211

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
