### PR TITLE
Fix some compiler crashing issues found by early adopters of keypaths.

### DIFF
--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -114,8 +114,12 @@ public:
                                              Type FromType, Type ToType,
                                              ModuleDecl *Module);
   
-  std::string mangleKeyPathGetterThunkHelper(const VarDecl *property);
-  std::string mangleKeyPathSetterThunkHelper(const VarDecl *property);
+  std::string mangleKeyPathGetterThunkHelper(const VarDecl *property,
+                                             GenericSignature *signature,
+                                             CanType baseType);
+  std::string mangleKeyPathSetterThunkHelper(const VarDecl *property,
+                                             GenericSignature *signature,
+                                             CanType baseType);
 
   std::string mangleTypeForDebugger(Type decl, const DeclContext *DC,
                                     GenericEnvironment *GE);

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -445,6 +445,8 @@ ERROR(expr_swift_keypath_invalid_component,none,
       "invalid component of Swift key path", ())
 ERROR(expr_swift_keypath_not_starting_with_type,none,
       "a Swift key path must begin with a type", ())
+ERROR(expr_swift_keypath_unimplemented_component,none,
+      "key path support for %0 components is not implemented", (StringRef))
 
 // Selector expressions.
 ERROR(expr_selector_no_objc_runtime,none,

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -228,8 +228,8 @@ namespace swift {
     Swift3ObjCInferenceWarnings WarnSwift3ObjCInference =
       Swift3ObjCInferenceWarnings::None;
     
-    /// Enable keypaths.
-    bool EnableExperimentalKeyPaths = true;
+    /// Enable keypath components that aren't fully implemented.
+    bool EnableExperimentalKeyPathComponents = false;
 
     /// When a conversion from String to Substring fails, emit a fix-it to append
     /// the void subscript '[]'.

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -269,9 +269,9 @@ def enable_experimental_property_behaviors :
   Flag<["-"], "enable-experimental-property-behaviors">,
   HelpText<"Enable experimental property behaviors">;
   
-def enable_experimental_keypaths :
-  Flag<["-"], "enable-experimental-keypaths">,
-  HelpText<"Enable experimental keypaths">;
+def enable_experimental_keypath_components :
+  Flag<["-"], "enable-experimental-keypath-components">,
+  HelpText<"Enable unimplemented keypath component kinds">;
 
 def enable_deserialization_recovery :
   Flag<["-"], "enable-deserialization-recovery">,

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -226,16 +226,26 @@ std::string ASTMangler::mangleGlobalVariableFull(const VarDecl *decl) {
   return finalize();
 }
 
-std::string ASTMangler::mangleKeyPathGetterThunkHelper(const VarDecl *property) {
+std::string ASTMangler::mangleKeyPathGetterThunkHelper(const VarDecl *property,
+                                                   GenericSignature *signature,
+                                                   CanType baseType) {
   beginMangling();
   appendEntity(property);
+  if (signature)
+    appendGenericSignature(signature);
+  appendType(baseType);
   appendOperator("TK");
   return finalize();
 }
 
-std::string ASTMangler::mangleKeyPathSetterThunkHelper(const VarDecl *property) {
+std::string ASTMangler::mangleKeyPathSetterThunkHelper(const VarDecl *property,
+                                                   GenericSignature *signature,
+                                                   CanType baseType) {
   beginMangling();
   appendEntity(property);
+  if (signature)
+    appendGenericSignature(signature);
+  appendType(baseType);
   appendOperator("Tk");
   return finalize();
 }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1138,7 +1138,7 @@ static bool isPolymorphic(const AbstractStorageDecl *storage) {
     return false;
 
   case DeclKind::Protocol:
-    return true;
+    return !storage->getDeclContext()->isExtensionContext();
 
   case DeclKind::Class:
     // Final properties can always be direct, even in classes.

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -1267,8 +1267,14 @@ NodePointer Demangler::demangleThunkOrSpecialization() {
     case 'k': {
       auto nodeKind = c == 'K' ? Node::Kind::KeyPathGetterThunkHelper
                                : Node::Kind::KeyPathSetterThunkHelper;
-      auto decl = popNode();
-      return createWithChild(nodeKind, decl);
+      auto type = popNode();
+      auto sigOrDecl = popNode();
+      if (sigOrDecl->getKind() == Node::Kind::DependentGenericSignature) {
+        auto decl = popNode();
+        return createWithChildren(nodeKind, decl, sigOrDecl, type);
+      } else {
+        return createWithChildren(nodeKind, sigOrDecl, type);
+      }
     }
     default:
       return nullptr;

--- a/lib/Demangling/NodePrinter.cpp
+++ b/lib/Demangling/NodePrinter.cpp
@@ -1190,10 +1190,24 @@ NodePointer NodePrinter::print(NodePointer Node, bool asPrefixContext) {
   case Node::Kind::KeyPathGetterThunkHelper:
     Printer << "key path getter for ";
     print(Node->getChild(0));
+    Printer << " : ";
+    if (Node->getNumChildren() == 2) {
+      print(Node->getChild(1));
+    } else {
+      print(Node->getChild(1));
+      print(Node->getChild(2));
+    }
     return nullptr;
   case Node::Kind::KeyPathSetterThunkHelper:
     Printer << "key path setter for ";
     print(Node->getChild(0));
+    Printer << " : ";
+    if (Node->getNumChildren() == 2) {
+      print(Node->getChild(1));
+    } else {
+      print(Node->getChild(1));
+      print(Node->getChild(2));
+    }
     return nullptr;
   case Node::Kind::FieldOffset: {
     print(Node->getChild(0)); // directness

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -914,8 +914,8 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.EnableExperimentalPropertyBehaviors |=
     Args.hasArg(OPT_enable_experimental_property_behaviors);
 
-  Opts.EnableExperimentalKeyPaths |=
-    Args.hasArg(OPT_enable_experimental_keypaths);
+  Opts.EnableExperimentalKeyPathComponents |=
+    Args.hasArg(OPT_enable_experimental_keypath_components);
 
   Opts.EnableClassResilience |=
     Args.hasArg(OPT_enable_class_resilience);

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -455,8 +455,6 @@ ParserResult<Expr> Parser::parseExprUnary(Diag<> Message, bool isExprBasic) {
   case tok::pound_keyPath:
     return parseExprKeyPathObjC();
   case tok::backslash:
-    if (!Context.LangOpts.EnableExperimentalKeyPaths)
-      return parseExprPostfix(Message, isExprBasic);
     return parseExprKeyPath();
 
   case tok::oper_postfix:

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -3982,6 +3982,9 @@ namespace {
       }
 
       simplifyExprType(E);
+      
+      if (E->getType()->hasError())
+        return E;
 
       SmallVector<KeyPathExpr::Component, 4> resolvedComponents;
 

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2797,6 +2797,13 @@ namespace {
         
         case KeyPathExpr::Component::Kind::OptionalChain: {
           didOptionalChain = true;
+          
+          // TODO: This currently crashes the compiler in some cases, so short-
+          // circuit out.
+          if (!CS.TC.Context.LangOpts.EnableExperimentalKeyPathComponents) {
+            return ErrorType::get(CS.TC.Context);
+          }
+          
           // We can't assign an optional back through an optional chain
           // today. Force the base to an rvalue.
           auto rvalueTy = CS.createTypeVariable(locator, 0);

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2828,8 +2828,7 @@ performMemberLookup(ConstraintKind constraintKind, DeclName memberName,
   result.OverallResult = MemberLookupResult::HasResults;
   
   // If we're looking for a subscript, consider key path operations.
-  if (memberName.isSimpleName(getASTContext().Id_subscript)
-      && getASTContext().LangOpts.EnableExperimentalKeyPaths) {
+  if (memberName.isSimpleName(getASTContext().Id_subscript)) {
     result.ViableCandidates.push_back(
         OverloadChoice(baseTy, OverloadChoiceKind::KeyPathApplication));
   }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3841,6 +3841,11 @@ ConstraintSystem::simplifyKeyPathConstraint(Type keyPathTy,
         return SolutionKind::Unsolved;
       }
       
+      // Discarded unsupported non-decl member lookups.
+      if (!choices[i].isDecl()) {
+        return SolutionKind::Error;
+      }
+      
       auto storage = cast<AbstractStorageDecl>(choices[i].getDecl());
       if (!storage->isSettable(DC)) {
         // A non-settable component makes the key path read-only, unless

--- a/test/SIL/Parser/keypath.sil
+++ b/test/SIL/Parser/keypath.sil
@@ -57,24 +57,24 @@ entry:
 }
 
 sil @id_a : $@convention(thin) () -> ()
-sil @get_s_int : $@convention(thin) (@in S, @thick S.Type) -> @out Int
-sil @set_s_int : $@convention(thin) (@in Int, @in S, @thick S.Type) -> ()
-sil @get_c_int : $@convention(thin) (@in C, @thick C.Type) -> @out Int
-sil @set_c_int : $@convention(thin) (@in Int, @in C, @thick C.Type) -> ()
-sil @get_fns_fnc : $@convention(thin) (@in @callee_owned (@in S) -> @out S, @thick ((S) -> S).Type) -> @out @callee_owned (@in C) -> @out C
-sil @set_fns_fnc : $@convention(thin) (@in @callee_owned (@in C) -> @out C, @in @callee_owned (@in S) -> @out S, @thick ((S) -> S).Type) -> ()
+sil @get_s_int : $@convention(thin) (@in S) -> @out Int
+sil @set_s_int : $@convention(thin) (@in Int, @in S) -> ()
+sil @get_c_int : $@convention(thin) (@in C) -> @out Int
+sil @set_c_int : $@convention(thin) (@in Int, @in C) -> ()
+sil @get_fns_fnc : $@convention(thin) (@in @callee_owned (@in S) -> @out S) -> @out @callee_owned (@in C) -> @out C
+sil @set_fns_fnc : $@convention(thin) (@in @callee_owned (@in C) -> @out C, @in @callee_owned (@in S) -> @out S) -> ()
 
 // CHECK-LABEL: sil shared @computed_properties
 sil shared @computed_properties : $@convention(thin) () -> () {
 entry:
-  // CHECK: keypath $KeyPath<S, Int>, (root $S; gettable_property $Int, id @id_a : $@convention(thin) () -> (), getter @get_s_int : $@convention(thin) (@in S, @thick S.Type) -> @out Int)
-  %a = keypath $KeyPath<S, Int>, (root $S; gettable_property $Int, id @id_a : $@convention(thin) () -> (), getter @get_s_int : $@convention(thin) (@in S, @thick S.Type) -> @out Int)
-  // CHECK: keypath $WritableKeyPath<S, Int>, (root $S; settable_property $Int, id @id_a : $@convention(thin) () -> (), getter @get_s_int : $@convention(thin) (@in S, @thick S.Type) -> @out Int, setter @set_s_int : $@convention(thin) (@in Int, @in S, @thick S.Type) -> ())
-  %b = keypath $WritableKeyPath<S, Int>, (root $S; settable_property $Int, id @id_a : $@convention(thin) () -> (), getter @get_s_int : $@convention(thin) (@in S, @thick S.Type) -> @out Int, setter @set_s_int : $@convention(thin) (@in Int, @in S, @thick S.Type) -> ())
-  // CHECK: keypath $WritableKeyPath<(S) -> S, (C) -> C>, (root $(S) -> S; settable_property $(C) -> C, id @id_a : $@convention(thin) () -> (), getter @get_fns_fnc : $@convention(thin) (@in @callee_owned (@in S) -> @out S, @thick ((S) -> S).Type) -> @out @callee_owned (@in C) -> @out C, setter @set_fns_fnc : $@convention(thin) (@in @callee_owned (@in C) -> @out C, @in @callee_owned (@in S) -> @out S, @thick ((S) -> S).Type) -> ())
-  %c = keypath $WritableKeyPath<(S) -> S, (C) -> C>, (root $(S) -> S; settable_property $(C) -> C, id @id_a : $@convention(thin) () -> (), getter @get_fns_fnc : $@convention(thin) (@in @callee_owned (@in S) -> @out S, @thick ((S) -> S).Type) -> @out @callee_owned (@in C) -> @out C, setter @set_fns_fnc : $@convention(thin) (@in @callee_owned (@in C) -> @out C, @in @callee_owned (@in S) -> @out S, @thick ((S) -> S).Type) -> ())
-  // CHECK: keypath $WritableKeyPath<C, Int>, (root $C; settable_property $Int, id #C.overridable!getter.1 : (C) -> () -> Int, getter @get_c_int : $@convention(thin) (@in C, @thick C.Type) -> @out Int, setter @set_c_int : $@convention(thin) (@in Int, @in C, @thick C.Type) -> ())
-  %d = keypath $WritableKeyPath<C, Int>, (root $C; settable_property $Int, id #C.overridable!getter.1 : (C) -> () -> Int, getter @get_c_int : $@convention(thin) (@in C, @thick C.Type) -> @out Int, setter @set_c_int : $@convention(thin) (@in Int, @in C, @thick C.Type) -> ())
+  // CHECK: keypath $KeyPath<S, Int>, (root $S; gettable_property $Int, id @id_a : $@convention(thin) () -> (), getter @get_s_int : $@convention(thin) (@in S) -> @out Int)
+  %a = keypath $KeyPath<S, Int>, (root $S; gettable_property $Int, id @id_a : $@convention(thin) () -> (), getter @get_s_int : $@convention(thin) (@in S) -> @out Int)
+  // CHECK: keypath $WritableKeyPath<S, Int>, (root $S; settable_property $Int, id @id_a : $@convention(thin) () -> (), getter @get_s_int : $@convention(thin) (@in S) -> @out Int, setter @set_s_int : $@convention(thin) (@in Int, @in S) -> ())
+  %b = keypath $WritableKeyPath<S, Int>, (root $S; settable_property $Int, id @id_a : $@convention(thin) () -> (), getter @get_s_int : $@convention(thin) (@in S) -> @out Int, setter @set_s_int : $@convention(thin) (@in Int, @in S) -> ())
+  // CHECK: keypath $WritableKeyPath<(S) -> S, (C) -> C>, (root $(S) -> S; settable_property $(C) -> C, id @id_a : $@convention(thin) () -> (), getter @get_fns_fnc : $@convention(thin) (@in @callee_owned (@in S) -> @out S) -> @out @callee_owned (@in C) -> @out C, setter @set_fns_fnc : $@convention(thin) (@in @callee_owned (@in C) -> @out C, @in @callee_owned (@in S) -> @out S) -> ())
+  %c = keypath $WritableKeyPath<(S) -> S, (C) -> C>, (root $(S) -> S; settable_property $(C) -> C, id @id_a : $@convention(thin) () -> (), getter @get_fns_fnc : $@convention(thin) (@in @callee_owned (@in S) -> @out S) -> @out @callee_owned (@in C) -> @out C, setter @set_fns_fnc : $@convention(thin) (@in @callee_owned (@in C) -> @out C, @in @callee_owned (@in S) -> @out S) -> ())
+  // CHECK: keypath $WritableKeyPath<C, Int>, (root $C; settable_property $Int, id #C.overridable!getter.1 : (C) -> () -> Int, getter @get_c_int : $@convention(thin) (@in C) -> @out Int, setter @set_c_int : $@convention(thin) (@in Int, @in C) -> ())
+  %d = keypath $WritableKeyPath<C, Int>, (root $C; settable_property $Int, id #C.overridable!getter.1 : (C) -> () -> Int, getter @get_c_int : $@convention(thin) (@in C) -> @out Int, setter @set_c_int : $@convention(thin) (@in Int, @in C) -> ())
 
   return undef : $()
 }

--- a/test/SIL/Serialization/keypath.sil
+++ b/test/SIL/Serialization/keypath.sil
@@ -62,24 +62,24 @@ entry:
 }
 
 sil @id_a : $@convention(thin) () -> ()
-sil @get_s_int : $@convention(thin) (@in S, @thick S.Type) -> @out Int
-sil @set_s_int : $@convention(thin) (@in Int, @in S, @thick S.Type) -> ()
-sil @get_c_int : $@convention(thin) (@in C, @thick C.Type) -> @out Int
-sil @set_c_int : $@convention(thin) (@in Int, @in C, @thick C.Type) -> ()
-sil @get_fns_fnc : $@convention(thin) (@in @callee_owned (@in S) -> @out S, @thick ((S) -> S).Type) -> @out @callee_owned (@in C) -> @out C
-sil @set_fns_fnc : $@convention(thin) (@in @callee_owned (@in C) -> @out C, @in @callee_owned (@in S) -> @out S, @thick ((S) -> S).Type) -> ()
+sil @get_s_int : $@convention(thin) (@in S) -> @out Int
+sil @set_s_int : $@convention(thin) (@in Int, @in S) -> ()
+sil @get_c_int : $@convention(thin) (@in C) -> @out Int
+sil @set_c_int : $@convention(thin) (@in Int, @in C) -> ()
+sil @get_fns_fnc : $@convention(thin) (@in @callee_owned (@in S) -> @out S) -> @out @callee_owned (@in C) -> @out C
+sil @set_fns_fnc : $@convention(thin) (@in @callee_owned (@in C) -> @out C, @in @callee_owned (@in S) -> @out S) -> ()
 
 // CHECK-LABEL: sil shared @computed_properties
 sil shared @computed_properties : $@convention(thin) () -> () {
 entry:
-  // CHECK: keypath $KeyPath<S, Int>, (root $S; gettable_property $Int, id @id_a : $@convention(thin) () -> (), getter @get_s_int : $@convention(thin) (@in S, @thick S.Type) -> @out Int)
-  %a = keypath $KeyPath<S, Int>, (root $S; gettable_property $Int, id @id_a : $@convention(thin) () -> (), getter @get_s_int : $@convention(thin) (@in S, @thick S.Type) -> @out Int)
-  // CHECK: keypath $WritableKeyPath<S, Int>, (root $S; settable_property $Int, id @id_a : $@convention(thin) () -> (), getter @get_s_int : $@convention(thin) (@in S, @thick S.Type) -> @out Int, setter @set_s_int : $@convention(thin) (@in Int, @in S, @thick S.Type) -> ())
-  %b = keypath $WritableKeyPath<S, Int>, (root $S; settable_property $Int, id @id_a : $@convention(thin) () -> (), getter @get_s_int : $@convention(thin) (@in S, @thick S.Type) -> @out Int, setter @set_s_int : $@convention(thin) (@in Int, @in S, @thick S.Type) -> ())
-  // CHECK: keypath $WritableKeyPath<(S) -> S, (C) -> C>, (root $(S) -> S; settable_property $(C) -> C, id @id_a : $@convention(thin) () -> (), getter @get_fns_fnc : $@convention(thin) (@in @callee_owned (@in S) -> @out S, @thick ((S) -> S).Type) -> @out @callee_owned (@in C) -> @out C, setter @set_fns_fnc : $@convention(thin) (@in @callee_owned (@in C) -> @out C, @in @callee_owned (@in S) -> @out S, @thick ((S) -> S).Type) -> ())
-  %c = keypath $WritableKeyPath<(S) -> S, (C) -> C>, (root $(S) -> S; settable_property $(C) -> C, id @id_a : $@convention(thin) () -> (), getter @get_fns_fnc : $@convention(thin) (@in @callee_owned (@in S) -> @out S, @thick ((S) -> S).Type) -> @out @callee_owned (@in C) -> @out C, setter @set_fns_fnc : $@convention(thin) (@in @callee_owned (@in C) -> @out C, @in @callee_owned (@in S) -> @out S, @thick ((S) -> S).Type) -> ())
-  // CHECK: keypath $WritableKeyPath<C, Int>, (root $C; settable_property $Int, id #C.overridable!getter.1 : (C) -> () -> Int, getter @get_c_int : $@convention(thin) (@in C, @thick C.Type) -> @out Int, setter @set_c_int : $@convention(thin) (@in Int, @in C, @thick C.Type) -> ())
-  %d = keypath $WritableKeyPath<C, Int>, (root $C; settable_property $Int, id #C.overridable!getter.1 : (C) -> () -> Int, getter @get_c_int : $@convention(thin) (@in C, @thick C.Type) -> @out Int, setter @set_c_int : $@convention(thin) (@in Int, @in C, @thick C.Type) -> ())
+  // CHECK: keypath $KeyPath<S, Int>, (root $S; gettable_property $Int, id @id_a : $@convention(thin) () -> (), getter @get_s_int : $@convention(thin) (@in S) -> @out Int)
+  %a = keypath $KeyPath<S, Int>, (root $S; gettable_property $Int, id @id_a : $@convention(thin) () -> (), getter @get_s_int : $@convention(thin) (@in S) -> @out Int)
+  // CHECK: keypath $WritableKeyPath<S, Int>, (root $S; settable_property $Int, id @id_a : $@convention(thin) () -> (), getter @get_s_int : $@convention(thin) (@in S) -> @out Int, setter @set_s_int : $@convention(thin) (@in Int, @in S) -> ())
+  %b = keypath $WritableKeyPath<S, Int>, (root $S; settable_property $Int, id @id_a : $@convention(thin) () -> (), getter @get_s_int : $@convention(thin) (@in S) -> @out Int, setter @set_s_int : $@convention(thin) (@in Int, @in S) -> ())
+  // CHECK: keypath $WritableKeyPath<(S) -> S, (C) -> C>, (root $(S) -> S; settable_property $(C) -> C, id @id_a : $@convention(thin) () -> (), getter @get_fns_fnc : $@convention(thin) (@in @callee_owned (@in S) -> @out S) -> @out @callee_owned (@in C) -> @out C, setter @set_fns_fnc : $@convention(thin) (@in @callee_owned (@in C) -> @out C, @in @callee_owned (@in S) -> @out S) -> ())
+  %c = keypath $WritableKeyPath<(S) -> S, (C) -> C>, (root $(S) -> S; settable_property $(C) -> C, id @id_a : $@convention(thin) () -> (), getter @get_fns_fnc : $@convention(thin) (@in @callee_owned (@in S) -> @out S) -> @out @callee_owned (@in C) -> @out C, setter @set_fns_fnc : $@convention(thin) (@in @callee_owned (@in C) -> @out C, @in @callee_owned (@in S) -> @out S) -> ())
+  // CHECK: keypath $WritableKeyPath<C, Int>, (root $C; settable_property $Int, id #C.overridable!getter.1 : (C) -> () -> Int, getter @get_c_int : $@convention(thin) (@in C) -> @out Int, setter @set_c_int : $@convention(thin) (@in Int, @in C) -> ())
+  %d = keypath $WritableKeyPath<C, Int>, (root $C; settable_property $Int, id #C.overridable!getter.1 : (C) -> () -> Int, getter @get_c_int : $@convention(thin) (@in C) -> @out Int, setter @set_c_int : $@convention(thin) (@in Int, @in C) -> ())
 
   return undef : $()
 }

--- a/test/SILGen/keypath_application.swift
+++ b/test/SILGen/keypath_application.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-experimental-keypaths -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -enable-experimental-keypath-components -emit-silgen %s | %FileCheck %s
 
 class A {}
 class B {}

--- a/test/SILGen/keypaths.swift
+++ b/test/SILGen/keypaths.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-experimental-keypaths -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -enable-experimental-keypath-components -emit-silgen %s | %FileCheck %s
 
 struct S<T> {
   var x: T

--- a/test/SILGen/keypaths.swift
+++ b/test/SILGen/keypaths.swift
@@ -27,6 +27,12 @@ protocol P {
   var y: String { get set }
 }
 
+extension P {
+  var z: String {
+    return y
+  }
+}
+
 // CHECK-LABEL: sil hidden @{{.*}}storedProperties
 func storedProperties<T>(_: T) {
   // CHECK: keypath $WritableKeyPath<S<T>, T>, <τ_0_0> (root $S<τ_0_0>; stored_property #S.x : $τ_0_0) <T>
@@ -133,4 +139,10 @@ func computedProperties<T: P>(_: T) {
   // CHECK-SAME:   setter @_T08keypaths1PP1ySSvTk : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in String, @inout τ_0_0) -> ()
   // CHECK-SAME: ) <T>
   _ = \T.y
+
+  // CHECK: keypath $KeyPath<T, String>, <τ_0_0 where τ_0_0 : P> (
+  // CHECK-SAME: root $τ_0_0;
+  // CHECK-SAME: gettable_property $String,
+  // CHECK-SAME:   id @
+  _ = \T.z
 }

--- a/test/SILGen/keypaths.swift
+++ b/test/SILGen/keypaths.swift
@@ -57,8 +57,8 @@ func computedProperties<T: P>(_: T) {
   // CHECK-SAME: root $C<τ_0_0>;
   // CHECK-SAME: settable_property $S<τ_0_0>, 
   // CHECK-SAME:   id #C.nonfinal!getter.1 : <T> (C<T>) -> () -> S<T>,
-  // CHECK-SAME:   getter @_T08keypaths1CC8nonfinalAA1SVyxGvTK : $@convention(thin) <τ_0_0> (@in C<τ_0_0>, @thick C<τ_0_0>.Type) -> @out S<τ_0_0>,
-  // CHECK-SAME:   setter @_T08keypaths1CC8nonfinalAA1SVyxGvTk : $@convention(thin) <τ_0_0> (@in S<τ_0_0>, @in C<τ_0_0>, @thick C<τ_0_0>.Type) -> ()
+  // CHECK-SAME:   getter @_T08keypaths1CC8nonfinalAA1SVyxGvAA1PRzlACyxGTK : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in C<τ_0_0>) -> @out S<τ_0_0>,
+  // CHECK-SAME:   setter @_T08keypaths1CC8nonfinalAA1SVyxGvAA1PRzlACyxGTk : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in S<τ_0_0>, @in C<τ_0_0>) -> ()
   // CHECK-SAME: ) <T>
   _ = \C<T>.nonfinal
 
@@ -66,7 +66,7 @@ func computedProperties<T: P>(_: T) {
   // CHECK-SAME: root $C<τ_0_0>;
   // CHECK-SAME: gettable_property $S<τ_0_0>,
   // CHECK-SAME:   id #C.computed!getter.1 : <T> (C<T>) -> () -> S<T>,
-  // CHECK-SAME:   getter @_T08keypaths1CC8computedAA1SVyxGvTK : $@convention(thin) <τ_0_0> (@in C<τ_0_0>, @thick C<τ_0_0>.Type) -> @out S<τ_0_0>
+  // CHECK-SAME:   getter @_T08keypaths1CC8computedAA1SVyxGvAA1PRzlACyxGTK : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in C<τ_0_0>) -> @out S<τ_0_0>
   // CHECK-SAME: ) <T>
   _ = \C<T>.computed
 
@@ -74,8 +74,8 @@ func computedProperties<T: P>(_: T) {
   // CHECK-SAME: root $C<τ_0_0>;
   // CHECK-SAME: settable_property $S<τ_0_0>, 
   // CHECK-SAME:   id #C.observed!getter.1 : <T> (C<T>) -> () -> S<T>,
-  // CHECK-SAME:   getter @_T08keypaths1CC8observedAA1SVyxGvTK : $@convention(thin) <τ_0_0> (@in C<τ_0_0>, @thick C<τ_0_0>.Type) -> @out S<τ_0_0>,
-  // CHECK-SAME:   setter @_T08keypaths1CC8observedAA1SVyxGvTk : $@convention(thin) <τ_0_0> (@in S<τ_0_0>, @in C<τ_0_0>, @thick C<τ_0_0>.Type) -> ()
+  // CHECK-SAME:   getter @_T08keypaths1CC8observedAA1SVyxGvAA1PRzlACyxGTK : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in C<τ_0_0>) -> @out S<τ_0_0>,
+  // CHECK-SAME:   setter @_T08keypaths1CC8observedAA1SVyxGvAA1PRzlACyxGTk : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in S<τ_0_0>, @in C<τ_0_0>) -> ()
   // CHECK-SAME: ) <T>
   _ = \C<T>.observed
 
@@ -90,15 +90,15 @@ func computedProperties<T: P>(_: T) {
   // CHECK-SAME: root $C<τ_0_0>;
   // CHECK-SAME: settable_property $() -> (), 
   // CHECK-SAME:   id ##C.reabstracted,
-  // CHECK-SAME:   getter @_T08keypaths1CC12reabstractedyycvTK : $@convention(thin) <τ_0_0> (@in C<τ_0_0>, @thick C<τ_0_0>.Type) -> @out @callee_owned (@in ()) -> @out (),
-  // CHECK-SAME:   setter @_T08keypaths1CC12reabstractedyycvTk : $@convention(thin) <τ_0_0> (@in @callee_owned (@in ()) -> @out (), @in C<τ_0_0>, @thick C<τ_0_0>.Type) -> ()
+  // CHECK-SAME:   getter @_T08keypaths1CC12reabstractedyycvAA1PRzlACyxGTK : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in C<τ_0_0>) -> @out @callee_owned (@in ()) -> @out (),
+  // CHECK-SAME:   setter @_T08keypaths1CC12reabstractedyycvAA1PRzlACyxGTk : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in @callee_owned (@in ()) -> @out (), @in C<τ_0_0>) -> ()
   // CHECK-SAME: ) <T>
   _ = \C<T>.reabstracted
 
   // CHECK: keypath $KeyPath<S<T>, C<T>>, <τ_0_0 where τ_0_0 : P> (
   // CHECK-SAME: root $S<τ_0_0>; gettable_property $C<τ_0_0>,
   // CHECK-SAME: id @_T08keypaths1SV8computedAA1CCyxGfg : $@convention(method) <τ_0_0> (@in_guaranteed S<τ_0_0>) -> @owned C<τ_0_0>,
-  // CHECK-SAME:   getter @_T08keypaths1SV8computedAA1CCyxGvTK : $@convention(thin) <τ_0_0> (@in S<τ_0_0>, @thick S<τ_0_0>.Type) -> @out C<τ_0_0>
+  // CHECK-SAME:   getter @_T08keypaths1SV8computedAA1CCyxGvAA1PRzlACyxGTK : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in S<τ_0_0>) -> @out C<τ_0_0>
   // CHECK-SAME: ) <T>
   _ = \S<T>.computed
 
@@ -106,8 +106,8 @@ func computedProperties<T: P>(_: T) {
   // CHECK-SAME: root $S<τ_0_0>;
   // CHECK-SAME: settable_property $C<τ_0_0>,
   // CHECK-SAME:   id @_T08keypaths1SV8observedAA1CCyxGfg : $@convention(method) <τ_0_0> (@in_guaranteed S<τ_0_0>) -> @owned C<τ_0_0>,
-  // CHECK-SAME:   getter @_T08keypaths1SV8observedAA1CCyxGvTK : $@convention(thin) <τ_0_0> (@in S<τ_0_0>, @thick S<τ_0_0>.Type) -> @out C<τ_0_0>,
-  // CHECK-SAME:   setter @_T08keypaths1SV8observedAA1CCyxGvTk : $@convention(thin) <τ_0_0> (@in C<τ_0_0>, @inout S<τ_0_0>, @thick S<τ_0_0>.Type) -> ()
+  // CHECK-SAME:   getter @_T08keypaths1SV8observedAA1CCyxGvAA1PRzlACyxGTK : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in S<τ_0_0>) -> @out C<τ_0_0>,
+  // CHECK-SAME:   setter @_T08keypaths1SV8observedAA1CCyxGvAA1PRzlACyxGTk : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in C<τ_0_0>, @inout S<τ_0_0>) -> ()
   // CHECK-SAME: ) <T>
   _ = \S<T>.observed
   _ = \S<T>.z.nonfinal
@@ -119,8 +119,8 @@ func computedProperties<T: P>(_: T) {
   // CHECK-SAME:  root $S<τ_0_0>;
   // CHECK-SAME:  settable_property $() -> (),
   // CHECK-SAME:    id ##S.reabstracted,
-  // CHECK-SAME:    getter @_T08keypaths1SV12reabstractedyycvTK : $@convention(thin) <τ_0_0> (@in S<τ_0_0>, @thick S<τ_0_0>.Type) -> @out @callee_owned (@in ()) -> @out (),
-  // CHECK-SAME:    setter @_T08keypaths1SV12reabstractedyycvTk : $@convention(thin) <τ_0_0> (@in @callee_owned (@in ()) -> @out (), @inout S<τ_0_0>, @thick S<τ_0_0>.Type) -> ()
+  // CHECK-SAME:    getter @_T08keypaths1SV12reabstractedyycvAA1PRzlACyxGTK : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in S<τ_0_0>) -> @out @callee_owned (@in ()) -> @out (),
+  // CHECK-SAME:    setter @_T08keypaths1SV12reabstractedyycvAA1PRzlACyxGTk : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in @callee_owned (@in ()) -> @out (), @inout S<τ_0_0>) -> ()
   // CHECK-SAME: ) <T>
   _ = \S<T>.reabstracted
 
@@ -128,21 +128,36 @@ func computedProperties<T: P>(_: T) {
   // CHECK-SAME: root $τ_0_0;
   // CHECK-SAME: gettable_property $Int, 
   // CHECK-SAME:   id #P.x!getter.1 : <Self where Self : P> (Self) -> () -> Int,
-  // CHECK-SAME:   getter @_T08keypaths1PP1xSivTK : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in τ_0_0) -> @out Int
+  // CHECK-SAME:   getter @_T08keypaths1PP1xSivAaBRzlxTK : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in τ_0_0) -> @out Int
   // CHECK-SAME: ) <T>
   _ = \T.x
   // CHECK: keypath $WritableKeyPath<T, String>, <τ_0_0 where τ_0_0 : P> (
   // CHECK-SAME: root $τ_0_0;
   // CHECK-SAME: settable_property $String,
   // CHECK-SAME:   id #P.y!getter.1 : <Self where Self : P> (Self) -> () -> String,
-  // CHECK-SAME:   getter @_T08keypaths1PP1ySSvTK : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in τ_0_0) -> @out String,
-  // CHECK-SAME:   setter @_T08keypaths1PP1ySSvTk : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in String, @inout τ_0_0) -> ()
+  // CHECK-SAME:   getter @_T08keypaths1PP1ySSvAaBRzlxTK : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in τ_0_0) -> @out String,
+  // CHECK-SAME:   setter @_T08keypaths1PP1ySSvAaBRzlxTk : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in String, @inout τ_0_0) -> ()
   // CHECK-SAME: ) <T>
   _ = \T.y
 
   // CHECK: keypath $KeyPath<T, String>, <τ_0_0 where τ_0_0 : P> (
   // CHECK-SAME: root $τ_0_0;
   // CHECK-SAME: gettable_property $String,
-  // CHECK-SAME:   id @
+  // CHECK-SAME:   id @_T08keypaths1PPAAE1zSSfg
   _ = \T.z
+}
+
+struct Concrete: P {
+  var x: Int
+  var y: String
+}
+
+// CHECK-LABEL: sil hidden @_T08keypaths35keyPathsWithSpecificGenericInstanceyyF
+func keyPathsWithSpecificGenericInstance() {
+  // CHECK: keypath $KeyPath<Concrete, String>, (
+  // CHECK-SAME: gettable_property $String,
+  // CHECK-SAME:   id @_T08keypaths1PPAAE1zSSfg
+  // CHECK-SAME:   getter @_T08keypaths1PPAAE1zSSvAA8ConcreteVTK : $@convention(thin) (@in Concrete) -> @out String
+  _ = \Concrete.z
+  _ = \S<Concrete>.computed
 }

--- a/test/SILGen/keypaths_objc.swift
+++ b/test/SILGen/keypaths_objc.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-experimental-keypaths -emit-silgen -import-objc-header %S/Inputs/keypaths_objc.h %s | %FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-experimental-keypath-components -emit-silgen -import-objc-header %S/Inputs/keypaths_objc.h %s | %FileCheck %s
 // REQUIRES: objc_interop
 
 import Foundation

--- a/test/expr/unary/keypath/keypath-unimplemented.swift
+++ b/test/expr/unary/keypath/keypath-unimplemented.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend -typecheck -verify %s
+
+struct A {
+  subscript(x: Int) -> Int { return x }
+  var c: C? = C()
+}
+
+class C {
+  var i = 0
+}
+
+func unsupportedComponents() {
+  _ = \A.c?.i // expected-error{{key path support for optional chaining components is not implemented}}
+  _ = \A.c!.i // expected-error{{key path support for optional force-unwrapping components is not implemented}}
+  _ = \A.[0] // expected-error{{key path support for subscript components is not implemented}}
+}

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -typecheck -parse-as-library -enable-experimental-keypaths  %s -verify
+// RUN: %target-swift-frontend -typecheck -parse-as-library -enable-experimental-keypath-components  %s -verify
 
 struct Sub {}
 struct OptSub {}

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -131,6 +131,28 @@ func testKeyPath(sub: Sub, optSub: OptSub, x: Int) {
   let _: ReferenceWritableKeyPath<Prop, B> = \.nonMutatingProperty
 }
 
+struct TupleStruct {
+  var unlabeled: (Int, String)
+  var labeled: (foo: Int, bar: String)
+}
+
+func tupleComponent() {
+  // TODO: Customized diagnostic
+  let _ = \(Int, String).0 // expected-error{{}}
+  let _ = \(Int, String).1 // expected-error{{}}
+  let _ = \TupleStruct.unlabeled.0 // expected-error{{}}
+  let _ = \TupleStruct.unlabeled.1 // expected-error{{}}
+
+  let _ = \(foo: Int, bar: String).0 // expected-error{{}}
+  let _ = \(foo: Int, bar: String).1 // expected-error{{}}
+  let _ = \(foo: Int, bar: String).foo // expected-error{{}}
+  let _ = \(foo: Int, bar: String).bar // expected-error{{}}
+  let _ = \TupleStruct.labeled.0 // expected-error{{}}
+  let _ = \TupleStruct.labeled.1 // expected-error{{}}
+  let _ = \TupleStruct.labeled.foo // expected-error{{}}
+  let _ = \TupleStruct.labeled.bar // expected-error{{}}
+}
+
 struct Z { }
 
 func testKeyPathSubscript(readonly: Z, writable: inout Z,

--- a/test/stdlib/KeyPath.swift
+++ b/test/stdlib/KeyPath.swift
@@ -192,7 +192,9 @@ keyPath.test("key path generic instantiation") {
   expectEqual(s_c_x_lt, s_c_x_lt2)
 }
 
-struct TestComputed {
+protocol P {}
+
+struct TestComputed: P {
   static var numNonmutatingSets = 0
   static var numMutatingSets = 0
 
@@ -222,6 +224,14 @@ struct TestComputed {
   }
 }
 
+extension P {
+  var readonlyProtoExt: Self { return self }
+  var mutatingProtoExt: Self {
+    get { return self }
+    set { self = newValue }
+  }
+}
+
 keyPath.test("computed properties") {
   var test = TestComputed()
 
@@ -244,13 +254,26 @@ keyPath.test("computed properties") {
 
   do {
     let tc_mutating = \TestComputed.mutating
-    TestComputed.resetCounts()
     expectTrue(test[keyPath: tc_mutating] !== test[keyPath: tc_mutating])
     expectEqual(test[keyPath: tc_mutating].value,
                 test[keyPath: tc_mutating].value)
     let newObject = LifetimeTracked(5)
     test[keyPath: tc_mutating] = newObject
     expectTrue(test.canary === newObject)
+  }
+
+  do {
+    let tc_readonlyProtoExt = \TestComputed.readonlyProtoExt
+    expectTrue(test.canary === test[keyPath: tc_readonlyProtoExt].canary)
+  }
+
+  do {
+    let tc_mutatingProtoExt = \TestComputed.mutatingProtoExt
+    expectTrue(test.canary === test[keyPath: tc_mutatingProtoExt].canary)
+    let oldTest = test
+    test[keyPath: tc_mutatingProtoExt] = TestComputed()
+    expectTrue(oldTest.canary !== test.canary)
+    expectTrue(test.canary === test[keyPath: tc_mutatingProtoExt].canary)
   }
 }
 

--- a/test/stdlib/KeyPath.swift
+++ b/test/stdlib/KeyPath.swift
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: %target-build-swift %s -Xfrontend -enable-experimental-keypaths -o %t/a.out
+// RUN: %target-build-swift %s -Xfrontend -enable-experimental-keypath-components -o %t/a.out
 // RUN: %target-run %t/a.out
 // REQUIRES: executable_test
 

--- a/test/stdlib/KeyPathImplementation.swift
+++ b/test/stdlib/KeyPathImplementation.swift
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: %target-build-swift %s -g -Xfrontend -enable-experimental-keypaths -o %t/a.out
+// RUN: %target-build-swift %s -g -Xfrontend -enable-experimental-keypath-components -o %t/a.out
 // RUN: %target-run %t/a.out
 // REQUIRES: executable_test
 

--- a/test/stdlib/KeyPathObjC.swift
+++ b/test/stdlib/KeyPathObjC.swift
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: %target-build-swift %s -Xfrontend -enable-experimental-keypaths -o %t/a.out
+// RUN: %target-build-swift %s -Xfrontend -enable-experimental-keypath-components -o %t/a.out
 // RUN: %target-run %t/a.out
 // REQUIRES: executable_test
 // REQUIRES: objc_interop


### PR DESCRIPTION
- Don't crash when a key path component resolves to a non-decl reference, such as a tuple or nested key path reference. Fixes SR-4888 | rdar://problem/32200643.
- Fix the handling of computed property references in key paths when a generic computed property is referenced with bound generic arguments, and fix the classification of protocol extension properties as "polymorphic" even though they're not polymorphically dispatched. Fixes rdar://problem/32201589.
- Diagnose unimplemented key path features early during Sema, to avoid the somewhat more brittle bailouts later in the pipeline. rdar://problem/32200714