### PR TITLE
[NFC] Miscellaneous cleanups for Parameters/Tuple Types

### DIFF
--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -54,7 +54,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// in source control, you should also update the comment to briefly
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
-const uint16_t VERSION_MINOR = 346; // Last change: dependency types for enums
+const uint16_t VERSION_MINOR = 347; // Last change: 'inout' on parameter types
 
 using DeclID = PointerEmbeddedInt<unsigned, 31>;
 using DeclIDField = BCFixed<31>;
@@ -598,7 +598,8 @@ namespace decls_block {
     TypeIDField,        // inner type
     BCFixed<1>,         // vararg?
     BCFixed<1>,         // autoclosure?
-    BCFixed<1>          // escaping?
+    BCFixed<1>,         // escaping?
+    BCFixed<1>          // inout?
   >;
 
   using TupleTypeLayout = BCRecordLayout<
@@ -611,7 +612,8 @@ namespace decls_block {
     TypeIDField,        // type
     BCFixed<1>,         // vararg?
     BCFixed<1>,         // autoclosure?
-    BCFixed<1>          // escaping?
+    BCFixed<1>,         // escaping?
+    BCFixed<1>          // inout?
   >;
 
   using FunctionTypeLayout = BCRecordLayout<

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -2737,6 +2737,14 @@ Type TupleType::get(ArrayRef<TupleTypeElt> Fields, const ASTContext &C) {
   return New;
 }
 
+TupleTypeElt::TupleTypeElt(Type ty, Identifier name,
+                           ParameterTypeFlags fl)
+: Name(name), ElementType(ty), Flags(fl) {
+  // FIXME: Re-enable this assertion and hunt down the callers that aren't
+  // setting parameter bits correctly.
+  // assert((ty->is<InOutType>() && fl.isInOut()) && "caller did not set flags");
+}
+
 void UnboundGenericType::Profile(llvm::FoldingSetNodeID &ID,
                                  GenericTypeDecl *TheDecl, Type Parent) {
   ID.AddPointer(TheDecl);

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -1028,7 +1028,7 @@ static ValueDecl *getCheckedTruncOperation(ASTContext &Context,
     return nullptr;
 
   Type OverflowBitTy = BuiltinIntegerType::get(1, Context);
-  TupleTypeElt ResultElts[] = { OutTy, OverflowBitTy };
+  TupleTypeElt ResultElts[] = { Type(OutTy), OverflowBitTy };
   Type ResultTy = TupleType::get(ResultElts, Context);
   return getBuiltinFunction(Id, { InTy }, ResultTy);
 }
@@ -1036,7 +1036,7 @@ static ValueDecl *getCheckedTruncOperation(ASTContext &Context,
 static ValueDecl *getCheckedConversionOperation(ASTContext &Context,
                                                 Identifier Id,
                                                 Type Ty) {
-  auto BuiltinTy = Ty->getAs<BuiltinIntegerType>();
+  Type BuiltinTy = Ty->getAs<BuiltinIntegerType>();
   if (!BuiltinTy)
     return nullptr;
 

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -727,7 +727,8 @@ swift::decomposeArgType(Type type, ArrayRef<Identifier> argumentLabels) {
 
     for (auto i : range(0, tupleTy->getNumElements())) {
       const auto &elt = tupleTy->getElement(i);
-      assert(elt.getParameterFlags().isNone() &&
+      assert((elt.getParameterFlags().isNone() ||
+              elt.getParameterFlags().isInOut()) &&
              "Vararg, autoclosure, or escaping argument tuple"
              "doesn't make sense");
       CallArgParam argParam;

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -3805,17 +3805,17 @@ Expected<Type> ModuleFile::getTypeChecked(TypeID TID) {
 
   case decls_block::PAREN_TYPE: {
     TypeID underlyingID;
-    bool isVariadic, isAutoClosure, isEscaping;
+    bool isVariadic, isAutoClosure, isEscaping, isInOut;
     decls_block::ParenTypeLayout::readRecord(scratch, underlyingID, isVariadic,
-                                             isAutoClosure, isEscaping);
+                                             isAutoClosure, isEscaping, isInOut);
 
     auto underlyingTy = getTypeChecked(underlyingID);
     if (!underlyingTy)
       return underlyingTy.takeError();
-
+    
     typeOrOffset = ParenType::get(
         ctx, underlyingTy.get(),
-        ParameterTypeFlags(isVariadic, isAutoClosure, isEscaping));
+        ParameterTypeFlags(isVariadic, isAutoClosure, isEscaping, isInOut));
     break;
   }
 
@@ -3835,17 +3835,17 @@ Expected<Type> ModuleFile::getTypeChecked(TypeID TID) {
 
       IdentifierID nameID;
       TypeID typeID;
-      bool isVariadic, isAutoClosure, isEscaping;
+      bool isVariadic, isAutoClosure, isEscaping, isInOut;
       decls_block::TupleTypeEltLayout::readRecord(
-          scratch, nameID, typeID, isVariadic, isAutoClosure, isEscaping);
+          scratch, nameID, typeID, isVariadic, isAutoClosure, isEscaping, isInOut);
 
       auto elementTy = getTypeChecked(typeID);
       if (!elementTy)
         return elementTy.takeError();
-
+      
       elements.emplace_back(
           elementTy.get(), getIdentifier(nameID),
-          ParameterTypeFlags(isVariadic, isAutoClosure, isEscaping));
+          ParameterTypeFlags(isVariadic, isAutoClosure, isEscaping, isInOut));
     }
 
     typeOrOffset = TupleType::get(elements, ctx);

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3248,7 +3248,7 @@ void Serializer::writeType(Type ty) {
     ParenTypeLayout::emitRecord(
         Out, ScratchRecord, abbrCode, addTypeRef(parenTy->getUnderlyingType()),
         paramFlags.isVariadic(), paramFlags.isAutoClosure(),
-        paramFlags.isEscaping());
+        paramFlags.isEscaping(), paramFlags.isInOut());
     break;
   }
 
@@ -3264,7 +3264,8 @@ void Serializer::writeType(Type ty) {
       TupleTypeEltLayout::emitRecord(
           Out, ScratchRecord, abbrCode, addDeclBaseNameRef(elt.getName()),
           addTypeRef(elt.getType()), paramFlags.isVariadic(),
-          paramFlags.isAutoClosure(), paramFlags.isEscaping());
+          paramFlags.isAutoClosure(), paramFlags.isEscaping(),
+          paramFlags.isInOut());
     }
 
     break;


### PR DESCRIPTION
* Move IsInOut bit into the type parameter flags and
make sure to serialize it.

* Remove some unused constructors and accessors.
