### PR TITLE
Fix easy crashers

### DIFF
--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -642,8 +642,10 @@ namespace {
     void printAbstractTypeParamCommon(AbstractTypeParamDecl *decl,
                                       const char *name) {
       printCommon(decl, name);
-      if (auto superclassTy = decl->getSuperclass()) {
-        OS << " superclass='" << superclassTy->getString() << "'";
+      if (decl->getDeclContext()->getGenericEnvironmentOfContext()) {
+        if (auto superclassTy = decl->getSuperclass()) {
+          OS << " superclass='" << superclassTy->getString() << "'";
+        }
       }
     }
 

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -445,6 +445,12 @@ DeclContext *DeclContext::getParentForLookup() const {
     // outer types.
     return getModuleScopeContext();
   }
+  if (isa<NominalTypeDecl>(this)) {
+    // If we are inside a nominal type that is inside a protocol,
+    // skip the protocol.
+    if (isa<ProtocolDecl>(getParent()))
+      return getModuleScopeContext();
+  }
   return getParent();
 }
 

--- a/lib/Sema/ITCDecl.cpp
+++ b/lib/Sema/ITCDecl.cpp
@@ -342,8 +342,6 @@ void IterativeTypeChecker::processResolveTypeDecl(
   if (auto typeAliasDecl = dyn_cast<TypeAliasDecl>(typeDecl)) {
     if (typeAliasDecl->getDeclContext()->isModuleScopeContext() &&
         typeAliasDecl->getGenericParams() == nullptr) {
-      typeAliasDecl->setValidationStarted();
-
       TypeResolutionOptions options = TR_TypeAliasUnderlyingType;
       if (typeAliasDecl->getFormalAccess() <= Accessibility::FilePrivate)
         options |= TR_KnownNonCascadingDependency;

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -459,6 +459,13 @@ LookupTypeResult TypeChecker::lookupMemberType(DeclContext *dc,
       // Use the type witness.
       auto concrete = conformance->getConcrete();
       Type memberType = concrete->getTypeWitness(assocType, this);
+
+      // This is the only case where NormalProtocolConformance::
+      // getTypeWitnessAndDecl() returns a null type.
+      if (concrete->getState() ==
+          ProtocolConformanceState::CheckingTypeWitnesses)
+        continue;
+
       assert(memberType && "Missing type witness?");
 
       // If we haven't seen this type result yet, add it to the result set.

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -414,6 +414,14 @@ LookupTypeResult TypeChecker::lookupMemberType(DeclContext *dc,
           continue;
         }
       }
+
+      // Nominal type members of protocols cannot be accessed with an
+      // archetype base, because we have no way to recover the correct
+      // substitutions.
+      if (type->is<ArchetypeType>() &&
+          isa<NominalTypeDecl>(typeDecl)) {
+        continue;
+      }
     }
 
     // Substitute the base into the member's type.

--- a/test/decl/nested/protocol.swift
+++ b/test/decl/nested/protocol.swift
@@ -40,9 +40,11 @@ protocol Racoon {
   associatedtype Stripes
   class Claw<T> { // expected-error{{type 'Claw' cannot be nested in protocol 'Racoon'}}
     func mangle(_ s: Stripes) {}
+    // expected-error@-1 {{use of undeclared type 'Stripes'}}
   }
   struct Fang<T> { // expected-error{{type 'Fang' cannot be nested in protocol 'Racoon'}}
     func gnaw(_ s: Stripes) {}
+    // expected-error@-1 {{use of undeclared type 'Stripes'}}
   }
   enum Fur { // expected-error{{type 'Fur' cannot be nested in protocol 'Racoon'}}
     case Stripes

--- a/test/decl/typealias/protocol.swift
+++ b/test/decl/typealias/protocol.swift
@@ -202,6 +202,8 @@ struct S7 : P7 {
 
   func inExpressionContext() {
     _ = Y.self
+    _ = T5.T1.self
+    _ = T5.T2.self
   }
 }
 

--- a/validation-test/compiler_crashers_fixed/28728-d-isbeingvalidated-d-hasvalidsignature.swift
+++ b/validation-test/compiler_crashers_fixed/28728-d-isbeingvalidated-d-hasvalidsignature.swift
@@ -6,6 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 typealias e:a
 struct A:a{}typealias a=A

--- a/validation-test/compiler_crashers_fixed/28733-parent-parent-is-nominaltype-parent-is-boundgenerictype-parent-is-unboundgeneric.swift
+++ b/validation-test/compiler_crashers_fixed/28733-parent-parent-is-nominaltype-parent-is-boundgenerictype-parent-is-unboundgeneric.swift
@@ -6,5 +6,5 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 protocol P{class a:Self.a

--- a/validation-test/compiler_crashers_fixed/28748-genericenv-nullptr-too-much-circularity.swift
+++ b/validation-test/compiler_crashers_fixed/28748-genericenv-nullptr-too-much-circularity.swift
@@ -6,5 +6,5 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 protocol A:a{{}typealias e:a}{}class a:A{typealias e:b

--- a/validation-test/compiler_crashers_fixed/28751-membertype-missing-type-witness.swift
+++ b/validation-test/compiler_crashers_fixed/28751-membertype-missing-type-witness.swift
@@ -6,5 +6,5 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 {class a:P{{}typealias a:Self.a}protocol P{typealias a

--- a/validation-test/compiler_crashers_fixed/28753-conforms-equivclass-conformsto-end.swift
+++ b/validation-test/compiler_crashers_fixed/28753-conforms-equivclass-conformsto-end.swift
@@ -6,5 +6,5 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-protocol P{{}class a:A{}protocol A:P.a{typealias a{}func a:a
+// RUN: not %target-swift-frontend %s -emit-ir
+protocol A:A{{}class a{let ca{a{

--- a/validation-test/compiler_crashers_fixed/28765-inprotocol-isrequirementsignaturecomputed-missing-signature.swift
+++ b/validation-test/compiler_crashers_fixed/28765-inprotocol-isrequirementsignaturecomputed-missing-signature.swift
@@ -6,5 +6,5 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-protocol A:A{{}class a{let ca{a{
+// RUN: not %target-swift-frontend %s -emit-ir
+protocol P{{}class a:A{}protocol A:P.a{typealias a{}func a:a

--- a/validation-test/compiler_crashers_fixed/28768-isactuallycanonicalornull-forming-a-cantype-out-of-a-non-canonical-type.swift
+++ b/validation-test/compiler_crashers_fixed/28768-isactuallycanonicalornull-forming-a-cantype-out-of-a-non-canonical-type.swift
@@ -6,6 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 Indexable
 & ManagedBuffer

--- a/validation-test/compiler_crashers_fixed/28773-unreachable-executed-at-swift-lib-sema-cssimplify-cpp-4808.swift
+++ b/validation-test/compiler_crashers_fixed/28773-unreachable-executed-at-swift-lib-sema-cssimplify-cpp-4808.swift
@@ -5,5 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 @objc protocol P{{}typealias a{}class a{let c=a{


### PR DESCRIPTION
These can be cherry-picked independently to swift-4.0-branch if needed. In particular the Type::transform() one looks like it could be bad, but I was unable to come up with a simple test case.