### PR TITLE
[swiftc (38 vs. 5565)] Add crasher in swift::TypeBase::getContextSubstitutions

### DIFF
--- a/validation-test/compiler_crashers/28796-result-second.swift
+++ b/validation-test/compiler_crashers/28796-result-second.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+class a<a{{{}}func b{extension{class a<a{{}class a:RangeReplaceableCollection


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeBase::getContextSubstitutions`.

Current number of unresolved compiler crashers: 38 (5565 resolved)

/cc @slavapestov - just wanted to let you know that this crasher caused an assertion failure for the assertion `result.second` added on 2017-03-07 by you in commit 3d4503a9 :-)

Assertion failure in [`lib/AST/Type.cpp (line 3259)`](https://github.com/apple/swift/blob/37e001d25bf34b66f5d4e1c43ec1fab06b956b3f/lib/AST/Type.cpp#L3259):

```
Assertion `result.second' failed.

When executing: TypeSubstitutionMap swift::TypeBase::getContextSubstitutions(const swift::DeclContext *, swift::GenericEnvironment *)
```

Assertion context:

```c++
        (void) result;
      }
    }
  }

  return substitutions;
}

SubstitutionMap TypeBase::getContextSubstitutionMap(
    ModuleDecl *module, const DeclContext *dc,
    GenericEnvironment *genericEnv) {
```
Stack trace:

```
0 0x0000000003a7b018 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3a7b018)
1 0x0000000003a7b756 SignalHandler(int) (/path/to/swift/bin/swift+0x3a7b756)
2 0x00007faff906a390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007faff758f428 gsignal /build/glibc-bfm8X4/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007faff759102a abort /build/glibc-bfm8X4/glibc-2.23/stdlib/abort.c:91:0
5 0x00007faff7587bd7 __assert_fail_base /build/glibc-bfm8X4/glibc-2.23/assert/assert.c:92:0
6 0x00007faff7587c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x00000000015d36d4 swift::TypeBase::getContextSubstitutions(swift::DeclContext const*, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x15d36d4)
8 0x00000000015cee70 swift::TypeBase::getContextSubstitutionMap(swift::ModuleDecl*, swift::DeclContext const*, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x15cee70)
9 0x0000000001589682 swift::GenericSignatureBuilder::InferRequirementsWalker::walkToTypePost(swift::Type) (/path/to/swift/bin/swift+0x1589682)
10 0x00000000015e115c swift::TypeVisitor<(anonymous namespace)::Traversal, bool>::visit(swift::Type) (/path/to/swift/bin/swift+0x15e115c)
11 0x00000000015e0134 swift::Type::walk(swift::TypeWalker&) const (/path/to/swift/bin/swift+0x15e0134)
12 0x000000000157d2e7 swift::GenericSignatureBuilder::addRequirement(swift::Requirement const&, swift::GenericSignatureBuilder::FloatingRequirementSource, swift::ModuleDecl*, swift::SubstitutionMap const*) (/path/to/swift/bin/swift+0x157d2e7)
13 0x000000000139c871 (anonymous namespace)::RequirementEnvironment::RequirementEnvironment(swift::TypeChecker&, swift::DeclContext*, swift::ValueDecl*, swift::ProtocolConformance*) (/path/to/swift/bin/swift+0x139c871)
14 0x00000000013a19ee (anonymous namespace)::ConformanceChecker::resolveWitnessViaLookup(swift::ValueDecl*) (/path/to/swift/bin/swift+0x13a19ee)
15 0x000000000139865c (anonymous namespace)::MultiConformanceChecker::checkAllConformances() (/path/to/swift/bin/swift+0x139865c)
16 0x0000000001399b02 swift::TypeChecker::checkConformancesInContext(swift::DeclContext*, swift::IterableDeclContext*) (/path/to/swift/bin/swift+0x1399b02)
17 0x000000000136913e (anonymous namespace)::DeclChecker::visitClassDecl(swift::ClassDecl*) (/path/to/swift/bin/swift+0x136913e)
18 0x000000000135853e (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x135853e)
19 0x000000000136915b (anonymous namespace)::DeclChecker::visitClassDecl(swift::ClassDecl*) (/path/to/swift/bin/swift+0x136915b)
20 0x000000000135853e (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x135853e)
21 0x00000000013689fb (anonymous namespace)::DeclChecker::visitExtensionDecl(swift::ExtensionDecl*) (/path/to/swift/bin/swift+0x13689fb)
22 0x0000000001358474 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x1358474)
23 0x0000000001358343 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x1358343)
24 0x00000000013c5676 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13c5676)
25 0x00000000013c39ad swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) (/path/to/swift/bin/swift+0x13c39ad)
26 0x00000000013c381d swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) (/path/to/swift/bin/swift+0x13c381d)
27 0x00000000013c452d swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0x13c452d)
28 0x00000000013e2588 typeCheckFunctionsAndExternalDecls(swift::TypeChecker&) (/path/to/swift/bin/swift+0x13e2588)
29 0x00000000013e343a swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x13e343a)
30 0x0000000000fa16cd swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xfa16cd)
31 0x00000000004abe59 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4abe59)
32 0x00000000004aa3f9 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4aa3f9)
33 0x0000000000465697 main (/path/to/swift/bin/swift+0x465697)
34 0x00007faff757a830 __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:325:0
35 0x0000000000462d39 _start (/path/to/swift/bin/swift+0x462d39)
```