### PR TITLE
[swift-4.0-branch][stdlib] Moving the Array.filter to _ArrayProtocol

### DIFF
--- a/stdlib/public/core/ArrayType.swift
+++ b/stdlib/public/core/ArrayType.swift
@@ -70,3 +70,15 @@ internal protocol _ArrayProtocol
   // For testing.
   var _buffer: _Buffer { get }
 }
+
+extension _ArrayProtocol {
+  // Since RangeReplaceableCollection now has a version of filter that is less
+  // efficient, we should make the default implementation coming from Sequence
+  // preferred.
+  @_inlineable
+  public func filter(
+    _ isIncluded: (Element) throws -> Bool
+  ) rethrows -> [Element] {
+    return try _filter(isIncluded)
+  }
+}

--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -1574,16 +1574,6 @@ extension ${Self} : RangeReplaceableCollection, _ArrayProtocol {
     }
   }
 
-  // Since RangeReplaceableCollection now has a version of filter that is less
-  // efficient, we should make the default implementation coming from Sequence
-  // preferred.
-  @_inlineable
-  public func filter(
-    _ isIncluded: (Element) throws -> Bool
-  ) rethrows -> [Element] {
-    return try _filter(isIncluded)
-  }
-
   //===--- algorithms -----------------------------------------------------===//
 
   @_inlineable

--- a/test/stdlib/RangeReplaceableFilterCompatibility.swift
+++ b/test/stdlib/RangeReplaceableFilterCompatibility.swift
@@ -35,5 +35,10 @@ tests.test("String.filter can return [Character]") {
   expectEqualSequence("HW", filtered)
 }
 
+tests.test("lazy.flatMap.filter ambiguity") {
+  // this expression should compile without ambiguity
+  _ = Array(0..<10).lazy.flatMap { .some($0) }.filter { _ in false }
+}
+
 runAllTests()
 


### PR DESCRIPTION
Resolves ambiguity in the following expression

  _ = Array(0..<10).lazy.flatMap { .some($0) }.filter { _ in false }

Fixes: <rdar://problem/32316948>

-----

* Explanation: Introducing Array.filter caused the source compatibility issue
* Scope of Issue: Overload resolution could not pick the right set of overloads in an expression like [42].lazy.flatMap { .some($0) }.filter { _ in false }. This fix de-prioritizes Array.filter by moving it to _ArrayProtocol
* Risk: Minimal
* Reviewed By: Ben Cohen
* Testing: Automated test suite + a dedicated test case
* Directions for QA: N/A
* Radar: <rdar://problem/32370364>