### PR TITLE
Bespoke array iterator [NOMERGE]

### DIFF
--- a/stdlib/public/core/ArrayBuffer.swift
+++ b/stdlib/public/core/ArrayBuffer.swift
@@ -600,10 +600,14 @@ extension _ArrayBuffer : Sequence {
     case contiguous(UnsafePointer<Element>, UnsafePointer<Element>)
     case cocoa(Int, Int)
     }
-    
+
+    @_versioned
     var _buffer: _Buffer
+    @_versioned
     var _owner: AnyObject
 
+    @_versioned
+    @inline(__always)
     mutating func next() -> Element? {
       switch _buffer {
       case .contiguous(let start, let end):
@@ -620,6 +624,8 @@ extension _ArrayBuffer : Sequence {
       }
     }
 
+    @_versioned
+    @inline(__always)
     init(_ b: _ArrayBuffer) {
       if _fastPath(b._isNative) {
         _owner = b._native._storage

--- a/stdlib/public/core/ArrayBuffer.swift
+++ b/stdlib/public/core/ArrayBuffer.swift
@@ -617,6 +617,8 @@ extension _ArrayBuffer : Sequence {
         return start.pointee
         
       case .cocoa(let start, let end):
+        if _canBeClass(Element.self) == 0 { Builtin.unreachable() }
+        
         guard _fastPath(start != end) else { return nil }
         _buffer = .cocoa(start + 1, end)
         let r = unsafeBitCast(_owner, to: _NSArrayCore.self).objectAt(start)
@@ -633,6 +635,7 @@ extension _ArrayBuffer : Sequence {
         _buffer = .contiguous(start, start + b.count)
       }
       else {
+        if _canBeClass(Element.self) == 0 { Builtin.unreachable() }
         _owner = b._nonNative
         let c = _CocoaArrayWrapper(b._nonNative)
         if let start = c.contiguousStorage(0..<b.count) {

--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -462,8 +462,33 @@ public struct ${Self}<Element>
 {
 
   public typealias Index = Int
-  public typealias Iterator = IndexingIterator<${Self}>
 
+  public struct Iterator : IteratorProtocol, Sequence {
+    internal typealias _Base = _Buffer.Iterator
+
+    @_versioned
+    internal var _base: _Base
+
+    @_versioned
+    @_inlineable
+    internal init(_ elements: ${Self}) {
+      _base = elements._buffer.makeIterator()
+    }
+
+    @_inlineable
+    public mutating func next() -> Element? { return _base.next() }
+    
+    @inline(__always)
+    public mutating func _initialize(
+      _ memory: UnsafeMutableBufferPointer<Element>
+    ) -> Int {
+      return _base._initialize(memory)
+    }
+  }
+
+  @_inlineable
+  public func makeIterator() -> Iterator { return Iterator(self) }
+  
 %if Self == 'ArraySlice':
   /// The position of the first element in a nonempty array.
   ///
@@ -1763,37 +1788,6 @@ extension ${Self} {
 
     // Invoke the body.
     return try body(&inoutBufferPointer)
-  }
-
-  @_inlineable
-  public func _copyContents(
-    initializing buffer: UnsafeMutableBufferPointer<Element>
-  ) -> (Iterator,UnsafeMutableBufferPointer<Element>.Index) {
-
-    guard !self.isEmpty else { return (makeIterator(),buffer.startIndex) }
-
-    // It is not OK for there to be no pointer/not enough space, as this is
-    // a precondition and Array never lies about its count.
-    guard var p = buffer.baseAddress
-      else { _preconditionFailure("Attempt to copy contents into nil buffer pointer") }
-    _precondition(self.count <= buffer.count, 
-      "Insufficient space allocated to copy array contents")
-
-    if let s = _baseAddressIfContiguous {
-      p.initialize(from: s, count: self.count)
-      // Need a _fixLifetime bracketing the _baseAddressIfContiguous getter
-      // and all uses of the pointer it returns:
-      _fixLifetime(self._owner)
-    } else {
-      for x in self {
-        p.initialize(to: x)
-        p += 1
-      }
-    }
-
-    var it = IndexingIterator(_elements: self)
-    it._position = endIndex
-    return (it,buffer.index(buffer.startIndex, offsetBy: self.count))
   }
 }
 %end

--- a/stdlib/public/core/CharacterUnicodeScalars.swift
+++ b/stdlib/public/core/CharacterUnicodeScalars.swift
@@ -125,13 +125,16 @@ extension Character.UnicodeScalarView : BidirectionalCollection {
     
     let small_ = _base._smallUTF16
     if _fastPath(small_ != nil), let u16 = small_ {
-      var i = u16[..<u16.index(u16.startIndex, offsetBy: i._encodedOffset)]
-        .reversed().makeIterator()
-      r = parser.parseScalar(from: &i)
+      let i0 = u16[..<u16.index(u16.startIndex, offsetBy: i._encodedOffset)]
+      let i1 = i0.reversed()
+      var i2 = i1.makeIterator()
+      r = parser.parseScalar(from: &i2)
     }
     else {
-      var i = _base._largeUTF16![..<i._encodedOffset].reversed().makeIterator()
-      r = parser.parseScalar(from: &i)
+      let i0 = _base._largeUTF16![..<i._encodedOffset]
+      let i1 = i0.reversed()
+      var i2 = i1.makeIterator()
+      r = parser.parseScalar(from: &i2)
     }
     
     switch r {

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -1415,6 +1415,7 @@ extension Sequence {
 
 extension IteratorProtocol {
   @_inlineable
+  @inline(__always)
   public mutating func _initialize(
     _ memory: UnsafeMutableBufferPointer<Element>
   ) -> Int {

--- a/test/Generics/deduction.swift
+++ b/test/Generics/deduction.swift
@@ -216,7 +216,7 @@ func callRangeOfIsBefore(_ ia: [Int], da: [Double]) {
 }
 
 func testEqualIterElementTypes<A: IteratorProtocol, B: IteratorProtocol>(_ a: A, _ b: B) where A.Element == B.Element {}
-// expected-note@-1 {{requirement specified as 'A.Element' == 'B.Element' [with A = IndexingIterator<[Int]>, B = IndexingIterator<[Double]>]}}
+// expected-note@-1 {{requirement specified as 'A.Element' == 'B.Element' [with A = Array<Int>.Iterator, B = Array<Double>.Iterator]}}
 func compareIterators() {
   var a: [Int] = []
   var b: [Double] = []

--- a/test/IDE/print_type_interface.swift
+++ b/test/IDE/print_type_interface.swift
@@ -73,7 +73,7 @@ extension D {
 // TYPE4-DAG: public func min() -> Int?
 // TYPE4-DAG: public mutating func insert<C>(contentsOf newElements: C, at i: Int)
 // TYPE4-DAG: public mutating func removeFirst(_ n: Int)
-// TYPE4-DAG: public func makeIterator() -> IndexingIterator<Array<Int>>
+// TYPE4-DAG: public func makeIterator() -> Array<Int>.Iterator
 // TYPE4-NOT: public func joined
 
 // RUN: %target-swift-ide-test -print-type-interface -usr=_TtGSaSS_ -module-name print_type_interface -source-filename %s | %FileCheck %s -check-prefix=TYPE5

--- a/test/SILGen/foreach.swift
+++ b/test/SILGen/foreach.swift
@@ -51,7 +51,7 @@ protocol GenericCollection : Collection {
 
 // CHECK-LABEL: sil hidden @_T07foreach13trivialStructySaySiGF : $@convention(thin) (@owned Array<Int>) -> () {
 // CHECK: bb0([[ARRAY:%.*]] : $Array<Int>):
-// CHECK:   [[ITERATOR_BOX:%.*]] = alloc_box ${ var IndexingIterator<Array<Int>> }, var, name "$x$generator"
+// CHECK:   [[ITERATOR_BOX:%.*]] = alloc_box ${ var Array<Int>.Iterator }, var, name "$x$generator"
 // CHECK:   [[PROJECT_ITERATOR_BOX:%.*]] = project_box [[ITERATOR_BOX]]
 // CHECK:   br [[LOOP_DEST:bb[0-9]+]]
 //
@@ -107,7 +107,7 @@ func trivialStructBreak(_ xx: [Int]) {
 
 // CHECK-LABEL: sil hidden @_T07foreach26trivialStructContinueBreakySaySiGF : $@convention(thin) (@owned Array<Int>) -> () {
 // CHECK: bb0([[ARRAY:%.*]] : $Array<Int>):
-// CHECK:   [[ITERATOR_BOX:%.*]] = alloc_box ${ var IndexingIterator<Array<Int>> }, var, name "$x$generator"
+// CHECK:   [[ITERATOR_BOX:%.*]] = alloc_box ${ var Array<Int>.Iterator }, var, name "$x$generator"
 // CHECK:   [[PROJECT_ITERATOR_BOX:%.*]] = project_box [[ITERATOR_BOX]]
 // CHECK:   [[MAKE_ITERATOR_FUNC:%.*]] = function_ref @_T0s10CollectionPssAARzs16IndexingIteratorVyxG0C0RtzlE04makeC0AEyF : $@convention(method) <τ_0_0 where τ_0_0 : Collection, τ_0_0.Iterator == IndexingIterator<τ_0_0>> (@in_guaranteed τ_0_0) -> @out IndexingIterator<τ_0_0>
 // CHECK:   [[BORROWED_ARRAY:%.*]] = begin_borrow [[ARRAY]]
@@ -119,7 +119,7 @@ func trivialStructBreak(_ xx: [Int]) {
 // CHECK: [[LOOP_DEST]]:
 // CHECK:   [[FUNC_REF:%.*]] = function_ref @_T0s16IndexingIteratorV4next7ElementQzSgyF : $@convention(method)
 // CHECK:   [[GET_ELT_STACK:%.*]] = alloc_stack $Optional<Int>
-// CHECK:   [[WRITE:%.*]] = begin_access [modify] [unknown] [[PROJECT_ITERATOR_BOX]] : $*IndexingIterator<Array<Int>>
+// CHECK:   [[WRITE:%.*]] = begin_access [modify] [unknown] [[PROJECT_ITERATOR_BOX]] : $*Array<Int>.Iterator
 // CHECK:   apply [[FUNC_REF]]<[Int]>([[GET_ELT_STACK]], [[WRITE]])
 // CHECK:   [[IND_VAR:%.*]] = load [trivial] [[GET_ELT_STACK]]
 // CHECK:   switch_enum [[IND_VAR]] : $Optional<Int>, case #Optional.some!enumelt.1: [[SOME_BB:bb[0-9]+]], case #Optional.none!enumelt: [[NONE_BB:bb[0-9]+]]
@@ -152,7 +152,7 @@ func trivialStructBreak(_ xx: [Int]) {
 // CHECK:   br [[CONT_BLOCK]]
 //
 // CHECK: [[CONT_BLOCK]]
-// CHECK:   destroy_value [[ITERATOR_BOX]] : ${ var IndexingIterator<Array<Int>> }
+// CHECK:   destroy_value [[ITERATOR_BOX]] : ${ var Array<Int>.Iterator }
 // CHECK:   [[FUNC_END_FUNC:%.*]] = function_ref @funcEnd : $@convention(thin) () -> ()
 // CHECK:   apply [[FUNC_END_FUNC]]()
 // CHECK:   destroy_value [[ARRAY]]

--- a/test/SILGen/statements.swift
+++ b/test/SILGen/statements.swift
@@ -164,7 +164,7 @@ func for_loops1(_ x: Int, c: Bool) {
 // CHECK-LABEL: sil hidden @{{.*}}for_loops2
 func for_loops2() {
   // rdar://problem/19316670
-  // CHECK: [[NEXT:%[0-9]+]] = function_ref @_T0s16IndexingIteratorV4next{{[_0-9a-zA-Z]*}}F
+  // CHECK: [[NEXT:%[0-9]+]] = function_ref @_T0Sa8IteratorV4next{{[_0-9a-zA-Z]*}}F
   // CHECK-NEXT: alloc_stack $Optional<MyClass>
   // CHECK-NEXT: [[WRITE:%.*]] = begin_access [modify] [unknown]
   // CHECK-NEXT: apply [[NEXT]]<[MyClass]>

--- a/test/stdlib/Inputs/CommonArrayTests.gyb
+++ b/test/stdlib/Inputs/CommonArrayTests.gyb
@@ -400,7 +400,7 @@ ${Suite}.test("${ArrayType}/AssociatedTypes") {
   typealias CollectionSlice = ArraySlice<OpaqueValue<Int>>
   expectCollectionAssociatedTypes(
     collectionType: Collection.self,
-    iteratorType: IndexingIterator<Collection>.self,
+    iteratorType: Collection.Iterator.self,
     subSequenceType: CollectionSlice.self,
     indexType: Int.self,
     indexDistanceType: Int.self,

--- a/validation-test/stdlib/SequenceType.swift.gyb
+++ b/validation-test/stdlib/SequenceType.swift.gyb
@@ -163,7 +163,7 @@ SequenceTypeTests.test("IteratorSequence/IteratorProtocol/empty") {
     let base = data.makeIterator()
     var iter = IteratorSequence(base)
     expectType(
-      IteratorSequence<IndexingIterator<Array<OpaqueValue<Int>>>>.self,
+      IteratorSequence<Array<OpaqueValue<Int>>.Iterator>.self,
       &iter)
     checkIterator(data, iter) { $0.value == $1.value }
   }
@@ -184,7 +184,7 @@ SequenceTypeTests.test("IteratorSequence/IteratorProtocol") {
     let base = data.makeIterator()
     var iter = IteratorSequence(base)
     expectType(
-      IteratorSequence<IndexingIterator<Array<OpaqueValue<Int>>>>.self,
+      IteratorSequence<Array<OpaqueValue<Int>>.Iterator>.self,
       &iter)
     checkIterator(data, iter) { $0.value == $1.value }
   }
@@ -205,7 +205,7 @@ SequenceTypeTests.test("IteratorSequence/Sequence/empty") {
     let base = data.makeIterator()
     var iter = IteratorSequence(base)
     expectType(
-      IteratorSequence<IndexingIterator<Array<OpaqueValue<Int>>>>.self,
+      IteratorSequence<Array<OpaqueValue<Int>>.Iterator>.self,
       &iter)
     checkSequence(data, iter) { $0.value == $1.value }
   }
@@ -226,7 +226,7 @@ SequenceTypeTests.test("IteratorSequence/Sequence") {
     let base = data.makeIterator()
     var iter = IteratorSequence(base)
     expectType(
-      IteratorSequence<IndexingIterator<Array<OpaqueValue<Int>>>>.self,
+      IteratorSequence<Array<OpaqueValue<Int>>.Iterator>.self,
       &iter)
     checkSequence(data, iter) { $0.value == $1.value }
   }


### PR DESCRIPTION
Work on moving `Sequence._copyContents` to `Iterator._initialize` (to be used for `String` optimization) speeds up most things a lot but breaks a couple of optimizations and reveals a type checker bug.