### PR TITLE
Add a utility script for checking for hex constants in IR tests.

### DIFF
--- a/test/IRGen/keypaths.sil
+++ b/test/IRGen/keypaths.sil
@@ -1,4 +1,7 @@
-// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+// RUN: rm -rf %t && mkdir -p %t
+// -- Convert <i32 0x...> constants to decimal constants that LLVM will print
+// RUN: %utils/chex.py < %s > %t/keypaths.sil
+// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %t/keypaths.sil --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
 
 sil_stage canonical
 import Swift
@@ -27,8 +30,8 @@ sil_vtable C {}
 // CHECK-SAME: [[WORD]] 0,
 // CHECK-SAME: %swift.type* (i8*)*
 // CHECK-SAME: %swift.type* (i8*)*
-//               -- 0x8000_0004 - instantiable in-line, size 4
-// CHECK-SAME: i32 -2147483644,
+//               -- instantiable in-line, size 4
+// CHECK-SAME: <i32 0x8000_0004>,
 // CHECK-64-SAME: [4 x i8] zeroinitializer,
 // -- offset of S.x
 // CHECK-SAME: i32 0 }>
@@ -38,8 +41,8 @@ sil_vtable C {}
 // CHECK-SAME: [[WORD]] 0,
 // CHECK-SAME: %swift.type* (i8*)*
 // CHECK-SAME: %swift.type* (i8*)*
-//               -- 0x8000_0004 - instantiable in-line, size 4
-// CHECK-SAME: i32 -2147483644,
+//               -- instantiable in-line, size 4
+// CHECK-SAME: <i32 0x8000_0004>,
 // CHECK-64-SAME: [4 x i8] zeroinitializer,
 // -- offset of S.y
 // CHECK-32-SAME: i32 4 }>
@@ -50,8 +53,8 @@ sil_vtable C {}
 // CHECK-SAME: [[WORD]] 0,
 // CHECK-SAME: %swift.type* (i8*)*
 // CHECK-SAME: %swift.type* (i8*)*
-//               -- 0x8000_0004 - instantiable in-line, size 4
-// CHECK-SAME: i32 -2147483644,
+//               -- instantiable in-line, size 4
+// CHECK-SAME: <i32 0x8000_0004>,
 // CHECK-64-SAME: [4 x i8] zeroinitializer,
 // -- offset of S.z
 // CHECK-32-SAME: i32 16 }>
@@ -62,46 +65,46 @@ sil_vtable C {}
 // CHECK-SAME: [[WORD]] 0,
 // CHECK-SAME: %swift.type* (i8*)*
 // CHECK-SAME: %swift.type* (i8*)*
-//               -- 0x8000_0004 - instantiable in-line, size 4
-// CHECK-SAME: i32 -2147483644,
+//               -- instantiable in-line, size 4
+// CHECK-SAME: <i32 0x8000_0004>,
 // CHECK-64-SAME: [4 x i8] zeroinitializer,
 // -- 0x4000_0000 (class) + offset of C.x
-// CHECK-32-SAME: i32 1073741836 }>
-// CHECK-64-SAME: i32 1073741840 }>
+// CHECK-32-SAME: <i32 0x4000_000c> }>
+// CHECK-64-SAME: <i32 0x4000_0010> }>
 
 // -- %e: C.y
 // CHECK: [[KP_E:@keypath.*]] = private global <{ {{.*}} }> <{
 // CHECK-SAME: [[WORD]] 0,
 // CHECK-SAME: %swift.type* (i8*)*
 // CHECK-SAME: %swift.type* (i8*)*
-//               -- 0x8000_0004 - instantiable in-line, size 4
-// CHECK-SAME: i32 -2147483644,
+//               -- instantiable in-line, size 4
+// CHECK-SAME: <i32 0x8000_0004>,
 // CHECK-64-SAME: [4 x i8] zeroinitializer,
 // -- 0x4000_0000 (class) + offset of C.y
-// CHECK-32-SAME: i32 1073741840 }>
-// CHECK-64-SAME: i32 1073741848 }>
+// CHECK-32-SAME: <i32 0x4000_0010> }>
+// CHECK-64-SAME: <i32 0x4000_0018> }>
 
 // -- %f: C.z
 // CHECK: [[KP_F:@keypath.*]] = private global <{ {{.*}} }> <{
 // CHECK-SAME: [[WORD]] 0,
 // CHECK-SAME: %swift.type* (i8*)*
 // CHECK-SAME: %swift.type* (i8*)*
-//               -- 0x8000_0004 - instantiable in-line, size 4
-// CHECK-SAME: i32 -2147483644,
+//               -- instantiable in-line, size 4
+// CHECK-SAME: <i32 0x8000_0004>,
 // CHECK-64-SAME: [4 x i8] zeroinitializer,
 // -- 0x4000_0000 (class) + offset of C.z
