### PR TITLE
[stdlib] SignedNumber to refine Comparable in Swift 3 mode

### DIFF
--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -3495,7 +3495,7 @@ public typealias Integer = BinaryInteger
 public typealias IntegerArithmetic = BinaryInteger
 
 @available(swift, obsoleted: 4)
-public typealias SignedNumber = SignedNumeric
+public typealias SignedNumber = SignedNumeric & Comparable
 
 @available(swift, obsoleted: 4)
 public typealias AbsoluteValuable = SignedNumeric & Comparable


### PR DESCRIPTION
Fixes: https://bugs.swift.org/browse/SR-4899