### PR TITLE
Disable generic inlining and partial specialization, except in libswi…

### DIFF
--- a/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
+++ b/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
@@ -31,7 +31,7 @@ llvm::cl::opt<bool> PrintShortestPathInfo(
     llvm::cl::desc("Print shortest-path information for inlining"));
 
 llvm::cl::opt<bool> EnableSILInliningOfGenerics(
-  "sil-inline-generics", llvm::cl::init(true),
+  "sil-inline-generics", llvm::cl::init(false),
   llvm::cl::desc("Enable inlining of generics"));
 
 //===----------------------------------------------------------------------===//

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -24,7 +24,7 @@ using namespace swift;
 
 /// Set to true to enable the support for partial specialization.
 llvm::cl::opt<bool> EnablePartialSpecialization(
-    "sil-partial-specialization", llvm::cl::init(true),
+    "sil-partial-specialization", llvm::cl::init(false),
     llvm::cl::desc("Enable partial specialization of generics"));
 
 /// If set, then generic specialization tries to specialize using

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -220,6 +220,9 @@ if(SWIFT_STDLIB_SIL_DEBUGGING)
   list(APPEND swift_stdlib_compile_flags "-Xfrontend" "-gsil")
 endif()
 
+list(APPEND swift_stdlib_compile_flags "-Xllvm" "-sil-inline-generics")
+list(APPEND swift_stdlib_compile_flags "-Xllvm" "-sil-partial-specialization")
+
 if(SWIFT_CHECK_ESSENTIAL_STDLIB)
   add_swift_library(swift_stdlib_essential ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB IS_STDLIB_CORE
       ${SWIFTLIB_ESSENTIAL})

--- a/test/SILOptimizer/devirt_specialized_inherited_interplay.swift
+++ b/test/SILOptimizer/devirt_specialized_inherited_interplay.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -sil-verify-all -O %s -emit-sil | %FileCheck %s
+// RUN: %target-swift-frontend -sil-verify-all -Xllvm -sil-inline-generics -O %s -emit-sil | %FileCheck %s
 
 // This file consists of tests for making sure that protocol conformances and
 // inherited conformances work well together when applied to each other. The

--- a/test/SILOptimizer/devirt_unbound_generic.swift
+++ b/test/SILOptimizer/devirt_unbound_generic.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sorted-sil -emit-sil -O %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -sil-inline-generics -emit-sorted-sil -emit-sil -O %s | %FileCheck %s
 
 // We used to crash on this when trying to devirtualize t.boo(a, 1),
 // because it is an "apply" with replacement types that contain

--- a/test/SILOptimizer/functionsigopts.sil
+++ b/test/SILOptimizer/functionsigopts.sil
@@ -1,5 +1,5 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -inline -function-signature-opts %s | %FileCheck %s
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -inline -function-signature-opts %s | %FileCheck -check-prefix=CHECK-NEGATIVE %s
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -sil-inline-generics -enable-sil-verify-all -inline -function-signature-opts %s | %FileCheck %s
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -sil-inline-generics -enable-sil-verify-all -inline -function-signature-opts %s | %FileCheck -check-prefix=CHECK-NEGATIVE %s
 
 import Builtin
 import Swift

--- a/test/SILOptimizer/opened_archetype_operands_tracking.sil
+++ b/test/SILOptimizer/opened_archetype_operands_tracking.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -O | %FileCheck %s
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -sil-inline-generics -enable-sil-verify-all %s -O | %FileCheck %s
 
 // Check some corner cases related to tracking of opened archetypes.
 // For example, the compiler used to crash compiling the "process" function (rdar://28024272)

--- a/test/SILOptimizer/partial_specialization.sil
+++ b/test/SILOptimizer/partial_specialization.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -generic-specializer -sil-partial-specialization-with-generic-substitutions  %s | %FileCheck %s
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -generic-specializer -sil-partial-specialization -sil-partial-specialization-with-generic-substitutions  %s | %FileCheck %s
 
 // Test different cases of partial specialization.
 // In particular, test the correctness of partial specializaitons where substitutions may be generic.

--- a/test/SILOptimizer/specialize.sil
+++ b/test/SILOptimizer/specialize.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -generic-specializer %s | %FileCheck %s
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -sil-partial-specialization -generic-specializer %s | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/specialize_dynamic_self.swift
+++ b/test/SILOptimizer/specialize_dynamic_self.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -O -primary-file %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -sil-inline-generics -emit-sil -O -primary-file %s | %FileCheck %s
 
 protocol P {}
 


### PR DESCRIPTION
…ftCore

This avoids code size regressions in programs while still getting the performance improvements in generic code in the stdlib.

rdar://problem/32277313

