### PR TITLE
[Parse] Provide better diagnostics for `func 1() {}`.

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -182,6 +182,9 @@ ERROR(expected_decl,none,
       "expected declaration", ())
 ERROR(expected_identifier_in_decl,none,
       "expected identifier in %0 declaration", (StringRef))
+ERROR(number_cant_start_decl_name,none,
+      "%0 name can only start with a letter or underscore, not a number",
+      (StringRef))
 ERROR(expected_identifier_after_case_comma,none,
       "expected identifier after comma in enum 'case' declaration", ())
 ERROR(decl_redefinition,none,

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2739,6 +2739,23 @@ parseIdentifierDeclName(Parser &P, Identifier &Result, SourceLoc &Loc,
 
   P.checkForInputIncomplete();
 
+  if (P.Tok.is(tok::integer_literal) || P.Tok.is(tok::floating_literal) ||
+      (P.Tok.is(tok::unknown) && isdigit(P.Tok.getText()[0]))) {
+    // Per rdar://problem/32316666, using numbers for identifiers is a common
+    // error for beginners, so it's worth handling this in a special way.
+    P.diagnose(P.Tok, diag::number_cant_start_decl_name, DeclKindName);
+
+    // Pretend this works as an identifier, which shouldn't be observable since
+    // actual uses of it will hit random other errors, e.g. `1()` won't be
+    // callable.
+    Result = P.Context.getIdentifier(P.Tok.getText());
+    Loc = P.Tok.getLoc();
+    P.consumeToken();
+
+    // We recovered, so this is a success.
+    return makeParserSuccess();
+  }
+
   if (P.Tok.isKeyword()) {
     P.diagnose(P.Tok, diag::keyword_cant_be_identifier, P.Tok.getText());
     P.diagnose(P.Tok, diag::backticks_to_escape)
@@ -4682,7 +4699,12 @@ Parser::parseDeclFunc(SourceLoc StaticLoc, StaticSpellingKind StaticSpelling,
   Token NameTok = Tok;
   SourceLoc NameLoc;
 
-  if (Tok.is(tok::identifier) || Tok.isKeyword()) {
+  if (Tok.isAny(tok::identifier, tok::integer_literal, tok::floating_literal,
+                tok::unknown) ||
+      Tok.isKeyword()) {
+    // This non-operator path is quite accepting of what tokens might be a name,
+    // because we're aggressive about recovering/providing good diagnostics for
+    // beginners.
     ParserStatus NameStatus =
         parseIdentifierDeclName(*this, SimpleName, NameLoc, "function",
                                 tok::l_paren, tok::arrow, tok::l_brace,

--- a/test/Parse/number_identifier_errors.swift
+++ b/test/Parse/number_identifier_errors.swift
@@ -1,0 +1,74 @@
+// RUN: %target-typecheck-verify-swift
+
+// Per rdar://problem/32316666 , it is a common mistake for beginners
+// to start a function name with a number, so it's worth
+// special-casing the diagnostic to make it clearer.
+
+func 1() {}
+// expected-error@-1 {{function name can only start with a letter or underscore, not a number}}
+func 2.0() {}
+// expected-error@-1 {{function name can only start with a letter or underscore, not a number}}
+func 3func() {}
+// expected-error@-1 {{function name can only start with a letter or underscore, not a number}}
+// expected-error@-2 {{expected a digit after integer literal prefix}}
+
+protocol 4 {
+  // expected-error@-1 {{protocol name can only start with a letter or underscore, not a number}}
+  associatedtype 5
+  // expected-error@-1 {{associatedtype name can only start with a letter or underscore, not a number}}
+}
+protocol 6.0 {
+  // expected-error@-1 {{protocol name can only start with a letter or underscore, not a number}}
+  associatedtype 7.0
+  // expected-error@-1 {{associatedtype name can only start with a letter or underscore, not a number}}
+}
+protocol 8protocol {
+  // expected-error@-1 {{protocol name can only start with a letter or underscore, not a number}}
+  // expected-error@-2 {{expected a digit after integer literal prefix}}
+  associatedtype 9associatedtype
+  // expected-error@-1 {{associatedtype name can only start with a letter or underscore, not a number}}
+  // expected-error@-2 {{expected a digit after integer literal prefix}}
+}
+
+typealias 10 = Int
+// expected-error@-1 {{typealias name can only start with a letter or underscore, not a number}}
+typealias 11.0 = Int
+// expected-error@-1 {{typealias name can only start with a letter or underscore, not a number}}
+typealias 12typealias = Int
+// expected-error@-1 {{typealias name can only start with a letter or underscore, not a number}}
+// expected-error@-2 {{expected a digit after integer literal prefix}}
+
+struct 13 {}
+// expected-error@-1 {{struct name can only start with a letter or underscore, not a number}}
+struct 14.0 {}
+// expected-error@-1 {{struct name can only start with a letter or underscore, not a number}}
+struct 15struct {}
+// expected-error@-1 {{struct name can only start with a letter or underscore, not a number}}
+// expected-error@-2 {{expected a digit after integer literal prefix}}
+
+enum 16 {}
+// expected-error@-1 {{enum name can only start with a letter or underscore, not a number}}
+enum 17.0 {}
+// expected-error@-1 {{enum name can only start with a letter or underscore, not a number}}
+enum 18enum {}
+// expected-error@-1 {{enum name can only start with a letter or underscore, not a number}}
+// expected-error@-2 {{expected a digit in floating point exponent}}
+
+class 19 {
+  // expected-error@-1 {{class name can only start with a letter or underscore, not a number}}
+  func 20() {}
+  // expected-error@-1 {{function name can only start with a letter or underscore, not a number}}
+}
+class 21.0 {
+  // expected-error@-1 {{class name can only start with a letter or underscore, not a number}}
+  func 22.0() {}
+  // expected-error@-1 {{function name can only start with a letter or underscore, not a number}}
+}
+
+class 23class {
+  // expected-error@-1 {{class name can only start with a letter or underscore, not a number}}
+  // expected-error@-2 {{expected a digit after integer literal prefix}}
+  func 24method() {}
+  // expected-error@-1 {{function name can only start with a letter or underscore, not a number}}
+  // expected-error@-2 {{expected a digit after integer literal prefix}}
+}


### PR DESCRIPTION
4.0 merge of https://github.com/apple/swift/pull/10426

Explanation: Improves diagnostics for the common error among beginners of defining a function where the name is or starts with a number `func 1() {}`.
Scope of Issue: Targeted enhancement of some diagnostics that are hard to interpret for beginners.
Risk: Minor, as it only changes error paths (adds a new branch that immediately emits an error diagnostic).
Reviewed By: Doug Gregor
Testing: CI test suite
Directions for QA: N/A
Radar: rdar://problem/32316666