### PR TITLE
[4.0] [Constraint solver] Do not allow unavailable decls to be favored.

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2980,8 +2980,8 @@ performMemberLookup(ConstraintKind constraintKind, DeclName memberName,
           }
         }
       }
-      
-      // If the invocation's argument expression has a favored constraint,
+
+      // If the invocation's argument expression has a favored type,
       // use that information to determine whether a specific overload for
       // the initializer should be favored.
       if (favoredType && result.FavoredChoice == ~0U) {
@@ -2996,7 +2996,8 @@ performMemberLookup(ConstraintKind constraintKind, DeclName memberName,
             argType = ctor.Decl->getInnermostDeclContext()
                 ->mapTypeIntoContext(argType);
             if (argType->isEqual(favoredType))
-              result.FavoredChoice = result.ViableCandidates.size();
+              if (!ctor->getAttrs().isUnavailable(getASTContext()))
+                result.FavoredChoice = result.ViableCandidates.size();
           }
         }
       }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1314,7 +1314,11 @@ void ConstraintSystem::addOverloadSet(Type boundType,
                                        *favoredChoice,
                                        useDC,
                                        locator);
-    
+
+    assert((!favoredChoice->isDecl() ||
+            !favoredChoice->getDecl()->getAttrs().isUnavailable(
+                getASTContext())) &&
+           "Cannot make unavailable decl favored!");
     bindOverloadConstraint->setFavored();
     
     overloads.push_back(bindOverloadConstraint);

--- a/test/Constraints/availability.swift
+++ b/test/Constraints/availability.swift
@@ -1,0 +1,17 @@
+// RUN: %target-typecheck-verify-swift -swift-version 4
+
+// Ensure that we do not select the unavailable failable init as the
+// only solution and then fail to typecheck.
+protocol P {}
+
+class C : P {
+  @available(swift, obsoleted: 4)
+  public init?(_ c: C) {
+  }
+
+  public init<T : P>(_ c: T) {}
+}
+
+func f(c: C) {
+  let _: C? = C(c)
+}


### PR DESCRIPTION
There is a short-circuiting hack in the constraint solver that speeds up
solving, but isn't generally sound. If we allow unavailable decls to be
considered "favored", this can fire and result in our choosing a
solution that involves the unavailable decl where other solutions exist.

Fixes rdar://problem/32570734.

(cherry picked from commit 65e338ea4aab10fe621227e7a6f8a963a9439192)
