### PR TITLE
Add Codable conformance to common CG types

### DIFF
--- a/stdlib/public/SDK/CoreGraphics/CoreGraphics.swift
+++ b/stdlib/public/SDK/CoreGraphics/CoreGraphics.swift
@@ -250,6 +250,21 @@ extension CGPoint : Equatable {
   }
 }
 
+extension CGPoint : Codable {
+  public init(from decoder: Decoder) throws {
+    var container = try decoder.unkeyedContainer()
+    let x = try container.decode(CGFloat.self)
+    let y = try container.decode(CGFloat.self)
+    self.init(x: x, y: y)
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.unkeyedContainer()
+    try container.encode(x)
+    try container.encode(y)
+  }
+}
+
 public extension CGSize {
   static var zero: CGSize {
     @_transparent // @fragile
@@ -302,6 +317,21 @@ extension CGSize : Equatable {
   }
 }
 
+extension CGSize : Codable {
+  public init(from decoder: Decoder) throws {
+    var container = try decoder.unkeyedContainer()
+    let width = try container.decode(CGFloat.self)
+    let height = try container.decode(CGFloat.self)
+    self.init(width: width, height: height)
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.unkeyedContainer()
+    try container.encode(width)
+    try container.encode(height)
+  }
+}
+
 public extension CGVector {
   static var zero: CGVector {
     @_transparent // @fragile
@@ -329,6 +359,21 @@ extension CGVector : Equatable {
 extension CGVector : CustomDebugStringConvertible {
   public var debugDescription : String {
     return "(\(dx), \(dy))"
+  }
+}
+
+extension CGVector : Codable {
+  public init(from decoder: Decoder) throws {
+    var container = try decoder.unkeyedContainer()
+    let dx = try container.decode(CGFloat.self)
+    let dy = try container.decode(CGFloat.self)
+    self.init(dx: dx, dy: dy)
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.unkeyedContainer()
+    try container.encode(dx)
+    try container.encode(dy)
   }
 }
 
@@ -411,11 +456,49 @@ extension CGRect : Equatable {
   }
 }
 
+extension CGRect : Codable {
+  public init(from decoder: Decoder) throws {
+    var container = try decoder.unkeyedContainer()
+    let origin = try container.decode(CGPoint.self)
+    let size = try container.decode(CGSize.self)
+    self.init(origin: origin, size: size)
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.unkeyedContainer()
+    try container.encode(origin)
+    try container.encode(size)
+  }
+}
+
 extension CGAffineTransform {
   public static var identity: CGAffineTransform {
    @_transparent // @fragile
    get { return CGAffineTransform(a: 1, b: 0, c: 0, d: 1, tx: 0, ty: 0) }
  }
+}
+
+extension CGAffineTransform : Codable {
+  public init(from decoder: Decoder) throws {
+    var container = try decoder.unkeyedContainer()
+    let a = try container.decode(CGFloat.self)
+    let b = try container.decode(CGFloat.self)
+    let c = try container.decode(CGFloat.self)
+    let d = try container.decode(CGFloat.self)
+    let tx = try container.decode(CGFloat.self)
+    let ty = try container.decode(CGFloat.self)
+    self.init(a: a, b: b, c: c, d: d, tx: tx, ty: ty)
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.unkeyedContainer()
+    try container.encode(a)
+    try container.encode(b)
+    try container.encode(c)
+    try container.encode(d)
+    try container.encode(tx)
+    try container.encode(ty)
+  }
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
**What's in this pull request?**
Addresses [SR-5237](https://bugs.swift.org/browse/SR-5237).
Gives a custom `Codable` implementation for `CGAffineTransform`, `CGPoint`, `CGSize`, `CGRect`, and `CGVector`, along with unit tests.