### PR TITLE
Re-factor Codable.decode functions to reduce the standard library code size

### DIFF
--- a/stdlib/public/core/Codable.swift
+++ b/stdlib/public/core/Codable.swift
@@ -3574,213 +3574,138 @@ public extension KeyedEncodingContainerProtocol {
 
 // Default implementations for decode(_:forKey:) in terms of decodeIfPresent(_:forKey:)
 public extension KeyedDecodingContainerProtocol {
-    public func decode(_ type: Bool.Type, forKey key: Key) throws -> Bool {
-        if let value = try decodeIfPresent(Bool.self, forKey: key) {
-            return value
-        } else if contains(key) {
+    @_semantics("optimize.sil.specialize.generic.never")
+    @_semantics("optimize.sil.specialize.generic.partial.never")
+    @inline(never)
+    internal func _errorInDecoding<T: Decodable>(_ type: T.Type, forKey key: Key) -> DecodingError {
+        if contains(key) {
             var path = codingPath
             path.append(key)
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: path, debugDescription: "Found null value when expecting non-optional type \(type) for coding key \"\(key)\""))
+            return DecodingError.valueNotFound(type, DecodingError.Context(codingPath: path, debugDescription: "Found null value when expecting non-optional type \(type) for coding key \"\(key)\""))
         } else {
             var path = codingPath
             path.append(key)
-            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: path, debugDescription: "Key not found when expecting non-optional type \(type) for coding key \"\(key)\""))
+            return DecodingError.keyNotFound(key, DecodingError.Context(codingPath: path, debugDescription: "Key not found when expecting non-optional type \(type) for coding key \"\(key)\""))
+        }
+    }
+
+    public func decode(_ type: Bool.Type, forKey key: Key) throws -> Bool {
+        if let value = try decodeIfPresent(Bool.self, forKey: key) {
+            return value
+        } else {
+            throw _errorInDecoding(type, forKey: key)
         }
     }
 
     public func decode(_ type: Int.Type, forKey key: Key) throws -> Int {
         if let value = try decodeIfPresent(Int.self, forKey: key) {
             return value
-        } else if contains(key) {
-            var path = codingPath
-            path.append(key)
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: path, debugDescription: "Found null value when expecting non-optional type \(type) for coding key \"\(key)\""))
         } else {
-            var path = codingPath
-            path.append(key)
-            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: path, debugDescription: "Key not found when expecting non-optional type \(type) for coding key \"\(key)\""))
+            throw _errorInDecoding(type, forKey: key)
         }
     }
 
     public func decode(_ type: Int8.Type, forKey key: Key) throws -> Int8 {
         if let value = try decodeIfPresent(Int8.self, forKey: key) {
             return value
-        } else if contains(key) {
-            var path = codingPath
-            path.append(key)
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: path, debugDescription: "Found null value when expecting non-optional type \(type) for coding key \"\(key)\""))
         } else {
-            var path = codingPath
-            path.append(key)
-            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: path, debugDescription: "Key not found when expecting non-optional type \(type) for coding key \"\(key)\""))
+            throw _errorInDecoding(type, forKey: key)
         }
     }
 
     public func decode(_ type: Int16.Type, forKey key: Key) throws -> Int16 {
         if let value = try decodeIfPresent(Int16.self, forKey: key) {
             return value
-        } else if contains(key) {
-            var path = codingPath
-            path.append(key)
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: path, debugDescription: "Found null value when expecting non-optional type \(type) for coding key \"\(key)\""))
         } else {
-            var path = codingPath
-            path.append(key)
-            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: path, debugDescription: "Key not found when expecting non-optional type \(type) for coding key \"\(key)\""))
+            throw _errorInDecoding(type, forKey: key)
         }
     }
 
     public func decode(_ type: Int32.Type, forKey key: Key) throws -> Int32 {
         if let value = try decodeIfPresent(Int32.self, forKey: key) {
             return value
-        } else if contains(key) {
-            var path = codingPath
-            path.append(key)
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: path, debugDescription: "Found null value when expecting non-optional type \(type) for coding key \"\(key)\""))
         } else {
-            var path = codingPath
-            path.append(key)
-            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: path, debugDescription: "Key not found when expecting non-optional type \(type) for coding key \"\(key)\""))
+            throw _errorInDecoding(type, forKey: key)
         }
     }
 
     public func decode(_ type: Int64.Type, forKey key: Key) throws -> Int64 {
         if let value = try decodeIfPresent(Int64.self, forKey: key) {
             return value
-        } else if contains(key) {
-            var path = codingPath
-            path.append(key)
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: path, debugDescription: "Found null value when expecting non-optional type \(type) for coding key \"\(key)\""))
         } else {
-            var path = codingPath
-            path.append(key)
-            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: path, debugDescription: "Key not found when expecting non-optional type \(type) for coding key \"\(key)\""))
+            throw _errorInDecoding(type, forKey: key)
         }
     }
 
     public func decode(_ type: UInt.Type, forKey key: Key) throws -> UInt {
         if let value = try decodeIfPresent(UInt.self, forKey: key) {
             return value
-        } else if contains(key) {
-            var path = codingPath
-            path.append(key)
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: path, debugDescription: "Found null value when expecting non-optional type \(type) for coding key \"\(key)\""))
         } else {
-            var path = codingPath
-            path.append(key)
-            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: path, debugDescription: "Key not found when expecting non-optional type \(type) for coding key \"\(key)\""))
+            throw _errorInDecoding(type, forKey: key)
         }
     }
 
     public func decode(_ type: UInt8.Type, forKey key: Key) throws -> UInt8 {
         if let value = try decodeIfPresent(UInt8.self, forKey: key) {
             return value
-        } else if contains(key) {
-            var path = codingPath
-            path.append(key)
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: path, debugDescription: "Found null value when expecting non-optional type \(type) for coding key \"\(key)\""))
         } else {
-            var path = codingPath
-            path.append(key)
-            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: path, debugDescription: "Key not found when expecting non-optional type \(type) for coding key \"\(key)\""))
+            throw _errorInDecoding(type, forKey: key)
         }
     }
 
     public func decode(_ type: UInt16.Type, forKey key: Key) throws -> UInt16 {
         if let value = try decodeIfPresent(UInt16.self, forKey: key) {
             return value
-        } else if contains(key) {
-            var path = codingPath
-            path.append(key)
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: path, debugDescription: "Found null value when expecting non-optional type \(type) for coding key \"\(key)\""))
         } else {
-            var path = codingPath
-            path.append(key)
-            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: path, debugDescription: "Key not found when expecting non-optional type \(type) for coding key \"\(key)\""))
+            throw _errorInDecoding(type, forKey: key)
         }
     }
 
     public func decode(_ type: UInt32.Type, forKey key: Key) throws -> UInt32 {
         if let value = try decodeIfPresent(UInt32.self, forKey: key) {
             return value
-        } else if contains(key) {
-            var path = codingPath
-            path.append(key)
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: path, debugDescription: "Found null value when expecting non-optional type \(type) for coding key \"\(key)\""))
         } else {
-            var path = codingPath
-            path.append(key)
-            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: path, debugDescription: "Key not found when expecting non-optional type \(type) for coding key \"\(key)\""))
+            throw _errorInDecoding(type, forKey: key)
         }
     }
 
     public func decode(_ type: UInt64.Type, forKey key: Key) throws -> UInt64 {
         if let value = try decodeIfPresent(UInt64.self, forKey: key) {
             return value
-        } else if contains(key) {
-            var path = codingPath
-            path.append(key)
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: path, debugDescription: "Found null value when expecting non-optional type \(type) for coding key \"\(key)\""))
         } else {
-            var path = codingPath
-            path.append(key)
-            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: path, debugDescription: "Key not found when expecting non-optional type \(type) for coding key \"\(key)\""))
+            throw _errorInDecoding(type, forKey: key)
         }
     }
 
     public func decode(_ type: Float.Type, forKey key: Key) throws -> Float {
         if let value = try decodeIfPresent(Float.self, forKey: key) {
             return value
-        } else if contains(key) {
-            var path = codingPath
-            path.append(key)
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: path, debugDescription: "Found null value when expecting non-optional type \(type) for coding key \"\(key)\""))
         } else {
-            var path = codingPath
-            path.append(key)
-            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: path, debugDescription: "Key not found when expecting non-optional type \(type) for coding key \"\(key)\""))
+            throw _errorInDecoding(type, forKey: key)
         }
     }
 
     public func decode(_ type: Double.Type, forKey key: Key) throws -> Double {
         if let value = try decodeIfPresent(Double.self, forKey: key) {
             return value
-        } else if contains(key) {
-            var path = codingPath
-            path.append(key)
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: path, debugDescription: "Found null value when expecting non-optional type \(type) for coding key \"\(key)\""))
         } else {
-            var path = codingPath
-            path.append(key)
-            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: path, debugDescription: "Key not found when expecting non-optional type \(type) for coding key \"\(key)\""))
+            throw _errorInDecoding(type, forKey: key)
         }
     }
 
     public func decode(_ type: String.Type, forKey key: Key) throws -> String {
         if let value = try decodeIfPresent(String.self, forKey: key) {
             return value
-        } else if contains(key) {
-            var path = codingPath
-            path.append(key)
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: path, debugDescription: "Found null value when expecting non-optional type \(type) for coding key \"\(key)\""))
         } else {
-            var path = codingPath
-            path.append(key)
-            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: path, debugDescription: "Key not found when expecting non-optional type \(type) for coding key \"\(key)\""))
+            throw _errorInDecoding(type, forKey: key)
         }
     }
 
     public func decode<T : Decodable>(_ type: T.Type, forKey key: Key) throws -> T {
         if let value = try decodeIfPresent(T.self, forKey: key) {
             return value
-        } else if contains(key) {
-            var path = codingPath
-            path.append(key)
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: path, debugDescription: "Found null value when expecting non-optional type \(type) for coding key \"\(key)\""))
         } else {
-            var path = codingPath
-            path.append(key)
-            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: path, debugDescription: "Key not found when expecting non-optional type \(type) for coding key \"\(key)\""))
+            throw _errorInDecoding(type, forKey: key)
         }
     }
 }
