### PR TITLE
Fix up #10418 for 32-bit platforms.

### DIFF
--- a/stdlib/public/SDK/Foundation/CheckClass.mm
+++ b/stdlib/public/SDK/Foundation/CheckClass.mm
@@ -56,8 +56,9 @@ namespace {
     template <size_t N>
     StringRefLite(const char (&staticStr)[N]) : data(staticStr), length(N) {}
 
-    StringRefLite(swift::TwoWordPair<const char *, uintptr_t> pair)
-        : data(pair.first), length(pair.second) {}
+    StringRefLite(swift::TwoWordPair<const char *, uintptr_t>::Return rawValue)
+        : data(swift::TwoWordPair<const char *, uintptr_t>(rawValue).first),
+          length(swift::TwoWordPair<const char *, uintptr_t>(rawValue).second){}
 
     NS_RETURNS_RETAINED
     NSString *newNSStringNoCopy() const {


### PR DESCRIPTION
...where swift::TwoWordPair is defined a little less freely. I was a little too clever here!