### PR TITLE
Fix typo in renamed function SR-5015

### DIFF
--- a/stdlib/public/SDK/Foundation/NSStringAPI.swift
+++ b/stdlib/public/SDK/Foundation/NSStringAPI.swift
@@ -1778,7 +1778,7 @@ extension String {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed: "componentsSeparated(by:)")
+  @available(*, unavailable, renamed: "components(separatedBy:)")
   public func componentsSeparatedBy(_ separator: String) -> [String] {
     fatalError("unavailable function can't be called")
   }


### PR DESCRIPTION
<!-- What's in this pull request? -->
The NSStringAPI was recommending a rename to a function that doesn't exist. Corrected it to the right one.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-5015](https://bugs.swift.org/browse/SR-5015).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
See also https://github.com/apple/swift-corelibs-foundation/pull/1014 for the fix in swift-corelibs-foundation