### PR TITLE
Non-NUL terminated string core

### DIFF
--- a/stdlib/public/core/Character.swift
+++ b/stdlib/public/core/Character.swift
@@ -179,13 +179,8 @@ public struct Character :
     default:
       _representation = Character(
         _largeRepresentationString: String(
-          _StringCore(
-            baseAddress: UnsafeMutableRawPointer(start), 
-            count: utf16.count,
-            elementShift: 1,
-            hasCocoaBuffer: false,
-            owner: nil)
-        ))._representation
+          _builtinUTF16StringLiteral: start,
+          utf16CodeUnitCount: utf16CodeUnitCount))._representation
     }
   }
   

--- a/stdlib/public/core/ManagedBuffer.swift
+++ b/stdlib/public/core/ManagedBuffer.swift
@@ -56,7 +56,7 @@ open class ManagedBuffer<Header, Element> {
 
   /// The actual number of elements that can be stored in this object.
   ///
-  /// This header may be nontrivial to compute; it is usually a good
+  /// This value may be nontrivial to compute; it is usually a good
   /// idea to store this information in the "header" area when
   /// an instance is created.
   public final var capacity: Int {

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -220,9 +220,18 @@ extension _StringCore {
     encoding targetEncoding: TargetEncoding.Type,
     _ body: (UnsafePointer<TargetEncoding.CodeUnit>, Int) throws -> Result
   ) rethrows -> Result {
+    typealias P = UnsafeMutablePointer<TargetEncoding.CodeUnit>
+    
     if _fastPath(hasContiguousStorage) {
       defer { _fixLifetime(self) }
       if isASCII {
+        if _fastPath(
+          hasNulTerminator && (
+            targetEncoding == Unicode.UTF8.self
+            || targetEncoding == Unicode.ASCII.self)) {
+          return try body(_identityCast(startASCII, to: P.self), count)
+        }
+        
         return try Swift._withCStringAndLength(
           encodedAs: targetEncoding,
           from: UnsafeBufferPointer(start: startASCII, count: count)[bounds],
@@ -231,6 +240,10 @@ extension _StringCore {
         )
       }
       else {
+        if _fastPath(hasNulTerminator && targetEncoding == Unicode.UTF16.self) {
+          return try body(_identityCast(startUTF16, to: P.self), count)
+        }
+        
         return try Swift._withCStringAndLength(
           encodedAs: targetEncoding,
           from: UnsafeBufferPointer(start: startUTF16, count: count)[bounds],
@@ -706,6 +719,7 @@ extension String : _ExpressibleByBuiltinUTF16StringLiteral {
         count: Int(utf16CodeUnitCount),
         elementShift: 1,
         hasCocoaBuffer: false,
+        hasNulTerminator: true,
         owner: nil))
   }
 }
@@ -725,6 +739,7 @@ extension String : _ExpressibleByBuiltinStringLiteral {
           count: Int(utf8CodeUnitCount),
           elementShift: 0,
           hasCocoaBuffer: false,
+          hasNulTerminator: true,
           owner: nil))
     }
     else {

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -719,7 +719,7 @@ extension String : _ExpressibleByBuiltinUTF16StringLiteral {
         count: Int(utf16CodeUnitCount),
         elementShift: 1,
         hasCocoaBuffer: false,
-        hasNulTerminator: true,
+        hasNulTerminator: false,
         owner: nil))
   }
 }
