### PR TITLE
[Exclusivity] Weaken assert when suggesting swap() Fix-It

### DIFF
--- a/test/SILOptimizer/exclusivity_static_diagnostics.swift
+++ b/test/SILOptimizer/exclusivity_static_diagnostics.swift
@@ -133,6 +133,10 @@ struct StructWithFixits {
     // expected-error@+2{{simultaneous accesses}}{{5-75=localOfGenericType.swapAt(paramIndex, paramIndex)}}
     // expected-note@+1{{conflicting access is here}}
     swap(&localOfGenericType[paramIndex], &localOfGenericType[paramIndex])
+
+    // expected-error@+2{{simultaneous accesses}}{{5-39=array1.swapAt(i, j)}}
+    // expected-note@+1{{conflicting access is here}}
+    Swift.swap(&array1[i], &array1[j]) // no-crash
   }
 
   mutating


### PR DESCRIPTION
This fixes a too-strong assertion when suggesting a Fix-It to replace
module-qualified calls to swap():

Swift.swap(&a[i], &a[j])

Other than weakening the assert, there is no functional change here.

rdar://problem/32358872
