### PR TITLE
Always try to call the most-derived ObjC protocol method

### DIFF
--- a/test/ClangImporter/Inputs/mirror_import_overrides_1.h
+++ b/test/ClangImporter/Inputs/mirror_import_overrides_1.h
@@ -1,0 +1,23 @@
+@protocol Context
+- (void) operate;
+@end
+
+@protocol A
+- (void) use: (nonnull void(^)(__nonnull id)) callback;
+@end
+
+@protocol B<A>
+@end
+
+@protocol C<A>
+- (void) use: (nonnull void(^)(__nonnull id<Context>)) callback;
+@end
+
+@protocol D<C, B>
+@end
+
+@interface NSObject
+@end
+
+@interface Widget : NSObject<D>
+@end

--- a/test/ClangImporter/Inputs/mirror_import_overrides_2.h
+++ b/test/ClangImporter/Inputs/mirror_import_overrides_2.h
@@ -1,0 +1,23 @@
+@protocol Context
+- (void) operate;
+@end
+
+@protocol A
+- (void) use: (nonnull void(^)(__nonnull id)) callback;
+@end
+
+@protocol B<A>
+@end
+
+@protocol C<A>
+- (void) use: (nonnull void(^)(__nonnull id<Context>)) callback;
+@end
+
+@protocol D<B, C>
+@end
+
+@interface NSObject
+@end
+
+@interface Widget : NSObject<D>
+@end

--- a/test/ClangImporter/mirror_import_overrides.swift
+++ b/test/ClangImporter/mirror_import_overrides.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -import-objc-header %S/Inputs/mirror_import_overrides_1.h -typecheck -verify %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -import-objc-header %S/Inputs/mirror_import_overrides_2.h -typecheck -verify %s
+
+// REQUIRES: objc_interop
+
+// rdar://31471034
+
+func foo(widget: Widget) {
+  widget.use { context in
+    context.operate()
+  }
+}


### PR DESCRIPTION
Don't mirror-import a protocol method if there's another method in the class's protocol hierarchy that overrides it.

rdar://31471034