### PR TITLE
[swiftc (35 vs. 5535)] Add crasher in swift::Expr::propagateLValueAccessKind

### DIFF
--- a/validation-test/compiler_crashers/28761-allowoverwrite-e-haslvalueaccesskind-l-value-access-kind-has-already-been-set.swift
+++ b/validation-test/compiler_crashers/28761-allowoverwrite-e-haslvalueaccesskind-l-value-access-kind-has-already-been-set.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+&_ is Character


### PR DESCRIPTION
Add test case for crash triggered in `swift::Expr::propagateLValueAccessKind`.

Current number of unresolved compiler crashers: 35 (5535 resolved)

/cc @rjmccall - just wanted to let you know that this crasher caused an assertion failure for the assertion `(AllowOverwrite || !E->hasLValueAccessKind()) && "l-value access kind has already been set"` added on 2015-09-29 by you in commit d1554f9fc :-)

Assertion failure in [`lib/AST/Expr.cpp (line 238)`](https://github.com/apple/swift/blob/d0c2ffc4a6759300266ced417c7cb98802a798a5/lib/AST/Expr.cpp#L238):

```
Assertion `(AllowOverwrite || !E->hasLValueAccessKind()) && "l-value access kind has already been set"' failed.

When executing: void swift::Expr::propagateLValueAccessKind(swift::AccessKind, llvm::function_ref<Type (Expr *)>, bool)::PropagateAccessKind::visit(swift::Expr *, swift::AccessKind)
```

Assertion context:

```c++
#endif
    {}

    void visit(Expr *E, AccessKind kind) {
      assert((AllowOverwrite || !E->hasLValueAccessKind()) &&
             "l-value access kind has already been set");

      assert(GetType(E)->isAssignableType() &&
             "setting access kind on non-l-value");
      E->setLValueAccessKind(kind);

```
Stack trace:

```
0 0x0000000003a60998 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3a60998)
1 0x0000000003a610d6 SignalHandler(int) (/path/to/swift/bin/swift+0x3a610d6)
2 0x00007f043836e390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007f0436894428 gsignal /build/glibc-9tT8Do/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f043689602a abort /build/glibc-9tT8Do/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f043688cbd7 __assert_fail_base /build/glibc-9tT8Do/glibc-2.23/assert/assert.c:92:0
6 0x00007f043688cc82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x000000000154b695 swift::Expr::propagateLValueAccessKind(swift::AccessKind, llvm::function_ref<swift::Type (swift::Expr*)>, bool)::PropagateAccessKind::visit(swift::Expr*, swift::AccessKind) (/path/to/swift/bin/swift+0x154b695)
8 0x000000000154b362 swift::Expr::propagateLValueAccessKind(swift::AccessKind, llvm::function_ref<swift::Type (swift::Expr*)>, bool) (/path/to/swift/bin/swift+0x154b362)
9 0x00000000013d3dd0 swift::constraints::ConstraintSystem::coerceToRValue(swift::Expr*) (/path/to/swift/bin/swift+0x13d3dd0)
10 0x00000000013d3d80 swift::constraints::ConstraintSystem::coerceToRValue(swift::Expr*) (/path/to/swift/bin/swift+0x13d3d80)
11 0x00000000013e402d swift::ASTVisitor<(anonymous namespace)::ExprRewriter, swift::Expr*, void, void, void, void, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x13e402d)
12 0x00000000013d85b4 (anonymous namespace)::ExprRewriter::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0x13d85b4)
13 0x00000000013ddc31 (anonymous namespace)::ExprWalker::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0x13ddc31)
14 0x000000000150e54c swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x150e54c)
15 0x00000000013d558f swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) (/path/to/swift/bin/swift+0x13d558f)
16 0x000000000132f05c swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x132f05c)
17 0x0000000001404080 (anonymous namespace)::FailureDiagnosis::typeCheckChildIndependently(swift::Expr*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<TCCFlags, unsigned int>, swift::ExprTypeCheckListener*, bool) (/path/to/swift/bin/swift+0x1404080)
18 0x00000000013fcdd5 (anonymous namespace)::FailureDiagnosis::diagnoseAmbiguity(swift::Expr*) (/path/to/swift/bin/swift+0x13fcdd5)
19 0x00000000013f9775 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) (/path/to/swift/bin/swift+0x13f9775)
20 0x00000000013fe1b9 swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) (/path/to/swift/bin/swift+0x13fe1b9)
21 0x000000000132b668 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0x132b668)
22 0x000000000132ef61 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x132ef61)
23 0x00000000013b2795 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13b2795)
24 0x00000000013b1fa6 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0x13b1fa6)
25 0x00000000013cfe10 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x13cfe10)
26 0x0000000000f98dd6 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf98dd6)
27 0x00000000004aa768 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4aa768)
28 0x00000000004a8d8b swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a8d8b)
29 0x00000000004655c7 main (/path/to/swift/bin/swift+0x4655c7)
30 0x00007f043687f830 __libc_start_main /build/glibc-9tT8Do/glibc-2.23/csu/../csu/libc-start.c:325:0
31 0x0000000000462c69 _start (/path/to/swift/bin/swift+0x462c69)
```