### PR TITLE
Sema: Fix bugs when applying solutions containing type(of:) [4.0]

### DIFF
--- a/test/Constraints/type_of_verified.swift
+++ b/test/Constraints/type_of_verified.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend -typecheck -swift-version 4 %s
+
+// These are in a separate file -- the absence of diagnostics causes the
+// AST verifier to check additional invariants
+
+func takesAnyType(_: Any.Type) {}
+
+class Base {}
+class Derived : Base {}
+
+let b: Base = Derived()
+
+_ = [b].filter { type(of: $0) == Derived.self }
+
+// Trailing closure...
+let _: (() -> ()).Type = type { }


### PR DESCRIPTION
* Description: Swift 4 mode brings new semantics for 'type(of:)' that make it behave more like an ordinary function lookup. The new implementation did not properly propagate the inferred type to the argument expression, causing crashes.

* Scope of the issue: Affects users migrating Swift 3.2 code to 4.0.

* Risk: Low, this makes the type(of:) code path behave a bit more like the normal function call path, coercing call arguments using the same mechanism.

* Tested: New tests added.

* Reviewed by: @DougGregor 

* Radar: <rdar://problem/32435723>