### PR TITLE
[swiftc (36 vs. 5565)] Add crasher in swift::Type::transformRec

### DIFF
--- a/validation-test/compiler_crashers/28794-swift-type-transformrec-llvm-function-ref-llvm-optional-swift-type-swift-typebas.swift
+++ b/validation-test/compiler_crashers/28794-swift-type-transformrec-llvm-function-ref-llvm-optional-swift-type-swift-typebas.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+class a<a:{a {}extension{P{}protocol A:a{P{}var f


### PR DESCRIPTION
Add test case for crash triggered in `swift::Type::transformRec`.

Current number of unresolved compiler crashers: 36 (5565 resolved)

Stack trace:

```
0 0x0000000003a7b018 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3a7b018)
1 0x0000000003a7b756 SignalHandler(int) (/path/to/swift/bin/swift+0x3a7b756)
2 0x00007f1f6ef37390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00000000015d7687 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x15d7687)
4 0x00000000015d3d09 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3d09)
5 0x00000000015d3fbf swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3fbf)
6 0x00000000015d2676 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x15d2676)
7 0x000000000156a39a swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x156a39a)
8 0x0000000001579166 swift::GenericSignatureBuilder::PotentialArchetype::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1579166)
9 0x000000000156a266 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x156a266)
10 0x00000000015d7689 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x15d7689)
11 0x00000000015d3d09 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3d09)
12 0x00000000015d3fbf swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3fbf)
13 0x00000000015d2676 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x15d2676)
14 0x000000000156a39a swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x156a39a)
15 0x0000000001579166 swift::GenericSignatureBuilder::PotentialArchetype::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1579166)
16 0x000000000156a266 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x156a266)
17 0x00000000015d7689 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x15d7689)
18 0x00000000015d3d09 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3d09)
19 0x00000000015d3fbf swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3fbf)
20 0x00000000015d2676 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x15d2676)
21 0x000000000156a39a swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x156a39a)
22 0x0000000001579166 swift::GenericSignatureBuilder::PotentialArchetype::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1579166)
23 0x000000000156a266 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x156a266)
24 0x00000000015d7689 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x15d7689)
25 0x00000000015d3d09 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3d09)
26 0x00000000015d3fbf swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3fbf)
27 0x00000000015d2676 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x15d2676)
28 0x000000000156a39a swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x156a39a)
29 0x0000000001579166 swift::GenericSignatureBuilder::PotentialArchetype::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1579166)
30 0x000000000156a266 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x156a266)
31 0x00000000015d7689 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x15d7689)
32 0x00000000015d3d09 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3d09)
33 0x00000000015d3fbf swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3fbf)
34 0x00000000015d2676 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x15d2676)
35 0x000000000156a39a swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x156a39a)
36 0x0000000001579166 swift::GenericSignatureBuilder::PotentialArchetype::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1579166)
37 0x000000000156a266 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x156a266)
38 0x00000000015d7689 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x15d7689)
39 0x00000000015d3d09 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3d09)
40 0x00000000015d3fbf swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3fbf)
41 0x00000000015d2676 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x15d2676)
42 0x000000000156a39a swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x156a39a)
43 0x0000000001579166 swift::GenericSignatureBuilder::PotentialArchetype::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1579166)
44 0x000000000156a266 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x156a266)
45 0x00000000015d7689 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x15d7689)
46 0x00000000015d3d09 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3d09)
47 0x00000000015d3fbf swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3fbf)
48 0x00000000015d2676 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x15d2676)
49 0x000000000156a39a swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x156a39a)
50 0x0000000001579166 swift::GenericSignatureBuilder::PotentialArchetype::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1579166)
51 0x000000000156a266 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x156a266)
52 0x00000000015d7689 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x15d7689)
53 0x00000000015d3d09 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3d09)
54 0x00000000015d3fbf swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3fbf)
55 0x00000000015d2676 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x15d2676)
56 0x000000000156a39a swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x156a39a)
57 0x0000000001579166 swift::GenericSignatureBuilder::PotentialArchetype::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1579166)
58 0x000000000156a266 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x156a266)
59 0x00000000015d7689 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x15d7689)
60 0x00000000015d3d09 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3d09)
61 0x00000000015d3fbf swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3fbf)
62 0x00000000015d2676 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x15d2676)
63 0x000000000156a39a swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x156a39a)
64 0x0000000001579166 swift::GenericSignatureBuilder::PotentialArchetype::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1579166)
65 0x000000000156a266 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x156a266)
66 0x00000000015d7689 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x15d7689)
67 0x00000000015d3d09 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3d09)
68 0x00000000015d3fbf swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3fbf)
69 0x00000000015d2676 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x15d2676)
70 0x000000000156a39a swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x156a39a)
71 0x0000000001579166 swift::GenericSignatureBuilder::PotentialArchetype::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1579166)
72 0x000000000156a266 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x156a266)
73 0x00000000015d7689 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x15d7689)
74 0x00000000015d3d09 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3d09)
75 0x00000000015d3fbf swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3fbf)
76 0x00000000015d2676 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x15d2676)
77 0x000000000156a39a swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x156a39a)
78 0x0000000001579166 swift::GenericSignatureBuilder::PotentialArchetype::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1579166)
79 0x000000000156a266 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x156a266)
80 0x00000000015d7689 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x15d7689)
81 0x00000000015d3d09 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3d09)
82 0x00000000015d3fbf swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3fbf)
83 0x00000000015d2676 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x15d2676)
84 0x000000000156a39a swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x156a39a)
85 0x0000000001579166 swift::GenericSignatureBuilder::PotentialArchetype::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1579166)
86 0x000000000156a266 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x156a266)
87 0x00000000015d7689 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x15d7689)
88 0x00000000015d3d09 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3d09)
89 0x00000000015d3fbf swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3fbf)
90 0x00000000015d2676 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x15d2676)
91 0x000000000156a39a swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x156a39a)
92 0x0000000001579166 swift::GenericSignatureBuilder::PotentialArchetype::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1579166)
93 0x000000000156a266 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x156a266)
94 0x00000000015d7689 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x15d7689)
95 0x00000000015d3d09 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3d09)
96 0x00000000015d3fbf swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3fbf)
97 0x00000000015d2676 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x15d2676)
98 0x000000000156a39a swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x156a39a)
99 0x0000000001579166 swift::GenericSignatureBuilder::PotentialArchetype::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1579166)
100 0x000000000156a266 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x156a266)
101 0x00000000015d7689 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x15d7689)
102 0x00000000015d3d09 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3d09)
103 0x00000000015d3fbf swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3fbf)
104 0x00000000015d2676 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x15d2676)
105 0x000000000156a39a swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x156a39a)
106 0x0000000001579166 swift::GenericSignatureBuilder::PotentialArchetype::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1579166)
107 0x000000000156a266 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x156a266)
108 0x00000000015d7689 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x15d7689)
109 0x00000000015d3d09 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3d09)
110 0x00000000015d3fbf swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3fbf)
111 0x00000000015d2676 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x15d2676)
112 0x000000000156a39a swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x156a39a)
113 0x0000000001579166 swift::GenericSignatureBuilder::PotentialArchetype::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1579166)
114 0x000000000156a266 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x156a266)
115 0x00000000015d7689 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x15d7689)
116 0x00000000015d3d09 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3d09)
117 0x00000000015d3fbf swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3fbf)
118 0x00000000015d2676 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x15d2676)
119 0x000000000156a39a swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x156a39a)
120 0x0000000001579166 swift::GenericSignatureBuilder::PotentialArchetype::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1579166)
121 0x000000000156a266 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x156a266)
122 0x00000000015d7689 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x15d7689)
123 0x00000000015d3d09 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3d09)
124 0x00000000015d3fbf swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3fbf)
125 0x00000000015d2676 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x15d2676)
126 0x000000000156a39a swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x156a39a)
127 0x0000000001579166 swift::GenericSignatureBuilder::PotentialArchetype::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1579166)
128 0x000000000156a266 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x156a266)
129 0x00000000015d7689 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x15d7689)
130 0x00000000015d3d09 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3d09)
131 0x00000000015d3fbf swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3fbf)
132 0x00000000015d2676 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x15d2676)
133 0x000000000156a39a swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x156a39a)
134 0x0000000001579166 swift::GenericSignatureBuilder::PotentialArchetype::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1579166)
135 0x000000000156a266 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x156a266)
136 0x00000000015d7689 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x15d7689)
137 0x00000000015d3d09 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3d09)
138 0x00000000015d3fbf swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3fbf)
139 0x00000000015d2676 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x15d2676)
140 0x000000000156a39a swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x156a39a)
141 0x0000000001579166 swift::GenericSignatureBuilder::PotentialArchetype::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1579166)
142 0x000000000156a266 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x156a266)
143 0x00000000015d7689 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x15d7689)
144 0x00000000015d3d09 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3d09)
145 0x00000000015d3fbf swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3fbf)
146 0x00000000015d2676 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x15d2676)
147 0x000000000156a39a swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x156a39a)
148 0x0000000001579166 swift::GenericSignatureBuilder::PotentialArchetype::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1579166)
149 0x000000000156a266 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x156a266)
150 0x00000000015d7689 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x15d7689)
151 0x00000000015d3d09 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3d09)
152 0x00000000015d3fbf swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3fbf)
153 0x00000000015d2676 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x15d2676)
154 0x000000000156a39a swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x156a39a)
155 0x0000000001579166 swift::GenericSignatureBuilder::PotentialArchetype::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1579166)
156 0x000000000156a266 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x156a266)
157 0x00000000015d7689 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x15d7689)
158 0x00000000015d3d09 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3d09)
159 0x00000000015d3fbf swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3fbf)
160 0x00000000015d2676 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x15d2676)
161 0x000000000156a39a swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x156a39a)
162 0x0000000001579166 swift::GenericSignatureBuilder::PotentialArchetype::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1579166)
163 0x000000000156a266 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x156a266)
164 0x00000000015d7689 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x15d7689)
165 0x00000000015d3d09 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3d09)
166 0x00000000015d3fbf swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3fbf)
167 0x00000000015d2676 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x15d2676)
168 0x000000000156a39a swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x156a39a)
169 0x0000000001579166 swift::GenericSignatureBuilder::PotentialArchetype::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1579166)
170 0x000000000156a266 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x156a266)
171 0x00000000015d7689 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x15d7689)
172 0x00000000015d3d09 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3d09)
173 0x00000000015d3fbf swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3fbf)
174 0x00000000015d2676 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x15d2676)
175 0x000000000156a39a swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x156a39a)
176 0x0000000001579166 swift::GenericSignatureBuilder::PotentialArchetype::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1579166)
177 0x000000000156a266 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x156a266)
178 0x00000000015d7689 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x15d7689)
179 0x00000000015d3d09 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3d09)
180 0x00000000015d3fbf swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3fbf)
181 0x00000000015d2676 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x15d2676)
182 0x000000000156a39a swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x156a39a)
183 0x0000000001579166 swift::GenericSignatureBuilder::PotentialArchetype::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1579166)
184 0x000000000156a266 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x156a266)
185 0x00000000015d7689 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x15d7689)
186 0x00000000015d3d09 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3d09)
187 0x00000000015d3fbf swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3fbf)
188 0x00000000015d2676 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x15d2676)
189 0x000000000156a39a swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x156a39a)
190 0x0000000001579166 swift::GenericSignatureBuilder::PotentialArchetype::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1579166)
191 0x000000000156a266 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x156a266)
192 0x00000000015d7689 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x15d7689)
193 0x00000000015d3d09 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3d09)
194 0x00000000015d3fbf swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3fbf)
195 0x00000000015d2676 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x15d2676)
196 0x000000000156a39a swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x156a39a)
197 0x0000000001579166 swift::GenericSignatureBuilder::PotentialArchetype::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1579166)
198 0x000000000156a266 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x156a266)
199 0x00000000015d7689 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x15d7689)
200 0x00000000015d3d09 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3d09)
201 0x00000000015d3fbf swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3fbf)
202 0x00000000015d2676 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x15d2676)
203 0x000000000156a39a swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x156a39a)
204 0x0000000001579166 swift::GenericSignatureBuilder::PotentialArchetype::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1579166)
205 0x000000000156a266 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x156a266)
206 0x00000000015d7689 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x15d7689)
207 0x00000000015d3d09 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3d09)
208 0x00000000015d3fbf swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3fbf)
209 0x00000000015d2676 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x15d2676)
210 0x000000000156a39a swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x156a39a)
211 0x0000000001579166 swift::GenericSignatureBuilder::PotentialArchetype::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1579166)
212 0x000000000156a266 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x156a266)
213 0x00000000015d7689 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x15d7689)
214 0x00000000015d3d09 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3d09)
215 0x00000000015d3fbf swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3fbf)
216 0x00000000015d2676 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x15d2676)
217 0x000000000156a39a swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x156a39a)
218 0x0000000001579166 swift::GenericSignatureBuilder::PotentialArchetype::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1579166)
219 0x000000000156a266 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x156a266)
220 0x00000000015d7689 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x15d7689)
221 0x00000000015d3d09 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3d09)
222 0x00000000015d3fbf swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3fbf)
223 0x00000000015d2676 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x15d2676)
224 0x000000000156a39a swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x156a39a)
225 0x0000000001579166 swift::GenericSignatureBuilder::PotentialArchetype::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1579166)
226 0x000000000156a266 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x156a266)
227 0x00000000015d7689 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x15d7689)
228 0x00000000015d3d09 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3d09)
229 0x00000000015d3fbf swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3fbf)
230 0x00000000015d2676 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x15d2676)
231 0x000000000156a39a swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x156a39a)
232 0x0000000001579166 swift::GenericSignatureBuilder::PotentialArchetype::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1579166)
233 0x000000000156a266 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x156a266)
234 0x00000000015d7689 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x15d7689)
235 0x00000000015d3d09 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3d09)
236 0x00000000015d3fbf swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3fbf)
237 0x00000000015d2676 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x15d2676)
238 0x000000000156a39a swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x156a39a)
239 0x0000000001579166 swift::GenericSignatureBuilder::PotentialArchetype::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1579166)
240 0x000000000156a266 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x156a266)
241 0x00000000015d7689 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x15d7689)
242 0x00000000015d3d09 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3d09)
243 0x00000000015d3fbf swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3fbf)
244 0x00000000015d2676 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x15d2676)
245 0x000000000156a39a swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x156a39a)
246 0x0000000001579166 swift::GenericSignatureBuilder::PotentialArchetype::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1579166)
247 0x000000000156a266 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x156a266)
248 0x00000000015d7689 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x15d7689)
249 0x00000000015d3d09 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3d09)
250 0x00000000015d3fbf swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3fbf)
251 0x00000000015d2676 swift::Type::subst(llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions) const (/path/to/swift/bin/swift+0x15d2676)
252 0x000000000156a39a swift::GenericEnvironment::mapTypeIntoContext(swift::Type, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>) const (/path/to/swift/bin/swift+0x156a39a)
253 0x0000000001579166 swift::GenericSignatureBuilder::PotentialArchetype::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1579166)
254 0x000000000156a266 swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x156a266)
255 0x00000000015d7689 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x15d7689)
```