### PR TITLE
[Serialization] Drop enums if a case payload can't be deserialized.

### DIFF
--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -54,7 +54,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// in source control, you should also update the comment to briefly
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
-const uint16_t VERSION_MINOR = 345; // Last change: list of dependency types
+const uint16_t VERSION_MINOR = 346; // Last change: dependency types for enums
 
 using DeclID = PointerEmbeddedInt<unsigned, 31>;
 using DeclIDField = BCFixed<31>;
@@ -802,7 +802,8 @@ namespace decls_block {
     TypeIDField,            // raw type
     AccessibilityKindField, // accessibility
     BCVBR<4>,               // number of conformances
-    BCArray<TypeIDField>    // inherited types
+    BCVBR<4>,               // number of inherited types
+    BCArray<TypeIDField>    // inherited types, followed by dependency types
     // Trailed by the generic parameters (if any), the members record, and
     // finally conformance info (if any).
   >;

--- a/test/Serialization/Recovery/typedefs-in-enums.swift
+++ b/test/Serialization/Recovery/typedefs-in-enums.swift
@@ -19,6 +19,9 @@ func use(_: BadEnum) {} // expected-error {{use of undeclared type 'BadEnum'}}
 func test() {
   _ = producesOkayEnum()
   _ = producesBadEnum() // expected-error {{use of unresolved identifier 'producesBadEnum'}}
+
+  // Force a lookup of the ==
+  _ = Optional(OkayEnum.noPayload).map { $0 == .noPayload }
 }
 
 #else // TEST
@@ -30,6 +33,10 @@ public enum BadEnum {
   case perfectlyOkayPayload(Int)
   case problematic(Any, WrappedInt)
   case alsoOkay(Any, Any, Any)
+
+  static public func ==(a: BadEnum, b: BadEnum) -> Bool {
+    return false
+  }
 }
 // CHECK-LABEL: enum BadEnum {
 // CHECK-RECOVERY-NOT: enum BadEnum
@@ -38,16 +45,22 @@ public enum OkayEnum {
   case noPayload
   case plainOldAlias(Any, UnwrappedInt)
   case other(Int)
+
+  static public func ==(a: OkayEnum, b: OkayEnum) -> Bool {
+    return false
+  }
 }
 // CHECK-LABEL: enum OkayEnum {
 // CHECK-NEXT:   case noPayload
 // CHECK-NEXT:   case plainOldAlias(Any, UnwrappedInt)
 // CHECK-NEXT:   case other(Int)
+// CHECK-NEXT:   static func ==(a: OkayEnum, b: OkayEnum) -> Bool
 // CHECK-NEXT: }
 // CHECK-RECOVERY-LABEL: enum OkayEnum {
 // CHECK-RECOVERY-NEXT:   case noPayload
 // CHECK-RECOVERY-NEXT:   case plainOldAlias(Any, Int32)
 // CHECK-RECOVERY-NEXT:   case other(Int)
+// CHECK-RECOVERY-NEXT:   static func ==(a: OkayEnum, b: OkayEnum) -> Bool
 // CHECK-RECOVERY-NEXT: }
 
 public enum OkayEnumWithSelfRefs {

--- a/test/Serialization/Recovery/typedefs-in-enums.swift
+++ b/test/Serialization/Recovery/typedefs-in-enums.swift
@@ -1,0 +1,81 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: %target-swift-frontend -emit-sil -o - -emit-module-path %t/Lib.swiftmodule -module-name Lib -I %S/Inputs/custom-modules -disable-objc-attr-requires-foundation-module %s > /dev/null
+
+// RUN: %target-swift-ide-test -source-filename=x -print-module -module-to-print Lib -I %t -I %S/Inputs/custom-modules | %FileCheck %s
+
+// RUN: %target-swift-ide-test -source-filename=x -print-module -module-to-print Lib -I %t -I %S/Inputs/custom-modules -Xcc -DBAD | %FileCheck -check-prefix CHECK-RECOVERY %s
+
+// RUN: %target-swift-frontend -typecheck -I %t -I %S/Inputs/custom-modules -Xcc -DBAD -DTEST %s -verify
+
+#if TEST
+
+import Typedefs
+import Lib
+
+func use(_: OkayEnum) {}
+// FIXME: Better to import the enum and make it unavailable.
+func use(_: BadEnum) {} // expected-error {{use of undeclared type 'BadEnum'}}
+
+func test() {
+  _ = producesOkayEnum()
+  _ = producesBadEnum() // expected-error {{use of unresolved identifier 'producesBadEnum'}}
+}
+
+#else // TEST
+
+import Typedefs
+
+public enum BadEnum {
+  case noPayload
+  case perfectlyOkayPayload(Int)
+  case problematic(Any, WrappedInt)
+  case alsoOkay(Any, Any, Any)
+}
+// CHECK-LABEL: enum BadEnum {
+// CHECK-RECOVERY-NOT: enum BadEnum
+
+public enum OkayEnum {
+  case noPayload
+  case plainOldAlias(Any, UnwrappedInt)
+  case other(Int)
+}
+// CHECK-LABEL: enum OkayEnum {
+// CHECK-NEXT:   case noPayload
+// CHECK-NEXT:   case plainOldAlias(Any, UnwrappedInt)
+// CHECK-NEXT:   case other(Int)
+// CHECK-NEXT: }
+// CHECK-RECOVERY-LABEL: enum OkayEnum {
+// CHECK-RECOVERY-NEXT:   case noPayload
+// CHECK-RECOVERY-NEXT:   case plainOldAlias(Any, Int32)
+// CHECK-RECOVERY-NEXT:   case other(Int)
+// CHECK-RECOVERY-NEXT: }
+
+public enum OkayEnumWithSelfRefs {
+  public struct Nested {}
+  indirect case selfRef(OkayEnumWithSelfRefs)
+  case nested(Nested)
+}
+// CHECK-LABEL: enum OkayEnumWithSelfRefs {
+// CHECK-NEXT:   struct Nested {
+// CHECK-NEXT:     init()
+// CHECK-NEXT:   }
+// CHECK-NEXT:   indirect case selfRef(OkayEnumWithSelfRefs)
+// CHECK-NEXT:   case nested(OkayEnumWithSelfRefs.Nested)
+// CHECK-NEXT: }
+// CHECK-RECOVERY-LABEL: enum OkayEnumWithSelfRefs {
+// CHECK-RECOVERY-NEXT:   struct Nested {
+// CHECK-RECOVERY-NEXT:     init()
+// CHECK-RECOVERY-NEXT:   }
+// CHECK-RECOVERY-NEXT:   indirect case selfRef(OkayEnumWithSelfRefs)
+// CHECK-RECOVERY-NEXT:   case nested(OkayEnumWithSelfRefs.Nested)
+// CHECK-RECOVERY-NEXT: }
+
+public func producesBadEnum() -> BadEnum { return .noPayload }
+// CHECK-LABEL: func producesBadEnum() -> BadEnum
+// CHECK-RECOVERY-NOT: func producesBadEnum() -> BadEnum
+
+public func producesOkayEnum() -> OkayEnum { return .noPayload }
+// CHECK-LABEL: func producesOkayEnum() -> OkayEnum
+// CHECK-RECOVERY-LABEL: func producesOkayEnum() -> OkayEnum
+
+#endif // TEST


### PR DESCRIPTION
Layout for an enum depends very intimately on its cases—both their existence and what their payload types are. That means there's no way to "partly" recover from failure to deserialize an individual case's payload type, the way we can partly recover from failing to deserialize an initializer in a class. Add deserialization recovery to enums by validating all of their payload types up front, and dropping the enum if we can't import all of the cases.

This is the first time where we're trying to do deserialization recovery for a *type*, and that could have many more ripple effects than for a var/func/subscript/init. A better answer here might be to still import the enum but mark it as unavailable, but in that case we'd have to make sure to propagate that unavailability to anything that *used* the enum as well. (In Swift, availability is checked based on use of the name, so if someone manages to refer to an enum using inferred types we'd be in trouble.)

There is one case here that's not covered: if an enum case has a payload that references a type declaration nested within the enum, but then that nested type *itself* can't be loaded for some reason, we have no way to check that up front, because we can't even try to load the nested type without loading its parent DeclContext (the enum). I can't think of an easy solution for this right now.

(In the future, we'll be able to support dropping a single case for resilient enums. But we're not there right now.)

rdar://problem/31920901

Oh, and handle operators that can't be deserialized too.
