### PR TITLE
Revert "[sil-inliner] Respect the @inline(__always) and @_transparent even if inlining of generics is disabled"

### DIFF
--- a/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
+++ b/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
@@ -365,6 +365,15 @@ static Optional<bool> shouldInlineGeneric(FullApplySite AI) {
   assert(!AI.getSubstitutions().empty() &&
          "Expected a generic apply");
 
+  if (!EnableSILInliningOfGenerics)
+    return false;
+
+  // If all substitutions are concrete, then there is no need to perform the
+  // generic inlining. Let the generic specializer create a specialized
+  // function and then decide if it is beneficial to inline it.
+  if (!hasArchetypes(AI.getSubstitutions()))
+    return false;
+
   SILFunction *Callee = AI.getReferencedFunction();
 
   // Do not inline @_semantics functions when compiling the stdlib,
@@ -384,17 +393,6 @@ static Optional<bool> shouldInlineGeneric(FullApplySite AI) {
   if (Callee->getInlineStrategy() == AlwaysInline || Callee->isTransparent())
     return true;
 
-  // All other generic functions should not be inlined if this kind of inlining
-  // is disabled.
-  if (!EnableSILInliningOfGenerics)
-    return false;
-
-  // If all substitutions are concrete, then there is no need to perform the
-  // generic inlining. Let the generic specializer create a specialized
-  // function and then decide if it is beneficial to inline it.
-  if (!hasArchetypes(AI.getSubstitutions()))
-    return false;
-
   // It is not clear yet if this function should be decided or not.
   return None;
 }
@@ -413,10 +411,10 @@ decideInWarmBlock(FullApplySite AI,
 
   SILFunction *Callee = AI.getReferencedFunction();
 
-  if (Callee->getInlineStrategy() == AlwaysInline || Callee->isTransparent()) {
+  if (Callee->getInlineStrategy() == AlwaysInline) {
     DEBUG(
       dumpCaller(AI.getFunction());
-      llvm::dbgs() << "    always-inline decision " << Callee->getName() << '\n';
+      llvm::dbgs() << "    always-inline decision " <<Callee->getName() << '\n';
     );
     return true;
   }
@@ -436,13 +434,8 @@ bool SILPerformanceInliner::decideInColdBlock(FullApplySite AI,
     return false;
   }
 
-  if (Callee->getInlineStrategy() == AlwaysInline || Callee->isTransparent()) {
-    DEBUG(
-      dumpCaller(AI.getFunction());
-      llvm::dbgs() << "    always-inline decision " << Callee->getName() << '\n';
-      );
+  if (Callee->getInlineStrategy() == AlwaysInline)
     return true;
-  }
 
   int CalleeCost = 0;
 

--- a/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
+++ b/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
@@ -678,10 +678,8 @@ SILFunction *swift::getEligibleFunction(FullApplySite AI,
   }
 
   if (!EnableSILInliningOfGenerics && AI.hasSubstitutions()) {
-    // Inlining of generics is not allowed unless it is an @inline(__always)
-    // or transparent function.
-    if (Callee->getInlineStrategy() != AlwaysInline && !Callee->isTransparent())
-      return nullptr;
+    // Inlining of generics is not allowed.
+    return nullptr;
   }
 
   // IRGen cannot handle partial_applies containing opened_existentials

--- a/test/SILGen/collection_cast_crash.swift
+++ b/test/SILGen/collection_cast_crash.swift
@@ -10,28 +10,28 @@ class KeyClass : Hashable {
 }
 func ==(lhs: KeyClass, rhs: KeyClass) -> Bool { return true }
 
-// CHECK-LABEL: sil shared @{{.*}}arrayUpCast{{.*}} <Ct where Ct : MyClass>
+// CHECK-LABEL: sil hidden @{{.*}}arrayUpCast{{.*}} <Ct where Ct : MyClass>
 func arrayUpCast<Ct: MyClass>(_ arr: [Ct]) -> [MyClass] {
   // CHECK: apply %{{[0-9]*}}<Ct, MyClass>(%{{[0-9]*}})
   return arr
   // CHECK: return	  
 }
 
-// CHECK-LABEL: sil shared @{{.*}}arrayDownCast{{.*}} <Ct where Ct : MyClass>
+// CHECK-LABEL: sil hidden @{{.*}}arrayDownCast{{.*}} <Ct where Ct : MyClass>
 func arrayDownCast<Ct: MyClass>(_ arr: [MyClass]) -> [Ct] {
   // CHECK: apply %{{[0-9]*}}<MyClass, Ct>(%{{[0-9]*}})
   return arr as! [Ct]
   // CHECK: return	  
 }
 
-// CHECK-LABEL: sil shared @{{.*}}dictUpCast{{.*}} <Ct where Ct : MyClass>
+// CHECK-LABEL: sil hidden @{{.*}}dictUpCast{{.*}} <Ct where Ct : MyClass>
 func dictUpCast<Ct: MyClass>(_ dict: [KeyClass:Ct]) -> [KeyClass:MyClass] {
   // CHECK: apply %{{[0-9]*}}<KeyClass, Ct, KeyClass, MyClass>(%{{[0-9]*}})
   return dict as [KeyClass:MyClass]
   // CHECK: return	  
 }
 
-// CHECK-LABEL: sil shared @{{.*}}dictDownCast{{.*}} <Ct where Ct : MyClass>
+// CHECK-LABEL: sil hidden @{{.*}}dictDownCast{{.*}} <Ct where Ct : MyClass>
 func dictDownCast<Ct: MyClass>(_ dict: [KeyClass:MyClass]) -> [KeyClass:Ct] {
   // CHECK: apply %{{[0-9]*}}<KeyClass, MyClass, KeyClass, Ct>(%{{[0-9]*}})
   return dict as! [KeyClass:Ct]

--- a/test/SILOptimizer/inline_generics.sil
+++ b/test/SILOptimizer/inline_generics.sil
@@ -1,5 +1,4 @@
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -inline -sil-inline-generics=true | %FileCheck %s
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -inline -sil-inline-generics=false | %FileCheck --check-prefix=DISABLED-GENERIC-INLINING-CHECK %s
 
 sil_stage canonical
 
@@ -112,68 +111,6 @@ bb0(%0 : $T, %1 : $@callee_owned (@owned P) -> Bool):
   %3 = apply %1(%2) : $@callee_owned (@owned P) -> Bool
   return %3 : $Bool
 } // end sil function 'thunk2'
-
-
-sil [always_inline] @alwaysInlineGenericCallee : $@convention(thin) <T> (@in T) -> @out T {
-bb0(%0 : $*T, %1 : $*T):
-  copy_addr [take] %1 to [initialization] %0 : $*T
-  %4 = tuple ()
-  return %4 : $()
-} // end sil function 'alwaysInlineGenericCallee'
-
-sil [transparent] @transparentGenericCallee : $@convention(thin) <T> (@in T) -> @out T {
-bb0(%0 : $*T, %1 : $*T):
-  copy_addr [take] %1 to [initialization] %0 : $*T
-  %4 = tuple ()
-  return %4 : $()
-} // end sil function 'transparentInlineGenericCallee'
-
-
-// Check that [always_inline] and [transparent] functions are inlined even if
-// inlining of generics is disabled. Regular generic functions should not be
-// inlined.
-// DISABLED-GENERIC-INLINING-CHECK-LABEL: sil @testComplexInliningOfGenerics
-// DISABLED-GENERIC-INLINING-CHECK-NOT: function_ref @{{.*}} 
-// DISABLED-GENERIC-INLINING-CHECK-NOT: apply 
-// DISABLED-GENERIC-INLINING-CHECK: [[FUNC:%[0-9]+]] = function_ref @genericFoo
-// DISABLED-GENERIC-INLINING-CHECK: apply [[FUNC]]
-// DISABLED-GENERIC-INLINING-CHECK-NOT: function_ref 
-// DISABLED-GENERIC-INLINING-CHECK-NOT: apply
-// DISABLED-GENERIC-INLINING-CHECK: end sil function 'testComplexInliningOfGenerics'
-
-// Check that all callees are inlined if inlining of generics is enabled.
-// CHECK-LABEL: sil @testComplexInliningOfGenerics
-// CHECK-NOT: apply
-// CHECK: end sil function 'testComplexInliningOfGenerics'
-sil @testComplexInliningOfGenerics : $@convention(thin) <T> (@in T) -> @out T {
-bb0(%0 : $*T, %1 : $*T):
-
-  // Call an [always_inline] function.
-  %3 = function_ref @alwaysInlineGenericCallee : $@convention(thin) <τ_0_0> (@in τ_0_0) -> @out τ_0_0
-  %4 = alloc_stack $T
-  copy_addr %1 to [initialization] %4 : $*T
-  %6 = apply %3<T>(%0, %4) : $@convention(thin) <τ_0_0> (@in τ_0_0) -> @out τ_0_0
-  dealloc_stack %4 : $*T
-
-  // Call a [transparent] function.
-  %8 = function_ref @transparentGenericCallee : $@convention(thin) <τ_0_0> (@in τ_0_0) -> @out τ_0_0
-  %9 = alloc_stack $T
-  copy_addr %1 to [initialization] %9 : $*T
-  %10 = apply %8<T>(%0, %9) : $@convention(thin) <τ_0_0> (@in τ_0_0) -> @out τ_0_0
-  dealloc_stack %9 : $*T
-
-  // Call a regular function.
-  // function_ref genericFoo<A> (A) -> A
-  %12 = function_ref @genericFoo : $@convention(thin) <τ_0_0> (@in τ_0_0) -> @out τ_0_0
-  %13 = alloc_stack $T
-  copy_addr %1 to [initialization] %13 : $*T
-  %15 = apply %12<T>(%0, %13) : $@convention(thin) <τ_0_0> (@in τ_0_0) -> @out τ_0_0
-  dealloc_stack %13 : $*T
-
-  destroy_addr %1 : $*T
-  %18 = tuple ()
-  return %18 : $()
-} // end sil function 'testComplexInliningOfGenerics'
 
 sil_default_witness_table P {
   no_default

--- a/test/SILOptimizer/performance_inliner.sil
+++ b/test/SILOptimizer/performance_inliner.sil
@@ -786,7 +786,7 @@ bb2:                                              // Preds: bb0 bb1
   return %16 : $()                                // id: %17
 }
 
-sil @slowHelper : $@convention(thin) () -> () {
+sil [transparent] @slowHelper : $@convention(thin) () -> () {
 bb0:
   // make it a non-trivial function
   %f = function_ref @unknown_function : $@convention(thin) () -> ()


### PR DESCRIPTION
Reverts apple/swift#9752
It seems to crash the CI bots