### PR TITLE
Serialization: Use nested type lookup table for cross-module references [4.0]

### DIFF
--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -4445,7 +4445,7 @@ void Serializer::writeAST(ModuleOrSourceFile DC,
     index_block::ObjCMethodTableLayout ObjCMethodTable(Out);
     writeObjCMethodTable(ObjCMethodTable, objcMethods);
 
-    if (DC.is<SourceFile *>() && enableNestedTypeLookupTable &&
+    if (enableNestedTypeLookupTable &&
         !nestedTypeDecls.empty()) {
       index_block::NestedTypeDeclsLayout NestedTypeDeclsTable(Out);
       writeNestedTypeDeclsTable(NestedTypeDeclsTable, nestedTypeDecls);

--- a/test/Serialization/Inputs/multi-module-nested-type-1.swift
+++ b/test/Serialization/Inputs/multi-module-nested-type-1.swift
@@ -1,0 +1,3 @@
+public struct X {
+  public typealias A = Int
+}

--- a/test/Serialization/Inputs/multi-module-nested-type-2.swift
+++ b/test/Serialization/Inputs/multi-module-nested-type-2.swift
@@ -1,0 +1,3 @@
+import other
+
+typealias B = X.A

--- a/test/Serialization/multi-module-nested-type-extension.swift
+++ b/test/Serialization/multi-module-nested-type-extension.swift
@@ -1,0 +1,19 @@
+// RUN: rm -rf %t && mkdir -p %t
+
+// Build the other module, which consists of a single source file.
+
+// RUN: %target-swift-frontend -emit-module -module-name other -o %t/multi-module-nested-type-1.swiftmodule -primary-file %S/Inputs/multi-module-nested-type-1.swift
+// RUN: %target-swift-frontend -emit-module -module-name other -o %t/other.swiftmodule %t/multi-module-nested-type-1.swiftmodule
+
+// Build this module, which consists of two source files.
+
+// RUN: %target-swift-frontend -emit-module -module-name me -o %t/multi-module-nested-type-2.swiftmodule -primary-file %S/Inputs/multi-module-nested-type-2.swift %s -I %t
+// RUN: %target-swift-frontend -emit-module -module-name me -o %t/multi-module-nested-type-3.swiftmodule %S/Inputs/multi-module-nested-type-2.swift -primary-file %s -I %t
+
+// RUN: %target-swift-frontend -emit-module -module-name me -o %t/me.swiftmodule %t/multi-module-nested-type-2.swiftmodule %t/multi-module-nested-type-3.swiftmodule -I %t
+
+import other
+
+extension X {
+  func takesB(_: B) {}
+}


### PR DESCRIPTION
* Description: Fixes a compiler crash when building a module containing multiple files in non-WMO mode, if the two files reference each other's declarations in a certain way that triggers recursive deserialization.

* Origination: Originally reported as a 3.1 regression, but the underlying problem has been there all along; some other change in 3.1 must have exposed it for the particular project in question

* Scope of the issue: Affects anyone using Swift to build their own modules, in non-WMO configurations.

* Risk: Low - we already used the 'nested type table' for references within a module, and if the lookup in this table fails, we fall back to the old code path.

* Tested: New test case added, reduced from the original bug report. Source compatibility suite passed against master branch.

* Reviewed by: Jordan Rose

* Radar: <rdar://problem/30976604>