### PR TITLE
[Type checker] Don't warn about implicit @objc due to overrides by default

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -6206,15 +6206,17 @@ public:
         if (func->isAccessor()) return;
       }
 
-      // If @objc was explicit or handles elsewhere, nothing to do.
+      // If @objc was explicit or handled elsewhere, nothing to do.
       if (!attr->isSwift3Inferred()) return;
 
-      // When warning about all deprecated @objc inference rules,
-      // we only need to do this check if we have implicit 'dynamic'.
-      if (TC.Context.LangOpts.WarnSwift3ObjCInference !=
-            Swift3ObjCInferenceWarnings::None) {
-        if (auto dynamicAttr = Base->getAttrs().getAttribute<DynamicAttr>())
-          if (!dynamicAttr->isImplicit()) return;
+      // If we aren't warning about Swift 3 @objc inference, we're done.
+      if (TC.Context.LangOpts.WarnSwift3ObjCInference ==
+            Swift3ObjCInferenceWarnings::None)
+        return;
+
+      // If 'dynamic' was implicit, we'll already have warned about this.
+      if (auto dynamicAttr = Base->getAttrs().getAttribute<DynamicAttr>()) {
+        if (!dynamicAttr->isImplicit()) return;
       }
 
       // The overridden declaration needs to be in an extension.

--- a/test/attr/attr_objc_swift3_deprecated_default.swift
+++ b/test/attr/attr_objc_swift3_deprecated_default.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend -disable-objc-attr-requires-foundation-module -typecheck -verify %s -swift-version 3
+// REQUIRES: objc_interop
+
+import Foundation
+
+class C : NSObject { }
+
+extension C {
+  func foo() { }
+}
+
+class D : C { }
+
+extension D {
+  override func foo() { }  // do not warn
+}


### PR DESCRIPTION
The deprecated `@objc` inference warnings are opt-in now, but this one
was still firing by default. Stop doing that. Fixes rdar://problem/32228731.
