### PR TITLE
Annotate a couple of +1-returning functions appropriately

### DIFF
--- a/stdlib/public/SwiftShims/CoreFoundationShims.h
+++ b/stdlib/public/SwiftShims/CoreFoundationShims.h
@@ -69,6 +69,7 @@ _swift_shims_CFIndex _swift_stdlib_CFStringGetLength(
     _swift_shims_CFStringRef _Nonnull theString);
 
 SWIFT_RUNTIME_STDLIB_INTERFACE
+__attribute__((ns_returns_retained))
 _swift_shims_CFStringRef _Nonnull _swift_stdlib_CFStringCreateWithSubstring(
     _swift_shims_CFAllocatorRef _Nullable alloc,
     _swift_shims_CFStringRef _Nonnull str, _swift_shims_CFRange range);
@@ -78,6 +79,7 @@ _swift_shims_UniChar _swift_stdlib_CFStringGetCharacterAtIndex(
     _swift_shims_CFStringRef _Nonnull theString, _swift_shims_CFIndex idx);
 
 SWIFT_RUNTIME_STDLIB_INTERFACE
+__attribute__((ns_returns_retained))
 _swift_shims_CFStringRef _Nonnull _swift_stdlib_CFStringCreateCopy(
     _swift_shims_CFAllocatorRef _Nullable alloc,
     _swift_shims_CFStringRef _Nonnull theString);

--- a/stdlib/public/core/StringBridge.swift
+++ b/stdlib/public/core/StringBridge.swift
@@ -25,7 +25,6 @@ func _stdlib_binary_CFStringCreateCopy(
   _ source: _CocoaString
 ) -> _CocoaString {
   let result = _swift_stdlib_CFStringCreateCopy(nil, source) as AnyObject
-  Builtin.release(result)
   return result
 }
 


### PR DESCRIPTION
Annotate a couple of +1-returning functions appropriately instead of trying to compensate in the caller.

One of the callers was apparently not _cocoaStringSlice trying to compensate, so this probably also fixes a leak.