### PR TITLE
[4.0] StdLib documentation revisions

### DIFF
--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -169,7 +169,7 @@ if True:
 ///   specific values.
 """
   elif Self == 'Array':
-    SelfDocComment = '''\
+    SelfDocComment = """\
 /// An ordered, random-access collection.
 ///
 /// Arrays are one of the most commonly used data types in an app. You use
@@ -447,9 +447,7 @@ if True:
 ///
 /// - Note: The `ContiguousArray` and `ArraySlice` types are not bridged;
 ///   instances of those types always have a contiguous block of memory as
-///   their storage.
-/// - SeeAlso: `ContiguousArray`, `ArraySlice`, `Sequence`, `Collection`,
-///   `RangeReplaceableCollection`'''
+///   their storage."""
   # FIXME: Write about Array up/down-casting.
   else:
     raise ValueError('Unhandled case: ' + Self)
@@ -620,8 +618,6 @@ public struct ${Self}<Element>
   /// - Returns: An index offset by `n` from the index `i`, unless that index
   ///   would be beyond `limit` in the direction of movement. In that case,
   ///   the method returns `nil`.
-  ///
-  /// - SeeAlso: `index(_:offsetBy:)`, `formIndex(_:offsetBy:limitedBy:)`
   @_inlineable
   public func index(
     _ i: Int, offsetBy n: Int, limitedBy limit: Int
@@ -736,10 +732,6 @@ public struct ${Self}<Element>
   ///
   /// - Parameter bounds: A range of integers. The bounds of the range must be
   ///   valid indices of the array.
-%if Self != 'ArraySlice':
-  ///
-  /// - SeeAlso: `ArraySlice`
-%end
   @_inlineable
   public subscript(bounds: Range<Int>) -> ArraySlice<Element> {
     get {
@@ -1683,12 +1675,10 @@ extension ${Self} {
   ///
   /// - Parameter body: A closure with an `UnsafeBufferPointer` parameter that
   ///   points to the contiguous storage for the array. ${contiguousCaveat} If
-  ///   `body` has a return value, it is used as the return value for the
-  ///   `withUnsafeBufferPointer(_:)` method. The pointer argument is valid
-  ///   only for the duration of the method's execution.
-  /// - Returns: The return value of the `body` closure parameter, if any.
-  ///
-  /// - SeeAlso: `withUnsafeMutableBufferPointer`, `UnsafeBufferPointer`
+  ///   `body` has a return value, that value is also used as the return value
+  ///   for the `withUnsafeBufferPointer(_:)` method. The pointer argument is
+  ///   valid only for the duration of the method's execution.
+  /// - Returns: The return value, if any, of the `body` closure parameter.
   @_inlineable
   public func withUnsafeBufferPointer<R>(
     _ body: (UnsafeBufferPointer<Element>) throws -> R
@@ -1727,13 +1717,11 @@ extension ${Self} {
   ///
   /// - Parameter body: A closure with an `UnsafeMutableBufferPointer`
   ///   parameter that points to the contiguous storage for the array.
-  ///   ${contiguousCaveat} If `body` has a return value, it is used as the
-  ///   return value for the `withUnsafeMutableBufferPointer(_:)` method. The
-  ///   pointer argument is valid only for the duration of the method's
-  ///   execution.
-  /// - Returns: The return value of the `body` closure parameter, if any.
-  ///
-  /// - SeeAlso: `withUnsafeBufferPointer`, `UnsafeMutableBufferPointer`
+  ///   ${contiguousCaveat} If `body` has a return value, that value is also
+  ///   used as the return value for the `withUnsafeMutableBufferPointer(_:)`
+  ///   method. The pointer argument is valid only for the duration of the
+  ///   method's execution.
+  /// - Returns: The return value, if any, of the `body` closure parameter.
   @_semantics("array.withUnsafeMutableBufferPointer")
   @inline(__always) // Performance: This method should get inlined into the
   // caller such that we can combine the partial apply with the apply in this
@@ -2260,12 +2248,11 @@ extension ${Self} {
   ///
   /// - Parameter body: A closure with an `UnsafeMutableRawBufferPointer`
   ///   parameter that points to the contiguous storage for the array.
-  ///   ${contiguousCaveat} If `body` has a return value, it is used as the
-  ///   return value for the `withUnsafeMutableBytes(_:)` method. The argument
-  ///   is valid only for the duration of the closure's execution.
-  /// - Returns: The return value of the `body` closure parameter, if any.
-  ///
-  /// - SeeAlso: `withUnsafeBytes`, `UnsafeMutableRawBufferPointer`
+  ///   ${contiguousCaveat} If `body` has a return value, that value is also
+  ///   used as the return value for the `withUnsafeMutableBytes(_:)` method.
+  ///   The argument is valid only for the duration of the closure's
+  ///   execution.
+  /// - Returns: The return value, if any, of the `body` closure parameter.
   @_inlineable
   public mutating func withUnsafeMutableBytes<R>(
     _ body: (UnsafeMutableRawBufferPointer) throws -> R
@@ -2296,12 +2283,10 @@ extension ${Self} {
   ///
   /// - Parameter body: A closure with an `UnsafeRawBufferPointer` parameter
   ///   that points to the contiguous storage for the array.
-  ///   ${contiguousCaveat} If `body` has a return value, it is used as the
-  ///   return value for the `withUnsafeBytes(_:)` method. The argument is
-  ///   valid only for the duration of the closure's execution.
-  /// - Returns: The return value of the `body` closure parameter, if any.
-  ///
-  /// - SeeAlso: `withUnsafeMutableBytes`, `UnsafeRawBufferPointer`
+  ///   ${contiguousCaveat} If `body` has a return value, that value is also
+  ///   used as the return value for the `withUnsafeBytes(_:)` method. The
+  ///   argument is valid only for the duration of the closure's execution.
+  /// - Returns: The return value, if any, of the `body` closure parameter.
   @_inlineable
   public func withUnsafeBytes<R>(
     _ body: (UnsafeRawBufferPointer) throws -> R
@@ -2360,7 +2345,6 @@ extension Array {
   ///
   /// - Complexity: O(*n*) if the array is bridged, where *n* is the length
   ///   of the array; otherwise, O(1).
-  /// - SeeAlso: `removeLast()`
   @_inlineable
   public mutating func popLast() -> Element? {
     guard !isEmpty else { return nil }
@@ -2375,7 +2359,6 @@ extension ContiguousArray {
   ///   otherwise, `nil`.
   ///
   /// - Complexity: O(1)
-  /// - SeeAlso: `removeLast()`
   @_inlineable
   public mutating func popLast() -> Element? {
     guard !isEmpty else { return nil }

--- a/stdlib/public/core/BidirectionalCollection.swift
+++ b/stdlib/public/core/BidirectionalCollection.swift
@@ -232,7 +232,6 @@ extension BidirectionalCollection where SubSequence == Self {
   ///   or more elements; otherwise, `nil`.
   ///
   /// - Complexity: O(1).
-  /// - SeeAlso: `removeLast()`
   public mutating func popLast() -> Element? {
     guard !isEmpty else { return nil }
     let element = last!
@@ -248,7 +247,6 @@ extension BidirectionalCollection where SubSequence == Self {
   /// - Returns: The last element of the collection.
   ///
   /// - Complexity: O(1)
-  /// - SeeAlso: `popLast()`
   @discardableResult
   public mutating func removeLast() -> Element {
     let element = last!

--- a/stdlib/public/core/Bool.swift
+++ b/stdlib/public/core/Bool.swift
@@ -145,7 +145,6 @@ extension Bool : Equatable, Hashable {
   /// - Note: The hash value is not guaranteed to be stable across different
   ///   invocations of the same program. Do not persist the hash value across
   ///   program runs.
-  /// - SeeAlso: `Hashable`
   @_transparent
   public var hashValue: Int {
     return self ? 1 : 0
@@ -160,8 +159,8 @@ extension Bool : Equatable, Hashable {
 extension Bool : LosslessStringConvertible {
   /// Creates a new Boolean value from the given string.
   ///
-  /// If `description` is any string other than `"true"` or `"false"`, the
-  /// result is `nil`. This initializer is case sensitive.
+  /// If the `description` value is any string other than `"true"` or
+  /// `"false"`, the result is `nil`. This initializer is case sensitive.
   ///
   /// - Parameter description: A string representation of the Boolean value.
   public init?(_ description: String) {

--- a/stdlib/public/core/Builtin.swift
+++ b/stdlib/public/core/Builtin.swift
@@ -82,24 +82,25 @@ func _canBeClass<T>(_: T.Type) -> Int8 {
 /// Returns the bits of the given instance, interpreted as having the specified
 /// type.
 ///
-/// Only use this function to convert the instance passed as `x` to a
-/// layout-compatible type when the conversion is not possible through other
-/// means. Common conversions that are supported by the standard library
+/// Use this function only to convert the instance passed as `x` to a
+/// layout-compatible type when conversion through other means is not
+/// possible. Common conversions supported by the Swift standard library
 /// include the following:
 ///
-/// - To convert an integer value from one type to another, use an initializer
-///   or the `numericCast(_:)` function.
-/// - To perform a bitwise conversion of an integer value to a different type,
-///   use an `init(bitPattern:)` or `init(truncatingBitPattern:)` initializer.
-/// - To convert between a pointer and an integer value with that bit pattern,
-///   or vice versa, use the `init(bitPattern:)` initializer for the
-///   destination type.
-/// - To perform a reference cast, use the casting operators (`as`, `as!`, or
-///   `as?`) or the `unsafeDowncast(_:to:)` function. Do not use
+/// - Value conversion from one integer type to another. Use the destination
+///   type's initializer or the `numericCast(_:)` function.
+/// - Bitwise conversion from one integer type to another. Use the destination
+///   type's `init(extendingOrTruncating:)` or `init(bitPattern:)`
+///   initializer.
+/// - Conversion from a pointer to an integer value with the bit pattern of the
+///   pointer's address in memory, or vice versa. Use the `init(bitPattern:)`
+///   initializer for the destination type.
+/// - Casting an instance of a reference type. Use the casting operators (`as`,
+///   `as!`, or `as?`) or the `unsafeDowncast(_:to:)` function. Do not use
 ///   `unsafeBitCast(_:to:)` with class or pointer types; doing so may
 ///   introduce undefined behavior.
 ///
-/// - Warning: Calling this function breaks the guarantees of Swift's type
+/// - Warning: Calling this function breaks the guarantees of the Swift type
 ///   system; use with extreme care.
 ///
 /// - Parameters:
@@ -656,12 +657,12 @@ func _trueAfterDiagnostics() -> Builtin.Int1 {
 /// particularly when the dynamic type is different from the static type. The
 /// *static type* of a value is the known, compile-time type of the value. The
 /// *dynamic type* of a value is the value's actual type at run-time, which
-/// may be nested inside its concrete type.
+/// can be nested inside its concrete type.
 ///
 /// In the following code, the `count` variable has the same static and dynamic
 /// type: `Int`. When `count` is passed to the `printInfo(_:)` function,
-/// however, the `value` parameter has a static type of `Any`, the type
-/// declared for the parameter, and a dynamic type of `Int`.
+/// however, the `value` parameter has a static type of `Any` (the type
+/// declared for the parameter) and a dynamic type of `Int`.
 ///
 ///     func printInfo(_ value: Any) {
 ///         let type = type(of: value)
@@ -673,7 +674,7 @@ func _trueAfterDiagnostics() -> Builtin.Int1 {
 ///     // '5' of type 'Int'
 ///
 /// The dynamic type returned from `type(of:)` is a *concrete metatype*
-/// (`T.Type`) for a class, structure, enumeration, or other non-protocol type
+/// (`T.Type`) for a class, structure, enumeration, or other nonprotocol type
 /// `T`, or an *existential metatype* (`P.Type`) for a protocol or protocol
 /// composition `P`. When the static type of the value passed to `type(of:)`
 /// is constrained to a class or protocol, you can use that metatype to access
@@ -709,19 +710,22 @@ func _trueAfterDiagnostics() -> Builtin.Int1 {
 /// retrieves the overridden value from the `EmojiSmiley` subclass, instead of
 /// the `Smiley` class's original definition.
 ///
+/// Finding the Dynamic Type in a Generic Context
+/// =============================================
+///
 /// Normally, you don't need to be aware of the difference between concrete and
 /// existential metatypes, but calling `type(of:)` can yield unexpected
 /// results in a generic context with a type parameter bound to a protocol. In
 /// a case like this, where a generic parameter `T` is bound to a protocol
 /// `P`, the type parameter is not statically known to be a protocol type in
-/// the body of the generic function, so `type(of:)` can only produce the
-/// concrete metatype `P.Protocol`.
+/// the body of the generic function. As a result, `type(of:)` can only
+/// produce the concrete metatype `P.Protocol`.
 ///
 /// The following example defines a `printGenericInfo(_:)` function that takes
 /// a generic parameter and declares the `String` type's conformance to a new
 /// protocol `P`. When `printGenericInfo(_:)` is called with a string that has
 /// `P` as its static type, the call to `type(of:)` returns `P.self` instead
-/// of the dynamic type inside the parameter, `String.self`.
+/// of `String.self` (the dynamic type inside the parameter).
 ///
 ///     func printGenericInfo<T>(_ value: T) {
 ///         let type = type(of: value)
@@ -750,8 +754,8 @@ func _trueAfterDiagnostics() -> Builtin.Int1 {
 ///     betterPrintGenericInfo(stringAsP)
 ///     // 'Hello!' of type 'String'
 ///
-/// - Parameter value: The value to find the dynamic type of.
-/// - Returns: The dynamic type, which is a value of metatype type.
+/// - Parameter value: The value for which to find the dynamic type.
+/// - Returns: The dynamic type, which is a metatype instance.
 @_transparent
 @_semantics("typechecker.type(of:)")
 public func type<T, Metatype>(of value: T) -> Metatype {
@@ -776,15 +780,15 @@ public func type<T, Metatype>(of value: T) -> Metatype {
 /// whether all the elements in an array match a predicate. The function won't
 /// compile as written, because a lazy collection's `filter(_:)` method
 /// requires an escaping closure. The lazy collection isn't persisted, so the
-/// `predicate` closure won't actually escape the body of the function, but
-/// even so it can't be used in this way.
+/// `predicate` closure won't actually escape the body of the function;
+/// nevertheless, it can't be used in this way.
 ///
 ///     func allValues(in array: [Int], match predicate: (Int) -> Bool) -> Bool {
 ///         return array.lazy.filter { !predicate($0) }.isEmpty
 ///     }
 ///     // error: closure use of non-escaping parameter 'predicate'...
 ///
-/// `withoutActuallyEscaping(_:do:)` provides a temporarily-escapable copy of
+/// `withoutActuallyEscaping(_:do:)` provides a temporarily escapable copy of
 /// `predicate` that _can_ be used in a call to the lazy view's `filter(_:)`
 /// method. The second version of `allValues(in:match:)` compiles without
 /// error, with the compiler guaranteeing that the `escapablePredicate`
@@ -816,7 +820,7 @@ public func type<T, Metatype>(of value: T) -> Metatype {
 /// returning. Even though the barrier guarantees that neither closure will
 /// escape the function, the `async(execute:)` method still requires that the
 /// closures passed be marked as `@escaping`, so the first version of the
-/// function does not compile. To resolve this, you can use
+/// function does not compile. To resolve these errors, you can use
 /// `withoutActuallyEscaping(_:do:)` to get copies of `f` and `g` that can be
 /// passed to `async(execute:)`.
 ///
@@ -831,19 +835,19 @@ public func type<T, Metatype>(of value: T) -> Metatype {
 ///         }
 ///     }
 ///
-/// - Important: The escapable copy of `closure` passed as `body` is only valid
+/// - Important: The escapable copy of `closure` passed to `body` is only valid
 ///   during the call to `withoutActuallyEscaping(_:do:)`. It is undefined
 ///   behavior for the escapable closure to be stored, referenced, or executed
 ///   after the function returns.
 ///
 /// - Parameters:
-///   - closure: A non-escaping closure value that will be made escapable for
-///     the duration of the execution of the `body` closure. If `body` has a
-///     return value, it is used as the return value for the
+///   - closure: A nonescaping closure value that is made escapable for the
+///     duration of the execution of the `body` closure. If `body` has a
+///     return value, that value is also used as the return value for the
 ///     `withoutActuallyEscaping(_:do:)` function.
-///   - body: A closure that will be immediately executed, receiving an
-///     escapable copy of `closure` as an argument.
-/// - Returns: The return value of the `body` closure, if any.
+///   - body: A closure that is executed immediately with an escapable copy of
+///     `closure` as its argument.
+/// - Returns: The return value, if any, of the `body` closure.
 @_transparent
 @_semantics("typechecker.withoutActuallyEscaping(_:do:)")
 public func withoutActuallyEscaping<ClosureType, ResultType>(

--- a/stdlib/public/core/CString.swift
+++ b/stdlib/public/core/CString.swift
@@ -143,8 +143,6 @@ extension String {
   /// - Returns: A tuple with the new string and a Boolean value that indicates
   ///   whether any repairs were made. If `isRepairing` is `false` and an
   ///   ill-formed sequence is detected, this method returns `nil`.
-  ///
-  /// - SeeAlso: `UnicodeCodec`
   public static func decodeCString<Encoding : _UnicodeEncoding>(
     _ cString: UnsafePointer<Encoding.CodeUnit>?,
     as encoding: Encoding.Type,

--- a/stdlib/public/core/ClosedRange.swift
+++ b/stdlib/public/core/ClosedRange.swift
@@ -174,8 +174,6 @@ public struct ClosedRangeIterator<Bound> : IteratorProtocol, Sequence
 /// bound by floating-point values, see the `ClosedRange` type. If you need to
 /// iterate over consecutive floating-point values, see the
 /// `stride(from:through:by:)` function.
-///
-/// - SeeAlso: `CountableRange`, `ClosedRange`, `Range`
 @_fixed_layout
 public struct CountableClosedRange<Bound> : RandomAccessCollection
   where
@@ -373,8 +371,6 @@ public struct CountableClosedRange<Bound> : RandomAccessCollection
 ///     let lowercaseA = "a"..."a"
 ///     print(lowercaseA.isEmpty)
 ///     // Prints "false"
-///
-/// - SeeAlso: `CountableRange`, `Range`, `CountableClosedRange`
 @_fixed_layout
 public struct ClosedRange<
   Bound : Comparable

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -32,8 +32,6 @@ public protocol _IndexableBase {
   /// Valid indices consist of the position of every element and a
   /// "past the end" position that's not valid for use as a subscript
   /// argument.
-  ///
-  /// - SeeAlso: endIndex
   associatedtype Index : Comparable
 
   /// The position of the first element in a nonempty collection.
@@ -153,8 +151,6 @@ public protocol _IndexableBase {
   ///
   /// - Parameter i: A valid index of the collection. `i` must be less than
   ///   `endIndex`.
-  ///
-  /// - SeeAlso: `index(after:)`
   func formIndex(after i: inout Index)
 }
 
@@ -195,7 +191,6 @@ public protocol _Indexable : _IndexableBase {
   ///   If `n` is negative, this is the same value as the result of `-n` calls
   ///   to `index(before:)`.
   ///
-  /// - SeeAlso: `index(_:offsetBy:limitedBy:)`, `formIndex(_:offsetBy:)`
   /// - Complexity: O(1) if the collection conforms to
   ///   `RandomAccessCollection`; otherwise, O(*n*), where *n* is the absolute
   ///   value of `n`.
@@ -238,7 +233,6 @@ public protocol _Indexable : _IndexableBase {
   ///   would be beyond `limit` in the direction of movement. In that case,
   ///   the method returns `nil`.
   ///
-  /// - SeeAlso: `index(_:offsetBy:)`, `formIndex(_:offsetBy:limitedBy:)`
   /// - Complexity: O(1) if the collection conforms to
   ///   `RandomAccessCollection`; otherwise, O(*n*), where *n* is the absolute
   ///   value of `n`.
@@ -256,7 +250,6 @@ public protocol _Indexable : _IndexableBase {
   ///   - n: The distance to offset `i`. `n` must not be negative unless the
   ///     collection conforms to the `BidirectionalCollection` protocol.
   ///
-  /// - SeeAlso: `index(_:offsetBy:)`, `formIndex(_:offsetBy:limitedBy:)`
   /// - Complexity: O(1) if the collection conforms to
   ///   `RandomAccessCollection`; otherwise, O(*n*), where *n* is the absolute
   ///   value of `n`.
@@ -280,7 +273,6 @@ public protocol _Indexable : _IndexableBase {
   ///   going beyond `limit`; otherwise, `false`. When the return value is
   ///   `false`, the value of `i` is equal to `limit`.
   ///
-  /// - SeeAlso: `index(_:offsetBy:)`, `formIndex(_:offsetBy:limitedBy:)`
   /// - Complexity: O(1) if the collection conforms to
   ///   `RandomAccessCollection`; otherwise, O(*n*), where *n* is the absolute
   ///   value of `n`.
@@ -428,20 +420,18 @@ public struct IndexingIterator<
 }
 
 /// A sequence whose elements can be traversed multiple times,
-/// nondestructively, and accessed by indexed subscript.
+/// nondestructively, and accessed by an indexed subscript.
 ///
 /// Collections are used extensively throughout the standard library. When you
-/// use arrays, dictionaries, views of a string's contents and other types,
-/// you benefit from the operations that the `Collection` protocol declares
-/// and implements.
-///
-/// In addition to the methods that collections inherit from the `Sequence`
+/// use arrays, dictionaries, and other collections, you benefit from the
+/// operations that the `Collection` protocol declares and implements. In
+/// addition to the operations that collections inherit from the `Sequence`
 /// protocol, you gain access to methods that depend on accessing an element
-/// at a specific position when using a collection.
+/// at a specific position in a collection.
 ///
-/// For example, if you want to print only the first word in a string, search
-/// for the index of the first space, and then create a subsequence up to that
-/// position.
+/// For example, if you want to print only the first word in a string, you can
+/// search for the index of the first space, and then create a substring up to
+/// that position.
 ///
 ///     let text = "Buffalo buffalo buffalo buffalo."
 ///     if let firstSpace = text.index(of: " ") {
@@ -462,7 +452,7 @@ public struct IndexingIterator<
 /// such as the `startIndex` property of a different collection, are invalid
 /// indices for this collection.
 ///
-/// Saved indices may become invalid as a result of mutating operations; for
+/// Saved indices may become invalid as a result of mutating operations. For
 /// more information about index invalidation in mutable collections, see the
 /// reference for the `MutableCollection` and `RangeReplaceableCollection`
 /// protocols, as well as for the specific type you're using.
@@ -470,9 +460,10 @@ public struct IndexingIterator<
 /// Accessing Individual Elements
 /// =============================
 ///
-/// You can access an element of a collection through its subscript with any
-/// valid index except the collection's `endIndex` property, a "past the end"
-/// index that does not correspond with any element of the collection.
+/// You can access an element of a collection through its subscript by using
+/// any valid index except the collection's `endIndex` property. This property
+/// is a "past the end" index that does not correspond with any element of the
+/// collection.
 ///
 /// Here's an example of accessing the first character in a string through its
 /// subscript:
@@ -499,7 +490,7 @@ public struct IndexingIterator<
 /// and shares the original collection's semantics.
 ///
 /// The following example creates a `firstWord` constant by using the
-/// `prefix(where:)` method to get a slice of the `text` string.
+/// `prefix(while:)` method to get a slice of the `text` string.
 ///
 ///     let firstWord = text.prefix(while: { $0 != " " })
 ///     print(firstWord)
@@ -553,7 +544,7 @@ public struct IndexingIterator<
 /// A slice inherits the value or reference semantics of its base collection.
 /// That is, when working with a slice of a mutable collection that has value
 /// semantics, such as an array, mutating the original collection triggers a
-/// copy of that collection, and does not affect the contents of the slice.
+/// copy of that collection and does not affect the contents of the slice.
 ///
 /// For example, if you update the last element of the `absences` array from
 /// `0` to `2`, the `secondHalf` slice is unchanged.
@@ -568,11 +559,12 @@ public struct IndexingIterator<
 /// =======================
 ///
 /// Although a sequence can be consumed as it is traversed, a collection is
-/// guaranteed to be multipass: Any element may be repeatedly accessed by
+/// guaranteed to be *multipass*: Any element can be repeatedly accessed by
 /// saving its index. Moreover, a collection's indices form a finite range of
-/// the positions of the collection's elements. This guarantees the safety of
-/// operations that depend on a sequence being finite, such as checking to see
-/// whether a collection contains an element.
+/// the positions of the collection's elements. The fact that all collections
+/// are finite guarantees the safety of many sequence operations, such as
+/// using the `contains(_:)` method to test whether a collection includes an
+/// element.
 ///
 /// Iterating over the elements of a collection by their positions yields the
 /// same elements in the same order as iterating over that collection using
@@ -606,31 +598,31 @@ public struct IndexingIterator<
 /// elements, make sure that its type conforms to the `Collection` protocol in
 /// order to give a more useful and more efficient interface for sequence and
 /// collection operations. To add `Collection` conformance to your type, you
-/// must declare at least the four following requirements:
+/// must declare at least the following requirements:
 ///
-/// - the `startIndex` and `endIndex` properties,
-/// - a subscript that provides at least read-only access to your type's
-///   elements, and
-/// - the `index(after:)` method for advancing an index into your collection.
+/// - The `startIndex` and `endIndex` properties
+/// - A subscript that provides at least read-only access to your type's
+///   elements
+/// - The `index(after:)` method for advancing an index into your collection
 ///
 /// Expected Performance
 /// ====================
 ///
 /// Types that conform to `Collection` are expected to provide the `startIndex`
 /// and `endIndex` properties and subscript access to elements as O(1)
-/// operations. Types that are not able to guarantee that expected performance
-/// must document the departure, because many collection operations depend on
-/// O(1) subscripting performance for their own performance guarantees.
+/// operations. Types that are not able to guarantee this performance must
+/// document the departure, because many collection operations depend on O(1)
+/// subscripting performance for their own performance guarantees.
 ///
 /// The performance of some collection operations depends on the type of index
 /// that the collection provides. For example, a random-access collection,
-/// which can measure the distance between two indices in O(1) time, will be
-/// able to calculate its `count` property in O(1) time. Conversely, because a
-/// forward or bidirectional collection must traverse the entire collection to
-/// count the number of contained elements, accessing its `count` property is
-/// an O(*n*) operation.
-public protocol Collection : _Indexable, Sequence 
-// FIXME(ABI) (Revert Where Clauses): Restore these 
+/// which can measure the distance between two indices in O(1) time, can
+/// calculate its `count` property in O(1) time. Conversely, because a forward
+/// or bidirectional collection must traverse the entire collection to count
+/// the number of contained elements, accessing its `count` property is an
+/// O(*n*) operation.
+public protocol Collection : _Indexable, Sequence
+// FIXME(ABI) (Revert Where Clauses): Restore these
 // where SubSequence: Collection, Indices: Collection,
 {
   /// A type that represents the number of steps between a pair of
@@ -793,7 +785,6 @@ public protocol Collection : _Indexable, Sequence
   /// - Returns: A subsequence up to, but not including, the `end` position.
   ///
   /// - Complexity: O(1)
-  /// - SeeAlso: `prefix(through:)`
   func prefix(upTo end: Index) -> SubSequence
 
   /// Returns a subsequence from the specified position to the end of the
@@ -860,7 +851,6 @@ public protocol Collection : _Indexable, Sequence
   /// - Returns: A subsequence up to, and including, the `end` position.
   ///
   /// - Complexity: O(1)
-  /// - SeeAlso: `prefix(upTo:)`
   func prefix(through position: Index) -> SubSequence
 
   /// A Boolean value indicating whether the collection is empty.
@@ -936,7 +926,6 @@ public protocol Collection : _Indexable, Sequence
   ///   If `n` is negative, this is the same value as the result of `-n` calls
   ///   to `index(before:)`.
   ///
-  /// - SeeAlso: `index(_:offsetBy:limitedBy:)`, `formIndex(_:offsetBy:)`
   /// - Complexity: O(1) if the collection conforms to
   ///   `RandomAccessCollection`; otherwise, O(*n*), where *n* is the absolute
   ///   value of `n`.
@@ -979,7 +968,6 @@ public protocol Collection : _Indexable, Sequence
   ///   would be beyond `limit` in the direction of movement. In that case,
   ///   the method returns `nil`.
   ///
-  /// - SeeAlso: `index(_:offsetBy:)`, `formIndex(_:offsetBy:limitedBy:)`
   /// - Complexity: O(1) if the collection conforms to
   ///   `RandomAccessCollection`; otherwise, O(*n*), where *n* is the absolute
   ///   value of `n`.
@@ -1078,7 +1066,6 @@ extension _Indexable {
   ///   If `n` is negative, this is the same value as the result of `-n` calls
   ///   to `index(before:)`.
   ///
-  /// - SeeAlso: `index(_:offsetBy:limitedBy:)`, `formIndex(_:offsetBy:)`
   /// - Complexity: O(1) if the collection conforms to
   ///   `RandomAccessCollection`; otherwise, O(*n*), where *n* is the absolute
   ///   value of `n`.
@@ -1124,7 +1111,6 @@ extension _Indexable {
   ///   would be beyond `limit` in the direction of movement. In that case,
   ///   the method returns `nil`.
   ///
-  /// - SeeAlso: `index(_:offsetBy:)`, `formIndex(_:offsetBy:limitedBy:)`
   /// - Complexity: O(1) if the collection conforms to
   ///   `RandomAccessCollection`; otherwise, O(*n*), where *n* is the absolute
   ///   value of `n`.
@@ -1145,7 +1131,6 @@ extension _Indexable {
   ///   - n: The distance to offset `i`. `n` must not be negative unless the
   ///     collection conforms to the `BidirectionalCollection` protocol.
   ///
-  /// - SeeAlso: `index(_:offsetBy:)`, `formIndex(_:offsetBy:limitedBy:)`
   /// - Complexity: O(1) if the collection conforms to
   ///   `RandomAccessCollection`; otherwise, O(*n*), where *n* is the absolute
   ///   value of `n`.
@@ -1172,7 +1157,6 @@ extension _Indexable {
   ///   going beyond `limit`; otherwise, `false`. When the return value is
   ///   `false`, the value of `i` is equal to `limit`.
   ///
-  /// - SeeAlso: `index(_:offsetBy:)`, `formIndex(_:offsetBy:limitedBy:)`
   /// - Complexity: O(1) if the collection conforms to
   ///   `RandomAccessCollection`; otherwise, O(*n*), where *n* is the absolute
   ///   value of `n`.
@@ -1644,7 +1628,6 @@ extension Collection {
   /// - Returns: A subsequence up to, but not including, the `end` position.
   ///
   /// - Complexity: O(1)
-  /// - SeeAlso: `prefix(through:)`
   @_inlineable
   public func prefix(upTo end: Index) -> SubSequence {
     return self[startIndex..<end]
@@ -1717,7 +1700,6 @@ extension Collection {
   /// - Returns: A subsequence up to, and including, the `end` position.
   ///
   /// - Complexity: O(1)
-  /// - SeeAlso: `prefix(upTo:)`
   @_inlineable
   public func prefix(through position: Index) -> SubSequence {
     return prefix(upTo: index(after: position))
@@ -1884,7 +1866,6 @@ extension Collection where SubSequence == Self {
   /// - Returns: The first element of the collection.
   ///
   /// - Complexity: O(1)
-  /// - SeeAlso: `popFirst()`
   @_inlineable
   @discardableResult
   public mutating func removeFirst() -> Element {

--- a/stdlib/public/core/CollectionAlgorithms.swift.gyb
+++ b/stdlib/public/core/CollectionAlgorithms.swift.gyb
@@ -53,8 +53,6 @@ extension Collection where Element : Equatable {
   /// - Parameter element: An element to search for in the collection.
   /// - Returns: The first index where `element` is found. If `element` is not
   ///   found in the collection, returns `nil`.
-  ///
-  /// - SeeAlso: `index(where:)`
   @_inlineable
   public func index(of element: Element) -> Index? {
     if let result = _customIndexOfEquatableElement(element) {
@@ -93,8 +91,6 @@ extension Collection {
   /// - Returns: The index of the first element for which `predicate` returns
   ///   `true`. If no elements in the collection satisfy the given predicate,
   ///   returns `nil`.
-  ///
-  /// - SeeAlso: `index(of:)`
   @_inlineable
   public func index(
     where predicate: (Element) throws -> Bool
@@ -252,8 +248,6 @@ extension ${Self} where Element : Comparable {
   ///     // Prints "["Peter", "Kweku", "Kofi", "Akosua", "Abena"]"
   ///
   /// - Returns: A sorted array of the ${sequenceKind}'s elements.
-  ///
-  /// - SeeAlso: `sorted(by:)`, `sort()`
   @_inlineable
   public func sorted() -> [Element] {
     var result = ContiguousArray(self)
@@ -326,8 +320,6 @@ ${orderingExplanation}
   ///   argument should be ordered before its second argument; otherwise,
   ///   `false`.
   /// - Returns: A sorted array of the ${sequenceKind}'s elements.
-  ///
-  /// - SeeAlso: `sorted()`, `sort(by:)`
   @_inlineable
   public func sorted(
     by areInIncreasingOrder:

--- a/stdlib/public/core/CompilerProtocols.swift
+++ b/stdlib/public/core/CompilerProtocols.swift
@@ -98,8 +98,6 @@
 ///     // Prints "false"
 ///     print(allowedMoves.rawValue & Directions.right.rawValue)
 ///     // Prints "0"
-///
-/// - SeeAlso: `OptionSet`, `FixedWidthInteger`
 public protocol RawRepresentable {
   /// The raw type that can be used to represent all values of the conforming
   /// type.
@@ -183,8 +181,6 @@ public func != <T : Equatable>(lhs: T, rhs: T) -> Bool
 /// `Optional` type conforms to `ExpressibleByNilLiteral`.
 /// `ExpressibleByNilLiteral` conformance for types that use `nil` for other
 /// purposes is discouraged.
-///
-/// - SeeAlso: `Optional`
 public protocol ExpressibleByNilLiteral {
   /// Creates an instance initialized with `nil`.
   init(nilLiteral: ())

--- a/stdlib/public/core/EmptyCollection.swift
+++ b/stdlib/public/core/EmptyCollection.swift
@@ -18,8 +18,6 @@
 //===----------------------------------------------------------------------===//
 
 /// An iterator that never produces an element.
-///
-/// - SeeAlso: `EmptyCollection<Element>`.
 public struct EmptyIterator<Element> : IteratorProtocol, Sequence {
   /// Creates an instance.
   public init() {}

--- a/stdlib/public/core/Equatable.swift
+++ b/stdlib/public/core/Equatable.swift
@@ -233,8 +233,6 @@ extension Equatable {
 /// - Parameters:
 ///   - lhs: A reference to compare.
 ///   - rhs: Another reference to compare.
-///
-/// - SeeAlso: `Equatable`, `==`, `!==`
 public func === (lhs: AnyObject?, rhs: AnyObject?) -> Bool {
   switch (lhs, rhs) {
   case let (l?, r?):
@@ -259,8 +257,6 @@ public func === (lhs: AnyObject?, rhs: AnyObject?) -> Bool {
 /// - Parameters:
 ///   - lhs: A reference to compare.
 ///   - rhs: Another reference to compare.
-///
-/// - SeeAlso: `Equatable`, `===`, `!=`
 public func !== (lhs: AnyObject?, rhs: AnyObject?) -> Bool {
   return !(lhs === rhs)
 }

--- a/stdlib/public/core/ExistentialCollection.swift.gyb
+++ b/stdlib/public/core/ExistentialCollection.swift.gyb
@@ -41,8 +41,6 @@ internal func _abstract(
 /// This iterator forwards its `next()` method to an arbitrary underlying
 /// iterator having the same `Element` type, hiding the specifics of the
 /// underlying `IteratorProtocol`.
-///
-/// - SeeAlso: `AnySequence`
 @_fixed_layout
 public struct AnyIterator<Element> : IteratorProtocol {
   /// Creates an iterator that wraps a base iterator but whose type depends
@@ -731,8 +729,6 @@ internal struct _ClosureBasedSequence<Iterator : IteratorProtocol>
 /// An instance of `AnySequence` forwards its operations to an underlying base
 /// sequence having the same `Element` type, hiding the specifics of the
 /// underlying sequence.
-///
-/// - SeeAlso: `AnyIterator`
 //@_versioned
 @_fixed_layout
 public struct AnySequence<Element> : Sequence {
@@ -940,8 +936,6 @@ internal final class _IndexBox<
 }
 
 /// A wrapper over an underlying index that hides the specific underlying type.
-///
-/// - SeeAlso: `AnyCollection`
 @_fixed_layout
 public struct AnyIndex {
   /// Creates a new index wrapping `base`.
@@ -1015,8 +1009,6 @@ protocol _AnyCollectionProtocol : Collection {
 /// An `${Self}` instance forwards its operations to a base collection having the
 /// same `Element` type, hiding the specifics of the underlying
 /// collection.
-///
-/// - SeeAlso: ${', '.join('`Any%sCollection`' % t for t in (2 * TRAVERSALS)[ti + 1 : ti + 3]) }
 @_fixed_layout
 public struct ${Self}<Element>
   : _AnyCollectionProtocol, ${SelfProtocol} {

--- a/stdlib/public/core/Flatten.swift.gyb
+++ b/stdlib/public/core/Flatten.swift.gyb
@@ -121,8 +121,6 @@ extension Sequence where Element : Sequence {
   ///
   /// - Returns: A flattened view of the elements of this
   ///   sequence of sequences.
-  ///
-  /// - SeeAlso: `flatMap(_:)`, `joined(separator:)`
   public func joined() -> FlattenSequence<Self> {
     return FlattenSequence(_base: self)
   }
@@ -397,8 +395,6 @@ extension ${collectionForTraversal(traversal)}
   ///
   /// - Returns: A flattened view of the elements of this
   ///   collection of collections.
-  ///
-  /// - SeeAlso: `flatMap(_:)`, `joined(separator:)`
   public func joined() -> ${Collection}<Self> {
     return ${Collection}(self)
   }

--- a/stdlib/public/core/FloatingPoint.swift.gyb
+++ b/stdlib/public/core/FloatingPoint.swift.gyb
@@ -304,8 +304,6 @@ public protocol FloatingPoint: SignedNumeric, Strideable, Hashable {
   ///     // Prints "false"
   ///     print(y.isNaN)
   ///     // Prints "true"
-  ///
-  /// - SeeAlso: `isNaN`, `signalingNaN`
   static var nan: Self { get }
 
   /// A signaling NaN ("not a number").
@@ -323,8 +321,6 @@ public protocol FloatingPoint: SignedNumeric, Strideable, Hashable {
   ///
   /// Other than these signaling operations, a signaling NaN behaves in the
   /// same manner as a quiet NaN.
-  ///
-  /// - SeeAlso: `nan`
   static var signalingNaN: Self { get }
 
   /// Positive infinity.
@@ -664,9 +660,6 @@ public protocol FloatingPoint: SignedNumeric, Strideable, Hashable {
   ///
   /// - Parameter other: The value to use when dividing this value.
   /// - Returns: The remainder of this value divided by `other`.
-  ///
-  /// - SeeAlso: `formRemainder(dividingBy:)`,
-  ///   `truncatingRemainder(dividingBy:)`
   func remainder(dividingBy other: Self) -> Self
 
   /// Replaces this value with the remainder of itself divided by the given
@@ -698,9 +691,6 @@ public protocol FloatingPoint: SignedNumeric, Strideable, Hashable {
   /// `remainder(dividingBy:)` method is always exact.
   ///
   /// - Parameter other: The value to use when dividing this value.
-  ///
-  /// - SeeAlso: `remainder(dividingBy:)`,
-  ///   `formTruncatingRemainder(dividingBy:)`
   mutating func formRemainder(dividingBy other: Self)
 
   /// Returns the remainder of this value divided by the given value using
@@ -734,9 +724,6 @@ public protocol FloatingPoint: SignedNumeric, Strideable, Hashable {
   /// - Parameter other: The value to use when dividing this value.
   /// - Returns: The remainder of this value divided by `other` using
   ///   truncating division.
-  ///
-  /// - SeeAlso: `formTruncatingRemainder(dividingBy:)`,
-  ///   `remainder(dividingBy:)`
   func truncatingRemainder(dividingBy other: Self) -> Self
 
   /// Replaces this value with the remainder of itself divided by the given
@@ -768,9 +755,6 @@ public protocol FloatingPoint: SignedNumeric, Strideable, Hashable {
   /// method is always exact.
   ///
   /// - Parameter other: The value to use when dividing this value.
-  ///
-  /// - SeeAlso: `truncatingRemainder(dividingBy:)`,
-  ///   `formRemainder(dividingBy:)`
   mutating func formTruncatingRemainder(dividingBy other: Self)
 
   /// Returns the square root of the value, rounded to a representable value.
@@ -787,14 +771,10 @@ public protocol FloatingPoint: SignedNumeric, Strideable, Hashable {
   ///     // distance == 5.0
   ///
   /// - Returns: The square root of the value.
-  ///
-  /// - SeeAlso: `sqrt(_:)`, `formSquareRoot()`
   func squareRoot() -> Self
 
   /// Replaces this value with its square root, rounded to a representable
   /// value.
-  ///
-  /// - SeeAlso: `sqrt(_:)`, `squareRoot()`
   mutating func formSquareRoot()
 
   /// Returns the result of adding the product of the two given values to this
@@ -973,8 +953,6 @@ public protocol FloatingPoint: SignedNumeric, Strideable, Hashable {
   ///
   /// - Parameter rule: The rounding rule to use.
   /// - Returns: The integral value found by rounding using `rule`.
-  ///
-  /// - SeeAlso: `rounded()`, `round(_:)`, `FloatingPointRoundingRule`
   func rounded(_ rule: FloatingPointRoundingRule) -> Self
 
   /// Rounds the value to an integral value using the specified rounding rule.
@@ -1011,8 +989,6 @@ public protocol FloatingPoint: SignedNumeric, Strideable, Hashable {
   ///     // w1 == 7.0
   ///
   /// - Parameter rule: The rounding rule to use.
-  ///
-  /// - SeeAlso: `round()`, `rounded(_:)`, `FloatingPointRoundingRule`
   mutating func round(_ rule: FloatingPointRoundingRule)
 
   /// The least representable value that compares greater than this value.
@@ -1266,14 +1242,10 @@ public enum FloatingPointClassification {
   case negativeInfinity
 
   /// A negative value that uses the full precision of the floating-point type.
-  ///
-  /// - SeeAlso: `FloatingPoint.isNormal`
   case negativeNormal
 
   /// A negative, nonzero number that does not use the full precision of the
   /// floating-point type.
-  ///
-  /// - SeeAlso: `FloatingPoint.isSubnormal`
   case negativeSubnormal
 
   /// A value equal to zero with a negative sign.
@@ -1284,13 +1256,9 @@ public enum FloatingPointClassification {
 
   /// A positive, nonzero number that does not use the full precision of the
   /// floating-point type.
-  ///
-  /// - SeeAlso: `FloatingPoint.isSubnormal`
   case positiveSubnormal
 
   /// A positive value that uses the full precision of the floating-point type.
-  ///
-  /// - SeeAlso: `FloatingPoint.isNormal`
   case positiveNormal
 
   /// A value equal to `+infinity`.
@@ -1568,8 +1536,6 @@ public protocol BinaryFloatingPoint: FloatingPoint, ExpressibleByFloatLiteral {
   /// The raw encoding of the value's exponent field.
   ///
   /// This value is unadjusted by the type's exponent bias.
-  ///
-  /// - SeeAlso: `exponentBitCount`
   var exponentBitPattern: RawExponent { get }
 
   /// The raw encoding of the value's significand field.
@@ -1663,8 +1629,6 @@ extension FloatingPoint {
   ///
   /// - Returns: The nearest integral value, or, if two integral values are
   ///   equally close, the integral value with greater magnitude.
-  ///
-  /// - SeeAlso: `rounded(_:)`, `round()`, `FloatingPointRoundingRule`
   @_transparent
   public func rounded() -> Self {
     return rounded(.toNearestOrAwayFromZero)
@@ -1689,8 +1653,6 @@ extension FloatingPoint {
   ///
   /// To specify an alternative rule for rounding, use the `round(_:)` method
   /// instead.
-  ///
-  /// - SeeAlso: `round(_:)`, `rounded()`, `FloatingPointRoundingRule`
   @_transparent
   public mutating func round() {
     round(.toNearestOrAwayFromZero)

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -160,8 +160,6 @@ extension ${Self}: BinaryFloatingPoint {
   /// [IEEE 754 specification][spec].
   ///
   /// [spec]: http://ieeexplore.ieee.org/servlet/opac?punumber=4610933
-  ///
-  /// - SeeAlso: `init(bitPattern:)`
   public var bitPattern: UInt${bits} {
     return UInt${bits}(Builtin.bitcast_FPIEEE${bits}_Int${bits}(_value))
   }
@@ -174,8 +172,6 @@ extension ${Self}: BinaryFloatingPoint {
   /// [spec]: http://ieeexplore.ieee.org/servlet/opac?punumber=4610933
   ///
   /// - Parameter bitPattern: The integer encoding of a `${Self}` instance.
-  ///
-  /// - SeeAlso: `bitPattern`
   public init(bitPattern: UInt${bits}) {
     self.init(_bits: Builtin.bitcast_Int${bits}_FPIEEE${bits}(bitPattern._value))
   }
@@ -793,8 +789,6 @@ extension ${Self} {
   ///     // Use 'abs(_:)' instead of 'magnitude'
   ///     print("Missed the target by \(abs(margin)) meters.")
   ///     // Prints "Missed the target by 0.25 meters."
-  ///
-  /// - SeeAlso: `abs(_:)`
   @_transparent
   public var magnitude: ${Self} {
     return ${Self}(_bits: Builtin.int_fabs_FPIEEE${bits}(_value))

--- a/stdlib/public/core/Hashable.swift
+++ b/stdlib/public/core/Hashable.swift
@@ -14,7 +14,7 @@
 ///
 /// You can use any type that conforms to the `Hashable` protocol in a set or
 /// as a dictionary key. Many types in the standard library conform to
-/// `Hashable`: strings, integers, floating-point and Boolean values, and even
+/// `Hashable`: Strings, integers, floating-point and Boolean values, and even
 /// sets provide a hash value by default. Your own custom types can be
 /// hashable as well. When you define an enumeration without associated
 /// values, it gains `Hashable` conformance automatically, and you can add
@@ -23,12 +23,12 @@
 ///
 /// A hash value, provided by a type's `hashValue` property, is an integer that
 /// is the same for any two instances that compare equally. That is, for two
-/// instances `a` and `b` of the same type, if `a == b` then
+/// instances `a` and `b` of the same type, if `a == b`, then
 /// `a.hashValue == b.hashValue`. The reverse is not true: Two instances with
 /// equal hash values are not necessarily equal to each other.
 ///
 /// - Important: Hash values are not guaranteed to be equal across different
-///   executions of your program. Do not save hash values to use during a
+///   executions of your program. Do not save hash values to use in a
 ///   future execution.
 ///
 /// Conforming to the Hashable Protocol
@@ -68,9 +68,9 @@
 /// point's `x` property with the hash value of its `y` property multiplied by
 /// a prime constant.
 ///
-/// - Note: The example given above is a reasonably good hash function for a
+/// - Note: The above example above is a reasonably good hash function for a
 ///   simple type. If you're writing a hash function for a custom type, choose
-///   a hashing algorithm that is appropriate for kinds of data your type
+///   a hashing algorithm that is appropriate for the kinds of data your type
 ///   comprises. Set and dictionary performance depends on hash values that
 ///   minimize collisions for their associated element and key types,
 ///   respectively.

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -440,8 +440,6 @@ internal struct _UnmanagedAnyObjectArray {
 /// unspecified. The instances of `NSSet` and `Set` share buffer using the
 /// same copy-on-write optimization that is used when two instances of `Set`
 /// share buffer.
-///
-/// - SeeAlso: `Hashable`
 @_fixed_layout
 public struct Set<Element : Hashable> :
   SetAlgebra, Hashable, Collection, ExpressibleByArrayLiteral {
@@ -1676,8 +1674,6 @@ public func _setBridgeFromObjectiveCConditional<
 /// `NSDictionary` and `Dictionary` share buffer using the same copy-on-write
 /// optimization that is used when two instances of `Dictionary` share
 /// buffer.
-///
-/// - SeeAlso: `Hashable`
 @_fixed_layout
 public struct Dictionary<Key : Hashable, Value> :
   Collection, ExpressibleByDictionaryLiteral {
@@ -1756,8 +1752,9 @@ public struct Dictionary<Key : Hashable, Value> :
   /// of key-value tuples that might have duplicate keys. As the dictionary is
   /// built, the initializer calls the `combine` closure with the current and
   /// new values for any duplicate keys. Pass a closure as `combine` that
-  /// selects which value to use in the returned dictionary, or to combine the
-  /// values as the dictionary is initialized.
+  /// returns the value to use in the resulting dictionary: The closure can
+  /// choose between the two values, combine them to produce a new value, or
+  /// even throw an error.
   ///
   /// The following example shows how to choose the first and last values for
   /// any duplicate keys:
@@ -1786,16 +1783,16 @@ public struct Dictionary<Key : Hashable, Value> :
     try _variantBuffer.merge(keysAndValues, uniquingKeysWith: combine)
   }
 
-  /// Creates a new dictionary where the keys are the groupings returned by the
-  /// given closure and the values are arrays of the elements that returned
-  /// each specific key.
+  /// Creates a new dictionary whose keys are the groupings returned by the
+  /// given closure and whose values are arrays of the elements that returned
+  /// each key.
   ///
   /// The arrays in the "values" position of the new dictionary each contain at
   /// least one element, with the elements in the same order as the source
   /// sequence.
   ///
   /// The following example declares an array of names, and then creates a
-  /// dictionary from that array by grouping the names by their first letter:
+  /// dictionary from that array by grouping the names by first letter:
   ///
   ///     let students = ["Kofi", "Abena", "Efua", "Kweku", "Akosua"]
   ///     let studentsByLetter = Dictionary(grouping: students, by: { $0.first! })
@@ -2081,7 +2078,7 @@ public struct Dictionary<Key : Hashable, Value> :
   /// Merges the key-value pairs in the given sequence into the dictionary,
   /// using a combining closure to determine the value for any duplicate keys.
   ///
-  /// Use the `combine` closure to select which value to use in the updated
+  /// Use the `combine` closure to select a value to use in the updated
   /// dictionary, or to combine existing and new values. As the key-value
   /// pairs are merged with the dictionary, the `combine` closure is called
   /// with the current and new values for any duplicate keys that are
@@ -2115,7 +2112,7 @@ public struct Dictionary<Key : Hashable, Value> :
   /// Merges the given dictionary into this dictionary, using a combining
   /// closure to determine the value for any duplicate keys.
   ///
-  /// Use the `combine` closure to select which value to use in the updated
+  /// Use the `combine` closure to select a value to use in the updated
   /// dictionary, or to combine existing and new values. As the key-values
   /// pairs in `other` are merged with this dictionary, the `combine` closure
   /// is called with the current and new values for any duplicate keys that
@@ -2147,11 +2144,11 @@ public struct Dictionary<Key : Hashable, Value> :
       other.lazy.map { ($0, $1) }, uniquingKeysWith: combine)
   }
 
-  /// Returns a new dictionary created by merging the key-value pairs in the
-  /// given sequence into the dictionary, using a combining closure to
-  /// determine the value for any duplicate keys.
+  /// Creates a dictionary by merging key-value pairs in a sequence into the
+  /// dictionary, using a combining closure to determine the value for
+  /// duplicate keys.
   ///
-  /// Use the `combine` closure to select which value to use in the returned
+  /// Use the `combine` closure to select a value to use in the returned
   /// dictionary, or to combine existing and new values. As the key-value
   /// pairs are merged with the dictionary, the `combine` closure is called
   /// with the current and new values for any duplicate keys that are
@@ -2184,11 +2181,11 @@ public struct Dictionary<Key : Hashable, Value> :
     return result
   }
 
-  /// Returns a new dictionary created by merging the given dictionary into
-  /// this dictionary, using a combining closure to determine the value for
-  /// any duplicate keys.
+  /// Creates a dictionary by merging the given dictionary into this
+  /// dictionary, using a combining closure to determine the value for
+  /// duplicate keys.
   ///
-  /// Use the `combine` closure to select which value to use in the returned
+  /// Use the `combine` closure to select a value to use in the returned
   /// dictionary, or to combine existing and new values. As the key-value
   /// pairs in `other` are merged with this dictionary, the `combine` closure
   /// is called with the current and new values for any duplicate keys that
@@ -2345,8 +2342,6 @@ public struct Dictionary<Key : Hashable, Value> :
   ///
   /// - Parameter elements: The key-value pairs that will make up the new
   ///   dictionary. Each key in `elements` must be unique.
-  ///
-  /// - SeeAlso: `ExpressibleByDictionaryLiteral`
   @effects(readonly)
   public init(dictionaryLiteral elements: (Key, Value)...) {
     self.init(_nativeBuffer: _NativeDictionaryBuffer.fromArray(elements))
@@ -5439,11 +5434,10 @@ extension ${Self} {
 %{
 if Self == 'Set':
   SubscriptingWithIndexDoc = """\
-/// Used to access the members in an instance of `Set<Element>`."""
+/// The position of an element in a set."""
 elif Self == 'Dictionary':
   SubscriptingWithIndexDoc = """\
-/// Used to access the key-value pairs in an instance of
-/// `Dictionary<Key, Value>`.
+/// The position of a key-value pair in a dictionary.
 ///
 /// Dictionary has two subscripting interfaces:
 ///

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -260,8 +260,6 @@ def operatorComment(operator, fixedWidth):
   /// - Parameters:
   ///   - lhs: The first value to add.
   ///   - rhs: The second value to add.
-  ///
-  /// - SeeAlso: `+`
 """,
         '&-': """\
   /// Returns the difference of the two given values, discarding any overflow.
@@ -279,8 +277,6 @@ def operatorComment(operator, fixedWidth):
   /// - Parameters:
   ///   - lhs: A numeric value.
   ///   - rhs: The value to subtract from `lhs`.
-  ///
-  /// - SeeAlso: `-`
 """,
         '&*': """\
   /// Returns the product of the two given values, discarding any overflow.
@@ -375,8 +371,6 @@ def operatorComment(operator, fixedWidth):
   ///   - rhs: The number of bits to shift `lhs` to the right. If `rhs` is
   ///     outside the range `0..<lhs.bitWidth`, it is masked to produce a
   ///     value within that range.
-  ///
-  /// - SeeAlso: `>>`, `&<<`
 """,
         '&<<': """\
   /// Returns the result of shifting a value's binary representation the
@@ -406,8 +400,6 @@ def operatorComment(operator, fixedWidth):
   ///   - rhs: The number of bits to shift `lhs` to the left. If `rhs` is
   ///     outside the range `0..<lhs.bitWidth`, it is masked to produce a
   ///     value within that range.
-  ///
-  /// - SeeAlso: `<<`, `&>>`
 """,
         '>>': """\
   /// Returns the result of shifting a value's binary representation the
@@ -459,8 +451,6 @@ def operatorComment(operator, fixedWidth):
   /// - Parameters:
   ///   - lhs: The value to shift.
   ///   - rhs: The number of bits to shift `lhs` to the right.
-  ///
-  /// - SeeAlso: `<<`
 """,
         '<<': """\
   /// Returns the result of shifting a value's binary representation the
@@ -501,8 +491,6 @@ def operatorComment(operator, fixedWidth):
   /// - Parameters:
   ///   - lhs: The value to shift.
   ///   - rhs: The number of bits to shift `lhs` to the left.
-  ///
-  /// - SeeAlso: `>>`
 """,
   }
     return comments[operator]
@@ -681,8 +669,6 @@ def assignmentOperatorComment(operator, fixedWidth):
   ///   - rhs: The number of bits to shift `lhs` to the right. If `rhs` is
   ///     outside the range `0..<lhs.bitWidth`, it is masked to produce a
   ///     value within that range.
-  ///
-  /// - SeeAlso: `>>=`, `&<<=`
 """,
         '&<<': """\
   /// Returns the result of shifting a value's binary representation the
@@ -713,8 +699,6 @@ def assignmentOperatorComment(operator, fixedWidth):
   ///   - rhs: The number of bits to shift `lhs` to the left. If `rhs` is
   ///     outside the range `0..<lhs.bitWidth`, it is masked to produce a
   ///     value within that range.
-  ///
-  /// - SeeAlso: `<<=`, `&>>=`
 """,
         '>>': """\
   /// Stores the result of shifting a value's binary representation the
@@ -771,8 +755,6 @@ def assignmentOperatorComment(operator, fixedWidth):
   /// - Parameters:
   ///   - lhs: The value to shift.
   ///   - rhs: The number of bits to shift `lhs` to the right.
-  ///
-  /// - SeeAlso: `<<=`
 """,
         '<<': """\
   /// Stores the result of shifting a value's binary representation the
@@ -817,8 +799,6 @@ def assignmentOperatorComment(operator, fixedWidth):
   /// - Parameters:
   ///   - lhs: The value to shift.
   ///   - rhs: The number of bits to shift `lhs` to the left.
-  ///
-  /// - SeeAlso: `>>=`
 """,
   }
     return comments[operator]
@@ -867,8 +847,6 @@ def overflowOperationComment(operator):
   ///   product. If the `overflow` component is `.overflow`, an overflow
   ///   occurred and the `partialValue` component contains the truncated
   ///   product of this value and `rhs`.
-  ///
-  /// - SeeAlso: `multipliedFullWidth(by:)`
 """,
         '/': """\
   /// Returns the quotient of dividing this value by the given value along with
@@ -883,8 +861,6 @@ def overflowOperationComment(operator):
   ///   is `.none`, the `partialValue` component contains the entire quotient.
   ///   If the `overflow` component is `.overflow`, an overflow occurred and
   ///   the `partialValue` component contains the truncated quotient.
-  ///
-  /// - SeeAlso: `doubleWidthDivide(_:_:)`
 """,
         '%': """\
   // FIXME(integers): the comment is for division instead of remainder
@@ -900,8 +876,6 @@ def overflowOperationComment(operator):
   ///   is `.none`, the `partialValue` component contains the entire quotient.
   ///   If the `overflow` component is `.overflow`, an overflow occurred and
   ///   the `partialValue` component contains the truncated quotient.
-  ///
-  /// - SeeAlso: `doubleWidthDivide(_:_:)`
 """,
     }
     return comments[operator]
@@ -1040,8 +1014,6 @@ public protocol Numeric : Equatable, ExpressibleByIntegerLiteral {
   /// to find an absolute value. In addition, because `abs(_:)` always returns
   /// a value of the same type, even in a generic context, using the function
   /// instead of the `magnitude` property is encouraged.
-  ///
-  /// - SeeAlso: `abs(_:)`
   var magnitude: Magnitude { get }
 
 % for x in binaryArithmetic['Numeric']:
@@ -1112,8 +1084,6 @@ public protocol SignedNumeric : Numeric {
   ///     // Overflow error
   ///
   /// - Returns: The additive inverse of this value.
-  ///
-  /// - SeeAlso: `negate()`
   static prefix func - (_ operand: Self) -> Self
 
   /// Replaces this value with its additive inverse.
@@ -1124,8 +1094,6 @@ public protocol SignedNumeric : Numeric {
   ///     var x = 21
   ///     x.negate()
   ///     // x == -21
-  ///
-  /// - SeeAlso: The unary minus operator (`-`).
   mutating func negate()
 }
 
@@ -2083,8 +2051,6 @@ ${overflowOperationComment(x.operator)}
   ///   - other: A value to multiply `self` by.
   /// - Returns: A tuple containing the high and low parts of the result of
   ///   multiplying `self` and `other`.
-  ///
-  /// - SeeAlso: `multipliedReportingOverflow(by:)`
   // FIXME(integers): figure out how to return DoubleWidth<Self> or correct the
   // doc comment
   func multipliedFullWidth(by other: Self) -> (high: Self, low: Self.Magnitude)
@@ -2146,8 +2112,6 @@ ${overflowOperationComment(x.operator)}
   /// If necessary, the byte order of this value is reversed from the typical
   /// byte order of this integer type. On a big-endian platform, for any
   /// integer `x`, `x == x.bigEndian`.
-  ///
-  /// - SeeAlso: `littleEndian`
   var bigEndian: Self { get }
 
   /// The little-endian representation of this integer.
@@ -2155,8 +2119,6 @@ ${overflowOperationComment(x.operator)}
   /// If necessary, the byte order of this value is reversed from the typical
   /// byte order of this integer type. On a little-endian platform, for any
   /// integer `x`, `x == x.littleEndian`.
-  ///
-  /// - SeeAlso: `bigEndian`
   var littleEndian: Self { get }
 
   /// A representation of this integer with the byte order swapped.
@@ -2375,8 +2337,6 @@ extension UnsignedInteger {
   /// to find an absolute value. In addition, because `abs(_:)` always returns
   /// a value of the same type, even in a generic context, using the function
   /// instead of the `magnitude` property is encouraged.
-  ///
-  /// - SeeAlso: `abs(_:)`
   @_transparent
   public var magnitude: Self { return self }
 

--- a/stdlib/public/core/Join.swift
+++ b/stdlib/public/core/Join.swift
@@ -166,8 +166,6 @@ extension Sequence where Element : Sequence {
   /// - Parameter separator: A sequence to insert between each of this
   ///   sequence's elements.
   /// - Returns: The joined sequence of elements.
-  ///
-  /// - SeeAlso: `joined()`
   public func joined<Separator : Sequence>(
     separator: Separator
   ) -> JoinedSequence<Self>

--- a/stdlib/public/core/LazyCollection.swift.gyb
+++ b/stdlib/public/core/LazyCollection.swift.gyb
@@ -21,8 +21,6 @@
 /// To add new lazy collection operations, extend this protocol with
 /// methods that return lazy wrappers that are themselves
 /// `LazyCollectionProtocol`s.
-///
-/// - SeeAlso: `LazySequenceProtocol`, `LazyCollection`
 public protocol LazyCollectionProtocol
   : Collection, LazySequenceProtocol {
   /// A `Collection` that can contain the same elements as this one,
@@ -249,8 +247,6 @@ extension ${TraversalCollection} {
   /// Use the `lazy` property when chaining operations to prevent
   /// intermediate operations from allocating storage, or when you only
   /// need a part of the final collection to avoid unnecessary computation.
-  ///
-  /// - SeeAlso: `LazySequenceProtocol`, `LazyCollectionProtocol`.
   @_inlineable
   public var lazy: ${Self}<Self> {
     return ${Self}(_base: self)

--- a/stdlib/public/core/LazySequence.swift
+++ b/stdlib/public/core/LazySequence.swift
@@ -182,8 +182,6 @@ extension Sequence {
   /// A sequence containing the same elements as this sequence,
   /// but on which some operations, such as `map` and `filter`, are
   /// implemented lazily.
-  ///
-  /// - SeeAlso: `LazySequenceProtocol`, `LazySequence`
   public var lazy: LazySequence<Self> {
     return LazySequence(_base: self)
   }

--- a/stdlib/public/core/LifetimeManager.swift
+++ b/stdlib/public/core/LifetimeManager.swift
@@ -16,8 +16,9 @@
 /// - Parameters:
 ///   - x: An instance to preserve until the execution of `body` is completed.
 ///   - body: A closure to execute that depends on the lifetime of `x` being
-///     extended.
-/// - Returns: The return value of `body`, if any.
+///     extended. If `body` has a return value, that value is also used as the
+///     return value for the `withExtendedLifetime(_:_:)` method.
+/// - Returns: The return value, if any, of the `body` closure parameter.
 @_inlineable
 public func withExtendedLifetime<T, Result>(
   _ x: T, _ body: () throws -> Result
@@ -32,8 +33,9 @@ public func withExtendedLifetime<T, Result>(
 /// - Parameters:
 ///   - x: An instance to preserve until the execution of `body` is completed.
 ///   - body: A closure to execute that depends on the lifetime of `x` being
-///     extended.
-/// - Returns: The return value of `body`, if any.
+///     extended. If `body` has a return value, that value is also used as the
+///     return value for the `withExtendedLifetime(_:_:)` method.
+/// - Returns: The return value, if any, of the `body` closure parameter.
 @_inlineable
 public func withExtendedLifetime<T, Result>(
   _ x: T, _ body: (T) throws -> Result
@@ -53,10 +55,10 @@ extension String {
   ///
   /// - Parameter body: A closure with a pointer parameter that points to a
   ///   null-terminated sequence of UTF-8 code units. If `body` has a return
-  ///   value, it is used as the return value for the `withCString(_:)`
-  ///   method. The pointer argument is valid only for the duration of the
-  ///   method's execution.
-  /// - Returns: The return value of the `body` closure parameter, if any.
+  ///   value, that value is also used as the return value for the
+  ///   `withCString(_:)` method. The pointer argument is valid only for the
+  ///   duration of the method's execution.
+  /// - Returns: The return value, if any, of the `body` closure parameter.
   @_inlineable
   public func withCString<Result>(
     _ body: (UnsafePointer<Int8>) throws -> Result
@@ -87,12 +89,11 @@ public func _fixLifetime<T>(_ x: T) {
 /// - Parameters:
 ///   - arg: An instance to temporarily use via pointer.
 ///   - body: A closure that takes a mutable pointer to `arg` as its sole
-///     argument. If the closure has a return value, it is used as the return
-///     value of the `withUnsafeMutablePointer(to:_:)` function. The pointer
-///     argument is valid only for the duration of the function's execution.
-/// - Returns: The return value of the `body` closure, if any.
-///
-/// - SeeAlso: `withUnsafePointer(to:_:)`
+///     argument. If the closure has a return value, that value is also used
+///     as the return value of the `withUnsafeMutablePointer(to:_:)` function.
+///     The pointer argument is valid only for the duration of the function's
+///     execution.
+/// - Returns: The return value, if any, of the `body` closure.
 @_inlineable
 public func withUnsafeMutablePointer<T, Result>(
   to arg: inout T,
@@ -115,12 +116,10 @@ public func withUnsafeMutablePointer<T, Result>(
 /// - Parameters:
 ///   - arg: An instance to temporarily use via pointer.
 ///   - body: A closure that takes a pointer to `arg` as its sole argument. If
-///     the closure has a return value, it is used as the return value of the
-///     `withUnsafePointer(to:_:)` function. The pointer argument is valid
-///     only for the duration of the function's execution.
-/// - Returns: The return value of the `body` closure, if any.
-///
-/// - SeeAlso: `withUnsafeMutablePointer(to:_:)`
+///     the closure has a return value, that value is also used as the return
+///     value of the `withUnsafePointer(to:_:)` function. The pointer argument
+///     is valid only for the duration of the function's execution.
+/// - Returns: The return value, if any, of the `body` closure.
 @_inlineable
 public func withUnsafePointer<T, Result>(
   to arg: inout T,

--- a/stdlib/public/core/MemoryLayout.swift
+++ b/stdlib/public/core/MemoryLayout.swift
@@ -48,8 +48,6 @@ public enum MemoryLayout<T> {
   ///
   /// When allocating memory for multiple instances of `T` using an unsafe
   /// pointer, use a multiple of the type's stride instead of its size.
-  ///
-  /// - SeeAlso: `stride`
   @_transparent
   public static var size: Int {
     return Int(Builtin.sizeof(T.self))
@@ -100,8 +98,6 @@ extension MemoryLayout {
   ///
   /// - Parameter value: A value representative of the type to describe.
   /// - Returns: The size, in bytes, of the given value's type.
-  ///
-  /// - SeeAlso: `MemoryLayout.size`
   @_transparent
   public static func size(ofValue value: T) -> Int {
     return MemoryLayout.size
@@ -130,8 +126,6 @@ extension MemoryLayout {
   ///
   /// - Parameter value: A value representative of the type to describe.
   /// - Returns: The stride, in bytes, of the given value's type.
-  ///
-  /// - SeeAlso: `MemoryLayout.stride`
   @_transparent
   public static func stride(ofValue value: T) -> Int {
     return MemoryLayout.stride
@@ -157,8 +151,6 @@ extension MemoryLayout {
   /// - Parameter value: A value representative of the type to describe.
   /// - Returns: The default memory alignment, in bytes, of the given value's
   ///   type. This value is always positive.
-  ///
-  /// - SeeAlso: `MemoryLayout.alignment`
   @_transparent
   public static func alignment(ofValue value: T) -> Int {
     return MemoryLayout.alignment

--- a/stdlib/public/core/Mirror.swift
+++ b/stdlib/public/core/Mirror.swift
@@ -856,8 +856,6 @@ extension String {
   ///
   ///     print(String(describing: p))
   ///     // Prints "(21, 30)"
-  ///
-  /// - SeeAlso: `String.init<Subject>(reflecting: Subject)`
   public init<Subject>(describing instance: Subject) {
     self.init()
     _print_unlocked(instance, &self)
@@ -907,8 +905,6 @@ extension String {
   ///
   ///     print(String(reflecting: p))
   ///     // Prints "Point(x: 21, y: 30)"
-  ///
-  /// - SeeAlso: `String.init<Subject>(Subject)`
   public init<Subject>(reflecting subject: Subject) {
     self.init()
     _debugPrint_unlocked(subject, &self)

--- a/stdlib/public/core/MutableCollection.swift
+++ b/stdlib/public/core/MutableCollection.swift
@@ -291,7 +291,7 @@ public protocol MutableCollection : _MutableIndexable, Collection
 
   /// Exchanges the values at the specified indices of the collection.
   ///
-  /// Both parameters must be valid indices of the collection that are not
+  /// Both parameters must be valid indices of the collection and not
   /// equal to `endIndex`. Passing the same index as both `i` and `j` has no
   /// effect.
   ///

--- a/stdlib/public/core/ObjectIdentifier.swift
+++ b/stdlib/public/core/ObjectIdentifier.swift
@@ -23,8 +23,6 @@ public struct ObjectIdentifier : Hashable {
   /// The hash value is not guaranteed to be stable across different
   /// invocations of the same program.  Do not persist the hash value across
   /// program runs.
-  ///
-  /// - SeeAlso: `Hashable`
   public var hashValue: Int {
     return Int(Builtin.ptrtoint_Word(_value))
   }

--- a/stdlib/public/core/OptionSet.swift
+++ b/stdlib/public/core/OptionSet.swift
@@ -82,8 +82,6 @@
 ///         print("Add more to your cart for free priority shipping!")
 ///     }
 ///     // Prints "You've earned free priority shipping!"
-///
-/// - SeeAlso: `FixedWidthInteger`, `SetAlgebra`
 public protocol OptionSet : SetAlgebra, RawRepresentable {
   // We can't constrain the associated Element type to be the same as
   // Self, but we can do almost as well with a default and a

--- a/stdlib/public/core/OutputStream.swift
+++ b/stdlib/public/core/OutputStream.swift
@@ -144,8 +144,6 @@ typealias Streamable = TextOutputStreamable
 ///
 ///     print(p)
 ///     // Prints "(21, 30)"
-///
-/// - SeeAlso: `String.init<T>(T)`, `CustomDebugStringConvertible`
 public protocol CustomStringConvertible {
   /// A textual representation of this instance.
   ///
@@ -232,8 +230,6 @@ public protocol LosslessStringConvertible : CustomStringConvertible {
 ///
 ///     print(String(reflecting: p))
 ///     // Prints "Point(x: 21, y: 30)"
-///
-/// - SeeAlso: `String.init<T>(reflecting: T)`, `CustomStringConvertible`
 public protocol CustomDebugStringConvertible {
   /// A textual representation of this instance, suitable for debugging.
   var debugDescription: String { get }

--- a/stdlib/public/core/Policy.swift
+++ b/stdlib/public/core/Policy.swift
@@ -248,12 +248,8 @@ public typealias _MaxBuiltinFloatType = Builtin.FPIEEE64
 ///         print("'obj' does not have a 'getIntegerValue()' method")
 ///     }
 ///     // Prints "The value of 'obj' is 100"
-///
-/// - SeeAlso: `AnyClass`
 #else
 /// The protocol to which all classes implicitly conform.
-///
-/// - SeeAlso: `AnyClass`
 #endif
 public typealias AnyObject = Builtin.AnyObject
 
@@ -284,8 +280,6 @@ public typealias AnyObject = Builtin.AnyObject
 ///
 ///     print(getDefaultValue(NSString.self))
 ///     // Prints "nil"
-///
-/// - SeeAlso: `AnyObject`
 public typealias AnyClass = AnyObject.Type
 
 /// A type that supports standard bitwise arithmetic operators.
@@ -377,8 +371,6 @@ public typealias AnyClass = AnyObject.Type
 /// - `x & Self.allZeros == .allZeros`
 /// - `x & ~Self.allZeros == x`
 /// - `~x == x ^ ~Self.allZeros`
-///
-/// - SeeAlso: `OptionSet`
 @available(swift, deprecated: 3.1, obsoleted: 4.0, message: "Use FixedWidthInteger protocol instead")
 public typealias BitwiseOperations = _BitwiseOperations
 

--- a/stdlib/public/core/Print.swift
+++ b/stdlib/public/core/Print.swift
@@ -49,9 +49,6 @@
 ///     space (`" "`).
 ///   - terminator: The string to print after all items have been printed. The
 ///     default is a newline (`"\n"`).
-///
-/// - SeeAlso: `debugPrint(_:separator:terminator:)`, `TextOutputStreamable`,
-///   `CustomStringConvertible`, `CustomDebugStringConvertible`
 @inline(never)
 @_semantics("stdlib_binary_only")
 public func print(
@@ -112,9 +109,6 @@ public func print(
 ///     space (`" "`).
 ///   - terminator: The string to print after all items have been printed. The
 ///     default is a newline (`"\n"`).
-///
-/// - SeeAlso: `print(_:separator:terminator:)`, `TextOutputStreamable`,
-///   `CustomStringConvertible`, `CustomDebugStringConvertible`
 @inline(never)
 @_semantics("stdlib_binary_only")
 public func debugPrint(
@@ -171,11 +165,6 @@ public func debugPrint(
 ///     default is a newline (`"\n"`).
 ///   - output: An output stream to receive the text representation of each
 ///     item.
-///
-/// - SeeAlso: `print(_:separator:terminator:)`,
-///   `debugPrint(_:separator:terminator:to:)`,
-///   `TextOutputStream`, `TextOutputStreamable`,
-///   `CustomStringConvertible`, `CustomDebugStringConvertible`
 @inline(__always)
 public func print<Target : TextOutputStream>(
   _ items: Any...,
@@ -224,11 +213,6 @@ public func print<Target : TextOutputStream>(
 ///     default is a newline (`"\n"`).
 ///   - output: An output stream to receive the text representation of each
 ///     item.
-///
-/// - SeeAlso: `debugPrint(_:separator:terminator:)`,
-///   `print(_:separator:terminator:to:)`,
-///   `TextOutputStream`, `TextOutputStreamable`,
-///   `CustomStringConvertible`, `CustomDebugStringConvertible`
 @inline(__always)
 public func debugPrint<Target : TextOutputStream>(
   _ items: Any...,

--- a/stdlib/public/core/Range.swift.gyb
+++ b/stdlib/public/core/Range.swift.gyb
@@ -104,8 +104,6 @@ public enum _DisabledRangeIndex_ {}
 ///     }
 ///     print(brackets(-99..<100, 0))
 ///     // Prints "0"
-///
-/// - SeeAlso: `CountableClosedRange`, `Range`, `ClosedRange`
 @_fixed_layout
 public struct CountableRange<Bound> : RandomAccessCollection
   where
@@ -342,8 +340,6 @@ extension CountableRange
 ///     let empty = 0.0..<0.0
 ///     print(empty.contains(0.0))          // Prints "false"
 ///     print(empty.isEmpty)                // Prints "true"
-///
-/// - SeeAlso: `CountableRange`, `ClosedRange`, `CountableClosedRange`
 @_fixed_layout
 public struct Range<
   Bound : Comparable
@@ -855,21 +851,22 @@ public struct PartialRangeFrom<Bound: Comparable>: RangeExpression {
   }
 }
 
-/// A partial interval extending upward from a lower bound.
+/// A partial interval extending upward from a lower bound that forms a
+/// sequence of increasing values.
 ///
-/// You create `PartialRangeFrom` instances by using the postfix range operator
-/// (postfix `...`).
+/// You create `CountablePartialRangeFrom` instances by using the postfix range
+/// operator (postfix `...`).
 ///
 ///     let atLeastFive = 5.0...
 ///
-/// You can use a `PartialRangeFrom` instance to quickly check if a value is
+/// You can use a countable partial range to quickly check if a value is
 /// contained in a particular range of values. For example:
 ///
 ///     atLeastFive.contains(4.0)     // false
 ///     atLeastFive.contains(5.0)     // true
 ///     atLeastFive.contains(6.0)     // true
 ///
-/// You can use a `PartialRangeFrom` instance of a collection's indices to
+/// You can use a countable partial range of a collection's indices to
 /// represent the range from the partial range's lower bound up to the end of
 /// the collection.
 ///
@@ -885,9 +882,8 @@ public struct PartialRangeFrom<Bound: Comparable>: RangeExpression {
 /// Using a Partial Range as a Sequence
 /// ===================================
 ///
-/// You can iterate over a `PartialRangeFrom` instance using a `for`-`in` loop,
-/// or call any sequence method that doesn't require that the sequence is
-/// finite.
+/// You can iterate over a countable partial range using a `for`-`in` loop, or
+/// call any sequence method that doesn't require that the sequence is finite.
 ///
 ///     func isTheMagicNumber(_ x: Int) -> Bool {
 ///         return x == 3
@@ -906,8 +902,8 @@ public struct PartialRangeFrom<Bound: Comparable>: RangeExpression {
 ///     // "3 is the magic number!"
 ///
 /// Because a `CountablePartialRangeFrom` sequence counts upward indefinitely,
-/// do not use one with methods such as `map(_:)`, `filter(_:)`, or
-/// `suffix(_:)` that read the entire sequence before returning. It is safe to
+/// do not use one with methods that read the entire sequence before
+/// returning, such as `map(_:)`, `filter(_:)`, or `suffix(_:)`. It is safe to
 /// use operations that put an upper limit on the number of elements they
 /// access, such as `prefix(_:)` or `dropFirst(_:)`, and operations that you
 /// can guarantee will terminate, such as passing a closure you know will

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -322,8 +322,6 @@ public protocol IteratorProtocol {
 /// makes no other requirements about element access, so routines that
 /// traverse a sequence should be considered O(*n*) unless documented
 /// otherwise.
-///
-/// - SeeAlso: `IteratorProtocol`, `Collection`
 public protocol Sequence {
   /// A type that provides the sequence's iteration interface and
   /// encapsulates its iteration state.
@@ -1291,7 +1289,6 @@ extension Sequence where
   ///   that satisfy `predicate`.
   ///
   /// - Complexity: O(*n*), where *n* is the length of the collection.
-  /// - SeeAlso: `prefix(while:)`
   @_inlineable
   public func drop(
     while predicate: (Element) throws -> Bool
@@ -1351,7 +1348,6 @@ extension Sequence where
   ///   satisfy `predicate`.
   ///
   /// - Complexity: O(*n*), where *n* is the length of the collection.
-  /// - SeeAlso: `drop(while:)`
   @_inlineable
   public func prefix(
     while predicate: (Element) throws -> Bool

--- a/stdlib/public/core/SequenceAlgorithms.swift.gyb
+++ b/stdlib/public/core/SequenceAlgorithms.swift.gyb
@@ -61,16 +61,16 @@ extension Sequence {
   ///     // Prints "3: 'f'"
   ///     // Prints "4: 't'"
   ///
-  /// When enumerating a collection, the integer part of each pair is a counter
-  /// for the enumeration, not necessarily the index of the paired value.
-  /// These counters can only be used as indices in instances of zero-based,
+  /// When you enumerate a collection, the integer part of each pair is a counter
+  /// for the enumeration, but is not necessarily the index of the paired value.
+  /// These counters can be used as indices only in instances of zero-based,
   /// integer-indexed collections, such as `Array` and `ContiguousArray`. For
   /// other collections the counters may be out of range or of the wrong type
   /// to use as an index. To iterate over the elements of a collection with its
   /// indices, use the `zip(_:_:)` function.
   ///
   /// This example iterates over the indices and elements of a set, building a
-  /// list of indices of names with five or fewer letters.
+  /// list consisting of indices of names with five or fewer letters.
   ///
   ///     let names: Set = ["Sofia", "Camilla", "Martina", "Mateo", "Nicolás"]
   ///     var shorterIndices: [SetIndex<String>] = []
@@ -127,8 +127,6 @@ ${orderingExplanation}
   /// - Returns: The sequence's minimum element, according to
   ///   `areInIncreasingOrder`. If the sequence has no elements, returns
   ///   `nil`.
-  ///
-  /// - SeeAlso: `min()`
 %   else:
   /// Returns the minimum element in the sequence.
   ///
@@ -141,8 +139,6 @@ ${orderingExplanation}
   ///
   /// - Returns: The sequence's minimum element. If the sequence has no
   ///   elements, returns `nil`.
-  ///
-  /// - SeeAlso: `min(by:)`
 %   end
   @_inlineable
   @warn_unqualified_access
@@ -181,8 +177,6 @@ ${orderingExplanation}
   ///   otherwise, `false`.
   /// - Returns: The sequence's maximum element if the sequence is not empty;
   ///   otherwise, `nil`.
-  ///
-  /// - SeeAlso: `max()`
 %   else:
   /// Returns the maximum element in the sequence.
   ///
@@ -195,8 +189,6 @@ ${orderingExplanation}
   ///
   /// - Returns: The sequence's maximum element. If the sequence has no
   ///   elements, returns `nil`.
-  ///
-  /// - SeeAlso: `max(by:)`
 %   end
   @_inlineable
   @warn_unqualified_access
@@ -244,8 +236,6 @@ ${equivalenceExplanation}
   /// - Returns: `true` if the initial elements of the sequence are equivalent
   ///   to the elements of `possiblePrefix`; otherwise, `false`. If
   ///   `possiblePrefix` has no elements, the return value is `true`.
-  ///
-  /// - SeeAlso: `starts(with:)`
 %   else:
   /// Returns a Boolean value indicating whether the initial elements of the
   /// sequence are the same as the elements in another sequence.
@@ -269,8 +259,6 @@ ${equivalenceExplanation}
   /// - Returns: `true` if the initial elements of the sequence are the same as
   ///   the elements of `possiblePrefix`; otherwise, `false`. If
   ///   `possiblePrefix` has no elements, the return value is `true`.
-  ///
-  /// - SeeAlso: `starts(with:by:)`
 %   end
   @_inlineable
   public func starts<PossiblePrefix>(
@@ -325,8 +313,6 @@ ${equivalenceExplanation}
   ///     are equivalent; otherwise, `false`.
   /// - Returns: `true` if this sequence and `other` contain equivalent items,
   ///   using `areEquivalent` as the equivalence test; otherwise, `false.`
-  ///
-  /// - SeeAlso: `elementsEqual(_:)`
 %   else:
   /// Returns a Boolean value indicating whether this sequence and another
   /// sequence contain the same elements in the same order.
@@ -347,8 +333,6 @@ ${equivalenceExplanation}
   /// - Parameter other: A sequence to compare to this sequence.
   /// - Returns: `true` if this sequence and `other` contain the same elements
   ///   in the same order.
-  ///
-  /// - SeeAlso: `elementsEqual(_:by:)`
 %   end
   @_inlineable
   public func elementsEqual<OtherSequence>(
@@ -410,7 +394,6 @@ ${orderingExplanation}
   ///   ordering, which has no connection to Unicode.  If you are sorting
   ///   strings to present to the end user, use `String` APIs that perform
   ///   localized comparison instead.
-  /// - SeeAlso: `lexicographicallyPrecedes(_:)`
 %   else:
   /// Returns a Boolean value indicating whether the sequence precedes another
   /// sequence in a lexicographical (dictionary) ordering, using the
@@ -435,7 +418,6 @@ ${orderingExplanation}
   ///   ordering, which has no connection to Unicode.  If you are sorting
   ///   strings to present to the end user, use `String` APIs that
   ///   perform localized comparison.
-  /// - SeeAlso: `lexicographicallyPrecedes(_:by:)`
 %   end
   @_inlineable
   public func lexicographicallyPrecedes<OtherSequence>(
@@ -675,7 +657,6 @@ extension Sequence {
   ///
   /// - Complexity: O(*m* + *n*), where *m* is the length of this sequence
   ///   and *n* is the length of the result.
-  /// - SeeAlso: `joined()`, `map(_:)`
   @_inlineable
   public func flatMap<SegmentOfResult : Sequence>(
     _ transform: (Element) throws -> SegmentOfResult

--- a/stdlib/public/core/SetAlgebra.swift
+++ b/stdlib/public/core/SetAlgebra.swift
@@ -50,8 +50,6 @@
 /// - `x.isStrictSuperset(of: y)` if and only if
 ///   `x.isSuperset(of: y) && x != y`
 /// - `x.isStrictSubset(of: y)` if and only if `x.isSubset(of: y) && x != y`
-/// 
-/// - SeeAlso: `OptionSet`, `Set`
 public protocol SetAlgebra : Equatable, ExpressibleByArrayLiteral {
   // FIXME: write tests for SetAlgebra
   

--- a/stdlib/public/core/StaticString.swift
+++ b/stdlib/public/core/StaticString.swift
@@ -126,10 +126,10 @@ public struct StaticString
   ///
   /// - Parameter body: A closure that takes a buffer pointer to the static
   ///   string's UTF-8 code unit sequence as its sole argument. If the closure
-  ///   has a return value, it is used as the return value of the
+  ///   has a return value, that value is also used as the return value of the
   ///   `withUTF8Buffer(invoke:)` method. The pointer argument is valid only
   ///   for the duration of the method's execution.
-  /// - Returns: The return value of the `body` closure, if any.
+  /// - Returns: The return value, if any, of the `body` closure.
   public func withUTF8Buffer<R>(
     _ body: (UnsafeBufferPointer<UInt8>) -> R) -> R {
     if hasPointerRepresentation {

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -81,10 +81,10 @@ public protocol StringProtocol
   ///
   /// - Parameter body: A closure with a pointer parameter that points to a
   ///   null-terminated sequence of UTF-8 code units. If `body` has a return
-  ///   value, it is used as the return value for the `withCString(_:)`
-  ///   method. The pointer argument is valid only for the duration of the
-  ///   method's execution.
-  /// - Returns: The return value of the `body` closure parameter, if any.
+  ///   value, that value is also used as the return value for the
+  ///   `withCString(_:)` method. The pointer argument is valid only for the
+  ///   duration of the method's execution.
+  /// - Returns: The return value, if any, of the `body` closure parameter.
   func withCString<Result>(
     _ body: (UnsafePointer<CChar>) throws -> Result) rethrows -> Result
 
@@ -98,12 +98,12 @@ public protocol StringProtocol
   /// - Parameters:
   ///   - body: A closure with a pointer parameter that points to a
   ///     null-terminated sequence of code units. If `body` has a return
-  ///     value, it is used as the return value for the
+  ///     value, that value is also used as the return value for the
   ///     `withCString(encodedAs:_:)` method. The pointer argument is valid
   ///     only for the duration of the method's execution.
   ///   - targetEncoding: The encoding in which the code units should be
   ///     interpreted.
-  /// - Returns: The return value of the `body` closure parameter, if any.
+  /// - Returns: The return value, if any, of the `body` closure parameter.
   func withCString<Result, Encoding: Unicode.Encoding>(
     encodedAs targetEncoding: Encoding.Type,
     _ body: (UnsafePointer<Encoding.CodeUnit>) throws -> Result
@@ -294,12 +294,12 @@ extension String {
   /// - Parameters:
   ///   - body: A closure with a pointer parameter that points to a
   ///     null-terminated sequence of code units. If `body` has a return
-  ///     value, it is used as the return value for the
+  ///     value, that value is also used as the return value for the
   ///     `withCString(encodedAs:_:)` method. The pointer argument is valid
   ///     only for the duration of the method's execution.
   ///   - targetEncoding: The encoding in which the code units should be
   ///     interpreted.
-  /// - Returns: The return value of the `body` closure parameter, if any.
+  /// - Returns: The return value, if any, of the `body` closure parameter.
   public func withCString<Result, TargetEncoding: Unicode.Encoding>(
     encodedAs targetEncoding: TargetEncoding.Type,
     _ body: (UnsafePointer<TargetEncoding.CodeUnit>) throws -> Result
@@ -313,39 +313,41 @@ extension String {
 
 /// A Unicode string value that is a collection of characters.
 ///
-/// A string is a series of characters, such as `"Swift"`. Strings in Swift are
-/// Unicode correct, locale insensitive, and designed to be efficient. The
-/// `String` type bridges with the Objective-C class `NSString` and offers
-/// interoperability with C functions that works with strings.
+/// A string is a series of characters, such as `"Swift"`, that forms a
+/// collection. Strings in Swift are Unicode correct and locale insensitive,
+/// and are designed to be efficient. The `String` type bridges with the
+/// Objective-C class `NSString` and offers interoperability with C functions
+/// that works with strings.
 ///
 /// You can create new strings using string literals or string interpolations.
-/// A string literal is a series of characters enclosed in quotes.
+/// A *string literal* is a series of characters enclosed in quotes.
 ///
 ///     let greeting = "Welcome!"
 ///
-/// String interpolations are string literals that evaluate any included
+/// *String interpolations* are string literals that evaluate any included
 /// expressions and convert the results to string form. String interpolations
-/// are an easy way to build a string from multiple pieces. Wrap each
+/// give you an easy way to build a string from multiple pieces. Wrap each
 /// expression in a string interpolation in parentheses, prefixed by a
 /// backslash.
 ///
 ///     let name = "Rosa"
 ///     let personalizedGreeting = "Welcome, \(name)!"
+///     // personalizedGreeting == "Welcome, Rosa!"
 ///
 ///     let price = 2
 ///     let number = 3
 ///     let cookiePrice = "\(number) cookies: $\(price * number)."
+///     // cookiePrice == "3 cookies: $6."
 ///
 /// Combine strings using the concatenation operator (`+`).
 ///
 ///     let longerGreeting = greeting + " We're glad you're here!"
-///     print(longerGreeting)
-///     // Prints "Welcome! We're glad you're here!"
+///     // longerGreeting == "Welcome! We're glad you're here!"
 ///
-/// Multiline string literals are enclosed in three double quotes (`"""`), with
-/// each delimiter on its own line. Indentation is stripped from each line of
-/// a multiline string literal to match the indentation of the closing
-/// delimiter.
+/// Multiline string literals are enclosed in three double quotation marks
+/// (`"""`), with each delimiter on its own line. Indentation is stripped from
+/// each line of a multiline string literal to match the indentation of the
+/// closing delimiter.
 ///
 ///     let banner = """
 ///               __,
@@ -364,16 +366,15 @@ extension String {
 ///
 ///     var otherGreeting = greeting
 ///     otherGreeting += " Have a nice time!"
-///     print(otherGreeting)
-///     // Prints "Welcome! Have a nice time!"
+///     // otherGreeting == "Welcome! Have a nice time!"
 ///
 ///     print(greeting)
 ///     // Prints "Welcome!"
 ///
 /// Comparing strings for equality using the equal-to operator (`==`) or a
-/// relational operator (like `<` and `>=`) is always performed using the
-/// Unicode canonical representation. This means that different
-/// representations of a string compare as being equal.
+/// relational operator (like `<` or `>=`) is always performed using Unicode
+/// canonical representation. As a result, different representations of a
+/// string compare as being equal.
 ///
 ///     let cafe1 = "Cafe\u{301}"
 ///     let cafe2 = "Café"
@@ -384,8 +385,8 @@ extension String {
 /// include an accent, so `"e\u{301}"` has the same canonical representation
 /// as the single Unicode code point `"é"`.
 ///
-/// Basic string operations are not sensitive to locale settings. This ensures
-/// that string comparisons and other operations always have a single, stable
+/// Basic string operations are not sensitive to locale settings, ensuring that
+/// string comparisons and other operations always have a single, stable
 /// result, allowing strings to be used as keys in `Dictionary` instances and
 /// for other purposes.
 ///
@@ -396,7 +397,7 @@ extension String {
 /// human-readable characters. Many individual characters, such as "é", "김",
 /// and "🇮🇳", can be made up of multiple Unicode code points. These code points
 /// are combined by Unicode's boundary algorithms into extended grapheme
-/// clusters, represented by Swift's `Character` type. Each element of a
+/// clusters, represented by the Swift `Character` type. Each element of a
 /// string is represented by a `Character` instance.
 ///
 /// For example, to retrieve the first word of a longer string, you can search
@@ -421,8 +422,7 @@ extension String {
 /// If you need to access the contents of a string as encoded in different
 /// Unicode encodings, use one of the string's `unicodeScalars`, `utf16`, or
 /// `utf8` properties. Each property provides access to a view of the string
-/// as a series of code units, each encoded in a different Unicode
-/// representation.
+/// as a series of code units, each encoded in a different Unicode encoding.
 ///
 /// To demonstrate the different views available for every string, the
 /// following examples use this `String` instance:
@@ -432,7 +432,7 @@ extension String {
 ///     // Prints "Café du 🌍"
 ///
 /// The `cafe` string is a collection of the nine characters that are visible
-/// in the printed string above.
+/// when the string is displayed.
 ///
 ///     print(cafe.count)
 ///     // Prints "9"
@@ -473,9 +473,7 @@ extension String {
 ///     // Prints "[67, 97, 102, 101, 769, 32, 100, 117, 32, 55356, 57101]"
 ///
 /// The elements of the `utf16` view are the code units for the string when
-/// encoded in UTF-16.
-///
-/// The elements of this collection match those accessed through indexed
+/// encoded in UTF-16. These elements match those accessed through indexed
 /// `NSString` APIs.
 ///
 ///     let nscafe = cafe as NSString
@@ -529,7 +527,7 @@ extension String {
 ///     // Prints "1"
 ///
 /// On the other hand, an emoji flag character is constructed from a pair of
-/// Unicode scalars values, like `"\u{1F1F5}"` and `"\u{1F1F7}"`. Each of
+/// Unicode scalar values, like `"\u{1F1F5}"` and `"\u{1F1F7}"`. Each of
 /// these scalar values, in turn, is too large to fit into a single UTF-16 or
 /// UTF-8 code unit. As a result, each view of the string `"🇵🇷"` reports a
 /// different length.
@@ -545,7 +543,7 @@ extension String {
 ///     // Prints "8"
 ///
 /// To check whether a string is empty, use its `isEmpty` property instead of
-/// comparing the length of one of the views to `0`. Unlike `isEmpty`,
+/// comparing the length of one of the views to `0`. Unlike with `isEmpty`,
 /// calculating a view's `count` property requires iterating through the
 /// elements of the string.
 ///
@@ -585,7 +583,7 @@ extension String {
 /// exponential growth strategy that makes appending to a string a constant
 /// time operation when averaged over many append operations.
 ///
-/// Bridging between String and NSString
+/// Bridging Between String and NSString
 /// ====================================
 ///
 /// Any `String` instance can be bridged to `NSString` using the type-cast
@@ -594,7 +592,7 @@ extension String {
 /// subclass of `NSString` can become a `String` instance, there are no
 /// guarantees about representation or efficiency when a `String` instance is
 /// backed by `NSString` storage. Because `NSString` is immutable, it is just
-/// as though the storage was shared by a copy: The first in any sequence of
+/// as though the storage was shared by a copy. The first in any sequence of
 /// mutating operations causes elements to be copied into unique, contiguous
 /// storage which may cost O(*n*) time and space, where *n* is the length of
 /// the string's encoded representation (or more, if the underlying `NSString`
@@ -609,9 +607,6 @@ extension String {
 /// [clusters]: http://www.unicode.org/glossary/#extended_grapheme_cluster
 /// [scalars]: http://www.unicode.org/glossary/#unicode_scalar_value
 /// [equivalence]: http://www.unicode.org/glossary/#canonical_equivalent
-///
-/// - SeeAlso: `String.CharacterView`, `String.UnicodeScalarView`,
-///   `String.UTF16View`, `String.UTF8View`
 @_fixed_layout
 public struct String {
   /// Creates an empty string.

--- a/stdlib/public/core/StringCharacterView.swift
+++ b/stdlib/public/core/StringCharacterView.swift
@@ -117,10 +117,10 @@ extension String {
   ///     // Prints "this happened, more or less."
   ///
   /// - Parameter body: A closure that takes a character view as its argument.
-  ///   The `CharacterView` argument is valid only for the duration of the
-  ///   closure's execution.
-  /// - Returns: The return value of the `body` closure, if any, is the return
-  ///   value of this method.
+  ///   If `body` has a return value, that value is also used as the return
+  ///   value for the `withMutableCharacters(_:)` method. The `CharacterView`
+  ///   argument is valid only for the duration of the closure's execution.
+  /// - Returns: The return value, if any, of the `body` closure parameter.
   public mutating func withMutableCharacters<R>(
     _ body: (inout CharacterView) -> R
   ) -> R {

--- a/stdlib/public/core/StringInterpolation.swift
+++ b/stdlib/public/core/StringInterpolation.swift
@@ -39,8 +39,6 @@ extension String : _ExpressibleByStringInterpolation {
   ///
   /// Do not call this initializer directly. It is used by the compiler when
   /// interpreting string interpolations.
-  ///
-  /// - SeeAlso: `ExpressibleByStringInterpolation`
   @_inlineable
   public init<T>(stringInterpolationSegment expr: T) {
     self = String(describing: expr)
@@ -50,8 +48,6 @@ extension String : _ExpressibleByStringInterpolation {
   ///
   /// Do not call this initializer directly. It is used by the compiler when
   /// interpreting string interpolations.
-  ///
-  /// - SeeAlso: `ExpressibleByStringInterpolation`
   @_inlineable
   public init<T: TextOutputStreamable> (stringInterpolationSegment expr: T) {
     self = _toStringReadOnlyStreamable(expr)
@@ -61,8 +57,6 @@ extension String : _ExpressibleByStringInterpolation {
   ///
   /// Do not call this initializer directly. It is used by the compiler when
   /// interpreting string interpolations.
-  ///
-  /// - SeeAlso: `ExpressibleByStringInterpolation`
   @_inlineable
   public init<T: CustomStringConvertible> (stringInterpolationSegment expr: T) {
     self = _toStringReadOnlyPrintable(expr)
@@ -72,8 +66,6 @@ extension String : _ExpressibleByStringInterpolation {
   ///
   /// Do not call this initializer directly. It is used by the compiler when
   /// interpreting string interpolations.
-  ///
-  /// - SeeAlso: `ExpressibleByStringInterpolation`
   public init<T: TextOutputStreamable & CustomStringConvertible> (stringInterpolationSegment expr: T) {
     self = _toStringReadOnlyStreamable(expr)
   }

--- a/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
+++ b/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
@@ -97,7 +97,6 @@ extension String : StringProtocol {
   ///   If `n` is negative, this is the same value as the result of `-n` calls
   ///   to `index(before:)`.
   ///
-  /// - SeeAlso: `index(_:offsetBy:limitedBy:)`
   /// - Complexity: O(*n*), where *n* is the absolute value of `n`.
   public func index(_ i: Index, offsetBy n: IndexDistance) -> Index {
     return characters.index(i, offsetBy: n)
@@ -139,7 +138,6 @@ extension String : StringProtocol {
   ///   would be beyond `limit` in the direction of movement. In that case,
   ///   the method returns `nil`.
   ///
-  /// - SeeAlso: `index(_:offsetBy:)`
   /// - Complexity: O(*n*), where *n* is the absolute value of `n`.
   public func index(
     _ i: Index, offsetBy n: IndexDistance, limitedBy limit: Index

--- a/stdlib/public/core/Substring.swift.gyb
+++ b/stdlib/public/core/Substring.swift.gyb
@@ -70,12 +70,12 @@ extension String {
 /// Calling this initializer copies the contents of the substring to a new
 /// string.
 ///
-/// - Important: Don't store substrings longer than you need to perform a
+/// - Important: Don't store substrings longer than you need them to perform a
 ///   specific operation. A substring holds a reference to the entire storage
-///   of the string it came from, not just to the portion it presents, even
+///   of the string it comes from, not just to the portion it presents, even
 ///   when there is no other reference to the original string. Storing
-///   substrings may therefore prolong the lifetime of string data that is no
-///   longer otherwise accessible, which can appear to be memory leakage.
+///   substrings may, therefore, prolong the lifetime of string data that is
+///   no longer otherwise accessible, which can appear to be memory leakage.
 public struct Substring : StringProtocol {
   public typealias Index = String.Index
   public typealias IndexDistance = String.IndexDistance
@@ -221,10 +221,10 @@ public struct Substring : StringProtocol {
   ///
   /// - Parameter body: A closure with a pointer parameter that points to a
   ///   null-terminated sequence of UTF-8 code units. If `body` has a return
-  ///   value, it is used as the return value for the `withCString(_:)`
-  ///   method. The pointer argument is valid only for the duration of the
-  ///   method's execution.
-  /// - Returns: The return value of the `body` closure parameter, if any.
+  ///   value, that value is also used as the return value for the
+  ///   `withCString(_:)` method. The pointer argument is valid only for the
+  ///   duration of the method's execution.
+  /// - Returns: The return value, if any, of the `body` closure parameter.
   public func withCString<Result>(
     _ body: (UnsafePointer<CChar>) throws -> Result) rethrows -> Result {
     return try _slice._base._core._withCSubstringAndLength(
@@ -246,11 +246,12 @@ public struct Substring : StringProtocol {
   /// - Parameters:
   ///   - body: A closure with a pointer parameter that points to a
   ///     null-terminated sequence of code units. If `body` has a return
-  ///     value, it is used as the return value for the
+  ///     value, that value is also used as the return value for the
   ///     `withCString(encodedAs:_:)` method. The pointer argument is valid
   ///     only for the duration of the method's execution.
-  ///   - targetEncoding: The encoding in which the code units should be interpreted.
-  /// - Returns: The return value of the `body` closure parameter, if any.
+  ///   - targetEncoding: The encoding in which the code units should be
+  ///     interpreted.
+  /// - Returns: The return value, if any, of the `body` closure parameter.
   public func withCString<Result, TargetEncoding: _UnicodeEncoding>(
     encodedAs targetEncoding: TargetEncoding.Type,
     _ body: (UnsafePointer<TargetEncoding.CodeUnit>) throws -> Result

--- a/stdlib/public/core/UnfoldSequence.swift
+++ b/stdlib/public/core/UnfoldSequence.swift
@@ -38,8 +38,6 @@
 ///   returns the next element.
 /// - Returns: A sequence that starts with `first` and continues with every
 ///   value returned by passing the previous element to `next`.
-///
-/// - SeeAlso: `sequence(state:next:)`
 public func sequence<T>(first: T, next: @escaping (T) -> T?) -> UnfoldFirstSequence<T> {
   // The trivial implementation where the state is the next value to return
   // has the downside of being unnecessarily eager (it evaluates `next` one
@@ -84,8 +82,6 @@ public func sequence<T>(first: T, next: @escaping (T) -> T?) -> UnfoldFirstSeque
 /// - Parameter next: A closure that accepts an `inout` state and returns the
 ///   next element of the sequence.
 /// - Returns: A sequence that yields each successive value from `next`.
-///
-/// - SeeAlso: `sequence(first:next:)`
 public func sequence<T, State>(state: State, next: @escaping (inout State) -> T?)
   -> UnfoldSequence<T, State> {
   return UnfoldSequence(_state: state, _next: next)
@@ -102,8 +98,6 @@ public typealias UnfoldFirstSequence<T> = UnfoldSequence<T, (T?, Bool)>
 ///
 /// Instances of `UnfoldSequence` are created with the functions
 /// `sequence(first:next:)` and `sequence(state:next:)`.
-///
-/// - SeeAlso: `sequence(first:next:)`, `sequence(state:next:)`
 public struct UnfoldSequence<Element, State> : Sequence, IteratorProtocol {
   public mutating func next() -> Element? {
     guard !_done else { return nil }

--- a/stdlib/public/core/Unicode.swift
+++ b/stdlib/public/core/Unicode.swift
@@ -20,8 +20,6 @@ import SwiftShims
 /// Each `UnicodeDecodingResult` instance can represent a Unicode scalar value,
 /// an indication that no more Unicode scalars are available, or an indication
 /// of a decoding error.
-/// 
-/// - SeeAlso: `UnicodeCodec.decode(next:)`
 @_fixed_layout
 public enum UnicodeDecodingResult : Equatable {
   /// A decoded Unicode scalar value.
@@ -59,8 +57,6 @@ public enum UnicodeDecodingResult : Equatable {
 /// UTF-8, UTF-16, and UTF-32 encoding schemes as the `UTF8`, `UTF16`, and
 /// `UTF32` types, respectively. Use the `Unicode.Scalar` type to work with
 /// decoded Unicode scalar values.
-///
-/// - SeeAlso: `UTF8`, `UTF16`, `UTF32`, `Unicode.Scalar`
 public protocol UnicodeCodec : Unicode.Encoding {
 
   /// Creates an instance of the codec.
@@ -763,8 +759,6 @@ extension UTF16 {
   ///   surrogate pair when encoded in UTF-16. To check whether `x` is
   ///   represented by a surrogate pair, use `UTF16.width(x) == 2`.
   /// - Returns: The leading surrogate code unit of `x` when encoded in UTF-16.
-  ///
-  /// - SeeAlso: `UTF16.width(_:)`, `UTF16.trailSurrogate(_:)`
   public static func leadSurrogate(_ x: Unicode.Scalar) -> UTF16.CodeUnit {
     _precondition(width(x) == 2)
     return 0xD800 + UTF16.CodeUnit(extendingOrTruncating:
@@ -788,8 +782,6 @@ extension UTF16 {
   ///   surrogate pair when encoded in UTF-16. To check whether `x` is
   ///   represented by a surrogate pair, use `UTF16.width(x) == 2`.
   /// - Returns: The trailing surrogate code unit of `x` when encoded in UTF-16.
-  ///
-  /// - SeeAlso: `UTF16.width(_:)`, `UTF16.leadSurrogate(_:)`
   public static func trailSurrogate(_ x: Unicode.Scalar) -> UTF16.CodeUnit {
     _precondition(width(x) == 2)
     return 0xDC00 + UTF16.CodeUnit(extendingOrTruncating:
@@ -817,8 +809,6 @@ extension UTF16 {
   /// - Parameter x: A UTF-16 code unit.
   /// - Returns: `true` if `x` is a high-surrogate code unit; otherwise,
   ///   `false`.
-  ///
-  /// - SeeAlso: `UTF16.width(_:)`, `UTF16.leadSurrogate(_:)`
   public static func isLeadSurrogate(_ x: CodeUnit) -> Bool {
     return 0xD800...0xDBFF ~= x
   }
@@ -845,8 +835,6 @@ extension UTF16 {
   /// - Parameter x: A UTF-16 code unit.
   /// - Returns: `true` if `x` is a low-surrogate code unit; otherwise,
   ///   `false`.
-  ///
-  /// - SeeAlso: `UTF16.width(_:)`, `UTF16.leadSurrogate(_:)`
   public static func isTrailSurrogate(_ x: CodeUnit) -> Bool {
     return 0xDC00...0xDFFF ~= x
   }

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -57,8 +57,6 @@ public struct UnsafeBufferPointerIterator<Element>
 /// instances stored in the underlying memory. However, initializing another
 /// collection with an `${Self}` instance copies the instances out of the
 /// referenced memory and into the new collection.
-///
-/// - SeeAlso: `Unsafe${Mutable}Pointer`, `Unsafe${Mutable}RawBufferPointer`
 @_fixed_layout
 public struct Unsafe${Mutable}BufferPointer<Element>
   : _${Mutable}Indexable, ${Mutable}Collection, RandomAccessCollection {

--- a/stdlib/public/core/UnsafePointer.swift.gyb
+++ b/stdlib/public/core/UnsafePointer.swift.gyb
@@ -739,9 +739,9 @@ public struct ${Self}<Pointee>
   ///   - body: A closure that takes a ${Mutable.lower()} typed pointer to the
   ///     same memory as this pointer, only bound to type `T`. The closure's
   ///     pointer argument is valid only for the duration of the closure's
-  ///     execution. If `body` has a return value, it is used as the return
-  ///     value for the `withMemoryRebound(to:capacity:_:)` method.
-  /// - Returns: The return value of the `body` closure parameter, if any.
+  ///     execution. If `body` has a return value, that value is also used as
+  ///     the return value for the `withMemoryRebound(to:capacity:_:)` method.
+  /// - Returns: The return value, if any, of the `body` closure parameter.
   @_inlineable
   public func withMemoryRebound<T, Result>(to type: T.Type, capacity count: Int,
     _ body: (${Self}<T>) throws -> Result
@@ -845,8 +845,6 @@ public struct ${Self}<Pointee>
   /// - Returns: The distance from this pointer to `end`, in strides of the
   ///   pointer's `Pointee` type. To access the stride, use
   ///   `MemoryLayout<Pointee>.stride`.
-  ///
-  /// - SeeAlso: `MemoryLayout`
   @_inlineable
   public func distance(to end: ${Self}) -> Int {
     return end - self
@@ -867,8 +865,6 @@ public struct ${Self}<Pointee>
   ///   zero.
   /// - Returns: A pointer offset from this pointer by `n` instances of the
   ///   `Pointee` type.
-  ///
-  /// - SeeAlso: `MemoryLayout`
   @_inlineable
   public func advanced(by n: Int) -> ${Self} {
     return self + n
@@ -950,8 +946,6 @@ extension ${Self} {
   ///     `lhs`. To access the stride, use `MemoryLayout<Pointee>.stride`.
   /// - Returns: A pointer offset from `lhs` by `rhs` instances of the
   ///   `Pointee` type.
-  ///
-  /// - SeeAlso: `MemoryLayout`
   @_transparent
   public static func + (lhs: ${Self}<Pointee>, rhs: Int) -> ${Self}<Pointee> {
     return ${Self}(Builtin.gep_Word(
@@ -971,8 +965,6 @@ extension ${Self} {
   ///   - rhs: A pointer.
   /// - Returns: A pointer offset from `rhs` by `lhs` instances of the
   ///   `Pointee` type.
-  ///
-  /// - SeeAlso: `MemoryLayout`
   @_transparent
   public static func + (lhs: Int, rhs: ${Self}<Pointee>) -> ${Self}<Pointee> {
     return rhs + lhs
@@ -991,8 +983,6 @@ extension ${Self} {
   ///     `lhs`. To access the stride, use `MemoryLayout<Pointee>.stride`.
   /// - Returns: A pointer offset backward from `lhs` by `rhs` instances of
   ///   the `Pointee` type.
-  ///
-  /// - SeeAlso: `MemoryLayout`
   @_transparent
   public static func - (lhs: ${Self}<Pointee>, rhs: Int) -> ${Self}<Pointee> {
     return lhs + -rhs
@@ -1014,8 +1004,6 @@ extension ${Self} {
   /// - Returns: The distance from `lhs` to `rhs`, in strides of the pointer's
   ///   `Pointee` type. To access the stride, use
   ///   `MemoryLayout<Pointee>.stride`.
-  ///
-  /// - SeeAlso: `MemoryLayout`
   @_transparent
   public static func - (lhs: ${Self}<Pointee>, rhs: ${Self}<Pointee>) -> Int {
     return
@@ -1035,8 +1023,6 @@ extension ${Self} {
   ///   - lhs: A pointer to advance in place.
   ///   - rhs: The number of strides of the pointer's `Pointee` type to offset
   ///     `lhs`. To access the stride, use `MemoryLayout<Pointee>.stride`.
-  ///
-  /// - SeeAlso: `MemoryLayout`
   @_transparent
   public static func += (lhs: inout ${Self}<Pointee>, rhs: Int) {
     lhs = lhs + rhs
@@ -1053,8 +1039,6 @@ extension ${Self} {
   ///   - lhs: A pointer to advance in place.
   ///   - rhs: The number of strides of the pointer's `Pointee` type to offset
   ///     `lhs`. To access the stride, use `MemoryLayout<Pointee>.stride`.
-  ///
-  /// - SeeAlso: `MemoryLayout`
   @_transparent
   public static func -= (lhs: inout ${Self}<Pointee>, rhs: Int) {
     lhs = lhs - rhs

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -92,8 +92,6 @@
 ///
 ///     destBytes[0..<n] = someBytes[n..<(n + n)]
 % end
-///
-/// - SeeAlso: `Unsafe${Mutable}RawPointer`, `Unsafe${Mutable}BufferPointer`
 @_fixed_layout
 public struct Unsafe${Mutable}RawBufferPointer
   : ${Mutable}Collection, RandomAccessCollection {
@@ -596,13 +594,11 @@ extension ${Self} {
 ///   - arg: An instance to temporarily access through a mutable raw buffer
 ///     pointer.
 ///   - body: A closure that takes a raw buffer pointer to the bytes of `arg`
-///     as its sole argument. If the closure has a return value, it is used as
-///     the return value of the `withUnsafeMutableBytes(of:_:)` function. The
-///     buffer pointer argument is valid only for the duration of the
-///     closure's execution.
-/// - Returns: The return value of the `body` closure, if any.
-///
-/// - SeeAlso: `withUnsafeMutablePointer(to:_:)`, `withUnsafeBytes(of:_:)`
+///     as its sole argument. If the closure has a return value, that value is
+///     also used as the return value of the `withUnsafeMutableBytes(of:_:)`
+///     function. The buffer pointer argument is valid only for the duration
+///     of the closure's execution.
+/// - Returns: The return value, if any, of the `body` closure.
 @_inlineable
 public func withUnsafeMutableBytes<T, Result>(
   of arg: inout T,
@@ -625,13 +621,11 @@ public func withUnsafeMutableBytes<T, Result>(
 /// - Parameters:
 ///   - arg: An instance to temporarily access through a raw buffer pointer.
 ///   - body: A closure that takes a raw buffer pointer to the bytes of `arg`
-///     as its sole argument. If the closure has a return value, it is used as
-///     the return value of the `withUnsafeBytes(of:_:)` function. The buffer
-///     pointer argument is valid only for the duration of the closure's
-///     execution.
-/// - Returns: The return value of the `body` closure, if any.
-///
-/// - SeeAlso: `withUnsafePointer(to:_:)`, `withUnsafeMutableBytes(of:_:)`
+///     as its sole argument. If the closure has a return value, that value is
+///     also used as the return value of the `withUnsafeBytes(of:_:)`
+///     function. The buffer pointer argument is valid only for the duration
+///     of the closure's execution.
+/// - Returns: The return value, if any, of the `body` closure.
 @_inlineable
 public func withUnsafeBytes<T, Result>(
   of arg: inout T,

--- a/stdlib/public/core/UnsafeRawPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawPointer.swift.gyb
@@ -427,8 +427,6 @@ public struct Unsafe${Mutable}RawPointer : Strideable, Hashable, _Pointer {
   ///     bytes.
   /// - Returns: A pointer to a newly allocated region of memory. The memory is
   ///   allocated, but not initialized.
-  ///
-  /// - SeeAlso: `UnsafeMutablePointer`
   @_inlineable
   public static func allocate(
     bytes size: Int, alignedTo: Int
@@ -509,8 +507,6 @@ public struct Unsafe${Mutable}RawPointer : Strideable, Hashable, _Pointer {
   ///
   /// - Parameter to: The type `T` that the memory has already been bound to.
   /// - Returns: A typed pointer to the same memory as this raw pointer.
-  ///
-  /// - SeeAlso: `bindMemory(to:capacity:)`
   @_transparent
   public func assumingMemoryBound<T>(to: T.Type) -> Unsafe${Mutable}Pointer<T> {
     return Unsafe${Mutable}Pointer<T>(_rawValue)

--- a/stdlib/public/core/VarArgs.swift
+++ b/stdlib/public/core/VarArgs.swift
@@ -77,12 +77,11 @@ let _x86_64RegisterSaveWords = _x86_64CountGPRegisters + _x86_64CountSSERegister
 /// - Parameters:
 ///   - args: An array of arguments to convert to a C `va_list` pointer.
 ///   - body: A closure with a `CVaListPointer` parameter that references the
-///     arguments passed as `args`. If `body` has a return value, it is used
-///     as the return value for the `withVaList(_:)` function. The pointer
-///     argument is valid only for the duration of the function's execution.
-/// - Returns: The return value of the `body` closure parameter, if any.
-///
-/// - SeeAlso: `getVaList(_:)`
+///     arguments passed as `args`. If `body` has a return value, that value
+///     is also used as the return value for the `withVaList(_:)` function.
+///     The pointer argument is valid only for the duration of the function's
+///     execution.
+/// - Returns: The return value, if any, of the `body` closure parameter.
 public func withVaList<R>(_ args: [CVarArg],
   _ body: (CVaListPointer) -> R) -> R {
   let builder = _VaListBuilder()
@@ -111,14 +110,13 @@ internal func _withVaList<R>(
 /// from the given array of arguments.
 ///
 /// You should prefer `withVaList(_:_:)` instead of this function. In some
-/// uses, such as in a `class` initializer, you may find that the
-/// language rules do not allow you to use `withVaList(_:_:)` as intended.
+/// uses, such as in a `class` initializer, you may find that the language
+/// rules do not allow you to use `withVaList(_:_:)` as intended.
 ///
 /// - Parameters args: An array of arguments to convert to a C `va_list`
 ///   pointer.
-/// - Returns: The return value of the `body` closure parameter, if any.
-///
-/// - SeeAlso: `withVaList(_:_:)`
+/// - Returns: A pointer that can be used with C functions that take a
+///   `va_list` argument.
 public func getVaList(_ args: [CVarArg]) -> CVaListPointer {
   let builder = _VaListBuilder()
   for a in args {

--- a/stdlib/public/core/Zip.swift
+++ b/stdlib/public/core/Zip.swift
@@ -107,8 +107,6 @@ public struct Zip2Iterator<
 ///     // Prints "two: 2
 ///     // Prints "three: 3"
 ///     // Prints "four: 4"
-///
-/// - SeeAlso: `zip(_:_:)`
 public struct Zip2Sequence<Sequence1 : Sequence, Sequence2 : Sequence>
   : Sequence {
 


### PR DESCRIPTION
This is a cherry pick of #10209.

* Explanation: Revises the documentation for a variety of standard library symbols, including removing the `SeeAlso` tags, which are inconsistent and have limited support.
* Scope: This includes only changes to the standard library's inline documentation.
* Radar/SR: rdar://problem/32749244
* Risk: Very Low
* Testing: The unit and validation test suites.