### PR TITLE
Ensure fatalError message logged on Android

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -359,9 +359,10 @@ function(_add_variant_link_flags)
     endif()
   elseif("${LFLAGS_SDK}" STREQUAL "ANDROID")
     list(APPEND result
-        "-ldl"
+        "-ldl" "-llog" "-latomic"
         "${SWIFT_ANDROID_NDK_PATH}/sources/cxx-stl/llvm-libc++/libs/armeabi-v7a/libc++_shared.so")
     list(APPEND library_search_directories
+        "${SWIFT_ANDROID_NDK_PATH}/toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/arm-linux-androideabi/lib/armv7-a"
         "${SWIFT_ANDROID_PREBUILT_PATH}/lib/gcc/arm-linux-androideabi/${SWIFT_ANDROID_NDK_GCC_VERSION}.x")
   else()
     # If lto is enabled, we need to add the object path flag so that the LTO code

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -1505,6 +1505,12 @@ function(add_swift_library name)
           if("${lib}" STREQUAL "ICU_UC")
             list(APPEND swiftlib_private_link_libraries_targets
                  "${SWIFT_${sdk}_ICU_UC}")
+            // temporary fix for atomic needing to be
+            // after object files for libswiftCore.so
+            if("${sdk}" STREQUAL "ANDROID")
+              list(APPEND swiftlib_private_link_libraries_targets
+                   "-latomic")
+            endif()
           elseif("${lib}" STREQUAL "ICU_I18N")
             list(APPEND swiftlib_private_link_libraries_targets
                  "${SWIFT_${sdk}_ICU_I18N}")

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -362,7 +362,7 @@ function(_add_variant_link_flags)
         "-ldl" "-llog" "-latomic"
         "${SWIFT_ANDROID_NDK_PATH}/sources/cxx-stl/llvm-libc++/libs/armeabi-v7a/libc++_shared.so")
     list(APPEND library_search_directories
-        "${SWIFT_ANDROID_NDK_PATH}/toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/arm-linux-androideabi/lib/armv7-a"
+        "${SWIFT_ANDROID_PREBUILT_PATH}/arm-linux-androideabi/lib/armv7-a"
         "${SWIFT_ANDROID_PREBUILT_PATH}/lib/gcc/arm-linux-androideabi/${SWIFT_ANDROID_NDK_GCC_VERSION}.x")
   else()
     # If lto is enabled, we need to add the object path flag so that the LTO code

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -359,7 +359,7 @@ function(_add_variant_link_flags)
     endif()
   elseif("${LFLAGS_SDK}" STREQUAL "ANDROID")
     list(APPEND result
-        "-ldl" "-llog" "-latomic"
+        "-ldl" "-llog" "-latomic" "-licudata" "-licui18n" "-licuuc"
         "${SWIFT_ANDROID_NDK_PATH}/sources/cxx-stl/llvm-libc++/libs/armeabi-v7a/libc++_shared.so")
     list(APPEND library_search_directories
         "${SWIFT_ANDROID_PREBUILT_PATH}/arm-linux-androideabi/lib/armv7-a"

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -1505,8 +1505,8 @@ function(add_swift_library name)
           if("${lib}" STREQUAL "ICU_UC")
             list(APPEND swiftlib_private_link_libraries_targets
                  "${SWIFT_${sdk}_ICU_UC}")
-            // temporary fix for atomic needing to be
-            // after object files for libswiftCore.so
+            # temporary fix for atomic needing to be
+            # after object files for libswiftCore.so
             if("${sdk}" STREQUAL "ANDROID")
               list(APPEND swiftlib_private_link_libraries_targets
                    "-latomic")

--- a/stdlib/public/runtime/Errors.cpp
+++ b/stdlib/public/runtime/Errors.cpp
@@ -46,11 +46,9 @@
 #include <execinfo.h>
 #endif
 
-#ifdef __APPLE__
+#if defined(__APPLE__)
 #include <asl.h>
-#endif
-
-#ifdef __ANDROID__
+#elif defined(__ANDROID__)
 #include <android/log.h>
 #endif
 
@@ -232,11 +230,10 @@ reportNow(uint32_t flags, const char *message)
 #else
   write(STDERR_FILENO, message, strlen(message));
 #endif
-#ifdef __APPLE__
+#if defined(__APPLE__)
   asl_log(nullptr, nullptr, ASL_LEVEL_ERR, "%s", message);
-#endif
-#ifdef __ANDROID__
-  __android_log_print(ANDROID_LOG_ERROR, "Swift", "%s", message);
+#elif defined(__ANDROID__)
+  __android_log_print(ANDROID_LOG_FATAL, "SwiftRuntime", "%s", message);
 #endif
 #if SWIFT_SUPPORTS_BACKTRACE_REPORTING
   if (flags & FatalErrorFlags::ReportBacktrace) {

--- a/stdlib/public/runtime/Errors.cpp
+++ b/stdlib/public/runtime/Errors.cpp
@@ -50,6 +50,10 @@
 #include <asl.h>
 #endif
 
+#ifdef __ANDROID__
+#include <android/log.h>
+#endif
+
 namespace FatalErrorFlags {
 enum: uint32_t {
   ReportBacktrace = 1 << 0
@@ -230,6 +234,9 @@ reportNow(uint32_t flags, const char *message)
 #endif
 #ifdef __APPLE__
   asl_log(nullptr, nullptr, ASL_LEVEL_ERR, "%s", message);
+#endif
+#ifdef __ANDROID__
+  __android_log_print(ANDROID_LOG_ERROR, "Swift", "%s", message);
 #endif
 #if SWIFT_SUPPORTS_BACKTRACE_REPORTING
   if (flags & FatalErrorFlags::ReportBacktrace) {

--- a/stdlib/public/runtime/ImageInspectionELF.cpp
+++ b/stdlib/public/runtime/ImageInspectionELF.cpp
@@ -68,8 +68,12 @@ static SectionInfo getSectionInfo(const char *imageName,
   SectionInfo sectionInfo = { 0, nullptr };
   void *handle = dlopen(imageName, RTLD_LAZY | RTLD_NOLOAD);
   if (!handle) {
+#ifdef __ANDROID__
+    return sectionInfo;
+#else
     fatalError(/* flags = */ 0, "dlopen() failed on `%s': %s", imageName,
                dlerror());
+#endif
   }
   void *symbol = dlsym(handle, sectionName);
   if (symbol) {

--- a/stdlib/public/runtime/ImageInspectionELF.cpp
+++ b/stdlib/public/runtime/ImageInspectionELF.cpp
@@ -68,12 +68,8 @@ static SectionInfo getSectionInfo(const char *imageName,
   SectionInfo sectionInfo = { 0, nullptr };
   void *handle = dlopen(imageName, RTLD_LAZY | RTLD_NOLOAD);
   if (!handle) {
-#ifdef __ANDROID__
-    return sectionInfo;
-#else
     fatalError(/* flags = */ 0, "dlopen() failed on `%s': %s", imageName,
                dlerror());
-#endif
   }
   void *symbol = dlsym(handle, sectionName);
   if (symbol) {


### PR DESCRIPTION
Change to make sure the message passed to fatalError() in Swift is logged to the console on Android. Requires linking with an additional library -llog so any help on exactly where in the CMake file this should be added would certainly be appreciated.

Resolves [SR-2734](https://bugs.swift.org/browse/SR-2734).
