### PR TITLE
Allow make_decl_objc diagnostic note into the FixitApplyDiagnosticCon…

### DIFF
--- a/include/swift/Migrator/FixitApplyDiagnosticConsumer.h
+++ b/include/swift/Migrator/FixitApplyDiagnosticConsumer.h
@@ -20,6 +20,7 @@
 #include "swift/AST/DiagnosticConsumer.h"
 #include "swift/Migrator/FixitFilter.h"
 #include "clang/Rewrite/Core/RewriteBuffer.h"
+#include "llvm/ADT/DenseSet.h"
 
 namespace swift {
 
@@ -44,6 +45,9 @@ class FixitApplyDiagnosticConsumer final
   /// The number of fix-its pushed into the rewrite buffer. Use this to
   /// determine whether to call `printResult`.
   unsigned NumFixitsApplied;
+
+  /// Tracks whether a SourceLoc already got an `@objc` insertion.
+  llvm::SmallPtrSet<const void *, 32> AddedObjC;
 
 public:
   FixitApplyDiagnosticConsumer(const StringRef Text,

--- a/include/swift/Migrator/FixitFilter.h
+++ b/include/swift/Migrator/FixitFilter.h
@@ -127,7 +127,9 @@ struct FixitFilter {
         Info.ID == diag::objc_inference_swift3_objc_derived.ID ||
         Info.ID == diag::missing_several_cases.ID ||
         Info.ID == diag::missing_particular_case.ID ||
-        Info.ID == diag::paren_void_probably_void.ID)
+        Info.ID == diag::paren_void_probably_void.ID ||
+        Info.ID == diag::make_decl_objc.ID ||
+        Info.ID == diag::optional_req_nonobjc_near_match_add_objc.ID)
       return true;
 
     return false;

--- a/lib/Migrator/FixitApplyDiagnosticConsumer.cpp
+++ b/lib/Migrator/FixitApplyDiagnosticConsumer.cpp
@@ -56,6 +56,14 @@ handleDiagnostic(SourceManager &SM, SourceLoc Loc,
                                           ThisBufferID);
     auto Length = Fixit.getRange().getByteLength();
 
+    if (Fixit.getText().ltrim().rtrim() == "@objc") {
+      if (AddedObjC.count(Loc.getOpaquePointerValue())) {
+        return;
+      } else {
+        AddedObjC.insert(Loc.getOpaquePointerValue());
+      }
+    }
+
     RewriteBuf.ReplaceText(Offset, Length, Fixit.getText());
     ++NumFixitsApplied;
   }

--- a/test/Migrator/Inputs/objc_inference.swift
+++ b/test/Migrator/Inputs/objc_inference.swift
@@ -23,3 +23,16 @@ func test(object: AnyObject, mine: MyClass) {
   _ = #keyPath(MyClass.propertyUsedInKeyPath)
   _ = object.usedViaAnyObject?()
 }
+
+class SelfReferences : NSObject {
+  var prop: Int = 2
+  func foo() {
+    _ = #selector(self.foo)
+    _ = #keyPath(prop)
+  }
+
+  func bar() {
+    _ = #selector(self.foo)
+    _ = #selector(self.bar)
+  }
+}

--- a/test/Migrator/Inputs/objc_inference_cross_file_A.swift
+++ b/test/Migrator/Inputs/objc_inference_cross_file_A.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+public class MyClass : NSObject {
+  @objc public func methodUsedInSelector() {}
+  @objc public var propertyUsedInKeyPath: Int { return 2 }
+  @objc dynamic var dynamicVarUsedInSelector: Int { return 2 }
+}

--- a/test/Migrator/Inputs/objc_inference_cross_file_B.swift
+++ b/test/Migrator/Inputs/objc_inference_cross_file_B.swift
@@ -1,0 +1,5 @@
+public func test(object: AnyObject, mine: MyClass) {
+  _ = #selector(MyClass.methodUsedInSelector)
+  _ = #selector(getter: MyClass.dynamicVarUsedInSelector)
+  _ = #keyPath(MyClass.propertyUsedInKeyPath)
+}

--- a/test/Migrator/complete_objc_inference.swift
+++ b/test/Migrator/complete_objc_inference.swift
@@ -1,0 +1,5 @@
+// REQUIRES: objc_interop
+// RUN: %target-swift-frontend -typecheck -swift-version 3 -enable-swift3-objc-inference %s
+// RUN: rm -rf %t && mkdir -p %t && %target-swift-frontend -c -primary-file %S/Inputs/objc_inference.swift -emit-migrated-file-path %t/complete_objc_inference.swift.result -emit-remap-file-path %t/complete_objc_inference.swift.remap -migrate-keep-objc-visibility -o /dev/null
+// RUN: diff -u %S/complete_objc_inference.swift.expected %t/complete_objc_inference.swift.result 
+// RUN: %target-swift-frontend -typecheck -swift-version 4 -enable-swift3-objc-inference %t/complete_objc_inference.swift.result

