### PR TITLE
IRGen: Use LLVM's alloc size to compute padding between types

### DIFF
--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -382,7 +382,9 @@ NativeConventionSchema::getCoercionTypes(
           packed = true;
         elts.push_back(type);
         expandedTyIndicesMap.push_back(idx - 1);
-        lastEnd = end;
+        lastEnd = begin + clang::CharUnits::fromQuantity(
+                              IGM.DataLayout.getTypeAllocSize(type));
+        assert(end <= lastEnd);
       });
 
   auto *coercionType = llvm::StructType::get(ctx, elts, packed);
@@ -419,7 +421,9 @@ NativeConventionSchema::getCoercionTypes(
           packed = true;
         elts.push_back(type);
         expandedTyIndicesMap.push_back(idx - 1);
-        lastEnd = end;
+        lastEnd = begin + clang::CharUnits::fromQuantity(
+                              IGM.DataLayout.getTypeAllocSize(type));
+        assert(end <= lastEnd);
       });
   auto *overlappedCoercionType = llvm::StructType::get(ctx, elts, packed);
   return {coercionType, overlappedCoercionType};

--- a/test/Interpreter/simd.swift
+++ b/test/Interpreter/simd.swift
@@ -1,5 +1,6 @@
 // RUN: %target-run-simple-swift | %FileCheck %s
 // REQUIRES: executable_test
+// REQUIRES: OS=macosx
 
 import simd
 

--- a/test/Interpreter/simd.swift
+++ b/test/Interpreter/simd.swift
@@ -1,0 +1,30 @@
+// RUN: %target-run-simple-swift | %FileCheck %s
+// REQUIRES: executable_test
+
+import simd
+
+public struct Vector3f {
+  var f3: float3
+  init() {
+    f3 = float3(0, 1, 2)
+  }
+}
+
+public struct TwoFloat {
+  var f0 : Float
+  var f1 : Float
+  init() {
+    f0 = 0.0
+    f1 = 1.0
+  }
+}
+
+public func test() -> (Vector3f, TwoFloat) {
+  let v = Vector3f()
+  let y = TwoFloat()
+  let r = (v, y)
+  return r
+}
+
+// CHECK: (main.Vector3f(f3: float3(0.0, 1.0, 2.0)), main.TwoFloat(f0: 0.0, f1: 1.0))
+print(test())


### PR DESCRIPTION
We need to subtract alignment padding when doing type layout in terms of llvm types

rdar://32618125
SR-5137