### PR TITLE
[swiftc (34 vs. 5535)] Add crasher in swift::GenericSignatureBuilder::finalize

### DIFF
--- a/validation-test/compiler_crashers/28760-dist-0-nested-type-should-have-matched-associated-type.swift
+++ b/validation-test/compiler_crashers/28760-dist-0-nested-type-should-have-matched-associated-type.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol P{typealias e:P{}class a{{}func a:Self.a.e


### PR DESCRIPTION
Add test case for crash triggered in `swift::GenericSignatureBuilder::finalize`.

Current number of unresolved compiler crashers: 34 (5535 resolved)

/cc @DougGregor - just wanted to let you know that this crasher caused an assertion failure for the assertion `dist > 0 && "nested type should have matched associated type"` added on 2014-10-10 by you in commit 09688472 :-)

Assertion failure in [`lib/AST/GenericSignatureBuilder.cpp (line 3686)`](https://github.com/apple/swift/blob/7e05b53c10ec459cf0b54096ea758a32ee97426a/lib/AST/GenericSignatureBuilder.cpp#L3686):

```
Assertion `dist > 0 && "nested type should have matched associated type"' failed.

When executing: swift::Identifier typoCorrectNestedType(GenericSignatureBuilder::PotentialArchetype *)
```

Assertion context:

```c++
        continue;

      unsigned dist = name.edit_distance(assocType->getName().str(),
                                         /*AllowReplacements=*/true,
                                         maxScore);
      assert(dist > 0 && "nested type should have matched associated type");
      if (bestEditDistance == 0 || dist == bestEditDistance) {
        bestEditDistance = dist;
        maxScore = bestEditDistance;
        bestMatches.push_back(assocType->getName());
      } else if (dist < bestEditDistance) {
```
Stack trace:

```
0 0x0000000003a60998 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3a60998)
1 0x0000000003a610d6 SignalHandler(int) (/path/to/swift/bin/swift+0x3a610d6)
2 0x00007fb52f813390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007fb52dd39428 gsignal /build/glibc-9tT8Do/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007fb52dd3b02a abort /build/glibc-9tT8Do/glibc-2.23/stdlib/abort.c:91:0
5 0x00007fb52dd31bd7 __assert_fail_base /build/glibc-9tT8Do/glibc-2.23/assert/assert.c:92:0
6 0x00007fb52dd31c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x000000000156da12 swift::GenericSignatureBuilder::finalize(swift::SourceLoc, llvm::ArrayRef<swift::GenericTypeParamType*>, bool) (/path/to/swift/bin/swift+0x156da12)
8 0x00000000013739fe swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0x13739fe)
9 0x0000000001359d89 (anonymous namespace)::DeclChecker::visitFuncDecl(swift::FuncDecl*) (/path/to/swift/bin/swift+0x1359d89)
10 0x0000000001345d9e (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x1345d9e)
11 0x000000000135688b (anonymous namespace)::DeclChecker::visitClassDecl(swift::ClassDecl*) (/path/to/swift/bin/swift+0x135688b)
12 0x0000000001345d8e (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x1345d8e)
13 0x000000000135792b (anonymous namespace)::DeclChecker::visitProtocolDecl(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0x135792b)
14 0x0000000001345c94 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x1345c94)
15 0x0000000001345ba3 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x1345ba3)
16 0x00000000013cfd95 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x13cfd95)
17 0x0000000000f98dd6 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf98dd6)
18 0x00000000004aa768 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4aa768)
19 0x00000000004a8d8b swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a8d8b)
20 0x00000000004655c7 main (/path/to/swift/bin/swift+0x4655c7)
21 0x00007fb52dd24830 __libc_start_main /build/glibc-9tT8Do/glibc-2.23/csu/../csu/libc-start.c:325:0
22 0x0000000000462c69 _start (/path/to/swift/bin/swift+0x462c69)
```