### PR TITLE
[4.0] Prevent _swift_runtime_on_report from having its arguments optimized out.

### DIFF
--- a/stdlib/public/runtime/Errors.cpp
+++ b/stdlib/public/runtime/Errors.cpp
@@ -245,7 +245,11 @@ void _swift_runtime_on_report(bool isFatal, const char *message,
   // Do nothing. This function is meant to be used by the debugger.
 
   // The following is necessary to avoid calls from being optimized out.
-  asm volatile("" ::: "memory");
+  asm volatile("" // Do nothing.
+               : // Output list, empty.
+               : "r" (isFatal), "r" (message), "r" (details) // Input list.
+               : // Clobber list, empty.
+               );
 }
 
 void swift::reportToDebugger(bool isFatal, const char *message,


### PR DESCRIPTION
Prevent _swift_runtime_on_report from having its arguments optimized out. Turns out an empty "asm volatile" isn't enough and we need to explicitly ask that the arguments are also not optimized out.

• **Explanation**: The call to the Swift runtime issue reporting debugger hook can get optimized in a way that we don't pass the correct values to the debugger.  The fix forces the compiler not to optimize the arguments out.
• **Scope**:  When the debugger is not attached, the bug doesn't affect anything.  With the LLDB  integration of Swift runtime issues, the bug can cause invalid data to be passed to the debugger.
• **Radar**:  <rdar://problem/32905453>
• **Risk**:  Very low risk.  The fix just prevents the compiler from optimizing arguments away.
• **Testing**:  I verified that an optimized build of Swift standard library correctly passes the arguments and provides the info to the debugger.
