### PR TITLE
IRGen: Don't use global offset variables if we have a dependent layout and an Objective-C super class

### DIFF
--- a/test/IRGen/objc_super.swift
+++ b/test/IRGen/objc_super.swift
@@ -81,6 +81,31 @@ class PartialApply : Gizmo {
 }
 
 class GenericRuncer<T> : Gizmo {
+  var x: Gizmo? = nil
+  var y: T?
+
+// Use a constant indirect field access instead of a non-constant direct
+// access because the layout dependents on the alignment of y.
+
+// CHECK: define hidden swiftcc i64 @_T010objc_super13GenericRuncerC1xSo5GizmoCSgfg(%T10objc_super13GenericRuncerC* swiftself)
+// CHECK:    inttoptr
+// CHECK:   [[CAST:%.*]] = bitcast %T10objc_super13GenericRuncerC* %0 to i64*
+// CHECK:   [[ISA:%.*]] = load i64, i64* [[CAST]]
+// CHECK:   [[ISAMASK:%.*]] = load i64, i64* @swift_isaMask
+// CHECK:   [[CLASS:%.*]] = and i64 [[ISA]], [[ISAMASK]]
+// CHECK:   [[TY:%.*]] = inttoptr i64 [[CLASS]] to %swift.type*
+// CHECK:   [[CAST:%.*]] = bitcast %swift.type* [[TY]] to i64*
+// CHECK:   [[OFFSETADDR:%.*]] = getelementptr inbounds i64, i64* [[CAST]], i64 19
+// CHECK:   [[FIELDOFFSET:%.*]] = load i64, i64* [[OFFSETADDR]]
+// CHECK:   [[BYTEADDR:%.*]] = bitcast %T10objc_super13GenericRuncerC* %0 to i8*
+// CHECK:   [[FIELDADDR:%.*]] = getelementptr inbounds i8, i8* [[BYTEADDR]], i64 [[FIELDOFFSET]]
+// CHECK:   [[XADDR:%.*]] = bitcast i8* [[FIELDADDR]] to %TSo5GizmoCSg*
+// CHECK:   [[OPTIONALADDR:%.*]] = bitcast %TSo5GizmoCSg* [[XADDR]] to i64*
+// CHECK:   [[OPTIONAL:%.*]] = load i64, i64* [[OPTIONALADDR]]
+// CHECK:   [[OBJ:%.*]] = inttoptr i64 [[OPTIONAL]] to %objc_object*
+// CHECK:    call %objc_object* @objc_retain(%objc_object* [[OBJ]]
+// CHECK:   ret i64 [[OPTIONAL]]
+
   // CHECK: define hidden swiftcc void @_T010objc_super13GenericRuncerC5runceyyFZ(%swift.type* swiftself) {{.*}} {
   override class func runce() {
     // CHECK:      [[CLASS:%.*]] = call %swift.type* @_T010objc_super13GenericRuncerCMa(%swift.type* %T)

--- a/test/Interpreter/Inputs/ObjCClasses/ObjCClasses.h
+++ b/test/Interpreter/Inputs/ObjCClasses/ObjCClasses.h
@@ -14,6 +14,12 @@ NS_ASSUME_NONNULL_BEGIN
 @property NSInteger t;
 @end
 
+@interface HasHiddenIvars2 : NSObject
+@property id x;
+@property id y;
+@property id z;
+@end
+
 @interface TestingNSError : NSObject
 + (BOOL)throwNilError:(NSError**)error;
 + (nullable void *)maybeThrow:(BOOL)shouldThrow error:(NSError **)error;

--- a/test/Interpreter/Inputs/ObjCClasses/ObjCClasses.m
+++ b/test/Interpreter/Inputs/ObjCClasses/ObjCClasses.m
@@ -10,6 +10,12 @@
 @synthesize t;
 @end
 
+@implementation HasHiddenIvars2
+@synthesize x;
+@synthesize y;
+@synthesize z;
+@end
+
 @implementation TestingNSError
 + (BOOL)throwNilError:(NSError **)error {
   return 0;

--- a/test/Interpreter/generic_objc_subclass.swift
+++ b/test/Interpreter/generic_objc_subclass.swift
@@ -279,3 +279,23 @@ class ConcreteOverrideOfDynamicMethod : GenericOverrideOfDynamicMethod<Int> {
 // CHECK: Goodbye from ConcreteOverrideOfDynamicMethod with T = Int
 // CHECK: Goodbye from ConcreteOverrideOfDynamicMethod
 ConcreteOverrideOfDynamicMethod.funkyTown()
+
+class Foo {}
+class Bar {}
+class DependOnAlignOf<T> : HasHiddenIvars2 {
+  var first = Foo()
+  var second = Bar()
+  var third: T?
+}
+
+let ad = DependOnAlignOf<Double>()
+let ai = DependOnAlignOf<Int>()
+
+let fd = { (ad.x, ad.first, ad.second, ad.third) }
+let fi = { (ai.x, ai.first, ai.second, ai.third) }
+
+// CHECK: (nil, a.Foo, a.Bar, nil)
+print(fd())
+
+// CHECK: (nil, a.Foo, a.Bar, nil)
+print(fi())


### PR DESCRIPTION
We can't use global offset variables if we are generic and layout
dependent on a generic parameter because the objective-c layout might
depend on the alignment of the generic stored property ('t' in the
example below).

class Foo<T> : NSFoobar {
  var x : AKlass = AKlass()
  var y : AKlass = AKlass()
  var t : T?
}

SR-4687
rdar://31813495