### PR TITLE
[swiftc (36 vs. 5535)] Add crasher in swift::constraints::ConstraintSystem::getTypeOfReference

### DIFF
--- a/validation-test/compiler_crashers/28762-valuetype-hasunboundgenerictype-valuetype-hastypeparameter.swift
+++ b/validation-test/compiler_crashers/28762-valuetype-hasunboundgenerictype-valuetype-hastypeparameter.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+guard let f==A:UnfoldSequence


### PR DESCRIPTION
Add test case for crash triggered in `swift::constraints::ConstraintSystem::getTypeOfReference`.

Current number of unresolved compiler crashers: 36 (5535 resolved)

/cc @slavapestov - just wanted to let you know that this crasher caused an assertion failure for the assertion `!valueType->hasUnboundGenericType() && !valueType->hasTypeParameter()` added on 2017-05-22 by you in commit b112e95a :-)

Assertion failure in [`lib/Sema/ConstraintSystem.cpp (line 841)`](https://github.com/apple/swift/blob/a290776ff092fc7a74e3259daf93440952166e09/lib/Sema/ConstraintSystem.cpp#L841):

```
Assertion `!valueType->hasUnboundGenericType() && !valueType->hasTypeParameter()' failed.

When executing: std::pair<Type, Type> swift::constraints::ConstraintSystem::getTypeOfReference(swift::ValueDecl *, swift::FunctionRefKind, swift::constraints::ConstraintLocatorBuilder, const swift::DeclRefExpr *)
```

Assertion context:

```c++
  // Unqualified reference to a type.
  if (auto typeDecl = dyn_cast<TypeDecl>(value)) {
    // Resolve the reference to this type declaration in our current context.
    auto type = TC.resolveTypeInContext(typeDecl, DC,
                                        TR_InExpression,
                                        /*isSpecialized=*/false);

    // Open the type.
    type = openUnboundGenericType(type, locator);

    // Module types are not wrapped in metatypes.
```
Stack trace:

```
0 0x0000000003a60998 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3a60998)
1 0x0000000003a610d6 SignalHandler(int) (/path/to/swift/bin/swift+0x3a610d6)
2 0x00007f2c4bc94390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007f2c4a1ba428 gsignal /build/glibc-9tT8Do/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f2c4a1bc02a abort /build/glibc-9tT8Do/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f2c4a1b2bd7 __assert_fail_base /build/glibc-9tT8Do/glibc-2.23/assert/assert.c:92:0
6 0x00007f2c4a1b2c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x00000000013173d0 swift::constraints::ConstraintSystem::getTypeOfReference(swift::ValueDecl*, swift::FunctionRefKind, swift::constraints::ConstraintLocatorBuilder, swift::DeclRefExpr const*) (/path/to/swift/bin/swift+0x13173d0)
8 0x0000000001318d51 swift::constraints::ConstraintSystem::resolveOverload(swift::constraints::ConstraintLocator*, swift::Type, swift::constraints::OverloadChoice, swift::DeclContext*) (/path/to/swift/bin/swift+0x1318d51)
9 0x00000000012cc5b4 swift::ASTVisitor<(anonymous namespace)::ConstraintGenerator, swift::Type, void, void, void, void, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x12cc5b4)
10 0x00000000012d27a8 (anonymous namespace)::ConstraintWalker::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0x12d27a8)
11 0x000000000150fd81 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x150fd81)
12 0x0000000001511cde (anonymous namespace)::Traversal::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0x1511cde)
13 0x000000000150e52b swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x150e52b)
14 0x00000000012c92a1 swift::constraints::ConstraintSystem::generateConstraints(swift::Expr*) (/path/to/swift/bin/swift+0x12c92a1)
15 0x00000000012f30d6 swift::constraints::ConstraintSystem::solve(swift::Expr*&, swift::Type, swift::ExprTypeCheckListener*, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0x12f30d6)
16 0x000000000132b624 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0x132b624)
17 0x000000000132ef61 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x132ef61)
18 0x00000000013338c4 swift::TypeChecker::typeCheckCondition(swift::Expr*&, swift::DeclContext*) (/path/to/swift/bin/swift+0x13338c4)
19 0x00000000013340e0 swift::TypeChecker::typeCheckExprPattern(swift::ExprPattern*, swift::DeclContext*, swift::Type) (/path/to/swift/bin/swift+0x13340e0)
20 0x000000000137dd36 swift::TypeChecker::coercePatternToType(swift::Pattern*&, swift::DeclContext*, swift::Type, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, swift::TypeLoc) (/path/to/swift/bin/swift+0x137dd36)
21 0x000000000137d5a1 swift::TypeChecker::coercePatternToType(swift::Pattern*&, swift::DeclContext*, swift::Type, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, swift::TypeLoc) (/path/to/swift/bin/swift+0x137d5a1)
22 0x000000000137c865 swift::TypeChecker::typeCheckPattern(swift::Pattern*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0x137c865)
23 0x00000000013339f3 swift::TypeChecker::typeCheckStmtCondition(llvm::MutableArrayRef<swift::StmtConditionElement>&, swift::DeclContext*, swift::Diag<>) (/path/to/swift/bin/swift+0x13339f3)
24 0x00000000013b2ef6 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13b2ef6)
25 0x00000000013b26c6 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13b26c6)
26 0x00000000013b1fa6 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0x13b1fa6)
27 0x00000000013cfe10 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x13cfe10)
28 0x0000000000f98dd6 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf98dd6)
29 0x00000000004aa768 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4aa768)
30 0x00000000004a8d8b swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a8d8b)
31 0x00000000004655c7 main (/path/to/swift/bin/swift+0x4655c7)
32 0x00007f2c4a1a5830 __libc_start_main /build/glibc-9tT8Do/glibc-2.23/csu/../csu/libc-start.c:325:0
33 0x0000000000462c69 _start (/path/to/swift/bin/swift+0x462c69)
```