### PR TITLE
Use isSubtypeOf rather than typesSatisfyConstraint.

### DIFF
--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -3793,15 +3793,11 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
         return CheckedCastKind::ValueCast;
 
       // Compare superclass bounds.
-      if (typesSatisfyConstraint(toSuperclass, fromSuperclass,
-                                 /*openArchetypes=*/true,
-                                 ConstraintKind::Subtype, dc))
+      if (isSubtypeOf(toSuperclass, fromSuperclass, dc))
         return CheckedCastKind::ValueCast;
 
       // An upcast is also OK.
-      if (typesSatisfyConstraint(fromSuperclass, toSuperclass,
-                                 /*openArchetypes=*/true,
-                                 ConstraintKind::Subtype, dc))
+      if (isSubtypeOf(fromSuperclass, toSuperclass, dc))
         return CheckedCastKind::ValueCast;
     }
   }
@@ -3813,18 +3809,13 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
   // If the destination type can be a supertype of the source type, we are
   // performing what looks like an upcast except it rebinds generic
   // parameters.
-  if (!metatypeCast &&
-      typesSatisfyConstraint(fromType, toType,
-                             /*openArchetypes=*/true,
-                             ConstraintKind::Subtype, dc)) {
+  if (!metatypeCast && isSubtypeOf(fromType, toType, dc)) {
     return CheckedCastKind::ValueCast;
   }
 
   // If the destination type can be a subtype of the source type, we have
   // a downcast.
-  if (typesSatisfyConstraint(toType, fromType,
-                             /*openArchetypes=*/true,
-                             ConstraintKind::Subtype, dc)) {
+  if (isSubtypeOf(toType, fromType, dc)) {
     return CheckedCastKind::ValueCast;
   }
   

--- a/test/Constraints/casts.swift
+++ b/test/Constraints/casts.swift
@@ -221,3 +221,22 @@ func process(p: Any?) {
 
 func compare<T>(_: T, _: T) {}
 func compare<T>(_: T?, _: T?) {}
+
+
+// <rdar://problem/32651746> [SR-5164]: Incorrect warning in swift4 cast
+protocol Proto {}
+class ArgBase {}
+class Other : ArgBase, Proto {}
+class TypeParam: ArgBase, Proto {}
+
+class U {}
+
+class Generic<T> : U where T : ArgBase, T : Proto {
+  func result() -> U {
+    return Generic<TypeParam>()
+  }
+
+  func test() {
+    _ = result() as! Generic<T> // no warning about always-failing cast
+  }
+}


### PR DESCRIPTION
The former is for subtype checks. The latter can be used for a variety
of constraint checks, and has extra flexibility, e.g. the ability to
open archetypes. Opening archetypes for subtype checks does not make
sense, though, since we end up with constraint systems that cannot be
solved because they potentially lack the type context that would be
required in order to choose bindings that resolve all of the
constraints.

Fixes rdar://problem/32651746 / SR-5164.
