### PR TITLE
[Parse] Fix #sourceLocation parsing in Decl position

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2120,12 +2120,6 @@ void Parser::delayParseFromBeginningToHere(ParserPosition BeginParserPosition,
 ParserResult<Decl>
 Parser::parseDecl(ParseDeclOptions Flags,
                   llvm::function_ref<void(Decl*)> Handler) {
-  if (Tok.isAny(tok::pound_sourceLocation, tok::pound_line)) {
-    auto LineDirectiveStatus = parseLineDirective(Tok.is(tok::pound_line));
-    if (LineDirectiveStatus.isError())
-      return LineDirectiveStatus;
-    // If success, go on. line directive never produce decls.
-  }
 
   if (Tok.is(tok::pound_if)) {
     auto IfConfigResult = parseIfConfig(
@@ -2870,6 +2864,13 @@ ParserStatus Parser::parseDeclItem(bool &PreviousHadSemi,
     auto endOfPrevious = getEndOfPreviousLoc();
     diagnose(endOfPrevious, diag::declaration_same_line_without_semi)
       .fixItInsert(endOfPrevious, ";");
+  }
+
+  if (Tok.isAny(tok::pound_sourceLocation, tok::pound_line)) {
+    auto LineDirectiveStatus = parseLineDirective(Tok.is(tok::pound_line));
+    if (LineDirectiveStatus.isError())
+      skipUntilDeclRBrace(tok::semi, tok::pound_endif);
+    return LineDirectiveStatus;
   }
 
   auto Result = parseDecl(Options, handler);

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -275,7 +275,8 @@ ParserStatus Parser::parseBraceItems(SmallVectorImpl<ASTNode> &Entries,
     // Parse the decl, stmt, or expression.
     PreviousHadSemi = false;
     if (isStartOfDecl()
-        && Tok.isNot(tok::pound_if, tok::pound_sourceLocation)) {
+        && Tok.isNot(
+            tok::pound_if, tok::pound_sourceLocation, tok::pound_line)) {
       ParserResult<Decl> DeclResult = 
           parseDecl(IsTopLevel ? PD_AllowTopLevel : PD_Default,
                     [&](Decl *D) {TmpDecls.push_back(D);});

--- a/test/Parse/line-directive-executable.swift
+++ b/test/Parse/line-directive-executable.swift
@@ -1,0 +1,64 @@
+// RUN: %target-run-simple-swift | %FileCheck %s
+// REQUIRES: executable_test
+
+print("START") // CHECK-LABEL: START
+
+func check(file: String = #file, line: Int = #line) {
+    print("\(file):\(line)")
+}
+
+#sourceLocation(file: "a.swift", line: 100)
+check() // CHECK-NEXT: {{^}}a.swift:100
+
+public struct S {
+    #sourceLocation(file: "b.swift", line: 100)
+    func foo() { check() }
+
+    #sourceLocation(file: "c.swift", line: 200)
+
+    func bar() { check() }
+
+    #sourceLocation(file: "d.swift", line: 300)
+}
+check() // CHECK-NEXT: {{^}}d.swift:301
+S().foo() // CHECK-NEXT: {{^}}b.swift:100
+S().bar() // CHECK-NEXT: {{^}}c.swift:201
+
+enum E {
+#sourceLocation(file: "e.swift", line: 400)
+}
+check() // CHECK-NEXT: {{^}}e.swift:401
+
+class C {
+#sourceLocation()
+}
+check() // CHECK-NEXT: .swift:[[@LINE]]
+
+extension C {
+#sourceLocation(file: "f.swift", line: 500)
+    static var file: String { return #file }
+
+    #sourceLocation(file: "g.swift", line: 600)
+    var line: Int { return #line }
+
+#sourceLocation(file: "h.swift", line: 700)
+}
+check() // CHECK-NEXT: {{^}}h.swift:701
+check(file: C.file, line: C().line) // CHECK-NEXT: {{^}}f.swift:600
+
+func test() {
+#sourceLocation(file: "i.swift", line: 800)
+    check()
+#sourceLocation(file: "j.swift", line: 900)
+}
+
+check() // CHECK-NEXT: {{^}}j.swift:902
+test() // CHECK-NEXT: {{^}}i.swift:800
+
+#sourceLocation()
+check() // CHECK-NEXT: .swift:[[@LINE]]
+
+#sourceLocation(file: "k.swift", line: 1000)
+
+
+check() // CHECK-NEXT: {{^}}k.swift:1002

--- a/test/Parse/line-directive.swift
+++ b/test/Parse/line-directive.swift
@@ -40,3 +40,16 @@ try #sourceLocation(file: "try.swift", line: 100)
 LABEL:
 #line 200 "labeled.swift"
 #sourceLocation()
+
+class C {
+#sourceLocation(file: "sr5242.swift", line: 100)
+    func foo() {}
+    let bar = 12
+#sourceLocation(file: "sr5242.swift", line: 200)
+}
+enum E {
+#sourceLocation(file: "sr5242.swift", line: 300)
+    case A, B
+    case C, D
+#sourceLocation()
+}


### PR DESCRIPTION
Fixes: https://bugs.swift.org/browse/SR-5242
`#sourceLocation` directive at end of declaration list position was rejected.

This is 4.0 regression introduced in #6979