-// CHECK-32-SAME: i32 1073741852 }>
-// CHECK-64-SAME: i32 1073741872 }>
+// CHECK-32-SAME: <i32 0x4000_001c> }>
+// CHECK-64-SAME: <i32 0x4000_0030> }>
 
 // -- %g: S.z.x
 // CHECK: [[KP_G:@keypath.*]] = private global <{ {{.*}} }> <{
 // CHECK-SAME: [[WORD]] 0,
 // CHECK-SAME: %swift.type* (i8*)*
 // CHECK-SAME: %swift.type* (i8*)*
-//                  -- 0x8000_000c - instantiable in-line, size 12
-// CHECK-32-SAME: i32 -2147483636,
-//                  -- 0x8000_0014 - instantiable in-line, size 16
-// CHECK-64-SAME: i32 -2147483628,
+//                  -- instantiable in-line, size 12
+// CHECK-32-SAME: <i32 0x8000_000c>,
+//                  -- instantiable in-line, size 20
+// CHECK-64-SAME: <i32 0x8000_0014>,
 // CHECK-64-SAME: [4 x i8] zeroinitializer,
 // -- offset of S.z
 // CHECK-32-SAME: i32 16,
@@ -109,22 +112,22 @@ sil_vtable C {}
 // CHECK-64-SAME: [4 x i8] zeroinitializer,
 // CHECK: %swift.type* (i8*)*
 // -- 0x4000_0000 (class) + offset of C.x
-// CHECK-32-SAME: i32 1073741836 }>
-// CHECK-64-SAME: i32 1073741840 }>
+// CHECK-32-SAME: <i32 0x4000_000c> }>
+// CHECK-64-SAME: <i32 0x4000_0010> }>
 
 // -- %h: C.z.x
 // CHECK: [[KP_H:@keypath.*]] = private global <{ {{.*}} }> <{
 // CHECK-SAME: [[WORD]] 0,
 // CHECK-SAME: %swift.type* (i8*)*
 // CHECK-SAME: %swift.type* (i8*)*
-//                  -- 0x8000_000c - instantiable in-line, size 12
-// CHECK-32-SAME: i32 -2147483636,
-//                  -- 0x8000_0014 - instantiable in-line, size 16
-// CHECK-64-SAME: i32 -2147483628,
+//                  -- instantiable in-line, size 12
+// CHECK-32-SAME: <i32 0x8000_000c>,
+//                  -- instantiable in-line, size 20
+// CHECK-64-SAME: <i32 0x8000_0014>,
 // CHECK-64-SAME: [4 x i8] zeroinitializer,
 // -- 0x4000_0000 (class) + offset of C.z
-// CHECK-32-SAME: i32 1073741852,
-// CHECK-64-SAME: i32 1073741872,
+// CHECK-32-SAME: <i32 0x4000_001c>,
+// CHECK-64-SAME: <i32 0x4000_0030>,
 // CHECK-64-SAME: [4 x i8] zeroinitializer,
 // CHECK: %swift.type* (i8*)*
 // -- offset of S.x
@@ -135,13 +138,13 @@ sil_vtable C {}
 // CHECK-SAME: [[WORD]] 0,
 // CHECK-SAME: %swift.type* (i8*)*
 // CHECK-SAME: %swift.type* (i8*)*
-//              -- 0x8000_0018 - instantiable in-line, size 24
-// CHECK-64-SAME: i32 -2147483624,
+//              -- instantiable in-line, size 24
+// CHECK-64-SAME: <i32 0x8000_0018>,
 // CHECK-64-SAME: [4 x i8] zeroinitializer,
-//              -- 0x8000_000c - instantiable in-line, size 12
-// CHECK-32-SAME: i32 -2147483636,
-// -- 0x2000_0000 - computed, get-only, identified by function pointer, no args
-// CHECK-SAME: i32 536870912,
+//              -- instantiable in-line, size 12
+// CHECK-32-SAME: <i32 0x8000_000c>,
+// -- computed, get-only, identified by function pointer, no args
+// CHECK-SAME: <i32 0x2000_0000>,
 // CHECK-64-SAME: [4 x i8] zeroinitializer,
 // CHECK-SAME: void ()* @k_id,
 // CHECK-SAME: void (%TSi*, %T8keypaths1SV*)* @k_get }>
@@ -151,13 +154,13 @@ sil_vtable C {}
 // CHECK-SAME: [[WORD]] 0,
 // CHECK-SAME: %swift.type* (i8*)*
 // CHECK-SAME: %swift.type* (i8*)*
