### PR TITLE
[sil-generic-specializer] Do not specialize Mirror._superclassIterator to reduce the stdlib code size

### DIFF
--- a/stdlib/public/core/Mirror.swift
+++ b/stdlib/public/core/Mirror.swift
@@ -162,6 +162,8 @@ public struct Mirror {
     return nil
   }
 
+  @_semantics("optimize.sil.specialize.generic.never")
+  @inline(never)
   @_versioned
   internal static func _superclassIterator<Subject>(
     _ subject: Subject, _ ancestorRepresentation: AncestorRepresentation


### PR DESCRIPTION
This shaves off 3.2% of the stdlib’s code size.
