### PR TITLE
[4.0] [Type checker] Warn deprecated @objc used to satisfy protocol requirements

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3247,6 +3247,11 @@ NOTE(objc_overriding_objc_decl,none,
 NOTE(objc_witness_objc_requirement,none,
      "satisfying requirement for %0 %1 in protocol %2",
      (DescriptiveDeclKind, DeclName, DeclName))
+WARNING(witness_swift3_objc_inference,none,
+        "use of %0 %1 to satisfy a requirement of protocol %2 depends on "
+        "'@objc' attribute inference deprecated in Swift 4",
+        (DescriptiveDeclKind, DeclName, Type))
+
 
 ERROR(objc_invalid_on_func_curried,none,
       "method cannot be %" OBJC_ATTR_SELECT "0 because curried functions "

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -417,7 +417,7 @@ ERROR(expr_keypath_non_objc_property,none,
       (DeclName))
 WARNING(expr_keypath_swift3_objc_inference,none,
         "argument of '#keyPath' refers to property %0 in %1 that depends on "
-        "'@objc' attribute inference deprecated in Swift 4",
+        "'@objc' inference deprecated in Swift 4",
         (DeclName, Identifier))
 ERROR(expr_keypath_type_of_property,none,
       "cannot refer to type member %0 within instance of type %1",
@@ -489,7 +489,7 @@ NOTE(make_decl_objc,none,
      (DescriptiveDeclKind))
 WARNING(expr_selector_swift3_objc_inference,none,
         "argument of '#selector' refers to %0 %1 in %2 that depends on "
-        "'@objc' attribute inference deprecated in Swift 4",
+        "'@objc' inference deprecated in Swift 4",
         (DescriptiveDeclKind, DeclName, Identifier))
 
 // Selectors-as-string-literals.
@@ -1154,7 +1154,7 @@ NOTE(variadic_superclass_init_here,none,
      "variadic superclass initializer defined here", ())
 
 WARNING(expr_dynamic_lookup_swift3_objc_inference,none,
-        "reference to %0 %1 of %2 depends on '@objc' attribute inference "
+        "reference to %0 %1 of %2 depends on '@objc' inference "
         "deprecated in Swift 4",
         (DescriptiveDeclKind, DeclName, Identifier))
 
@@ -3143,7 +3143,7 @@ NOTE(objc_inference_swift3_addnonobjc,none,
 
 ERROR(objc_for_generic_class,none,
       "generic subclasses of '@objc' classes cannot have an explicit '@objc' "
-      "attribute because they are not directly visible from Objective-C", ())
+      "because they are not directly visible from Objective-C", ())
 ERROR(objc_getter_for_nonobjc_property,none,
       "'@objc' getter for non-'@objc' property", ())
 ERROR(objc_getter_for_nonobjc_subscript,none,
@@ -3249,7 +3249,7 @@ NOTE(objc_witness_objc_requirement,none,
      (DescriptiveDeclKind, DeclName, DeclName))
 WARNING(witness_swift3_objc_inference,none,
         "use of %0 %1 to satisfy a requirement of protocol %2 depends on "
-        "'@objc' attribute inference deprecated in Swift 4",
+        "'@objc' inference deprecated in Swift 4",
         (DescriptiveDeclKind, DeclName, Type))
 
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5065,6 +5065,23 @@ void ConformanceChecker::checkConformance(MissingWitnessDiagnosisKind Kind) {
           Conformance->setInvalid();
           return;
         }
+
+        // If the @objc on the witness was inferred using the deprecated
+        // Swift 3 rules, warn if asked.
+        if (auto attr = witness->getAttrs().getAttribute<ObjCAttr>()) {
+          if (attr->isSwift3Inferred() &&
+              TC.Context.LangOpts.WarnSwift3ObjCInference
+                == Swift3ObjCInferenceWarnings::Minimal) {
+            TC.diagnose(Conformance->getLoc(),
+                        diag::witness_swift3_objc_inference,
+                        witness->getDescriptiveKind(), witness->getFullName(),
+                        Conformance->getProtocol()->getDeclaredInterfaceType());
+            TC.diagnose(witness, diag::make_decl_objc,
+                        witness->getDescriptiveKind())
+              .fixItInsert(witness->getAttributeInsertionLoc(false),
+                           "@objc ");
+          }
+        }
       }
     };
 

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -161,7 +161,7 @@ class subject_class1 { // no-error
 class subject_class2 : Protocol_Class1, PlainProtocol { // no-error
 }
 
-@objc // expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc' attribute because they are not directly visible from Objective-C}} {{1-7=}}
+@objc // expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc' because they are not directly visible from Objective-C}} {{1-7=}}
 class subject_genericClass<T> {
   @objc
   var subject_instanceVar: Int // no-error
@@ -173,7 +173,7 @@ class subject_genericClass<T> {
   func subject_instanceFunc() {} // no_error
 }
 
-@objc // expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc' attribute}} {{1-7=}}
+@objc // expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc'}} {{1-7=}}
 class subject_genericClass2<T> : Class_ObjC1 {
   @objc
   var subject_instanceVar: Int // no-error
@@ -359,10 +359,10 @@ class ConcreteContext3 {
 }
 
 func genericContext1<T>(_: T) {
-  @objc // expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc' attribute because they are not directly visible from Objective-C}} {{3-9=}}
+  @objc // expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc' because they are not directly visible from Objective-C}} {{3-9=}}
   class subject_inGenericContext {} // expected-error{{type 'subject_inGenericContext' cannot be nested in generic function 'genericContext1'}}
 
-  @objc // expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc' attribute}} {{3-9=}}
+  @objc // expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc'}} {{3-9=}}
   class subject_inGenericContext2 : Class_ObjC1 {} // expected-error{{type 'subject_inGenericContext2' cannot be nested in generic function 'genericContext1'}}
 
   class subject_constructor_inGenericContext { // expected-error{{type 'subject_constructor_inGenericContext' cannot be nested in generic function 'genericContext1'}}
@@ -382,10 +382,10 @@ func genericContext1<T>(_: T) {
 }
 
 class GenericContext2<T> {
-  @objc // expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc' attribute because they are not directly visible from Objective-C}} {{3-9=}}
+  @objc // expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc' because they are not directly visible from Objective-C}} {{3-9=}}
   class subject_inGenericContext {}
 
-  @objc // expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc' attribute}} {{3-9=}}
+  @objc // expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc'}} {{3-9=}}
   class subject_inGenericContext2 : Class_ObjC1 {}
 
   @objc
@@ -394,10 +394,10 @@ class GenericContext2<T> {
 
 class GenericContext3<T> {
   class MoreNested {
-    @objc // expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc' attribute because they are not directly visible from Objective-C}} {{5-11=}}
+    @objc // expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc' because they are not directly visible from Objective-C}} {{5-11=}}
     class subject_inGenericContext {}
 
-    @objc // expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc' attribute}} {{5-11=}}
+    @objc // expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc'}} {{5-11=}}
     class subject_inGenericContext2 : Class_ObjC1 {}
 
     @objc
@@ -405,14 +405,14 @@ class GenericContext3<T> {
   }
 }
 
-@objc // expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc' attribute because they are not directly visible from Objective-C}} {{1-7=}}
+@objc // expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc' because they are not directly visible from Objective-C}} {{1-7=}}
 class ConcreteSubclassOfGeneric : GenericContext3<Int> {}
 
 extension ConcreteSubclassOfGeneric {
   @objc func foo() {} // expected-error {{@objc is not supported within extensions of generic classes}}
 }
 
-@objc // expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc' attribute}} {{1-7=}}
+@objc // expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc'}} {{1-7=}}
 class ConcreteSubclassOfGeneric2 : subject_genericClass2<Int> {}
 
 extension ConcreteSubclassOfGeneric2 {

--- a/test/attr/attr_objc_swift3_deprecated_uses.swift
+++ b/test/attr/attr_objc_swift3_deprecated_uses.swift
@@ -86,3 +86,19 @@ func testDynamicCalls(ao: AnyObject) {
   ao.foo?() // expected-warning{{reference to instance method 'foo()' of 'ObjCSubclass' depends on '@objc' attribute inference deprecated in Swift 4}}
   _ = ao.bar! // expected-warning{{reference to var 'bar' of 'ObjCSubclass' depends on '@objc' attribute inference deprecated in Swift 4}}
 }
+
+// Subclass uses superclass members to satisfy an @objc protocol requirement.
+// rdar://problem/32431838
+@objc public protocol P {
+  func method()
+  @objc optional func optionalMethod()
+}
+
+class C : NSObject {
+  func method() { } // expected-note{{add '@objc' to expose this instance method to Objective-C}}{{3-3=@objc }}
+  func optionalMethod() { } // expected-note{{add '@objc' to expose this instance method to Objective-C}}{{3-3=@objc }}
+}
+
+class S : C, P {}
+// expected-warning@-1{{use of instance method 'method()' to satisfy a requirement of protocol 'P' depends on '@objc' attribute inference deprecated in Swift 4}}
+// expected-warning@-2{{use of instance method 'optionalMethod()' to satisfy a requirement of protocol 'P' depends on '@objc' attribute inference deprecated in Swift 4}}

--- a/test/attr/attr_objc_swift3_deprecated_uses.swift
+++ b/test/attr/attr_objc_swift3_deprecated_uses.swift
@@ -73,18 +73,18 @@ class SubclassDynamicMembers : DynamicMembers {
 }
 
 func testSelector(sc: ObjCSubclass, dm: DynamicMembers) {
-  _ = #selector(sc.foo) // expected-warning{{argument of '#selector' refers to instance method 'foo()' in 'ObjCSubclass' that depends on '@objc' attribute inference deprecated in Swift 4}}
+  _ = #selector(sc.foo) // expected-warning{{argument of '#selector' refers to instance method 'foo()' in 'ObjCSubclass' that depends on '@objc' inference deprecated in Swift 4}}
   _ = #selector(getter: dm.bar) // okay, explicit dynamic
 }
 
 func testKeypath(dm: DynamicMembers) {
-  _ = #keyPath(ObjCSubclass.bar)   // expected-warning{{argument of '#keyPath' refers to property 'bar' in 'ObjCSubclass' that depends on '@objc' attribute inference deprecated in Swift 4}}
+  _ = #keyPath(ObjCSubclass.bar)   // expected-warning{{argument of '#keyPath' refers to property 'bar' in 'ObjCSubclass' that depends on '@objc' inference deprecated in Swift 4}}
   _ = #keyPath(DynamicMembers.bar) // okay: dynamic keyword implies @objc
 }
 
 func testDynamicCalls(ao: AnyObject) {
-  ao.foo?() // expected-warning{{reference to instance method 'foo()' of 'ObjCSubclass' depends on '@objc' attribute inference deprecated in Swift 4}}
-  _ = ao.bar! // expected-warning{{reference to var 'bar' of 'ObjCSubclass' depends on '@objc' attribute inference deprecated in Swift 4}}
+  ao.foo?() // expected-warning{{reference to instance method 'foo()' of 'ObjCSubclass' depends on '@objc' inference deprecated in Swift 4}}
+  _ = ao.bar! // expected-warning{{reference to var 'bar' of 'ObjCSubclass' depends on '@objc' inference deprecated in Swift 4}}
 }
 
 // Subclass uses superclass members to satisfy an @objc protocol requirement.
@@ -100,5 +100,5 @@ class C : NSObject {
 }
 
 class S : C, P {}
-// expected-warning@-1{{use of instance method 'method()' to satisfy a requirement of protocol 'P' depends on '@objc' attribute inference deprecated in Swift 4}}
-// expected-warning@-2{{use of instance method 'optionalMethod()' to satisfy a requirement of protocol 'P' depends on '@objc' attribute inference deprecated in Swift 4}}
+// expected-warning@-1{{use of instance method 'method()' to satisfy a requirement of protocol 'P' depends on '@objc' inference deprecated in Swift 4}}
+// expected-warning@-2{{use of instance method 'optionalMethod()' to satisfy a requirement of protocol 'P' depends on '@objc' inference deprecated in Swift 4}}


### PR DESCRIPTION
Explanation: Warn about uses of declarations which have inferred @objc due to the
deprecated Swift 3 rules when the declarations are used to satisfy a
requirement of an @objc protocol.
Scope: Improves the migration experience for SE-0160.
Radar: rdar://problem/32431838
Risk: Very low; introduces a warning that is only enabled when a particular warning flag is passed to the compiler.
Testing: Compiler regression testing,