### PR TITLE
Remove DeclContext walk from resolveTypeInContext()

### DIFF
--- a/include/swift/AST/DebuggerClient.h
+++ b/include/swift/AST/DebuggerClient.h
@@ -27,7 +27,7 @@ class DebuggerClient {
 protected:
   ASTContext &Ctx;
 public:
-  typedef SmallVectorImpl<UnqualifiedLookupResult> ResultVector;
+  typedef SmallVectorImpl<LookupResultEntry> ResultVector;
 
   DebuggerClient(ASTContext &C) : Ctx(C) { }
   virtual ~DebuggerClient() = default;

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -1338,6 +1338,7 @@ public:
   
   /// Create a TypeExpr for a TypeDecl at the specified location.
   static TypeExpr *createForDecl(SourceLoc Loc, TypeDecl *D,
+                                 DeclContext *DC,
                                  bool isImplicit);
 
   /// Create a TypeExpr for a member TypeDecl of the given parent TypeDecl.

--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -38,8 +38,7 @@ namespace swift {
 struct LookupResultEntry {
 private:
 
-  /// The declaration through where we find Value. For instance,
-  ///
+  /// The declaration context through which we found Value. For instance,
   /// class BaseClass {
   ///   func foo() {}
   /// }
@@ -48,7 +47,7 @@ private:
   ///   func bar() {}
   /// }
   ///
-  /// When finding foo() from the body of DerivedClass, Base is DerivedClass.
+  /// When finding foo() from the body of DerivedClass, BaseDC is DerivedClass.
   ///
   /// Another example:
   ///
@@ -57,27 +56,29 @@ private:
   ///   func foo() {}
   /// }
   ///
-  /// When finding bar() from the function body of foo(), Base is the implicit
-  /// self parameter in foo().
-  ValueDecl *Base;
+  /// When finding bar() from the function body of foo(), BaseDC is the method
+  /// foo().
+  DeclContext *BaseDC;
 
   /// The declaration corresponds to the given name; i.e. the decl we are
   /// looking up.
   ValueDecl *Value;
 
 public:
-  LookupResultEntry(ValueDecl *value) : Base(nullptr), Value(value) { }
+  LookupResultEntry(ValueDecl *value) : BaseDC(nullptr), Value(value) { }
 
-  LookupResultEntry(ValueDecl *base, ValueDecl *value)
-    : Base(base), Value(value) { }
+  LookupResultEntry(DeclContext *baseDC, ValueDecl *value)
+    : BaseDC(baseDC), Value(value) { }
 
   ValueDecl *getValueDecl() const {
     return Value;
   }
-  
-  ValueDecl *getBaseDecl() const {
-    return Base;
+
+  DeclContext *getDeclContext() const {
+    return BaseDC;
   }
+
+  ValueDecl *getBaseDecl() const;
 };
 
 /// \brief This class implements and represents the result of performing

--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -34,8 +34,8 @@ namespace swift {
   class TypeDecl;
   class ValueDecl;
 
-/// UnqualifiedLookupResult - One result of unqualified lookup.
-struct UnqualifiedLookupResult {
+/// LookupResultEntry - One result of unqualified lookup.
+struct LookupResultEntry {
 private:
 
   /// The declaration through where we find Value. For instance,
@@ -66,9 +66,9 @@ private:
   ValueDecl *Value;
 
 public:
-  UnqualifiedLookupResult(ValueDecl *value) : Base(nullptr), Value(value) { }
+  LookupResultEntry(ValueDecl *value) : Base(nullptr), Value(value) { }
 
-  UnqualifiedLookupResult(ValueDecl *base, ValueDecl *value)
+  LookupResultEntry(ValueDecl *base, ValueDecl *value)
     : Base(base), Value(value) { }
 
   ValueDecl *getValueDecl() const {
@@ -96,7 +96,7 @@ public:
                     bool AllowProtocolMembers = false,
                     bool IgnoreAccessControl = false);
 
-  SmallVector<UnqualifiedLookupResult, 4> Results;
+  SmallVector<LookupResultEntry, 4> Results;
 
   /// \brief Return true if anything was found by the name lookup.
   bool isSuccess() const { return !Results.empty(); }
@@ -219,11 +219,11 @@ class NamedDeclConsumer : public VisibleDeclConsumer {
   virtual void anchor() override;
 public:
   DeclName name;
-  SmallVectorImpl<UnqualifiedLookupResult> &results;
+  SmallVectorImpl<LookupResultEntry> &results;
   bool isTypeLookup;
 
   NamedDeclConsumer(DeclName name,
-                    SmallVectorImpl<UnqualifiedLookupResult> &results,
+                    SmallVectorImpl<LookupResultEntry> &results,
                     bool isTypeLookup)
     : name(name), results(results), isTypeLookup(isTypeLookup) {}
 
@@ -233,7 +233,7 @@ public:
     if (isTypeLookup && !isa<TypeDecl>(VD))
       return;
     if (VD->getFullName().matchesRef(name))
-      results.push_back(UnqualifiedLookupResult(VD));
+      results.push_back(LookupResultEntry(VD));
   }
 };
 

--- a/include/swift/AST/TypeRepr.h
+++ b/include/swift/AST/TypeRepr.h
@@ -247,9 +247,13 @@ class ComponentIdentTypeRepr : public IdentTypeRepr {
   /// name binding will resolve this to a specific declaration.
   llvm::PointerUnion<Identifier, TypeDecl *> IdOrDecl;
 
+  /// The declaration context from which the bound declaration was
+  /// found. only valid if IdOrDecl is a TypeDecl.
+  DeclContext *DC;
+
 protected:
   ComponentIdentTypeRepr(TypeReprKind K, SourceLoc Loc, Identifier Id)
-    : IdentTypeRepr(K), Loc(Loc), IdOrDecl(Id) {}
+    : IdentTypeRepr(K), Loc(Loc), IdOrDecl(Id), DC(nullptr) {}
 
 public:
   SourceLoc getIdLoc() const { return Loc; }
@@ -264,7 +268,15 @@ public:
 
   TypeDecl *getBoundDecl() const { return IdOrDecl.dyn_cast<TypeDecl*>(); }
 
-  void setValue(TypeDecl *TD) { IdOrDecl = TD; }
+  DeclContext *getDeclContext() const {
+    assert(isBound());
+    return DC;
+  }
+
+  void setValue(TypeDecl *TD, DeclContext *DC) {
+    IdOrDecl = TD;
+    this->DC = DC;
+  }
 
   static bool classof(const TypeRepr *T) {
     return T->getKind() == TypeReprKind::SimpleIdent ||

--- a/include/swift/SIL/SILDebuggerClient.h
+++ b/include/swift/SIL/SILDebuggerClient.h
@@ -27,7 +27,7 @@ class SILBuilder;
 
 class SILDebuggerClient : public DebuggerClient {
 public:
-  typedef SmallVectorImpl<UnqualifiedLookupResult> ResultVector;
+  typedef SmallVectorImpl<LookupResultEntry> ResultVector;
 
   SILDebuggerClient(ASTContext &C) : DebuggerClient(C) { }
   virtual ~SILDebuggerClient() = default;

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -345,7 +345,7 @@ static DiscriminatorMatch matchDiscriminator(Identifier discriminator,
 
 static DiscriminatorMatch
 matchDiscriminator(Identifier discriminator,
-                   UnqualifiedLookupResult lookupResult) {
+                   LookupResultEntry lookupResult) {
   return matchDiscriminator(discriminator, lookupResult.getValueDecl());
 }
 
@@ -449,7 +449,7 @@ UnqualifiedLookup::UnqualifiedLookup(DeclName Name, DeclContext *DC,
   if (IsKnownNonCascading)
     isCascadingUse = false;
 
-  SmallVector<UnqualifiedLookupResult, 4> UnavailableInnerResults;
+  SmallVector<LookupResultEntry, 4> UnavailableInnerResults;
 
   if (Loc.isValid() &&
       DC->getParentSourceFile()->Kind != SourceFileKind::REPL &&
@@ -579,14 +579,14 @@ UnqualifiedLookup::UnqualifiedLookup(DeclName Name, DeclContext *DC,
         ValueDecl *baseDecl = nominal;
         if (selfDecl) baseDecl = selfDecl;
         for (auto result : lookup) {
-          Results.push_back(UnqualifiedLookupResult(baseDecl, result));
+          Results.push_back(LookupResultEntry(baseDecl, result));
         }
 
         if (!Results.empty()) {
           // Predicate that determines whether a lookup result should
           // be unavailable except as a last-ditch effort.
           auto unavailableLookupResult =
-              [&](const UnqualifiedLookupResult &result) {
+              [&](const LookupResultEntry &result) {
             auto &effectiveVersion = Ctx.LangOpts.EffectiveLanguageVersion;
             return result.getValueDecl()->getAttrs()
                 .isUnavailableInSwiftVersion(effectiveVersion);
@@ -818,20 +818,20 @@ UnqualifiedLookup::UnqualifiedLookup(DeclName Name, DeclContext *DC,
             // Types are local or metatype members.
             if (auto TD = dyn_cast<TypeDecl>(Result)) {
               if (isa<GenericTypeParamDecl>(TD))
-                Results.push_back(UnqualifiedLookupResult(Result));
+                Results.push_back(LookupResultEntry(Result));
               else
-                Results.push_back(UnqualifiedLookupResult(MetaBaseDecl, Result));
+                Results.push_back(LookupResultEntry(MetaBaseDecl, Result));
               continue;
             }
 
-            Results.push_back(UnqualifiedLookupResult(BaseDecl, Result));
+            Results.push_back(LookupResultEntry(BaseDecl, Result));
           }
 
           if (FoundAny) {
             // Predicate that determines whether a lookup result should
             // be unavailable except as a last-ditch effort.
             auto unavailableLookupResult =
-              [&](const UnqualifiedLookupResult &result) {
+              [&](const LookupResultEntry &result) {
               auto &effectiveVersion = Ctx.LangOpts.EffectiveLanguageVersion;
               return result.getValueDecl()->getAttrs()
                   .isUnavailableInSwiftVersion(effectiveVersion);
@@ -915,7 +915,7 @@ UnqualifiedLookup::UnqualifiedLookup(DeclName Name, DeclContext *DC,
                  resolutionKind, TypeResolver, DC, extraImports);
 
   for (auto VD : CurModuleResults)
-    Results.push_back(UnqualifiedLookupResult(VD));
+    Results.push_back(LookupResultEntry(VD));
 
   if (DebugClient)
     filterForDiscriminator(Results, DebugClient);
@@ -942,7 +942,7 @@ UnqualifiedLookup::UnqualifiedLookup(DeclName Name, DeclContext *DC,
 
   // Look for a module with the given name.
   if (Name.isSimpleName(M.getName())) {
-    Results.push_back(UnqualifiedLookupResult(&M));
+    Results.push_back(LookupResultEntry(&M));
     return;
   }
 
@@ -952,7 +952,7 @@ UnqualifiedLookup::UnqualifiedLookup(DeclName Name, DeclContext *DC,
   if (desiredModule) {
     forAllVisibleModules(DC, [&](const ModuleDecl::ImportedModule &import) -> bool {
       if (import.second == desiredModule) {
-        Results.push_back(UnqualifiedLookupResult(import.second));
+        Results.push_back(LookupResultEntry(import.second));
         return false;
       }
       return true;

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -2067,7 +2067,9 @@ Expr *Parser::parseExprIdentifier() {
     auto refKind = DeclRefKind::Ordinary;
     E = new (Context) UnresolvedDeclRefExpr(name, refKind, loc);
   } else if (auto TD = dyn_cast<TypeDecl>(D)) {
-    E = TypeExpr::createForDecl(loc.getBaseNameLoc(), TD, /*implicit*/false);
+    assert(!TD->getDeclContext()->isTypeContext());
+    E = TypeExpr::createForDecl(loc.getBaseNameLoc(), TD, /*DC*/nullptr,
+                                /*implicit*/false);
   } else {
     E = new (Context) DeclRefExpr(D, loc, /*Implicit=*/false);
   }

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -588,7 +588,7 @@ ParserResult<TypeRepr> Parser::parseTypeIdentifier() {
     // thing local (this returns null if nothing is found).
     if (auto Entry = lookupInScope(ComponentsR[0]->getIdentifier()))
       if (auto *TD = dyn_cast<TypeDecl>(Entry))
-        ComponentsR[0]->setValue(TD);
+        ComponentsR[0]->setValue(TD, nullptr);
 
     ITR = IdentTypeRepr::create(Context, ComponentsR);
   }

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -806,7 +806,7 @@ namespace {
       auto Comp = T->getComponentRange().front();
       if (auto Entry = P.lookupInScope(Comp->getIdentifier()))
         if (auto *TD = dyn_cast<TypeDecl>(Entry)) {
-          Comp->setValue(TD);
+          Comp->setValue(TD, nullptr);
           return false;
         }
       return true;

--- a/lib/RemoteAST/RemoteAST.cpp
+++ b/lib/RemoteAST/RemoteAST.cpp
@@ -159,7 +159,8 @@ public:
     TypeReprList genericArgReprs(args);
     GenericIdentTypeRepr genericRepr(SourceLoc(), decl->getName(),
                                      genericArgReprs.getList(), SourceRange());
-    genericRepr.setValue(decl);
+    // FIXME
+    genericRepr.setValue(decl, nullptr);
 
     Type genericType;
 
@@ -182,7 +183,8 @@ public:
           : GenericArgs(type->getGenericArgs()),
             Ident(SourceLoc(), type->getDecl()->getName(),
                   GenericArgs.getList(), SourceRange()) {
-          Ident.setValue(type->getDecl());
+          // FIXME
+          Ident.setValue(type->getDecl(), nullptr);
         }
 
         // SmallVector::emplace_back will never need to call this because
@@ -212,7 +214,8 @@ public:
           auto nominal = p->castTo<NominalType>();
           simpleComponents.emplace_back(SourceLoc(),
                                         nominal->getDecl()->getName());
-          simpleComponents.back().setValue(nominal->getDecl());
+          // FIXME
+          simpleComponents.back().setValue(nominal->getDecl(), nullptr);
           componentReprs.push_back(&simpleComponents.back());
         }
       }

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7813,7 +7813,7 @@ Solution::convertBooleanTypeToBuiltinI1(Expr *expr, ConstraintLocator *locator) 
     tc.diagnose(expr->getLoc(), diag::broken_bool);
     return nullptr;
   }
-  auto *builtinMethod = dyn_cast<FuncDecl>(members[0].Decl);
+  auto *builtinMethod = dyn_cast<FuncDecl>(members[0].getValueDecl());
   if (!builtinMethod) {
     tc.diagnose(expr->getLoc(), diag::broken_bool);
     return nullptr;

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1758,7 +1758,7 @@ void swift::maybeAddAccessorsToVariable(VarDecl *var, TypeChecker &TC) {
       // sure the property type matches later after validation.
       auto lookup = TC.lookupMember(dc, behaviorProtoTy, TC.Context.Id_value);
       for (auto found : lookup) {
-        if (auto foundVar = dyn_cast<VarDecl>(found.Decl)) {
+        if (auto foundVar = dyn_cast<VarDecl>(found.getValueDecl())) {
           if (valueProp) {
             TC.diagnose(behavior->getLoc(),
                         diag::property_behavior_protocol_reqt_ambiguous,

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -859,7 +859,7 @@ ConstraintSystem::getTypeOfReference(ValueDecl *value,
   // Unqualified reference to a type.
   if (auto typeDecl = dyn_cast<TypeDecl>(value)) {
     // Resolve the reference to this type declaration in our current context.
-    auto type = TC.resolveTypeInContext(typeDecl, DC,
+    auto type = TC.resolveTypeInContext(typeDecl, nullptr, DC,
                                         TR_InExpression,
                                         /*isSpecialized=*/false);
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -249,7 +249,9 @@ LookupResult &ConstraintSystem::lookupMember(Type base, DeclName name) {
 
   // We are performing dynamic lookup. Filter out redundant results early.
   llvm::DenseSet<std::tuple<char, ObjCSelector, CanType>> known;
-  result->filter([&](ValueDecl *decl) -> bool {
+  result->filter([&](LookupResultEntry entry) -> bool {
+    auto *decl = entry.getValueDecl();
+
     if (decl->isInvalid())
       return false;
 

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -511,7 +511,9 @@ static CallExpr *createContainerKeyedByCall(ASTContext &C, DeclContext *DC,
                                                 /*Implicit=*/true);
 
   // CodingKeys.self expr
-  auto *codingKeysExpr = TypeExpr::createForDecl(SourceLoc(), param,
+  auto *codingKeysExpr = TypeExpr::createForDecl(SourceLoc(),
+                                                 param,
+                                                 param->getDeclContext(),
                                                  /*Implicit=*/true);
   auto *codingKeysMetaTypeExpr = new (C) DotSelfExpr(codingKeysExpr,
                                                      SourceLoc(), SourceLoc());

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -3087,8 +3087,8 @@ class ObjCSelectorWalker : public ASTWalker {
     if (result.size() > 2) return true;
 
     // Dig out the methods.
-    auto firstMethod = dyn_cast<FuncDecl>(result[0].Decl);
-    auto secondMethod = dyn_cast<FuncDecl>(result[1].Decl);
+    auto firstMethod = dyn_cast<FuncDecl>(result[0].getValueDecl());
+    auto secondMethod = dyn_cast<FuncDecl>(result[1].getValueDecl());
     if (!firstMethod || !secondMethod) return true;
 
     // If one is a static/class method and the other is not...

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1232,7 +1232,7 @@ void AttributeChecker::checkApplicationMainAttribute(DeclAttribute *attr,
                                          SourceLoc(), lookupOptions);
 
   for (const auto &result : lookupMain) {
-    TC.validateDecl(result.Decl);
+    TC.validateDecl(result.getValueDecl());
   }
   auto Foundation = TC.Context.getLoadedModule(C.Id_Foundation);
   if (Foundation) {
@@ -1242,7 +1242,7 @@ void AttributeChecker::checkApplicationMainAttribute(DeclAttribute *attr,
                           SourceLoc(),
                           lookupOptions);
     for (const auto &result : lookupString) {
-      TC.validateDecl(result.Decl);
+      TC.validateDecl(result.getValueDecl());
     }
   }
 }

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1204,7 +1204,8 @@ void AttributeChecker::checkApplicationMainAttribute(DeclAttribute *attr,
                                            SourceLoc(),
                                            lookupOptions);
     if (lookup.size() == 1)
-      ApplicationDelegateProto = dyn_cast<ProtocolDecl>(lookup[0]);
+      ApplicationDelegateProto = dyn_cast<ProtocolDecl>(
+        lookup[0].getValueDecl());
   }
 
   if (!ApplicationDelegateProto ||

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -510,6 +510,7 @@ resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE, DeclContext *DC) {
     }
 
     return TypeExpr::createForDecl(Loc, D,
+                                   Lookup[0].getDeclContext(),
                                    UDRE->isImplicit());
   }
 
@@ -589,6 +590,7 @@ resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE, DeclContext *DC) {
   ResultValues.clear();
   bool AllMemberRefs = true;
   ValueDecl *Base = nullptr;
+  DeclContext *BaseDC = nullptr;
   for (auto Result : Lookup) {
     // Track the base for member declarations.
     if (Result.getBaseDecl() &&
@@ -600,6 +602,7 @@ resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE, DeclContext *DC) {
       }
 
       Base = Result.getBaseDecl();
+      BaseDC = Result.getDeclContext();
       continue;
     }
 
@@ -612,9 +615,10 @@ resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE, DeclContext *DC) {
     if (auto PD = dyn_cast<ProtocolDecl>(Base)) {
       BaseExpr = TypeExpr::createForDecl(Loc,
                                          PD->getGenericParams()->getParams().front(),
+                                         /*DC*/nullptr,
                                          /*isImplicit=*/true);
     } else if (auto NTD = dyn_cast<NominalTypeDecl>(Base)) {
-      BaseExpr = TypeExpr::createForDecl(Loc, NTD, /*isImplicit=*/true);
+      BaseExpr = TypeExpr::createForDecl(Loc, NTD, BaseDC, /*isImplicit=*/true);
     } else {
       BaseExpr = new (Context) DeclRefExpr(Base, UDRE->getNameLoc(),
                                            /*Implicit=*/true);

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -253,7 +253,7 @@ static bool matchesDeclRefKind(ValueDecl *value, DeclRefKind refKind) {
 static bool containsDeclRefKind(LookupResult &lookupResult,
                                 DeclRefKind refKind) {
   for (auto candidate : lookupResult) {
-    ValueDecl *D = candidate.Decl;
+    ValueDecl *D = candidate.getValueDecl();
     if (!D || !D->hasInterfaceType())
       continue;
     if (matchesDeclRefKind(D, refKind))
@@ -428,15 +428,15 @@ resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE, DeclContext *DC) {
                                                          relookupOptions);
     if (inaccessibleResults) {
       // FIXME: What if the unviable candidates have different levels of access?
-      const ValueDecl *first = inaccessibleResults.front().Decl;
+      const ValueDecl *first = inaccessibleResults.front().getValueDecl();
       diagnose(Loc, diag::candidate_inaccessible,
                Name, first->getFormalAccess());
 
       // FIXME: If any of the candidates (usually just one) are in the same
       // module we could offer a fix-it.
       for (auto lookupResult : inaccessibleResults) {
-        diagnose(lookupResult.Decl, diag::decl_declared_here,
-                 lookupResult.Decl->getFullName());
+        diagnose(lookupResult.getValueDecl(), diag::decl_declared_here,
+                 lookupResult.getValueDecl()->getFullName());
       }
 
       // Don't try to recover here; we'll get more access-related diagnostics
@@ -485,7 +485,7 @@ resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE, DeclContext *DC) {
     } else {
       // Note all the correction candidates.
       for (auto &result : Lookup) {
-        noteTypoCorrection(Name, nameLoc, result);
+        noteTypoCorrection(Name, nameLoc, result.getValueDecl());
       }
     }
 
@@ -499,8 +499,8 @@ resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE, DeclContext *DC) {
 
   // If we have an unambiguous reference to a type decl, form a TypeExpr.
   if (Lookup.size() == 1 && UDRE->getRefKind() == DeclRefKind::Ordinary &&
-      isa<TypeDecl>(Lookup[0].Decl)) {
-    auto *D = cast<TypeDecl>(Lookup[0].Decl);
+      isa<TypeDecl>(Lookup[0].getValueDecl())) {
+    auto *D = cast<TypeDecl>(Lookup[0].getValueDecl());
     // FIXME: This is odd.
     if (isa<ModuleDecl>(D)) {
       return new (Context) DeclRefExpr(D, UDRE->getNameLoc(),
@@ -517,13 +517,14 @@ resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE, DeclContext *DC) {
   SmallVector<ValueDecl*, 4> ResultValues;
   for (auto Result : Lookup) {
     // If we find a member, then all of the results aren't non-members.
-    bool IsMember = Result.Base && !isa<ModuleDecl>(Result.Base);
+    bool IsMember = (Result.getBaseDecl() &&
+                     !isa<ModuleDecl>(Result.getBaseDecl()));
     if (IsMember) {
       AllDeclRefs = false;
       break;
     }
 
-    ValueDecl *D = Result.Decl;
+    ValueDecl *D = Result.getValueDecl();
     if (!D->hasInterfaceType()) validateDecl(D);
 
     // FIXME: Circularity hack.
@@ -590,14 +591,15 @@ resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE, DeclContext *DC) {
   ValueDecl *Base = nullptr;
   for (auto Result : Lookup) {
     // Track the base for member declarations.
-    if (Result.Base && !isa<ModuleDecl>(Result.Base)) {
-      ResultValues.push_back(Result.Decl);
-      if (Base && Result.Base != Base) {
+    if (Result.getBaseDecl() &&
+        !isa<ModuleDecl>(Result.getBaseDecl())) {
+      ResultValues.push_back(Result.getValueDecl());
+      if (Base && Result.getBaseDecl() != Base) {
         AllMemberRefs = false;
         break;
       }
 
-      Base = Result.Base;
+      Base = Result.getBaseDecl();
       continue;
     }
 
@@ -2609,7 +2611,7 @@ bool TypeChecker::typeCheckExprPattern(ExprPattern *EP, DeclContext *DC,
   
   SmallVector<ValueDecl*, 4> choices;
   for (auto &result : matchLookup) {
-    choices.push_back(result.Decl);
+    choices.push_back(result.getValueDecl());
   }
   
   if (choices.empty()) {

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3409,7 +3409,7 @@ static void checkVarBehavior(VarDecl *decl, TypeChecker &TC) {
         FuncDecl *defaultInitStorageDecl = nullptr;
         FuncDecl *parameterizedInitStorageDecl = nullptr;
         for (auto found : lookup) {
-          if (auto foundFunc = dyn_cast<FuncDecl>(found.Decl)) {
+          if (auto foundFunc = dyn_cast<FuncDecl>(found.getValueDecl())) {
             if (!foundFunc->isStatic())
               continue;
             auto methodTy = foundFunc->getInterfaceType()
@@ -3442,7 +3442,7 @@ static void checkVarBehavior(VarDecl *decl, TypeChecker &TC) {
                       expectedDefaultInitStorageTy,
                       expectedParameterizedInitStorageTy);
           for (auto found : lookup)
-            TC.diagnose(found.Decl->getLoc(),
+            TC.diagnose(found.getValueDecl()->getLoc(),
                         diag::found_candidate);
           conformance->setInvalid();
           continue;
@@ -5731,7 +5731,7 @@ public:
       }
 
       for (auto memberResult : members) {
-        auto member = memberResult.Decl;
+        auto member = memberResult.getValueDecl();
 
         if (member->isInvalid())
           continue;
@@ -8244,7 +8244,7 @@ void TypeChecker::addImplicitConstructors(NominalTypeDecl *decl) {
                                     NameLookupFlags::IgnoreAccessibility);
 
     for (auto memberResult : ctors) {
-      auto member = memberResult.Decl;
+      auto member = memberResult.getValueDecl();
 
       // Skip unavailable superclass initializers.
       if (AvailableAttr::isUnavailable(member))
@@ -8468,7 +8468,7 @@ void TypeChecker::defineDefaultConstructor(NominalTypeDecl *decl) {
       // tuple.
       bool foundDefaultConstructor = false;
       for (auto memberResult : ctors) {
-        auto member = memberResult.Decl;
+        auto member = memberResult.getValueDecl();
 
         // Dig out the parameter tuple for this constructor.
         auto ctor = dyn_cast<ConstructorDecl>(member);

--- a/lib/Sema/TypeCheckExprObjC.cpp
+++ b/lib/Sema/TypeCheckExprObjC.cpp
@@ -264,7 +264,7 @@ Optional<Type> TypeChecker::checkObjCKeyPathExpr(DeclContext *dc,
       // Note all the correction candidates.
       for (auto &result : lookup) {
         noteTypoCorrection(componentName, DeclNameLoc(componentNameLoc),
-                           result);
+                           result.getValueDecl());
       }
 
       isInvalid = true;
@@ -277,13 +277,14 @@ Optional<Type> TypeChecker::checkObjCKeyPathExpr(DeclContext *dc,
     // If we have more than one result, filter out unavailable or
     // obviously unusable candidates.
     if (lookup.size() > 1) {
-      lookup.filter([&](LookupResult::Result result) -> bool {
+      lookup.filter([&](LookupResultEntry result) -> bool {
           // Drop unavailable candidates.
-          if (result->getAttrs().isUnavailable(Context))
+          if (result.getValueDecl()->getAttrs().isUnavailable(Context))
             return false;
 
           // Drop non-property, non-type candidates.
-          if (!isa<VarDecl>(result.Decl) && !isa<TypeDecl>(result.Decl))
+          if (!isa<VarDecl>(result.getValueDecl()) &&
+              !isa<TypeDecl>(result.getValueDecl()))
             return false;
 
           return true;
@@ -304,13 +305,14 @@ Optional<Type> TypeChecker::checkObjCKeyPathExpr(DeclContext *dc,
                  componentName);
 
       for (auto result : lookup) {
-        diagnose(result, diag::decl_declared_here, result->getFullName());
+        diagnose(result.getValueDecl(), diag::decl_declared_here,
+                 result.getValueDecl()->getFullName());
       }
       isInvalid = true;
       break;
     }
 
-    auto found = lookup.front().Decl;
+    auto found = lookup.front().getValueDecl();
 
     // Handle property references.
     if (auto var = dyn_cast<VarDecl>(found)) {

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -177,12 +177,12 @@ Type CompleteGenericTypeResolver::resolveDependentMemberType(
 
     // Correct to the single type result.
     ref->overwriteIdentifier(singleType->getBaseName().getIdentifier());
-    ref->setValue(singleType);
+    ref->setValue(singleType, nullptr);
   } else if (auto assocType = nestedPA->getResolvedAssociatedType()) {
-    ref->setValue(assocType);
+    ref->setValue(assocType, nullptr);
   } else {
     assert(nestedPA->getConcreteTypeDecl());
-    ref->setValue(nestedPA->getConcreteTypeDecl());
+    ref->setValue(nestedPA->getConcreteTypeDecl(), nullptr);
   }
 
   // If the nested type has been resolved to an associated type, use it.

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -148,8 +148,8 @@ Type CompleteGenericTypeResolver::resolveDependentMemberType(
                              corrections, &Builder);
 
     // Filter out non-types.
-    corrections.filter([](const LookupResult::Result &result) {
-      return isa<TypeDecl>(result.Decl);
+    corrections.filter([](const LookupResultEntry &result) {
+      return isa<TypeDecl>(result.getValueDecl());
     });
 
     // Check whether we have a single type result.
@@ -162,7 +162,8 @@ Type CompleteGenericTypeResolver::resolveDependentMemberType(
       TC.diagnose(nameLoc, diag::invalid_member_type, name, baseTy)
         .highlight(baseRange);
       for (const auto &suggestion : corrections)
-        TC.noteTypoCorrection(name, DeclNameLoc(nameLoc), suggestion);
+        TC.noteTypoCorrection(name, DeclNameLoc(nameLoc),
+                              suggestion.getValueDecl());
 
       return ErrorType::get(TC.Context);
     }

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -78,14 +78,15 @@ filterForEnumElement(TypeChecker &TC, DeclContext *DC, SourceLoc UseLoc,
   EnumElementDecl *foundElement = nullptr;
   VarDecl *foundConstant = nullptr;
 
-  for (LookupResult::Result result : foundElements) {
-    ValueDecl *e = result.Decl;
+  for (LookupResultEntry result : foundElements) {
+    ValueDecl *e = result.getValueDecl();
     assert(e);
     if (e->isInvalid()) {
       continue;
     }
     // Skip if the enum element was referenced as an instance member
-    if (!result.Base || !result.Base->getInterfaceType()->is<MetatypeType>()) {
+    if (!result.getBaseDecl() ||
+        !result.getBaseDecl()->getInterfaceType()->is<MetatypeType>()) {
       continue;
     }
 

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -162,7 +162,7 @@ struct ExprToIdentTypeRepr : public ASTVisitor<ExprToIdentTypeRepr, bool>
     if (auto *td = dyn_cast<TypeDecl>(dre->getDecl())) {
       components.push_back(
         new (C) SimpleIdentTypeRepr(dre->getLoc(), td->getName()));
-      components.back()->setValue(td);
+      components.back()->setValue(td, nullptr);
       return true;
     }
     return false;

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1303,7 +1303,7 @@ WitnessChecker::lookupValueWitnesses(ValueDecl *req, bool *ignoringNames) {
                                        SourceLoc(),
                                        lookupOptions);
     for (auto candidate : lookup) {
-      witnesses.push_back(candidate.Decl);
+      witnesses.push_back(candidate.getValueDecl());
     }
   } else {
     // Variable/function/subscript requirements.
@@ -1322,7 +1322,7 @@ WitnessChecker::lookupValueWitnesses(ValueDecl *req, bool *ignoringNames) {
     }
 
     for (auto candidate : candidates) {
-      witnesses.push_back(candidate);
+      witnesses.push_back(candidate.getValueDecl());
     }
   }
 
@@ -1374,7 +1374,7 @@ bool WitnessChecker::findBestWitness(
       auto lookup = TC.lookupUnqualified(overlay, requirement->getBaseName(),
                                          SourceLoc(), lookupOptions);
       for (auto candidate : lookup)
-        witnesses.push_back(candidate.Decl);
+        witnesses.push_back(candidate.getValueDecl());
       break;
     }
     case Done:

--- a/lib/Sema/TypeCheckREPL.cpp
+++ b/lib/Sema/TypeCheckREPL.cpp
@@ -50,7 +50,7 @@ struct REPLContext {
       if (!lookup)
         return true;
       for (auto result : lookup)
-        PrintDecls.push_back(result.Decl);
+        PrintDecls.push_back(result.getValueDecl());
     }
     {
       Identifier Id(Context.getIdentifier("_replDebugPrintln"));
@@ -59,7 +59,7 @@ struct REPLContext {
       if (!lookup)
         return true;
       for (auto result : lookup)
-        DebugPrintlnDecls.push_back(result.Decl);
+        DebugPrintlnDecls.push_back(result.getValueDecl());
     }
 
     return false;

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1470,7 +1470,7 @@ static bool checkSuperInit(TypeChecker &tc, ConstructorDecl *fromCtor,
 
     for (auto member : tc.lookupConstructors(fromCtor, superclassTy,
                                              lookupOptions)) {
-      auto superclassCtor = dyn_cast<ConstructorDecl>(member.Decl);
+      auto superclassCtor = dyn_cast<ConstructorDecl>(member.getValueDecl());
       if (!superclassCtor || !superclassCtor->isDesignatedInit() ||
           superclassCtor == ctor)
         continue;

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1016,7 +1016,7 @@ static Type diagnoseUnknownType(TypeChecker &tc, DeclContext *dc,
 
     // Looks like this is not a member type, but simply a member of parent type.
     if (!memberLookup.empty()) {
-      auto &member = memberLookup[0];
+      auto member = memberLookup[0].getValueDecl();
       tc.diagnose(comp->getIdLoc(), diag::invalid_member_reference,
                   member->getDescriptiveKind(), comp->getIdentifier(),
                   parentType)

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -900,14 +900,14 @@ static Type diagnoseUnknownType(TypeChecker &tc, DeclContext *dc,
                                  relookupOptions);
     if (!inaccessibleResults.empty()) {
       // FIXME: What if the unviable candidates have different levels of access?
-      auto first = cast<TypeDecl>(inaccessibleResults.front());
+      auto first = cast<TypeDecl>(inaccessibleResults.front().getValueDecl());
       tc.diagnose(comp->getIdLoc(), diag::candidate_inaccessible,
                   comp->getIdentifier(), first->getFormalAccess());
 
       // FIXME: If any of the candidates (usually just one) are in the same
       // module we could offer a fix-it.
       for (auto lookupResult : inaccessibleResults)
-        tc.diagnose(lookupResult, diag::type_declared_here);
+        tc.diagnose(lookupResult.getValueDecl(), diag::type_declared_here);
 
       // Don't try to recover here; we'll get more access-related diagnostics
       // downstream if we do.
@@ -1202,7 +1202,8 @@ resolveTopLevelIdentTypeComponent(TypeChecker &TC, DeclContext *DC,
   Type current;
   TypeDecl *currentDecl = nullptr;
   bool isAmbiguous = false;
-  for (const auto &typeDecl : globals) {
+  for (const auto entry : globals) {
+    auto *typeDecl = cast<TypeDecl>(entry.getValueDecl());
 
     // If necessary, add delayed members to the declaration.
     if (auto nomDecl = dyn_cast<NominalTypeDecl>(typeDecl)) {
@@ -1243,8 +1244,8 @@ resolveTopLevelIdentTypeComponent(TypeChecker &TC, DeclContext *DC,
       TC.diagnose(comp->getIdLoc(), diag::ambiguous_type_base,
                   comp->getIdentifier())
         .highlight(comp->getIdLoc());
-      for (auto typeDecl : globals) {
-        TC.diagnose(typeDecl, diag::found_candidate);
+      for (auto entry : globals) {
+        TC.diagnose(entry.getValueDecl(), diag::found_candidate);
       }
     }
 

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1049,7 +1049,9 @@ public:
   /// \param resolver The resolver for generic types.
   ///
   /// \returns the resolved type.
-  Type resolveTypeInContext(TypeDecl *typeDecl, DeclContext *fromDC,
+  Type resolveTypeInContext(TypeDecl *typeDecl,
+                            DeclContext *foundDC,
+                            DeclContext *fromDC,
                             TypeResolutionOptions options,
                             bool isSpecialized,
                             GenericTypeResolver *resolver = nullptr);

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -87,6 +87,12 @@ private:
   SmallVector<LookupResultEntry, 4> Results;
 
 public:
+  LookupResult() {}
+
+  explicit
+  LookupResult(const SmallVectorImpl<LookupResultEntry> &Results)
+    : Results(Results.begin(), Results.end()) {}
+
   typedef SmallVectorImpl<LookupResultEntry>::iterator iterator;
   iterator begin() { return Results.begin(); }
   iterator end() { return Results.end(); }
@@ -2012,7 +2018,7 @@ public:
   /// \param name The name of the entity to look for.
   /// \param loc The source location at which name lookup occurs.
   /// \param options Options that control name lookup.
-  SmallVector<TypeDecl *, 1>
+  LookupResult
   lookupUnqualifiedType(DeclContext *dc, DeclName name, SourceLoc loc,
                         NameLookupOptions options
                           = defaultUnqualifiedLookupOptions);

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -455,7 +455,7 @@ template <typename FnTy>
 void walkRelatedDecls(const ValueDecl *VD, const FnTy &Fn) {
   llvm::SmallDenseMap<DeclName, unsigned, 16> NamesSeen;
   ++NamesSeen[VD->getFullName()];
-  SmallVector<UnqualifiedLookupResult, 8> RelatedDecls;
+  SmallVector<LookupResultEntry, 8> RelatedDecls;
 
   if (isa<ParamDecl>(VD))
     return; // Parameters don't have interesting related declarations.

--- a/validation-test/compiler_crashers_fixed/28750-false-should-have-found-context-by-now.swift
+++ b/validation-test/compiler_crashers_fixed/28750-false-should-have-found-context-by-now.swift
@@ -6,5 +6,5 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 protocol P{struct A}class a:P{class a:A


### PR DESCRIPTION
Unqualified name lookup starts from an innermost context and walks up through parent contexts until it finds a declaration with the given name. For example, consider something like this:

```
class Base<T> {
  typealias A = [T]
}

class Derived : Base<Int> {
  class Nested {
    func foo() -> A { ... }
  }
}
```

The lookup of 'A' inside 'Nested' finds the typealias 'A' inside 'Base<T>'. Since the lookup is done from a nested type of 'Derived', we have to use 'Base<Int>' as the base type to get the substitution `T := Int`.

Previously, we would find the base type by performing a walk over all parent contexts, checking their superclasses and adopted protocols until we found the nested type in question. This duplicates work already done by name lookup, and has the potential to go out of sync with the name lookup implementation.

The new implementation instead saves the DeclContext resulting from the name lookup, avoiding the walk altogether.