### PR TITLE
[stdlib] Covariance is not enough

### DIFF
--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -78,6 +78,12 @@ public protocol StringProtocol
   ) rethrows -> Result
 }
 
+extension StringProtocol /* : LosslessStringConvertible */ {
+  public init?(_ description: String) {
+    self.init(description.characters)
+  }
+}
+
 /// Call body with a pointer to zero-terminated sequence of
 /// `TargetEncoding.CodeUnit` representing the same string as `source`, when
 /// `source` is interpreted as being encoded with `SourceEncoding`.

--- a/test/stdlib/StringAPI.swift
+++ b/test/stdlib/StringAPI.swift
@@ -365,6 +365,7 @@ StringTests.test("String.init(_:String)") {
   var s = String("")
   expectType(String.self, &s)
   var _ = String("") as String? // should also compile, but not be the default
+  var _ = String("")! // unwrapping optional should also work
 }
 
 


### PR DESCRIPTION
Even though the non-failable initializer satisfies the conformance, trying to force-unwrap the `String("")!` results in an error.
Reverting the original change and adding a test case.