### PR TITLE
[4.0] NSKeyedUnarchiver methods should take Data (instead of just NSData)

### DIFF
--- a/stdlib/public/SDK/Foundation/NSCoder.swift
+++ b/stdlib/public/SDK/Foundation/NSCoder.swift
@@ -145,27 +145,13 @@ extension NSKeyedUnarchiver {
   }
 
   @nonobjc
-  @available(swift, obsoleted: 4)
-  @available(OSX 10.11, iOS 9.0, *)
-  public class func unarchiveTopLevelObjectWithData(_ data: Data) throws -> AnyObject? {
-      return try self.unarchiveTopLevelObjectWithData(data as NSData)
-  }
-
-  @nonobjc
-  @available(swift, introduced: 4)
-  @available(OSX 10.11, iOS 9.0, *)
-  public class func unarchiveTopLevelObjectWithData(_ data: NSData) throws -> Any? {
-    var error: NSError?
-    let result = __NSKeyedUnarchiverUnarchiveObject(self, data, &error)
-    try resolveError(error)
-    return result
-  }
-
-  @nonobjc
   @available(swift, introduced: 4)
   @available(OSX 10.11, iOS 9.0, *)
   public class func unarchiveTopLevelObjectWithData(_ data: Data) throws -> Any? {
-      return try self.unarchiveTopLevelObjectWithData(data as NSData)
+    var error: NSError?
+    let result = __NSKeyedUnarchiverUnarchiveObject(self, data as NSData, &error)
+    try resolveError(error)
+    return result
   }
 }
 

--- a/stdlib/public/SDK/Foundation/NSCoder.swift
+++ b/stdlib/public/SDK/Foundation/NSCoder.swift
@@ -145,6 +145,13 @@ extension NSKeyedUnarchiver {
   }
 
   @nonobjc
+  @available(swift, obsoleted: 4)
+  @available(OSX 10.11, iOS 9.0, *)
+  public class func unarchiveTopLevelObjectWithData(_ data: Data) throws -> AnyObject? {
+      return try self.unarchiveTopLevelObjectWithData(data as NSData)
+  }
+
+  @nonobjc
   @available(swift, introduced: 4)
   @available(OSX 10.11, iOS 9.0, *)
   public class func unarchiveTopLevelObjectWithData(_ data: NSData) throws -> Any? {
@@ -152,6 +159,13 @@ extension NSKeyedUnarchiver {
     let result = __NSKeyedUnarchiverUnarchiveObject(self, data, &error)
     try resolveError(error)
     return result
+  }
+
+  @nonobjc
+  @available(swift, introduced: 4)
+  @available(OSX 10.11, iOS 9.0, *)
+  public class func unarchiveTopLevelObjectWithData(_ data: Data) throws -> Any? {
+      return try self.unarchiveTopLevelObjectWithData(data as NSData)
   }
 }
 


### PR DESCRIPTION
**What's in this pull request?**
Cherry-picks #10474 and #10515 to `swift-4.0-branch`.

**Explanation:** We missed a few `NSKeyedUnarchiver` methods during our original renaming for Swift — some of these methods still take `NSData` when they can take `Data`. We can add `Data` variants which bridge to `NSData` to fix this in a backwards-compatible way.
**Scope:** Affects those who want to use the proper top-level unarchiving methods in Swift.
**Radar:** rdar://problem/32177014
**Risk:** Low
**Testing:** Manual verification; this adds a new overload to a method we already have with the proper parameter.