### PR TITLE
[Foundation] Validate indexes and ranges passed into Data so that bounding conditions are respected

### DIFF
--- a/test/stdlib/TestData.swift
+++ b/test/stdlib/TestData.swift
@@ -1188,9 +1188,7 @@ DataTests.test("bounding failure append absurd length") {
     data.append("hello", count: Int.min)
 }
 
-DataTests.test("bounding failure subscript")
-        .skip(.always("fails with resilient stdlib (rdar://problem/30560514)"))
-        .code {
+DataTests.test("bounding failure subscript") {
     var data = "Hello World".data(using: .utf8)!
     expectCrashLater()
     data[100] = 4


### PR DESCRIPTION
This enforces index validation of ranges and indexes passed into Data so that reading or writing past the bounds is defined behavior by preconditions.

This resolves the following issues:
rdar://problem/30460514
rdar://problem/32019725