### PR TITLE
Debug Info: Generate imported entities for implicitly imported parent

### DIFF
--- a/test/DebugInfo/ImportClangSubmodule.swift
+++ b/test/DebugInfo/ImportClangSubmodule.swift
@@ -10,7 +10,12 @@
 // CHECK-SAME:                         configMacros:
 // CHECK-SAME:                         {{..}}-DFOO=foo{{..}}
 // CHECK-SAME:                         {{..}}-UBAR{{..}}
+
 // CHECK: !DIImportedEntity({{.*}}, entity: ![[SUBMODULE]], line: [[@LINE+1]])
 import ClangModule.SubModule
+
+// The Swift compiler uses an ugly hack that auto-imports a
+// submodule's top-level-module, even if we didn't ask for it.
+// CHECK: !DIImportedEntity({{.*}}, entity: ![[CLANGMODULE]])
 
 let bar = Bar()


### PR DESCRIPTION
… modules.

The Swift compiler uses an ugly hack that auto-imports a submodule's
top-level-module, even if we didn't ask for it. Reflect that in the
debug info.

<rdar://problem/31310320>
