### PR TITLE
Yet more metrics plumbing

### DIFF
--- a/include/swift/Basic/Statistic.h
+++ b/include/swift/Basic/Statistic.h
@@ -67,6 +67,8 @@ public:
     size_t DriverDepNominal;
     size_t DriverDepMember;
     size_t DriverDepExternal;
+
+    size_t ChildrenMaxRSS;
   };
 
   struct AlwaysOnFrontendCounters

--- a/include/swift/Basic/Statistic.h
+++ b/include/swift/Basic/Statistic.h
@@ -126,6 +126,8 @@ public:
     size_t NumIRComdatSymbols;
     size_t NumIRBasicBlocks;
     size_t NumIRInsts;
+
+    size_t NumLLVMBytesOutput;
   };
 
 private:

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -63,6 +63,7 @@ namespace swift {
   class Token;
   class TopLevelContext;
   struct TypeLoc;
+  class UnifiedStatsReporter;
 
   /// SILParserState - This is a context object used to optionally maintain SIL
   /// parsing context for the parser.
@@ -301,7 +302,8 @@ namespace swift {
 
   /// Turn the given LLVM module into native code and return true on error.
   bool performLLVM(IRGenOptions &Opts, ASTContext &Ctx,
-                   llvm::Module *Module);
+                   llvm::Module *Module,
+                   UnifiedStatsReporter *Stats=nullptr);
 
   /// Run the LLVM passes. In multi-threaded compilation this will be done for
   /// multiple LLVM modules in parallel.
@@ -320,7 +322,8 @@ namespace swift {
                    llvm::Module *Module,
                    llvm::TargetMachine *TargetMachine,
                    const version::Version &effectiveLanguageVersion,
-                   StringRef OutputFilename);
+                   StringRef OutputFilename,
+                   UnifiedStatsReporter *Stats=nullptr);
 
   /// Creates a TargetMachine from the IRGen opts and AST Context.
   std::unique_ptr<llvm::TargetMachine>

--- a/lib/Basic/Statistic.cpp
+++ b/lib/Basic/Statistic.cpp
@@ -167,6 +167,8 @@ UnifiedStatsReporter::publishAlwaysOnStatsToLLVM() {
     PUBLISH_STAT(C, "IRModule", NumIRComdatSymbols);
     PUBLISH_STAT(C, "IRModule", NumIRBasicBlocks);
     PUBLISH_STAT(C, "IRModule", NumIRInsts);
+
+    PUBLISH_STAT(C, "LLVM", NumLLVMBytesOutput);
   }
   if (DriverCounters) {
     auto &C = getDriverCounters();
@@ -255,6 +257,8 @@ UnifiedStatsReporter::printAlwaysOnStatsAndTimers(raw_ostream &OS) {
     PRINT_STAT(OS, delim, C, "IRModule", NumIRComdatSymbols);
     PRINT_STAT(OS, delim, C, "IRModule", NumIRBasicBlocks);
     PRINT_STAT(OS, delim, C, "IRModule", NumIRInsts);
+
+    PRINT_STAT(OS, delim, C, "LLVM", NumLLVMBytesOutput);
   }
   if (DriverCounters) {
     auto &C = getDriverCounters();

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -511,7 +511,7 @@ static bool performCompile(CompilerInstance &Instance,
     // TODO: remove once the frontend understands what action it should perform
     IRGenOpts.OutputKind = getOutputKind(Action);
 
-    return performLLVM(IRGenOpts, Instance.getASTContext(), Module.get());
+    return performLLVM(IRGenOpts, Instance.getASTContext(), Module.get(), Stats);
   }
 
   ReferencedNameTracker nameTracker;
@@ -967,7 +967,7 @@ static bool performCompile(CompilerInstance &Instance,
   // Now that we have a single IR Module, hand it over to performLLVM.
   return performLLVM(IRGenOpts, &Instance.getDiags(), nullptr, HashGlobal,
                   IRModule.get(), TargetMachine.get(), EffectiveLanguageVersion,
-                  opts.getSingleOutputFilename()) || HadError;
+                  opts.getSingleOutputFilename(), Stats) || HadError;
 }
 
 /// Returns true if an error occurred.


### PR DESCRIPTION
This just adds a couple additional always-on, top-level metrics (driver children max RSS and frontend emitted code-size) and extends the process-stats-dir.py helper script to generate LNT-compatible output and/or submit those metrics to an LNT server.