### PR TITLE
[GSB] Record unresolved potential archetypes as delayed requirements.

### DIFF
--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -265,6 +265,10 @@ private:
   GenericSignatureBuilder(const GenericSignatureBuilder &) = delete;
   GenericSignatureBuilder &operator=(const GenericSignatureBuilder &) = delete;
 
+  /// Record that the given potential archetype is unresolved, so we know to
+  /// resolve it later.
+  void recordUnresolvedType(PotentialArchetype *unresolvedPA);
+
   /// When a particular requirement cannot be resolved due to, e.g., a
   /// currently-unresolvable or nested type, this routine should be
   /// called to cope with the unresolved requirement.
@@ -293,6 +297,9 @@ private:
   ConstraintResult addConformanceRequirement(PotentialArchetype *T,
                                              ProtocolDecl *Proto,
                                              const RequirementSource *Source);
+
+  /// Try to resolve the given unresolved potential archetype.
+  ConstraintResult resolveUnresolvedType(PotentialArchetype *pa);
 
 public:
   /// \brief Add a new same-type requirement between two fully resolved types
@@ -1325,13 +1332,7 @@ class GenericSignatureBuilder::PotentialArchetype {
 
   /// \brief Construct a new potential archetype for an unresolved
   /// associated type.
-  PotentialArchetype(PotentialArchetype *parent, Identifier name)
-    : parentOrBuilder(parent), identifier(name), isUnresolvedNestedType(true),
-      IsRecursive(false), Invalid(false),
-      DiagnosedRename(false)
-  { 
-    assert(parent != nullptr && "Not an associated type?");
-  }
+  PotentialArchetype(PotentialArchetype *parent, Identifier name);
 
   /// \brief Construct a new potential archetype for an associated type.
   PotentialArchetype(PotentialArchetype *parent, AssociatedTypeDecl *assocType)
@@ -1688,6 +1689,9 @@ public:
 
     /// A same-type requirement.
     SameType,
+
+    /// An unresolved potential archetype.
+    Unresolved,
   };
 
   Kind kind;

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -1678,7 +1678,19 @@ public:
 /// Describes a requirement whose processing has been delayed for some reason.
 class GenericSignatureBuilder::DelayedRequirement {
 public:
-  RequirementKind kind;
+  enum Kind {
+    /// A type requirement, which may be a conformance or a superclass
+    /// requirement.
+    Type,
+
+    /// A layout requirement.
+    Layout,
+
+    /// A same-type requirement.
+    SameType,
+  };
+
+  Kind kind;
   UnresolvedType lhs;
   RequirementRHS rhs;
   FloatingRequirementSource source;

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -299,7 +299,8 @@ private:
                                              const RequirementSource *Source);
 
   /// Try to resolve the given unresolved potential archetype.
-  ConstraintResult resolveUnresolvedType(PotentialArchetype *pa);
+  ConstraintResult resolveUnresolvedType(PotentialArchetype *pa,
+                                         bool allowTypoCorrection);
 
 public:
   /// \brief Add a new same-type requirement between two fully resolved types

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -1025,6 +1025,16 @@ bool FloatingRequirementSource::isRecursive(
   return false;
 }
 
