### PR TITLE
[parser] Account for the length of multine string quotes when tokenizing interpolated string components

### DIFF
--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -172,6 +172,8 @@ static void getStringPartTokens(const Token &Tok, const LangOptions &LangOpts,
                                 const SourceManager &SM,
                                 int BufID, std::vector<Token> &Toks) {
   assert(Tok.is(tok::string_literal));
+  bool IsMultiline = Tok.IsMultilineString();
+  unsigned QuoteLen = IsMultiline ? 3 : 1;
   SmallVector<Lexer::StringSegment, 4> Segments;
   Lexer::getStringLiteralSegments(Tok, Segments, /*Diags=*/nullptr);
   for (unsigned i = 0, e = Segments.size(); i != e; ++i) {
@@ -183,17 +185,17 @@ static void getStringPartTokens(const Token &Tok, const LangOptions &LangOpts,
       unsigned Len = Seg.Length;
       if (isFirst) {
         // Include the quote.
-        Loc = Loc.getAdvancedLoc(-1);
-        ++Len;
+        Loc = Loc.getAdvancedLoc(-QuoteLen);
+        Len += QuoteLen;
       }
       if (isLast) {
         // Include the quote.
-        ++Len;
+        Len += QuoteLen;
       }
 
       StringRef Text = SM.extractText({ Loc, Len });
       Token NewTok;
-      NewTok.setToken(tok::string_literal, Text);
+      NewTok.setToken(tok::string_literal, Text, IsMultiline);
       Toks.push_back(NewTok);
 
     } else {

--- a/test/IDE/coloring.swift
+++ b/test/IDE/coloring.swift
@@ -226,6 +226,20 @@ func f(x: Int) -> Int {
   // string interpolation is the best
   // CHECK: <str>"This is string </str>\<anchor>(</anchor>genFn({(a:<type>Int</type> -> <type>Int</type>) <kw>in</kw> a})<anchor>)</anchor><str> interpolation"</str>
   "This is string \(genFn({(a:Int -> Int) in a})) interpolation"
+
+  // CHECK: <str>"""
+  // CHECK-NEXT: This is a multiline string.
+  // CHECK-NEXT: """</str>
+  """
+  This is a multiline string.
+"""
+
+  // CHECK: <str>"""
+  // CHECK-NEXT: This is a multiline</str>\<anchor>(</anchor> <str>"interpolated"</str> <anchor>)</anchor><str>string
+  // CHECK-NEXT: """</str>
+  """
+      This is a multiline\( "interpolated" )string
+   """
 }
 
 // CHECK: <kw>func</kw> bar(x: <type>Int</type>) -> (<type>Int</type>, <type>Float</type>) {


### PR DESCRIPTION
<!-- What's in this pull request? -->
This fixes a syntax coloring issue where only the innermost `"` characters were highlighted as part of the string, e.g:

```
""<str>"
  This is a string
  "</str>""
```

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves rdar://problem/32148117.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->