### PR TITLE
[4.0] Sema: missing switch case fixits should print payload names explicitly instead of printing underscores. rdar://32121806

### DIFF
--- a/lib/Sema/TypeCheckSwitchStmt.cpp
+++ b/lib/Sema/TypeCheckSwitchStmt.cpp
@@ -76,6 +76,9 @@ namespace {
     private:
       SpaceKind Kind;
       llvm::PointerIntPair<Type, 1, bool> TypeAndVal;
+
+      // In type space, we reuse HEAD to help us print meaningful name, e.g.,
+      // tuple element name in fixits.
       Identifier Head;
       std::forward_list<Space> Spaces;
 
@@ -134,8 +137,8 @@ namespace {
       }
       
     public:
-      explicit Space(Type T)
-        : Kind(SpaceKind::Type), TypeAndVal(T, false), Head(Identifier()),
+      explicit Space(Type T, Identifier NameForPrinting)
+        : Kind(SpaceKind::Type), TypeAndVal(T, false), Head(NameForPrinting),
           Spaces({}){}
       explicit Space(Type T, Identifier H, bool downgrade,
                      SmallVectorImpl<Space> &SP)
@@ -186,6 +189,12 @@ namespace {
       Identifier getHead() const {
         assert(getKind() == SpaceKind::Constructor
                && "Wrong kind of space tried to access head");
+        return Head;
+      }
+
+      Identifier getPrintingName() const {
+        assert(getKind() == SpaceKind::Type
+               && "Wrong kind of space tried to access printing name");
         return Head;
       }
 
@@ -750,7 +759,11 @@ namespace {
           if (!forDisplay) {
             getType()->print(buffer);
           }
-          buffer << "_";
+          Identifier Name = getPrintingName();
+          if (Name.empty())
+            buffer << "_";
+          else
+            buffer << tok::kw_let << " " << Name.str();
           break;
         }
       }
@@ -865,10 +878,11 @@ namespace {
                                TTy->getElements().end(),
                                std::back_inserter(constElemSpaces),
                                [&](TupleTypeElt ty){
-                                 return Space(ty.getType());
+                                 return Space(ty.getType(), ty.getName());
                                });
               } else if (auto *TTy = dyn_cast<ParenType>(eedTy.getPointer())) {
-                constElemSpaces.push_back(Space(TTy->getUnderlyingType()));
+                constElemSpaces.push_back(Space(TTy->getUnderlyingType(),
+                                                Identifier()));
               }
             }
             return Space(tp, eed->getName(),
@@ -882,7 +896,7 @@ namespace {
           std::transform(TTy->getElements().begin(), TTy->getElements().end(),
                          std::back_inserter(constElemSpaces),
                          [&](TupleTypeElt ty){
-            return Space(ty.getType());
+            return Space(ty.getType(), ty.getName());
           });
           // Create an empty constructor head for the tuple space.
           arr.push_back(Space(tp, Identifier(), /*canDowngrade*/false,
@@ -943,7 +957,7 @@ namespace {
         }
       }
       
-      Space totalSpace(Switch->getSubjectExpr()->getType());
+      Space totalSpace(Switch->getSubjectExpr()->getType(), Identifier());
       Space coveredSpace(spaces);
       size_t totalSpaceSize = totalSpace.getSize(TC);
       if (totalSpaceSize > Space::getMaximumSize()) {
@@ -1218,8 +1232,9 @@ namespace {
                                 bool &sawDowngradablePattern) {
       switch (item->getKind()) {
       case PatternKind::Any:
+        return Space(item->getType(), Identifier());
       case PatternKind::Named:
-        return Space(item->getType());
+        return Space(item->getType(), cast<NamedPattern>(item)->getBoundName());
       case PatternKind::Bool: {
         return Space(cast<BoolPattern>(item)->getValue());
       }
@@ -1231,7 +1246,7 @@ namespace {
           // These coercions are irrefutable.  Project with the original type
           // instead of the cast's target type to maintain consistency with the
           // scrutinee's type.
-          return Space(IP->getType());
+          return Space(IP->getType(), Identifier());
         case CheckedCastKind::Unresolved:
         case CheckedCastKind::ValueCast:
         case CheckedCastKind::ArrayDowncast:
@@ -1316,7 +1331,7 @@ namespace {
               || SP->getKind() == PatternKind::Tuple) {
             if (auto *TTy = SP->getType()->getAs<TupleType>()) {
               for (auto ty : TTy->getElements()) {
-                conArgSpace.push_back(Space(ty.getType()));
+                conArgSpace.push_back(Space(ty.getType(), ty.getName()));
               }
             } else {
               conArgSpace.push_back(projectPattern(TC, SP,

--- a/test/FixCode/fixits-switch.swift.result
+++ b/test/FixCode/fixits-switch.swift.result
@@ -55,19 +55,19 @@ func foo4(_ e : E2) -> Int {
   switch e {
   case .e2:
     return 1
-  case .e1(_, _):
+  case .e1(let a, let s):
 <#code#>
-case .e3(_):
+case .e3(let a):
 <#code#>
 case .e4(_):
 <#code#>
 case .e5(_, _):
 <#code#>
-case .e6(_, _):
+case .e6(let a, _):
 <#code#>
 case .e7:
 <#code#>
-case .e8(_, _, _):
+case .e8(let a, _, _):
 <#code#>
 case .e9(_, _, _):
 <#code#>
@@ -93,19 +93,19 @@ func foo6(_ e : E2) -> Int {
   switch e {
   case let .e1(x, y):
     return x + y
-  case .e2(_):
+  case .e2(let a):
 <#code#>
-case .e3(_):
+case .e3(let a):
 <#code#>
 case .e4(_):
 <#code#>
 case .e5(_, _):
 <#code#>
-case .e6(_, _):
+case .e6(let a, _):
 <#code#>
 case .e7:
 <#code#>
-case .e8(_, _, _):
+case .e8(let a, _, _):
 <#code#>
 case .e9(_, _, _):
 <#code#>
@@ -117,17 +117,17 @@ func foo7(_ e : E2) -> Int {
   case .e2(1): return 0
   case .e1: return 0
   case .e3: return 0
-  case .e2(_):
+  case .e2(let a):
 <#code#>
 case .e4(_):
 <#code#>
 case .e5(_, _):
 <#code#>
-case .e6(_, _):
+case .e6(let a, _):
 <#code#>
 case .e7:
 <#code#>
-case .e8(_, _, _):
+case .e8(let a, _, _):
 <#code#>
 case .e9(_, _, _):
 <#code#>


### PR DESCRIPTION
Explanation: The fixit for missing enum cases used to insert `_` for associated values of enum cases, which is not informative enough. As a consequence, it may create an extra step of jump to definition to figure out what the associate values signify. This patch changes "_" to using the actual payload name, e.g. "let X" in the content fixits create.
Reviewed by: @CodaFi 
Scope: Compiler Fixit
Radar: rdar://32121806
Risk: Low
Testing: Existing test updated