### PR TITLE
[Swift3.1] Set default CPU for s390x to support conversion between unsigned inte…

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -653,6 +653,8 @@ addCommonInvocationArguments(std::vector<std::string> &invocationArgStrs,
         triple.getArch() == llvm::Triple::aarch64_be) {
       invocationArgStrs.push_back("-mcpu=cyclone");
     }
+  } else if (triple.getArch() == llvm::Triple::systemz) {
+    invocationArgStrs.push_back("-march=z196");
   }
 
   const std::string &overrideResourceDir = importerOpts.OverrideResourceDir;

--- a/test/Misc/floatTruncation.swift
+++ b/test/Misc/floatTruncation.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-frontend -parse-stdlib -emit-assembly %s -o - | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-cpu
+
+// test converting floating point to unsigned integer
+import Swift
+let f = -123.0 as Float
+let x = Builtin.fptoui_FPIEEE32_Int8(f._value)
+
+// CHECK-NOT: (dummy CHECK line to avoid FileCheck complaints)
+// CHECK-s390x: clfebr %r{{[0-9]+}}, {{[0-7]+}}, %f{{[0-9]+}}, {{[0-9]+}}
+

--- a/test/Misc/target-cpu.swift
+++ b/test/Misc/target-cpu.swift
@@ -37,3 +37,6 @@
 // RUN: not %swift -typecheck -target x86_64-apple-watchos2 -Xcc -### %s 2>&1 | %FileCheck -check-prefix=WATCHSIMULATOR64_CPU %s
 // WATCHSIMULATOR64_CPU: "-target-cpu" "core2"
 
+// RUN: not %swift -typecheck -target s390x-unknown-linux-gnu -Xcc -### %s 2>&1 | %FileCheck -check-prefix=S390X_CPU %s
+// S390X_CPU: "-target-cpu" "z196"
+


### PR DESCRIPTION
…gers and floating point numbers

On System z, instructions for conversion between unsigned integers and floating point numbers was added in z196. We want to have this support by the default on Swift.

The missing support was exposed by the test swift/validation-test/stdlib/FixedPointConversion.swift.gyb. With this change, the test case passes on s390x.

The `-target-cpu` option is issuing the incorrect Clang option as I got this error:
```
> swiftc -target-cpu z196 testFloatingPoint.swift
<unknown>:0: warning: argument unused during compilation: '-mcpu=z196'
```
I have changed `-mcpu` to `-march`  in this PR.  From Clang's man page:
```
-arch <architecture>
              Specify the architecture to build for.
-march=<cpu>
              Specify that Clang should generate code for a specific processor family member and later.  For example, if you specify -march=i486, the compiler is allowed to generate instructions that are valid on  i486  and  later
              processors, but which may not exist on earlier ones.
```
