### PR TITLE
[swiftc (39 vs. 5528)] Add crasher in swift::GenericSignatureBuilder::resolveSuperConformance

### DIFF
--- a/validation-test/compiler_crashers/28758-swift-genericsignaturebuilder-resolvesuperconformance-swift-genericsignaturebuil.swift
+++ b/validation-test/compiler_crashers/28758-swift-genericsignaturebuilder-resolvesuperconformance-swift-genericsignaturebuil.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol P{{}typealias e:a{}}class a:P=extension P{typealias e:Self


### PR DESCRIPTION
Add test case for crash triggered in `swift::GenericSignatureBuilder::resolveSuperConformance`.

Current number of unresolved compiler crashers: 39 (5528 resolved)

Stack trace:

```
0 0x0000000003a5fe98 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3a5fe98)
1 0x0000000003a605d6 SignalHandler(int) (/path/to/swift/bin/swift+0x3a605d6)
2 0x00007f94db060390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x000000000155ec2f swift::GenericSignatureBuilder::resolveSuperConformance(swift::GenericSignatureBuilder::PotentialArchetype*, swift::ProtocolDecl*) (/path/to/swift/bin/swift+0x155ec2f)
4 0x0000000001568e0e swift::GenericSignatureBuilder::updateSuperclass(swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type, swift::GenericSignatureBuilder::RequirementSource const*)::$_21::operator()() const (/path/to/swift/bin/swift+0x1568e0e)
5 0x0000000001568d25 swift::GenericSignatureBuilder::updateSuperclass(swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type, swift::GenericSignatureBuilder::RequirementSource const*) (/path/to/swift/bin/swift+0x1568d25)
6 0x000000000156a264 swift::GenericSignatureBuilder::addSameTypeRequirementBetweenArchetypes(swift::GenericSignatureBuilder::PotentialArchetype*, swift::GenericSignatureBuilder::PotentialArchetype*, swift::GenericSignatureBuilder::RequirementSource const*) (/path/to/swift/bin/swift+0x156a264)
7 0x000000000156a86c swift::GenericSignatureBuilder::addSameTypeRequirement(llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::FloatingRequirementSource, swift::GenericSignatureBuilder::UnresolvedHandlingKind, llvm::function_ref<void (swift::Type, swift::Type)>) (/path/to/swift/bin/swift+0x156a86c)
8 0x00000000015615d4 swift::GenericSignatureBuilder::PotentialArchetype::updateNestedTypeForConformance(llvm::PointerUnion<swift::AssociatedTypeDecl*, swift::TypeAliasDecl*>, swift::GenericSignatureBuilder::PotentialArchetype::NestedTypeUpdate) (/path/to/swift/bin/swift+0x15615d4)
9 0x00000000015601e0 swift::GenericSignatureBuilder::PotentialArchetype::getNestedArchetypeAnchor(swift::Identifier, swift::GenericSignatureBuilder&, swift::GenericSignatureBuilder::PotentialArchetype::NestedTypeUpdate) (/path/to/swift/bin/swift+0x15601e0)
10 0x000000000156eb7c swift::GenericSignatureBuilder::checkSameTypeConstraints(llvm::ArrayRef<swift::GenericTypeParamType*>, swift::GenericSignatureBuilder::PotentialArchetype*) (/path/to/swift/bin/swift+0x156eb7c)
11 0x000000000156bd60 swift::GenericSignatureBuilder::finalize(swift::SourceLoc, llvm::ArrayRef<swift::GenericTypeParamType*>, bool) (/path/to/swift/bin/swift+0x156bd60)
12 0x00000000013747b9 swift::TypeChecker::checkGenericEnvironment(swift::GenericParamList*, swift::DeclContext*, swift::GenericSignature*, bool, llvm::function_ref<void (swift::GenericSignatureBuilder&)>) (/path/to/swift/bin/swift+0x13747b9)
13 0x0000000001374ba9 swift::TypeChecker::validateGenericTypeSignature(swift::GenericTypeDecl*) (/path/to/swift/bin/swift+0x1374ba9)
14 0x00000000013455a2 swift::TypeChecker::validateDecl(swift::ValueDecl*) (/path/to/swift/bin/swift+0x13455a2)
15 0x0000000001355193 (anonymous namespace)::DeclChecker::visitProtocolDecl(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0x1355193)
16 0x0000000001343814 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x1343814)
17 0x0000000001343723 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x1343723)
18 0x00000000013cdb45 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x13cdb45)
19 0x0000000000f97086 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf97086)
20 0x00000000004aa750 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4aa750)
21 0x00000000004a8d7b swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a8d7b)
22 0x00000000004655c7 main (/path/to/swift/bin/swift+0x4655c7)
23 0x00007f94d9571830 __libc_start_main /build/glibc-9tT8Do/glibc-2.23/csu/../csu/libc-start.c:325:0
24 0x0000000000462c69 _start (/path/to/swift/bin/swift+0x462c69)
```