### PR TITLE
Add Codable conformance to common Foundation types

### DIFF
--- a/stdlib/public/SDK/CoreGraphics/CGFloat.swift.gyb
+++ b/stdlib/public/SDK/CoreGraphics/CGFloat.swift.gyb
@@ -807,3 +807,35 @@ extension CGFloat : _CVarArgPassedAsDouble, _CVarArgAligned {
     return native._cVarArgAlignment
   }
 }
+
+extension CGFloat : Codable {
+  @_transparent
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    do {
+      self.native = try container.decode(NativeType.self)
+    } catch DecodingError.typeMismatch(let type, let context) {
+      // We may have encoded as a different type on a different platform. A
+      // strict fixed-format decoder may disallow a conversion, so let's try the
+      // other type.
+      do {
+        if NativeType.self == Float.self {
+          self.native = NativeType(try container.decode(Double.self))
+        } else {
+          self.native = NativeType(try container.decode(Float.self))
+        }
+      } catch {
+        // Failed to decode as the other type, too. This is neither a Float nor
+        // a Double. Throw the old error; we don't want to clobber the original
+        // info.
+        throw DecodingError.typeMismatch(type, context)
+      }
+    }
+  }
+
+  @_transparent
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(self.native)
+  }
+}

--- a/stdlib/public/SDK/Foundation/AffineTransform.swift
+++ b/stdlib/public/SDK/Foundation/AffineTransform.swift
@@ -330,4 +330,26 @@ extension NSAffineTransform : _HasCustomAnyHashableRepresentation {
     }
 }
 
+extension AffineTransform : Codable {
+    public init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        m11 = try container.decode(CGFloat.self)
+        m12 = try container.decode(CGFloat.self)
+        m21 = try container.decode(CGFloat.self)
+        m22 = try container.decode(CGFloat.self)
+        tX  = try container.decode(CGFloat.self)
+        tY  = try container.decode(CGFloat.self)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        try container.encode(self.m11)
+        try container.encode(self.m12)
+        try container.encode(self.m21)
+        try container.encode(self.m22)
+        try container.encode(self.tX)
+        try container.encode(self.tY)
+    }
+}
+
 #endif

--- a/stdlib/public/SDK/Foundation/Calendar.swift
+++ b/stdlib/public/SDK/Foundation/Calendar.swift
@@ -1009,7 +1009,7 @@ public struct Calendar : Hashable, Equatable, ReferenceConvertible, _MutableBoxi
         }
     }
     
-    private static func _fromNSCalendarIdentifier(_ identifier : NSCalendar.Identifier) -> Identifier {
+    internal static func _fromNSCalendarIdentifier(_ identifier : NSCalendar.Identifier) -> Identifier {
         if #available(OSX 10.10, iOS 8.0, *) {
             let identifierMap : [NSCalendar.Identifier : Identifier] =
                 [.gregorian : .gregorian,
@@ -1128,3 +1128,35 @@ extension NSCalendar : _HasCustomAnyHashableRepresentation {
     }
 }
 
+extension Calendar : Codable {
+    private enum CodingKeys : Int, CodingKey {
+        case identifier
+        case locale
+        case timeZone
+        case firstWeekday
+        case minimumDaysInFirstWeek
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let identifierString = try container.decode(String.self, forKey: .identifier)
+        let identifier = Calendar._fromNSCalendarIdentifier(NSCalendar.Identifier(rawValue: identifierString))
+        self.init(identifier: identifier)
+
+        self.locale = try container.decodeIfPresent(Locale.self, forKey: .locale)
+        self.timeZone = try container.decode(TimeZone.self, forKey: .timeZone)
+        self.firstWeekday = try container.decode(Int.self, forKey: .firstWeekday)
+        self.minimumDaysInFirstWeek = try container.decode(Int.self, forKey: .minimumDaysInFirstWeek)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        let identifier = Calendar._toNSCalendarIdentifier(self.identifier).rawValue
+        try container.encode(identifier, forKey: .identifier)
+        try container.encode(self.locale, forKey: .locale)
+        try container.encode(self.timeZone, forKey: .timeZone)
+        try container.encode(self.firstWeekday, forKey: .firstWeekday)
+        try container.encode(self.minimumDaysInFirstWeek, forKey: .minimumDaysInFirstWeek)
+    }
+}

--- a/stdlib/public/SDK/Foundation/CharacterSet.swift
+++ b/stdlib/public/SDK/Foundation/CharacterSet.swift
@@ -782,3 +782,19 @@ extension NSCharacterSet : _HasCustomAnyHashableRepresentation {
     }
 }
 
+extension CharacterSet : Codable {
+    private enum CodingKeys : Int, CodingKey {
+        case bitmap
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let bitmap = try container.decode(Data.self, forKey: .bitmap)
+        self.init(bitmapRepresentation: bitmap)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.bitmapRepresentation, forKey: .bitmap)
+    }
+}

--- a/stdlib/public/SDK/Foundation/Date.swift
+++ b/stdlib/public/SDK/Foundation/Date.swift
@@ -284,3 +284,16 @@ extension Date : CustomPlaygroundQuickLookable {
         return .text(summary)
     }
 }
+
+extension Date : Codable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let timestamp = try container.decode(Double.self)
+        self.init(timeIntervalSinceReferenceDate: timestamp)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(self.timeIntervalSinceReferenceDate)
+    }
+}

--- a/stdlib/public/SDK/Foundation/DateComponents.swift
+++ b/stdlib/public/SDK/Foundation/DateComponents.swift
@@ -352,3 +352,83 @@ extension NSDateComponents : _HasCustomAnyHashableRepresentation {
     }
 }
 
+extension DateComponents : Codable {
+    private enum CodingKeys : Int, CodingKey {
+        case calendar
+        case timeZone
+        case era
+        case year
+        case month
+        case day
+        case hour
+        case minute
+        case second
+        case nanosecond
+        case weekday
+        case weekdayOrdinal
+        case quarter
+        case weekOfMonth
+        case weekOfYear
+        case yearForWeekOfYear
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container  = try decoder.container(keyedBy: CodingKeys.self)
+        let calendar   = try container.decodeIfPresent(Calendar.self, forKey: .calendar)
+        let timeZone   = try container.decodeIfPresent(TimeZone.self, forKey: .timeZone)
+        let era        = try container.decodeIfPresent(Int.self, forKey: .era)
+        let year       = try container.decodeIfPresent(Int.self, forKey: .year)
+        let month      = try container.decodeIfPresent(Int.self, forKey: .month)
+        let day        = try container.decodeIfPresent(Int.self, forKey: .day)
+        let hour       = try container.decodeIfPresent(Int.self, forKey: .hour)
+        let minute     = try container.decodeIfPresent(Int.self, forKey: .minute)
+        let second     = try container.decodeIfPresent(Int.self, forKey: .second)
+        let nanosecond = try container.decodeIfPresent(Int.self, forKey: .nanosecond)
+
+        let weekday           = try container.decodeIfPresent(Int.self, forKey: .weekday)
+        let weekdayOrdinal    = try container.decodeIfPresent(Int.self, forKey: .weekdayOrdinal)
+        let quarter           = try container.decodeIfPresent(Int.self, forKey: .quarter)
+        let weekOfMonth       = try container.decodeIfPresent(Int.self, forKey: .weekOfMonth)
+        let weekOfYear        = try container.decodeIfPresent(Int.self, forKey: .weekOfYear)
+        let yearForWeekOfYear = try container.decodeIfPresent(Int.self, forKey: .yearForWeekOfYear)
+
+        self.init(calendar: calendar,
+                  timeZone: timeZone,
+                  era: era,
+                  year: year,
+                  month: month,
+                  day: day,
+                  hour: hour,
+                  minute: minute,
+                  second: second,
+                  nanosecond: nanosecond,
+                  weekday: weekday,
+                  weekdayOrdinal: weekdayOrdinal,
+                  quarter: quarter,
+                  weekOfMonth: weekOfMonth,
+                  weekOfYear: weekOfYear,
+                  yearForWeekOfYear: yearForWeekOfYear)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        // TODO: Replace all with encodeIfPresent, when added.
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        if self.calendar   != nil { try container.encode(self.calendar!, forKey: .calendar) }
+        if self.timeZone   != nil { try container.encode(self.timeZone!, forKey: .timeZone) }
+        if self.era        != nil { try container.encode(self.era!, forKey: .era) }
+        if self.year       != nil { try container.encode(self.year!, forKey: .year) }
+        if self.month      != nil { try container.encode(self.month!, forKey: .month) }
+        if self.day        != nil { try container.encode(self.day!, forKey: .day) }
+        if self.hour       != nil { try container.encode(self.hour!, forKey: .hour) }
+        if self.minute     != nil { try container.encode(self.minute!, forKey: .minute) }
+        if self.second     != nil { try container.encode(self.second!, forKey: .second) }
+        if self.nanosecond != nil { try container.encode(self.nanosecond!, forKey: .nanosecond) }
+
+        if self.weekday           != nil { try container.encode(self.weekday!, forKey: .weekday) }
+        if self.weekdayOrdinal    != nil { try container.encode(self.weekdayOrdinal!, forKey: .weekdayOrdinal) }
+        if self.quarter           != nil { try container.encode(self.quarter!, forKey: .quarter) }
+        if self.weekOfMonth       != nil { try container.encode(self.weekOfMonth!, forKey: .weekOfMonth) }
+        if self.weekOfYear        != nil { try container.encode(self.weekOfYear!, forKey: .weekOfYear) }
+        if self.yearForWeekOfYear != nil { try container.encode(self.yearForWeekOfYear!, forKey: .yearForWeekOfYear) }
+    }
+}

