### PR TITLE
[4.0] [StdlibUnittest] Avoid serializing references to ObjC runtime APIs

### DIFF
--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
@@ -624,6 +624,8 @@ func _stdlib_installTrapInterceptor()
 }
 #endif
 
+// Avoid serializing references to objc_setUncaughtExceptionHandler in SIL.
+@inline(never) @_semantics("stdlib_binary_only")
 func _childProcess() {
   _stdlib_installTrapInterceptor()
 


### PR DESCRIPTION
- **Explanation**: Avoid crashes when mixing 3.2 and 4.0 modes in the Swift test suite under certain build configurations.
- **Scope**: Affects our private StdlibUnittest only.
- **Radar**: (none)
- **Reviewed by**: @DougGregor 
- **Risk**: None. We don't ship this library or include it in downloadable toolchains.
- **Testing**: It fixed the issue on master.