### PR TITLE
Error when one associated type is constrained to another.

### DIFF
--- a/test/Sema/circular_decl_checking.swift
+++ b/test/Sema/circular_decl_checking.swift
@@ -43,9 +43,10 @@ func TopLevelGenericFunc2<T : TopLevelGenericFunc2>(x: T) -> T { return x} // ex
 var TopLevelVar: TopLevelVar? { return nil } // expected-error 2 {{use of undeclared type 'TopLevelVar'}}
 
 
-protocol AProtocol {
-  // FIXME: Should produce an error here, but it's currently causing problems.
-  associatedtype e : e
+// FIXME: The first error is redundant, isn't correct in what it states, and
+// also should be emitted on the inheritance clause.
+protocol AProtocol { // expected-error {{first type 'Self.e' in conformance requirement does not refer to a generic parameter or associated type}}
+  associatedtype e : e // expected-error {{inheritance from non-protocol, non-class type 'Self.e'}}
 }
 
 

--- a/test/decl/nested/protocol.swift
+++ b/test/decl/nested/protocol.swift
@@ -72,5 +72,6 @@ class OuterClass {
 
 class OtherGenericClass<T> {
   protocol InnerProtocol : OtherGenericClass { }
-  // expected-error@-1{{protocol 'InnerProtocol' cannot be nested inside another declaration}}
+  // expected-error@-1{{non-class type 'InnerProtocol' cannot inherit from class 'OtherGenericClass<T>'}}
+  // expected-error@-2{{protocol 'InnerProtocol' cannot be nested inside another declaration}}
 }

--- a/test/decl/protocol/req/unsatisfiable.swift
+++ b/test/decl/protocol/req/unsatisfiable.swift
@@ -30,3 +30,21 @@ protocol P3 {
   func f<T: P3>(_: T) where T.A == Self.A, T.A: C // expected-error{{instance method requirement 'f' cannot add constraint 'Self.A: C' on 'Self'}}
   func g<T: P3>(_: T) where T.A: C, T.A == Self.A  // expected-error{{instance method requirement 'g' cannot add constraint 'Self.A: C' on 'Self'}}
 }
+
+protocol Base {
+  associatedtype Assoc
+}
+
+// FIXME: The first error is redundant, isn't correct in what it states, and
+// also should be emitted on the inheritance clause.
+// FIXME: This used to /not/ error in Swift 3. It didn't impose any statically-
+// enforced requirements, but the compiler crashed if you used anything but the
+// same type.
+protocol Sub1: Base { // expected-error {{first type 'Self.Assoc' in conformance requirement does not refer to a generic parameter or associated type}}
+  associatedtype SubAssoc: Assoc // expected-error {{inheritance from non-protocol, non-class type 'Self.Assoc'}}
+}
+// FIXME: This error is incorrect in what it states and should be emitted on
+// the where-clause.
+protocol Sub2: Base { // expected-error {{first type 'Self.Assoc' in conformance requirement does not refer to a generic parameter or associated type}}
+  associatedtype SubAssoc where SubAssoc: Assoc
+}

--- a/validation-test/compiler_crashers_fixed/28693-swift-genericenvironment-queryinterfacetypesubstitutions-operator-swift-substitu.swift
+++ b/validation-test/compiler_crashers_fixed/28693-swift-genericenvironment-queryinterfacetypesubstitutions-operator-swift-substitu.swift
@@ -5,5 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 protocol b:Self


### PR DESCRIPTION
(...is constrained to be a subtype of another)

Previously the compiler would just mark the entry in the inheritance clause invalid and move on without emitting any errors; in certain circumstances in no-asserts builds this could actually lead to everything working "correctly" if all conforming types happened to pick the same concrete type for both associated types. In Swift 4 this can actually be enforced with a same-type requirement, which will guarantee that the two associated types are the same even in generic contexts.

This fix avoids assertions and crashes, but the diagnostic is still incorrect, and in the simple case of the inheritance clause it's redundant. Doing something better and possibly even downgrading it to a warning in Swift 3 mode is tracked by [SR-4981](https://bugs.swift.org/browse/SR-4981) / rdar://problem/32409449.