### PR TITLE
[GSB] AbstractProtocol requirements are never explicit.

### DIFF
--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -930,9 +930,13 @@ bool FloatingRequirementSource::isExplicit() const {
     return false;
 
   case AbstractProtocol:
+    // Requirements implied by other protocol conformance requirements are
+    // implicit, except when computing a requirement signature, where
+    // non-inferred ones are explicit, to allow flagging of redundant
+    // requirements.
     switch (storage.get<const RequirementSource *>()->kind) {
     case RequirementSource::RequirementSignatureSelf:
-      return true;
+      return !protocolReq.inferred;
 
     case RequirementSource::Concrete:
     case RequirementSource::Explicit:

--- a/test/Generics/protocol_where_clause.swift
+++ b/test/Generics/protocol_where_clause.swift
@@ -66,3 +66,14 @@ struct BadConcreteNestedConforms: NestedConforms {
   // expected-error@-1 {{type 'ConcreteParentNonFoo2.T' (aka 'Float') does not conform to protocol 'Foo2'}}
   typealias U = ConcreteParentNonFoo2
 }
+
+
+// SR4693:
+protocol P1 {}
+struct X: P1 {}
+struct Y<T: P1> {}
+
+protocol P2 {
+  associatedtype AT
+}
+protocol P3: P2 where AT == Y<X> {}


### PR DESCRIPTION
If they're considered explicit, requirement inference will complain when
it infers X: SomeProtocol for some concrete type X.

Fixes SR-4693, rdar://problem/31819616

I suspect this isn't correct, but the git history didn't reveal the reasoning, I'm not sure I fully grasped the space, and, tests seemed to pass locally.