### PR TITLE
[Markup] Print Tags in documentation comment XML

### DIFF
--- a/bindings/xml/comment-xml-schema.rng
+++ b/bindings/xml/comment-xml-schema.rng
@@ -47,6 +47,9 @@
           <ref name="ResultDiscussion" />
         </optional>
         <optional>
+          <ref name="Tags" />
+        </optional>
+        <optional>
           <ref name="Discussion" />
         </optional>
       </element>
@@ -116,6 +119,9 @@
           <ref name="ResultDiscussion" />
         </optional>
         <optional>
+          <ref name="Tags" />
+        </optional>
+        <optional>
           <ref name="Discussion" />
         </optional>
     </element>
@@ -166,6 +172,9 @@
         <optional>
           <ref name="ResultDiscussion" />
         </optional>
+        <optional>
+          <ref name="Tags" />
+        </optional>
 
         <optional>
           <ref name="Discussion" />
@@ -208,6 +217,9 @@
         </optional>
         <optional>
           <ref name="ResultDiscussion" />
+        </optional>
+        <optional>
+          <ref name="Tags" />
         </optional>
 
         <optional>
@@ -252,6 +264,9 @@
         <optional>
           <ref name="ResultDiscussion" />
         </optional>
+        <optional>
+          <ref name="Tags" />
+        </optional>
 
         <optional>
           <ref name="Discussion" />
@@ -293,6 +308,9 @@
         </optional>
         <optional>
           <ref name="ResultDiscussion" />
+        </optional>
+        <optional>
+          <ref name="Tags" />
         </optional>
 
         <optional>
@@ -336,6 +354,9 @@
         </optional>
         <optional>
           <ref name="ResultDiscussion" />
+        </optional>
+        <optional>
+          <ref name="Tags" />
         </optional>
 
         <optional>
@@ -635,6 +656,16 @@
           <element name="Discussion">
             <ref name="BlockContent" />
           </element>
+        </element>
+      </oneOrMore>
+    </element>
+  </define>
+
+  <define name="Tags">
+    <element name="Tags">
+      <oneOrMore>
+        <element name="Tag">
+          <data type="string" />
         </element>
       </oneOrMore>
     </element>

--- a/lib/IDE/CommentConversion.cpp
+++ b/lib/IDE/CommentConversion.cpp
@@ -245,6 +245,19 @@ struct CommentToXMLConverter {
     OS << "</ThrowsDiscussion>";
   }
 
+  void printTagFields(ArrayRef<StringRef> Tags) {
+    OS << "<Tags>";
+    for (const auto Tag : Tags) {
+      if (Tag.empty()) {
+        continue;
+      }
+      OS << "<Tag>";
+      appendWithXMLEscaping(OS, Tag);
+      OS << "</Tag>";
+    }
+    OS << "</Tags>";
+  }
+
   void visitDocComment(const DocComment *DC);
   void visitCommentParts(const swift::markup::CommentParts &Parts);
 };
@@ -270,6 +283,10 @@ void CommentToXMLConverter::visitCommentParts(const swift::markup::CommentParts 
 
   if (Parts.ThrowsField.hasValue())
     printThrowsDiscussion(Parts.ThrowsField.getValue());
+
+  if (!Parts.Tags.empty()) {
+    printTagFields(Parts.Tags);
+  }
 
   if (!Parts.BodyNodes.empty()) {
     OS << "<Discussion>";

--- a/test/Inputs/comment_to_something_conversion.swift
+++ b/test/Inputs/comment_to_something_conversion.swift
@@ -477,3 +477,15 @@ public func localizationKeyShouldNotAppearInDocComments() {}
 /// - LocalizationKey: ABC
 public func localizationKeyShouldNotAppearInDocComments2() {}
 // CHECK: DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>localizationKeyShouldNotAppearInDocComments2()</Name><USR>s:14comment_to_xml44localizationKeyShouldNotAppearInDocComments2yyF</USR><Declaration>public func localizationKeyShouldNotAppearInDocComments2()</Declaration><CommentParts></CommentParts></Function>]
+
+/// Brief.
+///
+/// - Tag:
+/// - Tag:  
+/// - Tag: Tag_A
+/// - Tag: Tag B
+/// - Tag: Dedupe tag
+/// - Tag: Dedupe tag
+/// - TAG: TAG_C
+public func tags() {}
+// CHECK: DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>tags()</Name><USR>s:14comment_to_xml4tagsyyF</USR><Declaration>public func tags()</Declaration><CommentParts><Abstract><Para>Brief.</Para></Abstract><Tags><Tag>Tag_A</Tag><Tag>Tag B</Tag><Tag>Dedupe tag</Tag><Tag>TAG_C</Tag></Tags></CommentParts></Function>]


### PR DESCRIPTION
This information needs to be picked up through SourceKit. It might be
useful as both metadata for sorting/filtering as well as presentation,
so it makes sense to print it in the normal XML inside CommentParts.

rdar://problem/32877771