### PR TITLE
Fix various problems with types in expression context

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -1382,12 +1382,37 @@ public:
   static TypeExpr *createImplicitHack(SourceLoc Loc, Type Ty, ASTContext &C);
 
   
-  /// Return a TypeExpr for a TypeDecl and the specified location.
+  /// Create a TypeExpr for a TypeDecl at the specified location.
   static TypeExpr *createForDecl(SourceLoc Loc, TypeDecl *D,
                                  bool isImplicit);
+
+  /// Create a TypeExpr for a member TypeDecl of the given parent TypeDecl.
+  static TypeExpr *createForMemberDecl(SourceLoc ParentNameLoc,
+                                       TypeDecl *Parent,
+                                       SourceLoc NameLoc,
+                                       TypeDecl *Decl);
+
+  /// Create a TypeExpr for a member TypeDecl of the given parent IdentTypeRepr.
+  static TypeExpr *createForMemberDecl(IdentTypeRepr *ParentTR,
+                                       SourceLoc NameLoc,
+                                       TypeDecl *Decl);
+
+  /// Create a TypeExpr for a generic TypeDecl with the given arguments applied
+  /// at the specified location.
   static TypeExpr *createForSpecializedDecl(SourceLoc Loc, TypeDecl *D,
                                             ArrayRef<TypeRepr*> args,
                                             SourceRange angleLocs);
