### PR TITLE
[swift-4.0-branch] [overlay] Add unavailble x/y to CGRect to redirect to minX/minY

### DIFF
--- a/stdlib/public/SDK/CoreGraphics/CoreGraphics.swift
+++ b/stdlib/public/SDK/CoreGraphics/CoreGraphics.swift
@@ -375,6 +375,12 @@ public extension CGRect {
            from: fromEdge)
     return (slice, remainder)
   }
+
+  @available(*, unavailable, renamed: "minX")
+  public var x: CGFloat { return minX }
+
+  @available(*, unavailable, renamed: "minY")
+  public var y: CGFloat { return minY }
 }
 
 extension CGRect : CustomReflectable, CustomPlaygroundQuickLookable {


### PR DESCRIPTION
* Explanation: Improves user expirience with the API by providing a fixit for a commonly misused CGRect properties.
* Scope of Issue: .x and .y properties are not available and .minX and .minY should be used instead.
* Risk: minimal, purely additive change with no functionality
* Reviewed By: Nate Begeman
* Testing: Automated test suite
* Directions for QA: N/A
* Radar: <rdar://problem/32574121>