### PR TITLE
Rename some X-Value-related entities

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -539,7 +539,7 @@ public:
 
   /// Determines whether this type is an lvalue. This includes both straight
   /// lvalue types as well as tuples or optionals of lvalues.
-  bool isLValueType() {
+  bool hasLValueType() {
     return getRecursiveProperties().isLValue();
   }
   
@@ -569,7 +569,7 @@ public:
   }
 
   /// \brief Check if this type is a valid type for the LHS of an assignment.
-  /// This mainly means isLValueType(), but empty tuples and tuples of empty
+  /// This mainly means hasLValueType(), but empty tuples and tuples of empty
   /// tuples also qualify.
   bool isAssignableType();
 
@@ -4388,7 +4388,7 @@ inline bool TypeBase::isTypeParameter() {
 }
 
 inline bool TypeBase::isMaterializable() {
-  if (isLValueType())
+  if (hasLValueType())
     return false;
   
   if (is<InOutType>())

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -3101,18 +3101,11 @@ DynamicSelfType *DynamicSelfType::get(Type selfType, const ASTContext &ctx) {
   return result;
 }
 
-static void checkFunctionRecursiveProperties(Type Input,
-                                             Type Result) {
-  // TODO: Would be nice to be able to assert these, but they trip during
-  // constraint solving:
-  //assert(!Input->getRecursiveProperties().isLValue()
-  //       && "function should not take lvalues directly as parameters");
-}
-
 static RecursiveTypeProperties getFunctionRecursiveProperties(Type Input,
                                                               Type Result) {
-  checkFunctionRecursiveProperties(Input, Result);
-
+//  assert(!Input->hasLValueType()
+//         && "function should not take lvalues directly as parameters");
+  
   auto properties = Input->getRecursiveProperties()
                   | Result->getRecursiveProperties();
   properties &= ~RecursiveTypeProperties::IsLValue;
@@ -3124,8 +3117,9 @@ static RecursiveTypeProperties getFunctionRecursiveProperties(Type Input,
 // always materializable.
 static RecursiveTypeProperties
 getGenericFunctionRecursiveProperties(Type Input, Type Result) {
-  checkFunctionRecursiveProperties(Input, Result);
-
+//  assert(!Input->hasLValueType()
+//         && "function should not take lvalues directly as parameters");
+  
   static_assert(RecursiveTypeProperties::BitWidth == 10,
                 "revisit this if you add new recursive type properties");
   RecursiveTypeProperties properties;

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -532,7 +532,7 @@ public:
       // Require an access kind to be set on every l-value expression.
       // Note that the empty tuple type is assignable but usually isn't
       // an l-value, so we have to be conservative there.
-      if (E->getType()->isLValueType() != E->hasLValueAccessKind() &&
+      if (E->getType()->hasLValueType() != E->hasLValueAccessKind() &&
           !(E->hasLValueAccessKind() && E->getType()->isAssignableType())) {
         Out << "l-value expression does not have l-value access kind set\n";
         E->print(Out);
@@ -1669,7 +1669,7 @@ public:
     }
 
     void verifyChecked(OptionalEvaluationExpr *E) {
-      if (E->getType()->isLValueType()) {
+      if (E->getType()->hasLValueType()) {
         Out << "Optional evaluation should not produce an lvalue";
         E->print(Out);
         abort();

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -261,16 +261,16 @@ void Expr::propagateLValueAccessKind(AccessKind accessKind,
     }
 
     void visitMemberRefExpr(MemberRefExpr *E, AccessKind accessKind) {
-      if (!GetType(E->getBase())->isLValueType()) return;
+      if (!GetType(E->getBase())->hasLValueType()) return;
       visit(E->getBase(), getBaseAccessKind(E->getMember(), accessKind));
     }
     void visitSubscriptExpr(SubscriptExpr *E, AccessKind accessKind) {
-      if (!GetType(E->getBase())->isLValueType()) return;
+      if (!GetType(E->getBase())->hasLValueType()) return;
       visit(E->getBase(), getBaseAccessKind(E->getDecl(), accessKind));
     }
     void visitKeyPathApplicationExpr(KeyPathApplicationExpr *E,
                                      AccessKind accessKind) {
-      if (!GetType(E->getBase())->isLValueType()) return;
+      if (!GetType(E->getBase())->hasLValueType()) return;
       auto kpDecl = GetType(E->getKeyPath())->castTo<BoundGenericType>()
         ->getDecl();
       AccessKind baseAccess;

--- a/lib/AST/LookupVisibleDecls.cpp
+++ b/lib/AST/LookupVisibleDecls.cpp
@@ -488,7 +488,7 @@ static void lookupVisibleMemberDeclsImpl(
     VisitedSet &Visited) {
   // Just look through l-valueness.  It doesn't affect name lookup.
   assert(BaseTy && "lookup into null type");
-  assert(!BaseTy->isLValueType());
+  assert(!BaseTy->hasLValueType());
 
   // Handle metatype references, as in "some_type.some_member".  These are
   // special and can't have extensions.
@@ -694,7 +694,7 @@ public:
   OverrideFilteringConsumer(Type BaseTy, const DeclContext *DC,
                             LazyResolver *resolver)
       : BaseTy(BaseTy), DC(DC), TypeResolver(resolver) {
-    assert(!BaseTy->isLValueType());
+    assert(!BaseTy->hasLValueType());
     if (auto *MetaTy = BaseTy->getAs<AnyMetatypeType>())
       BaseTy = MetaTy->getInstanceType();
     assert(DC && BaseTy);

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -467,7 +467,7 @@ bool TypeBase::isBool() {
 
 
 bool TypeBase::isAssignableType() {
-  if (isLValueType()) return true;
+  if (hasLValueType()) return true;
   if (auto tuple = getAs<TupleType>()) {
     for (auto eltType : tuple->getElementTypes()) {
       if (!eltType->isAssignableType())
@@ -480,7 +480,7 @@ bool TypeBase::isAssignableType() {
 
 Type TypeBase::getRValueType() {
   // If the type is not an lvalue, this is a no-op.
-  if (!isLValueType())
+  if (!hasLValueType())
     return this;
 
   return Type(this).transform([](Type t) -> Type {
@@ -3185,7 +3185,7 @@ TypeBase::getContextSubstitutions(const DeclContext *dc,
   assert(dc->isTypeContext());
   Type baseTy(this);
 
-  assert(!baseTy->isLValueType() && !baseTy->is<AnyMetatypeType>());
+  assert(!baseTy->hasLValueType() && !baseTy->is<AnyMetatypeType>());
 
   // The resulting set of substitutions. Always use this to ensure we
   // don't miss out on NRVO anywhere.

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -3465,7 +3465,7 @@ public:
     }
 
     if (leadingSequence.empty() && LHS->getType() &&
-        LHS->getType()->isLValueType()) {
+        LHS->getType()->hasLValueType()) {
       addAssignmentOperator(LHS->getType()->getRValueType(),
                             CurrDeclContext->getASTContext().TheEmptyTupleType);
     }

--- a/lib/IDE/SwiftSourceDocInfo.cpp
+++ b/lib/IDE/SwiftSourceDocInfo.cpp
@@ -861,7 +861,7 @@ public:
       ReferencedDecls.emplace_back(VD, Ty);
     } else {
       // LValue type should take precedence.
-      if (!It->Ty->isLValueType() && Ty->isLValueType()) {
+      if (!It->Ty->hasLValueType() && Ty->hasLValueType()) {
         It->Ty = Ty;
       }
     }

--- a/lib/IRGen/DebugTypeInfo.h
+++ b/lib/IRGen/DebugTypeInfo.h
@@ -100,8 +100,7 @@ public:
   // instead? Otherwise optionals of archetypes etc will still have
   // 'isImplicitlyIndirect()' return false.
   bool isImplicitlyIndirect() const {
-    return Type->isLValueType() || isArchetype() ||
-      Type->is<InOutType>();
+    return Type->hasLValueType() || isArchetype() || Type->is<InOutType>();
   }
 
   bool isNull() const { return Type == nullptr; }

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3545,7 +3545,7 @@ namespace {
     // If the destination is a tuple, recursively destructure.
     void visitTupleExpr(TupleExpr *E) {
       auto *TTy = E->getType()->castTo<TupleType>();
-      assert(TTy->isLValueType() || TTy->isVoid());
+      assert(TTy->hasLValueType() || TTy->isVoid());
       for (auto &elt : E->getElements()) {
         visit(elt);
       }
@@ -4507,7 +4507,7 @@ RValue RValueEmitter::visitUnevaluatedInstanceExpr(UnevaluatedInstanceExpr *E,
 }
 
 RValue SILGenFunction::emitRValue(Expr *E, SGFContext C) {
-  assert(!E->getType()->isLValueType() &&
+  assert(!E->getType()->hasLValueType() &&
          "l-values must be emitted with emitLValue");
   return RValueEmitter(*this).visit(E, C);
 }
@@ -4527,7 +4527,7 @@ void SILGenFunction::emitIgnoredExpr(Expr *E) {
   // arguments.
   
   FullExpr scope(Cleanups, CleanupLocation(E));
-  if (E->getType()->isLValueType()) {
+  if (E->getType()->hasLValueType()) {
     // Emit the l-value, but don't perform an access.
     FormalEvaluationScope scope(*this);
     emitLValue(E, AccessKind::Read);

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -2993,7 +2993,7 @@ SILGenFunction::emitOpenExistentialLValue(SILLocation loc,
                                           CanArchetypeType openedArchetype,
                                           CanType formalRValueType,
                                           AccessKind accessKind) {
-  assert(!formalRValueType->isLValueType());
+  assert(!formalRValueType->hasLValueType());
   LValueTypeData typeData = {
     AbstractionPattern::getOpaque(), formalRValueType,
     getLoweredType(formalRValueType).getObjectType()

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -1351,7 +1351,7 @@ namespace {
               base = cs.coerceToRValue(base);
             } else if (keyPathBGT->getDecl() ==
                          cs.getASTContext().getWritableKeyPathDecl()) {
-              resultIsLValue = cs.getType(base)->isLValueType();
+              resultIsLValue = cs.getType(base)->hasLValueType();
             } else if (keyPathBGT->getDecl() ==
                        cs.getASTContext().getReferenceWritableKeyPathDecl()) {
               resultIsLValue = true;
@@ -2594,7 +2594,7 @@ namespace {
         // tuple coercion to properly load & set access kind on all underlying elements
         // before taking a single element.
         baseTy = cs.getType(base);
-        if (!toType->isLValueType() && baseTy->isLValueType())
+        if (!toType->hasLValueType() && baseTy->hasLValueType())
           base = coerceToType(base, baseTy->getRValueType(), cs.getConstraintLocator(base));
 
         return cs.cacheType(new (cs.getASTContext())
@@ -3785,7 +3785,7 @@ namespace {
           return E;
         }
 
-        if (cs.getType(subExpr)->isLValueType()) {
+        if (cs.getType(subExpr)->hasLValueType()) {
           // Treat this like a read of the property.
           cs.propagateLValueAccessKind(subExpr, AccessKind::Read);
         }
@@ -5006,7 +5006,7 @@ Expr *ExprRewriter::coerceExistential(Expr *expr, Type toType,
 
   // Load tuples with lvalue elements.
   if (auto tupleType = fromType->getAs<TupleType>()) {
-    if (tupleType->isLValueType()) {
+    if (tupleType->hasLValueType()) {
       auto toTuple = tupleType->getRValueType()->castTo<TupleType>();
       SmallVector<int, 4> sources;
       SmallVector<unsigned, 4> variadicArgs;
@@ -7545,7 +7545,7 @@ Expr *ConstraintSystem::applySolution(Solution &solution, Expr *expr,
                                    getConstraintLocator(expr));
     if (!result)
       return nullptr;
-  } else if (getType(result)->isLValueType() && !discardedExpr) {
+  } else if (getType(result)->hasLValueType() && !discardedExpr) {
     // We referenced an lvalue. Load it.
     result = rewriter.coerceToType(result, getType(result)->getRValueType(),
                                    getConstraintLocator(expr));

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -1438,7 +1438,7 @@ CalleeCandidateInfo::evaluateCloseness(UncurriedCandidate candidate,
   // Check to see if the first argument expects an inout argument, but is not
   // an lvalue.
   Type firstArg = actualArgs[0].Ty;
-  if (candArgs[0].Ty->is<InOutType>() && !(firstArg->isLValueType() || firstArg->is<InOutType>()))
+  if (candArgs[0].Ty->is<InOutType>() && !(firstArg->hasLValueType() || firstArg->is<InOutType>()))
     return { CC_NonLValueInOut, {}};
   
   // If we have exactly one argument mismatching, classify it specially, so that
@@ -4115,7 +4115,7 @@ bool FailureDiagnosis::diagnoseContextualConversionError() {
                contextDecl == CS->TC.Context.getUnsafeRawPointerDecl() ||
                contextDecl == CS->TC.Context.getUnsafeMutableRawPointerDecl()) {
       for (Type arg : genericType->getGenericArgs()) {
-        if (arg->isEqual(exprType) && CS->getType(expr)->isLValueType()) {
+        if (arg->isEqual(exprType) && CS->getType(expr)->hasLValueType()) {
           diagnose(expr->getLoc(), diagID, exprType, contextualType).
             fixItInsert(expr->getStartLoc(), "&");
           return true;
@@ -6413,7 +6413,7 @@ bool FailureDiagnosis::visitAssignExpr(AssignExpr *assignExpr) {
 
   // If the result type is a non-lvalue, then we are failing because it is
   // immutable and that's not a great thing to assign to.
-  if (!destType->isLValueType()) {
+  if (!destType->hasLValueType()) {
     CS->diagnoseAssignmentFailure(destExpr, destType, assignExpr->getLoc());
     return true;
   }
@@ -6506,7 +6506,7 @@ bool FailureDiagnosis::visitInOutExpr(InOutExpr *IOE) {
   auto subExprType = CS->getType(subExpr);
 
   // The common cause is that the operand is not an lvalue.
-  if (!subExprType->isLValueType()) {
+  if (!subExprType->hasLValueType()) {
     diagnoseSubElementFailure(subExpr, IOE->getLoc(), *CS,
                               diag::cannot_pass_rvalue_inout_subelement,
                               diag::cannot_pass_rvalue_inout);

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1441,7 +1441,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
         // If the left-hand type variable cannot bind to an lvalue,
         // but we still have an lvalue, fail.
         if (!typeVar1->getImpl().canBindToLValue() &&
-            type2->isLValueType())
+            type2->hasLValueType())
           return SolutionKind::Error;
 
         // Okay. Bind below.
@@ -1489,7 +1489,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
       }
 
       if (!typeVar2->getImpl().canBindToLValue() &&
-          type1->isLValueType()) {
+          type1->hasLValueType()) {
         return SolutionKind::Error;
         
         // Okay. Bind below.

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1379,7 +1379,7 @@ static bool tryTypeVariableBindings(
       // Handle simple subtype bindings.
       if (binding.Kind == AllowedBindingKind::Subtypes &&
           typeVar->getImpl().canBindToLValue() &&
-          !type->isLValueType() &&
+          !type->hasLValueType() &&
           !type->is<InOutType>()) {
         // Try lvalue qualification in addition to rvalue qualification.
         auto subtype = LValueType::get(type);

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -2306,7 +2306,7 @@ void VarDeclUsageChecker::
 markBaseOfAbstractStorageDeclStore(Expr *base, ConcreteDeclRef decl) {
   // If the base is a class or an rvalue, then this store just loads the base.
   if (base->getType()->isAnyClassReferenceType() ||
-      !(base->getType()->isLValueType() || base->getType()->is<InOutType>())) {
+      !(base->getType()->hasLValueType() || base->getType()->is<InOutType>())) {
     base->walk(*this);
     return;
   }

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2856,7 +2856,7 @@ bool TypeChecker::isSubstitutableFor(Type type, ArchetypeType *archetype,
   return true;
 }
 
-Expr *TypeChecker::coerceToMaterializable(Expr *expr) {
+Expr *TypeChecker::coerceToRValue(Expr *expr) {
   // If expr has no type, just assume it's the right expr.
   if (!expr->getType())
     return expr;
@@ -2864,7 +2864,7 @@ Expr *TypeChecker::coerceToMaterializable(Expr *expr) {
   Type exprTy = expr->getType();
   
   // If the type is already materializable, then we're already done.
-  if (!exprTy->isLValueType())
+  if (!exprTy->hasLValueType())
     return expr;
   
   // Load lvalues.
@@ -2875,7 +2875,7 @@ Expr *TypeChecker::coerceToMaterializable(Expr *expr) {
 
   // Walk into parenthesized expressions to update the subexpression.
   if (auto paren = dyn_cast<IdentityExpr>(expr)) {
-    auto sub = coerceToMaterializable(paren->getSubExpr());
+    auto sub = coerceToRValue(paren->getSubExpr());
     paren->setSubExpr(sub);
     paren->setType(sub->getType());
     return paren;
@@ -2883,7 +2883,7 @@ Expr *TypeChecker::coerceToMaterializable(Expr *expr) {
 
   // Walk into 'try' and 'try!' expressions to update the subexpression.
   if (auto tryExpr = dyn_cast<AnyTryExpr>(expr)) {
-    auto sub = coerceToMaterializable(tryExpr->getSubExpr());
+    auto sub = coerceToRValue(tryExpr->getSubExpr());
     tryExpr->setSubExpr(sub);
     if (isa<OptionalTryExpr>(tryExpr) && !sub->getType()->hasError())
       tryExpr->setType(OptionalType::get(sub->getType()));
@@ -2898,7 +2898,7 @@ Expr *TypeChecker::coerceToMaterializable(Expr *expr) {
     for (auto &elt : tuple->getElements()) {
       // Materialize the element.
       auto oldType = elt->getType();
-      elt = coerceToMaterializable(elt);
+      elt = coerceToRValue(elt);
 
       // If the type changed at all, make a note of it.
       if (elt->getType().getPointer() != oldType.getPointer()) {

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -6573,7 +6573,7 @@ public:
 
     // Require the carried type to be materializable.
     if (auto argTy = EED->getArgumentInterfaceType()) {
-      assert(!argTy->isLValueType() && "enum element cannot carry @lvalue");
+      assert(!argTy->hasLValueType() && "enum element cannot carry @lvalue");
       
       if (!argTy->isMaterializable()) {
         TC.diagnose(EED->getLoc(), diag::enum_element_not_materializable, argTy);

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -1623,7 +1623,7 @@ bool TypeChecker::coerceParameterListToType(ParameterList *P, ClosureExpr *CE,
       }
     }
     
-    assert(!ty->isLValueType() && "Bound param type to @lvalue?");
+    assert(!ty->hasLValueType() && "Bound param type to @lvalue?");
     if (ty->is<InOutType>()) {
       param->setLet(false);
     } else if (auto *TTy = ty->getAs<TupleType>()) {

--- a/lib/Sema/TypeCheckREPL.cpp
+++ b/lib/Sema/TypeCheckREPL.cpp
@@ -217,7 +217,7 @@ namespace {
 /// description of the pattern involved.
 void REPLChecker::generatePrintOfExpression(StringRef NameStr, Expr *E) {
   // Always print rvalues, not lvalues.
-  E = TC.coerceToMaterializable(E);
+  E = TC.coerceToRValue(E);
 
   SourceLoc Loc = E->getStartLoc();
   SourceLoc EndLoc = E->getEndLoc();
@@ -304,7 +304,7 @@ void REPLChecker::processREPLTopLevelExpr(Expr *E) {
   // going to reparent it.
   auto TLCD = cast<TopLevelCodeDecl>(SF.Decls.back());
 
-  E = TC.coerceToMaterializable(E);
+  E = TC.coerceToRValue(E);
 
   // Create the meta-variable, let the typechecker name it.
   Identifier name = TC.getNextResponseVariableName(SF.getParentModule());
@@ -408,7 +408,7 @@ void REPLChecker::processREPLTopLevelPatternBinding(PatternBindingDecl *PBD) {
     // Replace the initializer of PBD with a reference to our repl temporary.
     Expr *E = TC.buildCheckedRefExpr(vd, &SF, DeclNameLoc(vd->getStartLoc()),
                                      /*Implicit=*/true);
-    E = TC.coerceToMaterializable(E);
+    E = TC.coerceToRValue(E);
     PBD->setInit(entryIdx, E);
     SF.Decls.push_back(PBTLCD);
     

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -862,7 +862,7 @@ public:
     // Type-check the subject expression.
     Expr *subjectExpr = S->getSubjectExpr();
     hadError |= TC.typeCheckExpression(subjectExpr, DC);
-    if (Expr *newSubjectExpr = TC.coerceToMaterializable(subjectExpr))
+    if (Expr *newSubjectExpr = TC.coerceToRValue(subjectExpr))
       subjectExpr = newSubjectExpr;
     S->setSubjectExpr(subjectExpr);
     Type subjectType = S->getSubjectExpr()->getType();
@@ -1080,7 +1080,7 @@ void TypeChecker::checkIgnoredExpr(Expr *E) {
   }
 
   // Complain about l-values that are neither loaded nor stored.
-  if (E->getType()->isLValueType()) {
+  if (E->getType()->hasLValueType()) {
     diagnose(E->getLoc(), diag::expression_unused_lvalue)
       .highlight(E->getSourceRange());
     return;

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1747,7 +1747,7 @@ public:
 
   /// \brief Coerce the given expression to materializable type, if it
   /// isn't already.
-  Expr *coerceToMaterializable(Expr *expr);
+  Expr *coerceToRValue(Expr *expr);
 
   /// Require that the library intrinsics for working with Optional<T>
   /// exist.


### PR DESCRIPTION
* Rename coerceToMaterializableValue to coerceToRValue

* Rename isLValueType to hasLValueType to better match the
intended semantics of the member.

<strike>* Turn on anti-LValue asserts in function types</strike>

The last commit is revertible if we fail any of the test suites.

This patch will be rebased on top of #10242 after it has been merged