### PR TITLE
[4.0] Disable diagnostics about problem NSCoding-conforming classes for now

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -227,6 +227,9 @@ namespace swift {
     /// of Swift do not.
     Swift3ObjCInferenceWarnings WarnSwift3ObjCInference =
       Swift3ObjCInferenceWarnings::None;
+
+    /// Diagnose uses of NSCoding with classes that have unstable mangled names.
+    bool EnableNSKeyedArchiverDiagnostics = false;
     
     /// Enable keypath components that aren't fully implemented.
     bool EnableExperimentalKeyPathComponents = false;

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -304,6 +304,13 @@ def disable_swift3_objc_inference :
   Flags<[FrontendOption, HelpHidden]>,
   HelpText<"Disable Swift 3's @objc inference rules for NSObject-derived classes and 'dynamic' members (emulates Swift 4 behavior)">;
 
+def enable_nskeyedarchiver_diagnostics :
+  Flag<["-"], "enable-nskeyedarchiver-diagnostics">,
+  HelpText<"Diagnose classes with unstable mangled names adopting NSCoding">;
+def disable_nskeyedarchiver_diagnostics :
+  Flag<["-"], "disable-nskeyedarchiver-diagnostics">,
+  HelpText<"Allow classes with unstable mangled names to adopt NSCoding">;
+
 def warn_long_function_bodies : Separate<["-"], "warn-long-function-bodies">,
   MetaVarName<"<n>">,
   HelpText<"Warns when type-checking a function takes longer than <n> ms">;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1038,6 +1038,11 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
     }
   }
 
+  Opts.EnableNSKeyedArchiverDiagnostics =
+      Args.hasFlag(OPT_enable_nskeyedarchiver_diagnostics,
+                   OPT_disable_nskeyedarchiver_diagnostics,
+                   Opts.EnableNSKeyedArchiverDiagnostics);
+
   llvm::Triple Target = Opts.Target;
   StringRef TargetArg;
   if (const Arg *A = Args.getLastArg(OPT_target)) {

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -6022,7 +6022,8 @@ void TypeChecker::checkConformancesInContext(DeclContext *dc,
           }
         }
 
-        if (kind && !hasExplicitObjCName(classDecl) &&
+        if (kind && getLangOpts().EnableNSKeyedArchiverDiagnostics &&
+            !hasExplicitObjCName(classDecl) &&
             !classDecl->getAttrs().hasAttribute<NSKeyedArchiverClassNameAttr>() &&
             !classDecl->getAttrs()
               .hasAttribute<NSKeyedArchiverEncodeNonGenericSubclassesOnlyAttr>()) {

--- a/test/decl/protocol/conforms/nscoding.swift
+++ b/test/decl/protocol/conforms/nscoding.swift
@@ -1,9 +1,13 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -swift-version 4 %s -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -swift-version 4 %s -enable-nskeyedarchiver-diagnostics -verify
+// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -swift-version 4 %s 2>&1 | %FileCheck -check-prefix CHECK-NO-DIAGS %s
 
 // RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -swift-version 4 %s -dump-ast 2> %t.ast
 // RUN: %FileCheck %s < %t.ast
 
 // REQUIRES: objc_interop
+
+// CHECK-NO-DIAGS-NOT: NSCoding
+// CHECK-NO-DIAGS-NOT: unstable
 
 import Foundation
 


### PR DESCRIPTION
- **Explanation**: Foundation's standard serialization mechanism, NSKeyedArchiver, can end up storing mangled names into persistent archives, which isn't really a good idea. However, the diagnostics we came up with to catch these cases are firing on classes where the authors had no intention of serializing them into persistent archives. Disable the diagnostics for now while we revisit the model.
- **Scope**: Affects non-top-level classes that conform directly or indirectly to NSCoding.
- **Radar**: rdar://problem/32306355
- **Reviewed by**: @DougGregor, @parkera 
- **Risk**: Very low. Puts the emission of diagnostics for problematic cases behind a feature flag that's off by default.
- **Testing**: Passed compiler regression tests.