### PR TITLE
Improve TBD validation logic

### DIFF
--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -271,8 +271,15 @@ public:
   /// variables by name when we print it out. This eases diffing of SIL files.
   bool EmitSortedSIL = false;
 
+  /// The different modes for validating TBD against the LLVM IR.
+  enum class TBDValidationMode {
+    None,           ///< Do no validation.
+    MissingFromTBD, ///< Only check for symbols that are in IR but not TBD.
+    All, ///< Check for symbols that are in IR but not TBD and TBD but not IR.
+  };
+
   /// Compare the symbols in the IR against the TBD file we would generate.
-  bool ValidateTBDAgainstIR = false;
+  TBDValidationMode ValidateTBDAgainstIR = TBDValidationMode::None;
 
   /// An enum with different modes for automatically crashing at defined times.
   enum class DebugCrashMode {

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -411,8 +411,9 @@ def group_info_path : Separate<["-"], "group-info-path">,
 def diagnostics_editor_mode : Flag<["-"], "diagnostics-editor-mode">,
 HelpText<"Diagnostics will be used in editor">;
 
-def validate_tbd_against_ir: Flag<["-"], "validate-tbd-against-ir">,
-    HelpText<"Compare the symbols in the IR against the TBD file that would be generated.">;
+def validate_tbd_against_ir_EQ: Joined<["-"], "validate-tbd-against-ir=">,
+    HelpText<"Compare the symbols in the IR against the TBD file that would be generated.">,
+    MetaVarName<"<level>">;
 
 // FIXME: Remove this flag when void subscripts are implemented.
 // This is used to guard preemptive testing for the fix-it.

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -191,7 +191,20 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
     Opts.StatsOutputDir = A->getValue();
   }
 
