### PR TITLE
Use a cast instead of trying to rely on higher level APIs.

### DIFF
--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -542,9 +542,22 @@ struct DelegateInitSelfWritebackCleanup : Cleanup {
       : loc(loc), lvalueAddress(lvalueAddress), value(value) {}
 
   void emit(SILGenFunction &gen, CleanupLocation) override {
-    gen.emitSemanticStore(loc, value, lvalueAddress,
-                          gen.getTypeLowering(lvalueAddress->getType()),
-                          IsInitialization);
+    SILValue valueToStore = value;
+    SILType lvalueObjTy = lvalueAddress->getType().getObjectType();
+
+    // If we calling a super.init and thus upcasted self, when we store self
+    // back into the self slot, we need to perform a downcast from the upcasted
+    // store value to the derived type of our lvalueAddress.
+    if (valueToStore->getType() != lvalueObjTy) {
+      assert(valueToStore->getType().isExactSuperclassOf(lvalueObjTy) &&
+             "Invalid usage of delegate init self writeback");
+      valueToStore = gen.B.createUncheckedRefCast(loc, valueToStore,
+                                                  lvalueObjTy);
+    }
+
+    auto &lowering = gen.B.getTypeLowering(lvalueAddress->getType());
+    lowering.emitStore(gen.B, loc, valueToStore, lvalueAddress,
+                       StoreOwnershipQualifier::Init);
   }
 
   void dump(SILGenFunction &gen) const override {


### PR DESCRIPTION
Use a cast instead of trying to rely on higher level APIs.

I missed this problem due to a missing test case in initializers.swift. In a
subsequent commit, I am going to add the rest of the missing cases with some
FileCheck tests for some of them. This is to ensure that the commit is easy to
review.

rdar://32539006
(cherry picked from commit cd55f466260b41b95cb0d113f9d7c6c86f6b0304)