### PR TITLE
[sil-opened-archetype-tracker] Fix a memory leak

### DIFF
--- a/lib/SIL/SILOpenedArchetypesTracker.cpp
+++ b/lib/SIL/SILOpenedArchetypesTracker.cpp
@@ -21,6 +21,7 @@ void SILOpenedArchetypesTracker::addOpenedArchetypeDef(CanArchetypeType archetyp
     // It is a forward definition created during deserialization.
     // Replace it with the real definition now.
     OldDef->replaceAllUsesWith(Def);
+    getFunction().getModule().deallocateInst(cast<SILInstruction>(OldDef));
     OldDef = SILValue();
   }
   assert(!OldDef &&


### PR DESCRIPTION
I found this leak when compiling part of the stdlib in -Onone mode. This means that it could affect SourceKit via diagnostics. Since SourceKit is long lasting, it makes sense to consider taking this.

----

Placeholder global_addr instructions were never destroyed.
Now they are inserted in the entry basic block and later removed from there by the end of SIL deserialization.

(cherry picked from commit 647466d0b0cef40856adf97d0a1addf5d353279d)