### PR TITLE
[stdlib] Mark String.init?(_: String) obsoleted in Swift 4

### DIFF
--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -79,6 +79,11 @@ public protocol StringProtocol
 }
 
 extension StringProtocol /* : LosslessStringConvertible */ {
+  // This overload is for the Swift 3 compatibility.
+  // In Swift 4, conformance is satisfied by the non-failable initializer, so
+  // that `String("") as String?` is still possible, but `String("")!` is not.
+  @available(swift, obsoleted: 4,
+    message: "Please use the non-failable initializer.")
   public init?(_ description: String) {
     self.init(description.characters)
   }

--- a/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
+++ b/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
@@ -36,11 +36,12 @@ extension String : StringProtocol {
     self.init(repeating: String(repeatedValue), count: count)
   }
 
-  // Now that String conforms to Collection, we need to disambiguate between:
+  // FIXME(strings): doc comment
+  // This initializer satisfies the conformance to LosslessStringConvertible
+  // and disambiguates between the following intitializers, now that String
+  // conforms to Collection:
   // - init<T>(_ value: T) where T : LosslessStringConvertible
   // - init<S>(_ characters: S) where S : Sequence, S.Iterator.Element == Character
-  // Cannot simply do init(_: String) as that would itself be ambiguous with
-  // init?(_ description: String)
   public init(_ other: String) {
     self.init(other._core)
   }

--- a/test/stdlib/StringAPI.swift
+++ b/test/stdlib/StringAPI.swift
@@ -361,13 +361,10 @@ StringTests.test("CompareStringsWithUnpairedSurrogates")
   )
 }
 
-StringTests.test("String.init(_:String)") {
+StringTests.test("String.init(_:String)/default type") {
   var s = String("")
   expectType(String.self, &s)
-  var _ = String("") as String? // should also compile, but not be the default
-  var _ = String("")! // unwrapping optional should also work
 }
-
 
 StringTests.test("[String].joined() -> String") {
   let s = ["hello", "world"].joined()

--- a/test/stdlib/StringCompatibility.swift
+++ b/test/stdlib/StringCompatibility.swift
@@ -37,5 +37,29 @@ Tests.test("ClosedRange/Subsript/ExpectedType") {
   expectType(ExpectedSubstring.self, &subsub)
 }
 
+Tests.test("String.init(_:String)/default type") {
+  var s = String("")
+  expectType(String.self, &s)
+}
+
+Tests.test("LosslessStringConvertible/generic") {
+  func f<T : LosslessStringConvertible>(_ x: T.Type) {
+    _ = T("")! // unwrapping optional should work in generic context
+  }
+  f(String.self)
+}
+
+Tests.test("LosslessStringConvertible/concrete") {
+  _ = String("") as String?
+}
+
+#if swift(>=4)
+#else
+Tests.test("LosslessStringConvertible/force unwrap") {
+  // Force unwrap should still work in Swift 3 mode
+  _ = String("")!
+}
+#endif
+
 
 runAllTests()


### PR DESCRIPTION
It is still possible to get the same behavior by providing an explicit
type context, or in a generic code, but otherwise, `String("")!` will
not compile.