### PR TITLE
Sema: Fix failure to produce diagnostics when 'is' casts are involved

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2716,8 +2716,7 @@ namespace {
     }
     
     Type visitEnumIsCaseExpr(EnumIsCaseExpr *expr) {
-      // Should already be type-checked.
-      return expr->getType();
+      return CS.getASTContext().getBoolDecl()->getDeclaredType();
     }
 
     Type visitEditorPlaceholderExpr(EditorPlaceholderExpr *E) {

--- a/test/Constraints/casts.swift
+++ b/test/Constraints/casts.swift
@@ -210,3 +210,14 @@ _ = seven as Int // expected-error {{cannot convert value of type 'Double' to ty
 func rdar29894174(v: B?) {
   let _ = [v].flatMap { $0 as? D }
 }
+
+// When re-typechecking a solution with an 'is' cast applied,
+// we would fail to produce a diagnostic.
+func process(p: Any?) {
+  compare(p is String)
+  // expected-error@-1 {{cannot invoke 'compare' with an argument list of type '(Bool)'}}
+  // expected-note@-2 {{overloads for 'compare' exist with these partially matching parameter lists: (T, T), (T?, T?)}}
+}
+
+func compare<T>(_: T, _: T) {}
+func compare<T>(_: T?, _: T?) {}

--- a/validation-test/compiler_crashers_2_fixed/0105-sr5050.swift
+++ b/validation-test/compiler_crashers_2_fixed/0105-sr5050.swift
@@ -1,4 +1,4 @@
-// RUN: not --crash %target-swift-frontend %s -typecheck
+// RUN: not %target-swift-frontend %s -typecheck
 // REQUIRES: asserts
 
 protocol P {}


### PR DESCRIPTION
When re-typechecking an expression during diagnostics, we begin by
erasing all the types in the expression. However, any expressions
created as part of applying the solution will remain.

CSGen was doing the wrong thing when it encountered EnumIsCaseExpr,
which can only appear in already-type checked ASTs.

Returning expr->getType() is not correct, because the type is not
yet set; returning a null type is intended to signal that a
diagnostic was already emitted, which causes Sema to stop
type checking.

The end result is that certain combinations of invalid code with
an 'is' cast nested inside would crash either the AST verifier
(with asserts on) or in SILGen (with asserts off), because we
would stop trying to diagnose the issue prematurely, and possibly
not emit a diagnostic at all.

Fixes <https://bugs.swift.org/browse/SR-5050> and
<rdar://problem/32487948>.