### PR TITLE
[4.0] Fix a bug related to handling of self-recursive apply and partial_apply instructions by TypeSubstCloner and generic specializer

### DIFF
--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -316,11 +316,10 @@ public:
         &F, OpenedArchetypes));
   }
 
-  ApplyInst *createApply(SILLocation Loc, SILValue Fn, SILType SubstFnTy,
-                         SILType Result, SubstitutionList Subs,
+  ApplyInst *createApply(SILLocation Loc, SILValue Fn, SubstitutionList Subs,
                          ArrayRef<SILValue> Args, bool isNonThrowing) {
-    return insert(ApplyInst::create(getSILDebugLocation(Loc), Fn, SubstFnTy,
-                                    Result, Subs, Args, isNonThrowing, F,
+    return insert(ApplyInst::create(getSILDebugLocation(Loc), Fn,
+                                    Subs, Args, isNonThrowing, F,
                                     OpenedArchetypes));
   }
 
@@ -328,27 +327,25 @@ public:
                          bool isNonThrowing) {
     SILFunctionConventions conventions(Fn->getType().castTo<SILFunctionType>(),
                                        getModule());
-    return createApply(Loc, Fn, Fn->getType(), conventions.getSILResultType(),
-                       SubstitutionList(), Args, isNonThrowing);
+    return createApply(Loc, Fn, SubstitutionList(), Args, isNonThrowing);
   }
 
-  TryApplyInst *createTryApply(SILLocation Loc, SILValue fn, SILType substFnTy,
-                               SubstitutionList subs,
-                               ArrayRef<SILValue> args, SILBasicBlock *normalBB,
+  TryApplyInst *createTryApply(SILLocation Loc, SILValue fn,
+                               SubstitutionList subs, ArrayRef<SILValue> args,
+                               SILBasicBlock *normalBB,
                                SILBasicBlock *errorBB) {
     return insertTerminator(TryApplyInst::create(getSILDebugLocation(Loc),
-                                                 fn, substFnTy, subs, args,
+                                                 fn, subs, args,
                                                  normalBB, errorBB, F,
                                                  OpenedArchetypes));
   }
 
   PartialApplyInst *createPartialApply(SILLocation Loc, SILValue Fn,
-                                       SILType SubstFnTy,
                                        SubstitutionList Subs,
                                        ArrayRef<SILValue> Args,
-                                       SILType ClosureTy) {
+                                       ParameterConvention CalleeConvention) {
     return insert(PartialApplyInst::create(getSILDebugLocation(Loc), Fn,
-                                           SubstFnTy, Subs, Args, ClosureTy, F,
+                                           Args, Subs, CalleeConvention, F,
                                            OpenedArchetypes));
   }
 

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -316,10 +316,14 @@ public:
         &F, OpenedArchetypes));
   }
 
