### PR TITLE
[sil] Change two SILInstruction::removeFromParent => SILInstruction::eraseFromParent.

### DIFF
--- a/lib/SIL/SILBuilder.cpp
+++ b/lib/SIL/SILBuilder.cpp
@@ -364,7 +364,7 @@ SILValue SILBuilder::emitThickToObjCMetatype(SILLocation Loc, SILValue Op,
     if (metatypeInst->use_empty() &&
         metatypeInst->getParent() == getInsertionBB()) {
       auto origLoc = metatypeInst->getLoc();
-      metatypeInst->removeFromParent();
+      metatypeInst->eraseFromParent();
       return createMetatype(origLoc, Ty);
     }
   }
@@ -382,7 +382,7 @@ SILValue SILBuilder::emitObjCToThickMetatype(SILLocation Loc, SILValue Op,
     if (metatypeInst->use_empty() &&
         metatypeInst->getParent() == getInsertionBB()) {
       auto origLoc = metatypeInst->getLoc();
-      metatypeInst->removeFromParent();
+      metatypeInst->eraseFromParent();
       return createMetatype(origLoc, Ty);
     }
   }


### PR DESCRIPTION
This fixes two similar leaks. The reason to take this is that it could affect SourceKit. I will explain when I post CCC.

----

[sil] Change two SILInstruction::removeFromParent => SILInstruction::eraseFromParent.

removeFromParent should only be used when one is moving a SILInstruction from
one block to another or in preparation for deleting an instruction. In this
case, we are removing these two SILInstructions from their parent block and
leaking the instruction. The right thing to do is to use eraseFromParent.

<rdar://problem/31276565>

(cherry picked from commit 5fa67e0adbc9a12daf991e738494dfc20acaf9be)
