### PR TITLE
[Migrator] Remove closure shorthand prefixing.

### DIFF
--- a/lib/Migrator/TupleSplatMigratorPass.cpp
+++ b/lib/Migrator/TupleSplatMigratorPass.cpp
@@ -96,20 +96,10 @@ struct TupleSplatMigratorPass : public ASTMigratorPass,
     }
 
     unsigned ClosureArity = Closure->getParameters()->size();
-    if (NativeArity == ClosureArity)
+    if (NativeArity <= ClosureArity)
       return false;
 
     ShorthandFinder Finder(Closure);
-    if (NativeArity == 1 && ClosureArity > 1) {
-      // Prepend $0. to existing references
-      Finder.forEachReference([this](Expr *Ref, ParamDecl* Def) {
-        if (auto *TE = dyn_cast<TupleElementExpr>(Ref))
-          Ref = TE->getBase();
-        SourceLoc AfterDollar = Ref->getStartLoc().getAdvancedLoc(1);
-        Editor.insert(AfterDollar, "0.");
-      });
-      return true;
-    }
 
     if (ClosureArity == 1 && NativeArity > 1) {
       // Remove $0. from existing references or if it's only $0, replace it

--- a/test/Migrator/tuple-arguments.swift.expected
+++ b/test/Migrator/tuple-arguments.swift.expected
@@ -46,14 +46,14 @@ func toString(indexes: Int?...) -> String {
   })
   let _ = indexes.reduce(0) { print(($0, $1)); return $0 + ($1 ?? 0)}
   let _ = indexes.reduce(0) { (true ? ($0, $1) : (1, 2)).0 + ($1 ?? 0) }
-  let _ = [(1, 2)].contains { $0.0 != $0.1 }
+  let _ = [(1, 2)].contains { $0 != $1 }
   _ = ["Hello", "Foo"].sorted { print(($0, $1)); return $0.characters.count > $1.characters.count }
-  _ = ["Hello" : 2].map { ($0.0, ($0.1)) }
+  _ = ["Hello" : 2].map { ($0, ($1)) }
 }
 
 extension Dictionary {
   public mutating func merge(with dictionary: Dictionary) {
-    dictionary.forEach { updateValue($0.1, forKey: $0.0) }
+    dictionary.forEach { updateValue($1, forKey: $0) }
   }
 }
 


### PR DESCRIPTION
In https://github.com/apple/swift/pull/10414, some SE-0110 features
were backed out, so the Migrator no longer needs to add `$0` shorthand
prefixing.

rdar://problem/32907276