### PR TITLE
[4.0] Add Codable conformance to common Foundation types

### DIFF
--- a/stdlib/public/SDK/CoreGraphics/CGFloat.swift.gyb
+++ b/stdlib/public/SDK/CoreGraphics/CGFloat.swift.gyb
@@ -807,3 +807,35 @@ extension CGFloat : _CVarArgPassedAsDouble, _CVarArgAligned {
     return native._cVarArgAlignment
   }
 }
+
+extension CGFloat : Codable {
+  @_transparent
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    do {
+      self.native = try container.decode(NativeType.self)
+    } catch DecodingError.typeMismatch(let type, let context) {
+      // We may have encoded as a different type on a different platform. A
+      // strict fixed-format decoder may disallow a conversion, so let's try the
+      // other type.
+      do {
+        if NativeType.self == Float.self {
+          self.native = NativeType(try container.decode(Double.self))
+        } else {
+          self.native = NativeType(try container.decode(Float.self))
+        }
+      } catch {
+        // Failed to decode as the other type, too. This is neither a Float nor
+        // a Double. Throw the old error; we don't want to clobber the original
+        // info.
+        throw DecodingError.typeMismatch(type, context)
+      }
+    }
+  }
+
+  @_transparent
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(self.native)
+  }
+}

--- a/stdlib/public/SDK/Foundation/AffineTransform.swift
+++ b/stdlib/public/SDK/Foundation/AffineTransform.swift
@@ -334,4 +334,26 @@ extension NSAffineTransform : _HasCustomAnyHashableRepresentation {
     }
 }
 
+extension AffineTransform : Codable {
+    public init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        m11 = try container.decode(CGFloat.self)
+        m12 = try container.decode(CGFloat.self)
+        m21 = try container.decode(CGFloat.self)
+        m22 = try container.decode(CGFloat.self)
+        tX  = try container.decode(CGFloat.self)
+        tY  = try container.decode(CGFloat.self)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        try container.encode(self.m11)
+        try container.encode(self.m12)
+        try container.encode(self.m21)
+        try container.encode(self.m22)
+        try container.encode(self.tX)
+        try container.encode(self.tY)
+    }
+}
+
 #endif

--- a/stdlib/public/SDK/Foundation/Calendar.swift
+++ b/stdlib/public/SDK/Foundation/Calendar.swift
@@ -1009,7 +1009,7 @@ public struct Calendar : Hashable, Equatable, ReferenceConvertible, _MutableBoxi
         }
     }
     
-    private static func _fromNSCalendarIdentifier(_ identifier : NSCalendar.Identifier) -> Identifier {
+    internal static func _fromNSCalendarIdentifier(_ identifier : NSCalendar.Identifier) -> Identifier {
         if #available(OSX 10.10, iOS 8.0, *) {
             let identifierMap : [NSCalendar.Identifier : Identifier] =
                 [.gregorian : .gregorian,
@@ -1128,3 +1128,35 @@ extension NSCalendar : _HasCustomAnyHashableRepresentation {
     }
 }
 
+extension Calendar : Codable {
+    private enum CodingKeys : Int, CodingKey {
+        case identifier
+        case locale
+        case timeZone
+        case firstWeekday
+        case minimumDaysInFirstWeek
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let identifierString = try container.decode(String.self, forKey: .identifier)
+        let identifier = Calendar._fromNSCalendarIdentifier(NSCalendar.Identifier(rawValue: identifierString))
+        self.init(identifier: identifier)
+
+        self.locale = try container.decodeIfPresent(Locale.self, forKey: .locale)
+        self.timeZone = try container.decode(TimeZone.self, forKey: .timeZone)
+        self.firstWeekday = try container.decode(Int.self, forKey: .firstWeekday)
+        self.minimumDaysInFirstWeek = try container.decode(Int.self, forKey: .minimumDaysInFirstWeek)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        let identifier = Calendar._toNSCalendarIdentifier(self.identifier).rawValue
+        try container.encode(identifier, forKey: .identifier)
+        try container.encode(self.locale, forKey: .locale)
+        try container.encode(self.timeZone, forKey: .timeZone)
+        try container.encode(self.firstWeekday, forKey: .firstWeekday)
+        try container.encode(self.minimumDaysInFirstWeek, forKey: .minimumDaysInFirstWeek)
+    }
+}

--- a/stdlib/public/SDK/Foundation/CharacterSet.swift
+++ b/stdlib/public/SDK/Foundation/CharacterSet.swift
@@ -806,3 +806,19 @@ extension NSCharacterSet : _HasCustomAnyHashableRepresentation {
     }
 }
 
+extension CharacterSet : Codable {
+    private enum CodingKeys : Int, CodingKey {
+        case bitmap
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let bitmap = try container.decode(Data.self, forKey: .bitmap)
+        self.init(bitmapRepresentation: bitmap)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.bitmapRepresentation, forKey: .bitmap)
+    }
+}

--- a/stdlib/public/SDK/Foundation/Data.swift
+++ b/stdlib/public/SDK/Foundation/Data.swift
@@ -1744,3 +1744,47 @@ extension NSData : _HasCustomAnyHashableRepresentation {
         return AnyHashable(Data._unconditionallyBridgeFromObjectiveC(self))
     }
 }
+
+extension Data : Codable {
+    public init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+
+        // It's more efficient to pre-allocate the buffer if we can.
+        if let count = container.count {
+            self.init(count: count)
+
+            // Loop only until count, not while !container.isAtEnd, in case count is underestimated (this is misbehavior) and we haven't allocated enough space.
+            // We don't want to write past the end of what we allocated.
+            for i in 0 ..< count {
+                let byte = try container.decode(UInt8.self)
+                self[i] = byte
+            }
+        } else {
+            self.init()
+        }
+
+        while !container.isAtEnd {
+            var byte = try container.decode(UInt8.self)
+            self.append(&byte, count: 1)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+
+        // Since enumerateBytes does not rethrow, we need to catch the error, stow it away, and rethrow if we stopped.
+        var caughtError: Error? = nil
+        self.enumerateBytes { (buffer: UnsafeBufferPointer<UInt8>, byteIndex: Data.Index, stop: inout Bool) in
+            do {
+                try container.encode(contentsOf: buffer)
+            } catch {
+                caughtError = error
+                stop = true
+            }
+        }
+
+        if let error = caughtError {
+            throw error
+        }
+    }
+}

