### PR TITLE
Allow Codable classes to share an Encoder with superclass

### DIFF
--- a/stdlib/public/SDK/Foundation/JSONEncoder.swift
+++ b/stdlib/public/SDK/Foundation/JSONEncoder.swift
@@ -190,7 +190,7 @@ fileprivate class _JSONEncoder : Encoder {
     /// Returns whether a new element can be encoded at this coding path.
     ///
     /// `true` if an element has not yet been encoded at this coding path; `false` otherwise.
-    var canEncodeNewElement: Bool {
+    var canEncodeNewValue: Bool {
         // Every time a new value gets encoded, the key it's encoded for is pushed onto the coding path (even if it's a nil key from an unkeyed container).
         // At the same time, every time a container is requested, a new value gets pushed onto the storage stack.
         // If there are more values on the storage stack than on the coding path, it means the value is requesting more than one container, which violates the precondition.
@@ -200,39 +200,43 @@ fileprivate class _JSONEncoder : Encoder {
         return self.storage.count == self.codingPath.count
     }
 
-    /// Asserts that a new container can be requested at this coding path.
-    /// `preconditionFailure()`s if one cannot be requested.
-    func assertCanRequestNewContainer() {
-        guard self.canEncodeNewElement else {
-            let previousContainerType: String
-            if self.storage.containers.last is NSDictionary {
-                previousContainerType = "keyed"
-            } else if self.storage.containers.last is NSArray {
-                previousContainerType = "unkeyed"
-            } else {
-                previousContainerType = "single value"
-            }
-
-            preconditionFailure("Attempt to encode with new container when already encoded with \(previousContainerType) container.")
-        }
-    }
-
     // MARK: - Encoder Methods
     func container<Key>(keyedBy: Key.Type) -> KeyedEncodingContainer<Key> {
-        assertCanRequestNewContainer()
-        let topContainer = self.storage.pushKeyedContainer()
+        // If an existing keyed container was already requested, return that one.
+        let topContainer: NSMutableDictionary
+        if self.canEncodeNewValue {
+            // We haven't yet pushed a container at this level; do so here.
+            topContainer = self.storage.pushKeyedContainer()
+        } else {
+            guard let container = self.storage.containers.last as? NSMutableDictionary else {
+                preconditionFailure("Attempt to push new keyed encoding container when already previously encoded at this path.")
+            }
+
+            topContainer = container
+        }
+
         let container = _JSONKeyedEncodingContainer<Key>(referencing: self, codingPath: self.codingPath, wrapping: topContainer)
         return KeyedEncodingContainer(container)
     }
 
     func unkeyedContainer() -> UnkeyedEncodingContainer {
-        assertCanRequestNewContainer()
-        let topContainer = self.storage.pushUnkeyedContainer()
+        // If an existing unkeyed container was already requested, return that one.
+        let topContainer: NSMutableArray
+        if self.canEncodeNewValue {
+            // We haven't yet pushed a container at this level; do so here.
+            topContainer = self.storage.pushUnkeyedContainer()
+        } else {
+            guard let container = self.storage.containers.last as? NSMutableArray else {
+                preconditionFailure("Attempt to push new unkeyed encoding container when already previously encoded at this path.")
+            }
+
+            topContainer = container
+        }
+
         return _JSONUnkeyedEncodingContainer(referencing: self, codingPath: self.codingPath, wrapping: topContainer)
     }
 
     func singleValueContainer() -> SingleValueEncodingContainer {
-        assertCanRequestNewContainer()
         return self
     }
 }
@@ -474,106 +478,89 @@ fileprivate struct _JSONUnkeyedEncodingContainer : UnkeyedEncodingContainer {
 }
 
 extension _JSONEncoder : SingleValueEncodingContainer {
-    // MARK: - Utility Methods
-
-    /// Asserts that a single value can be encoded at the current coding path (i.e. that one has not already been encoded through this container).
-    /// `preconditionFailure()`s if one cannot be encoded.
-    ///
-    /// This is similar to assertCanRequestNewContainer above.
-    func assertCanEncodeSingleValue() {
-        guard self.canEncodeNewElement else {
-            let previousContainerType: String
-            if self.storage.containers.last is NSDictionary {
-                previousContainerType = "keyed"
-            } else if self.storage.containers.last is NSArray {
-                previousContainerType = "unkeyed"
-            } else {
-                preconditionFailure("Attempt to encode multiple values in a single value container.")
-            }
-
-            preconditionFailure("Attempt to encode with new container when already encoded with \(previousContainerType) container.")
-        }
-    }
-
     // MARK: - SingleValueEncodingContainer Methods
 
+    func assertCanEncodeNewValue() {
+        precondition(self.canEncodeNewValue, "Attempt to encode value through single value container when previously value already encoded.")
+    }
+
     func encodeNil() throws {
-        assertCanEncodeSingleValue()
+        assertCanEncodeNewValue()
         self.storage.push(container: NSNull())
     }
 
     func encode(_ value: Bool) throws {
-        assertCanEncodeSingleValue()
+        assertCanEncodeNewValue()
         self.storage.push(container: box(value))
     }
 
     func encode(_ value: Int) throws {
-        assertCanEncodeSingleValue()
+        assertCanEncodeNewValue()
         self.storage.push(container: box(value))
     }
 
     func encode(_ value: Int8) throws {
-        assertCanEncodeSingleValue()
+        assertCanEncodeNewValue()
         self.storage.push(container: box(value))
     }
 
     func encode(_ value: Int16) throws {
-        assertCanEncodeSingleValue()
+        assertCanEncodeNewValue()
         self.storage.push(container: box(value))
     }
 
     func encode(_ value: Int32) throws {
-        assertCanEncodeSingleValue()
+        assertCanEncodeNewValue()
         self.storage.push(container: box(value))
     }
 
     func encode(_ value: Int64) throws {
-        assertCanEncodeSingleValue()
+        assertCanEncodeNewValue()
         self.storage.push(container: box(value))
     }
 
     func encode(_ value: UInt) throws {
-        assertCanEncodeSingleValue()
+        assertCanEncodeNewValue()
         self.storage.push(container: box(value))
     }
 
     func encode(_ value: UInt8) throws {
-        assertCanEncodeSingleValue()
+        assertCanEncodeNewValue()
         self.storage.push(container: box(value))
     }
 
     func encode(_ value: UInt16) throws {
-        assertCanEncodeSingleValue()
+        assertCanEncodeNewValue()
         self.storage.push(container: box(value))
     }
 
     func encode(_ value: UInt32) throws {
-        assertCanEncodeSingleValue()
+        assertCanEncodeNewValue()
         self.storage.push(container: box(value))
     }
 
     func encode(_ value: UInt64) throws {
-        assertCanEncodeSingleValue()
+        assertCanEncodeNewValue()
         self.storage.push(container: box(value))
     }
 
     func encode(_ value: String) throws {
-        assertCanEncodeSingleValue()
+        assertCanEncodeNewValue()
         self.storage.push(container: box(value))
     }
 
     func encode(_ value: Float) throws {
-        assertCanEncodeSingleValue()
+        assertCanEncodeNewValue()
         try self.storage.push(container: box(value))
     }
 
     func encode(_ value: Double) throws {
-        assertCanEncodeSingleValue()
+        assertCanEncodeNewValue()
         try self.storage.push(container: box(value))
     }
 
     func encode<T : Encodable>(_ value: T) throws {
-        assertCanEncodeSingleValue()
+        assertCanEncodeNewValue()
         try self.storage.push(container: box(value))
     }
 }
@@ -763,7 +750,7 @@ fileprivate class _JSONReferencingEncoder : _JSONEncoder {
 
     // MARK: - Coding Path Operations
 
-    override var canEncodeNewElement: Bool {
+    override var canEncodeNewValue: Bool {
         // With a regular encoder, the storage and coding path grow together.
         // A referencing encoder, however, inherits its parents coding path, as well as the key it was created for.
         // We have to take this into account.

--- a/stdlib/public/SDK/Foundation/PlistEncoder.swift
+++ b/stdlib/public/SDK/Foundation/PlistEncoder.swift
@@ -122,7 +122,7 @@ fileprivate class _PlistEncoder : Encoder {
     /// Returns whether a new element can be encoded at this coding path.
     ///
     /// `true` if an element has not yet been encoded at this coding path; `false` otherwise.
-    var canEncodeNewElement: Bool {
+    var canEncodeNewValue: Bool {
         // Every time a new value gets encoded, the key it's encoded for is pushed onto the coding path (even if it's a nil key from an unkeyed container).
         // At the same time, every time a container is requested, a new value gets pushed onto the storage stack.
         // If there are more values on the storage stack than on the coding path, it means the value is requesting more than one container, which violates the precondition.
@@ -132,39 +132,43 @@ fileprivate class _PlistEncoder : Encoder {
         return self.storage.count == self.codingPath.count
     }
 
-    /// Asserts that a new container can be requested at this coding path.
-    /// `preconditionFailure()`s if one cannot be requested.
-    func assertCanRequestNewContainer() {
-        guard self.canEncodeNewElement else {
-            let previousContainerType: String
-            if self.storage.containers.last is NSDictionary {
-                previousContainerType = "keyed"
-            } else if self.storage.containers.last is NSArray {
-                previousContainerType = "unkeyed"
-            } else {
-                previousContainerType = "single value"
-            }
-
-            preconditionFailure("Attempt to encode with new container when already encoded with \(previousContainerType) container.")
-        }
-    }
-
     // MARK: - Encoder Methods
     func container<Key>(keyedBy: Key.Type) -> KeyedEncodingContainer<Key> {
-        assertCanRequestNewContainer()
-        let topContainer = self.storage.pushKeyedContainer()
+        // If an existing keyed container was already requested, return that one.
+        let topContainer: NSMutableDictionary
+        if self.canEncodeNewValue {
+            // We haven't yet pushed a container at this level; do so here.
+            topContainer = self.storage.pushKeyedContainer()
+        } else {
+            guard let container = self.storage.containers.last as? NSMutableDictionary else {
+                preconditionFailure("Attempt to push new keyed encoding container when already previously encoded at this path.")
+            }
+
+            topContainer = container
+        }
+
         let container = _PlistKeyedEncodingContainer<Key>(referencing: self, codingPath: self.codingPath, wrapping: topContainer)
         return KeyedEncodingContainer(container)
     }
 
     func unkeyedContainer() -> UnkeyedEncodingContainer {
-        assertCanRequestNewContainer()
-        let topContainer = self.storage.pushUnkeyedContainer()
+        // If an existing unkeyed container was already requested, return that one.
+        let topContainer: NSMutableArray
+        if self.canEncodeNewValue {
+            // We haven't yet pushed a container at this level; do so here.
+            topContainer = self.storage.pushUnkeyedContainer()
+        } else {
+            guard let container = self.storage.containers.last as? NSMutableArray else {
+                preconditionFailure("Attempt to push new unkeyed encoding container when already previously encoded at this path.")
+            }
+
+            topContainer = container
+        }
+
         return _PlistUnkeyedEncodingContainer(referencing: self, codingPath: self.codingPath, wrapping: topContainer)
     }
 
     func singleValueContainer() -> SingleValueEncodingContainer {
-        assertCanRequestNewContainer()
         return self
     }
 }
@@ -382,106 +386,89 @@ fileprivate struct _PlistUnkeyedEncodingContainer : UnkeyedEncodingContainer {
 }
 
 extension _PlistEncoder : SingleValueEncodingContainer {
-    // MARK: - Utility Methods
-
-    /// Asserts that a single value can be encoded at the current coding path (i.e. that one has not already been encoded through this container).
-    /// `preconditionFailure()`s if one cannot be encoded.
-    ///
-    /// This is similar to assertCanRequestNewContainer above.
-    func assertCanEncodeSingleValue() {
-        guard self.canEncodeNewElement else {
-            let previousContainerType: String
-            if self.storage.containers.last is NSDictionary {
-                previousContainerType = "keyed"
-            } else if self.storage.containers.last is NSArray {
-                previousContainerType = "unkeyed"
-            } else {
-                preconditionFailure("Attempt to encode multiple values in a single value container.")
-            }
-
-            preconditionFailure("Attempt to encode with new container when already encoded with \(previousContainerType) container.")
-        }
-    }
-
     // MARK: - SingleValueEncodingContainer Methods
 
+    func assertCanEncodeNewValue() {
+        precondition(self.canEncodeNewValue, "Attempt to encode value through single value container when previously value already encoded.")
+    }
+
     func encodeNil() throws {
-        assertCanEncodeSingleValue()
+        assertCanEncodeNewValue()
         self.storage.push(container: _plistNullNSString)
     }
 
     func encode(_ value: Bool) throws {
-        assertCanEncodeSingleValue()
+        assertCanEncodeNewValue()
         self.storage.push(container: box(value))
     }
 
     func encode(_ value: Int) throws {
-        assertCanEncodeSingleValue()
+        assertCanEncodeNewValue()
         self.storage.push(container: box(value))
     }
 
     func encode(_ value: Int8) throws {
-        assertCanEncodeSingleValue()
+        assertCanEncodeNewValue()
         self.storage.push(container: box(value))
     }
 
     func encode(_ value: Int16) throws {
-        assertCanEncodeSingleValue()
+        assertCanEncodeNewValue()
         self.storage.push(container: box(value))
     }
 
     func encode(_ value: Int32) throws {
-        assertCanEncodeSingleValue()
+        assertCanEncodeNewValue()
         self.storage.push(container: box(value))
     }
 
     func encode(_ value: Int64) throws {
-        assertCanEncodeSingleValue()
+        assertCanEncodeNewValue()
         self.storage.push(container: box(value))
     }
 
     func encode(_ value: UInt) throws {
-        assertCanEncodeSingleValue()
+        assertCanEncodeNewValue()
         self.storage.push(container: box(value))
     }
 
     func encode(_ value: UInt8) throws {
-        assertCanEncodeSingleValue()
+        assertCanEncodeNewValue()
         self.storage.push(container: box(value))
     }
 
     func encode(_ value: UInt16) throws {
-        assertCanEncodeSingleValue()
+        assertCanEncodeNewValue()
         self.storage.push(container: box(value))
     }
 
     func encode(_ value: UInt32) throws {
-        assertCanEncodeSingleValue()
+        assertCanEncodeNewValue()
         self.storage.push(container: box(value))
     }
 
     func encode(_ value: UInt64) throws {
-        assertCanEncodeSingleValue()
+        assertCanEncodeNewValue()
         self.storage.push(container: box(value))
     }
 
     func encode(_ value: String) throws {
-        assertCanEncodeSingleValue()
+        assertCanEncodeNewValue()
         self.storage.push(container: box(value))
     }
 
     func encode(_ value: Float) throws {
-        assertCanEncodeSingleValue()
+        assertCanEncodeNewValue()
         self.storage.push(container: box(value))
     }
 
     func encode(_ value: Double) throws {
-        assertCanEncodeSingleValue()
+        assertCanEncodeNewValue()
         self.storage.push(container: box(value))
     }
 
     func encode<T : Encodable>(_ value: T) throws {
-        assertCanEncodeSingleValue()
+        assertCanEncodeNewValue()
         try self.storage.push(container: box(value))
     }
 }
@@ -576,7 +563,7 @@ fileprivate class _PlistReferencingEncoder : _PlistEncoder {
 
     // MARK: - Coding Path Operations
 
-    override var canEncodeNewElement: Bool {
+    override var canEncodeNewValue: Bool {
         // With a regular encoder, the storage and coding path grow together.
         // A referencing encoder, however, inherits its parents coding path, as well as the key it was created for.
         // We have to take this into account.

--- a/test/stdlib/TestJSONEncoder.swift
+++ b/test/stdlib/TestJSONEncoder.swift
@@ -86,6 +86,12 @@ class TestJSONEncoder : TestJSONEncoderSuper {
     _testRoundTrip(of: company)
   }
 
+  func testEncodingClassWhichSharesEncoderWithSuper() {
+    // Employee is a type which shares its encoder & decoder with its superclass, Person.
+    let employee = Employee.testValue
+    _testRoundTrip(of: employee)
+  }
+
   // MARK: - Output Formatting Tests
   func testEncodingOutputFormattingDefault() {
     let expectedJSON = "{\"name\":\"Johnny Appleseed\",\"email\":\"appleseed@apple.com\"}".data(using: .utf8)!
@@ -527,10 +533,6 @@ fileprivate struct Address : Codable, Equatable {
 fileprivate class Person : Codable, Equatable {
   let name: String
   let email: String
-
-  // FIXME: This property is present only in order to test the expected result of Codable synthesis in the compiler.
-  // We want to test against expected encoded output (to ensure this generates an encodeIfPresent call), but we need an output format for that.
-  // Once we have a VerifyingEncoder for compiler unit tests, we should move this test there.
   let website: URL?
 
   init(name: String, email: String, website: URL? = nil) {
@@ -539,23 +541,86 @@ fileprivate class Person : Codable, Equatable {
     self.website = website
   }
 
-  static func ==(_ lhs: Person, _ rhs: Person) -> Bool {
-    return lhs.name == rhs.name &&
-           lhs.email == rhs.email &&
-           lhs.website == rhs.website
+  private enum CodingKeys : String, CodingKey {
+    case name
+    case email
+    case website
   }
 
-  static var testValue: Person {
+  // FIXME: Remove when subclasses (Employee) are able to override synthesized conformance.
+  required init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    name = try container.decode(String.self, forKey: .name)
+    email = try container.decode(String.self, forKey: .email)
+    website = try container.decodeIfPresent(URL.self, forKey: .website)
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(name, forKey: .name)
+    try container.encode(email, forKey: .email)
+    try container.encodeIfPresent(website, forKey: .website)
+  }
+
+  func isEqual(_ other: Person) -> Bool {
+    return self.name == other.name &&
+           self.email == other.email &&
+           self.website == other.website
+  }
+
+  static func ==(_ lhs: Person, _ rhs: Person) -> Bool {
+    return lhs.isEqual(rhs)
+  }
+
+  class var testValue: Person {
     return Person(name: "Johnny Appleseed", email: "appleseed@apple.com")
+  }
+}
+
+/// A class which shares its encoder and decoder with its superclass.
+fileprivate class Employee : Person {
+  let id: Int
+
+  init(name: String, email: String, website: URL? = nil, id: Int) {
+    self.id = id
+    super.init(name: name, email: email, website: website)
+  }
+
+  enum CodingKeys : String, CodingKey {
+    case id
+  }
+
+  required init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    id = try container.decode(Int.self, forKey: .id)
+    try super.init(from: decoder)
+  }
+
+  override func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(id, forKey: .id)
+    try super.encode(to: encoder)
+  }
+
+  override func isEqual(_ other: Person) -> Bool {
+    if let employee = other as? Employee {
+      guard self.id == employee.id else { return false }
+    }
+
+    return super.isEqual(other)
+  }
+
+  override class var testValue: Employee {
+    return Employee(name: "Johnny Appleseed", email: "appleseed@apple.com", id: 42)
   }
 }
 
 /// A simple company struct which encodes as a dictionary of nested values.
 fileprivate struct Company : Codable, Equatable {
   let address: Address
-  var employees: [Person]
+  var employees: [Employee]
 
-  init(address: Address, employees: [Person]) {
+  init(address: Address, employees: [Employee]) {
     self.address = address
     self.employees = employees
   }
@@ -565,7 +630,7 @@ fileprivate struct Company : Codable, Equatable {
   }
 
   static var testValue: Company {
-    return Company(address: Address.testValue, employees: [Person.testValue])
+    return Company(address: Address.testValue, employees: [Employee.testValue])
   }
 }
 
@@ -797,6 +862,7 @@ JSONEncoderTests.test("testEncodingTopLevelStructuredClass") { TestJSONEncoder()
 JSONEncoderTests.test("testEncodingTopLevelStructuredSingleStruct") { TestJSONEncoder().testEncodingTopLevelStructuredSingleStruct() }
 JSONEncoderTests.test("testEncodingTopLevelStructuredSingleClass") { TestJSONEncoder().testEncodingTopLevelStructuredSingleClass() }
 JSONEncoderTests.test("testEncodingTopLevelDeepStructuredType") { TestJSONEncoder().testEncodingTopLevelDeepStructuredType()}
+JSONEncoderTests.test("testEncodingClassWhichSharesEncoderWithSuper") { TestJSONEncoder().testEncodingClassWhichSharesEncoderWithSuper() }
 JSONEncoderTests.test("testEncodingOutputFormattingDefault") { TestJSONEncoder().testEncodingOutputFormattingDefault() }
 JSONEncoderTests.test("testEncodingOutputFormattingPrettyPrinted") { TestJSONEncoder().testEncodingOutputFormattingPrettyPrinted() }
 JSONEncoderTests.test("testEncodingOutputFormattingSortedKeys") { TestJSONEncoder().testEncodingOutputFormattingSortedKeys() }


### PR DESCRIPTION
**What's in this pull request?**
Addresses [SR-5277](https://bugs.swift.org/browse/SR-5277).

On encode, we previously treated every container request as a push; instead, we should allow the same container type to be requested multiple times so a class can pass its Encoder directly to its superclass if it needs to.