### PR TITLE
[Foundation] Add fast paths for Data initialization for common sequences

### DIFF
--- a/stdlib/public/SDK/Foundation/Data.swift
+++ b/stdlib/public/SDK/Foundation/Data.swift
@@ -1087,15 +1087,10 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     public init<S: Sequence>(_ elements: S) where S.Iterator.Element == UInt8 {
         let underestimatedCount = elements.underestimatedCount
         self.init(count: underestimatedCount)
-        var idx = 0
-        for byte in elements {
-            if idx < underestimatedCount {
-                self[idx] = byte
-            } else {
-                self.append(byte)
-            }
-            idx += 1
-        }
+        
+        let (endIterator, _) = UnsafeMutableBufferPointer(start: _backing._bytes?.assumingMemoryBound(to: UInt8.self), count: underestimatedCount).initialize(from: elements)
+        var iter = endIterator
+        while let byte = iter.next() { self.append(byte) }
     }
     
     public init(_ bytes: Array<UInt8>) {
@@ -1658,11 +1653,24 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
         }
     }
     
+    public func _copyContents(initializing buffer: UnsafeMutableBufferPointer<UInt8>) -> (Iterator, UnsafeMutableBufferPointer<UInt8>.Index) {
+        guard !isEmpty else { return (makeIterator(), buffer.startIndex) }
+        guard let p = buffer.baseAddress else {
+            preconditionFailure("Attempt to copy contents into nil buffer pointer")
+        }
+        let cnt = count
+        precondition(cnt <= buffer.count, "Insufficient space allocated to copy Data contents")
+        
+        withUnsafeBytes { p.initialize(from: $0, count: cnt) }
+        
+        return (Iterator(endOf: self), buffer.index(buffer.startIndex, offsetBy: cnt))
+    }
+    
     /// An iterator over the contents of the data.
     ///
     /// The iterator will increment byte-by-byte.
     public func makeIterator() -> Data.Iterator {
-        return Iterator(_data: self)
+        return Iterator(self)
     }
     
     public struct Iterator : IteratorProtocol {
@@ -1675,11 +1683,18 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
         private var _idx: Data.Index
         private let _endIdx: Data.Index
         
-        fileprivate init(_data: Data) {
-            self._data = _data
+        fileprivate init(_ data: Data) {
+            _data = data
             _buffer = (0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0)
-            _idx = _data.startIndex
-            _endIdx = _data.endIndex
+            _idx = data.startIndex
+            _endIdx = data.endIndex
+        }
+        
+        fileprivate init(endOf data: Data) {
+            self._data = data
+            _buffer = (0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0)
+            _idx = data.endIndex
+            _endIdx = data.endIndex
         }
         
         public mutating func next() -> UInt8? {

--- a/stdlib/public/SDK/Foundation/Data.swift
+++ b/stdlib/public/SDK/Foundation/Data.swift
@@ -1082,6 +1082,43 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
         
     }
     
+    // slightly faster paths for common sequences
+    
+    public init<S: Sequence>(_ elements: S) where S.Iterator.Element == UInt8 {
+        let underestimatedCount = elements.underestimatedCount
+        self.init(count: underestimatedCount)
+        var idx = 0
+        for byte in elements {
+            if idx < underestimatedCount {
+                self[idx] = byte
+            } else {
+                self.append(byte)
+            }
+            idx += 1
+        }
+    }
+    
+    public init(_ bytes: Array<UInt8>) {
+        self.init(bytes: bytes)
+    }
+    
+    public init(_ bytes: ArraySlice<UInt8>) {
+        self.init(bytes: bytes)
+    }
+    
+    public init(_ buffer: UnsafeBufferPointer<UInt8>) {
+        self.init(buffer: buffer)
+    }
+    
+    public init(_ buffer: UnsafeMutableBufferPointer<UInt8>) {
+        self.init(buffer: buffer)
+    }
+    
+    public init(_ data: Data) {
+        _sliceRange = 0..<data.count
+        _backing = data._backing.mutableCopy(data._sliceRange)
+    }
+    
     @_versioned
     internal init(backing: _DataStorage, range: Range<Index>) {
         _backing = backing

--- a/test/stdlib/TestData.swift
+++ b/test/stdlib/TestData.swift
@@ -1136,6 +1136,42 @@ class TestData : TestDataSuper {
         d2.append(slice)
         expectEqual(Data(bytes: [1]), slice)
     }
+
+    func test_sequenceInitializers() {
+        let seq = repeatElement(UInt8(0x02), count: 3) // ensure we fall into the sequence case
+        
+        let dataFromSeq = Data(seq)
+        expectEqual(3, dataFromSeq.count)
+        expectEqual(UInt8(0x02), dataFromSeq[0])
+        expectEqual(UInt8(0x02), dataFromSeq[1])
+        expectEqual(UInt8(0x02), dataFromSeq[2])
+
+        let array: [UInt8] = [0, 1, 2, 3, 4, 5, 6]
+
+        let dataFromArray = Data(array)
+        expectEqual(array.count, dataFromArray.count)
+        expectEqual(array[0], dataFromArray[0])
+        expectEqual(array[1], dataFromArray[1])
+        expectEqual(array[2], dataFromArray[2])
+        expectEqual(array[3], dataFromArray[3])
+
+        let slice = array[1..<4]
+        
+        let dataFromSlice = Data(slice)
+        expectEqual(slice.count, dataFromSlice.count)
+        expectEqual(slice.first, dataFromSlice.first)
+        expectEqual(slice.last, dataFromSlice.last)
+
+        let data = Data(bytes: [1, 2, 3, 4, 5, 6, 7, 8, 9])
+
+        let dataFromData = Data(data)
+        expectEqual(data, dataFromData)
+
+        let sliceOfData = data[1..<3]
+
+        let dataFromSliceOfData = Data(sliceOfData)
+        expectEqual(sliceOfData, dataFromSliceOfData)
+    }
 }
 
 #if !FOUNDATION_XCTEST
@@ -1198,6 +1234,7 @@ DataTests.test("test_copyBytes1") { TestData().test_copyBytes1() }
 DataTests.test("test_copyBytes2") { TestData().test_copyBytes2() }
 DataTests.test("test_sliceOfSliceViaRangeExpression") { TestData().test_sliceOfSliceViaRangeExpression() }
 DataTests.test("test_appendingSlices") { TestData().test_appendingSlices() }
+DataTests.test("test_sequenceInitializers") { TestData().test_sequenceInitializers() }
 
 
 // XCTest does not have a crash detection, whereas lit does


### PR DESCRIPTION
There were some unfortunate slower than expected initializers on Data that were inherited from Collection adoption. This allows Data initialization to take the fast path in a select group of initializations; previously it would create a Data and then iterate byte by byte appending. Albeit that was relatively quick, we have faster options available.

This addresses the issue:
rdar://problem/32359974