### PR TITLE
[Type checker] Consistently mark used protocol conformances as "used".

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7513,38 +7513,9 @@ Expr *ConstraintSystem::applySolution(Solution &solution, Expr *expr,
     return nullptr;
   }
 
-  for (auto &e : solution.Conformances) {
-    const auto &conformance = e.second;
-
-    auto anchor = expr;
-    if (auto *locator = e.first)
-      anchor = locator->getAnchor();
-
-    if (conformance.isAbstract())
-      continue;
-
-    auto *concrete = conformance.getConcrete();
-    // If conformance check is not yet complete let's re-check using 'Used'
-    // to require conformance check to happen.
-    if (concrete->getState() != ProtocolConformanceState::Complete) {
-      if (auto conformance = TC.conformsToProtocol(
-              concrete->getType(), concrete->getProtocol(), DC,
-              ConformanceCheckFlags::InExpression |
-                  ConformanceCheckFlags::Used)) {
-        if (conformance->isAbstract())
-          continue;
-
-        concrete = conformance->getConcrete();
-      }
-    }
-
-    if (concrete->isComplete() && concrete->isInvalid()) {
-      TC.diagnose(anchor->getLoc(), diag::type_does_not_conform,
-                  concrete->getType(),
-                  concrete->getProtocol()->getDeclaredType());
-      return nullptr;
-    }
-  }
+  // Mark any normal conformances used in this solution as "used".
+  for (auto &e : solution.Conformances)
+    TC.markConformanceUsed(e.second, DC);
 
   ExprRewriter rewriter(*this, solution, suppressDiagnostics, skipClosures);
   ExprWalker walker(rewriter);

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7513,6 +7513,39 @@ Expr *ConstraintSystem::applySolution(Solution &solution, Expr *expr,
     return nullptr;
   }
 
