### PR TITLE
[swiftc (33 vs. 5526)] Add crasher in swift::TypeChecker::resolveTypeInContext

### DIFF
--- a/validation-test/compiler_crashers/28750-false-should-have-found-context-by-now.swift
+++ b/validation-test/compiler_crashers/28750-false-should-have-found-context-by-now.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol P{struct A}class a:P{class a:A


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeChecker::resolveTypeInContext`.

Current number of unresolved compiler crashers: 33 (5526 resolved)

/cc @slavapestov - just wanted to let you know that this crasher caused an assertion failure for the assertion `false && "Should have found context by now"` added on 2016-12-06 by you in commit fdaa88606 :-)

Assertion failure in [`lib/Sema/TypeCheckType.cpp (line 402)`](https://github.com/apple/swift/blob/50e4620c824932ce5d47b44870029821eb9d4885/lib/Sema/TypeCheckType.cpp#L402):

```
Assertion `false && "Should have found context by now"' failed.

When executing: std::tuple<Type, bool> findDeclContextForType(swift::TypeChecker &, swift::TypeDecl *, swift::DeclContext *, TypeResolutionOptions, swift::GenericTypeResolver *)
```

Assertion context:

```c++
      // If not, walk into the refined protocols, if any.
      pushRefined(protoDecl);
    }
  }

  assert(false && "Should have found context by now");
  return std::make_tuple(Type(), false);
}

Type TypeChecker::resolveTypeInContext(
       TypeDecl *typeDecl,
```
Stack trace:

```
0 0x0000000003a3b478 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3a3b478)
1 0x0000000003a3bbb6 SignalHandler(int) (/path/to/swift/bin/swift+0x3a3bbb6)
2 0x00007f33d9b4d390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007f33d8073428 gsignal /build/glibc-9tT8Do/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f33d807502a abort /build/glibc-9tT8Do/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f33d806bbd7 __assert_fail_base /build/glibc-9tT8Do/glibc-2.23/assert/assert.c:92:0
6 0x00007f33d806bc82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x000000000139e556 swift::TypeChecker::resolveTypeInContext(swift::TypeDecl*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0x139e556)
8 0x00000000013a68ce resolveTypeDecl(swift::TypeChecker&, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13a68ce)
9 0x00000000013a649f resolveTopLevelIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13a649f)
10 0x00000000013a0496 resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13a0496)
11 0x000000000139fec3 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x139fec3)
12 0x00000000013a1078 (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0x13a1078)
13 0x00000000013a0f7c swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13a0f7c)
14 0x000000000139f590 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x139f590)
15 0x000000000131db0c swift::TypeChecker::checkInheritanceClause(swift::Decl*, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0x131db0c)
16 0x0000000001326171 swift::TypeChecker::validateDecl(swift::ValueDecl*) (/path/to/swift/bin/swift+0x1326171)
17 0x00000000013352fc (anonymous namespace)::DeclChecker::visitClassDecl(swift::ClassDecl*) (/path/to/swift/bin/swift+0x13352fc)
18 0x00000000013249ce (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x13249ce)
19 0x00000000013353fb (anonymous namespace)::DeclChecker::visitClassDecl(swift::ClassDecl*) (/path/to/swift/bin/swift+0x13353fb)
20 0x00000000013249ce (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x13249ce)
21 0x00000000013247e3 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x13247e3)
22 0x00000000013ae445 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x13ae445)
23 0x0000000000f84f66 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf84f66)
24 0x00000000004aaa40 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4aaa40)
25 0x00000000004a906b swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a906b)
26 0x00000000004656d7 main (/path/to/swift/bin/swift+0x4656d7)
27 0x00007f33d805e830 __libc_start_main /build/glibc-9tT8Do/glibc-2.23/csu/../csu/libc-start.c:325:0
28 0x0000000000462d79 _start (/path/to/swift/bin/swift+0x462d79)
```