### PR TITLE
IRGen: Fix 'super.' calls to objc-dispatched static methods from generic classes

### DIFF
--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -60,9 +60,6 @@
 using namespace swift;
 using namespace irgen;
 
-static llvm::Value *emitLoadOfObjCHeapMetadataRef(IRGenFunction &IGF,
-                                                  llvm::Value *object);
-
 static Address emitAddressOfMetadataSlotAtIndex(IRGenFunction &IGF,
                                                 llvm::Value *metadata,
                                                 int index,
@@ -4380,7 +4377,7 @@ irgen::emitClassResilientInstanceSizeAndAlignMask(IRGenFunction &IGF,
 }
 
 /// Given a non-tagged object pointer, load a pointer to its class object.
-static llvm::Value *emitLoadOfObjCHeapMetadataRef(IRGenFunction &IGF,
+llvm::Value *irgen::emitLoadOfObjCHeapMetadataRef(IRGenFunction &IGF,
                                                   llvm::Value *object) {
   if (IGF.IGM.TargetInfo.hasISAMasking()) {
     object = IGF.Builder.CreateBitCast(object,

--- a/lib/IRGen/GenMeta.h
+++ b/lib/IRGen/GenMeta.h
@@ -204,6 +204,10 @@ namespace irgen {
                                            SILType objectType,
                                            bool suppressCast = false);
 
+  /// Given a non-tagged object pointer, load a pointer to its class object.
+  llvm::Value *emitLoadOfObjCHeapMetadataRef(IRGenFunction &IGF,
+                                             llvm::Value *object);
+
   /// Given a heap-object instance, with some heap-object type, produce a
   /// reference to its heap metadata by dynamically asking the runtime for it.
   llvm::Value *emitHeapMetadataRefForUnknownHeapObject(IRGenFunction &IGF,

--- a/test/IRGen/objc_super.swift
+++ b/test/IRGen/objc_super.swift
@@ -78,10 +78,30 @@ class PartialApply : Gizmo {
     acceptFn(super.frob)
   }
   // CHECK: }
-
-  // CHECK: define internal swiftcc void [[PARTIAL_FORWARDING_THUNK]](%swift.refcounted* swiftself) #0 {
-  // CHECK: call %swift.type* @_T010objc_super12PartialApplyCMa()
-  // CHECK: @"\01L_selector(frob)"
-  // CHECK: call void bitcast (void ()* @objc_msgSendSuper2
-  // CHECK: }
 }
+
+class GenericRuncer<T> : Gizmo {
+  // CHECK: define hidden swiftcc void @_T010objc_super13GenericRuncerC5runceyyFZ(%swift.type* swiftself) {{.*}} {
+  override class func runce() {
+    // CHECK:      [[CLASS:%.*]] = call %swift.type* @_T010objc_super13GenericRuncerCMa(%swift.type* %T)
+    // CHECK-NEXT: [[CLASS1:%.*]] = bitcast %swift.type* [[CLASS]] to %objc_class*
+    // CHECK-NEXT: [[CLASS2:%.*]] = bitcast %objc_class* [[CLASS1]] to i64*
+    // CHECK-NEXT: [[ISA:%.*]] = load i64, i64* [[CLASS2]], align 8
+    // CHECK-NEXT: [[ISA_MASK:%.*]] = load i64, i64* @swift_isaMask, align 8
+    // CHECK-NEXT: [[ISA_MASKED:%.*]] = and i64 [[ISA]], [[ISA_MASK]]
+    // CHECK-NEXT: [[ISA_PTR:%.*]] = inttoptr i64 [[ISA_MASKED]] to %swift.type*
+    // CHECK-NEXT: [[METACLASS:%.*]] = bitcast %swift.type* [[ISA_PTR]] to %objc_class*
+    // CHECK:      [[METACLASS_ADDR:%.*]] = getelementptr %objc_super, %objc_super* %objc_super, i32 0, i32 1
+    // CHECK-NEXT: store %objc_class* [[METACLASS]], %objc_class** [[METACLASS_ADDR]], align 8
+    // CHECK-NEXT: [[SELECTOR:%.*]] = load i8*, i8** @"\01L_selector(runce)", align 8
+    // CHECK-NEXT: call void bitcast (void ()* @objc_msgSendSuper2 to void (%objc_super*, i8*)*)(%objc_super* %objc_super, i8* [[SELECTOR]])
+    // CHECK-NEXT: ret void
+    super.runce()
+  }
+}
+
+// CHECK: define internal swiftcc void [[PARTIAL_FORWARDING_THUNK]](%swift.refcounted* swiftself) #0 {
+// CHECK: call %swift.type* @_T010objc_super12PartialApplyCMa()
+// CHECK: @"\01L_selector(frob)"
+// CHECK: call void bitcast (void ()* @objc_msgSendSuper2
+// CHECK: }

--- a/test/Interpreter/generic_objc_subclass.swift
+++ b/test/Interpreter/generic_objc_subclass.swift
@@ -249,3 +249,33 @@ let c = PandorasBox(30)
 // CHECK: 30
 // Uses ConstantDirect access pattern
 print(c.value)
+
+// Super method calls from a generic subclass of an @objc class
+class HasDynamicMethod : NSObject {
+  @objc dynamic class func funkyTown() {
+    print("Here we are with \(self)")
+  }
+}
+
+class GenericOverrideOfDynamicMethod<T> : HasDynamicMethod {
+  override class func funkyTown() {
+    print("Hello from \(self) with T = \(T.self)")
+    super.funkyTown()
+    print("Goodbye from \(self) with T = \(T.self)")
+  }
+}
+
+class ConcreteOverrideOfDynamicMethod : GenericOverrideOfDynamicMethod<Int> {
+  override class func funkyTown() {
+    print("Hello from \(self)")
+    super.funkyTown()
+    print("Goodbye from \(self)")
+  }
+}
+
+// CHECK: Hello from ConcreteOverrideOfDynamicMethod
+// CHECK: Hello from ConcreteOverrideOfDynamicMethod with T = Int
+// CHECK: Here we are with ConcreteOverrideOfDynamicMethod
+// CHECK: Goodbye from ConcreteOverrideOfDynamicMethod with T = Int
+// CHECK: Goodbye from ConcreteOverrideOfDynamicMethod
+ConcreteOverrideOfDynamicMethod.funkyTown()


### PR DESCRIPTION
If a class has runtime-initialized metadata, we cannot just
reference its metaclass symbol statically, and instead we must
realize the metadata and load its isa pointer at runtime.

Fixes <rdar://problem/23715486>.