### PR TITLE
[stdlib] Fix docs on Sequence.Iterator, .Element

### DIFF
--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -323,9 +323,11 @@ public protocol IteratorProtocol {
 /// traverse a sequence should be considered O(*n*) unless documented
 /// otherwise.
 public protocol Sequence {
+  /// A type representing the sequence's elements.
+  associatedtype Element
+
   /// A type that provides the sequence's iteration interface and
   /// encapsulates its iteration state.
-  associatedtype Element
   associatedtype Iterator : IteratorProtocol where Iterator.Element == Element
 
   /// A type that represents a subsequence of some of the sequence's elements.


### PR DESCRIPTION
<!-- What's in this pull request? -->
Here is a quickie that fixes the doc comment on `Sequence.Iterator` and adds a rudimentary description for `Sequence.Element`. The iterator's docs are currently misplaced on the `Element` type.

This PR contains no functional change.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->