### PR TITLE
gitignore ctags and vim configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@
 #==============================================================================#
 cscope.files
 cscope.out
+.vimrc
+tags
 
 #==============================================================================#
 # Directories to ignore (do not add trailing '/'s, they skip symlinks).


### PR DESCRIPTION
Vim users often rely on ctags, which create a "tags" file in the project root.
Additionally, by convention vim project-specific settings are often stored in a `.vimrc` file, also stored in a project root.