--- a/stdlib/public/SDK/Foundation/DateInterval.swift
+++ b/stdlib/public/SDK/Foundation/DateInterval.swift
@@ -15,7 +15,7 @@ import _SwiftCoreFoundationOverlayShims
 
 /// DateInterval represents a closed date interval in the form of [startDate, endDate].  It is possible for the start and end dates to be the same with a duration of 0.  DateInterval does not support reverse intervals i.e. intervals where the duration is less than 0 and the end date occurs earlier in time than the start date.
 @available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
-public struct DateInterval : ReferenceConvertible, Comparable, Hashable {
+public struct DateInterval : ReferenceConvertible, Comparable, Hashable, Codable {
     public typealias ReferenceType = NSDateInterval
     
     /// The start date.

--- a/stdlib/public/SDK/Foundation/Decimal.swift
+++ b/stdlib/public/SDK/Foundation/Decimal.swift
@@ -474,3 +474,58 @@ extension Decimal : _ObjectiveCBridgeable {
         return src.decimalValue
     }
 }
+
+extension Decimal : Codable {
+    private enum CodingKeys : Int, CodingKey {
+        case exponent
+        case length
+        case isNegative
+        case isCompact
+        case mantissa
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let exponent = try container.decode(CInt.self, forKey: .exponent)
+        let length = try container.decode(CUnsignedInt.self, forKey: .length)
+        let isNegative = try container.decode(Bool.self, forKey: .isNegative)
+        let isCompact = try container.decode(Bool.self, forKey: .isCompact)
+
+        var mantissaContainer = try container.nestedUnkeyedContainer(forKey: .mantissa)
+        var mantissa: (CUnsignedShort, CUnsignedShort, CUnsignedShort, CUnsignedShort,
+                       CUnsignedShort, CUnsignedShort, CUnsignedShort, CUnsignedShort) = (0,0,0,0,0,0,0,0)
+        mantissa.0 = try mantissaContainer.decode(CUnsignedShort.self)
+        mantissa.1 = try mantissaContainer.decode(CUnsignedShort.self)
+        mantissa.2 = try mantissaContainer.decode(CUnsignedShort.self)
+        mantissa.3 = try mantissaContainer.decode(CUnsignedShort.self)
+        mantissa.4 = try mantissaContainer.decode(CUnsignedShort.self)
+        mantissa.5 = try mantissaContainer.decode(CUnsignedShort.self)
+        mantissa.6 = try mantissaContainer.decode(CUnsignedShort.self)
+        mantissa.7 = try mantissaContainer.decode(CUnsignedShort.self)
+
+        self.init(_exponent: exponent,
+                  _length: length,
+                  _isNegative: CUnsignedInt(isNegative ? 1 : 0),
+                  _isCompact: CUnsignedInt(isCompact ? 1 : 0),
+                  _reserved: 0,
+                  _mantissa: mantissa)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(_exponent, forKey: .exponent)
+        try container.encode(_length, forKey: .length)
+        try container.encode(_isNegative == 0 ? false : true, forKey: .isNegative)
+        try container.encode(_isCompact == 0 ? false : true, forKey: .isCompact)
+
+        var mantissaContainer = container.nestedUnkeyedContainer(forKey: .mantissa)
+        try mantissaContainer.encode(_mantissa.0)
+        try mantissaContainer.encode(_mantissa.1)
+        try mantissaContainer.encode(_mantissa.2)
+        try mantissaContainer.encode(_mantissa.3)
+        try mantissaContainer.encode(_mantissa.4)
+        try mantissaContainer.encode(_mantissa.5)
+        try mantissaContainer.encode(_mantissa.6)
+        try mantissaContainer.encode(_mantissa.7)
+    }
+}

--- a/stdlib/public/SDK/Foundation/IndexSet.swift
+++ b/stdlib/public/SDK/Foundation/IndexSet.swift
@@ -917,3 +917,38 @@ private final class _MutablePairHandle<ImmutableType : NSObject, MutableType : N
         }
     }
 }
