### PR TITLE
[Type checker] Re-validate typealiases in protocols after protocol validation

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -45,6 +45,7 @@ namespace swift {
   class AssociatedTypeDecl;
   class ASTContext;
   class ClassDecl;
+  class DependentMemberType;
   class GenericTypeParamDecl;
   class GenericTypeParamType;
   class GenericParamList;
@@ -533,6 +534,12 @@ public:
   bool hasTypeParameter() {
     return getRecursiveProperties().hasTypeParameter();
   }
+
+  /// Find any unresolved dependent member type within this type.
+  ///
+  /// "Unresolved" dependent member types have no known associated type,
+  /// and are only used transiently in the type checker.
+  const DependentMemberType *findUnresolvedDependentMemberType();
 
   /// Return the root generic parameter of this type parameter type.
   GenericTypeParamType *getRootGenericParam();

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -2575,18 +2575,8 @@ public:
       // dependent member types.
       // FIXME: This is a general property of the type system.
       auto interfaceTy = AFD->getInterfaceType();
-      Type unresolvedDependentTy;
-      interfaceTy.findIf([&](Type type) -> bool {
-        if (auto dependent = type->getAs<DependentMemberType>()) {
-          if (dependent->getAssocType() == nullptr) {
-            unresolvedDependentTy = dependent;
-            return true;
-          }
-        }
-        return false;
-      });
-
-      if (unresolvedDependentTy) {
+      if (auto unresolvedDependentTy
+            = interfaceTy->findUnresolvedDependentMemberType()) {
         Out << "Unresolved dependent member type ";
         unresolvedDependentTy->print(Out);
         abort();

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -5266,14 +5266,8 @@ static void collectRequirements(GenericSignatureBuilder &builder,
 
       // Drop requirements involving concrete types containing
       // unresolved associated types.
-      if (repTy.findIf([](Type t) -> bool {
-            if (auto *depTy = dyn_cast<DependentMemberType>(t.getPointer()))
-              if (depTy->getAssocType() == nullptr)
-                return true;
-            return false;
-          })) {
+      if (repTy->findUnresolvedDependentMemberType())
         return;
-      }
     } else if (auto layoutConstraint = type.dyn_cast<LayoutConstraint>()) {
       requirements.push_back(Requirement(kind, depTy, layoutConstraint));
       return;

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3156,6 +3156,24 @@ Type Type::substDependentTypesWithErrorTypes() const {
                     SubstFlags::UseErrorType));
 }
 
+const DependentMemberType *TypeBase::findUnresolvedDependentMemberType() {
+  if (!hasTypeParameter()) return nullptr;
+
+  const DependentMemberType *unresolvedDepMemTy = nullptr;
+  Type(this).findIf([&](Type type) -> bool {
+    if (auto depMemTy = type->getAs<DependentMemberType>()) {
+      if (depMemTy->getAssocType() == nullptr) {
+        unresolvedDepMemTy = depMemTy;
+        return true;
+      }
+    }
+    return false;
+  });
+
+  return unresolvedDepMemTy;
+}
+
+
 Type TypeBase::getSuperclassForDecl(const ClassDecl *baseClass) {
   Type t(this);
   while (t) {

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3623,6 +3623,9 @@ case TypeKind::Id:
   case TypeKind::NameAlias: {
     auto alias = cast<NameAliasType>(base);
     auto underlyingTy = Type(alias->getSinglyDesugaredType());
+    if (!underlyingTy)
+      return Type();
+
     auto transformedTy = underlyingTy.transformRec(fn);
     if (!transformedTy)
       return Type();

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -6954,18 +6954,6 @@ bool swift::checkOverrides(TypeChecker &TC, ValueDecl *decl) {
   return DeclChecker::checkOverrides(TC, decl);
 }
 
-/// Determine whether the given type contains an unresolved dependent member
-/// type.
-static bool hasUnresolvedDependentMemberType(Type type) {
-  return type.findIf([](Type type) {
-    if (auto depMemTy = type->getAs<DependentMemberType>()) {
-      if (!depMemTy->getAssocType()) return true;
-    }
-
-    return false;
-  });
-}
-
 bool TypeChecker::isAvailabilitySafeForOverride(ValueDecl *override,
                                                 ValueDecl *base) {
   // API availability ranges are contravariant: make sure the version range
@@ -7270,8 +7258,8 @@ void TypeChecker::validateDecl(ValueDecl *D) {
           // FIXME: We never should have recorded such a type in the first
           // place.
           if (!aliasDecl->getUnderlyingTypeLoc().getType() ||
-              hasUnresolvedDependentMemberType(
-                aliasDecl->getUnderlyingTypeLoc().getType())) {
+              aliasDecl->getUnderlyingTypeLoc().getType()
+                ->findUnresolvedDependentMemberType()) {
             aliasDecl->getUnderlyingTypeLoc().setType(Type(),
                                                       /*validated=*/false);
             validateAccessibility(aliasDecl);

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -6954,6 +6954,18 @@ bool swift::checkOverrides(TypeChecker &TC, ValueDecl *decl) {
   return DeclChecker::checkOverrides(TC, decl);
 }
 
+/// Determine whether the given type contains an unresolved dependent member
+/// type.
+static bool hasUnresolvedDependentMemberType(Type type) {
+  return type.findIf([](Type type) {
+    if (auto depMemTy = type->getAs<DependentMemberType>()) {
+      if (!depMemTy->getAssocType()) return true;
+    }
+
+    return false;
+  });
+}
+
 bool TypeChecker::isAvailabilitySafeForOverride(ValueDecl *override,
                                                 ValueDecl *base) {
   // API availability ranges are contravariant: make sure the version range
@@ -7052,6 +7064,27 @@ static Optional<ObjCReason> shouldMarkClassAsObjC(TypeChecker &TC,
     return ObjCReason::ImplicitlyObjC;
 
   return None;
+}
+
+/// Validate the underlying type of the given typealias.
+static void validateTypealiasType(TypeChecker &tc, TypeAliasDecl *typeAlias) {
+  TypeResolutionOptions options = TR_TypeAliasUnderlyingType;
+  if (typeAlias->getFormalAccess() <= Accessibility::FilePrivate)
+    options |= TR_KnownNonCascadingDependency;
+
+  if (typeAlias->getDeclContext()->isModuleScopeContext() &&
+      typeAlias->getGenericParams() == nullptr) {
+    IterativeTypeChecker ITC(tc);
+    ITC.satisfy(requestResolveTypeDecl(typeAlias));
+  } else {
+    if (tc.validateType(typeAlias->getUnderlyingTypeLoc(),
+                        typeAlias, options)) {
+      typeAlias->setInvalid();
+      typeAlias->getUnderlyingTypeLoc().setInvalidType(tc.Context);
+    }
+
+    typeAlias->setUnderlyingType(typeAlias->getUnderlyingTypeLoc().getType());
+  }
 }
 
 void TypeChecker::validateDecl(ValueDecl *D) {
@@ -7161,25 +7194,7 @@ void TypeChecker::validateDecl(ValueDecl *D) {
     SWIFT_DEFER { typeAlias->setIsBeingValidated(false); };
 
     validateGenericTypeSignature(typeAlias);
-
-    TypeResolutionOptions options = TR_TypeAliasUnderlyingType;
-    if (typeAlias->getFormalAccess() <= Accessibility::FilePrivate)
-      options |= TR_KnownNonCascadingDependency;
-
-    if (typeAlias->getDeclContext()->isModuleScopeContext() &&
-        typeAlias->getGenericParams() == nullptr) {
-      IterativeTypeChecker ITC(*this);
-      ITC.satisfy(requestResolveTypeDecl(typeAlias));
-    } else {
-      if (validateType(typeAlias->getUnderlyingTypeLoc(),
-                       typeAlias, options)) {
-        typeAlias->setInvalid();
-        typeAlias->getUnderlyingTypeLoc().setInvalidType(Context);
-      }
-
-      typeAlias->setUnderlyingType(typeAlias->getUnderlyingTypeLoc().getType());
-    }
-
+    validateTypealiasType(*this, typeAlias);
     break;
   }
 
@@ -7246,8 +7261,28 @@ void TypeChecker::validateDecl(ValueDecl *D) {
     // FIXME: Hopefully this can all go away with the ITC.
     for (auto member : proto->getMembers()) {
       if (auto *aliasDecl = dyn_cast<TypeAliasDecl>(member)) {
-        if (!aliasDecl->isGeneric())
+        if (!aliasDecl->isGeneric()) {
           aliasDecl->setGenericEnvironment(proto->getGenericEnvironment());
+
+          // If the underlying alias declaration has a type parameter,
+          // we have unresolved dependent member types we will need to deal
+          // with. Wipe out the types and validate them again.
+          // FIXME: We never should have recorded such a type in the first
+          // place.
+          if (!aliasDecl->getUnderlyingTypeLoc().getType() ||
+              hasUnresolvedDependentMemberType(
+                aliasDecl->getUnderlyingTypeLoc().getType())) {
+            aliasDecl->getUnderlyingTypeLoc().setType(Type(),
+                                                      /*validated=*/false);
+            validateAccessibility(aliasDecl);
+
+            // Check generic parameters, if needed.
+            aliasDecl->setIsBeingValidated();
+            SWIFT_DEFER { aliasDecl->setIsBeingValidated(false); };
+
+            validateTypealiasType(*this, aliasDecl);
+          }
+        }
       }
     }
 

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -218,6 +218,7 @@ Type CompleteGenericTypeResolver::resolveDependentMemberType(
       if (auto proto =
             concrete->getDeclContext()
               ->getAsProtocolOrProtocolExtensionContext()) {
+        TC.validateDecl(proto);
         auto subMap = SubstitutionMap::getProtocolSubstitutions(
                         proto, baseTy, ProtocolConformanceRef(proto));
         return concrete->getDeclaredInterfaceType().subst(subMap);

--- a/validation-test/compiler_crashers_2_fixed/0107-rdar32700180.swift
+++ b/validation-test/compiler_crashers_2_fixed/0107-rdar32700180.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-frontend %s -emit-ir
+struct X<T: Q> {
+  func f(_: T.Z) { }
+}
+
+protocol P {
+  associatedtype A
+  associatedtype B
+}
+
+protocol Q {
+  associatedtype C: P
+  typealias Z = (C.A, C.B)
+}


### PR DESCRIPTION
Validation for typealiases in protocols is... odd. It needs to avoid
depending on the whole protocol being validated, so it does an initial
validation that can leave nested types of Self (and other associated
types) somewhat unresolved. In these cases, do something icky but
partially effective: when we resolve the protocol, go back and clean
up the types of these typealiases.

A better solution would allow us to use the types of these typealiases
within the Generic Signature Builder without recording them in the AST
as "the interface type", so there's no way unresolved nested types
could be found (and, therefore, nothing to "fix up" later). Howwever,
that's a more significant undertaking.

Fixes rdar://problem/32287795.