### PR TITLE
[test] Add regression test for already fixed syntax coloring crash (rdar31960764)

### DIFF
--- a/test/IDE/coloring_unclosed_hash_if.swift
+++ b/test/IDE/coloring_unclosed_hash_if.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-ide-test -syntax-coloring -source-filename %s | %FileCheck %s
+// RUN: %target-swift-ide-test -syntax-coloring -typecheck -source-filename %s | %FileCheck %s
+
+// CHECK: <#kw>#if</#kw> <#id>d</#id>
+// CHECK-NEXT: <kw>func</kw> bar() {
+// CHECK-NEXT: <#kw>#if</#kw> <#id>d</#id>
+// CHECK-NEXT: }
+// CHECK-NEXT: <kw>func</kw> foo() {}
+
+#if d
+func bar() {
+  #if d
+}
+func foo() {}


### PR DESCRIPTION
<!-- What's in this pull request? -->
Add regression test for crash when syntax highlighting an unclosed `#if ` followed by any non-whitespace character. The crash itself was incidentally fixed by the changes in https://github.com/apple/swift/pull/10289.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves rdar://problem/31960764

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->