### PR TITLE
[capture-promotion] Be sure to copy_value a struct_extracted value from a promoted capture even though the value is borrowed.

### DIFF
--- a/test/SILOptimizer/capture_promotion.swift
+++ b/test/SILOptimizer/capture_promotion.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend %s -emit-sil -o - -verify | %FileCheck %s
+// RUN: %target-swift-frontend %s -emit-sil -o - | %FileCheck %s
 
 class Foo {
   func foo() -> Int {

--- a/test/SILOptimizer/capture_promotion_ownership.sil
+++ b/test/SILOptimizer/capture_promotion_ownership.sil
@@ -332,3 +332,53 @@ bb0(%0: @trivial $*Int, %1 : @owned $<τ_0_0> { var τ_0_0 } <Foo>, %2 : @owned 
   %16 = tuple()
   return %16 : $()
 }
+
+// This test makes sure that we properly handle non load uses of
+// struct_element_addr that always have load users with the load occuring before
+// and after the element in the use list.
+
+sil @mutate_int : $@convention(thin) (@inout Int) -> ()
+
+// CHECK-LABEL: sil @test_closure_multiple_uses_of_struct_element_addr : $@convention(thin) () -> @owned @callee_owned () -> () {
+// CHECK: [[FUNC:%.*]] = function_ref @closure_multiple_uses_of_struct_element_addr : $@convention(thin)
+// CHECK: partial_apply [[FUNC]](
+// CHECK: } // end sil function 'test_closure_multiple_uses_of_struct_element_addr'
+sil @test_closure_multiple_uses_of_struct_element_addr : $@convention(thin) () -> @owned @callee_owned () -> () {
+bb0:
+  %0 = function_ref @baz_init : $@convention(thin) (@thin Baz.Type) -> @owned Baz
+  %1 = metatype $@thin Baz.Type
+
+  %2 = alloc_box $<τ_0_0> { var τ_0_0 } <Baz>
+  %3 = project_box %2 : $<τ_0_0> { var τ_0_0 } <Baz>, 0
+  %4 = apply %0(%1) : $@convention(thin) (@thin Baz.Type) -> @owned Baz
+  store %4 to [init] %3 : $*Baz
+
+  %5 = alloc_box $<τ_0_0> { var τ_0_0 } <Baz>
+  %6 = project_box %5 : $<τ_0_0> { var τ_0_0 } <Baz>, 0
+  %7 = apply %0(%1) : $@convention(thin) (@thin Baz.Type) -> @owned Baz
+  store %7 to [init] %6 : $*Baz
+
+  %8 = function_ref @closure_multiple_uses_of_struct_element_addr : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Baz>, @owned <τ_0_0> { var τ_0_0 } <Baz>) -> ()
+  %9 = partial_apply %8(%2, %5) : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Baz>, @owned <τ_0_0> { var τ_0_0 } <Baz>) -> ()
+
+  return %9 : $@callee_owned () -> ()
+}
+
+sil @closure_multiple_uses_of_struct_element_addr : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Baz>, @owned <τ_0_0> { var τ_0_0 } <Baz>) -> () {
+bb0(%0 : @owned $<τ_0_0> { var τ_0_0 } <Baz>, %1 : @owned $<τ_0_0> { var τ_0_0 } <Baz>):
+  %2 = project_box %0 : $<τ_0_0> { var τ_0_0 } <Baz>, 0
+  %3 = struct_element_addr %2 : $*Baz, #Baz.x
+  %4 = load [trivial] %3 : $*Int
+  %5 = function_ref @mutate_int : $@convention(thin) (@inout Int) -> ()
+  apply %5(%3) : $@convention(thin) (@inout Int) -> ()
+
+  %6 = project_box %1 : $<τ_0_0> { var τ_0_0 } <Baz>, 0
+  %7 = struct_element_addr %6 : $*Baz, #Baz.x
+  apply %5(%7) : $@convention(thin) (@inout Int) -> ()
+  %8 = load [trivial] %7 : $*Int
+
+  destroy_value %1 : $<τ_0_0> { var τ_0_0 } <Baz>
+  destroy_value %0 : $<τ_0_0> { var τ_0_0 } <Baz>
+  %9999 = tuple()
+  return %9999 : $()
+}

