### PR TITLE
Bind Android native log function to Swift print()

### DIFF
--- a/stdlib/public/stubs/LibcShims.cpp
+++ b/stdlib/public/stubs/LibcShims.cpp
@@ -22,6 +22,9 @@
 
 #include <stdlib.h>
 #include <stdio.h>
+#if defined(__ANDROID__)
+#include <android/log.h>
+#endif
 #include <string.h>
 #include "swift/Basic/Lazy.h"
 #include "../SwiftShims/LibcShims.h"
@@ -50,7 +53,11 @@ SWIFT_RUNTIME_STDLIB_INTERFACE
 __swift_size_t swift::_swift_stdlib_fwrite_stdout(const void *ptr,
                                                   __swift_size_t size,
                                                   __swift_size_t nitems) {
+#if defined(__ANDROID__)
+  return __android_log_write(ANDROID_LOG_DEBUG, "SwiftRuntime", static_cast<const char *>(ptr));
+#else
   return fwrite(ptr, size, nitems, stdout);
+#endif
 }
 
 SWIFT_RUNTIME_STDLIB_INTERFACE


### PR DESCRIPTION
<!-- What's in this pull request? -->
By default, Swift is printing to `stdout`, on Android we need to use the Android native log method.

This PR adds this binding.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
