### PR TITLE
[swiftc (33 vs. 5544)] Add crasher in swift::TypeBase::getCanonicalType(...)

### DIFF
--- a/validation-test/compiler_crashers/28768-isactuallycanonicalornull-forming-a-cantype-out-of-a-non-canonical-type.swift
+++ b/validation-test/compiler_crashers/28768-isactuallycanonicalornull-forming-a-cantype-out-of-a-non-canonical-type.swift
@@ -1,0 +1,11 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+Indexable
+& ManagedBuffer


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeBase::getCanonicalType(...)`.

Current number of unresolved compiler crashers: 33 (5544 resolved)

Assertion failure in [`include/swift/AST/Type.h (line 389)`](https://github.com/apple/swift/blob/2b0ddcd1d7da4df2e33bcfe8e5db097088fd0e49/include/swift/AST/Type.h#L389):

```
Assertion `isActuallyCanonicalOrNull() && "Forming a CanType out of a non-canonical type!"' failed.

When executing: swift::CanType::CanType(swift::TypeBase *)
```

Assertion context:

```c++
  static CanType getLValueOrInOutObjectTypeImpl(CanType type);

public:
  explicit CanType(TypeBase *P = 0) : Type(P) {
    assert(isActuallyCanonicalOrNull() &&
           "Forming a CanType out of a non-canonical type!");
  }
  explicit CanType(Type T) : Type(T) {
    assert(isActuallyCanonicalOrNull() &&
           "Forming a CanType out of a non-canonical type!");
  }
```
Stack trace:

```
0 0x0000000003a5f2b8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3a5f2b8)
1 0x0000000003a5f9f6 SignalHandler(int) (/path/to/swift/bin/swift+0x3a5f9f6)
2 0x00007f122f60b390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007f122db31428 gsignal /build/glibc-9tT8Do/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f122db3302a abort /build/glibc-9tT8Do/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f122db29bd7 __assert_fail_base /build/glibc-9tT8Do/glibc-2.23/assert/assert.c:92:0
6 0x00007f122db29c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x00000000015b182c swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x15b182c)
8 0x00000000015b139b swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x15b139b)
9 0x00000000012c7e5b swift::ASTVisitor<(anonymous namespace)::ConstraintGenerator, swift::Type, void, void, void, void, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x12c7e5b)
10 0x00000000012cddc8 (anonymous namespace)::ConstraintWalker::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0x12cddc8)
11 0x000000000150b49c swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x150b49c)
12 0x00000000012c4961 swift::constraints::ConstraintSystem::generateConstraints(swift::Expr*) (/path/to/swift/bin/swift+0x12c4961)
13 0x00000000012ee2e6 swift::constraints::ConstraintSystem::solve(swift::Expr*&, swift::Type, swift::ExprTypeCheckListener*, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0x12ee2e6)
14 0x0000000001326d44 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0x1326d44)
15 0x000000000132a6c2 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x132a6c2)
16 0x00000000013adeb5 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13adeb5)
17 0x00000000013ad6c6 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0x13ad6c6)
18 0x00000000013cbb00 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x13cbb00)
19 0x0000000000f93106 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf93106)
20 0x00000000004aaa09 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4aaa09)
21 0x00000000004a8f9c swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a8f9c)
22 0x00000000004655c7 main (/path/to/swift/bin/swift+0x4655c7)
23 0x00007f122db1c830 __libc_start_main /build/glibc-9tT8Do/glibc-2.23/csu/../csu/libc-start.c:325:0
24 0x0000000000462c69 _start (/path/to/swift/bin/swift+0x462c69)
```