### PR TITLE
[sil-generic-specializer] Add @_semantics("optimize.sil.specialize.generic.partial.never") to disable partial specialization on specific functions

### DIFF
--- a/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
+++ b/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
@@ -607,7 +607,7 @@ SILFunction *swift::getEligibleFunction(FullApplySite AI,
   if (Callee->hasSemanticsAttrs() || Callee->hasEffectsKind()) {
     if (WhatToInline == InlineSelection::NoSemanticsAndGlobalInit) {
       ArraySemanticsCall ASC(AI.getInstruction());
-      if (!ASC.canInlineEarly())
+      if (ASC && !ASC.canInlineEarly())
         return nullptr;
     }
     // The "availability" semantics attribute is treated like global-init.

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -2271,6 +2271,7 @@ ${operatorComment(x.nonMaskingOperator, True)}
 }
 
 extension FixedWidthInteger {
+  @_semantics("optimize.sil.specialize.generic.partial.never")
   public init<Other: BinaryInteger>(clamping source: Other) {
     if _slowPath(source < Self.min) {
       self = Self.min
@@ -2416,6 +2417,7 @@ extension UnsignedInteger {
 }
 
 extension UnsignedInteger where Self : FixedWidthInteger {
+  @_semantics("optimize.sil.specialize.generic.partial.never")
   @inline(__always)
   public init<T : BinaryInteger>(_ source: T) {
     // This check is potentially removable by the optimizer
@@ -2430,6 +2432,7 @@ extension UnsignedInteger where Self : FixedWidthInteger {
     self.init(extendingOrTruncating: source)
   }
 
+  @_semantics("optimize.sil.specialize.generic.partial.never")
   @inline(__always)
   public init?<T : BinaryInteger>(exactly source: T) {
     // This check is potentially removable by the optimizer
@@ -2494,6 +2497,7 @@ extension SignedInteger {
 }
 
 extension SignedInteger where Self : FixedWidthInteger {
+  @_semantics("optimize.sil.specialize.generic.partial.never")
   @inline(__always)
   public init<T : BinaryInteger>(_ source: T) {
     // This check is potentially removable by the optimizer
@@ -2510,6 +2514,7 @@ extension SignedInteger where Self : FixedWidthInteger {
     self.init(extendingOrTruncating: source)
   }
 
+  @_semantics("optimize.sil.specialize.generic.partial.never")
   @inline(__always)
   public init?<T : BinaryInteger>(exactly source: T) {
     // This check is potentially removable by the optimizer

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -211,6 +211,7 @@ extension _StringCore {
     }
   }
 
+  @_semantics("optimize.sil.specialize.generic.partial.never")
   internal func _withCSubstringAndLength<
     Result, TargetEncoding: Unicode.Encoding
   >(

--- a/test/SILOptimizer/inline_semantics.sil
+++ b/test/SILOptimizer/inline_semantics.sil
@@ -12,14 +12,40 @@ bb0:
   return %1 : $Int32                               // id: %2
 }
 
+//Not every @_semantics should be skipped during the early inlining pass, but
+//only those ones which are explicitly listed in shouldSkipApplyDuringEarlyInlining.
+
 //CHECK-LABEL: caller_func
-//CHECK: function_ref
-//CHECK: apply
-//CHECK-NEXT: ret
+//CHECK-NOT: function_ref
+//CHECK-NOT: apply
+//CHECK: end sil function 'caller_func'
 sil @caller_func : $@convention(thin) () -> Int32 {
 bb0:
   %0 = function_ref @callee_func : $@convention(thin) () -> Int32 // user: %1
   %1 = apply %0() : $@convention(thin) () -> Int32                // user: %2
+  return %1 : $Int32                                  // id: %2
+}
+
+sil [_semantics "array.make_mutable"] @callee_func_with_to_be_skipped_during_inlining_semantics : $@convention(method) (@inout Int32) -> Int32 {
+bb0(%self : $*Int32):
+  %0 = integer_literal $Builtin.Int32, 3           // user: %1
+  %1 = struct $Int32 (%0 : $Builtin.Int32)         // user: %2
+  return %1 : $Int32                               // id: %2
+}
+
+//Not every @_semantics should be skipped during the early inlining pass, but
+//only those ones which are explicitly listed in shouldSkipApplyDuringEarlyInlining.
+
+//CHECK-LABEL: caller_func2
+//CHECK: function_ref
+//CHECK: apply
+//CHECK: end sil function 'caller_func2'
+sil @caller_func2 : $@convention(thin) () -> Int32 {
+bb0:
+  %self = alloc_stack $Int32
+  %0 = function_ref @callee_func_with_to_be_skipped_during_inlining_semantics  : $@convention(method) (@inout Int32) -> Int32 // user: %1
+  %1 = apply %0(%self) : $@convention(method) (@inout Int32) -> Int32                 // user: %2
+  dealloc_stack %self : $*Int32
   return %1 : $Int32                                  // id: %2
 }
 


### PR DESCRIPTION
This new @_semantics is used to annotate some very big functions in the standard library. It reduced the code size of the stdlib by 2%.