### PR TITLE
[swiftc (32 vs. 5526)] Add crasher in swift::constraints::ConstraintSystem::resolveOverload

### DIFF
--- a/validation-test/compiler_crashers/28749-reftype-hastypeparameter-cannot-have-a-dependent-type-here.swift
+++ b/validation-test/compiler_crashers/28749-reftype-hastypeparameter-cannot-have-a-dependent-type-here.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+@objc protocol P{struct B{let c=a{}}typealias a{}typealias a


### PR DESCRIPTION
Add test case for crash triggered in `swift::constraints::ConstraintSystem::resolveOverload`.

Current number of unresolved compiler crashers: 32 (5526 resolved)

/cc @DougGregor - just wanted to let you know that this crasher caused an assertion failure for the assertion `!refType->hasTypeParameter() && "Cannot have a dependent type here"` added on 2015-07-07 by you in commit 3023a710 :-)

Assertion failure in [`lib/Sema/ConstraintSystem.cpp (line 1533)`](https://github.com/apple/swift/blob/3dd78ac537966fa186396c2b121dd611640b7118/lib/Sema/ConstraintSystem.cpp#L1533):

```
Assertion `!refType->hasTypeParameter() && "Cannot have a dependent type here"' failed.

When executing: void swift::constraints::ConstraintSystem::resolveOverload(swift::constraints::ConstraintLocator *, swift::Type, swift::constraints::OverloadChoice, swift::DeclContext *)
```

Assertion context:

```c++

    // Increase the score so that actual subscripts get preference.
    increaseScore(SK_KeyPathSubscript);
  }
  }
  assert(!refType->hasTypeParameter() && "Cannot have a dependent type here");

  // If we're binding to an init member, the 'throws' need to line up between
  // the bound and reference types.
  if (choice.isDecl()) {
    auto decl = choice.getDecl();
```
Stack trace:

```
0 0x0000000003a3a088 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3a3a088)
1 0x0000000003a3a7c6 SignalHandler(int) (/path/to/swift/bin/swift+0x3a3a7c6)
2 0x00007fe2a44b2390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007fe2a29d8428 gsignal /build/glibc-9tT8Do/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007fe2a29da02a abort /build/glibc-9tT8Do/glibc-2.23/stdlib/abort.c:91:0
5 0x00007fe2a29d0bd7 __assert_fail_base /build/glibc-9tT8Do/glibc-2.23/assert/assert.c:92:0
6 0x00007fe2a29d0c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x00000000012f7580 swift::constraints::ConstraintSystem::resolveOverload(swift::constraints::ConstraintLocator*, swift::Type, swift::constraints::OverloadChoice, swift::DeclContext*) (/path/to/swift/bin/swift+0x12f7580)
8 0x00000000012c8570 swift::constraints::ConstraintSystem::simplifyConstraint(swift::constraints::Constraint const&) (/path/to/swift/bin/swift+0x12c8570)
9 0x00000000012d62b8 swift::constraints::ConstraintSystem::solveSimplified(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0x12d62b8)
10 0x00000000012cdd55 swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0x12cdd55)
11 0x00000000012cd712 swift::constraints::ConstraintSystem::solve(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0x12cd712)
12 0x00000000012d0a48 swift::constraints::ConstraintSystem::solve(swift::Expr*&, swift::Type, swift::ExprTypeCheckListener*, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0x12d0a48)
13 0x00000000013098c4 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0x13098c4)
14 0x000000000130d326 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x130d326)
15 0x0000000001311411 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*, bool) (/path/to/swift/bin/swift+0x1311411)
16 0x00000000013115d6 swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int, bool) (/path/to/swift/bin/swift+0x13115d6)
17 0x0000000001329718 validatePatternBindingEntries(swift::TypeChecker&, swift::PatternBindingDecl*) (/path/to/swift/bin/swift+0x1329718)
18 0x0000000001323bcd (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x1323bcd)
19 0x000000000133453b (anonymous namespace)::DeclChecker::visitStructDecl(swift::StructDecl*) (/path/to/swift/bin/swift+0x133453b)
20 0x0000000001323b74 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x1323b74)
21 0x000000000133574b (anonymous namespace)::DeclChecker::visitProtocolDecl(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0x133574b)
22 0x0000000001323b84 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x1323b84)
23 0x0000000001323a93 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x1323a93)
24 0x00000000013ad885 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x13ad885)
25 0x0000000000f84766 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf84766)
26 0x00000000004aa580 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4aa580)
27 0x00000000004a8c6b swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a8c6b)
28 0x00000000004656d7 main (/path/to/swift/bin/swift+0x4656d7)
29 0x00007fe2a29c3830 __libc_start_main /build/glibc-9tT8Do/glibc-2.23/csu/../csu/libc-start.c:325:0
30 0x0000000000462d79 _start (/path/to/swift/bin/swift+0x462d79)
```