### PR TITLE
[4.0] Debugger hook/breakpoint for issue reporting from the Swift runtime

### DIFF
--- a/include/swift/Runtime/Debug.h
+++ b/include/swift/Runtime/Debug.h
@@ -134,6 +134,48 @@ void dumpStackTraceEntry(unsigned index, void *framePC,
 LLVM_ATTRIBUTE_NOINLINE
 void printCurrentBacktrace(unsigned framesToSkip = 1);
 
+/// Debugger breakpoint ABI. This structure is passed to the debugger (and needs
+/// to be stable) and describes extra information about a fatal error or a
+/// non-fatal warning, which should be logged as a runtime issue. Please keep
+/// all integer values pointer-sized.
+struct RuntimeErrorDetails {
+  // ABI version, needs to be "1" currently.
+  uintptr_t version;
+
+  // A short hyphenated string describing the type of the issue, e.g.
+  // "precondition-failed" or "exclusivity-violation".
+  const char *errorType;
+
+  // Description of the current thread's stack position.
+  const char *currentStackDescription;
+
+  // Number of frames in the current stack that should be ignored when reporting
+  // the issue (exluding the reportToDebugger/_swift_runtime_on_report frame).
+  // The remaining top frame should point to user's code where the bug is.
+  uintptr_t framesToSkip;
+
+  // Address of some associated object (if there's any).
+  void *memoryAddress;
+
+  // A structure describing an extra thread (and its stack) that is related.
+  struct Thread {
+    const char *description;
+    uint64_t threadID;
+    uintptr_t numFrames;
+    void **frames;
+  };
+
+  // Number of extra threads (excluding the current thread) that are related,
+  // and the pointer to the array of extra threads.
+  uintptr_t numExtraThreads;
+  Thread *threads;
+};
+
+/// Debugger hook. Calling this stops the debugger with a message and details
+/// about the issues.
+void reportToDebugger(bool isFatal, const char *message,
+                      RuntimeErrorDetails *details = nullptr);
+
 // namespace swift
 }
 

--- a/stdlib/public/runtime/Errors.cpp
+++ b/stdlib/public/runtime/Errors.cpp
@@ -239,6 +239,20 @@ reportNow(uint32_t flags, const char *message)
 #endif
 }
 
