### PR TITLE
[Migrator] Add fix-it tests to pick up swap exclusivity fix-its

### DIFF
--- a/include/swift/Migrator/FixitFilter.h
+++ b/include/swift/Migrator/FixitFilter.h
@@ -19,6 +19,7 @@
 
 #include "swift/AST/DiagnosticConsumer.h"
 #include "swift/AST/DiagnosticsSema.h"
+#include "swift/AST/DiagnosticsSIL.h"
 
 namespace swift {
 namespace migrator {
@@ -129,7 +130,9 @@ struct FixitFilter {
         Info.ID == diag::missing_particular_case.ID ||
         Info.ID == diag::paren_void_probably_void.ID ||
         Info.ID == diag::make_decl_objc.ID ||
-        Info.ID == diag::optional_req_nonobjc_near_match_add_objc.ID)
+        Info.ID == diag::optional_req_nonobjc_near_match_add_objc.ID ||
+        Info.ID == diag::exclusivity_access_required_swift3.ID ||
+        Info.ID == diag::exclusivity_access_required.ID)
       return true;
 
     return false;

--- a/test/Migrator/swap_fixit.swift
+++ b/test/Migrator/swap_fixit.swift
@@ -1,0 +1,30 @@
+// RUN: rm -rf %t && mkdir -p %t && %target-swift-frontend -c -emit-migrated-file-path %t/swap_fixit.swift.result -enforce-exclusivity=checked -swift-version 3 -primary-file %s -o /dev/null
+// RUN: diff -u %S/swap_fixit.swift.expected %t/swap_fixit.swift.result
+
+import Swift
+
+struct StructWithFixits {
+  var arrayProp: [Int] = [1, 2, 3]
+
+  mutating
+  func shouldHaveFixIts<T>(_ i: Int, _ j: Int, _ param: T, _ paramIndex: T.Index) where T : MutableCollection {
+    var array1 = [1, 2, 3]
+    swap(&array1[i + 5], &array1[j - 2])
+    swap(&self.arrayProp[i], &self.arrayProp[j])
+
+    var localOfGenericType = param
+    swap(&localOfGenericType[paramIndex], &localOfGenericType[paramIndex])
+  }
+
+  mutating
+  func shouldHaveNoFixIts(_ i: Int, _ j: Int) {
+    var array1 = [1, 2, 3]
+    var array2 = [1, 2, 3]
+
+    // Swapping between different arrays should cannot have the
+    // Fix-It.
+    swap(&array1[i], &array2[j]) // no-warning no-fixit
+    swap(&array1[i], &self.arrayProp[j]) // no-warning no-fixit
+  }
+}
+

--- a/test/Migrator/swap_fixit.swift.expected
+++ b/test/Migrator/swap_fixit.swift.expected
@@ -1,0 +1,30 @@
+// RUN: rm -rf %t && mkdir -p %t && %target-swift-frontend -c -emit-migrated-file-path %t/swap_fixit.swift.result -enforce-exclusivity=checked -swift-version 3 -primary-file %s -o /dev/null
+// RUN: diff -u %S/swap_fixit.swift.expected %t/swap_fixit.swift.result
+
+import Swift
+
+struct StructWithFixits {
+  var arrayProp: [Int] = [1, 2, 3]
+
+  mutating
+  func shouldHaveFixIts<T>(_ i: Int, _ j: Int, _ param: T, _ paramIndex: T.Index) where T : MutableCollection {
+    var array1 = [1, 2, 3]
+    array1.swapAt(i + 5, j - 2)
+    self.arrayProp.swapAt(i, j)
+
+    var localOfGenericType = param
+    localOfGenericType.swapAt(paramIndex, paramIndex)
+  }
+
+  mutating
+  func shouldHaveNoFixIts(_ i: Int, _ j: Int) {
+    var array1 = [1, 2, 3]
+    var array2 = [1, 2, 3]
+
+    // Swapping between different arrays should cannot have the
+    // Fix-It.
+    swap(&array1[i], &array2[j]) // no-warning no-fixit
+    swap(&array1[i], &self.arrayProp[j]) // no-warning no-fixit
+  }
+}
+


### PR DESCRIPTION
These are attached to warnings so they need to be added to the
opt-in list in the FixitFilter.

rdar://problem/31916085