### PR TITLE
Resolve missing references generated by ldd

### DIFF
--- a/utils/symbolicate-linux-fatal
+++ b/utils/symbolicate-linux-fatal
@@ -25,6 +25,7 @@
 from __future__ import print_function
 
 import argparse
+import os
 import subprocess
 
 import lldb
@@ -34,8 +35,11 @@ def process_ldd(lddoutput):
     dyn_libs = {}
     for line in lddoutput.splitlines():
         ldd_tokens = line.split()
-        if len(ldd_tokens) >= 3:
-            dyn_libs[ldd_tokens[0]] = ldd_tokens[2]
+        if len(ldd_tokens) >= 2:
+            lib = ldd_tokens[-2]
+            dyn_libs[ldd_tokens[0]] = lib
+            real_name = os.path.basename(os.path.realpath(lib)) 
+            dyn_libs[real_name] = lib
     return dyn_libs
 
 


### PR DESCRIPTION
When ldd returns a list of libraries, the binary reflects the name
that the library is known at at link time. However, it may be a
symlink to a different filename on the system, which can confuse
generated tools that capture the image name from a process map.
Handle both cases so that the logical name and the file name is handled.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
