### PR TITLE
Debug info: Avoid emitting module imports twice when access path differs

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -97,7 +97,7 @@ class IRGenDebugInfoImpl : public IRGenDebugInfo {
   /// A list of replaceable fwddecls that need to be RAUWed at the end.
   std::vector<std::pair<TypeBase *, llvm::TrackingMDRef>> ReplaceMap;
   /// The set of imported modules.
-  llvm::DenseSet<ModuleDecl::ImportedModule> ImportedModules;
+  llvm::DenseSet<ModuleDecl *> ImportedModules;
 
   llvm::BumpPtrAllocator DebugInfoNames;
   StringRef CWDName;                    /// The current working directory.
@@ -1558,7 +1558,7 @@ void IRGenDebugInfoImpl::finalize() {
   IGM.getSwiftModule()->getImportedModules(ModuleWideImports,
                                            ModuleDecl::ImportFilter::All);
   for (auto M : ModuleWideImports)
-    if (!ImportedModules.count(M))
+    if (!ImportedModules.count(M.second))
        DBuilder.createImportedModule(MainFile, getOrCreateModule(M), 0);
 
   // Finalize all replaceable forward declarations.
@@ -1731,7 +1731,7 @@ void IRGenDebugInfoImpl::emitImport(ImportDecl *D) {
   auto DIMod = getOrCreateModule(Imported);
   auto L = getDebugLoc(*this, D);
   DBuilder.createImportedModule(getOrCreateFile(L.Filename), DIMod, L.Line);
-  ImportedModules.insert(Imported);
+  ImportedModules.insert(Imported.second);
 }
 
 llvm::DISubprogram *IRGenDebugInfoImpl::emitFunction(SILFunction &SILFn,

--- a/test/DebugInfo/ImportClangSubmodule.swift
+++ b/test/DebugInfo/ImportClangSubmodule.swift
@@ -16,6 +16,8 @@ import ClangModule.SubModule
 
 // The Swift compiler uses an ugly hack that auto-imports a
 // submodule's top-level-module, even if we didn't ask for it.
+// CHECK-NOT: !DIImportedEntity({{.*}}, entity: ![[SUBMODULE]]
 // CHECK: !DIImportedEntity({{.*}}, entity: ![[CLANGMODULE]])
+// CHECK-NOT: !DIImportedEntity({{.*}}, entity: ![[SUBMODULE]]
 
 let bar = Bar()


### PR DESCRIPTION
This fixes a recent regression from 68a5cadb90e.
rdar://problem/32327266
