### PR TITLE
[swiftc (29 vs. 5544)] Add crasher in swift::ProtocolConformanceRef

### DIFF
--- a/validation-test/compiler_crashers/28764-swift-protocolconformanceref-llvm-function-ref-swift-protocolconformanceref-swif.swift
+++ b/validation-test/compiler_crashers/28764-swift-protocolconformanceref-llvm-function-ref-swift-protocolconformanceref-swif.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol P{typealias a}{protocol A:P{{}class a{{}}typealias a:RangeReplaceableCollection


### PR DESCRIPTION
Add test case for crash triggered in `swift::ProtocolConformanceRef`.

Current number of unresolved compiler crashers: 29 (5544 resolved)

Stack trace:

```
0 0x0000000003a5eb78 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3a5eb78)
1 0x0000000003a5f2b6 SignalHandler(int) (/path/to/swift/bin/swift+0x3a5f2b6)
2 0x00007f4adba35390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x0000000001575f1d swift::ProtocolConformanceRef llvm::function_ref<swift::ProtocolConformanceRef (swift::ProtocolDecl*)>::callback_fn<swift::GenericSignatureBuilder::addSameTypeRequirementToConcrete(swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type, swift::GenericSignatureBuilder::RequirementSource const*)::$_23>(long, swift::ProtocolDecl*) (/path/to/swift/bin/swift+0x1575f1d)
4 0x000000000155fbc9 concretizeNestedTypeFromConcreteParent(swift::GenericSignatureBuilder::PotentialArchetype*, swift::GenericSignatureBuilder::RequirementSource const*, swift::GenericSignatureBuilder::PotentialArchetype*, swift::GenericSignatureBuilder&, llvm::function_ref<swift::ProtocolConformanceRef (swift::ProtocolDecl*)>) (/path/to/swift/bin/swift+0x155fbc9)
5 0x0000000001568549 swift::GenericSignatureBuilder::addSameTypeRequirementToConcrete(swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type, swift::GenericSignatureBuilder::RequirementSource const*) (/path/to/swift/bin/swift+0x1568549)
6 0x0000000001567c0c swift::GenericSignatureBuilder::addSameTypeRequirement(llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::FloatingRequirementSource, swift::GenericSignatureBuilder::UnresolvedHandlingKind, llvm::function_ref<void (swift::Type, swift::Type)>) (/path/to/swift/bin/swift+0x1567c0c)
7 0x000000000155ee8e swift::GenericSignatureBuilder::PotentialArchetype::updateNestedTypeForConformance(llvm::PointerUnion<swift::AssociatedTypeDecl*, swift::TypeDecl*>, swift::GenericSignatureBuilder::PotentialArchetype::NestedTypeUpdate) (/path/to/swift/bin/swift+0x155ee8e)
8 0x000000000155d9d2 swift::GenericSignatureBuilder::PotentialArchetype::getNestedArchetypeAnchor(swift::Identifier, swift::GenericSignatureBuilder&, swift::GenericSignatureBuilder::PotentialArchetype::NestedTypeUpdate) (/path/to/swift/bin/swift+0x155d9d2)
9 0x000000000156be5c swift::GenericSignatureBuilder::checkSameTypeConstraints(llvm::ArrayRef<swift::GenericTypeParamType*>, swift::GenericSignatureBuilder::PotentialArchetype*) (/path/to/swift/bin/swift+0x156be5c)
10 0x0000000001569100 swift::GenericSignatureBuilder::finalize(swift::SourceLoc, llvm::ArrayRef<swift::GenericTypeParamType*>, bool) (/path/to/swift/bin/swift+0x1569100)
11 0x000000000136eaca swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0x136eaca)
12 0x0000000001353844 (anonymous namespace)::DeclChecker::visitConstructorDecl(swift::ConstructorDecl*) (/path/to/swift/bin/swift+0x1353844)
13 0x0000000001340eb4 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x1340eb4)
14 0x0000000001340da3 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x1340da3)
15 0x0000000001431c7e swift::createImplicitConstructor(swift::TypeChecker&, swift::NominalTypeDecl*, swift::ImplicitConstructorKind) (/path/to/swift/bin/swift+0x1431c7e)
16 0x00000000013494c2 swift::TypeChecker::defineDefaultConstructor(swift::NominalTypeDecl*) (/path/to/swift/bin/swift+0x13494c2)
17 0x0000000001348366 swift::TypeChecker::addImplicitConstructors(swift::NominalTypeDecl*) (/path/to/swift/bin/swift+0x1348366)
18 0x0000000001351af5 (anonymous namespace)::DeclChecker::visitClassDecl(swift::ClassDecl*) (/path/to/swift/bin/swift+0x1351af5)
19 0x0000000001340f9e (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x1340f9e)
20 0x0000000001352bdb (anonymous namespace)::DeclChecker::visitProtocolDecl(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0x1352bdb)
21 0x0000000001340ea4 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x1340ea4)
22 0x0000000001340da3 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x1340da3)
23 0x00000000013ada86 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13ada86)
24 0x00000000013ad13b swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) (/path/to/swift/bin/swift+0x13ad13b)
25 0x00000000013d102c swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) (/path/to/swift/bin/swift+0x13d102c)
26 0x000000000132a22d swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x132a22d)
27 0x00000000013adae5 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13adae5)
28 0x00000000013ad2f6 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0x13ad2f6)
29 0x00000000013cb730 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x13cb730)
30 0x0000000000f92b76 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf92b76)
31 0x00000000004aaa09 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4aaa09)
32 0x00000000004a8f9c swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a8f9c)
33 0x00000000004655c7 main (/path/to/swift/bin/swift+0x4655c7)
34 0x00007f4ad9f46830 __libc_start_main /build/glibc-9tT8Do/glibc-2.23/csu/../csu/libc-start.c:325:0
35 0x0000000000462c69 _start (/path/to/swift/bin/swift+0x462c69)
```