### PR TITLE
Don't apply dynamic enforcement to empty types

### DIFF
--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -1626,6 +1626,14 @@ bool IRGenModule::isPOD(SILType type, ResilienceExpansion expansion) {
   return getTypeInfo(type).isPOD(expansion);
 }
 
+/// Determine whether this type is known to be empty.
+bool IRGenModule::isKnownEmpty(SILType type, ResilienceExpansion expansion) {
+  if (auto tuple = type.getAs<TupleType>()) {
+    if (tuple->getNumElements() == 0)
+      return true;
+  }
+  return getTypeInfo(type).isKnownEmpty(expansion);
+}
 
 SpareBitVector IRGenModule::getSpareBitsForType(llvm::Type *scalarTy, Size size) {
   auto it = SpareBitsForTypes.find(scalarTy);

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -620,6 +620,7 @@ public:
   ExplosionSchema getSchema(SILType T);
   unsigned getExplosionSize(SILType T);
   llvm::PointerType *isSingleIndirectValue(SILType T);
+  bool isKnownEmpty(SILType type, ResilienceExpansion expansion);
   bool isPOD(SILType type, ResilienceExpansion expansion);
   clang::CanQual<clang::Type> getClangType(CanType type);
   clang::CanQual<clang::Type> getClangType(SILType type);

--- a/test/IRGen/access_markers.sil
+++ b/test/IRGen/access_markers.sil
@@ -105,6 +105,33 @@ bb0(%0 : $A, %1 : $*Builtin.UnsafeValueBuffer):
   return %20 : $()
 }
 
+sil @writeEmptyTuple : $(@inout ()) -> ()
+sil @readEmptyTuple : $(@in_guaranteed ()) -> ()
+
+// rdar://32039394 - Don't apply dynamic enforcement to empty types.
+// CHECK-LABEL: define {{.*}}void @testPairedBox(
+sil @testPairedBox : $(@guaranteed { var () }) -> () {
+bb0(%0 : ${ var () }):
+  // CHECK: entry:
+  %2 = project_box %0 : ${ var () }, 0
+
+  // CHECK-NEXT: call {{.*}}void @writeEmptyTuple(%swift.opaque* nocapture undef)
+  %3 = begin_access [modify] [dynamic] %2 : $*()
+  %write_fn = function_ref @writeEmptyTuple : $@convention(thin) (@inout ()) -> ()
+  apply %write_fn(%3) : $@convention(thin) (@inout ()) -> ()
+  %4 = end_access %3 : $*()
+
+  // CHECK-NEXT: call {{.*}}void @readEmptyTuple(%swift.opaque* noalias nocapture undef)
+  %5 = begin_access [read] [dynamic] %2 : $*()
+  %read_fn = function_ref @readEmptyTuple : $@convention(thin) (@in_guaranteed ()) -> ()
+  apply %read_fn(%5) : $@convention(thin) (@in_guaranteed ()) -> ()
+  %6 = end_access %5 : $*()
+
+  // CHECK-NEXT: ret void
+  %20 = tuple ()
+  return %20 : $()
+}
+
 // rdar://31964550
 // Just check that this doesn't crash.
 sil @testCopyAddr : $(@guaranteed A) -> () {


### PR DESCRIPTION
Fixes <rdar://32039394>.
