### PR TITLE
[gardening] Move SILInstruction::replaceAllUsesWithUndef onto ValueBase.

### DIFF
--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -171,13 +171,6 @@ public:
   /// \brief Drops all uses that belong to this instruction.
   void dropAllReferences();
 
-  /// \brief Replace all uses of this instruction with Undef.
-  ///
-  /// TODO: This should be on ValueBase, but ValueBase currently does not have
-  /// access to a SILModule. If that ever changes, this method should move to
-  /// ValueBase.
-  void replaceAllUsesWithUndef();
-
   /// Return the array of operands for this instruction.
   ArrayRef<Operand> getAllOperands() const;
 

--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -163,10 +163,15 @@ public:
   }
 
   /// Replace every use of a result of this instruction with the corresponding
-  /// result from RHS. The method assumes that both instructions have the same
-  /// number of results. To replace just one result use
-  /// SILValue::replaceAllUsesWith.
+  /// result from RHS.
+  ///
+  /// The method assumes that both instructions have the same number of
+  /// results. To replace just one result use SILValue::replaceAllUsesWith.
   void replaceAllUsesWith(ValueBase *RHS);
+
+  /// \brief Replace all uses of this instruction with an undef value of the
+  /// same type as the result of this instruction.
+  void replaceAllUsesWithUndef();
 
   /// Returns true if this value has no uses.
   /// To ignore debug-info instructions use swift::onlyHaveDebugUses instead

--- a/lib/SIL/SILInstruction.cpp
+++ b/lib/SIL/SILInstruction.cpp
@@ -170,14 +170,6 @@ void SILInstruction::dropAllReferences() {
   }
 }
 
-void SILInstruction::replaceAllUsesWithUndef() {
-  SILModule &Mod = getModule();
-  while (!use_empty()) {
-    Operand *Op = *use_begin();
-    Op->set(SILUndef::get(Op->get()->getType(), Mod));
-  }
-}
-
 namespace {
   class InstructionDestroyer : public SILVisitor<InstructionDestroyer> {
   public:

--- a/lib/SIL/SILValue.cpp
+++ b/lib/SIL/SILValue.cpp
@@ -45,6 +45,18 @@ void ValueBase::replaceAllUsesWith(ValueBase *RHS) {
   }
 }
 
+void ValueBase::replaceAllUsesWithUndef() {
+  SILModule *Mod = getModule();
+  if (!Mod) {
+    llvm_unreachable("replaceAllUsesWithUndef can only be used on ValueBase "
+                     "that have access to the parent module.");
+  }
+  while (!use_empty()) {
+    Operand *Op = *use_begin();
+    Op->set(SILUndef::get(Op->get()->getType(), Mod));
+  }
+}
+
 SILBasicBlock *ValueBase::getParentBlock() const {
   auto *NonConstThis = const_cast<ValueBase *>(this);
   if (auto *Inst = dyn_cast<SILInstruction>(NonConstThis))


### PR DESCRIPTION
This allows this method to also be used on SILArguments.
