### PR TITLE
[4.0] Serialization: Create a deserialized EnumDecl before deserializing its dependency types.

### DIFF
--- a/test/Serialization/Inputs/enum-mutual-circularity-2.swift
+++ b/test/Serialization/Inputs/enum-mutual-circularity-2.swift
@@ -1,0 +1,3 @@
+public enum TweedleDum {
+  indirect case dee(TweedleDee)
+}

--- a/test/Serialization/Inputs/enum-mutual-circularity-client.swift
+++ b/test/Serialization/Inputs/enum-mutual-circularity-client.swift
@@ -1,0 +1,3 @@
+import EnumCircularity
+
+func foo(_: TweedleDee) {}

--- a/test/Serialization/enum-mutual-circularity.swift
+++ b/test/Serialization/enum-mutual-circularity.swift
@@ -1,0 +1,9 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: %target-swift-frontend -emit-module -module-name EnumCircularity -o %t/partial1.swiftmodule -primary-file %s %S/Inputs/enum-mutual-circularity-2.swift
+// RUN: %target-swift-frontend -emit-module -module-name EnumCircularity -o %t/partial2.swiftmodule %s -primary-file %S/Inputs/enum-mutual-circularity-2.swift
+// RUN: %target-swift-frontend -emit-module -module-name EnumCircularity -o %t/EnumCircularity.swiftmodule %t/partial1.swiftmodule %t/partial2.swiftmodule
+// RUN: %target-swift-frontend -I %t -c -o %t/client.o %S/Inputs/enum-mutual-circularity-client.swift
+
+public enum TweedleDee {
+  indirect case dum(TweedleDum)
+}


### PR DESCRIPTION
Explanation: Breaks a circularity that can occur when two enums recur through each other.

Scope: Deserialization crash when two enums reference each other from different separately-compiled files that get merged together into one module.

Issue: rdar://problem/32337278

Risk: Low, small bug fix

Testing: Swift CI, project from Radar, source compatibility suite
