### PR TITLE
[swift-4.0] Fix SIL serialization of witness tables and protocol witness thunks

### DIFF
--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -234,10 +234,6 @@ public:
   /// is either the default definition or was otherwise deduced.
   bool usesDefaultDefinition(AssociatedTypeDecl *requirement) const;
 
-  /// Returns true if this conformance has a layout that is known to all
-  /// consumers, based on the type/protocol involved in it.
-  bool hasFixedLayout() const;
-
   // Make vanilla new/delete illegal for protocol conformances.
   void *operator new(size_t bytes) = delete;
   void operator delete(void *data) SWIFT_DELETE_OPERATOR_DELETED;

--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -152,6 +152,11 @@ public:
   /// \brief Enable large loadable types IRGen pass.
   bool EnableLargeLoadableTypes = false;
 
+  /// Enables the "fully fragile" resilience strategy.
+  ///
+  /// \see ResilienceStrategy::Fragile
+  bool SILSerializeAll = false;
+
   SILOptions() : Sanitize(SanitizerKind::None) {}
 
   /// Return a hash code of any components from these options that should

--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -157,6 +157,12 @@ public:
   /// \see ResilienceStrategy::Fragile
   bool SILSerializeAll = false;
 
+  /// If set, SIL witness tables will be serialized.
+  ///
+  /// It is supposed to be used only for compiling overlays.
+  /// User code should never be compiled with this flag set.
+  bool SILSerializeWitnessTables = false;
+
   SILOptions() : Sanitize(SanitizerKind::None) {}
 
   /// Return a hash code of any components from these options that should

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -240,11 +240,6 @@ public:
   /// by the Clang importer as part of semantic analysis.
   bool SerializeBridgingHeader = false;
 
-  /// Enables the "fully fragile" resilience strategy.
-  ///
-  /// \see ResilienceStrategy::Fragile
-  bool SILSerializeAll = false;
-
   /// Indicates whether or not the frontend should print statistics upon
   /// termination.
   bool PrintStats = false;

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -366,6 +366,9 @@ def sil_link_all : Flag<["-"], "sil-link-all">,
 def sil_serialize_all : Flag<["-"], "sil-serialize-all">,
   HelpText<"Serialize all generated SIL">;
 
+def sil_serialize_witness_tables : Flag<["-"], "sil-serialize-witness-tables">,
+  HelpText<"Serialize eligible SIL witness tables">;
+
 def sil_verify_all : Flag<["-"], "sil-verify-all">,
   HelpText<"Verify SIL after each transform">;
 

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -209,9 +209,6 @@ private:
   /// optimizations can assume that they see the whole module.
   bool wholeModule;
 
-  /// True if this SILModule is being completely serialized.
-  bool WholeModuleSerialized;
-
   /// The options passed into this SILModule.
   SILOptions &Options;
 
@@ -222,7 +219,7 @@ private:
   // Intentionally marked private so that we need to use 'constructSIL()'
   // to construct a SILModule.
   SILModule(ModuleDecl *M, SILOptions &Options, const DeclContext *associatedDC,
-            bool wholeModule, bool wholeModuleSerialized);
+            bool wholeModule);
 
   SILModule(const SILModule&) = delete;
   void operator=(const SILModule&) = delete;
@@ -285,23 +282,18 @@ public:
   ///
   /// If a source file is provided, SIL will only be emitted for decls in that
   /// source file, starting from the specified element number.
-  ///
-  /// If \p makeModuleFragile is true, all functions and global variables of
-  /// the module are marked as serialized. This is used for compiling the stdlib.
   static std::unique_ptr<SILModule>
   constructSIL(ModuleDecl *M, SILOptions &Options, FileUnit *sf = nullptr,
                Optional<unsigned> startElem = None,
-               bool makeModuleFragile = false,
                bool isWholeModule = false);
 
   /// \brief Create and return an empty SIL module that we can
   /// later parse SIL bodies directly into, without converting from an AST.
   static std::unique_ptr<SILModule>
   createEmptyModule(ModuleDecl *M, SILOptions &Options,
-                    bool WholeModule = false,
-                    bool WholeModuleSerialized = false) {
+                    bool WholeModule = false) {
     return std::unique_ptr<SILModule>(
-        new SILModule(M, Options, M, WholeModule, WholeModuleSerialized));
+        new SILModule(M, Options, M, WholeModule));
   }
 
   /// Get the Swift module associated with this SIL module.
