### PR TITLE
[4.0] [PrintAsObjC] Handle typealiases to non-type Clang declarations.

### DIFF
--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -1368,11 +1368,23 @@ private:
       return;
 
     if (alias->hasClangNode()) {
-      auto *clangTypeDecl = cast<clang::TypeDecl>(alias->getClangDecl());
-      os << clangTypeDecl->getName();
+      if (auto *clangTypeDecl =
+            dyn_cast<clang::TypeDecl>(alias->getClangDecl())) {
+        os << clangTypeDecl->getName();
 
-      if (isClangPointerType(clangTypeDecl))
+        if (isClangPointerType(clangTypeDecl))
+          printNullability(optionalKind);
+      } else if (auto *clangObjCClass
+                   = dyn_cast<clang::ObjCInterfaceDecl>(alias->getClangDecl())){
+        os << clangObjCClass->getName() << " *";
         printNullability(optionalKind);
+      } else {
+        auto *clangCompatAlias =
+          cast<clang::ObjCCompatibleAliasDecl>(alias->getClangDecl());
+        os << clangCompatAlias->getName() << " *";
+        printNullability(optionalKind);
+      }
+
       return;
     }
 

--- a/test/PrintAsObjC/Inputs/custom-modules/CompatibilityAlias.h
+++ b/test/PrintAsObjC/Inputs/custom-modules/CompatibilityAlias.h
@@ -1,0 +1,5 @@
+// This file is meant to be included with modules turned off, compiled against
+// the fake clang-importer-sdk.
+#import <Foundation.h>
+
+@compatibility_alias StringCheese NSString;

--- a/test/PrintAsObjC/Inputs/custom-modules/NestedClass.apinotes
+++ b/test/PrintAsObjC/Inputs/custom-modules/NestedClass.apinotes
@@ -1,0 +1,6 @@
+Name: NestedClass
+SwiftVersions:
+  - Version: 3.0
+    Classes:
+      - Name: InnerClass
+        SwiftName: InnerClass

--- a/test/PrintAsObjC/Inputs/custom-modules/NestedClass.h
+++ b/test/PrintAsObjC/Inputs/custom-modules/NestedClass.h
@@ -1,0 +1,10 @@
+// This file is meant to be included with modules turned off, compiled against
+// the fake clang-importer-sdk.
+#import <Foundation.h>
+
+@interface Outer : NSObject
+@end
+
+__attribute__((swift_name("Outer.Inner")))
+@interface InnerClass : NSObject
+@end

