### PR TITLE
[Mangling] Include private discriminators in constructor manglings

### DIFF
--- a/docs/ABI.rst
+++ b/docs/ABI.rst
@@ -877,8 +877,8 @@ Entities
   curry-thunk ::= 'Tc'
 
   // The leading type is the function type
-  entity-spec ::= type 'fC'                  // allocating constructor
-  entity-spec ::= type 'fc'                  // non-allocating constructor
+  entity-spec ::= type file-discriminator? 'fC'      // allocating constructor
+  entity-spec ::= type file-discriminator? 'fc'      // non-allocating constructor
   entity-spec ::= type 'fU' INDEX            // explicit anonymous closure expression
   entity-spec ::= type 'fu' INDEX            // implicit anonymous closure
   entity-spec ::= 'fA' INDEX                 // default argument N+1 generator
@@ -911,14 +911,16 @@ Entities
 
   decl-name ::= identifier
   decl-name ::= identifier 'L' INDEX         // locally-discriminated declaration
-  decl-name ::= identifier identifier 'LL'    // file-discriminated declaration
+  decl-name ::= identifier identifier 'LL'   // file-discriminated declaration
 
-The first identifier in a file-discriminated ``<decl-name>>`` is a string that
-represents the file the original declaration came from.
-It should be considered unique within the enclosing module.
-The second identifier is the name of the entity.
-Not all declarations marked ``private`` declarations will use this mangling;
-if the entity's context is enough to uniquely identify the entity, the simple
+  file-discriminator ::= identifier 'Ll'     // anonymous file-discriminated declaration
+
+The identifier in a ``<file-discriminator>`` and the first identifier in a
+file-discriminated ``<decl-name>`` is a string that represents the file the
+original declaration came from. It should be considered unique within the
+enclosing module. The second identifier is the name of the entity. Not all
+declarations marked ``private`` declarations will use this mangling; if the
+entity's context is enough to uniquely identify the entity, the simple
 ``identifier`` form is preferred.
 
 Declaration Contexts

--- a/lib/Demangling/NodePrinter.cpp
+++ b/lib/Demangling/NodePrinter.cpp
@@ -867,13 +867,19 @@ NodePointer NodePrinter::print(NodePointer Node, bool asPrefixContext) {
     Printer << " #" << (Node->getChild(0)->getIndex() + 1);
     return nullptr;
   case Node::Kind::PrivateDeclName:
-    if (Options.ShowPrivateDiscriminators)
-      Printer << '(';
+    if (Node->getNumChildren() > 1) {
+      if (Options.ShowPrivateDiscriminators)
+        Printer << '(';
 
-    print(Node->getChild(1));
+      print(Node->getChild(1));
 
-    if (Options.ShowPrivateDiscriminators)
-      Printer << " in " << Node->getChild(0)->getText() << ')';
+      if (Options.ShowPrivateDiscriminators)
+        Printer << " in " << Node->getChild(0)->getText() << ')';
+    } else {
+      if (Options.ShowPrivateDiscriminators) {
+        Printer << "(in " << Node->getChild(0)->getText() << ')';
+      }
+    }
     return nullptr;
   case Node::Kind::Module:
     if (Options.DisplayModuleNames)
@@ -1472,7 +1478,7 @@ NodePointer NodePrinter::print(NodePointer Node, bool asPrefixContext) {
                                          "__allocating_init" : "init");
   case Node::Kind::Constructor:
     return printEntity(Node, asPrefixContext, TypePrinting::FunctionStyle,
-                       /*hasName*/false, "init");
+                       /*hasName*/Node->getNumChildren() > 2, "init");
   case Node::Kind::Destructor:
     return printEntity(Node, asPrefixContext, TypePrinting::NoType,
                        /*hasName*/false, "deinit");
@@ -1771,8 +1777,9 @@ printEntity(NodePointer Entity, bool asPrefixContext, TypePrinting TypePr,
       Printer << " of ";
       ExtraName = "";
     }
+    size_t CurrentPos = Printer.getStringRef().size();
     print(Entity->getChild(1));
