### PR TITLE
[GSB] *Almost* eliminate the "AlwaysPartial" archetype resolution kind

### DIFF
--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -869,11 +869,10 @@ ConformanceAccessPath GenericSignature::getConformanceAccessPath(
       Type storedType = eraseAssociatedTypes(source->getStoredType());
 
       // Dig out the potential archetype for this stored type.
-      // FIXME: CompleteWellFormed here?
       auto pa =
         reqSigBuilder.resolveArchetype(
                                  storedType,
-                                 ArchetypeResolutionKind::AlwaysPartial);
+                                 ArchetypeResolutionKind::CompleteWellFormed);
       auto equivClass = pa->getOrCreateEquivalenceClass();
 
       // Find the conformance of this potential archetype to the protocol in

--- a/lib/Sema/GenericTypeResolver.h
+++ b/lib/Sema/GenericTypeResolver.h
@@ -100,14 +100,7 @@ public:
 /// This generic type resolver leaves generic type parameter types alone
 /// and only trivially resolves dependent member types.
 class DependentGenericTypeResolver : public GenericTypeResolver {
-  GenericSignatureBuilder &Builder;
-  ArrayRef<GenericTypeParamType *> GenericParams;
-
 public:
-  DependentGenericTypeResolver(GenericSignatureBuilder &builder,
-                               ArrayRef<GenericTypeParamType *> genericParams)
-    : Builder(builder), GenericParams(genericParams) { }
-
   virtual Type resolveGenericTypeParamType(GenericTypeParamType *gp);
 
   virtual Type resolveDependentMemberType(Type baseTy,

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -42,6 +42,7 @@ Type DependentGenericTypeResolver::resolveDependentMemberType(
                                      DeclContext *DC,
                                      SourceRange baseRange,
                                      ComponentIdentTypeRepr *ref) {
+#if true
   auto archetype =
     Builder.resolveArchetype(baseTy, ArchetypeResolutionKind::AlwaysPartial);
   assert(archetype && "Bad generic context nesting?");
@@ -49,17 +50,14 @@ Type DependentGenericTypeResolver::resolveDependentMemberType(
   return archetype
            ->getNestedType(ref->getIdentifier(), Builder)
            ->getDependentType(GenericParams, /*allowUnresolved=*/true);
+#else
+  return DependentMemberType::get(baseTy, ref->getIdentifier());
+#endif
 }
 
 Type DependentGenericTypeResolver::resolveSelfAssociatedType(
        Type selfTy, AssociatedTypeDecl *assocType) {
-  auto archetype =
-    Builder.resolveArchetype(selfTy, ArchetypeResolutionKind::AlwaysPartial);
-  assert(archetype && "Bad generic context nesting?");
-  
-  return archetype
-           ->getNestedType(assocType, Builder)
-           ->getDependentType(GenericParams, /*allowUnresolved=*/true);
+  return DependentMemberType::get(selfTy, assocType);
 }
 
 Type DependentGenericTypeResolver::resolveTypeOfContext(DeclContext *dc) {
@@ -74,14 +72,8 @@ bool DependentGenericTypeResolver::areSameType(Type type1, Type type2) {
   if (!type1->hasTypeParameter() && !type2->hasTypeParameter())
     return type1->isEqual(type2);
 
-  auto pa1 =
-    Builder.resolveArchetype(type1, ArchetypeResolutionKind::AlwaysPartial);
-  auto pa2 =
-    Builder.resolveArchetype(type2, ArchetypeResolutionKind::AlwaysPartial);
-  if (pa1 && pa2)
-    return pa1->isInSameEquivalenceClassAs(pa2);
-
-  return type1->isEqual(type2);
+  // Conservative answer: they could be the same.
+  return true;
 }
 
 void DependentGenericTypeResolver::recordParamType(ParamDecl *decl, Type type) {
@@ -281,11 +273,12 @@ bool CompleteGenericTypeResolver::areSameType(Type type1, Type type2) {
   if (!type1->hasTypeParameter() && !type2->hasTypeParameter())
     return type1->isEqual(type2);
 
-  // FIXME: Want CompleteWellFormed here?
   auto pa1 =
-    Builder.resolveArchetype(type1, ArchetypeResolutionKind::AlwaysPartial);
+    Builder.resolveArchetype(type1,
+                             ArchetypeResolutionKind::CompleteWellFormed);
   auto pa2 =
-    Builder.resolveArchetype(type2, ArchetypeResolutionKind::AlwaysPartial);
+    Builder.resolveArchetype(type2,
+                             ArchetypeResolutionKind::CompleteWellFormed);
   if (pa1 && pa2)
     return pa1->isInSameEquivalenceClassAs(pa2);
 

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -42,17 +42,7 @@ Type DependentGenericTypeResolver::resolveDependentMemberType(
                                      DeclContext *DC,
                                      SourceRange baseRange,
                                      ComponentIdentTypeRepr *ref) {
-#if true
-  auto archetype =
-    Builder.resolveArchetype(baseTy, ArchetypeResolutionKind::AlwaysPartial);
-  assert(archetype && "Bad generic context nesting?");
-
-  return archetype
-           ->getNestedType(ref->getIdentifier(), Builder)
-           ->getDependentType(GenericParams, /*allowUnresolved=*/true);
-#else
   return DependentMemberType::get(baseTy, ref->getIdentifier());
-#endif
 }
 
 Type DependentGenericTypeResolver::resolveSelfAssociatedType(
@@ -794,7 +784,7 @@ TypeChecker::validateGenericFuncSignature(AbstractFunctionDecl *func) {
 
   // Type check the function declaration, treating all generic type
   // parameters as dependent, unresolved.
-  DependentGenericTypeResolver dependentResolver(builder, allGenericParams);
+  DependentGenericTypeResolver dependentResolver;
   if (checkGenericFuncSignature(*this, &builder, func, dependentResolver))
     invalid = true;
 
@@ -1025,7 +1015,7 @@ TypeChecker::validateGenericSubscriptSignature(SubscriptDecl *subscript) {
 
   // Type check the function declaration, treating all generic type
   // parameters as dependent, unresolved.
-  DependentGenericTypeResolver dependentResolver(builder, allGenericParams);
+  DependentGenericTypeResolver dependentResolver;
   if (checkGenericSubscriptSignature(*this, &builder, subscript,
                                      dependentResolver))
     invalid = true;
@@ -1144,7 +1134,7 @@ GenericEnvironment *TypeChecker::checkGenericEnvironment(
 
   // Type check the generic parameters, treating all generic type
   // parameters as dependent, unresolved.
-  DependentGenericTypeResolver dependentResolver(builder, allGenericParams);
+  DependentGenericTypeResolver dependentResolver;
   if (recursivelyVisitGenericParams) {
     visitOuterToInner(genericParams,
                       [&](GenericParamList *gpList) {

--- a/test/Generics/associated_type_typo.swift
+++ b/test/Generics/associated_type_typo.swift
@@ -14,7 +14,7 @@ protocol P2 {
 protocol P3 { }
 protocol P4 { }
 
-// expected-error@+1{{'T' does not have a member type named 'assoc'; did you mean 'Assoc'?}}{{30-35=Assoc}}
+// expected-error@+1{{'assoc' is not a member type of 'T'}}
 func typoAssoc1<T : P1>(x: T.assoc, _: T) { } 
 
 // expected-error@+2{{'T' does not have a member type named 'assoc'; did you mean 'Assoc'?}}{{53-58=Assoc}}

--- a/validation-test/compiler_crashers_2_fixed/0084-rdar31093854.swift
+++ b/validation-test/compiler_crashers_2_fixed/0084-rdar31093854.swift
@@ -1,4 +1,4 @@
-// RUN: not %target-swift-frontend -swift-version 4 %s -typecheck -o /dev/null
+// RUN: %target-swift-frontend -swift-version 4 %s -typecheck -o /dev/null
 
 // This should actually type check successfully.
 

--- a/validation-test/compiler_crashers_fixed/28760-dist-0-nested-type-should-have-matched-associated-type.swift
+++ b/validation-test/compiler_crashers_fixed/28760-dist-0-nested-type-should-have-matched-associated-type.swift
@@ -6,5 +6,5 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 protocol P{typealias e:P{}class a{{}func a:Self.a.e


### PR DESCRIPTION
When resolving archetypes using the "always partial" resolution kind,
we allow the system to form potential archetypes which might be
invalid. Start limiting the use of this "always partial" resolution
kind, so that it can eventually be removed entirely to simplify the
invariants of the `GenericSignatureBuilder`.

Each of the callers should either be working with complete,
well-formed archetypes or they should not force any resolution this
early.

This PR currently limits the use of `ArchetypeResolutionKind::AlwaysPartial` to a single place in the `GenericSignatureBuilder`, which is the point at which we can start delaying resolution.
