### PR TITLE
Sema: Don't talk about @_versioned in diagnostics for default arguments [4.0]

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3601,6 +3601,9 @@ ERROR(resilience_decl_unavailable,
 #undef FRAGILE_FUNC_KIND
 
 NOTE(resilience_decl_declared_here,
+     none, "%0 %1 is not public", (DescriptiveDeclKind, DeclName))
+
+NOTE(resilience_decl_declared_here_versioned,
      none, "%0 %1 is not '@_versioned' or public", (DescriptiveDeclKind, DeclName))
 
 ERROR(designated_init_in_extension_resilient,none,

--- a/lib/Sema/ResilienceDiagnostics.cpp
+++ b/lib/Sema/ResilienceDiagnostics.cpp
@@ -113,8 +113,25 @@ bool TypeChecker::diagnoseInlineableDeclRef(SourceLoc loc,
            D->getDescriptiveKind(), D->getFullName(),
            D->getFormalAccessScope().accessibilityForDiagnostics(),
            getFragileFunctionKind(DC));
-  diagnose(D, diag::resilience_decl_declared_here,
-           D->getDescriptiveKind(), D->getFullName());
+
+  bool isDefaultArgument = false;
+  while (DC->isLocalContext()) {
+    if (isa<DefaultArgumentInitializer>(DC)) {
+      isDefaultArgument = true;
+      break;
+    }
+
+    DC = DC->getParent();
+  }
+
+  if (isDefaultArgument) {
+    diagnose(D, diag::resilience_decl_declared_here,
+             D->getDescriptiveKind(), D->getFullName());
+  } else {
+    diagnose(D, diag::resilience_decl_declared_here_versioned,
+             D->getDescriptiveKind(), D->getFullName());
+  }
+
   return true;
 }
 

--- a/test/attr/attr_inlineable.swift
+++ b/test/attr/attr_inlineable.swift
@@ -5,16 +5,13 @@
 // expected-error@-1 {{@_inlineable cannot be applied to this declaration}}
 
 private func privateFunction() {}
-// expected-note@-1 5{{global function 'privateFunction()' is not '@_versioned' or public}}
+// expected-note@-1{{global function 'privateFunction()' is not '@_versioned' or public}}
 fileprivate func fileprivateFunction() {}
-// expected-note@-1 5{{global function 'fileprivateFunction()' is not '@_versioned' or public}}
+// expected-note@-1{{global function 'fileprivateFunction()' is not '@_versioned' or public}}
 func internalFunction() {}
-// expected-note@-1 5{{global function 'internalFunction()' is not '@_versioned' or public}}
+// expected-note@-1{{global function 'internalFunction()' is not '@_versioned' or public}}
 @_versioned func versionedFunction() {}
 public func publicFunction() {}
-
-func internalIntFunction() -> Int {}
-// expected-note@-1 2{{global function 'internalIntFunction()' is not '@_versioned' or public}}
 
 private struct PrivateStruct {}
 // expected-note@-1 3{{struct 'PrivateStruct' is not '@_versioned' or public}}
@@ -135,72 +132,6 @@ public struct Struct {
     // OK
   }
 }
-
-func internalFunctionWithDefaultValue(
-    x: Int = {
-      struct Nested {}
-      // OK
-
-      publicFunction()
-      // OK
-      versionedFunction()
-      // OK
-      internalFunction()
-      // OK
-      fileprivateFunction()
-      // OK
-      privateFunction()
-      // OK
-
-      return 0
-    }(),
-    y: Int = internalIntFunction()) {}
-
-@_versioned func versionedFunctionWithDefaultValue(
-    x: Int = {
-      struct Nested {}
-      // expected-error@-1 {{type 'Nested' cannot be nested inside a default argument value}}
-
-      // FIXME: Some errors below are diagnosed twice
-
-      publicFunction()
-      // OK
-      versionedFunction()
-      // OK
-      internalFunction()
-      // expected-error@-1 2{{global function 'internalFunction()' is internal and cannot be referenced from a default argument value}}
-      fileprivateFunction()
-      // expected-error@-1 2{{global function 'fileprivateFunction()' is fileprivate and cannot be referenced from a default argument value}}
-      privateFunction()
-      // expected-error@-1 2{{global function 'privateFunction()' is private and cannot be referenced from a default argument value}}
-
-      return 0
-    }(),
-    y: Int = internalIntFunction()) {}
-    // expected-error@-1 {{global function 'internalIntFunction()' is internal and cannot be referenced from a default argument value}}
-
-public func publicFunctionWithDefaultValue(
-    x: Int = {
-      struct Nested {}
-      // expected-error@-1 {{type 'Nested' cannot be nested inside a default argument value}}
-
-      // FIXME: Some errors below are diagnosed twice
-
-      publicFunction()
-      // OK
-      versionedFunction()
-      // OK
-      internalFunction()
-      // expected-error@-1 2{{global function 'internalFunction()' is internal and cannot be referenced from a default argument value}}
-      fileprivateFunction()
-      // expected-error@-1 2{{global function 'fileprivateFunction()' is fileprivate and cannot be referenced from a default argument value}}
-      privateFunction()
-      // expected-error@-1 2{{global function 'privateFunction()' is private and cannot be referenced from a default argument value}}
-
-      return 0
-    }(),
-    y: Int = internalIntFunction()) {}
-    // expected-error@-1 {{global function 'internalIntFunction()' is internal and cannot be referenced from a default argument value}}
 
 // Make sure protocol extension members can reference protocol requirements
 // (which do not inherit the @_versioned attribute).