+
+extension IndexSet : Codable {
+    private enum CodingKeys : Int, CodingKey {
+        case indexes
+    }
+
+    private enum RangeCodingKeys : Int, CodingKey {
+        case location
+        case length
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        var indexesContainer = try container.nestedUnkeyedContainer(forKey: .indexes)
+        self.init()
+
+        while !indexesContainer.isAtEnd {
+            let rangeContainer = try indexesContainer.nestedContainer(keyedBy: RangeCodingKeys.self)
+            let startIndex = try rangeContainer.decode(Int.self, forKey: .location)
+            let count = try rangeContainer.decode(Int.self, forKey: .length)
+            self.insert(integersIn: startIndex ..< (startIndex + count))
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        var indexesContainer = container.nestedUnkeyedContainer(forKey: .indexes)
+
+        for range in self.rangeView {
+            var rangeContainer = indexesContainer.nestedContainer(keyedBy: RangeCodingKeys.self)
+            try rangeContainer.encode(range.startIndex, forKey: .location)
+            try rangeContainer.encode(range.count, forKey: .length)
+        }
+    }
+}

--- a/stdlib/public/SDK/Foundation/JSONEncoder.swift
+++ b/stdlib/public/SDK/Foundation/JSONEncoder.swift
@@ -177,16 +177,23 @@ fileprivate class _JSONEncoder : Encoder {
         return ret
     }
 
-    /// Asserts that a new container can be requested at this coding path.
-    /// `preconditionFailure()`s if one cannot be requested.
-    func assertCanRequestNewContainer() {
+    /// Returns whether a new element can be encoded at this coding path.
+    ///
+    /// `true` if an element has not yet been encoded at this coding path; `false` otherwise.
+    var canEncodeNewElement: Bool {
         // Every time a new value gets encoded, the key it's encoded for is pushed onto the coding path (even if it's a nil key from an unkeyed container).
         // At the same time, every time a container is requested, a new value gets pushed onto the storage stack.
         // If there are more values on the storage stack than on the coding path, it means the value is requesting more than one container, which violates the precondition.
-
+        //
         // This means that anytime something that can request a new container goes onto the stack, we MUST push a key onto the coding path.
         // Things which will not request containers do not need to have the coding path extended for them (but it doesn't matter if it is, because they will not reach here).
-        guard self.storage.count == self.codingPath.count else {
+        return self.storage.count == self.codingPath.count
+    }
+
+    /// Asserts that a new container can be requested at this coding path.
+    /// `preconditionFailure()`s if one cannot be requested.
+    func assertCanRequestNewContainer() {
+        guard self.canEncodeNewElement else {
             let previousContainerType: String
             if self.storage.containers.last is NSDictionary {
                 previousContainerType = "keyed"
@@ -457,14 +464,14 @@ fileprivate struct _JSONUnkeyedEncodingContainer : UnkeyedEncodingContainer {
 }
 
 extension _JSONEncoder : SingleValueEncodingContainer {
-    // MARK: Utility
+    // MARK: - Utility Methods
 
     /// Asserts that a single value can be encoded at the current coding path (i.e. that one has not already been encoded through this container).
     /// `preconditionFailure()`s if one cannot be encoded.
     ///
     /// This is similar to assertCanRequestNewContainer above.
     func assertCanEncodeSingleValue() {
-        guard self.storage.count == self.codingPath.count else {
+        guard self.canEncodeNewElement else {
             let previousContainerType: String
             if self.storage.containers.last is NSDictionary {
                 previousContainerType = "keyed"
@@ -691,6 +698,9 @@ extension _JSONEncoder {
         } else if T.self == Data.self {
             // Respect Data encoding strategy
             return try self.box((value as! Data))
+        } else if T.self == URL.self {
+            // Encode URLs as single strings.
+            return self.box((value as! URL).absoluteString)
         }
 
         // The value should request a container from the _JSONEncoder.
@@ -751,24 +761,13 @@ fileprivate class _JSONReferencingEncoder : _JSONEncoder {
         self.codingPath.append(key)
     }
 
-    // MARK: - Overridden Implementations
+    // MARK: - Coding Path Operations
 
-    /// Asserts that we can add a new container at this coding path. See _JSONEncoder.assertCanRequestNewContainer for the logic behind this.
-    override func assertCanRequestNewContainer() {
-        // We can push a new container given that we won't have two containers for the same coding path.
-        // We make sure of this by comparing the number of containers we already have to the length of our coding path (we can push 1 more container than the length of the path, since it starts off empty). Since we copied our reference's coding path (and pushed on the key we were created at), we need to account for that.
-        guard self.storage.count == self.codingPath.count - self.encoder.codingPath.count - 1 else {
-            let previousContainerType: String
-            if self.storage.containers.last is NSDictionary {
-                previousContainerType = "keyed"
-            } else if self.storage.containers.last is NSArray {
-                previousContainerType = "unkeyed"
-            } else {
-                previousContainerType = "single value"
-            }
-
-            preconditionFailure("Attempt to encode with new container when already encoded with \(previousContainerType) container.")
-        }
+    override var canEncodeNewElement: Bool {
+        // With a regular encoder, the storage and coding path grow together.
+        // A referencing encoder, however, inherits its parents coding path, as well as the key it was created for.
+        // We have to take this into account.
+        return self.storage.count == self.codingPath.count - self.encoder.codingPath.count - 1
     }
 
     // MARK: - Deinitialization
@@ -1851,6 +1850,17 @@ extension _JSONDecoder {
             decoded = (try self.unbox(value, as: Date.self) as! T)
         } else if T.self == Data.self {
             decoded = (try self.unbox(value, as: Data.self) as! T)
+        } else if T.self == URL.self {
+            guard let urlString = try self.unbox(value, as: String.self) else {
+                return nil
+            }
+
+            guard let url = URL(string: urlString) else {
+                throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath,
+                                                                        debugDescription: "Invalid URL string."))
+            }
+
+            decoded = (url as! T)
         } else {
             self.storage.push(container: value)
             decoded = try T(from: self)

--- a/stdlib/public/SDK/Foundation/Locale.swift
+++ b/stdlib/public/SDK/Foundation/Locale.swift
@@ -481,3 +481,19 @@ extension NSLocale : _HasCustomAnyHashableRepresentation {
     }
 }
 
+extension Locale : Codable {
+    private enum CodingKeys : Int, CodingKey {
+        case identifier
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let identifier = try container.decode(String.self, forKey: .identifier)
+        self.init(identifier: identifier)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.identifier, forKey: .identifier)
+    }
+}

--- a/stdlib/public/SDK/Foundation/Measurement.swift
+++ b/stdlib/public/SDK/Foundation/Measurement.swift
@@ -248,3 +248,75 @@ extension MeasurementFormatter {
         }
     }
 }
+
+// @available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
+// extension Unit : Codable {
+//     public convenience init(from decoder: Decoder) throws {
+//         let container = try decoder.singleValueContainer()
+//         let symbol = try container.decode(String.self)
+//         self.init(symbol: symbol)
+//     }
+
+//     public func encode(to encoder: Encoder) throws {
+//         var container = encoder.singleValueContainer()
+//         try container.encode(self.symbol)
+//     }
+// }
+
+@available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
+extension Measurement : Codable {
+    private enum CodingKeys : Int, CodingKey {
+        case value
+        case unit
+    }
+
+    private enum UnitCodingKeys : Int, CodingKey {
+        case symbol
+        case converter
+    }
+
+    private enum LinearConverterCodingKeys : Int, CodingKey {
+        case coefficient
+        case constant
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let value = try container.decode(Double.self, forKey: .value)
+
+        let unitContainer = try container.nestedContainer(keyedBy: UnitCodingKeys.self, forKey: .unit)
+        let symbol = try unitContainer.decode(String.self, forKey: .symbol)
+
+        let unit: UnitType
+        if UnitType.self is Dimension.Type {
+            let converterContainer = try unitContainer.nestedContainer(keyedBy: LinearConverterCodingKeys.self, forKey: .converter)
+            let coefficient = try converterContainer.decode(Double.self, forKey: .coefficient)
+            let constant = try converterContainer.decode(Double.self, forKey: .constant)
+            let unitMetaType = (UnitType.self as! Dimension.Type)
+            unit = (unitMetaType.init(symbol: symbol, converter: UnitConverterLinear(coefficient: coefficient, constant: constant)) as! UnitType)
+        } else {
+            unit = UnitType(symbol: symbol)
+        }
+
+        self.init(value: value, unit: unit)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.value, forKey: .value)
+
+        var unitContainer = container.nestedContainer(keyedBy: UnitCodingKeys.self, forKey: .unit)
+        try unitContainer.encode(self.unit.symbol, forKey: .symbol)
+
+        if UnitType.self is Dimension.Type {
+            guard type(of: (self.unit as! Dimension).converter) is UnitConverterLinear.Type else {
+                preconditionFailure("Cannot encode a Measurement whose UnitType has a non-linear unit converter.")
+            }
+
+            let converter = (self.unit as! Dimension).converter as! UnitConverterLinear
+            var converterContainer = unitContainer.nestedContainer(keyedBy: LinearConverterCodingKeys.self, forKey: .converter)
+            try converterContainer.encode(converter.coefficient, forKey: .coefficient)
+            try converterContainer.encode(converter.constant, forKey: .constant)
+        }
+    }
+}

--- a/stdlib/public/SDK/Foundation/NSRange.swift
+++ b/stdlib/public/SDK/Foundation/NSRange.swift
@@ -130,3 +130,18 @@ extension NSRange : CustomPlaygroundQuickLookable {
         return .range(Int64(location), Int64(length))
     }
 }
+
+extension NSRange : Codable {
+    public init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        let location = try container.decode(Int.self)
+        let length = try container.decode(Int.self)
+        self.init(location: location, length: length)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        try container.encode(self.location)
+        try container.encode(self.length)
+    }
+}

--- a/stdlib/public/SDK/Foundation/PersonNameComponents.swift
+++ b/stdlib/public/SDK/Foundation/PersonNameComponents.swift
@@ -145,3 +145,36 @@ extension NSPersonNameComponents : _HasCustomAnyHashableRepresentation {
     }
 }
 
+@available(OSX 10.11, iOS 9.0, *)
+extension PersonNameComponents : Codable {
+    private enum CodingKeys : Int, CodingKey {
+        case namePrefix
+        case givenName
+        case middleName
+        case familyName
+        case nameSuffix
+        case nickname
+    }
+
+    public init(from decoder: Decoder) throws {
+        self.init()
+
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.namePrefix = try container.decodeIfPresent(String.self, forKey: .namePrefix)
+        self.givenName  = try container.decodeIfPresent(String.self, forKey: .givenName)
+        self.middleName = try container.decodeIfPresent(String.self, forKey: .middleName)
+        self.familyName = try container.decodeIfPresent(String.self, forKey: .familyName)
+        self.nameSuffix = try container.decodeIfPresent(String.self, forKey: .nameSuffix)
+        self.nickname   = try container.decodeIfPresent(String.self, forKey: .nickname)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        if let np = self.namePrefix { try container.encode(np, forKey: .namePrefix) }
+        if let gn = self.givenName  { try container.encode(gn, forKey: .givenName) }
+        if let mn = self.middleName { try container.encode(mn, forKey: .middleName) }
+        if let fn = self.familyName { try container.encode(fn, forKey: .familyName) }
+        if let ns = self.nameSuffix { try container.encode(ns, forKey: .nameSuffix) }
+        if let nn = self.nickname   { try container.encode(nn, forKey: .nickname) }
+    }
+}

--- a/stdlib/public/SDK/Foundation/TimeZone.swift
+++ b/stdlib/public/SDK/Foundation/TimeZone.swift
@@ -277,3 +277,25 @@ extension NSTimeZone : _HasCustomAnyHashableRepresentation {
     }
 }
 
+extension TimeZone : Codable {
+    private enum CodingKeys : Int, CodingKey {
+        case identifier
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let identifier = try container.decode(String.self, forKey: .identifier)
+
+        guard let timeZone = TimeZone(identifier: identifier) else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath,
+                                                                    debugDescription: "Invalid TimeZone identifier."))
+        }
+
+        self = timeZone
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.identifier, forKey: .identifier)
+    }
+}

