### PR TITLE
Removing android define

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -2074,6 +2074,9 @@ IRGenDebugInfo *IRGenDebugInfo::createIRGenDebugInfo(const IRGenOptions &Opts,
   return new IRGenDebugInfoImpl(Opts, CI, IGM, M, SF);
 }
 
+
+IRGenDebugInfo::~IRGenDebugInfo() {}
+
 // Forwarding to the private implementation.
 void IRGenDebugInfo::finalize() {
   static_cast<IRGenDebugInfoImpl *>(this)->finalize();

--- a/lib/IRGen/IRGenDebugInfo.h
+++ b/lib/IRGen/IRGenDebugInfo.h
@@ -49,6 +49,7 @@ public:
                                               ClangImporter &CI,
                                               IRGenModule &IGM, llvm::Module &M,
                                               SourceFile *SF);
+  virtual ~IRGenDebugInfo();
 
   /// Finalize the llvm::DIBuilder owned by this object.
   void finalize();

--- a/stdlib/public/SwiftShims/LibcShims.h
+++ b/stdlib/public/SwiftShims/LibcShims.h
@@ -33,7 +33,7 @@ namespace swift { extern "C" {
 
 // This declaration is not universally correct.  We verify its correctness for
 // the current platform in the runtime code.
-#if defined(__linux__) && defined (__arm__) && !defined(__ANDROID__)
+#if defined(__linux__) && defined (__arm__) 
 typedef           int __swift_ssize_t;
 #elif defined(_WIN32)
 #if defined(_M_ARM) || defined(_M_IX86)

--- a/utils/swift-mode.el
+++ b/utils/swift-mode.el
@@ -350,7 +350,7 @@ Use `M-x hs-show-all' to show them again."
                            1)
                           ((save-match-data
                              (looking-at
-                              "case \\|default *:\\|[a-zA-Z_][a-zA-Z0-9_]*\\(\\s-\\|\n\\)*:\\(\\s-\\|\n\\)*\\(for\\|do\\|\\while\\|switch\\)\\>"))
+                              "case \\|default *:\\|[a-zA-Z_][a-zA-Z0-9_]*\\(\\s-\\|\n\\)*:\\(\\s-\\|\n\\)*\\(for\\|do\\|\\while\\|switch\\|repeat\\)\\>"))
                            1)
                           (t 0))))))
       (indent-line-to (max target-column 0)))


### PR DESCRIPTION
<!-- What's in this pull request? -->
Removing && !defined(__ANDROID__) part from LibcShims.h to resolve a bug

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-5059](https://bugs.swift.org/browse/SR-5059).
