### PR TITLE
Update BinaryInteger default initializer documentation [NFC]

### DIFF
--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -1363,25 +1363,22 @@ public protocol BinaryInteger :
   /// - Parameter source: A floating-point value to convert to an integer.
   init?<T : FloatingPoint>(exactly source: T)
 
-  /// Creates an integer from the given floating-point value, truncating any
-  /// fractional part.
-  ///
-  /// Truncating the fractional part of `source` is equivalent to rounding
-  /// toward zero.
+  /// Creates an integer from the given floating-point value rounded toward
+  /// zero.
   ///
   ///     let x = Int(21.5)
   ///     // x == 21
   ///     let y = Int(-21.5)
   ///     // y == -21
   ///
-  /// If `source` is outside the bounds of this type after truncation, a
-  /// runtime error may occur.
+  /// If `source` is outside the bounds of this type after rounding toward
+  /// zero, a runtime error may occur.
   ///
   ///     let z = UInt(-21.5)
   ///     // Error: ...the result would be less than UInt.min
   ///
   /// - Parameter source: A floating-point value to convert to an integer.
-  ///   `source` must be representable in this type after truncation.
+  ///   `source` must be representable in this type after rounding toward zero.
   init<T : FloatingPoint>(_ source: T)
 
   /// Creates a new instance from the given integer.

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -1363,7 +1363,7 @@ public protocol BinaryInteger :
   /// - Parameter source: A floating-point value to convert to an integer.
   init?<T : FloatingPoint>(exactly source: T)
 
-  /// Creates an integer from the given floating-point value rounded toward
+  /// Creates an integer from the given floating-point value, rounding toward
   /// zero.
   ///
   ///     let x = Int(21.5)


### PR DESCRIPTION
Some time ago, it was pointed out that "truncating" would be used only for bit pattern operations. As pointed out on Swift Evolution, this is the only spot where the same term is used for dropping the fractional part of a floating point value; elsewhere, it is always spelled--even in documentation--as "rounded toward zero." This PR updates the usage here to align with existing convention.
