### PR TITLE
Restore old behavior for name lookup inside 'lazy' in Swift 3 mode [4.0]

### DIFF
--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -642,9 +642,12 @@ UnqualifiedLookup::UnqualifiedLookup(DeclName Name, DeclContext *DC,
 
             DC = DC->getParent();
 
-            BaseDecl = selfParam;
             ExtendedType = DC->getSelfTypeInContext();
             MetaBaseDecl = DC->getAsNominalTypeOrNominalTypeExtensionContext();
+            if (Ctx.isSwiftVersion3())
+              BaseDecl = MetaBaseDecl;
+            else
+              BaseDecl = selfParam;
 
             isTypeLookup = PBD->isStatic();
           }
@@ -705,7 +708,7 @@ UnqualifiedLookup::UnqualifiedLookup(DeclName Name, DeclContext *DC,
             // might be type checking a default argument expression and
             // performing name lookup from there), the base declaration
             // is the nominal type, not 'self'.
-            if (!AFD->isImplicit() &&
+            if ((Ctx.isSwiftVersion3() || !AFD->isImplicit()) &&
                 Loc.isValid() &&
                 AFD->getBodySourceRange().isValid() &&
                 !SM.rangeContainsTokenLoc(AFD->getBodySourceRange(), Loc)) {

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -16,6 +16,7 @@
 //
 //===----------------------------------------------------------------------===//
 #include "TypeChecker.h"
+#include "swift/AST/Initializer.h"
 #include "swift/AST/NameLookup.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/Basic/TopCollection.h"
@@ -192,7 +193,10 @@ LookupResult TypeChecker::lookupUnqualified(DeclContext *dc, DeclName name,
       auto baseDC = baseParam->getDeclContext();
       if (isa<AbstractFunctionDecl>(baseDC))
         baseDC = baseDC->getParent();
+      if (isa<PatternBindingInitializer>(baseDC))
+        baseDC = baseDC->getParent();
       foundInType = baseDC->getDeclaredTypeInContext();
+      assert(foundInType && "bogus base declaration?");
     } else {
       auto baseNominal = cast<NominalTypeDecl>(found.getBaseDecl());
       for (auto currentDC = dc; currentDC; currentDC = currentDC->getParent()) {

--- a/test/Compatibility/lazy_properties.swift
+++ b/test/Compatibility/lazy_properties.swift
@@ -1,0 +1,57 @@
+// RUN: %target-typecheck-verify-swift -parse-as-library -swift-version 3
+
+class ReferenceSelfInLazyProperty {
+  lazy var refs = (i, f())
+  // expected-error@-1 {{cannot use instance member 'i' within property initializer; property initializers run before 'self' is available}}
+  lazy var trefs: (Int, Int) = (i, f())
+  // expected-error@-1 {{instance member 'i' cannot be used on type 'ReferenceSelfInLazyProperty'}}
+
+  lazy var qrefs = (self.i, self.f())
+  lazy var qtrefs: (Int, Int) = (self.i, self.f())
+
+  lazy var crefs = { (i, f()) }()
+  // expected-error@-1 {{instance member 'i' cannot be used on type 'ReferenceSelfInLazyProperty'}}
+
+  lazy var ctrefs: (Int, Int) = { (i, f()) }()
+  // expected-error@-1 {{instance member 'i' cannot be used on type 'ReferenceSelfInLazyProperty'}}
+
+  lazy var cqrefs = { (self.i, self.f()) }()
+  lazy var cqtrefs: (Int, Int) = { (self.i, self.f()) }()
+
+  lazy var mrefs = { () -> (Int, Int) in return (i, f()) }()
+  // expected-error@-1 {{instance member 'i' cannot be used on type 'ReferenceSelfInLazyProperty'}}
+
+  lazy var mtrefs: (Int, Int) = { return (i, f()) }()
+  // expected-error@-1 {{instance member 'i' cannot be used on type 'ReferenceSelfInLazyProperty'}}
+
+  lazy var mqrefs = { () -> (Int, Int) in (self.i, self.f()) }()
+  lazy var mqtrefs: (Int, Int) = { return (self.i, self.f()) }()
+
+  lazy var lcqrefs = { [unowned self] in (self.i, self.f()) }()
+  lazy var lcqtrefs: (Int, Int) = { [unowned self] in (self.i, self.f()) }()
+
+  lazy var lmrefs = { [unowned self] () -> (Int, Int) in return (i, f()) }()
+  // expected-error@-1 {{instance member 'i' cannot be used on type 'ReferenceSelfInLazyProperty'}}
+  lazy var lmtrefs: (Int, Int) = { [unowned self] in return (i, f()) }()
+  // expected-error@-1 {{instance member 'i' cannot be used on type 'ReferenceSelfInLazyProperty'}}
+
+  lazy var lmqrefs = { [unowned self] () -> (Int, Int) in (self.i, self.f()) }()
+  lazy var lmqtrefs: (Int, Int) = { [unowned self] in return (self.i, self.f()) }()
+
+  var i = 42
+  func f() -> Int { return 0 }
+}
+
+class ReferenceStaticInLazyProperty {
+  lazy var refs1 = i
+  lazy var refs2 = f()
+  // expected-error@-1 {{use of unresolved identifier 'f'}}
+
+  lazy var trefs1: Int = i
+  lazy var trefs2: Int = f()
+  // expected-error@-1 {{use of unresolved identifier 'f'}}
+
+  static var i = 42
+  static func f() -> Int { return 0 }
+  // expected-note@-1 {{did you mean 'f'?}}
+}

--- a/test/NameBinding/name_lookup.swift
+++ b/test/NameBinding/name_lookup.swift
@@ -528,7 +528,7 @@ class r21677702 {
 // <rdar://problem/16954496> lazy properties must use "self." in their body, and can weirdly refer to class variables directly
 class r16954496 {
   func bar() {}
-  lazy var x: Array<() -> Void> = [bar]
+  lazy var x: Array<() -> Void> = [bar] // expected-error {{cannot convert value of type '(r16954496) -> () -> ()' to expected element type '() -> Void'}}
 }
 
 

--- a/test/SILGen/objc_properties.swift
+++ b/test/SILGen/objc_properties.swift
@@ -242,7 +242,7 @@ class HasLazyProperty : NSObject, HasProperty {
     return nil
   }
 
-  lazy var window = instanceMethod()
+  lazy var window = self.instanceMethod()
 }
 
 // CHECK-LABEL: sil hidden @_T015objc_properties15HasLazyPropertyC6windowSo8NSObjectCSgfg : $@convention(method) (@guaranteed HasLazyProperty) -> @owned Optional<NSObject> {

--- a/test/decl/var/lazy_properties.swift
+++ b/test/decl/var/lazy_properties.swift
@@ -1,4 +1,3 @@
-// RUN: %target-typecheck-verify-swift -parse-as-library -swift-version 3
 // RUN: %target-typecheck-verify-swift -parse-as-library -swift-version 4
 
 lazy func lazy_func() {} // expected-error {{'lazy' may only be used on 'var' declarations}} {{1-6=}}
@@ -161,4 +160,20 @@ class ReferenceSelfInLazyProperty : BaseClass {
   func f() -> Int { return 0 }
 
   lazy var refBaseClassProp = baseInstanceProp
+}
+
+class ReferenceStaticInLazyProperty {
+  lazy var refs1 = i
+  // expected-error@-1 {{static member 'i' cannot be used on instance of type 'ReferenceStaticInLazyProperty'}}
+  lazy var refs2 = f()
+  // expected-error@-1 {{static member 'f' cannot be used on instance of type 'ReferenceStaticInLazyProperty'}}
+
+  lazy var trefs1: Int = i
+  // expected-error@-1 {{static member 'i' cannot be used on instance of type 'ReferenceStaticInLazyProperty'}}
+
+  lazy var trefs2: Int = f()
+  // expected-error@-1 {{static member 'f' cannot be used on instance of type 'ReferenceStaticInLazyProperty'}}
+
+  static var i = 42
+  static func f() -> Int { return 0 }
 }

--- a/test/decl/var/lazy_properties.swift
+++ b/test/decl/var/lazy_properties.swift
@@ -159,4 +159,6 @@ class ReferenceSelfInLazyProperty : BaseClass {
 
   var i = 42
   func f() -> Int { return 0 }
+
+  lazy var refBaseClassProp = baseInstanceProp
 }

--- a/validation-test/compiler_crashers_fixed/28763-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/28763-swift-typebase-getcanonicaltype.swift
@@ -5,5 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 protocol P{func a}extension P{lazy var f=a


### PR DESCRIPTION
* Description: Some fixes to name lookup behavior from 'lazy' expression initializers broke source compatibility in an obscure corner case. This PR restores the old behavior in Swift 3 mode. Also it fixes a crash regression.

* Scope of the issue: Could affect anyone using 'lazy' properties.

* Origination: The changes were introduced in master and merged into swift-4.0-branch a few days ago.

* Tested: New tests added for Swift 3.2 and 4.0 behavior, and a regression test for the crash.

* Reviewed by: @jrose-apple 

* Radar: <rdar://problem/32570766>