### PR TITLE
[4.0] Move Dictionary(grouping:by) down a level

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -40,6 +40,7 @@ set(SWIFT_BENCH_MODULES
     single-source/DictTest2
     single-source/DictTest3
     single-source/DictionaryBridge
+    single-source/DictionaryGroup
     single-source/DictionaryLiteral
     single-source/DictionaryRemove
     single-source/DictionarySwap

--- a/benchmark/single-source/DictionaryGroup.swift
+++ b/benchmark/single-source/DictionaryGroup.swift
@@ -1,0 +1,47 @@
+//===--- DictionaryGroup.swift --------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import TestsUtils
+
+@inline(never)
+public func run_DictionaryGroup(_ N: Int) {
+    let count = 100 * N
+    let result = count / 10
+    let dict = Dictionary(grouping: 0..<count, by: { $0 % 10 })
+    CheckResults(dict.count == 10)
+    CheckResults(dict[0]!.count == result)
+}
+
+class Box<T : Hashable> : Hashable {
+  var value: T
+
+  init(_ v: T) {
+    value = v
+  }
+
+  var hashValue: Int {
+    return value.hashValue
+  }
+
+  static func ==(lhs: Box, rhs: Box) -> Bool {
+    return lhs.value == rhs.value
+  }
+}
+
+@inline(never)
+public func run_DictionaryGroupOfObjects(_ N: Int) {
+    let count = 20 * N
+    let result = count / 10
+    let dict = Dictionary(grouping: (0..<count).map { Box($0) }, by: { Box($0.value % 10) })
+    CheckResults(dict.count == 10)
+    CheckResults(dict[Box(0)]!.count == result)
+}

--- a/benchmark/single-source/DictionaryGroup.swift
+++ b/benchmark/single-source/DictionaryGroup.swift
@@ -12,13 +12,16 @@
 
 import TestsUtils
 
+let count = 10_000
+let result = count / 10
+
 @inline(never)
 public func run_DictionaryGroup(_ N: Int) {
-    let count = 100 * N
-    let result = count / 10
+  for _ in 1...N {
     let dict = Dictionary(grouping: 0..<count, by: { $0 % 10 })
     CheckResults(dict.count == 10)
     CheckResults(dict[0]!.count == result)
+  }
 }
 
 class Box<T : Hashable> : Hashable {
@@ -39,9 +42,10 @@ class Box<T : Hashable> : Hashable {
 
 @inline(never)
 public func run_DictionaryGroupOfObjects(_ N: Int) {
-    let count = 20 * N
-    let result = count / 10
-    let dict = Dictionary(grouping: (0..<count).map { Box($0) }, by: { Box($0.value % 10) })
+  let objects = (0..<count).map { Box($0) }
+  for _ in 1...N {
+    let dict = Dictionary(grouping: objects, by: { Box($0.value % 10) })
     CheckResults(dict.count == 10)
     CheckResults(dict[Box(0)]!.count == result)
+  }
 }

--- a/benchmark/utils/main.swift
+++ b/benchmark/utils/main.swift
@@ -45,6 +45,7 @@ import DictTest
 import DictTest2
 import DictTest3
 import DictionaryBridge
+import DictionaryGroup
 import DictionaryLiteral
 import DictionaryRemove
 import DictionarySwap
@@ -181,6 +182,8 @@ addTo(&precommitTests, "Dictionary2OfObjects", run_Dictionary2OfObjects)
 addTo(&precommitTests, "Dictionary3", run_Dictionary3)
 addTo(&precommitTests, "Dictionary3OfObjects", run_Dictionary3OfObjects)
 addTo(&precommitTests, "DictionaryBridge", run_DictionaryBridge)
+addTo(&precommitTests, "DictionaryGroup", run_DictionaryGroup)
+addTo(&precommitTests, "DictionaryGroupOfObjects", run_DictionaryGroupOfObjects)
 addTo(&precommitTests, "DictionaryLiteral", run_DictionaryLiteral)
 addTo(&precommitTests, "DictionaryOfObjects", run_DictionaryOfObjects)
 addTo(&precommitTests, "DictionaryRemove", run_DictionaryRemove)

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -1810,9 +1810,7 @@ public struct Dictionary<Key : Hashable, Value> :
     by keyForValue: (S.Element) throws -> Key
   ) rethrows where Value == [S.Element] {
     self = [:]
-    for value in values {
-      self[try keyForValue(value), default: []].append(value)
-    }
+    try _variantBuffer.nativeGroup(values, by: keyForValue)
   }
 
   internal init(_nativeBuffer: _NativeDictionaryBuffer<Key, Value>) {
@@ -5051,6 +5049,32 @@ internal enum _Variant${Self}Buffer<${TypeParametersDecl}> : _HashBuffer {
 #else
       _sanityCheckFailure("internal error: unexpected cocoa ${Self}")
 #endif
+    }
+  }
+
+  internal mutating func nativeGroup<S: Sequence>(
+    _ values: S,
+    by keyForValue: (S.Element) throws -> Key
+  ) rethrows where Value == [S.Element] {
+    defer { _fixLifetime(asNative) }
+    for value in values {
+      let key = try keyForValue(value)
+      var (i, found) = asNative._find(key, startBucket: asNative._bucket(key))
+      if found {
+        asNative.values[i.offset].append(value)
+      } else {
+        let minCapacity = NativeBuffer.minimumCapacity(
+          minimumCount: asNative.count + 1,
+          maxLoadFactorInverse: _hashContainerDefaultMaxLoadFactorInverse)
+
+        let (_, capacityChanged) = ensureUniqueNativeBuffer(minCapacity)
+        if capacityChanged {
+          i = asNative._find(key, startBucket: asNative._bucket(key)).pos
+        }
+
+        asNative.initializeKey(key, value: [value], at: i.offset)
+        asNative.count += 1
+      }
     }
   }
 %end


### PR DESCRIPTION
This is a cherry pick of #10275, #10279, and #10306.

* Explanation: Moves the implementation of the `Dictionary(grouping:by:)` initializer down to the buffer level to avoid repeatedly duplicating arrays while building the grouped dictionary.
* Scope: This changes the implementation of a single initializer; there is no external change.
* Radar/SR: rdar://problem/32899123
* Risk: Low
* Testing: Added a benchmark to cover the initializer's performance. PR passed existing unit and validation tests.