### PR TITLE
Sema: Don't infer 'dynamic' for static methods and properties

### DIFF
--- a/test/attr/attr_dynamic_infer.swift
+++ b/test/attr/attr_dynamic_infer.swift
@@ -59,7 +59,7 @@ extension Sub {
 @objc class FinalTests {}
 
 extension FinalTests {
-  // CHECK:  @objc final func foo
+  // CHECK: @objc final func foo
   final func foo() { }
 
   // CHECK: @objc final var prop: Super
@@ -77,5 +77,11 @@ extension FinalTests {
     // CHECK: @objc final set
     set { }
   }
+
+  // CHECK: static @objc var x
+  static var x: Int = 0
+
+  // CHECK: @objc static func bar
+  static func bar() { }
 }
 


### PR DESCRIPTION
Otherwise, can crash in the AST verifier.

Fixes <rdar://problem/32862136>.