+LLVM_ATTRIBUTE_NOINLINE SWIFT_RUNTIME_EXPORT
+void _swift_runtime_on_report(bool isFatal, const char *message,
+                              RuntimeErrorDetails *details) {
+  // Do nothing. This function is meant to be used by the debugger.
+
+  // The following is necessary to avoid calls from being optimized out.
+  asm volatile("" ::: "memory");
+}
+
+void swift::reportToDebugger(bool isFatal, const char *message,
+                             RuntimeErrorDetails *details) {
+  _swift_runtime_on_report(isFatal, message, details);
+}
+
 /// Report a fatal error to system console, stderr, and crash logs.
 /// Does not crash by itself.
 void swift::swift_reportError(uint32_t flags,

--- a/stdlib/public/runtime/Exclusivity.cpp
+++ b/stdlib/public/runtime/Exclusivity.cpp
@@ -65,23 +65,6 @@ static const char *getAccessName(ExclusivityFlags flags) {
 }
 
 LLVM_ATTRIBUTE_ALWAYS_INLINE
-static void printConflictDetails(const char *oldAccessName, void *oldPC,
-                                 const char *newAccessName, void *newPC) {
-  fprintf(stderr, "Previous access (a %s) started at ", oldAccessName);
-  if (oldPC) {
-    dumpStackTraceEntry(0, oldPC, /*shortOutput=*/true);
-    fprintf(stderr, " (0x%lx).\n", (uintptr_t)oldPC);
-  } else {
-    fprintf(stderr, "<unknown>.\n");
-  }
-
-  fprintf(stderr, "Current access (a %s) started at:\n", newAccessName);
-  // The top frame is in swift_beginAccess, don't print it.
-  constexpr unsigned framesToSkip = 2;
-  printCurrentBacktrace(framesToSkip);
-}
-
-LLVM_ATTRIBUTE_ALWAYS_INLINE
 static void reportExclusivityConflict(ExclusivityFlags oldAction, void *oldPC,
                                       ExclusivityFlags newFlags, void *newPC,
                                       void *pointer) {
@@ -94,14 +77,53 @@ static void reportExclusivityConflict(ExclusivityFlags oldAction, void *oldPC,
     return;
   }
 
-  fprintf(stderr,
-          "Simultaneous accesses to 0x%lx, but modification requires exclusive "
-          "access.\n",
-          (uintptr_t)pointer);
-  printConflictDetails(getAccessName(oldAction), oldPC,
-                       getAccessName(getAccessAction(newFlags)), newPC);
+  constexpr unsigned maxMessageLength = 100;
+  constexpr unsigned maxAccessDescriptionLength = 50;
+  char message[maxMessageLength];
+  snprintf(message, sizeof(message),
+           "Simultaneous accesses to 0x%lx, but modification requires "
+           "exclusive access",
+           (uintptr_t)pointer);
+  fprintf(stderr, "%s.\n", message);
 
-  if (isWarningOnly(newFlags)) {
+  char oldAccess[maxAccessDescriptionLength];
+  snprintf(oldAccess, sizeof(oldAccess),
+           "Previous access (a %s) started at", getAccessName(oldAction));
+  fprintf(stderr, "%s ", oldAccess);
+  if (oldPC) {
+    dumpStackTraceEntry(0, oldPC, /*shortOutput=*/true);
+    fprintf(stderr, " (0x%lx).\n", (uintptr_t)oldPC);
+  } else {
+    fprintf(stderr, "<unknown>.\n");
+  }
+
+  char newAccess[maxAccessDescriptionLength];
+  snprintf(newAccess, sizeof(newAccess), "Current access (a %s) started at",
+           getAccessName(getAccessAction(newFlags)));
+  fprintf(stderr, "%s:\n", newAccess);
+  // The top frame is in swift_beginAccess, don't print it.
+  constexpr unsigned framesToSkip = 1;
+  printCurrentBacktrace(framesToSkip);
+
+  bool keepGoing = isWarningOnly(newFlags);
+
+  RuntimeErrorDetails::Thread secondaryThread = {
+    .description = oldAccess,
+    .numFrames = 1,
+    .frames = &oldPC
+  };
+  RuntimeErrorDetails details = {
+    .version = 1,
+    .errorType = "exclusivity-violation",
+    .currentStackDescription = newAccess,
+    .framesToSkip = framesToSkip,
+    .memoryAddress = pointer,
+    .numExtraThreads = 1,
+    .threads = &secondaryThread
+  };
+  reportToDebugger(!keepGoing, message, &details);
+
+  if (keepGoing) {
     return;
   }
 


### PR DESCRIPTION
This cherry-picks fec8d72ea318acd638982334804db5b6c6714a2f into swift-4.0-branch.

=== **CCC information** ===
**Explanation**: Implements a debugger hook for reporting runtime issues. Swift runtime has some features (exclusivity, objc inference) that currently log into stderr only, and we need to improve user workflow.
**Scope**: On the runtime side, this is a very limited change, which only adds an interface for the debugger to set a breakpoint on. The LLDB follow-up change will read the information about the runtime issue.
**Radar**: <rdar://problem/32085171>
**Risk**: This PR alone is very low risk, it only calls an empty function when a runtime issue is found (exclusivity violation, calling an implicit objc entrypoint).  The risk of the LLDB change will be discussed in the LLDB PR.
**Testing**: This was tested together with the LLDB change by running the LLDB test suite + the new 2 tests that verify the issue reporting is working for exclusivity and objc inference.