### PR TITLE
[Migrator] Make sure to lowercase properties in SetterToProperty

### DIFF
--- a/lib/Migrator/APIDiffMigratorPass.cpp
+++ b/lib/Migrator/APIDiffMigratorPass.cpp
@@ -605,8 +605,11 @@ struct APIDiffMigratorPass : public ASTMigratorPass, public SourceEntityWalker {
                                           Arg->getStartLoc().getAdvancedLoc(1));
 
           // Replace "x.getY(" with "x.Y =".
-          Editor.replace(ReplaceRange, (llvm::Twine(Walker.Result.str().
-                                                   substr(3)) + " = ").str());
+          auto Replacement = (llvm::Twine(Walker.Result.str()
+                                          .substr(3)) + " = ").str();
+          Replacement[0] = tolower(Replacement[0]);
+          Editor.replace(ReplaceRange, Replacement);
+
           // Remove ")"
           Editor.remove(CharSourceRange(SM, Arg->getEndLoc(), Arg->getEndLoc().
                                         getAdvancedLoc(1)));

--- a/test/Migrator/pre_fixit_pass.swift.expected
+++ b/test/Migrator/pre_fixit_pass.swift.expected
@@ -10,6 +10,6 @@ struct Old {}
 New()
 
 func foo(_ a : PropertyUserInterface) {
-  a.Field = 1
+  a.field = 1
   _ = a.field
 }

--- a/test/Migrator/property.swift.expected
+++ b/test/Migrator/property.swift.expected
@@ -6,7 +6,7 @@
 import Bar
 
 func foo(_ a : PropertyUserInterface) {
-  a.Field = 1
+  a.field = 1
   _ = a.field
 }
 


### PR DESCRIPTION
Previously we were only stripping `set` from the name and not
lowercasing the property.

rdar://problem/32845968