### PR TITLE
benchmarks: fix ByteSwap benchmark

### DIFF
--- a/benchmark/single-source/ByteSwap.swift
+++ b/benchmark/single-source/ByteSwap.swift
@@ -17,6 +17,7 @@ import Foundation
 import TestsUtils
 
 // a naive O(n) implementation of byteswap.
+@inline(never)
 func byteswap_n(_ a: UInt64) -> UInt64 {
 #if swift(>=4)
   return ((a & 0x00000000000000FF) &<< 56) |
@@ -40,6 +41,7 @@ func byteswap_n(_ a: UInt64) -> UInt64 {
 }
 
 // a O(logn) implementation of byteswap.
+@inline(never)
 func byteswap_logn(_ a: UInt64) -> UInt64 {
   var a = a
   a = (a & 0x00000000FFFFFFFF) << 32 | (a & 0xFFFFFFFF00000000) >> 32
@@ -50,10 +52,13 @@ func byteswap_logn(_ a: UInt64) -> UInt64 {
 
 @inline(never)
 public func run_ByteSwap(_ N: Int) {
-  for _ in 1...100*N {
+  var s: UInt64 = 0
+  for _ in 1...10000*N {
     // Check some results.
-    CheckResults(byteswap_logn(byteswap_n(2457)) == 2457)
-    CheckResults(byteswap_logn(byteswap_n(9129)) == 9129)
-    CheckResults(byteswap_logn(byteswap_n(3333)) == 3333)
+    let x : UInt64 = UInt64(getInt(0))
+    s = s &+ byteswap_logn(byteswap_n(x &+ 2457))
+          &+ byteswap_logn(byteswap_n(x &+ 9129))
+          &+ byteswap_logn(byteswap_n(x &+ 3333))
   }
+  CheckResults(s == (2457 &+ 9129 &+ 3333) &* 10000 &* N)
 }


### PR DESCRIPTION
*) Use getInt to prevent loop hoisting of the benchmark functions
*) Reduce the overhead of CheckResult by moving it out of the loop
*) Prevent inlining of the actual benchmark functions
