### PR TITLE
[Syntax] Don't serialize text for simple tokens

### DIFF
--- a/include/swift/Syntax/Serialization/SyntaxSerialization.h
+++ b/include/swift/Syntax/Serialization/SyntaxSerialization.h
@@ -132,18 +132,39 @@ struct TokenDescription {
 };
 
 /// Serialization traits for TokenDescription.
-/// TokenDescriptions are always serialized this way:
+/// TokenDescriptions always serialized with a token kind, which is
+/// the stringified version of their name in the tok:: enum.
 /// ```
 /// {
 ///   "kind": <token name, e.g. "kw_struct">,
-///   "text": <token text, e.g. "struct">
 /// }
 /// ```
+///
+/// For tokens that have some kind of text attached, like literals or
+/// identifiers, the serialized form will also have a "text" key containing
+/// that text as the value.
 template<>
 struct ObjectTraits<TokenDescription> {
   static void mapping(Output &out, TokenDescription &value) {
     out.mapRequired("kind", value.Kind);
-    out.mapRequired("text", value.Text);
+    switch (value.Kind) {
+      case tok::integer_literal:
+      case tok::floating_literal:
+      case tok::string_literal:
+      case tok::unknown:
+      case tok::code_complete:
+      case tok::identifier:
+      case tok::oper_binary_unspaced:
+      case tok::oper_binary_spaced:
+      case tok::oper_postfix:
+      case tok::oper_prefix:
+      case tok::dollarident:
+      case tok::comment:
+        out.mapRequired("text", value.Text);
+        break;
+      default:
+        break;
+    }
   }
 };
 

--- a/test/Syntax/Inputs/serialize_multiple_decls.json
+++ b/test/Syntax/Inputs/serialize_multiple_decls.json
@@ -4,8 +4,7 @@
     "layout": [
       {
         "tokenKind": {
-          "kind": "kw_struct",
-          "text": "struct"
+          "kind": "kw_struct"
         },
         "leadingTrivia": [
           {
@@ -51,8 +50,7 @@
       },
       {
         "tokenKind": {
-          "kind": "l_brace",
-          "text": "{"
+          "kind": "l_brace"
         },
         "leadingTrivia": [
 
@@ -64,8 +62,7 @@
       },
       {
         "tokenKind": {
-          "kind": "r_brace",
-          "text": "}"
+          "kind": "r_brace"
         },
         "leadingTrivia": [
           {
@@ -86,8 +83,7 @@
     "layout": [
       {
         "tokenKind": {
-          "kind": "kw_struct",
-          "text": "struct"
+          "kind": "kw_struct"
         },
         "leadingTrivia": [
           {
@@ -121,8 +117,7 @@
       },
       {
         "tokenKind": {
-          "kind": "l_brace",
-          "text": "{"
+          "kind": "l_brace"
         },
         "leadingTrivia": [
 
@@ -134,8 +129,7 @@
       },
       {
         "tokenKind": {
-          "kind": "r_brace",
-          "text": "}"
+          "kind": "r_brace"
         },
         "leadingTrivia": [
           {

--- a/test/Syntax/Inputs/serialize_struct_decl.json
+++ b/test/Syntax/Inputs/serialize_struct_decl.json
@@ -4,8 +4,7 @@
     "layout": [
       {
         "tokenKind": {
-          "kind": "kw_struct",
-          "text": "struct"
+          "kind": "kw_struct"
         },
         "leadingTrivia": [
           {
@@ -51,8 +50,7 @@
       },
       {
         "tokenKind": {
-          "kind": "l_brace",
-          "text": "{"
+          "kind": "l_brace"
         },
         "leadingTrivia": [
 
@@ -64,8 +62,7 @@
       },
       {
         "tokenKind": {
-          "kind": "kw_let",
-          "text": "let"
+          "kind": "kw_let"
         },
         "leadingTrivia": [
           {
@@ -103,8 +100,7 @@
       },
       {
         "tokenKind": {
-          "kind": "colon",
-          "text": ":"
+          "kind": "colon"
         },
         "leadingTrivia": [
 
@@ -132,8 +128,7 @@
       },
       {
         "tokenKind": {
-          "kind": "kw_let",
-          "text": "let"
+          "kind": "kw_let"
         },
         "leadingTrivia": [
           {
@@ -171,8 +166,7 @@
       },
       {
         "tokenKind": {
-          "kind": "colon",
-          "text": ":"
+          "kind": "colon"
         },
         "leadingTrivia": [
 
@@ -248,8 +242,7 @@
       },
       {
         "tokenKind": {
-          "kind": "r_brace",
-          "text": "}"
+          "kind": "r_brace"
         },
         "leadingTrivia": [
           {


### PR DESCRIPTION
The text for `tok::kw_struct`, and similar, are always known.
Save space by not serializing them.