### PR TITLE
Update where clause warning to error for Swift 4

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1413,7 +1413,7 @@ WARNING(swift3_where_inside_brackets,none,
         "'where' clause next to generic parameters is deprecated "
         "and will be removed in the future version of Swift", ())
 ERROR(where_inside_brackets,none,
-        "'where' clause next to generic parameters is deprecated", ())
+        "'where' clause next to generic parameters is obsoleted", ())
 
 //------------------------------------------------------------------------------
 // Conditional compilation parsing diagnostics

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1413,7 +1413,7 @@ WARNING(swift3_where_inside_brackets,none,
         "'where' clause next to generic parameters is deprecated "
         "and will be removed in the future version of Swift", ())
 ERROR(where_inside_brackets,none,
-        "'where' clause next to generic parameters is deprecated.", ())
+        "'where' clause next to generic parameters is deprecated", ())
 
 //------------------------------------------------------------------------------
 // Conditional compilation parsing diagnostics

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1409,9 +1409,11 @@ ERROR(where_without_generic_params,none,
       "'where' clause cannot be attached to "
       "%select{a non-generic|a protocol|an associated type}0 "
       "declaration", (unsigned))
-WARNING(where_inside_brackets,none,
+WARNING(swift3_where_inside_brackets,none,
         "'where' clause next to generic parameters is deprecated "
         "and will be removed in the future version of Swift", ())
+ERROR(where_inside_brackets,none,
+        "'where' clause next to generic parameters is deprecated.", ())
 
 //------------------------------------------------------------------------------
 // Conditional compilation parsing diagnostics

--- a/lib/Parse/ParseGeneric.cpp
+++ b/lib/Parse/ParseGeneric.cpp
@@ -205,11 +205,11 @@ Parser::diagnoseWhereClauseInGenericParamList(const GenericParamList *
     WhereClauseText << ',';
 
   // For Swift 3, keep this warning. 
-  const Diagnostic message = Context.isSwiftVersion3() 
+  const auto Message = Context.isSwiftVersion3() 
                              ? diag::swift3_where_inside_brackets 
                              : diag::where_inside_brackets;
 
-  auto Diag = diagnose(WhereRangeInsideBrackets.Start, message);
+  auto Diag = diagnose(WhereRangeInsideBrackets.Start, Message);
 
   Diag.fixItRemoveChars(RemoveWhereRange.getStart(),
                         RemoveWhereRange.getEnd());

--- a/lib/Parse/ParseGeneric.cpp
+++ b/lib/Parse/ParseGeneric.cpp
@@ -204,8 +204,13 @@ Parser::diagnoseWhereClauseInGenericParamList(const GenericParamList *
   if (Tok.is(tok::kw_where))
     WhereClauseText << ',';
 
-  auto Diag = diagnose(WhereRangeInsideBrackets.Start,
-                       diag::where_inside_brackets);
+  // For Swift 3, keep this warning. 
+  const Diagnostic message = Context.isSwiftVersion3() 
+                             ? diag::swift3_where_inside_brackets 
+                             : diag::where_inside_brackets;
+
+  auto Diag = diagnose(WhereRangeInsideBrackets.Start, message);
+
   Diag.fixItRemoveChars(RemoveWhereRange.getStart(),
                         RemoveWhereRange.getEnd());
 

--- a/test/Compatibility/deprecated_where_swift.swift
+++ b/test/Compatibility/deprecated_where_swift.swift
@@ -1,0 +1,82 @@
+// RUN: %target-swift-frontend -typecheck -verify %s -swift-version 3
+
+protocol Mashable { }
+protocol Womparable { }
+
+// FuncDecl: Choose 0
+func f1<T>(x: T) {}
+
+// FuncDecl: Choose 1
+// 1: Inherited constraint
+func f2<T: Mashable>(x: T) {} // no-warning
+// 2: Non-trailing where
+func f3<T where T: Womparable>(x: T) {} // expected-warning {{'where' clause next to generic parameters is deprecated and will be removed in the future version of Swift}} {{10-30=}} {{37-37= where T: Womparable}}
+// 3: Has return type
+func f4<T>(x: T) -> Int { return 2 } // no-warning
+// 4: Trailing where
+func f5<T>(x: T) where T : Equatable {} // no-warning
+
+// FuncDecl: Choose 2
+// 1,2
+func f12<T: Mashable where T: Womparable>(x: T) {} // expected-warning {{'where' clause next to generic parameters is deprecated and will be removed in the future version of Swift}} {{21-41=}} {{48-48= where T: Womparable}}
+// 1,3
+func f13<T: Mashable>(x: T) -> Int { return 2 } // no-warning
+// 1,4
+func f14<T: Mashable>(x: T) where T: Equatable {} // no-warning
+// 2,3
+func f23<T where T: Womparable>(x: T) -> Int { return 2 } // expected-warning {{'where' clause next to generic parameters is deprecated and will be removed in the future version of Swift}} {{11-31=}} {{45-45= where T: Womparable}}
+// 2,4
+func f24<T where T: Womparable>(x: T) where T: Equatable {} // expected-warning {{'where' clause next to generic parameters is deprecated and will be removed in the future version of Swift}} {{11-31=}} {{39-44=where T: Womparable,}}
+// 3,4
+func f34<T>(x: T) -> Int where T: Equatable { return 2 } // no-warning
+
+// FuncDecl: Choose 3
+// 1,2,3
+func f123<T: Mashable where T: Womparable>(x: T) -> Int { return 2 } // expected-warning {{'where' clause next to generic parameters is deprecated and will be removed in the future version of Swift}} {{22-42=}} {{56-56= where T: Womparable}}
+// 1,2,4
+func f124<T: Mashable where T: Womparable>(x: T) where T: Equatable {} // expected-warning {{'where' clause next to generic parameters is deprecated and will be removed in the future version of Swift}} {{22-42=}} {{50-55=where T: Womparable,}}
+// 2,3,4
+func f234<T where T: Womparable>(x: T) -> Int where T: Equatable { return 2 } // expected-warning {{'where' clause next to generic parameters is deprecated and will be removed in the future version of Swift}} {{12-32=}} {{47-52=where T: Womparable,}}
+
+// FuncDecl: Choose 4
+// 1,2,3,4
+func f1234<T: Mashable where T: Womparable>(x: T) -> Int where T: Equatable { return 2 } // expected-warning {{'where' clause next to generic parameters is deprecated and will be removed in the future version of Swift}} {{23-43=}} {{58-63=where T: Womparable,}}
+
+
+
+// NominalTypeDecl: Choose 0
+struct S0<T> {}
+
+// NominalTypeDecl: Choose 1
+// 1: Inherited constraint
+struct S1<T: Mashable> {} // no-warning
+// 2: Non-trailing where
+struct S2<T where T: Womparable> {} // expected-warning {{'where' clause next to generic parameters is deprecated and will be removed in the future version of Swift}} {{12-32=}} {{33-33= where T: Womparable}}
+// 3: Trailing where
+struct S3<T> where T : Equatable {} // no-warning
+
+// NominalTypeDecl: Choose 2
+// 1,2
+struct S12<T: Mashable where T: Womparable> {} // expected-warning {{'where' clause next to generic parameters is deprecated and will be removed in the future version of Swift}} {{23-43=}} {{44-44= where T: Womparable}}
+// 1,3
+struct S13<T: Mashable> where T: Equatable {} // no-warning
+// 2,3
+struct S23<T where T: Womparable> where T: Equatable {} // expected-warning {{'where' clause next to generic parameters is deprecated and will be removed in the future version of Swift}} {{13-33=}} {{35-40=where T: Womparable,}}
+
+// NominalTypeDecl: Choose 3
+// 1,2,3
+struct S123<T: Mashable where T: Womparable> where T: Equatable {} // expected-warning {{'where' clause next to generic parameters is deprecated and will be removed in the future version of Swift}} {{24-44=}} {{46-51=where T: Womparable,}}
+
+
+protocol ProtoA {}
+protocol ProtoB {}
+protocol ProtoC {}
+protocol ProtoD {}
+func testCombinedConstraints<T: ProtoA & ProtoB where T: ProtoC>(x: T) {} // expected-warning {{'where' clause next to generic parameters is deprecated and will be removed in the future version of Swift}} {{48-64=}} {{71-71= where T: ProtoC}}
+func testCombinedConstraints<T: ProtoA & ProtoB where T: ProtoC>(x: T) where T: ProtoD {} // expected-warning {{'where' clause next to generic parameters is deprecated and will be removed in the future version of Swift}} {{48-64=}} {{72-77=where T: ProtoC,}}
+
+func testCombinedConstraintsOld<T: protocol<ProtoA, ProtoB> where T: ProtoC>(x: T) {} // expected-warning {{'where' clause next to generic parameters is deprecated and will be removed in the future version of Swift}} {{60-76=}} {{83-83= where T: ProtoC}}
+// expected-warning@-1 {{'protocol<...>' composition syntax is deprecated}}
+func testCombinedConstraintsOld<T: protocol<ProtoA, ProtoB> where T: ProtoC>(x: T) where T: ProtoD {} // expected-warning {{'where' clause next to generic parameters is deprecated and will be removed in the future version of Swift}} {{60-76=}} {{84-89=where T: ProtoC,}}
+// expected-warning@-1 {{'protocol<...>' composition syntax is deprecated}}
+

--- a/test/Parse/deprecated_where.swift
+++ b/test/Parse/deprecated_where.swift
@@ -10,7 +10,7 @@ func f1<T>(x: T) {}
 // 1: Inherited constraint
 func f2<T: Mashable>(x: T) {} // no-warning
 // 2: Non-trailing where
-func f3<T where T: Womparable>(x: T) {} // expected-error {{'where' clause next to generic parameters is deprecated}} {{10-30=}} {{37-37= where T: Womparable}}
+func f3<T where T: Womparable>(x: T) {} // expected-error {{'where' clause next to generic parameters is obsoleted}} {{10-30=}} {{37-37= where T: Womparable}}
 // 3: Has return type
 func f4<T>(x: T) -> Int { return 2 } // no-warning
 // 4: Trailing where
@@ -18,29 +18,29 @@ func f5<T>(x: T) where T : Equatable {} // no-warning
 
 // FuncDecl: Choose 2
 // 1,2
-func f12<T: Mashable where T: Womparable>(x: T) {} // expected-error {{'where' clause next to generic parameters is deprecated}} {{21-41=}} {{48-48= where T: Womparable}}
+func f12<T: Mashable where T: Womparable>(x: T) {} // expected-error {{'where' clause next to generic parameters is obsoleted}} {{21-41=}} {{48-48= where T: Womparable}}
 // 1,3
 func f13<T: Mashable>(x: T) -> Int { return 2 } // no-warning
 // 1,4
 func f14<T: Mashable>(x: T) where T: Equatable {} // no-warning
 // 2,3
-func f23<T where T: Womparable>(x: T) -> Int { return 2 } // expected-error {{'where' clause next to generic parameters is deprecated}} {{11-31=}} {{45-45= where T: Womparable}}
+func f23<T where T: Womparable>(x: T) -> Int { return 2 } // expected-error {{'where' clause next to generic parameters is obsoleted}} {{11-31=}} {{45-45= where T: Womparable}}
 // 2,4
-func f24<T where T: Womparable>(x: T) where T: Equatable {} // expected-error {{'where' clause next to generic parameters is deprecated}} {{11-31=}} {{39-44=where T: Womparable,}}
+func f24<T where T: Womparable>(x: T) where T: Equatable {} // expected-error {{'where' clause next to generic parameters is obsoleted}} {{11-31=}} {{39-44=where T: Womparable,}}
 // 3,4
 func f34<T>(x: T) -> Int where T: Equatable { return 2 } // no-warning
 
 // FuncDecl: Choose 3
 // 1,2,3
-func f123<T: Mashable where T: Womparable>(x: T) -> Int { return 2 } // expected-error {{'where' clause next to generic parameters is deprecated}} {{22-42=}} {{56-56= where T: Womparable}}
+func f123<T: Mashable where T: Womparable>(x: T) -> Int { return 2 } // expected-error {{'where' clause next to generic parameters is obsoleted}} {{22-42=}} {{56-56= where T: Womparable}}
 // 1,2,4
-func f124<T: Mashable where T: Womparable>(x: T) where T: Equatable {} // expected-error {{'where' clause next to generic parameters is deprecated}} {{22-42=}} {{50-55=where T: Womparable,}}
+func f124<T: Mashable where T: Womparable>(x: T) where T: Equatable {} // expected-error {{'where' clause next to generic parameters is obsoleted}} {{22-42=}} {{50-55=where T: Womparable,}}
 // 2,3,4
-func f234<T where T: Womparable>(x: T) -> Int where T: Equatable { return 2 } // expected-error {{'where' clause next to generic parameters is deprecated}} {{12-32=}} {{47-52=where T: Womparable,}}
+func f234<T where T: Womparable>(x: T) -> Int where T: Equatable { return 2 } // expected-error {{'where' clause next to generic parameters is obsoleted}} {{12-32=}} {{47-52=where T: Womparable,}}
 
 // FuncDecl: Choose 4
 // 1,2,3,4
-func f1234<T: Mashable where T: Womparable>(x: T) -> Int where T: Equatable { return 2 } // expected-error {{'where' clause next to generic parameters is deprecated}} {{23-43=}} {{58-63=where T: Womparable,}}
+func f1234<T: Mashable where T: Womparable>(x: T) -> Int where T: Equatable { return 2 } // expected-error {{'where' clause next to generic parameters is obsoleted}} {{23-43=}} {{58-63=where T: Womparable,}}
 
 
 
@@ -51,32 +51,32 @@ struct S0<T> {}
 // 1: Inherited constraint
 struct S1<T: Mashable> {} // no-warning
 // 2: Non-trailing where
-struct S2<T where T: Womparable> {} // expected-error {{'where' clause next to generic parameters is deprecated}} {{12-32=}} {{33-33= where T: Womparable}}
+struct S2<T where T: Womparable> {} // expected-error {{'where' clause next to generic parameters is obsoleted}} {{12-32=}} {{33-33= where T: Womparable}}
 // 3: Trailing where
 struct S3<T> where T : Equatable {} // no-warning
 
 // NominalTypeDecl: Choose 2
 // 1,2
-struct S12<T: Mashable where T: Womparable> {} // expected-error {{'where' clause next to generic parameters is deprecated}} {{23-43=}} {{44-44= where T: Womparable}}
+struct S12<T: Mashable where T: Womparable> {} // expected-error {{'where' clause next to generic parameters is obsoleted}} {{23-43=}} {{44-44= where T: Womparable}}
 // 1,3
 struct S13<T: Mashable> where T: Equatable {} // no-warning
 // 2,3
-struct S23<T where T: Womparable> where T: Equatable {} // expected-error {{'where' clause next to generic parameters is deprecated}} {{13-33=}} {{35-40=where T: Womparable,}}
+struct S23<T where T: Womparable> where T: Equatable {} // expected-error {{'where' clause next to generic parameters is obsoleted}} {{13-33=}} {{35-40=where T: Womparable,}}
 
 // NominalTypeDecl: Choose 3
 // 1,2,3
-struct S123<T: Mashable where T: Womparable> where T: Equatable {} // expected-error {{'where' clause next to generic parameters is deprecated}} {{24-44=}} {{46-51=where T: Womparable,}}
+struct S123<T: Mashable where T: Womparable> where T: Equatable {} // expected-error {{'where' clause next to generic parameters is obsoleted}} {{24-44=}} {{46-51=where T: Womparable,}}
 
 
 protocol ProtoA {}
 protocol ProtoB {}
 protocol ProtoC {}
 protocol ProtoD {}
-func testCombinedConstraints<T: ProtoA & ProtoB where T: ProtoC>(x: T) {} // expected-error {{'where' clause next to generic parameters is deprecated}} {{48-64=}} {{71-71= where T: ProtoC}}
-func testCombinedConstraints<T: ProtoA & ProtoB where T: ProtoC>(x: T) where T: ProtoD {} // expected-error {{'where' clause next to generic parameters is deprecated}} {{48-64=}} {{72-77=where T: ProtoC,}}
+func testCombinedConstraints<T: ProtoA & ProtoB where T: ProtoC>(x: T) {} // expected-error {{'where' clause next to generic parameters is obsoleted}} {{48-64=}} {{71-71= where T: ProtoC}}
+func testCombinedConstraints<T: ProtoA & ProtoB where T: ProtoC>(x: T) where T: ProtoD {} // expected-error {{'where' clause next to generic parameters is obsoleted}} {{48-64=}} {{72-77=where T: ProtoC,}}
 
-func testCombinedConstraintsOld<T: protocol<ProtoA, ProtoB> where T: ProtoC>(x: T) {} // expected-error {{'where' clause next to generic parameters is deprecated}} {{60-76=}} {{83-83= where T: ProtoC}}
+func testCombinedConstraintsOld<T: protocol<ProtoA, ProtoB> where T: ProtoC>(x: T) {} // expected-error {{'where' clause next to generic parameters is obsoleted}} {{60-76=}} {{83-83= where T: ProtoC}}
 // expected-warning@-1 {{'protocol<...>' composition syntax is deprecated}}
-func testCombinedConstraintsOld<T: protocol<ProtoA, ProtoB> where T: ProtoC>(x: T) where T: ProtoD {} // expected-error {{'where' clause next to generic parameters is deprecated}} {{60-76=}} {{84-89=where T: ProtoC,}}
+func testCombinedConstraintsOld<T: protocol<ProtoA, ProtoB> where T: ProtoC>(x: T) where T: ProtoD {} // expected-error {{'where' clause next to generic parameters is obsoleted}} {{60-76=}} {{84-89=where T: ProtoC,}}
 // expected-warning@-1 {{'protocol<...>' composition syntax is deprecated}}
 

--- a/test/Parse/deprecated_where.swift
+++ b/test/Parse/deprecated_where.swift
@@ -10,7 +10,7 @@ func f1<T>(x: T) {}
 // 1: Inherited constraint
 func f2<T: Mashable>(x: T) {} // no-warning
 // 2: Non-trailing where
-func f3<T where T: Womparable>(x: T) {} // expected-warning {{'where' clause next to generic parameters is deprecated and will be removed in the future version of Swift}} {{10-30=}} {{37-37= where T: Womparable}}
+func f3<T where T: Womparable>(x: T) {} // expected-error {{'where' clause next to generic parameters is deprecated}} {{10-30=}} {{37-37= where T: Womparable}}
 // 3: Has return type
 func f4<T>(x: T) -> Int { return 2 } // no-warning
 // 4: Trailing where
@@ -18,29 +18,29 @@ func f5<T>(x: T) where T : Equatable {} // no-warning
 
 // FuncDecl: Choose 2
 // 1,2
-func f12<T: Mashable where T: Womparable>(x: T) {} // expected-warning {{'where' clause next to generic parameters is deprecated and will be removed in the future version of Swift}} {{21-41=}} {{48-48= where T: Womparable}}
+func f12<T: Mashable where T: Womparable>(x: T) {} // expected-error {{'where' clause next to generic parameters is deprecated}} {{21-41=}} {{48-48= where T: Womparable}}
 // 1,3
 func f13<T: Mashable>(x: T) -> Int { return 2 } // no-warning
 // 1,4
 func f14<T: Mashable>(x: T) where T: Equatable {} // no-warning
 // 2,3
-func f23<T where T: Womparable>(x: T) -> Int { return 2 } // expected-warning {{'where' clause next to generic parameters is deprecated and will be removed in the future version of Swift}} {{11-31=}} {{45-45= where T: Womparable}}
+func f23<T where T: Womparable>(x: T) -> Int { return 2 } // expected-error {{'where' clause next to generic parameters is deprecated}} {{11-31=}} {{45-45= where T: Womparable}}
 // 2,4
-func f24<T where T: Womparable>(x: T) where T: Equatable {} // expected-warning {{'where' clause next to generic parameters is deprecated and will be removed in the future version of Swift}} {{11-31=}} {{39-44=where T: Womparable,}}
+func f24<T where T: Womparable>(x: T) where T: Equatable {} // expected-error {{'where' clause next to generic parameters is deprecated}} {{11-31=}} {{39-44=where T: Womparable,}}
 // 3,4
 func f34<T>(x: T) -> Int where T: Equatable { return 2 } // no-warning
 
 // FuncDecl: Choose 3
 // 1,2,3
-func f123<T: Mashable where T: Womparable>(x: T) -> Int { return 2 } // expected-warning {{'where' clause next to generic parameters is deprecated and will be removed in the future version of Swift}} {{22-42=}} {{56-56= where T: Womparable}}
+func f123<T: Mashable where T: Womparable>(x: T) -> Int { return 2 } // expected-error {{'where' clause next to generic parameters is deprecated}} {{22-42=}} {{56-56= where T: Womparable}}
 // 1,2,4
-func f124<T: Mashable where T: Womparable>(x: T) where T: Equatable {} // expected-warning {{'where' clause next to generic parameters is deprecated and will be removed in the future version of Swift}} {{22-42=}} {{50-55=where T: Womparable,}}
+func f124<T: Mashable where T: Womparable>(x: T) where T: Equatable {} // expected-error {{'where' clause next to generic parameters is deprecated}} {{22-42=}} {{50-55=where T: Womparable,}}
 // 2,3,4
-func f234<T where T: Womparable>(x: T) -> Int where T: Equatable { return 2 } // expected-warning {{'where' clause next to generic parameters is deprecated and will be removed in the future version of Swift}} {{12-32=}} {{47-52=where T: Womparable,}}
+func f234<T where T: Womparable>(x: T) -> Int where T: Equatable { return 2 } // expected-error {{'where' clause next to generic parameters is deprecated}} {{12-32=}} {{47-52=where T: Womparable,}}
 
 // FuncDecl: Choose 4
 // 1,2,3,4
-func f1234<T: Mashable where T: Womparable>(x: T) -> Int where T: Equatable { return 2 } // expected-warning {{'where' clause next to generic parameters is deprecated and will be removed in the future version of Swift}} {{23-43=}} {{58-63=where T: Womparable,}}
+func f1234<T: Mashable where T: Womparable>(x: T) -> Int where T: Equatable { return 2 } // expected-error {{'where' clause next to generic parameters is deprecated}} {{23-43=}} {{58-63=where T: Womparable,}}
 
 
 
@@ -51,32 +51,32 @@ struct S0<T> {}
 // 1: Inherited constraint
 struct S1<T: Mashable> {} // no-warning
 // 2: Non-trailing where
-struct S2<T where T: Womparable> {} // expected-warning {{'where' clause next to generic parameters is deprecated and will be removed in the future version of Swift}} {{12-32=}} {{33-33= where T: Womparable}}
+struct S2<T where T: Womparable> {} // expected-error {{'where' clause next to generic parameters is deprecated}} {{12-32=}} {{33-33= where T: Womparable}}
 // 3: Trailing where
 struct S3<T> where T : Equatable {} // no-warning
 
 // NominalTypeDecl: Choose 2
 // 1,2
-struct S12<T: Mashable where T: Womparable> {} // expected-warning {{'where' clause next to generic parameters is deprecated and will be removed in the future version of Swift}} {{23-43=}} {{44-44= where T: Womparable}}
+struct S12<T: Mashable where T: Womparable> {} // expected-error {{'where' clause next to generic parameters is deprecated}} {{23-43=}} {{44-44= where T: Womparable}}
 // 1,3
 struct S13<T: Mashable> where T: Equatable {} // no-warning
 // 2,3
-struct S23<T where T: Womparable> where T: Equatable {} // expected-warning {{'where' clause next to generic parameters is deprecated and will be removed in the future version of Swift}} {{13-33=}} {{35-40=where T: Womparable,}}
+struct S23<T where T: Womparable> where T: Equatable {} // expected-error {{'where' clause next to generic parameters is deprecated}} {{13-33=}} {{35-40=where T: Womparable,}}
 
 // NominalTypeDecl: Choose 3
 // 1,2,3
-struct S123<T: Mashable where T: Womparable> where T: Equatable {} // expected-warning {{'where' clause next to generic parameters is deprecated and will be removed in the future version of Swift}} {{24-44=}} {{46-51=where T: Womparable,}}
+struct S123<T: Mashable where T: Womparable> where T: Equatable {} // expected-error {{'where' clause next to generic parameters is deprecated}} {{24-44=}} {{46-51=where T: Womparable,}}
 
 
 protocol ProtoA {}
 protocol ProtoB {}
 protocol ProtoC {}
 protocol ProtoD {}
-func testCombinedConstraints<T: ProtoA & ProtoB where T: ProtoC>(x: T) {} // expected-warning {{'where' clause next to generic parameters is deprecated and will be removed in the future version of Swift}} {{48-64=}} {{71-71= where T: ProtoC}}
-func testCombinedConstraints<T: ProtoA & ProtoB where T: ProtoC>(x: T) where T: ProtoD {} // expected-warning {{'where' clause next to generic parameters is deprecated and will be removed in the future version of Swift}} {{48-64=}} {{72-77=where T: ProtoC,}}
+func testCombinedConstraints<T: ProtoA & ProtoB where T: ProtoC>(x: T) {} // expected-error {{'where' clause next to generic parameters is deprecated}} {{48-64=}} {{71-71= where T: ProtoC}}
+func testCombinedConstraints<T: ProtoA & ProtoB where T: ProtoC>(x: T) where T: ProtoD {} // expected-error {{'where' clause next to generic parameters is deprecated}} {{48-64=}} {{72-77=where T: ProtoC,}}
 
-func testCombinedConstraintsOld<T: protocol<ProtoA, ProtoB> where T: ProtoC>(x: T) {} // expected-warning {{'where' clause next to generic parameters is deprecated and will be removed in the future version of Swift}} {{60-76=}} {{83-83= where T: ProtoC}}
+func testCombinedConstraintsOld<T: protocol<ProtoA, ProtoB> where T: ProtoC>(x: T) {} // expected-error {{'where' clause next to generic parameters is deprecated}} {{60-76=}} {{83-83= where T: ProtoC}}
 // expected-warning@-1 {{'protocol<...>' composition syntax is deprecated}}
-func testCombinedConstraintsOld<T: protocol<ProtoA, ProtoB> where T: ProtoC>(x: T) where T: ProtoD {} // expected-warning {{'where' clause next to generic parameters is deprecated and will be removed in the future version of Swift}} {{60-76=}} {{84-89=where T: ProtoC,}}
+func testCombinedConstraintsOld<T: protocol<ProtoA, ProtoB> where T: ProtoC>(x: T) where T: ProtoD {} // expected-error {{'where' clause next to generic parameters is deprecated}} {{60-76=}} {{84-89=where T: ProtoC,}}
 // expected-warning@-1 {{'protocol<...>' composition syntax is deprecated}}
 

--- a/test/Parse/deprecated_where.swift
+++ b/test/Parse/deprecated_where.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -typecheck -verify %s
+// RUN: %target-swift-frontend -typecheck -verify %s -swift-version 4
 
 protocol Mashable { }
 protocol Womparable { }

--- a/test/type/protocol_composition.swift
+++ b/test/type/protocol_composition.swift
@@ -161,5 +161,5 @@ struct S05<T> where T : P5? & P6 {} // expected-error {{inheritance from non-nam
 
 // SR-3124 - Protocol Composition Often Migrated Incorrectly
 struct S3124<T: protocol<P1, P3>> {} // expected-warning {{'protocol<...>' composition syntax is deprecated; join the protocols using '&'}} {{17-34=P1 & P3>}}
-func f3124_1<U where U: protocol<P1, P3>>(x: U)  {} // expected-warning {{'protocol<...>' composition syntax is deprecated; join the protocols using '&'}} {{25-42=P1 & P3>}} // expected-warning {{'where' clause}}
+func f3124_1<U where U: protocol<P1, P3>>(x: U)  {} // expected-warning {{'protocol<...>' composition syntax is deprecated; join the protocols using '&'}} {{25-42=P1 & P3>}} // expected-error {{'where' clause}}
 func f3124_2<U : protocol<P1>>(x: U)  {} // expected-warning {{'protocol<...>' composition syntax is deprecated and not needed here}} {{18-31=P1>}}


### PR DESCRIPTION
Update the warning of "where' clause next to generic parameters is deprecated" to an error for Swift > 3.

rdar://problem/32203888