### PR TITLE
[4.0] Sema: Don't crash when a tuple element is referenced in a key path.

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3841,6 +3841,11 @@ ConstraintSystem::simplifyKeyPathConstraint(Type keyPathTy,
         return SolutionKind::Unsolved;
       }
       
+      // Discarded unsupported non-decl member lookups.
+      if (!choices[i].isDecl()) {
+        return SolutionKind::Error;
+      }
+      
       auto storage = cast<AbstractStorageDecl>(choices[i].getDecl());
       if (!storage->isSettable(DC)) {
         // A non-settable component makes the key path read-only, unless

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -131,6 +131,28 @@ func testKeyPath(sub: Sub, optSub: OptSub, x: Int) {
   let _: ReferenceWritableKeyPath<Prop, B> = \.nonMutatingProperty
 }
 
+struct TupleStruct {
+  var unlabeled: (Int, String)
+  var labeled: (foo: Int, bar: String)
+}
+
+func tupleComponent() {
+  // TODO: Customized diagnostic
+  let _ = \(Int, String).0 // expected-error{{}}
+  let _ = \(Int, String).1 // expected-error{{}}
+  let _ = \TupleStruct.unlabeled.0 // expected-error{{}}
+  let _ = \TupleStruct.unlabeled.1 // expected-error{{}}
+
+  let _ = \(foo: Int, bar: String).0 // expected-error{{}}
+  let _ = \(foo: Int, bar: String).1 // expected-error{{}}
+  let _ = \(foo: Int, bar: String).foo // expected-error{{}}
+  let _ = \(foo: Int, bar: String).bar // expected-error{{}}
+  let _ = \TupleStruct.labeled.0 // expected-error{{}}
+  let _ = \TupleStruct.labeled.1 // expected-error{{}}
+  let _ = \TupleStruct.labeled.foo // expected-error{{}}
+  let _ = \TupleStruct.labeled.bar // expected-error{{}}
+}
+
 struct Z { }
 
 func testKeyPathSubscript(readonly: Z, writable: inout Z,


### PR DESCRIPTION
Explanation: Key path components referencing a tuple element, another key path dereference, or some other non-decl-reference would cause a compiler crash.

Scope: Reliable compiler crash when key paths try to reference tuple elements.

Issue: SR-4888, rdar://problem/32200643

Risk: Low

Testing: Swift CI, test case from Jira
