### PR TITLE
benchmarks: only search in benchmark source directories in generate_harness

### DIFF
--- a/utils/gyb_benchmark_support.py
+++ b/utils/gyb_benchmark_support.py
@@ -52,7 +52,8 @@ def get_run_funcs(filepath):
 
 
 def find_run_funcs():
-    swift_files = all_files(perf_dir, '.swift')
+    swift_files = all_files(single_source_dir, '.swift')
+    swift_files += all_files(multi_source_dir, '.swift')
     return sorted([func for f in swift_files for func in get_run_funcs(f)])
 
 


### PR DESCRIPTION
rdar://problem/32272114
