### PR TITLE
[Exclusivity] Relax closure enforcement on separate stored properties

### DIFF
--- a/lib/SILOptimizer/Mandatory/DiagnoseStaticExclusivity.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseStaticExclusivity.cpp
@@ -635,45 +635,11 @@ tryFixItWithCallToCollectionSwapAt(const BeginAccessInst *Access1,
 static std::string getPathDescription(DeclName BaseName, SILType BaseType,
                                       const IndexTrieNode *SubPath,
                                       SILModule &M) {
-  // Walk the trie to the root to collection the sequence (in reverse order).
-  llvm::SmallVector<unsigned, 4> ReversedIndices;
-  const IndexTrieNode *I = SubPath;
-  while (!I->isRoot()) {
-    ReversedIndices.push_back(I->getIndex());
-    I = I->getParent();
-  }
-
   std::string sbuf;
   llvm::raw_string_ostream os(sbuf);
 
   os << "'" << BaseName;
-
-  SILType ContainingType = BaseType;
-  for (unsigned Index : reversed(ReversedIndices)) {
-    os << ".";
-
-    if (StructDecl *D = ContainingType.getStructOrBoundGenericStruct()) {
-      auto Iter = D->getStoredProperties().begin();
-      std::advance(Iter, Index);
-      VarDecl *VD = *Iter;
-      os << VD->getBaseName();
-      ContainingType = ContainingType.getFieldType(VD, M);
-      continue;
-    }
-
-    if (auto TupleTy = ContainingType.getAs<TupleType>()) {
-      Identifier ElementName = TupleTy->getElement(Index).getName();
-      if (ElementName.empty())
-        os << Index;
-      else
-        os << ElementName;
-      ContainingType = ContainingType.getTupleElementType(Index);
-      continue;
-    }
-
-    llvm_unreachable("Unexpected type in projection SubPath!");
-  }
-
+  os << AccessSummaryAnalysis::getSubPathDescription(BaseType, SubPath, M);
   os << "'";
 
   return os.str();
@@ -848,64 +814,6 @@ static bool isCallToStandardLibrarySwap(ApplyInst *AI, ASTContext &Ctx) {
   return FD == Ctx.getSwap(nullptr);
 }
 
-/// If the instruction is a field or tuple projection and it has a single
-/// user return a pair of the single user and the projection index.
-/// Otherwise, return a pair with the component nullptr and the second
-/// unspecified.
-static std::pair<SILInstruction *, unsigned>
-getSingleAddressProjectionUser(SILInstruction *I) {
-  SILInstruction *SingleUser = nullptr;
-  unsigned ProjectionIndex = 0;
-
-  for (Operand *Use : I->getUses()) {
-    SILInstruction *User = Use->getUser();
-    if (isa<BeginAccessInst>(I) && isa<EndAccessInst>(User))
-      continue;
-
-    // We have more than a single user so bail.
-    if (SingleUser)
-      return std::make_pair(nullptr, 0);
-
-    switch (User->getKind()) {
-    case ValueKind::StructElementAddrInst:
-      ProjectionIndex = cast<StructElementAddrInst>(User)->getFieldNo();
-      SingleUser = User;
-      break;
-    case ValueKind::TupleElementAddrInst:
-      ProjectionIndex = cast<TupleElementAddrInst>(User)->getFieldNo();
-      SingleUser = User;
-      break;
-    default:
-      return std::make_pair(nullptr, 0);
-    }
-  }
-
-  return std::make_pair(SingleUser, ProjectionIndex);
-}
-
-/// Returns an IndexTrieNode that represents the single subpath accessed from
-/// BAI or the root if no such node exists.
-static const IndexTrieNode *findSubPathAccessed(BeginAccessInst *BAI,
-                                                IndexTrieNode *Root) {
-  IndexTrieNode *SubPath = Root;
-
-  // For each single-user projection of BAI, construct or get a node
-  // from the trie representing the index of the field or tuple element
-  // accessed by that projection.
-  SILInstruction *Iter = BAI;
-  while (true) {
-    std::pair<SILInstruction *, unsigned> ProjectionUser =
-        getSingleAddressProjectionUser(Iter);
-    if (!ProjectionUser.first)
-      break;
-
-    SubPath = SubPath->getChild(ProjectionUser.second);
-    Iter = ProjectionUser.first;
-  }
-
-  return SubPath;
-}
-
 /// If making an access of the given kind at the given subpath would
 /// would conflict, returns the first recorded access it would conflict
 /// with. Otherwise, returns None.
@@ -939,9 +847,13 @@ static void checkForViolationWithCall(
 
     const AccessSummaryAnalysis::ArgumentSummary &AS =
         FS.getAccessForArgument(CalleeIndex);
-    Optional<SILAccessKind> Kind = AS.getAccessKind();
-    if (!Kind)
+
+    unsigned SubAccessCount = AS.getSubAccessCount();
+    if (SubAccessCount == 0)
       continue;
+    SmallVector<AccessSummaryAnalysis::SubAccessSummary, 8> Sorted;
+    Sorted.reserve(SubAccessCount);
+    AS.getSortedSubAccesses(Sorted);
 
     SILValue Argument = Arguments[ArgumentIndex];
     assert(Argument->getType().isAddress());
@@ -952,14 +864,17 @@ static void checkForViolationWithCall(
       continue;
     const AccessInfo &Info = AccessIt->getSecond();
 
-    // TODO: For now, treat a summarized access as an access to the whole
-    // address. Once the summary analysis is sensitive to stored properties,
-    // this should be updated look at the subpaths from the summary.
-    const IndexTrieNode *SubPath = ASA->getSubPathTrieRoot();
-    if (auto Conflict = shouldReportAccess(Info, *Kind, SubPath)) {
-      SILLocation AccessLoc = AS.getAccessLoc();
-      const auto &SecondAccess = RecordedAccess(*Kind, AccessLoc, SubPath);
-      ConflictingAccesses.emplace_back(Storage, *Conflict, SecondAccess);
+    /// For each projection that the summarized function accesses on its
+    /// captures, check whether the access conflics with already-in-progress
+    /// access.
+    for (auto &SubAccess : Sorted) {
+      const IndexTrieNode *SubPath = SubAccess.getSubPath();
+      SILAccessKind Kind = SubAccess.getAccessKind();
+      if (auto Conflict = shouldReportAccess(Info, Kind, SubPath)) {
+        SILLocation AccessLoc = SubAccess.getAccessLoc();
+        const auto &SecondAccess = RecordedAccess(Kind, AccessLoc, SubPath);
+        ConflictingAccesses.emplace_back(Storage, *Conflict, SecondAccess);
+      }
     }
   }
 }
@@ -1086,8 +1001,7 @@ static void checkStaticExclusivity(SILFunction &Fn, PostOrderFunctionInfo *PO,
         SILAccessKind Kind = BAI->getAccessKind();
         const AccessedStorage &Storage = findAccessedStorage(BAI->getSource());
         AccessInfo &Info = Accesses[Storage];
-        const IndexTrieNode *SubPath =
-            findSubPathAccessed(BAI, ASA->getSubPathTrieRoot());
+        const IndexTrieNode *SubPath = ASA->findSubPathAccessed(BAI);
         if (auto Conflict = shouldReportAccess(Info, Kind, SubPath)) {
           ConflictingAccesses.emplace_back(Storage, *Conflict,
                                            RecordedAccess(BAI, SubPath));
@@ -1102,8 +1016,7 @@ static void checkStaticExclusivity(SILFunction &Fn, PostOrderFunctionInfo *PO,
         AccessInfo &Info = It->getSecond();
 
         BeginAccessInst *BAI = EAI->getBeginAccess();
-        const IndexTrieNode *SubPath =
-            findSubPathAccessed(BAI, ASA->getSubPathTrieRoot());
+        const IndexTrieNode *SubPath = ASA->findSubPathAccessed(BAI);
         Info.endAccess(EAI, SubPath);
 
         // If the storage location has no more in-progress accesses, remove

--- a/lib/SILOptimizer/UtilityPasses/AccessSummaryDumper.cpp
+++ b/lib/SILOptimizer/UtilityPasses/AccessSummaryDumper.cpp
@@ -39,7 +39,8 @@ class AccessSummaryDumper : public SILModuleTransform {
       }
       const AccessSummaryAnalysis::FunctionSummary &summary =
           analysis->getOrCreateSummary(&fn);
-      llvm::outs() << summary << "\n";
+      summary.print(llvm::outs(), &fn);
+      llvm::outs() << "\n";
     }
   }
 };

--- a/test/SILOptimizer/access_summary_analysis.sil
+++ b/test/SILOptimizer/access_summary_analysis.sil
@@ -11,8 +11,13 @@ struct StructWithStoredProperties {
   @sil_stored var g: Int
 }
 
+struct StructWithStructWithStoredProperties {
+  @sil_stored var a: StructWithStoredProperties
+  @sil_stored var b: StructWithStoredProperties
+}
+
 // CHECK-LABEL: @assignsToCapture
-// CHECK-NEXT: (modify, none)
+// CHECK-NEXT: ([modify], [])
 sil private @assignsToCapture : $@convention(thin) (@inout_aliasable Int, Int) -> () {
 bb0(%0 : $*Int, %1: $Int):
   %2 = begin_access [modify] [unknown] %0 : $*Int
@@ -23,7 +28,7 @@ bb0(%0 : $*Int, %1: $Int):
 }
 
 // CHECK-LABEL: @readsAndModifiesSameCapture
-// CHECK-NEXT: (modify)
+// CHECK-NEXT: ([modify])
 sil private @readsAndModifiesSameCapture : $@convention(thin) (@inout_aliasable Int) -> () {
 bb0(%0 : $*Int):
   %1 = begin_access [read] [unknown] %0 : $*Int
@@ -35,7 +40,7 @@ bb0(%0 : $*Int):
 }
 
 // CHECK-LABEL: @readsAndModifiesSeparateCaptures
-// CHECK-NEXT: (read, modify)
+// CHECK-NEXT: ([read], [modify])
 sil private @readsAndModifiesSeparateCaptures : $@convention(thin) (@inout_aliasable Int, @inout_aliasable Int) -> () {
 bb0(%0 : $*Int, %1 : $*Int):
   %2 = begin_access [read] [unknown] %0 : $*Int
@@ -47,7 +52,7 @@ bb0(%0 : $*Int, %1 : $*Int):
 }
 
 // CHECK-LABEL: @modifyInModifySubAccess
-// CHECK-NEXT: (modify)
+// CHECK-NEXT: ([modify])
 sil private @modifyInModifySubAccess : $@convention(thin) (@inout_aliasable Int) -> () {
 bb0(%0 : $*Int):
   %1 = begin_access [modify] [unknown] %0 : $*Int
@@ -59,7 +64,7 @@ bb0(%0 : $*Int):
 }
 
 // CHECK-LABEL: @readInModifySubAccess
-// CHECK-NEXT: (modify)
+// CHECK-NEXT: ([modify])
 sil private @readInModifySubAccess : $@convention(thin) (@inout_aliasable Int) -> () {
 bb0(%0 : $*Int):
   %1 = begin_access [modify] [unknown] %0 : $*Int
@@ -70,8 +75,107 @@ bb0(%0 : $*Int):
   return %3 : $()
 }
 
+// CHECK-LABEL: @accessSeparateStoredPropertiesOfSameCapture
+// CHECK-NEXT: ([.f modify, .g read])
+sil private @accessSeparateStoredPropertiesOfSameCapture : $@convention(thin) (@inout_aliasable StructWithStoredProperties) -> () {
+bb0(%0 : $*StructWithStoredProperties):
+  %1 = begin_access [modify] [unknown] %0: $*StructWithStoredProperties
+  %2 = struct_element_addr %1 : $*StructWithStoredProperties, #StructWithStoredProperties.f
+  %3 = end_access %1 : $*StructWithStoredProperties
+  %4 = begin_access [read] [unknown] %0: $*StructWithStoredProperties
+  %5 = struct_element_addr %4 : $*StructWithStoredProperties, #StructWithStoredProperties.g
+  %6 = end_access %4 : $*StructWithStoredProperties
+  %7 = tuple ()
+  return %7 : $()
+}
+
+// CHECK-LABEL: @accessSeparateElementsOfSameCapture
+// CHECK-NEXT: ([.0 modify, .1 read])
+sil private @accessSeparateElementsOfSameCapture : $@convention(thin) (@inout_aliasable (Int, Int)) -> () {
+bb0(%0 : $*(Int, Int)):
+  %1 = begin_access [modify] [unknown] %0: $*(Int, Int)
+  %2 = tuple_element_addr %1 : $*(Int, Int), 0
+  %3 = end_access %1 : $*(Int, Int)
+  %4 = begin_access [read] [unknown] %0: $*(Int, Int)
+  %5 = tuple_element_addr %4 : $*(Int, Int), 1
+  %6 = end_access %4 : $*(Int, Int)
+  %7 = tuple ()
+  return %7 : $()
+}
+
+// CHECK-LABEL: @accessSeparateNestedStoredPropertiesOfSameCapture
+// CHECK-NEXT: ([.a.f modify, .b.g modify])
+sil private @accessSeparateNestedStoredPropertiesOfSameCapture : $@convention(thin) (@inout_aliasable StructWithStructWithStoredProperties) -> () {
+bb0(%0 : $*StructWithStructWithStoredProperties):
+  %1 = begin_access [modify] [unknown] %0: $*StructWithStructWithStoredProperties
+  %2 = struct_element_addr %1 : $*StructWithStructWithStoredProperties, #StructWithStructWithStoredProperties.a
+  %3 = struct_element_addr %2 : $*StructWithStoredProperties, #StructWithStoredProperties.f
+  %4 = end_access %1 : $*StructWithStructWithStoredProperties
+  %5 = begin_access [modify] [unknown] %0: $*StructWithStructWithStoredProperties
+  %6 = struct_element_addr %5 : $*StructWithStructWithStoredProperties, #StructWithStructWithStoredProperties.b
+  %7 = struct_element_addr %6 : $*StructWithStoredProperties, #StructWithStoredProperties.g
+  %8 = end_access %5 : $*StructWithStructWithStoredProperties
+  %9 = tuple ()
+  return %9 : $()
+}
+
+
+// CHECK-LABEL: @accessSeparateStoredPropertiesOfSameCaptureOppositeOfDeclarationOrder
+// CHECK-NEXT: ([.f read, .g modify])
+sil private @accessSeparateStoredPropertiesOfSameCaptureOppositeOfDeclarationOrder : $@convention(thin) (@inout_aliasable StructWithStoredProperties) -> () {
+bb0(%0 : $*StructWithStoredProperties):
+  %1 = begin_access [modify] [unknown] %0: $*StructWithStoredProperties
+  %2 = struct_element_addr %1 : $*StructWithStoredProperties, #StructWithStoredProperties.g
+  %3 = end_access %1 : $*StructWithStoredProperties
+  %4 = begin_access [read] [unknown] %0: $*StructWithStoredProperties
+  %5 = struct_element_addr %4 : $*StructWithStoredProperties, #StructWithStoredProperties.f
+  %6 = end_access %4 : $*StructWithStoredProperties
+  %7 = tuple ()
+  return %7 : $()
+}
+
+// CHECK-LABEL: @accessAggregateDoesNotSubsumeAccessStoredProp
+// CHECK-NEXT: ([modify, .g modify])
+sil private @accessAggregateDoesNotSubsumeAccessStoredProp : $@convention(thin) (@inout_aliasable StructWithStoredProperties) -> () {
+bb0(%0 : $*StructWithStoredProperties):
+  %1 = begin_access [modify] [unknown] %0: $*StructWithStoredProperties
+  %3 = end_access %1 : $*StructWithStoredProperties
+  %4 = begin_access [modify] [unknown] %0: $*StructWithStoredProperties
+  %5 = struct_element_addr %4 : $*StructWithStoredProperties, #StructWithStoredProperties.g
+  %6 = end_access %4 : $*StructWithStoredProperties
+  %7 = tuple ()
+  return %7 : $()
+}
+
+// CHECK-LABEL: @accessAggregateDoesNotSubsumeAccessStoredPropWithAggregateSecond
+// CHECK-NEXT: ([modify, .f modify])
+sil private @accessAggregateDoesNotSubsumeAccessStoredPropWithAggregateSecond : $@convention(thin) (@inout_aliasable StructWithStoredProperties) -> () {
+bb0(%0 : $*StructWithStoredProperties):
+  %1 = begin_access [modify] [unknown] %0: $*StructWithStoredProperties
+  %2 = struct_element_addr %1 : $*StructWithStoredProperties, #StructWithStoredProperties.f
+  %3 = end_access %1 : $*StructWithStoredProperties
+  %4 = begin_access [modify] [unknown] %0: $*StructWithStoredProperties
+  %6 = end_access %4 : $*StructWithStoredProperties
+  %7 = tuple ()
+  return %7 : $()
+}
+
+// CHECK-LABEL: @accessSameStoredPropertyOfSameCapture
+// CHECK-NEXT: ([.f modify])
+sil private @accessSameStoredPropertyOfSameCapture : $@convention(thin) (@inout_aliasable StructWithStoredProperties) -> () {
+bb0(%0 : $*StructWithStoredProperties):
+  %1 = begin_access [read] [unknown] %0: $*StructWithStoredProperties
+  %2 = struct_element_addr %1 : $*StructWithStoredProperties, #StructWithStoredProperties.f
+  %3 = end_access %1 : $*StructWithStoredProperties
+  %4 = begin_access [modify] [unknown] %0: $*StructWithStoredProperties
+  %5 = struct_element_addr %4 : $*StructWithStoredProperties, #StructWithStoredProperties.f
+  %6 = end_access %4 : $*StructWithStoredProperties
+  %7 = tuple ()
+  return %7 : $()
+}
+
 // CHECK-LABEL: @addressToPointerOfStructElementAddr
-// CHECK-NEXT: (none)
+// CHECK-NEXT: ([])
 // This mirrors the code pattern for materializeForSet on a struct stored
 // property
 sil private @addressToPointerOfStructElementAddr : $@convention(method) (@inout StructWithStoredProperties) -> (Builtin.RawPointer) {
@@ -82,7 +186,7 @@ bb0(%1 : $*StructWithStoredProperties):
 }
 
 // CHECK-LABEL: @endUnpairedAccess
-// CHECK-NEXT: (none)
+// CHECK-NEXT: ([])
 sil private @endUnpairedAccess : $@convention(method) (@inout Builtin.UnsafeValueBuffer) -> () {
 bb0(%0 : $*Builtin.UnsafeValueBuffer):
   end_unpaired_access [dynamic] %0 : $*Builtin.UnsafeValueBuffer
@@ -91,7 +195,7 @@ bb0(%0 : $*Builtin.UnsafeValueBuffer):
 }
 
 // CHECK-LABEL: @tupleElementAddr
-// CHECK-NEXT: (modify)
+// CHECK-NEXT: ([modify])
 sil private @tupleElementAddr : $@convention(thin) (@inout_aliasable (Int, Int)) -> () {
 bb0(%0 : $*(Int, Int)):
   %1 = tuple_element_addr %0 : $*(Int, Int), 1
@@ -104,7 +208,7 @@ bb0(%0 : $*(Int, Int)):
 sil @closureWithMissingBody : $@convention(thin) (@inout_aliasable Int, Int) -> ()
 
 // CHECK-LABEL: @callClosureWithMissingBody
-// CHECK-NEXT: (none, none)
+// CHECK-NEXT: ([], [])
 sil private @callClosureWithMissingBody : $@convention(thin) (@inout_aliasable Int, Int) -> () {
 bb0(%0 : $*Int, %1 : $Int):
   %2 = function_ref @closureWithMissingBody : $@convention(thin) (@inout_aliasable Int, Int) -> ()
@@ -114,7 +218,7 @@ bb0(%0 : $*Int, %1 : $Int):
 }
 
 // CHECK-LABEL: @callClosureThatModifiesCapture
-// CHECK-NEXT: (modify, none)
+// CHECK-NEXT: ([modify], [])
 sil private @callClosureThatModifiesCapture : $@convention(thin) (@inout_aliasable Int, Int) -> () {
 bb0(%0 : $*Int, %1 : $Int):
   %2 = function_ref @assignsToCapture : $@convention(thin) (@inout_aliasable Int, Int) -> ()
@@ -124,7 +228,7 @@ bb0(%0 : $*Int, %1 : $Int):
 }
 
 // CHECK-LABEL: @throwingClosureThatModifesCapture
-// CHECK-NEXT: (modify)
+// CHECK-NEXT: ([modify])
 sil private @throwingClosureThatModifesCapture : $@convention(thin) (@inout_aliasable Int) -> @error Error {
 bb0(%0 : $*Int):
   %1 = begin_access [modify] [unknown] %0 : $*Int
@@ -133,7 +237,7 @@ bb0(%0 : $*Int):
   return %2 : $()
 }
 // CHECK-LABEL: @callThrowingClosureThatModifiesCapture
-// CHECK-NEXT: (modify)
+// CHECK-NEXT: ([modify])
 sil private @callThrowingClosureThatModifiesCapture : $@convention(thin) (@inout_aliasable Int) -> () {
 bb0(%0 : $*Int):
   %1 = function_ref @throwingClosureThatModifesCapture : $@convention(thin) (@inout_aliasable Int) -> @error Error
@@ -149,7 +253,7 @@ bb2(%5: $Error):
 sil @takesNoEscapeClosure : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
 
 // CHECK-LABEL: @partialApplyPassedOffToFunction
-// CHECK-NEXT: (modify, none)
+// CHECK-NEXT: ([modify], [])
 sil private @partialApplyPassedOffToFunction : $@convention(thin) (@inout_aliasable Int, Int) -> () {
 bb0(%0 : $*Int, %1: $Int):
   %2 = function_ref @assignsToCapture : $@convention(thin) (@inout_aliasable Int, Int) -> ()
@@ -164,7 +268,7 @@ sil @takesNoEscapeClosureTakingArgument : $@convention(thin) (@owned @callee_own
 sil @takesNoEscapeClosureTakingArgumentThrowing : $@convention(thin) (@owned @callee_owned (Int) -> (@error Error)) -> ()
 
 // CHECK-LABEL: @hasThreeCapturesAndTakesArgument
-// CHECK-NEXT: (none, modify, none, read)
+// CHECK-NEXT: ([], [modify], [], [read])
 sil private @hasThreeCapturesAndTakesArgument : $@convention(thin) (Int, @inout_aliasable Int, @inout_aliasable Int, @inout_aliasable Int) -> () {
 bb0(%0 : $Int, %1: $*Int, %2: $*Int, %3: $*Int):
   %4 = begin_access [modify] [unknown] %1 : $*Int
@@ -176,7 +280,7 @@ bb0(%0 : $Int, %1: $*Int, %2: $*Int, %3: $*Int):
 }
 
 // CHECK-LABEL: @partialApplyOfClosureTakingArgumentPassedOffToFunction
-// CHECK-NEXT: (modify, none, read
+// CHECK-NEXT: ([modify], [], [read])
 sil private @partialApplyOfClosureTakingArgumentPassedOffToFunction : $@convention(thin) (@inout_aliasable Int, @inout_aliasable Int, @inout_aliasable Int) -> () {
 bb0(%0 : $*Int, %1 : $*Int, %2 : $*Int):
   %3 = function_ref @hasThreeCapturesAndTakesArgument : $@convention(thin) (Int, @inout_aliasable Int, @inout_aliasable Int, @inout_aliasable Int) -> ()
@@ -188,7 +292,7 @@ bb0(%0 : $*Int, %1 : $*Int, %2 : $*Int):
 }
 
 // CHECK-LABEL: @partialApplyFollowedByConvertFunction
-// CHECK-NEXT: (modify, none, read)
+// CHECK-NEXT: ([modify], [], [read])
 sil private @partialApplyFollowedByConvertFunction : $@convention(thin) (@inout_aliasable Int, @inout_aliasable Int, @inout_aliasable Int) -> () {
 bb0(%0 : $*Int, %1 : $*Int, %2 : $*Int):
   %3 = function_ref @hasThreeCapturesAndTakesArgument : $@convention(thin) (Int, @inout_aliasable Int, @inout_aliasable Int, @inout_aliasable Int) -> ()
@@ -205,7 +309,7 @@ sil @takesAutoClosureReturningGeneric : $@convention(thin) <T where T : Equatabl
 sil @thunkForAutoClosure : $@convention(thin) (@owned @callee_owned () -> (Int, @error Error)) -> (@out Int, @error Error)
 
 // CHECK-LABEL: @readsAndThrows
-// CHECK-NEXT: (read)
+// CHECK-NEXT: ([read])
 sil private  @readsAndThrows : $@convention(thin) (@inout_aliasable Int) -> (Int, @error Error) {
 bb0(%0 : $*Int):
   %3 = begin_access [read] [unknown] %0 : $*Int
@@ -215,7 +319,7 @@ bb0(%0 : $*Int):
 }
 
 // CHECK-LABEL: @passPartialApplyAsArgumentToPartialApply
-// CHECK-NEXT: (read)
+// CHECK-NEXT: ([read])
 sil hidden @passPartialApplyAsArgumentToPartialApply : $@convention(thin) (@inout_aliasable Int) -> () {
 bb0(%0 : $*Int):
   %2 = function_ref @takesAutoClosureReturningGeneric : $@convention(thin) <τ_0_0 where τ_0_0 : Equatable> (@owned @callee_owned () -> (@out τ_0_0, @error Error)) -> ()
@@ -229,7 +333,7 @@ bb0(%0 : $*Int):
 }
 
 // CHECK-LABEL: @reads
-// CHECK-NEXT: (read)
+// CHECK-NEXT: ([read])
 sil private  @reads : $@convention(thin) (@inout_aliasable Int) -> Int {
 bb0(%0 : $*Int):
   %3 = begin_access [read] [unknown] %0 : $*Int
@@ -239,7 +343,7 @@ bb0(%0 : $*Int):
 }
 
 // CHECK-LABEL: @convertPartialApplyAndPassToPartialApply
-// CHECK-NEXT: (read)
+// CHECK-NEXT: ([read])
 sil hidden @convertPartialApplyAndPassToPartialApply : $@convention(thin) (@inout_aliasable Int) -> () {
 bb0(%0 : $*Int):
   %2 = function_ref @takesAutoClosureReturningGeneric : $@convention(thin) <τ_0_0 where τ_0_0 : Equatable> (@owned @callee_owned () -> (@out τ_0_0, @error Error)) -> ()
@@ -254,7 +358,7 @@ bb0(%0 : $*Int):
 }
 
 // CHECK-LABEL: @selfRecursion
-// CHECK-NEXT: (modify, none)
+// CHECK-NEXT: ([modify], [])
 sil private @selfRecursion : $@convention(thin) (@inout_aliasable Int, Int) -> () {
 bb0(%0 : $*Int, %1 : $Int):
   %2 = function_ref @selfRecursion : $@convention(thin) (@inout_aliasable Int, Int) -> ()
@@ -266,7 +370,7 @@ bb0(%0 : $*Int, %1 : $Int):
 }
 
 // CHECK-LABEL: @callsMutuallyRecursive
-// CHECK-NEXT: (modify, none)
+// CHECK-NEXT: ([modify], [])
 sil private @callsMutuallyRecursive : $@convention(thin) (@inout_aliasable Int, Int) -> () {
 bb0(%0 : $*Int, %1 : $Int):
   %2 = function_ref @mutualRecursion1 : $@convention(thin) (@inout_aliasable Int, Int) -> ()
@@ -276,7 +380,7 @@ bb0(%0 : $*Int, %1 : $Int):
 }
 
 // CHECK-LABEL: @mutualRecursion1
-// CHECK-NEXT: (modify, none)
+// CHECK-NEXT: ([modify], [])
 sil private @mutualRecursion1 : $@convention(thin) (@inout_aliasable Int, Int) -> () {
 bb0(%0 : $*Int, %1 : $Int):
   %2 = function_ref @mutualRecursion2 : $@convention(thin) (@inout_aliasable Int, Int) -> ()
@@ -288,7 +392,7 @@ bb0(%0 : $*Int, %1 : $Int):
 }
 
 // CHECK-LABEL: @mutualRecursion2
-// CHECK-NEXT: (modify, none)
+// CHECK-NEXT: ([modify], [])
 sil private @mutualRecursion2 : $@convention(thin) (@inout_aliasable Int, Int) -> () {
 bb0(%0 : $*Int, %1 : $Int):
   %2 = function_ref @mutualRecursion1 : $@convention(thin) (@inout_aliasable Int, Int) -> ()
@@ -312,7 +416,7 @@ bb0(%0 : $*Int, %1 : $Int):
 //     C
 //
 // CHECK-LABEL: @multipleCycleA
-// CHECK-NEXT: (modify)
+// CHECK-NEXT: ([modify])
 sil private @multipleCycleA : $@convention(thin) (@inout_aliasable Int) -> () {
 bb0(%0 : $*Int):
   %1 = function_ref @multipleCycleB : $@convention(thin) (@inout_aliasable Int) -> ()
@@ -324,7 +428,7 @@ bb0(%0 : $*Int):
 }
 
 // CHECK-LABEL: @multipleCycleB
-// CHECK-NEXT: (modify)
+// CHECK-NEXT: ([modify])
 sil private @multipleCycleB : $@convention(thin) (@inout_aliasable Int) -> () {
 bb0(%0 : $*Int):
   %1 = function_ref @multipleCycleA : $@convention(thin) (@inout_aliasable Int) -> ()
@@ -336,7 +440,7 @@ bb0(%0 : $*Int):
 }
 
 // CHECK-LABEL: @multipleCycleC
-// CHECK-NEXT: (modify)
+// CHECK-NEXT: ([modify])
 sil private @multipleCycleC : $@convention(thin) (@inout_aliasable Int) -> () {
 bb0(%0 : $*Int):
   %1 = function_ref @multipleCycleB : $@convention(thin) (@inout_aliasable Int) -> ()


### PR DESCRIPTION
Make the static enforcement of accesses in noescape closures stored-property
sensitive. This will relax the existing enforcement so that the following is
not diagnosed:

struct MyStruct {
   var x = X()
   var y = Y()

  mutating
  func foo() {
    x.mutatesAndTakesClosure() {
      _ = y.read()
   }
  }
}

To do this, update the access summary analysis to be stored-property sensitive.

rdar://problem/32987932
