### PR TITLE
[Foundation] Prevent incorrect slice access when dropping elements

### DIFF
--- a/stdlib/public/SDK/Foundation/IndexPath.swift
+++ b/stdlib/public/SDK/Foundation/IndexPath.swift
@@ -290,9 +290,9 @@ public struct IndexPath : ReferenceConvertible, Equatable, Hashable, MutableColl
                     case 0:
                         return .empty
                     case 1:
-                        return .single(slice[0])
+                        return .single(slice.first!)
                     case 2:
-                        return .pair(slice[0], slice[1])
+                        return .pair(slice.first!, slice.last!)
                     default:
                         return .array(Array<Int>(slice))
                     }

--- a/test/stdlib/TestIndexPath.swift
+++ b/test/stdlib/TestIndexPath.swift
@@ -720,6 +720,14 @@ class TestIndexPath: TestIndexPathSuper {
         let slice = indexPath[1..<1]
         expectEqual(0, slice.count)
     }
+
+    func test_dropFirst() {
+        var pth = IndexPath(indexes:[1,2,3,4])
+        while !pth.isEmpty {
+            // this should not crash 
+            pth = pth.dropFirst()
+        }
+    }
 }
 
 #if !FOUNDATION_XCTEST
@@ -772,5 +780,6 @@ IndexPathTests.test("test_AnyHashableContainingIndexPath") { TestIndexPath().tes
 IndexPathTests.test("test_AnyHashableCreatedFromNSIndexPath") { TestIndexPath().test_AnyHashableCreatedFromNSIndexPath() }
 IndexPathTests.test("test_unconditionallyBridgeFromObjectiveC") { TestIndexPath().test_unconditionallyBridgeFromObjectiveC() }
 IndexPathTests.test("test_slice_1ary") { TestIndexPath().test_slice_1ary() }
+IndexPathTests.test("test_dropFirst") { TestIndexPath().test_dropFirst() }
 runAllTests()
 #endif


### PR DESCRIPTION
Cherry pick of pr #10454

IndexPath initialization from slices incorrectly assumed that array slices would be indexed starting at 0, instead it should fetch the first and last elements for creating 1-ary and 2-ary IndexPath backing stores.

This resolves
rdar://problem/32823736

Explanation:
The previous refactor of IndexPath incorrectly accessed slices of arrays by counting indexes instead of indexes offset from the startIndex. This commit corrects that to utilize the first and last element of the slice.

Scope:
This is just runtime behavior of IndexPath

Radar (and possibly SR Issue):
rdar://problem/32926028

Risk:
These are newly introduced behaviors that have no current adoption other than the initial seeds.

Testing:
Unit tests were added to validate the behavior of slicing specifically in the reported case of dropFirst.