### PR TITLE
[4.0] Fix references to protocol extension properties and instantiated generic properties in keypaths.

### DIFF
--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -114,8 +114,12 @@ public:
                                              Type FromType, Type ToType,
                                              ModuleDecl *Module);
   
-  std::string mangleKeyPathGetterThunkHelper(const VarDecl *property);
-  std::string mangleKeyPathSetterThunkHelper(const VarDecl *property);
+  std::string mangleKeyPathGetterThunkHelper(const VarDecl *property,
+                                             GenericSignature *signature,
+                                             CanType baseType);
+  std::string mangleKeyPathSetterThunkHelper(const VarDecl *property,
+                                             GenericSignature *signature,
+                                             CanType baseType);
 
   std::string mangleTypeForDebugger(Type decl, const DeclContext *DC,
                                     GenericEnvironment *GE);

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -226,16 +226,26 @@ std::string ASTMangler::mangleGlobalVariableFull(const VarDecl *decl) {
   return finalize();
 }
 
-std::string ASTMangler::mangleKeyPathGetterThunkHelper(const VarDecl *property) {
+std::string ASTMangler::mangleKeyPathGetterThunkHelper(const VarDecl *property,
+                                                   GenericSignature *signature,
+                                                   CanType baseType) {
   beginMangling();
   appendEntity(property);
+  if (signature)
+    appendGenericSignature(signature);
+  appendType(baseType);
   appendOperator("TK");
   return finalize();
 }
 
-std::string ASTMangler::mangleKeyPathSetterThunkHelper(const VarDecl *property) {
+std::string ASTMangler::mangleKeyPathSetterThunkHelper(const VarDecl *property,
+                                                   GenericSignature *signature,
+                                                   CanType baseType) {
   beginMangling();
   appendEntity(property);
+  if (signature)
+    appendGenericSignature(signature);
+  appendType(baseType);
   appendOperator("Tk");
   return finalize();
 }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1137,7 +1137,7 @@ static bool isPolymorphic(const AbstractStorageDecl *storage) {
     return false;
 
   case DeclKind::Protocol:
-    return true;
+    return !storage->getDeclContext()->isExtensionContext();
 
   case DeclKind::Class:
     // Final properties can always be direct, even in classes.

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -1267,8 +1267,14 @@ NodePointer Demangler::demangleThunkOrSpecialization() {
     case 'k': {
       auto nodeKind = c == 'K' ? Node::Kind::KeyPathGetterThunkHelper
                                : Node::Kind::KeyPathSetterThunkHelper;
-      auto decl = popNode();
-      return createWithChild(nodeKind, decl);
+      auto type = popNode();
+      auto sigOrDecl = popNode();
+      if (sigOrDecl->getKind() == Node::Kind::DependentGenericSignature) {
+        auto decl = popNode();
+        return createWithChildren(nodeKind, decl, sigOrDecl, type);
+      } else {
+        return createWithChildren(nodeKind, sigOrDecl, type);
+      }
     }
     default:
       return nullptr;

--- a/lib/Demangling/NodePrinter.cpp
+++ b/lib/Demangling/NodePrinter.cpp
@@ -1190,10 +1190,24 @@ NodePointer NodePrinter::print(NodePointer Node, bool asPrefixContext) {
   case Node::Kind::KeyPathGetterThunkHelper:
     Printer << "key path getter for ";
     print(Node->getChild(0));
+    Printer << " : ";
+    if (Node->getNumChildren() == 2) {
+      print(Node->getChild(1));
+    } else {
+      print(Node->getChild(1));
+      print(Node->getChild(2));
+    }
     return nullptr;
   case Node::Kind::KeyPathSetterThunkHelper:
     Printer << "key path setter for ";
     print(Node->getChild(0));
+    Printer << " : ";
+    if (Node->getNumChildren() == 2) {
+      print(Node->getChild(1));
+    } else {
+      print(Node->getChild(1));
+      print(Node->getChild(2));
+    }
     return nullptr;
   case Node::Kind::FieldOffset: {
     print(Node->getChild(0)); // directness

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -3779,8 +3779,69 @@ public:
         case KeyPathPatternComponent::Kind::SettableProperty: {
           require(component.getComputedPropertyIndices().empty(),
                   "subscripts not implemented");
+        
+          // Getter should be <Sig...> @convention(thin) (@in Base) -> @out Result
+          {
+            auto getter = component.getComputedPropertyGetter();
+            auto substGetterType = getter->getLoweredFunctionType()
+              ->substGenericArgs(F.getModule(), KPI->getSubstitutions());
+            require(substGetterType->getRepresentation() ==
+                      SILFunctionTypeRepresentation::Thin,
+                    "getter should be a thin function");
+            
+              // TODO: indexes
+            require(substGetterType->getNumParameters() == 1,
+                    "getter should have one parameter");
+            auto baseParam = substGetterType->getSelfParameter();
+            require(baseParam.getConvention() == ParameterConvention::Indirect_In,
+                    "getter base parameter should be @in");
+            require(baseParam.getType() == loweredBaseTy.getSwiftRValueType(),
+                    "getter base parameter should match base of component");
+            require(substGetterType->getNumResults() == 1,
+                    "getter should have one result");
+            auto result = substGetterType->getResults()[0];
+            require(result.getConvention() == ResultConvention::Indirect,
+                    "getter result should be @out");
+            require(result.getType() == loweredComponentTy.getSwiftRValueType(),
+                    "getter result should match the maximal abstraction of the "
+                    "formal component type");
+          }
+          
+          if (kind == KeyPathPatternComponent::Kind::SettableProperty) {
+            // Setter should be
+            // <Sig...> @convention(thin) (@in Result, @in Base) -> ()
+            
+            auto setter = component.getComputedPropertySetter();
+            auto substSetterType = setter->getLoweredFunctionType()
+              ->substGenericArgs(F.getModule(), KPI->getSubstitutions());
+            
+            require(substSetterType->getRepresentation() ==
+                      SILFunctionTypeRepresentation::Thin,
+                    "getter should be a thin function");
+            
+            // TODO: indexes
+            require(substSetterType->getNumParameters() == 2,
+                    "setter should have two parameters");
+            auto baseParam = substSetterType->getSelfParameter();
+            require(baseParam.getConvention() ==
+                      ParameterConvention::Indirect_In
+                    || baseParam.getConvention() ==
+                        ParameterConvention::Indirect_Inout,
+                    "setter base parameter should be @in or @inout");
+            auto newValueParam = substSetterType->getParameters()[0];
+            require(newValueParam.getConvention() ==
+                      ParameterConvention::Indirect_In,
+                    "setter value parameter should be @in");
+            
+            require(newValueParam.getType() ==
+                      loweredComponentTy.getSwiftRValueType(),
+                    "setter value should match the maximal abstraction of the "
+                    "formal component type");
+            
+            require(substSetterType->getNumResults() == 0,
+                    "setter should have no results");
+          }
 
-          // TODO: Verify the signatures of the getter and setter
           break;
         }
         }

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2427,26 +2427,15 @@ RValue RValueEmitter::visitObjCSelectorExpr(ObjCSelectorExpr *e, SGFContext C) {
 static SILFunction *getOrCreateKeyPathGetter(SILGenFunction &SGF,
                                              SILLocation loc,
                                              VarDecl *property,
-                                             AccessStrategy strategy) {
-  // Build the signature of the thunk as expected by the keypath runtime.
-  // For concrete type properties, this is:
-  //   (@in Root, @thick Root.Type) -> @out Value
-  // with Root and Value maximally abstracted. For protocol properties, this is:
-  //   <Root: P> (@in Root) -> @out Value
-  // At the ABI level, this should lower to a signature looking like
-  //   void (sret void *outValue, void *inRoot, type *rootType, wtable *rootP)
-  // which can be abstractly invoked by the runtime.
-  auto typeContext = property->getDeclContext();
-  auto baseType = typeContext->getSelfInterfaceType()
-    ->getCanonicalType();
-  auto propertyType = baseType->getTypeOfMember(SGF.SGM.M.getSwiftModule(),
-                                                property)
-    ->getCanonicalType();
-  auto genericEnv = typeContext->getGenericEnvironmentOfContext();
-  auto genericSig = typeContext->getGenericSignatureOfContext()
-    ? typeContext->getGenericSignatureOfContext()->getCanonicalSignature()
+                                             AccessStrategy strategy,
+                                             GenericEnvironment *genericEnv,
+                                             CanType baseType,
+                                             CanType propertyType) {
+  auto genericSig = genericEnv
+    ? genericEnv->getGenericSignature()->getCanonicalSignature()
     : nullptr;
-  
+
+  // Build the signature of the thunk as expected by the keypath runtime.
   SILType loweredBaseTy, loweredPropTy;
   {
     GenericContextScope scope(SGF.SGM.Types, genericSig);
@@ -2456,16 +2445,8 @@ static SILFunction *getOrCreateKeyPathGetter(SILGenFunction &SGF,
                                        propertyType);
   }
   
-  SmallVector<SILParameterInfo, 2> params;
-  params.emplace_back(loweredBaseTy.getSwiftRValueType(),
-                      ParameterConvention::Indirect_In);
-  if (!typeContext->getAsProtocolOrProtocolExtensionContext()) {
-    // Add a thick metatype argument. This will act as a metadata source for the
-    // type's generic context, making the lowered calling convention uniform.
-    params.emplace_back(
-      CanMetatypeType::get(baseType, MetatypeRepresentation::Thick),
-      ParameterConvention::Direct_Unowned);
-  }
+  SILParameterInfo param(loweredBaseTy.getSwiftRValueType(),
+                         ParameterConvention::Indirect_In);
   SILResultInfo result(loweredPropTy.getSwiftRValueType(),
                        ResultConvention::Indirect);
   
@@ -2473,11 +2454,11 @@ static SILFunction *getOrCreateKeyPathGetter(SILGenFunction &SGF,
     SILFunctionType::ExtInfo(SILFunctionType::Representation::Thin,
                              /*pseudogeneric*/ false),
     ParameterConvention::Direct_Unowned,
-    params, result, None, SGF.getASTContext());
+    param, result, None, SGF.getASTContext());
   
   // Find the function and see if we already created it.
   auto name = Mangle::ASTMangler()
-    .mangleKeyPathGetterThunkHelper(property);
+    .mangleKeyPathGetterThunkHelper(property, genericSig, baseType);
   auto thunk = SGF.SGM.M.getOrCreateSharedFunction(loc, name,
                                                    signature,
                                                    IsBare,
@@ -2500,19 +2481,13 @@ static SILFunction *getOrCreateKeyPathGetter(SILGenFunction &SGF,
   SILGenFunction subSGF(SGM, *thunk);
   auto entry = thunk->begin();
   auto resultArgTy = result.getSILStorageType();
-  auto paramArgTy = params[0].getSILStorageType();
+  auto paramArgTy = param.getSILStorageType();
   if (genericEnv) {
     resultArgTy = genericEnv->mapTypeIntoContext(subSGF.SGM.M, resultArgTy);
     paramArgTy = genericEnv->mapTypeIntoContext(subSGF.SGM.M, paramArgTy);
   }
   auto resultArg = entry->createFunctionArgument(resultArgTy);
   auto paramArg = entry->createFunctionArgument(paramArgTy);
-  if (!typeContext->getAsProtocolOrProtocolExtensionContext()) {
-    auto metatypeArgTy = params[1].getSILStorageType();
-    if (genericEnv)
-      metatypeArgTy = genericEnv->mapTypeIntoContext(subSGF.SGM.M, metatypeArgTy);
-    entry->createFunctionArgument(metatypeArgTy);
-  }
   
   Scope scope(subSGF, loc);
   
@@ -2546,24 +2521,12 @@ static SILFunction *getOrCreateKeyPathGetter(SILGenFunction &SGF,
 SILFunction *getOrCreateKeyPathSetter(SILGenFunction &SGF,
                                       SILLocation loc,
                                       VarDecl *property,
-                                      AccessStrategy strategy) {
-  // Build the signature of the thunk as expected by the keypath runtime.
-  // For concrete type properties, this is:
-  //   (@in Value, @in Root, @thick Root.Type) -> ()
-  // with Root and Value maximally abstracted. For protocol properties, this is:
-  //   <Root: P> (@in Value, @in Root) -> ()
-  // At the ABI level, this should lower to a signature looking like
-  //   void (void *inValue, void *inRoot, type *rootType, wtable *rootP)
-  // which can be abstractly invoked by the runtime.
-  auto typeContext = property->getDeclContext();
-  auto baseType = typeContext->getSelfInterfaceType()
-    ->getCanonicalType();
-  auto propertyType = baseType->getTypeOfMember(SGF.SGM.M.getSwiftModule(),
-                                                property)
-    ->getCanonicalType();
-  auto genericEnv = typeContext->getGenericEnvironmentOfContext();
-  auto genericSig = typeContext->getGenericSignatureOfContext()
-    ? typeContext->getGenericSignatureOfContext()->getCanonicalSignature()
+                                      AccessStrategy strategy,
+                                      GenericEnvironment *genericEnv,
+                                      CanType baseType,
+                                      CanType propertyType) {
+  auto genericSig = genericEnv
+    ? genericEnv->getGenericSignature()->getCanonicalSignature()
     : nullptr;
 
   // Build the signature of the thunk as expected by the keypath runtime.
@@ -2576,35 +2539,27 @@ SILFunction *getOrCreateKeyPathSetter(SILGenFunction &SGF,
                                        propertyType);
   }
   
-  SmallVector<SILParameterInfo, 3> params;
-  // The newValue param
-  params.emplace_back(loweredPropTy.getSwiftRValueType(),
-                      ParameterConvention::Indirect_In);
-  // The base param
-  params.emplace_back(loweredBaseTy.getSwiftRValueType(),
-                      property->isSetterNonMutating()
-                        ? ParameterConvention::Indirect_In
-                        : ParameterConvention::Indirect_Inout);
+  SILParameterInfo propParam(loweredPropTy.getSwiftRValueType(),
+                             ParameterConvention::Indirect_In);
   
-  if (!typeContext->getAsProtocolOrProtocolExtensionContext()) {
-    // Add a thick metatype argument. This will act as a metadata source for the
-    // type's generic context, making the lowered calling convention uniform.
-    params.emplace_back(
-      CanMetatypeType::get(baseType, MetatypeRepresentation::Thick),
-      ParameterConvention::Direct_Unowned);
-  }
+  SILParameterInfo baseParam(loweredBaseTy.getSwiftRValueType(),
+                             property->isSetterNonMutating()
+                             ? ParameterConvention::Indirect_In
+                             : ParameterConvention::Indirect_Inout);
   
   auto signature = SILFunctionType::get(genericSig,
     SILFunctionType::ExtInfo(SILFunctionType::Representation::Thin,
                              /*pseudogeneric*/ false),
     ParameterConvention::Direct_Unowned,
-    params, {}, None, SGF.getASTContext());
+    {propParam, baseParam}, {}, None, SGF.getASTContext());
   
   // Mangle the name of the thunk to see if we already created it.
   SmallString<64> nameBuf;
   
   // Find the function and see if we already created it.
-  auto name = Mangle::ASTMangler().mangleKeyPathSetterThunkHelper(property);
+  auto name = Mangle::ASTMangler().mangleKeyPathSetterThunkHelper(property,
+                                                                  genericSig,
+                                                                  baseType);
   auto thunk = SGF.SGM.M.getOrCreateSharedFunction(loc, name,
                                                    signature,
                                                    IsBare,
@@ -2626,20 +2581,14 @@ SILFunction *getOrCreateKeyPathSetter(SILGenFunction &SGF,
   
   SILGenFunction subSGF(SGM, *thunk);
   auto entry = thunk->begin();
-  auto valueArgTy = params[0].getSILStorageType();
-  auto baseArgTy = params[1].getSILStorageType();
+  auto valueArgTy = propParam.getSILStorageType();
+  auto baseArgTy = baseParam.getSILStorageType();
   if (genericEnv) {
     valueArgTy = genericEnv->mapTypeIntoContext(subSGF.SGM.M, valueArgTy);
     baseArgTy = genericEnv->mapTypeIntoContext(subSGF.SGM.M, baseArgTy);
   }
   auto valueArg = entry->createFunctionArgument(valueArgTy);
   auto baseArg = entry->createFunctionArgument(baseArgTy);
-  if (!typeContext->getAsProtocolOrProtocolExtensionContext()) {
-    auto metatypeArgTy = params[2].getSILStorageType();
-    if (genericEnv)
-      metatypeArgTy = genericEnv->mapTypeIntoContext(subSGF.SGM.M, metatypeArgTy);
-    entry->createFunctionArgument(metatypeArgTy);
-  }
   
   Scope scope(subSGF, loc);
   
@@ -2748,6 +2697,7 @@ RValue RValueEmitter::visitKeyPathExpr(KeyPathExpr *E, SGFContext C) {
     switch (component.getKind()) {
     case KeyPathExpr::Component::Kind::Property: {
       auto decl = cast<VarDecl>(component.getDeclRef().getDecl());
+      auto oldBaseTy = baseTy;
       baseTy = baseTy->getTypeOfMember(SGF.SGM.SwiftModule, decl)
         ->getCanonicalType();
       
@@ -2778,11 +2728,15 @@ RValue RValueEmitter::visitKeyPathExpr(KeyPathExpr *E, SGFContext C) {
         auto id = getIdForKeyPathComponentComputedProperty(SGF, decl,
                                                            strategy);
         auto getter = getOrCreateKeyPathGetter(SGF, SILLocation(E),
-                 decl, strategy);
+                 decl, strategy,
+                 needsGenericContext ? SGF.F.getGenericEnvironment() : nullptr,
+                 oldBaseTy, baseTy);
         
         if (decl->isSettable(decl->getDeclContext())) {
           auto setter = getOrCreateKeyPathSetter(SGF, SILLocation(E),
-                 decl, strategy);
+                 decl, strategy,
+                 needsGenericContext ? SGF.F.getGenericEnvironment() : nullptr,
+                 oldBaseTy, baseTy);
           loweredComponents.push_back(
             KeyPathPatternComponent::forComputedSettableProperty(id,
                                                                  getter, setter,

--- a/test/SIL/Parser/keypath.sil
+++ b/test/SIL/Parser/keypath.sil
@@ -57,24 +57,24 @@ entry:
 }
 
 sil @id_a : $@convention(thin) () -> ()
-sil @get_s_int : $@convention(thin) (@in S, @thick S.Type) -> @out Int
-sil @set_s_int : $@convention(thin) (@in Int, @in S, @thick S.Type) -> ()
-sil @get_c_int : $@convention(thin) (@in C, @thick C.Type) -> @out Int
-sil @set_c_int : $@convention(thin) (@in Int, @in C, @thick C.Type) -> ()
-sil @get_fns_fnc : $@convention(thin) (@in @callee_owned (@in S) -> @out S, @thick ((S) -> S).Type) -> @out @callee_owned (@in C) -> @out C
-sil @set_fns_fnc : $@convention(thin) (@in @callee_owned (@in C) -> @out C, @in @callee_owned (@in S) -> @out S, @thick ((S) -> S).Type) -> ()
+sil @get_s_int : $@convention(thin) (@in S) -> @out Int
+sil @set_s_int : $@convention(thin) (@in Int, @in S) -> ()
+sil @get_c_int : $@convention(thin) (@in C) -> @out Int
+sil @set_c_int : $@convention(thin) (@in Int, @in C) -> ()
+sil @get_fns_fnc : $@convention(thin) (@in @callee_owned (@in S) -> @out S) -> @out @callee_owned (@in C) -> @out C
+sil @set_fns_fnc : $@convention(thin) (@in @callee_owned (@in C) -> @out C, @in @callee_owned (@in S) -> @out S) -> ()
 
 // CHECK-LABEL: sil shared @computed_properties
 sil shared @computed_properties : $@convention(thin) () -> () {
 entry:
-  // CHECK: keypath $KeyPath<S, Int>, (root $S; gettable_property $Int, id @id_a : $@convention(thin) () -> (), getter @get_s_int : $@convention(thin) (@in S, @thick S.Type) -> @out Int)
-  %a = keypath $KeyPath<S, Int>, (root $S; gettable_property $Int, id @id_a : $@convention(thin) () -> (), getter @get_s_int : $@convention(thin) (@in S, @thick S.Type) -> @out Int)
-  // CHECK: keypath $WritableKeyPath<S, Int>, (root $S; settable_property $Int, id @id_a : $@convention(thin) () -> (), getter @get_s_int : $@convention(thin) (@in S, @thick S.Type) -> @out Int, setter @set_s_int : $@convention(thin) (@in Int, @in S, @thick S.Type) -> ())
-  %b = keypath $WritableKeyPath<S, Int>, (root $S; settable_property $Int, id @id_a : $@convention(thin) () -> (), getter @get_s_int : $@convention(thin) (@in S, @thick S.Type) -> @out Int, setter @set_s_int : $@convention(thin) (@in Int, @in S, @thick S.Type) -> ())
-  // CHECK: keypath $WritableKeyPath<(S) -> S, (C) -> C>, (root $(S) -> S; settable_property $(C) -> C, id @id_a : $@convention(thin) () -> (), getter @get_fns_fnc : $@convention(thin) (@in @callee_owned (@in S) -> @out S, @thick ((S) -> S).Type) -> @out @callee_owned (@in C) -> @out C, setter @set_fns_fnc : $@convention(thin) (@in @callee_owned (@in C) -> @out C, @in @callee_owned (@in S) -> @out S, @thick ((S) -> S).Type) -> ())
-  %c = keypath $WritableKeyPath<(S) -> S, (C) -> C>, (root $(S) -> S; settable_property $(C) -> C, id @id_a : $@convention(thin) () -> (), getter @get_fns_fnc : $@convention(thin) (@in @callee_owned (@in S) -> @out S, @thick ((S) -> S).Type) -> @out @callee_owned (@in C) -> @out C, setter @set_fns_fnc : $@convention(thin) (@in @callee_owned (@in C) -> @out C, @in @callee_owned (@in S) -> @out S, @thick ((S) -> S).Type) -> ())
-  // CHECK: keypath $WritableKeyPath<C, Int>, (root $C; settable_property $Int, id #C.overridable!getter.1 : (C) -> () -> Int, getter @get_c_int : $@convention(thin) (@in C, @thick C.Type) -> @out Int, setter @set_c_int : $@convention(thin) (@in Int, @in C, @thick C.Type) -> ())
-  %d = keypath $WritableKeyPath<C, Int>, (root $C; settable_property $Int, id #C.overridable!getter.1 : (C) -> () -> Int, getter @get_c_int : $@convention(thin) (@in C, @thick C.Type) -> @out Int, setter @set_c_int : $@convention(thin) (@in Int, @in C, @thick C.Type) -> ())
+  // CHECK: keypath $KeyPath<S, Int>, (root $S; gettable_property $Int, id @id_a : $@convention(thin) () -> (), getter @get_s_int : $@convention(thin) (@in S) -> @out Int)
+  %a = keypath $KeyPath<S, Int>, (root $S; gettable_property $Int, id @id_a : $@convention(thin) () -> (), getter @get_s_int : $@convention(thin) (@in S) -> @out Int)
+  // CHECK: keypath $WritableKeyPath<S, Int>, (root $S; settable_property $Int, id @id_a : $@convention(thin) () -> (), getter @get_s_int : $@convention(thin) (@in S) -> @out Int, setter @set_s_int : $@convention(thin) (@in Int, @in S) -> ())
+  %b = keypath $WritableKeyPath<S, Int>, (root $S; settable_property $Int, id @id_a : $@convention(thin) () -> (), getter @get_s_int : $@convention(thin) (@in S) -> @out Int, setter @set_s_int : $@convention(thin) (@in Int, @in S) -> ())
+  // CHECK: keypath $WritableKeyPath<(S) -> S, (C) -> C>, (root $(S) -> S; settable_property $(C) -> C, id @id_a : $@convention(thin) () -> (), getter @get_fns_fnc : $@convention(thin) (@in @callee_owned (@in S) -> @out S) -> @out @callee_owned (@in C) -> @out C, setter @set_fns_fnc : $@convention(thin) (@in @callee_owned (@in C) -> @out C, @in @callee_owned (@in S) -> @out S) -> ())
+  %c = keypath $WritableKeyPath<(S) -> S, (C) -> C>, (root $(S) -> S; settable_property $(C) -> C, id @id_a : $@convention(thin) () -> (), getter @get_fns_fnc : $@convention(thin) (@in @callee_owned (@in S) -> @out S) -> @out @callee_owned (@in C) -> @out C, setter @set_fns_fnc : $@convention(thin) (@in @callee_owned (@in C) -> @out C, @in @callee_owned (@in S) -> @out S) -> ())
+  // CHECK: keypath $WritableKeyPath<C, Int>, (root $C; settable_property $Int, id #C.overridable!getter.1 : (C) -> () -> Int, getter @get_c_int : $@convention(thin) (@in C) -> @out Int, setter @set_c_int : $@convention(thin) (@in Int, @in C) -> ())
+  %d = keypath $WritableKeyPath<C, Int>, (root $C; settable_property $Int, id #C.overridable!getter.1 : (C) -> () -> Int, getter @get_c_int : $@convention(thin) (@in C) -> @out Int, setter @set_c_int : $@convention(thin) (@in Int, @in C) -> ())
 
   return undef : $()
 }

--- a/test/SIL/Serialization/keypath.sil
+++ b/test/SIL/Serialization/keypath.sil
@@ -62,24 +62,24 @@ entry:
 }
 
 sil @id_a : $@convention(thin) () -> ()
-sil @get_s_int : $@convention(thin) (@in S, @thick S.Type) -> @out Int
-sil @set_s_int : $@convention(thin) (@in Int, @in S, @thick S.Type) -> ()
-sil @get_c_int : $@convention(thin) (@in C, @thick C.Type) -> @out Int
-sil @set_c_int : $@convention(thin) (@in Int, @in C, @thick C.Type) -> ()
-sil @get_fns_fnc : $@convention(thin) (@in @callee_owned (@in S) -> @out S, @thick ((S) -> S).Type) -> @out @callee_owned (@in C) -> @out C
-sil @set_fns_fnc : $@convention(thin) (@in @callee_owned (@in C) -> @out C, @in @callee_owned (@in S) -> @out S, @thick ((S) -> S).Type) -> ()
+sil @get_s_int : $@convention(thin) (@in S) -> @out Int
+sil @set_s_int : $@convention(thin) (@in Int, @in S) -> ()
+sil @get_c_int : $@convention(thin) (@in C) -> @out Int
+sil @set_c_int : $@convention(thin) (@in Int, @in C) -> ()
+sil @get_fns_fnc : $@convention(thin) (@in @callee_owned (@in S) -> @out S) -> @out @callee_owned (@in C) -> @out C
+sil @set_fns_fnc : $@convention(thin) (@in @callee_owned (@in C) -> @out C, @in @callee_owned (@in S) -> @out S) -> ()
 
 // CHECK-LABEL: sil shared @computed_properties
 sil shared @computed_properties : $@convention(thin) () -> () {
 entry:
-  // CHECK: keypath $KeyPath<S, Int>, (root $S; gettable_property $Int, id @id_a : $@convention(thin) () -> (), getter @get_s_int : $@convention(thin) (@in S, @thick S.Type) -> @out Int)
-  %a = keypath $KeyPath<S, Int>, (root $S; gettable_property $Int, id @id_a : $@convention(thin) () -> (), getter @get_s_int : $@convention(thin) (@in S, @thick S.Type) -> @out Int)
-  // CHECK: keypath $WritableKeyPath<S, Int>, (root $S; settable_property $Int, id @id_a : $@convention(thin) () -> (), getter @get_s_int : $@convention(thin) (@in S, @thick S.Type) -> @out Int, setter @set_s_int : $@convention(thin) (@in Int, @in S, @thick S.Type) -> ())
-  %b = keypath $WritableKeyPath<S, Int>, (root $S; settable_property $Int, id @id_a : $@convention(thin) () -> (), getter @get_s_int : $@convention(thin) (@in S, @thick S.Type) -> @out Int, setter @set_s_int : $@convention(thin) (@in Int, @in S, @thick S.Type) -> ())
-  // CHECK: keypath $WritableKeyPath<(S) -> S, (C) -> C>, (root $(S) -> S; settable_property $(C) -> C, id @id_a : $@convention(thin) () -> (), getter @get_fns_fnc : $@convention(thin) (@in @callee_owned (@in S) -> @out S, @thick ((S) -> S).Type) -> @out @callee_owned (@in C) -> @out C, setter @set_fns_fnc : $@convention(thin) (@in @callee_owned (@in C) -> @out C, @in @callee_owned (@in S) -> @out S, @thick ((S) -> S).Type) -> ())
-  %c = keypath $WritableKeyPath<(S) -> S, (C) -> C>, (root $(S) -> S; settable_property $(C) -> C, id @id_a : $@convention(thin) () -> (), getter @get_fns_fnc : $@convention(thin) (@in @callee_owned (@in S) -> @out S, @thick ((S) -> S).Type) -> @out @callee_owned (@in C) -> @out C, setter @set_fns_fnc : $@convention(thin) (@in @callee_owned (@in C) -> @out C, @in @callee_owned (@in S) -> @out S, @thick ((S) -> S).Type) -> ())
-  // CHECK: keypath $WritableKeyPath<C, Int>, (root $C; settable_property $Int, id #C.overridable!getter.1 : (C) -> () -> Int, getter @get_c_int : $@convention(thin) (@in C, @thick C.Type) -> @out Int, setter @set_c_int : $@convention(thin) (@in Int, @in C, @thick C.Type) -> ())
-  %d = keypath $WritableKeyPath<C, Int>, (root $C; settable_property $Int, id #C.overridable!getter.1 : (C) -> () -> Int, getter @get_c_int : $@convention(thin) (@in C, @thick C.Type) -> @out Int, setter @set_c_int : $@convention(thin) (@in Int, @in C, @thick C.Type) -> ())
+  // CHECK: keypath $KeyPath<S, Int>, (root $S; gettable_property $Int, id @id_a : $@convention(thin) () -> (), getter @get_s_int : $@convention(thin) (@in S) -> @out Int)
+  %a = keypath $KeyPath<S, Int>, (root $S; gettable_property $Int, id @id_a : $@convention(thin) () -> (), getter @get_s_int : $@convention(thin) (@in S) -> @out Int)
+  // CHECK: keypath $WritableKeyPath<S, Int>, (root $S; settable_property $Int, id @id_a : $@convention(thin) () -> (), getter @get_s_int : $@convention(thin) (@in S) -> @out Int, setter @set_s_int : $@convention(thin) (@in Int, @in S) -> ())
+  %b = keypath $WritableKeyPath<S, Int>, (root $S; settable_property $Int, id @id_a : $@convention(thin) () -> (), getter @get_s_int : $@convention(thin) (@in S) -> @out Int, setter @set_s_int : $@convention(thin) (@in Int, @in S) -> ())
+  // CHECK: keypath $WritableKeyPath<(S) -> S, (C) -> C>, (root $(S) -> S; settable_property $(C) -> C, id @id_a : $@convention(thin) () -> (), getter @get_fns_fnc : $@convention(thin) (@in @callee_owned (@in S) -> @out S) -> @out @callee_owned (@in C) -> @out C, setter @set_fns_fnc : $@convention(thin) (@in @callee_owned (@in C) -> @out C, @in @callee_owned (@in S) -> @out S) -> ())
+  %c = keypath $WritableKeyPath<(S) -> S, (C) -> C>, (root $(S) -> S; settable_property $(C) -> C, id @id_a : $@convention(thin) () -> (), getter @get_fns_fnc : $@convention(thin) (@in @callee_owned (@in S) -> @out S) -> @out @callee_owned (@in C) -> @out C, setter @set_fns_fnc : $@convention(thin) (@in @callee_owned (@in C) -> @out C, @in @callee_owned (@in S) -> @out S) -> ())
+  // CHECK: keypath $WritableKeyPath<C, Int>, (root $C; settable_property $Int, id #C.overridable!getter.1 : (C) -> () -> Int, getter @get_c_int : $@convention(thin) (@in C) -> @out Int, setter @set_c_int : $@convention(thin) (@in Int, @in C) -> ())
+  %d = keypath $WritableKeyPath<C, Int>, (root $C; settable_property $Int, id #C.overridable!getter.1 : (C) -> () -> Int, getter @get_c_int : $@convention(thin) (@in C) -> @out Int, setter @set_c_int : $@convention(thin) (@in Int, @in C) -> ())
 
   return undef : $()
 }

--- a/test/SILGen/keypaths.swift
+++ b/test/SILGen/keypaths.swift
@@ -27,6 +27,12 @@ protocol P {
   var y: String { get set }
 }
 
+extension P {
+  var z: String {
+    return y
+  }
+}
+
 // CHECK-LABEL: sil hidden @{{.*}}storedProperties
 func storedProperties<T>(_: T) {
   // CHECK: keypath $WritableKeyPath<S<T>, T>, <τ_0_0> (root $S<τ_0_0>; stored_property #S.x : $τ_0_0) <T>
@@ -133,4 +139,10 @@ func computedProperties<T: P>(_: T) {
   // CHECK-SAME:   setter @_T08keypaths1PP1ySSvTk : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in String, @inout τ_0_0) -> ()
   // CHECK-SAME: ) <T>
   _ = \T.y
+
+  // CHECK: keypath $KeyPath<T, String>, <τ_0_0 where τ_0_0 : P> (
+  // CHECK-SAME: root $τ_0_0;
+  // CHECK-SAME: gettable_property $String,
+  // CHECK-SAME:   id @
+  _ = \T.z
 }

--- a/test/SILGen/keypaths.swift
+++ b/test/SILGen/keypaths.swift
@@ -57,8 +57,8 @@ func computedProperties<T: P>(_: T) {
   // CHECK-SAME: root $C<τ_0_0>;
   // CHECK-SAME: settable_property $S<τ_0_0>, 
   // CHECK-SAME:   id #C.nonfinal!getter.1 : <T> (C<T>) -> () -> S<T>,
-  // CHECK-SAME:   getter @_T08keypaths1CC8nonfinalAA1SVyxGvTK : $@convention(thin) <τ_0_0> (@in C<τ_0_0>, @thick C<τ_0_0>.Type) -> @out S<τ_0_0>,
-  // CHECK-SAME:   setter @_T08keypaths1CC8nonfinalAA1SVyxGvTk : $@convention(thin) <τ_0_0> (@in S<τ_0_0>, @in C<τ_0_0>, @thick C<τ_0_0>.Type) -> ()
+  // CHECK-SAME:   getter @_T08keypaths1CC8nonfinalAA1SVyxGvAA1PRzlACyxGTK : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in C<τ_0_0>) -> @out S<τ_0_0>,
+  // CHECK-SAME:   setter @_T08keypaths1CC8nonfinalAA1SVyxGvAA1PRzlACyxGTk : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in S<τ_0_0>, @in C<τ_0_0>) -> ()
   // CHECK-SAME: ) <T>
   _ = \C<T>.nonfinal
 
@@ -66,7 +66,7 @@ func computedProperties<T: P>(_: T) {
   // CHECK-SAME: root $C<τ_0_0>;
   // CHECK-SAME: gettable_property $S<τ_0_0>,
   // CHECK-SAME:   id #C.computed!getter.1 : <T> (C<T>) -> () -> S<T>,
-  // CHECK-SAME:   getter @_T08keypaths1CC8computedAA1SVyxGvTK : $@convention(thin) <τ_0_0> (@in C<τ_0_0>, @thick C<τ_0_0>.Type) -> @out S<τ_0_0>
+  // CHECK-SAME:   getter @_T08keypaths1CC8computedAA1SVyxGvAA1PRzlACyxGTK : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in C<τ_0_0>) -> @out S<τ_0_0>
   // CHECK-SAME: ) <T>
   _ = \C<T>.computed
 
@@ -74,8 +74,8 @@ func computedProperties<T: P>(_: T) {
   // CHECK-SAME: root $C<τ_0_0>;
   // CHECK-SAME: settable_property $S<τ_0_0>, 
   // CHECK-SAME:   id #C.observed!getter.1 : <T> (C<T>) -> () -> S<T>,
-  // CHECK-SAME:   getter @_T08keypaths1CC8observedAA1SVyxGvTK : $@convention(thin) <τ_0_0> (@in C<τ_0_0>, @thick C<τ_0_0>.Type) -> @out S<τ_0_0>,
-  // CHECK-SAME:   setter @_T08keypaths1CC8observedAA1SVyxGvTk : $@convention(thin) <τ_0_0> (@in S<τ_0_0>, @in C<τ_0_0>, @thick C<τ_0_0>.Type) -> ()
+  // CHECK-SAME:   getter @_T08keypaths1CC8observedAA1SVyxGvAA1PRzlACyxGTK : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in C<τ_0_0>) -> @out S<τ_0_0>,
+  // CHECK-SAME:   setter @_T08keypaths1CC8observedAA1SVyxGvAA1PRzlACyxGTk : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in S<τ_0_0>, @in C<τ_0_0>) -> ()
   // CHECK-SAME: ) <T>
   _ = \C<T>.observed
 
@@ -90,15 +90,15 @@ func computedProperties<T: P>(_: T) {
   // CHECK-SAME: root $C<τ_0_0>;
   // CHECK-SAME: settable_property $() -> (), 
   // CHECK-SAME:   id ##C.reabstracted,
-  // CHECK-SAME:   getter @_T08keypaths1CC12reabstractedyycvTK : $@convention(thin) <τ_0_0> (@in C<τ_0_0>, @thick C<τ_0_0>.Type) -> @out @callee_owned (@in ()) -> @out (),
-  // CHECK-SAME:   setter @_T08keypaths1CC12reabstractedyycvTk : $@convention(thin) <τ_0_0> (@in @callee_owned (@in ()) -> @out (), @in C<τ_0_0>, @thick C<τ_0_0>.Type) -> ()
+  // CHECK-SAME:   getter @_T08keypaths1CC12reabstractedyycvAA1PRzlACyxGTK : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in C<τ_0_0>) -> @out @callee_owned (@in ()) -> @out (),
+  // CHECK-SAME:   setter @_T08keypaths1CC12reabstractedyycvAA1PRzlACyxGTk : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in @callee_owned (@in ()) -> @out (), @in C<τ_0_0>) -> ()
   // CHECK-SAME: ) <T>
   _ = \C<T>.reabstracted
 
   // CHECK: keypath $KeyPath<S<T>, C<T>>, <τ_0_0 where τ_0_0 : P> (
   // CHECK-SAME: root $S<τ_0_0>; gettable_property $C<τ_0_0>,
   // CHECK-SAME: id @_T08keypaths1SV8computedAA1CCyxGfg : $@convention(method) <τ_0_0> (@in_guaranteed S<τ_0_0>) -> @owned C<τ_0_0>,
-  // CHECK-SAME:   getter @_T08keypaths1SV8computedAA1CCyxGvTK : $@convention(thin) <τ_0_0> (@in S<τ_0_0>, @thick S<τ_0_0>.Type) -> @out C<τ_0_0>
+  // CHECK-SAME:   getter @_T08keypaths1SV8computedAA1CCyxGvAA1PRzlACyxGTK : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in S<τ_0_0>) -> @out C<τ_0_0>
   // CHECK-SAME: ) <T>
   _ = \S<T>.computed
 
@@ -106,8 +106,8 @@ func computedProperties<T: P>(_: T) {
   // CHECK-SAME: root $S<τ_0_0>;
   // CHECK-SAME: settable_property $C<τ_0_0>,
   // CHECK-SAME:   id @_T08keypaths1SV8observedAA1CCyxGfg : $@convention(method) <τ_0_0> (@in_guaranteed S<τ_0_0>) -> @owned C<τ_0_0>,
-  // CHECK-SAME:   getter @_T08keypaths1SV8observedAA1CCyxGvTK : $@convention(thin) <τ_0_0> (@in S<τ_0_0>, @thick S<τ_0_0>.Type) -> @out C<τ_0_0>,
-  // CHECK-SAME:   setter @_T08keypaths1SV8observedAA1CCyxGvTk : $@convention(thin) <τ_0_0> (@in C<τ_0_0>, @inout S<τ_0_0>, @thick S<τ_0_0>.Type) -> ()
+  // CHECK-SAME:   getter @_T08keypaths1SV8observedAA1CCyxGvAA1PRzlACyxGTK : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in S<τ_0_0>) -> @out C<τ_0_0>,
+  // CHECK-SAME:   setter @_T08keypaths1SV8observedAA1CCyxGvAA1PRzlACyxGTk : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in C<τ_0_0>, @inout S<τ_0_0>) -> ()
   // CHECK-SAME: ) <T>
   _ = \S<T>.observed
   _ = \S<T>.z.nonfinal
@@ -119,8 +119,8 @@ func computedProperties<T: P>(_: T) {
   // CHECK-SAME:  root $S<τ_0_0>;
   // CHECK-SAME:  settable_property $() -> (),
   // CHECK-SAME:    id ##S.reabstracted,
-  // CHECK-SAME:    getter @_T08keypaths1SV12reabstractedyycvTK : $@convention(thin) <τ_0_0> (@in S<τ_0_0>, @thick S<τ_0_0>.Type) -> @out @callee_owned (@in ()) -> @out (),
-  // CHECK-SAME:    setter @_T08keypaths1SV12reabstractedyycvTk : $@convention(thin) <τ_0_0> (@in @callee_owned (@in ()) -> @out (), @inout S<τ_0_0>, @thick S<τ_0_0>.Type) -> ()
+  // CHECK-SAME:    getter @_T08keypaths1SV12reabstractedyycvAA1PRzlACyxGTK : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in S<τ_0_0>) -> @out @callee_owned (@in ()) -> @out (),
+  // CHECK-SAME:    setter @_T08keypaths1SV12reabstractedyycvAA1PRzlACyxGTk : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in @callee_owned (@in ()) -> @out (), @inout S<τ_0_0>) -> ()
   // CHECK-SAME: ) <T>
   _ = \S<T>.reabstracted
 
@@ -128,21 +128,36 @@ func computedProperties<T: P>(_: T) {
   // CHECK-SAME: root $τ_0_0;
   // CHECK-SAME: gettable_property $Int, 
   // CHECK-SAME:   id #P.x!getter.1 : <Self where Self : P> (Self) -> () -> Int,
-  // CHECK-SAME:   getter @_T08keypaths1PP1xSivTK : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in τ_0_0) -> @out Int
+  // CHECK-SAME:   getter @_T08keypaths1PP1xSivAaBRzlxTK : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in τ_0_0) -> @out Int
   // CHECK-SAME: ) <T>
   _ = \T.x
   // CHECK: keypath $WritableKeyPath<T, String>, <τ_0_0 where τ_0_0 : P> (
   // CHECK-SAME: root $τ_0_0;
   // CHECK-SAME: settable_property $String,
   // CHECK-SAME:   id #P.y!getter.1 : <Self where Self : P> (Self) -> () -> String,
-  // CHECK-SAME:   getter @_T08keypaths1PP1ySSvTK : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in τ_0_0) -> @out String,
-  // CHECK-SAME:   setter @_T08keypaths1PP1ySSvTk : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in String, @inout τ_0_0) -> ()
+  // CHECK-SAME:   getter @_T08keypaths1PP1ySSvAaBRzlxTK : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in τ_0_0) -> @out String,
+  // CHECK-SAME:   setter @_T08keypaths1PP1ySSvAaBRzlxTk : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in String, @inout τ_0_0) -> ()
   // CHECK-SAME: ) <T>
   _ = \T.y
 
   // CHECK: keypath $KeyPath<T, String>, <τ_0_0 where τ_0_0 : P> (
   // CHECK-SAME: root $τ_0_0;
   // CHECK-SAME: gettable_property $String,
-  // CHECK-SAME:   id @
+  // CHECK-SAME:   id @_T08keypaths1PPAAE1zSSfg
   _ = \T.z
+}
+
+struct Concrete: P {
+  var x: Int
+  var y: String
+}
+
+// CHECK-LABEL: sil hidden @_T08keypaths35keyPathsWithSpecificGenericInstanceyyF
+func keyPathsWithSpecificGenericInstance() {
+  // CHECK: keypath $KeyPath<Concrete, String>, (
+  // CHECK-SAME: gettable_property $String,
+  // CHECK-SAME:   id @_T08keypaths1PPAAE1zSSfg
+  // CHECK-SAME:   getter @_T08keypaths1PPAAE1zSSvAA8ConcreteVTK : $@convention(thin) (@in Concrete) -> @out String
+  _ = \Concrete.z
+  _ = \S<Concrete>.computed
 }

--- a/test/stdlib/KeyPath.swift
+++ b/test/stdlib/KeyPath.swift
@@ -192,7 +192,9 @@ keyPath.test("key path generic instantiation") {
   expectEqual(s_c_x_lt, s_c_x_lt2)
 }
 
-struct TestComputed {
+protocol P {}
+
+struct TestComputed: P {
   static var numNonmutatingSets = 0
   static var numMutatingSets = 0
 
@@ -222,6 +224,14 @@ struct TestComputed {
   }
 }
 
+extension P {
+  var readonlyProtoExt: Self { return self }
+  var mutatingProtoExt: Self {
+    get { return self }
+    set { self = newValue }
+  }
+}
+
 keyPath.test("computed properties") {
   var test = TestComputed()
 
@@ -244,13 +254,26 @@ keyPath.test("computed properties") {
 
   do {
     let tc_mutating = \TestComputed.mutating
-    TestComputed.resetCounts()
     expectTrue(test[keyPath: tc_mutating] !== test[keyPath: tc_mutating])
     expectEqual(test[keyPath: tc_mutating].value,
                 test[keyPath: tc_mutating].value)
     let newObject = LifetimeTracked(5)
     test[keyPath: tc_mutating] = newObject
     expectTrue(test.canary === newObject)
+  }
+
+  do {
+    let tc_readonlyProtoExt = \TestComputed.readonlyProtoExt
+    expectTrue(test.canary === test[keyPath: tc_readonlyProtoExt].canary)
+  }
+
+  do {
+    let tc_mutatingProtoExt = \TestComputed.mutatingProtoExt
+    expectTrue(test.canary === test[keyPath: tc_mutatingProtoExt].canary)
+    let oldTest = test
+    test[keyPath: tc_mutatingProtoExt] = TestComputed()
+    expectTrue(oldTest.canary !== test.canary)
+    expectTrue(test.canary === test[keyPath: tc_mutatingProtoExt].canary)
   }
 }
 


### PR DESCRIPTION
Explanation: The Sema AbstractStorageDecl::getAccessStrategy() call would incorrectly classify protocol extension methods as requiring dynamic dispatch, leading to a miscompile where key paths would attempt to identify them using nonexistent wtable entries. We would also emit the getter/setter thunks for a key path component with the wrong generic signature if the key path referenced a generic property with concrete generic arguments.

Scope: Key paths referencing protocol extension properties would always crash.

Issue: rdar://problem/32201589

Risk: Low. All other uses of getAccessStrategy don't distinguish behavior in the DirectToAccessor and DispatchToAccessor case. The code gen logic for keypath getter/setter thunks has no impact on other language features.

Testing: Swift CI, test case from Radar