### PR TITLE
[NFC?] Clean up use-of-temporary in closure diagnostics

### DIFF
--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -2420,8 +2420,8 @@ parseClosureSignatureIfPresent(SmallVectorImpl<CaptureListEntry> &captureList,
   // Extract names of the tuple elements and preserve the structure
   // of the tuple (with any nested tuples inside) to be able to use
   // it in the fix-it without any type information provided by user.
-  std::function<StringRef(const TypeRepr *)> getTupleNames =
-      [&](const TypeRepr *typeRepr) -> StringRef {
+  std::function<std::string (const TypeRepr *)> getTupleNames =
+      [&](const TypeRepr *typeRepr) -> std::string  {
     if (!typeRepr)
       return "";
 


### PR DESCRIPTION
Rebases and updates #10196, because the fix is valuable to have.

The recursive lambda used to return `StringRef`s pointing inside out-streams with backing buffers that were local to itself.  Instead, take the stream as a parameter and write into that directly.

Should be NFC, but the base patch claims that `test/Constraints/tuple_arguments.swift` occasionally fails because of this.