### PR TITLE
SILGen: Don't crash when a keypath references an inherited computed property.

### DIFF
--- a/test/SILGen/keypaths.swift
+++ b/test/SILGen/keypaths.swift
@@ -161,3 +161,13 @@ func keyPathsWithSpecificGenericInstance() {
   _ = \Concrete.z
   _ = \S<Concrete>.computed
 }
+
+class AA<T> {
+  var a: Int { get { return 0 } set { } }
+}
+class BB<U, V>: AA<V> {
+}
+
+func keyPathForInheritedMember() {
+  _ = \BB<Int, String>.a
+}


### PR DESCRIPTION
rdar://problem/32414969