### PR TITLE
[sil-inliner] Do not perform early performance inlining for function with certain @_semantics attributes

### DIFF
--- a/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
+++ b/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
@@ -608,6 +608,10 @@ static bool shouldSkipApplyDuringEarlyInlining(FullApplySite AI) {
   if (!Callee)
     return false;
 
+  if (Callee->hasSemanticsAttr("self_no_escaping_closure") ||
+      Callee->hasSemanticsAttr("pair_no_escaping_closure"))
+    return true;
+
   // Add here the checks for any specific @_effects attributes that need
   // to be skipped during the early inlining pass.
   if (Callee->hasEffectsKind())

--- a/test/SILOptimizer/inline_semantics.sil
+++ b/test/SILOptimizer/inline_semantics.sil
@@ -7,9 +7,9 @@ import Swift
 
 sil [_semantics "no_inline_plz"] @callee_func : $@convention(thin) () -> Int32 {
 bb0:
-  %0 = integer_literal $Builtin.Int32, 3           // user: %1
-  %1 = struct $Int32 (%0 : $Builtin.Int32)         // user: %2
-  return %1 : $Int32                               // id: %2
+  %0 = integer_literal $Builtin.Int32, 3
+  %1 = struct $Int32 (%0 : $Builtin.Int32)
+  return %1 : $Int32
 }
 
 //Not every @_semantics should be skipped during the early inlining pass, but
@@ -21,16 +21,16 @@ bb0:
 //CHECK: end sil function 'caller_func'
 sil @caller_func : $@convention(thin) () -> Int32 {
 bb0:
-  %0 = function_ref @callee_func : $@convention(thin) () -> Int32 // user: %1
-  %1 = apply %0() : $@convention(thin) () -> Int32                // user: %2
-  return %1 : $Int32                                  // id: %2
+  %0 = function_ref @callee_func : $@convention(thin) () -> Int32
+  %1 = apply %0() : $@convention(thin) () -> Int32
+  return %1 : $Int32
 }
 
 sil [_semantics "array.make_mutable"] @callee_func_with_to_be_skipped_during_inlining_semantics : $@convention(method) (@inout Int32) -> Int32 {
 bb0(%self : $*Int32):
-  %0 = integer_literal $Builtin.Int32, 3           // user: %1
-  %1 = struct $Int32 (%0 : $Builtin.Int32)         // user: %2
-  return %1 : $Int32                               // id: %2
+  %0 = integer_literal $Builtin.Int32, 3
+  %1 = struct $Int32 (%0 : $Builtin.Int32)
+  return %1 : $Int32
 }
 
 //Not every @_semantics should be skipped during the early inlining pass, but
@@ -44,17 +44,57 @@ sil @caller_func2 : $@convention(thin) () -> Int32 {
 bb0:
   %self = alloc_stack $Int32
   %0 = function_ref @callee_func_with_to_be_skipped_during_inlining_semantics  : $@convention(method) (@inout Int32) -> Int32 // user: %1
-  %1 = apply %0(%self) : $@convention(method) (@inout Int32) -> Int32                 // user: %2
+  %1 = apply %0(%self) : $@convention(method) (@inout Int32) -> Int32
   dealloc_stack %self : $*Int32
-  return %1 : $Int32                                  // id: %2
+  return %1 : $Int32
+}
+
+sil [_semantics "pair_no_escaping_closure"] @callee_func_with_pair_no_escaping_closure_semantics : $@convention(method) (@inout Int32) -> Int32 {
+bb0(%self : $*Int32):
+  %0 = integer_literal $Builtin.Int32, 3
+  %1 = struct $Int32 (%0 : $Builtin.Int32)
+  return %1 : $Int32
+}
+
+//CHECK-LABEL: caller_func3
+//CHECK: function_ref
+//CHECK: apply
+//CHECK: end sil function 'caller_func3'
+sil @caller_func3 : $@convention(thin) () -> Int32 {
+bb0:
+  %self = alloc_stack $Int32
+  %0 = function_ref @callee_func_with_pair_no_escaping_closure_semantics  : $@convention(method) (@inout Int32) -> Int32 // user: %1
+  %1 = apply %0(%self) : $@convention(method) (@inout Int32) -> Int32
+  dealloc_stack %self : $*Int32
+  return %1 : $Int32
+}
+
+sil [_semantics "self_no_escaping_closure"] @callee_func_with_self_no_escaping_closure_semantics : $@convention(method) (@inout Int32) -> Int32 {
+bb0(%self : $*Int32):
+  %0 = integer_literal $Builtin.Int32, 3
+  %1 = struct $Int32 (%0 : $Builtin.Int32)
+  return %1 : $Int32
+}
+
+//CHECK-LABEL: caller_func4
+//CHECK: function_ref
+//CHECK: apply
+//CHECK: end sil function 'caller_func4'
+sil @caller_func4 : $@convention(thin) () -> Int32 {
+bb0:
+  %self = alloc_stack $Int32
+  %0 = function_ref @callee_func_with_self_no_escaping_closure_semantics  : $@convention(method) (@inout Int32) -> Int32 // user: %1
+  %1 = apply %0(%self) : $@convention(method) (@inout Int32) -> Int32
+  dealloc_stack %self : $*Int32
+  return %1 : $Int32
 }
 
 // A function annotated with the @effects(readonly) attribute.
 sil [readonly] @callee_func2 : $@convention(thin) () -> Int32 {
 bb0:
-  %0 = integer_literal $Builtin.Int32, 3           // user: %1
-  %1 = struct $Int32 (%0 : $Builtin.Int32)         // user: %2
-  return %1 : $Int32                               // id: %2
+  %0 = integer_literal $Builtin.Int32, 3
+  %1 = struct $Int32 (%0 : $Builtin.Int32)
+  return %1 : $Int32 
 }
 
 //CHECK-LABEL: caller_func1
@@ -63,8 +103,8 @@ bb0:
 //CHECK-NEXT: ret
 sil @caller_func1 : $@convention(thin) () -> Int32 {
 bb0:
-  %0 = function_ref @callee_func2 : $@convention(thin) () -> Int32 // user: %1
-  %1 = apply %0() : $@convention(thin) () -> Int32                 // user: %2
-  return %1 : $Int32                                   // id: %2
+  %0 = function_ref @callee_func2 : $@convention(thin) () -> Int32
+  %1 = apply %0() : $@convention(thin) () -> Int32
+  return %1 : $Int32
 }
 


### PR DESCRIPTION
Specifically, do not perform the early inlining for functions annotated with @_semantics("pair_no_escaping_closure") and @_semantics("self_no_escaping_closure")

Add new tests and cleanup some tests.

It recovers from the performance regression that was recently introduced.

Fixes rdar://32555803
