### PR TITLE
Improve reporting of @objc inference issues from the Swift runtime

### DIFF
--- a/include/swift/Runtime/Debug.h
+++ b/include/swift/Runtime/Debug.h
@@ -139,7 +139,9 @@ void printCurrentBacktrace(unsigned framesToSkip = 1);
 /// non-fatal warning, which should be logged as a runtime issue. Please keep
 /// all integer values pointer-sized.
 struct RuntimeErrorDetails {
-  // ABI version, needs to be "1" currently.
+  static const uintptr_t currentVersion = 2;
+
+  // ABI version, needs to be set to "currentVersion".
   uintptr_t version;
 
   // A short hyphenated string describing the type of the issue, e.g.
@@ -169,6 +171,33 @@ struct RuntimeErrorDetails {
   // and the pointer to the array of extra threads.
   uintptr_t numExtraThreads;
   Thread *threads;
+
+  // Describes a suggested fix-it. Text in [startLine:startColumn,
+  // endLine:endColumn) is to be replaced with replacementText.
+  struct FixIt {
+    const char *filename;
+    uintptr_t startLine;
+    uintptr_t startColumn;
+    uintptr_t endLine;
+    uintptr_t endColumn;
+    const char *replacementText;
+  };
+
+  // Describes some extra information, possible with fix-its, about the current
+  // runtime issue.
+  struct Note {
+    const char *description;
+    uintptr_t numFixIts;
+    FixIt *fixIts;
+  };
+
+  // Number of suggested fix-its, and the pointer to the array of them.
+  uintptr_t numFixIts;
+  FixIt *fixIts;
+
+  // Number of related notes, and the pointer to the array of them.
+  uintptr_t numNotes;
+  Note *notes;
 };
 
 /// Debugger hook. Calling this stops the debugger with a message and details

--- a/stdlib/public/runtime/Exclusivity.cpp
+++ b/stdlib/public/runtime/Exclusivity.cpp
@@ -113,7 +113,7 @@ static void reportExclusivityConflict(ExclusivityFlags oldAction, void *oldPC,
     .frames = &oldPC
   };
   RuntimeErrorDetails details = {
-    .version = 1,
+    .version = RuntimeErrorDetails::currentVersion,
     .errorType = "exclusivity-violation",
     .currentStackDescription = newAccess,
     .framesToSkip = framesToSkip,

--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -1444,7 +1444,7 @@ void swift_objc_swift3ImplicitObjCEntrypoint(id self, SEL selector,
     .replacementText = "@objc "
   };
   RuntimeErrorDetails::Note note = {
-    .description = "Method declaration; add '@objc' here",
+    .description = "add '@objc' to expose this Swift declaration to Objective-C",
     .numFixIts = 1,
     .fixIts = &fixit
   };

--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -1435,10 +1435,25 @@ void swift_objc_swift3ImplicitObjCEntrypoint(id self, SEL selector,
            sel_getName(selector));
   asprintf(&nullTerminatedFilename, "%*s", (int)filenameLength, filename);
 
+  RuntimeErrorDetails::FixIt fixit = {
+    .filename = nullTerminatedFilename,
+    .startLine = line,
+    .endLine = line,
+    .startColumn = column,
+    .endColumn = column,
+    .replacementText = "@objc "
+  };
+  RuntimeErrorDetails::Note note = {
+    .description = "Method declaration; add '@objc' here",
+    .numFixIts = 1,
+    .fixIts = &fixit
+  };
   RuntimeErrorDetails details = {
-    .version = 1,
+    .version = RuntimeErrorDetails::currentVersion,
     .errorType = "implicit-objc-entrypoint",
-    .framesToSkip = 1
+    .framesToSkip = 1,
+    .numNotes = 1,
+    .notes = &note
   };
   bool isFatal = reporter == swift::fatalError;
   reportToDebugger(isFatal, message, &details);


### PR DESCRIPTION
Extend Swift runtime issue reporting for @objc inference to include details about the declaration of the method (that is missing the @objc annotation) and a suggested fix-it. This changes the ABI of RuntimeErrorDetails, so we're also bumping the version.

An appropriate LLDB pull request will follow.