### PR TITLE
[test] Don't depend on "Version: 4" sections working in API notes yet.

### DIFF
--- a/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/APINotesFrameworkTest.apinotes
+++ b/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/APINotesFrameworkTest.apinotes
@@ -157,10 +157,3 @@ SwiftVersions:
         SwiftName: aliasRenamedSwift3
       - Name: OptionyEnumRenamed
         SwiftName: renamedSwift3
-  - Version: 4
-    Classes:
-      - Name: ClassWithManyRenames
-        Methods:
-          - Selector: "classWithManyRenamesForInt:"
-            MethodKind: Class
-            SwiftName: "init(swift4Factory:)"

--- a/test/APINotes/versioned-objc.swift
+++ b/test/APINotes/versioned-objc.swift
@@ -46,18 +46,18 @@ func testRenamedGeneric() {
 func testRenamedClassMembers(obj: ClassWithManyRenames) {
   // CHECK-DIAGS-3: [[@LINE+1]]:{{[0-9]+}}: error: 'classWithManyRenamesForInt' has been replaced by 'init(swift3Factory:)'
   _ = ClassWithManyRenames.classWithManyRenamesForInt(0)
-  // CHECK-DIAGS-4: [[@LINE-1]]:{{[0-9]+}}: error: 'classWithManyRenamesForInt' has been replaced by 'init(swift4Factory:)'
+  // CHECK-DIAGS-4: [[@LINE-1]]:{{[0-9]+}}: error: 'classWithManyRenamesForInt' has been replaced by 'init(for:)'
 
   // CHECK-DIAGS-3: [[@LINE+1]]:{{[0-9]+}}: error: 'init(forInt:)' has been replaced by 'init(swift3Factory:)'
   _ = ClassWithManyRenames(forInt: 0)
-  // CHECK-DIAGS-4: [[@LINE-1]]:{{[0-9]+}}: error: 'init(forInt:)' has been replaced by 'init(swift4Factory:)'
+  // CHECK-DIAGS-4: [[@LINE-1]]:{{[0-9]+}}: error: 'init(forInt:)' has been replaced by 'init(for:)'
 
   // CHECK-DIAGS-3-NOT: :[[@LINE+1]]:{{[0-9]+}}:
   _ = ClassWithManyRenames(swift3Factory: 0)
-  // CHECK-DIAGS-4: [[@LINE-1]]:{{[0-9]+}}: error: 'init(swift3Factory:)' has been replaced by 'init(swift4Factory:)'
+  // CHECK-DIAGS-4: [[@LINE-1]]:{{[0-9]+}}: error: 'init(swift3Factory:)' has been replaced by 'init(for:)'
 
-  // CHECK-DIAGS-3: [[@LINE+1]]:{{[0-9]+}}: error: 'init(swift4Factory:)' has been replaced by 'init(swift3Factory:)'
-  _ = ClassWithManyRenames(swift4Factory: 0)
+  // CHECK-DIAGS-3: [[@LINE+1]]:{{[0-9]+}}: error: 'init(for:)' has been replaced by 'init(swift3Factory:)'
+  _ = ClassWithManyRenames(for: 0)
   // CHECK-DIAGS-4-NOT: :[[@LINE-1]]:{{[0-9]+}}:
 
 


### PR DESCRIPTION
This example works fine with just omit-needless-words and a Swift-3-only name.

Should fix the bots.

rdar://problem/32232087