### PR TITLE
[ClangImporter] API reaction to clang::CompilerInstance::getModuleHash

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2644,7 +2644,7 @@ clang::CodeGenOptions &ClangImporter::getClangCodeGenOpts() const {
 }
 
 std::string ClangImporter::getClangModuleHash() const {
-  return Impl.Invocation->getModuleHash();
+  return Impl.Invocation->getModuleHash(Impl.Instance->getDiagnostics());
 }
 
 Decl *ClangImporter::importDeclCached(const clang::NamedDecl *ClangDecl) {


### PR DESCRIPTION
getModuleHash in clang now takes a diagnostic engine to get more
information for uniquing the hash - this change was only needed
for swift-4.0-branch, so we're making the API adjustment here.

rdar://problem/32145037