@@ -330,7 +322,7 @@ public:
   }
 
   /// Returns true if everything in this SILModule is being serialized.
-  bool isWholeModuleSerialized() const { return WholeModuleSerialized; }
+  bool isWholeModuleSerialized() const { return Options.SILSerializeAll; }
 
   SILOptions &getOptions() const { return Options; }
 

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -242,25 +242,19 @@ namespace swift {
   ///
   /// The module must contain source files.
   ///
-  /// If \p makeModuleFragile is true, all functions and global variables of
-  /// the module are marked as fragile. This is used for compiling the stdlib.
   /// if \p wholeModuleCompilation is true, the optimizer assumes that the SIL
   /// of all files in the module is present in the SILModule.
   std::unique_ptr<SILModule>
   performSILGeneration(ModuleDecl *M, SILOptions &options,
-                       bool makeModuleFragile = false,
                        bool wholeModuleCompilation = false);
 
   /// Turn a source file into SIL IR.
   ///
   /// If \p StartElem is provided, the module is assumed to be only part of the
   /// SourceFile, and any optimizations should take that into account.
-  /// If \p makeModuleFragile is true, all functions and global variables of
-  /// the module are marked as fragile. This is used for compiling the stdlib.
   std::unique_ptr<SILModule>
   performSILGeneration(FileUnit &SF, SILOptions &options,
-                       Optional<unsigned> StartElem = None,
-                       bool makeModuleFragile = false);
+                       Optional<unsigned> StartElem = None);
 
   using ModuleOrSourceFile = PointerUnion<ModuleDecl *, SourceFile *>;
 

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -252,18 +252,6 @@ usesDefaultDefinition(AssociatedTypeDecl *requirement) const {
   CONFORMANCE_SUBCLASS_DISPATCH(usesDefaultDefinition, (requirement))
 }
 
