### PR TITLE
Sema: Fix conditional downcasts from Swift types to CF types [4.0]

### DIFF
--- a/test/Inputs/clang-importer-sdk/usr/include/CoreFoundation.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/CoreFoundation.h
@@ -14,6 +14,10 @@ typedef struct __attribute__((objc_bridge(NSString))) __CFString const *CFString
 typedef struct __CFTree *CFTreeRef;
 typedef const struct __attribute__((objc_bridge(CFURL))) __CFURL * CFURLRef;
 
+typedef struct __attribute__((objc_bridge(NSDictionary))) __CFDictionary const *CFDictionaryRef;
+typedef struct __attribute__((objc_bridge(NSArray))) __CFArray const *CFArrayRef;
+typedef struct __attribute__((objc_bridge(NSSet))) __CFSet const *CFSetRef;
+
 typedef CFTypeRef CFAliasForTypeRef;
 
 

--- a/test/expr/cast/cf.swift
+++ b/test/expr/cast/cf.swift
@@ -80,3 +80,25 @@ func testCFConvWithIUO(_ x: CFString!, y: NSString!) {
   acceptNSString(x)
   acceptCFString(y)
 }
+
+func testBridgedCFDowncast(array: [Any], dictionary: [AnyHashable : Any], set: Set<AnyHashable>) {
+  let cfArray = array as CFArray
+  let cfDictionary = dictionary as CFDictionary
+  let cfSet = set as CFSet
+
+  _ = array as? CFArray // expected-warning {{conditional cast from '[Any]' to 'CFArray' always succeeds}}
+  _ = dictionary as? CFDictionary // expected-warning {{conditional cast from '[AnyHashable : Any]' to 'CFDictionary' always succeeds}}
+  _ = set as? CFSet // expected-warning {{conditional cast from 'Set<AnyHashable>' to 'CFSet' always succeeds}}
+
+  _ = array as! CFArray // expected-warning {{forced cast from '[Any]' to 'CFArray' always succeeds}}
+  _ = dictionary as! CFDictionary // expected-warning {{forced cast from '[AnyHashable : Any]' to 'CFDictionary' always succeeds}}
+  _ = set as! CFSet // expected-warning {{forced cast from 'Set<AnyHashable>' to 'CFSet' always succeeds}}
+
+  _ = cfArray as! [Any]
+  _ = cfDictionary as! [AnyHashable : Any]
+  _ = cfSet as! Set<AnyHashable>
+
+  _ = cfArray as? [Any]
+  _ = cfDictionary as? [AnyHashable : Any]
+  _ = cfSet as? Set<AnyHashable>
+}


### PR DESCRIPTION
* Description: Fixes a crash when applying a solution containing a conditional or forced cast from a Swift collection to the corresponding CF collection type.

* Origination: The bug has always been there.

* Risk: Low, the code path in question would have asserted otherwise.

* Tested: New tests added.

* Reviewed by: @DougGregor 

* Radar: <rdar://problem/32227571>