### PR TITLE
[stdlib] Documentation revisions

### DIFF
--- a/stdlib/public/SDK/Foundation/NSStringAPI.swift
+++ b/stdlib/public/SDK/Foundation/NSStringAPI.swift
@@ -267,9 +267,8 @@ extension String {
   /// strings. See the `getLineStart(_:end:contentsEnd:for:)` method for
   /// additional information.
   ///
-  /// Case transformations aren't guaranteed to be symmetrical or to produce
-  /// strings of the same lengths as the originals. See lowercased for an
-  /// example.
+  /// Case transformations aren’t guaranteed to be symmetrical or to produce
+  /// strings of the same lengths as the originals.
   public var capitalized: String {
     return _ns.capitalized as String
   }
@@ -626,7 +625,7 @@ extension String {
 
   // @property NSStringEncoding fastestEncoding;
 
-  /// The fastest encoding to which the string may be converted without loss
+  /// The fastest encoding to which the string can be converted without loss
   /// of information.
   public var fastestEncoding: Encoding {
     return Encoding(rawValue: _ns.fastestEncoding)
@@ -825,10 +824,11 @@ extension String {
   //     encoding:(NSStringEncoding)encoding
   //     freeWhenDone:(BOOL)flag
 
-  /// Creates a new string that contains the specified number of bytes
-  /// from the given buffer interpreted
-  /// in the specified encoding, and optionally frees the buffer.  WARNING:
-  /// this initializer is not memory-safe!
+  /// Creates a new string that contains the specified number of bytes from the
+  /// given buffer, interpreted in the specified encoding, and optionally
+  /// frees the buffer.
+  ///
+  /// - Warning: This initializer is not memory-safe!
   public init?(
     bytesNoCopy bytes: UnsafeMutableRawPointer, length: Int,
     encoding: Encoding, freeWhenDone flag: Bool
@@ -862,8 +862,8 @@ extension String {
   //     length:(NSUInteger)length
   //     freeWhenDone:(BOOL)flag
 
-  /// Creates a new string that contains the specified
-  /// number of characters from a given array of UTF-16 Code Units
+  /// Creates a new string that contains the specified number of characters
+  /// from the given C array of UTF-16 code units.
   public init(
     utf16CodeUnitsNoCopy: UnsafePointer<unichar>,
     count: Int,
@@ -1715,7 +1715,7 @@ extension String {
   /// Locale-independent case-insensitive operation, and other needs, can be
   /// achieved by calling `range(of:options:range:locale:)`.
   ///
-  /// Equivalent to
+  /// Equivalent to:
   ///
   ///     range(of: other, options: .caseInsensitiveSearch,
   ///           locale: Locale.current) != nil

--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -1677,15 +1677,15 @@ extension ${Self} {
   ///     }
   ///     // 'sum' == 9
   ///
-  /// The pointer passed as an argument to `body` is valid only for the
-  /// lifetime of the closure. Do not escape it from the closure for later
-  /// use.
+  /// The pointer passed as an argument to `body` is valid only during the
+  /// execution of `withUnsafeBufferPointer(_:)`. Do not store or return the
+  /// pointer for later use.
   ///
   /// - Parameter body: A closure with an `UnsafeBufferPointer` parameter that
   ///   points to the contiguous storage for the array. ${contiguousCaveat} If
   ///   `body` has a return value, it is used as the return value for the
   ///   `withUnsafeBufferPointer(_:)` method. The pointer argument is valid
-  ///   only for the duration of the closure's execution.
+  ///   only for the duration of the method's execution.
   /// - Returns: The return value of the `body` closure parameter, if any.
   ///
   /// - SeeAlso: `withUnsafeMutableBufferPointer`, `UnsafeBufferPointer`
@@ -1716,9 +1716,9 @@ extension ${Self} {
   ///     print(numbers)
   ///     // Prints "[2, 1, 4, 3, 5]"
   ///
-  /// The pointer passed as an argument to `body` is valid only for the
-  /// lifetime of the closure. Do not escape it from the closure for later
-  /// use.
+  /// The pointer passed as an argument to `body` is valid only during the
+  /// execution of `withUnsafeMutableBufferPointer(_:)`. Do not store or
+  /// return the pointer for later use.
   ///
   /// - Warning: Do not rely on anything about the array that is the target of
   ///   this method during execution of the `body` closure; it might not
@@ -1729,7 +1729,7 @@ extension ${Self} {
   ///   parameter that points to the contiguous storage for the array.
   ///   ${contiguousCaveat} If `body` has a return value, it is used as the
   ///   return value for the `withUnsafeMutableBufferPointer(_:)` method. The
-  ///   pointer argument is valid only for the duration of the closure's
+  ///   pointer argument is valid only for the duration of the method's
   ///   execution.
   /// - Returns: The return value of the `body` closure parameter, if any.
   ///

--- a/stdlib/public/core/Character.swift
+++ b/stdlib/public/core/Character.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// A single extended grapheme cluster, which approximates a user-perceived
+/// A single extended grapheme cluster that approximates a user-perceived
 /// character.
 ///
 /// The `Character` type represents a character made up of one or more Unicode

--- a/stdlib/public/core/Codable.swift
+++ b/stdlib/public/core/Codable.swift
@@ -14,34 +14,39 @@
 // Codable
 //===----------------------------------------------------------------------===//
 
-/// Conformance to `Encodable` indicates that a type can encode itself to an external representation.
+/// A type that can encode itself to an external representation.
 public protocol Encodable {
-    /// Encodes `self` into the given encoder.
+    /// Encodes this value into the given encoder.
     ///
-    /// If `self` fails to encode anything, `encoder` will encode an empty keyed container in its place.
+    /// If the value fails to encode anything, `encoder` will encode an empty
+    /// keyed container in its place.
     ///
-    /// - parameter encoder: The encoder to write data to.
-    /// - throws: An error if any values are invalid for `encoder`'s format.
+    /// This function throws an error if any values are invalid for the given
+    /// encoder's format.
+    ///
+    /// - Parameter encoder: The encoder to write data to.
     func encode(to encoder: Encoder) throws
 }
 
-/// Conformance to `Decodable` indicates that a type can decode itself from an external representation.
+/// A type that can decode itself from an external representation.
 public protocol Decodable {
-    /// Initializes `self` by decoding from `decoder`.
+    /// Creates a new instance by decoding from the given decoder.
     ///
-    /// - parameter decoder: The decoder to read data from.
-    /// - throws: An error if reading from the decoder fails, or if read data is corrupted or otherwise invalid.
+    /// This initializer throws an error if reading from the decoder fails, or
+    /// if the data read is corrupted or otherwise invalid.
+    ///
+    /// - Parameter decoder: The decoder to read data from.
     init(from decoder: Decoder) throws
 }
 
-/// Conformance to `Codable` indicates that a type can convert itself into and out of an external representation.
+/// A type that can convert itself into and out of an external representation.
 public typealias Codable = Encodable & Decodable
 
 //===----------------------------------------------------------------------===//
 // CodingKey
 //===----------------------------------------------------------------------===//
 
-/// Conformance to `CodingKey` indicates that a type can be used as a key for encoding and decoding.
+/// A type that can be used as a key for encoding and decoding.
 public protocol CodingKey {
     /// The string to use in a named collection (e.g. a string-keyed dictionary).
     var stringValue: String { get }
@@ -66,7 +71,7 @@ public protocol CodingKey {
 // Encoder & Decoder
 //===----------------------------------------------------------------------===//
 
-/// An `Encoder` is a type which can encode values into a native format for external representation.
+/// A type that can encode values into a native format for external representation.
 public protocol Encoder {
     /// The path of coding keys taken to get to this point in encoding.
     /// A `nil` value indicates an unkeyed container.
@@ -99,7 +104,7 @@ public protocol Encoder {
     func singleValueContainer() -> SingleValueEncodingContainer
 }
 
-/// A `Decoder` is a type which can decode values from a native format into in-memory representations.
+/// A type that can decode values from a native format into in-memory representations.
 public protocol Decoder {
     /// The path of coding keys taken to get to this point in decoding.
     /// A `nil` value indicates an unkeyed container.
@@ -132,9 +137,11 @@ public protocol Decoder {
 // Keyed Encoding Containers
 //===----------------------------------------------------------------------===//
 
-/// Conformance to `KeyedEncodingContainerProtocol` indicates that a type provides a view into an `Encoder`'s storage and is used to hold the encoded properties of an `Encodable` type in a keyed manner.
+/// A type that provides a view into an encoder's storage and is used to hold
+/// the encoded properties of an encodable type in a keyed manner.
 ///
-/// Encoders should provide types conforming to `KeyedEncodingContainerProtocol` for their format.
+/// Encoders should provide types conforming to
+/// `KeyedEncodingContainerProtocol` for their format.
 public protocol KeyedEncodingContainerProtocol {
     associatedtype Key : CodingKey
 
@@ -286,7 +293,9 @@ public protocol KeyedEncodingContainerProtocol {
 }
 
 // An implementation of _KeyedEncodingContainerBase and _KeyedEncodingContainerBox are given at the bottom of this file.
-/// `KeyedEncodingContainer` is a type-erased box for `KeyedEncodingContainerProtocol` types, similar to `AnyCollection` and `AnyHashable`. This is the type which consumers of the API interact with directly.
+
+/// A concrete container that provides a view into an encoder's storage, making
+/// the encoded properties of an encodable type accessible by keys.
 public struct KeyedEncodingContainer<K : CodingKey> {
     public typealias Key = K
 
@@ -488,9 +497,11 @@ public struct KeyedEncodingContainer<K : CodingKey> {
     }
 }
 
-/// Conformance to `KeyedDecodingContainerProtocol` indicates that a type provides a view into a `Decoder`'s storage and is used to hold the encoded properties of a `Decodable` type in a keyed manner.
+/// A type that provides a view into a decoder's storage and is used to hold
+/// the encoded properties of a decodable type in a keyed manner.
 ///
-/// Decoders should provide types conforming to `UnkeyedDecodingContainer` for their format.
+/// Decoders should provide types conforming to `UnkeyedDecodingContainer` for
+/// their format.
 public protocol KeyedDecodingContainerProtocol {
     associatedtype Key : CodingKey
 
@@ -845,7 +856,9 @@ public protocol KeyedDecodingContainerProtocol {
 }
 
 // An implementation of _KeyedDecodingContainerBase and _KeyedDecodingContainerBox are given at the bottom of this file.
-/// `KeyedDecodingContainer` is a type-erased box for `KeyedDecodingContainerProtocol` types, similar to `AnyCollection` and `AnyHashable`. This is the type which consumers of the API interact with directly.
+
+/// A concrete container that provides a view into an decoder's storage, making
+/// the encoded properties of an decodable type accessible by keys.
 public struct KeyedDecodingContainer<K : CodingKey> : KeyedDecodingContainerProtocol {
     public typealias Key = K
 
@@ -1107,9 +1120,11 @@ public struct KeyedDecodingContainer<K : CodingKey> : KeyedDecodingContainerProt
 // Unkeyed Encoding Containers
 //===----------------------------------------------------------------------===//
 
-/// Conformance to `UnkeyedEncodingContainer` indicates that a type provides a view into an `Encoder`'s storage and is used to hold the encoded properties of an `Encodable` type sequentially, without keys.
+/// A type that provides a view into an encoder's storage and is used to hold
+/// the encoded properties of an encodable type sequentially, without keys.
 ///
-/// Encoders should provide types conforming to `UnkeyedEncodingContainer` for their format.
+/// Encoders should provide types conforming to `UnkeyedEncodingContainer` for
+/// their format.
 public protocol UnkeyedEncodingContainer {
     /// The path of coding keys taken to get to this point in encoding.
     /// A `nil` value indicates an unkeyed container.
@@ -1322,9 +1337,11 @@ public protocol UnkeyedEncodingContainer {
     mutating func superEncoder() -> Encoder
 }
 
-/// Conformance to `UnkeyedDecodingContainer` indicates that a type provides a view into a `Decoder`'s storage and is used to hold the encoded properties of a `Decodable` type sequentially, without keys.
+/// A type that provides a view into a decoder's storage and is used to hold
+/// the encoded properties of a decodable type sequentially, without keys.
 ///
-/// Decoders should provide types conforming to `UnkeyedDecodingContainer` for their format.
+/// Decoders should provide types conforming to `UnkeyedDecodingContainer` for
+/// their format.
 public protocol UnkeyedDecodingContainer {
     /// The path of coding keys taken to get to this point in decoding.
     /// A `nil` value indicates an unkeyed container.
@@ -1615,7 +1632,8 @@ public protocol UnkeyedDecodingContainer {
 // Single Value Encoding Containers
 //===----------------------------------------------------------------------===//
 
-/// A `SingleValueEncodingContainer` is a container which can support the storage and direct encoding of a single non-keyed value.
+/// A container that can support the storage and direct encoding of a single
+/// non-keyed value.
 public protocol SingleValueEncodingContainer {
     /// Encodes a single value of the given type.
     ///
@@ -1821,7 +1839,7 @@ public protocol SingleValueDecodingContainer {
 // User Info
 //===----------------------------------------------------------------------===//
 
-/// Represents a user-defined key for providing context for encoding and decoding.
+/// A user-defined key for providing context during encoding and decoding.
 public struct CodingUserInfoKey : RawRepresentable, Equatable, Hashable {
     public typealias RawValue = String
 
@@ -1853,7 +1871,7 @@ public struct CodingUserInfoKey : RawRepresentable, Equatable, Hashable {
 // Errors
 //===----------------------------------------------------------------------===//
 
-/// An `EncodingError` indicates that something has gone wrong during encoding of a value.
+/// An error that occurs during the encoding of a value.
 public enum EncodingError : Error {
     /// The context in which the error occurred.
     public struct Context {
@@ -1879,7 +1897,7 @@ public enum EncodingError : Error {
     case invalidValue(Any, Context)
 }
 
-/// A `DecodingError` indicates that something has gone wrong during decoding of a value.
+/// An error that occurs during the decoding of a value.
 public enum DecodingError : Error {
     /// The context in which the error occurred.
     public struct Context {

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -27,12 +27,15 @@ internal func _abstract(
 
 // MARK: Type-erased abstract base classes
 
+/// A type-erased key path, from any root type to any resulting value type.
 public class AnyKeyPath: Hashable, _AppendKeyPath {
+  /// The root type for this key path.
   @_inlineable
   public static var rootType: Any.Type {
     return _rootAndValueType.root
   }
 
+  /// The value type for this key path.
   @_inlineable
   public static var valueType: Any.Type {
     return _rootAndValueType.value
@@ -138,11 +141,14 @@ public class AnyKeyPath: Hashable, _AppendKeyPath {
   }
 }
 
+/// A partially type-erased key path, from a concrete root type to any
+/// resulting value type.
 public class PartialKeyPath<Root>: AnyKeyPath { }
 
 // MARK: Concrete implementations
 internal enum KeyPathKind { case readOnly, value, reference }
 
+/// A key path from a specific root type to a specific resulting value type.
 public class KeyPath<Root, Value>: PartialKeyPath<Root> {
   public typealias _Root = Root
   public typealias _Value = Value
@@ -219,6 +225,7 @@ public class KeyPath<Root, Value>: PartialKeyPath<Root> {
   }
 }
 
+/// A key path that supports reading from and writing to the resulting value.
 public class WritableKeyPath<Root, Value>: KeyPath<Root, Value> {
   // MARK: Implementation detail
   
@@ -268,6 +275,8 @@ public class WritableKeyPath<Root, Value>: KeyPath<Root, Value> {
 
 }
 
+/// A key path that supports reading from and writing to the resulting value
+/// with reference semantics.
 public class ReferenceWritableKeyPath<Root, Value>: WritableKeyPath<Root, Value> {
   // MARK: Implementation detail
 

--- a/stdlib/public/core/LifetimeManager.swift
+++ b/stdlib/public/core/LifetimeManager.swift
@@ -44,20 +44,19 @@ public func withExtendedLifetime<T, Result>(
 
 extension String {
 
-  /// Invokes the given closure on the contents of the string, represented as a
-  /// pointer to a null-terminated sequence of UTF-8 code units.
+  /// Calls the given closure with a pointer to the contents of the string,
+  /// represented as a null-terminated sequence of UTF-8 code units.
   ///
-  /// The `withCString(_:)` method ensures that the sequence's lifetime extends
-  /// through the execution of `body`. The pointer argument to `body` is only
-  /// valid for the lifetime of the closure. Do not escape it from the closure
-  /// for later use.
+  /// The pointer passed as an argument to `body` is valid only during the
+  /// execution of `withCString(_:)`. Do not store or return the pointer for
+  /// later use.
   ///
-  /// - Parameter body: A closure that takes a pointer to the string's UTF-8
-  ///   code unit sequence as its sole argument. If the closure has a return
-  ///   value, it is used as the return value of the `withCString(_:)` method.
-  ///   The pointer argument is valid only for the duration of the closure's
-  ///   execution.
-  /// - Returns: The return value of the `body` closure, if any.
+  /// - Parameter body: A closure with a pointer parameter that points to a
+  ///   null-terminated sequence of UTF-8 code units. If `body` has a return
+  ///   value, it is used as the return value for the `withCString(_:)`
+  ///   method. The pointer argument is valid only for the duration of the
+  ///   method's execution.
+  /// - Returns: The return value of the `body` closure parameter, if any.
   @_inlineable
   public func withCString<Result>(
     _ body: (UnsafePointer<Int8>) throws -> Result
@@ -75,21 +74,22 @@ public func _fixLifetime<T>(_ x: T) {
   Builtin.fixLifetime(x)
 }
 
-/// Invokes the given closure with a mutable pointer to the given argument.
+/// Calls the given closure with a mutable pointer to the given argument.
 ///
 /// The `withUnsafeMutablePointer(to:_:)` function is useful for calling
 /// Objective-C APIs that take in/out parameters (and default-constructible
 /// out parameters) by pointer.
 ///
-/// The pointer argument to `body` is valid only for the lifetime of the
-/// closure. Do not escape it from the closure for later use.
+/// The pointer argument to `body` is valid only during the execution of
+/// `withUnsafeMutablePointer(to:_:)`. Do not store or return the pointer for
+/// later use.
 ///
 /// - Parameters:
 ///   - arg: An instance to temporarily use via pointer.
 ///   - body: A closure that takes a mutable pointer to `arg` as its sole
 ///     argument. If the closure has a return value, it is used as the return
 ///     value of the `withUnsafeMutablePointer(to:_:)` function. The pointer
-///     argument is valid only for the duration of the closure's execution.
+///     argument is valid only for the duration of the function's execution.
 /// - Returns: The return value of the `body` closure, if any.
 ///
 /// - SeeAlso: `withUnsafePointer(to:_:)`
@@ -108,15 +108,16 @@ public func withUnsafeMutablePointer<T, Result>(
 /// APIs that take in/out parameters (and default-constructible out
 /// parameters) by pointer.
 ///
-/// The pointer argument to `body` is valid only for the lifetime of the
-/// closure. Do not escape it from the closure for later use.
+/// The pointer argument to `body` is valid only during the execution of
+/// `withUnsafePointer(to:_:)`. Do not store or return the pointer for later
+/// use.
 ///
 /// - Parameters:
 ///   - arg: An instance to temporarily use via pointer.
 ///   - body: A closure that takes a pointer to `arg` as its sole argument. If
 ///     the closure has a return value, it is used as the return value of the
 ///     `withUnsafePointer(to:_:)` function. The pointer argument is valid
-///     only for the duration of the closure's execution.
+///     only for the duration of the function's execution.
 /// - Returns: The return value of the `body` closure, if any.
 ///
 /// - SeeAlso: `withUnsafeMutablePointer(to:_:)`

--- a/stdlib/public/core/OptionSet.swift
+++ b/stdlib/public/core/OptionSet.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// A type that presents a mathematical set interface to a bitset.
+/// A type that presents a mathematical set interface to a bit set.
 ///
 /// You use the `OptionSet` protocol to represent bitset types, where
 /// individual bits represent members of a set. Adopting this protocol in

--- a/stdlib/public/core/Range.swift.gyb
+++ b/stdlib/public/core/Range.swift.gyb
@@ -916,7 +916,7 @@ public struct PartialRangeFrom<Bound: Comparable>: RangeExpression {
 /// In the following example, the `asciiTable` sequence is made by zipping
 /// together the characters in the `alphabet` string with a partial range
 /// starting at 65, the ASCII value of the capital letter A. Iterating over
-/// two zipped sequence continues only as long as the shorter of the two
+/// two zipped sequences continues only as long as the shorter of the two
 /// sequences, so the iteration stops at the end of `alphabet`.
 ///
 ///     let alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
@@ -933,7 +933,7 @@ public struct PartialRangeFrom<Bound: Comparable>: RangeExpression {
 ///
 /// The behavior of incrementing indefinitely is determined by the type of
 /// `Bound`. For example, iterating over an instance of
-/// `CountablePartialRangeFrom<Int>` will trap when the sequence's next value
+/// `CountablePartialRangeFrom<Int>` traps when the sequence's next value
 /// would be above `Int.max`.
 @_fixed_layout
 public struct CountablePartialRangeFrom<
@@ -1125,7 +1125,7 @@ extension Strideable where Stride: SignedInteger {
   ///
   /// The behavior of incrementing indefinitely is determined by the type of
   /// `Bound`. For example, iterating over an instance of
-  /// `CountablePartialRangeFrom<Int>` will trap when the sequence's next
+  /// `CountablePartialRangeFrom<Int>` traps when the sequence's next
   /// value would be above `Int.max`.
   ///
   /// - Parameter minimum: The lower bound for the range.

--- a/stdlib/public/core/Sort.swift
+++ b/stdlib/public/core/Sort.swift
@@ -338,11 +338,11 @@ func _heapSort<C>(
 
 /// Exchanges the values of the two given variables.
 ///
-/// The two variables passed must not alias each other. That is, it is an error to
-/// pass the same variable as both `a` and `b`.
+/// The two variables passed must not alias each other. For example, it is an
+/// error to pass the same variable as both `a` and `b`.
 ///
-/// In the following example, the call to `swap(_:_:)` guarantees that the value
-/// in `a` is always less than the value in `b`:
+/// In the following example, the call to `swap(_:_:)` guarantees that the
+/// value in `a` is always less than the value in `b`:
 ///
 ///     var a: Int = getNumber()
 ///     var b: Int = getNumber()

--- a/stdlib/public/core/StaticString.swift
+++ b/stdlib/public/core/StaticString.swift
@@ -121,14 +121,14 @@ public struct StaticString
   /// This method works regardless of whether the static string stores a
   /// pointer or a single Unicode scalar value.
   ///
-  /// The pointer argument to `body` is valid only for the lifetime of the
-  /// closure. Do not escape it from the closure for later use.
+  /// The pointer argument to `body` is valid only during the execution of
+  /// `withUTF8Buffer(_:)`. Do not store or return the pointer for later use.
   ///
   /// - Parameter body: A closure that takes a buffer pointer to the static
   ///   string's UTF-8 code unit sequence as its sole argument. If the closure
   ///   has a return value, it is used as the return value of the
   ///   `withUTF8Buffer(invoke:)` method. The pointer argument is valid only
-  ///   for the duration of the closure's execution.
+  ///   for the duration of the method's execution.
   /// - Returns: The return value of the `body` closure, if any.
   public func withUTF8Buffer<R>(
     _ body: (UnsafeBufferPointer<UInt8>) -> R) -> R {

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -44,44 +44,46 @@ public protocol StringProtocol
   ///
   /// - Parameters:
   ///   - codeUnits: A collection of code units encoded in the ecoding
-  ///     specified in `encoding`.
-  ///   - encoding: The encoding in which `codeUnits` should be interpreted.
+  ///     specified in `sourceEncoding`.
+  ///   - sourceEncoding: The encoding in which `codeUnits` should be
+  ///     interpreted.
   init<C: Collection, Encoding: Unicode.Encoding>(
-    decoding codeUnits: C, as encoding: Encoding.Type
+    decoding codeUnits: C, as sourceEncoding: Encoding.Type
   )
     where C.Iterator.Element == Encoding.CodeUnit
 
   /// Creates a string from the null-terminated, UTF-8 encoded sequence of
   /// bytes at the given pointer.
   ///
-  /// - Parameter nulTerminatedUTF8: A pointer to a sequence of contiguous,
+  /// - Parameter nullTerminatedUTF8: A pointer to a sequence of contiguous,
   ///   UTF-8 encoded bytes ending just before the first zero byte.
-  init(cString nulTerminatedUTF8: UnsafePointer<CChar>)
+  init(cString nullTerminatedUTF8: UnsafePointer<CChar>)
   
   /// Creates a string from the null-terminated sequence of bytes at the given
   /// pointer.
   ///
   /// - Parameters:
-  ///   - nulTerminatedCodeUnits: A pointer to a sequence of contiguous code
-  ///     units in the encoding specified in `encoding`, ending just before
-  ///     the first zero code unit.
-  ///   - encoding: The encoding in which the code units should be interpreted.
+  ///   - nullTerminatedCodeUnits: A pointer to a sequence of contiguous code
+  ///     units in the encoding specified in `sourceEncoding`, ending just
+  ///     before the first zero code unit.
+  ///   - sourceEncoding: The encoding in which the code units should be
+  ///     interpreted.
   init<Encoding: Unicode.Encoding>(
-    decodingCString nulTerminatedCodeUnits: UnsafePointer<Encoding.CodeUnit>,
-    as encoding: Encoding.Type)
-    
+    decodingCString nullTerminatedCodeUnits: UnsafePointer<Encoding.CodeUnit>,
+    as sourceEncoding: Encoding.Type)
+  
   /// Calls the given closure with a pointer to the contents of the string,
   /// represented as a null-terminated sequence of UTF-8 code units.
   ///
-  /// The pointer passed as an argument to `body` is valid only for the
-  /// lifetime of the closure. Do not escape it from the closure for later
-  /// use.
+  /// The pointer passed as an argument to `body` is valid only during the
+  /// execution of `withCString(_:)`. Do not store or return the pointer for
+  /// later use.
   ///
   /// - Parameter body: A closure with a pointer parameter that points to a
   ///   null-terminated sequence of UTF-8 code units. If `body` has a return
   ///   value, it is used as the return value for the `withCString(_:)`
   ///   method. The pointer argument is valid only for the duration of the
-  ///   closure's execution.
+  ///   method's execution.
   /// - Returns: The return value of the `body` closure parameter, if any.
   func withCString<Result>(
     _ body: (UnsafePointer<CChar>) throws -> Result) rethrows -> Result
@@ -89,20 +91,21 @@ public protocol StringProtocol
   /// Calls the given closure with a pointer to the contents of the string,
   /// represented as a null-terminated sequence of code units.
   ///
-  /// The pointer passed as an argument to `body` is valid only for the
-  /// lifetime of the closure. Do not escape it from the closure for later
-  /// use.
+  /// The pointer passed as an argument to `body` is valid only during the
+  /// execution of `withCString(encodedAs:_:)`. Do not store or return the
+  /// pointer for later use.
   ///
   /// - Parameters:
   ///   - body: A closure with a pointer parameter that points to a
   ///     null-terminated sequence of code units. If `body` has a return
   ///     value, it is used as the return value for the
   ///     `withCString(encodedAs:_:)` method. The pointer argument is valid
-  ///     only for the duration of the closure's execution.
-  ///   - encoding: The encoding in which the code units should be interpreted.
+  ///     only for the duration of the method's execution.
+  ///   - targetEncoding: The encoding in which the code units should be
+  ///     interpreted.
   /// - Returns: The return value of the `body` closure parameter, if any.
   func withCString<Result, Encoding: Unicode.Encoding>(
-    encodedAs encoding: Encoding.Type,
+    encodedAs targetEncoding: Encoding.Type,
     _ body: (UnsafePointer<Encoding.CodeUnit>) throws -> Result
   ) rethrows -> Result
 }
@@ -217,6 +220,14 @@ extension _StringCore {
 }
 
 extension String {
+  /// Creates a string from the given Unicode code units in the specified
+  /// encoding.
+  ///
+  /// - Parameters:
+  ///   - codeUnits: A collection of code units encoded in the ecoding
+  ///     specified in `sourceEncoding`.
+  ///   - sourceEncoding: The encoding in which `codeUnits` should be
+  ///     interpreted.
   public init<C: Collection, Encoding: Unicode.Encoding>(
     decoding codeUnits: C, as sourceEncoding: Encoding.Type
   ) where C.Iterator.Element == Encoding.CodeUnit {
@@ -224,26 +235,43 @@ extension String {
       codeUnits, encoding: sourceEncoding, repairIllFormedSequences: true)
     self = String(_StringCore(b!))
   }
-
-  /// Constructs a `String` having the same contents as `nulTerminatedCodeUnits`.
+  
+  /// Creates a string from the null-terminated sequence of bytes at the given
+  /// pointer.
   ///
-  /// - Parameter nulTerminatedCodeUnits: a sequence of contiguous code units in
-  ///   the given `encoding`, ending just before the first zero code unit.
-  /// - Parameter encoding: describes the encoding in which the code units
-  ///   should be interpreted.
+  /// - Parameters:
+  ///   - nullTerminatedCodeUnits: A pointer to a sequence of contiguous code
+  ///     units in the encoding specified in `sourceEncoding`, ending just
+  ///     before the first zero code unit.
+  ///   - sourceEncoding: The encoding in which the code units should be
+  ///     interpreted.
   public init<Encoding: Unicode.Encoding>(
-    decodingCString nulTerminatedCodeUnits: UnsafePointer<Encoding.CodeUnit>,
+    decodingCString nullTerminatedCodeUnits: UnsafePointer<Encoding.CodeUnit>,
     as sourceEncoding: Encoding.Type) {
 
     let codeUnits = _SentinelCollection(
-      UnsafeBufferPointer(_unboundedStartingAt: nulTerminatedCodeUnits),
+      UnsafeBufferPointer(_unboundedStartingAt: nullTerminatedCodeUnits),
       until: _IsZero()
     )
     self.init(decoding: codeUnits, as: sourceEncoding)
   }
-
-  /// Invokes the given closure on the contents of the string, represented as a
-  /// pointer to a null-terminated sequence of code units in the given encoding.
+  
+  /// Calls the given closure with a pointer to the contents of the string,
+  /// represented as a null-terminated sequence of code units.
+  ///
+  /// The pointer passed as an argument to `body` is valid only during the
+  /// execution of `withCString(encodedAs:_:)`. Do not store or return the
+  /// pointer for later use.
+  ///
+  /// - Parameters:
+  ///   - body: A closure with a pointer parameter that points to a
+  ///     null-terminated sequence of code units. If `body` has a return
+  ///     value, it is used as the return value for the
+  ///     `withCString(encodedAs:_:)` method. The pointer argument is valid
+  ///     only for the duration of the method's execution.
+  ///   - targetEncoding: The encoding in which the code units should be
+  ///     interpreted.
+  /// - Returns: The return value of the `body` closure parameter, if any.
   public func withCString<Result, TargetEncoding: Unicode.Encoding>(
     encodedAs targetEncoding: TargetEncoding.Type,
     _ body: (UnsafePointer<TargetEncoding.CodeUnit>) throws -> Result
@@ -286,9 +314,9 @@ extension String {
 ///     print(longerGreeting)
 ///     // Prints "Welcome! We're glad you're here!"
 ///
-/// Multiline string literals are enclosed in triple quotes (`"""`), with each
-/// delimiter on its own line. Indentation is stripped from each line of a
-/// multiline string literal to match the indentation of the closing
+/// Multiline string literals are enclosed in three double quotes (`"""`), with
+/// each delimiter on its own line. Indentation is stripped from each line of
+/// a multiline string literal to match the indentation of the closing
 /// delimiter.
 ///
 ///     let banner = """
@@ -448,8 +476,8 @@ extension String {
 ///     print(cLength)
 ///     // Prints "14"
 ///
-/// Counting the Length of a String
-/// ===============================
+/// Measuring the Length of a String
+/// ================================
 ///
 /// When you need to know the length of a string, you must first consider what
 /// you'll use the length for. Are you measuring the number of characters that
@@ -463,7 +491,7 @@ extension String {
 /// UTF-16 and UTF-8.
 ///
 ///     let capitalA = "A"
-///     print(capitalA.characters.count)
+///     print(capitalA.count)
 ///     // Prints "1"
 ///     print(capitalA.unicodeScalars.count)
 ///     // Prints "1"
@@ -479,7 +507,7 @@ extension String {
 /// different length.
 ///
 ///     let flag = "🇵🇷"
-///     print(flag.characters.count)
+///     print(flag.count)
 ///     // Prints "1"
 ///     print(flag.unicodeScalars.count)
 ///     // Prints "2"

--- a/stdlib/public/core/StringLegacy.swift
+++ b/stdlib/public/core/StringLegacy.swift
@@ -33,7 +33,7 @@ extension String {
   /// For example, use this initializer to create a string with ten `"ab"`
   /// strings in a row.
   ///
-  ///     let zeroes = String(repeating: "00", count: 10)
+  ///     let zeroes = String(repeating: "ab", count: 10)
   ///     print(zeroes)
   ///     // Prints "abababababababababab"
   ///
@@ -125,7 +125,7 @@ extension String {
   ///     // Prints "true"
   ///
   /// - Parameter prefix: A possible prefix to test against this string.
-  /// - Returns: `true` if the string begins with `prefix`, otherwise, `false`.
+  /// - Returns: `true` if the string begins with `prefix`; otherwise, `false`.
   public func hasPrefix(_ prefix: String) -> Bool {
     let selfCore = self._core
     let prefixCore = prefix._core
@@ -183,7 +183,7 @@ extension String {
   ///     // Prints "true"
   ///
   /// - Parameter suffix: A possible suffix to test against this string.
-  /// - Returns: `true` if the string ends with `suffix`, otherwise, `false`.
+  /// - Returns: `true` if the string ends with `suffix`; otherwise, `false`.
   public func hasSuffix(_ suffix: String) -> Bool {
     let selfCore = self._core
     let suffixCore = suffix._core

--- a/stdlib/public/core/Substring.swift.gyb
+++ b/stdlib/public/core/Substring.swift.gyb
@@ -57,7 +57,7 @@ extension String {
 ///
 ///     let rawInput = "126 a.b 22219 zzzzzz"
 ///     let numericPrefix = rawInput.prefix(while: { "0"..."9" ~= $0 })
-///     // numericPrefix is the Substring "126"
+///     // numericPrefix is the substring "126"
 ///
 /// When you need to store a substring or pass it to a function that requires a
 /// `String` instance, convert it using the `String.init(_:)` initializer.
@@ -70,12 +70,12 @@ extension String {
 /// Calling this initializer copies the contents of the substring to a new
 /// string.
 ///
-/// - Important: Long-term storage of `Substring` instances is discouraged. A
-///   substring holds a reference to the entire storage of a larger string,
-///   not just to the portion it presents, even after the original string's
-///   lifetime ends. Long-term storage of a substring may therefore prolong
-///   the lifetime of string data that is no longer otherwise accessible,
-///   which can appear to be memory leakage.
+/// - Important: Don't store substrings longer than you need to perform a
+///   specific operation. A substring holds a reference to the entire storage
+///   of the string it came from, not just to the portion it presents, even
+///   when there is no other reference to the original string. Storing
+///   substrings may therefore prolong the lifetime of string data that is no
+///   longer otherwise accessible, which can appear to be memory leakage.
 public struct Substring : StringProtocol {
   public typealias Index = String.Index
   public typealias IndexDistance = String.IndexDistance
@@ -173,51 +173,53 @@ public struct Substring : StringProtocol {
   ///
   /// - Parameters:
   ///   - codeUnits: A collection of code units encoded in the ecoding
-  ///     specified in `encoding`.
-  ///   - encoding: The encoding in which `codeUnits` should be interpreted.
+  ///     specified in `sourceEncoding`.
+  ///   - sourceEncoding: The encoding in which `codeUnits` should be
+  ///     interpreted.
   public init<C: Collection, Encoding: _UnicodeEncoding>(
-    decoding codeUnits: C, as encoding: Encoding.Type
+    decoding codeUnits: C, as sourceEncoding: Encoding.Type
   ) where C.Iterator.Element == Encoding.CodeUnit {
-    self.init(String(decoding: codeUnits, as: encoding))
+    self.init(String(decoding: codeUnits, as: sourceEncoding))
   }
 
   /// Creates a string from the null-terminated, UTF-8 encoded sequence of
   /// bytes at the given pointer.
   ///
-  /// - Parameter nulTerminatedUTF8: A pointer to a sequence of contiguous,
+  /// - Parameter nullTerminatedUTF8: A pointer to a sequence of contiguous,
   ///   UTF-8 encoded bytes ending just before the first zero byte.
-  public init(cString nulTerminatedUTF8: UnsafePointer<CChar>) {
-    self.init(String(cString: nulTerminatedUTF8))
+  public init(cString nullTerminatedUTF8: UnsafePointer<CChar>) {
+    self.init(String(cString: nullTerminatedUTF8))
   }
-  
+
   /// Creates a string from the null-terminated sequence of bytes at the given
   /// pointer.
   ///
   /// - Parameters:
-  ///   - nulTerminatedCodeUnits: A pointer to a sequence of contiguous code
-  ///     units in the encoding specified in `encoding`, ending just before
-  ///     the first zero code unit.
-  ///   - encoding: The encoding in which the code units should be interpreted.
+  ///   - nullTerminatedCodeUnits: A pointer to a sequence of contiguous code
+  ///     units in the encoding specified in `sourceEncoding`, ending just
+  ///     before the first zero code unit.
+  ///   - sourceEncoding: The encoding in which the code units should be
+  ///     interpreted.
   public init<Encoding: _UnicodeEncoding>(
-    decodingCString nulTerminatedCodeUnits: UnsafePointer<Encoding.CodeUnit>,
-    as encoding: Encoding.Type
+    decodingCString nullTerminatedCodeUnits: UnsafePointer<Encoding.CodeUnit>,
+    as sourceEncoding: Encoding.Type
   ) {
     self.init(
-      String(decodingCString: nulTerminatedCodeUnits, as: encoding))
+      String(decodingCString: nullTerminatedCodeUnits, as: sourceEncoding))
   }
-    
+
   /// Calls the given closure with a pointer to the contents of the string,
   /// represented as a null-terminated sequence of UTF-8 code units.
   ///
-  /// The pointer passed as an argument to `body` is valid only for the
-  /// lifetime of the closure. Do not escape it from the closure for later
-  /// use.
+  /// The pointer passed as an argument to `body` is valid only during the
+  /// execution of `withCString(_:)`. Do not store or return the pointer for
+  /// later use.
   ///
   /// - Parameter body: A closure with a pointer parameter that points to a
   ///   null-terminated sequence of UTF-8 code units. If `body` has a return
   ///   value, it is used as the return value for the `withCString(_:)`
   ///   method. The pointer argument is valid only for the duration of the
-  ///   closure's execution.
+  ///   method's execution.
   /// - Returns: The return value of the `body` closure parameter, if any.
   public func withCString<Result>(
     _ body: (UnsafePointer<CChar>) throws -> Result) rethrows -> Result {
@@ -233,25 +235,25 @@ public struct Substring : StringProtocol {
   /// Calls the given closure with a pointer to the contents of the string,
   /// represented as a null-terminated sequence of code units.
   ///
-  /// The pointer passed as an argument to `body` is valid only for the
-  /// lifetime of the closure. Do not escape it from the closure for later
-  /// use.
+  /// The pointer passed as an argument to `body` is valid only during the
+  /// execution of `withCString(encodedAs:_:)`. Do not store or return the
+  /// pointer for later use.
   ///
   /// - Parameters:
   ///   - body: A closure with a pointer parameter that points to a
   ///     null-terminated sequence of code units. If `body` has a return
   ///     value, it is used as the return value for the
   ///     `withCString(encodedAs:_:)` method. The pointer argument is valid
-  ///     only for the duration of the closure's execution.
-  ///   - encoding: The encoding in which the code units should be interpreted.
+  ///     only for the duration of the method's execution.
+  ///   - targetEncoding: The encoding in which the code units should be interpreted.
   /// - Returns: The return value of the `body` closure parameter, if any.
   public func withCString<Result, TargetEncoding: _UnicodeEncoding>(
-    encodedAs encoding: TargetEncoding.Type,
+    encodedAs targetEncoding: TargetEncoding.Type,
     _ body: (UnsafePointer<TargetEncoding.CodeUnit>) throws -> Result
   ) rethrows -> Result {
     return try _slice._base._core._withCSubstring(
       in: startIndex._base._position..<endIndex._base._position,
-      encoding: encoding, body)
+      encoding: targetEncoding, body)
   }
 }
 

--- a/stdlib/public/core/VarArgs.swift
+++ b/stdlib/public/core/VarArgs.swift
@@ -70,15 +70,16 @@ let _x86_64RegisterSaveWords = _x86_64CountGPRegisters + _x86_64CountSSERegister
 /// Invokes the given closure with a C `va_list` argument derived from the
 /// given array of arguments.
 ///
-/// The pointer passed as an argument to `body` is valid only for the lifetime
-/// of the closure. Do not escape it from the closure for later use.
+/// The pointer passed as an argument to `body` is valid only during the
+/// execution of `withVaList(_:_:)`. Do not store or return the pointer for
+/// later use.
 ///
 /// - Parameters:
 ///   - args: An array of arguments to convert to a C `va_list` pointer.
 ///   - body: A closure with a `CVaListPointer` parameter that references the
 ///     arguments passed as `args`. If `body` has a return value, it is used
 ///     as the return value for the `withVaList(_:)` function. The pointer
-///     argument is valid only for the duration of the closure's execution.
+///     argument is valid only for the duration of the function's execution.
 /// - Returns: The return value of the `body` closure parameter, if any.
 ///
 /// - SeeAlso: `getVaList(_:)`


### PR DESCRIPTION
- removed additional 'characters' references from String docs
- improved language around escaping pointer arguments
- key path type abstracts
- codable type abstract revisions
- a few more NSString API fixes
