### PR TITLE
Remove bogus options from benchmark build

### DIFF
--- a/benchmark/cmake/modules/AddSwiftBenchmarkSuite.cmake
+++ b/benchmark/cmake/modules/AddSwiftBenchmarkSuite.cmake
@@ -48,7 +48,6 @@ function (swift_benchmark_compile_archopts)
       "-target" "${target}"
       "-F" "${sdk}/../../../Developer/Library/Frameworks"
       "-${BENCH_COMPILE_ARCHOPTS_OPT}"
-      "-D" "INTERNAL_CHECKS_ENABLED"
       "-no-link-objc-runtime"
       "-I" "${srcdir}/utils/ObjectiveCTests")
 
@@ -63,7 +62,6 @@ function (swift_benchmark_compile_archopts)
       "-target" "${target}"
       "-F" "${sdk}/../../../Developer/Library/Frameworks"
       "-${driver_opt}"
-      "-D" "INTERNAL_CHECKS_ENABLED"
       "-no-link-objc-runtime")
 
   set(bench_library_objects)


### PR DESCRIPTION
This option is misleading, and never should have been there in the first place.  Fortunately it was having no effect because the standard library is already compiled to SIL and the internal checks have been eliminated from any benchmark build.

