### PR TITLE
[Migrator] Add `return` keyword when adding temp bindings in single-e…

### DIFF
--- a/test/Migrator/tuple-arguments.swift
+++ b/test/Migrator/tuple-arguments.swift
@@ -29,6 +29,15 @@ test6({ (_, _) in })
 test6({ (x:Int, y:Int) in })
 test6({ (_, _) ->() in })
 
+func test8(_: ((Int, Int)) -> Int) {}
+test8 { (_, _) -> Int in 2 }
+test8 { (x, y) in x }
+
+func isEven(_ x: Int) -> Bool { return x % 2 == 0 }
+let items = Array(zip(0..<10, 0..<10))
+_ = items.filter { (_, x) in isEven(x) }
+_ = items.filter { _ in true }
+
 func toString(indexes: Int?...) -> String {
   let _ = indexes.enumerated().flatMap({ (i: Int, index: Int?) -> String? in
     let _: Int = i

--- a/test/Migrator/tuple-arguments.swift.expected
+++ b/test/Migrator/tuple-arguments.swift.expected
@@ -26,11 +26,20 @@ func test7(_: ((Int, Int, Int)) -> ()) {}
 test7({ let (x,y,z) = $0; })
 test6({ let (x, y) = $0; })
 test6({ let (_, _) = $0; })
-test6({ (__val:(Int, Int)) in let (x,y) = __val;  })
-test6({ (__val:(Int, Int)) ->() in let (_,_) = __val;  })
+test6({ (__val:(Int, Int)) in let (x,y) = __val; })
+test6({ (__val:(Int, Int)) ->() in let (_,_) = __val; })
+
+func test8(_: ((Int, Int)) -> Int) {}
+test8 { (__val:(Int, Int)) -> Int in let (_,_) = __val; return 2 }
+test8 { let (x, y) = $0; return x }
+
+func isEven(_ x: Int) -> Bool { return x % 2 == 0 }
+let items = Array(zip(0..<10, 0..<10))
+_ = items.filter { let (_, x) = $0; return isEven(x) }
+_ = items.filter { _ in true }
 
 func toString(indexes: Int?...) -> String {
-  let _ = indexes.enumerated().flatMap({ (__val:(Int, Int?)) -> String? in let (i,index) = __val; 
+  let _ = indexes.enumerated().flatMap({ (__val:(Int, Int?)) -> String? in let (i,index) = __val;
     let _: Int = i
     if index != nil {}
     return ""


### PR DESCRIPTION
…xpression closures

The migrator pass to add tuple destructuring that now needs to add a
`return` statement for closures that were once single-expression but are
no longer because of the added statement to do the binding.

rdar://problem/32433206