### PR TITLE
[4.0] [Parse] Don't tell CodeCompletion nonsense about protocol/AT where clauses

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -5357,8 +5357,6 @@ parseDeclProtocol(ParseDeclOptions Flags, DeclAttributes &Attributes) {
     Status |= parseInheritance(InheritedProtocols, &classRequirementLoc);
   }
 
-  // Parse a 'where' clause if present. These are not supported, but we will
-  // get better QoI this way.
   TrailingWhereClause *TrailingWhere = nullptr;
   // Parse a 'where' clause if present.
   if (Tok.is(tok::kw_where)) {

--- a/lib/Parse/ParseGeneric.cpp
+++ b/lib/Parse/ParseGeneric.cpp
@@ -390,12 +390,7 @@ ParserStatus Parser::parseProtocolOrAssociatedTypeWhereClause(
     trailingWhere =
         TrailingWhereClause::create(Context, whereLoc, requirements);
   } else if (whereStatus.hasCodeCompletion()) {
-    // FIXME: this is completely (hah) cargo culted.
-    if (CodeCompletion && firstTypeInComplete) {
-      CodeCompletion->completeGenericParams(nullptr);
-    } else {
-      return makeParserCodeCompletionStatus();
-    }
+    return whereStatus;
   }
 
   return ParserStatus();

--- a/test/IDE/complete_crashes.swift
+++ b/test/IDE/complete_crashes.swift
@@ -196,3 +196,9 @@ struct S_RDAR_28991372 {
 
 S_RDAR_28991372(x: #^RDAR_28991372^#, y: <#T##Int#>)
 // RDAR_28991372: Begin completions
+
+// rdar://problem/31981486
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=RDAR_31981486 | %FileCheck %s -check-prefix=RDAR_31981486
+
+protocol P where #^RDAR_31981486^#
+// RDAR_31981486: Begin completions

--- a/validation-test/IDE/crashers_2/0012-protocol-where-clause.swift
+++ b/validation-test/IDE/crashers_2/0012-protocol-where-clause.swift
@@ -1,4 +1,0 @@
-// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-// REQUIRES: asserts
-
-protocol a where #^A^#

--- a/validation-test/IDE/crashers_2_fixed/0012-protocol-where-clause.swift
+++ b/validation-test/IDE/crashers_2_fixed/0012-protocol-where-clause.swift
@@ -1,0 +1,4 @@
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+// REQUIRES: asserts
+
+protocol a where #^A^#


### PR DESCRIPTION
**Explanation**: cherry pick of https://github.com/apple/swift/pull/9419 . This was misusing an API in a cargo-culted attempt to get better completions for things like `protocol Foo where Se<esc>`, which just resulted in crashes. The default completions aren't as helpful as they could be, but are definitely better than just crashing.
**Scope**: Anyone using the new where clauses in Xcode.
**Radar**: rdar://problem/32256159
**Risk**: Low: this is removing an incorrectly called, optional function call. 
**Testing**: Swift CI.