### PR TITLE
Correct getAccessStrategy for class extension storage decls.

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1165,7 +1165,13 @@ static bool isPolymorphic(const AbstractStorageDecl *storage) {
 
   case DeclKind::Class:
     // Final properties can always be direct, even in classes.
-    return !storage->isFinal();
+    if (storage->isFinal())
+      return false;
+    // Extension properties are statically dispatched, unless they're @objc.
+    if (storage->getDeclContext()->isExtensionContext()
+        && !storage->isObjC())
+      return false;
+    return true;
   }
   llvm_unreachable("bad DeclKind");
 }

--- a/test/SILGen/keypaths_objc.swift
+++ b/test/SILGen/keypaths_objc.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-experimental-keypath-components -emit-silgen -import-objc-header %S/Inputs/keypaths_objc.h %s | %FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-experimental-keypath-components -emit-ir -import-objc-header %S/Inputs/keypaths_objc.h %s
 // REQUIRES: objc_interop
 
 import Foundation
@@ -54,4 +55,24 @@ func objcKeypathIdentifiers() {
   _ = \Foo.dyn
   // CHECK: keypath $KeyPath<Foo, Int>, (objc "int"; {{.*}} id #Foo.int!getter.1 :
   _ = \Foo.int
+}
+
+struct X {}
+
+extension NSObject {
+    var x: X { return X() }
+    @objc var objc: Int { return 0 }
+    @objc dynamic var dynamic: Int { return 0 }
+}
+
+// CHECK-LABEL: sil hidden @{{.*}}nonobjcExtensionOfObjCClass
+func nonobjcExtensionOfObjCClass() {
+  // Should be treated as a statically-dispatch property
+  // CHECK: keypath $KeyPath<NSObject, X>, ({{.*}} id @
+  _ = \NSObject.x
+  // CHECK: keypath $KeyPath<NSObject, Int>, ({{.*}} id #NSObject.objc!getter.1.foreign
+  _ = \NSObject.objc
+  // CHECK: keypath $KeyPath<NSObject, Int>, ({{.*}} id #NSObject.dynamic!getter.1.foreign
+  _ = \NSObject.dynamic
+
 }


### PR DESCRIPTION
Class extension methods are non-polymorphic unless @objc. Fixes rdar://problem/32434652.