### PR TITLE
[swiftc (31 vs. 5544)] Add crasher in swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(...)

### DIFF
--- a/validation-test/compiler_crashers/28766-swift-iterativetypechecker-isqualifiedlookupindeclcontextsatisfied-swift-declcon.swift
+++ b/validation-test/compiler_crashers/28766-swift-iterativetypechecker-isqualifiedlookupindeclcontextsatisfied-swift-declcon.swift
@@ -1,0 +1,11 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol P{ a
+typealias e:A.eas ea}class A:Self.a{
+class a:A


### PR DESCRIPTION
Add test case for crash triggered in `swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(...)`.

Current number of unresolved compiler crashers: 31 (5544 resolved)

Stack trace:

```
0 0x0000000003a5f2b8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3a5f2b8)
1 0x0000000003a5f9f6 SignalHandler(int) (/path/to/swift/bin/swift+0x3a5f9f6)
2 0x00007fbcdc7c4390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00000000014792e9 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14792e9)
4 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
5 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
6 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
7 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
8 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
9 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
10 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
11 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
12 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
13 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
14 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
15 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
16 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
17 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
18 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
19 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
20 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
21 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
22 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
23 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
24 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
25 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
26 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
27 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
28 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
29 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
30 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
31 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
32 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
33 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
34 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
35 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
36 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
37 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
38 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
39 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
40 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
41 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
42 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
43 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
44 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
45 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
46 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
47 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
48 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
49 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
50 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
51 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
52 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
53 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
54 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
55 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
56 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
57 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
58 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
59 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
60 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
61 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
62 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
63 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
64 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
65 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
66 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
67 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
68 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
69 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
70 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
71 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
72 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
73 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
74 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
75 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
76 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
77 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
78 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
79 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
80 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
81 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
82 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
83 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
84 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
85 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
86 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
87 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
88 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
89 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
90 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
91 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
92 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
93 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
94 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
95 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
96 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
97 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
98 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
99 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
100 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
101 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
102 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
103 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
104 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
105 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
106 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
107 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
108 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
109 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
110 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
111 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
112 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
113 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
114 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
115 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
116 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
117 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
118 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
119 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
120 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
121 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
122 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
123 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
124 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
125 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
126 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
127 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
128 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
129 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
130 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
131 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
132 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
133 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
134 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
135 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
136 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
137 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
138 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
139 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
140 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
141 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
142 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
143 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
144 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
145 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
146 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
147 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
148 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
149 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
150 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
151 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
152 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
153 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
154 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
155 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
156 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
157 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
158 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
159 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
160 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
161 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
162 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
163 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
164 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
165 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
166 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
167 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
168 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
169 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
170 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
171 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
172 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
173 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
174 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
175 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
176 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
177 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
178 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
179 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
180 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
181 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
182 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
183 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
184 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
185 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
186 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
187 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
188 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
189 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
190 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
191 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
192 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
193 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
194 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
195 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
196 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
197 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
198 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
199 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
200 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
201 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
202 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
203 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
204 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
205 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
206 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
207 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
208 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
209 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
210 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
211 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
212 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
213 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
214 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
215 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
216 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
217 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
218 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
219 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
220 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
221 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
222 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
223 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
224 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
225 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
226 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
227 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
228 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
229 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
230 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
231 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
232 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
233 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
234 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
235 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
236 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
237 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
238 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
239 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
240 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
241 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
242 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
243 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
244 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
245 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
246 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
247 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
248 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
249 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
250 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
251 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
252 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
253 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
254 0x0000000001441d9e swift::IterativeTypeChecker::isSatisfied(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1441d9e)
255 0x00000000014793d6 swift::IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(swift::DeclContextLookupInfo) (/path/to/swift/bin/swift+0x14793d6)
```