### PR TITLE
[QoI] Improve diagnostic when unsupported tuple element references are used in key path literals

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -452,6 +452,8 @@ ERROR(expr_smart_keypath_value_covert_to_contextual_type,none,
       (Type, Type))
 ERROR(expr_string_interpolation_outside_string,none,
       "string interpolation can only appear inside a string literal", ())
+ERROR(unsupported_keypath_tuple_element_reference,none,
+      "key path cannot reference tuple elements", ())
 
 // Selector expressions.
 ERROR(expr_selector_no_objc_runtime,none,

--- a/test/expr/unary/keypath/keypath-unimplemented.swift
+++ b/test/expr/unary/keypath/keypath-unimplemented.swift
@@ -14,3 +14,7 @@ func unsupportedComponents() {
   _ = \A.c!.i // expected-error{{key path support for optional force-unwrapping components is not implemented}}
   _ = \A.[0] // expected-error{{key path support for subscript components is not implemented}}
 }
+
+// rdar://problem/32209039 - Improve diagnostic when unsupported tuple element references are used in key path literals
+let _ = \(Int, String).0 // expected-error {{key path cannot reference tuple elements}}
+let _ = \(a: Int, b: String).b // expected-error {{key path cannot reference tuple elements}}


### PR DESCRIPTION
Resolves: rdar://problem/32209039.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
