### PR TITLE
Demangler: make the demangler more tolerant with malformed symbols.

### DIFF
--- a/lib/Demangling/OldDemangler.cpp
+++ b/lib/Demangling/OldDemangler.cpp
@@ -32,12 +32,6 @@ using namespace Demangle;
 using llvm::Optional;
 using llvm::None;
 
-[[noreturn]]
-static void unreachable(const char *Message) {
-  fprintf(stderr, "fatal error: %s\n", Message);
-  std::abort();
-}
-
 namespace {
   struct FindPtr {
     FindPtr(Node *v) : Target(v) {}
@@ -575,7 +569,8 @@ private:
       return true;
     }
 
-    unreachable("Unknown constant prop specialization");
+    // Unknown constant prop specialization
+    return false;
   }
 
   bool demangleFuncSigSpecializationClosureProp(NodePointer parent) {
@@ -1483,7 +1478,8 @@ private:
       return Factory.createNode(Node::Kind::MetatypeRepresentation,
                                  "@objc_metatype");
 
-    unreachable("Unhandled metatype representation");
+    // Unknown metatype representation
+    return nullptr;
   }
   
   NodePointer demangleGenericRequirement() {
@@ -1546,7 +1542,7 @@ private:
           return nullptr;
         name = "m";
       } else {
-        unreachable("Unknown layout constraint");
+        return nullptr;
       }
 
       NodePointer second = Factory.createNode(kind, name);
@@ -2114,7 +2110,7 @@ private:
       case ImplConventionContext::Parameter: return (FOR_PARAMETER); \
       case ImplConventionContext::Result: return (FOR_RESULT);       \
       }                                                              \
-      unreachable("bad context");                               \
+      return StringRef();                                            \
     }
     auto Nothing = StringRef();
     CASE('a',   Nothing,                Nothing,         "@autoreleased")
@@ -2177,18 +2173,18 @@ private:
         return nullptr;
       kind = Node::Kind::ImplErrorResult;
     }
-  
-    auto getContext = [](Node::Kind kind) -> ImplConventionContext {
-      if (kind == Node::Kind::ImplParameter)
-        return ImplConventionContext::Parameter;
-      else if (kind == Node::Kind::ImplResult
-               || kind == Node::Kind::ImplErrorResult)
-        return ImplConventionContext::Result;
-      else
-        unreachable("unexpected node kind");
-    };
 
-    auto convention = demangleImplConvention(getContext(kind));
+    ImplConventionContext ConvCtx;
+    if (kind == Node::Kind::ImplParameter) {
+      ConvCtx = ImplConventionContext::Parameter;
+    } else if (kind == Node::Kind::ImplResult
+               || kind == Node::Kind::ImplErrorResult) {
+      ConvCtx = ImplConventionContext::Result;
+    } else {
+      return nullptr;
+    }
+
+    auto convention = demangleImplConvention(ConvCtx);
     if (convention.empty()) return nullptr;
     auto type = demangleType();
     if (!type) return nullptr;

--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -254,4 +254,5 @@ _T04main1_yyF ---> main._() -> ()
 _T04test6testitSiyt_tF ---> test.testit(()) -> Swift.Int
 _T08_ElementQzSbs5Error_pIxxdzo_ABSbsAC_pIxidzo_s26RangeReplaceableCollectionRzABRLClTR ---> {T:} reabstraction thunk helper <A where A: Swift.RangeReplaceableCollection, A._Element: AnyObject> from @callee_owned (@owned A._Element) -> (@unowned Swift.Bool, @error @owned Swift.Error) to @callee_owned (@in A._Element) -> (@unowned Swift.Bool, @error @owned Swift.Error)
 _T0Ix_IyB_Tr ---> {T:} reabstraction thunk from @callee_owned () -> () to @callee_unowned @convention(block) () -> ()
+_T0Rml ---> _T0Rml
 


### PR DESCRIPTION
Instead of crashing it just should not demangle malformed symbols.

rdar://problem/32113006
