### PR TITLE
[swiftc (35 vs. 5527)] Add crasher in swift::GenericSignature::getConformanceAccessPath

### DIFF
--- a/validation-test/compiler_crashers/28753-conforms-equivclass-conformsto-end.swift
+++ b/validation-test/compiler_crashers/28753-conforms-equivclass-conformsto-end.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol A:A{{}class a{let ca{a{


### PR DESCRIPTION
Add test case for crash triggered in `swift::GenericSignature::getConformanceAccessPath`.

Current number of unresolved compiler crashers: 35 (5527 resolved)

/cc @DougGregor - just wanted to let you know that this crasher caused an assertion failure for the assertion `conforms != equivClass->conformsTo.end()` added on 2017-03-06 by you in commit eaee4add :-)

Assertion failure in [`lib/AST/GenericSignature.cpp (line 882)`](https://github.com/apple/swift/blob/4ebd7163cb82ad6f3d0a9885d6c07e3af442ca8e/lib/AST/GenericSignature.cpp#L882):

```
Assertion `conforms != equivClass->conformsTo.end()' failed.

When executing: auto swift::GenericSignature::getConformanceAccessPath(swift::Type, swift::ProtocolDecl *, swift::ModuleDecl &)::(anonymous class)::operator()(swift::GenericSignature *, const RequirementSource *, swift::ProtocolDecl *, swift::Type) const
```

Assertion context:

```c++
      auto equivClass = pa->getOrCreateEquivalenceClass();

      // Find the conformance of this potential archetype to the protocol in
      // question.
      auto conforms = equivClass->conformsTo.find(conformingProto);
      assert(conforms != equivClass->conformsTo.end());

      // Compute the root type, canonicalizing it w.r.t. the protocol context.
      auto inProtoSig = inProtocol->getGenericSignature();
      auto conformsSource = getBestRequirementSource(conforms->second);
      Type localRootType = conformsSource->getRootPotentialArchetype()
```
Stack trace:

```
0 0x0000000003a4f3e8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3a4f3e8)
1 0x0000000003a4fb26 SignalHandler(int) (/path/to/swift/bin/swift+0x3a4fb26)
2 0x00007fa5cfe28390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007fa5ce34e428 gsignal /build/glibc-9tT8Do/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007fa5ce35002a abort /build/glibc-9tT8Do/glibc-2.23/stdlib/abort.c:91:0
5 0x00007fa5ce346bd7 __assert_fail_base /build/glibc-9tT8Do/glibc-2.23/assert/assert.c:92:0
6 0x00007fa5ce346c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x00000000015488c0 std::_Function_handler<void (swift::GenericSignature*, swift::GenericSignatureBuilder::RequirementSource const*, swift::ProtocolDecl*, swift::Type), swift::GenericSignature::getConformanceAccessPath(swift::Type, swift::ProtocolDecl*, swift::ModuleDecl&)::$_11>::_M_invoke(std::_Any_data const&, swift::GenericSignature*&&, swift::GenericSignatureBuilder::RequirementSource const*&&, swift::ProtocolDecl*&&, swift::Type&&) (/path/to/swift/bin/swift+0x15488c0)
8 0x0000000001547579 swift::GenericSignature::getConformanceAccessPath(swift::Type, swift::ProtocolDecl*, swift::ModuleDecl&) (/path/to/swift/bin/swift+0x1547579)
9 0x000000000159eb95 swift::SubstitutionMap::lookupConformance(swift::CanType, swift::ProtocolDecl*) const (/path/to/swift/bin/swift+0x159eb95)
10 0x0000000001547f9e bool llvm::function_ref<bool (swift::Type, llvm::ArrayRef<swift::Requirement>)>::callback_fn<swift::GenericSignature::getSubstitutions(swift::SubstitutionMap const&, llvm::SmallVectorImpl<swift::Substitution>&) const::$_8>(long, swift::Type, llvm::ArrayRef<swift::Requirement>) (/path/to/swift/bin/swift+0x1547f9e)
11 0x0000000001544e37 swift::GenericSignature::enumeratePairedRequirements(llvm::function_ref<bool (swift::Type, llvm::ArrayRef<swift::Requirement>)>) const (/path/to/swift/bin/swift+0x1544e37)
12 0x00000000015463a2 swift::GenericSignature::getSubstitutions(swift::SubstitutionMap const&, llvm::SmallVectorImpl<swift::Substitution>&) const (/path/to/swift/bin/swift+0x15463a2)
13 0x0000000001543b70 swift::GenericEnvironment::getForwardingSubstitutions() const (/path/to/swift/bin/swift+0x1543b70)
14 0x00000000013fd06f (anonymous namespace)::UncurriedCandidate::UncurriedCandidate(swift::ValueDecl*, unsigned int) (/path/to/swift/bin/swift+0x13fd06f)
15 0x000000000140cc10 (anonymous namespace)::CalleeCandidateInfo::collectCalleeCandidates(swift::Expr*, bool) (/path/to/swift/bin/swift+0x140cc10)
16 0x0000000001409632 (anonymous namespace)::FailureDiagnosis::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0x1409632)
17 0x00000000013ee52d swift::ASTVisitor<(anonymous namespace)::FailureDiagnosis, bool, void, void, void, void, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x13ee52d)
18 0x00000000013e7f4b swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) (/path/to/swift/bin/swift+0x13e7f4b)
19 0x00000000013ede82 swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) (/path/to/swift/bin/swift+0x13ede82)
20 0x000000000131aa48 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0x131aa48)
21 0x000000000131e466 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x131e466)
22 0x00000000013a1945 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13a1945)
23 0x000000000139fbdd swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) (/path/to/swift/bin/swift+0x139fbdd)
24 0x000000000139fa4d swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) (/path/to/swift/bin/swift+0x139fa4d)
25 0x00000000013a079d swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0x13a079d)
26 0x00000000013bdd08 typeCheckFunctionsAndExternalDecls(swift::TypeChecker&) (/path/to/swift/bin/swift+0x13bdd08)
27 0x00000000013bebe8 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x13bebe8)
28 0x0000000000f885f6 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf885f6)
29 0x00000000004aaac0 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4aaac0)
30 0x00000000004a90eb swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a90eb)
31 0x00000000004656d7 main (/path/to/swift/bin/swift+0x4656d7)
32 0x00007fa5ce339830 __libc_start_main /build/glibc-9tT8Do/glibc-2.23/csu/../csu/libc-start.c:325:0
33 0x0000000000462d79 _start (/path/to/swift/bin/swift+0x462d79)
```