### PR TITLE
Revert "Re-enable Lazy validation test."

### DIFF
--- a/validation-test/stdlib/Lazy.swift.gyb
+++ b/validation-test/stdlib/Lazy.swift.gyb
@@ -12,6 +12,8 @@
 // RUN: %target-run-simple-swiftgyb
 // REQUIRES: executable_test
 
+// REQUIRES: radar_31897334
+
 import StdlibUnittest
 import StdlibCollectionUnittest
 


### PR DESCRIPTION
Reverts apple/swift#10298. The test is still failing on some of the Apple-internal builders.