### PR TITLE
[cast-optimizer] Bail out on a conditional downcast to a subclass of a bridged ObjC class

### DIFF
--- a/lib/SILOptimizer/Utils/Local.cpp
+++ b/lib/SILOptimizer/Utils/Local.cpp
@@ -1461,6 +1461,13 @@ optimizeBridgedSwiftToObjCCast(SILInstruction *Inst,
   auto &M = Inst->getModule();
   auto Loc = Inst->getLoc();
 
+  // FIXME (rdar://problem/32319580): The code below handles a cast from a Swift
+  // value type to a subclass of its bridged type by emitting an unconditional
+  // cast, even if the cast is supposed to be conditional.
+  if (isConditional && !BridgedSourceTy->isEqual(BridgedTargetTy) &&
+      BridgedSourceTy->isBindableToSuperclassOf(BridgedTargetTy))
+    return nullptr;
+
   bool AddressOnlyType = false;
   if (!Src->getType().isLoadable(M) || !Dest->getType().isLoadable(M)) {
     AddressOnlyType = true;

--- a/test/SILOptimizer/cast_folding_objc.swift
+++ b/test/SILOptimizer/cast_folding_objc.swift
@@ -265,3 +265,37 @@ public func testBridgedCastFromSwiftToObjC(_ s: String) -> NSString {
   return s as NSString
 }
 
+public class MyString: NSString {}
+
+// Check that the cast-optimizer bails out on a conditional downcast to a subclass of a
+// bridged ObjC class.
+// CHECK-LABEL: sil [noinline] @{{.*}}testConditionalBridgedCastFromSwiftToNSObjectDerivedClass{{.*}}
+// CHECK-NOT: apply
+// CHECK-NOT: unconditional
+// CHECK-NOT: checked_cast_br
+// CHECK: checked_cast_addr_br
+// CHECK-NOT: apply
+// CHECK-NOT: unconditional
+// CHECK-NOT: checked_cast_br
+// CHECK: return
+@inline(never)
+public func testConditionalBridgedCastFromSwiftToNSObjectDerivedClass(_ s: String) -> MyString? {
+  return s as? MyString
+}
+
+// Check that the cast-optimizer does not bail out on an unconditional downcast to a subclass of a
+// bridged ObjC class.
+// CHECK-LABEL: sil [noinline] @{{.*}}testForcedBridgedCastFromSwiftToNSObjectDerivedClass{{.*}}
+// CHECK: function_ref @_T0SS10FoundationE19_bridgeToObjectiveC{{[_0-9a-zA-Z]*}}F
+// CHECK: apply
+// CHECK-NOT: apply
+// CHECK-NOT: checked_cast_br
+// CHECK: unconditional_checked_cast
+// CHECK-NOT: apply
+// CHECK-NOT: unconditional
+// CHECK-NOT: checked_cast
+// CHECK: return
+@inline(never)
+public func testForcedBridgedCastFromSwiftToNSObjectDerivedClass(_ s: String) -> MyString {
+    return s as! MyString
+}


### PR DESCRIPTION
This is very conservative fix for rdar://problem/32316838.
