### PR TITLE
Fix iterating empty IndexSets

### DIFF
--- a/stdlib/public/SDK/Foundation/IndexSet.swift
+++ b/stdlib/public/SDK/Foundation/IndexSet.swift
@@ -237,9 +237,14 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
     }
     
     public var startIndex: Index {
-        // If this winds up being NSNotFound, that's ok because then endIndex is also NSNotFound, and empty collections have startIndex == endIndex
-        let extent = _range(at: 0)
-        return Index(value: extent.lowerBound, extent: extent, rangeIndex: 0, rangeCount: _rangeCount)
+        let rangeCount = _rangeCount
+        if rangeCount > 0 {
+            // If this winds up being NSNotFound, that's ok because then endIndex is also NSNotFound, and empty collections have startIndex == endIndex
+            let extent = _range(at: 0)
+            return Index(value: extent.lowerBound, extent: extent, rangeIndex: 0, rangeCount: _rangeCount)
+        } else {
+            return Index(value: 0, extent: 0..<0, rangeIndex: -1, rangeCount: rangeCount)
+        }
     }
 
     public var endIndex: Index {

--- a/stdlib/public/SDK/Foundation/IndexSet.swift
+++ b/stdlib/public/SDK/Foundation/IndexSet.swift
@@ -15,23 +15,23 @@ import _SwiftFoundationOverlayShims
 
 extension IndexSet.Index {
     public static func ==(lhs: IndexSet.Index, rhs: IndexSet.Index) -> Bool {
-        return lhs.value == rhs.value && rhs.rangeIndex == rhs.rangeIndex
+        return lhs.value == rhs.value
     }
 
     public static func <(lhs: IndexSet.Index, rhs: IndexSet.Index) -> Bool {
-        return lhs.value < rhs.value && rhs.rangeIndex <= rhs.rangeIndex
+        return lhs.value < rhs.value
     }
 
     public static func <=(lhs: IndexSet.Index, rhs: IndexSet.Index) -> Bool {
-        return lhs.value <= rhs.value && rhs.rangeIndex <= rhs.rangeIndex
+        return lhs.value <= rhs.value
     }
 
     public static func >(lhs: IndexSet.Index, rhs: IndexSet.Index) -> Bool {
-        return lhs.value > rhs.value && rhs.rangeIndex >= rhs.rangeIndex
+        return lhs.value > rhs.value
     }
 
     public static func >=(lhs: IndexSet.Index, rhs: IndexSet.Index) -> Bool {
-        return lhs.value >= rhs.value && rhs.rangeIndex >= rhs.rangeIndex
+        return lhs.value >= rhs.value
     }
 }
 

--- a/test/stdlib/TestIndexSet.swift
+++ b/test/stdlib/TestIndexSet.swift
@@ -326,7 +326,7 @@ class TestIndexSet : TestIndexSetSuper {
     }
     
     func testEmptyIteration() {
-        let empty = IndexSet()
+        var empty = IndexSet()
         let start = empty.startIndex
         let end = empty.endIndex
         
@@ -344,6 +344,21 @@ class TestIndexSet : TestIndexSetSuper {
             count += 1
         }
         
+        expectEqual(count, 0)
+
+        empty.insert(5)
+        empty.remove(5)
+        
+        count = 0
+        for _ in empty {
+            count += 1
+        }
+        expectEqual(count, 0)
+
+        count = 0
+        for _ in empty.rangeView {
+            count += 1
+        }
         expectEqual(count, 0)
     }
     


### PR DESCRIPTION
`IndexSet.startIndex` was returning a garbage index if the index set was empty, but previously had indices. This caused various issues, most notably a crash (exception) upon iterating the set.

Also tweak the `IndexSet.Index` comparison operators to remove the broken `rangeIndex` tests. Besides testing the wrong variable, they were also just not necessary as the `value` is sufficient to compare indices.

Resolves [SR-4947](https://bugs.swift.org/browse/SR-4947).