--- a/stdlib/public/SDK/Foundation/URL.swift
+++ b/stdlib/public/SDK/Foundation/URL.swift
@@ -1172,6 +1172,34 @@ extension URL : CustomPlaygroundQuickLookable {
     }
 }
 
+extension URL : Codable {
+    private enum CodingKeys : Int, CodingKey {
+        case base
+        case relative
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let relative = try container.decode(String.self, forKey: .relative)
+        let base = try container.decodeIfPresent(URL.self, forKey: .base)
+
+        guard let url = URL(string: relative, relativeTo: base) else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath,
+                                                                    debugDescription: "Invalid URL string."))
+        }
+
+        self = url
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.relativeString, forKey: .relative)
+        if let base = self.baseURL {
+            try container.encode(base, forKey: .base)
+        }
+    }
+}
+
 //===----------------------------------------------------------------------===//
 // File references, for playgrounds.
 //===----------------------------------------------------------------------===//

--- a/stdlib/public/SDK/Foundation/UUID.swift
+++ b/stdlib/public/SDK/Foundation/UUID.swift
@@ -163,3 +163,21 @@ extension NSUUID : _HasCustomAnyHashableRepresentation {
     }
 }
 
+extension UUID : Codable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let uuidString = try container.decode(String.self)
+
+        guard let uuid = UUID(uuidString: uuidString) else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath,
+                                                                    debugDescription: "Attempted to decode UUID from invalid UUID string."))
+        }
+
+        self = uuid
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(self.uuidString)
+    }
+}

--- a/test/stdlib/Inputs/FoundationTestsShared.swift
+++ b/test/stdlib/Inputs/FoundationTestsShared.swift
@@ -1,0 +1,44 @@
+import Foundation
+import StdlibUnittest
+
+public func expectRoundTripEquality<T : Codable>(of value: T, encode: (T) throws -> Data, decode: (Data) throws -> T) where T : Equatable {
+    let data: Data
+    do {
+        data = try encode(value)
+    } catch {
+        fatalError("Unable to encode \(T.self) <\(value)>: \(error)")
+    }
+
+    let decoded: T
+    do {
+        decoded = try decode(data)
+    } catch {
+        fatalError("Unable to decode \(T.self) <\(value)>: \(error)")
+    }
+
+    expectEqual(value, decoded, "Decoded \(T.self) <\(decoded)> not equal to original <\(value)>")
+}
+
+public func expectRoundTripEqualityThroughJSON<T : Codable>(for value: T) where T : Equatable {
+    let encode = { (_ value: T) throws -> Data in
+        return try JSONEncoder().encode(value)
+    }
+
+    let decode = { (_ data: Data) throws -> T in
+        return try JSONDecoder().decode(T.self, from: data)
+    }
+
+    expectRoundTripEquality(of: value, encode: encode, decode: decode)
+}
+
+public func expectRoundTripEqualityThroughPlist<T : Codable>(for value: T) where T : Equatable {
+    let encode = { (_ value: T) throws -> Data in
+        return try PropertyListEncoder().encode(value)
+    }
+
+    let decode = { (_ data: Data) throws -> T in
+        return try PropertyListDecoder().decode(T.self, from: data)
+    }
+
+    expectRoundTripEquality(of: value, encode: encode, decode: decode)
+}

--- a/test/stdlib/TestAffineTransform.swift
+++ b/test/stdlib/TestAffineTransform.swift
@@ -6,11 +6,21 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// RUN: %target-run-simple-swift
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+//
+// RUN: pushd %t
+// RUN: %target-build-swift -emit-module -emit-library %S/Inputs/FoundationTestsShared.swift -module-name FoundationTestsShared -module-link-name FoundationTestsShared
+// RUN: popd %t
+//
+// RUN: %target-build-swift %s -I%t -L%t -o %t/TestAffineTransform
+// RUN: %target-run %t/TestAffineTransform
+//
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
 
 import Foundation
+import FoundationTestsShared
 
 #if os(OSX)
 
@@ -372,6 +382,46 @@ class TestAffineTransform : TestAffineTransformSuper {
     func test_unconditionallyBridgeFromObjectiveC() {
         expectEqual(AffineTransform(), AffineTransform._unconditionallyBridgeFromObjectiveC(nil))
     }
+
+    func test_EncodingRoundTrip_JSON() {
+        let values: [AffineTransform] = [
+            AffineTransform.identity,
+            AffineTransform(),
+            AffineTransform(translationByX: 2.0, byY: 2.0),
+            AffineTransform(scale: 2.0),
+            AffineTransform(rotationByDegrees: .pi / 2),
+
+            AffineTransform(m11: 1.0, m12: 2.5, m21: 66.2, m22: 40.2, tX: -5.5, tY: 3.7),
+            AffineTransform(m11: -55.66, m12: 22.7, m21: 1.5, m22: 0.0, tX: -22, tY: -33),
+            AffineTransform(m11: 4.5, m12: 1.1, m21: 0.025, m22: 0.077, tX: -0.55, tY: 33.2),
+            AffineTransform(m11: 7.0, m12: -2.3, m21: 6.7, m22: 0.25, tX: 0.556, tY: 0.99),
+            AffineTransform(m11: 0.498, m12: -0.284, m21: -0.742, m22: 0.3248, tX: 12, tY: 44)
+        ]
+
+        for transform in values {
+            expectRoundTripEqualityThroughJSON(for: transform)
+        }
+    }
+
+    func test_EncodingRoundTrip_Plist() {
+        let values: [AffineTransform] = [
+            AffineTransform.identity,
+            AffineTransform(),
+            AffineTransform(translationByX: 2.0, byY: 2.0),
+            AffineTransform(scale: 2.0),
+            AffineTransform(rotationByDegrees: .pi / 2),
+
+            AffineTransform(m11: 1.0, m12: 2.5, m21: 66.2, m22: 40.2, tX: -5.5, tY: 3.7),
+            AffineTransform(m11: -55.66, m12: 22.7, m21: 1.5, m22: 0.0, tX: -22, tY: -33),
+            AffineTransform(m11: 4.5, m12: 1.1, m21: 0.025, m22: 0.077, tX: -0.55, tY: 33.2),
+            AffineTransform(m11: 7.0, m12: -2.3, m21: 6.7, m22: 0.25, tX: 0.556, tY: 0.99),
+            AffineTransform(m11: 0.498, m12: -0.284, m21: -0.742, m22: 0.3248, tX: 12, tY: 44)
+        ]
+
+        for transform in values {
+            expectRoundTripEqualityThroughPlist(for: transform)
+        }
+    }
 }
 
 #if !FOUNDATION_XCTEST
