### PR TITLE
Fix AccessSummaryAnalysis to handle @convention(block) in nested noescape closures.

### DIFF
--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -6400,12 +6400,16 @@ public:
     case ValueKind::TryApplyInst:
       return 0;
     case ValueKind::PartialApplyInst:
+      // The arguments to partial_apply are a suffix of the arguments to the
+      // the actually-called function.
       return getSubstCalleeConv().getNumSILArguments() - getNumArguments();
     default:
       llvm_unreachable("not implemented for this instruction!");
     }
   }
 
+  // Translate the index of the argument to the full apply or partial_apply into
+  // to the corresponding index into the arguments of the called function.
   unsigned getCalleeArgIndex(Operand &oper) {
     assert(oper.getUser() == Inst);
     assert(oper.getOperandNumber() >= getOperandIndexOfFirstArgument());

--- a/lib/SILOptimizer/Analysis/AccessSummaryAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/AccessSummaryAnalysis.cpp
@@ -106,6 +106,8 @@ void AccessSummaryAnalysis::processArgument(FunctionInfo *info,
     case ValueKind::ExistentialMetatypeInst:
     case ValueKind::ValueMetatypeInst:
     case ValueKind::LoadInst:
+    case ValueKind::LoadBorrowInst:
+    case ValueKind::EndBorrowInst:
     case ValueKind::OpenExistentialAddrInst:
     case ValueKind::ProjectBlockStorageInst:
       // These likely represent scenarios in which we're not generating
@@ -129,24 +131,47 @@ void AccessSummaryAnalysis::processArgument(FunctionInfo *info,
 /// only ultimately used by an apply, a try_apply or as an argument (but not
 /// the called function) in a partial_apply.
 /// TODO: This really should be checked in the SILVerifier.
-static bool isExpectedUseOfNoEscapePartialApply(SILInstruction *user) {
-  if (!user)
-    return true;
+static bool hasExpectedUsesOfNoEscapePartialApply(SILInstruction *closure) {
+  for (Operand *use : closure->getUses()) {
+    SILInstruction *user = use->getUser();
 
-  // It is fine to call the partial apply
-  if (isa<ApplyInst>(user) || isa<TryApplyInst>(user)) {
-    return true;
+    // It is fine to call the partial apply
+    switch (user->getKind()) {
+    case ValueKind::ApplyInst:
+    case ValueKind::TryApplyInst:
+      return true;
+
+    case ValueKind::ConvertFunctionInst:
+      return hasExpectedUsesOfNoEscapePartialApply(user);
+
+    case ValueKind::PartialApplyInst:
+      return closure != cast<PartialApplyInst>(closure)->getCallee();
+
+    case ValueKind::StoreInst:
+    case ValueKind::DestroyValueInst:
+      // @block_storage is passed by storing it to the stack. We know this is
+      // still nonescaping simply because our original argument convention is
+      // @inout_aliasable. In this SIL, both store and destroy_value are users
+      // of %closure:
+      //
+      // %closure = partial_apply %f1(%arg)
+      //   : $@convention(thin) (@inout_aliasable T) -> ()
+      // %storage = alloc_stack $@block_storage @callee_owned () -> ()
+      // %block_addr = project_block_storage %storage
+      //   : $*@block_storage @callee_owned () -> ()
+      // store %closure to [init] %block_addr : $*@callee_owned () -> ()
+      // %block = init_block_storage_header %storage
+      //     : $*@block_storage @callee_owned () -> (),
+      //   invoke %f2 : $@convention(c)
+      //     (@inout_aliasable @block_storage @callee_owned () -> ()) -> (),
+      //   type $@convention(block) () -> ()
+      // %copy = copy_block %block : $@convention(block) () -> ()
+      // destroy_value %storage : $@callee_owned () -> ()
+      return true;
+    default:
+      return false;
+    }
   }
-
-  if (isa<ConvertFunctionInst>(user)) {
-    return isExpectedUseOfNoEscapePartialApply(user->getSingleUse()->getUser());
-  }
-
-  if (auto *PAI = dyn_cast<PartialApplyInst>(user)) {
-    return user != PAI->getCallee();
-  }
-
-  return false;
 }
 #endif
 
@@ -164,15 +189,8 @@ void AccessSummaryAnalysis::processPartialApply(FunctionInfo *callerInfo,
   assert(isa<FunctionRefInst>(apply->getCallee()) &&
          "Noescape partial apply of non-functionref?");
 
-  SILInstruction *user = apply->getSingleUse()->getUser();
-  assert(isExpectedUseOfNoEscapePartialApply(user) &&
-         "noescape partial_apply has unexpected use!");
-  (void)user;
-
-  // The arguments to partial_apply are a suffix of the arguments to the
-  // the actually-called function. Translate the index of the argument to
-  // the partial_apply into to the corresponding index into the arguments of
-  // the called function.
+  assert(hasExpectedUsesOfNoEscapePartialApply(apply)
+         && "noescape partial_apply has unexpected use!");
 
   // The argument index in the called function.
   ApplySite site(apply);

--- a/lib/SILOptimizer/Mandatory/AccessEnforcementSelection.cpp
+++ b/lib/SILOptimizer/Mandatory/AccessEnforcementSelection.cpp
@@ -57,6 +57,11 @@ static void setDynamicEnforcement(BeginAccessInst *access) {
 namespace {
 // Information about an address-type closure capture.
 // This is only valid for inout_aliasable parameters.
+//
+// TODO: Verify somewhere that we properly handle any non-inout_aliasable
+// partial apply captures or that they never happen. Eventually @inout_aliasable
+// should be simply replaced by @in or @out, once we don't have special aliasing
+// rules.
 struct AddressCapture {
   ApplySite site;
   unsigned calleeArgIdx;

--- a/lib/SILOptimizer/Mandatory/DiagnoseStaticExclusivity.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseStaticExclusivity.cpp
@@ -985,6 +985,11 @@ static PartialApplyInst *lookThroughForPartialApply(SILValue V) {
 /// if any of the @inout_aliasable captures passed to those closures have
 /// in-progress accesses that would conflict with any access the summary
 /// says the closure would perform.
+//
+/// TODO: We currently fail to statically diagnose non-escaping closures pased
+/// via @block_storage convention. To enforce this case, we should statically
+/// recognize when the apply takes a block argument that has been initialized to
+/// a non-escaping closure.
 static void checkForViolationsInNoEscapeClosures(
     const StorageMap &Accesses, FullApplySite FAS, AccessSummaryAnalysis *ASA,
     llvm::SmallVectorImpl<ConflictingAccess> &ConflictingAccesses) {


### PR DESCRIPTION
This analysis uses a whitelist so we can be sure not do miss any diagnostics. Naturally there are some very unusual cases that weren't part of that original whitelist. As I've already pointed out, these kind of assumptions should be ratified in SILVerifier, but that will need to come in a subsequent commit.