### PR TITLE
Emit the code to setup debug shadow copies of variables in the same scope

### DIFF
--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -729,7 +729,7 @@ public:
     if (!Alloca.isValid())
       Alloca = createAlloca(Ty, Align, Name+".addr");
 
-    ArtificialLocation AutoRestore(getDebugScope(), IGM.DebugInfo, Builder);
+    ArtificialLocation AutoRestore(Scope, IGM.DebugInfo, Builder);
     Builder.CreateStore(Storage, Alloca.getAddress(), Align);
     return Alloca.getAddress();
   }
@@ -769,7 +769,7 @@ public:
     Alignment align(layout->getAlignment());
 
     auto alloca = createAlloca(aggregateType, align, Name + ".debug");
-    ArtificialLocation AutoRestore(getDebugScope(), IGM.DebugInfo, Builder);
+    ArtificialLocation AutoRestore(Scope, IGM.DebugInfo, Builder);
     size_t i = 0;
     for (auto val : vals) {
       auto addr = Builder.CreateStructGEP(alloca, i,

--- a/test/DebugInfo/guard-let.swift
+++ b/test/DebugInfo/guard-let.swift
@@ -7,11 +7,14 @@ public func f(_ i : Int?)
   // CHECK: define {{.*}}@_T04main1fySiSgF
   // CHECK: %[[PHI:.*]] = phi
   // The shadow copy store should not have a location.
+  // Note that the strore must be in the same scope or else it might defeat
+  // livedebugvalues.
   // CHECK: store {{(i32|i64)}} %[[PHI]], {{(i32|i64)}}* %val.addr, align {{(4|8)}}, !dbg ![[DBG0:.*]]
   // CHECK: @llvm.dbg.declare(metadata {{(i32|i64)}}* %val.addr, {{.*}}, !dbg ![[DBG1:.*]]
   // CHECK: ![[F:.*]] = distinct !DISubprogram(name: "f",
-  // CHECK: ![[DBG0]] = !DILocation(line: 0, scope: ![[F]])
-  // CHECK: ![[DBG1]] = !DILocation(line: [[@LINE+1]],
+  // CHECK: ![[BLK:.*]] = distinct !DILexicalBlock(scope: ![[F]],
+  // CHECK: ![[DBG0]] = !DILocation(line: 0, scope: ![[BLK]])
+  // CHECK: ![[DBG1]] = !DILocation(line: [[@LINE+1]], {{.*}}scope: ![[BLK]]
   guard let val = i else { return }
   use(val)
 }
@@ -21,7 +24,7 @@ public func g(_ s : String?)
   // CHECK2: define {{.*}}@_T04main1gySSSgF
   // The shadow copy store should not have a location.
   // CHECK2: getelementptr inbounds {{.*}} %s.debug, {{.*}}, !dbg ![[DBG0:.*]]
-  // CHECK2: ![[G:.*]] = distinct !DISubprogram(name: "g",
+  // CHECK2: ![[G:.*]] = distinct !DISubprogram(name: "g"
   // CHECK2: ![[DBG0]] = !DILocation(line: 0, scope: ![[G]])
   guard let val = s else { return }
   use(val)


### PR DESCRIPTION
Emit the code to setup debug shadow copies of variables in the same scope
as the variable is in. If ASAN inserts additional basic blocks to sanitize
the store, it will reuse the location and scope. If the scope is not a
descendant of the scope of the variable an optimization in the live debug
values pass will kill all DEBUG_VALUEs and thus prevent them from being
propagated.

rdar://problem/30433661
