### PR TITLE
benchmarks: Make sure there is no constant propagation in the StringBuilder benchmarks.

### DIFF
--- a/benchmark/single-source/StringBuilder.swift
+++ b/benchmark/single-source/StringBuilder.swift
@@ -13,8 +13,8 @@
 import TestsUtils
 
 @inline(never)
-func buildString() -> String {
-  var sb = "a"
+func buildString(_ i: String) -> String {
+  var sb = i
   for str in ["b","c","d","pizza"] {
     sb += str
   }
@@ -24,26 +24,26 @@ func buildString() -> String {
 @inline(never)
 public func run_StringBuilder(_ N: Int) {
   for _ in 1...5000*N {
-    _ = buildString()
+    _ = buildString(getString("a"))
   }
 }
 
 @inline(never)
-func addString() -> String {
-  let s = "a" + "b" + "c" + "d" + "pizza"
+func addString(_ i: String) -> String {
+  let s = i + "b" + "c" + "d" + "pizza"
   return s
 }
 
 @inline(never)
 public func run_StringAdder(_ N: Int) {
   for _ in 1...5000*N {
-    _ = addString()
+    _ = addString(getString("a"))
   }
 }
 
 @inline(never)
-func buildStringUTF16() -> String {
-  var sb = "a"
+func buildStringUTF16(_ i: String) -> String {
+  var sb = i
   for str in ["🎉","c","d","pizza"] {
     sb += str
   }
@@ -53,14 +53,14 @@ func buildStringUTF16() -> String {
 @inline(never)
 public func run_StringUTF16Builder(_ N: Int) {
   for _ in 1...5000*N {
-    _ = buildStringUTF16()
+    _ = buildStringUTF16("a")
   }
 }
 
 
 @inline(never)
-func buildStringLong() -> String {
-  var sb = "👻"
+func buildStringLong(_ i: String) -> String {
+  var sb = i
   let long = "Swift is a multi-paradigm, compiled programming language created for iOS, OS X, watchOS, tvOS and Linux development by Apple Inc. Swift is designed to work with Apple's Cocoa and Cocoa Touch frameworks and the large body of existing Objective-C code written for Apple products. Swift is intended to be more resilient to erroneous code (\"safer\") than Objective-C and also more concise. It is built with the LLVM compiler framework included in Xcode 6 and later and uses the Objective-C runtime, which allows C, Objective-C, C++ and Swift code to run within a single program."
   sb += long
   return sb
@@ -71,7 +71,7 @@ func buildStringLong() -> String {
 @inline(never)
 public func run_StringBuilderLong(_ N: Int) {
   for _ in 1...5000*N {
-    _ = buildStringLong()
+    _ = buildStringLong("👻")
   }
 }
 

--- a/benchmark/utils/TestsUtils.swift
+++ b/benchmark/utils/TestsUtils.swift
@@ -98,3 +98,6 @@ public func blackHole<T>(_ x: T) {
 @inline(never)
 public func getInt(_ x: Int) -> Int { return x }
 
+// The same for String.
+@inline(never)
+public func getString(_ s: String) -> String { return s }


### PR DESCRIPTION
This fixes the StringAdder benchmark, where the string addition was completely constant folded.
It has only minimal effect on the other benchmarks in this file, because the optimizer didn't constant fold the strings there anyway.