### PR TITLE
[swift-4.0-branch][stdlib] Reverting the String.init?(_: String) behavior

### DIFF
--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -107,12 +107,6 @@ public protocol StringProtocol
   ) rethrows -> Result
 }
 
-extension StringProtocol /* : LosslessStringConvertible */ {
-  public init?(_ description: String) {
-    self.init(description.characters)
-  }
-}
-
 /// Call body with a pointer to zero-terminated sequence of
 /// `TargetEncoding.CodeUnit` representing the same string as `source`, when
 /// `source` is interpreted as being encoded with `SourceEncoding`.

--- a/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
+++ b/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
@@ -36,12 +36,17 @@ extension String : StringProtocol {
     self.init(repeating: String(repeatedValue), count: count)
   }
 
-  // Now that String conforms to Collection, we need to disambiguate between:
+  // FIXME(strings): doc comment
+  // This initializer disambiguates between the following intitializers, now
+  // that String conforms to Collection:
   // - init<T>(_ value: T) where T : LosslessStringConvertible
   // - init<S>(_ characters: S) where S : Sequence, S.Element == Character
-  // Cannot simply do init(_: String) as that would itself be ambiguous with
-  // init?(_ description: String)
-  public init(_ other: String) {
+  public init<T : StringProtocol>(_ other: T) {
+    self.init(other.characters)
+  }
+
+  // This initializer satisfies the LosslessStringConvertible conformance
+  public init?(_ other: String) {
     self.init(other._core)
   }
 

--- a/stdlib/public/core/Substring.swift.gyb
+++ b/stdlib/public/core/Substring.swift.gyb
@@ -459,11 +459,11 @@ extension String {
 extension Substring {
   @available(swift, obsoleted: 4)
   public subscript(bounds: Range<Index>) -> String {
-    return String(self[bounds])
+    return String(characters[bounds])
   }
 
   @available(swift, obsoleted: 4)
   public subscript(bounds: ClosedRange<Index>) -> String {
-    return String(self[bounds] as Substring)
+    return String(characters[bounds])
   }
 }

--- a/test/stdlib/StringAPI.swift
+++ b/test/stdlib/StringAPI.swift
@@ -361,12 +361,6 @@ StringTests.test("CompareStringsWithUnpairedSurrogates")
   )
 }
 
-StringTests.test("String.init(_:String)") {
-  var s = String("")
-  expectType(String.self, &s)
-  var _ = String("") as String? // should also compile, but not be the default
-}
-
 StringTests.test("[String].joined() -> String") {
   let s = ["hello", "world"].joined()
   _ = s == "" // should compile without error

--- a/test/stdlib/SubstringCompatibility.swift
+++ b/test/stdlib/SubstringCompatibility.swift
@@ -37,5 +37,28 @@ Tests.test("ClosedRange/Subsript/ExpectedType") {
   expectType(ExpectedSubstring.self, &subsub)
 }
 
+Tests.test("String.init(_:String)/default type") {
+  var s = String("")
+  expectType(String?.self, &s)
+}
+
+Tests.test("LosslessStringConvertible/generic") {
+  func f<T : LosslessStringConvertible>(_ x: T.Type) {
+    _ = T("")! // unwrapping optional should work in generic context
+  }
+  f(String.self)
+}
+
+Tests.test("LosslessStringConvertible/concrete") {
+  _ = String("") as String?
+}
+
+#if swift(>=4)
+#else
+Tests.test("LosslessStringConvertible/force unwrap") {
+  // Force unwrap should still work in Swift 3 mode
+  _ = String("")!
+}
+#endif
 
 runAllTests()


### PR DESCRIPTION
* Explanation: String("") should call the failable initializer by default to maintain source compatibility
* Scope of Issue: A saner behavior by default should only be available in Swift 4 mode, but it is not immediately clear how to achieve it, so the change is being reverted.
* Risk: Minimal
* Reviewed By: Dave Abrahams
* Testing: Automated test suite
* Directions for QA: N/A
* Radar: <rdar://problem/32254931>