### PR TITLE
[Foundation] 1-ary IndexPath forms invalid range on slices

### DIFF
--- a/stdlib/public/SDK/Foundation/IndexPath.swift
+++ b/stdlib/public/SDK/Foundation/IndexPath.swift
@@ -257,7 +257,8 @@ public struct IndexPath : ReferenceConvertible, Equatable, Hashable, MutableColl
                     }
                 case .single(let index):
                     switch (range.lowerBound, range.upperBound) {
-                    case (0, 0):
+                    case (0, 0): fallthrough
+                    case (1, 1):
                         return .empty
                     case (0, 1):
                         return .single(index)

--- a/test/stdlib/TestIndexPath.swift
+++ b/test/stdlib/TestIndexPath.swift
@@ -711,6 +711,15 @@ class TestIndexPath: TestIndexPathSuper {
     func test_unconditionallyBridgeFromObjectiveC() {
         expectEqual(IndexPath(), IndexPath._unconditionallyBridgeFromObjectiveC(nil))
     }
+
+    func test_slice_1ary() {
+        let indexPath: IndexPath = [0]
+        let res = indexPath.dropFirst()
+        expectEqual(0, res.count)
+
+        let slice = indexPath[1..<1]
+        expectEqual(0, slice.count)
+    }
 }
 
 #if !FOUNDATION_XCTEST
@@ -762,5 +771,6 @@ IndexPathTests.test("testObjcBridgeType") { TestIndexPath().testObjcBridgeType()
 IndexPathTests.test("test_AnyHashableContainingIndexPath") { TestIndexPath().test_AnyHashableContainingIndexPath() }
 IndexPathTests.test("test_AnyHashableCreatedFromNSIndexPath") { TestIndexPath().test_AnyHashableCreatedFromNSIndexPath() }
 IndexPathTests.test("test_unconditionallyBridgeFromObjectiveC") { TestIndexPath().test_unconditionallyBridgeFromObjectiveC() }
+IndexPathTests.test("test_slice_1ary") { TestIndexPath().test_slice_1ary() }
 runAllTests()
 #endif


### PR DESCRIPTION
This is a cherry pick of pr #10311 

1-ary IndexPaths incorrectly implemented slicing for ranges of 1..<1

This resolves https://github.com/apple/swift-corelibs-foundation/issues/3851.

Explanation: 
IndexPath had a missing case for 1..<1 in 1-ary variant storage when slicing ranges. This commit adds that missing case (since integers are not naturally exhaustive and fall into a default case they were hitting the "out of range" cases)

Scope: 
This is only runtime behavior for IndexPath and is a un-common use case (but still something that we should definitely not let fail)

Radar (and possibly SR Issue): 
* https://github.com/apple/swift-corelibs-foundation/issues/3851.
* rdar://problem/32619380

Risk:
This is relatively low risk since it is only a runtime behavior and only changes an un-common case.

Testing:
A unit test was added testing both the reported case of `dropFirst()` as well as the root cause of slicing.