--- a/stdlib/public/SDK/Foundation/Date.swift
+++ b/stdlib/public/SDK/Foundation/Date.swift
@@ -284,3 +284,16 @@ extension Date : CustomPlaygroundQuickLookable {
         return .text(summary)
     }
 }
+
+extension Date : Codable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let timestamp = try container.decode(Double.self)
+        self.init(timeIntervalSinceReferenceDate: timestamp)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(self.timeIntervalSinceReferenceDate)
+    }
+}

--- a/stdlib/public/SDK/Foundation/DateComponents.swift
+++ b/stdlib/public/SDK/Foundation/DateComponents.swift
@@ -353,3 +353,83 @@ extension NSDateComponents : _HasCustomAnyHashableRepresentation {
     }
 }
 
+extension DateComponents : Codable {
+    private enum CodingKeys : Int, CodingKey {
+        case calendar
+        case timeZone
+        case era
+        case year
+        case month
+        case day
+        case hour
+        case minute
+        case second
+        case nanosecond
+        case weekday
+        case weekdayOrdinal
+        case quarter
+        case weekOfMonth
+        case weekOfYear
+        case yearForWeekOfYear
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container  = try decoder.container(keyedBy: CodingKeys.self)
+        let calendar   = try container.decodeIfPresent(Calendar.self, forKey: .calendar)
+        let timeZone   = try container.decodeIfPresent(TimeZone.self, forKey: .timeZone)
+        let era        = try container.decodeIfPresent(Int.self, forKey: .era)
+        let year       = try container.decodeIfPresent(Int.self, forKey: .year)
+        let month      = try container.decodeIfPresent(Int.self, forKey: .month)
+        let day        = try container.decodeIfPresent(Int.self, forKey: .day)
+        let hour       = try container.decodeIfPresent(Int.self, forKey: .hour)
+        let minute     = try container.decodeIfPresent(Int.self, forKey: .minute)
+        let second     = try container.decodeIfPresent(Int.self, forKey: .second)
+        let nanosecond = try container.decodeIfPresent(Int.self, forKey: .nanosecond)
+
+        let weekday           = try container.decodeIfPresent(Int.self, forKey: .weekday)
+        let weekdayOrdinal    = try container.decodeIfPresent(Int.self, forKey: .weekdayOrdinal)
+        let quarter           = try container.decodeIfPresent(Int.self, forKey: .quarter)
+        let weekOfMonth       = try container.decodeIfPresent(Int.self, forKey: .weekOfMonth)
+        let weekOfYear        = try container.decodeIfPresent(Int.self, forKey: .weekOfYear)
+        let yearForWeekOfYear = try container.decodeIfPresent(Int.self, forKey: .yearForWeekOfYear)
+
+        self.init(calendar: calendar,
+                  timeZone: timeZone,
+                  era: era,
+                  year: year,
+                  month: month,
+                  day: day,
+                  hour: hour,
+                  minute: minute,
+                  second: second,
+                  nanosecond: nanosecond,
+                  weekday: weekday,
+                  weekdayOrdinal: weekdayOrdinal,
+                  quarter: quarter,
+                  weekOfMonth: weekOfMonth,
+                  weekOfYear: weekOfYear,
+                  yearForWeekOfYear: yearForWeekOfYear)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        // TODO: Replace all with encodeIfPresent, when added.
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        if self.calendar   != nil { try container.encode(self.calendar!, forKey: .calendar) }
+        if self.timeZone   != nil { try container.encode(self.timeZone!, forKey: .timeZone) }
+        if self.era        != nil { try container.encode(self.era!, forKey: .era) }
+        if self.year       != nil { try container.encode(self.year!, forKey: .year) }
+        if self.month      != nil { try container.encode(self.month!, forKey: .month) }
+        if self.day        != nil { try container.encode(self.day!, forKey: .day) }
+        if self.hour       != nil { try container.encode(self.hour!, forKey: .hour) }
+        if self.minute     != nil { try container.encode(self.minute!, forKey: .minute) }
+        if self.second     != nil { try container.encode(self.second!, forKey: .second) }
+        if self.nanosecond != nil { try container.encode(self.nanosecond!, forKey: .nanosecond) }
+
+        if self.weekday           != nil { try container.encode(self.weekday!, forKey: .weekday) }
+        if self.weekdayOrdinal    != nil { try container.encode(self.weekdayOrdinal!, forKey: .weekdayOrdinal) }
+        if self.quarter           != nil { try container.encode(self.quarter!, forKey: .quarter) }
+        if self.weekOfMonth       != nil { try container.encode(self.weekOfMonth!, forKey: .weekOfMonth) }
+        if self.weekOfYear        != nil { try container.encode(self.weekOfYear!, forKey: .weekOfYear) }
+        if self.yearForWeekOfYear != nil { try container.encode(self.yearForWeekOfYear!, forKey: .yearForWeekOfYear) }
+    }
+}

--- a/stdlib/public/SDK/Foundation/DateInterval.swift
+++ b/stdlib/public/SDK/Foundation/DateInterval.swift
@@ -15,7 +15,7 @@ import _SwiftCoreFoundationOverlayShims
 
 /// DateInterval represents a closed date interval in the form of [startDate, endDate].  It is possible for the start and end dates to be the same with a duration of 0.  DateInterval does not support reverse intervals i.e. intervals where the duration is less than 0 and the end date occurs earlier in time than the start date.
 @available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
