### PR TITLE
[4.0] [Type checker] Check type equality even for argument tuples in Swift 4.

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1372,7 +1372,9 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
     typeVar2 = dyn_cast<TypeVariableType>(type2.getPointer());
 
     // If the types are obviously equivalent, we're done.
-    if (type1.getPointer() == type2.getPointer())
+    if (isa<ParenType>(type1.getPointer()) ==
+          isa<ParenType>(type2.getPointer()) &&
+        type1->isEqual(type2))
       return SolutionKind::Solved;
   } else {
     typeVar1 = desugar1->getAs<TypeVariableType>();

--- a/test/decl/protocol/conforms/associated_type.swift
+++ b/test/decl/protocol/conforms/associated_type.swift
@@ -1,4 +1,5 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -swift-version 3
+// RUN: %target-typecheck-verify-swift -swift-version 4
 
 class C { }
 
@@ -8,4 +9,24 @@ protocol P {
 
 struct X : P { // expected-error{{type 'X' does not conform to protocol 'P'}}
   typealias AssocP = Int // expected-note{{possibly intended match 'X.AssocP' (aka 'Int') does not inherit from 'C'}}
+}
+
+// SR-5166
+protocol FooType {
+    associatedtype BarType
+
+    func foo(bar: BarType)
+    func foo(action: (BarType) -> Void)
+}
+
+protocol Bar {}
+
+class Foo: FooType {
+    typealias BarType = Bar
+
+    func foo(bar: Bar) {
+    }
+
+    func foo(action: (Bar) -> Void) {
+    }
 }


### PR DESCRIPTION
**Explanation**: In Swift 4 mode, comparisons of single-parameter, unlabeled functions could fail when the parameter types were different spellings of the same type. This manifested in nonsensical failures with protocol conformance checking, but could happen in a number of places.
**Scope**: Obviously-correct code that works in Swift 3.2 mode would fail (or produce weird results) in Swift 4 mode. We've only pinned a single SR/radar on this bug, but I highly suspect that there are others.
**Radar**: SR-5166 / rdar://problem/32666189.
**Risk**: Fairly low; the change is localized to Swift 4 mode and "obviously" an improvement of what we previously had.
**Testing**: New test + normal compiler regression testing.
