### PR TITLE
Emit llvm.dbg.declare intrisics immediately after the described alloca.

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -1998,8 +1998,13 @@ void IRGenDebugInfoImpl::emitDbgIntrinsic(
   // the variable that is live throughout the function. With SIL
   // optimizations this is not guaranteed and a variable can end up in
   // two allocas (for example, one function inlined twice).
-  if (isa<llvm::AllocaInst>(Storage)) {
-    DBuilder.insertDeclare(Storage, Var, Expr, DL, BB);
+  if (auto *Alloca = dyn_cast<llvm::AllocaInst>(Storage)) {
+    auto *ParentBB = Alloca->getParent();
+    auto InsertBefore = std::next(Alloca->getIterator());
+    if (InsertBefore != ParentBB->end())
+      DBuilder.insertDeclare(Alloca, Var, Expr, DL, &*InsertBefore);
+    else
+      DBuilder.insertDeclare(Alloca, Var, Expr, DL, ParentBB);
     return;
   }
 

--- a/test/DebugInfo/any.swift
+++ b/test/DebugInfo/any.swift
@@ -4,9 +4,9 @@ func markUsed<T>(_ t: T) {}
 
 func main() {
   // CHECK: call void @llvm.dbg.declare(metadata %Any* {{.*}}, metadata ![[S:.*]], metadata !{{[0-9]+}}), !dbg ![[DBG:.*]]
+  // CHECK: ![[S]] = !DILocalVariable(name: "s", {{.*}}line: [[@LINE+3]]
   // CHECK: ![[SCOPE:.*]] = distinct !DILexicalBlock({{.*}}line: 5, column: 13)
-  // CHECK: ![[S]] = !DILocalVariable(name: "s", {{.*}}line: [[@LINE+2]]
-  // CHECK: ![[DBG]] = !DILocation(line: [[@LINE+1]], column: 7, scope: ![[SCOPE]])
+  // CHECK: ![[DBG]] = !DILocation(line: [[@LINE+1]], column: 7, scope: ![[SCOPE:.*]])
   var s: Any = "hello world"
   var n: Any = 12
   var t: Any = (1,2)

--- a/test/DebugInfo/closure-args.swift
+++ b/test/DebugInfo/closure-args.swift
@@ -12,8 +12,8 @@ func main() -> Void
     var backward_ptr  =
     // CHECK: define internal {{.*}} i1 @_T04mainAAyyFSbSS_SStcfU_(
     // CHECK: %[[RANDOM_STR_ADDR:.*]] = alloca %TSS*, align {{(4|8)}}
-    // CHECK: store %TSS* %{{.*}}, %TSS** %[[RANDOM_STR_ADDR]], align {{(4|8)}}
     // CHECK-NEXT: call void @llvm.dbg.declare(metadata %TSS** %[[RANDOM_STR_ADDR]], metadata !{{.*}}, metadata !{{[0-9]+}}), !dbg
+    // CHECK: store %TSS* %{{.*}}, %TSS** %[[RANDOM_STR_ADDR]], align {{(4|8)}}
     // CHECK-DAG: !DILocalVariable(name: "lhs",{{.*}} line: [[@LINE+5]],
     // CHECK-DAG: !DILocalVariable(name: "rhs",{{.*}} line: [[@LINE+4]],
     // CHECK-DAG: !DILocalVariable(name: "random_string",{{.*}} line: 8,

--- a/test/DebugInfo/dbgvalue-insertpt.swift
+++ b/test/DebugInfo/dbgvalue-insertpt.swift
@@ -1,7 +1,10 @@
 // RUN: %target-swift-frontend -g -emit-ir %s | %FileCheck %s
+// FIXME: This test should be testing a non-shadow-copied value instead.
 for i in 0 ..< 3 {
   // CHECK: %[[ALLOCA:[0-9]+]] = alloca %TSiSg
   // CHECK: %i.addr = alloca i{{32|64}}
+  // CHECK-NEXT: call void @llvm.dbg.declare(metadata i{{32|64}}* %i.addr,
+  // CHECK-SAME:                           metadata ![[I:[0-9]+]],
   // CHECK: %[[CAST:[0-9]+]] = bitcast %TSiSg* %[[ALLOCA]] to i{{32|64}}*
   // CHECK: %[[LD:[0-9]+]] = load i{{32|64}}, i{{32|64}}* %[[CAST]]
   // CHECK: br i1 {{%.*}}, label %[[FAIL:.*]], label %[[SUCCESS:.*]],
@@ -12,7 +15,5 @@ for i in 0 ..< 3 {
   // CHECK: ; <label>:[[NEXT_BB]]:
   // CHECK: %[[PHI_VAL:.*]] = phi i{{32|64}} [ %[[LD]], %[[SUCCESS]] ]
   // CHECK: store i{{32|64}} %[[PHI_VAL]], i{{32|64}}* %i.addr
-  // CHECK-NEXT: call void @llvm.dbg.declare(metadata i{{32|64}}* %i.addr,
-  // CHECK-SAME:                           metadata ![[I:[0-9]+]],
   // CHECK: ![[I]] = !DILocalVariable(name: "i",
 }

--- a/test/DebugInfo/debug_value_addr.swift
+++ b/test/DebugInfo/debug_value_addr.swift
@@ -10,8 +10,8 @@
 // CHECK: define {{.*}}_T016debug_value_addr4testyxlF
 // CHECK: entry:
 // CHECK-NEXT: %[[TADDR:.*]] = alloca
-// CHECK: store %swift.opaque* %0, %swift.opaque** %[[TADDR:.*]], align
 // CHECK-NEXT: call void @llvm.dbg.declare({{.*}}%[[TADDR]]
+// CHECK: store %swift.opaque* %0, %swift.opaque** %[[TADDR:.*]], align
 
 struct S<T> {
   var a : T

--- a/test/DebugInfo/generic_arg.swift
+++ b/test/DebugInfo/generic_arg.swift
@@ -3,13 +3,13 @@ import StdlibUnittest
 func foo<T>(_ x: T) -> () {
   // CHECK: define {{.*}} @_T011generic_arg3fooyxlF
   // CHECK: %[[T:.*]] = alloca %swift.type*
-  // CHECK: %[[X:.*]] = alloca %swift.opaque*
-  // CHECK: store %swift.type* %T, %swift.type** %[[T]],
   // CHECK: call void @llvm.dbg.declare(metadata %swift.type** %[[T]],
   // CHECK-SAME:               metadata ![[T1:.*]], metadata ![[EMPTY:.*]])
-  // CHECK: store %swift.opaque* %0, %swift.opaque** %[[X]],
+  // CHECK: %[[X:.*]] = alloca %swift.opaque*
   // CHECK: call void @llvm.dbg.declare(metadata %swift.opaque** %[[X]],
   // CHECK-SAME:               metadata ![[X1:.*]], metadata ![[EMPTY]])
+  // CHECK: store %swift.type* %T, %swift.type** %[[T]],
+  // CHECK: store %swift.opaque* %0, %swift.opaque** %[[X]],
   // CHECK: ![[T1]] = !DILocalVariable(name: "$swift.type.T",
   // CHECK-SAME:                       flags: DIFlagArtificial)
   // CHECK: ![[EMPTY]] = !DIExpression()

--- a/test/DebugInfo/generic_arg3.swift
+++ b/test/DebugInfo/generic_arg3.swift
@@ -5,9 +5,9 @@ func apply<Type>(_ T : Type, fn: (Type) -> Type) -> Type { return fn(T) }
 public func f<Type>(_ value : Type)
 {
   // CHECK: define {{.*}}_T012generic_arg31fyxlFxxcfU_
-  // CHECK: store %swift.opaque* %1, %swift.opaque** %[[ALLOCA:.*]], align
-  // CHECK: call void @llvm.dbg.declare(metadata %swift.opaque** %[[ALLOCA]],
+  // CHECK: call void @llvm.dbg.declare(metadata %swift.opaque** %[[ALLOCA:[^,]+]],
   // CHECK-SAME:       metadata ![[ARG:.*]], metadata ![[EXPR:.*]])
+  // CHECK: store %swift.opaque* %1, %swift.opaque** %[[ALLOCA]], align
   // No deref here: The argument is an Archetype and this implicitly indirect.
   // CHECK: ![[EXPR]] = !DIExpression()
   // CHECK: ![[TY:.*]] = !DICompositeType({{.*}}identifier: "_T012generic_arg31fyxlFQq_D"

--- a/test/DebugInfo/generic_arg4.swift
+++ b/test/DebugInfo/generic_arg4.swift
@@ -3,14 +3,15 @@
 public struct Q<T> {
   let x: T
 }
-  // CHECK: define {{.*}}_T012generic_arg43fooySayAA1QVyxGGlF
-  // CHECK: store %[[TY:.*]]* %0, %[[TY]]** %[[ALLOCA:.*]], align
-  // CHECK: call void @llvm.dbg.declare(metadata %[[TY]]** %[[ALLOCA]],
-  // CHECK-SAME:       metadata ![[ARG:.*]], metadata ![[EXPR:.*]])
-  // No deref here: the array argument is passed by value.
-  // CHECK: ![[EXPR]] = !DIExpression()
-  // CHECK: ![[ARG]] = !DILocalVariable(name: "arg", arg: 1,
-  // CHECK-SAME:                        line: [[@LINE+2]], type: ![[TY:.*]])
-  // CHECK: ![[TY]] = !DICompositeType({{.*}}identifier: "_T0Say12generic_arg41QVyAA3fooySayACyxGGlFQq_GGD")
+// CHECK: define {{.*}}_T012generic_arg43fooySayAA1QVyxGGlF
+// CHECK: call void @llvm.dbg.declare
+// CHECK: call void @llvm.dbg.declare(metadata %[[TY:.*]]** %[[ALLOCA:[^,]+]],
+// CHECK-SAME:       metadata ![[ARG:.*]], metadata ![[EXPR:.*]])
+// CHECK: store %[[TY]]* %0, %[[TY]]** %[[ALLOCA]], align
+// No deref here: the array argument is passed by value.
+// CHECK: ![[EXPR]] = !DIExpression()
+// CHECK: ![[ARG]] = !DILocalVariable(name: "arg", arg: 1,
+// CHECK-SAME:                        line: [[@LINE+2]], type: ![[TY:.*]])
+// CHECK: ![[TY]] = !DICompositeType({{.*}}identifier: "_T0Say12generic_arg41QVyAA3fooySayACyxGGlFQq_GGD")
 public func foo<T>(_ arg: [Q<T>]) {
 }

--- a/test/DebugInfo/generic_arg5.swift
+++ b/test/DebugInfo/generic_arg5.swift
@@ -7,9 +7,10 @@ public struct S<Type>
 public func foo<Type>(_ values : [S<Type>])
 {
   // CHECK: define {{.*}}_T012generic_arg53fooySayAA1SVyxGGlFAESgAEcfU_
-  // CHECK: store %[[TY:.*]]* %1, %[[TY]]** %[[ALLOCA:.*]], align
-  // CHECK: call void @llvm.dbg.declare(metadata %[[TY]]** %[[ALLOCA]],
+  // CHECK: call void @llvm.dbg.declare
+  // CHECK: call void @llvm.dbg.declare(metadata %[[TY:.*]]** %[[ALLOCA:[^,]+]],
   // CHECK-SAME:       metadata ![[ARG:.*]], metadata ![[EXPR:.*]])
+  // CHECK: store %[[TY]]* %1, %[[TY]]** %[[ALLOCA]], align
   // The argument is a by-ref struct and thus needs to be dereferenced.
   // CHECK: ![[ARG]] = !DILocalVariable(name: "arg", arg: 1,
   // CHECK-SAME:                        line: [[@LINE+4]],

--- a/test/DebugInfo/guard-let.swift
+++ b/test/DebugInfo/guard-let.swift
@@ -5,16 +5,16 @@ func use<T>(_ t: T) {}
 public func f(_ i : Int?)
 {
   // CHECK: define {{.*}}@_T04main1fySiSgF
-  // CHECK: %[[PHI:.*]] = phi
   // The shadow copy store should not have a location.
-  // Note that the strore must be in the same scope or else it might defeat
+  // Note that the store must be in the same scope or else it might defeat
   // livedebugvalues.
-  // CHECK: store {{(i32|i64)}} %[[PHI]], {{(i32|i64)}}* %val.addr, align {{(4|8)}}, !dbg ![[DBG0:.*]]
-  // CHECK: @llvm.dbg.declare(metadata {{(i32|i64)}}* %val.addr, {{.*}}, !dbg ![[DBG1:.*]]
-  // CHECK: ![[F:.*]] = distinct !DISubprogram(name: "f",
-  // CHECK: ![[BLK:.*]] = distinct !DILexicalBlock(scope: ![[F]],
-  // CHECK: ![[DBG0]] = !DILocation(line: 0, scope: ![[BLK]])
-  // CHECK: ![[DBG1]] = !DILocation(line: [[@LINE+1]], {{.*}}scope: ![[BLK]]
+  // CHECK1: @llvm.dbg.declare(metadata {{(i32|i64)}}* %val.addr, {{.*}}, !dbg ![[DBG0:.*]]
+  // CHECK1: %[[PHI:.*]] = phi
+  // CHECK1: store {{(i32|i64)}} %[[PHI]], {{(i32|i64)}}* %val.addr, align {{(4|8)}}, !dbg ![[DBG1:.*]]
+  // CHECK1: ![[F:.*]] = distinct !DISubprogram(name: "f",
+  // CHECK1: ![[BLK:.*]] = distinct !DILexicalBlock(scope: ![[F]],
+  // CHECK1: ![[DBG0]] = !DILocation(line: [[@LINE+2]],
+  // CHECK1: ![[DBG1]] = !DILocation(line: 0, scope: ![[BLK]])
   guard let val = i else { return }
   use(val)
 }

--- a/test/DebugInfo/if.swift
+++ b/test/DebugInfo/if.swift
@@ -4,10 +4,10 @@ func yieldValue() -> Int64? { return 23 }
 
 // Verify that variables bound in the while statements are in distinct scopes.
 if let val = yieldValue() {
-// CHECK: ![[SCOPE1:[0-9]+]] = distinct !DILexicalBlock(scope: ![[MAIN:[0-9]+]]
-// CHECK: !DILocalVariable(name: "val", scope: ![[SCOPE1]]
+// CHECK: !DILocalVariable(name: "val", scope: ![[SCOPE1:[0-9]+]]
+// CHECK: ![[SCOPE1]] = distinct !DILexicalBlock(scope: ![[MAIN:[0-9]+]]
 }
 if let val = yieldValue() {
-// CHECK: ![[SCOPE2:[0-9]+]] = distinct !DILexicalBlock(scope: ![[MAIN]]
-// CHECK: !DILocalVariable(name: "val", scope: ![[SCOPE2]]
+// CHECK: !DILocalVariable(name: "val", scope: ![[SCOPE2:[0-9]+]]
+// CHECK: ![[SCOPE2]] = distinct !DILexicalBlock(scope: ![[MAIN]]
 }

--- a/test/DebugInfo/iuo_arg.swift
+++ b/test/DebugInfo/iuo_arg.swift
@@ -17,8 +17,8 @@ class MyClass {
   func filterImage(_ image: UIImage!, _ doSomething:Bool) -> UIImage
 	{
     // Test that image is in an alloca, but not an indirect location.
-    // CHECK: store {{(i32|i64)}} %0, {{(i32|i64)}}* %[[ALLOCA:.*]], align
-    // CHECK: call void @llvm.dbg.declare(metadata {{(i32|i64)}}* %[[ALLOCA]], metadata ![[IMAGE:.*]], metadata !{{[0-9]+}})
+    // CHECK: call void @llvm.dbg.declare(metadata {{(i32|i64)}}* %[[ALLOCA:.*]], metadata ![[IMAGE:.*]], metadata !{{[0-9]+}})
+    // CHECK: store {{(i32|i64)}} %0, {{(i32|i64)}}* %[[ALLOCA]], align
     // CHECK: ![[IMAGE]] = !DILocalVariable(name: "image", arg: 1
     // CHECK-NOT:                           flags:
     // CHECK-SAME:                          line: [[@LINE-7]]

--- a/test/DebugInfo/let.swift
+++ b/test/DebugInfo/let.swift
@@ -6,12 +6,9 @@ class DeepThought {
 
 func foo() -> Int64 {
   // CHECK: call void @llvm.dbg.declare(metadata %T3let11DeepThoughtC** {{.*}}, metadata ![[A:.*]], metadata !{{[0-9]+}})
-  // CHECK: !DILocalVariable(name: "machine"
-  // CHECK-NOT:              flags:
-  // CHECK-SAME:             line: [[@LINE+1]],
+  // CHECK-DAG: !DILocalVariable(name: "machine",{{.*}}line: [[@LINE+1]], type: !{{[0-9]+}})
   let machine = DeepThought()
-  // CHECK: !DILocalVariable(name: "a"
-  // CHECK-SAME:             line: [[@LINE+1]],
+  // CHECK-DAG: !DILocalVariable(name: "a", {{.*}}line: [[@LINE+1]],
   let a = machine.query()
   return a
 }

--- a/test/DebugInfo/patternmatching.swift
+++ b/test/DebugInfo/patternmatching.swift
@@ -5,6 +5,7 @@
 
 func markUsed<T>(_ t: T) {}
 
+// CHECK-SCOPES: define {{.*}}classifyPoint2
 func classifyPoint2(_ p: (Double, Double)) {
     func return_same (_ input : Double) -> Double
     {
@@ -24,33 +25,34 @@ switch p {
       // SIL-CHECK:  dealloc_stack{{.*}}line:[[@LINE-1]]:17:cleanup
       // Verify that the branch has a location >= the cleanup.
       // SIL-CHECK-NEXT:  br{{.*}}line:[[@LINE-3]]:17:cleanup
-      // CHECK-SCOPES: call {{.*}}markUsed
+      // CHECK-SCOPES: call void @llvm.dbg
+      // CHECK-SCOPES: call void @llvm.dbg
+      // CHECK-SCOPES: call void @llvm.dbg
       // CHECK-SCOPES: call void @llvm.dbg{{.*}}metadata ![[X1:[0-9]+]],
       // CHECK-SCOPES-SAME:                         !dbg ![[X1LOC:[0-9]+]]
       // CHECK-SCOPES: call void @llvm.dbg
       // CHECK-SCOPES: call void @llvm.dbg{{.*}}metadata ![[X2:[0-9]+]],
-      // CHECK-SCOPES-SAME:                         !dbg ![[X2LOC:[0-9]+]]
+      // CHECK-SCOPES-SAME:                              !dbg ![[X2LOC:[0-9]+]]
       // CHECK-SCOPES: call void @llvm.dbg
       // CHECK-SCOPES: call void @llvm.dbg{{.*}}metadata ![[X3:[0-9]+]],
-      // CHECK-SCOPES-SAME:                         !dbg ![[X3LOC:[0-9]+]]
-      // CHECK-SCOPES: !DILocalVariable(name: "x",
+      // CHECK-SCOPES-SAME:                              !dbg ![[X3LOC:[0-9]+]]
     case (let x, let y) where x == -y:
       // Verify that all variables end up in separate appropriate scopes.
-      // CHECK-SCOPES: !DILocalVariable(name: "x", scope: ![[SCOPE1:[0-9]+]],
-      // CHECK-SCOPES-SAME:             line: [[@LINE-3]]
+      // CHECK-SCOPES: ![[X1]] = !DILocalVariable(name: "x", scope: ![[SCOPE1:[0-9]+]],
+      // CHECK-SCOPES-SAME:                       line: [[@LINE-3]]
       // CHECK-SCOPES: ![[X1LOC]] = !DILocation(line: [[@LINE-4]], column: 15,
       // CHECK-SCOPES-SAME:                     scope: ![[SCOPE1]])
       // FIXME: ![[SCOPE1]] = distinct !DILexicalBlock({{.*}}line: [[@LINE-6]]
       markUsed(x)
     case (let x, let y) where x >= -10 && x < 10 && y >= -10 && y < 10:
-      // CHECK-SCOPES: !DILocalVariable(name: "x", scope: ![[SCOPE2:[0-9]+]],
-      // CHECK-SCOPES-SAME:             line: [[@LINE-2]]
+      // CHECK-SCOPES: ![[X2]] = !DILocalVariable(name: "x", scope: ![[SCOPE2:[0-9]+]],
+      // CHECK-SCOPES-SAME:                       line: [[@LINE-2]]
       // CHECK-SCOPES: ![[X2LOC]] = !DILocation(line: [[@LINE-3]], column: 15,
       // CHECK-SCOPES-SAME:                     scope: ![[SCOPE2]])
       markUsed(x)
     case (let x, let y):
-      // CHECK-SCOPES: !DILocalVariable(name: "x", scope: ![[SCOPE3:[0-9]+]],
-      // CHECK-SCOPES-SAME:             line: [[@LINE-2]]
+      // CHECK-SCOPES: ![[X3]] = !DILocalVariable(name: "x", scope: ![[SCOPE3:[0-9]+]],
+      // CHECK-SCOPES-SAME:                       line: [[@LINE-2]]
       // CHECK-SCOPES: ![[X3LOC]] = !DILocation(line: [[@LINE-3]], column: 15,
       // CHECK-SCOPES-SAME:                     scope: ![[SCOPE3]])
       markUsed(x)

--- a/test/DebugInfo/returnlocation.swift
+++ b/test/DebugInfo/returnlocation.swift
@@ -12,6 +12,7 @@ import Foundation
 // CHECK_NONE: define{{( protected)?}} {{.*}}void {{.*}}none
 public func none(_ a: inout Int64) {
   // CHECK_NONE: call void @llvm.dbg{{.*}}, !dbg
+  // CHECK_NONE: store{{.*}}, !dbg
   // CHECK_NONE: !dbg ![[NONE_INIT:.*]]
   a -= 2
   // CHECK_NONE: ret {{.*}}, !dbg ![[NONE_RET:.*]]

--- a/test/DebugInfo/shadowcopy-linetable.swift
+++ b/test/DebugInfo/shadowcopy-linetable.swift
@@ -7,9 +7,9 @@ func foo(_ x: inout Int64) {
   // line 0), but the code to load the value from the inout storage is
   // not.
   // CHECK: %[[X:.*]] = alloca %Ts5Int64V*, align {{(4|8)}}
+  // CHECK-NEXT: call void @llvm.dbg.declare
   // CHECK: store %Ts5Int64V* %0, %Ts5Int64V** %[[X]], align {{(4|8)}}
   // CHECK-SAME: !dbg ![[LOC0:.*]]
-  // CHECK-NEXT: call void @llvm.dbg.declare
   // CHECK-NEXT: getelementptr inbounds %Ts5Int64V, %Ts5Int64V* %0, i32 0, i32 0,
   // CHECK-SAME: !dbg ![[LOC1:.*]]
   // CHECK: ![[LOC0]] = !DILocation(line: 0,

--- a/test/DebugInfo/while.swift
+++ b/test/DebugInfo/while.swift
@@ -4,10 +4,10 @@ func yieldValues() -> Int64? { return .none }
 
 // Verify that variables bound in the while statements are in distinct scopes.
 while let val = yieldValues() {
-// CHECK: ![[SCOPE1:[0-9]+]] = distinct !DILexicalBlock(scope: ![[MAIN:[0-9]+]]
-// CHECK: !DILocalVariable(name: "val", scope: ![[SCOPE1]]
+// CHECK: !DILocalVariable(name: "val", scope: ![[SCOPE1:[0-9]+]]
+// CHECK: ![[SCOPE1]] = distinct !DILexicalBlock(scope: ![[MAIN:[0-9]+]]
 }
 while let val = yieldValues() {
-// CHECK: ![[SCOPE2:[0-9]+]] = distinct !DILexicalBlock(scope: ![[MAIN]]
-// CHECK: !DILocalVariable(name: "val", scope: ![[SCOPE2]]
+// CHECK: !DILocalVariable(name: "val", scope: ![[SCOPE2:[0-9]+]]
+// CHECK: ![[SCOPE2]] = distinct !DILexicalBlock(scope: ![[MAIN]]
 }


### PR DESCRIPTION
This cleanup change doesn't change the semantics, but it makes the
resulting IR much easier to read and debug.


