### PR TITLE
Sema: A call of a closure literal is noescape [4.0]

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5546,6 +5546,18 @@ Expr *ExprRewriter::coerceCallArguments(
   return shuffle;
 }
 
+static ClosureExpr *getClosureLiteralExpr(Expr *expr) {
+  expr = expr->getSemanticsProvidingExpr();
+
+  if (auto *captureList = dyn_cast<CaptureListExpr>(expr))
+    return captureList->getClosureBody();
+
+  if (auto *closure = dyn_cast<ClosureExpr>(expr))
+    return closure;
+
+  return nullptr;
+}
+
 /// If the expression is an explicit closure expression (potentially wrapped in
 /// IdentityExprs), change the type of the closure and identities to the
 /// specified type and return true.  Otherwise, return false with no effect.
@@ -5558,11 +5570,19 @@ static bool applyTypeToClosureExpr(ConstraintSystem &cs,
     return true;
   }
 
+  // Look through capture lists.
+  if (auto CLE = dyn_cast<CaptureListExpr>(expr)) {
+    if (!applyTypeToClosureExpr(cs, CLE->getClosureBody(), toType)) return false;
+    cs.setType(CLE, toType);
+    return true;
+  }
+
   // If we found an explicit ClosureExpr, update its type.
   if (auto CE = dyn_cast<ClosureExpr>(expr)) {
     cs.setType(CE, toType);
     return true;
   }
+
   // Otherwise fail.
   return false;
 }
@@ -6871,7 +6891,16 @@ Expr *ExprRewriter::finishApply(ApplyExpr *apply, Type openedType,
     // Use the subexpression as the function.
     fn = covariant->getSubExpr();
   }
-  
+
+  // An immediate application of a closure literal is always noescape.
+  if (getClosureLiteralExpr(fn)) {
+    if (auto fnTy = cs.getType(fn)->getAs<FunctionType>()) {
+      fnTy = cast<FunctionType>(
+        fnTy->withExtInfo(fnTy->getExtInfo().withNoEscape()));
+      fn = coerceToType(fn, fnTy, locator);
+    }
+  }
+
   apply->setFn(fn);
 
   // Check whether the argument is 'super'.

--- a/test/SILOptimizer/definite_init_diagnostics.swift
+++ b/test/SILOptimizer/definite_init_diagnostics.swift
@@ -85,6 +85,7 @@ func test2() {
   
   let b5: Any
   b5 = "x"   
+  { takes_inout_any(&b5) }()   // expected-error {{immutable value 'b5' may not be passed inout}}
   ({ takes_inout_any(&b5) })()   // expected-error {{immutable value 'b5' may not be passed inout}}
 
   // Structs

--- a/test/attr/attr_escaping.swift
+++ b/test/attr/attr_escaping.swift
@@ -160,3 +160,60 @@ class FooClass {
     set(newValue) { stored = newValue } // expected-error{{cannot assign value of type '(@escaping () -> Int) -> Void' to type 'Optional<(() -> Int) -> Void>'}}
   }
 }
+
+// A call of a closure literal should be non-escaping
+func takesInOut(y: inout Int) {
+  _ = {
+    y += 1 // no-error
+  }()
+
+  _ = ({
+    y += 1 // no-error
+  })()
+
+  _ = { () in
+    y += 1 // no-error
+  }()
+
+  _ = ({ () in
+    y += 1 // no-error
+  })()
+
+  _ = { () -> () in
+    y += 1 // no-error
+  }()
+
+  _ = ({ () -> () in
+    y += 1 // no-error
+  })()
+}
+
+class HasIVarCaptures {
+  var x: Int = 0
+
+  func method() {
+    _ = {
+      x += 1 // no-error
+    }()
+
+    _ = ({
+      x += 1 // no-error
+    })()
+
+    _ = { () in
+      x += 1 // no-error
+    }()
+
+    _ = ({ () in
+      x += 1 // no-error
+    })()
+
+    _ = { () -> () in
+      x += 1 // no-error
+    }()
+
+    _ = ({ () -> () in
+      x += 1 // no-error
+    })()
+  }
+}


### PR DESCRIPTION
* Description: Fixes a commonly-reported source compatibility regression in 4.0. If a closure's type was fully explicit (no type variables) we did not propagate the noescape bit from the call to the closure literal, thus we would require instance variables to be accessed with explicit "self." in cases where it was not needed before. Another related problem this also fixes was also present in 3.1 -- if a capture list was applied to a closure, we also required 'self.' qualification for instance variables (even if the capture list had nothing to do with 'self').

* Scope of the issue: All the examples I saw involved immediately calling a closure literal, so I made a narrow fix for this case.

* Origination: The original problem has existed for a long time but got worse recently.

* Risk: Low, this only affects immediate calls of closures. The PR I submitted to master had a further cleanup of the logic, but it's not necessary here.

* Tested: New tests added.

* Reviewed by: @DougGregor 

* Radar: <rdar://problem/32520406>.