### PR TITLE
[Exclusivity] Update static diagnostic text for "simultaneous" accesses

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -90,24 +90,24 @@ NOTE(previous_inout_alias,none,
       "previous aliasing argument", ())
 
 WARNING(exclusivity_access_required_swift3,none,
-        "simultaneous accesses to %0 %1, but "
-        "%select{initialization|read|modification|deinitialization}2 requires "
+        "overlapping accesses to %0, but "
+        "%select{initialization|read|modification|deinitialization}1 requires "
         "exclusive access; consider copying to a local variable",
-        (DescriptiveDeclKind, StringRef, unsigned))
+        (StringRef, unsigned))
 
 ERROR(exclusivity_access_required,none,
-      "simultaneous accesses to %0 %1, but "
-      "%select{initialization|read|modification|deinitialization}2 requires "
+      "overlapping accesses to %0, but "
+      "%select{initialization|read|modification|deinitialization}1 requires "
       "exclusive access; consider copying to a local variable",
-      (DescriptiveDeclKind, StringRef, unsigned))
+      (StringRef, unsigned))
 
 ERROR(exclusivity_access_required_unknown_decl,none,
-        "simultaneous accesses, but "
+        "overlapping accesses, but "
         "%select{initialization|read|modification|deinitialization}0 requires "
         "exclusive access; consider copying to a local variable", (unsigned))
 
 WARNING(exclusivity_access_required_unknown_decl_swift3,none,
-        "simultaneous accesses, but "
+        "overlapping accesses, but "
         "%select{initialization|read|modification|deinitialization}0 requires "
 "exclusive access; consider copying to a local variable", (unsigned))
 

