### PR TITLE
AST: Don't return hasTypeParameter() for DependentMemberTypes with an ErrorType base

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -81,7 +81,7 @@ namespace swift {
 /// on structural types.
 class RecursiveTypeProperties {
 public:
-  enum { BitWidth = 10 };
+  enum { BitWidth = 11 };
 
   /// A single property.
   ///
@@ -120,6 +120,9 @@ public:
     /// This type contains an Error type.
     HasError             = 0x200,
 
+    /// This type contains a DependentMemberType.
+    HasDependentMember   = 0x400,
+
     IsNotMaterializable  = (HasInOut | IsLValue)
   };
 
@@ -157,6 +160,10 @@ public:
 
   /// Does this type contain an error?
   bool hasError() const { return Bits & HasError; }
+
+  /// Does this type contain a dependent member type, possibly with a
+  /// non-type parameter base, such as a type variable or concrete type?
+  bool hasDependentMember() const { return Bits & HasDependentMember; }
 
   /// Is a type with these properties materializable: that is, is it a
   /// first-class value type?
@@ -197,6 +204,11 @@ public:
   /// Remove the HasTypeParameter property from this set.
   void removeHasTypeParameter() {
     Bits &= ~HasTypeParameter;
+  }
+
+  /// Remove the HasDependentMember property from this set.
+  void removeHasDependentMember() {
+    Bits &= ~HasDependentMember;
   }
 
   /// Test for a particular property in this set.
@@ -562,6 +574,12 @@ public:
   /// Determine whether this type contains an error type.
   bool hasError() const {
     return getRecursiveProperties().hasError();
+  }
+
+  /// Does this type contain a dependent member type, possibly with a
+  /// non-type parameter base, such as a type variable or concrete type?
+  bool hasDependentMember() const {
+    return getRecursiveProperties().hasDependentMember();
   }
 
   /// \brief Check if this type is a valid type for the LHS of an assignment.

--- a/validation-test/compiler_crashers_2_fixed/0102-sr4575.swift
+++ b/validation-test/compiler_crashers_2_fixed/0102-sr4575.swift
@@ -1,0 +1,13 @@
+// RUN: not %target-swift-frontend %s -typecheck
+struct V<T> : BidirectionalCollection {}
+struct S {
+  func bar<T>(_ to: T.Type) -> V<T> {
+    return V<T>()
+  }
+}
+
+extension S {
+  func foo<R>(_ body: (UnsafeBufferPointer<UTF16.CodeUnit>) -> R) -> R {
+    return Array(self.bar(UTF16.self)).withUnsafeBufferPointer(body)
+  }
+}

--- a/validation-test/compiler_crashers_fixed/28746-second-missing-second-type.swift
+++ b/validation-test/compiler_crashers_fixed/28746-second-missing-second-type.swift
@@ -5,6 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 ReversedRandomAccessIndex.init((

--- a/validation-test/compiler_crashers_fixed/28749-reftype-hastypeparameter-cannot-have-a-dependent-type-here.swift
+++ b/validation-test/compiler_crashers_fixed/28749-reftype-hastypeparameter-cannot-have-a-dependent-type-here.swift
@@ -5,6 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 @objc protocol P{struct B{let c=a{}}typealias a{}typealias a


### PR DESCRIPTION
Instead, introduce a new hasDependentMember() recursive property.

The only place that cares about this is associated type inference,
where I changed all existing hasTypeParameter() checks to instead
check (hasTypeParameter() || hasDependentMember()). We could
probably refine this over time and remove some of the
hasTypeParameter() checks, but I'm being conservative for now.

Fixes <https://bugs.swift.org/browse/SR-4575> and
<rdar://problem/31603113> and <rdar://problem/31566154> 