### PR TITLE
[4.0] [CMake] iOS simulator should still build 32-bit by default.

### DIFF
--- a/cmake/modules/DarwinSDKs.cmake
+++ b/cmake/modules/DarwinSDKs.cmake
@@ -25,7 +25,7 @@ is_sdk_requested(IOS_SIMULATOR swift_build_ios_simulator)
 if(swift_build_ios_simulator)
   configure_sdk_darwin(
       IOS_SIMULATOR "iOS Simulator" "${SWIFT_DARWIN_DEPLOYMENT_VERSION_IOS}"
-      iphonesimulator ios-simulator ios "x86_64")
+      iphonesimulator ios-simulator ios "i386;x86_64")
   configure_target_variant(
       IOS_SIMULATOR-DA "iOS Debug+Asserts"   IOS_SIMULATOR DA "Debug+Asserts")
   configure_target_variant(


### PR DESCRIPTION
- **Explanation**: The iOS simulator build was accidentally set to only build a 64-bit slice. Reactivate the 32-bit slice by adding "i386" back into the list of supported architectures.
- **Scope**: Affects all iOS simulator libraries (the stdlib and overlays, plus support libraries like StdlibUnittest)
- **Radar**: rdar://problem/32862833
- **Reviewed by**: @shahmishal 
- **Risk**: Very low. This was a previously working and tested configuration.
- **Testing**: Verified locally that both slices were being built once again.