### PR TITLE
[ConstraintSystem] Invalidate solution in presence of error types

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -6271,6 +6271,14 @@ bool FailureDiagnosis::visitAssignExpr(AssignExpr *assignExpr) {
                                               TCC_AllowLValue);
   if (!destExpr) return true;
 
+  if (auto *KPE = dyn_cast<KeyPathExpr>(assignExpr->getSrc())) {
+    // Presence of error type means that key path has already
+    // been diagnosed as invalid by constraint generator, most
+    // likely the key path has unsupported operations.
+    if (KPE->getType()->hasError())
+      return true;
+  }
+
   auto destType = destExpr->getType();
   if (destType->is<UnresolvedType>() || destType->hasTypeVariable()) {
     // Look closer into why destination has unresolved types since such

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1357,8 +1357,8 @@ private:
   /// \brief Finalize this constraint system; we're done attempting to solve
   /// it.
   ///
-  /// \returns the solution.
-  Solution finalize(FreeTypeVariableBinding allowFreeTypeVariables);
+  /// \returns the solution if no problems were discovered.
+  Optional<Solution> finalize(FreeTypeVariableBinding allowFreeTypeVariables);
 
   /// \brief Apply the given solution to the current constraint system.
   ///

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2489,7 +2489,7 @@ Type ConstraintSystem::computeAssignDestType(Expr *dest, SourceLoc equalLoc) {
   // lvalue.  Emit them if present.
   if (!Fixes.empty()) {
     auto solution = finalize(FreeTypeVariableBinding::Allow);
-    if (applySolutionFixes(dest, solution))
+    if (solution && applySolutionFixes(dest, *solution))
       return Type();
   }
 

--- a/validation-test/compiler_crashers_2_fixed/0100-sr4575-1.swift
+++ b/validation-test/compiler_crashers_2_fixed/0100-sr4575-1.swift
@@ -1,0 +1,14 @@
+// RUN: not %target-swift-frontend %s -typecheck
+
+struct V<T> : BidirectionalCollection {}
+struct S {
+  func bar<T>(_ to: T.Type) -> V<T> {
+    return V<T>()
+  }
+}
+
+extension S {
+  func foo<R>(_ body: (UnsafeBufferPointer<UTF16.CodeUnit>) -> R) -> R {
+    return Array(self.bar(UTF16.self)).withUnsafeBufferPointer(body)
+  }
+}

--- a/validation-test/compiler_crashers_2_fixed/0101-sr4575-2.swift
+++ b/validation-test/compiler_crashers_2_fixed/0101-sr4575-2.swift
@@ -1,0 +1,13 @@
+// RUN: not %target-swift-frontend %s -typecheck
+
+struct V<T> {}
+extension V : BidirectionalCollection {}
+struct S {
+  func bar<T>(_ to: T.Type) -> V<T> {
+    return V<T>()
+  }
+
+  func foo() {
+    let _ = Array(self.bar(UTF16.self)) // expected-error {{generic parameter 'Element' could not be inferred}}
+  }
+}

--- a/validation-test/compiler_crashers_fixed/28754-value-openexistentials-end-didnt-see-this-ove-in-a-containing-openexistentialexp.swift
+++ b/validation-test/compiler_crashers_fixed/28754-value-openexistentials-end-didnt-see-this-ove-in-a-containing-openexistentialexp.swift
@@ -6,7 +6,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 protocol A:RangeReplaceableCollection
 typealias e:a._=A.init(
 [.e


### PR DESCRIPTION
In `ConstraintSystem::finalize` if simplification of one of the
type variables present in the system results in introduction of
error type to the possible solution, let's not return that solution,
because that might cause problems down the road in verifier.

One of the reasons why `simplifyType` could produce an error type
is related to substitution of associated types using newly
discovered base type because its protocol conformance as not
properly verified until later on.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-4575](https://bugs.swift.org/browse/SR-4575).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
