### PR TITLE
Make maybeScopeless declaration unconditionally available

### DIFF
--- a/include/swift/SIL/SILDebugScope.h
+++ b/include/swift/SIL/SILDebugScope.h
@@ -70,10 +70,8 @@ public:
 #endif
 };
 
-#ifndef NDEBUG
 /// Determine whether an instruction may not have a SILDebugScope.
 bool maybeScopeless(SILInstruction &I);
-#endif
 
 /// Knows how to make a deep copy of a debug scope.
 class ScopeCloner {


### PR DESCRIPTION
I forgot to do it when I made the implementation of maybeScopeless unconditionally available.