-public struct DateInterval : ReferenceConvertible, Comparable, Hashable {
+public struct DateInterval : ReferenceConvertible, Comparable, Hashable, Codable {
     public typealias ReferenceType = NSDateInterval
     
     /// The start date.

--- a/stdlib/public/SDK/Foundation/Decimal.swift
+++ b/stdlib/public/SDK/Foundation/Decimal.swift
@@ -475,3 +475,58 @@ extension Decimal : _ObjectiveCBridgeable {
         return result!
     }
 }
+
+extension Decimal : Codable {
+    private enum CodingKeys : Int, CodingKey {
+        case exponent
+        case length
+        case isNegative
+        case isCompact
+        case mantissa
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let exponent = try container.decode(CInt.self, forKey: .exponent)
+        let length = try container.decode(CUnsignedInt.self, forKey: .length)
+        let isNegative = try container.decode(Bool.self, forKey: .isNegative)
+        let isCompact = try container.decode(Bool.self, forKey: .isCompact)
+
+        var mantissaContainer = try container.nestedUnkeyedContainer(forKey: .mantissa)
+        var mantissa: (CUnsignedShort, CUnsignedShort, CUnsignedShort, CUnsignedShort,
+                       CUnsignedShort, CUnsignedShort, CUnsignedShort, CUnsignedShort) = (0,0,0,0,0,0,0,0)
+        mantissa.0 = try mantissaContainer.decode(CUnsignedShort.self)
+        mantissa.1 = try mantissaContainer.decode(CUnsignedShort.self)
+        mantissa.2 = try mantissaContainer.decode(CUnsignedShort.self)
+        mantissa.3 = try mantissaContainer.decode(CUnsignedShort.self)
+        mantissa.4 = try mantissaContainer.decode(CUnsignedShort.self)
+        mantissa.5 = try mantissaContainer.decode(CUnsignedShort.self)
+        mantissa.6 = try mantissaContainer.decode(CUnsignedShort.self)
+        mantissa.7 = try mantissaContainer.decode(CUnsignedShort.self)
+
+        self.init(_exponent: exponent,
+                  _length: length,
+                  _isNegative: CUnsignedInt(isNegative ? 1 : 0),
+                  _isCompact: CUnsignedInt(isCompact ? 1 : 0),
+                  _reserved: 0,
+                  _mantissa: mantissa)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(_exponent, forKey: .exponent)
+        try container.encode(_length, forKey: .length)
+        try container.encode(_isNegative == 0 ? false : true, forKey: .isNegative)
+        try container.encode(_isCompact == 0 ? false : true, forKey: .isCompact)
+
+        var mantissaContainer = container.nestedUnkeyedContainer(forKey: .mantissa)
+        try mantissaContainer.encode(_mantissa.0)
+        try mantissaContainer.encode(_mantissa.1)
+        try mantissaContainer.encode(_mantissa.2)
+        try mantissaContainer.encode(_mantissa.3)
+        try mantissaContainer.encode(_mantissa.4)
+        try mantissaContainer.encode(_mantissa.5)
+        try mantissaContainer.encode(_mantissa.6)
+        try mantissaContainer.encode(_mantissa.7)
+    }
+}

--- a/stdlib/public/SDK/Foundation/IndexSet.swift
+++ b/stdlib/public/SDK/Foundation/IndexSet.swift
@@ -916,3 +916,38 @@ private final class _MutablePairHandle<ImmutableType : NSObject, MutableType : N
         }
     }
 }
