### PR TITLE
[Migrator] Don't take var -> let fix-it

### DIFF
--- a/include/swift/Migrator/FixitFilter.h
+++ b/include/swift/Migrator/FixitFilter.h
@@ -102,7 +102,6 @@ struct FixitFilter {
     // Fixits from warnings/notes that should be applied.
     if (Info.ID == diag::forced_downcast_coercion.ID ||
         Info.ID == diag::forced_downcast_noop.ID ||
-        Info.ID == diag::variable_never_mutated.ID ||
         Info.ID == diag::function_type_no_parens.ID ||
         Info.ID == diag::convert_let_to_var.ID ||
         Info.ID == diag::parameter_extraneous_double_up.ID ||

--- a/test/Migrator/no_var_to_let.swift
+++ b/test/Migrator/no_var_to_let.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-frontend -typecheck %s -swift-version 3
+// RUN: rm -rf %t && mkdir -p %t && %target-swift-frontend -c -update-code -primary-file %s -emit-migrated-file-path %t/no_var_to_let.swift.result -swift-version 3 -o /dev/null
+// RUN: diff -u %s %t/no_var_to_let.swift.result
+// RUN: %target-swift-frontend -typecheck %s -swift-version 4
+
+// Note that the diff run line indicates that there should be no change.
+
+// The compiler should not suggest `let` instead of `var` here because
+// it is a compile error to say `for let ...`.
+// rdar://problem/32390726
+
+for var i in 0..<10 {
+  _ = i + 1
+}


### PR DESCRIPTION
This isn't generally useful for Swift 4 migration and in some cases
can result in code that doesn't compile, like `for let i in ...`.

rdar://problem/32390791
rdar://problem/32390726