### PR TITLE
Add a virtual destructor to avoid leaking the new private impl's memory.

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -2074,6 +2074,9 @@ IRGenDebugInfo *IRGenDebugInfo::createIRGenDebugInfo(const IRGenOptions &Opts,
   return new IRGenDebugInfoImpl(Opts, CI, IGM, M, SF);
 }
 
+
+IRGenDebugInfo::~IRGenDebugInfo() {}
+
 // Forwarding to the private implementation.
 void IRGenDebugInfo::finalize() {
   static_cast<IRGenDebugInfoImpl *>(this)->finalize();

--- a/lib/IRGen/IRGenDebugInfo.h
+++ b/lib/IRGen/IRGenDebugInfo.h
@@ -49,6 +49,7 @@ public:
                                               ClangImporter &CI,
                                               IRGenModule &IGM, llvm::Module &M,
                                               SourceFile *SF);
+  virtual ~IRGenDebugInfo();
 
   /// Finalize the llvm::DIBuilder owned by this object.
   void finalize();


### PR DESCRIPTION
rdar://problem/32520596
