### PR TITLE
Formatting: Avoid formatting multi-line string literals since it may change behavior. rdar://32135036

### DIFF
--- a/include/swift/IDE/Formatting.h
+++ b/include/swift/IDE/Formatting.h
@@ -27,11 +27,13 @@ public:
 /// \brief Returns the offset (in bytes) to the start of \p LineIndex
 size_t getOffsetOfLine(unsigned LineIndex, StringRef Text);
 
-/// \brief Returns the offset to the first Non-WhiteSpace Character
-size_t getOffsetOfTrimmedLine(unsigned LineIndex, StringRef Text);
+/// \brief Returns the offset to the first Character. If \p Trim is true, the
+///    first character is Non-WhiteSpace.
+size_t getOffsetOfLine(unsigned LineIndex, StringRef Text, bool Trim);
 
-/// \brief Returns the Text on \p LineIndex, excluding Leading WS
-StringRef getTrimmedTextForLine(unsigned LineIndex, StringRef Text);
+/// \brief Returns the Text on \p LineIndex, excluding Leading WS if \p Trim is
+///   true.
+StringRef getTextForLine(unsigned LineIndex, StringRef Text, bool Trim);
 
 /// \brief Returns the number of spaces at the beginning of \p LineIndex
 /// or if indenting is done by Tabs, the number of Tabs * TabWidthp

--- a/lib/IDE/Formatting.cpp
+++ b/lib/IDE/Formatting.cpp
@@ -58,6 +58,7 @@ class FormatContext {
   swift::ASTWalker::ParentTy End;
   bool InDocCommentBlock;
   bool InCommentLine;
+  bool InStringLiteral;
   SiblingAlignInfo SiblingInfo;
 
 public:
@@ -67,9 +68,11 @@ public:
                 swift::ASTWalker::ParentTy End = swift::ASTWalker::ParentTy(),
                 bool InDocCommentBlock = false,
                 bool InCommentLine = false,
+                bool InStringLiteral = false,
                 SiblingAlignInfo SiblingInfo = SiblingAlignInfo())
     :SM(SM), Stack(Stack), Cursor(Stack.rbegin()), Start(Start), End(End),
      InDocCommentBlock(InDocCommentBlock), InCommentLine(InCommentLine),
+     InStringLiteral(InStringLiteral),
      SiblingInfo(SiblingInfo) { }
 
   FormatContext parent() {
@@ -87,10 +90,14 @@ public:
     return InCommentLine;
   }
 
+  bool IsInStringLiteral() const {
+    return InStringLiteral;
+  }
+
   bool isSwitchControlStmt(unsigned LineIndex, StringRef Text) {
     if (!isSwitchContext())
       return false;
-    StringRef LineText = swift::ide::getTrimmedTextForLine(LineIndex, Text);
+    StringRef LineText = swift::ide::getTextForLine(LineIndex, Text, /*Trim*/true);
     return LineText.startswith("break") || LineText.startswith("continue") ||
       LineText.startswith("return") || LineText.startswith("fallthrough");
   }
@@ -635,6 +642,7 @@ class FormatWalker : public SourceEntityWalker {
   swift::ASTWalker::ParentTy AtEnd;
   bool InDocCommentBlock = false;
   bool InCommentLine = false;
+  bool InStringLiteral = false;
   std::vector<Token> Tokens;
   LangOptions Options;
   TokenIt CurrentTokIt;
@@ -726,7 +734,8 @@ public:
     walk(SF);
     scanForComments(SourceLoc());
     return FormatContext(SM, Stack, AtStart, AtEnd, InDocCommentBlock,
-                         InCommentLine, SCollector.getSiblingInfo());
+                         InCommentLine, InStringLiteral,
+                         SCollector.getSiblingInfo());
   }
 
   ArrayRef<Token> getTokens() {
@@ -760,6 +769,12 @@ public:
   }
 
   bool walkToExprPre(Expr *E) override {
+    if (E->getKind() == ExprKind::StringLiteral &&
+        SM.isBeforeInBuffer(E->getStartLoc(), TargetLocation) &&
+        SM.isBeforeInBuffer(TargetLocation,
+                            Lexer::getLocForEndOfToken(SM, E->getEndLoc()))) {
+      InStringLiteral = true;
+    }
     return HandlePre(E, E->getStartLoc(), E->getEndLoc());
   }
 
@@ -784,7 +799,7 @@ public:
 
     // If having sibling locs to align with, respect siblings.
     if (FC.HasSibling()) {
-      StringRef Line = swift::ide::getTrimmedTextForLine(LineIndex, Text);
+      StringRef Line = swift::ide::getTextForLine(LineIndex, Text, /*Trim*/true);
       StringBuilder Builder;
       FC.padToSiblingColumn(Builder);
       if (FC.needExtraIndentationForSibling()) {
@@ -795,6 +810,11 @@ public:
       }
       Builder.append(Line);
       return std::make_pair(LineRange(LineIndex, 1), Builder.str().str());
+    }
+
+    if (FC.IsInStringLiteral()) {
+      return std::make_pair(LineRange(LineIndex, 1),
+        swift::ide::getTextForLine(LineIndex, Text, /*Trim*/false));
     }
 
     // Take the current indent position of the outer context, then add another
