### PR TITLE
A patch to make swiftc build in FreeBSD

### DIFF
--- a/stdlib/public/SwiftShims/LibcShims.h
+++ b/stdlib/public/SwiftShims/LibcShims.h
@@ -117,6 +117,8 @@ double _swift_stdlib_squareRoot(double _self) {
 typedef int __swift_pthread_key_t;
 #elif defined(__linux__)
 typedef unsigned int __swift_pthread_key_t;
+#elif defined(__FreeBSD__)
+typedef int __swift_pthread_key_t;
 #else
 typedef unsigned long __swift_pthread_key_t;
 #endif


### PR DESCRIPTION
This PR patches LibcShims.h to enable swiftc to build in FreeBSD 