### PR TITLE
We also need to pass a min-vers string to the ClangImporter when running under the embed-bitcode mode

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -563,24 +563,6 @@ getNormalInvocationArguments(std::vector<std::string> &invocationArgStrs,
     }
   }
 
-  if (triple.isOSDarwin()) {
-    std::string minVersionBuf;
-    llvm::raw_string_ostream minVersionOpt{minVersionBuf};
-    minVersionOpt << getMinVersionOptNameForDarwinTriple(triple);
-
-    unsigned major, minor, micro;
-    if (triple.isiOS()) {
-      triple.getiOSVersion(major, minor, micro);
-    } else if (triple.isWatchOS()) {
-      triple.getWatchOSVersion(major, minor, micro);
-    } else {
-      assert(triple.isMacOSX());
-      triple.getMacOSXVersion(major, minor, micro);
-    }
-    minVersionOpt << clang::VersionTuple(major, minor, micro);
-    invocationArgStrs.push_back(std::move(minVersionOpt.str()));
-  }
-
   if (searchPathOpts.SDKPath.empty()) {
     invocationArgStrs.push_back("-Xclang");
     invocationArgStrs.push_back("-nostdsysteminc");
@@ -664,6 +646,24 @@ addCommonInvocationArguments(std::vector<std::string> &invocationArgStrs,
 
   invocationArgStrs.push_back("-target");
   invocationArgStrs.push_back(triple.str());
+
+  if (triple.isOSDarwin()) {
+    std::string minVersionBuf;
+    llvm::raw_string_ostream minVersionOpt{minVersionBuf};
+    minVersionOpt << getMinVersionOptNameForDarwinTriple(triple);
+
+    unsigned major, minor, micro;
+    if (triple.isiOS()) {
+      triple.getiOSVersion(major, minor, micro);
+    } else if (triple.isWatchOS()) {
+      triple.getWatchOSVersion(major, minor, micro);
+    } else {
+      assert(triple.isMacOSX());
+      triple.getMacOSXVersion(major, minor, micro);
+    }
+    minVersionOpt << clang::VersionTuple(major, minor, micro);
+    invocationArgStrs.push_back(std::move(minVersionOpt.str()));
+  }
 
   invocationArgStrs.push_back(ImporterImpl::moduleImportBufferName);
 

--- a/test/Frontend/embed-bitcode-tvos.ll
+++ b/test/Frontend/embed-bitcode-tvos.ll
@@ -1,0 +1,20 @@
+; REQUIRES: CODEGENERATOR=AArch64
+; RUN: llvm-as %s -o %t.bc
+; RUN: %swift -target arm64-apple-tvos9 -c -module-name someModule -embed-bitcode -disable-llvm-optzns -o %t2.o %t.bc -dump-clang-diagnostics 2> %t.diags.txt
+; RUN: llvm-objdump -macho -private-headers %t2.o | %FileCheck %s
+; RUN: %FileCheck -check-prefix CHECK-IMPORTER %s < %t.diags.txt
+
+target triple = "arm64-apple-tvos9.0"
+target datalayout = "e-m:o-i64:64-i128:128-n32:64-S128"
+
+; CHECK: LC_VERSION_MIN_TVOS
+
+; CHECK-IMPORTER: clang
+; CHECK-IMPORTER: -fembed-bitcode
+; CHECK-IMPORTER: -target
+; CHECK-IMPORTER: -mtvos-version-min=9
+; CHECK-IMPORTER-NOT: argument unused
+
+define i32 @f0() nounwind ssp {
+       ret i32 0
+}


### PR DESCRIPTION
Otherwise, it will return the wrong triple when queried.

rdar://32863670

• Explanation: We recently added code to query the ClangImporter for the target triple. This code is on the swift-4.0-branch. Unfortunately, this leads to a bug where the clang importer returns the wrong triple when invoked with the -embed-bitcode option.
This patch fixes this.

This leads to object files that contain a linker minimum version for iOS instead of tvOS which prevents the swift compiler toolchain from building with bitcode embedded.

• Origination: The problem exists in the swift-4.0-branch.

• Risk: Low. This should only affect the -embed-bitcode option that now gets a clang-importer with the correct triple.

• Testing: A Swift regression test was added.
