### PR TITLE
[stdlib] Reverting the String.init?(_: String) behavior

### DIFF
--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -107,17 +107,6 @@ public protocol StringProtocol
   ) rethrows -> Result
 }
 
-extension StringProtocol /* : LosslessStringConvertible */ {
-  // This overload is for the Swift 3 compatibility.
-  // In Swift 4, conformance is satisfied by the non-failable initializer, so
-  // that `String("") as String?` is still possible, but `String("")!` is not.
-  @available(swift, obsoleted: 4,
-    message: "Please use the non-failable initializer.")
-  public init?(_ description: String) {
-    self.init(description.characters)
-  }
-}
-
 /// Call body with a pointer to zero-terminated sequence of
 /// `TargetEncoding.CodeUnit` representing the same string as `source`, when
 /// `source` is interpreted as being encoded with `SourceEncoding`.

--- a/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
+++ b/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
@@ -37,12 +37,16 @@ extension String : StringProtocol {
   }
 
   // FIXME(strings): doc comment
-  // This initializer satisfies the conformance to LosslessStringConvertible
-  // and disambiguates between the following intitializers, now that String
-  // conforms to Collection:
+  // This initializer disambiguates between the following intitializers, now
+  // that String conforms to Collection:
   // - init<T>(_ value: T) where T : LosslessStringConvertible
   // - init<S>(_ characters: S) where S : Sequence, S.Element == Character
-  public init(_ other: String) {
+  public init<T : StringProtocol>(_ other: T) {
+    self.init(other.characters)
+  }
+
+  // This initializer satisfies the LosslessStringConvertible conformance
+  public init?(_ other: String) {
     self.init(other._core)
   }
 

--- a/stdlib/public/core/Substring.swift.gyb
+++ b/stdlib/public/core/Substring.swift.gyb
@@ -459,11 +459,11 @@ extension String {
 extension Substring {
   @available(swift, obsoleted: 4)
   public subscript(bounds: Range<Index>) -> String {
-    return String(self[bounds])
+    return String(characters[bounds])
   }
 
   @available(swift, obsoleted: 4)
   public subscript(bounds: ClosedRange<Index>) -> String {
-    return String(self[bounds] as Substring)
+    return String(characters[bounds])
   }
 }

--- a/test/stdlib/StringAPI.swift
+++ b/test/stdlib/StringAPI.swift
@@ -361,11 +361,6 @@ StringTests.test("CompareStringsWithUnpairedSurrogates")
   )
 }
 
-StringTests.test("String.init(_:String)/default type") {
-  var s = String("")
-  expectType(String.self, &s)
-}
-
 StringTests.test("[String].joined() -> String") {
   let s = ["hello", "world"].joined()
   _ = s == "" // should compile without error

--- a/test/stdlib/StringCompatibility.swift
+++ b/test/stdlib/StringCompatibility.swift
@@ -39,7 +39,7 @@ Tests.test("ClosedRange/Subsript/ExpectedType") {
 
 Tests.test("String.init(_:String)/default type") {
   var s = String("")
-  expectType(String.self, &s)
+  expectType(String?.self, &s)
 }
 
 Tests.test("LosslessStringConvertible/generic") {


### PR DESCRIPTION
One cannot simply change the default behavior of `String.init(_: String)`, because:

```swift
let blah = String("hello")
return blah!
```

<rdar://problem/32146774>