### PR TITLE
[QoI] Fix crash when constructing existential metatype without '.init'

### DIFF
--- a/test/Constraints/protocols.swift
+++ b/test/Constraints/protocols.swift
@@ -184,9 +184,9 @@ func staticExistential(_ p: P.Type, pp: P.Protocol) {
 
   let ppp: P = p.init()
 
-  _ = pp() // expected-error{{value of type 'P.Protocol' is a protocol; it cannot be instantiated}} // expected-error{{initializing from a metatype value must reference 'init' explicitly}}
-  _ = pp().bar // expected-error{{value of type 'P.Protocol' is a protocol; it cannot be instantiated}} // expected-error{{initializing from a metatype value must reference 'init' explicitly}}
-  _ = pp().bar(2) // expected-error{{value of type 'P.Protocol' is a protocol; it cannot be instantiated}} // expected-error{{initializing from a metatype value must reference 'init' explicitly}}
+  _ = pp() // expected-error{{value of type 'P.Protocol' is a protocol; it cannot be instantiated}}
+  _ = pp().bar // expected-error{{value of type 'P.Protocol' is a protocol; it cannot be instantiated}}
+  _ = pp().bar(2) // expected-error{{value of type 'P.Protocol' is a protocol; it cannot be instantiated}}
 
   _ = pp.init() // expected-error{{value of type 'P.Protocol' is a protocol; it cannot be instantiated}}
   _ = pp.init().bar // expected-error{{value of type 'P.Protocol' is a protocol; it cannot be instantiated}}

--- a/validation-test/compiler_crashers_2_fixed/0086-sr4301.swift
+++ b/validation-test/compiler_crashers_2_fixed/0086-sr4301.swift
@@ -1,4 +1,4 @@
-// RUN: not --crash %target-swift-frontend -typecheck -primary-file %s
+// RUN: not %target-swift-frontend -typecheck -primary-file %s
 
 protocol P {
   init()


### PR DESCRIPTION
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-4301](https://bugs.swift.org/browse/SR-4301).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
