### PR TITLE
[4.0][Parse] Don't invalidate compilation condition with invalid platform condition argument

### DIFF
--- a/lib/Parse/ParseIfConfig.cpp
+++ b/lib/Parse/ParseIfConfig.cpp
@@ -321,6 +321,8 @@ public:
                    diag::unsupported_platform_runtime_condition_argument);
         return nullptr;
       }
+
+      // Just a warning for other unsupported arguments.
       StringRef DiagName;
       switch (*Kind) {
       case PlatformConditionKind::OS:
@@ -338,7 +340,6 @@ public:
       for (auto suggestion : suggestions)
         D.diagnose(Loc, diag::note_typo_candidate, suggestion)
           .fixItReplace(Arg->getSourceRange(), suggestion);
-      return nullptr;
     }
 
     return E;

--- a/test/Parse/ConditionalCompilation/basicParseErrors.swift
+++ b/test/Parse/ConditionalCompilation/basicParseErrors.swift
@@ -114,3 +114,27 @@ undefinedFunc() // ignored.
 #else
 undefinedFunc() // expected-error {{use of unresolved identifier 'undefinedFunc'}}
 #endif
+
+/// Invalid platform condition arguments don't invalidate the whole condition.
+#if !arch(tecture) && !os(ystem) && !_endian(ness)
+// expected-warning@-1 {{unknown architecture for build configuration 'arch'}}
+// expected-note@-2 {{did you mean 'arm'?}} {{11-18=arm}}
+// expected-warning@-3 {{unknown operating system for build configuration 'os'}}
+// expected-note@-4 {{did you mean 'OSX'?}} {{27-32=OSX}}
+// expected-note@-5 {{did you mean 'PS4'?}} {{27-32=PS4}}
+// expected-warning@-6 {{unknown endianness for build configuration '_endian'}}
+// expected-note@-7 {{did you mean 'big'?}} {{46-50=big}}
+func fn_k() {}
+#endif
+fn_k()
+
+#if os(cillator) || arch(ive)
+// expected-warning@-1 {{unknown operating system for build configuration 'os'}}
+// expected-note@-2 {{did you mean 'macOS'?}} {{8-16=macOS}}
+// expected-note@-3 {{did you mean 'iOS'?}} {{8-16=iOS}}
+// expected-warning@-4 {{unknown architecture for build configuration 'arch'}}
+// expected-note@-5 {{did you mean 'arm'?}} {{26-29=arm}}
+// expected-note@-6 {{did you mean 'i386'?}} {{26-29=i386}}
+func undefinedFunc() // ignored.
+#endif
+undefinedFunc() // expected-error {{use of unresolved identifier 'undefinedFunc'}}


### PR DESCRIPTION
Cherry-pick #10221 into 4.0

**Explanation:** Fix a 4.0 regression where compilation condition with platform condition with unsupported argument was unexpectedly invalidated. For example `#if arch(x86_64) || arch(ppc64)` should evaluates to `true` for `x86_64` target even while `ppc64` is not valid argument for `arch()` platform condition. The issue was introduced in #7955. This is a regression that breaks existing code. e.g. https://github.com/apple/swift-corelibs-foundation/pull/1026
**Scope:** Affects `#if` and `#elseif` condition which contains unsupported arguments for platform condition`os()`, `arch()`, and `_endian()`
**SR Issue:** N/A
**Risk:** Low
**Testing:** Added test cases.