### PR TITLE
[Migrator] Add null check when pre-fix-it passes fail

### DIFF
--- a/lib/Migrator/Migrator.cpp
+++ b/lib/Migrator/Migrator.cpp
@@ -38,7 +38,9 @@ bool migrator::updateCodeAndEmitRemap(CompilerInstance *Instance,
       Invocation.getLangOptions().EffectiveLanguageVersion);
 
     // If we still couldn't fix all of the errors, give up.
-    if (PreFixItInstance->getASTContext().hadError()) {
+    if (PreFixItInstance == nullptr ||
+        !PreFixItInstance->hasASTContext() ||
+        PreFixItInstance->getASTContext().hadError()) {
       return true;
     }
     M.StartInstance = PreFixItInstance.get();

--- a/test/Migrator/Inputs/never_compiles_safely_exits_breaking_code.swift
+++ b/test/Migrator/Inputs/never_compiles_safely_exits_breaking_code.swift
@@ -1,0 +1,1 @@
+func foo(_ f: (Void) -> ()) {}

--- a/test/Migrator/never_compiles_safely_exits.swift
+++ b/test/Migrator/never_compiles_safely_exits.swift
@@ -1,0 +1,11 @@
+// For files that can never compile, make sure we don't crash when
+// attempting to do some pre-fixit runs early in the Migrator pipeline.
+// Since this code isn't fixable, the invocation should exit with non-zero status.
+
+// RUN: not %target-swift-frontend -typecheck -update-code -primary-file %s %S/Inputs/never_compiles_safely_exits_breaking_code.swift -emit-remap-file-path %t/never_compiles_safely_exits.remap -emit-migrated-file-path %t/never_compiles_safely_exits.result -swift-version 4
+// RUN: not ls %t/never_compiles_safely_exits.swift.result
+// RUN: not ls %t/never_compiles_safely_exits.swift.remap
+
+func bar() {
+  foo(bar)
+}


### PR DESCRIPTION
If code is irreparably broken when migrating, make sure to
check that the pre-fix-it compiler instance is `nullptr` and
bail if so.

rdar://problem/32240138