### PR TITLE
[swiftc (29 vs. 5563)] Add crasher in swift::TypeChecker::validateGenericTypeSignature(...)

### DIFF
--- a/validation-test/compiler_crashers/28784-genericsigorenv-isnull-getgenericsignature-getcanonicalsignature-genericenv-getg.swift
+++ b/validation-test/compiler_crashers/28784-genericsigorenv-isnull-getgenericsignature-getcanonicalsignature-genericenv-getg.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+extension P{{}}protocol P{protocol P{protocol A{{}typealias a{}}typealias e:A.a}typealias e:P


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeChecker::validateGenericTypeSignature(...)`.

Current number of unresolved compiler crashers: 29 (5563 resolved)

/cc @slavapestov - just wanted to let you know that this crasher caused an assertion failure for the assertion `(GenericSigOrEnv.isNull() || getGenericSignature()->getCanonicalSignature() == genericEnv->getGenericSignature()->getCanonicalSignature()) && "set a generic environment with a different generic signature"` added on 2017-02-17 by you in commit ad78604e :-)

Assertion failure in [`lib/AST/Decl.cpp (line 665)`](https://github.com/apple/swift/blob/531c2e8868d608e03af588c27eb6c479c861cf87/lib/AST/Decl.cpp#L665):

```
Assertion `(GenericSigOrEnv.isNull() || getGenericSignature()->getCanonicalSignature() == genericEnv->getGenericSignature()->getCanonicalSignature()) && "set a generic environment with a different generic signature"' failed.

When executing: void swift::GenericContext::setGenericEnvironment(swift::GenericEnvironment *)
```

Assertion context:

```c++

void GenericContext::setGenericEnvironment(GenericEnvironment *genericEnv) {
  assert((GenericSigOrEnv.isNull() ||
          getGenericSignature()->getCanonicalSignature() ==
            genericEnv->getGenericSignature()->getCanonicalSignature()) &&
         "set a generic environment with a different generic signature");
  this->GenericSigOrEnv = genericEnv;
  if (genericEnv)
    genericEnv->setOwningDeclContext(this);
}

```
Stack trace:

```
0 0x0000000003a765e8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3a765e8)
1 0x0000000003a76d26 SignalHandler(int) (/path/to/swift/bin/swift+0x3a76d26)
2 0x00007f147faff390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007f147e024428 gsignal /build/glibc-bfm8X4/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f147e02602a abort /build/glibc-bfm8X4/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f147e01cbd7 __assert_fail_base /build/glibc-bfm8X4/glibc-2.23/assert/assert.c:92:0
6 0x00007f147e01cc82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x000000000153d04b (/path/to/swift/bin/swift+0x153d04b)
8 0x0000000001386244 swift::TypeChecker::validateGenericTypeSignature(swift::GenericTypeDecl*) (/path/to/swift/bin/swift+0x1386244)
9 0x0000000001357050 swift::TypeChecker::validateDecl(swift::ValueDecl*) (/path/to/swift/bin/swift+0x1357050)
10 0x0000000001356ae9 swift::TypeChecker::validateDecl(swift::ValueDecl*) (/path/to/swift/bin/swift+0x1356ae9)
11 0x0000000001388bdd swift::TypeChecker::lookupMemberType(swift::DeclContext*, swift::Type, swift::Identifier, swift::OptionSet<swift::NameLookupFlags, unsigned int>) (/path/to/swift/bin/swift+0x1388bdd)
12 0x00000000013d218b resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13d218b)
13 0x00000000013d1939 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13d1939)
14 0x00000000013d26a8 (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0x13d26a8)
15 0x00000000013d25ac swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13d25ac)
16 0x00000000013d0fb0 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13d0fb0)
17 0x000000000148c461 swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) (/path/to/swift/bin/swift+0x148c461)
18 0x0000000001455fc6 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) (/path/to/swift/bin/swift+0x1455fc6)
19 0x000000000134d699 swift::TypeChecker::resolveInheritanceClause(llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>) (/path/to/swift/bin/swift+0x134d699)
20 0x0000000001576e24 swift::GenericSignatureBuilder::addInheritedRequirements(swift::TypeDecl*, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::RequirementSource const*, swift::ModuleDecl*) (/path/to/swift/bin/swift+0x1576e24)
21 0x00000000015774f4 swift::GenericSignatureBuilder::addConformanceRequirement(swift::GenericSignatureBuilder::PotentialArchetype*, swift::ProtocolDecl*, swift::GenericSignatureBuilder::RequirementSource const*) (/path/to/swift/bin/swift+0x15774f4)
22 0x000000000157ae25 swift::GenericSignatureBuilder::addTypeRequirement(llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::FloatingRequirementSource, swift::GenericSignatureBuilder::UnresolvedHandlingKind) (/path/to/swift/bin/swift+0x157ae25)
23 0x000000000158c811 swift::GenericSignatureBuilder::ConstraintResult llvm::function_ref<swift::GenericSignatureBuilder::ConstraintResult (swift::Type, swift::TypeRepr const*)>::callback_fn<swift::GenericSignatureBuilder::addInheritedRequirements(swift::TypeDecl*, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::RequirementSource const*, swift::ModuleDecl*)::$_26>(long, swift::Type, swift::TypeRepr const*) (/path/to/swift/bin/swift+0x158c811)
24 0x0000000001584ff2 std::_Function_handler<void (swift::Type, swift::TypeRepr const*), visitInherited(llvm::ArrayRef<swift::TypeLoc>, llvm::function_ref<swift::GenericSignatureBuilder::ConstraintResult (swift::Type, swift::TypeRepr const*)>)::$_60>::_M_invoke(std::_Any_data const&, swift::Type&&, swift::TypeRepr const*&&) (/path/to/swift/bin/swift+0x1584ff2)
25 0x0000000001576f21 swift::GenericSignatureBuilder::addInheritedRequirements(swift::TypeDecl*, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::RequirementSource const*, swift::ModuleDecl*) (/path/to/swift/bin/swift+0x1576f21)
26 0x00000000015774f4 swift::GenericSignatureBuilder::addConformanceRequirement(swift::GenericSignatureBuilder::PotentialArchetype*, swift::ProtocolDecl*, swift::GenericSignatureBuilder::RequirementSource const*) (/path/to/swift/bin/swift+0x15774f4)
27 0x000000000157ae25 swift::GenericSignatureBuilder::addTypeRequirement(llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::FloatingRequirementSource, swift::GenericSignatureBuilder::UnresolvedHandlingKind) (/path/to/swift/bin/swift+0x157ae25)
28 0x000000000158c811 swift::GenericSignatureBuilder::ConstraintResult llvm::function_ref<swift::GenericSignatureBuilder::ConstraintResult (swift::Type, swift::TypeRepr const*)>::callback_fn<swift::GenericSignatureBuilder::addInheritedRequirements(swift::TypeDecl*, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::RequirementSource const*, swift::ModuleDecl*)::$_26>(long, swift::Type, swift::TypeRepr const*) (/path/to/swift/bin/swift+0x158c811)
29 0x0000000001584ff2 std::_Function_handler<void (swift::Type, swift::TypeRepr const*), visitInherited(llvm::ArrayRef<swift::TypeLoc>, llvm::function_ref<swift::GenericSignatureBuilder::ConstraintResult (swift::Type, swift::TypeRepr const*)>)::$_60>::_M_invoke(std::_Any_data const&, swift::Type&&, swift::TypeRepr const*&&) (/path/to/swift/bin/swift+0x1584ff2)
30 0x0000000001576f21 swift::GenericSignatureBuilder::addInheritedRequirements(swift::TypeDecl*, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::RequirementSource const*, swift::ModuleDecl*) (/path/to/swift/bin/swift+0x1576f21)
31 0x0000000001576d3e swift::GenericSignatureBuilder::addGenericParameterRequirements(swift::GenericTypeParamDecl*) (/path/to/swift/bin/swift+0x1576d3e)
32 0x0000000001382832 swift::TypeChecker::checkGenericParamList(swift::GenericSignatureBuilder*, swift::GenericParamList*, swift::GenericSignature*, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0x1382832)
33 0x0000000001385e14 swift::TypeChecker::checkGenericEnvironment(swift::GenericParamList*, swift::DeclContext*, swift::GenericSignature*, bool, llvm::function_ref<void (swift::GenericSignatureBuilder&)>) (/path/to/swift/bin/swift+0x1385e14)
34 0x000000000135bf8c checkExtensionGenericParams(swift::TypeChecker&, swift::ExtensionDecl*, swift::Type, swift::GenericParamList*) (/path/to/swift/bin/swift+0x135bf8c)
35 0x000000000134f56f swift::TypeChecker::validateExtension(swift::ExtensionDecl*) (/path/to/swift/bin/swift+0x134f56f)
36 0x00000000013655eb (anonymous namespace)::DeclChecker::visitExtensionDecl(swift::ExtensionDecl*) (/path/to/swift/bin/swift+0x13655eb)
37 0x00000000013552c4 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x13552c4)
38 0x0000000001355193 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x1355193)
39 0x00000000013dff04 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x13dff04)
40 0x0000000000f9de7d swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf9de7d)
41 0x00000000004abe79 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4abe79)
42 0x00000000004aa419 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4aa419)
43 0x0000000000465697 main (/path/to/swift/bin/swift+0x465697)
44 0x00007f147e00f830 __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:325:0
45 0x0000000000462d39 _start (/path/to/swift/bin/swift+0x462d39)
```