### PR TITLE
Sema: Fix bug where lazy properties could become stored sometimes

### DIFF
--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -807,6 +807,9 @@ static bool doesStorageNeedSetter(AbstractStorageDecl *storage) {
 static void addTrivialAccessorsToStorage(AbstractStorageDecl *storage,
                                          TypeChecker &TC) {
   assert(!storage->hasAccessorFunctions() && "already has accessors?");
+  assert(!storage->getAttrs().hasAttribute<LazyAttr>());
+  assert(!storage->getAttrs().hasAttribute<NSManagedAttr>());
+
   auto *DC = storage->getDeclContext();
 
   // Create the getter.
@@ -922,10 +925,7 @@ void TypeChecker::synthesizeWitnessAccessorsForStorage(
   // If the decl is stored, convert it to StoredWithTrivialAccessors
   // by synthesizing the full set of accessors.
   if (!storage->hasAccessorFunctions()) {
-    if (storage->getAttrs().hasAttribute<NSManagedAttr>())
-      convertNSManagedStoredVarToComputed(cast<VarDecl>(storage), *this);
-    else
-      addTrivialAccessorsToStorage(storage, *this);
+    addTrivialAccessorsToStorage(storage, *this);
 
     if (auto getter = storage->getGetter())
       validateDecl(getter);

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -7320,6 +7320,9 @@ void TypeChecker::validateDecl(ValueDecl *D) {
       checkDeclAttributesEarly(VD);
       validateAttributes(*this, VD);
 
+      // Synthesize accessors as necessary.
+      maybeAddAccessorsToVariable(VD, *this);
+
       // FIXME: Guarding the rest of these things together with early attribute
       // validation is a hack. It's necessary because properties can get types
       // before validateDecl is called.
@@ -7395,9 +7398,6 @@ void TypeChecker::validateDecl(ValueDecl *D) {
           }
         }
       }
-
-      // Synthesize accessors as necessary.
-      maybeAddAccessorsToVariable(VD, *this);
 
       // Make sure the getter and setter have valid types, since they will be
       // used by SILGen for any accesses to this variable.

--- a/test/SILGen/objc_properties.swift
+++ b/test/SILGen/objc_properties.swift
@@ -225,3 +225,24 @@ class NonObjCBaseClass : NSObject {
 
 // CHECK-LABEL: sil hidden [thunk] @_T015objc_properties12ObjCSubclassC8propertySifgTo
 // CHECK-LABEL: sil hidden [thunk] @_T015objc_properties12ObjCSubclassC8propertySifsTo
+
+// Make sure lazy properties that witness @objc protocol requirements are
+// correctly formed
+//
+// <https://bugs.swift.org/browse/SR-1825>
+
+@objc protocol HasProperty {
+    @objc var window: NSObject? { get set }
+}
+
+class HasLazyProperty : NSObject, HasProperty {
+  func instanceMethod() -> NSObject? {
+    return nil
+  }
+
+  lazy var window = instanceMethod()
+}
+
+// CHECK-LABEL: sil hidden @_T015objc_properties15HasLazyPropertyC6windowSo8NSObjectCSgfg : $@convention(method) (@guaranteed HasLazyProperty) -> @owned Optional<NSObject> {
+// CHECK: class_method %0 : $HasLazyProperty, #HasLazyProperty.instanceMethod!1 : (HasLazyProperty) -> () -> NSObject?
+// CHECK: return


### PR DESCRIPTION
If synthesizeWitnessAccessorsForStorage() got called on a lazy
property before maybeAddAccessorsToVariable(), we would build
it as a stored property instead.

This count result in bogus diagnostics, assertions and bad runtime
behavior.

Fixes <https://bugs.swift.org/browse/SR-1825> and <rdar://problem/30154467>.