### PR TITLE
[Foundation] Correct symbolic availability for CFURL component characer set accessors

### DIFF
--- a/stdlib/public/SDK/Foundation/CharacterSet.swift
+++ b/stdlib/public/SDK/Foundation/CharacterSet.swift
@@ -13,6 +13,7 @@
 @_exported import Foundation // Clang module
 import CoreFoundation
 import _SwiftCoreFoundationOverlayShims
+import _SwiftFoundationOverlayShims
 
 private func _utfRangeToCFRange(_ inRange : Range<Unicode.Scalar>) -> CFRange {
     return CFRange(
@@ -513,35 +514,59 @@ public struct CharacterSet : ReferenceConvertible, Equatable, Hashable, SetAlgeb
     }
     
     // MARK: Static functions, from NSURL
-    
+
     /// Returns the character set for characters allowed in a user URL subcomponent.
     public static var urlUserAllowed : CharacterSet {
-        return CharacterSet(_uncopiedImmutableReference: _CFURLComponentsGetURLUserAllowedCharacterSet() as NSCharacterSet)
+        if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
+            return CharacterSet(_uncopiedImmutableReference: _CFURLComponentsGetURLUserAllowedCharacterSet() as NSCharacterSet)
+        } else {
+            return CharacterSet(_uncopiedImmutableReference: _NSURLComponentsGetURLUserAllowedCharacterSet() as! NSCharacterSet)
+        }
     }
     
     /// Returns the character set for characters allowed in a password URL subcomponent.
     public static var urlPasswordAllowed : CharacterSet {
-        return CharacterSet(_uncopiedImmutableReference: _CFURLComponentsGetURLPasswordAllowedCharacterSet() as NSCharacterSet)
+        if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
+            return CharacterSet(_uncopiedImmutableReference: _CFURLComponentsGetURLPasswordAllowedCharacterSet() as NSCharacterSet)
+        } else {
+            return CharacterSet(_uncopiedImmutableReference: _NSURLComponentsGetURLPasswordAllowedCharacterSet() as! NSCharacterSet)
+        }
     }
     
     /// Returns the character set for characters allowed in a host URL subcomponent.
     public static var urlHostAllowed : CharacterSet {
-        return CharacterSet(_uncopiedImmutableReference: _CFURLComponentsGetURLHostAllowedCharacterSet() as NSCharacterSet)
+        if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
+            return CharacterSet(_uncopiedImmutableReference: _CFURLComponentsGetURLHostAllowedCharacterSet() as NSCharacterSet)
+        } else {
+            return CharacterSet(_uncopiedImmutableReference: _NSURLComponentsGetURLHostAllowedCharacterSet() as! NSCharacterSet)
+        }
     }
     
     /// Returns the character set for characters allowed in a path URL component.
     public static var urlPathAllowed : CharacterSet {
-        return CharacterSet(_uncopiedImmutableReference: _CFURLComponentsGetURLPathAllowedCharacterSet() as NSCharacterSet)
+        if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
+            return CharacterSet(_uncopiedImmutableReference: _CFURLComponentsGetURLPathAllowedCharacterSet() as NSCharacterSet)
+        } else {
+            return CharacterSet(_uncopiedImmutableReference: _NSURLComponentsGetURLPathAllowedCharacterSet() as! NSCharacterSet)
+        }
     }
     
     /// Returns the character set for characters allowed in a query URL component.
     public static var urlQueryAllowed : CharacterSet {
-        return CharacterSet(_uncopiedImmutableReference: _CFURLComponentsGetURLQueryAllowedCharacterSet() as NSCharacterSet)
+        if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
+            return CharacterSet(_uncopiedImmutableReference: _CFURLComponentsGetURLQueryAllowedCharacterSet() as NSCharacterSet)
+        } else {
+            return CharacterSet(_uncopiedImmutableReference: _NSURLComponentsGetURLQueryAllowedCharacterSet() as! NSCharacterSet)
+        }
     }
     
     /// Returns the character set for characters allowed in a fragment URL component.
     public static var urlFragmentAllowed : CharacterSet {
-        return CharacterSet(_uncopiedImmutableReference: _CFURLComponentsGetURLFragmentAllowedCharacterSet() as NSCharacterSet)
+        if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
+            return CharacterSet(_uncopiedImmutableReference: _CFURLComponentsGetURLFragmentAllowedCharacterSet() as NSCharacterSet)
+        } else {
+            return CharacterSet(_uncopiedImmutableReference: _NSURLComponentsGetURLFragmentAllowedCharacterSet() as! NSCharacterSet)
+        }
     }
     
     // MARK: Immutable functions

