### PR TITLE
[swiftc (34 vs. 5527)] Add crasher in swift::ProtocolDecl::findProtocolSelfReferences

### DIFF
--- a/validation-test/compiler_crashers/28752-hasinterfacetype-no-interface-type-was-set.swift
+++ b/validation-test/compiler_crashers/28752-hasinterfacetype-no-interface-type-was-set.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+@objc protocol P{typealias e:P{}var a}{}extension P{typealias e:P


### PR DESCRIPTION
Add test case for crash triggered in `swift::ProtocolDecl::findProtocolSelfReferences`.

Current number of unresolved compiler crashers: 34 (5527 resolved)

/cc @slavapestov - just wanted to let you know that this crasher caused an assertion failure for the assertion `hasInterfaceType() && "No interface type was set"` added on 2016-12-04 by you in commit c1a21613 :-)

Assertion failure in [`lib/AST/Decl.cpp (line 1787)`](https://github.com/apple/swift/blob/69d69c723b8faa55021630a087d62e19d37afac8/lib/AST/Decl.cpp#L1787):

```
Assertion `hasInterfaceType() && "No interface type was set"' failed.

When executing: swift::Type swift::ValueDecl::getInterfaceType() const
```

Assertion context:

```c++
bool ValueDecl::hasInterfaceType() const {
  return !TypeAndAccess.getPointer().isNull();
}

Type ValueDecl::getInterfaceType() const {
  assert(hasInterfaceType() && "No interface type was set");
  return TypeAndAccess.getPointer();
}

void ValueDecl::setInterfaceType(Type type) {
  // lldb creates global typealiases with archetypes in them.
```
Stack trace:

```
0 0x0000000003a4f3e8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3a4f3e8)
1 0x0000000003a4fb26 SignalHandler(int) (/path/to/swift/bin/swift+0x3a4fb26)
2 0x00007fafb7e37390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007fafb635d428 gsignal /build/glibc-9tT8Do/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007fafb635f02a abort /build/glibc-9tT8Do/glibc-2.23/stdlib/abort.c:91:0
5 0x00007fafb6355bd7 __assert_fail_base /build/glibc-9tT8Do/glibc-2.23/assert/assert.c:92:0
6 0x00007fafb6355c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x0000000001524035 swift::ProtocolDecl::findProtocolSelfReferences(swift::ValueDecl const*, bool, bool) const (/path/to/swift/bin/swift+0x1524035)
8 0x00000000015245ad swift::ProtocolDecl::existentialTypeSupportedSlow(swift::LazyResolver*) (/path/to/swift/bin/swift+0x15245ad)
9 0x0000000001579ae0 swift::ModuleDecl::lookupConformance(swift::Type, swift::ProtocolDecl*, swift::LazyResolver*) (/path/to/swift/bin/swift+0x1579ae0)
10 0x0000000001372cae swift::TypeChecker::conformsToProtocol(swift::Type, swift::ProtocolDecl*, swift::DeclContext*, swift::OptionSet<swift::ConformanceCheckFlags, unsigned int>, swift::SourceLoc) (/path/to/swift/bin/swift+0x1372cae)
11 0x0000000001373a6a swift::TypeChecker::LookUpConformance::operator()(swift::CanType, swift::Type, swift::ProtocolType*) const (/path/to/swift/bin/swift+0x1373a6a)
12 0x00000000013671a2 std::_Function_handler<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*), swift::TypeChecker::LookUpConformance>::_M_invoke(std::_Any_data const&, swift::CanType&&, swift::Type&&, swift::ProtocolType*&&) (/path/to/swift/bin/swift+0x13671a2)
13 0x000000000155a551 swift::GenericSignatureBuilder::addSameTypeRequirementToConcrete(swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type, swift::GenericSignatureBuilder::RequirementSource const*) (/path/to/swift/bin/swift+0x155a551)
14 0x0000000001559f7c swift::GenericSignatureBuilder::addSameTypeRequirement(llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::FloatingRequirementSource, swift::GenericSignatureBuilder::UnresolvedHandlingKind, llvm::function_ref<void (swift::Type, swift::Type)>) (/path/to/swift/bin/swift+0x1559f7c)
15 0x0000000001550ce4 swift::GenericSignatureBuilder::PotentialArchetype::updateNestedTypeForConformance(llvm::PointerUnion<swift::AssociatedTypeDecl*, swift::TypeAliasDecl*>, swift::GenericSignatureBuilder::PotentialArchetype::NestedTypeUpdate) (/path/to/swift/bin/swift+0x1550ce4)
16 0x000000000154f8f0 swift::GenericSignatureBuilder::PotentialArchetype::getNestedArchetypeAnchor(swift::Identifier, swift::GenericSignatureBuilder&, swift::GenericSignatureBuilder::PotentialArchetype::NestedTypeUpdate) (/path/to/swift/bin/swift+0x154f8f0)
17 0x000000000155e4ac swift::GenericSignatureBuilder::checkSameTypeConstraints(llvm::ArrayRef<swift::GenericTypeParamType*>, swift::GenericSignatureBuilder::PotentialArchetype*) (/path/to/swift/bin/swift+0x155e4ac)
18 0x000000000155b690 swift::GenericSignatureBuilder::finalize(swift::SourceLoc, llvm::ArrayRef<swift::GenericTypeParamType*>, bool) (/path/to/swift/bin/swift+0x155b690)
19 0x0000000001365d09 swift::TypeChecker::checkGenericEnvironment(swift::GenericParamList*, swift::DeclContext*, swift::GenericSignature*, bool, llvm::function_ref<void (swift::GenericSignatureBuilder&)>) (/path/to/swift/bin/swift+0x1365d09)
20 0x00000000013660f9 swift::TypeChecker::validateGenericTypeSignature(swift::GenericTypeDecl*) (/path/to/swift/bin/swift+0x13660f9)
21 0x0000000001336bc2 swift::TypeChecker::validateDecl(swift::ValueDecl*) (/path/to/swift/bin/swift+0x1336bc2)
22 0x00000000013466e3 (anonymous namespace)::DeclChecker::visitProtocolDecl(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0x13466e3)
23 0x0000000001334e34 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x1334e34)
24 0x0000000001334d43 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x1334d43)
25 0x00000000013beae5 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x13beae5)
26 0x0000000000f885f6 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf885f6)
27 0x00000000004aaac0 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4aaac0)
28 0x00000000004a90eb swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a90eb)
29 0x00000000004656d7 main (/path/to/swift/bin/swift+0x4656d7)
30 0x00007fafb6348830 __libc_start_main /build/glibc-9tT8Do/glibc-2.23/csu/../csu/libc-start.c:325:0
31 0x0000000000462d79 _start (/path/to/swift/bin/swift+0x462d79)
```