### PR TITLE
[IRGen] Revert EmptyBoxType changes from #10326

### DIFF
--- a/docs/Runtime.md
+++ b/docs/Runtime.md
@@ -71,7 +71,6 @@ Rename with a non-`stdlib` naming scheme.
 
 ```
 000000000001cb30 T _swift_allocBox
-000000000001cb30 T _swift_allocEmptyBox
 000000000001c990 T _swift_allocObject
 000000000001ca60 T _swift_bufferAllocate
 000000000001ca90 T _swift_bufferHeaderSize

--- a/include/swift/Runtime/HeapObject.h
+++ b/include/swift/Runtime/HeapObject.h
@@ -169,10 +169,6 @@ SWIFT_RUNTIME_EXPORT
 BoxPair::Return swift_makeBoxUnique(OpaqueValue *buffer, Metadata const *type,
                                     size_t alignMask);
 
-/// Returns the address of a heap object representing all empty box types.
-SWIFT_RUNTIME_EXPORT
-HeapObject* swift_allocEmptyBox();
-
 // Allocate plain old memory. This is the generalized entry point
 // Never returns nil. The returned memory is uninitialized. 
 //

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -1761,9 +1761,6 @@ struct TargetHeapLocalVariableMetadata
   static bool classof(const TargetMetadata<Runtime> *metadata) {
     return metadata->getKind() == MetadataKind::HeapLocalVariable;
   }
-  constexpr TargetHeapLocalVariableMetadata()
-      : TargetHeapMetadata<Runtime>(MetadataKind::HeapLocalVariable),
-        OffsetToFirstCapture(0), CaptureDescription(nullptr) {}
 };
 using HeapLocalVariableMetadata
   = TargetHeapLocalVariableMetadata<InProcess>;

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -73,11 +73,6 @@ FUNCTION(ProjectBox, swift_projectBox, DefaultCC,
          ARGS(RefCountedPtrTy),
          ATTRS(NoUnwind, ReadNone))
 
-FUNCTION(AllocEmptyBox, swift_allocEmptyBox, DefaultCC,
-         RETURNS(RefCountedPtrTy),
-         ARGS(),
-         ATTRS(NoUnwind))
-
 // RefCounted *swift_allocObject(Metadata *type, size_t size, size_t alignMask);
 FUNCTION_WITH_GLOBAL_SYMBOL_AND_IMPL(AllocObject, swift_allocObject,
          _swift_allocObject, _swift_allocObject_, RegisterPreservingCC,

--- a/lib/IRGen/GenHeap.cpp
+++ b/lib/IRGen/GenHeap.cpp
@@ -1430,7 +1430,7 @@ public:
   allocate(IRGenFunction &IGF, SILType boxedType, GenericEnvironment *env,
            const llvm::Twine &name) const override {
     return OwnedAddress(IGF.getTypeInfo(boxedType).getUndefAddress(),
-                        IGF.emitAllocEmptyBoxCall());
+                        IGF.IGM.RefCountedNull);
   }
 
   void
@@ -1584,11 +1584,7 @@ const TypeInfo *TypeConverter::convertBoxType(SILBoxType *T) {
   // For fixed-sized types, we can emit concrete box metadata.
   auto &fixedTI = cast<FixedTypeInfo>(eltTI);
 
-  // Because we assume in enum's that payloads with a Builtin.NativeObject which
-  // is also the type for indirect enum cases have extra inhabitants of pointers
-  // we can't have a nil pointer as a representation for an empty box type --
-  // nil conflicts with the extra inhabitants. We return a static singleton
-  // empty box object instead.
+  // For empty types, we don't really need to allocate anything.
   if (fixedTI.isKnownEmpty(ResilienceExpansion::Maximal)) {
     if (!EmptyBoxTI)
       EmptyBoxTI = new EmptyBoxTypeInfo(IGM);

--- a/lib/IRGen/IRGenFunction.cpp
+++ b/lib/IRGen/IRGenFunction.cpp
@@ -209,20 +209,6 @@ llvm::Value *IRGenFunction::emitProjectBoxCall(llvm::Value *box,
   return call;
 }
 
-llvm::Value *IRGenFunction::emitAllocEmptyBoxCall() {
-  llvm::Attribute::AttrKind attrKinds[] = {
-    llvm::Attribute::NoUnwind,
-  };
-  auto attrs = llvm::AttributeSet::get(IGM.LLVMContext,
-                                       llvm::AttributeSet::FunctionIndex,
-                                       attrKinds);
-  llvm::CallInst *call =
-    Builder.CreateCall(IGM.getAllocEmptyBoxFn(), {});
-  call->setCallingConv(IGM.DefaultCC);
-  call->setAttributes(attrs);
-  return call;
-}
-
 static void emitDeallocatingCall(IRGenFunction &IGF, llvm::Constant *fn,
                                  std::initializer_list<llvm::Value *> args) {
   auto cc = IGF.IGM.DefaultCC;

--- a/lib/IRGen/IRGenFunction.h
+++ b/lib/IRGen/IRGenFunction.h
@@ -188,8 +188,6 @@ public:
 
   llvm::Value *emitProjectBoxCall(llvm::Value *box, llvm::Value *typeMetadata);
 
-  llvm::Value *emitAllocEmptyBoxCall();
-
   // Emit a reference to the canonical type metadata record for the given AST
   // type. This can be used to identify the type at runtime. For types with
   // abstraction difference, the metadata contains the layout information for

--- a/stdlib/public/SwiftShims/GlobalObjects.h
+++ b/stdlib/public/SwiftShims/GlobalObjects.h
@@ -88,13 +88,6 @@ struct _SwiftHashingSecretKey _swift_stdlib_Hashing_secretKey;
 SWIFT_RUNTIME_STDLIB_INTERFACE
 __swift_uint64_t _swift_stdlib_HashingDetail_fixedSeedOverride;
 
-struct _SwiftEmptyBoxStorage {
-  struct HeapObject header;
-};
-
-SWIFT_RUNTIME_STDLIB_INTERFACE
-struct _SwiftEmptyBoxStorage _EmptyBoxStorage;
-
 #ifdef __cplusplus
 
 static_assert(std::is_pod<_SwiftEmptyArrayStorage>::value,

--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -31,7 +31,6 @@
 #include <cstdio>
 #include <cstdlib>
 #include <thread>
-#include "../SwiftShims/GlobalObjects.h"
 #include "../SwiftShims/RuntimeShims.h"
 #if SWIFT_OBJC_INTEROP
 # include <objc/NSObject.h>
@@ -226,12 +225,6 @@ OpaqueValue *swift::swift_projectBox(HeapObject *o) {
     return nullptr;
   auto metadata = static_cast<const GenericBoxHeapMetadata *>(o->metadata);
   return metadata->project(o);
-}
-
-HeapObject *swift::swift_allocEmptyBox() {
-  auto heapObject = reinterpret_cast<HeapObject*>(&_EmptyBoxStorage);
-  SWIFT_RT_ENTRY_CALL(swift_retain)(heapObject);
-  return heapObject;
 }
 
 // Forward-declare this, but define it after swift_release.

--- a/stdlib/public/stubs/GlobalObjects.cpp
+++ b/stdlib/public/stubs/GlobalObjects.cpp
@@ -35,6 +35,10 @@ ClassMetadata CLASS_METADATA_SYM(s27_RawNativeDictionaryStorage);
 // _direct type metadata for Swift._RawNativeSetStorage
 SWIFT_RUNTIME_STDLIB_INTERFACE
 ClassMetadata CLASS_METADATA_SYM(s20_RawNativeSetStorage);
+
+// _direct type metadata for Swift._EmptyBoxStorage
+SWIFT_RUNTIME_STDLIB_INTERFACE
+ClassMetadata CLASS_METADATA_SYM(s16_EmptyBoxStorage);
 } // namespace swift
 
 swift::_SwiftEmptyArrayStorage swift::_swiftEmptyArrayStorage = {
@@ -134,6 +138,7 @@ swift::_SwiftEmptyBoxStorage swift::_EmptyBoxStorage = {
  // HeapObject header;
   {
     &_emptyBoxStorageMetadata,
+    //&swift::CLASS_METADATA_SYM(s16_EmptyBoxStorage), // isa pointer
   }
 };
 

--- a/stdlib/public/stubs/GlobalObjects.cpp
+++ b/stdlib/public/stubs/GlobalObjects.cpp
@@ -35,10 +35,6 @@ ClassMetadata CLASS_METADATA_SYM(s27_RawNativeDictionaryStorage);
 // _direct type metadata for Swift._RawNativeSetStorage
 SWIFT_RUNTIME_STDLIB_INTERFACE
 ClassMetadata CLASS_METADATA_SYM(s20_RawNativeSetStorage);
-
-// _direct type metadata for Swift._EmptyBoxStorage
-SWIFT_RUNTIME_STDLIB_INTERFACE
-ClassMetadata CLASS_METADATA_SYM(s16_EmptyBoxStorage);
 } // namespace swift
 
 swift::_SwiftEmptyArrayStorage swift::_swiftEmptyArrayStorage = {
@@ -130,18 +126,6 @@ void swift::_swift_instantiateInertHeapObject(void *address,
                                               const HeapMetadata *metadata) {
   ::new (address) HeapObject{metadata};
 }
-
-swift::HeapLocalVariableMetadata _emptyBoxStorageMetadata;
-
-/// The signleton empty box storage object.
-swift::_SwiftEmptyBoxStorage swift::_EmptyBoxStorage = {
- // HeapObject header;
-  {
-    &_emptyBoxStorageMetadata,
-    //&swift::CLASS_METADATA_SYM(s16_EmptyBoxStorage), // isa pointer
-  }
-};
-
 
 namespace llvm { namespace hashing { namespace detail {
   // An extern variable expected by LLVM's hashing templates. We don't link any

--- a/test/IRGen/access_markers.sil
+++ b/test/IRGen/access_markers.sil
@@ -114,7 +114,8 @@ sil @testPairedBox : $(@guaranteed { var () }) -> () {
 bb0(%0 : ${ var () }):
   // CHECK: entry:
   %2 = project_box %0 : ${ var () }, 0
-  //  CHECK-NEXT: call {{.*}}void @writeEmptyTuple(%swift.opaque* nocapture undef)
+
+  // CHECK-NEXT: call {{.*}}void @writeEmptyTuple(%swift.opaque* nocapture undef)
   %3 = begin_access [modify] [dynamic] %2 : $*()
   %write_fn = function_ref @writeEmptyTuple : $@convention(thin) (@inout ()) -> ()
   apply %write_fn(%3) : $@convention(thin) (@inout ()) -> ()

--- a/test/IRGen/partial_apply.sil
+++ b/test/IRGen/partial_apply.sil
@@ -365,8 +365,7 @@ sil public_external @partial_empty_box : $@convention(thin) (@owned <τ_0_0> { v
 // CHECK-LABEL: define{{( protected)?}} swiftcc void @empty_box()
 sil @empty_box : $@convention(thin) () -> () {
 entry:
-  // CHECK: [[BOX:%.*]] = call {{.*}}swift_allocEmptyBox
-  // CHECK: store %swift.refcounted* [[BOX]]
+  // CHECK: store %swift.refcounted* null
   // CHECK: store %swift.opaque* undef
   %b = alloc_box $<τ_0_0> { var τ_0_0 } <()>
   %ba = project_box %b : $<τ_0_0> { var τ_0_0 } <()>, 0

--- a/test/Interpreter/enum.swift
+++ b/test/Interpreter/enum.swift
@@ -553,50 +553,5 @@ presentEitherOr(EitherOr<(), String>.Right("foo")) // CHECK-NEXT: Right(foo)
 // CHECK-NEXT: Right(foo)
 presentEitherOrsOf(t: (), u: "foo")
 
-// SR-5148
-enum Payload {
-    case email
-}
-enum Test {
-    case a
-    indirect case b(Payload)
-}
-
-@inline(never)
-func printA() {
-    print("an a")
-}
-
-@inline(never)
-func printB() {
-    print("an b")
-}
-
-@inline(never)
-func testCase(_ testEmail: Test) {
-  switch testEmail {
-    case .a:
-      printA()
-    case .b:
-      printB()
-  }
-}
-
-@inline(never)
-func createTestB() -> Test  {
-  return Test.b(.email)
-}
-
-@inline(never)
-func createTestA() -> Test  {
-  return Test.a
-}
-
-// CHECK-NEXT: an b
-testCase(createTestB())
-// CHECK-NEXT: b(a.Payload.email)
-print(createTestB())
-// CHECK-NEXT: a
-print(createTestA())
 // CHECK-NEXT: done
 print("done")


### PR DESCRIPTION
Reverts #10326 and its follow-up clean-up #10357 because it [broke the Ubuntu 16.10 bot](https://ci.swift.org/view/Dashboard/job/oss-swift-incremental-RA-linux-ubuntu-16_10/4241/). Not sure why this wasn't caught by PR testing.

> /usr/bin/ld.gold: error: stdlib/public/runtime/CMakeFiles/swiftRuntime-linux-x86_64.dir/HeapObject.cpp.o: cannot make copy relocation for protected symbol '_EmptyBoxStorage', defined in lib/swift/linux/x86_64/libswiftCore.so
