### PR TITLE
Fix demangler problems (crash, hang) with malformed symbols

### DIFF
--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -1326,7 +1326,8 @@ NodePointer Demangler::demangleFunctionSpecialization() {
       case FunctionSigSpecializationParamKind::ClosureProp: {
         size_t FixedChildren = Param->getNumChildren();
         while (NodePointer Ty = popNode(Node::Kind::Type)) {
-          assert(ParamKind == FunctionSigSpecializationParamKind::ClosureProp);
+          if (ParamKind != FunctionSigSpecializationParamKind::ClosureProp)
+            return nullptr;
           Param = addChild(Param, Ty);
         }
         NodePointer Name = popNode(Node::Kind::Identifier);

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -442,6 +442,10 @@ NodePointer Demangler::demangleMultiSubstitutions() {
   int RepeatCount = -1;
   while (true) {
     char c = nextChar();
+    if (c == 0) {
+      // End of text.
+      return nullptr;
+    }
     if (isLowerLetter(c)) {
       // It's a substitution with an index < 26.
       NodePointer Nd = pushMultiSubstitutions(RepeatCount, c - 'a');

--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -254,4 +254,5 @@ _T04main1_yyF ---> main._() -> ()
 _T04test6testitSiyt_tF ---> test.testit(()) -> Swift.Int
 _T0Rml ---> _T0Rml
 _T0Tk ---> _T0Tk
+_T0A8 ---> _T0A8
 

--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -255,4 +255,5 @@ _T04test6testitSiyt_tF ---> test.testit(()) -> Swift.Int
 _T0Rml ---> _T0Rml
 _T0Tk ---> _T0Tk
 _T0A8 ---> _T0A8
+_T0s30ReversedRandomAccessCollectionVyxGTfq3nnpf_nTfq1cn_nTfq4x_n ---> _T0s30ReversedRandomAccessCollectionVyxGTfq3nnpf_nTfq1cn_nTfq4x_n
 


### PR DESCRIPTION
Explanation: This fixes two problems with the demangler which can show up when demangling malformed symbols: a crash and an assert-fail.

Scope: This problem can cause a crash in tools which use the demangler and try to demangle symbols which are not necessarily swift symbols.

Radar: rdar://problem/32359287

Risk: Low. The two new safety checks in this change only trigger if the demangler would have crashed/hanged in the previous version.

Testing: There is a test for swift-ci