### PR TITLE
Expand implicit tuple patterns in the AST

### DIFF
--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -1468,6 +1468,35 @@ recur:
                      resolver))
         return true;
       EEP->setSubPattern(sub);
+    } else if (auto argType = elt->getArgumentInterfaceType()) {
+      // Else if the element pattern has no sub-pattern but the element type has
+      // associated values, expand it to be semantically equivalent to an
+      // element pattern of wildcards.
+      Type elementType = enumTy->getTypeOfMember(elt->getModuleContext(),
+                                                 elt, argType);
+      SmallVector<TuplePatternElt, 8> elements;
+      if (auto *TTy = dyn_cast<TupleType>(elementType.getPointer())) {
+        for (auto &elt : TTy->getElements()) {
+          auto *subPattern = new (Context) AnyPattern(SourceLoc());
+          elements.push_back(TuplePatternElt(elt.getName(), SourceLoc(),
+                                             subPattern));
+        }
+      } else {
+        auto parenTy = dyn_cast<ParenType>(elementType.getPointer());
+        assert(parenTy && "Associated value type is neither paren nor tuple?");
+        
+        auto *subPattern = new (Context) AnyPattern(SourceLoc());
+        elements.push_back(TuplePatternElt(Identifier(), SourceLoc(),
+                                           subPattern));
+      }
+      Pattern *sub = TuplePattern::createSimple(Context, SourceLoc(),
+                                                elements, SourceLoc(),
+                                                /*implicit*/true);
+      if (coercePatternToType(sub, dc, elementType,
+                              subOptions|TR_FromNonInferredPattern|TR_EnumPatternPayload,
+                              resolver))
+        return true;
+      EEP->setSubPattern(sub);
     }
 
     EEP->setElementDecl(elt);

--- a/test/SILGen/switch.swift
+++ b/test/SILGen/switch.swift
@@ -680,7 +680,9 @@ func test_union_1(u: MaybePair) {
 
   // CHECK: [[IS_BOTH]]([[TUP:%.*]] : $(Int, String)):
   case .Both:
-  // CHECK:   destroy_value [[TUP]] : $(Int, String)
+  // CHECK:   tuple_extract [[TUP]] : $(Int, String), 0
+  // CHECK:   [[TUP_STR:%.*]] = tuple_extract [[TUP]] : $(Int, String), 1
+  // CHECK:   destroy_value [[TUP_STR]] : $String
   // CHECK:   function_ref @_T06switch1dyyF
   // CHECK:   br [[CONT]]
     d()

--- a/test/Sema/exhaustive_switch.swift
+++ b/test/Sema/exhaustive_switch.swift
@@ -412,6 +412,12 @@ enum OverlyLargeSpaceEnum {
   case case11
 }
 
+enum ContainsOverlyLargeEnum {
+  case one(OverlyLargeSpaceEnum)
+  case two(OverlyLargeSpaceEnum)
+  case three(OverlyLargeSpaceEnum, OverlyLargeSpaceEnum)
+}
+
 func quiteBigEnough() -> Bool {
   switch (OverlyLargeSpaceEnum.case1, OverlyLargeSpaceEnum.case2) { // expected-error {{switch must be exhaustive}}
   // expected-note@-1 {{do you want to add a default clause?}}
@@ -490,6 +496,13 @@ func quiteBigEnough() -> Bool {
   case (.case2, .case2): return true
   case (.case3, .case3): return true
   case _: return true
+  }
+  
+  // No diagnostic
+  switch ContainsOverlyLargeEnum.one(.case0) {
+  case .one: return true
+  case .two: return true
+  case .three: return true
   }
 }
 


### PR DESCRIPTION
This patch expands what were previously hidden tuple patterns inside enum element patterns that match a case with associated values.  For example:

```swift
enum X {
  case y(bool)
}

switch X.y(true) {
  case .y: ()
}
```

`case .y` used to be typechecked as an enum element pattern with no sub-pattern.  Now, it will be typechecked as `case .y(_)`.

This allows the elimination of corner cases in the Space Engine and fixes the size heuristic in the case of large sub-patterns that were being omitted by the user in a pattern match.