@@ -3884,153 +3809,134 @@ public extension UnkeyedEncodingContainer {
 
 // Default implementations for decode(_:) in terms of decodeIfPresent(_:)
 public extension UnkeyedDecodingContainer {
+    @_semantics("optimize.sil.specialize.generic.never")
+    @_semantics("optimize.sil.specialize.generic.partial.never")
+    @inline(never)
+    internal func _errorInDecoding<T: Decodable>(_ type: T.Type) -> DecodingError {
+        if !isAtEnd {
+            return DecodingError.valueNotFound(type, DecodingError.Context(codingPath: codingPath, debugDescription: "Found null value when expecting non-optional type \(type)"))
+        } else {
+            return DecodingError.valueNotFound(type, DecodingError.Context(codingPath: codingPath, debugDescription: "No remaining elements when expecting non-optional type \(type)"))
+        }
+    }
+
     mutating func decode(_ type: Bool.Type) throws -> Bool {
         if let value = try decodeIfPresent(Bool.self) {
             return value
-        } else if !isAtEnd {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: codingPath, debugDescription: "Found null value when expecting non-optional type \(type)"))
         } else {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: codingPath, debugDescription: "No remaining elements when expecting non-optional type \(type)"))
+            throw _errorInDecoding(type)
         }
     }
 
     mutating func decode(_ type: Int.Type) throws -> Int {
         if let value = try decodeIfPresent(Int.self) {
             return value
-        } else if !isAtEnd {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: codingPath, debugDescription: "Found null value when expecting non-optional type \(type)"))
         } else {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: codingPath, debugDescription: "No remaining elements when expecting non-optional type \(type)"))
