### PR TITLE
[QoI] Add a fix-it with missing parameters for closures

### DIFF
--- a/test/Compatibility/tuple_arguments.swift
+++ b/test/Compatibility/tuple_arguments.swift
@@ -1478,3 +1478,11 @@ let pages3: MutableProperty<(data: DataSourcePage<Int>, totalCount: Int)> = Muta
     data: DataSourcePage<Int>.notLoaded,
     totalCount: 0
 ))
+
+// rdar://problem/32301091 - Make sure that in Swift 3 mode following expressions still compile just fine
+
+func rdar32301091_1(_ :((Int, Int) -> ())!) {}
+rdar32301091_1 { _ in } // Ok in Swift 3
+
+func rdar32301091_2(_ :(Int, Int) -> ()) {}
+rdar32301091_2 { _ in } // Ok in Swift 3

--- a/test/Constraints/tuple_arguments.swift
+++ b/test/Constraints/tuple_arguments.swift
@@ -1514,3 +1514,15 @@ func r32214649_2<X>(_ a: [X], _ f: (X) -> Bool) -> [X] {
 func r32214649_3<X>(_ a: [X]) -> [X] {
   return a.filter { _ in return true }
 }
+
+// rdar://problem/32301091 - [SE-0110] causes errors when passing a closure with a single underscore to a block accepting multiple parameters
+
+func rdar32301091_1(_ :((Int, Int) -> ())!) {}
+rdar32301091_1 { _ in }
+// expected-error@-1 {{contextual closure type '(Int, Int) -> ()' expects 2 arguments, but 1 was used in closure body}} {{19-19=,_ }}
+
+func rdar32301091_2(_ :(Int, Int) -> ()) {}
+rdar32301091_2 { _ in }
+// expected-error@-1 {{contextual closure type '(Int, Int) -> ()' expects 2 arguments, but 1 was used in closure body}} {{19-19=,_ }}
+rdar32301091_2 { x in }
+// expected-error@-1 {{contextual closure type '(Int, Int) -> ()' expects 2 arguments, but 1 was used in closure body}} {{19-19=,<#arg#> }}


### PR DESCRIPTION
If there are parameters missing in the closure declaration and
all of the present ones are anonymous let's emit a fix it suggesting
missing parameters.

Resolves: rdar://problem/32301091
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
