### PR TITLE
SILGen: Fix problems with local generic functions

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -868,13 +868,17 @@ public:
 
     auto afd = dyn_cast<AbstractFunctionDecl>(e->getDecl());
 
+    CaptureInfo captureInfo;
+
     // Otherwise, we have a statically-dispatched call.
-    SubstitutionList subs;
-    if (e->getDeclRef().isSpecialized() &&
-        (!afd ||
-         !afd->getDeclContext()->isLocalContext() ||
-         afd->getCaptureInfo().hasGenericParamCaptures()))
-      subs = e->getDeclRef().getSubstitutions();
+    SubstitutionList subs = e->getDeclRef().getSubstitutions();
+
+    if (afd) {
+      captureInfo = SGF.SGM.Types.getLoweredLocalCaptures(afd);
+      if (afd->getDeclContext()->isLocalContext() &&
+          !captureInfo.hasGenericParamCaptures())
+        subs = SubstitutionList();
+    }
 
     // Enum case constructor references are open-coded.
     if (isa<EnumElementDecl>(e->getDecl()))
@@ -884,7 +888,7 @@ public:
     
     // If the decl ref requires captures, emit the capture params.
     if (afd) {
-      if (SGF.SGM.M.Types.hasLoweredLocalCaptures(afd)) {
+      if (!captureInfo.getCaptures().empty()) {
         SmallVector<ManagedValue, 4> captures;
         SGF.emitCaptures(e, afd, CaptureEmission::ImmediateApplication,
                          captures);
@@ -4899,6 +4903,15 @@ static Callee getBaseAccessorFunctionRef(SILGenFunction &SGF,
                                          bool isDirectUse,
                                          SubstitutionList subs) {
   auto *decl = cast<AbstractFunctionDecl>(constant.getDecl());
+
+  // The accessor might be a local function that does not capture any
+  // generic parameters, in which case we don't want to pass in any
+  // substitutions.
+  auto captureInfo = SGF.SGM.Types.getLoweredLocalCaptures(decl);
+  if (decl->getDeclContext()->isLocalContext() &&
+      !captureInfo.hasGenericParamCaptures()) {
+    subs = SubstitutionList();
+  }
 
   // If this is a method in a protocol, generate it as a protocol call.
   if (isa<ProtocolDecl>(decl->getDeclContext())) {

--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -229,10 +229,14 @@ public:
   std::pair<bool, Expr *> walkToDeclRefExpr(DeclRefExpr *DRE) {
     auto *D = DRE->getDecl();
 
-    // Capture the generic parameters of the decl.
-    if (!AFR.isObjC() || !D->isObjC() || isa<ConstructorDecl>(D)) {
-      for (auto sub : DRE->getDeclRef().getSubstitutions()) {
-        checkType(sub.getReplacement(), DRE->getLoc());
+    // Capture the generic parameters of the decl, unless it's a
+    // local declaration in which case we will pick up generic
+    // parameter references transitively.
+    if (!D->getDeclContext()->isLocalContext()) {
+      if (!AFR.isObjC() || !D->isObjC() || isa<ConstructorDecl>(D)) {
+        for (auto sub : DRE->getDeclRef().getSubstitutions()) {
+          checkType(sub.getReplacement(), DRE->getLoc());
+        }
       }
     }
 

--- a/test/SILGen/generic_closures.swift
+++ b/test/SILGen/generic_closures.swift
@@ -8,14 +8,27 @@ var zero: Int
 func generic_nondependent_context<T>(_ x: T, y: Int) -> Int {
   func foo() -> Int { return y }
 
+  func bar() -> Int { return y }
+
   // CHECK: [[FOO:%.*]] = function_ref @_T016generic_closures0A21_nondependent_context{{.*}} : $@convention(thin) (Int) -> Int
   // CHECK: [[FOO_CLOSURE:%.*]] = partial_apply [[FOO]](%1)
   // CHECK: destroy_value [[FOO_CLOSURE]]
   let _ = foo
 
+  // CHECK: [[BAR:%.*]] = function_ref @_T016generic_closures0A21_nondependent_context{{.*}} : $@convention(thin) (Int) -> Int
+  // CHECK: [[BAR_CLOSURE:%.*]] = partial_apply [[BAR]](%1)
+  // CHECK: destroy_value [[BAR_CLOSURE]]
+  let _ = bar
+
   // CHECK: [[FOO:%.*]] = function_ref @_T016generic_closures0A21_nondependent_context{{.*}} : $@convention(thin) (Int) -> Int
   // CHECK: [[FOO_CLOSURE:%.*]] = apply [[FOO]]
-  return foo()
+  _ = foo()
+
+  // CHECK: [[BAR:%.*]] = function_ref @_T016generic_closures0A21_nondependent_context{{.*}} : $@convention(thin) (Int) -> Int
+  // CHECK: [[BAR_CLOSURE:%.*]] = apply [[BAR]]
+
+  // CHECK: [[BAR_CLOSURE]]
+  return bar()
 }
 
 // CHECK-LABEL: sil hidden @_T016generic_closures0A8_capture{{[_0-9a-zA-Z]*}}F
@@ -29,6 +42,8 @@ func generic_capture<T>(_ x: T) -> Any.Type {
 
   // CHECK: [[FOO:%.*]] = function_ref @_T016generic_closures0A8_capture{{.*}} : $@convention(thin) <τ_0_0> () -> @thick Any.Type
   // CHECK: [[FOO_CLOSURE:%.*]] = apply [[FOO]]<T>()
+
+  // CHECK: return [[FOO_CLOSURE]]
   return foo()
 }
 
@@ -43,6 +58,8 @@ func generic_capture_cast<T>(_ x: T, y: Any) -> Bool {
 
   // CHECK: [[FOO:%.*]] = function_ref @_T016generic_closures0A13_capture_cast{{.*}} : $@convention(thin) <τ_0_0> (@in Any) -> Bool
   // CHECK: [[FOO_CLOSURE:%.*]] = apply [[FOO]]<T>([[ARG:%.*]])
+
+  // CHECK: return [[FOO_CLOSURE]]
   return foo(y)
 }
 
@@ -61,6 +78,8 @@ func generic_nocapture_existential<T>(_ x: T, y: Concept) -> Bool {
 
   // CHECK: [[FOO:%.*]] = function_ref @_T016generic_closures0A22_nocapture_existential{{.*}} : $@convention(thin) (@in Concept) -> Bool
   // CHECK: [[FOO_CLOSURE:%.*]] = apply [[FOO]]([[ARG:%.*]])
+
+  // CHECK: return [[FOO_CLOSURE]]
   return foo(y)
 }
 
@@ -75,6 +94,8 @@ func generic_dependent_context<T>(_ x: T, y: Int) -> T {
 
   // CHECK: [[FOO:%.*]] = function_ref @_T016generic_closures0A18_dependent_context{{.*}} : $@convention(thin) <τ_0_0> (@owned <τ_0_0> { var τ_0_0 } <τ_0_0>) -> @out τ_0_0
   // CHECK: [[FOO_CLOSURE:%.*]] = apply [[FOO]]<T>
+
+  // CHECK: return
   return foo()
 }
 

--- a/test/SILGen/properties.swift
+++ b/test/SILGen/properties.swift
@@ -325,6 +325,25 @@ func logical_local_get(_ x: Int) -> Int {
 // CHECK-: sil private [[PROP_GET_CLOSURE]]
 // CHECK: bb0(%{{[0-9]+}} : $Int):
 
+func logical_generic_local_get<T>(_ x: Int, _: T) {
+  var prop1: Int {
+    get {
+      return x
+    }
+  }
+
+  _ = prop1
+
+  var prop2: Int {
+    get {
+      _ = T.self
+      return x
+    }
+  }
+
+  _ = prop2
+}
+
 // CHECK-LABEL: sil hidden @_T010properties26logical_local_captured_get{{[_0-9a-zA-Z]*}}F
 func logical_local_captured_get(_ x: Int) -> Int {
   var prop : Int {
@@ -654,7 +673,26 @@ func local_observing_property(_ arg: Int) {
 // CHECK: [[PB:%.*]] = project_box [[BOX]]
 // CHECK: store [[ARG]] to [trivial] [[PB]]
 
+func local_generic_observing_property<T>(_ arg: Int, _: T) {
+  var localproperty1: Int = arg {
+    didSet {
+      takeInt(localproperty1)
+    }
+  }
+  
+  takeInt(localproperty1)
+  localproperty1 = arg
 
+  var localproperty2: Int = arg {
+    didSet {
+      _ = T.self
+      takeInt(localproperty2)
+    }
+  }
+  
+  takeInt(localproperty2)
+  localproperty2 = arg
+}
 
 
 // <rdar://problem/16006333> observing properties don't work in @objc classes


### PR DESCRIPTION
When evaluating if a call of a local function requires substitutions,
we checked if the immediate function being referenced captured
generic parameters, without checking if it transitively captured
generic parameters via other local functions it references.

Also, when calling accessors, we did not perform this check at all.

Fix both ordinary function calls and accessor calls to drop the
substitutions only if the *lowered* local captures say it is safe.

Finally, fix Sema to not consider substitutions in local function
references as generic parameter captures, since we now correctly
calculate the transitive closure of all captures.

Fixes <rdar://problem/32761305> and related issues.