### PR TITLE
[4.0] Rename @NSKeyedArchive* attributes.

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -273,7 +273,7 @@ DECL_ATTR(_implements, Implements,
           | NotSerialized | UserInaccessible,
           /* Not serialized */ 67)
 
-DECL_ATTR(NSKeyedArchiveLegacy, NSKeyedArchiveLegacy,
+DECL_ATTR(NSKeyedArchiverClassName, NSKeyedArchiverClassName,
           OnClass | NotSerialized | LongAttribute,
           /*Not serialized */ 68)
 
@@ -281,8 +281,8 @@ SIMPLE_DECL_ATTR(_staticInitializeObjCMetadata, StaticInitializeObjCMetadata,
                  OnClass | NotSerialized | LongAttribute | RejectByParser,
                  /*Not serialized */ 69)
 
-SIMPLE_DECL_ATTR(NSKeyedArchiveSubclassesOnly,
-                 NSKeyedArchiveSubclassesOnly,
+SIMPLE_DECL_ATTR(NSKeyedArchiverEncodeNonGenericSubclassesOnly,
+                 NSKeyedArchiverEncodeNonGenericSubclassesOnly,
                  OnClass | NotSerialized | LongAttribute,
                  /*Not serialized */ 70)
 

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -1161,21 +1161,21 @@ public:
   }
 };
 
