### PR TITLE
[4.0] SILGen: Use VarDecl::getInterfaceType instead of getType in emitForeignToNativeThunk.

### DIFF
--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -1238,7 +1238,8 @@ void SILGenFunction::emitForeignToNativeThunk(SILDeclRef thunk) {
   // formally present in the constructor body.
   Type allocatorSelfType;
   if (thunk.kind == SILDeclRef::Kind::Allocator) {
-    allocatorSelfType = forwardedParameters[0]->getType(getASTContext())
+    allocatorSelfType = forwardedParameters[0]
+      ->getInterfaceType(getASTContext())
       ->getLValueOrInOutObjectType();
     forwardedParameters = forwardedParameters.slice(1);
   }

--- a/test/SILGen/Inputs/objc_required_designated_init_2.swift
+++ b/test/SILGen/Inputs/objc_required_designated_init_2.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+open class Boom: NSObject {
+  public override required init() {
+    super.init()
+  }
+}
+

--- a/test/SILGen/objc_required_designated_init.swift
+++ b/test/SILGen/objc_required_designated_init.swift
@@ -1,0 +1,12 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: %target-swift-frontend -emit-module %S/Inputs/objc_required_designated_init_2.swift -module-name Booms -o %t/Booms.swiftmodule
+// RUN: %target-swift-frontend -I %t -emit-silgen -verify %s
+
+import Booms
+
+class Baboom: Boom {
+  required init() {
+    super.init()
+  }
+}
+

--- a/test/SILGen/objc_required_designated_init.swift
+++ b/test/SILGen/objc_required_designated_init.swift
@@ -2,6 +2,8 @@
 // RUN: %target-swift-frontend -emit-module %S/Inputs/objc_required_designated_init_2.swift -module-name Booms -o %t/Booms.swiftmodule
 // RUN: %target-swift-frontend -I %t -emit-silgen -verify %s
 
+// REQUIRES: objc_interop
+
 import Booms
 
 class Baboom: Boom {


### PR DESCRIPTION
Explanation: open required designated initializers in subclasses of ObjC classes would crash due to the  legacy `getType()` interface on their parameter decls not getting set.

Scope: open required designated initializers in subclasses of ObjC classes will crash.

Issue: rdar://problem/32280288

Risk: Low, small bug fix.

Testing: Swift CI, internal projects