### PR TITLE
[swiftc (40 vs. 5565)] Add crasher in swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator(...)

### DIFF
--- a/validation-test/compiler_crashers/28798-swift-genericenvironment-queryinterfacetypesubstitutions-operator-swift-substitu.swift
+++ b/validation-test/compiler_crashers/28798-swift-genericenvironment-queryinterfacetypesubstitutions-operator-swift-substitu.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol P}{{{<(}}}{}extension P{class a{func<(t:a


### PR DESCRIPTION
Add test case for crash triggered in `swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator(...)`.

Current number of unresolved compiler crashers: 40 (5565 resolved)

Stack trace:

```
0 0x0000000003a7b018 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3a7b018)
1 0x0000000003a7b756 SignalHandler(int) (/path/to/swift/bin/swift+0x3a7b756)
2 0x00007f5a36922390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x000000000156a19d swift::GenericEnvironment::QueryInterfaceTypeSubstitutions::operator()(swift::SubstitutableType*) const (/path/to/swift/bin/swift+0x156a19d)
4 0x000000000156a337 swift::GenericEnvironment::mapTypeIntoContext(swift::GenericTypeParamType*) const (/path/to/swift/bin/swift+0x156a337)
5 0x0000000001327ac7 swift::constraints::ConstraintSystem::openGeneric(swift::DeclContext*, swift::DeclContext*, swift::GenericSignature*, bool, swift::constraints::ConstraintLocatorBuilder, llvm::DenseMap<swift::GenericTypeParamType*, swift::TypeVariableType*, llvm::DenseMapInfo<swift::GenericTypeParamType*>, llvm::detail::DenseMapPair<swift::GenericTypeParamType*, swift::TypeVariableType*> >&) (/path/to/swift/bin/swift+0x1327ac7)
6 0x000000000132827f swift::constraints::ConstraintSystem::openFunctionType(swift::AnyFunctionType*, unsigned int, swift::constraints::ConstraintLocatorBuilder, llvm::DenseMap<swift::GenericTypeParamType*, swift::TypeVariableType*, llvm::DenseMapInfo<swift::GenericTypeParamType*>, llvm::detail::DenseMapPair<swift::GenericTypeParamType*, swift::TypeVariableType*> >&, swift::DeclContext*, swift::DeclContext*, bool) (/path/to/swift/bin/swift+0x132827f)
7 0x00000000013297fe swift::constraints::ConstraintSystem::getTypeOfReference(swift::ValueDecl*, swift::FunctionRefKind, swift::constraints::ConstraintLocatorBuilder, swift::DeclRefExpr const*) (/path/to/swift/bin/swift+0x13297fe)
8 0x000000000132b581 swift::constraints::ConstraintSystem::resolveOverload(swift::constraints::ConstraintLocator*, swift::Type, swift::constraints::OverloadChoice, swift::DeclContext*) (/path/to/swift/bin/swift+0x132b581)
9 0x00000000012dddd5 swift::ASTVisitor<(anonymous namespace)::ConstraintGenerator, swift::Type, void, void, void, void, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x12dddd5)
10 0x00000000012e3fd8 (anonymous namespace)::ConstraintWalker::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0x12e3fd8)
11 0x0000000001526c3c (anonymous namespace)::Traversal::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0x1526c3c)
12 0x0000000001526258 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x1526258)
13 0x0000000001526258 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x1526258)
14 0x0000000001526258 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x1526258)
15 0x0000000001526c1a (anonymous namespace)::Traversal::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0x1526c1a)
16 0x00000000015234db swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x15234db)
17 0x00000000012dab51 swift::constraints::ConstraintSystem::generateConstraints(swift::Expr*) (/path/to/swift/bin/swift+0x12dab51)
18 0x0000000001304986 swift::constraints::ConstraintSystem::solve(swift::Expr*&, swift::Type, swift::ExprTypeCheckListener*, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0x1304986)
19 0x000000000133d8d4 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0x133d8d4)
20 0x00000000013413a0 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x13413a0)
21 0x00000000013c56d5 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13c56d5)
22 0x00000000013c4ee6 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0x13c4ee6)
23 0x00000000013e33b0 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x13e33b0)
24 0x0000000000fa16cd swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xfa16cd)
25 0x00000000004abe59 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4abe59)
26 0x00000000004aa3f9 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4aa3f9)
27 0x0000000000465697 main (/path/to/swift/bin/swift+0x465697)
28 0x00007f5a34e32830 __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:325:0
29 0x0000000000462d39 _start (/path/to/swift/bin/swift+0x462d39)
```