### PR TITLE
[swiftc (32 vs. 5565)] Add crasher in swift::TypeChecker::resolveWitness

### DIFF
--- a/validation-test/compiler_crashers/28790-conformance-getwitness-requirement-nullptr-getdecl-already-have-a-non-optional-w.swift
+++ b/validation-test/compiler_crashers/28790-conformance-getwitness-requirement-nullptr-getdecl-already-have-a-non-optional-w.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+class a:P{class a{}{}func a:a{}func a{}}@objc protocol P{{}func a


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeChecker::resolveWitness`.

Current number of unresolved compiler crashers: 32 (5565 resolved)

Assertion failure in [`lib/Sema/TypeCheckProtocol.cpp (line 2481)`](https://github.com/apple/swift/blob/93701535d1e6c5dc43e104d387265d89fa35836d/lib/Sema/TypeCheckProtocol.cpp#L2481):

```
Assertion `!Conformance->getWitness(requirement, nullptr).getDecl() && "Already have a non-optional witness?"' failed.

When executing: void (anonymous namespace)::ConformanceChecker::recordInvalidWitness(swift::ValueDecl *)
```

Assertion context:

```c++
  assert(Conformance->isInvalid());

  // If we already recorded this witness, don't do so again.
  if (Conformance->hasWitness(requirement)) {
    assert(!Conformance->getWitness(requirement, nullptr).getDecl() &&
           "Already have a non-optional witness?");
    return;
  }

  // Record that there is no witness.
  Conformance->setWitness(requirement, Witness());
```
Stack trace:

```
0 0x0000000003a7b018 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3a7b018)
1 0x0000000003a7b756 SignalHandler(int) (/path/to/swift/bin/swift+0x3a7b756)
2 0x00007effb40e4390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007effb2609428 gsignal /build/glibc-bfm8X4/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007effb260b02a abort /build/glibc-bfm8X4/glibc-2.23/stdlib/abort.c:91:0
5 0x00007effb2601bd7 __assert_fail_base /build/glibc-bfm8X4/glibc-2.23/assert/assert.c:92:0
6 0x00007effb2601c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x00000000013c110a (/path/to/swift/bin/swift+0x13c110a)
8 0x000000000139ed9b swift::TypeChecker::resolveWitness(swift::NormalProtocolConformance const*, swift::ValueDecl*) (/path/to/swift/bin/swift+0x139ed9b)
9 0x00000000015bdcfd swift::NormalProtocolConformance::getWitness(swift::ValueDecl*, swift::LazyResolver*) const (/path/to/swift/bin/swift+0x15bdcfd)
10 0x00000000015bdbcf swift::ProtocolConformance::getWitnessDecl(swift::ValueDecl*, swift::LazyResolver*) const (/path/to/swift/bin/swift+0x15bdbcf)
11 0x000000000139be1f swift::TypeChecker::findWitnessedObjCRequirements(swift::ValueDecl const*, bool) (/path/to/swift/bin/swift+0x139be1f)
12 0x000000000135e7f3 shouldMarkAsObjC(swift::TypeChecker&, swift::ValueDecl const*, bool) (/path/to/swift/bin/swift+0x135e7f3)
13 0x000000000136caeb (anonymous namespace)::DeclChecker::visitFuncDecl(swift::FuncDecl*) (/path/to/swift/bin/swift+0x136caeb)
14 0x0000000001358464 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x1358464)
15 0x000000000135a494 swift::TypeChecker::validateDecl(swift::ValueDecl*) (/path/to/swift/bin/swift+0x135a494)
16 0x0000000001358f22 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x1358f22)
17 0x000000000136915b (anonymous namespace)::DeclChecker::visitClassDecl(swift::ClassDecl*) (/path/to/swift/bin/swift+0x136915b)
18 0x000000000135853e (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x135853e)
19 0x0000000001358343 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x1358343)
20 0x00000000013e3344 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x13e3344)
21 0x0000000000fa16cd swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xfa16cd)
22 0x00000000004abe59 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4abe59)
23 0x00000000004aa3f9 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4aa3f9)
24 0x0000000000465697 main (/path/to/swift/bin/swift+0x465697)
25 0x00007effb25f4830 __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:325:0
26 0x0000000000462d39 _start (/path/to/swift/bin/swift+0x462d39)
```