### PR TITLE
[CoreGraphics] Make CGColor adopt _ExpressibleByColorLiteral. 

### DIFF
--- a/stdlib/public/SDK/CoreGraphics/CoreGraphics.swift
+++ b/stdlib/public/SDK/CoreGraphics/CoreGraphics.swift
@@ -48,6 +48,19 @@ extension CGColor {
 #endif
 }
 
+public protocol _CGColorInitTrampoline {
+  init(red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat)
+}
+
+extension _CGColorInitTrampoline {
+  public init(colorLiteralRed red: Float, green: Float, blue: Float,
+              alpha: Float) {
+    self.init(red: CGFloat(red), green: CGFloat(green), blue: CGFloat(blue),
+              alpha: CGFloat(alpha))
+  }
+}
+
+extension CGColor : _CGColorInitTrampoline, _ExpressibleByColorLiteral { }
 
 //===----------------------------------------------------------------------===//
 // CGColorSpace

--- a/stdlib/public/SDK/CoreGraphics/CoreGraphics.swift
+++ b/stdlib/public/SDK/CoreGraphics/CoreGraphics.swift
@@ -17,9 +17,11 @@ import Darwin
 // CGAffineTransform
 //===----------------------------------------------------------------------===//
 
-extension CGAffineTransform: Equatable {}
-public func ==(lhs: CGAffineTransform, rhs: CGAffineTransform) -> Bool {
-  return lhs.__equalTo(rhs)
+extension CGAffineTransform: Equatable {
+  public static func ==(lhs: CGAffineTransform,
+                        rhs: CGAffineTransform) -> Bool {
+    return lhs.__equalTo(rhs)
+  }
 }
 
 //===----------------------------------------------------------------------===//
@@ -228,10 +230,11 @@ extension CGPoint : CustomDebugStringConvertible {
   }
 }
 
-extension CGPoint : Equatable {}
-@_transparent // @fragile
-public func == (lhs: CGPoint, rhs: CGPoint) -> Bool {
-  return lhs.x == rhs.x  &&  lhs.y == rhs.y
+extension CGPoint : Equatable {
+  @_transparent // @fragile
+  public static func == (lhs: CGPoint, rhs: CGPoint) -> Bool {
+    return lhs.x == rhs.x  &&  lhs.y == rhs.y
+  }
 }
 
 public extension CGSize {
@@ -279,10 +282,11 @@ extension CGSize : CustomDebugStringConvertible {
   }
 }
 
-extension CGSize : Equatable {}
-@_transparent // @fragile
-public func == (lhs: CGSize, rhs: CGSize) -> Bool {
-  return lhs.width == rhs.width  &&  lhs.height == rhs.height
+extension CGSize : Equatable {
+  @_transparent // @fragile
+  public static func == (lhs: CGSize, rhs: CGSize) -> Bool {
+    return lhs.width == rhs.width  &&  lhs.height == rhs.height
+  }
 }
 
 public extension CGVector {
@@ -302,10 +306,11 @@ public extension CGVector {
   }
 }
 
-extension CGVector : Equatable {}
-@_transparent // @fragile
-public func == (lhs: CGVector, rhs: CGVector) -> Bool {
-  return lhs.dx == rhs.dx  &&  lhs.dy == rhs.dy
+extension CGVector : Equatable {
+  @_transparent // @fragile
+  public static func == (lhs: CGVector, rhs: CGVector) -> Bool {
+    return lhs.dx == rhs.dx  &&  lhs.dy == rhs.dy
+  }
 }
 
 extension CGVector : CustomDebugStringConvertible {
@@ -380,10 +385,11 @@ extension CGRect : CustomDebugStringConvertible {
   }
 }
 
-extension CGRect : Equatable {}
-@_transparent // @fragile
-public func == (lhs: CGRect, rhs: CGRect) -> Bool {
-  return lhs.equalTo(rhs)
+extension CGRect : Equatable {
+  @_transparent // @fragile
+  public static func == (lhs: CGRect, rhs: CGRect) -> Bool {
+    return lhs.equalTo(rhs)
+  }
 }
 
 extension CGAffineTransform {

--- a/validation-test/stdlib/CoreGraphics-execute.swift
+++ b/validation-test/stdlib/CoreGraphics-execute.swift
@@ -48,6 +48,17 @@ CoreGraphicsTests.test("CGColor.components") {
   expectEqual(components[3], 1)
 }
 
+CoreGraphicsTests.test("CGColor/ExpressibleByColorLiteral") {
+  let colorLit: CGColor = #colorLiteral(red: 0.25, green: 0.5, blue: 0.75,
+                                        alpha: 1.0)
+  let components = colorLit.components!
+  expectEqual(components.count, 4)
+  expectEqual(components[0], 0.25)
+  expectEqual(components[1], 0.50)
+  expectEqual(components[2], 0.75)
+  expectEqual(components[3], 1.0)
+}
+
 //===----------------------------------------------------------------------===//
 // CGPoint
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
The backflips here are because we cannot add initializers to imported
CF types; they would be factory initializers. Fixes
rdar://problem/32196175.