### PR TITLE
Various existential l-value fixes

### DIFF
--- a/lib/SILGen/LValue.h
+++ b/lib/SILGen/LValue.h
@@ -97,7 +97,7 @@ public:
     TupleElementKind,           // tuple_element_addr
     StructElementKind,          // struct_element_addr
     OptionalObjectKind,         // optional projection
-    OpenedExistentialKind,      // opened opaque existential
+    OpenOpaqueExistentialKind,  // opened opaque existential
     AddressorKind,              // var/subscript addressor
     ValueKind,                  // random base pointer as an lvalue
     KeyPathApplicationKind,     // applying a key path
@@ -107,6 +107,7 @@ public:
     OwnershipKind,              // weak pointer remapping
     AutoreleasingWritebackKind, // autorelease pointer on set
     WritebackPseudoKind,        // a fake component to customize writeback
+    OpenClassExistentialKind,   // opened class existential
     // Translation LValue kinds (a subtype of logical)
     OrigToSubstKind,            // generic type substitution
     SubstToOrigKind,            // generic type substitution

--- a/lib/SILGen/LValue.h
+++ b/lib/SILGen/LValue.h
@@ -107,7 +107,7 @@ public:
     OwnershipKind,              // weak pointer remapping
     AutoreleasingWritebackKind, // autorelease pointer on set
     WritebackPseudoKind,        // a fake component to customize writeback
