### PR TITLE
[swiftc (41 vs. 5569)] Add crasher in swift::TypeBase::getDesugaredType(...)

### DIFF
--- a/validation-test/compiler_crashers/28803-swift-typebase-getdesugaredtype.swift
+++ b/validation-test/compiler_crashers/28803-swift-typebase-getdesugaredtype.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol P{typealias a:Collection
+typealias a=(t:Self.a


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeBase::getDesugaredType(...)`.

Current number of unresolved compiler crashers: 41 (5569 resolved)

Stack trace:

```
0 0x0000000003a7b018 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3a7b018)
1 0x0000000003a7b756 SignalHandler(int) (/path/to/swift/bin/swift+0x3a7b756)
2 0x00007f169798e390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00000000015ce1d0 swift::TypeBase::getDesugaredType() (/path/to/swift/bin/swift+0x15ce1d0)
4 0x00000000015d26ed swift::LookUpConformanceInModule::operator()(swift::CanType, swift::Type, swift::ProtocolType*) const (/path/to/swift/bin/swift+0x15d26ed)
5 0x0000000000c283d2 std::_Function_handler<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*), swift::LookUpConformanceInModule>::_M_invoke(std::_Any_data const&, swift::CanType&&, swift::Type&&, swift::ProtocolType*&&) (/path/to/swift/bin/swift+0xc283d2)
6 0x0000000001581541 swift::GenericSignatureBuilder::addSameTypeRequirementToConcrete(swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type, swift::GenericSignatureBuilder::RequirementSource const*) (/path/to/swift/bin/swift+0x1581541)
7 0x0000000001580f6c swift::GenericSignatureBuilder::addSameTypeRequirement(llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::FloatingRequirementSource, swift::GenericSignatureBuilder::UnresolvedHandlingKind, llvm::function_ref<void (swift::Type, swift::Type)>) (/path/to/swift/bin/swift+0x1580f6c)
8 0x0000000001577b2e swift::GenericSignatureBuilder::PotentialArchetype::updateNestedTypeForConformance(llvm::PointerUnion<swift::AssociatedTypeDecl*, swift::TypeDecl*>, swift::GenericSignatureBuilder::PotentialArchetype::NestedTypeUpdate) (/path/to/swift/bin/swift+0x1577b2e)
9 0x00000000015766f4 swift::GenericSignatureBuilder::PotentialArchetype::getNestedArchetypeAnchor(swift::Identifier, swift::GenericSignatureBuilder&, swift::GenericSignatureBuilder::PotentialArchetype::NestedTypeUpdate) (/path/to/swift/bin/swift+0x15766f4)
10 0x0000000001575c93 swift::GenericSignatureBuilder::PotentialArchetype::getArchetypeAnchor(swift::GenericSignatureBuilder&) (/path/to/swift/bin/swift+0x1575c93)
11 0x0000000001578a96 swift::GenericSignatureBuilder::PotentialArchetype::getTypeInContext(swift::GenericSignatureBuilder&, swift::GenericEnvironment*) (/path/to/swift/bin/swift+0x1578a96)
12 0x00000000015799f1 swift::ArchetypeType::resolveNestedType(std::pair<swift::Identifier, swift::Type>&) const (/path/to/swift/bin/swift+0x15799f1)
13 0x00000000015d1898 swift::ArchetypeType::getNestedType(swift::Identifier) const (/path/to/swift/bin/swift+0x15d1898)
14 0x00000000015d2b46 getMemberForBaseType(llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::Type, swift::Type, swift::AssociatedTypeDecl*, swift::Identifier, swift::SubstOptions) (/path/to/swift/bin/swift+0x15d2b46)
15 0x00000000015d778d llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x15d778d)
16 0x00000000015d3d09 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15d3d09)
17 0x00000000015cef95 swift::Type::subst(swift::SubstitutionMap const&, swift::SubstOptions) const (/path/to/swift/bin/swift+0x15cef95)
18 0x00000000013d38be swift::TypeChecker::substMemberTypeWithBase(swift::ModuleDecl*, swift::TypeDecl*, swift::Type) (/path/to/swift/bin/swift+0x13d38be)
19 0x000000000138bff4 swift::TypeChecker::lookupMemberType(swift::DeclContext*, swift::Type, swift::Identifier, swift::OptionSet<swift::NameLookupFlags, unsigned int>) (/path/to/swift/bin/swift+0x138bff4)
20 0x00000000013d54db resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13d54db)
21 0x00000000013d4c89 swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13d4c89)
22 0x00000000013d59f8 (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0x13d59f8)
23 0x00000000013d71ab (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0x13d71ab)
24 0x00000000013d58fc swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13d58fc)
25 0x00000000013d4300 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x13d4300)
26 0x000000000135b505 validateTypealiasType(swift::TypeChecker&, swift::TypeAliasDecl*) (/path/to/swift/bin/swift+0x135b505)
27 0x000000000135a2e5 swift::TypeChecker::validateDecl(swift::ValueDecl*) (/path/to/swift/bin/swift+0x135a2e5)
28 0x0000000001369ee3 (anonymous namespace)::DeclChecker::visitProtocolDecl(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0x1369ee3)
29 0x0000000001358444 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x1358444)
30 0x0000000001358343 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x1358343)
31 0x00000000013e3344 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x13e3344)
32 0x0000000000fa16cd swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xfa16cd)
33 0x00000000004abe59 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4abe59)
34 0x00000000004aa3f9 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4aa3f9)
35 0x0000000000465697 main (/path/to/swift/bin/swift+0x465697)
36 0x00007f1695e9e830 __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:325:0
37 0x0000000000462d39 _start (/path/to/swift/bin/swift+0x462d39)
```