### PR TITLE
Demangler: fix a hang in case a malformed symbol ends with an 'A<digit>'

### DIFF
--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -442,6 +442,10 @@ NodePointer Demangler::demangleMultiSubstitutions() {
   int RepeatCount = -1;
   while (true) {
     char c = nextChar();
+    if (c == 0) {
+      // End of text.
+      return nullptr;
+    }
     if (isLowerLetter(c)) {
       // It's a substitution with an index < 26.
       NodePointer Nd = pushMultiSubstitutions(RepeatCount, c - 'a');

--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -256,4 +256,5 @@ _T08_ElementQzSbs5Error_pIxxdzo_ABSbsAC_pIxidzo_s26RangeReplaceableCollectionRzA
 _T0Ix_IyB_Tr ---> {T:} reabstraction thunk from @callee_owned () -> () to @callee_unowned @convention(block) () -> ()
 _T0Rml ---> _T0Rml
 _T0Tk ---> _T0Tk
+_T0A8 ---> _T0A8
 


### PR DESCRIPTION
For example _T0A8

rdar://problem/32359287
