### PR TITLE
Runtime hook for logging on the use of unstable runtime names with NSCoding

### DIFF
--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -92,6 +92,9 @@ enum class ClassFlags : uint32_t {
 
   /// Does this class use Swift 1.0 refcounting?
   UsesSwift1Refcounting = 0x2,
+
+  /// Has this class a custom name, specified with the @objc attribute?
+  HasCustomObjCName = 0x4
 };
 inline bool operator&(ClassFlags a, ClassFlags b) {
   return (uint32_t(a) & uint32_t(b)) != 0;

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -19,6 +19,7 @@
 #include "swift/AST/CanTypeVisitor.h"
 #include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/Decl.h"
+#include "swift/AST/Attr.h"
 #include "swift/AST/IRGenOptions.h"
 #include "swift/AST/SubstitutionMap.h"
 #include "swift/AST/Types.h"
@@ -3348,6 +3349,14 @@ namespace {
             == ReferenceCounting::Native) {
         flags |= ClassFlags::UsesSwift1Refcounting;
       }
+
+      DeclAttributes attrs = Target->getAttrs();
+      if (auto objc = attrs.getAttribute<ObjCAttr>()) {
+        if (objc->getName())
+          flags |= ClassFlags::HasCustomObjCName;
+      }
+      if (attrs.hasAttribute<ObjCRuntimeNameAttr>())
+        flags |= ClassFlags::HasCustomObjCName;
 
       B.addInt32((uint32_t) flags);
     }

