### PR TITLE
[WIP - DO NOT MERGE] Assert if we attempt to bind a type involving ErrorType.

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -109,7 +109,9 @@ bool ConstraintSystem::typeVarOccursInType(TypeVariableType *typeVar,
 
 void ConstraintSystem::assignFixedType(TypeVariableType *typeVar, Type type,
                                        bool updateState) {
-  
+  assert(!type->hasError() &&
+         "Should not be assigning a type involving ErrorType!");
+
   typeVar->getImpl().assignFixedType(type, getSavedBindings());
 
   if (!updateState)


### PR DESCRIPTION
We may hit this assert currently during diagnostics. In general it would be nice to work toward a world where we never attempted to bind a type involving ErrorType.