### PR TITLE
[ClangImporter] Import Swift 3 and 4 names for enumerators.

### DIFF
--- a/lib/ClangImporter/ImportName.h
+++ b/lib/ClangImporter/ImportName.h
@@ -363,9 +363,6 @@ private:
                       ArrayRef<const clang::ParmVarDecl *> params,
                       bool isInitializer, bool hasCustomName);
 
-  /// Whether we should import this as Swift Private
-  bool shouldBeSwiftPrivate(const clang::NamedDecl *, clang::Sema &clangSema);
-
   EffectiveClangContext determineEffectiveContext(const clang::NamedDecl *,
                                                   const clang::DeclContext *,
                                                   ImportNameVersion version);

--- a/lib/ClangImporter/SwiftLookupTable.h
+++ b/lib/ClangImporter/SwiftLookupTable.h
@@ -133,6 +133,20 @@ public:
     assert(getKind() == UnresolvedContext);
     return StringRef(Unresolved.Data, UnresolvedLength);
   }
+
+  /// Compares two EffectiveClangContexts without resolving unresolved names.
+  bool equalsWithoutResolving(const EffectiveClangContext &other) const {
+    if (getKind() != other.getKind())
+      return false;
+    switch (getKind()) {
+    case DeclContext:
+      return DC == other.DC;
+    case TypedefContext:
+      return Typedef == other.Typedef;
+    case UnresolvedContext:
+      return getUnresolvedName() == other.getUnresolvedName();
+    }
+  }
 };
 
 #if LLVM_PTR_SIZE == 4

--- a/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/APINotesFrameworkTest.apinotes
+++ b/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/APINotesFrameworkTest.apinotes
@@ -108,3 +108,15 @@ SwiftVersions:
         SwiftName: ImportantCAlias
       - Name: EnclosingStructIdentifier
         SwiftName: EnclosingStructIdentifier
+    Enumerators:
+      - Name: AnonymousEnumRenamed
+        SwiftName: AnonymousEnumRenamedSwift3
+      - Name: UnknownEnumRenamed
+        SwiftName: UnknownEnumRenamedSwift3
+      - Name: TrueEnumRenamed
+        SwiftName: renamedSwift3
+      - Name: TrueEnumAliasRenamed
+        SwiftName: aliasRenamedSwift3
+      - Name: OptionyEnumRenamed
+        SwiftName: renamedSwift3
+    

--- a/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/APINotesFrameworkTest.h
+++ b/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/APINotesFrameworkTest.h
@@ -22,6 +22,7 @@ __attribute__((objc_root_class))
 #endif // __OBJC__
 
 #import <APINotesFrameworkTest/Classes.h>
+#import <APINotesFrameworkTest/Enums.h>
 #import <APINotesFrameworkTest/ImportAsMember.h>
 #import <APINotesFrameworkTest/Properties.h>
 #import <APINotesFrameworkTest/Protocols.h>

--- a/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/Enums.h
+++ b/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/Enums.h
@@ -1,0 +1,24 @@
+#pragma clang assume_nonnull begin
+
+enum {
+  AnonymousEnumValue,
+  AnonymousEnumRenamed __attribute__((swift_name("AnonymousEnumRenamedSwiftUnversioned")))
+};
+
+enum UnknownEnum {
+  UnknownEnumValue,
+  UnknownEnumRenamed __attribute__((swift_name("UnknownEnumRenamedSwiftUnversioned")))
+};
+
+enum __attribute__((enum_extensibility(open))) TrueEnum {
+  TrueEnumValue,
+  TrueEnumRenamed __attribute__((swift_name("renamedSwiftUnversioned"))),
+  TrueEnumAliasRenamed __attribute__((swift_name("aliasRenamedSwiftUnversioned")))
+};
+
+enum __attribute__((flag_enum)) OptionyEnum {
+  OptionyEnumValue = 1,
+  OptionyEnumRenamed __attribute__((swift_name("renamedSwiftUnversioned"))) = 2
+};
+
+#pragma clang assume_nonnull end

--- a/test/APINotes/versioned.swift
+++ b/test/APINotes/versioned.swift
@@ -89,6 +89,127 @@ func testAKA(structValue: ImportantCStruct, aliasValue: ImportantCAlias) {
   // CHECK-DIAGS-3: versioned.swift:[[@LINE-1]]:16: error: cannot convert value of type 'Optional<ImportantCAlias>' (aka 'Optional<Int32>') to specified type 'Int'
 }
 
