### PR TITLE
[4.0] Fold ConstraintSolver::coerceToRValue() into TypeChecker::coerceToRValue()

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7411,32 +7411,15 @@ namespace {
 } // end anonymous namespace
 
 Expr *ConstraintSystem::coerceToRValue(Expr *expr) {
-  // Can't load from an inout value.
-  if (auto *iot = getType(expr)->getAs<InOutType>()) {
-    // Emit a fixit if we can find the & expression that turned this into an
-    // inout.
-    auto &tc = getTypeChecker();
-    if (auto addrOf =
-        dyn_cast<InOutExpr>(expr->getSemanticsProvidingExpr())) {
-      tc.diagnose(expr->getLoc(), diag::load_of_explicit_lvalue,
-                  iot->getObjectType())
-        .fixItRemove(SourceRange(addrOf->getLoc()));
-      return coerceToRValue(addrOf->getSubExpr());
-    } else {
-      tc.diagnose(expr->getLoc(), diag::load_of_explicit_lvalue,
-                  iot->getObjectType());
-      return expr;
-    }
-  }
-
-  // If we already have an rvalue, we're done, otherwise emit a load.
-  if (auto lvalueTy = getType(expr)->getAs<LValueType>()) {
-    propagateLValueAccessKind(expr, AccessKind::Read);
-    return cacheType(new (getASTContext())
-                         LoadExpr(expr, lvalueTy->getObjectType()));
-  }
-
-  return expr;
+  auto &tc = getTypeChecker();
+  return tc.coerceToMaterializable(expr,
+                                   [&](Expr *expr) {
+                                     return getType(expr);
+                                   },
+                                   [&](Expr *expr, Type type) {
+                                     expr->setType(type);
+                                     cacheType(expr);
+                                   });
 }
 
 /// Emit the fixes computed as part of the solution, returning true if we were

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1747,7 +1747,13 @@ public:
 
   /// \brief Coerce the given expression to materializable type, if it
   /// isn't already.
-  Expr *coerceToMaterializable(Expr *expr);
+  Expr *coerceToMaterializable(Expr *expr,
+                               llvm::function_ref<Type(Expr *)> getType
+                                 = [](Expr *expr) { return expr->getType(); },
+                               llvm::function_ref<void(Expr *, Type)> setType
+                                 = [](Expr *expr, Type type) {
+                                     expr->setType(type);
+                               });
 
   /// Require that the library intrinsics for working with Optional<T>
   /// exist.

--- a/validation-test/compiler_crashers_2_fixed/0106-rdar32700180.swift
+++ b/validation-test/compiler_crashers_2_fixed/0106-rdar32700180.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-frontend %s -emit-ir
+// REQUIRES: objc_interop
+
+func f(_: AnyObject?) { }
+
+class C {
+  private var a: Int
+  private var b: Int
+
+  func test() {
+    f((self.a, self.b) as AnyObject)
+  }
+
+  init() {
+    a = 0
+    b = 0
+  }
+}
+


### PR DESCRIPTION
**Explanation**: The type checker failed to handle tuples containing lvalues (e.g., references to "var" properties in a class) along some paths, causing crashes in SILGen and (for asserts builds) AST verifier errors.
**Scope**: It's not clear that this ever worked, but seems fairly common. I think we've just made users suffer needlessly by getting this wrong.
**Radar**: rdar://problem/32700180
**Risk**: Low; re-use an established code path to fix the problems here rather than a poor duplication of it.
**Testing**: Tested example from radar, plus normal compiler qualification.
