### PR TITLE
[swiftc (37 vs. 5544)] Add crasher in swift::TypeChecker::checkDeclAttributesEarly(...)

### DIFF
--- a/validation-test/compiler_crashers/28772-loc-isvalid-diagnosing-attribute-with-invalid-location.swift
+++ b/validation-test/compiler_crashers/28772-loc-isvalid-diagnosing-attribute-with-invalid-location.swift
@@ -1,0 +1,11 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+class a{@objc@dynamic
+let d


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeChecker::checkDeclAttributesEarly(...)`.

Current number of unresolved compiler crashers: 37 (5544 resolved)

/cc @DougGregor - just wanted to let you know that this crasher caused an assertion failure for the assertion `loc.isValid() && "Diagnosing attribute with invalid location"` added on 2017-04-22 by you in commit 25ce6fa2 :-)

Assertion failure in [`lib/Sema/TypeCheckAttr.cpp (line 39)`](https://github.com/apple/swift/blob/df10b0fe02444d92116c0d0851849774fff0db57/lib/Sema/TypeCheckAttr.cpp#L39):

```
Assertion `loc.isValid() && "Diagnosing attribute with invalid location"' failed.

When executing: void (anonymous namespace)::diagnoseAndRemoveAttr(swift::TypeChecker &, swift::Decl *, swift::DeclAttribute *, ArgTypes &&...) [ArgTypes = <swift::Diag<> &>]
```

Assertion context:

```c++
  void diagnoseAndRemoveAttr(TypeChecker &TC, Decl *D, DeclAttribute *attr,
                             ArgTypes &&...Args) {
    assert(!D->hasClangNode() && "Clang imported propagated a bogus attribute");
    if (!D->hasClangNode()) {
      SourceLoc loc = attr->getLocation();
      assert(loc.isValid() && "Diagnosing attribute with invalid location");
      if (loc.isInvalid()) {
        loc = D->getLoc();
      }
      if (loc.isValid()) {
        TC.diagnose(loc, std::forward<ArgTypes>(Args)...)
```
Stack trace:

```
0 0x0000000003a5f2b8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3a5f2b8)
1 0x0000000003a5f9f6 SignalHandler(int) (/path/to/swift/bin/swift+0x3a5f9f6)
2 0x00007f46fccd0390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007f46fb1f6428 gsignal /build/glibc-9tT8Do/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f46fb1f802a abort /build/glibc-9tT8Do/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f46fb1eebd7 __assert_fail_base /build/glibc-9tT8Do/glibc-2.23/assert/assert.c:92:0
6 0x00007f46fb1eec82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x00000000014612fd (/path/to/swift/bin/swift+0x14612fd)
8 0x000000000145bc70 swift::TypeChecker::checkDeclAttributesEarly(swift::Decl*) (/path/to/swift/bin/swift+0x145bc70)
9 0x0000000001354bbc (anonymous namespace)::DeclChecker::visitFuncDecl(swift::FuncDecl*) (/path/to/swift/bin/swift+0x1354bbc)
10 0x0000000001341454 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x1341454)
11 0x000000000134346d swift::TypeChecker::validateDecl(swift::ValueDecl*) (/path/to/swift/bin/swift+0x134346d)
12 0x000000000134809d validateAbstractStorageDecl(swift::AbstractStorageDecl*, swift::TypeChecker&) (/path/to/swift/bin/swift+0x134809d)
13 0x00000000013441b1 swift::TypeChecker::validateDecl(swift::ValueDecl*) (/path/to/swift/bin/swift+0x13441b1)
14 0x0000000001358ae3 std::_Function_handler<void (swift::VarDecl*), (anonymous namespace)::DeclChecker::visitBoundVars(swift::Pattern*)::{lambda(swift::VarDecl*)#1}>::_M_invoke(std::_Any_data const&, swift::VarDecl*&&) (/path/to/swift/bin/swift+0x1358ae3)
15 0x000000000159ff1f swift::Pattern::forEachVariable(std::function<void (swift::VarDecl*)> const&) const (/path/to/swift/bin/swift+0x159ff1f)
16 0x00000000013415f2 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x13415f2)
17 0x00000000013520cb (anonymous namespace)::DeclChecker::visitClassDecl(swift::ClassDecl*) (/path/to/swift/bin/swift+0x13520cb)
18 0x000000000134152e (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x134152e)
19 0x0000000001341333 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x1341333)
20 0x00000000013cba85 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x13cba85)
21 0x0000000000f93106 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf93106)
22 0x00000000004aaa09 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4aaa09)
23 0x00000000004a8f9c swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a8f9c)
24 0x00000000004655c7 main (/path/to/swift/bin/swift+0x4655c7)
25 0x00007f46fb1e1830 __libc_start_main /build/glibc-9tT8Do/glibc-2.23/csu/../csu/libc-start.c:325:0
26 0x0000000000462c69 _start (/path/to/swift/bin/swift+0x462c69)
```