### PR TITLE
Demangler: make the demangler more tolerant with malformed symbols.

### DIFF
--- a/lib/Demangling/OldDemangler.cpp
+++ b/lib/Demangling/OldDemangler.cpp
@@ -32,12 +32,6 @@ using namespace Demangle;
 using llvm::Optional;
 using llvm::None;
 
-[[noreturn]]
-static void unreachable(const char *Message) {
-  fprintf(stderr, "fatal error: %s\n", Message);
-  std::abort();
-}
-
 namespace {
   struct FindPtr {
     FindPtr(Node *v) : Target(v) {}
@@ -575,7 +569,8 @@ private:
       return true;
     }
 
-    unreachable("Unknown constant prop specialization");
+    // Unknown constant prop specialization
+    return false;
   }
 
   bool demangleFuncSigSpecializationClosureProp(NodePointer parent) {
@@ -1484,7 +1479,8 @@ private:
       return Factory.createNode(Node::Kind::MetatypeRepresentation,
                                  "@objc_metatype");
 
-    unreachable("Unhandled metatype representation");
+    // Unknown metatype representation
+    return nullptr;
   }
   
   NodePointer demangleGenericRequirement() {
@@ -1547,7 +1543,7 @@ private:
           return nullptr;
         name = "m";
       } else {
-        unreachable("Unknown layout constraint");
+        return nullptr;
       }
 
       NodePointer second = Factory.createNode(kind, name);
@@ -2115,7 +2111,7 @@ private:
       case ImplConventionContext::Parameter: return (FOR_PARAMETER); \
       case ImplConventionContext::Result: return (FOR_RESULT);       \
       }                                                              \
-      unreachable("bad context");                               \
+      return StringRef();                                            \
     }
     auto Nothing = StringRef();
     CASE('a',   Nothing,                Nothing,         "@autoreleased")
@@ -2178,18 +2174,18 @@ private:
         return nullptr;
       kind = Node::Kind::ImplErrorResult;
     }
-  
-    auto getContext = [](Node::Kind kind) -> ImplConventionContext {
-      if (kind == Node::Kind::ImplParameter)
-        return ImplConventionContext::Parameter;
-      else if (kind == Node::Kind::ImplResult
-               || kind == Node::Kind::ImplErrorResult)
-        return ImplConventionContext::Result;
-      else
-        unreachable("unexpected node kind");
-    };
 
-    auto convention = demangleImplConvention(getContext(kind));
+    ImplConventionContext ConvCtx;
+    if (kind == Node::Kind::ImplParameter) {
+      ConvCtx = ImplConventionContext::Parameter;
+    } else if (kind == Node::Kind::ImplResult
+               || kind == Node::Kind::ImplErrorResult) {
+      ConvCtx = ImplConventionContext::Result;
+    } else {
+      return nullptr;
+    }
+
+    auto convention = demangleImplConvention(ConvCtx);
     if (convention.empty()) return nullptr;
     auto type = demangleType();
     if (!type) return nullptr;

--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -252,4 +252,5 @@ _T0s13_UnicodeViewsVss22RandomAccessCollectionRzs0A8EncodingR_11SubSequence_5Ind
 _T010Foundation11MeasurementV12SimulatorKitSo9UnitAngleCRszlE11OrientationO2eeoiSbAcDEAGOyAF_G_AKtFZ ---> static (extension in SimulatorKit):Foundation.Measurement<A where A == __C.UnitAngle>.Orientation.== infix((extension in SimulatorKit):Foundation.Measurement<__C.UnitAngle>.Orientation, (extension in SimulatorKit):Foundation.Measurement<__C.UnitAngle>.Orientation) -> Swift.Bool
 _T04main1_yyF ---> main._() -> ()
 _T04test6testitSiyt_tF ---> test.testit(()) -> Swift.Int
+_T0Rml ---> _T0Rml
 


### PR DESCRIPTION

Explanation: There are some cases in the demangler where it can crash if the input symbol is not a valid mangled swift name. Either this is by getting into an intended unreachable -> abort. Or the error conditions are not checked properly. This change removes all unreachables and also adds additional checks for error conditions.

Scope: This problem can cause a crash in tools which use the demangler and try to demangle symbols which are not necessarily swift symbols.

Radar: rdar://problem/32113006

Risk: Low. This change only affects code which ended up in an abort.

Testing: There is a test for swift-ci