### PR TITLE
[CSDiag] Fix crasher in KeyPathExpr diagnosis

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -6824,6 +6824,9 @@ bool FailureDiagnosis::visitClosureExpr(ClosureExpr *CE) {
 
 static bool diagnoseKeyPathUnsupportedOperations(TypeChecker &TC,
                                                  KeyPathExpr *KPE) {
+  if (KPE->isObjC())
+    return false;
+
   using ComponentKind = KeyPathExpr::Component::Kind;
   const auto components = KPE->getComponents();
 

--- a/validation-test/compiler_crashers_fixed/28756-isobjc-cannot-get-root-type-of-objc-keypath.swift
+++ b/validation-test/compiler_crashers_fixed/28756-isobjc-cannot-get-root-type-of-objc-keypath.swift
@@ -5,7 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: deterministic-behavior
 // REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 guard#keyPath($


### PR DESCRIPTION
Fixes @practicalswift's crasher 28756 (#9904). New KeyPathExpr diagnosis recently added in #9845 did not work for Obj-C key paths.