+PotentialArchetype::PotentialArchetype(PotentialArchetype *parent,
+                                       Identifier name)
+  : parentOrBuilder(parent), identifier(name), isUnresolvedNestedType(true),
+  IsRecursive(false), Invalid(false),
+  DiagnosedRename(false)
+{
+  assert(parent != nullptr && "Not an associated type?");
+  getBuilder()->recordUnresolvedType(this);
+}
+
 GenericSignatureBuilder::PotentialArchetype::~PotentialArchetype() {
   ++NumPotentialArchetypes;
 
@@ -1200,6 +1210,15 @@ void EquivalenceClass::dump(llvm::raw_ostream &out) const {
 
 void EquivalenceClass::dump() const {
   dump(llvm::errs());
+}
+
+void GenericSignatureBuilder::recordUnresolvedType(
+                                          PotentialArchetype *unresolvedPA) {
+  ++Impl->NumUnresolvedNestedTypes;
+
+  Impl->DelayedRequirements.push_back(
+    {DelayedRequirement::Unresolved, unresolvedPA, RequirementRHS(),
+     FloatingRequirementSource::forAbstract()});
 }
 
 ConstraintResult GenericSignatureBuilder::handleUnresolvedRequirement(
@@ -1770,7 +1789,6 @@ PotentialArchetype *PotentialArchetype::getNestedArchetypeAnchor(
   auto &nested = NestedTypes[name];
   if (nested.empty()) {
     nested.push_back(new PotentialArchetype(this, name));
-    ++builder.Impl->NumUnresolvedNestedTypes;
 
     auto rep = getRepresentative();
     if (rep != this) {
@@ -2786,6 +2804,32 @@ ConstraintResult GenericSignatureBuilder::addConformanceRequirement(
   }
 
   return ConstraintResult::Resolved;
+}
+
+ConstraintResult GenericSignatureBuilder::resolveUnresolvedType(
+                                          PotentialArchetype *pa) {
+  // If something else resolved this type, we're done.
+  if (!pa->isUnresolved())
+    return ConstraintResult::Resolved;
+
+  // If the parent isn't resolved, we can't resolve this now.
+  auto parentPA = pa->getParent();
+  if (parentPA->isUnresolved())
+    return ConstraintResult::Unresolved;
+
+  // Resolve this via its parent.
+  auto resolvedPA =
+    parentPA->getNestedArchetypeAnchor(
+                        pa->getNestedName(),
+                        *this,
+                        PotentialArchetype::NestedTypeUpdate::ResolveExisting);
+  if (resolvedPA) {
+    assert(!pa->isUnresolved() && "This type must have been resolved");
+    return ConstraintResult::Resolved;
+  }
+
+  // We are unable to resolve this constraint.
+  return ConstraintResult::Unresolved;
 }
 
 ConstraintResult GenericSignatureBuilder::addLayoutRequirementDirect(
@@ -4145,6 +4189,10 @@ void GenericSignatureBuilder::processDelayedRequirements() {
         reqResult = addSameTypeRequirement(
                                req.lhs, asUnresolvedType(req.rhs), req.source,
                                UnresolvedHandlingKind::ReturnUnresolved);
+        break;
+
+      case DelayedRequirement::Unresolved:
+        reqResult = resolveUnresolvedType(req.lhs.get<PotentialArchetype *>());
         break;
       }
 

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -85,11 +85,6 @@ struct GenericSignatureBuilder::Implementation {
   /// The potential archetypes for the generic parameters in \c GenericParams.
   SmallVector<PotentialArchetype *, 4> PotentialArchetypes;
 
-  /// The number of nested types that haven't yet been resolved to archetypes.
-  /// Once all requirements have been added, this will be zero in well-formed
-  /// code.
-  unsigned NumUnresolvedNestedTypes = 0;
-
   /// The nested types that have been renamed.
   SmallVector<PotentialArchetype *, 4> RenamedNestedTypes;
 
@@ -1099,9 +1094,6 @@ void GenericSignatureBuilder::PotentialArchetype::resolveAssociatedType(
   isUnresolvedNestedType = false;
   identifier.assocTypeOrConcrete = assocType;
   assert(assocType->getName() == getNestedName());
-  assert(builder.Impl->NumUnresolvedNestedTypes > 0 &&
-         "Mismatch in number of unresolved nested types");
-  --builder.Impl->NumUnresolvedNestedTypes;
 }
 
 void GenericSignatureBuilder::PotentialArchetype::resolveConcreteType(
@@ -1111,9 +1103,6 @@ void GenericSignatureBuilder::PotentialArchetype::resolveConcreteType(
   isUnresolvedNestedType = false;
   identifier.assocTypeOrConcrete = concreteDecl;
   assert(concreteDecl->getName() == getNestedName());
-  assert(builder.Impl->NumUnresolvedNestedTypes > 0 &&
-         "Mismatch in number of unresolved nested types");
-  --builder.Impl->NumUnresolvedNestedTypes;
 }
 
 Optional<ConcreteConstraint>
@@ -1214,8 +1203,6 @@ void EquivalenceClass::dump() const {
 
 void GenericSignatureBuilder::recordUnresolvedType(
                                           PotentialArchetype *unresolvedPA) {
-  ++Impl->NumUnresolvedNestedTypes;
-
   Impl->DelayedRequirements.push_back(
     {DelayedRequirement::Unresolved, unresolvedPA, RequirementRHS(),
      FloatingRequirementSource::forAbstract()});
@@ -2806,8 +2793,59 @@ ConstraintResult GenericSignatureBuilder::addConformanceRequirement(
   return ConstraintResult::Resolved;
 }
 
+/// Perform typo correction on the given nested type, producing the
+/// corrected name (if successful).
+static Identifier typoCorrectNestedType(
+                    GenericSignatureBuilder::PotentialArchetype *pa) {
+  StringRef name = pa->getNestedName().str();
+
+  // Look through all of the associated types of all of the protocols
+  // to which the parent conforms.
+  llvm::SmallVector<Identifier, 2> bestMatches;
+  unsigned bestEditDistance = 0;
+  unsigned maxScore = (name.size() + 1) / 3;
+  for (auto proto : pa->getParent()->getConformsTo()) {
+    for (auto member : getProtocolMembers(proto)) {
+      auto assocType = dyn_cast<AssociatedTypeDecl>(member);
+      if (!assocType)
+        continue;
+
+      unsigned dist = name.edit_distance(assocType->getName().str(),
+                                         /*AllowReplacements=*/true,
+                                         maxScore);
+      assert(dist > 0 && "nested type should have matched associated type");
+      if (bestEditDistance == 0 || dist == bestEditDistance) {
+        bestEditDistance = dist;
+        maxScore = bestEditDistance;
+        bestMatches.push_back(assocType->getName());
+      } else if (dist < bestEditDistance) {
+        bestEditDistance = dist;
+        maxScore = bestEditDistance;
+        bestMatches.clear();
+        bestMatches.push_back(assocType->getName());
+      }
+    }
+  }
+
+  // FIXME: Look through the superclass.
+
+  // If we didn't find any matches at all, fail.
+  if (bestMatches.empty())
+    return Identifier();
+
+  // Make sure that we didn't find more than one match at the best
+  // edit distance.
+  for (auto other : llvm::makeArrayRef(bestMatches).slice(1)) {
+    if (other != bestMatches.front())
+      return Identifier();
+  }
+
+  return bestMatches.front();
+}
+
 ConstraintResult GenericSignatureBuilder::resolveUnresolvedType(
-                                          PotentialArchetype *pa) {
+                                          PotentialArchetype *pa,
+                                          bool allowTypoCorrection) {
   // If something else resolved this type, we're done.
   if (!pa->isUnresolved())
     return ConstraintResult::Resolved;
@@ -2828,8 +2866,31 @@ ConstraintResult GenericSignatureBuilder::resolveUnresolvedType(
     return ConstraintResult::Resolved;
   }
 
-  // We are unable to resolve this constraint.
-  return ConstraintResult::Unresolved;
+  // If we aren't allowed to perform typo correction, we can't resolve the
+  // constraint.
+  if (!allowTypoCorrection)
+    return ConstraintResult::Unresolved;
+
+  // Try to typo correct to a nested type name.
+  Identifier correction = typoCorrectNestedType(pa);
+  if (correction.empty()) {
+    pa->setInvalid();
+    return ConstraintResult::Conflicting;
+  }
+
+  // Note that this is being renamed.
+  pa->saveNameForRenaming();
+  Impl->RenamedNestedTypes.push_back(pa);
+
+  // Resolve the associated type and merge the potential archetypes.
+  auto replacement = pa->getParent()->getNestedType(correction, *this);
+  pa->resolveAssociatedType(replacement->getResolvedAssociatedType(),
+                            *this);
+  addSameTypeRequirement(pa, replacement,
+                         RequirementSource::forNestedTypeNameMatch(pa),
+                         UnresolvedHandlingKind::GenerateConstraints);
+
+  return ConstraintResult::Resolved;
 }
 
 ConstraintResult GenericSignatureBuilder::addLayoutRequirementDirect(
@@ -3749,56 +3810,6 @@ void GenericSignatureBuilder::inferRequirements(
   }
 }
 
-/// Perform typo correction on the given nested type, producing the
-/// corrected name (if successful).
-static Identifier typoCorrectNestedType(
-                    GenericSignatureBuilder::PotentialArchetype *pa) {
-  StringRef name = pa->getNestedName().str();
-
-  // Look through all of the associated types of all of the protocols
-  // to which the parent conforms.
-  llvm::SmallVector<Identifier, 2> bestMatches;
-  unsigned bestEditDistance = 0;
-  unsigned maxScore = (name.size() + 1) / 3;
-  for (auto proto : pa->getParent()->getConformsTo()) {
-    for (auto member : getProtocolMembers(proto)) {
-      auto assocType = dyn_cast<AssociatedTypeDecl>(member);
-      if (!assocType)
-        continue;
-
-      unsigned dist = name.edit_distance(assocType->getName().str(),
-                                         /*AllowReplacements=*/true,
-                                         maxScore);
-      assert(dist > 0 && "nested type should have matched associated type");
-      if (bestEditDistance == 0 || dist == bestEditDistance) {
-        bestEditDistance = dist;
-        maxScore = bestEditDistance;
-        bestMatches.push_back(assocType->getName());
-      } else if (dist < bestEditDistance) {
-        bestEditDistance = dist;
-        maxScore = bestEditDistance;
-        bestMatches.clear();
-        bestMatches.push_back(assocType->getName());
-      }
-    }
-  }
-
-  // FIXME: Look through the superclass.
-
-  // If we didn't find any matches at all, fail.
-  if (bestMatches.empty())
-    return Identifier();
-
-  // Make sure that we didn't find more than one match at the best
-  // edit distance.
-  for (auto other : llvm::makeArrayRef(bestMatches).slice(1)) {
-    if (other != bestMatches.front())
-      return Identifier();
-  }
-
-  return bestMatches.front();
-}
-
 namespace swift {
   template<typename T>
   bool operator<(const Constraint<T> &lhs, const Constraint<T> &rhs) {
@@ -4104,33 +4115,6 @@ GenericSignatureBuilder::finalize(SourceLoc loc,
       }
     }
   }
-
-  // If any nested types remain unresolved, produce diagnostics.
-  if (Impl->NumUnresolvedNestedTypes > 0) {
-    visitPotentialArchetypes([&](PotentialArchetype *pa) {
-      // We only care about nested types that haven't been resolved.
-      if (!pa->isUnresolved()) return;
-
-      // Try to typo correct to a nested type name.
-      Identifier correction = typoCorrectNestedType(pa);
-      if (correction.empty()) {
-        pa->setInvalid();
-        return;
-      }
-
-      // Note that this is being renamed.
-      pa->saveNameForRenaming();
-      Impl->RenamedNestedTypes.push_back(pa);
-      
-      // Resolve the associated type and merge the potential archetypes.
-      auto replacement = pa->getParent()->getNestedType(correction, *this);
-      pa->resolveAssociatedType(replacement->getResolvedAssociatedType(),
-                                *this);
-      addSameTypeRequirement(pa, replacement,
-                             RequirementSource::forNestedTypeNameMatch(pa),
-                             UnresolvedHandlingKind::GenerateConstraints);
-    });
-  }
 }
 
 bool GenericSignatureBuilder::diagnoseRemainingRenames(
@@ -4162,11 +4146,16 @@ static GenericSignatureBuilder::UnresolvedType asUnresolvedType(
 
 void GenericSignatureBuilder::processDelayedRequirements() {
   bool anySolved = !Impl->DelayedRequirements.empty();
+  bool allowTypoCorrection = false;
   while (anySolved) {
     // Steal the delayed requirements so we can reprocess them.
     anySolved = false;
     auto delayed = std::move(Impl->DelayedRequirements);
     Impl->DelayedRequirements.clear();
+
+    // Whether we saw any unresolve type constraints that we couldn't
+    // resolve.
+    bool hasUnresolvedUnresolvedTypes = false;
 
     // Process delayed requirements.
     for (const auto &req : delayed) {
@@ -4192,7 +4181,9 @@ void GenericSignatureBuilder::processDelayedRequirements() {
         break;
 
       case DelayedRequirement::Unresolved:
-        reqResult = resolveUnresolvedType(req.lhs.get<PotentialArchetype *>());
+        reqResult = resolveUnresolvedType(
+                                      req.lhs.get<PotentialArchetype *>(),
+                                      allowTypoCorrection);
         break;
       }
 
@@ -4210,8 +4201,18 @@ void GenericSignatureBuilder::processDelayedRequirements() {
       case ConstraintResult::Unresolved:
         // Add the requirement back.
         Impl->DelayedRequirements.push_back(req);
+
+        if (req.kind == DelayedRequirement::Unresolved)
+          hasUnresolvedUnresolvedTypes = true;
         break;
       }
+    }
+
+    // If we didn't solve anything, but we did see some unresolved types,
+    // try again with typo correction enabled.
+    if (!anySolved && hasUnresolvedUnresolvedTypes && !allowTypoCorrection) {
+      allowTypoCorrection = true;
+      anySolved = true;
     }
   }
 }

--- a/test/decl/protocol/req/where_clause.swift
+++ b/test/decl/protocol/req/where_clause.swift
@@ -1,0 +1,18 @@
+// RUN: %target-typecheck-verify-swift
+
+// rdar://problem/31401161
+class C1 {}
+
+protocol P1 {
+  associatedtype Element
+}
+
+protocol P2 : P1 {
+  associatedtype SubSequence : P1 // expected-note{{'SubSequence' declared here}}
+}
+
+protocol P3 : P2 {
+  associatedtype SubSequence : P2 // expected-warning{{redeclaration of associated type 'SubSequence' from protocol 'P2' is better expressed as a 'where' clause on the protocol}}
+}
+
+func foo<S>(_: S) where S.SubSequence.Element == C1, S : P3 {}

--- a/validation-test/IDE/crashers_2_fixed/0006-crazy-associated-types.swift
+++ b/validation-test/IDE/crashers_2_fixed/0006-crazy-associated-types.swift
@@ -1,4 +1,4 @@
-// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
 // REQUIRES: asserts
 
 protocol a {

--- a/validation-test/compiler_crashers_2_fixed/0097-rdar32077627.swift
+++ b/validation-test/compiler_crashers_2_fixed/0097-rdar32077627.swift
@@ -1,3 +1,3 @@
-// RUN: not --crash %target-swift-frontend -typecheck -primary-file %s
+// RUN: not %target-swift-frontend -typecheck -primary-file %s
 
 func hexEncodeBytes<T: Collection>(_ bytes: T) where T.Generator.Element == UInt8 { }


### PR DESCRIPTION
Whenever we form a potential archetype that is unresolved (because it
names a member wasn't known at the time the potential archetype was
formed), create a corresponding delayed requirement to resolve the
potential archetype. This ensures that all potential archetypes get a
chance to be resolve, fixing the

    nested type should have matched associated type

assertion in rdar://problem/31401161 (and others). Fold typo correction into this scheme, fixing rdar://problem/31048352 and rdar://problem/32077627.