### PR TITLE
[4.0] Add a size heuristic to the Space Engine

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -286,6 +286,11 @@ SIMPLE_DECL_ATTR(NSKeyedArchiverEncodeNonGenericSubclassesOnly,
                  OnClass | NotSerialized | LongAttribute,
                  /*Not serialized */ 70)
 
+// HACK: Attribute needed to preserve source compatibility by downgrading errors
+// due to an SDK change in Dispatch
+SIMPLE_DECL_ATTR(_downgrade_exhaustivity_check, DowngradeExhaustivityCheck,
+                 OnEnumElement | LongAttribute | UserInaccessible, 71)
+
 #undef TYPE_ATTR
 #undef DECL_ATTR_ALIAS
 #undef SIMPLE_DECL_ATTR

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3701,6 +3701,10 @@ NOTE(missing_particular_case,none,
 WARNING(redundant_particular_case,none,
         "case is already handled by previous patterns; consider removing it",())
 
+// HACK: Downgrades the above to warnings if any of the cases is marked
+// @_downgrade_exhaustivity_check.
+WARNING(non_exhaustive_switch_warn_swift3,none, "switch must be exhaustive", ())
+
 #ifndef DIAG_NO_UNDEF
 # if defined(DIAG)
 #  undef DIAG

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -840,6 +840,8 @@ namespace {
 
     void visitEnumElementDecl(EnumElementDecl *EED) {
       printCommon(EED, "enum_element_decl");
+      if (EED->getAttrs().hasAttribute<DowngradeExhaustivityCheckAttr>())
+        OS << "@_downgrade_exhaustivity_check";
       PrintWithColorRAII(OS, ParenthesisColor) << ')';
     }
 

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -506,6 +506,10 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
     Printer.printAttrName("@_staticInitializeObjCMetadata");
     break;
 
+  case DAK_DowngradeExhaustivityCheck:
+    Printer.printAttrName("@_downgrade_exhaustivity_check");
+    break;
+    
   case DAK_Count:
     llvm_unreachable("exceed declaration attribute kinds");
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -107,6 +107,7 @@ public:
   IGNORED_ATTR(NSKeyedArchiverClassName)
   IGNORED_ATTR(StaticInitializeObjCMetadata)
   IGNORED_ATTR(NSKeyedArchiverEncodeNonGenericSubclassesOnly)
+  IGNORED_ATTR(DowngradeExhaustivityCheck)
 #undef IGNORED_ATTR
 
   // @noreturn has been replaced with a 'Never' return type.
@@ -784,6 +785,7 @@ public:
     IGNORED_ATTR(ObjCMembers)
     IGNORED_ATTR(StaticInitializeObjCMetadata)
     IGNORED_ATTR(NSKeyedArchiverEncodeNonGenericSubclassesOnly)
+    IGNORED_ATTR(DowngradeExhaustivityCheck)
 #undef IGNORED_ATTR
 
   void visitAvailableAttr(AvailableAttr *attr);

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -6103,6 +6103,7 @@ public:
     UNINTERESTING_ATTR(NSKeyedArchiverClassName)
     UNINTERESTING_ATTR(StaticInitializeObjCMetadata)
     UNINTERESTING_ATTR(NSKeyedArchiverEncodeNonGenericSubclassesOnly)
+    UNINTERESTING_ATTR(DowngradeExhaustivityCheck)
 #undef UNINTERESTING_ATTR
 
     void visitAvailableAttr(AvailableAttr *attr) {

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5915,7 +5915,7 @@ static bool hasGenericAncestry(ClassDecl *classDecl) {
 /// Infer the attribute tostatic-initialize the Objective-C metadata for the
 /// given class, if needed.
 static void inferStaticInitializeObjCMetadata(ClassDecl *classDecl,
-                                               bool requiresNSCodingAttr) {
+                                              bool requiresNSCodingAttr) {
   // If we already have the attribute, there's nothing to do.
   if (classDecl->getAttrs().hasAttribute<StaticInitializeObjCMetadataAttr>())
     return;

--- a/test/SILGen/downgrade_exhaustivity_swift3.swift
+++ b/test/SILGen/downgrade_exhaustivity_swift3.swift
@@ -1,0 +1,48 @@
+// RUN: %target-swift-frontend -swift-version 3 -emit-silgen %s | %FileCheck %s
+
+enum Downgradable {
+  case spoon
+  case hat
+  @_downgrade_exhaustivity_check
+  case fork
+}
+
+// CHECK-LABEL: sil hidden @_T029downgrade_exhaustivity_swift343testDowngradableOmittedPatternIsUnreachableyAA0E0OSg3pat_tF
+func testDowngradableOmittedPatternIsUnreachable(pat : Downgradable?) {
+  // CHECK: switch_enum {{%.*}} : $Downgradable, case #Downgradable.spoon!enumelt: [[CASE1:bb[0-9]+]], case #Downgradable.hat!enumelt: [[CASE2:bb[0-9]+]], default [[DEFAULT_CASE:bb[0-9]+]]
+  switch pat! {
+  // CHECK: [[CASE1]]:
+  case .spoon:
+    break
+  // CHECK: [[CASE2]]:
+  case .hat:
+    break
+  // CHECK: [[DEFAULT_CASE]]:
+  // CHECK-NEXT:   unreachable
+  }
+  
+  // CHECK: switch_enum {{%[0-9]+}} : $Downgradable, case #Downgradable.spoon!enumelt: {{bb[0-9]+}}, case #Downgradable.hat!enumelt: {{bb[0-9]+}}, default [[TUPLE_DEFAULT_CASE_1:bb[0-9]+]]
+  // CHECK: switch_enum [[Y:%[0-9]+]] : $Downgradable, case #Downgradable.spoon!enumelt: {{bb[0-9]+}}, case #Downgradable.hat!enumelt: {{bb[0-9]+}}, default [[TUPLE_DEFAULT_CASE_2:bb[0-9]+]]
+  switch (pat!, pat!) {
+  case (.spoon, .spoon):
+    break
+  case (.spoon, .hat):
+    break
+  case (.hat, .spoon):
+    break
+  case (.hat, .hat):
+    break
+  // CHECK: [[TUPLE_DEFAULT_CASE_2]]:
+  // CHECK-NEXT:   unreachable
+    
+  // CHECK: switch_enum [[Y]] : $Downgradable, case #Downgradable.spoon!enumelt: {{bb[0-9]+}}, case #Downgradable.hat!enumelt: {{bb[0-9]+}}, default [[TUPLE_DEFAULT_CASE_3:bb[0-9]+]]
+    
+  // CHECK: [[TUPLE_DEFAULT_CASE_3]]:
+  // CHECK-NEXT:   unreachable
+    
+  // CHECK: [[TUPLE_DEFAULT_CASE_1]]:
+  // CHECK-NEXT:   unreachable
+  }
+  
+}
+

--- a/test/Sema/exhaustive_switch.swift
+++ b/test/Sema/exhaustive_switch.swift
@@ -329,7 +329,7 @@ func checkDiagnosticMinimality(x: Runcible?) {
   case (.hat, .spoon):
     break
   }
-  
+
   switch (x!, x!) { // expected-error {{switch must be exhaustive}}
   // expected-note@-1 {{add missing case: '(.fork, _)'}}
   // expected-note@-2 {{add missing case: '(.hat, .spoon)'}}
@@ -341,5 +341,160 @@ func checkDiagnosticMinimality(x: Runcible?) {
     break
   case (.hat, .hat):
     break
+  }
+}
+
+enum LargeSpaceEnum {
+  case case0
+  case case1
+  case case2
+  case case3
+  case case4
+  case case5
+  case case6
+  case case7
+  case case8
+  case case9
+  case case10
+}
+
+func notQuiteBigEnough() -> Bool {
+  switch (LargeSpaceEnum.case1, LargeSpaceEnum.case2) { // expected-error {{switch must be exhaustive}}
+  // expected-note@-1 110 {{add missing case:}}
+  case (.case0, .case0): return true
+  case (.case1, .case1): return true
+  case (.case2, .case2): return true
+  case (.case3, .case3): return true
+  case (.case4, .case4): return true
+  case (.case5, .case5): return true
+  case (.case6, .case6): return true
+  case (.case7, .case7): return true
+  case (.case8, .case8): return true
+  case (.case9, .case9): return true
+  case (.case10, .case10): return true
+  }
+}
+
+enum OverlyLargeSpaceEnum {
+  case case0
+  case case1
+  case case2
+  case case3
+  case case4
+  case case5
+  case case6
+  case case7
+  case case8
+  case case9
+  case case10
+  case case11
+}
+
+func quiteBigEnough() -> Bool {
+  switch (OverlyLargeSpaceEnum.case1, OverlyLargeSpaceEnum.case2) { // expected-error {{switch must be exhaustive}}
+  // expected-note@-1 {{do you want to add a default clause?}}
+  case (.case0, .case0): return true
+  case (.case1, .case1): return true
+  case (.case2, .case2): return true
+  case (.case3, .case3): return true
+  case (.case4, .case4): return true
+  case (.case5, .case5): return true
+  case (.case6, .case6): return true
+  case (.case7, .case7): return true
+  case (.case8, .case8): return true
+  case (.case9, .case9): return true
+  case (.case10, .case10): return true
+  case (.case11, .case11): return true
+  }
+
+  // No diagnostic
+  switch (OverlyLargeSpaceEnum.case1, OverlyLargeSpaceEnum.case2) { // expected-error {{switch must be exhaustive}}
+  // expected-note@-1 {{do you want to add a default clause?}}
+  case (.case0, _): return true
+  case (.case1, _): return true
+  case (.case2, _): return true
+  case (.case3, _): return true
+  case (.case4, _): return true
+  case (.case5, _): return true
+  case (.case6, _): return true
+  case (.case7, _): return true
+  case (.case8, _): return true
+  case (.case9, _): return true
+  case (.case10, _): return true
+  }
+
+
+  // No diagnostic
+  switch (OverlyLargeSpaceEnum.case1, OverlyLargeSpaceEnum.case2) {
+  case (.case0, _): return true
+  case (.case1, _): return true
+  case (.case2, _): return true
+  case (.case3, _): return true
+  case (.case4, _): return true
+  case (.case5, _): return true
+  case (.case6, _): return true
+  case (.case7, _): return true
+  case (.case8, _): return true
+  case (.case9, _): return true
+  case (.case10, _): return true
+  case (.case11, _): return true
+  }
+
+  // No diagnostic
+  switch (OverlyLargeSpaceEnum.case1, OverlyLargeSpaceEnum.case2) {
+  case (_, .case0): return true
+  case (_, .case1): return true
+  case (_, .case2): return true
+  case (_, .case3): return true
+  case (_, .case4): return true
+  case (_, .case5): return true
+  case (_, .case6): return true
+  case (_, .case7): return true
+  case (_, .case8): return true
+  case (_, .case9): return true
+  case (_, .case10): return true
+  case (_, .case11): return true
+  }
+
+  // No diagnostic
+  switch (OverlyLargeSpaceEnum.case1, OverlyLargeSpaceEnum.case2) {
+  case (_, _): return true
+  }
+
+  // No diagnostic
+  switch (OverlyLargeSpaceEnum.case1, OverlyLargeSpaceEnum.case2) {
+  case (.case0, .case0): return true
+  case (.case1, .case1): return true
+  case (.case2, .case2): return true
+  case (.case3, .case3): return true
+  case _: return true
+  }
+}
+
+indirect enum InfinitelySized {
+  case one
+  case two
+  case recur(InfinitelySized)
+  case mutualRecur(MutuallyRecursive, InfinitelySized)
+}
+
+indirect enum MutuallyRecursive {
+  case one
+  case two
+  case recur(MutuallyRecursive)
+  case mutualRecur(InfinitelySized, MutuallyRecursive)
+}
+
+func infinitelySized() -> Bool {
+  switch (InfinitelySized.one, InfinitelySized.one) { // expected-error {{switch must be exhaustive}}
+  // expected-note@-1 10 {{add missing case:}}
+  case (.one, .one): return true
+  case (.two, .two): return true
+  }
+  
+  switch (MutuallyRecursive.one, MutuallyRecursive.one) { // expected-error {{switch must be exhaustive}}
+  // expected-note@-1 10 {{add missing case:}}
+  case (.one, .one): return true
+  case (.two, .two): return true
   }
 }

--- a/test/attr/attr_downgrade_exhaustivity.swift
+++ b/test/attr/attr_downgrade_exhaustivity.swift
@@ -1,0 +1,150 @@
+// RUN: %target-typecheck-verify-swift -swift-version 3 %s
+
+enum Runcible {
+  case spoon
+  case hat
+  @_downgrade_exhaustivity_check
+  case fork
+}
+
+enum Trioptional {
+  case some(Runcible)
+  case just(Runcible)
+  case none
+}
+
+enum Fungible {
+  case cash
+  case giftCard
+}
+
+func missingCases(x: Runcible?, y: Runcible?, z: Trioptional) {
+  // Should warn in S3 mode that `fork` isn't used
+  switch x! { // expected-warning {{switch must be exhaustive}}
+  // expected-note@-1 {{add missing case: '.fork'}}
+  case .spoon:
+    break
+  case .hat:
+    break
+  }
+
+  // Should warn in S3 mode that `fork` isn't used
+  switch (x!, y!) { // expected-warning {{switch must be exhaustive}}
+  // expected-note@-1 3 {{add missing case:}}
+  case (.spoon, .spoon):
+    break
+  case (.spoon, .hat):
+    break
+  case (.hat, .spoon):
+    break
+  case (.hat, .hat):
+    break
+  }
+  
+  // Should error, since `fork` is used but not totally covered
+  switch (x!, y!) { // expected-error {{switch must be exhaustive}}
+  // expected-note@-1 {{add missing case: '(.fork, .hat)'}}
+  // expected-note@-2 {{add missing case: '(.fork, .fork)'}}
+  // expected-note@-3 {{add missing case: '(.hat, .fork)'}}
+  // expected-note@-4 {{add missing case: '(_, .fork)'}}
+  case (.spoon, .spoon):
+    break
+  case (.spoon, .hat):
+    break
+  case (.hat, .spoon):
+    break
+  case (.hat, .hat):
+    break
+  case (.fork, .spoon):
+    break
+  }
+  
+  // Should error, since `fork` is used but not totally covered
+  switch (x!, y!) { // expected-error {{switch must be exhaustive}}
+  // expected-note@-1 {{add missing case: '(.fork, _)'}}
+  // expected-note@-2 {{add missing case: '(.spoon, .fork)'}}
+  case (.spoon, .spoon):
+    break
+  case (.spoon, .hat):
+    break
+  case (.hat, .spoon):
+    break
+  case (.hat, .hat):
+    break
+  case (.hat, .fork):
+    break
+  }
+  
+  // Should warn in S3 mode that `fork` isn't used
+  switch x { // expected-warning {{switch must be exhaustive}}
+  // expected-note@-1 {{add missing case: '.some(.fork)'}}
+  case .some(.spoon):
+    break
+  case .some(.hat):
+    break
+  case .none:
+    break
+  }
+  
+  // Should warn in S3 mode that `fork` isn't used
+  switch (x, y!) { // expected-warning {{switch must be exhaustive}}
+  // expected-note@-1 {{add missing case: '(.some(.fork), _)'}}
+  // expected-note@-2 {{add missing case: '(.none, .fork)'}}
+  // expected-note@-3 {{add missing case: '(.some(.hat), .fork)'}}
+  // expected-note@-4 {{add missing case: '(_, .fork)'}}
+  case (.some(.spoon), .spoon):
+    break
+  case (.some(.spoon), .hat):
+    break
+  case (.some(.hat), .spoon):
+    break
+  case (.some(.hat), .hat):
+    break
+  case (.none, .spoon):
+    break
+  case (.none, .hat):
+    break
+  }
+
+  // Should warn in S3 mode that `fork` isn't used
+  switch (x, y) { // expected-warning {{switch must be exhaustive}}
+  // expected-note@-1 {{add missing case: '(.some(.fork), _)'}}
+  // expected-note@-2 {{add missing case: '(_, .some(.fork))'}}
+  // expected-note@-3 {{add missing case: '(.some(.hat), .some(.fork))'}}
+  // expected-note@-4 {{add missing case: '(.none, _)'}}
+  case (.some(.spoon), .some(.spoon)):
+    break
+  case (.some(.spoon), .some(.hat)):
+    break
+  case (.some(.spoon), .none):
+    break
+  case (.some(.hat), .some(.spoon)):
+    break
+  case (.some(.hat), .some(.hat)):
+    break
+  case (.some(.hat), .none):
+    break
+  case (.some(.hat), .some(.spoon)): // expected-warning {{case is already handled by previous patterns; consider removing it}}
+    break
+  case (.some(.hat), .some(.hat)): // expected-warning {{case is already handled by previous patterns; consider removing it}}
+    break
+  case (.some(.hat), .none): // expected-warning {{case is already handled by previous patterns; consider removing it}}
+    break
+  }
+  
+  // Should warn in S3 mode that `fork` isn't used
+  switch z { // expected-warning {{switch must be exhaustive}}
+  // expected-note@-1 {{add missing case: '.some(.fork)'}}
+  // expected-note@-2 {{add missing case: '.just(.fork)'}}
+  case .some(.spoon):
+    break
+  case .some(.hat):
+    break
+  case .just(.spoon):
+    break
+  case .just(.hat):
+    break
+  case .none:
+    break
+  }
+}

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -729,6 +729,7 @@ std::vector<UIdent> SwiftLangSupport::UIDsFromDeclAttributes(const DeclAttribute
     // Ignore these.
     case DAK_ShowInInterface:
     case DAK_RawDocComment:
+    case DAK_DowngradeExhaustivityCheck:
       continue;
     default:
       break;


### PR DESCRIPTION
• Explanation: Type checking switch statements looking for exhaustive patterns is a potentially factorial process.  Introduce a reasonable size limit to fall back to a linear-time heuristic instead of the full check.
• Scope of Issue:  A large enough switch over a large enough enum case can cause the compiler to hang for hours computing a fixit.
• Origination: Noticed by Harlan Haskins while TableGen’ing a very very large enum and a similarly enormous switch statement .
• Risk: Low. 
• Reviewed By: Xi Ge, Joe Groff
• Testing: New regression tests added, confirmed locally that the patch resolves Harlan’s original issue.
• Directions for QE: (Optional) Verify with the test case in the patch.
• Radar URL: rdar://32480026
