### PR TITLE
Remove a hack to change linkage from public_external to shared.

### DIFF
--- a/lib/SILOptimizer/Transforms/SILCleanup.cpp
+++ b/lib/SILOptimizer/Transforms/SILCleanup.cpp
@@ -47,12 +47,6 @@ static void cleanFunction(SILFunction &Fn) {
       }
     }
   }
-
-  // Rename functions with public_external linkage to prevent symbol conflict
-  // with stdlib.
-  if (Fn.isDefinition() && Fn.getLinkage() == SILLinkage::PublicExternal) {
-    Fn.setLinkage(SILLinkage::SharedExternal);
-  }
 }
 
 namespace {

--- a/test/IRGen/sil_linkage.sil
+++ b/test/IRGen/sil_linkage.sil
@@ -8,7 +8,7 @@ sil_stage canonical
 // CHECK: define{{( protected)?}} swiftcc void @hidden_fragile_function_test() {{.*}} {
 // CHECK: define linkonce_odr hidden swiftcc void @shared_fragile_function_test() {{.*}} {
 // CHECK: define{{( protected)?}} swiftcc void @private_fragile_function_test() {{.*}} {
-// CHECK: define linkonce_odr hidden swiftcc void @public_external_fragile_function_def_test() {{.*}} {
+// CHECK: define available_externally swiftcc void @public_external_fragile_function_def_test() {{.*}} {
 // CHECK: define{{( protected)?}} available_externally swiftcc void @hidden_external_fragile_function_def_test() {{.*}} {
 // CHECK: define linkonce_odr hidden swiftcc void @shared_external_fragile_function_def_test() {{.*}} {
 // CHECK: define{{( protected)?}} available_externally swiftcc void @private_external_fragile_function_def_test() {{.*}} {
@@ -16,7 +16,7 @@ sil_stage canonical
 // CHECK: define hidden swiftcc void @hidden_resilient_function_test() {{.*}} {
 // CHECK: define linkonce_odr hidden swiftcc void @shared_resilient_function_test() {{.*}} {
 // CHECK: define internal swiftcc void @private_resilient_function_test() {{.*}}{
-// CHECK: define linkonce_odr hidden swiftcc void @public_external_resilient_function_def_test() {{.*}} {
+// CHECK: define available_externally swiftcc void @public_external_resilient_function_def_test() {{.*}} {
 // CHECK: define{{( protected)?}} available_externally hidden swiftcc void @hidden_external_resilient_function_def_test() {{.*}} {
 // CHECK: define linkonce_odr hidden swiftcc void @shared_external_resilient_function_def_test() {{.*}} {
 


### PR DESCRIPTION
Explanation:  This change fixes a big code duplication problem. The compiler generated code for public functions which are imported from the stdlib - and are also available in the swiftCore library.
This got worse since we use public linkage for @_versioned internal functions in the stdlib.
The code size overhead by this duplication is up to 40% for some projects. Which means that by fixing this, we get up to 40% code size reduction.
There is no significant impact on benchmark performance.

Scope: This problem has a big effect on the code size.

Radar: rdar://problem/32265845

Risk: Low. It has no effect on generated code (it only removes duplicated functions). And it has no effect on generated swiftmodule files.

Testing: There is a specific test for swift-ci. Also it's implicitly tested by all tests/projects which link an executable.