### PR TITLE
[Syntax] Serialize top level decls as an array

### DIFF
--- a/test/Syntax/Inputs/serialize_multiple_decls.json
+++ b/test/Syntax/Inputs/serialize_multiple_decls.json
@@ -152,4 +152,3 @@
     "presence": "Present"
   }
 ]
-

--- a/test/Syntax/Inputs/serialize_multiple_decls.json
+++ b/test/Syntax/Inputs/serialize_multiple_decls.json
@@ -1,0 +1,155 @@
+[
+  {
+    "kind": "UnknownDecl",
+    "layout": [
+      {
+        "tokenKind": {
+          "kind": "kw_struct",
+          "text": "struct"
+        },
+        "leadingTrivia": [
+          {
+            "kind": "LineComment",
+            "value": "\/\/ RUN: %swift-syntax-test -input-source-filename %s -serialize-raw-tree > %t"
+          },
+          {
+            "kind": "Newline",
+            "value": 1
+          },
+          {
+            "kind": "LineComment",
+            "value": "\/\/ RUN: diff %t %S\/Inputs\/serialize_multiple_decls.json"
+          },
+          {
+            "kind": "Newline",
+            "value": 2
+          }
+        ],
+        "trailingTrivia": [
+          {
+            "kind": "Space",
+            "value": 1
+          }
+        ],
+        "presence": "Present"
+      },
+      {
+        "tokenKind": {
+          "kind": "identifier",
+          "text": "A"
+        },
+        "leadingTrivia": [
+
+        ],
+        "trailingTrivia": [
+          {
+            "kind": "Space",
+            "value": 1
+          }
+        ],
+        "presence": "Present"
+      },
+      {
+        "tokenKind": {
+          "kind": "l_brace",
+          "text": "{"
+        },
+        "leadingTrivia": [
+
+        ],
+        "trailingTrivia": [
+
+        ],
+        "presence": "Present"
+      },
+      {
+        "tokenKind": {
+          "kind": "r_brace",
+          "text": "}"
+        },
+        "leadingTrivia": [
+          {
+            "kind": "Newline",
+            "value": 1
+          }
+        ],
+        "trailingTrivia": [
+
+        ],
+        "presence": "Present"
+      }
+    ],
+    "presence": "Present"
+  },
+  {
+    "kind": "UnknownDecl",
+    "layout": [
+      {
+        "tokenKind": {
+          "kind": "kw_struct",
+          "text": "struct"
+        },
+        "leadingTrivia": [
+          {
+            "kind": "Newline",
+            "value": 2
+          }
+        ],
+        "trailingTrivia": [
+          {
+            "kind": "Space",
+            "value": 1
+          }
+        ],
+        "presence": "Present"
+      },
+      {
+        "tokenKind": {
+          "kind": "identifier",
+          "text": "B"
+        },
+        "leadingTrivia": [
+
+        ],
+        "trailingTrivia": [
+          {
+            "kind": "Space",
+            "value": 1
+          }
+        ],
+        "presence": "Present"
+      },
+      {
+        "tokenKind": {
+          "kind": "l_brace",
+          "text": "{"
+        },
+        "leadingTrivia": [
+
+        ],
+        "trailingTrivia": [
+
+        ],
+        "presence": "Present"
+      },
+      {
+        "tokenKind": {
+          "kind": "r_brace",
+          "text": "}"
+        },
+        "leadingTrivia": [
+          {
+            "kind": "Newline",
+            "value": 1
+          }
+        ],
+        "trailingTrivia": [
+
+        ],
+        "presence": "Present"
+      }
+    ],
+    "presence": "Present"
+  }
+]
+

--- a/test/Syntax/Inputs/serialize_struct_decl.json
+++ b/test/Syntax/Inputs/serialize_struct_decl.json
@@ -270,4 +270,3 @@
     "presence": "Present"
   }
 ]
-

