### PR TITLE
Revert "[Exclusivity] Check that accesses are well-formed during diagnostics."

### DIFF
--- a/test/SILOptimizer/exclusivity_static_diagnostics.sil
+++ b/test/SILOptimizer/exclusivity_static_diagnostics.sil
@@ -462,15 +462,3 @@ bb23:
 bbUnreachable:
   br bb22
 }
-
-// Check that a pointer_to_address access passes diagnostics.
-//
-// CHECK-LABEL: sil hidden  @pointerToAddr
-sil hidden  @pointerToAddr : $@convention(thin) (Builtin.RawPointer) -> Int {
-bb0(%0: $Builtin.RawPointer):
-  %adr = pointer_to_address %0 : $Builtin.RawPointer to [strict] $*Int
-  %access = begin_access [read] [dynamic] %adr : $*Int
-  %val = load [trivial] %access : $*Int
-  end_access %access : $*Int
-  return %val : $Int
-}


### PR DESCRIPTION
Reverts apple/swift#9520

This assertion triggers during -enforce-exclusivity-checked testing. I'll work on fixing those.