-    OpenClassExistentialKind,   // opened class existential
+    OpenNonOpaqueExistentialKind,  // opened class or metatype existential
     // Translation LValue kinds (a subtype of logical)
     OrigToSubstKind,            // generic type substitution
     SubstToOrigKind,            // generic type substitution

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -4020,10 +4020,14 @@ void SILGenFunction::emitOpenExistentialExprImpl(
     // Create a writeback scope for the access to the existential lvalue.
     writebackScope.emplace(*this);
 
+    Type formalRValueType =
+      E->getOpaqueValue()->getType()->getLValueOrInOutObjectType();
+
     accessKind = E->getExistentialValue()->getLValueAccessKind();
     auto lv = emitLValue(E->getExistentialValue(), accessKind);
     lv = emitOpenExistentialLValue(E, std::move(lv),
                                    CanArchetypeType(E->getOpenedArchetype()),
+                                   formalRValueType->getCanonicalType(),
                                    accessKind);
     auto addr = emitAddressOfLValue(E, std::move(lv), accessKind);
     state = {addr, false, false};

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -4010,29 +4010,33 @@ void SILGenFunction::emitOpenExistentialExprImpl(
        llvm::function_ref<void(Expr *)> emitSubExpr) {
   Optional<FormalEvaluationScope> writebackScope;
 
+  Type opaqueValueType = E->getOpaqueValue()->getType()->getRValueType();
+
   // Emit the existential value.
-  ManagedValue existentialValue;
+  SILGenFunction::OpaqueValueState state;
+
   AccessKind accessKind;
   if (E->getExistentialValue()->getType()->is<LValueType>()) {
     // Create a writeback scope for the access to the existential lvalue.
     writebackScope.emplace(*this);
 
     accessKind = E->getExistentialValue()->getLValueAccessKind();
-    existentialValue = emitAddressOfLValue(
-                         E->getExistentialValue(),
-                         emitLValue(E->getExistentialValue(), accessKind),
-                         accessKind);
+    auto lv = emitLValue(E->getExistentialValue(), accessKind);
+    lv = emitOpenExistentialLValue(E, std::move(lv),
+                                   CanArchetypeType(E->getOpenedArchetype()),
+                                   accessKind);
+    auto addr = emitAddressOfLValue(E, std::move(lv), accessKind);
+    state = {addr, false, false};
   } else {
     accessKind = AccessKind::Read;
-    existentialValue = emitRValueAsSingleValue(
-                         E->getExistentialValue(),
-                         SGFContext::AllowGuaranteedPlusZero);
-  }
+    auto existentialValue = emitRValueAsSingleValue(
+      E->getExistentialValue(),
+      SGFContext::AllowGuaranteedPlusZero);
   
-  Type opaqueValueType = E->getOpaqueValue()->getType()->getRValueType();
-  SILGenFunction::OpaqueValueState state = emitOpenExistential(
+    state = emitOpenExistential(
       E, existentialValue, E->getOpenedArchetype(),
       getLoweredType(opaqueValueType), accessKind);
+  }
 
   // Register the opaque value for the projected existential.
   SILGenFunction::OpaqueValueRAII opaqueValueRAII(

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1305,6 +1305,7 @@ public:
   LValue emitOpenExistentialLValue(SILLocation loc,
                                    LValue &&existentialLV,
                                    CanArchetypeType openedArchetype,
+                                   CanType formalRValueType,
                                    AccessKind accessKind);
 
   RValue emitLoadOfLValue(SILLocation loc, LValue &&src, SGFContext C,

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1302,6 +1302,10 @@ public:
   ManagedValue emitAddressOfLValue(SILLocation loc, LValue &&src,
                                    AccessKind accessKind,
                                    TSanKind tsanKind = TSanKind::None);
+  LValue emitOpenExistentialLValue(SILLocation loc,
+                                   LValue &&existentialLV,
+                                   CanArchetypeType openedArchetype,
+                                   AccessKind accessKind);
 
   RValue emitLoadOfLValue(SILLocation loc, LValue &&src, SGFContext C,
                           bool isGuaranteedValid = false);

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -975,7 +975,7 @@ public:
   /// \param openedArchetype The opened existential archetype.
   /// \param loweredOpenedType The lowered type of the projection, which in
   /// practice will be the openedArchetype, possibly wrapped in a metatype.
-  SILGenFunction::OpaqueValueState
+  OpaqueValueState
   emitOpenExistential(SILLocation loc,
                       ManagedValue existentialValue,
                       ArchetypeType *openedArchetype,

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -631,16 +631,15 @@ namespace {
   /// A physical path component which projects out an opened archetype
   /// from an existential.
   class OpenOpaqueExistentialComponent : public PhysicalPathComponent {
-    static LValueTypeData getOpenedArchetypeTypeData(CanArchetypeType type) {
-      return {
-        AbstractionPattern::getOpaque(), type,
-        SILType::getPrimitiveObjectType(type)
-      };
+    CanArchetypeType getOpenedArchetype() const {
+      return cast<ArchetypeType>(getSubstFormalType());
     }
   public:
-    OpenOpaqueExistentialComponent(CanArchetypeType openedArchetype)
-      : PhysicalPathComponent(getOpenedArchetypeTypeData(openedArchetype),
-                              OpenOpaqueExistentialKind) {}
+    OpenOpaqueExistentialComponent(CanArchetypeType openedArchetype,
+                                   LValueTypeData typeData)
+      : PhysicalPathComponent(typeData, OpenOpaqueExistentialKind) {
+      assert(getOpenedArchetype() == openedArchetype);
+    }
 
     ManagedValue offset(SILGenFunction &SGF, SILLocation loc, ManagedValue base,
                         AccessKind accessKind) && override {
@@ -669,8 +668,7 @@ namespace {
         llvm_unreachable("Bad existential representation for address-only type");
       }
 
-      SGF.setArchetypeOpeningSite(cast<ArchetypeType>(getSubstFormalType()),
-                                  addr);
+      SGF.setArchetypeOpeningSite(getOpenedArchetype(), addr);
       return ManagedValue::forLValue(addr);
     }
 
@@ -679,21 +677,17 @@ namespace {
     }
   };
 
-  /// A local path component for the payload of a class existential.
+  /// A local path component for the payload of a class or metatype existential.
   ///
   /// TODO: Could be physical if we had a way to project out the
   /// payload.
-  class OpenClassExistentialComponent : public LogicalPathComponent {
-    static LValueTypeData getOpenedArchetypeTypeData(CanArchetypeType type) {
-      return {
-        AbstractionPattern::getOpaque(), type,
-        SILType::getPrimitiveObjectType(type)
-      };
-    }
+  class OpenNonOpaqueExistentialComponent : public LogicalPathComponent {
+    CanArchetypeType OpenedArchetype;
   public:
-    OpenClassExistentialComponent(CanArchetypeType openedArchetype)
-      : LogicalPathComponent(getOpenedArchetypeTypeData(openedArchetype),
-                             OpenClassExistentialKind) {}
+    OpenNonOpaqueExistentialComponent(CanArchetypeType openedArchetype,
+                                      LValueTypeData typeData)
+      : LogicalPathComponent(typeData, OpenNonOpaqueExistentialKind),
+        OpenedArchetype(openedArchetype) {}
 
     AccessKind getBaseAccessKind(SILGenFunction &SGF,
                                  AccessKind kind) const override {
@@ -716,15 +710,23 @@ namespace {
       auto result = SGF.emitLoad(loc, base.getValue(), TL,
                                  SGFContext(), IsNotTake);
 
-      assert(refType.isExistentialType() &&
+      assert(refType.isAnyExistentialType() &&
              "base for open existential component must be an existential");
-      assert(refType.getPreferredExistentialRepresentation(SGF.SGM.M)
-             == ExistentialRepresentation::Class);
-      auto ref = SGF.B.createOpenExistentialRef(
-        loc, result, getTypeOfRValue());
+      ManagedValue ref;
+      if (refType.is<ExistentialMetatypeType>()) {
+        assert(refType.getPreferredExistentialRepresentation(SGF.SGM.M)
+                 == ExistentialRepresentation::Metatype);
+        ref = ManagedValue::forUnmanaged(
+                SGF.B.createOpenExistentialMetatype(loc,
+                                                    result.getUnmanagedValue(),
+                                                    getTypeOfRValue()));
+      } else {
+        assert(refType.getPreferredExistentialRepresentation(SGF.SGM.M)
+                 == ExistentialRepresentation::Class);
+        ref = SGF.B.createOpenExistentialRef(loc, result, getTypeOfRValue());
+      }
 
-      SGF.setArchetypeOpeningSite(cast<ArchetypeType>(getSubstFormalType()),
-                                  ref.getValue());
+      SGF.setArchetypeOpeningSite(OpenedArchetype, ref.getValue());
 
       return RValue(SGF, loc, getSubstFormalType(), ref);
     }
@@ -734,15 +736,24 @@ namespace {
       auto payload = std::move(value).forwardAsSingleValue(SGF, loc);
 
       SmallVector<ProtocolConformanceRef, 2> conformances;
-      for (auto proto : cast<ArchetypeType>(getSubstFormalType())->getConformsTo())
+      for (auto proto : OpenedArchetype->getConformsTo())
         conformances.push_back(ProtocolConformanceRef(proto));
 
-      auto ref = SGF.B.createInitExistentialRef(
-        loc,
-        base.getType().getObjectType(),
-        getSubstFormalType(),
-        payload,
-        SGF.getASTContext().AllocateCopy(conformances));
+      SILValue ref;
+      if (base.getType().is<ExistentialMetatypeType>()) {
+        ref = SGF.B.createInitExistentialMetatype(
+                loc,
+                payload,
+                base.getType().getObjectType(),
+                SGF.getASTContext().AllocateCopy(conformances));
+      } else {
+        ref = SGF.B.createInitExistentialRef(
+                loc,
+                base.getType().getObjectType(),
+                getSubstFormalType(),
+                payload,
+                SGF.getASTContext().AllocateCopy(conformances));
+      }
 
       auto &TL = SGF.getTypeLowering(base.getType());
       SGF.emitSemanticStore(loc, ref,
@@ -752,13 +763,13 @@ namespace {
     std::unique_ptr<LogicalPathComponent>
     clone(SILGenFunction &SGF, SILLocation loc) const override {
       LogicalPathComponent *clone =
-        new OpenClassExistentialComponent(
-          cast<ArchetypeType>(getSubstFormalType()));
+        new OpenNonOpaqueExistentialComponent(OpenedArchetype, getTypeData());
       return std::unique_ptr<LogicalPathComponent>(clone);
     }
 
     void print(raw_ostream &OS) const override {
-      OS << "OpenClassExistentialComponent(...)\n";
+      OS << "OpenNonOpaqueExistentialComponent(" << OpenedArchetype
+         << ", ...)\n";
     }
   };
 
@@ -2076,6 +2087,7 @@ LValue SILGenLValue::visitOpaqueValueExpr(OpaqueValueExpr *e,
     lv = SGF.emitOpenExistentialLValue(
         opened, std::move(lv),
         CanArchetypeType(opened->getOpenedArchetype()),
+        e->getType()->getLValueOrInOutObjectType()->getCanonicalType(),
         accessKind);
     return lv;
   }
@@ -2977,23 +2989,30 @@ LValue
 SILGenFunction::emitOpenExistentialLValue(SILLocation loc,
                                           LValue &&lv,
                                           CanArchetypeType openedArchetype,
+                                          CanType formalRValueType,
                                           AccessKind accessKind) {
+  assert(!formalRValueType->isLValueType());
+  LValueTypeData typeData = {
+    AbstractionPattern::getOpaque(), formalRValueType,
+    getLoweredType(formalRValueType).getObjectType()
+  };
+
   // Open up the existential.
   auto rep = lv.getTypeOfRValue()
     .getPreferredExistentialRepresentation(SGM.M);
   switch (rep) {
   case ExistentialRepresentation::Opaque:
   case ExistentialRepresentation::Boxed: {
-    lv.add<OpenOpaqueExistentialComponent>(openedArchetype);
+    lv.add<OpenOpaqueExistentialComponent>(openedArchetype, typeData);
     break;
   }
+  case ExistentialRepresentation::Metatype:
   case ExistentialRepresentation::Class: {
-    lv.add<OpenClassExistentialComponent>(openedArchetype);
+    lv.add<OpenNonOpaqueExistentialComponent>(openedArchetype, typeData);
     break;
   }
-  default:
-    llvm_unreachable("Cannot perform lvalue access of "
-                     "non-opaque, non-class existential");
+  case ExistentialRepresentation::None:
+    llvm_unreachable("cannot open non-existential");
   }
 
   return std::move(lv);

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -583,7 +583,7 @@ namespace {
   public:
     OpenOpaqueExistentialComponent(CanArchetypeType openedArchetype)
       : PhysicalPathComponent(getOpenedArchetypeTypeData(openedArchetype),
-                              OpenedExistentialKind) {}
+                              OpenOpaqueExistentialKind) {}
 
     ManagedValue offset(SILGenFunction &SGF, SILLocation loc, ManagedValue base,
                         AccessKind accessKind) && override {
@@ -603,6 +603,89 @@ namespace {
 
     void print(raw_ostream &OS) const override {
       OS << "OpenOpaqueExistentialComponent(" << getSubstFormalType() << ")\n";
+    }
+  };
+
+  /// A local path component for the payload of a class existential.
+  ///
+  /// TODO: Could be physical if we had a way to project out the
+  /// payload.
+  class OpenClassExistentialComponent : public LogicalPathComponent {
+    static LValueTypeData getOpenedArchetypeTypeData(CanArchetypeType type) {
+      return {
+        AbstractionPattern::getOpaque(), type,
+        SILType::getPrimitiveObjectType(type)
+      };
+    }
+  public:
+    OpenClassExistentialComponent(CanArchetypeType openedArchetype)
+      : LogicalPathComponent(getOpenedArchetypeTypeData(openedArchetype),
+                             OpenClassExistentialKind) {}
+
+    AccessKind getBaseAccessKind(SILGenFunction &SGF,
+                                 AccessKind kind) const override {
+      // Always use the same access kind for the base.
+      return kind;
+    }
+
+    void diagnoseWritebackConflict(LogicalPathComponent *RHS,
+                                   SILLocation loc1, SILLocation loc2,
+                                   SILGenFunction &SGF) override {
+      // no useful writeback diagnostics at this point
+    }
+
+    RValue get(SILGenFunction &SGF, SILLocation loc,
+               ManagedValue base, SGFContext c) && override {
+      auto refType = base.getType().getObjectType();
+      auto &TL = SGF.getTypeLowering(refType);
+
+      // Load the original value.
+      auto result = SGF.emitLoad(loc, base.getValue(), TL,
+                                 SGFContext(), IsNotTake);
+
+      assert(refType.isExistentialType() &&
+             "base for open existential component must be an existential");
+      assert(refType.getPreferredExistentialRepresentation(SGF.SGM.M)
+             == ExistentialRepresentation::Class);
+      auto ref = SGF.B.createOpenExistentialRef(
+        loc, result, getTypeOfRValue());
+
+      SGF.setArchetypeOpeningSite(cast<ArchetypeType>(getSubstFormalType()),
+                                  ref.getValue());
+
+      return RValue(SGF, loc, getSubstFormalType(), ref);
+    }
+
+    void set(SILGenFunction &SGF, SILLocation loc,
+             RValue &&value, ManagedValue base) && override {
+      auto payload = std::move(value).forwardAsSingleValue(SGF, loc);
+
+      SmallVector<ProtocolConformanceRef, 2> conformances;
+      for (auto proto : cast<ArchetypeType>(getSubstFormalType())->getConformsTo())
+        conformances.push_back(ProtocolConformanceRef(proto));
+
+      auto ref = SGF.B.createInitExistentialRef(
+        loc,
+        base.getType().getObjectType(),
+        getSubstFormalType(),
+        payload,
+        SGF.getASTContext().AllocateCopy(conformances));
+
+      auto &TL = SGF.getTypeLowering(base.getType());
+      SGF.emitSemanticStore(loc, ref,
+                            base.getValue(), TL, IsNotInitialization);
+    }
+
+    std::unique_ptr<LogicalPathComponent>
+    clone(SILGenFunction &SGF, SILLocation loc) const override {
+      LogicalPathComponent *clone =
+        new OpenClassExistentialComponent(
+          cast<ArchetypeType>(getSubstFormalType()));
+      return std::unique_ptr<LogicalPathComponent>(clone);
+    }
+
+    void print(raw_ostream &OS) const override {
+      OS << "OpenClassExistentialComponent(...)\n";
     }
   };
 
@@ -2813,6 +2896,31 @@ ManagedValue SILGenFunction::emitAddressOfLValue(SILLocation loc,
   assert(addr.getType().isAddress() &&
          "resolving lvalue did not give an address");
   return ManagedValue::forLValue(addr.getValue());
+}
+
+LValue
+SILGenFunction::emitOpenExistentialLValue(SILLocation loc,
+                                          LValue &&lv,
+                                          CanArchetypeType openedArchetype,
+                                          AccessKind accessKind) {
+  // Open up the existential.
+  auto rep = lv.getTypeOfRValue()
+    .getPreferredExistentialRepresentation(SGM.M);
+  switch (rep) {
+  case ExistentialRepresentation::Opaque: {
+    lv.add<OpenOpaqueExistentialComponent>(openedArchetype);
+    break;
+  }
+  case ExistentialRepresentation::Class: {
+    lv.add<OpenClassExistentialComponent>(openedArchetype);
+    break;
+  }
+  default:
+    llvm_unreachable("Cannot perform lvalue access of "
+                     "non-opaque, non-class existential");
+  }
+
+  return std::move(lv);
 }
 
 void SILGenFunction::emitAssignToLValue(SILLocation loc, RValue &&src,

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -227,6 +227,63 @@ ManagedValue LogicalPathComponent::getMaterialized(SILGenFunction &SGF,
                                                    SILLocation loc,
                                                    ManagedValue base,
                                                    AccessKind kind) && {
+  if (getTypeOfRValue().getSwiftRValueType()->hasOpenedExistential()) {
+    if (kind == AccessKind::Read) {
+      // Emit a 'get' into the temporary.
+      RValue value =
+        std::move(*this).get(SGF, loc, base, SGFContext());
+
+      // Create a temporary.
+      std::unique_ptr<TemporaryInitialization> temporaryInit =
+        SGF.emitFormalAccessTemporary(loc,
+                                      SGF.getTypeLowering(getTypeOfRValue()));
+
+      std::move(value).forwardInto(SGF, loc, temporaryInit.get());
+
+      return temporaryInit->getManagedAddress();
+    }
+
+    assert(SGF.InWritebackScope &&
+         "materializing l-value for modification without writeback scope");
+
+    // Clone anything else about the component that we might need in the
+    // writeback.
+    auto clonedComponent = clone(SGF, loc);
+
+    SILValue mv;
+    {
+      FormalEvaluationScope Scope(SGF);
+
+      // Otherwise, we need to emit a get and set.  Borrow the base for
+      // the getter.
+      ManagedValue getterBase =
+        base ? base.formalAccessBorrow(SGF, loc) : ManagedValue();
+
+      // Emit a 'get' into a temporary and then pop the borrow of base.
+      RValue value =
+        std::move(*this).get(SGF, loc, getterBase, SGFContext());
+
+      mv = std::move(value).forwardAsSingleValue(SGF, loc);
+    }
+
+    auto &TL = SGF.getTypeLowering(getTypeOfRValue());
+
+    // Create a temporary.
+    std::unique_ptr<TemporaryInitialization> temporaryInit =
+      SGF.emitFormalAccessTemporary(loc, TL);
+
+    SGF.emitSemanticStore(loc, mv, temporaryInit->getAddress(),
+                          TL, IsInitialization);
+    temporaryInit->finishInitialization(SGF);
+
+    auto temporary = temporaryInit->getManagedAddress();
+
+    // Push a writeback for the temporary.
+    pushWriteback(SGF, loc, std::move(clonedComponent), base,
+                  MaterializedLValue(temporary));
+    return temporary.unmanagedBorrow();
+  }
+
   // If this is just for a read, emit a load into a temporary memory
   // location.
   if (kind == AccessKind::Read) {

--- a/test/SILOptimizer/devirt_protocol_method_invocations.swift
+++ b/test/SILOptimizer/devirt_protocol_method_invocations.swift
@@ -192,6 +192,12 @@ public func testExMetatype() -> Int {
   return type.size
 }
 
+// rdar://32288618
+public func testExMetatypeVar() -> Int {
+  var type: StaticP.Type = HasStatic<Int>.self
+  return type.size
+}
+
 // IRGen used to crash on the testPropagationOfConcreteTypeIntoExistential method.
 // rdar://26286278
 


### PR DESCRIPTION
There are a variety of problems with SILGen for class and metatype existential values held in mutable variables.  Those problems are currently masked for class types by a quirk of Sema, which we are not proposing to change in swift-4.0-branch.  However, they are exposed for metatype values, leading to crashes in SILGen.

This combines #9637 and #9852 for swift-4.0-branch.  It fixes rdar://32288618.

This patch affects code generation for mutable existential l-values.  Because of the quirk in Sema, its largest impact is on existential metatypes: specifically, when they're held in mutable variables.

The risk is fairly low.  This patch does change some important code paths, but they are relatively well-tested for the most important cases.  The main case affected otherwise is the existential-metatype case, which currently just doesn't compile at all.

This has been tested with our full regression test suite.