### PR TITLE
Fixing grammar in error messages.

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1421,7 +1421,7 @@ WARNING(swift3_where_inside_brackets,none,
         "'where' clause next to generic parameters is deprecated "
         "and will be removed in the future version of Swift", ())
 ERROR(where_inside_brackets,none,
-        "'where' clause next to generic parameters is obsoleted", ())
+        "'where' clause next to generic parameters is obsolete", ())
 
 //------------------------------------------------------------------------------
 // Conditional compilation parsing diagnostics

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1421,7 +1421,8 @@ WARNING(swift3_where_inside_brackets,none,
         "'where' clause next to generic parameters is deprecated "
         "and will be removed in the future version of Swift", ())
 ERROR(where_inside_brackets,none,
-        "'where' clause next to generic parameters is obsolete", ())
+        "'where' clause next to generic parameters is obsolete, "
+        "must be written following the declaration's type", ())
 
 //------------------------------------------------------------------------------
 // Conditional compilation parsing diagnostics

--- a/test/Parse/deprecated_where.swift
+++ b/test/Parse/deprecated_where.swift
@@ -10,7 +10,7 @@ func f1<T>(x: T) {}
 // 1: Inherited constraint
 func f2<T: Mashable>(x: T) {} // no-warning
 // 2: Non-trailing where
-func f3<T where T: Womparable>(x: T) {} // expected-error {{'where' clause next to generic parameters is obsoleted}} {{10-30=}} {{37-37= where T: Womparable}}
+func f3<T where T: Womparable>(x: T) {} // expected-error {{'where' clause next to generic parameters is obsolete}} {{10-30=}} {{37-37= where T: Womparable}}
 // 3: Has return type
 func f4<T>(x: T) -> Int { return 2 } // no-warning
 // 4: Trailing where
@@ -18,29 +18,29 @@ func f5<T>(x: T) where T : Equatable {} // no-warning
 
 // FuncDecl: Choose 2
 // 1,2
-func f12<T: Mashable where T: Womparable>(x: T) {} // expected-error {{'where' clause next to generic parameters is obsoleted}} {{21-41=}} {{48-48= where T: Womparable}}
+func f12<T: Mashable where T: Womparable>(x: T) {} // expected-error {{'where' clause next to generic parameters is obsolete}} {{21-41=}} {{48-48= where T: Womparable}}
 // 1,3
 func f13<T: Mashable>(x: T) -> Int { return 2 } // no-warning
 // 1,4
 func f14<T: Mashable>(x: T) where T: Equatable {} // no-warning
 // 2,3
-func f23<T where T: Womparable>(x: T) -> Int { return 2 } // expected-error {{'where' clause next to generic parameters is obsoleted}} {{11-31=}} {{45-45= where T: Womparable}}
+func f23<T where T: Womparable>(x: T) -> Int { return 2 } // expected-error {{'where' clause next to generic parameters is obsolete}} {{11-31=}} {{45-45= where T: Womparable}}
 // 2,4
-func f24<T where T: Womparable>(x: T) where T: Equatable {} // expected-error {{'where' clause next to generic parameters is obsoleted}} {{11-31=}} {{39-44=where T: Womparable,}}
+func f24<T where T: Womparable>(x: T) where T: Equatable {} // expected-error {{'where' clause next to generic parameters is obsolete}} {{11-31=}} {{39-44=where T: Womparable,}}
 // 3,4
 func f34<T>(x: T) -> Int where T: Equatable { return 2 } // no-warning
 
 // FuncDecl: Choose 3
 // 1,2,3
-func f123<T: Mashable where T: Womparable>(x: T) -> Int { return 2 } // expected-error {{'where' clause next to generic parameters is obsoleted}} {{22-42=}} {{56-56= where T: Womparable}}
+func f123<T: Mashable where T: Womparable>(x: T) -> Int { return 2 } // expected-error {{'where' clause next to generic parameters is obsolete}} {{22-42=}} {{56-56= where T: Womparable}}
 // 1,2,4
-func f124<T: Mashable where T: Womparable>(x: T) where T: Equatable {} // expected-error {{'where' clause next to generic parameters is obsoleted}} {{22-42=}} {{50-55=where T: Womparable,}}
+func f124<T: Mashable where T: Womparable>(x: T) where T: Equatable {} // expected-error {{'where' clause next to generic parameters is obsolete}} {{22-42=}} {{50-55=where T: Womparable,}}
 // 2,3,4
-func f234<T where T: Womparable>(x: T) -> Int where T: Equatable { return 2 } // expected-error {{'where' clause next to generic parameters is obsoleted}} {{12-32=}} {{47-52=where T: Womparable,}}
+func f234<T where T: Womparable>(x: T) -> Int where T: Equatable { return 2 } // expected-error {{'where' clause next to generic parameters is obsolete}} {{12-32=}} {{47-52=where T: Womparable,}}
 
 // FuncDecl: Choose 4
 // 1,2,3,4
