### PR TITLE
[4.0] Diagnose Substring-to-String conversions resulting from subscripting.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3493,6 +3493,12 @@ NOTE(availability_protocol_requirement_here, none,
 NOTE(availability_conformance_introduced_here, none,
      "conformance introduced here", ())
 
+// This doesn't display as an availability diagnostic, but it's
+// implemented there and fires when these subscripts are marked
+// unavailable, so it seems appropriate to put it here.
+ERROR(availabilty_string_subscript_migration, none,
+      "subscripts returning String were obsoleted in Swift 4; explicitly construct a String from subscripted result", ())
+
 //------------------------------------------------------------------------------
 // @discardableResult
 //------------------------------------------------------------------------------

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2002,6 +2002,59 @@ bool TypeChecker::diagnoseExplicitUnavailability(const ValueDecl *D,
   });
 }
 
+/// Check if this is a subscript declaration inside String or
+/// Substring that returns String, and if so return true.
+bool isSubscriptReturningString(const ValueDecl *D, ASTContext &Context) {
+  // Is this a subscript?
+  if (!isa<SubscriptDecl>(D))
+    return false;
+
+  // Is the subscript declared in String or Substring?
+  auto *declContext = D->getDeclContext();
+  assert(declContext && "Expected decl context!");
+
+  auto *stringDecl = Context.getStringDecl();
+  auto *substringDecl = Context.getSubstringDecl();
+
+  auto *typeDecl = declContext->getAsNominalTypeOrNominalTypeExtensionContext();
+  if (!typeDecl)
+    return false;
+
+  if (typeDecl != stringDecl && typeDecl != substringDecl)
+    return false;
+
+  // Is the subscript index one we want to emit a special diagnostic
+  // for, and the return type String?
+  auto fnTy = D->getInterfaceType()->getAs<AnyFunctionType>();
+  assert(fnTy && "Expected function type for subscript decl!");
+
+  // We're only going to warn for BoundGenericStructType with a single
+  // type argument that is not Int!
+  auto inputTy = fnTy->getInput()->getAs<BoundGenericStructType>();
+  if (!inputTy)
+    return false;
+
+  auto genericArgs = inputTy->getGenericArgs();
+  if (genericArgs.size() != 1)
+    return false;
+
+  // The subscripts taking T<Int> do not return Substring, and our
+  // special fixit does not help here.
+  auto intDecl = Context.getIntDecl();
+  auto nominalTypeParam = genericArgs[0]->getAs<NominalType>();
+  if (!nominalTypeParam)
+    return false;
+
+  if (nominalTypeParam->getDecl() == intDecl)
+    return false;
+
+  auto resultTy = fnTy->getResult()->getAs<NominalType>();
+  if (!resultTy)
+    return false;
+
+  return resultTy->getDecl() == stringDecl;
+}
+
 bool TypeChecker::diagnoseExplicitUnavailability(
     const ValueDecl *D,
     SourceRange R,
@@ -2055,6 +2108,14 @@ bool TypeChecker::diagnoseExplicitUnavailability(
                              newName, EncodedMessage.Message);
         attachRenameFixIts(diag);
       }
+    } else if (isSubscriptReturningString(D, Context)) {
+      diagnose(Loc, diag::availabilty_string_subscript_migration)
+        .highlight(R)
+        .fixItInsert(R.Start, "String(")
+        .fixItInsertAfter(R.End, ")");
+
+      // Skip the note emitted below.
+      return true;
     } else if (Attr->Message.empty()) {
       diagnose(Loc, inSwift ? diag::availability_decl_unavailable_in_swift
                             : diag::availability_decl_unavailable,

--- a/test/Sema/substring_to_string_conversion_swift3.swift
+++ b/test/Sema/substring_to_string_conversion_swift3.swift
@@ -1,0 +1,87 @@
+// RUN: %target-swift-frontend -typecheck -verify -swift-version 3 %s
+
+let s = "Hello"
+let ss = s[s.startIndex..<s.endIndex]
+
+// CTP_Initialization
+do {
+  let s1: String = { return ss }()
+  _ = s1
+}
+
+// CTP_ReturnStmt
+do {
+  func returnsAString() -> String {
+    return ss
+  }
+}
+
+// CTP_ThrowStmt
+// Doesn't really make sense for this fix-it - see case in diagnoseContextualConversionError:
+// The conversion destination of throw is always ErrorType (at the moment)
+// if this ever expands, this should be a specific form like () is for
+// return.
+
+// CTP_EnumCaseRawValue
+// Substrings can't be raw values because they aren't literals.
+
+// CTP_DefaultParameter
+do {
+  func foo(x: String = ss) {}
+}
+
+// CTP_CalleeResult
+do {
+  func getSubstring() -> Substring { return ss } // expected-error {{cannot convert return expression of type 'String' to return type 'Substring'}}
+  let gottenString : String = getSubstring() // expected-error {{cannot convert value of type 'Substring' to specified type 'String'}} {{31-31=String(}} {{45-45=)}}
+  _ = gottenString
+}
+
+// CTP_CallArgument
+do {
+  func takesAString(_ s: String) {}
+  takesAString(ss)
+}
+
+// CTP_ClosureResult
+do {
+  [ss].map { (x: Substring) -> String in x } // expected-error {{declared closure result 'String' is incompatible with contextual type '_'}}
+}
+
+// CTP_ArrayElement
+do {
+  let a: [String] = [ ss ]
+  _ = a
+}
+
+// CTP_DictionaryKey
+do {
+  let d: [ String : String ] = [ ss : s ]
+  _ = d
+}
+
+// CTP_DictionaryValue
+do {
+  let d: [ String : String ] = [ s : ss ]
+  _ = d
+}
+
+// CTP_CoerceOperand
+do {
+  let s1: String = ss as String
+  _ = s1
+}
+
+// CTP_AssignSource
+do {
+  let s1: String = ss
+  _ = s1
+}
+
+func takesString(_ s: String) {}
+
+func apply(_ fn: (String) -> (), _ s: String) {
+  fn(s[s.startIndex..<s.endIndex])
+  let _: String = s[s.startIndex..<s.endIndex]
+  _ = s[s.startIndex..<s.endIndex] as String
+}

--- a/test/Sema/substring_to_string_conversion_swift4.swift
+++ b/test/Sema/substring_to_string_conversion_swift4.swift
@@ -78,3 +78,11 @@ do {
   _ = s1
 }
 
+// Substring-to-String via subscripting in a context expecting String
+func takesString(_ s: String) {}
+
+func apply(_ fn: (String) -> (), _ s: String) {
+  fn(s[s.startIndex..<s.endIndex]) // expected-error{{subscripts returning String were obsoleted in Swift 4; explicitly construct a String from subscripted result}} {{6-6=String(}} {{34-34=)}}
+  let _: String = s[s.startIndex..<s.endIndex] // expected-error{{subscripts returning String were obsoleted in Swift 4; explicitly construct a String from subscripted result}} {{19-19=String(}} {{47-47=)}}
+  _ = s[s.startIndex..<s.endIndex] as String // expected-error{{subscripts returning String were obsoleted in Swift 4; explicitly construct a String from subscripted result}} {{7-7=String(}} {{35-35=)}}
+}


### PR DESCRIPTION
When we have a Substring-to-String conversion as a result of
subscripting in a context expecting String, we emit the rather generic
and unactionable availability diagnostic.

Instead, to aid in migration, emit a highly specialized diagnostic and
fixit when we're compiling for -swift-version 4.

(cherry picked from commit 70c0e855819280a2ce8d8ba8aed7634a36454b57)
