### PR TITLE
[Foundation] Make CocoaError.Code and URLError.Code Hashable.

### DIFF
--- a/stdlib/public/SDK/Foundation/NSError.swift
+++ b/stdlib/public/SDK/Foundation/NSError.swift
@@ -602,13 +602,17 @@ public struct CocoaError : _BridgedStoredNSError {
   public static var _nsErrorDomain: String { return NSCocoaErrorDomain }
 
   /// The error code itself.
-  public struct Code : RawRepresentable, _ErrorCodeProtocol {
+  public struct Code : RawRepresentable, Hashable, _ErrorCodeProtocol {
     public typealias _ErrorType = CocoaError
 
     public let rawValue: Int
 
     public init(rawValue: Int) {
       self.rawValue = rawValue
+    }
+    
+    public var hashValue: Int {
+      return self.rawValue
     }
   }
 }
@@ -1845,13 +1849,17 @@ public struct URLError : _BridgedStoredNSError {
   public static var _nsErrorDomain: String { return NSURLErrorDomain }
 
   /// The error code itself.
-  public struct Code : RawRepresentable, _ErrorCodeProtocol {
+  public struct Code : RawRepresentable, Hashable, _ErrorCodeProtocol {
     public typealias _ErrorType = URLError
 
     public let rawValue: Int
 
     public init(rawValue: Int) {
       self.rawValue = rawValue
+    }
+
+    public var hashValue: Int {
+      return self.rawValue
     }
   }
 }

--- a/test/stdlib/NSError.swift
+++ b/test/stdlib/NSError.swift
@@ -53,4 +53,9 @@ tests.test("convenience") {
     expectEqual("bar", (error3 as NSError).userInfo["foo"] as? String)
 }
 
+tests.test("Hashable") {
+  checkHashable([CocoaError.Code.fileNoSuchFile, .fileReadUnknown, .keyValueValidation], equalityOracle: { $0 == $1 })
+  checkHashable([URLError.Code.unknown, .cancelled, .badURL], equalityOracle: { $0 == $1 })
+}
+
 runAllTests()


### PR DESCRIPTION
This is consistent with imported error codes, which are always Hashable. URLError.Code was also Hashable in Swift 3.1 by virtue of being defined as an enum; the change to a struct broke that.

rdar://problem/32066434