### PR TITLE
Fixed clang 4.0 compilation under Arch Linux with icu59.1-1

### DIFF
--- a/stdlib/public/stubs/UnicodeNormalization.cpp
+++ b/stdlib/public/stubs/UnicodeNormalization.cpp
@@ -88,7 +88,7 @@ private:
     for (unsigned char c = 0; c < 128; ++c) {
       UErrorCode ErrorCode = U_ZERO_ERROR;
       intptr_t NumCollationElts = 0;
-#if (defined(__CYGWIN__) || defined( _MSC_VER)) || defined(__linux__)
+#if defined(__CYGWIN__) || defined( _MSC_VER) || defined(__linux__)
       UChar Buffer[1];
 #else
       uint16_t Buffer[1];
@@ -129,11 +129,11 @@ swift::_swift_stdlib_unicode_compare_utf16_utf16(const uint16_t *LeftString,
                                                  int32_t LeftLength,
                                                  const uint16_t *RightString,
                                                  int32_t RightLength) {
-#if (defined(__CYGWIN__) || defined( _MSC_VER)) || defined(__linux__)
+#if defined(__CYGWIN__) || defined( _MSC_VER) || defined(__linux__)
   // ICU UChar type is platform dependent. In Cygwin, it is defined
   // as wchar_t which size is 2. It seems that the underlying binary
   // representation is same with swift utf16 representation.
-  // On clang 4.0 under a recent linux unicode uses the built-in char16_t type
+  // On Clang 4.0 under a recent Linux, ICU uses the built-in char16_t type.
   return ucol_strcoll(GetRootCollator(),
     reinterpret_cast<const UChar *>(LeftString), LeftLength,
     reinterpret_cast<const UChar *>(RightString), RightLength);
@@ -159,7 +159,7 @@ swift::_swift_stdlib_unicode_compare_utf8_utf16(const unsigned char *LeftString,
   UErrorCode ErrorCode = U_ZERO_ERROR;
 
   uiter_setUTF8(&LeftIterator, reinterpret_cast<const char *>(LeftString), LeftLength);
-#if (defined(__CYGWIN__) || defined( _MSC_VER)) || defined(__linux__)
+#if defined(__CYGWIN__) || defined( _MSC_VER) || defined(__linux__)
   uiter_setString(&RightIterator, reinterpret_cast<const UChar *>(RightString),
                   RightLength);
 #else
@@ -202,7 +202,7 @@ swift::_swift_stdlib_unicode_compare_utf8_utf8(const unsigned char *LeftString,
 void *swift::_swift_stdlib_unicodeCollationIterator_create(
     const __swift_uint16_t *Str, __swift_uint32_t Length) {
   UErrorCode ErrorCode = U_ZERO_ERROR;
-#if (defined(__CYGWIN__) || defined( _MSC_VER)) || defined(__linux__)
+#if defined(__CYGWIN__) || defined( _MSC_VER) || defined(__linux__)
   UCollationElements *CollationIterator = ucol_openElements(
     GetRootCollator(), reinterpret_cast<const UChar *>(Str), Length,
     &ErrorCode);
@@ -247,7 +247,7 @@ swift::_swift_stdlib_unicode_strToUpper(uint16_t *Destination,
                                         const uint16_t *Source,
                                         int32_t SourceLength) {
   UErrorCode ErrorCode = U_ZERO_ERROR;
-#if (defined(__CYGWIN__) || defined( _MSC_VER)) || defined(__linux__)
+#if defined(__CYGWIN__) || defined( _MSC_VER) || defined(__linux__)
   uint32_t OutputLength = u_strToUpper(reinterpret_cast<UChar *>(Destination),
                                        DestinationCapacity,
                                        reinterpret_cast<const UChar *>(Source),
@@ -274,7 +274,7 @@ swift::_swift_stdlib_unicode_strToLower(uint16_t *Destination,
                                         const uint16_t *Source,
                                         int32_t SourceLength) {
   UErrorCode ErrorCode = U_ZERO_ERROR;
-#if (defined(__CYGWIN__) || defined( _MSC_VER)) || defined(__linux__)
+#if defined(__CYGWIN__) || defined( _MSC_VER) || defined(__linux__)
   uint32_t OutputLength = u_strToLower(reinterpret_cast<UChar *>(Destination),
                                        DestinationCapacity,
                                        reinterpret_cast<const UChar *>(Source),
@@ -333,9 +333,10 @@ void swift::__swift_stdlib_ubrk_close(
 swift::__swift_stdlib_UBreakIterator *swift::__swift_stdlib_ubrk_open(
     swift::__swift_stdlib_UBreakIteratorType type, const char *locale,
     const uint16_t *text, int32_t textLength, __swift_stdlib_UErrorCode *status) {
-#if (defined(__CYGWIN__) || defined( _MSC_VER)) || defined(__linux__)
+#if defined(__CYGWIN__) || defined( _MSC_VER) || defined(__linux__)
   return ptr_cast<swift::__swift_stdlib_UBreakIterator>(
-      ubrk_open(static_cast<UBreakIteratorType>(type), locale, reinterpret_cast<const UChar*>(text), textLength,
+      ubrk_open(static_cast<UBreakIteratorType>(type), locale,
+		reinterpret_cast<const UChar*>(text), textLength,
                 ptr_cast<UErrorCode>(status)));
 #else      
   return ptr_cast<swift::__swift_stdlib_UBreakIterator>(

--- a/stdlib/public/stubs/UnicodeNormalization.cpp
+++ b/stdlib/public/stubs/UnicodeNormalization.cpp
@@ -36,10 +36,6 @@
 
 #pragma clang diagnostic pop
 
-// clang 4.0 under a recent linux has unicode with built-in char16_t support
-#if (defined(__CYGWIN__) || defined( _MSC_VER)) || defined(__linux__)
-#define __USE_UCHAR 1
-#endif
 
 static const UCollator *MakeRootCollator() {
   UErrorCode ErrorCode = U_ZERO_ERROR;
@@ -92,7 +88,7 @@ private:
     for (unsigned char c = 0; c < 128; ++c) {
       UErrorCode ErrorCode = U_ZERO_ERROR;
       intptr_t NumCollationElts = 0;
-#if defined(__USE_UCHAR)
+#if (defined(__CYGWIN__) || defined( _MSC_VER)) || defined(__linux__)
       UChar Buffer[1];
 #else
       uint16_t Buffer[1];
@@ -133,10 +129,11 @@ swift::_swift_stdlib_unicode_compare_utf16_utf16(const uint16_t *LeftString,
                                                  int32_t LeftLength,
                                                  const uint16_t *RightString,
                                                  int32_t RightLength) {
-#if defined(__USE_UCHAR)
+#if (defined(__CYGWIN__) || defined( _MSC_VER)) || defined(__linux__)
   // ICU UChar type is platform dependent. In Cygwin, it is defined
   // as wchar_t which size is 2. It seems that the underlying binary
   // representation is same with swift utf16 representation.
+  // On clang 4.0 under a recent linux unicode uses the built-in char16_t type
   return ucol_strcoll(GetRootCollator(),
     reinterpret_cast<const UChar *>(LeftString), LeftLength,
     reinterpret_cast<const UChar *>(RightString), RightLength);
@@ -162,7 +159,7 @@ swift::_swift_stdlib_unicode_compare_utf8_utf16(const unsigned char *LeftString,
   UErrorCode ErrorCode = U_ZERO_ERROR;
 
   uiter_setUTF8(&LeftIterator, reinterpret_cast<const char *>(LeftString), LeftLength);
-#if defined(__USE_UCHAR)
+#if (defined(__CYGWIN__) || defined( _MSC_VER)) || defined(__linux__)
   uiter_setString(&RightIterator, reinterpret_cast<const UChar *>(RightString),
                   RightLength);
 #else
@@ -205,7 +202,7 @@ swift::_swift_stdlib_unicode_compare_utf8_utf8(const unsigned char *LeftString,
 void *swift::_swift_stdlib_unicodeCollationIterator_create(
     const __swift_uint16_t *Str, __swift_uint32_t Length) {
   UErrorCode ErrorCode = U_ZERO_ERROR;
-#if defined(__USE_UCHAR)
+#if (defined(__CYGWIN__) || defined( _MSC_VER)) || defined(__linux__)
   UCollationElements *CollationIterator = ucol_openElements(
     GetRootCollator(), reinterpret_cast<const UChar *>(Str), Length,
     &ErrorCode);
@@ -250,7 +247,7 @@ swift::_swift_stdlib_unicode_strToUpper(uint16_t *Destination,
                                         const uint16_t *Source,
                                         int32_t SourceLength) {
   UErrorCode ErrorCode = U_ZERO_ERROR;
-#if defined(__USE_UCHAR)
+#if (defined(__CYGWIN__) || defined( _MSC_VER)) || defined(__linux__)
   uint32_t OutputLength = u_strToUpper(reinterpret_cast<UChar *>(Destination),
                                        DestinationCapacity,
                                        reinterpret_cast<const UChar *>(Source),
@@ -277,7 +274,7 @@ swift::_swift_stdlib_unicode_strToLower(uint16_t *Destination,
                                         const uint16_t *Source,
                                         int32_t SourceLength) {
   UErrorCode ErrorCode = U_ZERO_ERROR;
-#if defined(__USE_UCHAR)
+#if (defined(__CYGWIN__) || defined( _MSC_VER)) || defined(__linux__)
   uint32_t OutputLength = u_strToLower(reinterpret_cast<UChar *>(Destination),
                                        DestinationCapacity,
                                        reinterpret_cast<const UChar *>(Source),
@@ -336,7 +333,7 @@ void swift::__swift_stdlib_ubrk_close(
 swift::__swift_stdlib_UBreakIterator *swift::__swift_stdlib_ubrk_open(
     swift::__swift_stdlib_UBreakIteratorType type, const char *locale,
     const uint16_t *text, int32_t textLength, __swift_stdlib_UErrorCode *status) {
-#ifdef __USE_UCHAR
+#if (defined(__CYGWIN__) || defined( _MSC_VER)) || defined(__linux__)
   return ptr_cast<swift::__swift_stdlib_UBreakIterator>(
       ubrk_open(static_cast<UBreakIteratorType>(type), locale, reinterpret_cast<const UChar*>(text), textLength,
                 ptr_cast<UErrorCode>(status)));


### PR DESCRIPTION
I've modified the defines inside UnicodeNormalization.cpp in order to fix the compilation erros against clang-4.0. On my setup, UChar is defined as a built-in char16_t.

See original pull request: https://github.com/apple/swift/pull/10203