### PR TITLE
Restrict WalkToVarDecls to Expressions and Patterns

### DIFF
--- a/lib/AST/Pattern.cpp
+++ b/lib/AST/Pattern.cpp
@@ -166,27 +166,24 @@ namespace {
         fn(Named->getDecl());
       return P;
     }
-    
-    bool walkToDeclPre(Decl *D) override {
-      // Skip walking into decls -- they open a new scope.
-      return false;
+
+    // Only walk into an expression insofar as it doesn't open a new scope -
+    // that is, don't walk into a closure body.
+    std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
+      if (isa<ClosureExpr>(E)) {
+        return { false, E };
+      }
+      return { true, E };
     }
-    
+
+    // Don't walk into anything else.
     std::pair<bool, Stmt *> walkToStmtPre(Stmt *S) override {
       return { false, S };
     }
-    
-    std::pair<bool, Pattern*> walkToPatternPre(Pattern *P) override {
-      return { false, P };
-    }
-    
     bool walkToTypeLocPre(TypeLoc &TL) override { return false; }
-    
     bool walkToTypeReprPre(TypeRepr *T) override { return false; }
-    
-    bool walkToParameterListPre(ParameterList *PL) override {
-      return false;
-    }
+    bool walkToParameterListPre(ParameterList *PL) override { return false; }
+    bool walkToDeclPre(Decl *D) override { return false; }
   };
 } // end anonymous namespace
 

--- a/lib/AST/Pattern.cpp
+++ b/lib/AST/Pattern.cpp
@@ -166,6 +166,27 @@ namespace {
         fn(Named->getDecl());
       return P;
     }
+    
+    bool walkToDeclPre(Decl *D) override {
+      // Skip walking into decls -- they open a new scope.
+      return false;
+    }
+    
+    std::pair<bool, Stmt *> walkToStmtPre(Stmt *S) override {
+      return { false, S };
+    }
+    
+    std::pair<bool, Pattern*> walkToPatternPre(Pattern *P) override {
+      return { false, P };
+    }
+    
+    bool walkToTypeLocPre(TypeLoc &TL) override { return false; }
+    
+    bool walkToTypeReprPre(TypeRepr *T) override { return false; }
+    
+    bool walkToParameterListPre(ParameterList *PL) override {
+      return false;
+    }
   };
 } // end anonymous namespace
 

--- a/validation-test/compiler_crashers_fixed/28482-hasaccessibility-accessibility-not-computed-yet.swift
+++ b/validation-test/compiler_crashers_fixed/28482-hasaccessibility-accessibility-not-computed-yet.swift
@@ -5,6 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 // REQUIRES: asserts
 {guard let{protocol A{extension{let d}}}let f=d


### PR DESCRIPTION
Resolve a crasher caused by `WalkToVarDecls` walking into pretty much anything and everything as long as it could reach a pattern.  If the pattern was an expression pattern, Parse would perform lookup into every variable in any inner scope.  Because the expression in this pattern is a closure, this meant the user could introduce any number of inner declaration contexts.  Here, Parse, content to bind a declref, fed the malformed AST to the type checker which balked.  Later, the validator took a turn and landed inside a declaration whose parent decl contexts had not yet been validated.