### PR TITLE
[4.0] Fix some issues in handling of withoutActuallyEscaping.

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -6744,7 +6744,8 @@ Expr *ExprRewriter::finishApply(ApplyExpr *apply, Type openedType,
         assert(arg->getNumElements() == 2 && "should have two arguments");
         auto nonescaping = arg->getElements()[0];
         auto body = arg->getElements()[1];
-        auto bodyFnTy = cs.getType(body)->castTo<FunctionType>();
+        auto bodyTy = cs.getType(body)->getLValueOrInOutObjectType();
+        auto bodyFnTy = bodyTy->castTo<FunctionType>();
         auto escapableType = bodyFnTy->getInput();
         auto resultType = bodyFnTy->getResult();
         

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3682,9 +3682,6 @@ ConstraintSystem::simplifyEscapableFunctionOfConstraint(
 
   type2 = getFixedTypeRecursive(type2, flags, /*wantRValue=*/true);
   if (auto fn2 = type2->getAs<FunctionType>()) {
-    // We should have the noescape end of the relation.
-    if (!fn2->getExtInfo().isNoEscape())
-      return SolutionKind::Error;
     // Solve forward by binding the other type variable to the escapable
     // variation of this type.
     auto fn1 = fn2->withExtInfo(fn2->getExtInfo().withNoEscape(false));

--- a/test/Constraints/without_actually_escaping_no_errors.swift
+++ b/test/Constraints/without_actually_escaping_no_errors.swift
@@ -1,0 +1,34 @@
+// RUN: %target-swift-frontend -module-name main -typecheck -swift-version 3 %s
+// RUN: %target-swift-frontend -module-name main -typecheck -swift-version 4 %s
+
+// These tests are split out to ensure that we run the AST verifier's
+// special post-type-checked verifications, which don't currently
+// happen if any errors occur anywhere during compilation.
+
+func rdar32239354_1(_ fn: () -> Void) {
+  var other: (() -> Void) -> Void = { _ in  }
+
+  withoutActuallyEscaping(fn, do: other)
+  // Reassign to avoid warning about changing this to a let, since we
+  // need this to be a var to trigger the original issue.
+  other = { _ in }
+}
+
+func rdar32239354_2(_ fn: () -> Void, other: inout (() -> Void) -> Void) {
+  withoutActuallyEscaping(fn, do: other)
+}
+
+func testVariations(
+  _ no_escape: () -> (),
+  _ escape: @escaping () -> (),
+  _ takesFn: (()->()) -> ()->()
+) -> () -> () {
+  withoutActuallyEscaping(no_escape) { _ in }
+  withoutActuallyEscaping({}) { _ in }
+  withoutActuallyEscaping(escape) { _ in }
+  _ = withoutActuallyEscaping(no_escape, do: takesFn)
+  _ = withoutActuallyEscaping(escape, do: takesFn)
+  _ = withoutActuallyEscaping(no_escape) {
+    return takesFn($0)
+  }
+}


### PR DESCRIPTION
We need to strip inout/lvalue before casting the second parameter's type
to FunctionType.

There were also some verification issues and the fact that we weren't
allowing already-escaping closures to be passed to it (which is not
useful, but shouldn't result in an error and really awful
diagnostic). We can potentially look at diagnosing this with a warning
at some point in the future.

Fixes rdar://problem/32239354.

(cherry picked from commit b8cc0151136b0e0df84ee7ed5c4bf844bc46c4d0)
