### PR TITLE
Speculative optimization: wider decoding buffers

### DIFF
--- a/stdlib/public/core/UIntBuffer.swift
+++ b/stdlib/public/core/UIntBuffer.swift
@@ -16,9 +16,12 @@
 //===----------------------------------------------------------------------===//
 @_fixed_layout
 public struct _UIntBuffer<
-  Storage: UnsignedInteger & FixedWidthInteger, 
-  Element: UnsignedInteger & FixedWidthInteger
+  Storage_: UnsignedInteger & FixedWidthInteger, 
+  Element_: UnsignedInteger & FixedWidthInteger
 > {
+  public typealias Storage = Storage_
+  public typealias Element = Element_
+  
   public var _storage: Storage
   public var _bitCount: UInt8
 

--- a/stdlib/public/core/UTF16.swift
+++ b/stdlib/public/core/UTF16.swift
@@ -95,13 +95,13 @@ extension _Unicode.UTF16 : UnicodeEncoding {
   }
   
   public struct ForwardParser {
-    public typealias _Buffer = _UIntBuffer<UInt32, UInt16>
+    public typealias _Buffer = _UIntBuffer<UInt64, UInt16>
     public init() { _buffer = _Buffer() }
     public var _buffer: _Buffer
   }
   
   public struct ReverseParser {
-    public typealias _Buffer = _UIntBuffer<UInt32, UInt16>
+    public typealias _Buffer = _UIntBuffer<UInt64, UInt16>
     public init() { _buffer = _Buffer() }
     public var _buffer: _Buffer
   }

--- a/stdlib/public/core/UTF16.swift
+++ b/stdlib/public/core/UTF16.swift
@@ -120,11 +120,9 @@ extension UTF16.ReverseParser : UnicodeParser, _UTFParser {
   }
   
   public func _bufferedScalar(bitCount: UInt8) -> Encoding.EncodedScalar {
+    let s = UInt32(extendingOrTruncating: _buffer._storage)
     return Encoding.EncodedScalar(
-      _storage:
-        (_buffer._storage &<< 16 | _buffer._storage &>> 16) &>> (32 - bitCount),
-      _bitCount: bitCount
-    )
+      _storage: (s &<< 16 | s &>> 16) &>> (32 - bitCount), _bitCount: bitCount)
   }
 }
 
@@ -141,8 +139,7 @@ extension _Unicode.UTF16.ForwardParser : UnicodeParser, _UTFParser {
   }
   
   public func _bufferedScalar(bitCount: UInt8) -> Encoding.EncodedScalar {
-    var r = _buffer
-    r._bitCount = bitCount
-    return r
+    let s = UInt32(extendingOrTruncating: _buffer._storage)
+    return Encoding.EncodedScalar(_storage: s, _bitCount: bitCount)
   }
 }

--- a/stdlib/public/core/UTF8.swift
+++ b/stdlib/public/core/UTF8.swift
@@ -210,8 +210,9 @@ extension UTF8.ReverseParser : UnicodeParser, _UTFParser {
   @inline(__always)
   @_inlineable
   public func _bufferedScalar(bitCount: UInt8) -> Encoding.EncodedScalar {
+    let s = UInt32(extendingOrTruncating: _buffer._storage)
     return Encoding.EncodedScalar(
-      _storage: _buffer._storage.byteSwapped &>> (32 - bitCount),
+      _storage: s.byteSwapped &>> (32 - bitCount),
       _bitCount: bitCount
     )
   }
@@ -280,8 +281,9 @@ extension _Unicode.UTF8.ForwardParser : UnicodeParser, _UTFParser {
   }
   
   public func _bufferedScalar(bitCount: UInt8) -> Encoding.EncodedScalar {
-    var r = _buffer
-    r._bitCount = bitCount
+    let r = Encoding.EncodedScalar(
+      _storage: UInt32(extendingOrTruncating: _buffer._storage),
+      _bitCount: bitCount)
     return r
   }
 }

--- a/stdlib/public/core/UTF8.swift
+++ b/stdlib/public/core/UTF8.swift
@@ -123,7 +123,7 @@ extension _Unicode.UTF8 : UnicodeEncoding {
 
   @_fixed_layout
   public struct ForwardParser {
-    public typealias _Buffer = _UIntBuffer<UInt32, UInt8>
+    public typealias _Buffer = _UIntBuffer<UInt64, UInt8>
     @inline(__always)
     @_inlineable
     public init() { _buffer = _Buffer() }
@@ -132,7 +132,7 @@ extension _Unicode.UTF8 : UnicodeEncoding {
   
   @_fixed_layout
   public struct ReverseParser {
-    public typealias _Buffer = _UIntBuffer<UInt32, UInt8>
+    public typealias _Buffer = _UIntBuffer<UInt64, UInt8>
     @inline(__always)
     @_inlineable
     public init() { _buffer = _Buffer() }

--- a/stdlib/public/core/UTFEncoding.swift
+++ b/stdlib/public/core/UTFEncoding.swift
@@ -71,9 +71,10 @@ where Encoding.EncodedScalar == _UIntBuffer<UInt32, Encoding.CodeUnit> {
     
     // Consume the decoded bytes (or maximal subpart of ill-formed sequence).
     let encodedScalar = _bufferedScalar(bitCount: scalarBitCount)
-    
-    _buffer._storage = UInt32(
-      // widen to 64 bits so that we can empty the buffer in the 4-byte case
+
+    _buffer._storage = type(of: _buffer._storage).init(
+      // Widen to 64 bits so that we can empty a 32-bit buffer in the 4-byte
+      // case.
       extendingOrTruncating: UInt64(_buffer._storage) &>> scalarBitCount)
       
     _buffer._bitCount = _buffer._bitCount &- scalarBitCount

--- a/stdlib/public/core/UTFEncoding.swift
+++ b/stdlib/public/core/UTFEncoding.swift
@@ -22,7 +22,7 @@ public protocol _UTFParser {
   func _parseMultipleCodeUnits() -> (isValid: Bool, bitCount: UInt8)
   func _bufferedScalar(bitCount: UInt8) -> _UIntBuffer<UInt32, Encoding.CodeUnit>
   
-  var _buffer: _UIntBuffer<UInt32, Encoding.CodeUnit> { get set }
+  var _buffer: _UIntBuffer<UInt64, Encoding.CodeUnit> { get set }
 }
 
 extension _UTFParser

--- a/stdlib/public/core/Unicode.swift
+++ b/stdlib/public/core/Unicode.swift
@@ -228,7 +228,7 @@ extension _Unicode.UTF8 : UnicodeCodec {
       return (value, 1)
     }
     var p = ForwardParser()
-    p._buffer._storage = buffer
+    p._buffer._storage = ForwardParser._Buffer.Storage(buffer)
     p._buffer._bitCount = 32
     var i = EmptyCollection<UInt8>().makeIterator()
     switch p.parseScalar(from: &i) {


### PR DESCRIPTION
This changes the buffers to 64 bits everywhere.  There's a good chance we want 32 bits on 32-bit platforms, but this will give us a read on whether there's any win to be had.