### PR TITLE
[4.0] Quash Pattern-Related Corner Cases

### DIFF
--- a/test/SILGen/switch.swift
+++ b/test/SILGen/switch.swift
@@ -680,7 +680,9 @@ func test_union_1(u: MaybePair) {
 
   // CHECK: [[IS_BOTH]]([[TUP:%.*]] : $(Int, String)):
   case .Both:
-  // CHECK:   destroy_value [[TUP]] : $(Int, String)
+  // CHECK:   tuple_extract [[TUP]] : $(Int, String), 0
+  // CHECK:   [[TUP_STR:%.*]] = tuple_extract [[TUP]] : $(Int, String), 1
+  // CHECK:   destroy_value [[TUP_STR]] : $String
   // CHECK:   function_ref @_T06switch1dyyF
   // CHECK:   br [[CONT]]
     d()

--- a/test/Sema/exhaustive_switch.swift
+++ b/test/Sema/exhaustive_switch.swift
@@ -412,6 +412,12 @@ enum OverlyLargeSpaceEnum {
   case case11
 }
 
+enum ContainsOverlyLargeEnum {
+  case one(OverlyLargeSpaceEnum)
+  case two(OverlyLargeSpaceEnum)
+  case three(OverlyLargeSpaceEnum, OverlyLargeSpaceEnum)
+}
+
 func quiteBigEnough() -> Bool {
   switch (OverlyLargeSpaceEnum.case1, OverlyLargeSpaceEnum.case2) { // expected-error {{switch must be exhaustive}}
   // expected-note@-1 {{do you want to add a default clause?}}
@@ -490,6 +496,13 @@ func quiteBigEnough() -> Bool {
   case (.case2, .case2): return true
   case (.case3, .case3): return true
   case _: return true
+  }
+  
+  // No diagnostic
+  switch ContainsOverlyLargeEnum.one(.case0) {
+  case .one: return true
+  case .two: return true
+  case .three: return true
   }
 }
 

--- a/test/Sema/exhaustive_switch.swift
+++ b/test/Sema/exhaustive_switch.swift
@@ -6,6 +6,19 @@ func foo(a: Int?, b: Int?) -> Int {
   case (_, .none): return 2
   case (.some(_), .some(_)): return 3
   }
+    
+  switch (a, b) {
+  case (.none, _): return 1
+  case (_, .none): return 2
+  case (_?, _?): return 3
+  }
+  
+  switch Optional<(Int?, Int?)>.some((a, b)) {
+  case .none: return 1
+  case let (_, x?)?: return x
+  case let (x?, _)?: return x
+  case (.none, .none)?: return 0
+  }
 }
 
 func bar(a: Bool, b: Bool) -> Int {
@@ -46,6 +59,15 @@ func foo() {
     ()
   case (_, .B(_)):
     ()
+  }
+  
+  switch (Foo.A(1), Optional<(Int, Int)>.some((0, 0))) {
+  case (.A(_), _):
+    break
+  case (.B(_), (let q, _)?):
+    print(q)
+  case (.B(_), nil):
+    break
   }
 }
 


### PR DESCRIPTION
• Explanation: The Space Engine previously worked around a lot of the representation issues around patterns and it seemed to work well.  But, given the corner case in the linked radar, it is necessary to rewrite one particular kind of pattern to better suit the Space Engine.  This patch rewrites patterns that match enum cases with associated arguments to patterns with wildcards if the associated arguments are left unmatched by the user.  This enables a number of logic cleanups and simplifications in addition to unblocking the project in the radar.
• Risk: Low.
• Reviewed By: Joe Groff
• Testing: Existing regression tests updated, new tests added.
• Radar URL: rdar://32549000 