### PR TITLE
[4.0] Don't classify bridging casts as WillSucceed if the object-to-value cast can fail.

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -425,6 +425,10 @@ public:
 
   /// Retrieve the declaration of Foundation.NSError.
   ClassDecl *getNSErrorDecl() const;
+  /// Retrieve the declaration of Foundation.NSNumber.
+  ClassDecl *getNSNumberDecl() const;
+  /// Retrieve the declaration of Foundation.NSValue.
+  ClassDecl *getNSValueDecl() const;
 
   // Declare accessors for the known declarations.
 #define FUNC_DECL(Name, Id) \
@@ -486,6 +490,11 @@ public:
   /// library or Cocoa framework types that is known to be bridged by another
   /// module's overlay, for layering or implementation detail reasons.
   bool isTypeBridgedInExternalModule(NominalTypeDecl *nominal) const;
+
+  /// True if the given type is an Objective-C class that serves as the bridged
+  /// object type for many Swift value types, meaning that the conversion from
+  /// an object to a value is a conditional cast.
+  bool isObjCClassWithMultipleSwiftBridgedTypes(Type t);
 
   /// Get the Objective-C type that a Swift type bridges to, if any.
   /// 

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -83,6 +83,11 @@ using AssociativityCacheType =
   llvm::DenseMap<std::pair<PrecedenceGroupDecl *, PrecedenceGroupDecl *>,
                  Associativity>;
 
