### PR TITLE
Sema: Fix bugs when applying solutions containg type(of:)

### DIFF
--- a/test/Constraints/type_of_verified.swift
+++ b/test/Constraints/type_of_verified.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend -typecheck -swift-version 4 %s
+
+// These are in a separate file -- the absence of diagnostics causes the
+// AST verifier to check additional invariants
+
+func takesAnyType(_: Any.Type) {}
+
+class Base {}
+class Derived : Base {}
+
+let b: Base = Derived()
+
+_ = [b].filter { type(of: $0) == Derived.self }
+
+// Trailing closure...
+let _: (() -> ()).Type = type { }


### PR DESCRIPTION
When applying a solution to an ApplyExpr, we have to coerce the
argument to the input type of the function. This is because the
solution succeeds if the argument is convertible to the
function's input, not just if they are equal.

We were forgetting to do that for the special case of a type(of:),
which has its own semantics.

Fixes <rdar://problem/32435723> and
<https://bugs.swift.org/browse/SR-5168>.