### PR TITLE
[swiftc (32 vs. 5563)] Add crasher in swift::GenericSignatureBuilder::addSameTypeRequirementToConcrete

### DIFF
--- a/validation-test/compiler_crashers/28788-conformance-isconcrete-concrete-isexistentialtype.swift
+++ b/validation-test/compiler_crashers/28788-conformance-isconcrete-concrete-isexistentialtype.swift
@@ -1,0 +1,13 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol P{
+typealias e:RangeReplaceableCollection
+}{}extension P{{}func e
+typealias e:FlattenCollection


### PR DESCRIPTION
Add test case for crash triggered in `swift::GenericSignatureBuilder::addSameTypeRequirementToConcrete`.

Current number of unresolved compiler crashers: 32 (5563 resolved)

/cc @DougGregor - just wanted to let you know that this crasher caused an assertion failure for the assertion `conformance->isConcrete() || Concrete->isExistentialType()` added on 2017-02-23 by you in commit cbbf4154 :-)

Assertion failure in [`lib/AST/GenericSignatureBuilder.cpp (line 3371)`](https://github.com/apple/swift/blob/c21699b4e5715a24c754becbc89e784210d7220d/lib/AST/GenericSignatureBuilder.cpp#L3371):

```
Assertion `conformance->isConcrete() || Concrete->isExistentialType()' failed.

When executing: ConstraintResult swift::GenericSignatureBuilder::addSameTypeRequirementToConcrete(swift::GenericSignatureBuilder::PotentialArchetype *, swift::Type, const swift::GenericSignatureBuilder::RequirementSource *)
```

Assertion context:

```c++
    }

    conformances.insert({protocol, *conformance});

    // Abstract conformances are acceptable for existential types.
    assert(conformance->isConcrete() || Concrete->isExistentialType());

    // Update the requirement source now that we know it's concrete.
    // FIXME: Bad concrete source info.
    auto concreteSource = Source->viaConcrete(*this,
                                              conformance->isConcrete()
```
Stack trace:

```
0 0x0000000003a7b018 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3a7b018)
1 0x0000000003a7b756 SignalHandler(int) (/path/to/swift/bin/swift+0x3a7b756)
2 0x00007f5d03513390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007f5d01a38428 gsignal /build/glibc-bfm8X4/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f5d01a3a02a abort /build/glibc-bfm8X4/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f5d01a30bd7 __assert_fail_base /build/glibc-bfm8X4/glibc-2.23/assert/assert.c:92:0
6 0x00007f5d01a30c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x0000000001581a04 swift::GenericSignatureBuilder::addSameTypeRequirementToConcrete(swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type, swift::GenericSignatureBuilder::RequirementSource const*) (/path/to/swift/bin/swift+0x1581a04)
8 0x0000000001580f6c swift::GenericSignatureBuilder::addSameTypeRequirement(llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::FloatingRequirementSource, swift::GenericSignatureBuilder::UnresolvedHandlingKind, llvm::function_ref<void (swift::Type, swift::Type)>) (/path/to/swift/bin/swift+0x1580f6c)
9 0x000000000157895b concretizeNestedTypeFromConcreteParent(swift::GenericSignatureBuilder::PotentialArchetype*, swift::GenericSignatureBuilder::RequirementSource const*, swift::GenericSignatureBuilder::PotentialArchetype*, swift::GenericSignatureBuilder&, llvm::function_ref<swift::ProtocolConformanceRef (swift::ProtocolDecl*)>) (/path/to/swift/bin/swift+0x157895b)
10 0x0000000001577ce3 swift::GenericSignatureBuilder::PotentialArchetype::updateNestedTypeForConformance(llvm::PointerUnion<swift::AssociatedTypeDecl*, swift::TypeDecl*>, swift::GenericSignatureBuilder::PotentialArchetype::NestedTypeUpdate) (/path/to/swift/bin/swift+0x1577ce3)
11 0x00000000015762fc swift::GenericSignatureBuilder::PotentialArchetype::getNestedArchetypeAnchor(swift::Identifier, swift::GenericSignatureBuilder&, swift::GenericSignatureBuilder::PotentialArchetype::NestedTypeUpdate) (/path/to/swift/bin/swift+0x15762fc)
12 0x00000000015848fc swift::GenericSignatureBuilder::checkSameTypeConstraints(llvm::ArrayRef<swift::GenericTypeParamType*>, swift::GenericSignatureBuilder::PotentialArchetype*) (/path/to/swift/bin/swift+0x15848fc)
13 0x000000000158245a swift::GenericSignatureBuilder::finalize(swift::SourceLoc, llvm::ArrayRef<swift::GenericTypeParamType*>, bool) (/path/to/swift/bin/swift+0x158245a)
14 0x000000000138647a swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0x138647a)
15 0x000000000136c69b (anonymous namespace)::DeclChecker::visitFuncDecl(swift::FuncDecl*) (/path/to/swift/bin/swift+0x136c69b)
16 0x0000000001358464 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x1358464)
17 0x000000000135a494 swift::TypeChecker::validateDecl(swift::ValueDecl*) (/path/to/swift/bin/swift+0x135a494)
18 0x00000000015761cb swift::GenericSignatureBuilder::PotentialArchetype::getNestedArchetypeAnchor(swift::Identifier, swift::GenericSignatureBuilder&, swift::GenericSignatureBuilder::PotentialArchetype::NestedTypeUpdate) (/path/to/swift/bin/swift+0x15761cb)
19 0x00000000015848fc swift::GenericSignatureBuilder::checkSameTypeConstraints(llvm::ArrayRef<swift::GenericTypeParamType*>, swift::GenericSignatureBuilder::PotentialArchetype*) (/path/to/swift/bin/swift+0x15848fc)
20 0x000000000158245a swift::GenericSignatureBuilder::finalize(swift::SourceLoc, llvm::ArrayRef<swift::GenericTypeParamType*>, bool) (/path/to/swift/bin/swift+0x158245a)
21 0x0000000001389040 swift::TypeChecker::checkGenericEnvironment(swift::GenericParamList*, swift::DeclContext*, swift::GenericSignature*, bool, llvm::function_ref<void (swift::GenericSignatureBuilder&)>) (/path/to/swift/bin/swift+0x1389040)
22 0x0000000001389429 swift::TypeChecker::validateGenericTypeSignature(swift::GenericTypeDecl*) (/path/to/swift/bin/swift+0x1389429)
23 0x000000000135a200 swift::TypeChecker::validateDecl(swift::ValueDecl*) (/path/to/swift/bin/swift+0x135a200)
24 0x0000000001369ee3 (anonymous namespace)::DeclChecker::visitProtocolDecl(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0x1369ee3)
25 0x0000000001358444 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x1358444)
26 0x0000000001358343 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x1358343)
27 0x00000000013e3344 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x13e3344)
28 0x0000000000fa16cd swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xfa16cd)
29 0x00000000004abe59 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4abe59)
30 0x00000000004aa3f9 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4aa3f9)
31 0x0000000000465697 main (/path/to/swift/bin/swift+0x465697)
32 0x00007f5d01a23830 __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:325:0
33 0x0000000000462d39 _start (/path/to/swift/bin/swift+0x462d39)
```