### PR TITLE
Inliner improvements

### DIFF
--- a/include/swift/SILOptimizer/Utils/PerformanceInlinerUtils.h
+++ b/include/swift/SILOptimizer/Utils/PerformanceInlinerUtils.h
@@ -24,6 +24,24 @@
 
 using namespace swift;
 
+extern llvm::cl::opt<bool> EnableSILInliningOfGenerics;
+
+namespace swift {
+
+// Controls the decision to inline functions with @_semantics, @effect and
+// global_init attributes.
+enum class InlineSelection {
+  Everything,
+  NoGlobalInit, // and no availability semantics calls
+  NoSemanticsAndGlobalInit
+};
+
+// Returns the callee of an apply_inst if it is basically inlineable.
+SILFunction *getEligibleFunction(FullApplySite AI,
+                                 InlineSelection WhatToInline);
+
+} // end swift namespace
+
 //===----------------------------------------------------------------------===//
 //                               ConstantTracker
 //===----------------------------------------------------------------------===//

--- a/include/swift/SILOptimizer/Utils/PerformanceInlinerUtils.h
+++ b/include/swift/SILOptimizer/Utils/PerformanceInlinerUtils.h
@@ -27,6 +27,7 @@ using namespace swift;
 extern llvm::cl::opt<bool> EnableSILInliningOfGenerics;
 
 namespace swift {
+class SideEffectAnalysis;
 
 // Controls the decision to inline functions with @_semantics, @effect and
 // global_init attributes.
@@ -40,6 +41,9 @@ enum class InlineSelection {
 SILFunction *getEligibleFunction(FullApplySite AI,
                                  InlineSelection WhatToInline);
 
+// Returns true if this is a pure call, i.e. the callee has no side-effects
+// and all arguments are constants.
+bool isPureCall(FullApplySite AI, SideEffectAnalysis *SEA);
 } // end swift namespace
 
 //===----------------------------------------------------------------------===//

--- a/test/SILOptimizer/functionsigopts.sil
+++ b/test/SILOptimizer/functionsigopts.sil
@@ -68,6 +68,17 @@ sil @use_Int64 : $@convention(thin) (Int64) -> ()
 sil @use_Generic : $@convention(thin) <T>(@in_guaranteed T) -> ()
 
 
+sil_global public @sil_global1 : $Builtin.Int32
+
+sil @update_global: $@convention(thin) () -> () {
+bb0:
+  %sil_global1_addr = global_addr @sil_global1 : $*Builtin.Int32
+  %1 = integer_literal $Builtin.Int32, 1
+  store %1 to %sil_global1_addr : $*Builtin.Int32
+  %4 = tuple ()
+  return %4 : $()
+}
+
 // CHECK-LABEL: sil [thunk] [always_inline] @argument_with_incomplete_epilogue_release
 // CHECK: [[IN2:%.*]] = struct_extract [[IN1:%.*]] : $goo, #goo.top
 // CHECK: function_ref @_T041argument_with_incomplete_epilogue_releaseTf4x_nTf4gn_n : $@convention(thin) (@guaranteed foo, @owned foo) -> ()
@@ -328,6 +339,8 @@ bb0(%0 : $boo):
   %3 = struct_extract %1 : $baz, #baz.end
   release_value  %2 : $foo
   release_value  %3 : $foo
+  %f = function_ref @update_global: $@convention(thin) () -> ()
+  apply %f() : $@convention(thin) () -> ()
   %4 = tuple ()
   return %4 : $()
 }
@@ -1460,6 +1473,10 @@ bb0(%0 : $Builtin.Int32):
 
   %1 = function_ref @s1 : $@convention(thin) (Builtin.Int32) -> ()
   apply %1(%0) : $@convention(thin) (Builtin.Int32) -> ()
+
+  %f = function_ref @update_global: $@convention(thin) () -> ()
+  apply %f() : $@convention(thin) () -> ()
+
   %9999 = tuple()
   return %9999 : $()
 }

--- a/test/SILOptimizer/inliner_coldblocks.sil
+++ b/test/SILOptimizer/inliner_coldblocks.sil
@@ -7,6 +7,17 @@ import Builtin
 import Swift
 import SwiftShims
 
+sil_global public @sil_global1 : $Builtin.Int32
+
+sil @update_global: $@convention(thin) () -> () {
+bb0:
+  %sil_global1_addr = global_addr @sil_global1 : $*Builtin.Int32
+  %1 = integer_literal $Builtin.Int32, 1
+  store %1 to %sil_global1_addr : $*Builtin.Int32
+  %4 = tuple ()
+  return %4 : $()
+}
+
 sil @callee : $@convention(thin) () -> () {
 bb0:
   // make it a non-trivial function
@@ -172,6 +183,10 @@ bb0:
   %c28 = builtin "assert_configuration"() : $Builtin.Int32
   %c29 = builtin "assert_configuration"() : $Builtin.Int32
   %c30 = builtin "assert_configuration"() : $Builtin.Int32
+
+  %f = function_ref @update_global: $@convention(thin) () -> ()
+  apply %f() : $@convention(thin) () -> ()
+
   %r = tuple ()
   return %r : $()
 }


### PR DESCRIPTION
- Move some functionality from PerformanceInliner into PerformanceInlinerUtils to make it re-usable by other optimization passes.
- Always inline pure functions (i.e. no side-effects) with constant arguments. If there is a call of a pure function with constant arguments, it always makes sense to inline it, because we know that the whole computation will be constant folded.