### PR TITLE
[4.0] Fix some embarrassing list-management bugs with the exclusivity runtime

### DIFF
--- a/stdlib/public/runtime/Exclusivity.cpp
+++ b/stdlib/public/runtime/Exclusivity.cpp
@@ -150,7 +150,7 @@ struct Access {
 
   void setNext(Access *next) {
     NextAndAction =
-      reinterpret_cast<uintptr_t>(next) | (NextAndAction & NextMask);
+      reinterpret_cast<uintptr_t>(next) | (NextAndAction & ActionMask);
   }
 
   ExclusivityFlags getAccessAction() const {
@@ -209,8 +209,11 @@ public:
       return;
     }
 
-    for (Access *last = cur; cur != nullptr; last = cur, cur = cur->getNext()) {
-      if (last == access) {
+    Access *last = cur;
+    for (cur = cur->getNext(); cur != nullptr;
+         last = cur, cur = cur->getNext()) {
+      assert(last->getNext() == cur);
+      if (cur == access) {
         last->setNext(cur->getNext());
         return;
       }


### PR DESCRIPTION
Due to inadequate testing (my fault), a buggy change to the linked-list management (also my fault) in the exclusivity enforcement runtime basically completely broke things when accesses did not follow a perfect stack discipline.  Accesses are typically nested, so this escaped our notice.  This patch fixes the two bugs that were introduced and adds a much-nested test of this case.

We are tracking this problem as rdar://32866493.

The bug affects the runtime enforcement of the SE-0176 exclusive access rule.  Any access to memory requiring dynamic enforcement, such as a class property, could be affected, although most accesses will trivially follow stack discipline and thus not demonstrate the problem.  The bug leaves the runtime holding dangling references to temporary memory; subsequent attempts to begin tracking an access are likely to spuriously crash.

The risk of the fix is low: the fixes are straightforwardly correct, and they are adequately tested by the improved unit-testing of the runtime.