### PR TITLE
[swiftc (34 vs. 5544)] Add crasher in swift::TypeChecker::resolveWitness

### DIFF
--- a/validation-test/compiler_crashers/28769-conformance-gettypewitness-assoctype-nullptr-isequal-type-conflicting-type-witne.swift
+++ b/validation-test/compiler_crashers/28769-conformance-gettypewitness-assoctype-nullptr-isequal-type-conflicting-type-witne.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol P{{}func a{}typealias e}struct A:P{typealias e:Self.a{}typealias e:Self.a{}typealias e:P


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeChecker::resolveWitness`.

Current number of unresolved compiler crashers: 34 (5544 resolved)

/cc @DougGregor - just wanted to let you know that this crasher caused an assertion failure for the assertion `Conformance->getTypeWitness(assocType, nullptr) ->isEqual(type) && "Conflicting type witness deductions"` added on 2017-04-04 by you in commit 5c89eb84 :-)

Assertion failure in [`lib/Sema/TypeCheckProtocol.cpp (line 2497)`](https://github.com/apple/swift/blob/a5b5609137882ac2939ca96fbe3025fb6e34640d/lib/Sema/TypeCheckProtocol.cpp#L2497):

```
Assertion `Conformance->getTypeWitness(assocType, nullptr) ->isEqual(type) && "Conflicting type witness deductions"' failed.

When executing: void (anonymous namespace)::ConformanceChecker::recordTypeWitness(swift::AssociatedTypeDecl *, swift::Type, swift::TypeDecl *, bool)
```

Assertion context:

```c++
                                           bool performRedeclarationCheck) {

  // If we already recoded this type witness, there's nothing to do.
  if (Conformance->hasTypeWitness(assocType)) {
    assert(Conformance->getTypeWitness(assocType, nullptr)
             ->isEqual(type) && "Conflicting type witness deductions");
    return;
  }

  if (typeDecl) {
    // Check access.
```
Stack trace:

```
0 0x0000000003a5f2b8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3a5f2b8)
1 0x0000000003a5f9f6 SignalHandler(int) (/path/to/swift/bin/swift+0x3a5f9f6)
2 0x00007fc4aecc3390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007fc4ad1e9428 gsignal /build/glibc-9tT8Do/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007fc4ad1eb02a abort /build/glibc-9tT8Do/glibc-2.23/stdlib/abort.c:91:0
5 0x00007fc4ad1e1bd7 __assert_fail_base /build/glibc-9tT8Do/glibc-2.23/assert/assert.c:92:0
6 0x00007fc4ad1e1c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x000000000139b0ef (anonymous namespace)::ConformanceChecker::recordTypeWitness(swift::AssociatedTypeDecl*, swift::Type, swift::TypeDecl*, bool) (/path/to/swift/bin/swift+0x139b0ef)
8 0x0000000001398507 (anonymous namespace)::ConformanceChecker::resolveTypeWitnessViaLookup(swift::AssociatedTypeDecl*) (/path/to/swift/bin/swift+0x1398507)
9 0x000000000138578a (anonymous namespace)::ConformanceChecker::resolveTypeWitnesses() (/path/to/swift/bin/swift+0x138578a)
10 0x000000000138737c swift::TypeChecker::resolveWitness(swift::NormalProtocolConformance const*, swift::ValueDecl*) (/path/to/swift/bin/swift+0x138737c)
11 0x00000000015a53fd swift::NormalProtocolConformance::getWitness(swift::ValueDecl*, swift::LazyResolver*) const (/path/to/swift/bin/swift+0x15a53fd)
12 0x00000000015a52cf swift::ProtocolConformance::getWitnessDecl(swift::ValueDecl*, swift::LazyResolver*) const (/path/to/swift/bin/swift+0x15a52cf)
13 0x0000000001373e3b (anonymous namespace)::LookupResultBuilder::add(swift::ValueDecl*, swift::ValueDecl*, swift::Type) (/path/to/swift/bin/swift+0x1373e3b)
14 0x0000000001374699 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>)::$_1::operator()() const (/path/to/swift/bin/swift+0x1374699)
15 0x0000000001374517 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>) (/path/to/swift/bin/swift+0x1374517)
16 0x00000000013c4184 diagnoseUnknownType(swift::TypeChecker&, swift::DeclContext*, swift::Type, swift::SourceRange, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::OptionSet<swift::NameLookupFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13c4184)
17 0x00000000013bde15 resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13bde15)
18 0x00000000013bd489 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13bd489)
19 0x00000000013be1f8 (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0x13be1f8)
20 0x00000000013be0fc swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13be0fc)
21 0x00000000013bcb50 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13bcb50)
22 0x00000000013431f9 swift::TypeChecker::validateDecl(swift::ValueDecl*) (/path/to/swift/bin/swift+0x13431f9)
23 0x0000000001351a1f (anonymous namespace)::DeclChecker::visitTypeAliasDecl(swift::TypeAliasDecl*) (/path/to/swift/bin/swift+0x1351a1f)
24 0x0000000001341404 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x1341404)
25 0x0000000001351f5b (anonymous namespace)::DeclChecker::visitStructDecl(swift::StructDecl*) (/path/to/swift/bin/swift+0x1351f5b)
26 0x0000000001341414 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x1341414)
27 0x0000000001341333 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x1341333)
28 0x00000000013cba85 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x13cba85)
29 0x0000000000f93106 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf93106)
30 0x00000000004aaa09 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4aaa09)
31 0x00000000004a8f9c swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a8f9c)
32 0x00000000004655c7 main (/path/to/swift/bin/swift+0x4655c7)
33 0x00007fc4ad1d4830 __libc_start_main /build/glibc-9tT8Do/glibc-2.23/csu/../csu/libc-start.c:325:0
34 0x0000000000462c69 _start (/path/to/swift/bin/swift+0x462c69)
```