### PR TITLE
[4.0] Dictionary Decodable Fix

### DIFF
--- a/stdlib/public/core/Codable.swift
+++ b/stdlib/public/core/Codable.swift
@@ -3412,11 +3412,11 @@ extension Dictionary : Decodable /* where Key : Decodable, Value : Decodable */ 
         // Initialize self here so we can print type(of: self).
         self.init()
 
-        guard Key.self is Encodable.Type else {
+        guard Key.self is Decodable.Type else {
             preconditionFailure("\(type(of: self)) does not conform to Decodable because \(Key.self) does not conform to Decodable.")
         }
 
-        guard Value.self is Encodable.Type else {
+        guard Value.self is Decodable.Type else {
             preconditionFailure("\(type(of: self)) does not conform to Decodable because \(Value.self) does not conform to Decodable.")
         }
 


### PR DESCRIPTION
**What's in this pull request?**
Cherry-picks #10105 to `swift-4.0-branch-06-02-2017`.

**Explanation:** `Dictionary` needs to gate on its keys and values being `Decodable` for its `init(from:)`. Due to copy pasta, the implementation currently gates on them being `Encodable`, which is wrong.
**Scope:** This affects anyone trying to decode a `Dictionary` with the new `Codable` APIs.
**Radar:** rdar://problem/32567725
**Risk:** Low
**Testing:** Tested locally. This doesn't currently have a unit test in place because we need to put together infrastructure that decouples `Codable` implementation from an output format. See rdar://problem/32567771.