### PR TITLE
[swiftc (42 vs. 5569)] Add crasher in swift::GenericSignatureBuilder::addRequirement

### DIFF
--- a/validation-test/compiler_crashers/28804-second.swift
+++ b/validation-test/compiler_crashers/28804-second.swift
@@ -1,0 +1,12 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+class a<a{
+protocol A{{}typealias e where f=A
+protocol A


### PR DESCRIPTION
Add test case for crash triggered in `swift::GenericSignatureBuilder::addRequirement`.

Current number of unresolved compiler crashers: 42 (5569 resolved)

Assertion failure in [`include/swift/AST/Requirement.h (line 66)`](https://github.com/apple/swift/blob/36e8d2861b75e80631344aedf9fc86116f117e45/include/swift/AST/Requirement.h#L66):

```
Assertion `second' failed.

When executing: swift::Requirement::Requirement(swift::RequirementKind, swift::Type, swift::Type)
```

Assertion context:

```c++
public:
  /// Create a conformance or same-type requirement.
  Requirement(RequirementKind kind, Type first, Type second)
    : FirstTypeAndKind(first, kind), SecondType(second) {
    assert(first);
    assert(second);
  }

  /// Create a layout constraint requirement.
  Requirement(RequirementKind kind, Type first, LayoutConstraint second)
    : FirstTypeAndKind(first, kind), SecondLayout(second) {
```
Stack trace:

```
0 0x0000000003a7b018 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3a7b018)
1 0x0000000003a7b756 SignalHandler(int) (/path/to/swift/bin/swift+0x3a7b756)
2 0x00007ff8d8771390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007ff8d6c96428 gsignal /build/glibc-bfm8X4/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007ff8d6c9802a abort /build/glibc-bfm8X4/glibc-2.23/stdlib/abort.c:91:0
5 0x00007ff8d6c8ebd7 __assert_fail_base /build/glibc-bfm8X4/glibc-2.23/assert/assert.c:92:0
6 0x00007ff8d6c8ec82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x000000000157e217 swift::GenericSignatureBuilder::addRequirement(swift::RequirementRepr const*, swift::GenericSignatureBuilder::FloatingRequirementSource, swift::SubstitutionMap const*, swift::ModuleDecl*) (/path/to/swift/bin/swift+0x157e217)
8 0x000000000157bd6f swift::GenericSignatureBuilder::addConformanceRequirement(swift::GenericSignatureBuilder::PotentialArchetype*, swift::ProtocolDecl*, swift::GenericSignatureBuilder::RequirementSource const*) (/path/to/swift/bin/swift+0x157bd6f)
9 0x000000000157fc55 swift::GenericSignatureBuilder::addTypeRequirement(llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::FloatingRequirementSource, swift::GenericSignatureBuilder::UnresolvedHandlingKind) (/path/to/swift/bin/swift+0x157fc55)
10 0x0000000001590d41 swift::GenericSignatureBuilder::ConstraintResult llvm::function_ref<swift::GenericSignatureBuilder::ConstraintResult (swift::Type, swift::TypeRepr const*)>::callback_fn<swift::GenericSignatureBuilder::addInheritedRequirements(swift::TypeDecl*, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::RequirementSource const*, swift::ModuleDecl*)::$_26>(long, swift::Type, swift::TypeRepr const*) (/path/to/swift/bin/swift+0x1590d41)
11 0x0000000001589522 std::_Function_handler<void (swift::Type, swift::TypeRepr const*), visitInherited(llvm::ArrayRef<swift::TypeLoc>, llvm::function_ref<swift::GenericSignatureBuilder::ConstraintResult (swift::Type, swift::TypeRepr const*)>)::$_59>::_M_invoke(std::_Any_data const&, swift::Type&&, swift::TypeRepr const*&&) (/path/to/swift/bin/swift+0x1589522)
12 0x000000000157b6a1 swift::GenericSignatureBuilder::addInheritedRequirements(swift::TypeDecl*, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::RequirementSource const*, swift::ModuleDecl*) (/path/to/swift/bin/swift+0x157b6a1)
13 0x000000000157b4be swift::GenericSignatureBuilder::addGenericParameterRequirements(swift::GenericTypeParamDecl*) (/path/to/swift/bin/swift+0x157b4be)
14 0x0000000001385a22 swift::TypeChecker::checkGenericParamList(swift::GenericSignatureBuilder*, swift::GenericParamList*, swift::GenericSignature*, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0x1385a22)
15 0x0000000001389004 swift::TypeChecker::checkGenericEnvironment(swift::GenericParamList*, swift::DeclContext*, swift::GenericSignature*, bool, llvm::function_ref<void (swift::GenericSignatureBuilder&)>) (/path/to/swift/bin/swift+0x1389004)
16 0x0000000001389429 swift::TypeChecker::validateGenericTypeSignature(swift::GenericTypeDecl*) (/path/to/swift/bin/swift+0x1389429)
17 0x000000000135a200 swift::TypeChecker::validateDecl(swift::ValueDecl*) (/path/to/swift/bin/swift+0x135a200)
18 0x0000000001369ee3 (anonymous namespace)::DeclChecker::visitProtocolDecl(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0x1369ee3)
19 0x0000000001358444 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x1358444)
20 0x000000000136915b (anonymous namespace)::DeclChecker::visitClassDecl(swift::ClassDecl*) (/path/to/swift/bin/swift+0x136915b)
21 0x000000000135853e (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x135853e)
22 0x0000000001358343 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x1358343)
23 0x00000000013e3344 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x13e3344)
24 0x0000000000fa16cd swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xfa16cd)
25 0x00000000004abe59 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4abe59)
26 0x00000000004aa3f9 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4aa3f9)
27 0x0000000000465697 main (/path/to/swift/bin/swift+0x465697)
28 0x00007ff8d6c81830 __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:325:0
29 0x0000000000462d39 _start (/path/to/swift/bin/swift+0x462d39)
```