### PR TITLE
[swiftc (35 vs. 5528)] Add crasher in swift::Expr::walk(...)

### DIFF
--- a/validation-test/compiler_crashers/28754-value-openexistentials-end-didnt-see-this-ove-in-a-containing-openexistentialexp.swift
+++ b/validation-test/compiler_crashers/28754-value-openexistentials-end-didnt-see-this-ove-in-a-containing-openexistentialexp.swift
@@ -1,0 +1,12 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol A:RangeReplaceableCollection
+typealias e:a._=A.init(
+[.e


### PR DESCRIPTION
Add test case for crash triggered in `swift::Expr::walk(...)`.

Current number of unresolved compiler crashers: 35 (5528 resolved)

/cc @lattner - just wanted to let you know that this crasher caused an assertion failure for the assertion `value != OpenExistentials.end() && "didn't see this OVE in a containing OpenExistentialExpr?"` added on 2015-11-15 by you in commit 13792f91 :-)

Assertion failure in [`lib/Sema/CSDiag.cpp (line 3223)`](https://github.com/apple/swift/blob/1c4f299a3c2c0a369926aef7be34a87dd3c3564b/lib/Sema/CSDiag.cpp#L3223):

```
Assertion `value != OpenExistentials.end() && "didn't see this OVE in a containing OpenExistentialExpr?"' failed.

When executing: virtual std::pair<bool, Expr *> eraseOpenedExistentials(swift::Expr *&)::ExistentialEraser::walkToExprPre(swift::Expr *)
```

Assertion context:

```c++
      }

      if (auto OVE = dyn_cast<OpaqueValueExpr>(expr)) {
        auto value = OpenExistentials.find(OVE);
        assert(value != OpenExistentials.end() &&
               "didn't see this OVE in a containing OpenExistentialExpr?");
        return { true, value->second };
      }

      // Handle collection upcasts specially so that we don't blow up on
      // their embedded OVEs.
```
Stack trace:

```
0 0x0000000003a5fe98 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3a5fe98)
1 0x0000000003a605d6 SignalHandler(int) (/path/to/swift/bin/swift+0x3a605d6)
2 0x00007efea3b8d390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007efea20b3428 gsignal /build/glibc-9tT8Do/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007efea20b502a abort /build/glibc-9tT8Do/glibc-2.23/stdlib/abort.c:91:0
5 0x00007efea20abbd7 __assert_fail_base /build/glibc-9tT8Do/glibc-2.23/assert/assert.c:92:0
6 0x00007efea20abc82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x00000000014063d4 eraseOpenedExistentials(swift::Expr*&)::ExistentialEraser::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x14063d4)
8 0x0000000001510e95 (anonymous namespace)::Traversal::visitSelfApplyExpr(swift::SelfApplyExpr*) (/path/to/swift/bin/swift+0x1510e95)
9 0x0000000001510d2a (anonymous namespace)::Traversal::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0x1510d2a)
10 0x000000000150d55b swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x150d55b)
11 0x0000000001402581 (anonymous namespace)::FailureDiagnosis::typeCheckChildIndependently(swift::Expr*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<TCCFlags, unsigned int>, swift::ExprTypeCheckListener*, bool) (/path/to/swift/bin/swift+0x1402581)
12 0x00000000013ffc00 swift::ASTVisitor<(anonymous namespace)::FailureDiagnosis, bool, void, void, void, void, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x13ffc00)
13 0x00000000013f67ab swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) (/path/to/swift/bin/swift+0x13f67ab)
14 0x00000000013fc579 swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) (/path/to/swift/bin/swift+0x13fc579)
15 0x00000000013292e8 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0x13292e8)
16 0x000000000132cbd6 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x132cbd6)
17 0x00000000013b0a85 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13b0a85)
18 0x00000000013b0296 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0x13b0296)
19 0x00000000013cdbc0 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x13cdbc0)
20 0x0000000000f97086 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf97086)
21 0x00000000004aa750 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4aa750)
22 0x00000000004a8d7b swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a8d7b)
23 0x00000000004655c7 main (/path/to/swift/bin/swift+0x4655c7)
24 0x00007efea209e830 __libc_start_main /build/glibc-9tT8Do/glibc-2.23/csu/../csu/libc-start.c:325:0
25 0x0000000000462c69 _start (/path/to/swift/bin/swift+0x462c69)
```