### PR TITLE
[swiftc (37 vs. 5528)] Add crasher in swift::ASTVisitor

### DIFF
--- a/validation-test/compiler_crashers/28756-isobjc-cannot-get-root-type-of-objc-keypath.swift
+++ b/validation-test/compiler_crashers/28756-isobjc-cannot-get-root-type-of-objc-keypath.swift
@@ -1,0 +1,11 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: deterministic-behavior
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+guard#keyPath($


### PR DESCRIPTION
Add test case for crash triggered in `swift::ASTVisitor`.

Current number of unresolved compiler crashers: 37 (5528 resolved)

/cc @huonw - just wanted to let you know that this crasher caused an assertion failure for the assertion `!isObjC() && "cannot get root type of ObjC keypath"` added on 2017-05-01 by you in commit 07c5ab8fb2 :-)

Assertion failure in [`include/swift/AST/Expr.h (line 4891)`](https://github.com/apple/swift/blob/f91a58e0ea82269b173d83cf9b760ea8379ea58e/include/swift/AST/Expr.h#L4891):

```
Assertion `!isObjC() && "cannot get root type of ObjC keypath"' failed.

When executing: swift::TypeRepr *swift::KeyPathExpr::getRootType() const
```

Assertion context:

```c++
    assert(!isObjC() && "cannot set parsed path of ObjC keypath");
    ParsedPath = path;
  }

  TypeRepr *getRootType() const {
    assert(!isObjC() && "cannot get root type of ObjC keypath");
    return RootType;
  }
  void setRootType(TypeRepr *rootType) {
    assert(!isObjC() && "cannot set root type of ObjC keypath");
    RootType = rootType;
```
Stack trace:

```
0 0x0000000003a5fe98 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3a5fe98)
1 0x0000000003a605d6 SignalHandler(int) (/path/to/swift/bin/swift+0x3a605d6)
2 0x00007f5683dfa390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007f5682320428 gsignal /build/glibc-9tT8Do/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f568232202a abort /build/glibc-9tT8Do/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f5682318bd7 __assert_fail_base /build/glibc-9tT8Do/glibc-2.23/assert/assert.c:92:0
6 0x00007f5682318c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x0000000001401a6f swift::ASTVisitor<(anonymous namespace)::FailureDiagnosis, bool, void, void, void, void, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x1401a6f)
8 0x00000000013f67ab swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) (/path/to/swift/bin/swift+0x13f67ab)
9 0x00000000013fc579 swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) (/path/to/swift/bin/swift+0x13fc579)
10 0x00000000013292e8 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0x13292e8)
11 0x000000000132cbd6 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x132cbd6)
12 0x0000000001331464 swift::TypeChecker::typeCheckCondition(swift::Expr*&, swift::DeclContext*) (/path/to/swift/bin/swift+0x1331464)
13 0x0000000001331650 swift::TypeChecker::typeCheckStmtCondition(llvm::MutableArrayRef<swift::StmtConditionElement>&, swift::DeclContext*, swift::Diag<>) (/path/to/swift/bin/swift+0x1331650)
14 0x00000000013b11e6 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13b11e6)
15 0x00000000013b09b6 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13b09b6)
16 0x00000000013b0296 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0x13b0296)
17 0x00000000013cdbc0 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x13cdbc0)
18 0x0000000000f97086 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf97086)
19 0x00000000004aa750 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4aa750)
20 0x00000000004a8d7b swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a8d7b)
21 0x00000000004655c7 main (/path/to/swift/bin/swift+0x4655c7)
22 0x00007f568230b830 __libc_start_main /build/glibc-9tT8Do/glibc-2.23/csu/../csu/libc-start.c:325:0
23 0x0000000000462c69 _start (/path/to/swift/bin/swift+0x462c69)
```