### PR TITLE
[stdlib] Make single-grapheme check debug-only

### DIFF
--- a/stdlib/public/core/Character.swift
+++ b/stdlib/public/core/Character.swift
@@ -180,7 +180,7 @@ public struct Character :
     // high bit is 1.
     _precondition(
       s._core.count != 0, "Can't form a Character from an empty String")
-    _precondition(
+    _debugPrecondition(
       s.index(after: s.startIndex) == s.endIndex,
       "Can't form a Character from a String containing more than one extended grapheme cluster")
 

--- a/test/stdlib/CharacterTraps.swift
+++ b/test/stdlib/CharacterTraps.swift
@@ -25,8 +25,8 @@ CharacterTraps.test("CharacterFromEmptyString")
 
 CharacterTraps.test("CharacterFromMoreThanOneGraphemeCluster")
   .skip(.custom(
-    { _isFastAssertConfiguration() },
-    reason: "this trap is not guaranteed to happen in -Ounchecked"))
+    { !_isDebugAssertConfiguration() },
+    reason: "this trap is only guaranteed to happen in Debug builds"))
   .code {
   var s = "ab"
   expectCrashLater()


### PR DESCRIPTION
Because of the way grapheme breaking changes across updates to ICU and the Unicode standard, it may not even be legit to check this at all.  It's certainly **not unsafe** to skip the check, so let's see if we can do that in release builds, as grapheme breaking is expensive.