@@ -395,6 +445,8 @@ AffineTransformTests.test("test_hashing_values") { TestAffineTransform().test_ha
 AffineTransformTests.test("test_AnyHashableContainingAffineTransform") { TestAffineTransform().test_AnyHashableContainingAffineTransform() }
 AffineTransformTests.test("test_AnyHashableCreatedFromNSAffineTransform") { TestAffineTransform().test_AnyHashableCreatedFromNSAffineTransform() }
 AffineTransformTests.test("test_unconditionallyBridgeFromObjectiveC") { TestAffineTransform().test_unconditionallyBridgeFromObjectiveC() }
+AffineTransformTests.test("test_EncodingRoundTrip_JSON") { TestAffineTransform().test_EncodingRoundTrip_JSON() }
+AffineTransformTests.test("test_EncodingRoundTrip_Plist") { TestAffineTransform().test_EncodingRoundTrip_Plist() }
 runAllTests()
 #endif
     

--- a/test/stdlib/TestCalendar.swift
+++ b/test/stdlib/TestCalendar.swift
@@ -9,15 +9,20 @@
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
 //
+// RUN: pushd %t
+// RUN: %target-build-swift -emit-module -emit-library %S/Inputs/FoundationTestsShared.swift -module-name FoundationTestsShared -module-link-name FoundationTestsShared
+// RUN: popd %t
+//
 // RUN: %target-clang %S/Inputs/FoundationBridge/FoundationBridge.m -c -o %t/FoundationBridgeObjC.o -g
-// RUN: %target-build-swift %s -I %S/Inputs/FoundationBridge/ -Xlinker %t/FoundationBridgeObjC.o -o %t/TestCalendar
-
-// RUN: %target-run %t/TestCalendar > %t.txt
+// RUN: %target-build-swift %s -I %S/Inputs/FoundationBridge/ -I%t -L%t -Xlinker %t/FoundationBridgeObjC.o -o %t/TestCalendar
+// RUN: %target-run %t/TestCalendar
+//
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
 
 import Foundation
 import FoundationBridgeObjC
+import FoundationTestsShared
 
 #if FOUNDATION_XCTEST
     import XCTest
@@ -285,6 +290,52 @@ class TestCalendar : TestCalendarSuper {
             expectEqual(anyHashables[1], anyHashables[2])
         }
     }
+
+    func test_EncodingRoundTrip_JSON() {
+        let values: [Calendar] = [
+            Calendar(identifier: .gregorian),
+            Calendar(identifier: .buddhist),
+            Calendar(identifier: .chinese),
+            Calendar(identifier: .coptic),
+            Calendar(identifier: .ethiopicAmeteMihret),
+            Calendar(identifier: .ethiopicAmeteAlem),
+            Calendar(identifier: .hebrew),
+            Calendar(identifier: .iso8601),
+            Calendar(identifier: .indian),
+            Calendar(identifier: .islamic),
+            Calendar(identifier: .islamicCivil),
+            Calendar(identifier: .japanese),
+            Calendar(identifier: .persian),
+            Calendar(identifier: .republicOfChina),
+        ]
+
+        for calendar in values {
+            expectRoundTripEqualityThroughJSON(for: calendar)
+        }
+    }
+
+    func test_EncodingRoundTrip_Plist() {
+        let values: [Calendar] = [
+            Calendar(identifier: .gregorian),
+            Calendar(identifier: .buddhist),
+            Calendar(identifier: .chinese),
+            Calendar(identifier: .coptic),
+            Calendar(identifier: .ethiopicAmeteMihret),
+            Calendar(identifier: .ethiopicAmeteAlem),
+            Calendar(identifier: .hebrew),
+            Calendar(identifier: .iso8601),
+            Calendar(identifier: .indian),
+            Calendar(identifier: .islamic),
+            Calendar(identifier: .islamicCivil),
+            Calendar(identifier: .japanese),
+            Calendar(identifier: .persian),
+            Calendar(identifier: .republicOfChina),
+        ]
+
+        for calendar in values {
+            expectRoundTripEqualityThroughPlist(for: calendar)
+        }
+    }
 }
 
 #if !FOUNDATION_XCTEST
@@ -295,5 +346,7 @@ CalendarTests.test("test_equality") { TestCalendar().test_equality() }
 CalendarTests.test("test_properties") { TestCalendar().test_properties() }
 CalendarTests.test("test_AnyHashableContainingCalendar") { TestCalendar().test_AnyHashableContainingCalendar() }
 CalendarTests.test("test_AnyHashableCreatedFromNSCalendar") { TestCalendar().test_AnyHashableCreatedFromNSCalendar() }
+CalendarTests.test("test_EncodingRoundTrip_JSON") { TestCalendar().test_EncodingRoundTrip_JSON() }
+CalendarTests.test("test_EncodingRoundTrip_Plist") { TestCalendar().test_EncodingRoundTrip_Plist() }
 runAllTests()
 #endif

--- a/test/stdlib/TestCharacterSet.swift
+++ b/test/stdlib/TestCharacterSet.swift
@@ -6,11 +6,21 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// RUN: %target-run-simple-swift
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+//
+// RUN: pushd %t
+// RUN: %target-build-swift -emit-module -emit-library %S/Inputs/FoundationTestsShared.swift -module-name FoundationTestsShared -module-link-name FoundationTestsShared
+// RUN: popd %t
+//
+// RUN: %target-build-swift %s -I%t -L%t -o %t/TestCharacterSet
+// RUN: %target-run %t/TestCharacterSet
+//
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
 
 import Foundation
+import FoundationTestsShared
 
 #if FOUNDATION_XCTEST
 import XCTest
@@ -305,6 +315,54 @@ class TestCharacterSet : TestCharacterSetSuper {
     func test_unconditionallyBridgeFromObjectiveC() {
         expectEqual(CharacterSet(), CharacterSet._unconditionallyBridgeFromObjectiveC(nil))
     }
+
+    func test_EncodingRoundTrip_JSON() {
+        let values: [CharacterSet] = [
+            CharacterSet.controlCharacters,
+            CharacterSet.whitespaces,
+            CharacterSet.whitespacesAndNewlines,
+            CharacterSet.decimalDigits,
+            CharacterSet.letters,
+            CharacterSet.lowercaseLetters,
+            CharacterSet.uppercaseLetters,
+            CharacterSet.nonBaseCharacters,
+            CharacterSet.alphanumerics,
+            CharacterSet.decomposables,
+            CharacterSet.illegalCharacters,
+            CharacterSet.punctuationCharacters,
+            CharacterSet.capitalizedLetters,
+            CharacterSet.symbols,
+            CharacterSet.newlines
+        ]
+
+        for characterSet in values {
+            expectRoundTripEqualityThroughJSON(for: characterSet)
+        }
+    }
+
+    func test_EncodingRoundTrip_Plist() {
+        let values: [CharacterSet] = [
+            CharacterSet.controlCharacters,
+            CharacterSet.whitespaces,
+            CharacterSet.whitespacesAndNewlines,
+            CharacterSet.decimalDigits,
+            CharacterSet.letters,
+            CharacterSet.lowercaseLetters,
+            CharacterSet.uppercaseLetters,
+            CharacterSet.nonBaseCharacters,
+            CharacterSet.alphanumerics,
+            CharacterSet.decomposables,
+            CharacterSet.illegalCharacters,
+            CharacterSet.punctuationCharacters,
+            CharacterSet.capitalizedLetters,
+            CharacterSet.symbols,
+            CharacterSet.newlines
+        ]
+
+        for characterSet in values {
+            expectRoundTripEqualityThroughPlist(for: characterSet)
+        }
+    }
 }
 
 #if !FOUNDATION_XCTEST
