### PR TITLE
Revert "Build fix: Update fix-it stub editor test"

### DIFF
--- a/test/decl/protocol/conforms/fixit_stub_editor.swift
+++ b/test/decl/protocol/conforms/fixit_stub_editor.swift
@@ -1,9 +1,6 @@
 // RUN: %target-typecheck-verify-swift -diagnostics-editor-mode
-// REQUIRES: objc_interop
 
-import Foundation
-
-@objc protocol P1 {
+protocol P1 {
   @available(iOS, unavailable)
   func foo1()
   func foo2()
@@ -14,10 +11,7 @@ protocol P2 {
   func bar2()
 }
 
-class C1 : P1, P2 {}
-// expected-error@-1 {{type 'C1' does not conform to protocol 'P1'}}
-// expected-error@-2 {{type 'C1' does not conform to protocol 'P2'}}
-// expected-note@-3 {{do you want to add protocol stubs?}} {{20-20=\n    func foo2() {\n        <#code#>\n    \}\n\n    func bar1() {\n        <#code#>\n    \}\n\n    func bar2() {\n        <#code#>\n    \}\n}}
+class C1 : P1, P2 {} // expected-error{{type 'C1' does not conform to protocol 'P1'}} expected-error{{type 'C1' does not conform to protocol 'P2'}} expected-note{{do you want to add protocol stubs?}}{{20-20=\n    func foo1() {\n        <#code#>\n    \}\n\n    func foo2() {\n        <#code#>\n    \}\n\n    func bar1() {\n        <#code#>\n    \}\n\n    func bar2() {\n        <#code#>\n    \}\n}}
 
 protocol P3 {
   associatedtype T1


### PR DESCRIPTION
This reverts commit 9a17226d263b594a3a2a369d3951387a974139f5.

```
Script:
--
/Users/buildnode/jenkins/workspace/oss-swift-incremental-RA-osx/buildbot_incremental/swift-macosx-x86_64/bin/swiftc -frontend -target x86_64-apple-macosx10.9  -module-cache-path '/var/folders/_8/79jmzf2142z2xydc_01btlx00000gn/T/swift-testsuite-clang-module-cacheaaPFQx' -sdk /Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk -swift-version 3 -typecheck -verify -disable-objc-attr-requires-foundation-module /Users/buildnode/jenkins/workspace/oss-swift-incremental-RA-osx/swift/test/decl/protocol/conforms/fixit_stub_editor.swift -diagnostics-editor-mode
--
Exit Code: 1

Command Output (stderr):
--
/Users/buildnode/jenkins/workspace/oss-swift-incremental-RA-osx/swift/test/decl/protocol/conforms/fixit_stub_editor.swift:20:60: error: expected fix-it not seen; actual fix-its: {{20-20=\n    func foo1() {\n        <#code#>\n    \}\n\n    func foo2() {\n        <#code#>\n    \}\n\n    func bar1() {\n        <#code#>\n    \}\n\n    func bar2() {\n        <#code#>\n    \}\n}}
// expected-note@-3 {{do you want to add protocol stubs?}} {{20-20=\n    func foo2() {\n        <#code#>\n    \}\n\n    func bar1() {\n        <#code#>\n    \}\n\n    func bar2() {\n        <#code#>\n    \}\n}}
                                                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                                           {{20-20=\n    func foo1() {\n        <#code#>\n    \}\n\n    func foo2() {\n        <#code#>\n    \}\n\n    func bar1() {\n        <#code#>\n    \}\n\n    func bar2() {\n        <#code#>\n    \}\n}}

--

```