--- a/stdlib/public/SDK/Foundation/CMakeLists.txt
+++ b/stdlib/public/SDK/Foundation/CMakeLists.txt
@@ -54,6 +54,7 @@ add_swift_library(swiftFoundation ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SD
   URLComponents.swift
   URLRequest.swift
   UUID.swift
+  CheckClass.mm
 
   SWIFT_COMPILE_FLAGS "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}" "-Xllvm" "-sil-inline-generics" "-Xllvm" "-sil-partial-specialization"
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"

--- a/stdlib/public/SDK/Foundation/CheckClass.mm
+++ b/stdlib/public/SDK/Foundation/CheckClass.mm
@@ -1,0 +1,59 @@
+#import <Foundation/Foundation.h>
+
+#include "swift/Runtime/Metadata.h"
+
+@interface NSKeyedUnarchiver (SwiftAdditions)
++ (int)_swift_checkClassAndWarnForKeyedArchiving:(Class)cls
+                                       operation:(int)operation
+     NS_SWIFT_NAME(_swift_checkClassAndWarnForKeyedArchiving(_:operation:));
+@end
+
+@implementation NSKeyedUnarchiver (SwiftAdditions)
+
+/// Checks if class \p cls is good for archiving.
+///
+/// If not, a runtime warning is printed.
+///
+/// \param operation Specifies the archiving operation. Valid operations are:
+/// 0:       archiving
+/// 1:       unarchiving
+/// \return Returns the status
+/// 0:       not a problem class (either non-Swift or has an explicit name)
+/// 1:       a Swift generic class
+/// 2:       a Swift non-generic class where adding @objc is valid
+/// Future versions of this API will return nonzero values for additional cases
+/// that mean the class shouldn't be archived.
++ (int)_swift_checkClassAndWarnForKeyedArchiving:(Class)cls
+                                       operation:(int)operation {
+  const swift::ClassMetadata *theClass = (swift::ClassMetadata *)cls;
+
+  // Is it a (real) swift class?
+  if (!theClass->isTypeMetadata() || theClass->isArtificialSubclass())
+    return 0;
+
+  // Does the class already have a custom name?
+  if (theClass->getFlags() & swift::ClassFlags::HasCustomObjCName)
+    return 0;
+
+  const char *className = [NSStringFromClass(cls) UTF8String];
+
+  // Is it a mangled name?
+  if (!(className[0] == '_' && className[1] == 'T'))
+    return 0;
+  // Is it a name in the form <module>.<class>? Note: the module name could
+  // start with "_T".
+  if (strchr(className, '.'))
+    return 0;
+
+  // Is it a generic class?
+  if (theClass->getDescription()->GenericParams.isGeneric()) {
+    // TODO: print a warning
+    return 1;
+  }
+
+  // It's a swift class with a (compiler generated) mangled name, which should
+  // be written into an NSArchive.
+  // TODO: print a warning
+  return 2;
+}
+@end

--- a/stdlib/public/SDK/Foundation/CheckClass.mm
+++ b/stdlib/public/SDK/Foundation/CheckClass.mm
@@ -56,8 +56,9 @@ namespace {
     template <size_t N>
     StringRefLite(const char (&staticStr)[N]) : data(staticStr), length(N) {}
 
-    StringRefLite(swift::TwoWordPair<const char *, uintptr_t> pair)
-        : data(pair.first), length(pair.second) {}
+    StringRefLite(swift::TwoWordPair<const char *, uintptr_t>::Return rawValue)
+        : data(swift::TwoWordPair<const char *, uintptr_t>(rawValue).first),
+          length(swift::TwoWordPair<const char *, uintptr_t>(rawValue).second){}
 
     NS_RETURNS_RETAINED
     NSString *newNSStringNoCopy() const {

--- a/stdlib/public/SDK/Foundation/CheckClass.mm
+++ b/stdlib/public/SDK/Foundation/CheckClass.mm
@@ -1,6 +1,14 @@
 #import <Foundation/Foundation.h>
 
+#include <objc/runtime.h>
+
 #include "swift/Runtime/Metadata.h"
+
+// Aliases for Objective-C runtime entry points.
+static const char *class_getName(const swift::ClassMetadata* type) {
+  return class_getName(
+    reinterpret_cast<Class>(const_cast<swift::ClassMetadata*>(type)));
+}
 
 @interface NSKeyedUnarchiver (SwiftAdditions)
 + (int)_swift_checkClassAndWarnForKeyedArchiving:(Class)cls
@@ -35,9 +43,8 @@
   if (theClass->getFlags() & swift::ClassFlags::HasCustomObjCName)
     return 0;
 
-  const char *className = [NSStringFromClass(cls) UTF8String];
-
   // Is it a mangled name?
+  const char *className = class_getName(theClass);
   if (!(className[0] == '_' && className[1] == 'T'))
     return 0;
   // Is it a name in the form <module>.<class>? Note: the module name could

--- a/stdlib/public/SDK/Foundation/CheckClass.mm
+++ b/stdlib/public/SDK/Foundation/CheckClass.mm
@@ -4,12 +4,6 @@
 
 #include "swift/Runtime/Metadata.h"
 
-// Aliases for Objective-C runtime entry points.
-static const char *class_getName(const swift::ClassMetadata* type) {
-  return class_getName(
-    reinterpret_cast<Class>(const_cast<swift::ClassMetadata*>(type)));
-}
-
 @interface NSKeyedUnarchiver (SwiftAdditions)
 + (int)_swift_checkClassAndWarnForKeyedArchiving:(Class)cls
                                        operation:(int)operation
@@ -44,7 +38,7 @@ static const char *class_getName(const swift::ClassMetadata* type) {
     return 0;
 
   // Is it a mangled name?
-  const char *className = class_getName(theClass);
+  const char *className = class_getName(cls);
   if (!(className[0] == '_' && className[1] == 'T'))
     return 0;
   // Is it a name in the form <module>.<class>? Note: the module name could

--- a/test/Interpreter/SDK/Inputs/check_class_for_archiving.h
+++ b/test/Interpreter/SDK/Inputs/check_class_for_archiving.h
@@ -1,0 +1,7 @@
+#import <Foundation/Foundation.h>
+
+@interface NSKeyedUnarchiver (SwiftAdditions)
++ (int)_swift_checkClassAndWarnForKeyedArchiving:(Class)cls operation:(int)operation
+    NS_SWIFT_NAME(_swift_checkClassAndWarnForKeyedArchiving(_:operation:));
+@end
+

--- a/test/Interpreter/SDK/check_class_for_archiving.swift
+++ b/test/Interpreter/SDK/check_class_for_archiving.swift
@@ -1,0 +1,60 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -module-name=_Test -import-objc-header %S/Inputs/check_class_for_archiving.h -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+import Foundation
+
+class SwiftClass {}
+
+class ObjcClass : NSObject {}
+
+private class PrivateClass : NSObject {}
+
+@objc(named_class)
+private class NamedClass1 : NSObject {}
+
+@objc(_T3nix11NamedClass2C)
+private class NamedClass2 : NSObject {}
+
+class GenericClass<T> : NSObject {}
+
+class DerivedClass : GenericClass<Int> {}
+
+@objc(_T3nix20DerivedClassWithNameC)
+private class DerivedClassWithName : GenericClass<Int> {}
+
+struct ABC {
+  class InnerClass : NSObject {}
+}
+
+struct DEF<T> {
+  class InnerClass : NSObject {}
+}
+
+let op: Int32 = 0 // archiving
+
+// CHECK: SwiftClass: 0
+print("SwiftClass: \(NSKeyedUnarchiver._swift_checkClassAndWarnForKeyedArchiving(SwiftClass.self, operation: op))")
+// CHECK: ObjcClass: 0
+print("ObjcClass: \(NSKeyedUnarchiver._swift_checkClassAndWarnForKeyedArchiving(ObjcClass.self, operation: op))")
+// CHECK: PrivateClass: 2
+print("PrivateClass: \(NSKeyedUnarchiver._swift_checkClassAndWarnForKeyedArchiving(PrivateClass.self, operation: op))")
+// CHECK: NamedClass1: 0
+print("NamedClass1: \(NSKeyedUnarchiver._swift_checkClassAndWarnForKeyedArchiving(NamedClass1.self, operation: op))")
+// CHECK: NamedClass2: 0
+print("NamedClass2: \(NSKeyedUnarchiver._swift_checkClassAndWarnForKeyedArchiving(NamedClass2.self, operation: op))")
+// CHECK: GenericClass: 1
+print("GenericClass: \(NSKeyedUnarchiver._swift_checkClassAndWarnForKeyedArchiving(GenericClass<Int>.self, operation: op))")
+// CHECK: DerivedClass: 0
+print("DerivedClass: \(NSKeyedUnarchiver._swift_checkClassAndWarnForKeyedArchiving(DerivedClass.self, operation: op))")
+// CHECK: DerivedClassWithName: 0
+print("DerivedClassWithName: \(NSKeyedUnarchiver._swift_checkClassAndWarnForKeyedArchiving(DerivedClass.self, operation: op))")
+// CHECK: InnerClass: 2
+print("InnerClass: \(NSKeyedUnarchiver._swift_checkClassAndWarnForKeyedArchiving(ABC.InnerClass.self, operation: op))")
+// CHECK: InnerClass2: 1
+print("InnerClass2: \(NSKeyedUnarchiver._swift_checkClassAndWarnForKeyedArchiving(DEF<Int>.InnerClass.self, operation: op))")
+// CHECK: NSKeyedUnarchiver: 0
+print("NSKeyedUnarchiver: \(NSKeyedUnarchiver._swift_checkClassAndWarnForKeyedArchiving(NSKeyedUnarchiver.self, operation: op))")

--- a/test/Interpreter/SDK/check_class_for_archiving.swift
+++ b/test/Interpreter/SDK/check_class_for_archiving.swift
@@ -1,4 +1,4 @@
-// RUN: %empty-directory(%t)
+// RUN: rm -rf %t && mkdir -p %t
 // RUN: %target-build-swift %s -module-name=_Test -import-objc-header %S/Inputs/check_class_for_archiving.h -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 

--- a/test/Interpreter/SDK/check_class_for_archiving_log.swift
+++ b/test/Interpreter/SDK/check_class_for_archiving_log.swift
@@ -1,0 +1,173 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -module-name=_Test -import-objc-header %S/Inputs/check_class_for_archiving.h -o %t/a.out
+// RUN: %target-run %t/a.out 2>&1 | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+// This test doesn't use StdlibUnittest because it's primarily concerned with
+// checking the presence and absence of output.
+
+import Foundation
+
+class SwiftClass {}
+
+func checkArchiving(_ cls: AnyObject.Type) {
+  NSKeyedUnarchiver._swift_checkClassAndWarnForKeyedArchiving(cls, operation: 0)
+}
+func checkUnarchiving(_ cls: AnyObject.Type) {
+  NSKeyedUnarchiver._swift_checkClassAndWarnForKeyedArchiving(cls, operation: 1)
+}
+
+func mark(line: Int32 = #line) {
+  NSLog("--%d--", line)
+}
+
+mark() // CHECK: --[[@LINE]]--
+checkArchiving(SwiftClass.self)
+mark() // CHECK-NEXT: --[[@LINE]]--
+
+
+private class ArchivedTwice {}
+
+checkArchiving(ArchivedTwice.self)
+// CHECK-NEXT: Attempting to archive Swift class '_Test.(ArchivedTwice in {{.+}})' with mangled runtime name '_TtC{{.+[0-9]+}}ArchivedTwice'
+// CHECK-NEXT: @objc(_TtC{{.+[0-9]+}}ArchivedTwice)
+// CHECK-NEXT: @objc(ABCArchivedTwice)
+mark() // CHECK-NEXT: --[[@LINE]]--
+checkArchiving(ArchivedTwice.self)
+mark() // CHECK-NEXT: --[[@LINE]]--
+
+private class UnarchivedTwice {}
+
+checkUnarchiving(UnarchivedTwice.self)
+// CHECK-NEXT: Attempting to unarchive Swift class '_Test.(UnarchivedTwice in {{.+}})' with mangled runtime name '_TtC{{.+[0-9]+}}UnarchivedTwice'
+// CHECK-NEXT: @objc(_TtC{{.+[0-9]+}}UnarchivedTwice)
+// CHECK-NEXT: @objc(ABCUnarchivedTwice)
+mark() // CHECK-NEXT: --[[@LINE]]--
+checkUnarchiving(UnarchivedTwice.self)
+mark() // CHECK-NEXT: --[[@LINE]]--
+
+private class ArchivedThenUnarchived {}
+
+checkArchiving(ArchivedThenUnarchived.self)
+// CHECK-NEXT: Attempting to archive Swift class '_Test.(ArchivedThenUnarchived in {{.+}})' with mangled runtime name '_TtC{{.+[0-9]+}}ArchivedThenUnarchived'
+// CHECK-NEXT: @objc(_TtC{{.+[0-9]+}}ArchivedThenUnarchived)
+// CHECK-NEXT: @objc(ABCArchivedThenUnarchived)
+mark() // CHECK-NEXT: --[[@LINE]]--
+checkUnarchiving(ArchivedThenUnarchived.self)
+mark() // CHECK-NEXT: --[[@LINE]]--
+
+private class UnarchivedThenArchived {}
+
+checkUnarchiving(UnarchivedThenArchived.self)
+// CHECK-NEXT: Attempting to unarchive Swift class '_Test.(UnarchivedThenArchived in {{.+}})' with mangled runtime name '_TtC{{.+[0-9]+}}UnarchivedThenArchived'
+// CHECK-NEXT: @objc(_TtC{{.+[0-9]+}}UnarchivedThenArchived)
+// CHECK-NEXT: @objc(ABCUnarchivedThenArchived)
+mark() // CHECK-NEXT: --[[@LINE]]--
+checkArchiving(UnarchivedThenArchived.self)
+mark() // CHECK-NEXT: --[[@LINE]]--
+
+class Outer {
+  class ArchivedTwice {}
+  class UnarchivedTwice {}
+  class ArchivedThenUnarchived {}
+  class UnarchivedThenArchived {}
+}
+
+checkArchiving(Outer.ArchivedTwice.self)
+// CHECK-NEXT: Attempting to archive Swift class '_Test.Outer.ArchivedTwice'
+// CHECK-NEXT: @objc(_TtC{{.+[0-9]+}}ArchivedTwice)
+// CHECK-NEXT: @objc(ABCArchivedTwice)
+mark() // CHECK-NEXT: --[[@LINE]]--
+checkArchiving(Outer.ArchivedTwice.self)
+mark() // CHECK-NEXT: --[[@LINE]]--
+
+checkUnarchiving(Outer.UnarchivedTwice.self)
+// CHECK-NEXT: Attempting to unarchive Swift class '_Test.Outer.UnarchivedTwice'
+// CHECK-NEXT: @objc(_TtC{{.+[0-9]+}}UnarchivedTwice)
+// CHECK-NEXT: @objc(ABCUnarchivedTwice)
+mark() // CHECK-NEXT: --[[@LINE]]--
+checkUnarchiving(Outer.UnarchivedTwice.self)
+mark() // CHECK-NEXT: --[[@LINE]]--
+
+checkArchiving(Outer.ArchivedThenUnarchived.self)
+// CHECK-NEXT: Attempting to archive Swift class '_Test.Outer.ArchivedThenUnarchived'
+// CHECK-NEXT: @objc(_TtC{{.+[0-9]+}}ArchivedThenUnarchived)
+// CHECK-NEXT: @objc(ABCArchivedThenUnarchived)
+mark() // CHECK-NEXT: --[[@LINE]]--
+checkUnarchiving(Outer.ArchivedThenUnarchived.self)
+mark() // CHECK-NEXT: --[[@LINE]]--
+
+checkUnarchiving(Outer.UnarchivedThenArchived.self)
+// CHECK-NEXT: Attempting to unarchive Swift class '_Test.Outer.UnarchivedThenArchived'
+// CHECK-NEXT: @objc(_TtC{{.+[0-9]+}}UnarchivedThenArchived)
+// CHECK-NEXT: @objc(ABCUnarchivedThenArchived)
+mark() // CHECK-NEXT: --[[@LINE]]--
+checkArchiving(Outer.UnarchivedThenArchived.self)
+mark() // CHECK-NEXT: --[[@LINE]]--
+
+
+private class 日本語 {}
+
+checkArchiving(日本語.self)
+// CHECK-NEXT: Attempting to archive Swift class '_Test.(日本語 in {{.+}})'
+// CHECK-NEXT: @objc(_TtC{{.+[0-9]+}}9日本語)
+// CHECK-NEXT: @objc(ABCMyModel)
+mark() // CHECK-NEXT: --[[@LINE]]--
+checkArchiving(日本語.self)
+mark() // CHECK-NEXT: --[[@LINE]]--
+
+
+class ArchivedTwiceGeneric<T> {}
+
+checkArchiving(ArchivedTwiceGeneric<Int>.self)
+// CHECK-NEXT: Attempting to archive generic Swift class '_Test.ArchivedTwiceGeneric<Swift.Int>' with mangled runtime name '_TtGC5_Test20ArchivedTwiceGenericSi_'
+// CHECK-NEXT: NSKeyedUnarchiver.setClass(_:forClassName:)
+// CHECK-SAME: _TtGC5_Test20ArchivedTwiceGenericSi_
+// CHECK-NEXT: NSKeyedArchiver.setClassName(_:for:)
+mark() // CHECK-NEXT: --[[@LINE]]--
+checkArchiving(ArchivedTwiceGeneric<Int>.self)
+mark() // CHECK-NEXT: --[[@LINE]]--
+
+checkArchiving(ArchivedTwiceGeneric<NSObject>.self)
+// CHECK-NEXT: Attempting to archive generic Swift class '_Test.ArchivedTwiceGeneric<__ObjC.NSObject>' with mangled runtime name '_TtGC5_Test20ArchivedTwiceGenericCSo8NSObject_'
+// CHECK-NEXT: NSKeyedUnarchiver.setClass(_:forClassName:)
+// CHECK-SAME: _TtGC5_Test20ArchivedTwiceGenericCSo8NSObject_
+// CHECK-NEXT: NSKeyedArchiver.setClassName(_:for:)
+mark() // CHECK-NEXT: --[[@LINE]]--
+checkArchiving(ArchivedTwiceGeneric<NSObject>.self)
+mark() // CHECK-NEXT: --[[@LINE]]--
+
+class UnarchivedTwiceGeneric<T> {}
+
+checkUnarchiving(UnarchivedTwiceGeneric<Int>.self)
+// CHECK-NEXT: Attempting to unarchive generic Swift class '_Test.UnarchivedTwiceGeneric<Swift.Int>' with mangled runtime name '_TtGC5_Test22UnarchivedTwiceGenericSi_'
+// CHECK-NEXT: NSKeyedUnarchiver.setClass(_:forClassName:)
+// CHECK-SAME: _TtGC5_Test22UnarchivedTwiceGenericSi_
+// CHECK-NEXT: NSKeyedArchiver.setClassName(_:for:)
+mark() // CHECK-NEXT: --[[@LINE]]--
+checkUnarchiving(UnarchivedTwiceGeneric<Int>.self)
+mark() // CHECK-NEXT: --[[@LINE]]--
+
+class ArchivedThenUnarchivedGeneric<T> {}
+
+checkArchiving(ArchivedThenUnarchivedGeneric<Int>.self)
+// CHECK-NEXT: Attempting to archive generic Swift class '_Test.ArchivedThenUnarchivedGeneric<Swift.Int>' with mangled runtime name '_TtGC5_Test29ArchivedThenUnarchivedGenericSi_'
+// CHECK-NEXT: NSKeyedUnarchiver.setClass(_:forClassName:)
+// CHECK-SAME: _TtGC5_Test29ArchivedThenUnarchivedGenericSi_
+// CHECK-NEXT: NSKeyedArchiver.setClassName(_:for:)
+mark() // CHECK-NEXT: --[[@LINE]]--
+checkUnarchiving(ArchivedThenUnarchivedGeneric<Int>.self)
+mark() // CHECK-NEXT: --[[@LINE]]--
+
+class UnarchivedThenArchivedGeneric<T> {}
+
+checkUnarchiving(UnarchivedThenArchivedGeneric<Int>.self)
+// CHECK-NEXT: Attempting to unarchive generic Swift class '_Test.UnarchivedThenArchivedGeneric<Swift.Int>' with mangled runtime name '_TtGC5_Test29UnarchivedThenArchivedGenericSi_'
+// CHECK-NEXT: NSKeyedUnarchiver.setClass(_:forClassName:)
+// CHECK-SAME: _TtGC5_Test29UnarchivedThenArchivedGenericSi_
+// CHECK-NEXT: NSKeyedArchiver.setClassName(_:for:)
+mark() // CHECK-NEXT: --[[@LINE]]--
+checkArchiving(UnarchivedThenArchivedGeneric<Int>.self)
+mark() // CHECK-NEXT: --[[@LINE]]--

--- a/test/Interpreter/SDK/check_class_for_archiving_log.swift
+++ b/test/Interpreter/SDK/check_class_for_archiving_log.swift
@@ -1,4 +1,4 @@
-// RUN: %empty-directory(%t)
+// RUN: rm -rf %t && mkdir -p %t
 // RUN: %target-build-swift %s -module-name=_Test -import-objc-header %S/Inputs/check_class_for_archiving.h -o %t/a.out
 // RUN: %target-run %t/a.out 2>&1 | %FileCheck %s
 


### PR DESCRIPTION
- **Explanation**: Foundation's standard serialization mechanism, NSKeyedArchiver, can end up storing mangled names into persistent archives, which isn't really a good idea. This provides a run-time hook that Foundation can call (on a new enough OS) to validate that we're not doing such a thing. (Consider it the run-time half of #10155.)
- **Scope**: Affects classes that conform to NSCoding that do not have "simple" mangled names, if they are actually archived or unarchived.
- **Radar**: rdar://problem/32414508
- **Reviewed by**: me (@eeckstein's parts), @itaiferber (my parts)
- **Risk**: Low. This adds a new entry point via the Foundation overlay; nothing uses it yet. The only change to existing classes is the new metadata flag, which nothing else is reading.
- **Testing**: Added compiler regression tests.