### PR TITLE
Add objc_retainAutoreleasedReturnValue()

### DIFF
--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -292,6 +292,26 @@ void SWIFT_RT_ENTRY_IMPL(swift_nonatomic_retain_n)(HeapObject *object, uint32_t 
     object->refCounts.incrementNonAtomic(n);
 }
 
+#if !SWIFT_OBJC_INTEROP
+
+// For CF functions with 'Get' semantics, the compiler currently assumes that
+// the result is autoreleased and must be retained. It does so on all platforms
+// by emitting a call to objc_retainAutoreleasedReturnValue. On Darwin, this is
+// implemented by the ObjC runtime. On Linux, there is no runtime, and therefore
+// we have to stub it out here ourselves. The compiler will eventually call
+// swift_release to balance the retain below. This is a workaround until the
+// compiler no longer emits this callout on Linux.
+SWIFT_RT_ENTRY_VISIBILITY
+extern "C"
+void *objc_retainAutoreleasedReturnValue(HeapObject *obj) {
+    if (obj) {
+        swift::swift_retain(obj);
+        return obj;
+    }
+    else return NULL;
+}
+#endif
+
 void swift::swift_release(HeapObject *object)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
   SWIFT_RT_ENTRY_REF(swift_release)(object);


### PR DESCRIPTION
- This function has been duplicated in both swift-corelibs-libdispatch
  and swift-corelibs-foundation. Moving it to stdlib consolidates
  it and makes it available when not linking with Dispatch or
  Foundation.

- Only required for non-Apple targets as the Objc Runtime provides
  the appropiate function on Apple targets.

This needs to be tested/merged at the same time as https://github.com/apple/swift-corelibs-libdispatch/pull/258 which removes it from libdispatch otherwise there will be a duplicate symbol when testing libdispatch.

Foundation will be fixed in a followup PR but shouldn't have a problem with duplicate symbols as it currently links using `--allow-multiple-definition`