### PR TITLE
[GSB] Resolve nested types by looking into superclass constraints.

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2372,6 +2372,9 @@ public:
     return D->getKind() >= DeclKind::First_TypeDecl &&
            D->getKind() <= DeclKind::Last_TypeDecl;
   }
+
+  /// Compute an ordering between two type declarations that is ABI-stable.
+  static int compare(const TypeDecl *type1, const TypeDecl *type2);
 };
 
 /// A type declaration that can have generic parameters attached to it.  Because

--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -494,6 +494,19 @@ public:
                          = nullptr,
                        bool sorted = false) const;
 
+  /// Retrieve the syntactic depth of this declaration context, i.e.,
+  /// the number of non-module-scoped contexts.
+  ///
+  /// For an extension of a nested type, the extension is depth 1.
+  unsigned getSyntacticDepth() const;
+
+  /// Retrieve the semantic depth of this declaration context, i.e.,
+  /// the number of non-module-scoped contexts.
+  ///
+  /// For an extension of a nested type, the depth of the nested type itself
+  /// is also included.
+  unsigned getSemanticDepth() const;
+
   /// \returns true if traversal was aborted, false otherwise.
   bool walkContext(ASTWalker &Walker);
 

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -1399,6 +1399,9 @@ public:
     return dyn_cast<AssociatedTypeDecl>(identifier.assocTypeOrConcrete);
   }
 
+  /// Determine whether this PA is still unresolved.
+  bool isUnresolved() const { return isUnresolvedNestedType; }
+
   /// Resolve the potential archetype to the given associated type.
   void resolveAssociatedType(AssociatedTypeDecl *assocType,
                              GenericSignatureBuilder &builder);

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2067,6 +2067,39 @@ Type TypeDecl::getDeclaredInterfaceType() const {
   return interfaceType->castTo<MetatypeType>()->getInstanceType();
 }
 
