### PR TITLE
[4.0] Add a safeguard for diagnostic minimality

### DIFF
--- a/test/Sema/exhaustive_switch.swift
+++ b/test/Sema/exhaustive_switch.swift
@@ -309,3 +309,37 @@ func checkPatternCasts() {
   case .two: break
   }
 }
+
+enum Runcible {
+  case spoon
+  case hat
+  case fork
+}
+
+func checkDiagnosticMinimality(x: Runcible?) {
+  switch (x!, x!) { // expected-error {{switch must be exhaustive}}
+  // expected-note@-1 {{add missing case: '(.fork, _)'}}
+  // expected-note@-2 {{add missing case: '(.hat, .hat)'}}
+  // expected-note@-3 {{add missing case: '(.hat, .fork)'}}
+  // expected-note@-4 {{add missing case: '(_, .fork)'}}
+  case (.spoon, .spoon):
+    break
+  case (.spoon, .hat):
+    break
+  case (.hat, .spoon):
+    break
+  }
+  
+  switch (x!, x!) { // expected-error {{switch must be exhaustive}}
+  // expected-note@-1 {{add missing case: '(.fork, _)'}}
+  // expected-note@-2 {{add missing case: '(.hat, .spoon)'}}
+  // expected-note@-3 {{add missing case: '(.hat, .fork)'}}
+  // expected-note@-4 {{add missing case: '(.spoon, .hat)'}}
+  // expected-note@-5 {{add missing case: '(.spoon, .fork)'}}
+  // expected-note@-6 {{add missing case: '(_, .fork)'}}
+  case (.spoon, .spoon):
+    break
+  case (.hat, .hat):
+    break
+  }
+}


### PR DESCRIPTION
Explanation: An external user had concerns about the wordiness of the average exhaustiveness checker's diagnostics.  This adds a filter to guarantee that the absolute bare-minimum fixit that covers the missing cases is actually emitted.
Scope: The diagnostic is whitelisted by the migrator.
Radar: Self-filed as rdar://problem/32433340
Risk: None; Tests added to harden the existing guarantees.