--- a/test/PrintAsObjC/Inputs/custom-modules/module.map
+++ b/test/PrintAsObjC/Inputs/custom-modules/module.map
@@ -32,3 +32,13 @@ module OverrideBase [system] {
 module OtherModule {
   // Deliberately empty. Used by depends-on-swift-framework.swift.
 }
+
+module CompatibilityAlias {
+  header "CompatibilityAlias.h"
+  export *
+}
+
+module NestedClass {
+  header "NestedClass.h"
+  export *
+}

--- a/test/PrintAsObjC/classes.swift
+++ b/test/PrintAsObjC/classes.swift
@@ -19,7 +19,7 @@
 // RUN: %FileCheck --check-prefix=NEGATIVE %s < %t/classes.h
 // RUN: %check-in-clang -I %S/Inputs/custom-modules/ %t/classes.h
 // RUN: not %check-in-clang -I %S/Inputs/custom-modules/ -fno-modules -Qunused-arguments %t/classes.h
-// RUN: %check-in-clang -I %S/Inputs/custom-modules/ -fno-modules -Qunused-arguments %t/classes.h -include Foundation.h -include CoreFoundation.h -include objc_generics.h -include SingleGenericClass.h
+// RUN: %check-in-clang -I %S/Inputs/custom-modules/ -fno-modules -Qunused-arguments %t/classes.h -include Foundation.h -include CoreFoundation.h -include objc_generics.h -include SingleGenericClass.h -include CompatibilityAlias.h
 
 // CHECK-NOT: AppKit;
 // CHECK-NOT: Properties;
@@ -28,6 +28,7 @@
 // CHECK-NEXT: @import CoreGraphics;
 // CHECK-NEXT: @import CoreFoundation;
 // CHECK-NEXT: @import objc_generics;
+// CHECK-NEXT: @import CompatibilityAlias;
 // CHECK-NEXT: @import SingleGenericClass;
 // CHECK-NOT: AppKit;
 // CHECK-NOT: Swift;
@@ -35,6 +36,7 @@ import Foundation
 import objc_generics
 import AppKit // only used in implementations
 import CoreFoundation
+import CompatibilityAlias
 import SingleGenericClass
 
 // CHECK-LABEL: @interface A1{{$}}
@@ -724,6 +726,15 @@ public class NonObjCClass { }
 
 @objc class Spoon: Fungible {}
 
+// CHECK-LABEL: @interface UsesCompatibilityAlias
+@objc class UsesCompatibilityAlias : NSObject {
+  // CHECK-NEXT: - (StringCheese * _Nullable)foo SWIFT_WARN_UNUSED_RESULT;
+  @objc func foo() -> StringCheese? { return nil }
+
+  // CHECK-NEXT: - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
+}
+// CHECK-NEXT: @end
+
 // CHECK-LABEL: @interface UsesImportedGenerics
 @objc class UsesImportedGenerics {
   // CHECK: - (GenericClass<id> * _Nonnull)takeAndReturnGenericClass:(GenericClass<NSString *> * _Nullable)x SWIFT_WARN_UNUSED_RESULT;
@@ -739,4 +750,3 @@ public class NonObjCClass { }
   @objc func referenceSingleGenericClass(_: SingleImportedObjCGeneric<AnyObject>?) {}
 }
 // CHECK: @end
-

--- a/test/PrintAsObjC/versioned.swift
+++ b/test/PrintAsObjC/versioned.swift
@@ -1,0 +1,28 @@
+// REQUIRES: objc_interop
+
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+
+// FIXME: BEGIN -enable-source-import hackaround
+// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t %S/../Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift
+// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/CoreGraphics.swift
+// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/Foundation.swift
+// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/AppKit.swift
+// FIXME: END -enable-source-import hackaround
+
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -I %S/Inputs/custom-modules -o %t %s -disable-objc-attr-requires-foundation-module -swift-version 3
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -parse-as-library %t/versioned.swiftmodule -typecheck -I %S/Inputs/custom-modules -emit-objc-header-path %t/versioned.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module -swift-version 3
+// RUN: %FileCheck %s < %t/versioned.h
+// RUN: %check-in-clang -I %S/Inputs/custom-modules/ %t/versioned.h
+// RUN: %check-in-clang -I %S/Inputs/custom-modules/ -fno-modules -Qunused-arguments %t/versioned.h -include Foundation.h -include NestedClass.h
+
+import NestedClass
+
+// CHECK-LABEL: @interface UsesNestedClass
+@objc class UsesNestedClass : NSObject {
+  // CHECK-NEXT: - (InnerClass * _Nullable)foo SWIFT_WARN_UNUSED_RESULT;
+  @objc func foo() -> InnerClass? { return nil }
+
+  // CHECK-NEXT: - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
+}
+// CHECK-NEXT: @end


### PR DESCRIPTION
**Explanation**: The Objective-C interface printer was unable to print imported `typealias` declarations that refer to Objective-C classes (e.g., due to `NS_SWIFT_NAME` that is reversed via API notes) or compatible aliases (which are rare); it would crash.
**Scope**: Fairly narrow scope: one needs to get an Objective-C type to import as as `typealias` (e.g., using one of the aforementioned approaches), and then use that `typealias` in an` @objc` API that gets emitted to the generated header.
**Radar**: rdar://problem/32308192
**Risk**: Very low; an obviously-crashing code path handles two more cases.
**Testing**: Compiler regression testing.
