### PR TITLE
benchmarks: Fix the BitCount benchmark

### DIFF
--- a/benchmark/single-source/BitCount.swift
+++ b/benchmark/single-source/BitCount.swift
@@ -31,10 +31,12 @@ func countBitSet(_ num: Int) -> Int {
 
 @inline(never)
 public func run_BitCount(_ N: Int) {
-  for _ in 1...100*N {
+  var sum = 0
+  for _ in 1...1000*N {
     // Check some results.
-    CheckResults(countBitSet(1) == 1)
-    CheckResults(countBitSet(2) == 1)
-    CheckResults(countBitSet(2457) == 6)
+    sum = sum &+ countBitSet(getInt(1))
+              &+ countBitSet(getInt(2))
+              &+ countBitSet(getInt(2457))
   }
+  CheckResults(sum == 8 * 1000 * N)
 }

--- a/benchmark/utils/TestsUtils.swift
+++ b/benchmark/utils/TestsUtils.swift
@@ -91,3 +91,10 @@ public func someProtocolFactory() -> SomeProtocol { return MyStruct() }
 // which are using it.
 public func blackHole<T>(_ x: T) {
 }
+
+// Return the passed argument without letting the optimizer know that.
+// It's important that this function is in another module than the tests
+// which are using it.
+@inline(never)
+public func getInt(_ x: Int) -> Int { return x }
+


### PR DESCRIPTION
*) Increase the iteration count, so that we cat a time value > 100 for better accuracy
*) Use getInt to prevent constant propgation and loop hoisting
