### PR TITLE
[4.0] Collate Codable diagnostics

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2046,7 +2046,7 @@ ERROR(broken_decodable_requirement,none,
       "Decodable protocol is broken: unexpected requirement", ())
 
 NOTE(codable_extraneous_codingkey_case_here,none,
-     "CodingKey case %0 does match any stored properties", (Identifier))
+     "CodingKey case %0 does not match any stored properties", (Identifier))
 NOTE(codable_non_conforming_property_here,none,
      "cannot automatically synthesize %0 because %1 does not conform to %0", (Type, Type))
 NOTE(codable_non_decoded_property_here,none,

--- a/test/decl/protocol/special/coding/class_codable_failure_diagnostics.swift
+++ b/test/decl/protocol/special/coding/class_codable_failure_diagnostics.swift
@@ -1,0 +1,133 @@
+// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -swift-version 4 %s 2>&1 | %FileCheck %s
+
+// Codable class with non-Codable property.
+class C1 : Codable {
+  class Nested {}
+  var a: String = ""
+  var b: Int = 0
+  var c: Nested = Nested()
+
+  // CHECK: error: type 'C1' does not conform to protocol 'Decodable'
+  // CHECK: note: cannot automatically synthesize 'Decodable' because 'C1.Nested' does not conform to 'Decodable'
+  // CHECK: note: protocol requires initializer 'init(from:)' with type 'Decodable'
+
+  // CHECK: error: type 'C1' does not conform to protocol 'Encodable'
+  // CHECK: note: cannot automatically synthesize 'Encodable' because 'C1.Nested' does not conform to 'Encodable'
+  // CHECK: note: protocol requires function 'encode(to:)' with type 'Encodable'
+}
+
+// Codable class with non-enum CodingKeys.
+class C2 : Codable {
+  var a: String = ""
+  var b: Int = 0
+  var c: Double?
+
+  struct CodingKeys : CodingKey {
+    var stringValue = ""
+    var intValue = nil
+    init?(stringValue: String) {}
+    init?(intValue: Int) {}
+  }
+
+  // CHECK: error: type 'C2' does not conform to protocol 'Decodable'
+  // CHECK: note: cannot automatically synthesize 'Decodable' because 'CodingKeys' is not an enum
+  // CHECK: note: protocol requires initializer 'init(from:)' with type 'Decodable'
+
+  // CHECK: error: type 'C2' does not conform to protocol 'Encodable'
+  // CHECK: note: cannot automatically synthesize 'Encodable' because 'CodingKeys' is not an enum
+  // CHECK: note: protocol requires function 'encode(to:)' with type 'Encodable'
+}
+
+// Codable class with CodingKeys not conforming to CodingKey.
+class C3 : Codable {
+  var a: String = ""
+  var b: Int = 0
+  var c: Double?
+
+  enum CodingKeys : String {
+    case a
+    case b
+    case c
+  }
+
+  // CHECK: error: type 'C3' does not conform to protocol 'Decodable'
+  // CHECK: note: cannot automatically synthesize 'Decodable' because 'CodingKeys' does not conform to CodingKey
+  // CHECK: note: protocol requires initializer 'init(from:)' with type 'Decodable'
+
+  // CHECK: error: type 'C3' does not conform to protocol 'Encodable'
+  // CHECK: note: cannot automatically synthesize 'Encodable' because 'CodingKeys' does not conform to CodingKey
+  // CHECK: note: protocol requires function 'encode(to:)' with type 'Encodable'
+}
+
+// Codable class with extraneous CodingKeys
+class C4 : Codable {
+  var a: String = ""
+  var b: Int = 0
+  var c: Double?
+
+  enum CodingKeys : String, CodingKey {
+    case a
+    case a2
+    case b
+    case b2
+    case c
+    case c2
+  }
+
+  // CHECK: error: type 'C4' does not conform to protocol 'Decodable'
+  // CHECK: note: CodingKey case 'a2' does not match any stored properties
+  // CHECK: note: CodingKey case 'b2' does not match any stored properties
+  // CHECK: note: CodingKey case 'c2' does not match any stored properties
+  // CHECK: note: protocol requires initializer 'init(from:)' with type 'Decodable'
+
+  // CHECK: error: type 'C4' does not conform to protocol 'Encodable'
+  // CHECK: note: CodingKey case 'a2' does not match any stored properties
+  // CHECK: note: CodingKey case 'b2' does not match any stored properties
+  // CHECK: note: CodingKey case 'c2' does not match any stored properties
+  // CHECK: note: protocol requires function 'encode(to:)' with type 'Encodable'
+}
+
+// Codable class with non-decoded property (which has no default value).
+class C5 : Codable {
+  var a: String = ""
+  var b: Int
+  var c: Double?
+
+  enum CodingKeys : String, CodingKey {
+    case a
+    case c
+  }
+
+  // CHECK: error: class 'C5' has no initializers
+  // CHECK: note: stored property 'b' without initial value prevents synthesized initializers
+
+  // CHECK: error: type 'C5' does not conform to protocol 'Decodable'
+  // CHECK: note: cannot automatically synthesize 'Decodable' because 'b' does not have a matching CodingKey and does not have a default value
+  // CHECK: note: protocol requires initializer 'init(from:)' with type 'Decodable'
+}
+
+// Codable class with non-decoded property (which has no default value).
+class C6 : Codable {
+  var a: String = ""
+  var b: Int
+  var c: Double?
+
+  enum CodingKeys : String, CodingKey {
+    case a
+    case c
+  }
+
+  init() {
+    b = 5
+  }
+
+  // CHECK: error: type 'C6' does not conform to protocol 'Decodable'
+  // CHECK: note: cannot automatically synthesize 'Decodable' because 'b' does not have a matching CodingKey and does not have a default value
+  // CHECK: note: protocol requires initializer 'init(from:)' with type 'Decodable'
+}
+
+// Classes cannot yet synthesize Encodable or Decodable in extensions.
+class C7 {}
+extension C7 : Codable {}
+// CHECK: error: implementation of 'Decodable' cannot be automatically synthesized in an extension yet
+// CHECK: error: implementation of 'Encodable' cannot be automatically synthesized in an extension yet

--- a/test/decl/protocol/special/coding/struct_codable_failure_diagnostics.swift
+++ b/test/decl/protocol/special/coding/struct_codable_failure_diagnostics.swift
@@ -1,0 +1,110 @@
+// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -swift-version 4 %s 2>&1 | %FileCheck %s
+
+// Codable struct with non-Codable property.
+struct S1 : Codable {
+  struct Nested {}
+  var a: String = ""
+  var b: Int = 0
+  var c: Nested = Nested()
+
+  // CHECK: error: type 'S1' does not conform to protocol 'Decodable'
+  // CHECK: note: cannot automatically synthesize 'Decodable' because 'S1.Nested' does not conform to 'Decodable'
+  // CHECK: note: protocol requires initializer 'init(from:)' with type 'Decodable'
+
+  // CHECK: error: type 'S1' does not conform to protocol 'Encodable'
+  // CHECK: note: cannot automatically synthesize 'Encodable' because 'S1.Nested' does not conform to 'Encodable'
+  // CHECK: note: protocol requires function 'encode(to:)' with type 'Encodable'
+}
+
+// Codable struct with non-enum CodingKeys.
+struct S2 : Codable {
+  var a: String = ""
+  var b: Int = 0
+  var c: Double?
+
+  struct CodingKeys : CodingKey {
+    var stringValue: String = ""
+    var intValue: Int? = nil
+    init?(stringValue: String) {}
+    init?(intValue: Int) {}
+  }
+
+  // CHECK: error: type 'S2' does not conform to protocol 'Decodable'
+  // CHECK: note: cannot automatically synthesize 'Decodable' because 'CodingKeys' is not an enum
+  // CHECK: note: protocol requires initializer 'init(from:)' with type 'Decodable'
+
+  // CHECK: error: type 'S2' does not conform to protocol 'Encodable'
+  // CHECK: note: cannot automatically synthesize 'Encodable' because 'CodingKeys' is not an enum
+  // CHECK: note: protocol requires function 'encode(to:)' with type 'Encodable'
+}
+
+// Codable struct with CodingKeys not conforming to CodingKey.
+struct S3 : Codable {
+  var a: String = ""
+  var b: Int = 0
+  var c: Double?
+
+  enum CodingKeys : String {
+    case a
+    case b
+    case c
+  }
+
+  // CHECK: error: type 'S3' does not conform to protocol 'Decodable'
+  // CHECK: note: cannot automatically synthesize 'Decodable' because 'CodingKeys' does not conform to CodingKey
+  // CHECK: note: protocol requires initializer 'init(from:)' with type 'Decodable'
+
+  // CHECK: error: type 'S3' does not conform to protocol 'Encodable'
+  // CHECK: note: cannot automatically synthesize 'Encodable' because 'CodingKeys' does not conform to CodingKey
+  // CHECK: note: protocol requires function 'encode(to:)' with type 'Encodable'
+}
+
+// Codable struct with extraneous CodingKeys
+struct S4 : Codable {
+  var a: String = ""
+  var b: Int = 0
+  var c: Double?
+
+  enum CodingKeys : String, CodingKey {
+    case a
+    case a2
+    case b
+    case b2
+    case c
+    case c2
+  }
+
+  // CHECK: error: type 'S4' does not conform to protocol 'Decodable'
+  // CHECK: note: CodingKey case 'a2' does not match any stored properties
+  // CHECK: note: CodingKey case 'b2' does not match any stored properties
+  // CHECK: note: CodingKey case 'c2' does not match any stored properties
+  // CHECK: note: protocol requires initializer 'init(from:)' with type 'Decodable'
+
+  // CHECK: error: type 'S4' does not conform to protocol 'Encodable'
+  // CHECK: note: CodingKey case 'a2' does not match any stored properties
+  // CHECK: note: CodingKey case 'b2' does not match any stored properties
+  // CHECK: note: CodingKey case 'c2' does not match any stored properties
+  // CHECK: note: protocol requires function 'encode(to:)' with type 'Encodable'
+}
+
+// Codable struct with non-decoded property (which has no default value).
+struct S5 : Codable {
+  var a: String = ""
+  var b: Int
+  var c: Double?
+
+  enum CodingKeys : String, CodingKey {
+    case a
+    case c
+  }
+
+  // CHECK: error: type 'S5' does not conform to protocol 'Decodable'
+  // CHECK: note: cannot automatically synthesize 'Decodable' because 'b' does not have a matching CodingKey and does not have a default value
+  // CHECK: note: protocol requires initializer 'init(from:)' with type 'Decodable'
+}
+
+// Structs cannot yet synthesize Encodable or Decodable in extensions.
+struct S6 {}
+extension S6 : Codable {}
+// CHECK: error: implementation of 'Decodable' cannot be automatically synthesized in an extension yet
+// CHECK: error: implementation of 'Encodable' cannot be automatically synthesized in an extension yet


### PR DESCRIPTION
**What's in this pull request?**
Cherry-picks #10253 to swift-4.0-branch.

**Explanation:** `Codable` failures produced diagnostics and notes explaining what failed during synthesis. These diagnostics were being output as they were generated, which was suboptimal because it meant that NOTEs could be produced before the error they were related to.

This was bad for consumers like Xcode, which associate NOTEs with the last error or warning diagnostic. If the only error in produced was a diagnostic from `Codable` synthesis, the initial NOTEs would be lost in the Xcode UI.

This collates these notes using a diagnostic transaction and only outputs the errors if something actually goes wrong.

**Scope:** Improves QoL for everyone adopting `Codable` and receiving diagnostics.
**Radar:** rdar://problem/32427064
**Risk:** Low
**Testing:** Manual verification of expected ordering of notes.