### PR TITLE
[code-completion] Add filter rules for description in addition filter-name

### DIFF
--- a/test/SourceKit/CodeComplete/Inputs/filter-rules/hideDesc.json
+++ b/test/SourceKit/CodeComplete/Inputs/filter-rules/hideDesc.json
@@ -1,0 +1,10 @@
+[
+  {
+    key.kind: source.codecompletion.description,
+    key.hide: 1,
+    key.names: [
+      "over(Int)",
+      "[Int]"
+    ]
+  }
+]

--- a/test/SourceKit/CodeComplete/Inputs/filter-rules/showDesc.json
+++ b/test/SourceKit/CodeComplete/Inputs/filter-rules/showDesc.json
@@ -1,0 +1,16 @@
+[
+  {
+    key.kind: source.codecompletion.identifier,
+    key.hide: 1,
+    key.names: [
+      "[]"
+    ]
+  },
+  {
+    key.kind: source.codecompletion.description,
+    key.hide: 0,
+    key.names: [
+      "[Float]"
+    ]
+  }
+]

--- a/test/SourceKit/CodeComplete/complete_filter_rules.swift
+++ b/test/SourceKit/CodeComplete/complete_filter_rules.swift
@@ -183,3 +183,50 @@ func testHideOp10() {
   struct local {}
   local#^HIDE_OP_10^#
 }
+
+// RUN: %complete-test -filter-rules=%S/Inputs/filter-rules/hideDesc.json -tok=HIDE_DESC_1 %s -- -F %S/../Inputs/libIDE-mock-sdk | %FileCheck %s -check-prefix=HIDE_DESC_1
+func testHideDesc1() {
+  struct Local {
+    func over(_: Int) {}
+    func over(_: Float) {}
+  }
+
+  Local().#^HIDE_DESC_1^#
+}
+// HIDE_DESC_1-NOT: over
+// HIDE_DESC_1: over(Float)
+// HIDE_DESC_1-NOT: over
+
+// RUN: %complete-test -filter-rules=%S/Inputs/filter-rules/hideDesc.json -tok=HIDE_DESC_2 %s -- -F %S/../Inputs/libIDE-mock-sdk | %FileCheck %s -check-prefix=HIDE_DESC_2
+// RUN: %complete-test -filter-rules=%S/Inputs/filter-rules/hideDesc.json -tok=HIDE_DESC_3 %s -- -F %S/../Inputs/libIDE-mock-sdk | %FileCheck %s -check-prefix=HIDE_DESC_2
+func testHideDesc2() {
+  struct Local {
+    subscript(_: Int) -> Int { return 0 }
+    subscript(_: Float) -> Float { return 0.0 }
+  }
+
+  Local()#^HIDE_DESC_2^#
+
+  let local = Local()
+  #^HIDE_DESC_3,local^#
+}
+// HIDE_DESC_2-NOT: [Int]
+// HIDE_DESC_2: [Float]
+// HIDE_DESC_2-NOT: [Int]
+
+// RUN: %complete-test -filter-rules=%S/Inputs/filter-rules/showDesc.json -tok=SHOW_DESC_2 %s -- -F %S/../Inputs/libIDE-mock-sdk | %FileCheck %s -check-prefix=SHOW_DESC_2
+// RUN: %complete-test -filter-rules=%S/Inputs/filter-rules/showDesc.json -tok=SHOW_DESC_3 %s -- -F %S/../Inputs/libIDE-mock-sdk | %FileCheck %s -check-prefix=SHOW_DESC_2
+func testHideDesc2() {
+  struct Local {
+    subscript(_: Int) -> Int { return 0 }
+    subscript(_: Float) -> Float { return 0.0 }
+  }
+
+  Local()#^SHOW_DESC_2^#
+
+  let local = Local()
+  #^SHOW_DESC_3,local^#
+}
+// SHOW_DESC_2-NOT: [Int]
+// SHOW_DESC_2: [Float]
+// SHOW_DESC_2-NOT: [Int]

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -153,6 +153,7 @@ struct FilterRule {
     Literal,
     CustomCompletion,
     Identifier,
+    Description,
   };
   Kind kind;
   bool hide;

