### PR TITLE
[4.0] [Serialization] Stop pre-loading generic environments.

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1474,6 +1474,10 @@ public:
                                  GenericSignature *genericSig,
                                  uint64_t genericEnvData);
 
+  /// Whether this generic context has a lazily-created generic environment
+  /// that has not yet been constructed.
+  bool hasLazyGenericEnvironment() const;
+
   /// Set the generic context of this context.
   void setGenericEnvironment(GenericEnvironment *genericEnv);
 };

--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -312,6 +312,10 @@ public:
   /// of its parents.
   GenericEnvironment *getGenericEnvironmentOfContext() const;
 
+  /// Whether the context has a generic environment that will be constructed
+  /// on first access (but has not yet been constructed).
+  bool contextHasLazyGenericEnvironment() const;
+
   /// Map an interface type to a contextual type within this context.
   Type mapTypeIntoContext(Type type) const;
 

--- a/include/swift/Serialization/ModuleFile.h
+++ b/include/swift/Serialization/ModuleFile.h
@@ -84,17 +84,6 @@ class ModuleFile : public LazyMemberLoader {
   /// The number of entities that are currently being deserialized.
   unsigned NumCurrentDeserializingEntities = 0;
 
-  /// Declaration contexts with delayed generic environments, which will be
-  /// completed as a pending action.
-  ///
-  /// This should only be used on the module returned by
-  /// getModuleFileForDelayedActions().
-  ///
-  /// FIXME: This is needed because completing a generic environment can
-  /// require the type checker, which might be gone if we delay generic
-  /// environments too far. It is a hack.
-  std::vector<DeclContext *> DelayedGenericEnvironments;
-
   /// RAII class to be used when deserializing an entity.
   class DeserializingEntityRAII {
     ModuleFile &MF;

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -653,6 +653,10 @@ GenericEnvironment *GenericContext::getGenericEnvironment() const {
   return nullptr;
 }
 
+bool GenericContext::hasLazyGenericEnvironment() const {
+  return GenericSigOrEnv.dyn_cast<GenericSignature *>() != nullptr;
+}
+
 void GenericContext::setGenericEnvironment(GenericEnvironment *genericEnv) {
   assert((GenericSigOrEnv.isNull() ||
           getGenericSignature()->getCanonicalSignature() ==

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -207,12 +207,6 @@ ModuleFile &ModuleFile::getModuleFileForDelayedActions() {
 void ModuleFile::finishPendingActions() {
   assert(&getModuleFileForDelayedActions() == this &&
          "wrong module used for delayed actions");
-  while (!DelayedGenericEnvironments.empty()) {
-    // Force completion of the last generic environment.
-    auto genericEnvDC = DelayedGenericEnvironments.back();
-    DelayedGenericEnvironments.pop_back();
-    (void)genericEnvDC->getGenericEnvironmentOfContext();
-  }
 }
 
 /// Translate from the serialization DefaultArgumentKind enumerators, which are
@@ -922,8 +916,6 @@ void ModuleFile::configureGenericEnvironment(
   // creation.
   if (auto genericSig = sigOrEnv.dyn_cast<GenericSignature *>()) {
     genericDecl->setLazyGenericEnvironment(this, genericSig, envID);
-    ModuleFile &delayedActionFile = getModuleFileForDelayedActions();
-    delayedActionFile.DelayedGenericEnvironments.push_back(genericDecl);
     return;
   }
 

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -1297,11 +1297,7 @@ Status ModuleFile::associateWithFileContext(FileUnit *file,
   return getStatus();
 }
 
-ModuleFile::~ModuleFile() {
-  assert(DelayedGenericEnvironments.empty() &&
-         "either finishPendingActions() was never called, or someone forgot "
-         "to use getModuleFileForDelayedActions()");
-}
+ModuleFile::~ModuleFile() { }
 
 void ModuleFile::lookupValue(DeclName name,
                              SmallVectorImpl<ValueDecl*> &results) {


### PR DESCRIPTION
**Explanation**: Improve compile-time performance by lazily completed deserialized "generic environments, which avoids a significant amount of up-front work that is rarely required by later stages.
**Scope**: In the trivial case (`let _ = [1, 2]`), provides a 50% time reduction in type-checking. On an actual project we've been using for benchmarking, it was a 25% time reduction. Because this affects deserialization of the standard library, there will be a win across all Swift projects, although the affect will likely be lesser for large source files (where deserialization time is less likely to dominate) and with Release WMO builds (where deserialization time is amortized away)
**Radar**: rdar://problem/32102638
**Risk**: Moderate. A while ago (pre-Swift-3.1) we made generic environment deserialization lazy, then ran into problems when we did so that would manifest as crashes in the optimizer. We *think* we've fixed all of the underlying issues that caused those crashes, but because such problems only occur at scale, the normal compiler regression test suite isn't a good way to flush out such issues.
**Testing**: Compiler regression testing, source compatibility suite, built a couple of nontrivial apps .