### PR TITLE
Rdar 32547102 float varargs overflow to gp args area swift 4.0 branch

### DIFF
--- a/stdlib/public/core/VarArgs.swift
+++ b/stdlib/public/core/VarArgs.swift
@@ -59,6 +59,19 @@ protocol _CVarArgAligned : CVarArg {
 #if arch(x86_64)
 @_versioned
 let _x86_64CountGPRegisters = 6
+// Note to future visitors concerning the following SSE register count.
+//
+// AMD64-ABI section 3.5.7 says -- as recently as v0.99.7, Nov 2014 -- to make
+// room in the va_list register-save area for 16 SSE registers (XMM0..15). This
+// may seem surprising, because the calling convention of that ABI only uses the
+// first 8 SSE registers for argument-passing; why save the other 8?
+//
+// According to a comment in X86_64ABIInfo::EmitVAArg, in clang's TargetInfo,
+// the AMD64-ABI spec is itself in error on this point ("NOTE: 304 is a typo").
+// This comment (and calculation) in clang has been there since varargs support
+// was added in 2009, in rev be9eb093; so if you're about to change this value
+// from 8 to 16 based on reading the spec, probably the bug you're looking for
+// is elsewhere.
 @_versioned
 let _x86_64CountSSERegisters = 8
 @_versioned

--- a/stdlib/public/core/VarArgs.swift
+++ b/stdlib/public/core/VarArgs.swift
@@ -450,7 +450,9 @@ final internal class _VaListBuilder {
       }
       sseRegistersUsed += 1
     }
-    else if encoded.count == 1 && gpRegistersUsed < _x86_64CountGPRegisters {
+    else if encoded.count == 1
+      && !(arg is _CVarArgPassedAsDouble)
+      && gpRegistersUsed < _x86_64CountGPRegisters {
       storage[gpRegistersUsed] = encoded[0]
       gpRegistersUsed += 1
     }

--- a/test/stdlib/VarArgs.swift
+++ b/test/stdlib/VarArgs.swift
@@ -100,5 +100,29 @@ func test_varArgs4() {
 }
 test_varArgs4()
 
+func test_varArgs5() {
+  var args = [CVarArg]()
+
+  // Confirm the absence of a bug (on x86-64) wherein floats were stored in
+  // the GP register-save area after the SSE register-save area was
+  // exhausted, rather than spilling into the overflow argument area.
+  //
+  // This is not caught by test_varArgs1 above, because it exhauses the
+  // GP register-save area before the SSE area.
+
+  var format = "rdar-32547102: "
+  for i in 0..<12 {
+    args.append(Float(i))
+    format += "%.1f "
+  }
+
+  // CHECK: rdar-32547102: 0.0 1.0 2.0 3.0 4.0 5.0 6.0 7.0 8.0 9.0 10.0 11.0
+  withVaList(args) {
+    vprintf(format + "\n", $0)
+  }
+}
+test_varArgs5()
+
+
 // CHECK: done.
 print("done.")


### PR DESCRIPTION
Cherry-pick of #10237 to swift-4.0-branch

fixes rdar://32547102