### PR TITLE
[QoI] Unify member diagnostics into one FailureDiagnosis method

### DIFF
--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -222,8 +222,7 @@ struct StructWithOptionalArray {
 }
 
 func testStructWithOptionalArray(_ foo: StructWithOptionalArray) -> Int {
-  // TODO: Restore regressed diagnostics rdar://problem/31724211
-  return foo.array[0]  // expected-error {{}}
+  return foo.array[0]  // expected-error {{value of optional type '[Int]?' not unwrapped; did you mean to use '!' or '?'?}} {{19-19=!}}
 }
 
 

--- a/test/Sema/typo_correction.swift
+++ b/test/Sema/typo_correction.swift
@@ -82,7 +82,7 @@ func test_too_many_but_some_better() {
 // type variables.
 _ = [Any]().withUnsafeBufferPointer { (buf) -> [Any] in
   guard let base = buf.baseAddress else { return [] }
-  return (base ..< base + buf.count).m // expected-error {{value of type 'CountableRange<_>' has no member 'm'}}
+  return (base ..< base + buf.count).m // expected-error {{value of type 'CountableRange<UnsafePointer<Any>>' has no member 'm'}}
 }
 
 // Typo correction with class-bound archetypes.

--- a/test/expr/unary/selector/selector.swift
+++ b/test/expr/unary/selector/selector.swift
@@ -115,10 +115,7 @@ func testParseErrors3(_ c1: C1) {
 }
 
 func testParseErrors4() {
-  // Subscripts
-  // TODO: rdar://problem/31724211 -- improve diagnostic regression from
-  // global keypath subscripts
-  _ = #selector(C1.subscript) // expected-error{{}}
+  _ = #selector(C1.subscript) // expected-error{{type 'C1.Type' has no subscript members}}
 }
 
 // SR-1827


### PR DESCRIPTION
This changes aim to unify logic behind member diagnostics 
into a single method instead of maintaining different versions
in `visitUnresolvedMemberExpr`, `visitSubscriptExpr`, 
`visitUnresolvedDotExpr` and `diagnoseGeneralMemberFailure`.
Since all of aforementioned methods do the same thing, with
minor expression specific differences, it makes sense to put
most of the logic into a single place and provide appropriate
callbacks to implement expression specific logic.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