-  ApplyInst *createApply(SILLocation Loc, SILValue Fn, SubstitutionList Subs,
-                         ArrayRef<SILValue> Args, bool isNonThrowing) {
+  ApplyInst *
+  createApply(SILLocation Loc, SILValue Fn, SubstitutionList Subs,
+              ArrayRef<SILValue> Args, bool isNonThrowing,
+              Optional<SILModuleConventions> ModuleConventions = None) {
     return insert(ApplyInst::create(getSILDebugLocation(Loc), Fn,
-                                    Subs, Args, isNonThrowing, F,
+                                    Subs, Args, isNonThrowing,
+                                    ModuleConventions,
+                                    F,
                                     OpenedArchetypes));
   }
 

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -572,8 +572,6 @@ SILCloner<ImplClass>::visitApplyInst(ApplyInst *Inst) {
   doPostProcess(Inst,
     getBuilder().createApply(getOpLocation(Inst->getLoc()),
                              getOpValue(Inst->getCallee()),
-                             getOpType(Inst->getSubstCalleeSILType()),
-                             getOpType(Inst->getType()),
                              getOpSubstitutions(Inst->getSubstitutions()),
                              Args,
                              Inst->isNonThrowing()));
@@ -587,7 +585,6 @@ SILCloner<ImplClass>::visitTryApplyInst(TryApplyInst *Inst) {
   doPostProcess(Inst,
     getBuilder().createTryApply(getOpLocation(Inst->getLoc()),
                                 getOpValue(Inst->getCallee()),
-                                getOpType(Inst->getSubstCalleeSILType()),
                                 getOpSubstitutions(Inst->getSubstitutions()),
                                 Args,
                                 getOpBasicBlock(Inst->getNormalBB()),
@@ -600,12 +597,14 @@ SILCloner<ImplClass>::visitPartialApplyInst(PartialApplyInst *Inst) {
   auto Args = getOpValueArray<8>(Inst->getArguments());
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
   doPostProcess(Inst,
-    getBuilder().createPartialApply(getOpLocation(Inst->getLoc()),
-                                    getOpValue(Inst->getCallee()),
-                                    getOpType(Inst->getSubstCalleeSILType()),
-                                    getOpSubstitutions(Inst->getSubstitutions()),
-                                    Args,
-                                    getOpType(Inst->getType())));
+                getBuilder().createPartialApply(
+                    getOpLocation(Inst->getLoc()),
+                    getOpValue(Inst->getCallee()),
+                    getOpSubstitutions(Inst->getSubstitutions()), Args,
+                    Inst->getType()
+                        .getSwiftRValueType()
+                        ->getAs<SILFunctionType>()
+                        ->getCalleeConvention()));
 }
 
 template<typename ImplClass>

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -1300,6 +1300,7 @@ class ApplyInst : public ApplyInstBase<ApplyInst, SILInstruction> {
   static ApplyInst *create(SILDebugLocation DebugLoc, SILValue Callee,
                            SubstitutionList Substitutions,
                            ArrayRef<SILValue> Args, bool isNonThrowing,
+                           Optional<SILModuleConventions> ModuleConventions,
                            SILFunction &F,
                            SILOpenedArchetypesState &OpenedArchetypes);
 

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -1298,7 +1298,6 @@ class ApplyInst : public ApplyInstBase<ApplyInst, SILInstruction> {
             bool isNonThrowing);
 
   static ApplyInst *create(SILDebugLocation DebugLoc, SILValue Callee,
-                           SILType SubstCalleeType, SILType ReturnType,
                            SubstitutionList Substitutions,
                            ArrayRef<SILValue> Args, bool isNonThrowing,
                            SILFunction &F,
@@ -1330,9 +1329,9 @@ class PartialApplyInst
                    SILType ClosureType);
 
   static PartialApplyInst *create(SILDebugLocation DebugLoc, SILValue Callee,
-                                  SILType SubstCalleeType,
+                                  ArrayRef<SILValue> Args,
                                   SubstitutionList Substitutions,
-                                  ArrayRef<SILValue> Args, SILType ClosureType,
+                                  ParameterConvention CalleeConvention,
                                   SILFunction &F,
                                   SILOpenedArchetypesState &OpenedArchetypes);
 
@@ -6236,7 +6235,6 @@ class TryApplyInst
                SILBasicBlock *normalBB, SILBasicBlock *errorBB);
 
   static TryApplyInst *create(SILDebugLocation DebugLoc, SILValue callee,
-                              SILType substCalleeType,
                               SubstitutionList substitutions,
                               ArrayRef<SILValue> args, SILBasicBlock *normalBB,
                               SILBasicBlock *errorBB, SILFunction &F,

--- a/include/swift/SIL/TypeSubstCloner.h
+++ b/include/swift/SIL/TypeSubstCloner.h
@@ -47,6 +47,86 @@ class TypeSubstCloner : public SILClonerWithScopes<ImplClass> {
     }
   }
 
+  // A helper class for cloning different kinds of apply instructions.
+  // Supports cloning of self-recursive functions.
+  class ApplySiteCloningHelper {
+    SILValue Callee;
+    SubstitutionList Subs;
+    SmallVector<SILValue, 8> Args;
+    SmallVector<Substitution, 8> NewSubsList;
+    SmallVector<Substitution, 8> RecursiveSubsList;
+
+  public:
+    ApplySiteCloningHelper(ApplySite AI, TypeSubstCloner &Cloner)
+        : Callee(Cloner.getOpValue(AI.getCallee())) {
+      SILType SubstCalleeSILType = Cloner.getOpType(AI.getSubstCalleeSILType());
+
+      Args = Cloner.template getOpValueArray<8>(AI.getArguments());
+      SILBuilder &Builder = Cloner.getBuilder();
+      Builder.setCurrentDebugScope(Cloner.super::getOpScope(AI.getDebugScope()));
+
+      // Remap substitutions.
+      NewSubsList = Cloner.getOpSubstitutions(AI.getSubstitutions());
+      Subs = NewSubsList;
+
+      if (!Cloner.Inlining) {
+        FunctionRefInst *FRI = dyn_cast<FunctionRefInst>(AI.getCallee());
+        if (FRI && FRI->getReferencedFunction() == AI.getFunction() &&
+            Subs == Cloner.ApplySubs) {
+          // Handle recursions by replacing the apply to the callee with an
+          // apply to the newly specialized function, but only if substitutions
+          // are the same.
+          auto LoweredFnTy = Builder.getFunction().getLoweredFunctionType();
+          auto RecursiveSubstCalleeSILType = LoweredFnTy;
+          auto GenSig = LoweredFnTy->getGenericSignature();
+          if (GenSig) {
+            // Compute substitutions for the specialized function. These
+            // substitutions may be different from the original ones, e.g.
+            // there can be less substitutions.
+            GenSig->getSubstitutions(AI.getFunction()
+                                         ->getLoweredFunctionType()
+                                         ->getGenericSignature()
+                                         ->getSubstitutionMap(Subs),
+                                     RecursiveSubsList);
+            // Use the new set of substitutions to compute the new
+            // substituted callee type.
+            RecursiveSubstCalleeSILType = LoweredFnTy->substGenericArgs(
+                AI.getModule(), RecursiveSubsList);
+          }
+
+          // The specialized recursive function may have different calling
+          // convention for parameters. E.g. some of former indirect parameters
+          // may become direct. Some of indirect return values may become
+          // direct. Do not replace the callee in that case.
+          if (SubstCalleeSILType.getSwiftRValueType() ==
+              RecursiveSubstCalleeSILType) {
+            Subs = RecursiveSubsList;
+            Callee = Builder.createFunctionRef(
+                Cloner.getOpLocation(AI.getLoc()), &Builder.getFunction());
+            SubstCalleeSILType =
+                SILType::getPrimitiveObjectType(RecursiveSubstCalleeSILType);
+          }
+        }
+      }
+
+      assert(Subs.empty() ||
+             SubstCalleeSILType ==
+                 Callee->getType().substGenericArgs(AI.getModule(), Subs));
+    }
+
+    ArrayRef<SILValue> getArguments() const {
+      return Args;
+    }
+
+    SILValue getCallee() const {
+      return Callee;
+    }
+
+    SubstitutionList getSubstitutions() const {
+      return Subs;
+    }
+  };
+
 public:
   using SILClonerWithScopes<ImplClass>::asImpl;
   using SILClonerWithScopes<ImplClass>::getBuilder;
@@ -105,79 +185,32 @@ protected:
   }
 
   void visitApplyInst(ApplyInst *Inst) {
-    auto Args = this->template getOpValueArray<8>(Inst->getArguments());
+    ApplySiteCloningHelper Helper(ApplySite::isa(Inst), *this);
+    ApplyInst *N =
+        getBuilder().createApply(getOpLocation(Inst->getLoc()),
+                                 Helper.getCallee(), Helper.getSubstitutions(),
+                                 Helper.getArguments(), Inst->isNonThrowing());
+    doPostProcess(Inst, N);
+  }
 
-    // Handle recursions by replacing the apply to the callee with an apply to
-    // the newly specialized function, but only if substitutions are the same.
-    SILBuilder &Builder = getBuilder();
-    Builder.setCurrentDebugScope(super::getOpScope(Inst->getDebugScope()));
-    SILValue CalleeVal = Inst->getCallee();
-    if (!Inlining) {
-      FunctionRefInst *FRI = dyn_cast<FunctionRefInst>(CalleeVal);
-      if (FRI && FRI->getReferencedFunction() == Inst->getFunction() &&
-          Inst->getSubstitutions() == this->ApplySubs) {
-        FRI = Builder.createFunctionRef(getOpLocation(Inst->getLoc()),
-                                        &Builder.getFunction());
-        ApplyInst *NAI =
-          Builder.createApply(getOpLocation(Inst->getLoc()), FRI, Args, Inst->isNonThrowing());
-        doPostProcess(Inst, NAI);
-        return;
-      }
-    }
-
-    SmallVector<Substitution, 16> TempSubstList;
-    for (auto &Sub : Inst->getSubstitutions()) {
-      TempSubstList.push_back(asImpl().getOpSubstitution(Sub));
-    }
-
-    ApplyInst *N = Builder.createApply(
-      getOpLocation(Inst->getLoc()), getOpValue(CalleeVal),
-        TempSubstList, Args, Inst->isNonThrowing());
+  void visitTryApplyInst(TryApplyInst *Inst) {
+    ApplySiteCloningHelper Helper(ApplySite::isa(Inst), *this);
+    TryApplyInst *N = getBuilder().createTryApply(
+        getOpLocation(Inst->getLoc()), Helper.getCallee(),
+        Helper.getSubstitutions(), Helper.getArguments(),
+        getOpBasicBlock(Inst->getNormalBB()),
+        getOpBasicBlock(Inst->getErrorBB()));
     doPostProcess(Inst, N);
   }
 
   void visitPartialApplyInst(PartialApplyInst *Inst) {
-    auto Args = this->template getOpValueArray<8>(Inst->getArguments());
-
-    // Handle recursions by replacing the apply to the callee with an apply to
-    // the newly specialized function.
-    SILValue CalleeVal = Inst->getCallee();
-    SILBuilderWithPostProcess<TypeSubstCloner, 4> Builder(this, Inst);
-    Builder.setCurrentDebugScope(super::getOpScope(Inst->getDebugScope()));
-    SmallVector<Substitution, 16> TempSubstList;
-    if (!Inlining) {
-      FunctionRefInst *FRI = dyn_cast<FunctionRefInst>(CalleeVal);
-      if (FRI && FRI->getReferencedFunction() == Inst->getFunction()) {
-        auto LoweredFnTy = Builder.getFunction().getLoweredFunctionType();
-        auto GenSig = LoweredFnTy->getGenericSignature();
-        if (GenSig) {
-          GenSig->getSubstitutions(
-              Inst->getFunction()
-                  ->getLoweredFunctionType()
-                  ->getGenericSignature()
-                  ->getSubstitutionMap(Inst->getSubstitutions()),
-              TempSubstList);
-        }
-        for (auto &Sub : TempSubstList) {
-          Sub = asImpl().getOpSubstitution(Sub);
-        }
-        SubstitutionList Subs = TempSubstList;
-        FRI = Builder.createFunctionRef(getOpLocation(Inst->getLoc()),
-                                        &Builder.getFunction());
-        Builder.createPartialApply(
-            getOpLocation(Inst->getLoc()), FRI, Subs, Args,
-            Inst->getType().getAs<SILFunctionType>()->getCalleeConvention());
-        return;
-      }
-    }
-
-    for (auto &Sub : Inst->getSubstitutions()) {
-      TempSubstList.push_back(asImpl().getOpSubstitution(Sub));
-    }
-
-    Builder.createPartialApply(
-        getOpLocation(Inst->getLoc()), getOpValue(CalleeVal), TempSubstList,
-        Args, Inst->getType().getAs<SILFunctionType>()->getCalleeConvention());
+    ApplySiteCloningHelper Helper(ApplySite::isa(Inst), *this);
+    auto ParamConvention =
+        Inst->getType().getAs<SILFunctionType>()->getCalleeConvention();
+    PartialApplyInst *N = getBuilder().createPartialApply(
+        getOpLocation(Inst->getLoc()), Helper.getCallee(),
+        Helper.getSubstitutions(), Helper.getArguments(), ParamConvention);
+    doPostProcess(Inst, N);
   }
 
   /// Attempt to simplify a conditional checked cast.

--- a/include/swift/SIL/TypeSubstCloner.h
+++ b/include/swift/SIL/TypeSubstCloner.h
@@ -132,7 +132,6 @@ protected:
 
     ApplyInst *N = Builder.createApply(
       getOpLocation(Inst->getLoc()), getOpValue(CalleeVal),
-        getOpType(Inst->getSubstCalleeSILType()), getOpType(Inst->getType()),
         TempSubstList, Args, Inst->isNonThrowing());
     doPostProcess(Inst, N);
   }
@@ -165,11 +164,9 @@ protected:
         SubstitutionList Subs = TempSubstList;
         FRI = Builder.createFunctionRef(getOpLocation(Inst->getLoc()),
                                         &Builder.getFunction());
-        Builder.createPartialApply(getOpLocation(Inst->getLoc()), FRI,
-                                   getOpType(Inst->getSubstCalleeSILType()),
-                                   Subs,
-                                   Args,
-                                   getOpType(Inst->getType()));
+        Builder.createPartialApply(
+            getOpLocation(Inst->getLoc()), FRI, Subs, Args,
+            Inst->getType().getAs<SILFunctionType>()->getCalleeConvention());
         return;
       }
     }
