### PR TITLE
[4.0] [Type checker] Re-validate typealiases in protocols after protocol validation

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -45,6 +45,7 @@ namespace swift {
   class AssociatedTypeDecl;
   class ASTContext;
   class ClassDecl;
+  class DependentMemberType;
   class GenericTypeParamDecl;
   class GenericTypeParamType;
   class GenericParamList;
@@ -551,6 +552,12 @@ public:
   bool hasTypeParameter() {
     return getRecursiveProperties().hasTypeParameter();
   }
+
+  /// Find any unresolved dependent member type within this type.
+  ///
+  /// "Unresolved" dependent member types have no known associated type,
+  /// and are only used transiently in the type checker.
+  const DependentMemberType *findUnresolvedDependentMemberType();
 
   /// Return the root generic parameter of this type parameter type.
   GenericTypeParamType *getRootGenericParam();

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -2562,18 +2562,8 @@ public:
       // dependent member types.
       // FIXME: This is a general property of the type system.
       auto interfaceTy = AFD->getInterfaceType();
-      Type unresolvedDependentTy;
-      interfaceTy.findIf([&](Type type) -> bool {
-        if (auto dependent = type->getAs<DependentMemberType>()) {
-          if (dependent->getAssocType() == nullptr) {
-            unresolvedDependentTy = dependent;
-            return true;
-          }
-        }
-        return false;
-      });
-
-      if (unresolvedDependentTy) {
+      if (auto unresolvedDependentTy
+            = interfaceTy->findUnresolvedDependentMemberType()) {
         Out << "Unresolved dependent member type ";
         unresolvedDependentTy->print(Out);
         abort();

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -5258,14 +5258,8 @@ static void collectRequirements(GenericSignatureBuilder &builder,
 
       // Drop requirements involving concrete types containing
       // unresolved associated types.
-      if (repTy.findIf([](Type t) -> bool {
-            if (auto *depTy = dyn_cast<DependentMemberType>(t.getPointer()))
-              if (depTy->getAssocType() == nullptr)
-                return true;
-            return false;
-          })) {
+      if (repTy->findUnresolvedDependentMemberType())
         return;
-      }
     } else if (auto layoutConstraint = type.dyn_cast<LayoutConstraint>()) {
       requirements.push_back(Requirement(kind, depTy, layoutConstraint));
       return;

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3156,6 +3156,24 @@ Type Type::substDependentTypesWithErrorTypes() const {
                     SubstFlags::UseErrorType));
 }
 
+const DependentMemberType *TypeBase::findUnresolvedDependentMemberType() {
+  if (!hasTypeParameter()) return nullptr;
+
+  const DependentMemberType *unresolvedDepMemTy = nullptr;
+  Type(this).findIf([&](Type type) -> bool {
+    if (auto depMemTy = type->getAs<DependentMemberType>()) {
+      if (depMemTy->getAssocType() == nullptr) {
+        unresolvedDepMemTy = depMemTy;
+        return true;
+      }
+    }
+    return false;
+  });
+
+  return unresolvedDepMemTy;
+}
+
+
 Type TypeBase::getSuperclassForDecl(const ClassDecl *baseClass) {
   Type t(this);
   while (t) {

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3623,6 +3623,9 @@ case TypeKind::Id:
   case TypeKind::NameAlias: {
     auto alias = cast<NameAliasType>(base);
     auto underlyingTy = Type(alias->getSinglyDesugaredType());
+    if (!underlyingTy)
+      return Type();
+
     auto transformedTy = underlyingTy.transformRec(fn);
     if (!transformedTy)
       return Type();

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -6950,18 +6950,6 @@ bool swift::checkOverrides(TypeChecker &TC, ValueDecl *decl) {
   return DeclChecker::checkOverrides(TC, decl);
 }
 
-/// Determine whether the given type contains an unresolved dependent member
-/// type.
-static bool hasUnresolvedDependentMemberType(Type type) {
-  return type.findIf([](Type type) {
-    if (auto depMemTy = type->getAs<DependentMemberType>()) {
-      if (!depMemTy->getAssocType()) return true;
-    }
-
-    return false;
-  });
-}
-
 bool TypeChecker::isAvailabilitySafeForOverride(ValueDecl *override,
                                                 ValueDecl *base) {
   // API availability ranges are contravariant: make sure the version range
@@ -7266,8 +7254,8 @@ void TypeChecker::validateDecl(ValueDecl *D) {
           // FIXME: We never should have recorded such a type in the first
           // place.
           if (!aliasDecl->getUnderlyingTypeLoc().getType() ||
-              hasUnresolvedDependentMemberType(
-                aliasDecl->getUnderlyingTypeLoc().getType())) {
+              aliasDecl->getUnderlyingTypeLoc().getType()
+                ->findUnresolvedDependentMemberType()) {
             aliasDecl->getUnderlyingTypeLoc().setType(Type(),
                                                       /*validated=*/false);
             validateAccessibility(aliasDecl);

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -218,6 +218,7 @@ Type CompleteGenericTypeResolver::resolveDependentMemberType(
       if (auto proto =
             concrete->getDeclContext()
               ->getAsProtocolOrProtocolExtensionContext()) {
+        TC.validateDecl(proto);
         auto subMap = SubstitutionMap::getProtocolSubstitutions(
                         proto, baseTy, ProtocolConformanceRef(proto));
         return concrete->getDeclaredInterfaceType().subst(subMap);

--- a/validation-test/compiler_crashers_2_fixed/0107-rdar32700180.swift
+++ b/validation-test/compiler_crashers_2_fixed/0107-rdar32700180.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-frontend %s -emit-ir
+struct X<T: Q> {
+  func f(_: T.Z) { }
+}
+
+protocol P {
+  associatedtype A
+  associatedtype B
+}
+
+protocol Q {
+  associatedtype C: P
+  typealias Z = (C.A, C.B)
+}


### PR DESCRIPTION
**Explanation**: Typealiases in protocols that are defined in terms of other associated types of that protocol would cause the compiler to crash in some multi-file scenarios.
**Scope**: Relatively few Swift projects seem to use this feature, but those that do are likely to crash with no workaround. This is a regression from Swift 3.
**Radar**: rdar://problem/32287795
**Risk**: Low-ish. The fix itself is a bit hacky, but the risk is mitigated because the change only kicks in for those cases where the compiler will currently crash.
**Testing**: Compiler regression testing, built the medium-sized project that demonstrated the regression and makes extensive use of these features, added test cases reduced from said project.