### PR TITLE
[ClangImporter] Fix indirection mismatch surrounding swift_newtype

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -5285,16 +5285,30 @@ Decl *SwiftDeclConverter::importGlobalAsMethod(
   auto &C = Impl.SwiftContext;
   SmallVector<ParameterList *, 2> bodyParams;
 
-  // There is an inout 'self' when we have an instance method of a
-  // value-semantic type whose 'self' parameter is a
-  // pointer-to-non-const.
+  // There is an inout 'self' when the parameter is a pointer to a non-const
+  // instance of the type we're importing onto. Importing this as a method means
+  // that the method should be treated as mutating in this situation.
   bool selfIsInOut = false;
   if (selfIdx && !dc->getDeclaredTypeOfContext()->hasReferenceSemantics()) {
     auto selfParam = decl->getParamDecl(*selfIdx);
     auto selfParamTy = selfParam->getType();
     if ((selfParamTy->isPointerType() || selfParamTy->isReferenceType()) &&
-        !selfParamTy->getPointeeType().isConstQualified())
+        !selfParamTy->getPointeeType().isConstQualified()) {
       selfIsInOut = true;
+
+      // If there's a swift_newtype, check the levels of indirection: self is
+      // only inout if this is a pointer to the typedef type (which itself is a
+      // pointer).
+      if (auto nominalTypeDecl =
+              dc->getAsNominalTypeOrNominalTypeExtensionContext()) {
+        if (auto clangDCTy = dyn_cast_or_null<clang::TypedefNameDecl>(
+                nominalTypeDecl->getClangDecl()))
+          if (auto newtypeAttr = getSwiftNewtypeAttr(clangDCTy, getVersion()))
+            if (clangDCTy->getUnderlyingType().getCanonicalType() !=
+                selfParamTy->getPointeeType().getCanonicalType())
+              selfIsInOut = false;
+      }
+    }
   }
 
   bodyParams.push_back(ParameterList::createWithoutLoc(ParamDecl::createSelf(

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -424,22 +424,12 @@ enum class ConventionsKind : uint8_t {
                 ClassDecl::ForeignKind::CFType) {
             return false;
           }
-          // swift_newtype-ed CF type as foreign class
-          if (auto typedefTy = clangTy->getAs<clang::TypedefType>()) {
-            if (typedefTy->getDecl()->getAttr<clang::SwiftNewtypeAttr>()) {
-              // Make sure that we actually made the struct during import
-              if (auto underlyingType =
-                      substTy->getSwiftNewtypeUnderlyingType()) {
-                if (auto underlyingClass =
-                        underlyingType->getClassOrBoundGenericClass()) {
-                  if (underlyingClass->getForeignClassKind() ==
-                          ClassDecl::ForeignKind::CFType) {
-                    return false;
-                  }
-                }
-              }
-            }
-          }
+        }
+
+        // swift_newtypes are always passed directly
+        if (auto typedefTy = clangTy->getAs<clang::TypedefType>()) {
+          if (typedefTy->getDecl()->getAttr<clang::SwiftNewtypeAttr>())
+            return false;
         }
 
         return true;

--- a/test/IDE/Inputs/custom-modules/Newtype.h
+++ b/test/IDE/Inputs/custom-modules/Newtype.h
@@ -102,3 +102,29 @@ __attribute((swift_name("NSSomeContext.Name")));
 
 extern const NSSomeContextName NSMyContextName;
 
+typedef struct T *TRef __attribute((swift_newtype(struct)));
+typedef const struct T *ConstTRef __attribute((swift_newtype(struct)));
+extern _Nonnull TRef create_T(void);
+extern _Nonnull ConstTRef create_ConstT(void);
+extern void destroy_T(TRef);
+extern void destroy_ConstT(ConstTRef);
+
+extern void mutate_TRef_Pointee(TRef) __attribute((swift_name("TRef.mutatePointee(self:)")));
+extern void mutate_TRef(TRef *) __attribute((swift_name("TRef.mutate(self:)")));
+extern void use_ConstT(ConstTRef)
+    __attribute((swift_name("ConstTRef.use(self:)")));
+
+
+typedef struct T *__nonnull *TRefRef __attribute((swift_newtype(struct)));
+typedef struct T *__nonnull const *ConstTRefRef __attribute((swift_newtype(struct)));
+extern _Nonnull TRefRef create_TRef(void);
+extern _Nonnull ConstTRefRef create_ConstTRef(void);
+extern void destroy_TRef(TRefRef);
+extern void destroy_ConstTRef(ConstTRefRef);
+
+extern void mutate_TRefRef_Pointee(TRefRef)
+    __attribute((swift_name("TRefRef.mutatePointee(self:)")));
+extern void mutate_TRefRef(TRefRef*)
+    __attribute((swift_name("TRefRef.mutate(self:)")));
+extern void use_ConstTRef(ConstTRefRef)
+    __attribute((swift_name("ConstTRefRef.use(self:)")));

--- a/test/IDE/newtype.swift
+++ b/test/IDE/newtype.swift
@@ -149,6 +149,54 @@
 // PRINT-NEXT:  extension NSSomeContext.Name {
 // PRINT-NEXT:    static let myContextName: NSSomeContext.Name
 // PRINT-NEXT:  }
+//
+// PRINT-NEXT: struct TRef : RawRepresentable, _SwiftNewtypeWrapper, Equatable, Hashable {
+// PRINT-NEXT:   init(_ rawValue: OpaquePointer)
+// PRINT-NEXT:   init(rawValue: OpaquePointer)
+// PRINT-NEXT:   let rawValue: OpaquePointer
+// PRINT-NEXT:   typealias RawValue = OpaquePointer
+// PRINT-NEXT: }
+// PRINT-NEXT: struct ConstTRef : RawRepresentable, _SwiftNewtypeWrapper, Equatable, Hashable {
+// PRINT-NEXT:   init(_ rawValue: OpaquePointer)
+// PRINT-NEXT:   init(rawValue: OpaquePointer)
+// PRINT-NEXT:   let rawValue: OpaquePointer
+// PRINT-NEXT:   typealias RawValue = OpaquePointer
+// PRINT-NEXT: }
+// PRINT-NEXT: func create_T() -> TRef
+// PRINT-NEXT: func create_ConstT() -> ConstTRef
+// PRINT-NEXT: func destroy_T(_: TRef!)
+// PRINT-NEXT: func destroy_ConstT(_: ConstTRef!)
+// PRINT-NEXT: extension TRef {
+// PRINT-NEXT:   func mutatePointee()
+// PRINT-NEXT:   mutating func mutate()
+// PRINT-NEXT: }
+// PRINT-NEXT: extension ConstTRef {
+// PRINT-NEXT:   func use()
+// PRINT-NEXT: }
+//
+// PRINT-NEXT: struct TRefRef : RawRepresentable, _SwiftNewtypeWrapper, Equatable, Hashable {
+// PRINT-NEXT:   init(_ rawValue: UnsafeMutablePointer<OpaquePointer>)
+// PRINT-NEXT:   init(rawValue: UnsafeMutablePointer<OpaquePointer>)
+// PRINT-NEXT:   let rawValue: UnsafeMutablePointer<OpaquePointer>
+// PRINT-NEXT:   typealias RawValue = UnsafeMutablePointer<OpaquePointer>
+// PRINT-NEXT: }
+// PRINT-NEXT: struct ConstTRefRef : RawRepresentable, _SwiftNewtypeWrapper, Equatable, Hashable {
+// PRINT-NEXT:   init(_ rawValue: UnsafePointer<OpaquePointer>)
+// PRINT-NEXT:   init(rawValue: UnsafePointer<OpaquePointer>)
+// PRINT-NEXT:   let rawValue: UnsafePointer<OpaquePointer>
+// PRINT-NEXT:   typealias RawValue = UnsafePointer<OpaquePointer>
+// PRINT-NEXT: }
+// PRINT-NEXT: func create_TRef() -> TRefRef
+// PRINT-NEXT: func create_ConstTRef() -> ConstTRefRef
+// PRINT-NEXT: func destroy_TRef(_: TRefRef!)
+// PRINT-NEXT: func destroy_ConstTRef(_: ConstTRefRef!)
+// PRINT-NEXT: extension TRefRef {
+// PRINT-NEXT:   func mutatePointee()
+// PRINT-NEXT:   mutating func mutate()
+// PRINT-NEXT: }
+// PRINT-NEXT: extension ConstTRefRef {
+// PRINT-NEXT:   func use()
+// PRINT-NEXT: }
 
 import Newtype
 

--- a/test/IRGen/newtype.swift
+++ b/test/IRGen/newtype.swift
@@ -166,9 +166,9 @@ public func mutate() {
   // rather than passing a pointer indirectly. I.e. only 1 overall level of
   // indirection for non-mutating, 2 for mutating.
   //
-  // OPT: [[TRefAlloca:%.+]] = alloca %struct.T*, align 8
+  // OPT: [[TRefAlloca:%.+]] = alloca %struct.T*,
   // OPT: [[TRef:%.+]] = tail call %struct.T* @create_T()
-  // OPT: store %struct.T* [[TRef]], %struct.T** [[TRefAlloca]], align 8
+  // OPT: store %struct.T* [[TRef]], %struct.T** [[TRefAlloca]],
   var myT = create_T()
 
   // OPT: [[TRefConst:%.+]] = tail call %struct.T* @create_ConstT()
@@ -182,7 +182,7 @@ public func mutate() {
 
   // Since myT itself got mutated, now we have to reload from the alloca
   //
-  // OPT: [[TRefReloaded:%.+]] = load %struct.T*, %struct.T** [[TRefAlloca]], align 8
+  // OPT: [[TRefReloaded:%.+]] = load %struct.T*, %struct.T** [[TRefAlloca]],
   // OPT: call void @mutate_TRef_Pointee(%struct.T* [[TRefReloaded]])
   myT.mutatePointee()
 
@@ -199,9 +199,9 @@ public func mutateRef() {
   // a pointer pointer indirectly. I.e. only 2 overall levels of indirection for
   // non-mutating, 3 for mutating.
   //
-  // OPT: [[TRefRefAlloca:%.+]] = alloca %struct.T**, align 8
+  // OPT: [[TRefRefAlloca:%.+]] = alloca %struct.T**,
   // OPT: [[TRefRef:%.+]] = tail call %struct.T** @create_TRef()
-  // OPT: store %struct.T** [[TRefRef]], %struct.T*** [[TRefRefAlloca]], align 8
+  // OPT: store %struct.T** [[TRefRef]], %struct.T*** [[TRefRefAlloca]]
   var myTRef = create_TRef()
 
   // OPT: [[ConstTRefRef:%.+]] = tail call %struct.T** @create_ConstTRef()
@@ -215,7 +215,7 @@ public func mutateRef() {
 
   // Since myTRef itself got mutated, now we have to reload from the alloca
   //
-  // OPT: [[TRefReloaded:%.+]] = load %struct.T**, %struct.T*** [[TRefRefAlloca]], align 8
+  // OPT: [[TRefReloaded:%.+]] = load %struct.T**, %struct.T*** [[TRefRefAlloca]]
   // OPT: call void @mutate_TRefRef_Pointee(%struct.T** [[TRefReloaded]])
   myTRef.mutatePointee()
 

--- a/test/IRGen/newtype.swift
+++ b/test/IRGen/newtype.swift
@@ -158,3 +158,71 @@ class ObjCTest {
     return num
   }
 }
+
+// OPT-LABEL: _T07newtype6mutateyyF
+public func mutate() {
+  // Check for a mismatch in indirectness of the swift_newtype and the Clang
+  // type. These pointers should be passed directly for non-mutating functions,
+  // rather than passing a pointer indirectly. I.e. only 1 overall level of
+  // indirection for non-mutating, 2 for mutating.
+  //
+  // OPT: [[TRefAlloca:%.+]] = alloca %struct.T*, align 8
+  // OPT: [[TRef:%.+]] = tail call %struct.T* @create_T()
+  // OPT: store %struct.T* [[TRef]], %struct.T** [[TRefAlloca]], align 8
+  var myT = create_T()
+
+  // OPT: [[TRefConst:%.+]] = tail call %struct.T* @create_ConstT()
+  let myConstT = create_ConstT()
+
+  // OPT: tail call void @mutate_TRef_Pointee(%struct.T* [[TRef]])
+  myT.mutatePointee()
+
+  // OPT: call void @mutate_TRef(%struct.T** nonnull [[TRefAlloca]])
+  myT.mutate()
+
+  // Since myT itself got mutated, now we have to reload from the alloca
+  //
+  // OPT: [[TRefReloaded:%.+]] = load %struct.T*, %struct.T** [[TRefAlloca]], align 8
+  // OPT: call void @mutate_TRef_Pointee(%struct.T* [[TRefReloaded]])
+  myT.mutatePointee()
+
+  // OPT: call void @use_ConstT(%struct.T* [[TRefConst]])
+  myConstT.use()
+
+  // OPT: ret void
+}
+
+// OPT-LABEL: _T07newtype9mutateRefyyF
+public func mutateRef() {
+  // Check for a mismatch in indirectness of the swift_newtype and the Clang
+  // type. These pointer pointers should be passed directly, rather than passing
+  // a pointer pointer indirectly. I.e. only 2 overall levels of indirection for
+  // non-mutating, 3 for mutating.
+  //
+  // OPT: [[TRefRefAlloca:%.+]] = alloca %struct.T**, align 8
+  // OPT: [[TRefRef:%.+]] = tail call %struct.T** @create_TRef()
+  // OPT: store %struct.T** [[TRefRef]], %struct.T*** [[TRefRefAlloca]], align 8
+  var myTRef = create_TRef()
+
+  // OPT: [[ConstTRefRef:%.+]] = tail call %struct.T** @create_ConstTRef()
+  let myConstTRef = create_ConstTRef()
+
+  // OPT: tail call void @mutate_TRefRef_Pointee(%struct.T** [[TRefRef]])
+  myTRef.mutatePointee()
+
+  // OPT: call void @mutate_TRefRef(%struct.T*** nonnull [[TRefRefAlloca]])
+  myTRef.mutate()
+
+  // Since myTRef itself got mutated, now we have to reload from the alloca
+  //
+  // OPT: [[TRefReloaded:%.+]] = load %struct.T**, %struct.T*** [[TRefRefAlloca]], align 8
+  // OPT: call void @mutate_TRefRef_Pointee(%struct.T** [[TRefReloaded]])
+  myTRef.mutatePointee()
+
+  // OPT: call void @use_ConstTRef(%struct.T** [[ConstTRefRef]])
+  myConstTRef.use()
+
+  // OPT: ret void
+}
+
+


### PR DESCRIPTION
Previously, we did not properly handle levels of indirection for
swift_newtype-ed typedefs of pointer types. We imported them in a way
that tried to present the value semantics of the pointee rather than
of the pointer. We then tried (sometimes incorrectly) to detect and
fix this up during SILGen.

Instead, model with the value semantics of the pointer itself. SILGen
can then be simplified to just pass swift_newtypes the same as any
other struct: directly for non-mutating and indirectly for mutating
(i.e. inout self). Tests added.

<!-- What's in this pull request? -->
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<rdar://problem/26899737>

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->