+func testRenamedEnumConstants() {
+  _ = AnonymousEnumValue // okay
+
+  // CHECK-DIAGS-4: [[@LINE+1]]:7: error: 'AnonymousEnumRenamed' has been renamed to 'AnonymousEnumRenamedSwiftUnversioned'
+  _ = AnonymousEnumRenamed
+  // CHECK-DIAGS-3: [[@LINE-1]]:7: error: 'AnonymousEnumRenamed' has been renamed to 'AnonymousEnumRenamedSwift3'
+
+  // CHECK-DIAGS-4-NOT: :[[@LINE+1]]:7:
+  _ = AnonymousEnumRenamedSwiftUnversioned
+  // CHECK-DIAGS-3: [[@LINE-1]]:7: error: 'AnonymousEnumRenamedSwiftUnversioned' has been renamed to 'AnonymousEnumRenamedSwift3'
+
+  // CHECK-DIAGS-4: [[@LINE+1]]:7: error: 'AnonymousEnumRenamedSwift3' has been renamed to 'AnonymousEnumRenamedSwiftUnversioned'
+  _ = AnonymousEnumRenamedSwift3
+  // CHECK-DIAGS-3-NOT: :[[@LINE-1]]:7:
+}
+
+func testRenamedUnknownEnum() {
+  _ = UnknownEnumValue // okay
+
+  // CHECK-DIAGS-4: [[@LINE+1]]:7: error: 'UnknownEnumRenamed' has been renamed to 'UnknownEnumRenamedSwiftUnversioned'
+  _ = UnknownEnumRenamed
+  // CHECK-DIAGS-3: [[@LINE-1]]:7: error: 'UnknownEnumRenamed' has been renamed to 'UnknownEnumRenamedSwift3'
+
+  // CHECK-DIAGS-4-NOT: :[[@LINE+1]]:7:
+  _ = UnknownEnumRenamedSwiftUnversioned
+  // CHECK-DIAGS-3: [[@LINE-1]]:7: error: 'UnknownEnumRenamedSwiftUnversioned' has been renamed to 'UnknownEnumRenamedSwift3'
+
+  // CHECK-DIAGS-4: [[@LINE+1]]:7: error: 'UnknownEnumRenamedSwift3' has been renamed to 'UnknownEnumRenamedSwiftUnversioned'
+  _ = UnknownEnumRenamedSwift3
+  // CHECK-DIAGS-3-NOT: :[[@LINE-1]]:7:
+}
+
+func testRenamedTrueEnum() {
+  // CHECK-DIAGS: [[@LINE+1]]:7: error: use of unresolved identifier 'TrueEnumValue'
+  _ = TrueEnumValue
+
+  // CHECK-DIAGS: [[@LINE+1]]:7: error: type 'TrueEnum' has no member 'TrueEnumValue'
+  _ = TrueEnum.TrueEnumValue
+
+  // CHECK-DIAGS: [[@LINE+1]]:16: error: 'Value' has been renamed to 'value'
+  _ = TrueEnum.Value
+
+  _ = TrueEnum.value // okay
+
+  // CHECK-DIAGS: [[@LINE+1]]:7: error: use of unresolved identifier 'TrueEnumRenamed'
+  _ = TrueEnumRenamed
+
+  // CHECK-DIAGS: [[@LINE+1]]:7: error: type 'TrueEnum' has no member 'TrueEnumRenamed'
+  _ = TrueEnum.TrueEnumRenamed
+
+  // CHECK-DIAGS-4: [[@LINE+1]]:16: error: 'Renamed' has been renamed to 'renamedSwiftUnversioned'
+  _ = TrueEnum.Renamed
+  // CHECK-DIAGS-3: [[@LINE-1]]:16: error: 'Renamed' has been renamed to 'renamedSwift3'
+
+  // CHECK-DIAGS: [[@LINE+1]]:7: error: type 'TrueEnum' has no member 'renamed'
+  _ = TrueEnum.renamed
+
+  // CHECK-DIAGS-4-NOT: :[[@LINE+1]]:16:
+  _ = TrueEnum.renamedSwiftUnversioned
+  // CHECK-DIAGS-3: [[@LINE-1]]:16: error: 'renamedSwiftUnversioned' has been renamed to 'renamedSwift3'
+
+  // CHECK-DIAGS-4: [[@LINE+1]]:16: error: 'renamedSwift3' has been renamed to 'renamedSwiftUnversioned'
+  _ = TrueEnum.renamedSwift3
+  // CHECK-DIAGS-3-NOT: :[[@LINE-1]]:16:
+
+  // CHECK-DIAGS: [[@LINE+1]]:7: error: use of unresolved identifier 'TrueEnumAliasRenamed'
+  _ = TrueEnumAliasRenamed
+
+  // CHECK-DIAGS: [[@LINE+1]]:7: error: type 'TrueEnum' has no member 'TrueEnumAliasRenamed'
+  _ = TrueEnum.TrueEnumAliasRenamed
+
+  // CHECK-DIAGS-4: [[@LINE+1]]:16: error: 'AliasRenamed' has been renamed to 'aliasRenamedSwiftUnversioned'
+  _ = TrueEnum.AliasRenamed
+  // CHECK-DIAGS-3: [[@LINE-1]]:16: error: 'AliasRenamed' has been renamed to 'aliasRenamedSwift3'
+
+  // CHECK-DIAGS: [[@LINE+1]]:7: error: type 'TrueEnum' has no member 'aliasRenamed'
+  _ = TrueEnum.aliasRenamed
+
+  // CHECK-DIAGS-4-NOT: :[[@LINE+1]]:16:
+  _ = TrueEnum.aliasRenamedSwiftUnversioned
+  // CHECK-DIAGS-3: [[@LINE-1]]:16: error: 'aliasRenamedSwiftUnversioned' has been renamed to 'aliasRenamedSwift3'
+
+  // CHECK-DIAGS-4: [[@LINE+1]]:16: error: 'aliasRenamedSwift3' has been renamed to 'aliasRenamedSwiftUnversioned'
+  _ = TrueEnum.aliasRenamedSwift3
+  // CHECK-DIAGS-3-NOT: :[[@LINE-1]]:16:
+}
+
+func testRenamedOptionyEnum() {
+  // CHECK-DIAGS: [[@LINE+1]]:7: error: use of unresolved identifier 'OptionyEnumValue'
+  _ = OptionyEnumValue
+
+  // CHECK-DIAGS: [[@LINE+1]]:7: error: type 'OptionyEnum' has no member 'OptionyEnumValue'
+  _ = OptionyEnum.OptionyEnumValue
+
+  // CHECK-DIAGS: [[@LINE+1]]:19: error: 'Value' has been renamed to 'value'
+  _ = OptionyEnum.Value
+
+  _ = OptionyEnum.value // okay
+
+  // CHECK-DIAGS: [[@LINE+1]]:7: error: use of unresolved identifier 'OptionyEnumRenamed'
+  _ = OptionyEnumRenamed
+
+  // CHECK-DIAGS: [[@LINE+1]]:7: error: type 'OptionyEnum' has no member 'OptionyEnumRenamed'
+  _ = OptionyEnum.OptionyEnumRenamed
+
+  // CHECK-DIAGS-4: [[@LINE+1]]:19: error: 'Renamed' has been renamed to 'renamedSwiftUnversioned'
+  _ = OptionyEnum.Renamed
+  // CHECK-DIAGS-3: [[@LINE-1]]:19: error: 'Renamed' has been renamed to 'renamedSwift3'
+
+  // CHECK-DIAGS: [[@LINE+1]]:7: error: type 'OptionyEnum' has no member 'renamed'
+  _ = OptionyEnum.renamed
+
+  // CHECK-DIAGS-4-NOT: :[[@LINE+1]]:19:
+  _ = OptionyEnum.renamedSwiftUnversioned
+  // CHECK-DIAGS-3: [[@LINE-1]]:19: error: 'renamedSwiftUnversioned' has been renamed to 'renamedSwift3'
+
+  // CHECK-DIAGS-4: [[@LINE+1]]:19: error: 'renamedSwift3' has been renamed to 'renamedSwiftUnversioned'
+  _ = OptionyEnum.renamedSwift3
+  // CHECK-DIAGS-3-NOT: :[[@LINE-1]]:19:
+}
+
 #endif
 
 #if !swift(>=4)


### PR DESCRIPTION
Also lays the groundwork for rdar://problem/16513537, which is about being able to find an enum by its original top-level name so that we can show a diagnostic for that. I'll file a public bug about that later.

rdar://problem/31893305