### PR TITLE
[ConstraintSolver] Refactor `solveSimplified` to consolidate disjunction choice attributes/operations

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4986,3 +4986,26 @@ ConstraintSystem::simplifyConstraint(const Constraint &constraint) {
 
   llvm_unreachable("Unhandled ConstraintKind in switch.");
 }
+
+void ConstraintSystem::simplifyDisjunctionChoice(Constraint *choice) {
+  // Simplify this term in the disjunction.
+  switch (simplifyConstraint(*choice)) {
+  case ConstraintSystem::SolutionKind::Error:
+    if (!failedConstraint)
+      failedConstraint = choice;
+    solverState->retireConstraint(choice);
+    break;
+
+  case ConstraintSystem::SolutionKind::Solved:
+    solverState->retireConstraint(choice);
+    break;
+
+  case ConstraintSystem::SolutionKind::Unsolved:
+    InactiveConstraints.push_back(choice);
+    CG.addConstraint(choice);
+    break;
+  }
+
+  // Record this as a generated constraint.
+  solverState->addGeneratedConstraint(choice);
+}


### PR DESCRIPTION
Consolidate some of the attributes and operations common to disjunction choice
in new `DisjunctionChoice` class, which simplifies implementation of the
`ConstraintSystem::solveSimplified` method related to overload selection.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