-bool ProtocolConformance::hasFixedLayout() const {
-  // A conformance/witness table has fixed layout if type has a fixed layout in
-  // all resilience domains, and the conformance is externally visible.
-  if (auto nominal = getType()->getAnyNominal())
-    if (nominal->hasFixedLayout() &&
-        getProtocol()->getEffectiveAccess() >= Accessibility::Public &&
-        nominal->getEffectiveAccess() >= Accessibility::Public)
-      return true;
-
-  return false;
-}
-
 GenericEnvironment *ProtocolConformance::getGenericEnvironment() const {
   switch (getKind()) {
   case ProtocolConformanceKind::Inherited:

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1329,6 +1329,9 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
     Opts.MergePartialModules = true;
 
   Opts.SILSerializeAll |= Args.hasArg(OPT_sil_serialize_all);
+  Opts.SILSerializeWitnessTables |=
+    Args.hasArg(OPT_sil_serialize_witness_tables);
+
   // Parse the optimization level.
   if (const Arg *A = Args.getLastArg(OPT_O_Group)) {
     if (A->getOption().matches(OPT_Onone)) {

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -859,7 +859,6 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
       Args.hasArg(OPT_serialize_debugging_options);
   Opts.EnableSourceImport |= Args.hasArg(OPT_enable_source_import);
   Opts.ImportUnderlyingModule |= Args.hasArg(OPT_import_underlying_module);
-  Opts.SILSerializeAll |= Args.hasArg(OPT_sil_serialize_all);
   Opts.EnableSerializationNestedTypeLookupTable &=
       !Args.hasArg(OPT_disable_serialization_nested_type_lookup_table);
 
@@ -1329,6 +1328,7 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
   if (Args.hasArg(OPT_sil_merge_partial_modules))
     Opts.MergePartialModules = true;
 
+  Opts.SILSerializeAll |= Args.hasArg(OPT_sil_serialize_all);
   // Parse the optimization level.
   if (const Arg *A = Args.getLastArg(OPT_O_Group)) {
     if (A->getOption().matches(OPT_Onone)) {

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -55,8 +55,7 @@ std::string CompilerInvocation::getPCHHash() const {
 void CompilerInstance::createSILModule(bool WholeModule) {
   assert(MainModule && "main module not created yet");
   TheSILModule = SILModule::createEmptyModule(
-      getMainModule(), Invocation.getSILOptions(), WholeModule,
-      Invocation.getFrontendOptions().SILSerializeAll);
+    getMainModule(), Invocation.getSILOptions(), WholeModule);
 }
 
 void CompilerInstance::setPrimarySourceFile(SourceFile *SF) {
@@ -250,7 +249,7 @@ ModuleDecl *CompilerInstance::getMainModule() {
 
     if (Invocation.getFrontendOptions().EnableResilience)
       MainModule->setResilienceStrategy(ResilienceStrategy::Resilient);
-    else if (Invocation.getFrontendOptions().SILSerializeAll)
+    else if (Invocation.getSILOptions().SILSerializeAll)
       MainModule->setResilienceStrategy(ResilienceStrategy::Fragile);
   }
   return MainModule;

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -691,13 +691,13 @@ static bool performCompile(CompilerInstance &Instance,
       }
       astGuaranteedToCorrespondToSIL = !fileIsSIB(PrimaryFile);
       SM = performSILGeneration(*PrimaryFile, Invocation.getSILOptions(),
-                                None, opts.SILSerializeAll);
+                                None);
     } else {
       auto mod = Instance.getMainModule();
       astGuaranteedToCorrespondToSIL =
           llvm::none_of(mod->getFiles(), fileIsSIB);
       SM = performSILGeneration(mod, Invocation.getSILOptions(),
-                                opts.SILSerializeAll, true);
+                                true);
     }
   }
 
@@ -835,7 +835,8 @@ static bool performCompile(CompilerInstance &Instance,
       serializationOpts.OutputPath = opts.ModuleOutputPath.c_str();
       serializationOpts.DocOutputPath = opts.ModuleDocOutputPath.c_str();
       serializationOpts.GroupInfoPath = opts.GroupInfoPath.c_str();
-      serializationOpts.SerializeAllSIL = opts.SILSerializeAll;
+      serializationOpts.SerializeAllSIL =
+          Invocation.getSILOptions().SILSerializeAll;
       if (opts.SerializeBridgingHeader)
         serializationOpts.ImportedHeader = opts.ImplicitObjCHeaderPath;
       serializationOpts.ModuleLinkName = opts.ModuleLinkName;

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1352,9 +1352,8 @@ bool LinkEntity::isFragile(ForDefinition_t isDefinition) const {
     auto isCompletelySerialized = conformanceModule->getResilienceStrategy() ==
                                   ResilienceStrategy::Fragile;
 
-    // The conformance is fragile if it is in a -sil-serialize-all module, or
-    // has a fully publicly determined layout.
-    return isCompletelySerialized || conformance->hasFixedLayout();
+    // The conformance is fragile if it is in a -sil-serialize-all module.
+    return isCompletelySerialized;
   }
   return false;
 }

--- a/lib/SIL/SILModule.cpp
+++ b/lib/SIL/SILModule.cpp
@@ -83,12 +83,10 @@ class SILModule::SerializationCallback : public SerializedSILLoader::Callback {
 };
 
 SILModule::SILModule(ModuleDecl *SwiftModule, SILOptions &Options,
-                     const DeclContext *associatedDC, bool wholeModule,
-                     bool wholeModuleSerialized)
+                     const DeclContext *associatedDC, bool wholeModule)
     : TheSwiftModule(SwiftModule), AssociatedDeclContext(associatedDC),
       Stage(SILStage::Raw), Callback(new SILModule::SerializationCallback()),
-      wholeModule(wholeModule), WholeModuleSerialized(wholeModuleSerialized),
-      Options(Options), Types(*this) {}
+      wholeModule(wholeModule), Options(Options), Types(*this) {}
 
 SILModule::~SILModule() {
   // Decrement ref count for each SILGlobalVariable with static initializers.

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -38,9 +38,9 @@ using namespace Lowering;
 // SILGenModule Class implementation
 //===----------------------------------------------------------------------===//
 
-SILGenModule::SILGenModule(SILModule &M, ModuleDecl *SM, bool makeModuleFragile)
+SILGenModule::SILGenModule(SILModule &M, ModuleDecl *SM)
   : M(M), Types(M.Types), SwiftModule(SM), TopLevelSGF(nullptr),
-    Profiler(nullptr), makeModuleFragile(makeModuleFragile) {
+    Profiler(nullptr) {
 }
 
 SILGenModule::~SILGenModule() {
@@ -451,7 +451,7 @@ SILFunction *SILGenModule::getEmittedFunction(SILDeclRef constant,
       if (isAvailableExternally(F->getLinkage())) {
         F->setLinkage(constant.getLinkage(ForDefinition));
       }
-      if (makeModuleFragile) {
+      if (isMakeModuleFragile()) {
         F->setSerialized(IsSerialized);
       }
     }
@@ -498,7 +498,7 @@ SILFunction *SILGenModule::getFunction(SILDeclRef constant,
 
   assert(F && "SILFunction should have been defined");
 
-  if (makeModuleFragile) {
+  if (isMakeModuleFragile()) {
     SILLinkage linkage = constant.getLinkage(forDefinition);
     if (linkage != SILLinkage::PublicExternal) {
       F->setSerialized(IsSerialized);
@@ -959,7 +959,7 @@ SILFunction *SILGenModule::emitLazyGlobalInitializer(StringRef funcName,
       M.createFunction(SILLinkage::Private,
                        funcName, initSILType, nullptr,
                        SILLocation(binding), IsNotBare, IsNotTransparent,
-                       makeModuleFragile
+                       isMakeModuleFragile()
                            ? IsSerialized
                            : IsNotSerialized);
   f->setDebugScope(new (M) SILDebugScope(RegularLocation(binding), f));
@@ -1375,7 +1375,7 @@ void SILGenModule::emitSourceFile(SourceFile *sf, unsigned startElem) {
 
 std::unique_ptr<SILModule>
 SILModule::constructSIL(ModuleDecl *mod, SILOptions &options, FileUnit *SF,
-                        Optional<unsigned> startElem, bool makeModuleFragile,
+                        Optional<unsigned> startElem,
                         bool isWholeModule) {
   SharedTimer timer("SILGen");
   const DeclContext *DC;
@@ -1391,8 +1391,8 @@ SILModule::constructSIL(ModuleDecl *mod, SILOptions &options, FileUnit *SF,
   }
 
   std::unique_ptr<SILModule> M(
-      new SILModule(mod, options, DC, isWholeModule, makeModuleFragile));
-  SILGenModule SGM(*M, mod, makeModuleFragile);
+      new SILModule(mod, options, DC, isWholeModule));
+  SILGenModule SGM(*M, mod);
 
   if (SF) {
     if (auto *file = dyn_cast<SourceFile>(SF)) {
@@ -1450,16 +1450,14 @@ SILModule::constructSIL(ModuleDecl *mod, SILOptions &options, FileUnit *SF,
 std::unique_ptr<SILModule>
 swift::performSILGeneration(ModuleDecl *mod,
                             SILOptions &options,
-                            bool makeModuleFragile,
                             bool wholeModuleCompilation) {
-  return SILModule::constructSIL(mod, options, nullptr, None, makeModuleFragile,
+  return SILModule::constructSIL(mod, options, nullptr, None,
                                  wholeModuleCompilation);
 }
 
 std::unique_ptr<SILModule>
 swift::performSILGeneration(FileUnit &sf, SILOptions &options,
-                            Optional<unsigned> startElem,
-                            bool makeModuleFragile) {
+                            Optional<unsigned> startElem) {
   return SILModule::constructSIL(sf.getParentModule(), options, &sf, startElem,
-                                 makeModuleFragile, false);
+                                 false);
 }

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -106,7 +106,7 @@ public:
   
   /// If true, all functions and globals are made fragile. Currently only used
   /// for compiling the stdlib.
-  bool makeModuleFragile;
+  bool isMakeModuleFragile() const { return M.getOptions().SILSerializeAll; }
   
   Optional<SILDeclRef> StringToNSStringFn;
   Optional<SILDeclRef> NSStringToStringFn;
@@ -136,7 +136,7 @@ public:
   Optional<ProtocolConformance *> NSErrorConformanceToError;
 
 public:
-  SILGenModule(SILModule &M, ModuleDecl *SM, bool makeModuleFragile);
+  SILGenModule(SILModule &M, ModuleDecl *SM);
 
   ~SILGenModule();
   

--- a/lib/SILGen/SILGenGlobalVariable.cpp
+++ b/lib/SILGen/SILGenGlobalVariable.cpp
@@ -47,7 +47,7 @@ SILGlobalVariable *SILGenModule::getSILGlobalVariable(VarDecl *gDecl,
   SILType silTy = M.Types.getLoweredTypeOfGlobal(gDecl);
 
   auto *silGlobal = SILGlobalVariable::create(M, link,
-                                              makeModuleFragile
+                                              isMakeModuleFragile()
                                                 ? IsSerialized
                                                 : IsNotSerialized,
                                               mangledName, silTy,
@@ -223,7 +223,7 @@ void SILGenModule::emitGlobalInitialization(PatternBindingDecl *pd,
   // TODO: include the module in the onceToken's name mangling.
   // Then we can make it fragile.
   auto onceToken = SILGlobalVariable::create(M, SILLinkage::Private,
-                                             makeModuleFragile
+                                             isMakeModuleFragile()
                                                ? IsSerialized
                                                : IsNotSerialized,
                                              onceTokenBuffer, onceSILTy);

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -315,7 +315,7 @@ public:
 
     // Serialize the witness table if we're serializing everything with
     // -sil-serialize-all, or if the conformance itself thinks it should be.
-    if (SGM.makeModuleFragile)
+    if (SGM.isMakeModuleFragile())
       Serialized = IsSerialized;
 
     auto *nominal = Conformance->getType()->getAnyNominal();
@@ -431,7 +431,7 @@ public:
       // then SILGen gives the member private linkage, ignoring the more
       // visible accessibility it was given in the AST.
       witnessLinkage = SILLinkage::Public;
-      witnessSerialized = (SGM.makeModuleFragile
+      witnessSerialized = (SGM.isMakeModuleFragile()
                            ? IsSerialized
                            : IsNotSerialized);
     } else {

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -315,7 +315,13 @@ public:
 
     // Serialize the witness table if we're serializing everything with
     // -sil-serialize-all, or if the conformance itself thinks it should be.
-    if (SGM.makeModuleFragile || Conformance->hasFixedLayout())
+    if (SGM.makeModuleFragile)
+      Serialized = IsSerialized;
+
+    auto *nominal = Conformance->getType()->getAnyNominal();
+    if (nominal->hasFixedLayout() &&
+        proto->getEffectiveAccess() >= Accessibility::Public &&
+        nominal->getEffectiveAccess() >= Accessibility::Public)
       Serialized = IsSerialized;
 
     // Not all protocols use witness tables; in this case we just skip

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -314,12 +314,18 @@ public:
     Serialized = IsNotSerialized;
 
     // Serialize the witness table if we're serializing everything with
-    // -sil-serialize-all, or if the conformance itself thinks it should be.
+    // -sil-serialize-all.
     if (SGM.isMakeModuleFragile())
       Serialized = IsSerialized;
 
     auto *nominal = Conformance->getType()->getAnyNominal();
-    if (nominal->hasFixedLayout() &&
+    // Serialize the witness table if the conformance itself thinks it should be
+    // and resilience is explicitly enabled for this compilaiton or if we serialize
+    // all eligible witness tables.
+    if ((SGM.M.getSwiftModule()->getResilienceStrategy() ==
+             ResilienceStrategy::Resilient ||
+         SGM.M.getOptions().SILSerializeWitnessTables) &&
+        nominal->hasFixedLayout() &&
         proto->getEffectiveAccess() >= Accessibility::Public &&
         nominal->getEffectiveAccess() >= Accessibility::Public)
       Serialized = IsSerialized;

--- a/stdlib/CMakeLists.txt
+++ b/stdlib/CMakeLists.txt
@@ -93,11 +93,14 @@ add_custom_target(swift-test-stdlib ALL
 
 if(SWIFT_STDLIB_ENABLE_RESILIENCE)
   set(STDLIB_SIL_SERIALIZE_ALL)
+  set(STDLIB_SIL_SERIALIZE_WITNESS_TABLES)
 else()
   if(SWIFT_STDLIB_SIL_SERIALIZE_ALL)
     set(STDLIB_SIL_SERIALIZE_ALL "-Xfrontend" "-sil-serialize-all")
+    set(STDLIB_SIL_SERIALIZE_WITNESS_TABLES "-Xfrontend" "-sil-serialize-witness-tables")
   else()
     set(STDLIB_SIL_SERIALIZE_ALL)
+    set(STDLIB_SIL_SERIALIZE_WITNESS_TABLES)
   endif()
 endif()
 

--- a/stdlib/public/SDK/CMakeLists.txt
+++ b/stdlib/public/SDK/CMakeLists.txt
@@ -8,6 +8,8 @@ if(SWIFT_BUILD_STATIC_SDK_OVERLAY)
   list(APPEND SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES STATIC)
 endif()
 
+list(APPEND SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS "${STDLIB_SIL_SERIALIZE_WITNESS_TABLES}")
+
 set(all_overlays "Accelerate;AppKit;ARKit;AssetsLibrary;AVFoundation;CallKit;CloudKit;Contacts;CoreAudio;CoreData;CoreFoundation;CoreGraphics;CoreImage;CoreLocation;CoreMedia;CryptoTokenKit;Dispatch;Foundation;GameplayKit;GLKit;HomeKit;IOKit;Intents;MapKit;ObjectiveC;OpenCL;os;Photos;QuartzCore;SafariServices;SceneKit;simd;SpriteKit;UIKit;WatchKit;XCTest;XPC")
 
 if(DEFINED SWIFT_OVERLAY_TARGETS)

--- a/test/ClangImporter/enum-error.swift
+++ b/test/ClangImporter/enum-error.swift
@@ -1,14 +1,14 @@
 // REQUIRES: OS=macosx
 
-// RUN: %target-swift-frontend -DVALUE -emit-sil %s -import-objc-header %S/Inputs/enum-error.h | %FileCheck %s -check-prefix=VALUE
-// RUN: %target-swift-frontend -DEMPTYCATCH -emit-sil %s -import-objc-header %S/Inputs/enum-error.h | %FileCheck %s -check-prefix=EMPTYCATCH
-// RUN: %target-swift-frontend -DASQEXPR -emit-sil %s -import-objc-header %S/Inputs/enum-error.h | %FileCheck %s -check-prefix=ASQEXPR
-// RUN: %target-swift-frontend -DASBANGEXPR -emit-sil %s -import-objc-header %S/Inputs/enum-error.h | %FileCheck %s -check-prefix=ASBANGEXPR
-// RUN: %target-swift-frontend -DCATCHIS -emit-sil %s -import-objc-header %S/Inputs/enum-error.h | %FileCheck %s -check-prefix=CATCHIS
-// RUN: %target-swift-frontend -DCATCHAS -emit-sil %s -import-objc-header %S/Inputs/enum-error.h | %FileCheck %s -check-prefix=CATCHAS
-// RUN: %target-swift-frontend -DGENERICONLY -emit-sil %s -import-objc-header %S/Inputs/enum-error.h | %FileCheck %s -check-prefix=GENERICONLY
+// RUN: %target-swift-frontend -DVALUE -emit-sil -sil-serialize-witness-tables %s -import-objc-header %S/Inputs/enum-error.h | %FileCheck %s -check-prefix=VALUE
+// RUN: %target-swift-frontend -DEMPTYCATCH -emit-sil -sil-serialize-witness-tables %s -import-objc-header %S/Inputs/enum-error.h | %FileCheck %s -check-prefix=EMPTYCATCH
+// RUN: %target-swift-frontend -DASQEXPR -emit-sil -sil-serialize-witness-tables %s -import-objc-header %S/Inputs/enum-error.h | %FileCheck %s -check-prefix=ASQEXPR
+// RUN: %target-swift-frontend -DASBANGEXPR -emit-sil -sil-serialize-witness-tables %s -import-objc-header %S/Inputs/enum-error.h | %FileCheck %s -check-prefix=ASBANGEXPR
+// RUN: %target-swift-frontend -DCATCHIS -emit-sil -sil-serialize-witness-tables %s -import-objc-header %S/Inputs/enum-error.h | %FileCheck %s -check-prefix=CATCHIS
+// RUN: %target-swift-frontend -DCATCHAS -emit-sil -sil-serialize-witness-tables %s -import-objc-header %S/Inputs/enum-error.h | %FileCheck %s -check-prefix=CATCHAS
+// RUN: %target-swift-frontend -DGENERICONLY -emit-sil -sil-serialize-witness-tables %s -import-objc-header %S/Inputs/enum-error.h | %FileCheck %s -check-prefix=GENERICONLY
 
-// RUN: not %target-swift-frontend -DEXHAUSTIVE -emit-sil %s -import-objc-header %S/Inputs/enum-error.h 2>&1 | %FileCheck %s -check-prefix=EXHAUSTIVE
+// RUN: not %target-swift-frontend -DEXHAUSTIVE -emit-sil -sil-serialize-witness-tables %s -import-objc-header %S/Inputs/enum-error.h 2>&1 | %FileCheck %s -check-prefix=EXHAUSTIVE
 // RUN: %target-swift-frontend -typecheck %s -import-objc-header %S/Inputs/enum-error.h -DERRORS -verify
 
 // RUN: echo '#include "enum-error.h"' > %t.m

--- a/test/SILGen/SILDeclRef.swift
+++ b/test/SILGen/SILDeclRef.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -emit-sil %s | %FileCheck %s
-// RUN: %target-swift-frontend -emit-sil %s | %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -module-name="SILDeclRef"  - | %FileCheck %s
+// RUN: %target-swift-frontend -emit-sil -sil-serialize-witness-tables %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-sil -sil-serialize-witness-tables %s | %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -module-name="SILDeclRef"  - | %FileCheck %s
 
 // Check that all SILDeclRefs are represented in the text form with a signature.
 // This allows to avoid ambiguities which sometimes arise e.g. when a

--- a/test/SILGen/external-associated-type-conformance.swift
+++ b/test/SILGen/external-associated-type-conformance.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen -import-objc-header %S/Inputs/external-associated-type-conformance.h %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -sil-serialize-witness-tables -import-objc-header %S/Inputs/external-associated-type-conformance.h %s | %FileCheck %s
 // REQUIRES: objc_interop
 
 extension BadError: LocalizedError {}

--- a/test/SILGen/guaranteed_self.swift
+++ b/test/SILGen/guaranteed_self.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -emit-silgen %s -disable-objc-attr-requires-foundation-module | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -emit-silgen -sil-serialize-witness-tables %s -disable-objc-attr-requires-foundation-module | %FileCheck %s
 
 protocol Fooable {
   init()

--- a/test/SILGen/objc_bridging_any.swift
+++ b/test/SILGen/objc_bridging_any.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -Xllvm -sil-print-debuginfo -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -Xllvm -sil-print-debuginfo -emit-silgen -sil-serialize-witness-tables %s | %FileCheck %s
 // REQUIRES: objc_interop
 
 import Foundation

--- a/test/SILGen/objc_enum.swift
+++ b/test/SILGen/objc_enum.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -emit-silgen > %t.out
+// RUN: %target-swift-frontend -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -emit-silgen -sil-serialize-witness-tables > %t.out
 // RUN: %FileCheck -check-prefix=CHECK -check-prefix=CHECK-%target-ptrsize %s < %t.out
 // RUN: %FileCheck -check-prefix=NEGATIVE %s < %t.out
 

--- a/test/SILGen/objc_imported_generic.swift
+++ b/test/SILGen/objc_imported_generic.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-silgen -sil-serialize-witness-tables %s | %FileCheck %s
 // For integration testing, ensure we get through IRGen too.
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-ir -verify -DIRGEN_INTEGRATION_TEST %s
 

--- a/test/SILGen/objc_witnesses.swift
+++ b/test/SILGen/objc_witnesses.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen -sdk %S/Inputs -I %S/Inputs -enable-source-import %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -sil-serialize-witness-tables -sdk %S/Inputs -I %S/Inputs -enable-source-import %s | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/SILGen/testable-multifile.swift
+++ b/test/SILGen/testable-multifile.swift
@@ -3,9 +3,9 @@
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: %target-swift-frontend -emit-module %S/Inputs/TestableMultifileHelper.swift -enable-testing -o %t
 
-// RUN: %target-swift-frontend -emit-silgen -I %t %s %S/testable-multifile-other.swift -module-name main | %FileCheck %s
-// RUN: %target-swift-frontend -emit-silgen -I %t %S/testable-multifile-other.swift %s -module-name main | %FileCheck %s
-// RUN: %target-swift-frontend -emit-silgen -I %t -primary-file %s %S/testable-multifile-other.swift -module-name main | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -sil-serialize-witness-tables -I %t %s %S/testable-multifile-other.swift -module-name main | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -sil-serialize-witness-tables -I %t %S/testable-multifile-other.swift %s -module-name main | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -sil-serialize-witness-tables -I %t -primary-file %s %S/testable-multifile-other.swift -module-name main | %FileCheck %s
 
 // Just make sure we don't crash later on.
 // RUN: %target-swift-frontend -emit-ir -I %t -primary-file %s %S/testable-multifile-other.swift -module-name main -o /dev/null

--- a/test/SILGen/witness_accessibility.swift
+++ b/test/SILGen/witness_accessibility.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -emit-silgen -sil-serialize-witness-tables %s | %FileCheck %s
 
 public protocol P {
   func publicRequirement()

--- a/test/SILGen/witness_same_type.swift
+++ b/test/SILGen/witness_same_type.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -sil-serialize-witness-tables %s | %FileCheck %s
 // RUN: %target-swift-frontend -emit-ir %s
 
 protocol Fooable {

--- a/test/SILGen/witness_tables.swift
+++ b/test/SILGen/witness_tables.swift
@@ -1,8 +1,8 @@
-// RUN: %target-swift-frontend -emit-silgen -I %S/Inputs -enable-source-import %s -disable-objc-attr-requires-foundation-module > %t.sil
+// RUN: %target-swift-frontend -emit-silgen -sil-serialize-witness-tables -I %S/Inputs -enable-source-import %s -disable-objc-attr-requires-foundation-module > %t.sil
 // RUN: %FileCheck -check-prefix=TABLE -check-prefix=TABLE-ALL %s < %t.sil
 // RUN: %FileCheck -check-prefix=SYMBOL %s < %t.sil
 
-// RUN: %target-swift-frontend -emit-silgen -I %S/Inputs -enable-source-import %s -disable-objc-attr-requires-foundation-module -enable-testing > %t.testable.sil
+// RUN: %target-swift-frontend -emit-silgen -sil-serialize-witness-tables -I %S/Inputs -enable-source-import %s -disable-objc-attr-requires-foundation-module -enable-testing > %t.testable.sil
 // RUN: %FileCheck -check-prefix=TABLE-TESTABLE -check-prefix=TABLE-ALL %s < %t.testable.sil
 // RUN: %FileCheck -check-prefix=SYMBOL-TESTABLE %s < %t.testable.sil
 

--- a/test/SILOptimizer/dead_function_elimination.swift
+++ b/test/SILOptimizer/dead_function_elimination.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend %s -O -emit-sil | %FileCheck %s
-// RUN: %target-swift-frontend %s -O -emit-sil -enable-testing | %FileCheck -check-prefix=CHECK-TESTING %s
+// RUN: %target-swift-frontend %s -O -emit-sil -sil-serialize-witness-tables | %FileCheck %s
+// RUN: %target-swift-frontend %s -O -emit-sil -sil-serialize-witness-tables -enable-testing | %FileCheck -check-prefix=CHECK-TESTING %s
 
 // Check if cycles are removed.
 

--- a/test/SILOptimizer/devirt_materializeForSet.swift
+++ b/test/SILOptimizer/devirt_materializeForSet.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -O -emit-sil %s | %FileCheck %s
+// RUN: %target-swift-frontend -O -emit-sil -sil-serialize-witness-tables %s | %FileCheck %s
 
 // Check that compiler does not crash on the devirtualization of materializeForSet methods
 // and produces a correct code.

--- a/test/Serialization/sil-imported-enums.swift
+++ b/test/Serialization/sil-imported-enums.swift
@@ -2,12 +2,12 @@
 // RUN: mkdir -p %t
 
 // FIXME: BEGIN -enable-source-import hackaround
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %clang-importer-sdk-path/swift-modules/CoreGraphics.swift
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %clang-importer-sdk-path/swift-modules/Foundation.swift
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -sil-serialize-witness-tables -o %t %clang-importer-sdk-path/swift-modules/CoreGraphics.swift
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -sil-serialize-witness-tables -o %t %clang-importer-sdk-path/swift-modules/Foundation.swift
 // FIXME: END -enable-source-import hackaround
 
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-module -o %t -parse-as-library %S/Inputs/use_imported_enums.swift -module-name UsesImportedEnums
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-sil %s | %FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-module -sil-serialize-witness-tables -o %t -parse-as-library %S/Inputs/use_imported_enums.swift -module-name UsesImportedEnums
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-sil -sil-serialize-witness-tables %s | %FileCheck %s
 
 // REQUIRES: objc_interop
 


### PR DESCRIPTION
Serialize witness tables only if it -sil-serialize-all or -sil-serialize-witness-tables options are provided, which should happen only when building the stdlib and overlays, or it is a compilation with explicitly enabled resilience support. Disable serialization of witness tables in all other cases.

Disabling the serialization of witness tables also avoids serialization of protocol witness thunks, whose serialization in 3rd party code sometimes resulted in performance degradation, because resilience checking rules used by many parts of the compiler would prohibit certain optimizations like inlining or specialization, if the caller was serialized and the callee would not be serialized.

• Explanation: This is fix to recover the performance regression reported for Beta1. 

• Scope of Issue: Compiling a 3rd party code that does not use resilience may result in performance degradation, because some optimizations like specialization or inlining  could be skipped due to some serialization related checks. 

• Origination: rdar://32718853 by an external developer

• Risk: Low. It restricts SIL serialization of witness tables and protocol witness thunks.

This should fix rdar://32718853