### PR TITLE
AST: Tweak a concrete-nested-type-of-archetype hack slightly [4.0]

### DIFF
--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -223,7 +223,8 @@ SubstitutionMap::lookupConformance(CanType type, ProtocolDecl *proto) const {
       auto *M = proto->getParentModule();
       auto substType = type.subst(*this);
       if (substType &&
-          !substType->is<ArchetypeType>() &&
+          (!substType->is<ArchetypeType>() ||
+           substType->castTo<ArchetypeType>()->getSuperclass()) &&
           !substType->isTypeParameter() &&
           !substType->isExistentialType()) {
         auto lazyResolver = M->getASTContext().getLazyResolver();

--- a/validation-test/compiler_crashers_2_fixed/0108-sr4088.swift
+++ b/validation-test/compiler_crashers_2_fixed/0108-sr4088.swift
@@ -1,0 +1,23 @@
+// RUN: %target-swift-frontend -emit-ir -primary-file %s
+
+class UITableViewCell {}
+class UITableView {}
+
+extension UITableViewCell: ReusableViewProtocol {
+    public typealias ParentView = UITableView
+}
+
+protocol ReusableViewProtocol {
+    associatedtype ParentView
+}
+
+protocol ReusableViewFactoryProtocol {
+    associatedtype View: ReusableViewProtocol
+    func configure(parentView: View.ParentView)
+}
+
+extension ReusableViewFactoryProtocol where View: UITableViewCell {
+    func tableCellFor(tableView: UITableView) {
+        configure(parentView: tableView)
+    }
+}


### PR DESCRIPTION
* Description: There is a long-standing representational issue where SubstitutionMaps have a hard time dealing with associated types that are constrained to concrete types, but themselves have nested associated types. We put in a workaround in 3.1. In 4.0, I made the workaround slightly narrower so that we can test the conformance lookup logic better. Unfortunately I missed a case in 4.0 where we should have applied the workaround but didn't. This patch brings back the workaround in that specific case.

* Scope of the issue: Affects an open source project in the source compatibility test suite (JSQDataSourcesKit).

* Origination: Regression in 4.0.

* Risk: Very low, this just performs a module-based lookup in one more case that wasn't being done before, and this should always work.

* Tested: Reduced test case added.

* Reviewed by: @DougGregor 

* Radar: rdar://problem/32773028