### PR TITLE
[4.0] Sema: Track writes through WritableKeyPaths for mutation warnings.

### DIFF
--- a/test/expr/unary/keypath/keypath-mutation.swift
+++ b/test/expr/unary/keypath/keypath-mutation.swift
@@ -1,0 +1,22 @@
+// RUN: %target-swift-frontend -typecheck -verify %s
+
+struct User {
+  var id: Int
+  var name: String
+}
+
+func setting<Root, Value>(_ kp: WritableKeyPath<Root, Value>, _ root: Root, _ value: Value) -> Root {
+  var copy = root
+  // Should not warn about lack of mutation
+  copy[keyPath: kp] = value
+  return copy
+}
+
+func referenceSetting<Root, Value>(_ kp: ReferenceWritableKeyPath<Root, Value>, _ root: Root, _ value: Value) -> Root {
+  // Should warn about lack of mutation, since a RefKeyPath doesn't modify its
+  // base.
+  // expected-warning@+1 {{was never mutated}}
+  var copy = root
+  copy[keyPath: kp] = value
+  return copy
+}


### PR DESCRIPTION
Explanation: We would erroneously flag a `var` as not being mutated if the only mutations were through WritableKeyPaths.

Scope: Annoying hard-to-dismiss warning incorrectly raised when using keypaths in common idioms

Issue: Fixes SR-5214 | rdar://problem/32599483

Risk: Low, small bug fix to a QoI diagnostic

Testing: CI, test case from Jira