+
+  /// Create a TypeExpr from an IdentTypeRepr with the given arguments applied
+  /// at the specified location.
+  ///
+  /// Returns nullptr if the reference cannot be formed, which is a hack due
+  /// to limitations in how we model generic typealiases.
+  static TypeExpr *createForSpecializedDecl(IdentTypeRepr *ParentTR,
+                                            ArrayRef<TypeRepr*> Args,
+                                            SourceRange AngleLocs,
+                                            ASTContext &C);
+
   TypeLoc &getTypeLoc() { return Info; }
   TypeLoc getTypeLoc() const { return Info; }
   TypeRepr *getTypeRepr() const { return Info.getTypeRepr(); }

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1557,6 +1557,11 @@ namespace {
           // open type.
           auto locator = CS.getConstraintLocator(expr);
           for (size_t i = 0, size = specializations.size(); i < size; ++i) {
+            if (tc.validateType(specializations[i], CS.DC,
+                                (TR_InExpression |
+                                 TR_AllowUnboundGenerics)))
+              return Type();
+
             CS.addConstraint(ConstraintKind::Equal,
                              typeVars[i], specializations[i].getType(),
                              locator);

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1537,7 +1537,7 @@ namespace {
         if (BoundGenericType *bgt
               = meta->getInstanceType()->getAs<BoundGenericType>()) {
           ArrayRef<Type> typeVars = bgt->getGenericArgs();
-          ArrayRef<TypeLoc> specializations = expr->getUnresolvedParams();
+          MutableArrayRef<TypeLoc> specializations = expr->getUnresolvedParams();
 
           // If we have too many generic arguments, complain.
           if (specializations.size() > typeVars.size()) {

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -481,6 +481,12 @@ static bool isDeclAsSpecializedAs(TypeChecker &tc, DeclContext *dc,
     log << "\n";
   }
 
+  auto *innerDC1 = decl1->getInnermostDeclContext();
+  auto *innerDC2 = decl2->getInnermostDeclContext();
+
+  auto *outerDC1 = decl1->getDeclContext();
+  auto *outerDC2 = decl2->getDeclContext();
+
   if (!tc.specializedOverloadComparisonCache.count({decl1, decl2})) {
 
     auto compareSpecializations = [&] () -> bool {
@@ -516,18 +522,16 @@ static bool isDeclAsSpecializedAs(TypeChecker &tc, DeclContext *dc,
       }
 
       // Members of protocol extensions have special overloading rules.
-      ProtocolDecl *inProtocolExtension1 = decl1->getDeclContext()
+      ProtocolDecl *inProtocolExtension1 = outerDC1
                                              ->getAsProtocolExtensionContext();
-      ProtocolDecl *inProtocolExtension2 = decl2->getDeclContext()
+      ProtocolDecl *inProtocolExtension2 = outerDC2
                                              ->getAsProtocolExtensionContext();
       if (inProtocolExtension1 && inProtocolExtension2) {
         // Both members are in protocol extensions.
         // Determine whether the 'Self' type from the first protocol extension
         // satisfies all of the requirements of the second protocol extension.
-        DeclContext *dc1 = decl1->getDeclContext();
-        DeclContext *dc2 = decl2->getDeclContext();
-        bool better1 = isProtocolExtensionAsSpecializedAs(tc, dc1, dc2);
-        bool better2 = isProtocolExtensionAsSpecializedAs(tc, dc2, dc1);
+        bool better1 = isProtocolExtensionAsSpecializedAs(tc, outerDC1, outerDC2);
+        bool better2 = isProtocolExtensionAsSpecializedAs(tc, outerDC2, outerDC1);
         if (better1 != better2) {
           return better1;
         }
@@ -554,8 +558,8 @@ static bool isDeclAsSpecializedAs(TypeChecker &tc, DeclContext *dc,
         }
       } else {
         // Add a curried 'self' type.
-        type1 = addCurriedSelfType(tc.Context, type1, decl1->getDeclContext());
-        type2 = addCurriedSelfType(tc.Context, type2, decl2->getDeclContext());
+        type1 = addCurriedSelfType(tc.Context, type1, outerDC1);
+        type2 = addCurriedSelfType(tc.Context, type2, outerDC2);
 
         // For a subscript declaration, only look at the input type (i.e., the
         // indices).
@@ -578,31 +582,44 @@ static bool isDeclAsSpecializedAs(TypeChecker &tc, DeclContext *dc,
         openedType2 = cs.openFunctionType(
             funcType, /*numArgumentLabelsToRemove=*/0, locator,
             /*replacements=*/unused,
-            decl2->getInnermostDeclContext(),
-            decl2->getDeclContext(),
+            innerDC2,
+            outerDC2,
             /*skipProtocolSelfConstraint=*/false);
       } else {
+        cs.openGeneric(innerDC2,
+                       outerDC2,
+                       innerDC2->getGenericSignatureOfContext(),
+                       /*skipProtocolSelfConstraint=*/false,
+                       locator,
+                       unused);
+
         openedType2 = cs.openType(type2, locator, unused);
       }
 
       // Get the type of a reference to the first declaration, swapping in
       // archetypes for the dependent types.
       OpenedTypeMap replacements;
-      auto dc1 = decl1->getInnermostDeclContext();
       Type openedType1;
       if (auto *funcType = type1->getAs<AnyFunctionType>()) {
         openedType1 = cs.openFunctionType(
             funcType, /*numArgumentLabelsToRemove=*/0, locator,
             replacements,
-            dc1,
-            decl1->getDeclContext(),
+            innerDC1,
+            outerDC1,
             /*skipProtocolSelfConstraint=*/false);
       } else {
+        cs.openGeneric(innerDC1,
+                       outerDC1,
+                       innerDC1->getGenericSignatureOfContext(),
+                       /*skipProtocolSelfConstraint=*/false,
+                       locator,
+                       replacements);
+
         openedType1 = cs.openType(type1, locator, replacements);
       }
 
       for (const auto &replacement : replacements) {
-        if (auto mapped = dc1->mapTypeIntoContext(replacement.first)) {
+        if (auto mapped = innerDC1->mapTypeIntoContext(replacement.first)) {
           cs.addConstraint(ConstraintKind::Bind, replacement.second, mapped,
                            locator);
         }
@@ -611,12 +628,12 @@ static bool isDeclAsSpecializedAs(TypeChecker &tc, DeclContext *dc,
       // Extract the self types from the declarations, if they have them.
       Type selfTy1;
       Type selfTy2;
-      if (decl1->getDeclContext()->isTypeContext()) {
+      if (outerDC1->isTypeContext()) {
         auto funcTy1 = openedType1->castTo<FunctionType>();
         selfTy1 = funcTy1->getInput()->getRValueInstanceType();
         openedType1 = funcTy1->getResult();
       }
-      if (decl2->getDeclContext()->isTypeContext()) {
+      if (outerDC2->isTypeContext()) {
         auto funcTy2 = openedType2->castTo<FunctionType>();
         selfTy2 = funcTy2->getInput()->getRValueInstanceType();
         openedType2 = funcTy2->getResult();
@@ -625,8 +642,7 @@ static bool isDeclAsSpecializedAs(TypeChecker &tc, DeclContext *dc,
       // Determine the relationship between the 'self' types and add the
       // appropriate constraints. The constraints themselves never fail, but
       // they help deduce type variables that were opened.
-      switch (computeSelfTypeRelationship(tc, dc, decl1->getDeclContext(),
-                                          decl2->getDeclContext())) {
+      switch (computeSelfTypeRelationship(tc, dc, outerDC1, outerDC2)) {
       case SelfTypeRelationship::Unrelated:
         // Skip the self types parameter entirely.
         break;
@@ -645,15 +661,13 @@ static bool isDeclAsSpecializedAs(TypeChecker &tc, DeclContext *dc,
 
       case SelfTypeRelationship::ConformsTo:
         cs.addConstraint(ConstraintKind::ConformsTo, selfTy1,
-                         cast<ProtocolDecl>(decl2->getDeclContext())
-                           ->getDeclaredType(),
+                         cast<ProtocolDecl>(outerDC2)->getDeclaredType(),
                          locator);
         break;
 
       case SelfTypeRelationship::ConformedToBy:
         cs.addConstraint(ConstraintKind::ConformsTo, selfTy2,
-                         cast<ProtocolDecl>(decl1->getDeclContext())
-                           ->getDeclaredType(),
+                         cast<ProtocolDecl>(outerDC1)->getDeclaredType(),
                          locator);
         break;
       }
@@ -675,10 +689,10 @@ static bool isDeclAsSpecializedAs(TypeChecker &tc, DeclContext *dc,
         auto funcTy2 = openedType2->castTo<FunctionType>();
         SmallVector<CallArgParam, 4> params1 =
           decomposeParamType(funcTy1->getInput(), decl1,
-                             decl1->getDeclContext()->isTypeContext());
+                             outerDC1->isTypeContext());
         SmallVector<CallArgParam, 4> params2 =
           decomposeParamType(funcTy2->getInput(), decl2,
-                             decl2->getDeclContext()->isTypeContext());
+                             outerDC2->isTypeContext());
 
         unsigned numParams1 = params1.size();
         unsigned numParams2 = params2.size();

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1953,13 +1953,6 @@ public:
                    bool skipProtocolSelfConstraint,
                    ConstraintLocatorBuilder locator,
                    OpenedTypeMap &replacements);
-  void openGeneric(DeclContext *innerDC,
-                   DeclContext *outerDC,
-                   ArrayRef<GenericTypeParamType *> params,
-                   ArrayRef<Requirement> requirements,
-                   bool skipProtocolSelfConstraint,
-                   ConstraintLocatorBuilder locator,
-                   OpenedTypeMap &replacements);
 
   /// Record the set of opened types for the given locator.
   void recordOpenedTypes(

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1118,22 +1118,8 @@ TypeExpr *PreCheckExpression::simplifyNestedTypeExpr(UnresolvedDotExpr *UDE) {
         // If there is no nested type with this name, we have a lookup of
         // a non-type member, so leave the expression as-is.
         if (Result.size() == 1) {
-          auto *NewDecl = Result.front().first;
-          // Filter out dicey cases that we diagnose or handle later:
-          //
-          // 1) Dependent typealias or associated type reference with
-          //    protocol base.
-          if (NewDecl->getDeclaredInterfaceType()->hasTypeParameter() &&
-              BaseTy->isExistentialType())
-            return nullptr;
-
-          // 2) Generic typealias reference with unbound generic base.
-          if (isa<TypeAliasDecl>(NewDecl) &&
-              NewDecl->getDeclaredInterfaceType()->hasTypeParameter() &&
-              BaseTy->hasUnboundGenericType())
-            return nullptr;
-
-          return TypeExpr::createForMemberDecl(ITR, NameLoc, NewDecl);
+          return TypeExpr::createForMemberDecl(ITR, NameLoc,
+                                               Result.front().first);
         }
       }
     }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -6649,9 +6649,7 @@ bool TypeChecker::isProtocolExtensionUsable(DeclContext *dc, Type type,
   OpenedTypeMap replacements;
   auto genericSig = protocolExtension->getGenericSignature();
   
-  cs.openGeneric(protocolExtension, protocolExtension,
-                 genericSig->getGenericParams(),
-                 genericSig->getRequirements(), false,
+  cs.openGeneric(protocolExtension, protocolExtension, genericSig, false,
                  ConstraintLocatorBuilder(nullptr), replacements);
 
   // Bind the 'Self' type variable to the provided type.

--- a/test/ClangImporter/enum-with-target.swift
+++ b/test/ClangImporter/enum-with-target.swift
@@ -14,7 +14,7 @@ let calendarUnitsDep: NSCalendarUnitDeprecated = [.eraCalendarUnitDeprecated, .y
 // rdar://problem/21081557
 func pokeRawValue(_ random: SomeRandomEnum) {
   switch (random) {
-  case SomeRandomEnum.RawValue // expected-error{{type 'SomeRandomEnum' has no member 'RawValue'}}
+  case SomeRandomEnum.RawValue // expected-error{{expression pattern of type 'Int.Type' cannot match values of type 'SomeRandomEnum'}}
     // expected-error@-1{{expected ':' after 'case'}}
   }
 }

--- a/test/Compatibility/type_expr.swift
+++ b/test/Compatibility/type_expr.swift
@@ -1,0 +1,37 @@
+// RUN: %target-typecheck-verify-swift -swift-version 3
+
+func takesOneArg<T>(_: T.Type) {}
+func takesTwoArgs<T>(_: T.Type, _: Int) {}
+
+func testMissingSelf() {
+  // None of these were not caught in Swift 3.
+  // See test/Compatibility/type_expr.swift.
+
+  takesOneArg(Int)
+  // expected-warning@-1 {{missing '.self' for reference to metatype of type 'Int'}}
+
+  takesOneArg(Swift.Int)
+  // expected-warning@-1 {{missing '.self' for reference to metatype of type 'Int'}}
+
+  takesTwoArgs(Int, 0)
+  // expected-warning@-1 {{missing '.self' for reference to metatype of type 'Int'}}
+
+  takesTwoArgs(Swift.Int, 0)
+  // expected-warning@-1 {{missing '.self' for reference to metatype of type 'Int'}}
+
+  Swift.Int // expected-warning {{expression of type 'Int.Type' is unused}}
+  // expected-warning@-1 {{missing '.self' for reference to metatype of type 'Int'}}
+
+  _ = Swift.Int
+  // expected-warning@-1 {{missing '.self' for reference to metatype of type 'Int'}}
+
+  Int // expected-warning {{expression of type 'Int.Type' is unused}}
+  // expected-error@-1 {{expected member name or constructor call after type name}}
+  // expected-note@-2 {{add arguments after the type to construct a value of the type}}
+  // expected-note@-3 {{use '.self' to reference the type object}}
+
+  _ = Int
+  // expected-error@-1 {{expected member name or constructor call after type name}}
+  // expected-note@-2 {{add arguments after the type to construct a value of the type}}
+  // expected-note@-3 {{use '.self' to reference the type object}}
+}

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -260,7 +260,7 @@ protocol SubProto: BaseProto {}
   func copy() -> Any
 }
 
-struct FullyGeneric<Foo> {} // expected-note 6 {{'Foo' declared as parameter to type 'FullyGeneric'}} expected-note 6 {{generic type 'FullyGeneric' declared here}}
+struct FullyGeneric<Foo> {} // expected-note 11 {{'Foo' declared as parameter to type 'FullyGeneric'}} expected-note 1 {{generic type 'FullyGeneric' declared here}}
 
 struct AnyClassBound<Foo: AnyObject> {} // expected-note {{'Foo' declared as parameter to type 'AnyClassBound'}} expected-note {{generic type 'AnyClassBound' declared here}}
 struct AnyClassBound2<Foo> where Foo: AnyObject {} // expected-note {{'Foo' declared as parameter to type 'AnyClassBound2'}}
@@ -369,21 +369,24 @@ func testFixItTypePosition() {
 }
 
 func testFixItNested() {
-  _ = Array<FullyGeneric>() // expected-error {{reference to generic type 'FullyGeneric' requires arguments in <...>}} {{25-25=<Any>}}
+  _ = Array<FullyGeneric>() // expected-error {{generic parameter 'Foo' could not be inferred}}
+  // expected-note@-1 {{explicitly specify the generic arguments to fix this issue}} {{25-25=<Any>}}
   _ = [FullyGeneric]() // expected-error {{generic parameter 'Foo' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{20-20=<Any>}}
 
-  _ = FullyGeneric<FullyGeneric>() // expected-error {{reference to generic type 'FullyGeneric' requires arguments in <...>}} {{32-32=<Any>}}
+  _ = FullyGeneric<FullyGeneric>() // expected-error {{generic parameter 'Foo' could not be inferred}}
 
-  _ = Pair<
-    FullyGeneric, // expected-error {{reference to generic type 'FullyGeneric' requires arguments in <...>}} {{17-17=<Any>}}
+  _ = Pair< // expected-error {{generic parameter 'Foo' could not be inferred}}
+    FullyGeneric,
+    // expected-note@-1 {{explicitly specify the generic arguments to fix this issue}} {{17-17=<Any>}}
     FullyGeneric // FIXME: We could diagnose both of these, but we don't.
   >()
-  _ = Pair<
+  _ = Pair< // expected-error {{generic parameter 'Foo' could not be inferred}}
     FullyGeneric<Any>,
-    FullyGeneric // expected-error {{reference to generic type 'FullyGeneric' requires arguments in <...>}} {{17-17=<Any>}}
+    FullyGeneric
   >()
-  _ = Pair<
-    FullyGeneric, // expected-error {{reference to generic type 'FullyGeneric' requires arguments in <...>}} {{17-17=<Any>}}
+  _ = Pair< // expected-error {{generic parameter 'Foo' could not be inferred}}
+    FullyGeneric,
+    // expected-note@-1 {{explicitly specify the generic arguments to fix this issue}} {{17-17=<Any>}}
     FullyGeneric<Any>
   >()
 

--- a/test/Generics/invalid.swift
+++ b/test/Generics/invalid.swift
@@ -53,9 +53,9 @@ func eatDinnerConcrete(d: Pizzas<Pepper>.DeepDish,
 
 func badDiagnostic1() {
 
-  _ = Lunch<Pizzas<Pepper>.NewYork>.Dinner<HotDog>( // expected-error {{expression type 'Lunch<Pizzas<Pepper>.NewYork>.Dinner<HotDog>' is ambiguous without more context}}
+  _ = Lunch<Pizzas<Pepper>.NewYork>.Dinner<HotDog>(
       leftovers: Pizzas<ChiliFlakes>.NewYork(),
-      transformation: { _ in HotDog() })
+      transformation: { _ in HotDog() }) // expected-error {{cannot convert value of type 'HotDog' to closure result type '_'}}
 }
 
 func badDiagnostic2() {

--- a/test/IDE/complete_from_swift_module.swift
+++ b/test/IDE/complete_from_swift_module.swift
@@ -72,8 +72,8 @@ func testCompleteModuleQualified4() {
   foo_swift_module.BarGenericSwiftStruct2#^MODULE_QUALIFIED_4^#
 }
 // MODULE_QUALIFIED_4: Begin completions
-// MODULE_QUALIFIED_4-NEXT: Decl[Constructor]/CurrNominal:    ({#t: BarProtocol#}, {#u: U#})[#BarGenericSwiftStruct2<BarProtocol, U>#]
-// MODULE_QUALIFIED_4-NEXT: Decl[InstanceMethod]/CurrNominal: .bar2InstanceFunc({#self: BarGenericSwiftStruct2<BarProtocol, U>#})[#() -> Void#]
+// MODULE_QUALIFIED_4-NEXT: Decl[Constructor]/CurrNominal:    ({#t: BarProtocol#}, {#u: BarProtocol#})[#BarGenericSwiftStruct2<BarProtocol, BarProtocol>#]
+// MODULE_QUALIFIED_4-NEXT: Decl[InstanceMethod]/CurrNominal: .bar2InstanceFunc({#self: BarGenericSwiftStruct2<BarProtocol, BarProtocol>#})[#() -> Void#]
 // MODULE_QUALIFIED_4: Decl[InfixOperatorFunction]/OtherModule[Swift]: != {#Any.Type?#}[#Bool#];
 // MODULE_QUALIFIED_4-NEXT: End completions
 

--- a/test/Parse/enum_element_pattern_swift4.swift
+++ b/test/Parse/enum_element_pattern_swift4.swift
@@ -9,7 +9,8 @@ enum E {
 
   static func testE(e: E) {
     switch e {
-    case A<UndefinedTy>(): // expected-error {{use of undeclared type 'UndefinedTy'}}
+    case A<UndefinedTy>(): // expected-error {{cannot specialize a non-generic definition}}
+    // expected-note@-1 {{while parsing this '<' as a type parameter bracket}}
       break
     case B<Int>(): // expected-error {{cannot specialize a non-generic definition}} expected-note {{while parsing this '<' as a type parameter bracket}}
       break
@@ -21,7 +22,8 @@ enum E {
 
 func testE(e: E) {
   switch e {
-  case E.A<UndefinedTy>(): // expected-error {{use of undeclared type 'UndefinedTy'}}
+  case E.A<UndefinedTy>(): // expected-error {{cannot specialize a non-generic definition}}
+  // expected-note@-1 {{while parsing this '<' as a type parameter bracket}}
     break
   case E.B<Int>(): // expected-error {{cannot specialize a non-generic definition}} expected-note {{while parsing this '<' as a type parameter bracket}}
     break

--- a/test/Parse/generic_disambiguation.swift
+++ b/test/Parse/generic_disambiguation.swift
@@ -26,9 +26,11 @@ var a, b, c, d : Int
 _ = a < b
 _ = (a < b, c > d)
 // Parses as generic because of lparen after '>'
-(a < b, c > (d)) // expected-error{{use of undeclared type 'b'}}
+(a < b, c > (d)) // expected-error{{cannot specialize a non-generic definition}}
+// expected-note@-1 {{while parsing this '<' as a type parameter bracket}}
 // Parses as generic because of lparen after '>'
-(a<b, c>(d)) // expected-error{{use of undeclared type 'b'}} 
+(a<b, c>(d)) // expected-error{{cannot specialize a non-generic definition}}
+// expected-note@-1 {{while parsing this '<' as a type parameter bracket}}
 _ = a>(b)
 _ = a > (b)
 

--- a/test/Parse/type_expr.swift
+++ b/test/Parse/type_expr.swift
@@ -134,7 +134,9 @@ func typeOfShadowing() {
   // TODO: Errors need improving here.
   _ = type(of: Gen<Foo>.Bar) // expected-error{{argument labels '(of:)' do not match any available overloads}}
                              // expected-note@-1{{overloads for 'type' exist with these partially matching parameter lists: (T.Type), (fo: T.Type)}}
-  _ = type(Gen<Foo>.Bar) // expected-warning{{missing '.self' for reference to metatype of type 'Gen<Foo>.Bar'}}
+  _ = type(Gen<Foo>.Bar) // expected-error{{expected member name or constructor call after type name}}
+  // expected-note@-1{{add arguments after the type to construct a value of the type}}
+  // expected-note@-2{{use '.self' to reference the type object}}
   _ = type(of: Gen<Foo>.Bar.self, flag: false) // No error here.
   _ = type(fo: Foo.Bar.self) // No error here.
   _ = type(of: Foo.Bar.self, [1, 2, 3]) // No error here.
@@ -300,3 +302,41 @@ func complexSequence() {
 }
 
 func takesVoid(f: Void -> ()) {} // expected-error {{single argument function types require parentheses}} {{19-23=()}}
+
+func takesOneArg<T>(_: T.Type) {}
+func takesTwoArgs<T>(_: T.Type, _: Int) {}
+
+func testMissingSelf() {
+  // None of these were not caught in Swift 3.
+  // See test/Compatibility/type_expr.swift.
+
+  takesOneArg(Int)
+  // expected-error@-1 {{expected member name or constructor call after type name}}
+  // expected-note@-2 {{add arguments after the type to construct a value of the type}}
+  // expected-note@-3 {{use '.self' to reference the type object}}
+
+  takesOneArg(Swift.Int)
+  // expected-error@-1 {{expected member name or constructor call after type name}}
+  // expected-note@-2 {{add arguments after the type to construct a value of the type}}
+  // expected-note@-3 {{use '.self' to reference the type object}}
+
+  takesTwoArgs(Int, 0)
+  // expected-error@-1 {{expected member name or constructor call after type name}}
+  // expected-note@-2 {{add arguments after the type to construct a value of the type}}
+  // expected-note@-3 {{use '.self' to reference the type object}}
+
+  takesTwoArgs(Swift.Int, 0)
+  // expected-error@-1 {{expected member name or constructor call after type name}}
+  // expected-note@-2 {{add arguments after the type to construct a value of the type}}
+  // expected-note@-3 {{use '.self' to reference the type object}}
+
+  Swift.Int // expected-warning {{expression of type 'Int.Type' is unused}}
+  // expected-error@-1 {{expected member name or constructor call after type name}}
+  // expected-note@-2 {{add arguments after the type to construct a value of the type}}
+  // expected-note@-3 {{use '.self' to reference the type object}}
+
+  _ = Swift.Int
+  // expected-error@-1 {{expected member name or constructor call after type name}}
+  // expected-note@-2 {{add arguments after the type to construct a value of the type}}
+  // expected-note@-3 {{use '.self' to reference the type object}}
+}

--- a/test/SourceKit/Sema/sema_module.swift
+++ b/test/SourceKit/Sema/sema_module.swift
@@ -3,4 +3,4 @@ Swift.String
 Swift
 // CHECK: key.kind: source.lang.swift.ref.struct,
 // CHECK: key.severity: source.diagnostic.severity.error,
-// CHECK-NEXT: key.description: "expected module member name after module name",
+// CHECK-NEXT: key.description: "expected member name or constructor call after type name",

--- a/test/decl/typealias/generic.swift
+++ b/test/decl/typealias/generic.swift
@@ -224,6 +224,15 @@ let _: ConcreteStruct.O<Int> = ConcreteStruct.O(123)
 let _: ConcreteStruct.O<Int> = ConcreteStruct.O<Int>(123)
 
 // Qualified lookup of generic typealiases nested inside generic contexts
+//
+// FIXME marks cases which still don't work correctly, and either produce a
+// spurious diagnostic, or are actually invalid and do not diagnose.
+//
+// This occurs because the constraint solver does the wrong thing with an
+// UnresolvedSpecializeExpr applied to a generic typealias.
+//
+// In the other cases, we manage to fold the UnresolvedSpecializeExpr in the
+// precheckExpression() phase, which handles generic typealiases correctly.
 
 let _ = GenericClass.TA<Float>(a: 4.0, b: 1) // FIXME
 let _ = GenericClass.TA<Float>(a: 1, b: 4.0)
@@ -231,8 +240,8 @@ let _ = GenericClass.TA<Float>(a: 1, b: 4.0)
 let _ = GenericClass<Int>.TA(a: 4.0, b: 1) // expected-error {{'Double' is not convertible to 'Int'}}
 let _ = GenericClass<Int>.TA(a: 1, b: 4.0)
 
-let _ = GenericClass<Int>.TA<Float>(a: 4.0, b: 1) // expected-error {{'Int' is not convertible to 'Float'}}
-let _ = GenericClass<Int>.TA<Float>(a: 1, b: 4.0) // FIXME // expected-error {{'Int' is not convertible to 'Float'}}
+let _ = GenericClass<Int>.TA<Float>(a: 4.0, b: 1) // expected-error {{'Double' is not convertible to 'Int'}}
+let _ = GenericClass<Int>.TA<Float>(a: 1, b: 4.0)
 
 let _: GenericClass.TA = GenericClass.TA(a: 4.0, b: 1)
 let _: GenericClass.TA = GenericClass.TA(a: 1, b: 4.0)
@@ -243,8 +252,8 @@ let _: GenericClass.TA = GenericClass.TA<Float>(a: 1, b: 4.0)
 let _: GenericClass.TA = GenericClass<Int>.TA(a: 4.0, b: 1) // expected-error {{'Double' is not convertible to 'Int'}}
 let _: GenericClass.TA = GenericClass<Int>.TA(a: 1, b: 4.0)
 
-let _: GenericClass.TA = GenericClass<Int>.TA<Float>(a: 4.0, b: 1) // expected-error {{'Int' is not convertible to 'Float'}}
-let _: GenericClass.TA = GenericClass<Int>.TA<Float>(a: 1, b: 4.0) // FIXME // expected-error {{'Int' is not convertible to 'Float'}}
+let _: GenericClass.TA = GenericClass<Int>.TA<Float>(a: 4.0, b: 1) // expected-error {{'Double' is not convertible to 'Int'}}
+let _: GenericClass.TA = GenericClass<Int>.TA<Float>(a: 1, b: 4.0)
 
 let _: GenericClass<Int>.TA = GenericClass.TA(a: 4.0, b: 1) // expected-error {{cannot convert value of type 'MyType<Double, Int>' to specified type 'GenericClass<Int>.TA'}}
 let _: GenericClass<Int>.TA = GenericClass.TA(a: 1, b: 4.0)
@@ -255,8 +264,8 @@ let _: GenericClass<Int>.TA = GenericClass.TA<Float>(a: 1, b: 4.0) // FIXME // e
 let _: GenericClass<Int>.TA = GenericClass<Int>.TA(a: 4.0, b: 1) // expected-error {{'Double' is not convertible to 'Int'}}
 let _: GenericClass<Int>.TA = GenericClass<Int>.TA(a: 1, b: 4.0)
 
-let _: GenericClass<Int>.TA = GenericClass<Int>.TA<Float>(a: 4.0, b: 1) // expected-error {{'Int' is not convertible to 'Float'}}
-let _: GenericClass<Int>.TA = GenericClass<Int>.TA<Float>(a: 1, b: 4.0) // FIXME // expected-error {{'Int' is not convertible to 'Float'}}
+let _: GenericClass<Int>.TA = GenericClass<Int>.TA<Float>(a: 4.0, b: 1) // expected-error {{'Double' is not convertible to 'Int'}}
+let _: GenericClass<Int>.TA = GenericClass<Int>.TA<Float>(a: 1, b: 4.0)
 
 let _: GenericClass<Int>.TA<Float> = GenericClass.TA(a: 4.0, b: 1) // expected-error {{cannot convert value of type 'MyType<Double, Int>' to specified type 'MyType<Int, Float>'}}
 let _: GenericClass<Int>.TA<Float> = GenericClass.TA(a: 1, b: 4.0)
@@ -267,8 +276,8 @@ let _: GenericClass<Int>.TA<Float> = GenericClass.TA<Float>(a: 1, b: 4.0) // FIX
 let _: GenericClass<Int>.TA<Float> = GenericClass<Int>.TA(a: 4.0, b: 1) // expected-error {{'Double' is not convertible to 'Int'}}
 let _: GenericClass<Int>.TA<Float> = GenericClass<Int>.TA(a: 1, b: 4.0)
 
-let _: GenericClass<Int>.TA<Float> = GenericClass<Int>.TA<Float>(a: 4.0, b: 1) // expected-error {{'Int' is not convertible to 'Float'}}
-let _: GenericClass<Int>.TA<Float> = GenericClass<Int>.TA<Float>(a: 1, b: 4.0) // FIXME // expected-error {{'Int' is not convertible to 'Float'}}
+let _: GenericClass<Int>.TA<Float> = GenericClass<Int>.TA<Float>(a: 4.0, b: 1) // expected-error {{'Double' is not convertible to 'Int'}}
+let _: GenericClass<Int>.TA<Float> = GenericClass<Int>.TA<Float>(a: 1, b: 4.0)
 
 func takesUnsugaredType2(m: MyType<Int, Float>) {}
 func takesSugaredType2(m: GenericClass<Int>.TA<Float>) {

--- a/test/decl/typealias/generic.swift
+++ b/test/decl/typealias/generic.swift
@@ -228,7 +228,7 @@ let _: ConcreteStruct.O<Int> = ConcreteStruct.O<Int>(123)
 let _ = GenericClass.TA<Float>(a: 4.0, b: 1) // FIXME
 let _ = GenericClass.TA<Float>(a: 1, b: 4.0)
 
-let _ = GenericClass<Int>.TA(a: 4.0, b: 1) // expected-error {{cannot invoke value of type 'MyType<Int, _>.Type' with argument list '(a: Double, b: Int)'}}
+let _ = GenericClass<Int>.TA(a: 4.0, b: 1) // expected-error {{'Double' is not convertible to 'Int'}}
 let _ = GenericClass<Int>.TA(a: 1, b: 4.0)
 
 let _ = GenericClass<Int>.TA<Float>(a: 4.0, b: 1) // expected-error {{'Int' is not convertible to 'Float'}}
@@ -240,31 +240,31 @@ let _: GenericClass.TA = GenericClass.TA(a: 1, b: 4.0)
 let _: GenericClass.TA = GenericClass.TA<Float>(a: 4.0, b: 1) // FIXME
 let _: GenericClass.TA = GenericClass.TA<Float>(a: 1, b: 4.0)
 
-let _: GenericClass.TA = GenericClass<Int>.TA(a: 4.0, b: 1) // expected-error {{cannot invoke value of type 'MyType<Int, _>.Type' with argument list '(a: Double, b: Int)'}}
+let _: GenericClass.TA = GenericClass<Int>.TA(a: 4.0, b: 1) // expected-error {{'Double' is not convertible to 'Int'}}
 let _: GenericClass.TA = GenericClass<Int>.TA(a: 1, b: 4.0)
 
 let _: GenericClass.TA = GenericClass<Int>.TA<Float>(a: 4.0, b: 1) // expected-error {{'Int' is not convertible to 'Float'}}
 let _: GenericClass.TA = GenericClass<Int>.TA<Float>(a: 1, b: 4.0) // FIXME // expected-error {{'Int' is not convertible to 'Float'}}
 
-let _: GenericClass<Int>.TA = GenericClass.TA(a: 4.0, b: 1) // expected-error {{cannot invoke value of type 'MyType<_, _>.Type' with argument list '(a: Double, b: Int)'}}
+let _: GenericClass<Int>.TA = GenericClass.TA(a: 4.0, b: 1) // expected-error {{cannot convert value of type 'MyType<Double, Int>' to specified type 'GenericClass<Int>.TA'}}
 let _: GenericClass<Int>.TA = GenericClass.TA(a: 1, b: 4.0)
 
-let _: GenericClass<Int>.TA = GenericClass.TA<Float>(a: 4.0, b: 1) // expected-error {{cannot invoke value of type 'MyType<Float, _>.Type' with argument list '(a: Double, b: Int)'}}
-let _: GenericClass<Int>.TA = GenericClass.TA<Float>(a: 1, b: 4.0) // FIXME // expected-error {{cannot invoke value of type 'MyType<Float, _>.Type' with argument list '(a: Int, b: Double)'}}
+let _: GenericClass<Int>.TA = GenericClass.TA<Float>(a: 4.0, b: 1) // expected-error {{cannot convert value of type 'MyType<Float, Int>' to specified type 'GenericClass<Int>.TA'}}
+let _: GenericClass<Int>.TA = GenericClass.TA<Float>(a: 1, b: 4.0) // FIXME // expected-error {{cannot convert value of type 'MyType<Float, Double>' to specified type 'GenericClass<Int>.TA'}}
 
-let _: GenericClass<Int>.TA = GenericClass<Int>.TA(a: 4.0, b: 1) // expected-error {{cannot invoke value of type 'MyType<Int, _>.Type' with argument list '(a: Double, b: Int)'}}
+let _: GenericClass<Int>.TA = GenericClass<Int>.TA(a: 4.0, b: 1) // expected-error {{'Double' is not convertible to 'Int'}}
 let _: GenericClass<Int>.TA = GenericClass<Int>.TA(a: 1, b: 4.0)
 
 let _: GenericClass<Int>.TA = GenericClass<Int>.TA<Float>(a: 4.0, b: 1) // expected-error {{'Int' is not convertible to 'Float'}}
 let _: GenericClass<Int>.TA = GenericClass<Int>.TA<Float>(a: 1, b: 4.0) // FIXME // expected-error {{'Int' is not convertible to 'Float'}}
 
-let _: GenericClass<Int>.TA<Float> = GenericClass.TA(a: 4.0, b: 1) // expected-error {{cannot invoke value of type 'MyType<_, _>.Type' with argument list '(a: Double, b: Int)'}}
+let _: GenericClass<Int>.TA<Float> = GenericClass.TA(a: 4.0, b: 1) // expected-error {{cannot convert value of type 'MyType<Double, Int>' to specified type 'MyType<Int, Float>'}}
 let _: GenericClass<Int>.TA<Float> = GenericClass.TA(a: 1, b: 4.0)
 
-let _: GenericClass<Int>.TA<Float> = GenericClass.TA<Float>(a: 4.0, b: 1) // expected-error {{cannot invoke value of type 'MyType<Float, _>.Type' with argument list '(a: Double, b: Int)'}}
-let _: GenericClass<Int>.TA<Float> = GenericClass.TA<Float>(a: 1, b: 4.0) // FIXME // expected-error {{cannot invoke value of type 'MyType<Float, _>.Type' with argument list '(a: Int, b: Double)'}}
+let _: GenericClass<Int>.TA<Float> = GenericClass.TA<Float>(a: 4.0, b: 1) // expected-error {{cannot convert value of type 'MyType<Float, Int>' to specified type 'MyType<Int, Float>'}}
+let _: GenericClass<Int>.TA<Float> = GenericClass.TA<Float>(a: 1, b: 4.0) // FIXME // expected-error {{cannot convert value of type 'MyType<Float, Double>' to specified type 'MyType<Int, Float>'}}
 
-let _: GenericClass<Int>.TA<Float> = GenericClass<Int>.TA(a: 4.0, b: 1) // expected-error {{cannot invoke value of type 'MyType<Int, _>.Type' with argument list '(a: Double, b: Int)'}}
+let _: GenericClass<Int>.TA<Float> = GenericClass<Int>.TA(a: 4.0, b: 1) // expected-error {{'Double' is not convertible to 'Int'}}
 let _: GenericClass<Int>.TA<Float> = GenericClass<Int>.TA(a: 1, b: 4.0)
 
 let _: GenericClass<Int>.TA<Float> = GenericClass<Int>.TA<Float>(a: 4.0, b: 1) // expected-error {{'Int' is not convertible to 'Float'}}

--- a/test/type/array.swift
+++ b/test/type/array.swift
@@ -47,11 +47,27 @@ typealias FixIt0 = Int[] // expected-error{{array types are now written with the
 class Outer {
   class Middle {
     class Inner {}
+    class GenericInner<V> {}
+
     typealias Alias = Inner
+  }
+
+  class GenericMiddle<U> {
+    class Inner {}
   }
 
   typealias Alias = Middle
 }
+
+class GenericOuter<T> {
+  class Middle {
+    class Inner {}
+  }
+}
+
+func takesMiddle(_: [Outer.Middle]) {}
+
+takesMiddle([Outer.Middle]())
 
 func takesInner(_: [Outer.Middle.Inner]) {}
 
@@ -64,6 +80,29 @@ takesInner([array.Outer.Middle.Inner]())
 takesInner([array.Outer.Alias.Inner]())
 takesInner([array.Outer.Middle.Alias]())
 takesInner([array.Outer.Alias.Alias]())
+
+func takesMiddle(_: [GenericOuter<Int>.Middle]) {}
+
+takesMiddle([GenericOuter<Int>.Middle]())
+
+func takesInner(_: [GenericOuter<Int>.Middle.Inner]) {}
+
+takesInner([GenericOuter<Int>.Middle.Inner]())
+takesInner([array.GenericOuter<Int>.Middle.Inner]())
+
+func takesMiddle(_: [Outer.GenericMiddle<Int>]) {}
+
+takesMiddle([Outer.GenericMiddle<Int>]())
+
+func takesInner(_: [Outer.GenericMiddle<Int>.Inner]) {}
+
+takesInner([Outer.GenericMiddle<Int>.Inner]())
+takesInner([array.Outer.GenericMiddle<Int>.Inner]())
+
+func takesInner(_: [Outer.Middle.GenericInner<Int>]) {}
+
+takesInner([Outer.Middle.GenericInner<Int>]())
+takesInner([array.Outer.Middle.GenericInner<Int>]())
 
 // FIXME: We should support this with nested types of generic parameters also
 protocol HasAssocType {

--- a/test/type/protocol_composition.swift
+++ b/test/type/protocol_composition.swift
@@ -168,8 +168,8 @@ func f3124_2<U : protocol<P1>>(x: U)  {} // expected-warning {{'protocol<...>' c
 func takesP1AndP2(_: [AnyObject & P1 & P2]) {}
 
 takesP1AndP2([AnyObject & P1 & P2]())
-// takesP1AndP2([Swift.AnyObject & P1 & P2]()) // FIXME
-// takesP1AndP2([AnyObject & protocol_composition.P1 & P2]()) // FIXME
-// takesP1AndP2([AnyObject & P1 & protocol_composition.P2]()) // FIXME
+takesP1AndP2([Swift.AnyObject & P1 & P2]())
+takesP1AndP2([AnyObject & protocol_composition.P1 & P2]())
+takesP1AndP2([AnyObject & P1 & protocol_composition.P2]())
 takesP1AndP2([DoesNotExist & P1 & P2]()) // expected-error {{use of unresolved identifier 'DoesNotExist'}}
 takesP1AndP2([Swift.DoesNotExist & P1 & P2]()) // expected-error {{module 'Swift' has no member named 'DoesNotExist'}}


### PR DESCRIPTION
The parser doesn't know if a dot expression references a member or a type. This creates an ambiguity with array literals and some other cases. We resolve these ambiguities with a pre-check pass which attempts to fold certain expressions to types.

This now works better. Examples that did not work before:

```
_ = [A.B]()
_ = [Outer<Int>.Inner<String>]()
_ = [SomeClass<Int> & MyProto]()
```

Also, patch up a few cases in Swift 3 mode where '.self' was previously not required to emit a warning, for example:

```
_ = Swift.Int
foo(Swift.Int, 0)
```

In Swift 4 mode, omission of '.self' is now an error in these cases. Unfortunately there are still some holes in the '.self' check.

There is a fair bit of refactoring here; see the individual commit messages for details. Basically the code paths for type lookup in expression context and type lookup in type context each had their own quirks; I attempted to reconcile the differences and unify the implementations more while maintaining compatibility with old behaviors.

Fixes <rdar://problem/16849958> and <https://bugs.swift.org/browse/SR-349>.