### PR TITLE
Improve experience of derivation of Codable types

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2008,6 +2008,9 @@ NOTE(enum_raw_value_incrementing_from_zero,none,
 
 // Derived conformances
 
+ERROR(cannot_synthesize_in_extension,none,
+      "implementation of %0 cannot be automatically synthesized in an extension yet", (Type))
+
 ERROR(broken_raw_representable_requirement,none,
       "RawRepresentable protocol is broken: unexpected requirement", ())
 ERROR(broken_equatable_requirement,none,
@@ -2028,6 +2031,17 @@ ERROR(broken_encodable_requirement,none,
       "Encodable protocol is broken: unexpected requirement", ())
 ERROR(broken_decodable_requirement,none,
       "Decodable protocol is broken: unexpected requirement", ())
+
+NOTE(codable_extraneous_codingkey_case_here,none,
+     "CodingKey case %0 does match any stored properties", (Identifier))
+NOTE(codable_non_conforming_property_here,none,
+     "cannot automatically synthesize %0 because %1 does not conform to %0", (Type, Identifier))
+NOTE(codable_non_decoded_property_here,none,
+     "cannot automatically synthesize %0 because %1 does not have a matching CodingKey and does not have a default value", (Type, Identifier))
+NOTE(codable_codingkeys_type_is_not_an_enum_here,none,
+     "cannot automatically synthesize %0 because 'CodingKeys' is not an enum", (Type))
+NOTE(codable_codingkeys_type_does_not_conform_here,none,
+     "cannot automatically synthesize %0 because 'CodingKeys' does not conform to CodingKey", (Type))
 
 // Dynamic Self
 ERROR(dynamic_self_non_method,none,

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -14,7 +14,7 @@
 // protocols for a struct or class.
 //
 //===----------------------------------------------------------------------===//
-//
+
 #include "TypeChecker.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/Expr.h"
@@ -31,108 +31,89 @@ using namespace DerivedConformance;
 /// Returns whether the type represented by the given ClassDecl inherits from a
 /// type which conforms to the given protocol.
 ///
-/// \param type The \c ClassDecl whose superclass to look up.
+/// \param target The \c ClassDecl whose superclass to look up.
 ///
 /// \param proto The protocol to check conformance for.
-static bool inheritsConformanceTo(ClassDecl *type, ProtocolDecl *proto) {
-  if (!type->hasSuperclass())
+static bool inheritsConformanceTo(ClassDecl *target, ProtocolDecl *proto) {
+  if (!target->hasSuperclass())
     return false;
 
-  auto &C = type->getASTContext();
-  auto *superclassDecl = type->getSuperclassDecl();
+  auto &C = target->getASTContext();
+  auto *superclassDecl = target->getSuperclassDecl();
   auto *superclassModule = superclassDecl->getModuleContext();
-  return (bool)superclassModule->lookupConformance(type->getSuperclass(),
+  return (bool)superclassModule->lookupConformance(target->getSuperclass(),
                                                    proto,
                                                    C.getLazyResolver());
 }
 
 /// Returns whether the superclass of the given class conforms to Encodable.
 ///
-/// \param type The \c ClassDecl whose superclass to check.
-static bool superclassIsEncodable(ClassDecl *type) {
-    auto &C = type->getASTContext();
-    return inheritsConformanceTo(type,
+/// \param target The \c ClassDecl whose superclass to check.
+static bool superclassIsEncodable(ClassDecl *target) {
+    auto &C = target->getASTContext();
+    return inheritsConformanceTo(target,
                                  C.getProtocol(KnownProtocolKind::Encodable));
 }
 
 /// Returns whether the superclass of the given class conforms to Decodable.
 ///
-/// \param type The \c ClassDecl whose superclass to check.
-static bool superclassIsDecodable(ClassDecl *type) {
-    auto &C = type->getASTContext();
-    return inheritsConformanceTo(type,
+/// \param target The \c ClassDecl whose superclass to check.
+static bool superclassIsDecodable(ClassDecl *target) {
+    auto &C = target->getASTContext();
+    return inheritsConformanceTo(target,
                                  C.getProtocol(KnownProtocolKind::Decodable));
 }
 
-/// Validates that all the variables declared in the given list of declarations
-/// conform to the given protocol.
+/// Returns whether the given variable conforms to the given protocol.
 ///
-/// Produces a diagnostic on the given typechecker for every var which does not
-/// conform. Calls a success callback for every var which does conform.
-///
-/// \param tc The typechecker to use in validating {En,Decodable} conformance.
+/// \param tc The typechecker to use in validating {En,De}codable conformance.
 ///
 /// \param context The \c DeclContext the var declarations belong to.
 ///
-/// \param vars The var range to validate.
+/// \param varDecl The \c VarDecl to validate.
 ///
-/// \param proto The protocol to check conformance to.
-///
-/// \param callback A callback to call on every valid var decl.
-template <typename ValidVarCallback>
-static bool
-validateVarsConformToProtocol(TypeChecker &tc, DeclContext *context,
-                              NominalTypeDecl::StoredPropertyRange &vars,
-                              ProtocolDecl *proto, ValidVarCallback &callback) {
-  bool allConform = true;
-  for (auto varDecl : vars) {
-    // If the decl doesn't yet have a type, we may be seeing it before the type
-    // checker has gotten around to evaluating its type. For example:
-    //
-    // func foo() {
-    //   let b = Bar(from: decoder) // <- evaluates Bar conformance to Codable,
-    //                              //    forcing derivation
-    // }
-    //
-    // struct Bar : Codable {
-    //   var x: Int // <- we get to valuate x's var decl here, but its type
-    //              //    hasn't yet been evaluated
-    // }
-    //
-    // Validate the decl eagerly.
-    if (!varDecl->hasType())
-      tc.validateDecl(varDecl);
+/// \param proto The \c ProtocolDecl to check conformance to.
+static bool varConformsToProtocol(TypeChecker &tc, DeclContext *context,
+                                  VarDecl *varDecl, ProtocolDecl *proto) {
+  // If the decl doesn't yet have a type, we may be seeing it before the type
+  // checker has gotten around to evaluating its type. For example:
+  //
+  // func foo() {
+  //   let b = Bar(from: decoder) // <- evaluates Bar conformance to Codable,
+  //                              //    forcing derivation
+  // }
+  //
+  // struct Bar : Codable {
+  //   var x: Int // <- we get to valuate x's var decl here, but its type
+  //              //    hasn't yet been evaluated
+  // }
+  //
+  // Validate the decl eagerly.
+  if (!varDecl->hasType())
+    tc.validateDecl(varDecl);
 
-    // If the var decl didn't validate, it may still not have a type; confirm it
-    // has a type before ensuring the type conforms to Codable.
-    if (!varDecl->hasType() ||
-        !tc.conformsToProtocol(varDecl->getType(), proto, context,
-                               ConformanceCheckFlags::Used)) {
-      // TODO: We should produce a diagnostic note here explaining that we found
-      //       a var not conforming to Codable.
-      allConform = false;
-      continue;
-    }
-
-    callback(varDecl);
-  }
-
-  return allConform;
+  // If the var decl didn't validate, it may still not have a type; confirm it
+  // has a type before ensuring the type conforms to Codable.
+  // TODO: Peer through Optional and collection types to get at inner type.
+  return varDecl->hasType() &&
+         tc.conformsToProtocol(varDecl->getType(), proto, context,
+                               ConformanceCheckFlags::Used);
 }
 
 /// Validates the given CodingKeys enum decl by ensuring its cases are a 1-to-1
 /// match with the stored vars of the given type.
 ///
-/// \param tc The typechecker to use in validating {En,Decodable} conformance.
+/// \param tc The typechecker to use in validating {En,De}codable conformance.
 ///
 /// \param codingKeysDecl The \c CodingKeys enum decl to validate.
 ///
-/// \param type The nominal type decl to validate the \c CodingKeys against.
+/// \param target The nominal type decl to validate the \c CodingKeys against.
 ///
 /// \param proto The {En,De}codable protocol to validate all the keys conform
 /// to.
-static bool validateCodingKeysEnum(TypeChecker &tc, EnumDecl *codingKeysDecl,
-                                   NominalTypeDecl *type, ProtocolDecl *proto) {
+static bool
+validateCodingKeysEnum(TypeChecker &tc, EnumDecl *codingKeysDecl,
+                       NominalTypeDecl *target, ProtocolDecl *proto) {
   // Look through all var decls in the given type.
   // * Filter out lazy/computed vars (currently already done by
   //   getStoredProperties).
@@ -140,38 +121,64 @@ static bool validateCodingKeysEnum(TypeChecker &tc, EnumDecl *codingKeysDecl,
   //
   // If any of the entries in the CodingKeys decl are not present in the type
   // by name, then this decl doesn't match.
-  // If there are any vars left in the type, then this decl doesn't match.
-  //
-  // NOTE: If we change the behavior to ignore vars with default values, then we
-  //       can further filter out the type names to remove those which
-  //       correspond to vars with default values.
-  llvm::SmallDenseSet<Identifier, 8> names;
+  // If there are any vars left in the type which don't have a default value
+  // (for Decodable), then this decl doesn't match.
 
-  auto storedProperties = type->getStoredProperties(/*skipInaccessible=*/true);
-  auto validVarCallback = [&names](VarDecl *varDecl) {
-    names.insert(varDecl->getName());
-  };
-
-  if (!validateVarsConformToProtocol(tc, type->getDeclContext(),
-                                     storedProperties, proto, validVarCallback))
-    return false;
-
-  for (auto elt : codingKeysDecl->getAllElements()) {
-    auto it = names.find(elt->getName());
-    if (it == names.end()) {
-      // TODO: Produce diagnostic here complaining that the CodingKeys enum
-      //       contains a case which does not correspond to a var.
-      // TODO: Investigate typo-correction here; perhaps the case name was
-      //       misspelled and we can provide a fix-it.
-      return false;
-    }
-
-    names.erase(it);
+  // Here we'll hold on to properties by name -- when we've validated a property
+  // against its CodingKey entry, it will get removed.
+  llvm::SmallDenseMap<Identifier, VarDecl *, 8> properties;
+  for (auto *varDecl : target->getStoredProperties(/*skipInaccessible=*/true)) {
+    properties[varDecl->getName()] = varDecl;
   }
 
-  // TODO: Produce diagnostic here complaining that there are vars which are not
-  //       listed in the CodingKeys enum.
-  return names.empty();
+  bool propertiesAreValid = true;
+  for (auto elt : codingKeysDecl->getAllElements()) {
+    auto it = properties.find(elt->getName());
+    if (it == properties.end()) {
+      tc.diagnose(elt->getLoc(), diag::codable_extraneous_codingkey_case_here,
+                  elt->getName());
+      // TODO: Investigate typo-correction here; perhaps the case name was
+      //       misspelled and we can provide a fix-it.
+      propertiesAreValid = false;
+      continue;
+    }
+
+    // We have a property to map to. Ensure it's {En,De}codable.
+    bool conforms = varConformsToProtocol(tc, target->getDeclContext(),
+                                          it->second, proto);
+    if (!conforms) {
+      tc.diagnose(it->second->getLoc(),
+                  diag::codable_non_conforming_property_here,
+                  proto->getDeclaredType(), it->second->getName());
+      propertiesAreValid = false;
+      continue;
+    }
+
+    // The property was valid. Remove it from the list.
+    properties.erase(it);
+  }
+
+  if (!propertiesAreValid)
+    return false;
+
+  // If there are any remaining properties which the CodingKeys did not cover,
+  // we can skip them on encode. On decode, though, we can only skip them if
+  // they have a default value.
+  if (!properties.empty() &&
+      proto == tc.Context.getProtocol(KnownProtocolKind::Decodable)) {
+    for (auto it = properties.begin(); it != properties.end(); ++it) {
+      if (it->second->getParentInitializer() != nullptr) {
+        // Var has a default value.
+        continue;
+      }
+
+      propertiesAreValid = false;
+      tc.diagnose(it->second->getLoc(), diag::codable_non_decoded_property_here,
+                  proto->getDeclaredType(), it->first);
+    }
+  }
+
+  return propertiesAreValid;
 }
 
 /// Returns whether the given type has a valid nested \c CodingKeys enum.
@@ -184,15 +191,15 @@ static bool validateCodingKeysEnum(TypeChecker &tc, EnumDecl *codingKeysDecl,
 ///
 /// \param tc The typechecker to use in validating {En,Decodable} conformance.
 ///
-/// \param type The type decl whose nested \c CodingKeys type to validate.
+/// \param target The type decl whose nested \c CodingKeys type to validate.
 ///
 /// \param proto The {En,De}codable protocol to ensure the properties matching
 /// the keys conform to.
 static std::pair</* has type? */ bool, /* error? */ bool>
-hasValidCodingKeysEnum(TypeChecker &tc, NominalTypeDecl *type,
+hasValidCodingKeysEnum(TypeChecker &tc, NominalTypeDecl *target,
                        ProtocolDecl *proto) {
   auto &C = tc.Context;
-  auto codingKeysDecls = type->lookupDirect(DeclName(C.Id_CodingKeys));
+  auto codingKeysDecls = target->lookupDirect(DeclName(C.Id_CodingKeys));
   if (codingKeysDecls.empty())
     return {/* has type? */ false, /* error? */ false};
 
@@ -203,41 +210,42 @@ hasValidCodingKeysEnum(TypeChecker &tc, NominalTypeDecl *type,
 
   auto *codingKeysTypeDecl = dyn_cast<TypeDecl>(result);
   if (!codingKeysTypeDecl) {
-    // TODO: Produce a diagnostic complaining that the "CodingKeys" entity we
-    //       found is not a type.
+    tc.diagnose(result->getLoc(),
+                diag::codable_codingkeys_type_is_not_an_enum_here,
+                proto->getDeclaredType());
     return {/* has type? */ true, /* error? */ true};
+  }
+
+  // CodingKeys may be a typealias. If so, follow the alias to its canonical
+  // type.
+  auto codingKeysType = codingKeysTypeDecl->getDeclaredInterfaceType();
+  if (isa<TypeAliasDecl>(codingKeysTypeDecl)) {
+    auto canType = codingKeysType->getCanonicalType();
+    assert(canType);
+    codingKeysTypeDecl = canType->getAnyNominal();
   }
 
   // Ensure that the type we found conforms to the CodingKey protocol.
   auto *codingKeyProto = C.getProtocol(KnownProtocolKind::CodingKey);
-  auto codingKeysType = codingKeysTypeDecl->getDeclaredInterfaceType();
   if (!tc.conformsToProtocol(codingKeysType, codingKeyProto,
-                             type->getDeclContext(),
+                             target->getDeclContext(),
                              ConformanceCheckFlags::Used)) {
-    // TODO: Produce a diagnostic complaining that the "CodingKeys" entity we
-    //       found does not conform to CodingKey.
+    tc.diagnose(codingKeysTypeDecl->getLoc(),
+                diag::codable_codingkeys_type_does_not_conform_here,
+                proto->getDeclaredType());
     return {/* has type? */ true, /* error? */ true};
   }
 
-  // CodingKeys should eventually be an enum. If it's a typealias, we'll need to
-  // follow it.
-  auto *codingKeysEnum = dyn_cast<EnumDecl>(result);
-  if (isa<TypeAliasDecl>(result)) {
-    // TODO: Do we have to follow through multiple layers of typealiases
-    //       here? Or will getCanonicalType() do that for us?
-    auto canType = codingKeysType->getCanonicalType();
-    assert(canType);
-
-    codingKeysEnum = dyn_cast<EnumDecl>(codingKeysType->getAnyNominal());
-  }
-
+  // CodingKeys must be an enum for synthesized conformance.
+  auto *codingKeysEnum = dyn_cast<EnumDecl>(codingKeysTypeDecl);
   if (!codingKeysEnum) {
-    // TODO: Produce a diagnostic complaining that we cannot derive Codable
-    //       with a non-enum CodingKeys type.
+    tc.diagnose(codingKeysTypeDecl->getLoc(),
+                diag::codable_codingkeys_type_is_not_an_enum_here,
+                proto->getDeclaredType());
     return {/* has type? */ true, /* error? */ true};
   }
 
-  bool valid = validateCodingKeysEnum(tc, codingKeysEnum, type, proto);
+  bool valid = validateCodingKeysEnum(tc, codingKeysEnum, target, proto);
   return {/* has type? */ true, /* error? */ !valid};
 }
 
@@ -248,16 +256,16 @@ hasValidCodingKeysEnum(TypeChecker &tc, NominalTypeDecl *type,
 ///
 /// \param tc The typechecker to use in validating {En,De}codable conformance.
 ///
-/// \param type The nominal type decl whose nested \c CodingKeys type to
+/// \param target The nominal type decl whose nested \c CodingKeys type to
 /// synthesize.
 ///
 /// \param proto The {En,De}codable protocol to validate all the keys conform
 /// to.
 static EnumDecl *synthesizeCodingKeysEnum(TypeChecker &tc,
-                                          NominalTypeDecl *type,
+                                          NominalTypeDecl *target,
                                           ProtocolDecl *proto) {
   auto &C = tc.Context;
-  auto *typeDC = cast<DeclContext>(type);
+  auto *targetDC = cast<DeclContext>(target);
 
   // We want to look through all the var declarations of this type to create
   // enum cases based on those var names.
@@ -267,7 +275,7 @@ static EnumDecl *synthesizeCodingKeysEnum(TypeChecker &tc,
   MutableArrayRef<TypeLoc> inherited = C.AllocateCopy(protoTypeLoc);
 
   auto *enumDecl = new (C) EnumDecl(SourceLoc(), C.Id_CodingKeys, SourceLoc(),
-                                    inherited, nullptr, typeDC);
+                                    inherited, nullptr, targetDC);
   enumDecl->setImplicit();
   enumDecl->setAccessibility(Accessibility::Private);
 
@@ -276,7 +284,7 @@ static EnumDecl *synthesizeCodingKeysEnum(TypeChecker &tc,
 
   // For classes which inherit from something Encodable or Decodable, we
   // provide case `super` as the first key (to be used in encoding super).
-  auto *classDecl = dyn_cast<ClassDecl>(type);
+  auto *classDecl = dyn_cast<ClassDecl>(target);
   if (classDecl &&
       (superclassIsEncodable(classDecl) || superclassIsDecodable(classDecl))) {
     // TODO: Ensure the class doesn't already have or inherit a variable named
@@ -291,25 +299,59 @@ static EnumDecl *synthesizeCodingKeysEnum(TypeChecker &tc,
 
   // Each of these vars needs a case in the enum. For each var decl, if the type
   // conforms to {En,De}codable, add it to the enum.
-  auto storedProperties = type->getStoredProperties(/*skipInaccessible=*/true);
-  auto validVarCallback = [&C, &enumDC, &mutableEnumDC](VarDecl *varDecl) {
+  bool allConform = true;
+  for (auto *varDecl : target->getStoredProperties(/*skipInaccessible=*/true)) {
+    if (!varConformsToProtocol(tc, target->getDeclContext(), varDecl, proto)) {
+      tc.diagnose(varDecl->getLoc(),
+                  diag::codable_non_conforming_property_here,
+                  proto->getDeclaredType(), varDecl->getName());
+      allConform = false;
+      continue;
+    }
+
     auto *elt = new (C) EnumElementDecl(SourceLoc(), varDecl->getName(),
                                         TypeLoc(), /*HasArgumentType=*/false,
                                         SourceLoc(), nullptr, enumDC);
     elt->setImplicit();
     mutableEnumDC->addMember(elt);
-  };
+  }
 
-  if (!validateVarsConformToProtocol(tc, type->getDeclContext(),
-                                     storedProperties, proto, validVarCallback))
+  if (!allConform)
     return nullptr;
 
   // Forcibly derive conformance to CodingKey.
   tc.checkConformancesInContext(enumDC, mutableEnumDC);
 
   // Add to the type.
-  cast<IterableDeclContext>(type)->addMember(enumDecl);
+  cast<IterableDeclContext>(target)->addMember(enumDecl);
   return enumDecl;
+}
+
+/// Fetches the \c CodingKeys enum nested in \c target, potentially reaching
+/// through a typealias if the "CodingKeys" entity is a typealias.
+///
+/// This is only useful once a \c CodingKeys enum has been validated (via \c
+/// hasValidCodingKeysEnum) or synthesized (via \c synthesizeCodingKeysEnum).
+///
+/// \param C The \c ASTContext to perform the lookup in.
+///
+/// \param target The target type to look in.
+///
+/// \return A retrieved canonical \c CodingKeys enum if \c target has a valid
+/// one; \c nullptr otherwise.
+static EnumDecl *lookupEvaluatedCodingKeysEnum(ASTContext &C,
+                                               NominalTypeDecl *target) {
+  auto codingKeyDecls = target->lookupDirect(DeclName(C.Id_CodingKeys));
+  if (codingKeyDecls.empty())
+    return nullptr;
+
+  auto *codingKeysDecl = codingKeyDecls.front();
+  if (auto *typealiasDecl = dyn_cast<TypeAliasDecl>(codingKeysDecl)) {
+    codingKeysDecl = typealiasDecl->getDeclaredInterfaceType()
+                                  ->getCanonicalType()->getAnyNominal();
+  }
+
+  return dyn_cast<EnumDecl>(codingKeysDecl);
 }
 
 /// Creates a new var decl representing
@@ -412,18 +454,18 @@ static void deriveBodyEncodable_encode(AbstractFunctionDecl *encodeDecl) {
   // }
 
   // The enclosing type decl.
-  auto *typeDecl = cast<NominalTypeDecl>(encodeDecl->getDeclContext());
+  auto *targetDecl = cast<NominalTypeDecl>(encodeDecl->getDeclContext());
 
   auto *funcDC = cast<DeclContext>(encodeDecl);
   auto &C = funcDC->getASTContext();
 
-  // We'll want the CodingKeys enum for this type.
-  auto *codingKeysDecl = typeDecl->lookupDirect(DeclName(C.Id_CodingKeys))[0];
+  // We'll want the CodingKeys enum for this type, potentially looking through
+  // a typealias.
+  auto *codingKeysEnum = lookupEvaluatedCodingKeysEnum(C, targetDecl);
   // We should have bailed already if:
   // a) The type does not have CodingKeys
-  assert(codingKeysDecl && "Missing CodingKeys decl.");
   // b) The type is not an enum
-  auto *codingKeysEnum = cast<EnumDecl>(codingKeysDecl);
+  assert(codingKeysEnum && "Missing CodingKeys decl.");
 
   SmallVector<ASTNode, 5> statements;
 
@@ -476,7 +518,7 @@ static void deriveBodyEncodable_encode(AbstractFunctionDecl *encodeDecl) {
     // Only ill-formed code would produce multiple results for this lookup.
     // This would get diagnosed later anyway, so we're free to only look at
     // the first result here.
-    auto matchingVars = typeDecl->lookupDirect(DeclName(elt->getName()));
+    auto matchingVars = targetDecl->lookupDirect(DeclName(elt->getName()));
 
     // self.x
     auto *selfRef = createSelfDeclRef(encodeDecl);
@@ -509,7 +551,7 @@ static void deriveBodyEncodable_encode(AbstractFunctionDecl *encodeDecl) {
   }
 
   // Classes which inherit from something Codable should encode super as well.
-  auto *classDecl = dyn_cast<ClassDecl>(typeDecl);
+  auto *classDecl = dyn_cast<ClassDecl>(targetDecl);
   if (classDecl && superclassIsEncodable(classDecl)) {
     // Need to generate `try super.encode(to: container.superEncoder())`
 
@@ -560,11 +602,11 @@ static void deriveBodyEncodable_encode(AbstractFunctionDecl *encodeDecl) {
 ///
 /// \param parentDecl The parent declaration of the type.
 ///
-/// \param type The nominal type to synthesize the function for.
+/// \param target The nominal type to synthesize the function for.
 static FuncDecl *deriveEncodable_encode(TypeChecker &tc, Decl *parentDecl,
-                                        NominalTypeDecl *type) {
+                                        NominalTypeDecl *target) {
   auto &C = tc.Context;
-  auto *typeDC = cast<DeclContext>(type);
+  auto *targetDC = cast<DeclContext>(target);
 
   // Expected type: (Self) -> (Encoder) throws -> ()
   // Constructed as: func type
@@ -590,10 +632,10 @@ static FuncDecl *deriveEncodable_encode(TypeChecker &tc, Decl *parentDecl,
   auto innerType = FunctionType::get(inputType, returnType, extInfo);
 
   // Params: (self [implicit], Encoder)
-  auto *selfDecl = ParamDecl::createSelf(SourceLoc(), typeDC);
+  auto *selfDecl = ParamDecl::createSelf(SourceLoc(), targetDC);
   auto *encoderParam = new (C) ParamDecl(/*isLet=*/true, SourceLoc(),
                                          SourceLoc(), C.Id_to, SourceLoc(),
-                                         C.Id_encoder, encoderType, typeDC);
+                                         C.Id_encoder, encoderType, targetDC);
   encoderParam->setInterfaceType(encoderType);
 
   ParameterList *params[] = {ParameterList::createWithoutLoc(selfDecl),
@@ -605,24 +647,26 @@ static FuncDecl *deriveEncodable_encode(TypeChecker &tc, Decl *parentDecl,
                                       SourceLoc(), name, SourceLoc(),
                                       /*Throws=*/true, SourceLoc(), SourceLoc(),
                                       nullptr, params,
-                                      TypeLoc::withoutLoc(returnType), typeDC);
+                                      TypeLoc::withoutLoc(returnType),
+                                      targetDC);
   encodeDecl->setImplicit();
   encodeDecl->setBodySynthesizer(deriveBodyEncodable_encode);
 
   // This method should be marked as 'override' for classes inheriting Encodable
   // conformance from a parent class.
-  auto *classDecl = dyn_cast<ClassDecl>(type);
+  auto *classDecl = dyn_cast<ClassDecl>(target);
   if (classDecl && superclassIsEncodable(classDecl)) {
     auto *attr = new (C) SimpleDeclAttr<DAK_Override>(/*IsImplicit=*/true);
     encodeDecl->getAttrs().add(attr);
   }
 
   // Evaluate the type of Self in (Self) -> (Encoder) throws -> ().
-  Type selfType = typeDC->getDeclaredInterfaceType();
+  Type selfType = targetDC->getDeclaredInterfaceType();
   Type interfaceType;
-  if (auto sig = typeDC->getGenericSignatureOfContext()) {
+  if (auto sig = targetDC->getGenericSignatureOfContext()) {
     // Evaluate the below, but in a generic environment (if Self is generic).
-    encodeDecl->setGenericEnvironment(typeDC->getGenericEnvironmentOfContext());
+    encodeDecl->setGenericEnvironment(
+            targetDC->getGenericEnvironmentOfContext());
     interfaceType = GenericFunctionType::get(sig, selfType, innerType,
                                              FunctionType::ExtInfo());
   } else {
@@ -631,16 +675,16 @@ static FuncDecl *deriveEncodable_encode(TypeChecker &tc, Decl *parentDecl,
   }
 
   encodeDecl->setInterfaceType(interfaceType);
-  encodeDecl->setAccessibility(std::max(type->getFormalAccess(),
+  encodeDecl->setAccessibility(std::max(target->getFormalAccess(),
                                         Accessibility::Internal));
 
   // If the type was not imported, the derived conformance is either from the
   // type itself or an extension, in which case we will emit the declaration
   // normally.
-  if (type->hasClangNode())
+  if (target->hasClangNode())
     tc.Context.addExternalDecl(encodeDecl);
 
-  cast<IterableDeclContext>(type)->addMember(encodeDecl);
+  cast<IterableDeclContext>(target)->addMember(encodeDecl);
   return encodeDecl;
 }
 
@@ -666,18 +710,18 @@ static void deriveBodyDecodable_init(AbstractFunctionDecl *initDecl) {
   // }
 
   // The enclosing type decl.
-  auto *typeDecl = cast<NominalTypeDecl>(initDecl->getDeclContext());
+  auto *targetDecl = cast<NominalTypeDecl>(initDecl->getDeclContext());
 
   auto *funcDC = cast<DeclContext>(initDecl);
   auto &C = funcDC->getASTContext();
 
-  // We'll want the CodingKeys enum for this type.
-  auto *codingKeysDecl = typeDecl->lookupDirect(DeclName(C.Id_CodingKeys))[0];
+  // We'll want the CodingKeys enum for this type, potentially looking through
+  // a typealias.
+  auto *codingKeysEnum = lookupEvaluatedCodingKeysEnum(C, targetDecl);
   // We should have bailed already if:
   // a) The type does not have CodingKeys
-  assert(codingKeysDecl && "Missing CodingKeys decl.");
   // b) The type is not an enum
-  auto *codingKeysEnum = cast<EnumDecl>(codingKeysDecl);
+  assert(codingKeysEnum && "Missing CodingKeys decl.");
 
   // Generate a reference to containerExpr ahead of time in case there are no
   // properties to encode or decode, but the type is a class which inherits from
@@ -732,7 +776,7 @@ static void deriveBodyDecodable_init(AbstractFunctionDecl *initDecl) {
       // Only ill-formed code would produce multiple results for this lookup.
       // This would get diagnosed later anyway, so we're free to only look at
       // the first result here.
-      auto matchingVars = typeDecl->lookupDirect(DeclName(elt->getName()));
+      auto matchingVars = targetDecl->lookupDirect(DeclName(elt->getName()));
       auto *varDecl = cast<VarDecl>(matchingVars[0]);
 
       // Don't output a decode statement for a var let with a default value.
@@ -742,8 +786,8 @@ static void deriveBodyDecodable_init(AbstractFunctionDecl *initDecl) {
       // Type.self (where Type === type(of: x)
       auto varType = varDecl->getType();
       auto *metaTyRef = TypeExpr::createImplicit(varType, C);
-      auto *typeExpr = new (C) DotSelfExpr(metaTyRef, SourceLoc(), SourceLoc(),
-                                           varType);
+      auto *targetExpr = new (C) DotSelfExpr(metaTyRef, SourceLoc(),
+                                             SourceLoc(), varType);
 
       // CodingKeys.x
       auto *eltRef = new (C) DeclRefExpr(elt, DeclNameLoc(), /*implicit=*/true);
@@ -758,7 +802,7 @@ static void deriveBodyDecodable_init(AbstractFunctionDecl *initDecl) {
                                                    /*Implicit=*/true);
 
       // container.decode(Type.self, forKey: CodingKeys.x)
-      Expr *args[2] = {typeExpr, keyExpr};
+      Expr *args[2] = {targetExpr, keyExpr};
       auto *callExpr = CallExpr::createImplicit(C, decodeCall,
                                                 C.AllocateCopy(args),
                                                 C.AllocateCopy(argNames));
@@ -778,7 +822,7 @@ static void deriveBodyDecodable_init(AbstractFunctionDecl *initDecl) {
   }
 
   // Classes which inherit from something Decodable should decode super as well.
-  auto *classDecl = dyn_cast<ClassDecl>(typeDecl);
+  auto *classDecl = dyn_cast<ClassDecl>(targetDecl);
   if (classDecl && superclassIsDecodable(classDecl)) {
     // Need to generate `try super.init(from: container.superDecoder())`
 
@@ -829,11 +873,11 @@ static void deriveBodyDecodable_init(AbstractFunctionDecl *initDecl) {
 ///
 /// \param parentDecl The parent declaration of the type.
 ///
-/// \param type The nominal type to synthesize the function for.
+/// \param target The nominal type to synthesize the function for.
 static ValueDecl *deriveDecodable_init(TypeChecker &tc, Decl *parentDecl,
-                                       NominalTypeDecl *type) {
+                                       NominalTypeDecl *target) {
   auto &C = tc.Context;
-  auto *typeDC = cast<DeclContext>(type);
+  auto *targetDC = cast<DeclContext>(target);
 
   // Expected type: (Self) -> (Decoder) throws -> (Self)
   // Constructed as: func type
@@ -854,21 +898,21 @@ static ValueDecl *deriveDecodable_init(TypeChecker &tc, Decl *parentDecl,
                                        /*Throws=*/true);
 
   // (Self)
-  auto returnType = typeDC->getDeclaredInterfaceType();
+  auto returnType = targetDC->getDeclaredInterfaceType();
 
   // (from: Decoder) throws -> (Self)
   Type innerType = FunctionType::get(inputType, returnType, extInfo);
 
   // Params: (self [implicit], Decoder)
   // self should be inout if the type is a value type; not inout otherwise.
-  auto inOut = !isa<ClassDecl>(type);
-  auto *selfDecl = ParamDecl::createSelf(SourceLoc(), typeDC,
+  auto inOut = !isa<ClassDecl>(target);
+  auto *selfDecl = ParamDecl::createSelf(SourceLoc(), targetDC,
                                          /*isStatic=*/false,
                                          /*isInOut=*/inOut);
   auto *decoderParamDecl = new (C) ParamDecl(/*isLet=*/true, SourceLoc(),
                                              SourceLoc(), C.Id_from,
                                              SourceLoc(), C.Id_decoder,
-                                             decoderType, typeDC);
+                                             decoderType, targetDC);
   decoderParamDecl->setImplicit();
   decoderParamDecl->setInterfaceType(decoderType);
 
@@ -882,12 +926,12 @@ static ValueDecl *deriveDecodable_init(TypeChecker &tc, Decl *parentDecl,
       /*Failability=*/OTK_None,
       /*FailabilityLoc=*/SourceLoc(),
       /*Throws=*/true, /*ThrowsLoc=*/SourceLoc(), selfDecl, paramList,
-      /*GenericParams=*/nullptr, typeDC);
+      /*GenericParams=*/nullptr, targetDC);
   initDecl->setImplicit();
   initDecl->setBodySynthesizer(deriveBodyDecodable_init);
 
   // This constructor should be marked as `required` for non-final classes.
-  if (isa<ClassDecl>(type) && !type->getAttrs().hasAttribute<FinalAttr>()) {
+  if (isa<ClassDecl>(target) && !target->getAttrs().hasAttribute<FinalAttr>()) {
     auto *reqAttr = new (C) SimpleDeclAttr<DAK_Required>(/*IsImplicit=*/true);
     initDecl->getAttrs().add(reqAttr);
   }
@@ -896,9 +940,9 @@ static ValueDecl *deriveDecodable_init(TypeChecker &tc, Decl *parentDecl,
   Type selfInitType = initDecl->computeInterfaceSelfType(/*init=*/true);
   Type interfaceType;
   Type initializerType;
-  if (auto sig = typeDC->getGenericSignatureOfContext()) {
+  if (auto sig = targetDC->getGenericSignatureOfContext()) {
     // Evaluate the below, but in a generic environment (if Self is generic).
-    initDecl->setGenericEnvironment(typeDC->getGenericEnvironmentOfContext());
+    initDecl->setGenericEnvironment(targetDC->getGenericEnvironmentOfContext());
     interfaceType = GenericFunctionType::get(sig, selfType, innerType,
                                              FunctionType::ExtInfo());
     initializerType = GenericFunctionType::get(sig, selfInitType, innerType,
@@ -912,15 +956,15 @@ static ValueDecl *deriveDecodable_init(TypeChecker &tc, Decl *parentDecl,
   initDecl->setInterfaceType(interfaceType);
   initDecl->setInitializerInterfaceType(initializerType);
   initDecl->setAccessibility(
-      std::max(type->getFormalAccess(), Accessibility::Internal));
+      std::max(target->getFormalAccess(), Accessibility::Internal));
 
   // If the type was not imported, the derived conformance is either from the
   // type itself or an extension, in which case we will emit the declaration
   // normally.
-  if (type->hasClangNode())
+  if (target->hasClangNode())
     tc.Context.addExternalDecl(initDecl);
 
-  cast<IterableDeclContext>(type)->addMember(initDecl);
+  cast<IterableDeclContext>(target)->addMember(initDecl);
   return initDecl;
 }
 
@@ -931,14 +975,14 @@ static ValueDecl *deriveDecodable_init(TypeChecker &tc, Decl *parentDecl,
 ///
 /// \param tc The typechecker to use in validating {En,Decodable} conformance.
 ///
-/// \param type The type to validate.
+/// \param target The type to validate.
 ///
 /// \param proto The *codable protocol to check for validity.
-static bool canSynthesize(TypeChecker &tc, NominalTypeDecl *type,
+static bool canSynthesize(TypeChecker &tc, NominalTypeDecl *target,
                           ProtocolDecl *proto) {
   // First, look up if the type has a valid CodingKeys enum we can use.
   bool hasType, error;
-  std::tie(hasType, error) = hasValidCodingKeysEnum(tc, type, proto);
+  std::tie(hasType, error) = hasValidCodingKeysEnum(tc, target, proto);
 
   // We found a type, but it wasn't valid.
   if (error)
@@ -946,7 +990,7 @@ static bool canSynthesize(TypeChecker &tc, NominalTypeDecl *type,
 
   // We can try to synthesize a type here.
   if (!hasType) {
-    auto *synthesizedEnum = synthesizeCodingKeysEnum(tc, type, proto);
+    auto *synthesizedEnum = synthesizeCodingKeysEnum(tc, target, proto);
     if (!synthesizedEnum)
       return false;
   }
@@ -956,10 +1000,10 @@ static bool canSynthesize(TypeChecker &tc, NominalTypeDecl *type,
 
 ValueDecl *DerivedConformance::deriveEncodable(TypeChecker &tc,
                                               Decl *parentDecl,
-                                              NominalTypeDecl *type,
+                                              NominalTypeDecl *target,
                                               ValueDecl *requirement) {
     // We can only synthesize Encodable for structs and classes.
-    if (!isa<StructDecl>(type) && !isa<ClassDecl>(type))
+    if (!isa<StructDecl>(target) && !isa<ClassDecl>(target))
         return nullptr;
 
     if (requirement->getName() != tc.Context.Id_encode) {
@@ -968,19 +1012,26 @@ ValueDecl *DerivedConformance::deriveEncodable(TypeChecker &tc,
         return nullptr;
     }
 
+    // Conformance can't be synthesized in an extension.
+    auto encodableProto = tc.Context.getProtocol(KnownProtocolKind::Encodable);
+    auto encodableType = encodableProto->getDeclaredType();
+    if (target != parentDecl) {
+        tc.diagnose(parentDecl->getLoc(), diag::cannot_synthesize_in_extension,
+                    encodableType);
+        return nullptr;
+    }
+
     // Check other preconditions for synthesized conformance.
     // This synthesizes a CodingKeys enum if possible.
-    auto encodableProto = tc.Context.getProtocol(KnownProtocolKind::Encodable);
-    if (canSynthesize(tc, type, encodableProto))
-        return deriveEncodable_encode(tc, parentDecl, type);
+    if (canSynthesize(tc, target, encodableProto))
+        return deriveEncodable_encode(tc, parentDecl, target);
 
     // Known protocol requirement but could not synthesize.
     // FIXME: We have to output at least one error diagnostic here because we
     // returned true from NominalTypeDecl::derivesProtocolConformance; if we
     // don't, we expect to return a witness here later and crash on an
     // assertion.  Producing an error stops compilation before then.
-    auto encodableType = encodableProto->getDeclaredType();
-    tc.diagnose(type, diag::type_does_not_conform, type->getDeclaredType(),
+    tc.diagnose(target, diag::type_does_not_conform, target->getDeclaredType(),
                 encodableType);
     tc.diagnose(requirement, diag::no_witnesses, diag::RequirementKind::Func,
                 requirement->getFullName(), encodableType, /*AddFixIt=*/false);
@@ -989,10 +1040,10 @@ ValueDecl *DerivedConformance::deriveEncodable(TypeChecker &tc,
 
 ValueDecl *DerivedConformance::deriveDecodable(TypeChecker &tc,
                                                Decl *parentDecl,
-                                               NominalTypeDecl *type,
+                                               NominalTypeDecl *target,
                                                ValueDecl *requirement) {
     // We can only synthesize Encodable for structs and classes.
-    if (!isa<StructDecl>(type) && !isa<ClassDecl>(type))
+    if (!isa<StructDecl>(target) && !isa<ClassDecl>(target))
         return nullptr;
 
     if (requirement->getName() != tc.Context.Id_init) {
@@ -1001,19 +1052,26 @@ ValueDecl *DerivedConformance::deriveDecodable(TypeChecker &tc,
         return nullptr;
     }
 
+    // Conformance can't be synthesized in an extension.
+    auto decodableProto = tc.Context.getProtocol(KnownProtocolKind::Decodable);
+    auto decodableType = decodableProto->getDeclaredType();
+    if (target != parentDecl) {
+        tc.diagnose(parentDecl->getLoc(), diag::cannot_synthesize_in_extension,
+                    decodableType);
+        return nullptr;
+    }
+
     // Check other preconditions for synthesized conformance.
     // This synthesizes a CodingKeys enum if possible.
-    auto decodableProto = tc.Context.getProtocol(KnownProtocolKind::Decodable);
-    if (canSynthesize(tc, type, decodableProto))
-        return deriveDecodable_init(tc, parentDecl, type);
+    if (canSynthesize(tc, target, decodableProto))
+        return deriveDecodable_init(tc, parentDecl, target);
 
     // Known protocol requirement but could not synthesize.
     // FIXME: We have to output at least one error diagnostic here because we
     // returned true from NominalTypeDecl::derivesProtocolConformance; if we
     // don't, we expect to return a witness here later and crash on an
     // assertion.  Producing an error stops compilation before then.
-    auto decodableType = decodableProto->getDeclaredType();
-    tc.diagnose(type, diag::type_does_not_conform, type->getDeclaredType(),
+    tc.diagnose(target, diag::type_does_not_conform, target->getDeclaredType(),
                 decodableType);
     tc.diagnose(requirement, diag::no_witnesses,
                 diag::RequirementKind::Constructor, requirement->getFullName(),

--- a/test/decl/protocol/special/coding/class_codable_codingkeys_typealias.swift
+++ b/test/decl/protocol/special/coding/class_codable_codingkeys_typealias.swift
@@ -1,0 +1,27 @@
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
+
+// Simple classes with all Codable properties whose CodingKeys come from a
+// typealias should get derived conformance to Codable.
+class SimpleClass : Codable {
+  var x: Int = 1
+  var y: Double = .pi
+  static var z: String = "foo"
+
+  private typealias CodingKeys = A // expected-note {{'CodingKeys' declared here}}
+  private typealias A = B
+  private typealias B = C
+  private typealias C = MyRealCodingKeys
+
+  private enum MyRealCodingKeys : String, CodingKey {
+    case x
+    case y
+  }
+}
+
+// They should receive synthesized init(from:) and an encode(to:).
+let _ = SimpleClass.init(from:)
+let _ = SimpleClass.encode(to:)
+
+// The synthesized CodingKeys type should not be accessible from outside the
+// class.
+let _ = SimpleClass.CodingKeys.self // expected-error {{'CodingKeys' is inaccessible due to 'private' protection level}}

--- a/test/decl/protocol/special/coding/class_codable_computed_vars.swift
+++ b/test/decl/protocol/special/coding/class_codable_computed_vars.swift
@@ -27,13 +27,10 @@ class ClassWithComputedMembers : Codable {
   }
 }
 
-// These are wrapped in a dummy function to avoid binding a global variable.
-func foo() {
-  // They should receive synthesized init(from:) and an encode(to:).
-  let _ = ClassWithComputedMembers.init(from:)
-  let _ = ClassWithComputedMembers.encode(to:)
+// They should receive synthesized init(from:) and an encode(to:).
+let _ = ClassWithComputedMembers.init(from:)
+let _ = ClassWithComputedMembers.encode(to:)
 
-  // The synthesized CodingKeys type should not be accessible from outside the
-  // class.
-  let _ = ClassWithComputedMembers.CodingKeys.self // expected-error {{'CodingKeys' is inaccessible due to 'private' protection level}}
-}
+// The synthesized CodingKeys type should not be accessible from outside the
+// class.
+let _ = ClassWithComputedMembers.CodingKeys.self // expected-error {{'CodingKeys' is inaccessible due to 'private' protection level}}

--- a/test/decl/protocol/special/coding/class_codable_ignore_nonconforming_property.swift
+++ b/test/decl/protocol/special/coding/class_codable_ignore_nonconforming_property.swift
@@ -1,0 +1,26 @@
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
+
+struct NonCodable {}
+
+// Classes which have a default property that is not Codable, but which has a
+// default value and is skipped in its CodingKeys should still derive
+// conformance.
+class SimpleClass : Codable {
+  var w: NonCodable = NonCodable()
+  var x: Int = 1
+  var y: Double = .pi
+  static var z: String = "foo"
+
+  private enum CodingKeys : String, CodingKey { // expected-note {{'CodingKeys' declared here}}
+    case x
+    case y
+  }
+}
+
+// They should receive synthesized init(from:) and an encode(to:).
+let _ = SimpleClass.init(from:)
+let _ = SimpleClass.encode(to:)
+
+// The synthesized CodingKeys type should not be accessible from outside the
+// class.
+let _ = SimpleClass.CodingKeys.self // expected-error {{'CodingKeys' is inaccessible due to 'private' protection level}}

--- a/test/decl/protocol/special/coding/class_codable_inheritance.swift
+++ b/test/decl/protocol/special/coding/class_codable_inheritance.swift
@@ -43,13 +43,10 @@ class SimpleChildClass : SimpleClass {
   }
 }
 
-// These are wrapped in a dummy function to avoid binding a global variable.
-func foo() {
-  // They should receive synthesized init(from:) and an encode(to:).
-  let _ = SimpleChildClass.init(from:)
-  let _ = SimpleChildClass.encode(to:)
+// They should receive synthesized init(from:) and an encode(to:).
+let _ = SimpleChildClass.init(from:)
+let _ = SimpleChildClass.encode(to:)
 
-  // The synthesized CodingKeys type should not be accessible from outside the
-  // class.
-  let _ = SimpleChildClass.CodingKeys.self // expected-error {{'CodingKeys' is inaccessible due to 'private' protection level}}
-}
+// The synthesized CodingKeys type should not be accessible from outside the
+// class.
+let _ = SimpleChildClass.CodingKeys.self // expected-error {{'CodingKeys' is inaccessible due to 'private' protection level}}

--- a/test/decl/protocol/special/coding/class_codable_invalid_codingkeys.swift
+++ b/test/decl/protocol/special/coding/class_codable_invalid_codingkeys.swift
@@ -1,0 +1,37 @@
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
+
+// Classes with a CodingKeys entity which is not a type should not derive
+// conformance.
+class InvalidCodingKeys1 : Codable { // expected-error {{type 'InvalidCodingKeys1' does not conform to protocol 'Decodable'}}
+// expected-error@-1 {{type 'InvalidCodingKeys1' does not conform to protocol 'Encodable'}}
+  let CodingKeys = 5 // expected-note {{cannot automatically synthesize 'Decodable' because 'CodingKeys' is not an enum}}
+  // expected-note@-1 {{cannot automatically synthesize 'Encodable' because 'CodingKeys' is not an enum}}
+}
+
+// Classes with a CodingKeys entity which does not conform to CodingKey should
+// not derive conformance.
+class InvalidCodingKeys2 : Codable { // expected-error {{type 'InvalidCodingKeys2' does not conform to protocol 'Decodable'}}
+  // expected-error@-1 {{type 'InvalidCodingKeys2' does not conform to protocol 'Encodable'}}
+  enum CodingKeys {} // expected-note {{cannot automatically synthesize 'Decodable' because 'CodingKeys' does not conform to CodingKey}}
+  // expected-note@-1 {{cannot automatically synthesize 'Encodable' because 'CodingKeys' does not conform to CodingKey}}
+}
+
+// Classes with a CodingKeys entity which is not an enum should not derive
+// conformance.
+class InvalidCodingKeys3 : Codable { // expected-error {{type 'InvalidCodingKeys3' does not conform to protocol 'Decodable'}}
+  // expected-error@-1 {{type 'InvalidCodingKeys3' does not conform to protocol 'Encodable'}}
+  struct CodingKeys : CodingKey { // expected-note {{cannot automatically synthesize 'Decodable' because 'CodingKeys' is not an enum}}
+    // expected-note@-1 {{cannot automatically synthesize 'Encodable' because 'CodingKeys' is not an enum}}
+      var stringValue: String
+      init?(stringValue: String) {
+          self.stringValue = stringValue
+          self.intValue = nil
+      }
+
+      var intValue: Int?
+      init?(intValue: Int) {
+          self.stringValue = "\(intValue)"
+          self.intValue = intValue
+      }
+  }
+}

--- a/test/decl/protocol/special/coding/class_codable_nonconforming_property.swift
+++ b/test/decl/protocol/special/coding/class_codable_nonconforming_property.swift
@@ -1,0 +1,36 @@
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
+
+struct NonCodable {}
+
+// Classes whose properties are not all Codable should fail to synthesize
+// conformance.
+class NonConformingClass : Codable { // expected-error {{type 'NonConformingClass' does not conform to protocol 'Decodable'}}
+  // expected-error@-1 {{type 'NonConformingClass' does not conform to protocol 'Decodable'}}
+  // expected-error@-2 {{type 'NonConformingClass' does not conform to protocol 'Encodable'}}
+  // expected-error@-3 {{type 'NonConformingClass' does not conform to protocol 'Encodable'}}
+  // expected-note@-4 {{did you mean 'init'?}}
+  var w: NonCodable = NonCodable() // expected-note {{cannot automatically synthesize 'Decodable' because 'w' does not conform to 'Decodable'}}
+  // expected-note@-1 {{cannot automatically synthesize 'Decodable' because 'w' does not conform to 'Decodable'}}
+  // expected-note@-2 {{cannot automatically synthesize 'Encodable' because 'w' does not conform to 'Encodable'}}
+  // expected-note@-3 {{cannot automatically synthesize 'Encodable' because 'w' does not conform to 'Encodable'}}
+  var x: Int = 1
+  var y: Double = .pi
+  static var z: String = "foo"
+
+  // These lines have to be within the NonConformingClass type because
+  // CodingKeys should be private.
+  func foo() {
+    // They should not get a CodingKeys type.
+    let _ = NonConformingClass.CodingKeys.self // expected-error {{type 'NonConformingClass' has no member 'CodingKeys'}}
+    let _ = NonConformingClass.CodingKeys.x // expected-error {{type 'NonConformingClass' has no member 'CodingKeys'}}
+    let _ = NonConformingClass.CodingKeys.y // expected-error {{type 'NonConformingClass' has no member 'CodingKeys'}}
+    let _ = NonConformingClass.CodingKeys.z // expected-error {{type 'NonConformingClass' has no member 'CodingKeys'}}
+  }
+}
+
+// They should not receive Codable methods.
+let _ = NonConformingClass.init(from:) // expected-error {{type 'NonConformingClass' has no member 'init(from:)'}}
+let _ = NonConformingClass.encode(to:) // expected-error {{type 'NonConformingClass' has no member 'encode(to:)'}}
+
+// They should not get a CodingKeys type.
+let _ = NonConformingClass.CodingKeys.self // expected-error {{type 'NonConformingClass' has no member 'CodingKeys'}}

--- a/test/decl/protocol/special/coding/class_codable_simple.swift
+++ b/test/decl/protocol/special/coding/class_codable_simple.swift
@@ -22,13 +22,10 @@ class SimpleClass : Codable {
   }
 }
 
-// These are wrapped in a dummy function to avoid binding a global variable.
-func foo() {
-  // They should receive synthesized init(from:) and an encode(to:).
-  let _ = SimpleClass.init(from:)
-  let _ = SimpleClass.encode(to:)
+// They should receive synthesized init(from:) and an encode(to:).
+let _ = SimpleClass.init(from:)
+let _ = SimpleClass.encode(to:)
 
-  // The synthesized CodingKeys type should not be accessible from outside the
-  // class.
-  let _ = SimpleClass.CodingKeys.self // expected-error {{'CodingKeys' is inaccessible due to 'private' protection level}}
-}
+// The synthesized CodingKeys type should not be accessible from outside the
+// class.
+let _ = SimpleClass.CodingKeys.self // expected-error {{'CodingKeys' is inaccessible due to 'private' protection level}}

--- a/test/decl/protocol/special/coding/class_codable_simple_extension.swift
+++ b/test/decl/protocol/special/coding/class_codable_simple_extension.swift
@@ -1,36 +1,29 @@
-// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
+// RUN: %target-typecheck-verify-swift
 
-// Simple classes where Codable conformance is added in extensions should still
-// derive conformance.
-class SimpleClass {
+// Simple classes where Codable conformance is added in extensions should not
+// derive conformance yet.
+class SimpleClass { // expected-note {{did you mean 'init'?}}
   var x: Int = 1
   var y: Double = .pi
   static var z: String = "foo"
 
-  // These lines have to be within the SimpleClass type because CodingKeys
-  // should be private.
   func foo() {
-    // They should receive a synthesized CodingKeys enum.
-    let _ = SimpleClass.CodingKeys.self
-
-    // The enum should have a case for each of the vars.
-    let _ = SimpleClass.CodingKeys.x
-    let _ = SimpleClass.CodingKeys.y
-
-    // Static vars should not be part of the CodingKeys enum.
-    let _ = SimpleClass.CodingKeys.z // expected-error {{type 'SimpleClass.CodingKeys' has no member 'z'}}
+    // They should not get a CodingKeys type.
+    let _ = SimpleClass.CodingKeys.self // expected-error {{type 'SimpleClass' has no member 'CodingKeys'}}
+    let _ = SimpleClass.CodingKeys.x // expected-error {{type 'SimpleClass' has no member 'CodingKeys'}}
+    let _ = SimpleClass.CodingKeys.y // expected-error {{type 'SimpleClass' has no member 'CodingKeys'}}
+    let _ = SimpleClass.CodingKeys.z // expected-error {{type 'SimpleClass' has no member 'CodingKeys'}}
   }
 }
 
-extension SimpleClass : Codable {}
+extension SimpleClass : Codable {} // expected-error {{implementation of 'Decodable' cannot be automatically synthesized in an extension}}
+// expected-error@-1 {{implementation of 'Decodable' cannot be automatically synthesized in an extension}}
+// expected-error@-2 {{implementation of 'Encodable' cannot be automatically synthesized in an extension}}
+// expected-error@-3 {{implementation of 'Encodable' cannot be automatically synthesized in an extension}}
 
-// These are wrapped in a dummy function to avoid binding a global variable.
-func foo() {
-  // They should receive synthesized init(from:) and an encode(to:).
-  let _ = SimpleClass.init(from:)
-  let _ = SimpleClass.encode(to:)
+// They should not receive Codable methods.
+let _ = SimpleClass.init(from:) // expected-error {{type 'SimpleClass' has no member 'init(from:)'}}
+let _ = SimpleClass.encode(to:) // expected-error {{type 'SimpleClass' has no member 'encode(to:)'}}
 
-  // The synthesized CodingKeys type should not be accessible from outside the
-  // class.
-  let _ = SimpleClass.CodingKeys.self // expected-error {{'CodingKeys' is inaccessible due to 'private' protection level}}
-}
+// They should not get a CodingKeys type.
+let _ = SimpleClass.CodingKeys.self // expected-error {{type 'SimpleClass' has no member 'CodingKeys'}}

--- a/test/decl/protocol/special/coding/struct_codable_codingkeys_typealias.swift
+++ b/test/decl/protocol/special/coding/struct_codable_codingkeys_typealias.swift
@@ -1,0 +1,27 @@
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
+
+// Simple structs with all Codable properties whose CodingKeys come from a
+// typealias should get derived conformance to Codable.
+struct SimpleStruct : Codable {
+  var x: Int = 1
+  var y: Double = .pi
+  static var z: String = "foo"
+
+  private typealias CodingKeys = A // expected-note {{'CodingKeys' declared here}}
+  private typealias A = B
+  private typealias B = C
+  private typealias C = MyRealCodingKeys
+
+  private enum MyRealCodingKeys : String, CodingKey {
+    case x
+    case y
+  }
+}
+
+// They should receive synthesized init(from:) and an encode(to:).
+let _ = SimpleStruct.init(from:)
+let _ = SimpleStruct.encode(to:)
+
+// The synthesized CodingKeys type should not be accessible from outside the
+// struct.
+let _ = SimpleStruct.CodingKeys.self // expected-error {{'CodingKeys' is inaccessible due to 'private' protection level}}

--- a/test/decl/protocol/special/coding/struct_codable_ignore_nonconforming_property.swift
+++ b/test/decl/protocol/special/coding/struct_codable_ignore_nonconforming_property.swift
@@ -1,0 +1,26 @@
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
+
+struct NonCodable {}
+
+// Structs which have a default property that is not Codable, but which has a
+// default value and is skipped in its CodingKeys should still derive
+// conformance.
+struct SimpleStruct : Codable {
+  var w: NonCodable = NonCodable()
+  var x: Int
+  var y: Double
+  static var z: String = "foo"
+
+  private enum CodingKeys : String, CodingKey { // expected-note {{'CodingKeys' declared here}}
+    case x
+    case y
+  }
+}
+
+// They should receive synthesized init(from:) and an encode(to:).
+let _ = SimpleStruct.init(from:)
+let _ = SimpleStruct.encode(to:)
+
+// The synthesized CodingKeys type should not be accessible from outside the
+// struct.
+let _ = SimpleStruct.CodingKeys.self // expected-error {{'CodingKeys' is inaccessible due to 'private' protection level}}

--- a/test/decl/protocol/special/coding/struct_codable_invalid_codingkeys.swift
+++ b/test/decl/protocol/special/coding/struct_codable_invalid_codingkeys.swift
@@ -1,0 +1,37 @@
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
+
+// Structs with a CodingKeys entity which is not a type should not derive
+// conformance.
+struct InvalidCodingKeys1 : Codable { // expected-error {{type 'InvalidCodingKeys1' does not conform to protocol 'Decodable'}}
+// expected-error@-1 {{type 'InvalidCodingKeys1' does not conform to protocol 'Encodable'}}
+  let CodingKeys = 5 // expected-note {{cannot automatically synthesize 'Decodable' because 'CodingKeys' is not an enum}}
+  // expected-note@-1 {{cannot automatically synthesize 'Encodable' because 'CodingKeys' is not an enum}}
+}
+
+// Structs with a CodingKeys entity which does not conform to CodingKey should
+// not derive conformance.
+struct InvalidCodingKeys2 : Codable { // expected-error {{type 'InvalidCodingKeys2' does not conform to protocol 'Decodable'}}
+  // expected-error@-1 {{type 'InvalidCodingKeys2' does not conform to protocol 'Encodable'}}
+  enum CodingKeys {} // expected-note {{cannot automatically synthesize 'Decodable' because 'CodingKeys' does not conform to CodingKey}}
+  // expected-note@-1 {{cannot automatically synthesize 'Encodable' because 'CodingKeys' does not conform to CodingKey}}
+}
+
+// Structs with a CodingKeys entity which is not an enum should not derive
+// conformance.
+struct InvalidCodingKeys3 : Codable { // expected-error {{type 'InvalidCodingKeys3' does not conform to protocol 'Decodable'}}
+  // expected-error@-1 {{type 'InvalidCodingKeys3' does not conform to protocol 'Encodable'}}
+  struct CodingKeys : CodingKey { // expected-note {{cannot automatically synthesize 'Decodable' because 'CodingKeys' is not an enum}}
+    // expected-note@-1 {{cannot automatically synthesize 'Encodable' because 'CodingKeys' is not an enum}}
+      var stringValue: String
+      init?(stringValue: String) {
+          self.stringValue = stringValue
+          self.intValue = nil
+      }
+
+      var intValue: Int?
+      init?(intValue: Int) {
+          self.stringValue = "\(intValue)"
+          self.intValue = intValue
+      }
+  }
+}

--- a/test/decl/protocol/special/coding/struct_codable_nonconforming_property.swift
+++ b/test/decl/protocol/special/coding/struct_codable_nonconforming_property.swift
@@ -1,0 +1,36 @@
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
+
+struct NonCodable {}
+
+// Structs whose properties are not all Codable should fail to synthesize
+// conformance.
+struct NonConformingStruct : Codable { // expected-error {{type 'NonConformingStruct' does not conform to protocol 'Decodable'}}
+  // expected-error@-1 {{type 'NonConformingStruct' does not conform to protocol 'Decodable'}}
+  // expected-error@-2 {{type 'NonConformingStruct' does not conform to protocol 'Encodable'}}
+  // expected-error@-3 {{type 'NonConformingStruct' does not conform to protocol 'Encodable'}}
+  // expected-note@-4 {{did you mean 'init'?}}
+  var w: NonCodable // expected-note {{cannot automatically synthesize 'Decodable' because 'w' does not conform to 'Decodable'}}
+  // expected-note@-1 {{cannot automatically synthesize 'Decodable' because 'w' does not conform to 'Decodable'}}
+  // expected-note@-2 {{cannot automatically synthesize 'Encodable' because 'w' does not conform to 'Encodable'}}
+  // expected-note@-3 {{cannot automatically synthesize 'Encodable' because 'w' does not conform to 'Encodable'}}
+  var x: Int
+  var y: Double
+  static var z: String = "foo"
+
+  // These lines have to be within the NonConformingStruct type because
+  // CodingKeys should be private.
+  func foo() {
+    // They should not get a CodingKeys type.
+    let _ = NonConformingStruct.CodingKeys.self // expected-error {{type 'NonConformingStruct' has no member 'CodingKeys'}}
+    let _ = NonConformingStruct.CodingKeys.x // expected-error {{type 'NonConformingStruct' has no member 'CodingKeys'}}
+    let _ = NonConformingStruct.CodingKeys.y // expected-error {{type 'NonConformingStruct' has no member 'CodingKeys'}}
+    let _ = NonConformingStruct.CodingKeys.z // expected-error {{type 'NonConformingStruct' has no member 'CodingKeys'}}
+  }
+}
+
+// They should not receive Codable methods.
+let _ = NonConformingStruct.init(from:) // expected-error {{type 'NonConformingStruct' has no member 'init(from:)'}}
+let _ = NonConformingStruct.encode(to:) // expected-error {{type 'NonConformingStruct' has no member 'encode(to:)'}}
+
+// They should not get a CodingKeys type.
+let _ = NonConformingStruct.CodingKeys.self // expected-error {{type 'NonConformingStruct' has no member 'CodingKeys'}}

--- a/test/decl/protocol/special/coding/struct_codable_simple_extension.swift
+++ b/test/decl/protocol/special/coding/struct_codable_simple_extension.swift
@@ -1,36 +1,29 @@
 // RUN: %target-typecheck-verify-swift -verify-ignore-unknown
 
-// Simple structs where Codable conformance is added in extensions should still
-// derive conformance.
-struct SimpleStruct {
+// Simple structs where Codable conformance is added in extensions should not
+// derive conformance yet.
+struct SimpleStruct { // expected-note {{did you mean 'init'?}}
   var x: Int
   var y: Double
   static var z: String = "foo"
 
-  // These lines have to be within the SimpleStruct type because CodingKeys
-  // should be private.
   func foo() {
-    // They should receive synthesized init(from:) and an encode(to:).
-    let _ = SimpleStruct.init(from:)
-    let _ = SimpleStruct.encode(to:)
-
-    // They should receive a synthesized CodingKeys enum.
-    let _ = SimpleStruct.CodingKeys.self
-
-    // The enum should have a case for each of the vars.
-    let _ = SimpleStruct.CodingKeys.x
-    let _ = SimpleStruct.CodingKeys.y
-
-    // Static vars should not be part of the CodingKeys enum.
-    let _ = SimpleStruct.CodingKeys.z // expected-error {{type 'SimpleStruct.CodingKeys' has no member 'z'}}
+    // They should not receive a synthesized CodingKeys enum.
+    let _ = SimpleStruct.CodingKeys.self // expected-error {{type 'SimpleStruct' has no member 'CodingKeys'}}
+    let _ = SimpleStruct.CodingKeys.x // expected-error {{type 'SimpleStruct' has no member 'CodingKeys'}}
+    let _ = SimpleStruct.CodingKeys.y // expected-error {{type 'SimpleStruct' has no member 'CodingKeys'}}
+    let _ = SimpleStruct.CodingKeys.z // expected-error {{type 'SimpleStruct' has no member 'CodingKeys'}}
   }
 }
 
-extension SimpleStruct : Codable {}
+extension SimpleStruct : Codable {} // expected-error {{implementation of 'Decodable' cannot be automatically synthesized in an extension}}
+// expected-error@-1 {{implementation of 'Decodable' cannot be automatically synthesized in an extension}}
+// expected-error@-2 {{implementation of 'Encodable' cannot be automatically synthesized in an extension}}
+// expected-error@-3 {{implementation of 'Encodable' cannot be automatically synthesized in an extension}}
 
-// These are wrapped in a dummy function to avoid binding a global variable.
-func foo() {
-  // The synthesized CodingKeys type should not be accessible from outside the
-  // struct.
-  let _ = SimpleStruct.CodingKeys.self // expected-error {{'CodingKeys' is inaccessible due to 'private' protection level}}
-}
+// They should not receive Codable methods.
+let _ = SimpleStruct.init(from:) // expected-error {{type 'SimpleStruct' has no member 'init(from:)'}}
+let _ = SimpleStruct.encode(to:) // expected-error {{type 'SimpleStruct' has no member 'encode(to:)'}}
+
+// They should not get a CodingKeys type.
+let _ = SimpleStruct.CodingKeys.self // expected-error {{type 'SimpleStruct' has no member 'CodingKeys'}}


### PR DESCRIPTION
**What's in this pull request?**

* Introduce diagnostics that explain why derivation of Encodable/Decodable fail rather than just silently failing
* Allow properties with default values to be omitted from CodingKeys enum and from encoding/decoding
* If `CodingKeys` is a typealias, reach through it more consistently to get at the final target type
* Add unit tests to confirm this new behavior for classes and structs

> NOTE: Although this made the diff bigger, standalone variables named "type" have been renamed to "target" throughout, since the word "type" may be ambiguous and makes debugging impossible. "target" is unique.

This addresses [SR-4920](https://bugs.swift.org/browse/SR-4920), at least in the short term.