### PR TITLE
migrator: handle qualified replacement for member reference expression.  rdar://32845918

### DIFF
--- a/lib/Migrator/APIDiffMigratorPass.cpp
+++ b/lib/Migrator/APIDiffMigratorPass.cpp
@@ -367,20 +367,26 @@ struct APIDiffMigratorPass : public ASTMigratorPass, public SourceEntityWalker {
   }
 
   bool handleQualifiedReplacement(Expr* Call) {
-    if (auto *DSC = dyn_cast<DotSyntaxCallExpr>(Call)) {
-      if (auto FD = DSC->getFn()->getReferencedDecl().getDecl()) {
-        for (auto *I :getRelatedDiffItems(FD)) {
-          if (auto *Item = dyn_cast<TypeMemberDiffItem>(I)) {
-            if (Item->Subkind == TypeMemberDiffItemSubKind::
-                QualifiedReplacement) {
-              Editor.replace(Call->getSourceRange(),
-                (llvm::Twine(Item->newTypeName) + "." +
-                  Item->getNewName().base()).str());
-              return true;
-            }
+    auto handleDecl = [&](ValueDecl *VD, SourceRange ToReplace) {
+      for (auto *I: getRelatedDiffItems(VD)) {
+        if (auto *Item = dyn_cast<TypeMemberDiffItem>(I)) {
+          if (Item->Subkind == TypeMemberDiffItemSubKind::QualifiedReplacement) {
+            Editor.replace(ToReplace, (llvm::Twine(Item->newTypeName) + "." +
+              Item->getNewName().base()).str());
+            return true;
           }
         }
       }
+      return false;
+    };
+    if (auto *DSC = dyn_cast<DotSyntaxCallExpr>(Call)) {
+      if (auto FD = DSC->getFn()->getReferencedDecl().getDecl()) {
+        if (handleDecl(FD, Call->getSourceRange()))
+          return true;
+      }
+    } else if (auto MRE = dyn_cast<MemberRefExpr>(Call)) {
+      if (handleDecl(MRE->getReferencedDecl().getDecl(), MRE->getSourceRange()))
+        return true;
     }
     return false;
   }

--- a/test/Migrator/Inputs/Cities.swift
+++ b/test/Migrator/Inputs/Cities.swift
@@ -9,6 +9,9 @@ open class Cities {
   open func buderim() -> Cities? { return Cities(x: 1) }
   open func noosa() -> [[String : Cities]?] { return [] }
   open func maroochy(x: Int?, y: Int?) {}
+  public struct CityKind {
+    static public let Town = 1
+  }
 }
 
 public protocol ExtraCities {

--- a/test/Migrator/Inputs/qualified.json
+++ b/test/Migrator/Inputs/qualified.json
@@ -22,5 +22,13 @@
     "OldTypeName": "FooComparisonResult",
     "NewPrintedName": "NewFooOrderedSame",
     "NewTypeName": "NewFooComparisonResult"
+  },
+  {
+    "DiffItemKind": "TypeMemberDiffItem",
+    "Usr": "s:6CitiesAAC8CityKindV4TownSivZ",
+    "OldPrintedName": "town",
+    "OldTypeName": "Cities.CityKind",
+    "NewPrintedName": "NewTown",
+    "NewTypeName": "NewCityKind"
   }
 ]

--- a/test/Migrator/qualified-replacement.swift
+++ b/test/Migrator/qualified-replacement.swift
@@ -1,11 +1,15 @@
 // REQUIRES: objc_interop
-// RUN: %empty-directory(%t) && %target-swift-frontend -c -update-code -primary-file %s -F %S/mock-sdk -api-diff-data-file %S/Inputs/qualified.json -emit-migrated-file-path %t/qualified-replacement.swift.result -emit-remap-file-path %t/qualified-replacement.swift.remap -o /dev/null
+// RUN: %empty-directory(%t.mod)
+// RUN: %target-swift-frontend -emit-module -o %t.mod/Cities.swiftmodule %S/Inputs/Cities.swift -module-name Cities -parse-as-library
+// RUN: %empty-directory(%t) && %target-swift-frontend -c -update-code -primary-file %s -F %S/mock-sdk -I %t.mod -api-diff-data-file %S/Inputs/qualified.json -emit-migrated-file-path %t/qualified-replacement.swift.result -emit-remap-file-path %t/qualified-replacement.swift.remap -o /dev/null
 // RUN: diff -u %S/qualified-replacement.swift.expected %t/qualified-replacement.swift.result
 
+import Cities
 import Bar
 func foo() {
   _ = PropertyUserInterface.fieldPlus
   PropertyUserInterface.methodPlus(1)
   _ = FooComparisonResult.orderedSame
   let _ : FooComparisonResult = .orderedSame
+  _ = Cities.CityKind.Town
 }

--- a/test/Migrator/qualified-replacement.swift.expected
+++ b/test/Migrator/qualified-replacement.swift.expected
@@ -1,11 +1,15 @@
 // REQUIRES: objc_interop
-// RUN: %empty-directory(%t) && %target-swift-frontend -c -update-code -primary-file %s -F %S/mock-sdk -api-diff-data-file %S/Inputs/qualified.json -emit-migrated-file-path %t/qualified-replacement.swift.result -emit-remap-file-path %t/qualified-replacement.swift.remap -o /dev/null
+// RUN: %empty-directory(%t.mod)
+// RUN: %target-swift-frontend -emit-module -o %t.mod/Cities.swiftmodule %S/Inputs/Cities.swift -module-name Cities -parse-as-library
+// RUN: %empty-directory(%t) && %target-swift-frontend -c -update-code -primary-file %s -F %S/mock-sdk -I %t.mod -api-diff-data-file %S/Inputs/qualified.json -emit-migrated-file-path %t/qualified-replacement.swift.result -emit-remap-file-path %t/qualified-replacement.swift.remap -o /dev/null
 // RUN: diff -u %S/qualified-replacement.swift.expected %t/qualified-replacement.swift.result
 
+import Cities
 import Bar
 func foo() {
   _ = NewPropertyUserInterface.newFieldPlus
   NewPropertyUserInterface.newMethodPlus(1)
   _ = NewFooComparisonResult.NewFooOrderedSame
   let _ : FooComparisonResult = NewFooComparisonResult.NewFooOrderedSame
+  _ = NewCityKind.NewTown
 }


### PR DESCRIPTION
Previously, we only handle dot syntax call expression for qualified
replacement, i.e. changing from A.a to B.b. This patch teaches the tool
to handle the migration of member reference expression tool.