-  Opts.ValidateTBDAgainstIR |= Args.hasArg(OPT_validate_tbd_against_ir);
+  if (const Arg *A = Args.getLastArg(OPT_validate_tbd_against_ir_EQ)) {
+    using Mode = FrontendOptions::TBDValidationMode;
+    StringRef value = A->getValue();
+    if (value == "none") {
+      Opts.ValidateTBDAgainstIR = Mode::None;
+    } else if (value == "missing") {
+      Opts.ValidateTBDAgainstIR = Mode::MissingFromTBD;
+    } else if (value == "all") {
+      Opts.ValidateTBDAgainstIR = Mode::All;
+    } else {
+      Diags.diagnose(SourceLoc(), diag::error_unsupported_option_argument,
+                     A->getOption().getPrefixedName(), value);
+    }
+  }
 
   if (const Arg *A = Args.getLastArg(OPT_warn_long_function_bodies)) {
     unsigned attempt;

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -53,6 +53,7 @@
 #include "swift/Migrator/Migrator.h"
 #include "swift/PrintAsObjC/PrintAsObjC.h"
 #include "swift/Serialization/SerializationOptions.h"
+#include "swift/Serialization/SerializedModuleLoader.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
 
 // FIXME: We're just using CompilerInstance::createOutputFile.
@@ -673,19 +674,30 @@ static bool performCompile(CompilerInstance &Instance,
          "All actions not requiring SILGen must have been handled!");
 
   std::unique_ptr<SILModule> SM = Instance.takeSILModule();
+  // Records whether the SIL is directly computed from the AST we have, meaning
+  // that it will exactly match the source. It might not if, for instance, some
+  // of the inputs are SIB with extra explicit SIL.
+  auto astGuaranteedToCorrespondToSIL = false;
   if (!SM) {
+    auto fileIsSIB = [](const FileUnit *File) -> bool {
+      auto SASTF = dyn_cast<SerializedASTFile>(File);
+      return SASTF && SASTF->isSIB();
+    };
     if (opts.PrimaryInput.hasValue() && opts.PrimaryInput.getValue().isFilename()) {
       FileUnit *PrimaryFile = PrimarySourceFile;
       if (!PrimaryFile) {
         auto Index = opts.PrimaryInput.getValue().Index;
         PrimaryFile = Instance.getMainModule()->getFiles()[Index];
       }
+      astGuaranteedToCorrespondToSIL = !fileIsSIB(PrimaryFile);
       SM = performSILGeneration(*PrimaryFile, Invocation.getSILOptions(),
                                 None, opts.SILSerializeAll);
     } else {
-      SM = performSILGeneration(Instance.getMainModule(), Invocation.getSILOptions(),
-                                opts.SILSerializeAll,
-                                true);
+      auto mod = Instance.getMainModule();
+      astGuaranteedToCorrespondToSIL =
+          llvm::none_of(mod->getFiles(), fileIsSIB);
+      SM = performSILGeneration(mod, Invocation.getSILOptions(),
+                                opts.SILSerializeAll, true);
     }
   }
 
@@ -925,7 +937,8 @@ static bool performCompile(CompilerInstance &Instance,
     allSymbols = true;
     LLVM_FALLTHROUGH;
   case FrontendOptions::TBDValidationMode::MissingFromTBD: {
-    if (!inputFileKindCanHaveTBDValidated(Invocation.getInputKind()))
+    if (!inputFileKindCanHaveTBDValidated(Invocation.getInputKind()) ||
+        !astGuaranteedToCorrespondToSIL)
       break;
 
     auto hasMultipleIRGenThreads = Invocation.getSILOptions().NumThreads > 1;

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -925,6 +925,9 @@ static bool performCompile(CompilerInstance &Instance,
     allSymbols = true;
     LLVM_FALLTHROUGH;
   case FrontendOptions::TBDValidationMode::MissingFromTBD: {
+    if (!inputFileKindCanHaveTBDValidated(Invocation.getInputKind()))
+      break;
+
     auto hasMultipleIRGenThreads = Invocation.getSILOptions().NumThreads > 1;
     bool error;
     if (PrimarySourceFile)

--- a/lib/FrontendTool/TBD.cpp
+++ b/lib/FrontendTool/TBD.cpp
@@ -60,6 +60,21 @@ bool swift::writeTBD(ModuleDecl *M, bool hasMultipleIRGenThreads,
   return false;
 }
 
+bool swift::inputFileKindCanHaveTBDValidated(InputFileKind kind) {
+  // Only things that involve an AST can have a TBD file computed, at the
+  // moment.
+  switch (kind) {
+  case InputFileKind::IFK_Swift:
+  case InputFileKind::IFK_Swift_Library:
+    return true;
+  case InputFileKind::IFK_None:
+  case InputFileKind::IFK_Swift_REPL:
+  case InputFileKind::IFK_SIL:
+  case InputFileKind::IFK_LLVM_IR:
+    return false;
+  }
+}
+
 static bool validateSymbolSet(DiagnosticEngine &diags,
                               llvm::StringSet<> symbols, llvm::Module &IRModule,
                               bool diagnoseExtraSymbolsInTBD) {

--- a/lib/FrontendTool/TBD.h
+++ b/lib/FrontendTool/TBD.h
@@ -13,6 +13,8 @@
 #ifndef SWIFT_FRONTENDTOOL_TBD_H
 #define SWIFT_FRONTENDTOOL_TBD_H
 
+#include "swift/Frontend/FrontendOptions.h"
+
 namespace llvm {
 class StringRef;
 class Module;
@@ -24,6 +26,7 @@ class FrontendOptions;
 
 bool writeTBD(ModuleDecl *M, bool hasMultipleIRGenThreads,
               llvm::StringRef OutputFilename);
+bool inputFileKindCanHaveTBDValidated(InputFileKind kind);
 bool validateTBD(ModuleDecl *M, llvm::Module &IRModule,
                  bool hasMultipleIRGenThreads, bool diagnoseExtraSymbolsInTBD);
 bool validateTBD(FileUnit *M, llvm::Module &IRModule,

--- a/lib/FrontendTool/TBD.h
+++ b/lib/FrontendTool/TBD.h
@@ -25,9 +25,9 @@ class FrontendOptions;
 bool writeTBD(ModuleDecl *M, bool hasMultipleIRGenThreads,
               llvm::StringRef OutputFilename);
 bool validateTBD(ModuleDecl *M, llvm::Module &IRModule,
-                 bool hasMultipleIRGenThreads);
+                 bool hasMultipleIRGenThreads, bool diagnoseExtraSymbolsInTBD);
 bool validateTBD(FileUnit *M, llvm::Module &IRModule,
-                 bool hasMultipleIRGenThreads);
+                 bool hasMultipleIRGenThreads, bool diagnoseExtraSymbolsInTBD);
 }
 
 #endif

--- a/test/TBD/class.swift
+++ b/test/TBD/class.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir -o- -parse-as-library -module-name test -validate-tbd-against-ir %s
+// RUN: %target-swift-frontend -emit-ir -o- -parse-as-library -module-name test -validate-tbd-against-ir=all %s
 
 open class OpenNothing {}
 

--- a/test/TBD/class_objc.swift
+++ b/test/TBD/class_objc.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir -o- -parse-as-library -module-name test -import-objc-header %S/Inputs/objc_class_header.h -validate-tbd-against-ir %s
+// RUN: %target-swift-frontend -emit-ir -o- -parse-as-library -module-name test -import-objc-header %S/Inputs/objc_class_header.h -validate-tbd-against-ir=all %s
 
 // REQUIRES: objc_interop
 

--- a/test/TBD/extension.swift
+++ b/test/TBD/extension.swift
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: %target-build-swift %S/Inputs/extension_types.swift -module-name ExtensionTypes -emit-module -emit-module-path %t/ExtensionTypes.swiftmodule
-// RUN: %target-swift-frontend -emit-ir -o- -parse-as-library -module-name test -validate-tbd-against-ir -I %t %s
+// RUN: %target-swift-frontend -emit-ir -o- -parse-as-library -module-name test -validate-tbd-against-ir=all -I %t %s
 
 import ExtensionTypes
 

--- a/test/TBD/function.swift
+++ b/test/TBD/function.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir -o- -parse-as-library -module-name test -validate-tbd-against-ir %s
+// RUN: %target-swift-frontend -emit-ir -o- -parse-as-library -module-name test -validate-tbd-against-ir=all %s
 
 public func publicNoArgs() {}
 public func publicSomeArgs(_: Int, x: Int) {}

--- a/test/TBD/global.swift
+++ b/test/TBD/global.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir -o- -parse-as-library -module-name test -validate-tbd-against-ir %s
+// RUN: %target-swift-frontend -emit-ir -o- -parse-as-library -module-name test -validate-tbd-against-ir=all %s
 
 public let publicLet: Int = 0
 internal let internalLet: Int = 0

--- a/test/TBD/main.swift
+++ b/test/TBD/main.swift
@@ -1,3 +1,3 @@
-// RUN: %target-swift-frontend -emit-ir -o- -module-name test -validate-tbd-against-ir %s
+// RUN: %target-swift-frontend -emit-ir -o- -module-name test -validate-tbd-against-ir=all %s
 
 // Top-level code (i.e. implicit `main`) should be handled

--- a/test/TBD/protocol.swift
+++ b/test/TBD/protocol.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir -o- -parse-as-library -module-name test -validate-tbd-against-ir %s
+// RUN: %target-swift-frontend -emit-ir -o- -parse-as-library -module-name test -validate-tbd-against-ir=all %s
 
 public protocol Public {
     func publicMethod()

--- a/test/TBD/struct.swift
+++ b/test/TBD/struct.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir -o- -parse-as-library -module-name test -validate-tbd-against-ir %s
+// RUN: %target-swift-frontend -emit-ir -o- -parse-as-library -module-name test -validate-tbd-against-ir=all %s
 
 public struct PublicNothing {}
 


### PR DESCRIPTION
This restricts the validation of TBD to cases when we know that SIL/IR is entirely computed from AST (from which we compute the list of symbols), rather than situations when, say, compiling IR/SIL directly, or a SIB file which may also include SIL.

Additionally, split -validation-tbd-against-ir to be able allow the TBD to have extra symbols, letting us ensure that we include everything without having to ensure that we don't include extraneous ones (missing symbols is worse than extra symbols).