### PR TITLE
Guaranteed ARC Opts: Access instructions do not reduce refcounts.

### DIFF
--- a/lib/SILOptimizer/Mandatory/GuaranteedARCOpts.cpp
+++ b/lib/SILOptimizer/Mandatory/GuaranteedARCOpts.cpp
@@ -76,7 +76,9 @@ static bool couldReduceStrongRefcount(SILInstruction *Inst) {
       isa<RetainValueInst>(Inst) || isa<UnownedRetainInst>(Inst) ||
       isa<UnownedReleaseInst>(Inst) || isa<StrongRetainUnownedInst>(Inst) ||
       isa<StoreWeakInst>(Inst) || isa<StrongRetainInst>(Inst) ||
-      isa<AllocStackInst>(Inst) || isa<DeallocStackInst>(Inst))
+      isa<AllocStackInst>(Inst) || isa<DeallocStackInst>(Inst) ||
+      isa<BeginAccessInst>(Inst) || isa<EndAccessInst>(Inst) ||
+      isa<BeginUnpairedAccessInst>(Inst) || isa<EndUnpairedAccessInst>(Inst))
     return false;
 
   // Assign and copyaddr of trivial types cannot drop refcounts, and 'inits'


### PR DESCRIPTION
Fixes <rdar://problem/32560531> MatMul regression with dynamic
exclusivity checks due to retain/release.
