### PR TITLE
[QoI] Improve diagnostics for subscript with invalid index arguments

### DIFF
--- a/test/Constraints/subscript.swift
+++ b/test/Constraints/subscript.swift
@@ -106,3 +106,13 @@ class C_r25601561 {
     return s
   }
 }
+
+// rdar://problem/31977679 - Misleading diagnostics when using subscript with incorrect argument
+
+func r31977679_1(_ properties: [String: String]) -> Any? {
+  return properties[0] // expected-error {{cannot subscript a value of type '[String : String]' with an index of type 'Int'}}
+}
+
+func r31977679_2(_ properties: [String: String]) -> Any? {
+  return properties["foo"] // Ok
+}

--- a/test/stdlib/RangeDiagnostics.swift
+++ b/test/stdlib/RangeDiagnostics.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 // RUN: %target-typecheck-verify-swift
-// XFAIL: linux
 
 import StdlibUnittest
 
@@ -283,7 +282,7 @@ func disallowSubscriptingOnIntegers() {
     r3[0]       // expected-error {{cannot subscript a value of type 'CountableClosedRange<UInt>' with an index of type 'Int'}}
     // expected-note@-1 {{overloads for 'subscript'}}
 
-    r0[UInt(0)] // expected-error {{ambiguous reference to member 'subscript'}}
+    r0[UInt(0)] // expected-error {{cannot subscript a value of type 'CountableRange<Int>' with an index of type 'UInt'}}
     r1[UInt(0)] // expected-error {{ambiguous use of 'subscript'}}
     r2[UInt(0)] // expected-error {{cannot subscript a value of type 'CountableClosedRange<Int>' with an index of type 'UInt'}}
     // expected-note@-1 {{overloads for 'subscript' exist}}
@@ -292,18 +291,17 @@ func disallowSubscriptingOnIntegers() {
 
     r0[0..<4]   // expected-error {{ambiguous use of 'subscript'}}
     r1[0..<4]   // expected-error {{ambiguous use of 'subscript'}}
-    r2[0..<4]   // expected-error {{ambiguous reference to member 'subscript'}}
-    r3[0..<4]   // expected-error {{ambiguous reference to member 'subscript'}}
+    r2[0..<4]   // expected-error {{cannot subscript a value of type 'CountableClosedRange<Int>' with an index of type 'CountableRange<Int>'}}
+    r3[0..<4]   // expected-error {{cannot subscript a value of type 'CountableClosedRange<UInt>' with an index of type 'CountableRange<Int>'}}
     (10..<100)[0]           // expected-error {{ambiguous use of 'subscript'}}
-    (UInt(10)...100)[0..<4] // expected-error {{cannot subscript a value of type 'CountableClosedRange<_>' with an index of type 'CountableRange<_>'}}
-    // expected-note@-1 {{overloads for 'subscript'}}
+    (UInt(10)...100)[0..<4] // expected-error {{cannot subscript a value of type 'CountableClosedRange<UInt>' with an index of type 'CountableRange<Int>'}}
 
     r0[0...4]   // expected-error {{ambiguous use of 'subscript'}}
     r1[0...4]   // expected-error {{ambiguous use of 'subscript'}}
-    r2[0...4]   // expected-error {{ambiguous reference to member 'subscript'}}
-    r3[0...4]   // expected-error {{ambiguous reference to member 'subscript'}} 
-    (10...100)[0...4] // expected-error {{cannot subscript a value of type 'CountableClosedRange<_>' with an index of type 'CountableClosedRange<_>'}} expected-note {{overloads for 'subscript' exist with these partially matching parameter lists: (ClosedRangeIndex<Bound>), (Range<ClosedRangeIndex<Bound>>), (Range<Self.Index>), (R), ((UnboundedRange_) -> ()), (ClosedRange<Self.Index>), (CountableRange<Self.Index>), (CountableClosedRange<Self.Index>)}}
-    (UInt(10)...100)[0...4] // expected-error {{cannot subscript a value of type 'CountableClosedRange<_>' with an index of type 'CountableClosedRange<_>'}} expected-note {{overloads for 'subscript' exist with these partially matching parameter lists: (ClosedRangeIndex<Bound>), (Range<ClosedRangeIndex<Bound>>), (Range<Self.Index>), (R), ((UnboundedRange_) -> ()), (ClosedRange<Self.Index>), (CountableRange<Self.Index>), (CountableClosedRange<Self.Index>)}}
+    r2[0...4]   // expected-error {{cannot subscript a value of type 'CountableClosedRange<Int>' with an index of type 'CountableClosedRange<Int>'}}
+    r3[0...4]   // expected-error {{cannot subscript a value of type 'CountableClosedRange<UInt>' with an index of type 'CountableClosedRange<Int>'}}
+    (10...100)[0...4] // expected-error {{cannot subscript a value of type 'CountableClosedRange<Int>' with an index of type 'CountableClosedRange<Int>'}}
+    (UInt(10)...100)[0...4] // expected-error {{cannot subscript a value of type 'CountableClosedRange<UInt>' with an index of type 'CountableClosedRange<Int>'}}
 
     r0[r0]      // expected-error {{ambiguous use of 'subscript'}}
     r0[r1]      // expected-error {{ambiguous subscript with base type 'CountableRange<Int>' and index type 'CountableRange<UInt>'}}
@@ -315,15 +313,15 @@ func disallowSubscriptingOnIntegers() {
     r1[r2]      // expected-error {{ambiguous subscript with base type 'CountableRange<UInt>' and index type 'CountableClosedRange<Int>'}}
     r1[r3]      // expected-error {{ambiguous use of 'subscript'}}
 
-    r2[r0]      // expected-error {{ambiguous reference to member 'subscript'}}
-    r2[r1]      // expected-error {{ambiguous reference to member 'subscript'}}
-    r2[r2]      // expected-error {{ambiguous reference to member 'subscript'}}
-    r2[r3]      // expected-error {{ambiguous reference to member 'subscript'}}
+    r2[r0]      // expected-error {{cannot subscript a value of type 'CountableClosedRange<Int>' with an index of type 'CountableRange<Int>'}}
+    r2[r1]      // expected-error {{cannot subscript a value of type 'CountableClosedRange<Int>' with an index of type 'CountableRange<UInt>'}}
+    r2[r2]      // expected-error {{cannot subscript a value of type 'CountableClosedRange<Int>' with an index of type 'CountableClosedRange<Int>'}}
+    r2[r3]      // expected-error {{cannot subscript a value of type 'CountableClosedRange<Int>' with an index of type 'CountableClosedRange<UInt>'}}
 
-    r3[r0]      // expected-error {{ambiguous reference to member 'subscript'}}
-    r3[r1]      // expected-error {{ambiguous reference to member 'subscript'}}
-    r3[r2]      // expected-error {{ambiguous reference to member 'subscript'}}
-    r3[r3]      // expected-error {{ambiguous reference to member 'subscript'}}
+    r3[r0]      // expected-error {{cannot subscript a value of type 'CountableClosedRange<UInt>' with an index of type 'CountableRange<Int>'}}
+    r3[r1]      // expected-error {{cannot subscript a value of type 'CountableClosedRange<UInt>' with an index of type 'CountableRange<UInt>'}}
+    r3[r2]      // expected-error {{cannot subscript a value of type 'CountableClosedRange<UInt>' with an index of type 'CountableClosedRange<Int>'}}
+    r3[r3]      // expected-error {{cannot subscript a value of type 'CountableClosedRange<UInt>' with an index of type 'CountableClosedRange<UInt>'}}
   }
 
   do {
@@ -346,17 +344,14 @@ func disallowSubscriptingOnIntegers() {
     r2[0..<4]   // expected-error {{type 'ClosedRange<Int>' has no subscript members}}
     r3[0..<4]   // expected-error {{type 'ClosedRange<UInt>' has no subscript members}}
     (10..<100)[0]           // expected-error {{ambiguous use of 'subscript'}}
-    (UInt(10)...100)[0..<4] // expected-error {{cannot subscript a value of type 'CountableClosedRange<_>' with an index of type 'CountableRange<_>'}}
-    // expected-note@-1 {{overloads for 'subscript'}}
+    (UInt(10)...100)[0..<4] // expected-error {{cannot subscript a value of type 'CountableClosedRange<UInt>' with an index of type 'CountableRange<Int>'}}
 
     r0[0...4]   // expected-error {{type 'Range<Int>' has no subscript members}}
     r1[0...4]   // expected-error {{type 'Range<UInt>' has no subscript members}}
     r2[0...4]   // expected-error {{type 'ClosedRange<Int>' has no subscript members}}
     r3[0...4]   // expected-error {{type 'ClosedRange<UInt>' has no subscript members}}
-    (10...100)[0...4] // expected-error {{cannot subscript a value of type 'CountableClosedRange<_>' with an index of type 'CountableClosedRange<_>'}}
-    // expected-note@-1 {{overloads for 'subscript'}}
-    (UInt(10)...100)[0...4] // expected-error {{cannot subscript a value of type 'CountableClosedRange<_>' with an index of type 'CountableClosedRange<_>'}}
-    // expected-note@-1 {{overloads for 'subscript'}}
+    (10...100)[0...4] // expected-error {{cannot subscript a value of type 'CountableClosedRange<Int>' with an index of type 'CountableClosedRange<Int>'}}
+    (UInt(10)...100)[0...4] // expected-error {{cannot subscript a value of type 'CountableClosedRange<UInt>' with an index of type 'CountableClosedRange<Int>'}}
 
     r0[r0]      // expected-error {{type 'Range<Int>' has no subscript members}}
     r0[r1]      // expected-error {{type 'Range<Int>' has no subscript members}}


### PR DESCRIPTION
In `FailureDiagnosis::visitSubscriptExpr` if there is only a single
candidate available, verify that the problem is actually related
to the contextual mismatch by type-checking whole subscript without
contextual info, if that returns a type - it's contextual, otherwise
diagnose as incorrect argument type problem.

Resolves: rdar://problem/31977679

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
