### PR TITLE
[4.0] [Exclusivity] Relax intra-procedural diagnostics on separate stored structs

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -90,24 +90,24 @@ NOTE(previous_inout_alias,none,
       "previous aliasing argument", ())
 
 WARNING(exclusivity_access_required_swift3,none,
-        "simultaneous accesses to %0 %1, but "
-        "%select{initialization|read|modification|deinitialization}2 requires "
+        "overlapping accesses to %0, but "
+        "%select{initialization|read|modification|deinitialization}1 requires "
         "exclusive access; consider copying to a local variable",
-        (DescriptiveDeclKind, StringRef, unsigned))
+        (StringRef, unsigned))
 
 ERROR(exclusivity_access_required,none,
-      "simultaneous accesses to %0 %1, but "
-      "%select{initialization|read|modification|deinitialization}2 requires "
+      "overlapping accesses to %0, but "
+      "%select{initialization|read|modification|deinitialization}1 requires "
       "exclusive access; consider copying to a local variable",
-      (DescriptiveDeclKind, StringRef, unsigned))
+      (StringRef, unsigned))
 
 ERROR(exclusivity_access_required_unknown_decl,none,
-        "simultaneous accesses, but "
+        "overlapping accesses, but "
         "%select{initialization|read|modification|deinitialization}0 requires "
         "exclusive access; consider copying to a local variable", (unsigned))
 
 WARNING(exclusivity_access_required_unknown_decl_swift3,none,
-        "simultaneous accesses, but "
+        "overlapping accesses, but "
         "%select{initialization|read|modification|deinitialization}0 requires "
 "exclusive access; consider copying to a local variable", (unsigned))
 

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -93,13 +93,13 @@ WARNING(exclusivity_access_required_swift3,none,
         "simultaneous accesses to %0 %1, but "
         "%select{initialization|read|modification|deinitialization}2 requires "
         "exclusive access; consider copying to a local variable",
-        (DescriptiveDeclKind, Identifier, unsigned))
+        (DescriptiveDeclKind, StringRef, unsigned))
 
 ERROR(exclusivity_access_required,none,
       "simultaneous accesses to %0 %1, but "
       "%select{initialization|read|modification|deinitialization}2 requires "
       "exclusive access; consider copying to a local variable",
-      (DescriptiveDeclKind, Identifier, unsigned))
+      (DescriptiveDeclKind, StringRef, unsigned))
 
 ERROR(exclusivity_access_required_unknown_decl,none,
         "simultaneous accesses, but "

--- a/include/swift/SILOptimizer/Analysis/AccessSummaryAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/AccessSummaryAnalysis.h
@@ -1,0 +1,194 @@
+//===--- AccessSummaryAnalysis.h - SIL Access Summary Analysis --*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements an interprocedural analysis pass that summarizes
+// the formal accesses that a function makes to its address-type arguments.
+// These summaries are used to statically diagnose violations of exclusive
+// accesses for noescape closures.
+//
+//===----------------------------------------------------------------------===//
+#ifndef SWIFT_SILOPTIMIZER_ANALYSIS_ACCESS_SUMMARY_ANALYSIS_H_
+#define SWIFT_SILOPTIMIZER_ANALYSIS_ACCESS_SUMMARY_ANALYSIS_H_
+
+#include "swift/SIL/SILFunction.h"
+#include "swift/SIL/SILInstruction.h"
+#include "swift/SILOptimizer/Analysis/BottomUpIPAnalysis.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallVector.h"
+
+namespace swift {
+
+class AccessSummaryAnalysis : public BottomUpIPAnalysis {
+public:
+  /// Summarizes the accesses that a function begins on an argument.
+  class ArgumentSummary {
+  private:
+    /// The kind of access begun on the argument.
+    /// 'None' means no access performed.
+    Optional<SILAccessKind> Kind = None;
+
+    /// The location of the access. Used for diagnostics.
+    SILLocation AccessLoc = SILLocation((Expr *)nullptr);
+
+  public:
+    Optional<SILAccessKind> getAccessKind() const { return Kind; }
+
+    SILLocation getAccessLoc() const { return AccessLoc; }
+
+    /// The lattice operation on argument summaries.
+    bool mergeWith(const ArgumentSummary &other);
+
+    /// Merge in an access to the argument of the given kind at the given
+    /// location. Returns true if the merge caused the summary to change.
+    bool mergeWith(SILAccessKind otherKind, SILLocation otherLoc);
+
+    /// Returns a description of the summary. For debugging and testing
+    /// purposes.
+    StringRef getDescription() const;
+  };
+
+  /// Summarizes the accesses that a function begins on its arguments.
+  class FunctionSummary {
+  private:
+    llvm::SmallVector<ArgumentSummary, 6> ArgAccesses;
+
+  public:
+    FunctionSummary(unsigned argCount) : ArgAccesses(argCount) {}
+
+    /// Returns of summary of the the function accesses that argument at the
+    /// given index.
+    ArgumentSummary &getAccessForArgument(unsigned argument) {
+      return ArgAccesses[argument];
+    }
+
+    const ArgumentSummary &getAccessForArgument(unsigned argument) const {
+      return ArgAccesses[argument];
+    }
+
+    /// Returns the number of argument in the summary.
+    unsigned getArgumentCount() const { return ArgAccesses.size(); }
+  };
+
+  friend raw_ostream &operator<<(raw_ostream &os,
+                                 const FunctionSummary &summary);
+
+  class FunctionInfo;
+  /// Records a flow of a caller's argument to a called function.
+  /// This flow is used to iterate the interprocedural analysis to a fixpoint.
+  struct ArgumentFlow {
+    /// The index of the argument in the caller.
+    const unsigned CallerArgumentIndex;
+
+    /// The index of the argument in the callee.
+    const unsigned CalleeArgumentIndex;
+
+    FunctionInfo *const CalleeFunctionInfo;
+  };
+
+  /// Records the summary and argument flows for a given function.
+  /// Used by the BottomUpIPAnalysis to propagate information
+  /// from callees to callers.
+  class FunctionInfo : public FunctionInfoBase<FunctionInfo> {
+  private:
+    FunctionSummary FS;
+
+    SILFunction *F;
+
+    llvm::SmallVector<ArgumentFlow, 8> RecordedArgumentFlows;
+
+  public:
+    FunctionInfo(SILFunction *F) : FS(F->getArguments().size()), F(F) {}
+
+    SILFunction *getFunction() const { return F; }
+
+    ArrayRef<ArgumentFlow> getArgumentFlows() const {
+      return RecordedArgumentFlows;
+    }
+
+    const FunctionSummary &getSummary() const { return FS; }
+    FunctionSummary &getSummary() { return FS; }
+
+    /// Record a flow of an argument in this function to a callee.
+    void recordFlow(const ArgumentFlow &flow) {
+      flow.CalleeFunctionInfo->addCaller(this, nullptr);
+      RecordedArgumentFlows.push_back(flow);
+    }
+  };
+
+private:
+  /// Maps functions to the information the analysis keeps for each function.
+  llvm::DenseMap<SILFunction *, FunctionInfo *> FunctionInfos;
+
+  llvm::SpecificBumpPtrAllocator<FunctionInfo> Allocator;
+public:
+  AccessSummaryAnalysis() : BottomUpIPAnalysis(AnalysisKind::AccessSummary) {}
+
+  /// Returns a summary of the accesses performed by the given function.
+  const FunctionSummary &getOrCreateSummary(SILFunction *Fn);
+
+  virtual void initialize(SILPassManager *PM) override {}
+  virtual void invalidate() override;
+  virtual void invalidate(SILFunction *F, InvalidationKind K) override;
+  virtual void notifyAddFunction(SILFunction *F) override {}
+  virtual void notifyDeleteFunction(SILFunction *F) override {
+    invalidate(F, InvalidationKind::Nothing);
+  }
+  virtual void invalidateFunctionTables() override {}
+
+  static bool classof(const SILAnalysis *S) {
+    return S->getKind() == AnalysisKind::AccessSummary;
+  }
+
+private:
+  typedef BottomUpFunctionOrder<FunctionInfo> FunctionOrder;
+
+  /// Returns the BottomUpIPAnalysis information for the given function.
+  FunctionInfo *getFunctionInfo(SILFunction *F);
+
+  /// Summarizes the given function and iterates the interprocedural analysis
+  /// to a fixpoint.
+  void recompute(FunctionInfo *initial);
+
+  /// Propagate the access summary from the argument of a called function
+  /// to the caller.
+  bool propagateFromCalleeToCaller(FunctionInfo *callerInfo,
+                                   ArgumentFlow site);
+
+  /// Summarize the given function and schedule it for interprocedural
+  /// analysis.
+  void processFunction(FunctionInfo *info, FunctionOrder &order);
+
+  /// Summarize how the function uses the given argument.
+  void processArgument(FunctionInfo *info, SILFunctionArgument *argment,
+                        ArgumentSummary &summary, FunctionOrder &order);
+
+  /// Summarize a partial_apply instruction.
+  void processPartialApply(FunctionInfo *callerInfo,
+                           unsigned callerArgumentIndex,
+                           PartialApplyInst *apply,
+                           Operand *applyArgumentOperand, FunctionOrder &order);
+
+  /// Summarize apply or try_apply
+  void processFullApply(FunctionInfo *callerInfo, unsigned callerArgumentIndex,
+                        FullApplySite apply, Operand *argumentOperand,
+                        FunctionOrder &order);
+
+  /// Summarize a call site and schedule it for interprocedural analysis.
+  void processCall(FunctionInfo *callerInfo, unsigned callerArgumentIndex,
+                   SILFunction *calledFunction, unsigned argumentIndex,
+                   FunctionOrder &order);
+};
+
+} // end namespace swift
+
+#endif
+

--- a/include/swift/SILOptimizer/Analysis/Analysis.def
+++ b/include/swift/SILOptimizer/Analysis/Analysis.def
@@ -23,6 +23,7 @@
 #define ANALYSIS(NAME)
 #endif
 
+ANALYSIS(AccessSummary)
 ANALYSIS(Alias)
 ANALYSIS(BasicCallee)
 ANALYSIS(Caller)

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -56,6 +56,8 @@ PASS(ABCOpt, "abcopts",
      "Array Bounds Check Optimization")
 PASS(AccessEnforcementSelection, "access-enforcement-selection",
      "Access Enforcement Selection")
+PASS(AccessSummaryDumper, "access-summary-dump",
+     "Dump Address Parameter Access Summary")
 PASS(InactiveAccessMarkerElimination, "inactive-access-marker-elim",
      "Inactive Access Marker Elimination.")
 PASS(FullAccessMarkerElimination, "full-access-marker-elim",

--- a/include/swift/SILOptimizer/Utils/IndexTrie.h
+++ b/include/swift/SILOptimizer/Utils/IndexTrie.h
@@ -1,0 +1,66 @@
+//===--- IndexTrie - Trie for a sequence of integer indices ----*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SILOPTIMIZER_UTILS_INDEXTREE_H
+#define SWIFT_SILOPTIMIZER_UTILS_INDEXTREE_H
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/SmallVector.h"
+#include <algorithm>
+
+namespace swift {
+
+// Trie node representing a sequence of unsigned integer indices.
+class IndexTrieNode {
+  static const unsigned RootIdx = ~0U;
+  unsigned Index;
+  llvm::SmallVector<IndexTrieNode*, 8> Children;
+
+public:
+  IndexTrieNode(): Index(RootIdx) {}
+
+  explicit IndexTrieNode(unsigned V): Index(V) {}
+
+  IndexTrieNode(IndexTrieNode &) =delete;
+  IndexTrieNode &operator=(const IndexTrieNode&) =delete;
+
+  ~IndexTrieNode() {
+    for (auto *N : Children)
+      delete N;
+  }
+
+  bool isRoot() const { return Index == RootIdx; }
+
+  bool isLeaf() const { return Children.empty(); }
+
+  unsigned getIndex() const { return Index; }
+
+  IndexTrieNode *getChild(unsigned Idx) {
+    assert(Idx != RootIdx);
+
+    auto I = std::lower_bound(Children.begin(), Children.end(), Idx,
+                              [](IndexTrieNode *a, unsigned i) {
+                                return a->Index < i;
+                              });
+    if (I != Children.end() && (*I)->Index == Idx)
+      return *I;
+    auto *N = new IndexTrieNode(Idx);
+    Children.insert(I, N);
+    return N;
+  }
+
+  ArrayRef<IndexTrieNode*> getChildren() const { return Children; }
+};
+
+} // end namespace swift
+
+#endif

--- a/include/swift/SILOptimizer/Utils/IndexTrie.h
+++ b/include/swift/SILOptimizer/Utils/IndexTrie.h
@@ -24,11 +24,12 @@ class IndexTrieNode {
   static const unsigned RootIdx = ~0U;
   unsigned Index;
   llvm::SmallVector<IndexTrieNode*, 8> Children;
+  IndexTrieNode *Parent;
 
 public:
-  IndexTrieNode(): Index(RootIdx) {}
+  IndexTrieNode(): Index(RootIdx), Parent(nullptr) {}
 
-  explicit IndexTrieNode(unsigned V): Index(V) {}
+  explicit IndexTrieNode(unsigned V, IndexTrieNode *P): Index(V), Parent(P) {}
 
   IndexTrieNode(IndexTrieNode &) =delete;
   IndexTrieNode &operator=(const IndexTrieNode&) =delete;
@@ -53,12 +54,29 @@ public:
                               });
     if (I != Children.end() && (*I)->Index == Idx)
       return *I;
-    auto *N = new IndexTrieNode(Idx);
+    auto *N = new IndexTrieNode(Idx, this);
     Children.insert(I, N);
     return N;
   }
 
   ArrayRef<IndexTrieNode*> getChildren() const { return Children; }
