### PR TITLE
Revert "[docs] Add the description of @_semantics("optimize.sil.specialize.generic.partial.never") and the new @_specialized syntax"

### DIFF
--- a/docs/Generics.rst
+++ b/docs/Generics.rst
@@ -720,7 +720,7 @@ type parameters.::
 
   struct S<T> {
     var x: T
-    @_specialize(where T == Int, U == Float)
+    @_specialize(Int, Float)
     mutating func exchangeSecond<U>(_ u: U, _ t: T) -> (U, T) {
       x = t
       return (u, x)
@@ -740,41 +740,6 @@ used in conjunction with rigorous performance analysis. Eventually,
 a similar attribute could be defined in the language, allowing it to be
 exposed as part of a function's API. That would allow direct dispatch
 to specialized code without type checks, even across modules.
-
-The exact syntax of the @_specialize function attribute is defined as: ::
-
-  @_specialize(exported: true, kind: full, where K == Int, V == Int)
-  @_specialize(exported: false, kind: partial, where K: _Trivial64)
-  func dictFunction<K, V>(dict: Dictionary<K, V>) {
-  }
-  ```
-    
-If 'exported' is set, the corresponding specialization would have a public
-visibility and can be used by clients. If 'exported' is omitted, it's value
-is assumed to be 'false'.
-
-If 'kind' is 'full' it means a full specialization and the compiler will
-produce an error if you forget to specify the type for some of the generic
-parameters in the 'where' clause. If 'kind' is 'partial' it means a partial
-specialization. If 'kind' is omitted, its value is assumed to be 'full.
-
-The requirements in the where clause may be same-type constaints like 'T == Int',
-but they may also specify so-called layout constraints like 'T: _Trivial'.
-
-The following layout constraints are currently supported:
-  * AnyObject - the actual parameter should be an instance of a class
-  * _NativeClass - the actual parameter should be an instance of a Swift native
-    class
-  * _RefCountedObject - the actual parameter should be a reference-counted object
-  * _NativeRefCountedObject - the actual parameter should be a Swift-native
-    reference-counted object
-  * _Trivial - the actual parameter should be of a trivial type, i.e. a type
-    without any reference counted properties.
-  * _Trivial(SizeInBits) - like _Trivial, but the size of the type should be
-    exactly 'SizeInBits' bits.
-  * _TrivialAtMost(SizeInBits) - like _Trivial, but the size of the type should
-    be at most 'SizeInBits' bits.
-  
 
 Existential Types and Generics
 ------------------------------

--- a/docs/HighLevelSILOptimizations.rst
+++ b/docs/HighLevelSILOptimizations.rst
@@ -55,8 +55,7 @@ Annotation of code in the standard library
 
 We use the ``@_semantics`` attribute to annotate code in the standard library.
 These annotations can be used by the high-level SIL optimizer to perform
-domain-specific optimizations. The same function may have multiple ``@_semantics``
-attributes.
+domain-specific optimizations.
 
 This is an example of the ``@_semantics`` attribute::
 
@@ -366,9 +365,6 @@ sil.specialize.generic.never
 
    The sil optimizer should never create generic specializations of this function. 
 
-optimize.sil.specialize.generic.partial.never
-
-   The sil optimizer should never create generic partial specializations of this function. 
 
 Availability checks
 ~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Reverts apple/swift#10073, which broke the doc build.