### PR TITLE
[WIP] [QoI] Add checking for direct subscript reference in ExprRewriter

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -58,6 +58,8 @@ ERROR(ambiguous_subscript,none,
 ERROR(type_not_subscriptable,none,
       "type %0 has no subscript members",
       (Type))
+ERROR(use_brace_notation_for_subscript,none,
+      "brace notation is required when refering to subscript", ())
 
 ERROR(could_not_find_tuple_member,none,
       "value of tuple type %0 has no member %1", (Type, DeclName))

--- a/test/Constraints/subscript.swift
+++ b/test/Constraints/subscript.swift
@@ -106,3 +106,15 @@ class C_r25601561 {
     return s
   }
 }
+
+class B_27017206 {
+  subscript(_ keyword: String) -> [B_27017206] {
+    return []
+  }
+}
+class D_27017206 : B_27017206 {
+  func foo() {
+    self.subscript("bar")
+    // expected-error@-1 {{brace notation is required when refering to subscript}}
+  }
+}


### PR DESCRIPTION
Some of the correctly typed expressions involving direct call to
subscript make it past type-checker because (currently) there is
no difference between subscript call and `subscript` member reference
for type-checker point of view. This results in SIL crashes, let's
prevent it by putting additional check into ExprRewriter.

Resolves: rdar://problem/27017206

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
