### PR TITLE
Guaranteed ARC Opts: Access instructions do not reduce refcounts.

### DIFF
--- a/lib/SILOptimizer/Mandatory/GuaranteedARCOpts.cpp
+++ b/lib/SILOptimizer/Mandatory/GuaranteedARCOpts.cpp
@@ -76,7 +76,9 @@ static bool couldReduceStrongRefcount(SILInstruction *Inst) {
       isa<RetainValueInst>(Inst) || isa<UnownedRetainInst>(Inst) ||
       isa<UnownedReleaseInst>(Inst) || isa<StrongRetainUnownedInst>(Inst) ||
       isa<StoreWeakInst>(Inst) || isa<StrongRetainInst>(Inst) ||
-      isa<AllocStackInst>(Inst) || isa<DeallocStackInst>(Inst))
+      isa<AllocStackInst>(Inst) || isa<DeallocStackInst>(Inst) ||
+      isa<BeginAccessInst>(Inst) || isa<EndAccessInst>(Inst) ||
+      isa<BeginUnpairedAccessInst>(Inst) || isa<EndUnpairedAccessInst>(Inst))
     return false;
 
   // Assign and copyaddr of trivial types cannot drop refcounts, and 'inits'

--- a/test/SILOptimizer/guaranteed_arc_opts_qualified.sil
+++ b/test/SILOptimizer/guaranteed_arc_opts_qualified.sil
@@ -137,3 +137,24 @@ bb0(%0 : $*Builtin.NativeObject):
   %9999 = tuple()
   return %9999 : $()
 }
+
+class C {
+  var val: Builtin.Int32
+  init(i: Builtin.Int32)
+  deinit
+}
+
+// CHECK-LABEL: sil @access_test : $@convention(thin) (@owned C, Builtin.Int32) -> ()
+// CHECK-NOT: strong_retain
+// CHECK-NOT: strong_release
+sil @access_test : $@convention(thin) (@owned C, Builtin.Int32) -> () {
+bb0(%0 : $C, %1 : $Builtin.Int32):
+  strong_retain %0 : $C
+  %valadr = ref_element_addr %0 : $C, #C.val
+  %access = begin_access [modify] [dynamic] %valadr : $*Builtin.Int32
+  store %1 to %access : $*Builtin.Int32
+  end_access %access : $*Builtin.Int32
+  strong_release %0 : $C
+  %9999 = tuple()
+  return %9999 : $()
+}


### PR DESCRIPTION
Fixes <rdar://problem/32560531> MatMul regression with dynamic
exclusivity checks due to retain/release.

(cherry picked from commit b44bc36834541089bd8d46145b28bb444adefafc)
