### PR TITLE
AST: Tweak a concrete-nested-type-of-archetype hack slightly

### DIFF
--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -223,7 +223,8 @@ SubstitutionMap::lookupConformance(CanType type, ProtocolDecl *proto) const {
       auto *M = proto->getParentModule();
       auto substType = type.subst(*this);
       if (substType &&
-          !substType->is<ArchetypeType>() &&
+          (!substType->is<ArchetypeType>() ||
+           substType->castTo<ArchetypeType>()->getSuperclass()) &&
           !substType->isTypeParameter() &&
           !substType->isExistentialType()) {
         auto lazyResolver = M->getASTContext().getLazyResolver();

--- a/validation-test/compiler_crashers_2_fixed/0108-sr4088.swift
+++ b/validation-test/compiler_crashers_2_fixed/0108-sr4088.swift
@@ -1,0 +1,23 @@
+// RUN: %target-swift-frontend -emit-ir -primary-file %s
+
+class UITableViewCell {}
+class UITableView {}
+
+extension UITableViewCell: ReusableViewProtocol {
+    public typealias ParentView = UITableView
+}
+
+protocol ReusableViewProtocol {
+    associatedtype ParentView
+}
+
+protocol ReusableViewFactoryProtocol {
+    associatedtype View: ReusableViewProtocol
+    func configure(parentView: View.ParentView)
+}
+
+extension ReusableViewFactoryProtocol where View: UITableViewCell {
+    func tableCellFor(tableView: UITableView) {
+        configure(parentView: tableView)
+    }
+}


### PR DESCRIPTION
When an archetype conforms to a protocol abstractly (ie, it is
not class-constrained and we don't have any further information
other than that it conforms), we can recover nested types,
but we cannot recover the conformance of those nested types
to protocols if those conformances are concrete (the nested
type might be concrete, or it might be a class-constrained
archetype).

To work around this, we added a hack where if the conformance
lookup in the SubstitutionMap fails, we fall back to the module.

This is horrible and unprincipled, but has to remain in place
until more infrastructure is plumbed through.

Commit 620db5f74c1ec57d832814ebf3811ca1bb4262ce made this
workaround apply in fewer cases, so that we could still catch
cases where the SubstitutionMap was constructed with missing
conformances.

Unfortunately this workaround didn't handle the case where the
nested type was an archetype with a superclass constraint.

This will all go away soon, but for now tweak the logic a bit,
since I really want to keep the "narrow" workaround in place
and not the general fallback, otherwise we run the risk of
SubstitutionMap conformance lookup bitrotting completely.

Fixes <https://bugs.swift.org/browse/SR-4088> and
<rdar://problem/32773028>.