### PR TITLE
Document the added lit substitution swift_src_root

### DIFF
--- a/docs/Testing.rst
+++ b/docs/Testing.rst
@@ -385,6 +385,9 @@ Other substitutions:
 * ``%platform-sdk-overlay-dir``: absolute path of the directory where the SDK
   overlay module files for the target platform are stored.
 
+* ``%swift_src_root``: absolute path of the directory where the Swift source
+  code is stored.
+
 * ``%{python}``: run the same Python interpreter that's being used to run the
   current ``lit`` test.
 


### PR DESCRIPTION
`%swift_src_root`: absolute path to the directory where the Swift source code is stored.
The substitution was introduced in #8641, I have used it again in #9999, I guess it makes sense to properly document it, too...