@@ -330,6 +388,8 @@ CharacterSetTests.test("test_bitmap") { TestCharacterSet().test_bitmap() }
 CharacterSetTests.test("test_setOperationsOfEmptySet") { TestCharacterSet().test_setOperationsOfEmptySet() }
 CharacterSetTests.test("test_moreSetOperations") { TestCharacterSet().test_moreSetOperations() }
 CharacterSetTests.test("test_unconditionallyBridgeFromObjectiveC") { TestCharacterSet().test_unconditionallyBridgeFromObjectiveC() }
+CharacterSetTests.test("test_EncodingRoundTrip_JSON") { TestCharacterSet().test_EncodingRoundTrip_JSON() }
+CharacterSetTests.test("test_EncodingRoundTrip_Plist") { TestCharacterSet().test_EncodingRoundTrip_Plist() }
 runAllTests()
 #endif
 

--- a/test/stdlib/TestDateComponents.swift
+++ b/test/stdlib/TestDateComponents.swift
@@ -1,0 +1,64 @@
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+//
+// RUN: pushd %t
+// RUN: %target-build-swift -emit-module -emit-library %S/Inputs/FoundationTestsShared.swift -module-name FoundationTestsShared -module-link-name FoundationTestsShared
+// RUN: popd %t
+//
+// RUN: %target-build-swift %s -I%t -L%t -o %t/TestDateComponents
+// RUN: %target-run %t/TestDateComponents
+//
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+import Foundation
+import FoundationTestsShared
+
+#if FOUNDATION_XCTEST
+import XCTest
+class TestDateComponentsSuper : XCTestCase { }
+#else
+import StdlibUnittest
+class TestDateComponentsSuper { }
+#endif
+
+class TestDateComponents : TestDateComponentsSuper {
+    func test_EncodingRoundTrip_JSON() {
+        let components: Set<Calendar.Component> = [
+            .era, .year, .month, .day, .hour, .minute, .second, .nanosecond,
+            .weekday, .weekdayOrdinal, .quarter, .weekOfMonth, .weekOfYear,
+            .yearForWeekOfYear, .timeZone, .calendar
+        ]
+
+        let calendar = Calendar(identifier: .gregorian)
+        let dateComponents = calendar.dateComponents(components, from: Date())
+        expectRoundTripEqualityThroughJSON(for: dateComponents)
+    }
+
+    func test_EncodingRoundTrip_Plist() {
+        let components: Set<Calendar.Component> = [
+            .era, .year, .month, .day, .hour, .minute, .second, .nanosecond,
+            .weekday, .weekdayOrdinal, .quarter, .weekOfMonth, .weekOfYear,
+            .yearForWeekOfYear, .timeZone, .calendar
+        ]
+
+        let calendar = Calendar(identifier: .gregorian)
+        let dateComponents = calendar.dateComponents(components, from: Date())
+        expectRoundTripEqualityThroughPlist(for: dateComponents)
+    }
+}
+
+#if !FOUNDATION_XCTEST
+var DateComponentsTests = TestSuite("TestDateComponents")
+DateComponentsTests.test("test_EncodingRoundTrip_JSON") { TestDateComponents().test_EncodingRoundTrip_JSON() }
+DateComponentsTests.test("test_EncodingRoundTrip_Plist") { TestDateComponents().test_EncodingRoundTrip_Plist() }
+runAllTests()
+#endif

--- a/test/stdlib/TestDateInterval.swift
+++ b/test/stdlib/TestDateInterval.swift
@@ -6,11 +6,21 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// RUN: %target-run-simple-swift
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+//
+// RUN: pushd %t
+// RUN: %target-build-swift -emit-module -emit-library %S/Inputs/FoundationTestsShared.swift -module-name FoundationTestsShared -module-link-name FoundationTestsShared
+// RUN: popd %t
+//
+// RUN: %target-build-swift %s -I%t -L%t -o %t/TestDateInterval
+// RUN: %target-run %t/TestDateInterval
+//
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
 
 import Foundation
+import FoundationTestsShared
 
 #if FOUNDATION_XCTEST
 import XCTest
@@ -165,6 +175,38 @@ class TestDateInterval : TestDateIntervalSuper {
             expectEqual(anyHashables[1], anyHashables[2])
         }
     }
+
+    func test_EncodingRoundTrip_JSON() {
+        if #available(iOS 10.10, OSX 10.12, tvOS 10.0, watchOS 3.0, *) {
+            let now = Date()
+            let values: [DateInterval] = [
+                DateInterval(),
+                DateInterval(start: Date.distantPast, end: now),
+                DateInterval(start: now, end: Date.distantFuture),
+                DateInterval(start: Date.distantPast, end: Date.distantFuture)
+            ]
+
+            for interval in values {
+                expectRoundTripEqualityThroughJSON(for: interval)
+            }
+        }
+    }
+
+    func test_EncodingRoundTrip_Plist() {
+        if #available(iOS 10.10, OSX 10.12, tvOS 10.0, watchOS 3.0, *) {
+            let now = Date()
+            let values: [DateInterval] = [
+                DateInterval(),
+                DateInterval(start: Date.distantPast, end: now),
+                DateInterval(start: now, end: Date.distantFuture),
+                DateInterval(start: Date.distantPast, end: Date.distantFuture)
+            ]
+
+            for interval in values {
+                expectRoundTripEqualityThroughPlist(for: interval)
+            }
+        }
+    }
 }
 
 #if !FOUNDATION_XCTEST
