### PR TITLE
IRGen: Fix Objective-C class allocation path

### DIFF
--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -714,12 +714,7 @@ llvm::Value *irgen::emitClassAllocation(IRGenFunction &IGF, SILType selfType,
       emitClassHeapMetadataRef(IGF, classType, MetadataValueType::ObjCClass,
                                /*allow uninitialized*/ true);
     StackAllocSize = -1;
-    auto &ti = IGF.getTypeInfo(selfType);
-    assert(ti.getSchema().size() == 1);
-    assert(!ti.getSchema().containsAggregate());
-    auto destType = ti.getSchema()[0].getScalarType();
-    auto *val = emitObjCAllocObjectCall(IGF, metadata, selfType.getSwiftRValueType());
-    return IGF.Builder.CreateBitCast(val, destType);
+    return emitObjCAllocObjectCall(IGF, metadata, selfType);
   }
 
   llvm::Value *metadata =
@@ -755,8 +750,7 @@ llvm::Value *irgen::emitClassAllocationDynamic(IRGenFunction &IGF,
                                                TailArraysRef TailArrays) {
   // If we need to use Objective-C allocation, do so.
   if (objc) {
-    return emitObjCAllocObjectCall(IGF, metadata, 
-                                   selfType.getSwiftRValueType());
+    return emitObjCAllocObjectCall(IGF, metadata, selfType);
   }
 
   // Otherwise, allocate using Swift's routines.

--- a/lib/IRGen/GenObjC.cpp
+++ b/lib/IRGen/GenObjC.cpp
@@ -752,7 +752,7 @@ void irgen::addObjCMethodCallImplicitArguments(IRGenFunction &IGF,
 /// Call [self allocWithZone: nil].
 llvm::Value *irgen::emitObjCAllocObjectCall(IRGenFunction &IGF,
                                             llvm::Value *self,
-                                            CanType classType) {
+                                            SILType selfType) {
   // Get an appropriately-cast function pointer.
   auto fn = IGF.IGM.getObjCAllocWithZoneFn();
 
@@ -763,7 +763,11 @@ llvm::Value *irgen::emitObjCAllocObjectCall(IRGenFunction &IGF,
   }
   
   auto call = IGF.Builder.CreateCall(fn, self);
-  return call;
+
+  // Cast the returned pointer to the right type.
+  auto &classTI = IGF.getTypeInfo(selfType);
+  llvm::Type *destType = classTI.getStorageType();
+  return IGF.Builder.CreateBitCast(call, destType);
 }
 
 static llvm::Function *emitObjCPartialApplicationForwarder(IRGenModule &IGM,

--- a/lib/IRGen/GenObjC.h
+++ b/lib/IRGen/GenObjC.h
@@ -224,7 +224,7 @@ namespace irgen {
   /// Allocate an Objective-C object.
   llvm::Value *emitObjCAllocObjectCall(IRGenFunction &IGF,
                                        llvm::Value *classPtr,
-                                       CanType resultType);
+                                       SILType resultType);
 
 } // end namespace irgen
 } // end namespace swift

--- a/test/IRGen/objc_alloc.sil
+++ b/test/IRGen/objc_alloc.sil
@@ -42,3 +42,33 @@ bb3(%3 : $Gizmo):
   return %6 : $()
 }
 
+// CHECK-LABEL: define {{.*}} @class_test
+// CHECK:  [[ALLOC1:%.*]] = call %objc_object* @objc_allocWithZone
+// CHECK:  [[CAST1:%.*]] = bitcast %objc_object* [[ALLOC1]] to [[KLASS:%.*]]*
+// CHECK:  br
+
+// CHECK:  [[ALLOC2:%.*]] = call %objc_object* @objc_allocWithZone
+// CHECK:  [[CAST2:%.*]] = bitcast %objc_object* [[ALLOC2]] to [[KLASS]]*
+// CHECK:  br
+
+// CHECK:  phi [[KLASS]]* [ [[CAST2]], %{{.*}} ], [ [[CAST1]], %{{.*}} ]
+// CHECK:  ret
+
+
+sil @class_test : $@convention(thin) (@owned Optional<Int>, @thick Gizmo.Type) -> () {
+bb0(%0 : $Optional<Int>, %1:  $@thick Gizmo.Type):
+  %4 = thick_to_objc_metatype %1 : $@thick Gizmo.Type to $@objc_metatype Gizmo.Type
+  switch_enum %0 : $Optional<Int>, case #Optional.none!enumelt: bb1, case #Optional.some!enumelt.1: bb2
+
+bb1:
+  %5 = alloc_ref_dynamic [objc] %4 : $@objc_metatype Gizmo.Type, $Gizmo
+  br bb3(%5 : $Gizmo)
+
+bb2:
+  %2 = alloc_ref_dynamic [objc] %4 : $@objc_metatype Gizmo.Type, $Gizmo
+  br bb3(%2 : $Gizmo)
+
+bb3(%3 : $Gizmo):
+  %6 = tuple ()
+  return %6 : $()
+}


### PR DESCRIPTION
We need to cast the returned pointer to the class type. Heed John's advice and
sink the bitcast into the allocation function.

rdar://32264626