### PR TITLE
[PrintAsObjC] Don't warn about inferred '@objc' in Swift 3 mode.

### DIFF
--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -809,6 +809,11 @@ private:
   }
 
   void printSwift3ObjCDeprecatedInference(ValueDecl *VD) {
+    const LangOptions &langOpts = M.getASTContext().LangOpts;
+    if (!langOpts.EnableSwift3ObjCInference ||
+        langOpts.WarnSwift3ObjCInference == Swift3ObjCInferenceWarnings::None) {
+      return;
+    }
     auto attr = VD->getAttrs().getAttribute<ObjCAttr>();
     if (!attr || !attr->isSwift3Inferred())
       return;

--- a/test/PrintAsObjC/swift3_deprecated_objc_inference.swift
+++ b/test/PrintAsObjC/swift3_deprecated_objc_inference.swift
@@ -11,12 +11,19 @@
 // FIXME: END -enable-source-import hackaround
 
 
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -I %S/Inputs/custom-modules -o %t %s -disable-objc-attr-requires-foundation-module -swift-version 3
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -parse-as-library %t/swift3_deprecated_objc_inference.swiftmodule -typecheck -I %S/Inputs/custom-modules -emit-objc-header-path %t/swift3_deprecated_objc_inference.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module -swift-version 3
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -I %S/Inputs/custom-modules -o %t %s -disable-objc-attr-requires-foundation-module -swift-version 4 -enable-swift3-objc-inference -warn-swift3-objc-inference-minimal
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -parse-as-library %t/swift3_deprecated_objc_inference.swiftmodule -typecheck -I %S/Inputs/custom-modules -emit-objc-header-path %t/swift3_deprecated_objc_inference.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module -swift-version 4 -enable-swift3-objc-inference -warn-swift3-objc-inference-minimal
 // RUN: %FileCheck %s < %t/swift3_deprecated_objc_inference.h
 // RUN: %check-in-clang -I %S/Inputs/custom-modules/ %t/swift3_deprecated_objc_inference.h
 
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -I %S/Inputs/custom-modules -o %t/swift3_deprecated_objc_inference_nowarn.swiftmodule %s -disable-objc-attr-requires-foundation-module -swift-version 4 -enable-swift3-objc-inference
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -parse-as-library %t/swift3_deprecated_objc_inference_nowarn.swiftmodule -typecheck -I %S/Inputs/custom-modules -emit-objc-header-path %t/swift3_deprecated_objc_inference_nowarn.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module -swift-version 4 -enable-swift3-objc-inference
+// RUN: %FileCheck -check-prefix=CHECK-NOWARN %s < %t/swift3_deprecated_objc_inference_nowarn.h
+// RUN: %check-in-clang -I %S/Inputs/custom-modules/ %t/swift3_deprecated_objc_inference_nowarn.h
+
 import Foundation
+
+// CHECK-NOWARN-NOT: @objc
 
 // CHECK-LABEL: @interface A1{{$}}
 // CHECK-NEXT: init


### PR DESCRIPTION
Only do so in modes where `@objc` *is* inferred but we're supposed to warn about it. Neither plain old Swift 3 nor plain old Swift 4 are in this state, but we have frontend options that allow us to set that up for migration purposes.

rdar://problem/32284936