### PR TITLE
Fix the access order for open-existential l-values

### DIFF
--- a/test/SILGen/assignment.swift
+++ b/test/SILGen/assignment.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -enforce-exclusivity=checked %s | %FileCheck %s
 
 class C {}
 
@@ -14,7 +14,7 @@ var a = A()
 class D { var child: C = C() }
 
 // Verify that the LHS is formally evaluated before the RHS.
-// CHECK: sil hidden @_T010assignment5test1yyF : $@convention(thin) () -> () {
+// CHECK-LABEL: sil hidden @_T010assignment5test1yyF : $@convention(thin) () -> () {
 func test1() {
   // CHECK: [[CTOR:%.*]] = function_ref @_T010assignment1DC{{[_0-9a-zA-Z]*}}fC
   // CHECK: [[T0:%.*]] = metatype $@thick D.Type
@@ -25,4 +25,24 @@ func test1() {
   // CHECK: [[SETTER:%.*]] = class_method [[D]] : $D,  #D.child!setter.1
   // CHECK: apply [[SETTER]]([[C]], [[D]])
   D().child = C()
+}
+
+// rdar://32039566
+protocol P {
+  var left: Int {get set}
+  var right: Int {get set}
+}
+
+// Verify that the access to the LHS does not begin until after the
+// RHS is formally evaluated.
+// CHECK-LABEL: sil hidden @_T010assignment15copyRightToLeftyAA1P_pz1p_tF : $@convention(thin) (@inout P) -> () {
+func copyRightToLeft(p: inout P) {
+  // CHECK: bb0(%0 : $*P):
+  // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] %0 : $*P
+  // CHECK:   [[READ_OPEN:%.*]] = open_existential_addr immutable_access [[READ]]
+  // CHECK:   end_access [[READ]] : $*P
+  // CHECK:   [[WRITE:%.*]] = begin_access [modify] [unknown] %0 : $*P
+  // CHECK:   [[WRITE_OPEN:%.*]] = open_existential_addr mutable_access [[WRITE]]
+  // CHECK:   end_access [[WRITE]] : $*P
+  p.left = p.right
 }


### PR DESCRIPTION
Don't eagerly begin the access to the existential l-value in an open-existential l-value during formal evaluation.  There's no reason this can't wait until the access begins.

rdar://32039566