### PR TITLE
Update SK_LastScoreKind to SK_KeyPathSubscript.

### DIFF
--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -417,7 +417,7 @@ enum ScoreKind {
   /// A key path application subscript.
   SK_KeyPathSubscript,
   
-  SK_LastScoreKind = SK_EmptyExistentialConversion,
+  SK_LastScoreKind = SK_KeyPathSubscript,
 };
 
 /// The number of score kinds.

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -230,6 +230,63 @@ func testKeyPathSubscript(readonly: Z, writable: inout Z,
   writable[keyPath: akp] = anyqSink2 // expected-error{{cannot assign to immutable}}
 }
 
+struct ZwithSubscript {
+  subscript(keyPath: KeyPath<ZwithSubscript, Int>) -> Int { return 0 }
+  subscript(keyPath: WritableKeyPath<ZwithSubscript, Int>) -> Int { return 0 }
+  subscript(keyPath: ReferenceWritableKeyPath<ZwithSubscript, Int>) -> Int { return 0 }
+  subscript(keyPath: PartialKeyPath<ZwithSubscript>) -> Any { return 0 }
+}
+
+func testKeyPathSubscript(readonly: ZwithSubscript, writable: inout ZwithSubscript,
+                          kp: KeyPath<ZwithSubscript, Int>,
+                          wkp: WritableKeyPath<ZwithSubscript, Int>,
+                          rkp: ReferenceWritableKeyPath<ZwithSubscript, Int>) {
+  var sink: Int
+  sink = readonly[keyPath: kp]
+  sink = writable[keyPath: kp]
+  sink = readonly[keyPath: wkp]
+  sink = writable[keyPath: wkp]
+  sink = readonly[keyPath: rkp]
+  sink = writable[keyPath: rkp]
+
+  // FIXME: keypath application rather than subscripting if subscript parameter defined without a separate internal name
+  readonly[keyPath: kp] = sink // expected-error{{cannot assign to immutable expression of type 'Int'}}
+  // FIXME: keypath application rather than subscripting if subscript parameter defined without a separate internal name
+  writable[keyPath: kp] = sink // expected-error{{cannot assign to immutable expression of type 'Int'}}
+  // FIXME: keypath application rather than subscripting if subscript parameter defined without a separate internal name
+  readonly[keyPath: wkp] = sink // expected-error{{cannot assign to immutable expression of type 'Int'}}
+  // FIXME: silently falls back to keypath application, which seems inconsistent
+  writable[keyPath: wkp] = sink
+  // FIXME: silently falls back to keypath application, which seems inconsistent
+  readonly[keyPath: rkp] = sink
+  // FIXME: silently falls back to keypath application, which seems inconsistent
+  writable[keyPath: rkp] = sink
+
+  let pkp: PartialKeyPath = rkp
+
+  var anySink1 = readonly[keyPath: pkp]
+  expect(&anySink1, toHaveType: Exactly<Any>.self)
+  var anySink2 = writable[keyPath: pkp]
+  expect(&anySink2, toHaveType: Exactly<Any>.self)
+
+  // FIXME: keypath application rather than subscripting if subscript parameter defined without a separate internal name
+  readonly[keyPath: pkp] = anySink1 // expected-error{{cannot assign to immutable expression of type 'Any'}}
+  // FIXME: keypath application rather than subscripting if subscript parameter defined without a separate internal name
+  writable[keyPath: pkp] = anySink2 // expected-error{{cannot assign to immutable expression of type 'Any'}}
+
+  let akp: AnyKeyPath = pkp
+
+  var anyqSink1 = readonly[keyPath: akp]
+  expect(&anyqSink1, toHaveType: Exactly<Any?>.self)
+  var anyqSink2 = writable[keyPath: akp]
+  expect(&anyqSink2, toHaveType: Exactly<Any?>.self)
+
+  // FIXME: silently falls back to keypath application, which seems inconsistent
+  readonly[keyPath: akp] = anyqSink1 // expected-error{{cannot assign to immutable}}
+  // FIXME: silently falls back to keypath application, which seems inconsistent
+  writable[keyPath: akp] = anyqSink2 // expected-error{{cannot assign to immutable}}
+}
+
 func testKeyPathSubscriptMetatype(readonly: Z.Type, writable: inout Z.Type,
                                   kp: KeyPath<Z.Type, Int>,
                                   wkp: WritableKeyPath<Z.Type, Int>,


### PR DESCRIPTION
When this score kind was added, the marker for the last score kind was
not updated. As a result, increasing the score for SK_KeyPathSubscript
was not actually having an effect.

Add tests that include a type with subscripts that also take the key
paths as their argument with an identical argument label ("keyPath").

These tests show that we're actually falling back on the keypath
application in many cases despite the score kind specific to keypath
application. I'll open a couple new JIRAs to investigate this
behavior.

The update to SK_LastScoreKind results in fixing a crash in these tests
that happens as a result of an assumption in CSRanking.cpp that if we're
comparing two solutions we end up with decls for overloads to compare,
which isn't the case here due to the keypath application.