+            throw _errorInDecoding(type)
         }
     }
 
     mutating func decode(_ type: Int8.Type) throws -> Int8 {
         if let value = try decodeIfPresent(Int8.self) {
             return value
-        } else if !isAtEnd {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: codingPath, debugDescription: "Found null value when expecting non-optional type \(type)"))
         } else {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: codingPath, debugDescription: "No remaining elements when expecting non-optional type \(type)"))
+            throw _errorInDecoding(type)
         }
     }
 
     mutating func decode(_ type: Int16.Type) throws -> Int16 {
         if let value = try decodeIfPresent(Int16.self) {
             return value
-        } else if !isAtEnd {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: codingPath, debugDescription: "Found null value when expecting non-optional type \(type)"))
         } else {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: codingPath, debugDescription: "No remaining elements when expecting non-optional type \(type)"))
+            throw _errorInDecoding(type)
         }
     }
 
     mutating func decode(_ type: Int32.Type) throws -> Int32 {
         if let value = try decodeIfPresent(Int32.self) {
             return value
-        } else if !isAtEnd {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: codingPath, debugDescription: "Found null value when expecting non-optional type \(type)"))
         } else {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: codingPath, debugDescription: "No remaining elements when expecting non-optional type \(type)"))
+            throw _errorInDecoding(type)
         }
     }
 
     mutating func decode(_ type: Int64.Type) throws -> Int64 {
         if let value = try decodeIfPresent(Int64.self) {
             return value
-        } else if !isAtEnd {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: codingPath, debugDescription: "Found null value when expecting non-optional type \(type)"))
         } else {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: codingPath, debugDescription: "No remaining elements when expecting non-optional type \(type)"))
