### PR TITLE
[ClangImporter] Import ObjC members under Swift 3 and 4 names.

### DIFF
--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1169,6 +1169,23 @@ public:
   /// Determine the effective Clang context for the given Swift nominal type.
   EffectiveClangContext getEffectiveClangContext(NominalTypeDecl *nominal);
 
+  /// Attempts to import the name of \p decl with each possible
+  /// ImportNameVersion. \p action will be called with each unique name.
+  ///
+  /// In this case, "unique" means either the full name is distinct or the
+  /// effective context is distinct. This method does not attempt to handle
+  /// "unresolved" contexts in any special way---if one name references a
+  /// particular Clang declaration and the other has an unresolved context that
+  /// will eventually reference that declaration, the contexts will still be
+  /// considered distinct.
+  ///
+  /// The names are generated in the same order as
+  /// forEachImportNameVersionFromCurrent. The current name is always first.
+  void forEachDistinctName(
+      const clang::NamedDecl *decl,
+      llvm::function_ref<void(importer::ImportedName,
+                              importer::ImportNameVersion)> action);
+
   /// Dump the Swift-specific name lookup tables we generate.
   void dumpSwiftLookupTables();
 

--- a/lib/ClangImporter/SwiftLookupTable.h
+++ b/lib/ClangImporter/SwiftLookupTable.h
@@ -56,10 +56,10 @@ namespace swift {
 /// Swift name, this will be recorded as
 class EffectiveClangContext {
 public:
-  enum Kind {
+  enum Kind : uint8_t {
     DeclContext,
     TypedefContext,
-    UnresolvedContext,
+    UnresolvedContext, // must be last
   };
 
 private:
@@ -70,15 +70,19 @@ private:
       const char *Data;
     } Unresolved;
   };
-  Kind TheKind;
-  unsigned UnresolvedLength;
-  
+
+  /// If KindOrBiasedLength < Kind::UnresolvedContext, this represents a Kind.
+  /// Otherwise it's (uintptr_t)Kind::UnresolvedContext plus the length of
+  /// Unresolved.Data.
+  uintptr_t KindOrBiasedLength;
+
 public:
-  EffectiveClangContext() : TheKind(DeclContext) {
+  EffectiveClangContext() : KindOrBiasedLength(DeclContext) {
     DC = nullptr;
   }
 
-  EffectiveClangContext(const clang::DeclContext *dc) : TheKind(DeclContext) {
+  EffectiveClangContext(const clang::DeclContext *dc)
+      : KindOrBiasedLength(DeclContext) {
     assert(dc != nullptr && "use null constructor instead");
     if (auto tagDecl = dyn_cast<clang::TagDecl>(dc)) {
       DC = tagDecl->getCanonicalDecl();
@@ -99,14 +103,13 @@ public:
   }
 
   EffectiveClangContext(const clang::TypedefNameDecl *typedefName)
-    : TheKind(TypedefContext)
-  {
+    : KindOrBiasedLength(TypedefContext) {
     Typedef = typedefName->getCanonicalDecl();
   }
 
-  EffectiveClangContext(StringRef unresolved) : TheKind(UnresolvedContext) {
+  EffectiveClangContext(StringRef unresolved)
+      : KindOrBiasedLength(UnresolvedContext + unresolved.size()) {
     Unresolved.Data = unresolved.data();
-    UnresolvedLength = unresolved.size();
   }
 
   /// Determine whether this effective Clang context was set.
@@ -115,7 +118,12 @@ public:
   }
 
   /// Determine the kind of effective Clang context.
-  Kind getKind() const { return TheKind; }
+  Kind getKind() const {
+    if (KindOrBiasedLength >= UnresolvedContext)
+      return UnresolvedContext;
+    return static_cast<Kind>(KindOrBiasedLength);
+
+  }
 
   /// Retrieve the declaration context.
   const clang::DeclContext *getAsDeclContext() const {
@@ -131,7 +139,7 @@ public:
   /// Retrieve the unresolved context name.
   StringRef getUnresolvedName() const {
     assert(getKind() == UnresolvedContext);
-    return StringRef(Unresolved.Data, UnresolvedLength);
+    return StringRef(Unresolved.Data, KindOrBiasedLength - UnresolvedContext);
   }
 
   /// Compares two EffectiveClangContexts without resolving unresolved names.
@@ -149,13 +157,8 @@ public:
   }
 };
 
-#if LLVM_PTR_SIZE == 4
-static_assert(sizeof(EffectiveClangContext) <= 4 * sizeof(void *),
-              "should fit in four pointers");
-#else
 static_assert(sizeof(EffectiveClangContext) <= 2 * sizeof(void *),
-              "should fit in a couple pointers");
-#endif
+              "should be small");
 
 class SwiftLookupTableReader;
 class SwiftLookupTableWriter;

--- a/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/APINotesFrameworkTest.apinotes
+++ b/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/APINotesFrameworkTest.apinotes
@@ -88,12 +88,39 @@ SwiftVersions:
         SwiftImportAsNonGeneric: true
       - Name: RenamedGeneric
         SwiftName: OldRenamedGeneric
+      - Name: ClassWithManyRenames
+        Methods:
+          - Selector: "classWithManyRenamesForInt:"
+            MethodKind: Class
+            SwiftName: "init(swift3Factory:)"
+          - Selector: "initWithBoolean:"
+            MethodKind: Instance
+            SwiftName: "init(swift3Boolean:)"
+          - Selector: "doImportantThings"
+            MethodKind: Instance
+            SwiftName: "swift3DoImportantThings()"
+        Properties:
+          - Name: "importantClassProperty"
+            PropertyKind: Class
+            SwiftName: "swift3ClassProperty"
     Protocols:
       - Name: ProtoWithVersionedUnavailableMember
         Methods:
           - Selector: requirement
             MethodKind: Instance
             ResultType: 'ForwardClass * _Nullable'
+      - Name: ProtoWithManyRenames
+        Methods:
+          - Selector: "initWithBoolean:"
+            MethodKind: Instance
+            SwiftName: "init(swift3Boolean:)"
+          - Selector: "doImportantThings"
+            MethodKind: Instance
+            SwiftName: "swift3DoImportantThings()"
+        Properties:
+          - Name: "importantClassProperty"
+            PropertyKind: Class
+            SwiftName: "swift3ClassProperty"
     Functions:
       - Name: acceptDoublePointer
         SwiftName: 'acceptPointer(_:)'
@@ -119,4 +146,10 @@ SwiftVersions:
         SwiftName: aliasRenamedSwift3
       - Name: OptionyEnumRenamed
         SwiftName: renamedSwift3
-    
+  - Version: 4
+    Classes:
+      - Name: ClassWithManyRenames
+        Methods:
+          - Selector: "classWithManyRenamesForInt:"
+            MethodKind: Class
+            SwiftName: "init(swift4Factory:)"

--- a/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/APINotesFrameworkTest.apinotes
+++ b/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/APINotesFrameworkTest.apinotes
@@ -103,6 +103,9 @@ SwiftVersions:
           - Name: "importantClassProperty"
             PropertyKind: Class
             SwiftName: "swift3ClassProperty"
+          - Name: "importantInstanceProperty"
+            PropertyKind: Instance
+            SwiftName: "swift3InstanceProperty"
     Protocols:
       - Name: ProtoWithVersionedUnavailableMember
         Methods:

--- a/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/Classes.h
+++ b/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/Classes.h
@@ -8,5 +8,13 @@
 @interface RenamedGeneric<Element: Base *> : Base
 @end
 
+@interface ClassWithManyRenames : Base
++ (instancetype)classWithManyRenamesForInt:(int)value;
+- (instancetype)initWithBoolean:(_Bool)value __attribute__((swift_name("init(finalBoolean:)")));
+
+- (void)doImportantThings __attribute__((swift_name("finalDoImportantThings()")));
+@property (class, nullable) id importantClassProperty __attribute__((swift_name("finalClassProperty")));
+@end
+
 #pragma clang assume_nonnull end
 #endif // __OBJC__

--- a/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/Classes.h
+++ b/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/Classes.h
@@ -14,6 +14,7 @@
 
 - (void)doImportantThings __attribute__((swift_name("finalDoImportantThings()")));
 @property (class, nullable) id importantClassProperty __attribute__((swift_name("finalClassProperty")));
+@property (nullable) id importantInstanceProperty __attribute__((swift_name("finalInstanceProperty")));
 @end
 
 #pragma clang assume_nonnull end

--- a/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/Protocols.h
+++ b/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/Protocols.h
@@ -7,5 +7,11 @@
 - (nullable id)requirement;
 @end
 
+@protocol ProtoWithManyRenames
+- (instancetype)initWithBoolean:(_Bool)value __attribute__((swift_name("init(finalBoolean:)")));
+- (void)doImportantThings __attribute__((swift_name("finalDoImportantThings()")));
+@property (class, nullable) id importantClassProperty __attribute__((swift_name("finalClassProperty")));
+@end
+
 #pragma clang assume_nonnull end
 #endif // __OBJC__

--- a/test/APINotes/versioned-objc-dynamic-lookup.swift
+++ b/test/APINotes/versioned-objc-dynamic-lookup.swift
@@ -1,0 +1,35 @@
+// RUN: rm -rf %t && mkdir -p %t
+
+// RUN: not %target-swift-frontend -typecheck -F %S/Inputs/custom-frameworks -swift-version 4 %s 2>&1 | %FileCheck -check-prefix=CHECK-DIAGS -check-prefix=CHECK-DIAGS-4 %s
+// RUN: not %target-swift-frontend -typecheck -F %S/Inputs/custom-frameworks -swift-version 3 %s 2>&1 | %FileCheck -check-prefix=CHECK-DIAGS -check-prefix=CHECK-DIAGS-3 %s
+
+// REQUIRES: objc_interop
+
+import APINotesFrameworkTest
+
+func testRenamedClassMembers(obj: AnyObject) {
+  // CHECK-DIAGS-3: [[@LINE+1]]:{{[0-9]+}}: error: 'doImportantThings()' has been renamed to 'swift3DoImportantThings()'
+  obj.doImportantThings()
+  // CHECK-DIAGS-4: [[@LINE-1]]:{{[0-9]+}}: error: 'doImportantThings()' has been renamed to 'finalDoImportantThings()'
+
+  // CHECK-DIAGS-3-NOT: :[[@LINE+1]]:{{[0-9]+}}:
+  obj.swift3DoImportantThings()
+  // CHECK-DIAGS-4: [[@LINE-1]]:{{[0-9]+}}: error: 'swift3DoImportantThings()' has been renamed to 'finalDoImportantThings()'
+
+  // CHECK-DIAGS-3: [[@LINE+1]]:{{[0-9]+}}: error: 'finalDoImportantThings()' has been renamed to 'swift3DoImportantThings()'
+  obj.finalDoImportantThings()
+  // CHECK-DIAGS-4-NOT: :[[@LINE-1]]:{{[0-9]+}}:
+
+
+  // CHECK-DIAGS-3: [[@LINE+1]]:{{[0-9]+}}: error: 'importantInstanceProperty' has been renamed to 'swift3InstanceProperty'
+  _ = obj.importantInstanceProperty
+  // CHECK-DIAGS-4: [[@LINE-1]]:{{[0-9]+}}: error: 'importantInstanceProperty' has been renamed to 'finalInstanceProperty'
+
+  // CHECK-DIAGS-3-NOT: :[[@LINE+1]]:{{[0-9]+}}:
+  _ = obj.swift3InstanceProperty
+  // CHECK-DIAGS-4: [[@LINE-1]]:{{[0-9]+}}: error: 'swift3InstanceProperty' has been renamed to 'finalInstanceProperty'
+
+  // CHECK-DIAGS-3: [[@LINE+1]]:{{[0-9]+}}: error: 'finalInstanceProperty' has been renamed to 'swift3InstanceProperty'
+  _ = obj.finalInstanceProperty
+  // CHECK-DIAGS-4-NOT: :[[@LINE-1]]:{{[0-9]+}}:
+}

--- a/test/APINotes/versioned-objc.swift
+++ b/test/APINotes/versioned-objc.swift
@@ -43,4 +43,101 @@ func testRenamedGeneric() {
   // CHECK-DIAGS-4:[[@LINE-1]]:{{[0-9]+}}: error: 'RenamedGeneric' requires that 'SwiftClass' inherit from 'Base'
 }
 
+func testRenamedClassMembers(obj: ClassWithManyRenames) {
+  // CHECK-DIAGS-3: [[@LINE+1]]:{{[0-9]+}}: error: 'classWithManyRenamesForInt' has been replaced by 'init(swift3Factory:)'
+  _ = ClassWithManyRenames.classWithManyRenamesForInt(0)
+  // CHECK-DIAGS-4: [[@LINE-1]]:{{[0-9]+}}: error: 'classWithManyRenamesForInt' has been replaced by 'init(swift4Factory:)'
+
+  // CHECK-DIAGS-3: [[@LINE+1]]:{{[0-9]+}}: error: 'init(forInt:)' has been replaced by 'init(swift3Factory:)'
+  _ = ClassWithManyRenames(forInt: 0)
+  // CHECK-DIAGS-4: [[@LINE-1]]:{{[0-9]+}}: error: 'init(forInt:)' has been replaced by 'init(swift4Factory:)'
+
+  // CHECK-DIAGS-3-NOT: :[[@LINE+1]]:{{[0-9]+}}:
+  _ = ClassWithManyRenames(swift3Factory: 0)
+  // CHECK-DIAGS-4: [[@LINE-1]]:{{[0-9]+}}: error: 'init(swift3Factory:)' has been replaced by 'init(swift4Factory:)'
+
+  // CHECK-DIAGS-3: [[@LINE+1]]:{{[0-9]+}}: error: 'init(swift4Factory:)' has been replaced by 'init(swift3Factory:)'
+  _ = ClassWithManyRenames(swift4Factory: 0)
+  // CHECK-DIAGS-4-NOT: :[[@LINE-1]]:{{[0-9]+}}:
+
+
+  // CHECK-DIAGS-3: [[@LINE+1]]:{{[0-9]+}}: error: 'init(boolean:)' has been renamed to 'init(swift3Boolean:)'
+  _ = ClassWithManyRenames(boolean: false)
+  // CHECK-DIAGS-4: [[@LINE-1]]:{{[0-9]+}}: error: 'init(boolean:)' has been renamed to 'init(finalBoolean:)'
+
+  // CHECK-DIAGS-3-NOT: :[[@LINE+1]]:{{[0-9]+}}:
+  _ = ClassWithManyRenames(swift3Boolean: false)
+  // CHECK-DIAGS-4: [[@LINE-1]]:{{[0-9]+}}: error: 'init(swift3Boolean:)' has been renamed to 'init(finalBoolean:)'
+
+  // CHECK-DIAGS-3: [[@LINE+1]]:{{[0-9]+}}: error: 'init(finalBoolean:)' has been renamed to 'init(swift3Boolean:)'
+  _ = ClassWithManyRenames(finalBoolean: false)
+  // CHECK-DIAGS-4-NOT: :[[@LINE-1]]:{{[0-9]+}}:
+
+
+  // CHECK-DIAGS-3: [[@LINE+1]]:{{[0-9]+}}: error: 'doImportantThings()' has been renamed to 'swift3DoImportantThings()'
+  obj.doImportantThings()
+  // CHECK-DIAGS-4: [[@LINE-1]]:{{[0-9]+}}: error: 'doImportantThings()' has been renamed to 'finalDoImportantThings()'
+
+  // CHECK-DIAGS-3-NOT: :[[@LINE+1]]:{{[0-9]+}}:
+  obj.swift3DoImportantThings()
+  // CHECK-DIAGS-4: [[@LINE-1]]:{{[0-9]+}}: error: 'swift3DoImportantThings()' has been renamed to 'finalDoImportantThings()'
+
+  // CHECK-DIAGS-3: [[@LINE+1]]:{{[0-9]+}}: error: 'finalDoImportantThings()' has been renamed to 'swift3DoImportantThings()'
+  obj.finalDoImportantThings()
+  // CHECK-DIAGS-4-NOT: :[[@LINE-1]]:{{[0-9]+}}:
+
+
+  // CHECK-DIAGS-3: [[@LINE+1]]:{{[0-9]+}}: error: 'importantClassProperty' has been renamed to 'swift3ClassProperty'
+  _ = ClassWithManyRenames.importantClassProperty
+  // CHECK-DIAGS-4: [[@LINE-1]]:{{[0-9]+}}: error: 'importantClassProperty' has been renamed to 'finalClassProperty'
+
+  // CHECK-DIAGS-3-NOT: :[[@LINE+1]]:{{[0-9]+}}:
+  _ = ClassWithManyRenames.swift3ClassProperty
+  // CHECK-DIAGS-4: [[@LINE-1]]:{{[0-9]+}}: error: 'swift3ClassProperty' has been renamed to 'finalClassProperty'
+
+  // CHECK-DIAGS-3: [[@LINE+1]]:{{[0-9]+}}: error: 'finalClassProperty' has been renamed to 'swift3ClassProperty'
+  _ = ClassWithManyRenames.finalClassProperty
+  // CHECK-DIAGS-4-NOT: :[[@LINE-1]]:{{[0-9]+}}:
+}
+
+func testRenamedProtocolMembers(obj: ProtoWithManyRenames) {
+  // CHECK-DIAGS-3: [[@LINE+1]]:{{[0-9]+}}: error: 'init(boolean:)' has been renamed to 'init(swift3Boolean:)'
+  _ = type(of: obj).init(boolean: false)
+  // CHECK-DIAGS-4: [[@LINE-1]]:{{[0-9]+}}: error: 'init(boolean:)' has been renamed to 'init(finalBoolean:)'
+
+  // CHECK-DIAGS-3-NOT: :[[@LINE+1]]:{{[0-9]+}}:
+  _ = type(of: obj).init(swift3Boolean: false)
+  // CHECK-DIAGS-4: [[@LINE-1]]:{{[0-9]+}}: error: 'init(swift3Boolean:)' has been renamed to 'init(finalBoolean:)'
+
+  // CHECK-DIAGS-3: [[@LINE+1]]:{{[0-9]+}}: error: 'init(finalBoolean:)' has been renamed to 'init(swift3Boolean:)'
+  _ = type(of: obj).init(finalBoolean: false)
+  // CHECK-DIAGS-4-NOT: :[[@LINE-1]]:{{[0-9]+}}:
+
+
+  // CHECK-DIAGS-3: [[@LINE+1]]:{{[0-9]+}}: error: 'doImportantThings()' has been renamed to 'swift3DoImportantThings()'
+  obj.doImportantThings()
+  // CHECK-DIAGS-4: [[@LINE-1]]:{{[0-9]+}}: error: 'doImportantThings()' has been renamed to 'finalDoImportantThings()'
+
+  // CHECK-DIAGS-3-NOT: :[[@LINE+1]]:{{[0-9]+}}:
+  obj.swift3DoImportantThings()
+  // CHECK-DIAGS-4: [[@LINE-1]]:{{[0-9]+}}: error: 'swift3DoImportantThings()' has been renamed to 'finalDoImportantThings()'
+
+  // CHECK-DIAGS-3: [[@LINE+1]]:{{[0-9]+}}: error: 'finalDoImportantThings()' has been renamed to 'swift3DoImportantThings()'
+  obj.finalDoImportantThings()
+  // CHECK-DIAGS-4-NOT: :[[@LINE-1]]:{{[0-9]+}}:
+
+
+  // CHECK-DIAGS-3: [[@LINE+1]]:{{[0-9]+}}: error: 'importantClassProperty' has been renamed to 'swift3ClassProperty'
+  _ = type(of: obj).importantClassProperty
+  // CHECK-DIAGS-4: [[@LINE-1]]:{{[0-9]+}}: error: 'importantClassProperty' has been renamed to 'finalClassProperty'
+
+  // CHECK-DIAGS-3-NOT: :[[@LINE+1]]:{{[0-9]+}}:
+  _ = type(of: obj).swift3ClassProperty
+  // CHECK-DIAGS-4: [[@LINE-1]]:{{[0-9]+}}: error: 'swift3ClassProperty' has been renamed to 'finalClassProperty'
+
+  // CHECK-DIAGS-3: [[@LINE+1]]:{{[0-9]+}}: error: 'finalClassProperty' has been renamed to 'swift3ClassProperty'
+  _ = type(of: obj).finalClassProperty
+  // CHECK-DIAGS-4-NOT: :[[@LINE-1]]:{{[0-9]+}}:
+}
+
 let unrelatedDiagnostic: Int = nil

--- a/test/ClangImporter/Inputs/SwiftPrivateAttr.txt
+++ b/test/ClangImporter/Inputs/SwiftPrivateAttr.txt
@@ -9,21 +9,21 @@ class Foo : NSObject, __PrivProto {
   func __oneArg(_ arg: Int32)
   func __twoArgs(_ arg: Int32, other arg2: Int32)
   class func __withNoArgs() -> Self!
+  @available(swift, obsoleted: 3, renamed: "__withNoArgs()")
+  class func __fooWithNoArgs() -> Self!
+  convenience init!(__oneArg arg: Int32)
   @available(*, unavailable, renamed: "init(__oneArg:)", message: "Not available in Swift")
   class func __fooWithOneArg(_ arg: Int32) -> Self!
-  convenience init!(__oneArg arg: Int32)
+  convenience init!(__twoArgs arg: Int32, other arg2: Int32)
   @available(*, unavailable, renamed: "init(__twoArgs:other:)", message: "Not available in Swift")
   class func __fooWithTwoArgs(_ arg: Int32, other arg2: Int32) -> Self!
-  convenience init!(__twoArgs arg: Int32, other arg2: Int32)
+  convenience init!(__ arg: Int32)
   @available(*, unavailable, renamed: "init(__:)", message: "Not available in Swift")
   class func __foo(_ arg: Int32) -> Self!
-  convenience init!(__ arg: Int32)
   func objectForKeyedSubscript(_ index: Any!) -> Any!
   func __setObject(_ object: Any!, forKeyedSubscript index: Any!)
   func __objectAtIndexedSubscript(_ index: Int32) -> Any!
   func setObject(_ object: Any!, atIndexedSubscript index: Int32)
-  @available(swift, obsoleted: 3, renamed: "__withNoArgs()")
-  class func __fooWithNoArgs() -> Self!
   init()
 }
 class Bar : NSObject {

--- a/test/IDE/print_clang_decls_AppKit.swift
+++ b/test/IDE/print_clang_decls_AppKit.swift
@@ -20,7 +20,11 @@
 // APPKIT-LABEL: {{^}}class NSView : NSObject, NSCoding, NSAccessibility {{{$}}
 // APPKIT-NEXT: init?(coder aDecoder: NSCoder)
 // APPKIT-NEXT: func isDescendant(of aView: NSView) -> Bool
+// APPKIT-NEXT: @available(swift, obsoleted: 3, renamed: "isDescendant(of:)")
+// APPKIT-NEXT: func isDescendantOf(_ aView: NSView) -> Bool
 // APPKIT-NEXT: func ancestorShared(with aView: NSView) -> NSView?
+// APPKIT-NEXT: @available(swift, obsoleted: 3, renamed: "ancestorShared(with:)")
+// APPKIT-NEXT: func ancestorSharedWithView(_ aView: NSView) -> NSView?
 // APPKIT-NEXT: func addSubview(_ aView: NSView)
 // APPKIT-NEXT: func addSubview(_ aView: NSView, positioned place: UInt32, relativeTo otherView: NSView?)
 // APPKIT-NEXT: unowned(unsafe) var superview: @sil_unmanaged NSView? { get }

--- a/test/IDE/print_clang_swift_name.swift
+++ b/test/IDE/print_clang_swift_name.swift
@@ -12,75 +12,79 @@
 class Test : NSObject {
   
   // "Factory methods" that we'd rather have as initializers.
-  @available(*, unavailable, renamed: "init()", message: "Not available in Swift")
-  class func a() -> Self
   @available(*, unavailable, message: "superseded by import of -[NSObject init]")
   convenience init()
+  @available(*, unavailable, renamed: "init()", message: "Not available in Swift")
+  class func a() -> Self
+  convenience init(dummyParam: ())
   @available(*, unavailable, renamed: "init(dummyParam:)", message: "Not available in Swift")
   class func b() -> Self
-  convenience init(dummyParam: ())
   
+  convenience init(cc x: Any)
   @available(*, unavailable, renamed: "init(cc:)", message: "Not available in Swift")
   class func c(_ x: Any) -> Self
-  convenience init(cc x: Any)
+  convenience init(_ x: Any)
   @available(*, unavailable, renamed: "init(_:)", message: "Not available in Swift")
   class func d(_ x: Any) -> Self
-  convenience init(_ x: Any)
   
+  convenience init(aa a: Any, _ b: Any, cc c: Any)
   @available(*, unavailable, renamed: "init(aa:_:cc:)", message: "Not available in Swift")
   class func e(_ a: Any, e b: Any, e c: Any) -> Self
-  convenience init(aa a: Any, _ b: Any, cc c: Any)
   
+  /*not inherited*/ init(fixedType: ())
   @available(*, unavailable, renamed: "init(fixedType:)", message: "Not available in Swift")
   class func f() -> Test
-  /*not inherited*/ init(fixedType: ())
   
   // Would-be initializers.
   class func zz() -> Self
-  class func yy(aa x: Any) -> Self
-  class func xx(_ x: Any, bb xx: Any) -> Self
   @available(swift, obsoleted: 3, renamed: "zz()")
   class func testZ() -> Self
+  class func yy(aa x: Any) -> Self
+  @available(*, unavailable, renamed: "yy(aa:)", message: "Not available in Swift")
+  class func testY(_ x: Any) -> Self
+  class func xx(_ x: Any, bb xx: Any) -> Self
+  @available(*, unavailable, renamed: "xx(_:bb:)", message: "Not available in Swift")
+  class func testX(_ x: Any, xx: Any) -> Self
   
   init()
 }
 
 class TestError : NSObject {
   // Factory methods with NSError.
+  convenience init(error: ()) throws
   @available(*, unavailable, renamed: "init(error:)", message: "Not available in Swift")
   class func err1() throws -> Self
-  convenience init(error: ()) throws
+  convenience init(aa x: Any?, error: ()) throws
   @available(*, unavailable, renamed: "init(aa:error:)", message: "Not available in Swift")
   class func err2(_ x: Any?) throws -> Self
-  convenience init(aa x: Any?, error: ()) throws
+  convenience init(aa x: Any?, error: (), block: @escaping () -> Void) throws
   @available(*, unavailable, renamed: "init(aa:error:block:)", message: "Not available in Swift")
   class func err3(_ x: Any?, callback block: @escaping () -> Void) throws -> Self
-  convenience init(aa x: Any?, error: (), block: @escaping () -> Void) throws
+  convenience init(error: (), block: @escaping () -> Void) throws
   @available(*, unavailable, renamed: "init(error:block:)", message: "Not available in Swift")
   class func err4(callback block: @escaping () -> Void) throws -> Self
-  convenience init(error: (), block: @escaping () -> Void) throws
   
+  convenience init(aa x: Any?) throws
   @available(*, unavailable, renamed: "init(aa:)", message: "Not available in Swift")
   class func err5(_ x: Any?) throws -> Self
-  convenience init(aa x: Any?) throws
+  convenience init(aa x: Any?, block: @escaping () -> Void) throws
   @available(*, unavailable, renamed: "init(aa:block:)", message: "Not available in Swift")
   class func err6(_ x: Any?, callback block: @escaping () -> Void) throws -> Self
-  convenience init(aa x: Any?, block: @escaping () -> Void) throws
+  convenience init(block: @escaping () -> Void) throws
   @available(*, unavailable, renamed: "init(block:)", message: "Not available in Swift")
   class func err7(callback block: @escaping () -> Void) throws -> Self
-  convenience init(block: @escaping () -> Void) throws
   
   // Would-be initializers.
   class func ww(_ x: Any?) throws -> Self
-  class func w2(_ x: Any?, error: ()) throws -> Self
-  class func vv() throws -> Self
-  class func v2(error: ()) throws -> Self
   @available(swift, obsoleted: 3, renamed: "ww(_:)")
   class func testW(_ x: Any?) throws -> Self
+  class func w2(_ x: Any?, error: ()) throws -> Self
   @available(swift, obsoleted: 3, renamed: "w2(_:error:)")
   class func testW2(_ x: Any?) throws -> Self
+  class func vv() throws -> Self
   @available(swift, obsoleted: 3, renamed: "vv()")
   class func testV() throws -> Self
+  class func v2(error: ()) throws -> Self
   @available(swift, obsoleted: 3, renamed: "v2(error:)")
   class func testV2() throws -> Self
   init()

--- a/test/IDE/print_omit_needless_words.swift
+++ b/test/IDE/print_omit_needless_words.swift
@@ -261,25 +261,37 @@
 // CHECK-OMIT-NEEDLESS-WORDS: func addDoodle(_: ABCDoodle)
 
 // Protocols as contexts
-// CHECK-OMIT-NEEDLESS-WORDS: protocol OMWLanding {
+// CHECK-OMIT-NEEDLESS-WORDS-LABEL: protocol OMWLanding {
 // CHECK-OMIT-NEEDLESS-WORDS-NEXT: func flip()
 
 // Verify that we get the Swift name from the original declaration.
-// CHECK-OMIT-NEEDLESS-WORDS: protocol OMWWiggle
+// CHECK-OMIT-NEEDLESS-WORDS-LABEL: protocol OMWWiggle
 // CHECK-OMIT-NEEDLESS-WORDS-NEXT: func joinSub()
 // CHECK-OMIT-NEEDLESS-WORDS-NEXT: func wiggle1()
+// CHECK-OMIT-NEEDLESS-WORDS-NEXT: @available(swift, obsoleted: 3, renamed: "wiggle1()")
+// CHECK-OMIT-NEEDLESS-WORDS-NEXT: func conflicting1()
 // CHECK-OMIT-NEEDLESS-WORDS-NEXT: var wiggleProp1: Int { get }
+// CHECK-OMIT-NEEDLESS-WORDS-NEXT: @available(swift, obsoleted: 3, renamed: "wiggleProp1")
+// CHECK-OMIT-NEEDLESS-WORDS-NEXT: var conflictingProp1: Int { get }
 
-// CHECK-OMIT-NEEDLESS-WORDS: protocol OMWWaggle
+// CHECK-OMIT-NEEDLESS-WORDS-LABEL: protocol OMWWaggle
 // CHECK-OMIT-NEEDLESS-WORDS-NEXT: func waggle1()
+// CHECK-OMIT-NEEDLESS-WORDS-NEXT: @available(swift, obsoleted: 3, renamed: "waggle1()")
+// CHECK-OMIT-NEEDLESS-WORDS-NEXT: func conflicting1()
 // CHECK-OMIT-NEEDLESS-WORDS-NEXT: var waggleProp1: Int { get }
+// CHECK-OMIT-NEEDLESS-WORDS-NEXT: @available(swift, obsoleted: 3, renamed: "waggleProp1")
+// CHECK-OMIT-NEEDLESS-WORDS-NEXT: var conflictingProp1: Int { get }
 
-// CHECK-OMIT-NEEDLESS-WORDS: class OMWSuper
+// CHECK-OMIT-NEEDLESS-WORDS-LABEL: class OMWSuper
 // CHECK-OMIT-NEEDLESS-WORDS-NEXT: func jump()
+// CHECK-OMIT-NEEDLESS-WORDS-NEXT: @available(swift, obsoleted: 3, renamed: "jump()")
+// CHECK-OMIT-NEEDLESS-WORDS-NEXT: func jumpSuper()
 // CHECK-OMIT-NEEDLESS-WORDS-NEXT: var wiggleProp1: Int { get }
 
-// CHECK-OMIT-NEEDLESS-WORDS: class OMWSub
+// CHECK-OMIT-NEEDLESS-WORDS-LABEL: class OMWSub
 // CHECK-OMIT-NEEDLESS-WORDS-NEXT: func jump()
+// CHECK-OMIT-NEEDLESS-WORDS-NEXT: @available(swift, obsoleted: 3, renamed: "jump()")
+// CHECK-OMIT-NEEDLESS-WORDS-NEXT: func jumpSuper()
 // CHECK-OMIT-NEEDLESS-WORDS-NEXT: func joinSub()
 
 // CHECK-OMIT-NEEDLESS-WORDS-DIAGS: inconsistent Swift name for Objective-C method 'conflicting1' in 'OMWSub' ('waggle1()' in 'OMWWaggle' vs. 'wiggle1()' in 'OMWWiggle')


### PR DESCRIPTION
...so that developers get proper diagnostics when they use the wrong name. Also stick in a few ClangImporter cleanups.

rdar://problem/29170671