### PR TITLE
[swiftc (32 vs. 5563)] Add crasher in swift::GenericSignatureBuilder::finalize

### DIFF
--- a/validation-test/compiler_crashers/28787-dist-0-nested-type-should-have-matched-associated-type.swift
+++ b/validation-test/compiler_crashers/28787-dist-0-nested-type-should-have-matched-associated-type.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+{protocol P{typealias e:P{}typealias e:Self.a.a protocol P{typealias a


### PR DESCRIPTION
Add test case for crash triggered in `swift::GenericSignatureBuilder::finalize`.

Current number of unresolved compiler crashers: 32 (5563 resolved)

/cc @DougGregor - just wanted to let you know that this crasher caused an assertion failure for the assertion `dist > 0 && "nested type should have matched associated type"` added on 2017-06-19 by you in commit fe7ba8b7 :-)

Assertion failure in [`lib/AST/GenericSignatureBuilder.cpp (line 3741)`](https://github.com/apple/swift/blob/2b5710b437801ac691ed5fd3a5430e294bbdbdde/lib/AST/GenericSignatureBuilder.cpp#L3741):

```
Assertion `dist > 0 && "nested type should have matched associated type"' failed.

When executing: swift::Identifier typoCorrectNestedType(GenericSignatureBuilder::PotentialArchetype *)
```

Assertion context:

```c++
```
Stack trace:

```
0 0x0000000003a765e8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3a765e8)
1 0x0000000003a76d26 SignalHandler(int) (/path/to/swift/bin/swift+0x3a76d26)
2 0x00007f91055f4390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007f9103b19428 gsignal /build/glibc-bfm8X4/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f9103b1b02a abort /build/glibc-bfm8X4/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f9103b11bd7 __assert_fail_base /build/glibc-bfm8X4/glibc-2.23/assert/assert.c:92:0
6 0x00007f9103b11c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x000000000157e6c3 swift::GenericSignatureBuilder::finalize(swift::SourceLoc, llvm::ArrayRef<swift::GenericTypeParamType*>, bool) (/path/to/swift/bin/swift+0x157e6c3)
8 0x0000000001385e50 swift::TypeChecker::checkGenericEnvironment(swift::GenericParamList*, swift::DeclContext*, swift::GenericSignature*, bool, llvm::function_ref<void (swift::GenericSignatureBuilder&)>) (/path/to/swift/bin/swift+0x1385e50)
9 0x0000000001386239 swift::TypeChecker::validateGenericTypeSignature(swift::GenericTypeDecl*) (/path/to/swift/bin/swift+0x1386239)
10 0x0000000001357050 swift::TypeChecker::validateDecl(swift::ValueDecl*) (/path/to/swift/bin/swift+0x1357050)
11 0x0000000001366d33 (anonymous namespace)::DeclChecker::visitProtocolDecl(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0x1366d33)
12 0x0000000001355294 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x1355294)
13 0x0000000001355193 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x1355193)
14 0x00000000013c2486 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13c2486)
15 0x00000000013c1b3b swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) (/path/to/swift/bin/swift+0x13c1b3b)
16 0x00000000013e571c swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) (/path/to/swift/bin/swift+0x13e571c)
17 0x000000000133e2df swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x133e2df)
18 0x00000000013c24e5 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13c24e5)
19 0x00000000013c1cf6 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0x13c1cf6)
20 0x00000000013dff70 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x13dff70)
21 0x0000000000f9de7d swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xf9de7d)
22 0x00000000004abe79 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4abe79)
23 0x00000000004aa419 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4aa419)
24 0x0000000000465697 main (/path/to/swift/bin/swift+0x465697)
25 0x00007f9103b04830 __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:325:0
26 0x0000000000462d39 _start (/path/to/swift/bin/swift+0x462d39)
```