### PR TITLE
AST: Fix ProtocolDecl::getInheritedProtocols() for protocols that inherit from compositions [4.0]

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2905,10 +2905,13 @@ ProtocolDecl::getInheritedProtocols() const {
         // Only protocols can appear in the inheritance clause
         // of a protocol -- anything else should get diagnosed
         // elsewhere.
-        if (auto *protoTy = type->getAs<ProtocolType>()) {
-          auto *protoDecl = protoTy->getDecl();
-          if (known.insert(protoDecl).second)
-            result.push_back(protoDecl);
+        if (type->isExistentialType()) {
+          auto layout = type->getExistentialLayout();
+          for (auto protoTy : layout.getProtocols()) {
+            auto *protoDecl = protoTy->getDecl();
+            if (known.insert(protoDecl).second)
+              result.push_back(protoDecl);
+          }
         }
       }
     }

--- a/test/NameBinding/Inputs/protocol-inheritance.swift
+++ b/test/NameBinding/Inputs/protocol-inheritance.swift
@@ -1,0 +1,18 @@
+public protocol Critter {
+  associatedtype Fur
+}
+public protocol Pet {}
+
+public typealias Cat = Critter & Pet
+
+public protocol Kitten : Cat {}
+
+extension Kitten {
+  public func pet() -> Fur {
+    while true {}
+  }
+}
+
+public final class Meow<Purrs> : Kitten {
+  public typealias Fur = Purrs
+}

--- a/test/NameBinding/protocol-inheritance.swift
+++ b/test/NameBinding/protocol-inheritance.swift
@@ -1,0 +1,5 @@
+// RUN: %target-swift-frontend -typecheck -primary-file %s %S/Inputs/protocol-inheritance.swift
+
+func kitty<Purrs>(cat: Meow<Purrs>) {
+  cat.pet()
+}


### PR DESCRIPTION
* Description: Fix a name lookup bug in a multi-file scenario where a protocol defined in another source file inherits from a typealias containing a protocol composition. Manifests as an assertion failure in Sema when asserts are on, and a SILGen crash when asserts are off.

* Origination: Recent regression introduced by the associated type where clause work.

* Risk: Low, the modified code should behave identically except when a protocol composition type appears in the inheritance clause.

* Tested: Added a reduced test case from a user project that encountered the bug.

* Reviewed by: @DougGregor

* Radar: <rdar://problem/32595988>