### PR TITLE
Disable TestData with reslience temporarily

### DIFF
--- a/test/stdlib/TestData.swift
+++ b/test/stdlib/TestData.swift
@@ -15,6 +15,7 @@
 // RUN: %target-run %t/TestData
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
+// UNSUPPORTED: resilient_stdlib
 
 import Foundation
 import Dispatch


### PR DESCRIPTION
This test is broken on our resilience bot; disable it until it is fixed.

rdar://problem/32472729