+
+extension IndexSet : Codable {
+    private enum CodingKeys : Int, CodingKey {
+        case indexes
+    }
+
+    private enum RangeCodingKeys : Int, CodingKey {
+        case location
+        case length
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        var indexesContainer = try container.nestedUnkeyedContainer(forKey: .indexes)
+        self.init()
+
+        while !indexesContainer.isAtEnd {
+            let rangeContainer = try indexesContainer.nestedContainer(keyedBy: RangeCodingKeys.self)
+            let startIndex = try rangeContainer.decode(Int.self, forKey: .location)
+            let count = try rangeContainer.decode(Int.self, forKey: .length)
+            self.insert(integersIn: startIndex ..< (startIndex + count))
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        var indexesContainer = container.nestedUnkeyedContainer(forKey: .indexes)
+
+        for range in self.rangeView {
+            var rangeContainer = indexesContainer.nestedContainer(keyedBy: RangeCodingKeys.self)
+            try rangeContainer.encode(range.startIndex, forKey: .location)
+            try rangeContainer.encode(range.count, forKey: .length)
+        }
+    }
+}

--- a/stdlib/public/SDK/Foundation/JSONEncoder.swift
+++ b/stdlib/public/SDK/Foundation/JSONEncoder.swift
@@ -177,16 +177,23 @@ fileprivate class _JSONEncoder : Encoder {
         return ret
     }
 
-    /// Asserts that a new container can be requested at this coding path.
-    /// `preconditionFailure()`s if one cannot be requested.
-    func assertCanRequestNewContainer() {
+    /// Returns whether a new element can be encoded at this coding path.
+    ///
+    /// `true` if an element has not yet been encoded at this coding path; `false` otherwise.
+    var canEncodeNewElement: Bool {
         // Every time a new value gets encoded, the key it's encoded for is pushed onto the coding path (even if it's a nil key from an unkeyed container).
         // At the same time, every time a container is requested, a new value gets pushed onto the storage stack.
         // If there are more values on the storage stack than on the coding path, it means the value is requesting more than one container, which violates the precondition.
-
+        //
         // This means that anytime something that can request a new container goes onto the stack, we MUST push a key onto the coding path.
         // Things which will not request containers do not need to have the coding path extended for them (but it doesn't matter if it is, because they will not reach here).
-        guard self.storage.count == self.codingPath.count else {
+        return self.storage.count == self.codingPath.count
+    }
+
+    /// Asserts that a new container can be requested at this coding path.
+    /// `preconditionFailure()`s if one cannot be requested.
+    func assertCanRequestNewContainer() {
+        guard self.canEncodeNewElement else {
             let previousContainerType: String
             if self.storage.containers.last is NSDictionary {
                 previousContainerType = "keyed"
@@ -457,14 +464,14 @@ fileprivate struct _JSONUnkeyedEncodingContainer : UnkeyedEncodingContainer {
 }
 
 extension _JSONEncoder : SingleValueEncodingContainer {
-    // MARK: Utility
+    // MARK: - Utility Methods
 
     /// Asserts that a single value can be encoded at the current coding path (i.e. that one has not already been encoded through this container).
     /// `preconditionFailure()`s if one cannot be encoded.
     ///
     /// This is similar to assertCanRequestNewContainer above.
     func assertCanEncodeSingleValue() {
-        guard self.storage.count == self.codingPath.count else {
+        guard self.canEncodeNewElement else {
             let previousContainerType: String
             if self.storage.containers.last is NSDictionary {
                 previousContainerType = "keyed"
@@ -691,6 +698,9 @@ extension _JSONEncoder {
         } else if T.self == Data.self {
             // Respect Data encoding strategy
             return try self.box((value as! Data))
+        } else if T.self == URL.self {
+            // Encode URLs as single strings.
+            return self.box((value as! URL).absoluteString)
         }
 
         // The value should request a container from the _JSONEncoder.
@@ -751,24 +761,13 @@ fileprivate class _JSONReferencingEncoder : _JSONEncoder {
         self.codingPath.append(key)
     }
 
-    // MARK: - Overridden Implementations
+    // MARK: - Coding Path Operations
 
-    /// Asserts that we can add a new container at this coding path. See _JSONEncoder.assertCanRequestNewContainer for the logic behind this.
-    override func assertCanRequestNewContainer() {
-        // We can push a new container given that we won't have two containers for the same coding path.
-        // We make sure of this by comparing the number of containers we already have to the length of our coding path (we can push 1 more container than the length of the path, since it starts off empty). Since we copied our reference's coding path (and pushed on the key we were created at), we need to account for that.
-        guard self.storage.count == self.codingPath.count - self.encoder.codingPath.count - 1 else {
-            let previousContainerType: String
-            if self.storage.containers.last is NSDictionary {
-                previousContainerType = "keyed"
-            } else if self.storage.containers.last is NSArray {
-                previousContainerType = "unkeyed"
-            } else {
-                previousContainerType = "single value"
-            }
-
-            preconditionFailure("Attempt to encode with new container when already encoded with \(previousContainerType) container.")
-        }
+    override var canEncodeNewElement: Bool {
+        // With a regular encoder, the storage and coding path grow together.
+        // A referencing encoder, however, inherits its parents coding path, as well as the key it was created for.
+        // We have to take this into account.
+        return self.storage.count == self.codingPath.count - self.encoder.codingPath.count - 1
     }
 
     // MARK: - Deinitialization
@@ -1851,6 +1850,17 @@ extension _JSONDecoder {
             decoded = (try self.unbox(value, as: Date.self) as! T)
         } else if T.self == Data.self {
             decoded = (try self.unbox(value, as: Data.self) as! T)
+        } else if T.self == URL.self {
+            guard let urlString = try self.unbox(value, as: String.self) else {
+                return nil
+            }
+
+            guard let url = URL(string: urlString) else {
+                throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath,
+                                                                        debugDescription: "Invalid URL string."))
+            }
+
+            decoded = (url as! T)
         } else {
             self.storage.push(container: value)
             decoded = try T(from: self)

--- a/stdlib/public/SDK/Foundation/Locale.swift
+++ b/stdlib/public/SDK/Foundation/Locale.swift
@@ -481,3 +481,19 @@ extension NSLocale : _HasCustomAnyHashableRepresentation {
     }
 }
 
+extension Locale : Codable {
+    private enum CodingKeys : Int, CodingKey {
+        case identifier
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let identifier = try container.decode(String.self, forKey: .identifier)
+        self.init(identifier: identifier)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.identifier, forKey: .identifier)
+    }
+}

--- a/stdlib/public/SDK/Foundation/Measurement.swift
+++ b/stdlib/public/SDK/Foundation/Measurement.swift
@@ -248,3 +248,75 @@ extension MeasurementFormatter {
         }
     }
 }
+
+// @available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
+// extension Unit : Codable {
+//     public convenience init(from decoder: Decoder) throws {
+//         let container = try decoder.singleValueContainer()
+//         let symbol = try container.decode(String.self)
+//         self.init(symbol: symbol)
+//     }
+
+//     public func encode(to encoder: Encoder) throws {
+//         var container = encoder.singleValueContainer()
+//         try container.encode(self.symbol)
+//     }
+// }
+
+@available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
+extension Measurement : Codable {
+    private enum CodingKeys : Int, CodingKey {
+        case value
+        case unit
+    }
+
+    private enum UnitCodingKeys : Int, CodingKey {
+        case symbol
+        case converter
+    }
+
+    private enum LinearConverterCodingKeys : Int, CodingKey {
+        case coefficient
+        case constant
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let value = try container.decode(Double.self, forKey: .value)
+
+        let unitContainer = try container.nestedContainer(keyedBy: UnitCodingKeys.self, forKey: .unit)
+        let symbol = try unitContainer.decode(String.self, forKey: .symbol)
+
+        let unit: UnitType
+        if UnitType.self is Dimension.Type {
+            let converterContainer = try unitContainer.nestedContainer(keyedBy: LinearConverterCodingKeys.self, forKey: .converter)
+            let coefficient = try converterContainer.decode(Double.self, forKey: .coefficient)
+            let constant = try converterContainer.decode(Double.self, forKey: .constant)
+            let unitMetaType = (UnitType.self as! Dimension.Type)
+            unit = (unitMetaType.init(symbol: symbol, converter: UnitConverterLinear(coefficient: coefficient, constant: constant)) as! UnitType)
+        } else {
+            unit = UnitType(symbol: symbol)
+        }
+
+        self.init(value: value, unit: unit)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.value, forKey: .value)
+
+        var unitContainer = container.nestedContainer(keyedBy: UnitCodingKeys.self, forKey: .unit)
+        try unitContainer.encode(self.unit.symbol, forKey: .symbol)
+
+        if UnitType.self is Dimension.Type {
+            guard type(of: (self.unit as! Dimension).converter) is UnitConverterLinear.Type else {
+                preconditionFailure("Cannot encode a Measurement whose UnitType has a non-linear unit converter.")
+            }
+
+            let converter = (self.unit as! Dimension).converter as! UnitConverterLinear
+            var converterContainer = unitContainer.nestedContainer(keyedBy: LinearConverterCodingKeys.self, forKey: .converter)
+            try converterContainer.encode(converter.coefficient, forKey: .coefficient)
+            try converterContainer.encode(converter.constant, forKey: .constant)
+        }
+    }
+}

--- a/stdlib/public/SDK/Foundation/NSRange.swift
+++ b/stdlib/public/SDK/Foundation/NSRange.swift
@@ -172,3 +172,17 @@ extension NSRange : CustomPlaygroundQuickLookable {
     }
 }
 
+extension NSRange : Codable {
+    public init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        let location = try container.decode(Int.self)
+        let length = try container.decode(Int.self)
+        self.init(location: location, length: length)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        try container.encode(self.location)
+        try container.encode(self.length)
+    }
+}

--- a/stdlib/public/SDK/Foundation/PersonNameComponents.swift
+++ b/stdlib/public/SDK/Foundation/PersonNameComponents.swift
@@ -145,3 +145,36 @@ extension NSPersonNameComponents : _HasCustomAnyHashableRepresentation {
     }
 }
 
+@available(OSX 10.11, iOS 9.0, *)
+extension PersonNameComponents : Codable {
+    private enum CodingKeys : Int, CodingKey {
+        case namePrefix
+        case givenName
+        case middleName
+        case familyName
+        case nameSuffix
+        case nickname
+    }
+
+    public init(from decoder: Decoder) throws {
+        self.init()
+
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.namePrefix = try container.decodeIfPresent(String.self, forKey: .namePrefix)
+        self.givenName  = try container.decodeIfPresent(String.self, forKey: .givenName)
+        self.middleName = try container.decodeIfPresent(String.self, forKey: .middleName)
+        self.familyName = try container.decodeIfPresent(String.self, forKey: .familyName)
+        self.nameSuffix = try container.decodeIfPresent(String.self, forKey: .nameSuffix)
+        self.nickname   = try container.decodeIfPresent(String.self, forKey: .nickname)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        if let np = self.namePrefix { try container.encode(np, forKey: .namePrefix) }
+        if let gn = self.givenName  { try container.encode(gn, forKey: .givenName) }
+        if let mn = self.middleName { try container.encode(mn, forKey: .middleName) }
+        if let fn = self.familyName { try container.encode(fn, forKey: .familyName) }
+        if let ns = self.nameSuffix { try container.encode(ns, forKey: .nameSuffix) }
+        if let nn = self.nickname   { try container.encode(nn, forKey: .nickname) }
+    }
+}

--- a/stdlib/public/SDK/Foundation/TimeZone.swift
+++ b/stdlib/public/SDK/Foundation/TimeZone.swift
@@ -277,3 +277,25 @@ extension NSTimeZone : _HasCustomAnyHashableRepresentation {
     }
 }
 
+extension TimeZone : Codable {
+    private enum CodingKeys : Int, CodingKey {
+        case identifier
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let identifier = try container.decode(String.self, forKey: .identifier)
+
+        guard let timeZone = TimeZone(identifier: identifier) else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath,
+                                                                    debugDescription: "Invalid TimeZone identifier."))
+        }
+
+        self = timeZone
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.identifier, forKey: .identifier)
+    }
+}

