### PR TITLE
SIL optimizer: Don’t crash if the user illegally lets an address of a local variable escape with withUnsafePointer

### DIFF
--- a/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
+++ b/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
@@ -865,8 +865,19 @@ bool MemoryToRegisters::run() {
         DEBUG(llvm::dbgs() << "*** Deleting single block AllocStackInst: "
                            << *ASI);
         I++;
-        ASI->eraseFromParent();
-        NumInstRemoved++;
+        if (ASI->use_empty()) {
+          // After removing all the allocation instructions the ASI should not
+          // have any uses.
+          ASI->eraseFromParent();
+          NumInstRemoved++;
+        } else {
+          // Handle a corner case where the ASI still has uses:
+          // This can come up if the source contains a withUnsafePointer where
+          // the pointer escapes. It's illegal code but we should not crash.
+          // Re-insert a dealloc_stack so that the verifier is happy.
+          B.setInsertionPoint(std::next(ASI->getIterator()));
+          B.createDeallocStack(ASI->getLoc(), ASI);
+        }
         Changed = true;
         continue;
       }

--- a/test/SILOptimizer/illegal_escaping_address.swift
+++ b/test/SILOptimizer/illegal_escaping_address.swift
@@ -1,0 +1,51 @@
+// RUN: %target-swift-frontend -O -sil-verify-all -emit-sil -parse-as-library %s
+
+// Check that the compiler does not crash for illegal escaping of an address
+// of a local variable.
+
+var gg = 0
+
+@inline(never)
+public func consume(_ x: Int) {
+  gg = x
+}
+
+public func test_load_after_dealloc_multi_block(b: Bool) {
+  var p: UnsafePointer<Int>? = nil
+  if (true) {
+    var local = 42
+    p = withUnsafePointer(to: &local) { p in
+      return p
+    }
+  }
+  if b {
+    consume(p!.pointee)
+  }
+}
+
+public func test_load_after_dealloc_single_block() {
+  var p: UnsafePointer<Int>? = nil
+  if (true) {
+    var local = 42
+    p = withUnsafePointer(to: &local) { p in
+      return p
+    }
+  }
+  consume(p!.pointee)
+}
+
+public func test_address_escaping_function_multi_block(b: Bool) -> UnsafePointer<Int>? {
+  var local = 42
+  let p: UnsafePointer<Int> = withUnsafePointer(to: &local) { p in return p }
+  if b {
+    return p
+  }
+  return nil
+}
+
+public func test_address_escaping_function_single_block() -> UnsafePointer<Int> {
+  var local = 42
+  let p: UnsafePointer<Int> = withUnsafePointer(to: &local) { p in return p }
+  return p
+}
+


### PR DESCRIPTION
rdar://problem/32307046

