### PR TITLE
[Exclusivity] Add analysis pass summarizing accesses to inout_aliasab…

### DIFF
--- a/include/swift/SILOptimizer/Analysis/AccessSummaryAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/AccessSummaryAnalysis.h
@@ -1,0 +1,194 @@
+//===--- AccessSummaryAnalysis.h - SIL Access Summary Analysis --*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements an interprocedural analysis pass that summarizes
+// the formal accesses that a function makes to its address-type arguments.
+// These summaries are used to statically diagnose violations of exclusive
+// accesses for noescape closures.
+//
+//===----------------------------------------------------------------------===//
+#ifndef SWIFT_SILOPTIMIZER_ANALYSIS_ACCESS_SUMMARY_ANALYSIS_H_
+#define SWIFT_SILOPTIMIZER_ANALYSIS_ACCESS_SUMMARY_ANALYSIS_H_
+
+#include "swift/SIL/SILFunction.h"
+#include "swift/SIL/SILInstruction.h"
+#include "swift/SILOptimizer/Analysis/BottomUpIPAnalysis.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallVector.h"
+
+namespace swift {
+
+class AccessSummaryAnalysis : public BottomUpIPAnalysis {
+public:
+  /// Summarizes the accesses that a function begins on an argument.
+  class ArgumentSummary {
+  private:
+    /// The kind of access begun on the argument.
+    /// 'None' means no access performed.
+    Optional<SILAccessKind> Kind = None;
+
+    /// The location of the access. Used for diagnostics.
+    SILLocation AccessLoc = SILLocation((Expr *)nullptr);
+
+  public:
+    Optional<SILAccessKind> getAccessKind() const { return Kind; }
+
+    SILLocation getAccessLoc() const { return AccessLoc; }
+
+    /// The lattice operation on argument summaries.
+    bool mergeWith(const ArgumentSummary &other);
+
+    /// Merge in an access to the argument of the given kind at the given
+    /// location. Returns true if the merge caused the summary to change.
+    bool mergeWith(SILAccessKind otherKind, SILLocation otherLoc);
+
+    /// Returns a description of the summary. For debugging and testing
+    /// purposes.
+    StringRef getDescription() const;
+  };
+
+  /// Summarizes the accesses that a function begins on its arguments.
+  class FunctionSummary {
+  private:
+    llvm::SmallVector<ArgumentSummary, 6> ArgAccesses;
+
+  public:
+    FunctionSummary(unsigned argCount) : ArgAccesses(argCount) {}
+
+    /// Returns of summary of the the function accesses that argument at the
+    /// given index.
+    ArgumentSummary &getAccessForArgument(unsigned argument) {
+      return ArgAccesses[argument];
+    }
+
+    const ArgumentSummary &getAccessForArgument(unsigned argument) const {
+      return ArgAccesses[argument];
+    }
+
+    /// Returns the number of argument in the summary.
+    unsigned getArgumentCount() const { return ArgAccesses.size(); }
+  };
+
+  friend raw_ostream &operator<<(raw_ostream &os,
+                                 const FunctionSummary &summary);
+
+  class FunctionInfo;
+  /// Records a flow of a caller's argument to a called function.
+  /// This flow is used to iterate the interprocedural analysis to a fixpoint.
+  struct ArgumentFlow {
+    /// The index of the argument in the caller.
+    const unsigned CallerArgumentIndex;
+
+    /// The index of the argument in the callee.
+    const unsigned CalleeArgumentIndex;
+
+    FunctionInfo *const CalleeFunctionInfo;
+  };
+
+  /// Records the summary and argument flows for a given function.
+  /// Used by the BottomUpIPAnalysis to propagate information
+  /// from callees to callers.
+  class FunctionInfo : public FunctionInfoBase<FunctionInfo> {
+  private:
+    FunctionSummary FS;
+
+    SILFunction *F;
+
+    llvm::SmallVector<ArgumentFlow, 8> RecordedArgumentFlows;
+
+  public:
+    FunctionInfo(SILFunction *F) : FS(F->getArguments().size()), F(F) {}
+
+    SILFunction *getFunction() const { return F; }
+
+    ArrayRef<ArgumentFlow> getArgumentFlows() const {
+      return RecordedArgumentFlows;
+    }
+
+    const FunctionSummary &getSummary() const { return FS; }
+    FunctionSummary &getSummary() { return FS; }
+
+    /// Record a flow of an argument in this function to a callee.
+    void recordFlow(const ArgumentFlow &flow) {
+      flow.CalleeFunctionInfo->addCaller(this, nullptr);
+      RecordedArgumentFlows.push_back(flow);
+    }
+  };
+
+private:
+  /// Maps functions to the information the analysis keeps for each function.
+  llvm::DenseMap<SILFunction *, FunctionInfo *> FunctionInfos;
+
+  llvm::SpecificBumpPtrAllocator<FunctionInfo> Allocator;
+public:
+  AccessSummaryAnalysis() : BottomUpIPAnalysis(AnalysisKind::AccessSummary) {}
+
+  /// Returns a summary of the accesses performed by the given function.
+  const FunctionSummary &getOrCreateSummary(SILFunction *Fn);
+
+  virtual void initialize(SILPassManager *PM) override {}
+  virtual void invalidate() override;
+  virtual void invalidate(SILFunction *F, InvalidationKind K) override;
+  virtual void notifyAddFunction(SILFunction *F) override {}
+  virtual void notifyDeleteFunction(SILFunction *F) override {
+    invalidate(F, InvalidationKind::Nothing);
+  }
+  virtual void invalidateFunctionTables() override {}
+
+  static bool classof(const SILAnalysis *S) {
+    return S->getKind() == AnalysisKind::AccessSummary;
+  }
+
+private:
+  typedef BottomUpFunctionOrder<FunctionInfo> FunctionOrder;
+
+  /// Returns the BottomUpIPAnalysis information for the given function.
+  FunctionInfo *getFunctionInfo(SILFunction *F);
+
+  /// Summarizes the given function and iterates the interprocedural analysis
+  /// to a fixpoint.
+  void recompute(FunctionInfo *initial);
+
+  /// Propagate the access summary from the argument of a called function
+  /// to the caller.
+  bool propagateFromCalleeToCaller(FunctionInfo *callerInfo,
+                                   ArgumentFlow site);
+
+  /// Summarize the given function and schedule it for interprocedural
+  /// analysis.
+  void processFunction(FunctionInfo *info, FunctionOrder &order);
+
+  /// Summarize how the function uses the given argument.
+  void processArgument(FunctionInfo *info, SILFunctionArgument *argment,
+                        ArgumentSummary &summary, FunctionOrder &order);
+
+  /// Summarize a partial_apply instruction.
+  void processPartialApply(FunctionInfo *callerInfo,
+                           unsigned callerArgumentIndex,
+                           PartialApplyInst *apply,
+                           Operand *applyArgumentOperand, FunctionOrder &order);
+
+  /// Summarize apply or try_apply
+  void processFullApply(FunctionInfo *callerInfo, unsigned callerArgumentIndex,
+                        FullApplySite apply, Operand *argumentOperand,
+                        FunctionOrder &order);
+
+  /// Summarize a call site and schedule it for interprocedural analysis.
+  void processCall(FunctionInfo *callerInfo, unsigned callerArgumentIndex,
+                   SILFunction *calledFunction, unsigned argumentIndex,
+                   FunctionOrder &order);
+};
+
+} // end namespace swift
+
+#endif
+

