### PR TITLE
[benchmark] Support for running benchmarks by ordinal number

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -90,9 +90,17 @@ Using the Benchmark Driver
 
 ### Examples
 
-1. `$ ./Benchmark_O --num-iters=1 --num-samples=1`
-2. `$ ./Benchmark_Onone --list`
-3. `$ ./Benchmark_Ounchecked Ackermann`
+* `$ ./Benchmark_O --num-iters=1 --num-samples=1`
+* `$ ./Benchmark_Onone --list`
+* `$ ./Benchmark_Ounchecked Ackermann`
+
+### Note
+As a shortcut, you can also refer to benchmarks by their ordinal numbers.
+The regular `--list` option does not provide these, but you can run:
+* `$ ./Benchmark_O --list --run-all | tail -n +2 | nl`
+You can use ordinal numbers instead of test names like this:
+* `$ ./Benchmark_O 1 42`
+* `$ ./Benchmark_Driver run 1 42`
 
 Using the Harness Generator
 ---------------------------

--- a/benchmark/scripts/Benchmark_Driver
+++ b/benchmark/scripts/Benchmark_Driver
@@ -124,6 +124,7 @@ def get_tests(driver_path, args):
     if args.benchmarks or args.filters:
         driver.append('--run-all')
     tests = subprocess.check_output(driver).split()[2:]
+    tests.extend(map(str, range(1, len(tests) + 1)))  # ordinal numbers
     if args.filters:
         regexes = [re.compile(pattern) for pattern in args.filters]
         return sorted(list(set([name for pattern in regexes


### PR DESCRIPTION
Add support for running benchmarks by reffering to them by their ordinal number in `Benchmark_Driver`, as is supported by `Benchmark_O`(`Onone`, `Ounchecked`).

Updated documentation to reflect this.