### PR TITLE
[4.0] Allow SingleValueContainers to decode collections

### DIFF
--- a/stdlib/public/SDK/Foundation/JSONEncoder.swift
+++ b/stdlib/public/SDK/Foundation/JSONEncoder.swift
@@ -962,18 +962,6 @@ fileprivate class _JSONDecoder : Decoder {
     }
 
     func singleValueContainer() throws -> SingleValueDecodingContainer {
-        guard !(self.storage.topContainer is [String : Any]) else {
-            throw DecodingError.typeMismatch(SingleValueDecodingContainer.self,
-                                             DecodingError.Context(codingPath: self.codingPath,
-                                                                   debugDescription: "Cannot get single value decoding container -- found keyed container instead."))
-        }
-
-        guard !(self.storage.topContainer is [Any]) else {
-            throw DecodingError.typeMismatch(SingleValueDecodingContainer.self,
-                                             DecodingError.Context(codingPath: self.codingPath,
-                                                                   debugDescription: "Cannot get single value decoding container -- found unkeyed container instead."))
-        }
-
         return self
     }
 }

--- a/stdlib/public/SDK/Foundation/PlistEncoder.swift
+++ b/stdlib/public/SDK/Foundation/PlistEncoder.swift
@@ -733,18 +733,6 @@ fileprivate class _PlistDecoder : Decoder {
     }
 
     func singleValueContainer() throws -> SingleValueDecodingContainer {
-        guard !(self.storage.topContainer is [String : Any]) else {
-            throw DecodingError.typeMismatch(SingleValueDecodingContainer.self,
-                                             DecodingError.Context(codingPath: self.codingPath,
-                                                     debugDescription: "Cannot get single value decoding container -- found keyed container instead."))
-        }
-
-        guard !(self.storage.topContainer is [Any]) else {
-            throw DecodingError.typeMismatch(SingleValueDecodingContainer.self,
-                                             DecodingError.Context(codingPath: self.codingPath,
-                                                     debugDescription: "Cannot get single value decoding container -- found unkeyed container instead."))
-        }
-
         return self
     }
 }


### PR DESCRIPTION
**What's in this pull request?**
Cherry-picks #10249 for swift-4.0-branch. Addresses [SR-5089](https://bugs.swift.org/browse/SR-5089).

* **Explanation:** `SingleValueDecondingContainer`s in JSON and Plist previously held the assertion that attempting to decode an array or dictionary from them was a type mismatch (since those represented unkeyed and keyed containers, respectively). This assertion is no longer true, though, since `encode<T : Encodable>(_:)` and `decode<T : Decodable>(_:)` allow you to do just that.

  This lifts the assertion and adds unit tests to both implementations to ensure this works.
* **Scope:** Affects those using the new Codable API to encode and decode from a single value container.
* **Radar:** rdar://problem/32567981
* **Risk:** Low
* **Testing:** This adds new unit tests to confirm expected behavior.