### PR TITLE
swift-api-digester: teach the tool to serialize/deserialize super class Usrs. rdar://32778228

### DIFF
--- a/include/swift/IDE/DigesterEnums.def
+++ b/include/swift/IDE/DigesterEnums.def
@@ -88,6 +88,7 @@ KEY(typeAttributes)
 KEY(declAttributes)
 KEY(declKind)
 KEY(ownership)
+KEY(superclassUsr)
 
 KNOWN_TYPE(Optional)
 KNOWN_TYPE(ImplicitlyUnwrappedOptional)

--- a/test/api-digester/Inputs/cake.swift
+++ b/test/api-digester/Inputs/cake.swift
@@ -7,7 +7,9 @@ public struct S1 {
   public func foo6() -> Void {}
 }
 
-public class C1 {
+public class C0 {}
+
+public class C1: C0 {
 	open class func foo1() {}
 	public weak var Ins : C1?
 	public unowned var Ins2 : C1 = C1()

--- a/test/api-digester/Inputs/cake1.swift
+++ b/test/api-digester/Inputs/cake1.swift
@@ -13,6 +13,7 @@ public class C1 {
   public weak var CIIns1 : C1?
   public var CIIns2 : C1?
   public func foo3(a : Void?) {}
+  public func foo4(a : Void?) {}
 }
 
 public class C3 {}

--- a/test/api-digester/Inputs/cake2.swift
+++ b/test/api-digester/Inputs/cake2.swift
@@ -7,7 +7,11 @@ public struct S1 {
   public func foo5(x : Int, y: Int, z: Int) {}
 }
 
-public class C1 {
+public class C0 {
+  public func foo4(a : Void?) {}
+}
+
+public class C1: C0 {
   public func foo1() {}
   public func foo2(_ : ()->()) {}
   public var CIIns1 : C1?

--- a/test/api-digester/Outputs/Cake.txt
+++ b/test/api-digester/Outputs/Cake.txt
@@ -1,7 +1,6 @@
 
 /* Removed Decls */
 Class C3 has been removed
-Constructor C1.init() has been removed
 Constructor Somestruct2.init(_:) has been removed
 
 /* Moved Decls */

--- a/test/api-digester/Outputs/cake.json
+++ b/test/api-digester/Outputs/cake.json
@@ -5,6 +5,33 @@
   "children": [
     {
       "kind": "TypeDecl",
+      "name": "C0",
+      "printedName": "C0",
+      "declKind": "Class",
+      "usr": "s:4cake2C0C",
+      "location": "",
+      "moduleName": "cake",
+      "children": [
+        {
+          "kind": "Constructor",
+          "name": "init",
+          "printedName": "init()",
+          "declKind": "Constructor",
+          "usr": "s:4cake2C0CACycfc",
+          "location": "",
+          "moduleName": "cake",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "C0",
+              "printedName": "C0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "TypeDecl",
       "name": "S1",
       "printedName": "S1",
       "declKind": "Struct",
@@ -95,6 +122,7 @@
       "usr": "s:4cake2C1C",
       "location": "",
       "moduleName": "cake",
+      "superclassUsr": "s:4cake2C0C",
       "children": [
         {
           "kind": "Function",


### PR DESCRIPTION
This can help us eliminate false positives when we report removed
declarations are actually moved to a newly-introduced super class.