### PR TITLE
[Exclusivity] Minor fix for a theoretical bug in SILBuilder emitDestroy.

### DIFF
--- a/lib/SIL/SILBuilder.cpp
+++ b/lib/SIL/SILBuilder.cpp
@@ -160,7 +160,7 @@ SILBasicBlock *SILBuilder::splitBlockForFallthrough() {
 static bool setAccessToDeinit(BeginAccessInst *beginAccess) {
   // It's possible that AllocBoxToStack could catch some cases that
   // AccessEnforcementSelection does not promote to [static]. Ultimately, this
-  // should be an assert, but only after we the two passes can be fixes to share
+  // should be an assert, but only after we the two passes can be fixed to share
   // a common analysis.
   if (beginAccess->getEnforcement() == SILAccessEnforcement::Dynamic)
     return false;
@@ -175,6 +175,7 @@ SILBuilder::emitDestroyAddr(SILLocation Loc, SILValue Operand) {
   // copy_addr from the specified operand.  If so, we can fold this into the
   // copy_addr as a take.
   BeginAccessInst *beginAccess = nullptr;
+  CopyAddrInst *copyAddrTake = nullptr;
   auto I = getInsertionPoint(), BBStart = getInsertionBB()->begin();
   while (I != BBStart) {
     auto *Inst = &*--I;
@@ -185,10 +186,27 @@ SILBuilder::emitDestroyAddr(SILLocation Loc, SILValue Operand) {
           CA->setIsTakeOfSrc(IsTake);
           return CA;
         }
-        if (CA->getSrc() == beginAccess && setAccessToDeinit(beginAccess)) {
-          CA->setIsTakeOfSrc(IsTake);
-          return CA;
+        // If this copy_addr is accessing the same source, continue searching
+        // backward until we see the begin_access. If any side effects occur
+        // between the `%adr = begin_access %src` and `copy_addr %adr` then we
+        // cannot promote the access to a deinit. `[deinit]` requires exclusive
+        // access, but an instruction with side effects may require shared
+        // access.
+        if (CA->getSrc() == beginAccess) {
+          copyAddrTake = CA;
+          continue;
         }
+      }
+    }
+
+    // If we've already seen a copy_addr that can be convert to `take`, then
+    // stop at the begin_access for the copy's source.
+    if (copyAddrTake && beginAccess == Inst) {
+      // If `setAccessToDeinit()` returns `true` it has modified the access
+      // instruction, so we are committed to the transformation on that path.
+      if (setAccessToDeinit(beginAccess)) {
+        copyAddrTake->setIsTakeOfSrc(IsTake);
+        return copyAddrTake;
       }
     }
 

--- a/test/SILOptimizer/allocbox_to_stack_ownership.sil
+++ b/test/SILOptimizer/allocbox_to_stack_ownership.sil
@@ -1039,6 +1039,7 @@ bb3:
 // CHECK: [[READ:%.*]] = begin_access [deinit] [static] [[STK]] : $*T
 // CHECK: copy_addr [take] [[READ]] to [initialization] %1 : $*T
 // CHECK: end_access [[READ]] : $*T
+// CHECK-NOT: destroy_addr
 // CHECK: dealloc_stack [[STK]] : $*T
 // CHECK: destroy_addr %2 : $*T
 // CHECK: return %{{.*}} : $()
@@ -1052,6 +1053,47 @@ bb0(%0 : @owned $*T, %1 : @owned $*T, %2 : @owned $*T):
   copy_addr %7 to [initialization] %0 : $*T
   end_access %7 : $*T
   %10 = begin_access [read] [static] %5 : $*T
+  copy_addr %10 to [initialization] %1 : $*T
+  end_access %10 : $*T
+  destroy_value %4 : $<τ_0_0> { var τ_0_0 } <T>
+  destroy_addr %2 : $*T
+  %15 = tuple ()
+  return %15 : $()
+}
+
+// Test that
+//  begin_access [read], <other access>, copy_addr, end_access, destroy_addr
+// is *not* folded into
+//  begin_access [deinit], copy_addr [take], end_access
+//
+// CHECK-LABEL: sil @nodeinit_access : $@convention(thin) <T> (@in T) -> (@out T, @out T) {
+// CHECK: bb0(%0 : @trivial $*T, %1 : @trivial $*T, %2 : @trivial $*T):
+// CHECK: [[STK:%.*]] = alloc_stack $T, var, name "x"
+// CHECK: copy_addr %2 to [initialization] [[STK]] : $*T
+// CHECK: [[READ:%.*]] = begin_access [read] [static] [[STK]] : $*T
+// CHECK: copy_addr [[READ]] to [initialization] %0 : $*T
+// CHECK: end_access [[READ]] : $*T
+// CHECK: [[READ:%.*]] = begin_access [read] [static] [[STK]] : $*T
+// CHECK: [[INNER:%.*]] = begin_access [read] [static] [[READ]] : $*T
+// CHECK: end_access [[INNER]] : $*T
+// CHECK: copy_addr [[READ]] to [initialization] %1 : $*T
+// CHECK: end_access [[READ]] : $*T
+// CHECK: destroy_addr [[STK]] : $*T
+// CHECK: dealloc_stack [[STK]] : $*T
+// CHECK: destroy_addr %2 : $*T
+// CHECK: return %{{.*}} : $()
+// CHECK-LABEL: } // end sil function 'nodeinit_access'
+sil @nodeinit_access : $@convention(thin) <T> (@in T) -> (@out T, @out T) {
+bb0(%0 : @owned $*T, %1 : @owned $*T, %2 : @owned $*T):
+  %4 = alloc_box $<τ_0_0> { var τ_0_0 } <T>, var, name "x"
+  %5 = project_box %4 : $<τ_0_0> { var τ_0_0 } <T>, 0
+  copy_addr %2 to [initialization] %5 : $*T
+  %7 = begin_access [read] [static] %5 : $*T
+  copy_addr %7 to [initialization] %0 : $*T
+  end_access %7 : $*T
+  %10 = begin_access [read] [static] %5 : $*T
+  %innerAccess = begin_access [read] [static] %10 : $*T
+  end_access %innerAccess : $*T
   copy_addr %10 to [initialization] %1 : $*T
   end_access %10 : $*T
   destroy_value %4 : $<τ_0_0> { var τ_0_0 } <T>


### PR DESCRIPTION
Given:
 %box = alloc_box
 %var = project_box %box, 0
 ...
 %access = begin_access [unknown] [read] %var
 ...<other>...
 copy_addr %access to ...
 end_access %access
 destroy_addr %box

Only fold
  begin_access [read] + copy_addr + end_access + destroy_addr
into
  begin_access [deinit] + copy_addr [take] + end_access

if the code in <other> has no side effects.

Fixes <rdar://problem/31920646> [Exclusivity] Fix the SILBuilder emitDestroy
peephole to generate correct access markers.
