### PR TITLE
[4.0] [ClangImporter] Correct curried method types for SE-110.

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3768,8 +3768,11 @@ namespace {
                                  methodTy->getExtInfo());
       }
 
-      // Add the 'self' parameter to the function type.
-      type = FunctionType::get(selfInterfaceType, type);
+      // Add the 'self' parameter to the function type. NB. a method's formal
+      // type should be (Type) -> (Args...) -> Ret, not Type -> (Args...) ->
+      // Ret.
+      auto parenSelfType = ParenType::get(Impl.SwiftContext, selfInterfaceType);
+      type = FunctionType::get(parenSelfType, type);
 
       auto interfaceType = getGenericMethodType(dc, type->castTo<AnyFunctionType>());
       result->setInterfaceType(interfaceType);

--- a/test/ClangImporter/Inputs/objc_curried_method.h
+++ b/test/ClangImporter/Inputs/objc_curried_method.h
@@ -1,0 +1,6 @@
+@interface Bar
+@end
+
+@interface Foo : Bar
+- (void)someMethod;
+@end

--- a/test/ClangImporter/objc_curried_method.swift
+++ b/test/ClangImporter/objc_curried_method.swift
@@ -1,0 +1,11 @@
+// RUN: %target-swift-frontend -swift-version 3 -typecheck %s -import-objc-header %S/Inputs/objc_curried_method.h
+// RUN: %target-swift-frontend -swift-version 4 -typecheck %s -import-objc-header %S/Inputs/objc_curried_method.h
+
+// REQUIRES: objc_interop
+
+// rdar://problem/32588152
+
+func apply(_: (Foo) -> () -> Void) {}
+
+apply(Foo.someMethod)
+


### PR DESCRIPTION
4.0 merge of https://github.com/apple/swift/pull/10233 .

Explanation: Some Objective-C methods would fail to coerce to the expected function types due to behavior with paren types in functions changing with SE-110. This would results in a source-breaking errors with confusing error messages.
Scope: Minor source-breaking regression from 3.1.
Radar: rdar://problem/32588152
Risk: Low: other parts of the compiler do the same thing (e.g. https://github.com/apple/swift/pull/9454 ).
Testing: CI testing.