### PR TITLE
[WIP] An alternative design for heterogeneous comparison

### DIFF
--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
@@ -2423,7 +2423,7 @@ public func expectEqualsUnordered<
 public func expectEqualsUnordered<T : Strideable>(
   _ expected: CountableRange<T>, _ actual: [T], ${TRACE}
 ) {
-  if expected.count != actual.count {
+  if Int(exactly: expected.count) != actual.count {
     expectationFailure("expected elements: \"\(expected)\"\n"
       + "actual: \"\(actual)\" (of type \(String(reflecting: type(of: actual))))",
       trace: ${trace})

--- a/stdlib/public/core/IntegerParsing.swift
+++ b/stdlib/public/core/IntegerParsing.swift
@@ -24,7 +24,7 @@ internal func _asciiDigit<CodeUnit : UnsignedInteger, Result : BinaryInteger>(
   else if _fastPath(upper ~= u) { d = u &- upper.lowerBound &+ 10 }
   else if _fastPath(lower ~= u) { d = u &- lower.lowerBound &+ 10 }
   else { return nil }
-  guard _fastPath(d < radix) else { return nil }
+  guard _fastPath(Result(clamping: d) < radix) else { return nil }
   return Result(extendingOrTruncating: d)
 }
 
@@ -67,13 +67,15 @@ internal func _parseASCII<
 where CodeUnits.Element : UnsignedInteger {
   let c0_ = codeUnits.next()
   guard _fastPath(c0_ != nil), let c0 = c0_ else { return nil }
-  if _fastPath(c0 != _ascii16("+") && c0 != _ascii16("-")) {
+  let plus = CodeUnits.Element(exactly: _ascii16("+"))
+  let minus = CodeUnits.Element(exactly: _ascii16("-"))
+  if _fastPath(c0 != plus && c0 != minus) {
     return _parseUnsignedASCII(
       first: c0, rest: &codeUnits, radix: radix, positive: true)
   }
   let c1_ = codeUnits.next()
   guard _fastPath(c1_ != nil), let c1 = c1_ else { return nil }
-  if _fastPath(c0 == _ascii16("-")) {
+  if _fastPath(c0 == minus) {
     return _parseUnsignedASCII(
       first: c1, rest: &codeUnits, radix: radix, positive: false)
   }

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -2254,9 +2254,10 @@ ${operatorComment(x.nonMaskingOperator, True)}
   public static func ${x.helper}Generic <
     Other : BinaryInteger
   >(_ lhs: inout Self, _ rhs: Other) {
+    let rhs = Int(clamping: rhs)
     let shift = rhs < -Self.bitWidth ? -Self.bitWidth
                 : rhs > Self.bitWidth ? Self.bitWidth
-                : Int(rhs)
+                : rhs
     lhs = ${x.helper}(lhs, shift)
   }
 
@@ -2284,10 +2285,13 @@ ${operatorComment(x.nonMaskingOperator, True)}
 
 extension FixedWidthInteger {
   public init<Other: BinaryInteger>(clamping source: Other) {
-    if _slowPath(source < Self.min) {
+    if _slowPath(Other.isSigned && source.bitWidth > Self.bitWidth &&
+      source < Other(Self.min)) {
       self = Self.min
     }
-    else if _slowPath(source > Self.max) {
+    else if _slowPath(((source.bitWidth > Self.bitWidth) ||
+      (source.bitWidth == Self.bitWidth && !Other.isSigned)) &&
+      source > Other(Self.max)) {
       self = Self.max
     }
     else { self = Self(extendingOrTruncating: source) }
@@ -2436,7 +2440,7 @@ extension UnsignedInteger where Self : FixedWidthInteger {
     }
     // This check is potentially removable by the optimizer
     if source.bitWidth >= Self.bitWidth {
-      _precondition(source <= Self.max,
+      _precondition(source <= T(Self.max),
         "Not enough bits to represent a signed value")
     }
     self.init(extendingOrTruncating: source)
@@ -2450,7 +2454,7 @@ extension UnsignedInteger where Self : FixedWidthInteger {
     }
     // The width check can be eliminated by the optimizer
     if source.bitWidth >= Self.bitWidth &&
-       source > Self.max {
+       source > T(Self.max) {
       return nil
     }
     self.init(extendingOrTruncating: source)
@@ -2510,13 +2514,13 @@ extension SignedInteger where Self : FixedWidthInteger {
   public init<T : BinaryInteger>(_ source: T) {
     // This check is potentially removable by the optimizer
     if T.isSigned && source.bitWidth > Self.bitWidth {
-      _precondition(source >= Self.min,
+      _precondition(source >= T(Self.min),
         "Not enough bits to represent a signed value")
     }
     // This check is potentially removable by the optimizer
     if (source.bitWidth > Self.bitWidth) ||
        (source.bitWidth == Self.bitWidth && !T.isSigned) {
-      _precondition(source <= Self.max,
+      _precondition(source <= T(Self.max),
         "Not enough bits to represent a signed value")
     }
     self.init(extendingOrTruncating: source)
@@ -2525,13 +2529,13 @@ extension SignedInteger where Self : FixedWidthInteger {
   @inline(__always)
   public init?<T : BinaryInteger>(exactly source: T) {
     // This check is potentially removable by the optimizer
-    if T.isSigned && source.bitWidth > Self.bitWidth && source < Self.min {
+    if T.isSigned && source.bitWidth > Self.bitWidth && source < T(Self.min) {
       return nil
     }
     // The width check can be eliminated by the optimizer
     if (source.bitWidth > Self.bitWidth ||
         (source.bitWidth == Self.bitWidth && !T.isSigned)) &&
-       source > Self.max {
+       source > T(Self.max) {
       return nil
     }
     self.init(extendingOrTruncating: source)

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -1663,7 +1663,15 @@ extension Int {
 //===--- Heterogeneous comparison -----------------------------------------===//
 //===----------------------------------------------------------------------===//
 
-extension BinaryInteger {
+/// This protocol is an implementation detail of concrete binary integer types.
+/// Do not use it directly.
+public protocol _BinaryInteger : BinaryInteger {
+  // FIXME(integers): This protocol is necessary to permit heterogeneous
+  // comparison on concrete types without defaulting to heterogeneous
+  // comparison with literals in generic code.
+}
+
+extension _BinaryInteger {
   /// Returns a Boolean value indicating whether the two given values are
   /// equal.
   ///
@@ -1684,7 +1692,7 @@ extension BinaryInteger {
   ///   - rhs: Another integer to compare.
   @inline(__always)
   public static func == <
-    Other : BinaryInteger
+    Other : _BinaryInteger
   >(lhs: Self, rhs: Other) -> Bool {
     let lhsNegative = Self.isSigned && lhs < (0 as Self)
     let rhsNegative = Other.isSigned && rhs < (0 as Other)
@@ -1741,7 +1749,7 @@ extension BinaryInteger {
   ///   - rhs: Another integer to compare.
   @_transparent
   public static func != <
-    Other : BinaryInteger
+    Other : _BinaryInteger
   >(lhs: Self, rhs: Other) -> Bool {
     return !(lhs == rhs)
   }
@@ -1757,7 +1765,7 @@ extension BinaryInteger {
   ///   - lhs: An integer to compare.
   ///   - rhs: Another integer to compare.
   @inline(__always)
-  public static func < <Other : BinaryInteger>(lhs: Self, rhs: Other) -> Bool {
+  public static func < <Other : _BinaryInteger>(lhs: Self, rhs: Other) -> Bool {
     let lhsNegative = Self.isSigned && lhs < (0 as Self)
     let rhsNegative = Other.isSigned && rhs < (0 as Other)
     if lhsNegative != rhsNegative { return lhsNegative }
@@ -1800,7 +1808,9 @@ extension BinaryInteger {
   ///   - rhs: Another integer to compare.
   @_transparent
   //@inline(__always)
-  public static func <= <Other : BinaryInteger>(lhs: Self, rhs: Other) -> Bool {
+  public static func <= <
+    Other : _BinaryInteger
+  >(lhs: Self, rhs: Other) -> Bool {
     return !(rhs < lhs)
   }
 
@@ -1816,7 +1826,9 @@ extension BinaryInteger {
   ///   - rhs: Another integer to compare.
   @_transparent
   //@inline(__always)
-  public static func >= <Other : BinaryInteger>(lhs: Self, rhs: Other) -> Bool {
+  public static func >= <
+    Other : _BinaryInteger
+  >(lhs: Self, rhs: Other) -> Bool {
     return !(lhs < rhs)
   }
 
@@ -1832,7 +1844,7 @@ extension BinaryInteger {
   ///   - rhs: Another integer to compare.
   @_transparent
   //@inline(__always)
-  public static func > <Other : BinaryInteger>(lhs: Self, rhs: Other) -> Bool {
+  public static func > <Other : _BinaryInteger>(lhs: Self, rhs: Other) -> Bool {
     return rhs < lhs
   }
 }
@@ -1844,15 +1856,15 @@ extension BinaryInteger {
 // recursion.
 //
 //     <T : Comparable>(T, T) -> Bool
-//     <T : BinaryInteger, U : BinaryInteger>(T, U) -> Bool
+//     <T : _BinaryInteger, U : _BinaryInteger>(T, U) -> Bool
 //
 // so we define:
 //
-//     <T : BinaryInteger>(T, T) -> Bool
+//     <T : _BinaryInteger>(T, T) -> Bool
 //
 //===----------------------------------------------------------------------===//
 
-extension BinaryInteger {
+extension _BinaryInteger {
   @_transparent
   public static func != (lhs: Self, rhs: Self) -> Bool {
     return !(lhs == rhs)
@@ -2572,7 +2584,7 @@ extension SignedInteger where Self : FixedWidthInteger {
 %   end
 @_fixed_layout
 public struct ${Self}
-  : FixedWidthInteger, ${Unsigned}Integer,
+  : _BinaryInteger, FixedWidthInteger, ${Unsigned}Integer,
     _ExpressibleByBuiltinIntegerLiteral {
 
   @_transparent
@@ -2644,6 +2656,33 @@ public struct ${Self}
   @_transparent
   public static func < (lhs: ${Self}, rhs: ${Self}) -> Bool {
     return Bool(Builtin.cmp_${u}lt_Int${bits}(lhs._value, rhs._value))
+  }
+
+  // FIXME(integers): these overloads are here in order for the compiler to
+  // prefer them to the generic ones on _BinaryInteger, in cases like the
+  // following, where choosing Int as a literal type leads to overflow:
+  //
+  //   UInt64() > 0x8000_0000_0000_0000
+  //   UInt64() != 0xFFFF_FFFF_FFFF_FFFF
+
+  @_transparent
+  public static func != (lhs: ${Self}, rhs: ${Self}) -> Bool {
+    return !(lhs == rhs)
+  }
+
+  @_transparent
+  public static func <= (lhs: ${Self}, rhs: ${Self}) -> Bool {
+    return !(rhs < lhs)
+  }
+
+  @_transparent
+  public static func >= (lhs: ${Self}, rhs: ${Self}) -> Bool {
+    return !(lhs < rhs)
+  }
+
+  @_transparent
+  public static func > (lhs: ${Self}, rhs: ${Self}) -> Bool {
+    return rhs < lhs
   }
 
 // FIXME(integers): pending optimizer work on handling the case where the

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -274,7 +274,8 @@ public struct Unsafe${Mutable}RawBufferPointer
   @_inlineable
   public func copyBytes<C : Collection>(from source: C
   ) where C.Element == UInt8 {
-    _debugPrecondition(source.count <= self.count,
+    let count = Int(exactly: source.count)
+    _debugPrecondition(count != nil && count! <= self.count,
       "${Self}.copyBytes source has too many elements")
     guard let position = _position else {
       return

--- a/test/stdlib/Integers.swift.gyb
+++ b/test/stdlib/Integers.swift.gyb
@@ -614,5 +614,24 @@ tests.test("signum/concrete") {
 % end
 }
 
+tests.test("no literal overflows/generic") {
+  func check<T : BinaryInteger>(_ x: T) {
+  // These expressions should use the homogeneous versions of comparison
+  // operators and not result in compile-time overflow errors.
+% for op in ['==', '!=', '<', '<=', '>', '>=']:
+    _ = x ${op} 0xFFFF_FFFF_FFFF_FFFF
+% end
+  }
+  check(42 as UInt64)
+}
+
+tests.test("no literal overflows/concrete") {
+  // These expressions should use the homogeneous versions of comparison
+  // operators and not result in compile-time overflow errors.
+  let u64: UInt64 = 42
+% for op in ['==', '!=', '<', '<=', '>', '>=']:
+  _ = u64 ${op} 0xFFFF_FFFF_FFFF_FFFF
+% end
+}
 
 runAllTests()


### PR DESCRIPTION
<!-- What's in this pull request? -->
SE-0104 introduces heterogeneous overloads for equality and comparison operators. However, this leads to an issue during some comparisons with a literal where the typechecker prefers heterogeneous comparison with an `Int` over homogeneous comparison, as reported in [SR-4984](https://bugs.swift.org/browse/SR-4984):

```
(swift) UInt() != 0xFFFF_FFFF_FFFF_FFFF
<REPL Input>:1:11: error: integer literal '18446744073709551615' overflows when stored into 'Int'
UInt() != 0xFFFF_FFFF_FFFF_FFFF
          ^
```

However, `UInt() == 0xFFFF_FFFF_FFFF_FFFF` works as expected because a concrete implementation of `==` is defined in `UInt`. This issue can be solved for concrete types by moving derived equality and comparison operators to concrete types, as in #9909.

Even after #9909, however, the same defect continues to persist with generic code. The workaround for `0xFFFF_FFFF_FFFF_FFFF` is to write `0xFFFF_FFFF_FFFF_FFFF as T`, which by itself is not extremely onerous. However, other pitfalls like `x == ~0` vs. `x == (~0 as T)` (or any bitwise operation) are concerning because they do not trip compiler diagnostics. Although the aim of SE-0104 was to enable better and more generic algorithms, this represents a real setback in ergonomics due to the frequency with which such comparisons are used: consistent use of homogeneous comparisons can affect a significant swath of code. (For example, see https://github.com/xwu/NumericAnnex/pull/3/commits/042ae884abecfabc9f655041da8eea7d58854bfd.)

#9932 demonstrates that it is not possible to support heterogeneous comparison in generic code without this problem. Therefore, this PR moves the implementation of heterogeneous comparison operators from `BinaryInteger` to a refinement named `_BinaryInteger` to which concrete types conform. Generic code will then be able to use only homogeneous comparison--until such time as the compiler supports additional features that make possible the intended design.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->