### PR TITLE
Sema: Fix a few problems with generic typealiases in protocols [4.0]

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -379,7 +379,7 @@ Type ConstraintSystem::openUnboundGenericType(UnboundGenericType *unbound,
 
   if (parentTy) {
     auto subs = parentTy->getContextSubstitutions(
-      parentTy->getAnyNominal());
+      unboundDecl->getDeclContext());
     for (auto pair : subs) {
       auto found = replacements.find(
         cast<GenericTypeParamType>(pair.first));


### PR DESCRIPTION
- Description: Fixes a few problems reported in 4.0 beta 1. Partly a regression.

- Scope of the issue: Could affect anyone defining generic typealiases inside protocols.

- Origination: It looks like the regression crept in when other problems were fixed in 4.0.

- Risk: Low, we're removing the "type is not dependent" fast path since it was broken, and skipping the well-formed check for generic arguments in a case where we should not do the check. Existing valid code should not be affected.

- Tested: New tests added.

- Reviewed by: @DougGregor 

- Radar: Fixes <rdar://problem/32633645>.