### PR TITLE
[stdlib] Removing a String.init?(_: String), non-failable is enough

### DIFF
--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -78,12 +78,6 @@ public protocol StringProtocol
   ) rethrows -> Result
 }
 
-extension StringProtocol /* : LosslessStringConvertible */ {
-  public init?(_ description: String) {
-    self.init(description.characters)
-  }
-}
-
 /// Call body with a pointer to zero-terminated sequence of
 /// `TargetEncoding.CodeUnit` representing the same string as `source`, when
 /// `source` is interpreted as being encoded with `SourceEncoding`.


### PR DESCRIPTION
Turns out non-failable initializer satisfies the failable initializer requirement.