--- a/lib/SILOptimizer/Mandatory/DiagnoseStaticExclusivity.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseStaticExclusivity.cpp
@@ -660,7 +660,7 @@ static void diagnoseExclusivityViolation(const ConflictingAccess &Violation,
         VD->getBaseName(), BaseType, MainAccess.getSubPath(), M);
     auto D =
         diagnose(Ctx, MainAccess.getAccessLoc().getSourceLoc(), DiagnosticID,
-                 VD->getDescriptiveKind(), PathDescription, AccessKindForMain);
+                 PathDescription, AccessKindForMain);
     D.highlight(RangeForMain);
     tryFixItWithCallToCollectionSwapAt(FirstAccess.getInstruction(),
                                        SecondAccess.getInstruction(),

--- a/test/SILGen/polymorphic_inout_aliasing.swift
+++ b/test/SILGen/polymorphic_inout_aliasing.swift
@@ -11,7 +11,7 @@ class Story {
   }
 
   func test() {
-    // expected-warning@+2 {{simultaneous accesses to var 'finalStored', but modification requires exclusive access; consider copying to a local variable}}
+    // expected-warning@+2 {{overlapping accesses to 'finalStored', but modification requires exclusive access; consider copying to a local variable}}
     // expected-note@+1 {{conflicting access is here}}
     swap(&self.finalStored[0], &self.finalStored[1])
     swap(&self.overridableStored[0], &self.overridableStored[1])
@@ -24,7 +24,7 @@ protocol Storied {
 }
 
 func testProtocol<T: Storied>(x: inout T) {
-  // expected-warning@+2 {{simultaneous accesses to parameter 'x', but modification requires exclusive access; consider copying to a local variable}}
+  // expected-warning@+2 {{overlapping accesses to 'x', but modification requires exclusive access; consider copying to a local variable}}
   // expected-note@+1 {{conflicting access is here}}
   swap(&x.protocolRequirement[0], &x.protocolRequirement[1])
 }

--- a/test/SILOptimizer/exclusivity_static_diagnostics.sil
+++ b/test/SILOptimizer/exclusivity_static_diagnostics.sil
@@ -38,7 +38,7 @@ bb0(%0 : $Int):
   %3 = project_box %2 : ${ var Int }, 0
   store %0 to [trivial] %3 : $*Int
   %4 = function_ref @takesTwoInouts : $@convention(thin) (@inout Int, @inout Int) -> ()
-  %5 = begin_access [modify] [unknown] %3 : $*Int  // expected-error {{simultaneous accesses, but modification requires exclusive access; consider copying to a local variable}}
+  %5 = begin_access [modify] [unknown] %3 : $*Int  // expected-error {{overlapping accesses, but modification requires exclusive access; consider copying to a local variable}}
   %6 = begin_access [modify] [unknown] %3 : $*Int  // expected-note {{conflicting access is here}}
   %7 = apply %4(%5, %6) : $@convention(thin) (@inout Int, @inout Int) -> ()
   end_access %6 : $*Int
@@ -55,7 +55,7 @@ bb0(%0 : $Int):
   %3 = project_box %2 : ${ var Int }, 0
   store %0 to [trivial] %3 : $*Int
   %4 = function_ref @takesTwoInouts : $@convention(thin) (@inout Int, @inout Int) -> ()
-  %5 = begin_access [modify] [unknown] %3 : $*Int  // expected-error {{simultaneous accesses, but modification requires exclusive access; consider copying to a local variable}}
+  %5 = begin_access [modify] [unknown] %3 : $*Int  // expected-error {{overlapping accesses, but modification requires exclusive access; consider copying to a local variable}}
   %6 = begin_access [modify] [unknown] %5 : $*Int
   %7 = begin_access [modify] [unknown] %3 : $*Int  // expected-note {{conflicting access is here}}
   %8 = apply %4(%5, %6) : $@convention(thin) (@inout Int, @inout Int) -> ()
@@ -147,7 +147,7 @@ bb0(%0 : $Int, %1 : $Builtin.Int1):
   br bb1
 bb1:
   // Make sure we don't diagnose twice.
-  %4 = begin_access [modify] [unknown] %3 : $*Int // expected-error {{simultaneous accesses, but modification requires exclusive access; consider copying to a local variable}}
+  %4 = begin_access [modify] [unknown] %3 : $*Int // expected-error {{overlapping accesses, but modification requires exclusive access; consider copying to a local variable}}
   %5 = begin_access [modify] [unknown] %3 : $*Int // expected-note {{conflicting access is here}}
   end_access %5: $*Int
   end_access %4: $*Int
@@ -199,7 +199,7 @@ bb0(%0 : $Int):
   %2 = project_box %1 : ${ var Int }, 0
   store %0 to [trivial] %2 : $*Int
   %4 = begin_access [read] [unknown] %2 : $*Int // expected-note {{conflicting access is here}}
-  %5 = begin_access [modify] [unknown] %2 : $*Int // expected-error {{simultaneous accesses, but modification requires exclusive access; consider copying to a local variable}}
+  %5 = begin_access [modify] [unknown] %2 : $*Int // expected-error {{overlapping accesses, but modification requires exclusive access; consider copying to a local variable}}
   end_access %5 : $*Int
   end_access %4: $*Int
   destroy_value %1 : ${ var Int }
@@ -213,7 +213,7 @@ bb0(%0 : $Int):
   %1 = alloc_box ${ var Int }
   %2 = project_box %1 : ${ var Int }, 0
   store %0 to [trivial] %2 : $*Int
-  %4 = begin_access [modify] [unknown] %2 : $*Int // expected-error {{simultaneous accesses, but modification requires exclusive access; consider copying to a local variable}}
+  %4 = begin_access [modify] [unknown] %2 : $*Int // expected-error {{overlapping accesses, but modification requires exclusive access; consider copying to a local variable}}
   %5 = begin_access [read] [unknown] %2 : $*Int // expected-note {{conflicting access is here}}
   end_access %5 : $*Int
   end_access %4: $*Int
@@ -232,7 +232,7 @@ sil hidden @classStoredProperty : $@convention(thin) (ClassWithStoredProperty) -
 bb0(%0 : $ClassWithStoredProperty):
   %1 = ref_element_addr %0 : $ClassWithStoredProperty, #ClassWithStoredProperty.f
 
-  // expected-error@+1{{simultaneous accesses to var 'f', but modification requires exclusive access; consider copying to a local variable}}
+  // expected-error@+1{{overlapping accesses to 'f', but modification requires exclusive access; consider copying to a local variable}}
   %2 = begin_access [modify] [dynamic] %1 : $*Int
   %3 = ref_element_addr %0 : $ClassWithStoredProperty, #ClassWithStoredProperty.f
 
@@ -252,7 +252,7 @@ bb0(%0 : $ClassWithStoredProperty):
   %2 = begin_borrow %0 : $ClassWithStoredProperty
   %3 = ref_element_addr %1 : $ClassWithStoredProperty, #ClassWithStoredProperty.f
 
-  // expected-error@+1{{simultaneous accesses to var 'f', but modification requires exclusive access; consider copying to a local variable}}
+  // expected-error@+1{{overlapping accesses to 'f', but modification requires exclusive access; consider copying to a local variable}}
   %4 = begin_access [modify] [dynamic] %3 : $*Int
   %5 = ref_element_addr %2 : $ClassWithStoredProperty, #ClassWithStoredProperty.f
 
@@ -279,7 +279,7 @@ bb0(%0 : $Int):
   store %0 to [trivial] %3 : $*Int
   %4 = copy_value %2 : ${ var Int }
   %5 = project_box %4 : ${ var Int }, 0
-  %6 = begin_access [modify] [unknown] %3 : $*Int  // expected-error {{simultaneous accesses, but modification requires exclusive access; consider copying to a local variable}}
+  %6 = begin_access [modify] [unknown] %3 : $*Int  // expected-error {{overlapping accesses, but modification requires exclusive access; consider copying to a local variable}}
   %7 = begin_access [modify] [unknown] %5 : $*Int  // expected-note {{conflicting access is here}}
   end_access %7 : $*Int
   end_access %6: $*Int
@@ -297,7 +297,7 @@ bb0(%0 : $Int):
   %3 = project_box %2 : ${ var Int }, 0
   store %0 to [trivial] %3 : $*Int
   %4 = project_box %2 : ${ var Int }, 0
-  %5 = begin_access [modify] [unknown] %3 : $*Int  // expected-error {{simultaneous accesses, but modification requires exclusive access; consider copying to a local variable}}
+  %5 = begin_access [modify] [unknown] %3 : $*Int  // expected-error {{overlapping accesses, but modification requires exclusive access; consider copying to a local variable}}
   %6 = begin_access [modify] [unknown] %4 : $*Int  // expected-note {{conflicting access is here}}
   end_access %6 : $*Int
   end_access %5: $*Int
@@ -315,7 +315,7 @@ sil hidden @modifySameGlobal : $@convention(thin) (Int) -> () {
 bb0(%0 : $Int):
   %1 = global_addr @global1 :$*Int
   %2 = global_addr @global1 :$*Int
-  %3 = begin_access [modify] [unknown] %1 : $*Int  // expected-error {{simultaneous accesses, but modification requires exclusive access; consider copying to a local variable}}
+  %3 = begin_access [modify] [unknown] %1 : $*Int  // expected-error {{overlapping accesses, but modification requires exclusive access; consider copying to a local variable}}
   %4 = begin_access [modify] [unknown] %2 : $*Int  // expected-note {{conflicting access is here}}
   end_access %4 : $*Int
   end_access %3: $*Int
@@ -348,7 +348,7 @@ bb0(%0 : $Int):
   store %0 to [trivial] %3 : $*Int
   %4 = function_ref @takesTwoInouts : $@convention(thin) (@inout Int, @inout Int) -> ()
   %5 = begin_access [read] [unknown] %3 : $*Int  // expected-note {{conflicting access is here}}
-  %6 = begin_access [modify] [unknown] %3 : $*Int  // expected-error {{simultaneous accesses, but modification requires exclusive access; consider copying to a local variable}}
+  %6 = begin_access [modify] [unknown] %3 : $*Int  // expected-error {{overlapping accesses, but modification requires exclusive access; consider copying to a local variable}}
   %7 = begin_access [read] [unknown] %3 : $*Int // no-error
   %8 = apply %4(%5, %6) : $@convention(thin) (@inout Int, @inout Int) -> ()
   end_access %7 : $*Int
@@ -368,7 +368,7 @@ bb0(%0 : $Int):
   %3 = project_box %2 : ${ var Int }, 0
   store %0 to [trivial] %3 : $*Int
   %4 = function_ref @takesTwoInouts : $@convention(thin) (@inout Int, @inout Int) -> ()
-  %5 = begin_access [modify] [unknown] %3 : $*Int  // expected-error {{simultaneous accesses, but modification requires exclusive access; consider copying to a local variable}}
+  %5 = begin_access [modify] [unknown] %3 : $*Int  // expected-error {{overlapping accesses, but modification requires exclusive access; consider copying to a local variable}}
   %6 = begin_access [modify] [unknown] %3 : $*Int  // expected-note {{conflicting access is here}}
   %7 = begin_access [modify] [unknown] %3 : $*Int  // no-error
   %8 = apply %4(%5, %6) : $@convention(thin) (@inout Int, @inout Int) -> ()
@@ -392,7 +392,7 @@ bb0(%0 : $Int):
   %4 = function_ref @takesTwoInouts : $@convention(thin) (@inout Int, @inout Int) -> ()
   %5 = begin_access [modify] [unknown] %3 : $*Int  // no-note
   end_access %5 : $*Int
-  %6 = begin_access [modify] [unknown] %3 : $*Int  // expected-error {{simultaneous accesses, but modification requires exclusive access; consider copying to a local variable}}
+  %6 = begin_access [modify] [unknown] %3 : $*Int  // expected-error {{overlapping accesses, but modification requires exclusive access; consider copying to a local variable}}
   %7 = begin_access [modify] [unknown] %3 : $*Int  // expected-note {{conflicting access is here}}
   %8 = apply %4(%5, %6) : $@convention(thin) (@inout Int, @inout Int) -> ()
   end_access %7 : $*Int
@@ -606,7 +606,7 @@ bb0(%0 : $Int):
   %2 = alloc_box ${ var StructWithStoredProps }
   %3 = project_box %2 : ${ var StructWithStoredProps }, 0
   %4 = function_ref @takesTwoInouts : $@convention(thin) (@inout Int, @inout Int) -> ()
-  %5 = begin_access [modify] [unknown] %3 : $*StructWithStoredProps // expected-error {{simultaneous accesses, but modification requires exclusive access; consider copying to a local variable}}
+  %5 = begin_access [modify] [unknown] %3 : $*StructWithStoredProps // expected-error {{overlapping accesses, but modification requires exclusive access; consider copying to a local variable}}
   %6 = struct_element_addr %5 : $*StructWithStoredProps, #StructWithStoredProps.x
   %7 = begin_access [modify] [unknown] %3 : $*StructWithStoredProps // expected-note {{conflicting access is here}}
   %8 = struct_element_addr %7 : $*StructWithStoredProps, #StructWithStoredProps.x
@@ -624,7 +624,7 @@ bb0(%0 : $Int):
   %2 = alloc_box ${ var StructWithStoredProps }
   %3 = project_box %2 : ${ var StructWithStoredProps }, 0
   %4 = function_ref @takesInoutIntAndStructWithStoredProps : $@convention(thin) (@inout Int, @inout StructWithStoredProps) -> ()
-  %5 = begin_access [modify] [unknown] %3 : $*StructWithStoredProps // expected-error {{simultaneous accesses, but modification requires exclusive access; consider copying to a local variable}}
+  %5 = begin_access [modify] [unknown] %3 : $*StructWithStoredProps // expected-error {{overlapping accesses, but modification requires exclusive access; consider copying to a local variable}}
   %6 = struct_element_addr %5 : $*StructWithStoredProps, #StructWithStoredProps.x
   %7 = begin_access [modify] [unknown] %3 : $*StructWithStoredProps // expected-note {{conflicting access is here}}
   %8 = apply %4(%6, %7) : $@convention(thin) (@inout Int, @inout StructWithStoredProps) -> ()
@@ -641,7 +641,7 @@ bb0(%0 : $Int):
   %2 = alloc_box ${ var StructWithStoredProps }
   %3 = project_box %2 : ${ var StructWithStoredProps }, 0
   %4 = function_ref @takesInoutIntAndStructWithStoredProps : $@convention(thin) (@inout Int, @inout StructWithStoredProps) -> ()
-  %5 = begin_access [modify] [unknown] %3 : $*StructWithStoredProps // expected-error {{simultaneous accesses, but modification requires exclusive access; consider copying to a local variable}}
+  %5 = begin_access [modify] [unknown] %3 : $*StructWithStoredProps // expected-error {{overlapping accesses, but modification requires exclusive access; consider copying to a local variable}}
   %6 = struct_element_addr %5 : $*StructWithStoredProps, #StructWithStoredProps.n
   %7 = struct_element_addr %6 : $*NestedStructWithStoredProps, #NestedStructWithStoredProps.a
   %8 = begin_access [modify] [unknown] %3 : $*StructWithStoredProps // expected-note {{conflicting access is here}}
@@ -677,7 +677,7 @@ bb0(%0 : $Int):
   %2 = alloc_box ${ var (Int, Int) }
   %3 = project_box %2 : ${ var (Int, Int) }, 0
   %4 = function_ref @takesTwoInouts : $@convention(thin) (@inout Int, @inout Int) -> ()
-  %5 = begin_access [modify] [unknown] %3 : $*(Int, Int) // expected-error {{simultaneous accesses, but modification requires exclusive access; consider copying to a local variable}}
+  %5 = begin_access [modify] [unknown] %3 : $*(Int, Int) // expected-error {{overlapping accesses, but modification requires exclusive access; consider copying to a local variable}}
   %6 = tuple_element_addr %5 : $*(Int, Int), 0
   %7 = begin_access [modify] [unknown] %3 : $*(Int, Int) // expected-note {{conflicting access is here}}
   %8 = tuple_element_addr %7 : $*(Int, Int), 0

--- a/test/SILOptimizer/exclusivity_static_diagnostics_swift3.swift
+++ b/test/SILOptimizer/exclusivity_static_diagnostics_swift3.swift
@@ -12,7 +12,7 @@ func simpleInoutDiagnostic() {
 
   // expected-error@+4{{inout arguments are not allowed to alias each other}}
   // expected-note@+3{{previous aliasing argument}}
-  // expected-warning@+2{{simultaneous accesses to var 'i', but modification requires exclusive access; consider copying to a local variable}}
+  // expected-warning@+2{{overlapping accesses to 'i', but modification requires exclusive access; consider copying to a local variable}}
   // expected-note@+1{{conflicting access is here}}
   takesTwoInouts(&i, &i)
 }
@@ -24,7 +24,7 @@ struct X {
 func diagnoseOnSameField() {
   var x = X()
 
-  // expected-warning@+2{{simultaneous accesses to var 'x.f', but modification requires exclusive access; consider copying to a local variable}}
+  // expected-warning@+2{{overlapping accesses to 'x.f', but modification requires exclusive access; consider copying to a local variable}}
   // expected-note@+1{{conflicting access is here}}
   takesTwoInouts(&x.f, &x.f)
 }


### PR DESCRIPTION
Remove the descriptive decl kind (since with subpaths it is not correct and
cannot represent a tuple element) and change "simultaneous" to "overlapping"
in order to lower the register slightly and avoid connoting threading.

For example, for the following:

   takesTwoInouts(&x.f, &x.f)

the diagnostic will change from

"simultaneous accesses to var 'x.f', but modification requires exclusive access;
consider copying to a local variable"

to

"overlapping accesses to 'x.f', but modification requires exclusive access;
consider copying to a local variable"
