### PR TITLE
[Migrator] Don't add -aarch64-use-tbi twice

### DIFF
--- a/lib/Migrator/Migrator.cpp
+++ b/lib/Migrator/Migrator.cpp
@@ -112,6 +112,12 @@ Migrator::performAFixItMigration(version::Version SwiftLanguageVersion) {
   CompilerInvocation Invocation { StartInvocation };
   Invocation.clearInputs();
   Invocation.getLangOptions().EffectiveLanguageVersion = SwiftLanguageVersion;
+  auto &LLVMArgs = Invocation.getFrontendOptions().LLVMArgs;
+  auto aarch64_use_tbi = std::find(LLVMArgs.begin(), LLVMArgs.end(),
+                                   "-aarch64-use-tbi");
+  if (aarch64_use_tbi != LLVMArgs.end()) {
+    LLVMArgs.erase(aarch64_use_tbi);
+  }
 
   // SE-0160: When migrating, always use the Swift 3 @objc inference rules,
   // which drives warnings with the "@objc" Fix-Its.

--- a/test/Migrator/Inputs/no_duplicate_aarch64_use_tbi_OFM.json
+++ b/test/Migrator/Inputs/no_duplicate_aarch64_use_tbi_OFM.json
@@ -1,0 +1,6 @@
+{
+  "./no_duplicate_aarch64_use_tbi.swift": {
+    "object": "./a.o",
+    "remap": "./no_duplicate_aarch64_use_tbi.remap"
+  }
+}

--- a/test/Migrator/no_duplicate_aarch64_use_tbi.swift
+++ b/test/Migrator/no_duplicate_aarch64_use_tbi.swift
@@ -1,0 +1,7 @@
+// RUN: %target-swift-frontend -typecheck %s -swift-version 3
+// RUN: rm -rf %t && mkdir -p %t && %target-swift-frontend -c -primary-file %s -emit-migrated-file-path %t/no_duplicate_aarch64_use_tbi.swift.result -swift-version 3 -Xllvm -aarch64-use-tbi -o /dev/null
+// RUN: diff -u %s.expected %t/no_duplicate_aarch64_use_tbi.swift.result
+// RUN: %target-swift-frontend -typecheck %s.expected -swift-version 4
+// RUN: %target-swift-frontend -typecheck %t/no_duplicate_aarch64_use_tbi.swift.result -swift-version 4
+
+public func foo(_ f: (Void) -> ()) {}

--- a/test/Migrator/no_duplicate_aarch64_use_tbi.swift.expected
+++ b/test/Migrator/no_duplicate_aarch64_use_tbi.swift.expected
@@ -1,0 +1,7 @@
+// RUN: %target-swift-frontend -typecheck %s -swift-version 3
+// RUN: rm -rf %t && mkdir -p %t && %target-swift-frontend -c -primary-file %s -emit-migrated-file-path %t/no_duplicate_aarch64_use_tbi.swift.result -swift-version 3 -Xllvm -aarch64-use-tbi -o /dev/null
+// RUN: diff -u %s.expected %t/no_duplicate_aarch64_use_tbi.swift.result
+// RUN: %target-swift-frontend -typecheck %s.expected -swift-version 4
+// RUN: %target-swift-frontend -typecheck %t/no_duplicate_aarch64_use_tbi.swift.result -swift-version 4
+
+public func foo(_ f: () -> ()) {}


### PR DESCRIPTION
Setting up an invocation adds -aarch64-use-tbi if the target is for
AArch64. In the fix-it passes, we inherit the frontend options which
already has it from the driver passing it down to the frontend.

rdar://problem/32284152