### PR TITLE
Rip out SILGenApply's ArchetypeCalleeBuilder

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -587,15 +587,6 @@ public:
         constant(inputConstant.asForeign(protocol->isObjC())) {}
 
   Callee build() {
-    // Link back to something to create a data dependency if we have
-    // an opened type.
-    SILValue openingSite;
-    auto archetype =
-        getSelfType()->getRValueInstanceType()->castTo<ArchetypeType>();
-    if (archetype->getOpenedExistentialType()) {
-      openingSite = SGF.getArchetypeOpeningSite(archetype);
-    }
-
     // Then if we need to materialize self into memory, do so.
     if (shouldMaterializeSelf()) {
       SILLocation selfLoc = selfValue.getLocation();
@@ -603,7 +594,7 @@ public:
       setSelfValueToAddress(selfLoc, address);
     }
 
-    return Callee::forArchetype(SGF, openingSite, getSelfType(), constant,
+    return Callee::forArchetype(SGF, SILValue(), getSelfType(), constant,
                                 subs, loc);
   }
 

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -67,7 +67,6 @@ static ManagedValue emitBuiltinRetain(SILGenFunction &gen,
                                        SILLocation loc,
                                        SubstitutionList substitutions,
                                        ArrayRef<ManagedValue> args,
-                                       CanFunctionType formalApplyType,
                                        SGFContext C) {
   // The value was produced at +1; we can produce an unbalanced retain simply by
   // disabling the cleanup. But this would violate ownership semantics. Instead,
@@ -81,7 +80,6 @@ static ManagedValue emitBuiltinRelease(SILGenFunction &gen,
                                        SILLocation loc,
                                        SubstitutionList substitutions,
                                        ArrayRef<ManagedValue> args,
-                                       CanFunctionType formalApplyType,
                                        SGFContext C) {
   // The value was produced at +1, so to produce an unbalanced
   // release we need to leave the cleanup intact and then do a *second*
@@ -95,7 +93,6 @@ static ManagedValue emitBuiltinAutorelease(SILGenFunction &gen,
                                            SILLocation loc,
                                            SubstitutionList substitutions,
                                            ArrayRef<ManagedValue> args,
-                                           CanFunctionType formalApplyType,
                                            SGFContext C) {
   gen.B.createUnmanagedAutoreleaseValue(loc, args[0].getValue(),
                                         gen.B.getDefaultAtomicity());
@@ -118,7 +115,6 @@ static ManagedValue emitBuiltinTryPin(SILGenFunction &gen,
                                       SILLocation loc,
                                       SubstitutionList subs,
                                       ArrayRef<ManagedValue> args,
-                                      CanFunctionType formalApplyType,
                                       SGFContext C) {
   assert(args.size() == 1);
 
@@ -140,7 +136,6 @@ static ManagedValue emitBuiltinUnpin(SILGenFunction &gen,
                                      SILLocation loc,
                                      SubstitutionList subs,
                                      ArrayRef<ManagedValue> args,
-                                     CanFunctionType formalApplyType,
                                      SGFContext C) {
   assert(args.size() == 1);
 
@@ -157,7 +152,6 @@ static ManagedValue emitBuiltinLoadOrTake(SILGenFunction &gen,
                                           SILLocation loc,
                                           SubstitutionList substitutions,
                                           ArrayRef<ManagedValue> args,
-                                          CanFunctionType formalApplyType,
                                           SGFContext C,
                                           IsTake_t isTake,
                                           bool isStrict,
@@ -183,10 +177,9 @@ static ManagedValue emitBuiltinLoad(SILGenFunction &gen,
                                     SILLocation loc,
                                     SubstitutionList substitutions,
                                     ArrayRef<ManagedValue> args,
-                                    CanFunctionType formalApplyType,
                                     SGFContext C) {
   return emitBuiltinLoadOrTake(gen, loc, substitutions, args,
-                               formalApplyType, C, IsNotTake,
+                               C, IsNotTake,
                                /*isStrict*/ true, /*isInvariant*/ false);
 }
 
@@ -194,20 +187,18 @@ static ManagedValue emitBuiltinLoadRaw(SILGenFunction &gen,
                                        SILLocation loc,
                                        SubstitutionList substitutions,
                                        ArrayRef<ManagedValue> args,
-                                       CanFunctionType formalApplyType,
                                        SGFContext C) {
   return emitBuiltinLoadOrTake(gen, loc, substitutions, args,
-                               formalApplyType, C, IsNotTake,
+                               C, IsNotTake,
                                /*isStrict*/ false, /*isInvariant*/ false);
 }
 static ManagedValue emitBuiltinLoadInvariant(SILGenFunction &gen,
                                              SILLocation loc,
                                              SubstitutionList substitutions,
                                              ArrayRef<ManagedValue> args,
-                                             CanFunctionType formalApplyType,
                                              SGFContext C) {
   return emitBuiltinLoadOrTake(gen, loc, substitutions, args,
-                               formalApplyType, C, IsNotTake,
+                               C, IsNotTake,
                                /*isStrict*/ false, /*isInvariant*/ true);
 }
 
@@ -215,10 +206,9 @@ static ManagedValue emitBuiltinTake(SILGenFunction &gen,
                                     SILLocation loc,
                                     SubstitutionList substitutions,
                                     ArrayRef<ManagedValue> args,
-                                    CanFunctionType formalApplyType,
                                     SGFContext C) {
   return emitBuiltinLoadOrTake(gen, loc, substitutions, args,
-                               formalApplyType, C, IsTake,
+                               C, IsTake,
                                /*isStrict*/ true, /*isInvariant*/ false);
 }
 
@@ -227,7 +217,6 @@ static ManagedValue emitBuiltinDestroy(SILGenFunction &gen,
                                        SILLocation loc,
                                        SubstitutionList substitutions,
                                        ArrayRef<ManagedValue> args,
-                                       CanFunctionType formalApplyType,
                                        SGFContext C) {
   assert(args.size() == 2 && "destroy should have two arguments");
   assert(substitutions.size() == 1 &&
@@ -259,7 +248,6 @@ static ManagedValue emitBuiltinAssign(SILGenFunction &gen,
                                       SILLocation loc,
                                       SubstitutionList substitutions,
                                       ArrayRef<ManagedValue> args,
-                                      CanFunctionType formalApplyType,
                                       SGFContext C) {
   assert(args.size() >= 2 && "assign should have two arguments");
   assert(substitutions.size() == 1 &&
@@ -291,7 +279,6 @@ static ManagedValue emitBuiltinInit(SILGenFunction &gen,
                                     SILLocation loc,
                                     SubstitutionList substitutions,
                                     Expr *tuple,
-                                    CanFunctionType formalApplyType,
                                     SGFContext C) {
   auto args = decomposeArguments(gen, tuple, 2);
 
@@ -315,7 +302,6 @@ static ManagedValue emitBuiltinFixLifetime(SILGenFunction &gen,
                                            SILLocation loc,
                                            SubstitutionList substitutions,
                                            ArrayRef<ManagedValue> args,
-                                           CanFunctionType formalApplyType,
                                            SGFContext C) {
   for (auto arg : args) {
     gen.B.createFixLifetime(loc, arg.getValue());
@@ -362,7 +348,6 @@ static ManagedValue emitBuiltinUnsafeCastToNativeObject(SILGenFunction &gen,
                                          SILLocation loc,
                                          SubstitutionList substitutions,
                                          ArrayRef<ManagedValue> args,
-                                         CanFunctionType formalApplyType,
                                          SGFContext C) {
   return emitCastToReferenceType(gen, loc, substitutions, args, C,
                         SILType::getNativeObjectType(gen.F.getASTContext()));
@@ -374,7 +359,6 @@ static ManagedValue emitBuiltinCastToNativeObject(SILGenFunction &gen,
                                          SILLocation loc,
                                          SubstitutionList substitutions,
                                          ArrayRef<ManagedValue> args,
-                                         CanFunctionType formalApplyType,
                                          SGFContext C) {
   CanType ty = args[0].getType().getSwiftRValueType();
   (void)ty;
@@ -382,8 +366,7 @@ static ManagedValue emitBuiltinCastToNativeObject(SILGenFunction &gen,
          "Can only cast types that use native reference counting to native "
          "object");
   return emitBuiltinUnsafeCastToNativeObject(gen, loc, substitutions,
-                                             args, formalApplyType,
-                                             C);
+                                             args, C);
 }
 
 
@@ -392,7 +375,6 @@ static ManagedValue emitBuiltinCastToUnknownObject(SILGenFunction &gen,
                                          SILLocation loc,
                                          SubstitutionList substitutions,
                                          ArrayRef<ManagedValue> args,
-                                         CanFunctionType formalApplyType,
                                          SGFContext C) {
   return emitCastToReferenceType(gen, loc, substitutions, args, C,
                         SILType::getUnknownObjectType(gen.F.getASTContext()));
@@ -436,7 +418,6 @@ static ManagedValue emitBuiltinCastFromNativeObject(SILGenFunction &gen,
                                          SILLocation loc,
                                          SubstitutionList substitutions,
                                          ArrayRef<ManagedValue> args,
-                                         CanFunctionType formalApplyType,
                                          SGFContext C) {
   return emitCastFromReferenceType(gen, loc, substitutions, args, C);
 }
@@ -446,7 +427,6 @@ static ManagedValue emitBuiltinCastFromUnknownObject(SILGenFunction &gen,
                                          SILLocation loc,
                                          SubstitutionList substitutions,
                                          ArrayRef<ManagedValue> args,
-                                         CanFunctionType formalApplyType,
                                          SGFContext C) {
   return emitCastFromReferenceType(gen, loc, substitutions, args, C);
 }
@@ -456,7 +436,6 @@ static ManagedValue emitBuiltinBridgeToRawPointer(SILGenFunction &gen,
                                         SILLocation loc,
                                         SubstitutionList substitutions,
                                         ArrayRef<ManagedValue> args,
-                                        CanFunctionType formalApplyType,
                                         SGFContext C) {
   assert(args.size() == 1 && "bridge should have a single argument");
   
@@ -474,7 +453,6 @@ static ManagedValue emitBuiltinBridgeFromRawPointer(SILGenFunction &gen,
                                         SILLocation loc,
                                         SubstitutionList substitutions,
                                         ArrayRef<ManagedValue> args,
-                                        CanFunctionType formalApplyType,
                                         SGFContext C) {
   assert(substitutions.size() == 1 &&
          "bridge should have a single substitution");
@@ -498,7 +476,6 @@ static ManagedValue emitBuiltinAddressOf(SILGenFunction &gen,
                                          SILLocation loc,
                                          SubstitutionList substitutions,
                                          ArrayRef<ManagedValue> args,
-                                         CanFunctionType formalApplyType,
                                          SGFContext C) {
   assert(args.size() == 1 && "addressof should have a single argument");
   
@@ -515,7 +492,6 @@ static ManagedValue emitBuiltinGepRaw(SILGenFunction &gen,
                                       SILLocation loc,
                                       SubstitutionList substitutions,
                                       ArrayRef<ManagedValue> args,
-                                      CanFunctionType formalApplyType,
                                       SGFContext C) {
   assert(args.size() == 2 && "gepRaw should be given two arguments");
   
@@ -530,7 +506,6 @@ static ManagedValue emitBuiltinGep(SILGenFunction &gen,
                                    SILLocation loc,
                                    SubstitutionList substitutions,
                                    ArrayRef<ManagedValue> args,
-                                   CanFunctionType formalApplyType,
                                    SGFContext C) {
   assert(substitutions.size() == 1 && "gep should have two substitutions");
   assert(args.size() == 3 && "gep should be given three arguments");
@@ -552,7 +527,6 @@ static ManagedValue emitBuiltinGetTailAddr(SILGenFunction &gen,
                                            SILLocation loc,
                                            SubstitutionList substitutions,
                                            ArrayRef<ManagedValue> args,
-                                           CanFunctionType formalApplyType,
                                            SGFContext C) {
   assert(substitutions.size() == 2 && "getTailAddr should have two substitutions");
   assert(args.size() == 4 && "gep should be given four arguments");
@@ -576,7 +550,6 @@ static ManagedValue emitBuiltinCondFail(SILGenFunction &gen,
                                         SILLocation loc,
                                         SubstitutionList substitutions,
                                         ArrayRef<ManagedValue> args,
-                                        CanFunctionType formalApplyType,
                                         SGFContext C) {
   assert(args.size() == 1 && "condfail should be given one argument");
   
@@ -590,7 +563,6 @@ emitBuiltinCastReference(SILGenFunction &gen,
                          SILLocation loc,
                          SubstitutionList substitutions,
                          ArrayRef<ManagedValue> args,
-                         CanFunctionType formalApplyType,
                          SGFContext C) {
   assert(args.size() == 1 && "castReference should be given one argument");
   assert(substitutions.size() == 2 && "castReference should have two subs");
@@ -652,7 +624,6 @@ static ManagedValue emitBuiltinReinterpretCast(SILGenFunction &gen,
                                          SILLocation loc,
                                          SubstitutionList substitutions,
                                          ArrayRef<ManagedValue> args,
-                                         CanFunctionType formalApplyType,
                                          SGFContext C) {
   assert(args.size() == 1 && "reinterpretCast should be given one argument");
   assert(substitutions.size() == 2 && "reinterpretCast should have two subs");
@@ -712,7 +683,6 @@ static ManagedValue emitBuiltinCastToBridgeObject(SILGenFunction &gen,
                                                   SILLocation loc,
                                                   SubstitutionList subs,
                                                   ArrayRef<ManagedValue> args,
-                                                  CanFunctionType formalApplyType,
                                                   SGFContext C) {
   assert(args.size() == 2 && "cast should have two arguments");
   assert(subs.size() == 1 && "cast should have a type substitution");
@@ -754,7 +724,6 @@ static ManagedValue emitBuiltinCastReferenceFromBridgeObject(
                                                   SILLocation loc,
                                                   SubstitutionList subs,
                                                   ArrayRef<ManagedValue> args,
-                                                  CanFunctionType formalApplyType,
                                                   SGFContext C) {
   assert(args.size() == 1 && "cast should have one argument");
   assert(subs.size() == 1 && "cast should have a type substitution");
@@ -781,7 +750,6 @@ static ManagedValue emitBuiltinCastBitPatternFromBridgeObject(
                                                   SILLocation loc,
                                                   SubstitutionList subs,
                                                   ArrayRef<ManagedValue> args,
-                                                  CanFunctionType formalApplyType,
                                                   SGFContext C) {
   assert(args.size() == 1 && "cast should have one argument");
   assert(subs.empty() && "cast should not have subs");
@@ -800,7 +768,6 @@ static ManagedValue emitBuiltinIsUnique(SILGenFunction &gen,
                                         SILLocation loc,
                                         SubstitutionList subs,
                                         ArrayRef<ManagedValue> args,
-                                        CanFunctionType formalApplyType,
                                         SGFContext C) {
 
   assert(subs.size() == 1 && "isUnique should have a single substitution");
@@ -817,7 +784,6 @@ emitBuiltinIsUniqueOrPinned(SILGenFunction &gen,
                                SILLocation loc,
                                SubstitutionList subs,
                                ArrayRef<ManagedValue> args,
-                               CanFunctionType formalApplyType,
                                SGFContext C) {
   assert(subs.size() == 1 && "isUnique should have a single substitution");
   assert(args.size() == 1 && "isUnique should have a single argument");
@@ -836,7 +802,6 @@ emitBuiltinIsUnique_native(SILGenFunction &gen,
                            SILLocation loc,
                            SubstitutionList subs,
                            ArrayRef<ManagedValue> args,
-                           CanFunctionType formalApplyType,
                            SGFContext C) {
 
   assert(subs.size() == 1 && "isUnique_native should have one sub.");
@@ -854,7 +819,6 @@ emitBuiltinIsUniqueOrPinned_native(SILGenFunction &gen,
                                    SILLocation loc,
                                    SubstitutionList subs,
                                    ArrayRef<ManagedValue> args,
-                                   CanFunctionType formalApplyType,
                                    SGFContext C) {
 
   assert(subs.size() == 1 && "isUniqueOrPinned_native should have one sub.");
@@ -871,7 +835,6 @@ static ManagedValue emitBuiltinBindMemory(SILGenFunction &gen,
                                           SILLocation loc,
                                           SubstitutionList subs,
                                           ArrayRef<ManagedValue> args,
-                                          CanFunctionType formalApplyType,
                                           SGFContext C) {
   assert(subs.size() == 1 && "bindMemory should have a single substitution");
   assert(args.size() == 3 && "bindMemory should have three argument");
@@ -890,7 +853,6 @@ static ManagedValue emitBuiltinAllocWithTailElems(SILGenFunction &gen,
                                               SILLocation loc,
                                               SubstitutionList subs,
                                               ArrayRef<ManagedValue> args,
-                                              CanFunctionType formalApplyType,
                                               SGFContext C) {
   unsigned NumTailTypes = subs.size() - 1;
   assert(args.size() == NumTailTypes * 2 + 1 &&
@@ -923,7 +885,6 @@ static ManagedValue emitBuiltinProjectTailElems(SILGenFunction &gen,
                                                 SILLocation loc,
                                                 SubstitutionList subs,
                                                 ArrayRef<ManagedValue> args,
-                                                CanFunctionType formalApplyType,
                                                 SGFContext C) {
   assert(subs.size() == 2 &&
          "allocWithTailElems should have two substitutions");
@@ -948,7 +909,6 @@ static ManagedValue emitBuiltinTypeTrait(SILGenFunction &gen,
                                         SILLocation loc,
                                         SubstitutionList substitutions,
                                         ArrayRef<ManagedValue> args,
-                                        CanFunctionType formalApplyType,
                                         SGFContext C) {
   assert(substitutions.size() == 1
          && "type trait should take a single type parameter");

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -336,7 +336,6 @@ static ManagedValue emitCastToReferenceType(SILGenFunction &gen,
       = ArchetypeType::getOpened(substitutions[0].getReplacement());
     SILType loweredOpenedTy = gen.getLoweredLoadableType(openedTy);
     arg = gen.B.createOpenExistentialRef(loc, arg, loweredOpenedTy);
-    gen.setArchetypeOpeningSite(openedTy, arg.getValue());
   }
 
   // Return the cast result.
@@ -711,7 +710,6 @@ static ManagedValue emitBuiltinCastToBridgeObject(SILGenFunction &gen,
       = ArchetypeType::getOpened(subs[0].getReplacement());
     SILType loweredOpenedTy = gen.getLoweredLoadableType(openedTy);
     ref = gen.B.createOpenExistentialRef(loc, ref, loweredOpenedTy);
-    gen.setArchetypeOpeningSite(openedTy, ref);
   }
   
   SILValue result = gen.B.createRefToBridgeObject(loc, ref, bits);

--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -859,7 +859,6 @@ SILGenFunction::emitOpenExistential(
   case ExistentialRepresentation::None:
     llvm_unreachable("not existential");
   }
-  setArchetypeOpeningSite(openedArchetype, archetypeMV.getValue());
 
   assert(!canConsume || isUnique); (void) isUnique;
 

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -943,21 +943,6 @@ public:
                                             CanType inputTy,
                                             SILType resultTy);
 
-  /// OpenedArchetypes - Mappings of opened archetypes back to the
-  /// instruction which opened them.
-  llvm::DenseMap<ArchetypeType *, SILValue> ArchetypeOpenings;
-
-  SILValue getArchetypeOpeningSite(ArchetypeType *archetype) const {
-    auto it = ArchetypeOpenings.find(archetype);
-    assert(it != ArchetypeOpenings.end() &&
-           "opened archetype was not registered with SILGenFunction");
-    return it->second;
-  }
-
-  void setArchetypeOpeningSite(ArchetypeType *archetype, SILValue site) {
-    ArchetypeOpenings.insert({archetype, site});
-  }
-
   struct OpaqueValueState {
     ManagedValue Value;
     bool IsConsumable;

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -627,14 +627,11 @@ namespace {
   /// A physical path component which projects out an opened archetype
   /// from an existential.
   class OpenOpaqueExistentialComponent : public PhysicalPathComponent {
-    CanArchetypeType getOpenedArchetype() const {
-      return cast<ArchetypeType>(getSubstFormalType());
-    }
   public:
     OpenOpaqueExistentialComponent(CanArchetypeType openedArchetype,
                                    LValueTypeData typeData)
       : PhysicalPathComponent(typeData, OpenOpaqueExistentialKind) {
-      assert(getOpenedArchetype() == openedArchetype);
+      assert(getSubstFormalType() == openedArchetype);
     }
 
     ManagedValue offset(SILGenFunction &SGF, SILLocation loc, ManagedValue base,
@@ -664,7 +661,6 @@ namespace {
         llvm_unreachable("Bad existential representation for address-only type");
       }
 
-      SGF.setArchetypeOpeningSite(getOpenedArchetype(), addr);
       return ManagedValue::forLValue(addr);
     }
 
@@ -721,8 +717,6 @@ namespace {
                  == ExistentialRepresentation::Class);
         ref = SGF.B.createOpenExistentialRef(loc, result, getTypeOfRValue());
       }
-
-      SGF.setArchetypeOpeningSite(OpenedArchetype, ref.getValue());
 
       return RValue(SGF, loc, getSubstFormalType(), ref);
     }

--- a/lib/SILGen/SpecializedEmitter.h
+++ b/lib/SILGen/SpecializedEmitter.h
@@ -43,7 +43,6 @@ public:
                                      SILLocation,
                                      SubstitutionList,
                                      Expr *argument,
-                                     CanFunctionType formalApplyType,
                                      SGFContext);
 
   /// A special function for emitting a call after the arguments
@@ -52,7 +51,6 @@ public:
                                     SILLocation,
                                     SubstitutionList,
                                     ArrayRef<ManagedValue>,
-                                    CanFunctionType formalApplyType,
                                     SGFContext);
 
   enum class Kind {

--- a/test/SILGen/partial_apply_protocol_class_refinement_method.swift
+++ b/test/SILGen/partial_apply_protocol_class_refinement_method.swift
@@ -6,8 +6,10 @@ protocol Q: class, P {}
 // CHECK-LABEL: sil hidden @_T046partial_apply_protocol_class_refinement_method0A5ApplyyycAA1Q_pF
 func partialApply(_ q: Q) -> () -> () {
   // CHECK: [[OPENED:%.*]] = open_existential_ref
-  // CHECK: store [[OPENED]] to [init] [[TMP:%.*]] :
-  // CHECK: copy_addr [[TMP:%.*]] to [initialization] [[CONSUMABLE_TMP:%.*]] :
-  // CHECK: apply {{%.*}}<{{.*}}>([[CONSUMABLE_TMP]])
+  // CHECK: [[COPY:%.*]] = copy_value [[OPENED]]
+  // CHECK: [[TMP:%.*]] = alloc_stack 
+  // CHECK: store [[COPY]] to [init] [[TMP:%.*]] :
+  // CHECK: apply {{%.*}}<{{.*}}>([[TMP]])
+  // CHECK-NEXT: dealloc_stack [[TMP]]
   return q.foo
 }

--- a/test/SILGen/protocol_class_refinement.swift
+++ b/test/SILGen/protocol_class_refinement.swift
@@ -31,11 +31,11 @@ func getObjectUID<T: ObjectUID>(x: T) -> (Int, Int, Int, Int) {
   // CHECK: [[XBOX:%.*]] = alloc_box $<τ_0_0 where τ_0_0 : ObjectUID> { var τ_0_0 } <T>
   // CHECK: [[PB:%.*]] = project_box [[XBOX]]
   // -- call x.uid()
+  // CHECK: [[GET_UID:%.*]] = witness_method $T, #UID.uid!1
   // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[PB]] : $*T
   // CHECK: [[X:%.*]] = load [copy] [[READ]]
   // CHECK: [[X_TMP:%.*]] = alloc_stack
   // CHECK: store [[X]] to [init] [[X_TMP]]
-  // CHECK: [[GET_UID:%.*]] = witness_method $T, #UID.uid!1
   // CHECK: [[UID:%.*]] = apply [[GET_UID]]<T>([[X_TMP]])
   // CHECK: [[X2:%.*]] = load [take] [[X_TMP]]
   // CHECK: destroy_value [[X2]]
@@ -46,11 +46,11 @@ func getObjectUID<T: ObjectUID>(x: T) -> (Int, Int, Int, Int) {
   x.clsid = x.uid()
 
   // -- call x.uid()
+  // CHECK: [[GET_UID:%.*]] = witness_method $T, #UID.uid!1
   // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[PB]] : $*T
   // CHECK: [[X:%.*]] = load [copy] [[READ]]
   // CHECK: [[X_TMP:%.*]] = alloc_stack
   // CHECK: store [[X]] to [init] [[X_TMP]]
-  // CHECK: [[GET_UID:%.*]] = witness_method $T, #UID.uid!1
   // CHECK: [[UID:%.*]] = apply [[GET_UID]]<T>([[X_TMP]])
   // CHECK: [[X2:%.*]] = load [take] [[X_TMP]]
   // CHECK: destroy_value [[X2]]
@@ -61,11 +61,14 @@ func getObjectUID<T: ObjectUID>(x: T) -> (Int, Int, Int, Int) {
   x.nextCLSID = x.uid()
 
   // -- call x.uid()
-  // CHECK: [[X1:%.*]] = load [copy] [[PB]]
-  // CHECK: [[X:%.*]] = load [copy] [[PB]]
+  // CHECK: [[READ1:%.*]] = begin_access [read] [unknown] [[PB]] : $*T
+  // CHECK: [[X1:%.*]] = load [copy] [[READ1]]
+  // CHECK: [[GET_UID:%.*]] = witness_method $T, #UID.uid!1
+  // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[PB]] : $*T
+  // CHECK: [[X:%.*]] = load [copy] [[READ]]
   // CHECK: [[X_TMP:%.*]] = alloc_stack
   // CHECK: store [[X]] to [init] [[X_TMP]]
-  // CHECK: [[GET_UID:%.*]] = witness_method $T, #UID.uid!1
+
   // CHECK: [[UID:%.*]] = apply [[GET_UID]]<T>([[X_TMP]])
   // CHECK: [[X2:%.*]] = load [take] [[X_TMP]]
   // CHECK: destroy_value [[X2]]
@@ -75,6 +78,8 @@ func getObjectUID<T: ObjectUID>(x: T) -> (Int, Int, Int, Int) {
   // CHECK: destroy_value [[X1]]
   x.secondNextCLSID = x.uid()
   return (x.iid, x.clsid, x.nextCLSID, x.secondNextCLSID)
+
+  // CHECK: return
 }
 
 // CHECK-LABEL: sil hidden @_T025protocol_class_refinement16getBaseObjectUID{{[_0-9a-zA-Z]*}}F
@@ -83,11 +88,11 @@ func getBaseObjectUID<T: UID where T: Base>(x: T) -> (Int, Int, Int) {
   // CHECK: [[XBOX:%.*]] = alloc_box $<τ_0_0 where τ_0_0 : Base, τ_0_0 : UID> { var τ_0_0 } <T>
   // CHECK: [[PB:%.*]] = project_box [[XBOX]]
   // -- call x.uid()
+  // CHECK: [[GET_UID:%.*]] = witness_method $T, #UID.uid!1
   // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[PB]] : $*T
   // CHECK: [[X:%.*]] = load [copy] [[READ]]
   // CHECK: [[X_TMP:%.*]] = alloc_stack
   // CHECK: store [[X]] to [init] [[X_TMP]]
-  // CHECK: [[GET_UID:%.*]] = witness_method $T, #UID.uid!1
   // CHECK: [[UID:%.*]] = apply [[GET_UID]]<T>([[X_TMP]])
   // CHECK: [[X2:%.*]] = load [take] [[X_TMP]]
   // CHECK: destroy_value [[X2]]
@@ -98,11 +103,11 @@ func getBaseObjectUID<T: UID where T: Base>(x: T) -> (Int, Int, Int) {
   x.clsid = x.uid()
 
   // -- call x.uid()
+  // CHECK: [[GET_UID:%.*]] = witness_method $T, #UID.uid!1
   // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[PB]] : $*T
   // CHECK: [[X:%.*]] = load [copy] [[READ]]
   // CHECK: [[X_TMP:%.*]] = alloc_stack
   // CHECK: store [[X]] to [init] [[X_TMP]]
-  // CHECK: [[GET_UID:%.*]] = witness_method $T, #UID.uid!1
   // CHECK: [[UID:%.*]] = apply [[GET_UID]]<T>([[X_TMP]])
   // CHECK: [[X2:%.*]] = load [take] [[X_TMP]]
   // CHECK: destroy_value [[X2]]
@@ -112,4 +117,6 @@ func getBaseObjectUID<T: UID where T: Base>(x: T) -> (Int, Int, Int) {
   // CHECK: apply [[SET_NEXTCLSID]]<T>([[UID]], [[WRITE]])
   x.nextCLSID = x.uid()
   return (x.iid, x.clsid, x.nextCLSID)
+
+  // CHECK: return
 }

--- a/test/SILGen/subclass_existentials.swift
+++ b/test/SILGen/subclass_existentials.swift
@@ -137,16 +137,16 @@ func methodCalls(
 
   // CHECK: [[BORROW:%.*]] = begin_borrow %0 : $Base<Int> & P
   // CHECK: [[PAYLOAD:%.*]] = open_existential_ref [[BORROW]] : $Base<Int> & P to $@opened("{{.*}}") Base<Int> & P
-  // CHECK: [[SELF_BOX:%.*]] = alloc_stack $@opened("{{.*}}") Base<Int> & P
-  // CHECK: store [[PAYLOAD]] to [init] [[SELF_BOX]] : $*@opened("{{.*}}") Base<Int> & P
   // CHECK: [[METHOD:%.*]] = witness_method $@opened("{{.*}}") Base<Int> & P, #P.protocolSelfReturn!1 : <Self where Self : P> (Self) -> () -> @dynamic_self Self, %16 : $@opened("{{.*}}") Base<Int> & P : $@convention(witness_method) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @out τ_0_0
   // CHECK: [[RESULT_BOX:%.*]] = alloc_stack $@opened("{{.*}}") Base<Int> & P
+  // CHECK: [[SELF_BOX:%.*]] = alloc_stack $@opened("{{.*}}") Base<Int> & P
+  // CHECK: store_borrow [[PAYLOAD]] to [[SELF_BOX]] : $*@opened("{{.*}}") Base<Int> & P
   // CHECK: apply [[METHOD]]<@opened("{{.*}}") Base<Int> & P>([[RESULT_BOX]], [[SELF_BOX]]) : $@convention(witness_method) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @out τ_0_0
-  // CHECK: [[RESULT_REF:%.*]] = load [take] %20 : $*@opened("{{.*}}") Base<Int> & P
+  // CHECK: dealloc_stack [[SELF_BOX]] : $*@opened("{{.*}}") Base<Int> & P
+  // CHECK: [[RESULT_REF:%.*]] = load [take] [[RESULT_BOX]] : $*@opened("{{.*}}") Base<Int> & P
   // CHECK: [[RESULT:%.*]] = init_existential_ref [[RESULT_REF]] : $@opened("{{.*}}") Base<Int> & P : $@opened("{{.*}}") Base<Int> & P, $Base<Int> & P
   // CHECK: destroy_value [[RESULT]] : $Base<Int> & P
   // CHECK: dealloc_stack [[RESULT_BOX]] : $*@opened("{{.*}}") Base<Int> & P
-  // CHECK: dealloc_stack [[SELF_BOX]] : $*@opened("{{.*}}") Base<Int> & P
   // CHECK: end_borrow [[BORROW]] from %0 : $Base<Int> & P
   let _: Base<Int> & P = baseAndP.protocolSelfReturn()
 


### PR DESCRIPTION
This is a major simplification to the code path for forming protocol method calls.