-//              -- 0x8000_0020 - instantiable in-line, size 32
-// CHECK-64-SAME: i32 -2147483616,
+//              -- instantiable in-line, size 32
+// CHECK-64-SAME: <i32 0x8000_0020>,
 // CHECK-64-SAME: [4 x i8] zeroinitializer,
-//              -- 0x8000_0010 - instantiable in-line, size 16
-// CHECK-32-SAME: i32 -2147483632,
-// -- 0x2a00_0000 - computed, settable, nonmutating, identified by vtable, no args
-// CHECK-SAME: i32 704643072,
+//              -- instantiable in-line, size 16
+// CHECK-32-SAME: <i32 0x8000_0010>,
+// -- computed, settable, nonmutating, identified by vtable, no args
+// CHECK-SAME: <i32 0x2a00_0000>,
 // CHECK-64-SAME: [4 x i8] zeroinitializer,
 // CHECK-SAME: [[WORD]]
 // CHECK-SAME: void (%TSi*, %T8keypaths1CC**)* @l_get,
@@ -168,13 +171,13 @@ sil_vtable C {}
 // CHECK-SAME: [[WORD]] 0,
 // CHECK-SAME: %swift.type* (i8*)*
 // CHECK-SAME: %swift.type* (i8*)*
-//              -- 0x8000_0020 - instantiable in-line, size 32
-// CHECK-64-SAME: i32 -2147483616,
+//              -- instantiable in-line, size 32
+// CHECK-64-SAME: <i32 0x8000_0020>,
 // CHECK-64-SAME: [4 x i8] zeroinitializer,
-//              -- 0x8000_0010 - instantiable in-line, size 16
-// CHECK-32-SAME: i32 -2147483632,
-// -- 0x3c00_0000 - computed, settable, nonmutating, identified by property offset, no args
-// CHECK-SAME: i32 1006632960,
+//              -- instantiable in-line, size 16
+// CHECK-32-SAME: <i32 0x8000_0010>,
+// -- computed, settable, nonmutating, identified by property offset, no args
+// CHECK-SAME: <i32 0x3c00_0000>,
 // CHECK-64-SAME: [4 x i8] zeroinitializer,
 // CHECK-SAME: [[WORD]]
 // CHECK-SAME: void (%swift.function*, %T8keypaths1SV*)* @m_get,
@@ -189,8 +192,8 @@ sil_vtable C {}
 //             -- size 8
 // CHECK-SAME: i32 8,
 // CHECK-64-SAME: [4 x i8] zeroinitializer,
-//             -- 0x1ffffffe - struct with runtime-resolved offset
-// CHECK-SAME: i32 536870910,
+//             -- struct with runtime-resolved offset
+// CHECK-SAME: <i32 0x1ffffffe>,
 // CHECK-32-SAME: i32 12 }>
 // CHECK-64-SAME: i32 24 }>
 
@@ -202,8 +205,8 @@ sil_vtable C {}
 //             -- size 8
 // CHECK-SAME: i32 8,
 // CHECK-64-SAME: [4 x i8] zeroinitializer,
-//             -- 0x1ffffffe - struct with runtime-resolved offset
-// CHECK-SAME: i32 536870910,
+//             -- struct with runtime-resolved offset
+// CHECK-SAME: <i32 0x1ffffffe>,
 // CHECK-32-SAME: i32 16 }>
 // CHECK-64-SAME: i32 32 }>
 

--- a/utils/chex.py
+++ b/utils/chex.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+# Check HEX -- a stupid filter that allows hexadecimal literals to be checked
+# for in LLVM IR FileCheck tests. It works by replacing occurrences of
+# strings matching the regex /< (i[0-9]+) \s+ (0x[0-9A-Fa-f]+) >/x with the
+# decimal literal equivalent that would really appear in printed LLVM IR.
+
+from __future__ import print_function
+
+import re
+import sys
+
+hex = re.compile(r"""<(i([0-9]+)\s+)0x([0-9A-Fa-f_]+)>""")
+
+
+def hexReplace(match):
+    # Integer type is match group 1
+    ty = match.group(1)
+    # Integer bit width is match group 2
+    bits = int(match.group(2))
+    # Hex value is match group 3
+    value = int(match.group(3).replace("_", ""), base=16)
+    # LLVM prints the decimal value as if it's two's-complement signed in
+    # the given bitwidth, so the printed value will be negative if
+    # greater than 2^(bits - 1)
+    if value >= (1 << (bits - 1)):
+        value -= 1 << bits
+    return ty + str(value)
+
+
+for line in sys.stdin:
+    print(re.sub(hex, hexReplace, line), end="")


### PR DESCRIPTION
LLVM always prints IR constants as signed decimal, which is not ideal when looking for packed bit patterns in tests. Add a little filter script that turns hex constants of the form `<iNN 0xNNNNN>` into the decimal output we'd expect from the LLVM printer.