### PR TITLE
runtime: add a runtime function _swift_checkClassAndWarnForKeyedArchiving

### DIFF
--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -92,6 +92,9 @@ enum class ClassFlags : uint32_t {
 
   /// Does this class use Swift 1.0 refcounting?
   UsesSwift1Refcounting = 0x2,
+
+  /// Has this class a custom name, specified with the @objc attribute?
+  HasCustomObjCName = 0x4
 };
 inline bool operator&(ClassFlags a, ClassFlags b) {
   return (uint32_t(a) & uint32_t(b)) != 0;

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -19,6 +19,7 @@
 #include "swift/AST/CanTypeVisitor.h"
 #include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/Decl.h"
+#include "swift/AST/Attr.h"
 #include "swift/AST/IRGenOptions.h"
 #include "swift/AST/SubstitutionMap.h"
 #include "swift/AST/Types.h"
@@ -3348,6 +3349,14 @@ namespace {
             == ReferenceCounting::Native) {
         flags |= ClassFlags::UsesSwift1Refcounting;
       }
+
+      DeclAttributes attrs = Target->getAttrs();
+      if (auto objc = attrs.getAttribute<ObjCAttr>()) {
+        if (objc->getName())
+          flags |= ClassFlags::HasCustomObjCName;
+      }
+      if (attrs.hasAttribute<ObjCRuntimeNameAttr>())
+        flags |= ClassFlags::HasCustomObjCName;
 
       B.addInt32((uint32_t) flags);
     }

