### PR TITLE
migrator: use the right method to get the location of return type. rdar://32545812

### DIFF
--- a/include/swift/AST/TypeLoc.h
+++ b/include/swift/AST/TypeLoc.h
@@ -54,6 +54,7 @@ public:
 
   /// Get the representative location of this type, for diagnostic
   /// purposes.
+  /// This location is not necessarily the start location of the type repr.
   SourceLoc getLoc() const;
   SourceRange getSourceRange() const;
 

--- a/lib/Migrator/APIDiffMigratorPass.cpp
+++ b/lib/Migrator/APIDiffMigratorPass.cpp
@@ -692,7 +692,7 @@ struct APIDiffMigratorPass : public ASTMigratorPass, public SourceEntityWalker {
     switch (DiffItem->DiffKind) {
     case NodeAnnotation::GetterToProperty: {
       auto FuncLoc = FD->getFuncLoc();
-      auto ReturnTyLoc = FD->getBodyResultTypeLoc().getLoc();
+      auto ReturnTyLoc = FD->getBodyResultTypeLoc().getSourceRange().Start;
       auto NameLoc = FD->getNameLoc();
       if (FuncLoc.isInvalid() || ReturnTyLoc.isInvalid() || NameLoc.isInvalid())
         break;

--- a/test/Migrator/Inputs/API.json
+++ b/test/Migrator/Inputs/API.json
@@ -108,6 +108,17 @@
   {
     "DiffItemKind": "CommonDiffItem",
     "NodeKind": "Function",
+    "NodeAnnotation": "GetterToProperty",
+    "ChildIndex": "0",
+    "LeftUsr": "c:@M@null@objc(cs)C(im)field2",
+    "LeftComment": "",
+    "RightUsr": "",
+    "RightComment": "",
+    "ModuleName": "bar"
+  },
+  {
+    "DiffItemKind": "CommonDiffItem",
+    "NodeKind": "Function",
     "NodeAnnotation": "SetterToProperty",
     "ChildIndex": "0",
     "LeftUsr": "c:objc(cs)PropertyUserInterface(im)setField:",

--- a/test/Migrator/mock-sdk/Bar.framework/Headers/Bar.h
+++ b/test/Migrator/mock-sdk/Bar.framework/Headers/Bar.h
@@ -11,7 +11,7 @@ int barGlobalVariableOldEnumElement = 1;
 int barGlobalFuncOldName(int a);
 
 @interface BarForwardDeclaredClass
-- (id)initWithOldLabel0:(int)frame;
+- (id _Nonnull)initWithOldLabel0:(int)frame;
 - (void) barInstanceFunc0;
 - (void) barInstanceFunc1:(int)info anotherValue:(int)info1 anotherValue1:(int)info2 anotherValue2:(int)info3;
 - (void) barInstanceFunc2:(int)info toRemove:(int)info1 toRemove1:(int)info2 toRemove2:(int)info3;
@@ -23,6 +23,7 @@ enum BarForwardDeclaredEnum {
 
 @interface PropertyUserInterface
 - (int) field;
+- (int * _Nullable) field2;
 - (void) setField:(int)info;
 + (int) fieldPlus;
 + (void) methodPlus:(int)info;

--- a/test/Migrator/property.swift
+++ b/test/Migrator/property.swift
@@ -11,4 +11,5 @@ func foo(_ a : PropertyUserInterface) {
 
 class C: PropertyUserInterface {
   public override func field() -> Int32 { return 1 }
+  public override func field2() -> UnsafeMutablePointer<Int32>? { return nil }
 }

--- a/test/Migrator/property.swift.expected
+++ b/test/Migrator/property.swift.expected
@@ -11,4 +11,5 @@ func foo(_ a : PropertyUserInterface) {
 
 class C: PropertyUserInterface {
   public override var field: Int32 { return 1 }
+  public override var field2: UnsafeMutablePointer<Int32>? { return nil }
 }


### PR DESCRIPTION
TypeLoc::getLoc() is not necessarily the start location of the type repr.
