### PR TITLE
Sema: Bind context generic params using the current ConstraintSystem's generic environment instead of the decl's DC.

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -868,7 +868,7 @@ static void bindArchetypesFromContext(
     ConstraintLocator *locatorPtr,
     const OpenedTypeMap &replacements) {
 
-  auto *genericEnv = outerDC->getGenericEnvironmentOfContext();
+  auto *genericEnv = cs.DC->getGenericEnvironmentOfContext();
 
   for (const auto *parentDC = outerDC;
        !parentDC->isModuleScopeContext();

--- a/test/SILGen/sibling-nested-generic.swift
+++ b/test/SILGen/sibling-nested-generic.swift
@@ -1,0 +1,21 @@
+// RUN: %target-swift-frontend -emit-silgen -verify %s
+
+protocol AP {
+  associatedtype B: BP
+  var b: B { get }
+}
+protocol BP {}
+
+func foo<A: AP>(x: A) -> A {
+  func bar<B: BP>(x: B) {
+  }
+  func bas<B: BP>(x: B) {
+    bar(x: x)
+  }
+
+  func bang() -> A { return x }
+  func bong(_: A) {}
+
+  let x = bang()
+  bong(x)
+}

--- a/validation-test/compiler_crashers_fixed/28744-swift-genericenvironment-maptypeoutofcontext-swift-genericenvironment-swift-type.swift
+++ b/validation-test/compiler_crashers_fixed/28744-swift-genericenvironment-maptypeoutofcontext-swift-genericenvironment-swift-type.swift
@@ -5,5 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 protocol P extension P{var f=A.a}extension P{struct A{func a:Self


### PR DESCRIPTION
Fixes SR-4833.

rdar://problem/32134718