### PR TITLE
Don't classify bridging casts as WillSucceed if the object-to-value cast can fail.

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -425,6 +425,10 @@ public:
 
   /// Retrieve the declaration of Foundation.NSError.
   ClassDecl *getNSErrorDecl() const;
+  /// Retrieve the declaration of Foundation.NSNumber.
+  ClassDecl *getNSNumberDecl() const;
+  /// Retrieve the declaration of Foundation.NSValue.
+  ClassDecl *getNSValueDecl() const;
 
   // Declare accessors for the known declarations.
 #define FUNC_DECL(Name, Id) \
@@ -486,6 +490,11 @@ public:
   /// library or Cocoa framework types that is known to be bridged by another
   /// module's overlay, for layering or implementation detail reasons.
   bool isTypeBridgedInExternalModule(NominalTypeDecl *nominal) const;
+
+  /// True if the given type is an Objective-C class that serves as the bridged
+  /// object type for many Swift value types, meaning that the conversion from
+  /// an object to a value is a conditional cast.
+  bool isObjCClassWithMultipleSwiftBridgedTypes(Type t);
 
   /// Get the Objective-C type that a Swift type bridges to, if any.
   /// 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3559,7 +3559,7 @@ ConstraintSystem::simplifyBridgingConstraint(Type type1,
       // We accepted these coercions in Swift 3 mode, so we have to live with
       // them (but give a warning) in that language mode.
       if (!TC.Context.LangOpts.isSwiftVersion3()
-          && TC.isObjCClassWithMultipleSwiftBridgedTypes(objcClass, DC))
+          && TC.Context.isObjCClassWithMultipleSwiftBridgedTypes(objcClass))
         return SolutionKind::Error;
 
       // If the bridged value type is generic, the generic arguments

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -3466,7 +3466,7 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
   if (Context.LangOpts.isSwiftVersion3() && extraFromOptionals == 0) {
     // Do the check for a bridging conversion now that we deferred above.
     if (isObjCBridgedTo(fromType, toType, dc, &unwrappedIUO) && !unwrappedIUO) {
-      if (isObjCClassWithMultipleSwiftBridgedTypes(fromType, dc)) {
+      if (Context.isObjCClassWithMultipleSwiftBridgedTypes(fromType)) {
         return CheckedCastKind::Swift3BridgingDowncast;
       }
       return CheckedCastKind::BridgingCoercion;

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -171,33 +171,6 @@ Type TypeChecker::getNSErrorType(DeclContext *dc) {
                                   dc);
 }
 
-Type TypeChecker::getNSNumberType(DeclContext *dc) {
-  return getObjectiveCNominalType(*this, NSNumberType, Context.Id_Foundation,
-                                  Context.getSwiftId(
-                                               KnownFoundationEntity::NSNumber),
-                                  dc);
-}
-
-Type TypeChecker::getNSValueType(DeclContext *dc) {
-  return getObjectiveCNominalType(*this, NSValueType, Context.Id_Foundation,
-                                  Context.getSwiftId(
-                                               KnownFoundationEntity::NSValue),
-                                  dc);
-}
-
-bool TypeChecker::isObjCClassWithMultipleSwiftBridgedTypes(Type t,
-                                                           DeclContext *dc) {
-  if (auto nsNumber = getNSNumberType(dc)) {
-    if (t->isEqual(nsNumber))
-      return true;
-  }
-  if (auto nsValue = getNSValueType(dc)) {
-    if (t->isEqual(nsValue))
-      return true;
-  }
-  return false;
-}
-
 Type TypeChecker::getObjCSelectorType(DeclContext *dc) {
   return getObjectiveCNominalType(*this, ObjCSelectorType,
                                   Context.Id_ObjectiveC,

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -888,14 +888,9 @@ public:
   Type getUInt8Type(DeclContext *dc);
   Type getNSObjectType(DeclContext *dc);
   Type getNSErrorType(DeclContext *dc);
-  Type getNSNumberType(DeclContext *dc);
-  Type getNSValueType(DeclContext *dc);
   Type getObjCSelectorType(DeclContext *dc);
   Type getExceptionType(DeclContext *dc, SourceLoc loc);
   
-  /// True if `t` is an ObjC class that multiple Swift value types bridge into.
-  bool isObjCClassWithMultipleSwiftBridgedTypes(Type t, DeclContext *dc);
-
   /// \brief Try to resolve an IdentTypeRepr, returning either the referenced
   /// Type or an ErrorType in case of error.
   Type resolveIdentifierType(DeclContext *DC,

--- a/test/SILOptimizer/cast_folding_objc_bridging_conditional.sil
+++ b/test/SILOptimizer/cast_folding_objc_bridging_conditional.sil
@@ -1,0 +1,31 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-sil %s | %FileCheck %s
+// REQUIRES: objc_interop
+
+sil_stage raw
+
+import Swift
+import Foundation
+
+struct MyError: Error {}
+
+// CHECK-LABEL: sil @cast_nserror_to_specific_error
+sil @cast_nserror_to_specific_error : $@convention(thin) (@in NSError, @in NSNumber, @in NSValue) -> () {
+entry(%0 : $*NSError, %1 : $*NSNumber, %2 : $*NSValue):
+  %f = function_ref @use : $@convention(thin) <T> (@in T) -> ()
+  %a = alloc_stack $MyError
+  // CHECK: checked_cast_addr_br {{.*}} NSError {{.*}} to MyError
+  checked_cast_addr_br take_always NSError in %0 : $*NSError to MyError in %a : $*MyError, yes, no
+
+yes:
+  apply %f<MyError>(%a) : $@convention(thin) <T> (@in T) -> ()
+  br done
+
+no:
+  br done
+
+done:
+  dealloc_stack %a : $*MyError
+  return undef : $()
+}
+
+sil @use : $@convention(thin) <T> (@in T) -> ()


### PR DESCRIPTION
When casting from an object type to a bridged Swift value type, classifyDynamicCast would use the cast classification for the target type's bridged object type, which would be trivially WillSucceed for thinks like NSNumber-to-Int or NSError-to-SomeError, even though the bridging itself could fail. Fixing this fixes SR-2920|rdar://problem/31404281.
