### PR TITLE
[Sema] Suggest #selector(self.foo) instead of #selector(TypeName.foo) when possible.

### DIFF
--- a/test/FixCode/fixits-apply-objc.swift
+++ b/test/FixCode/fixits-apply-objc.swift
@@ -13,6 +13,86 @@ import ObjectiveC
   }
 }
 
+@objc class OtherClass {
+  func test(s: Selectors) {
+    s.takeSel("mySel")
+    s.takeSel(Selector("mySel"))
+  }
+}
+
+@objc class Base {
+  func baseSel() {}
+}
+
+@objc class Outer {
+  func takeSel(_: Selector) {}
+  func outerSel() {}
+
+  @objc class Inner: Base {
+    func takeSel(_: Selector) {}
+
+    func innerSel() {}
+
+    func test(s: Selectors, o: Outer) {
+      s.takeSel("mySel")
+      s.takeSel(Selector("mySel"))
+
+      takeSel("innerSel")
+      takeSel(Selector("innerSel"))
+
+      takeSel("baseSel")
+      takeSel(Selector("baseSel"))
+
+      o.takeSel("outerSel")
+      o.takeSel(Selector("outerSel"))
+    }
+  }
+
+  func test(s: Selectors, i: Inner) {
+    s.takeSel("mySel")
+    s.takeSel(Selector("mySel"))
+
+    i.takeSel("innerSel")
+    i.takeSel(Selector("innerSel"))
+
+    i.takeSel("baseSel")
+    i.takeSel(Selector("baseSel"))
+
+    takeSel("outerSel")
+    takeSel(Selector("outerSel"))
+  }
+}
+
+extension Outer {
+  func test2(s: Selectors, i: Inner) {
+    s.takeSel("mySel")
+    s.takeSel(Selector("mySel"))
+
+    i.takeSel("innerSel")
+    i.takeSel(Selector("innerSel"))
+
+    i.takeSel("baseSel")
+    i.takeSel(Selector("baseSel"))
+
+    takeSel("outerSel")
+    takeSel(Selector("outerSel"))
+  }
+}
+
+func freeTest(s: Selectors, o: Outer, i: Outer.Inner) {
+  s.takeSel("mySel")
+  s.takeSel(Selector("mySel"))
+
+  i.takeSel("innerSel")
+  i.takeSel(Selector("innerSel"))
+
+  i.takeSel("baseSel")
+  i.takeSel(Selector("baseSel"))
+
+  o.takeSel("outerSel")
+  o.takeSel(Selector("outerSel"))
+}
+
 func foo(an : Any) {
   let a1 : AnyObject
   a1 = an

--- a/test/FixCode/fixits-apply-objc.swift.result
+++ b/test/FixCode/fixits-apply-objc.swift.result
@@ -8,9 +8,89 @@ import ObjectiveC
   func takeSel(_: Selector) {}
   func mySel() {}
   func test() {
-    takeSel(#selector(Selectors.mySel))
-    takeSel(#selector(Selectors.mySel))
+    takeSel(#selector(self.mySel))
+    takeSel(#selector(self.mySel))
   }
+}
+
+@objc class OtherClass {
+  func test(s: Selectors) {
+    s.takeSel(#selector(Selectors.mySel))
+    s.takeSel(#selector(Selectors.mySel))
+  }
+}
+
+@objc class Base {
+  func baseSel() {}
+}
+
+@objc class Outer {
+  func takeSel(_: Selector) {}
+  func outerSel() {}
+
+  @objc class Inner: Base {
+    func takeSel(_: Selector) {}
+
+    func innerSel() {}
+
+    func test(s: Selectors, o: Outer) {
+      s.takeSel(#selector(Selectors.mySel))
+      s.takeSel(#selector(Selectors.mySel))
+
+      takeSel(#selector(self.innerSel))
+      takeSel(#selector(self.innerSel))
+
+      takeSel(#selector(self.baseSel))
+      takeSel(#selector(self.baseSel))
+
+      o.takeSel(#selector(Outer.outerSel))
+      o.takeSel(#selector(Outer.outerSel))
+    }
+  }
+
+  func test(s: Selectors, i: Inner) {
+    s.takeSel(#selector(Selectors.mySel))
+    s.takeSel(#selector(Selectors.mySel))
+
+    i.takeSel(#selector(Inner.innerSel))
+    i.takeSel(#selector(Inner.innerSel))
+
+    i.takeSel(#selector(Base.baseSel))
+    i.takeSel(#selector(Base.baseSel))
+
+    takeSel(#selector(self.outerSel))
+    takeSel(#selector(self.outerSel))
+  }
+}
+
+extension Outer {
+  func test2(s: Selectors, i: Inner) {
+    s.takeSel(#selector(Selectors.mySel))
+    s.takeSel(#selector(Selectors.mySel))
+
+    i.takeSel(#selector(Inner.innerSel))
+    i.takeSel(#selector(Inner.innerSel))
+
+    i.takeSel(#selector(Base.baseSel))
+    i.takeSel(#selector(Base.baseSel))
+
+    takeSel(#selector(self.outerSel))
+    takeSel(#selector(self.outerSel))
+  }
+}
+
+func freeTest(s: Selectors, o: Outer, i: Outer.Inner) {
+  s.takeSel(#selector(Selectors.mySel))
+  s.takeSel(#selector(Selectors.mySel))
+
+  i.takeSel(#selector(Inner.innerSel))
+  i.takeSel(#selector(Inner.innerSel))
+
+  i.takeSel(#selector(Base.baseSel))
+  i.takeSel(#selector(Base.baseSel))
+
+  o.takeSel(#selector(Outer.outerSel))
+  o.takeSel(#selector(Outer.outerSel))
 }
 
 func foo(an : Any) {


### PR DESCRIPTION
When inside a declaration or extension of TypeName, humans usually don't write
the full typename like #selector(TypeName.foo), but instead prefer the neater
form #selector(self.foo). The compiler has enough information to do this too.

Fixes rdar://problem/25284692 .
