### PR TITLE
[4.0] [ClangImporter] Fix importType to return interface types for generic parameters

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -128,7 +128,7 @@ createVarWithPattern(ASTContext &cxt, DeclContext *dc, Identifier name, Type ty,
       /*IsStatic*/false,
       /*IsLet*/isLet,
       /*IsCaptureList*/false,
-      SourceLoc(), name, ty, dc);
+      SourceLoc(), name, dc->mapTypeIntoContext(ty), dc);
   if (isImplicit)
     var->setImplicit();
   var->setInterfaceType(ty);
@@ -3167,7 +3167,7 @@ namespace {
                        /*IsStatic*/false, /*IsLet*/ false,
                        /*IsCaptureList*/false,
                        Impl.importSourceLoc(decl->getLocStart()),
-                       name, type, dc);
+                       name, dc->mapTypeIntoContext(type), dc);
       result->setInterfaceType(type);
 
       // If this is a compatibility stub, mark is as such.
@@ -3388,7 +3388,7 @@ namespace {
                               /*IsStatic*/ false, /*IsLet*/ false,
                               /*IsCaptureList*/false,
                               Impl.importSourceLoc(decl->getLocation()),
-                              name, type, dc);
+                              name, dc->mapTypeIntoContext(type), dc);
       result->setInterfaceType(type);
 
       // Handle attributes.
@@ -3464,7 +3464,7 @@ namespace {
                        /*IsLet*/Impl.shouldImportGlobalAsLet(decl->getType()),
                        /*IsCaptureList*/false,
                        Impl.importSourceLoc(decl->getLocation()),
-                       name, type, dc);
+                       name, dc->mapTypeIntoContext(type), dc);
       result->setInterfaceType(type);
 
       // If imported as member, the member should be final.
@@ -4324,7 +4324,6 @@ namespace {
                                          isInSystemModule(dc),
                                          /*isFullyBridgeable*/false);
         if (superclassType) {
-          superclassType = result->mapTypeOutOfContext(superclassType);
           assert(superclassType->is<ClassType>() ||
                  superclassType->is<BoundGenericClassType>());
           inheritedTypes.push_back(TypeLoc::withoutLoc(superclassType));
@@ -4539,8 +4538,8 @@ namespace {
           getOverridableAccessibility(dc),
           /*IsStatic*/decl->isClassProperty(), /*IsLet*/false,
           /*IsCaptureList*/false, Impl.importSourceLoc(decl->getLocation()),
-          name, type, dc);
-      result->setInterfaceType(dc->mapTypeOutOfContext(type));
+          name, dc->mapTypeIntoContext(type), dc);
+      result->setInterfaceType(type);
 
       // Turn this into a computed property.
       // FIXME: Fake locations for '{' and '}'?
@@ -4930,6 +4929,7 @@ SwiftDeclConverter::importSwiftNewtype(const clang::TypedefNameDecl *decl,
   auto storedUnderlyingType = Impl.importType(
       decl->getUnderlyingType(), ImportTypeKind::Value, isInSystemModule(dc),
       decl->getUnderlyingType()->isBlockPointerType(), OTK_None);
+
   if (auto objTy = storedUnderlyingType->getAnyOptionalObjectType())
     storedUnderlyingType = objTy;
 
@@ -5474,7 +5474,8 @@ SwiftDeclConverter::getImplicitProperty(ImportedName importedName,
 
   auto property = Impl.createDeclWithClangNode<VarDecl>(
       getter, Accessibility::Public, /*IsStatic*/isStatic, /*isLet*/false,
-      /*IsCaptureList*/false, SourceLoc(), propertyName, swiftPropertyType, dc);
+      /*IsCaptureList*/false, SourceLoc(), propertyName,
+      dc->mapTypeIntoContext(swiftPropertyType), dc);
   property->setInterfaceType(swiftPropertyType);
 
   // Note that we've formed this property.
@@ -7692,11 +7693,11 @@ ClangImporter::Implementation::createConstant(Identifier name, DeclContext *dc,
     var = createDeclWithClangNode<VarDecl>(ClangN, Accessibility::Public,
                                            /*IsStatic*/isStatic, /*IsLet*/false,
                                            /*IsCaptureList*/false, SourceLoc(),
-                                           name, type, dc);
+                                           name, dc->mapTypeIntoContext(type), dc);
   } else {
     var = new (SwiftContext)
         VarDecl(/*IsStatic*/isStatic, /*IsLet*/false, /*IsCaptureList*/false,
-                SourceLoc(), name, type, dc);
+                SourceLoc(), name, dc->mapTypeIntoContext(type), dc);
   }
 
   var->setInterfaceType(type);

--- a/test/ClangImporter/Inputs/typedef-with-generic-param.h
+++ b/test/ClangImporter/Inputs/typedef-with-generic-param.h
@@ -1,0 +1,9 @@
+#import <Foundation/Foundation.h>
+
+@interface Foo <__covariant T>
+typedef void (^CompletionBlock)(T _Nullable result, NSError *_Nullable error);
+@end
+
+@interface Foo <T> (Convenience)
++ (Foo<T> *)fooWithCompletionBlock: (void (^)(CompletionBlock adapter))block;
+@end

--- a/test/ClangImporter/typedef_with_generic_param.swift
+++ b/test/ClangImporter/typedef_with_generic_param.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-frontend -typecheck %s -import-objc-header %S/Inputs/typedef-with-generic-param.h 2>&1
+
+// REQUIRES: OS=macosx
+
+typealias Result<T> = (T?, Error?)
+typealias Handler<T> = (Result<T>) -> Void
+
+func foo<T>(_ handler: Handler<T>?) {}
+
+let _ = Foo<AnyObject>(completionBlock: foo)


### PR DESCRIPTION
* Description: `ClangImporter`'s `importType` should always return interface types
for everything it imports, which helps to avoid tracking of declaration
contexts and remapping returned types in/out of them.

* Scope of the issue: Avoid unnecessarily mapping types in/out of the declaration context while
importing.

* Risk: Low.

* Tested: New test cases added, Swift CI.

* Reviewed by: Doug Gregor, Slava Pestov.

* Resolves: rdar://problem/32298667

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
