### PR TITLE
[DO NOT MERGE] [build-script] iOS simulator should still build 32-bit by default.

### DIFF
--- a/utils/swift_build_support/swift_build_support/targets.py
+++ b/utils/swift_build_support/swift_build_support/targets.py
@@ -92,7 +92,7 @@ class StdlibDeploymentTarget(object):
 
     iOS = DarwinPlatform("iphoneos", archs=["armv7", "armv7s", "arm64"],
                          sdk_name="IOS")
-    iOSSimulator = DarwinPlatform("iphonesimulator", archs=["x86_64"],
+    iOSSimulator = DarwinPlatform("iphonesimulator", archs=["i386", "x86_64"],
                                   sdk_name="IOS_SIMULATOR",
                                   is_simulator=True)
 


### PR DESCRIPTION
build-script version of #10510.

rdar://problem/32862833
