### PR TITLE
Adjust the expression type checker timeout to 10 minutes.

### DIFF
--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -549,7 +549,8 @@ void CompilerInstance::performSema() {
         performTypeChecking(*SF, PersistentState.getTopLevelContext(),
                             TypeCheckOptions, /*curElem*/ 0,
                             options.WarnLongFunctionBodies,
-                            options.WarnLongExpressionTypeChecking);
+                            options.WarnLongExpressionTypeChecking,
+                            options.SolverExpressionTimeThreshold);
 
   // Even if there were no source files, we should still record known
   // protocols.

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -837,7 +837,7 @@ private:
 
   /// If non-zero, abort the expression type checker if it takes more
   /// than this many seconds.
-  unsigned ExpressionTimeoutThreshold = 60;
+  unsigned ExpressionTimeoutThreshold = 600;
 
   /// If true, the time it takes to type-check each function will be dumped
   /// to llvm::errs().


### PR DESCRIPTION
The old threshold was sometimes being reached on an ASAN bot.

Also fix a spot where I missed passing in the override value from the
command-line.

rdar://problem/32925008
