### PR TITLE
[ClangImporter] Test for not being in a module correctly.

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -1768,10 +1768,10 @@ shouldSuppressGenericParamsImport(const LangOptions &langOpts,
   // the SwiftImportAsNonGeneric API note. Once we can guarantee that that
   // attribute is present in all contexts, we can remove this check.
   auto isFromFoundationModule = [](const clang::Decl *decl) -> bool {
-    Optional<clang::Module *> module = getClangSubmoduleForDecl(decl);
+    clang::Module *module = getClangSubmoduleForDecl(decl).getValue();
     if (!module)
       return false;
-    return module.getValue()->getTopLevelModuleName() == "Foundation";
+    return module->getTopLevelModuleName() == "Foundation";
   };
 
   if (langOpts.isSwiftVersion3() || isFromFoundationModule(decl)) {

--- a/test/ClangImporter/MixedSource/Inputs/mixed-target/header.h
+++ b/test/ClangImporter/MixedSource/Inputs/mixed-target/header.h
@@ -75,3 +75,8 @@ typedef int NameInCategory;
 @interface ClassThatHasAProtocolTypedPropertyButMembersAreNeverLoaded
 @property (weak) id <ForwardProtoFromOtherFile> weakProtoProp;
 @end
+
+
+@interface GenericObjCClass<Param : id <ForwardProto>> : Base
+- (instancetype)init;
+@end

--- a/test/ClangImporter/MixedSource/mixed-target-using-header-swift4.swift
+++ b/test/ClangImporter/MixedSource/mixed-target-using-header-swift4.swift
@@ -1,0 +1,4 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/../Inputs/custom-modules -import-objc-header %S/Inputs/mixed-target/header.h -typecheck -primary-file %S/mixed-target-using-header.swift %S/Inputs/mixed-target/other-file.swift -disable-objc-attr-requires-foundation-module -verify -swift-version 4
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/../Inputs/custom-modules -import-objc-header %S/Inputs/mixed-target/header.h -emit-sil -primary-file %S/mixed-target-using-header.swift %S/Inputs/mixed-target/other-file.swift -disable-objc-attr-requires-foundation-module -o /dev/null -D SILGEN -swift-version 4
+
+// REQUIRES: objc_interop

--- a/test/ClangImporter/MixedSource/mixed-target-using-header.swift
+++ b/test/ClangImporter/MixedSource/mixed-target-using-header.swift
@@ -75,6 +75,11 @@ func testProtocolNamingConflict() {
   d = c // expected-error {{cannot assign value of type 'ConflictingName2?' to type 'ConflictingName2Protocol?'}}
   _ = d
 }
+
+func testObjCGenerics() {
+  _ = GenericObjCClass<ForwardProtoAdopter>()
+  _ = GenericObjCClass<Base>() // expected-error {{type 'Base' does not conform to protocol 'ForwardProto'}}
+}
 #endif
 
 func testDeclsNestedInObjCContainers() {


### PR DESCRIPTION
For the `Optional<Module *>` returned by getClangSubmoduleForDecl, the outside Optional specifies whether there's an answer at all. That answer can still be null if the declaration comes from a bridging header.  In this particular case, we're guaranteed to get an answer, but that answer may be null.

rdar://problem/32463543