### PR TITLE
Fix the test by removing a system-dependent check

### DIFF
--- a/test/stdlib/ManagedBuffer.swift
+++ b/test/stdlib/ManagedBuffer.swift
@@ -12,8 +12,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
-// UNSUPPORTED: OS=linux-gnu
-
 import StdlibUnittest
 
 
@@ -193,7 +191,6 @@ tests.test("ManagedBufferPointer") {
     let s = buf!
     expectEqual(0, s.count)
     expectLE(10, s.capacity)
-    expectGE(12, s.capacity)  // allow some over-allocation but not too much
     
     expectEqual(s.count, mgr.header.count.value)
     expectEqual(s.capacity, mgr.header.capacity)


### PR DESCRIPTION
The removed check was dependent on the malloc implementation of the target operating system, because it asks for a real size of the allocated memory block. Usually, there is only a minor over-allocation due to the way how most malloc implementations work. But this is not guaranteed to hold for any malloc implementation.

rdar://problem/32315336