### PR TITLE
Debugger hook/breakpoint for issue reporting from the Swift runtime

### DIFF
--- a/include/swift/Runtime/Debug.h
+++ b/include/swift/Runtime/Debug.h
@@ -169,19 +169,6 @@ struct RuntimeErrorDetails {
   // and the pointer to the array of extra threads.
   uintptr_t numExtraThreads;
   Thread *threads;
-
-  // Description of a related object (other than 'memoryAddress').
-  struct RelatedObject {
-    const char *description;
-    const char *filename;
-    uintptr_t line;
-    uintptr_t column;
-  };
-
-  // Number of extra source locations that are related, and the pointer to the
-  // array of them.
-  uintptr_t numRelatedObjects;
-  RelatedObject *relatedObjects;
 };
 
 /// Debugger hook. Calling this stops the debugger with a message and details

--- a/include/swift/Runtime/Debug.h
+++ b/include/swift/Runtime/Debug.h
@@ -149,6 +149,11 @@ struct RuntimeErrorDetails {
   // Description of the current thread's stack position.
   const char *currentStackDescription;
 
+  // Number of frames in the current stack that should be ignored when reporting
+  // the issue (exluding the reportToDebugger/_swift_runtime_on_report frame).
+  // The remaining top frame should point to user's code where the bug is.
+  uintptr_t framesToSkip;
+
   // Address of some associated object (if there's any).
   void *memoryAddress;
 

--- a/include/swift/Runtime/Debug.h
+++ b/include/swift/Runtime/Debug.h
@@ -138,7 +138,7 @@ void printCurrentBacktrace(unsigned framesToSkip = 1);
 /// to be stable) and describes extra information about a fatal error or a
 /// non-fatal warning, which should be logged as a runtime issue. Please keep
 /// all integer values pointer-sized.
-struct _RuntimeErrorDetails {
+struct RuntimeErrorDetails {
   // ABI version, needs to be "1" currently.
   uintptr_t version;
 
@@ -181,8 +181,8 @@ struct _RuntimeErrorDetails {
 
 /// Debugger hook. Calling this stops the debugger with a message and details
 /// about the issues.
-void _reportToDebugger(bool isFatal, const char *message,
-                      _RuntimeErrorDetails *details = nullptr);
+void reportToDebugger(bool isFatal, const char *message,
+                      RuntimeErrorDetails *details = nullptr);
 
 // namespace swift
 }

--- a/stdlib/public/runtime/Errors.cpp
+++ b/stdlib/public/runtime/Errors.cpp
@@ -244,17 +244,17 @@ reportNow(uint32_t flags, const char *message)
 }
 
 LLVM_ATTRIBUTE_NOINLINE SWIFT_RUNTIME_EXPORT
-void __swift_runtime_on_report(bool isFatal, const char *message,
-                               _RuntimeErrorDetails *details) {
+void _swift_runtime_on_report(bool isFatal, const char *message,
+                              RuntimeErrorDetails *details) {
   // Do nothing. This function is meant to be used by the debugger.
 
   // The following is necessary to avoid calls from being optimized out.
   asm volatile("" ::: "memory");
 }
 
-void swift::_reportToDebugger(bool isFatal, const char *message,
-                              _RuntimeErrorDetails *details) {
-  __swift_runtime_on_report(isFatal, message, details);
+void swift::reportToDebugger(bool isFatal, const char *message,
+                             RuntimeErrorDetails *details) {
+  _swift_runtime_on_report(isFatal, message, details);
 }
 
 /// Report a fatal error to system console, stderr, and crash logs.

--- a/stdlib/public/runtime/Errors.cpp
+++ b/stdlib/public/runtime/Errors.cpp
@@ -243,6 +243,20 @@ reportNow(uint32_t flags, const char *message)
 #endif
 }
 
+LLVM_ATTRIBUTE_NOINLINE SWIFT_RUNTIME_EXPORT
+void __swift_runtime_on_report(bool isFatal, const char *message,
+                               _RuntimeErrorDetails *details) {
+  // Do nothing. This function is meant to be used by the debugger.
+
+  // The following is necessary to avoid calls from being optimized out.
+  asm volatile("" ::: "memory");
+}
+
+void swift::_reportToDebugger(bool isFatal, const char *message,
+                              _RuntimeErrorDetails *details) {
+  __swift_runtime_on_report(isFatal, message, details);
+}
+
 /// Report a fatal error to system console, stderr, and crash logs.
 /// Does not crash by itself.
 void swift::swift_reportError(uint32_t flags,

--- a/stdlib/public/runtime/Exclusivity.cpp
+++ b/stdlib/public/runtime/Exclusivity.cpp
@@ -107,12 +107,12 @@ static void reportExclusivityConflict(ExclusivityFlags oldAction, void *oldPC,
 
   bool keepGoing = isWarningOnly(newFlags);
 
-  _RuntimeErrorDetails::Thread secondaryThread = {
-      .description = oldAccess,
-      .numFrames = 1,
-      .frames = &oldPC
+  RuntimeErrorDetails::Thread secondaryThread = {
+    .description = oldAccess,
+    .numFrames = 1,
+    .frames = &oldPC
   };
-  _RuntimeErrorDetails details = {
+  RuntimeErrorDetails details = {
     .version = 1,
     .errorType = "exclusivity-violation",
     .currentStackDescription = newAccess,
@@ -120,7 +120,7 @@ static void reportExclusivityConflict(ExclusivityFlags oldAction, void *oldPC,
     .numExtraThreads = 1,
     .threads = &secondaryThread
   };
-  _reportToDebugger(!keepGoing, message, &details);
+  reportToDebugger(!keepGoing, message, &details);
 
   if (keepGoing) {
     return;

--- a/stdlib/public/runtime/Exclusivity.cpp
+++ b/stdlib/public/runtime/Exclusivity.cpp
@@ -116,6 +116,7 @@ static void reportExclusivityConflict(ExclusivityFlags oldAction, void *oldPC,
     .version = 1,
     .errorType = "exclusivity-violation",
     .currentStackDescription = newAccess,
+    .framesToSkip = framesToSkip,
     .memoryAddress = pointer,
     .numExtraThreads = 1,
     .threads = &secondaryThread

--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -1436,7 +1436,7 @@ void swift_objc_swift3ImplicitObjCEntrypoint(id self, SEL selector,
   asprintf(&nullTerminatedFilename, "%*s", (int)filenameLength, filename);
 
   RuntimeErrorDetails::RelatedObject methodDeclaration = {
-    .description = "Method declaration",
+    .description = "Method declaration; add @objc here",
     .filename = nullTerminatedFilename,
     .line = line,
     .column = column
@@ -1444,6 +1444,7 @@ void swift_objc_swift3ImplicitObjCEntrypoint(id self, SEL selector,
   RuntimeErrorDetails details = {
     .version = 1,
     .errorType = "implicit-objc-entrypoint",
+    .framesToSkip = 1,
     .numRelatedObjects = 1,
     .relatedObjects = &methodDeclaration
   };

--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -1435,20 +1435,20 @@ void swift_objc_swift3ImplicitObjCEntrypoint(id self, SEL selector,
            sel_getName(selector));
   asprintf(&nullTerminatedFilename, "%*s", (int)filenameLength, filename);
 
-  _RuntimeErrorDetails::RelatedObject methodDeclaration = {
+  RuntimeErrorDetails::RelatedObject methodDeclaration = {
     .description = "Method declaration",
     .filename = nullTerminatedFilename,
     .line = line,
     .column = column
   };
-  _RuntimeErrorDetails details = {
+  RuntimeErrorDetails details = {
     .version = 1,
     .errorType = "implicit-objc-entrypoint",
     .numRelatedObjects = 1,
     .relatedObjects = &methodDeclaration
   };
   bool isFatal = reporter == swift::fatalError;
-  _reportToDebugger(isFatal, message, &details);
+  reportToDebugger(isFatal, message, &details);
 
   reporter(flags,
            "*** %s:%zu:%zu: %s; add explicit '@objc' to the declaration to "

--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -1457,6 +1457,7 @@ void swift_objc_swift3ImplicitObjCEntrypoint(id self, SEL selector,
            "message\n",
            nullTerminatedFilename, line, column, message);
   free(message);
+  free(nullTerminatedFilename);
 }
 
 #endif

--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -1425,17 +1425,37 @@ void swift_objc_swift3ImplicitObjCEntrypoint(id self, SEL selector,
   
   if (filenameLength > INT_MAX)
     filenameLength = INT_MAX;
-  
-  reporter(
-    flags,
-    "*** %*s:%zu:%zu: implicit Objective-C entrypoint %c[%s %s] "
-    "is deprecated and will be removed in Swift 4; "
-    "add explicit '@objc' to the declaration to emit the Objective-C "
-    "entrypoint in Swift 4 and suppress this message\n",
-    (int)filenameLength, filename, line, column,
-    isInstanceMethod ? '-' : '+',
-    class_getName([self class]),
-    sel_getName(selector));
+
+  char *message, *nullTerminatedFilename;
+  asprintf(&message,
+           "implicit Objective-C entrypoint %c[%s %s] is deprecated and will "
+           "be removed in Swift 4",
+           isInstanceMethod ? '-' : '+',
+           class_getName([self class]),
+           sel_getName(selector));
+  asprintf(&nullTerminatedFilename, "%*s", (int)filenameLength, filename);
+
+  _RuntimeErrorDetails::RelatedObject methodDeclaration = {
+    .description = "Method declaration",
+    .filename = nullTerminatedFilename,
+    .line = line,
+    .column = column
+  };
+  _RuntimeErrorDetails details = {
+    .version = 1,
+    .errorType = "implicit-objc-entrypoint",
+    .numRelatedObjects = 1,
+    .relatedObjects = &methodDeclaration
+  };
+  bool isFatal = reporter == swift::fatalError;
+  _reportToDebugger(isFatal, message, &details);
+
+  reporter(flags,
+           "*** %s:%zu:%zu: %s; add explicit '@objc' to the declaration to "
+           "emit the Objective-C entrypoint in Swift 4 and suppress this "
+           "message\n",
+           nullTerminatedFilename, line, column, message);
+  free(message);
 }
 
 #endif

--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -1435,18 +1435,10 @@ void swift_objc_swift3ImplicitObjCEntrypoint(id self, SEL selector,
            sel_getName(selector));
   asprintf(&nullTerminatedFilename, "%*s", (int)filenameLength, filename);
 
-  RuntimeErrorDetails::RelatedObject methodDeclaration = {
-    .description = "Method declaration; add @objc here",
-    .filename = nullTerminatedFilename,
-    .line = line,
-    .column = column
-  };
   RuntimeErrorDetails details = {
     .version = 1,
     .errorType = "implicit-objc-entrypoint",
-    .framesToSkip = 1,
-    .numRelatedObjects = 1,
-    .relatedObjects = &methodDeclaration
+    .framesToSkip = 1
   };
   bool isFatal = reporter == swift::fatalError;
   reportToDebugger(isFatal, message, &details);


### PR DESCRIPTION
This implements a debugger hook (breakpoint) API and data structure. This structure is passed to the debugger and describes extra information about a fatal error or a non-fatal warning, which should be logged as a runtime issue.

This debugger hook is then used from two places, which currently only log to stderr:
- Runtime exclusivity violations.
- Swift 3 implicit Obj-C entrypoints.

A subsequent LLDB support will be able to catch these callbacks and show the runtime issues in a better way than just logging them to stderr.  When the debugger is not attached, this shouldn't have any effect.
