### PR TITLE
Scale benchmarks with 6-figure times back to 5-figures

### DIFF
--- a/benchmark/single-source/ObjectiveCBridging.swift
+++ b/benchmark/single-source/ObjectiveCBridging.swift
@@ -292,7 +292,7 @@ func testObjectiveCBridgeFromNSDictionaryAnyObject() {
   let nsString = NSString(cString: "NSString that does not fit in tagged pointer", encoding: String.Encoding.utf8.rawValue)!
 
   var nativeInt : Int?
-  for _ in 0 ..< 10_000 {
+  for _ in 0 ..< 1_000 {
     if let nativeDictionary : [NSString : NSNumber] = conditionalCast(nsDictionary) {
        nativeInt = forcedCast(nativeDictionary[nsString])
     }

--- a/benchmark/single-source/ObjectiveCBridgingStubs.swift
+++ b/benchmark/single-source/ObjectiveCBridgingStubs.swift
@@ -201,7 +201,7 @@ public func run_ObjectiveCBridgeStubDateMutation(N: Int) {
 @inline(never)
 func testObjectiveCBridgeStubURLAppendPath() {
   let startUrl = URL(string: "/")!
-  for _ in 0 ..< 10_000 {
+  for _ in 0 ..< 1_000 {
     var url = startUrl
     for _ in 0 ..< 10 {
       url.appendPathComponent("foo")

--- a/benchmark/single-source/ObjectiveCNoBridgingStubs.swift
+++ b/benchmark/single-source/ObjectiveCNoBridgingStubs.swift
@@ -158,7 +158,7 @@ public func run_ObjectiveCBridgeStubNSDateMutationRef(N: Int) {
 @inline(never)
 func testObjectiveCBridgeStubURLAppendPathRef() {
   let startUrl = URL(string: "/")!
-  for _ in 0 ..< 10_000 {
+  for _ in 0 ..< 1_000 {
     var url = startUrl
     for _ in 0 ..< 10 {
       url = url.appendingPathComponent("foo")


### PR DESCRIPTION
They seem to take disproportionately long in the benchmark suite.
