### PR TITLE
[Migrator] Don't run AST passes when in Swift 4 or later

### DIFF
--- a/lib/Migrator/Migrator.cpp
+++ b/lib/Migrator/Migrator.cpp
@@ -53,9 +53,11 @@ bool migrator::updateCodeAndEmitRemap(CompilerInstance *Instance,
   }
 
   // Phase 2: Syntactic Transformations
-  auto FailedSyntacticPasses = M.performSyntacticPasses();
-  if (FailedSyntacticPasses) {
-    return true;
+  if (Invocation.getLangOptions().EffectiveLanguageVersion[0] < 4) {
+    auto FailedSyntacticPasses = M.performSyntacticPasses();
+    if (FailedSyntacticPasses) {
+      return true;
+    }
   }
 
   // Phase 3: Post Fix-it Passes

--- a/lib/Migrator/README.md
+++ b/lib/Migrator/README.md
@@ -48,7 +48,7 @@ Here are the passes:
 2. AST Passes
 
    If the Pre-fix-it Pass was successful, or skipped because it was unnecessary, the
-   *AST Passes* run. These include:
+   *AST Passes* run if you are migrating *from before Swift 4*. These include:
 
    - API Diff Pass
 

--- a/test/Migrator/DoubleEditAPI.json
+++ b/test/Migrator/DoubleEditAPI.json
@@ -1,6 +1,13 @@
 [
   {
     "DiffItemKind": "TypeMemberDiffItem",
+    "Usr": "c:@E@FooComparisonResult@FooOrderedAscending",
+    "OldPrintedName": "FooOrderedAscending",
+    "NewPrintedName": "orderedAscending",
+    "NewTypeName": "FooComparisonResult"
+  },
+  {
+    "DiffItemKind": "TypeMemberDiffItem",
     "Usr": "c:@SA@SomeItemSet",
     "OldPrintedName": "SomeItemSet",
     "NewPrintedName": "some",

--- a/test/Migrator/no_ast_passes_after_swift4.swift
+++ b/test/Migrator/no_ast_passes_after_swift4.swift
@@ -1,0 +1,9 @@
+// REQUIRES: objc_interop
+// RUN: %empty-directory(%t) && %target-swift-frontend -c -update-code -primary-file %s -F %S/mock-sdk -api-diff-data-file %S/Inputs/DoubleEditAPI.json -emit-migrated-file-path %t/no_ast_passes_after_swift4.swift.result -emit-remap-file-path %t/no_ast_passes_after_swift4.swift.remap -o /dev/null -swift-version 4
+// RUN: diff -u %S/no_ast_passes_after_swift4.swift.expected %t/no_ast_passes_after_swift4.swift.result
+// RUN: %target-swift-frontend -typecheck -F %S/mock-sdk -swift-version 4 %t/no_ast_passes_after_swift4.swift.result
+
+import Bar
+func foo() -> FooComparisonResult {
+  return FooComparisonResult.orderedAscending
+}

--- a/test/Migrator/no_ast_passes_after_swift4.swift.expected
+++ b/test/Migrator/no_ast_passes_after_swift4.swift.expected
@@ -1,0 +1,9 @@
+// REQUIRES: objc_interop
+// RUN: %empty-directory(%t) && %target-swift-frontend -c -update-code -primary-file %s -F %S/mock-sdk -api-diff-data-file %S/Inputs/DoubleEditAPI.json -emit-migrated-file-path %t/no_ast_passes_after_swift4.swift.result -emit-remap-file-path %t/no_ast_passes_after_swift4.swift.remap -o /dev/null -swift-version 4
+// RUN: diff -u %S/no_ast_passes_after_swift4.swift.expected %t/no_ast_passes_after_swift4.swift.result
+// RUN: %target-swift-frontend -typecheck -F %S/mock-sdk -swift-version 4 %t/no_ast_passes_after_swift4.swift.result
+
+import Bar
+func foo() -> FooComparisonResult {
+  return FooComparisonResult.orderedAscending
+}


### PR DESCRIPTION
AST passes assume that you are migrating from a version earlier
than Swift 4, where declaration references and type names may be
unconditionally renamed if their USRs match.

For example, this can happen for TypeMemberDiffItem entries where the
Objective-C USR is the same in Swift 3 and Swift 4, but the type is
spelled differently in Swift 4. A concrete example of this is:

`NSDocumentTypeDocumentAttribute` (Swift 3) ->
  `NSAttributedString.DocumentAttributeKey` (Swift 4).

Although this declaration is imported differently in Swift 4, its
Objective-C USR is `c:@NSDocumentTypeDocumentAttribute` for both.

rdar://problem/32604558