### PR TITLE
Sema: Fix failure to produce diagnostics when 'is' casts are involved [4.0]

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2716,8 +2716,7 @@ namespace {
     }
     
     Type visitEnumIsCaseExpr(EnumIsCaseExpr *expr) {
-      // Should already be type-checked.
-      return expr->getType();
+      return CS.getASTContext().getBoolDecl()->getDeclaredType();
     }
 
     Type visitEditorPlaceholderExpr(EditorPlaceholderExpr *E) {

--- a/test/Constraints/casts.swift
+++ b/test/Constraints/casts.swift
@@ -210,3 +210,14 @@ _ = seven as Int // expected-error {{cannot convert value of type 'Double' to ty
 func rdar29894174(v: B?) {
   let _ = [v].flatMap { $0 as? D }
 }
+
+// When re-typechecking a solution with an 'is' cast applied,
+// we would fail to produce a diagnostic.
+func process(p: Any?) {
+  compare(p is String)
+  // expected-error@-1 {{cannot invoke 'compare' with an argument list of type '(Bool)'}}
+  // expected-note@-2 {{overloads for 'compare' exist with these partially matching parameter lists: (T, T), (T?, T?)}}
+}
+
+func compare<T>(_: T, _: T) {}
+func compare<T>(_: T?, _: T?) {}


### PR DESCRIPTION
* Description: Fix a crash-on-invalid where the combination of an 'is' cast inside other invalid code would sometimes cause the type checker to not emit a diagnostic. In a no-assert build this crashes in SILGen, otherwise the AST verifier.

* Scope of the issue: Reported a few times externally, people are hitting this with invalid code.

* Origination: The issue is present in 3.1 also.

* Risk: Very low, this gives more correct behavior to a code path only exercised during diagnostics.

* Tested: New test added to ensure a diagnostic is emitted.

* Reviewed by: @rudkx 

* Radar: rdar://problem/32487948