### PR TITLE
Remove conditional compilation from maybeScopeless, because SILVerifier is not conditionally compiled anymore

### DIFF
--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -4417,11 +4417,9 @@ void SILModule::verify() const {
   }
 }
 
-#ifndef NDEBUG
 /// Determine whether an instruction may not have a SILDebugScope.
 bool swift::maybeScopeless(SILInstruction &I) {
   if (I.getFunction()->isBare())
     return true;
   return !isa<DebugValueInst>(I) && !isa<DebugValueAddrInst>(I);
 }
-#endif


### PR DESCRIPTION
This should unbreak the no-asserts builds