### PR TITLE
stdlib: Outline integer parsing code in FixedWidthInteger.init(_: radix:) on the slow paths

### DIFF
--- a/stdlib/public/core/IntegerParsing.swift
+++ b/stdlib/public/core/IntegerParsing.swift
@@ -84,10 +84,11 @@ where CodeUnits.Element : UnsignedInteger {
 }
 
 extension FixedWidthInteger {
-  /// _parseASCII function thunk that prevents inlining used as an
-  /// implementation detail for FixedWidthInteger.init(_: radix:).
+  // _parseASCII function thunk that prevents inlining used as an implementation
+  // detail for FixedWidthInteger.init(_: radix:) on the slow path to save code
+  // size.
   @inline(never)
-  internal static func _parseASCIIOutlined<
+  internal static func _parseASCIISlowPath<
     CodeUnits : IteratorProtocol, Result: FixedWidthInteger
   >(
     codeUnits: inout CodeUnits, radix: Result
@@ -138,7 +139,7 @@ extension FixedWidthInteger {
     let result: Self?
     if _slowPath(c._baseAddress == nil) {
       var i = s.utf16.makeIterator()
-      result = Self._parseASCIIOutlined(codeUnits: &i, radix: r)
+      result = Self._parseASCIISlowPath(codeUnits: &i, radix: r)
     }
     else if _fastPath(c.elementWidth == 1), let a = c.asciiBuffer {
       var i = a.makeIterator()
@@ -147,7 +148,7 @@ extension FixedWidthInteger {
     else {
       let b = UnsafeBufferPointer(start: c.startUTF16, count: c.count)
       var i = b.makeIterator()
-      result = Self._parseASCIIOutlined(codeUnits: &i, radix: r)
+      result = Self._parseASCIISlowPath(codeUnits: &i, radix: r)
     }
     guard _fastPath(result != nil) else { return nil }
     self = result!

--- a/stdlib/public/core/IntegerParsing.swift
+++ b/stdlib/public/core/IntegerParsing.swift
@@ -83,17 +83,19 @@ where CodeUnits.Element : UnsignedInteger {
   }
 }
 
-@inline(never)
-internal func _parseASCIIOutlined<
-  CodeUnits : IteratorProtocol, Result: FixedWidthInteger
->(
-  codeUnits: inout CodeUnits, radix: Result
-) -> Result?
-where CodeUnits.Element : UnsignedInteger {
-  return _parseASCII(codeUnits: &codeUnits, radix: radix)
-}
-
 extension FixedWidthInteger {
+  /// _parseASCII function thunk that prevents inlining used as an
+  /// implementation detail for FixedWidthInteger.init(_: radix:).
+  @inline(never)
+  internal static func _parseASCIIOutlined<
+    CodeUnits : IteratorProtocol, Result: FixedWidthInteger
+  >(
+    codeUnits: inout CodeUnits, radix: Result
+  ) -> Result?
+  where CodeUnits.Element : UnsignedInteger {
+    return _parseASCII(codeUnits: &codeUnits, radix: radix)
+  }
+
   /// Creates a new integer value from the given string and radix.
   ///
   /// The string passed as `text` may begin with a plus or minus sign character
@@ -136,7 +138,7 @@ extension FixedWidthInteger {
     let result: Self?
     if _slowPath(c._baseAddress == nil) {
       var i = s.utf16.makeIterator()
-      result = _parseASCIIOutlined(codeUnits: &i, radix: r)
+      result = Self._parseASCIIOutlined(codeUnits: &i, radix: r)
     }
     else if _fastPath(c.elementWidth == 1), let a = c.asciiBuffer {
       var i = a.makeIterator()
@@ -145,7 +147,7 @@ extension FixedWidthInteger {
     else {
       let b = UnsafeBufferPointer(start: c.startUTF16, count: c.count)
       var i = b.makeIterator()
-      result = _parseASCIIOutlined(codeUnits: &i, radix: r)
+      result = Self._parseASCIIOutlined(codeUnits: &i, radix: r)
     }
     guard _fastPath(result != nil) else { return nil }
     self = result!

--- a/stdlib/public/core/IntegerParsing.swift
+++ b/stdlib/public/core/IntegerParsing.swift
@@ -83,6 +83,16 @@ where CodeUnits.Element : UnsignedInteger {
   }
 }
 
+@inline(never)
+internal func _parseASCIIOutlined<
+  CodeUnits : IteratorProtocol, Result: FixedWidthInteger
+>(
+  codeUnits: inout CodeUnits, radix: Result
+) -> Result?
+where CodeUnits.Element : UnsignedInteger {
+  return _parseASCII(codeUnits: &codeUnits, radix: radix)
+}
+
 extension FixedWidthInteger {
   /// Creates a new integer value from the given string and radix.
   ///
@@ -126,7 +136,7 @@ extension FixedWidthInteger {
     let result: Self?
     if _slowPath(c._baseAddress == nil) {
       var i = s.utf16.makeIterator()
-      result = _parseASCII(codeUnits: &i, radix: r)
+      result = _parseASCIIOutlined(codeUnits: &i, radix: r)
     }
     else if _fastPath(c.elementWidth == 1), let a = c.asciiBuffer {
       var i = a.makeIterator()
@@ -135,7 +145,7 @@ extension FixedWidthInteger {
     else {
       let b = UnsafeBufferPointer(start: c.startUTF16, count: c.count)
       var i = b.makeIterator()
-      result = _parseASCII(codeUnits: &i, radix: r)
+      result = _parseASCIIOutlined(codeUnits: &i, radix: r)
     }
     guard _fastPath(result != nil) else { return nil }
     self = result!


### PR DESCRIPTION

This reduces code size by 20k on an app that uses this function.

rdar://32519912
