### PR TITLE
[4.0] Update and re-enable the diagnostics for using unstable runtime names with NSCoding

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -281,10 +281,7 @@ SIMPLE_DECL_ATTR(_staticInitializeObjCMetadata, StaticInitializeObjCMetadata,
                  OnClass | NotSerialized | LongAttribute | RejectByParser,
                  /*Not serialized */ 69)
 
-SIMPLE_DECL_ATTR(NSKeyedArchiverEncodeNonGenericSubclassesOnly,
-                 NSKeyedArchiverEncodeNonGenericSubclassesOnly,
-                 OnClass | NotSerialized | LongAttribute,
-                 /*Not serialized */ 70)
+// 70 is available; it was not a serialized attribute.
 
 // HACK: Attribute needed to preserve source compatibility by downgrading errors
 // due to an SDK change in Dispatch

--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -273,8 +273,8 @@ DECL_ATTR(_implements, Implements,
           | NotSerialized | UserInaccessible,
           /* Not serialized */ 67)
 
-DECL_ATTR(NSKeyedArchiverClassName, NSKeyedArchiverClassName,
-          OnClass | NotSerialized | LongAttribute,
+DECL_ATTR(_objcRuntimeName, ObjCRuntimeName,
+          OnClass | NotSerialized | UserInaccessible | RejectByParser,
           /*Not serialized */ 68)
 
 SIMPLE_DECL_ATTR(_staticInitializeObjCMetadata, StaticInitializeObjCMetadata,

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -1161,21 +1161,26 @@ public:
   }
 };
 