--- a/test/decl/func/default-values-swift4.swift
+++ b/test/decl/func/default-values-swift4.swift
@@ -1,0 +1,80 @@
+// RUN: %target-typecheck-verify-swift -swift-version 4
+// RUN: %target-typecheck-verify-swift -swift-version 4 -enable-testing
+
+private func privateFunction() {}
+// expected-note@-1 4{{global function 'privateFunction()' is not public}}
+fileprivate func fileprivateFunction() {}
+// expected-note@-1 4{{global function 'fileprivateFunction()' is not public}}
+func internalFunction() {}
+// expected-note@-1 4{{global function 'internalFunction()' is not public}}
+@_versioned func versionedFunction() {}
+public func publicFunction() {}
+
+func internalIntFunction() -> Int {}
+// expected-note@-1 2{{global function 'internalIntFunction()' is not public}}
+
+func internalFunctionWithDefaultValue(
+    x: Int = {
+      struct Nested {}
+      // OK
+
+      publicFunction()
+      // OK
+      versionedFunction()
+      // OK
+      internalFunction()
+      // OK
+      fileprivateFunction()
+      // OK
+      privateFunction()
+      // OK
+
+      return 0
+    }(),
+    y: Int = internalIntFunction()) {}
+
+@_versioned func versionedFunctionWithDefaultValue(
+    x: Int = {
+      struct Nested {}
+      // expected-error@-1 {{type 'Nested' cannot be nested inside a default argument value}}
+
+      // FIXME: Some errors below are diagnosed twice
+
+      publicFunction()
+      // OK
+      versionedFunction()
+      // OK
+      internalFunction()
+      // expected-error@-1 2{{global function 'internalFunction()' is internal and cannot be referenced from a default argument value}}
+      fileprivateFunction()
+      // expected-error@-1 2{{global function 'fileprivateFunction()' is fileprivate and cannot be referenced from a default argument value}}
+      privateFunction()
+      // expected-error@-1 2{{global function 'privateFunction()' is private and cannot be referenced from a default argument value}}
+
+      return 0
+    }(),
+    y: Int = internalIntFunction()) {}
+    // expected-error@-1 {{global function 'internalIntFunction()' is internal and cannot be referenced from a default argument value}}
+
+public func publicFunctionWithDefaultValue(
+    x: Int = {
+      struct Nested {}
+      // expected-error@-1 {{type 'Nested' cannot be nested inside a default argument value}}
+
+      // FIXME: Some errors below are diagnosed twice
+
+      publicFunction()
+      // OK
+      versionedFunction()
+      // OK
+      internalFunction()
+      // expected-error@-1 2{{global function 'internalFunction()' is internal and cannot be referenced from a default argument value}}
+      fileprivateFunction()
+      // expected-error@-1 2{{global function 'fileprivateFunction()' is fileprivate and cannot be referenced from a default argument value}}
+      privateFunction()
+      // expected-error@-1 2{{global function 'privateFunction()' is private and cannot be referenced from a default argument value}}
+
+      return 0
+    }(),
+    y: Int = internalIntFunction()) {}
+    // expected-error@-1 {{global function 'internalIntFunction()' is internal and cannot be referenced from a default argument value}}


### PR DESCRIPTION
* Description: Just a cosmetic fix, don't talk about @_versioned in diagnostics pertaining to default arguments.

* Origination: Swift 3.1 added resilience diagnostics for inlineable code, which is not an officially supported feature, but in Swift 4 we switched these checks on for default argument expressions as well, so they should not talk about internal attributes.

* Risk: None, hopefully.

* Tested: Test updated for new diagnostic strings.

* Reviewed by: @jrose-apple 

* Radar: Fixes <rdar://problem/32445206>.