### PR TITLE
[Serialization] Use effective language version for "module too old".

### DIFF
--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -232,7 +232,7 @@ FileUnit *SerializedModuleLoader::loadAST(
 
     SmallString<32> versionBuf;
     llvm::raw_svector_ostream versionString(versionBuf);
-    versionString << version::Version::getCurrentLanguageVersion();
+    versionString << Ctx.LangOpts.EffectiveLanguageVersion;
     if (versionString.str() == shortVersion)
       return false;
 

--- a/test/Serialization/version-mismatches.swift
+++ b/test/Serialization/version-mismatches.swift
@@ -1,12 +1,25 @@
 // RUN: not %target-swift-frontend %s -typecheck -I %S/Inputs/too-old/ -show-diagnostics-after-fatal 2>&1 | %FileCheck -check-prefix CHECK -check-prefix TOO-OLD %s
 // RUN: not %target-swift-frontend %s -typecheck -I %S/Inputs/too-new/ -show-diagnostics-after-fatal 2>&1 | %FileCheck -check-prefix CHECK -check-prefix TOO-NEW %s
+
 // RUN: not %target-swift-frontend %s -typecheck -I %S/Inputs/too-old-language/ -show-diagnostics-after-fatal 2>&1 | %FileCheck -check-prefix CHECK -check-prefix LANGUAGE %s
 // RUN: not %target-swift-frontend %s -typecheck -I %S/Inputs/too-new-language/ -show-diagnostics-after-fatal 2>&1 | %FileCheck -check-prefix CHECK -check-prefix LANGUAGE %s
+
+// Update this line when "-swift-version 3" is no longer supported.
+// RUN: not %target-swift-frontend %s -typecheck -I %S/Inputs/too-new-language/ -show-diagnostics-after-fatal -swift-version 3 2>&1 | %FileCheck -check-prefix CHECK -check-prefix LANGUAGE-3 %s
+// Update this line when "-swift-version 4" is no longer supported.
+// RUN: not %target-swift-frontend %s -typecheck -I %S/Inputs/too-new-language/ -show-diagnostics-after-fatal -swift-version 4 2>&1 | %FileCheck -check-prefix CHECK -check-prefix LANGUAGE-4 %s
 
 import Library
 // TOO-OLD: :[[@LINE-1]]:8: error: module file was created by an older version of the compiler; rebuild 'Library' and try again: {{.*}}too-old/Library.swiftmodule{{$}}
 // TOO-NEW: :[[@LINE-2]]:8: error: module file was created by a newer version of the compiler: {{.*}}too-new/Library.swiftmodule{{$}}
-// LANGUAGE: :[[@LINE-3]]:8: error: module compiled with Swift X.Y cannot be imported in Swift {{.+}}.{{.+}}: {{.*}}too-{{old|new}}-language/Library.swiftmodule{{$}}
+
+// Update this line when the default language version changes
+// LANGUAGE: :[[@LINE-5]]:8: error: module compiled with Swift X.Y cannot be imported in Swift {{.+}}.{{.+}}: {{.*}}too-{{old|new}}-language/Library.swiftmodule{{$}}
+
+// Update this line when "-swift-version 3" is no longer supported.
+// LANGUAGE-3: :[[@LINE-8]]:8: error: module compiled with Swift X.Y cannot be imported in Swift 3.{{.+}}: {{.*}}too-{{old|new}}-language/Library.swiftmodule{{$}}
+// Update this line when "-swift-version 3" is no longer supported.
+// LANGUAGE-4: :[[@LINE-10]]:8: error: module compiled with Swift X.Y cannot be imported in Swift 4.{{.+}}: {{.*}}too-{{old|new}}-language/Library.swiftmodule{{$}}
 
 // Compiler thinks that the module is empty in all cases.
 // CHECK: :[[@LINE+1]]:1: error: module 'Library' has no member named 'foo'


### PR DESCRIPTION
People were getting confused when it said "module compiled with Swift 3.1 cannot be imported into Swift 4.0" when they were passing "-swift-version 3".

rdar://problem/32187112