### PR TITLE
Runtime: Only complain about a deprecated ObjC entry point once.

### DIFF
--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -1242,7 +1242,7 @@ FUNCTION(GetInitializedObjCClass, swift_getInitializedObjCClass, RegisterPreserv
 FUNCTION(Swift3ImplicitObjCEntrypoint, swift_objc_swift3ImplicitObjCEntrypoint,
          DefaultCC,
          RETURNS(VoidTy),
-         ARGS(ObjCPtrTy, ObjCSELTy, Int8PtrTy, SizeTy, SizeTy, SizeTy),
+         ARGS(ObjCPtrTy, ObjCSELTy, Int8PtrTy, SizeTy, SizeTy, SizeTy, Int8PtrTy),
          ATTRS(NoUnwind))
 
 #endif

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -385,6 +385,12 @@ IRGenModule::IRGenModule(IRGenerator &irgen,
 
   initClangTypeConverter();
 
+  if (ClangASTContext) {
+    auto atomicBoolTy = ClangASTContext->getAtomicType(ClangASTContext->BoolTy);
+    AtomicBoolSize = Size(ClangASTContext->getTypeSize(atomicBoolTy));
+    AtomicBoolAlign = Alignment(ClangASTContext->getTypeSize(atomicBoolTy));
+  }
+
   IsSwiftErrorInRegister =
     clang::CodeGen::swiftcall::isSwiftErrorLoweredInRegister(
       ClangCodeGen->CGM());

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -492,7 +492,7 @@ public:
   llvm::PointerType *ErrorPtrTy;       /// %swift.error*
   llvm::StructType *OpenedErrorTripleTy; /// { %swift.opaque*, %swift.type*, i8** }
   llvm::PointerType *OpenedErrorTriplePtrTy; /// { %swift.opaque*, %swift.type*, i8** }*
-
+  
   unsigned InvariantMetadataID; /// !invariant.load
   unsigned DereferenceableID;   /// !dereferenceable
   llvm::MDNode *InvariantNode;
@@ -574,9 +574,14 @@ public:
   void error(SourceLoc loc, const Twine &message);
 
   bool useDllStorage();
+  
+  Size getAtomicBoolSize() const { return AtomicBoolSize; }
+  Alignment getAtomicBoolAlignment() const { return AtomicBoolAlign; }
 
 private:
   Size PtrSize;
+  Size AtomicBoolSize;
+  Alignment AtomicBoolAlign;
   llvm::Type *FixedBufferTy;          /// [N x i8], where N == 3 * sizeof(void*)
 
   llvm::Type *ValueWitnessTys[MaxNumValueWitnesses];

--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -1365,7 +1365,13 @@ SWIFT_RUNTIME_EXPORT
 void swift_objc_swift3ImplicitObjCEntrypoint(id self, SEL selector,
                                              const char *filename,
                                              size_t filenameLength,
-                                             size_t line, size_t column) {
+                                             size_t line, size_t column,
+                                             std::atomic<bool> *didLog) {
+  // Only log once. We should have been given a unique zero-initialized
+  // atomic flag for each entry point.
+  if (didLog->exchange(true))
+    return;
+  
   // Figure out how much reporting we want by querying the environment
   // variable SWIFT_DEBUG_IMPLICIT_OBJC_ENTRYPOINT. We have four meaningful
   // levels:

--- a/test/IRGen/objc_deprecated_objc_thunks.swift
+++ b/test/IRGen/objc_deprecated_objc_thunks.swift
@@ -16,7 +16,7 @@ class ObjCSubclass : NSObject {
 // CHECK-SWIFT4-LABEL: define hidden void @_T0016objc_deprecated_A7_thunks12ObjCSubclassC3fooyyFTo(%0*, i8*)
 // CHECK-SWIFT4: entry:
 // CHECK-SWIFT4: [[SELF:%[0-9]+]] = bitcast %0* %0 to %objc_object*
-// CHECK-SWIFT4-NEXT: call void @swift_objc_swift3ImplicitObjCEntrypoint(%objc_object* [[SELF]], i8* %1, i8* getelementptr inbounds ({{.*}}[[FILENAME_STR]]{{.*}}), i64 [[FILENAME_LENGTH:[0-9]+]], i64 13, i64 3)
+// CHECK-SWIFT4-NEXT: call void @swift_objc_swift3ImplicitObjCEntrypoint(%objc_object* [[SELF]], i8* %1, i8* getelementptr inbounds ({{.*}}[[FILENAME_STR]]{{.*}}), i64 [[FILENAME_LENGTH:[0-9]+]], i64 13, i64 3, i8* {{.*}})
 
 // CHECK-SWIFT3-LABEL: define hidden void @_T0016objc_deprecated_A7_thunks12ObjCSubclassC3fooyyFTo(%0*, i8*)
 // CHECK-SWIFT3: entry:

--- a/test/Interpreter/SDK/objc_swift3_deprecated_objc_inference.swift
+++ b/test/Interpreter/SDK/objc_swift3_deprecated_objc_inference.swift
@@ -45,8 +45,12 @@ DeprecatedObjCInferenceTestSuite.test("messagingObjCInference") {
 	// CHECK_WARNINGS: .swift:26:3: implicit Objective-C entrypoint -[a.MyClass foo]
 	// CHECK_CRASH: .swift:26:3: implicit Objective-C entrypoint -[a.MyClass foo]
 	x.perform(Selector(fooSel))
+	// CHECK_WARNINGS-NOT: .swift:26:3: implicit Objective-C entrypoint -[a.MyClass foo]
+	x.perform(Selector(fooSel))
 
 	// CHECK_WARNINGS: .swift:27:3: implicit Objective-C entrypoint +[a.MyClass bar]
+	type(of: x).perform(Selector(barSel))
+	// CHECK_WARNINGS-NOT: .swift:27:3: implicit Objective-C entrypoint +[a.MyClass bar]
 	type(of: x).perform(Selector(barSel))
 
 	// CHECK_NOTHING-NEXT: ---End 


### PR DESCRIPTION
We only need to alert the user once. rdar://problem/32229417