### PR TITLE
[Diagnostics] Fix checking for presence of type variables in closure return expression

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -8390,9 +8390,9 @@ diagnoseAmbiguousMultiStatementClosure(ClosureExpr *closure) {
       // constraint system through declaration types.
       bool hasUnresolvedParams = false;
       resultExpr->forEachChildExpr([&](Expr *childExpr) -> Expr *{
-        if (auto DRE = dyn_cast<DeclRefExpr>(resultExpr)) {
+        if (auto DRE = dyn_cast<DeclRefExpr>(childExpr)) {
           if (auto param = dyn_cast<ParamDecl>(DRE->getDecl())) {
-            auto paramType = param->getType();
+            auto paramType = param->hasType() ? param->getType() : Type();
             if (!paramType || paramType->hasTypeVariable()) {
               hasUnresolvedParams = true;
               return nullptr;

--- a/validation-test/compiler_crashers_fixed/28663-impl-getgraphindex-typevariables-size-out-of-bounds-index.swift
+++ b/validation-test/compiler_crashers_fixed/28663-impl-getgraphindex-typevariables-size-out-of-bounds-index.swift
@@ -5,6 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 (_==_{return($0)u

--- a/validation-test/compiler_crashers_fixed/28664-typevariables-impl-getgraphindex-typevar-type-variable-mismatch.swift
+++ b/validation-test/compiler_crashers_fixed/28664-typevariables-impl-getgraphindex-typevar-type-variable-mismatch.swift
@@ -5,7 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 [.s{return($0
 protocol r


### PR DESCRIPTION
Instead of validating sub-expressions included in the closure's result
`diagnoseAmbiguousMultiStatementClosure` was only checking parent expression
by mistake.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
