### PR TITLE
Add a size heuristic to the Space Engine

### DIFF
--- a/test/Sema/exhaustive_switch.swift
+++ b/test/Sema/exhaustive_switch.swift
@@ -329,7 +329,7 @@ func checkDiagnosticMinimality(x: Runcible?) {
   case (.hat, .spoon):
     break
   }
-  
+
   switch (x!, x!) { // expected-error {{switch must be exhaustive}}
   // expected-note@-1 {{add missing case: '(.fork, _)'}}
   // expected-note@-2 {{add missing case: '(.hat, .spoon)'}}
@@ -341,5 +341,160 @@ func checkDiagnosticMinimality(x: Runcible?) {
     break
   case (.hat, .hat):
     break
+  }
+}
+
+enum LargeSpaceEnum {
+  case case0
+  case case1
+  case case2
+  case case3
+  case case4
+  case case5
+  case case6
+  case case7
+  case case8
+  case case9
+  case case10
+}
+
+func notQuiteBigEnough() -> Bool {
+  switch (LargeSpaceEnum.case1, LargeSpaceEnum.case2) { // expected-error {{switch must be exhaustive}}
+  // expected-note@-1 110 {{add missing case:}}
+  case (.case0, .case0): return true
+  case (.case1, .case1): return true
+  case (.case2, .case2): return true
+  case (.case3, .case3): return true
+  case (.case4, .case4): return true
+  case (.case5, .case5): return true
+  case (.case6, .case6): return true
+  case (.case7, .case7): return true
+  case (.case8, .case8): return true
+  case (.case9, .case9): return true
+  case (.case10, .case10): return true
+  }
+}
+
+enum OverlyLargeSpaceEnum {
+  case case0
+  case case1
+  case case2
+  case case3
+  case case4
+  case case5
+  case case6
+  case case7
+  case case8
+  case case9
+  case case10
+  case case11
+}
+
+func quiteBigEnough() -> Bool {
+  switch (OverlyLargeSpaceEnum.case1, OverlyLargeSpaceEnum.case2) { // expected-error {{switch must be exhaustive}}
+  // expected-note@-1 {{do you want to add a default clause?}}
+  case (.case0, .case0): return true
+  case (.case1, .case1): return true
+  case (.case2, .case2): return true
+  case (.case3, .case3): return true
+  case (.case4, .case4): return true
+  case (.case5, .case5): return true
+  case (.case6, .case6): return true
+  case (.case7, .case7): return true
+  case (.case8, .case8): return true
+  case (.case9, .case9): return true
+  case (.case10, .case10): return true
+  case (.case11, .case11): return true
+  }
+
+  // No diagnostic
+  switch (OverlyLargeSpaceEnum.case1, OverlyLargeSpaceEnum.case2) { // expected-error {{switch must be exhaustive}}
+  // expected-note@-1 {{do you want to add a default clause?}}
+  case (.case0, _): return true
+  case (.case1, _): return true
+  case (.case2, _): return true
+  case (.case3, _): return true
+  case (.case4, _): return true
+  case (.case5, _): return true
+  case (.case6, _): return true
+  case (.case7, _): return true
+  case (.case8, _): return true
+  case (.case9, _): return true
+  case (.case10, _): return true
+  }
+
+
+  // No diagnostic
+  switch (OverlyLargeSpaceEnum.case1, OverlyLargeSpaceEnum.case2) {
+  case (.case0, _): return true
+  case (.case1, _): return true
+  case (.case2, _): return true
+  case (.case3, _): return true
+  case (.case4, _): return true
+  case (.case5, _): return true
+  case (.case6, _): return true
+  case (.case7, _): return true
+  case (.case8, _): return true
+  case (.case9, _): return true
+  case (.case10, _): return true
+  case (.case11, _): return true
+  }
+
+  // No diagnostic
+  switch (OverlyLargeSpaceEnum.case1, OverlyLargeSpaceEnum.case2) {
+  case (_, .case0): return true
+  case (_, .case1): return true
+  case (_, .case2): return true
+  case (_, .case3): return true
+  case (_, .case4): return true
+  case (_, .case5): return true
+  case (_, .case6): return true
+  case (_, .case7): return true
+  case (_, .case8): return true
+  case (_, .case9): return true
+  case (_, .case10): return true
+  case (_, .case11): return true
+  }
+
+  // No diagnostic
+  switch (OverlyLargeSpaceEnum.case1, OverlyLargeSpaceEnum.case2) {
+  case (_, _): return true
+  }
+
+  // No diagnostic
+  switch (OverlyLargeSpaceEnum.case1, OverlyLargeSpaceEnum.case2) {
+  case (.case0, .case0): return true
+  case (.case1, .case1): return true
+  case (.case2, .case2): return true
+  case (.case3, .case3): return true
+  case _: return true
+  }
+}
+
+indirect enum InfinitelySized {
+  case one
+  case two
+  case recur(InfinitelySized)
+  case mutualRecur(MutuallyRecursive, InfinitelySized)
+}
+
+indirect enum MutuallyRecursive {
+  case one
+  case two
+  case recur(MutuallyRecursive)
+  case mutualRecur(InfinitelySized, MutuallyRecursive)
+}
+
+func infinitelySized() -> Bool {
+  switch (InfinitelySized.one, InfinitelySized.one) { // expected-error {{switch must be exhaustive}}
+  // expected-note@-1 10 {{add missing case:}}
+  case (.one, .one): return true
+  case (.two, .two): return true
+  }
+  
+  switch (MutuallyRecursive.one, MutuallyRecursive.one) { // expected-error {{switch must be exhaustive}}
+  // expected-note@-1 10 {{add missing case:}}
+  case (.one, .one): return true
+  case (.two, .two): return true
   }
 }


### PR DESCRIPTION
<rdar://32480026>

This is a particularly tricky tradeoff to have to make here.  On the one
hand, we want diagnostics about incomplete patterns to provide as much
information as possible.  On the other, pattern matrices grow
quasi-factorially in the size of the argument.  That is, an enum with 10
cases that is switched on as a 2-tuple/argument list creates a total
subspace covering of size 100.  For sufficiently large inputs, this can
DOS the Swift compiler.

It is simply not useful to present more than about 100 notes to the
user, nor is it useful to waste an enormous amount of time trying to
compute these subspaces for the limited information the diagnostic will
provide.  Instead, short circuit if the size of the enum is above some
arbitrary threshold (currently 128) and just offer to add a 'default'.

Notably, this change is not *technically* source compatible in that it
ignores the new '@_downgrade_exhaustivity_check'. However to hit up
against this heuristic would require the user to be switching over four
DispatchTimeIntervals in a quadruple or using an equivalently-sized
enormous enum case.  At which point we're hitting on the very reason
this heuristic exists.

There are definitely other, more informative, paths that we can take
here.  GHC, for example, seems to run a highly limited form of space
subtraction when the input space is too large, and simply reports the
top 3 missing cases along with some ellipses.  For now, I just want to
cut off this hang in the compiler.
