### PR TITLE
[DO NOT MERGE][stdlib] Restore recursive where clauses on Collection protocols

### DIFF
--- a/stdlib/private/StdlibCollectionUnittest/CheckCollectionInstance.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/CheckCollectionInstance.swift.gyb
@@ -257,8 +257,7 @@ public func checkCollection<${genericParam}, C : Collection>(
   ${TRACE},
   resiliencyChecks: CollectionMisuseResiliencyChecks = .all,
   sameValue: (${Element}, ${Element}) -> Bool
-) where C.Iterator.Element == ${Element},
-  C.SubSequence : Collection {
+) where C.Iterator.Element == ${Element} {
 
   checkForwardCollection(expected, collection, message(),
     stackTrace: stackTrace, showFrame: showFrame, file: file, line: line,
@@ -278,7 +277,6 @@ public func check${Traversal}Collection<
   resiliencyChecks: CollectionMisuseResiliencyChecks = .all
 ) where
   C.Iterator.Element == ${Element},
-  C.SubSequence : ${TraversalCollection},
   ${Element} : Equatable {
 
   check${Traversal}Collection(
@@ -298,8 +296,7 @@ public func check${Traversal}Collection<
   resiliencyChecks: CollectionMisuseResiliencyChecks = .all,
   sameValue: (${Element}, ${Element}) -> Bool
 ) where
-  C.Iterator.Element == ${Element},
-  C.SubSequence : ${TraversalCollection} {
+  C.Iterator.Element == ${Element} {
 
   checkOneLevelOf${Traversal}Collection(expected, collection, ${trace},
     resiliencyChecks: resiliencyChecks, sameValue: sameValue)
@@ -504,8 +501,7 @@ ${genericParam}, S : ${TraversalCollection}
   resiliencyChecks: CollectionMisuseResiliencyChecks = .all,
   sameValue: (${Element}, ${Element}) -> Bool
 ) where
-  S.Iterator.Element == ${Element},
-  S.SubSequence : ${TraversalCollection} {
+  S.Iterator.Element == ${Element} {
 
   let expectedArray = Array(expected)
 

--- a/stdlib/private/StdlibCollectionUnittest/CheckCollectionType.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/CheckCollectionType.swift.gyb
@@ -471,16 +471,9 @@ internal enum _SubSequenceSubscriptOnRangeMode {
 %{
   from gyb_stdlib_support import collectionForTraversal
   def testConstraints(protocol):
-    if protocol == 'Collection':
-      subseq_as_collection = 'CollectionWithEquatableElement.SubSequence : Collection,'
-    else:
-      subseq_as_collection=''
     return '''
     C : %(protocol)s,
     CollectionWithEquatableElement : %(protocol)s,
-    %(subseq_as_collection)s
-    C.SubSequence : %(protocol)s,
-    C.Indices : %(protocol)s,
     CollectionWithEquatableElement.Iterator.Element : Equatable
   ''' % locals()
 
@@ -493,6 +486,7 @@ internal enum _SubSequenceSubscriptOnRangeMode {
     makeCollectionOfEquatable: @escaping (
       [CollectionWithEquatableElement.Iterator.Element]
     ) -> CollectionWithEquatableElement,
+
 
     wrapValueIntoEquatable: @escaping (
       MinimalEquatableValue) -> CollectionWithEquatableElement.Iterator.Element,

--- a/stdlib/private/StdlibCollectionUnittest/CheckMutableCollectionType.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/CheckMutableCollectionType.swift.gyb
@@ -121,8 +121,6 @@ extension TestSuite {
     isFixedLengthCollection: Bool,
     collectionIsBidirectional: Bool = false
   ) where
-    C.SubSequence : MutableCollection,
-    C.Indices : Collection,
     CollectionWithEquatableElement.Iterator.Element : Equatable,
     CollectionWithComparableElement.Iterator.Element : Comparable {
 
@@ -783,8 +781,6 @@ self.test("\(testNamePrefix).partition/InvalidOrderings") {
     withUnsafeMutableBufferPointerIsSupported: Bool,
     isFixedLengthCollection: Bool
   ) where
-    C.SubSequence : BidirectionalCollection & MutableCollection,
-    C.Indices : BidirectionalCollection,
     CollectionWithEquatableElement.Iterator.Element : Equatable,
     CollectionWithComparableElement.Iterator.Element : Comparable {
 
@@ -929,8 +925,6 @@ self.test("\(testNamePrefix).partition/DispatchesThrough_withUnsafeMutableBuffer
     withUnsafeMutableBufferPointerIsSupported: Bool,
     isFixedLengthCollection: Bool
   ) where
-    C.SubSequence : RandomAccessCollection & MutableCollection,
-    C.Indices : RandomAccessCollection,
     CollectionWithEquatableElement.Iterator.Element : Equatable,
     CollectionWithComparableElement.Iterator.Element : Comparable {
 

--- a/stdlib/private/StdlibCollectionUnittest/CheckRangeReplaceableCollectionType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckRangeReplaceableCollectionType.swift
@@ -462,10 +462,7 @@ extension TestSuite {
     outOfBoundsIndexOffset: Int = 1,
     collectionIsBidirectional: Bool = false
   ) where
-    C.SubSequence : Collection,
-    C.Indices : Collection,
-    CollectionWithEquatableElement.Iterator.Element : Equatable,
-    CollectionWithEquatableElement.SubSequence : Collection {
+    CollectionWithEquatableElement.Iterator.Element : Equatable {
 
     var testNamePrefix = testNamePrefix
 
@@ -1180,8 +1177,6 @@ self.test("\(testNamePrefix).OperatorPlus") {
     resiliencyChecks: CollectionMisuseResiliencyChecks = .all,
     outOfBoundsIndexOffset: Int = 1
   ) where
-    C.SubSequence : BidirectionalCollection & RangeReplaceableCollection,
-    C.Indices : BidirectionalCollection,
     CollectionWithEquatableElement.Iterator.Element : Equatable {
 
     var testNamePrefix = testNamePrefix
@@ -1302,8 +1297,6 @@ self.test("\(testNamePrefix).removeLast(n: Int)/whereIndexIsBidirectional/remove
     resiliencyChecks: CollectionMisuseResiliencyChecks = .all,
     outOfBoundsIndexOffset: Int = 1
   ) where
-    C.SubSequence : RandomAccessCollection & RangeReplaceableCollection,
-    C.Indices : RandomAccessCollection,
     CollectionWithEquatableElement.Iterator.Element : Equatable {
 
     var testNamePrefix = testNamePrefix

--- a/stdlib/private/StdlibCollectionUnittest/CheckRangeReplaceableSliceType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckRangeReplaceableSliceType.swift
@@ -33,7 +33,6 @@ extension TestSuite {
     collectionIsBidirectional: Bool = false
   ) where
     C.SubSequence == C,
-    C.Indices : Collection,
     CollectionWithEquatableElement.SubSequence == CollectionWithEquatableElement,
     CollectionWithEquatableElement.Iterator.Element : Equatable {
 
@@ -165,7 +164,6 @@ extension TestSuite {
     outOfBoundsIndexOffset: Int = 1
   ) where
     C.SubSequence == C,
-    C.Indices : BidirectionalCollection,
     CollectionWithEquatableElement.SubSequence == CollectionWithEquatableElement,
     CollectionWithEquatableElement.Iterator.Element : Equatable {
 
@@ -310,7 +308,6 @@ extension TestSuite {
     outOfBoundsIndexOffset: Int = 1
   ) where
     C.SubSequence == C,
-    C.Indices : RandomAccessCollection,
     CollectionWithEquatableElement.SubSequence == CollectionWithEquatableElement,
     CollectionWithEquatableElement.Iterator.Element : Equatable {
 

--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
@@ -376,14 +376,7 @@ public func expectSequenceType<X : Sequence>(_ x: X) -> X
 % for Mutable in ['', 'Mutable']:
 public func expect${Mutable}CollectionType<X : ${Mutable}Collection>(
   _ x: X.Type
-) where
-  // FIXME(ABI)#2 (Associated Types with where clauses): there should be no constraints in
-  // the 'where' clause, all of these should be required by the protocol.
-%   if Mutable == '':
-  X.SubSequence : Collection,
-%   end
-  // X.SubSequence.Indices == X.Indices, // FIXME(ABI)#3 (Recursive Protocol Constraints): can't have this constraint now.
-  X.Indices : Collection {}
+) { }
 % end
 
 /// A slice is a `Collection` that when sliced returns an instance of
@@ -421,12 +414,7 @@ public func expectCollectionAssociatedTypes<X : Collection>(
   indexType: X.Index.Type,
   indexDistanceType: X.IndexDistance.Type,
   indicesType: X.Indices.Type
-) where
-  // FIXME(ABI)#6 (Associated Types with where clauses): there should be no constraints in
-  // the 'where' clause, all of these should be required by the protocol.
-  X.SubSequence : Collection,
-  // X.SubSequence.Indices == X.Indices, // FIXME(ABI)#7 (Recursive Protocol Constraints): can't have this constraint now.
-  X.Indices : Collection {}
+) { }
 
 /// Check that all associated types of a `BidirectionalCollection` are what we
 /// expect them to be.
@@ -437,12 +425,7 @@ public func expectBidirectionalCollectionAssociatedTypes<X : BidirectionalCollec
   indexType: X.Index.Type,
   indexDistanceType: X.IndexDistance.Type,
   indicesType: X.Indices.Type
-) where
-  // FIXME(ABI)#8 (Associated Types with where clauses): there should be no constraints in
-  // the 'where' clause, all of these should be required by the protocol.
-  X.SubSequence : BidirectionalCollection,
-  // X.SubSequence.Indices == X.Indices, // FIXME(ABI)#9 (Recursive Protocol Constraints): can't have this constraint now.
-  X.Indices : BidirectionalCollection {}
+) { }
 
 /// Check that all associated types of a `RandomAccessCollection` are what we
 /// expect them to be.
@@ -453,12 +436,7 @@ public func expectRandomAccessCollectionAssociatedTypes<X : RandomAccessCollecti
   indexType: X.Index.Type,
   indexDistanceType: X.IndexDistance.Type,
   indicesType: X.Indices.Type
-) where
-  // FIXME(ABI)#10 (Associated Types with where clauses): there should be no constraints in
-  // the 'where' clause, all of these should be required by the protocol.
-  X.SubSequence : RandomAccessCollection,
-  // X.SubSequence.Indices == X.Indices, // FIXME(ABI)#11 (Recursive Protocol Constraints): can't have this constraint now.
-  X.Indices : RandomAccessCollection {}
+) { }
 
 public struct AssertionResult : CustomStringConvertible {
   init(isPass: Bool) {

--- a/stdlib/public/core/ArrayBufferProtocol.swift
+++ b/stdlib/public/core/ArrayBufferProtocol.swift
@@ -16,10 +16,7 @@
 internal protocol _ArrayBufferProtocol
   : MutableCollection, RandomAccessCollection {
 
-  associatedtype Indices 
-  // FIXME(ABI) (Revert Where Clauses): Remove this conformance
-  : RandomAccessCollection 
-    = CountableRange<Int>
+  associatedtype Indices = CountableRange<Int>
 
   /// The type of elements stored in the buffer.
   associatedtype Element

--- a/stdlib/public/core/BidirectionalCollection.swift
+++ b/stdlib/public/core/BidirectionalCollection.swift
@@ -66,9 +66,7 @@ public protocol _BidirectionalIndexable : _Indexable {
 /// - If `i > c.startIndex && i <= c.endIndex`
 ///   `c.index(after: c.index(before: i)) == i`.
 public protocol BidirectionalCollection : _BidirectionalIndexable, Collection 
-// FIXME(ABI) (Revert Where Clauses): Restore these 
-// where SubSequence: BidirectionalCollection, Indices: BidirectionalCollection
-{
+where SubSequence: BidirectionalCollection, Indices: BidirectionalCollection {
 
 // TODO: swift-3-indexing-model - replaces functionality in BidirectionalIndex
   /// Returns the position immediately before the given index.
@@ -86,17 +84,11 @@ public protocol BidirectionalCollection : _BidirectionalIndexable, Collection
 
   /// A sequence that can represent a contiguous subrange of the collection's
   /// elements.
-  associatedtype SubSequence
-  // FIXME(ABI) (Revert Where Clauses): Remove these conformances
-  : _BidirectionalIndexable, Collection
-    = BidirectionalSlice<Self>
+  associatedtype SubSequence = BidirectionalSlice<Self>
 
   /// A type that represents the indices that are valid for subscripting the
   /// collection, in ascending order.
-  associatedtype Indices 
-  // FIXME(ABI) (Revert Where Clauses): Remove these conformances
-  : _BidirectionalIndexable, Collection
-    = DefaultBidirectionalIndices<Self>
+  associatedtype Indices = DefaultBidirectionalIndices<Self>
 
   /// The indices that are valid for subscripting the collection, in ascending
   /// order.

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -647,8 +647,8 @@ public struct IndexingIterator<
 /// count the number of contained elements, accessing its `count` property is
 /// an O(*n*) operation.
 public protocol Collection : _Indexable, Sequence 
-// FIXME(ABI) (Revert Where Clauses): Restore these 
-// where SubSequence: Collection, Indices: Collection,
+where SubSequence: Collection, Indices: Collection,
+      SubSequence.Index == Index
 {
   /// A type that represents the number of steps between a pair of
   /// indices.
@@ -675,15 +675,9 @@ public protocol Collection : _Indexable, Sequence
   /// This associated type appears as a requirement in the `Sequence`
   /// protocol, but it is restated here with stricter constraints. In a
   /// collection, the subsequence should also conform to `Collection`.
-  associatedtype SubSequence
-  // FIXME(ABI) (Revert Where Clauses): remove these conformances:
-  : _IndexableBase, Sequence
-     = Slice<Self>
-      where SubSequence.SubSequence == SubSequence
-  // FIXME(ABI) (Revert Where Clauses): and this where clause:
-          , Iterator.Element == SubSequence.Iterator.Element
-          , SubSequence.Index == Index
-            
+  associatedtype SubSequence = Slice<Self>
+      where Iterator.Element == SubSequence.Iterator.Element,
+            SubSequence.SubSequence == SubSequence
 
   // FIXME(ABI)#98 (Recursive Protocol Constraints):
   // FIXME(ABI)#99 (Associated Types with where clauses):
@@ -745,15 +739,10 @@ public protocol Collection : _Indexable, Sequence
 
   /// A type that represents the indices that are valid for subscripting the
   /// collection, in ascending order.
-  associatedtype Indices
-  // FIXME(ABI) (Revert Where Clauses): Remove these two conformances 
-  : _Indexable, Sequence
-    = DefaultIndices<Self>
-    where Indices.Iterator.Element == Index, 
+  associatedtype Indices = DefaultIndices<Self>
+    where Indices.Iterator.Element == Index,
           Indices.Index == Index
-  // FIXME(ABI) (Revert Where Clauses): Remove this where clause
-        , Indices.SubSequence == Indices
-        
+
   // FIXME(ABI)#100 (Recursive Protocol Constraints):
   // associatedtype Indices : Collection
   //   where

--- a/stdlib/public/core/ExistentialCollection.swift.gyb
+++ b/stdlib/public/core/ExistentialCollection.swift.gyb
@@ -423,21 +423,14 @@ internal class _AnyRandomAccessCollectionBox<Element>
 %     assert False, 'Unknown kind'
 %   end
 
-
-
 @_fixed_layout
 @_versioned
 internal final class _${Kind}Box<S : ${Kind}> : _Any${Kind}Box<S.Iterator.Element>
+%  if Kind == 'Sequence':
   where
   S.SubSequence : ${Kind},
-// FIXME(ABI) (Revert Where Clauses): apply all this only to Sequence:
-%  if Kind == 'Sequence':
   S.SubSequence.Iterator.Element == S.Iterator.Element,
   S.SubSequence.SubSequence == S.SubSequence
-// FIXME(ABI) (Revert Where Clauses): remove this else clause:
-%  else:
-  S.SubSequence.Indices : ${Kind},
-  S.Indices : ${Kind}
 %  end
 {
   internal typealias Element = S.Iterator.Element
@@ -1042,12 +1035,8 @@ public struct ${Self}<Element>
   @_inlineable
   public init<C : ${SubProtocol}>(_ base: C)
     where
-    // FIXME(ABI) (Revert Where Clauses): remove next 3 lines
-    C.SubSequence : ${SubProtocol},
-    C.SubSequence.Indices : ${SubProtocol},
-    C.Indices : ${SubProtocol},
-    // FIXME(ABI)#101 (Associated Types with where clauses): these constraints
-    // should be applied to associated types of Collection.
+    // FIXME(ABI)#101 (Associated Types with where clauses): these constraints should be applied to
+    // associated types of Collection.
     C.SubSequence.Iterator.Element == Element
      {
     // Traversal: ${Traversal}

--- a/stdlib/public/core/Mirror.swift
+++ b/stdlib/public/core/Mirror.swift
@@ -214,10 +214,7 @@ public struct Mirror {
     children: C,
     displayStyle: DisplayStyle? = nil,
     ancestorRepresentation: AncestorRepresentation = .generated
-  ) where C.Iterator.Element == Child 
-  // FIXME(ABI) (Revert Where Clauses): Remove these 
-  , C.SubSequence : Collection, C.SubSequence.Indices : Collection, C.Indices : Collection
-  {
+  ) where C.Iterator.Element == Child {
 
     self.subjectType = Subject.self
     self._makeSuperclassMirror = Mirror._superclassIterator(
@@ -264,10 +261,7 @@ public struct Mirror {
     unlabeledChildren: C,
     displayStyle: DisplayStyle? = nil,
     ancestorRepresentation: AncestorRepresentation = .generated
-  ) 
-  // FIXME(ABI) (Revert Where Clauses): Remove these two clauses
-  where C.SubSequence : Collection, C.Indices : Collection
-  {
+  ) {
 
     self.subjectType = Subject.self
     self._makeSuperclassMirror = Mirror._superclassIterator(

--- a/stdlib/public/core/MutableCollection.swift
+++ b/stdlib/public/core/MutableCollection.swift
@@ -197,13 +197,8 @@ public protocol _MutableIndexable : _Indexable {
 ///     a[i] = x
 ///     let y = x
 public protocol MutableCollection : _MutableIndexable, Collection
-// FIXME(ABI) (Revert Where Clauses): restore this:
-// where SubSequence: MutableCollection
-{
-  associatedtype SubSequence
-  // FIXME(ABI) (Revert Where Clauses): remove this conformance:
-  : Collection
-   = MutableSlice<Self>
+where SubSequence: MutableCollection {
+  associatedtype SubSequence = MutableSlice<Self>
 
   /// Accesses the element at the specified position.
   ///

--- a/stdlib/public/core/RandomAccessCollection.swift
+++ b/stdlib/public/core/RandomAccessCollection.swift
@@ -48,22 +48,15 @@ public protocol _RandomAccessIndexable : _BidirectionalIndexable {
 /// `distance(from:to:)` methods with O(1) efficiency.
 public protocol RandomAccessCollection :
   _RandomAccessIndexable, BidirectionalCollection
-// FIXME(ABI) (Revert Where Clauses): Restore this:
-// where SubSequence: RandomAccessCollection, Indices: RandomAccessCollection
+  where SubSequence: RandomAccessCollection, Indices: RandomAccessCollection
 {
   /// A collection that represents a contiguous subrange of the collection's
   /// elements.
-  associatedtype SubSequence
-  // FIXME(ABI) (Revert Where Clauses): Remove these two constraints:
-   : _RandomAccessIndexable, BidirectionalCollection
-   = RandomAccessSlice<Self>
+  associatedtype SubSequence = RandomAccessSlice<Self>
 
   /// A type that represents the indices that are valid for subscripting the
   /// collection, in ascending order.
-  associatedtype Indices 
-  // FIXME(ABI) (Revert Where Clauses): Remove these two constraints:
-  : _RandomAccessIndexable, BidirectionalCollection
-  = DefaultRandomAccessIndices<Self>
+  associatedtype Indices = DefaultRandomAccessIndices<Self>
 
   /// The indices that are valid for subscripting the collection, in ascending
   /// order.


### PR DESCRIPTION
For when the compile time issues are resolved.

Reverts apple/swift#9512
