### PR TITLE
[4.0] [Driver] Pass -warn-swift3-objc-inference-(minimal|complete) to the frontend

### DIFF
--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -126,6 +126,9 @@ static void addCommonFrontendArgs(const ToolChain &TC,
   inputArgs.AddLastArg(arguments, options::OPT_autolink_force_load);
   inputArgs.AddLastArg(arguments, options::OPT_color_diagnostics);
   inputArgs.AddLastArg(arguments, options::OPT_fixit_all);
+  inputArgs.AddLastArg(arguments,
+                       options::OPT_warn_swift3_objc_inference_minimal,
+                       options::OPT_warn_swift3_objc_inference_complete);
   inputArgs.AddLastArg(arguments, options::OPT_enable_app_extension);
   inputArgs.AddLastArg(arguments, options::OPT_enable_testing);
   inputArgs.AddLastArg(arguments, options::OPT_g_Group);

--- a/test/Driver/warn_swift3_objc_inference.swift
+++ b/test/Driver/warn_swift3_objc_inference.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swiftc_driver -warn-swift3-objc-inference-minimal -driver-print-jobs %s 2>&1 | %FileCheck -check-prefix=CHECK-MINIMAL %s
+// RUN: %target-swiftc_driver -warn-swift3-objc-inference-complete -warn-swift3-objc-inference-minimal -driver-print-jobs %s 2>&1 | %FileCheck -check-prefix=CHECK-MINIMAL %s
+// RUN: %target-swiftc_driver -warn-swift3-objc-inference-complete -driver-print-jobs %s 2>&1 | %FileCheck -check-prefix=CHECK-COMPLETE %s
+// RUN: %target-swiftc_driver -warn-swift3-objc-inference-minimal -warn-swift3-objc-inference-complete -driver-print-jobs %s 2>&1 | %FileCheck -check-prefix=CHECK-COMPLETE %s
+
+// REQUIRES: objc_interop
+
+// CHECK-MINIMAL: -warn-swift3-objc-inference-minimal
+// CHECK-COMPLETE: -warn-swift3-objc-inference-complete


### PR DESCRIPTION
**Explanation**: The driver wasn't passing `-warn-swift3-objc-inference-minimal` or `-warn-swift3-objc-inference-complete` through to the frontend, so the option was ineffective without `-Xfrontend`.
**Scope**: Affects the migration path for SE-0160 "Limiting @objc inference", particularly because the generated header wouldn't contain the expected annotations.
**Radar**: rdar://problem/32428233
**Risk**: Very low; now we're passing through a flag that we weren't before. In theory, this could start trigging more warnings for code left in the partial-migration state.
**Testing**: Compiler regression testing with a new test ensuring that the driver passes these flags through.
