### PR TITLE
[swift-4.0-branch][stdlib] Add a Swift 4 only RangeRepleaceable.filter returning Self

### DIFF
--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -1574,6 +1574,16 @@ extension ${Self} : RangeReplaceableCollection, _ArrayProtocol {
     }
   }
 
+  // Since RangeReplaceableCollection now has a version of filter that is less
+  // efficient, we should make the default implementation coming from Sequence
+  // preferred.
+  @_inlineable
+  public func filter(
+    _ isIncluded: (Element) throws -> Bool
+  ) rethrows -> [Element] {
+    return try _filter(isIncluded)
+  }
+
   //===--- algorithms -----------------------------------------------------===//
 
   @_inlineable

--- a/stdlib/public/core/RangeReplaceableCollection.swift.gyb
+++ b/stdlib/public/core/RangeReplaceableCollection.swift.gyb
@@ -1212,6 +1212,31 @@ public func += <
   lhs.append(contentsOf: rhs)
 }
 
+extension RangeReplaceableCollection {
+  /// Returns a new collection of the same type containing, in order, the
+  /// elements of the original collection that satisfy the given predicate.
+  ///
+  /// In this example, `filter(_:)` is used to include only names shorter than
+  /// five characters.
+  ///
+  ///     let cast = ["Vivien", "Marlon", "Kim", "Karl"]
+  ///     let shortNames = cast.filter { $0.count < 5 }
+  ///     print(shortNames)
+  ///     // Prints "["Kim", "Karl"]"
+  ///
+  /// - Parameter isIncluded: A closure that takes an element of the
+  ///   sequence as its argument and returns a Boolean value indicating
+  ///   whether the element should be included in the returned array.
+  /// - Returns: An array of the elements that `isIncluded` allowed.
+  @_inlineable
+  @available(swift, introduced: 4.0)
+  public func filter(
+    _ isIncluded: (Element) throws -> Bool
+  ) rethrows -> Self {
+    return try Self(self.lazy.filter(isIncluded))
+  }
+}
+
 @available(*, unavailable, renamed: "RangeReplaceableCollection")
 public typealias RangeReplaceableCollectionType = RangeReplaceableCollection
 

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -877,6 +877,13 @@ extension Sequence {
   public func filter(
     _ isIncluded: (Element) throws -> Bool
   ) rethrows -> [Element] {
+    return try _filter(isIncluded)
+  }
+
+  @_transparent
+  public func _filter(
+    _ isIncluded: (Element) throws -> Bool
+  ) rethrows -> [Element] {
 
     var result = ContiguousArray<Element>()
 

--- a/test/stdlib/ArrayFilter.swift
+++ b/test/stdlib/ArrayFilter.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-frontend -swift-version 4 -O %s -emit-sil | %FileCheck %s
+
+// This test is testing that even in presence of
+// RangeReplaceableCollection.filter(_:), Arrays are still calling the default
+// implementation from Sequence.
+
+// CHECK-NOT: RangeReplaceableCollection.filter(_:)
+@inline(never)
+public func foobar(_ xs: [Int]) -> [Int] {
+  return xs.filter { _ in false }
+}
+

--- a/test/stdlib/RangeReplaceableFilterCompatibility.swift
+++ b/test/stdlib/RangeReplaceableFilterCompatibility.swift
@@ -1,0 +1,29 @@
+// RUN: rm -rf %t ; mkdir -p %t
+// RUN: %target-build-swift %s -o %t/a.out3 -swift-version 3 && %target-run %t/a.out3
+// RUN: %target-build-swift %s -o %t/a.out4 -swift-version 4 && %target-run %t/a.out4
+
+import StdlibUnittest
+
+var tests = TestSuite("RangeReplaceableFilterCompatibility")
+
+tests.test("String.filter return type") {
+  var filtered = "Hello, World".filter { $0 < "A" }
+#if swift(>=4)
+  expectType(String.self, &filtered)
+#else
+  expectType([Character].self, &filtered)
+#endif
+}
+
+tests.test("Array.filter return type") {
+  var filtered = Array(0..<10).filter { $0 % 2 == 0 }
+  expectType([Int].self, &filtered)
+}
+
+tests.test("String.filter can return [Character]") {
+  let filtered = "Hello, World".filter { "A" <= $0 && $0 <= "Z"} as [Character]
+  expectEqualSequence("HW", filtered)
+}
+
+
+runAllTests()

--- a/test/stdlib/RangeReplaceableFilterCompatibility.swift
+++ b/test/stdlib/RangeReplaceableFilterCompatibility.swift
@@ -20,10 +20,20 @@ tests.test("Array.filter return type") {
   expectType([Int].self, &filtered)
 }
 
+tests.test("ContiguousArray.filter return type") {
+  var filtered = ContiguousArray(0..<10).filter { $0 % 2 == 0 }
+  expectType([Int].self, &filtered)
+}
+
+tests.test("ArraySlice.filter return type") {
+  var filtered = Array(0..<10)[0..<10].filter { $0 % 2 == 0 }
+  expectType([Int].self, &filtered)
+}
+
 tests.test("String.filter can return [Character]") {
   let filtered = "Hello, World".filter { "A" <= $0 && $0 <= "Z"} as [Character]
   expectEqualSequence("HW", filtered)
 }
 
-
 runAllTests()
+


### PR DESCRIPTION
* Explanation: This overload allows String.filter to return a String, and not
[Character]. (Partial implementation of  https://github.com/apple/swift-evolution/blob/master/proposals/0174-filter-range-replaceable.md
* Scope of Issue: Introduces the new overload in Swift 4 mode only. Tests make sure that the behavior for Swift 3 remains the same.
* Risk: Minimal
* Reviewed By: Ben Cohen
* Testing: Automated test suite + special test cases
* Directions for QA: N/A
* Radar: <rdar://problem/32284321> [swift-4.0-branch]