### PR TITLE
Change NSKeyedUnarchiver method instead of adding overloads

### DIFF
--- a/stdlib/public/SDK/Foundation/NSCoder.swift
+++ b/stdlib/public/SDK/Foundation/NSCoder.swift
@@ -145,27 +145,13 @@ extension NSKeyedUnarchiver {
   }
 
   @nonobjc
-  @available(swift, obsoleted: 4)
-  @available(OSX 10.11, iOS 9.0, *)
-  public class func unarchiveTopLevelObjectWithData(_ data: Data) throws -> AnyObject? {
-      return try self.unarchiveTopLevelObjectWithData(data as NSData)
-  }
-
-  @nonobjc
-  @available(swift, introduced: 4)
-  @available(OSX 10.11, iOS 9.0, *)
-  public class func unarchiveTopLevelObjectWithData(_ data: NSData) throws -> Any? {
-    var error: NSError?
-    let result = __NSKeyedUnarchiverUnarchiveObject(self, data, &error)
-    try resolveError(error)
-    return result
-  }
-
-  @nonobjc
   @available(swift, introduced: 4)
   @available(OSX 10.11, iOS 9.0, *)
   public class func unarchiveTopLevelObjectWithData(_ data: Data) throws -> Any? {
-      return try self.unarchiveTopLevelObjectWithData(data as NSData)
+    var error: NSError?
+    let result = __NSKeyedUnarchiverUnarchiveObject(self, data as NSData, &error)
+    try resolveError(error)
+    return result
   }
 }
 


### PR DESCRIPTION
**What's in this pull request?**
Reverts and modifies the changes made in #10474. We'd prefer to take a different approach here.

The `unarchiveTopLevelObjectWithData` which returns `Any?` (instead of `AnyObject?`) was added in Swift 4 and has only shipped in the betas so far. Instead of adding new overloads which take different types, we should just fix this one and call it a day.