### PR TITLE
[swiftc (39 vs. 5569)] Add crasher in swift::TypeBase::getContextSubstitutions

### DIFF
--- a/validation-test/compiler_crashers/28801-swift-typebase-getcontextsubstitutions-swift-declcontext-const-swift-genericenvi.swift
+++ b/validation-test/compiler_crashers/28801-swift-typebase-getcontextsubstitutions-swift-declcontext-const-swift-genericenvi.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol P{{}class a}extension CountableRange{class a:A.a
+protocol A:P


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeBase::getContextSubstitutions`.

Current number of unresolved compiler crashers: 39 (5569 resolved)

Stack trace:

```
0 0x0000000003a7b018 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3a7b018)
1 0x0000000003a7b756 SignalHandler(int) (/path/to/swift/bin/swift+0x3a7b756)
2 0x00007f7c28151390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00000000015d343f swift::TypeBase::getContextSubstitutions(swift::DeclContext const*, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x15d343f)
4 0x00000000015cee70 swift::TypeBase::getContextSubstitutionMap(swift::ModuleDecl*, swift::DeclContext const*, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x15cee70)
5 0x000000000144969f swift::createDesignatedInitOverride(swift::TypeChecker&, swift::ClassDecl*, swift::ConstructorDecl*, swift::DesignatedInitKind) (/path/to/swift/bin/swift+0x144969f)
6 0x000000000135feb6 swift::TypeChecker::addImplicitConstructors(swift::NominalTypeDecl*) (/path/to/swift/bin/swift+0x135feb6)
7 0x0000000001369115 (anonymous namespace)::DeclChecker::visitClassDecl(swift::ClassDecl*) (/path/to/swift/bin/swift+0x1369115)
8 0x000000000135853e (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x135853e)
9 0x00000000013689fb (anonymous namespace)::DeclChecker::visitExtensionDecl(swift::ExtensionDecl*) (/path/to/swift/bin/swift+0x13689fb)
10 0x0000000001358474 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x1358474)
11 0x0000000001358343 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x1358343)
12 0x00000000013e33ca swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x13e33ca)
13 0x0000000000fa16cd swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xfa16cd)
14 0x00000000004abe59 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4abe59)
15 0x00000000004aa3f9 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4aa3f9)
16 0x0000000000465697 main (/path/to/swift/bin/swift+0x465697)
17 0x00007f7c26661830 __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:325:0
18 0x0000000000462d39 _start (/path/to/swift/bin/swift+0x462d39)
```