### PR TITLE
Don't add rpath to swift with statically linking

### DIFF
--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -1245,6 +1245,10 @@ toolchains::Darwin::constructInvocation(const LinkJobAction &job,
     Arguments.push_back("-force_load_swift_libs");
   } else {
     Arguments.push_back(context.Args.MakeArgString(RuntimeLibPath));
+    // FIXME: We probably shouldn't be adding an rpath here unless we know ahead
+    // of time the standard library won't be copied. SR-1967
+    Arguments.push_back("-rpath");
+    Arguments.push_back(context.Args.MakeArgString(RuntimeLibPath));
   }
 
   if (context.Args.hasArg(options::OPT_profile_generate)) {
@@ -1282,11 +1286,6 @@ toolchains::Darwin::constructInvocation(const LinkJobAction &job,
 
     Arguments.push_back(context.Args.MakeArgString(LibProfile));
   }
-
-  // FIXME: We probably shouldn't be adding an rpath here unless we know ahead
-  // of time the standard library won't be copied.
-  Arguments.push_back("-rpath");
-  Arguments.push_back(context.Args.MakeArgString(RuntimeLibPath));
 
   // FIXME: Properly handle deployment targets.
   assert(Triple.isiOS() || Triple.isWatchOS() || Triple.isMacOSX());

--- a/test/Driver/linker.swift
+++ b/test/Driver/linker.swift
@@ -2,6 +2,9 @@
 // RUN: %FileCheck %s < %t.simple.txt
 // RUN: %FileCheck -check-prefix SIMPLE %s < %t.simple.txt
 
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 -static-stdlib %s 2>&1 > %t.simple.txt
+// RUN: %FileCheck -check-prefix SIMPLE_STATIC -implicit-check-not -rpath %s < %t.simple.txt
+
 // RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-ios7.1 %s 2>&1 > %t.simple.txt
 // RUN: %FileCheck -check-prefix IOS_SIMPLE %s < %t.simple.txt
 
@@ -67,6 +70,23 @@
 // SIMPLE-DAG: -macosx_version_min 10.{{[0-9]+}}.{{[0-9]+}}
 // SIMPLE-NOT: -syslibroot
 // SIMPLE: -o linker
+
+
+// SIMPLE_STATIC: swift
+// SIMPLE_STATIC: -o [[OBJECTFILE:.*]]
+
+// SIMPLE_STATIC-NEXT: bin/ld{{"? }}
+// SIMPLE_STATIC: [[OBJECTFILE]]
+// SIMPLE_STATIC: -lobjc
+// SIMPLE_STATIC: -lSystem
+// SIMPLE_STATIC: -arch x86_64
+// SIMPLE_STATIC: -L [[STDLIB_PATH:[^ ]+/lib/swift_static/macosx]]
+// SIMPLE_STATIC: -lc++
+// SIMPLE_STATIC: -framework Foundation
+// SIMPLE_STATIC: -force_load_swift_libs
+// SIMPLE_STATIC: -macosx_version_min 10.{{[0-9]+}}.{{[0-9]+}}
+// SIMPLE_STATIC: -no_objc_category_merging
+// SIMPLE_STATIC: -o linker
 
 
 // IOS_SIMPLE: swift


### PR DESCRIPTION
This updates the rpath linking logic to only add the rpath that points
to the swift dylibs in the case that the libraries are not statically
linked into the binary.

This fix is marginally relevant to https://bugs.swift.org/browse/SR-1967, but does not solve the core problem here.