### PR TITLE
[runtime] Add swift_unownedIsEqual and swift_unknownUnownedIsEqual.

### DIFF
--- a/include/swift/Runtime/HeapObject.h
+++ b/include/swift/Runtime/HeapObject.h
@@ -639,6 +639,14 @@ static inline void swift_unownedTakeAssign(UnownedReference *dest,
   swift_unownedRelease(oldValue);
 }
 
+static inline bool swift_unownedIsEqual(UnownedReference *ref,
+                                        HeapObject *value) {
+  bool isEqual = ref->Value == value;
+  if (isEqual)
+    swift_unownedCheck(value);
+  return isEqual;
+}
+
 /*****************************************************************************/
 /****************************** WEAK REFERENCES ******************************/
 /*****************************************************************************/
@@ -1152,6 +1160,22 @@ void swift_unknownUnownedTakeAssign(UnownedReference *dest,
 static inline void swift_unknownUnownedTakeAssign(UnownedReference *dest,
                                                   UnownedReference *src) {
   swift_unownedTakeAssign(dest, src);
+}
+
+#endif /* SWIFT_OBJC_INTEROP */
+
+#if SWIFT_OBJC_INTEROP
+
+/// Return `*ref == value` when ref might not refer to a native Swift object.
+/// Does not halt when *ref is a dead object as long as *ref != value.
+SWIFT_RUNTIME_EXPORT
+bool swift_unknownUnownedIsEqual(UnownedReference *ref, void *value);
+
+#else
+
+static inline bool swift_unknownUnownedIsEqual(UnownedReference *ref,
+                                               void *value) {
+  return swift_unownedIsEqual(ref, value);
 }
 
 #endif /* SWIFT_OBJC_INTEROP */

--- a/include/swift/Runtime/HeapObject.h
+++ b/include/swift/Runtime/HeapObject.h
@@ -1175,7 +1175,7 @@ bool swift_unknownUnownedIsEqual(UnownedReference *ref, void *value);
 
 static inline bool swift_unknownUnownedIsEqual(UnownedReference *ref,
                                                void *value) {
-  return swift_unownedIsEqual(ref, value);
+  return swift_unownedIsEqual(ref, static_cast<HeapObject *>(value));
 }
 
 #endif /* SWIFT_OBJC_INTEROP */

--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -922,6 +922,21 @@ void swift::swift_unknownUnownedTakeAssign(UnownedReference *dest,
   dest->Value = src->Value;
 }
 
+bool swift::swift_unknownUnownedIsEqual(UnownedReference *ref, void *value) {
+  if (!ref->Value) {
+    return value == nullptr;
+  } else if (auto objcRef = dyn_cast<ObjCUnownedReference>(ref)) {
+    auto refValue = objc_loadWeakRetained(&objcRef->storage()->WeakRef);
+    bool isEqual = (void*)refValue == value;
+    // This ObjC case has no deliberate unowned check here,
+    // unlike the Swift case.
+    [refValue release];
+    return isEqual;
+  } else {
+    return swift_unownedIsEqual(ref, (HeapObject *)value);
+  }
+}
+
 /*****************************************************************************/
 /************************** UNKNOWN WEAK REFERENCES **************************/
 /*****************************************************************************/


### PR DESCRIPTION
It is safe to test pointer equality of an unowned variable, even if
the unowned variable refers to a dead object. Allowing this operation
without an unnecessary unowned abort enables some kinds of caching
schemes more cheaply than can be done with weak variables.

rdar://32142240
