### PR TITLE
[4.0] [AST Verifier] Don't verify parsed function bodies in a type-checked AST.

### DIFF
--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -451,6 +451,28 @@ public:
     bool shouldVerifyChecked(Pattern *S) { return S->hasType(); }
     bool shouldVerifyChecked(Decl *S) { return true; }
 
+    // Only verify functions if they have bodies we can safely walk.
+    // FIXME: This is a bit of a hack; we should be able to check the
+    // invariants of a parsed body as well.
+    bool shouldVerify(AbstractFunctionDecl *afd) {
+      switch (afd->getBodyKind()) {
+      case AbstractFunctionDecl::BodyKind::None:
+      case AbstractFunctionDecl::BodyKind::TypeChecked:
+      case AbstractFunctionDecl::BodyKind::Skipped:
+      case AbstractFunctionDecl::BodyKind::MemberwiseInitializer:
+        return true;
+
+      case AbstractFunctionDecl::BodyKind::Unparsed:
+      case AbstractFunctionDecl::BodyKind::Parsed:
+      case AbstractFunctionDecl::BodyKind::Synthesize:
+        if (auto SF = dyn_cast<SourceFile>(afd->getModuleScopeContext())) {
+          return SF->ASTStage < SourceFile::TypeChecked;
+        }
+
+        return false;
+      }
+    }
+
     // Default cases for cleaning up as we exit a node.
     void cleanup(Expr *E) { }
     void cleanup(Stmt *S) { }


### PR DESCRIPTION
**Explanation**: Eliminates an AST verifier crash on reasonable ASTs where we ended up
synthesizing the body for a function (e.g., from the Clang importer) that we don't actually need to type-check.
**Scope**: This is a fairly common source of AST verifier crashes in builds with assertions enabled, but otherwise has zero effect.
**Radar**: rdar://problem/32774779
**Risk**: Zero risk to customer builds; this code is disabled in non-assertions compilers.
**Testing**: Built the affected project with assertions enabled, plus of course normal compiler regression testing.