### PR TITLE
SILGen: Don't emit generator functions for caller-side default parameteres

### DIFF
--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -264,7 +264,8 @@ public:
   void emitEnumConstructor(EnumElementDecl *decl);
 
   /// Emits the default argument generator with the given expression.
-  void emitDefaultArgGenerator(SILDeclRef constant, Expr *arg);
+  void emitDefaultArgGenerator(SILDeclRef constant, Expr *arg,
+                               DefaultArgumentKind kind);
 
   /// Emits the stored property initializer for the given pattern.
   void emitStoredPropertyInitialization(PatternBindingDecl *pd, unsigned i);

--- a/test/SILGen/default_arguments.swift
+++ b/test/SILGen/default_arguments.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -Xllvm -sil-full-demangle -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -emit-silgen %s | %FileCheck %s --check-prefix=NEGATIVE
 
 // __FUNCTION__ used as top-level parameter produces the module name.
 // CHECK-LABEL: sil @main
@@ -74,17 +75,13 @@ func testMagicLiterals(file: String = #file,
 // Check that default argument generator functions don't leak information about
 // user's source.
 //
-// CHECK-LABEL: sil hidden @_T017default_arguments17testMagicLiteralsySS4file_SS8functionSi4lineSi6columntFfA_
-// CHECK: string_literal utf16 ""
+// NEGATIVE-NOT: sil hidden @_T017default_arguments17testMagicLiteralsySS4file_SS8functionSi4lineSi6columntFfA_
 //
-// CHECK-LABEL: sil hidden @_T017default_arguments17testMagicLiteralsySS4file_SS8functionSi4lineSi6columntFfA0_
-// CHECK: string_literal utf16 ""
+// NEGATIVE-NOT: sil hidden @_T017default_arguments17testMagicLiteralsySS4file_SS8functionSi4lineSi6columntFfA0_
 //
-// CHECK-LABEL: sil hidden @_T017default_arguments17testMagicLiteralsySS4file_SS8functionSi4lineSi6columntFfA1_
-// CHECK: integer_literal $Builtin.Int2048, 0
+// NEGATIVE-NOT: sil hidden @_T017default_arguments17testMagicLiteralsySS4file_SS8functionSi4lineSi6columntFfA1_
 //
-// CHECK-LABEL: sil hidden @_T017default_arguments17testMagicLiteralsySS4file_SS8functionSi4lineSi6columntFfA2_
-// CHECK: integer_literal $Builtin.Int2048, 0
+// NEGATIVE-NOT: sil hidden @_T017default_arguments17testMagicLiteralsySS4file_SS8functionSi4lineSi6columntFfA2_
 
 func closure(_: () -> ()) {}
 func autoclosure(_: @autoclosure () -> ()) {}

--- a/test/SILGen/dso_handle.swift
+++ b/test/SILGen/dso_handle.swift
@@ -8,16 +8,9 @@
 // CHECK-NEXT: [[DSOPtr:%[0-9]+]] = address_to_pointer [[DSOAddr]] : $*Builtin.RawPointer to $Builtin.RawPointer
 // CHECK-NEXT: [[DSOPtrStruct:[0-9]+]] = struct $UnsafeRawPointer ([[DSOPtr]] : $Builtin.RawPointer)
 
-
-// CHECK-LABEL: sil hidden @_T010dso_handle14printDSOHandleS2V0A0_tFfA_
-// CHECK: [[DSOAddr:%[0-9]+]] = global_addr [[DSO]] : $*Builtin.RawPointer
-// CHECK-NEXT: [[DSOPtr:%[0-9]+]] = address_to_pointer [[DSOAddr]] : $*Builtin.RawPointer to $Builtin.RawPointer
-// CHECK-NEXT: [[DSOPtrStruct:%[0-9]+]] = struct $UnsafeRawPointer ([[DSOPtr]] : $Builtin.RawPointer)
-// CHECK-NEXT: return [[DSOPtrStruct]] : $UnsafeRawPointer
 func printDSOHandle(dso: UnsafeRawPointer = #dsohandle) -> UnsafeRawPointer {
   print(dso)
   return dso
 }
 
 _ = printDSOHandle()
-


### PR DESCRIPTION
* Description: Fix a crash while emitting a default argument generator for #dsohandle for an inlineable function, by not emitting the generator in this case, since we never use it for "caller-side" default parameters like #file, #line, #dsohandle, etc.

* Risk: Low, might cause linker errors if someone really is calling the generator in this case.

* Scope of the issue: Affects people defining @inline(__always) functions, while this isn't an officially supported feature it does get used.

* Origination: Introduced in 3.1.

* Reviewed by: @jckarter 

* Radar: Fixes <rdar://problem/32597278>.