### PR TITLE
[test] Print "Available features" list in ASCIIbetical order.

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1106,4 +1106,4 @@ if platform.system() == 'Linux':
         config.available_features.add("LinuxDistribution=" + distributor + '-' + release)
         lit_config.note('Running tests on %s-%s' % (distributor, release))
 
-lit_config.note("Available features: " + ", ".join(config.available_features))
+lit_config.note("Available features: " + ", ".join(sorted(config.available_features)))


### PR DESCRIPTION
I mostly got fed up with the related features like CODEGENERATOR=X being scattered throughout the other unrelated-and-mostly-lowercase features.