### PR TITLE
[swiftc (30 vs. 5544)] Add crasher in swift::GenericSignature::getConformanceAccessPath

### DIFF
--- a/validation-test/compiler_crashers/28765-inprotocol-isrequirementsignaturecomputed-missing-signature.swift
+++ b/validation-test/compiler_crashers/28765-inprotocol-isrequirementsignaturecomputed-missing-signature.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol P{{}class a:A{}protocol A:P.a{typealias a{}func a:a


### PR DESCRIPTION
Add test case for crash triggered in `swift::GenericSignature::getConformanceAccessPath`.

Current number of unresolved compiler crashers: 30 (5544 resolved)

/cc @DougGregor - just wanted to let you know that this crasher caused an assertion failure for the assertion `inProtocol->isRequirementSignatureComputed() && "missing signature"` added on 2017-03-08 by you in commit 1f8b0f9b :-)

Assertion failure in [`lib/AST/GenericSignature.cpp (line 857)`](https://github.com/apple/swift/blob/aae1b681e76840593c0bf286a78a353d00640e48/lib/AST/GenericSignature.cpp#L857):

```
Assertion `inProtocol->isRequirementSignatureComputed() && "missing signature"' failed.

When executing: auto swift::GenericSignature::getConformanceAccessPath(swift::Type, swift::ProtocolDecl *, swift::ModuleDecl &)::(anonymous class)::operator()(swift::GenericSignature *, const RequirementSource *, swift::ProtocolDecl *, swift::Type) const
```

Assertion context:

```c++

      // Canonicalize this step with respect to the requirement signature.
      if (!inProtocol->isRequirementSignatureComputed()) {
        inProtocol->computeRequirementSignature();
        assert(inProtocol->isRequirementSignatureComputed() &&
               "missing signature");
      }

      // Get a generic signature builder for the requirement signature. This has
      // the requirement we need.
      auto reqSig = inProtocol->getRequirementSignature();
```
Stack trace:

```
0 0x0000000003a5f2b8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3a5f2b8)
1 0x0000000003a5f9f6 SignalHandler(int) (/path/to/swift/bin/swift+0x3a5f9f6)
2 0x00007fa1551e2390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007fa153708428 gsignal /build/glibc-9tT8Do/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007fa15370a02a abort /build/glibc-9tT8Do/glibc-2.23/stdlib/abort.c:91:0
5 0x00007fa153700bd7 __assert_fail_base /build/glibc-9tT8Do/glibc-2.23/assert/assert.c:92:0
6 0x00007fa153700c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x00000000015570f0 std::_Function_base::_Base_manager<swift::GenericSignature::getConformanceAccessPath(swift::Type, swift::ProtocolDecl*, swift::ModuleDecl&)::$_11>::_M_manager(std::_Any_data&, std::_Any_data const&, std::_Manager_operation) (/path/to/swift/bin/swift+0x15570f0)
8 0x0000000001556fc3 std::_Function_handler<void (swift::GenericSignature*, swift::GenericSignatureBuilder::RequirementSource const*, swift::ProtocolDecl*, swift::Type), swift::GenericSignature::getConformanceAccessPath(swift::Type, swift::ProtocolDecl*, swift::ModuleDecl&)::$_11>::_M_invoke(std::_Any_data const&, swift::GenericSignature*&&, swift::GenericSignatureBuilder::RequirementSource const*&&, swift::ProtocolDecl*&&, swift::Type&&) (/path/to/swift/bin/swift+0x1556fc3)
9 0x0000000001555d09 swift::GenericSignature::getConformanceAccessPath(swift::Type, swift::ProtocolDecl*, swift::ModuleDecl&) (/path/to/swift/bin/swift+0x1555d09)
10 0x00000000015ad825 swift::SubstitutionMap::lookupConformance(swift::CanType, swift::ProtocolDecl*) const (/path/to/swift/bin/swift+0x15ad825)
11 0x00000000015b9f80 swift::LookUpConformanceInSubstitutionMap::operator()(swift::CanType, swift::Type, swift::ProtocolType*) const (/path/to/swift/bin/swift+0x15b9f80)
12 0x0000000000c246d9 llvm::Optional<swift::ProtocolConformanceRef> llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>::callback_fn<swift::LookUpConformanceInSubstitutionMap>(long, swift::CanType, swift::Type, swift::ProtocolType*) (/path/to/swift/bin/swift+0xc246d9)
13 0x00000000015ba484 getMemberForBaseType(llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::Type, swift::Type, swift::AssociatedTypeDecl*, swift::Identifier, swift::SubstOptions) (/path/to/swift/bin/swift+0x15ba484)
14 0x00000000015bee5d llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_17>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x15bee5d)
15 0x00000000015bb3d9 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15bb3d9)
16 0x00000000015b6765 swift::Type::subst(swift::SubstitutionMap const&, swift::SubstOptions) const (/path/to/swift/bin/swift+0x15b6765)
17 0x00000000013bc10e swift::TypeChecker::substMemberTypeWithBase(swift::ModuleDecl*, swift::TypeDecl*, swift::Type) (/path/to/swift/bin/swift+0x13bc10e)
18 0x00000000013bbe00 swift::TypeChecker::resolveTypeInContext(swift::TypeDecl*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0x13bbe00)
19 0x00000000013c3a1e resolveTypeDecl(swift::TypeChecker&, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13c3a1e)
20 0x00000000013c2e19 resolveTopLevelIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13c2e19)
21 0x00000000013bdab3 resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13bdab3)
22 0x00000000013bd489 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13bd489)
23 0x00000000013be1f8 (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0x13be1f8)
24 0x00000000013be0fc swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13be0fc)
25 0x00000000013bcb50 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13bcb50)
26 0x00000000013556d3 (anonymous namespace)::DeclChecker::visitFuncDecl(swift::FuncDecl*) (/path/to/swift/bin/swift+0x13556d3)
27 0x0000000001341454 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x1341454)
28 0x000000000134346d swift::TypeChecker::validateDecl(swift::ValueDecl*) (/path/to/swift/bin/swift+0x134346d)
29 0x0000000001341f12 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x1341f12)
30 0x000000000135316b (anonymous namespace)::DeclChecker::visitProtocolDecl(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0x135316b)
31 0x0000000001341434 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x1341434)
32 0x000000000135316b (anonymous namespace)::DeclChecker::visitProtocolDecl(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0x135316b)
33 0x0000000001341434 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x1341434)
34 0x0000000001341333 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x1341333)
35 0x00000000013cba85 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x13cba85)
36 0x0000000000f93106 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf93106)
37 0x00000000004aaa09 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4aaa09)
38 0x00000000004a8f9c swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a8f9c)
39 0x00000000004655c7 main (/path/to/swift/bin/swift+0x4655c7)
40 0x00007fa1536f3830 __libc_start_main /build/glibc-9tT8Do/glibc-2.23/csu/../csu/libc-start.c:325:0
41 0x0000000000462c69 _start (/path/to/swift/bin/swift+0x462c69)
```