### PR TITLE
DI: Fix 'self.init' delegation to an imported factory initializer inherited from a base class [4.0]

### DIFF
--- a/test/SILOptimizer/definite_init_objc_factory_init.swift
+++ b/test/SILOptimizer/definite_init_objc_factory_init.swift
@@ -52,3 +52,20 @@ extension SomeClass {
     self.init(value: double)
   }
 }
+
+class SubHive : Hive {
+  // CHECK-LABEL: sil hidden @_T0027definite_init_objc_factory_B07SubHiveCACyt20delegatesToInherited_tcfc : $@convention(method) (@owned SubHive) -> @owned SubHive
+  convenience init(delegatesToInherited: ()) {
+    // CHECK: [[UPCAST:%.*]] = upcast %0 : $SubHive to $Hive
+    // CHECK: [[METATYPE:%.*]] = value_metatype $@thick Hive.Type, [[UPCAST]] : $Hive
+    // CHECK: [[METHOD:%.*]] = class_method [volatile] [[METATYPE]] : $@thick Hive.Type, #Hive.init!allocator.1.foreign : (Hive.Type) -> (Bee!) -> Hive!
+    // CHECK: [[OBJC:%.*]] = thick_to_objc_metatype [[METATYPE]] : $@thick Hive.Type to $@objc_metatype Hive.Type
+    // CHECK: apply [[METHOD]]({{.*}}, [[OBJC]])
+
+    // CHECK: [[METATYPE:%.*]] = value_metatype $@thick SubHive.Type, %0 : $SubHive
+    // CHECK-NEXT: dealloc_partial_ref %0 : $SubHive, [[METATYPE]] : $@thick SubHive.Type
+
+    // CHECK: return {{%.*}} : $SubHive
+    self.init(queen: Bee())
+  }
+}


### PR DESCRIPTION
* Description: A user in the labs reported an issue when calling an NSButton initializer inherited by an NSButton subclass. The initializer is a static factory method in Objective-C and we weren't handling the superclass delegation correctly in DI, causing us to reject the self.init call as an escaping use of 'self'. However the constructor method in question is declared as returning `instancetype`, and a test shows that it is indeed covariant, so we should allow this call.

* Scope of the issue: Affects anyone trying to subclass SDK classes that may define these constructors.

* Origination: It looks like it was broken in 3.1 as well.

* Risk: Low, makes DI recognize a new code pattern, treating a value_metatype_inst of an upcast_inst the same as a value_metatype_inst of self itself.

* Tested: New test added.

* Reviewed by: @DougGregor 

* Radar: Fixes <rdar://problem/32697794>.