### PR TITLE
[swift-4.0-branch] Fix access level for extern_proc.p_starttime

### DIFF
--- a/stdlib/public/Platform/Darwin.swift.gyb
+++ b/stdlib/public/Platform/Darwin.swift.gyb
@@ -74,7 +74,8 @@ public let ${prefix}_TRUE_MIN = ${type}.leastNonzeroMagnitude
 // Macros defined in bsd/sys/proc.h that do not import into Swift.
 extension extern_proc {
     // #define p_starttime p_un.__p_starttime
-    @_transparent var p_starttime: timeval {
+    @_transparent
+    public var p_starttime: timeval {
         get { return self.p_un.__p_starttime }
         set { self.p_un.__p_starttime = newValue }
     }


### PR DESCRIPTION
* Explanation: The original fix did not mark the new property as public which made it unavailable outside the standard library. This change fixes the access level.
* Scope of Issue: Makes an existing API public (which was the intention in the first place)
* Risk: none
* Reviewed By: Ted Kremenek
* Testing: Automated test suite
* Directions for QA: N/A
* Radar: <rdar://problem/32819749>