+
+  IndexTrieNode *getParent() const { return Parent; }
+
+  /// Returns true when the sequence of indices represented by this
+  /// node is a prefix of the sequence represented by the passed-in node.
+  bool isPrefixOf(const IndexTrieNode *Other) const {
+    const IndexTrieNode *I = Other;
+
+    do {
+      if (this == I)
+        return true;
+
+      I = I->getParent();
+    } while (I);
+
+    return false;
+  }
 };
 
 } // end namespace swift

--- a/lib/SILOptimizer/Analysis/AccessSummaryAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/AccessSummaryAnalysis.cpp
@@ -1,0 +1,329 @@
+//===--- AccessSummaryAnalysis.cpp - SIL Access Summary Analysis ----------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#define DEBUG_TYPE "sil-access-summary-analysis"
+#include "swift/SIL/SILArgument.h"
+#include "swift/SILOptimizer/Analysis/AccessSummaryAnalysis.h"
+#include "swift/SILOptimizer/Analysis/FunctionOrder.h"
+#include "swift/SILOptimizer/PassManager/PassManager.h"
+
+using namespace swift;
+
+void AccessSummaryAnalysis::processFunction(FunctionInfo *info,
+                                            FunctionOrder &order) {
+  // Does the summary need to be recomputed?
+  if (order.prepareForVisiting(info))
+    return;
+
+  // Compute function summary on a per-argument basis.
+  unsigned index = 0;
+  for (SILArgument *arg : info->getFunction()->getArguments()) {
+    FunctionSummary &functionSummary = info->getSummary();
+    ArgumentSummary &argSummary =
+        functionSummary.getAccessForArgument(index);
+    index++;
+
+    auto *functionArg = cast<SILFunctionArgument>(arg);
+    // Only summarize @inout_aliasable arguments.
+    SILArgumentConvention convention =
+        functionArg->getArgumentConvention().Value;
+    if (convention != SILArgumentConvention::Indirect_InoutAliasable)
+      continue;
+
+    processArgument(info, functionArg, argSummary, order);
+  }
+}
+
+/// Track uses of the arguments, recording in the summary any accesses
+/// started by a begin_access and any flows of the arguments to other
+/// functions.
+void AccessSummaryAnalysis::processArgument(FunctionInfo *info,
+                                             SILFunctionArgument *argument,
+                                             ArgumentSummary &summary,
+                                             FunctionOrder &order) {
+  unsigned argumentIndex = argument->getIndex();
+
+  // Use a worklist to track argument uses to be processed.
+  llvm::SmallVector<Operand *, 32> worklist;
+
+  // Start by adding the immediate uses of the argument to the worklist.
+  worklist.append(argument->use_begin(), argument->use_end());
+
+  // Iterate to follow uses of the arguments.
+  while (!worklist.empty()) {
+    Operand *operand = worklist.pop_back_val();
+    SILInstruction *user = operand->getUser();
+
+    switch (user->getKind()) {
+    case ValueKind::BeginAccessInst: {
+      auto *BAI = cast<BeginAccessInst>(user);
+      summary.mergeWith(BAI->getAccessKind(), BAI->getLoc());
+      // We don't add the users of the begin_access to the worklist because
+      // even if these users eventually begin an access to the address
+      // or a projection from it, that access can't begin more exclusive
+      // access than this access -- otherwise it will be diagnosed
+      // elsewhere.
+      break;
+    }
+    case ValueKind::EndUnpairedAccessInst:
+      // Don't diagnose unpaired access statically.
+      assert(cast<EndUnpairedAccessInst>(user)->getEnforcement() ==
+             SILAccessEnforcement::Dynamic);
+      break;
+    case ValueKind::StructElementAddrInst:
+    case ValueKind::TupleElementAddrInst:
+      // Eventually we'll summarize individual struct elements separately.
+      // For now an access to a part of the struct is treated as an access
+      // to the whole struct.
+      worklist.append(user->use_begin(), user->use_end());
+      break;
+    case ValueKind::DebugValueAddrInst:
+    case ValueKind::AddressToPointerInst:
+      // Ignore these uses, they don't affect formal accesses.
+      break;
+    case ValueKind::PartialApplyInst:
+      processPartialApply(info, argumentIndex, cast<PartialApplyInst>(user),
+                          operand, order);
+      break;
+    case ValueKind::ApplyInst:
+      processFullApply(info, argumentIndex, cast<ApplyInst>(user), operand,
+                       order);
+      break;
+    case ValueKind::TryApplyInst:
+      processFullApply(info, argumentIndex, cast<TryApplyInst>(user), operand,
+                       order);
+      break;
+    case ValueKind::CopyAddrInst:
+    case ValueKind::ExistentialMetatypeInst:
+    case ValueKind::LoadInst:
+    case ValueKind::OpenExistentialAddrInst:
+    case ValueKind::ProjectBlockStorageInst:
+      // These likely represent scenarios in which we're not generating
+      // begin access markers. Ignore these for now. But we really should
+      // add SIL verification to ensure all loads and stores have associated
+      // access markers.
+      break;
+    default:
+      // TODO: These requirements should be checked for in the SIL verifier.
+      llvm_unreachable("Unrecognized argument use");
+    }
+  }
+}
+
+void AccessSummaryAnalysis::processPartialApply(FunctionInfo *callerInfo,
+                                                unsigned callerArgumentIndex,
+                                                PartialApplyInst *apply,
+                                                Operand *applyArgumentOperand,
+                                                FunctionOrder &order) {
+  SILFunction *calleeFunction = apply->getCalleeFunction();
+  assert(calleeFunction && !calleeFunction->empty() &&
+         "Missing definition of noescape closure?");
+
+  // Make sure the partial_apply is not calling the result of another
+  // partial_apply.
+  assert(isa<FunctionRefInst>(apply->getCallee()) &&
+         "Noescape partial apply of non-functionref?");
+
+  // Make sure the partial_apply is used by an apply and not another
+  // partial_apply
+  SILInstruction *user = apply->getSingleUse()->getUser();
+  assert((isa<ApplyInst>(user) || isa<TryApplyInst>(user) ||
+          isa<ConvertFunctionInst>(user)) &&
+         "noescape partial_apply has non-apply use!");
+  (void)user;
+
+  // The arguments to partial_apply are a suffix of the arguments to the
+  // the actually-called function. Translate the index of the argument to
+  // the partial_apply into to the corresponding index into the arguments of
+  // the called function.
+
+  // The first operand to partial_apply is the called function, so adjust the
+  // operand number to get the argument.
+  unsigned partialApplyArgumentIndex =
+      applyArgumentOperand->getOperandNumber() - 1;
+
+  // The argument index in the called function.
+  unsigned argumentIndex = calleeFunction->getArguments().size() -
+                           apply->getNumArguments() + partialApplyArgumentIndex;
+  processCall(callerInfo, callerArgumentIndex, calleeFunction, argumentIndex,
+              order);
+}
+
+void AccessSummaryAnalysis::processFullApply(FunctionInfo *callerInfo,
+                                             unsigned callerArgumentIndex,
+                                             FullApplySite apply,
+                                             Operand *argumentOperand,
+                                             FunctionOrder &order) {
+  unsigned operandNumber = argumentOperand->getOperandNumber();
+  assert(operandNumber > 0 && "Summarizing apply for non-argument?");
+
+  unsigned calleeArgumentIndex = operandNumber - 1;
+  SILFunction *callee = apply.getCalleeFunction();
+  // We can't apply a summary for function whose body we can't see.
+  // Since user-provided closures are always in the same module as their callee
+  // This likely indicates a missing begin_access before an open-coded
+  // call.
+  if (!callee || callee->empty())
+    return;
+
+  processCall(callerInfo, callerArgumentIndex, callee, calleeArgumentIndex,
+              order);
+}
+
+void AccessSummaryAnalysis::processCall(FunctionInfo *callerInfo,
+                                        unsigned callerArgumentIndex,
+                                        SILFunction *callee,
+                                        unsigned argumentIndex,
+                                        FunctionOrder &order) {
+  // Record the flow of an argument from  the caller to the callee so that
+  // the interprocedural analysis can iterate to a fixpoint.
+  FunctionInfo *calleeInfo = getFunctionInfo(callee);
+  ArgumentFlow flow = {callerArgumentIndex, argumentIndex, calleeInfo};
+  callerInfo->recordFlow(flow);
+  if (!calleeInfo->isVisited()) {
+    processFunction(calleeInfo, order);
+    order.tryToSchedule(calleeInfo);
+  }
+
+  propagateFromCalleeToCaller(callerInfo, flow);
+}
+
+bool AccessSummaryAnalysis::ArgumentSummary::mergeWith(SILAccessKind otherKind,
+                                                        SILLocation otherLoc) {
+  // In the lattice, a modification-like accesses subsume a read access or no
+  // access.
+  if (!Kind.hasValue() ||
+      (*Kind == SILAccessKind::Read && otherKind != SILAccessKind::Read)) {
+    Kind = otherKind;
+    AccessLoc = otherLoc;
+    return true;
+  }
+
+  return false;
+}
+
+bool AccessSummaryAnalysis::ArgumentSummary::mergeWith(
+    const ArgumentSummary &other) {
+  if (other.Kind.hasValue())
+    return mergeWith(*other.Kind, other.AccessLoc);
+  return false;
+}
+
+void AccessSummaryAnalysis::recompute(FunctionInfo *initial) {
+  allocNewUpdateID();
+
+  FunctionOrder order(getCurrentUpdateID());
+
+  // Summarize the function and its callees.
+  processFunction(initial, order);
+
+  // Build the bottom-up order.
+  order.tryToSchedule(initial);
+  order.finishScheduling();
+
+  // Iterate the interprocedural analysis to a fixed point.
+  bool needAnotherIteration;
+  do {
+    needAnotherIteration = false;
+    for (FunctionInfo *calleeInfo : order) {
+      for (const auto &callerEntry : calleeInfo->getCallers()) {
+        assert(callerEntry.isValid());
+        if (!order.wasRecomputedWithCurrentUpdateID(calleeInfo))
+          continue;
+
+        FunctionInfo *callerInfo = callerEntry.Caller;
+
+        // Propagate from callee to caller.
+        for (const auto &argumentFlow : callerInfo->getArgumentFlows()) {
+          if (argumentFlow.CalleeFunctionInfo != calleeInfo)
+            continue;
+
+          bool changed = propagateFromCalleeToCaller(callerInfo, argumentFlow);
+          if (changed && !callerInfo->isScheduledAfter(calleeInfo)) {
+            needAnotherIteration = true;
+          }
+        }
+      }
+    }
+  } while (needAnotherIteration);
+}
+
+StringRef AccessSummaryAnalysis::ArgumentSummary::getDescription() const {
+  if (Optional<SILAccessKind> kind = getAccessKind()) {
+    return getSILAccessKindName(*kind);
+  }
+
+  return "none";
+}
+
+bool AccessSummaryAnalysis::propagateFromCalleeToCaller(
+    FunctionInfo *callerInfo, ArgumentFlow flow) {
+  // For a given flow from a caller's argument to a callee's argument,
+  // propagate the argument summary information to the caller.
+
+  FunctionInfo *calleeInfo = flow.CalleeFunctionInfo;
+  const auto &calleeArgument =
+      calleeInfo->getSummary().getAccessForArgument(flow.CalleeArgumentIndex);
+  auto &callerArgument =
+      callerInfo->getSummary().getAccessForArgument(flow.CallerArgumentIndex);
+
+  bool changed = callerArgument.mergeWith(calleeArgument);
+  return changed;
+}
+
+AccessSummaryAnalysis::FunctionInfo *
+AccessSummaryAnalysis::getFunctionInfo(SILFunction *F) {
+  FunctionInfo *&FInfo = FunctionInfos[F];
+  if (!FInfo) {
+    FInfo = new (Allocator.Allocate()) FunctionInfo(F);
+  }
+  return FInfo;
+}
+
+const AccessSummaryAnalysis::FunctionSummary &
+AccessSummaryAnalysis::getOrCreateSummary(SILFunction *fn) {
+  FunctionInfo *info = getFunctionInfo(fn);
+  if (!info->isValid())
+    recompute(info);
+
+  return info->getSummary();
+}
+
+void AccessSummaryAnalysis::AccessSummaryAnalysis::invalidate() {
+  FunctionInfos.clear();
+  Allocator.DestroyAll();
+}
+
+void AccessSummaryAnalysis::invalidate(SILFunction *F, InvalidationKind K) {
+  FunctionInfos.erase(F);
+}
+
+SILAnalysis *swift::createAccessSummaryAnalysis(SILModule *M) {
+  return new AccessSummaryAnalysis();
+}
+
+raw_ostream &swift::
+operator<<(raw_ostream &os,
+           const AccessSummaryAnalysis::FunctionSummary &summary) {
+  unsigned argCount = summary.getArgumentCount();
+  os << "(";
+
+  if (argCount > 0) {
+    os << summary.getAccessForArgument(0).getDescription();
+    for (unsigned i = 1; i < argCount; i++) {
+      os << ",  " << summary.getAccessForArgument(i).getDescription();
+    }
+  }
+
+  os << ")";
+  return os;
+}

