### PR TITLE
Reject checked casts that remove levels of optionality

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -3172,7 +3172,7 @@ namespace {
       // If we have an imbalance of optionals or a collection
       // downcast, handle this as a checked cast followed by a
       // a 'hasValue' check.
-      if (fromOptionals.size() != toOptionals.size() ||
+      if (fromOptionals.size() < toOptionals.size() ||
           castKind == CheckedCastKind::ArrayDowncast ||
           castKind == CheckedCastKind::DictionaryDowncast ||
           castKind == CheckedCastKind::SetDowncast) {

--- a/test/Constraints/casts.swift
+++ b/test/Constraints/casts.swift
@@ -210,3 +210,11 @@ _ = seven as Int // expected-error {{cannot convert value of type 'Double' to ty
 func rdar29894174(v: B?) {
   let _ = [v].flatMap { $0 as? D }
 }
+
+enum AGreatEnum<T> {}
+
+func isCastFromOptionalToNonOptional(_ value: Any?) {
+  assert(value is AGreatEnum) // expected-error{{generic parameter 'T' could not be inferred in cast to 'AGreatEnum<_>'}}
+  // epected-note@-1{{'T' declared as parameter to type 'AGreatEnum'}}
+  // epected-note@-2{{explicitly specify the generic arguments to fix this issue}}{{29-34=<Any>}}
+}


### PR DESCRIPTION
Instead of synthesizing checked cast expressions when there is _any_
optional imbalance, instead only synthesize them when we actually intend
to insert an optional promotion, i.e. when the "from" type has
_fewer_ levels of optionality than the "to" type.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-5085](https://bugs.swift.org/browse/SR-5085).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->