### PR TITLE
[4.0] KeyPaths: Add support for optional chaining/forcing components.

### DIFF
--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -1469,6 +1469,11 @@ public:
     StoredProperty,
     GettableProperty,
     SettableProperty,
+    Last_Packed = SettableProperty, // Last enum value that can be packed in
+                                    // a PointerIntPair
+    OptionalChain,
+    OptionalForce,
+    OptionalWrap,
   };
   
   // The pair of a captured index value and its Hashable conformance for a
@@ -1479,40 +1484,63 @@ public:
   };
   
 private:
-  // Value is the VarDecl* for StoredProperty, and the SILFunction* of the
-  // Getter for computed properties
-  llvm::PointerIntPair<void *, 2, Kind> ValueAndKind;
+  static constexpr const unsigned KindPackingBits = 2;
+  static constexpr const unsigned UnpackedKind = (1u << KindPackingBits) - 1;
+  static_assert((unsigned)Kind::Last_Packed < UnpackedKind,
+                "too many kinds to pack");
+                
+  // Value is the VarDecl* for StoredProperty, the SILFunction* of the
+  // Getter for computed properties, or the Kind for other kinds
+  llvm::PointerIntPair<void *, KindPackingBits, unsigned> ValueAndKind;
   // false if id is a SILFunction*; true if id is a SILDeclRef
-  llvm::PointerIntPair<SILFunction *, 2, ComputedPropertyId::KindType>
+  llvm::PointerIntPair<SILFunction *, 2,
+                       ComputedPropertyId::KindType>
     SetterAndIdKind;
   ComputedPropertyId::ValueType IdValue;
   ArrayRef<IndexPair> Indices;
   CanType ComponentType;
-
+  
+  unsigned kindForPacking(Kind k) {
+    auto value = (unsigned)k;
+    assert(value <= (unsigned)Kind::Last_Packed);
+    return value;
+  }
+  
+  KeyPathPatternComponent(Kind kind, CanType ComponentType)
+    : ValueAndKind((void*)((uintptr_t)kind << KindPackingBits), UnpackedKind),
+      ComponentType(ComponentType)
+  {
+    assert(kind > Kind::Last_Packed && "wrong initializer");
+  }
+  
   KeyPathPatternComponent(VarDecl *storedProp, Kind kind,
                           CanType ComponentType)
-    : ValueAndKind(storedProp, kind), ComponentType(ComponentType) {}
+    : ValueAndKind(storedProp, kindForPacking(kind)),
+      ComponentType(ComponentType) {}
 
   KeyPathPatternComponent(ComputedPropertyId id, Kind kind,
                           SILFunction *getter,
                           SILFunction *setter,
                           ArrayRef<IndexPair> indices,
                           CanType ComponentType)
-    : ValueAndKind(getter, kind),
+    : ValueAndKind(getter, kindForPacking(kind)),
       SetterAndIdKind(setter, id.Kind),
       IdValue(id.Value),
       Indices(indices),
       ComponentType(ComponentType) {}
 
 public:
-  KeyPathPatternComponent() : ValueAndKind(nullptr, (Kind)0) {}
+  KeyPathPatternComponent() : ValueAndKind(nullptr, 0) {}
 
   bool isNull() const {
     return ValueAndKind.getPointer() == nullptr;
   }
 
   Kind getKind() const {
-    return ValueAndKind.getInt();
+    auto packedKind = ValueAndKind.getInt();
+    if (packedKind != UnpackedKind)
+      return (Kind)packedKind;
+    return (Kind)((uintptr_t)ValueAndKind.getPointer() >> KindPackingBits);
   }
   
   CanType getComponentType() const {
@@ -1525,6 +1553,9 @@ public:
       return static_cast<VarDecl*>(ValueAndKind.getPointer());
     case Kind::GettableProperty:
     case Kind::SettableProperty:
+    case Kind::OptionalChain:
+    case Kind::OptionalForce:
+    case Kind::OptionalWrap:
       llvm_unreachable("not a stored property");
     }
     llvm_unreachable("unhandled kind");
