### PR TITLE
[stubs] Autolink against icucore on Darwin.

### DIFF
--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -1240,7 +1240,6 @@ toolchains::Darwin::constructInvocation(const LinkJobAction &job,
     Arguments.push_back("-framework");
     Arguments.push_back("Foundation");
     Arguments.push_back("-force_load_swift_libs");
-    Arguments.push_back("-licucore");
   } else {
     Arguments.push_back(context.Args.MakeArgString(RuntimeLibPath));
   }

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -1237,10 +1237,10 @@ toolchains::Darwin::constructInvocation(const LinkJobAction &job,
     getRuntimeStaticLibraryPath(StaticRuntimeLibPath, context.Args, *this);
     Arguments.push_back(context.Args.MakeArgString(StaticRuntimeLibPath));
     Arguments.push_back("-lc++");
-    Arguments.push_back("-licucore");
     Arguments.push_back("-framework");
     Arguments.push_back("Foundation");
     Arguments.push_back("-force_load_swift_libs");
+    Arguments.push_back("-licucore");
   } else {
     Arguments.push_back(context.Args.MakeArgString(RuntimeLibPath));
   }

--- a/stdlib/public/stubs/UnicodeNormalization.cpp
+++ b/stdlib/public/stubs/UnicodeNormalization.cpp
@@ -317,6 +317,10 @@ int32_t ubrk_preceding(UBreakIterator *, int32_t);
 int32_t ubrk_following(UBreakIterator *, int32_t);
 void ubrk_setText(UBreakIterator *, const UChar *, int32_t, UErrorCode *);
 }
+
+// Force an autolink with ICU
+asm(".linker_option \"-licucore\"\n");
+
 #endif // defined(__APPLE__)
 
 void swift::__swift_stdlib_ubrk_close(

--- a/test/Driver/static-stdlib-icu.swift
+++ b/test/Driver/static-stdlib-icu.swift
@@ -1,8 +1,0 @@
-// REQUIRES: OS=macosx
-// Note: This is really about the /host/ environment
-
-// RUN: %swiftc_driver -driver-print-jobs -static-stdlib %S/../Inputs/empty.swift | %FileCheck -check-prefix STATIC %s
-// RUN: %swiftc_driver -driver-print-jobs %S/../Inputs/empty.swift | %FileCheck -check-prefix NO_STATIC %s
-
-// STATIC: {{.*}}-L {{[^ ]*}}/lib/swift_static/macosx {{.*}}-licucore 
-// NO_STATIC: {{.*}}-L {{[^ ]*}}/lib/swift/macosx


### PR DESCRIPTION
Programs using a statically linked build of the standard library need
to explicitly link against icucore. There are various potential
hacks^Wsolutions to this problem, and this is an attempt at a lesser
of evils approach.

Emit a linker directive to perform autolinking against icucore on
Darwin systems. This allows us to avoid hacking the compiler driver
and propagating that hack onto any build systems that don't go through
the driver.