### PR TITLE
[Foundation] add additional conformances and functionality to NSRange

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -6089,13 +6089,15 @@ void TypeChecker::checkConformancesInContext(DeclContext *dc,
     auto extendedNominal =
       diag.ExistingDC->getAsNominalTypeOrNominalTypeExtensionContext();
     if (existingModule != dc->getParentModule() &&
-        (existingModule == extendedNominal->getParentModule() ||
+        (existingModule->getName() ==
+           extendedNominal->getParentModule()->getName() ||
          existingModule == diag.Protocol->getParentModule())) {
       // Warn about the conformance.
       diagnose(diag.Loc, diag::redundant_conformance_adhoc,
                dc->getDeclaredInterfaceType(),
                diag.Protocol->getName(),
-               existingModule == extendedNominal->getParentModule(),
+               existingModule->getName() ==
+                 extendedNominal->getParentModule()->getName(),
                existingModule->getName());
 
       // Complain about any declarations in this extension whose names match

--- a/stdlib/public/SDK/Foundation/NSRange.swift
+++ b/stdlib/public/SDK/Foundation/NSRange.swift
@@ -12,33 +12,117 @@
 
 @_exported import Foundation // Clang module
 
+extension NSRange : Hashable {
+    public var hashValue: Int { 
+        return Int(bitPattern: UInt(location) ^ UInt(location))
+    }
+
+    public static func==(_ lhs: NSRange, _ rhs: NSRange) -> Bool {
+        return lhs.location == rhs.location && rhs.length == rhs.length
+    }
+}
+
+extension NSRange : CustomStringConvertible, CustomDebugStringConvertible {
+    public var description: String { return "{\(location), \(length)}" }
+    public var debugDescription: String { return "{\(location), \(length)}" }
+}
+
+extension NSRange {
+    public init?(_ string: String) {
+        if string.isEmpty {
+            // fail early if the string is empty
+            return nil
+        }
+        let scanner = Scanner(string: string)
+        let digitSet = CharacterSet.decimalDigits
+        let _ = scanner.scanUpToCharacters(from: digitSet, into: nil)
+        if scanner.isAtEnd {
+            // fail early if there are no decimal digits
+            return nil
+        }
+        var location = 0
+        guard scanner.scanInt(&location) else {
+            return nil
+        }
+        if scanner.isAtEnd {
+            // return early if there are no more characters after the first int in the string
+            return nil
+        }
+        let _ = scanner.scanUpToCharacters(from: digitSet, into: nil)
+        if scanner.isAtEnd {
+            // return early if there are no integer characters after the first int in the string
+            return nil
+        }
+        var length = 0
+        guard scanner.scanInt(&length) else {
+            return nil
+        }
+        
+        self.location = location
+        self.length = length
+    }
+}
+
+extension NSRange {
+    public var lowerBound: Int { return location }
+    
+    public var upperBound: Int { return location + length }
+    
+    public func contains(_ index: Int) -> Bool { return (!(index < location) && (index - location) < length) }
+    
+    public mutating func formUnion(_ other: NSRange) {
+        self = union(other)
+    }
+
+    public func union(_ other: NSRange) -> NSRange {
+        let max1 = location + length
+        let max2 = other.location + other.length
+        let maxend = (max1 < max2) ? max2 : max1
+        let minloc = location < other.location ? location : other.location
+        return NSRange(location: minloc, length: maxend - minloc)
+    }
+
+    public func intersection(_ other: NSRange) -> NSRange? {
+        let max1 = location + length
+        let max2 = other.location + other.length
+        let minend = (max1 < max2) ? max1 : max2
+        if other.location <= location && location < max2 {
+            return NSRange(location: location, length: minend - location)
+        } else if location <= other.location && other.location < max1 {
+            return NSRange(location: other.location, length: minend - other.location);
+        }
+        return nil
+    }
+}
+
+
 //===----------------------------------------------------------------------===//
 // Ranges
 //===----------------------------------------------------------------------===//
 
 extension NSRange {
-  public init(_ x: Range<Int>) {
-    location = x.lowerBound
-    length = x.count
-  }
+    public init(_ x: Range<Int>) {
+        location = x.lowerBound
+        length = x.count
+    }
 
-  // FIXME(ABI)#75 (Conditional Conformance): this API should be an extension on Range.
-  // Can't express it now because the compiler does not support conditional
-  // extensions with type equality constraints.
-  public func toRange() -> Range<Int>? {
-    if location == NSNotFound { return nil }
-    return location..<(location+length)
-  }
+    // FIXME(ABI)#75 (Conditional Conformance): this API should be an extension on Range.
+    // Can't express it now because the compiler does not support conditional
+    // extensions with type equality constraints.
+    public func toRange() -> Range<Int>? {
+        if location == NSNotFound { return nil }
+        return location..<(location+length)
+    }
 }
 
 extension NSRange : CustomReflectable {
-  public var customMirror: Mirror {
-    return Mirror(self, children: ["location": location, "length": length])
-  }
+    public var customMirror: Mirror {
+        return Mirror(self, children: ["location": location, "length": length])
+    }
 }
 
 extension NSRange : CustomPlaygroundQuickLookable {
-  public var customPlaygroundQuickLook: PlaygroundQuickLook {
-    return .range(Int64(location), Int64(length))
-  }
+    public var customPlaygroundQuickLook: PlaygroundQuickLook {
+        return .range(Int64(location), Int64(length))
+    }
 }

--- a/stdlib/public/SDK/Foundation/NSRange.swift
+++ b/stdlib/public/SDK/Foundation/NSRange.swift
@@ -13,8 +13,12 @@
 @_exported import Foundation // Clang module
 
 extension NSRange : Hashable {
-    public var hashValue: Int { 
-        return Int(bitPattern: UInt(location) ^ UInt(location))
+    public var hashValue: Int {
+#if arch(i386) || arch(arm)
+        return Int(bitPattern: (UInt(bitPattern: location) | (UInt(bitPattern: length) << 16)))
+#elseif arch(x86_64) || arch(arm64)
+        return Int(bitPattern: (UInt(bitPattern: location) | (UInt(bitPattern: length) << 32)))
+#endif
     }
 
     public static func==(_ lhs: NSRange, _ rhs: NSRange) -> Bool {

--- a/test/Compatibility/bridging-nsnumber-and-nsvalue.swift.gyb
+++ b/test/Compatibility/bridging-nsnumber-and-nsvalue.swift.gyb
@@ -45,7 +45,6 @@ extension Equatable {
   }
 }
 extension Hashable { public var hashValue: Int { fatalError("trill hiphy") } }
-extension NSRange: Hashable {}
 extension CGSize: Hashable {}
 extension CGPoint: Hashable {}
 extension CGRect: Hashable {}

--- a/test/Compatibility/range_hashable.swift
+++ b/test/Compatibility/range_hashable.swift
@@ -1,0 +1,9 @@
+// RUN: %target-typecheck-verify-swift -swift-version 3
+
+// REQUIRES: objc_interop
+
+import Foundation
+
+extension NSRange : Hashable { // expected-warning{{conformance of '_NSRange' to protocol 'Hashable' was already stated in the type's module 'Foundation'}}
+  var hashValue: Int { return 0 } // expected-note{{var 'hashValue' will not be used to satisfy the conformance to 'Hashable'}}
+}

--- a/test/Constraints/bridging-nsnumber-and-nsvalue.swift.gyb
+++ b/test/Constraints/bridging-nsnumber-and-nsvalue.swift.gyb
@@ -29,7 +29,6 @@ coercionTypes = {
     'CGRect',
     'CGPoint',
     'CGSize',
-    'NSRange',
   ],
 }
 }%
@@ -41,7 +40,6 @@ extension Equatable {
   }
 }
 extension Hashable { public var hashValue: Int { fatalError("trill hiphy") } }
-extension NSRange: Hashable {}
 extension CGSize: Hashable {}
 extension CGPoint: Hashable {}
 extension CGRect: Hashable {}


### PR DESCRIPTION
Explanation: NSRange is used widely in a number of Cocoa APIs; it has a few free-floating functions used to manipulate and parse ranges. These functiosn should be hoisted into NSRange and protocols should be adopted where appropriate.

NSRange can be converted to a string; therefore it should adopt CustomStringConvertible and CustomDebugStringConvertible. It also has a free floating function NSEqualRanges which can more appropriately be expressed as adopting Equatable. Furthermore NSMaxRange can be exposed as upperBound to fall in line with Range. Also it can move NSUnionRange to be a member function to create new and mutate NSRanges.

Scope: This is an additive API change for NSRange. It has no language changes.

Radar (and possibly SR Issue): rdar://problem/21626767

Risk: It is possible that existing projects may implement Hashable or Equatable for NSRange, however the authoritative source for these definitions should be determined by the framework that determines that type.

Testing: This was tested against the existing set of tests for NSRange.