### PR TITLE
[GSB] Only use matching superclass constraints in enumerated requirements

### DIFF
--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -4941,13 +4941,16 @@ namespace {
   /// Retrieve the best requirement source from a set of constraints.
   template<typename T>
   const RequirementSource *getBestConstraintSource(
-                                        ArrayRef<Constraint<T>> constraints) {
-    auto bestSource = constraints.front().source;
+                                  ArrayRef<Constraint<T>> constraints,
+                                  llvm::function_ref<bool(const T&)> matches) {
+    Optional<const RequirementSource *> bestSource;
     for (const auto &constraint : constraints) {
-      if (constraint.source->compare(bestSource) < 0)
+      if (!matches(constraint.value)) continue;
+
+      if (!bestSource || constraint.source->compare(*bestSource) < 0)
         bestSource = constraint.source;
     }
-    return bestSource;
+    return *bestSource;
   }
 } // end anonymous namespace
 
@@ -5052,14 +5055,21 @@ void GenericSignatureBuilder::enumerateRequirements(llvm::function_ref<
     // If we have a superclass, produce a superclass requirement
     if (equivClass->superclass && !equivClass->recursiveSuperclassType) {
       f(RequirementKind::Superclass, archetype, equivClass->superclass,
-        getBestConstraintSource<Type>(equivClass->superclassConstraints));
+        getBestConstraintSource<Type>(equivClass->superclassConstraints,
+                        [&](const Type &type) {
+                          return type->isEqual(equivClass->superclass) ||
+                            equivClass->superclass->hasError();
+                        }));
     }
 
     // If we have a layout constraint, produce a layout requirement.
     if (equivClass->layout) {
       f(RequirementKind::Layout, archetype, equivClass->layout,
         getBestConstraintSource<LayoutConstraint>(
-                                              equivClass->layoutConstraints));
+                        equivClass->layoutConstraints,
+                                    [&](const LayoutConstraint &layout) {
+                                      return layout == equivClass->layout;
+                                    }));
     }
 
     // Enumerate conformance requirements.
