### PR TITLE
[Diagnostics] Suggest removing anonymous closure parameters if none are expected

### DIFF
--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -517,3 +517,15 @@ returnsArray().flatMap { $0 }.flatMap { }
 
 // rdar://problem/30271695
 _ = ["hi"].flatMap { $0.isEmpty ? nil : $0 }
+
+// rdar://problem/32432145 - compiler should emit fixit to remove "_ in" in closures if 0 parameters is expected
+
+func r32432145(_ a: () -> ()) {}
+r32432145 { _ in let _ = 42 } // Ok in Swift 3
+r32432145 { _ in // Ok in Swift 3
+  print("answer is 42")
+}
+r32432145 { _,_ in
+  // expected-error@-1 {{contextual closure type '() -> ()' expects 0 arguments, but 2 were used in closure body}} {{13-19=}}
+  print("answer is 42")
+}

--- a/test/Constraints/closures_swift4.swift
+++ b/test/Constraints/closures_swift4.swift
@@ -1,0 +1,18 @@
+// RUN: %target-typecheck-verify-swift -swift-version 4
+
+// rdar://problem/32432145 - compiler should emit fixit to remove "_ in" in closures if 0 parameters is expected
+
+func r32432145(_ a: () -> ()) {}
+
+r32432145 { _ in let _ = 42 }
+// expected-error@-1 {{contextual closure type '() -> ()' expects 0 arguments, but 1 was used in closure body}} {{13-17=}}
+
+r32432145 { _ in
+  // expected-error@-1 {{contextual closure type '() -> ()' expects 0 arguments, but 1 was used in closure body}} {{13-17=}}
+  print("answer is 42")
+}
+
+r32432145 { _,_ in
+  // expected-error@-1 {{contextual closure type '() -> ()' expects 0 arguments, but 2 were used in closure body}} {{13-19=}}
+  print("answer is 42")
+}


### PR DESCRIPTION
If the contextual closure type expects no parameters but N
parameters where used and all of the them are anonymous, let's
suggest removing them.

Resolves: rdar://problem/32432145

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
