### PR TITLE
[4.0] [SE-0160] Emit runtime warnings by default.

### DIFF
--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -1364,18 +1364,19 @@ SWIFT_CC(swift)
 SWIFT_RUNTIME_EXPORT
 void swift_objc_swift3ImplicitObjCEntrypoint(id self, SEL selector) {
   // Figure out how much reporting we want by querying the environment
-  // variable SWIFT_DEBUG_IMPLICIT_OBJC_ENTRYPOINT. We have four
+  // variable SWIFT_DEBUG_IMPLICIT_OBJC_ENTRYPOINT. We have four meaningful
   // levels:
   //
   //   0: Don't report anything
   //   1: Complain about uses of implicit @objc entrypoints.
   //   2: Complain about uses of implicit @objc entrypoints, with backtraces
   //      if possible.
-  //   3: Complain about uses of implicit @objc entrypoints, with backtraces
-  //      if possible, then abort().
+  //   3: Complain about uses of implicit @objc entrypoints, then abort().
   //
   // The actual reportLevel is stored as the above values +1, so that
   // 0 indicates we have not yet checked. It's fine to race through here.
+  //
+  // The default, if SWIFT_DEBUG_IMPLICIT_OBJC_ENTRYPOINT is not set, is 2.
   static int storedReportLevel = 0;
   if (storedReportLevel == 0) {
     auto reportLevelStr = getenv("SWIFT_DEBUG_IMPLICIT_OBJC_ENTRYPOINT");
@@ -1384,7 +1385,7 @@ void swift_objc_swift3ImplicitObjCEntrypoint(id self, SEL selector) {
         reportLevelStr[1] == 0)
       storedReportLevel = (reportLevelStr[0] - '0') + 1;
     else
-      storedReportLevel = 1;
+      storedReportLevel = 3;
   }
 
   int reportLevel = storedReportLevel - 1;

--- a/test/Interpreter/SDK/objc_swift3_deprecated_objc_inference.swift
+++ b/test/Interpreter/SDK/objc_swift3_deprecated_objc_inference.swift
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t  &&  mkdir -p %t
 // RUN: %target-build-swift -swift-version 4 -Xfrontend -enable-swift3-objc-inference %s -o %t/a.out
-// RUN: %target-run %t/a.out 2>&1 | %FileCheck %s -check-prefix=CHECK_NOTHING
+// RUN: %target-run %t/a.out 2>&1 | %FileCheck %s -check-prefix=CHECK_WARNINGS
 // RUN: env SWIFT_DEBUG_IMPLICIT_OBJC_ENTRYPOINT=0 SIMCTL_CHILD_SWIFT_DEBUG_IMPLICIT_OBJC_ENTRYPOINT=0 %target-run %t/a.out 2>&1 | %FileCheck %s -check-prefix=CHECK_NOTHING
 
 // RUN: env SWIFT_DEBUG_IMPLICIT_OBJC_ENTRYPOINT=1 SIMCTL_CHILD_SWIFT_DEBUG_IMPLICIT_OBJC_ENTRYPOINT=2 %target-run %t/a.out > %t/level1.log 2>&1


### PR DESCRIPTION
**Explanation**: Enable runtime logging for the implicit `@objc` entry points deprecated by [SE-0160](https://github.com/apple/swift-evolution/blob/master/proposals/0160-objc-inference.md) by default when in the transitory "Swift 4 with Swift 3 `@objc` inference` state.

**Scope**: Applications that have been mostly migrated to Swift 4 but are still relying on Swift 3 `@objc` inference.

**Radar**: rdar://problem/32229395

**Risk**: Low; enables some logging in the transitory "Swift 4 with Swift 3 `@objc` inference` state. I guess in theory our logging could cause an application to crash, but it's unlikely.

**Testing**: Compiler regression testing.
