### PR TITLE
[test] Add missing ':' for FileCheck directives

### DIFF
--- a/test/IRGen/big_types_corner_cases.swift
+++ b/test/IRGen/big_types_corner_cases.swift
@@ -83,7 +83,7 @@ public class BigClass {
   }
 }
 
-// CHECK-LABEL define{{( protected)?}} hidden swiftcc void @_T022big_types_corner_cases8BigClassC03useE6StructyAA0eH0V0aH0_tF(%T22big_types_corner_cases9BigStructV* noalias nocapture dereferenceable({{.*}}), %T22big_types_corner_cases8BigClassC* swiftself) #0 {
+// CHECK-LABEL: define{{( protected)?}} hidden swiftcc void @_T022big_types_corner_cases8BigClassC03useE6StructyAA0eH0V0aH0_tF(%T22big_types_corner_cases9BigStructV* noalias nocapture dereferenceable({{.*}}), %T22big_types_corner_cases8BigClassC* swiftself) #0 {
 // CHECK: getelementptr inbounds %T22big_types_corner_cases8BigClassC, %T22big_types_corner_cases8BigClassC*
 // CHECK: call void @_T0SqWy
 // CHECK: [[BITCAST:%.*]] = bitcast i8* {{.*}} to void (%T22big_types_corner_cases9BigStructV*, %swift.refcounted*)*

--- a/test/IRGen/builtins.swift
+++ b/test/IRGen/builtins.swift
@@ -531,7 +531,7 @@ struct Abc {
 	var value : Builtin.Word
 }
 
