### PR TITLE
Generalize sanitizer tests.

### DIFF
--- a/test/Sanitizers/asan.swift
+++ b/test/Sanitizers/asan.swift
@@ -1,9 +1,8 @@
-// RUN: %target-swiftc_driver %s -g -sanitize=address -o %t_tsan-binary
-// RUN: not env ASAN_OPTIONS=abort_on_error=0 %target-run %t_tsan-binary 2>&1 | %FileCheck %s
+// RUN: %target-swiftc_driver %s -g -sanitize=address -o %t_asan-binary
+// RUN: not env %env-ASAN_OPTIONS=abort_on_error=0 %target-run %t_asan-binary 2>&1 | %FileCheck %s
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
 // REQUIRES: asan_runtime
-// XFAIL: linux
 
 // Make sure we can handle swifterror. LLVM's address sanitizer pass needs to
 // ignore swifterror addresses.

--- a/test/Sanitizers/tsan-ignores-arc-locks.swift
+++ b/test/Sanitizers/tsan-ignores-arc-locks.swift
@@ -1,7 +1,6 @@
 // RUN: %target-build-swift -sanitize=thread %s -o %t_binary
-// RUN: TSAN_OPTIONS=ignore_interceptors_accesses=1:halt_on_error=1 %t_binary
+// RUN: %env-TSAN_OPTIONS=ignore_interceptors_accesses=1:halt_on_error=1 %t_binary
 // REQUIRES: executable_test
-// REQUIRES: CPU=x86_64
 // REQUIRES: tsan_runtime
 // REQUIRES: objc_interop
 

--- a/test/Sanitizers/tsan-inout.swift
+++ b/test/Sanitizers/tsan-inout.swift
@@ -1,13 +1,11 @@
 // RUN: %target-build-swift %S/Inputs/tsan-uninstrumented.swift -module-name TSanUninstrumented -emit-module -emit-module-path %T/TSanUninstrumented.swiftmodule -parse-as-library
 // RUN: %target-build-swift %S/Inputs/tsan-uninstrumented.swift -c -module-name TSanUninstrumented -parse-as-library -o %T/TSanUninstrumented.o
 // RUN: %target-swiftc_driver %s %T/TSanUninstrumented.o -I%T -L%T -g -sanitize=thread -o %t_tsan-binary
-// RUN: not env TSAN_OPTIONS=abort_on_error=0 %target-run %t_tsan-binary 2>&1 | %FileCheck %s
-// RUN: not env TSAN_OPTIONS=abort_on_error=0:ignore_interceptors_accesses=0 %target-run %t_tsan-binary 2>&1 | %FileCheck %s --check-prefix CHECK-INTERCEPTORS-ACCESSES
+// RUN: not env %env-TSAN_OPTIONS=abort_on_error=0 %target-run %t_tsan-binary 2>&1 | %FileCheck %s
+// RUN: not env %env-TSAN_OPTIONS=abort_on_error=0:ignore_interceptors_accesses=0 %target-run %t_tsan-binary 2>&1 | %FileCheck %s --check-prefix CHECK-INTERCEPTORS-ACCESSES
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
-// REQUIRES: CPU=x86_64
 // REQUIRES: tsan_runtime
-// XFAIL: linux
 
 // Test ThreadSanitizer execution end-to-end when calling
 // an uninstrumented module with inout parameters

--- a/test/Sanitizers/tsan-norace-block-release.swift
+++ b/test/Sanitizers/tsan-norace-block-release.swift
@@ -1,10 +1,8 @@
 // RUN: %target-swiftc_driver %s -g -sanitize=thread -o %t_tsan-binary
-// RUN: env TSAN_OPTIONS=abort_on_error=0:ignore_interceptors_accesses=1 %target-run %t_tsan-binary 2>&1 | %FileCheck %s
+// RUN: env %env-TSAN_OPTIONS=abort_on_error=0:ignore_interceptors_accesses=1 %target-run %t_tsan-binary 2>&1 | %FileCheck %s
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
-// REQUIRES: CPU=x86_64
 // REQUIRES: tsan_runtime
-// XFAIL: linux
 
 // Test that we do not report a race on block release operation.
 import Foundation

--- a/test/Sanitizers/tsan-norace-deinit-run-time.swift
+++ b/test/Sanitizers/tsan-norace-deinit-run-time.swift
@@ -1,10 +1,8 @@
 // RUN: %target-swiftc_driver %s -g -sanitize=thread -o %t_tsan-binary
