### PR TITLE
stdlib: Add another missing @_versioned annotation

### DIFF
--- a/stdlib/public/core/HeapBuffer.swift
+++ b/stdlib/public/core/HeapBuffer.swift
@@ -13,6 +13,7 @@
 import SwiftShims
 typealias _HeapObject = SwiftShims.HeapObject
 
+@_versioned
 internal protocol _HeapBufferHeader_ {
   associatedtype Value
   init(_ value: Value)


### PR DESCRIPTION
We cannot diagnose uses of a non-public conformance yet, so this
was resulting in a linker failure.

Fixes <rdar://problem/32536790>.