### PR TITLE
Prefix countRepresentedWords with underscore [NFC]

### DIFF
--- a/stdlib/public/core/DoubleWidth.swift.gyb
+++ b/stdlib/public/core/DoubleWidth.swift.gyb
@@ -176,9 +176,9 @@ public struct DoubleWidth<Base : FixedWidthInteger> :
       }
 
       // TODO: move to Int128 just like init(_builtinIntegerLiteral:) ?
-      return (n < _storage.low.countRepresentedWords) ?
+      return (n < _storage.low._countRepresentedWords) ?
         _storage.low._word(at: n) :
-        _storage.high._word(at: n - _storage.low.countRepresentedWords)
+        _storage.high._word(at: n - _storage.low._countRepresentedWords)
     }
   }
 

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -1548,7 +1548,7 @@ extension BinaryInteger {
   ///
   /// This property is a constant for instances of fixed-width integer types.
   @_transparent
-  public var countRepresentedWords: Int {
+  public var _countRepresentedWords: Int {
     return (self.bitWidth + ${word_bits} - 1) / ${word_bits}
   }
 
@@ -1896,11 +1896,11 @@ extension BinaryInteger {
   }
 
   // FIXME(integers): inefficient. Should get rid of _word(at:) and
-  // countRepresentedWords, and make `words` the basic operation.
+  // _countRepresentedWords, and make `words` the basic operation.
   public var words: [UInt] {
     var result = [UInt]()
-    result.reserveCapacity(countRepresentedWords)
-    for i in 0..<self.countRepresentedWords {
+    result.reserveCapacity(_countRepresentedWords)
+    for i in 0..<self._countRepresentedWords {
       result.append(_word(at: i))
     }
     return result
@@ -2328,7 +2328,7 @@ ${unsafeOperationComment(x.operator)}
     else {
       var result: Self = source < (0 as T) ? ~0 : 0
       // start with the most significant word
-      var n = source.countRepresentedWords
+      var n = source._countRepresentedWords
       while n >= 0 {
         // masking is OK here because this we have already ensured
         // that Self.bitWidth > ${word_bits}.  Not masking results in
@@ -2801,7 +2801,7 @@ ${assignmentOperatorComment(x.operator, True)}
   @_transparent
   public func _word(at n: Int) -> UInt {
     _precondition(n >= 0, "Negative word index")
-    if _fastPath(n < countRepresentedWords) {
+    if _fastPath(n < _countRepresentedWords) {
       let shift = UInt(n._value) &* ${word_bits}
       let bitWidth = UInt(self.bitWidth._value)
       _sanityCheck(shift < bitWidth)

--- a/test/Prototypes/BigInt.swift
+++ b/test/Prototypes/BigInt.swift
@@ -121,7 +121,7 @@ public struct _BigInt<Word: FixedWidthInteger & UnsignedInteger> :
     // FIXME: This is broken on 32-bit arch w/ Word = UInt64
     let wordRatio = UInt.bitWidth / Word.bitWidth
     _sanityCheck(wordRatio != 0)
-    for i in 0..<source.countRepresentedWords {
+    for i in 0..<source._countRepresentedWords {
       var sourceWord = source._word(at: i)
       for _ in 0..<wordRatio {
         _data.append(Word(extendingOrTruncating: sourceWord))


### PR DESCRIPTION
<!-- What's in this pull request? -->
An incidental issue uncovered while reading through the code for other reasons: 

Per comments, `countRepresentedWords` is slated for eventual removal along with `_word(at:)`. It's not a part of SE-0104. Therefore, let's show users that it's not intended for public consumption.

Interestingly, all current uses of the API in the Swift project itself are for implementing `_word(at:)` or calling `_word(at:)`.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->