### PR TITLE
Temporarily comment out code to set runtime function attributes.

### DIFF
--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -461,8 +461,8 @@ llvm::Constant *swift::getRuntimeFn(llvm::Module &Module,
     }
     // FIXME: getting attributes here without setting them does
     // nothing. This cannot be fixed until the attributes are correctly specified.
-    fn->addAttributes(llvm::AttributeList::FunctionIndex, buildFnAttr);
-    fn->addAttributes(llvm::AttributeList::ReturnIndex, buildRetAttr);
+    //fn->addAttributes(llvm::AttributeList::FunctionIndex, buildFnAttr);
+    //fn->addAttributes(llvm::AttributeList::ReturnIndex, buildRetAttr);
   }
 
   return cache;


### PR DESCRIPTION
Before my change in e24a6f1d30, the previous code did nothing. I saw the
comment but did not think it really meant what it says. My change
caused the function attributes to be set and that led to all sorts of
mayhem. E.G., I know for sure that the “swift_dynamicCast” entry should
not be ReadOnly because it returns its result by assigning through one
of its arguments. We need to audit the attributes for those runtime
functions before we can turn this on (tracked in rdar://problem/20802330)