### PR TITLE
Update example for Unmanaged.toOpaque so it compiles with Swift 3

### DIFF
--- a/stdlib/public/core/Unmanaged.swift
+++ b/stdlib/public/core/Unmanaged.swift
@@ -40,7 +40,7 @@ public struct Unmanaged<Instance : AnyObject> {
   ///
   /// This operation does not change reference counts.
   ///
-  ///     let str0: CFString = "boxcar"
+  ///     let str0 = "boxcar" as CFString
   ///     let bits = Unmanaged.passUnretained(str0)
   ///     let ptr = bits.toOpaque()
   ///


### PR DESCRIPTION
We need an explicit cast to `CFString` and assigning a string to a variable of type `CFString` is not sufficient.

This finishes up [SR-1911](https://bugs.swift.org/browse/SR-1911).
