### PR TITLE
Update latex_paper_size to latex_elements.papersize

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -11,7 +11,7 @@ SET(SWIFT_SPHINX_PAPER_SIZE "letter"
 
 SET(SPHINX_ARGS
   -W
-  -D latex_paper_size=${SWIFT_SPHINX_PAPER_SIZE}
+  -D latex_elements.papersize=${SWIFT_SPHINX_PAPER_SIZE}
   -d ${CMAKE_BINARY_DIR}/doctrees)
 
 if(SPHINX_EXECUTABLE)

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -8,8 +8,8 @@ PAPER         =
 BUILDDIR      = _build
 
 # Internal variables.
-PAPEROPT_a4     = -D latex_paper_size=a4
-PAPEROPT_letter = -D latex_paper_size=letter
+PAPEROPT_a4     = -D latex_elements.papersize=a4
+PAPEROPT_letter = -D latex_elements.papersize=letter
 ALLSPHINXOPTS   = -W -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .


### PR DESCRIPTION
`latex_paper_size` is deprecated as of Sphinx 1.5.  This fails any build that happens to mention the documentation.