### PR TITLE
[stdlib] Optimize interaction of StringCore-based collections

### DIFF
--- a/stdlib/public/core/Builtin.swift
+++ b/stdlib/public/core/Builtin.swift
@@ -114,6 +114,12 @@ public func unsafeBitCast<T, U>(_ x: T, to type: U.Type) -> U {
   return Builtin.reinterpretCast(x)
 }
 
+@_transparent
+public func _identityCast<T, U>(_ x: T, to expectedType: U.Type) -> U {
+  _precondition(type(of: x) == expectedType, "_identityCast to wrong type")
+  return Builtin.reinterpretCast(x)
+}
+
 /// `unsafeBitCast` something to `AnyObject`.
 @_transparent
 internal func _reinterpretCastToAnyObject<T>(_ x: T) -> AnyObject {

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -118,6 +118,33 @@ extension StringProtocol /* : LosslessStringConvertible */ {
   }
 }
 
+/// A protocol that provides fast access to a known representation of String.
+///
+/// Can be used to specialize generic functions that would otherwise end up
+/// doing grapheme breaking to vend individual characters.
+internal protocol _SwiftStringView {
+  /// Returns a `String` that may be unsuitable for long-term storage with the
+  /// same contents as `self`.
+  func _ephemeralString() -> String
+  
+  /// Returns a `String` suitable for long-term storage that has the same
+  /// contents as `self`.
+  func _persistentString() -> String
+}
+
+extension _SwiftStringView {
+  func _substring() -> Substring {
+    return _ephemeralString()[...]
+  }
+  func _ephemeralString() -> String {
+    return _persistentString()
+  }
+}
+
+extension String : _SwiftStringView {
+  func _persistentString() -> String { return characters._persistentString() }
+}
+
 /// Call body with a pointer to zero-terminated sequence of
 /// `TargetEncoding.CodeUnit` representing the same string as `source`, when
 /// `source` is interpreted as being encoded with `SourceEncoding`.

--- a/stdlib/public/core/StringCharacterView.swift
+++ b/stdlib/public/core/StringCharacterView.swift
@@ -151,6 +151,20 @@ extension String {
   }
 }
 
+extension String.CharacterView : _SwiftStringView {
+  func _persistentString() -> String {
+    // FIXME: we might want to make sure our _StringCore isn't somehow a slice
+    // of some larger storage before blindly wrapping/returning it as
+    // persistent.  That said, if current benchmarks are measuring these cases,
+    // we might end up regressing something by copying the storage.  For now,
+    // assume we are not a slice; we can come back and measure the effects of
+    // this fix later.  If we make the fix we should use the line below as an
+    // implementation of _ephemeralString
+    return String(self._core)
+  }
+}
+
+
 /// `String.CharacterView` is a collection of `Character`.
 extension String.CharacterView : BidirectionalCollection {
   internal typealias UnicodeScalarView = String.UnicodeScalarView
@@ -544,9 +558,15 @@ extension String.CharacterView : RangeReplaceableCollection {
   ///
   /// - Parameter characters: A sequence of characters.
   public init<S : Sequence>(_ characters: S)
-    where S.Element == Character {
-    self = String.CharacterView()
-    self.append(contentsOf: characters)
+  where S.Element == Character {
+    let v0 = characters as? _SwiftStringView
+    if _fastPath(v0 != nil), let v = v0 {
+      self = v._persistentString().characters
+    }
+    else {
+      self = String.CharacterView()
+      self.append(contentsOf: characters)
+    }
   }
 }
 

--- a/stdlib/public/core/StringUTF16.swift
+++ b/stdlib/public/core/StringUTF16.swift
@@ -352,6 +352,11 @@ extension String {
   public typealias UTF16Index = UTF16View.Index
 }
 
+extension String.UTF16View : _SwiftStringView {
+  func _ephemeralString() -> String { return _persistentString() }
+  func _persistentString() -> String { return String(self._core) }
+}
+
 extension String.UTF16View.Index : Comparable {
   // FIXME: swift-3-indexing-model: add complete set of forwards for Comparable 
   //        assuming String.UTF8View.Index continues to exist

--- a/stdlib/public/core/StringUTF8.swift
+++ b/stdlib/public/core/StringUTF8.swift
@@ -454,6 +454,11 @@ extension String {
   public typealias UTF8Index = UTF8View.Index
 }
 
+extension String.UTF8View : _SwiftStringView {
+  func _persistentString() -> String { return String(self._core) }
+}
+
+
 extension String.UTF8View.Index : Comparable {
   // FIXME: swift-3-indexing-model: add complete set of forwards for Comparable 
   //        assuming String.UTF8View.Index continues to exist

--- a/stdlib/public/core/StringUnicodeScalarView.swift
+++ b/stdlib/public/core/StringUnicodeScalarView.swift
@@ -326,6 +326,10 @@ extension String {
   public typealias UnicodeScalarIndex = UnicodeScalarView.Index
 }
 
+extension String.UnicodeScalarView : _SwiftStringView {
+  func _persistentString() -> String { return String(_core) }
+}
+
 extension String {
   /// The string's value represented as a collection of Unicode scalar values.
   public var unicodeScalars: UnicodeScalarView {

--- a/stdlib/public/core/Substring.swift.gyb
+++ b/stdlib/public/core/Substring.swift.gyb
@@ -255,6 +255,30 @@ public struct Substring : StringProtocol {
   }
 }
 
+extension Substring : _SwiftStringView {
+  func _persistentString() -> String {
+    let wholeCore = _slice._base._core
+    let native = wholeCore.nativeBuffer
+    if _fastPath(native != nil), let n = native {
+      if _fastPath(
+        n.start == wholeCore._baseAddress && n.usedCount == wholeCore.count) {
+        return String(wholeCore)
+      }
+    }
+    var r = String()
+    r._core.append(_ephemeralString()._core)
+    return r
+  }
+  
+  func _ephemeralString() -> String {
+    let wholeCore = _slice._base._core
+    let subCore : _StringCore = wholeCore[
+      startIndex._base._position..<endIndex._base._position]
+    // check that we haven't allocated a new buffer for the result
+    _sanityCheck(subCore._owner === wholeCore._owner)
+    return String(subCore)
+  }
+}
 
 extension Substring : CustomReflectable {
   public var customMirror: Mirror {
@@ -358,6 +382,20 @@ extension Substring {
 }
 
 #endif
+
+extension Substring : RangeReplaceableCollection {
+  public init<S : Sequence>(_ elements: S)
+  where S.Element == Character {
+    let e0 = elements as? _SwiftStringView
+    if _fastPath(e0 != nil), let e = e0 {
+      self = e._substring()
+    }
+    else {
+      self = String(elements)[...]
+    }
+  }
+  // TODO: specialize append(contentsOf:) similarly
+}
 
 extension Substring {
   public func lowercased() -> String {


### PR DESCRIPTION
Adding _SwiftStringCore allows us to specialize String algorithms to avoid
traversing individual Characters.  Local benchmark shows an 80x speedup in one
case.
