### PR TITLE
[swiftc (22 vs. 5563)] Add crasher in swift::ProtocolDecl::requiresClassSlow(...)

### DIFF
--- a/validation-test/compiler_crashers/28776-type-should-have-type-checked-inheritance-clause-by-now.swift
+++ b/validation-test/compiler_crashers/28776-type-should-have-type-checked-inheritance-clause-by-now.swift
@@ -1,0 +1,13 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol P{typealias a{}class a
+{}typealias a{}class a
+}{extension{class a:P
+protocol A:A


### PR DESCRIPTION
Add test case for crash triggered in `swift::ProtocolDecl::requiresClassSlow(...)`.

Current number of unresolved compiler crashers: 22 (5563 resolved)

/cc @slavapestov - just wanted to let you know that this crasher caused an assertion failure for the assertion `type && "Should have type checked inheritance clause by now"` added on 2017-04-28 by you in commit 0d4a0b7d :-)

Assertion failure in [`lib/AST/Decl.cpp (line 2989)`](https://github.com/apple/swift/blob/c9b59ed6441a930fe160724e709f0403838b22a9/lib/AST/Decl.cpp#L2989):

```
Assertion `type && "Should have type checked inheritance clause by now"' failed.

When executing: bool swift::ProtocolDecl::requiresClassSlow()
```

Assertion context:

```c++

  // Otherwise, check if the inheritance clause contains a
  // class-constrained existential.
  //
  // FIXME: Use the requirement signature if available.
  ProtocolDeclBits.RequiresClass = false;
  for (auto inherited : getInherited()) {
    auto type = inherited.getType();
    assert(type && "Should have type checked inheritance clause by now");
    if (type->isExistentialType()) {
      auto layout = type->getExistentialLayout();
```
Stack trace:

```
0 0x0000000003a5fdb8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3a5fdb8)
1 0x0000000003a604f6 SignalHandler(int) (/path/to/swift/bin/swift+0x3a604f6)
2 0x00007fa9bd99d390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007fa9bbec3428 gsignal /build/glibc-9tT8Do/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007fa9bbec502a abort /build/glibc-9tT8Do/glibc-2.23/stdlib/abort.c:91:0
5 0x00007fa9bbebbbd7 __assert_fail_base /build/glibc-9tT8Do/glibc-2.23/assert/assert.c:92:0
6 0x00007fa9bbebbc82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x0000000001532956 swift::ProtocolDecl::requiresClassSlow() (/path/to/swift/bin/swift+0x1532956)
8 0x00000000014ddfb5 swift::ASTVisitor<(anonymous namespace)::PrintAST, void, void, void, void, void, void>::visit(swift::Decl*) (/path/to/swift/bin/swift+0x14ddfb5)
9 0x00000000014d4be7 (anonymous namespace)::PrintAST::visit(swift::Decl*) (/path/to/swift/bin/swift+0x14d4be7)
10 0x00000000014e0985 (anonymous namespace)::PrintAST::printMembersOfDecl(swift::Decl*, bool, bool, bool) (/path/to/swift/bin/swift+0x14e0985)
11 0x00000000014ded89 swift::ASTVisitor<(anonymous namespace)::PrintAST, void, void, void, void, void, void>::visit(swift::Decl*) (/path/to/swift/bin/swift+0x14ded89)
12 0x00000000014d4be7 (anonymous namespace)::PrintAST::visit(swift::Decl*) (/path/to/swift/bin/swift+0x14d4be7)
13 0x00000000014d493b swift::Decl::print(swift::ASTPrinter&, swift::PrintOptions const&) const (/path/to/swift/bin/swift+0x14d493b)
14 0x0000000001543402 swift::DiagnosticEngine::emitDiagnostic(swift::Diagnostic const&) (/path/to/swift/bin/swift+0x1543402)
15 0x0000000001540a8f swift::DiagnosticEngine::flushActiveDiagnostic() (/path/to/swift/bin/swift+0x1540a8f)
16 0x000000000139cac1 std::_Function_handler<void (swift::NormalProtocolConformance*), (anonymous namespace)::ConformanceChecker::resolveTypeWitnessViaLookup(swift::AssociatedTypeDecl*)::$_31>::_M_invoke(std::_Any_data const&, swift::NormalProtocolConformance*&&) (/path/to/swift/bin/swift+0x139cac1)
17 0x0000000001389c55 (anonymous namespace)::ConformanceChecker::diagnoseOrDefer(swift::ValueDecl*, bool, std::function<void (swift::NormalProtocolConformance*)>) (/path/to/swift/bin/swift+0x1389c55)
18 0x0000000001399428 (anonymous namespace)::ConformanceChecker::resolveTypeWitnessViaLookup(swift::AssociatedTypeDecl*) (/path/to/swift/bin/swift+0x1399428)
19 0x000000000138657a (anonymous namespace)::ConformanceChecker::resolveTypeWitnesses() (/path/to/swift/bin/swift+0x138657a)
20 0x00000000013819ee (anonymous namespace)::MultiConformanceChecker::checkAllConformances() (/path/to/swift/bin/swift+0x13819ee)
21 0x00000000013830f2 swift::TypeChecker::checkConformancesInContext(swift::DeclContext*, swift::IterableDeclContext*) (/path/to/swift/bin/swift+0x13830f2)
22 0x000000000135290e (anonymous namespace)::DeclChecker::visitClassDecl(swift::ClassDecl*) (/path/to/swift/bin/swift+0x135290e)
23 0x0000000001341f7e (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x1341f7e)
24 0x00000000013521cb (anonymous namespace)::DeclChecker::visitExtensionDecl(swift::ExtensionDecl*) (/path/to/swift/bin/swift+0x13521cb)
25 0x0000000001341eb4 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x1341eb4)
26 0x0000000001341d83 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x1341d83)
27 0x00000000013aee16 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13aee16)
28 0x00000000013ae4cb swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) (/path/to/swift/bin/swift+0x13ae4cb)
29 0x00000000013d246c swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) (/path/to/swift/bin/swift+0x13d246c)
30 0x000000000132b20d swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x132b20d)
31 0x00000000013aee75 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13aee75)
32 0x00000000013ae686 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0x13ae686)
33 0x00000000013ccb70 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x13ccb70)
34 0x0000000000f93b16 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf93b16)
35 0x00000000004ab3d9 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4ab3d9)
36 0x00000000004a996c swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a996c)
37 0x00000000004655c7 main (/path/to/swift/bin/swift+0x4655c7)
38 0x00007fa9bbeae830 __libc_start_main /build/glibc-9tT8Do/glibc-2.23/csu/../csu/libc-start.c:325:0
39 0x0000000000462c69 _start (/path/to/swift/bin/swift+0x462c69)
```