### PR TITLE
[stdlib] Heterogeneous comparisons for concrete integer types

### DIFF
--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -2646,6 +2646,31 @@ public struct ${Self}
     return Bool(Builtin.cmp_${u}lt_Int${bits}(lhs._value, rhs._value))
   }
 
+  // FIXME(integers): these overloads are here in order for the compiler to
+  // prefer them to the generic ones on BinaryInteger, in cases like the
+  // following, where choosing Int as a literal type leads to overflow:
+  //   UInt64() > 0x8000_0000_0000_0000
+  //   UInt64() != 0xFFFF_FFFF_FFFF_FFFF
+  @_transparent
+  public static func != (lhs: ${Self}, rhs: ${Self}) -> Bool {
+    return !(lhs == rhs)
+  }
+
+  @_transparent
+  public static func <= (lhs: ${Self}, rhs: ${Self}) -> Bool {
+    return !(rhs < lhs)
+  }
+
+  @_transparent
+  public static func >= (lhs: ${Self}, rhs: ${Self}) -> Bool {
+    return !(lhs < rhs)
+  }
+
+  @_transparent
+  public static func > (lhs: ${Self}, rhs: ${Self}) -> Bool {
+    return rhs < lhs
+  }
+
 // FIXME(integers): pending optimizer work on handling the case where the
 // boolean value is wrapped into a two-case enum and then immediately
 // unwrapped. <rdar://problem/29004429>

--- a/test/stdlib/Integers.swift.gyb
+++ b/test/stdlib/Integers.swift.gyb
@@ -614,5 +614,14 @@ tests.test("signum/concrete") {
 % end
 }
 
+tests.test("no literal overflows") {
+  // these expressions should use the homogeneous versions of comparison
+  // operators and not result in compile-time overflow errors.
+  let u64: UInt64 = 42
+% for op in ['==', '!=', '<', '<=', '>', '>=']:
+  _ = u64 ${op} 0xFFFF_FFFF_FFFF_FFFF
+% end
+}
+
 
 runAllTests()


### PR DESCRIPTION
With the introduction of heterogeneous overloads for equality and
comparison operators, it became possible to compare UInt to Int8 and
vice versa, but it also led to the problems like the one reported in:

https://bugs.swift.org/browse/SR-4984

```
(swift) UInt() != 0xFFFF_FFFF_FFFF_FFFF
<REPL Input>:1:11: error: integer literal '18446744073709551615' overflows when stored into 'Int'
UInt() != 0xFFFF_FFFF_FFFF_FFFF
          ^
```

In this case even in the presence of a homogeneous overload for `!=`,
the typechecker first tries `Int` as a type for a literal and
successfully finds a solution for the whole expression via a
heterogeneous overload.

At the same time `UInt() == 0XFFFF_FFFF_FFFF_FFFF` works, i.e. selects
the correct overload. Which means that homogeneous versions of derived
equality and comparison operators should be moved to concrete types, in
order to be preferred by the solver. And this is exactly what this
change is doing.