### PR TITLE
[PrintAsObjC] Handle the importer's compatibility typealiases.

### DIFF
--- a/lib/AST/SwiftNameTranslation.cpp
+++ b/lib/AST/SwiftNameTranslation.cpp
@@ -28,7 +28,8 @@ using namespace swift;
 StringRef swift::objc_translation::
 getNameForObjC(const ValueDecl *VD, CustomNamesOnly_t customNamesOnly) {
   assert(isa<ClassDecl>(VD) || isa<ProtocolDecl>(VD) || isa<StructDecl>(VD) ||
-         isa<EnumDecl>(VD) || isa<EnumElementDecl>(VD));
+         isa<EnumDecl>(VD) || isa<EnumElementDecl>(VD) ||
+         isa<TypeAliasDecl>(VD));
   if (auto objc = VD->getAttrs().getAttribute<ObjCAttr>()) {
     if (auto name = objc->getName()) {
       assert(name->getNumSelectorPieces() == 1);

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -1366,7 +1366,8 @@ private:
     if (alias->hasClangNode()) {
       if (auto *clangTypeDecl =
             dyn_cast<clang::TypeDecl>(alias->getClangDecl())) {
-        os << clangTypeDecl->getName();
+        maybePrintTagKeyword(alias);
+        os << getNameForObjC(alias);
 
         if (isClangPointerType(clangTypeDecl))
           printNullability(optionalKind);
@@ -1392,7 +1393,7 @@ private:
     visitPart(alias->getUnderlyingTypeLoc().getType(), optionalKind);
   }
 
-  void maybePrintTagKeyword(const NominalTypeDecl *NTD) {
+  void maybePrintTagKeyword(const TypeDecl *NTD) {
     if (isa<EnumDecl>(NTD) && !NTD->hasClangNode()) {
       os << "enum ";
       return;

--- a/test/PrintAsObjC/Inputs/custom-modules/NestedClass.apinotes
+++ b/test/PrintAsObjC/Inputs/custom-modules/NestedClass.apinotes
@@ -4,3 +4,11 @@ SwiftVersions:
     Classes:
       - Name: InnerClass
         SwiftName: InnerClass
+    Tags:
+      - Name: InnerStruct
+        SwiftName: InnerStruct
+    Typedefs:
+      - Name: InnerAlias
+        SwiftName: InnerAlias
+      - Name: InnerAnonStruct
+        SwiftName: InnerAnonStruct

--- a/test/PrintAsObjC/Inputs/custom-modules/NestedClass.h
+++ b/test/PrintAsObjC/Inputs/custom-modules/NestedClass.h
@@ -8,3 +8,14 @@
 __attribute__((swift_name("Outer.Inner")))
 @interface InnerClass : NSObject
 @end
+
+struct __attribute__((swift_name("Outer.InnerV"))) InnerStruct {
+  int value;
+};
+
+typedef struct {
+  int value;
+} InnerAnonStruct __attribute__((swift_name("Outer.InnerAS")));
+
+typedef int InnerAlias __attribute__((swift_name("Outer.InnerA")));
+

--- a/test/PrintAsObjC/versioned.swift
+++ b/test/PrintAsObjC/versioned.swift
@@ -22,6 +22,12 @@ import NestedClass
 @objc class UsesNestedClass : NSObject {
   // CHECK-NEXT: - (InnerClass * _Nullable)foo SWIFT_WARN_UNUSED_RESULT;
   @objc func foo() -> InnerClass? { return nil }
+  // CHECK-NEXT: - (void)fooStruct:(struct InnerStruct)_;
+  @objc func fooStruct(_: InnerStruct) {}
+  // CHECK-NEXT: - (void)fooAnonStruct:(InnerAnonStruct)_;
+  @objc func fooAnonStruct(_: InnerAnonStruct) {}
+  // CHECK-NEXT: - (void)fooAlias:(InnerAlias)_;
+  @objc func fooAlias(_: InnerAlias) {}
 
   // CHECK-NEXT: - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 }


### PR DESCRIPTION
These are TypeAliasDecls whose Clang nodes are not TypedefNameDecls. This worked all right for classes, but dropped the tag keyword (e.g. `struct`) for tag decls with names of their own, and didn't print any name at all for C types that used the typedef-for-anonymous-tag pattern.

rdar://problem/32514335