### PR TITLE
[swiftc (23 vs. 5563)] Add crasher in swift::TypeBase::getCanonicalType(...)

### DIFF
--- a/validation-test/compiler_crashers/28777-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers/28777-swift-typebase-getcanonicaltype.swift
@@ -1,0 +1,11 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+{
+f
+typealias a:b{}var f=a.a


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeBase::getCanonicalType(...)`.

Current number of unresolved compiler crashers: 23 (5563 resolved)

Stack trace:

```
0 0x0000000003a5fdb8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3a5fdb8)
1 0x0000000003a604f6 SignalHandler(int) (/path/to/swift/bin/swift+0x3a604f6)
2 0x00007fad0da22390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00000000015b1974 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x15b1974)
4 0x0000000001334eb1 (anonymous namespace)::PreCheckExpression::simplifyTypeExpr(swift::Expr*) (/path/to/swift/bin/swift+0x1334eb1)
5 0x0000000001333bf7 (anonymous namespace)::PreCheckExpression::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0x1333bf7)
6 0x000000000150bdfc swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x150bdfc)
7 0x00000000013276d5 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0x13276d5)
8 0x000000000132b112 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x132b112)
9 0x000000000132f264 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*, bool) (/path/to/swift/bin/swift+0x132f264)
10 0x000000000132f4c6 swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int, bool) (/path/to/swift/bin/swift+0x132f4c6)
11 0x0000000001347af8 validatePatternBindingEntries(swift::TypeChecker&, swift::PatternBindingDecl*) (/path/to/swift/bin/swift+0x1347af8)
12 0x0000000001343e88 swift::TypeChecker::validateDecl(swift::ValueDecl*) (/path/to/swift/bin/swift+0x1343e88)
13 0x0000000001325bca swift::TypeChecker::resolveDeclRefExpr(swift::UnresolvedDeclRefExpr*, swift::DeclContext*) (/path/to/swift/bin/swift+0x1325bca)
14 0x00000000013335a2 (anonymous namespace)::PreCheckExpression::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x13335a2)
15 0x000000000150bdab swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x150bdab)
16 0x00000000013276d5 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0x13276d5)
17 0x000000000132b112 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x132b112)
18 0x00000000013aee75 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13aee75)
19 0x00000000013ae4cb swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) (/path/to/swift/bin/swift+0x13ae4cb)
20 0x00000000013d246c swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) (/path/to/swift/bin/swift+0x13d246c)
21 0x000000000132b20d swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x132b20d)
22 0x00000000013aee75 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13aee75)
23 0x00000000013ae686 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0x13ae686)
24 0x00000000013ccb70 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x13ccb70)
25 0x0000000000f93b16 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf93b16)
26 0x00000000004ab3d9 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4ab3d9)
27 0x00000000004a996c swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a996c)
28 0x00000000004655c7 main (/path/to/swift/bin/swift+0x4655c7)
29 0x00007fad0bf33830 __libc_start_main /build/glibc-9tT8Do/glibc-2.23/csu/../csu/libc-start.c:325:0
30 0x0000000000462c69 _start (/path/to/swift/bin/swift+0x462c69)
```