### PR TITLE
4.0: [Diag] Correct fixit location of "?" when pattern matching optional with non-optional

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -6233,7 +6233,7 @@ bool FailureDiagnosis::visitApplyExpr(ApplyExpr *callExpr) {
       diag.highlight(rhsExpr->getSourceRange());
       if (auto optUnwrappedType = rhsType->getOptionalObjectType()) {
         if (lhsType->isEqual(optUnwrappedType)) {
-          diag.fixItInsert(lhsExpr->getEndLoc(), "?");
+          diag.fixItInsertAfter(lhsExpr->getEndLoc(), "?");
         }
       }
       return true;

--- a/test/Constraints/patterns.swift
+++ b/test/Constraints/patterns.swift
@@ -165,7 +165,7 @@ default: break
 
 // <rdar://problem/21995744> QoI: Binary operator '~=' cannot be applied to operands of type 'String' and 'String?'
 switch ("foo" as String?) {
-case "what": break // expected-error{{expression pattern of type 'String' cannot match values of type 'String?'}}
+case "what": break // expected-error{{expression pattern of type 'String' cannot match values of type 'String?'}} {{12-12=?}}
 default: break
 }
 

--- a/test/expr/unary/selector/selector.swift
+++ b/test/expr/unary/selector/selector.swift
@@ -134,7 +134,7 @@ default:
 }
 
 switch optionalSel {
-case #selector(SR1827.bar): // expected-error{{expression pattern of type 'Selector' cannot match values of type 'Selector?'}} {{26-26=?}}
+case #selector(SR1827.bar): // expected-error{{expression pattern of type 'Selector' cannot match values of type 'Selector?'}} {{27-27=?}}
   break
 case #selector(SR1827.bar)!: // expected-error{{cannot force unwrap value of non-optional type 'Selector'}}
   break


### PR DESCRIPTION
Cherry pick of #10152

Trying to pattern match an optional with a non-optional should provide
a fixit inserting a "?" after the last token and not before it.

This caused wrong migrations for switch statements switching on an API that changed from non-optional to optional. For these the '?' in the case statements would be inserted before the pattern to be matched which is invalid Swift code.

Scope: Only this single fixit
Risk: Very low
Original PR approved by @CodaFi in a lab