### PR TITLE
Add Swift 3 backward compatibility apinotes for ScreenSaver.

### DIFF
--- a/apinotes/CMakeLists.txt
+++ b/apinotes/CMakeLists.txt
@@ -38,6 +38,7 @@ set(SWIFT_API_NOTES_INPUTS
   QuickLook
   SafariServices
   SceneKit
+  ScreenSaver
   ScriptingBridge
   SpriteKit
   StoreKit

--- a/apinotes/ScreenSaver.apinotes
+++ b/apinotes/ScreenSaver.apinotes
@@ -1,0 +1,13 @@
+---
+Name: ScreenSaver
+SwiftVersions:
+- Version: 3
+  Classes:
+  - Name: ScreenSaverView
+    Properties:
+    - Name: hasConfigureSheet
+      PropertyKind: Instance
+      SwiftImportAsAccessors: true
+    - Name: configureSheet
+      PropertyKind: Instance
+      SwiftImportAsAccessors: true


### PR DESCRIPTION
Explanation: Adds apinotes for ScreenSaver framework to roll back API changes for Swift 3
Scope of Issue: Uses of ScreenSaver framework in Swift 3 mode
Risk: Minimal
Testing: Tested in Xcode on project broken by original API changes
Directions for QA: N/A
Radar: rdar://problem/32967031