### PR TITLE
[WIP] Add _BinaryInteger to break ambiguities in comparison

### DIFF
--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -1339,7 +1339,7 @@ extension Numeric {
 ///     }
 ///     // Prints "23 is greater than -23."
 public protocol BinaryInteger :
-  Hashable, Numeric, CustomStringConvertible, Strideable, _BinaryInteger {
+  /* Hashable, Numeric, CustomStringConvertible, Strideable, */ _BinaryInteger {
 
   /// A Boolean value indicating whether this type is a signed integer type.
   ///
@@ -1777,6 +1777,18 @@ public protocol _BinaryInteger :
 }
 
 extension _BinaryInteger {
+  public static func == <
+    Other : _BinaryInteger
+  >(lhs: Self, rhs: Other) -> Bool {
+    fatalError("not implemented")
+  }
+
+  public static func < <
+    Other : _BinaryInteger
+  >(lhs: Self, rhs: Other) -> Bool {
+    fatalError("not implemented")
+  }
+
   /// Returns a Boolean value indicating whether the two given values are not
   /// equal.
   ///

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -1663,7 +1663,15 @@ extension Int {
 //===--- Heterogeneous comparison -----------------------------------------===//
 //===----------------------------------------------------------------------===//
 
-extension BinaryInteger {
+/// This protocol is an implementation detail of `BinaryInteger`. Do not use it
+/// directly.
+public protocol _BinaryInteger :
+  Hashable, Numeric, CustomStringConvertible, Strideable {
+  // FIXME(integers): This protocol is necessary for breaking ambiguities in
+  // generic code.
+}
+
+extension _BinaryInteger where Self : BinaryInteger {
   /// Returns a Boolean value indicating whether the two given values are
   /// equal.
   ///
@@ -1683,9 +1691,7 @@ extension BinaryInteger {
   ///   - lhs: An integer to compare.
   ///   - rhs: Another integer to compare.
   @inline(__always)
-  public static func == <
-    Other : BinaryInteger
-  >(lhs: Self, rhs: Other) -> Bool {
+  public static func == <Other : BinaryInteger>(lhs: Self, rhs: Other) -> Bool {
     let lhsNegative = Self.isSigned && lhs < (0 as Self)
     let rhsNegative = Other.isSigned && rhs < (0 as Other)
 
@@ -1762,32 +1768,6 @@ extension BinaryInteger {
 
     return Other(extendingOrTruncating: lhs) < rhs
   }
-}
-
-//===----------------------------------------------------------------------===//
-//===--- Ambiguity breakers -----------------------------------------------===//
-//===----------------------------------------------------------------------===//
-
-/// This protocol is an implementation detail of `BinaryInteger`. Do not use it
-/// directly.
-public protocol _BinaryInteger :
-  Hashable, Numeric, CustomStringConvertible, Strideable {
-  // FIXME(integers): This protocol is necessary for breaking ambiguities in
-  // generic code.
-}
-
-extension _BinaryInteger {
-  public static func == <
-    Other : _BinaryInteger
-  >(lhs: Self, rhs: Other) -> Bool {
-    fatalError("not implemented")
-  }
-
-  public static func < <
-    Other : _BinaryInteger
-  >(lhs: Self, rhs: Other) -> Bool {
-    fatalError("not implemented")
-  }
 
   /// Returns a Boolean value indicating whether the two given values are not
   /// equal.
@@ -1808,9 +1788,7 @@ extension _BinaryInteger {
   ///   - lhs: An integer to compare.
   ///   - rhs: Another integer to compare.
   @_transparent
-  public static func != <
-    Other : _BinaryInteger
-  >(lhs: Self, rhs: Other) -> Bool {
+  public static func != <Other : BinaryInteger>(lhs: Self, rhs: Other) -> Bool {
     return !(lhs == rhs)
   }
 
@@ -1826,9 +1804,7 @@ extension _BinaryInteger {
   ///   - rhs: Another integer to compare.
   @_transparent
   //@inline(__always)
-  public static func <= <
-    Other : _BinaryInteger
-  >(lhs: Self, rhs: Other) -> Bool {
+  public static func <= <Other : BinaryInteger>(lhs: Self, rhs: Other) -> Bool {
     return !(rhs < lhs)
   }
 
@@ -1844,9 +1820,7 @@ extension _BinaryInteger {
   ///   - rhs: Another integer to compare.
   @_transparent
   //@inline(__always)
-  public static func >= <
-    Other : _BinaryInteger
-  >(lhs: Self, rhs: Other) -> Bool {
+  public static func >= <Other : BinaryInteger>(lhs: Self, rhs: Other) -> Bool {
     return !(lhs < rhs)
   }
 
@@ -1862,7 +1836,7 @@ extension _BinaryInteger {
   ///   - rhs: Another integer to compare.
   @_transparent
   //@inline(__always)
-  public static func > <Other : _BinaryInteger>(lhs: Self, rhs: Other) -> Bool {
+  public static func > <Other : BinaryInteger>(lhs: Self, rhs: Other) -> Bool {
     return rhs < lhs
   }
 }

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -1727,6 +1727,29 @@ extension _BinaryInteger where Self : BinaryInteger {
     return lhs == Self(extendingOrTruncating: rhs)
   }
 
+  /// Returns a Boolean value indicating whether the two given values are not
+  /// equal.
+  ///
+  /// You can check the inequality of instances of any `BinaryInteger` types
+  /// using the not-equal-to operator (`!=`). For example, you can test
+  /// whether the first `UInt8` value in a string's UTF-8 encoding is not
+  /// equal to the first `UInt32` value in its Unicode scalar view:
+  ///
+  ///     let gameName = "Red Light, Green Light"
+  ///     if let firstUTF8 = gameName.utf8.first,
+  ///         let firstScalar = gameName.unicodeScalars.first?.value {
+  ///         print("First code values are different: \(firstUTF8 != firstScalar)")
+  ///     }
+  ///     // Prints "First code values are different: false"
+  ///
+  /// - Parameters:
+  ///   - lhs: An integer to compare.
+  ///   - rhs: Another integer to compare.
+  @_transparent
+  public static func != <Other : BinaryInteger>(lhs: Self, rhs: Other) -> Bool {
+    return !(lhs == rhs)
+  }
+
   /// Returns a Boolean value indicating whether the value of the first
   /// argument is less than that of the second argument.
   ///
@@ -1767,29 +1790,6 @@ extension _BinaryInteger where Self : BinaryInteger {
     }
 
     return Other(extendingOrTruncating: lhs) < rhs
-  }
-
-  /// Returns a Boolean value indicating whether the two given values are not
-  /// equal.
-  ///
-  /// You can check the inequality of instances of any `BinaryInteger` types
-  /// using the not-equal-to operator (`!=`). For example, you can test
-  /// whether the first `UInt8` value in a string's UTF-8 encoding is not
-  /// equal to the first `UInt32` value in its Unicode scalar view:
-  ///
-  ///     let gameName = "Red Light, Green Light"
-  ///     if let firstUTF8 = gameName.utf8.first,
-  ///         let firstScalar = gameName.unicodeScalars.first?.value {
-  ///         print("First code values are different: \(firstUTF8 != firstScalar)")
-  ///     }
-  ///     // Prints "First code values are different: false"
-  ///
-  /// - Parameters:
-  ///   - lhs: An integer to compare.
-  ///   - rhs: Another integer to compare.
-  @_transparent
-  public static func != <Other : BinaryInteger>(lhs: Self, rhs: Other) -> Bool {
-    return !(lhs == rhs)
   }
 
   /// Returns a Boolean value indicating whether the value of the first

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -1339,7 +1339,7 @@ extension Numeric {
 ///     }
 ///     // Prints "23 is greater than -23."
 public protocol BinaryInteger :
-  Hashable, Numeric, CustomStringConvertible, Strideable {
+  Hashable, Numeric, CustomStringConvertible, Strideable, _BinaryInteger {
 
   /// A Boolean value indicating whether this type is a signed integer type.
   ///
@@ -1866,7 +1866,7 @@ extension _BinaryInteger {
 //
 //     <T : BinaryInteger>(T, T) -> Bool
 
-extension BinaryInteger : _BinaryInteger {
+extension BinaryInteger {
   @_transparent
   public static func != (lhs: Self, rhs: Self) -> Bool {
     return !(lhs == rhs)

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -1721,31 +1721,6 @@ extension BinaryInteger {
     return lhs == Self(extendingOrTruncating: rhs)
   }
 
-  /// Returns a Boolean value indicating whether the two given values are not
-  /// equal.
-  ///
-  /// You can check the inequality of instances of any `BinaryInteger` types
-  /// using the not-equal-to operator (`!=`). For example, you can test
-  /// whether the first `UInt8` value in a string's UTF-8 encoding is not
-  /// equal to the first `UInt32` value in its Unicode scalar view:
-  ///
-  ///     let gameName = "Red Light, Green Light"
-  ///     if let firstUTF8 = gameName.utf8.first,
-  ///         let firstScalar = gameName.unicodeScalars.first?.value {
-  ///         print("First code values are different: \(firstUTF8 != firstScalar)")
-  ///     }
-  ///     // Prints "First code values are different: false"
-  ///
-  /// - Parameters:
-  ///   - lhs: An integer to compare.
-  ///   - rhs: Another integer to compare.
-  @_transparent
-  public static func != <
-    Other : BinaryInteger
-  >(lhs: Self, rhs: Other) -> Bool {
-    return !(lhs == rhs)
-  }
-
   /// Returns a Boolean value indicating whether the value of the first
   /// argument is less than that of the second argument.
   ///
@@ -1787,6 +1762,45 @@ extension BinaryInteger {
 
     return Other(extendingOrTruncating: lhs) < rhs
   }
+}
+
+//===----------------------------------------------------------------------===//
+//===--- Ambiguity breakers -----------------------------------------------===//
+//===----------------------------------------------------------------------===//
+
+/// This protocol is an implementation detail of `BinaryInteger`. Do not use it
+/// directly.
+public protocol _BinaryInteger :
+  Hashable, Numeric, CustomStringConvertible, Strideable {
+  // FIXME(integers): This protocol is necessary for breaking ambiguities in
+  // generic code.
+}
+
+extension _BinaryInteger {
+  /// Returns a Boolean value indicating whether the two given values are not
+  /// equal.
+  ///
+  /// You can check the inequality of instances of any `BinaryInteger` types
+  /// using the not-equal-to operator (`!=`). For example, you can test
+  /// whether the first `UInt8` value in a string's UTF-8 encoding is not
+  /// equal to the first `UInt32` value in its Unicode scalar view:
+  ///
+  ///     let gameName = "Red Light, Green Light"
+  ///     if let firstUTF8 = gameName.utf8.first,
+  ///         let firstScalar = gameName.unicodeScalars.first?.value {
+  ///         print("First code values are different: \(firstUTF8 != firstScalar)")
+  ///     }
+  ///     // Prints "First code values are different: false"
+  ///
+  /// - Parameters:
+  ///   - lhs: An integer to compare.
+  ///   - rhs: Another integer to compare.
+  @_transparent
+  public static func != <
+    Other : _BinaryInteger
+  >(lhs: Self, rhs: Other) -> Bool {
+    return !(lhs == rhs)
+  }
 
   /// Returns a Boolean value indicating whether the value of the first
   /// argument is less than or equal to that of the second argument.
@@ -1800,7 +1814,9 @@ extension BinaryInteger {
   ///   - rhs: Another integer to compare.
   @_transparent
   //@inline(__always)
-  public static func <= <Other : BinaryInteger>(lhs: Self, rhs: Other) -> Bool {
+  public static func <= <
+    Other : _BinaryInteger
+  >(lhs: Self, rhs: Other) -> Bool {
     return !(rhs < lhs)
   }
 
@@ -1816,7 +1832,9 @@ extension BinaryInteger {
   ///   - rhs: Another integer to compare.
   @_transparent
   //@inline(__always)
-  public static func >= <Other : BinaryInteger>(lhs: Self, rhs: Other) -> Bool {
+  public static func >= <
+    Other : _BinaryInteger
+  >(lhs: Self, rhs: Other) -> Bool {
     return !(lhs < rhs)
   }
 
@@ -1832,27 +1850,23 @@ extension BinaryInteger {
   ///   - rhs: Another integer to compare.
   @_transparent
   //@inline(__always)
-  public static func > <Other : BinaryInteger>(lhs: Self, rhs: Other) -> Bool {
+  public static func > <Other : _BinaryInteger>(lhs: Self, rhs: Other) -> Bool {
     return rhs < lhs
   }
 }
 
-//===----------------------------------------------------------------------===//
-//===--- Ambiguity breakers -----------------------------------------------===//
 // These two versions of the operators are not ordered with respect to one
 // another, but the compiler choses the second one, and that results in infinite
 // recursion.
 //
 //     <T : Comparable>(T, T) -> Bool
-//     <T : BinaryInteger, U : BinaryInteger>(T, U) -> Bool
+//     <T : _BinaryInteger, U : _BinaryInteger>(T, U) -> Bool
 //
 // so we define:
 //
 //     <T : BinaryInteger>(T, T) -> Bool
-//
-//===----------------------------------------------------------------------===//
 
-extension BinaryInteger {
+extension BinaryInteger : _BinaryInteger {
   @_transparent
   public static func != (lhs: Self, rhs: Self) -> Bool {
     return !(lhs == rhs)

--- a/test/stdlib/Integers.swift.gyb
+++ b/test/stdlib/Integers.swift.gyb
@@ -614,5 +614,24 @@ tests.test("signum/concrete") {
 % end
 }
 
+tests.test("no literal overflows/generic") {
+  func check<T : BinaryInteger>(_ x: T) {
+  // These expressions should use the homogeneous versions of comparison
+  // operators and not result in compile-time overflow errors.
+% for op in ['==', '!=', '<', '<=', '>', '>=']:
+    _ = x ${op} 0xFFFF_FFFF_FFFF_FFFF
+% end
+  }
+  check(42 as UInt64)
+}
+
+tests.test("no literal overflows/concrete") {
+  // These expressions should use the homogeneous versions of comparison
+  // operators and not result in compile-time overflow errors.
+  let u64: UInt64 = 42
+% for op in ['==', '!=', '<', '<=', '>', '>=']:
+  _ = u64 ${op} 0xFFFF_FFFF_FFFF_FFFF
+% end
+}
 
 runAllTests()


### PR DESCRIPTION
<!-- What's in this pull request? -->
SE-0104 introduces heterogeneous overloads for equality and comparison operators. However, this leads to an issue during some comparisons with a literal where the typechecker prefers heterogeneous comparison with an `Int` over homogeneous comparison, as reported in [SR-4984](https://bugs.swift.org/browse/SR-4984):

```
(swift) UInt() != 0xFFFF_FFFF_FFFF_FFFF
<REPL Input>:1:11: error: integer literal '18446744073709551615' overflows when stored into 'Int'
UInt() != 0xFFFF_FFFF_FFFF_FFFF
          ^
```

However, `UInt() == 0XFFFF_FFFF_FFFF_FFFF` works as expected.

This issue can be solved for concrete types by moving derived (in)equality and comparison operators to concrete types, as in #9909. However, the same defect would continue to persist with generic code.

Since the aim of SE-0104 was to enable better and more generic algorithms, a complete resolution is in order. This PR adds an implementation detail of `BinaryInteger` named `_BinaryInteger`, which contains the derived heterogeneous (in)equality and comparison operators. `BinaryInteger` then refines the implementation detail and already contains derived homogeneous (in)equality and comparison operators.

> WIP: local testing not complete.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-4984](https://bugs.swift.org/browse/SR-4984).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->