### PR TITLE
[swiftc (34 vs. 5565)] Add crasher in swift::GenericSignature::getConformanceAccessPath

### DIFF
--- a/validation-test/compiler_crashers/28792-conforms-equivclass-conformsto-end.swift
+++ b/validation-test/compiler_crashers/28792-conforms-equivclass-conformsto-end.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol A:A{struct B{{}var a{class a{class ss:a


### PR DESCRIPTION
Add test case for crash triggered in `swift::GenericSignature::getConformanceAccessPath`.

Current number of unresolved compiler crashers: 34 (5565 resolved)

/cc @DougGregor - just wanted to let you know that this crasher caused an assertion failure for the assertion `conforms != equivClass->conformsTo.end()` added on 2017-03-06 by you in commit eaee4add :-)

Assertion failure in [`lib/AST/GenericSignature.cpp (line 881)`](https://github.com/apple/swift/blob/1afcafcd249e4877cf264a37a1208aeab03148d1/lib/AST/GenericSignature.cpp#L881):

```
Assertion `conforms != equivClass->conformsTo.end()' failed.

When executing: auto swift::GenericSignature::getConformanceAccessPath(swift::Type, swift::ProtocolDecl *, swift::ModuleDecl &)::(anonymous class)::operator()(swift::GenericSignature *, const RequirementSource *, swift::ProtocolDecl *, swift::Type) const
```

Assertion context:

```c++
      auto equivClass = pa->getOrCreateEquivalenceClass();

      // Find the conformance of this potential archetype to the protocol in
      // question.
      auto conforms = equivClass->conformsTo.find(conformingProto);
      assert(conforms != equivClass->conformsTo.end());

      // Compute the root type, canonicalizing it w.r.t. the protocol context.
      auto inProtoSig = inProtocol->getGenericSignature();
      auto conformsSource = getBestRequirementSource(conforms->second);
      Type localRootType = conformsSource->getRootPotentialArchetype()
```
Stack trace:

```
0 0x0000000003a7b018 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3a7b018)
1 0x0000000003a7b756 SignalHandler(int) (/path/to/swift/bin/swift+0x3a7b756)
2 0x00007f439f990390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007f439deb5428 gsignal /build/glibc-bfm8X4/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f439deb702a abort /build/glibc-bfm8X4/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f439deadbd7 __assert_fail_base /build/glibc-bfm8X4/glibc-2.23/assert/assert.c:92:0
6 0x00007f439deadc82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x000000000156f280 std::_Function_handler<void (swift::GenericSignature*, swift::GenericSignatureBuilder::RequirementSource const*, swift::ProtocolDecl*, swift::Type), swift::GenericSignature::getConformanceAccessPath(swift::Type, swift::ProtocolDecl*, swift::ModuleDecl&)::$_11>::_M_invoke(std::_Any_data const&, swift::GenericSignature*&&, swift::GenericSignatureBuilder::RequirementSource const*&&, swift::ProtocolDecl*&&, swift::Type&&) (/path/to/swift/bin/swift+0x156f280)
8 0x000000000156df39 swift::GenericSignature::getConformanceAccessPath(swift::Type, swift::ProtocolDecl*, swift::ModuleDecl&) (/path/to/swift/bin/swift+0x156df39)
9 0x00000000015c6044 swift::SubstitutionMap::lookupConformance(swift::CanType, swift::ProtocolDecl*) const (/path/to/swift/bin/swift+0x15c6044)
10 0x000000000156e95e bool llvm::function_ref<bool (swift::Type, llvm::ArrayRef<swift::Requirement>)>::callback_fn<swift::GenericSignature::getSubstitutions(swift::SubstitutionMap const&, llvm::SmallVectorImpl<swift::Substitution>&) const::$_8>(long, swift::Type, llvm::ArrayRef<swift::Requirement>) (/path/to/swift/bin/swift+0x156e95e)
11 0x000000000156b7f7 swift::GenericSignature::enumeratePairedRequirements(llvm::function_ref<bool (swift::Type, llvm::ArrayRef<swift::Requirement>)>) const (/path/to/swift/bin/swift+0x156b7f7)
12 0x000000000156cd62 swift::GenericSignature::getSubstitutions(swift::SubstitutionMap const&, llvm::SmallVectorImpl<swift::Substitution>&) const (/path/to/swift/bin/swift+0x156cd62)
13 0x00000000013e6499 swift::constraints::Solution::computeSubstitutions(swift::GenericSignature*, swift::constraints::ConstraintLocator*, llvm::SmallVectorImpl<swift::Substitution>&) const (/path/to/swift/bin/swift+0x13e6499)
14 0x00000000013fca9d swift::ASTVisitor<(anonymous namespace)::ExprRewriter, swift::Expr*, void, void, void, void, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x13fca9d)
15 0x00000000013eba14 (anonymous namespace)::ExprRewriter::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0x13eba14)
16 0x00000000013f14d1 (anonymous namespace)::ExprWalker::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0x13f14d1)
17 0x0000000001526c3c (anonymous namespace)::Traversal::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0x1526c3c)
18 0x00000000015240fb swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x15240fb)
19 0x00000000015234db swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x15234db)
20 0x00000000013e89a0 swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) (/path/to/swift/bin/swift+0x13e89a0)
21 0x000000000134148f swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x134148f)
22 0x00000000013c56d5 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13c56d5)
23 0x00000000013c3e11 swift::TypeChecker::typeCheckConstructorBodyUntil(swift::ConstructorDecl*, swift::SourceLoc) (/path/to/swift/bin/swift+0x13c3e11)
24 0x00000000013c382d swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) (/path/to/swift/bin/swift+0x13c382d)
25 0x00000000013c452d swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0x13c452d)
26 0x00000000013e2588 typeCheckFunctionsAndExternalDecls(swift::TypeChecker&) (/path/to/swift/bin/swift+0x13e2588)
27 0x00000000013e343a swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x13e343a)
28 0x0000000000fa16cd swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xfa16cd)
29 0x00000000004abe59 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4abe59)
30 0x00000000004aa3f9 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4aa3f9)
31 0x0000000000465697 main (/path/to/swift/bin/swift+0x465697)
32 0x00007f439dea0830 __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:325:0
33 0x0000000000462d39 _start (/path/to/swift/bin/swift+0x462d39)
```