--- a/tools/SourceKit/lib/SwiftLang/CodeCompletion.h
+++ b/tools/SourceKit/lib/SwiftLang/CodeCompletion.h
@@ -231,13 +231,13 @@ struct FilterRules {
   // FIXME: hide individual custom completions
 
   llvm::StringMap<bool> hideModule;
-  llvm::StringMap<bool> hideByName;
+  llvm::StringMap<bool> hideByFilterName;
+  llvm::StringMap<bool> hideByDescription;
 
   bool hideCompletion(Completion *completion) const;
-  bool hideCompletion(SwiftResult *completion,
-                      StringRef name,
-                      void *customKind = nullptr) const;
-  bool hideName(StringRef name) const;
+  bool hideCompletion(SwiftResult *completion, StringRef name,
+                      StringRef description, void *customKind = nullptr) const;
+  bool hideFilterName(StringRef name) const;
 };
 
 } // end namespace CodeCompletion

--- a/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
+++ b/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
@@ -447,22 +447,32 @@ static bool isHighPriorityKeyword(CodeCompletionKeywordKind kind) {
   }
 }
 
-bool FilterRules::hideName(StringRef name) const {
-  auto I = hideByName.find(name);
-  if (I != hideByName.end())
-      return I->getValue();
+bool FilterRules::hideFilterName(StringRef name) const {
+  auto I = hideByFilterName.find(name);
+  if (I != hideByFilterName.end())
+    return I->getValue();
   return hideAll;
 }
 
 bool FilterRules::hideCompletion(Completion *completion) const {
-  return hideCompletion(completion, completion->getName(), completion->getCustomKind());
+  return hideCompletion(completion, completion->getName(),
+                        completion->getDescription(),
+                        completion->getCustomKind());
 }
 
-bool FilterRules::hideCompletion(SwiftResult *completion, StringRef name, void *customKind) const {
+bool FilterRules::hideCompletion(SwiftResult *completion, StringRef filterName,
+                                 StringRef description,
+                                 void *customKind) const {
 
-  if (!name.empty()) {
-    auto I = hideByName.find(name);
-    if (I != hideByName.end())
+  if (!description.empty()) {
+    auto I = hideByDescription.find(description);
+    if (I != hideByDescription.end())
+      return I->getValue();
+  }
+
+  if (!filterName.empty()) {
+    auto I = hideByFilterName.find(filterName);
+    if (I != hideByFilterName.end())
       return I->getValue();
   }
 

--- a/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
@@ -123,6 +123,7 @@ static LazySKDUID KindKeyword("source.codecompletion.keyword");
 static LazySKDUID KindLiteral("source.codecompletion.literal");
 static LazySKDUID KindCustom("source.codecompletion.custom");
 static LazySKDUID KindIdentifier("source.codecompletion.identifier");
+static LazySKDUID KindDescription("source.codecompletion.description");
 
 static UIdent DiagKindNote("source.diagnostic.severity.note");
 static UIdent DiagKindWarning("source.diagnostic.severity.warning");
@@ -1719,6 +1720,8 @@ static sourcekitd_response_t codeCompleteOpen(StringRef Name,
         rule.kind = FilterRule::CustomCompletion;
       } else if (kind == KindIdentifier) {
         rule.kind = FilterRule::Identifier;
+      } else if (kind == KindDescription) {
+        rule.kind = FilterRule::Description;
       } else {
         // Warning: unknown
       }
@@ -1737,6 +1740,16 @@ static sourcekitd_response_t codeCompleteOpen(StringRef Name,
         break;
       case FilterRule::Module:
       case FilterRule::Identifier: {
+        SmallVector<const char *, 8> names;
+        if (dict.getStringArray(KeyNames, names, false)) {
+          failed = true;
+          CCC.failed("filter rule missing required key 'key.names'");
+          return true;
+        }
+        rule.names.assign(names.begin(), names.end());
+        break;
+      }
+      case FilterRule::Description: {
         SmallVector<const char *, 8> names;
         if (dict.getStringArray(KeyNames, names, false)) {
           failed = true;


### PR DESCRIPTION
* Explanation: This is an extension to our "filter-rules" API for code-completion, which allows the client of sourcekitd to create custom filters to hide/show various kinds of completions.  The new rule is for filtering based on the description text of the completion.
* Scope: Only affects clients that adopt the new API.
* Radar: rdar://problem/28920034
* Risk: Low; only affects clients that adopt the new API.
* Testing: Regression tests added.