--- a/test/Migrator/complete_objc_inference.swift.expected
+++ b/test/Migrator/complete_objc_inference.swift.expected
@@ -1,0 +1,38 @@
+import Foundation
+
+class MyClass : NSObject {
+  @objc var propertyUsedInKeyPath : NSObject? = nil
+  @objc dynamic var dynamicVarUsedInSelector : Int { return 2 }
+  @objc func overridden() {}
+  @objc func usedViaAnyObject() {}
+  @objc func unused() {}
+}
+
+extension MyClass {
+  @objc func inExtensionAndOverridden() {}
+}
+
+class MySubClass : MyClass {
+  override func overridden() {}
+  override func inExtensionAndOverridden() {}
+}
+
+func test(object: AnyObject, mine: MyClass) {
+  _ = #selector(MyClass.overridden)
+  _ = #selector(getter: MyClass.dynamicVarUsedInSelector)
+  _ = #keyPath(MyClass.propertyUsedInKeyPath)
+  _ = object.usedViaAnyObject?()
+}
+
+class SelfReferences : NSObject {
+  @objc var prop: Int = 2
+  @objc func foo() {
+    _ = #selector(self.foo)
+    _ = #keyPath(prop)
+  }
+
+  @objc func bar() {
+    _ = #selector(self.foo)
+    _ = #selector(self.bar)
+  }
+}

--- a/test/Migrator/minimal_objc_inference.swift
+++ b/test/Migrator/minimal_objc_inference.swift
@@ -1,11 +1,5 @@
-// RUN: rm -rf %t && mkdir -p %t && %target-swift-frontend -c -primary-file %S/Inputs/minimal_objc_inference.swift -emit-migrated-file-path %t/migrated_minimal_objc_inference.swift -emit-remap-file-path %t/migrated_minimal_objc_inference.swift.remap -o /dev/null
-// RUN: %FileCheck %s < %t/migrated_minimal_objc_inference.swift
 // REQUIRES: objc_interop
-
-// CHECK-NOT: @objc var propertyUsedInKeyPath: NSObject? = nil
-// CHECK:     @objc dynamic var dynamicVarUsedInSelector : Int { return 2 }
-// CHECK-NOT: @objc func overridden() {}
-// CHECK-NOT: @objc func usedViaAnyObject() {}
-// CHECK-NOT: @objc func inExtensionAndOverridden() {}
-// CHECK-NOT: @objc func unused() {}
-
+// RUN: %target-swift-frontend -typecheck -swift-version 3 %s
+// RUN: rm -rf %t && mkdir -p %t && %target-swift-frontend -c -primary-file %S/Inputs/objc_inference.swift -emit-migrated-file-path %t/minimal_objc_inference.swift.result -emit-remap-file-path %t/minimal_objc_inference.swift.remap -o /dev/null
+// RUN: diff -u %S/minimal_objc_inference.swift.expected %t/minimal_objc_inference.swift.result
+// RUN: %target-swift-frontend -typecheck -swift-version 4 %t/minimal_objc_inference.swift.result

--- a/test/Migrator/minimal_objc_inference.swift.expected
+++ b/test/Migrator/minimal_objc_inference.swift.expected
@@ -1,0 +1,38 @@
+import Foundation
+
+class MyClass : NSObject {
+  @objc var propertyUsedInKeyPath : NSObject? = nil
+  @objc dynamic var dynamicVarUsedInSelector : Int { return 2 }
+  @objc func overridden() {}
+  @objc func usedViaAnyObject() {}
+  func unused() {}
+}
+
+extension MyClass {
+  @objc func inExtensionAndOverridden() {}
+}
+
+class MySubClass : MyClass {
+  override func overridden() {}
+  override func inExtensionAndOverridden() {}
+}
+
+func test(object: AnyObject, mine: MyClass) {
+  _ = #selector(MyClass.overridden)
+  _ = #selector(getter: MyClass.dynamicVarUsedInSelector)
+  _ = #keyPath(MyClass.propertyUsedInKeyPath)
+  _ = object.usedViaAnyObject?()
+}
+
+class SelfReferences : NSObject {
+  @objc var prop: Int = 2
+  @objc func foo() {
+    _ = #selector(self.foo)
+    _ = #keyPath(prop)
+  }
+
+  @objc func bar() {
+    _ = #selector(self.foo)
+    _ = #selector(self.bar)
+  }
+}

--- a/test/Migrator/objc_inference_cross_file.swift
+++ b/test/Migrator/objc_inference_cross_file.swift
@@ -1,0 +1,5 @@
+// REQUIRES: objc_interop
+// RUN: %target-swift-frontend -typecheck -swift-version 3 -primary-file %S/Inputs/objc_inference_cross_file_A.swift %S/Inputs/objc_inference_cross_file_B.swift
+// RUN: rm -rf %t && mkdir -p %t && %target-swift-frontend -c -update-code -primary-file %S/Inputs/objc_inference_cross_file_A.swift %S/Inputs/objc_inference_cross_file_B.swift -emit-migrated-file-path %t/objc_inference_cross_file.swift.result -migrate-keep-objc-visibility -o /dev/null
+// RUN: diff -u %S/objc_inference_cross_file.swift.expected %t/objc_inference_cross_file.swift.result
+// RUN: %target-swift-frontend -typecheck -swift-version 4 -primary-file %t/objc_inference_cross_file.swift.result %S/Inputs/objc_inference_cross_file_B.swift

--- a/test/Migrator/objc_inference_cross_file.swift.expected
+++ b/test/Migrator/objc_inference_cross_file.swift.expected
@@ -1,0 +1,7 @@
+import Foundation
+
+public class MyClass : NSObject {
+  @objc public func methodUsedInSelector() {}
+  @objc public var propertyUsedInKeyPath: Int { return 2 }
+  @objc dynamic var dynamicVarUsedInSelector: Int { return 2 }
+}


### PR DESCRIPTION
…sumer

This allows the migrator to pick up fix-its from notes such as:

“Argument of #selector refers to instance method '___' that is not
exposed to Objective-C”

Add some more testing for minimal/complete workflows, and upstream
the cross-file fix-it test.

rdar://problem/32228948