### PR TITLE
Sema: Fix a few problems with generic typealiases in protocols

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -379,7 +379,7 @@ Type ConstraintSystem::openUnboundGenericType(UnboundGenericType *unbound,
 
   if (parentTy) {
     auto subs = parentTy->getContextSubstitutions(
-      parentTy->getAnyNominal());
+      unboundDecl->getDeclContext());
     for (auto pair : subs) {
       auto found = replacements.find(
         cast<GenericTypeParamType>(pair.first));


### PR DESCRIPTION
- Unqualified lookup was incorrectly checking generic arguments even
  when resolving interface types, resulting in a bogus 'Self does
  not conform to P' error when referencing a generic typealias from
  inside a protocol.

- The generic argument check was also done incorrectly if the
  underlying type did not contain any type parameters, resulting
  in bogus ErrorTypes. Just remove the no-type-parameter
  "optimization" instead, since it was working around another
  crash.

- When opening up a generic typealias in the constraint solver, we
  did the wrong thing if the generic typealias was defined in a
  protocol, producing concrete substitutions for the parent type
  instead of a 'Self := ParentType' substitution.

Fixes <rdar://problem/32633645>.