### PR TITLE
[Clang importer] Make sure that the first argument of Set/Dictionary types are Hashable.

### DIFF
--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -886,7 +886,7 @@ public:
 
   /// \brief Determines whether the given type matches an implicit type
   /// bound of "Hashable", which is used to validate NSDictionary/NSSet.
-  bool matchesNSObjectBound(Type type);
+  bool matchesHashableBound(Type type);
 
   /// \brief Look up and attempt to import a Clang declaration with
   /// the given name.

--- a/test/ClangImporter/Inputs/custom-modules/ObjCBridgeNonconforming.h
+++ b/test/ClangImporter/Inputs/custom-modules/ObjCBridgeNonconforming.h
@@ -1,0 +1,6 @@
+@import ObjectiveC;
+@import Foundation;
+
+@interface ObjCBridgeNonconforming
+@property NSSet<NSDictionary<NSString *, id> *> * _Nonnull foo;
+@end

--- a/test/ClangImporter/Inputs/custom-modules/module.map
+++ b/test/ClangImporter/Inputs/custom-modules/module.map
@@ -175,3 +175,7 @@ module MacrosRedefB {
 module IndirectFields {
   header "IndirectFields.h"
 }
+
+module ObjCBridgeNonconforming {
+  header "ObjCBridgeNonconforming.h"
+}

--- a/test/ClangImporter/objc_bridging_generics.swift
+++ b/test/ClangImporter/objc_bridging_generics.swift
@@ -1,9 +1,10 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -verify -swift-version 4 %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -verify -swift-version 4 -I %S/Inputs/custom-modules %s
 
 // REQUIRES: objc_interop
 
 import Foundation
 import objc_generics
+import ObjCBridgeNonconforming
 
 func testNSArrayBridging(_ hive: Hive) {
   _ = hive.bees as [Bee]
@@ -391,4 +392,9 @@ let third: Third! = Third()
 
 func useThird() {
   _ = third.description
+}
+
+
+func testNonconforming(bnc: ObjCBridgeNonconforming) {
+  let _: Int = bnc.foo // expected-error{{cannot convert value of type 'Set<AnyHashable>' to specified type 'Int'}}
 }


### PR DESCRIPTION
**Explanation**: Eliminate a crash due to importing an Objective-C API with a `Set` or `Dictionary` aren't that is a non-`Hashable` `struct` or `enum` type. For example, instead of importing `NSSet<NSSet<id>>` as the nonsensical type `Set<Set<Any>>` (because `Set` isn't `Hashable`), import it as the safer `Set<AnyHashable>`.
**Scope**: The scope of the fix is pretty limited, since Swift would complain or crash if you ever actually tried to import such an API. However, see **Risk**.
**Radar**: rdar://problem/30622665
**Risk**: The fix performs a conformance check in a new place in the Clang importer. We have seen some problems with performing conformance checks elsewhere in the Clang importer that manifest as circularity issues that would crash the compiler. It's hard to assess whether such circularities will come up beyond just "qualify the compiler and see if it breaks".
**Testing**: Compiler regression testing.