### PR TITLE
[4.0] [QoI] Improve diagnostics for Smart KeyPath

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -447,6 +447,9 @@ ERROR(expr_swift_keypath_not_starting_with_type,none,
       "a Swift key path must begin with a type", ())
 ERROR(expr_swift_keypath_unimplemented_component,none,
       "key path support for %0 components is not implemented", (StringRef))
+ERROR(expr_smart_keypath_value_covert_to_contextual_type,none,
+      "KeyPath value type %0 cannot be converted to contextual type %1",
+      (Type, Type))
 
 // Selector expressions.
 ERROR(expr_selector_no_objc_runtime,none,

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -958,3 +958,15 @@ class SR_4692_b {
   private func f(x: Int, y: Bool) {
   }
 }
+
+// rdar://problem/32101765 - Keypath diagnostics are not actionable/helpful
+
+struct R32101765 { let prop32101765 = 0 }
+let _: KeyPath<R32101765, Float> = \.prop32101765
+// expected-error@-1 {{KeyPath value type 'Int' cannot be converted to contextual type 'Float'}}
+let _: KeyPath<R32101765, Float> = \R32101765.prop32101765
+// expected-error@-1 {{KeyPath value type 'Int' cannot be converted to contextual type 'Float'}}
+let _: KeyPath<R32101765, Float> = \.prop32101765.unknown
+// expected-error@-1 {{type 'Int' has no member 'unknown'}}
+let _: KeyPath<R32101765, Float> = \R32101765.prop32101765.unknown
+// expected-error@-1 {{type 'Int' has no member 'unknown'}}


### PR DESCRIPTION
Description: Add `FailureDiagnostics::visitKeyPathExpr` to try and diagnose contextual
value type problems related to Smart KeyPath feature. If problems with
contextual value type can't be diagnosed let's walk components and see
if there are any structural problems with expression itself e.g. unknown
members and incorrect types in the path.

* Origination: Introduction of SE-0161 requires improvements in diagnostics to
handle contextual information given in form of KeyPath class hierarchy.

* Scope of the issue: diagnostic improvements for Smart KeyPath feature (SE-0161).

* Risk: Low, diagnostic improvements.

* Tested: New test cases added, Swift CI.

* Reviewed by: Joe Groff

* Resolves: rdar://problem/32101765

(cherry picked from commit 8e8ead31d39cb9bc822be2c04e690f782f8b7c26)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
