### PR TITLE
[SE-0176] Enable static enforcement of exclusive access by default

### DIFF
--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -141,7 +141,7 @@ public:
   SanitizerKind Sanitize : 2;
 
   /// Emit compile-time diagnostics when the law of exclusivity is violated.
-  bool EnforceExclusivityStatic = false;
+  bool EnforceExclusivityStatic = true;
 
   /// Suppress static diagnostics for violations of exclusive access for calls
   /// to the Standard Library's swap() free function.

--- a/test/SILGen/polymorphic_inout_aliasing.swift
+++ b/test/SILGen/polymorphic_inout_aliasing.swift
@@ -22,5 +22,7 @@ protocol Storied {
 }
 
 func testProtocol<T: Storied>(x: inout T) {
+  // expected-warning@+2 {{simultaneous accesses to parameter 'x', but modification requires exclusive access; consider copying to a local variable}}
+  // expected-note@+1 {{conflicting access is here}}
   swap(&x.protocolRequirement[0], &x.protocolRequirement[1])
 }


### PR DESCRIPTION
Turn on static checks for the already-accepted portions of SE-0176: Enforce
Exclusive Access to Memory.

This includes static checking for overlapping inout parameter accesses
(and inout-to-pointer accesses).

Static violations are warnings in Swift 3 compatibility mode and errors
in Swift 4 mode.

Dynamic enforcement is not enabled by default.

This does not add static checking for the Non-Escaping Recursion
Restriction rule nor the Non-Escaping Parameter Call Restriction rule. These
are revisions to SE-0176 still under review.