-// CHECK-LABEL define hidden {{.*}}@_T08builtins22assumeNonNegative_testBwAA3AbcVzF
+// CHECK-LABEL: define hidden {{.*}}@_T08builtins22assumeNonNegative_testBwAA3AbcVzF
 func assumeNonNegative_test(_ x: inout Abc) -> Builtin.Word {
   // CHECK: load {{.*}}, !range ![[R:[0-9]+]]
   return Builtin.assumeNonNegative_Word(x.value)
@@ -542,7 +542,7 @@ func return_word(_ x: Builtin.Word) -> Builtin.Word {
 	return x
 }
 
-// CHECK-LABEL define hidden {{.*}}@_T08builtins23assumeNonNegative_test2BwAA3AbcVzF
+// CHECK-LABEL: define hidden {{.*}}@_T08builtins23assumeNonNegative_test2BwBwF
 func assumeNonNegative_test2(_ x: Builtin.Word) -> Builtin.Word {
   // CHECK: call {{.*}}, !range ![[R]]
   return Builtin.assumeNonNegative_Word(return_word(x))

--- a/test/Index/roles.swift
+++ b/test/Index/roles.swift
@@ -226,7 +226,7 @@ protocol X {
   var reqProp: Int { get }
   // CHECK: [[@LINE-1]]:7 | instance-property/Swift | reqProp | [[reqProp_USR:.*]] | Def,RelChild | rel: 1
   // CHECK: [[@LINE-2]]:22 | instance-method/acc-get/Swift | getter:reqProp | {{.*}} | Def,Dyn,RelChild,RelAcc | rel: 1
-  // CHECK-NEXT  RelChild,RelAcc | instance-property/Swift | reqProp_USR | [[reqProp_USR]]
+  // CHECK-NEXT: RelChild,RelAcc | instance-property/Swift | reqProp | [[reqProp_USR]]
 }
 
 protocol Y {}

--- a/test/Interpreter/SDK/objc_keypath.swift
+++ b/test/Interpreter/SDK/objc_keypath.swift
@@ -36,10 +36,10 @@ band.members = [Person(firstName: "John", lastName: "Lennon"),
 // CHECK: ===Members===
 // CHECK-NEXT: (
 // CHECK-NEXT:    Lennon, John
-// CHECK-NEXT     McCartney, Paul,
-// CHECK-NEXT     Harrison, George,
-// CHECK-NEXT     Star, Ringo
-// CHECK-NEXT)
+// CHECK-NEXT:    McCartney, Paul
+// CHECK-NEXT:    Harrison, George
+// CHECK-NEXT:    Star, Ringo
+// CHECK-NEXT: )
 print("===Members===")
 print((band.value(forKeyPath: #keyPath(Band.members))! as AnyObject).description)
 

--- a/test/PrintAsObjC/circularity.swift
+++ b/test/PrintAsObjC/circularity.swift
@@ -86,9 +86,9 @@ class E2: ProtoImpl {}
 // CHECK-LABEL: @interface F1 : ProtoImpl
 class F1: ProtoImpl {
 } // CHECK: @end
-// CHECK-LABEL @interface F2 : ProtoImpl
+// CHECK-LABEL: @interface F2 : ProtoImpl
 // CHECK: @end
-// CHECK-LABEL @interface F1 (SWIFT_EXTENSION(circularity))
+// CHECK-LABEL: @interface F1 (SWIFT_EXTENSION(circularity))
 extension F1 {
   // CHECK: - (void)test:
   func test(_: NeedsProto<F2>) {}
@@ -99,9 +99,9 @@ class F2: ProtoImpl {}
 // CHECK-LABEL: @interface G1 : ProtoImpl
 class G1: ProtoImpl {
 } // CHECK: @end
-// CHECK-LABEL @protocol G2 <Proto>
+// CHECK-LABEL: @protocol G2 <Proto>
 // CHECK: @end
-// CHECK-LABEL @interface G1 (SWIFT_EXTENSION(circularity))
+// CHECK-LABEL: @interface G1 (SWIFT_EXTENSION(circularity))
 extension G1 {
   // CHECK: - (void)test:
   func test(_: NeedsProto<G2>) {}

--- a/test/SILGen/auto_closures.swift
+++ b/test/SILGen/auto_closures.swift
@@ -15,7 +15,7 @@ func call_auto_closure(_ x: @autoclosure () -> Bool) -> Bool {
   return x()
 }
 
-// CHECK-LABEL sil @_T013auto_closures05test_A21_closure_with_capture{{[_0-9a-zA-Z]*}}F
+// CHECK-LABEL: sil hidden @_T013auto_closures05test_A21_closure_with_capture{{[_0-9a-zA-Z]*}}F
 func test_auto_closure_with_capture(_ x: Bool) -> Bool {
   // CHECK: [[CLOSURE:%.*]] = function_ref @_T013auto_closures05test_A21_closure_with_capture
   // CHECK: [[WITHCAPTURE:%.*]] = partial_apply [[CLOSURE]](

--- a/test/SILGen/materializeForSet.swift
+++ b/test/SILGen/materializeForSet.swift
@@ -445,7 +445,7 @@ struct GenericSubscriptWitness : GenericSubscriptProtocol {
 // CHECK-NEXT:    [[RESULT:%.*]] = tuple ()
 // CHECK-NEXT:    return [[RESULT]] : $()
 
-// CHECK-LABEL sil hidden [transparent] [thunk] @_T017materializeForSet23GenericSubscriptWitnessVAA0dE8ProtocolA2aDP9subscriptqd__qd__clufmTW : $@convention(witness_method) <τ_0_0> (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @in τ_0_0, @inout GenericSubscriptWitness) -> (Builtin.RawPointer, Optional<Builtin.RawPointer>) {
+// CHECK-LABEL: sil hidden [transparent] @_T017materializeForSet23GenericSubscriptWitnessV9subscriptxxclufm : $@convention(method) <T> (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @in T, @inout GenericSubscriptWitness) -> (Builtin.RawPointer, Optional<Builtin.RawPointer>) {
 // CHECK:      bb0(%0 : $Builtin.RawPointer, %1 : $*Builtin.UnsafeValueBuffer, %2 : $*T, %3 : $*GenericSubscriptWitness):
 // CHECK-NEXT:   [[BUFFER:%.*]] = alloc_value_buffer $T in %1 : $*Builtin.UnsafeValueBuffer
 // CHECK-NEXT:   copy_addr %2 to [initialization] [[BUFFER]] : $*T

--- a/test/SILGen/vtables.swift
+++ b/test/SILGen/vtables.swift
@@ -130,11 +130,11 @@ class Derived : Base {
   }
 }
 
-
 // CHECK: sil_vtable RequiredInitDerived {
 // CHECK-NEXT: #SimpleInitBase.init!initializer.1: {{.*}} : _T07vtables19RequiredInitDerivedC{{[_0-9a-zA-Z]*}}fc
-// CHECK-NEXT  #RequiredInitDerived.init!allocator.1: {{.*}} : _TFC7vtables19RequiredInitDerivedC
-// CHECK-NEXT}
+// CHECK-NEXT: #RequiredInitDerived.init!allocator.1: {{.*}} : _T07vtables19RequiredInitDerivedC
+// CHECK-NEXT: #RequiredInitDerived.deinit!deallocator: _T07vtables19RequiredInitDerivedCfD
+// CHECK-NEXT: }
 
 class SimpleInitBase { }
 

--- a/test/SILOptimizer/copyforward.sil
+++ b/test/SILOptimizer/copyforward.sil
@@ -450,7 +450,7 @@ bb0:
 // CHECK-LABEL: sil @nil_comparison
 // CHECK:  alloc_stack
 // CHECK-NOT: copy_addr
-// CHECK-NOT destroy_addr
+// CHECK-NOT: destroy_addr
 // CHECK: switch_enum_addr %0
 // CHECK: [[D:%.*]] = unchecked_take_enum_data_addr %0
 // CHECK: destroy_addr [[D]]

--- a/test/SILOptimizer/dead_store_elim.sil
+++ b/test/SILOptimizer/dead_store_elim.sil
@@ -1038,7 +1038,7 @@ bb0(%0 : $*Example):
 
 /// Make sure we can coalesce the 2 live stores to the 2 fields in S4.
 ///
-/// CHECK-LABEL : partial_dead_store_struct_in_struct
+/// CHECK-LABEL: partial_dead_store_struct_in_struct
 /// CHECK: [[RET0:%.+]] = struct_extract
 /// CHECK: [[RET1:%.+]] = struct_element_addr
 /// CHECK: {{ store}} [[RET0:%.+]] to [[RET1:%.+]] : $*S4
@@ -1058,7 +1058,7 @@ bb0(%0 : $*S5):
 
 /// Make sure we do not coalesce the 2 live stores to the 2 fields in S6.
 ///
-/// CHECK-LABEL : sil hidden @discontiguous_partial_dead_store_simple_struct
+/// CHECK-LABEL: sil hidden @discontiguous_partial_dead_store_simple_struct
 /// CHECK: store
 /// CHECK: store
 sil hidden @discontiguous_partial_dead_store_simple_struct : $@convention(thin) (@inout S6) -> () {
@@ -1077,7 +1077,7 @@ bb0(%0 : $*S6):
 
 /// Make sure we generate the store to field x first.
 ///
-/// CHECK-LABEL : sil hidden @discontiguous_partial_dead_store_lives_insert_deterministically
+/// CHECK-LABEL: sil hidden @discontiguous_partial_dead_store_lives_insert_deterministically
 /// CHECK: bb0([[A:%.*]] : $*S6):
 /// CHECK: [[IN:%.*]] = apply
 /// CHECK: [[EXT1:%.*]] = struct_extract [[IN]] : $S6, #S6.x
@@ -1121,7 +1121,7 @@ bb0(%0 : $*S7):
 /// i.e. too many stores generated, but make sure we track the store correctly
 /// so that we can get rid of store %56 to %57 : $*Int.
 ///
-/// CHECK-LABEL : partial_dead_store_bail_out_proper_propagation
+/// CHECK-LABEL: partial_dead_store_bail_out_proper_propagation
 /// CHECK: bb0
 /// CHECK-NOT: {{ store}}
 /// CHECK: function_ref

--- a/test/SILOptimizer/earlycodemotion.sil
+++ b/test/SILOptimizer/earlycodemotion.sil
@@ -1341,7 +1341,7 @@ bb1:                                              // Preds: bb0
 // Make sure we were able to sink the release.
 // CHECK: strong_release
 // CHECK-NEXT: tuple ()
-// CHECK-NEXT return
+// CHECK-NEXT: return
 
 bb2:                                              // Preds: bb4 bb5
   %5 = tuple ()                                   // user: %6

--- a/test/SILOptimizer/functionsigopts.sil
+++ b/test/SILOptimizer/functionsigopts.sil
@@ -511,7 +511,7 @@ bb0(%0 : $boo):
 // CHECK-LABEL: sil [serialized] [thunk] [always_inline] @owned_to_unowned_retval_with_error_result : $@convention(thin) (@owned boo) -> (@owned boo, @error Error) {
 // CHECK: function_ref @_T041owned_to_unowned_retval_with_error_resultTfq4n_g : $@convention(thin) (@owned boo) -> (boo, @error Error)
 // CHECK: bb1
-// CHECK-NOT retain_value
+// CHECK-NOT: retain_value
 // CHECK: bb2
 sil [serialized] @owned_to_unowned_retval_with_error_result : $@convention(thin) (@owned boo) -> (@owned boo, @error Error) {
 bb0(%0 : $boo):

--- a/test/SILOptimizer/mandatory_inlining.swift
+++ b/test/SILOptimizer/mandatory_inlining.swift
@@ -108,7 +108,7 @@ func test_chained_short_circuit(_ x: Bool, y: Bool, z: Bool) -> Bool {
 // recursively inlined properly)
 
 // CHECK-LABEL: sil hidden @_T018mandatory_inlining26test_chained_short_circuit{{[_0-9a-zA-Z]*}}F
-  // CHECK-NOT = apply [transparent]
+  // CHECK-NOT: = apply [transparent]
   // CHECK: return
 
 
@@ -122,7 +122,7 @@ func testInlineUnionElement() -> X {
   return X.onetransp
   // CHECK-LABEL: sil hidden @_T018mandatory_inlining22testInlineUnionElementAA1XOyF
   // CHECK: enum $X, #X.onetransp!enumelt
-  // CHECK-NOT = apply
+  // CHECK-NOT: = apply
   // CHECK: return
 }
 


### PR DESCRIPTION
In `FileCheck` tests, check prefixes must be immediately followed by ':'.
These are both invalid, hence ignored:
```
// CHECK expected
// CHECK : expected
```
This PR fixes these misusage, and update the expected strings so that the tests pass.