### PR TITLE
[stdlib] Dump _StringStorage.grow()

### DIFF
--- a/stdlib/public/core/StringBuffer.swift
+++ b/stdlib/public/core/StringBuffer.swift
@@ -194,63 +194,6 @@ public struct _StringBuffer {
     return cap + offset <= capacity
   }
 
-
-  /// Attempt to claim unused capacity in the buffer.
-  ///
-  /// Operation succeeds if there is sufficient capacity, and either:
-  /// - the buffer is uniquely-referenced, or
-  /// - `oldUsedEnd` points to the end of the currently used capacity.
-  ///
-  /// - parameter bounds: Range of the substring that the caller tries
-  ///   to extend.
-  /// - parameter newUsedCount: The desired size of the substring.
-  @inline(__always)
-  @discardableResult
-  mutating func grow(
-    oldBounds bounds: Range<UnsafeRawPointer>, newUsedCount: Int
-  ) -> Bool {
-    var newUsedCount = newUsedCount
-    // The substring to be grown could be pointing in the middle of this
-    // _StringBuffer.  Adjust the size so that it covers the imaginary
-    // substring from the start of the buffer to `oldUsedEnd`.
-    newUsedCount
-      += (bounds.lowerBound - UnsafeRawPointer(start)) &>> elementShift
-
-    if _slowPath(newUsedCount > capacity) {
-      return false
-    }
-
-    let newUsedEnd = start + (newUsedCount &<< elementShift)
-
-    if _fastPath(self._storage.isUniquelyReferenced()) {
-      usedEnd = newUsedEnd
-      return true
-    }
-
-    // Optimization: even if the buffer is shared, but the substring we are
-    // trying to grow is located at the end of the buffer, it can be grown in
-    // place.  The operation should be implemented in a thread-safe way,
-    // though.
-    //
-    // if usedEnd == bounds.upperBound {
-    //  usedEnd = newUsedEnd
-    //  return true
-    // }
-
-    // &StringBufferIVars.usedEnd
-    let usedEndPhysicalPtr = UnsafeMutableRawPointer(_storage._value)
-      .assumingMemoryBound(to: Optional<UnsafeRawPointer>.self)
-    // Create a temp var to hold the exchanged `expected` value.
-    var expected : UnsafeRawPointer? = bounds.upperBound
-    if _stdlib_atomicCompareExchangeStrongPtr(
-      object: usedEndPhysicalPtr, expected: &expected,
-      desired: UnsafeRawPointer(newUsedEnd)) {
-      return true
-    }
-
-    return false
-  }
-
   var _anyObject: AnyObject? {
     return _storage.storage != nil ? _storage.storage! : nil
   }

--- a/stdlib/public/core/StringCore.swift
+++ b/stdlib/public/core/StringCore.swift
@@ -431,11 +431,8 @@ public struct _StringCore {
       let usedEnd = _pointer(toElementAt:count)
 
       // Attempt to claim unused capacity in the buffer
-      if _fastPath(
-        buffer.grow(
-          oldBounds: UnsafeRawPointer(usedStart)..<UnsafeRawPointer(usedEnd),
-          newUsedCount: newSize)
-      ) {
+      if _fastPath(buffer.start == _baseAddress && newSize <= buffer.capacity) {
+        buffer.usedEnd = buffer.start + (newSize &<< elementShift)
         count = newSize
         return (0, usedEnd)
       }

--- a/validation-test/stdlib/String.swift
+++ b/validation-test/stdlib/String.swift
@@ -406,15 +406,8 @@ StringTests.test("appendToSubstring") {
         s0 = s0[s0.index(_nth: sliceStart)..<s0.index(_nth: sliceEnd)]
         expectEqual(originalIdentity, s0.bufferID)
         s0 += "x"
-        // For a small string size, the allocator could round up the allocation
-        // and we could get some unused capacity in the buffer.  In that case,
-        // the identity would not change.
-        if sliceEnd != initialSize {
-          if sliceStart != sliceEnd {
-            expectNotEqual(originalIdentity, s0.bufferID)
-          } else {
-            expectEqual(0, s0.bufferID)
-          }
+        if sliceStart == sliceEnd {
+          expectEqual(0, s0.bufferID)
         }
         expectEqual(
           String(


### PR DESCRIPTION
This implementation detail was adding lots of needless complexity