### PR TITLE
[sil] Change two SILInstruction::removeFromParent => SILInstruction::eraseFromParent.

### DIFF
--- a/include/swift/SIL/SILBasicBlock.h
+++ b/include/swift/SIL/SILBasicBlock.h
@@ -425,11 +425,8 @@ private:
 public:
   static void deleteNode(SILBasicBlock *BB) { BB->~SILBasicBlock(); }
 
-  void addNodeToList(SILBasicBlock *BB) {}
-
   void transferNodesFromList(ilist_traits<SILBasicBlock> &SrcTraits,
                              block_iterator First, block_iterator Last);
-
 private:
   static void createNode(const SILBasicBlock &);
 };

--- a/lib/SIL/SILBuilder.cpp
+++ b/lib/SIL/SILBuilder.cpp
@@ -364,7 +364,7 @@ SILValue SILBuilder::emitThickToObjCMetatype(SILLocation Loc, SILValue Op,
     if (metatypeInst->use_empty() &&
         metatypeInst->getParent() == getInsertionBB()) {
       auto origLoc = metatypeInst->getLoc();
-      metatypeInst->removeFromParent();
+      metatypeInst->eraseFromParent();
       return createMetatype(origLoc, Ty);
     }
   }
@@ -382,7 +382,7 @@ SILValue SILBuilder::emitObjCToThickMetatype(SILLocation Loc, SILValue Op,
     if (metatypeInst->use_empty() &&
         metatypeInst->getParent() == getInsertionBB()) {
       auto origLoc = metatypeInst->getLoc();
-      metatypeInst->removeFromParent();
+      metatypeInst->eraseFromParent();
       return createMetatype(origLoc, Ty);
     }
   }


### PR DESCRIPTION
[sil] Change two SILInstruction::removeFromParent => SILInstruction::eraseFromParent.

removeFromParent should only be used when one is moving a SILInstruction from
one block to another or in preparation for deleting an instruction. In this
case, we are removing these two SILInstructions from their parent block and
leaking the instruction. The right thing to do is to use eraseFromParent.

<rdar://problem/31276565>
