### PR TITLE
[4.0][migrator] Handle getter function to property change in function overrides.

### DIFF
--- a/include/swift/IDE/APIDigesterData.h
+++ b/include/swift/IDE/APIDigesterData.h
@@ -118,6 +118,17 @@ public:
       return false;
     }
   }
+
+  bool isToPropertyChange() const {
+    switch (DiffKind) {
+    case NodeAnnotation::GetterToProperty:
+    case NodeAnnotation::SetterToProperty:
+      return true;
+    default:
+      return false;
+    }
+  }
+
   StringRef getNewName() const { assert(isRename()); return RightComment; }
   APIDiffItemKind getKind() const override {
     return APIDiffItemKind::ADK_CommonDiffItem;

--- a/test/Migrator/property.swift
+++ b/test/Migrator/property.swift
@@ -8,3 +8,7 @@ func foo(_ a : PropertyUserInterface) {
   a.setField(1)
   _ = a.field()
 }
+
+class C: PropertyUserInterface {
+  public override func field() -> Int32 { return 1 }
+}

--- a/test/Migrator/property.swift.expected
+++ b/test/Migrator/property.swift.expected
@@ -8,3 +8,7 @@ func foo(_ a : PropertyUserInterface) {
   a.Field = 1
   _ = a.field
 }
+
+class C: PropertyUserInterface {
+  public override var field: Int32 { return 1 }
+}


### PR DESCRIPTION
We used to only migrate them in call sites, e.g. changing from
``p.getHeight()`` to ``p.Height``. However, with experimenting on more real-world
projects, we realize migrating overrides is equally important.

rdar://32265583