### PR TITLE
swift-api-digester: more strict when detecting moved declarations.

### DIFF
--- a/tools/swift-api-digester/swift-api-digester.cpp
+++ b/tools/swift-api-digester/swift-api-digester.cpp
@@ -2666,7 +2666,8 @@ void DiagnosisEmitter::collectAddedDecls(NodePtr Root,
 SDKNodeDecl *DiagnosisEmitter::findAddedDecl(const SDKNodeDecl *Root) {
   for (auto *Added : AddedDecls) {
     if (Root->getKind() == Added->getKind() &&
-        Root->getPrintedName() == Added->getPrintedName())
+        Root->getPrintedName() == Added->getPrintedName() &&
+        Root->getUsr() == Added->getUsr())
       return Added;
   }
   return nullptr;


### PR DESCRIPTION
We've witnessed high positive rate in this case.
rdar://31694080