### PR TITLE
[swiftc (27 vs. 5563)] Add crasher in swift::ProtocolCompositionType::get

### DIFF
--- a/validation-test/compiler_crashers/28782-superclass-superclass-isequal-t-should-have-diagnosed-multiple-superclasses-by-n.swift
+++ b/validation-test/compiler_crashers/28782-superclass-superclass-isequal-t-should-have-diagnosed-multiple-superclasses-by-n.swift
@@ -1,0 +1,12 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+[.a{}ExtendedGraphemeClusterLiteralConvertible
+& ManagedBuffer
+& ManagedBuffer


### PR DESCRIPTION
Add test case for crash triggered in `swift::ProtocolCompositionType::get`.

Current number of unresolved compiler crashers: 27 (5563 resolved)

/cc @slavapestov - just wanted to let you know that this crasher caused an assertion failure for the assertion `(!Superclass || Superclass->isEqual(T)) && "Should have diagnosed multiple superclasses by now"` added on 2017-04-09 by you in commit 32a75058 :-)

Assertion failure in [`lib/AST/Type.cpp (line 911)`](https://github.com/apple/swift/blob/ffcca776a22f71bc7e39dccc5b97c7ad91efaf8b/lib/AST/Type.cpp#L911):

```
Assertion `(!Superclass || Superclass->isEqual(T)) && "Should have diagnosed multiple superclasses by now"' failed.

When executing: void addProtocols(swift::Type, SmallVectorImpl<swift::ProtocolDecl *> &, swift::Type &, bool &)
```

Assertion context:

```c++
  if (auto Proto = T->getAs<ProtocolType>()) {
    auto KnownPos = Known.find(Proto->getDecl());
    if (KnownPos != Known.end()) {
      // We've come across a protocol that is in our original list. Zap it.
      Protocols[KnownPos->second] = nullptr;
      ZappedAny = true;
    }

    if (Visited.insert(Proto->getDecl()).second) {
      Stack.push_back(Proto->getDecl());
      for (auto Inherited : Proto->getDecl()->getInheritedProtocols())
```
Stack trace:

```
0 0x0000000003a765e8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3a765e8)
1 0x0000000003a76d26 SignalHandler(int) (/path/to/swift/bin/swift+0x3a76d26)
2 0x00007f305c203390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007f305a728428 gsignal /build/glibc-bfm8X4/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f305a72a02a abort /build/glibc-bfm8X4/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f305a720bd7 __assert_fail_base /build/glibc-bfm8X4/glibc-2.23/assert/assert.c:92:0
6 0x00007f305a720c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x00000000015cde6b (/path/to/swift/bin/swift+0x15cde6b)
8 0x00000000015c9951 swift::ProtocolCompositionType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>, bool) (/path/to/swift/bin/swift+0x15c9951)
9 0x00000000015c5715 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x15c5715)
10 0x00000000012daff3 swift::ASTVisitor<(anonymous namespace)::ConstraintGenerator, swift::Type, void, void, void, void, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x12daff3)
11 0x00000000012e0ff8 (anonymous namespace)::ConstraintWalker::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0x12e0ff8)
12 0x00000000015226f1 (anonymous namespace)::Traversal::visitCollectionExpr(swift::CollectionExpr*) (/path/to/swift/bin/swift+0x15226f1)
13 0x000000000151f1cb swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x151f1cb)
14 0x00000000012d7b71 swift::constraints::ConstraintSystem::generateConstraints(swift::Expr*) (/path/to/swift/bin/swift+0x12d7b71)
15 0x00000000013017d6 swift::constraints::ConstraintSystem::solve(swift::Expr*&, swift::Type, swift::ExprTypeCheckListener*, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0x13017d6)
16 0x000000000133a724 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0x133a724)
17 0x000000000133e1f0 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x133e1f0)
18 0x00000000013c24e5 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13c24e5)
19 0x00000000013c1cf6 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0x13c1cf6)
20 0x00000000013dff70 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x13dff70)
21 0x0000000000f9de7d swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf9de7d)
22 0x00000000004abe79 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4abe79)
23 0x00000000004aa419 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4aa419)
24 0x0000000000465697 main (/path/to/swift/bin/swift+0x465697)
25 0x00007f305a713830 __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:325:0
26 0x0000000000462d39 _start (/path/to/swift/bin/swift+0x462d39)
```