### PR TITLE
Clean up some UB

### DIFF
--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -31,8 +31,9 @@ using namespace Lowering;
 
 SILGenFunction::SILGenFunction(SILGenModule &SGM, SILFunction &F)
     : SGM(SGM), F(F), silConv(SGM.M), StartOfPostmatter(F.end()),
-      B(*this, createBasicBlock()), OpenedArchetypesTracker(F),
+      B(*this), OpenedArchetypesTracker(F),
       CurrentSILLoc(F.getLocation()), Cleanups(*this) {
+  B.setInsertionPoint(createBasicBlock());
   B.setCurrentDebugScope(F.getDebugScope());
   B.setOpenedArchetypesTracker(&OpenedArchetypesTracker);
 }

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -3708,8 +3708,8 @@ static bool trySequenceSubsequenceConversionFixIts(InFlightDiagnostic &diag,
   if (CS->TC.getLangOpts().FixStringToSubstringConversions) {
     // String -> Substring conversion
     // Add '[]' void subscript call to turn the whole String into a Substring
-    if (fromType->getCanonicalType() == String->getCanonicalType()) {
-      if (toType->getCanonicalType() == Substring->getCanonicalType()) {
+    if (fromType->isEqual(String)) {
+      if (toType->isEqual(Substring)) {
         diag.fixItInsertAfter(expr->getEndLoc (), "[]");
         return true;
       }
@@ -3718,8 +3718,8 @@ static bool trySequenceSubsequenceConversionFixIts(InFlightDiagnostic &diag,
 
   // Substring -> String conversion
   // Wrap in String.init
-  if (fromType->getCanonicalType() == Substring->getCanonicalType()) {
-    if (toType->getCanonicalType() == String->getCanonicalType()) {
+  if (fromType->isEqual(Substring)) {
+    if (toType->isEqual(String)) {
       diag.fixItInsert(expr->getLoc(), "String(");
       diag.fixItInsertAfter(expr->getSourceRange().End, ")");
       return true;


### PR DESCRIPTION
* The SILBuilder could potentially reference itself during its own
initialization if a valid insertion point was left around and a
new basic block was created.  Move basic block creation after the
initializer instead.

* CSDiag was comparing canonical types for equality directly, which
leads to mixed-type comparisons if one side of the comparison is nullptr.
Use isEqual instead.

God, I love UBSan