--- a/stdlib/public/SwiftShims/CFCharacterSetShims.h
+++ b/stdlib/public/SwiftShims/CFCharacterSetShims.h
@@ -14,12 +14,12 @@ CF_IMPLICIT_BRIDGING_ENABLED
 CF_EXTERN_C_BEGIN
 _Pragma("clang assume_nonnull begin")
 
-CF_EXPORT CFCharacterSetRef _CFURLComponentsGetURLUserAllowedCharacterSet();
-CF_EXPORT CFCharacterSetRef _CFURLComponentsGetURLPasswordAllowedCharacterSet();
-CF_EXPORT CFCharacterSetRef _CFURLComponentsGetURLHostAllowedCharacterSet();
-CF_EXPORT CFCharacterSetRef _CFURLComponentsGetURLPathAllowedCharacterSet();
-CF_EXPORT CFCharacterSetRef _CFURLComponentsGetURLQueryAllowedCharacterSet();
-CF_EXPORT CFCharacterSetRef _CFURLComponentsGetURLFragmentAllowedCharacterSet();
+CF_EXPORT CFCharacterSetRef _CFURLComponentsGetURLUserAllowedCharacterSet() API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT CFCharacterSetRef _CFURLComponentsGetURLPasswordAllowedCharacterSet() API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT CFCharacterSetRef _CFURLComponentsGetURLHostAllowedCharacterSet() API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT CFCharacterSetRef _CFURLComponentsGetURLPathAllowedCharacterSet() API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT CFCharacterSetRef _CFURLComponentsGetURLQueryAllowedCharacterSet() API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT CFCharacterSetRef _CFURLComponentsGetURLFragmentAllowedCharacterSet() API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
 
 _Pragma("clang assume_nonnull end")
 CF_EXTERN_C_END

--- a/stdlib/public/SwiftShims/CMakeLists.txt
+++ b/stdlib/public/SwiftShims/CMakeLists.txt
@@ -29,6 +29,7 @@ set(sources
   FoundationOverlayShims.h
   FoundationShimSupport.h
   NSCalendarShims.h
+  NSCharacterSetShims.h
   NSCoderShims.h
   NSDataShims.h
   NSDictionaryShims.h

--- a/stdlib/public/SwiftShims/FoundationOverlayShims.h
+++ b/stdlib/public/SwiftShims/FoundationOverlayShims.h
@@ -17,6 +17,7 @@
 
 #import "FoundationShimSupport.h"
 #import "NSCalendarShims.h"
+#import "NSCharacterSetShims.h"
 #import "NSCoderShims.h"
 #import "NSDataShims.h"
 #import "NSDictionaryShims.h"

--- a/stdlib/public/SwiftShims/NSCharacterSetShims.h
+++ b/stdlib/public/SwiftShims/NSCharacterSetShims.h
@@ -1,0 +1,41 @@
+//===--- NSCharacterSetShims.h - Foundation declarations for CharacterSet overlay -----===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#import "FoundationShimSupport.h"
+
+NS_BEGIN_DECLS
+
+NS_INLINE NS_RETURNS_RETAINED NS_NON_BRIDGED(NSCharacterSet *) _NSURLComponentsGetURLUserAllowedCharacterSet(void) {
+	return NSCharacterSet.URLUserAllowedCharacterSet;
+}
+
+NS_INLINE NS_RETURNS_RETAINED NS_NON_BRIDGED(NSCharacterSet *) _NSURLComponentsGetURLPasswordAllowedCharacterSet(void) {
+	return NSCharacterSet.URLPasswordAllowedCharacterSet;
+}
+
+NS_INLINE NS_RETURNS_RETAINED NS_NON_BRIDGED(NSCharacterSet *) _NSURLComponentsGetURLHostAllowedCharacterSet(void) {
+	return NSCharacterSet.URLHostAllowedCharacterSet;
+}
+
+NS_INLINE NS_RETURNS_RETAINED NS_NON_BRIDGED(NSCharacterSet *) _NSURLComponentsGetURLPathAllowedCharacterSet(void) {
+	return NSCharacterSet.URLPathAllowedCharacterSet;
+}
+
+NS_INLINE NS_RETURNS_RETAINED NS_NON_BRIDGED(NSCharacterSet *) _NSURLComponentsGetURLQueryAllowedCharacterSet(void) {
+	return NSCharacterSet.URLQueryAllowedCharacterSet;
+}
+
+NS_INLINE NS_RETURNS_RETAINED NS_NON_BRIDGED(NSCharacterSet *) _NSURLComponentsGetURLFragmentAllowedCharacterSet(void) {
+	return NSCharacterSet.URLFragmentAllowedCharacterSet;
+}
+
+NS_END_DECLS


### PR DESCRIPTION
This resolves <rdar://problem/32188090>
tvOS 9.0 did not have the symbols for the CFURLComponents accessor methods for character sets; this change works around that to use the Foundation variants via shim functions