### PR TITLE
Sema: Track writes through WritableKeyPaths for mutation warnings.

### DIFF
--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -2365,6 +2365,17 @@ void VarDeclUsageChecker::markStoredOrInOutExpr(Expr *E, unsigned Flags) {
     return;
   }
   
+  // Likewise for key path applications. An application of a WritableKeyPath
+  // reads and writes its base.
+  if (auto *KPA = dyn_cast<KeyPathApplicationExpr>(E)) {
+    auto &C = KPA->getType()->getASTContext();
+    KPA->getKeyPath()->walk(*this);
+    if (KPA->getKeyPath()->getType()->getAnyNominal()
+          == C.getWritableKeyPathDecl())
+      markStoredOrInOutExpr(KPA->getBase(), RK_Written|RK_Read);
+    return;
+  }
+  
   if (auto *ioe = dyn_cast<InOutExpr>(E))
     return markStoredOrInOutExpr(ioe->getSubExpr(), RK_Written|RK_Read);
   

--- a/test/expr/unary/keypath/keypath-mutation.swift
+++ b/test/expr/unary/keypath/keypath-mutation.swift
@@ -1,0 +1,22 @@
+// RUN: %target-swift-frontend -typecheck -verify %s
+
+struct User {
+  var id: Int
+  var name: String
+}
+
+func setting<Root, Value>(_ kp: WritableKeyPath<Root, Value>, _ root: Root, _ value: Value) -> Root {
+  var copy = root
+  // Should not warn about lack of mutation
+  copy[keyPath: kp] = value
+  return copy
+}
+
+func referenceSetting<Root, Value>(_ kp: ReferenceWritableKeyPath<Root, Value>, _ root: Root, _ value: Value) -> Root {
+  // Should warn about lack of mutation, since a RefKeyPath doesn't modify its
+  // base.
+  // expected-warning@+1 {{was never mutated}}
+  var copy = root
+  copy[keyPath: kp] = value
+  return copy
+}


### PR DESCRIPTION
Previously we would erroneously flag a `var` as not being mutated if the only mutations were through WritableKeyPaths. Fixes SR-5214 | rdar://problem/32599483.
