### PR TITLE
[IDE] Preserve order for Clang declarations with the same source loc.

### DIFF
--- a/lib/IDE/ModuleInterfacePrinting.cpp
+++ b/lib/IDE/ModuleInterfacePrinting.cpp
@@ -450,12 +450,12 @@ void swift::ide::printSubmoduleInterface(
 
   // Sort imported declarations in source order *within a submodule*.
   for (auto &P : ClangDecls) {
-    std::sort(P.second.begin(), P.second.end(),
-              [&](std::pair<Decl *, clang::SourceLocation> LHS,
-                  std::pair<Decl *, clang::SourceLocation> RHS) -> bool {
-                return ClangSourceManager.isBeforeInTranslationUnit(LHS.second,
-                                                                    RHS.second);
-              });
+    std::stable_sort(P.second.begin(), P.second.end(),
+                     [&](std::pair<Decl *, clang::SourceLocation> LHS,
+                         std::pair<Decl *, clang::SourceLocation> RHS) -> bool {
+      return ClangSourceManager.isBeforeInTranslationUnit(LHS.second,
+                                                          RHS.second);
+    });
   }
 
   // Sort Swift declarations so that we print them in a consistent order.

--- a/test/ClangImporter/Inputs/SwiftPrivateAttr.txt
+++ b/test/ClangImporter/Inputs/SwiftPrivateAttr.txt
@@ -107,11 +107,11 @@ struct NSOptions : OptionSet {
   static var __PrivA: NSOptions { get }
   static var B: NSOptions { get }
 }
-@available(swift, obsoleted: 3, renamed: "__PrivCFType")
-typealias __PrivCFTypeRef = __PrivCFType
 class __PrivCFType : _CFObject {
 }
+@available(swift, obsoleted: 3, renamed: "__PrivCFType")
+typealias __PrivCFTypeRef = __PrivCFType
+typealias __PrivCFSub = __PrivCFType
 @available(swift, obsoleted: 3, renamed: "__PrivCFSub")
 typealias __PrivCFSubRef = __PrivCFSub
-typealias __PrivCFSub = __PrivCFType
 typealias __PrivInt = Int32


### PR DESCRIPTION
This usually indicates the same declaration being imported multiple ways; trust the ClangImporter to provide a reasonable order for these.

Necessary to get consistent behavior for my next PR across Mac and Linux.