### PR TITLE
[index] Add missing parameter and return type references in subscript declarations

### DIFF
--- a/test/Index/kinds.swift
+++ b/test/Index/kinds.swift
@@ -37,6 +37,9 @@ struct AStruct {
       return base
     }
   }
+  // CHECK: [[@LINE-20]]:13 | param/Swift | index | {{.*}} | Def,RelChild | rel: 1
+  // CHECK: [[@LINE-21]]:20 | struct/Swift | Int | {{.*}} | Ref | rel: 0
+  // CHECK: [[@LINE-22]]:28 | struct/Swift | Int | {{.*}} | Ref | rel: 0
 }
 
 // Class


### PR DESCRIPTION
<!-- What's in this pull request? -->
Subscript return types, parameters, and parameter types were not being indexed, so were being missed in rename operations. This patch removes the special case code for subscripts that was preventing these from being indexed.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves rdar://problem/32314185.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->