### PR TITLE
[ClangImporter] Don't pass API notes options when compiling bitcode.

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -620,6 +620,23 @@ getNormalInvocationArguments(std::vector<std::string> &invocationArgStrs,
       "-Xclang", "-fmodule-format=obj",
     });
   }
+
+  // Enable API notes alongside headers/in frameworks.
+  invocationArgStrs.push_back("-fapinotes-modules");
+
+  // Add API notes paths.
+  for (const auto &searchPath : searchPathOpts.ImportSearchPaths) {
+    invocationArgStrs.push_back("-iapinotes-modules");
+    invocationArgStrs.push_back(searchPath);
+  }
+  invocationArgStrs.push_back("-iapinotes-modules");
+  invocationArgStrs.push_back(searchPathOpts.RuntimeLibraryImportPath);
+
+  // Map the Swift major version into the API notes version for Swift. This
+  // has the effect of allowing API notes to effect changes only on Swift
+  // major versions, not minor versions.
+  invocationArgStrs.push_back("-fapinotes-swift-version=" +
+                              llvm::itostr(languageVersion[0]));
 }
 
 static void
@@ -691,23 +708,6 @@ addCommonInvocationArguments(std::vector<std::string> &invocationArgStrs,
   for (auto extraArg : importerOpts.ExtraArgs) {
     invocationArgStrs.push_back(extraArg);
   }
-
-  // Enable API notes alongside headers/in frameworks.
-  invocationArgStrs.push_back("-fapinotes-modules");
-
-  // Add API notes paths.
-  for (const auto &searchPath : searchPathOpts.ImportSearchPaths) {
-    invocationArgStrs.push_back("-iapinotes-modules");
-    invocationArgStrs.push_back(searchPath);
-  }
-  invocationArgStrs.push_back("-iapinotes-modules");
-  invocationArgStrs.push_back(searchPathOpts.RuntimeLibraryImportPath);
-
-  // Map the Swift major version into the API notes version for Swift. This
-  // has the effect of allowing API notes to effect changes only on Swift
-  // major versions, not minor versions.
-  invocationArgStrs.push_back("-fapinotes-swift-version=" +
-    llvm::itostr(ctx.LangOpts.EffectiveLanguageVersion[0]));
 }
 
 bool ClangImporter::canReadPCH(StringRef PCHFilename) {

--- a/test/Frontend/embed-bitcode.ll
+++ b/test/Frontend/embed-bitcode.ll
@@ -23,6 +23,7 @@ target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
 ; CHECK-IMPORTER: clang
 ; CHECK-IMPORTER: -fembed-bitcode
 ; CHECK-IMPORTER: -target
+; CHECK-IMPORTER-NOT: argument unused
 
 define i32 @f0() nounwind ssp {
        ret i32 0


### PR DESCRIPTION
- **Explanation**: We were setting up our embedded Clang context with API notes options even when trying to compile bitcode. This resulted in an "argument unused" warning, since these options have no effect on bitcode compilation. Stop doing that. (`-embed-bitcode` compiles in two steps: source -> bitcode, then bitcode -> object file. This is about the second step.)
- **Scope**: Affects builds with `-embed-bitcode` turned on.
- **Radar**: rdar://problem/31372950
- **Reviewed by**: me (patch by @bob-wilson)
- **Risk**: Very low. These arguments would have been ignored anyway.
- **Testing**: Added compiler regression test.