@@ -1533,6 +1564,9 @@ public:
   ComputedPropertyId getComputedPropertyId() const {
     switch (getKind()) {
     case Kind::StoredProperty:
+    case Kind::OptionalChain:
+    case Kind::OptionalForce:
+    case Kind::OptionalWrap:
       llvm_unreachable("not a computed property");
     case Kind::GettableProperty:
     case Kind::SettableProperty:
@@ -1544,6 +1578,9 @@ public:
   SILFunction *getComputedPropertyGetter() const {
     switch (getKind()) {
     case Kind::StoredProperty:
+    case Kind::OptionalChain:
+    case Kind::OptionalForce:
+    case Kind::OptionalWrap:
       llvm_unreachable("not a computed property");
     case Kind::GettableProperty:
     case Kind::SettableProperty:
@@ -1556,6 +1593,9 @@ public:
     switch (getKind()) {
     case Kind::StoredProperty:
     case Kind::GettableProperty:
+    case Kind::OptionalChain:
+    case Kind::OptionalForce:
+    case Kind::OptionalWrap:
       llvm_unreachable("not a settable computed property");
     case Kind::SettableProperty:
       return SetterAndIdKind.getPointer();
@@ -1566,6 +1606,9 @@ public:
   ArrayRef<IndexPair> getComputedPropertyIndices() const {
     switch (getKind()) {
     case Kind::StoredProperty:
+    case Kind::OptionalChain:
+    case Kind::OptionalForce:
+    case Kind::OptionalWrap:
       llvm_unreachable("not a computed property");
     case Kind::GettableProperty:
     case Kind::SettableProperty:
@@ -1597,6 +1640,24 @@ public:
                               CanType ty) {
     return KeyPathPatternComponent(identifier, Kind::SettableProperty,
                                    getter, setter, indices, ty);
+  }
+  
+  static KeyPathPatternComponent
+  forOptional(Kind kind, CanType ty) {
+    switch (kind) {
+    case Kind::OptionalChain:
+    case Kind::OptionalForce:
+      break;
+    case Kind::OptionalWrap:
+      assert(ty->getAnyOptionalObjectType()
+             && "optional wrap didn't form optional?!");
+      break;
+    case Kind::StoredProperty:
+    case Kind::GettableProperty:
+    case Kind::SettableProperty:
+      llvm_unreachable("not an optional kind");
+    }
+    return KeyPathPatternComponent(kind, ty);
   }
   
   void incrementRefCounts() const;

--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -380,7 +380,17 @@ IRGenModule::getAddrOfKeyPathPattern(KeyPathPattern *pattern,
                                "generic computed key paths");
         return llvm::UndefValue::get(Int8PtrTy);
       }
+      break;
     }
+    case KeyPathPatternComponent::Kind::OptionalChain:
+      fields.addInt32(KeyPathComponentHeader::forOptionalChain().getData());
+      break;
+    case KeyPathPatternComponent::Kind::OptionalForce:
+      fields.addInt32(KeyPathComponentHeader::forOptionalForce().getData());
+      break;
+    case KeyPathPatternComponent::Kind::OptionalWrap:
+      fields.addInt32(KeyPathComponentHeader::forOptionalWrap().getData());
+      break;
     }
     
     // For all but the last component, we pack in the type of the component.

--- a/lib/SIL/SILInstructions.cpp
+++ b/lib/SIL/SILInstructions.cpp
@@ -1983,6 +1983,9 @@ bool KeyPathPatternComponent::isComputedSettablePropertyMutating() const {
   switch (getKind()) {
   case Kind::StoredProperty:
   case Kind::GettableProperty:
+  case Kind::OptionalChain:
+  case Kind::OptionalWrap:
+  case Kind::OptionalForce:
     llvm_unreachable("not a settable computed property");
   case Kind::SettableProperty: {
     auto setter = getComputedPropertySetter();
@@ -1997,6 +2000,9 @@ forEachRefcountableReference(const KeyPathPatternComponent &component,
                          llvm::function_ref<void (SILFunction*)> forFunction) {
   switch (component.getKind()) {
   case KeyPathPatternComponent::Kind::StoredProperty:
+  case KeyPathPatternComponent::Kind::OptionalChain:
+  case KeyPathPatternComponent::Kind::OptionalWrap:
+  case KeyPathPatternComponent::Kind::OptionalForce:
     return;
   case KeyPathPatternComponent::Kind::SettableProperty:
     forFunction(component.getComputedPropertySetter());
@@ -2043,6 +2049,9 @@ KeyPathPattern::get(SILModule &M, CanGenericSignature signature,
   for (auto component : components) {
     switch (component.getKind()) {
     case KeyPathPatternComponent::Kind::StoredProperty:
+    case KeyPathPatternComponent::Kind::OptionalChain:
+    case KeyPathPatternComponent::Kind::OptionalWrap:
+    case KeyPathPatternComponent::Kind::OptionalForce:
       break;
       
     case KeyPathPatternComponent::Kind::GettableProperty:
@@ -2104,6 +2113,11 @@ void KeyPathPattern::Profile(llvm::FoldingSetNodeID &ID,
   for (auto &component : components) {
     ID.AddInteger((unsigned)component.getKind());
     switch (component.getKind()) {
+    case KeyPathPatternComponent::Kind::OptionalForce:
+    case KeyPathPatternComponent::Kind::OptionalWrap:
+    case KeyPathPatternComponent::Kind::OptionalChain:
+      break;
+      
     case KeyPathPatternComponent::Kind::StoredProperty:
       ID.AddPointer(component.getStoredPropertyDecl());
       break;

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -1860,6 +1860,25 @@ public:
                && "todo");
         break;
       }
+      case KeyPathPatternComponent::Kind::OptionalWrap:
+      case KeyPathPatternComponent::Kind::OptionalChain:
+      case KeyPathPatternComponent::Kind::OptionalForce: {
+        switch (kind) {
+        case KeyPathPatternComponent::Kind::OptionalWrap:
+          *this << "optional_wrap : $";
+          break;
+        case KeyPathPatternComponent::Kind::OptionalChain:
+          *this << "optional_chain : $";
+          break;
+        case KeyPathPatternComponent::Kind::OptionalForce:
+          *this << "optional_force : $";
+          break;
+        default:
+          llvm_unreachable("out of sync");
+        }
+        *this << component.getComponentType();
+        break;
+      }
       }
     }
     

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -3824,6 +3824,24 @@ public:
 
           break;
         }
+        case KeyPathPatternComponent::Kind::OptionalChain: {
+          require(OptionalType::get(componentTy)->isEqual(baseTy),
+                  "chaining component should unwrap optional");
+          require(leafTy->getAnyOptionalObjectType(),
+                  "key path with chaining component should have optional "
+                  "result");
+          break;
+        }
+        case KeyPathPatternComponent::Kind::OptionalForce: {
+          require(OptionalType::get(componentTy)->isEqual(baseTy),
+                  "forcing component should unwrap optional");
+          break;
+        }
+        case KeyPathPatternComponent::Kind::OptionalWrap: {
+          require(OptionalType::get(baseTy)->isEqual(componentTy),
+                  "wrapping component should wrap optional");
+          break;
+        }
         }
         
         baseTy = componentTy;

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2744,7 +2744,7 @@ RValue RValueEmitter::visitKeyPathExpr(KeyPathExpr *E, SGFContext C) {
   auto baseTy = rootTy;
   
   for (auto &component : E->getComponents()) {
-    switch (component.getKind()) {
+    switch (auto kind = component.getKind()) {
     case KeyPathExpr::Component::Kind::Property: {
       auto decl = cast<VarDecl>(component.getDeclRef().getDecl());
       auto oldBaseTy = baseTy;
@@ -2806,12 +2806,34 @@ RValue RValueEmitter::visitKeyPathExpr(KeyPathExpr *E, SGFContext C) {
       break;
     }
         
-    case KeyPathExpr::Component::Kind::Subscript:
     case KeyPathExpr::Component::Kind::OptionalChain:
     case KeyPathExpr::Component::Kind::OptionalForce:
-    case KeyPathExpr::Component::Kind::OptionalWrap:
-      return unsupported("non-property key path component");
-      
+    case KeyPathExpr::Component::Kind::OptionalWrap: {
+      KeyPathPatternComponent::Kind loweredKind;
+      switch (kind) {
+      case KeyPathExpr::Component::Kind::OptionalChain:
+        loweredKind = KeyPathPatternComponent::Kind::OptionalChain;
+        baseTy = baseTy->getAnyOptionalObjectType()->getCanonicalType();
+        break;
+      case KeyPathExpr::Component::Kind::OptionalForce:
+        loweredKind = KeyPathPatternComponent::Kind::OptionalForce;
+        baseTy = baseTy->getAnyOptionalObjectType()->getCanonicalType();
+        break;
+      case KeyPathExpr::Component::Kind::OptionalWrap:
+        loweredKind = KeyPathPatternComponent::Kind::OptionalWrap;
+        baseTy = OptionalType::get(baseTy)->getCanonicalType();
+        break;
+      default:
+        llvm_unreachable("out of sync");
+      }
+      loweredComponents.push_back(
+                    KeyPathPatternComponent::forOptional(loweredKind, baseTy));
+      break;
+    }
+        
+    case KeyPathExpr::Component::Kind::Subscript:
+      return unsupported("subscript key path component");
+        
     case KeyPathExpr::Component::Kind::Invalid:
     case KeyPathExpr::Component::Kind::UnresolvedProperty:
     case KeyPathExpr::Component::Kind::UnresolvedSubscript:

--- a/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
+++ b/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
@@ -226,6 +226,9 @@ protected:
         continue;
       }
       case KeyPathPatternComponent::Kind::StoredProperty:
+      case KeyPathPatternComponent::Kind::OptionalChain:
+      case KeyPathPatternComponent::Kind::OptionalForce:
+      case KeyPathPatternComponent::Kind::OptionalWrap:            
         continue;
       }
     }

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -4202,7 +4202,8 @@ namespace {
           baseTy &&
           !baseTy->hasUnresolvedType() &&
           !baseTy->isEqual(leafTy)) {
-        assert(leafTy->getAnyOptionalObjectType()->isEqual(baseTy));
+        assert(leafTy->getAnyOptionalObjectType()
+                     ->isEqual(baseTy->getLValueOrInOutObjectType()));
         auto component = KeyPathExpr::Component::forOptionalWrap(leafTy);
         resolvedComponents.push_back(component);
         baseTy = leafTy;

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2848,15 +2848,9 @@ namespace {
         case KeyPathExpr::Component::Kind::OptionalChain: {
           didOptionalChain = true;
           
-          // TODO: This currently crashes the compiler in some cases, so short-
-          // circuit out.
-          if (!CS.TC.Context.LangOpts.EnableExperimentalKeyPathComponents) {
-            return ErrorType::get(CS.TC.Context);
-          }
-          
           // We can't assign an optional back through an optional chain
           // today. Force the base to an rvalue.
-          auto rvalueTy = CS.createTypeVariable(locator, TVO_CanBindToInOut);
+          auto rvalueTy = CS.createTypeVariable(locator, 0);
           CS.addConstraint(ConstraintKind::Equal, base, rvalueTy, locator);
           base = rvalueTy;
           LLVM_FALLTHROUGH;

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1468,23 +1468,12 @@ void PreCheckExpression::resolveKeyPathExpr(KeyPathExpr *KPE) {
 
         expr = SE->getBase();
       } else if (auto BOE = dyn_cast<BindOptionalExpr>(expr)) {
-        if (!TC.Context.LangOpts.EnableExperimentalKeyPathComponents) {
-          TC.diagnose(BOE->getLoc(),
-                      diag::expr_swift_keypath_unimplemented_component,
-                      "optional chaining");
-        }
-
         // .? or ?
         components.push_back(KeyPathExpr::Component::forUnresolvedOptionalChain(
             BOE->getQuestionLoc()));
 
         expr = BOE->getSubExpr();
       } else if (auto FVE = dyn_cast<ForceValueExpr>(expr)) {
-        if (!TC.Context.LangOpts.EnableExperimentalKeyPathComponents) {
-          TC.diagnose(FVE->getLoc(),
-                      diag::expr_swift_keypath_unimplemented_component,
-                      "optional force-unwrapping");
-        }
         // .! or !
         components.push_back(KeyPathExpr::Component::forUnresolvedOptionalForce(
             FVE->getExclaimLoc()));

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -2143,6 +2143,18 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn, SILBasicBlock *BB,
                                                                {}, type));
         break;
       }
+      case KeyPathComponentKindEncoding::OptionalChain:
+        components.push_back(KeyPathPatternComponent::forOptional(
+            KeyPathPatternComponent::Kind::OptionalChain, type));
+        break;
+      case KeyPathComponentKindEncoding::OptionalForce:
+        components.push_back(KeyPathPatternComponent::forOptional(
+            KeyPathPatternComponent::Kind::OptionalForce, type));
+        break;
+      case KeyPathComponentKindEncoding::OptionalWrap:
+        components.push_back(KeyPathPatternComponent::forOptional(
+            KeyPathPatternComponent::Kind::OptionalWrap, type));
+        break;
       }
     }
     

--- a/lib/Serialization/SILFormat.h
+++ b/lib/Serialization/SILFormat.h
@@ -73,6 +73,9 @@ enum class KeyPathComponentKindEncoding : uint8_t {
   StoredProperty,
   GettableProperty,
   SettableProperty,
+  OptionalChain,
+  OptionalForce,
+  OptionalWrap,
 };
 enum class KeyPathComputedComponentIdKindEncoding : uint8_t {
   Property,

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -1900,6 +1900,15 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
         assert(component.getComputedPropertyIndices().empty()
                && "indices not implemented");
         break;
+      case KeyPathPatternComponent::Kind::OptionalChain:
+        handleComponentCommon(KeyPathComponentKindEncoding::OptionalChain);
+        break;
+      case KeyPathPatternComponent::Kind::OptionalForce:
+        handleComponentCommon(KeyPathComponentKindEncoding::OptionalForce);
+        break;
+      case KeyPathPatternComponent::Kind::OptionalWrap:
+        handleComponentCommon(KeyPathComponentKindEncoding::OptionalWrap);
+        break;
       }
     }
     

--- a/test/SIL/Parser/keypath.sil
+++ b/test/SIL/Parser/keypath.sil
@@ -90,3 +90,14 @@ entry:
 
   return undef : $()
 }
+
+// CHECK-LABEL: sil @optional
+sil @optional : $@convention(thin) () -> () {
+entry:
+  // CHECK: keypath $KeyPath<Optional<Int>, Optional<Int>>, (root $Optional<Int>; optional_chain : $Int; optional_wrap : $Optional<Int>)
+  %a = keypath $KeyPath<Optional<Int>, Optional<Int>>, (root $Optional<Int>; optional_chain : $Int; optional_wrap : $Optional<Int>)
+  // CHECK: keypath $KeyPath<Optional<Int>, Int>, (root $Optional<Int>; optional_force : $Int)
+  %b = keypath $KeyPath<Optional<Int>, Int>, (root $Optional<Int>; optional_force : $Int)
+
+  return undef : $()
+}

--- a/test/SIL/Serialization/keypath.sil
+++ b/test/SIL/Serialization/keypath.sil
@@ -96,12 +96,24 @@ entry:
   return undef : $()
 }
 
+// CHECK-LABEL: sil shared @optional
+sil shared @optional : $@convention(thin) () -> () {
+entry:
+  // CHECK: keypath $KeyPath<Optional<Int>, Optional<Int>>, (root $Optional<Int>; optional_chain : $Int; optional_wrap : $Optional<Int>)
+  %a = keypath $KeyPath<Optional<Int>, Optional<Int>>, (root $Optional<Int>; optional_chain : $Int; optional_wrap : $Optional<Int>)
+  // CHECK: keypath $KeyPath<Optional<Int>, Int>, (root $Optional<Int>; optional_force : $Int)
+  %b = keypath $KeyPath<Optional<Int>, Int>, (root $Optional<Int>; optional_force : $Int)
+
+  return undef : $()
+}
+
 sil @serialize_all : $@convention(thin) () -> () {
 entry:
   %0 = function_ref @stored_properties : $@convention(thin) () -> ()
   %1 = function_ref @stored_properties_generic : $@convention(thin) <D: P, E: Q, F: R> () -> ()
   %2 = function_ref @computed_properties : $@convention(thin) () -> ()
   %3 = function_ref @computed_properties_generic : $@convention(thin) <D: P, E: Q, F: R> () -> ()
+  %4 = function_ref @optional : $@convention(thin) () -> ()
 
   unreachable
 }

--- a/test/SILGen/keypaths.swift
+++ b/test/SILGen/keypaths.swift
@@ -182,3 +182,30 @@ func keyPathForExistentialMember() {
   _ = \P.z
   _ = \P.w
 }
+
+struct OptionalFields {
+  var x: S<Int>?
+}
+struct OptionalFields2 {
+  var y: OptionalFields?
+}
+
+// CHECK-LABEL: sil hidden @_T08keypaths18keyPathForOptionalyyF
+func keyPathForOptional() {
+  // CHECK: keypath $WritableKeyPath<OptionalFields, S<Int>>, (
+  // CHECK-SAME:   stored_property #OptionalFields.x : $Optional<S<Int>>;
+  // CHECK-SAME:   optional_force : $S<Int>)
+  _ = \OptionalFields.x!
+  // CHECK: keypath $KeyPath<OptionalFields, Optional<String>>, (
+  // CHECK-SAME:   stored_property #OptionalFields.x : $Optional<S<Int>>;
+  // CHECK-SAME:   optional_chain : $S<Int>;
+  // CHECK-SAME:   stored_property #S.y : $String;
+  // CHECK-SAME:   optional_wrap : $Optional<String>)
+  _ = \OptionalFields.x?.y
+  // CHECK: keypath $KeyPath<OptionalFields2, Optional<S<Int>>>, (
+  // CHECK-SAME:   root $OptionalFields2;
+  // CHECK-SAME:   stored_property #OptionalFields2.y : $Optional<OptionalFields>;
+  // CHECK-SAME:   optional_chain : $OptionalFields;
+  // CHECK-SAME:   stored_property #OptionalFields.x : $Optional<S<Int>>)
+  _ = \OptionalFields2.y?.x
+}

--- a/test/expr/unary/keypath/keypath-unimplemented.swift
+++ b/test/expr/unary/keypath/keypath-unimplemented.swift
@@ -10,8 +10,6 @@ class C {
 }
 
 func unsupportedComponents() {
-  _ = \A.c?.i // expected-error{{key path support for optional chaining components is not implemented}}
-  _ = \A.c!.i // expected-error{{key path support for optional force-unwrapping components is not implemented}}
   _ = \A.[0] // expected-error{{key path support for subscript components is not implemented}}
 }
 

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -322,6 +322,20 @@ func testKeyPathSubscriptTuple(readonly: (Z,Z), writable: inout (Z,Z),
   writable[keyPath: rkp] = sink
 }
 
+struct AA {
+  subscript(x: Int) -> Int { return x }
+  var c: CC? = CC()
+}
+
+class CC {
+  var i = 0
+}
+
+func testKeyPathOptional() {
+  _ = \AA.c?.i
+  _ = \AA.c!.i
+}
+
 func testSyntaxErrors() { // expected-note{{}}
   // TODO: recovery
   _ = \.  ; // expected-error{{expected member name following '.'}}


### PR DESCRIPTION
Explanation: Adds support for optional chaining and force-unwrapping components in keypaths, part of the original proposal that didn't make it into the first Swift beta.

Scope: New feature

Issue: rdar://problem/31768715

Risk: Low, additive feature work that should not disturb existing code.

Testing: Swift CI