### PR TITLE
[swiftc (36 vs. 5544)] Add crasher in swift::GenericSignatureBuilder::addSameTypeRequirementDirect

### DIFF
--- a/validation-test/compiler_crashers/28771-unreachable-executed-at-swift-include-swift-ast-cantypevisitor-h-41.swift
+++ b/validation-test/compiler_crashers/28771-unreachable-executed-at-swift-include-swift-ast-cantypevisitor-h-41.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol A{typealias a{}typealias a=FlattenCollection}protocol b:A


### PR DESCRIPTION
Add test case for crash triggered in `swift::GenericSignatureBuilder::addSameTypeRequirementDirect`.

Current number of unresolved compiler crashers: 36 (5544 resolved)

Stack trace:

```
0 0x0000000003a5f2b8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3a5f2b8)
1 0x0000000003a5f9f6 SignalHandler(int) (/path/to/swift/bin/swift+0x3a5f9f6)
2 0x00007f58a3639390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007f58a1b5f428 gsignal /build/glibc-9tT8Do/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f58a1b6102a abort /build/glibc-9tT8Do/glibc-2.23/stdlib/abort.c:91:0
5 0x00000000039fb95d llvm::llvm_unreachable_internal(char const*, char const*, unsigned int) (/path/to/swift/bin/swift+0x39fb95d)
6 0x00000000015778b4 bool swift::CanTypeVisitor<swift::TypeMatcher<swift::GenericSignatureBuilder::addSameTypeRequirementBetweenConcrete(swift::Type, swift::Type, swift::GenericSignatureBuilder::FloatingRequirementSource, llvm::function_ref<void (swift::Type, swift::Type)>)::ReqTypeMatcher>::MatchVisitor, bool, swift::Type, swift::Type>::visit<>(swift::CanType, swift::Type, swift::Type) (/path/to/swift/bin/swift+0x15778b4)
7 0x0000000001569002 swift::GenericSignatureBuilder::addSameTypeRequirementDirect(swift::GenericSignatureBuilder::ResolvedType, swift::GenericSignatureBuilder::ResolvedType, swift::GenericSignatureBuilder::FloatingRequirementSource, llvm::function_ref<void (swift::Type, swift::Type)>) (/path/to/swift/bin/swift+0x1569002)
8 0x000000000156834c swift::GenericSignatureBuilder::addSameTypeRequirement(llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::FloatingRequirementSource, swift::GenericSignatureBuilder::UnresolvedHandlingKind, llvm::function_ref<void (swift::Type, swift::Type)>) (/path/to/swift/bin/swift+0x156834c)
9 0x0000000001568767 swift::GenericSignatureBuilder::addSameTypeRequirementToConcrete(swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type, swift::GenericSignatureBuilder::RequirementSource const*) (/path/to/swift/bin/swift+0x1568767)
10 0x000000000156834c swift::GenericSignatureBuilder::addSameTypeRequirement(llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::FloatingRequirementSource, swift::GenericSignatureBuilder::UnresolvedHandlingKind, llvm::function_ref<void (swift::Type, swift::Type)>) (/path/to/swift/bin/swift+0x156834c)
11 0x000000000155f5ce swift::GenericSignatureBuilder::PotentialArchetype::updateNestedTypeForConformance(llvm::PointerUnion<swift::AssociatedTypeDecl*, swift::TypeDecl*>, swift::GenericSignatureBuilder::PotentialArchetype::NestedTypeUpdate) (/path/to/swift/bin/swift+0x155f5ce)
12 0x000000000155e112 swift::GenericSignatureBuilder::PotentialArchetype::getNestedArchetypeAnchor(swift::Identifier, swift::GenericSignatureBuilder&, swift::GenericSignatureBuilder::PotentialArchetype::NestedTypeUpdate) (/path/to/swift/bin/swift+0x155e112)
13 0x000000000156c59c swift::GenericSignatureBuilder::checkSameTypeConstraints(llvm::ArrayRef<swift::GenericTypeParamType*>, swift::GenericSignatureBuilder::PotentialArchetype*) (/path/to/swift/bin/swift+0x156c59c)
14 0x0000000001569840 swift::GenericSignatureBuilder::finalize(swift::SourceLoc, llvm::ArrayRef<swift::GenericTypeParamType*>, bool) (/path/to/swift/bin/swift+0x1569840)
15 0x0000000001371c20 swift::TypeChecker::checkGenericEnvironment(swift::GenericParamList*, swift::DeclContext*, swift::GenericSignature*, bool, llvm::function_ref<void (swift::GenericSignatureBuilder&)>) (/path/to/swift/bin/swift+0x1371c20)
16 0x0000000001372009 swift::TypeChecker::validateGenericTypeSignature(swift::GenericTypeDecl*) (/path/to/swift/bin/swift+0x1372009)
17 0x0000000001343262 swift::TypeChecker::validateDecl(swift::ValueDecl*) (/path/to/swift/bin/swift+0x1343262)
18 0x0000000001352e53 (anonymous namespace)::DeclChecker::visitProtocolDecl(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0x1352e53)
19 0x0000000001341434 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x1341434)
20 0x0000000001341333 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x1341333)
21 0x00000000013cba85 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x13cba85)
22 0x0000000000f93106 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf93106)
23 0x00000000004aaa09 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4aaa09)
24 0x00000000004a8f9c swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a8f9c)
25 0x00000000004655c7 main (/path/to/swift/bin/swift+0x4655c7)
26 0x00007f58a1b4a830 __libc_start_main /build/glibc-9tT8Do/glibc-2.23/csu/../csu/libc-start.c:325:0
27 0x0000000000462c69 _start (/path/to/swift/bin/swift+0x462c69)
```