--- a/include/swift/SILOptimizer/Analysis/Analysis.def
+++ b/include/swift/SILOptimizer/Analysis/Analysis.def
@@ -23,6 +23,7 @@
 #define ANALYSIS(NAME)
 #endif
 
+ANALYSIS(AccessSummary)
 ANALYSIS(Alias)
 ANALYSIS(BasicCallee)
 ANALYSIS(Caller)

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -56,6 +56,8 @@ PASS(ABCOpt, "abcopts",
      "Array Bounds Check Optimization")
 PASS(AccessEnforcementSelection, "access-enforcement-selection",
      "Access Enforcement Selection")
+PASS(AccessSummaryDumper, "access-summary-dump",
+     "Dump Address Parameter Access Summary")
 PASS(InactiveAccessMarkerElimination, "inactive-access-marker-elim",
      "Inactive Access Marker Elimination.")
 PASS(FullAccessMarkerElimination, "full-access-marker-elim",

--- a/lib/SILOptimizer/Analysis/AccessSummaryAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/AccessSummaryAnalysis.cpp
@@ -1,0 +1,329 @@
+//===--- AccessSummaryAnalysis.cpp - SIL Access Summary Analysis ----------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#define DEBUG_TYPE "sil-access-summary-analysis"
+#include "swift/SIL/SILArgument.h"
+#include "swift/SILOptimizer/Analysis/AccessSummaryAnalysis.h"
+#include "swift/SILOptimizer/Analysis/FunctionOrder.h"
+#include "swift/SILOptimizer/PassManager/PassManager.h"
+
+using namespace swift;
+
+void AccessSummaryAnalysis::processFunction(FunctionInfo *info,
+                                            FunctionOrder &order) {
+  // Does the summary need to be recomputed?
+  if (order.prepareForVisiting(info))
+    return;
+
+  // Compute function summary on a per-argument basis.
+  unsigned index = 0;
+  for (SILArgument *arg : info->getFunction()->getArguments()) {
+    FunctionSummary &functionSummary = info->getSummary();
+    ArgumentSummary &argSummary =
+        functionSummary.getAccessForArgument(index);
+    index++;
+
+    auto *functionArg = cast<SILFunctionArgument>(arg);
+    // Only summarize @inout_aliasable arguments.
+    SILArgumentConvention convention =
+        functionArg->getArgumentConvention().Value;
+    if (convention != SILArgumentConvention::Indirect_InoutAliasable)
+      continue;
+
+    processArgument(info, functionArg, argSummary, order);
+  }
+}
+
+/// Track uses of the arguments, recording in the summary any accesses
+/// started by a begin_access and any flows of the arguments to other
+/// functions.
+void AccessSummaryAnalysis::processArgument(FunctionInfo *info,
+                                             SILFunctionArgument *argument,
+                                             ArgumentSummary &summary,
+                                             FunctionOrder &order) {
+  unsigned argumentIndex = argument->getIndex();
+
+  // Use a worklist to track argument uses to be processed.
+  llvm::SmallVector<Operand *, 32> worklist;
+
+  // Start by adding the immediate uses of the argument to the worklist.
+  worklist.append(argument->use_begin(), argument->use_end());
+
+  // Iterate to follow uses of the arguments.
+  while (!worklist.empty()) {
+    Operand *operand = worklist.pop_back_val();
+    SILInstruction *user = operand->getUser();
+
+    switch (user->getKind()) {
+    case ValueKind::BeginAccessInst: {
+      auto *BAI = cast<BeginAccessInst>(user);
+      summary.mergeWith(BAI->getAccessKind(), BAI->getLoc());
+      // We don't add the users of the begin_access to the worklist because
+      // even if these users eventually begin an access to the address
+      // or a projection from it, that access can't begin more exclusive
+      // access than this access -- otherwise it will be diagnosed
+      // elsewhere.
+      break;
+    }
+    case ValueKind::EndUnpairedAccessInst:
+      // Don't diagnose unpaired access statically.
+      assert(cast<EndUnpairedAccessInst>(user)->getEnforcement() ==
+             SILAccessEnforcement::Dynamic);
+      break;
+    case ValueKind::StructElementAddrInst:
+    case ValueKind::TupleElementAddrInst:
+      // Eventually we'll summarize individual struct elements separately.
+      // For now an access to a part of the struct is treated as an access
+      // to the whole struct.
+      worklist.append(user->use_begin(), user->use_end());
+      break;
+    case ValueKind::DebugValueAddrInst:
+    case ValueKind::AddressToPointerInst:
+      // Ignore these uses, they don't affect formal accesses.
+      break;
+    case ValueKind::PartialApplyInst:
+      processPartialApply(info, argumentIndex, cast<PartialApplyInst>(user),
+                          operand, order);
+      break;
+    case ValueKind::ApplyInst:
+      processFullApply(info, argumentIndex, cast<ApplyInst>(user), operand,
+                       order);
+      break;
+    case ValueKind::TryApplyInst:
+      processFullApply(info, argumentIndex, cast<TryApplyInst>(user), operand,
+                       order);
+      break;
+    case ValueKind::CopyAddrInst:
+    case ValueKind::ExistentialMetatypeInst:
+    case ValueKind::LoadInst:
+    case ValueKind::OpenExistentialAddrInst:
+    case ValueKind::ProjectBlockStorageInst:
+      // These likely represent scenarios in which we're not generating
+      // begin access markers. Ignore these for now. But we really should
+      // add SIL verification to ensure all loads and stores have associated
+      // access markers.
+      break;
+    default:
+      // TODO: These requirements should be checked for in the SIL verifier.
+      llvm_unreachable("Unrecognized argument use");
+    }
+  }
+}
+
+void AccessSummaryAnalysis::processPartialApply(FunctionInfo *callerInfo,
+                                                unsigned callerArgumentIndex,
+                                                PartialApplyInst *apply,
+                                                Operand *applyArgumentOperand,
+                                                FunctionOrder &order) {
+  SILFunction *calleeFunction = apply->getCalleeFunction();
+  assert(calleeFunction && !calleeFunction->empty() &&
+         "Missing definition of noescape closure?");
+
+  // Make sure the partial_apply is not calling the result of another
+  // partial_apply.
+  assert(isa<FunctionRefInst>(apply->getCallee()) &&
+         "Noescape partial apply of non-functionref?");
+
+  // Make sure the partial_apply is used by an apply and not another
+  // partial_apply
+  SILInstruction *user = apply->getSingleUse()->getUser();
+  assert((isa<ApplyInst>(user) || isa<TryApplyInst>(user) ||
+          isa<ConvertFunctionInst>(user)) &&
+         "noescape partial_apply has non-apply use!");
+  (void)user;
+
+  // The arguments to partial_apply are a suffix of the arguments to the
+  // the actually-called function. Translate the index of the argument to
+  // the partial_apply into to the corresponding index into the arguments of
+  // the called function.
+
+  // The first operand to partial_apply is the called function, so adjust the
+  // operand number to get the argument.
+  unsigned partialApplyArgumentIndex =
+      applyArgumentOperand->getOperandNumber() - 1;
+
+  // The argument index in the called function.
+  unsigned argumentIndex = calleeFunction->getArguments().size() -
+                           apply->getNumArguments() + partialApplyArgumentIndex;
+  processCall(callerInfo, callerArgumentIndex, calleeFunction, argumentIndex,
+              order);
+}
+
+void AccessSummaryAnalysis::processFullApply(FunctionInfo *callerInfo,
+                                             unsigned callerArgumentIndex,
+                                             FullApplySite apply,
+                                             Operand *argumentOperand,
+                                             FunctionOrder &order) {
+  unsigned operandNumber = argumentOperand->getOperandNumber();
+  assert(operandNumber > 0 && "Summarizing apply for non-argument?");
+
+  unsigned calleeArgumentIndex = operandNumber - 1;
+  SILFunction *callee = apply.getCalleeFunction();
+  // We can't apply a summary for function whose body we can't see.
+  // Since user-provided closures are always in the same module as their callee
+  // This likely indicates a missing begin_access before an open-coded
+  // call.
+  if (!callee || callee->empty())
+    return;
+
+  processCall(callerInfo, callerArgumentIndex, callee, calleeArgumentIndex,
+              order);
+}
+
+void AccessSummaryAnalysis::processCall(FunctionInfo *callerInfo,
+                                        unsigned callerArgumentIndex,
+                                        SILFunction *callee,
+                                        unsigned argumentIndex,
+                                        FunctionOrder &order) {
+  // Record the flow of an argument from  the caller to the callee so that
+  // the interprocedural analysis can iterate to a fixpoint.
+  FunctionInfo *calleeInfo = getFunctionInfo(callee);
+  ArgumentFlow flow = {callerArgumentIndex, argumentIndex, calleeInfo};
+  callerInfo->recordFlow(flow);
+  if (!calleeInfo->isVisited()) {
+    processFunction(calleeInfo, order);
+    order.tryToSchedule(calleeInfo);
+  }
+
+  propagateFromCalleeToCaller(callerInfo, flow);
+}
+
+bool AccessSummaryAnalysis::ArgumentSummary::mergeWith(SILAccessKind otherKind,
+                                                        SILLocation otherLoc) {
+  // In the lattice, a modification-like accesses subsume a read access or no
+  // access.
+  if (!Kind.hasValue() ||
+      (*Kind == SILAccessKind::Read && otherKind != SILAccessKind::Read)) {
+    Kind = otherKind;
+    AccessLoc = otherLoc;
+    return true;
+  }
+
+  return false;
+}
+
+bool AccessSummaryAnalysis::ArgumentSummary::mergeWith(
+    const ArgumentSummary &other) {
+  if (other.Kind.hasValue())
+    return mergeWith(*other.Kind, other.AccessLoc);
+  return false;
+}
+
+void AccessSummaryAnalysis::recompute(FunctionInfo *initial) {
+  allocNewUpdateID();
+
+  FunctionOrder order(getCurrentUpdateID());
+
+  // Summarize the function and its callees.
+  processFunction(initial, order);
+
+  // Build the bottom-up order.
+  order.tryToSchedule(initial);
+  order.finishScheduling();
+
+  // Iterate the interprocedural analysis to a fixed point.
+  bool needAnotherIteration;
+  do {
+    needAnotherIteration = false;
+    for (FunctionInfo *calleeInfo : order) {
+      for (const auto &callerEntry : calleeInfo->getCallers()) {
+        assert(callerEntry.isValid());
+        if (!order.wasRecomputedWithCurrentUpdateID(calleeInfo))
+          continue;
+
+        FunctionInfo *callerInfo = callerEntry.Caller;
+
+        // Propagate from callee to caller.
+        for (const auto &argumentFlow : callerInfo->getArgumentFlows()) {
+          if (argumentFlow.CalleeFunctionInfo != calleeInfo)
+            continue;
+
+          bool changed = propagateFromCalleeToCaller(callerInfo, argumentFlow);
+          if (changed && !callerInfo->isScheduledAfter(calleeInfo)) {
+            needAnotherIteration = true;
+          }
+        }
+      }
+    }
+  } while (needAnotherIteration);
+}
+
+StringRef AccessSummaryAnalysis::ArgumentSummary::getDescription() const {
+  if (Optional<SILAccessKind> kind = getAccessKind()) {
+    return getSILAccessKindName(*kind);
+  }
+
+  return "none";
+}
+
+bool AccessSummaryAnalysis::propagateFromCalleeToCaller(
+    FunctionInfo *callerInfo, ArgumentFlow flow) {
+  // For a given flow from a caller's argument to a callee's argument,
+  // propagate the argument summary information to the caller.
+
+  FunctionInfo *calleeInfo = flow.CalleeFunctionInfo;
+  const auto &calleeArgument =
+      calleeInfo->getSummary().getAccessForArgument(flow.CalleeArgumentIndex);
+  auto &callerArgument =
+      callerInfo->getSummary().getAccessForArgument(flow.CallerArgumentIndex);
+
+  bool changed = callerArgument.mergeWith(calleeArgument);
+  return changed;
+}
+
+AccessSummaryAnalysis::FunctionInfo *
+AccessSummaryAnalysis::getFunctionInfo(SILFunction *F) {
+  FunctionInfo *&FInfo = FunctionInfos[F];
+  if (!FInfo) {
+    FInfo = new (Allocator.Allocate()) FunctionInfo(F);
+  }
+  return FInfo;
+}
+
+const AccessSummaryAnalysis::FunctionSummary &
+AccessSummaryAnalysis::getOrCreateSummary(SILFunction *fn) {
+  FunctionInfo *info = getFunctionInfo(fn);
+  if (!info->isValid())
+    recompute(info);
+
+  return info->getSummary();
+}
+
+void AccessSummaryAnalysis::AccessSummaryAnalysis::invalidate() {
+  FunctionInfos.clear();
+  Allocator.DestroyAll();
+}
+
+void AccessSummaryAnalysis::invalidate(SILFunction *F, InvalidationKind K) {
+  FunctionInfos.erase(F);
+}
+
+SILAnalysis *swift::createAccessSummaryAnalysis(SILModule *M) {
+  return new AccessSummaryAnalysis();
+}
+
+raw_ostream &swift::
+operator<<(raw_ostream &os,
+           const AccessSummaryAnalysis::FunctionSummary &summary) {
+  unsigned argCount = summary.getArgumentCount();
+  os << "(";
+
+  if (argCount > 0) {
+    os << summary.getAccessForArgument(0).getDescription();
+    for (unsigned i = 1; i < argCount; i++) {
+      os << ",  " << summary.getAccessForArgument(i).getDescription();
+    }
+  }
+
+  os << ")";
+  return os;
+}

--- a/lib/SILOptimizer/Analysis/CMakeLists.txt
+++ b/lib/SILOptimizer/Analysis/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(ANALYSIS_SOURCES
   Analysis/ARCAnalysis.cpp
+  Analysis/AccessSummaryAnalysis.cpp
   Analysis/AliasAnalysis.cpp
   Analysis/Analysis.cpp
   Analysis/ArraySemantic.cpp

--- a/lib/SILOptimizer/UtilityPasses/AccessSummaryDumper.cpp
+++ b/lib/SILOptimizer/UtilityPasses/AccessSummaryDumper.cpp
@@ -1,0 +1,51 @@
+//===--- AccessSummaryDumper.cpp - Dump access summaries for functions -----===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#define DEBUG_TYPE "sil-access-summary-dumper"
+#include "swift/SIL/SILArgument.h"
+#include "swift/SIL/SILFunction.h"
+#include "swift/SIL/SILInstruction.h"
+#include "swift/SIL/SILValue.h"
+#include "swift/SILOptimizer/Analysis/AccessSummaryAnalysis.h"
+#include "swift/SILOptimizer/PassManager/Passes.h"
+#include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "llvm/Support/Debug.h"
+
+using namespace swift;
+
+namespace {
+
+/// Dumps summaries of kinds of accesses a function performs on its
+/// @inout_aliasiable arguments.
+class AccessSummaryDumper : public SILModuleTransform {
+
+  void run() override {
+    auto *analysis = PM->getAnalysis<AccessSummaryAnalysis>();
+
+    for (auto &fn : *getModule()) {
+      llvm::outs() << "@" << fn.getName() << "\n";
+      if (fn.empty()) {
+        llvm::outs() << "<unknown>\n";
+        continue;
+      }
+      const AccessSummaryAnalysis::FunctionSummary &summary =
+          analysis->getOrCreateSummary(&fn);
+      llvm::outs() << summary << "\n";
+    }
+  }
+};
+
+} // end anonymous namespace
+
+SILTransform *swift::createAccessSummaryDumper() {
+  return new AccessSummaryDumper();
+}

--- a/lib/SILOptimizer/UtilityPasses/CMakeLists.txt
+++ b/lib/SILOptimizer/UtilityPasses/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(UTILITYPASSES_SOURCES
   UtilityPasses/AADumper.cpp
+  UtilityPasses/AccessSummaryDumper.cpp
   UtilityPasses/BasicCalleePrinter.cpp
   UtilityPasses/BasicInstructionPropertyDumper.cpp
   UtilityPasses/BugReducerTester.cpp

--- a/test/SILOptimizer/access_summary_analysis.sil
+++ b/test/SILOptimizer/access_summary_analysis.sil
@@ -1,0 +1,294 @@
+// RUN: %target-sil-opt  %s -assume-parsing-unqualified-ownership-sil -access-summary-dump -o /dev/null | %FileCheck %s
+
+sil_stage raw
+
+import Builtin
+import Swift
+import SwiftShims
+
+struct StructWithStoredProperties {
+  @sil_stored var f: Int
+  @sil_stored var g: Int
+}
+
+// CHECK-LABEL: @assignsToCapture
+// CHECK-NEXT: (modify, none)
+sil private @assignsToCapture : $@convention(thin) (@inout_aliasable Int, Int) -> () {
+bb0(%0 : $*Int, %1: $Int):
+  %2 = begin_access [modify] [unknown] %0 : $*Int
+  assign %1 to %2 : $*Int
+  end_access %2 : $*Int
+  %3 = tuple ()
+  return %3 : $()
+}
+
+// CHECK-LABEL: @readsAndModifiesSameCapture
+// CHECK-NEXT: (modify)
+sil private @readsAndModifiesSameCapture : $@convention(thin) (@inout_aliasable Int) -> () {
+bb0(%0 : $*Int):
+  %1 = begin_access [read] [unknown] %0 : $*Int
+  end_access %1 : $*Int
+  %2 = begin_access [modify] [unknown] %0 : $*Int
+  end_access %2 : $*Int
+  %3 = tuple ()
+  return %3 : $()
+}
+
+// CHECK-LABEL: @readsAndModifiesSeparateCaptures
+// CHECK-NEXT: (read, modify)
+sil private @readsAndModifiesSeparateCaptures : $@convention(thin) (@inout_aliasable Int, @inout_aliasable Int) -> () {
+bb0(%0 : $*Int, %1 : $*Int):
+  %2 = begin_access [read] [unknown] %0 : $*Int
+  end_access %2 : $*Int
+  %3 = begin_access [modify] [unknown] %1 : $*Int
+  end_access %3 : $*Int
+  %4 = tuple ()
+  return %4 : $()
+}
+
+// CHECK-LABEL: @modifyInModifySubAccess
+// CHECK-NEXT: (modify)
+sil private @modifyInModifySubAccess : $@convention(thin) (@inout_aliasable Int) -> () {
+bb0(%0 : $*Int):
+  %1 = begin_access [modify] [unknown] %0 : $*Int
+  %2 = begin_access [modify] [unknown] %1 : $*Int
+  end_access %2 : $*Int
+  end_access %1 : $*Int
+  %3 = tuple ()
+  return %3 : $()
+}
+
+// CHECK-LABEL: @readInModifySubAccess
+// CHECK-NEXT: (modify)
+sil private @readInModifySubAccess : $@convention(thin) (@inout_aliasable Int) -> () {
+bb0(%0 : $*Int):
+  %1 = begin_access [modify] [unknown] %0 : $*Int
+  %2 = begin_access [read] [unknown] %1 : $*Int
+  end_access %2 : $*Int
+  end_access %1 : $*Int
+  %3 = tuple ()
+  return %3 : $()
+}
+
+// CHECK-LABEL: @addressToPointerOfStructElementAddr
+// CHECK-NEXT: (none)
+// This mirrors the code pattern for materializeForSet on a struct stored
+// property
+sil private @addressToPointerOfStructElementAddr : $@convention(method) (@inout StructWithStoredProperties) -> (Builtin.RawPointer) {
+bb0(%1 : $*StructWithStoredProperties):
+  %2 = struct_element_addr %1 : $*StructWithStoredProperties, #StructWithStoredProperties.f
+  %3 = address_to_pointer %2 : $*Int to $Builtin.RawPointer
+  return %3 : $(Builtin.RawPointer)
+}
+
+// CHECK-LABEL: @endUnpairedAccess
+// CHECK-NEXT: (none)
+sil private @endUnpairedAccess : $@convention(method) (@inout Builtin.UnsafeValueBuffer) -> () {
+bb0(%0 : $*Builtin.UnsafeValueBuffer):
+  end_unpaired_access [dynamic] %0 : $*Builtin.UnsafeValueBuffer
+  %1 = tuple ()
+  return %1 : $()
+}
+
+// CHECK-LABEL: @tupleElementAddr
+// CHECK-NEXT: (modify)
+sil private @tupleElementAddr : $@convention(thin) (@inout_aliasable (Int, Int)) -> () {
+bb0(%0 : $*(Int, Int)):
+  %1 = tuple_element_addr %0 : $*(Int, Int), 1
+  %2 = begin_access [modify] [unknown] %1 : $*Int
+  end_access %2 : $*Int
+  %3 = tuple ()
+  return %3 : $()
+}
+
+sil @closureWithMissingBody : $@convention(thin) (@inout_aliasable Int, Int) -> ()
+
+// CHECK-LABEL: @callClosureWithMissingBody
+// CHECK-NEXT: (none, none)
+sil private @callClosureWithMissingBody : $@convention(thin) (@inout_aliasable Int, Int) -> () {
+bb0(%0 : $*Int, %1 : $Int):
+  %2 = function_ref @closureWithMissingBody : $@convention(thin) (@inout_aliasable Int, Int) -> ()
+  %3 = apply %2(%0, %1) : $@convention(thin) (@inout_aliasable Int, Int) -> () // no-crash
+  %4 = tuple ()
+  return %4 : $()
+}
+
+// CHECK-LABEL: @callClosureThatModifiesCapture
+// CHECK-NEXT: (modify, none)
+sil private @callClosureThatModifiesCapture : $@convention(thin) (@inout_aliasable Int, Int) -> () {
+bb0(%0 : $*Int, %1 : $Int):
+  %2 = function_ref @assignsToCapture : $@convention(thin) (@inout_aliasable Int, Int) -> ()
+  %3 = apply %2(%0, %1) : $@convention(thin) (@inout_aliasable Int, Int) -> ()
+  %4 = tuple ()
+  return %4 : $()
+}
+
+// CHECK-LABEL: @throwingClosureThatModifesCapture
+// CHECK-NEXT: (modify)
+sil private @throwingClosureThatModifesCapture : $@convention(thin) (@inout_aliasable Int) -> @error Error {
+bb0(%0 : $*Int):
+  %1 = begin_access [modify] [unknown] %0 : $*Int
+  end_access %1 : $*Int
+  %2 = tuple ()
+  return %2 : $()
+}
+// CHECK-LABEL: @callThrowingClosureThatModifiesCapture
+// CHECK-NEXT: (modify)
+sil private @callThrowingClosureThatModifiesCapture : $@convention(thin) (@inout_aliasable Int) -> () {
+bb0(%0 : $*Int):
+  %1 = function_ref @throwingClosureThatModifesCapture : $@convention(thin) (@inout_aliasable Int) -> @error Error
+  %2 = try_apply %1(%0) : $@convention(thin) (@inout_aliasable Int) -> @error Error, normal bb1, error bb2
+bb1(%3 : $()):
+  %4 = tuple ()
+  return %4 : $()
+bb2(%5: $Error):
+  %6 = builtin "unexpectedError"(%5 : $Error) : $()
+  unreachable
+}
+
+sil @takesNoEscapeClosure : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+
+// CHECK-LABEL: @partialApplyPassedOffToFunction
+// CHECK-NEXT: (modify, none)
+sil private @partialApplyPassedOffToFunction : $@convention(thin) (@inout_aliasable Int, Int) -> () {
+bb0(%0 : $*Int, %1: $Int):
+  %2 = function_ref @assignsToCapture : $@convention(thin) (@inout_aliasable Int, Int) -> ()
+  %3 = partial_apply %2(%0, %1) : $@convention(thin) (@inout_aliasable Int, Int) -> ()
+  %4 = function_ref @takesNoEscapeClosure : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  %5 = apply %4(%3) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  %6 = tuple ()
+  return %6 : $()
+}
+
+sil @takesNoEscapeClosureTakingArgument : $@convention(thin) (@owned @callee_owned (Int) -> ()) -> ()
+sil @takesNoEscapeClosureTakingArgumentThrowing : $@convention(thin) (@owned @callee_owned (Int) -> (@error Error)) -> ()
+
+// CHECK-LABEL: @hasThreeCapturesAndTakesArgument
+// CHECK-NEXT: (none, modify, none, read)
+sil private @hasThreeCapturesAndTakesArgument : $@convention(thin) (Int, @inout_aliasable Int, @inout_aliasable Int, @inout_aliasable Int) -> () {
+bb0(%0 : $Int, %1: $*Int, %2: $*Int, %3: $*Int):
+  %4 = begin_access [modify] [unknown] %1 : $*Int
+  end_access %4 : $*Int
+  %5 = begin_access [read] [unknown] %3 : $*Int
+  end_access %5 : $*Int
+  %6 = tuple ()
+  return %6 : $()
+}
+
+// CHECK-LABEL: @partialApplyOfClosureTakingArgumentPassedOffToFunction
+// CHECK-NEXT: (modify, none, read
+sil private @partialApplyOfClosureTakingArgumentPassedOffToFunction : $@convention(thin) (@inout_aliasable Int, @inout_aliasable Int, @inout_aliasable Int) -> () {
+bb0(%0 : $*Int, %1 : $*Int, %2 : $*Int):
+  %3 = function_ref @hasThreeCapturesAndTakesArgument : $@convention(thin) (Int, @inout_aliasable Int, @inout_aliasable Int, @inout_aliasable Int) -> ()
+  %4 = partial_apply %3(%0, %1, %2) : $@convention(thin) (Int, @inout_aliasable Int, @inout_aliasable Int, @inout_aliasable Int) -> ()
+  %5 = function_ref @takesNoEscapeClosureTakingArgument : $@convention(thin) (@owned @callee_owned (Int) -> ()) -> ()
+  %6 = apply %5(%4) : $@convention(thin) (@owned @callee_owned (Int) -> ()) -> ()
+  %7 = tuple ()
+  return %7 : $()
+}
+
+// CHECK-LABEL: @partialApplyFollowedByConvertFunction
+// CHECK-NEXT: (modify, none, read)
+sil private @partialApplyFollowedByConvertFunction : $@convention(thin) (@inout_aliasable Int, @inout_aliasable Int, @inout_aliasable Int) -> () {
+bb0(%0 : $*Int, %1 : $*Int, %2 : $*Int):
+  %3 = function_ref @hasThreeCapturesAndTakesArgument : $@convention(thin) (Int, @inout_aliasable Int, @inout_aliasable Int, @inout_aliasable Int) -> ()
+  %4 = partial_apply %3(%0, %1, %2) : $@convention(thin) (Int, @inout_aliasable Int, @inout_aliasable Int, @inout_aliasable Int) -> ()
+  %5 = convert_function %4 : $@callee_owned (Int) -> () to $@callee_owned (Int) -> @error Error
+  %6 = function_ref @takesNoEscapeClosureTakingArgumentThrowing : $@convention(thin) (@owned @callee_owned (Int) -> @error Error) -> ()
+  %7 = apply %6(%5) : $@convention(thin) (@owned @callee_owned (Int) -> @error Error) -> ()
+  %8 = tuple ()
+  return %8 : $()
+}
+
+// CHECK-LABEL: @selfRecursion
+// CHECK-NEXT: (modify, none)
+sil private @selfRecursion : $@convention(thin) (@inout_aliasable Int, Int) -> () {
+bb0(%0 : $*Int, %1 : $Int):
+  %2 = function_ref @selfRecursion : $@convention(thin) (@inout_aliasable Int, Int) -> ()
+  %3 = apply %2(%0, %1) : $@convention(thin) (@inout_aliasable Int, Int) -> ()
+  %4 = begin_access [modify] [unknown] %0 : $*Int
+  end_access %4 : $*Int
+  %5 = tuple ()
+  return %5 : $()
+}
+
+// CHECK-LABEL: @callsMutuallyRecursive
+// CHECK-NEXT: (modify, none)
+sil private @callsMutuallyRecursive : $@convention(thin) (@inout_aliasable Int, Int) -> () {
+bb0(%0 : $*Int, %1 : $Int):
+  %2 = function_ref @mutualRecursion1 : $@convention(thin) (@inout_aliasable Int, Int) -> ()
+  %3 = apply %2(%0, %1) : $@convention(thin) (@inout_aliasable Int, Int) -> ()
+  %4 = tuple ()
+  return %4 : $()
+}
+
+// CHECK-LABEL: @mutualRecursion1
+// CHECK-NEXT: (modify, none)
+sil private @mutualRecursion1 : $@convention(thin) (@inout_aliasable Int, Int) -> () {
+bb0(%0 : $*Int, %1 : $Int):
+  %2 = function_ref @mutualRecursion2 : $@convention(thin) (@inout_aliasable Int, Int) -> ()
+  %3 = apply %2(%0, %1) : $@convention(thin) (@inout_aliasable Int, Int) -> ()
+  %4 = begin_access [modify] [unknown] %0 : $*Int
+  end_access %4 : $*Int
+  %5 = tuple ()
+  return %5 : $()
+}
+
+// CHECK-LABEL: @mutualRecursion2
+// CHECK-NEXT: (modify, none)
+sil private @mutualRecursion2 : $@convention(thin) (@inout_aliasable Int, Int) -> () {
+bb0(%0 : $*Int, %1 : $Int):
+  %2 = function_ref @mutualRecursion1 : $@convention(thin) (@inout_aliasable Int, Int) -> ()
+  %3 = apply %2(%0, %1) : $@convention(thin) (@inout_aliasable Int, Int) -> ()
+  %4 = begin_access [read] [unknown] %0 : $*Int
+  end_access %4 : $*Int
+  %5 = tuple ()
+  return %5 : $()
+}
+
+// Multiple cycles. This requires two iterations of the edge propagation.
+// Once to propagate the modify from A to B and one to propagate from
+// B to C
+//
+//      A [Call B then later modify param]
+//    / |
+//    \ |
+//     B
+//    / |
+//    \ |
+//     C
+//
+// CHECK-LABEL: @multipleCycleA
+// CHECK-NEXT: (modify)
+sil private @multipleCycleA : $@convention(thin) (@inout_aliasable Int) -> () {
+bb0(%0 : $*Int):
+  %1 = function_ref @multipleCycleB : $@convention(thin) (@inout_aliasable Int) -> ()
+  %2 = apply %1(%0) : $@convention(thin) (@inout_aliasable Int) -> ()
+  %3 = begin_access [modify] [unknown] %0 : $*Int
+  end_access %3 : $*Int
+  %5 = tuple ()
+  return %5 : $()
+}
+
+// CHECK-LABEL: @multipleCycleB
+// CHECK-NEXT: (modify)
+sil private @multipleCycleB : $@convention(thin) (@inout_aliasable Int) -> () {
+bb0(%0 : $*Int):
+  %1 = function_ref @multipleCycleA : $@convention(thin) (@inout_aliasable Int) -> ()
+  %2 = apply %1(%0) : $@convention(thin) (@inout_aliasable Int) -> ()
+  %3 = function_ref @multipleCycleC : $@convention(thin) (@inout_aliasable Int) -> ()
+  %4 = apply %3(%0) : $@convention(thin) (@inout_aliasable Int) -> ()
+  %5 = tuple ()
+  return %5 : $()
+}
+
+// CHECK-LABEL: @multipleCycleC
+// CHECK-NEXT: (modify)
+sil private @multipleCycleC : $@convention(thin) (@inout_aliasable Int) -> () {
+bb0(%0 : $*Int):
+  %1 = function_ref @multipleCycleB : $@convention(thin) (@inout_aliasable Int) -> ()
+  %2 = apply %1(%0) : $@convention(thin) (@inout_aliasable Int) -> ()
+  %4 = tuple ()
+  return %4 : $()
+}
+


### PR DESCRIPTION
…le params

Add an interprocedural SIL analysis pass that summarizes the accesses that
closures make on their @inout_aliasable captures. This will be used to
statically enforce exclusivity for calls to functions that take noescape
closures.

The analysis summarizes the accesses on each parameter independently and
uses the BottomUpIPAnalysis utility class to iterate to a fixed point when
there are cycles in the call graph.

For now, the analysis is not stored-property-sensitive -- that will come in a
latter commit.