### PR TITLE
[NFC] Kill decomposeParamType

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -2313,8 +2313,8 @@ public:
   public:
     explicit Param(Type t) : Ty(t), Label(Identifier()), Flags() {}
     explicit Param(const TupleTypeElt &tte)
-      : Ty(tte.getType()), Label(tte.getName()),
-        Flags(tte.getParameterFlags()) {}
+      : Ty(tte.isVararg() ? tte.getVarargBaseTy() : tte.getType()),
+        Label(tte.getName()), Flags(tte.getParameterFlags()) {}
     
   private:
     /// The type of the parameter. For a variadic parameter, this is the
@@ -2332,6 +2332,8 @@ public:
     
     Identifier getLabel() const { return Label; }
     
+    ParameterTypeFlags getParameterFlags() const { return Flags; }
+
     /// Whether the parameter is varargs
     bool isVariadic() const { return Flags.isVariadic(); }
     
@@ -2622,13 +2624,12 @@ struct CallArgParam {
 SmallVector<CallArgParam, 4>
 decomposeArgType(Type type, ArrayRef<Identifier> argumentLabels);
 
-/// Break a parameter type into an array of \c CallArgParams.
-///
-/// \param paramOwner The declaration that owns this parameter.
-/// \param level The level of parameters that are being decomposed.
-SmallVector<CallArgParam, 4>
-decomposeParamType(Type type, const ValueDecl *paramOwner, unsigned level);
-
+/// Break the parameter list into an array of booleans describing whether
+/// the argument type at each index has a default argument associated with
+/// it.
+void computeDefaultMap(Type type, const ValueDecl *paramOwner, unsigned level,
+                       SmallVectorImpl<bool> &outDefaultMap);
+  
 /// Turn a param list into a symbolic and printable representation that does not
 /// include the types, something like (: , b:, c:)
 std::string getParamListAsString(ArrayRef<CallArgParam> parameters);

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -3161,8 +3161,7 @@ static SmallVector<AnyFunctionType::Param, 4> decomposeInputType(Type type) {
   case TypeKind::Tuple: {
     auto tupleTy = cast<TupleType>(type.getPointer());
     for (auto &elt : tupleTy->getElements()) {
-      AnyFunctionType::Param param(elt);
-      result.push_back(param);
+      result.push_back(AnyFunctionType::Param(elt));
     }
     return result;
   }

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -679,12 +679,12 @@ static bool isDeclAsSpecializedAs(TypeChecker &tc, DeclContext *dc,
         // second type's inputs, i.e., can we forward the arguments?
         auto funcTy1 = openedType1->castTo<FunctionType>();
         auto funcTy2 = openedType2->castTo<FunctionType>();
-        SmallVector<CallArgParam, 4> params1 =
-          decomposeParamType(funcTy1->getInput(), decl1,
-                             outerDC1->isTypeContext());
-        SmallVector<CallArgParam, 4> params2 =
-          decomposeParamType(funcTy2->getInput(), decl2,
-                             outerDC2->isTypeContext());
+        auto params1 = funcTy1->getParams();
+        auto params2 = funcTy2->getParams();
+        SmallVector<bool, 4> defaultMapType2;
+        computeDefaultMap(funcTy2->getInput(), decl2,
+                          outerDC2->isTypeContext(),
+                          defaultMapType2);
 
         unsigned numParams1 = params1.size();
         unsigned numParams2 = params2.size();
@@ -694,8 +694,8 @@ static bool isDeclAsSpecializedAs(TypeChecker &tc, DeclContext *dc,
         bool compareTrailingClosureParamsSeparately = false;
         if (!tc.getLangOpts().isSwiftVersion3()) {
           if (numParams1 > 0 && numParams2 > 0 &&
-              params1.back().Ty->is<AnyFunctionType>() &&
-              params2.back().Ty->is<AnyFunctionType>()) {
+              params1.back().getType()->is<AnyFunctionType>() &&
+              params2.back().getType()->is<AnyFunctionType>()) {
             compareTrailingClosureParamsSeparately = true;
             --numParams1;
             --numParams2;
@@ -703,7 +703,8 @@ static bool isDeclAsSpecializedAs(TypeChecker &tc, DeclContext *dc,
         }
 
         auto maybeAddSubtypeConstraint =
-            [&](const CallArgParam &param1, const CallArgParam &param2) -> bool{
+            [&](const AnyFunctionType::Param &param1,
+                const AnyFunctionType::Param &param2) -> bool {
           // If one parameter is variadic and the other is not...
           if (param1.isVariadic() != param2.isVariadic()) {
             // If the first parameter is the variadic one, it's not
@@ -714,8 +715,8 @@ static bool isDeclAsSpecializedAs(TypeChecker &tc, DeclContext *dc,
           }
 
           // Check whether the first parameter is a subtype of the second.
-          cs.addConstraint(ConstraintKind::Subtype, param1.Ty, param2.Ty,
-                           locator);
+          cs.addConstraint(ConstraintKind::Subtype,
+                           param1.getType(), param2.getType(), locator);
           return true;
         };
 
@@ -726,7 +727,7 @@ static bool isDeclAsSpecializedAs(TypeChecker &tc, DeclContext *dc,
             // We need either a default argument or a variadic
             // argument for the first declaration to be more
             // specialized.
-            if (!params2[i].HasDefaultArgument &&
+            if (!defaultMapType2[i] &&
                 !params2[i].isVariadic())
               return false;
 

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2635,7 +2635,8 @@ public:
 /// the parameters (as described by the given parameter type).
 ///
 /// \param argTuple The arguments.
-/// \param paramTuple The parameters.
+/// \param params The parameters.
+/// \param defaultMap A map indicating if the parameter at that index has a default value.
 /// \param hasTrailingClosure Whether the last argument is a trailing closure.
 /// \param allowFixes Whether to allow fixes when matching arguments.
 ///
@@ -2646,7 +2647,8 @@ public:
 /// bound to each of the parameters.
 /// \returns true if the call arguments could not be matched to the parameters.
 bool matchCallArguments(ArrayRef<CallArgParam> argTuple,
-                        ArrayRef<CallArgParam> paramTuple,
+                        ArrayRef<AnyFunctionType::Param> params,
+                        const SmallVectorImpl<bool> &defaultMap,
                         bool hasTrailingClosure,
                         bool allowFixes,
                         MatchCallArgumentListener &listener,


### PR DESCRIPTION
`AnyFunctionType::Param` is now the source of truth when it comes to information about parameter types.  Information about default arguments on parameter decls is computed separately by `swift:: computeDefaultMap`.