### PR TITLE
Disable HashQuadratic benchmark

### DIFF
--- a/benchmark/utils/main.swift
+++ b/benchmark/utils/main.swift
@@ -232,7 +232,6 @@ addTo(&precommitTests, "DropWhileSequenceLazy", run_DropWhileSequenceLazy)
 addTo(&precommitTests, "ErrorHandling", run_ErrorHandling)
 addTo(&precommitTests, "GlobalClass", run_GlobalClass)
 addTo(&precommitTests, "Hanoi", run_Hanoi)
-addTo(&precommitTests, "HashQuadratic", run_HashQuadratic)
 addTo(&precommitTests, "HashTest", run_HashTest)
 addTo(&precommitTests, "Histogram", run_Histogram)
 addTo(&precommitTests, "Integrate", run_Integrate)
@@ -506,6 +505,7 @@ addTo(&otherTests, "ExistentialTestTwoMethodCalls_IntValueBuffer2", run_Existent
 addTo(&otherTests, "ExistentialTestTwoMethodCalls_IntValueBuffer3", run_ExistentialTestTwoMethodCalls_IntValueBuffer3)
 addTo(&otherTests, "ExistentialTestTwoMethodCalls_IntValueBuffer4", run_ExistentialTestTwoMethodCalls_IntValueBuffer4)
 addTo(&otherTests, "Fibonacci", run_Fibonacci)
+addTo(&otherTests, "HashQuadratic", run_HashQuadratic)
 
 // String tests, an extended benchmark suite exercising finer-granularity
 // behavior of our Strings.

--- a/benchmark/utils/main.swift.gyb
+++ b/benchmark/utils/main.swift.gyb
@@ -34,8 +34,9 @@ imports = sorted(tests + [msb.name for msb in multisource_benches])
 
 other_re = [
     "Ackermann",
+    "ExistentialTest.+",
     "Fibonacci",
-    "ExistentialTest.+"
+    "HashQuadratic"
 ]
 
 string_re = [


### PR DESCRIPTION
Moving HashQuadratic performance test from “precommit” suite to “other”, so that it does not slow down the testing until we have a fix for [SR-3268](https://bugs.swift.org/browse/SR-3268).

As warned in [discussion on SR-3268](https://bugs.swift.org/browse/SR-3268?focusedCommentId=19829&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-19829):
> Adding a benchmark now would probably be inappropriate as it would DDOS the benchmarking infra. One should definitely be added with a fix.

It appears that https://github.com/apple/swift/commit/ca99ee2c342e07a277938ba2bb1b5bfd418ce0c2 mentioned in #7617, when the HashQuadratic test was added, does not fix the issue and did impose a great tax on running the benchmark suite.

This moves the benchmark off of the critical path until we have a fix.