--- a/stdlib/public/SDK/Foundation/URL.swift
+++ b/stdlib/public/SDK/Foundation/URL.swift
@@ -1172,6 +1172,34 @@ extension URL : CustomPlaygroundQuickLookable {
     }
 }
 
+extension URL : Codable {
+    private enum CodingKeys : Int, CodingKey {
+        case base
+        case relative
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let relative = try container.decode(String.self, forKey: .relative)
+        let base = try container.decodeIfPresent(URL.self, forKey: .base)
+
+        guard let url = URL(string: relative, relativeTo: base) else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath,
+                                                                    debugDescription: "Invalid URL string."))
+        }
+
+        self = url
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.relativeString, forKey: .relative)
+        if let base = self.baseURL {
+            try container.encode(base, forKey: .base)
+        }
+    }
+}
+
 //===----------------------------------------------------------------------===//
 // File references, for playgrounds.
 //===----------------------------------------------------------------------===//

--- a/stdlib/public/SDK/Foundation/UUID.swift
+++ b/stdlib/public/SDK/Foundation/UUID.swift
@@ -163,3 +163,21 @@ extension NSUUID : _HasCustomAnyHashableRepresentation {
     }
 }
 
+extension UUID : Codable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let uuidString = try container.decode(String.self)
+
+        guard let uuid = UUID(uuidString: uuidString) else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath,
+                                                                    debugDescription: "Attempted to decode UUID from invalid UUID string."))
+        }
+
+        self = uuid
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(self.uuidString)
+    }
+}

