### PR TITLE
Properly diagnose crashers involving nested assign exprs

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -7458,6 +7458,43 @@ bool FailureDiagnosis::visitExpr(Expr *E) {
 bool FailureDiagnosis::diagnoseExprFailure() {
   assert(CS && expr);
 
+  class AssignExprFinder : public ASTWalker {
+  public:
+    Expr *foundAssign = nullptr;
+
+    // Walk through the expr looking for assignments nested in them.
+    std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
+      if (auto *AE = dyn_cast<AssignExpr>(E)) {
+        foundAssign = AE;
+        return { false, E };
+      }
+      if (auto *AE = dyn_cast<DiscardAssignmentExpr>(E)) {
+        foundAssign = AE;
+        return { false, E };
+      }
+      return { true, E };
+    }
+
+    // Don't walk into anything else.
+    std::pair<bool, Stmt *> walkToStmtPre(Stmt *S) override {
+      return { false, S };
+    }
+    std::pair<bool, Pattern*> walkToPatternPre(Pattern *P) override {
+      return { false, P };
+    }
+    bool walkToDeclPre(Decl *D) override { return false; }
+    bool walkToTypeLocPre(TypeLoc &TL) override { return false; }
+    bool walkToTypeReprPre(TypeRepr *T) override { return false; }
+    bool walkToParameterListPre(ParameterList *PL) override { return false; }
+  };
+
+  // First, directly diagnose nested assignment expressions.
+  AssignExprFinder assignFinder;
+  if (expr->walk(assignFinder), assignFinder.foundAssign != nullptr) {
+    diagnoseAmbiguity(assignFinder.foundAssign);
+    return true;
+  }
+
   // Our general approach is to do a depth first traversal of the broken
   // expression tree, type checking as we go.  If we find a subtree that cannot
   // be type checked on its own (even to an incomplete type) then that is where

--- a/validation-test/compiler_crashers_fixed/28618-unreachable-executed-at-swift-include-swift-ast-exprnodes-def-78.swift
+++ b/validation-test/compiler_crashers_fixed/28618-unreachable-executed-at-swift-include-swift-ast-exprnodes-def-78.swift
@@ -5,5 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 [.h=_

--- a/validation-test/compiler_crashers_fixed/28626-objectty-is-lvaluetype-objectty-is-inouttype-cannot-have-inout-or-lvalue-wrapped.swift
+++ b/validation-test/compiler_crashers_fixed/28626-objectty-is-lvaluetype-objectty-is-inouttype-cannot-have-inout-or-lvalue-wrapped.swift
@@ -5,5 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-[(t:_._=(
+// RUN: not %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+&[_=(&_

--- a/validation-test/compiler_crashers_fixed/28627-unreachable-executed-at-swift-include-swift-ast-exprnodes-def-79.swift
+++ b/validation-test/compiler_crashers_fixed/28627-unreachable-executed-at-swift-include-swift-ast-exprnodes-def-79.swift
@@ -5,6 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-(_==_{return($0)u
+// RUN: not %target-swift-frontend %s -emit-ir
+[(t:_._=(

--- a/validation-test/compiler_crashers_fixed/28628-gettype-e-isassignabletype-setting-access-kind-on-non-l-value.swift
+++ b/validation-test/compiler_crashers_fixed/28628-gettype-e-isassignabletype-setting-access-kind-on-non-l-value.swift
@@ -5,5 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-(Int==_{
+// RUN: not %target-swift-frontend %s -emit-ir
+// REQUIRES: asserts
+&(_=nil?=nil

--- a/validation-test/compiler_crashers_fixed/28663-impl-getgraphindex-typevariables-size-out-of-bounds-index.swift
+++ b/validation-test/compiler_crashers_fixed/28663-impl-getgraphindex-typevariables-size-out-of-bounds-index.swift
@@ -5,6 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
 // REQUIRES: asserts
-&(_=nil?=nil
+// RUN: not %target-swift-frontend %s -emit-ir
+(_==_{return($0)u

--- a/validation-test/compiler_crashers_fixed/28739-unreachable-executed-at-swift-lib-ast-type-cpp-229.swift
+++ b/validation-test/compiler_crashers_fixed/28739-unreachable-executed-at-swift-lib-ast-type-cpp-229.swift
@@ -5,6 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-// REQUIRES: asserts
-&[_=(&_
+// RUN: not %target-swift-frontend %s -emit-ir
+(Int==_{


### PR DESCRIPTION
Resolves a class of crashers where the expression under scrutiny contained assignment or discard expressions.  When the expression walker would move to diagnose them, it would type check them independently and in the process attempt to do strange things like propagate lvalue-ness to an assignment or request if a discard expression was assignable.

Before walking, drill into the expression to search for these bogus subexpressions and diagnose them as ambiguous.