### PR TITLE
[4.0][index] Add missing parameter and return type references in subscript declarations

### DIFF
--- a/test/Index/kinds.swift
+++ b/test/Index/kinds.swift
@@ -37,6 +37,9 @@ struct AStruct {
       return base
     }
   }
+  // CHECK: [[@LINE-20]]:13 | param/Swift | index | {{.*}} | Def,RelChild | rel: 1
+  // CHECK: [[@LINE-21]]:20 | struct/Swift | Int | {{.*}} | Ref | rel: 0
+  // CHECK: [[@LINE-22]]:28 | struct/Swift | Int | {{.*}} | Ref | rel: 0
 }
 
 // Class


### PR DESCRIPTION

* Explanation: The indexer wasn't covering subscript params or return types, resulting in a rename of any type references there failing and renames initiated on other occurrences of those types not updating them.
* Scope of Issue: Affects rename of symbols used in subscript param/return types.
* Radar: rdar://problem/32314185
* Origination: The indexer was explicitly avoiding indexing subscript indices, though its unclear why from (the 2013 commit message doesn't mention a reason).
* Risk: Low; This patch removes special case handling of subscripts.
* Testing: Added regression tests for these cases

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
