### PR TITLE
[stdlib] Static linking test case

### DIFF
--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -1237,10 +1237,10 @@ toolchains::Darwin::constructInvocation(const LinkJobAction &job,
     getRuntimeStaticLibraryPath(StaticRuntimeLibPath, context.Args, *this);
     Arguments.push_back(context.Args.MakeArgString(StaticRuntimeLibPath));
     Arguments.push_back("-lc++");
+    Arguments.push_back("-licucore");
     Arguments.push_back("-framework");
     Arguments.push_back("Foundation");
     Arguments.push_back("-force_load_swift_libs");
-    Arguments.push_back("-licucore");
   } else {
     Arguments.push_back(context.Args.MakeArgString(RuntimeLibPath));
   }

--- a/test/Driver/static-stdlib-icu.swift
+++ b/test/Driver/static-stdlib-icu.swift
@@ -1,0 +1,8 @@
+// REQUIRES: OS=macosx
+// Note: This is really about the /host/ environment
+
+// RUN: %swiftc_driver -driver-print-jobs -static-stdlib %S/../Inputs/empty.swift | %FileCheck -check-prefix STATIC %s
+// RUN: %swiftc_driver -driver-print-jobs %S/../Inputs/empty.swift | %FileCheck -check-prefix NO_STATIC %s
+
+// STATIC: {{.*}}-L {{[^ ]*}}/lib/swift_static/macosx {{.*}}-licucore 
+// NO_STATIC: {{.*}}-L {{[^ ]*}}/lib/swift/macosx


### PR DESCRIPTION
Adds a test case that the compiler driver will properly insert
-licucore for static standard library builds. This test runs even on
builds that don't build a static standard library, so PR testing can
regressions here.

<!-- What's in this pull request? -->
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
