### PR TITLE
[cast-optimizer] Properly handle conditional bridged casts in optimizeBridgedSwiftToObjCCast

### DIFF
--- a/lib/SIL/DynamicCasts.cpp
+++ b/lib/SIL/DynamicCasts.cpp
@@ -633,19 +633,8 @@ swift::classifyDynamicCast(ModuleDecl *M,
   if (source->isBridgeableObjectType() && mayBridgeToObjectiveC(M, target)) {
     // Try to get the ObjC type which is bridged to target type.
     assert(!target.isAnyExistentialType());
-    if (Type ObjCTy = M->getASTContext().getBridgedToObjC(M, target)) {
-      // If the bridged ObjC type is known, check if
-      // source type can be cast into it.
-      auto canCastToBridgedType = classifyDynamicCast(M, source,
-          ObjCTy->getCanonicalType(),
-          /* isSourceTypeExact */ false, isWholeModuleOpts);
-      // Temper our enthusiasm if the bridge from the ObjC type to the target
-      // value type may fail.
-      if (canCastToBridgedType == DynamicCastFeasibility::WillSucceed
-          && M->getASTContext().isObjCClassWithMultipleSwiftBridgedTypes(ObjCTy))
-        return DynamicCastFeasibility::MaySucceed;
-      return canCastToBridgedType;
-    }
+    // ObjC-to-Swift casts may fail. And in most cases it is impossible to
+    // statically predict the outcome. So, let's be conservative here.
     return DynamicCastFeasibility::MaySucceed;
   }
   

--- a/lib/SILOptimizer/Utils/Local.cpp
+++ b/lib/SILOptimizer/Utils/Local.cpp
@@ -1847,9 +1847,10 @@ simplifyCheckedCastAddrBranchInst(CheckedCastAddrBranchInst *Inst) {
   // To apply the bridged optimizations, we should
   // ensure that types are not existential,
   // and that not both types are classes.
-  BridgedI = optimizeBridgedCasts(Inst, Inst->getConsumptionKind(),
-                                  true, Src, Dest, SourceType,
-                                  TargetType, SuccessBB, FailureBB);
+  BridgedI = optimizeBridgedCasts(
+      Inst, Inst->getConsumptionKind(),
+      /* isConditional */ Feasibility == DynamicCastFeasibility::MaySucceed,
+      Src, Dest, SourceType, TargetType, SuccessBB, FailureBB);
 
   if (!BridgedI) {
     // If the cast may succeed or fail, and it can't be optimized into a
@@ -1960,9 +1961,10 @@ CastOptimizer::simplifyCheckedCastBranchInst(CheckedCastBranchInst *Inst) {
     auto Src = Inst->getOperand();
     auto Dest = SILValue();
     // Apply the bridged cast optimizations.
-    auto BridgedI = optimizeBridgedCasts(Inst,
-        CastConsumptionKind::CopyOnSuccess, false, Src, Dest, SourceType,
-        TargetType, nullptr, nullptr);
+    auto BridgedI = optimizeBridgedCasts(
+        Inst, CastConsumptionKind::CopyOnSuccess,
+        /* isConditional */ Feasibility == DynamicCastFeasibility::MaySucceed,
+        Src, Dest, SourceType, TargetType, nullptr, nullptr);
 
     if (BridgedI) {
       CastedValue = BridgedI;
@@ -2044,8 +2046,9 @@ SILInstruction *CastOptimizer::simplifyCheckedCastValueBranchInst(
     auto Dest = SILValue();
     // Apply the bridged cast optimizations.
     auto BridgedI = optimizeBridgedCasts(
-        Inst, CastConsumptionKind::CopyOnSuccess, false, Src, Dest,
-        SourceType, TargetType, nullptr, nullptr);
+        Inst, CastConsumptionKind::CopyOnSuccess,
+        /* isConditional */ Feasibility == DynamicCastFeasibility::MaySucceed,
+        Src, Dest, SourceType, TargetType, nullptr, nullptr);
 
     if (BridgedI) {
       CastedValue = BridgedI;

--- a/lib/SILOptimizer/Utils/Local.cpp
+++ b/lib/SILOptimizer/Utils/Local.cpp
@@ -1961,6 +1961,8 @@ CastOptimizer::simplifyCheckedCastBranchInst(CheckedCastBranchInst *Inst) {
     auto Src = Inst->getOperand();
     auto Dest = SILValue();
     // Apply the bridged cast optimizations.
+    // TODO: Bridged casts cannot be expressed by checked_cast_br yet.
+    // Should we ever support it, please review this code.
     auto BridgedI = optimizeBridgedCasts(
         Inst, CastConsumptionKind::CopyOnSuccess,
         /* isConditional */ Feasibility == DynamicCastFeasibility::MaySucceed,
@@ -1968,6 +1970,8 @@ CastOptimizer::simplifyCheckedCastBranchInst(CheckedCastBranchInst *Inst) {
 
     if (BridgedI) {
       CastedValue = BridgedI;
+      llvm_unreachable(
+        "Bridged casts cannot be expressed by checked_cast_br yet");
     } else {
       // If the cast may succeed or fail and can't be turned into a bridging
       // call, then let it be.
@@ -2045,6 +2049,9 @@ SILInstruction *CastOptimizer::simplifyCheckedCastValueBranchInst(
     auto Src = Inst->getOperand();
     auto Dest = SILValue();
     // Apply the bridged cast optimizations.
+    // TODO: Bridged casts cannot be expressed by checked_cast_value_br yet.
+    // Once the support for opaque values has landed, please review this
+    // code.
     auto BridgedI = optimizeBridgedCasts(
         Inst, CastConsumptionKind::CopyOnSuccess,
         /* isConditional */ Feasibility == DynamicCastFeasibility::MaySucceed,
@@ -2052,6 +2059,8 @@ SILInstruction *CastOptimizer::simplifyCheckedCastValueBranchInst(
 
     if (BridgedI) {
       CastedValue = BridgedI;
+      llvm_unreachable(
+          "Bridged casts cannot be expressed by checked_cast_value_br yet");
     } else {
       // If the cast may succeed or fail and can't be turned into a bridging
       // call, then let it be.

--- a/test/SILOptimizer/cast_folding_objc.swift
+++ b/test/SILOptimizer/cast_folding_objc.swift
@@ -270,13 +270,13 @@ public class MyString: NSString {}
 // Check that the cast-optimizer bails out on a conditional downcast to a subclass of a
 // bridged ObjC class.
 // CHECK-LABEL: sil [noinline] @{{.*}}testConditionalBridgedCastFromSwiftToNSObjectDerivedClass{{.*}}
+// CHECK: function_ref @_T0SS10FoundationE19_bridgeToObjectiveC{{[_0-9a-zA-Z]*}}F
+// CHECK: apply
+// CHECK-NOT: apply
+// CHECK-NOT: unconditional_checked_cast
+// CHECK: checked_cast_br
 // CHECK-NOT: apply
 // CHECK-NOT: unconditional
-// CHECK-NOT: checked_cast_br
-// CHECK: checked_cast_addr_br
-// CHECK-NOT: apply
-// CHECK-NOT: unconditional
-// CHECK-NOT: checked_cast_br
 // CHECK: return
 @inline(never)
 public func testConditionalBridgedCastFromSwiftToNSObjectDerivedClass(_ s: String) -> MyString? {


### PR DESCRIPTION
If there is a conditional bridged cast from a swift type to an objc type and this cast happens in two stages, where:
-  in the firs stage the Swift type is casted to its bridged ObjC class (e.g. String to NSString) and
-  in the second stage there is a downcast to a subclass of a bridged ObjC class (e.g. NSString to MyString)

then the second stage should use a conditional cast.

rdar://32319580