### PR TITLE
[DO NOT MERGE] Revert "[stdlib] Restore @inline(__always) on Collection.first"

### DIFF
--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -1359,15 +1359,12 @@ extension Collection {
   ///     // Prints "10"
   @_inlineable
   public var first: Element? {
-    @inline(__always)
-    get {
-      // NB: Accessing `startIndex` may not be O(1) for some lazy collections,
-      // so instead of testing `isEmpty` and then returning the first element,
-      // we'll just rely on the fact that the iterator always yields the
-      // first element first.
-      var i = makeIterator()
-      return i.next()
-    }
+    // NB: Accessing `startIndex` may not be O(1) for some lazy collections,
+    // so instead of testing `isEmpty` and then returning the first element,
+    // we'll just rely on the fact that the iterator always yields the
+    // first element first.
+    var i = makeIterator()
+    return i.next()
   }
   
   // TODO: swift-3-indexing-model - uncomment and replace above ready (or should we still use the iterator one?)


### PR DESCRIPTION
Reverts apple/swift#9593 for benchmarking purposes.