@@ -175,5 +217,7 @@ DateIntervalTests.test("test_checkIntersection") { TestDateInterval().test_check
 DateIntervalTests.test("test_validIntersections") { TestDateInterval().test_validIntersections() }
 DateIntervalTests.test("test_AnyHashableContainingDateInterval") { TestDateInterval().test_AnyHashableContainingDateInterval() }
 DateIntervalTests.test("test_AnyHashableCreatedFromNSDateInterval") { TestDateInterval().test_AnyHashableCreatedFromNSDateInterval() }
+DateIntervalTests.test("test_EncodingRoundTrip_JSON") { TestDateInterval().test_EncodingRoundTrip_JSON() }
+DateIntervalTests.test("test_EncodingRoundTrip_Plist") { TestDateInterval().test_EncodingRoundTrip_Plist() }
 runAllTests()
 #endif

--- a/test/stdlib/TestIndexPath.swift
+++ b/test/stdlib/TestIndexPath.swift
@@ -6,11 +6,21 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// RUN: %target-run-simple-swift
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+//
+// RUN: pushd %t
+// RUN: %target-build-swift -emit-module -emit-library %S/Inputs/FoundationTestsShared.swift -module-name FoundationTestsShared -module-link-name FoundationTestsShared
+// RUN: popd %t
+//
+// RUN: %target-build-swift %s -I%t -L%t -o %t/TestIndexPath
+// RUN: %target-run %t/TestIndexPath
+//
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
 
 import Foundation
+import FoundationTestsShared
 
 #if FOUNDATION_XCTEST
 import XCTest
@@ -711,6 +721,32 @@ class TestIndexPath: TestIndexPathSuper {
     func test_unconditionallyBridgeFromObjectiveC() {
         expectEqual(IndexPath(), IndexPath._unconditionallyBridgeFromObjectiveC(nil))
     }
+
+    func test_RoundTripEncoding_JSON() {
+        let values: [IndexPath] = [
+            IndexPath(), // empty
+            IndexPath(index: 0), // single
+            IndexPath(indexes: [1, 2]), // pair
+            IndexPath(indexes: [3, 4, 5, 6, 7, 8]), // array
+        ]
+
+        for indexPath in values {
+            expectRoundTripEqualityThroughJSON(for: indexPath)
+        }
+    }
+
+    func test_RoundTripEncoding_Plist() {
+        let values: [IndexPath] = [
+            IndexPath(), // empty
+            IndexPath(index: 0), // single
+            IndexPath(indexes: [1, 2]), // pair
+            IndexPath(indexes: [3, 4, 5, 6, 7, 8]), // array
+        ]
+
+        for indexPath in values {
+            expectRoundTripEqualityThroughPlist(for: indexPath)
+        }
+    }
 }
 
 #if !FOUNDATION_XCTEST
@@ -762,5 +798,7 @@ IndexPathTests.test("testObjcBridgeType") { TestIndexPath().testObjcBridgeType()
 IndexPathTests.test("test_AnyHashableContainingIndexPath") { TestIndexPath().test_AnyHashableContainingIndexPath() }
 IndexPathTests.test("test_AnyHashableCreatedFromNSIndexPath") { TestIndexPath().test_AnyHashableCreatedFromNSIndexPath() }
 IndexPathTests.test("test_unconditionallyBridgeFromObjectiveC") { TestIndexPath().test_unconditionallyBridgeFromObjectiveC() }
+IndexPathTests.test("test_RoundTripEncoding_JSON") { TestIndexPath().test_RoundTripEncoding_JSON() }
+IndexPathTests.test("test_RoundTripEncoding_Plist") { TestIndexPath().test_RoundTripEncoding_Plist() }
 runAllTests()
 #endif

--- a/test/stdlib/TestIndexSet.swift
+++ b/test/stdlib/TestIndexSet.swift
@@ -6,11 +6,21 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// RUN: %target-run-simple-swift
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+//
+// RUN: pushd %t
+// RUN: %target-build-swift -emit-module -emit-library %S/Inputs/FoundationTestsShared.swift -module-name FoundationTestsShared -module-link-name FoundationTestsShared
+// RUN: popd %t
+//
+// RUN: %target-build-swift %s -I%t -L%t -o %t/TestIndexSet
+// RUN: %target-run %t/TestIndexSet
+//
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
 
 import Foundation
+import FoundationTestsShared
 
 #if FOUNDATION_XCTEST
 import XCTest
@@ -823,6 +833,30 @@ class TestIndexSet : TestIndexSetSuper {
     func test_unconditionallyBridgeFromObjectiveC() {
         expectEqual(IndexSet(), IndexSet._unconditionallyBridgeFromObjectiveC(nil))
     }
+
+    func test_EncodingRoundTrip_JSON() {
+        let values: [IndexSet] = [
+            IndexSet(),
+            IndexSet(integer: 42),
+            IndexSet(integersIn: 0 ..< Int.max)
+        ]
+
+        for indexSet in values {
+            expectRoundTripEqualityThroughJSON(for: indexSet)
+        }
+    }
+
+    func test_EncodingRoundTrip_Plist() {
+        let values: [IndexSet] = [
+            IndexSet(),
+            IndexSet(integer: 42),
+            IndexSet(integersIn: 0 ..< Int.max)
+        ]
+
+        for indexSet in values {
+            expectRoundTripEqualityThroughPlist(for: indexSet)
+        }
+    }
 }
 
 #if !FOUNDATION_XCTEST
@@ -849,6 +883,8 @@ IndexSetTests.test("test_findIndex") { TestIndexSet().test_findIndex() }
 IndexSetTests.test("test_AnyHashableContainingIndexSet") { TestIndexSet().test_AnyHashableContainingIndexSet() }
 IndexSetTests.test("test_AnyHashableCreatedFromNSIndexSet") { TestIndexSet().test_AnyHashableCreatedFromNSIndexSet() }
 IndexSetTests.test("test_unconditionallyBridgeFromObjectiveC") { TestIndexSet().test_unconditionallyBridgeFromObjectiveC() }
+IndexSetTests.test("test_EncodingRoundTrip_JSON") { TestIndexSet().test_EncodingRoundTrip_JSON() }
+IndexSetTests.test("test_EncodingRoundTrip_Plist") { TestIndexSet().test_EncodingRoundTrip_Plist() }
 runAllTests()
 #endif
 

--- a/test/stdlib/TestLocale.swift
+++ b/test/stdlib/TestLocale.swift
@@ -9,15 +9,20 @@
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
 //
+// RUN: pushd %t
+// RUN: %target-build-swift -emit-module -emit-library %S/Inputs/FoundationTestsShared.swift -module-name FoundationTestsShared -module-link-name FoundationTestsShared
+// RUN: popd %t
+//
 // RUN: %target-clang %S/Inputs/FoundationBridge/FoundationBridge.m -c -o %t/FoundationBridgeObjC.o -g
-// RUN: %target-build-swift %s -I %S/Inputs/FoundationBridge/ -Xlinker %t/FoundationBridgeObjC.o -o %t/TestLocale
-
-// RUN: %target-run %t/TestLocale > %t.txt
+// RUN: %target-build-swift %s -I %S/Inputs/FoundationBridge/ -I%t -L%t -Xlinker %t/FoundationBridgeObjC.o -o %t/TestLocale
+// RUN: %target-run %t/TestLocale
+//
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
 
 import Foundation
 import FoundationBridgeObjC
+import FoundationTestsShared
 
 #if FOUNDATION_XCTEST
     import XCTest
@@ -136,6 +141,40 @@ class TestLocale : TestLocaleSuper {
         expectNotEqual(anyHashables[0], anyHashables[1])
         expectEqual(anyHashables[1], anyHashables[2])
     }
+
+    func test_EncodingRoundTrip_JSON() {
+        let values: [Locale] = [
+            Locale(identifier: ""),
+            Locale(identifier: "en"),
+            Locale(identifier: "en_US"),
+            Locale(identifier: "en_US_POSIX"),
+            Locale(identifier: "uk"),
+            Locale(identifier: "fr_FR"),
+            Locale(identifier: "fr_BE"),
+            Locale(identifier: "zh-Hant-HK")
+        ]
+
+        for locale in values {
+            expectRoundTripEqualityThroughJSON(for: locale)
+        }
+    }
+
+    func test_EncodingRoundTrip_Plist() {
+        let values: [Locale] = [
+            Locale(identifier: ""),
+            Locale(identifier: "en"),
+            Locale(identifier: "en_US"),
+            Locale(identifier: "en_US_POSIX"),
+            Locale(identifier: "uk"),
+            Locale(identifier: "fr_FR"),
+            Locale(identifier: "fr_BE"),
+            Locale(identifier: "zh-Hant-HK")
+        ]
+
+        for locale in values {
+            expectRoundTripEqualityThroughPlist(for: locale)
+        }
+    }
 }
 
 #if !FOUNDATION_XCTEST
@@ -146,5 +185,7 @@ LocaleTests.test("test_localizedStringFunctions") { TestLocale().test_localizedS
 LocaleTests.test("test_properties") { TestLocale().test_properties() }
 LocaleTests.test("test_AnyHashableContainingLocale") { TestLocale().test_AnyHashableContainingLocale() }
 LocaleTests.test("test_AnyHashableCreatedFromNSLocale") { TestLocale().test_AnyHashableCreatedFromNSLocale() }
+LocaleTests.test("test_EncodingRoundTrip_JSON") { TestLocale().test_EncodingRoundTrip_JSON() }
+LocaleTests.test("test_EncodingRoundTrip_Plist") { TestLocale().test_EncodingRoundTrip_Plist() }
 runAllTests()
 #endif

--- a/test/stdlib/TestMeasurement.swift
+++ b/test/stdlib/TestMeasurement.swift
@@ -6,11 +6,21 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// RUN: %target-run-simple-swift
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+//
+// RUN: pushd %t
+// RUN: %target-build-swift -emit-module -emit-library %S/Inputs/FoundationTestsShared.swift -module-name FoundationTestsShared -module-link-name FoundationTestsShared
+// RUN: popd %t
+//
+// RUN: %target-build-swift %s -I%t -L%t -o %t/TestMeasurement
+// RUN: %target-run %t/TestMeasurement
+//
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
 
 import Foundation
+import FoundationTestsShared
 
 #if FOUNDATION_XCTEST
     import XCTest
@@ -178,6 +188,30 @@ class TestMeasurement : TestMeasurementSuper {
         expectNotEqual(anyHashables[0], anyHashables[1])
         expectEqual(anyHashables[1], anyHashables[2])
     }
+
+    func test_EncodingRoundTrip_JSON() {
+        let measurements = [
+            Measurement(value: 1, unit: MyDimensionalUnit.unitA),
+            Measurement(value: 1, unit: MyDimensionalUnit.unitKiloA),
+            Measurement(value: 1, unit: MyDimensionalUnit.unitMegaA)
+        ]
+
+        for measurement in measurements {
+            expectRoundTripEqualityThroughJSON(for: measurement)
+        }
+    }
+
+    func test_EncodingRoundTrip_Plist() {
+        let measurements = [
+            Measurement(value: 1, unit: MyDimensionalUnit.unitA),
+            Measurement(value: 1, unit: MyDimensionalUnit.unitKiloA),
+            Measurement(value: 1, unit: MyDimensionalUnit.unitMegaA)
+        ]
+
+        for measurement in measurements {
+            expectRoundTripEqualityThroughPlist(for: measurement)
+        }
+    }
 }
 
 #if !FOUNDATION_XCTEST
@@ -191,7 +225,9 @@ if #available(OSX 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *) {
     MeasurementTests.test("testEquality") { TestMeasurement().testEquality() }
     MeasurementTests.test("testComparison") { TestMeasurement().testComparison() }
     MeasurementTests.test("test_AnyHashableContainingMeasurement") { TestMeasurement().test_AnyHashableContainingMeasurement() }
-  MeasurementTests.test("test_AnyHashableCreatedFromNSMeasurement") { TestMeasurement().test_AnyHashableCreatedFromNSMeasurement() }
+    MeasurementTests.test("test_AnyHashableCreatedFromNSMeasurement") { TestMeasurement().test_AnyHashableCreatedFromNSMeasurement() }
+    MeasurementTests.test("test_EncodingRoundTrip_JSON") { TestMeasurement().test_EncodingRoundTrip_JSON() }
+    MeasurementTests.test("test_EncodingRoundTrip_Plist") { TestMeasurement().test_EncodingRoundTrip_Plist() }
     runAllTests()
 }
 #endif