@@ -833,7 +853,7 @@ public:
     }
 
     // Reformat the specified line with the calculated indent.
-    StringRef Line = swift::ide::getTrimmedTextForLine(LineIndex, Text);
+    StringRef Line = swift::ide::getTextForLine(LineIndex, Text, /*Trim*/true);
     std::string IndentedLine;
     if (FmtOptions.UseTabs)
       IndentedLine.assign(ExpandedIndent / FmtOptions.TabWidth, '\t');
@@ -905,20 +925,20 @@ size_t swift::ide::getOffsetOfLine(unsigned LineIndex, StringRef Text) {
   return LineOffset;
 }
 
-size_t swift::ide::getOffsetOfTrimmedLine(unsigned LineIndex, StringRef Text) {
+size_t swift::ide::getOffsetOfLine(unsigned LineIndex, StringRef Text, bool Trim) {
   size_t LineOffset = swift::ide::getOffsetOfLine(LineIndex, Text);
-
+  if (!Trim)
+    return LineOffset;
   // Skip leading whitespace.
   size_t FirstNonWSOnLine = Text.find_first_not_of(" \t\v\f", LineOffset);
   if (FirstNonWSOnLine != std::string::npos)
     LineOffset = FirstNonWSOnLine;
-
   return LineOffset;
 }
 
-llvm::StringRef swift::ide::getTrimmedTextForLine(unsigned LineIndex,
-                                                  StringRef Text) {
-  size_t LineOffset = getOffsetOfTrimmedLine(LineIndex, Text);
+llvm::StringRef swift::ide::getTextForLine(unsigned LineIndex, StringRef Text,
+                                           bool Trim) {
+  size_t LineOffset = getOffsetOfLine(LineIndex, Text, Trim);
   size_t LineEnd = Text.find_first_of("\r\n", LineOffset);
   return Text.slice(LineOffset, LineEnd);
 }
@@ -948,7 +968,7 @@ std::pair<LineRange, std::string> swift::ide::reformat(LineRange Range,
   auto SourceBufferID = SF.getBufferID().getValue();
   StringRef Text = SM.getLLVMSourceMgr()
     .getMemoryBuffer(SourceBufferID)->getBuffer();
-  size_t Offset = getOffsetOfTrimmedLine(Range.startLine(), Text);
+  size_t Offset = getOffsetOfLine(Range.startLine(), Text, /*Trim*/true);
   SourceLoc Loc = SM.getLocForBufferStart(SourceBufferID)
     .getAdvancedLoc(Offset);
   FormatContext FC = walker.walkToLocation(Loc);

--- a/test/SourceKit/CodeFormat/indent-multiline-string.swift
+++ b/test/SourceKit/CodeFormat/indent-multiline-string.swift
@@ -3,14 +3,18 @@ func foo() {
 this is line1,
      this is line2,
 """
+  let s1 =
+  "content"
 }
 
 // RUN: %sourcekitd-test -req=format -line=3 -length=1 %s >%t.response
 // RUN: %sourcekitd-test -req=format -line=4 -length=1 %s >>%t.response
 // RUN: %sourcekitd-test -req=format -line=5 -length=1 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=7 -length=1 %s >>%t.response
 
 // RUN: %FileCheck --strict-whitespace %s <%t.response
 
 // CHECK: key.sourcetext: "this is line1,"
 // CHECK: key.sourcetext: "     this is line2,"
 // CHECK: key.sourcetext: "\"\"\""
+// CHECK: key.sourcetext: "    \"content\""

--- a/test/SourceKit/CodeFormat/indent-multiline-string.swift
+++ b/test/SourceKit/CodeFormat/indent-multiline-string.swift
@@ -1,0 +1,16 @@
+func foo() {
+  let s1 = """
+this is line1,
+     this is line2,
+"""
+}
+
+// RUN: %sourcekitd-test -req=format -line=3 -length=1 %s >%t.response
+// RUN: %sourcekitd-test -req=format -line=4 -length=1 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=5 -length=1 %s >>%t.response
+
+// RUN: %FileCheck --strict-whitespace %s <%t.response
+
+// CHECK: key.sourcetext: "this is line1,"
+// CHECK: key.sourcetext: "     this is line2,"
+// CHECK: key.sourcetext: "\"\"\""


### PR DESCRIPTION
Before we figure out how to indent them consistently without altering behavior, we should leave them alone.