### PR TITLE
[4.0] Escalate the warning about the "== Self" type soundness hole to an error

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1416,11 +1416,6 @@ ERROR(witness_self_same_type,none,
       " (in protocol %5) due to same-type requirement involving 'Self'",
       (DescriptiveDeclKind, DeclName, Type, DescriptiveDeclKind,
        DeclName, Type))
-WARNING(witness_self_same_type_warn,none,
-      "%0 %1 in non-final class %2 cannot be used to satisfy requirement %3 %4"
-      " (in protocol %5) due to same-type requirement involving 'Self'",
-      (DescriptiveDeclKind, DeclName, Type, DescriptiveDeclKind,
-       DeclName, Type))
 NOTE(witness_self_weaken_same_type,none,
       "consider weakening the same-type requirement %0 == %1 to a superclass "
       "requirement", (Type, Type))

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3121,9 +3121,7 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
           auto proto = Conformance->getProtocol();
           auto &diags = proto->getASTContext().Diags;
           diags.diagnose(witness->getLoc(),
-                         proto->getASTContext().LangOpts.isSwiftVersion3()
-                           ? diag::witness_self_same_type_warn
-                           : diag::witness_self_same_type,
+                         diag::witness_self_same_type,
                          witness->getDescriptiveKind(),
                          witness->getFullName(),
                          Conformance->getType(),

--- a/test/Compatibility/self_same_type.swift
+++ b/test/Compatibility/self_same_type.swift
@@ -1,5 +1,10 @@
 // RUN: %target-typecheck-verify-swift -swift-version 3
 
+// Note: while Swift 3.2 originally intended to provide backward
+// compatibility here, the type-soundness issue was considered so severe
+// (due to it breaking the optimizer) that that we escalated it to an
+// error.
+
 protocol P {
   associatedtype T
 }
@@ -9,7 +14,7 @@ protocol Q {
 }
 
 class C1: Q {
-  func foo<T: P>(_: T, _: C1) where T.T == C1 {} // expected-warning{{instance method 'foo' in non-final class 'C1' cannot be used to satisfy requirement instance method 'foo' (in protocol 'Q') due to same-type requirement involving 'Self'}}}}
+  func foo<T: P>(_: T, _: C1) where T.T == C1 {} // expected-error{{instance method 'foo' in non-final class 'C1' cannot be used to satisfy requirement instance method 'foo' (in protocol 'Q') due to same-type requirement involving 'Self'}}}}
     // expected-note@-1{{consider weakening the same-type requirement 'T.T' == 'C1' to a superclass requirement}}{{41-43=:}}
 }
 


### PR DESCRIPTION
**Explanation**: Swift 3 had a type soundness hole in protocol conformance checking where the requirement contained an `== Self" constraint and the witness was a member of a non-final class. We closed this hole in Swift 4, but left it as a warning in Swift 3.2. Unfortunately, this soundness hole breaks invariants that the SIL optimizer depends on, so the optimizer will crash. Escalate the warning to an error *even in Swift 3.2 mode* to close this type hole, because it's better to reject a program than crash trying to compile it. 
**Scope**: We know of one project that will start to be rejected in Swift 3.2 mode because of this change, because that project is (unintentionally) exploiting the type soundness hole. Today, that project can only compile as Swift 3.2 and only with the optimizers turned off.
**Radar**: rdar://problem/28601761
**Risk**: Very low. The risk to anyone not depending on this type soundness hole is zero; some projects that were depending on this type soundness hole will now fail to compile (with a Fix-It to suggest how to avoid the hole).
**Testing**: Compiler regression testing.