### PR TITLE
Immediately called closures are always noescape

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4111,14 +4111,6 @@ retry:
           == SolutionKind::Error)
       return SolutionKind::Error;
 
-    // If our type constraints is for a FunctionType, move over the @noescape
-    // flag.
-    if (func1->isNoEscape() &&
-        !func2->isNoEscape() &&
-        func2->hasTypeVariable()) {
-      auto &extraExtInfo = extraFunctionAttrs[func2];
-      extraExtInfo = extraExtInfo.withNoEscape();
-    }
     return SolutionKind::Solved;
   }
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1713,23 +1713,6 @@ Type simplifyTypeImpl(ConstraintSystem &cs, Type type, Fn getFixedTypeFn) {
       return DependentMemberType::get(ErrorType::get(newBase), assocType);
     }
 
-    // If this is a FunctionType and we inferred new function attributes, apply
-    // them.
-    if (auto ft = dyn_cast<FunctionType>(type.getPointer())) {
-      auto it = cs.extraFunctionAttrs.find(ft);
-      if (it != cs.extraFunctionAttrs.end()) {
-        auto extInfo = ft->getExtInfo();
-        if (it->second.isNoEscape())
-          extInfo = extInfo.withNoEscape();
-        if (it->second.throws())
-          extInfo = extInfo.withThrows();
-        return FunctionType::get(
-            simplifyTypeImpl(cs, ft->getInput(), getFixedTypeFn),
-            simplifyTypeImpl(cs, ft->getResult(), getFixedTypeFn),
-            extInfo);
-      }
-    }
-    
     return type;
   });
 }

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1261,12 +1261,6 @@ public:
   /// that locator.
   llvm::DenseMap<ConstraintLocator *, ArgumentLabelState> ArgumentLabels;
 
-  /// \brief The set of additional attributes inferred for a FunctionType.  Note
-  /// that this is not state kept as part of SolverState, so it only supports
-  /// function attributes that need to be set invariant of the actual typing of
-  /// the solution.
-  llvm::SmallDenseMap<FunctionType*, FunctionType::ExtInfo> extraFunctionAttrs;
-
   ResolvedOverloadSetListItem *getResolvedOverloadSets() const {
     return resolvedOverloadSets;
   }

--- a/test/SILOptimizer/definite_init_diagnostics.swift
+++ b/test/SILOptimizer/definite_init_diagnostics.swift
@@ -85,6 +85,7 @@ func test2() {
   
   let b5: Any
   b5 = "x"   
+  { takes_inout_any(&b5) }()   // expected-error {{immutable value 'b5' may not be passed inout}}
   ({ takes_inout_any(&b5) })()   // expected-error {{immutable value 'b5' may not be passed inout}}
 
   // Structs

--- a/test/attr/attr_escaping.swift
+++ b/test/attr/attr_escaping.swift
@@ -160,3 +160,60 @@ class FooClass {
     set(newValue) { stored = newValue } // expected-error{{cannot assign value of type '(@escaping () -> Int) -> Void' to type 'Optional<(() -> Int) -> Void>'}}
   }
 }
+
+// A call of a closure literal should be non-escaping
+func takesInOut(y: inout Int) {
+  _ = {
+    y += 1 // no-error
+  }()
+
+  _ = ({
+    y += 1 // no-error
+  })()
+
+  _ = { () in
+    y += 1 // no-error
+  }()
+
+  _ = ({ () in
+    y += 1 // no-error
+  })()
+
+  _ = { () -> () in
+    y += 1 // no-error
+  }()
+
+  _ = ({ () -> () in
+    y += 1 // no-error
+  })()
+}
+
+class HasIVarCaptures {
+  var x: Int = 0
+
+  func method() {
+    _ = {
+      x += 1 // no-error
+    }()
+
+    _ = ({
+      x += 1 // no-error
+    })()
+
+    _ = { () in
+      x += 1 // no-error
+    }()
+
+    _ = ({ () in
+      x += 1 // no-error
+    })()
+
+    _ = { () -> () in
+      x += 1 // no-error
+    }()
+
+    _ = ({ () -> () in
+      x += 1 // no-error
+    })()
+  }
+}

--- a/test/decl/var/lazy_properties.swift
+++ b/test/decl/var/lazy_properties.swift
@@ -143,12 +143,19 @@ class ReferenceSelfInLazyProperty : BaseClass {
   lazy var cqtrefs: (Int, Int) = { (self.i, self.f()) }()
 
   lazy var mrefs = { () -> (Int, Int) in return (i, f()) }()
-  // expected-error@-1 {{call to method 'f' in closure requires explicit 'self.' to make capture semantics explicit}}
-  // expected-error@-2 {{reference to property 'i' in closure requires explicit 'self.' to make capture semantics explicit}}
   lazy var mtrefs: (Int, Int) = { return (i, f()) }()
 
   lazy var mqrefs = { () -> (Int, Int) in (self.i, self.f()) }()
   lazy var mqtrefs: (Int, Int) = { return (self.i, self.f()) }()
+
+  lazy var lcqrefs = { [unowned self] in (self.i, self.f()) }()
+  lazy var lcqtrefs: (Int, Int) = { [unowned self] in (self.i, self.f()) }()
+
+  lazy var lmrefs = { [unowned self] () -> (Int, Int) in return (i, f()) }()
+  lazy var lmtrefs: (Int, Int) = { [unowned self] in return (i, f()) }()
+
+  lazy var lmqrefs = { [unowned self] () -> (Int, Int) in (self.i, self.f()) }()
+  lazy var lmqtrefs: (Int, Int) = { [unowned self] in return (self.i, self.f()) }()
 
   var i = 42
   func f() -> Int { return 0 }


### PR DESCRIPTION
Fixes https://bugs.swift.org/browse/SR-4563, <rdar://problem/31910280> and <rdar://problem/32409133>.