### PR TITLE
[4.0][migrator] Do proper lookup and avoid prefixing typeof(of:) if the only found name is the stdlib one.

### DIFF
--- a/lib/Migrator/TypeOfMigratorPass.cpp
+++ b/lib/Migrator/TypeOfMigratorPass.cpp
@@ -24,8 +24,10 @@ using namespace swift::migrator;
 
 namespace {
 
-struct TypeOfMigratorPass: public ASTMigratorPass,
+class TypeOfMigratorPass: public ASTMigratorPass,
   public SourceEntityWalker {
+
+  std::vector<DeclContext *> ContextStack;
 
   void handleTypeOf(const DynamicTypeExpr *DTE) {
     if (!SF->getASTContext().LangOpts.isSwiftVersion3()) {
@@ -39,12 +41,22 @@ struct TypeOfMigratorPass: public ASTMigratorPass,
 
     UnqualifiedLookup Lookup {
       { SF->getASTContext().getIdentifier("type") },
-      SF->getModuleScopeContext(),
-      /*TypeResolver=*/nullptr,
+      ContextStack.empty() ? SF->getModuleScopeContext() : ContextStack.back(),
+      /*TypeResolver=*/SF->getASTContext().getLazyResolver(),
       /*IsKnownPrivate=*/false,
       DTE->getLoc()
     };
-    if (Lookup.Results.empty()) {
+    auto isShadowing = [&]() -> bool {
+      if (Lookup.Results.empty())
+        return false;
+      if (Lookup.Results.size() != 1)
+        return true;
+      if (auto VD = Lookup.Results.front().getValueDecl()) {
+        return !VD->getModuleContext()->isStdlibModule();
+      }
+      return false;
+    };
+    if (!isShadowing()) {
       // There won't be a name shadowing here in Swift 4, so we don't need to
       // do anything.
       return;
@@ -58,6 +70,19 @@ struct TypeOfMigratorPass: public ASTMigratorPass,
     }
     return true;
   }
+
+  bool walkToDeclPre(Decl *D, CharSourceRange Range) override {
+    if (auto DC = dyn_cast<DeclContext>(D))
+      ContextStack.push_back(DC);
+    return true;
+  }
+
+  bool walkToDeclPost(Decl *D) override {
+    if (isa<DeclContext>(D))
+      ContextStack.pop_back();
+    return true;
+  }
+
 public:
   TypeOfMigratorPass(EditorAdapter &Editor,
                          SourceFile *SF,

--- a/test/Migrator/prefix_typeof_expr_unneeded.swift
+++ b/test/Migrator/prefix_typeof_expr_unneeded.swift
@@ -1,0 +1,16 @@
+// RUN: rm -rf %t && mkdir -p %t && %target-swift-frontend -typecheck -update-code -primary-file %s -emit-migrated-file-path %t.result
+// RUN: diff -u %s.expected %t.result
+// RUN: %target-swift-frontend -typecheck %t.result -swift-version 4
+
+class HasTypeMethod {
+  var type: Int {
+    _ = type(of: 1)
+    return 1
+  }
+}
+
+class NoTypeMethod {
+  func meth() {
+    _ = type(of: 1) // Don't need to add prefix
+  }
+}

--- a/test/Migrator/prefix_typeof_expr_unneeded.swift.expected
+++ b/test/Migrator/prefix_typeof_expr_unneeded.swift.expected
@@ -1,0 +1,16 @@
+// RUN: rm -rf %t && mkdir -p %t && %target-swift-frontend -typecheck -update-code -primary-file %s -emit-migrated-file-path %t.result
+// RUN: diff -u %s.expected %t.result
+// RUN: %target-swift-frontend -typecheck %t.result -swift-version 4
+
+class HasTypeMethod {
+  var type: Int {
+    _ = Swift.type(of: 1)
+    return 1
+  }
+}
+
+class NoTypeMethod {
+  func meth() {
+    _ = type(of: 1) // Don't need to add prefix
+  }
+}


### PR DESCRIPTION
master: https://github.com/apple/swift/pull/9688

rdar://32229317