--- a/stdlib/public/SDK/Foundation/CMakeLists.txt
+++ b/stdlib/public/SDK/Foundation/CMakeLists.txt
@@ -51,6 +51,7 @@ add_swift_library(swiftFoundation ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SD
   URLComponents.swift
   URLRequest.swift
   UUID.swift
+  CheckClass.mm
 
   SWIFT_COMPILE_FLAGS "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}" "-Xllvm" "-sil-inline-generics" "-Xllvm" "-sil-partial-specialization"
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"

--- a/stdlib/public/SDK/Foundation/CheckClass.mm
+++ b/stdlib/public/SDK/Foundation/CheckClass.mm
@@ -1,0 +1,59 @@
+#import <Foundation/Foundation.h>
+
+#include "swift/Runtime/Metadata.h"
+
+@interface NSKeyedUnarchiver (SwiftAdditions)
++ (int)_swift_checkClassAndWarnForKeyedArchiving:(Class)cls
+                                       operation:(int)operation
+     NS_SWIFT_NAME(_swift_checkClassAndWarnForKeyedArchiving(_:operation:));
+@end
+
+@implementation NSKeyedUnarchiver (SwiftAdditions)
+
+/// Checks if class \p cls is good for archiving.
+///
+/// If not, a runtime warning is printed.
+///
+/// \param operation Specifies the archiving operation. Valid operations are:
+/// 0:       archiving
+/// 1:       unarchiving
+/// \return Returns the status
+/// 0:       not a problem class (either non-Swift or has an explicit name)
+/// 1:       a Swift generic class
+/// 2:       a Swift non-generic class where adding @objc is valid
+/// Future versions of this API will return nonzero values for additional cases
+/// that mean the class shouldn't be archived.
++ (int)_swift_checkClassAndWarnForKeyedArchiving:(Class)cls
+                                       operation:(int)operation {
+  const swift::ClassMetadata *theClass = (swift::ClassMetadata *)cls;
+
+  // Is it a (real) swift class?
+  if (!theClass->isTypeMetadata() || theClass->isArtificialSubclass())
+    return 0;
+
+  // Does the class already have a custom name?
+  if (theClass->getFlags() & swift::ClassFlags::HasCustomObjCName)
+    return 0;
+
+  const char *className = [NSStringFromClass(cls) UTF8String];
+
+  // Is it a mangled name?
+  if (!(className[0] == '_' && className[1] == 'T'))
+    return 0;
+  // Is it a name in the form <module>.<class>? Note: the module name could
+  // start with "_T".
+  if (strchr(className, '.'))
+    return 0;
+
+  // Is it a generic class?
+  if (theClass->getDescription()->GenericParams.isGeneric()) {
+    // TODO: print a warning
+    return 1;
+  }
+
+  // It's a swift class with a (compiler generated) mangled name, which should
+  // be written into an NSArchive.
+  // TODO: print a warning
+  return 2;
+}
+@end

--- a/test/Interpreter/SDK/Inputs/check_class_for_archiving.h
+++ b/test/Interpreter/SDK/Inputs/check_class_for_archiving.h
@@ -1,0 +1,7 @@
+#import <Foundation/Foundation.h>
+
+@interface NSKeyedUnarchiver (SwiftAdditions)
++ (int)_swift_checkClassAndWarnForKeyedArchiving:(Class)cls operation:(int)operation
+    NS_SWIFT_NAME(_swift_checkClassAndWarnForKeyedArchiving(_:operation:));
+@end
+

--- a/test/Interpreter/SDK/check_class_for_archiving.swift
+++ b/test/Interpreter/SDK/check_class_for_archiving.swift
@@ -1,0 +1,60 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -module-name=_Test -import-objc-header %S/Inputs/check_class_for_archiving.h -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+import Foundation
+
+class SwiftClass {}
+
+class ObjcClass : NSObject {}
+
+private class PrivateClass : NSObject {}
+
+@objc(named_class)
+private class NamedClass1 : NSObject {}
+
+@objc(_T3nix11NamedClass2C)
+private class NamedClass2 : NSObject {}
+
+class GenericClass<T> : NSObject {}
+
+class DerivedClass : GenericClass<Int> {}
+
+@objc(_T3nix20DerivedClassWithNameC)
+private class DerivedClassWithName : GenericClass<Int> {}
+
+struct ABC {
+  class InnerClass : NSObject {}
+}
+
+struct DEF<T> {
+  class InnerClass : NSObject {}
+}
+
+let op: Int32 = 0 // archiving
+
+// CHECK: SwiftClass: 0
+print("SwiftClass: \(NSKeyedUnarchiver._swift_checkClassAndWarnForKeyedArchiving(SwiftClass.self, operation: op))")
+// CHECK: ObjcClass: 0
+print("ObjcClass: \(NSKeyedUnarchiver._swift_checkClassAndWarnForKeyedArchiving(ObjcClass.self, operation: op))")
+// CHECK: PrivateClass: 2
+print("PrivateClass: \(NSKeyedUnarchiver._swift_checkClassAndWarnForKeyedArchiving(PrivateClass.self, operation: op))")
+// CHECK: NamedClass1: 0
+print("NamedClass1: \(NSKeyedUnarchiver._swift_checkClassAndWarnForKeyedArchiving(NamedClass1.self, operation: op))")
+// CHECK: NamedClass2: 0
+print("NamedClass2: \(NSKeyedUnarchiver._swift_checkClassAndWarnForKeyedArchiving(NamedClass2.self, operation: op))")
+// CHECK: GenericClass: 1
+print("GenericClass: \(NSKeyedUnarchiver._swift_checkClassAndWarnForKeyedArchiving(GenericClass<Int>.self, operation: op))")
+// CHECK: DerivedClass: 0
+print("DerivedClass: \(NSKeyedUnarchiver._swift_checkClassAndWarnForKeyedArchiving(DerivedClass.self, operation: op))")
+// CHECK: DerivedClassWithName: 0
+print("DerivedClassWithName: \(NSKeyedUnarchiver._swift_checkClassAndWarnForKeyedArchiving(DerivedClass.self, operation: op))")
+// CHECK: InnerClass: 2
+print("InnerClass: \(NSKeyedUnarchiver._swift_checkClassAndWarnForKeyedArchiving(ABC.InnerClass.self, operation: op))")
+// CHECK: InnerClass2: 1
+print("InnerClass2: \(NSKeyedUnarchiver._swift_checkClassAndWarnForKeyedArchiving(DEF<Int>.InnerClass.self, operation: op))")
+// CHECK: NSKeyedUnarchiver: 0
+print("NSKeyedUnarchiver: \(NSKeyedUnarchiver._swift_checkClassAndWarnForKeyedArchiving(NSKeyedUnarchiver.self, operation: op))")


### PR DESCRIPTION
This function checks if a mangled class name is going to be written into an NSArchive.
If yes, a warning should be printed and the return value should indicate that.

TODO: print the actual warning

rdar://problem/32414508
