### PR TITLE
Re-gyb sorting (#9818)

### DIFF
--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -115,7 +115,7 @@ set(SWIFTLIB_ESSENTIAL
   ShadowProtocols.swift
   Shims.swift
   Slice.swift.gyb
-  Sort.swift
+  Sort.swift.gyb
   StaticString.swift
   Stride.swift.gyb
   StringCharacterView.swift # ORDER DEPENDENCY: Must precede String.swift

--- a/stdlib/public/core/CollectionAlgorithms.swift.gyb
+++ b/stdlib/public/core/CollectionAlgorithms.swift.gyb
@@ -380,7 +380,7 @@ extension MutableCollection
       return ()
     }
     if didSortUnsafeBuffer == nil {
-      _introSort(&self, subRange: startIndex..<endIndex, by: <)
+      _introSort(&self, subRange: startIndex..<endIndex)
     }
   }
 }

--- a/stdlib/public/core/Sort.swift.gyb
+++ b/stdlib/public/core/Sort.swift.gyb
@@ -10,15 +10,40 @@
 //
 //===----------------------------------------------------------------------===//
 
+%{
+def cmp(a, b, p):
+  if p:
+    return "(try areInIncreasingOrder(" + a + ", " + b + "))"
+  else:
+    return "(" + a + " < " + b + ")"
+
+}%
+
+// Generate two versions of sorting functions: one with an explicitly passed
+// predicate 'areInIncreasingOrder' and the other for Comparable types that don't
+// need such a predicate.
+% preds = [True, False]
+% for p in preds:
+%{
+if p:
+  rethrows_ = "rethrows"
+  try_ = "try"
+else:
+  rethrows_ = ""
+  try_ = ""
+}%
+
 @_inlineable
 @_versioned
 func _insertionSort<C>(
   _ elements: inout C,
-  subRange range: Range<C.Index>,
-  by areInIncreasingOrder: (C.Element, C.Element) throws -> Bool
-) rethrows where 
-  C : MutableCollection & BidirectionalCollection 
-{
+  subRange range: Range<C.Index>
+  ${", by areInIncreasingOrder: (C.Element, C.Element) throws -> Bool" if p else ""}
+) ${rethrows_} 
+  where
+  C : MutableCollection & BidirectionalCollection
+  ${"" if p else ", C.Element : Comparable"} {
+
   if !range.isEmpty {
     let start = range.lowerBound
 
@@ -37,20 +62,25 @@ func _insertionSort<C>(
       // moving elements forward to make room.
       var i = sortedEnd
       repeat {
-        let predecessor: C.Element =
-          elements[elements.index(before: i)]
+        let predecessor: C.Element = elements[elements.index(before: i)]
 
-        // If closure throws the error, We catch the error put the element at
-        // right place and rethrow the error.
+        % if p:
+        // If clouser throws the error, We catch the error put the element at right
+        // place and rethrow the error.
         do {
-        // if x doesn't belong before y, we've found its position
-        if try !areInIncreasingOrder(x, predecessor) {
+          // if x doesn't belong before y, we've found its position
+          if !${cmp("x", "predecessor", p)} {
             break
           }
         } catch {
           elements[i] = x
           throw error
         }
+        % else:
+        if !${cmp("x", "predecessor", p)} {
+          break
+        }
+        % end
 
         // Move y forward
         elements[i] = predecessor
@@ -78,11 +108,12 @@ func _insertionSort<C>(
 public // @testable
 func _sort3<C>(
   _ elements: inout C,
-  _ a: C.Index, _ b: C.Index, _ c: C.Index,
-  by areInIncreasingOrder: (C.Element, C.Element) throws -> Bool
-) rethrows
+  _ a: C.Index, _ b: C.Index, _ c: C.Index
+  ${", by areInIncreasingOrder: (C.Element, C.Element) throws -> Bool" if p else ""}
+) ${rethrows_}
   where
   C : MutableCollection & RandomAccessCollection
+  ${"" if p else ", C.Element : Comparable"}
 {
   // There are thirteen possible permutations for the original ordering of
   // the elements at indices `a`, `b`, and `c`. The comments in the code below
@@ -104,8 +135,8 @@ func _sort3<C>(
   //   122, 212, or 221.
   // - If all three elements are equivalent, they are already in order: 111.
 
-  switch (try areInIncreasingOrder(elements[b], elements[a]),
-          try areInIncreasingOrder(elements[c], elements[b])) {
+  switch (${cmp("elements[b]", "elements[a]", p)},
+    ${cmp("elements[c]", "elements[b]", p)}) {
   case (false, false):
     // 0 swaps: 123, 112, 122, 111
     break
@@ -120,7 +151,7 @@ func _sort3<C>(
     // swap(a, b): 213->123, 212->122, 312->132, 211->121
     elements.swapAt(a, b)
 
-    if try areInIncreasingOrder(elements[c], elements[b]) {
+    if ${cmp("elements[c]", "elements[b]", p)} {
       // 132 (started as 312), 121 (started as 211)
       // swap(b, c): 132->123, 121->112
       elements.swapAt(b, c)
@@ -131,7 +162,7 @@ func _sort3<C>(
     // swap(b, c): 132->123, 121->112, 231->213, 221->212
     elements.swapAt(b, c)
 
-    if try areInIncreasingOrder(elements[b], elements[a]) {
+    if ${cmp("elements[b]", "elements[a]", p)} {
       // 213 (started as 231), 212 (started as 221)
       // swap(a, b): 213->123, 212->122
       elements.swapAt(a, b)
@@ -149,11 +180,12 @@ func _sort3<C>(
 @_versioned
 func _partition<C>(
   _ elements: inout C,
-  subRange range: Range<C.Index>,
-  by areInIncreasingOrder: (C.Element, C.Element) throws -> Bool
-) rethrows -> C.Index
+  subRange range: Range<C.Index>
+  ${", by areInIncreasingOrder: (C.Element, C.Element) throws -> Bool" if p else ""}
+) ${rethrows_} -> C.Index
   where
   C : MutableCollection & RandomAccessCollection
+  ${"" if p else ", C.Element : Comparable"}
 {
   var lo = range.lowerBound
   var hi = elements.index(before: range.upperBound)
@@ -162,7 +194,8 @@ func _partition<C>(
   // as the pivot for the partition.
   let half = numericCast(elements.distance(from: lo, to: hi)) as UInt / 2
   let mid = elements.index(lo, offsetBy: numericCast(half))
-  try _sort3(&elements, lo, mid, hi, by: areInIncreasingOrder)
+  ${try_} _sort3(&elements, lo, mid, hi
+    ${", by: areInIncreasingOrder" if p else ""})
   let pivot = elements[mid]
 
   // Loop invariants:
@@ -173,7 +206,7 @@ func _partition<C>(
     FindLo: do {
       elements.formIndex(after: &lo)
       while lo != hi {
-        if try !areInIncreasingOrder(elements[lo], pivot) { break FindLo }
+        if !${cmp("elements[lo]", "pivot", p)} { break FindLo }
         elements.formIndex(after: &lo)
       }
       break Loop
@@ -182,7 +215,7 @@ func _partition<C>(
     FindHi: do {
       elements.formIndex(before: &hi)
       while hi != lo {
-        if try areInIncreasingOrder(elements[hi], pivot) { break FindHi }
+        if ${cmp("elements[hi]", "pivot", p)} { break FindHi }
         elements.formIndex(before: &hi)
       }
       break Loop
@@ -198,20 +231,25 @@ func _partition<C>(
 public // @testable
 func _introSort<C>(
   _ elements: inout C,
-  subRange range: Range<C.Index>,
-  by areInIncreasingOrder: (C.Element, C.Element) throws -> Bool
-) rethrows 
+  subRange range: Range<C.Index>
+  ${", by areInIncreasingOrder: (C.Element, C.Element) throws -> Bool" if p else ""}
+) ${rethrows_} 
   where
   C : MutableCollection & RandomAccessCollection
-{
-  let count = elements.distance(from: range.lowerBound, to: range.upperBound)
+  ${"" if p else ", C.Element : Comparable"} {
+
+  let count =
+    elements.distance(from: range.lowerBound, to: range.upperBound)
   if count < 2 {
     return
   }
   // Set max recursion depth to 2*floor(log(N)), as suggested in the introsort
   // paper: http://www.cs.rpi.edu/~musser/gp/introsort.ps
   let depthLimit = 2 * _floorLog2(Int64(count))
-  try _introSortImpl(&elements, subRange: range,  by: areInIncreasingOrder,
+  ${try_} _introSortImpl(
+    &elements,
+    subRange: range,
+    ${"by: areInIncreasingOrder," if p else ""}
     depthLimit: depthLimit)
 }
 
@@ -219,32 +257,47 @@ func _introSort<C>(
 @_versioned
 func _introSortImpl<C>(
   _ elements: inout C,
-  subRange range: Range<C.Index>,
-  by areInIncreasingOrder: (C.Element, C.Element) throws -> Bool,
+  subRange range: Range<C.Index>
+  ${", by areInIncreasingOrder: (C.Element, C.Element) throws -> Bool" if p else ""},
   depthLimit: Int
-) rethrows
+) ${rethrows_}
   where
   C : MutableCollection & RandomAccessCollection
-{
+  ${"" if p else ", C.Element : Comparable"} {
+
   // Insertion sort is better at handling smaller regions.
   if elements.distance(from: range.lowerBound, to: range.upperBound) < 20 {
-    try _insertionSort(&elements, subRange: range, by: areInIncreasingOrder)
+    ${try_} _insertionSort(
+      &elements,
+      subRange: range
+      ${", by: areInIncreasingOrder" if p else ""})
     return
   }
   if depthLimit == 0 {
-    try _heapSort(&elements, subRange: range, by: areInIncreasingOrder)
+    ${try_} _heapSort(
+      &elements,
+      subRange: range
+      ${", by: areInIncreasingOrder" if p else ""})
     return
   }
 
   // Partition and sort.
   // We don't check the depthLimit variable for underflow because this variable
   // is always greater than zero (see check above).
-  let partIdx: C.Index = try _partition(&elements, subRange: range,
-    by: areInIncreasingOrder)
-  try _introSortImpl(&elements, subRange: range.lowerBound..<partIdx,
-    by: areInIncreasingOrder, depthLimit: depthLimit &- 1)
-  try _introSortImpl(&elements, subRange: partIdx..<range.upperBound,
-    by: areInIncreasingOrder, depthLimit: depthLimit &- 1)
+  let partIdx: C.Index = ${try_} _partition(
+    &elements,
+    subRange: range
+    ${", by: areInIncreasingOrder" if p else ""})
+  ${try_} _introSortImpl(
+    &elements,
+    subRange: range.lowerBound..<partIdx,
+    ${"by: areInIncreasingOrder, " if p else ""}
+    depthLimit: depthLimit &- 1)
+  ${try_} _introSortImpl(
+    &elements,
+    subRange: partIdx..<range.upperBound,
+    ${"by: areInIncreasingOrder, " if p else ""}
+    depthLimit: depthLimit &- 1)
 }
 
 @_inlineable
@@ -252,12 +305,13 @@ func _introSortImpl<C>(
 func _siftDown<C>(
   _ elements: inout C,
   index: C.Index,
-  subRange range: Range<C.Index>,
-  by areInIncreasingOrder: (C.Element, C.Element) throws -> Bool
-) rethrows
+  subRange range: Range<C.Index>
+  ${", by areInIncreasingOrder: (C.Element, C.Element) throws -> Bool" if p else ""}
+) ${rethrows_}
   where
   C : MutableCollection & RandomAccessCollection
-{
+  ${"" if p else ", C.Element : Comparable"} {
+
   let countToIndex = elements.distance(from: range.lowerBound, to: index)
   let countFromIndex = elements.distance(from: index, to: range.upperBound)
   // Check if left child is within bounds. If not, return, because there are
@@ -267,13 +321,13 @@ func _siftDown<C>(
   }
   let left = elements.index(index, offsetBy: countToIndex + 1)
   var largest = index
-  if try areInIncreasingOrder(elements[largest], elements[left]) {
+  if ${cmp("elements[largest]", "elements[left]", p)} {
     largest = left
   }
   // Check if right child is also within bounds before trying to examine it.
   if countToIndex + 2 < countFromIndex {
     let right = elements.index(after: left)
-    if try areInIncreasingOrder(elements[largest], elements[right]) {
+    if ${cmp("elements[largest]", "elements[right]", p)} {
       largest = right
     }
   }
@@ -281,8 +335,11 @@ func _siftDown<C>(
   // down.
   if largest != index {
     elements.swapAt(index, largest)
-    try _siftDown(&elements, index: largest, subRange: range,
-      by: areInIncreasingOrder)
+    ${try_} _siftDown(
+      &elements,
+      index: largest,
+      subRange: range
+      ${", by: areInIncreasingOrder" if p else ""})
   }
 }
 
@@ -290,12 +347,12 @@ func _siftDown<C>(
 @_versioned
 func _heapify<C>(
   _ elements: inout C,
-  subRange range: Range<C.Index>,
-  by areInIncreasingOrder: (C.Element, C.Element) throws -> Bool
-) rethrows
+  subRange range: Range<C.Index>
+  ${", by areInIncreasingOrder: (C.Element, C.Element) throws -> Bool" if p else ""}
+) ${rethrows_}
   where
   C : MutableCollection & RandomAccessCollection
-{
+  ${"" if p else ", C.Element : Comparable"} {
   // Here we build a heap starting from the lowest nodes and moving to the root.
   // On every step we sift down the current node to obey the max-heap property:
   //   parent >= max(leftChild, rightChild)
@@ -310,8 +367,11 @@ func _heapify<C>(
 
   while node != root {
     elements.formIndex(before: &node)
-    try _siftDown(&elements, index: node, subRange: range,
-      by: areInIncreasingOrder)
+    ${try_} _siftDown(
+      &elements,
+      index: node,
+      subRange: range
+      ${", by: areInIncreasingOrder" if p else ""})
   }
 }
 
@@ -319,40 +379,36 @@ func _heapify<C>(
 @_versioned
 func _heapSort<C>(
   _ elements: inout C,
-  subRange range: Range<C.Index>,
-  by areInIncreasingOrder: (C.Element, C.Element) throws -> Bool
-) rethrows
+  subRange range: Range<C.Index>
+  ${", by areInIncreasingOrder: (C.Element, C.Element) throws -> Bool" if p else ""}
+) ${rethrows_} 
   where
   C : MutableCollection & RandomAccessCollection
-{
+  ${"" if p else ", C.Element : Comparable"} {
   var hi = range.upperBound
   let lo = range.lowerBound
-  try _heapify(&elements, subRange: range, by: areInIncreasingOrder)
+  ${try_} _heapify(
+    &elements,
+    subRange: range
+    ${", by: areInIncreasingOrder" if p else ""})
   elements.formIndex(before: &hi)
   while hi != lo {
     elements.swapAt(lo, hi)
-    try _siftDown(&elements, index: lo, subRange: lo..<hi, by: areInIncreasingOrder)
+    ${try_} _siftDown(
+      &elements,
+      index: lo,
+      subRange: lo..<hi
+      ${", by: areInIncreasingOrder" if p else ""})
     elements.formIndex(before: &hi)
   }
 }
 
-/// Exchanges the values of the two given variables.
+% end
+// for p in preds
+
+/// Exchange the values of `a` and `b`.
 ///
-/// The two variables passed must not alias each other. For example, it is an
-/// error to pass the same variable as both `a` and `b`.
-///
-/// In the following example, the call to `swap(_:_:)` guarantees that the
-/// value in `a` is always less than the value in `b`:
-///
-///     var a: Int = getNumber()
-///     var b: Int = getNumber()
-///     if a >= b {
-///         swap(&a, &b)
-///     }
-///
-/// - Parameters:
-///   - i: The first value to swap.
-///   - j: The index of the second value to swap.
+/// - Precondition: `a` and `b` do not alias each other.
 @_inlineable
 public func swap<T>(_ a: inout T, _ b: inout T) {
   // Semantically equivalent to (a, b) = (b, a).
@@ -370,4 +426,3 @@ public func swap<T>(_ a: inout T, _ b: inout T) {
   // Initialize P2.
   Builtin.initialize(tmp, p2)
 }
-

--- a/validation-test/stdlib/Algorithm.swift
+++ b/validation-test/stdlib/Algorithm.swift
@@ -229,7 +229,7 @@ Algorithm.test("sort3/simple")
     [1, 2, 3], [1, 3, 2], [2, 1, 3], [2, 3, 1], [3, 1, 2], [3, 2, 1]
   ]) {
     var input = $0
-    _sort3(&input, 0, 1, 2, by: <)
+    _sort3(&input, 0, 1, 2)
     expectEqual([1, 2, 3], input)
 }
 

--- a/validation-test/stdlib/Sort.swift.gyb
+++ b/validation-test/stdlib/Sort.swift.gyb
@@ -99,6 +99,7 @@ class OffsetCollection : MutableCollection, RandomAccessCollection {
 %   for p in withPredicateValues:
 // workaround for <rdar://problem/18900352> gyb miscompiles nested loops
 %     comparePredicate = "<" if p else ""
+%     commaComparePredicate = ", by: <" if p else ""
 %     name = "lessPredicate" if p else "noPredicate"
 
 Algorithm.test("${t}/sorted/${name}") {
@@ -119,8 +120,7 @@ Algorithm.test("${t}/sorted/${name}") {
   let i1 = 400
   let i2 = 700
   sortedAry2 = ary
-  _introSort(&sortedAry2, subRange: i1..<i2, by: <)
-
+  _introSort(&sortedAry2, subRange: i1..<i2${commaComparePredicate})
   expectEqual(ary[0..<i1], sortedAry2[0..<i1])
   expectSortedCollection(sortedAry2[i1..<i2], ary[i1..<i2])
   expectEqual(ary[i2..<count], sortedAry2[i2..<count])


### PR DESCRIPTION
Cherry-pick of #9818 

Explanation: To reduce code size, the duplication using gym of the sort algorithms (one using `Comparable` and one taking a closure) was collapsed into one implementation. This passed PR benchmarks, but later was discovered to have performance impact other cases.
Scope: Affects the implementation of the stdlib sort algorithms.
Radar: rdar://problem/31939398
Risk: Low. This is a revert, albeit not the automated one as the source has changed slightly since (mainly elimination of `Iterator.` for `Element`).
Testing: Passed compiler regression tests covering sorting.