@@ -179,9 +176,8 @@ protected:
     }
 
     Builder.createPartialApply(
-      getOpLocation(Inst->getLoc()), getOpValue(CalleeVal),
-        getOpType(Inst->getSubstCalleeSILType()), TempSubstList, Args,
-        getOpType(Inst->getType()));
+        getOpLocation(Inst->getLoc()), getOpValue(CalleeVal), TempSubstList,
+        Args, Inst->getType().getAs<SILFunctionType>()->getCalleeConvention());
   }
 
   /// Attempt to simplify a conditional checked cast.

--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -1815,8 +1815,7 @@ void LoadableByAddress::recreateSingleApply(SILInstruction *applyInst) {
   case ValueKind::ApplyInst: {
     ApplyInst *castedApply = dyn_cast<ApplyInst>(applyInst);
     assert(castedApply && "ValueKind is ApplyInst but cast to it failed");
-    newApply = applyBuilder.createApply(castedApply->getLoc(), callee,
-                                        newSubType, resultType, newSubs,
+    newApply = applyBuilder.createApply(castedApply->getLoc(), callee, newSubs,
                                         callArgs, castedApply->isNonThrowing());
     applyInst->replaceAllUsesWith(newApply);
     break;
@@ -1825,7 +1824,7 @@ void LoadableByAddress::recreateSingleApply(SILInstruction *applyInst) {
     TryApplyInst *castedApply = dyn_cast<TryApplyInst>(applyInst);
     assert(castedApply && "ValueKind is TryApplyInst but cast to it failed");
     newApply = applyBuilder.createTryApply(
-        castedApply->getLoc(), callee, newSubType, newSubs, callArgs,
+        castedApply->getLoc(), callee, newSubs, callArgs,
         castedApply->getNormalBB(), castedApply->getErrorBB());
     applyInst->replaceAllUsesWith(newApply);
     break;
@@ -1839,10 +1838,14 @@ void LoadableByAddress::recreateSingleApply(SILInstruction *applyInst) {
         castedApply->getType().castTo<SILFunctionType>();
     SILType newSILType =
         getNewSILFunctionType(genEnv, origClosureType, *currIRMod);
+    auto partialApplyConvention = castedApply->getType()
+                                      .getSwiftRValueType()
+                                      ->getAs<SILFunctionType>()
+                                      ->getCalleeConvention();
 
     newApply = applyBuilder.createPartialApply(castedApply->getLoc(), callee,
-                                               newSubType, newSubs, callArgs,
-                                               newSILType);
+                                               newSubs, callArgs,
+                                               partialApplyConvention);
     applyInst->replaceAllUsesWith(newApply);
     break;
   }

--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -1782,13 +1782,9 @@ void LoadableByAddress::recreateSingleApply(SILInstruction *applyInst) {
   }
   SILFunctionType *newSILFunctionType =
       getNewSILFunctionTypePtr(genEnv, origSILFunctionType, *currIRMod);
-  SILType newSubType =
-      getNewSILFunctionType(genEnv, origSILFunctionType, *currIRMod);
   CanSILFunctionType newCanSILFuncType(newSILFunctionType);
   SILFunctionConventions newSILFunctionConventions(newCanSILFuncType,
                                                    *getModule());
-  SILType resultType = newSILFunctionConventions.getSILResultType();
-
   SmallVector<Substitution, 4> newSubs;
   for (Substitution sub : applySite.getSubstitutions()) {
     Type origType = sub.getReplacement();
@@ -1836,8 +1832,6 @@ void LoadableByAddress::recreateSingleApply(SILInstruction *applyInst) {
     // Change the type of the Closure
     SILFunctionType *origClosureType =
         castedApply->getType().castTo<SILFunctionType>();
-    SILType newSILType =
-        getNewSILFunctionType(genEnv, origClosureType, *currIRMod);
     auto partialApplyConvention = castedApply->getType()
                                       .getSwiftRValueType()
                                       ->getAs<SILFunctionType>()

--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -1830,8 +1830,6 @@ void LoadableByAddress::recreateSingleApply(SILInstruction *applyInst) {
     assert(castedApply &&
            "ValueKind is PartialApplyInst but cast to it failed");
     // Change the type of the Closure
-    SILFunctionType *origClosureType =
-        castedApply->getType().castTo<SILFunctionType>();
     auto partialApplyConvention = castedApply->getType()
                                       .getSwiftRValueType()
                                       ->getAs<SILFunctionType>()

--- a/lib/Parse/ParseSIL.cpp
+++ b/lib/Parse/ParseSIL.cpp
@@ -4497,9 +4497,7 @@ bool SILParser::parseCallInstruction(SILLocation InstLoc,
       Args.push_back(getLocalValue(ArgName, expectedTy, InstLoc, B));
     }
 
-    ResultVal =
-        B.createApply(InstLoc, FnVal, FnTy, substConv.getSILResultType(), subs,
-                      Args, IsNonThrowingApply);
+    ResultVal = B.createApply(InstLoc, FnVal, subs, Args, IsNonThrowingApply);
     break;
   }
   case ValueKind::PartialApplyInst: {
@@ -4524,8 +4522,8 @@ bool SILParser::parseCallInstruction(SILLocation InstLoc,
       SILBuilder::getPartialApplyResultType(Ty, ArgNames.size(), SILMod, subs,
                                             PartialApplyConvention);
     // FIXME: Why the arbitrary order difference in IRBuilder type argument?
-    ResultVal = B.createPartialApply(InstLoc, FnVal, FnTy,
-                                     subs, Args, closureTy);
+    ResultVal = B.createPartialApply(InstLoc, FnVal, subs, Args,
+                                     PartialApplyConvention);
     break;
   }
   case ValueKind::TryApplyInst: {
@@ -4557,8 +4555,7 @@ bool SILParser::parseCallInstruction(SILLocation InstLoc,
 
     SILBasicBlock *normalBB = getBBForReference(normalBBName, normalBBLoc);
     SILBasicBlock *errorBB = getBBForReference(errorBBName, errorBBLoc);
-    ResultVal = B.createTryApply(InstLoc, FnVal, FnTy,
-                                 subs, args, normalBB, errorBB);
+    ResultVal = B.createTryApply(InstLoc, FnVal, subs, args, normalBB, errorBB);
     break;
   }
   }

--- a/lib/Parse/ParseSIL.cpp
+++ b/lib/Parse/ParseSIL.cpp
@@ -4518,9 +4518,6 @@ bool SILParser::parseCallInstruction(SILLocation InstLoc,
       Args.push_back(getLocalValue(ArgName, expectedTy, InstLoc, B));
     }
 
-    SILType closureTy =
-      SILBuilder::getPartialApplyResultType(Ty, ArgNames.size(), SILMod, subs,
-                                            PartialApplyConvention);
     // FIXME: Why the arbitrary order difference in IRBuilder type argument?
     ResultVal = B.createPartialApply(InstLoc, FnVal, subs, Args,
                                      PartialApplyConvention);

--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -108,7 +108,7 @@ ApplyInst *SILGenBuilder::createApply(SILLocation loc, SILValue fn,
                                       SubstitutionList subs,
                                       ArrayRef<SILValue> args) {
   getSILGenModule().useConformancesFromSubstitutions(subs);
-  return SILBuilder::createApply(loc, fn, substFnTy, result, subs, args, false);
+  return SILBuilder::createApply(loc, fn, subs, args, false);
 }
 
 TryApplyInst *
@@ -116,8 +116,7 @@ SILGenBuilder::createTryApply(SILLocation loc, SILValue fn, SILType substFnTy,
                               SubstitutionList subs, ArrayRef<SILValue> args,
                               SILBasicBlock *normalBB, SILBasicBlock *errorBB) {
   getSILGenModule().useConformancesFromSubstitutions(subs);
-  return SILBuilder::createTryApply(loc, fn, substFnTy, subs, args, normalBB,
-                                    errorBB);
+  return SILBuilder::createTryApply(loc, fn, subs, args, normalBB, errorBB);
 }
 
 PartialApplyInst *
@@ -125,8 +124,9 @@ SILGenBuilder::createPartialApply(SILLocation loc, SILValue fn,
                                   SILType substFnTy, SubstitutionList subs,
                                   ArrayRef<SILValue> args, SILType closureTy) {
   getSILGenModule().useConformancesFromSubstitutions(subs);
-  return SILBuilder::createPartialApply(loc, fn, substFnTy, subs, args,
-                                        closureTy);
+  return SILBuilder::createPartialApply(
+      loc, fn, subs, args,
+      closureTy.getAs<SILFunctionType>()->getCalleeConvention());
 }
 
 BuiltinInst *SILGenBuilder::createBuiltin(SILLocation loc, Identifier name,

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -1077,7 +1077,6 @@ namespace {
 
         auto substCallbackFnType = origCallbackFnType->substGenericArgs(
             M, substitutions);
-        auto substCallbackType = SILType::getPrimitiveObjectType(substCallbackFnType);
         auto metatypeType =
             SGF.getSILType(substCallbackFnType->getParameters().back());
 

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -1119,8 +1119,8 @@ namespace {
                                        rawPointerTy);
 
         // Apply the callback.
-        SGF.B.createApply(loc, callback, substCallbackType,
-                          emptyTupleTy, substitutions, {
+        SGF.B.createApply(loc, callback,
+                          substitutions, {
                             temporaryPointer,
                             materialized.callbackStorage,
                             baseAddress,

--- a/lib/SILOptimizer/Analysis/ArraySemantic.cpp
+++ b/lib/SILOptimizer/Analysis/ArraySemantic.cpp
@@ -715,7 +715,6 @@ bool swift::ArraySemanticsCall::replaceByAppendingValues(
   SILBuilderWithScope Builder(SemanticsCall);
   auto Loc = SemanticsCall->getLoc();
   auto *FnRef = Builder.createFunctionRef(Loc, AppendFn);
-  auto FnTy = FnRef->getType();
 
   if (Vals.size() > 1) {
     // Create a call to reserveCapacityForAppend() to reserve space for multiple

--- a/lib/SILOptimizer/Analysis/ArraySemantic.cpp
+++ b/lib/SILOptimizer/Analysis/ArraySemantic.cpp
@@ -734,10 +734,7 @@ bool swift::ArraySemanticsCall::replaceByAppendingValues(
       Builder.createIntegerLiteral(Loc, BuiltinIntTy, Vals.size());
     StructInst *Capacity = Builder.createStruct(Loc,
         SILType::getPrimitiveObjectType(CanType(IntType)), {CapacityLiteral});
-    Builder.createApply(Loc, ReserveFnRef,
-                        ReserveFnRef->getType().substGenericArgs(M, Subs),
-                        ReserveFnTy->getAllResultsType(), Subs,
-                        {Capacity, ArrRef}, false);
+    Builder.createApply(Loc, ReserveFnRef, Subs, {Capacity, ArrRef}, false);
   }
 
   for (SILValue V : Vals) {
@@ -750,9 +747,7 @@ bool swift::ArraySemanticsCall::replaceByAppendingValues(
                                 IsInitialization_t::IsInitialization);
 
     SILValue Args[] = {AllocStackInst, ArrRef};
-    Builder.createApply(Loc, FnRef, FnTy.substGenericArgs(M, Subs),
-                        FnTy.castTo<SILFunctionType>()->getAllResultsType(), Subs,
-                        Args, false);
+    Builder.createApply(Loc, FnRef, Subs, Args, false);
     Builder.createDeallocStack(Loc, AllocStackInst);
     if (!isConsumedParameter(AppendFnTy->getParameters()[0].getConvention())) {
       ValLowering.emitDestroyValue(Builder, Loc, CopiedVal);

--- a/lib/SILOptimizer/IPO/CapturePromotion.cpp
+++ b/lib/SILOptimizer/IPO/CapturePromotion.cpp
@@ -1240,9 +1240,9 @@ processPartialApplyInst(PartialApplyInst *PAI, IndicesSet &PromotableIndices,
   auto SubstFnTy = FnTy.substGenericArgs(M, PAI->getSubstitutions());
 
   // Create a new partial apply with the new arguments.
-  auto *NewPAI = B.createPartialApply(PAI->getLoc(), FnVal, SubstFnTy,
-                                      PAI->getSubstitutions(), Args,
-                                      PAI->getType());
+  auto *NewPAI = B.createPartialApply(
+      PAI->getLoc(), FnVal, PAI->getSubstitutions(), Args,
+      PAI->getType().getAs<SILFunctionType>()->getCalleeConvention());
   PAI->replaceAllUsesWith(NewPAI);
   PAI->eraseFromParent();
   if (FRI->use_empty()) {

--- a/lib/SILOptimizer/IPO/CapturePromotion.cpp
+++ b/lib/SILOptimizer/IPO/CapturePromotion.cpp
@@ -1237,8 +1237,6 @@ processPartialApplyInst(PartialApplyInst *PAI, IndicesSet &PromotableIndices,
     ++NumCapturesPromoted;
   }
 
-  auto SubstFnTy = FnTy.substGenericArgs(M, PAI->getSubstitutions());
-
   // Create a new partial apply with the new arguments.
   auto *NewPAI = B.createPartialApply(
       PAI->getLoc(), FnVal, PAI->getSubstitutions(), Args,

--- a/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
@@ -351,7 +351,6 @@ static void rewriteApplyInst(const CallSiteDescriptor &CSDesc,
     }
   }
 
-  auto loweredConv = NewF->getConventions();
   Builder.setInsertionPoint(AI.getInstruction());
   FullApplySite NewAI;
   if (auto *TAI = dyn_cast<TryApplyInst>(AI)) {

--- a/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
@@ -351,9 +351,7 @@ static void rewriteApplyInst(const CallSiteDescriptor &CSDesc,
     }
   }
 
-  SILType LoweredType = NewF->getLoweredType();
   auto loweredConv = NewF->getConventions();
-  SILType ResultType = loweredConv.getSILResultType();
   Builder.setInsertionPoint(AI.getInstruction());
   FullApplySite NewAI;
   if (auto *TAI = dyn_cast<TryApplyInst>(AI)) {

--- a/lib/SILOptimizer/IPO/EagerSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/EagerSpecializer.cpp
@@ -163,13 +163,7 @@ emitApplyWithRethrow(SILBuilder &Builder,
   SILBasicBlock *ErrorBB = F.createBasicBlock();
   SILBasicBlock *NormalBB = F.createBasicBlock();
 
-  Builder.createTryApply(Loc,
-                         FuncRef,
-                         SILType::getPrimitiveObjectType(CanSILFuncTy),
-                         Subs,
-                         CallArgs,
-                         NormalBB,
-                         ErrorBB);
+  Builder.createTryApply(Loc, FuncRef, Subs, CallArgs, NormalBB, ErrorBB);
 
   {
     // Emit the rethrow logic.
@@ -261,7 +255,6 @@ emitInvocation(SILBuilder &Builder,
   if (!CanSILFuncTy->hasErrorResult() ||
       CalleeFunc->findThrowBB() == CalleeFunc->end()) {
     return Builder.createApply(CalleeFunc->getLocation(), FuncRefInst,
-                               CalleeSILSubstFnTy, fnConv.getSILResultType(),
                                Subs, CallArgs, isNonThrowing);
   }
 
@@ -575,9 +568,8 @@ void EagerDispatch::emitRefCountedObjectCheck(SILBasicBlock *FailedTypeCheckBB,
   auto SILFnTy = SILType::getPrimitiveObjectType(CanFnTy);
   SILFunctionConventions fnConv(CanFnTy, Builder.getModule());
   auto SILResultTy = fnConv.getSILResultType();
-  auto IsClassRuntimeCheck =
-      Builder.createApply(Loc, FRI, SILFnTy, SILResultTy, {Sub}, {GenericMT},
-                          /* isNonThrowing */ false);
+  auto IsClassRuntimeCheck = Builder.createApply(Loc, FRI, {Sub}, {GenericMT},
+                                                 /* isNonThrowing */ false);
   // Extract the i1 from the Bool struct.
   StructDecl *BoolStruct = cast<StructDecl>(Ctx.getBoolDecl());
   auto Members = BoolStruct->lookupDirect(Ctx.Id_value_);

--- a/lib/SILOptimizer/IPO/EagerSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/EagerSpecializer.cpp
@@ -563,11 +563,6 @@ void EagerDispatch::emitRefCountedObjectCheck(SILBasicBlock *FailedTypeCheckBB,
   Builder.emitBlock(IsClassCheckBB);
 
   auto *FRI = Builder.createFunctionRef(Loc, IsClassF);
-  auto CanFnTy = IsClassF->getLoweredFunctionType()->substGenericArgs(
-      Builder.getModule(), {Sub});
-  auto SILFnTy = SILType::getPrimitiveObjectType(CanFnTy);
-  SILFunctionConventions fnConv(CanFnTy, Builder.getModule());
-  auto SILResultTy = fnConv.getSILResultType();
   auto IsClassRuntimeCheck = Builder.createApply(Loc, FRI, {Sub}, {GenericMT},
                                                  /* isNonThrowing */ false);
   // Extract the i1 from the Bool struct.

--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -965,9 +965,8 @@ void ApplyRewriter::convertApplyWithIndirectResults() {
   switch (origCallInst->getKind()) {
   case ValueKind::ApplyInst:
     newCallInst = callBuilder.createApply(
-        loc, apply.getCallee(), apply.getSubstCalleeSILType(),
-        loweredCalleeConv.getSILResultType(), apply.getSubstitutions(),
-        newCallArgs, cast<ApplyInst>(origCallInst)->isNonThrowing());
+        loc, apply.getCallee(), apply.getSubstitutions(), newCallArgs,
+        cast<ApplyInst>(origCallInst)->isNonThrowing());
     break;
   case ValueKind::TryApplyInst:
     // TODO: insert dealloc in the catch block.

--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -966,7 +966,8 @@ void ApplyRewriter::convertApplyWithIndirectResults() {
   case ValueKind::ApplyInst:
     newCallInst = callBuilder.createApply(
         loc, apply.getCallee(), apply.getSubstitutions(), newCallArgs,
-        cast<ApplyInst>(origCallInst)->isNonThrowing());
+        cast<ApplyInst>(origCallInst)->isNonThrowing(),
+        SILModuleConventions::getLoweredAddressConventions());
     break;
   case ValueKind::TryApplyInst:
     // TODO: insert dealloc in the catch block.

--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -297,8 +297,6 @@ bool PartialApplyCombiner::processSingleApply(FullApplySite AI) {
   }
 
   auto Callee = PAI->getCallee();
-  auto FnType = PAI->getSubstCalleeSILType();
-  SILType ResultTy = PAI->getSubstCalleeConv().getSILResultType();
   SubstitutionList Subs = PAI->getSubstitutions();
 
   // The partial_apply might be substituting in an open existential type.
@@ -448,7 +446,6 @@ SILCombiner::optimizeApplyOfConvertFunctionInst(FullApplySite AI,
     }
   }
 
-  SILType CCSILTy = SILType::getPrimitiveObjectType(ConvertCalleeTy);
   // Create the new apply inst.
   SILInstruction *NAI;
   if (auto *TAI = dyn_cast<TryApplyInst>(AI))
@@ -1172,7 +1169,6 @@ SILInstruction *SILCombiner::visitApplyInst(ApplyInst *AI) {
     }
     // The type of the substitution is the source type of the thin to thick
     // instruction.
-    SILType substTy = TTTFI->getOperand()->getType();
     Builder.addOpenedArchetypeOperands(AI);
     auto *NewAI = Builder.createApply(AI->getLoc(), TTTFI->getOperand(),
                                       AI->getSubstitutions(), Arguments,
@@ -1304,7 +1300,6 @@ SILInstruction *SILCombiner::visitTryApplyInst(TryApplyInst *AI) {
     }
     // The type of the substitution is the source type of the thin to thick
     // instruction.
-    SILType substTy = TTTFI->getOperand()->getType();
     auto *NewAI = Builder.createTryApply(AI->getLoc(), TTTFI->getOperand(),
                                          AI->getSubstitutions(), Arguments,
                                          AI->getNormalBB(), AI->getErrorBB());

--- a/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
+++ b/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
@@ -841,10 +841,10 @@ specializePartialApply(PartialApplyInst *PartialApply,
   CanSILFunctionType CanFnTy = ClonedFn->getLoweredFunctionType();
   auto const &Subs = PartialApply->getSubstitutions();
   CanSILFunctionType SubstCalleeTy = CanFnTy->substGenericArgs(M, Subs);
-  return Builder.createPartialApply(PartialApply->getLoc(), FunctionRef,
-                                 SILType::getPrimitiveObjectType(SubstCalleeTy),
-                                    PartialApply->getSubstitutions(), Args,
-                                    PartialApply->getType());
+  return Builder.createPartialApply(
+      PartialApply->getLoc(), FunctionRef, PartialApply->getSubstitutions(),
+      Args,
+      PartialApply->getType().getAs<SILFunctionType>()->getCalleeConvention());
 }
 
 static void

--- a/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
+++ b/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
@@ -838,9 +838,7 @@ specializePartialApply(PartialApplyInst *PartialApply,
   // Build the function_ref and partial_apply.
   SILValue FunctionRef = Builder.createFunctionRef(PartialApply->getLoc(),
                                                    ClonedFn);
-  CanSILFunctionType CanFnTy = ClonedFn->getLoweredFunctionType();
   auto const &Subs = PartialApply->getSubstitutions();
-  CanSILFunctionType SubstCalleeTy = CanFnTy->substGenericArgs(M, Subs);
   return Builder.createPartialApply(
       PartialApply->getLoc(), FunctionRef, PartialApply->getSubstitutions(),
       Args,

--- a/lib/SILOptimizer/Transforms/CSE.cpp
+++ b/lib/SILOptimizer/Transforms/CSE.cpp
@@ -1014,7 +1014,7 @@ static bool tryToCSEOpenExtCall(OpenExistentialAddrInst *From,
                                 Builder.getModule());
   auto ResTy = fnConv.getSILResultType();
 
-  ApplyInst *NAI = Builder.createApply(ToAI->getLoc(), ToWMI, FnTy, ResTy,
+  ApplyInst *NAI = Builder.createApply(ToAI->getLoc(), ToWMI,
                                        ToAI->getSubstitutions(), Args,
                                        ToAI->isNonThrowing());
   FromAI->replaceAllUsesWith(NAI);

--- a/lib/SILOptimizer/Transforms/CSE.cpp
+++ b/lib/SILOptimizer/Transforms/CSE.cpp
@@ -1009,11 +1009,6 @@ static bool tryToCSEOpenExtCall(OpenExistentialAddrInst *From,
       Args.push_back(Op == From ? To : Op);
   }
 
-  auto FnTy = ToAI->getSubstCalleeSILType();
-  SILFunctionConventions fnConv(FnTy.castTo<SILFunctionType>(),
-                                Builder.getModule());
-  auto ResTy = fnConv.getSILResultType();
-
   ApplyInst *NAI = Builder.createApply(ToAI->getLoc(), ToWMI,
                                        ToAI->getSubstitutions(), Args,
                                        ToAI->isNonThrowing());

--- a/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
@@ -745,16 +745,13 @@ void FunctionSignatureTransform::createFunctionSignatureOptimizedFunction() {
         SILType::getPrimitiveObjectType(FunctionTy->getErrorResult().getType());
     auto *ErrorArg =
         ErrorBlock->createPHIArgument(Error, ValueOwnershipKind::Owned);
-    Builder.createTryApply(Loc, FRI, SubstCalleeSILType, Subs,
-                           ThunkArgs, NormalBlock, ErrorBlock);
+    Builder.createTryApply(Loc, FRI, Subs, ThunkArgs, NormalBlock, ErrorBlock);
 
     Builder.setInsertionPoint(ErrorBlock);
     Builder.createThrow(Loc, ErrorArg);
     Builder.setInsertionPoint(NormalBlock);
   } else {
-    ReturnValue = Builder.createApply(Loc, FRI, SubstCalleeSILType, ResultType,
-                                      Subs, ThunkArgs,
-                                      false);
+    ReturnValue = Builder.createApply(Loc, FRI, Subs, ThunkArgs, false);
   }
 
   // Set up the return results.

--- a/lib/SILOptimizer/Transforms/ReleaseDevirtualizer.cpp
+++ b/lib/SILOptimizer/Transforms/ReleaseDevirtualizer.cpp
@@ -169,8 +169,7 @@ bool ReleaseDevirtualizer::createDeallocCall(SILType AllocType,
   if (auto *Sig = NTD->getGenericSignature())
     Sig->getSubstitutions(AllocSubMap, AllocSubsts);
 
-  B.createApply(ReleaseInst->getLoc(), MI, DeallocSILType, ReturnType,
-                AllocSubsts, { object }, false);
+  B.createApply(ReleaseInst->getLoc(), MI, AllocSubsts, {object}, false);
 
   NumReleasesDevirtualized++;
   ReleaseInst->eraseFromParent();

--- a/lib/SILOptimizer/Transforms/ReleaseDevirtualizer.cpp
+++ b/lib/SILOptimizer/Transforms/ReleaseDevirtualizer.cpp
@@ -149,9 +149,6 @@ bool ReleaseDevirtualizer::createDeallocCall(SILType AllocType,
 
   DeallocType = DeallocType->substGenericArgs(M, AllocSubMap);
 
-  SILType ReturnType = Dealloc->getConventions().getSILResultType();
-  SILType DeallocSILType = SILType::getPrimitiveObjectType(DeallocType);
-
   SILBuilder B(ReleaseInst);
   if (object->getType() != AllocType)
     object = B.createUncheckedRefCast(ReleaseInst->getLoc(), object, AllocType);

--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -2026,8 +2026,6 @@ bool SimplifyCFG::simplifyTryApplyBlock(TryApplyInst *TAI) {
 
     DEBUG(llvm::dbgs() << "replace with apply: " << *TAI);
     ApplyInst *NewAI = Builder.createApply(TAI->getLoc(), Callee,
-                                           CalleeType,
-                                           ResultTy,
                                            TAI->getSubstitutions(),
                                            Args, CalleeFnTy->hasErrorResult());
 

--- a/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
+++ b/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
@@ -61,8 +61,6 @@ static FullApplySite CloneApply(FullApplySite AI, SILBuilder &Builder) {
   switch (AI.getInstruction()->getKind()) {
   case ValueKind::ApplyInst:
     NAI = Builder.createApply(AI.getLoc(), AI.getCallee(),
-                                   AI.getSubstCalleeSILType(),
-                                   AI.getType(),
                                    AI.getSubstitutions(),
                                    Ret,
                                    cast<ApplyInst>(AI)->isNonThrowing());
@@ -70,7 +68,6 @@ static FullApplySite CloneApply(FullApplySite AI, SILBuilder &Builder) {
   case ValueKind::TryApplyInst: {
     auto *TryApplyI = cast<TryApplyInst>(AI.getInstruction());
     NAI = Builder.createTryApply(AI.getLoc(), AI.getCallee(),
-                                      AI.getSubstCalleeSILType(),
                                       AI.getSubstitutions(),
                                       Ret,
                                       TryApplyI->getNormalBB(),
@@ -204,7 +201,7 @@ static FullApplySite speculateMonomorphicTarget(FullApplySite AI,
       Args.push_back(Arg);
     }
     FullApplySite NewVirtAI = Builder.createTryApply(VirtAI.getLoc(), VirtAI.getCallee(),
-        VirtAI.getSubstCalleeSILType(), VirtAI.getSubstitutions(),
+        VirtAI.getSubstitutions(),
         Args, NormalBB, ErrorBB);
     VirtAI.getInstruction()->eraseFromParent();
     VirtAI = NewVirtAI;

--- a/lib/SILOptimizer/UtilityPasses/BugReducerTester.cpp
+++ b/lib/SILOptimizer/UtilityPasses/BugReducerTester.cpp
@@ -145,8 +145,7 @@ class BugReducerTester : public SILFunctionTransform {
         RuntimeCrasherFunc->dump();
         SILBuilder B(Apply->getIterator());
         B.createApply(Loc, B.createFunctionRef(Loc, RuntimeCrasherFunc),
-                      RuntimeCrasherFunc->getLoweredType(),
-                      M.Types.getEmptyTupleType(), SubstitutionList(),
+                      SubstitutionList(),
                       ArrayRef<SILValue>(), false /*NoThrow*/);
 
         Apply->replaceAllUsesWith(SILUndef::get(Apply->getType(), M));

--- a/lib/SILOptimizer/Utils/CFG.cpp
+++ b/lib/SILOptimizer/Utils/CFG.cpp
@@ -294,8 +294,7 @@ void swift::changeBranchTarget(TermInst *T, unsigned EdgeIdx,
     for (auto &Op : TAI->getArgumentOperands())
       Arguments.push_back(Op.get());
 
-    B.createTryApply(TAI->getLoc(), TAI->getCallee(),
-                     TAI->getSubstCalleeSILType(), TAI->getSubstitutions(),
+    B.createTryApply(TAI->getLoc(), TAI->getCallee(), TAI->getSubstitutions(),
                      Arguments, NormalBB, ErrorBB);
 
     TAI->eraseFromParent();

--- a/lib/SILOptimizer/Utils/Devirtualize.cpp
+++ b/lib/SILOptimizer/Utils/Devirtualize.cpp
@@ -613,8 +613,6 @@ DevirtualizationResult swift::devirtualizeClassMethod(FullApplySite AI,
 
   SILType ResultTy = substConv.getSILResultType();
 
-  SILType SubstCalleeSILType =
-    SILType::getPrimitiveObjectType(SubstCalleeType);
   FullApplySite NewAI;
 
   SILBasicBlock *ResultBB = nullptr;
@@ -880,8 +878,6 @@ devirtualizeWitnessMethod(ApplySite AI, SILFunction *F,
   SILLocation Loc = AI.getLoc();
   FunctionRefInst *FRI = Builder.createFunctionRef(Loc, F);
 
-  auto SubstCalleeSILType = SILType::getPrimitiveObjectType(SubstCalleeCanType);
-  auto ResultSILType = substConv.getSILResultType();
   ApplySite SAI;
 
   SmallVector<Substitution, 4> NewSubs;
@@ -905,9 +901,6 @@ devirtualizeWitnessMethod(ApplySite AI, SILFunction *F,
                                       .getSwiftRValueType()
                                       ->getAs<SILFunctionType>()
                                       ->getCalleeConvention();
-    auto PAIResultType = SILBuilder::getPartialApplyResultType(
-        SubstCalleeSILType, Arguments.size(), Module, {},
-        PartialApplyConvention);
     auto *NewPAI = Builder.createPartialApply(
         Loc, FRI, NewSubs, Arguments, PartialApplyConvention);
     // Check if any casting is required for the return value.

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -1805,8 +1805,6 @@ static ApplySite replaceWithSpecializedCallee(ApplySite AI,
     return NewAI;
   }
   if (auto *PAI = dyn_cast<PartialApplyInst>(AI)) {
-    // SILType PTy =
-    // SILType::getPrimitiveObjectType(ReInfo.getSpecializedType());
     auto *NewPAI = Builder.createPartialApply(
         Loc, Callee, Subs, Arguments,
         PAI->getType().getAs<SILFunctionType>()->getCalleeConvention());

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -1764,9 +1764,8 @@ static ApplySite replaceWithSpecializedCallee(ApplySite AI,
   if (auto *TAI = dyn_cast<TryApplyInst>(AI)) {
     SILBasicBlock *ResultBB = TAI->getNormalBB();
     assert(ResultBB->getSinglePredecessorBlock() == TAI->getParent());
-    auto *NewTAI =
-        Builder.createTryApply(Loc, Callee, CalleeSILSubstFnTy, Subs, Arguments,
-                               ResultBB, TAI->getErrorBB());
+    auto *NewTAI = Builder.createTryApply(Loc, Callee, Subs, Arguments,
+                                          ResultBB, TAI->getErrorBB());
     if (StoreResultTo) {
       assert(substConv.useLoweredAddresses());
       // The original normal result of the try_apply is an empty tuple.
@@ -1784,9 +1783,8 @@ static ApplySite replaceWithSpecializedCallee(ApplySite AI,
     return NewTAI;
   }
   if (auto *A = dyn_cast<ApplyInst>(AI)) {
-    auto *NewAI = Builder.createApply(Loc, Callee, CalleeSILSubstFnTy,
-                                      substConv.getSILResultType(), Subs,
-                                      Arguments, A->isNonThrowing());
+    auto *NewAI = Builder.createApply(Loc, Callee, Subs, Arguments,
+                                      A->isNonThrowing());
     if (StoreResultTo) {
       assert(substConv.useLoweredAddresses());
       if (!CalleeSILSubstFnTy.isNoReturnFunction()) {
@@ -1812,9 +1810,9 @@ static ApplySite replaceWithSpecializedCallee(ApplySite AI,
     // SILType PTy =
     // SILType::getPrimitiveObjectType(ReInfo.getSpecializedType());
     SILType PTy = CalleeSILSubstFnTy;
-    auto *NewPAI =
-        Builder.createPartialApply(Loc, Callee, PTy, Subs, Arguments,
-                                   SILType::getPrimitiveObjectType(NewPAType));
+    auto *NewPAI = Builder.createPartialApply(
+        Loc, Callee, Subs, Arguments,
+        PAI->getType().getAs<SILFunctionType>()->getCalleeConvention());
     PAI->replaceAllUsesWith(NewPAI);
     return NewPAI;
   }
@@ -1949,15 +1947,12 @@ SILValue ReabstractionThunkGenerator::createReabstractionThunkApply(
   auto SILResultTy =
       SpecializedFunc->mapTypeIntoContext(specConv.getSILResultType());
   if (!SpecializedFunc->getLoweredFunctionType()->hasErrorResult()) {
-    return Builder.createApply(Loc, FRI, CalleeSILSubstFnTy,
-                               SILResultTy, Subs, Arguments,
-                               false);
+    return Builder.createApply(Loc, FRI, Subs, Arguments, false);
   }
   // Create the logic for calling a throwing function.
   SILBasicBlock *NormalBB = Thunk->createBasicBlock();
   SILBasicBlock *ErrorBB = Thunk->createBasicBlock();
-  Builder.createTryApply(Loc, FRI, CalleeSILSubstFnTy, Subs,
-                         Arguments, NormalBB, ErrorBB);
+  Builder.createTryApply(Loc, FRI, Subs, Arguments, NormalBB, ErrorBB);
   auto *ErrorVal = ErrorBB->createPHIArgument(
       SpecializedFunc->mapTypeIntoContext(specConv.getSILErrorType()),
       ValueOwnershipKind::Owned);
@@ -2173,9 +2168,9 @@ void swift::trySpecializeApplyOfGeneric(
     auto Subs = ReInfo.getCallerParamSubstitutions();
     auto CalleeSubstFnTy = getCalleeSubstFunctionType(FRI, Subs);
     auto CalleeSILSubstFnTy = SILType::getPrimitiveObjectType(CalleeSubstFnTy);
-    auto *NewPAI = Builder.createPartialApply(PAI->getLoc(), FRI,
-                                              CalleeSILSubstFnTy, Subs,
-                                              Arguments, PAI->getType());
+    auto *NewPAI = Builder.createPartialApply(
+        PAI->getLoc(), FRI, Subs, Arguments,
+        PAI->getType().getAs<SILFunctionType>()->getCalleeConvention());
     PAI->replaceAllUsesWith(NewPAI);
     DeadApplies.insert(PAI);
     return;

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -1805,11 +1805,8 @@ static ApplySite replaceWithSpecializedCallee(ApplySite AI,
     return NewAI;
   }
   if (auto *PAI = dyn_cast<PartialApplyInst>(AI)) {
-    CanSILFunctionType NewPAType = ReInfo.createSpecializedType(
-        PAI->getFunctionType(), Builder.getModule());
     // SILType PTy =
     // SILType::getPrimitiveObjectType(ReInfo.getSpecializedType());
-    SILType PTy = CalleeSILSubstFnTy;
     auto *NewPAI = Builder.createPartialApply(
         Loc, Callee, Subs, Arguments,
         PAI->getType().getAs<SILFunctionType>()->getCalleeConvention());
@@ -1941,11 +1938,7 @@ SILValue ReabstractionThunkGenerator::createReabstractionThunkApply(
   SILFunction *Thunk = &Builder.getFunction();
   auto *FRI = Builder.createFunctionRef(Loc, SpecializedFunc);
   auto Subs = Thunk->getForwardingSubstitutions();
-  auto CalleeSubstFnTy = getCalleeSubstFunctionType(FRI, Subs);
-  auto CalleeSILSubstFnTy = SILType::getPrimitiveObjectType(CalleeSubstFnTy);
   auto specConv = SpecializedFunc->getConventions();
-  auto SILResultTy =
-      SpecializedFunc->mapTypeIntoContext(specConv.getSILResultType());
   if (!SpecializedFunc->getLoweredFunctionType()->hasErrorResult()) {
     return Builder.createApply(Loc, FRI, Subs, Arguments, false);
   }
@@ -2166,8 +2159,6 @@ void swift::trySpecializeApplyOfGeneric(
       Arguments.push_back(Op.get());
     }
     auto Subs = ReInfo.getCallerParamSubstitutions();
-    auto CalleeSubstFnTy = getCalleeSubstFunctionType(FRI, Subs);
-    auto CalleeSILSubstFnTy = SILType::getPrimitiveObjectType(CalleeSubstFnTy);
     auto *NewPAI = Builder.createPartialApply(
         PAI->getLoc(), FRI, Subs, Arguments,
         PAI->getType().getAs<SILFunctionType>()->getCalleeConvention());

--- a/lib/SILOptimizer/Utils/Local.cpp
+++ b/lib/SILOptimizer/Utils/Local.cpp
@@ -862,9 +862,6 @@ SILInstruction *StringConcatenationOptimizer::optimize() {
   // Type.
   Arguments.push_back(FuncResultType);
 
-  auto FnTy = FRIConvertFromBuiltin->getType();
-  auto fnConv = FRIConvertFromBuiltin->getConventions();
-  auto STResultType = fnConv.getSILResultType();
   return Builder.createApply(AI->getLoc(), FRIConvertFromBuiltin,
                              SubstitutionList(), Arguments,
                              false);
@@ -1361,7 +1358,6 @@ optimizeBridgedObjCToSwiftCast(SILInstruction *Inst,
   auto SILFnTy = FuncRef->getType();
   SILType SubstFnTy = SILFnTy.substGenericArgs(M, SubMap);
   SILFunctionConventions substConv(SubstFnTy.castTo<SILFunctionType>(), M);
-  SILType ResultTy = substConv.getSILResultType();
 
   // Temporary to hold the intermediate result.
   AllocStackInst *Tmp = nullptr;
@@ -1551,7 +1547,6 @@ optimizeBridgedSwiftToObjCCast(SILInstruction *Inst,
 
   SILType SubstFnTy = SILFnTy.substGenericArgs(M, SubMap);
   SILFunctionConventions substConv(SubstFnTy.castTo<SILFunctionType>(), M);
-  SILType ResultTy = substConv.getSILResultType();
 
   auto FnRef = Builder.createFunctionRef(Loc, BridgedFunc);
   if (Src->getType().isAddress() && !substConv.isSILIndirect(ParamTypes[0])) {

--- a/lib/SILOptimizer/Utils/Local.cpp
+++ b/lib/SILOptimizer/Utils/Local.cpp
@@ -865,8 +865,8 @@ SILInstruction *StringConcatenationOptimizer::optimize() {
   auto FnTy = FRIConvertFromBuiltin->getType();
   auto fnConv = FRIConvertFromBuiltin->getConventions();
   auto STResultType = fnConv.getSILResultType();
-  return Builder.createApply(AI->getLoc(), FRIConvertFromBuiltin, FnTy,
-                             STResultType, SubstitutionList(), Arguments,
+  return Builder.createApply(AI->getLoc(), FRIConvertFromBuiltin,
+                             SubstitutionList(), Arguments,
                              false);
 }
 
@@ -1395,8 +1395,7 @@ optimizeBridgedObjCToSwiftCast(SILInstruction *Inst,
   SmallVector<Substitution, 4> Subs;
   Conf.getRequirement()->getGenericSignature()->getSubstitutions(SubMap, Subs);
 
-  auto *AI = Builder.createApply(Loc, FuncRef, SubstFnTy, ResultTy, Subs, Args,
-                                 false);
+  auto *AI = Builder.createApply(Loc, FuncRef, Subs, Args, false);
 
   // If the source of a cast should be destroyed, emit a release.
   if (auto *UCCAI = dyn_cast<UnconditionalCheckedCastAddrInst>(Inst)) {
@@ -1643,8 +1642,7 @@ optimizeBridgedSwiftToObjCCast(SILInstruction *Inst,
     Sig->getSubstitutions(SubMap, Subs);
 
   // Generate a code to invoke the bridging function.
-  auto *NewAI = Builder.createApply(Loc, FnRef, SubstFnTy, ResultTy, Subs, Src,
-                                    false);
+  auto *NewAI = Builder.createApply(Loc, FnRef, Subs, Src, false);
 
   if (needReleaseAfterCall) {
     Builder.createReleaseValue(Loc, Src, Builder.getDefaultAtomicity());

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -1081,10 +1081,9 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn, SILBasicBlock *BB,
       Substitutions.push_back(*sub);
     }
 
-    ResultVal =
-        Builder.createApply(Loc, getLocalValue(ValID, FnTy), SubstFnTy,
-                            substConventions.getSILResultType(), Substitutions,
-                            Args, IsNonThrowingApply != 0);
+    ResultVal = Builder.createApply(Loc, getLocalValue(ValID, FnTy),
+                                    Substitutions, Args,
+                                    IsNonThrowingApply != 0);
     break;
   }
   case ValueKind::TryApplyInst: {
@@ -1119,10 +1118,8 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn, SILBasicBlock *BB,
       Substitutions.push_back(*sub);
     }
 
-    ResultVal = Builder.createTryApply(Loc,
-                                       getLocalValue(ValID, FnTy),
-                                       SubstFnTy, Substitutions, Args,
-                                       normalBB, errorBB);
+    ResultVal = Builder.createTryApply(Loc, getLocalValue(ValID, FnTy),
+                                       Substitutions, Args, normalBB, errorBB);
     break;
   }
   case ValueKind::PartialApplyInst: {
@@ -1157,9 +1154,9 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn, SILBasicBlock *BB,
           ListOfValues[I], fnConv.getSILArgumentType(I + unappliedArgs)));
 
     // FIXME: Why the arbitrary order difference in IRBuilder type argument?
-    ResultVal = Builder.createPartialApply(Loc, FnVal, SubstFnTy,
-                                           Substitutions, Args,
-                                           closureTy);
+    ResultVal = Builder.createPartialApply(
+        Loc, FnVal, Substitutions, Args,
+        closureTy.getAs<SILFunctionType>()->getCalleeConvention());
     break;
   }
   case ValueKind::BuiltinInst: {

--- a/test/SILOptimizer/specialize.sil
+++ b/test/SILOptimizer/specialize.sil
@@ -614,3 +614,31 @@ bb3:
   %8 = tuple ()
   return %8 : $()
 }
+
+struct YYY<T> {
+}
+
+enum MyOptional<T> {
+  case none
+  case some(T)
+}
+
+// Check that a specialization of a self-recursive function is produced
+// and it is not crashing the compiler.
+// CHECK-LABEL: sil shared @_T025testSelfRecursiveFunction4main10MyOptionalOyAB3YYYVyypGG_Tg5 : $@convention(thin) (MyOptional<YYY<Any>>) -> ()
+sil @testSelfRecursiveFunction : $@convention(thin) <T> (@in T) -> () {
+bb0(%0 : $*T):
+  %2 = function_ref @testSelfRecursiveFunction : $@convention(thin) <τ_0_0> (@in τ_0_0) -> ()
+  %3 = alloc_stack $MyOptional<YYY<Any>>
+  inject_enum_addr %3 : $*MyOptional<YYY<Any>>, #MyOptional.none!enumelt
+  %5 = tuple ()
+  %6 = load %3 : $*MyOptional<YYY<Any>>
+  %7 = alloc_stack $MyOptional<YYY<Any>>
+  store %6 to %7 : $*MyOptional<YYY<Any>>
+  %9 = apply %2<MyOptional<YYY<Any>>>(%7) : $@convention(thin) <τ_0_0> (@in τ_0_0) -> ()
+  dealloc_stack %7 : $*MyOptional<YYY<Any>>
+  dealloc_stack %3 : $*MyOptional<YYY<Any>>
+  destroy_addr %0 : $*T
+  %13 = tuple ()
+  return %13 : $()
+} // end sil function 'testSelfRecursiveFunction'

--- a/validation-test/compiler_crashers_fixed/28736-anonymous-namespacesilverifier-require.swift
+++ b/validation-test/compiler_crashers_fixed/28736-anonymous-namespacesilverifier-require.swift
@@ -4,7 +4,7 @@
 //
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-// RUN: not --crash %target-swift-frontend -primary-file %s -emit-ir -O
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -O
 // non-fuzz (@dusek)
 
 func f<T>(_ a:T)->Void{f(nil as[Any]?)}


### PR DESCRIPTION
Description: TypeSubstCloner and generic specializer would produce incorrect SIL for applies and partial_applies, especially for self-recursive functions. Types and number of arguments may get wrong in such cases.

Scope of the issue: SIL optimizer would produce SIL which does not pass the SIL verifier or crash the compiler later if verifier is disabled. Some internal projects are affected by this issue. Potentially it can happen on any code with self-recursive functions when it is optimized with -O.
Origination: Bug reports on internal projects (rdar://31899989 and rdar://31886854)

Risk: Low. The majority of the code is re-factoring, which among other things removes the possibility to provide wrong types when constructing different kinds of apply instructions. Plus it introduces stricter checks in the TypeSubstCloner for self-recursive functions.

Tested: New test cases added. Internal projects successfully build with these changes.

Reviewed by: Erik Eckstein and Slava Pestov

Resolves: rdar://31899989 and rdar://31886854