### PR TITLE
Fix an assertion in DiagnostStaticExclusivity and add a .sil test.

### DIFF
--- a/lib/SILOptimizer/Analysis/AccessSummaryAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/AccessSummaryAnalysis.cpp
@@ -145,7 +145,7 @@ static bool hasExpectedUsesOfNoEscapePartialApply(SILInstruction *closure) {
       return hasExpectedUsesOfNoEscapePartialApply(user);
 
     case ValueKind::PartialApplyInst:
-      return closure != cast<PartialApplyInst>(closure)->getCallee();
+      return closure != cast<PartialApplyInst>(user)->getCallee();
 
     case ValueKind::StoreInst:
     case ValueKind::DestroyValueInst:

--- a/test/SILOptimizer/access_summary_analysis.sil
+++ b/test/SILOptimizer/access_summary_analysis.sil
@@ -228,6 +228,31 @@ bb0(%0 : $*Int):
   return %8 : $()
 }
 
+// CHECK-LABEL: @reads
+// CHECK-NEXT: (read)
+sil private  @reads : $@convention(thin) (@inout_aliasable Int) -> Int {
+bb0(%0 : $*Int):
+  %3 = begin_access [read] [unknown] %0 : $*Int
+  %4 = load %3 : $*Int
+  end_access %3 : $*Int
+  return %4 : $Int
+}
+
+// CHECK-LABEL: @convertPartialApplyAndPassToPartialApply
+// CHECK-NEXT: (read)
+sil hidden @convertPartialApplyAndPassToPartialApply : $@convention(thin) (@inout_aliasable Int) -> () {
+bb0(%0 : $*Int):
+  %2 = function_ref @takesAutoClosureReturningGeneric : $@convention(thin) <τ_0_0 where τ_0_0 : Equatable> (@owned @callee_owned () -> (@out τ_0_0, @error Error)) -> ()
+  %3 = function_ref @reads : $@convention(thin) (@inout_aliasable Int) -> Int
+  %4 = partial_apply %3(%0) : $@convention(thin) (@inout_aliasable Int) -> Int
+  %5 = convert_function %4 : $@callee_owned () -> Int to $@callee_owned () -> (Int, @error Error)
+  %6 = function_ref @thunkForAutoClosure : $@convention(thin) (@owned @callee_owned () -> (Int, @error Error)) -> (@out Int, @error Error)
+  %7 = partial_apply %6(%5) : $@convention(thin) (@owned @callee_owned () -> (Int, @error Error)) -> (@out Int, @error Error)
+  %8 = apply %2<Int>(%7) : $@convention(thin) <τ_0_0 where τ_0_0 : Equatable> (@owned @callee_owned () -> (@out τ_0_0, @error Error)) -> ()
+  %9 = tuple ()
+  return %9 : $()
+}
+
 // CHECK-LABEL: @selfRecursion
 // CHECK-NEXT: (modify, none)
 sil private @selfRecursion : $@convention(thin) (@inout_aliasable Int, Int) -> () {


### PR DESCRIPTION
This is a same-day fix for a typo introduced here:

commit c2c55eea129d78ea1fbb8b35af181a51c2eaae8a
Author: Andrew Trick <atrick@apple.com>
Date:   Wed Jun 21 16:08:06 2017

    AccessSummaryAnalysis: handle @convention(block) in nested nonescape closures.
