### PR TITLE
[stdlib] String: drop TLS setText cache.

### DIFF
--- a/stdlib/public/core/ThreadLocalStorage.swift
+++ b/stdlib/public/core/ThreadLocalStorage.swift
@@ -40,12 +40,7 @@ internal struct _ThreadLocalStorage {
   // compare unequal if a new StringCore happens to be created in the same
   // memory.
   //
-  // private
-  weak var associatedStringOwner: AnyObject? = nil
-  // private
-  var associatedBaseAddress: UnsafeMutableRawPointer? = nil
-  // private
-  var associatedCountAndFlags: UInt = 0
+  // TODO: unowned reference to string owner, base address, and _countAndFlags
 
   // private: Should only be called by _initializeThreadLocalStorage
   init(_uBreakIterator: OpaquePointer) {
@@ -77,21 +72,11 @@ internal struct _ThreadLocalStorage {
     _sanityCheck(core._owner != nil || core._baseAddress != nil,
       "invalid StringCore")
 
-    // Check if we must reset the text
-    if tlsPtr[0].associatedStringOwner !== core._owner
-    || tlsPtr[0].associatedBaseAddress != core._baseAddress
-    || tlsPtr[0].associatedCountAndFlags != core._countAndFlags
-    {
-      // cache miss
-      var err = __swift_stdlib_U_ZERO_ERROR
-      let corePtr: UnsafeMutablePointer<UTF16.CodeUnit>
-      corePtr = core.startUTF16
-      __swift_stdlib_ubrk_setText(brkIter, corePtr, Int32(core.count), &err)
-      _precondition(err.isSuccess, "unexpected ubrk_setUText failure")
-      tlsPtr[0].associatedStringOwner = core._owner
-      tlsPtr[0].associatedBaseAddress = core._baseAddress
-      tlsPtr[0].associatedCountAndFlags = core._countAndFlags
-    }
+    var err = __swift_stdlib_U_ZERO_ERROR
+    let corePtr: UnsafeMutablePointer<UTF16.CodeUnit>
+    corePtr = core.startUTF16
+    __swift_stdlib_ubrk_setText(brkIter, corePtr, Int32(core.count), &err)
+    _precondition(err.isSuccess, "unexpected ubrk_setUText failure")
 
     return brkIter
   }
@@ -104,8 +89,6 @@ internal func _destroyTLS(_ ptr: UnsafeMutableRawPointer?) {
     "_destroyTLS was called, but with nil...")
   let tlsPtr = ptr!.assumingMemoryBound(to: _ThreadLocalStorage.self)
   __swift_stdlib_ubrk_close(tlsPtr[0].uBreakIterator)
-  tlsPtr[0].associatedStringOwner = nil
-  tlsPtr[0].associatedBaseAddress = nil
   tlsPtr.deinitialize(count: 1)
   tlsPtr.deallocate(capacity: 1)
 


### PR DESCRIPTION
The overhead of the weak reference overwhelms the savings from
avoiding the setText, when there's a fair amount of reference counting
involved. The real solution will be to use an unowned reference. For
now, drop the cache and introduce it once we have more runtime
functionality.

<!-- What's in this pull request? -->
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
