### PR TITLE
[GSB] Only use matching superclass constraints in enumerated requirements

### DIFF
--- a/test/Generics/superclass_constraint.swift
+++ b/test/Generics/superclass_constraint.swift
@@ -101,7 +101,7 @@ class C2 : C, P4 { }
 
 // CHECK: superclassConformance3
 // CHECK: Requirements:
-// CHECK-NEXT: τ_0_0 : C2 [τ_0_0: Explicit @ {{.*}}:46]
+// CHECK-NEXT: τ_0_0 : C2 [τ_0_0: Explicit @ {{.*}}:61]
 // CHECK-NEXT: τ_0_0 : _NativeClass [τ_0_0: Explicit @ {{.*}}:46 -> Superclass]
 // CHECK-NEXT: τ_0_0 : P4 [τ_0_0: Explicit @ {{.*}}:61 -> Superclass (C2: P4)]
 // CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : C2>

--- a/test/Generics/superclass_constraint.swift
+++ b/test/Generics/superclass_constraint.swift
@@ -167,3 +167,19 @@ func superclassLookup1<T: C8 & P8>(_: T) where T.A == T.B { }
 func superclassLookup2<T: P8>(_: T) where T.A == T.B, T: C8 { }
 
 func superclassLookup3<T>(_: T) where T.A == T.B, T: C8, T: P8 { }
+
+// SR-5165
+class C9 {}
+
+protocol P9 {}
+
+class C10 : C9, P9 { }
+
+protocol P10 {
+  associatedtype A: C9
+}
+
+// CHECK: superclass_constraint.(file).testP10
+// CHECK: Generic signature: <T where T : P10, T.A : C10>
+// CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : P10, τ_0_0.A : C10>
+func testP10<T>(_: T) where T: P10, T.A: C10 { }


### PR DESCRIPTION
**Explanation**: When a superclass constraint on an associated type (provided by a protocol) is further refined in a generic function, the later superclass constraint is lost. This is a regression from Swift 3.1.
**Scope**: Limited to uses of superclass constraints, which are somewhat common but tend to be quite simple.
**Radar**: SR-5165 / rdar://problem/32658705.
**Risk**: Very low; ensures that we never drop one of the constraints, but otherwise cannot fail.
**Testing**: Compiler regression testing.