### PR TITLE
[swiftc (26 vs. 5563)] Add crasher in swift::TypeChecker::validateDecl(...)

### DIFF
--- a/validation-test/compiler_crashers/28780-hasinterfacetype-no-interface-type-was-set.swift
+++ b/validation-test/compiler_crashers/28780-hasinterfacetype-no-interface-type-was-set.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+class a{func a:A.a:class A:a{{}func a


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeChecker::validateDecl(...)`.

Current number of unresolved compiler crashers: 26 (5563 resolved)

/cc @slavapestov - just wanted to let you know that this crasher caused an assertion failure for the assertion `hasInterfaceType() && "No interface type was set"` added on 2016-12-04 by you in commit c1a21613 :-)

Assertion failure in [`lib/AST/Decl.cpp (line 1813)`](https://github.com/apple/swift/blob/1a9ccd347c8784f52499a6372741b27962a3135a/lib/AST/Decl.cpp#L1813):

```
Assertion `hasInterfaceType() && "No interface type was set"' failed.

When executing: swift::Type swift::ValueDecl::getInterfaceType() const
```

Assertion context:

```c++
bool ValueDecl::hasInterfaceType() const {
  return !TypeAndAccess.getPointer().isNull();
}

Type ValueDecl::getInterfaceType() const {
  assert(hasInterfaceType() && "No interface type was set");
  return TypeAndAccess.getPointer();
}

void ValueDecl::setInterfaceType(Type type) {
  // lldb creates global typealiases with archetypes in them.
```
Stack trace:

```
0 0x0000000003a5fdb8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3a5fdb8)
1 0x0000000003a604f6 SignalHandler(int) (/path/to/swift/bin/swift+0x3a604f6)
2 0x00007f798906f390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007f7987595428 gsignal /build/glibc-9tT8Do/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f798759702a abort /build/glibc-9tT8Do/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f798758dbd7 __assert_fail_base /build/glibc-9tT8Do/glibc-2.23/assert/assert.c:92:0
6 0x00007f798758dc82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x000000000152d1bf (/path/to/swift/bin/swift+0x152d1bf)
8 0x0000000001340259 (anonymous namespace)::DeclChecker::checkOverrides(swift::TypeChecker&, swift::ValueDecl*) (/path/to/swift/bin/swift+0x1340259)
9 0x0000000001356016 (anonymous namespace)::DeclChecker::visitFuncDecl(swift::FuncDecl*) (/path/to/swift/bin/swift+0x1356016)
10 0x0000000001341ea4 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x1341ea4)
11 0x0000000001343ecd swift::TypeChecker::validateDecl(swift::ValueDecl*) (/path/to/swift/bin/swift+0x1343ecd)
12 0x000000000159ab1c swift::DeclContext::lookupQualified(swift::Type, swift::DeclName, swift::NLOptions, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&) const (/path/to/swift/bin/swift+0x159ab1c)
13 0x00000000013750c6 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>)::$_1::operator()() const (/path/to/swift/bin/swift+0x13750c6)
14 0x0000000001374f77 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>) (/path/to/swift/bin/swift+0x1374f77)
15 0x00000000013c51f4 diagnoseUnknownType(swift::TypeChecker&, swift::DeclContext*, swift::Type, swift::SourceRange, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::OptionSet<swift::NameLookupFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13c51f4)
16 0x00000000013bee85 resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13bee85)
17 0x00000000013be4f9 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13be4f9)
18 0x00000000013bf268 (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0x13bf268)
19 0x00000000013bf16c swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13bf16c)
20 0x00000000013bdb70 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13bdb70)
21 0x0000000001355f35 (anonymous namespace)::DeclChecker::visitFuncDecl(swift::FuncDecl*) (/path/to/swift/bin/swift+0x1355f35)
22 0x0000000001341ea4 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x1341ea4)
23 0x000000000135292b (anonymous namespace)::DeclChecker::visitClassDecl(swift::ClassDecl*) (/path/to/swift/bin/swift+0x135292b)
24 0x0000000001341f7e (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x1341f7e)
25 0x0000000001341d83 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x1341d83)
26 0x00000000013ccaf5 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x13ccaf5)
27 0x0000000000f93b16 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf93b16)
28 0x00000000004ab3d9 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4ab3d9)
29 0x00000000004a996c swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a996c)
30 0x00000000004655c7 main (/path/to/swift/bin/swift+0x4655c7)
31 0x00007f7987580830 __libc_start_main /build/glibc-9tT8Do/glibc-2.23/csu/../csu/libc-start.c:325:0
32 0x0000000000462c69 _start (/path/to/swift/bin/swift+0x462c69)
```