### PR TITLE
[Serialization] Use decl mangling for local decls, not type mangling.

### DIFF
--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -4468,8 +4468,7 @@ void Serializer::writeAST(ModuleOrSourceFile DC,
     for (auto TD : localTypeDecls) {
       hasLocalTypes = true;
       Mangle::ASTMangler Mangler;
-      std::string MangledName = Mangler.mangleTypeAsUSR(
-                                              TD->getDeclaredInterfaceType());
+      std::string MangledName = Mangler.mangleDeclAsUSR(TD, /*USRPrefix*/"");
       assert(!MangledName.empty() && "Mangled type came back empty!");
       localTypeGenerator.insert(MangledName, {
         addDeclRef(TD), TD->getLocalDiscriminator()

--- a/test/IDE/local_types.swift
+++ b/test/IDE/local_types.swift
@@ -2,7 +2,9 @@
 
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: %target-swiftc_driver -swift-version 3 -v -emit-module -module-name LocalTypes -o %t/LocalTypes.swiftmodule %s
-// RUN: %target-swift-ide-test -swift-version 3 -print-local-types -I %t -module-to-print LocalTypes -source-filename %s | %FileCheck %s
+// RUN: %target-swift-ide-test -swift-version 3 -print-local-types -I %t -module-to-print LocalTypes -source-filename %s > %t.dump
+// RUN: %FileCheck %s < %t.dump
+// RUN: %FileCheck -check-prefix=NEGATIVE %s < %t.dump
 
 public func singleFunc() {
   // CHECK-DAG: 10LocalTypes10singleFuncyyF06SingleD6StructL_V
@@ -20,6 +22,27 @@ public func singleFunc() {
   enum SingleFuncEnum {
     case SFEI(Int)
   }
+
+  // CHECK-DAG: 10LocalTypes10singleFuncyyF13GenericStructL_V
+  struct GenericStruct<T> {
+    let sfgsi: Int
+  }
+
+  // CHECK-DAG: 10LocalTypes10singleFuncyyF12GenericClassL_C
+  class GenericClass<T> {
+    let sfgci: Int = 0
+  }
+
+  // CHECK-DAG: 10LocalTypes10singleFuncyyF11GenericEnumL_O
+  enum GenericEnum<T> {
+    case sfgei(Int)
+  }
+
+  // We'll need to handle this if we start saving alias types.
+  // NEGATIVE-NOT: AliasAAA
+  typealias SingleFuncAliasAAA = Int
+  // NEGATIVE-NOT: AliasGGG
+  typealias GenericAliasGGG<T> = (T, T)
 }
 
 public func singleFuncWithDuplicates(_ fake: Bool) {

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -1572,15 +1572,27 @@ static int doPrintLocalTypes(const CompilerInvocation &InitInvok,
       node = node->getFirstChild();
 
       switch (node->getKind()) {
-        case NodeKind::Structure:
-        case NodeKind::Class:
-        case NodeKind::Enum:
-          break;
+      case NodeKind::Structure:
+      case NodeKind::Class:
+      case NodeKind::Enum:
+        break;
 
-        default:
-          llvm::errs() << "Expected a nominal type node in " <<
-            MangledName << "\n";
-          return EXIT_FAILURE;
+      case NodeKind::BoundGenericStructure:
+      case NodeKind::BoundGenericClass:
+      case NodeKind::BoundGenericEnum:
+        // Base type
+        typeNode = node->getFirstChild();
+        // Nominal type
+        node = typeNode->getFirstChild();
+        assert(node->getKind() == NodeKind::Structure ||
+               node->getKind() == NodeKind::Class ||
+               node->getKind() == NodeKind::Enum);
+        break;
+
+      default:
+        llvm::errs() << "Expected a nominal type node in " <<
+          MangledName << "\n";
+        return EXIT_FAILURE;
       }
 
       while (node->getKind() != NodeKind::LocalDeclName)


### PR DESCRIPTION
Otherwise we get an error with local generic types. We don't need the complexity of type mangling anyway.

[SR-5038](https://bugs.swift.org/browse/SR-5038) / rdar://problem/32488971