### PR TITLE
Sema: Don't crash when type-checking a KeyPathExpr that's already type-checked.

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -4750,6 +4750,25 @@ public:
       return getKind() != Kind::Invalid;
     }
     
+    bool isResolved() const {
+      if (!getComponentType())
+        return false;
+      
+      switch (getKind()) {
+      case Kind::Subscript:
+      case Kind::OptionalChain:
+      case Kind::OptionalWrap:
+      case Kind::OptionalForce:
+      case Kind::Property:
+        return true;
+      
+      case Kind::UnresolvedSubscript:
+      case Kind::UnresolvedProperty:
+      case Kind::Invalid:
+        return false;
+      }
+    }
+    
     Expr *getIndexExpr() const {
       switch (getKind()) {
       case Kind::Subscript:

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -3988,6 +3988,20 @@ namespace {
       if (E->getType()->hasError())
         return E;
 
+      // If a component is already resolved, then all of them should be
+      // resolved, and we can let the expression be. This might happen when
+      // re-checking a failed system for diagnostics.
+      if (!E->getComponents().empty()
+          && E->getComponents().front().isResolved()) {
+        assert([&]{
+          for (auto &c : E->getComponents())
+            if (!c.isResolved())
+              return false;
+          return true;
+        }());
+        return E;
+      }
+
       SmallVector<KeyPathExpr::Component, 4> resolvedComponents;
 
       // Resolve each of the components.

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2756,11 +2756,26 @@ namespace {
         return ErrorType::get(CS.getASTContext());
       }
       
-      // If the key path contained any syntactically invalid components, bail
-      // out.
-      for (auto &c : E->getComponents())
-        if (!c.isValid())
+      for (auto &c : E->getComponents()) {
+        // If the key path contained any syntactically invalid components, bail
+        // out.
+        if (!c.isValid()) {
           return ErrorType::get(CS.getASTContext());
+        }
+        
+        // If a component is already resolved, then all of them should be
+        // resolved, and we can let the expression be. This might happen when
+        // re-checking a failed system for diagnostics.
+        if (c.isResolved()) {
+          assert([&]{
+            for (auto &c : E->getComponents())
+              if (!c.isResolved())
+                return false;
+            return true;
+          }());
+          return E->getType();
+        }
+      }
       
       // For native key paths, traverse the key path components to set up
       // appropriate type relationships at each level.

--- a/test/expr/unary/keypath/salvage-with-other-type-errors.swift
+++ b/test/expr/unary/keypath/salvage-with-other-type-errors.swift
@@ -1,0 +1,31 @@
+// RUN: %target-swift-frontend -typecheck -verify %s
+
+// Ensure that key path exprs can tolerate being re-type-checked when necessary
+// to diagnose other errors in adjacent exprs.
+
+struct P<T: K> { }
+
+struct S {
+    init<B>(_ a: P<B>) {
+        fatalError()
+    }
+}
+
+protocol K { }
+
+func + <Object>(lhs: KeyPath<A, Object>, rhs: String) -> P<Object> {
+    fatalError()
+}
+
+// expected-error@+1{{}}
+func + (lhs: KeyPath<A, String>, rhs: String) -> P<String> {
+    fatalError()
+}
+
+struct A {
+    let id: String
+}
+
+extension A: K {
+    static let j = S(\A.id + "id")
+}


### PR DESCRIPTION
This can come up when re-checking a larger expression for diagnostics. Fixes SR-4965.
rdar://problem/32328705