### PR TITLE
[AST] Use ParenType for the input type of canonical function types.

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -1422,6 +1422,11 @@ public:
                                        : value - ParameterTypeFlags::Escaping);
   }
 
+  ParameterTypeFlags withInOut(bool isInout) const {
+    return ParameterTypeFlags(isInout ? value | ParameterTypeFlags::InOut
+                                      : value - ParameterTypeFlags::InOut);
+  }
+
   bool operator ==(const ParameterTypeFlags &other) const {
     return value.toRaw() == other.value.toRaw();
   }

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -2490,7 +2490,14 @@ public:
   /// \brief Break an input type into an array of \c AnyFunctionType::Params.
   static void decomposeInput(Type type,
                              SmallVectorImpl<AnyFunctionType::Param> &result);
-  
+
+  /// \brief Take an array of parameters and turn it into an input type.
+  ///
+  /// The result type is only there as a way to extract the ASTContext when
+  /// needed.
+  static Type composeInput(ASTContext &ctx, ArrayRef<Param> params,
+                           bool canonicalVararg);
+
   Type getInput() const { return Input; }
   Type getResult() const { return Output; }
   ArrayRef<AnyFunctionType::Param> getParams() const;
@@ -2521,6 +2528,10 @@ public:
     return getExtInfo().throws();
   }
 
+  /// Determine whether the given function input type is one of the
+  /// canonical forms.
+  static bool isCanonicalFunctionInputType(Type input);
+
   /// Returns a new function type exactly like this one but with the ExtInfo
   /// replaced.
   AnyFunctionType *withExtInfo(ExtInfo info) const;
@@ -2533,7 +2544,11 @@ public:
 };
 BEGIN_CAN_TYPE_WRAPPER(AnyFunctionType, Type)
   typedef AnyFunctionType::ExtInfo ExtInfo;
-  PROXY_CAN_TYPE_SIMPLE_GETTER(getInput)
+
+  CanType getInput() const {
+    return getPointer()->getInput()->getCanonicalType();
+  }
+
   PROXY_CAN_TYPE_SIMPLE_GETTER(getResult)
   
   CanAnyFunctionType withExtInfo(ExtInfo info) const {
@@ -2557,7 +2572,10 @@ public:
 
   static FunctionType *get(Type Input, Type Result, const ExtInfo &Info);
       
-      
+  static FunctionType *get(ArrayRef<AnyFunctionType::Param> params,
+                           Type result, const ExtInfo &info,
+                           bool canonicalVararg = false);
+
   // Retrieve the input parameters of this function type.
   ArrayRef<AnyFunctionType::Param> getParams() const {
     return {getTrailingObjects<AnyFunctionType::Param>(), getNumParams()};
@@ -2576,13 +2594,22 @@ private:
 };
 BEGIN_CAN_TYPE_WRAPPER(FunctionType, AnyFunctionType)
   static CanFunctionType get(CanType input, CanType result) {
-    return CanFunctionType(FunctionType::get(input, result));
+    return CanFunctionType(
+             FunctionType::get(input, result)
+               ->getCanonicalType()->castTo<FunctionType>());
   }
   static CanFunctionType get(CanType input, CanType result,
                              const ExtInfo &info) {
-    return CanFunctionType(FunctionType::get(input, result, info));
+    return CanFunctionType(
+             FunctionType::get(input, result, info)
+               ->getCanonicalType()->castTo<FunctionType>());
   }
-  
+  static CanFunctionType get(ArrayRef<AnyFunctionType::Param> params,
+                             Type result, const ExtInfo &info) {
+    return CanFunctionType(FunctionType::get(params, result, info,
+                                             /*canonicalVararg=*/true));
+  }
+
   CanFunctionType withExtInfo(ExtInfo info) const {
     return CanFunctionType(cast<FunctionType>(getPointer()->withExtInfo(info)));
   }
@@ -2634,7 +2661,14 @@ public:
                                   Type input,
                                   Type result,
                                   const ExtInfo &info);
-      
+
+  /// Create a new generic function type.
+  static GenericFunctionType *get(GenericSignature *sig,
+                                  ArrayRef<Param> params,
+                                  Type result,
+                                  const ExtInfo &info,
+                                  bool canonicalVararg = false);
+
   // Retrieve the input parameters of this function type.
   ArrayRef<AnyFunctionType::Param> getParams() const {
     return {getTrailingObjects<AnyFunctionType::Param>(), getNumParams()};
@@ -2690,7 +2724,19 @@ BEGIN_CAN_TYPE_WRAPPER(GenericFunctionType, AnyFunctionType)
     auto fnType = GenericFunctionType::get(sig, input, result, info);
     return cast<GenericFunctionType>(fnType->getCanonicalType());
   }
-  
+
+  /// Create a new generic function type.
+  static CanGenericFunctionType get(CanGenericSignature sig,
+                                    ArrayRef<AnyFunctionType::Param> params,
+                                    CanType result,
+                                    const ExtInfo &info) {
+    // Knowing that the argument types are independently canonical is
+    // not sufficient to guarantee that the function type will be canonical.
+    auto fnType = GenericFunctionType::get(sig, params, result, info,
+                                             /*canonicalVararg=*/true);
+    return cast<GenericFunctionType>(fnType->getCanonicalType());
+  }
+
   CanGenericSignature getGenericSignature() const {
     return CanGenericSignature(getPointer()->getGenericSignature());
   }

