### PR TITLE
[swiftc (27 vs. 5563)] Add crasher in swift::TypeChecker::checkConformancesInContext

### DIFF
--- a/validation-test/compiler_crashers/28781-requirementsignature-getting-requirement-signature-before-computing-it.swift
+++ b/validation-test/compiler_crashers/28781-requirementsignature-getting-requirement-signature-before-computing-it.swift
@@ -1,0 +1,12 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol A{{}class a{let c{
+struct A:P
+protocol P{{}{}typealias e:=A


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeChecker::checkConformancesInContext`.

Current number of unresolved compiler crashers: 27 (5563 resolved)

/cc @huonw - just wanted to let you know that this crasher caused an assertion failure for the assertion `RequirementSignature && "getting requirement signature before computing it"` added on 2017-02-01 by you in commit 74091fbce :-)

Assertion failure in [`include/swift/AST/Decl.h (line 3711)`](https://github.com/apple/swift/blob/da87ab81c773d3712e8b9e64173c815917d7486b/include/swift/AST/Decl.h#L3711):

```
Assertion `RequirementSignature && "getting requirement signature before computing it"' failed.

When executing: swift::GenericSignature *swift::ProtocolDecl::getRequirementSignature() const
```

Assertion context:

```c++
  ///
  /// These are the requirements like any inherited protocols and conformances
  /// for associated types that are mentioned literally in this
  /// decl. Requirements implied via inheritance are not mentioned, nor is the
  /// conformance of Self to this protocol.
  GenericSignature *getRequirementSignature() const {
    assert(RequirementSignature &&
           "getting requirement signature before computing it");
    return RequirementSignature;
  }

```
Stack trace:

```
0 0x0000000003a5fdb8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3a5fdb8)
1 0x0000000003a604f6 SignalHandler(int) (/path/to/swift/bin/swift+0x3a604f6)
2 0x00007fa559f45390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007fa55846b428 gsignal /build/glibc-9tT8Do/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007fa55846d02a abort /build/glibc-9tT8Do/glibc-2.23/stdlib/abort.c:91:0
5 0x00007fa558463bd7 __assert_fail_base /build/glibc-9tT8Do/glibc-2.23/assert/assert.c:92:0
6 0x00007fa558463c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x000000000139c82d checkTypeWitness(swift::TypeChecker&, swift::DeclContext*, swift::ProtocolDecl*, swift::AssociatedTypeDecl*, swift::Type) (/path/to/swift/bin/swift+0x139c82d)
8 0x00000000013a6176 (anonymous namespace)::ConformanceChecker::resolveTypeWitnesses()::$_44::operator()(unsigned int) const (/path/to/swift/bin/swift+0x13a6176)
9 0x0000000001386a43 (anonymous namespace)::ConformanceChecker::resolveTypeWitnesses() (/path/to/swift/bin/swift+0x1386a43)
10 0x00000000013819ee (anonymous namespace)::MultiConformanceChecker::checkAllConformances() (/path/to/swift/bin/swift+0x13819ee)
11 0x00000000013830f2 swift::TypeChecker::checkConformancesInContext(swift::DeclContext*, swift::IterableDeclContext*) (/path/to/swift/bin/swift+0x13830f2)
12 0x0000000001352797 (anonymous namespace)::DeclChecker::visitStructDecl(swift::StructDecl*) (/path/to/swift/bin/swift+0x1352797)
13 0x0000000001341e64 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x1341e64)
14 0x0000000001341d83 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x1341d83)
15 0x00000000013aee16 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13aee16)
16 0x00000000013ad10d swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) (/path/to/swift/bin/swift+0x13ad10d)
17 0x00000000013acf7d swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) (/path/to/swift/bin/swift+0x13acf7d)
18 0x00000000013adccd swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0x13adccd)
19 0x00000000013cbd18 typeCheckFunctionsAndExternalDecls(swift::TypeChecker&) (/path/to/swift/bin/swift+0x13cbd18)
20 0x00000000013ccbf8 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x13ccbf8)
21 0x0000000000f93b16 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf93b16)
22 0x00000000004ab3d9 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4ab3d9)
23 0x00000000004a996c swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4a996c)
24 0x00000000004655c7 main (/path/to/swift/bin/swift+0x4655c7)
25 0x00007fa558456830 __libc_start_main /build/glibc-9tT8Do/glibc-2.23/csu/../csu/libc-start.c:325:0
26 0x0000000000462c69 _start (/path/to/swift/bin/swift+0x462c69)
```