### PR TITLE
Allow synthesis of Codable for weak/unowned vars

### DIFF
--- a/test/decl/protocol/special/coding/class_codable_non_strong_vars.swift
+++ b/test/decl/protocol/special/coding/class_codable_non_strong_vars.swift
@@ -1,0 +1,35 @@
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
+
+// Classes with Codable properties (with non-strong ownership) should get
+// derived conformance to Codable.
+class NonStrongClass : Codable {
+  class NestedClass : Codable {
+    init() {}
+  }
+
+  weak var x: NestedClass? = NestedClass()
+  unowned var y: NestedClass = NestedClass()
+  static var z: String = "foo"
+
+  // These lines have to be within the NonStrongClass type because CodingKeys
+  // should be private.
+  func foo() {
+    // They should receive a synthesized CodingKeys enum.
+    let _ = NonStrongClass.CodingKeys.self
+
+    // The enum should have a case for each of the vars.
+    let _ = NonStrongClass.CodingKeys.x
+    let _ = NonStrongClass.CodingKeys.y
+
+    // Static vars should not be part of the CodingKeys enum.
+    let _ = NonStrongClass.CodingKeys.z // expected-error {{type 'NonStrongClass.CodingKeys' has no member 'z'}}
+  }
+}
+
+// They should receive synthesized init(from:) and an encode(to:).
+let _ = NonStrongClass.init(from:)
+let _ = NonStrongClass.encode(to:)
+
+// The synthesized CodingKeys type should not be accessible from outside the
+// class.
+let _ = NonStrongClass.CodingKeys.self // expected-error {{'CodingKeys' is inaccessible due to 'private' protection level}}

--- a/test/decl/protocol/special/coding/struct_codable_non_strong_vars.swift
+++ b/test/decl/protocol/special/coding/struct_codable_non_strong_vars.swift
@@ -1,0 +1,35 @@
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
+
+// Structs with Codable properties (with non-strong ownership) should get
+// derived conformance to Codable.
+struct NonStrongStruct : Codable {
+  class NestedClass : Codable {
+    init() {}
+  }
+
+  weak var x: NestedClass? = NestedClass()
+  unowned var y: NestedClass = NestedClass()
+  static var z: String = "foo"
+
+  // These lines have to be within the NonStrongStruct type because CodingKeys
+  // should be private.
+  func foo() {
+    // They should receive a synthesized CodingKeys enum.
+    let _ = NonStrongStruct.CodingKeys.self
+
+    // The enum should have a case for each of the vars.
+    let _ = NonStrongStruct.CodingKeys.x
+    let _ = NonStrongStruct.CodingKeys.y
+
+    // Static vars should not be part of the CodingKeys enum.
+    let _ = NonStrongStruct.CodingKeys.z // expected-error {{type 'NonStrongStruct.CodingKeys' has no member 'z'}}
+  }
+}
+
+// They should receive synthesized init(from:) and an encode(to:).
+let _ = NonStrongStruct.init(from:)
+let _ = NonStrongStruct.encode(to:)
+
+// The synthesized CodingKeys type should not be accessible from outside the
+// class.
+let _ = NonStrongStruct.CodingKeys.self // expected-error {{'CodingKeys' is inaccessible due to 'private' protection level}}


### PR DESCRIPTION
**What's in this pull request?**
Allows non-strong (i.e. `weak`/`unowned`/`unmanaged`) vars to participate in Codable synthesis.

The type of non-strong properties is wrapped in a `ReferenceStorageType`, which does not conform to `Codable`. This needs to be unwrapped so the inner reference type can be considered for `Codable` conformance.