### PR TITLE
[4.0] Change the signature of reportToDebugger and _swift_runtime_on_report to avoid using 'bool'

### DIFF
--- a/include/swift/Runtime/Debug.h
+++ b/include/swift/Runtime/Debug.h
@@ -171,9 +171,14 @@ struct RuntimeErrorDetails {
   Thread *threads;
 };
 
+enum: uintptr_t {
+  RuntimeErrorFlagNone = 0,
+  RuntimeErrorFlagFatal = 1 << 0
+};
+
 /// Debugger hook. Calling this stops the debugger with a message and details
 /// about the issues.
-void reportToDebugger(bool isFatal, const char *message,
+void reportToDebugger(uintptr_t flags, const char *message,
                       RuntimeErrorDetails *details = nullptr);
 
 // namespace swift

--- a/stdlib/public/runtime/Errors.cpp
+++ b/stdlib/public/runtime/Errors.cpp
@@ -240,21 +240,21 @@ reportNow(uint32_t flags, const char *message)
 }
 
 LLVM_ATTRIBUTE_NOINLINE SWIFT_RUNTIME_EXPORT
-void _swift_runtime_on_report(bool isFatal, const char *message,
+void _swift_runtime_on_report(uintptr_t flags, const char *message,
                               RuntimeErrorDetails *details) {
   // Do nothing. This function is meant to be used by the debugger.
 
   // The following is necessary to avoid calls from being optimized out.
   asm volatile("" // Do nothing.
                : // Output list, empty.
-               : "r" (isFatal), "r" (message), "r" (details) // Input list.
+               : "r" (flags), "r" (message), "r" (details) // Input list.
                : // Clobber list, empty.
                );
 }
 
-void swift::reportToDebugger(bool isFatal, const char *message,
+void swift::reportToDebugger(uintptr_t flags, const char *message,
                              RuntimeErrorDetails *details) {
-  _swift_runtime_on_report(isFatal, message, details);
+  _swift_runtime_on_report(flags, message, details);
 }
 
 /// Report a fatal error to system console, stderr, and crash logs.

--- a/stdlib/public/runtime/Exclusivity.cpp
+++ b/stdlib/public/runtime/Exclusivity.cpp
@@ -121,7 +121,10 @@ static void reportExclusivityConflict(ExclusivityFlags oldAction, void *oldPC,
     .numExtraThreads = 1,
     .threads = &secondaryThread
   };
-  reportToDebugger(!keepGoing, message, &details);
+  uintptr_t flags = RuntimeErrorFlagNone;
+  if (!keepGoing)
+    flags = RuntimeErrorFlagFatal;
+  reportToDebugger(flags, message, &details);
 
   if (keepGoing) {
     return;

--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -1440,8 +1440,10 @@ void swift_objc_swift3ImplicitObjCEntrypoint(id self, SEL selector,
     .errorType = "implicit-objc-entrypoint",
     .framesToSkip = 1
   };
-  bool isFatal = reporter == swift::fatalError;
-  reportToDebugger(isFatal, message, &details);
+  uintptr_t runtime_error_flags = RuntimeErrorFlagNone;
+  if (reporter == swift::fatalError)
+    runtime_error_flags = RuntimeErrorFlagFatal;
+  reportToDebugger(runtime_error_flags, message, &details);
 
   reporter(flags,
            "*** %s:%zu:%zu: %s; add explicit '@objc' to the declaration to "


### PR DESCRIPTION
Change the signature of reportToDebugger and _swift_runtime_on_report to avoid using 'bool'. It's much easier to work with native-width integers only in LLDB.