### PR TITLE
Runtime: Add newline to implicit ObjC entrypoint log message.

### DIFF
--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -1416,7 +1416,7 @@ void swift_objc_swift3ImplicitObjCEntrypoint(id self, SEL selector,
     "*** %*s:%zu:%zu: implicit Objective-C entrypoint %c[%s %s] "
     "is deprecated and will be removed in Swift 4; "
     "add explicit '@objc' to the declaration to emit the Objective-C "
-    "entrypoint in Swift 4 and suppress this message",
+    "entrypoint in Swift 4 and suppress this message\n",
     (int)filenameLength, filename, line, column,
     isInstanceMethod ? '-' : '+',
     class_getName([self class]),


### PR DESCRIPTION
See if this clears up buffering issues in CI. rdar://problem/32272992

Cherry-picked from @jckarter  https://github.com/apple/swift/pull/9734

CCC
Explanation: Inconsistent testing arose due to buffering of expected output not newline terminated
Scope: Limited to tests
Radar (and possibly SR Issue): rdar://problem/32272992
Risk: Low, limited only to tests
Testing: CI testing

<!-- What's in this pull request? -->
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->