### PR TITLE
[swiftc (35 vs. 5565)] Add crasher in swift::GenericSignatureBuilder::Constraint

### DIFF
--- a/validation-test/compiler_crashers/28793-nestedpabyname-didnt-find-the-associated-type-we-wanted.swift
+++ b/validation-test/compiler_crashers/28793-nestedpabyname-didnt-find-the-associated-type-we-wanted.swift
@@ -1,0 +1,13 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol A:RangeReplaceableCollection
+protocol P{
+protocol A
+class a:A{}typealias a:A{}typealias a:RangeReplaceableCollection


### PR DESCRIPTION
Add test case for crash triggered in `swift::GenericSignatureBuilder::Constraint`.

Current number of unresolved compiler crashers: 35 (5565 resolved)

/cc @DougGregor - just wanted to let you know that this crasher caused an assertion failure for the assertion `nestedPAByName && "Didn't find the associated type we wanted"` added on 2017-03-23 by you in commit 8bd863e6 :-)

Assertion failure in [`lib/AST/GenericSignatureBuilder.cpp (line 347)`](https://github.com/apple/swift/blob/bf7838c9cf4e83961b92fb6868f5a94b622f664b/lib/AST/GenericSignatureBuilder.cpp#L347):

```
Assertion `nestedPAByName && "Didn't find the associated type we wanted"' failed.

When executing: PotentialArchetype *replaceSelfWithPotentialArchetype(PotentialArchetype *, swift::Type)
```

Assertion context:

```c++

      if (auto result = findNested(otherBasePA))
        return result;
    }

    assert(nestedPAByName && "Didn't find the associated type we wanted");
    return nestedPAByName;
  }

  assert(depTy->is<GenericTypeParamType>() && "missing Self?");
  return selfPA;
```
Stack trace:

```
0 0x0000000003a7b018 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3a7b018)
1 0x0000000003a7b756 SignalHandler(int) (/path/to/swift/bin/swift+0x3a7b756)
2 0x00007f92b6c18390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007f92b513d428 gsignal /build/glibc-bfm8X4/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f92b513f02a abort /build/glibc-bfm8X4/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f92b5135bd7 __assert_fail_base /build/glibc-bfm8X4/glibc-2.23/assert/assert.c:92:0
6 0x00007f92b5135c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x0000000001570d1c replaceSelfWithPotentialArchetype(swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type) (/path/to/swift/bin/swift+0x1570d1c)
8 0x0000000001594a08 bool __gnu_cxx::__ops::_Iter_pred<bool (anonymous namespace)::removeSelfDerived<swift::Type>(std::vector<swift::GenericSignatureBuilder::Constraint<swift::Type>, std::allocator<swift::GenericSignatureBuilder::Constraint<swift::Type> > >&, bool)::{lambda(swift::GenericSignatureBuilder::Constraint<swift::Type> const&)#1}>::operator()<__gnu_cxx::__normal_iterator<swift::GenericSignatureBuilder::Constraint<swift::Type>*, std::vector<swift::GenericSignatureBuilder::Constraint<swift::Type>, std::allocator<swift::GenericSignatureBuilder::Constraint<swift::Type> > > > >(__gnu_cxx::__normal_iterator<swift::GenericSignatureBuilder::Constraint<swift::Type>*, std::vector<swift::GenericSignatureBuilder::Constraint<swift::Type>, std::allocator<swift::GenericSignatureBuilder::Constraint<swift::Type> > > >) (/path/to/swift/bin/swift+0x1594a08)
9 0x0000000001593cf3 swift::GenericSignatureBuilder::Constraint<swift::Type> swift::GenericSignatureBuilder::checkConstraintList<swift::Type, swift::Type>(llvm::ArrayRef<swift::GenericTypeParamType*>, std::vector<swift::GenericSignatureBuilder::Constraint<swift::Type>, std::allocator<swift::GenericSignatureBuilder::Constraint<swift::Type> > >&, llvm::function_ref<bool (swift::GenericSignatureBuilder::Constraint<swift::Type> const&)>, llvm::function_ref<swift::GenericSignatureBuilder::ConstraintRelation (swift::Type const&)>, llvm::Optional<swift::Diag<unsigned int, swift::Type, swift::Type, swift::Type> >, swift::Diag<swift::Type, swift::Type>, swift::Diag<unsigned int, swift::Type, swift::Type>, llvm::function_ref<swift::Type (swift::Type const&)>, bool) (/path/to/swift/bin/swift+0x1593cf3)
10 0x0000000001586a0f swift::GenericSignatureBuilder::checkConcreteTypeConstraints(llvm::ArrayRef<swift::GenericTypeParamType*>, swift::GenericSignatureBuilder::PotentialArchetype*) (/path/to/swift/bin/swift+0x1586a0f)
11 0x0000000001582267 swift::GenericSignatureBuilder::finalize(swift::SourceLoc, llvm::ArrayRef<swift::GenericTypeParamType*>, bool) (/path/to/swift/bin/swift+0x1582267)
12 0x00000000015887c3 swift::GenericSignatureBuilder::computeGenericSignature(swift::SourceLoc, bool) (/path/to/swift/bin/swift+0x15887c3)
13 0x000000000154af9f swift::ProtocolDecl::computeRequirementSignature() (/path/to/swift/bin/swift+0x154af9f)
14 0x000000000135a3a0 swift::TypeChecker::validateDecl(swift::ValueDecl*) (/path/to/swift/bin/swift+0x135a3a0)
15 0x0000000001369ee3 (anonymous namespace)::DeclChecker::visitProtocolDecl(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0x1369ee3)
16 0x0000000001358444 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x1358444)
17 0x0000000001358343 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x1358343)
18 0x00000000013e3344 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x13e3344)
19 0x0000000000fa16cd swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xfa16cd)
20 0x00000000004abe59 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4abe59)
21 0x00000000004aa3f9 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4aa3f9)
22 0x0000000000465697 main (/path/to/swift/bin/swift+0x465697)
23 0x00007f92b5128830 __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:325:0
24 0x0000000000462d39 _start (/path/to/swift/bin/swift+0x462d39)
```