### PR TITLE
[Diagnostics] Fix localizable quotation marks for printing ValueDecls

### DIFF
--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -429,9 +429,9 @@ static void formatDiagnosticArgument(StringRef Modifier,
     break;
 
   case DiagnosticArgumentKind::ValueDecl:
-    Out << '\'';
+    Out << FormatOpts.OpeningQuotationMark;
     Arg.getAsValueDecl()->getFullName().printPretty(Out);
-    Out << '\'';
+    Out << FormatOpts.ClosingQuotationMark;
     break;
 
   case DiagnosticArgumentKind::Type: {


### PR DESCRIPTION
- **Explanation**: Some refactoring work landed in master pre-branch in order to make it easier to cherry-pick later. This included some very old code that predated the diagnostic engine's support for localizable quotation marks. This patch restores that support using the new code.
- **Scope**: Only affects the printing of decls as diagnostic arguments.
- **Radar**: rdar://problem/32631388
- **Reviewed by**: @mxswd  
- **Risk**: Very low. Replaces literal strings with a StringRef already used elsewhere.
- **Testing**: Passed compiler regression tests.