### PR TITLE
[stubs] Autolink against icucore on Darwin

### DIFF
--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -1240,7 +1240,6 @@ toolchains::Darwin::constructInvocation(const LinkJobAction &job,
     Arguments.push_back("-framework");
     Arguments.push_back("Foundation");
     Arguments.push_back("-force_load_swift_libs");
-    Arguments.push_back("-licucore");
   } else {
     Arguments.push_back(context.Args.MakeArgString(RuntimeLibPath));
   }

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -1240,6 +1240,7 @@ toolchains::Darwin::constructInvocation(const LinkJobAction &job,
     Arguments.push_back("-framework");
     Arguments.push_back("Foundation");
     Arguments.push_back("-force_load_swift_libs");
+    Arguments.push_back("-licucore");
   } else {
     Arguments.push_back(context.Args.MakeArgString(RuntimeLibPath));
   }

--- a/stdlib/public/stubs/UnicodeNormalization.cpp
+++ b/stdlib/public/stubs/UnicodeNormalization.cpp
@@ -317,6 +317,10 @@ int32_t ubrk_preceding(UBreakIterator *, int32_t);
 int32_t ubrk_following(UBreakIterator *, int32_t);
 void ubrk_setText(UBreakIterator *, const UChar *, int32_t, UErrorCode *);
 }
+
+// Force an autolink with ICU
+asm(".linker_option \"-licucore\"\n");
+
 #endif // defined(__APPLE__)
 
 void swift::__swift_stdlib_ubrk_close(


### PR DESCRIPTION
<!-- What's in this pull request? -->
4.0 cherry-pick of https://github.com/apple/swift/pull/9780

Explanation: Users of statically linked stdlib need to explicitly link against icucore. This adds an auto linking directive to the stubs to provide that.
Scope: Command line targets and those who want to statically link against swift core 
Radar (and possibly SR Issue): rdar://problem/32286893
Risk: Low. Only affects static linking and is more robust on Apple platforms than the driver hack from yesterday
Testing: Full CI testing

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->