### PR TITLE
Disable IRGen test case pic.swift until it is fixed

### DIFF
--- a/test/IRGen/pic.swift
+++ b/test/IRGen/pic.swift
@@ -4,6 +4,7 @@
 // RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -module-name main -S -o - | %FileCheck -check-prefix=%target-cpu %s
 
 // XFAIL: linux
+// REQUIRES: rdar_32513284
 
 var global: Int = 0
 


### PR DESCRIPTION
This test fails on armv7 on a bot. Disable until I have fixed it.

rdar://32513284