--- a/test/stdlib/TestNSRange.swift
+++ b/test/stdlib/TestNSRange.swift
@@ -1,0 +1,65 @@
+
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+//
+// RUN: pushd %t
+// RUN: %target-build-swift -emit-module -emit-library %S/Inputs/FoundationTestsShared.swift -module-name FoundationTestsShared -module-link-name FoundationTestsShared
+// RUN: popd %t
+//
+// RUN: %target-build-swift %s -I%t -L%t -o %t/TestNSRange
+// RUN: %target-run %t/TestNSRange
+//
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+import Foundation
+import FoundationTestsShared
+
+#if FOUNDATION_XCTEST
+import XCTest
+class TestNSRangeSuper : XCTestCase { }
+#else
+import StdlibUnittest
+class TestNSRangeSuper { }
+#endif
+
+class TestNSRange : TestNSRangeSuper {
+    func test_EncodingRoundTrip_JSON() {
+        let values: [NSRange] = [
+            NSRange(),
+            NSRange(location: 0, length: Int.max),
+            NSRange(location: NSNotFound, length: 0)
+        ]
+
+        for range in values {
+            expectRoundTripEqualityThroughJSON(for: range)
+        }
+    }
+
+    func test_EncodingRoundTrip_Plist() {
+        let values: [NSRange] = [
+            NSRange(),
+            NSRange(location: 0, length: Int.max),
+            NSRange(location: NSNotFound, length: 0)
+        ]
+
+        for range in values {
+            expectRoundTripEqualityThroughPlist(for: range)
+        }
+    }
+}
+
+#if !FOUNDATION_XCTEST
+var NSRangeTests = TestSuite("TestNSRange")
+NSRangeTests.test("test_EncodingRoundTrip_JSON") { TestNSRange().test_EncodingRoundTrip_JSON() }
+NSRangeTests.test("test_EncodingRoundTrip_Plist") { TestNSRange().test_EncodingRoundTrip_Plist() }
+runAllTests()
+#endif

--- a/test/stdlib/TestURL.swift
+++ b/test/stdlib/TestURL.swift
@@ -6,11 +6,21 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// RUN: %target-run-simple-swift
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+//
+// RUN: pushd %t
+// RUN: %target-build-swift -emit-module -emit-library %S/Inputs/FoundationTestsShared.swift -module-name FoundationTestsShared -module-link-name FoundationTestsShared
+// RUN: popd %t
+//
+// RUN: %target-build-swift %s -I%t -L%t -o %t/TestURL
+// RUN: %target-run %t/TestURL
+//
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
 
 import Foundation
+import FoundationTestsShared
 
 #if FOUNDATION_XCTEST
 import XCTest
@@ -376,6 +386,40 @@ class TestURL : TestURLSuper {
         expectNotEqual(anyHashables[0], anyHashables[1])
         expectEqual(anyHashables[1], anyHashables[2])
     }
+
+    func test_EncodingRoundTrip_JSON() {
+        var values: [URL] = [
+            URL(fileURLWithPath: NSTemporaryDirectory()),
+            URL(fileURLWithPath: "/"),
+            URL(string: "http://apple.com")!,
+            URL(string: "swift", relativeTo: URL(string: "http://apple.com")!)!
+        ]
+
+        if #available(OSX 10.11, iOS 9.0, *) {
+            values.append(URL(fileURLWithPath: "bin/sh", relativeTo: URL(fileURLWithPath: "/")))
+        }
+
+        for url in values {
+            expectRoundTripEqualityThroughJSON(for: url)
+        }
+    }
+
+    func test_EncodingRoundTrip_Plist() {
+        var values: [URL] = [
+            URL(fileURLWithPath: NSTemporaryDirectory()),
+            URL(fileURLWithPath: "/"),
+            URL(string: "http://apple.com")!,
+            URL(string: "swift", relativeTo: URL(string: "http://apple.com")!)!
+        ]
+
+        if #available(OSX 10.11, iOS 9.0, *) {
+            values.append(URL(fileURLWithPath: "bin/sh", relativeTo: URL(fileURLWithPath: "/")))
+        }
+
+        for url in values {
+            expectRoundTripEqualityThroughPlist(for: url)
+        }
+    }
 }
 
 #if !FOUNDATION_XCTEST
@@ -397,5 +441,7 @@ URLTests.test("test_AnyHashableContainingURLQueryItem") { TestURL().test_AnyHash
 URLTests.test("test_AnyHashableCreatedFromNSURLQueryItem") { TestURL().test_AnyHashableCreatedFromNSURLQueryItem() }
 URLTests.test("test_AnyHashableContainingURLRequest") { TestURL().test_AnyHashableContainingURLRequest() }
 URLTests.test("test_AnyHashableCreatedFromNSURLRequest") { TestURL().test_AnyHashableCreatedFromNSURLRequest() }
+URLTests.test("test_EncodingRoundTrip_JSON") { TestURL().test_EncodingRoundTrip_JSON() }
+URLTests.test("test_EncodingRoundTrip_Plist") { TestURL().test_EncodingRoundTrip_Plist() }
 runAllTests()
 #endif


### PR DESCRIPTION
**What's in this pull request**
Add conformances + unit tests for
* CGFloat
* AffineTransform
* Calendar
* CharacterSet
* DateComponents
* DateInterval
* Decimal
* IndexPath
* IndexSet
* Locale
* Measurement
* NSRange
* PersonNameComponents
* TimeZone
* URL
* UUID

along with some unit tests for each.

Resolves [SR-4789](https://bugs.swift.org/browse/SR-4789) and [SR-4790](https://bugs.swift.org/browse/SR-4790).