### PR TITLE
[4.0] [ClangImporter] Fix indirection mismatch surrounding swift_newtype

### DIFF
--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -424,22 +424,12 @@ enum class ConventionsKind : uint8_t {
                 ClassDecl::ForeignKind::CFType) {
             return false;
           }
-          // swift_newtype-ed CF type as foreign class
-          if (auto typedefTy = clangTy->getAs<clang::TypedefType>()) {
-            if (typedefTy->getDecl()->getAttr<clang::SwiftNewtypeAttr>()) {
-              // Make sure that we actually made the struct during import
-              if (auto underlyingType =
-                      substTy->getSwiftNewtypeUnderlyingType()) {
-                if (auto underlyingClass =
-                        underlyingType->getClassOrBoundGenericClass()) {
-                  if (underlyingClass->getForeignClassKind() ==
-                          ClassDecl::ForeignKind::CFType) {
-                    return false;
-                  }
-                }
-              }
-            }
-          }
+        }
+
+        // swift_newtypes are always passed directly
+        if (auto typedefTy = clangTy->getAs<clang::TypedefType>()) {
+          if (typedefTy->getDecl()->getAttr<clang::SwiftNewtypeAttr>())
+            return false;
         }
 
         return true;

--- a/test/IDE/Inputs/custom-modules/Newtype.h
+++ b/test/IDE/Inputs/custom-modules/Newtype.h
@@ -102,3 +102,29 @@ __attribute((swift_name("NSSomeContext.Name")));
 
 extern const NSSomeContextName NSMyContextName;
 
+typedef struct T *TRef __attribute((swift_newtype(struct)));
+typedef const struct T *ConstTRef __attribute((swift_newtype(struct)));
+extern _Nonnull TRef create_T(void);
+extern _Nonnull ConstTRef create_ConstT(void);
+extern void destroy_T(TRef);
+extern void destroy_ConstT(ConstTRef);
+
+extern void mutate_TRef_Pointee(TRef) __attribute((swift_name("TRef.mutatePointee(self:)")));
+extern void mutate_TRef(TRef *) __attribute((swift_name("TRef.mutate(self:)")));
+extern void use_ConstT(ConstTRef)
+    __attribute((swift_name("ConstTRef.use(self:)")));
+
+
+typedef struct T *__nonnull *TRefRef __attribute((swift_newtype(struct)));
+typedef struct T *__nonnull const *ConstTRefRef __attribute((swift_newtype(struct)));
+extern _Nonnull TRefRef create_TRef(void);
+extern _Nonnull ConstTRefRef create_ConstTRef(void);
+extern void destroy_TRef(TRefRef);
+extern void destroy_ConstTRef(ConstTRefRef);
+
+extern void mutate_TRefRef_Pointee(TRefRef)
+    __attribute((swift_name("TRefRef.mutatePointee(self:)")));
+extern void mutate_TRefRef(TRefRef*)
+    __attribute((swift_name("TRefRef.mutate(self:)")));
+extern void use_ConstTRef(ConstTRefRef)
+    __attribute((swift_name("ConstTRefRef.use(self:)")));

--- a/test/IDE/newtype.swift
+++ b/test/IDE/newtype.swift
@@ -150,6 +150,54 @@
 // PRINT-NEXT:  extension NSSomeContext.Name {
 // PRINT-NEXT:    static let myContextName: NSSomeContext.Name
 // PRINT-NEXT:  }
+//
+// PRINT-NEXT: struct TRef : RawRepresentable, _SwiftNewtypeWrapper, Equatable, Hashable {
+// PRINT-NEXT:   init(_ rawValue: OpaquePointer)
+// PRINT-NEXT:   init(rawValue: OpaquePointer)
+// PRINT-NEXT:   let rawValue: OpaquePointer
+// PRINT-NEXT:   typealias RawValue = OpaquePointer
+// PRINT-NEXT: }
+// PRINT-NEXT: struct ConstTRef : RawRepresentable, _SwiftNewtypeWrapper, Equatable, Hashable {
+// PRINT-NEXT:   init(_ rawValue: OpaquePointer)
+// PRINT-NEXT:   init(rawValue: OpaquePointer)
+// PRINT-NEXT:   let rawValue: OpaquePointer
+// PRINT-NEXT:   typealias RawValue = OpaquePointer
+// PRINT-NEXT: }
+// PRINT-NEXT: func create_T() -> TRef
+// PRINT-NEXT: func create_ConstT() -> ConstTRef
+// PRINT-NEXT: func destroy_T(_: TRef!)
+// PRINT-NEXT: func destroy_ConstT(_: ConstTRef!)
+// PRINT-NEXT: extension TRef {
+// PRINT-NEXT:   func mutatePointee()
+// PRINT-NEXT:   mutating func mutate()
+// PRINT-NEXT: }
+// PRINT-NEXT: extension ConstTRef {
+// PRINT-NEXT:   func use()
+// PRINT-NEXT: }
+//
+// PRINT-NEXT: struct TRefRef : RawRepresentable, _SwiftNewtypeWrapper, Equatable, Hashable {
+// PRINT-NEXT:   init(_ rawValue: UnsafeMutablePointer<OpaquePointer>)
+// PRINT-NEXT:   init(rawValue: UnsafeMutablePointer<OpaquePointer>)
+// PRINT-NEXT:   let rawValue: UnsafeMutablePointer<OpaquePointer>
+// PRINT-NEXT:   typealias RawValue = UnsafeMutablePointer<OpaquePointer>
+// PRINT-NEXT: }
+// PRINT-NEXT: struct ConstTRefRef : RawRepresentable, _SwiftNewtypeWrapper, Equatable, Hashable {
+// PRINT-NEXT:   init(_ rawValue: UnsafePointer<OpaquePointer>)
+// PRINT-NEXT:   init(rawValue: UnsafePointer<OpaquePointer>)
+// PRINT-NEXT:   let rawValue: UnsafePointer<OpaquePointer>
+// PRINT-NEXT:   typealias RawValue = UnsafePointer<OpaquePointer>
+// PRINT-NEXT: }
+// PRINT-NEXT: func create_TRef() -> TRefRef
+// PRINT-NEXT: func create_ConstTRef() -> ConstTRefRef
+// PRINT-NEXT: func destroy_TRef(_: TRefRef!)
+// PRINT-NEXT: func destroy_ConstTRef(_: ConstTRefRef!)
+// PRINT-NEXT: extension TRefRef {
+// PRINT-NEXT:   func mutatePointee()
+// PRINT-NEXT:   mutating func mutate()
+// PRINT-NEXT: }
+// PRINT-NEXT: extension ConstTRefRef {
+// PRINT-NEXT:   func use()
+// PRINT-NEXT: }
 
 import Newtype
 

