### PR TITLE
Speculative fix for test output race conditions

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -144,6 +144,18 @@ class SwiftTest(lit.formats.ShTest, object):
         self.skipped_tests = set()
 
     def before_test(self, test, litConfig):
+        _, tmp_base = lit.TestRunner.getTempPaths(test)
+        
+        # Apparently despite the docs, tmpDir is not actually unique for each test, but
+        # tmpBase is.  Remove it here and add a tmpBase substitution in before_test.
+        # Speculative fix for rdar://32928464.
+        try:
+            percentT_index = [x[0] for x in test.config.substitutions].index('%T')
+        except ValueError: pass
+        else:
+            test.config.substitutions.pop(percentT_index)
+        test.config.substitutions.append(('%T', tmp_base))
+        
         if self.coverage_mode:
             # FIXME: The compiler crashers run so fast they fill up the
             # merger's queue (and therefore the build bot's disk)
@@ -151,8 +163,7 @@ class SwiftTest(lit.formats.ShTest, object):
                 test.config.environment["LLVM_PROFILE_FILE"] = os.devnull
                 self.skipped_tests.add(test.getSourcePath())
                 return
-
-            _, tmp_base = lit.TestRunner.getTempPaths(test)
+            
             if self.coverage_mode == "NOT_MERGED":
                 profdir = tmp_base + '.profdir'
                 if not os.path.exists(profdir):
@@ -356,11 +367,6 @@ lit_config.note("Using test results dir: " + config.swift_test_results_dir)
 completion_cache_path = tempfile.mkdtemp(prefix="swift-testsuite-completion-cache")
 ccp_opt = "-completion-cache-path %r" % completion_cache_path
 lit_config.note("Using code completion cache: " + completion_cache_path)
-
-# Apparently despite the docs, tmpDir is not actually unique for each test, but
-# tmpBase is.  Speculative fix for rdar://31520207.
-config.substitutions.remove( ('%T', tmpDir) )
-config.substitutions.append( ('%T', tmpBase) )
 
 config.substitutions.append( ('%swift_obj_root', config.swift_obj_root) )
 config.substitutions.append( ('%swift_src_root', config.swift_src_root) )

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -154,8 +154,10 @@ class SwiftTest(lit.formats.ShTest, object):
         except ValueError: pass
         else:
             test.config.substitutions.pop(percentT_index)
-        test.config.substitutions.append(('%T', tmp_base))
-        
+
+            test.config.substitutions.append(
+                ('%T', '$(mkdir -p %r && echo %r)' % (tmp_base, tmp_base)))
+
         if self.coverage_mode:
             # FIXME: The compiler crashers run so fast they fill up the
             # merger's queue (and therefore the build bot's disk)

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -357,6 +357,11 @@ completion_cache_path = tempfile.mkdtemp(prefix="swift-testsuite-completion-cach
 ccp_opt = "-completion-cache-path %r" % completion_cache_path
 lit_config.note("Using code completion cache: " + completion_cache_path)
 
+# Apparently despite the docs, tmpDir is not actually unique for each test, but
+# tmpBase is.  Speculative fix for rdar://31520207.
+config.substitutions.remove( ('%T', tmpDir) )
+config.substitutions.append( ('%T', tmpBase) )
+
 config.substitutions.append( ('%swift_obj_root', config.swift_obj_root) )
 config.substitutions.append( ('%swift_src_root', config.swift_src_root) )
 config.substitutions.append( ('%{python}', sys.executable) )


### PR DESCRIPTION
Sometimes two tests will simultaneously try to write the same file in the temporary directory. This change tries to prevent that problem.
