### PR TITLE
swift-api-digester: detect the move of static members only.

### DIFF
--- a/include/swift/IDE/APIDigesterData.h
+++ b/include/swift/IDE/APIDigesterData.h
@@ -219,6 +219,7 @@ public:
 //
 enum class TypeMemberDiffItemSubKind {
   SimpleReplacement,
+  QualifiedReplacement,
   GlobalFuncToStaticProperty,
   HoistSelfOnly,
   HoistSelfAndRemoveParam,

--- a/lib/IDE/APIDigesterData.cpp
+++ b/lib/IDE/APIDigesterData.cpp
@@ -134,9 +134,12 @@ swift::ide::api::TypeMemberDiffItem::getSubKind() const {
     } else if (ToProperty) {
       assert(OldName.argSize() == 1);
       return TypeMemberDiffItemSubKind::HoistSelfAndUseProperty;
-    } else {
+    } else if (oldTypeName.empty()) {
       assert(NewName.argSize() + 1 == OldName.argSize());
       return TypeMemberDiffItemSubKind::HoistSelfOnly;
+    } else {
+      assert(NewName.argSize() == OldName.argSize());
+      return TypeMemberDiffItemSubKind::QualifiedReplacement;
     }
   } else if (ToProperty) {
     assert(OldName.argSize() == 0);

--- a/lib/Migrator/APIDiffMigratorPass.cpp
+++ b/lib/Migrator/APIDiffMigratorPass.cpp
@@ -439,7 +439,8 @@ struct APIDiffMigratorPass : public ASTMigratorPass, public SourceEntityWalker {
     }
     if (!Item)
       return false;
-    if (Item->Subkind == TypeMemberDiffItemSubKind::SimpleReplacement)
+    if (Item->Subkind == TypeMemberDiffItemSubKind::SimpleReplacement ||
+        Item->Subkind == TypeMemberDiffItemSubKind::QualifiedReplacement)
       return false;
 
     if (Item->Subkind == TypeMemberDiffItemSubKind::GlobalFuncToStaticProperty) {
@@ -490,6 +491,7 @@ struct APIDiffMigratorPass : public ASTMigratorPass, public SourceEntityWalker {
     switch (Item->Subkind) {
     case TypeMemberDiffItemSubKind::GlobalFuncToStaticProperty:
     case TypeMemberDiffItemSubKind::SimpleReplacement:
+    case TypeMemberDiffItemSubKind::QualifiedReplacement:
       llvm_unreachable("should be handled elsewhere");
     case TypeMemberDiffItemSubKind::HoistSelfOnly:
       // we are done here.

--- a/test/api-digester/Inputs/APINotesLeft/APINotesTest.apinotes
+++ b/test/api-digester/Inputs/APINotesLeft/APINotesTest.apinotes
@@ -2,3 +2,6 @@ Name: APINotesTest
 Globals:
   - Name: ANTGlobalValue
     SwiftName: OldType.oldMember
+Protocols:
+  - Name: TypeWithMethod
+    SwiftName: SwiftTypeWithMethodLeft

--- a/test/api-digester/Inputs/APINotesLeft/APINotesTest.h
+++ b/test/api-digester/Inputs/APINotesLeft/APINotesTest.h
@@ -4,3 +4,8 @@ extern int ANTGlobalValue;
 @end
 @interface OldType
 @end
+
+@protocol TypeWithMethod
+  -(void) minusPrint;
+  +(void) plusPrint;
+@end

--- a/test/api-digester/Inputs/APINotesRight/APINotesTest.apinotes
+++ b/test/api-digester/Inputs/APINotesRight/APINotesTest.apinotes
@@ -2,3 +2,6 @@ Name: APINotesTest
 Globals:
   - Name: ANTGlobalValue
     SwiftName: NewType.newMember
+Protocols:
+  - Name: TypeWithMethod
+    SwiftName: SwiftTypeWithMethodRight

--- a/test/api-digester/Inputs/APINotesRight/APINotesTest.h
+++ b/test/api-digester/Inputs/APINotesRight/APINotesTest.h
@@ -4,3 +4,8 @@ extern int ANTGlobalValue;
 @end
 @interface OldType
 @end
+
+@protocol TypeWithMethod
+  -(void) minusPrint;
+  +(void) plusPrint;
+@end

--- a/test/api-digester/Outputs/apinotes-migrator-gen.json
+++ b/test/api-digester/Outputs/apinotes-migrator-gen.json
@@ -6,5 +6,13 @@
     "OldTypeName": "OldType",
     "NewPrintedName": "newMember",
     "NewTypeName": "NewType"
+  },
+  {
+    "DiffItemKind": "TypeMemberDiffItem",
+    "Usr": "c:objc(pl)TypeWithMethod(cm)plusPrint",
+    "OldPrintedName": "plusPrint()",
+    "OldTypeName": "SwiftTypeWithMethodLeft",
+    "NewPrintedName": "plusPrint()",
+    "NewTypeName": "SwiftTypeWithMethodRight"
   }
 ]


### PR DESCRIPTION
This patch restricts the detection of moved members to be static members,
since only in this case we need to update qualified access to
them. The move of instance members will be either handled by rename or
we don't need to update anything at all.

Additionally, this patch introduces a sub-kind of type member diff item
called qualified replacement to describe the aforementioned case. However,
the migrator part has not started to honor this sub-kind yet.

rdar://32466196
