### PR TITLE
[sil-opened-archetype-tracker] Fix a memory leak

### DIFF
--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -423,7 +423,10 @@ public:
     return insert(new (F.getModule())
                       GlobalAddrInst(getSILDebugLocation(Loc), g));
   }
-
+  GlobalAddrInst *createGlobalAddr(SILLocation Loc, SILType Ty) {
+    return insert(new (F.getModule())
+                  GlobalAddrInst(getSILDebugLocation(Loc), Ty));
+  }
   IntegerLiteralInst *createIntegerLiteral(IntegerLiteralExpr *E);
 
   IntegerLiteralInst *createIntegerLiteral(SILLocation Loc, SILType Ty,


### PR DESCRIPTION
Placeholder global_addr instructions were never destroyed.
Now they are inserted in the entry basic block and later removed from there by the end of SIL deserialization.