+int TypeDecl::compare(const TypeDecl *type1, const TypeDecl *type2) {
+  // Order based on the enclosing declaration.
+  auto dc1 = type1->getDeclContext();
+  auto dc2 = type2->getDeclContext();
+
+  // Prefer lower depths.
+  auto depth1 = dc1->getSemanticDepth();
+  auto depth2 = dc2->getSemanticDepth();
+  if (depth1 != depth2)
+    return depth1 < depth2 ? -1 : +1;
+
+  // Prefer module names earlier in the alphabet.
+  if (dc1->isModuleScopeContext() && dc2->isModuleScopeContext()) {
+    auto module1 = dc1->getParentModule();
+    auto module2 = dc2->getParentModule();
+    if (int result = module1->getName().str().compare(module2->getName().str()))
+      return result;
+  }
+
+  auto nominal1 = dc1->getAsNominalTypeOrNominalTypeExtensionContext();
+  auto nominal2 = dc2->getAsNominalTypeOrNominalTypeExtensionContext();
+  if (static_cast<bool>(nominal1) != static_cast<bool>(nominal2)) {
+    return static_cast<bool>(nominal1) ? -1 : +1;
+  }
+  if (nominal1 && nominal2) {
+    if (int result = compare(nominal1, nominal2))
+      return result;
+  }
+
+  return type1->getBaseName().getIdentifier().str().compare(
+                                  type2->getBaseName().getIdentifier().str());
+}
+
 bool NominalTypeDecl::hasFixedLayout() const {
   // Private and (unversioned) internal types always have a
   // fixed layout.

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2096,8 +2096,16 @@ int TypeDecl::compare(const TypeDecl *type1, const TypeDecl *type2) {
       return result;
   }
 
-  return type1->getBaseName().getIdentifier().str().compare(
-                                  type2->getBaseName().getIdentifier().str());
+  if (int result = type1->getBaseName().getIdentifier().str().compare(
+                                  type2->getBaseName().getIdentifier().str()))
+    return result;
+
+  // Error case: two type declarations that cannot be distinguished.
+  if (type1 < type2)
+    return -1;
+  if (type1 > type2)
+    return +1;
+  return 0;
 }
 
 bool NominalTypeDecl::hasFixedLayout() const {

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -656,6 +656,30 @@ DeclContext::isCascadingContextForLookup(bool functionsAreNonCascading) const {
   return getParent()->isCascadingContextForLookup(true);
 }
 
+unsigned DeclContext::getSyntacticDepth() const {
+  // Module scope == depth 0.
+  if (isModuleScopeContext())
+    return 0;
+
+  return 1 + getParent()->getSyntacticDepth();
+}
+
+unsigned DeclContext::getSemanticDepth() const {
+  // For extensions, count the depth of the nominal type being extended.
+  if (auto ext = dyn_cast<ExtensionDecl>(this)) {
+    if (auto nominal = getAsNominalTypeOrNominalTypeExtensionContext())
+      return nominal->getSemanticDepth();
+
+    return 1;
+  }
+
+  // Module scope == depth 0.
+  if (isModuleScopeContext())
+    return 0;
+
+  return 1 + getParent()->getSemanticDepth();
+}
+
 bool DeclContext::walkContext(ASTWalker &Walker) {
   switch (getContextKind()) {
   case DeclContextKind::Module:

--- a/lib/AST/GenericEnvironment.cpp
+++ b/lib/AST/GenericEnvironment.cpp
@@ -33,17 +33,6 @@ GenericEnvironment::GenericEnvironment(GenericSignature *signature,
                           Type());
 }
 
-/// Compute the depth of the \c DeclContext chain.
-static unsigned declContextDepth(const DeclContext *dc) {
-  unsigned depth = 0;
-  while (auto parentDC = dc->getParent()) {
-    ++depth;
-    dc = parentDC;
-  }
-
-  return depth;
-}
-
 void GenericEnvironment::setOwningDeclContext(DeclContext *newOwningDC) {
   if (!OwningDC) {
     OwningDC = newOwningDC;
@@ -54,8 +43,8 @@ void GenericEnvironment::setOwningDeclContext(DeclContext *newOwningDC) {
     return;
 
   // Find the least common ancestor context to be the owner.
-  unsigned oldDepth = declContextDepth(OwningDC);
-  unsigned newDepth = declContextDepth(newOwningDC);
+  unsigned oldDepth = OwningDC->getSyntacticDepth();
+  unsigned newDepth = newOwningDC->getSyntacticDepth();
 
   while (oldDepth > newDepth) {
     OwningDC = OwningDC->getParent();

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -948,17 +948,7 @@ static void addMinimumProtocols(Type T,
 /// \brief Compare two protocols to establish an ordering between them.
 int ProtocolType::compareProtocols(ProtocolDecl * const* PP1,
                                    ProtocolDecl * const* PP2) {
-  auto *P1 = *PP1;
-  auto *P2 = *PP2;
-  ModuleDecl *M1 = P1->getParentModule();
-  ModuleDecl *M2 = P2->getParentModule();
-
-  // Try ordering based on module name, first.
-  if (int result = M1->getName().str().compare(M2->getName().str()))
-    return result;
-
-  // Order based on protocol name.
-  return P1->getName().str().compare(P2->getName().str());
+  return TypeDecl::compare(*PP1, *PP2);
 }
 
 bool ProtocolType::visitAllProtocols(

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -209,12 +209,13 @@ Type CompleteGenericTypeResolver::resolveDependentMemberType(
     return DependentMemberType::get(baseTy, assocType);
   }
 
-  // If the nested type comes from a type alias, use either the alias's
-  // concrete type, or resolve its components down to another dependent member.
-  if (auto alias = nestedPA->getTypeAliasDecl()) {
-    assert(!alias->getGenericParams() && "Generic typealias in protocol");
-    ref->setValue(alias);
-    return TC.substMemberTypeWithBase(DC->getParentModule(), alias, baseTy);
+  // If the nested type comes from a concrete type, substitute the base type
+  // into it.
+  if (auto concrete = nestedPA->getConcreteTypeDecl()) {
+    ref->setValue(concrete);
+    if (baseTy->isTypeParameter())
+      return DependentMemberType::get(baseTy, concrete->getName());
+    return TC.substMemberTypeWithBase(DC->getParentModule(), concrete, baseTy);
   }
   
   Identifier name = ref->getIdentifier();

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -213,32 +213,33 @@ Type CompleteGenericTypeResolver::resolveDependentMemberType(
   // into it.
   if (auto concrete = nestedPA->getConcreteTypeDecl()) {
     ref->setValue(concrete);
-    if (baseTy->isTypeParameter())
-      return DependentMemberType::get(baseTy, concrete->getName());
-    return TC.substMemberTypeWithBase(DC->getParentModule(), concrete, baseTy);
-  }
-  
-  Identifier name = ref->getIdentifier();
-  SourceLoc nameLoc = ref->getIdLoc();
 
-  // Check whether the name can be found in the superclass.
-  // FIXME: The generic signature builder should be doing this and mapping down to a
-  // concrete type.
-  if (auto superclassTy = basePA->getSuperclass()) {
-    if (auto lookup = TC.lookupMemberType(DC, superclassTy, name)) {
-      if (lookup.isAmbiguous()) {
-        TC.diagnoseAmbiguousMemberType(baseTy, baseRange, name, nameLoc,
-                                       lookup);
-        return ErrorType::get(TC.Context);
+    if (baseTy->isTypeParameter()) {
+      if (auto proto =
+            concrete->getDeclContext()
+              ->getAsProtocolOrProtocolExtensionContext()) {
+        auto subMap = SubstitutionMap::getProtocolSubstitutions(
+                        proto, baseTy, ProtocolConformanceRef(proto));
+        return concrete->getDeclaredInterfaceType().subst(subMap);
       }
 
-      ref->setValue(lookup.front().first);
-      // FIXME: Record (via type sugar) that this was referenced via baseTy.
-      return lookup.front().second;
+      if (auto superclass = basePA->getSuperclass()) {
+        return superclass->getTypeOfMember(
+                                         DC->getParentModule(), concrete,
+                                         concrete->getDeclaredInterfaceType());
+      }
+
+      llvm_unreachable("shouldn't have a concrete decl here");
     }
+
+    return TC.substMemberTypeWithBase(DC->getParentModule(), concrete, baseTy);
   }
 
+  assert(nestedPA->isUnresolved() && "meaningless unresolved type");
+
   // Complain that there is no suitable type.
+  Identifier name = ref->getIdentifier();
+  SourceLoc nameLoc = ref->getIdLoc();
   TC.diagnose(nameLoc, diag::invalid_member_type, name, baseTy)
     .highlight(baseRange);
   return ErrorType::get(TC.Context);

--- a/test/Generics/superclass_constraint.swift
+++ b/test/Generics/superclass_constraint.swift
@@ -152,3 +152,18 @@ class Classical : Elementary {
 }
 
 func genericFunc<T : Elementary, U : Classical>(_: T, _: U) where T.Element == U.Element {}
+
+// Lookup within superclass constraints.
+protocol P8 {
+  associatedtype B
+}
+
+class C8 {
+  struct A { }
+}
+
+func superclassLookup1<T: C8 & P8>(_: T) where T.A == T.B { }
+
+func superclassLookup2<T: P8>(_: T) where T.A == T.B, T: C8 { }
+
+func superclassLookup3<T>(_: T) where T.A == T.B, T: C8, T: P8 { }


### PR DESCRIPTION
This was previously handled very late, by the type checker, which led
to weird ordering dependencies and meant that we could end up with
well-formed code where the GSB was left with unresolved types. We want
such states to never exist, so make sure we can resolve everything in
the GSB.