### PR TITLE
[4.0] [PrintAsObjC] Handle the importer's compatibility typealiases

### DIFF
--- a/lib/AST/SwiftNameTranslation.cpp
+++ b/lib/AST/SwiftNameTranslation.cpp
@@ -28,7 +28,8 @@ using namespace swift;
 StringRef swift::objc_translation::
 getNameForObjC(const ValueDecl *VD, CustomNamesOnly_t customNamesOnly) {
   assert(isa<ClassDecl>(VD) || isa<ProtocolDecl>(VD) || isa<StructDecl>(VD) ||
-         isa<EnumDecl>(VD) || isa<EnumElementDecl>(VD));
+         isa<EnumDecl>(VD) || isa<EnumElementDecl>(VD) ||
+         isa<TypeAliasDecl>(VD));
   if (auto objc = VD->getAttrs().getAttribute<ObjCAttr>()) {
     if (auto name = objc->getName()) {
       assert(name->getNumSelectorPieces() == 1);

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -1370,7 +1370,8 @@ private:
     if (alias->hasClangNode()) {
       if (auto *clangTypeDecl =
             dyn_cast<clang::TypeDecl>(alias->getClangDecl())) {
-        os << clangTypeDecl->getName();
+        maybePrintTagKeyword(alias);
+        os << getNameForObjC(alias);
 
         if (isClangPointerType(clangTypeDecl))
           printNullability(optionalKind);
@@ -1396,7 +1397,7 @@ private:
     visitPart(alias->getUnderlyingTypeLoc().getType(), optionalKind);
   }
 
-  void maybePrintTagKeyword(const NominalTypeDecl *NTD) {
+  void maybePrintTagKeyword(const TypeDecl *NTD) {
     if (isa<EnumDecl>(NTD) && !NTD->hasClangNode()) {
       os << "enum ";
       return;

--- a/test/PrintAsObjC/Inputs/custom-modules/NestedClass.apinotes
+++ b/test/PrintAsObjC/Inputs/custom-modules/NestedClass.apinotes
@@ -4,3 +4,11 @@ SwiftVersions:
     Classes:
       - Name: InnerClass
         SwiftName: InnerClass
+    Tags:
+      - Name: InnerStruct
+        SwiftName: InnerStruct
+    Typedefs:
+      - Name: InnerAlias
+        SwiftName: InnerAlias
+      - Name: InnerAnonStruct
+        SwiftName: InnerAnonStruct

--- a/test/PrintAsObjC/Inputs/custom-modules/NestedClass.h
+++ b/test/PrintAsObjC/Inputs/custom-modules/NestedClass.h
@@ -8,3 +8,14 @@
 __attribute__((swift_name("Outer.Inner")))
 @interface InnerClass : NSObject
 @end
+
+struct __attribute__((swift_name("Outer.InnerV"))) InnerStruct {
+  int value;
+};
+
+typedef struct {
+  int value;
+} InnerAnonStruct __attribute__((swift_name("Outer.InnerAS")));
+
+typedef int InnerAlias __attribute__((swift_name("Outer.InnerA")));
+

--- a/test/PrintAsObjC/versioned.swift
+++ b/test/PrintAsObjC/versioned.swift
@@ -22,6 +22,12 @@ import NestedClass
 @objc class UsesNestedClass : NSObject {
   // CHECK-NEXT: - (InnerClass * _Nullable)foo SWIFT_WARN_UNUSED_RESULT;
   @objc func foo() -> InnerClass? { return nil }
+  // CHECK-NEXT: - (void)fooStruct:(struct InnerStruct)_;
+  @objc func fooStruct(_: InnerStruct) {}
+  // CHECK-NEXT: - (void)fooAnonStruct:(InnerAnonStruct)_;
+  @objc func fooAnonStruct(_: InnerAnonStruct) {}
+  // CHECK-NEXT: - (void)fooAlias:(InnerAlias)_;
+  @objc func fooAlias(_: InnerAlias) {}
 
   // CHECK-NEXT: - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 }


### PR DESCRIPTION
- **Explanation**: If an imported type has been renamed between Swift 3 and Swift 4, both names are available for use in Swift 3.2, with the "old" name being a typealias for the new name. PrintAsObjC, however, didn't expect to see typealiases with Clang nodes that weren't typedefs or Objective-C classes. Add support for these kinds of typealiases by doing the same thing we'd do for an underlying struct type.
- **Scope**: Affects use of typealiases created by the ClangImporter in APIs that are exposed in the generated Objective-C header.
- **Radar**: rdar://problem/32514335
- **Reviewed by**: @milseman  
- **Risk**: Low. Uses existing code paths to handle this case.
- **Testing**: Passed compiler regression test, confirmed that the original test case now generates correct headers.