### PR TITLE
[swiftc (24 vs. 5563)] Add crasher in swift::ValueDecl::getFormalAccess

### DIFF
--- a/validation-test/compiler_crashers/28778-hasaccessibility-accessibility-not-computed-yet.swift
+++ b/validation-test/compiler_crashers/28778-hasaccessibility-accessibility-not-computed-yet.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+extension{let d=r protocol A{{}extension{func<(Int=


### PR DESCRIPTION
Add test case for crash triggered in `swift::ValueDecl::getFormalAccess`.

Current number of unresolved compiler crashers: 24 (5563 resolved)

/cc @jrose-apple - just wanted to let you know that this crasher caused an assertion failure for the assertion `hasAccessibility() && "accessibility not computed yet"` added on 2014-06-24 by you in commit 6cca3529e :-)

Assertion failure in [`include/swift/AST/Decl.h (line 2178)`](https://github.com/apple/swift/blob/fbb153b75979ec44eb995ab3a70660da0c3dc0e8/include/swift/AST/Decl.h#L2178):

```
Assertion `hasAccessibility() && "accessibility not computed yet"' failed.

When executing: swift::Accessibility swift::ValueDecl::getFormalAccess(const swift::DeclContext *, bool) const
```

Assertion context:

```c++
  /// taken into account.
  ///
  /// \sa getFormalAccessScope
  Accessibility getFormalAccess(const DeclContext *useDC = nullptr,
                                bool respectVersionedAttr = false) const {
    assert(hasAccessibility() && "accessibility not computed yet");
    Accessibility result = TypeAndAccess.getInt().getValue();
    if (respectVersionedAttr &&
        result == Accessibility::Internal &&
        isVersionedInternalDecl()) {
      assert(!useDC);
```
Stack trace:

```
0 0x0000000003a5fdb8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3a5fdb8)
1 0x0000000003a604f6 SignalHandler(int) (/path/to/swift/bin/swift+0x3a604f6)
2 0x00007f236baba390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007f2369fe0428 gsignal /build/glibc-9tT8Do/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f2369fe202a abort /build/glibc-9tT8Do/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f2369fd8bd7 __assert_fail_base /build/glibc-9tT8Do/glibc-2.23/assert/assert.c:92:0
6 0x00007f2369fd8c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x000000000152ea73 swift::ValueDecl::getFormalAccess(swift::DeclContext const*, bool) const (/path/to/swift/bin/swift+0x152ea73)
8 0x000000000152c3b6 swift::ValueDecl::getFormalAccessScope(swift::DeclContext const*, bool) const (/path/to/swift/bin/swift+0x152c3b6)
9 0x000000000153c371 swift::DeclContext::getResilienceExpansion() const (/path/to/swift/bin/swift+0x153c371)
10 0x000000000145b552 swift::TypeChecker::diagnoseInlineableDeclRef(swift::SourceLoc, swift::ValueDecl const*, swift::DeclContext const*) (/path/to/swift/bin/swift+0x145b552)
11 0x000000000146a0f6 (anonymous namespace)::AvailabilityWalker::diagAvailability(swift::ValueDecl const*, swift::SourceRange, swift::ApplyExpr const*, bool, bool) (/path/to/swift/bin/swift+0x146a0f6)
12 0x00000000014688fe swift::diagnoseDeclAvailability(swift::ValueDecl const*, swift::TypeChecker&, swift::DeclContext*, swift::SourceRange, bool, bool) (/path/to/swift/bin/swift+0x14688fe)
13 0x00000000013be764 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13be764)
14 0x00000000013bf268 (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0x13bf268)
15 0x00000000013bf16c swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13bf16c)
16 0x00000000013bdb70 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13bdb70)
17 0x00000000013778c9 validateParameterType(swift::ParamDecl*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver&, swift::TypeChecker&) (/path/to/swift/bin/swift+0x13778c9)
18 0x0000000001377779 swift::TypeChecker::typeCheckParameterList(swift::ParameterList*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver&) (/path/to/swift/bin/swift+0x1377779)
19 0x0000000001362a93 (anonymous namespace)::DeclChecker::semaFuncParamPatterns(swift::AbstractFunctionDecl*, swift::GenericTypeResolver&) (/path/to/swift/bin/swift+0x1362a93)
20 0x0000000001355f4b (anonymous namespace)::DeclChecker::visitFuncDecl(swift::FuncDecl*) (/path/to/swift/bin/swift+0x1355f4b)
21 0x0000000001341ea4 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x1341ea4)
22 0x0000000001343ecd swift::TypeChecker::validateDecl(swift::ValueDecl*) (/path/to/swift/bin/swift+0x1343ecd)
23 0x0000000001595695 swift::namelookup::ResolutionKind recordImportDecls<llvm::DenseMap<swift::DeclBaseName, std::pair<swift::namelookup::ResolutionKind, llvm::SmallSet<swift::CanType, 4u, (anonymous namespace)::SortCanType> >, llvm::DenseMapInfo<swift::DeclBaseName>, llvm::detail::DenseMapPair<swift::DeclBaseName, std::pair<swift::namelookup::ResolutionKind, llvm::SmallSet<swift::CanType, 4u, (anonymous namespace)::SortCanType> > > > >(swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&, llvm::ArrayRef<swift::ValueDecl*>, llvm::DenseMap<swift::DeclBaseName, std::pair<swift::namelookup::ResolutionKind, llvm::SmallSet<swift::CanType, 4u, (anonymous namespace)::SortCanType> >, llvm::DenseMapInfo<swift::DeclBaseName>, llvm::detail::DenseMapPair<swift::DeclBaseName, std::pair<swift::namelookup::ResolutionKind, llvm::SmallSet<swift::CanType, 4u, (anonymous namespace)::SortCanType> > > >&, swift::namelookup::ResolutionKind) (/path/to/swift/bin/swift+0x1595695)
24 0x00000000015938aa void lookupInModule<llvm::DenseMap<swift::DeclBaseName, std::pair<swift::namelookup::ResolutionKind, llvm::SmallSet<swift::CanType, 4u, (anonymous namespace)::SortCanType> >, llvm::DenseMapInfo<swift::DeclBaseName>, llvm::detail::DenseMapPair<swift::DeclBaseName, std::pair<swift::namelookup::ResolutionKind, llvm::SmallSet<swift::CanType, 4u, (anonymous namespace)::SortCanType> > > >, swift::namelookup::lookupVisibleDeclsInModule(swift::ModuleDecl*, llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, llvm::SmallVectorImpl<swift::ValueDecl*>&, swift::NLKind, swift::namelookup::ResolutionKind, swift::LazyResolver*, swift::DeclContext const*, llvm::ArrayRef<std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*> >)::$_1>(swift::ModuleDecl*, llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, llvm::SmallVectorImpl<swift::ValueDecl*>&, swift::namelookup::ResolutionKind, bool, swift::LazyResolver*, llvm::SmallDenseMap<std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*>, llvm::TinyPtrVector<swift::ValueDecl*>, 32u, llvm::DenseMapInfo<std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*> >, llvm::detail::DenseMapPair<std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*>, llvm::TinyPtrVector<swift::ValueDecl*> > >&, swift::DeclContext const*, bool, llvm::ArrayRef<std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*> >, swift::namelookup::lookupVisibleDeclsInModule(swift::ModuleDecl*, llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, llvm::SmallVectorImpl<swift::ValueDecl*>&, swift::NLKind, swift::namelookup::ResolutionKind, swift::LazyResolver*, swift::DeclContext const*, llvm::ArrayRef<std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*> >)::$_1) (/path/to/swift/bin/swift+0x15938aa)
25 0x00000000015930f3 swift::namelookup::lookupVisibleDeclsInModule(swift::ModuleDecl*, llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, llvm::SmallVectorImpl<swift::ValueDecl*>&, swift::NLKind, swift::namelookup::ResolutionKind, swift::LazyResolver*, swift::DeclContext const*, llvm::ArrayRef<std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*> >) (/path/to/swift/bin/swift+0x15930f3)
26 0x00000000015819fd swift::lookupVisibleDecls(swift::VisibleDeclConsumer&, swift::DeclContext const*, swift::LazyResolver*, bool, swift::SourceLoc) (/path/to/swift/bin/swift+0x15819fd)
27 0x0000000001375c38 swift::TypeChecker::performTypoCorrection(swift::DeclContext*, swift::DeclRefKind, swift::Type, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>, swift::LookupResult&, unsigned int) (/path/to/swift/bin/swift+0x1375c38)
28 0x0000000001326be8 swift::TypeChecker::resolveDeclRefExpr(swift::UnresolvedDeclRefExpr*, swift::DeclContext*) (/path/to/swift/bin/swift+0x1326be8)
29 0x00000000013335a2 (anonymous namespace)::PreCheckExpression::walkToExprPre(swift::Expr*) (/path/to/swift/bin/swift+0x13335a2)
30 0x000000000150bdab swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x150bdab)
31 0x00000000013276d5 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0x13276d5)
32 0x000000000132b112 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x132b112)
33 0x000000000132f264 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*, bool) (/path/to/swift/bin/swift+0x132f264)
34 0x000000000132f4c6 swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int, bool) (/path/to/swift/bin/swift+0x132f4c6)
35 0x0000000001347af8 validatePatternBindingEntries(swift::TypeChecker&, swift::PatternBindingDecl*) (/path/to/swift/bin/swift+0x1347af8)
36 0x0000000001341ecd (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x1341ecd)
37 0x00000000013521cb (anonymous namespace)::DeclChecker::visitExtensionDecl(swift::ExtensionDecl*) (/path/to/swift/bin/swift+0x13521cb)
38 0x0000000001341eb4 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x1341eb4)
39 0x0000000001341d83 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x1341d83)
40 0x00000000013ccaf5 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x13ccaf5)
41 0x0000000000f93b16 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf93b16)
42 0x00000000004ab3d9 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4ab3d9)
43 0x00000000004a996c swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a996c)
44 0x00000000004655c7 main (/path/to/swift/bin/swift+0x4655c7)
45 0x00007f2369fcb830 __libc_start_main /build/glibc-9tT8Do/glibc-2.23/csu/../csu/libc-start.c:325:0
46 0x0000000000462c69 _start (/path/to/swift/bin/swift+0x462c69)
```