### PR TITLE
[4.0] SILGen: Remove assertion that rejected context-free nested functions in generic contexts when referenced as C function pointers.

### DIFF
--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -1422,8 +1422,6 @@ ManagedValue emitCFunctionPointer(SILGenFunction &gen,
     // in the metatype.
     assert(!declRef.getDecl()->getDeclContext()->isTypeContext()
            && "c pointers to static methods not implemented");
-    assert(declRef.getSubstitutions().empty()
-           && "c pointers to generics not implemented");
     loc = declRef.getDecl();
   };
   

--- a/test/SILGen/c_function_pointers.swift
+++ b/test/SILGen/c_function_pointers.swift
@@ -63,3 +63,9 @@ struct StructWithInitializers {
   init(a: ()) {}
   init(b: ()) {}
 }
+
+func pointers_to_nested_local_functions_in_generics<T>(x: T) -> Int{
+  func foo(y: Int) -> Int { return y }
+
+  return calls(foo, 0)
+}


### PR DESCRIPTION
Explanation: An assertion failure would occur when taking a C function pointer to a non-generic, non-capturing local function inside a generic context, which is supposed to be supported.

Scope: Compatibility regression affecting https://github.com/groue/GRDB.swift.git

Issue: SR-5023 | rdar://problem/32426540

Risk: Low, only removes an overly-broad assertion

Testing: Swift CI, affected project