### PR TITLE
Diagnose misplaced associated values in simple enum patterns

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2890,7 +2890,11 @@ ERROR(single_tuple_parameter_mismatch,none,
 ERROR(unknown_single_tuple_parameter_mismatch,none,
       "single parameter of type %0 is expected in call", (Type))
 
-
+ERROR(enum_element_pattern_assoc_values_mismatch,none,
+      "pattern with associated values does not match enum case %0",
+      (Identifier))
+NOTE(enum_element_pattern_assoc_values_remove,none,
+     "remove associated values to make the pattern match", ())
 ERROR(tuple_pattern_length_mismatch,none,
       "tuple pattern has the wrong length for tuple type %0", (Type))
 ERROR(tuple_pattern_label_mismatch,none,

--- a/test/Parse/enum_element_pattern_swift4.swift
+++ b/test/Parse/enum_element_pattern_swift4.swift
@@ -27,9 +27,11 @@ func testE(e: E) {
     break
   case E.B<Int>(): // expected-error {{cannot specialize a non-generic definition}} expected-note {{while parsing this '<' as a type parameter bracket}}
     break
-  case .C(): // FIXME: This should be rejected as well.
+  case .C(): // expected-error {{pattern with associated values does not match enum case 'C'}}
+             // expected-note@-1 {{remove associated values to make the pattern match}} {{10-12=}} 
     break
-  case .D(let payload): // FIXME: ditto.
+  case .D(let payload): // expected-error{{pattern with associated values does not match enum case 'D'}}
+                        // expected-note@-1 {{remove associated values to make the pattern match}} {{10-23=}}
     let _: () = payload
     break
   default:
@@ -37,10 +39,10 @@ func testE(e: E) {
   }
 
   guard
-    // Currently, these will be asserted in SILGen,
-    // or in no-assert build, verify-failed in IRGen
-    case .C() = e, // FIXME: Should be rejected.
-    case .D(let payload) = e // FIXME: ditto.
+    case .C() = e, // expected-error {{pattern with associated values does not match enum case 'C'}} 
+                   // expected-note@-1 {{remove associated values to make the pattern match}} {{12-14=}}
+    case .D(let payload) = e // expected-error {{pattern with associated values does not match enum case 'D'}}
+                             // expected-note@-1 {{remove associated values to make the pattern match}} {{12-25=}}
   else { return }
 }
 
@@ -51,8 +53,10 @@ func canThrow() throws {
 
 do {
   try canThrow()
-} catch E.A() { // FIXME: Should be rejected.
+} catch E.A() { // expected-error {{pattern with associated values does not match enum case 'A'}}
+                // expected-note@-1 {{remove associated values to make the pattern match}} {{12-14=}}
   // ..
-} catch E.B(let payload) { // FIXME: ditto.
+} catch E.B(let payload) { // expected-error {{pattern with associated values does not match enum case 'B'}}
+                           // expected-note@-1 {{remove associated values to make the pattern match}} {{12-25=}} 
   let _: () = payload
 }

--- a/test/Parse/matching_patterns.swift
+++ b/test/Parse/matching_patterns.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-source-import
+// RUN: %target-typecheck-verify-swift -swift-version 4 -I %S/Inputs -enable-source-import
 
 import imported_enums
 
@@ -85,8 +85,12 @@ enum Voluntary<T> : Equatable {
       ()
 
     case .Naught,
-         .Naught(),
-         .Naught(_, _): // expected-error{{tuple pattern has the wrong length for tuple type '()'}}
+         .Naught(), // expected-error {{pattern with associated values does not match enum case 'Naught'}}
+                    // expected-note@-1 {{remove associated values to make the pattern match}} {{17-19=}}
+         .Naught(_), // expected-error{{pattern with associated values does not match enum case 'Naught'}}
+                     // expected-note@-1 {{remove associated values to make the pattern match}} {{17-20=}}
+         .Naught(_, _): // expected-error{{pattern with associated values does not match enum case 'Naught'}}
+                        // expected-note@-1 {{remove associated values to make the pattern match}} {{17-23=}}
       ()
 
     case .Mere,
@@ -112,13 +116,21 @@ enum Voluntary<T> : Equatable {
 }
 
 var n : Voluntary<Int> = .Naught
+if case let .Naught(value) = n {} // expected-error{{pattern with associated values does not match enum case 'Naught'}}
+                                  // expected-note@-1 {{remove associated values to make the pattern match}} {{20-27=}}
+if case let .Naught(value1, value2, value3) = n {} // expected-error{{pattern with associated values does not match enum case 'Naught'}}
+                                                   // expected-note@-1 {{remove associated values to make the pattern match}} {{20-44=}}
+
+
 
 switch n {
 case Foo.A: // expected-error{{enum case 'A' is not a member of type 'Voluntary<Int>'}}
   ()
 case Voluntary<Int>.Naught,
-     Voluntary<Int>.Naught(),
-     Voluntary<Int>.Naught(_, _), // expected-error{{tuple pattern has the wrong length for tuple type '()'}}
+     Voluntary<Int>.Naught(), // expected-error {{pattern with associated values does not match enum case 'Naught'}}
+                              // expected-note@-1 {{remove associated values to make the pattern match}} {{27-29=}}
+     Voluntary<Int>.Naught(_, _), // expected-error{{pattern with associated values does not match enum case 'Naught'}}
+                                  // expected-note@-1 {{remove associated values to make the pattern match}} {{27-33=}}
      Voluntary.Naught,
      .Naught:
   ()


### PR DESCRIPTION
Because of an unhandled case in the type checking of patterns it is possible to bind any number of arguments to a "simple" enum case without associated values.  In this case, one of two things would happen: 

1) The compiler would crash
2) The compiler would miscompile the enum payload.  Maybe you would get `()`, maybe you would get garbage.

Cut this off at the source by properly diagnosing this case and offering to remove the offending sub-pattern.  

Resolves [SR-3466](https://bugs.swift.org/browse/SR-3466) and [SR-4766](https://bugs.swift.org/browse/SR-4766).

