### PR TITLE
[4.0] Serialization: Handle possibly-null serialized xrefs for optional protocol witnesses.

### DIFF
--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4590,7 +4590,7 @@ void ModuleFile::finishNormalConformance(NormalProtocolConformance *conformance,
     
     auto deserializedReq = getDeclChecked(*rawIDIter++);
     if (deserializedReq) {
-      req = cast<ValueDecl>(*deserializedReq);
+      req = cast_or_null<ValueDecl>(*deserializedReq);
     } else if (getContext().LangOpts.EnableDeserializationRecovery) {
       consumeError(deserializedReq.takeError());
       req = nullptr;
@@ -4603,7 +4603,7 @@ void ModuleFile::finishNormalConformance(NormalProtocolConformance *conformance,
     ValueDecl *witness;
     auto deserializedWitness = getDeclChecked(*rawIDIter++);
     if (deserializedWitness) {
-      witness = cast<ValueDecl>(*deserializedWitness);
+      witness = cast_or_null<ValueDecl>(*deserializedWitness);
     // Across language compatibility versions, the witnessing decl may have
     // changed its signature as seen by the current compatibility version.
     // In that case, we want the conformance to still be available, but
@@ -4705,7 +4705,8 @@ void ModuleFile::finishNormalConformance(NormalProtocolConformance *conformance,
     auto first = cast<AssociatedTypeDecl>(getDecl(*rawIDIter++));
     auto second = getType(*rawIDIter++);
     auto third = cast_or_null<TypeDecl>(getDecl(*rawIDIter++));
-    if (isa<TypeAliasDecl>(third) &&
+    if (third &&
+        isa<TypeAliasDecl>(third) &&
         third->getModuleContext() != getAssociatedModule() &&
         !third->getDeclaredInterfaceType()->isEqual(second)) {
       // Conservatively drop references to typealiases in other modules

--- a/test/Serialization/Inputs/cross_module_optional_protocol_reqt.h
+++ b/test/Serialization/Inputs/cross_module_optional_protocol_reqt.h
@@ -1,0 +1,16 @@
+@import Foundation;
+
+@interface ObjCFoo: NSObject
+@end
+
+@protocol ObjCProto <NSObject>
+
+- (void)nonoptionalMethod;
+
+@optional
+- (void)optionalMethod;
+
+@required
+- (void)nonoptionalMethod2;
+
+@end

--- a/test/Serialization/Inputs/cross_module_optional_protocol_reqt_2.swift
+++ b/test/Serialization/Inputs/cross_module_optional_protocol_reqt_2.swift
@@ -1,0 +1,5 @@
+
+public struct Bar<T: SwiftProto> {}
+public struct Baz {
+  var bar: Bar<Foo>
+}

--- a/test/Serialization/cross_module_optional_protocol_reqt.swift
+++ b/test/Serialization/cross_module_optional_protocol_reqt.swift
@@ -1,0 +1,12 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: %target-swift-frontend -module-name cross_module_optional_protocol_reqt -c -emit-module-path %t/cross_module_optional_protocol_reqt~partial.swiftmodule -primary-file %s %S/Inputs/cross_module_optional_protocol_reqt_2.swift -import-objc-header %S/Inputs/cross_module_optional_protocol_reqt.h -o /dev/null
+// RUN: %target-swift-frontend -module-name cross_module_optional_protocol_reqt -c -emit-module-path %t/cross_module_optional_protocol_reqt_2~partial.swiftmodule %s -primary-file %S/Inputs/cross_module_optional_protocol_reqt_2.swift -import-objc-header %S/Inputs/cross_module_optional_protocol_reqt.h -o /dev/null
+// RUN: %target-swift-frontend -module-name cross_module_optional_protocol_reqt -emit-module -emit-module-path %t/cross_module_optional_protocol_reqt.swiftmodule %t/cross_module_optional_protocol_reqt~partial.swiftmodule %t/cross_module_optional_protocol_reqt_2~partial.swiftmodule -import-objc-header %S/Inputs/cross_module_optional_protocol_reqt.h
+// REQUIRES: objc_interop
+
+public protocol SwiftProto: ObjCProto {}
+
+public class Foo: ObjCFoo, SwiftProto {
+  public func nonoptionalMethod() {}
+  public func nonoptionalMethod2() {}
+}


### PR DESCRIPTION
Explanation: The deserialization code for protocol conformances failed to account for null witness xrefs deserialized to represent an `optional` protocol requirement with no witness in the conformance.

Scope: Any code using `optional` protocol requirements crashes when deserialized.

Issue: SR-4850, rdar://problem/32134722.

Risk: Low, bug fix.

Testing: Swift CI, compatibility suite, tests from radar and Jira