### PR TITLE
[stdlib] Fixed image inspection for Win32

### DIFF
--- a/stdlib/public/runtime/ImageInspectionWin32.cpp
+++ b/stdlib/public/runtime/ImageInspectionWin32.cpp
@@ -185,9 +185,10 @@ static int _addImageCallback(struct _swift_dl_phdr_info *info,
   if (conformances)
     inspectArgs->fnAddImageBlock(conformances, conformancesSize);
 
-#if defined(_WIN32)
-  FreeLibrary(handle);
-#else
+  // There is no close function or free function for GetModuleHandle(),
+  // especially we should not pass a handle returned by GetModuleHandle to the 
+  // FreeLibrary function.
+#if defined(__CYGWIN__)
   dlclose(handle);
 #endif
   return 0;


### PR DESCRIPTION
Removed calling FreeLibrary().
See GetModuleHandle function in MSDN.
