### PR TITLE
Let CodingKey inherit CustomStringConvertible for better debugging

### DIFF
--- a/stdlib/public/core/Codable.swift
+++ b/stdlib/public/core/Codable.swift
@@ -71,7 +71,7 @@ extension CodingKey {
     /// A textual representation of this key.
     public var description: String {
         let intValue = self.intValue?.description ?? "nil"
-        return "\(String(describing: type(of: self)))(stringValue: \(stringValue), intValue: \(intValue))"
+        return "\(String(describing: type(of: self)))(stringValue: \"\(stringValue)\", intValue: \(intValue))"
     }
 
     /// A textual representation of this key, suitable for debugging.

--- a/stdlib/public/core/Codable.swift
+++ b/stdlib/public/core/Codable.swift
@@ -47,7 +47,7 @@ public typealias Codable = Encodable & Decodable
 //===----------------------------------------------------------------------===//
 
 /// A type that can be used as a key for encoding and decoding.
-public protocol CodingKey: CustomStringConvertible {
+public protocol CodingKey: CustomStringConvertible, CustomDebugStringConvertible {
     /// The string to use in a named collection (e.g. a string-keyed dictionary).
     var stringValue: String { get }
 
@@ -68,8 +68,15 @@ public protocol CodingKey: CustomStringConvertible {
 }
 
 extension CodingKey {
+    /// A textual representation of this key.
     public var description: String {
-        return stringValue
+        let intValue = self.intValue?.description ?? "nil"
+        return "\(String(describing: type(of: self)))(stringValue: \(stringValue), intValue: \(intValue))"
+    }
+
+    /// A textual representation of this key, suitable for debugging.
+    public var debugDescription: String {
+        return description
     }
 }
 

--- a/stdlib/public/core/Codable.swift
+++ b/stdlib/public/core/Codable.swift
@@ -71,7 +71,7 @@ extension CodingKey {
     /// A textual representation of this key.
     public var description: String {
         let intValue = self.intValue?.description ?? "nil"
-        return "\(String(describing: type(of: self)))(stringValue: \"\(stringValue)\", intValue: \(intValue))"
+        return "\(type(of: self))(stringValue: \"\(stringValue)\", intValue: \(intValue))"
     }
 
     /// A textual representation of this key, suitable for debugging.

--- a/stdlib/public/core/Codable.swift
+++ b/stdlib/public/core/Codable.swift
@@ -47,7 +47,7 @@ public typealias Codable = Encodable & Decodable
 //===----------------------------------------------------------------------===//
 
 /// A type that can be used as a key for encoding and decoding.
-public protocol CodingKey {
+public protocol CodingKey: CustomStringConvertible {
     /// The string to use in a named collection (e.g. a string-keyed dictionary).
     var stringValue: String { get }
 
@@ -65,6 +65,12 @@ public protocol CodingKey {
     /// - parameter intValue: The integer value of the desired key.
     /// - returns: An instance of `Self` from the given integer, or `nil` if the given integer does not correspond to any instance of `Self`.
     init?(intValue: Int)
+}
+
+extension CodingKey {
+    public var description: String {
+        return stringValue
+    }
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
```swift
struct MyStruct: Codable {
    let test: String
}

let json = "{}".data(using: .utf8)!

do {
    let decoder = JSONDecoder()
    let decoded = try decoder.decode(MyStruct.self, from: json)
    print(decoded)
}
catch {
    print(error)
}
```

### Result

```
keyNotFound(CodableDemo.MyStruct.(CodingKeys in _CCD964A2735AA22BDC9F8350D8585760).test, Swift.DecodingError.Context(codingPath: [Optional(CodableDemo.MyStruct.(CodingKeys in _CCD964A2735AA22BDC9F8350D8585760).test)], debugDescription: "Key not found when expecting non-optional type String for coding key \"test\""))
```

Current `DecodingError` and `EncodingError` is hard to read when printing to the console, so I think `protocol CodingKey` should inherit `CustomStringConvertible` for better debugging.