-    if (!ExtraName.empty())
+    if (Printer.getStringRef().size() != CurrentPos && !ExtraName.empty())
       Printer << '.';
   }
   if (!ExtraName.empty()) {

--- a/lib/Demangling/Remangler.cpp
+++ b/lib/Demangling/Remangler.cpp
@@ -273,6 +273,7 @@ class Remangler {
   void mangleAnyNominalType(Node *node);
   void mangleAnyGenericType(Node *node, char TypeOp);
   void mangleGenericArgs(Node *node, char &Separator);
+  void mangleAnyConstructor(Node *node, char kindOp);
 
 #define NODE(ID)                                                        \
   void mangle##ID(Node *node);
@@ -478,8 +479,7 @@ void Remangler::mangleGenericArgs(Node *node, char &Separator) {
 }
 
 void Remangler::mangleAllocator(Node *node) {
-  mangleChildNodes(node);
-  Buffer << "fC";
+  mangleAnyConstructor(node, 'C');
 }
 
 void Remangler::mangleArgumentTuple(Node *node) {
@@ -600,9 +600,18 @@ void Remangler::mangleClass(Node *node) {
   mangleAnyNominalType(node);
 }
 
+void Remangler::mangleAnyConstructor(Node *node, char kindOp) {
+  mangleChildNode(node, 0);
+  if (node->getNumChildren() > 2) {
+    assert(node->getNumChildren() == 3);
+    mangleChildNode(node, 2);
+  }
+  mangleChildNode(node, 1);
+  Buffer << "f" << kindOp;
+}
+
 void Remangler::mangleConstructor(Node *node) {
-  mangleChildNodes(node);
-  Buffer << "fc";
+  mangleAnyConstructor(node, 'c');
 }
 
 void Remangler::mangleDeallocator(Node *node) {
@@ -1385,7 +1394,7 @@ void Remangler::manglePrefixOperator(Node *node) {
 
 void Remangler::manglePrivateDeclName(Node *node) {
   mangleChildNodesReversed(node);
-  Buffer << "LL";
+  Buffer << (node->getNumChildren() == 1 ? "Ll" : "LL");
 }
 
 void Remangler::mangleProtocol(Node *node) {

--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -259,4 +259,4 @@ _T0Tk ---> _T0Tk
 _T0A8 ---> _T0A8
 _T0s30ReversedRandomAccessCollectionVyxGTfq3nnpf_nTfq1cn_nTfq4x_n ---> _T0s30ReversedRandomAccessCollectionVyxGTfq3nnpf_nTfq1cn_nTfq4x_n
 _T03abc6testitySiFTm ---> merged abc.testit(Swift.Int) -> ()
-
+_T04main4TestCACSi1x_tc6_PRIV_Llfc ---> main.Test.(in _PRIV_).init(x: Swift.Int) -> main.Test

--- a/test/Demangle/Inputs/simplified-manglings.txt
+++ b/test/Demangle/Inputs/simplified-manglings.txt
@@ -204,4 +204,4 @@ _TTRXFo_oCSo13SKPhysicsBodydVSC7CGPointdVSC8CGVectordGSpV10ObjectiveC8ObjCBool__
 _T0So13SKPhysicsBodyCSC7CGPointVSC8CGVectorVSpy10ObjectiveC8ObjCBoolVGIxxyyy_AbdFSpyAIGIyByyyy_TR ---> thunk for @callee_owned (@owned SKPhysicsBody, @unowned CGPoint, @unowned CGVector, @unowned UnsafeMutablePointer<ObjCBool>) -> ()
 _T04main1_yyF ---> _()
 _T03abc6testitySiFTm ---> testit(_:)
-
+_T04main4TestCACSi1x_tc6_PRIV_Llfc ---> Test.init(x:)

--- a/test/SILGen/mangling_private.swift
+++ b/test/SILGen/mangling_private.swift
@@ -21,20 +21,32 @@ private func privateFunc() -> Int {
 public struct PublicStruct {
   // CHECK-LABEL: sil private @_T016mangling_private12PublicStructV0B6Method33_A3CCBB841DB59E79A4AD4EE458655068LLyyFZ
   private static func privateMethod() {}
+
+  // CHECK-LABEL: sil private @_T016mangling_private12PublicStructVACSi1x_tc33_A3CCBB841DB59E79A4AD4EE458655068LlfC
+  private init(x: Int) {}
 }
 
 public struct InternalStruct {
   // CHECK-LABEL: sil private @_T016mangling_private14InternalStructV0B6Method33_A3CCBB841DB59E79A4AD4EE458655068LLyyFZ
   private static func privateMethod() {}
+
+  // CHECK-LABEL: sil private @_T016mangling_private14InternalStructVACSi1x_tc33_A3CCBB841DB59E79A4AD4EE458655068LlfC
+  private init(x: Int) {}
 }
 
 private struct PrivateStruct {
   // CHECK-LABEL: sil private @_T016mangling_private13PrivateStruct33_A3CCBB841DB59E79A4AD4EE458655068LLV0B6MethodyyFZ
   private static func privateMethod() {}
 
+  // CHECK-LABEL: sil private @_T016mangling_private13PrivateStruct33_A3CCBB841DB59E79A4AD4EE458655068LLVADSi1x_tcfC
+  private init(x: Int) {}
+
   struct Inner {
     // CHECK-LABEL: sil private @_T016mangling_private13PrivateStruct33_A3CCBB841DB59E79A4AD4EE458655068LLV5InnerV0B6MethodyyFZ
     private static func privateMethod() {}
+
+    // CHECK-LABEL: sil private @_T016mangling_private13PrivateStruct33_A3CCBB841DB59E79A4AD4EE458655068LLV5InnerVAFSi1x_tcfC
+    private init(x: Int) {}
   }
 }
 
@@ -47,10 +59,16 @@ func localTypes() {
 extension PublicStruct {
   // CHECK-LABEL: sil private @_T016mangling_private12PublicStructV16extPrivateMethod33_A3CCBB841DB59E79A4AD4EE458655068LLyyF
   private func extPrivateMethod() {}
+
+  // CHECK-LABEL: sil private @_T016mangling_private12PublicStructVACSi3ext_tc33_A3CCBB841DB59E79A4AD4EE458655068LlfC
+  private init(ext: Int) {}
 }
 extension PrivateStruct {
   // CHECK-LABEL: sil private @_T016mangling_private13PrivateStruct33_A3CCBB841DB59E79A4AD4EE458655068LLV03extC6MethodyyF
   private func extPrivateMethod() {}
+
+  // CHECK-LABEL: sil private @_T016mangling_private13PrivateStruct33_A3CCBB841DB59E79A4AD4EE458655068LLVADSi3ext_tcfC
+  private init(ext: Int) {}
 }
 
 // CHECK-LABEL: sil private @_T016mangling_private10localTypesyyF11LocalStructL_V0B6MethodyyFZ


### PR DESCRIPTION
Previously, two constructors with the same full name and argument types would get identical manglings even if they were declared `private` or `fileprivate` in different files. This would lead to symbol collisions in whole-module builds. Add a new mangling node for private discriminators on base-name-less decls to make this unique.

This still doesn't fix the existing issue with private members, named or not, conflicting when they're in the *same* file, but since Swift 4 makes those members visible to one another (SE-0169) that's only an issue in Swift 3 mode anyway, and as such probably won't get fixed at all.

rdar://problem/27758199
