### PR TITLE
Fixed code style issues reported by python-lint.

### DIFF
--- a/utils/process-stats-dir.py
+++ b/utils/process-stats-dir.py
@@ -291,4 +291,5 @@ def main():
             show_incrementality(args)
     return None
 
+
 sys.exit(main())

--- a/utils/vim/swift-format.py
+++ b/utils/vim/swift-format.py
@@ -91,5 +91,6 @@ def main(argc, argv):
         if op[0] is not 'equal':
             vim.current.buffer[op[1]:op[2]] = lines[op[3]:op[4]]
 
+
 if __name__ == '__main__':
     main(len(sys.argv), sys.argv)


### PR DESCRIPTION
This PR fixes coding style issues reported by python-lint, that were introduced in #8610 by @compnerd and #9474 by @graydon

I've done the mistake of forgetting to run `swift/utils/python_lint.py ` before commiting modified python sources, too.

How come these "errors" were in the tree for 22 and 21 days, respectively, and didn't break the build? I thought the validation-tests would catch this hard.

@moiseev Please review, test and merge (@ci-swift doesn't listen to me yet...)