### PR TITLE
[SourceKit] restore __raw_doc_comment identifier

### DIFF
--- a/test/SourceKit/DocumentStructure/structure.swift.placeholders.response
+++ b/test/SourceKit/DocumentStructure/structure.swift.placeholders.response
@@ -77,7 +77,12 @@
       key.offset: 225,
       key.length: 36,
       key.nameoffset: 229,
-      key.namelength: 7
+      key.namelength: 7,
+      key.attributes: [
+        {
+          key.attribute: source.decl.attribute.__raw_doc_comment
+        }
+      ]
     },
     {
       key.kind: source.lang.swift.expr.array,

--- a/test/SourceKit/DocumentStructure/structure.swift.response
+++ b/test/SourceKit/DocumentStructure/structure.swift.response
@@ -397,6 +397,11 @@
       key.namelength: 11,
       key.bodyoffset: 703,
       key.bodylength: 186,
+      key.attributes: [
+        {
+          key.attribute: source.decl.attribute.__raw_doc_comment
+        }
+      ],
       key.substructure: [
         {
           key.kind: source.lang.swift.syntaxtype.comment.mark,
@@ -415,6 +420,11 @@
           key.namelength: 16,
           key.bodyoffset: 762,
           key.bodylength: 125,
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.__raw_doc_comment
+            }
+          ],
           key.substructure: [
             {
               key.kind: source.lang.swift.decl.var.parameter,
@@ -557,7 +567,12 @@
       key.offset: 1079,
       key.length: 15,
       key.nameoffset: 1089,
-      key.namelength: 4
+      key.namelength: 4,
+      key.attributes: [
+        {
+          key.attribute: source.decl.attribute.__raw_doc_comment
+        }
+      ]
     },
     {
       key.kind: source.lang.swift.decl.function.free,
@@ -900,6 +915,9 @@
       key.attributes: [
         {
           key.attribute: source.decl.attribute.objc
+        },
+        {
+          key.attribute: source.decl.attribute.__raw_doc_comment
         }
       ],
       key.elements: [

--- a/test/SourceKit/DocumentStructure/structure_object_literals.swift.response
+++ b/test/SourceKit/DocumentStructure/structure_object_literals.swift.response
@@ -11,7 +11,12 @@
       key.length: 65,
       key.typename: "S",
       key.nameoffset: 148,
-      key.namelength: 5
+      key.namelength: 5,
+      key.attributes: [
+        {
+          key.attribute: source.decl.attribute.__raw_doc_comment
+        }
+      ]
     },
     {
       key.kind: source.lang.swift.expr.object_literal,

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -728,7 +728,6 @@ std::vector<UIdent> SwiftLangSupport::UIDsFromDeclAttributes(const DeclAttribute
     case DAK_SetterAccessibility:
     // Ignore these.
     case DAK_ShowInInterface:
-    case DAK_RawDocComment:
       continue;
     default:
       break;


### PR DESCRIPTION
This identifier can be used with sourcekit related tools to find doc
comments.

This reverts c78f1699cc67aa43dbe59ae3a6ec7ea9b9840003

Resolves [SR-2487](https://bugs.swift.org/browse/SR-2487)