-// RUN: env TSAN_OPTIONS=abort_on_error=0:ignore_interceptors_accesses=1 %target-run %t_tsan-binary 2>&1 | %FileCheck %s
+// RUN: env %env-TSAN_OPTIONS=abort_on_error=0:ignore_interceptors_accesses=1 %target-run %t_tsan-binary 2>&1 | %FileCheck %s
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
-// REQUIRES: CPU=x86_64
 // REQUIRES: tsan_runtime
-// XFAIL: linux
 
 // Test that we do not report a race on deinit; the synchronization is guaranteed by runtime.
 import Foundation

--- a/test/Sanitizers/tsan-type-metadata.swift
+++ b/test/Sanitizers/tsan-type-metadata.swift
@@ -1,9 +1,7 @@
 // RUN: %target-build-swift -sanitize=thread %s -o %t_binary
-// RUN: TSAN_OPTIONS=ignore_interceptors_accesses=1:halt_on_error=1 %t_binary
+// RUN: %env-TSAN_OPTIONS=ignore_interceptors_accesses=1:halt_on_error=1 %t_binary
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
-// REQUIRES: CPU=x86_64
-// REQUIRES: OS=macosx
 // REQUIRES: tsan_runtime
 
 // We expect not to report any races on this testcase.

--- a/test/Sanitizers/tsan.swift
+++ b/test/Sanitizers/tsan.swift
@@ -1,8 +1,7 @@
 // RUN: %target-swiftc_driver %s -g -sanitize=thread -o %t_tsan-binary
-// RUN: not env TSAN_OPTIONS=abort_on_error=0 %target-run %t_tsan-binary 2>&1 | %FileCheck %s
+// RUN: not env %env-TSAN_OPTIONS=abort_on_error=0 %target-run %t_tsan-binary 2>&1 | %FileCheck %s
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
-// REQUIRES: CPU=x86_64
 // REQUIRES: tsan_runtime
 
 // Make sure we can handle swifterror and don't bail during the LLVM

--- a/test/Sanitizers/witness_table_lookup.swift
+++ b/test/Sanitizers/witness_table_lookup.swift
@@ -1,8 +1,6 @@
 // RUN: %target-build-swift -sanitize=thread %s -o %t_binary
-// RUN: TSAN_OPTIONS=ignore_interceptors_accesses=1:halt_on_error=1 %t_binary
+// RUN: %env-TSAN_OPTIONS=ignore_interceptors_accesses=1:halt_on_error=1 %t_binary
 // REQUIRES: executable_test
-// REQUIRES: CPU=x86_64
-// REQUIRES: OS=macosx
 // REQUIRES: tsan_runtime
 
 // Check that TSan does not report spurious races in witness table lookup.

--- a/test/Sanitizers/witness_table_lookup.swift
+++ b/test/Sanitizers/witness_table_lookup.swift
@@ -2,6 +2,7 @@
 // RUN: %env-TSAN_OPTIONS=ignore_interceptors_accesses=1:halt_on_error=1 %t_binary
 // REQUIRES: executable_test
 // REQUIRES: tsan_runtime
+// REQUIRES: objc_interop
 
 // Check that TSan does not report spurious races in witness table lookup.
 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -886,7 +886,7 @@ else:
 # In order to make tests OS-agnostic, names of environment variables should be
 # prefixed with `%env-`, which is then expanded to the appropriate prefix.
 ENV_VAR_PREFIXES = {'iphonesimulator': 'SIMCTL_CHILD_'}
-config.substitutions.append(('%env-', ENV_VAR_PREFIXES.get(xcrun_sdk_name, "")))
+config.substitutions.append(('%env-', ENV_VAR_PREFIXES.get(config.target_sdk_name, "")))
 config.substitutions.append(("%target-sdk-name", config.target_sdk_name))
 
 config.compiler_rt_libs = []

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -881,6 +881,12 @@ else:
                      "target_build_swift for platform " + config.variant_triple)
 
 
+# Different OS's require different prefixes for the environment variables to be
+# propagated to the calling contexts.
+# In order to make tests OS-agnostic, names of environment variables should be
+# prefixed with `%env-`, which is then expanded to the appropriate prefix.
+ENV_VAR_PREFIXES = {'iphonesimulator': 'SIMCTL_CHILD_'}
+config.substitutions.append(('%env-', ENV_VAR_PREFIXES.get(xcrun_sdk_name, "")))
 config.substitutions.append(("%target-sdk-name", config.target_sdk_name))
 
 config.compiler_rt_libs = []


### PR DESCRIPTION
 - Remove redundant XFAIL/REQUIRE, *_runtime variable should be
sufficient to specify whether the test can be run.
 - Provide required machinery to pass environment variables
to different operating systems in a generalized way
(e.g. iOS Simulator only passes environment variables starting with a
certain prefix).