### PR TITLE
Serialization: Create a deserialized EnumDecl before deserializing its dependency types.

### DIFF
--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2323,29 +2323,22 @@ void Serializer::writeForeignErrorConvention(const ForeignErrorConvention &fec){
 /// - \p decl is declared in an extension of a type that depends on
 ///   \p problemContext
 static bool contextDependsOn(const NominalTypeDecl *decl,
-                             const DeclContext *problemContext) {
-  const DeclContext *dc = decl;
-  do {
-    if (dc == problemContext)
-      return true;
-    if (auto *extension = dyn_cast<ExtensionDecl>(dc))
-      dc = extension->getAsNominalTypeOrNominalTypeExtensionContext();
-    else
-      dc = dc->getParent();
-  } while (!dc->isModuleScopeContext());
-  return false;
+                             const ModuleDecl *problemModule) {
+  return decl->getParentModule() == problemModule;
 }
 
 static void collectDependenciesFromType(llvm::SmallSetVector<Type, 4> &seen,
                                         Type ty,
-                                        const DeclContext *excluding) {
+                                        const ModuleDecl *excluding) {
   ty.visit([&](Type next) {
     auto *nominal = next->getAnyNominal();
     if (!nominal)
       return;
-    // FIXME: The child context case is still important for enums. It's
+    // FIXME: Types in the same module are still important for enums. It's
     // possible an enum element has a payload that references a type declaration
-    // nested within the enum that can't be imported (for whatever reason).
+    // from the same module that can't be imported (for whatever reason).
+    // However, we need a more robust handling of deserialization dependencies
+    // that can handle circularities. rdar://problem/32359173
     if (contextDependsOn(nominal, excluding))
       return;
     seen.insert(nominal->getDeclaredInterfaceType());
@@ -2712,7 +2705,7 @@ void Serializer::writeDecl(const Decl *D) {
         continue;
       collectDependenciesFromType(dependencyTypes,
                                   nextElt->getArgumentInterfaceType(),
-                                  /*excluding*/theEnum);
+                                  /*excluding*/theEnum->getParentModule());
     }
     for (Type ty : dependencyTypes)
       inheritedAndDependencyTypes.push_back(addTypeRef(ty));

--- a/test/Serialization/Inputs/enum-mutual-circularity-2.swift
+++ b/test/Serialization/Inputs/enum-mutual-circularity-2.swift
@@ -1,0 +1,3 @@
+public enum TweedleDum {
+  indirect case dee(TweedleDee)
+}

--- a/test/Serialization/Inputs/enum-mutual-circularity-client.swift
+++ b/test/Serialization/Inputs/enum-mutual-circularity-client.swift
@@ -1,0 +1,3 @@
+import EnumCircularity
+
+func foo(_: TweedleDee) {}

--- a/test/Serialization/enum-mutual-circularity.swift
+++ b/test/Serialization/enum-mutual-circularity.swift
@@ -1,0 +1,9 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: %target-swift-frontend -emit-module -module-name EnumCircularity -o %t/partial1.swiftmodule -primary-file %s %S/Inputs/enum-mutual-circularity-2.swift
+// RUN: %target-swift-frontend -emit-module -module-name EnumCircularity -o %t/partial2.swiftmodule %s -primary-file %S/Inputs/enum-mutual-circularity-2.swift
+// RUN: %target-swift-frontend -emit-module -module-name EnumCircularity -o %t/EnumCircularity.swiftmodule %t/partial1.swiftmodule %t/partial2.swiftmodule
+// RUN: %target-swift-frontend -I %t -c -o %t/client.o %S/Inputs/enum-mutual-circularity-client.swift
+
+public enum TweedleDee {
+  indirect case dum(TweedleDum)
+}


### PR DESCRIPTION
Breaks a circularity that can occur when two enums recur through each other. Fixes rdar://problem/32337278.