### PR TITLE
[swift-4.0-branch][overlay] Implement UIFocusEnvironment.contains using a shim

### DIFF
--- a/stdlib/public/SDK/UIKit/UIKit.swift
+++ b/stdlib/public/SDK/UIKit/UIKit.swift
@@ -13,6 +13,10 @@
 import Foundation
 @_exported import UIKit
 
+#if os(iOS) || os(tvOS)
+import _SwiftUIKitOverlayShims
+#endif
+
 //===----------------------------------------------------------------------===//
 // UIGeometry
 //===----------------------------------------------------------------------===//
@@ -277,13 +281,15 @@ extension UIContentSizeCategory {
 #if os(iOS) || os(tvOS)
 @available(iOS 11.0, tvOS 11.0, *)
 extension UIFocusEnvironment {
+  @available(iOS 11.0, tvOS 11.0, *)
   public func contains(_ environment: UIFocusEnvironment) -> Bool {
-    return UIFocusSystem.environment(self, contains: environment)
+    return _swift_UIKit_UIFocusEnvironmentContainsEnvironment(self, environment)
   }
 }
 
 @available(iOS 11.0, tvOS 11.0, *)
 extension UIFocusItem {
+  @available(iOS 11.0, tvOS 11.0, *)
   public var isFocused: Bool {
     return self === UIScreen.main.focusedItem
   }

--- a/stdlib/public/SwiftShims/CMakeLists.txt
+++ b/stdlib/public/SwiftShims/CMakeLists.txt
@@ -16,9 +16,10 @@ set(sources
   Visibility.h
 
   DispatchOverlayShims.h
-  ObjectiveCOverlayShims.h
   OSOverlayShims.h
+  ObjectiveCOverlayShims.h
   SafariServicesOverlayShims.h
+  UIKitOverlayShims.h
   XCTestOverlayShims.h
   XPCOverlayShims.h
 

--- a/stdlib/public/SwiftShims/UIKitOverlayShims.h
+++ b/stdlib/public/SwiftShims/UIKitOverlayShims.h
@@ -1,0 +1,34 @@
+//===--- UIKitOverlayShims.h ---===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===--------------------===//
+
+#ifndef SWIFT_STDLIB_SHIMS_UIKIT_OVERLAY_H
+#define SWIFT_STDLIB_SHIMS_UIKIT_OVERLAY_H
+
+@import UIKit;
+
+#if __has_feature(nullability)
+#pragma clang assume_nonnull begin
+#endif
+
+#if TARGET_OS_TV || TARGET_OS_IOS
+static inline BOOL _swift_UIKit_UIFocusEnvironmentContainsEnvironment(id<UIFocusEnvironment> environment, id<UIFocusEnvironment> otherEnvironment) {
+  return [UIFocusSystem environment:environment containsEnvironment:otherEnvironment];
+}
+#endif // TARGET_OS_TV || TARGET_OS_IOS
+
+#if __has_feature(nullability)
+#pragma clang assume_nonnull end
+#endif
+
+
+#endif // SWIFT_STDLIB_SHIMS_UIKIT_OVERLAY_H
+

--- a/stdlib/public/SwiftShims/module.modulemap
+++ b/stdlib/public/SwiftShims/module.modulemap
@@ -40,6 +40,10 @@ module _SwiftSafariServicesOverlayShims {
   header "SafariServicesOverlayShims.h"
 }
 
+module _SwiftUIKitOverlayShims {
+  header "UIKitOverlayShims.h"
+}
+
 module _SwiftXCTestOverlayShims {
   header "XCTestOverlayShims.h"
 }


### PR DESCRIPTION
* Explanation: Dispatches the implementation of UIFocusEnvironment.contains through a shim in order to hide the ObjC API from Swift.
* Scope of Issue: 
* Risk: Minor, as it simply introduces an extra level of indirection
* Reviewed By: MAtt Ricketson
* Testing: Autoamted test suite
* Directions for QA: N/A
* Radar: <rdar://problem/32547858>