### PR TITLE
[cast-optimizer] Fix casting of P.Protocol to P.Type

### DIFF
--- a/lib/SIL/DynamicCasts.cpp
+++ b/lib/SIL/DynamicCasts.cpp
@@ -390,6 +390,22 @@ swift::classifyDynamicCast(ModuleDecl *M,
             sourceMetatype.isAnyExistentialType())
       return DynamicCastFeasibility::WillSucceed;
 
+    // If the source and target are the same existential type, but the source is
+    // P.Protocol and the dest is P.Type, then we need to consider whether the
+    // protocol is self-conforming.
+    // The only cases where a protocol self-conforms are objc protocols, but
+    // we're going to expect P.Type to hold a class object. And this case
+    // doesn't matter since for a self-conforming protocol type there can't be
+    // any type-level methods.
+    // Thus we consider this kind of cast to always fail. The only exception
+    // from this rule is when the target is Any.Type, because *.Protocol
+    // can always be casted to Any.Type.
+    if (source->isAnyExistentialType() && isa<MetatypeType>(sourceMetatype) &&
+        isa<ExistentialMetatypeType>(targetMetatype)) {
+      return target->isAny() ? DynamicCastFeasibility::WillSucceed
+                             : DynamicCastFeasibility::WillFail;
+    }
+
     if (targetMetatype.isAnyExistentialType() &&
         (isa<ProtocolType>(target) || isa<ProtocolCompositionType>(target))) {
       auto Feasibility = classifyDynamicCastToProtocol(source,

--- a/test/SILOptimizer/cast_folding.swift
+++ b/test/SILOptimizer/cast_folding.swift
@@ -7,6 +7,7 @@
 // which returns either true or false, i.e. all type checks should folded statically.
 
 public protocol P {}
+public protocol R {}
 
 protocol Q: P {}
 
@@ -948,6 +949,87 @@ public func test41() -> Bool {
 @inline(never)
 public func test42(_ p: P) -> Bool {
     return cast42(p)
+}
+
+// CHECK-LABEL: sil [noinline] @{{.*}}test43{{.*}}
+// CHECK: bb0
+// CHECK-NEXT: %0 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT: %1 = struct $Bool
+// CHECK-NEXT: return %1
+@inline(never)
+public func test43() -> Bool {
+  return P.self is Any.Type
+}
+
+// CHECK-LABEL: sil [noinline] @{{.*}}test44{{.*}}
+// CHECK: bb0
+// CHECK-NEXT: %0 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT: %1 = struct $Bool
+// CHECK-NEXT: return %1
+@inline(never)
+public func test44() -> Bool {
+  return Any.self is Any.Type
+}
+
+// CHECK-LABEL: sil [noinline] @{{.*}}test45{{.*}}
+// CHECK: bb0
+// CHECK-NEXT: %0 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT: %1 = struct $Bool
+// CHECK-NEXT: return %1
+@inline(never)
+public func test45() -> Bool {
+  return (P & R).self is Any.Type
+}
+
+// CHECK-LABEL: sil [noinline] @{{.*}}test46{{.*}}
+// CHECK: bb0
+// CHECK-NEXT: %0 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT: %1 = struct $Bool
+// CHECK-NEXT: return %1
+@inline(never)
+public func test46() -> Bool {
+  return AnyObject.self is Any.Type
+}
+
+// CHECK-LABEL: sil [noinline] @{{.*}}test47{{.*}}
+// CHECK: bb0
+// CHECK-NEXT: %0 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT: %1 = struct $Bool
+// CHECK-NEXT: return %1
+@inline(never)
+public func test47() -> Bool {
+  return Any.Type.self is Any.Type
+}
+
+// CHECK-LABEL: sil [noinline] @{{.*}}test48{{.*}}
+// CHECK: bb0
+// CHECK-NEXT: %0 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT: %1 = struct $Bool
+// CHECK-NEXT: return %1
+@inline(never)
+public func test48() -> Bool {
+  return Any.Type.self is Any.Type.Type
+}
+
+func cast<U, V>(_ u: U.Type) -> V? {
+  return u as? V
+}
+
+// CHECK-LABEL: sil [noinline] @{{.*}}testCastAnyObjectProtocolTo{{.*}}Type
+// CHECK: %0 = enum $Optional{{.*}}, #Optional.none!enumelt
+// CHECK-NEXT: return %0
+@inline(never)
+public func testCastAnyObjectProtocolToAnyObjectType() -> AnyObject.Type? {
+  return cast(AnyObject.self)
+}
+
+// CHECK-LABEL: // testCastProtocolTypeProtocolToProtocolTypeType
+// CHECK: sil [noinline] @{{.*}}testCastProtocol{{.*}}$@convention(thin) () -> Optional<@thick P.Type.Type>
+// CHECK: %0 = enum $Optional{{.*}}, #Optional.none!enumelt
+// CHECK-NEXT: return %0
+@inline(never)
+public func testCastProtocolTypeProtocolToProtocolTypeType() -> P.Type.Type? {
+  return P.Type.self as? P.Type.Type
 }
 
 print("test0=\(test0())")

--- a/test/SILOptimizer/cast_folding_objc.swift
+++ b/test/SILOptimizer/cast_folding_objc.swift
@@ -196,6 +196,38 @@ public func testCastEveryToNonClassType<T>(_ o: T) -> Int.Type {
   return o as! Int.Type
 }
 
+func cast<U, V>(_ u: U.Type) -> V? {
+  return u as? V
+}
+
+public protocol P {
+}
+
+// Any casts from P.Protocol to P.Type should fail.
+@inline(never)
+public func testCastPProtocolToPType() -> ObjCP.Type? {
+  return cast(ObjCP.self)
+}
+
+@objc
+public protocol ObjCP {
+}
+
+@inline(never)
+public func testCastObjCPProtocolToObjCPType() -> ObjCP.Type? {
+  return cast(ObjCP.self)
+}
+
+@inline(never)
+public func testCastProtocolCompositionProtocolToProtocolCompositionType() -> (P & ObjCP).Type? {
+  return cast((P & ObjCP).self)
+}
+
+@inline(never)
+public func testCastProtocolCompositionProtocolToProtocolType () -> P.Type? {
+  return (P & ObjCP).self as? P.Type
+}
+
 print("test0=\(test0())")
 
 
@@ -241,7 +273,17 @@ print("test0=\(test0())")
 // CHECK-LABEL: sil [noinline] @{{.*}}testCastEveryToNonClassType
 // CHECK:         unconditional_checked_cast_addr
 
+// CHECK-LABEL: sil [noinline] @{{.*}}testCastPProtocolToPType
+// CHECK: %0 = enum $Optional{{.*}}, #Optional.none!enumelt
+// CHECK-NEXT: return %0
 
+// CHECK-LABEL: sil [noinline] @{{.*}}testCastObjCPProtocolTo{{.*}}PType
+// CHECK: %0 = enum $Optional{{.*}}, #Optional.none!enumelt
+// CHECK-NEXT: return %0
+
+// CHECK-LABEL: sil [noinline] @{{.*}}testCastProtocolComposition{{.*}}Type
+// CHECK: %0 = enum $Optional{{.*}}, #Optional.none!enumelt
+// CHECK-NEXT: return %0
 
 // Check that compiler understands that this cast always succeeds.
 // Since it is can be statically proven that NSString is bridgeable to String,


### PR DESCRIPTION
If the source and target are the same existential type, but the source is P.Protocol and the dest is P.Type, then we need to consider whether the protocol is self-conforming.
The only cases where a protocol self-conforms are objc protocols, but we're going to expect P.Type to hold a class object. And this case doesn't matter since for a self-conforming protocol type there can't be any type-level methods.

Thus we consider this kind of cast to always fail. The only exception from this rule is when the target is Any.Type, because *.Protocol can always be casted to Any.Type.

• Explanation: This is a correctness fix.

• Scope of Issue: Casts of the form A.Protocol to B.Type were miscompiled in certain cases.

• Origination: rdar://32682967 by an external developer

• Risk: Rather low. The type of cast fixed by this radar is not that popular.

Fixes rdar://32682967