-/// Defines the @NSKeyedArchiverClassNameAttr attribute.
-class NSKeyedArchiverClassNameAttr : public DeclAttribute {
+/// A limited variant of \c @objc that's used for classes with generic ancestry.
+class ObjCRuntimeNameAttr : public DeclAttribute {
+  static StringRef getSimpleName(const ObjCAttr &Original) {
+    assert(Original.hasName());
+    return Original.getName()->getSimpleName().str();
+  }
 public:
-  NSKeyedArchiverClassNameAttr(StringRef Name, SourceLoc AtLoc, SourceRange Range, bool Implicit)
-    : DeclAttribute(DAK_NSKeyedArchiverClassName, AtLoc, Range, Implicit),
+  ObjCRuntimeNameAttr(StringRef Name, SourceLoc AtLoc, SourceRange Range,
+                      bool Implicit)
+    : DeclAttribute(DAK_ObjCRuntimeName, AtLoc, Range, Implicit),
       Name(Name) {}
 
-  NSKeyedArchiverClassNameAttr(StringRef Name, bool Implicit)
-    : NSKeyedArchiverClassNameAttr(Name, SourceLoc(), SourceRange(), /*Implicit=*/true) {}
+  explicit ObjCRuntimeNameAttr(const ObjCAttr &Original)
+    : ObjCRuntimeNameAttr(getSimpleName(Original), Original.AtLoc,
+                          Original.Range, Original.isImplicit()) {}
 
-  /// The legacy mangled name.
   const StringRef Name;
 
   static bool classof(const DeclAttribute *DA) {
-    return DA->getKind() == DAK_NSKeyedArchiverClassName;
+    return DA->getKind() == DAK_ObjCRuntimeName;
   }
 };
 

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1317,6 +1317,8 @@ ERROR(attr_objc_expected_rparen,none,
       "expected ')' after name for @objc", ())
 ERROR(attr_objc_empty_name,none,
       "expected name within parentheses of @objc attribute", ())
+ERROR(attr_nskeyedarchiverclassname_removed, none,
+      "@NSKeyedArchiverClassName has been removed; use @objc instead", ())
 
 // opened
 ERROR(opened_attribute_expected_lparen,none,

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1319,6 +1319,9 @@ ERROR(attr_objc_empty_name,none,
       "expected name within parentheses of @objc attribute", ())
 ERROR(attr_nskeyedarchiverclassname_removed, none,
       "@NSKeyedArchiverClassName has been removed; use @objc instead", ())
+ERROR(attr_nskeyedarchiverencodenongenericsubclassesonly_removed, none,
+      "@NSKeyedArchiverEncodeNonGenericSubclassesOnly is no longer necessary",
+      ())
 
 // opened
 ERROR(opened_attribute_expected_lparen,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1246,10 +1246,6 @@ NOTE(add_NSKeyedArchiverEncodeNonGenericSubclassesOnly_attr,none,
      "add @NSKeyedArchiverEncodeNonGenericSubclassesOnly "
      "and only archive specific subclasses of this class", (Type))
 
-ERROR(attr_NSKeyedArchiverClassName_generic,none,
-      "'@NSKeyedArchiverClassName' cannot be applied to generic class %0",
-      (Type))
-
 // Generic types
 ERROR(unsupported_type_nested_in_generic_function,none,
       "type %0 cannot be nested in generic function %1",

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1228,23 +1228,19 @@ ERROR(pattern_binds_no_variables,none,
       (unsigned))
 
 ERROR(nscoding_unstable_mangled_name,none,
-      "%select{private|fileprivate|nested|local|generic}0 class %1 has an "
+      "%select{private|fileprivate|nested|local}0 class %1 has an "
       "unstable name when archiving via 'NSCoding'",
       (unsigned, Type))
 WARNING(nscoding_unstable_mangled_name_warn,none,
-        "%select{private|fileprivate|nested|local|generic}0 class %1 has an "
+        "%select{private|fileprivate|nested|local}0 class %1 has an "
         "unstable name when archiving via 'NSCoding'",
         (unsigned, Type))
-NOTE(unstable_mangled_name_add_objc,none,
-     "for new classes, add '@objc' to specify a unique, prefixed Objective-C "
+NOTE(unstable_mangled_name_add_objc_new,none,
+     "for new classes, use '@objc' to specify a unique, prefixed Objective-C "
      "runtime name", ())
-NOTE(unstable_mangled_name_add_NSKeyedArchiverClassName,none,
-     "for compatibility with existing archives, use '@NSKeyedArchiverClassName' "
-     "to record the Swift 3 mangled name", ())
-NOTE(add_NSKeyedArchiverEncodeNonGenericSubclassesOnly_attr,none,
-     "generic class %0 should not be archived directly; "
-     "add @NSKeyedArchiverEncodeNonGenericSubclassesOnly "
-     "and only archive specific subclasses of this class", (Type))
+NOTE(unstable_mangled_name_add_objc,none,
+     "for compatibility with existing archives, use '@objc' "
+     "to record the Swift 3 runtime name", ())
 
 // Generic types
 ERROR(unsupported_type_nested_in_generic_function,none,

--- a/include/swift/AST/Identifier.h
+++ b/include/swift/AST/Identifier.h
@@ -582,6 +582,12 @@ public:
     return Storage.getArgumentNames();
   }
 
+  /// Asserts that this is a nullary selector and returns the single identifier.
+  Identifier getSimpleName() const {
+    assert(Storage.isSimpleName() && "not a nullary selector");
+    return Storage.getBaseIdentifier();
+  }
+
   /// Get a string representation of the selector.
   ///
   /// \param scratch Scratch space to use.

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -229,7 +229,7 @@ namespace swift {
       Swift3ObjCInferenceWarnings::None;
 
     /// Diagnose uses of NSCoding with classes that have unstable mangled names.
-    bool EnableNSKeyedArchiverDiagnostics = false;
+    bool EnableNSKeyedArchiverDiagnostics = true;
     
     /// Enable keypath components that aren't fully implemented.
     bool EnableExperimentalKeyPathComponents = false;

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -1217,14 +1217,6 @@ FUNCTION(GetKeyPath, swift_getKeyPath, C_CC,
          ARGS(Int8PtrTy, Int8PtrTy),
          ATTRS(NoUnwind))
 
-// func _registerClassNameForArchiving(_ nameOrNull: UnsafePointer<CChar>?,
-//                                     _ c: AnyClass)
-FUNCTION(RegisterClassNameForArchiving, swift_registerClassNameForArchiving,
-         SwiftCC,
-         RETURNS(VoidTy),
-         ARGS(Int8PtrTy, TypeMetadataPtrTy),
-         ATTRS(NoUnwind))
-
 #if SWIFT_OBJC_INTEROP || !defined(SWIFT_RUNTIME_GENERATE_GLOBAL_SYMBOLS)
 
 // Put here all definitions of runtime functions which are:

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -1321,8 +1321,8 @@ namespace decls_block {
   using SynthesizedProtocolDeclAttrLayout
     = BCRecordLayout<SynthesizedProtocol_DECL_ATTR>;
   using ImplementsDeclAttrLayout = BCRecordLayout<Implements_DECL_ATTR>;
-  using NSKeyedArchiverClassNameDeclAttrLayout
-    = BCRecordLayout<NSKeyedArchiverClassName_DECL_ATTR>;
+  using ObjCRuntimeNameDeclAttrLayout
+    = BCRecordLayout<ObjCRuntimeName_DECL_ATTR>;
 
   using InlineDeclAttrLayout = BCRecordLayout<
     Inline_DECL_ATTR,

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -493,10 +493,10 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
     break;
   }
 
-  case DAK_NSKeyedArchiverClassName: {
-    Printer.printAttrName("@NSKeyedArchiverClassName");
+  case DAK_ObjCRuntimeName: {
+    Printer.printAttrName("@objc");
     Printer << "(";
-    auto *attr = cast<NSKeyedArchiverClassNameAttr>(this);
+    auto *attr = cast<ObjCRuntimeNameAttr>(this);
     Printer << "\"" << attr->Name << "\"";
     Printer << ")";
     break;
@@ -571,6 +571,7 @@ StringRef DeclAttribute::getAttrName() const {
   case DAK_AutoClosure:
     return "autoclosure";
   case DAK_ObjC:
+  case DAK_ObjCRuntimeName:
     return "objc";
   case DAK_Inline: {
     switch (cast<InlineAttr>(this)->getKind()) {
@@ -626,8 +627,6 @@ StringRef DeclAttribute::getAttrName() const {
     return "_specialize";
   case DAK_Implements:
     return "_implements";
-  case DAK_NSKeyedArchiverClassName:
-    return "NSKeyedArchiverClassName";
   }
   llvm_unreachable("bad DeclAttrKind");
 }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2759,6 +2759,8 @@ StringRef ClassDecl::getObjCRuntimeName(
     return objcClass->getObjCRuntimeNameAsString();
 
   // If there is an 'objc' attribute with a name, use that name.
+  if (auto attr = getAttrs().getAttribute<ObjCRuntimeNameAttr>())
+    return attr->Name;
   if (auto objc = getAttrs().getAttribute<ObjCAttr>()) {
     if (auto name = objc->getName())
       return name->getString(buffer);

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -971,7 +971,7 @@ void IRGenModule::emitClassDecl(ClassDecl *D) {
                     classTI.getLayout(*this, selfType),
                     classTI.getClassLayout(*this, selfType));
 
-  IRGen.addClassForArchiveNameRegistration(D);
+  IRGen.addClassForEagerInitialization(D);
 
   emitNestedTypeDecls(D->getMembers());
   emitFieldMetadataRecord(D);

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -731,7 +731,7 @@ static std::unique_ptr<llvm::Module> performIRGeneration(IRGenOptions &Opts,
       IGM.emitTypeMetadataRecords();
       IGM.emitBuiltinReflectionMetadata();
       IGM.emitReflectionMetadataVersion();
-      irgen.emitNSArchiveClassNameRegistration();
+      irgen.emitEagerClassInitialization();
     }
 
     // Emit symbols for eliminated dead methods.
@@ -910,7 +910,7 @@ static void performParallelIRGeneration(IRGenOptions &Opts,
 
   irgen.emitReflectionMetadataVersion();
 
-  irgen.emitNSArchiveClassNameRegistration();
+  irgen.emitEagerClassInitialization();
 
   // Emit reflection metadata for builtin and imported types.
   irgen.emitBuiltinReflectionMetadata();

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -758,11 +758,8 @@ void IRGenerator::addLazyWitnessTable(const ProtocolConformance *Conf) {
   }
 }
 
-void IRGenerator::addClassForArchiveNameRegistration(ClassDecl *ClassDecl) {
-
-  // Those two attributes are interesting to us
-  if (!ClassDecl->getAttrs().hasAttribute<NSKeyedArchiverClassNameAttr>() &&
-      !ClassDecl->getAttrs().hasAttribute<StaticInitializeObjCMetadataAttr>())
+void IRGenerator::addClassForEagerInitialization(ClassDecl *ClassDecl) {
+  if (!ClassDecl->getAttrs().hasAttribute<StaticInitializeObjCMetadataAttr>())
     return;
 
   // Exclude some classes where those attributes make no sense but could be set
@@ -775,7 +772,7 @@ void IRGenerator::addClassForArchiveNameRegistration(ClassDecl *ClassDecl) {
   if (ClassDecl->hasClangNode())
     return;
 
-  ClassesForArchiveNameRegistration.push_back(ClassDecl);
+  ClassesForEagerInitialization.push_back(ClassDecl);
 }
 
 llvm::AttributeSet IRGenModule::getAllocAttrs() {

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -222,7 +222,7 @@ private:
   /// The queue of lazy witness tables to emit.
   llvm::SmallVector<SILWitnessTable *, 4> LazyWitnessTables;
 
-  llvm::SmallVector<ClassDecl *, 4> ClassesForArchiveNameRegistration;
+  llvm::SmallVector<ClassDecl *, 4> ClassesForEagerInitialization;
 
   /// The order in which all the SIL function definitions should
   /// appear in the translation unit.
@@ -298,7 +298,7 @@ public:
   /// Emit a symbol identifying the reflection metadata version.
   void emitReflectionMetadataVersion();
 
-  void emitNSArchiveClassNameRegistration();
+  void emitEagerClassInitialization();
 
   /// Checks if the metadata of \p Nominal can be emitted lazily.
   ///
@@ -338,7 +338,7 @@ public:
                                       fn, IGM});
   }
 
-  void addClassForArchiveNameRegistration(ClassDecl *ClassDecl);
+  void addClassForEagerInitialization(ClassDecl *ClassDecl);
 
   unsigned getFunctionOrder(SILFunction *F) {
     auto it = FunctionOrder.find(F);

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -106,7 +106,6 @@ public:
   IGNORED_ATTR(DiscardableResult)
   IGNORED_ATTR(Implements)
   IGNORED_ATTR(StaticInitializeObjCMetadata)
-  IGNORED_ATTR(NSKeyedArchiverEncodeNonGenericSubclassesOnly)
   IGNORED_ATTR(DowngradeExhaustivityCheck)
 #undef IGNORED_ATTR
 
@@ -785,7 +784,6 @@ public:
     IGNORED_ATTR(ShowInInterface)
     IGNORED_ATTR(ObjCMembers)
     IGNORED_ATTR(StaticInitializeObjCMetadata)
-    IGNORED_ATTR(NSKeyedArchiverEncodeNonGenericSubclassesOnly)
     IGNORED_ATTR(DowngradeExhaustivityCheck)
 #undef IGNORED_ATTR
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -86,6 +86,7 @@ public:
   IGNORED_ATTR(ObjC)
   IGNORED_ATTR(ObjCBridged)
   IGNORED_ATTR(ObjCNonLazyRealization)
+  IGNORED_ATTR(ObjCRuntimeName)
   IGNORED_ATTR(Optional)
   IGNORED_ATTR(Postfix)
   IGNORED_ATTR(Prefix)
@@ -104,7 +105,6 @@ public:
   IGNORED_ATTR(ShowInInterface)
   IGNORED_ATTR(DiscardableResult)
   IGNORED_ATTR(Implements)
-  IGNORED_ATTR(NSKeyedArchiverClassName)
   IGNORED_ATTR(StaticInitializeObjCMetadata)
   IGNORED_ATTR(NSKeyedArchiverEncodeNonGenericSubclassesOnly)
   IGNORED_ATTR(DowngradeExhaustivityCheck)
@@ -769,6 +769,7 @@ public:
     IGNORED_ATTR(ObjC)
     IGNORED_ATTR(ObjCBridged)
     IGNORED_ATTR(ObjCNonLazyRealization)
+    IGNORED_ATTR(ObjCRuntimeName)
     IGNORED_ATTR(Optional)
     IGNORED_ATTR(Ownership)
     IGNORED_ATTR(Override)
@@ -827,7 +828,6 @@ public:
   
   void visitDiscardableResultAttr(DiscardableResultAttr *attr);
   void visitImplementsAttr(ImplementsAttr *attr);
-  void visitNSKeyedArchiverClassNameAttr(NSKeyedArchiverClassNameAttr *attr);
 };
 } // end anonymous namespace
 
@@ -1958,18 +1958,6 @@ void AttributeChecker::visitImplementsAttr(ImplementsAttr *attr) {
     TC.diagnose(attr->getLocation(),
                 diag::implements_attr_non_protocol_type)
       .highlight(ProtoTypeLoc.getTypeRepr()->getSourceRange());
-  }
-}
-
-void AttributeChecker::visitNSKeyedArchiverClassNameAttr(
-                                              NSKeyedArchiverClassNameAttr *attr) {
-  auto classDecl = dyn_cast<ClassDecl>(D);
-  if (!classDecl) return;
-
-  // Generic classes can't use @NSKeyedArchiverClassName.
-  if (classDecl->getGenericSignatureOfContext()) {
-    diagnoseAndRemoveAttr(attr, diag::attr_NSKeyedArchiverClassName_generic,
-                          classDecl->getDeclaredInterfaceType());
   }
 }
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -6138,8 +6138,8 @@ public:
     UNINTERESTING_ATTR(DiscardableResult)
 
     UNINTERESTING_ATTR(ObjCMembers)
+    UNINTERESTING_ATTR(ObjCRuntimeName)
     UNINTERESTING_ATTR(Implements)
-    UNINTERESTING_ATTR(NSKeyedArchiverClassName)
     UNINTERESTING_ATTR(StaticInitializeObjCMetadata)
     UNINTERESTING_ATTR(NSKeyedArchiverEncodeNonGenericSubclassesOnly)
     UNINTERESTING_ATTR(DowngradeExhaustivityCheck)
@@ -7022,6 +7022,13 @@ static Optional<ObjCReason> shouldMarkClassAsObjC(TypeChecker &TC,
 
   if (auto attr = CD->getAttrs().getAttribute<ObjCAttr>()) {
     if (kind == ObjCClassKind::ObjCMembers) {
+      if (attr->hasName() && !CD->isGenericContext()) {
+        // @objc with a name on a non-generic subclass of a generic class is
+        // just controlling the runtime name. Don't diagnose this case.
+        CD->getAttrs().add(new (TC.Context) ObjCRuntimeNameAttr(*attr));
+        return None;
+      }
+
       TC.diagnose(attr->getLocation(), diag::objc_for_generic_class)
         .fixItRemove(attr->getRangeWithAt());
     }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -6141,7 +6141,6 @@ public:
     UNINTERESTING_ATTR(ObjCRuntimeName)
     UNINTERESTING_ATTR(Implements)
     UNINTERESTING_ATTR(StaticInitializeObjCMetadata)
-    UNINTERESTING_ATTR(NSKeyedArchiverEncodeNonGenericSubclassesOnly)
     UNINTERESTING_ATTR(DowngradeExhaustivityCheck)
 #undef UNINTERESTING_ATTR
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -6019,6 +6019,9 @@ static bool isNSCoding(ProtocolDecl *protocol) {
 
 /// Whether the given class has an explicit '@objc' name.
 static bool hasExplicitObjCName(ClassDecl *classDecl) {
+  if (classDecl->getAttrs().hasAttribute<ObjCRuntimeNameAttr>())
+    return true;
+
   auto objcAttr = classDecl->getAttrs().getAttribute<ObjCAttr>();
   if (!objcAttr) return false;
 
@@ -6046,13 +6049,8 @@ static void inferStaticInitializeObjCMetadata(ClassDecl *classDecl,
   if (classDecl->getAttrs().hasAttribute<StaticInitializeObjCMetadataAttr>())
     return;
 
-  // A class with the @NSKeyedArchiverClassNameAttr will end up getting registered
-  // with the Objective-C runtime anyway.
-  if (classDecl->getAttrs().hasAttribute<NSKeyedArchiverClassNameAttr>())
-    return;
-
-  // A class with @NSKeyedArchiverEncodeNonGenericSubclassesOnly promises not to be archived,
-  // so don't static-initialize its Objective-C metadata.
+  // A class with @NSKeyedArchiverEncodeNonGenericSubclassesOnly promises not to
+  // be archived, so don't static-initialize its Objective-C metadata.
   if (classDecl->getAttrs().hasAttribute<NSKeyedArchiverEncodeNonGenericSubclassesOnlyAttr>())
     return;
 
@@ -6150,7 +6148,6 @@ void TypeChecker::checkConformancesInContext(DeclContext *dc,
 
         if (kind && getLangOpts().EnableNSKeyedArchiverDiagnostics &&
             !hasExplicitObjCName(classDecl) &&
-            !classDecl->getAttrs().hasAttribute<NSKeyedArchiverClassNameAttr>() &&
             !classDecl->getAttrs()
               .hasAttribute<NSKeyedArchiverEncodeNonGenericSubclassesOnlyAttr>()) {
           SourceLoc loc;

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1955,11 +1955,12 @@ void Serializer::writeDeclAttribute(const DeclAttribute *DA) {
   case DAK_SetterAccessibility:
   case DAK_ObjCBridged:
   case DAK_SynthesizedProtocol:
-  case DAK_Count:
   case DAK_Implements:
-  case DAK_NSKeyedArchiverClassName:
+  case DAK_ObjCRuntimeName:
     llvm_unreachable("cannot serialize attribute");
-    return;
+
+  case DAK_Count:
+    llvm_unreachable("not a real attribute");
 
 #define SIMPLE_DECL_ATTR(_, CLASS, ...)\
   case DAK_##CLASS: { \

--- a/stdlib/public/SDK/Foundation/Foundation.swift
+++ b/stdlib/public/SDK/Foundation/Foundation.swift
@@ -95,20 +95,3 @@ extension CVarArg where Self: _ObjectiveCBridgeable {
     return _encodeBitsAsWords(object)
   }
 }
-
-//===----------------------------------------------------------------------===//
-// Runtime support for NSKeyedArchives
-//===----------------------------------------------------------------------===//
-
-@_silgen_name("swift_registerClassNameForArchiving")
-public func _registerClassNameForArchiving(_ nameForClass: UnsafePointer<CChar>,
-                                           _ classType: AnyClass) {
-  // If it's not possible to create a String from the name, it should abort
-  // and not fail silently.
-  let nameStr = String(utf8String: nameForClass)!
-
-  // Register the class name mapping for archiving and unarchiving.
-  NSKeyedArchiver.setClassName(nameStr, for: classType)
-  NSKeyedUnarchiver.setClass(classType, forClassName: nameStr)
-}
-

--- a/test/IDE/complete_decl_attribute.swift
+++ b/test/IDE/complete_decl_attribute.swift
@@ -58,7 +58,7 @@ func method(){}
 @#^KEYWORD3^#
 class C {}
 
-// KEYWORD3:                  Begin completions, 9 items
+// KEYWORD3:                  Begin completions, 8 items
 // KEYWORD3-NEXT:             Keyword/None:                       available[#Class Attribute#]; name=available{{$}}
 // KEYWORD3-NEXT:             Keyword/None:                       objc[#Class Attribute#]; name=objc{{$}}
 // KEYWORD3-NEXT:             Keyword/None:                       IBDesignable[#Class Attribute#]; name=IBDesignable{{$}}
@@ -67,7 +67,6 @@ class C {}
 // KEYWORD3-NEXT:             Keyword/None:                       objcMembers[#Class Attribute#]; name=objcMembers{{$}}
 // KEYWORD3-NEXT:             Keyword/None:                       NSApplicationMain[#Class Attribute#]; name=NSApplicationMain{{$}}
 // KEYWORD3-NEXT:             Keyword/None:                       objc_non_lazy_realization[#Class Attribute#]; name=objc_non_lazy_realization{{$}}
-// KEYWORD3-NEXT:             Keyword/None:                       NSKeyedArchiverEncodeNonGenericSubclassesOnly[#Class Attribute#]; name=NSKeyedArchiverEncodeNonGenericSubclassesOnly{{$}}
 // KEYWORD3-NEXT:             End completions
 
 @#^KEYWORD4^#
@@ -87,7 +86,7 @@ struct S{}
 
 @#^KEYWORD_LAST^#
 
-// KEYWORD_LAST:                  Begin completions, 22 items
+// KEYWORD_LAST:                  Begin completions, 21 items
 // KEYWORD_LAST-NEXT:             Keyword/None:                       available[#Declaration Attribute#]; name=available{{$}}
 // KEYWORD_LAST-NEXT:             Keyword/None:                       objc[#Declaration Attribute#]; name=objc{{$}}
 // KEYWORD_LAST-NEXT:             Keyword/None:                       noreturn[#Declaration Attribute#]; name=noreturn{{$}}
@@ -109,5 +108,4 @@ struct S{}
 // KEYWORD_LAST-NEXT:             Keyword/None:                       warn_unqualified_access[#Declaration Attribute#]; name=warn_unqualified_access
 // KEYWORD_LAST-NEXT:             Keyword/None:                       discardableResult[#Declaration Attribute#]; name=discardableResult
 // KEYWORD_LAST-NEXT:             Keyword/None:                       GKInspectable[#Declaration Attribute#]; name=GKInspectable{{$}}
-// KEYWORD_LAST-NEXT:             Keyword/None:                       NSKeyedArchiverEncodeNonGenericSubclassesOnly[#Declaration Attribute#]; name=NSKeyedArchiverEncodeNonGenericSubclassesOnly{{$}}
 // KEYWORD_LAST-NEXT:             End completions

--- a/test/IDE/complete_decl_attribute.swift
+++ b/test/IDE/complete_decl_attribute.swift
@@ -58,7 +58,7 @@ func method(){}
 @#^KEYWORD3^#
 class C {}
 
-// KEYWORD3:                  Begin completions, 10 items
+// KEYWORD3:                  Begin completions, 9 items
 // KEYWORD3-NEXT:             Keyword/None:                       available[#Class Attribute#]; name=available{{$}}
 // KEYWORD3-NEXT:             Keyword/None:                       objc[#Class Attribute#]; name=objc{{$}}
 // KEYWORD3-NEXT:             Keyword/None:                       IBDesignable[#Class Attribute#]; name=IBDesignable{{$}}
@@ -67,7 +67,6 @@ class C {}
 // KEYWORD3-NEXT:             Keyword/None:                       objcMembers[#Class Attribute#]; name=objcMembers{{$}}
 // KEYWORD3-NEXT:             Keyword/None:                       NSApplicationMain[#Class Attribute#]; name=NSApplicationMain{{$}}
 // KEYWORD3-NEXT:             Keyword/None:                       objc_non_lazy_realization[#Class Attribute#]; name=objc_non_lazy_realization{{$}}
-// KEYWORD3-NEXT:             Keyword/None:                       NSKeyedArchiverClassName[#Class Attribute#]; name=NSKeyedArchiverClassName{{$}}
 // KEYWORD3-NEXT:             Keyword/None:                       NSKeyedArchiverEncodeNonGenericSubclassesOnly[#Class Attribute#]; name=NSKeyedArchiverEncodeNonGenericSubclassesOnly{{$}}
 // KEYWORD3-NEXT:             End completions
 
@@ -88,7 +87,7 @@ struct S{}
 
 @#^KEYWORD_LAST^#
 
-// KEYWORD_LAST:                  Begin completions, 23 items
+// KEYWORD_LAST:                  Begin completions, 22 items
 // KEYWORD_LAST-NEXT:             Keyword/None:                       available[#Declaration Attribute#]; name=available{{$}}
 // KEYWORD_LAST-NEXT:             Keyword/None:                       objc[#Declaration Attribute#]; name=objc{{$}}
 // KEYWORD_LAST-NEXT:             Keyword/None:                       noreturn[#Declaration Attribute#]; name=noreturn{{$}}
@@ -110,6 +109,5 @@ struct S{}
 // KEYWORD_LAST-NEXT:             Keyword/None:                       warn_unqualified_access[#Declaration Attribute#]; name=warn_unqualified_access
 // KEYWORD_LAST-NEXT:             Keyword/None:                       discardableResult[#Declaration Attribute#]; name=discardableResult
 // KEYWORD_LAST-NEXT:             Keyword/None:                       GKInspectable[#Declaration Attribute#]; name=GKInspectable{{$}}
-// KEYWORD_LAST-NEXT:             Keyword/None:                       NSKeyedArchiverClassName[#Declaration Attribute#]; name=NSKeyedArchiverClassName{{$}}
 // KEYWORD_LAST-NEXT:             Keyword/None:                       NSKeyedArchiverEncodeNonGenericSubclassesOnly[#Declaration Attribute#]; name=NSKeyedArchiverEncodeNonGenericSubclassesOnly{{$}}
 // KEYWORD_LAST-NEXT:             End completions

--- a/test/Interpreter/SDK/archive_attributes.swift
+++ b/test/Interpreter/SDK/archive_attributes.swift
@@ -2,7 +2,7 @@
 // RUN: %target-build-swift %s -module-name=test -DENCODE -o %t/encode
 // RUN: %target-build-swift %s -module-name=test -o %t/decode
 // RUN: %target-run %t/encode %t/test.arc
-// RUN: %FileCheck -check-prefix=CHECK-ARCHIVE %s < %t/test.arc
+// RUN: plutil -p %t/test.arc | %FileCheck -check-prefix=CHECK-ARCHIVE %s
 // RUN: %target-run %t/decode %t/test.arc | %FileCheck %s
 
 // REQUIRES: executable_test
@@ -14,8 +14,8 @@
 import Foundation
 
 struct ABC {
-  // CHECK-ARCHIVE-DAG: nested_class_coding
-  @NSKeyedArchiverClassName("nested_class_coding")
+  // CHECK-ARCHIVE-DAG: "$classname" => "nested_class_coding"
+  @objc(nested_class_coding)
   class NestedClass : NSObject, NSCoding {
     var i : Int
 
@@ -33,8 +33,8 @@ struct ABC {
   }
 }
 
-// CHECK-ARCHIVE-DAG: private_class_coding
-@NSKeyedArchiverClassName("private_class_coding")
+// CHECK-ARCHIVE-DAG: "$classname" => "private_class_coding"
+@objc(private_class_coding)
 private class PrivateClass : NSObject, NSCoding {
   var pi : Int
 
@@ -65,7 +65,7 @@ class GenericClass<T> : NSObject, NSCoding {
   }
 }
 
-// CHECK-ARCHIVE-DAG: test.IntClass
+// CHECK-ARCHIVE-DAG: "$classname" => "test.IntClass"
 class IntClass : GenericClass<Int> {
 
   init(ii: Int) {
@@ -83,8 +83,8 @@ class IntClass : GenericClass<Int> {
   }
 }
 
-// CHECK-ARCHIVE-DAG: double_class_coding
-@NSKeyedArchiverClassName("double_class_coding")
+// CHECK-ARCHIVE-DAG: "$classname" => "double_class_coding"
+@objc(double_class_coding)
 class DoubleClass : GenericClass<Double> {
 
   init(dd: Double) {
@@ -102,8 +102,8 @@ class DoubleClass : GenericClass<Double> {
   }
 }
 
-// CHECK-ARCHIVE-DAG: top_level_coding
-@NSKeyedArchiverClassName("top_level_coding")
+// CHECK-ARCHIVE-DAG: "$classname" => "top_level_coding"
+@objc(top_level_coding)
 class TopLevel : NSObject, NSCoding {
   var tli : Int
 

--- a/test/Interpreter/SDK/archive_attributes.swift
+++ b/test/Interpreter/SDK/archive_attributes.swift
@@ -51,7 +51,6 @@ private class PrivateClass : NSObject, NSCoding {
   }
 }
 
-@NSKeyedArchiverEncodeNonGenericSubclassesOnly
 class GenericClass<T> : NSObject, NSCoding {
   var gi : T? = nil
 

--- a/test/Interpreter/SDK/archiving_generic_swift_class.swift
+++ b/test/Interpreter/SDK/archiving_generic_swift_class.swift
@@ -6,7 +6,6 @@
 
 import Foundation
 
-@NSKeyedArchiverEncodeNonGenericSubclassesOnly
 final class Foo<T: NSCoding>: NSObject, NSCoding {
   var one, two: T
 

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -419,6 +419,13 @@ extension ConcreteSubclassOfGeneric2 {
   @objc func foo() {} // expected-error {{@objc is not supported within extensions of generic classes}}
 }
 
+@objc(CustomNameForSubclassOfGeneric) // okay
+class ConcreteSubclassOfGeneric3 : GenericContext3<Int> {}
+
+extension ConcreteSubclassOfGeneric3 {
+  @objc func foo() {} // expected-error {{@objc is not supported within extensions of generic classes}}
+}
+
 class subject_subscriptIndexed1 {
   @objc
   subscript(a: Int) -> Int { // no-error

--- a/test/attr/attr_objc_swift3_deprecated.swift
+++ b/test/attr/attr_objc_swift3_deprecated.swift
@@ -19,6 +19,21 @@ class DynamicMembers {
   dynamic var bar: NSObject? = nil // expected-warning{{inference of '@objc' for 'dynamic' members is deprecated}}{{3-3=@objc }}
 }
 
+class GenericClass<T>: NSObject {}
+
+class SubclassOfGeneric: GenericClass<Int> {
+  func foo() { } // expected-warning{{inference of '@objc' for members of Objective-C-derived classes is deprecated}}
+    // expected-note@-1{{add `@objc` to continue exposing an Objective-C entry point (Swift 3 behavior)}}{{3-3=@objc }}
+    // expected-note@-2{{add `@nonobjc` to suppress the Objective-C entry point (Swift 4 behavior)}}{{3-3=@nonobjc }}
+}
+
+@objc(SubclassOfGenericCustom)
+class SubclassOfGenericCustomName: GenericClass<Int> {
+  func foo() { } // expected-warning{{inference of '@objc' for members of Objective-C-derived classes is deprecated}}
+    // expected-note@-1{{add `@objc` to continue exposing an Objective-C entry point (Swift 3 behavior)}}{{3-3=@objc }}
+    // expected-note@-2{{add `@nonobjc` to suppress the Objective-C entry point (Swift 4 behavior)}}{{3-3=@nonobjc }}
+}
+
 // Suppress diagnostices about references to inferred @objc declarations
 // in this mode.
 func test(sc: ObjCSubclass, dm: DynamicMembers) {

--- a/test/decl/protocol/conforms/nscoding.swift
+++ b/test/decl/protocol/conforms/nscoding.swift
@@ -101,9 +101,9 @@ class CodingE<T> : CodingB<T> {   // expected-error{{generic class 'CodingE<T>' 
   override func encode(coder: NSCoder) { }
 }
 
-// @NSKeyedArchiverClassName suppressions
+// @objc suppressions
 extension CodingA {
-  @NSKeyedArchiverClassName("TheNestedE")
+  @objc(TheNestedE)
   class NestedE : NSObject, NSCoding {
     required init(coder: NSCoder) { }
     func encode(coder: NSCoder) { }
@@ -116,28 +116,21 @@ class CodingGeneric<T> : NSObject, NSCoding {
   func encode(coder: NSCoder) { }
 }
 
-@NSKeyedArchiverClassName("TheCodingF")
+@objc(TheCodingF)
 fileprivate class CodingF : NSObject, NSCoding {
   required init(coder: NSCoder) { }
   func encode(coder: NSCoder) { }
 }
 
-@NSKeyedArchiverClassName("TheCodingG")
+@objc(TheCodingG)
 private class CodingG : NSObject, NSCoding {
   required init(coder: NSCoder) { }
   func encode(coder: NSCoder) { }
 }
 
-// Errors with @NSKeyedArchiverClassName.
-@NSKeyedArchiverClassName("TheCodingG") // expected-error{{@NSKeyedArchiverClassName may only be used on 'class' declarations}}
-struct Foo { }
-
-@NSKeyedArchiverClassName("TheCodingG") // expected-error{{'@NSKeyedArchiverClassName' cannot be applied to generic class 'Bar<T>'}}
-class Bar<T> : NSObject { }
-
 extension CodingB {
-  @NSKeyedArchiverClassName("GenericViaParent") // expected-error{{'@NSKeyedArchiverClassName' cannot be applied to generic class 'CodingB<T>.GenericViaParent'}}
-  class GenericViaParent : NSObject { }
+  @objc(GenericViaScope) // expected-error {{generic subclasses of '@objc' classes cannot have an explicit '@objc' because they are not directly visible from Objective-C}}
+  class GenericViaScope : NSObject { }
 }
 
 // Inference of @_staticInitializeObjCMetadata.
@@ -150,6 +143,7 @@ class DontAllowStaticInits { }
 // CHECK-NOT: class_decl "CodingA"{{.*}}@_staticInitializeObjCMetadata
 // CHECK: class_decl "NestedA"{{.*}}@_staticInitializeObjCMetadata
 // CHECK: class_decl "NestedC"{{.*}}@_staticInitializeObjCMetadata
-// CHECK-NOT: class_decl "NestedE"{{.*}}@_staticInitializeObjCMetadata
+// CHECK: class_decl "NestedE"{{.*}}@_staticInitializeObjCMetadata
 // CHECK-NOT: class_decl "CodingGeneric"{{.*}}@_staticInitializeObjCMetadata
+// CHECK-NOT: class_decl "GenericViaScope"{{.*}}@_staticInitializeObjCMetadata
 // CHECK: class_decl "SubclassOfCodingE"{{.*}}@_staticInitializeObjCMetadata

--- a/test/decl/protocol/conforms/nscoding.swift
+++ b/test/decl/protocol/conforms/nscoding.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -swift-version 4 %s -enable-nskeyedarchiver-diagnostics -verify
-// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -swift-version 4 %s 2>&1 | %FileCheck -check-prefix CHECK-NO-DIAGS %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -swift-version 4 %s -verify
+// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -swift-version 4 %s -disable-nskeyedarchiver-diagnostics 2>&1 | %FileCheck -check-prefix CHECK-NO-DIAGS %s
 
 // RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -swift-version 4 %s -dump-ast 2> %t.ast
 // RUN: %FileCheck %s < %t.ast
@@ -12,6 +12,7 @@
 import Foundation
 
 // Top-level classes
+// CHECK-NOT: class_decl "CodingA"{{.*}}@_staticInitializeObjCMetadata
 class CodingA : NSObject, NSCoding {
   required init(coder: NSCoder) { }
   func encode(coder: NSCoder) { }
@@ -20,26 +21,29 @@ class CodingA : NSObject, NSCoding {
 
 // Nested classes
 extension CodingA {
+  // CHECK: class_decl "NestedA"{{.*}}@_staticInitializeObjCMetadata
   class NestedA : NSObject, NSCoding { // expected-error{{nested class 'CodingA.NestedA' has an unstable name when archiving via 'NSCoding'}}
-    // expected-note@-1{{for new classes, add '@objc' to specify a unique, prefixed Objective-C runtime name}}{{3-3=@objc(<#Objective-C class name#>)}}
-    // expected-note@-2{{for compatibility with existing archives, use '@NSKeyedArchiverClassName' to record the Swift 3 mangled name}}{{3-3=@NSKeyedArchiverClassName("_TtCC8nscoding7CodingA7NestedA")}}
+    // expected-note@-1{{for compatibility with existing archives, use '@objc' to record the Swift 3 runtime name}}{{3-3=@objc(_TtCC8nscoding7CodingA7NestedA)}}
+    // expected-note@-2{{for new classes, use '@objc' to specify a unique, prefixed Objective-C runtime name}}{{3-3=@objc(<#prefixed Objective-C class name#>)}}
     required init(coder: NSCoder) { }
     func encode(coder: NSCoder) { }
   }
 
   class NestedB : NSObject {
-    // expected-note@-1{{for new classes, add '@objc' to specify a unique, prefixed Objective-C runtime name}}{{3-3=@objc(<#Objective-C class name#>)}}
-    // expected-note@-2{{for compatibility with existing archives, use '@NSKeyedArchiverClassName' to record the Swift 3 mangled name}}{{3-3=@NSKeyedArchiverClassName("_TtCC8nscoding7CodingA7NestedB")}}
+    // expected-note@-1{{for compatibility with existing archives, use '@objc' to record the Swift 3 runtime name}}{{3-3=@objc(_TtCC8nscoding7CodingA7NestedB)}}
+    // expected-note@-2{{for new classes, use '@objc' to specify a unique, prefixed Objective-C runtime name}}{{3-3=@objc(<#prefixed Objective-C class name#>)}}
     required init(coder: NSCoder) { }
     func encode(coder: NSCoder) { }
   }
 
+  // CHECK: class_decl "NestedC"{{.*}}@_staticInitializeObjCMetadata
   @objc(CodingA_NestedC)
   class NestedC : NSObject, NSCoding {
     required init(coder: NSCoder) { }
     func encode(coder: NSCoder) { }
   }
 
+  // CHECK: class_decl "NestedD"{{.*}}@_staticInitializeObjCMetadata
   @objc(CodingA_NestedD)
   class NestedD : NSObject {
     required init(coder: NSCoder) { }
@@ -54,68 +58,54 @@ extension CodingA.NestedD: NSCoding { // okay
 }
 
 // Generic classes
-class CodingB<T> : NSObject, NSCoding {   // expected-error{{generic class 'CodingB<T>' has an unstable name when archiving via 'NSCoding'}}
-  // expected-note@-1{{generic class 'CodingB<T>' should not be archived directly}}{{1-1=@NSKeyedArchiverEncodeNonGenericSubclassesOnly}}
+// CHECK-NOT: class_decl "CodingB"{{.*}}@_staticInitializeObjCMetadata
+class CodingB<T> : NSObject, NSCoding {
   required init(coder: NSCoder) { }
   func encode(coder: NSCoder) { }
 }
 
 extension CodingB {
-  class NestedA : NSObject, NSCoding { // expected-error{{generic class 'CodingB<T>.NestedA' has an unstable name when archiving via 'NSCoding'}}
-    // expected-note@-1{{generic class 'CodingB<T>.NestedA' should not be archived directly}}{{3-3=@NSKeyedArchiverEncodeNonGenericSubclassesOnly}}
+  class NestedA : NSObject, NSCoding {
     required init(coder: NSCoder) { }
     func encode(coder: NSCoder) { }
   }
 }
 
 // Fileprivate classes.
-fileprivate class CodingC : NSObject, NSCoding {    // expected-error{{fileprivate class 'CodingC' has an unstable name when archiving via 'NSCoding'}}
-  // expected-note@-1{{for new classes, add '@objc' to specify a unique, prefixed Objective-C runtime name}}{{1-1=@objc(<#Objective-C class name#>)}}
-  // expected-note@-2{{for compatibility with existing archives, use '@NSKeyedArchiverClassName' to record the Swift 3 mangled name}}{{1-1=@NSKeyedArchiverClassName("_TtC8nscodingP33_0B4E7641C0BD1F170280EEDD0D0C1F6C7CodingC")}}
+// CHECK-NOT: class_decl "CodingC"{{.*}}@_staticInitializeObjCMetadata
+fileprivate class CodingC : NSObject, NSCoding { // expected-error{{fileprivate class 'CodingC' has an unstable name when archiving via 'NSCoding'}}
+  // expected-note@-1{{for compatibility with existing archives, use '@objc' to record the Swift 3 runtime name}}{{1-1=@objc(_TtC8nscodingP33_0B4E7641C0BD1F170280EEDD0D0C1F6C7CodingC)}}
+  // expected-note@-2{{for new classes, use '@objc' to specify a unique, prefixed Objective-C runtime name}}{{1-1=@objc(<#prefixed Objective-C class name#>)}}
   required init(coder: NSCoder) { }
   func encode(coder: NSCoder) { }
 }
 
 // Private classes
-private class CodingD : NSObject, NSCoding {       // expected-error{{private class 'CodingD' has an unstable name when archiving via 'NSCoding'}}
-  // expected-note@-1{{for new classes, add '@objc' to specify a unique, prefixed Objective-C runtime name}}{{1-1=@objc(<#Objective-C class name#>)}}
-  // expected-note@-2{{for compatibility with existing archives, use '@NSKeyedArchiverClassName' to record the Swift 3 mangled name}}{{1-1=@NSKeyedArchiverClassName("_TtC8nscodingP33_0B4E7641C0BD1F170280EEDD0D0C1F6C7CodingD")}}
+private class CodingD : NSObject, NSCoding { // expected-error{{private class 'CodingD' has an unstable name when archiving via 'NSCoding'}}
+  // expected-note@-1{{for compatibility with existing archives, use '@objc' to record the Swift 3 runtime name}}{{1-1=@objc(_TtC8nscodingP33_0B4E7641C0BD1F170280EEDD0D0C1F6C7CodingD)}}
+  // expected-note@-2{{for new classes, use '@objc' to specify a unique, prefixed Objective-C runtime name}}{{1-1=@objc(<#prefixed Objective-C class name#>)}}
   required init(coder: NSCoder) { }
   func encode(coder: NSCoder) { }
 }
 
 // Local classes.
 func someFunction() {
-  class LocalCoding : NSObject, NSCoding {       // expected-error{{local class 'LocalCoding' has an unstable name when archiving via 'NSCoding'}}
-  // expected-note@-1{{for new classes, add '@objc' to specify a unique, prefixed Objective-C runtime name}}{{3-3=@objc(<#Objective-C class name#>)}}
-  // expected-note@-2{{for compatibility with existing archives, use '@NSKeyedArchiverClassName' to record the Swift 3 mangled name}}{{3-3=@NSKeyedArchiverClassName("_TtCF8nscoding12someFunctionFT_T_L_11LocalCoding")}}
+  class LocalCoding : NSObject, NSCoding { // expected-error{{local class 'LocalCoding' has an unstable name when archiving via 'NSCoding'}}
+  // expected-note@-1{{for compatibility with existing archives, use '@objc' to record the Swift 3 runtime name}}{{3-3=@objc(_TtCF8nscoding12someFunctionFT_T_L_11LocalCoding)}}
+  // expected-note@-2{{for new classes, use '@objc' to specify a unique, prefixed Objective-C runtime name}}{{3-3=@objc(<#prefixed Objective-C class name#>)}}
   required init(coder: NSCoder) { }
   func encode(coder: NSCoder) { }
 }
 }
 
 // Inherited conformances.
-class CodingE<T> : CodingB<T> {   // expected-error{{generic class 'CodingE<T>' has an unstable name when archiving via 'NSCoding'}}
-    // expected-note@-1{{generic class 'CodingE<T>' should not be archived directly}}{{1-1=@NSKeyedArchiverEncodeNonGenericSubclassesOnly}}
+// CHECK-NOT: class_decl "CodingE"{{.*}}@_staticInitializeObjCMetadata
+class CodingE<T> : CodingB<T> {
   required init(coder: NSCoder) { super.init(coder: coder) }
   override func encode(coder: NSCoder) { }
 }
 
 // @objc suppressions
-extension CodingA {
-  @objc(TheNestedE)
-  class NestedE : NSObject, NSCoding {
-    required init(coder: NSCoder) { }
-    func encode(coder: NSCoder) { }
-  }
-}
-
-@NSKeyedArchiverEncodeNonGenericSubclassesOnly
-class CodingGeneric<T> : NSObject, NSCoding {
-  required init(coder: NSCoder) { }
-  func encode(coder: NSCoder) { }
-}
-
 @objc(TheCodingF)
 fileprivate class CodingF : NSObject, NSCoding {
   required init(coder: NSCoder) { }
@@ -129,21 +119,41 @@ private class CodingG : NSObject, NSCoding {
 }
 
 extension CodingB {
+  // CHECK-NOT: class_decl "GenericViaScope"{{.*}}@_staticInitializeObjCMetadata
   @objc(GenericViaScope) // expected-error {{generic subclasses of '@objc' classes cannot have an explicit '@objc' because they are not directly visible from Objective-C}}
   class GenericViaScope : NSObject { }
 }
 
 // Inference of @_staticInitializeObjCMetadata.
+// CHECK-NOT: class_decl "SubclassOfCodingA"{{.*}}@_staticInitializeObjCMetadata
+class SubclassOfCodingA : CodingA { }
+
+// CHECK: class_decl "SubclassOfCodingE"{{.*}}@_staticInitializeObjCMetadata
 class SubclassOfCodingE : CodingE<Int> { }
 
-// But don't allow one to write @_staticInitializeObjCMetadata!
+// Do not warn when simply inheriting from classes that conform to NSCoding.
+// The subclass may never be serialized. But do still infer static
+// initialization, just in case.
+// CHECK-NOT: class_decl "PrivateSubclassOfCodingA"{{.*}}@_staticInitializeObjCMetadata
+private class PrivateSubclassOfCodingA : CodingA { }
+// CHECK: class_decl "PrivateSubclassOfCodingE"{{.*}}@_staticInitializeObjCMetadata
+private class PrivateSubclassOfCodingE : CodingE<Int> { }
+
+// But do warn when inherited through a protocol.
+protocol AlsoNSCoding : NSCoding {}
+private class CodingH : NSObject, AlsoNSCoding { // expected-error{{private class 'CodingH' has an unstable name when archiving via 'NSCoding'}}
+  // expected-note@-1{{for compatibility with existing archives, use '@objc' to record the Swift 3 runtime name}}{{1-1=@objc(_TtC8nscodingP33_0B4E7641C0BD1F170280EEDD0D0C1F6C7CodingH)}}
+  // expected-note@-2{{for new classes, use '@objc' to specify a unique, prefixed Objective-C runtime name}}{{1-1=@objc(<#prefixed Objective-C class name#>)}}
+  required init(coder: NSCoder) { }
+  func encode(coder: NSCoder) { }
+}
+
+@NSKeyedArchiverClassName( "abc" ) // expected-error {{@NSKeyedArchiverClassName has been removed; use @objc instead}} {{2-26=objc}} {{28-29=}} {{32-33=}}
+class OldArchiverAttribute: NSObject {}
+
+@NSKeyedArchiverEncodeNonGenericSubclassesOnly // expected-error {{@NSKeyedArchiverEncodeNonGenericSubclassesOnly is no longer necessary}} {{1-48=}}
+class OldArchiverAttributeGeneric<T>: NSObject {}
+
+// Don't allow one to write @_staticInitializeObjCMetadata!
 @_staticInitializeObjCMetadata // expected-error{{unknown attribute '_staticInitializeObjCMetadata'}}
 class DontAllowStaticInits { }
-
-// CHECK-NOT: class_decl "CodingA"{{.*}}@_staticInitializeObjCMetadata
-// CHECK: class_decl "NestedA"{{.*}}@_staticInitializeObjCMetadata
-// CHECK: class_decl "NestedC"{{.*}}@_staticInitializeObjCMetadata
-// CHECK: class_decl "NestedE"{{.*}}@_staticInitializeObjCMetadata
-// CHECK-NOT: class_decl "CodingGeneric"{{.*}}@_staticInitializeObjCMetadata
-// CHECK-NOT: class_decl "GenericViaScope"{{.*}}@_staticInitializeObjCMetadata
-// CHECK: class_decl "SubclassOfCodingE"{{.*}}@_staticInitializeObjCMetadata


### PR DESCRIPTION
- **Explanation**: Foundation's standard serialization mechanism, NSKeyedArchiver, can end up storing mangled names into persistent archives, which isn't really a good idea. We're going to solve this with a run-time check that suggests changing the name, or at least explicitly confirming the current mangled name in use, but we can catch the obvious cases at compile-time as well.
- **Scope**: Affects classes that conform directly to NSCoding that do not have "simple" mangled names.
- **Radar**: rdar://problem/32314195 (and rdar://problem/32414557)
- **Reviewed by**: @DougGregor, @itaiferber  
- **Risk**: Medium-low.
- **Testing**: Passed updated compiler regression tests, confirmed that the problematic cases from #9809 will not cause issues now.