### PR TITLE
[Foundation] 1-ary IndexPath forms invalid range on slices

### DIFF
--- a/stdlib/public/SDK/Foundation/IndexPath.swift
+++ b/stdlib/public/SDK/Foundation/IndexPath.swift
@@ -257,7 +257,8 @@ public struct IndexPath : ReferenceConvertible, Equatable, Hashable, MutableColl
                     }
                 case .single(let index):
                     switch (range.lowerBound, range.upperBound) {
-                    case (0, 0):
+                    case (0, 0): fallthrough
+                    case (1, 1):
                         return .empty
                     case (0, 1):
                         return .single(index)

--- a/test/stdlib/TestIndexPath.swift
+++ b/test/stdlib/TestIndexPath.swift
@@ -711,6 +711,15 @@ class TestIndexPath: TestIndexPathSuper {
     func test_unconditionallyBridgeFromObjectiveC() {
         expectEqual(IndexPath(), IndexPath._unconditionallyBridgeFromObjectiveC(nil))
     }
+
+    func test_slice_1ary() {
+        let indexPath: IndexPath = [0]
+        let res = indexPath.dropFirst()
+        expectEqual(0, res.count)
+
+        let slice = indexPath[1..<1]
+        expectEqual(0, slice.count)
+    }
 }
 
 #if !FOUNDATION_XCTEST
@@ -762,5 +771,6 @@ IndexPathTests.test("testObjcBridgeType") { TestIndexPath().testObjcBridgeType()
 IndexPathTests.test("test_AnyHashableContainingIndexPath") { TestIndexPath().test_AnyHashableContainingIndexPath() }
 IndexPathTests.test("test_AnyHashableCreatedFromNSIndexPath") { TestIndexPath().test_AnyHashableCreatedFromNSIndexPath() }
 IndexPathTests.test("test_unconditionallyBridgeFromObjectiveC") { TestIndexPath().test_unconditionallyBridgeFromObjectiveC() }
+IndexPathTests.test("test_slice_1ary") { TestIndexPath().test_slice_1ary() }
 runAllTests()
 #endif


### PR DESCRIPTION
1-ary IndexPaths incorrectly implemented slicing for ranges of 1..<1

This resolves https://github.com/apple/swift-corelibs-foundation/issues/3851.