### PR TITLE
[Migrator] Expand tuple destructuring to support tuple input types

### DIFF
--- a/test/Migrator/no_extraneous_argument_labels.swift
+++ b/test/Migrator/no_extraneous_argument_labels.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -typecheck %s -swift-version 3
 // RUN: rm -rf %t && mkdir -p %t && %target-swift-frontend -c -primary-file %s -emit-migrated-file-path %t/no_extraneous_argument_labels.result -swift-version 3 -o /dev/null
 // RUN: diff -u %s.expected %t/no_extraneous_argument_labels.result
-// RUN: not %target-swift-frontend -typecheck %s.expected -swift-version 4
+// RUN: %target-swift-frontend -typecheck %s.expected -swift-version 4
 
 func foo(_ oc: [String]) {
   var args: [String] = []

--- a/test/Migrator/no_extraneous_argument_labels.swift.expected
+++ b/test/Migrator/no_extraneous_argument_labels.swift.expected
@@ -1,12 +1,12 @@
 // RUN: %target-swift-frontend -typecheck %s -swift-version 3
 // RUN: rm -rf %t && mkdir -p %t && %target-swift-frontend -c -primary-file %s -emit-migrated-file-path %t/no_extraneous_argument_labels.result -swift-version 3 -o /dev/null
 // RUN: diff -u %s.expected %t/no_extraneous_argument_labels.result
-// RUN: not %target-swift-frontend -typecheck %s.expected -swift-version 4
+// RUN: %target-swift-frontend -typecheck %s.expected -swift-version 4
 
 func foo(_ oc: [String]) {
   var args: [String] = []
   let dictionary: [String: String] = [:]
   args.append(contentsOf: oc.map { orderedColumn in
-    dictionary.first { (column, value) in true }!.value
+    dictionary.first { let (column, value) = $0; return true }!.value
   })
 }

--- a/test/Migrator/tuple-arguments.swift
+++ b/test/Migrator/tuple-arguments.swift
@@ -56,3 +56,6 @@ extension Dictionary {
     dictionary.forEach { updateValue($1, forKey: $0) }
   }
 }
+
+let dictionary: [String: String] = [:]
+_ = dictionary.first { (column, value) in true }!.value

--- a/test/Migrator/tuple-arguments.swift.expected
+++ b/test/Migrator/tuple-arguments.swift.expected
@@ -56,3 +56,6 @@ extension Dictionary {
     dictionary.forEach { updateValue($0.1, forKey: $0.0) }
   }
 }
+
+let dictionary: [String: String] = [:]
+_ = dictionary.first { let (column, value) = $0; return true }!.value


### PR DESCRIPTION
The migrator pass that converts single-argument function input types
doesn't handle the case when the function input has a label and is
therefore a tuple. Expand it to handle that possibility.

rdar://problem/32477319