--- a/lib/SILOptimizer/Analysis/AccessSummaryAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/AccessSummaryAnalysis.cpp
@@ -301,6 +301,8 @@ AccessSummaryAnalysis::getOrCreateSummary(SILFunction *fn) {
 void AccessSummaryAnalysis::AccessSummaryAnalysis::invalidate() {
   FunctionInfos.clear();
   Allocator.DestroyAll();
+  delete SubPathTrie;
+  SubPathTrie = new IndexTrieNode();
 }
 
 void AccessSummaryAnalysis::invalidate(SILFunction *F, InvalidationKind K) {

--- a/lib/SILOptimizer/Analysis/CMakeLists.txt
+++ b/lib/SILOptimizer/Analysis/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(ANALYSIS_SOURCES
   Analysis/ARCAnalysis.cpp
+  Analysis/AccessSummaryAnalysis.cpp
   Analysis/AliasAnalysis.cpp
   Analysis/Analysis.cpp
   Analysis/ArraySemantic.cpp

--- a/lib/SILOptimizer/Mandatory/DiagnoseStaticExclusivity.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseStaticExclusivity.cpp
@@ -316,9 +316,9 @@ static StringRef extractExprText(const Expr *E, SourceManager &SM) {
 /// Returns true when the call expression is a call to swap() in the Standard
 /// Library.
 /// This is a helper function that is only used in an assertion, which is why
-/// it is in a namespace rather than 'static'.
-namespace {
-bool isCallToStandardLibrarySwap(CallExpr *CE, ASTContext &Ctx) {
+/// it is in the ifndef.
+#ifndef NDEBUG
+static bool isCallToStandardLibrarySwap(CallExpr *CE, ASTContext &Ctx) {
   if (CE->getCalledValue() == Ctx.getSwap(nullptr))
     return true;
 
@@ -331,7 +331,7 @@ bool isCallToStandardLibrarySwap(CallExpr *CE, ASTContext &Ctx) {
 
   return false;
 }
-} // end anonymous namespace
+#endif
 
 /// Do a sytactic pattern match to try to safely suggest a Fix-It to rewrite
 /// calls like swap(&collection[index1], &collection[index2]) to
@@ -611,7 +611,7 @@ static AccessedStorage findAccessedStorage(SILValue Source) {
 /// Returns true when the apply calls the Standard Library swap().
 /// Used for fix-its to suggest replacing with Collection.swapAt()
 /// on exclusivity violations.
-bool isCallToStandardLibrarySwap(ApplyInst *AI, ASTContext &Ctx) {
+static bool isCallToStandardLibrarySwap(ApplyInst *AI, ASTContext &Ctx) {
   SILFunction *SF = AI->getReferencedFunction();
   if (!SF)
     return false;

--- a/lib/SILOptimizer/Mandatory/DiagnoseStaticExclusivity.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseStaticExclusivity.cpp
@@ -162,8 +162,32 @@ public:
   }
 };
 
-/// Models the in-progress accesses for a single storage location.
-class AccessInfo {
+/// Records an access to an address and the single subpath of projections
+/// that was performed on the address, if such a single subpath exists.
+class RecordedAccess {
+private:
+  BeginAccessInst *Inst;
+  ProjectionPath SubPath;
+
+public:
+  RecordedAccess(BeginAccessInst *BAI, const ProjectionPath &SubPath)
+      : Inst(BAI), SubPath(SubPath) {}
+
+  BeginAccessInst *getInstruction() const { return Inst; }
+
+  SILAccessKind getAccessKind() const { return Inst->getAccessKind(); }
+
+  SILLocation getAccessLoc() const { return Inst->getLoc(); }
+
+  const ProjectionPath &getSubPath() const { return SubPath; }
+};
+
+/// Records the in-progress accesses to a given sub path.
+class SubAccessInfo {
+public:
+  SubAccessInfo(const ProjectionPath &P) : Path(P) {}
+
+  ProjectionPath Path;
 
   /// The number of in-progress 'read' accesses (that is 'begin_access [read]'
   /// instructions that have not yet had the corresponding 'end_access').
@@ -174,36 +198,14 @@ class AccessInfo {
 
   /// The instruction that began the first in-progress access to the storage
   /// location. Used for diagnostic purposes.
-  const BeginAccessInst *FirstAccess = nullptr;
+  Optional<RecordedAccess> FirstAccess = None;
 
 public:
-  // Returns true when beginning an access of the given Kind will
-  // result in a conflict with a previous access.
-  bool conflictsWithAccess(SILAccessKind Kind) {
-    if (Kind == SILAccessKind::Read) {
-      // A read conflicts with any non-read accesses.
-      return NonReads > 0;
-    }
-
-    // A non-read access conflicts with any other access.
-    return NonReads > 0 || Reads > 0;
-  }
-
-  /// Returns true when there must have already been a conflict diagnosed
-  /// for an in-progress access. Used to suppress multiple diagnostics for
-  /// the same underlying access violation.
-  bool alreadyHadConflict() {
-    return (NonReads > 0 && Reads > 0) || (NonReads > 1);
-  }
-
-  /// Returns true when there are any accesses to this location in progress.
-  bool hasAccessesInProgress() { return Reads > 0 || NonReads > 0; }
-
   /// Increment the count for given access.
-  void beginAccess(const BeginAccessInst *BAI) {
+  void beginAccess(BeginAccessInst *BAI, const ProjectionPath &SubPath) {
     if (!FirstAccess) {
       assert(Reads == 0 && NonReads == 0);
-      FirstAccess = BAI;
+      FirstAccess = RecordedAccess(BAI, SubPath);
     }
 
     if (BAI->getAccessKind() == SILAccessKind::Read)
@@ -213,7 +215,7 @@ public:
   }
 
   /// Decrement the count for given access.
-  void endAccess(const EndAccessInst *EAI) {
+  void endAccess(EndAccessInst *EAI) {
     if (EAI->getBeginAccess()->getAccessKind() == SILAccessKind::Read)
       Reads--;
     else
@@ -222,11 +224,118 @@ public:
     // If all open accesses are now ended, forget the location of the
     // first access.
     if (Reads == 0 && NonReads == 0)
-      FirstAccess = nullptr;
+      FirstAccess = None;
   }
 
-  /// Returns the instruction that began the first in-progress access.
-  const BeginAccessInst *getFirstAccess() { return FirstAccess; }
+  /// Returns true when there are any accesses to this location in progress.
+  bool hasAccessesInProgress() const { return Reads > 0 || NonReads > 0; }
+
+  /// Returns true when there must have already been a conflict diagnosed
+  /// for an in-progress access. Used to suppress multiple diagnostics for
+  /// the same underlying access violation.
+  bool alreadyHadConflict() const {
+    return (NonReads > 0 && Reads > 0) || (NonReads > 1);
+  }
+
+  // Returns true when beginning an access of the given Kind can
+  // result in a conflict with a previous access.
+  bool canConflictWithAccessOfKind(SILAccessKind Kind) const {
+    if (Kind == SILAccessKind::Read) {
+      // A read conflicts with any non-read accesses.
+      return NonReads > 0;
+    }
+
+    // A non-read access conflicts with any other access.
+    return NonReads > 0 || Reads > 0;
+  }
+
+  bool conflictsWithAccess(SILAccessKind Kind,
+                           const ProjectionPath &SubPath) const {
+    if (!canConflictWithAccessOfKind(Kind))
+      return false;
+
+    SubSeqRelation_t Relation = Path.computeSubSeqRelation(SubPath);
+    // If the one path is a subsequence of the other (or they are the same)
+    // then access the same storage.
+    return (Relation != SubSeqRelation_t::Unknown);
+  }
+};
+
+/// Models the in-progress accesses for an address on which access has begun
+/// with a begin_access instruction. For a given address, tracks the
+/// count and kinds of accesses as well as the subpaths (i.e., projections) that
+/// were accessed.
+class AccessInfo {
+  using SubAccessVector = SmallVector<SubAccessInfo, 4>;
+
+  SubAccessVector SubAccesses;
+
+  /// Returns the SubAccess info for accessing at the given SubPath.
+  SubAccessInfo &findOrCreateSubAccessInfo(const ProjectionPath &SubPath) {
+    for (auto &Info : SubAccesses) {
+      if (Info.Path == SubPath)
+        return Info;
+    }
+
+    SubAccesses.emplace_back(SubPath);
+    return SubAccesses.back();
+  }
+
+  SubAccessVector::const_iterator
+  findFirstSubPathWithConflict(SILAccessKind OtherKind,
+                               const ProjectionPath &OtherSubPath) const {
+    // Note this iteration requires deterministic ordering for repeatable
+    // diagnostics.
+    for (auto I = SubAccesses.begin(), E = SubAccesses.end(); I != E; ++I) {
+      const SubAccessInfo &Access = *I;
+      if (Access.conflictsWithAccess(OtherKind, OtherSubPath))
+        return I;
+    }
+
+    return SubAccesses.end();
+  }
+
+public:
+  // Returns the previous access when beginning an access of the given Kind will
+  // result in a conflict with a previous access.
+  Optional<RecordedAccess>
+  conflictsWithAccess(SILAccessKind Kind, const ProjectionPath &SubPath) const {
+    auto I = findFirstSubPathWithConflict(Kind, SubPath);
+    if (I == SubAccesses.end())
+      return None;
+
+    return I->FirstAccess;
+  }
+
+  /// Returns true if any subpath of has already had a conflict.
+  bool alreadyHadConflict() const {
+    for (const auto &SubAccess : SubAccesses) {
+      if (SubAccess.alreadyHadConflict())
+        return true;
+    }
+    return false;
+  }
+
+  /// Returns true when there are any accesses to this location in progress.
+  bool hasAccessesInProgress() const {
+    for (const auto &SubAccess : SubAccesses) {
+      if (SubAccess.hasAccessesInProgress())
+        return true;
+    }
+    return false;
+  }
+
+  /// Increment the count for given access.
+  void beginAccess(BeginAccessInst *BAI, const ProjectionPath &SubPath) {
+    SubAccessInfo &SubAccess = findOrCreateSubAccessInfo(SubPath);
+    SubAccess.beginAccess(BAI, SubPath);
+  }
+
+  /// Decrement the count for given access.
+  void endAccess(EndAccessInst *EAI, const ProjectionPath &SubPath) {
+    SubAccessInfo &SubAccess = findOrCreateSubAccessInfo(SubPath);
+    SubAccess.endAccess(EAI);
+  }
 };
 
 /// Indicates whether a 'begin_access' requires exclusive access
@@ -242,11 +351,17 @@ enum class ExclusiveOrShared_t : unsigned {
 /// Tracks the in-progress accesses on per-storage-location basis.
 using StorageMap = llvm::SmallDenseMap<AccessedStorage, AccessInfo, 4>;
 
-/// A pair of 'begin_access' instructions that conflict.
+/// Represents two accesses that conflict and their underlying storage.
 struct ConflictingAccess {
-  AccessedStorage Storage;
-  const BeginAccessInst *FirstAccess;
-  const BeginAccessInst *SecondAccess;
+public:
+  /// Create a conflict for two begin_access instructions in the same function.
+  ConflictingAccess(const AccessedStorage &Storage, const RecordedAccess &First,
+                    const RecordedAccess &Second)
+      : Storage(Storage), FirstAccess(First), SecondAccess(Second) {}
+
+  const AccessedStorage Storage;
+  const RecordedAccess FirstAccess;
+  const RecordedAccess SecondAccess;
 };
 
 } // end anonymous namespace
@@ -296,11 +411,10 @@ template <> struct DenseMapInfo<AccessedStorage> {
 
 } // end namespace llvm
 
-
-/// Returns whether a 'begin_access' requires exclusive or shared access
-/// to its storage.
-static ExclusiveOrShared_t getRequiredAccess(const BeginAccessInst *BAI) {
-  if (BAI->getAccessKind() == SILAccessKind::Read)
+/// Returns whether an access of the given kind requires exclusive or shared
+/// access to its storage.
+static ExclusiveOrShared_t getRequiredAccess(SILAccessKind Kind) {
+  if (Kind == SILAccessKind::Read)
     return ExclusiveOrShared_t::SharedAccess;
 
   return ExclusiveOrShared_t::ExclusiveAccess;
@@ -461,63 +575,107 @@ tryFixItWithCallToCollectionSwapAt(const BeginAccessInst *Access1,
   Diag.fixItReplace(FoundCall->getSourceRange(), FixItText);
 }
 
+/// Returns a string representation of the BaseName and the SubPath
+/// suitable for use in diagnostic text. Only supports the Projections
+/// that stored-property relaxation supports: struct stored properties
+/// and tuple elements.
+static std::string getPathDescription(DeclName BaseName, SILType BaseType,
+                                      ProjectionPath SubPath, SILModule &M) {
+  std::string sbuf;
+  llvm::raw_string_ostream os(sbuf);
+
+  os << "'" << BaseName;
+
+  SILType ContainingType = BaseType;
+  for (auto &P : SubPath) {
+    os << ".";
+    switch (P.getKind()) {
+    case ProjectionKind::Struct:
+      os << P.getVarDecl(ContainingType)->getBaseName();
+      break;
+    case ProjectionKind::Tuple: {
+      // Use the tuple element's name if present, otherwise use its index.
+      Type SwiftTy = ContainingType.getSwiftRValueType();
+      TupleType *TupleTy = SwiftTy->getAs<TupleType>();
+      assert(TupleTy && "Tuple projection on non-tuple type!?");
+
+      Identifier ElementName = TupleTy->getElement(P.getIndex()).getName();
+      if (ElementName.empty())
+        os << P.getIndex();
+      else
+        os << ElementName;
+      break;
+    }
+    default:
+      llvm_unreachable("Unexpected projection kind in SubPath!");
+    }
+    ContainingType = P.getType(ContainingType, M);
+  }
+
+  os << "'";
+
+  return os.str();
+}
+
 /// Emits a diagnostic if beginning an access with the given in-progress
 /// accesses violates the law of exclusivity. Returns true when a
 /// diagnostic was emitted.
-static void diagnoseExclusivityViolation(const AccessedStorage &Storage,
-                                         const BeginAccessInst *PriorAccess,
-                                         const BeginAccessInst *NewAccess,
+static void diagnoseExclusivityViolation(const ConflictingAccess &Violation,
                                          ArrayRef<ApplyInst *> CallsToSwap,
                                          ASTContext &Ctx) {
 
-  DEBUG(llvm::dbgs() << "Conflict on " << *PriorAccess
-        << "\n  vs " << *NewAccess
-        << "\n  in function " << *PriorAccess->getFunction());
+  const AccessedStorage &Storage = Violation.Storage;
+  const RecordedAccess &FirstAccess = Violation.FirstAccess;
+  const RecordedAccess &SecondAccess = Violation.SecondAccess;
+
+  DEBUG(llvm::dbgs() << "Conflict on " << *FirstAccess.getInstruction()
+                     << "\n  vs " << *SecondAccess.getInstruction()
+                     << "\n  in function "
+                     << *FirstAccess.getInstruction()->getFunction());
 
   // Can't have a conflict if both accesses are reads.
-  assert(!(PriorAccess->getAccessKind() == SILAccessKind::Read &&
-           NewAccess->getAccessKind() == SILAccessKind::Read));
+  assert(!(FirstAccess.getAccessKind() == SILAccessKind::Read &&
+           SecondAccess.getAccessKind() == SILAccessKind::Read));
 
-  ExclusiveOrShared_t PriorRequires = getRequiredAccess(PriorAccess);
+  ExclusiveOrShared_t FirstRequires =
+      getRequiredAccess(FirstAccess.getAccessKind());
 
   // Diagnose on the first access that requires exclusivity.
-  const BeginAccessInst *AccessForMainDiagnostic = PriorAccess;
-  const BeginAccessInst *AccessForNote = NewAccess;
-  if (PriorRequires != ExclusiveOrShared_t::ExclusiveAccess) {
-    AccessForMainDiagnostic = NewAccess;
-    AccessForNote = PriorAccess;
-  }
+  bool FirstIsMain = (FirstRequires == ExclusiveOrShared_t::ExclusiveAccess);
+  const RecordedAccess &MainAccess = (FirstIsMain ? FirstAccess : SecondAccess);
+  const RecordedAccess &NoteAccess = (FirstIsMain ? SecondAccess : FirstAccess);
 
-  SourceRange rangeForMain =
-    AccessForMainDiagnostic->getLoc().getSourceRange();
+  SourceRange RangeForMain = MainAccess.getAccessLoc().getSourceRange();
   unsigned AccessKindForMain =
-      static_cast<unsigned>(AccessForMainDiagnostic->getAccessKind());
+      static_cast<unsigned>(MainAccess.getAccessKind());
 
   if (const ValueDecl *VD = Storage.getStorageDecl()) {
     // We have a declaration, so mention the identifier in the diagnostic.
     auto DiagnosticID = (Ctx.LangOpts.isSwiftVersion3() ?
                          diag::exclusivity_access_required_swift3 :
                          diag::exclusivity_access_required);
-    auto D = diagnose(Ctx, AccessForMainDiagnostic->getLoc().getSourceLoc(),
-                       DiagnosticID,
-                       VD->getDescriptiveKind(),
-                       VD->getBaseName(),
-                       AccessKindForMain);
-    D.highlight(rangeForMain);
-    tryFixItWithCallToCollectionSwapAt(PriorAccess, NewAccess,
+    SILType BaseType = FirstAccess.getInstruction()->getType().getAddressType();
+    SILModule &M = FirstAccess.getInstruction()->getModule();
+    std::string PathDescription = getPathDescription(
+        VD->getBaseName(), BaseType, MainAccess.getSubPath(), M);
+    auto D =
+        diagnose(Ctx, MainAccess.getAccessLoc().getSourceLoc(), DiagnosticID,
+                 VD->getDescriptiveKind(), PathDescription, AccessKindForMain);
+    D.highlight(RangeForMain);
+    tryFixItWithCallToCollectionSwapAt(FirstAccess.getInstruction(),
+                                       SecondAccess.getInstruction(),
                                        CallsToSwap, Ctx, D);
   } else {
     auto DiagnosticID = (Ctx.LangOpts.isSwiftVersion3() ?
                          diag::exclusivity_access_required_unknown_decl_swift3 :
                          diag::exclusivity_access_required_unknown_decl);
-    diagnose(Ctx, AccessForMainDiagnostic->getLoc().getSourceLoc(),
-             DiagnosticID,
+    diagnose(Ctx, MainAccess.getAccessLoc().getSourceLoc(), DiagnosticID,
              AccessKindForMain)
-        .highlight(rangeForMain);
+        .highlight(RangeForMain);
   }
-  diagnose(Ctx, AccessForNote->getLoc().getSourceLoc(),
+  diagnose(Ctx, NoteAccess.getAccessLoc().getSourceLoc(),
            diag::exclusivity_conflicting_access)
-      .highlight(AccessForNote->getLoc().getSourceRange());
+      .highlight(NoteAccess.getAccessLoc().getSourceRange());
 }
 
 /// Make a best effort to find the underlying object for the purpose
@@ -626,6 +784,55 @@ static bool isCallToStandardLibrarySwap(ApplyInst *AI, ASTContext &Ctx) {
   return FD == Ctx.getSwap(nullptr);
 }
 
+static SILInstruction *getSingleAddressProjectionUser(SILInstruction *I) {
+  SILInstruction *SingleUser = nullptr;
+
+  for (Operand *Use : I->getUses()) {
+    SILInstruction *User = Use->getUser();
+    if (isa<BeginAccessInst>(I) && isa<EndAccessInst>(User))
+      continue;
+
+    // We have more than a single user so bail.
+    if (SingleUser)
+      return nullptr;
+
+    switch (User->getKind()) {
+    case ValueKind::StructElementAddrInst:
+    case ValueKind::TupleElementAddrInst:
+      SingleUser = User;
+      break;
+    default:
+      return nullptr;
+    }
+  }
+
+  return SingleUser;
+}
+
+static ProjectionPath findSubPathAccessed(BeginAccessInst *BAI) {
+  ProjectionPath SubPath(BAI->getType(), BAI->getType());
+
+  SILInstruction *Iter = BAI;
+
+  while ((Iter = getSingleAddressProjectionUser(Iter))) {
+    SubPath.push_back(Projection(Iter));
+  }
+
+  return SubPath;
+}
+
+/// If making an access of the given kind at the given subpath would
+/// would conflict, returns the first recorded access it would conflict
+/// with. Otherwise, returns None.
+Optional<RecordedAccess> shouldReportAccess(const AccessInfo &Info,
+                                            swift::SILAccessKind Kind,
+                                            const ProjectionPath &SubPath) {
+  if (Info.alreadyHadConflict())
+    return None;
+
+  return Info.conflictsWithAccess(Kind, SubPath);
+}
+
 static void checkStaticExclusivity(SILFunction &Fn, PostOrderFunctionInfo *PO) {
   // The implementation relies on the following SIL invariants:
   //    - All incoming edges to a block must have the same in-progress
@@ -692,20 +899,23 @@ static void checkStaticExclusivity(SILFunction &Fn, PostOrderFunctionInfo *PO) {
         SILAccessKind Kind = BAI->getAccessKind();
         const AccessedStorage &Storage = findAccessedStorage(BAI->getSource());
         AccessInfo &Info = Accesses[Storage];
-        if (Info.conflictsWithAccess(Kind) && !Info.alreadyHadConflict()) {
-          const BeginAccessInst *Conflict = Info.getFirstAccess();
-          assert(Conflict && "Must already have had access to conflict!");
-          ConflictingAccesses.push_back({ Storage, Conflict, BAI });
+        ProjectionPath SubPath = findSubPathAccessed(BAI);
+        if (auto Conflict = shouldReportAccess(Info, Kind, SubPath)) {
+          ConflictingAccesses.emplace_back(Storage, *Conflict,
+                                           RecordedAccess(BAI, SubPath));
         }
 
-        Info.beginAccess(BAI);
+        Info.beginAccess(BAI, SubPath);
         continue;
       }
 
       if (auto *EAI = dyn_cast<EndAccessInst>(&I)) {
         auto It = Accesses.find(findAccessedStorage(EAI->getSource()));
         AccessInfo &Info = It->getSecond();
-        Info.endAccess(EAI);
+
+        BeginAccessInst *BAI = EAI->getBeginAccess();
+        const ProjectionPath &SubPath = findSubPathAccessed(BAI);
+        Info.endAccess(EAI, SubPath);
 
         // If the storage location has no more in-progress accesses, remove
         // it to keep the StorageMap lean.
@@ -729,11 +939,7 @@ static void checkStaticExclusivity(SILFunction &Fn, PostOrderFunctionInfo *PO) {
   // Now that we've collected violations and suppressed calls, emit
   // diagnostics.
   for (auto &Violation : ConflictingAccesses) {
-    const BeginAccessInst *PriorAccess = Violation.FirstAccess;
-    const BeginAccessInst *NewAccess = Violation.SecondAccess;
-
-    diagnoseExclusivityViolation(Violation.Storage, PriorAccess, NewAccess,
-                                 CallsToSwap, Fn.getASTContext());
+    diagnoseExclusivityViolation(Violation, CallsToSwap, Fn.getASTContext());
   }
 }
 

--- a/lib/SILOptimizer/Mandatory/DiagnoseStaticExclusivity.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseStaticExclusivity.cpp
@@ -660,7 +660,7 @@ static void diagnoseExclusivityViolation(const ConflictingAccess &Violation,
         VD->getBaseName(), BaseType, MainAccess.getSubPath(), M);
     auto D =
         diagnose(Ctx, MainAccess.getAccessLoc().getSourceLoc(), DiagnosticID,
-                 VD->getDescriptiveKind(), PathDescription, AccessKindForMain);
+                 PathDescription, AccessKindForMain);
     D.highlight(RangeForMain);
     tryFixItWithCallToCollectionSwapAt(FirstAccess.getInstruction(),
                                        SecondAccess.getInstruction(),

--- a/lib/SILOptimizer/UtilityPasses/AccessSummaryDumper.cpp
+++ b/lib/SILOptimizer/UtilityPasses/AccessSummaryDumper.cpp
@@ -1,0 +1,51 @@
+//===--- AccessSummaryDumper.cpp - Dump access summaries for functions -----===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#define DEBUG_TYPE "sil-access-summary-dumper"
+#include "swift/SIL/SILArgument.h"
+#include "swift/SIL/SILFunction.h"
+#include "swift/SIL/SILInstruction.h"
+#include "swift/SIL/SILValue.h"
+#include "swift/SILOptimizer/Analysis/AccessSummaryAnalysis.h"
+#include "swift/SILOptimizer/PassManager/Passes.h"
+#include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "llvm/Support/Debug.h"
+
+using namespace swift;
+
+namespace {
+
+/// Dumps summaries of kinds of accesses a function performs on its
+/// @inout_aliasiable arguments.
+class AccessSummaryDumper : public SILModuleTransform {
+
+  void run() override {
+    auto *analysis = PM->getAnalysis<AccessSummaryAnalysis>();
+
+    for (auto &fn : *getModule()) {
+      llvm::outs() << "@" << fn.getName() << "\n";
+      if (fn.empty()) {
+        llvm::outs() << "<unknown>\n";
+        continue;
+      }
+      const AccessSummaryAnalysis::FunctionSummary &summary =
+          analysis->getOrCreateSummary(&fn);
+      llvm::outs() << summary << "\n";
+    }
+  }
+};
+
+} // end anonymous namespace
+
+SILTransform *swift::createAccessSummaryDumper() {
+  return new AccessSummaryDumper();
+}

--- a/lib/SILOptimizer/UtilityPasses/CMakeLists.txt
+++ b/lib/SILOptimizer/UtilityPasses/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(UTILITYPASSES_SOURCES
   UtilityPasses/AADumper.cpp
+  UtilityPasses/AccessSummaryDumper.cpp
   UtilityPasses/BasicCalleePrinter.cpp
   UtilityPasses/BasicInstructionPropertyDumper.cpp
   UtilityPasses/BugReducerTester.cpp

--- a/test/SILGen/polymorphic_inout_aliasing.swift
+++ b/test/SILGen/polymorphic_inout_aliasing.swift
@@ -11,7 +11,7 @@ class Story {
   }
 
   func test() {
-    // expected-warning@+2 {{simultaneous accesses to var 'finalStored', but modification requires exclusive access; consider copying to a local variable}}
+    // expected-warning@+2 {{overlapping accesses to 'finalStored', but modification requires exclusive access; consider copying to a local variable}}
     // expected-note@+1 {{conflicting access is here}}
     swap(&self.finalStored[0], &self.finalStored[1])
     swap(&self.overridableStored[0], &self.overridableStored[1])
@@ -24,7 +24,7 @@ protocol Storied {
 }
 
 func testProtocol<T: Storied>(x: inout T) {
-  // expected-warning@+2 {{simultaneous accesses to parameter 'x', but modification requires exclusive access; consider copying to a local variable}}
+  // expected-warning@+2 {{overlapping accesses to 'x', but modification requires exclusive access; consider copying to a local variable}}
   // expected-note@+1 {{conflicting access is here}}
   swap(&x.protocolRequirement[0], &x.protocolRequirement[1])
 }

--- a/test/SILOptimizer/access_summary_analysis.sil
+++ b/test/SILOptimizer/access_summary_analysis.sil
@@ -1,0 +1,294 @@
+// RUN: %target-sil-opt  %s -assume-parsing-unqualified-ownership-sil -access-summary-dump -o /dev/null | %FileCheck %s
+
+sil_stage raw
+
+import Builtin
+import Swift
+import SwiftShims
+
+struct StructWithStoredProperties {
+  @sil_stored var f: Int
+  @sil_stored var g: Int
+}
+
+// CHECK-LABEL: @assignsToCapture
+// CHECK-NEXT: (modify, none)
+sil private @assignsToCapture : $@convention(thin) (@inout_aliasable Int, Int) -> () {
+bb0(%0 : $*Int, %1: $Int):
+  %2 = begin_access [modify] [unknown] %0 : $*Int
+  assign %1 to %2 : $*Int
+  end_access %2 : $*Int
+  %3 = tuple ()
+  return %3 : $()
+}
+
+// CHECK-LABEL: @readsAndModifiesSameCapture
+// CHECK-NEXT: (modify)
+sil private @readsAndModifiesSameCapture : $@convention(thin) (@inout_aliasable Int) -> () {
+bb0(%0 : $*Int):
+  %1 = begin_access [read] [unknown] %0 : $*Int
+  end_access %1 : $*Int
+  %2 = begin_access [modify] [unknown] %0 : $*Int
+  end_access %2 : $*Int
+  %3 = tuple ()
+  return %3 : $()
+}
+
+// CHECK-LABEL: @readsAndModifiesSeparateCaptures
+// CHECK-NEXT: (read, modify)
+sil private @readsAndModifiesSeparateCaptures : $@convention(thin) (@inout_aliasable Int, @inout_aliasable Int) -> () {
+bb0(%0 : $*Int, %1 : $*Int):
+  %2 = begin_access [read] [unknown] %0 : $*Int
+  end_access %2 : $*Int
+  %3 = begin_access [modify] [unknown] %1 : $*Int
+  end_access %3 : $*Int
+  %4 = tuple ()
+  return %4 : $()
+}
+
+// CHECK-LABEL: @modifyInModifySubAccess
+// CHECK-NEXT: (modify)
+sil private @modifyInModifySubAccess : $@convention(thin) (@inout_aliasable Int) -> () {
+bb0(%0 : $*Int):
+  %1 = begin_access [modify] [unknown] %0 : $*Int
+  %2 = begin_access [modify] [unknown] %1 : $*Int
+  end_access %2 : $*Int
+  end_access %1 : $*Int
+  %3 = tuple ()
+  return %3 : $()
+}
+
+// CHECK-LABEL: @readInModifySubAccess
+// CHECK-NEXT: (modify)
+sil private @readInModifySubAccess : $@convention(thin) (@inout_aliasable Int) -> () {
+bb0(%0 : $*Int):
+  %1 = begin_access [modify] [unknown] %0 : $*Int
+  %2 = begin_access [read] [unknown] %1 : $*Int
+  end_access %2 : $*Int
+  end_access %1 : $*Int
+  %3 = tuple ()
+  return %3 : $()
+}
+
+// CHECK-LABEL: @addressToPointerOfStructElementAddr
+// CHECK-NEXT: (none)
+// This mirrors the code pattern for materializeForSet on a struct stored
+// property
+sil private @addressToPointerOfStructElementAddr : $@convention(method) (@inout StructWithStoredProperties) -> (Builtin.RawPointer) {
+bb0(%1 : $*StructWithStoredProperties):
+  %2 = struct_element_addr %1 : $*StructWithStoredProperties, #StructWithStoredProperties.f
+  %3 = address_to_pointer %2 : $*Int to $Builtin.RawPointer
+  return %3 : $(Builtin.RawPointer)
+}
+
+// CHECK-LABEL: @endUnpairedAccess
+// CHECK-NEXT: (none)
+sil private @endUnpairedAccess : $@convention(method) (@inout Builtin.UnsafeValueBuffer) -> () {
+bb0(%0 : $*Builtin.UnsafeValueBuffer):
+  end_unpaired_access [dynamic] %0 : $*Builtin.UnsafeValueBuffer
+  %1 = tuple ()
+  return %1 : $()
+}
+
+// CHECK-LABEL: @tupleElementAddr
+// CHECK-NEXT: (modify)
+sil private @tupleElementAddr : $@convention(thin) (@inout_aliasable (Int, Int)) -> () {
+bb0(%0 : $*(Int, Int)):
+  %1 = tuple_element_addr %0 : $*(Int, Int), 1
+  %2 = begin_access [modify] [unknown] %1 : $*Int
+  end_access %2 : $*Int
+  %3 = tuple ()
+  return %3 : $()
+}
+
+sil @closureWithMissingBody : $@convention(thin) (@inout_aliasable Int, Int) -> ()
+
+// CHECK-LABEL: @callClosureWithMissingBody
+// CHECK-NEXT: (none, none)
+sil private @callClosureWithMissingBody : $@convention(thin) (@inout_aliasable Int, Int) -> () {
+bb0(%0 : $*Int, %1 : $Int):
+  %2 = function_ref @closureWithMissingBody : $@convention(thin) (@inout_aliasable Int, Int) -> ()
+  %3 = apply %2(%0, %1) : $@convention(thin) (@inout_aliasable Int, Int) -> () // no-crash
+  %4 = tuple ()
+  return %4 : $()
+}
+
+// CHECK-LABEL: @callClosureThatModifiesCapture
+// CHECK-NEXT: (modify, none)
+sil private @callClosureThatModifiesCapture : $@convention(thin) (@inout_aliasable Int, Int) -> () {
+bb0(%0 : $*Int, %1 : $Int):
+  %2 = function_ref @assignsToCapture : $@convention(thin) (@inout_aliasable Int, Int) -> ()
+  %3 = apply %2(%0, %1) : $@convention(thin) (@inout_aliasable Int, Int) -> ()
+  %4 = tuple ()
+  return %4 : $()
+}
+
+// CHECK-LABEL: @throwingClosureThatModifesCapture
+// CHECK-NEXT: (modify)
+sil private @throwingClosureThatModifesCapture : $@convention(thin) (@inout_aliasable Int) -> @error Error {
+bb0(%0 : $*Int):
+  %1 = begin_access [modify] [unknown] %0 : $*Int
+  end_access %1 : $*Int
+  %2 = tuple ()
+  return %2 : $()
+}
+// CHECK-LABEL: @callThrowingClosureThatModifiesCapture
+// CHECK-NEXT: (modify)
+sil private @callThrowingClosureThatModifiesCapture : $@convention(thin) (@inout_aliasable Int) -> () {
+bb0(%0 : $*Int):
+  %1 = function_ref @throwingClosureThatModifesCapture : $@convention(thin) (@inout_aliasable Int) -> @error Error
+  %2 = try_apply %1(%0) : $@convention(thin) (@inout_aliasable Int) -> @error Error, normal bb1, error bb2
+bb1(%3 : $()):
+  %4 = tuple ()
+  return %4 : $()
+bb2(%5: $Error):
+  %6 = builtin "unexpectedError"(%5 : $Error) : $()
+  unreachable
+}
+
+sil @takesNoEscapeClosure : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+
+// CHECK-LABEL: @partialApplyPassedOffToFunction
+// CHECK-NEXT: (modify, none)
+sil private @partialApplyPassedOffToFunction : $@convention(thin) (@inout_aliasable Int, Int) -> () {
+bb0(%0 : $*Int, %1: $Int):
+  %2 = function_ref @assignsToCapture : $@convention(thin) (@inout_aliasable Int, Int) -> ()
+  %3 = partial_apply %2(%0, %1) : $@convention(thin) (@inout_aliasable Int, Int) -> ()
+  %4 = function_ref @takesNoEscapeClosure : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  %5 = apply %4(%3) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  %6 = tuple ()
+  return %6 : $()
+}
+
+sil @takesNoEscapeClosureTakingArgument : $@convention(thin) (@owned @callee_owned (Int) -> ()) -> ()
+sil @takesNoEscapeClosureTakingArgumentThrowing : $@convention(thin) (@owned @callee_owned (Int) -> (@error Error)) -> ()
+
+// CHECK-LABEL: @hasThreeCapturesAndTakesArgument
+// CHECK-NEXT: (none, modify, none, read)
+sil private @hasThreeCapturesAndTakesArgument : $@convention(thin) (Int, @inout_aliasable Int, @inout_aliasable Int, @inout_aliasable Int) -> () {
+bb0(%0 : $Int, %1: $*Int, %2: $*Int, %3: $*Int):
+  %4 = begin_access [modify] [unknown] %1 : $*Int
+  end_access %4 : $*Int
+  %5 = begin_access [read] [unknown] %3 : $*Int
+  end_access %5 : $*Int
+  %6 = tuple ()
+  return %6 : $()
+}
+
+// CHECK-LABEL: @partialApplyOfClosureTakingArgumentPassedOffToFunction
+// CHECK-NEXT: (modify, none, read
+sil private @partialApplyOfClosureTakingArgumentPassedOffToFunction : $@convention(thin) (@inout_aliasable Int, @inout_aliasable Int, @inout_aliasable Int) -> () {
+bb0(%0 : $*Int, %1 : $*Int, %2 : $*Int):
+  %3 = function_ref @hasThreeCapturesAndTakesArgument : $@convention(thin) (Int, @inout_aliasable Int, @inout_aliasable Int, @inout_aliasable Int) -> ()
+  %4 = partial_apply %3(%0, %1, %2) : $@convention(thin) (Int, @inout_aliasable Int, @inout_aliasable Int, @inout_aliasable Int) -> ()
+  %5 = function_ref @takesNoEscapeClosureTakingArgument : $@convention(thin) (@owned @callee_owned (Int) -> ()) -> ()
+  %6 = apply %5(%4) : $@convention(thin) (@owned @callee_owned (Int) -> ()) -> ()
+  %7 = tuple ()
+  return %7 : $()
+}
+
+// CHECK-LABEL: @partialApplyFollowedByConvertFunction
+// CHECK-NEXT: (modify, none, read)
+sil private @partialApplyFollowedByConvertFunction : $@convention(thin) (@inout_aliasable Int, @inout_aliasable Int, @inout_aliasable Int) -> () {
+bb0(%0 : $*Int, %1 : $*Int, %2 : $*Int):
+  %3 = function_ref @hasThreeCapturesAndTakesArgument : $@convention(thin) (Int, @inout_aliasable Int, @inout_aliasable Int, @inout_aliasable Int) -> ()
+  %4 = partial_apply %3(%0, %1, %2) : $@convention(thin) (Int, @inout_aliasable Int, @inout_aliasable Int, @inout_aliasable Int) -> ()
+  %5 = convert_function %4 : $@callee_owned (Int) -> () to $@callee_owned (Int) -> @error Error
+  %6 = function_ref @takesNoEscapeClosureTakingArgumentThrowing : $@convention(thin) (@owned @callee_owned (Int) -> @error Error) -> ()
+  %7 = apply %6(%5) : $@convention(thin) (@owned @callee_owned (Int) -> @error Error) -> ()
+  %8 = tuple ()
+  return %8 : $()
+}
+
+// CHECK-LABEL: @selfRecursion
+// CHECK-NEXT: (modify, none)
+sil private @selfRecursion : $@convention(thin) (@inout_aliasable Int, Int) -> () {
+bb0(%0 : $*Int, %1 : $Int):
+  %2 = function_ref @selfRecursion : $@convention(thin) (@inout_aliasable Int, Int) -> ()
+  %3 = apply %2(%0, %1) : $@convention(thin) (@inout_aliasable Int, Int) -> ()
+  %4 = begin_access [modify] [unknown] %0 : $*Int
+  end_access %4 : $*Int
+  %5 = tuple ()
+  return %5 : $()
+}
+
+// CHECK-LABEL: @callsMutuallyRecursive
+// CHECK-NEXT: (modify, none)
+sil private @callsMutuallyRecursive : $@convention(thin) (@inout_aliasable Int, Int) -> () {
+bb0(%0 : $*Int, %1 : $Int):
+  %2 = function_ref @mutualRecursion1 : $@convention(thin) (@inout_aliasable Int, Int) -> ()
+  %3 = apply %2(%0, %1) : $@convention(thin) (@inout_aliasable Int, Int) -> ()
+  %4 = tuple ()
+  return %4 : $()
+}
+
+// CHECK-LABEL: @mutualRecursion1
+// CHECK-NEXT: (modify, none)
+sil private @mutualRecursion1 : $@convention(thin) (@inout_aliasable Int, Int) -> () {
+bb0(%0 : $*Int, %1 : $Int):
+  %2 = function_ref @mutualRecursion2 : $@convention(thin) (@inout_aliasable Int, Int) -> ()
+  %3 = apply %2(%0, %1) : $@convention(thin) (@inout_aliasable Int, Int) -> ()
+  %4 = begin_access [modify] [unknown] %0 : $*Int
+  end_access %4 : $*Int
+  %5 = tuple ()
+  return %5 : $()
+}
+
+// CHECK-LABEL: @mutualRecursion2
+// CHECK-NEXT: (modify, none)
+sil private @mutualRecursion2 : $@convention(thin) (@inout_aliasable Int, Int) -> () {
+bb0(%0 : $*Int, %1 : $Int):
+  %2 = function_ref @mutualRecursion1 : $@convention(thin) (@inout_aliasable Int, Int) -> ()
+  %3 = apply %2(%0, %1) : $@convention(thin) (@inout_aliasable Int, Int) -> ()
+  %4 = begin_access [read] [unknown] %0 : $*Int
+  end_access %4 : $*Int
+  %5 = tuple ()
+  return %5 : $()
+}
+
+// Multiple cycles. This requires two iterations of the edge propagation.
+// Once to propagate the modify from A to B and one to propagate from
+// B to C
+//
+//      A [Call B then later modify param]
+//    / |
+//    \ |
+//     B
+//    / |
+//    \ |
+//     C
+//
+// CHECK-LABEL: @multipleCycleA
+// CHECK-NEXT: (modify)
+sil private @multipleCycleA : $@convention(thin) (@inout_aliasable Int) -> () {
+bb0(%0 : $*Int):
+  %1 = function_ref @multipleCycleB : $@convention(thin) (@inout_aliasable Int) -> ()
+  %2 = apply %1(%0) : $@convention(thin) (@inout_aliasable Int) -> ()
+  %3 = begin_access [modify] [unknown] %0 : $*Int
+  end_access %3 : $*Int
+  %5 = tuple ()
+  return %5 : $()
+}
+
+// CHECK-LABEL: @multipleCycleB
+// CHECK-NEXT: (modify)
+sil private @multipleCycleB : $@convention(thin) (@inout_aliasable Int) -> () {
+bb0(%0 : $*Int):
+  %1 = function_ref @multipleCycleA : $@convention(thin) (@inout_aliasable Int) -> ()
+  %2 = apply %1(%0) : $@convention(thin) (@inout_aliasable Int) -> ()
+  %3 = function_ref @multipleCycleC : $@convention(thin) (@inout_aliasable Int) -> ()
+  %4 = apply %3(%0) : $@convention(thin) (@inout_aliasable Int) -> ()
+  %5 = tuple ()
+  return %5 : $()
+}
+
+// CHECK-LABEL: @multipleCycleC
+// CHECK-NEXT: (modify)
+sil private @multipleCycleC : $@convention(thin) (@inout_aliasable Int) -> () {
+bb0(%0 : $*Int):
+  %1 = function_ref @multipleCycleB : $@convention(thin) (@inout_aliasable Int) -> ()
+  %2 = apply %1(%0) : $@convention(thin) (@inout_aliasable Int) -> ()
+  %4 = tuple ()
+  return %4 : $()
+}
+

--- a/test/SILOptimizer/exclusivity_static_diagnostics.sil
+++ b/test/SILOptimizer/exclusivity_static_diagnostics.sil
@@ -38,7 +38,7 @@ bb0(%0 : $Int):
   %3 = project_box %2 : ${ var Int }, 0
   store %0 to [trivial] %3 : $*Int
   %4 = function_ref @takesTwoInouts : $@convention(thin) (@inout Int, @inout Int) -> ()
-  %5 = begin_access [modify] [unknown] %3 : $*Int  // expected-error {{simultaneous accesses, but modification requires exclusive access; consider copying to a local variable}}
+  %5 = begin_access [modify] [unknown] %3 : $*Int  // expected-error {{overlapping accesses, but modification requires exclusive access; consider copying to a local variable}}
   %6 = begin_access [modify] [unknown] %3 : $*Int  // expected-note {{conflicting access is here}}
   %7 = apply %4(%5, %6) : $@convention(thin) (@inout Int, @inout Int) -> ()
   end_access %6 : $*Int
@@ -55,7 +55,7 @@ bb0(%0 : $Int):
   %3 = project_box %2 : ${ var Int }, 0
   store %0 to [trivial] %3 : $*Int
   %4 = function_ref @takesTwoInouts : $@convention(thin) (@inout Int, @inout Int) -> ()
-  %5 = begin_access [modify] [unknown] %3 : $*Int  // expected-error {{simultaneous accesses, but modification requires exclusive access; consider copying to a local variable}}
+  %5 = begin_access [modify] [unknown] %3 : $*Int  // expected-error {{overlapping accesses, but modification requires exclusive access; consider copying to a local variable}}
   %6 = begin_access [modify] [unknown] %5 : $*Int
   %7 = begin_access [modify] [unknown] %3 : $*Int  // expected-note {{conflicting access is here}}
   %8 = apply %4(%5, %6) : $@convention(thin) (@inout Int, @inout Int) -> ()
@@ -147,7 +147,7 @@ bb0(%0 : $Int, %1 : $Builtin.Int1):
   br bb1
 bb1:
   // Make sure we don't diagnose twice.
-  %4 = begin_access [modify] [unknown] %3 : $*Int // expected-error {{simultaneous accesses, but modification requires exclusive access; consider copying to a local variable}}
+  %4 = begin_access [modify] [unknown] %3 : $*Int // expected-error {{overlapping accesses, but modification requires exclusive access; consider copying to a local variable}}
   %5 = begin_access [modify] [unknown] %3 : $*Int // expected-note {{conflicting access is here}}
   end_access %5: $*Int
   end_access %4: $*Int
@@ -199,7 +199,7 @@ bb0(%0 : $Int):
   %2 = project_box %1 : ${ var Int }, 0
   store %0 to [trivial] %2 : $*Int
   %4 = begin_access [read] [unknown] %2 : $*Int // expected-note {{conflicting access is here}}
-  %5 = begin_access [modify] [unknown] %2 : $*Int // expected-error {{simultaneous accesses, but modification requires exclusive access; consider copying to a local variable}}
+  %5 = begin_access [modify] [unknown] %2 : $*Int // expected-error {{overlapping accesses, but modification requires exclusive access; consider copying to a local variable}}
   end_access %5 : $*Int
   end_access %4: $*Int
   destroy_value %1 : ${ var Int }
@@ -213,7 +213,7 @@ bb0(%0 : $Int):
   %1 = alloc_box ${ var Int }
   %2 = project_box %1 : ${ var Int }, 0
   store %0 to [trivial] %2 : $*Int
-  %4 = begin_access [modify] [unknown] %2 : $*Int // expected-error {{simultaneous accesses, but modification requires exclusive access; consider copying to a local variable}}
+  %4 = begin_access [modify] [unknown] %2 : $*Int // expected-error {{overlapping accesses, but modification requires exclusive access; consider copying to a local variable}}
   %5 = begin_access [read] [unknown] %2 : $*Int // expected-note {{conflicting access is here}}
   end_access %5 : $*Int
   end_access %4: $*Int
@@ -232,7 +232,7 @@ sil hidden @classStoredProperty : $@convention(thin) (ClassWithStoredProperty) -
 bb0(%0 : $ClassWithStoredProperty):
   %1 = ref_element_addr %0 : $ClassWithStoredProperty, #ClassWithStoredProperty.f
 
-  // expected-error@+1{{simultaneous accesses to var 'f', but modification requires exclusive access; consider copying to a local variable}}
+  // expected-error@+1{{overlapping accesses to 'f', but modification requires exclusive access; consider copying to a local variable}}
   %2 = begin_access [modify] [dynamic] %1 : $*Int
   %3 = ref_element_addr %0 : $ClassWithStoredProperty, #ClassWithStoredProperty.f
 
@@ -252,7 +252,7 @@ bb0(%0 : $ClassWithStoredProperty):
   %2 = begin_borrow %0 : $ClassWithStoredProperty
   %3 = ref_element_addr %1 : $ClassWithStoredProperty, #ClassWithStoredProperty.f
 
-  // expected-error@+1{{simultaneous accesses to var 'f', but modification requires exclusive access; consider copying to a local variable}}
+  // expected-error@+1{{overlapping accesses to 'f', but modification requires exclusive access; consider copying to a local variable}}
   %4 = begin_access [modify] [dynamic] %3 : $*Int
   %5 = ref_element_addr %2 : $ClassWithStoredProperty, #ClassWithStoredProperty.f
 
@@ -279,7 +279,7 @@ bb0(%0 : $Int):
   store %0 to [trivial] %3 : $*Int
   %4 = copy_value %2 : ${ var Int }
   %5 = project_box %4 : ${ var Int }, 0
-  %6 = begin_access [modify] [unknown] %3 : $*Int  // expected-error {{simultaneous accesses, but modification requires exclusive access; consider copying to a local variable}}
+  %6 = begin_access [modify] [unknown] %3 : $*Int  // expected-error {{overlapping accesses, but modification requires exclusive access; consider copying to a local variable}}
   %7 = begin_access [modify] [unknown] %5 : $*Int  // expected-note {{conflicting access is here}}
   end_access %7 : $*Int
   end_access %6: $*Int
@@ -297,7 +297,7 @@ bb0(%0 : $Int):
   %3 = project_box %2 : ${ var Int }, 0
   store %0 to [trivial] %3 : $*Int
   %4 = project_box %2 : ${ var Int }, 0
-  %5 = begin_access [modify] [unknown] %3 : $*Int  // expected-error {{simultaneous accesses, but modification requires exclusive access; consider copying to a local variable}}
+  %5 = begin_access [modify] [unknown] %3 : $*Int  // expected-error {{overlapping accesses, but modification requires exclusive access; consider copying to a local variable}}
   %6 = begin_access [modify] [unknown] %4 : $*Int  // expected-note {{conflicting access is here}}
   end_access %6 : $*Int
   end_access %5: $*Int
@@ -315,7 +315,7 @@ sil hidden @modifySameGlobal : $@convention(thin) (Int) -> () {
 bb0(%0 : $Int):
   %1 = global_addr @global1 :$*Int
   %2 = global_addr @global1 :$*Int
-  %3 = begin_access [modify] [unknown] %1 : $*Int  // expected-error {{simultaneous accesses, but modification requires exclusive access; consider copying to a local variable}}
+  %3 = begin_access [modify] [unknown] %1 : $*Int  // expected-error {{overlapping accesses, but modification requires exclusive access; consider copying to a local variable}}
   %4 = begin_access [modify] [unknown] %2 : $*Int  // expected-note {{conflicting access is here}}
   end_access %4 : $*Int
   end_access %3: $*Int
@@ -348,7 +348,7 @@ bb0(%0 : $Int):
   store %0 to [trivial] %3 : $*Int
   %4 = function_ref @takesTwoInouts : $@convention(thin) (@inout Int, @inout Int) -> ()
   %5 = begin_access [read] [unknown] %3 : $*Int  // expected-note {{conflicting access is here}}
-  %6 = begin_access [modify] [unknown] %3 : $*Int  // expected-error {{simultaneous accesses, but modification requires exclusive access; consider copying to a local variable}}
+  %6 = begin_access [modify] [unknown] %3 : $*Int  // expected-error {{overlapping accesses, but modification requires exclusive access; consider copying to a local variable}}
   %7 = begin_access [read] [unknown] %3 : $*Int // no-error
   %8 = apply %4(%5, %6) : $@convention(thin) (@inout Int, @inout Int) -> ()
   end_access %7 : $*Int
@@ -368,7 +368,7 @@ bb0(%0 : $Int):
   %3 = project_box %2 : ${ var Int }, 0
   store %0 to [trivial] %3 : $*Int
   %4 = function_ref @takesTwoInouts : $@convention(thin) (@inout Int, @inout Int) -> ()
-  %5 = begin_access [modify] [unknown] %3 : $*Int  // expected-error {{simultaneous accesses, but modification requires exclusive access; consider copying to a local variable}}
+  %5 = begin_access [modify] [unknown] %3 : $*Int  // expected-error {{overlapping accesses, but modification requires exclusive access; consider copying to a local variable}}
   %6 = begin_access [modify] [unknown] %3 : $*Int  // expected-note {{conflicting access is here}}
   %7 = begin_access [modify] [unknown] %3 : $*Int  // no-error
   %8 = apply %4(%5, %6) : $@convention(thin) (@inout Int, @inout Int) -> ()
@@ -392,7 +392,7 @@ bb0(%0 : $Int):
   %4 = function_ref @takesTwoInouts : $@convention(thin) (@inout Int, @inout Int) -> ()
   %5 = begin_access [modify] [unknown] %3 : $*Int  // no-note
   end_access %5 : $*Int
-  %6 = begin_access [modify] [unknown] %3 : $*Int  // expected-error {{simultaneous accesses, but modification requires exclusive access; consider copying to a local variable}}
+  %6 = begin_access [modify] [unknown] %3 : $*Int  // expected-error {{overlapping accesses, but modification requires exclusive access; consider copying to a local variable}}
   %7 = begin_access [modify] [unknown] %3 : $*Int  // expected-note {{conflicting access is here}}
   %8 = apply %4(%5, %6) : $@convention(thin) (@inout Int, @inout Int) -> ()
   end_access %7 : $*Int
@@ -606,7 +606,7 @@ bb0(%0 : $Int):
   %2 = alloc_box ${ var StructWithStoredProps }
   %3 = project_box %2 : ${ var StructWithStoredProps }, 0
   %4 = function_ref @takesTwoInouts : $@convention(thin) (@inout Int, @inout Int) -> ()
-  %5 = begin_access [modify] [unknown] %3 : $*StructWithStoredProps // expected-error {{simultaneous accesses, but modification requires exclusive access; consider copying to a local variable}}
+  %5 = begin_access [modify] [unknown] %3 : $*StructWithStoredProps // expected-error {{overlapping accesses, but modification requires exclusive access; consider copying to a local variable}}
   %6 = struct_element_addr %5 : $*StructWithStoredProps, #StructWithStoredProps.x
   %7 = begin_access [modify] [unknown] %3 : $*StructWithStoredProps // expected-note {{conflicting access is here}}
   %8 = struct_element_addr %7 : $*StructWithStoredProps, #StructWithStoredProps.x
@@ -624,7 +624,7 @@ bb0(%0 : $Int):
   %2 = alloc_box ${ var StructWithStoredProps }
   %3 = project_box %2 : ${ var StructWithStoredProps }, 0
   %4 = function_ref @takesInoutIntAndStructWithStoredProps : $@convention(thin) (@inout Int, @inout StructWithStoredProps) -> ()
-  %5 = begin_access [modify] [unknown] %3 : $*StructWithStoredProps // expected-error {{simultaneous accesses, but modification requires exclusive access; consider copying to a local variable}}
+  %5 = begin_access [modify] [unknown] %3 : $*StructWithStoredProps // expected-error {{overlapping accesses, but modification requires exclusive access; consider copying to a local variable}}
   %6 = struct_element_addr %5 : $*StructWithStoredProps, #StructWithStoredProps.x
   %7 = begin_access [modify] [unknown] %3 : $*StructWithStoredProps // expected-note {{conflicting access is here}}
   %8 = apply %4(%6, %7) : $@convention(thin) (@inout Int, @inout StructWithStoredProps) -> ()
@@ -641,7 +641,7 @@ bb0(%0 : $Int):
   %2 = alloc_box ${ var StructWithStoredProps }
   %3 = project_box %2 : ${ var StructWithStoredProps }, 0
   %4 = function_ref @takesInoutIntAndStructWithStoredProps : $@convention(thin) (@inout Int, @inout StructWithStoredProps) -> ()
-  %5 = begin_access [modify] [unknown] %3 : $*StructWithStoredProps // expected-error {{simultaneous accesses, but modification requires exclusive access; consider copying to a local variable}}
+  %5 = begin_access [modify] [unknown] %3 : $*StructWithStoredProps // expected-error {{overlapping accesses, but modification requires exclusive access; consider copying to a local variable}}
   %6 = struct_element_addr %5 : $*StructWithStoredProps, #StructWithStoredProps.n
   %7 = struct_element_addr %6 : $*NestedStructWithStoredProps, #NestedStructWithStoredProps.a
   %8 = begin_access [modify] [unknown] %3 : $*StructWithStoredProps // expected-note {{conflicting access is here}}
@@ -677,7 +677,7 @@ bb0(%0 : $Int):
   %2 = alloc_box ${ var (Int, Int) }
   %3 = project_box %2 : ${ var (Int, Int) }, 0
   %4 = function_ref @takesTwoInouts : $@convention(thin) (@inout Int, @inout Int) -> ()
-  %5 = begin_access [modify] [unknown] %3 : $*(Int, Int) // expected-error {{simultaneous accesses, but modification requires exclusive access; consider copying to a local variable}}
+  %5 = begin_access [modify] [unknown] %3 : $*(Int, Int) // expected-error {{overlapping accesses, but modification requires exclusive access; consider copying to a local variable}}
   %6 = tuple_element_addr %5 : $*(Int, Int), 0
   %7 = begin_access [modify] [unknown] %3 : $*(Int, Int) // expected-note {{conflicting access is here}}
   %8 = tuple_element_addr %7 : $*(Int, Int), 0

--- a/test/SILOptimizer/exclusivity_static_diagnostics.sil
+++ b/test/SILOptimizer/exclusivity_static_diagnostics.sil
@@ -545,3 +545,146 @@ bb0(%0 : $Storage, %1 : $Builtin.Word):
   end_access %3 : $*UInt
   return %8 : $Int
 }
+
+// Stored property relaxation.
+
+struct NestedStructWithStoredProps {
+  var a: Int
+  var b: Int
+}
+
+struct StructWithStoredProps {
+  var x: Int
+  var y: Int
+
+  var n: NestedStructWithStoredProps
+}
+
+sil @takesInoutIntAndStructWithStoredProps : $@convention(thin) (@inout Int, @inout StructWithStoredProps) -> ()
+
+// CHECK-LABEL: sil hidden @twoSeparateStoredProperties
+sil hidden @twoSeparateStoredProperties : $@convention(thin) (Int) -> () {
+bb0(%0 : $Int):
+  %2 = alloc_box ${ var StructWithStoredProps }
+  %3 = project_box %2 : ${ var StructWithStoredProps }, 0
+  %4 = function_ref @takesTwoInouts : $@convention(thin) (@inout Int, @inout Int) -> ()
+  %5 = begin_access [modify] [unknown] %3 : $*StructWithStoredProps
+  %6 = struct_element_addr %5 : $*StructWithStoredProps, #StructWithStoredProps.x
+  %7 = begin_access [modify] [unknown] %3 : $*StructWithStoredProps // no-error
+  %8 = struct_element_addr %7 : $*StructWithStoredProps, #StructWithStoredProps.y
+  %9 = apply %4(%6, %8) : $@convention(thin) (@inout Int, @inout Int) -> ()
+  end_access %7 : $*StructWithStoredProps
+  end_access %5: $*StructWithStoredProps
+  destroy_value %2 : ${ var StructWithStoredProps }
+  %10 = tuple ()
+  return %10 : $()
+}
+
+// CHECK-LABEL: sil hidden @twoSeparateNestedStoredProperties
+sil hidden @twoSeparateNestedStoredProperties : $@convention(thin) (Int) -> () {
+bb0(%0 : $Int):
+  %2 = alloc_box ${ var StructWithStoredProps }
+  %3 = project_box %2 : ${ var StructWithStoredProps }, 0
+  %4 = function_ref @takesTwoInouts : $@convention(thin) (@inout Int, @inout Int) -> ()
+  %5 = begin_access [modify] [unknown] %3 : $*StructWithStoredProps
+  %6 = struct_element_addr %5 : $*StructWithStoredProps, #StructWithStoredProps.n
+  %7 = struct_element_addr %6 : $*NestedStructWithStoredProps, #NestedStructWithStoredProps.a
+  %8 = begin_access [modify] [unknown] %3 : $*StructWithStoredProps // no-error
+  %9 = struct_element_addr %8 : $*StructWithStoredProps, #StructWithStoredProps.n
+  %10 = struct_element_addr %9 : $*NestedStructWithStoredProps, #NestedStructWithStoredProps.b
+  %11 = apply %4(%7, %10) : $@convention(thin) (@inout Int, @inout Int) -> ()
+  end_access %8 : $*StructWithStoredProps
+  end_access %5: $*StructWithStoredProps
+  destroy_value %2 : ${ var StructWithStoredProps }
+  %12 = tuple ()
+  return %12 : $()
+}
+
+// CHECK-LABEL: sil hidden @theSameStoredProperty
+sil hidden @theSameStoredProperty : $@convention(thin) (Int) -> () {
+bb0(%0 : $Int):
+  %2 = alloc_box ${ var StructWithStoredProps }
+  %3 = project_box %2 : ${ var StructWithStoredProps }, 0
+  %4 = function_ref @takesTwoInouts : $@convention(thin) (@inout Int, @inout Int) -> ()
+  %5 = begin_access [modify] [unknown] %3 : $*StructWithStoredProps // expected-error {{simultaneous accesses, but modification requires exclusive access; consider copying to a local variable}}
+  %6 = struct_element_addr %5 : $*StructWithStoredProps, #StructWithStoredProps.x
+  %7 = begin_access [modify] [unknown] %3 : $*StructWithStoredProps // expected-note {{conflicting access is here}}
+  %8 = struct_element_addr %7 : $*StructWithStoredProps, #StructWithStoredProps.x
+  %9 = apply %4(%6, %8) : $@convention(thin) (@inout Int, @inout Int) -> ()
+  end_access %7 : $*StructWithStoredProps
+  end_access %5: $*StructWithStoredProps
+  destroy_value %2 : ${ var StructWithStoredProps }
+  %10 = tuple ()
+  return %10 : $()
+}
+
+// CHECK-LABEL: sil hidden @storedPropertyAndAggregate
+sil hidden @storedPropertyAndAggregate : $@convention(thin) (Int) -> () {
+bb0(%0 : $Int):
+  %2 = alloc_box ${ var StructWithStoredProps }
+  %3 = project_box %2 : ${ var StructWithStoredProps }, 0
+  %4 = function_ref @takesInoutIntAndStructWithStoredProps : $@convention(thin) (@inout Int, @inout StructWithStoredProps) -> ()
+  %5 = begin_access [modify] [unknown] %3 : $*StructWithStoredProps // expected-error {{simultaneous accesses, but modification requires exclusive access; consider copying to a local variable}}
+  %6 = struct_element_addr %5 : $*StructWithStoredProps, #StructWithStoredProps.x
+  %7 = begin_access [modify] [unknown] %3 : $*StructWithStoredProps // expected-note {{conflicting access is here}}
+  %8 = apply %4(%6, %7) : $@convention(thin) (@inout Int, @inout StructWithStoredProps) -> ()
+  end_access %7 : $*StructWithStoredProps
+  end_access %5: $*StructWithStoredProps
+  destroy_value %2 : ${ var StructWithStoredProps }
+  %9 = tuple ()
+  return %9 : $()
+}
+
+// CHECK-LABEL: sil hidden @nestedStoredPropertyAndAggregate
+sil hidden @nestedStoredPropertyAndAggregate : $@convention(thin) (Int) -> () {
+bb0(%0 : $Int):
+  %2 = alloc_box ${ var StructWithStoredProps }
+  %3 = project_box %2 : ${ var StructWithStoredProps }, 0
+  %4 = function_ref @takesInoutIntAndStructWithStoredProps : $@convention(thin) (@inout Int, @inout StructWithStoredProps) -> ()
+  %5 = begin_access [modify] [unknown] %3 : $*StructWithStoredProps // expected-error {{simultaneous accesses, but modification requires exclusive access; consider copying to a local variable}}
+  %6 = struct_element_addr %5 : $*StructWithStoredProps, #StructWithStoredProps.n
+  %7 = struct_element_addr %6 : $*NestedStructWithStoredProps, #NestedStructWithStoredProps.a
+  %8 = begin_access [modify] [unknown] %3 : $*StructWithStoredProps // expected-note {{conflicting access is here}}
+  %9 = struct_element_addr %8 : $*StructWithStoredProps, #StructWithStoredProps.n
+  end_access %8 : $*StructWithStoredProps
+  end_access %5: $*StructWithStoredProps
+  destroy_value %2 : ${ var StructWithStoredProps }
+  %10 = tuple ()
+  return %10 : $()
+}
+
+// CHECK-LABEL: sil hidden @twoSeparateTupleElements
+sil hidden @twoSeparateTupleElements : $@convention(thin) (Int) -> () {
+bb0(%0 : $Int):
+  %2 = alloc_box ${ var (Int, Int) }
+  %3 = project_box %2 : ${ var (Int, Int) }, 0
+  %4 = function_ref @takesTwoInouts : $@convention(thin) (@inout Int, @inout Int) -> ()
+  %5 = begin_access [modify] [unknown] %3 : $*(Int, Int)
+  %6 = tuple_element_addr %5 : $*(Int, Int), 0
+  %7 = begin_access [modify] [unknown] %3 : $*(Int, Int) // no-error
+  %8 = tuple_element_addr %7 : $*(Int, Int), 1
+  %9 = apply %4(%6, %8) : $@convention(thin) (@inout Int, @inout Int) -> ()
+  end_access %7 : $*(Int, Int)
+  end_access %5: $*(Int, Int)
+  destroy_value %2 : ${ var (Int, Int) }
+  %10 = tuple ()
+  return %10 : $()
+}
+
+// CHECK-LABEL: sil hidden @sameTupleElement
+sil hidden @sameTupleElement : $@convention(thin) (Int) -> () {
+bb0(%0 : $Int):
+  %2 = alloc_box ${ var (Int, Int) }
+  %3 = project_box %2 : ${ var (Int, Int) }, 0
+  %4 = function_ref @takesTwoInouts : $@convention(thin) (@inout Int, @inout Int) -> ()
+  %5 = begin_access [modify] [unknown] %3 : $*(Int, Int) // expected-error {{simultaneous accesses, but modification requires exclusive access; consider copying to a local variable}}
+  %6 = tuple_element_addr %5 : $*(Int, Int), 0
+  %7 = begin_access [modify] [unknown] %3 : $*(Int, Int) // expected-note {{conflicting access is here}}
+  %8 = tuple_element_addr %7 : $*(Int, Int), 0
+  %9 = apply %4(%6, %8) : $@convention(thin) (@inout Int, @inout Int) -> ()
+  end_access %7 : $*(Int, Int)
+  end_access %5: $*(Int, Int)
+  destroy_value %2 : ${ var (Int, Int) }
+  %10 = tuple ()
+  return %10 : $()
+}

--- a/test/SILOptimizer/exclusivity_static_diagnostics.swift
+++ b/test/SILOptimizer/exclusivity_static_diagnostics.swift
@@ -92,8 +92,8 @@ func violationWithGenericType<T>(_ p: T) {
 
 // Helper.
 struct StructWithTwoStoredProp {
-  var f1: Int
-  var f2: Int
+  var f1: Int = 7
+  var f2: Int = 8
 }
 
 // Take an unsafe pointer to a stored property while accessing another stored property.
@@ -181,4 +181,42 @@ struct StructWithFixits {
     // expected-note@+1{{conflicting access is here}}
     mySwap(&array1[i], &array1[j])
   }
+}
+
+func inoutSeparateStructStoredProperties() {
+  var s = StructWithTwoStoredProp()
+  takesTwoInouts(&s.f1, &s.f2) // no-error
+}
+
+func inoutSameStoredProperty() {
+  var s = StructWithTwoStoredProp()
+  takesTwoInouts(&s.f1, &s.f1)
+  // expected-error@-1{{simultaneous accesses to var 's.f1', but modification requires exclusive access; consider copying to a local variable}}
+  // expected-note@-2{{conflicting access is here}}
+}
+
+func inoutSeparateTupleElements() {
+  var t = (1, 4)
+  takesTwoInouts(&t.0, &t.1) // no-error
+}
+
+func inoutSameTupleElement() {
+  var t = (1, 4)
+  takesTwoInouts(&t.0, &t.0) // no-error
+  // expected-error@-1{{simultaneous accesses to var 't.0', but modification requires exclusive access; consider copying to a local variable}}
+  // expected-note@-2{{conflicting access is here}}
+}
+
+func inoutSameTupleNamedElement() {
+  var t = (name1: 1, name2: 4)
+  takesTwoInouts(&t.name2, &t.name2) // no-error
+  // expected-error@-1{{simultaneous accesses to var 't.name2', but modification requires exclusive access; consider copying to a local variable}}
+  // expected-note@-2{{conflicting access is here}}
+}
+
+func inoutSamePropertyInSameTuple() {
+  var t = (name1: 1, name2: StructWithTwoStoredProp())
+  takesTwoInouts(&t.name2.f1, &t.name2.f1) // no-error
+  // expected-error@-1{{simultaneous accesses to var 't.name2.f1', but modification requires exclusive access; consider copying to a local variable}}
+  // expected-note@-2{{conflicting access is here}}
 }

--- a/test/SILOptimizer/exclusivity_static_diagnostics.swift
+++ b/test/SILOptimizer/exclusivity_static_diagnostics.swift
@@ -202,21 +202,21 @@ func inoutSeparateTupleElements() {
 
 func inoutSameTupleElement() {
   var t = (1, 4)
-  takesTwoInouts(&t.0, &t.0) // no-error
+  takesTwoInouts(&t.0, &t.0)
   // expected-error@-1{{overlapping accesses to 't.0', but modification requires exclusive access; consider copying to a local variable}}
   // expected-note@-2{{conflicting access is here}}
 }
 
 func inoutSameTupleNamedElement() {
   var t = (name1: 1, name2: 4)
-  takesTwoInouts(&t.name2, &t.name2) // no-error
+  takesTwoInouts(&t.name2, &t.name2)
   // expected-error@-1{{overlapping accesses to 't.name2', but modification requires exclusive access; consider copying to a local variable}}
   // expected-note@-2{{conflicting access is here}}
 }
 
 func inoutSamePropertyInSameTuple() {
   var t = (name1: 1, name2: StructWithTwoStoredProp())
-  takesTwoInouts(&t.name2.f1, &t.name2.f1) // no-error
+  takesTwoInouts(&t.name2.f1, &t.name2.f1)
   // expected-error@-1{{overlapping accesses to 't.name2.f1', but modification requires exclusive access; consider copying to a local variable}}
   // expected-note@-2{{conflicting access is here}}
 }

--- a/test/SILOptimizer/exclusivity_static_diagnostics_swift3.swift
+++ b/test/SILOptimizer/exclusivity_static_diagnostics_swift3.swift
@@ -24,7 +24,7 @@ struct X {
 func diagnoseOnSameField() {
   var x = X()
 
-  // expected-warning@+2{{simultaneous accesses to var 'x', but modification requires exclusive access; consider copying to a local variable}}
+  // expected-warning@+2{{simultaneous accesses to var 'x.f', but modification requires exclusive access; consider copying to a local variable}}
   // expected-note@+1{{conflicting access is here}}
   takesTwoInouts(&x.f, &x.f)
 }

--- a/test/SILOptimizer/exclusivity_static_diagnostics_swift3.swift
+++ b/test/SILOptimizer/exclusivity_static_diagnostics_swift3.swift
@@ -12,7 +12,7 @@ func simpleInoutDiagnostic() {
 
   // expected-error@+4{{inout arguments are not allowed to alias each other}}
   // expected-note@+3{{previous aliasing argument}}
-  // expected-warning@+2{{simultaneous accesses to var 'i', but modification requires exclusive access; consider copying to a local variable}}
+  // expected-warning@+2{{overlapping accesses to 'i', but modification requires exclusive access; consider copying to a local variable}}
   // expected-note@+1{{conflicting access is here}}
   takesTwoInouts(&i, &i)
 }
@@ -24,7 +24,7 @@ struct X {
 func diagnoseOnSameField() {
   var x = X()
 
-  // expected-warning@+2{{simultaneous accesses to var 'x.f', but modification requires exclusive access; consider copying to a local variable}}
+  // expected-warning@+2{{overlapping accesses to 'x.f', but modification requires exclusive access; consider copying to a local variable}}
   // expected-note@+1{{conflicting access is here}}
   takesTwoInouts(&x.f, &x.f)
 }


### PR DESCRIPTION
This is a series of commits that relaxes the intra-procedural static enforcement of exclusive access so that we no longer diagnose on accesses to separate stored structs of the same property.

https://bugs.swift.org/browse/SR-5119
rdar://problem/31909639

This PR includes the AccessSummaryAnalysis, although the only thing it is used for in this PR is the shared IndexTrie to represent projection paths. This PR doesn't actually run any of the inter procedural closure analysis. That will be CCC'd to swift-4.0 in a different in a different PR.