### PR TITLE
[StdlibUnittest] Avoid serializing references to ObjC runtime APIs.

### DIFF
--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
@@ -624,6 +624,8 @@ func _stdlib_installTrapInterceptor()
 }
 #endif
 
+// Avoid serializing references to objc_setUncaughtExceptionHandler in SIL.
+@inline(never) @_semantics("stdlib_binary_only")
 func _childProcess() {
   _stdlib_installTrapInterceptor()
 


### PR DESCRIPTION
Specifically, objc_setUncaughtExceptionHandler, whose nullability is now annotated in Swift 4 mode when using the Xcode 9 SDKs. That means it has a different signature in Swift 3 and Swift 4 mode, which means that references from SIL will fail when deserialized in the other mode. (The recovery support added in earlier commits doesn't cover serialized SIL.)

This resulted in crashes when building with -build-serialized-stdlib-unittest, which enables -sil-serialize-all / "magic performance mode" when building the StdlibUnittest module like it does the standard library.

None of this affects developer code, because developer code doesn't serialize anything (if they're playing by the rules).