@@ -739,7 +739,7 @@ extension String : _ExpressibleByBuiltinStringLiteral {
           count: Int(utf8CodeUnitCount),
           elementShift: 0,
           hasCocoaBuffer: false,
-          hasNulTerminator: true,
+          hasNulTerminator: false,
           owner: nil))
     }
     else {

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -130,10 +130,13 @@ extension _SwiftStringView {
 
 extension StringProtocol {
   internal var _ephemeralString : String {
-    if _fastPath(self is _SwiftStringView) {
-      return (self as! _SwiftStringView)._ephemeralContent
+    @inline(__always)
+    get {
+      if _fastPath(self is _SwiftStringView) {
+        return (self as! _SwiftStringView)._ephemeralContent
+      }
+      return String(String.CharacterView(self))
     }
-    return String(String.CharacterView(self))
   }
 
   internal var _persistentString : String {

--- a/stdlib/public/core/StringBridge.swift
+++ b/stdlib/public/core/StringBridge.swift
@@ -179,7 +179,7 @@ extension String {
       count: length,
       elementShift: isUTF16 ? 1 : 0,
       hasCocoaBuffer: true,
-      hasNulTerminator: nulTerminatedASCII != nil,
+      hasNulTerminator: false,
       owner: cfImmutableValue)
   }
 }

--- a/stdlib/public/core/StringBuffer.swift
+++ b/stdlib/public/core/StringBuffer.swift
@@ -18,24 +18,19 @@ struct _StringBufferIVars {
     capacityAndElementShift = _elementWidth - 1
   }
 
-  internal init(
-    _usedEnd: UnsafeMutableRawPointer,
-    byteCapacity: Int,
-    elementWidth: Int
-  ) {
-    _sanityCheck(elementWidth == 1 || elementWidth == 2)
-    _sanityCheck((byteCapacity & 0x1) == 0)
-    self.usedEnd = _usedEnd
-    self.capacityAndElementShift = byteCapacity + (elementWidth - 1)
-  }
-
   // This stored property should be stored at offset zero.  We perform atomic
   // operations on it using _HeapBuffer's pointer.
   var usedEnd: UnsafeMutableRawPointer?
 
   var capacityAndElementShift: Int
   var byteCapacity: Int {
-    return capacityAndElementShift & ~0x1
+    get {
+      return Int(extendingOrTruncating:
+        UInt(extendingOrTruncating: capacityAndElementShift) &>> 1)
+    }
+    set {
+      capacityAndElementShift = elementShift | (newValue &<< 1)
+    }
   }
   var elementShift: Int {
     return capacityAndElementShift & 0x1
@@ -58,37 +53,43 @@ public struct _StringBuffer {
     _storage = storage
   }
 
+  /// Creates an instance with sufficient space for `capacity` elements and a
+  /// `NUL` terminator.
+  ///
+  /// - Postcondition: `usedCount == initialSize`, 
+  ///
+  /// - Requires: `initialSize` <= `capacity`
+  /// - Requires: `elementWidth == 1 || elementWidth == 2`
   public init(capacity: Int, initialSize: Int, elementWidth: Int) {
     _sanityCheck(elementWidth == 1 || elementWidth == 2)
     _sanityCheck(initialSize <= capacity)
-    // We don't check for elementWidth overflow and underflow because
-    // elementWidth is known to be 1 or 2.
-    let elementShift = elementWidth &- 1
-
-    // We need at least 1 extra byte if we're storing 8-bit elements,
-    // because indexing will always grab 2 consecutive bytes at a
-    // time.
-    let capacityBump = 1 &- elementShift
-
-    // Used to round capacity up to nearest multiple of 16 bits, the
-    // element size of our storage.
-    let divRound = 1 &- elementShift
-    _storage = _Storage(
-      HeapBufferStorage.self,
-      _StringBufferIVars(_elementWidth: elementWidth),
-      (capacity + capacityBump + divRound) &>> divRound
-    )
-    // This conditional branch should fold away during code gen.
-    if elementShift == 0 {
-      start.bindMemory(to: UTF8.CodeUnit.self, capacity: initialSize)
+    let header = _StringBufferIVars(_elementWidth: elementWidth)
+    if elementWidth == 1 {
+      // 1 byte to ensure rounding up when dividing by 2 and 1 byte for NUL
+      // termination.
+      _storage = _Storage(HeapBufferStorage.self, header, (capacity + 2) &>> 1)
+      
+      let nulTerminatedUTF8Capacity = _storage.capacity &<< 1
+      _storage.value.byteCapacity = nulTerminatedUTF8Capacity &- 1
+      
+      let p = start.bindMemory(
+        to: UTF8.CodeUnit.self, capacity: nulTerminatedUTF8Capacity)
+      p[initialSize] = 0
+      
+      self.usedEnd = UnsafeMutableRawPointer(p + initialSize)
     }
     else {
-      start.bindMemory(to: UTF16.CodeUnit.self, capacity: initialSize)
-    }
+      _storage = _Storage(HeapBufferStorage.self, header, capacity + 1)
 
-    self.usedEnd = start + (initialSize &<< elementShift)
-    _storage.value.capacityAndElementShift
-      = ((_storage.capacity - capacityBump) &<< 1) + elementShift
+      let nulTerminatedUTF16Capacity = _storage.capacity
+      _storage.value.byteCapacity = (nulTerminatedUTF16Capacity &- 1) &<< 1
+      
+      let p = start.bindMemory(
+        to: UTF16.CodeUnit.self, capacity: nulTerminatedUTF16Capacity)
+      p[initialSize] = 0
+      
+      self.usedEnd = UnsafeMutableRawPointer(p + initialSize)
+    }
   }
 
   static func fromCodeUnits<Input : Sequence, Encoding : _UnicodeEncoding>(

--- a/stdlib/public/core/StringBuffer.swift
+++ b/stdlib/public/core/StringBuffer.swift
@@ -74,7 +74,6 @@ public struct _StringBuffer {
       
       let p = start.bindMemory(
         to: UTF8.CodeUnit.self, capacity: nulTerminatedUTF8Capacity)
-      p[initialSize] = 0
       
       self.usedEnd = UnsafeMutableRawPointer(p + initialSize)
     }
@@ -86,7 +85,6 @@ public struct _StringBuffer {
       
       let p = start.bindMemory(
         to: UTF16.CodeUnit.self, capacity: nulTerminatedUTF16Capacity)
-      p[initialSize] = 0
       
       self.usedEnd = UnsafeMutableRawPointer(p + initialSize)
     }

--- a/stdlib/public/core/StringCore.swift
+++ b/stdlib/public/core/StringCore.swift
@@ -544,7 +544,6 @@ public struct _StringCore {
       _sanityCheck(newStorage.elementShift == 1)
       let start = newStorage.start.assumingMemoryBound(to: UTF16.CodeUnit.self)
       _cocoaStringReadAll(cocoaBuffer!, start)
-      start[newSize] = 0
 #else
       _sanityCheckFailure("_copyInPlace: non-native string without objc runtime")
 #endif
@@ -626,7 +625,6 @@ public struct _StringCore {
       _sanityCheck(elementWidth == 2)
       let start = destination.assumingMemoryBound(to: UTF16.CodeUnit.self)
       _cocoaStringReadAll(rhs.cocoaBuffer!, start)
-      start[count + rhs.count] = 0
       hasNulTerminator = true
 #else
       _sanityCheckFailure("subscript: non-native string without objc runtime")

--- a/stdlib/public/core/StringCore.swift
+++ b/stdlib/public/core/StringCore.swift
@@ -68,6 +68,7 @@ public struct _StringCore {
         "Opaque cocoa strings should have an elementWidth of 2")
     }
     else if _baseAddress == _emptyStringBase {
+      _sanityCheck(nativeBuffer == nil)
       _sanityCheck(!hasCocoaBuffer)
       _sanityCheck(count == 0, "Empty string storage with non-zero count")
       _sanityCheck(_owner == nil, "String pointing at empty storage has owner")
@@ -615,6 +616,7 @@ public struct _StringCore {
       count + rhs.count, minElementWidth: minElementWidth)
 
     if _fastPath(rhs.hasContiguousStorage) {
+      _sanityCheck(nativeBuffer != nil)
       _StringCore._appendElements(
         rhs._baseAddress!, srcElementWidth: rhs.elementWidth,
         dstStart: destination, dstElementWidth:elementWidth, count: rhs.count)
@@ -788,6 +790,7 @@ extension _StringCore : RangeReplaceableCollection {
         for i in 0..<growth {
           destination8[i] = UTF8.CodeUnit(iter.next()!)
         }
+        _sanityCheck(nativeBuffer != nil)
         startASCII[growth] = 0
       }
       else {
@@ -796,6 +799,7 @@ extension _StringCore : RangeReplaceableCollection {
         for i in 0..<growth {
           destination16[i] = iter.next()!
         }
+        _sanityCheck(nativeBuffer != nil)
         startUTF16[growth] = 0
       }
     }

--- a/stdlib/public/core/Substring.swift.gyb
+++ b/stdlib/public/core/Substring.swift.gyb
@@ -227,13 +227,7 @@ public struct Substring : StringProtocol {
   /// - Returns: The return value of the `body` closure parameter, if any.
   public func withCString<Result>(
     _ body: (UnsafePointer<CChar>) throws -> Result) rethrows -> Result {
-    return try _slice._base._core._withCSubstringAndLength(
-      in: startIndex._base._position..<endIndex._base._position,
-      encoding: UTF8.self) {
-      p, length in try p.withMemoryRebound(to: CChar.self, capacity: length) {
-        try body($0)
-      }
-    }
+    return try _ephemeralString.withCString(body)
   }
 
   /// Calls the given closure with a pointer to the contents of the string,
@@ -255,9 +249,7 @@ public struct Substring : StringProtocol {
     encodedAs targetEncoding: TargetEncoding.Type,
     _ body: (UnsafePointer<TargetEncoding.CodeUnit>) throws -> Result
   ) rethrows -> Result {
-    return try _slice._base._core._withCSubstring(
-      in: startIndex._base._position..<endIndex._base._position,
-      encoding: targetEncoding, body)
+    return try _ephemeralString.withCString(encodedAs: targetEncoding, body)
   }
 }
 

--- a/test/Interpreter/SDK/Foundation_test.swift
+++ b/test/Interpreter/SDK/Foundation_test.swift
@@ -236,6 +236,7 @@ FoundationTestSuite.test("rdar://17584531") {
   var dict: NSDictionary = ["status": 200, "people": [["id": 255, "name": ["first": "John", "last": "Appleseed"] as NSDictionary] as NSDictionary] as NSArray]
   var dict2 = dict["people"].flatMap { $0 as? NSArray }?[0] as! NSDictionary
   expectEqual("Optional(255)", String(describing: dict2["id" as NSString]))
+
 }
 
 FoundationTestSuite.test("DarwinBoolean smoke test") {

--- a/validation-test/stdlib/String.swift
+++ b/validation-test/stdlib/String.swift
@@ -669,7 +669,7 @@ StringTests.test("COW/replaceSubrange/end") {
     let literalIdentity = str.bufferID
 
     // Move the string to the heap.
-    str.reserveCapacity(32)
+    str.reserveCapacity(str._core.nativeBuffer?.capacity ?? str._core.count + 1)
     expectNotEqual(literalIdentity, str.bufferID)
     let heapStrIdentity1 = str.bufferID
 


### PR DESCRIPTION
This PR leaves in place most of the changes in https://github.com/dabrahams/swift/tree/NUL-terminated-StringCore (which I've been unable to get to work due to fragile `_StringCore` design) but disables the actual NUL termination so tests still pass.  In particular, this keeps a change that fully-utilizes the capacity of allocated ASCII buffers, which wasn't the case before.  It's worth benchmarking.