### PR TITLE
Demangler: don’t crash if demangling a malformed KeyPath[GS]etterThunkHelper

### DIFF
--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -1263,7 +1263,8 @@ NodePointer Demangler::demangleThunkOrSpecialization() {
                                : Node::Kind::KeyPathSetterThunkHelper;
       auto type = popNode();
       auto sigOrDecl = popNode();
-      if (sigOrDecl->getKind() == Node::Kind::DependentGenericSignature) {
+      if (sigOrDecl &&
+          sigOrDecl->getKind() == Node::Kind::DependentGenericSignature) {
         auto decl = popNode();
         return createWithChildren(nodeKind, decl, sigOrDecl, type);
       } else {

--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -253,4 +253,5 @@ _T010Foundation11MeasurementV12SimulatorKitSo9UnitAngleCRszlE11OrientationO2eeoi
 _T04main1_yyF ---> main._() -> ()
 _T04test6testitSiyt_tF ---> test.testit(()) -> Swift.Int
 _T0Rml ---> _T0Rml
+_T0Tk ---> _T0Tk
 


### PR DESCRIPTION
Explanation: The demangler crashes when it tries to demangle certain types of non-swift symbols.

Scope: This problem can cause a crash in tools which use the demangler and try to demangle symbols which are not necessarily swift symbols.

Radar: rdar://problem/32333373

Risk: Low. It's just an additional null-pointer check.

Testing: There is a test for swift-ci
