### PR TITLE
[swiftc (28 vs. 5563)] Add crasher in swift::GenericSignature::getConformanceAccessPath

### DIFF
--- a/validation-test/compiler_crashers/28783-hasconformanceinsignature-inprotocol-getrequirementsignature-subjecttype-conform.swift
+++ b/validation-test/compiler_crashers/28783-hasconformanceinsignature-inprotocol-getrequirementsignature-subjecttype-conform.swift
@@ -1,0 +1,12 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+class a:A
+protocol A:a{
+protocol A{struct a{var f:A


### PR DESCRIPTION
Add test case for crash triggered in `swift::GenericSignature::getConformanceAccessPath`.

Current number of unresolved compiler crashers: 28 (5563 resolved)

/cc @DougGregor - just wanted to let you know that this crasher caused an assertion failure for the assertion `hasConformanceInSignature(inProtocol->getRequirementSignature(), subjectType, conformingProto) && "missing explicit conformance in requirement signature"` added on 2017-03-08 by you in commit 1f8b0f9b :-)

Assertion failure in [`lib/AST/GenericSignature.cpp (line 846)`](https://github.com/apple/swift/blob/36f689d1d20fac3c339bdc2657765c5349569ceb/lib/AST/GenericSignature.cpp#L846):

```
Assertion `hasConformanceInSignature(inProtocol->getRequirementSignature(), subjectType, conformingProto) && "missing explicit conformance in requirement signature"' failed.

When executing: auto swift::GenericSignature::getConformanceAccessPath(swift::Type, swift::ProtocolDecl *, swift::ModuleDecl &)::(anonymous class)::operator()(swift::GenericSignature *, const RequirementSource *, swift::ProtocolDecl *, swift::Type) const
```

Assertion context:

```c++
          ->getCanonicalTypeInContext(subjectType,
                                      *inProtocol->getParentModule());

        assert(hasConformanceInSignature(inProtocol->getRequirementSignature(),
                                         subjectType, conformingProto) &&
               "missing explicit conformance in requirement signature");

        // Record this step.
        path.path.push_back({subjectType, conformingProto});
        return;
      }
```
Stack trace:

```
0 0x0000000003a765e8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3a765e8)
1 0x0000000003a76d26 SignalHandler(int) (/path/to/swift/bin/swift+0x3a76d26)
2 0x00007f54b7228390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007f54b574d428 gsignal /build/glibc-bfm8X4/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f54b574f02a abort /build/glibc-bfm8X4/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f54b5745bd7 __assert_fail_base /build/glibc-bfm8X4/glibc-2.23/assert/assert.c:92:0
6 0x00007f54b5745c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x000000000156a921 std::_Function_handler<void (swift::GenericSignature*, swift::GenericSignatureBuilder::RequirementSource const*, swift::ProtocolDecl*, swift::Type), swift::GenericSignature::getConformanceAccessPath(swift::Type, swift::ProtocolDecl*, swift::ModuleDecl&)::$_11>::_M_invoke(std::_Any_data const&, swift::GenericSignature*&&, swift::GenericSignatureBuilder::RequirementSource const*&&, swift::ProtocolDecl*&&, swift::Type&&) (/path/to/swift/bin/swift+0x156a921)
8 0x000000000156abc3 std::_Function_handler<void (swift::GenericSignature*, swift::GenericSignatureBuilder::RequirementSource const*, swift::ProtocolDecl*, swift::Type), swift::GenericSignature::getConformanceAccessPath(swift::Type, swift::ProtocolDecl*, swift::ModuleDecl&)::$_11>::_M_invoke(std::_Any_data const&, swift::GenericSignature*&&, swift::GenericSignatureBuilder::RequirementSource const*&&, swift::ProtocolDecl*&&, swift::Type&&) (/path/to/swift/bin/swift+0x156abc3)
9 0x0000000001569909 swift::GenericSignature::getConformanceAccessPath(swift::Type, swift::ProtocolDecl*, swift::ModuleDecl&) (/path/to/swift/bin/swift+0x1569909)
10 0x00000000015c1b15 swift::SubstitutionMap::lookupConformance(swift::CanType, swift::ProtocolDecl*) const (/path/to/swift/bin/swift+0x15c1b15)
11 0x000000000156a32e bool llvm::function_ref<bool (swift::Type, llvm::ArrayRef<swift::Requirement>)>::callback_fn<swift::GenericSignature::getSubstitutions(swift::SubstitutionMap const&, llvm::SmallVectorImpl<swift::Substitution>&) const::$_8>(long, swift::Type, llvm::ArrayRef<swift::Requirement>) (/path/to/swift/bin/swift+0x156a32e)
12 0x00000000015671c7 swift::GenericSignature::enumeratePairedRequirements(llvm::function_ref<bool (swift::Type, llvm::ArrayRef<swift::Requirement>)>) const (/path/to/swift/bin/swift+0x15671c7)
13 0x0000000001568732 swift::GenericSignature::getSubstitutions(swift::SubstitutionMap const&, llvm::SmallVectorImpl<swift::Substitution>&) const (/path/to/swift/bin/swift+0x1568732)
14 0x00000000013e3059 swift::constraints::Solution::computeSubstitutions(swift::GenericSignature*, swift::constraints::ConstraintLocator*, llvm::SmallVectorImpl<swift::Substitution>&) const (/path/to/swift/bin/swift+0x13e3059)
15 0x00000000013e9bd2 (anonymous namespace)::ExprRewriter::buildMemberRef(swift::Expr*, swift::Type, swift::SourceLoc, swift::ValueDecl*, swift::DeclNameLoc, swift::Type, swift::constraints::ConstraintLocatorBuilder, swift::constraints::ConstraintLocatorBuilder, bool, swift::FunctionRefKind, swift::AccessSemantics, bool) (/path/to/swift/bin/swift+0x13e9bd2)
16 0x00000000013f6a4d swift::ASTVisitor<(anonymous namespace)::ExprRewriter, swift::Expr*, void, void, void, void, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x13f6a4d)
17 0x00000000013e85d4 (anonymous namespace)::ExprRewriter::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0x13e85d4)
18 0x00000000013ee081 (anonymous namespace)::ExprWalker::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0x13ee081)
19 0x000000000151f1ec swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x151f1ec)
20 0x00000000013e5560 swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) (/path/to/swift/bin/swift+0x13e5560)
21 0x000000000133e2df swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x133e2df)
22 0x00000000013c3928 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13c3928)
23 0x00000000013c2416 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13c2416)
24 0x00000000013c07bd swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) (/path/to/swift/bin/swift+0x13c07bd)
25 0x00000000013c062d swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) (/path/to/swift/bin/swift+0x13c062d)
26 0x00000000013c133d swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0x13c133d)
27 0x00000000013df148 typeCheckFunctionsAndExternalDecls(swift::TypeChecker&) (/path/to/swift/bin/swift+0x13df148)
28 0x00000000013dfffa swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x13dfffa)
29 0x0000000000f9de7d swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf9de7d)
30 0x00000000004abe79 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4abe79)
31 0x00000000004aa419 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4aa419)
32 0x0000000000465697 main (/path/to/swift/bin/swift+0x465697)
33 0x00007f54b5738830 __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:325:0
34 0x0000000000462d39 _start (/path/to/swift/bin/swift+0x462d39)
```