-func f1234<T: Mashable where T: Womparable>(x: T) -> Int where T: Equatable { return 2 } // expected-error {{'where' clause next to generic parameters is obsoleted}} {{23-43=}} {{58-63=where T: Womparable,}}
+func f1234<T: Mashable where T: Womparable>(x: T) -> Int where T: Equatable { return 2 } // expected-error {{'where' clause next to generic parameters is obsolete}} {{23-43=}} {{58-63=where T: Womparable,}}
 
 
 
@@ -51,32 +51,32 @@ struct S0<T> {}
 // 1: Inherited constraint
 struct S1<T: Mashable> {} // no-warning
 // 2: Non-trailing where
-struct S2<T where T: Womparable> {} // expected-error {{'where' clause next to generic parameters is obsoleted}} {{12-32=}} {{33-33= where T: Womparable}}
+struct S2<T where T: Womparable> {} // expected-error {{'where' clause next to generic parameters is obsolete}} {{12-32=}} {{33-33= where T: Womparable}}
 // 3: Trailing where
 struct S3<T> where T : Equatable {} // no-warning
 
 // NominalTypeDecl: Choose 2
 // 1,2
-struct S12<T: Mashable where T: Womparable> {} // expected-error {{'where' clause next to generic parameters is obsoleted}} {{23-43=}} {{44-44= where T: Womparable}}
+struct S12<T: Mashable where T: Womparable> {} // expected-error {{'where' clause next to generic parameters is obsolete}} {{23-43=}} {{44-44= where T: Womparable}}
 // 1,3
 struct S13<T: Mashable> where T: Equatable {} // no-warning
 // 2,3
-struct S23<T where T: Womparable> where T: Equatable {} // expected-error {{'where' clause next to generic parameters is obsoleted}} {{13-33=}} {{35-40=where T: Womparable,}}
+struct S23<T where T: Womparable> where T: Equatable {} // expected-error {{'where' clause next to generic parameters is obsolete}} {{13-33=}} {{35-40=where T: Womparable,}}
 
 // NominalTypeDecl: Choose 3
 // 1,2,3
-struct S123<T: Mashable where T: Womparable> where T: Equatable {} // expected-error {{'where' clause next to generic parameters is obsoleted}} {{24-44=}} {{46-51=where T: Womparable,}}
+struct S123<T: Mashable where T: Womparable> where T: Equatable {} // expected-error {{'where' clause next to generic parameters is obsolete}} {{24-44=}} {{46-51=where T: Womparable,}}
 
 
 protocol ProtoA {}
 protocol ProtoB {}
 protocol ProtoC {}
 protocol ProtoD {}
-func testCombinedConstraints<T: ProtoA & ProtoB where T: ProtoC>(x: T) {} // expected-error {{'where' clause next to generic parameters is obsoleted}} {{48-64=}} {{71-71= where T: ProtoC}}
-func testCombinedConstraints<T: ProtoA & ProtoB where T: ProtoC>(x: T) where T: ProtoD {} // expected-error {{'where' clause next to generic parameters is obsoleted}} {{48-64=}} {{72-77=where T: ProtoC,}}
+func testCombinedConstraints<T: ProtoA & ProtoB where T: ProtoC>(x: T) {} // expected-error {{'where' clause next to generic parameters is obsolete}} {{48-64=}} {{71-71= where T: ProtoC}}
+func testCombinedConstraints<T: ProtoA & ProtoB where T: ProtoC>(x: T) where T: ProtoD {} // expected-error {{'where' clause next to generic parameters is obsolete}} {{48-64=}} {{72-77=where T: ProtoC,}}
 
-func testCombinedConstraintsOld<T: protocol<ProtoA, ProtoB> where T: ProtoC>(x: T) {} // expected-error {{'where' clause next to generic parameters is obsoleted}} {{60-76=}} {{83-83= where T: ProtoC}}
+func testCombinedConstraintsOld<T: protocol<ProtoA, ProtoB> where T: ProtoC>(x: T) {} // expected-error {{'where' clause next to generic parameters is obsolete}} {{60-76=}} {{83-83= where T: ProtoC}}
 // expected-warning@-1 {{'protocol<...>' composition syntax is deprecated}}
-func testCombinedConstraintsOld<T: protocol<ProtoA, ProtoB> where T: ProtoC>(x: T) where T: ProtoD {} // expected-error {{'where' clause next to generic parameters is obsoleted}} {{60-76=}} {{84-89=where T: ProtoC,}}
+func testCombinedConstraintsOld<T: protocol<ProtoA, ProtoB> where T: ProtoC>(x: T) where T: ProtoD {} // expected-error {{'where' clause next to generic parameters is obsolete}} {{60-76=}} {{84-89=where T: ProtoC,}}
 // expected-warning@-1 {{'protocol<...>' composition syntax is deprecated}}
 


### PR DESCRIPTION
"is obsoleted" is only used in context of "X is obsoleted by Y".
When used as a rough synonym of "deprecated" the proper grammar is "is
obsolete".