### PR TITLE
[stdlib] Restore signatures to use UnsafeMutableBufferPointer.

### DIFF
--- a/stdlib/private/StdlibCollectionUnittest/CheckMutableCollectionType.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/CheckMutableCollectionType.swift.gyb
@@ -446,10 +446,9 @@ self.test("\(testNamePrefix)._withUnsafeMutableBufferPointerIfSupported()/semant
   for test in subscriptRangeTests {
     var c = makeWrappedCollection(test.collection)
     var result = c._withUnsafeMutableBufferPointerIfSupported {
-      (baseAddress, count) -> OpaqueValue<Array<OpaqueValue<Int>>> in
-      let bufferPointer =
-        UnsafeMutableBufferPointer(start: baseAddress, count: count)
-      return OpaqueValue(Array(bufferPointer.map(extractValue)))
+      (bufferPointer) -> OpaqueValue<Array<OpaqueValue<Int>>> in
+      let value = OpaqueValue(bufferPointer.map(extractValue))
+      return value
     }
     expectType(Optional<OpaqueValue<Array<OpaqueValue<Int>>>>.self, &result)
     if withUnsafeMutableBufferPointerIsSupported {

--- a/stdlib/private/StdlibCollectionUnittest/LoggingWrappers.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/LoggingWrappers.swift.gyb
@@ -460,7 +460,7 @@ public struct ${Self}<
   }
 
   public mutating func _withUnsafeMutableBufferPointerIfSupported<R>(
-    _ body: (UnsafeMutablePointer<Iterator.Element>, Int) throws -> R
+    _ body: (inout UnsafeMutableBufferPointer<Iterator.Element>) throws -> R
   ) rethrows -> R? {
     Log._withUnsafeMutableBufferPointerIfSupported[selfType] += 1
     let result = try base._withUnsafeMutableBufferPointerIfSupported(body)
@@ -659,7 +659,7 @@ public struct ${Self}<
   }
 
   public mutating func _withUnsafeMutableBufferPointerIfSupported<R>(
-    _ body: (UnsafeMutablePointer<Iterator.Element>, Int) throws -> R
+    _ body: (inout UnsafeMutableBufferPointer<Iterator.Element>) throws -> R
   ) rethrows -> R? {
     Log._withUnsafeMutableBufferPointerIfSupported[selfType] += 1
     let result = try base._withUnsafeMutableBufferPointerIfSupported(body)

--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -1573,11 +1573,11 @@ extension ${Self} : RangeReplaceableCollection, _ArrayProtocol {
 
   @_inlineable
   public mutating func _withUnsafeMutableBufferPointerIfSupported<R>(
-    _ body: (UnsafeMutablePointer<Element>, Int) throws -> R
+    _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
   ) rethrows -> R? {
     return try withUnsafeMutableBufferPointer {
       (bufferPointer) -> R in
-      let r = try body(bufferPointer.baseAddress!, bufferPointer.count)
+      let r = try body(&bufferPointer)
       return r
     }
   }

--- a/stdlib/public/core/CollectionAlgorithms.swift.gyb
+++ b/stdlib/public/core/CollectionAlgorithms.swift.gyb
@@ -168,9 +168,7 @@ extension MutableCollection where Self : BidirectionalCollection {
     by belongsInSecondPartition: (Element) throws -> Bool
   ) rethrows -> Index {
     let maybeOffset = try _withUnsafeMutableBufferPointerIfSupported {
-      (baseAddress, count) -> Int in
-      var bufferPointer =
-        UnsafeMutableBufferPointer(start: baseAddress, count: count)
+      (bufferPointer) -> Int in
       let unsafeBufferPivot = try bufferPointer.partition(
         by: belongsInSecondPartition)
       return unsafeBufferPivot - bufferPointer.startIndex
@@ -365,9 +363,7 @@ extension MutableCollection
   public mutating func sort() {
     let didSortUnsafeBuffer: Void? =
       _withUnsafeMutableBufferPointerIfSupported {
-      (baseAddress, count) -> Void in
-      var bufferPointer =
-        UnsafeMutableBufferPointer(start: baseAddress, count: count)
+      (bufferPointer) -> Void in
       bufferPointer.sort()
       return ()
     }
@@ -443,9 +439,7 @@ ${orderingExplanation}
 
     let didSortUnsafeBuffer: Void? =
       try _withUnsafeMutableBufferPointerIfSupported {
-      (baseAddress, count) -> Void in
-      var bufferPointer =
-        UnsafeMutableBufferPointer(start: baseAddress, count: count)
+      (bufferPointer) -> Void in
       try bufferPointer.sort(by: areInIncreasingOrder)
       return ()
     }

--- a/stdlib/public/core/MutableCollection.swift
+++ b/stdlib/public/core/MutableCollection.swift
@@ -311,21 +311,15 @@ public protocol MutableCollection : _MutableIndexable, Collection
   /// same algorithm on `body`\ 's argument lets you trade safety for
   /// speed.
   mutating func _withUnsafeMutableBufferPointerIfSupported<R>(
-    _ body: (UnsafeMutablePointer<Element>, Int) throws -> R
+    _ body: (inout UnsafeMutableBufferPointer<Iterator.Element>) throws -> R
   ) rethrows -> R?
-  // FIXME(ABI)#53 (Type Checker): the signature should use
-  // UnsafeMutableBufferPointer, but the compiler can't handle that.
-  //
-  // <rdar://problem/21933004> Restore the signature of
-  // _withUnsafeMutableBufferPointerIfSupported() that mentions
-  // UnsafeMutableBufferPointer
 }
 
 // TODO: swift-3-indexing-model - review the following
 extension MutableCollection {
   @_inlineable
   public mutating func _withUnsafeMutableBufferPointerIfSupported<R>(
-    _ body: (UnsafeMutablePointer<Element>, Int) throws -> R
+    _ body: (inout UnsafeMutableBufferPointer<Iterator.Element>) throws -> R
   ) rethrows -> R? {
     return nil
   }

--- a/test/stdlib/Inputs/CommonArrayTests.gyb
+++ b/test/stdlib/Inputs/CommonArrayTests.gyb
@@ -277,10 +277,9 @@ ${Suite}.test("${ArrayType}/_withUnsafeMutableBufferPointerIfSupported")
     do {
       // Read.
       var result = a._withUnsafeMutableBufferPointerIfSupported {
-        (baseAddress, count) -> OpaqueValue<[OpaqueValue<Int>]> in
-        let bufferPointer =
-          UnsafeMutableBufferPointer(start: baseAddress, count: count)
-        return OpaqueValue(Array(bufferPointer))
+        (bufferPointer) -> OpaqueValue<[OpaqueValue<Int>]> in
+        let r = OpaqueValue(Array(bufferPointer))
+        return r
       }
       expectType(Optional<OpaqueValue<Array<OpaqueValue<Int>>>>.self, &result)
       expectEqualSequence(test.sequence, result!.value.map { $0.value })
@@ -289,9 +288,7 @@ ${Suite}.test("${ArrayType}/_withUnsafeMutableBufferPointerIfSupported")
     do {
       // Read and write.
       var result = a._withUnsafeMutableBufferPointerIfSupported {
-        (baseAddress, count) -> OpaqueValue<Array<OpaqueValue<Int>>> in
-        let bufferPointer =
-          UnsafeMutableBufferPointer(start: baseAddress, count: count)
+        (bufferPointer) -> OpaqueValue<Array<OpaqueValue<Int>>> in
         let result = OpaqueValue(Array(bufferPointer))
         for i in bufferPointer.indices {
           bufferPointer[i] = OpaqueValue(bufferPointer[i].value * 10)
@@ -314,7 +311,7 @@ ${Suite}.test("${ArrayType}/_withUnsafeMutableBufferPointerIfSupported/Replacing
   .code {
   var a = getFresh${ArrayType}([ OpaqueValue(10) ])
   var result = a._withUnsafeMutableBufferPointerIfSupported {
-    (baseAddress, count) -> OpaqueValue<Int> in
+    (bufferPointer) -> OpaqueValue<Int> in
     // buffer = UnsafeMutableBufferPointer(start: buffer.baseAddress, count: 0)
     // FIXME: does not trap since the buffer is not passed inout.
     // expectCrashLater()
@@ -328,7 +325,7 @@ ${Suite}.test("${ArrayType}/_withUnsafeMutableBufferPointerIfSupported/Replacing
   .code {
   var a = getFresh${ArrayType}([ OpaqueValue(10) ])
   var result = a._withUnsafeMutableBufferPointerIfSupported {
-    (baseAddress, count) -> OpaqueValue<Int> in
+    (bufferPointer) -> OpaqueValue<Int> in
     // buffer = UnsafeMutableBufferPointer(start: nil, count: 1)
     // FIXME: does not trap since the buffer is not passed inout.
     // expectCrashLater()


### PR DESCRIPTION
Resolves rdar://problem/21933004.