### PR TITLE
CursorInfo: Teach SemaLocResolver to recognize the start of an expression.

### DIFF
--- a/include/swift/IDE/Utils.h
+++ b/include/swift/IDE/Utils.h
@@ -148,6 +148,7 @@ enum class SemaTokenKind {
   Invalid,
   ValueRef,
   ModuleRef,
+  ExprStart,
   StmtStart,
 };
 
@@ -164,6 +165,7 @@ struct SemaToken {
   DeclContext *DC = nullptr;
   Type ContainerType;
   Stmt *TrailingStmt = nullptr;
+  Expr *TrailingExpr = nullptr;
 
   SemaToken() = default;
   SemaToken(ValueDecl *ValueD, TypeDecl *CtorTyRef, ExtensionDecl *ExtTyRef,
@@ -175,6 +177,8 @@ struct SemaToken {
                                                Mod(Mod), Loc(Loc) { }
   SemaToken(Stmt *TrailingStmt) : Kind(SemaTokenKind::StmtStart),
                                   TrailingStmt(TrailingStmt) {}
+  SemaToken(Expr* TrailingExpr) : Kind(SemaTokenKind::ExprStart),
+                                  TrailingExpr(TrailingExpr) {}
   bool isValid() const { return !isInvalid(); }
   bool isInvalid() const { return Kind == SemaTokenKind::Invalid; }
 };
@@ -191,6 +195,7 @@ public:
   SourceManager &getSourceMgr() const;
 private:
   bool walkToExprPre(Expr *E) override;
+  bool walkToExprPost(Expr *E) override;
   bool walkToDeclPre(Decl *D, CharSourceRange Range) override;
   bool walkToDeclPost(Decl *D) override;
   bool walkToStmtPre(Stmt *S) override;
@@ -211,6 +216,7 @@ private:
                   SourceLoc Loc, bool IsRef, Type Ty = Type());
   bool tryResolve(ModuleEntity Mod, SourceLoc Loc);
   bool tryResolve(Stmt *St);
+  bool tryResolve(Expr *Exp);
   bool visitSubscriptReference(ValueDecl *D, CharSourceRange Range,
                                bool IsOpenBracket) override;
 };

--- a/lib/IDE/SwiftSourceDocInfo.cpp
+++ b/lib/IDE/SwiftSourceDocInfo.cpp
@@ -108,6 +108,14 @@ bool SemaLocResolver::tryResolve(Stmt *St) {
   return false;
 }
 
+bool SemaLocResolver::tryResolve(Expr *Exp) {
+  if (Exp->getStartLoc() == LocToResolve) {
+    SemaTok = { Exp };
+    return true;
+  }
+  return false;
+}
+
 bool SemaLocResolver::visitSubscriptReference(ValueDecl *D, CharSourceRange Range,
                                               bool IsOpenBracket) {
   // We should treat both open and close brackets equally
@@ -187,6 +195,12 @@ bool SemaLocResolver::walkToExprPre(Expr *E) {
     }
   }
   return true;
+}
+
+bool SemaLocResolver::walkToExprPost(Expr *E) {
+  if (isDone())
+    return false;
+  return !tryResolve(E);
 }
 
 bool SemaLocResolver::visitCallArgName(Identifier Name, CharSourceRange Range,

--- a/lib/IDE/SwiftSourceDocInfo.cpp
+++ b/lib/IDE/SwiftSourceDocInfo.cpp
@@ -109,7 +109,7 @@ bool SemaLocResolver::tryResolve(Stmt *St) {
 }
 
 bool SemaLocResolver::tryResolve(Expr *Exp) {
-  if (Exp->getStartLoc() == LocToResolve) {
+  if (!Exp->isImplicit() && Exp->getStartLoc() == LocToResolve) {
     SemaTok = { Exp };
     return true;
   }

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -1181,6 +1181,7 @@ static void resolveCursor(SwiftLangSupport &Lang,
         }
         return;
       }
+      case SemaTokenKind::ExprStart:
       case SemaTokenKind::StmtStart: {
         Receiver({});
         return;


### PR DESCRIPTION
A location is resolved to the start of an expression only when it cannot be further refined to other kind, e.g. a reference. rdar://32749670