@@ -5073,7 +5083,10 @@ void GenericSignatureBuilder::enumerateRequirements(llvm::function_ref<
 
         protocolSources.insert(
           {conforms.first,
-           getBestConstraintSource<ProtocolDecl *>(conforms.second)});
+           getBestConstraintSource<ProtocolDecl *>(conforms.second,
+             [&](ProtocolDecl *proto) {
+               return proto == conforms.first;
+             })});
       }
     }
 

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -4940,9 +4940,9 @@ void GenericSignatureBuilder::visitPotentialArchetypes(F f) {
 namespace {
   /// Retrieve the best requirement source from a set of constraints.
   template<typename T>
-  const RequirementSource *getBestConstraintSource(
-                                  ArrayRef<Constraint<T>> constraints,
-                                  llvm::function_ref<bool(const T&)> matches) {
+  Optional<const RequirementSource *>
+  getBestConstraintSource(ArrayRef<Constraint<T>> constraints,
+                          llvm::function_ref<bool(const T&)> matches) {
     Optional<const RequirementSource *> bestSource;
     for (const auto &constraint : constraints) {
       if (!matches(constraint.value)) continue;
@@ -4950,7 +4950,8 @@ namespace {
       if (!bestSource || constraint.source->compare(*bestSource) < 0)
         bestSource = constraint.source;
     }
-    return *bestSource;
+
+    return bestSource;
   }
 } // end anonymous namespace
 
@@ -5054,22 +5055,30 @@ void GenericSignatureBuilder::enumerateRequirements(llvm::function_ref<
 
     // If we have a superclass, produce a superclass requirement
     if (equivClass->superclass && !equivClass->recursiveSuperclassType) {
-      f(RequirementKind::Superclass, archetype, equivClass->superclass,
+      auto bestSource =
         getBestConstraintSource<Type>(equivClass->superclassConstraints,
-                        [&](const Type &type) {
-                          return type->isEqual(equivClass->superclass) ||
-                            equivClass->superclass->hasError();
-                        }));
+           [&](const Type &type) {
+             return type->isEqual(equivClass->superclass);
+          });
+
+      if (!bestSource)
+        bestSource = RequirementSource::forAbstract(archetype);
+
+      f(RequirementKind::Superclass, archetype, equivClass->superclass,
+        *bestSource);
     }
 
     // If we have a layout constraint, produce a layout requirement.
     if (equivClass->layout) {
-      f(RequirementKind::Layout, archetype, equivClass->layout,
-        getBestConstraintSource<LayoutConstraint>(
-                        equivClass->layoutConstraints,
-                                    [&](const LayoutConstraint &layout) {
-                                      return layout == equivClass->layout;
-                                    }));
+      auto bestSource = getBestConstraintSource<LayoutConstraint>(
+                          equivClass->layoutConstraints,
+                          [&](const LayoutConstraint &layout) {
+                            return layout == equivClass->layout;
+                          });
+      if (!bestSource)
+        bestSource = RequirementSource::forAbstract(archetype);
+
+      f(RequirementKind::Layout, archetype, equivClass->layout, *bestSource);
     }
 
     // Enumerate conformance requirements.
@@ -5083,7 +5092,7 @@ void GenericSignatureBuilder::enumerateRequirements(llvm::function_ref<
 
         protocolSources.insert(
           {conforms.first,
-           getBestConstraintSource<ProtocolDecl *>(conforms.second,
+           *getBestConstraintSource<ProtocolDecl *>(conforms.second,
              [&](ProtocolDecl *proto) {
                return proto == conforms.first;
              })});

--- a/test/Generics/superclass_constraint.swift
+++ b/test/Generics/superclass_constraint.swift
@@ -152,3 +152,34 @@ class Classical : Elementary {
 }
 
 func genericFunc<T : Elementary, U : Classical>(_: T, _: U) where T.Element == U.Element {}
+
+// Lookup within superclass constraints.
+protocol P8 {
+  associatedtype B
+}
+
+class C8 {
+  struct A { }
+}
+
+func superclassLookup1<T: C8 & P8>(_: T) where T.A == T.B { }
+
+func superclassLookup2<T: P8>(_: T) where T.A == T.B, T: C8 { }
+
+func superclassLookup3<T>(_: T) where T.A == T.B, T: C8, T: P8 { }
+
+// SR-5165
+class C9 {}
+
+protocol P9 {}
+
+class C10 : C9, P9 { }
+
+protocol P10 {
+  associatedtype A: C9
+}
+
+// CHECK: superclass_constraint.(file).testP10
+// CHECK: Generic signature: <T where T : P10, T.A : C10>
+// CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : P10, τ_0_0.A : C10>
+func testP10<T>(_: T) where T: P10, T.A: C10 { }

--- a/test/Generics/superclass_constraint.swift
+++ b/test/Generics/superclass_constraint.swift
@@ -101,7 +101,7 @@ class C2 : C, P4 { }
 
 // CHECK: superclassConformance3
 // CHECK: Requirements:
-// CHECK-NEXT: τ_0_0 : C2 [τ_0_0: Explicit @ {{.*}}:46]
+// CHECK-NEXT: τ_0_0 : C2 [τ_0_0: Explicit @ {{.*}}:61]
 // CHECK-NEXT: τ_0_0 : _NativeClass [τ_0_0: Explicit @ {{.*}}:46 -> Superclass]
 // CHECK-NEXT: τ_0_0 : P4 [τ_0_0: Explicit @ {{.*}}:61 -> Superclass (C2: P4)]
 // CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : C2>


### PR DESCRIPTION
**Explanation**: When a superclass constraint on an associated type (provided by a protocol) is further refined in a generic function, the later superclass constraint is lost. This is a regression from Swift 3.1.
**Scope**: Limited to uses of superclass constraints, which are somewhat common but tend to be quite simple.
**Radar**: SR-5165 / rdar://problem/32658705.
**Risk**: Very low; ensures that we never drop one of the constraints, but otherwise cannot fail.
**Testing**: Compiler regression testing.