### PR TITLE
Sema: Don't crash when recovering type errors from malformed keypath expressions.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -450,6 +450,8 @@ ERROR(expr_swift_keypath_unimplemented_component,none,
 ERROR(expr_smart_keypath_value_covert_to_contextual_type,none,
       "KeyPath value type %0 cannot be converted to contextual type %1",
       (Type, Type))
+ERROR(expr_string_interpolation_outside_string,none,
+      "string interpolation can only appear inside a string literal", ())
 
 // Selector expressions.
 ERROR(expr_selector_no_objc_runtime,none,

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -4607,6 +4607,7 @@ public:
   class Component {
   public:
     enum class Kind: unsigned {
+      Invalid,
       UnresolvedProperty,
       UnresolvedSubscript,
       Property,
@@ -4641,7 +4642,7 @@ public:
     {}
     
   public:
-    Component() : Component({}, nullptr, (Kind)0, Type(), SourceLoc()) {}
+    Component() : Component({}, nullptr, Kind::Invalid, Type(), SourceLoc()) {}
     
     /// Create an unresolved component for a property.
     static Component forUnresolvedProperty(DeclName UnresolvedName,
@@ -4745,12 +4746,17 @@ public:
       return SubscriptIndexExprAndKind.getInt();
     }
     
+    bool isValid() const {
+      return getKind() != Kind::Invalid;
+    }
+    
     Expr *getIndexExpr() const {
       switch (getKind()) {
       case Kind::Subscript:
       case Kind::UnresolvedSubscript:
         return SubscriptIndexExprAndKind.getPointer();
         
+      case Kind::Invalid:
       case Kind::OptionalChain:
       case Kind::OptionalWrap:
       case Kind::OptionalForce:
@@ -4765,6 +4771,7 @@ public:
       case Kind::UnresolvedProperty:
         return Decl.UnresolvedName;
 
+      case Kind::Invalid:
       case Kind::Subscript:
       case Kind::UnresolvedSubscript:
       case Kind::OptionalChain:
@@ -4781,6 +4788,7 @@ public:
       case Kind::Subscript:
         return Decl.ResolvedDecl;
 
+      case Kind::Invalid:
       case Kind::UnresolvedProperty:
       case Kind::UnresolvedSubscript:
       case Kind::OptionalChain:

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2429,6 +2429,10 @@ public:
       OS.indent(Indent + 2);
       OS << "(component=";
       switch (component.getKind()) {
+      case KeyPathExpr::Component::Kind::Invalid:
+        OS << "invalid ";
+        break;
+
       case KeyPathExpr::Component::Kind::OptionalChain:
         OS << "optional_chain ";
         break;

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -969,6 +969,7 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
       case KeyPathExpr::Component::Kind::OptionalForce:
       case KeyPathExpr::Component::Kind::Property:
       case KeyPathExpr::Component::Kind::UnresolvedProperty:
+      case KeyPathExpr::Component::Kind::Invalid:
         // No subexpr to visit.
         break;
       }

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2753,7 +2753,7 @@ RValue RValueEmitter::visitKeyPathExpr(KeyPathExpr *E, SGFContext C) {
     case KeyPathExpr::Component::Kind::OptionalWrap:
       return unsupported("non-property key path component");
       
-    
+    case KeyPathExpr::Component::Kind::Invalid:
     case KeyPathExpr::Component::Kind::UnresolvedProperty:
     case KeyPathExpr::Component::Kind::UnresolvedSubscript:
       llvm_unreachable("not resolved");

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -305,6 +305,7 @@ static bool buildObjCKeyPathString(KeyPathExpr *E,
       // when indexing a Dictionary or NSDictionary by string, or when applying
       // a mapping subscript operation to Array/Set or NSArray/NSSet.
       return false;
+    case KeyPathExpr::Component::Kind::Invalid:
     case KeyPathExpr::Component::Kind::UnresolvedProperty:
     case KeyPathExpr::Component::Kind::UnresolvedSubscript:
       // Don't bother building the key path string if the key path didn't even
@@ -4123,6 +4124,7 @@ namespace {
         case KeyPathExpr::Component::Kind::Property:
         case KeyPathExpr::Component::Kind::Subscript:
         case KeyPathExpr::Component::Kind::OptionalWrap:
+        case KeyPathExpr::Component::Kind::Invalid:
           llvm_unreachable("already resolved");
         }
 

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -6953,6 +6953,7 @@ static bool diagnoseKeyPathComponents(ConstraintSystem *CS, KeyPathExpr *KPE,
       componentName = TC.Context.Id_subscript;
       break;
 
+    case KeyPathExpr::Component::Kind::Invalid:
     case KeyPathExpr::Component::Kind::OptionalChain:
     case KeyPathExpr::Component::Kind::OptionalForce:
       // FIXME: Diagnose optional chaining and forcing properly.

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2755,7 +2755,13 @@ namespace {
         CS.TC.diagnose(E->getLoc(), diag::expr_keypath_no_keypath_type);
         return ErrorType::get(CS.getASTContext());
       }
-
+      
+      // If the key path contained any syntactically invalid components, bail
+      // out.
+      for (auto &c : E->getComponents())
+        if (!c.isValid())
+          return ErrorType::get(CS.getASTContext());
+      
       // For native key paths, traverse the key path components to set up
       // appropriate type relationships at each level.
       auto locator = CS.getConstraintLocator(E);
@@ -2778,6 +2784,9 @@ namespace {
       for (unsigned i : indices(E->getComponents())) {
         auto &component = E->getComponents()[i];
         switch (auto kind = component.getKind()) {
+        case KeyPathExpr::Component::Kind::Invalid:
+          llvm_unreachable("should have bailed out");
+        
         case KeyPathExpr::Component::Kind::UnresolvedProperty: {
           auto memberTy = CS.createTypeVariable(locator, TVO_CanBindToLValue);
           auto refKind = component.getUnresolvedDeclName().isSimpleName()

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3823,6 +3823,9 @@ ConstraintSystem::simplifyKeyPathConstraint(Type keyPathTy,
     auto &component = keyPath->getComponents()[i];
     
     switch (component.getKind()) {
+    case KeyPathExpr::Component::Kind::Invalid:
+      return SolutionKind::Error;
+      
     case KeyPathExpr::Component::Kind::UnresolvedProperty:
     case KeyPathExpr::Component::Kind::UnresolvedSubscript: {
       // If no choice was made, leave the constraint unsolved.

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1511,9 +1511,18 @@ void PreCheckExpression::resolveKeyPathExpr(KeyPathExpr *KPE) {
         assert(OEE == outermostExpr);
         expr = OEE->getSubExpr();
       } else {
-        if (emitErrors)
-          TC.diagnose(expr->getLoc(),
-                      diag::expr_swift_keypath_invalid_component);
+        if (emitErrors) {
+          // \(<expr>) may be an attempt to write a string interpolation outside
+          // of a string literal; diagnose this case specially.
+          if (isa<ParenExpr>(expr) || isa<TupleExpr>(expr)) {
+            TC.diagnose(expr->getLoc(),
+                        diag::expr_string_interpolation_outside_string);
+          } else {
+            TC.diagnose(expr->getLoc(),
+                        diag::expr_swift_keypath_invalid_component);
+          }
+        }
+        components.push_back(KeyPathExpr::Component());
         return;
       }
     }

--- a/lib/Sema/TypeCheckExprObjC.cpp
+++ b/lib/Sema/TypeCheckExprObjC.cpp
@@ -199,6 +199,9 @@ Optional<Type> TypeChecker::checkObjCKeyPathExpr(DeclContext *dc,
     // ObjC keypaths only support named segments.
     // TODO: Perhaps we can map subscript components to dictionary keys.
     switch (auto kind = component.getKind()) {
+    case KeyPathExpr::Component::Kind::Invalid:
+      continue;
+
     case KeyPathExpr::Component::Kind::UnresolvedProperty:
       break;
     case KeyPathExpr::Component::Kind::UnresolvedSubscript:

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -131,6 +131,11 @@ func testKeyPath(sub: Sub, optSub: OptSub, x: Int) {
   let _: ReferenceWritableKeyPath<Prop, B> = \.nonMutatingProperty
 }
 
+func testDisembodiedStringInterpolation(x: Int) {
+  \(x) // expected-error{{string interpolation}}
+  \(x, radix: 16) // expected-error{{string interpolation}}
+}
+
 struct TupleStruct {
   var unlabeled: (Int, String)
   var labeled: (foo: Int, bar: String)


### PR DESCRIPTION
It's particularly likely someone will try to type `\(foo)`, which looks like a string interpolation segment, outside of a string literal, so give that case a special diagnostic. Fixes rdar://problem/32315365.