### PR TITLE
Number bridge updates

### DIFF
--- a/stdlib/public/SDK/Foundation/NSNumber.swift
+++ b/stdlib/public/SDK/Foundation/NSNumber.swift
@@ -451,8 +451,24 @@ extension Float : _ObjectiveCBridgeable {
     }
     
     public static func _conditionallyBridgeFromObjectiveC(_ x: NSNumber, result: inout Float?) -> Bool {
-        guard let value = Float(exactly: x) else { return false }
-        result = value
+        guard let value = Double(exactly: x) else { return false }
+        guard !value.isNaN else {
+            result = Float.nan
+            return true
+        }
+        guard !value.isInfinite else {
+            if value.sign == .minus {
+                result = -Float.infinity
+            } else {
+                result = Float.infinity
+            }
+            return true
+        }
+        guard Swift.abs(value) <= Double(Float.greatestFiniteMagnitude) else {
+            return false
+        }
+        
+        result = Float(value)
         return true
     }
     

--- a/stdlib/public/SDK/Foundation/NSNumber.swift
+++ b/stdlib/public/SDK/Foundation/NSNumber.swift
@@ -14,7 +14,7 @@
 import CoreGraphics
 
 extension Int8 : _ObjectiveCBridgeable {
-    @available(swift, deprecated: 4)
+    @available(swift, deprecated: 4, renamed: "init(truncating:)")
     public init(_ number: NSNumber) {
         self = number.int8Value
     }
@@ -55,7 +55,7 @@ extension Int8 : _ObjectiveCBridgeable {
 }
 
 extension UInt8 : _ObjectiveCBridgeable {
-    @available(swift, deprecated: 4)
+    @available(swift, deprecated: 4, renamed: "init(truncating:)")
     public init(_ number: NSNumber) {
         self = number.uint8Value
     }
@@ -96,7 +96,7 @@ extension UInt8 : _ObjectiveCBridgeable {
 }
 
 extension Int16 : _ObjectiveCBridgeable {
-    @available(swift, deprecated: 4)
+    @available(swift, deprecated: 4, renamed: "init(truncating:)")
     public init(_ number: NSNumber) {
         self = number.int16Value
     }
@@ -137,7 +137,7 @@ extension Int16 : _ObjectiveCBridgeable {
 }
 
 extension UInt16 : _ObjectiveCBridgeable {
-    @available(swift, deprecated: 4)
+    @available(swift, deprecated: 4, renamed: "init(truncating:)")
     public init(_ number: NSNumber) {
         self = number.uint16Value
     }
@@ -178,7 +178,7 @@ extension UInt16 : _ObjectiveCBridgeable {
 }
 
 extension Int32 : _ObjectiveCBridgeable {
-    @available(swift, deprecated: 4)
+    @available(swift, deprecated: 4, renamed: "init(truncating:)")
     public init(_ number: NSNumber) {
         self = number.int32Value
     }
@@ -219,7 +219,7 @@ extension Int32 : _ObjectiveCBridgeable {
 }
 
 extension UInt32 : _ObjectiveCBridgeable {
-    @available(swift, deprecated: 4)
+    @available(swift, deprecated: 4, renamed: "init(truncating:)")
     public init(_ number: NSNumber) {
         self = number.uint32Value
     }
@@ -260,7 +260,7 @@ extension UInt32 : _ObjectiveCBridgeable {
 }
 
 extension Int64 : _ObjectiveCBridgeable {
-    @available(swift, deprecated: 4)
+    @available(swift, deprecated: 4, renamed: "init(truncating:)")
     public init(_ number: NSNumber) {
         self = number.int64Value
     }
@@ -301,7 +301,7 @@ extension Int64 : _ObjectiveCBridgeable {
 }
 
 extension UInt64 : _ObjectiveCBridgeable {
-    @available(swift, deprecated: 4)
+    @available(swift, deprecated: 4, renamed: "init(truncating:)")
     public init(_ number: NSNumber) {
         self = number.uint64Value
     }
@@ -342,7 +342,7 @@ extension UInt64 : _ObjectiveCBridgeable {
 }
 
 extension Int : _ObjectiveCBridgeable {
-    @available(swift, deprecated: 4)
+    @available(swift, deprecated: 4, renamed: "init(truncating:)")
     public init(_ number: NSNumber) {
         self = number.intValue
     }
@@ -383,7 +383,7 @@ extension Int : _ObjectiveCBridgeable {
 }
 
 extension UInt : _ObjectiveCBridgeable {
-    @available(swift, deprecated: 4)
+    @available(swift, deprecated: 4, renamed: "init(truncating:)")
     public init(_ number: NSNumber) {
         self = number.uintValue
     }
@@ -424,7 +424,7 @@ extension UInt : _ObjectiveCBridgeable {
 }
 
 extension Float : _ObjectiveCBridgeable {
-    @available(swift, deprecated: 4)
+    @available(swift, deprecated: 4, renamed: "init(truncating:)")
     public init(_ number: NSNumber) {
         self = number.floatValue
     }
@@ -465,7 +465,7 @@ extension Float : _ObjectiveCBridgeable {
 }
 
 extension Double : _ObjectiveCBridgeable {
-    @available(swift, deprecated: 4)
+    @available(swift, deprecated: 4, renamed: "init(truncating:)")
     public init(_ number: NSNumber) {
         self = number.doubleValue
     }
@@ -513,7 +513,7 @@ extension Double : _ObjectiveCBridgeable {
 }
 
 extension Bool : _ObjectiveCBridgeable {
-    @available(swift, deprecated: 4)
+    @available(swift, deprecated: 4, renamed: "init(truncating:)")
     public init(_ number: NSNumber) {
         self = number.boolValue
     }
@@ -564,7 +564,7 @@ extension Bool : _ObjectiveCBridgeable {
 }
 
 extension CGFloat : _ObjectiveCBridgeable {
-    @available(swift, deprecated: 4)
+    @available(swift, deprecated: 4, renamed: "init(truncating:)")
     public init(_ number: NSNumber) {
         native = CGFloat.NativeType(truncating: number)
     }

--- a/test/stdlib/TestNSNumberBridging.swift
+++ b/test/stdlib/TestNSNumberBridging.swift
@@ -18,6 +18,58 @@ import StdlibUnittest
 import Foundation
 import CoreGraphics
 
+extension Float {
+    init?(reasonably value: Float) {
+        self = value
+    }
+
+    init?(reasonably value: Double) {
+        guard !value.isNaN else {
+            self = Float.nan
+            return
+        }
+
+        guard !value.isInfinite else {
+            if value.sign == .minus {
+                self = -Float.infinity
+            } else {
+                self = Float.infinity
+            }
+            return
+        }
+
+        guard abs(value) <= Double(Float.greatestFiniteMagnitude) else {
+            return nil
+        }
+        
+        self = Float(value)
+    }
+}
+
+extension Double {
+    init?(reasonably value: Float) {
+        guard !value.isNaN else {
+            self = Double.nan
+            return
+        }
+
+        guard !value.isInfinite else {
+            if value.sign == .minus {
+                self = -Double.infinity
+            } else {
+                self = Double.infinity
+            }
+            return
+        }
+
+        self = Double(value)
+    }
+
+    init?(reasonably value: Double) {
+        self = value
+    }
+}
+
 var nsNumberBridging = TestSuite("NSNumberBridging")
 
 func testFloat(_ lhs: Float?, _ rhs: Float?, file: String = #file, line: UInt = #line) {
@@ -645,7 +697,7 @@ func testNSNumberBridgeFromFloat() {
             expectEqual(UInt(exactly: interestingValue), uint)
 
             let float = (number!) as? Float
-            let expectedFloat = Float(exactly: interestingValue)
+            let expectedFloat = Float(reasonably: interestingValue)
             testFloat(expectedFloat, float)
             
             let double = (number!) as? Double
@@ -685,7 +737,7 @@ func testNSNumberBridgeFromDouble() {
             expectEqual(UInt(exactly: interestingValue), uint)
 
             let float = (number!) as? Float
-            let expectedFloat = Float(exactly: interestingValue)
+            let expectedFloat = Float(reasonably: interestingValue)
             testFloat(expectedFloat, float)
             
             let double = (number!) as? Double
@@ -725,7 +777,7 @@ func testNSNumberBridgeFromCGFloat() {
             expectEqual(UInt(exactly: interestingValue.native), uint)
             
             let float = (number!) as? Float
-            let expectedFloat = Float(exactly: interestingValue.native)
+            let expectedFloat = Float(reasonably: interestingValue.native)
             testFloat(expectedFloat, float)
             
             let double = (number!) as? Double

--- a/validation-test/stdlib/ValidationNSNumberBridging.swift
+++ b/validation-test/stdlib/ValidationNSNumberBridging.swift
@@ -18,6 +18,58 @@ import StdlibUnittest
 import Foundation
 import CoreGraphics
 
+extension Float {
+    init?(reasonably value: Float) {
+        self = value
+    }
+
+    init?(reasonably value: Double) {
+        guard !value.isNaN else {
+            self = Float.nan
+            return
+        }
+
+        guard !value.isInfinite else {
+            if value.sign == .minus {
+                self = -Float.infinity
+            } else {
+                self = Float.infinity
+            }
+            return
+        }
+
+        guard abs(value) <= Double(Float.greatestFiniteMagnitude) else {
+            return nil
+        }
+        
+        self = Float(value)
+    }
+}
+
+extension Double {
+    init?(reasonably value: Float) {
+        guard !value.isNaN else {
+            self = Double.nan
+            return
+        }
+
+        guard !value.isInfinite else {
+            if value.sign == .minus {
+                self = -Double.infinity
+            } else {
+                self = Double.infinity
+            }
+            return
+        }
+
+        self = Double(value)
+    }
+
+    init?(reasonably value: Double) {
+        self = value
+    }
+}
+
 var nsNumberBridging = TestSuite("NSNumberBridgingValidation")
 
 func testFloat(_ lhs: Float?, _ rhs: Float?, file: String = #file, line: UInt = #line) {
@@ -645,7 +697,7 @@ func testNSNumberBridgeFromFloat() {
             expectEqual(UInt(exactly: interestingValue), uint)
 
             let float = (number!) as? Float
-            let expectedFloat = Float(exactly: interestingValue)
+            let expectedFloat = Float(reasonably: interestingValue)
             testFloat(expectedFloat, float)
             
             let double = (number!) as? Double
@@ -685,7 +737,7 @@ func testNSNumberBridgeFromDouble() {
             expectEqual(UInt(exactly: interestingValue), uint)
 
             let float = (number!) as? Float
-            let expectedFloat = Float(exactly: interestingValue)
+            let expectedFloat = Float(reasonably: interestingValue)
             testFloat(expectedFloat, float)
             
             let double = (number!) as? Double
@@ -725,7 +777,7 @@ func testNSNumberBridgeFromCGFloat() {
             expectEqual(UInt(exactly: interestingValue.native), uint)
             
             let float = (number!) as? Float
-            let expectedFloat = Float(exactly: interestingValue.native)
+            let expectedFloat = Float(reasonably: interestingValue.native)
             testFloat(expectedFloat, float)
             
             let double = (number!) as? Double


### PR DESCRIPTION
<!-- What's in this pull request? -->
This adds deprecation migration notes for numeric types like Int, Int32, Float etc from NSNumbers so that developers can easily migrate to better interfaces for constructing numeric values from NSNumbers.

This also relaxes the bridging of Floating point values so that NSNumber -> Float does not lead to unexpected behavior. 

This resolves the following issues:
<rdar://problem/32633511>
<rdar://problem/32739894> (and a number of other related issues that will be updated later)
https://bugs.swift.org/browse/SR-5179


