### PR TITLE
[Driver] For the persistent PCH job there is no output path, the frontend determines the filename to use.

### DIFF
--- a/include/swift/Driver/Action.h
+++ b/include/swift/Driver/Action.h
@@ -287,7 +287,8 @@ class GeneratePCHJobAction : public JobAction {
   virtual void anchor();
 public:
   GeneratePCHJobAction(Action *Input, StringRef persistentPCHDir)
-    : JobAction(Action::GeneratePCHJob, Input, types::TY_PCH),
+    : JobAction(Action::GeneratePCHJob, Input,
+                persistentPCHDir.empty() ? types::TY_PCH : types::TY_Nothing),
       PersistentPCHDir(persistentPCHDir) {}
 
   bool isPersistentPCH() const { return !PersistentPCHDir.empty(); }

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -1759,8 +1759,7 @@ static StringRef getOutputFilename(Compilation &C,
   if (auto *PCHAct = dyn_cast<GeneratePCHJobAction>(JA)) {
     // For a persistent PCH we don't use an output, the frontend determines
     // the filename to use for the PCH.
-    if (PCHAct->isPersistentPCH())
-      return StringRef();
+    assert(!PCHAct->isPersistentPCH());
     AtTopLevel = false;
   }
 

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -808,7 +808,10 @@ ToolChain::constructInvocation(const GeneratePCHJobAction &job,
                                const JobContext &context) const {
   assert(context.Inputs.empty());
   assert(context.InputActions.size() == 1);
-  assert(context.Output.getPrimaryOutputType() == types::TY_PCH);
+  assert((!job.isPersistentPCH() &&
+            context.Output.getPrimaryOutputType() == types::TY_PCH) ||
+         (job.isPersistentPCH() &&
+            context.Output.getPrimaryOutputType() == types::TY_Nothing));
 
   ArgStringList Arguments;
 

--- a/test/Driver/bridging-pch.swift
+++ b/test/Driver/bridging-pch.swift
@@ -20,7 +20,12 @@
 
 // Test persistent PCH
 
-// RUN: %swiftc_driver -typecheck -driver-print-actions -import-objc-header %S/Inputs/bridging-header.h -pch-output-dir %t/pch %s 2>&1 | %FileCheck %s -check-prefix=YESPCHACT
+// RUN: %swiftc_driver -typecheck -driver-print-actions -import-objc-header %S/Inputs/bridging-header.h -pch-output-dir %t/pch %s 2>&1 | %FileCheck %s -check-prefix=PERSISTENT-YESPCHACT
+// PERSISTENT-YESPCHACT: 0: input, "{{.*}}Inputs/bridging-header.h", objc-header
+// PERSISTENT-YESPCHACT: 1: generate-pch, {0}, none
+// PERSISTENT-YESPCHACT: 2: input, "{{.*}}bridging-pch.swift", swift
+// PERSISTENT-YESPCHACT: 3: compile, {2, 1}, none
+
 // RUN: %swiftc_driver -typecheck -disable-bridging-pch -driver-print-actions -import-objc-header %S/Inputs/bridging-header.h -pch-output-dir %t/pch %s 2>&1 | %FileCheck %s -check-prefix=NOPCHACT
 
 // RUN: %swiftc_driver -typecheck -driver-print-jobs -import-objc-header %S/Inputs/bridging-header.h -pch-output-dir %t/pch -disable-bridging-pch %s 2>&1 | %FileCheck %s -check-prefix=PERSISTENT-DISABLED-YESPCHJOB
@@ -30,6 +35,9 @@
 // RUN: %swiftc_driver -typecheck -driver-print-jobs -import-objc-header %S/Inputs/bridging-header.h -pch-output-dir %t/pch %s 2>&1 | %FileCheck %s -check-prefix=PERSISTENT-YESPCHJOB
 // PERSISTENT-YESPCHJOB: {{.*}}swift -frontend {{.*}} -emit-pch -pch-output-dir {{.*}}/pch
 // PERSISTENT-YESPCHJOB: {{.*}}swift -frontend {{.*}} -import-objc-header {{.*}}bridging-header.h -pch-output-dir {{.*}}/pch -pch-disable-validation
+
+// RUN: %swiftc_driver -typecheck -import-objc-header %S/Inputs/bridging-header.h -pch-output-dir %t/pch -parseable-output -driver-skip-execution %s 2>&1 | %FileCheck %s -check-prefix=PERSISTENT-OUTPUT
+// PERSISTENT-OUTPUT-NOT: "outputs": [
 
 // RUN: %swiftc_driver -typecheck -driver-print-jobs -import-objc-header %S/Inputs/bridging-header.h -pch-output-dir %t/pch -whole-module-optimization %s 2>&1 | %FileCheck %s -check-prefix=PERSISTENT-WMO-YESPCHJOB --implicit-check-not pch-disable-validation
 // PERSISTENT-WMO-YESPCHJOB: {{.*}}swift -frontend {{.*}} -import-objc-header {{.*}}bridging-header.h -pch-output-dir {{.*}}/pch


### PR DESCRIPTION
Previously the parseable output would have an empty string as the output of the PCH job, this fixes the issue.
