### PR TITLE
[Migrator] FixitApplyDiagnosticConsumer: Ignore diags with invalid So…

### DIFF
--- a/lib/Migrator/FixitApplyDiagnosticConsumer.cpp
+++ b/lib/Migrator/FixitApplyDiagnosticConsumer.cpp
@@ -37,6 +37,9 @@ handleDiagnostic(SourceManager &SM, SourceLoc Loc,
                  StringRef FormatString,
                  ArrayRef<DiagnosticArgument> FormatArgs,
                  const DiagnosticInfo &Info) {
+  if (Loc.isInvalid()) {
+    return;
+  }
   auto ThisBufferID = SM.findBufferContainingLoc(Loc);
   auto ThisBufferName = SM.getIdentifierForBuffer(ThisBufferID);
   if (ThisBufferName != BufferName) {

--- a/test/Migrator/invalid_sourceloc.swift
+++ b/test/Migrator/invalid_sourceloc.swift
@@ -1,0 +1,6 @@
+// REQUIRES: objc_interop
+// RUN: rm -rf %t && mkdir -p %t && not %swift -c -update-code -primary-file %s -emit-migrated-file-path %t/api-special-cases.swift.result -emit-remap-file-path %t/api-special-cases.swift.remap -o /dev/null
+
+// A failed import due to a missing -sdk frontend argument produces a
+// diagnostic with an invalid sourceloc.
+import CoreGraphics


### PR DESCRIPTION
…urceLocs

Some diagnostics showing up during migration may not have valid source
locations, so we obviously can't map that onto a buffer onto which we'd
apply a fix-it.

rdar://problem/32213595