### PR TITLE
[QoI] Check before trying to emit fix-it to convert from array to dictionary

### DIFF
--- a/test/Constraints/dictionary_literal.swift
+++ b/test/Constraints/dictionary_literal.swift
@@ -97,3 +97,17 @@ func testDefaultExistentials() {
   let _ = ["a" : "hello", 17 : "string"]
   // expected-error@-1{{heterogeneous collection literal could only be inferred to 'Dictionary<AnyHashable, String>'}}
 }
+
+// SR-4952, rdar://problem/32330004 - Assertion failure during swift::ASTVisitor<::FailureDiagnosis,...>::visit
+func rdar32330004_1() -> [String: Any] {
+  return ["a""one": 1, "two": 2, "three": 3] // expected-note {{did you mean to use a dictionary literal instead?}}
+  // expected-error@-1 2 {{expected ',' separator}}
+  // expected-error@-2 {{expected expression in container literal}}
+  // expected-error@-3 {{contextual type '[String : Any]' cannot be used with array literal}}
+}
+
+func rdar32330004_2() -> [String: Any] {
+  return ["a", 0, "one", 1, "two", 2, "three", 3]
+  // expected-error@-1 {{contextual type '[String : Any]' cannot be used with array literal}}
+  // expected-note@-2 {{did you mean to use a dictionary literal instead?}} {{14-15=:}} {{24-25=:}} {{34-35=:}} {{46-47=:}}
+}


### PR DESCRIPTION
Before trying to replace every other "," with ":" to help convert
from array to dictionary, let's first check if it's appropriate e.g.
the number of commas matches the number of elements and number of
elements in the array is even which constitutes key/value pairs.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-4952](https://bugs.swift.org/browse/SR-4952).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
