### PR TITLE
Demangler: replace an assert with a bail-condition.

### DIFF
--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -1326,7 +1326,8 @@ NodePointer Demangler::demangleFunctionSpecialization() {
       case FunctionSigSpecializationParamKind::ClosureProp: {
         size_t FixedChildren = Param->getNumChildren();
         while (NodePointer Ty = popNode(Node::Kind::Type)) {
-          assert(ParamKind == FunctionSigSpecializationParamKind::ClosureProp);
+          if (ParamKind != FunctionSigSpecializationParamKind::ClosureProp)
+            return nullptr;
           Param = addChild(Param, Ty);
         }
         NodePointer Name = popNode(Node::Kind::Identifier);

--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -257,4 +257,5 @@ _T0Ix_IyB_Tr ---> {T:} reabstraction thunk from @callee_owned () -> () to @calle
 _T0Rml ---> _T0Rml
 _T0Tk ---> _T0Tk
 _T0A8 ---> _T0A8
+_T0s30ReversedRandomAccessCollectionVyxGTfq3nnpf_nTfq1cn_nTfq4x_n ---> _T0s30ReversedRandomAccessCollectionVyxGTfq3nnpf_nTfq1cn_nTfq4x_n
 


### PR DESCRIPTION
The assert condition can be false for a malformed symbol, like _T0s30ReversedRandomAccessCollectionVyxGTfq3nnpf_nTfq1cn_nTfq4x_n

rdar://problem/32359287
