### PR TITLE
[4.0] Sema: Reject unimplemented key path components during resolveKeyPathExpr

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -445,6 +445,8 @@ ERROR(expr_swift_keypath_invalid_component,none,
       "invalid component of Swift key path", ())
 ERROR(expr_swift_keypath_not_starting_with_type,none,
       "a Swift key path must begin with a type", ())
+ERROR(expr_swift_keypath_unimplemented_component,none,
+      "key path support for %0 components is not implemented", (StringRef))
 
 // Selector expressions.
 ERROR(expr_selector_no_objc_runtime,none,

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -228,8 +228,8 @@ namespace swift {
     Swift3ObjCInferenceWarnings WarnSwift3ObjCInference =
       Swift3ObjCInferenceWarnings::None;
     
-    /// Enable keypaths.
-    bool EnableExperimentalKeyPaths = true;
+    /// Enable keypath components that aren't fully implemented.
+    bool EnableExperimentalKeyPathComponents = false;
 
     /// When a conversion from String to Substring fails, emit a fix-it to append
     /// the void subscript '[]'.

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -269,9 +269,9 @@ def enable_experimental_property_behaviors :
   Flag<["-"], "enable-experimental-property-behaviors">,
   HelpText<"Enable experimental property behaviors">;
   
-def enable_experimental_keypaths :
-  Flag<["-"], "enable-experimental-keypaths">,
-  HelpText<"Enable experimental keypaths">;
+def enable_experimental_keypath_components :
+  Flag<["-"], "enable-experimental-keypath-components">,
+  HelpText<"Enable unimplemented keypath component kinds">;
 
 def enable_deserialization_recovery :
   Flag<["-"], "enable-deserialization-recovery">,

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -914,8 +914,8 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.EnableExperimentalPropertyBehaviors |=
     Args.hasArg(OPT_enable_experimental_property_behaviors);
 
-  Opts.EnableExperimentalKeyPaths |=
-    Args.hasArg(OPT_enable_experimental_keypaths);
+  Opts.EnableExperimentalKeyPathComponents |=
+    Args.hasArg(OPT_enable_experimental_keypath_components);
 
   Opts.EnableClassResilience |=
     Args.hasArg(OPT_enable_class_resilience);

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -455,8 +455,6 @@ ParserResult<Expr> Parser::parseExprUnary(Diag<> Message, bool isExprBasic) {
   case tok::pound_keyPath:
     return parseExprKeyPathObjC();
   case tok::backslash:
-    if (!Context.LangOpts.EnableExperimentalKeyPaths)
-      return parseExprPostfix(Message, isExprBasic);
     return parseExprKeyPath();
 
   case tok::oper_postfix:

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -3982,6 +3982,9 @@ namespace {
       }
 
       simplifyExprType(E);
+      
+      if (E->getType()->hasError())
+        return E;
 
       SmallVector<KeyPathExpr::Component, 4> resolvedComponents;
 

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2880,6 +2880,13 @@ namespace {
         
         case KeyPathExpr::Component::Kind::OptionalChain: {
           didOptionalChain = true;
+          
+          // TODO: This currently crashes the compiler in some cases, so short-
+          // circuit out.
+          if (!CS.TC.Context.LangOpts.EnableExperimentalKeyPathComponents) {
+            return ErrorType::get(CS.TC.Context);
+          }
+          
           // We can't assign an optional back through an optional chain
           // today. Force the base to an rvalue.
           auto rvalueTy = CS.createTypeVariable(locator, 0);

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2828,8 +2828,7 @@ performMemberLookup(ConstraintKind constraintKind, DeclName memberName,
   result.OverallResult = MemberLookupResult::HasResults;
   
   // If we're looking for a subscript, consider key path operations.
-  if (memberName.isSimpleName(getASTContext().Id_subscript)
-      && getASTContext().LangOpts.EnableExperimentalKeyPaths) {
+  if (memberName.isSimpleName(getASTContext().Id_subscript)) {
     result.ViableCandidates.push_back(
         OverloadChoice(baseTy, OverloadChoiceKind::KeyPathApplication));
   }

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1313,6 +1313,9 @@ TypeExpr *PreCheckExpression::simplifyTypeExpr(Expr *E) {
 void PreCheckExpression::resolveKeyPathExpr(KeyPathExpr *KPE) {
   if (KPE->isObjC())
     return;
+  
+  if (!KPE->getComponents().empty())
+    return;
 
   TypeRepr *rootType = nullptr;
   SmallVector<KeyPathExpr::Component, 4> components;
@@ -1343,6 +1346,12 @@ void PreCheckExpression::resolveKeyPathExpr(KeyPathExpr *KPE) {
 
         expr = UDE->getBase();
       } else if (auto SE = dyn_cast<SubscriptExpr>(expr)) {
+        if (!TC.Context.LangOpts.EnableExperimentalKeyPathComponents) {
+          TC.diagnose(SE->getLoc(),
+                      diag::expr_swift_keypath_unimplemented_component,
+                      "subscript");
+        }
+      
         // .[0] or just plain [0]
         components.push_back(
             KeyPathExpr::Component::forUnresolvedSubscriptWithPrebuiltIndexExpr(
@@ -1350,12 +1359,23 @@ void PreCheckExpression::resolveKeyPathExpr(KeyPathExpr *KPE) {
 
         expr = SE->getBase();
       } else if (auto BOE = dyn_cast<BindOptionalExpr>(expr)) {
+        if (!TC.Context.LangOpts.EnableExperimentalKeyPathComponents) {
+          TC.diagnose(BOE->getLoc(),
+                      diag::expr_swift_keypath_unimplemented_component,
+                      "optional chaining");
+        }
+
         // .? or ?
         components.push_back(KeyPathExpr::Component::forUnresolvedOptionalChain(
             BOE->getQuestionLoc()));
 
         expr = BOE->getSubExpr();
       } else if (auto FVE = dyn_cast<ForceValueExpr>(expr)) {
+        if (!TC.Context.LangOpts.EnableExperimentalKeyPathComponents) {
+          TC.diagnose(FVE->getLoc(),
+                      diag::expr_swift_keypath_unimplemented_component,
+                      "optional force-unwrapping");
+        }
         // .! or !
         components.push_back(KeyPathExpr::Component::forUnresolvedOptionalForce(
             FVE->getExclaimLoc()));

--- a/test/SILGen/keypath_application.swift
+++ b/test/SILGen/keypath_application.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-experimental-keypaths -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -enable-experimental-keypath-components -emit-silgen %s | %FileCheck %s
 
 class A {}
 class B {}

--- a/test/SILGen/keypaths.swift
+++ b/test/SILGen/keypaths.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-experimental-keypaths -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -enable-experimental-keypath-components -emit-silgen %s | %FileCheck %s
 
 struct S<T> {
   var x: T

--- a/test/SILGen/keypaths_objc.swift
+++ b/test/SILGen/keypaths_objc.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-experimental-keypaths -emit-silgen -import-objc-header %S/Inputs/keypaths_objc.h %s | %FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-experimental-keypath-components -emit-silgen -import-objc-header %S/Inputs/keypaths_objc.h %s | %FileCheck %s
 // REQUIRES: objc_interop
 
 import Foundation

--- a/test/expr/unary/keypath/keypath-unimplemented.swift
+++ b/test/expr/unary/keypath/keypath-unimplemented.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend -typecheck -verify %s
+
+struct A {
+  subscript(x: Int) -> Int { return x }
+  var c: C? = C()
+}
+
+class C {
+  var i = 0
+}
+
+func unsupportedComponents() {
+  _ = \A.c?.i // expected-error{{key path support for optional chaining components is not implemented}}
+  _ = \A.c!.i // expected-error{{key path support for optional force-unwrapping components is not implemented}}
+  _ = \A.[0] // expected-error{{key path support for subscript components is not implemented}}
+}

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -typecheck -parse-as-library -enable-experimental-keypaths  %s -verify
+// RUN: %target-swift-frontend -typecheck -parse-as-library -enable-experimental-keypath-components  %s -verify
 
 struct Sub {}
 struct OptSub {}

--- a/test/stdlib/KeyPath.swift
+++ b/test/stdlib/KeyPath.swift
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: %target-build-swift %s -Xfrontend -enable-experimental-keypaths -o %t/a.out
+// RUN: %target-build-swift %s -Xfrontend -enable-experimental-keypath-components -o %t/a.out
 // RUN: %target-run %t/a.out
 // REQUIRES: executable_test
 

--- a/test/stdlib/KeyPathImplementation.swift
+++ b/test/stdlib/KeyPathImplementation.swift
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: %target-build-swift %s -g -Xfrontend -enable-experimental-keypaths -o %t/a.out
+// RUN: %target-build-swift %s -g -Xfrontend -enable-experimental-keypath-components -o %t/a.out
 // RUN: %target-run %t/a.out
 // REQUIRES: executable_test
 

--- a/test/stdlib/KeyPathObjC.swift
+++ b/test/stdlib/KeyPathObjC.swift
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: %target-build-swift %s -Xfrontend -enable-experimental-keypaths -o %t/a.out
+// RUN: %target-build-swift %s -Xfrontend -enable-experimental-keypath-components -o %t/a.out
 // RUN: %target-run %t/a.out
 // REQUIRES: executable_test
 // REQUIRES: objc_interop


### PR DESCRIPTION
Explanation: Diagnose unimplemented key path features early in Sema to avoid exposing issues deeper down the pipeline.

Scope: Attempting to use unimplemented key path features may crash. It's more robust to diagnose up front.

Issue: rdar://problem/32200714

Risk: Low, impact is only on a new feature. Should have no impact on existing code.

Testing: Swift CI, test cases from Radar