### PR TITLE
[Parse] Fix InFlightDiagnostic lifetime

### DIFF
--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -196,11 +196,12 @@ ParserResult<TypeRepr> Parser::parseTypeSimple(Diag<> MessageID,
     }
     LLVM_FALLTHROUGH;
   default:
-    auto diag = diagnose(Tok, MessageID);
-    // If the next token is closing or separating, the type was likely forgotten
-    if (Tok.isAny(tok::r_paren, tok::r_brace, tok::r_square, tok::arrow,
-                  tok::equal, tok::comma, tok::semi)) {
-      diag.fixItInsert(getEndOfPreviousLoc(), " <#type#>");
+    {
+      auto diag = diagnose(Tok, MessageID);
+      // If the next token is closing or separating, the type was likely forgotten
+      if (Tok.isAny(tok::r_paren, tok::r_brace, tok::r_square, tok::arrow,
+                    tok::equal, tok::comma, tok::semi))
+        diag.fixItInsert(getEndOfPreviousLoc(), " <#type#>");
     }
     if (Tok.isKeyword() && !Tok.isAtStartOfLine()) {
       ty = makeParserErrorResult(new (Context) ErrorTypeRepr(Tok.getLoc()));

--- a/validation-test/compiler_crashers_fixed/28759-activediagnostic-already-have-an-active-diagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/28759-activediagnostic-already-have-an-active-diagnostic.swift
@@ -6,5 +6,5 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 extension in($A


### PR DESCRIPTION
Fixes @practicalswift's crasher 28759 (#9907), which seems to have been introduced in #9294.