### PR TITLE
[stdlib] SignedNumber to refine Comparable in Swift 3 mode

### DIFF
--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -3490,7 +3490,7 @@ public typealias Integer = BinaryInteger
 public typealias IntegerArithmetic = BinaryInteger
 
 @available(swift, obsoleted: 4)
-public typealias SignedNumber = SignedNumeric
+public typealias SignedNumber = SignedNumeric & Comparable
 
 @available(swift, obsoleted: 4)
 public typealias AbsoluteValuable = SignedNumeric & Comparable


### PR DESCRIPTION
Fixes: https://bugs.swift.org/browse/SR-4899

* Explanation: SignedNumber protocol used to refine Comparable in Swift 3
* Scope of Issue: When I introduced the SignedNumber type alias for source compatibility in Swift 3 mode, the Comparable part was lost. This change introduces it back.
* Risk: Minimal
* Reviewed By: Ben Cohen
* Testing: Automated test suite
* Directions for QA: N/A
* Radar: <rdar://problem/32235653>