### PR TITLE
[DO NOT MERGE] Speculative optimization: inline many Iterator.next() impls

### DIFF
--- a/stdlib/public/SDK/Dispatch/Data.swift
+++ b/stdlib/public/SDK/Dispatch/Data.swift
@@ -315,6 +315,7 @@ public struct DispatchDataIterator : IteratorProtocol, Sequence {
 
 	/// Advance to the next element and return it, or `nil` if no next
 	/// element exists.
+  @inline(__always)
 	public mutating func next() -> DispatchData._Element? {
 		if _position == _count { return nil }
 		let element = _ptr.load(fromByteOffset: _position, as: UInt8.self)
@@ -323,8 +324,11 @@ public struct DispatchDataIterator : IteratorProtocol, Sequence {
 	}
 
 	internal let _data: __DispatchData
+  @_versioned
 	internal var _ptr: UnsafeRawPointer!
+  @_versioned
 	internal var _count: Int
+  @_versioned
 	internal var _position: DispatchData.Index
 }
 

--- a/stdlib/public/core/Algorithm.swift
+++ b/stdlib/public/core/Algorithm.swift
@@ -114,6 +114,7 @@ public struct EnumeratedIterator<
   ///
   /// Once `nil` has been returned, all subsequent calls return `nil`.
   @_inlineable
+  @inline(__always)
   public mutating func next() -> Element? {
     guard let b = _base.next() else { return nil }
     let result = (offset: _count, element: b)

--- a/stdlib/public/core/BridgeObjectiveC.swift
+++ b/stdlib/public/core/BridgeObjectiveC.swift
@@ -553,6 +553,7 @@ internal struct _CocoaFastEnumerationStackBuf {
   internal var _item15: UnsafeRawPointer?
 
   @_transparent
+  @_versioned
   internal var count: Int {
     return 16
   }

--- a/stdlib/public/core/Character.swift
+++ b/stdlib/public/core/Character.swift
@@ -276,6 +276,7 @@ public struct Character :
         self._data = data
       }
 
+      @inline(__always)
       internal mutating func next() -> UInt8? {
         let result = UInt8(extendingOrTruncating: _data)
         if result == 0xFF {

--- a/stdlib/public/core/ClosedRange.swift
+++ b/stdlib/public/core/ClosedRange.swift
@@ -115,6 +115,7 @@ public struct ClosedRangeIterator<Bound> : IteratorProtocol, Sequence
   }
 
   @_inlineable
+  @inline(__always)
   public mutating func next() -> Bound? {
     let r = _nextResult
     if let x = r {

--- a/stdlib/public/core/CollectionOfOne.swift
+++ b/stdlib/public/core/CollectionOfOne.swift
@@ -26,12 +26,14 @@ public struct IteratorOverOne<Element> : IteratorProtocol, Sequence {
   ///
   /// - Precondition: `next()` has not been applied to a copy of `self`
   ///   since the copy was made.
+  @inline(__always)
   public mutating func next() -> Element? {
     let result = _elements
     _elements = nil
     return result
   }
 
+  @_versioned
   internal var _elements: Element?
 }
 

--- a/stdlib/public/core/DropWhile.swift.gyb
+++ b/stdlib/public/core/DropWhile.swift.gyb
@@ -28,6 +28,7 @@ from gyb_stdlib_support import (
 public struct LazyDropWhileIterator<Base : IteratorProtocol> :
   IteratorProtocol, Sequence {
 
+  @inline(__always)
   public mutating func next() -> Base.Element? {
     // Once the predicate has failed for the first time, the base iterator
     // can be used for the rest of the elements.
@@ -51,8 +52,11 @@ public struct LazyDropWhileIterator<Base : IteratorProtocol> :
     self._predicate = predicate
   }
 
+  @_versioned
   internal var _predicateHasFailed = false
+  @_versioned
   internal var _base: Base
+  @_versioned
   internal let _predicate: (Base.Element) -> Bool
 }
 

--- a/stdlib/public/core/EmptyCollection.swift
+++ b/stdlib/public/core/EmptyCollection.swift
@@ -25,6 +25,7 @@ public struct EmptyIterator<Element> : IteratorProtocol, Sequence {
   public init() {}
 
   /// Returns `nil`, indicating that there are no more elements.
+  @inline(__always)
   public mutating func next() -> Element? {
     return nil
   }

--- a/stdlib/public/core/ExistentialCollection.swift.gyb
+++ b/stdlib/public/core/ExistentialCollection.swift.gyb
@@ -103,6 +103,7 @@ public struct AnyIterator<Element> : IteratorProtocol {
   ///
   /// Once `nil` has been returned, all subsequent calls return `nil`.
   @_inlineable
+  @inline(__always)
   public func next() -> Element? {
     return _box.next()
   }
@@ -125,6 +126,7 @@ internal struct _ClosureBasedIterator<Element> : IteratorProtocol {
   }
   @_inlineable
   @_versioned
+  @inline(__always)
   internal func next() -> Element? { return _body() }
   @_versioned
   internal let _body: () -> Element?
@@ -140,6 +142,7 @@ internal class _AnyIteratorBoxBase<Element> : IteratorProtocol {
   ///
   /// - Note: Subclasses must override this method.
   @_versioned
+  @inline(__always)
   internal func next() -> Element? { _abstract() }
 }
 
@@ -153,6 +156,7 @@ internal final class _IteratorBox<
   internal init(_ base: Base) { self._base = base }
   @_inlineable
   @_versioned
+  @inline(__always)
   internal override func next() -> Base.Element? { return _base.next() }
   @_versioned
   internal var _base: Base

--- a/stdlib/public/core/Filter.swift.gyb
+++ b/stdlib/public/core/Filter.swift.gyb
@@ -32,6 +32,7 @@ public struct LazyFilterIterator<
   ///
   /// - Precondition: `next()` has not been applied to a copy of `self`
   ///   since the copy was made.
+  @inline(__always)
   public mutating func next() -> Base.Element? {
     while let n = _base.next() {
       if _predicate(n) {
@@ -54,10 +55,12 @@ public struct LazyFilterIterator<
   /// The underlying iterator whose elements are being filtered.
   public var base: Base { return _base }
 
+  @_versioned
   internal var _base: Base
 
   /// The predicate used to determine which elements produced by
   /// `base` are also produced by `self`.
+  @_versioned
   internal let _predicate: (Base.Element) -> Bool
 }
 

--- a/stdlib/public/core/Flatten.swift.gyb
+++ b/stdlib/public/core/Flatten.swift.gyb
@@ -41,6 +41,7 @@ public struct FlattenIterator<Base : IteratorProtocol> : IteratorProtocol, Seque
   ///
   /// - Precondition: `next()` has not been applied to a copy of `self`
   ///   since the copy was made.
+  @inline(__always)
   public mutating func next() -> Base.Element.Iterator.Element? {
     repeat {
       if _fastPath(_inner != nil) {
@@ -58,7 +59,9 @@ public struct FlattenIterator<Base : IteratorProtocol> : IteratorProtocol, Seque
     while true
   }
 
+  @_versioned
   internal var _base: Base
+  @_versioned
   internal var _inner: Base.Element.Iterator?
 }
 

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -273,10 +273,13 @@ internal func _stdlib_NSObject_isEqual(_ lhs: AnyObject, _ rhs: AnyObject) -> Bo
 ///
 /// Accesses the underlying raw memory as Unmanaged<AnyObject> using untyped
 /// memory accesses. The memory remains bound to managed AnyObjects.
+@_versioned
 internal struct _UnmanagedAnyObjectArray {
   /// Underlying pointer.
+  @_versioned
   internal var value: UnsafeMutableRawPointer
 
+  @_versioned
   internal init(_ up: UnsafeMutablePointer<AnyObject>) {
     self.value = UnsafeMutableRawPointer(up)
   }
@@ -286,6 +289,7 @@ internal struct _UnmanagedAnyObjectArray {
     self.init(unwrapped)
   }
 
+  @_versioned
   internal subscript(i: Int) -> AnyObject {
     get {
       let unmanaged = value.load(
@@ -5506,21 +5510,26 @@ final internal class _Cocoa${Self}Iterator : IteratorProtocol {
 
   // This stored property should be stored at offset zero.  There's code below
   // relying on this.
+  @_versioned
   internal var _fastEnumerationState: _SwiftNSFastEnumerationState =
     _makeSwiftNSFastEnumerationState()
 
   // This stored property should be stored right after `_fastEnumerationState`.
   // There's code below relying on this.
+  @_versioned
   internal var _fastEnumerationStackBuf = _CocoaFastEnumerationStackBuf()
 
+  @_versioned
   internal let cocoa${Self}: _NS${Self}
 
+  @_versioned
   internal var _fastEnumerationStatePtr:
     UnsafeMutablePointer<_SwiftNSFastEnumerationState> {
     return _getUnsafePointerToStoredProperties(self).assumingMemoryBound(
       to: _SwiftNSFastEnumerationState.self)
   }
 
+  @_versioned
   internal var _fastEnumerationStackBufPtr:
     UnsafeMutablePointer<_CocoaFastEnumerationStackBuf> {
     return UnsafeMutableRawPointer(_fastEnumerationStatePtr + 1)
@@ -5531,7 +5540,9 @@ final internal class _Cocoa${Self}Iterator : IteratorProtocol {
   // Int8 just because our storage holds 16 elements: fast enumeration is
   // allowed to return inner pointers to the container, which can be much
   // larger.
+  @_versioned
   internal var itemIndex: Int = 0
+  @_versioned
   internal var itemCount: Int = 0
 
   @_versioned
@@ -5540,6 +5551,7 @@ final internal class _Cocoa${Self}Iterator : IteratorProtocol {
   }
 
   @_versioned
+  @inline(__always)
   internal func next() -> Element? {
     if itemIndex < 0 {
       return nil

--- a/stdlib/public/core/Join.swift
+++ b/stdlib/public/core/Join.swift
@@ -36,6 +36,7 @@ public struct JoinedIterator<Base : IteratorProtocol> : IteratorProtocol
   /// exists.
   ///
   /// Once `nil` has been returned, all subsequent calls return `nil`.
+  @inline(__always)
   public mutating func next() -> Base.Element.Iterator.Element? {
     while true {
       switch _state {
@@ -77,11 +78,16 @@ public struct JoinedIterator<Base : IteratorProtocol> : IteratorProtocol
     }
   }
 
+  @_versioned
   internal var _base: Base
+  @_versioned
   internal var _inner: Base.Element.Iterator?
+  @_versioned
   internal var _separatorData: ContiguousArray<Base.Element.Iterator.Element>
+  @_versioned
   internal var _separator:
     ContiguousArray<Base.Element.Iterator.Element>.Iterator?
+  @_versioned
   internal var _state: _JoinIteratorState = .start
 }
 

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -1062,6 +1062,7 @@ internal struct KeyPathBuffer {
     fatalError("TODO")
   }
   
+  @inline(__always)
   mutating func next() -> (RawKeyPathComponent, Any.Type?) {
     let header = pop(RawKeyPathComponent.Header.self)
     // Track if this is the last component of the reference prefix.

--- a/stdlib/public/core/Map.swift.gyb
+++ b/stdlib/public/core/Map.swift.gyb
@@ -33,6 +33,7 @@ public struct LazyMapIterator<
   /// - Precondition: `next()` has not been applied to a copy of `self`
   ///   since the copy was made.
   @_inlineable
+  @inline(__always)
   public mutating func next() -> Element? {
     return _base.next().map(_transform)
   }

--- a/stdlib/public/core/PrefixWhile.swift.gyb
+++ b/stdlib/public/core/PrefixWhile.swift.gyb
@@ -28,6 +28,7 @@ from gyb_stdlib_support import (
 public struct LazyPrefixWhileIterator<Base : IteratorProtocol> :
   IteratorProtocol, Sequence {
 
+  @inline(__always)
   public mutating func next() -> Base.Element? {
     // Return elements from the base iterator until one fails the predicate.
     if !_predicateHasFailed, let nextElement = _base.next() {
@@ -45,8 +46,11 @@ public struct LazyPrefixWhileIterator<Base : IteratorProtocol> :
     self._predicate = predicate
   }
 
+  @_versioned
   internal var _predicateHasFailed = false
+  @_versioned
   internal var _base: Base
+  @_versioned
   internal let _predicate: (Base.Element) -> Bool
 }
 

--- a/stdlib/public/core/Range.swift.gyb
+++ b/stdlib/public/core/Range.swift.gyb
@@ -801,6 +801,7 @@ extension CountablePartialRangeFrom: Sequence {
     @_inlineable
     public init(_current: Bound) { self._current = _current }
     @_inlineable
+    @inline(__always)
     public mutating func next() -> Bound? {
       defer { _current = _current.advanced(by: 1) }
       return _current

--- a/stdlib/public/core/SentinelCollection.swift
+++ b/stdlib/public/core/SentinelCollection.swift
@@ -32,6 +32,7 @@ where IsSentinel.Input == Base.Element {
     _isSentinel = condition
   }
   
+  @inline(__always)
   mutating func next() -> Base.Element? {
     guard _fastPath(!_expired) else { return nil }
     let x = _base.next()

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -671,6 +671,7 @@ internal class _DropFirstSequence<Base : IteratorProtocol>
 
   @_versioned
   @_inlineable
+  @inline(__always)
   internal func next() -> Base.Element? {
     while _dropped < _limit {
       if _iterator.next() == nil {
@@ -730,6 +731,7 @@ internal class _PrefixSequence<Base : IteratorProtocol>
 
   @_versioned
   @_inlineable
+  @inline(__always)
   internal func next() -> Base.Element? {
     if _taken >= _maxLength { return nil }
     _taken += 1
@@ -793,6 +795,7 @@ internal class _DropWhileSequence<Base : IteratorProtocol>
 
   @_versioned
   @_inlineable
+  @inline(__always)
   internal func next() -> Base.Element? {
     guard _nextElement != nil else {
       return _iterator.next()
@@ -1468,6 +1471,7 @@ public struct IteratorSequence<
   /// - Precondition: `next()` has not been applied to a copy of `self`
   ///   since the copy was made.
   @_inlineable
+  @inline(__always)
   public mutating func next() -> Base.Element? {
     return _base.next()
   }

--- a/stdlib/public/core/Stride.swift.gyb
+++ b/stdlib/public/core/Stride.swift.gyb
@@ -179,6 +179,7 @@ public struct StrideToIterator<Element : Strideable> : IteratorProtocol {
   /// Once `nil` has been returned, all subsequent calls return `nil`.
 
   @_inlineable
+  @inline(__always)
   public mutating func next() -> Element? {
     let result = _current.value
     if _stride > 0 ? result >= _end : result <= _end {
@@ -269,6 +270,7 @@ public struct StrideThroughIterator<Element : Strideable> : IteratorProtocol {
   ///
   /// Once `nil` has been returned, all subsequent calls return `nil`.
   @_inlineable
+  @inline(__always)
   public mutating func next() -> Element? {
     let result = _current.value
     if _stride > 0 ? result >= _end : result <= _end {

--- a/stdlib/public/core/StringUnicodeScalarView.swift
+++ b/stdlib/public/core/StringUnicodeScalarView.swift
@@ -244,6 +244,7 @@ extension String {
       ///
       /// - Precondition: `next()` has not been applied to a copy of `self`
       ///   since the copy was made.
+      @inline(__always)
       public mutating func next() -> UnicodeScalar? {
         var result: UnicodeDecodingResult
         if _baseSet {
@@ -269,11 +270,17 @@ extension String {
           return UnicodeScalar(0xfffd)
         }
       }
+      @_versioned
       internal var _decoder: UTF16 = UTF16()
+      @_versioned
       internal let _baseSet: Bool
+      @_versioned
       internal let _ascii: Bool
+      @_versioned
       internal var _asciiBase: UnsafeBufferPointerIterator<UInt8>!
+      @_versioned
       internal var _base: UnsafeBufferPointerIterator<UInt16>!
+      @_versioned
       internal var _iterator: IndexingIterator<_StringCore>!
     }
 

--- a/stdlib/public/core/UnfoldSequence.swift
+++ b/stdlib/public/core/UnfoldSequence.swift
@@ -105,6 +105,7 @@ public typealias UnfoldFirstSequence<T> = UnfoldSequence<T, (T?, Bool)>
 ///
 /// - SeeAlso: `sequence(first:next:)`, `sequence(state:next:)`
 public struct UnfoldSequence<Element, State> : Sequence, IteratorProtocol {
+  @inline(__always)
   public mutating func next() -> Element? {
     guard !_done else { return nil }
     if let elt = _next(&_state) {
@@ -120,7 +121,10 @@ public struct UnfoldSequence<Element, State> : Sequence, IteratorProtocol {
     self._next = _next
   }
 
+  @_versioned
   internal var _state: State
+  @_versioned
   internal let _next: (inout State) -> Element?
+  @_versioned
   internal var _done = false
 }

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -21,6 +21,7 @@ public struct UnsafeBufferPointerIterator<Element>
   ///
   /// Once `nil` has been returned, all subsequent calls return `nil`.
   @_inlineable
+  @inline(__always)
   public mutating func next() -> Element? {
     if _position == _end { return nil }
 

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -116,6 +116,7 @@ public struct Unsafe${Mutable}RawBufferPointer
     /// - Returns: The next sequential byte in the raw buffer if another byte
     ///   exists; otherwise, `nil`.
     @_inlineable
+    @inline(__always)
     public mutating func next() -> UInt8? {
       if _position == _end { return nil }
 

--- a/stdlib/public/core/Zip.swift
+++ b/stdlib/public/core/Zip.swift
@@ -63,6 +63,7 @@ public struct Zip2Iterator<
   /// exists.
   ///
   /// Once `nil` has been returned, all subsequent calls return `nil`.
+  @inline(__always)
   public mutating func next() -> Element? {
     // The next() function needs to track if it has reached the end.  If we
     // didn't, and the first sequence is longer than the second, then when we
@@ -83,8 +84,11 @@ public struct Zip2Iterator<
     return (element1, element2)
   }
 
+  @_versioned
   internal var _baseStream1: Iterator1
+  @_versioned
   internal var _baseStream2: Iterator2
+  @_versioned
   internal var _reachedEnd: Bool = false
 }
 


### PR DESCRIPTION
failure to inline an Iterator's next() method has proven to be a very common ARC
optimization barrier.

This creates many indiscriminate @_versioned annotations, so should be carefully reviewed before merging.
