### PR TITLE
Escalate the warning about the "== Self" type soundness hole to an error

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1420,11 +1420,6 @@ ERROR(witness_self_same_type,none,
       " (in protocol %5) due to same-type requirement involving 'Self'",
       (DescriptiveDeclKind, DeclName, Type, DescriptiveDeclKind,
        DeclName, Type))
-WARNING(witness_self_same_type_warn,none,
-      "%0 %1 in non-final class %2 cannot be used to satisfy requirement %3 %4"
-      " (in protocol %5) due to same-type requirement involving 'Self'",
-      (DescriptiveDeclKind, DeclName, Type, DescriptiveDeclKind,
-       DeclName, Type))
 NOTE(witness_self_weaken_same_type,none,
       "consider weakening the same-type requirement %0 == %1 to a superclass "
       "requirement", (Type, Type))

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3122,9 +3122,7 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
           auto proto = Conformance->getProtocol();
           auto &diags = proto->getASTContext().Diags;
           diags.diagnose(witness->getLoc(),
-                         proto->getASTContext().LangOpts.isSwiftVersion3()
-                           ? diag::witness_self_same_type_warn
-                           : diag::witness_self_same_type,
+                         diag::witness_self_same_type,
                          witness->getDescriptiveKind(),
                          witness->getFullName(),
                          Conformance->getType(),

--- a/test/Compatibility/self_same_type.swift
+++ b/test/Compatibility/self_same_type.swift
@@ -1,5 +1,10 @@
 // RUN: %target-typecheck-verify-swift -swift-version 3
 
+// Note: while Swift 3.2 originally intended to provide backward
+// compatibility here, the type-soundness issue was considered so severe
+// (due to it breaking the optimizer) that that we escalated it to an
+// error.
+
 protocol P {
   associatedtype T
 }
@@ -9,7 +14,7 @@ protocol Q {
 }
 
 class C1: Q {
-  func foo<T: P>(_: T, _: C1) where T.T == C1 {} // expected-warning{{instance method 'foo' in non-final class 'C1' cannot be used to satisfy requirement instance method 'foo' (in protocol 'Q') due to same-type requirement involving 'Self'}}}}
+  func foo<T: P>(_: T, _: C1) where T.T == C1 {} // expected-error{{instance method 'foo' in non-final class 'C1' cannot be used to satisfy requirement instance method 'foo' (in protocol 'Q') due to same-type requirement involving 'Self'}}}}
     // expected-note@-1{{consider weakening the same-type requirement 'T.T' == 'C1' to a superclass requirement}}{{41-43=:}}
 }
 


### PR DESCRIPTION
Swift 3 had a type soundness hole in protocol conformance checking
where the requirement contained an `== Self` constraint and the
witness was a member of a non-final class. We previously closed the
type soundness hole in PR #9830, but left it as a warning in Swift 3
compatibility mode.

Escalate that warning to an error. The optimizers break due to this
type soundness hole, and of course it can lead to other runtime
breakage because it violates the type system.

Fixes rdar://problem/28601761.