+  for (auto &e : solution.Conformances) {
+    const auto &conformance = e.second;
+
+    auto anchor = expr;
+    if (auto *locator = e.first)
+      anchor = locator->getAnchor();
+
+    if (conformance.isAbstract())
+      continue;
+
+    auto *concrete = conformance.getConcrete();
+    // If conformance check is not yet complete let's re-check using 'Used'
+    // to require conformance check to happen.
+    if (concrete->getState() != ProtocolConformanceState::Complete) {
+      if (auto conformance = TC.conformsToProtocol(
+              concrete->getType(), concrete->getProtocol(), DC,
+              ConformanceCheckFlags::InExpression |
+                  ConformanceCheckFlags::Used)) {
+        if (conformance->isAbstract())
+          continue;
+
+        concrete = conformance->getConcrete();
+      }
+    }
+
+    if (concrete->isComplete() && concrete->isInvalid()) {
+      TC.diagnose(anchor->getLoc(), diag::type_does_not_conform,
+                  concrete->getType(),
+                  concrete->getProtocol()->getDeclaredType());
+      return nullptr;
+    }
+  }
+
   ExprRewriter rewriter(*this, solution, suppressDiagnostics, skipClosures);
   ExprWalker walker(rewriter);
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2473,19 +2473,22 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
   // separately.
   switch (kind) {
   case ConstraintKind::SelfObjectOfProtocol:
-    if (TC.containsProtocol(type, protocol, DC,
-                            ConformanceCheckFlags::InExpression))
+    if (auto conformance =
+          TC.containsProtocol(type, protocol, DC,
+                              ConformanceCheckFlags::InExpression)) {
+      CheckedConformances.push_back({getConstraintLocator(locator),
+                                     *conformance});
       return SolutionKind::Solved;
+    }
     break;
   case ConstraintKind::ConformsTo:
   case ConstraintKind::LiteralConformsTo: {
     // Check whether this type conforms to the protocol.
-    auto conformance = TC.conformsToProtocol(
-        type, protocol, DC, ConformanceCheckFlags::InExpression);
-
-    if (conformance) {
-      CheckedConformances.push_back(
-          {getConstraintLocator(locator), std::move(*conformance)});
+    if (auto conformance =
+          TC.conformsToProtocol(type, protocol, DC,
+                                ConformanceCheckFlags::InExpression)) {
+      CheckedConformances.push_back({getConstraintLocator(locator),
+                                     *conformance});
       return SolutionKind::Solved;
     }
     break;

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2478,12 +2478,19 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
       return SolutionKind::Solved;
     break;
   case ConstraintKind::ConformsTo:
-  case ConstraintKind::LiteralConformsTo:
+  case ConstraintKind::LiteralConformsTo: {
     // Check whether this type conforms to the protocol.
-    if (TC.conformsToProtocol(type, protocol, DC,
-                              ConformanceCheckFlags::InExpression))
+    auto conformance = TC.conformsToProtocol(
+        type, protocol, DC, ConformanceCheckFlags::InExpression);
+
+    if (conformance) {
+      CheckedConformances.push_back(
+          {getConstraintLocator(locator), std::move(*conformance)});
       return SolutionKind::Solved;
+    }
     break;
+  }
+
   default:
     llvm_unreachable("bad constraint kind");
   }

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -201,6 +201,9 @@ Solution ConstraintSystem::finalize(
   solution.DefaultedConstraints.insert(DefaultedConstraints.begin(),
                                        DefaultedConstraints.end());
 
+  for (auto &e : CheckedConformances)
+    solution.Conformances.push_back({e.first, e.second});
+
   return solution;
 }
 
@@ -260,6 +263,10 @@ void ConstraintSystem::applySolution(const Solution &solution) {
   // Register the defaulted type variables.
   DefaultedConstraints.append(solution.DefaultedConstraints.begin(),
                               solution.DefaultedConstraints.end());
+
+  // Register the conformances checked along the way to arrive to solution.
+  for (auto &conformance : solution.Conformances)
+    CheckedConformances.push_back(conformance);
 
   // Register any fixes produced along this path.
   Fixes.append(solution.Fixes.begin(), solution.Fixes.end());
@@ -452,6 +459,7 @@ ConstraintSystem::SolverScope::SolverScope(ConstraintSystem &cs)
   numOpenedTypes = cs.OpenedTypes.size();
   numOpenedExistentialTypes = cs.OpenedExistentialTypes.size();
   numDefaultedConstraints = cs.DefaultedConstraints.size();
+  numCheckedConformances = cs.CheckedConformances.size();
   PreviousScore = cs.CurrentScore;
 
   cs.solverState->registerScope(this);
@@ -502,7 +510,10 @@ ConstraintSystem::SolverScope::~SolverScope() {
 
   // Remove any defaulted type variables.
   truncate(cs.DefaultedConstraints, numDefaultedConstraints);
-  
+
+  // Remove any conformances checked along the current path.
+  truncate(cs.CheckedConformances, numCheckedConformances);
+
   // Reset the previous score.
   cs.CurrentScore = PreviousScore;
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1753,15 +1753,13 @@ Type Solution::simplifyType(Type type) const {
 }
 
 size_t Solution::getTotalMemory() const {
-  return sizeof(*this) +
-    typeBindings.getMemorySize() +
-    overloadChoices.getMemorySize() +
-    ConstraintRestrictions.getMemorySize() +
-    llvm::capacity_in_bytes(Fixes) +
-    DisjunctionChoices.getMemorySize() +
-    OpenedTypes.getMemorySize() +
-    OpenedExistentialTypes.getMemorySize() +
-    (DefaultedConstraints.size() * sizeof(void*));
+  return sizeof(*this) + typeBindings.getMemorySize() +
+         overloadChoices.getMemorySize() +
+         ConstraintRestrictions.getMemorySize() +
+         llvm::capacity_in_bytes(Fixes) + DisjunctionChoices.getMemorySize() +
+         OpenedTypes.getMemorySize() + OpenedExistentialTypes.getMemorySize() +
+         (DefaultedConstraints.size() * sizeof(void *)) +
+         llvm::capacity_in_bytes(Conformances);
 }
 
 DeclName OverloadChoice::getName() const {

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -562,6 +562,9 @@ public:
   /// The locators of \c Defaultable constraints whose defaults were used.
   llvm::SmallPtrSet<ConstraintLocator *, 8> DefaultedConstraints;
 
+  llvm::SmallVector<std::pair<ConstraintLocator *, ProtocolConformanceRef>, 8>
+      Conformances;
+
   /// \brief Simplify the given type by substituting all occurrences of
   /// type variables for their fixed types.
   Type simplifyType(Type type) const;
@@ -967,6 +970,9 @@ private:
   SmallVector<std::pair<ConstraintLocator *, ArchetypeType *>, 4>
     OpenedExistentialTypes;
 
+  SmallVector<std::pair<ConstraintLocator *, ProtocolConformanceRef>, 8>
+      CheckedConformances;
+
 public:
   /// The locators of \c Defaultable constraints whose defaults were used.
   SmallVector<ConstraintLocator *, 8> DefaultedConstraints;
@@ -1335,6 +1341,8 @@ public:
 
     /// The length of \c DefaultedConstraints.
     unsigned numDefaultedConstraints;
+
+    unsigned numCheckedConformances;
 
     /// The previous score.
     Score PreviousScore;

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -3117,6 +3117,19 @@ void Solution::dump(raw_ostream &out) const {
       out << "\n";
     }
   }
+
+  if (!Conformances.empty()) {
+    out << "\nConformances:\n";
+    auto &cs = getConstraintSystem();
+    for (auto &e : Conformances) {
+      out.indent(2);
+      out << "At ";
+      e.first->dump(&cs.getASTContext().SourceMgr, out);
+      out << "\n";
+      e.second.dump(out);
+      out << "\n";
+    }
+  }
 }
 
 void ConstraintSystem::dump() {

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5471,20 +5471,8 @@ Optional<ProtocolConformanceRef> TypeChecker::conformsToProtocol(
   }
 
   // If we're using this conformance, note that.
-  if (options.contains(ConformanceCheckFlags::Used) &&
-      lookupResult->isConcrete()) {
-    auto concrete = lookupResult->getConcrete();
-    auto normalConf = concrete->getRootNormalConformance();
-
-    // If the conformance is incomplete, queue it for completion.
-    if (normalConf->isIncomplete())
-      UsedConformances.insert(normalConf);
-
-    // Record the usage of this conformance in the enclosing source
-    // file.
-    if (auto sf = DC->getParentSourceFile()) {
-      sf->addUsedConformance(normalConf);
-    }
+  if (options.contains(ConformanceCheckFlags::Used)) {
+    markConformanceUsed(*lookupResult, DC);
   }
 
   // When requested, print the conformance access path used to find this
@@ -5545,6 +5533,24 @@ TypeChecker::conformsToProtocol(Type T, ProtocolDecl *Proto, DeclContext *DC,
   auto conformance = conformsToProtocol(T, Proto, DC, options, ComplainLoc);
   return conformance ? ConformsToProtocolResult::success(*conformance)
                      : ConformsToProtocolResult::failure();
+}
+
+void TypeChecker::markConformanceUsed(ProtocolConformanceRef conformance,
+                                      DeclContext *dc) {
+  if (conformance.isAbstract()) return;
+
+  auto normalConformance =
+    conformance.getConcrete()->getRootNormalConformance();
+
+  if (normalConformance->isComplete()) return;
+
+  UsedConformances.insert(normalConformance);
+
+  // Record the usage of this conformance in the enclosing source
+  // file.
+  if (auto sf = dc->getParentSourceFile()) {
+    sf->addUsedConformance(normalConformance);
+  }
 }
 
 Optional<ProtocolConformanceRef>

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1854,6 +1854,11 @@ public:
                      ConformanceCheckOptions options, SourceLoc ComplainLoc,
                      UnsatisfiedDependency *unsatisfiedDependency);
 
+  /// Mark the given protocol conformance as "used" from the given declaration
+  /// context.
+  void markConformanceUsed(ProtocolConformanceRef conformance,
+                           DeclContext *dc);
+
   /// Functor class suitable for use as a \c LookupConformanceFn to look up a
   /// conformance through a particular declaration context using the given
   /// type checker.

--- a/test/IRGen/Inputs/conformance_multifile_1.swift
+++ b/test/IRGen/Inputs/conformance_multifile_1.swift
@@ -1,0 +1,10 @@
+protocol Super {}
+protocol P : Super { }
+
+enum E {}
+
+extension E : P { }
+
+enum E2 {
+  case Filter(P)
+}

--- a/test/IRGen/conformance_multifile.swift
+++ b/test/IRGen/conformance_multifile.swift
@@ -1,0 +1,8 @@
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir -primary-file %s %S/Inputs/conformance_multifile_1.swift | %FileCheck %s
+
+func g<U>(_ f : (E) throws -> (U)) {}
+
+// CHECK: _T021conformance_multifile1tyyF
+func t() {
+  g(E2.Filter)
+}


### PR DESCRIPTION
Keep track of the protocol conformances required to form a particular
solution. At the point where we apply a solution, mark each of those
conformances as "used" so we're sure they are complete for later
phases (SILGen, SIL optimizer, IRGen). This general mechanism makes
sure we don't miss any cases in CSApply, such as the multi-case
illustrated in the new test where CSApply doesn't form any AST notes
describing the type erasure in a function conversion, so it otherwise
wouldn't see the conformance to mark it "used".

Pavel went most of the way down this path to track conformances last
month for unrelated reasons (that didn't really pan out). Resurrect
his work to track conformances, but only use them to mark as "used".

Fixes rdar://problem/32111710.