--- a/lib/AST/TypeWalker.cpp
+++ b/lib/AST/TypeWalker.cpp
@@ -73,8 +73,11 @@ class Traversal : public TypeVisitor<Traversal, bool>
   }
 
   bool visitAnyFunctionType(AnyFunctionType *ty) {
-    if (doIt(ty->getInput()))
-      return true;
+    for (const auto &param : ty->getParams()) {
+      if (doIt(param.getType()))
+        return true;
+    }
+
     return doIt(ty->getResult());
   }
 

--- a/lib/IDE/TypeReconstruction.cpp
+++ b/lib/IDE/TypeReconstruction.cpp
@@ -695,7 +695,8 @@ static void VisitNodeAddressor(
   // and they bear no connection to their original variable at the interface
   // level
   CanFunctionType swift_can_func_type =
-      CanFunctionType::get(ast->TheEmptyTupleType, ast->TheRawPointerType);
+    CanFunctionType::get({}, ast->TheRawPointerType,
+                         AnyFunctionType::ExtInfo());
   result._types.push_back(swift_can_func_type.getPointer());
 }
 

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -1692,8 +1692,9 @@ namespace {
       case SILFunctionType::Representation::Thick:
         // All function types look like () -> ().
         // FIXME: It'd be nice not to have to call through the runtime here.
-        return IGF.emitTypeMetadataRef(CanFunctionType::get(C.TheEmptyTupleType,
-                                                          C.TheEmptyTupleType));
+        return IGF.emitTypeMetadataRef(
+                 CanFunctionType::get({ }, C.TheEmptyTupleType,
+                                      AnyFunctionType::ExtInfo()));
       case SILFunctionType::Representation::Block:
         // All block types look like Builtin.UnknownObject.
         return emitDirectMetadataRef(C.TheUnknownObjectType);
@@ -1876,7 +1877,8 @@ namespace {
       case SILFunctionType::Representation::Thick:
         // All function types look like () -> ().
         return emitFromValueWitnessTable(
-                CanFunctionType::get(C.TheEmptyTupleType, C.TheEmptyTupleType));
+                 CanFunctionType::get({ }, C.TheEmptyTupleType,
+                                      AnyFunctionType::ExtInfo()));
       case SILFunctionType::Representation::Block:
         // All block types look like Builtin.UnknownObject.
         return emitFromValueWitnessTable(C.TheUnknownObjectType);

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -927,8 +927,7 @@ void IRGenModule::emitBuiltinReflectionMetadata() {
     // extra inhabitants as these. But maybe it's best not to codify
     // that in the ABI anyway.
     CanType thinFunction = CanFunctionType::get(
-      TupleType::getEmpty(Context),
-      TupleType::getEmpty(Context),
+      { }, Context.TheEmptyTupleType,
       AnyFunctionType::ExtInfo().withRepresentation(
           FunctionTypeRepresentation::Thin));
     BuiltinTypes.insert(thinFunction);

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -2318,7 +2318,7 @@ TypeConverter::getLoweredASTFunctionType(CanAnyFunctionType fnType,
 
   // Merge inputs and generic parameters from the uncurry levels.
   for (;;) {
-    inputs.push_back(TupleTypeElt(fnType->getInput()));
+    inputs.push_back(TupleTypeElt(fnType->getInput()->getCanonicalType()));
 
     // The uncurried function calls all of the intermediate function
     // levels and so throws if any of them do.

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -1891,12 +1891,11 @@ TypeConverter::getFunctionInterfaceTypeWithCaptures(CanAnyFunctionType funcType,
                                                funcType->throws());
 
   if (!genericSig)
-    return CanFunctionType::get(funcType.getInput(),
-                                funcType.getResult(),
+    return CanFunctionType::get(funcType->getParams(), funcType.getResult(),
                                 innerExtInfo);
-    
+
   return CanGenericFunctionType::get(genericSig,
-                                     funcType.getInput(),
+                                     funcType->getParams(),
                                      funcType.getResult(),
                                      innerExtInfo);
 }


### PR DESCRIPTION
As a step toward eliminating the single input type
representation of function parameters, add more constraints on that
input type. It can be one of:

* A tuple type, for multiple parameters,
* A parenthesized type, for a single parameter, or
* A type variable type, for specific cases in the type checker

Enforce these constraints for *canonical* types as well, so the
canonical form of:

    typealias MyInt = Int
    typealias MyFuncType = (MyInt) -> Int

is now:

    (Int) -> Int

rather than:

    Int -> Int

This affects canonicalization of `FunctionType` and
`GenericFunctionType`. Enhance both, as well as their `Can*Type`
counterparts, with "get" operators that take an array of
`AnyFunctionType::Param`, and start switching a few clients over to this
new, preferred API.
