### PR TITLE
[4.0] [Serialization] Fix incorrect counting of value witnesses

### DIFF
--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2743,6 +2743,35 @@ void ProtocolConformance::dump(llvm::raw_ostream &out, unsigned indent) const {
 
     printCommon("normal");
     // Maybe print information about the conforming context?
+    if (normal->isLazilyResolved()) {
+      out << " lazy";
+    } else {
+      forEachTypeWitness(nullptr, [&](const AssociatedTypeDecl *req,
+                                      Type ty, const TypeDecl *) -> bool {
+        out << '\n';
+        out.indent(indent + 2);
+        PrintWithColorRAII(out, ParenthesisColor) << '(';
+        out << "assoc_type req=" << req->getName() << " type=";
+        PrintWithColorRAII(out, TypeColor) << ty;
+        PrintWithColorRAII(out, ParenthesisColor) << ')';
+        return false;
+      });
+      normal->forEachValueWitness(nullptr, [&](const ValueDecl *req,
+                                               Witness witness) {
+        out << '\n';
+        out.indent(indent + 2);
+        PrintWithColorRAII(out, ParenthesisColor) << '(';
+        out << "value req=" << req->getFullName() << " witness=";
+        if (!witness) {
+          out << "(none)";
+        } else if (witness.getDecl() == req) {
+          out << "(dynamic)";
+        } else {
+          witness.getDecl()->dumpRef(out);
+        }
+        PrintWithColorRAII(out, ParenthesisColor) << ')';
+      });
+    }
 
     for (auto conformance : normal->getSignatureConformances()) {
       out << '\n';

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1296,6 +1296,7 @@ void Serializer::writeNormalConformance(
 
   conformance->forEachValueWitness(nullptr,
     [&](ValueDecl *req, Witness witness) {
+      ++numValueWitnesses;
       data.push_back(addDeclRef(req));
       data.push_back(addDeclRef(witness.getDecl()));
       assert(witness.getDecl() || req->getAttrs().hasAttribute<OptionalAttr>()
@@ -1319,11 +1320,10 @@ void Serializer::writeNormalConformance(
 
         // Requirements come at the end.
       } else {
-        data.push_back(0);
+        data.push_back(/*number of generic parameters*/0);
       }
 
       data.push_back(witness.getSubstitutions().size());
-      ++numValueWitnesses;
   });
 
   conformance->forEachTypeWitness(/*resolver=*/nullptr,

--- a/test/Serialization/cross_module_optional_protocol_reqt.swift
+++ b/test/Serialization/cross_module_optional_protocol_reqt.swift
@@ -2,7 +2,22 @@
 // RUN: %target-swift-frontend -module-name cross_module_optional_protocol_reqt -c -emit-module-path %t/cross_module_optional_protocol_reqt~partial.swiftmodule -primary-file %s %S/Inputs/cross_module_optional_protocol_reqt_2.swift -import-objc-header %S/Inputs/cross_module_optional_protocol_reqt.h -o /dev/null
 // RUN: %target-swift-frontend -module-name cross_module_optional_protocol_reqt -c -emit-module-path %t/cross_module_optional_protocol_reqt_2~partial.swiftmodule %s -primary-file %S/Inputs/cross_module_optional_protocol_reqt_2.swift -import-objc-header %S/Inputs/cross_module_optional_protocol_reqt.h -o /dev/null
 // RUN: %target-swift-frontend -module-name cross_module_optional_protocol_reqt -emit-module -emit-module-path %t/cross_module_optional_protocol_reqt.swiftmodule %t/cross_module_optional_protocol_reqt~partial.swiftmodule %t/cross_module_optional_protocol_reqt_2~partial.swiftmodule -import-objc-header %S/Inputs/cross_module_optional_protocol_reqt.h
+// RUN: %target-swift-frontend -I %t -typecheck %s -DTEST -module-name main
 // REQUIRES: objc_interop
+
+#if TEST
+
+import cross_module_optional_protocol_reqt
+
+func test(_ foo: Foo) {
+  // At one point this forced deserialization of the conformance to ObjCProto,
+  // which was corrupted by the presence of the optional requirement with no
+  // witness.
+  foo.nonoptionalMethod()
+  foo.nonoptionalMethod2()
+}
+
+#else // TEST
 
 public protocol SwiftProto: ObjCProto {}
 
@@ -10,3 +25,5 @@ public class Foo: ObjCFoo, SwiftProto {
   public func nonoptionalMethod() {}
   public func nonoptionalMethod2() {}
 }
+
+#endif // TEST


### PR DESCRIPTION
- **Explanation**: As of Swift 4, the compiler records when a protocol is missing a witness for a particular requirement instead of just leaving it out. We serialize these missing witnesses slightly differently than regular ones, and there was a bug in that logic, which led to witnesses being dropped or even corrupted when accessed from another module. This manifested as various assertion failures in the cases we know about…but doesn't actually affect the behavior of the program except in a few limited code paths. Still, we should fix this!
- **Scope**: Affects conformances to protocols with optional or unavailable requirements, and even then the issue only manifests when the conformance is used in certain ways from another module.
- **Radar**: rdar://problem/32308603
- **Reviewed by**: @DougGregor
- **Risk**: Low. The change moves one line of code across a branch to where it should have been all along.
- **Testing**: Passed compiler regression tests, original failure case compiled successfully.
