### PR TITLE
[swiftc (43 vs. 5569)] Add crasher in swift::GenericSignatureBuilder::checkSameTypeConstraints

### DIFF
--- a/validation-test/compiler_crashers/28805-constraint-source-isderivedrequirement-must-not-be-derived.swift
+++ b/validation-test/compiler_crashers/28805-constraint-source-isderivedrequirement-must-not-be-derived.swift
@@ -1,0 +1,11 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol P{typealias a:RangeReplaceableCollection
+class a{}{}typealias e:Self.a.a


### PR DESCRIPTION
Add test case for crash triggered in `swift::GenericSignatureBuilder::checkSameTypeConstraints`.

Current number of unresolved compiler crashers: 43 (5569 resolved)

/cc @DougGregor - just wanted to let you know that this crasher caused an assertion failure for the assertion `!constraint.source->isDerivedRequirement() && "Must not be derived"` added on 2017-03-21 by you in commit ddc27755 :-)

Assertion failure in [`lib/AST/GenericSignatureBuilder.cpp (line 4763)`](https://github.com/apple/swift/blob/946b1503984804f4eb8a288660e9e6c58149f71e/lib/AST/GenericSignatureBuilder.cpp#L4763):

```
Assertion `!constraint.source->isDerivedRequirement() && "Must not be derived"' failed.

When executing: void swift::GenericSignatureBuilder::checkSameTypeConstraints(ArrayRef<swift::GenericTypeParamType *>, swift::GenericSignatureBuilder::PotentialArchetype *)
```

Assertion context:

```c++

void GenericSignatureBuilder::checkSameTypeConstraints(
                          ArrayRef<GenericTypeParamType *> genericParams,
                          PotentialArchetype *pa) {
  auto equivClass = pa->getEquivalenceClassIfPresent();
  if (!equivClass || !equivClass->derivedSameTypeComponents.empty())
    return;

  // Make sure that we've build the archetype anchors for each potential
  // archetype in this equivalence class. This is important to do for *all*
  // potential archetypes because some non-archetype anchors will nonetheless
```
Stack trace:

```
0 0x0000000003a7b018 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3a7b018)
1 0x0000000003a7b756 SignalHandler(int) (/path/to/swift/bin/swift+0x3a7b756)
2 0x00007f1aedfcb390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007f1aec4f0428 gsignal /build/glibc-bfm8X4/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f1aec4f202a abort /build/glibc-bfm8X4/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f1aec4e8bd7 __assert_fail_base /build/glibc-bfm8X4/glibc-2.23/assert/assert.c:92:0
6 0x00007f1aec4e8c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x0000000001585c35 swift::GenericSignatureBuilder::checkSameTypeConstraints(llvm::ArrayRef<swift::GenericTypeParamType*>, swift::GenericSignatureBuilder::PotentialArchetype*) (/path/to/swift/bin/swift+0x1585c35)
8 0x000000000158245a swift::GenericSignatureBuilder::finalize(swift::SourceLoc, llvm::ArrayRef<swift::GenericTypeParamType*>, bool) (/path/to/swift/bin/swift+0x158245a)
9 0x00000000015887c3 swift::GenericSignatureBuilder::computeGenericSignature(swift::SourceLoc, bool) (/path/to/swift/bin/swift+0x15887c3)
10 0x000000000154af9f swift::ProtocolDecl::computeRequirementSignature() (/path/to/swift/bin/swift+0x154af9f)
11 0x000000000135a3a0 swift::TypeChecker::validateDecl(swift::ValueDecl*) (/path/to/swift/bin/swift+0x135a3a0)
12 0x0000000001369ee3 (anonymous namespace)::DeclChecker::visitProtocolDecl(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0x1369ee3)
13 0x0000000001358444 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x1358444)
14 0x0000000001358343 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x1358343)
15 0x00000000013e3344 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x13e3344)
16 0x0000000000fa16cd swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xfa16cd)
17 0x00000000004abe59 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4abe59)
18 0x00000000004aa3f9 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4aa3f9)
19 0x0000000000465697 main (/path/to/swift/bin/swift+0x465697)
20 0x00007f1aec4db830 __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:325:0
21 0x0000000000462d39 _start (/path/to/swift/bin/swift+0x462d39)
```