### PR TITLE
stdlib: Make _HeapBufferHeader @_versioned to fix resilient build

### DIFF
--- a/stdlib/public/core/HeapBuffer.swift
+++ b/stdlib/public/core/HeapBuffer.swift
@@ -19,6 +19,7 @@ internal protocol _HeapBufferHeader_ {
   var value: Value { get set }
 }
 
+@_versioned
 internal struct _HeapBufferHeader<T> : _HeapBufferHeader_ {
   typealias Value = T
   init(_ value: T) { self.value = value }


### PR DESCRIPTION
Fixes <rdar://problem/32536790>.