### PR TITLE
[ClangImporter] Honor the 'DC' parameter for importStringLiteral.

### DIFF
--- a/lib/ClangImporter/ImportMacro.cpp
+++ b/lib/ClangImporter/ImportMacro.cpp
@@ -190,10 +190,6 @@ static ValueDecl *importStringLiteral(ClangImporter::Implementation &Impl,
                                       const clang::Token &tok,
                                       MappedStringLiteralKind kind,
                                       const clang::MacroInfo *ClangN) {
-  DeclContext *dc = Impl.getClangModuleForMacro(MI);
-  if (!dc)
-    return nullptr;
-
   assert(isStringToken(tok));
 
   clang::ActionResult<clang::Expr*> result =
@@ -209,7 +205,7 @@ static ValueDecl *importStringLiteral(ClangImporter::Implementation &Impl,
   if (!importTy)
     return nullptr;
 
-  return Impl.createConstant(name, dc, importTy, parsed->getString(),
+  return Impl.createConstant(name, DC, importTy, parsed->getString(),
                              ConstantConvertKind::Coerce, /*static*/ false,
                              ClangN);
 }


### PR DESCRIPTION
We don't have any way to import a macro into a different DeclContext anyway, but even then this saves a bit of unnecessary work.

Groundwork for rdar://problem/32199805, which is that upstream Clang has removed a bunch of facilities for going from a SourceLocation or MacroInfo to a Module in favor of things like clang::ModuleMacro.