### PR TITLE
SILGen: Remove assertion that rejected context-free nested functions in generic contexts when referenced as C function pointers.

### DIFF
--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -1483,8 +1483,6 @@ ManagedValue emitCFunctionPointer(SILGenFunction &gen,
     // in the metatype.
     assert(!declRef.getDecl()->getDeclContext()->isTypeContext()
            && "c pointers to static methods not implemented");
-    assert(declRef.getSubstitutions().empty()
-           && "c pointers to generics not implemented");
     loc = declRef.getDecl();
   };
   

--- a/test/SILGen/c_function_pointers.swift
+++ b/test/SILGen/c_function_pointers.swift
@@ -63,3 +63,9 @@ struct StructWithInitializers {
   init(a: ()) {}
   init(b: ()) {}
 }
+
+func pointers_to_nested_local_functions_in_generics<T>(x: T) -> Int{
+  func foo(y: Int) -> Int { return y }
+
+  return calls(foo, 0)
+}


### PR DESCRIPTION
A ConcreteDeclRef to a nested function will include substitutions for its enclosing generic parameters, even if they aren't captured by use locally within the function. The assertion here is probably unnecessary since inconsistencies here should be caught by assertions elsewhere. Fixes SR-5023 | rdar://problem/32426540.