### PR TITLE
[stdlib] Static stdlib requires explicit -licucore

### DIFF
--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -1240,6 +1240,7 @@ toolchains::Darwin::constructInvocation(const LinkJobAction &job,
     Arguments.push_back("-framework");
     Arguments.push_back("Foundation");
     Arguments.push_back("-force_load_swift_libs");
+    Arguments.push_back("-licucore");
   } else {
     Arguments.push_back(context.Args.MakeArgString(RuntimeLibPath));
   }


### PR DESCRIPTION
<!-- What's in this pull request? -->
4.0 cherry-pick of https://github.com/apple/swift/pull/9739. 

CCC
Explanation: Standard library needs to link against ICU. This means that users of statically linked standard libraries also need to link against the system's ICU. This change passes on the necessary flags in the Driver.
Scope: Affects the compiler driver, by adding a new link argument.
Radar (and possibly SR Issue): <rdar://problem/32273129>
Risk: Low, affects driver build with static standard library. Without this, such a build would result in linker errors about missing ICU symbols.
Testing: CI integration testing, and the Swift Package bot
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
