### PR TITLE
[Sema] Diagnose with full name of mismatched compound names

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -628,7 +628,7 @@ ERROR(unspaced_unary_operator,none,
 
 
 ERROR(use_unresolved_identifier,none,
-      "use of unresolved %select{identifier|operator}1 %0", (DeclName, bool))
+      "use of unresolved %select{identifier|operator}1 '%0'", (StringRef, bool))
 NOTE(confusable_character,none,
       "%select{identifier|operator}0 '%1' contains possibly confused characters; "
       "did you mean to use '%2'?",

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -7194,7 +7194,7 @@ static bool diagnoseKeyPathComponents(ConstraintSystem *CS, KeyPathExpr *KPE,
                     currentType, componentName);
       else
         TC.diagnose(componentNameLoc, diag::use_unresolved_identifier,
-                    componentName, false);
+                    componentName.str(), false);
 
       // Note all the correction candidates.
       for (auto &result : lookup) {

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -461,9 +461,9 @@ resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE, DeclContext *DC) {
     // identifiers, we explicitly get the full serialized DeclName for this
     // diagnostic.
     StringRef nameStr = Name.getBaseName().str();
+    llvm::SmallString<10> scratch;
     for (auto &result : Lookup) {
       if (result->getBaseName() == Name.getBaseName()) {
-        llvm::SmallString<10> scratch;
         nameStr = Name.getString(scratch);
         break;
       }

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -454,12 +454,17 @@ resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE, DeclContext *DC) {
     
     // Check if any lookups share a basename. If that's the case, we need
     // to disambiguate the diagnostic by printing the UDRE's full name.
+    //
+    // We need to build a string here because the default printing behavior for
+    // DeclNames skips printing arguments if all the names are empty. Because
+    // we want to be explicit if there is any ambiguity in the unresolved
+    // identifiers, we explicitly get the full serialized DeclName for this
+    // diagnostic.
     StringRef nameStr = Name.getBaseName().str();
     for (auto &result : Lookup) {
       if (result->getBaseName() == Name.getBaseName()) {
         llvm::SmallString<10> scratch;
-        Name.getString(scratch);
-        nameStr = scratch.str();
+        nameStr = Name.getString(scratch);
         break;
       }
     }

--- a/lib/Sema/TypeCheckExprObjC.cpp
+++ b/lib/Sema/TypeCheckExprObjC.cpp
@@ -257,7 +257,7 @@ Optional<Type> TypeChecker::checkObjCKeyPathExpr(DeclContext *dc,
                  currentType, componentName);
       else
         diagnose(componentNameLoc, diag::use_unresolved_identifier,
-                 componentName, false);
+                 componentName.str(), false);
 
       // Note all the correction candidates.
       for (auto &result : lookup) {

--- a/test/Compatibility/unqualified_lookup.swift
+++ b/test/Compatibility/unqualified_lookup.swift
@@ -2,7 +2,7 @@
 
 // Stupid Swift 3 unqualified lookup quirk
 
-func f3(_ x: Int, _ y: Int, z: Int) { } // expected-note{{did you mean 'f3'?}}
+func f3(_ x: Int, _ y: Int, z: Int) { } // expected-note{{did you mean 'f3(_:_:z:)'?}}
 
 struct S0 {
   func testS0() {

--- a/test/Sema/typo_correction.swift
+++ b/test/Sema/typo_correction.swift
@@ -119,3 +119,8 @@ func takesAnyObjectArchetype<T : AnyObject>(_ t: T) {
   _ = t.rawPointer
   // expected-error@-1 {{value of type 'T' has no member 'rawPointer'}}
 }
+
+func someFunction() {} //expected-note{{did you mean 'someFunction'?}}
+func someFunction(_ x: Int, y: Bool) {} //expected-note{{did you mean 'someFunction(_:y:)'?}}
+
+_ = someFunction(_:) //expected-error {{use of unresolved identifier 'someFunction(_:)'}}

--- a/test/decl/protocol/special/coding/struct_codable_nonconforming_property.swift
+++ b/test/decl/protocol/special/coding/struct_codable_nonconforming_property.swift
@@ -20,7 +20,7 @@ struct NonConformingStruct : Codable { // expected-error {{type 'NonConformingSt
   // expected-error@-1 {{type 'NonConformingStruct' does not conform to protocol 'Decodable'}}
   // expected-error@-2 {{type 'NonConformingStruct' does not conform to protocol 'Encodable'}}
   // expected-error@-3 {{type 'NonConformingStruct' does not conform to protocol 'Encodable'}}
-  // expected-note@-4 {{did you mean 'init'?}}
+  // expected-note@-4 {{did you mean 'init(w:x:y:nonCodable}}
   var w: NonCodable // expected-note {{cannot automatically synthesize 'Decodable' because 'NonCodable' does not conform to 'Decodable'}}
   // expected-note@-1 {{cannot automatically synthesize 'Decodable' because 'NonCodable' does not conform to 'Decodable'}}
   // expected-note@-2 {{cannot automatically synthesize 'Encodable' because 'NonCodable' does not conform to 'Encodable'}}

--- a/test/decl/protocol/special/coding/struct_codable_simple_extension.swift
+++ b/test/decl/protocol/special/coding/struct_codable_simple_extension.swift
@@ -2,7 +2,7 @@
 
 // Simple structs where Codable conformance is added in extensions should not
 // derive conformance yet.
-struct SimpleStruct { // expected-note {{did you mean 'init'?}}
+struct SimpleStruct { // expected-note {{did you mean 'init(x:y:)'?}}
   var x: Int
   var y: Double
   static var z: String = "foo"


### PR DESCRIPTION
<!-- What's in this pull request? -->

When using a fully-qualified reference to a decl that doesn't have a matching argument set, print the full name of both the decl's name and the referencing name.

```swift
func foo() {} // did you mean 'foo'?
func foo(x: Int) {} // did you mean 'foo(x:)'?
foo(_:) // use of unresolved identifier 'foo(_:)'
```

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-4867](https://bugs.swift.org/browse/SR-4867).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->