### PR TITLE
Fix mutating method calls on class existentials

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -708,7 +708,8 @@ namespace {
       // better SILGen.
       if (isLValue &&
           (isNonMutatingMember(member) ||
-           isMetatype || baseTy->isClassExistentialType())) {
+           member->getDeclContext()->getDeclaredTypeOfContext()
+             ->hasReferenceSemantics())) {
         base = cs.coerceToRValue(base);
         isLValue = false;
       }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1124,16 +1124,9 @@ ConstraintSystem::getTypeOfMemberReference(
     auto selfTy = openType(outerDC->getSelfInterfaceType(), locator,
                            replacements);
 
-    // We want to track if the generic context is represented by a
-    // class-bound existential so we won't inappropriately wrap the
-    // self type in an inout later on.
-    auto isClassBoundExistential = outerDC->getDeclaredTypeOfContext()
-        ->isClassExistentialType();
-
     // If self is a struct, properly qualify it based on our base
     // qualification.  If we have an lvalue coming in, we expect an inout.
-    if (!isClassBoundExistential &&
-        !selfTy->hasReferenceSemantics() &&
+    if (!outerDC->getDeclaredTypeOfContext()->hasReferenceSemantics() &&
         baseTy->is<LValueType>() &&
         !selfTy->hasError())
       selfTy = InOutType::get(selfTy);

--- a/test/Interpreter/subclass_existentials.swift
+++ b/test/Interpreter/subclass_existentials.swift
@@ -18,8 +18,7 @@
 
 import StdlibUnittest
 
-// FIXME: Various Sema and SILGen crashes if this is not ': class'
-protocol P : class {
+protocol P {
   init(protocolInit: ())
 
   func protocolMethodReturnsSelf() -> Self

--- a/test/SILGen/class_bound_protocols.swift
+++ b/test/SILGen/class_bound_protocols.swift
@@ -1,4 +1,11 @@
-// RUN: %target-swift-frontend -parse-stdlib -parse-as-library -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -parse-stdlib -parse-as-library -module-name Swift -emit-silgen %s | %FileCheck %s
+
+enum Optional<T> {
+  case some(T)
+  case none
+}
+
+precedencegroup AssignmentPrecedence {}
 
 // -- Class-bound archetypes and existentials are *not* address-only and can
 //    be manipulated using normal reference type value semantics.
@@ -22,7 +29,7 @@ class ConcreteClass : NotClassBound, ClassBound, ClassBound2 {
 
 class ConcreteSubclass : ConcreteClass { }
 
-// CHECK-LABEL: sil hidden @_T021class_bound_protocols0a1_B8_generic{{[_0-9a-zA-Z]*}}F
+// CHECK-LABEL: sil hidden @_T0s19class_bound_generic{{[_0-9a-zA-Z]*}}F
 func class_bound_generic<T : ClassBound>(x: T) -> T {
   var x = x
   // CHECK: bb0([[X:%.*]] : $T):
@@ -39,7 +46,7 @@ func class_bound_generic<T : ClassBound>(x: T) -> T {
   // CHECK:   return [[X1]]
 }
 
-// CHECK-LABEL: sil hidden @_T021class_bound_protocols0a1_B10_generic_2{{[_0-9a-zA-Z]*}}F
+// CHECK-LABEL: sil hidden @_T0s21class_bound_generic_2{{[_0-9a-zA-Z]*}}F
 func class_bound_generic_2<T : ClassBound & NotClassBound>(x: T) -> T {
   var x = x
   // CHECK: bb0([[X:%.*]] : $T):
@@ -55,7 +62,7 @@ func class_bound_generic_2<T : ClassBound & NotClassBound>(x: T) -> T {
   // CHECK:   return [[X1]]
 }
 
-// CHECK-LABEL: sil hidden @_T021class_bound_protocols0a1_B9_protocol{{[_0-9a-zA-Z]*}}F
+// CHECK-LABEL: sil hidden @_T0s20class_bound_protocol{{[_0-9a-zA-Z]*}}F
 func class_bound_protocol(x: ClassBound) -> ClassBound {
   var x = x
   // CHECK: bb0([[X:%.*]] : $ClassBound):
@@ -71,7 +78,7 @@ func class_bound_protocol(x: ClassBound) -> ClassBound {
   // CHECK:   return [[X1]]
 }
 
-// CHECK-LABEL: sil hidden @_T021class_bound_protocols0a1_B21_protocol_composition{{[_0-9a-zA-Z]*}}F
+// CHECK-LABEL: sil hidden @_T0s32class_bound_protocol_composition{{[_0-9a-zA-Z]*}}F
 func class_bound_protocol_composition(x: ClassBound & NotClassBound)
 -> ClassBound & NotClassBound {
   var x = x
@@ -88,14 +95,14 @@ func class_bound_protocol_composition(x: ClassBound & NotClassBound)
   // CHECK:   return [[X1]]
 }
 
-// CHECK-LABEL: sil hidden @_T021class_bound_protocols0a1_B8_erasure{{[_0-9a-zA-Z]*}}F
+// CHECK-LABEL: sil hidden @_T0s19class_bound_erasure{{[_0-9a-zA-Z]*}}F
 func class_bound_erasure(x: ConcreteClass) -> ClassBound {
   return x
   // CHECK: [[PROTO:%.*]] = init_existential_ref {{%.*}} : $ConcreteClass, $ClassBound
   // CHECK: return [[PROTO]]
 }
 
-// CHECK-LABEL: sil hidden @_T021class_bound_protocols0a1_B19_existential_upcastAA10ClassBound_pAaC_AA0F6Bound2p1x_tF :
+// CHECK-LABEL: sil hidden @_T0s30class_bound_existential_upcasts10ClassBound_psAB_s0E6Bound2p1x_tF :
 func class_bound_existential_upcast(x: ClassBound & ClassBound2)
 -> ClassBound {
   return x
@@ -108,9 +115,9 @@ func class_bound_existential_upcast(x: ClassBound & ClassBound2)
   // CHECK:   destroy_value [[ARG]]
   // CHECK:   return [[PROTO]]
 }
-// CHECK: } // end sil function '_T021class_bound_protocols0a1_B19_existential_upcastAA10ClassBound_pAaC_AA0F6Bound2p1x_tF'
+// CHECK: } // end sil function '_T0s30class_bound_existential_upcasts10ClassBound_psAB_s0E6Bound2p1x_tF'
 
-// CHECK-LABEL: sil hidden @_T021class_bound_protocols0a1_B30_to_unbound_existential_upcast{{[_0-9a-zA-Z]*}}F
+// CHECK-LABEL: sil hidden @_T0s41class_bound_to_unbound_existential_upcasts13NotClassBound_ps0hI0_sABp1x_tF :
 // CHECK: bb0([[ARG0:%.*]] : $*NotClassBound, [[ARG1:%.*]] : $ClassBound & NotClassBound):
 // CHECK:   [[BORROWED_ARG1:%.*]] = begin_borrow [[ARG1]]
 // CHECK:   [[X_OPENED:%.*]] = open_existential_ref [[BORROWED_ARG1]] : $ClassBound & NotClassBound to [[OPENED_TYPE:\$@opened(.*) ClassBound & NotClassBound]]
@@ -124,7 +131,7 @@ func class_bound_to_unbound_existential_upcast
   return x
 }
 
-// CHECK-LABEL: sil hidden @_T021class_bound_protocols0a1_B7_method{{[_0-9a-zA-Z]*}}F
+// CHECK-LABEL: sil hidden @_T0s18class_bound_methodys10ClassBound_p1x_tF :
 // CHECK: bb0([[ARG:%.*]] : $ClassBound):
 func class_bound_method(x: ClassBound) {
   var x = x
@@ -144,6 +151,72 @@ func class_bound_method(x: ClassBound) {
   // CHECK: destroy_value [[XBOX]]
   // CHECK: destroy_value [[ARG]]
 }
-// CHECK: } // end sil function '_T021class_bound_protocols0a1_B7_methodyAA10ClassBound_p1x_tF'
+// CHECK: } // end sil function '_T0s18class_bound_methodys10ClassBound_p1x_tF'
 
+// rdar://problem/31858378
+struct Value {}
 
+protocol HasMutatingMethod {
+  mutating func mutateMe()
+  var mutatingCounter: Value { get set }
+  var nonMutatingCounter: Value { get nonmutating set }
+}
+
+protocol InheritsMutatingMethod : class, HasMutatingMethod {}
+
+func takesInOut<T>(_: inout T) {}
+
+// CHECK-LABEL: sil hidden @_T0s27takesInheritsMutatingMethodys0bcD0_pz1x_s5ValueV1ytF : $@convention(thin) (@inout InheritsMutatingMethod, Value) -> () {
+func takesInheritsMutatingMethod(x: inout InheritsMutatingMethod,
+                                 y: Value) {
+  // CHECK:      [[X_ADDR:%.*]] = begin_access [modify] [unknown] %0 : $*InheritsMutatingMethod
+  // CHECK-NEXT: [[X_VALUE:%.*]] = load [copy] [[X_ADDR]] : $*InheritsMutatingMethod
+  // CHECK-NEXT: [[X_PAYLOAD:%.*]] = open_existential_ref [[X_VALUE]] : $InheritsMutatingMethod to $@opened("{{.*}}") InheritsMutatingMethod
+  // CHECK-NEXT: [[TEMPORARY:%.*]] = alloc_stack $@opened("{{.*}}") InheritsMutatingMethod
+  // CHECK-NEXT: store [[X_PAYLOAD]] to [init] [[TEMPORARY]] : $*@opened("{{.*}}") InheritsMutatingMethod
+  // CHECK-NEXT: [[METHOD:%.*]] = witness_method $@opened("{{.*}}") InheritsMutatingMethod, #HasMutatingMethod.mutateMe!1 : <Self where Self : HasMutatingMethod> (inout Self) -> () -> (), [[X_PAYLOAD]] : $@opened("{{.*}}") InheritsMutatingMethod : $@convention(witness_method) <τ_0_0 where τ_0_0 : HasMutatingMethod> (@inout τ_0_0) -> ()
+  // CHECK-NEXT: apply [[METHOD]]<@opened("{{.*}}") InheritsMutatingMethod>([[TEMPORARY]]) : $@convention(witness_method) <τ_0_0 where τ_0_0 : HasMutatingMethod> (@inout τ_0_0) -> ()
+  // CHECK-NEXT: [[X_PAYLOAD:%.*]] = load [take] [[TEMPORARY]] : $*@opened("{{.*}}") InheritsMutatingMethod
+  // CHECK-NEXT: [[X_VALUE:%.*]] = init_existential_ref [[X_PAYLOAD]] : $@opened("{{.*}}") InheritsMutatingMethod : $@opened("{{.*}}") InheritsMutatingMethod, $InheritsMutatingMethod
+  // CHECK-NEXT: assign [[X_VALUE]] to [[X_ADDR]] : $*InheritsMutatingMethod
+  // CHECK-NEXT: end_access [[X_ADDR]] : $*InheritsMutatingMethod
+  // CHECK-NEXT: dealloc_stack [[TEMPORARY]] : $*@opened("{{.*}}") InheritsMutatingMethod
+  x.mutateMe()
+
+  // CHECK-NEXT: [[RESULT_BOX:%.*]] = alloc_stack $Value
+  // CHECK-NEXT: [[RESULT:%.*]] = mark_uninitialized [var] [[RESULT_BOX]] : $*Value
+  // CHECK-NEXT: [[X_ADDR:%.*]] = begin_access [read] [unknown] %0 : $*InheritsMutatingMethod
+  // CHECK-NEXT: [[X_VALUE:%.*]] = load [copy] [[X_ADDR]] : $*InheritsMutatingMethod
+  // CHECK-NEXT: [[X_PAYLOAD:%.*]] = open_existential_ref [[X_VALUE]] : $InheritsMutatingMethod to $@opened("{{.*}}") InheritsMutatingMethod
+  // CHECK-NEXT: [[TEMPORARY:%.*]] = alloc_stack $@opened("{{.*}}") InheritsMutatingMethod
+  // CHECK-NEXT: store [[X_PAYLOAD]] to [init] [[TEMPORARY]] : $*@opened("{{.*}}") InheritsMutatingMethod
+  // CHECK-NEXT: [[METHOD:%.*]] = witness_method $@opened("{{.*}}") InheritsMutatingMethod, #HasMutatingMethod.mutatingCounter!getter.1 : <Self where Self : HasMutatingMethod> (Self) -> () -> Value, [[X_PAYLOAD]] : $@opened("{{.*}}") InheritsMutatingMethod : $@convention(witness_method) <τ_0_0 where τ_0_0 : HasMutatingMethod> (@in_guaranteed τ_0_0) -> Value
+  // CHECK-NEXT: [[RESULT_VALUE:%.*]] = apply [[METHOD]]<@opened("{{.*}}") InheritsMutatingMethod>(%21) : $@convention(witness_method) <τ_0_0 where τ_0_0 : HasMutatingMethod> (@in_guaranteed τ_0_0) -> Value
+  // CHECK-NEXT: [[X_VALUE:%.*]] = load [take] [[TEMPORARY]] : $*@opened("{{.*}}") InheritsMutatingMethod
+  // CHECK-NEXT: destroy_value [[X_VALUE]] : $@opened("{{.*}}") InheritsMutatingMethod
+  // CHECK-NEXT: end_access [[X_ADDR]] : $*InheritsMutatingMethod
+  // CHECK-NEXT: assign [[RESULT_VALUE]] to [[RESULT]] : $*Value
+  // CHECK-NEXT: dealloc_stack [[TEMPORARY]] : $*@opened("{{.*}}") InheritsMutatingMethod
+  // CHECK-NEXT: dealloc_stack [[RESULT_BOX]] : $*Value
+  _ = x.mutatingCounter
+
+  // CHECK-NEXT: [[X_ADDR:%.*]] = begin_access [modify] [unknown] %0 : $*InheritsMutatingMethod
+  // CHECK-NEXT: [[X_VALUE:%.*]] = load [copy] [[X_ADDR]] : $*InheritsMutatingMethod
+  // CHECK-NEXT: [[X_PAYLOAD:%.*]] = open_existential_ref [[X_VALUE]] : $InheritsMutatingMethod to $@opened("{{.*}}") InheritsMutatingMethod
+  // CHECK-NEXT: [[TEMPORARY:%.*]] = alloc_stack $@opened("{{.*}}") InheritsMutatingMethod
+  // CHECK-NEXT: store [[X_PAYLOAD]] to [init] [[TEMPORARY]] : $*@opened("{{.*}}") InheritsMutatingMethod
+  // CHECK-NEXT: [[METHOD:%.*]] = witness_method $@opened("{{.*}}") InheritsMutatingMethod, #HasMutatingMethod.mutatingCounter!setter.1 : <Self where Self : HasMutatingMethod> (inout Self) -> (Value) -> (), [[X_PAYLOAD]] : $@opened("{{.*}}") InheritsMutatingMethod : $@convention(witness_method) <τ_0_0 where τ_0_0 : HasMutatingMethod> (Value, @inout τ_0_0) -> ()
+  // CHECK-NEXT: apply [[METHOD]]<@opened("{{.*}}") InheritsMutatingMethod>(%1, [[TEMPORARY]]) : $@convention(witness_method) <τ_0_0 where τ_0_0 : HasMutatingMethod> (Value, @inout τ_0_0) -> ()
+  // CHECK-NEXT: [[X_PAYLOAD:%.*]] = load [take] [[TEMPORARY]] : $*@opened("{{.*}}") InheritsMutatingMethod
+  // CHECK-NEXT: [[X_VALUE:%.*]] = init_existential_ref [[X_PAYLOAD]] : $@opened("{{.*}}") InheritsMutatingMethod : $@opened("{{.*}}") InheritsMutatingMethod, $InheritsMutatingMethod
+  // CHECK-NEXT: assign [[X_VALUE]] to [[X_ADDR]] : $*InheritsMutatingMethod
+  // CHECK-NEXT: end_access [[X_ADDR]] : $*InheritsMutatingMethod
+  // CHECK-NEXT: dealloc_stack [[TEMPORARY]] : $*@opened("{{.*}}") InheritsMutatingMethod
+  x.mutatingCounter = y
+
+  takesInOut(&x.mutatingCounter)
+
+  _ = x.nonMutatingCounter
+  x.nonMutatingCounter = y
+  takesInOut(&x.nonMutatingCounter)
+}

--- a/test/SILGen/subclass_existentials.swift
+++ b/test/SILGen/subclass_existentials.swift
@@ -183,8 +183,7 @@ func methodCalls(
   // CHECK-NEXT: }
 }
 
-// FIXME: Various Sema and SILGen crashes if this is not ': class'
-protocol PropertyP : class {
+protocol PropertyP {
   var p: PropertyP & PropertyC { get set }
 
   subscript(key: Int) -> Int { get set }
@@ -207,19 +206,20 @@ class PropertyC {
 
 // CHECK-LABEL: sil hidden @_T021subclass_existentials16propertyAccessesyAA9PropertyP_AA0E1CCXcF : $@convention(thin) (@owned PropertyC & PropertyP) -> () {
 func propertyAccesses(_ x: PropertyP & PropertyC) {
-  x.p.p = x
-  x.c.c = x
+  var xx = x
+  xx.p.p = x
+  xx.c.c = x
 
-  propertyAccesses(x.p)
-  propertyAccesses(x.c)
+  propertyAccesses(xx.p)
+  propertyAccesses(xx.c)
 
-  _ = x[1]
-  x[1] = 1
-  x[1] += 1
+  _ = xx[1]
+  xx[1] = 1
+  xx[1] += 1
 
-  _ = x[(1, 2)]
-  x[(1, 2)] = 1
-  x[(1, 2)] += 1
+  _ = xx[(1, 2)]
+  xx[(1, 2)] = 1
+  xx[(1, 2)] += 1
 }
 
 // CHECK-LABEL: sil hidden @_T021subclass_existentials19functionConversionsyAA1P_AA4BaseCySiGXcyc07returnsE4AndP_AaC_AFXcXpyc0feG5PTypeAA7DerivedCyc0fI0AJmyc0fI4TypeAA1R_AJXcyc0fiG1RAaM_AJXcXpyc0fiG5RTypetF : $@convention(thin) (@owned @callee_owned () -> @owned Base<Int> & P, @owned @callee_owned () -> @thick (Base<Int> & P).Type, @owned @callee_owned () -> @owned Derived, @owned @callee_owned () -> @thick Derived.Type, @owned @callee_owned () -> @owned Derived & R, @owned @callee_owned () -> @thick (Derived & R).Type) -> () {


### PR DESCRIPTION
This builds upon https://github.com/apple/swift/pull/9625 and https://github.com/apple/swift/pull/9637 to address miscompiles and assertions with a peculiar corner case -- performing a mutating method call on a class existential.

This can manifest in one of two ways:

1) A class-constrained protocol inherits from a non-class-constrained protocol, and the latter has mutating methods.
2) A protocol composition type contains both a class-constrained and a non-class-constrained protocol, or a superclass constraint and a non-class-constrained protocol.

The root cause is that mutating methods take the opened `self` value as an inout parameter, but we had no way to model an inout access of the payload inside a class existential at the SIL level. I've decided to model it as a logical lvalue component where the "get" strips the existential witness tables to produce a reference, and the "set" adds the witness tables back to the reference to form a new existential.

Note that this miscompile was occurring irrespective of whether the mutating method was defined in an extension, or in the class itself. The problem was that incorrect code was being generated at the *call site*, where it is not known how the method is implemented, and `self` has to be passed as an inout value.

Fixes <rdar://problem/31858378>.