### PR TITLE
[swiftc (37 vs. 5565)] Add crasher in swift::GenericSignature::getConformanceAccessPath

### DIFF
--- a/validation-test/compiler_crashers/28795-inprotocol-isrequirementsignaturecomputed-missing-signature.swift
+++ b/validation-test/compiler_crashers/28795-inprotocol-isrequirementsignaturecomputed-missing-signature.swift
@@ -1,0 +1,11 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol A:A.b{func 丏
+protocol b:Collection


### PR DESCRIPTION
Add test case for crash triggered in `swift::GenericSignature::getConformanceAccessPath`.

Current number of unresolved compiler crashers: 37 (5565 resolved)

/cc @DougGregor - just wanted to let you know that this crasher caused an assertion failure for the assertion `inProtocol->isRequirementSignatureComputed() && "missing signature"` added on 2017-03-08 by you in commit 1f8b0f9b :-)

Assertion failure in [`lib/AST/GenericSignature.cpp (line 857)`](https://github.com/apple/swift/blob/db2429e0422d96993ac99e3fd2e9490ee2588a71/lib/AST/GenericSignature.cpp#L857):

```
Assertion `inProtocol->isRequirementSignatureComputed() && "missing signature"' failed.

When executing: auto swift::GenericSignature::getConformanceAccessPath(swift::Type, swift::ProtocolDecl *, swift::ModuleDecl &)::(anonymous class)::operator()(swift::GenericSignature *, const RequirementSource *, swift::ProtocolDecl *, swift::Type) const
```

Assertion context:

```c++

      // Canonicalize this step with respect to the requirement signature.
      if (!inProtocol->isRequirementSignatureComputed()) {
        inProtocol->computeRequirementSignature();
        assert(inProtocol->isRequirementSignatureComputed() &&
               "missing signature");
      }

      // Get a generic signature builder for the requirement signature. This has
      // the requirement we need.
      auto reqSig = inProtocol->getRequirementSignature();
```
Stack trace:

```
0 0x0000000003a7b018 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3a7b018)
1 0x0000000003a7b756 SignalHandler(int) (/path/to/swift/bin/swift+0x3a7b756)
2 0x00007fd567c1f390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007fd566144428 gsignal /build/glibc-bfm8X4/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007fd56614602a abort /build/glibc-bfm8X4/glibc-2.23/stdlib/abort.c:91:0
5 0x00007fd56613cbd7 __assert_fail_base /build/glibc-bfm8X4/glibc-2.23/assert/assert.c:92:0
6 0x00007fd56613cc82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x000000000156f320 std::_Function_base::_Base_manager<swift::GenericSignature::getConformanceAccessPath(swift::Type, swift::ProtocolDecl*, swift::ModuleDecl&)::$_11>::_M_manager(std::_Any_data&, std::_Any_data const&, std::_Manager_operation) (/path/to/swift/bin/swift+0x156f320)
8 0x000000000156df39 swift::GenericSignature::getConformanceAccessPath(swift::Type, swift::ProtocolDecl*, swift::ModuleDecl&) (/path/to/swift/bin/swift+0x156df39)
9 0x00000000015c6044 swift::SubstitutionMap::lookupConformance(swift::CanType, swift::ProtocolDecl*) const (/path/to/swift/bin/swift+0x15c6044)
10 0x00000000015d2850 swift::LookUpConformanceInSubstitutionMap::operator()(swift::CanType, swift::Type, swift::ProtocolType*) const (/path/to/swift/bin/swift+0x15d2850)
11 0x0000000000c28519 llvm::Optional<swift::ProtocolConformanceRef> llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>::callback_fn<swift::LookUpConformanceInSubstitutionMap>(long, swift::CanType, swift::Type, swift::ProtocolType*) (/path/to/swift/bin/swift+0xc28519)
12 0x00000000015d2d54 getMemberForBaseType(llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::Type, swift::Type, swift::AssociatedTypeDecl*, swift::Identifier, swift::SubstOptions) (/path/to/swift/bin/swift+0x15d2d54)
13 0x00000000015d778d llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x15d778d)
14 0x00000000015d3d09 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3d09)
15 0x00000000015cef95 swift::Type::subst(swift::SubstitutionMap const&, swift::SubstOptions) const (/path/to/swift/bin/swift+0x15cef95)
16 0x000000000157d3da swift::GenericSignatureBuilder::addRequirement(swift::Requirement const&, swift::GenericSignatureBuilder::FloatingRequirementSource, swift::ModuleDecl*, swift::SubstitutionMap const*) (/path/to/swift/bin/swift+0x157d3da)
17 0x000000000157e36f swift::GenericSignatureBuilder::addConformanceRequirement(swift::GenericSignatureBuilder::PotentialArchetype*, swift::ProtocolDecl*, swift::GenericSignatureBuilder::RequirementSource const*)::$_16::operator()(swift::TypeDecl*, swift::TypeDecl*) const (/path/to/swift/bin/swift+0x157e36f)
18 0x000000000157cd3e swift::GenericSignatureBuilder::addConformanceRequirement(swift::GenericSignatureBuilder::PotentialArchetype*, swift::ProtocolDecl*, swift::GenericSignatureBuilder::RequirementSource const*) (/path/to/swift/bin/swift+0x157cd3e)
19 0x000000000157fc55 swift::GenericSignatureBuilder::addTypeRequirement(llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::FloatingRequirementSource, swift::GenericSignatureBuilder::UnresolvedHandlingKind) (/path/to/swift/bin/swift+0x157fc55)
20 0x000000000157d62b swift::GenericSignatureBuilder::addRequirement(swift::Requirement const&, swift::GenericSignatureBuilder::FloatingRequirementSource, swift::ModuleDecl*, swift::SubstitutionMap const*) (/path/to/swift/bin/swift+0x157d62b)
21 0x000000000157b936 swift::GenericSignatureBuilder::addConformanceRequirement(swift::GenericSignatureBuilder::PotentialArchetype*, swift::ProtocolDecl*, swift::GenericSignatureBuilder::RequirementSource const*) (/path/to/swift/bin/swift+0x157b936)
22 0x000000000157fc55 swift::GenericSignatureBuilder::addTypeRequirement(llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::FloatingRequirementSource, swift::GenericSignatureBuilder::UnresolvedHandlingKind) (/path/to/swift/bin/swift+0x157fc55)
23 0x000000000157d62b swift::GenericSignatureBuilder::addRequirement(swift::Requirement const&, swift::GenericSignatureBuilder::FloatingRequirementSource, swift::ModuleDecl*, swift::SubstitutionMap const*) (/path/to/swift/bin/swift+0x157d62b)
24 0x000000000158862d swift::GenericSignatureBuilder::addGenericSignature(swift::GenericSignature*) (/path/to/swift/bin/swift+0x158862d)
25 0x000000000149fd36 swift::ASTContext::getOrCreateGenericSignatureBuilder(swift::CanGenericSignature, swift::ModuleDecl*) (/path/to/swift/bin/swift+0x149fd36)
26 0x000000000156d40c swift::GenericSignature::conformsToProtocol(swift::Type, swift::ProtocolDecl*, swift::ModuleDecl&) (/path/to/swift/bin/swift+0x156d40c)
27 0x00000000015c6021 swift::SubstitutionMap::lookupConformance(swift::CanType, swift::ProtocolDecl*) const (/path/to/swift/bin/swift+0x15c6021)
28 0x00000000015d2850 swift::LookUpConformanceInSubstitutionMap::operator()(swift::CanType, swift::Type, swift::ProtocolType*) const (/path/to/swift/bin/swift+0x15d2850)
29 0x0000000000c28519 llvm::Optional<swift::ProtocolConformanceRef> llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>::callback_fn<swift::LookUpConformanceInSubstitutionMap>(long, swift::CanType, swift::Type, swift::ProtocolType*) (/path/to/swift/bin/swift+0xc28519)
30 0x00000000015d2d54 getMemberForBaseType(llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::Type, swift::Type, swift::AssociatedTypeDecl*, swift::Identifier, swift::SubstOptions) (/path/to/swift/bin/swift+0x15d2d54)
31 0x00000000015d778d llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x15d778d)
32 0x00000000015d3d09 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3d09)
33 0x00000000015cef95 swift::Type::subst(swift::SubstitutionMap const&, swift::SubstOptions) const (/path/to/swift/bin/swift+0x15cef95)
34 0x000000000157d3da swift::GenericSignatureBuilder::addRequirement(swift::Requirement const&, swift::GenericSignatureBuilder::FloatingRequirementSource, swift::ModuleDecl*, swift::SubstitutionMap const*) (/path/to/swift/bin/swift+0x157d3da)
35 0x000000000157e36f swift::GenericSignatureBuilder::addConformanceRequirement(swift::GenericSignatureBuilder::PotentialArchetype*, swift::ProtocolDecl*, swift::GenericSignatureBuilder::RequirementSource const*)::$_16::operator()(swift::TypeDecl*, swift::TypeDecl*) const (/path/to/swift/bin/swift+0x157e36f)
36 0x000000000157cd3e swift::GenericSignatureBuilder::addConformanceRequirement(swift::GenericSignatureBuilder::PotentialArchetype*, swift::ProtocolDecl*, swift::GenericSignatureBuilder::RequirementSource const*) (/path/to/swift/bin/swift+0x157cd3e)
37 0x000000000157fc55 swift::GenericSignatureBuilder::addTypeRequirement(llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::FloatingRequirementSource, swift::GenericSignatureBuilder::UnresolvedHandlingKind) (/path/to/swift/bin/swift+0x157fc55)
38 0x000000000157d62b swift::GenericSignatureBuilder::addRequirement(swift::Requirement const&, swift::GenericSignatureBuilder::FloatingRequirementSource, swift::ModuleDecl*, swift::SubstitutionMap const*) (/path/to/swift/bin/swift+0x157d62b)
39 0x000000000157b936 swift::GenericSignatureBuilder::addConformanceRequirement(swift::GenericSignatureBuilder::PotentialArchetype*, swift::ProtocolDecl*, swift::GenericSignatureBuilder::RequirementSource const*) (/path/to/swift/bin/swift+0x157b936)
40 0x000000000157fc55 swift::GenericSignatureBuilder::addTypeRequirement(llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::FloatingRequirementSource, swift::GenericSignatureBuilder::UnresolvedHandlingKind) (/path/to/swift/bin/swift+0x157fc55)
41 0x000000000157d62b swift::GenericSignatureBuilder::addRequirement(swift::Requirement const&, swift::GenericSignatureBuilder::FloatingRequirementSource, swift::ModuleDecl*, swift::SubstitutionMap const*) (/path/to/swift/bin/swift+0x157d62b)
42 0x000000000158862d swift::GenericSignatureBuilder::addGenericSignature(swift::GenericSignature*) (/path/to/swift/bin/swift+0x158862d)
43 0x000000000138591a swift::TypeChecker::checkGenericParamList(swift::GenericSignatureBuilder*, swift::GenericParamList*, swift::GenericSignature*, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0x138591a)
44 0x00000000013867d1 checkGenericFuncSignature(swift::TypeChecker&, swift::GenericSignatureBuilder*, swift::AbstractFunctionDecl*, swift::GenericTypeResolver&) (/path/to/swift/bin/swift+0x13867d1)
45 0x0000000001386450 swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0x1386450)
46 0x000000000136c69b (anonymous namespace)::DeclChecker::visitFuncDecl(swift::FuncDecl*) (/path/to/swift/bin/swift+0x136c69b)
47 0x0000000001358464 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x1358464)
48 0x000000000136a1fb (anonymous namespace)::DeclChecker::visitProtocolDecl(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0x136a1fb)
49 0x0000000001358444 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x1358444)
50 0x0000000001358343 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x1358343)
51 0x00000000013e3344 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x13e3344)
52 0x0000000000fa16cd swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xfa16cd)
53 0x00000000004abe59 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4abe59)
54 0x00000000004aa3f9 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4aa3f9)
55 0x0000000000465697 main (/path/to/swift/bin/swift+0x465697)
56 0x00007fd56612f830 __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:325:0
57 0x0000000000462d39 _start (/path/to/swift/bin/swift+0x462d39)
```