### PR TITLE
Fixes for #dsohandle default arguments [4.0]

### DIFF
--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -264,7 +264,8 @@ public:
   void emitEnumConstructor(EnumElementDecl *decl);
 
   /// Emits the default argument generator with the given expression.
-  void emitDefaultArgGenerator(SILDeclRef constant, Expr *arg);
+  void emitDefaultArgGenerator(SILDeclRef constant, Expr *arg,
+                               DefaultArgumentKind kind);
 
   /// Emits the stored property initializer for the given pattern.
   void emitStoredPropertyInitialization(PatternBindingDecl *pd, unsigned i);

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2927,7 +2927,7 @@ visitMagicIdentifierLiteralExpr(MagicIdentifierLiteralExpr *E, SGFContext C) {
     auto DSOGlobal = SGF.SGM.M.lookUpGlobalVariable("__dso_handle");
     if (!DSOGlobal)
       DSOGlobal = SILGlobalVariable::create(SGF.SGM.M,
-                                            SILLinkage::HiddenExternal,
+                                            SILLinkage::PublicExternal,
                                             IsNotSerialized, "__dso_handle",
                                             BuiltinRawPtrTy);
     auto DSOAddr = SGF.B.createGlobalAddr(SILLoc, DSOGlobal);

--- a/test/SILGen/default_arguments.swift
+++ b/test/SILGen/default_arguments.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -Xllvm -sil-full-demangle -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -emit-silgen %s | %FileCheck %s --check-prefix=NEGATIVE
 
 // __FUNCTION__ used as top-level parameter produces the module name.
 // CHECK-LABEL: sil @main
@@ -74,17 +75,13 @@ func testMagicLiterals(file: String = #file,
 // Check that default argument generator functions don't leak information about
 // user's source.
 //
-// CHECK-LABEL: sil hidden @_T017default_arguments17testMagicLiteralsySS4file_SS8functionSi4lineSi6columntFfA_
-// CHECK: string_literal utf16 ""
+// NEGATIVE-NOT: sil hidden @_T017default_arguments17testMagicLiteralsySS4file_SS8functionSi4lineSi6columntFfA_
 //
-// CHECK-LABEL: sil hidden @_T017default_arguments17testMagicLiteralsySS4file_SS8functionSi4lineSi6columntFfA0_
-// CHECK: string_literal utf16 ""
+// NEGATIVE-NOT: sil hidden @_T017default_arguments17testMagicLiteralsySS4file_SS8functionSi4lineSi6columntFfA0_
 //
-// CHECK-LABEL: sil hidden @_T017default_arguments17testMagicLiteralsySS4file_SS8functionSi4lineSi6columntFfA1_
-// CHECK: integer_literal $Builtin.Int2048, 0
+// NEGATIVE-NOT: sil hidden @_T017default_arguments17testMagicLiteralsySS4file_SS8functionSi4lineSi6columntFfA1_
 //
-// CHECK-LABEL: sil hidden @_T017default_arguments17testMagicLiteralsySS4file_SS8functionSi4lineSi6columntFfA2_
-// CHECK: integer_literal $Builtin.Int2048, 0
+// NEGATIVE-NOT: sil hidden @_T017default_arguments17testMagicLiteralsySS4file_SS8functionSi4lineSi6columntFfA2_
 
 func closure(_: () -> ()) {}
 func autoclosure(_: @autoclosure () -> ()) {}

--- a/test/SILGen/dso_handle.swift
+++ b/test/SILGen/dso_handle.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -Xllvm -sil-full-demangle -emit-silgen %s | %FileCheck %s
 
-// CHECK: sil_global hidden_external [[DSO:@__dso_handle]] : $Builtin.RawPointer
+// CHECK: sil_global [[DSO:@__dso_handle]] : $Builtin.RawPointer
 
 // CHECK-LABEL: sil @main : $@convention(c)
 // CHECK: bb0
@@ -11,6 +11,14 @@
 func printDSOHandle(dso: UnsafeRawPointer = #dsohandle) -> UnsafeRawPointer {
   print(dso)
   return dso
+}
+
+@_inlineable public func printDSOHandleInlineable(dso: UnsafeRawPointer = #dsohandle) -> UnsafeRawPointer {
+  return dso
+}
+
+@_inlineable public func callsPrintDSOHandleInlineable() {
+  printDSOHandleInlineable()
 }
 
 _ = printDSOHandle()

--- a/test/SILGen/dso_handle.swift
+++ b/test/SILGen/dso_handle.swift
@@ -8,16 +8,9 @@
 // CHECK-NEXT: [[DSOPtr:%[0-9]+]] = address_to_pointer [[DSOAddr]] : $*Builtin.RawPointer to $Builtin.RawPointer
 // CHECK-NEXT: [[DSOPtrStruct:[0-9]+]] = struct $UnsafeRawPointer ([[DSOPtr]] : $Builtin.RawPointer)
 
-
-// CHECK-LABEL: sil hidden @_T010dso_handle14printDSOHandleS2V0A0_tFfA_
-// CHECK: [[DSOAddr:%[0-9]+]] = global_addr [[DSO]] : $*Builtin.RawPointer
-// CHECK-NEXT: [[DSOPtr:%[0-9]+]] = address_to_pointer [[DSOAddr]] : $*Builtin.RawPointer to $Builtin.RawPointer
-// CHECK-NEXT: [[DSOPtrStruct:%[0-9]+]] = struct $UnsafeRawPointer ([[DSOPtr]] : $Builtin.RawPointer)
-// CHECK-NEXT: return [[DSOPtrStruct]] : $UnsafeRawPointer
 func printDSOHandle(dso: UnsafeRawPointer = #dsohandle) -> UnsafeRawPointer {
   print(dso)
   return dso
 }
 
 _ = printDSOHandle()
-


### PR DESCRIPTION
* Description: A user reported assertion failures while trying to define a default argument with a value of #dsohandle for an @inline(__always) function. While the latter is not a documented feature, we shouldn't crash.

* Scope of the issue: Affects a narrow set of use-cases but it's a simple fix I think.

* Risk: Low

* Tested: New tests added

* Reviewed by: @jckarter

* Radar: rdar://problem/32597278