### PR TITLE
[Foundation] Unbreaking the expression that used to be too complex

### DIFF
--- a/stdlib/public/SDK/Foundation/AffineTransform.swift
+++ b/stdlib/public/SDK/Foundation/AffineTransform.swift
@@ -270,13 +270,7 @@ public struct AffineTransform : ReferenceConvertible, Hashable, CustomStringConv
     }
     
     public var hashValue : Int {
-        // FIXME(integers): the expression was broken into pieces to speed up
-        // compilation.
-        // Used to be just: return Int(m11 + m12 + m21 + m22 + tX + tY)
-        let a: CGFloat = m11 + m12
-        let b: CGFloat = m21 + m22
-        let c: CGFloat = tX + tY
-        return Int(a + b + c)
+        return Int(m11 + m12 + m21 + m22 + tX + tY)
     }
     
     public var description: String {


### PR DESCRIPTION
This expression was broken into sub-expressions to speed up compilation at one point in development of new integer protocols. Now it is no longer necessary, as `CGFloat` defines `+` (as opposed to relying on the implementation inherited from `Numeric`), and the typechecker is happy.