--- a/test/IRGen/newtype.swift
+++ b/test/IRGen/newtype.swift
@@ -167,9 +167,9 @@ public func mutate() {
   // rather than passing a pointer indirectly. I.e. only 1 overall level of
   // indirection for non-mutating, 2 for mutating.
   //
-  // OPT: [[TRefAlloca:%.+]] = alloca %struct.T*, align 8
+  // OPT: [[TRefAlloca:%.+]] = alloca %struct.T*,
   // OPT: [[TRef:%.+]] = tail call %struct.T* @create_T()
-  // OPT: store %struct.T* [[TRef]], %struct.T** [[TRefAlloca]], align 8
+  // OPT: store %struct.T* [[TRef]], %struct.T** [[TRefAlloca]],
   var myT = create_T()
 
   // OPT: [[TRefConst:%.+]] = tail call %struct.T* @create_ConstT()
@@ -183,7 +183,7 @@ public func mutate() {
 
   // Since myT itself got mutated, now we have to reload from the alloca
   //
-  // OPT: [[TRefReloaded:%.+]] = load %struct.T*, %struct.T** [[TRefAlloca]], align 8
+  // OPT: [[TRefReloaded:%.+]] = load %struct.T*, %struct.T** [[TRefAlloca]],
   // OPT: call void @mutate_TRef_Pointee(%struct.T* [[TRefReloaded]])
   myT.mutatePointee()
 
@@ -200,9 +200,9 @@ public func mutateRef() {
   // a pointer pointer indirectly. I.e. only 2 overall levels of indirection for
   // non-mutating, 3 for mutating.
   //
-  // OPT: [[TRefRefAlloca:%.+]] = alloca %struct.T**, align 8
+  // OPT: [[TRefRefAlloca:%.+]] = alloca %struct.T**,
   // OPT: [[TRefRef:%.+]] = tail call %struct.T** @create_TRef()
-  // OPT: store %struct.T** [[TRefRef]], %struct.T*** [[TRefRefAlloca]], align 8
+  // OPT: store %struct.T** [[TRefRef]], %struct.T*** [[TRefRefAlloca]]
   var myTRef = create_TRef()
 
   // OPT: [[ConstTRefRef:%.+]] = tail call %struct.T** @create_ConstTRef()
@@ -216,7 +216,7 @@ public func mutateRef() {
 
   // Since myTRef itself got mutated, now we have to reload from the alloca
   //
-  // OPT: [[TRefReloaded:%.+]] = load %struct.T**, %struct.T*** [[TRefRefAlloca]], align 8
+  // OPT: [[TRefReloaded:%.+]] = load %struct.T**, %struct.T*** [[TRefRefAlloca]]
   // OPT: call void @mutate_TRefRef_Pointee(%struct.T** [[TRefReloaded]])
   myTRef.mutatePointee()
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
4.0 cherry-pick version of https://github.com/apple/swift/pull/10254.

CCC
Explanation: We were passing swift_newtype-ed typedefs with a wrong level of indirection when passed as inout self, as we were trying to model value semantics of the pointee rather the pointer. This fixes that and simplifies SILGen a little.
Scope: Limited, as it is in the intersection of swift_newtype and import-as-member. However, when it does come up, it's disastrous.
Radar (and possibly SR Issue): rdar://problem/26899737
Risk: Low, has limited scope. There is a chance someone could of been relying on the broken behavior, but that's unlikely.
Testing: Full CI testing.
