### PR TITLE
Swift 3 api preserving changes

### DIFF
--- a/stdlib/public/core/StringCharacterView.swift
+++ b/stdlib/public/core/StringCharacterView.swift
@@ -693,27 +693,18 @@ extension String.CharacterView : RangeReplaceableCollection {
   /// 
   /// - Parameter newElements: A sequence of characters.
   public mutating func append<S : Sequence>(contentsOf newElements: S)
-    where S.Element == Character {
-    reserveCapacity(_core.count + newElements.underestimatedCount)
-    for c in newElements {
-      self.append(c)
-    }
-  }
-
-  /// Creates a new character view containing the characters in the given
-  /// sequence.
-  ///
-  /// - Parameter characters: A sequence of characters.
-  public init<S : Sequence>(_ characters: S)
   where S.Element == Character {
-    let v0 = characters as? _SwiftStringView
-    if _fastPath(v0 != nil), let v = v0 {
-      self = v._persistentContent.characters
+    if _fastPath(newElements is _SwiftStringView) {
+      let v = newElements as! _SwiftStringView
+      if _fastPath(_core.count == 0) {
+        _core = v._persistentContent._core
+        return
+      }
+      _core.append(v._ephemeralContent._core)
+      return
     }
-    else {
-      self = String.CharacterView()
-      self.append(contentsOf: characters)
-    }
+    reserveCapacity(_core.count + newElements.underestimatedCount)
+    for c in newElements { self.append(c) }
   }
 }
 

--- a/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
+++ b/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
@@ -36,15 +36,15 @@ extension String : StringProtocol {
     self.init(repeating: String(repeatedValue), count: count)
   }
 
-  // FIXME(strings): doc comment
   // This initializer disambiguates between the following intitializers, now
   // that String conforms to Collection:
   // - init<T>(_ value: T) where T : LosslessStringConvertible
   // - init<S>(_ characters: S) where S : Sequence, S.Element == Character
-  public init<T : StringProtocol>(_ other: T) {
-    self.init(other.characters)
+  public init<S : Sequence & LosslessStringConvertible>(_ other: S)
+  where S.Element == Character {
+    self._core = CharacterView(other)._core
   }
-
+  
   // This initializer satisfies the LosslessStringConvertible conformance
   public init?(_ other: String) {
     self.init(other._core)

--- a/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
+++ b/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
@@ -46,6 +46,7 @@ extension String : StringProtocol {
   }
   
   // This initializer satisfies the LosslessStringConvertible conformance
+  @available(swift, obsoleted: 4, message: "String.init(_:String) is no longer failable")
   public init?(_ other: String) {
     self.init(other._core)
   }

--- a/stdlib/public/core/Substring.swift.gyb
+++ b/stdlib/public/core/Substring.swift.gyb
@@ -88,6 +88,10 @@ public struct Substring : StringProtocol {
     _slice = RangeReplaceableBidirectionalSlice()
   }
 
+  internal init(_slice: RangeReplaceableBidirectionalSlice<String>) {
+    self._slice = _slice
+  }
+  
   /// Creates a substring with the specified bounds within the given string.
   ///
   /// - Parameters:
@@ -455,53 +459,21 @@ extension Substring : ExpressibleByStringLiteral {
   }
 }
 
-// The purpose of this protocol is backward compatibility with Swift 3 code,
-// where String subscripts returned String.
-// Since the Substring returning subscripts are introduced by the protocol
-// extension, they will be less specific than the String-returning ones
-// declared on the String type itself, thus avoiding ambiguity.
-public protocol _RangeSubscriptableString {
-  associatedtype Index : Comparable
-  func _subscript(_ bounds: Range<Index>) -> Substring
-  func _subscript(_ bounds: ClosedRange<Index>) -> Substring
-}
-
-// Without the `where` subscripts will be ambiguous
-extension _RangeSubscriptableString where Self : RangeReplaceableCollection {
-% for Range in ['Range', 'ClosedRange']:
-  public subscript(bounds: ${Range}<Index>) -> Substring {
-    return _subscript(bounds)
-  }
-% end
-}
-
-extension String : _RangeSubscriptableString {
-% for Range in ['Range', 'ClosedRange']:
-  /// Accesses the text in the given range.
-  ///
-  /// - Complexity: O(*n*) if the underlying string is bridged from
-  ///   Objective-C, where *n* is the length of the string; otherwise, O(1).
-  public func _subscript(_ bounds: ${Range}<Index>) -> Substring {
-    return Substring(_base: String(self._core), bounds)
-  }
-% end
-}
-
-extension Substring : _RangeSubscriptableString {
-% for Range in ['Range', 'ClosedRange']:
-  public func _subscript(_ bounds: ${Range}<Index>) -> Substring {
-    let subSlice = _slice[bounds]
-    let bounds = (lower: subSlice.startIndex, upper: subSlice.endIndex)
-%   if Range == 'ClosedRange':
-    // Creating Substring using the half-open range, since subSlice already
-    // handled the ClosedRange case.
-%   end
-    return Substring(_base: _slice._base, Range(uncheckedBounds: bounds))
-  }
-% end
-}
-
+//===--- String/Substring Slicing Support ---------------------------------===//
+/// In Swift 3.2, in the absence of type context,
+///
+///     someString[someString.startIndex..<someString.endIndex]
+///
+/// was deduced to be of type `String`.  Therefore have a more-specific
+/// Swift-3-only `subscript` overload on `String` (and `Substring`) that
+/// continues to produce `String`.
 extension String {
+  @available(swift, introduced: 4)
+  public subscript(r: Range<Index>) -> Substring {
+    return Substring(
+      _slice: RangeReplaceableBidirectionalSlice(base: self, bounds: r))
+  }
+
   @available(swift, obsoleted: 4)
   public subscript(bounds: Range<Index>) -> String {
     return String(characters[bounds])
@@ -514,6 +486,11 @@ extension String {
 }
 
 extension Substring {
+  @available(swift, introduced: 4)
+  public subscript(r: Range<Index>) -> Substring {
+    return Substring(_slice: _slice[r])
+  }
+
   @available(swift, obsoleted: 4)
   public subscript(bounds: Range<Index>) -> String {
     return String(characters[bounds])
@@ -524,3 +501,4 @@ extension Substring {
     return String(characters[bounds])
   }
 }
+//===----------------------------------------------------------------------===//

--- a/test/stdlib/StringCompatibility.swift
+++ b/test/stdlib/StringCompatibility.swift
@@ -4,58 +4,275 @@
 
 import StdlibUnittest
 
+//===--- MyString ---------------------------------------------------------===//
+/// A simple StringProtocol with a wacky .description that proves
+/// LosslessStringConvertible is not infecting ordinary constructions by using
+/// .description as the content of a copied string.
+struct MyString {
+  var base: String
+}
+
+extension MyString : BidirectionalCollection {
+  typealias Iterator = String.Iterator
+  typealias Index = String.Index
+  typealias IndexDistance = String.IndexDistance
+  func makeIterator() -> Iterator { return base.makeIterator() }
+  var startIndex: String.Index { return base.startIndex }
+  var endIndex: String.Index { return base.startIndex }
+  subscript(i: Index) -> Character { return base[i] }
+  func index(after i: Index) -> Index { return base.index(after: i) }
+  func index(before i: Index) -> Index { return base.index(before: i) }
+  func index(_ i: Index, offsetBy n: IndexDistance) -> Index {
+    return base.index(i, offsetBy: n)
+  }
+  func distance(from i: Index, to j: Index) -> IndexDistance {
+    return base.distance(from: i, to: j)
+  }
+}
+
+extension MyString : RangeReplaceableCollection {
+  init() { base = "" }
+  mutating func append<S: Sequence>(contentsOf s: S)
+  where S.Element == Character {
+    base.append(contentsOf: s)
+  }
+  mutating func replaceSubrange<C: Collection>(_ r: Range<Index>, with c: C)
+  where C.Element == Character {
+    base.replaceSubrange(r, with: c)
+  }
+}
+
+extension MyString : CustomStringConvertible {
+  var description: String { return "***MyString***" }
+}
+
+extension MyString : TextOutputStream {
+  public mutating func write(_ other: String) {
+    append(contentsOf: other)
+  }
+}
+
+extension MyString : TextOutputStreamable {
+  public func write<Target : TextOutputStream>(to target: inout Target) {
+    target.write(base)
+  }
+}
+
+extension MyString : ExpressibleByUnicodeScalarLiteral {
+  public init(unicodeScalarLiteral value: String) {
+    base = .init(unicodeScalarLiteral: value)
+  }
+}
+extension MyString : ExpressibleByExtendedGraphemeClusterLiteral {
+  public init(extendedGraphemeClusterLiteral value: String) {
+    base = .init(extendedGraphemeClusterLiteral: value)
+  }
+}
+
+extension MyString : ExpressibleByStringLiteral {
+  public init(stringLiteral value: String) {
+    base = .init(stringLiteral: value)
+  }
+}
+
+extension MyString : CustomReflectable {
+  public var customMirror: Mirror {
+    return base.customMirror
+  }
+}
+
+extension MyString : CustomPlaygroundQuickLookable {
+  public var customPlaygroundQuickLook: PlaygroundQuickLook {
+    return base.customPlaygroundQuickLook
+  }
+}
+
+extension MyString : CustomDebugStringConvertible {
+  public var debugDescription: String {
+    return "(***MyString***)"
+  }
+}
+
+extension MyString : Equatable {
+  public static func ==(lhs: MyString, rhs: MyString) -> Bool {
+    return lhs.base == rhs.base
+  }
+}
+
+extension MyString : Comparable {
+  public static func <(lhs: MyString, rhs: MyString) -> Bool {
+    return lhs.base < rhs.base
+  }
+}
+
+extension MyString : Hashable {
+  public var hashValue : Int {
+    return base.hashValue
+  }
+}
+
+#if _runtime(_ObjC)
+
+extension MyString {
+  public func hasPrefix(_ prefix: String) -> Bool {
+    return self.base.hasPrefix(prefix)
+  }
+
+  public func hasSuffix(_ suffix: String) -> Bool {
+    return self.base.hasSuffix(suffix)
+  }
+}
+
+#endif
+
+extension MyString : StringProtocol {
+  typealias UTF8Index = String.UTF8Index
+  typealias UTF16Index = String.UTF16Index
+  typealias UnicodeScalarIndex = String.UnicodeScalarIndex
+  var utf8: String.UTF8View { return base.utf8 }
+  var utf16: String.UTF16View { return base.utf16 }
+  var unicodeScalars: String.UnicodeScalarView { return base.unicodeScalars }
+  var characters: String.CharacterView { return base.characters }
+  func lowercased() -> String {
+    return base.lowercased()
+  }
+  func uppercased() -> String {
+    return base.uppercased()
+  }
+
+  init<C: Collection, Encoding: Unicode.Encoding>(
+    decoding codeUnits: C, as sourceEncoding: Encoding.Type
+  )
+  where C.Iterator.Element == Encoding.CodeUnit {
+    base = .init(decoding: codeUnits, as: sourceEncoding)
+  }
+
+  init(cString nullTerminatedUTF8: UnsafePointer<CChar>) {
+    base = .init(cString: nullTerminatedUTF8)
+  }
+  
+  init<Encoding: Unicode.Encoding>(
+    decodingCString nullTerminatedCodeUnits: UnsafePointer<Encoding.CodeUnit>,
+    as sourceEncoding: Encoding.Type) {
+    base = .init(decodingCString: nullTerminatedCodeUnits, as: sourceEncoding)
+  }
+  
+  func withCString<Result>(
+    _ body: (UnsafePointer<CChar>) throws -> Result) rethrows -> Result {
+    return try base.withCString(body)
+  }
+
+  func withCString<Result, Encoding: Unicode.Encoding>(
+    encodedAs targetEncoding: Encoding.Type,
+    _ body: (UnsafePointer<Encoding.CodeUnit>) throws -> Result
+  ) rethrows -> Result {
+    return try base.withCString(encodedAs: targetEncoding, body)
+  }
+}
+//===----------------------------------------------------------------------===//
+
 #if swift(>=4)
 
-public typealias ExpectedSubstring = Substring
+public typealias ExpectedConcreteSlice = Substring
+public typealias ExpectedStringFromString = String
+let swift = 4
 
 #else
 
-public typealias ExpectedSubstring = String
+public typealias ExpectedConcreteSlice = String
+public typealias ExpectedStringFromString = String?
+let swift = 3
 
 #endif
 
 var Tests = TestSuite("SubstringCompatibility")
 
-Tests.test("Range/Subscript/ExpectedType") {
+Tests.test("String/Range/Slice/ExpectedType/\(swift)") {
   var s = "hello world"
   var sub = s[s.startIndex ..< s.endIndex]
   var subsub = sub[s.startIndex ..< s.endIndex]
 
   expectType(String.self, &s)
-  expectType(ExpectedSubstring.self, &sub)
-  expectType(ExpectedSubstring.self, &subsub)
+  expectType(ExpectedConcreteSlice.self, &sub)
+  expectType(ExpectedConcreteSlice.self, &subsub)
 }
 
-Tests.test("ClosedRange/Subsript/ExpectedType") {
+Tests.test("String/ClosedRange/Slice/ExpectedType/\(swift)") {
   var s = "hello world"
   let lastIndex = s.index(before:s.endIndex)
   var sub = s[s.startIndex ... lastIndex]
   var subsub = sub[s.startIndex ... lastIndex]
 
   expectType(String.self, &s)
-  expectType(ExpectedSubstring.self, &sub)
-  expectType(ExpectedSubstring.self, &subsub)
+  expectType(ExpectedConcreteSlice.self, &sub)
+  expectType(ExpectedConcreteSlice.self, &subsub)
 }
 
-Tests.test("String.init(_:String)/default type") {
-  var s = String("")
-  expectType(String?.self, &s)
+Tests.test("Substring/Range/Slice/ExpectedType/\(swift)") {
+  let s = "hello world" as Substring
+  var sub = s[s.startIndex ..< s.endIndex]
+  var subsub = sub[s.startIndex ..< s.endIndex]
+
+  expectType(ExpectedConcreteSlice.self, &sub)
+  expectType(ExpectedConcreteSlice.self, &subsub)
 }
 
-Tests.test("LosslessStringConvertible/generic") {
+Tests.test("Substring/ClosedRange/Slice/ExpectedType/\(swift)") {
+  let s = "hello world" as Substring
+  let lastIndex = s.index(before:s.endIndex)
+  var sub = s[s.startIndex ... lastIndex]
+  var subsub = sub[s.startIndex ... lastIndex]
+
+  expectType(ExpectedConcreteSlice.self, &sub)
+  expectType(ExpectedConcreteSlice.self, &subsub)
+}
+
+Tests.test("RangeReplaceable.init/generic/\(swift)") {
+  func check<
+    T: RangeReplaceableCollection, S: Collection
+  >(_: T.Type, from source: S)
+  where T.Element : Equatable, T.Element == S.Element
+  {
+    var r = T(source)
+    expectType(T.self, &r)
+    expectEqualSequence(Array(source), Array(r))
+  }
+
+  check(String.self, from: "a" as String)
+  check(Substring.self, from: "b" as String)
+  // FIXME: Why isn't this working?
+  // check(MyString.self, from: "c" as String)
+  
+  check(String.self, from: "d" as Substring)
+  check(Substring.self, from: "e" as Substring)
+  // FIXME: Why isn't this working?
+  // check(MyString.self, from: "f" as Substring)
+
+  // FIXME: Why isn't this working?
+  // check(String.self, from: "g" as MyString)
+  // check(Substring.self, from: "h" as MyString)
+  check(MyString.self, from: "i" as MyString)
+}
+
+Tests.test("String.init(someString)/default type/\(swift)") {
+  var s = String("" as String)
+  expectType(ExpectedStringFromString.self, &s)
+}
+
+Tests.test("Substring.init(someString)/default type/\(swift)") {
+  var s = Substring("" as Substring)
+  expectType(Substring.self, &s)
+}
+
+Tests.test("LosslessStringConvertible/generic/\(swift)") {
   func f<T : LosslessStringConvertible>(_ x: T.Type) {
     _ = T("")! // unwrapping optional should work in generic context
   }
   f(String.self)
 }
 
-Tests.test("LosslessStringConvertible/concrete") {
-  _ = String("") as String?
-}
-
-#if swift(>=4)
-#else
-Tests.test("LosslessStringConvertible/force unwrap") {
+#if !swift(>=4)
+Tests.test("LosslessStringConvertible/force unwrap/\(swift)") {
   // Force unwrap should still work in Swift 3 mode
   _ = String("")!
 }


### PR DESCRIPTION
- Optimizations for String/Substring interaction
- Makes String(otherString) non-failable for Swift 4