### PR TITLE
Sema: Don't infer 'dynamic' for static methods and properties [4.0]

### DIFF
--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -734,6 +734,8 @@ namespace {
         OS << " final";
       if (VD->isObjC())
         OS << " @objc";
+      if (VD->isDynamic())
+        OS << " dynamic";
     }
 
     void printCommon(NominalTypeDecl *NTD, const char *Name,

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2318,8 +2318,6 @@ void PrintAST::visitPatternBindingDecl(PatternBindingDecl *decl) {
 
   if (anyVar)
     printDocumentationComment(anyVar);
-  if (decl->isStatic())
-    printStaticKeyword(decl->getCorrectStaticSpelling());
 
   // FIXME: PatternBindingDecls don't have attributes themselves, so just assume
   // the variables all have the same attributes. This isn't exactly true
@@ -2327,6 +2325,12 @@ void PrintAST::visitPatternBindingDecl(PatternBindingDecl *decl) {
   if (anyVar) {
     printAttributes(anyVar);
     printAccessibility(anyVar);
+  }
+
+  if (decl->isStatic())
+    printStaticKeyword(decl->getCorrectStaticSpelling());
+
+  if (anyVar) {
     Printer << (anyVar->isSettable(anyVar->getDeclContext()) ? "var " : "let ");
   } else {
     Printer << "let ";

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -186,10 +186,6 @@ static FuncDecl *createGetterPrototype(AbstractStorageDecl *storage,
   if (storage->isGetterMutating())
     getter->setMutating();
 
-  // If the var is marked final, then so is the getter.
-  if (storage->isFinal())
-    makeFinal(TC.Context, getter);
-
   if (storage->isStatic())
     getter->setStatic();
 
@@ -238,10 +234,6 @@ static FuncDecl *createSetterPrototype(AbstractStorageDecl *storage,
 
   if (isStatic)
     setter->setStatic();
-
-  // If the var is marked final, then so is the getter.
-  if (storage->isFinal())
-    makeFinal(TC.Context, setter);
 
   return setter;
 }
@@ -824,17 +816,10 @@ static void addTrivialAccessorsToStorage(AbstractStorageDecl *storage,
   // Okay, we have both the getter and setter.  Set them in VD.
   storage->addTrivialAccessors(getter, setter, nullptr);
 
-  bool isDynamic = (storage->isDynamic() && storage->isObjC());
-  if (isDynamic)
-    makeDynamic(TC.Context, getter);
-
   // Synthesize the body of the getter.
   synthesizeTrivialGetter(getter, storage, TC);
 
   if (setter) {
-    if (isDynamic)
-      makeDynamic(TC.Context, setter);
-
     // Synthesize the body of the setter.
     synthesizeTrivialSetter(setter, storage, setterValueParam, TC);
   }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2560,8 +2560,8 @@ static void inferDynamic(ASTContext &ctx, ValueDecl *D) {
   if (auto VD = dyn_cast<VarDecl>(D)) {
     auto staticSpelling = VD->getParentPatternBinding()->getStaticSpelling();
 
-    // The presence of 'static' bocks the inference of 'dynamic'.
-    if (VD->isStatic() && staticSpelling == StaticSpellingKind::KeywordStatic)
+    // The presence of 'static' blocks the inference of 'dynamic'.
+    if (staticSpelling == StaticSpellingKind::KeywordStatic)
       return;
 
     if (VD->isLet() && !isNSManaged)
@@ -2577,7 +2577,7 @@ static void inferDynamic(ASTContext &ctx, ValueDecl *D) {
     auto staticSpelling = FD->getStaticSpelling();
 
     // The presence of 'static' bocks the inference of 'dynamic'.
-    if (FD->isStatic() && staticSpelling == StaticSpellingKind::KeywordStatic)
+    if (staticSpelling == StaticSpellingKind::KeywordStatic)
       return;
   }
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1245,12 +1245,14 @@ static void validatePatternBindingEntries(TypeChecker &tc,
 
 void swift::makeFinal(ASTContext &ctx, ValueDecl *D) {
   if (D && !D->isFinal()) {
+    assert(!D->isDynamic());
     D->getAttrs().add(new (ctx) FinalAttr(/*IsImplicit=*/true));
   }
 }
 
 void swift::makeDynamic(ASTContext &ctx, ValueDecl *D) {
   if (D && !D->isDynamic()) {
+    assert(!D->isFinal());
     D->getAttrs().add(new (ctx) DynamicAttr(/*IsImplicit=*/true));
   }
 }
@@ -2556,14 +2558,28 @@ static void inferDynamic(ASTContext &ctx, ValueDecl *D) {
 
   // Variables declared with 'let' cannot be 'dynamic'.
   if (auto VD = dyn_cast<VarDecl>(D)) {
-    if (VD->isLet() && !isNSManaged) return;
+    auto staticSpelling = VD->getParentPatternBinding()->getStaticSpelling();
+
+    // The presence of 'static' bocks the inference of 'dynamic'.
+    if (VD->isStatic() && staticSpelling == StaticSpellingKind::KeywordStatic)
+      return;
+
+    if (VD->isLet() && !isNSManaged)
+      return;
   }
 
   // Accessors should not infer 'dynamic' on their own; they can get it from
   // their storage decls.
-  if (auto FD = dyn_cast<FuncDecl>(D))
+  if (auto FD = dyn_cast<FuncDecl>(D)) {
     if (FD->isAccessor())
       return;
+
+    auto staticSpelling = FD->getStaticSpelling();
+
+    // The presence of 'static' bocks the inference of 'dynamic'.
+    if (FD->isStatic() && staticSpelling == StaticSpellingKind::KeywordStatic)
+      return;
+  }
 
   // The presence of 'final' on a class prevents 'dynamic'.
   auto classDecl = D->getDeclContext()->getAsClassOrClassExtensionContext();
@@ -5170,8 +5186,7 @@ public:
 
         // If the storage is dynamic or final, propagate to this accessor.
         if (isObjC &&
-            storage->isDynamic() &&
-            !storage->isFinal())
+            storage->isDynamic())
           makeDynamic(TC.Context, FD);
 
         if (storage->isFinal())

--- a/test/attr/attr_dynamic_infer.swift
+++ b/test/attr/attr_dynamic_infer.swift
@@ -59,7 +59,7 @@ extension Sub {
 @objc class FinalTests {}
 
 extension FinalTests {
-  // CHECK:  @objc final func foo
+  // CHECK: @objc final func foo
   final func foo() { }
 
   // CHECK: @objc final var prop: Super
@@ -77,5 +77,11 @@ extension FinalTests {
     // CHECK: @objc final set
     set { }
   }
+
+  // CHECK: static @objc var x
+  static var x: Int = 0
+
+  // CHECK: @objc static func bar
+  static func bar() { }
 }
 

--- a/test/attr/attr_dynamic_infer.swift
+++ b/test/attr/attr_dynamic_infer.swift
@@ -78,7 +78,7 @@ extension FinalTests {
     set { }
   }
 
-  // CHECK: static @objc var x
+  // CHECK: @objc static var x
   static var x: Int = 0
 
   // CHECK: @objc static func bar


### PR DESCRIPTION
* Description: Fix a bug where we would infer 'dynamic' for static properties in extensions of @objc classes, which would trigger AST verifier assertions and possibly other problems, because a 'final' declaration cannot be 'dynamic', and 'static' implies 'final'.

* Scope of the issue: Affects AudioKit, a third-party project.

* Origination: Probably been there for a while, just discovered now.

* Risk: I had to cherry-pick another refactoring I did on master a couple of weeks ago but I think it's relatively stable by now.

* Reviewed by: @jrose-apple 

* Tested: New test case added.

* Radar: <rdar://problem/32862136>