-/// Defines the @NSKeyedArchiveLegacyAttr attribute.
-class NSKeyedArchiveLegacyAttr : public DeclAttribute {
+/// Defines the @NSKeyedArchiverClassNameAttr attribute.
+class NSKeyedArchiverClassNameAttr : public DeclAttribute {
 public:
-  NSKeyedArchiveLegacyAttr(StringRef Name, SourceLoc AtLoc, SourceRange Range, bool Implicit)
-    : DeclAttribute(DAK_NSKeyedArchiveLegacy, AtLoc, Range, Implicit),
+  NSKeyedArchiverClassNameAttr(StringRef Name, SourceLoc AtLoc, SourceRange Range, bool Implicit)
+    : DeclAttribute(DAK_NSKeyedArchiverClassName, AtLoc, Range, Implicit),
       Name(Name) {}
 
-  NSKeyedArchiveLegacyAttr(StringRef Name, bool Implicit)
-    : NSKeyedArchiveLegacyAttr(Name, SourceLoc(), SourceRange(), /*Implicit=*/true) {}
+  NSKeyedArchiverClassNameAttr(StringRef Name, bool Implicit)
+    : NSKeyedArchiverClassNameAttr(Name, SourceLoc(), SourceRange(), /*Implicit=*/true) {}
 
   /// The legacy mangled name.
   const StringRef Name;
 
   static bool classof(const DeclAttribute *DA) {
-    return DA->getKind() == DAK_NSKeyedArchiveLegacy;
+    return DA->getKind() == DAK_NSKeyedArchiverClassName;
   }
 };
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1223,16 +1223,16 @@ WARNING(nscoding_unstable_mangled_name_warn,none,
 NOTE(unstable_mangled_name_add_objc,none,
      "for new classes, add '@objc' to specify a unique, prefixed Objective-C "
      "runtime name", ())
-NOTE(unstable_mangled_name_add_nskeyedarchivelegacy,none,
-     "for compatibility with existing archives, use '@NSKeyedArchiveLegacy' "
+NOTE(unstable_mangled_name_add_NSKeyedArchiverClassName,none,
+     "for compatibility with existing archives, use '@NSKeyedArchiverClassName' "
      "to record the Swift 3 mangled name", ())
-NOTE(add_nskeyedarchivesubclassesonly_attr,none,
+NOTE(add_NSKeyedArchiverEncodeNonGenericSubclassesOnly_attr,none,
      "generic class %0 should not be archived directly; "
-     "add @NSKeyedArchiveSubclassesOnly "
+     "add @NSKeyedArchiverEncodeNonGenericSubclassesOnly "
      "and only archive specific subclasses of this class", (Type))
 
-ERROR(attr_nskeyedarchivelegacy_generic,none,
-      "'@NSKeyedArchiveLegacy' cannot be applied to generic class %0",
+ERROR(attr_NSKeyedArchiverClassName_generic,none,
+      "'@NSKeyedArchiverClassName' cannot be applied to generic class %0",
       (Type))
 
 // Generic types

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -1317,8 +1317,8 @@ namespace decls_block {
   using SynthesizedProtocolDeclAttrLayout
     = BCRecordLayout<SynthesizedProtocol_DECL_ATTR>;
   using ImplementsDeclAttrLayout = BCRecordLayout<Implements_DECL_ATTR>;
-  using NSKeyedArchiveLegacyDeclAttrLayout
-    = BCRecordLayout<NSKeyedArchiveLegacy_DECL_ATTR>;
+  using NSKeyedArchiverClassNameDeclAttrLayout
+    = BCRecordLayout<NSKeyedArchiverClassName_DECL_ATTR>;
 
   using InlineDeclAttrLayout = BCRecordLayout<
     Inline_DECL_ATTR,

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -493,10 +493,10 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
     break;
   }
 
-  case DAK_NSKeyedArchiveLegacy: {
-    Printer.printAttrName("@NSKeyedArchiveLegacy");
+  case DAK_NSKeyedArchiverClassName: {
+    Printer.printAttrName("@NSKeyedArchiverClassName");
     Printer << "(";
-    auto *attr = cast<NSKeyedArchiveLegacyAttr>(this);
+    auto *attr = cast<NSKeyedArchiverClassNameAttr>(this);
     Printer << "\"" << attr->Name << "\"";
     Printer << ")";
     break;
@@ -622,8 +622,8 @@ StringRef DeclAttribute::getAttrName() const {
     return "_specialize";
   case DAK_Implements:
     return "_implements";
-  case DAK_NSKeyedArchiveLegacy:
-    return "NSKeyedArchiveLegacy";
+  case DAK_NSKeyedArchiverClassName:
+    return "NSKeyedArchiverClassName";
   }
   llvm_unreachable("bad DeclAttrKind");
 }

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -973,7 +973,7 @@ void IRGenerator::emitNSArchiveClassNameRegistration() {
     Type Ty = CD->getDeclaredType();
     llvm::Value *MetaData = RegisterIGF.emitTypeMetadataRef(getAsCanType(Ty));
     if (auto *LegacyAttr = CD->getAttrs().
-          getAttribute<NSKeyedArchiveLegacyAttr>()) {
+          getAttribute<NSKeyedArchiverClassNameAttr>()) {
       // Register the name for the class in the NSKeyed(Un)Archiver.
       llvm::Value *NameStr = IGM->getAddrOfGlobalString(LegacyAttr->Name);
       RegisterIGF.Builder.CreateCall(IGM->getRegisterClassNameForArchivingFn(),

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -755,7 +755,7 @@ void IRGenerator::addLazyWitnessTable(const ProtocolConformance *Conf) {
 void IRGenerator::addClassForArchiveNameRegistration(ClassDecl *ClassDecl) {
 
   // Those two attributes are interesting to us
-  if (!ClassDecl->getAttrs().hasAttribute<NSKeyedArchiveLegacyAttr>() &&
+  if (!ClassDecl->getAttrs().hasAttribute<NSKeyedArchiverClassNameAttr>() &&
       !ClassDecl->getAttrs().hasAttribute<StaticInitializeObjCMetadataAttr>())
     return;
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -744,7 +744,7 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
 
   case DAK_CDecl:
   case DAK_SILGenName:
-  case DAK_NSKeyedArchiveLegacy: {
+  case DAK_NSKeyedArchiverClassName: {
     if (!consumeIf(tok::l_paren)) {
       diagnose(Loc, diag::attr_expected_lparen, AttrName,
                DeclAttribute::isDeclModifier(DK));
@@ -787,8 +787,8 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
       else if (DK == DAK_CDecl)
         Attributes.add(new (Context) CDeclAttr(AsmName.getValue(), AtLoc,
                                                AttrRange, /*Implicit=*/false));
-      else if (DK == DAK_NSKeyedArchiveLegacy)
-        Attributes.add(new (Context) NSKeyedArchiveLegacyAttr(
+      else if (DK == DAK_NSKeyedArchiverClassName)
+        Attributes.add(new (Context) NSKeyedArchiverClassNameAttr(
                                                AsmName.getValue(), AtLoc,
                                                AttrRange, /*Implicit=*/false));
       else

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -104,9 +104,9 @@ public:
   IGNORED_ATTR(ShowInInterface)
   IGNORED_ATTR(DiscardableResult)
   IGNORED_ATTR(Implements)
-  IGNORED_ATTR(NSKeyedArchiveLegacy)
+  IGNORED_ATTR(NSKeyedArchiverClassName)
   IGNORED_ATTR(StaticInitializeObjCMetadata)
-  IGNORED_ATTR(NSKeyedArchiveSubclassesOnly)
+  IGNORED_ATTR(NSKeyedArchiverEncodeNonGenericSubclassesOnly)
 #undef IGNORED_ATTR
 
   // @noreturn has been replaced with a 'Never' return type.
@@ -783,7 +783,7 @@ public:
     IGNORED_ATTR(ShowInInterface)
     IGNORED_ATTR(ObjCMembers)
     IGNORED_ATTR(StaticInitializeObjCMetadata)
-    IGNORED_ATTR(NSKeyedArchiveSubclassesOnly)
+    IGNORED_ATTR(NSKeyedArchiverEncodeNonGenericSubclassesOnly)
 #undef IGNORED_ATTR
 
   void visitAvailableAttr(AvailableAttr *attr);
@@ -825,7 +825,7 @@ public:
   
   void visitDiscardableResultAttr(DiscardableResultAttr *attr);
   void visitImplementsAttr(ImplementsAttr *attr);
-  void visitNSKeyedArchiveLegacyAttr(NSKeyedArchiveLegacyAttr *attr);
+  void visitNSKeyedArchiverClassNameAttr(NSKeyedArchiverClassNameAttr *attr);
 };
 } // end anonymous namespace
 
@@ -1959,14 +1959,14 @@ void AttributeChecker::visitImplementsAttr(ImplementsAttr *attr) {
   }
 }
 
-void AttributeChecker::visitNSKeyedArchiveLegacyAttr(
-                                              NSKeyedArchiveLegacyAttr *attr) {
+void AttributeChecker::visitNSKeyedArchiverClassNameAttr(
+                                              NSKeyedArchiverClassNameAttr *attr) {
   auto classDecl = dyn_cast<ClassDecl>(D);
   if (!classDecl) return;
 
-  // Generic classes can't use @NSKeyedArchiveLegacy.
+  // Generic classes can't use @NSKeyedArchiverClassName.
   if (classDecl->getGenericSignatureOfContext()) {
-    diagnoseAndRemoveAttr(attr, diag::attr_nskeyedarchivelegacy_generic,
+    diagnoseAndRemoveAttr(attr, diag::attr_NSKeyedArchiverClassName_generic,
                           classDecl->getDeclaredInterfaceType());
   }
 }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -6100,9 +6100,9 @@ public:
 
     UNINTERESTING_ATTR(ObjCMembers)
     UNINTERESTING_ATTR(Implements)
-    UNINTERESTING_ATTR(NSKeyedArchiveLegacy)
+    UNINTERESTING_ATTR(NSKeyedArchiverClassName)
     UNINTERESTING_ATTR(StaticInitializeObjCMetadata)
-    UNINTERESTING_ATTR(NSKeyedArchiveSubclassesOnly)
+    UNINTERESTING_ATTR(NSKeyedArchiverEncodeNonGenericSubclassesOnly)
 #undef UNINTERESTING_ATTR
 
     void visitAvailableAttr(AvailableAttr *attr) {

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5918,14 +5918,14 @@ static void inferStaticInitializeObjCMetadata(ClassDecl *classDecl,
   if (classDecl->getAttrs().hasAttribute<StaticInitializeObjCMetadataAttr>())
     return;
 
-  // A class with the @NSKeyedArchiveLegacyAttr will end up getting registered
+  // A class with the @NSKeyedArchiverClassNameAttr will end up getting registered
   // with the Objective-C runtime anyway.
-  if (classDecl->getAttrs().hasAttribute<NSKeyedArchiveLegacyAttr>())
+  if (classDecl->getAttrs().hasAttribute<NSKeyedArchiverClassNameAttr>())
     return;
 
-  // A class with @NSKeyedArchiveSubclassesOnly promises not to be archived,
+  // A class with @NSKeyedArchiverEncodeNonGenericSubclassesOnly promises not to be archived,
   // so don't static-initialize its Objective-C metadata.
-  if (classDecl->getAttrs().hasAttribute<NSKeyedArchiveSubclassesOnlyAttr>())
+  if (classDecl->getAttrs().hasAttribute<NSKeyedArchiverEncodeNonGenericSubclassesOnlyAttr>())
     return;
 
   // If we know that the Objective-C metadata will be statically registered,
@@ -6021,9 +6021,9 @@ void TypeChecker::checkConformancesInContext(DeclContext *dc,
         }
 
         if (kind && !hasExplicitObjCName(classDecl) &&
-            !classDecl->getAttrs().hasAttribute<NSKeyedArchiveLegacyAttr>() &&
+            !classDecl->getAttrs().hasAttribute<NSKeyedArchiverClassNameAttr>() &&
             !classDecl->getAttrs()
-              .hasAttribute<NSKeyedArchiveSubclassesOnlyAttr>()) {
+              .hasAttribute<NSKeyedArchiverEncodeNonGenericSubclassesOnlyAttr>()) {
           SourceLoc loc;
           if (auto normal = dyn_cast<NormalProtocolConformance>(conformance))
             loc = normal->getLoc();
@@ -6046,15 +6046,15 @@ void TypeChecker::checkConformancesInContext(DeclContext *dc,
               .fixItInsert(insertionLoc,
                            "@objc(<#Objective-C class name#>)");
             diagnose(classDecl,
-                     diag::unstable_mangled_name_add_nskeyedarchivelegacy)
+                     diag::unstable_mangled_name_add_NSKeyedArchiverClassName)
               .fixItInsert(insertionLoc,
-                           "@NSKeyedArchiveLegacy(\"" +
+                           "@NSKeyedArchiverClassName(\"" +
                            mangler.mangleObjCRuntimeName(classDecl) +
                            "\")");
           } else {
-            diagnose(classDecl, diag::add_nskeyedarchivesubclassesonly_attr,
+            diagnose(classDecl, diag::add_NSKeyedArchiverEncodeNonGenericSubclassesOnly_attr,
                      classDecl->getDeclaredInterfaceType())
-              .fixItInsert(insertionLoc, "@NSKeyedArchiveSubclassesOnly");
+              .fixItInsert(insertionLoc, "@NSKeyedArchiverEncodeNonGenericSubclassesOnly");
           }
         }
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1951,7 +1951,7 @@ void Serializer::writeDeclAttribute(const DeclAttribute *DA) {
   case DAK_SynthesizedProtocol:
   case DAK_Count:
   case DAK_Implements:
-  case DAK_NSKeyedArchiveLegacy:
+  case DAK_NSKeyedArchiverClassName:
     llvm_unreachable("cannot serialize attribute");
     return;
 

--- a/test/IDE/complete_decl_attribute.swift
+++ b/test/IDE/complete_decl_attribute.swift
@@ -67,8 +67,8 @@ class C {}
 // KEYWORD3-NEXT:             Keyword/None:                       objcMembers[#Class Attribute#]; name=objcMembers{{$}}
 // KEYWORD3-NEXT:             Keyword/None:                       NSApplicationMain[#Class Attribute#]; name=NSApplicationMain{{$}}
 // KEYWORD3-NEXT:             Keyword/None:                       objc_non_lazy_realization[#Class Attribute#]; name=objc_non_lazy_realization{{$}}
-// KEYWORD3-NEXT:             Keyword/None:                       NSKeyedArchiveLegacy[#Class Attribute#]; name=NSKeyedArchiveLegacy{{$}}
-// KEYWORD3-NEXT:             Keyword/None:                       NSKeyedArchiveSubclassesOnly[#Class Attribute#]; name=NSKeyedArchiveSubclassesOnly{{$}}
+// KEYWORD3-NEXT:             Keyword/None:                       NSKeyedArchiverClassName[#Class Attribute#]; name=NSKeyedArchiverClassName{{$}}
+// KEYWORD3-NEXT:             Keyword/None:                       NSKeyedArchiverEncodeNonGenericSubclassesOnly[#Class Attribute#]; name=NSKeyedArchiverEncodeNonGenericSubclassesOnly{{$}}
 // KEYWORD3-NEXT:             End completions
 
 @#^KEYWORD4^#
@@ -110,6 +110,6 @@ struct S{}
 // KEYWORD_LAST-NEXT:             Keyword/None:                       warn_unqualified_access[#Declaration Attribute#]; name=warn_unqualified_access
 // KEYWORD_LAST-NEXT:             Keyword/None:                       discardableResult[#Declaration Attribute#]; name=discardableResult
 // KEYWORD_LAST-NEXT:             Keyword/None:                       GKInspectable[#Declaration Attribute#]; name=GKInspectable{{$}}
-// KEYWORD_LAST-NEXT:             Keyword/None:                       NSKeyedArchiveLegacy[#Declaration Attribute#]; name=NSKeyedArchiveLegacy{{$}}
-// KEYWORD_LAST-NEXT:             Keyword/None:                       NSKeyedArchiveSubclassesOnly[#Declaration Attribute#]; name=NSKeyedArchiveSubclassesOnly{{$}}
+// KEYWORD_LAST-NEXT:             Keyword/None:                       NSKeyedArchiverClassName[#Declaration Attribute#]; name=NSKeyedArchiverClassName{{$}}
+// KEYWORD_LAST-NEXT:             Keyword/None:                       NSKeyedArchiverEncodeNonGenericSubclassesOnly[#Declaration Attribute#]; name=NSKeyedArchiverEncodeNonGenericSubclassesOnly{{$}}
 // KEYWORD_LAST-NEXT:             End completions

--- a/test/Interpreter/SDK/archive_attributes.swift
+++ b/test/Interpreter/SDK/archive_attributes.swift
@@ -14,7 +14,7 @@ import Foundation
 
 struct ABC {
   // CHECK-ARCHIVE-DAG: nested_class_coding
-  @NSKeyedArchiveLegacy("nested_class_coding")
+  @NSKeyedArchiverClassName("nested_class_coding")
   class NestedClass : NSObject, NSCoding {
     var i : Int
 
@@ -33,7 +33,7 @@ struct ABC {
 }
 
 // CHECK-ARCHIVE-DAG: private_class_coding
-@NSKeyedArchiveLegacy("private_class_coding")
+@NSKeyedArchiverClassName("private_class_coding")
 private class PrivateClass : NSObject, NSCoding {
   var pi : Int
 
@@ -50,7 +50,7 @@ private class PrivateClass : NSObject, NSCoding {
   }
 }
 
-@NSKeyedArchiveSubclassesOnly
+@NSKeyedArchiverEncodeNonGenericSubclassesOnly
 class GenericClass<T> : NSObject, NSCoding {
   var gi : T? = nil
 
@@ -83,7 +83,7 @@ class IntClass : GenericClass<Int> {
 }
 
 // CHECK-ARCHIVE-DAG: double_class_coding
-@NSKeyedArchiveLegacy("double_class_coding")
+@NSKeyedArchiverClassName("double_class_coding")
 class DoubleClass : GenericClass<Double> {
 
   init(dd: Double) {
@@ -102,7 +102,7 @@ class DoubleClass : GenericClass<Double> {
 }
 
 // CHECK-ARCHIVE-DAG: top_level_coding
-@NSKeyedArchiveLegacy("top_level_coding")
+@NSKeyedArchiverClassName("top_level_coding")
 class TopLevel : NSObject, NSCoding {
   var tli : Int
 

--- a/test/Interpreter/SDK/archiving_generic_swift_class.swift
+++ b/test/Interpreter/SDK/archiving_generic_swift_class.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-@NSKeyedArchiveSubclassesOnly
+@NSKeyedArchiverEncodeNonGenericSubclassesOnly
 final class Foo<T: NSCoding>: NSObject, NSCoding {
   var one, two: T
 

--- a/test/decl/protocol/conforms/nscoding.swift
+++ b/test/decl/protocol/conforms/nscoding.swift
@@ -18,14 +18,14 @@ class CodingA : NSObject, NSCoding {
 extension CodingA {
   class NestedA : NSObject, NSCoding { // expected-error{{nested class 'CodingA.NestedA' has an unstable name when archiving via 'NSCoding'}}
     // expected-note@-1{{for new classes, add '@objc' to specify a unique, prefixed Objective-C runtime name}}{{3-3=@objc(<#Objective-C class name#>)}}
-    // expected-note@-2{{for compatibility with existing archives, use '@NSKeyedArchiveLegacy' to record the Swift 3 mangled name}}{{3-3=@NSKeyedArchiveLegacy("_TtCC8nscoding7CodingA7NestedA")}}
+    // expected-note@-2{{for compatibility with existing archives, use '@NSKeyedArchiverClassName' to record the Swift 3 mangled name}}{{3-3=@NSKeyedArchiverClassName("_TtCC8nscoding7CodingA7NestedA")}}
     required init(coder: NSCoder) { }
     func encode(coder: NSCoder) { }
   }
 
   class NestedB : NSObject {
     // expected-note@-1{{for new classes, add '@objc' to specify a unique, prefixed Objective-C runtime name}}{{3-3=@objc(<#Objective-C class name#>)}}
-    // expected-note@-2{{for compatibility with existing archives, use '@NSKeyedArchiveLegacy' to record the Swift 3 mangled name}}{{3-3=@NSKeyedArchiveLegacy("_TtCC8nscoding7CodingA7NestedB")}}
+    // expected-note@-2{{for compatibility with existing archives, use '@NSKeyedArchiverClassName' to record the Swift 3 mangled name}}{{3-3=@NSKeyedArchiverClassName("_TtCC8nscoding7CodingA7NestedB")}}
     required init(coder: NSCoder) { }
     func encode(coder: NSCoder) { }
   }
@@ -51,14 +51,14 @@ extension CodingA.NestedD: NSCoding { // okay
 
 // Generic classes
 class CodingB<T> : NSObject, NSCoding {   // expected-error{{generic class 'CodingB<T>' has an unstable name when archiving via 'NSCoding'}}
-  // expected-note@-1{{generic class 'CodingB<T>' should not be archived directly}}{{1-1=@NSKeyedArchiveSubclassesOnly}}
+  // expected-note@-1{{generic class 'CodingB<T>' should not be archived directly}}{{1-1=@NSKeyedArchiverEncodeNonGenericSubclassesOnly}}
   required init(coder: NSCoder) { }
   func encode(coder: NSCoder) { }
 }
 
 extension CodingB {
   class NestedA : NSObject, NSCoding { // expected-error{{generic class 'CodingB<T>.NestedA' has an unstable name when archiving via 'NSCoding'}}
-    // expected-note@-1{{generic class 'CodingB<T>.NestedA' should not be archived directly}}{{3-3=@NSKeyedArchiveSubclassesOnly}}
+    // expected-note@-1{{generic class 'CodingB<T>.NestedA' should not be archived directly}}{{3-3=@NSKeyedArchiverEncodeNonGenericSubclassesOnly}}
     required init(coder: NSCoder) { }
     func encode(coder: NSCoder) { }
   }
@@ -67,7 +67,7 @@ extension CodingB {
 // Fileprivate classes.
 fileprivate class CodingC : NSObject, NSCoding {    // expected-error{{fileprivate class 'CodingC' has an unstable name when archiving via 'NSCoding'}}
   // expected-note@-1{{for new classes, add '@objc' to specify a unique, prefixed Objective-C runtime name}}{{1-1=@objc(<#Objective-C class name#>)}}
-  // expected-note@-2{{for compatibility with existing archives, use '@NSKeyedArchiveLegacy' to record the Swift 3 mangled name}}{{1-1=@NSKeyedArchiveLegacy("_TtC8nscodingP33_0B4E7641C0BD1F170280EEDD0D0C1F6C7CodingC")}}
+  // expected-note@-2{{for compatibility with existing archives, use '@NSKeyedArchiverClassName' to record the Swift 3 mangled name}}{{1-1=@NSKeyedArchiverClassName("_TtC8nscodingP33_0B4E7641C0BD1F170280EEDD0D0C1F6C7CodingC")}}
   required init(coder: NSCoder) { }
   func encode(coder: NSCoder) { }
 }
@@ -75,7 +75,7 @@ fileprivate class CodingC : NSObject, NSCoding {    // expected-error{{filepriva
 // Private classes
 private class CodingD : NSObject, NSCoding {       // expected-error{{private class 'CodingD' has an unstable name when archiving via 'NSCoding'}}
   // expected-note@-1{{for new classes, add '@objc' to specify a unique, prefixed Objective-C runtime name}}{{1-1=@objc(<#Objective-C class name#>)}}
-  // expected-note@-2{{for compatibility with existing archives, use '@NSKeyedArchiveLegacy' to record the Swift 3 mangled name}}{{1-1=@NSKeyedArchiveLegacy("_TtC8nscodingP33_0B4E7641C0BD1F170280EEDD0D0C1F6C7CodingD")}}
+  // expected-note@-2{{for compatibility with existing archives, use '@NSKeyedArchiverClassName' to record the Swift 3 mangled name}}{{1-1=@NSKeyedArchiverClassName("_TtC8nscodingP33_0B4E7641C0BD1F170280EEDD0D0C1F6C7CodingD")}}
   required init(coder: NSCoder) { }
   func encode(coder: NSCoder) { }
 }
@@ -84,7 +84,7 @@ private class CodingD : NSObject, NSCoding {       // expected-error{{private cl
 func someFunction() {
   class LocalCoding : NSObject, NSCoding {       // expected-error{{local class 'LocalCoding' has an unstable name when archiving via 'NSCoding'}}
   // expected-note@-1{{for new classes, add '@objc' to specify a unique, prefixed Objective-C runtime name}}{{3-3=@objc(<#Objective-C class name#>)}}
-  // expected-note@-2{{for compatibility with existing archives, use '@NSKeyedArchiveLegacy' to record the Swift 3 mangled name}}{{3-3=@NSKeyedArchiveLegacy("_TtCF8nscoding12someFunctionFT_T_L_11LocalCoding")}}
+  // expected-note@-2{{for compatibility with existing archives, use '@NSKeyedArchiverClassName' to record the Swift 3 mangled name}}{{3-3=@NSKeyedArchiverClassName("_TtCF8nscoding12someFunctionFT_T_L_11LocalCoding")}}
   required init(coder: NSCoder) { }
   func encode(coder: NSCoder) { }
 }
@@ -92,47 +92,47 @@ func someFunction() {
 
 // Inherited conformances.
 class CodingE<T> : CodingB<T> {   // expected-error{{generic class 'CodingE<T>' has an unstable name when archiving via 'NSCoding'}}
-    // expected-note@-1{{generic class 'CodingE<T>' should not be archived directly}}{{1-1=@NSKeyedArchiveSubclassesOnly}}
+    // expected-note@-1{{generic class 'CodingE<T>' should not be archived directly}}{{1-1=@NSKeyedArchiverEncodeNonGenericSubclassesOnly}}
   required init(coder: NSCoder) { super.init(coder: coder) }
   override func encode(coder: NSCoder) { }
 }
 
-// @NSKeyedArchiveLegacy suppressions
+// @NSKeyedArchiverClassName suppressions
 extension CodingA {
-  @NSKeyedArchiveLegacy("TheNestedE")
+  @NSKeyedArchiverClassName("TheNestedE")
   class NestedE : NSObject, NSCoding {
     required init(coder: NSCoder) { }
     func encode(coder: NSCoder) { }
   }
 }
 
-@NSKeyedArchiveSubclassesOnly
+@NSKeyedArchiverEncodeNonGenericSubclassesOnly
 class CodingGeneric<T> : NSObject, NSCoding {
   required init(coder: NSCoder) { }
   func encode(coder: NSCoder) { }
 }
 
-@NSKeyedArchiveLegacy("TheCodingF")
+@NSKeyedArchiverClassName("TheCodingF")
 fileprivate class CodingF : NSObject, NSCoding {
   required init(coder: NSCoder) { }
   func encode(coder: NSCoder) { }
 }
 
-@NSKeyedArchiveLegacy("TheCodingG")
+@NSKeyedArchiverClassName("TheCodingG")
 private class CodingG : NSObject, NSCoding {
   required init(coder: NSCoder) { }
   func encode(coder: NSCoder) { }
 }
 
-// Errors with @NSKeyedArchiveLegacy.
-@NSKeyedArchiveLegacy("TheCodingG") // expected-error{{@NSKeyedArchiveLegacy may only be used on 'class' declarations}}
+// Errors with @NSKeyedArchiverClassName.
+@NSKeyedArchiverClassName("TheCodingG") // expected-error{{@NSKeyedArchiverClassName may only be used on 'class' declarations}}
 struct Foo { }
 
-@NSKeyedArchiveLegacy("TheCodingG") // expected-error{{'@NSKeyedArchiveLegacy' cannot be applied to generic class 'Bar<T>'}}
+@NSKeyedArchiverClassName("TheCodingG") // expected-error{{'@NSKeyedArchiverClassName' cannot be applied to generic class 'Bar<T>'}}
 class Bar<T> : NSObject { }
 
 extension CodingB {
-  @NSKeyedArchiveLegacy("GenericViaParent") // expected-error{{'@NSKeyedArchiveLegacy' cannot be applied to generic class 'CodingB<T>.GenericViaParent'}}
+  @NSKeyedArchiverClassName("GenericViaParent") // expected-error{{'@NSKeyedArchiverClassName' cannot be applied to generic class 'CodingB<T>.GenericViaParent'}}
   class GenericViaParent : NSObject { }
 }
 


### PR DESCRIPTION
**Explanation**: Rename two newly-introduced attributes (`@NSKeyedArchiveLegacy` and `@ NSKeyedArchiveSubclassesOnly `) to more descriptive names (`@NSKeyedArchiverClassName` and `@NSKeyedArchiverEncodeNonGenericSubclassesOnly`, respectively).
**Scope**: These are new attributes, so no existing code will be affected.
**Radar**: rdar://problem/32178796
**Risk**: Effectively zero.
**Testing**: Compiler regression testing.

(cherry picked from commit 7955aa13e63fc3da24ad9bfb44c1c07ae1551bff)

