### PR TITLE
[Migrator] Don't pick up extraneous argument label fix-it

### DIFF
--- a/include/swift/Migrator/FixitFilter.h
+++ b/include/swift/Migrator/FixitFilter.h
@@ -96,6 +96,12 @@ struct FixitFilter {
       return false;
     }
 
+    // The type-checker can erroneously report this diagnostic in the case of
+    // mismatching closure arguments to things that now take a tuple via SE-0110.
+    if (Info.ID == diag::extra_argument_labels.ID) {
+      return false;
+    }
+
     if (Kind == DiagnosticKind::Error)
       return true;
 

--- a/test/Migrator/no_extraneous_argument_labels.swift
+++ b/test/Migrator/no_extraneous_argument_labels.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-frontend -typecheck %s -swift-version 3
+// RUN: rm -rf %t && mkdir -p %t && %target-swift-frontend -c -primary-file %s -emit-migrated-file-path %t/no_extraneous_argument_labels.result -swift-version 3 -o /dev/null
+// RUN: diff -u %s.expected %t/no_extraneous_argument_labels.result
+// RUN: not %target-swift-frontend -typecheck %s.expected -swift-version 4
+
+func foo(_ oc: [String]) {
+  var args: [String] = []
+  let dictionary: [String: String] = [:]
+  args.append(contentsOf: oc.map { orderedColumn in
+    dictionary.first { (column, value) in true }!.value
+  })
+}

--- a/test/Migrator/no_extraneous_argument_labels.swift.expected
+++ b/test/Migrator/no_extraneous_argument_labels.swift.expected
@@ -1,0 +1,12 @@
+// RUN: %target-swift-frontend -typecheck %s -swift-version 3
+// RUN: rm -rf %t && mkdir -p %t && %target-swift-frontend -c -primary-file %s -emit-migrated-file-path %t/no_extraneous_argument_labels.result -swift-version 3 -o /dev/null
+// RUN: diff -u %s.expected %t/no_extraneous_argument_labels.result
+// RUN: not %target-swift-frontend -typecheck %s.expected -swift-version 4
+
+func foo(_ oc: [String]) {
+  var args: [String] = []
+  let dictionary: [String: String] = [:]
+  args.append(contentsOf: oc.map { orderedColumn in
+    dictionary.first { (column, value) in true }!.value
+  })
+}


### PR DESCRIPTION
This can be incorrectly reported by the type-checker when
argument arity doesn't match in trailing closure arguments.
This diagnostic isn't generally useful for the migrator.

rdar://problem/32477119
rdar://problem/32432254