### PR TITLE
[build-script] Add support for compiling swift with leaks sanitizer.

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -898,6 +898,18 @@ build-subdir=buildbot_incremental_asan
 
 enable-asan
 
+[preset: buildbot_incremental_linux,lsan]
+build-subdir=buildbot_incremental_lsan
+
+release-debuginfo
+assertions
+enable-lsan
+
+dash-dash
+
+build-ninja
+reconfigure
+
 #===------------------------------------------------------------------------===#
 # OS X Package Builders
 #===------------------------------------------------------------------------===#

--- a/utils/build-script
+++ b/utils/build-script
@@ -682,6 +682,14 @@ class BuildScriptInvocation(object):
         # NOT pass them to build-script-impl.
         if args.enable_asan:
             impl_args += ["--enable-asan"]
+        # If we have lsan, we need to export our suppression list. The actual
+        # passing in of the LSAN flag is done via the normal cmake method. We
+        # do not pass the flag to build-script-impl.
+        if args.enable_lsan:
+            supp_file = os.path.join(SWIFT_SOURCE_ROOT, SWIFT_REPO_NAME,
+                                     "utils",
+                                     "lsan_leaks_suppression_list.txt")
+            os.environ['LSAN_OPTIONS'] = 'suppressions={}'.format(supp_file)
         if args.verbose_build:
             impl_args += ["--verbose-build"]
         if args.install_symroot:
@@ -2018,6 +2026,10 @@ iterations with -O",
     parser.add_argument(
         "--enable-tsan-runtime",
         help="enable Thread Sanitizer on the swift runtime")
+    parser.add_argument(
+        "--enable-lsan",
+        help="enable Leak Sanitizer for swift tools",
+        action=arguments.action.optional_bool)
 
     parser.add_argument(
         "--compiler-vendor",

--- a/utils/lsan_leaks_suppression_list.txt
+++ b/utils/lsan_leaks_suppression_list.txt
@@ -1,0 +1,2 @@
+leak:*buildCompilation*
+leak:*llvm::TableGenMain*

--- a/utils/swift_build_support/swift_build_support/cmake.py
+++ b/utils/swift_build_support/swift_build_support/cmake.py
@@ -92,6 +92,8 @@ class CMake(object):
             sanitizers.append('Undefined')
         if args.enable_tsan:
             sanitizers.append('Thread')
+        if args.enable_lsan:
+            sanitizers.append('Leaks')
         if sanitizers:
             define("LLVM_USE_SANITIZER", ";".join(sanitizers))
 

--- a/utils/swift_build_support/tests/test_cmake.py
+++ b/utils/swift_build_support/tests/test_cmake.py
@@ -33,6 +33,7 @@ class CMakeTestCase(unittest.TestCase):
                          enable_asan=False,
                          enable_ubsan=False,
                          enable_tsan=False,
+                         enable_lsan=False,
                          export_compile_commands=False,
                          distcc=False,
                          cmake_generator="Ninja",
@@ -144,6 +145,18 @@ class CMakeTestCase(unittest.TestCase):
             list(cmake.common_options()),
             ["-G", "Ninja",
              "-DLLVM_USE_SANITIZER=Address;Undefined;Thread",
+             "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
+             "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
+             "-DCMAKE_MAKE_PROGRAM=" + self.which_ninja(args)])
+
+    def test_common_options_lsan(self):
+        args = self.default_args()
+        args.enable_lsan = True
+        cmake = self.cmake(args)
+        self.assertEqual(
+            list(cmake.common_options()),
+            ["-G", "Ninja",
+             "-DLLVM_USE_SANITIZER=Leaks",
              "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
              "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
              "-DCMAKE_MAKE_PROGRAM=" + self.which_ninja(args)])


### PR DESCRIPTION
This only enables the swift compiler (not its output) to be used with leaks
sanitizer on linux.

Some important notes: On Linux, right now we are not completely leak clean. I
was only able to get a -Onone build of the stdlib without triggering lsan (I was
unable to run the optimizer and the tests successfully). Additionally even at
-Onone, I had to suppress some leaks in the driver. The point of this though is
to prevent any further -Onone leaks from being committed to the tree since
-Onone leaks that are not bounded (unlike the driver bugs) could cause SourceKit
to leak memory. Since SourceKit is a long running process... such a type of leak
would be bad.

rdar://32876901
