### PR TITLE
Revert "[stdlib] Implementing copy constructors for integer types"

### DIFF
--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -2578,13 +2578,6 @@ public struct ${Self}
   : FixedWidthInteger, ${Unsigned}Integer,
     _ExpressibleByBuiltinIntegerLiteral {
 
-%   if Self != 'Int':
-  @_transparent
-  public init(_ other: ${Self}) {
-    self.init(other._value)
-  }
-%   end
-
   @_transparent
   public init(_builtinIntegerLiteral x: _MaxBuiltinIntegerType) {
     _value = Builtin.s_to_${u}_checked_trunc_${IntLiteral}_${BuiltinName}(x).0

--- a/test/stdlib/Integers.swift.gyb
+++ b/test/stdlib/Integers.swift.gyb
@@ -614,18 +614,5 @@ tests.test("signum/concrete") {
 % end
 }
 
-tests.test("CopyConstructors") {
-% for suffix in ['8', '16', '32', '64', '']:
-%   for u in ['U', '']:
-%     Type = u + 'Int' + suffix
-  do {
-    let x = ${Type}(42)
-    let y = 42 as ${Type}
-    expectEqual(x, y)
-    expectEqualType(type(of: x), type(of: y))
-  }
-%   end
-% end
-}
 
 runAllTests()


### PR DESCRIPTION
This reverts commit 3f0d1e61aa2d74fc1e044b504dbf56a7dc96f731.

The copy constructors don't really solve any problems, but produce extra
work for the overload resolution.