--- a/test/SILOptimizer/capture_promotion_ownership.sil
+++ b/test/SILOptimizer/capture_promotion_ownership.sil
@@ -29,6 +29,7 @@ sil @convert_from_integer_literal : $@convention(thin) (Builtin.Word, @thin Int.
 sil @foo_allocating_init : $@convention(thin) (@thick Foo.Type) -> @owned Foo
 sil @baz_init : $@convention(thin) (@thin Baz.Type) -> @owned Baz
 sil @dummy_func : $@convention(thin) (Int, Int, Int) -> Int
+sil @destructured_baz_user : $@convention(thin) (@owned Bar, @guaranteed Bar, Int) -> ()
 
 // CHECK-LABEL: sil @test_capture_promotion
 sil @test_capture_promotion : $@convention(thin) () -> @owned @callee_owned () -> (Int, Builtin.Int64) {
@@ -381,4 +382,92 @@ bb0(%0 : @owned $<τ_0_0> { var τ_0_0 } <Baz>, %1 : @owned $<τ_0_0> { var τ_0
   destroy_value %0 : $<τ_0_0> { var τ_0_0 } <Baz>
   %9999 = tuple()
   return %9999 : $()
+}
+
+// CHECK-LABEL: sil @test_capture_projection_test : $@convention(thin) () -> @owned @callee_owned () -> () {
+sil @test_capture_projection_test : $@convention(thin) () -> @owned @callee_owned () -> () {
+bb0:
+  %0 = function_ref @baz_init : $@convention(thin) (@thin Baz.Type) -> @owned Baz
+  %1 = metatype $@thin Baz.Type
+
+  // CHECK: [[BOX1:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <Baz>
+  %2 = alloc_box $<τ_0_0> { var τ_0_0 } <Baz>
+  %3 = project_box %2 : $<τ_0_0> { var τ_0_0 } <Baz>, 0
+  %4 = apply %0(%1) : $@convention(thin) (@thin Baz.Type) -> @owned Baz
+  store %4 to [init] %3 : $*Baz
+
+  // CHECK: [[BOX2:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <Baz>
+  %5 = alloc_box $<τ_0_0> { var τ_0_0 } <Baz>
+  %6 = project_box %5 : $<τ_0_0> { var τ_0_0 } <Baz>, 0
+  %7 = apply %0(%1) : $@convention(thin) (@thin Baz.Type) -> @owned Baz
+  store %7 to [init] %6 : $*Baz
+
+  // CHECK: [[BOX1_COPY:%.*]] = copy_value [[BOX1]]
+  // CHECK: [[BOX2_COPY:%.*]] = copy_value [[BOX2]]
+  // CHECK: [[BOX2_COPY_PB:%.*]] = project_box [[BOX2_COPY]]
+  // CHECK-NOT: function_ref @closure_indirect_result :
+  // CHECK: [[SPECIALIZED_FUNC:%.*]] = function_ref @_T023closure_projection_testTf2ni_n : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Baz>, @owned Baz) -> ()
+  // CHECK-NOT: function_ref @closure_projection_test :
+  // CHECK: [[LOADBAZ:%.*]] = load [copy] [[BOX2_COPY_PB]] : $*Baz
+  // CHECK: destroy_value [[BOX2_COPY]]
+  %19 = copy_value %2 : $<τ_0_0> { var τ_0_0 } <Baz>
+  %20 = copy_value %5 : $<τ_0_0> { var τ_0_0 } <Baz>
+  %17 = function_ref @closure_projection_test : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Baz>, @owned <τ_0_0> { var τ_0_0 } <Baz>) -> ()
+
+  // The partial apply has one value argument for each pair of arguments that was
+  // previously used to capture and pass the variable by reference
+  // CHECK: {{.*}} = partial_apply [[SPECIALIZED_FUNC]]([[BOX1_COPY]], [[LOADBAZ]])
+  %21 = partial_apply %17(%19, %20) : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Baz>, @owned <τ_0_0> { var τ_0_0 } <Baz>) -> ()
+
+  destroy_value %2 : $<τ_0_0> { var τ_0_0 } <Baz>
+  destroy_value %5 : $<τ_0_0> { var τ_0_0 } <Baz>
+
+  return %21 : $@callee_owned () -> ()
+}
+
+// CHECK-LABEL: sil @_T023closure_projection_testTf2ni_n : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Baz>, @owned Baz) -> () {
+// CHECK: bb0([[UNPROMOTED_BAZ:%.*]] : @owned $<τ_0_0> { var τ_0_0 } <Baz>, [[BAZ:%.*]] : @owned $Baz):
+// CHECK:   [[BORROWED_BAZ:%.*]] = begin_borrow [[BAZ]] : $Baz
+// CHECK:   [[X:%.*]] = struct_extract [[BORROWED_BAZ]] : $Baz, #Baz.x
+// CHECK:   [[BAR:%.*]] = struct_extract [[BORROWED_BAZ]] : $Baz, #Baz.bar
+// CHECK:   [[BAR_COPY:%.*]] = copy_value [[BAR]]
+// CHECK:   [[BAR2:%.*]] = struct_extract [[BORROWED_BAZ]] : $Baz, #Baz.bar
+// CHECK:   [[BAR2_COPY:%.*]] = copy_value [[BAR2]]
+// CHECK:   [[BAR2_COPY_BORROW:%.*]] = begin_borrow [[BAR2_COPY]]
+// CHECK:   apply {{%.*}}([[BAR_COPY]], [[BAR2_COPY_BORROW]], [[X]])
+// CHECK:   end_borrow [[BAR2_COPY_BORROW]] from [[BAR2_COPY]]
+// CHECK:   destroy_value [[BAR2_COPY]]
+// CHECK:   end_borrow [[BORROWED_BAZ]] from [[BAZ]]
+// CHECK:   destroy_value [[BAZ]]
+// CHECK: } // end sil function '_T023closure_projection_testTf2ni_n'
+sil @closure_projection_test : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Baz>, @owned <τ_0_0> { var τ_0_0 } <Baz>) -> () {
+bb0(%0 : @owned $<τ_0_0> { var τ_0_0 } <Baz>, %1 : @owned $<τ_0_0> { var τ_0_0 } <Baz>):
+  %0a = project_box %0 : $<τ_0_0> { var τ_0_0 } <Baz>, 0
+  %2 = struct_element_addr %0a : $*Baz, #Baz.x
+  %3 = struct_element_addr %0a : $*Baz, #Baz.bar
+  %4 = load [trivial] %2 : $*Int
+  %5 = load [take] %3 : $*Bar
+  %6 = load [copy] %3 : $*Bar
+  %7 = begin_borrow %6 : $Bar
+  %8 = function_ref @destructured_baz_user : $@convention(thin) (@owned Bar, @guaranteed Bar, Int) -> ()
+  apply %8(%5, %7, %4) : $@convention(thin) (@owned Bar, @guaranteed Bar, Int) -> ()
+  end_borrow %7 from %6 : $Bar, $Bar
+  destroy_value %6 : $Bar
+
+  %1a = project_box %1 : $<τ_0_0> { var τ_0_0 } <Baz>, 0
+  %9 = struct_element_addr %1a : $*Baz, #Baz.x
+  %10 = struct_element_addr %1a : $*Baz, #Baz.bar
+  %11 = load [trivial] %9 : $*Int
+  %12 = load [copy] %10 : $*Bar
+  %13 = load [copy] %10 : $*Bar
+  %14 = begin_borrow %13 : $Bar
+  %15 = function_ref @destructured_baz_user : $@convention(thin) (@owned Bar, @guaranteed Bar, Int) -> ()
+  apply %15(%12, %14, %11) : $@convention(thin) (@owned Bar, @guaranteed Bar, Int) -> ()
+  end_borrow %14 from %13 : $Bar, $Bar
+  destroy_value %13 : $Bar
+
+  destroy_value %1 : $<τ_0_0> { var τ_0_0 } <Baz>
+  destroy_value %0 : $<τ_0_0> { var τ_0_0 } <Baz>
+  %t = tuple()
+  return %t : $()
 }

--- a/test/SILOptimizer/capture_promotion_ownership.swift
+++ b/test/SILOptimizer/capture_promotion_ownership.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend %s -enable-sil-ownership -disable-sil-linking -emit-sil -o - -verify | %FileCheck %s
+// RUN: %target-swift-frontend %s -enable-sil-ownership -disable-sil-linking -emit-sil -o - | %FileCheck %s
 
 // NOTE: We add -disable-sil-linking to the compile line to ensure that we have
 // access to declarations for standard library types, but not definitions. This


### PR DESCRIPTION
[capture-promotion] Be sure to copy_value a struct_extracted value from a promoted capture even though the value is borrowed.

The issue here is that we know that the given value is already borrowed, so
technically, we do not need a copy. The problem is that there is still
potentially a destroy of the value that will be cloned by the closure cloner.
This results in use-after-frees.

This commit fixes the problem by inserting the relevant copy_value and changing
the borrowed value into a +1 copy.

This is a bug that would have been caught by the Ownership verifier since a
borrowed value can not be destroyed (so the verifier would have tripped).

rdar://32625475
(cherry picked from commit ac67f337e9c62b6b3f58a7fa959eb79c8886e93e)
