### PR TITLE
Fix a couple of silly problems with extensions [4.0]

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1337,9 +1337,6 @@ ERROR(extension_constrained_inheritance,none,
       "inheritance clause", (Type))
 ERROR(extension_protocol_inheritance,none,
       "extension of protocol %0 cannot have an inheritance clause", (Type))
-ERROR(extension_protocol_via_typealias,none,
-      "protocol %0 in the module being compiled cannot be extended via a "
-      "type alias", (Type))
 ERROR(objc_generic_extension_using_type_parameter,none,
       "extension of a generic Objective-C class cannot access the class's "
       "generic parameters at runtime", ())

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -61,17 +61,10 @@ DeclContext::getAsTypeOrTypeExtensionContext() const {
     auto ED = cast<ExtensionDecl>(this);
     auto type = ED->getExtendedType();
 
-    if (type.isNull() || type->hasError())
+    if (!type)
       return nullptr;
 
-    if (auto ND = type->getNominalOrBoundGenericNominal())
-      return ND;
-
-    if (auto unbound = dyn_cast<UnboundGenericType>(type.getPointer())) {
-      return unbound->getDecl();
-    }
-
-    return nullptr;
+    return type->getAnyNominal();
   }
 
   case DeclContextKind::GenericTypeDecl:

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -7804,18 +7804,6 @@ void TypeChecker::validateExtension(ExtensionDecl *ext) {
   // FIXME: Probably the above comes up elsewhere, perhaps getAs<>()
   // should be fixed.
   if (auto proto = extendedType->getCanonicalType()->getAs<ProtocolType>()) {
-    if (!isa<ProtocolType>(extendedType.getPointer()) &&
-        proto->getDecl()->getParentModule() == ext->getParentModule()) {
-      // Protocols in the same module cannot be extended via a typealias;
-      // we could end up being unable to resolve the generic signature.
-      diagnose(ext->getLoc(), diag::extension_protocol_via_typealias, proto)
-        .fixItReplace(ext->getExtendedTypeLoc().getSourceRange(),
-                      proto->getDecl()->getName().str());
-      ext->setInvalid();
-      ext->getExtendedTypeLoc().setInvalidType(Context);
-      return;
-    }
-
     GenericEnvironment *env;
     std::tie(env, extendedType) =
         checkExtensionGenericParams(*this, ext, proto, ext->getGenericParams());

--- a/test/decl/ext/generic.swift
+++ b/test/decl/ext/generic.swift
@@ -158,3 +158,9 @@ struct S5<Q> {
 }
 
 extension S5 : P4 {}
+
+// rdar://problem/21607421
+public typealias Array2 = Array
+extension Array2 where QQQ : VVV {}
+// expected-error@-1 {{use of undeclared type 'QQQ'}}
+// expected-error@-2 {{use of undeclared type 'VVV'}}

--- a/test/decl/ext/protocol.swift
+++ b/test/decl/ext/protocol.swift
@@ -921,9 +921,10 @@ extension BadProto1 {
   }
 }
 
+// rdar://problem/20756244
 protocol BadProto3 { }
 typealias BadProto4 = BadProto3
-extension BadProto4 { } // expected-error{{protocol 'BadProto3' in the module being compiled cannot be extended via a type alias}}{{11-20=BadProto3}}
+extension BadProto4 { } // okay
 
 typealias RawRepresentableAlias = RawRepresentable
 extension RawRepresentableAlias { } // okay
@@ -948,6 +949,6 @@ class BadClass5 : BadProto5 {} // expected-error{{type 'BadClass5' does not conf
 typealias A = BadProto1
 typealias B = BadProto1
 
-extension A & B { // expected-error{{protocol 'BadProto1' in the module being compiled cannot be extended via a type alias}}
+extension A & B { // okay
 
 }

--- a/validation-test/compiler_crashers_fixed/28738-impl-genericparams-empty-key-depth-impl-genericparams-back-getdepth-key-index-im.swift
+++ b/validation-test/compiler_crashers_fixed/28738-impl-genericparams-empty-key-depth-impl-genericparams-back-getdepth-key-index-im.swift
@@ -6,5 +6,5 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 protocol P}extension P{{}typealias a:P}extension P.a{protocol P


### PR DESCRIPTION
* Description: A **constrained** extension of a typealias would result in a crash. Also, there was an old limitation that prevented us from being able to define a **protocol** extension with a typealias *in the same module*, probably as a workaround for some related problem, but it doesn't seem like this restriction is necessary anymore. Note that the crash I fixed occurs regardless of the module that the type is defined in, so maybe the restriction was bogus to begin with.

* Origination: The crash was first reported against Swift 2 so this is an old problem. The related restriction has been there even longer.

* Scope of the issue: Probably extensions of typealiases is not something people do intentionally very often, but happens when we rename a type and add a typealias for the old name.

* Risk: Very low, we already desugar the type on this code path so we know this succeeds. Lifting the restriction might make some code that used to diagnose crash, but from my understanding of how extensions and name lookup works in today's Swift this doesn't seem likely. I strongly suspect it is vestigial, but @DougGregor can confirm.

* Tested: New test case added, existing test for extension of protocol via typealias updated to reflect that it no longer produces a diagnostic.

* Reviewed by: @DougGregor 

* Radar: rdar://problem/21607421