+            throw _errorInDecoding(type)
         }
     }
 
     mutating func decode(_ type: UInt.Type) throws -> UInt {
         if let value = try decodeIfPresent(UInt.self) {
             return value
-        } else if !isAtEnd {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: codingPath, debugDescription: "Found null value when expecting non-optional type \(type)"))
         } else {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: codingPath, debugDescription: "No remaining elements when expecting non-optional type \(type)"))
+            throw _errorInDecoding(type)
         }
     }
 
     mutating func decode(_ type: UInt8.Type) throws -> UInt8 {
         if let value = try decodeIfPresent(UInt8.self) {
             return value
-        } else if !isAtEnd {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: codingPath, debugDescription: "Found null value when expecting non-optional type \(type)"))
         } else {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: codingPath, debugDescription: "No remaining elements when expecting non-optional type \(type)"))
+            throw _errorInDecoding(type)
         }
     }
 
     mutating func decode(_ type: UInt16.Type) throws -> UInt16 {
         if let value = try decodeIfPresent(UInt16.self) {
             return value
-        } else if !isAtEnd {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: codingPath, debugDescription: "Found null value when expecting non-optional type \(type)"))
         } else {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: codingPath, debugDescription: "No remaining elements when expecting non-optional type \(type)"))
+            throw _errorInDecoding(type)
         }
     }
 
     mutating func decode(_ type: UInt32.Type) throws -> UInt32 {
         if let value = try decodeIfPresent(UInt32.self) {
             return value
-        } else if !isAtEnd {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: codingPath, debugDescription: "Found null value when expecting non-optional type \(type)"))
         } else {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: codingPath, debugDescription: "No remaining elements when expecting non-optional type \(type)"))
+            throw _errorInDecoding(type)
         }
     }
 
     mutating func decode(_ type: UInt64.Type) throws -> UInt64 {
         if let value = try decodeIfPresent(UInt64.self) {
             return value
-        } else if !isAtEnd {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: codingPath, debugDescription: "Found null value when expecting non-optional type \(type)"))
         } else {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: codingPath, debugDescription: "No remaining elements when expecting non-optional type \(type)"))
+            throw _errorInDecoding(type)
         }
     }
 
     mutating func decode(_ type: Float.Type) throws -> Float {
         if let value = try decodeIfPresent(Float.self) {
             return value
-        } else if !isAtEnd {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: codingPath, debugDescription: "Found null value when expecting non-optional type \(type)"))
         } else {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: codingPath, debugDescription: "No remaining elements when expecting non-optional type \(type)"))
+            throw _errorInDecoding(type)
         }
     }
 
     mutating func decode(_ type: Double.Type) throws -> Double {
         if let value = try decodeIfPresent(Double.self) {
             return value
-        } else if !isAtEnd {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: codingPath, debugDescription: "Found null value when expecting non-optional type \(type)"))
         } else {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: codingPath, debugDescription: "No remaining elements when expecting non-optional type \(type)"))
+            throw _errorInDecoding(type)
         }
     }
 
     mutating func decode(_ type: String.Type) throws -> String {
         if let value = try decodeIfPresent(String.self) {
             return value
-        } else if !isAtEnd {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: codingPath, debugDescription: "Found null value when expecting non-optional type \(type)"))
         } else {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: codingPath, debugDescription: "No remaining elements when expecting non-optional type \(type)"))
+            throw _errorInDecoding(type)
         }
     }
 
     mutating func decode<T : Decodable>(_ type: T.Type) throws -> T {
         if let value = try decodeIfPresent(T.self) {
             return value
-        } else if !isAtEnd {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: codingPath, debugDescription: "Found null value when expecting non-optional type \(type)"))
         } else {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: codingPath, debugDescription: "No remaining elements when expecting non-optional type \(type)"))
+            throw _errorInDecoding(type)
         }
     }
 }


### PR DESCRIPTION
Move the error reporting slow-path into a separate function, which is not inlined or specialized.
This reduced the stdlib code size by almost 1%.

