### PR TITLE
Add -disable-sil-linking to four simple SIL serialization tests.

### DIFF
--- a/test/Serialization/alignment.swift
+++ b/test/Serialization/alignment.swift
@@ -1,7 +1,7 @@
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
 // RUN: %target-swift-frontend %s -emit-module -parse-as-library -o %t
-// RUN: %target-sil-opt -enable-sil-verify-all %t/alignment.swiftmodule -o - | %FileCheck %s
+// RUN: %target-sil-opt -disable-sil-linking -enable-sil-verify-all %t/alignment.swiftmodule -o - | %FileCheck %s
 
 //CHECK: @_alignment(16) struct Foo {
 @_alignment(16) struct Foo {}

--- a/test/Serialization/default-witness-table-deserialization.swift
+++ b/test/Serialization/default-witness-table-deserialization.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend %s -module-name Test -sil-serialize-all -emit-module -emit-module-path - -o /dev/null | %target-sil-opt -enable-sil-verify-all -module-name="Test" | %FileCheck %s
+// RUN: %target-swift-frontend %s -module-name Test -sil-serialize-all -emit-module -emit-module-path - -o /dev/null | %target-sil-opt -enable-sil-verify-all -disable-sil-linking -module-name="Test" | %FileCheck %s
 
 // Check that default witness tables are properly deserialized.
 // rdar://problem/29173229

--- a/test/Serialization/global_init.swift
+++ b/test/Serialization/global_init.swift
@@ -2,7 +2,7 @@
 // RUN: mkdir -p %t
 // RUN: %target-swift-frontend -emit-module -parse-as-library -sil-serialize-all -o %t %s
 // RUN: llvm-bcanalyzer %t/global_init.swiftmodule | %FileCheck %s -check-prefix=BCANALYZER
-// RUN: %target-sil-opt -enable-sil-verify-all %t/global_init.swiftmodule | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -disable-sil-linking %t/global_init.swiftmodule | %FileCheck %s
 
 // BCANALYZER-NOT: UnknownCode
 

--- a/test/Serialization/serialize_attr.swift
+++ b/test/Serialization/serialize_attr.swift
@@ -2,7 +2,7 @@
 // RUN: mkdir -p %t
 // RUN: %target-swift-frontend -emit-module -parse-as-library -sil-serialize-all -o %t %s
 // RUN: llvm-bcanalyzer %t/serialize_attr.swiftmodule | %FileCheck %s -check-prefix=BCANALYZER
-// RUN: %target-sil-opt -enable-sil-verify-all %t/serialize_attr.swiftmodule | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -disable-sil-linking %t/serialize_attr.swiftmodule | %FileCheck %s
 
 // BCANALYZER-NOT: UnknownCode
 


### PR DESCRIPTION
What these tests are testing has nothing to do with whether or not we deserialize anything from the standard library, and not doing so saves more than two minutes (single-threaded) on my machine from each test.