### PR TITLE
AST: Fix ProtocolDecl::getInheritedProtocols() for protocols that inherit from compositions

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2905,10 +2905,13 @@ ProtocolDecl::getInheritedProtocols() const {
         // Only protocols can appear in the inheritance clause
         // of a protocol -- anything else should get diagnosed
         // elsewhere.
-        if (auto *protoTy = type->getAs<ProtocolType>()) {
-          auto *protoDecl = protoTy->getDecl();
-          if (known.insert(protoDecl).second)
-            result.push_back(protoDecl);
+        if (type->isExistentialType()) {
+          auto layout = type->getExistentialLayout();
+          for (auto protoTy : layout.getProtocols()) {
+            auto *protoDecl = protoTy->getDecl();
+            if (known.insert(protoDecl).second)
+              result.push_back(protoDecl);
+          }
         }
       }
     }

--- a/test/NameBinding/Inputs/protocol-inheritance.swift
+++ b/test/NameBinding/Inputs/protocol-inheritance.swift
@@ -1,0 +1,18 @@
+public protocol Critter {
+  associatedtype Fur
+}
+public protocol Pet {}
+
+public typealias Cat = Critter & Pet
+
+public protocol Kitten : Cat {}
+
+extension Kitten {
+  public func pet() -> Fur {
+    while true {}
+  }
+}
+
+public final class Meow<Purrs> : Kitten {
+  public typealias Fur = Purrs
+}

--- a/test/NameBinding/protocol-inheritance.swift
+++ b/test/NameBinding/protocol-inheritance.swift
@@ -1,0 +1,5 @@
+// RUN: %target-swift-frontend -typecheck -primary-file %s %S/Inputs/protocol-inheritance.swift
+
+func kitty<Purrs>(cat: Meow<Purrs>) {
+  cat.pet()
+}


### PR DESCRIPTION
We allow protocols to inherit from protocol compositions
defined via a typealias, eg,

```
typealias PQ = P & Q

protocol R : PQ {}
```

Sometimes, `ProtocolDecl::getInheritedProtocols()` is called before
the protocol's requirement signature has been computed. In this
case, we walk the inheritance clause of the protocol directly.
This walk was only looking at ProtocolType members of the
inheritance clause, ignoring ProtocolCompositionTypes.

As a result, name lookup could fail with an assertion because of
not being able to "see" members inherited via the protocol
composition.

Fixes <rdar://problem/32595988>.