### PR TITLE
SIL: Refactor SILFunctionType::substGenericArgs to tolerate substitutions to non-polymorphic function types.

### DIFF
--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -2133,12 +2133,14 @@ SILFunctionType::substGenericArgs(SILModule &silModule,
 CanSILFunctionType
 SILFunctionType::substGenericArgs(SILModule &silModule,
                                   const SubstitutionMap &subs) {
+  if (!isPolymorphic()) {
+    return CanSILFunctionType(this);
+  }
+  
   if (subs.empty()) {
-    assert(!isPolymorphic() && "no args for polymorphic substitution");
     return CanSILFunctionType(this);
   }
 
-  assert(isPolymorphic());
   return substGenericArgs(silModule,
                           QuerySubstitutionMap{subs},
                           LookUpConformanceInSubstitutionMap(subs));

--- a/test/SILGen/fully-concrete-extension-of-generic.swift
+++ b/test/SILGen/fully-concrete-extension-of-generic.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-frontend -emit-silgen -verify %s 
+
+class C<T> {
+  init() {}
+}
+
+extension C where T == Int {
+  convenience init(forInt _: ()) {
+    self.init()
+  }
+}
+
+func exerciseInits(which: Bool) -> C<Int> {
+  if which {
+    return C()
+  } else {
+    return C(forInt: ())
+  }
+}


### PR DESCRIPTION
Explanation: Removes a harmless assertion failure that is covering up other issues in asserts-enabled builds.

Scope: Causes code that successfully builds with asserts-disabled compilers to fail for no reason

Issue: rdar://problem/32182121

Risk: Low, real problems with substitutions falling out of sync with generic environments are well-checked-for by assertions and verifiers elsewhere in the compiler.

Testing: Swift CI, project from Radar