### PR TITLE
[Constraint solver] Gather constraints from adjacencies of equiv class.

### DIFF
--- a/test/Constraints/gather_all_adjacencies.swift
+++ b/test/Constraints/gather_all_adjacencies.swift
@@ -1,0 +1,38 @@
+// RUN: %target-swift-frontend -typecheck %s
+
+// SR-5120 / rdar://problem/32618740
+protocol InitCollection: Collection {
+  init(_ array: [Iterator.Element])
+}
+
+protocol InitAny {
+  init()
+}
+
+extension Array: InitCollection {
+  init(_ array: [Iterator.Element]) {
+    self = array
+  }
+}
+
+extension String: InitAny {
+  init() {
+    self = "bar"
+  }
+}
+
+class Foo {
+  func foo<T: InitCollection, U: InitAny>(of type: U.Type) -> T
+  where T.Iterator.Element == U
+  {
+    return T.init([U.init()])
+  }
+
+  func foo<T: InitCollection, U: InitAny>(of type: U.Type) -> T?
+  where T.Iterator.Element == U
+  {
+    return T.init([U.init()])
+  }
+}
+
+let _: [String] = Foo().foo(of: String.self)


### PR DESCRIPTION
    When gathering constraints for a type variable, we were gathering all of
    the constraints for the members of the equivalence class, and then for
    the adjacencies of the representative of the equivalence class, but not
    from the adjacencies of other members of the equivalence class.
    
    For example for:
      #3 = $T3
      #4 = $T4 equivalent to $T3
      #5 = $T5 as $T4.Element
    
    after binding $T3 we would collect the constraints related to $T3 and
    $T4, but not $T5. The end result can be that we finish examining all
    disjunctions and type bindings but still have inactive constraints in
    the constraint graph, which is treated as a failure in the solver.
    
    Fixes SR-5120 / rdar://problem/32618740.
