### PR TITLE
[4.0] [ClangImporter] Import-as-member support for anonymous enum constants

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3067,7 +3067,7 @@ namespace {
         auto result = Impl.createConstant(name, dc, type,
                                           clang::APValue(decl->getInitVal()),
                                           ConstantConvertKind::Coerce,
-                                          /*static*/ false, decl);
+                                          /*static*/dc->isTypeContext(), decl);
         Impl.ImportedDecls[{decl->getCanonicalDecl(), getVersion()}] = result;
 
         // If this is a compatibility stub, mark it as such.
@@ -7423,8 +7423,7 @@ ClangImporter::Implementation::importDeclContextOf(
 
   // If the declaration was not global to start with, we're done.
   bool isGlobal =
-    decl->getDeclContext()->getRedeclContext()->isTranslationUnit() &&
-    !isa<clang::EnumConstantDecl>(decl);
+    decl->getDeclContext()->getRedeclContext()->isTranslationUnit();
   if (!isGlobal) return importedDC;
 
   // If the resulting declaration context is not a nominal type,
@@ -7592,6 +7591,7 @@ ClangImporter::Implementation::createConstant(Identifier name, DeclContext *dc,
   func->setStatic(isStatic);
   func->setInterfaceType(getterType);
   func->setAccessibility(getOverridableAccessibility(dc));
+  func->setImplicit();
 
   // If we're not done type checking, build the getter body.
   if (!hasFinishedTypeChecking()) {

--- a/lib/ClangImporter/SwiftLookupTable.cpp
+++ b/lib/ClangImporter/SwiftLookupTable.cpp
@@ -418,9 +418,13 @@ static bool isGlobalAsMember(SwiftLookupTable::SingleEntry entry,
   // We have a declaration.
   auto decl = entry.get<clang::NamedDecl *>();
 
-  // Enumerators are always stored within the enumeration, despite
-  // having the translation unit as their redeclaration context.
-  if (isa<clang::EnumConstantDecl>(decl)) return false;
+  // Enumerators have the translation unit as their redeclaration context,
+  // but members of anonymous enums are still allowed to be in the
+  // global-as-member category.
+  if (isa<clang::EnumConstantDecl>(decl)) {
+    const auto *theEnum = cast<clang::EnumDecl>(decl->getDeclContext());
+    return !theEnum->hasNameForLinkage();
+  }
 
   // If the redeclaration context is namespace-scope, then we're
   // mapping as a member.

--- a/test/ClangImporter/Inputs/custom-modules/SwiftName.h
+++ b/test/ClangImporter/Inputs/custom-modules/SwiftName.h
@@ -1,6 +1,12 @@
 #define SWIFT_NAME(X) __attribute__((swift_name(#X)))
 
-#define SWIFT_ENUM(_type, _name) enum _name : _type _name; enum __attribute__((enum_extensibility(open))) _name : _type
+#if __OBJC__
+# define SWIFT_ENUM(_type, _name) \
+  enum _name : _type _name; enum __attribute__((enum_extensibility(open))) _name : _type
+#else
+# define SWIFT_ENUM(_type, _name) \
+  enum _name _name; enum __attribute__((enum_extensibility(open))) _name
+#endif
 
 void drawString(const char *, int x, int y) SWIFT_NAME(drawString(_:x:y:));
 
@@ -26,9 +32,25 @@ typedef int my_int_t SWIFT_NAME(MyInt);
 void spuriousAPINotedSwiftName(int);
 void poorlyNamedFunction(const char *);
 
+struct BoxForConstants {
+  int dummy;
+};
+
+enum {
+  AnonymousEnumConstant SWIFT_NAME(BoxForConstants.anonymousEnumConstant)
+};
+
+#if __OBJC__
 @interface Foo
 - (instancetype)init;
 @end
 
 void acceptsClosure(id value, void (*fn)(void)) SWIFT_NAME(Foo.accepts(self:closure:));
 void acceptsClosureStatic(void (*fn)(void)) SWIFT_NAME(Foo.accepts(closure:));
+
+enum {
+  // Note that there was specifically a crash when renaming onto an ObjC class,
+  // not just a struct.
+  AnonymousEnumConstantObjC SWIFT_NAME(Foo.anonymousEnumConstant)
+};
+#endif

--- a/test/ClangImporter/attr-swift_name_renaming-objc.swift
+++ b/test/ClangImporter/attr-swift_name_renaming-objc.swift
@@ -1,0 +1,27 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/Inputs/custom-modules -Xcc -w -typecheck -verify %s
+
+// REQUIRES: objc_interop
+
+import SwiftName
+
+func test() {
+  // This particular instance method mapping previously caused a crash because
+  // of the trailing closure.
+  acceptsClosure(Foo(), test) // expected-error {{'acceptsClosure' has been replaced by instance method 'Foo.accepts(closure:)'}} {{3-17=(Foo()).accepts}} {{18-25=}} {{25-25=closure: }}
+  acceptsClosure(Foo()) {} // expected-error {{'acceptsClosure' has been replaced by instance method 'Foo.accepts(closure:)'}} {{3-17=(Foo()).accepts}} {{18-23=}}
+
+  Foo().accepts(closure: test)
+  Foo().accepts() {}
+  Foo().accepts {}
+
+  acceptsClosureStatic(test) // expected-error {{'acceptsClosureStatic' has been replaced by 'Foo.accepts(closure:)'}} {{3-23=Foo.accepts}}
+  acceptsClosureStatic() {} // expected-error {{'acceptsClosureStatic' has been replaced by 'Foo.accepts(closure:)'}} {{3-23=Foo.accepts}}
+  acceptsClosureStatic {} // expected-error {{'acceptsClosureStatic' has been replaced by 'Foo.accepts(closure:)'}} {{3-23=Foo.accepts}}
+
+  Foo.accepts(closure: test)
+  Foo.accepts() {}
+  Foo.accepts {}
+
+  _ = AnonymousEnumConstantObjC // expected-error {{'AnonymousEnumConstantObjC' has been renamed to 'Foo.anonymousEnumConstant'}}
+  _ = Foo.anonymousEnumConstant // okay
+}

--- a/test/ClangImporter/attr-swift_name_renaming.swift
+++ b/test/ClangImporter/attr-swift_name_renaming.swift
@@ -1,7 +1,5 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/Inputs/custom-modules -Xcc -w -typecheck -verify %s
 
-// XFAIL: linux
-
 import SwiftName
 
 func test() {
@@ -34,20 +32,6 @@ func test() {
   spuriousAPINotedSwiftName(0)
   nicelyRenamedFunction("go apinotes!")
 
-  // This particular instance method mapping previously caused a crash because
-  // of the trailing closure.
-  acceptsClosure(Foo(), test) // expected-error {{'acceptsClosure' has been replaced by instance method 'Foo.accepts(closure:)'}} {{3-17=(Foo()).accepts}} {{18-25=}} {{25-25=closure: }}
-  acceptsClosure(Foo()) {} // expected-error {{'acceptsClosure' has been replaced by instance method 'Foo.accepts(closure:)'}} {{3-17=(Foo()).accepts}} {{18-23=}}
-
-  Foo().accepts(closure: test)
-  Foo().accepts() {}
-  Foo().accepts {}
-
-  acceptsClosureStatic(test) // expected-error {{'acceptsClosureStatic' has been replaced by 'Foo.accepts(closure:)'}} {{3-23=Foo.accepts}}
-  acceptsClosureStatic() {} // expected-error {{'acceptsClosureStatic' has been replaced by 'Foo.accepts(closure:)'}} {{3-23=Foo.accepts}}
-  acceptsClosureStatic {} // expected-error {{'acceptsClosureStatic' has been replaced by 'Foo.accepts(closure:)'}} {{3-23=Foo.accepts}}
-
-  Foo.accepts(closure: test)
-  Foo.accepts() {}
-  Foo.accepts {}
+  _ = AnonymousEnumConstant // expected-error {{'AnonymousEnumConstant' has been renamed to 'BoxForConstants.anonymousEnumConstant'}}
+  _ = BoxForConstants.anonymousEnumConstant // okay
 }


### PR DESCRIPTION
Cherry-pick of #9633 to the 4.0 branch. Reviewed by @milseman.

rdar://problem/32208235