### PR TITLE
[4.0] SILGen: Substitute initializer's interface type into thunk's context in emitForeignToNativeThunk.

### DIFF
--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -1241,6 +1241,9 @@ void SILGenFunction::emitForeignToNativeThunk(SILDeclRef thunk) {
     allocatorSelfType = forwardedParameters[0]
       ->getInterfaceType(getASTContext())
       ->getLValueOrInOutObjectType();
+    if (F.getGenericEnvironment())
+      allocatorSelfType = F.getGenericEnvironment()
+        ->mapTypeIntoContext(allocatorSelfType);
     forwardedParameters = forwardedParameters.slice(1);
   }
 

--- a/test/SILGen/Inputs/objc_required_designated_init.h
+++ b/test/SILGen/Inputs/objc_required_designated_init.h
@@ -1,0 +1,5 @@
+@import Foundation;
+
+@interface NSBoom<T> : NSObject
+
+@end

--- a/test/SILGen/Inputs/objc_required_designated_init_2.swift
+++ b/test/SILGen/Inputs/objc_required_designated_init_2.swift
@@ -6,3 +6,9 @@ open class Boom: NSObject {
   }
 }
 
+open class Badaboom<U>: NSBoom<NSString> {
+  public override required init() {
+    super.init()
+  }
+}
+

--- a/test/SILGen/objc_required_designated_init.swift
+++ b/test/SILGen/objc_required_designated_init.swift
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: %target-swift-frontend -emit-module %S/Inputs/objc_required_designated_init_2.swift -module-name Booms -o %t/Booms.swiftmodule
-// RUN: %target-swift-frontend -I %t -emit-silgen -verify %s
+// RUN: %target-swift-frontend -emit-module %S/Inputs/objc_required_designated_init_2.swift -module-name Booms -o %t/Booms.swiftmodule -import-objc-header %S/Inputs/objc_required_designated_init.h
+// RUN: %target-swift-frontend -I %t -emit-silgen -verify %s -import-objc-header %S/Inputs/objc_required_designated_init.h
 
 // REQUIRES: objc_interop
 
@@ -12,3 +12,8 @@ class Baboom: Boom {
   }
 }
 
+class BigBadaBoom<V>: Badaboom<V> {
+  required init() {
+    super.init()
+  }
+}


### PR DESCRIPTION
Explanation: SILGen could crash when emitting the foreign-to-native thunk for an initializer of a generic subclass of a generic ObjC class.

Scope: Bug fix

Issue: rdar://problem/32331915, rdar://problem/32320625

Risk: Low, small bug fix

Testing: Swift CI