### PR TITLE
[swift-4.0-branch][overlay] Fix CMTimeRange.isValid

### DIFF
--- a/stdlib/public/SDK/CoreMedia/CMTimeRange.swift
+++ b/stdlib/public/SDK/CoreMedia/CMTimeRange.swift
@@ -29,7 +29,9 @@ extension CMTimeRange {
 
   public var isValid: Bool {
     return self.start.isValid &&
-      self.duration.isValid && (self.duration.epoch == 0)
+      self.duration.isValid &&
+      (self.duration.epoch == 0) &&
+      (self.duration.value >= 0)
   }
 
   public var isIndefinite: Bool {


### PR DESCRIPTION
* Explanation: Swift Overlay implementation of CMTimeRange.isValid behaves differently from the similar C API.
* Risk: Minimal
* Reviewed By: Ben Cohen
* Testing: Automated test suite
* Directions for QA: N/A
* Radar: <rdar://problem/32473214>