### PR TITLE
[sil] Change InstructionDestroyer from a SILVisitor into a SILInstructionVisitor

### DIFF
--- a/lib/SIL/SILInstruction.cpp
+++ b/lib/SIL/SILInstruction.cpp
@@ -169,9 +169,11 @@ void SILInstruction::dropAllReferences() {
 }
 
 namespace {
-  class InstructionDestroyer : public SILVisitor<InstructionDestroyer> {
-  public:
-#define VALUE(CLASS, PARENT) void visit##CLASS(CLASS *I) { I->~CLASS(); }
+class InstructionDestroyer
+    : public SILInstructionVisitor<InstructionDestroyer> {
+public:
+#define INST(CLASS, PARENT, TEXTUALNAME, MEMBEHAVIOR, MAYRELEASE)              \
+  void visit##CLASS(CLASS *I) { I->~CLASS(); }
 #include "swift/SIL/SILNodes.def"
   };
 } // end anonymous namespace


### PR DESCRIPTION
[sil] Change InstructionDestroyer from a SILVisitor into a SILInstructionVisitor

1. This code is only actually used to destroy instructions.
2. This introduces an invocation of the destructors of arguments. Arguments are
always bump ptr allocated and trivial, so this destructor invocation should always be
dead.
