### PR TITLE
[stdlib] Adding RangeReplaceable.filter returning Self

### DIFF
--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -1574,6 +1574,16 @@ extension ${Self} : RangeReplaceableCollection, _ArrayProtocol {
     }
   }
 
+  // Since RangeReplaceableCollection now has a version of filter that is less
+  // efficient, we should make the default implementation coming from Sequence
+  // preferred.
+  @_inlineable
+  public func filter(
+    _ isIncluded: (Element) throws -> Bool
+  ) rethrows -> [Element] {
+    return try _filter(isIncluded)
+  }
+
   //===--- algorithms -----------------------------------------------------===//
 
   @_inlineable

--- a/stdlib/public/core/RangeReplaceableCollection.swift.gyb
+++ b/stdlib/public/core/RangeReplaceableCollection.swift.gyb
@@ -1212,6 +1212,31 @@ public func += <
   lhs.append(contentsOf: rhs)
 }
 
+extension RangeReplaceableCollection {
+  /// Returns a new collection of the same type containing, in order, the
+  /// elements of the original collection that satisfy the given predicate.
+  ///
+  /// In this example, `filter(_:)` is used to include only names shorter than
+  /// five characters.
+  ///
+  ///     let cast = ["Vivien", "Marlon", "Kim", "Karl"]
+  ///     let shortNames = cast.filter { $0.count < 5 }
+  ///     print(shortNames)
+  ///     // Prints "["Kim", "Karl"]"
+  ///
+  /// - Parameter isIncluded: A closure that takes an element of the
+  ///   sequence as its argument and returns a Boolean value indicating
+  ///   whether the element should be included in the returned array.
+  /// - Returns: An array of the elements that `isIncluded` allowed.
+  @_inlineable
+  @available(swift, introduced: 4.0)
+  public func filter(
+    _ isIncluded: (Element) throws -> Bool
+  ) rethrows -> Self {
+    return try Self(self.lazy.filter(isIncluded))
+  }
+}
+
 @available(*, unavailable, renamed: "RangeReplaceableCollection")
 public typealias RangeReplaceableCollectionType = RangeReplaceableCollection
 

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -877,6 +877,13 @@ extension Sequence {
   public func filter(
     _ isIncluded: (Element) throws -> Bool
   ) rethrows -> [Element] {
+    return try _filter(isIncluded)
+  }
+
+  @_transparent
+  public func _filter(
+    _ isIncluded: (Element) throws -> Bool
+  ) rethrows -> [Element] {
 
     var result = ContiguousArray<Element>()
 

--- a/test/stdlib/RangeReplaceableFilterCompatibility.swift
+++ b/test/stdlib/RangeReplaceableFilterCompatibility.swift
@@ -1,0 +1,29 @@
+// RUN: rm -rf %t ; mkdir -p %t
+// RUN: %target-build-swift %s -o %t/a.out3 -swift-version 3 && %target-run %t/a.out3
+// RUN: %target-build-swift %s -o %t/a.out4 -swift-version 4 && %target-run %t/a.out4
+
+import StdlibUnittest
+
+var tests = TestSuite("RangeReplaceableFilterCompatibility")
+
+tests.test("String.filter return type") {
+  var filtered = "Hello, World".filter { $0 < "A" }
+#if swift(>=4)
+  expectType(String.self, &filtered)
+#else
+  expectType([Character].self, &filtered)
+#endif
+}
+
+tests.test("Array.filter return type") {
+  var filtered = Array(0..<10).filter { $0 % 2 == 0 }
+  expectType([Int].self, &filtered)
+}
+
+tests.test("String.filter can return [Character]") {
+  let filtered = "Hello, World".filter { "A" <= $0 && $0 <= "Z"} as [Character]
+  expectEqualSequence("HW", filtered)
+}
+
+
+runAllTests()


### PR DESCRIPTION
This overload allows `String.filter` to return a `String`, and not
`[Character]`.

In the other hand, introduction of this overload makes `[123].filter`
somewhat ambiguous in a sence, that the compiler will now prefer an
implementatin from a more concrete protocol, which is less efficient for
arrays, therefore extra work is needed to make sure Array types fallback
to the `Sequence.filter`.

Implements: <rdar://problem/32209927>