### PR TITLE
Revert "Un-XFAIL Lazy.swift test"

### DIFF
--- a/validation-test/stdlib/Lazy.swift.gyb
+++ b/validation-test/stdlib/Lazy.swift.gyb
@@ -12,6 +12,8 @@
 // RUN: %target-run-simple-swiftgyb
 // REQUIRES: executable_test
 
+// REQUIRES: radar_31897334
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 


### PR DESCRIPTION
Reverts apple/swift#9777 as they are still failing on some specific builds.