### PR TITLE
[sourcekitd] Take the colons out of name-translation API

### DIFF
--- a/test/SourceKit/NameTranslation/basic.swift
+++ b/test/SourceKit/NameTranslation/basic.swift
@@ -23,6 +23,7 @@ func foo2 (_ a : FooClassDerived) {
 // RUN: %sourcekitd-test -req=translate -objc-selector FooClassDerived2 -pos=3:23 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK11 %s
 // RUN: %sourcekitd-test -req=translate -objc-name fooProperty2 -pos=6:16 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK2 %s
 // RUN: %sourcekitd-test -req=translate -objc-selector fooInstanceFunc1 -pos=7:16 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK3 %s
+// RUN: %sourcekitd-test -req=translate -objc-selector fooInstanceFunc1: -pos=7:16 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK3 %s
 // RUN: %sourcekitd-test -req=translate -objc-selector fooFunc3:d:d:d: -pos=8:4 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK-NONE %s
 
 // RUN: %sourcekitd-test -req=translate -objc-selector fooBaseInstanceFuncOverridden1 -pos=12:13 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK4 %s
@@ -42,7 +43,6 @@ func foo2 (_ a : FooClassDerived) {
 // RUN: %sourcekitd-test -req=translate -objc-selector initWithfloat2:D: -pos=17:13 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK-NONE %s
 // RUN: %sourcekitd-test -req=translate -objc-selector init: -pos=17:13 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK13 %s
 // RUN: %sourcekitd-test -req=translate -objc-selector iit: -pos=17:13 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK13 %s
-// RUN: %sourcekitd-test -req=translate -objc-selector init: -pos=18:13 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK-NONE %s
 // RUN: %sourcekitd-test -req=translate -objc-selector NAME -pos=18:13 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK14 %s
 
 // CHECK1: FooClassDerived2

--- a/test/SourceKit/NameTranslation/init.swift
+++ b/test/SourceKit/NameTranslation/init.swift
@@ -7,7 +7,7 @@ func foo2 () {
 
 // REQUIRES: objc_interop
 // RUN: %sourcekitd-test -req=translate -objc-selector initWithFloat2: -pos=4:15 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK1 %s
-// RUN: %sourcekitd-test -req=translate -objc-selector initWithFloat2 -pos=4:15 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK-NONE %s
+// RUN: %sourcekitd-test -req=translate -objc-selector initWithFloat2 -pos=4:15 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK1 %s
 // RUN: %sourcekitd-test -req=translate -objc-selector initWithFloat2:second2: -pos=5:15 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK2 %s
 // RUN: %sourcekitd-test -req=translate -objc-selector initWithFloat2:second2:third: -pos=5:15 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK-NONE %s
 // RUN: %sourcekitd-test -req=translate -objc-selector initFloat2:second2: -pos=5:15 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK2 %s

--- a/test/SourceKit/NameTranslation/swiftnames.swift
+++ b/test/SourceKit/NameTranslation/swiftnames.swift
@@ -51,8 +51,13 @@ class C2 {}
   @objc open func /*MyClass_foo*/foo(/*MyClass_foo_p1*/bar: Int, /*MyClass_foo_p2*/baz: Int) {}
 }
 
+class C3: NSObject {
+  @objc func oneArg(_: Int) {}
+}
+
 // REQUIRES: objc_interop
 // RUN: %sourcekitd-test -req=translate -swift-name "foo(a:b:c:)" -pos=11:11 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK1 %s
+// RUN: %sourcekitd-test -req=translate -swift-name "foo(a:b:c:)" -pos=11:11 %s -print-raw-response -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK_RAW1 %s
 // RUN: %sourcekitd-test -req=translate -swift-name "bar(x:y:)" -pos=11:11 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECKFEWER1 %s
 // RUN: %sourcekitd-test -req=translate -swift-name "bar(::)" -pos=11:11 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECKMISSING1 %s
 // RUN: %sourcekitd-test -req=translate -swift-name "(x:y:z:)" -pos=11:11 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECKMISSING2 %s
@@ -63,6 +68,7 @@ class C2 {}
 // RUN: %sourcekitd-test -req=translate -swift-name "foo2(a:b:c:)" -pos=12:11 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK6 %s
 // RUN: %sourcekitd-test -req=translate -swift-name "foo2(_:_:_:)" -pos=12:11 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK7 %s
 // RUN: %sourcekitd-test -req=translate -swift-name "foo1()" -pos=14:11 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK8 %s
+// RUN: %sourcekitd-test -req=translate -swift-name "foo1()" -pos=14:11 %s -print-raw-response -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK_RAW8 %s
 // RUN: %sourcekitd-test -req=translate -swift-name "foo1(a:b:c:)" -pos=14:11 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK-NONE %s
 // RUN: %sourcekitd-test -req=translate -swift-name "C11" -pos=1:8 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK9 %s
 
@@ -76,6 +82,8 @@ class C2 {}
 // RUN: %sourcekitd-test -req=translate -swift-name "A2" -pos=41:10 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK14 %s
 // RUN: %sourcekitd-test -req=translate -swift-name "C3" -pos=48:8 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK15 %s
 // RUN: %sourcekitd-test -req=translate -swift-name "bar(_:other:)" -pos=51:36 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK16 %s
+// RUN: %sourcekitd-test -req=translate -swift-name "zoo(m:)" -pos=55:14 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK17 %s
+// RUN: %sourcekitd-test -req=translate -swift-name "zoo(m:)" -pos=55:14 %s -print-raw-response -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK_RAW17 %s
 
 // CHECK-NONE: <empty name translation info>
 // CHECK1: fooWithA:b:c:
@@ -85,7 +93,7 @@ class C2 {}
 // CHECK5: foo1:::
 // CHECK6: foo2WithA:b:c:
 // CHECK7: foo2:::
-// CHECK8: foo1
+// CHECK8: foo1{{$}}
 // CHECK9: C11
 
 // CHECK10: initWithA1:b2:
@@ -95,7 +103,24 @@ class C2 {}
 // CHECK14: CustomErrorA2
 // CHECK15: C2ObjC
 // CHECK16: bar:other:
+// CHECK17: zooWithM:
 
 // CHECKFEWER1: barWithX:y:c:
 // CHECKMISSING1: barWithA:b:c:
 // CHECKMISSING2: fooWithX:y:z:
+
+// CHECK_RAW1-LABEL: key.selectorpieces
+// CHECK_RAW1: "fooWithA"
+// CHECK_RAW1: "b"
+// CHECK_RAW1: "c"
+// CHECK_RAW1: key.namekind: source.lang.name.kind.objc
+
+// CHECK_RAW8-LABEL: key.selectorpieces
+// CHECK_RAW8: "foo1"
+// CHECK_RAW8: key.namekind: source.lang.name.kind.objc
+// CHECK_RAW8: key.is_zero_arg_selector: 1
+
+// CHECK_RAW17-LABEL: key.selectorpieces
+// CHECK_RAW17: "zooWithM"
+// CHECK_RAW17: key.namekind: source.lang.name.kind.objc
+// CHECK_RAW17-NOT: key.is_zero_arg_selector

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -300,6 +300,7 @@ struct NameTranslatingInfo {
   UIdent NameKind;
   StringRef BaseName;
   std::vector<StringRef> ArgNames;
+  bool IsZeroArgSelector = false;
 };
 
 struct RelatedIdentsInfo {

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -900,17 +900,10 @@ getClangDeclarationName(const clang::NamedDecl *ND, NameTranslatingInfo &Info) {
   if (!Info.BaseName.empty()) {
     return clang::DeclarationName(&Ctx.Idents.get(Info.BaseName));
   } else {
-    StringRef last = Info.ArgNames.back();
-
     switch (OrigName.getNameKind()) {
     case clang::DeclarationName::ObjCZeroArgSelector:
-      if (last.endswith(":"))
-        return clang::DeclarationName();
-      break;
     case clang::DeclarationName::ObjCOneArgSelector:
     case clang::DeclarationName::ObjCMultiArgSelector:
-      if (!last.empty() && !last.endswith(":"))
-        return clang::DeclarationName();
       break;
     default:
       return clang::DeclarationName();
@@ -982,8 +975,8 @@ static bool passNameInfoForDecl(const ValueDecl *VD, NameTranslatingInfo &Info,
       if (Selector.getNumArgs()) {
         assert(Pieces.back().empty());
         Pieces.pop_back();
-        std::transform(Pieces.begin(), Pieces.end(), Pieces.begin(),
-          [](StringRef P) { return StringRef(P.data(), P.size() + 1); });
+      } else {
+        Result.IsZeroArgSelector = true;
       }
       Result.ArgNames.insert(Result.ArgNames.begin(), Pieces.begin(), Pieces.end());
       Receiver(Result);

--- a/tools/SourceKit/tools/sourcekitd/lib/API/DictionaryKeys.h
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/DictionaryKeys.h
@@ -132,6 +132,7 @@ extern SourceKit::UIdent KeyArgNames;
 extern SourceKit::UIdent KeySelectorPieces;
 extern SourceKit::UIdent KeyNameKind;
 extern SourceKit::UIdent KeyLocalizationKey;
+extern SourceKit::UIdent KeyIsZeroArgSelector;
 
 extern SourceKit::UIdent KeySwiftVersion;
 

--- a/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
@@ -1523,6 +1523,9 @@ static void reportNameInfo(const NameTranslatingInfo &Info, ResponseReceiver Rec
       NameEle.set(KeyName, N);
     }
   }
+  if (Info.IsZeroArgSelector) {
+    Elem.set(KeyIsZeroArgSelector, Info.IsZeroArgSelector);
+  }
   Rec(RespBuilder.createResponse());
 }
 

--- a/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-Common.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-Common.cpp
@@ -145,6 +145,7 @@ UIdent sourcekitd::KeyArgNames("key.argnames");
 UIdent sourcekitd::KeySelectorPieces("key.selectorpieces");
 UIdent sourcekitd::KeyNameKind("key.namekind");
 UIdent sourcekitd::KeyLocalizationKey("key.localization_key");
+UIdent sourcekitd::KeyIsZeroArgSelector("key.is_zero_arg_selector");
 
 UIdent sourcekitd::KeySwiftVersion("key.swift_version");
 
@@ -247,6 +248,7 @@ static UIdent *OrderedKeys[] = {
   &KeySelectorPieces,
   &KeyNameKind,
   &KeyLocalizationKey,
+  &KeyIsZeroArgSelector,
 
   &KeySwiftVersion,
 };


### PR DESCRIPTION
This makes us more lenient about what we accept for Objective-C
selectors by allowing you to include or not include the trailing colons.
We don't actually need that information, because we have access to the
declaration, so it was only being used for validation, which made the
API harder to use for clients that didn't carefully track zero vs
one-arg selector names.

Also remove the colons from the response, and instead add a bit to say
whether it is a zero-arg or one-arg selector.  This makes the response
easier to use for clients that don't care about this information, and
more consistent with the change to the input.

rdar://problem/32177934

----------

* Explanation: See commit message above^
* Scope: Affects clients of name-translation API.
* Radar: rdar://problem/32177934
* Risk: Low.
* Testing: Regression tests added.