### PR TITLE
[sil] Delete SILInstruction::removeFromParent().

### DIFF
--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -150,15 +150,12 @@ public:
   /// is already set in when creating an instruction.
   void setDebugLocation(SILDebugLocation Loc) { Location = Loc; }
 
-  /// removeFromParent - This method unlinks 'self' from the containing basic
-  /// block, but does not delete it.
-  ///
-  void removeFromParent();
-
-  /// eraseFromParent - This method unlinks 'self' from the containing basic
-  /// block and deletes it.
-  ///
+  /// This method unlinks 'self' from the containing basic block and deletes it.
   void eraseFromParent();
+
+  /// Unlink this instruction from its current basic block and insert the
+  /// instruction such that it is the first instruction of \p Block.
+  void moveFront(SILBasicBlock *Block);
 
   /// Unlink this instruction from its current basic block and insert it into
   /// the basic block that Later lives in, right before Later.

--- a/lib/IRGen/AllocStackHoisting.cpp
+++ b/lib/IRGen/AllocStackHoisting.cpp
@@ -111,8 +111,7 @@ insertDeallocStackAtEndOf(SmallVectorImpl<SILInstruction *> &FunctionExits,
 /// Hack to workaround a clang LTO bug.
 LLVM_ATTRIBUTE_NOINLINE
 void moveAllocStackToBeginningOfBlock(AllocStackInst* AS, SILBasicBlock *BB) {
-  AS->removeFromParent();
-  BB->push_front(AS);
+  AS->moveFront(BB);
 }
 
 /// Assign a single alloc_stack instruction to all the alloc_stacks in the
@@ -388,8 +387,7 @@ void HoistAllocStack::hoist() {
     auto *EntryBB = F->getEntryBlock();
     for (auto *AllocStack : AllocStackToHoist) {
       // Insert at the beginning of the entry block.
-      AllocStack->removeFromParent();
-      EntryBB->push_front(AllocStack);
+      AllocStack->moveFront(EntryBB);
       // Delete dealloc_stacks.
       eraseDeallocStacks(AllocStack);
     }

--- a/lib/SIL/SILInstruction.cpp
+++ b/lib/SIL/SILInstruction.cpp
@@ -109,19 +109,17 @@ SILModule &SILInstruction::getModule() const {
   return getFunction()->getModule();
 }
 
-/// removeFromParent - This method unlinks 'self' from the containing basic
-/// block, but does not delete it.
-///
-void SILInstruction::removeFromParent() {
-  getParent()->remove(this);
-}
-
 /// eraseFromParent - This method unlinks 'self' from the containing basic
 /// block and deletes it.
 ///
 void SILInstruction::eraseFromParent() {
   assert(use_empty() && "There are uses of instruction being deleted.");
   getParent()->erase(this);
+}
+
+void SILInstruction::moveFront(SILBasicBlock *Block) {
+  getParent()->remove(this);
+  Block->push_front(this);
 }
 
 /// Unlink this instruction from its current basic block and insert it into

--- a/lib/SILOptimizer/IPO/EagerSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/EagerSpecializer.cpp
@@ -102,8 +102,7 @@ static void addReturnValueImpl(SILBasicBlock *RetBB, SILBasicBlock *NewRetBB,
       // expects.
       auto *TupleI = cast<SILInstruction>(RetInst->getOperand(0));
       if (TupleI->hasOneUse()) {
-        TupleI->removeFromParent();
-        RetBB->insert(RetInst, TupleI);
+        TupleI->moveBefore(RetInst);
       } else {
         TupleI = TupleI->clone(RetInst);
         RetInst->setOperand(0, TupleI);

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -2237,8 +2237,7 @@ handleConditionalDestroys(SILValue ControlVariableAddr) {
       }
       case DIKind::Yes:
         // super.init() already called, just release the value.
-        Release->removeFromParent();
-        B.getInsertionBB()->insert(B.getInsertionPoint(), Release);
+        Release->moveBefore(&*B.getInsertionPoint());
         continue;
       }
     }


### PR DESCRIPTION
[sil] Delete SILInstruction::removeFromParent().

This is a very easily misused API since it allows for users to leak instructions
if they are not careful. This commit removes this API and replaces the small
number of uses of this API with higher level APIs that accomplish the same task
without using `removeFromParent()`. There were no API users that specifically
required removeFromParent.

An example of one way we were using `removeFromParent` is to move a SILInstruction
to the front of a block. That does not require exposing an API like
`removeFromParent()`... we can just create a higher level API like the one added
in this commit: `SILInstruction::moveFront(SILBasicBlock *)`.

rdar://31276565