### PR TITLE
[Foundation] Correct data subscript indexing to be offset from the base index

### DIFF
--- a/stdlib/public/SDK/Foundation/Data.swift
+++ b/stdlib/public/SDK/Foundation/Data.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #if DEPLOYMENT_RUNTIME_SWIFT
-
+    
 #if os(OSX) || os(iOS)
 import Darwin
 #elseif os(Linux)
@@ -19,24 +19,24 @@ import Glibc
 #endif
     
 import CoreFoundation
-
+    
 internal func __NSDataInvokeDeallocatorUnmap(_ mem: UnsafeMutableRawPointer, _ length: Int) {
     munmap(mem, length)
 }
-
+    
 internal func __NSDataInvokeDeallocatorFree(_ mem: UnsafeMutableRawPointer, _ length: Int) {
     free(mem)
 }
-
+    
 #else
-
+    
 @_exported import Foundation // Clang module
 import _SwiftFoundationOverlayShims
 import _SwiftCoreFoundationOverlayShims
-
+    
 @_silgen_name("__NSDataWriteToURL")
 internal func __NSDataWriteToURL(_ data: NSData, _ url: NSURL, _ options: UInt, _ error: NSErrorPointer) -> Bool
-
+    
 #endif
 
 public final class _DataStorage {
@@ -341,7 +341,7 @@ public final class _DataStorage {
         case .customReference(let d):
             let data = d.mutableCopy() as! NSMutableData
             data.append(bytes, length: length)
-            _backing = .customReference(data)
+            _backing = .customMutableReference(data)
         case .customMutableReference(let d):
             d.append(bytes, length: length)
         }
@@ -421,7 +421,7 @@ public final class _DataStorage {
             if _length < range.location + range.length {
                 let newLength = range.location + range.length
                 if _capacity < newLength {
-
+                    
                     _grow(newLength, false)
                 }
                 _length = newLength
@@ -471,7 +471,7 @@ public final class _DataStorage {
                     memset(mutableBytes! + start, 0, replacementLength)
                 }
             }
-
+            
             if resultingLength < currentLength {
                 setLength(resultingLength)
             }
@@ -703,50 +703,64 @@ public final class _DataStorage {
     }
     
     public func withInteriorPointerReference<T>(_ range: Range<Int>, _ work: (NSData) throws -> T) rethrows -> T {
+        if range.count == 0 {
+            return try work(NSData()) // zero length data can be optimized as a singleton
+        }
+        
         switch _backing {
         case .swift:
-            let d = _bytes == nil ? NSData() : NSData(bytesNoCopy: _bytes!.advanced(by: range.lowerBound), length: range.count, freeWhenDone: false)
-            return try work(d)
+            return try work(NSData(bytesNoCopy: _bytes!.advanced(by: range.lowerBound), length: range.count, freeWhenDone: false))
         case .immutable(let d):
-            if range.lowerBound == 0 && range.upperBound == _length {
-                return try work(d)
-            } else {
-                return try work(d.subdata(with: NSRange(location: range.lowerBound, length: range.count))._bridgeToObjectiveC())
+            guard range.lowerBound == 0 && range.upperBound == _length else {
+                return try work(NSData(bytesNoCopy: _bytes!.advanced(by: range.lowerBound), length: range.count, freeWhenDone: false))
             }
+            return try work(d)
         case .mutable(let d):
-            if range.lowerBound == 0 && range.upperBound == _length {
-                return try work(d)
-            } else {
-                return try work(d.subdata(with: NSRange(location: range.lowerBound, length: range.count))._bridgeToObjectiveC())
+            guard range.lowerBound == 0 && range.upperBound == _length else {
+                return try work(NSData(bytesNoCopy: _bytes!.advanced(by: range.lowerBound), length: range.count, freeWhenDone: false))
             }
+            return try work(d)
         case .customReference(let d):
-            if range.lowerBound == 0 && range.upperBound == _length {
-                return try work(d)
-            } else {
-                return try work(d.subdata(with: NSRange(location: range.lowerBound, length: range.count))._bridgeToObjectiveC())
+            guard range.lowerBound == 0 && range.upperBound == _length else {
+                
+                return try work(NSData(bytesNoCopy: UnsafeMutableRawPointer(mutating: d.bytes.advanced(by: range.lowerBound)), length: range.count, freeWhenDone: false))
             }
+            return try work(d)
         case .customMutableReference(let d):
-            if range.lowerBound == 0 && range.upperBound == _length {
-                return try work(d)
-            } else {
-                return try work(d.subdata(with: NSRange(location: range.lowerBound, length: range.count))._bridgeToObjectiveC())
+            guard range.lowerBound == 0 && range.upperBound == _length else {
+                return try work(NSData(bytesNoCopy: UnsafeMutableRawPointer(mutating: d.bytes.advanced(by: range.lowerBound)), length: range.count, freeWhenDone: false))
             }
+            return try work(d)
         }
     }
     
-    public func bridgedReference() -> NSData {
+    public func bridgedReference(_ range: Range<Int>) -> NSData {
+        if range.count == 0 {
+            return NSData() // zero length data can be optimized as a singleton
+        }
+        
         switch _backing {
         case .swift:
-            return _NSSwiftData(backing: self)
+            return _NSSwiftData(backing: self, range: range)
         case .immutable(let d):
+            guard range.lowerBound == 0 && range.upperBound == _length else {
+                return _NSSwiftData(backing: self, range: range)
+            }
             return d
         case .mutable(let d):
+            guard range.lowerBound == 0 && range.upperBound == _length else {
+                return _NSSwiftData(backing: self, range: range)
+            }
             return d
         case .customReference(let d):
+            guard range.lowerBound == 0 && range.upperBound == d.length else {
+                return _NSSwiftData(backing: self, range: range)
+            }
             return d
         case .customMutableReference(let d):
-            // Because this is returning an object that may be mutated in the future it needs to create a copy to prevent
-            // any further mutations out from under the receiver
+            guard range.lowerBound == 0 && range.upperBound == d.length else {
+                return d.subdata(with: NSRange(location: range.lowerBound, length: range.count))._bridgeToObjectiveC()
+            }
             return d.copy() as! NSData
         }
     }
@@ -777,14 +791,15 @@ public final class _DataStorage {
 
 internal class _NSSwiftData : NSData {
     var _backing: _DataStorage!
+    var _range: Range<Data.Index>!
     
-    convenience init(backing: _DataStorage) {
+    convenience init(backing: _DataStorage, range: Range<Data.Index>) {
         self.init()
         _backing = backing
+        _range = range
     }
-    
     override var length: Int {
-        return _backing.length
+        return _range.count
     }
     
     override var bytes: UnsafeRawPointer {
@@ -795,20 +810,28 @@ internal class _NSSwiftData : NSData {
         // return value here is not needed to be an allocated value. This is specifically
         // needed to live like this to be source compatible with Swift3. Beyond that point
         // this API may be subject to correction.
-        return _backing.bytes ?? UnsafeRawPointer(bitPattern: 0xBAD0)!
+        guard let bytes = _backing.bytes else {
+            return UnsafeRawPointer(bitPattern: 0xBAD0)!
+        }
+        
+        return bytes.advanced(by: _range.lowerBound)
     }
     
     override func copy(with zone: NSZone? = nil) -> Any {
-        return NSData(bytes: _backing.bytes, length: _backing.length)
+        return self
     }
-
+    
+    override func mutableCopy(with zone: NSZone? = nil) -> Any {
+        return NSMutableData(bytes: bytes, length: length)
+    }
+    
 #if !DEPLOYMENT_RUNTIME_SWIFT
     @objc
     func _isCompact() -> Bool {
         return true
     }
 #endif
-
+    
 #if DEPLOYMENT_RUNTIME_SWIFT
     override func _providesConcreteBacking() -> Bool {
         return true
@@ -942,7 +965,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
         }
         _sliceRange = 0..<count
     }
-
+    
     /// Initialize a `Data` with a repeating byte pattern
     ///
     /// - parameter repeatedValue: A byte to initialize the pattern
@@ -1055,7 +1078,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
             _backing = _DataStorage(customReference: reference.copy() as! NSData)
             _sliceRange = 0..<reference.length
         }
-
+        
     }
     
     @_versioned
@@ -1174,7 +1197,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
 #if !DEPLOYMENT_RUNTIME_SWIFT
     @inline(__always)
     private func _shouldUseNonAtomicWriteReimplementation(options: Data.WritingOptions = []) -> Bool {
-        
+    
         // Avoid a crash that happens on OS X 10.11.x and iOS 9.x or before when writing a bridged Data non-atomically with Foundation's standard write() implementation.
         if !options.contains(.atomic) {
             #if os(OSX)
@@ -1402,7 +1425,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
                 // In the future, if we keep the malloced pointer and count inside this struct/ref instead of deferring to NSData, we may be able to do this more efficiently.
                 self.count = resultCount
             }
-
+            
             let shift = resultCount - currentCount
             let start = subrange.lowerBound
             
@@ -1432,7 +1455,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
         let resultingLength = currentLength - nsRange.length + cnt
         _sliceRange = _sliceRange.lowerBound..<(_sliceRange.lowerBound + resultingLength)
     }
-
+    
     /// Return a new copy of the data in a specified range.
     ///
     /// - parameter range: The range to copy.
@@ -1495,7 +1518,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     public subscript(index: Index) -> UInt8 {
         @inline(__always)
         get {
-            return _backing.bytes!.advanced(by: _sliceRange.lowerBound + index).assumingMemoryBound(to: UInt8.self).pointee
+            return _backing.bytes!.advanced(by: index).assumingMemoryBound(to: UInt8.self).pointee
         }
         @inline(__always)
         set {
@@ -1517,39 +1540,24 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
         }
     }
     
-    public subscript(bounds: CountableRange<Index>) -> Data {
+    public subscript<R: RangeExpression>(_ rangeExpression: R) -> Data
+        where R.Bound: FixedWidthInteger, R.Bound.Stride : SignedInteger {
         @inline(__always)
         get {
-            return Data(backing: _backing, range: bounds.lowerBound..<bounds.upperBound)
+            let range = rangeExpression.relative(to: 0..<R.Bound.max)
+            let start: Int = numericCast(range.lowerBound)
+            let end: Int = numericCast(range.upperBound)
+            return Data(backing: _backing, range: start..<end)
         }
         @inline(__always)
         set {
-            replaceSubrange(bounds, with: newValue)
+            let range = rangeExpression.relative(to: 0..<R.Bound.max)
+            let start: Int = numericCast(range.lowerBound)
+            let end: Int = numericCast(range.upperBound)
+            replaceSubrange(start..<end, with: newValue)
         }
+            
     }
-    
-    public subscript(bounds: ClosedRange<Index>) -> Data {
-        @inline(__always)
-        get {
-            return Data(backing: _backing, range: bounds.lowerBound..<bounds.upperBound)
-        }
-        @inline(__always)
-        set {
-            replaceSubrange(bounds.lowerBound..<bounds.upperBound, with: newValue)
-        }
-    }
-    
-    public subscript(bounds: CountableClosedRange<Index>) -> Data {
-        @inline(__always)
-        get {
-            return Data(backing: _backing, range: bounds.lowerBound..<bounds.upperBound)
-        }
-        @inline(__always)
-        set {
-            replaceSubrange(bounds.lowerBound..<bounds.upperBound, with: newValue)
-        }
-    }
-    
     
     /// The start `Index` in the data.
     public var startIndex: Index {
@@ -1646,14 +1654,18 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
         let backing1 = d1._backing
         let backing2 = d2._backing
         if backing1 === backing2 {
-            return true
+            if d1._sliceRange == d2._sliceRange {
+                return true
+            }
         }
-        let length1 = backing1.length
-        if length1 != backing2.length {
+        let length1 = d1.count
+        if length1 != d2.count {
             return false
         }
         if backing1.bytes == backing2.bytes {
-            return true
+            if d1._sliceRange == d2._sliceRange {
+                return true
+            }
         }
         if length1 > 0 {
             return d1.withUnsafeBytes { (b1) in
@@ -1716,7 +1728,7 @@ internal typealias DataBridgeType = _ObjectiveCBridgeable
 extension Data : DataBridgeType {
     @_semantics("convertToObjectiveC")
     public func _bridgeToObjectiveC() -> NSData {
-        return _backing.bridgedReference()
+        return _backing.bridgedReference(_sliceRange)
     }
     
     public static func _forceBridgeFromObjectiveC(_ input: NSData, result: inout Data?) {
@@ -1747,11 +1759,11 @@ extension NSData : _HasCustomAnyHashableRepresentation {
 extension Data : Codable {
     public init(from decoder: Decoder) throws {
         var container = try decoder.unkeyedContainer()
-
+        
         // It's more efficient to pre-allocate the buffer if we can.
         if let count = container.count {
             self.init(count: count)
-
+            
             // Loop only until count, not while !container.isAtEnd, in case count is underestimated (this is misbehavior) and we haven't allocated enough space.
             // We don't want to write past the end of what we allocated.
             for i in 0 ..< count {
@@ -1761,16 +1773,16 @@ extension Data : Codable {
         } else {
             self.init()
         }
-
+        
         while !container.isAtEnd {
             var byte = try container.decode(UInt8.self)
             self.append(&byte, count: 1)
         }
     }
-
+    
     public func encode(to encoder: Encoder) throws {
         var container = encoder.unkeyedContainer()
-
+        
         // Since enumerateBytes does not rethrow, we need to catch the error, stow it away, and rethrow if we stopped.
         var caughtError: Error? = nil
         self.enumerateBytes { (buffer: UnsafeBufferPointer<UInt8>, byteIndex: Data.Index, stop: inout Bool) in
@@ -1781,7 +1793,7 @@ extension Data : Codable {
                 stop = true
             }
         }
-
+        
         if let error = caughtError {
             throw error
         }

--- a/test/stdlib/Inputs/FoundationBridge/FoundationBridge.m
+++ b/test/stdlib/Inputs/FoundationBridge/FoundationBridge.m
@@ -89,53 +89,10 @@
     return self;
 }
 
-- (void)dealloc {
-    [_verifier release];
-    [_data release];
-    [super dealloc];
-}
-
-- (id)retain {
-    [_verifier appendAction:ObjectBehaviorActionRetain];
-    return [super retain];
-}
-
-- (id)copyWithZone:(NSZone *)zone {
-    [_verifier appendAction:ObjectBehaviorActionCopy];
-    return [super retain];
-}
-
-- (id)mutableCopyWithZone:(NSZone *)zone {
-    [_verifier appendAction:ObjectBehaviorActionMutableCopy];
-    return [[MutableDataVerifier alloc] initWithData:_data];
-}
-
-- (NSUInteger)length {
-    return _data.length;
-}
-
-- (const void *)bytes {
-    return _data.bytes;
-}
-
-@end
-
-@implementation MutableDataVerifier
-
-- (instancetype)init {
+- (instancetype)initWithData:(NSData *)data verifier:(ObjectBehaviorVerifier *)verifier {
     self = [super init];
     if (self) {
-        _verifier = [[ObjectBehaviorVerifier alloc] init];
-        char *bytes = "hello world";
-        _data = [[NSMutableData alloc] initWithBytes:bytes length:strlen(bytes)];
-    }
-    return self;
-}
-
-- (instancetype)initWithData:(NSData *)data {
-    self = [super init];
-    if (self) {
-        _verifier = [[ObjectBehaviorVerifier alloc] init];
+        _verifier = [verifier retain];
         _data = [data mutableCopyWithZone:nil];
     }
     return self;
@@ -159,7 +116,63 @@
 
 - (id)mutableCopyWithZone:(NSZone *)zone {
     [_verifier appendAction:ObjectBehaviorActionMutableCopy];
-    return [[MutableDataVerifier alloc] initWithData:_data];
+    return [[MutableDataVerifier alloc] initWithData:_data verifier:_verifier];
+}
+
+- (NSUInteger)length {
+    return _data.length;
+}
+
+- (const void *)bytes {
+    return _data.bytes;
+}
+
+- (NSData *)subdataWithRange:(NSRange)range {
+    return [_data subdataWithRange:range];
+}
+
+@end
+
+@implementation MutableDataVerifier
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        _verifier = [[ObjectBehaviorVerifier alloc] init];
+        char *bytes = "hello world";
+        _data = [[NSMutableData alloc] initWithBytes:bytes length:strlen(bytes)];
+    }
+    return self;
+}
+
+- (instancetype)initWithData:(NSData *)data verifier:(ObjectBehaviorVerifier *)verifier {
+    self = [super init];
+    if (self) {
+        _verifier = [verifier retain];
+        _data = [data mutableCopyWithZone:nil];
+    }
+    return self;
+}
+
+- (void)dealloc {
+    [_verifier release];
+    [_data release];
+    [super dealloc];
+}
+
+- (id)retain {
+    [_verifier appendAction:ObjectBehaviorActionRetain];
+    return [super retain];
+}
+
+- (id)copyWithZone:(NSZone *)zone {
+    [_verifier appendAction:ObjectBehaviorActionCopy];
+    return [[ImmutableDataVerifier alloc] initWithData:_data verifier:_verifier];
+}
+
+- (id)mutableCopyWithZone:(NSZone *)zone {
+    [_verifier appendAction:ObjectBehaviorActionMutableCopy];
+    return [[MutableDataVerifier alloc] initWithData:_data verifier:_verifier];
 }
 
 - (NSUInteger)length {
@@ -176,6 +189,14 @@
 
 - (void *)mutableBytes {
     return _data.mutableBytes;
+}
+
+- (void)appendBytes:(const void *)bytes length:(NSUInteger)length {
+    [_data appendBytes:bytes length:length];
+}
+
+- (NSData *)subdataWithRange:(NSRange)range {
+    return [_data subdataWithRange:range];
 }
 
 @end

--- a/test/stdlib/TestData.swift
+++ b/test/stdlib/TestData.swift
@@ -729,18 +729,19 @@ class TestData : TestDataSuper {
         object.verifier.reset()
         var data = object as Data
         expectTrue(object.verifier.wasCopied)
-        expectFalse(object.verifier.wasMutableCopied)
+        expectFalse(object.verifier.wasMutableCopied, "Expected an invocation to mutableCopy")
 
         object.verifier.reset()
         expectTrue(data.count == object.length)
-        expectFalse(object.verifier.wasCopied)
+        expectFalse(object.verifier.wasCopied, "Expected an invocation to copy")
 
         object.verifier.reset()
         data.append("test", count: 4)
-        expectTrue(object.verifier.wasMutableCopied)
+        expectTrue(object.verifier.wasMutableCopied, "Expected an invocation to mutableCopy")
 
-        let preservedObjectness = (data as NSData) is MutableDataVerifier
-        expectTrue(preservedObjectness)
+        let d = data as NSData
+        let preservedObjectness = d is ImmutableDataVerifier
+        expectTrue(preservedObjectness, "Expected ImmutableDataVerifier but got \(object_getClass(d))")
     }
 
     func test_basicMutableDataMutation() {
@@ -749,18 +750,20 @@ class TestData : TestDataSuper {
         object.verifier.reset()
         var data = object as Data
         expectTrue(object.verifier.wasCopied)
-        expectFalse(object.verifier.wasMutableCopied)
+        expectFalse(object.verifier.wasMutableCopied, "Expected an invocation to mutableCopy")
         
         object.verifier.reset()
         expectTrue(data.count == object.length)
-        expectFalse(object.verifier.wasCopied)
+        expectFalse(object.verifier.wasCopied, "Expected an invocation to copy")
         
         object.verifier.reset()
         data.append("test", count: 4)
-        expectTrue(object.verifier.wasMutableCopied)
-        
-        let preservedObjectness = (data as NSData) is MutableDataVerifier
-        expectTrue(preservedObjectness)
+        expectTrue(object.verifier.wasMutableCopied, "Expected an invocation to mutableCopy")
+        object.verifier.dump()
+
+        let d = data as NSData
+        let preservedObjectness = d is ImmutableDataVerifier
+        expectTrue(preservedObjectness, "Expected ImmutableDataVerifier but got \(object_getClass(d))")
     }
 
     func test_roundTrip() {
@@ -1008,6 +1011,67 @@ class TestData : TestDataSuper {
     func test_unconditionallyBridgeFromObjectiveC() {
         expectEqual(Data(), Data._unconditionallyBridgeFromObjectiveC(nil))
     }
+
+    func test_sliceIndexing() {
+        let d = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
+        let slice = d[5..<10]
+        expectEqual(slice[5], d[5])
+    }
+    
+    func test_sliceEquality() {
+        let d = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
+        let slice = d[5..<7]
+        let expected = Data(bytes: [5, 6])
+        expectEqual(expected, slice)
+    }
+    
+    func test_sliceEquality2() {
+        let d = Data(bytes: [5, 6, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
+        let slice1 = d[0..<2]
+        let slice2 = d[5..<7]
+        expectEqual(slice1, slice2)
+    }
+    
+    func test_splittingHttp() {
+        func split(_ data: Data, on delimiter: String) -> [Data] {
+            let dataDelimeter = delimiter.data(using: .utf8)!
+            var found = [Data]()
+            let start = data.startIndex
+            let end = data.endIndex.advanced(by: -dataDelimeter.count)
+            guard end >= start else { return [data] }
+            var index = start
+            var previousIndex = index
+            while index < end {
+                let slice = data[index..<index.advanced(by: dataDelimeter.count)]
+                
+                if slice == dataDelimeter {
+                    found.append(data[previousIndex..<index])
+                    previousIndex = index + dataDelimeter.count
+                }
+                
+                index = index.advanced(by: 1)
+            }
+            if index < data.endIndex { found.append(data[index..<index]) }
+            return found
+        }
+        let data = "GET /index.html HTTP/1.1\r\nHost: www.example.com\r\n\r\n".data(using: .ascii)!
+        let fields = split(data, on: "\r\n")
+        let splitFields = fields.map { String(data:$0, encoding: .utf8)! }
+        expectEqual([
+            "GET /index.html HTTP/1.1",
+            "Host: www.example.com",
+            ""
+        ], splitFields)
+    }
+
+    func test_map() {
+        let d1 = Data(bytes: [81, 0, 0, 0, 14])
+        let d2 = d1[1...4]
+        expectEqual(4, d2.count)
+        let expected: [UInt8] = [0, 0, 0, 14]
+        let actual = d2.map { $0 }
+        expectEqual(expected, actual)
+    }
 }
 
 #if !FOUNDATION_XCTEST
@@ -1059,6 +1123,11 @@ DataTests.test("test_replaceSubrange") { TestData().test_replaceSubrange() }
 DataTests.test("test_sliceWithUnsafeBytes") { TestData().test_sliceWithUnsafeBytes() }
 DataTests.test("test_sliceIteration") { TestData().test_sliceIteration() }
 DataTests.test("test_unconditionallyBridgeFromObjectiveC") { TestData().test_unconditionallyBridgeFromObjectiveC() }
+DataTests.test("test_sliceIndexing") { TestData().test_sliceIndexing() }
+DataTests.test("test_sliceEquality") { TestData().test_sliceEquality() }
+DataTests.test("test_sliceEquality2") { TestData().test_sliceEquality2() }
+DataTests.test("test_splittingHttp") { TestData().test_splittingHttp() }
+DataTests.test("test_map") { TestData().test_map() }
 
 // XCTest does not have a crash detection, whereas lit does
 DataTests.test("bounding failure subdata") {


### PR DESCRIPTION
Resolves https://bugs.swift.org/browse/SR-4964

Subsequences of Data inappropriately ignored the slice regions of both bridged data as well as certain index accessors.