### PR TITLE
[process-stats-dir] Divide delta by old rather than new.

### DIFF
--- a/utils/process-stats-dir.py
+++ b/utils/process-stats-dir.py
@@ -240,7 +240,7 @@ def compare_frontend_stats(args):
             if old == 0 or new == 0:
                 continue
             delta = (new - old)
-            delta_pct = round((float(delta) / float(new)) * 100.0, 2)
+            delta_pct = round((float(delta) / float(old)) * 100.0, 2)
             if (stat_name.startswith("time.") and
                abs(delta) < args.delta_usec_thresh):
                 continue


### PR DESCRIPTION
Make the output or `--compare-frontend-stats` make a little more sense.