### PR TITLE
Implement @_downgrade_exhaustivity_check

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -286,6 +286,11 @@ SIMPLE_DECL_ATTR(NSKeyedArchiverEncodeNonGenericSubclassesOnly,
                  OnClass | NotSerialized | LongAttribute,
                  /*Not serialized */ 70)
 
+// HACK: Attribute needed to preserve source compatibility by downgrading errors
+// due to an SDK change in Dispatch
+SIMPLE_DECL_ATTR(_downgrade_exhaustivity_check, DowngradeExhaustivityCheck,
+                 OnEnumElement | LongAttribute | UserInaccessible, 71)
+
 #undef TYPE_ATTR
 #undef DECL_ATTR_ALIAS
 #undef SIMPLE_DECL_ATTR

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3724,6 +3724,10 @@ NOTE(missing_particular_case,none,
 WARNING(redundant_particular_case,none,
         "case is already handled by previous patterns; consider removing it",())
 
+// HACK: Downgrades the above to warnings if any of the cases is marked
+// @_downgrade_exhaustivity_check.
+WARNING(non_exhaustive_switch_warn_swift3,none, "switch must be exhaustive", ())
+
 #ifndef DIAG_NO_UNDEF
 # if defined(DIAG)
 #  undef DIAG

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -840,6 +840,8 @@ namespace {
 
     void visitEnumElementDecl(EnumElementDecl *EED) {
       printCommon(EED, "enum_element_decl");
+      if (EED->getAttrs().hasAttribute<DowngradeExhaustivityCheckAttr>())
+        OS << "@_downgrade_exhaustivity_check";
       PrintWithColorRAII(OS, ParenthesisColor) << ')';
     }
 

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -506,6 +506,10 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
     Printer.printAttrName("@_staticInitializeObjCMetadata");
     break;
 
+  case DAK_DowngradeExhaustivityCheck:
+    Printer.printAttrName("@_downgrade_exhaustivity_check");
+    break;
+    
   case DAK_Count:
     llvm_unreachable("exceed declaration attribute kinds");
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -107,6 +107,7 @@ public:
   IGNORED_ATTR(NSKeyedArchiverClassName)
   IGNORED_ATTR(StaticInitializeObjCMetadata)
   IGNORED_ATTR(NSKeyedArchiverEncodeNonGenericSubclassesOnly)
+  IGNORED_ATTR(DowngradeExhaustivityCheck)
 #undef IGNORED_ATTR
 
   // @noreturn has been replaced with a 'Never' return type.
@@ -784,6 +785,7 @@ public:
     IGNORED_ATTR(ObjCMembers)
     IGNORED_ATTR(StaticInitializeObjCMetadata)
     IGNORED_ATTR(NSKeyedArchiverEncodeNonGenericSubclassesOnly)
+    IGNORED_ATTR(DowngradeExhaustivityCheck)
 #undef IGNORED_ATTR
 
   void visitAvailableAttr(AvailableAttr *attr);

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -6142,6 +6142,7 @@ public:
     UNINTERESTING_ATTR(NSKeyedArchiverClassName)
     UNINTERESTING_ATTR(StaticInitializeObjCMetadata)
     UNINTERESTING_ATTR(NSKeyedArchiverEncodeNonGenericSubclassesOnly)
+    UNINTERESTING_ATTR(DowngradeExhaustivityCheck)
 #undef UNINTERESTING_ATTR
 
     void visitAvailableAttr(AvailableAttr *attr) {

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -6014,7 +6014,7 @@ static bool hasGenericAncestry(ClassDecl *classDecl) {
 /// Infer the attribute tostatic-initialize the Objective-C metadata for the
 /// given class, if needed.
 static void inferStaticInitializeObjCMetadata(ClassDecl *classDecl,
-                                               bool requiresNSCodingAttr) {
+                                              bool requiresNSCodingAttr) {
   // If we already have the attribute, there's nothing to do.
   if (classDecl->getAttrs().hasAttribute<StaticInitializeObjCMetadataAttr>())
     return;

--- a/test/SILGen/downgrade_exhaustivity_swift3.swift
+++ b/test/SILGen/downgrade_exhaustivity_swift3.swift
@@ -1,0 +1,48 @@
+// RUN: %target-swift-frontend -swift-version 3 -emit-silgen %s | %FileCheck %s
+
+enum Downgradable {
+  case spoon
+  case hat
+  @_downgrade_exhaustivity_check
+  case fork
+}
+
+// CHECK-LABEL: sil hidden @_T029downgrade_exhaustivity_swift343testDowngradableOmittedPatternIsUnreachableyAA0E0OSg3pat_tF
+func testDowngradableOmittedPatternIsUnreachable(pat : Downgradable?) {
+  // CHECK: switch_enum {{%.*}} : $Downgradable, case #Downgradable.spoon!enumelt: [[CASE1:bb[0-9]+]], case #Downgradable.hat!enumelt: [[CASE2:bb[0-9]+]], default [[DEFAULT_CASE:bb[0-9]+]]
+  switch pat! {
+  // CHECK: [[CASE1]]:
+  case .spoon:
+    break
+  // CHECK: [[CASE2]]:
+  case .hat:
+    break
+  // CHECK: [[DEFAULT_CASE]]:
+  // CHECK-NEXT:   unreachable
+  }
+  
+  // CHECK: switch_enum {{%[0-9]+}} : $Downgradable, case #Downgradable.spoon!enumelt: {{bb[0-9]+}}, case #Downgradable.hat!enumelt: {{bb[0-9]+}}, default [[TUPLE_DEFAULT_CASE_1:bb[0-9]+]]
+  // CHECK: switch_enum [[Y:%[0-9]+]] : $Downgradable, case #Downgradable.spoon!enumelt: {{bb[0-9]+}}, case #Downgradable.hat!enumelt: {{bb[0-9]+}}, default [[TUPLE_DEFAULT_CASE_2:bb[0-9]+]]
+  switch (pat!, pat!) {
+  case (.spoon, .spoon):
+    break
+  case (.spoon, .hat):
+    break
+  case (.hat, .spoon):
+    break
+  case (.hat, .hat):
+    break
+  // CHECK: [[TUPLE_DEFAULT_CASE_2]]:
+  // CHECK-NEXT:   unreachable
+    
+  // CHECK: switch_enum [[Y]] : $Downgradable, case #Downgradable.spoon!enumelt: {{bb[0-9]+}}, case #Downgradable.hat!enumelt: {{bb[0-9]+}}, default [[TUPLE_DEFAULT_CASE_3:bb[0-9]+]]
+    
+  // CHECK: [[TUPLE_DEFAULT_CASE_3]]:
+  // CHECK-NEXT:   unreachable
+    
+  // CHECK: [[TUPLE_DEFAULT_CASE_1]]:
+  // CHECK-NEXT:   unreachable
+  }
+  
+}
+

--- a/test/attr/attr_downgrade_exhaustivity.swift
+++ b/test/attr/attr_downgrade_exhaustivity.swift
@@ -1,0 +1,150 @@
+// RUN: %target-typecheck-verify-swift -swift-version 3 %s
+
+enum Runcible {
+  case spoon
+  case hat
+  @_downgrade_exhaustivity_check
+  case fork
+}
+
+enum Trioptional {
+  case some(Runcible)
+  case just(Runcible)
+  case none
+}
+
+enum Fungible {
+  case cash
+  case giftCard
+}
+
+func missingCases(x: Runcible?, y: Runcible?, z: Trioptional) {
+  // Should warn in S3 mode that `fork` isn't used
+  switch x! { // expected-warning {{switch must be exhaustive}}
+  // expected-note@-1 {{add missing case: '.fork'}}
+  case .spoon:
+    break
+  case .hat:
+    break
+  }
+
+  // Should warn in S3 mode that `fork` isn't used
+  switch (x!, y!) { // expected-warning {{switch must be exhaustive}}
+  // expected-note@-1 3 {{add missing case:}}
+  case (.spoon, .spoon):
+    break
+  case (.spoon, .hat):
+    break
+  case (.hat, .spoon):
+    break
+  case (.hat, .hat):
+    break
+  }
+  
+  // Should error, since `fork` is used but not totally covered
+  switch (x!, y!) { // expected-error {{switch must be exhaustive}}
+  // expected-note@-1 {{add missing case: '(.fork, .hat)'}}
+  // expected-note@-2 {{add missing case: '(.fork, .fork)'}}
+  // expected-note@-3 {{add missing case: '(.hat, .fork)'}}
+  // expected-note@-4 {{add missing case: '(_, .fork)'}}
+  case (.spoon, .spoon):
+    break
+  case (.spoon, .hat):
+    break
+  case (.hat, .spoon):
+    break
+  case (.hat, .hat):
+    break
+  case (.fork, .spoon):
+    break
+  }
+  
+  // Should error, since `fork` is used but not totally covered
+  switch (x!, y!) { // expected-error {{switch must be exhaustive}}
+  // expected-note@-1 {{add missing case: '(.fork, _)'}}
+  // expected-note@-2 {{add missing case: '(.spoon, .fork)'}}
+  case (.spoon, .spoon):
+    break
+  case (.spoon, .hat):
+    break
+  case (.hat, .spoon):
+    break
+  case (.hat, .hat):
+    break
+  case (.hat, .fork):
+    break
+  }
+  
+  // Should warn in S3 mode that `fork` isn't used
+  switch x { // expected-warning {{switch must be exhaustive}}
+  // expected-note@-1 {{add missing case: '.some(.fork)'}}
+  case .some(.spoon):
+    break
+  case .some(.hat):
+    break
+  case .none:
+    break
+  }
+  
+  // Should warn in S3 mode that `fork` isn't used
+  switch (x, y!) { // expected-warning {{switch must be exhaustive}}
+  // expected-note@-1 {{add missing case: '(.some(.fork), _)'}}
+  // expected-note@-2 {{add missing case: '(.none, .fork)'}}
+  // expected-note@-3 {{add missing case: '(.some(.hat), .fork)'}}
+  // expected-note@-4 {{add missing case: '(_, .fork)'}}
+  case (.some(.spoon), .spoon):
+    break
+  case (.some(.spoon), .hat):
+    break
+  case (.some(.hat), .spoon):
+    break
+  case (.some(.hat), .hat):
+    break
+  case (.none, .spoon):
+    break
+  case (.none, .hat):
+    break
+  }
+
+  // Should warn in S3 mode that `fork` isn't used
+  switch (x, y) { // expected-warning {{switch must be exhaustive}}
+  // expected-note@-1 {{add missing case: '(.some(.fork), _)'}}
+  // expected-note@-2 {{add missing case: '(_, .some(.fork))'}}
+  // expected-note@-3 {{add missing case: '(.some(.hat), .some(.fork))'}}
+  // expected-note@-4 {{add missing case: '(.none, _)'}}
+  case (.some(.spoon), .some(.spoon)):
+    break
+  case (.some(.spoon), .some(.hat)):
+    break
+  case (.some(.spoon), .none):
+    break
+  case (.some(.hat), .some(.spoon)):
+    break
+  case (.some(.hat), .some(.hat)):
+    break
+  case (.some(.hat), .none):
+    break
+  case (.some(.hat), .some(.spoon)): // expected-warning {{case is already handled by previous patterns; consider removing it}}
+    break
+  case (.some(.hat), .some(.hat)): // expected-warning {{case is already handled by previous patterns; consider removing it}}
+    break
+  case (.some(.hat), .none): // expected-warning {{case is already handled by previous patterns; consider removing it}}
+    break
+  }
+  
+  // Should warn in S3 mode that `fork` isn't used
+  switch z { // expected-warning {{switch must be exhaustive}}
+  // expected-note@-1 {{add missing case: '.some(.fork)'}}
+  // expected-note@-2 {{add missing case: '.just(.fork)'}}
+  case .some(.spoon):
+    break
+  case .some(.hat):
+    break
+  case .just(.spoon):
+    break
+  case .just(.hat):
+    break
+  case .none:
+    break
+  }
+}

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -729,6 +729,7 @@ std::vector<UIdent> SwiftLangSupport::UIDsFromDeclAttributes(const DeclAttribute
     // Ignore these.
     case DAK_ShowInInterface:
     case DAK_RawDocComment:
+    case DAK_DowngradeExhaustivityCheck:
       continue;
     default:
       break;


### PR DESCRIPTION
Dispatch requests the ability to add a new case, but to treat missing
instances of that case in patterns as warnings instead of errors.  It is
still an error to make reference to the annotated case in at least one
pattern then not cover the rest of the space, but it is not an error
to omit the space of patterns referencing the case entirely.

This attribute is private and uglified to intentionally discourage
its use outside just this one use case.
