### PR TITLE
[4.0][SourceKit] Make sure to propagate the SIL options from the compiler invocation when doing performSILGeneration() to get the SIL diagnostics

### DIFF
--- a/test/SourceKit/Sema/sil_diags.swift
+++ b/test/SourceKit/Sema/sil_diags.swift
@@ -1,0 +1,15 @@
+// RUN: %sourcekitd-test -req=sema %s -- %s -enforce-exclusivity=checked | %FileCheck %s -check-prefix=CHECKED
+// RUN: %sourcekitd-test -req=sema %s -- %s -enforce-exclusivity=none | %FileCheck %s -check-prefix=NONE
+// CHECKED: modification requires exclusive access
+// NONE-NOT: modification requires exclusive access
+
+struct X {
+  var f = 7
+}
+
+func takesInout<T>(_ p1: inout T, _ p2: inout T) {}
+
+func hasStaticViolation() {
+  var l = X()
+  takesInout(&l.f, &l.f)
+}

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -835,7 +835,7 @@ ASTUnitRef ASTProducer::createASTUnit(SwiftASTManager::Implementation &MgrImpl,
     // don't block any other AST processing for the same SwiftInvocation.
 
     if (auto SF = CompIns.getPrimarySourceFile()) {
-      SILOptions SILOpts;
+      SILOptions SILOpts = Invocation.getSILOptions();
       std::unique_ptr<SILModule> SILMod = performSILGeneration(*SF, SILOpts);
       runSILDiagnosticPasses(*SILMod);
     }


### PR DESCRIPTION
master: https://github.com/apple/swift/pull/9854

rdar://32329669