+#define FOR_KNOWN_FOUNDATION_TYPES(MACRO) \
+  MACRO(NSError) \
+  MACRO(NSNumber) \
+  MACRO(NSValue)
+
 struct ASTContext::Implementation {
   Implementation();
   ~Implementation();
@@ -153,8 +158,11 @@ struct ASTContext::Implementation {
   /// The declaration of ObjectiveC.ObjCBool.
   StructDecl *ObjCBoolDecl = nullptr;
 
-  /// The declaration of Foundation.NSError.
-  ClassDecl *NSErrorDecl = nullptr;
+#define CACHE_FOUNDATION_DECL(NAME) \
+  /** The declaration of Foundation.NAME. */ \
+  ClassDecl *NAME##Decl = nullptr;
+FOR_KNOWN_FOUNDATION_TYPES(CACHE_FOUNDATION_DECL)
+#undef CACHE_FOUNDATION_DECL
 
   // Declare cached declarations for each of the known declarations.
 #define FUNC_DECL(Name, Id) FuncDecl *Get##Name = nullptr;
@@ -743,25 +751,30 @@ StructDecl *ASTContext::getObjCBoolDecl() const {
   return Impl.ObjCBoolDecl;
 }
 
-ClassDecl *ASTContext::getNSErrorDecl() const {
-  if (!Impl.NSErrorDecl) {
-    if (ModuleDecl *M = getLoadedModule(Id_Foundation)) {
-      // Note: use unqualified lookup so we find NSError regardless of
-      // whether it's defined in the Foundation module or the Clang
-      // Foundation module it imports.
-      UnqualifiedLookup lookup(getIdentifier("NSError"), M, nullptr);
-      if (auto type = lookup.getSingleTypeResult()) {
-        if (auto classDecl = dyn_cast<ClassDecl>(type)) {
-          if (classDecl->getGenericParams() == nullptr) {
-            Impl.NSErrorDecl = classDecl;
-          }
-        }
-      }
-    }
-  }
-
-  return Impl.NSErrorDecl;
+#define GET_FOUNDATION_DECL(NAME) \
+ClassDecl *ASTContext::get##NAME##Decl() const { \
+  if (!Impl.NAME##Decl) { \
+    if (ModuleDecl *M = getLoadedModule(Id_Foundation)) { \
+      /* Note: use unqualified lookup so we find NSError regardless of */ \
+      /* whether it's defined in the Foundation module or the Clang */ \
+      /* Foundation module it imports. */ \
+      UnqualifiedLookup lookup(getIdentifier(#NAME), M, nullptr); \
+      if (auto type = lookup.getSingleTypeResult()) { \
+        if (auto classDecl = dyn_cast<ClassDecl>(type)) { \
+          if (classDecl->getGenericParams() == nullptr) { \
+            Impl.NAME##Decl = classDecl; \
+          } \
+        } \
+      } \
+    } \
+  } \
+  \
+  return Impl.NAME##Decl; \
 }
+
+FOR_KNOWN_FOUNDATION_TYPES(GET_FOUNDATION_DECL)
+#undef GET_FOUNDATION_DECL
+#undef FOR_KNOWN_FOUNDATION_TYPES
 
 ProtocolDecl *ASTContext::getProtocol(KnownProtocolKind kind) const {
   // Check whether we've already looked for and cached this protocol.
@@ -4054,6 +4067,21 @@ bool ASTContext::isTypeBridgedInExternalModule(
           // gets upset if you don't use the NSValue subclasses its factory
           // methods instantiate.
           nominal->getParentModule()->getName() == Id_CoreMedia);
+}
+
+bool ASTContext::isObjCClassWithMultipleSwiftBridgedTypes(Type t) {
+  auto clas = t->getClassOrBoundGenericClass();
+  if (!clas)
+    return false;
+  
+  if (clas == getNSErrorDecl())
+    return true;
+  if (clas == getNSNumberDecl())
+    return true;
+  if (clas == getNSValueDecl())
+    return true;
+  
+  return false;
 }
 
 Type ASTContext::getBridgedToObjC(const DeclContext *dc, Type type,

--- a/lib/SILOptimizer/Utils/Local.cpp
+++ b/lib/SILOptimizer/Utils/Local.cpp
@@ -1808,10 +1808,6 @@ simplifyCheckedCastAddrBranchInst(CheckedCastAddrBranchInst *Inst) {
                           isSourceTypeExact,
                           Mod.isWholeModule());
 
-  if (Feasibility == DynamicCastFeasibility::MaySucceed) {
-    return nullptr;
-  }
-
   if (Feasibility == DynamicCastFeasibility::WillFail) {
     if (shouldDestroyOnFailure(Inst->getConsumptionKind())) {
       auto &srcTL = Builder.getModule().getTypeLowering(Src->getType());
@@ -1823,60 +1819,67 @@ simplifyCheckedCastAddrBranchInst(CheckedCastAddrBranchInst *Inst) {
     return NewI;
   }
 
-  // Cast will succeed
-
-  // Replace by unconditional_addr_cast, followed by a branch.
-  // The unconditional_addr_cast can be skipped, if the result of a cast
-  // is not used afterwards.
   bool ResultNotUsed = isa<AllocStackInst>(Dest);
-  for (auto Use : Dest->getUses()) {
-    auto *User = Use->getUser();
-    if (isa<DeallocStackInst>(User) || User == Inst)
-      continue;
-    ResultNotUsed = false;
-    break;
+  if (ResultNotUsed) {
+    for (auto Use : Dest->getUses()) {
+      auto *User = Use->getUser();
+      if (isa<DeallocStackInst>(User) || User == Inst)
+        continue;
+      ResultNotUsed = false;
+      break;
+    }
   }
 
   auto *BB = Inst->getParent();
 
-  if (!ResultNotUsed) {
-    SILInstruction *BridgedI = nullptr;
+  SILInstruction *BridgedI = nullptr;
 
-    // To apply the bridged optimizations, we should
-    // ensure that types are not existential,
-    // and that not both types are classes.
-    BridgedI = optimizeBridgedCasts(Inst, Inst->getConsumptionKind(),
-                                    true, Src, Dest, SourceType,
-                                    TargetType, SuccessBB, FailureBB);
+  // To apply the bridged optimizations, we should
+  // ensure that types are not existential,
+  // and that not both types are classes.
+  BridgedI = optimizeBridgedCasts(Inst, Inst->getConsumptionKind(),
+                                  true, Src, Dest, SourceType,
+                                  TargetType, SuccessBB, FailureBB);
 
-    if (!BridgedI) {
-      // Since it is an addr cast, only address types are handled here.
-      if (!Src->getType().isAddress() || !Dest->getType().isAddress()) {
-        return nullptr;
-      } else if (!emitSuccessfulIndirectUnconditionalCast(
-                     Builder, Mod.getSwiftModule(), Loc,
-                     Inst->getConsumptionKind(), Src, SourceType, Dest,
-                     TargetType, Inst)) {
-        // No optimization was possible.
-        return nullptr;
-      }
+  if (!BridgedI) {
+    // If the cast may succeed or fail, and it can't be optimized into a
+    // bridging operation, then let it be.
+    if (Feasibility == DynamicCastFeasibility::MaySucceed) {
+      return nullptr;
+    }
+
+    assert(Feasibility == DynamicCastFeasibility::WillSucceed);
+    
+    // Replace by unconditional_addr_cast, followed by a branch.
+    // The unconditional_addr_cast can be skipped, if the result of a cast
+    // is not used afterwards.
+    if (ResultNotUsed) {
       EraseInstAction(Inst);
-    }
-    SILInstruction *NewI = &BB->back();
-    if (!isa<TermInst>(NewI)) {
       Builder.setInsertionPoint(BB);
-      NewI = Builder.createBranch(Loc, SuccessBB);
+      auto *NewI = Builder.createBranch(Loc, SuccessBB);
+      WillSucceedAction();
+      return NewI;
     }
-    WillSucceedAction();
-    return NewI;
-  } else {
-    // Result is not used.
+    
+    // Since it is an addr cast, only address types are handled here.
+    if (!Src->getType().isAddress() || !Dest->getType().isAddress()) {
+      return nullptr;
+    } else if (!emitSuccessfulIndirectUnconditionalCast(
+                   Builder, Mod.getSwiftModule(), Loc,
+                   Inst->getConsumptionKind(), Src, SourceType, Dest,
+                   TargetType, Inst)) {
+      // No optimization was possible.
+      return nullptr;
+    }
     EraseInstAction(Inst);
-    Builder.setInsertionPoint(BB);
-    auto *NewI = Builder.createBranch(Loc, SuccessBB);
-    WillSucceedAction();
-    return NewI;
   }
+  SILInstruction *NewI = &BB->back();
+  if (!isa<TermInst>(NewI)) {
+    Builder.setInsertionPoint(BB);
+    NewI = Builder.createBranch(Loc, SuccessBB);
+  }
+  WillSucceedAction();
+  return NewI;
 }
 
 SILInstruction *
@@ -1932,10 +1935,6 @@ CastOptimizer::simplifyCheckedCastBranchInst(CheckedCastBranchInst *Inst) {
                           TargetType,
                           isSourceTypeExact);
 
-  if (Feasibility == DynamicCastFeasibility::MaySucceed) {
-    return nullptr;
-  }
-
   SILBuilderWithScope Builder(Inst);
 
   if (Feasibility == DynamicCastFeasibility::WillFail) {
@@ -1945,39 +1944,45 @@ CastOptimizer::simplifyCheckedCastBranchInst(CheckedCastBranchInst *Inst) {
     return NewI;
   }
 
-  // Casting will succeed.
-
-  // Replace by unconditional_cast, followed by a branch.
-  // The unconditional_cast can be skipped, if the result of a cast
-  // is not used afterwards.
   bool ResultNotUsed = SuccessBB->getArgument(0)->use_empty();
   SILValue CastedValue;
   if (Op->getType() != LoweredTargetType) {
-    if (!ResultNotUsed) {
-      auto Src = Inst->getOperand();
-      auto Dest = SILValue();
-      // To apply the bridged casts optimizations.
-      auto BridgedI = optimizeBridgedCasts(Inst,
-          CastConsumptionKind::CopyOnSuccess, false, Src, Dest, SourceType,
-          TargetType, nullptr, nullptr);
+    auto Src = Inst->getOperand();
+    auto Dest = SILValue();
+    // Apply the bridged cast optimizations.
+    auto BridgedI = optimizeBridgedCasts(Inst,
+        CastConsumptionKind::CopyOnSuccess, false, Src, Dest, SourceType,
+        TargetType, nullptr, nullptr);
 
-      if (BridgedI) {
-        CastedValue = BridgedI;
-      } else {
+    if (BridgedI) {
+      CastedValue = BridgedI;
+    } else {
+      // If the cast may succeed or fail and can't be turned into a bridging
+      // call, then let it be.
+      if (Feasibility == DynamicCastFeasibility::MaySucceed) {
+        return nullptr;
+      }
+      
+      assert(Feasibility == DynamicCastFeasibility::WillSucceed);
+
+      // Replace by unconditional_cast, followed by a branch.
+      // The unconditional_cast can be skipped, if the result of a cast
+      // is not used afterwards.
+      if (!ResultNotUsed) {
         if (!canUseScalarCheckedCastInstructions(Mod, SourceType, TargetType))
           return nullptr;
 
         CastedValue = emitSuccessfulScalarUnconditionalCast(
           Builder, Mod.getSwiftModule(), Loc, Op, LoweredTargetType,
           SourceType, TargetType, Inst);
+      } else {
+        CastedValue = SILUndef::get(LoweredTargetType, Mod);
       }
-
       if (!CastedValue)
         CastedValue =
-            Builder.createUnconditionalCheckedCast(Loc, Op, LoweredTargetType);
-    } else {
-      CastedValue = SILUndef::get(LoweredTargetType, Mod);
+          Builder.createUnconditionalCheckedCast(Loc, Op, LoweredTargetType);
     }
+
   } else {
     // No need to cast.
     CastedValue = Op;
@@ -2011,10 +2016,6 @@ SILInstruction *CastOptimizer::simplifyCheckedCastValueBranchInst(
   auto Feasibility = classifyDynamicCast(Mod.getSwiftModule(), SourceType,
                                          TargetType, isSourceTypeExact);
 
-  if (Feasibility == DynamicCastFeasibility::MaySucceed) {
-    return nullptr;
-  }
-
   SILBuilderWithScope Builder(Inst);
 
   if (Feasibility == DynamicCastFeasibility::WillFail) {
@@ -2026,37 +2027,45 @@ SILInstruction *CastOptimizer::simplifyCheckedCastValueBranchInst(
 
   // Casting will succeed.
 
-  // Replace by unconditional_cast, followed by a branch.
-  // The unconditional_cast can be skipped, if the result of a cast
-  // is not used afterwards.
   bool ResultNotUsed = SuccessBB->getArgument(0)->use_empty();
   SILValue CastedValue;
   if (Op->getType() != LoweredTargetType) {
-    if (!ResultNotUsed) {
-      auto Src = Inst->getOperand();
-      auto Dest = SILValue();
-      // To apply the bridged casts optimizations.
-      auto BridgedI = optimizeBridgedCasts(
-          Inst, CastConsumptionKind::CopyOnSuccess, false, Src, Dest,
-          SourceType, TargetType, nullptr, nullptr);
+    auto Src = Inst->getOperand();
+    auto Dest = SILValue();
+    // Apply the bridged cast optimizations.
+    auto BridgedI = optimizeBridgedCasts(
+        Inst, CastConsumptionKind::CopyOnSuccess, false, Src, Dest,
+        SourceType, TargetType, nullptr, nullptr);
 
-      if (BridgedI) {
-        CastedValue = BridgedI;
-      } else {
-        if (!canUseScalarCheckedCastInstructions(Mod, SourceType, TargetType))
-          return nullptr;
+    if (BridgedI) {
+      CastedValue = BridgedI;
+    } else {
+      // If the cast may succeed or fail and can't be turned into a bridging
+      // call, then let it be.
+      if (Feasibility == DynamicCastFeasibility::MaySucceed) {
+        return nullptr;
+      }
 
+      assert(Feasibility == DynamicCastFeasibility::WillSucceed);
+      
+      // Replace by unconditional_cast, followed by a branch.
+      // The unconditional_cast can be skipped, if the result of a cast
+      // is not used afterwards.
+      
+      if (!canUseScalarCheckedCastInstructions(Mod, SourceType, TargetType))
+        return nullptr;
+
+      if (!ResultNotUsed) {
         CastedValue = emitSuccessfulScalarUnconditionalCast(
             Builder, Mod.getSwiftModule(), Loc, Op, LoweredTargetType,
             SourceType, TargetType, Inst);
+      } else {
+        CastedValue = SILUndef::get(LoweredTargetType, Mod);
       }
-
-      if (!CastedValue)
-        CastedValue = Builder.createUnconditionalCheckedCastValue(
-            Loc, CastConsumptionKind::TakeAlways, Op, LoweredTargetType);
-    } else {
-      CastedValue = SILUndef::get(LoweredTargetType, Mod);
     }
+    if (!CastedValue)
+      CastedValue = Builder.createUnconditionalCheckedCastValue(
+          Loc, CastConsumptionKind::TakeAlways, Op, LoweredTargetType);
   } else {
     // No need to cast.
     CastedValue = Op;
@@ -2322,10 +2331,6 @@ optimizeUnconditionalCheckedCastInst(UnconditionalCheckedCastInst *Inst) {
                           Inst->getTargetType(),
                           isSourceTypeExact);
 
-  if (Feasibility == DynamicCastFeasibility::MaySucceed) {
-    return nullptr;
-  }
-
   if (Feasibility == DynamicCastFeasibility::WillFail) {
     // Remove the cast and insert a trap, followed by an
     // unreachable instruction.
@@ -2352,43 +2357,51 @@ optimizeUnconditionalCheckedCastInst(UnconditionalCheckedCastInst *Inst) {
       WillSucceedAction();
       return nullptr;
     }
+  }
 
-    SILBuilderWithScope Builder(Inst);
+  SILBuilderWithScope Builder(Inst);
 
-    // Try to apply the bridged casts optimizations
-    auto SourceType = LoweredSourceType.getSwiftRValueType();
-    auto TargetType = LoweredTargetType.getSwiftRValueType();
-    auto Src = Inst->getOperand();
-    auto NewI = optimizeBridgedCasts(Inst, CastConsumptionKind::CopyOnSuccess,
-                                     false, Src, SILValue(), SourceType,
-                                     TargetType, nullptr, nullptr);
-    if (NewI) {
-      ReplaceInstUsesAction(Inst, NewI);
-      EraseInstAction(Inst);
-      WillSucceedAction();
-      return NewI;
-    }
-
-    if (isBridgingCast(SourceType, TargetType))
-      return nullptr;
-
-    auto Result = emitSuccessfulScalarUnconditionalCast(Builder,
-                      Mod.getSwiftModule(), Loc, Op,
-                      LoweredTargetType,
-                      LoweredSourceType.getSwiftRValueType(),
-                      LoweredTargetType.getSwiftRValueType(),
-                      Inst);
-
-    if (!Result) {
-      // No optimization was possible.
-      return nullptr;
-    }
-
-    ReplaceInstUsesAction(Inst, Result);
+  // Try to apply the bridged casts optimizations
+  auto SourceType = LoweredSourceType.getSwiftRValueType();
+  auto TargetType = LoweredTargetType.getSwiftRValueType();
+  auto Src = Inst->getOperand();
+  auto NewI = optimizeBridgedCasts(Inst, CastConsumptionKind::CopyOnSuccess,
+                                   false, Src, SILValue(), SourceType,
+                                   TargetType, nullptr, nullptr);
+  if (NewI) {
+    ReplaceInstUsesAction(Inst, NewI);
     EraseInstAction(Inst);
     WillSucceedAction();
-    return Result;
+    return NewI;
   }
+
+  // If the cast may succeed or fail and can't be optimized into a bridging
+  // call, let it be.
+  if (Feasibility == DynamicCastFeasibility::MaySucceed) {
+    return nullptr;
+  }
+  
+  assert(Feasibility == DynamicCastFeasibility::WillSucceed);
+
+  if (isBridgingCast(SourceType, TargetType))
+    return nullptr;
+
+  auto Result = emitSuccessfulScalarUnconditionalCast(Builder,
+                    Mod.getSwiftModule(), Loc, Op,
+                    LoweredTargetType,
+                    LoweredSourceType.getSwiftRValueType(),
+                    LoweredTargetType.getSwiftRValueType(),
+                    Inst);
+
+  if (!Result) {
+    // No optimization was possible.
+    return nullptr;
+  }
+
+  ReplaceInstUsesAction(Inst, Result);
+  EraseInstAction(Inst);
+  WillSucceedAction();
+  return Result;
 
   return nullptr;
 }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3559,7 +3559,7 @@ ConstraintSystem::simplifyBridgingConstraint(Type type1,
       // We accepted these coercions in Swift 3 mode, so we have to live with
       // them (but give a warning) in that language mode.
       if (!TC.Context.LangOpts.isSwiftVersion3()
-          && TC.isObjCClassWithMultipleSwiftBridgedTypes(objcClass, DC))
+          && TC.Context.isObjCClassWithMultipleSwiftBridgedTypes(objcClass))
         return SolutionKind::Error;
 
       // If the bridged value type is generic, the generic arguments

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -3435,7 +3435,7 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
   if (Context.LangOpts.isSwiftVersion3() && extraFromOptionals == 0) {
     // Do the check for a bridging conversion now that we deferred above.
     if (isObjCBridgedTo(fromType, toType, dc, &unwrappedIUO) && !unwrappedIUO) {
-      if (isObjCClassWithMultipleSwiftBridgedTypes(fromType, dc)) {
+      if (Context.isObjCClassWithMultipleSwiftBridgedTypes(fromType)) {
         return CheckedCastKind::Swift3BridgingDowncast;
       }
       return CheckedCastKind::BridgingCoercion;

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -171,33 +171,6 @@ Type TypeChecker::getNSErrorType(DeclContext *dc) {
                                   dc);
 }
 
-Type TypeChecker::getNSNumberType(DeclContext *dc) {
-  return getObjectiveCNominalType(*this, NSNumberType, Context.Id_Foundation,
-                                  Context.getSwiftId(
-                                               KnownFoundationEntity::NSNumber),
-                                  dc);
-}
-
-Type TypeChecker::getNSValueType(DeclContext *dc) {
-  return getObjectiveCNominalType(*this, NSValueType, Context.Id_Foundation,
-                                  Context.getSwiftId(
-                                               KnownFoundationEntity::NSValue),
-                                  dc);
-}
-
-bool TypeChecker::isObjCClassWithMultipleSwiftBridgedTypes(Type t,
-                                                           DeclContext *dc) {
-  if (auto nsNumber = getNSNumberType(dc)) {
-    if (t->isEqual(nsNumber))
-      return true;
-  }
-  if (auto nsValue = getNSValueType(dc)) {
-    if (t->isEqual(nsValue))
-      return true;
-  }
-  return false;
-}
-
 Type TypeChecker::getObjCSelectorType(DeclContext *dc) {
   return getObjectiveCNominalType(*this, ObjCSelectorType,
                                   Context.Id_ObjectiveC,

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -883,14 +883,9 @@ public:
   Type getUInt8Type(DeclContext *dc);
   Type getNSObjectType(DeclContext *dc);
   Type getNSErrorType(DeclContext *dc);
-  Type getNSNumberType(DeclContext *dc);
-  Type getNSValueType(DeclContext *dc);
   Type getObjCSelectorType(DeclContext *dc);
   Type getExceptionType(DeclContext *dc, SourceLoc loc);
   
-  /// True if `t` is an ObjC class that multiple Swift value types bridge into.
-  bool isObjCClassWithMultipleSwiftBridgedTypes(Type t, DeclContext *dc);
-
   /// \brief Try to resolve an IdentTypeRepr, returning either the referenced
   /// Type or an ErrorType in case of error.
   Type resolveIdentifierType(DeclContext *DC,

--- a/test/SILOptimizer/cast_folding_objc_bridging_conditional.sil
+++ b/test/SILOptimizer/cast_folding_objc_bridging_conditional.sil
@@ -1,0 +1,31 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-sil %s | %FileCheck %s
+// REQUIRES: objc_interop
+
+sil_stage raw
+
+import Swift
+import Foundation
+
+struct MyError: Error {}
+
+// CHECK-LABEL: sil @cast_nserror_to_specific_error
+sil @cast_nserror_to_specific_error : $@convention(thin) (@in NSError, @in NSNumber, @in NSValue) -> () {
+entry(%0 : $*NSError, %1 : $*NSNumber, %2 : $*NSValue):
+  %f = function_ref @use : $@convention(thin) <T> (@in T) -> ()
+  %a = alloc_stack $MyError
+  // CHECK: checked_cast_addr_br {{.*}} NSError {{.*}} to MyError
+  checked_cast_addr_br take_always NSError in %0 : $*NSError to MyError in %a : $*MyError, yes, no
+
+yes:
+  apply %f<MyError>(%a) : $@convention(thin) <T> (@in T) -> ()
+  br done
+
+no:
+  br done
+
+done:
+  dealloc_stack %a : $*MyError
+  return undef : $()
+}
+
+sil @use : $@convention(thin) <T> (@in T) -> ()


### PR DESCRIPTION
Explanation: When casting from an object type to a bridged Swift value type, classifyDynamicCast would use the cast classification for the target type's bridged object type, which would be trivially WillSucceed for thinks like NSNumber-to-Int or NSError-to-SomeError, even though the bridging itself could fail.

Scope: `nsError as? SwiftError` casts would miscompile as unconditional casts, crashing the program if the cast failed. This is also a lurking bug in classifying casts from NSNumber or NSValue, though in those cases another optimizer pass that turns the casts into bridging calls fires first and manages to do the right thing. This is reported as a regression from 3.0.

Issue: SR-2920, rdar://problem/31404281

Risk: Low

Testing: Swift CI, Test case from Jira
