### PR TITLE
SR-648: Allow swiftpm to statically link binaries on Linux

### DIFF
--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -1534,8 +1534,6 @@ toolchains::GenericUnix::constructInvocation(const LinkJobAction &job,
   addPrimaryInputsOfType(Arguments, context.Inputs, types::TY_Object);
   addInputsOfType(Arguments, context.InputActions, types::TY_Object);
 
-  context.Args.AddAllArgs(Arguments, options::OPT_Xlinker);
-  context.Args.AddAllArgs(Arguments, options::OPT_linker_option_Group);
   for (const Arg *arg : context.Args.filtered(options::OPT_F,
                                               options::OPT_Fsystem)) {
     if (arg->getOption().matches(options::OPT_Fsystem))
@@ -1608,6 +1606,9 @@ toolchains::GenericUnix::constructInvocation(const LinkJobAction &job,
     Arguments.push_back(context.Args.MakeArgString(
         Twine("-u", llvm::getInstrProfRuntimeHookVarName())));
   }
+
+  context.Args.AddAllArgs(Arguments, options::OPT_Xlinker);
+  context.Args.AddAllArgs(Arguments, options::OPT_linker_option_Group);
 
   // Just before the output option, allow GenericUnix toolchains to add
   // additional inputs.

--- a/test/Driver/linker-args-order-linux.swift
+++ b/test/Driver/linker-args-order-linux.swift
@@ -1,11 +1,8 @@
 // Statically link a "hello world" program
-// REQUIRES: OS=linux-gnu
 // REQUIRES: static_stdlib
 print("hello world!")
 // RUN: %empty-directory(%t)
-// RUN: %target-swiftc_driver -v -static-stdlib -o %t/static-stdlib %s -Xlinker --no-allow-multiple-definition 2>&1| %FileCheck %s
-// CHECK: Swift version
-// CHECK: Target: x86_64-unknown-linux-gnu
+// RUN: %target-swiftc_driver -driver-print-jobs -static-stdlib -o %t/static-stdlib %s -Xlinker --no-allow-multiple-definition 2>&1| %FileCheck %s
 // CHECK: {{.*}}/swift -frontend -c -primary-file {{.*}}/linker-args-order-linux.swift -target x86_64-unknown-linux-gnu -disable-objc-interop
 // CHECK: {{.*}}/swift-autolink-extract{{.*}}
 // CHECK: {{.*}}swift_begin.o /{{.*}}/linker-args-order-linux-{{[a-z0-9]+}}.o @/{{.*}}/linker-args-order-linux-{{[a-z0-9]+}}.autolink {{.*}} @{{.*}}/static-stdlib-args.lnk {{.*}} -Xlinker --no-allow-multiple-definition {{.*}}/swift_end.o

--- a/test/Driver/linker-args-order-linux.swift
+++ b/test/Driver/linker-args-order-linux.swift
@@ -1,0 +1,11 @@
+// Statically link a "hello world" program
+// REQUIRES: OS=linux-gnu
+// REQUIRES: static_stdlib
+print("hello world!")
+// RUN: %empty-directory(%t)
+// RUN: %target-swiftc_driver -v -static-stdlib -o %t/static-stdlib %s -Xlinker --no-allow-multiple-definition 2>&1| %FileCheck %s
+// CHECK: Swift version
+// CHECK: Target: x86_64-unknown-linux-gnu
+// CHECK: {{.*}}/swift -frontend -c -primary-file {{.*}}/linker-args-order-linux.swift -target x86_64-unknown-linux-gnu -disable-objc-interop
+// CHECK: {{.*}}/swift-autolink-extract{{.*}}
+// CHECK: {{.*}}swift_begin.o /{{.*}}/linker-args-order-linux-{{[a-z0-9]+}}.o @/{{.*}}/linker-args-order-linux-{{[a-z0-9]+}}.autolink {{.*}} @{{.*}}/static-stdlib-args.lnk {{.*}} -Xlinker --no-allow-multiple-definition {{.*}}/swift_end.o

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2454,6 +2454,13 @@ for host in "${ALL_HOSTS[@]}"; do
                     else
                         dispatch_build_variant_arg="debug"
                     fi
+
+                    if [ $(true_false "${BUILD_SWIFT_STATIC_STDLIB}") == "TRUE" ]; then
+                        libdispatch_enable_static="--enable-static=yes"
+                    else
+                        libdispatch_enable_static=""
+                    fi
+
                     call mkdir -p "${LIBDISPATCH_BUILD_DIR}"
                     with_pushd "${LIBDISPATCH_SOURCE_DIR}" \
                         call autoreconf -fvi
@@ -2461,7 +2468,7 @@ for host in "${ALL_HOSTS[@]}"; do
                         call env CC="${LLVM_BIN}/clang" CXX="${LLVM_BIN}/clang++" SWIFTC="${SWIFTC_BIN}" \
                             "${LIBDISPATCH_SOURCE_DIR}"/configure --with-swift-toolchain="${SWIFT_BUILD_PATH}" \
                             --with-build-variant=$dispatch_build_variant_arg \
-                            --prefix="$(get_host_install_destdir ${host})$(get_host_install_prefix ${host})"
+                            --prefix="$(get_host_install_destdir ${host})$(get_host_install_prefix ${host})" ${libdispatch_enable_static}
                 else
                     echo "Skipping reconfiguration of libdispatch"
                 fi
@@ -3050,10 +3057,16 @@ for host in "${ALL_HOSTS[@]}"; do
                 echo "--- Installing ${product} ---"
                 XCTEST_BUILD_DIR=$(build_directory ${host} xctest)
                 XCTEST_INSTALL_PREFIX="${host_install_destdir}${host_install_prefix}/lib/swift/${LIB_TARGET}"
+                if [ $(true_false "${BUILD_SWIFT_STATIC_STDLIB}") == "TRUE" ]; then
+                    XCTEST_STATIC_INSTALL_PREFIX="${host_install_destdir}${host_install_prefix}/lib/swift_static/${LIB_TARGET}"
+                    xctest_static_install="--static-library-install-path=${XCTEST_STATIC_INSTALL_PREFIX}"
+                else
+                    xctest_static_install=""
+                fi
                 # Note that installing directly to /usr/lib/swift usually
                 # requires root permissions.
                 call "${XCTEST_SOURCE_DIR}"/build_script.py install \
-                    --library-install-path="${XCTEST_INSTALL_PREFIX}" \
+                    --library-install-path="${XCTEST_INSTALL_PREFIX}" ${xctest_static_install} \
                     --module-install-path="${XCTEST_INSTALL_PREFIX}"/"${SWIFT_HOST_VARIANT_ARCH}" \
                     "${XCTEST_BUILD_DIR}"
 
@@ -3093,6 +3106,11 @@ for host in "${ALL_HOSTS[@]}"; do
                 LIBDISPATCH_BUILD_DIR=$(build_directory ${host} ${product})
                 with_pushd "${LIBDISPATCH_BUILD_DIR}" \
                     call make install
+                DISPATCH_LIBDIR="${host_install_destdir}${host_install_prefix}/lib/swift/${SWIFT_HOST_VARIANT}"
+                DISPATCH_LIBDIR_STATIC="${host_install_destdir}${host_install_prefix}/lib/swift_static/${SWIFT_HOST_VARIANT}"
+                if [ -f "$DISPATCH_LIBDIR/libdispatch.a" ]; then
+                    mv "$DISPATCH_LIBDIR/libdispatch.a" "$DISPATCH_LIBDIR_STATIC"
+                fi
 
                 # As libdispatch installation is self-contained, we break early here.
                 continue


### PR DESCRIPTION
This PR requires https://github.com/apple/swift-corelibs-foundation/pull/1011 and 
https://github.com/apple/swift-corelibs-xctest/pull/190 to be merged beforehand.

- If --build-swift-static-stdlib option is used then also produce
  static versions of libXCTest.a and libdispatch.a and put them
  into the lib/swift_static/linux/ toolchain directory.
  libFoundation.a is already being built and deployed there.

- Binaries with the swift libs statically linked in can then be
  built with using the command:

  swift build -Xswiftc -static-stdlib -Xlinker -lcurl -Xlinker -lxml2 -Xlinker -lbsd -Xlinker --allow-multiple-definition

  Note: This is a dynamic binary with the libswiftCore,  libFoundation and libdispatch libraries statically linked in.

- Further fixes should reduce the complexity of the above command.

There arent any unit tests in this PR, however I will add a followup one which builds a static version of TestFoundation to test xctest, libdispatch and libfoundation together.