--- a/test/Syntax/Inputs/serialize_struct_decl.json
+++ b/test/Syntax/Inputs/serialize_struct_decl.json
@@ -1,270 +1,273 @@
-{
-  "kind": "UnknownDecl",
-  "layout": [
-    {
-      "tokenKind": {
-        "kind": "kw_struct",
-        "text": "struct"
-      },
-      "leadingTrivia": [
-        {
-          "kind": "LineComment",
-          "value": "\/\/ RUN: %swift-syntax-test -input-source-filename %s -serialize-raw-tree > %t"
+[
+  {
+    "kind": "UnknownDecl",
+    "layout": [
+      {
+        "tokenKind": {
+          "kind": "kw_struct",
+          "text": "struct"
         },
-        {
-          "kind": "Newline",
-          "value": 1
+        "leadingTrivia": [
+          {
+            "kind": "LineComment",
+            "value": "\/\/ RUN: %swift-syntax-test -input-source-filename %s -serialize-raw-tree > %t"
+          },
+          {
+            "kind": "Newline",
+            "value": 1
+          },
+          {
+            "kind": "LineComment",
+            "value": "\/\/ RUN: diff %t %S\/Inputs\/serialize_struct_decl.json"
+          },
+          {
+            "kind": "Newline",
+            "value": 2
+          }
+        ],
+        "trailingTrivia": [
+          {
+            "kind": "Space",
+            "value": 1
+          }
+        ],
+        "presence": "Present"
+      },
+      {
+        "tokenKind": {
+          "kind": "identifier",
+          "text": "Foo"
         },
-        {
-          "kind": "LineComment",
-          "value": "\/\/ RUN: diff %t %S\/Inputs\/serialize_struct_decl.json"
+        "leadingTrivia": [
+
+        ],
+        "trailingTrivia": [
+          {
+            "kind": "Space",
+            "value": 1
+          }
+        ],
+        "presence": "Present"
+      },
+      {
+        "tokenKind": {
+          "kind": "l_brace",
+          "text": "{"
         },
-        {
-          "kind": "Newline",
-          "value": 2
-        }
-      ],
-      "trailingTrivia": [
-        {
-          "kind": "Space",
-          "value": 1
-        }
-      ],
-      "presence": "Present"
-    },
-    {
-      "tokenKind": {
-        "kind": "identifier",
-        "text": "Foo"
-      },
-      "leadingTrivia": [
+        "leadingTrivia": [
 
-      ],
-      "trailingTrivia": [
-        {
-          "kind": "Space",
-          "value": 1
-        }
-      ],
-      "presence": "Present"
-    },
-    {
-      "tokenKind": {
-        "kind": "l_brace",
-        "text": "{"
-      },
-      "leadingTrivia": [
+        ],
+        "trailingTrivia": [
 
-      ],
-      "trailingTrivia": [
-
-      ],
-      "presence": "Present"
-    },
-    {
-      "tokenKind": {
-        "kind": "kw_let",
-        "text": "let"
+        ],
+        "presence": "Present"
       },
-      "leadingTrivia": [
-        {
-          "kind": "Newline",
-          "value": 1
+      {
+        "tokenKind": {
+          "kind": "kw_let",
+          "text": "let"
         },
-        {
-          "kind": "Space",
-          "value": 2
-        }
-      ],
-      "trailingTrivia": [
-        {
-          "kind": "Space",
-          "value": 3
-        }
-      ],
-      "presence": "Present"
-    },
-    {
-      "tokenKind": {
-        "kind": "identifier",
-        "text": "bar"
+        "leadingTrivia": [
+          {
+            "kind": "Newline",
+            "value": 1
+          },
+          {
+            "kind": "Space",
+            "value": 2
+          }
+        ],
+        "trailingTrivia": [
+          {
+            "kind": "Space",
+            "value": 3
+          }
+        ],
+        "presence": "Present"
       },
-      "leadingTrivia": [
-
-      ],
-      "trailingTrivia": [
-        {
-          "kind": "Space",
-          "value": 1
-        }
-      ],
-      "presence": "Present"
-    },
-    {
-      "tokenKind": {
-        "kind": "colon",
-        "text": ":"
-      },
-      "leadingTrivia": [
-
-      ],
-      "trailingTrivia": [
-        {
-          "kind": "Space",
-          "value": 1
-        }
-      ],
-      "presence": "Present"
-    },
-    {
-      "tokenKind": {
-        "kind": "identifier",
-        "text": "Int"
-      },
-      "leadingTrivia": [
-
-      ],
-      "trailingTrivia": [
-
-      ],
-      "presence": "Present"
-    },
-    {
-      "tokenKind": {
-        "kind": "kw_let",
-        "text": "let"
-      },
-      "leadingTrivia": [
-        {
-          "kind": "Newline",
-          "value": 2
+      {
+        "tokenKind": {
+          "kind": "identifier",
+          "text": "bar"
         },
-        {
-          "kind": "Space",
-          "value": 2
-        }
-      ],
-      "trailingTrivia": [
-        {
-          "kind": "Space",
-          "value": 1
-        }
-      ],
-      "presence": "Present"
-    },
-    {
-      "tokenKind": {
-        "kind": "identifier",
-        "text": "baz"
-      },
-      "leadingTrivia": [
+        "leadingTrivia": [
 
-      ],
-      "trailingTrivia": [
-        {
-          "kind": "Space",
-          "value": 1
-        }
-      ],
-      "presence": "Present"
-    },
-    {
-      "tokenKind": {
-        "kind": "colon",
-        "text": ":"
+        ],
+        "trailingTrivia": [
+          {
+            "kind": "Space",
+            "value": 1
+          }
+        ],
+        "presence": "Present"
       },
-      "leadingTrivia": [
-
-      ],
-      "trailingTrivia": [
-        {
-          "kind": "Space",
-          "value": 1
-        }
-      ],
-      "presence": "Present"
-    },
-    {
-      "tokenKind": {
-        "kind": "identifier",
-        "text": "Array"
-      },
-      "leadingTrivia": [
-
-      ],
-      "trailingTrivia": [
-        {
-          "kind": "Space",
-          "value": 1
-        }
-      ],
-      "presence": "Present"
-    },
-    {
-      "tokenKind": {
-        "kind": "oper_binary_spaced",
-        "text": "<"
-      },
-      "leadingTrivia": [
-
-      ],
-      "trailingTrivia": [
-        {
-          "kind": "Space",
-          "value": 1
-        }
-      ],
-      "presence": "Present"
-    },
-    {
-      "tokenKind": {
-        "kind": "identifier",
-        "text": "Int"
-      },
-      "leadingTrivia": [
-
-      ],
-      "trailingTrivia": [
-        {
-          "kind": "Space",
-          "value": 1
-        }
-      ],
-      "presence": "Present"
-    },
-    {
-      "tokenKind": {
-        "kind": "oper_binary_spaced",
-        "text": ">"
-      },
-      "leadingTrivia": [
-
-      ],
-      "trailingTrivia": [
-
-      ],
-      "presence": "Present"
-    },
-    {
-      "tokenKind": {
-        "kind": "r_brace",
-        "text": "}"
-      },
-      "leadingTrivia": [
-        {
-          "kind": "Newline",
-          "value": 1
+      {
+        "tokenKind": {
+          "kind": "colon",
+          "text": ":"
         },
-        {
-          "kind": "Space",
-          "value": 6
-        }
-      ],
-      "trailingTrivia": [
+        "leadingTrivia": [
 
-      ],
-      "presence": "Present"
-    }
-  ],
-  "presence": "Present"
-}
+        ],
+        "trailingTrivia": [
+          {
+            "kind": "Space",
+            "value": 1
+          }
+        ],
+        "presence": "Present"
+      },
+      {
+        "tokenKind": {
+          "kind": "identifier",
+          "text": "Int"
+        },
+        "leadingTrivia": [
+
+        ],
+        "trailingTrivia": [
+
+        ],
+        "presence": "Present"
+      },
+      {
+        "tokenKind": {
+          "kind": "kw_let",
+          "text": "let"
+        },
+        "leadingTrivia": [
+          {
+            "kind": "Newline",
+            "value": 2
+          },
+          {
+            "kind": "Space",
+            "value": 2
+          }
+        ],
+        "trailingTrivia": [
+          {
+            "kind": "Space",
+            "value": 1
+          }
+        ],
+        "presence": "Present"
+      },
+      {
+        "tokenKind": {
+          "kind": "identifier",
+          "text": "baz"
+        },
+        "leadingTrivia": [
+
+        ],
+        "trailingTrivia": [
+          {
+            "kind": "Space",
+            "value": 1
+          }
+        ],
+        "presence": "Present"
+      },
+      {
+        "tokenKind": {
+          "kind": "colon",
+          "text": ":"
+        },
+        "leadingTrivia": [
+
+        ],
+        "trailingTrivia": [
+          {
+            "kind": "Space",
+            "value": 1
+          }
+        ],
+        "presence": "Present"
+      },
+      {
+        "tokenKind": {
+          "kind": "identifier",
+          "text": "Array"
+        },
+        "leadingTrivia": [
+
+        ],
+        "trailingTrivia": [
+          {
+            "kind": "Space",
+            "value": 1
+          }
+        ],
+        "presence": "Present"
+      },
+      {
+        "tokenKind": {
+          "kind": "oper_binary_spaced",
+          "text": "<"
+        },
+        "leadingTrivia": [
+
+        ],
+        "trailingTrivia": [
+          {
+            "kind": "Space",
+            "value": 1
+          }
+        ],
+        "presence": "Present"
+      },
+      {
+        "tokenKind": {
+          "kind": "identifier",
+          "text": "Int"
+        },
+        "leadingTrivia": [
+
+        ],
+        "trailingTrivia": [
+          {
+            "kind": "Space",
+            "value": 1
+          }
+        ],
+        "presence": "Present"
+      },
+      {
+        "tokenKind": {
+          "kind": "oper_binary_spaced",
+          "text": ">"
+        },
+        "leadingTrivia": [
+
+        ],
+        "trailingTrivia": [
+
+        ],
+        "presence": "Present"
+      },
+      {
+        "tokenKind": {
+          "kind": "r_brace",
+          "text": "}"
+        },
+        "leadingTrivia": [
+          {
+            "kind": "Newline",
+            "value": 1
+          },
+          {
+            "kind": "Space",
+            "value": 6
+          }
+        ],
+        "trailingTrivia": [
+
+        ],
+        "presence": "Present"
+      }
+    ],
+    "presence": "Present"
+  }
+]
+

--- a/test/Syntax/serialize_multiple_decls.swift
+++ b/test/Syntax/serialize_multiple_decls.swift
@@ -1,0 +1,8 @@
+// RUN: %swift-syntax-test -input-source-filename %s -serialize-raw-tree > %t
+// RUN: diff %t %S/Inputs/serialize_multiple_decls.json
+
+struct A {
+}
+
+struct B {
+}

--- a/tools/swift-syntax-test/swift-syntax-test.cpp
+++ b/tools/swift-syntax-test/swift-syntax-test.cpp
@@ -246,11 +246,13 @@ int doSerializeRawTree(const char *MainExecutablePath,
   getSyntaxTree(MainExecutablePath, InputFilename, Instance,
                 TopLevelDecls, Tokens);
 
-  for (auto &Node : TopLevelDecls) {
-    swift::json::Output out(llvm::outs());
-    auto Raw = Node.getRaw();
-    out << Raw;
+  std::vector<RC<syntax::RawSyntax>> RawTopLevelDecls;
+  for (auto &Decl : TopLevelDecls) {
+    RawTopLevelDecls.push_back(Decl.getRaw());
   }
+
+  swift::json::Output out(llvm::outs());
+  out << RawTopLevelDecls;
 
   llvm::outs() << "\n";
 


### PR DESCRIPTION
Previously the syntax serialization test printed each top-level decl individually. This now prints them as an array of top-level decls.