### PR TITLE
[Migrator] Use toLowercaseWord to lowercase SetterToProperty changes

### DIFF
--- a/lib/Migrator/APIDiffMigratorPass.cpp
+++ b/lib/Migrator/APIDiffMigratorPass.cpp
@@ -12,6 +12,7 @@
 
 #include "swift/AST/USRGeneration.h"
 #include "swift/AST/ASTVisitor.h"
+#include "swift/Basic/StringExtras.h"
 #include "swift/Frontend/Frontend.h"
 #include "swift/IDE/Utils.h"
 #include "swift/Index/Utils.h"
@@ -607,8 +608,9 @@ struct APIDiffMigratorPass : public ASTMigratorPass, public SourceEntityWalker {
           // Replace "x.getY(" with "x.Y =".
           auto Replacement = (llvm::Twine(Walker.Result.str()
                                           .substr(3)) + " = ").str();
-          Replacement[0] = tolower(Replacement[0]);
-          Editor.replace(ReplaceRange, Replacement);
+          SmallString<64> Scratch;
+          Editor.replace(ReplaceRange,
+                         camel_case::toLowercaseInitialisms(Replacement, Scratch));
 
           // Remove ")"
           Editor.remove(CharSourceRange(SM, Arg->getEndLoc(), Arg->getEndLoc().

--- a/test/Migrator/Inputs/API.json
+++ b/test/Migrator/Inputs/API.json
@@ -130,6 +130,17 @@
   {
     "DiffItemKind": "CommonDiffItem",
     "NodeKind": "Function",
+    "NodeAnnotation": "SetterToProperty",
+    "ChildIndex": "0",
+    "LeftUsr": "c:objc(cs)PropertyUserInterface(im)setURL:",
+    "LeftComment": "",
+    "RightUsr": "",
+    "RightComment": "",
+    "ModuleName": "bar"
+  },
+  {
+    "DiffItemKind": "CommonDiffItem",
+    "NodeKind": "Function",
     "NodeAnnotation": "UnwrapOptional",
     "ChildIndex": "2",
     "LeftUsr": "s:6CitiesAAC10mooloolabayAB1x_ABSg1ytF",

--- a/test/Migrator/mock-sdk/Bar.framework/Headers/Bar.h
+++ b/test/Migrator/mock-sdk/Bar.framework/Headers/Bar.h
@@ -25,6 +25,7 @@ enum BarForwardDeclaredEnum {
 - (int) field;
 - (int * _Nullable) field2;
 - (void) setField:(int)info;
+- (void) setURL:(int)url;
 + (int) fieldPlus;
 + (void) methodPlus:(int)info;
 + (void) methodPlus;

--- a/test/Migrator/pre_fixit_pass.swift
+++ b/test/Migrator/pre_fixit_pass.swift
@@ -11,5 +11,6 @@ Old()
 
 func foo(_ a : PropertyUserInterface) {
   a.setField(1)
+  a.setURL(1)
   _ = a.field()
 }

--- a/test/Migrator/pre_fixit_pass.swift.expected
+++ b/test/Migrator/pre_fixit_pass.swift.expected
@@ -11,5 +11,6 @@ New()
 
 func foo(_ a : PropertyUserInterface) {
   a.field = 1
+  a.url = 1
   _ = a.field
 }

--- a/test/Migrator/property.swift
+++ b/test/Migrator/property.swift
@@ -7,6 +7,7 @@ import Bar
 
 func foo(_ a : PropertyUserInterface) {
   a.setField(1)
+  a.setURL(1)
   _ = a.field()
 }
 

--- a/test/Migrator/property.swift.expected
+++ b/test/Migrator/property.swift.expected
@@ -7,6 +7,7 @@ import Bar
 
 func foo(_ a : PropertyUserInterface) {
   a.field = 1
+  a.url = 1
   _ = a.field
 }
 


### PR DESCRIPTION
Post-commit review follow-up:
This works better for properties that were all-caps, such as `URL`.

Thanks @harlanhaskins for the tip!

rdar://problem/32845968