### PR TITLE
Handle selector inference for a readwrite witness of a read-only req

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -6467,6 +6467,8 @@ TypeChecker::findWitnessedObjCRequirements(const ValueDecl *witness,
             if (!storageReq)
               continue;
             req = storageReq->getAccessorFunction(accessorKind);
+            if (!req)
+              continue;
           }
           result.push_back(req);
           if (anySingleRequirement) return result;

--- a/test/decl/protocol/objc.swift
+++ b/test/decl/protocol/objc.swift
@@ -246,3 +246,15 @@ class C8SubB: C8Base {
 
   @objc(getTheProp) func collision() {} // okay
 }
+
+// These used to crash because the requirement is get-only.
+class C8SubRW: C8Base {
+  var prop: Int {
+    get { return 0 }
+    set {}
+  }
+}
+
+class C8SubRW2: C8Base {
+  var prop: Int = 0
+}


### PR DESCRIPTION
The storage declaration will match a requirement in the protocol, but the setter decl will not. Just keep going.

rdar://problem/32358570