### PR TITLE
[Parse] Fix skipping string interpolation in Lexer

### DIFF
--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -1244,6 +1244,9 @@ static const char *skipToEndOfInterpolatedExpression(const char *CurPtr,
                                                      DiagnosticEngine *Diags,
                                                      bool MultilineString) {
   llvm::SmallVector<char, 4> OpenDelimiters;
+  llvm::SmallVector<bool, 4> AllowNewline;
+  AllowNewline.push_back(MultilineString);
+
   auto inStringLiteral = [&]() {
     return !OpenDelimiters.empty() &&
            (OpenDelimiters.back() == '"' || OpenDelimiters.back() == '\'');
@@ -1262,27 +1265,46 @@ static const char *skipToEndOfInterpolatedExpression(const char *CurPtr,
     // interpolated ones are no exception - unless multiline literals.
     case '\n':
     case '\r':
-      if (MultilineString)
+      if (AllowNewline.back())
         continue;
       // Will be diagnosed as an unterminated string literal.
       return CurPtr-1;
 
     case '"':
-    case '\'':
-      if (inStringLiteral()) {
-        // Is it the closing quote?
+    case '\'': {
+      if (!AllowNewline.back() && inStringLiteral()) {
         if (OpenDelimiters.back() == CurPtr[-1]) {
+          // Closing single line string literal.
           OpenDelimiters.pop_back();
+          AllowNewline.pop_back();
         }
-        // Otherwise it's an ordinary character; treat it normally.
-      } else {
-        OpenDelimiters.push_back(CurPtr[-1]);
+        // Otherwise, it's just a quote in string literal. e.g. "foo's".
+        continue;
       }
-      if (*CurPtr == '"' && *(CurPtr + 1) == '"' && *(CurPtr - 1) == '"') {
-        MultilineString = true;
+
+      bool isMultilineQuote = (
+          *CurPtr == '"' && *(CurPtr + 1) == '"' && *(CurPtr - 1) == '"');
+      if (isMultilineQuote)
         CurPtr += 2;
+
+      if (!inStringLiteral()) {
+        // Open string literal
+        OpenDelimiters.push_back(CurPtr[-1]);
+        AllowNewline.push_back(isMultilineQuote);
+        continue;
       }
+
+      // We are in multiline string literal.
+      assert(AllowNewline.back() && "other cases must be handled above");
+      if (isMultilineQuote) {
+        // Close multiline string literal.
+        OpenDelimiters.pop_back();
+        AllowNewline.pop_back();
+      }
+
+      // Otherwise, it's just a normal character in multiline string.
       continue;
+    }
     case '\\':
       if (inStringLiteral()) {
         char escapedChar = *CurPtr++;

--- a/test/Parse/multiline_errors.swift
+++ b/test/Parse/multiline_errors.swift
@@ -106,3 +106,17 @@ Three B
           // expected-error@-14{{unexpected space in indentation of next 4 lines in multi-line string literal}}
           // expected-note@-7{{should match tab here}}
           // expected-note@-16{{change indentation of these lines to match closing delimiter}} {{1-1=		}} {{1-1=		}} {{1-1=		}} {{1-1=		}}
+
+_ = "hello\("""
+            world
+            """
+            )!"
+            // expected-error@-4 {{unterminated string literal}}
+            // expected-error@-2 {{unterminated string literal}}
+
+_ = "hello\(
+            """
+            world
+            """)!"
+            // expected-error@-4 {{unterminated string literal}}
+            // expected-error@-2 {{unterminated string literal}}

--- a/test/Parse/multiline_string.swift
+++ b/test/Parse/multiline_string.swift
@@ -160,3 +160,24 @@ _ = """
 // CHECK: "hello"
 // CHECK: "world"
 // CHECK: "\nabc"
+
+_ = "hello\("""
+            "world'
+            """)abc"
+// CHECK: "hello"
+// CHECK: "\"world'"
+// CHECK: "abc"
+
+_ = """
+    welcome
+    \(
+      "to\("""
+           Swift
+           """)"
+    )
+    !
+    """
+// CHECK: "welcome\n"
+// CHECK: "to"
+// CHECK: "Swift"
+// CHECK: "\n!"


### PR DESCRIPTION
Maintain inner most string literal mode to determine whether we allow
newline character or not.

* Disallow newline after multiline string in string interpolation. ([SR-5171](https://bugs.swift.org/browse/SR-5171))

  ```swift
  "abc\("""
        defg
        """ // ← This newline should be rejected.
        )hij"
  ```
* Allow unbalanced `"` in multiline string in string interpolation.

  ```swift
  "abc\("""
        "defg ← This unbalanced quote should be accepted
        """)hij"
  ```