### PR TITLE
Disable TestDecimal on Linux temporarily

### DIFF
--- a/test/stdlib/TestDecimal.swift
+++ b/test/stdlib/TestDecimal.swift
@@ -16,6 +16,9 @@
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
 
+// SR5067: crashing sometimes on Linux.
+// REQUIRES: OS=macosx
+
 import Foundation
 import FoundationBridgeObjC
 


### PR DESCRIPTION
This test is crashing on our bots sometimes:
https://bugs.swift.org/browse/SR-5067
