### PR TITLE
[4.0] IRGen: Use LLVM's alloc size to compute padding between types

### DIFF
--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -382,7 +382,9 @@ NativeConventionSchema::getCoercionTypes(
           packed = true;
         elts.push_back(type);
         expandedTyIndicesMap.push_back(idx - 1);
-        lastEnd = end;
+        lastEnd = begin + clang::CharUnits::fromQuantity(
+                              IGM.DataLayout.getTypeAllocSize(type));
+        assert(end <= lastEnd);
       });
 
   auto *coercionType = llvm::StructType::get(ctx, elts, packed);
@@ -419,7 +421,9 @@ NativeConventionSchema::getCoercionTypes(
           packed = true;
         elts.push_back(type);
         expandedTyIndicesMap.push_back(idx - 1);
-        lastEnd = end;
+        lastEnd = begin + clang::CharUnits::fromQuantity(
+                              IGM.DataLayout.getTypeAllocSize(type));
+        assert(end <= lastEnd);
       });
   auto *overlappedCoercionType = llvm::StructType::get(ctx, elts, packed);
   return {coercionType, overlappedCoercionType};

--- a/test/Interpreter/simd.swift
+++ b/test/Interpreter/simd.swift
@@ -1,0 +1,31 @@
+// RUN: %target-run-simple-swift | %FileCheck %s
+// REQUIRES: executable_test
+// REQUIRES: OS=macosx
+
+import simd
+
+public struct Vector3f {
+  var f3: float3
+  init() {
+    f3 = float3(0, 1, 2)
+  }
+}
+
+public struct TwoFloat {
+  var f0 : Float
+  var f1 : Float
+  init() {
+    f0 = 0.0
+    f1 = 1.0
+  }
+}
+
+public func test() -> (Vector3f, TwoFloat) {
+  let v = Vector3f()
+  let y = TwoFloat()
+  let r = (v, y)
+  return r
+}
+
+// CHECK: (main.Vector3f(f3: float3(0.0, 1.0, 2.0)), main.TwoFloat(f0: 0.0, f1: 1.0))
+print(test())


### PR DESCRIPTION
We need to subtract alignment padding when doing type layout in terms of llvm types.

• Explanation: We miscalculated padding between types that have different llvm allocation and store size in the swift calling convention. The patch uses the alloc size when computing the necessary padding for physical types.

This leads to wrong answers for types such as a pair of ( <3xfloat>, i64) because the offset for the second element is wrong.

• Scope of Issue: This gets exposed in code that uses simd  types on x86-64 such as <3 x float>

• Risk: Low. This only affects code that uses the swift calling convention and only has an effect if llvm’s storesize != llvm’s alloc size.

• Testing: Swift regression test was added.

rdar://32618125
SR-5137


