### PR TITLE
[stdlib] Various documentation improvements

### DIFF
--- a/stdlib/public/SDK/Foundation/NSStringAPI.swift
+++ b/stdlib/public/SDK/Foundation/NSStringAPI.swift
@@ -124,8 +124,8 @@ extension String {
 
   // @property (class) const NSStringEncoding *availableStringEncodings;
 
-  /// Returns an Array of the encodings string objects support
-  /// in the application's environment.
+  /// An array of the encodings that strings support in the application's
+  /// environment.
   public static var availableStringEncodings: [Encoding] {
     var result = [Encoding]()
     var p = NSString.availableStringEncodings
@@ -138,15 +138,20 @@ extension String {
 
   // @property (class) NSStringEncoding defaultCStringEncoding;
 
-  /// Returns the C-string encoding assumed for any method accepting
-  /// a C string as an argument.
+  /// The C-string encoding assumed for any method accepting a C string as an
+  /// argument.
   public static var defaultCStringEncoding: Encoding {
     return Encoding(rawValue: NSString.defaultCStringEncoding)
   }
 
   // + (NSString *)localizedNameOfStringEncoding:(NSStringEncoding)encoding
 
-  /// Returns a human-readable string giving the name of a given encoding.
+  /// Returns a human-readable string giving the name of the specified encoding.
+  ///
+  /// - Parameter encoding: A string encoding. For possible values, see
+  ///   `String.Encoding`.
+  /// - Returns: A human-readable string giving the name of `encoding` in the
+  ///   current locale.
   public static func localizedName(
     of encoding: Encoding
   ) -> String {
@@ -216,7 +221,7 @@ extension String {
 
   // + (instancetype)stringWithUTF8String:(const char *)bytes
 
-  /// Produces a string created by copying the data from a given
+  /// Creates a string by copying the data from a given
   /// C array of UTF8-encoded bytes.
   public init?(utf8String bytes: UnsafePointer<CChar>) {
     if let ns = NSString(utf8String: bytes) {
@@ -234,24 +239,44 @@ extension String {
 
   // - (BOOL)canBeConvertedToEncoding:(NSStringEncoding)encoding
 
-  /// Returns a Boolean value that indicates whether the
-  /// `String` can be converted to a given encoding without loss of
-  /// information.
+  /// Returns a Boolean value that indicates whether the string can be
+  /// converted to the specified encoding without loss of information.
+  ///
+  /// - Parameter encoding: A string encoding.
+  /// - Returns: `true` if the string can be encoded in `encoding` without loss
+  ///   of information; otherwise, `false`.
   public func canBeConverted(to encoding: Encoding) -> Bool {
     return _ns.canBeConverted(to: encoding.rawValue)
   }
 
   // @property NSString* capitalizedString
 
-  /// Produce a string with the first character from each word changed
-  /// to the corresponding uppercase value.
+  /// A copy of the string with each word changed to its corresponding
+  /// capitalized spelling.
+  ///
+  /// This property performs the canonical (non-localized) mapping. It is
+  /// suitable for programming operations that require stable results not
+  /// depending on the current locale.
+  ///
+  /// A capitalized string is a string with the first character in each word
+  /// changed to its corresponding uppercase value, and all remaining
+  /// characters set to their corresponding lowercase values. A "word" is any
+  /// sequence of characters delimited by spaces, tabs, or line terminators.
+  /// Some common word delimiting punctuation isn't considered, so this
+  /// property may not generally produce the desired results for multiword
+  /// strings. See the `getLineStart(_:end:contentsEnd:for:)` method for
+  /// additional information.
+  ///
+  /// Case transformations aren’t guaranteed to be symmetrical or to produce
+  /// strings of the same lengths as the originals. See lowercased for an
+  /// example.
   public var capitalized: String {
     return _ns.capitalized as String
   }
 
   // @property (readonly, copy) NSString *localizedCapitalizedString NS_AVAILABLE(10_11, 9_0);
 
-  /// A capitalized representation of the `String` that is produced
+  /// A capitalized representation of the string that is produced
   /// using the current locale.
   @available(OSX 10.11, iOS 9.0, *)
   public var localizedCapitalized: String {
@@ -260,7 +285,7 @@ extension String {
 
   // - (NSString *)capitalizedStringWithLocale:(Locale *)locale
 
-  /// Returns a capitalized representation of the `String`
+  /// Returns a capitalized representation of the string
   /// using the specified locale.
   public func capitalized(with locale: Locale?) -> String {
     return _ns.capitalized(with: locale) as String
@@ -284,7 +309,7 @@ extension String {
   //     commonPrefixWithString:(NSString *)aString
   //     options:(StringCompareOptions)mask
 
-  /// Returns a string containing characters the `String` and a
+  /// Returns a string containing characters this string and the
   /// given string have in common, starting from the beginning of each
   /// up to the first characters that aren't equivalent.
   public func commonPrefix(
@@ -343,11 +368,12 @@ extension String {
   //     matchesIntoArray:(NSArray **)outputArray
   //     filterTypes:(NSArray *)filterTypes
 
-  /// Interprets the `String` as a path in the file system and
+  /// Interprets the string as a path in the file system and
   /// attempts to perform filename completion, returning a numeric
   /// value that indicates whether a match was possible, and by
-  /// reference the longest path that matches the `String`.
-  /// Returns the actual number of matching paths.
+  /// reference the longest path that matches the string.
+  ///
+  /// - Returns: The actual number of matching paths.
   public func completePath(
     into outputName: UnsafeMutablePointer<String>? = nil,
     caseSensitive: Bool,
@@ -390,8 +416,8 @@ extension String {
   // - (NSArray *)
   //     componentsSeparatedByCharactersInSet:(NSCharacterSet *)separator
 
-  /// Returns an array containing substrings from the `String`
-  /// that have been divided by characters in a given set.
+  /// Returns an array containing substrings from the string
+  /// that have been divided by characters in the given set.
   public func components(separatedBy separator: CharacterSet) -> [String] {
     return _ns.components(separatedBy: separator)
   }
@@ -399,15 +425,41 @@ extension String {
 
   // - (NSArray *)componentsSeparatedByString:(NSString *)separator
 
-  /// Returns an array containing substrings from the `String`
-  /// that have been divided by a given separator.
+  /// Returns an array containing substrings from the string that have been
+  /// divided by the given separator.
+  ///
+  /// The substrings in the resulting array appear in the same order as the
+  /// original string. Adjacent occurrences of the separator string produce
+  /// empty strings in the result. Similarly, if the string begins or ends
+  /// with the separator, the first or last substring, respectively, is empty.
+  /// The following example shows this behavior:
+  ///
+  ///     let list1 = "Karin, Carrie, David"
+  ///     let items1 = list1.components(separatedBy: ", ")
+  ///     // ["Karin", "Carrie", "David"]
+  ///
+  ///     // Beginning with the separator:
+  ///     let list2 = ", Norman, Stanley, Fletcher"
+  ///     let items2 = list2.components(separatedBy: ", ")
+  ///     // ["", "Norman", "Stanley", "Fletcher"
+  ///
+  /// If the list has no separators, the array contains only the original
+  /// string itself.
+  ///
+  ///     let name = "Karin"
+  ///     let list = name.components(separatedBy: ", ")
+  ///     // ["Karin"]
+  ///
+  /// - Parameter separator: The separator string.
+  /// - Returns: An array containing substrings that have been divided from the
+  ///   string using `separator`.
   public func components(separatedBy separator: String) -> [String] {
     return _ns.components(separatedBy: separator)
   }
 
   // - (const char *)cStringUsingEncoding:(NSStringEncoding)encoding
 
-  /// Returns a representation of the `String` as a C string
+  /// Returns a representation of the string as a C string
   /// using a given encoding.
   public func cString(using encoding: Encoding) -> [CChar]? {
     return withExtendedLifetime(_ns) {
@@ -435,16 +487,14 @@ extension String {
 
   // @property NSString* decomposedStringWithCanonicalMapping;
 
-  /// Returns a string made by normalizing the `String`'s
-  /// contents using Form D.
+  /// A string created by normalizing the string's contents using Form D.
   public var decomposedStringWithCanonicalMapping: String {
     return _ns.decomposedStringWithCanonicalMapping
   }
 
   // @property NSString* decomposedStringWithCompatibilityMapping;
 
-  /// Returns a string made by normalizing the `String`'s
-  /// contents using Form KD.
+  /// A string created by normalizing the string's contents using Form KD.
   public var decomposedStringWithCompatibilityMapping: String {
     return _ns.decomposedStringWithCompatibilityMapping
   }
@@ -523,8 +573,35 @@ extension String {
   //         BOOL *stop)
   //       )block
 
-  /// Enumerates the substrings of the specified type in the
-  /// specified range of the string.
+  /// Enumerates the substrings of the specified type in the specified range of
+  /// the string.
+  ///
+  /// Mutation of a string value while enumerating its substrings is not
+  /// supported. If you need to mutate a string from within `body`, convert
+  /// your string to an `NSMutableString` instance and then call the
+  /// `enumerateSubstrings(in:options:using:)` method.
+  ///
+  /// - Parameters:
+  ///   - range: The range within the string to enumerate substrings.
+  ///   - opts: Options specifying types of substrings and enumeration styles.
+  ///     If `opts` is omitted or empty, `body` is called a single time with
+  ///     the range of the string specified by `range`.
+  ///   - body: The closure executed for each substring in the enumeration. The
+  ///     closure takes four arguments:
+  ///     - The enumerated substring. If `substringNotRequired` is included in
+  ///       `opts`, this parameter is `nil` for every execution of the
+  ///       closure.
+  ///     - The range of the enumerated substring in the string that
+  ///       `enumerate(in:options:_:)` was called on.
+  ///     - The range that includes the substring as well as any separator or
+  ///       filler characters that follow. For instance, for lines,
+  ///       `enclosingRange` contains the line terminators. The enclosing
+  ///       range for the first string enumerated also contains any characters
+  ///       that occur before the string. Consecutive enclosing ranges are
+  ///       guaranteed not to overlap, and every single character in the
+  ///       enumerated range is included in one and only one enclosing range.
+  ///     - An `inout` Boolean value that the closure can use to stop the
+  ///       enumeration by setting `stop = true`.
   public func enumerateSubstrings(
     in range: Range<Index>,
     options opts: EnumerationOptions = [],
@@ -549,8 +626,8 @@ extension String {
 
   // @property NSStringEncoding fastestEncoding;
 
-  /// Returns the fastest encoding to which the `String` may be
-  /// converted without loss of information.
+  /// The fastest encoding to which the string may be converted without loss
+  /// of information.
   public var fastestEncoding: Encoding {
     return Encoding(rawValue: _ns.fastestEncoding)
   }
@@ -724,8 +801,12 @@ extension String {
   //     length:(NSUInteger)length
   //     encoding:(NSStringEncoding)encoding
 
-  /// Produces an initialized `NSString` object equivalent to the given
-  /// `bytes` interpreted in the given `encoding`.
+  /// Creates a new string equivalent to the given bytes interpreted in the
+  /// specified encoding.
+  ///
+  /// - Parameters:
+  ///   - bytes: A sequence of bytes to interpret using `encoding`.
+  ///   - encoding: The ecoding to use to interpret `bytes`.
   public init? <S: Sequence>(bytes: S, encoding: Encoding)
     where S.Iterator.Element == UInt8 {
     let byteArray = Array(bytes)
@@ -744,9 +825,9 @@ extension String {
   //     encoding:(NSStringEncoding)encoding
   //     freeWhenDone:(BOOL)flag
 
-  /// Produces an initialized `String` object that contains a
-  /// given number of bytes from a given buffer of bytes interpreted
-  /// in a given encoding, and optionally frees the buffer.  WARNING:
+  /// Creates a new string that contains the specified number of bytes
+  /// from the given buffer interpreted
+  /// in the specified encoding, and optionally frees the buffer.  WARNING:
   /// this initializer is not memory-safe!
   public init?(
     bytesNoCopy bytes: UnsafeMutableRawPointer, length: Int,
@@ -767,9 +848,8 @@ extension String {
   //     initWithCharacters:(const unichar *)characters
   //     length:(NSUInteger)length
 
-  /// Returns an initialized `String` object that contains a
-  /// given number of characters from a given array of Unicode
-  /// characters.
+  /// Creates a new string that contains the specified number of characters
+  /// from the given C array of Unicode characters.
   public init(
     utf16CodeUnits: UnsafePointer<unichar>,
     count: Int
@@ -782,7 +862,7 @@ extension String {
   //     length:(NSUInteger)length
   //     freeWhenDone:(BOOL)flag
 
-  /// Returns an initialized `String` object that contains a given
+  /// Creates a new string that contains the specified
   /// number of characters from a given array of UTF-16 Code Units
   public init(
     utf16CodeUnitsNoCopy: UnsafePointer<unichar>,
@@ -895,9 +975,9 @@ extension String {
       return nil
     }
   }
-  
+
   // FIXME: handle optional locale with default arguments
-  
+
   // - (instancetype)
   //     initWithData:(NSData *)data
   //     encoding:(NSStringEncoding)encoding
@@ -908,7 +988,7 @@ extension String {
     guard let s = NSString(data: data, encoding: encoding.rawValue) else { return nil }
     self = s as String
   }
-  
+
   // - (instancetype)initWithFormat:(NSString *)format, ...
 
   /// Returns a `String` object initialized by using a given
@@ -1036,8 +1116,8 @@ extension String {
 
   // - (NSComparisonResult)localizedCaseInsensitiveCompare:(NSString *)aString
 
-  /// Compares the string and a given string using a
-  /// case-insensitive, localized, comparison.
+  /// Compares the string and the given string using a case-insensitive,
+  /// localized, comparison.
   public
   func localizedCaseInsensitiveCompare(_ aString: String) -> ComparisonResult {
     return _ns.localizedCaseInsensitiveCompare(aString)
@@ -1045,13 +1125,12 @@ extension String {
 
   // - (NSComparisonResult)localizedCompare:(NSString *)aString
 
-  /// Compares the string and a given string using a localized
-  /// comparison.
+  /// Compares the string and the given string using a localized comparison.
   public func localizedCompare(_ aString: String) -> ComparisonResult {
     return _ns.localizedCompare(aString)
   }
 
-  /// Compares strings as sorted by the Finder.
+  /// Compares the string and the given string as sorted by the Finder.
   public func localizedStandardCompare(_ string: String) -> ComparisonResult {
     return _ns.localizedStandardCompare(string)
   }
@@ -1114,16 +1193,14 @@ extension String {
 
   // @property NSString* precomposedStringWithCanonicalMapping;
 
-  /// Returns a string made by normalizing the `String`'s
-  /// contents using Form C.
+  /// A string created by normalizing the string's contents using Form C.
   public var precomposedStringWithCanonicalMapping: String {
     return _ns.precomposedStringWithCanonicalMapping
   }
 
   // @property NSString * precomposedStringWithCompatibilityMapping;
 
-  /// Returns a string made by normalizing the `String`'s
-  /// contents using Form KC.
+  /// A string created by normalizing the string's contents using Form KC.
   public var precomposedStringWithCompatibilityMapping: String {
     return _ns.precomposedStringWithCompatibilityMapping
   }
@@ -1244,8 +1321,8 @@ extension String {
 
   // - (BOOL)localizedStandardContainsString:(NSString *)str NS_AVAILABLE(10_11, 9_0);
 
-  /// Returns `true` if `self` contains `string`, taking the current locale
-  /// into account.
+  /// Returns a Boolean value indicating whether the string contains the given
+  /// string, taking the current locale into account.
   ///
   /// This is the most appropriate method for doing user-level string searches,
   /// similar to how searches are done generally in the system.  The search is
@@ -1273,8 +1350,8 @@ extension String {
 
   // @property NSStringEncoding smallestEncoding;
 
-  /// Returns the smallest encoding to which the `String` can
-  /// be converted without loss of information.
+  /// The smallest encoding to which the string can be converted without
+  /// loss of information.
   public var smallestEncoding: Encoding {
     return Encoding(rawValue: _ns.smallestEncoding)
   }
@@ -1293,9 +1370,8 @@ extension String {
   //     stringByAddingPercentEncodingWithAllowedCharacters:
   //       (NSCharacterSet *)allowedCharacters
 
-  /// Returns a new string made from the `String` by replacing
-  /// all characters not in the specified set with percent encoded
-  /// characters.
+  /// Returns a new string created by replacing all characters in the string
+  /// not in the specified set with percent encoded characters.
   public func addingPercentEncoding(
     withAllowedCharacters allowedCharacters: CharacterSet
   ) -> String? {
@@ -1328,9 +1404,8 @@ extension String {
 
   // - (NSString *)stringByAppendingFormat:(NSString *)format, ...
 
-  /// Returns a string made by appending to the `String` a
-  /// string constructed from a given format string and the following
-  /// arguments.
+  /// Returns a string created by appending a string constructed from a given
+  /// format string and the following arguments.
   public func appendingFormat(
     _ format: String, _ arguments: CVarArg...
   ) -> String {
@@ -1363,8 +1438,7 @@ extension String {
 
   // - (NSString *)stringByAppendingString:(NSString *)aString
 
-  /// Returns a new string made by appending a given string to
-  /// the `String`.
+  /// Returns a new string created by appending the given string.
   public func appending(_ aString: String) -> String {
     return _ns.appending(aString)
   }
@@ -1434,9 +1508,8 @@ extension String {
 
   // @property NSString* stringByRemovingPercentEncoding;
 
-  /// Returns a new string made from the `String` by replacing
-  /// all percent encoded sequences with the matching UTF-8
-  /// characters.
+  /// A new string made from the string by replacing all percent encoded
+  /// sequences with the matching UTF-8 characters.
   public var removingPercentEncoding: String? {
     return _ns.removingPercentEncoding
   }
@@ -1464,7 +1537,7 @@ extension String {
   //     range:(NSRange)searchRange
 
   /// Returns a new string in which all occurrences of a target
-  /// string in a specified range of the `String` are replaced by
+  /// string in a specified range of the string are replaced by
   /// another given string.
   public func replacingOccurrences(
     of target: String,
@@ -1634,20 +1707,18 @@ extension String {
     }
     return r
   }
-  
-  /// Returns `true` iff `other` is non-empty and contained within
-  /// `self` by case-insensitive, non-literal search, taking into
-  /// account the current locale.
+
+  /// Returns a Boolean value indicating whether the given string is non-empty
+  /// and contained within this string by case-insensitive, non-literal
+  /// search, taking into account the current locale.
   ///
-  /// Locale-independent case-insensitive operation, and other needs,
-  /// can be achieved by calling
-  /// `rangeOfString(_:options:_, range:_locale:_)`.
+  /// Locale-independent case-insensitive operation, and other needs, can be
+  /// achieved by calling `range(of:options:range:locale:)`.
   ///
   /// Equivalent to
   ///
-  ///     self.rangeOf(
-  ///       other, options: .CaseInsensitiveSearch,
-  ///       locale: Locale.current) != nil
+  ///     range(of: other, options: .caseInsensitiveSearch,
+  ///           locale: Locale.current) != nil
   public func localizedCaseInsensitiveContains(_ other: String) -> Bool {
     let r = self.range(
       of: other, options: .caseInsensitive, locale: Locale.current
@@ -1883,7 +1954,7 @@ extension String {
   ) -> String {
     fatalError("unavailable function can't be called")
   }
-  
+
   @available(*, unavailable, renamed: "replacingCharacters(in:with:)")
   public func replacingCharactersIn(
     _ range: Range<Index>, withString replacement: String

--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -95,8 +95,8 @@ if True:
 ///
 ///     let midpoint = absences.count / 2
 ///
-///     let firstHalf = absences.prefix(upTo: midpoint)
-///     let secondHalf = absences.suffix(from: midpoint)
+///     let firstHalf = absences[..<midpoint]
+///     let secondHalf = absences[midpoint...]
 ///
 /// Neither the `firstHalf` nor `secondHalf` slices allocate any new storage
 /// of their own. Instead, each presents a view onto the storage of the
@@ -151,7 +151,7 @@ if True:
 /// Here's an implementation of those steps:
 ///
 ///     if let i = absences.index(where: { $0 > 0 }) {                      // 1
-///         let absencesAfterFirst = absences.suffix(from: i + 1)           // 2
+///         let absencesAfterFirst = absences[(i + 1)...]                   // 2
 ///         if let j = absencesAfterFirst.index(where: { $0 > 0 }) {        // 3
 ///             print("The first day with absences had \(absences[i]).")    // 4
 ///             print("The second day with absences had \(absences[j]).")

--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -170,7 +170,7 @@ if True:
 """
   elif Self == 'Array':
     SelfDocComment = '''\
-/// An ordered, random-access collection.
+/// An ordered, random-access collection of elements of a single type.
 ///
 /// Arrays are one of the most commonly used data types in an app. You use
 /// arrays to organize your app's data. Specifically, you use the `Array` type

--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -170,7 +170,7 @@ if True:
 """
   elif Self == 'Array':
     SelfDocComment = '''\
-/// An ordered, random-access collection of elements of a single type.
+/// An ordered, random-access collection.
 ///
 /// Arrays are one of the most commonly used data types in an app. You use
 /// arrays to organize your app's data. Specifically, you use the `Array` type

--- a/stdlib/public/core/Bool.swift
+++ b/stdlib/public/core/Bool.swift
@@ -202,9 +202,9 @@ extension Bool {
 }
 
 extension Bool {
-  /// Performs a logical AND operation on two Bool values.
+  /// Performs a logical AND operation on two Boolean values.
   ///
-  /// The logical AND operator (`&&`) combines two Bool values and returns
+  /// The logical AND operator (`&&`) combines two Boolean values and returns
   /// `true` if both of the values are `true`. If either of the values is
   /// `false`, the operator returns `false`.
   ///
@@ -241,9 +241,9 @@ extension Bool {
     return lhs ? try rhs() : false
   }
 
-  /// Performs a logical OR operation on two Bool values.
+  /// Performs a logical OR operation on two Boolean values.
   ///
-  /// The logical OR operator (`||`) combines two Bool values and returns
+  /// The logical OR operator (`||`) combines two Boolean values and returns
   /// `true` if at least one of the values is `true`. If both values are
   /// `false`, the operator returns `false`.
   ///

--- a/stdlib/public/core/Builtin.swift
+++ b/stdlib/public/core/Builtin.swift
@@ -817,12 +817,13 @@ public func type<T, Metatype>(of value: T) -> Metatype {
 ///   behavior for the escapable closure to be stored, referenced, or executed
 ///   after the function returns.
 ///
-/// - Parameter closure: A non-escaping closure value that will be made
-///   escapable for the duration of the execution of the `body` closure. If
-///   `body` has a return value, it is used as the return value for the
-///   `withoutActuallyEscaping(_:do:)` function.
-/// - Parameter body: A closure that will be immediately executed, receiving an
-///   escapable copy of `closure` as an argument.
+/// - Parameters:
+///   - closure: A non-escaping closure value that will be made escapable for
+///     the duration of the execution of the `body` closure. If `body` has a
+///     return value, it is used as the return value for the
+///     `withoutActuallyEscaping(_:do:)` function.
+///   - body: A closure that will be immediately executed, receiving an
+///     escapable copy of `closure` as an argument.
 /// - Returns: The return value of the `body` closure, if any.
 @_transparent
 @_semantics("typechecker.withoutActuallyEscaping(_:do:)")

--- a/stdlib/public/core/Character.swift
+++ b/stdlib/public/core/Character.swift
@@ -16,11 +16,12 @@
 /// The `Character` type represents a character made up of one or more Unicode
 /// scalar values, grouped by a Unicode boundary algorithm. Generally, a
 /// `Character` instance matches what the reader of a string will perceive as
-/// a single character. The number of visible characters is generally the most
-/// natural way to count the length of a string.
+/// a single character. Strings are collections of `Character` instances, so
+/// the number of visible characters is generally the most natural way to
+/// count the length of a string.
 ///
 ///     let greeting = "Hello! 🐥"
-///     print("Character count: \(greeting.characters.count)")
+///     print("Character count: \(greeting.count)")
 ///     // Prints "Character count: 8"
 ///
 /// Because each character in a string can be made up of one or more Unicode

--- a/stdlib/public/core/Character.swift
+++ b/stdlib/public/core/Character.swift
@@ -21,8 +21,8 @@
 /// count the length of a string.
 ///
 ///     let greeting = "Hello! 🐥"
-///     print("Character count: \(greeting.count)")
-///     // Prints "Character count: 8"
+///     print("Length: \(greeting.count)")
+///     // Prints "Length: 8"
 ///
 /// Because each character in a string can be made up of one or more Unicode
 /// code points, the number of characters in a string may not match the length

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -506,7 +506,7 @@ public struct IndexingIterator<
 /// collection can contain zero or more of the original collection's elements
 /// and shares the original collection's semantics.
 ///
-/// The following example, creates a `firstWord` constant by using the
+/// The following example creates a `firstWord` constant by using the
 /// `prefix(_:)` method to get a slice of the `text` string.
 ///
 ///     let firstWord = text.prefix(7)
@@ -565,10 +565,9 @@ public struct IndexingIterator<
 /// -----------------------------------
 ///
 /// A slice inherits the value or reference semantics of its base collection.
-/// That is, when working with a slice of a mutable
-/// collection that has value semantics, such as an array, mutating the
-/// original collection triggers a copy of that collection, and does not
-/// affect the contents of the slice.
+/// That is, when working with a slice of a mutable collection that has value
+/// semantics, such as an array, mutating the original collection triggers a
+/// copy of that collection, and does not affect the contents of the slice.
 ///
 /// For example, if you update the last element of the `absences` array from
 /// `0` to `2`, the `secondHalf` slice is unchanged.

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -453,15 +453,15 @@ public struct IndexingIterator<
 ///
 ///     let text = "Buffalo buffalo buffalo buffalo."
 ///     if let firstSpace = text.index(of: " ") {
-///         print(text.prefix(upTo: firstSpace))
+///         print(text[..<firstSpace])
 ///     }
 ///     // Prints "Buffalo"
 ///
-/// The `firstSpace` constant is an index into the `text` string---the position of the first space in the
-/// string. You can store indices in variables, and pass them to
-/// collection algorithms or use them later to access the corresponding
-/// element. In the example above, `firstSpace` is used to extract the prefix
-/// that contains elements up to that index.
+/// The `firstSpace` constant is an index into the `text` string---the position
+/// of the first space in the string. You can store indices in variables, and
+/// pass them to collection algorithms or use them later to access the
+/// corresponding element. In the example above, `firstSpace` is used to
+/// extract the prefix that contains elements up to that index.
 ///
 /// You can pass only valid indices to collection operations. You can find a
 /// complete set of a collection's valid indices by starting with the
@@ -514,20 +514,18 @@ public struct IndexingIterator<
 ///     // Prints "Buffalo"
 ///
 /// You can retrieve the same slice using other methods, such as finding the
-/// terminating index, and then using the `prefix(upTo:)` method, which takes
-/// an index as its parameter, or by using the view's ranged subscript.
+/// terminating index, and the using the string's ranged subscript, or by
+/// using the `prefix(upTo:)` method, which takes an index as its parameter.
 ///
 ///     if let firstSpace = text.index(of: " ") {
-///         print(text.prefix(upTo: firstSpace))
+///         print(text[..<firstSpace]
 ///         // Prints "Buffalo"
 ///
-///         let start = text.startIndex
-///         print(text[start..<firstSpace])
+///         print(text.prefix(upTo: firstSpace))
 ///         // Prints "Buffalo"
 ///     }
 ///
-/// The retrieved slice of `text` is equivalent in each of these
-/// cases.
+/// The retrieved slice of `text` is equivalent in each of these cases.
 ///
 /// Slices Share Indices
 /// --------------------
@@ -795,6 +793,15 @@ public protocol Collection : _Indexable, Sequence
   ///     print(numbers.prefix(upTo: numbers.startIndex))
   ///     // Prints "[]"
   ///
+  /// Using the `prefix(upTo:)` method is equivalent to using a partial
+  /// half-open range as the collection's subscript. The subscript notation is
+  /// preferred over `prefix(upTo:)`.
+  ///
+  ///     if let i = numbers.index(of: 40) {
+  ///         print(numbers[..<i])
+  ///     }
+  ///     // Prints "[10, 20, 30]"
+  ///
   /// - Parameter end: The "past the end" index of the resulting subsequence.
   ///   `end` must be a valid index of the collection.
   /// - Returns: A subsequence up to, but not including, the `end` position.
@@ -822,6 +829,15 @@ public protocol Collection : _Indexable, Sequence
   ///     print(numbers.suffix(from: numbers.endIndex))
   ///     // Prints "[]"
   ///
+  /// Using the `suffix(from:)` method is equivalent to using a partial range
+  /// from the index as the collection's subscript. The subscript notation is
+  /// preferred over `suffix(from:)`.
+  ///
+  ///     if let i = numbers.index(of: 40) {
+  ///         print(numbers[i...])
+  ///     }
+  ///     // Prints "[40, 50, 60]"
+  ///
   /// - Parameter start: The index at which to start the resulting subsequence.
   ///   `start` must be a valid index of the collection.
   /// - Returns: A subsequence starting at the `start` position.
@@ -840,6 +856,15 @@ public protocol Collection : _Indexable, Sequence
   ///     let numbers = [10, 20, 30, 40, 50, 60]
   ///     if let i = numbers.index(of: 40) {
   ///         print(numbers.prefix(through: i))
+  ///     }
+  ///     // Prints "[10, 20, 30, 40]"
+  ///
+  /// Using the `prefix(through:)` method is equivalent to using a partial
+  /// closed range as the collection's subscript. The subscript notation is
+  /// preferred over `prefix(through:)`.
+  ///
+  ///     if let i = numbers.index(of: 40) {
+  ///         print(numbers[...i])
   ///     }
   ///     // Prints "[10, 20, 30, 40]"
   ///
@@ -1619,6 +1644,15 @@ extension Collection {
   ///     print(numbers.prefix(upTo: numbers.startIndex))
   ///     // Prints "[]"
   ///
+  /// Using the `prefix(upTo:)` method is equivalent to using a partial
+  /// half-open range as the collection's subscript. The subscript notation is
+  /// preferred over `prefix(upTo:)`.
+  ///
+  ///     if let i = numbers.index(of: 40) {
+  ///         print(numbers[..<i])
+  ///     }
+  ///     // Prints "[10, 20, 30]"
+  ///
   /// - Parameter end: The "past the end" index of the resulting subsequence.
   ///   `end` must be a valid index of the collection.
   /// - Returns: A subsequence up to, but not including, the `end` position.
@@ -1649,6 +1683,15 @@ extension Collection {
   ///     print(numbers.suffix(from: numbers.endIndex))
   ///     // Prints "[]"
   ///
+  /// Using the `suffix(from:)` method is equivalent to using a partial range
+  /// from the index as the collection's subscript. The subscript notation is
+  /// preferred over `suffix(from:)`.
+  ///
+  ///     if let i = numbers.index(of: 40) {
+  ///         print(numbers[i...])
+  ///     }
+  ///     // Prints "[40, 50, 60]"
+  ///
   /// - Parameter start: The index at which to start the resulting subsequence.
   ///   `start` must be a valid index of the collection.
   /// - Returns: A subsequence starting at the `start` position.
@@ -1670,6 +1713,15 @@ extension Collection {
   ///     let numbers = [10, 20, 30, 40, 50, 60]
   ///     if let i = numbers.index(of: 40) {
   ///         print(numbers.prefix(through: i))
+  ///     }
+  ///     // Prints "[10, 20, 30, 40]"
+  ///
+  /// Using the `prefix(through:)` method is equivalent to using a partial
+  /// closed range as the collection's subscript. The subscript notation is
+  /// preferred over `prefix(through:)`.
+  ///
+  ///     if let i = numbers.index(of: 40) {
+  ///         print(numbers[...i])
   ///     }
   ///     // Prints "[10, 20, 30, 40]"
   ///

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -502,26 +502,22 @@ public struct IndexingIterator<
 /// ================================
 ///
 /// You can access a slice of a collection through its ranged subscript or by
-/// calling methods like `prefix(_:)` or `suffix(from:)`. A slice of a
+/// calling methods like `prefix(while:)` or `suffix(_:)`. A slice of a
 /// collection can contain zero or more of the original collection's elements
 /// and shares the original collection's semantics.
 ///
 /// The following example creates a `firstWord` constant by using the
-/// `prefix(_:)` method to get a slice of the `text` string.
+/// `prefix(where:)` method to get a slice of the `text` string.
 ///
-///     let firstWord = text.prefix(7)
+///     let firstWord = text.prefix(while: { $0 != " " })
 ///     print(firstWord)
 ///     // Prints "Buffalo"
 ///
-/// You can retrieve the same slice using other methods, such as finding the
-/// terminating index, and the using the string's ranged subscript, or by
-/// using the `prefix(upTo:)` method, which takes an index as its parameter.
+/// You can retrieve the same slice using the string's ranged subscript, which
+/// takes a range expression.
 ///
 ///     if let firstSpace = text.index(of: " ") {
 ///         print(text[..<firstSpace]
-///         // Prints "Buffalo"
-///
-///         print(text.prefix(upTo: firstSpace))
 ///         // Prints "Buffalo"
 ///     }
 ///

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -448,18 +448,17 @@ public struct IndexingIterator<
 /// at a specific position when using a collection.
 ///
 /// For example, if you want to print only the first word in a string, search
-/// for the index of the first space and then create a subsequence up to that
+/// for the index of the first space, and then create a subsequence up to that
 /// position.
 ///
 ///     let text = "Buffalo buffalo buffalo buffalo."
-///     if let firstSpace = text.characters.index(of: " ") {
-///         print(String(text.characters.prefix(upTo: firstSpace)))
+///     if let firstSpace = text.index(of: " ") {
+///         print(text.prefix(upTo: firstSpace))
 ///     }
 ///     // Prints "Buffalo"
 ///
-/// The `firstSpace` constant is an index into the `text.characters`
-/// collection. `firstSpace` is the position of the first space in the
-/// collection. You can store indices in variables, and pass them to
+/// The `firstSpace` constant is an index into the `text` string---the position of the first space in the
+/// string. You can store indices in variables, and pass them to
 /// collection algorithms or use them later to access the corresponding
 /// element. In the example above, `firstSpace` is used to extract the prefix
 /// that contains elements up to that index.
@@ -486,7 +485,7 @@ public struct IndexingIterator<
 /// Here's an example of accessing the first character in a string through its
 /// subscript:
 ///
-///     let firstChar = text.characters[text.characters.startIndex]
+///     let firstChar = text[text.startIndex]
 ///     print(firstChar)
 ///     // Prints "B"
 ///
@@ -496,7 +495,7 @@ public struct IndexingIterator<
 /// using the `first` property, which has the value of the first element of
 /// the collection, or `nil` if the collection is empty.
 ///
-///     print(text.characters.first)
+///     print(text.first)
 ///     // Prints "Optional("B")"
 ///
 /// Accessing Slices of a Collection
@@ -508,27 +507,26 @@ public struct IndexingIterator<
 /// and shares the original collection's semantics.
 ///
 /// The following example, creates a `firstWord` constant by using the
-/// `prefix(_:)` method to get a slice of the `text` string's `characters`
-/// view.
+/// `prefix(_:)` method to get a slice of the `text` string.
 ///
-///     let firstWord = text.characters.prefix(7)
-///     print(String(firstWord))
+///     let firstWord = text.prefix(7)
+///     print(firstWord)
 ///     // Prints "Buffalo"
 ///
 /// You can retrieve the same slice using other methods, such as finding the
 /// terminating index, and then using the `prefix(upTo:)` method, which takes
 /// an index as its parameter, or by using the view's ranged subscript.
 ///
-///     if let firstSpace = text.characters.index(of: " ") {
-///         print(text.characters.prefix(upTo: firstSpace))
+///     if let firstSpace = text.index(of: " ") {
+///         print(text.prefix(upTo: firstSpace))
 ///         // Prints "Buffalo"
 ///
-///         let start = text.characters.startIndex
-///         print(text.characters[start..<firstSpace])
+///         let start = text.startIndex
+///         print(text[start..<firstSpace])
 ///         // Prints "Buffalo"
 ///     }
 ///
-/// The retrieved slice of `text.characters` is equivalent in each of these
+/// The retrieved slice of `text` is equivalent in each of these
 /// cases.
 ///
 /// Slices Share Indices
@@ -598,7 +596,7 @@ public struct IndexingIterator<
 /// indices or the view itself is being iterated.
 ///
 ///     let word = "Swift"
-///     for character in word.characters {
+///     for character in word {
 ///         print(character)
 ///     }
 ///     // Prints "S"
@@ -607,8 +605,8 @@ public struct IndexingIterator<
 ///     // Prints "f"
 ///     // Prints "t"
 ///
-///     for i in word.characters.indices {
-///         print(word.characters[i])
+///     for i in word.indices {
+///         print(word[i])
 ///     }
 ///     // Prints "S"
 ///     // Prints "w"
@@ -864,7 +862,7 @@ public protocol Collection : _Indexable, Sequence
   /// through the elements of the collection.
   ///
   ///     let horseName = "Silver"
-  ///     if horseName.characters.isEmpty {
+  ///     if horseName.isEmpty {
   ///         print("I've been through the desert on a horse with no name.")
   ///     } else {
   ///         print("Hi ho, \(horseName)!")
@@ -1319,7 +1317,7 @@ extension Collection {
   /// through the elements of the collection.
   ///
   ///     let horseName = "Silver"
-  ///     if horseName.characters.isEmpty {
+  ///     if horseName.isEmpty {
   ///         print("I've been through the desert on a horse with no name.")
   ///     } else {
   ///         print("Hi ho, \(horseName)!")
@@ -1420,7 +1418,7 @@ extension Collection {
   ///     let cast = ["Vivien", "Marlon", "Kim", "Karl"]
   ///     let lowercaseNames = cast.map { $0.lowercaseString }
   ///     // 'lowercaseNames' == ["vivien", "marlon", "kim", "karl"]
-  ///     let letterCounts = cast.map { $0.characters.count }
+  ///     let letterCounts = cast.map { $0.count }
   ///     // 'letterCounts' == [6, 6, 3, 4]
   ///
   /// - Parameter transform: A mapping closure. `transform` accepts an
@@ -1701,25 +1699,20 @@ extension Collection {
   /// that was originally separated by one or more spaces.
   ///
   ///     let line = "BLANCHE:   I don't want realism. I want magic!"
-  ///     print(line.characters.split(whereSeparator: { $0 == " " })
-  ///                          .map(String.init))
+  ///     print(line.split(whereSeparator: { $0 == " " }))
   ///     // Prints "["BLANCHE:", "I", "don\'t", "want", "realism.", "I", "want", "magic!"]"
   ///
   /// The second example passes `1` for the `maxSplits` parameter, so the
   /// original string is split just once, into two new strings.
   ///
-  ///     print(
-  ///         line.characters.split(
-  ///             maxSplits: 1, whereSeparator: { $0 == " " }
-  ///             ).map(String.init))
+  ///     print(line.split(maxSplits: 1, whereSeparator: { $0 == " " }))
   ///     // Prints "["BLANCHE:", "  I don\'t want realism. I want magic!"]"
   ///
   /// The final example passes `false` for the `omittingEmptySubsequences`
   /// parameter, so the returned array contains empty strings where spaces
   /// were repeated.
   ///
-  ///     print(line.characters.split(omittingEmptySubsequences: false, whereSeparator: { $0 == " " })
-  ///                           .map(String.init))
+  ///     print(line.split(omittingEmptySubsequences: false, whereSeparator: { $0 == " " }))
   ///     // Prints "["BLANCHE:", "", "", "I", "don\'t", "want", "realism.", "I", "want", "magic!"]"
   ///
   /// - Parameters:
@@ -1801,23 +1794,20 @@ extension Collection where Iterator.Element : Equatable {
   /// was originally separated by one or more spaces.
   ///
   ///     let line = "BLANCHE:   I don't want realism. I want magic!"
-  ///     print(line.characters.split(separator: " ")
-  ///                          .map(String.init))
+  ///     print(line.split(separator: " "))
   ///     // Prints "["BLANCHE:", "I", "don\'t", "want", "realism.", "I", "want", "magic!"]"
   ///
   /// The second example passes `1` for the `maxSplits` parameter, so the
   /// original string is split just once, into two new strings.
   ///
-  ///     print(line.characters.split(separator: " ", maxSplits: 1)
-  ///                           .map(String.init))
+  ///     print(line.split(separator: " ", maxSplits: 1))
   ///     // Prints "["BLANCHE:", "  I don\'t want realism. I want magic!"]"
   ///
   /// The final example passes `false` for the `omittingEmptySubsequences`
   /// parameter, so the returned array contains empty strings where spaces
   /// were repeated.
   ///
-  ///     print(line.characters.split(separator: " ", omittingEmptySubsequences: false)
-  ///                           .map(String.init))
+  ///     print(line.split(separator: " ", omittingEmptySubsequences: false))
   ///     // Prints "["BLANCHE:", "", "", "I", "don\'t", "want", "realism.", "I", "want", "magic!"]"
   ///
   /// - Parameters:

--- a/stdlib/public/core/FloatingPoint.swift.gyb
+++ b/stdlib/public/core/FloatingPoint.swift.gyb
@@ -170,10 +170,11 @@ word_bits = int(CMAKE_SIZEOF_VOID_P) * 8
 public protocol FloatingPoint: SignedNumeric, Strideable, Hashable {
 
   // For the minimumMagnitude and maximumMagnitude methods
-  // FIXME(integers): document me properly
+  /// A type that can represent the absolute value of any possible value of the
+  /// conforming type.
   associatedtype Magnitude = Self
 
-  /// A type that represents any written exponent.
+  /// A type that can represent any written exponent.
   associatedtype Exponent: SignedInteger
 
   /// Creates a new value from the given sign, exponent, and significand.

--- a/stdlib/public/core/FloatingPoint.swift.gyb
+++ b/stdlib/public/core/FloatingPoint.swift.gyb
@@ -493,61 +493,44 @@ public protocol FloatingPoint: SignedNumeric, Strideable, Hashable {
   /// [spec]: http://ieeexplore.ieee.org/servlet/opac?punumber=4610933
   var significand: Self { get }
 
-  /// Returns the sum of this value and the given value, rounded to a
+  /// Adds two values and produces their sum, rounded to a
   /// representable value.
   ///
-  /// This method serves as the basis for the addition operator (`+`). For
+  /// The addition operator (`+`) calculates the sum of its two arguments. For
   /// example:
   ///
   ///     let x = 1.5
-  ///     print(x.adding(2.25))
-  ///     // Prints "3.75"
-  ///     print(x + 2.25)
-  ///     // Prints "3.75"
+  ///     let y = x + 2.25
+  ///     // y == 3.75
   ///
-  /// The `adding(_:)` method implements the addition operation defined by the
+  /// The `+` operator implements the addition operation defined by the
   /// [IEEE 754 specification][spec].
   ///
   /// [spec]: http://ieeexplore.ieee.org/servlet/opac?punumber=4610933
   ///
-  /// - Parameter other: The value to add.
-  /// - Returns: The sum of this value and `other`, rounded to a representable
-  ///   value.
-  ///
-  /// - SeeAlso: `add(_:)`
-  // FIXME(integers): revise the doc comment
+  /// - Parameters:
+  ///   - lhs: The first value to add.
+  ///   - rhs: The second value to add.
   static func +(_ lhs: Self, _ rhs: Self) -> Self
 
-  /// Adds the given value to this value in place, rounded to a representable
-  /// value.
+  /// Adds two values and stores the result in the left-hand-side variable,
+  /// rounded to a representable value.
   ///
-  /// This method serves as the basis for the in-place addition operator
-  /// (`+=`). For example:
-  ///
-  ///     var (x, y) = (2.25, 2.25)
-  ///     x.add(7.0)
-  ///     // x == 9.25
-  ///     y += 7.0
-  ///     // y == 9.25
-  ///
-  /// - Parameter other: The value to add.
-  ///
-  /// - SeeAlso: `adding(_:)`
-  // FIXME(integers): revise the doc comment
+  /// - Parameters:
+  ///   - lhs: The first value to add.
+  ///   - rhs: The second value to add.
   static func +=(_ lhs: inout Self, _ rhs: Self)
 
-  /// Returns the additive inverse of this value.
+  /// Calculates the additive inverse of a value.
   ///
-  /// The result is always exact. This method serves as the basis for the
-  /// negation operator (prefixed `-`). For example:
+  /// The unary minus operator (prefix `-`) calculates the negation of its
+  /// operand. The result is always exact.
   ///
   ///     let x = 21.5
   ///     let y = -x
   ///     // y == -21.5
   ///
-  /// - Returns: The additive inverse of this value.
-  ///
-  /// - SeeAlso: `negate()`
+  /// - Parameter operand: The value to negate.
   static prefix func - (_ operand: Self) -> Self
 
   /// Replaces this value with its additive inverse.
@@ -558,137 +541,94 @@ public protocol FloatingPoint: SignedNumeric, Strideable, Hashable {
   ///     var x = 21.5
   ///     x.negate()
   ///     // x == -21.5
-  ///
-  /// - SeeAlso: The unary minus operator (`-`).
   mutating func negate()
 
-  /// Returns the difference of this value and the given value, rounded to a
-  /// representable value.
+  /// Subtracts one value from another and produces their difference, rounded
+  /// to a representable value.
   ///
-  /// This method serves as the basis for the subtraction operator (`-`). For
-  /// example:
+  /// The subtraction operator (`-`) calculates the difference of its two
+  /// arguments. For example:
   ///
   ///     let x = 7.5
-  ///     print(x.subtracting(2.25))
-  ///     // Prints "5.25"
-  ///     print(x - 2.25)
-  ///     // Prints "5.25"
-  ///
-  /// The `subtracting(_:)` method implements the subtraction operation
-  /// defined by the [IEEE 754 specification][spec].
-  ///
-  /// [spec]: http://ieeexplore.ieee.org/servlet/opac?punumber=4610933
-  ///
-  /// - Parameter other: The value to subtract from this value.
-  /// - Returns: The difference of this value and `other`, rounded to a
-  ///   representable value.
-  ///
-  /// - SeeAlso: `subtract(_:)`
-  // FIXME(integers): revise the doc comment (it also mentiones 'addition')
-  static func -(_ lhs: Self, _ rhs: Self) -> Self
-
-  /// Subtracts the given value from this value in place, rounding to a
-  /// representable value.
-  ///
-  /// This method serves as the basis for the in-place subtraction operator
-  /// (`-=`). For example:
-  ///
-  ///     var (x, y) = (7.5, 7.5)
-  ///     x.subtract(2.25)
-  ///     // x == 5.25
-  ///     y -= 2.25
+  ///     let y = x - 2.25
   ///     // y == 5.25
   ///
-  /// - Parameter other: The value to subtract.
+  /// The `-` operator implements the subtraction operation defined by the
+  /// [IEEE 754 specification][spec].
   ///
-  /// - SeeAlso: `subtracting(_:)`
-  // FIXME(integers): revise the doc comment
+  /// [spec]: http://ieeexplore.ieee.org/servlet/opac?punumber=4610933
+  ///
+  /// - Parameters:
+  ///   - lhs: A numeric value.
+  ///   - rhs: The value to subtract from `lhs`.
+  static func -(_ lhs: Self, _ rhs: Self) -> Self
+
+  /// Subtracts the second value from the first and stores the difference in
+  /// the left-hand-side variable, rounding to a representable value.
+  ///
+  /// - Parameters:
+  ///   - lhs: A numeric value.
+  ///   - rhs: The value to subtract from `lhs`.
   static func -=(_ lhs: inout Self, _ rhs: Self)
 
-  /// Returns the product of this value and the given value, rounded to a
+  /// Multiplies two values and produces their product, rounding to a
   /// representable value.
   ///
-  /// This method serves as the basis for the multiplication operator (`*`).
-  /// For example:
+  /// The multiplication operator (`*`) calculates the product of its two
+  /// arguments. For example:
   ///
   ///     let x = 7.5
-  ///     print(x.multiplied(by: 2.25))
-  ///     // Prints "16.875"
-  ///     print(x * 2.25)
-  ///     // Prints "16.875"
+  ///     let y = x * 2.25
+  ///     // y == 16.875
   ///
-  /// The `multiplied(by:)` method implements the multiplication operation
-  /// defined by the [IEEE 754 specification][spec].
+  /// The `*` operator implements the multiplication operation defined by the
+  /// [IEEE 754 specification][spec].
   ///
   /// [spec]: http://ieeexplore.ieee.org/servlet/opac?punumber=4610933
   ///
-  /// - Parameter other: The value to multiply by this value.
-  /// - Returns: The product of this value and `other`, rounded to a
-  ///   representable value.
-  ///
-  /// - SeeAlso: `multiply(by:)`
-  // FIXME(integers): revise the doc comment
+  /// - Parameters:
+  ///   - lhs: The first value to multiply.
+  ///   - rhs: The second value to multiply.
   static func *(_ lhs: Self, _ rhs: Self) -> Self
 
-  /// Multiplies this value by the given value in place, rounding to a
-  /// representable value.
+  /// Multiplies two values and stores the result in the left-hand-side
+  /// variable, rounding to a representable value.
   ///
-  /// This method serves as the basis for the in-place multiplication operator
-  /// (`*=`). For example:
-  ///
-  ///     var (x, y) = (7.5, 7.5)
-  ///     x.multiply(by: 2.25)
-  ///     // x == 16.875
-  ///     y *= 2.25
-  ///     // y == 16.875
-  ///
-  /// - Parameter other: The value to multiply by this value.
-  ///
-  /// - SeeAlso: `multiplied(by:)`
-  // FIXME(integers): revise the doc comment
+  /// - Parameters:
+  ///   - lhs: The first value to multiply.
+  ///   - rhs: The second value to multiply.
   static func *=(_ lhs: inout Self, _ rhs: Self)
 
-  /// Returns the quotient of this value and the given value, rounded to a
-  /// representable value.
+  /// Returns the quotient of dividing the first value by the second, rounded
+  /// to a representable value.
   ///
-  /// This method serves as the basis for the division operator (`/`). For
-  /// example:
+  /// The division operator (`/`) calculates the quotient of the division if
+  /// `rhs` is nonzero. If `rhs` is zero, the result of the division is
+  /// infinity, with the sign of the result matching the sign of `lhs`.
   ///
-  ///     let x = 7.5
-  ///     let y = x.divided(by: 2.25)
-  ///     // y == 16.875
-  ///     let z = x * 2.25
-  ///     // z == 16.875
+  ///     let x = 16.875
+  ///     let y = x / 2.25
+  ///     // y == 7.5
   ///
-  /// The `divided(by:)` method implements the division operation
-  /// defined by the [IEEE 754 specification][spec].
+  ///     let z = x / 0
+  ///     // z.isInfinite == true
+  ///
+  /// The `/` operator implements the division operation defined by the [IEEE
+  /// 754 specification][spec].
   ///
   /// [spec]: http://ieeexplore.ieee.org/servlet/opac?punumber=4610933
   ///
-  /// - Parameter other: The value to use when dividing this value.
-  /// - Returns: The quotient of this value and `other`, rounded to a
-  ///   representable value.
-  ///
-  /// - SeeAlso: `divide(by:)`
-  // FIXME(integers): revise the doc comment
+  /// - Parameters:
+  ///   - lhs: The value to divide.
+  ///   - rhs: The value to divide `lhs` by.
   static func /(_ lhs: Self, _ rhs: Self) -> Self
 
-  /// Divides this value by the given value in place, rounding to a
-  /// representable value.
+  /// Divides the first value by the second and stores the quotient in the
+  /// left-hand-side variable, rounding to a representable value.
   ///
-  /// This method serves as the basis for the in-place division operator
-  /// (`/=`). For example:
-  ///
-  ///     var (x, y) = (16.875, 16.875)
-  ///     x.divide(by: 2.25)
-  ///     // x == 7.5
-  ///     y /= 2.25
-  ///     // y == 7.5
-  ///
-  /// - Parameter other: The value to use when dividing this value.
-  ///
-  /// - SeeAlso: `divided(by:)`
-  // FIXME(integers): revise the doc comment
+  /// - Parameters:
+  ///   - lhs: The value to divide.
+  ///   - rhs: The value to divide `lhs` by.
   static func /=(_ lhs: inout Self, _ rhs: Self)
 
   /// Returns the remainder of this value divided by the given value.

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -785,7 +785,7 @@ public struct Set<Element : Hashable> :
   /// five characters.
   ///
   ///     let cast: Set = ["Vivien", "Marlon", "Kim", "Karl"]
-  ///     let shortNames = cast.filter { $0.characters.count < 5 }
+  ///     let shortNames = cast.filter { $0.count < 5 }
   ///
   ///     shortNames.isSubset(of: cast)
   ///     // true

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -2562,6 +2562,17 @@ extension SignedInteger where Self : FixedWidthInteger {
 %   u = 's' if signed else 'u'
 %   U = 'U' if signed else ''
 %   z = 's' if signed else 'z'
+
+%   Article = 'An' if bits == 8 else 'A'
+%   if bits == word_bits:
+/// ${'A ' if signed else 'An un'}signed integer value type.
+///
+/// On 32-bit platforms, `${Self}` is the same size as `${Self}32`, and
+/// on 64-bit platforms, `${Self}` is the same size as `${Self}64`.
+%   else:
+/// ${Article} ${bits}-bit ${'' if signed else 'un'}signed integer value
+/// type.
+%   end
 @_fixed_layout
 public struct ${Self}
   : FixedWidthInteger, ${Unsigned}Integer,

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -1016,7 +1016,7 @@ public protocol Numeric : Equatable, ExpressibleByIntegerLiteral {
   ///     let y = Int8(exactly: 1_000)
   ///     // y == nil
   ///
-  /// - Parameter source: A floating-point value to convert to an integer.
+  /// - Parameter source: A value to convert to this type of integer.
   init?<T : BinaryInteger>(exactly source: T)
 
   // FIXME(ABI)#44 (Recursive Protocol Constraints): should be just
@@ -1246,7 +1246,7 @@ extension Numeric {
 /// value is representable in the resulting type.
 ///
 ///     let e = Int8(exactly: 23.0)       // integral value, representable
-///     // e == Optional(127)
+///     // e == Optional(23)
 ///
 ///     let f = Int8(exactly: 23.75)      // fractional value, representable
 ///     // f == nil
@@ -1976,12 +1976,12 @@ public enum ArithmeticOverflow {
 ///     extension FixedWidthInteger {
 ///         var binaryString: String {
 ///             var result: [String] = []
-///             for i in Swift.stride(from: 0, to: Self.bitWidth, by: 8) {
-///                 let wordValue = UInt8(extendingOrTruncating: self >> i)
-///                 let word = String(wordValue, radix: 2)
+///             for i in 0..<(Self.bitWidth / 8) {
+///                 let byte = UInt8(extendingOrTruncating: self >> (i * 8))
+///                 let byteString = String(byte, radix: 2)
 ///                 let padding = String(repeating: "0",
-///                                      count: 8 - word.characters.count)
-///                 result.append(padding + word)
+///                                      count: 8 - byteString.count)
+///                 result.append(padding + byteString)
 ///             }
 ///             return "0b" + result.reversed().joined(separator: "_")
 ///         }
@@ -2009,9 +2009,9 @@ public enum ArithmeticOverflow {
 ///         return result
 ///     }
 ///
-///     let (x, y): (Int8, Int8) = (10, 100)
+///     let (x, y): (Int8, Int8) = (9, 123)
 ///     print(squared(x))
-///     // Prints "Optional(100)"
+///     // Prints "Optional(81)"
 ///     print(squared(y))
 ///     // Prints "nil"
 ///

--- a/stdlib/public/core/MutableCollection.swift
+++ b/stdlib/public/core/MutableCollection.swift
@@ -250,8 +250,8 @@ public protocol MutableCollection : _MutableIndexable, Collection
   subscript(bounds: Range<Index>) -> SubSequence {get set}
 
   /// Reorders the elements of the collection such that all the elements
-  /// that match the given predicate are after all the elements that do
-  /// not match the predicate.
+  /// that match the given predicate are after all the elements that don't
+  /// match.
   ///
   /// After partitioning a collection, there is a pivot index `p` where
   /// no element before `p` satisfies the `belongsInSecondPartition`
@@ -289,10 +289,16 @@ public protocol MutableCollection : _MutableIndexable, Collection
     by belongsInSecondPartition: (Iterator.Element) throws -> Bool
   ) rethrows -> Index
 
-  /// Exchange the values at indices `i` and `j`.
+  /// Exchanges the values at the specified indices of the collection.
   ///
-  /// Has no effect when `i` and `j` are equal.
-  mutating func swapAt(_ i: Index, _ j: Index)  
+  /// Both parameters must be valid indices of the collection that are not
+  /// equal to `endIndex`. Passing the same index as both `i` and `j` has no
+  /// effect.
+  ///
+  /// - Parameters:
+  ///   - i: The index of the first value to swap.
+  ///   - j: The index of the second value to swap.
+  mutating func swapAt(_ i: Index, _ j: Index)
   
   /// Call `body(p)`, where `p` is a pointer to the collection's
   /// mutable contiguous storage.  If no such storage exists, it is
@@ -357,9 +363,15 @@ extension MutableCollection {
     }
   }
 
-  /// Exchange the values at indices `i` and `j`.
+  /// Exchanges the values at the specified indices of the collection.
   ///
-  /// Has no effect when `i` and `j` are equal.
+  /// Both parameters must be valid indices of the collection that are not
+  /// equal to `endIndex`. Calling `swapAt(_:_:)` with the same index as both
+  /// `i` and `j` has no effect.
+  ///
+  /// - Parameters:
+  ///   - i: The index of the first value to swap.
+  ///   - j: The index of the second value to swap.
   @_inlineable
   public mutating func swapAt(_ i: Index, _ j: Index) {
     guard i != j else { return }

--- a/stdlib/public/core/MutableCollection.swift
+++ b/stdlib/public/core/MutableCollection.swift
@@ -267,13 +267,13 @@ public protocol MutableCollection : _MutableIndexable, Collection
   ///     // numbers == [30, 10, 20, 30, 30, 60, 40]
   ///
   /// The `numbers` array is now arranged in two partitions. The first
-  /// partition, `numbers.prefix(upTo: p)`, is made up of the elements that
-  /// are not greater than 30. The second partition, `numbers.suffix(from: p)`,
+  /// partition, `numbers[..<p]`, is made up of the elements that
+  /// are not greater than 30. The second partition, `numbers[p...]`,
   /// is made up of the elements that *are* greater than 30.
   ///
-  ///     let first = numbers.prefix(upTo: p)
+  ///     let first = numbers[..<p]
   ///     // first == [30, 10, 20, 30, 30]
-  ///     let second = numbers.suffix(from: p)
+  ///     let second = numbers[p...]
   ///     // second == [60, 40]
   ///
   /// - Parameter belongsInSecondPartition: A predicate used to partition

--- a/stdlib/public/core/OptionSet.swift
+++ b/stdlib/public/core/OptionSet.swift
@@ -10,10 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// A type that presents a mathematical set interface to a bit mask.
+/// A type that presents a mathematical set interface to a bitset.
 ///
-/// You use the `OptionSet` protocol to represent bit mask types, where
-/// individual bits represent members of the set. Adopting this protocol in
+/// You use the `OptionSet` protocol to represent bitset types, where
+/// individual bits represent members of a set. Adopting this protocol in
 /// your custom types lets you perform set-related operations such as
 /// membership tests, unions, and intersections on those types. What's more,
 /// when implemented using specific criteria, adoption of this protocol
@@ -30,8 +30,8 @@
 /// For example, consider a custom type called `ShippingOptions` that is an
 /// option set of the possible ways to ship a customer's purchase.
 /// `ShippingOptions` includes a `rawValue` property of type `Int` that stores
-/// the bit mask of available shipping options. The static members `NextDay`,
-/// `SecondDay`, `Priority`, and `Standard` are unique, individual options.
+/// the bit mask of available shipping options. The static members `nextDay`,
+/// `secondDay`, `priority`, and `standard` are unique, individual options.
 ///
 ///     struct ShippingOptions: OptionSet {
 ///         let rawValue: Int

--- a/stdlib/public/core/Optional.swift
+++ b/stdlib/public/core/Optional.swift
@@ -68,7 +68,7 @@
 /// -----------------
 ///
 /// To safely access the properties and methods of a wrapped instance, use the
-/// postfix optional chaining operator (`?`). The following example uses
+/// postfix optional chaining operator (postfix `?`). The following example uses
 /// optional chaining to access the `hasSuffix(_:)` method on a `String?`
 /// instance.
 ///

--- a/stdlib/public/core/Range.swift.gyb
+++ b/stdlib/public/core/Range.swift.gyb
@@ -830,7 +830,7 @@ extension CountablePartialRangeFrom: Sequence {
 }
 
 extension Comparable {
-  /// Returns a partial range up to but not including its maximum.
+  /// Returns a partial range up to, but not including, its upper bound.
   ///
   /// Use the partial range up to operator (`..<`) to create a partial range of
   /// any type that conforms to the `Comparable` protocol. This example creates
@@ -840,29 +840,30 @@ extension Comparable {
   ///     print(lessThanFive.contains(3.14))  // Prints "true"
   ///     print(lessThanFive.contains(5.0))   // Prints "false"
   ///
-  /// Partial ranges can be used to slice types conforming to `Collection`
+  /// You can use a partial range to can be used to slice types conforming to `Collection`
   /// from the start of the collection up to, but not including, the maximum.
   ///
-  /// let array = Array(0..<5)
-  /// print(array[..<3])      // prints [0, 1, 2]
+  ///     let numbers = [10, 20, 30, 40, 50, 60, 70]
+  ///     print(numbers[..<3])
+  ///     // Prints "[0, 1, 2]"
   ///
-  /// - Parameters:
-  ///   - maximum: The upper bound for the range.
+  /// - Parameter maximum: The upper bound for the range.
   @_transparent
   public static prefix func ..<(maximum: Self) -> PartialRangeUpTo<Self> {
     return PartialRangeUpTo(maximum)
   }
 
-  /// Returns a partial range up to and including its maximum.
+  /// Returns a partial range up to, and including, its upper bound.
   ///
   /// Use the partial range up to operator (`...`) to create a partial range of
   /// any type that conforms to the `Comparable` protocol. This example creates
-  /// a `PartialRangeThrough<Double>` up to 5.
+  /// a `PartialRangeThrough<Double>` that includes any value less than or equal to `5.0`.
   ///
-  ///     let upToFive = ..<5.0
-  ///     print(upToFive.contains(4))   // Prints "true"
-  ///     print(upToFive.contains(5))   // Prints "true"
-  ///     print(upToFive.contains(6))  // Prints "false"
+  ///     let throughFive = ..<5.0
+  ///
+  ///     throughFive.contains(4.0)       // true
+  ///     throughFive.contains(5.0)       // true
+  ///     throughFive.contains(6.0)       // false
   ///
   /// Partial ranges can be used to slice types conforming to `Collection`
   /// from the start of the collection up to the maximum.

--- a/stdlib/public/core/Range.swift.gyb
+++ b/stdlib/public/core/Range.swift.gyb
@@ -15,16 +15,15 @@
 /// the collection can then slice itself with that `Range`.
 public protocol RangeExpression {
   associatedtype Bound: Comparable
-  /// Returns `self` expressed as a range of indices within `collection`.
+  /// Returns the range of indices within the given collection described by
+  /// this range expression.
   ///
-  /// -Parameter collection: The collection `self` should be
-  ///                        relative to.
-  ///
-  /// -Returns: A `Range<Bound>` suitable for slicing `collection`.
-  ///           The return value is *not* guaranteed to be inside
-  ///           its bounds. Callers should apply the same preconditions
-  ///           to the return value as they would to a range provided
-  ///           directly by the user.
+  /// - Parameter collection: The collection to evaluate this range expression
+  ///   in relation to.
+  /// - Returns: A range suitable for slicing `collection`. The returned range
+  ///   is *not* guaranteed to be inside the bounds of `collection`. Callers
+  ///   should apply the same preconditions to the return value as they would
+  ///   to a range provided directly by the user.
   func relative<C: _Indexable>(
     to collection: C
   ) -> Range<Bound> where C.Index == Bound
@@ -740,6 +739,27 @@ public func ..< <Bound>(
   return CountableRange(uncheckedBounds: (lower: minimum, upper: maximum))
 }
 
+/// A partial half-open interval up to, but not including, an upper bound.
+///
+/// You create `PartialRangeUpTo` instances by using the prefix half-open range
+/// operator (prefix `..<`).
+///
+///     let upToFive = ..<5.0
+///
+/// You can use a `PartialRangeUpTo` instance to quickly check if a value is
+/// contained in a particular range of values. For example:
+///
+///     upToFive.contains(3.14)       // true
+///     upToFive.contains(6.28)       // false
+///     upToFive.contains(5.0)        // false
+///
+/// You can use a `PartialRangeUpTo` instance of a collection's indices to
+/// represent the range from the start of the collection up to, but not
+/// including, the partial range's upper bound.
+///
+///     let numbers = [10, 20, 30, 40, 50, 60, 70]
+///     print(numbers[..<3])
+///     // Prints "[10, 20, 30]"
 @_fixed_layout
 public struct PartialRangeUpTo<Bound: Comparable>: RangeExpression {
   public init(_ upperBound: Bound) { self.upperBound = upperBound }
@@ -758,6 +778,27 @@ public struct PartialRangeUpTo<Bound: Comparable>: RangeExpression {
   }
 }
 
+/// A partial half-open interval up to, and including, an upper bound.
+///
+/// You create `PartialRangeThrough` instances by using the prefix closed range
+/// operator (prefix `...`).
+///
+///     let throughFive = ...5.0
+///
+/// You can use a `PartialRangeThrough` instance to quickly check if a value is
+/// contained in a particular range of values. For example:
+///
+///     throughFive.contains(4.0)     // true
+///     throughFive.contains(5.0)     // true
+///     throughFive.contains(6.0)     // false
+///
+/// You can use a `PartialRangeThrough` instance of a collection's indices to
+/// represent the range from the start of the collection up to, and including,
+/// the partial range's upper bound.
+///
+///     let numbers = [10, 20, 30, 40, 50, 60, 70]
+///     print(numbers[...3])
+///     // Prints "[10, 20, 30, 40]"
 @_fixed_layout
 public struct PartialRangeThrough<Bound: Comparable>: RangeExpression {  
   public init(_ upperBound: Bound) { self.upperBound = upperBound }
@@ -775,6 +816,27 @@ public struct PartialRangeThrough<Bound: Comparable>: RangeExpression {
   }
 }
 
+/// A partial interval extending upward from a lower bound.
+///
+/// You create `PartialRangeFrom` instances by using the postfix range
+/// operator (postfix `...`).
+///
+///     let atLeastFive = 5.0...
+///
+/// You can use a `PartialRangeFrom` instance to quickly check if a value is
+/// contained in a particular range of values. For example:
+///
+///     atLeastFive.contains(4.0)     // false
+///     atLeastFive.contains(5.0)     // true
+///     atLeastFive.contains(6.0)     // true
+///
+/// You can use a `PartialRangeFrom` instance of a collection's indices to
+/// represent the range from the partial range's lower bound up to the end
+/// of the collection.
+///
+///     let numbers = [10, 20, 30, 40, 50, 60, 70]
+///     print(numbers[3...])
+///     // Prints "[40, 50, 60, 70]"
 @_fixed_layout
 public struct PartialRangeFrom<Bound: Comparable>: RangeExpression {
   public init(_ lowerBound: Bound) { self.lowerBound = lowerBound }
@@ -793,6 +855,86 @@ public struct PartialRangeFrom<Bound: Comparable>: RangeExpression {
   }
 }
 
+/// A partial interval extending upward from a lower bound.
+///
+/// You create `PartialRangeFrom` instances by using the postfix range operator
+/// (postfix `...`).
+///
+///     let atLeastFive = 5.0...
+///
+/// You can use a `PartialRangeFrom` instance to quickly check if a value is
+/// contained in a particular range of values. For example:
+///
+///     atLeastFive.contains(4.0)     // false
+///     atLeastFive.contains(5.0)     // true
+///     atLeastFive.contains(6.0)     // true
+///
+/// You can use a `PartialRangeFrom` instance of a collection's indices to
+/// represent the range from the partial range's lower bound up to the end of
+/// the collection.
+///
+///     let numbers = [10, 20, 30, 40, 50, 60, 70]
+///     print(numbers[3...])
+///     // Prints "[40, 50, 60, 70]"
+///
+/// You can create a countable partial range over any type that conforms to the
+/// `Strideable` protocol and uses an integer as its associated `Stride` type.
+/// By default, Swift's integer and pointer types are usable as the bounds of
+/// a countable range.
+///
+/// Using a Partial Range as a Sequence
+/// ===================================
+///
+/// You can iterate over a `PartialRangeFrom` instance using a `for`-`in` loop,
+/// or call any sequence method that doesn't require that the sequence is
+/// finite.
+///
+///     func isTheMagicNumber(_ x: Int) -> Bool {
+///         return x == 3
+///     }
+///
+///     for x in 1... {
+///         if isTheMagicNumber(x) {
+///             print("\(x) is the magic number!")
+///             break
+///         } else {
+///             print("\(x) wasn't it...")
+///         }
+///     }
+///     // "1 wasn't it..."
+///     // "2 wasn't it..."
+///     // "3 is the magic number!"
+///
+/// Because a `CountablePartialRangeFrom` sequence counts upward indefinitely,
+/// do not use one with methods such as `map(_:)`, `filter(_:)`, or
+/// `suffix(_:)` that read the entire sequence before returning. It is safe to
+/// use operations that put an upper limit on the number of elements they
+/// access, such as `prefix(_:)` or `dropFirst(_:)`, and operations that you
+/// can guarantee will terminate, such as passing a closure you know will
+/// eventually return `true` to `first(where:)`.
+///
+/// In the following example, the `asciiTable` sequence is made by zipping
+/// together the characters in the `alphabet` string with a partial range
+/// starting at 65, the ASCII value of the capital letter A. Iterating over
+/// two zipped sequence continues only as long as the shorter of the two
+/// sequences, so the iteration stops at the end of `alphabet`.
+///
+///     let alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+///     let asciiTable = zip(65..., alphabet)
+///     for (code, letter) in asciiTable {
+///         print(code, letter)
+///     }
+///     // "65 A"
+///     // "66 B"
+///     // "67 C"
+///     // ...
+///     // "89 Y"
+///     // "90 Z"
+///
+/// The behavior of incrementing indefinitely is determined by the type of
+/// `Bound`. For example, iterating over an instance of
+/// `CountablePartialRangeFrom<Int>` will trap when the sequence's next value
+/// would be above `Int.max`.
 @_fixed_layout
 public struct CountablePartialRangeFrom<
   Bound: Strideable
@@ -832,20 +974,24 @@ extension CountablePartialRangeFrom: Sequence {
 extension Comparable {
   /// Returns a partial range up to, but not including, its upper bound.
   ///
-  /// Use the partial range up to operator (`..<`) to create a partial range of
-  /// any type that conforms to the `Comparable` protocol. This example creates
-  /// a `PartialRangeUpTo<Double>` up to, but not including, 5.0.
+  /// Use the prefix half-open range operator (prefix `..<`) to create a
+  /// partial range of any type that conforms to the `Comparable` protocol.
+  /// This example creates a `PartialRangeUpTo<Double>` instance that includes
+  /// any value less than `5.0`.
   ///
-  ///     let lessThanFive = ..<5.0
-  ///     print(lessThanFive.contains(3.14))  // Prints "true"
-  ///     print(lessThanFive.contains(5.0))   // Prints "false"
+  ///     let upToFive = ..<5.0
   ///
-  /// You can use a partial range to can be used to slice types conforming to `Collection`
-  /// from the start of the collection up to, but not including, the maximum.
+  ///     upToFive.contains(3.14)       // true
+  ///     upToFive.contains(6.28)       // false
+  ///     upToFive.contains(5.0)        // false
+  ///
+  /// You can use this type of partial range of a collection's indices to
+  /// represent the range from the start of the collection up to, but not
+  /// including, the partial range's upper bound.
   ///
   ///     let numbers = [10, 20, 30, 40, 50, 60, 70]
   ///     print(numbers[..<3])
-  ///     // Prints "[0, 1, 2]"
+  ///     // Prints "[10, 20, 30]"
   ///
   /// - Parameter maximum: The upper bound for the range.
   @_transparent
@@ -855,42 +1001,53 @@ extension Comparable {
 
   /// Returns a partial range up to, and including, its upper bound.
   ///
-  /// Use the partial range up to operator (`...`) to create a partial range of
-  /// any type that conforms to the `Comparable` protocol. This example creates
-  /// a `PartialRangeThrough<Double>` that includes any value less than or equal to `5.0`.
+  /// Use the prefix closed range operator (prefix `...`) to create a partial
+  /// range of any type that conforms to the `Comparable` protocol. This
+  /// example creates a `PartialRangeThrough<Double>` instance that includes
+  /// any value less than or equal to `5.0`.
   ///
-  ///     let throughFive = ..<5.0
+  ///     let throughFive = ...5.0
   ///
-  ///     throughFive.contains(4.0)       // true
-  ///     throughFive.contains(5.0)       // true
-  ///     throughFive.contains(6.0)       // false
+  ///     throughFive.contains(4.0)     // true
+  ///     throughFive.contains(5.0)     // true
+  ///     throughFive.contains(6.0)     // false
   ///
-  /// Partial ranges can be used to slice types conforming to `Collection`
-  /// from the start of the collection up to the maximum.
+  /// You can use this type of partial range of a collection's indices to
+  /// represent the range from the start of the collection up to, and
+  /// including, the partial range's upper bound.
   ///
-  /// let array = Array(0..<5)
-  /// print(array[...3])      // prints [0, 1, 2, 3]
+  ///     let numbers = [10, 20, 30, 40, 50, 60, 70]
+  ///     print(numbers[...3])
+  ///     // Prints "[10, 20, 30, 40]"
   ///
-  /// - Parameters:
-  ///   - maximum: The upper bound for the range.
+  /// - Parameter maximum: The upper bound for the range.
   @_transparent
   public static prefix func ...(maximum: Self) -> PartialRangeThrough<Self> {
     return PartialRangeThrough(maximum)
   }
 
-  /// Returns a countable partial range from a lower bound.
+  /// Returns a partial range extending upward from a lower bound.
   ///
-  /// Use the partial range up to operator (`...`) to create a range of any type
-  /// that conforms to the `Strideable` protocol with an associated integer
-  /// `Stride` type, such as any of the standard library's integer types. This
-  /// example creates a `CountablePartialRangeFrom<Int>` from 5 up.
+  /// Use the postfix range operator (postfix `...`) to create a partial range
+  /// of any type that conforms to the `Comparable` protocol. This example
+  /// creates a `PartialRangeFrom<Double>` instance that includes any value
+  /// greater than or equal to `5.0`.
   ///
-  ///     let fiveOrMore = 5...
-  ///     print(fiveOrMore.contains(3))         // Prints "false"
-  ///     print(fiveOrMore.contains(5))         // Prints "true"
+  ///     let atLeastFive = 5.0...
   ///
-  /// - Parameters:
-  ///   - minimum: The lower bound for the range.
+  ///     atLeastFive.contains(4.0)     // false
+  ///     atLeastFive.contains(5.0)     // true
+  ///     atLeastFive.contains(6.0)     // true
+  ///
+  /// You can use this type of partial range of a collection's indices to
+  /// represent the range from the partial range's lower bound up to the end
+  /// of the collection.
+  ///
+  ///     let numbers = [10, 20, 30, 40, 50, 60, 70]
+  ///     print(numbers[3...])
+  ///     // Prints "[40, 50, 60, 70]"
+  ///
+  /// - Parameter minimum: The lower bound for the range.
   @_transparent
   public static postfix func ...(minimum: Self) -> PartialRangeFrom<Self> {
     return PartialRangeFrom(minimum)
@@ -898,31 +1055,80 @@ extension Comparable {
 }
 
 extension Strideable where Stride: SignedInteger {
-  /// Returns a countable partial range from a lower bound.
+  /// Returns a countable partial range extending upward from a lower bound.
   ///
-  /// Use the partial range up to operator (`...`) to create a range of any type
-  /// that conforms to the `Strideable` protocol with an associated integer
-  /// `Stride` type, such as any of the standard library's integer types. This
-  /// example creates a `CountablePartialRangeFrom<Int>` from 5 up.
+  /// Use the postfix range operator (postfix `...`) to create a partial range
+  /// of any type that conforms to the `Strideable` protocol with an
+  /// associated integer `Stride` type, such as any of the standard library's
+  /// integer types. This example creates a `CountablePartialRangeFrom<Int>`
+  /// instance that includes any value greater than or equal to `5`.
   ///
-  ///     let fiveOrMore = 5...
-  ///     print(fiveOrMore.contains(3))         // Prints "false"
-  ///     print(fiveOrMore.contains(5))         // Prints "true"
+  ///     let atLeastFive = 5...
   ///
-  /// You can use sequence methods on these partial ranges.
+  ///     atLeastFive.contains(4)       // false
+  ///     atLeastFive.contains(5)       // true
+  ///     atLeastFive.contains(6)       // true
   ///
-  /// let alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-  /// let asciiTable = zip(0x41..., alphabet)
-  /// for (code, letter) in asciiTable { print(code, letter) }
+  /// You can use this type of partial range of a collection's indices to
+  /// represent the range from the partial range's lower bound up to the end
+  /// of the collection.
   ///
-  /// Note that these sequences count up indefinitely. You should not use them
-  /// with algorithms such as `map` or `filter` that will try to read the entire
-  /// sequence eagerly. The upper limit for the sequence is determined by the
-  /// type of `Bound`. For example, `CountablePartialRangeFrom<Int>` will trap
-  /// when the sequences' next value would be above `Int.max`.
+  ///     let numbers = [10, 20, 30, 40, 50, 60, 70]
+  ///     print(numbers[3...])
+  ///     // Prints "[40, 50, 60, 70]"
   ///
-  /// - Parameters:
-  ///   - minimum: The lower bound for the range.
+  /// You can also iterate over this type of partial range using a `for`-`in`
+  /// loop, or call any sequence method that doesn't require that the sequence
+  /// is finite.
+  ///
+  ///     func isTheMagicNumber(_ x: Int) -> Bool {
+  ///         return x == 3
+  ///     }
+  ///
+  ///     for x in 1... {
+  ///         if isTheMagicNumber(x) {
+  ///             print("\(x) is the magic number!")
+  ///             break
+  ///         } else {
+  ///             print("\(x) wasn't it...")
+  ///         }
+  ///     }
+  ///     // "1 wasn't it..."
+  ///     // "2 wasn't it..."
+  ///     // "3 is the magic number!"
+  ///
+  /// Because a sequence created with the postfix range operator counts upward
+  /// indefinitely, do not use one with methods such as `map(_:)`,
+  /// `filter(_:)`, or `suffix(_:)` that read the entire sequence before
+  /// returning. It is safe to use operations that put an upper limit on the
+  /// number of elements they access, such as `prefix(_:)` or `dropFirst(_:)`,
+  /// and operations that you can guarantee will terminate, such as passing a
+  /// closure you know will eventually return `true` to `first(where:)`.
+  ///
+  /// In the following example, the `asciiTable` sequence is made by zipping
+  /// together the characters in the `alphabet` string with a partial range
+  /// starting at 65, the ASCII value of the capital letter A.
+  /// Iterating over two zipped sequence continues only as long as the shorter
+  /// of the two sequences, so the iteration stops at the end of `alphabet`.
+  ///
+  ///     let alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+  ///     let asciiTable = zip(65..., alphabet)
+  ///     for (code, letter) in asciiTable {
+  ///         print(code, letter)
+  ///     }
+  ///     // "65 A"
+  ///     // "66 B"
+  ///     // "67 C"
+  ///     // ...
+  ///     // "89 Y"
+  ///     // "90 Z"
+  ///
+  /// The behavior of incrementing indefinitely is determined by the type of
+  /// `Bound`. For example, iterating over an instance of
+  /// `CountablePartialRangeFrom<Int>` will trap when the sequence's next
+  /// value would be above `Int.max`.
+  ///
+  /// - Parameter minimum: The lower bound for the range.
   @_transparent
   public static postfix func ...(minimum: Self)
   -> CountablePartialRangeFrom<Self> {

--- a/stdlib/public/core/Reverse.swift
+++ b/stdlib/public/core/Reverse.swift
@@ -17,7 +17,7 @@ extension MutableCollection where Self : BidirectionalCollection {
   ///
   ///     var characters: [Character] = ["C", "a", "f", "é"]
   ///     characters.reverse()
-  ///     print(cafe.characters)
+  ///     print(characters)
   ///     // Prints "["é", "f", "a", "C"]
   ///
   /// - Complexity: O(*n*), where *n* is the number of elements in the
@@ -86,12 +86,12 @@ public struct ReversedIndex<Base : Collection> : Comparable {
   /// `"a"` character in a string's character view.
   ///
   ///     let name = "Horatio"
-  ///     let aIndex = name.characters.index(of: "a")!
-  ///     // name.characters[aIndex] == "a"
+  ///     let aIndex = name.index(of: "a")!
+  ///     // name[aIndex] == "a"
   ///
-  ///     let reversedCharacters = name.characters.reversed()
-  ///     let i = ReversedIndex<String.CharacterView>(aIndex)
-  ///     // reversedCharacters[i] == "r"
+  ///     let reversedName = name.reversed()
+  ///     let i = ReversedIndex<String>(aIndex)
+  ///     // reversedName[i] == "r"
   ///
   /// The element at the position created using `ReversedIndex<...>(aIndex)` is
   /// `"r"`, the character before `"a"` in the `name` string.
@@ -286,12 +286,12 @@ public struct ReversedRandomAccessIndex<
   /// index of the `"a"` character in a string's character view.
   ///
   ///     let name = "Horatio"
-  ///     let aIndex = name.characters.index(of: "a")!
-  ///     // name.characters[aIndex] == "a"
+  ///     let aIndex = name.index(of: "a")!
+  ///     // name[aIndex] == "a"
   ///
-  ///     let reversedCharacters = name.characters.reversed()
-  ///     let i = ReversedIndex<String.CharacterView>(aIndex)
-  ///     // reversedCharacters[i] == "r"
+  ///     let reversedName = name.reversed()
+  ///     let i = ReversedIndex<String>(aIndex)
+  ///     // reversedName[i] == "r"
   ///
   /// The element at the position created using `ReversedIndex<...>(aIndex)` is
   /// `"r"`, the character before `"a"` in the `name` string. Viewed from the
@@ -453,8 +453,8 @@ extension BidirectionalCollection {
   /// string in reverse order:
   ///
   ///     let word = "Backwards"
-  ///     for char in word.characters.reversed() {
-  ///         print(char, terminator="")
+  ///     for char in word.reversed() {
+  ///         print(char, terminator: "")
   ///     }
   ///     // Prints "sdrawkcaB"
   ///
@@ -463,7 +463,7 @@ extension BidirectionalCollection {
   /// example, to get the reversed version of a string, reverse its
   /// characters and initialize a new `String` instance from the result.
   ///
-  ///     let reversedWord = String(word.characters.reversed())
+  ///     let reversedWord = String(word.reversed())
   ///     print(reversedWord)
   ///     // Prints "sdrawkcaB"
   ///

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -91,7 +91,7 @@
 /// `animals` array introduced earlier as an example:
 ///
 ///     let longestAnimal = animals.reduce1 { current, element in
-///         if current.characters.count > element.characters.count {
+///         if current.count > element.count {
 ///             return current
 ///         } else {
 ///             return element
@@ -365,7 +365,7 @@ public protocol Sequence {
   ///     let cast = ["Vivien", "Marlon", "Kim", "Karl"]
   ///     let lowercaseNames = cast.map { $0.lowercased() }
   ///     // 'lowercaseNames' == ["vivien", "marlon", "kim", "karl"]
-  ///     let letterCounts = cast.map { $0.characters.count }
+  ///     let letterCounts = cast.map { $0.count }
   ///     // 'letterCounts' == [6, 6, 3, 4]
   ///
   /// - Parameter transform: A mapping closure. `transform` accepts an
@@ -384,7 +384,7 @@ public protocol Sequence {
   /// five characters.
   ///
   ///     let cast = ["Vivien", "Marlon", "Kim", "Karl"]
-  ///     let shortNames = cast.filter { $0.characters.count < 5 }
+  ///     let shortNames = cast.filter { $0.count < 5 }
   ///     print(shortNames)
   ///     // Prints "["Kim", "Karl"]"
   ///
@@ -562,27 +562,25 @@ public protocol Sequence {
   /// that was originally separated by one or more spaces.
   ///
   ///     let line = "BLANCHE:   I don't want realism. I want magic!"
-  ///     print(line.characters.split(whereSeparator: { $0 == " " })
-  ///                          .map(String.init))
+  ///     print(line.split(whereSeparator: { $0 == " " })
+  ///               .map(String.init))
   ///     // Prints "["BLANCHE:", "I", "don\'t", "want", "realism.", "I", "want", "magic!"]"
   ///
   /// The second example passes `1` for the `maxSplits` parameter, so the
   /// original string is split just once, into two new strings.
   ///
   ///     print(
-  ///         line.characters.split(maxSplits: 1, whereSeparator: { $0 == " " })
-  ///                        .map(String.init))
+  ///         line.split(maxSplits: 1, whereSeparator: { $0 == " " })
+  ///             .map(String.init))
   ///     // Prints "["BLANCHE:", "  I don\'t want realism. I want magic!"]"
   ///
   /// The final example passes `false` for the `omittingEmptySubsequences`
   /// parameter, so the returned array contains empty strings where spaces
   /// were repeated.
   ///
-  ///     print(
-  ///         line.characters.split(
-  ///             omittingEmptySubsequences: false, 
-  ///             whereSeparator: { $0 == " " })
-  ///         ).map(String.init))
+  ///     print(line.split(omittingEmptySubsequences: false,
+  ///                      whereSeparator: { $0 == " " })
+  ///          ).map(String.init))
   ///     // Prints "["BLANCHE:", "", "", "I", "don\'t", "want", "realism.", "I", "want", "magic!"]"
   ///
   /// - Parameters:
@@ -830,7 +828,7 @@ extension Sequence {
   ///     let cast = ["Vivien", "Marlon", "Kim", "Karl"]
   ///     let lowercaseNames = cast.map { $0.lowercased() }
   ///     // 'lowercaseNames' == ["vivien", "marlon", "kim", "karl"]
-  ///     let letterCounts = cast.map { $0.characters.count }
+  ///     let letterCounts = cast.map { $0.count }
   ///     // 'letterCounts' == [6, 6, 3, 4]
   ///
   /// - Parameter transform: A mapping closure. `transform` accepts an
@@ -866,7 +864,7 @@ extension Sequence {
   /// five characters.
   ///
   ///     let cast = ["Vivien", "Marlon", "Kim", "Karl"]
-  ///     let shortNames = cast.filter { $0.characters.count < 5 }
+  ///     let shortNames = cast.filter { $0.count < 5 }
   ///     print(shortNames)
   ///     // Prints "["Kim", "Karl"]"
   ///
@@ -950,15 +948,15 @@ extension Sequence {
   /// that was originally separated by one or more spaces.
   ///
   ///     let line = "BLANCHE:   I don't want realism. I want magic!"
-  ///     print(line.characters.split(whereSeparator: { $0 == " " })
-  ///                          .map(String.init))
+  ///     print(line.split(whereSeparator: { $0 == " " })
+  ///               .map(String.init))
   ///     // Prints "["BLANCHE:", "I", "don\'t", "want", "realism.", "I", "want", "magic!"]"
   ///
   /// The second example passes `1` for the `maxSplits` parameter, so the
   /// original string is split just once, into two new strings.
   ///
   ///     print(
-  ///        line.characters.split(maxSplits: 1, whereSeparator: { $0 == " " })
+  ///        line.split(maxSplits: 1, whereSeparator: { $0 == " " })
   ///                       .map(String.init))
   ///     // Prints "["BLANCHE:", "  I don\'t want realism. I want magic!"]"
   ///
@@ -966,7 +964,7 @@ extension Sequence {
   /// the returned array contains empty strings where spaces were repeated.
   ///
   ///     print(
-  ///         line.characters.split(
+  ///         line.split(
   ///             omittingEmptySubsequences: false, 
   ///             whereSeparator: { $0 == " " }
   ///         ).map(String.init))
@@ -1152,23 +1150,23 @@ extension Sequence where Iterator.Element : Equatable {
   /// was originally separated by one or more spaces.
   ///
   ///     let line = "BLANCHE:   I don't want realism. I want magic!"
-  ///     print(line.characters.split(separator: " ")
-  ///                          .map(String.init))
+  ///     print(line.split(separator: " ")
+  ///               .map(String.init))
   ///     // Prints "["BLANCHE:", "I", "don\'t", "want", "realism.", "I", "want", "magic!"]"
   ///
   /// The second example passes `1` for the `maxSplits` parameter, so the
   /// original string is split just once, into two new strings.
   ///
-  ///     print(line.characters.split(separator: " ", maxSplits: 1)
-  ///                           .map(String.init))
+  ///     print(line.split(separator: " ", maxSplits: 1)
+  ///               .map(String.init))
   ///     // Prints "["BLANCHE:", "  I don\'t want realism. I want magic!"]"
   ///
   /// The final example passes `false` for the `omittingEmptySubsequences`
   /// parameter, so the returned array contains empty strings where spaces
   /// were repeated.
   ///
-  ///     print(line.characters.split(separator: " ", omittingEmptySubsequences: false)
-  ///                           .map(String.init))
+  ///     print(line.split(separator: " ", omittingEmptySubsequences: false)
+  ///               .map(String.init))
   ///     // Prints "["BLANCHE:", "", "", "I", "don\'t", "want", "realism.", "I", "want", "magic!"]"
   ///
   /// - Parameters:

--- a/stdlib/public/core/SequenceAlgorithms.swift.gyb
+++ b/stdlib/public/core/SequenceAlgorithms.swift.gyb
@@ -56,7 +56,7 @@ extension Sequence {
   /// This example enumerates the characters of the string "Swift" and prints
   /// each character along with its place in the string.
   ///
-  ///     for (n, c) in "Swift".characters.enumerated() {
+  ///     for (n, c) in "Swift".enumerated() {
   ///         print("\(n): '\(c)'")
   ///     }
   ///     // Prints "0: 'S'"
@@ -79,7 +79,7 @@ extension Sequence {
   ///     let names: Set = ["Sofia", "Camilla", "Martina", "Mateo", "Nicolás"]
   ///     var shorterIndices: [SetIndex<String>] = []
   ///     for (i, name) in zip(names.indices, names) {
-  ///         if name.characters.count <= 5 {
+  ///         if name.count <= 5 {
   ///             shorterIndices.append(i)
   ///         }
   ///     }

--- a/stdlib/public/core/Sort.swift
+++ b/stdlib/public/core/Sort.swift
@@ -336,9 +336,23 @@ func _heapSort<C>(
   }
 }
 
-/// Exchange the values of `a` and `b`.
+/// Exchanges the values of the two given variables.
 ///
-/// - Precondition: `a` and `b` do not alias each other.
+/// The two variables passed must not alias each other. That is, it is an error to
+/// pass the same variable as both `a` and `b`.
+///
+/// In the following example, the call to `swap(_:_:)` guarantees that the value
+/// in `a` is always less than the value in `b`:
+///
+///     var a: Int = getNumber()
+///     var b: Int = getNumber()
+///     if a >= b {
+///         swap(&a, &b)
+///     }
+///
+/// - Parameters:
+///   - i: The first value to swap.
+///   - j: The index of the second value to swap.
 @_inlineable
 public func swap<T>(_ a: inout T, _ b: inout T) {
   // Semantically equivalent to (a, b) = (b, a).

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -38,32 +38,34 @@ public protocol StringProtocol
   func lowercased() -> String
   func uppercased() -> String
 
-  /// Constructs a `String` having the same contents as `codeUnits`.
+  /// Creates a string from the given Unicode code units in the specific encoding.
   ///
-  /// - Parameter codeUnits: a collection of code units in
-  ///   the given `encoding`.
-  /// - Parameter encoding: describes the encoding in which the code units
+  /// - Parameters:
+  ///   - codeUnits: A collection of code units encoded in the ecoding specified in
+  ///   `encoding`.
+  ///   - encoding: The encoding in which `codeUnits`
   ///   should be interpreted.
   init<C: Collection, Encoding: Unicode.Encoding>(
     decoding codeUnits: C, as encoding: Encoding.Type
   )
     where C.Iterator.Element == Encoding.CodeUnit
 
-  /// Constructs a `String` having the same contents as `nulTerminatedUTF8`.
+  /// Creates a string from the null-terminated, UTF-8 encoded sequence of bytes at the given pointer.
   ///
-  /// - Parameter nulTerminatedUTF8: a sequence of contiguous UTF-8 encoded 
-  ///   bytes ending just before the first zero byte (NUL character).
+  /// - Parameter nulTerminatedUTF8: A pointer to a sequence of contiguous, UTF-8 encoded
+  ///   bytes ending just before the first zero byte.
   init(cString nulTerminatedUTF8: UnsafePointer<CChar>)
   
-  /// Constructs a `String` having the same contents as `nulTerminatedCodeUnits`.
+  /// Creates a string from the null-terminated sequence of bytes at the given pointer.
   ///
-  /// - Parameter nulTerminatedCodeUnits: a sequence of contiguous code units in
-  ///   the given `encoding`, ending just before the first zero code unit.
-  /// - Parameter encoding: describes the encoding in which the code units
+  /// - Parameters:
+  ///   - nulTerminatedCodeUnits: A pointer to a sequence of contiguous code units in
+  ///   the encoding specified in `encoding`, ending just before the first zero code unit.
+  ///   - encoding: The encoding in which the code units
   ///   should be interpreted.
   init<Encoding: Unicode.Encoding>(
     decodingCString nulTerminatedCodeUnits: UnsafePointer<Encoding.CodeUnit>,
-    as: Encoding.Type)
+    as encoding: Encoding.Type)
     
   /// Invokes the given closure on the contents of the string, represented as a
   /// pointer to a null-terminated sequence of UTF-8 code units.

--- a/stdlib/public/core/StringCharacterView.swift
+++ b/stdlib/public/core/StringCharacterView.swift
@@ -51,7 +51,7 @@ extension String {
   ///
   ///     let name = "Marie Curie"
   ///     if let firstSpace = name.characters.index(of: " ") {
-  ///         let firstName = String(name.characters.prefix(upTo: firstSpace))
+  ///         let firstName = String(name.characters[..<firstSpace])
   ///         print(firstName)
   ///     }
   ///     // Prints "Marie"
@@ -100,8 +100,8 @@ extension String {
   ///     var str = "All this happened, more or less."
   ///     let afterSpace = str.withMutableCharacters { chars -> String.CharacterView in
   ///         if let i = chars.index(of: " ") {
-  ///             let result = chars.suffix(from: chars.index(after: i))
-  ///             chars.removeSubrange(i..<chars.endIndex)
+  ///             let result = chars[chars.index(after: i)...]
+  ///             chars.removeSubrange(i...)
   ///             return result
   ///         }
   ///         return String.CharacterView()
@@ -135,10 +135,12 @@ extension String {
   /// Use this initializer to recover a string after performing a collection
   /// slicing operation on a string's character view.
   ///
-  ///     let poem = "'Twas brillig, and the slithy toves / " +
-  ///                "Did gyre and gimbal in the wabe: / " +
-  ///                "All mimsy were the borogoves / " +
-  ///                "And the mome raths outgrabe."
+  ///     let poem = """
+  ///           'Twas brillig, and the slithy toves /
+  ///           Did gyre and gimbal in the wabe: /
+  ///           All mimsy were the borogoves /
+  ///           And the mome raths outgrabe.
+  ///           """
   ///     let excerpt = String(poem.characters.prefix(22)) + "..."
   ///     print(excerpt)
   ///     // Prints "'Twas brillig, and the..."
@@ -167,7 +169,7 @@ extension String.CharacterView : BidirectionalCollection {
   ///     let hearts = "Hearts <3 ♥︎ 💘"
   ///     if let i = hearts.characters.index(of: " ") {
   ///         let j = i.samePosition(in: hearts.utf8)
-  ///         print(Array(hearts.utf8.prefix(upTo: j)))
+  ///         print(Array(hearts.utf8[..<j]))
   ///     }
   ///     // Prints "[72, 101, 97, 114, 116, 115]"
   public struct Index : Comparable, CustomPlaygroundQuickLookable {

--- a/stdlib/public/core/StringIndexConversions.swift
+++ b/stdlib/public/core/StringIndexConversions.swift
@@ -15,24 +15,24 @@ extension String.Index {
   /// specified `UnicodeScalarView` position.
   ///
   /// The following example converts the position of the Unicode scalar `"e"`
-  /// into its corresponding position in the string's character view. The
-  /// character at that position is the composed `"é"` character.
+  /// into its corresponding position in the string. The character at that
+  /// position is the composed `"é"` character.
   ///
   ///     let cafe = "Cafe\u{0301}"
   ///     print(cafe)
   ///     // Prints "Café"
   ///
   ///     let scalarsIndex = cafe.unicodeScalars.index(of: "e")!
-  ///     let charactersIndex = String.Index(scalarsIndex, within: cafe)!
+  ///     let stringIndex = String.Index(scalarsIndex, within: cafe)!
   ///
-  ///     print(String(cafe.characters.prefix(through: charactersIndex)))
+  ///     print(cafe[...stringIndex])
   ///     // Prints "Café"
   ///
   /// If the position passed in `unicodeScalarIndex` doesn't have an exact
-  /// corresponding position in `other.characters`, the result of the
-  /// initializer is `nil`. For example, an attempt to convert the position of
-  /// the combining acute accent (`"\u{0301}"`) fails. Combining Unicode
-  /// scalars do not have their own position in a character view.
+  /// corresponding position in `other`, the result of the initializer is
+  /// `nil`. For example, an attempt to convert the position of the combining
+  /// acute accent (`"\u{0301}"`) fails. Combining Unicode scalars do not have
+  /// their own position in a string.
   ///
   ///     let nextIndex = String.Index(cafe.unicodeScalars.index(after: scalarsIndex),
   ///                                  within: cafe)
@@ -58,27 +58,26 @@ extension String.Index {
   /// specified `UTF16View` position.
   ///
   /// The following example finds the position of a space in a string's `utf16`
-  /// view and then converts that position to an index in the string's
-  /// `characters` view. The value `32` is the UTF-16 encoded value of a space
-  /// character.
+  /// view and then converts that position to an index in the string. The
+  /// value `32` is the UTF-16 encoded value of a space character.
   ///
   ///     let cafe = "Café 🍵"
   ///
   ///     let utf16Index = cafe.utf16.index(of: 32)!
-  ///     let charactersIndex = String.Index(utf16Index, within: cafe)!
+  ///     let stringIndex = String.Index(utf16Index, within: cafe)!
   ///
-  ///     print(String(cafe.characters.prefix(upTo: charactersIndex)))
+  ///     print(cafe[..<stringIndex])
   ///     // Prints "Café"
   ///
   /// If the position passed in `utf16Index` doesn't have an exact
-  /// corresponding position in `other.characters`, the result of the
-  /// initializer is `nil`. For example, an attempt to convert the position of
-  /// the trailing surrogate of a UTF-16 surrogate pair fails.
+  /// corresponding position in `other`, the result of the initializer is
+  /// `nil`. For example, an attempt to convert the position of the trailing
+  /// surrogate of a UTF-16 surrogate pair fails.
   ///
   /// The next example attempts to convert the indices of the two UTF-16 code
   /// points that represent the teacup emoji (`"🍵"`). The index of the lead
-  /// surrogate is successfully converted to a position in `other.characters`,
-  /// but the index of the trailing surrogate is not.
+  /// surrogate is successfully converted to a position in `other`, but the
+  /// index of the trailing surrogate is not.
   ///
   ///     let emojiHigh = cafe.utf16.index(after: utf16Index)
   ///     print(String.Index(emojiHigh, within: cafe))
@@ -110,9 +109,9 @@ extension String.Index {
   /// specified `UTF8View` position.
   ///
   /// If the position passed in `utf8Index` doesn't have an exact corresponding
-  /// position in `other.characters`, the result of the initializer is `nil`.
-  /// For example, an attempt to convert the position of a UTF-8 continuation
-  /// byte returns `nil`.
+  /// position in `other`, the result of the initializer is `nil`. For
+  /// example, an attempt to convert the position of a UTF-8 continuation byte
+  /// returns `nil`.
   ///
   /// - Parameters:
   ///   - utf8Index: A position in the `utf8` view of the `other` parameter.
@@ -135,15 +134,15 @@ extension String.Index {
   /// Returns the position in the given UTF-8 view that corresponds exactly to
   /// this index.
   ///
-  /// The index must be a valid index of `String(utf8).characters`.
+  /// The index must be a valid index of `String(utf8)`.
   ///
   /// This example first finds the position of the character `"é"` and then uses
   /// this method find the same position in the string's `utf8` view.
   ///
   ///     let cafe = "Café"
-  ///     if let i = cafe.characters.index(of: "é") {
+  ///     if let i = cafe.index(of: "é") {
   ///         let j = i.samePosition(in: cafe.utf8)
-  ///         print(Array(cafe.utf8.suffix(from: j)))
+  ///         print(Array(cafe.utf8[j...]))
   ///     }
   ///     // Prints "[195, 169]"
   ///
@@ -158,13 +157,13 @@ extension String.Index {
   /// Returns the position in the given UTF-16 view that corresponds exactly to
   /// this index.
   ///
-  /// The index must be a valid index of `String(utf16).characters`.
+  /// The index must be a valid index of `String(utf16)`.
   ///
   /// This example first finds the position of the character `"é"` and then uses
   /// this method find the same position in the string's `utf16` view.
   ///
   ///     let cafe = "Café"
-  ///     if let i = cafe.characters.index(of: "é") {
+  ///     if let i = cafe.index(of: "é") {
   ///         let j = i.samePosition(in: cafe.utf16)
   ///         print(cafe.utf16[j])
   ///     }
@@ -181,14 +180,14 @@ extension String.Index {
   /// Returns the position in the given view of Unicode scalars that
   /// corresponds exactly to this index.
   ///
-  /// The index must be a valid index of `String(unicodeScalars).characters`.
+  /// The index must be a valid index of `String(unicodeScalars)`.
   ///
   /// This example first finds the position of the character `"é"` and then uses
   /// this method find the same position in the string's `unicodeScalars`
   /// view.
   ///
   ///     let cafe = "Café"
-  ///     if let i = cafe.characters.index(of: "é") {
+  ///     if let i = cafe.index(of: "é") {
   ///         let j = i.samePosition(in: cafe.unicodeScalars)
   ///         print(cafe.unicodeScalars[j])
   ///     }

--- a/stdlib/public/core/StringLegacy.swift
+++ b/stdlib/public/core/StringLegacy.swift
@@ -30,12 +30,12 @@ extension String {
   /// Creates a new string representing the given string repeated the specified
   /// number of times.
   ///
-  /// For example, use this initializer to create a string with ten `"00"`
+  /// For example, use this initializer to create a string with ten `"ab"`
   /// strings in a row.
   ///
   ///     let zeroes = String(repeating: "00", count: 10)
   ///     print(zeroes)
-  ///     // Prints "00000000000000000000"
+  ///     // Prints "abababababababababab"
   ///
   /// - Parameters:
   ///   - repeatedValue: The string to repeat.
@@ -228,7 +228,7 @@ extension String {
   /// prints its length:
   ///
   ///     let max = String(Int.max)
-  ///     print("\(max) has \(max.utf16.count) digits.")
+  ///     print("\(max) has \(max.count) digits.")
   ///     // Prints "9223372036854775807 has 19 digits."
   ///
   /// Numerals greater than 9 are represented as Roman letters. These letters
@@ -266,7 +266,7 @@ extension String {
   /// prints its length:
   ///
   ///     let max = String(Int.max)
-  ///     print("\(max) has \(max.utf16.count) digits.")
+  ///     print("\(max) has \(max.count) digits.")
   ///     // Prints "9223372036854775807 has 19 digits."
   ///
   /// Numerals greater than 9 are represented as Roman letters. These letters
@@ -305,7 +305,7 @@ extension String {
   /// prints its length:
   ///
   ///     let max = String(Int.max)
-  ///     print("\(max) has \(max.utf16.count) digits.")
+  ///     print("\(max) has \(max.count) digits.")
   ///     // Prints "9223372036854775807 has 19 digits."
   ///
   /// Numerals greater than 9 are represented as Roman letters. These letters
@@ -343,7 +343,7 @@ extension String {
   /// prints its length:
   ///
   ///     let max = String(Int.max)
-  ///     print("\(max) has \(max.utf16.count) digits.")
+  ///     print("\(max) has \(max.count) digits.")
   ///     // Prints "9223372036854775807 has 19 digits."
   ///
   /// Numerals greater than 9 are represented as Roman letters. These letters
@@ -381,7 +381,7 @@ extension String {
   /// prints its length:
   ///
   ///     let max = String(Int.max)
-  ///     print("\(max) has \(max.utf16.count) digits.")
+  ///     print("\(max) has \(max.count) digits.")
   ///     // Prints "9223372036854775807 has 19 digits."
   ///
   /// Numerals greater than 9 are represented as Roman letters. These letters

--- a/stdlib/public/core/StringUTF16.swift
+++ b/stdlib/public/core/StringUTF16.swift
@@ -120,11 +120,11 @@ extension String {
     /// You can convert between indices of the different string views by using
     /// conversion initializers and the `samePosition(in:)` method overloads.
     /// For example, the following code sample finds the index of the first
-    /// space in the string's character view and then converts that to the same
+    /// space in a string and then converts that to the same
     /// position in the UTF-16 view.
     ///
     ///     let hearts = "Hearts <3 ♥︎ 💘"
-    ///     if let i = hearts.characters.index(of: " ") {
+    ///     if let i = hearts.index(of: " ") {
     ///         let j = i.samePosition(in: hearts.utf16)
     ///         print(Array(hearts.utf16.suffix(from: j)))
     ///         print(hearts.utf16.suffix(from: j))
@@ -440,16 +440,15 @@ extension String.UTF16View.Index {
   }
 
   /// Creates an index in the given UTF-16 view that corresponds exactly to the
-  /// specified `CharacterView` position.
+  /// specified string position.
   ///
-  /// The following example finds the position of a space in a string's `characters`
-  /// view and then converts that position to an index in the string's
+  /// The following example finds the position of a space in a string and then converts that position to an index in the string's
   /// `utf16` view.
   ///
   ///     let cafe = "Café 🍵"
   ///
-  ///     let characterIndex = cafe.characters.index(of: "é")!
-  ///     let utf16Index = String.UTF16View.Index(characterIndex, within: cafe.utf16)
+  ///     let index = cafe.index(of: "é")!
+  ///     let utf16Index = String.UTF16View.Index(index, within: cafe.utf16)
   ///
   ///     print(cafe.utf16.prefix(through: utf16Index))
   ///     // Prints "Café"

--- a/stdlib/public/core/StringUTF16.swift
+++ b/stdlib/public/core/StringUTF16.swift
@@ -56,7 +56,7 @@ extension String {
   ///
   ///     let favemoji = "My favorite emoji is 🎉"
   ///     if let i = favemoji.utf16.index(where: { $0 >= 128 }) {
-  ///         let asciiPrefix = String(favemoji.utf16.prefix(upTo: i))
+  ///         let asciiPrefix = String(favemoji.utf16[..<i])
   ///         print(asciiPrefix)
   ///     }
   ///     // Prints "My favorite emoji is "
@@ -126,8 +126,8 @@ extension String {
     ///     let hearts = "Hearts <3 ♥︎ 💘"
     ///     if let i = hearts.index(of: " ") {
     ///         let j = i.samePosition(in: hearts.utf16)
-    ///         print(Array(hearts.utf16.suffix(from: j)))
-    ///         print(hearts.utf16.suffix(from: j))
+    ///         print(Array(hearts.utf16[j...]))
+    ///         print(hearts.utf16[j...])
     ///     }
     ///     // Prints "[32, 60, 51, 32, 9829, 65038, 32, 55357, 56472]"
     ///     // Prints " <3 ♥︎ 💘"
@@ -324,7 +324,7 @@ extension String {
   ///
   ///     let picnicGuest = "Deserving porcupine"
   ///     if let i = picnicGuest.utf16.index(of: 32) {
-  ///         let adjective = String(picnicGuest.utf16.prefix(upTo: i))
+  ///         let adjective = String(picnicGuest.utf16[..<i])
   ///         print(adjective)
   ///     }
   ///     // Prints "Optional(Deserving)"
@@ -384,7 +384,7 @@ extension String.UTF16View.Index {
   ///     let utf8Index = cafe.utf8.index(of: 32)!
   ///     let utf16Index = String.UTF16View.Index(utf8Index, within: cafe.utf16)!
   ///
-  ///     print(cafe.utf16.prefix(upTo: utf16Index))
+  ///     print(cafe.utf16[..<utf16Index])
   ///     // Prints "Café"
   ///
   /// If the position passed as `utf8Index` doesn't have an exact corresponding
@@ -425,7 +425,7 @@ extension String.UTF16View.Index {
   ///     let scalarIndex = cafe.unicodeScalars.index(of: "é")!
   ///     let utf16Index = String.UTF16View.Index(scalarIndex, within: cafe.utf16)
   ///
-  ///     print(cafe.utf16.prefix(through: utf16Index))
+  ///     print(cafe.utf16[...utf16Index])
   ///     // Prints "Café"
   ///
   /// - Parameters:
@@ -442,24 +442,23 @@ extension String.UTF16View.Index {
   /// Creates an index in the given UTF-16 view that corresponds exactly to the
   /// specified string position.
   ///
-  /// The following example finds the position of a space in a string and then converts that position to an index in the string's
-  /// `utf16` view.
+  /// The following example finds the position of a space in a string and then
+  /// converts that position to an index in the string's `utf16` view.
   ///
   ///     let cafe = "Café 🍵"
   ///
-  ///     let index = cafe.index(of: "é")!
-  ///     let utf16Index = String.UTF16View.Index(index, within: cafe.utf16)
+  ///     let stringIndex = cafe.index(of: "é")!
+  ///     let utf16Index = String.UTF16View.Index(stringIndex, within: cafe.utf16)
   ///
-  ///     print(cafe.utf16.prefix(through: utf16Index))
+  ///     print(cafe.utf16[...utf16Index])
   ///     // Prints "Café"
   ///
   /// - Parameters:
-  ///   - characterIndex: A position in a `CharacterView` instance.
-  ///     `characterIndex` must be an element in
-  ///     `String(utf16).characters.indices`.
+  ///   - index: A position in a string. `index` must be an element in
+  ///     `String(utf16).indices`.
   ///   - utf16: The `UTF16View` in which to find the new position.
-  public init(_ characterIndex: String.Index, within utf16: String.UTF16View) {
-    _offset = characterIndex._utf16Index
+  public init(_ index: String.Index, within utf16: String.UTF16View) {
+    _offset = index._utf16Index
   }
 
   /// Returns the position in the given UTF-8 view that corresponds exactly to
@@ -474,7 +473,7 @@ extension String.UTF16View.Index {
   ///     let cafe = "Café 🍵"
   ///     let i = cafe.utf16.index(of: 32)!
   ///     let j = i.samePosition(in: cafe.utf8)!
-  ///     print(Array(cafe.utf8.prefix(upTo: j)))
+  ///     print(Array(cafe.utf8[..<j]))
   ///     // Prints "[67, 97, 102, 195, 169]"
   ///
   /// - Parameter utf8: The view to use for the index conversion.
@@ -500,7 +499,7 @@ extension String.UTF16View.Index {
   ///     let cafe = "Café 🍵"
   ///     let i = cafe.utf16.index(of: 32)!
   ///     let j = i.samePosition(in: cafe.unicodeScalars)!
-  ///     print(cafe.unicodeScalars.prefix(upTo: j))
+  ///     print(cafe.unicodeScalars[..<j])
   ///     // Prints "Café"
   ///
   /// - Parameter unicodeScalars: The view to use for the index conversion.
@@ -527,7 +526,7 @@ extension String.UTF16View.Index {
   ///     let cafe = "Café 🍵"
   ///     let i = cafe.utf16.index(of: 32)!
   ///     let j = i.samePosition(in: cafe)!
-  ///     print(cafe[cafe.startIndex ..< j])
+  ///     print(cafe[..<j])
   ///     // Prints "Café"
   ///
   /// - Parameter characters: The string to use for the index conversion.

--- a/stdlib/public/core/StringUTF8.swift
+++ b/stdlib/public/core/StringUTF8.swift
@@ -200,10 +200,10 @@ extension String {
     /// position in the UTF-8 view.
     ///
     ///     let hearts = "Hearts <3 ♥︎ 💘"
-    ///     if let i = hearts.characters.index(of: " ") {
+    ///     if let i = hearts.index(of: " ") {
     ///         let j = i.samePosition(in: hearts.utf8)
-    ///         print(Array(hearts.utf8.prefix(upTo: j)))
-    ///         print(hearts.utf8.prefix(upTo: j))
+    ///         print(Array(hearts.utf8[..<j]))
+    ///         print(hearts.utf8[..<j])
     ///     }
     ///     // Prints "[72, 101, 97, 114, 116, 115]"
     ///     // Prints "Hearts"
@@ -430,7 +430,7 @@ extension String {
   ///
   ///     let picnicGuest = "Deserving porcupine"
   ///     if let i = picnicGuest.utf8.index(of: 32) {
-  ///         let adjective = String(picnicGuest.utf8.prefix(upTo: i))
+  ///         let adjective = String(picnicGuest.utf8[..<i])
   ///         print(adjective)
   ///     }
   ///     // Prints "Optional(Deserving)"
@@ -524,7 +524,7 @@ extension String.UTF8View.Index {
   ///     let utf16Index = cafe.utf16.index(of: 32)!
   ///     let utf8Index = String.UTF8View.Index(utf16Index, within: cafe.utf8)!
   ///
-  ///     print(Array(cafe.utf8.prefix(upTo: utf8Index)))
+  ///     print(Array(cafe.utf8[..<utf8Index]))
   ///     // Prints "[67, 97, 102, 195, 169]"
   ///
   /// If the position passed in `utf16Index` doesn't have an exact
@@ -582,7 +582,7 @@ extension String.UTF8View.Index {
   ///     let scalarsIndex = cafe.unicodeScalars.index(of: "e")!
   ///     let utf8Index = String.UTF8View.Index(scalarsIndex, within: cafe.utf8)
   ///
-  ///     print(Array(cafe.utf8.prefix(through: utf8Index)))
+  ///     print(Array(cafe.utf8[...utf8Index]))
   ///     // Prints "[67, 97, 102, 101]"
   ///
   /// - Parameters:
@@ -604,19 +604,19 @@ extension String.UTF8View.Index {
   /// into its corresponding position in the string's `utf8` view.
   ///
   ///     let cafe = "Café 🍵"
-  ///     let characterIndex = cafe.characters.index(of: "🍵")!
-  ///     let utf8Index = String.UTF8View.Index(characterIndex, within: cafe.utf8)
+  ///     let stringIndex = cafe.index(of: "🍵")!
+  ///     let utf8Index = String.UTF8View.Index(stringIndex, within: cafe.utf8)
   ///
-  ///     print(Array(cafe.utf8.suffix(from: utf8Index)))
+  ///     print(Array(cafe.utf8[utf8Index...]))
   ///     // Prints "[240, 159, 141, 181]"
   ///
   /// - Parameters:
-  ///   - characterIndex: A position in a `CharacterView` instance.
-  ///     `characterIndex` must be an element of
-  ///     `String(utf8).characters.indices`.
+  ///   - index: A position in a string instance.
+  ///     `index` must be an element of
+  ///     `String(utf8).indices`.
   ///   - utf8: The `UTF8View` in which to find the new position.
-  public init(_ characterIndex: String.Index, within utf8: String.UTF8View) {
-    self.init(utf8._core, _utf16Offset: characterIndex._base._position)
+  public init(_ index: String.Index, within utf8: String.UTF8View) {
+    self.init(utf8._core, _utf16Offset: index._base._position)
   }
 
   /// Returns the position in the given UTF-16 view that corresponds exactly to
@@ -631,7 +631,7 @@ extension String.UTF8View.Index {
   ///     let cafe = "Café 🍵"
   ///     let i = cafe.utf8.index(of: 32)!
   ///     let j = i.samePosition(in: cafe.utf16)!
-  ///     print(cafe.utf16.prefix(upTo: j))
+  ///     print(cafe.utf16[..<j])
   ///     // Prints "Café"
   ///
   /// - Parameter utf16: The view to use for the index conversion.
@@ -657,7 +657,7 @@ extension String.UTF8View.Index {
   ///     let cafe = "Café 🍵"
   ///     let i = cafe.utf8.index(of: 32)!
   ///     let j = i.samePosition(in: cafe.unicodeScalars)!
-  ///     print(cafe.unicodeScalars.prefix(upTo: j))
+  ///     print(cafe.unicodeScalars[..<j])
   ///     // Prints "Café"
   ///
   /// - Parameter unicodeScalars: The view to use for the index conversion.
@@ -675,7 +675,7 @@ extension String.UTF8View.Index {
   /// Returns the position in the given string that corresponds exactly to this
   /// index.
   ///
-  /// This index must be a valid index of `characters.utf8`.
+  /// This index must be a valid index of `utf8`.
   ///
   /// This example first finds the position of a space (UTF-8 code point `32`)
   /// in a string's `utf8` view and then uses this method find the same position
@@ -684,7 +684,7 @@ extension String.UTF8View.Index {
   ///     let cafe = "Café 🍵"
   ///     let i = cafe.utf8.index(of: 32)!
   ///     let j = i.samePosition(in: cafe)!
-  ///     print(cafe[cafe.startIndex ..< j])
+  ///     print(cafe[..<j])
   ///     // Prints "Café"
   ///
   /// - Parameter characters: The string to use for the index conversion.

--- a/stdlib/public/core/StringUnicodeScalarView.swift
+++ b/stdlib/public/core/StringUnicodeScalarView.swift
@@ -34,10 +34,10 @@ extension String {
   ///
   /// Some characters that are visible in a string are made up of more than one
   /// Unicode scalar value. In that case, a string's `unicodeScalars` view
-  /// contains more values than its `characters` view.
+  /// contains more elements than the string itself.
   ///
   ///     let flag = "🇵🇷"
-  ///     for c in flag.characters {
+  ///     for c in flag {
   ///         print(c)
   ///     }
   ///     // 🇵🇷
@@ -53,7 +53,7 @@ extension String {
   ///
   ///     let favemoji = "My favorite emoji is 🎉"
   ///     if let i = favemoji.unicodeScalars.index(where: { $0.value >= 128 }) {
-  ///         let asciiPrefix = String(favemoji.unicodeScalars.prefix(upTo: i))
+  ///         let asciiPrefix = String(favemoji.unicodeScalars[..<i])
   ///         print(asciiPrefix)
   ///     }
   ///     // Prints "My favorite emoji is "
@@ -94,10 +94,10 @@ extension String {
     /// position in the Unicode scalars view:
     ///
     ///     let hearts = "Hearts <3 ♥︎ 💘"
-    ///     let i = hearts.characters.index(of: "♥︎")!
+    ///     let i = hearts.index(of: "♥︎")!
     ///
     ///     let j = i.samePosition(in: hearts.unicodeScalars)
-    ///     print(hearts.unicodeScalars.suffix(from: j))
+    ///     print(hearts.unicodeScalars[j...])
     ///     // Prints "♥︎ 💘"
     ///     print(hearts.unicodeScalars[j].value)
     ///     // Prints "9829"
@@ -309,7 +309,7 @@ extension String {
   ///
   ///     let picnicGuest = "Deserving porcupine"
   ///     if let i = picnicGuest.unicodeScalars.index(of: " ") {
-  ///         let adjective = String(picnicGuest.unicodeScalars.prefix(upTo: i))
+  ///         let adjective = String(picnicGuest.unicodeScalars[..<i])
   ///         print(adjective)
   ///     }
   ///     // Prints "Deserving"
@@ -433,7 +433,7 @@ extension String.UnicodeScalarIndex {
   ///     let utf16Index = cafe.utf16.index(of: 32)!
   ///     let scalarIndex = String.UnicodeScalarView.Index(utf16Index, within: cafe.unicodeScalars)!
   ///
-  ///     print(String(cafe.unicodeScalars.prefix(upTo: scalarIndex)))
+  ///     print(String(cafe.unicodeScalars[..<scalarIndex]))
   ///     // Prints "Café"
   ///
   /// If the position passed in `utf16Index` doesn't have an exact
@@ -442,10 +442,10 @@ extension String.UnicodeScalarIndex {
   /// the trailing surrogate of a UTF-16 surrogate pair fails.
   ///
   /// - Parameters:
-  ///   - utf16Index: A position in the `utf16` view of the `characters`
-  ///     parameter.
-  ///   - unicodeScalars: The `UnicodeScalarView` instance referenced by both
-  ///     `utf16Index` and the resulting index.
+  ///   - utf16Index: A position in the `utf16` view of a string. `utf16Index`
+  ///     must be an element of `String(unicodeScalars).utf16.indices`.
+  ///   - unicodeScalars: The `UnicodeScalarView` in which to find the new
+  ///     position.
   public init?(
     _ utf16Index: String.UTF16Index,
     within unicodeScalars: String.UnicodeScalarView
@@ -480,10 +480,10 @@ extension String.UnicodeScalarIndex {
   /// byte returns `nil`.
   ///
   /// - Parameters:
-  ///   - utf8Index: A position in the `utf8` view of the `characters`
-  ///     parameter.
-  ///   - unicodeScalars: The `UnicodeScalarView` instance referenced by both
-  ///     `utf8Index` and the resulting index.
+  ///   - utf8Index: A position in the `utf8` view of a string. `utf8Index`
+  ///     must be an element of `String(unicodeScalars).utf8.indices`.
+  ///   - unicodeScalars: The `UnicodeScalarView` in which to find the new
+  ///     position.
   public init?(
     _ utf8Index: String.UTF8Index,
     within unicodeScalars: String.UnicodeScalarView
@@ -508,22 +508,22 @@ extension String.UnicodeScalarIndex {
   /// into its corresponding position in the string's `unicodeScalars` view.
   ///
   ///     let cafe = "Café 🍵"
-  ///     let characterIndex = cafe.characters.index(of: "🍵")!
-  ///     let scalarIndex = String.UnicodeScalarView.Index(characterIndex, within: cafe.unicodeScalars)
+  ///     let stringIndex = cafe.index(of: "🍵")!
+  ///     let scalarIndex = String.UnicodeScalarView.Index(stringIndex, within: cafe.unicodeScalars)
   ///
-  ///     print(cafe.unicodeScalars.suffix(from: scalarIndex))
+  ///     print(cafe.unicodeScalars[scalarIndex...])
   ///     // Prints "🍵"
   ///
   /// - Parameters:
-  ///   - characterIndex: A position in a `CharacterView` instance.
-  ///     `characterIndex` must be an element of
-  ///     `String(utf8).characters.indices`.
-  ///   - utf8: The `UTF8View` in which to find the new position.
+  ///   - index: A position in a string. `index` must be an element of
+  ///     `String(unicodeScalars).indices`.
+  ///   - unicodeScalars: The `UnicodeScalarView` in which to find the new
+  ///     position.
   public init(
-    _ characterIndex: String.Index,
+    _ index: String.Index,
     within unicodeScalars: String.UnicodeScalarView
   ) {
-    self.init(_position: characterIndex._base._position)
+    self.init(_position: index._base._position)
   }
 
   /// Returns the position in the given UTF-8 view that corresponds exactly to
@@ -537,7 +537,7 @@ extension String.UnicodeScalarIndex {
   ///     let cafe = "Café"
   ///     if let i = cafe.unicodeScalars.index(of: "é") {
   ///         let j = i.samePosition(in: cafe.utf8)
-  ///         print(Array(cafe.utf8.suffix(from: j)))
+  ///         print(Array(cafe.utf8[j...]))
   ///     }
   ///     // Prints "[195, 169]"
   ///
@@ -556,7 +556,7 @@ extension String.UnicodeScalarIndex {
   /// this method find the same position in the string's `utf16` view.
   ///
   ///     let cafe = "Café"
-  ///     if let i = cafe.characters.index(of: "é") {
+  ///     if let i = cafe.unicodeScalars.index(of: "é") {
   ///         let j = i.samePosition(in: cafe.utf16)
   ///         print(cafe.utf16[j])
   ///     }
@@ -582,7 +582,7 @@ extension String.UnicodeScalarIndex {
   ///     let cafe = "Café 🍵"
   ///     let i = cafe.unicodeScalars.index(of: "🍵")
   ///     let j = i.samePosition(in: cafe)!
-  ///     print(cafe.suffix(from: j))
+  ///     print(cafe[j...])
   ///     // Prints "🍵"
   ///
   /// - Parameter characters: The string to use for the index conversion.

--- a/stdlib/public/core/Substring.swift.gyb
+++ b/stdlib/public/core/Substring.swift.gyb
@@ -12,11 +12,70 @@
 
 extension String {
   // FIXME(strings): at least temporarily remove it to see where it was applied
+  /// Creates a new string from the given substring.
+  ///
+  /// - Parameter substring: A substring to convert to a standalone `String`
+  ///   instance.
+  ///
+  /// - Complexity: O(*n*), where *n* is the length of `substring`.
   public init(_ substring: Substring) {
     self = String(substring._slice)
   }
 }
 
+/// A slice of a string.
+///
+/// When you create a slice of a string, a `Substring` instance is the result.
+/// Operating on substrings is fast and efficient because a substring shares
+/// its storage with the original string. The `Substring` type presents the
+/// same interface as `String`, so you can avoid or defer any copying of the
+/// string's contents.
+///
+/// The following example creates a `greeting` string, and then finds the
+/// substring of the first sentence:
+///
+///     let greeting = "Hi there! It's nice to meet you! 👋"
+///     let endOfSentence = greeting.index(of: "!")!
+///     let firstSentence = greeting[...endOfSentence]
+///     // firstSentence == "Hi there!"
+///
+/// You can perform many string operations on a substring. Here, we find the
+/// length of the first sentence and create an uppercase version.
+///
+///     print("'\(firstSentence)' is \(firstSentence.count) characters long.")
+///     // Prints "'Hi there!' is 9 characters long."
+///
+///     let shoutingSentence = firstSentence.uppercased()
+///     // shoutingSentence == "HI THERE!"
+///
+/// Converting a Substring to a String
+/// ==================================
+///
+/// This example defines a `rawData` string with some unstructured data, and
+/// then uses the string's `prefix(while:)` method to create a substring of
+/// the numeric prefix:
+///
+///     let rawInput = "126 a.b 22219 zzzzzz"
+///     let numericPrefix = rawInput.prefix(while: { "0"..."9" ~= $0 })
+///     // numericPrefix is the Substring "126"
+///
+/// When you need to store a substring or pass it to a function that requires a
+/// `String` instance, convert it using the `String.init(_:)` initializer.
+///
+///     _ = Int(numericPrefix, radix: 10)
+///     // error: cannot convert value...
+///     let prefix = Int(String(numericPrefix), radix: 10)
+///     // prefix == 126
+///
+/// Calling this initializer copies the contents of the substring to a new
+/// string.
+///
+/// - Important: Long-term storage of `Substring` instances is discouraged. A
+///   substring holds a reference to the entire storage of a larger string,
+///   not just to the portion it presents, even after the original string's
+///   lifetime ends. Long-term storage of a substring may therefore prolong
+///   the lifetime of string data that is no longer otherwise accessible,
+///   which can appear to be memory leakage.
 public struct Substring : StringProtocol {
   public typealias Index = String.Index
   public typealias IndexDistance = String.IndexDistance
@@ -24,10 +83,17 @@ public struct Substring : StringProtocol {
 
   internal var _slice: RangeReplaceableBidirectionalSlice<String>
 
+  /// Creates an empty substring.
   public init() {
     _slice = RangeReplaceableBidirectionalSlice()
   }
 
+  /// Creates a substring with the specified bounds within the given string.
+  ///
+  /// - Parameters:
+  ///   - base: The string to create a substring of.
+  ///   - bounds: The range of `base` to use for the substring. The lower and
+  ///     upper bounds of `bounds` must be valid indices of `base`.
   public init(_base base: String, _ bounds: Range<Index>) {
     _slice = RangeReplaceableBidirectionalSlice(base: base, bounds: bounds)
   }
@@ -102,32 +168,57 @@ public struct Substring : StringProtocol {
 
 % end
 
+  /// Creates a string from the given Unicode code units in the specified
+  /// encoding.
+  ///
+  /// - Parameters:
+  ///   - codeUnits: A collection of code units encoded in the ecoding
+  ///     specified in `encoding`.
+  ///   - encoding: The encoding in which `codeUnits` should be interpreted.
   public init<C: Collection, Encoding: _UnicodeEncoding>(
-    decoding codeUnits: C, as sourceEncoding: Encoding.Type
+    decoding codeUnits: C, as encoding: Encoding.Type
   ) where C.Iterator.Element == Encoding.CodeUnit {
-    self.init(String(decoding: codeUnits, as: sourceEncoding))
+    self.init(String(decoding: codeUnits, as: encoding))
   }
 
+  /// Creates a string from the null-terminated, UTF-8 encoded sequence of
+  /// bytes at the given pointer.
+  ///
+  /// - Parameter nulTerminatedUTF8: A pointer to a sequence of contiguous,
+  ///   UTF-8 encoded bytes ending just before the first zero byte.
   public init(cString nulTerminatedUTF8: UnsafePointer<CChar>) {
     self.init(String(cString: nulTerminatedUTF8))
   }
   
-  /// Constructs a `String` having the same contents as `nulTerminatedCodeUnits`.
+  /// Creates a string from the null-terminated sequence of bytes at the given
+  /// pointer.
   ///
-  /// - Parameter nulTerminatedCodeUnits: a sequence of contiguous code units in
-  ///   the given `encoding`, ending just before the first zero code unit.
-  /// - Parameter encoding: describes the encoding in which the code units
-  ///   should be interpreted.
+  /// - Parameters:
+  ///   - nulTerminatedCodeUnits: A pointer to a sequence of contiguous code
+  ///     units in the encoding specified in `encoding`, ending just before
+  ///     the first zero code unit.
+  ///   - encoding: The encoding in which the code units should be interpreted.
   public init<Encoding: _UnicodeEncoding>(
     decodingCString nulTerminatedCodeUnits: UnsafePointer<Encoding.CodeUnit>,
-    as targetEncoding: Encoding.Type
+    as encoding: Encoding.Type
   ) {
     self.init(
-      String(decodingCString: nulTerminatedCodeUnits, as: targetEncoding))
+      String(decodingCString: nulTerminatedCodeUnits, as: encoding))
   }
     
-  /// Invokes the given closure on the contents of the string, represented as a
-  /// pointer to a null-terminated sequence of UTF-8 code units.
+  /// Calls the given closure with a pointer to the contents of the string,
+  /// represented as a null-terminated sequence of UTF-8 code units.
+  ///
+  /// The pointer passed as an argument to `body` is valid only for the
+  /// lifetime of the closure. Do not escape it from the closure for later
+  /// use.
+  ///
+  /// - Parameter body: A closure with an pointer parameter that points to a
+  ///   null-terminated sequence of UTF-8 code units. If `body` has a return
+  ///   value, it is used as the return value for the `withCString(_:)`
+  ///   method. The pointer argument is valid only for the duration of the
+  ///   closure's execution.
+  /// - Returns: The return value of the `body` closure parameter, if any.
   public func withCString<Result>(
     _ body: (UnsafePointer<CChar>) throws -> Result) rethrows -> Result {
     return try _slice._base._core._withCSubstringAndLength(
@@ -139,15 +230,28 @@ public struct Substring : StringProtocol {
     }
   }
 
-  /// Invokes the given closure on the contents of the string, represented as a
-  /// pointer to a null-terminated sequence of code units in the given encoding.
+  /// Calls the given closure with a pointer to the contents of the string,
+  /// represented as a null-terminated sequence of code units.
+  ///
+  /// The pointer passed as an argument to `body` is valid only for the
+  /// lifetime of the closure. Do not escape it from the closure for later
+  /// use.
+  ///
+  /// - Parameters:
+  ///   - body: A closure with an pointer parameter that points to a
+  ///     null-terminated sequence of code units. If `body` has a return
+  ///     value, it is used as the return value for the
+  ///     `withCString(encodedAs:_:)` method. The pointer argument is valid
+  ///     only for the duration of the closure's execution.
+  ///   - encoding: The encoding in which the code units should be interpreted.
+  /// - Returns: The return value of the `body` closure parameter, if any.
   public func withCString<Result, TargetEncoding: _UnicodeEncoding>(
-    encodedAs targetEncoding: TargetEncoding.Type,
+    encodedAs encoding: TargetEncoding.Type,
     _ body: (UnsafePointer<TargetEncoding.CodeUnit>) throws -> Result
   ) rethrows -> Result {
     return try _slice._base._core._withCSubstring(
       in: startIndex._base._position..<endIndex._base._position,
-      encoding: targetEncoding, body)
+      encoding: encoding, body)
   }
 }
 


### PR DESCRIPTION
* string documentation revisions
* revise examples throughout to use range expressions instead of e.g. `prefix(upTo: _)`
* partial ranges and operators
* documented `swap(_:_:)` and `MutableCollection.swapAt(_:_:)`
* removing `.characters` from examples
* improvements to the String Foundation overlay docs
* integer type documentation revisions
* fixed discussions for floating-point operators
* minor revisions elsewhere
