### PR TITLE
SIL: Refactor SILFunctionType::substGenericArgs to tolerate substitutions to non-polymorphic function types.

### DIFF
--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -2135,12 +2135,14 @@ SILFunctionType::substGenericArgs(SILModule &silModule,
 CanSILFunctionType
 SILFunctionType::substGenericArgs(SILModule &silModule,
                                   const SubstitutionMap &subs) {
+  if (!isPolymorphic()) {
+    return CanSILFunctionType(this);
+  }
+  
   if (subs.empty()) {
-    assert(!isPolymorphic() && "no args for polymorphic substitution");
     return CanSILFunctionType(this);
   }
 
-  assert(isPolymorphic());
   return substGenericArgs(silModule,
                           QuerySubstitutionMap{subs},
                           LookUpConformanceInSubstitutionMap(subs));

--- a/test/SILGen/fully-concrete-extension-of-generic.swift
+++ b/test/SILGen/fully-concrete-extension-of-generic.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-frontend -emit-silgen -verify %s 
+
+class C<T> {
+  init() {}
+}
+
+extension C where T == Int {
+  convenience init(forInt _: ()) {
+    self.init()
+  }
+}
+
+func exerciseInits(which: Bool) -> C<Int> {
+  if which {
+    return C()
+  } else {
+    return C(forInt: ())
+  }
+}


### PR DESCRIPTION
This can come up when functions are lowered in contexts where there are contextual generic parameters, but their genericity has been same-typed away, such as in extensions to specific instantiations of generic types. Fixes rdar://problem/32182121.