### PR TITLE
[4.0] [GSB] Don't warn about redundancies due to inference from result types.

### DIFF
--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -905,7 +905,8 @@ ConformanceAccessPath GenericSignature::getConformanceAccessPath(
 
     // We are at an explicit or inferred requirement.
     assert(source->kind == RequirementSource::Explicit ||
-           source->kind == RequirementSource::Inferred);
+           source->kind == RequirementSource::Inferred ||
+           source->kind == RequirementSource::QuietlyInferred);
 
     // Skip trivial path elements. These occur when querying a requirement
     // signature.

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -7708,7 +7708,8 @@ checkExtensionGenericParams(TypeChecker &tc, ExtensionDecl *ext, Type type,
   // Local function used to infer requirements from the extended type.
   auto inferExtendedTypeReqs = [&](GenericSignatureBuilder &builder) {
     auto source =
-      GenericSignatureBuilder::FloatingRequirementSource::forInferred(nullptr);
+      GenericSignatureBuilder::FloatingRequirementSource::forInferred(
+                                          nullptr, /*quietly=*/false);
 
     builder.inferRequirements(*ext->getModuleContext(),
                               TypeLoc::withoutLoc(extInterfaceType),

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -524,7 +524,8 @@ static bool checkGenericFuncSignature(TypeChecker &tc,
           fn->getBodyResultTypeLoc().getTypeRepr()) {
         auto source =
           GenericSignatureBuilder::FloatingRequirementSource::forInferred(
-                                      fn->getBodyResultTypeLoc().getTypeRepr());
+              fn->getBodyResultTypeLoc().getTypeRepr(),
+              /*quietly=*/true);
         builder->inferRequirements(*func->getParentModule(),
                                    fn->getBodyResultTypeLoc(),
                                    source);
@@ -966,7 +967,8 @@ static bool checkGenericSubscriptSignature(TypeChecker &tc,
   if (genericParams && builder) {
     auto source =
       GenericSignatureBuilder::FloatingRequirementSource::forInferred(
-                                  subscript->getElementTypeLoc().getTypeRepr());
+          subscript->getElementTypeLoc().getTypeRepr(),
+          /*quietly=*/true);
 
     builder->inferRequirements(*subscript->getParentModule(),
                                subscript->getElementTypeLoc(),
@@ -981,9 +983,10 @@ static bool checkGenericSubscriptSignature(TypeChecker &tc,
                                        resolver);
 
   // Infer requirements from the pattern.
-  if (builder)
+  if (builder) {
     builder->inferRequirements(*subscript->getParentModule(), params,
                                genericParams);
+  }
 
   return badType;
 }

--- a/test/Generics/same_type_constraints.swift
+++ b/test/Generics/same_type_constraints.swift
@@ -365,3 +365,10 @@ struct X11<T: P10> where T.A == T.B { }
 
 func intracomponentInferred<T>(_: X11<T>) // expected-note{{previous same-type constraint 'T.A' == 'T.B' inferred from type here}}
   where T.A == T.B { } // expected-warning{{redundant same-type constraint 'T.A' == 'T.B'}}
+
+// Suppress redundant same-type constraint warnings from result types.
+struct StructTakingP1<T: P1> { }
+
+func resultTypeSuppress<T: P1>() -> StructTakingP1<T> {
+  return StructTakingP1()
+}


### PR DESCRIPTION
**Explanation**: Suppress "redundant constraint" warnings when they are due to a constraint inferred from the result type of a generic function. In this case, the warnings cause much more confusion than benefit.
**Scope**: QoI change. Eliminates some frustrating/spurious warnings, but is otherwise fairly limited.
**Radar**: SR-5072 / rdar://problem/31357967
**Risk**: Fairly low risk; adds some cases to the `GenericSignatureBuilder` to affect warnings, but not much else.
**Testing**: Compiler regression testing.
