### PR TITLE
Use clang's effective llvm triple for IR generation

### DIFF
--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -268,8 +268,9 @@ namespace swift {
   void serialize(ModuleOrSourceFile DC, const SerializationOptions &options,
                  const SILModule *M = nullptr);
 
-  /// Get the CPU and subtarget feature options to use when emitting code.
-  std::tuple<llvm::TargetOptions, std::string, std::vector<std::string>>
+  /// Get the CPU, subtarget feature options, and triple to use when emitting code.
+  std::tuple<llvm::TargetOptions, std::string, std::vector<std::string>,
+             std::string>
   getIRTargetOptions(IRGenOptions &Opts, ASTContext &Ctx);
 
   /// Turn the given Swift module into either LLVM IR or native code

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -127,9 +127,9 @@ IRGenModule::IRGenModule(IRGenerator &irgen,
       ClangCodeGen(createClangCodeGenerator(Context, LLVMContext, irgen.Opts,
                                             ModuleName)),
       Module(*ClangCodeGen->GetModule()), LLVMContext(Module.getContext()),
-      DataLayout(target->createDataLayout()), Triple(Context.LangOpts.Target),
-      TargetMachine(std::move(target)), silConv(irgen.SIL),
-      OutputFilename(OutputFilename),
+      DataLayout(target->createDataLayout()),
+      Triple(irgen.getEffectiveClangTriple()), TargetMachine(std::move(target)),
+      silConv(irgen.SIL), OutputFilename(OutputFilename),
       TargetInfo(SwiftTargetInfo::get(*this)), DebugInfo(nullptr),
       ModuleHash(nullptr), ObjCInterop(Context.LangOpts.EnableObjCInterop),
       Types(*new TypeConverter(*this)) {
@@ -1182,4 +1182,11 @@ IRGenModule *IRGenerator::getGenModule(SILFunction *f) {
     return IGM;
 
   return getPrimaryIGM();
+}
+
+llvm::Triple IRGenerator::getEffectiveClangTriple() {
+  auto CI = static_cast<ClangImporter *>(
+      &*SIL.getASTContext().getClangModuleLoader());
+  assert(CI && "no clang module loader");
+  return llvm::Triple(CI->getTargetInfo().getTargetOpts().Triple);
 }

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -355,6 +355,9 @@ public:
     }
     return nullptr;
   }
+
+  /// Return the effective triple used by clang.
+  llvm::Triple getEffectiveClangTriple();
 };
 
 class ConstantReference {
@@ -393,7 +396,7 @@ public:
   llvm::Module &Module;
   llvm::LLVMContext &LLVMContext;
   const llvm::DataLayout DataLayout;
-  const llvm::Triple &Triple;
+  const llvm::Triple Triple;
   std::unique_ptr<llvm::TargetMachine> TargetMachine;
   ModuleDecl *getSwiftModule() const;
   Lowering::TypeConverter &getSILTypes() const;

--- a/lib/Immediate/Immediate.cpp
+++ b/lib/Immediate/Immediate.cpp
@@ -360,8 +360,9 @@ int swift::RunImmediately(CompilerInstance &CI, const ProcessCmdLine &CmdLine,
   std::string ErrorMsg;
   llvm::TargetOptions TargetOpt;
   std::string CPU;
+  std::string Triple;
   std::vector<std::string> Features;
-  std::tie(TargetOpt, CPU, Features)
+  std::tie(TargetOpt, CPU, Features, Triple)
     = getIRTargetOptions(IRGenOpts, swiftModule->getASTContext());
   builder.setRelocationModel(llvm::Reloc::PIC_);
   builder.setTargetOptions(TargetOpt);

--- a/lib/Immediate/REPL.cpp
+++ b/lib/Immediate/REPL.cpp
@@ -953,8 +953,9 @@ public:
     std::string ErrorMsg;
     llvm::TargetOptions TargetOpt;
     std::string CPU;
+    std::string Triple;
     std::vector<std::string> Features;
-    std::tie(TargetOpt, CPU, Features)
+    std::tie(TargetOpt, CPU, Features, Triple)
       = getIRTargetOptions(IRGenOpts, CI.getASTContext());
     
     builder.setRelocationModel(llvm::Reloc::PIC_);

--- a/test/IRGen/abi_v7k.swift
+++ b/test/IRGen/abi_v7k.swift
@@ -68,7 +68,7 @@ func testEmpty(x: Empty) -> Empty {
 // CHECK-LABEL: define hidden swiftcc i32 @_T08test_v7k0A6Single{{.*}}()
 // CHECK: ret i32 1
 // V7K-LABEL: __T08test_v7k0A6Single
-// V7K: movw    r0, #1
+// V7K: movs    r0, #1
 enum SingleCase { case X }
 func testSingle(x: SingleCase) -> Int32{
   switch x {
@@ -94,9 +94,9 @@ func testData(x: DataCase) -> Double {
 // CHECK: [[ID:%[0-9]+]] = phi i32 [ 2, {{.*}} ], [ 1, {{.*}} ]
 // CHECK: ret i32 [[ID]]
 // V7K-LABEL: __T08test_v7k0A6Clike2
-// V7K: tst r0, #1
-// V7K: movw r0, #1
-// V7K: movw r0, #2
+// V7K: tst.w r0, #1
+// V7K: movs r0, #1
+// V7K: movs r0, #2
 enum CLike2 {
   case A
   case B
@@ -116,7 +116,7 @@ func testClike2(x: CLike2) -> Int {
 // V7K-LABEL: __T08test_v7k0A6Clike8
 // V7K: sxtb r1, r1
 // V7K: cmp r1, #0
-// V7K: movw r0, #1
+// V7K: movs r0, #1
 // V7K: mvn r0, #0
 enum CLike8 {
   case A
@@ -149,7 +149,7 @@ func testClike8(t: Int, x: CLike8) -> Int {
 // CHECK: bitcast i64 [[RESULT]] to double
 // CHECK: phi double [ 0.000000e+00, {{.*}} ]
 // V7K-LABEL: __T08test_v7k0A7SingleP
-// V7K: tst     r2, #1
+// V7K: tst.w     r2, #1
 // V7K: vmov.f64 d0
 enum SinglePayload {
   case Paragraph
@@ -202,12 +202,12 @@ func testMultiP(x: MultiPayload) -> Double {
 // CHECK: [[ID:%[0-9]+]] = bitcast i32 %0 to float
 // CHECK: ret float
 // V7K-LABEL: __T08test_v7k0A3Opt
-// V7K:         tst     r1, #1
-// V7K:         str     r0, [r7, [[SLOT:#-[0-9]+]]
-// V7K:         ldr     r0, [r7, [[SLOT]]
+// V7K:         tst.w     r1, #1
+// V7K:         str     r0, [sp, [[SLOT:#[0-9]+]]
+// V7K:         ldr     r0, [sp, [[SLOT]]
 // V7K:         vmov    s0, r0
-// V7K:         vstr    s0, [r7, [[SLOT2:#-[0-9]+]]
-// V7K:         vldr    s0, [r7, [[SLOT2]]
+// V7K:         vstr    s0, [sp, [[SLOT2:#[0-9]+]]
+// V7K:         vldr    s0, [sp, [[SLOT2]]
 // V7K:         pop     {{{.*}}, pc}
 func testOpt(x: Float?) -> Float {
   return x!
@@ -291,9 +291,9 @@ func testRet3() -> MyRect2 {
 // V7K: cmp r1, r2
 // V7K: str r0, [sp, [[IDX:#[0-9]+]]]
 // V7K: ldr [[R0_RELOAD:r[0-9]+]], [sp, [[IDX]]]
-// V7K: str {{.*}}, [{{.*}}[[R0_RELOAD]]]
-// V7K: str {{.*}}, [{{.*}}[[R0_RELOAD]], #4]
-// V7K: str {{.*}}, [{{.*}}[[R0_RELOAD]], #8]
+// V7K: str.w {{.*}}, [{{.*}}[[R0_RELOAD]]]
+// V7K: str.w {{.*}}, [{{.*}}[[R0_RELOAD]], #4]
+// V7K: str.w {{.*}}, [{{.*}}[[R0_RELOAD]], #8]
 // V7K: str {{.*}}, [{{.*}}[[R0_RELOAD]], #12]
 // V7K: str {{.*}}, [{{.*}}[[R0_RELOAD]], #16]
 // V7K: str {{.*}}, [{{.*}}[[R0_RELOAD]], #20]
@@ -340,7 +340,7 @@ func minMax3(x : Int, y : Int) -> Ret? {
 // V7K-LABEL: __T08test_v7k0A4Ret5
 // V7K:   ldrb    r1, [r0]
 // V7K:   vldr    d16, [r0, #8]
-// V7K:   add     r0, r0, #296
+// V7K:   add.w     r0, r0, #296
 // V7K:   vldr    d18, [r0]
 // V7K:   sxtb    r0, r1
 // V7K:   vmov    s0, r0

--- a/test/IRGen/arm_to_thumb_darwin.sil
+++ b/test/IRGen/arm_to_thumb_darwin.sil
@@ -1,0 +1,28 @@
+// RUN: %swift -target armv7-apple-ios7 %s -gnone -emit-ir -o - | %FileCheck %s -check-prefix=IOS
+// RUN: %swift -target armv7k-apple-watchos2 %s -gnone -emit-ir -o - | %FileCheck %s -check-prefix=WATCHOS
+
+// REQUIRES: CODEGENERATOR=ARM
+
+sil_stage canonical
+import Builtin
+
+// IOS: target triple = "thumbv7-apple-ios7
+
+// IOS: define{{( protected)?}} swiftcc i32 @word_literal() {{.*}} {
+// IOS: entry:
+// IOS:   ret i32 12345
+// IOS: }
+
+
+// WATCHOS: target triple = "thumbv7k-apple-watchos2
+
+// WATCHOS: define{{( protected)?}} swiftcc i32 @word_literal() {{.*}} {
+// WATCHOS: entry:
+// WATCHOS:   ret i32 12345
+// WATCHOS: }
+
+sil @word_literal : $() -> Builtin.Word {
+entry:
+  %w = integer_literal $Builtin.Word, 12345
+  return %w : $Builtin.Word
+}

--- a/test/IRGen/osx-targets.swift
+++ b/test/IRGen/osx-targets.swift
@@ -5,7 +5,7 @@
 // REQUIRES: OS=macosx
 
 // CHECK: target triple = "x86_64-apple-macosx10.
-// CHECK-SPECIFIC: target triple = "x86_64-apple-macosx10.12"
+// CHECK-SPECIFIC: target triple = "x86_64-apple-macosx10.12.0"
 
 public func anchor() {}
 anchor()

--- a/test/IRGen/pic.swift
+++ b/test/IRGen/pic.swift
@@ -23,26 +23,26 @@ public func use_global() -> Int {
 // Check for the runtime memory enforcement call. The global address may be
 // materialized in a different register prior to that call.
 // armv7:         bl _swift_beginAccess
-// armv7:         movw [[R_ADR:r.*]], :lower16:(__T04main6globalSiv-([[PIC_0:L.*]]+8))
-// armv7:         movt [[R_ADR]], :upper16:(__T04main6globalSiv-([[PIC_0]]+8))
+// armv7:         movw [[R_ADR:r.*]], :lower16:(__T04main6globalSiv-([[PIC_0:L.*]]+4))
+// armv7:         movt [[R_ADR]], :upper16:(__T04main6globalSiv-([[PIC_0]]+4))
 // armv7:       [[PIC_0]]:{{$}}
-// armv7:         add [[R_ADR]], pc, [[R_ADR]]
+// armv7:         add [[R_ADR]], pc
 // armv7:         ldr [[R_ADR]], {{\[}}[[R_ADR]]{{\]}}
 
 // armv7s-LABEL: __T04main10use_globalSiyF:
 // armv7s:         bl _swift_beginAccess
-// armv7s:         movw [[R_ADR:r.*]], :lower16:(__T04main6globalSiv-([[PIC_0:L.*]]+8))
-// armv7s:         movt [[R_ADR]], :upper16:(__T04main6globalSiv-([[PIC_0]]+8))
+// armv7s:         movw [[R_ADR:r.*]], :lower16:(__T04main6globalSiv-([[PIC_0:L.*]]+4))
+// armv7s:         movt [[R_ADR]], :upper16:(__T04main6globalSiv-([[PIC_0]]+4))
 // armv7s:       [[PIC_0]]:{{$}}
-// armv7s:         add [[R_ADR]], pc, [[R_ADR]]
+// armv7s:         add [[R_ADR]], pc
 // armv7s:         ldr [[R_ADR]], {{\[}}[[R_ADR]]{{\]}}
 
 // armv7k-LABEL: __T04main10use_globalSiyF:
 // armv7k:         bl _swift_beginAccess
-// armv7k:        movw [[R_ADR:r.*]], :lower16:(__T04main6globalSiv-([[PIC_0:L.*]]+8))
-// armv7k:        movt [[R_ADR]], :upper16:(__T04main6globalSiv-([[PIC_0]]+8))
+// armv7k:        movw [[R_ADR:r.*]], :lower16:(__T04main6globalSiv-([[PIC_0:L.*]]+4))
+// armv7k:        movt [[R_ADR]], :upper16:(__T04main6globalSiv-([[PIC_0]]+4))
 // armv7k:      [[PIC_0]]:{{$}}
-// armv7k:        add [[R_ADR]], pc, [[R_ADR]]
+// armv7k:        add [[R_ADR]], pc
 // armv7k:        ldr [[R_ADR]], {{\[}}[[R_ADR]]{{\]}}
 
 // arm64-LABEL: __T04main10use_globalSiyF:


### PR DESCRIPTION
Transform armv7 llvm triples to thumbv7 triples in the swift frontend (like clang does for c) on  darwin/ios platforms such that we generate smaller code.

• Explanation: armv7 llvm triples to thumbv7 triples in the swift frontend

• Scope of Issue: New ‘feature’ to reduce the code size on armv7(s/k) architectures 

• Origination: N/A

• Testing: Existing Swift CI and benchmark tests