--- a/test/stdlib/CodableTests.swift
+++ b/test/stdlib/CodableTests.swift
@@ -1,0 +1,498 @@
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+import Foundation
+
+#if FOUNDATION_XCTEST
+import XCTest
+class TestCodableSuper : XCTestCase { }
+#else
+import StdlibUnittest
+class TestCodableSuper { }
+#endif
+
+// MARK: - Helper Functions
+@available(OSX 10.11, iOS 9.0, *)
+func makePersonNameComponents(namePrefix: String? = nil,
+                              givenName: String? = nil,
+                              middleName: String? = nil,
+                              familyName: String? = nil,
+                              nameSuffix: String? = nil,
+                              nickname: String? = nil) -> PersonNameComponents {
+    var result = PersonNameComponents()
+    result.namePrefix = namePrefix
+    result.givenName = givenName
+    result.middleName = middleName
+    result.familyName = familyName
+    result.nameSuffix = nameSuffix
+    result.nickname = nickname
+    return result
+}
+
+func expectRoundTripEquality<T : Codable>(of value: T, encode: (T) throws -> Data, decode: (Data) throws -> T) where T : Equatable {
+    let data: Data
+    do {
+        data = try encode(value)
+    } catch {
+        fatalError("Unable to encode \(T.self) <\(value)>: \(error)")
+    }
+
+    let decoded: T
+    do {
+        decoded = try decode(data)
+    } catch {
+        fatalError("Unable to decode \(T.self) <\(value)>: \(error)")
+    }
+
+    expectEqual(value, decoded, "Decoded \(T.self) <\(decoded)> not equal to original <\(value)>")
+}
+
+func expectRoundTripEqualityThroughJSON<T : Codable>(for value: T) where T : Equatable {
+    let encode = { (_ value: T) throws -> Data in
+        return try JSONEncoder().encode(value)
+    }
+
+    let decode = { (_ data: Data) throws -> T in
+        return try JSONDecoder().decode(T.self, from: data)
+    }
+
+    expectRoundTripEquality(of: value, encode: encode, decode: decode)
+}
+
+func expectRoundTripEqualityThroughPlist<T : Codable>(for value: T) where T : Equatable {
+    let encode = { (_ value: T) throws -> Data in
+        return try PropertyListEncoder().encode(value)
+    }
+
+    let decode = { (_ data: Data) throws -> T in
+        return try PropertyListDecoder().decode(T.self, from: data)
+    }
+
+    expectRoundTripEquality(of: value, encode: encode, decode: decode)
+}
+
+// MARK: - Helper Types
+// A wrapper around a UUID that will allow it to be encoded at the top level of an encoder.
+struct UUIDCodingWrapper : Codable, Equatable {
+    let value: UUID
+
+    init(_ value: UUID) {
+        self.value = value
+    }
+
+    static func ==(_ lhs: UUIDCodingWrapper, _ rhs: UUIDCodingWrapper) -> Bool {
+        return lhs.value == rhs.value
+    }
+}
+
+// MARK: - Tests
+class TestCodable : TestCodableSuper {
+    // MARK: - AffineTransform
+#if os(OSX)
+    lazy var affineTransformValues: [AffineTransform] = [
+        AffineTransform.identity,
+        AffineTransform(),
+        AffineTransform(translationByX: 2.0, byY: 2.0),
+        AffineTransform(scale: 2.0),
+        AffineTransform(rotationByDegrees: .pi / 2),
+
+        AffineTransform(m11: 1.0, m12: 2.5, m21: 66.2, m22: 40.2, tX: -5.5, tY: 3.7),
+        AffineTransform(m11: -55.66, m12: 22.7, m21: 1.5, m22: 0.0, tX: -22, tY: -33),
+        AffineTransform(m11: 4.5, m12: 1.1, m21: 0.025, m22: 0.077, tX: -0.55, tY: 33.2),
+        AffineTransform(m11: 7.0, m12: -2.3, m21: 6.7, m22: 0.25, tX: 0.556, tY: 0.99),
+        AffineTransform(m11: 0.498, m12: -0.284, m21: -0.742, m22: 0.3248, tX: 12, tY: 44)
+    ]
+
+    func test_AffineTransform_JSON() {
+        for transform in affineTransformValues {
+            expectRoundTripEqualityThroughJSON(for: transform)
+        }
+    }
+
+    func test_AffineTransform_Plist() {
+        for transform in affineTransformValues {
+            expectRoundTripEqualityThroughPlist(for: transform)
+        }
+    }
+#endif
+
+    // MARK: - Calendar
+    lazy var calendarValues: [Calendar] = [
+        Calendar(identifier: .gregorian),
+        Calendar(identifier: .buddhist),
+        Calendar(identifier: .chinese),
+        Calendar(identifier: .coptic),
+        Calendar(identifier: .ethiopicAmeteMihret),
+        Calendar(identifier: .ethiopicAmeteAlem),
+        Calendar(identifier: .hebrew),
+        Calendar(identifier: .iso8601),
+        Calendar(identifier: .indian),
+        Calendar(identifier: .islamic),
+        Calendar(identifier: .islamicCivil),
+        Calendar(identifier: .japanese),
+        Calendar(identifier: .persian),
+        Calendar(identifier: .republicOfChina),
+    ]
+
+    func test_Calendar_JSON() {
+        for calendar in calendarValues {
+            expectRoundTripEqualityThroughJSON(for: calendar)
+        }
+    }
+
+    func test_Calendar_Plist() {
+        for calendar in calendarValues {
+            expectRoundTripEqualityThroughPlist(for: calendar)
+        }
+    }
+
+    // MARK: - CharacterSet
+    lazy var characterSetValues: [CharacterSet] = [
+        CharacterSet.controlCharacters,
+        CharacterSet.whitespaces,
+        CharacterSet.whitespacesAndNewlines,
+        CharacterSet.decimalDigits,
+        CharacterSet.letters,
+        CharacterSet.lowercaseLetters,
+        CharacterSet.uppercaseLetters,
+        CharacterSet.nonBaseCharacters,
+        CharacterSet.alphanumerics,
+        CharacterSet.decomposables,
+        CharacterSet.illegalCharacters,
+        CharacterSet.punctuationCharacters,
+        CharacterSet.capitalizedLetters,
+        CharacterSet.symbols,
+        CharacterSet.newlines
+    ]
+
+    func test_CharacterSet_JSON() {
+        for characterSet in characterSetValues {
+            expectRoundTripEqualityThroughJSON(for: characterSet)
+        }
+    }
+
+    func test_CharacterSet_Plist() {
+        for characterSet in characterSetValues {
+            expectRoundTripEqualityThroughPlist(for: characterSet)
+        }
+    }
+
+    // MARK: - DateComponents
+    lazy var dateComponents: Set<Calendar.Component> = [
+        .era, .year, .month, .day, .hour, .minute, .second, .nanosecond,
+        .weekday, .weekdayOrdinal, .quarter, .weekOfMonth, .weekOfYear,
+        .yearForWeekOfYear, .timeZone, .calendar
+    ]
+
+    func test_DateComponents_JSON() {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = calendar.dateComponents(dateComponents, from: Date())
+        expectRoundTripEqualityThroughJSON(for: components)
+    }
+
+    func test_DateComponents_Plist() {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = calendar.dateComponents(dateComponents, from: Date())
+        expectRoundTripEqualityThroughPlist(for: components)
+    }
+
+    // MARK: - DateInterval
+    @available(OSX 10.12, iOS 10.10, watchOS 3.0, tvOS 10.0, *)
+    lazy var dateIntervalValues: [DateInterval] = [
+        DateInterval(),
+        DateInterval(start: Date.distantPast, end: Date()),
+        DateInterval(start: Date(), end: Date.distantFuture),
+        DateInterval(start: Date.distantPast, end: Date.distantFuture)
+    ]
+
+    @available(OSX 10.12, iOS 10.10, watchOS 3.0, tvOS 10.0, *)
+    func test_DateInterval_JSON() {
+        for interval in dateIntervalValues {
+            expectRoundTripEqualityThroughJSON(for: interval)
+        }
+    }
+
+    @available(OSX 10.12, iOS 10.10, watchOS 3.0, tvOS 10.0, *)
+    func test_DateInterval_Plist() {
+        for interval in dateIntervalValues {
+            expectRoundTripEqualityThroughPlist(for: interval)
+        }
+    }
+
+    // MARK: - Decimal
+    lazy var decimalValues: [Decimal] = [
+        Decimal.leastFiniteMagnitude,
+        Decimal.greatestFiniteMagnitude,
+        Decimal.leastNormalMagnitude,
+        Decimal.leastNonzeroMagnitude,
+        Decimal.pi,
+        Decimal()
+    ]
+
+    func test_Decimal_JSON() {
+        for decimal in decimalValues {
+            expectRoundTripEqualityThroughJSON(for: decimal)
+        }
+    }
+
+    func test_Decimal_Plist() {
+        for decimal in decimalValues {
+            expectRoundTripEqualityThroughPlist(for: decimal)
+        }
+    }
+
+    // MARK: - IndexPath
+    lazy var indexPathValues: [IndexPath] = [
+        IndexPath(), // empty
+        IndexPath(index: 0), // single
+        IndexPath(indexes: [1, 2]), // pair
+        IndexPath(indexes: [3, 4, 5, 6, 7, 8]), // array
+    ]
+
+    func test_IndexPath_JSON() {
+        for indexPath in indexPathValues {
+            expectRoundTripEqualityThroughJSON(for: indexPath)
+        }
+    }
+
+    func test_IndexPath_Plist() {
+        for indexPath in indexPathValues {
+            expectRoundTripEqualityThroughPlist(for: indexPath)
+        }
+    }
+
+    // MARK: - IndexSet
+    lazy var indexSetValues: [IndexSet] = [
+        IndexSet(),
+        IndexSet(integer: 42),
+        IndexSet(integersIn: 0 ..< Int.max)
+    ]
+
+    func test_IndexSet_JSON() {
+        for indexSet in indexSetValues {
+            expectRoundTripEqualityThroughJSON(for: indexSet)
+        }
+    }
+
+    func test_IndexSet_Plist() {
+        for indexSet in indexSetValues {
+            expectRoundTripEqualityThroughPlist(for: indexSet)
+        }
+    }
+
+    // MARK: - Locale
+    lazy var localeValues: [Locale] = [
+        Locale(identifier: ""),
+        Locale(identifier: "en"),
+        Locale(identifier: "en_US"),
+        Locale(identifier: "en_US_POSIX"),
+        Locale(identifier: "uk"),
+        Locale(identifier: "fr_FR"),
+        Locale(identifier: "fr_BE"),
+        Locale(identifier: "zh-Hant-HK")
+    ]
+
+    func test_Locale_JSON() {
+        for locale in localeValues {
+            expectRoundTripEqualityThroughJSON(for: locale)
+        }
+    }
+
+    func test_Locale_Plist() {
+        for locale in localeValues {
+            expectRoundTripEqualityThroughPlist(for: locale)
+        }
+    }
+
+    // MARK: - Measurement
+    @available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
+    lazy var unitValues: [Dimension] = [
+        UnitAcceleration.metersPerSecondSquared,
+        UnitMass.kilograms,
+        UnitLength.miles
+    ]
+
+    @available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
+    func test_Measurement_JSON() {
+        for unit in unitValues {
+            expectRoundTripEqualityThroughJSON(for: Measurement(value: 42, unit: unit))
+        }
+    }
+
+    @available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
+    func test_Measurement_Plist() {
+        for unit in unitValues {
+            expectRoundTripEqualityThroughJSON(for: Measurement(value: 42, unit: unit))
+        }
+    }
+
+    // MARK: - NSRange
+    lazy var nsrangeValues: [NSRange] = [
+        NSRange(),
+        NSRange(location: 0, length: Int.max),
+        NSRange(location: NSNotFound, length: 0),
+    ]
+
+    func test_NSRange_JSON() {
+        for range in nsrangeValues {
+            expectRoundTripEqualityThroughJSON(for: range)
+        }
+    }
+
+    func test_NSRange_Plist() {
+        for range in nsrangeValues {
+            expectRoundTripEqualityThroughPlist(for: range)
+        }
+    }
+
+    // MARK: - PersonNameComponents
+    @available(OSX 10.11, iOS 9.0, *)
+    lazy var personNameComponentsValues: [PersonNameComponents] = [
+        makePersonNameComponents(givenName: "John", familyName: "Appleseed"),
+        makePersonNameComponents(givenName: "John", familyName: "Appleseed", nickname: "Johnny"),
+        makePersonNameComponents(namePrefix: "Dr.", givenName: "Jane", middleName: "A.", familyName: "Appleseed", nameSuffix: "Esq.", nickname: "Janie")
+    ]
+
+    @available(OSX 10.11, iOS 9.0, *)
+    func test_PersonNameComponents_JSON() {
+        for components in personNameComponentsValues {
+            expectRoundTripEqualityThroughJSON(for: components)
+        }
+    }
+
+    @available(OSX 10.11, iOS 9.0, *)
+    func test_PersonNameComponents_Plist() {
+        for components in personNameComponentsValues {
+            expectRoundTripEqualityThroughPlist(for: components)
+        }
+    }
+
+    // MARK: - TimeZone
+    lazy var timeZoneValues: [TimeZone] = [
+        TimeZone(identifier: "America/Los_Angeles")!,
+        TimeZone(identifier: "UTC")!,
+        TimeZone.current
+    ]
+
+    func test_TimeZone_JSON() {
+        for timeZone in timeZoneValues {
+            expectRoundTripEqualityThroughJSON(for: timeZone)
+        }
+    }
+
+    func test_TimeZone_Plist() {
+        for timeZone in timeZoneValues {
+            expectRoundTripEqualityThroughPlist(for: timeZone)
+        }
+    }
+
+    // MARK: - URL
+    lazy var urlValues: [URL] = {
+        var values: [URL] = [
+            URL(fileURLWithPath: NSTemporaryDirectory()),
+            URL(fileURLWithPath: "/"),
+            URL(string: "http://apple.com")!,
+            URL(string: "swift", relativeTo: URL(string: "http://apple.com")!)!
+        ]
+
+        if #available(OSX 10.11, iOS 9.0, *) {
+            values.append(URL(fileURLWithPath: "bin/sh", relativeTo: URL(fileURLWithPath: "/")))
+        }
+
+        return values
+    }()
+
+    func test_URL_JSON() {
+        for url in urlValues {
+            expectRoundTripEqualityThroughJSON(for: url)
+        }
+    }
+
+    func test_URL_Plist() {
+        for url in urlValues {
+            expectRoundTripEqualityThroughPlist(for: url)
+        }
+    }
+
+    // MARK: - UUID
+    lazy var uuidValues: [UUID] = [
+        UUID(),
+        UUID(uuidString: "E621E1F8-C36C-495A-93FC-0C247A3E6E5F")!,
+        UUID(uuidString: "e621e1f8-c36c-495a-93fc-0c247a3e6e5f")!,
+        UUID(uuid: uuid_t(0xe6,0x21,0xe1,0xf8,0xc3,0x6c,0x49,0x5a,0x93,0xfc,0x0c,0x24,0x7a,0x3e,0x6e,0x5f))
+    ]
+
+    func test_UUID_JSON() {
+        for uuid in uuidValues {
+            // We have to wrap the UUID since we cannot have a top-level string.
+            expectRoundTripEqualityThroughJSON(for: UUIDCodingWrapper(uuid))
+        }
+    }
+
+    func test_UUID_Plist() {
+        for uuid in uuidValues {
+            // We have to wrap the UUID since we cannot have a top-level string.
+            expectRoundTripEqualityThroughPlist(for: UUIDCodingWrapper(uuid))
+        }
+    }
+}
+
+#if !FOUNDATION_XCTEST
+var CodableTests = TestSuite("TestCodable")
+
+#if os(OSX)
+    CodableTests.test("test_AffineTransform_JSON") { TestCodable().test_AffineTransform_JSON() }
+    CodableTests.test("test_AffineTransform_Plist") { TestCodable().test_AffineTransform_Plist() }
+#endif
+
+CodableTests.test("test_Calendar_JSON") { TestCodable().test_Calendar_JSON() }
+CodableTests.test("test_Calendar_Plist") { TestCodable().test_Calendar_Plist() }
+CodableTests.test("test_CharacterSet_JSON") { TestCodable().test_CharacterSet_JSON() }
+CodableTests.test("test_CharacterSet_Plist") { TestCodable().test_CharacterSet_Plist() }
+CodableTests.test("test_DateComponents_JSON") { TestCodable().test_DateComponents_JSON() }
+CodableTests.test("test_DateComponents_Plist") { TestCodable().test_DateComponents_Plist() }
+
+if #available(OSX 10.12, iOS 10.10, watchOS 3.0, tvOS 10.0, *) {
+    // CodableTests.test("test_DateInterval_JSON") { TestCodable().test_DateInterval_JSON() }
+    CodableTests.test("test_DateInterval_Plist") { TestCodable().test_DateInterval_Plist() }
+}
+
+CodableTests.test("test_Decimal_JSON") { TestCodable().test_Decimal_JSON() }
+CodableTests.test("test_Decimal_Plist") { TestCodable().test_Decimal_Plist() }
+CodableTests.test("test_IndexPath_JSON") { TestCodable().test_IndexPath_JSON() }
+CodableTests.test("test_IndexPath_Plist") { TestCodable().test_IndexPath_Plist() }
+CodableTests.test("test_IndexSet_JSON") { TestCodable().test_IndexSet_JSON() }
+CodableTests.test("test_IndexSet_Plist") { TestCodable().test_IndexSet_Plist() }
+CodableTests.test("test_Locale_JSON") { TestCodable().test_Locale_JSON() }
+CodableTests.test("test_Locale_Plist") { TestCodable().test_Locale_Plist() }
+
+if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
+    // CodableTests.test("test_Measurement_JSON") { TestCodable().test_Measurement_JSON() }
+    // CodableTests.test("test_Measurement_Plist") { TestCodable().test_Measurement_Plist() }
+}
+
+CodableTests.test("test_NSRange_JSON") { TestCodable().test_NSRange_JSON() }
+CodableTests.test("test_NSRange_Plist") { TestCodable().test_NSRange_Plist() }
+
+if #available(OSX 10.11, iOS 9.0, *) {
+    CodableTests.test("test_PersonNameComponents_JSON") { TestCodable().test_PersonNameComponents_JSON() }
+    CodableTests.test("test_PersonNameComponents_Plist") { TestCodable().test_PersonNameComponents_Plist() }
+}
+
+CodableTests.test("test_TimeZone_JSON") { TestCodable().test_TimeZone_JSON() }
+CodableTests.test("test_TimeZone_Plist") { TestCodable().test_TimeZone_Plist() }
+CodableTests.test("test_URL_JSON") { TestCodable().test_URL_JSON() }
+CodableTests.test("test_URL_Plist") { TestCodable().test_URL_Plist() }
+CodableTests.test("test_UUID_JSON") { TestCodable().test_UUID_JSON() }
+CodableTests.test("test_UUID_Plist") { TestCodable().test_UUID_Plist() }
+runAllTests()
+#endif


### PR DESCRIPTION
**What's in this pull request?**
This cherry-picks #9715 for Swift 4.

**Explanation:**
Add conformances + unit tests for
* CGFloat
* AffineTransform
* Calendar
* CharacterSet
* DateComponents
* DateInterval
* Decimal
* IndexPath
* IndexSet
* Locale
* Measurement
* NSRange
* PersonNameComponents
* TimeZone
* URL
* UUID

along with some unit tests for each.

**Scope:** This is an important change for users of the new `Codable` API as it introduces a set of Foundation types that are immediately eligible for encoding & decoding. `Date` and `Data` are already `Codable`, but others like `URL` and `UUID` are critical.

**Radar:** rdar://problem/31950471
**Risk:** Low
**Testing:** This adds unit tests to confirm round-trip encoding behavior for all affected types.