### PR TITLE
[Sema] Allow self-assignment with parenthesized right-side

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -4264,8 +4264,14 @@ bool TypeChecker::diagnoseSelfAssignment(const Expr *E) {
   if (!AE)
     return false;
 
+  // Allow the use of parentheses to express self-assignment when it's a deliberate choice
+  auto src = AE->getSrc();
+  auto loadSrc = dyn_cast<LoadExpr>(src);
+  if (loadSrc != nullptr && isa<ParenExpr>(loadSrc->getSubExpr()))
+    return false;
+
   auto LHSDecl = findReferencedDecl(AE->getDest());
-  auto RHSDecl = findReferencedDecl(AE->getSrc());
+  auto RHSDecl = findReferencedDecl(src);
 
   if (LHSDecl.second && LHSDecl == RHSDecl) {
     diagnose(AE->getLoc(), LHSDecl.first ? diag::self_assignment_prop

--- a/test/Sema/diag_self_assign.swift
+++ b/test/Sema/diag_self_assign.swift
@@ -8,14 +8,18 @@ class SA1 {
   init(fooi: Int) {
     var foo = fooi
     foo = foo // expected-error {{assigning a variable to itself}}
+    foo = (foo) // no-error
     self.foo = self.foo // expected-error {{assigning a property to itself}}
+    self.foo = (self.foo) // no-error
     foo = self.foo // no-error
     self.foo = foo // no-error
   }
   func f(fooi: Int) {
     var foo = fooi
     foo = foo // expected-error {{assigning a variable to itself}}
+    foo = (foo) // no-error
     self.foo = self.foo // expected-error {{assigning a property to itself}}
+    self.foo = (self.foo) // no-error
     foo = self.foo // no-error
     self.foo = foo // no-error
   }
@@ -31,14 +35,18 @@ class SA2 {
   init(fooi: Int) {
     var foo = fooi
     foo = foo // expected-error {{assigning a variable to itself}}
+    foo = (foo) // no-error
     self.foo = self.foo // expected-error {{assigning a property to itself}}
+    self.foo = (self.foo) // no-error
     foo = self.foo // no-error
     self.foo = foo // no-error
   }
   func f(fooi: Int) {
     var foo = fooi
     foo = foo // expected-error {{assigning a variable to itself}}
+    foo = (foo) // no-error
     self.foo = self.foo // expected-error {{assigning a property to itself}}
+    self.foo = (self.foo) // no-error
     foo = self.foo // no-error
     self.foo = foo // no-error
   }
@@ -74,6 +82,7 @@ class SA5 {
 }
 func SA5_test(a: SA4, b: SA4) {
   a.foo = a.foo // expected-error {{assigning a property to itself}}
+  a.foo = (a.foo) // no-error
   a.foo = b.foo
 }
 


### PR DESCRIPTION
Per the discussion in the Jira ticket, this PR restores the ability to perform self-assignments if the right side of the expression is wrapped in parentheses:
`self.name = (self.name)`

Resolves [SR-4464](https://bugs.swift.org/browse/SR-4464) and addresses feedback on #8607
