### PR TITLE
[Diagnostics] Add buffer offset information to the serialized diagnostics

### DIFF
--- a/lib/Frontend/SerializedDiagnosticConsumer.cpp
+++ b/lib/Frontend/SerializedDiagnosticConsumer.cpp
@@ -266,13 +266,14 @@ void SerializedDiagnosticConsumer::addLocToRecord(SourceLoc Loc,
     return;
   }
 
+  auto bufferId = SM.findBufferContainingLoc(Loc);
   unsigned line, col;
   std::tie(line, col) = SM.getLineAndColumn(Loc);
 
   Record.push_back(getEmitFile(Filename));
   Record.push_back(line);
   Record.push_back(col);
-  Record.push_back(0);
+  Record.push_back(SM.getLocOffsetInBuffer(Loc, bufferId));
 }
 
 void SerializedDiagnosticConsumer::addRangeToRecord(CharSourceRange Range,


### PR DESCRIPTION
Some of the tools rely on the presence of buffer offset to correctly
navigate to the diagnostic area from the serialized diagnostics output,
let's get it based on the source location provided.

Resolves: rdar://problem/22935476

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
