### PR TITLE
Refactor SILGenApply::visitDeclRefExpr()

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -632,6 +632,7 @@ public:
     SelfApplyExpr = theSelfApplyExpr;
     SelfType = theSelfApplyExpr->getType();
   }
+
   void setSelfParam(ArgumentSource &&theSelfParam, Type selfType) {
     assert(!SelfParam && "already set this!");
     SelfParam = std::move(theSelfParam);

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -661,12 +661,14 @@ public:
   void visitApplyExpr(ApplyExpr *e) {
     if (e->isSuper()) {
       applySuper(e);
-    } else if (applyInitDelegation(e)) {
-      // Already done
-    } else {
-      CallSites.push_back(e);
-      visit(e->getFn());
+      return;
     }
+
+    if (applyInitDelegation(e))
+      return;
+
+    CallSites.push_back(e);
+    visit(e->getFn());
   }
 
   /// Given a metatype value for the type, allocate an Objective-C


### PR DESCRIPTION
This PR performs some cleanup of SILGenApply::visitDeclRefExpr(). It and a bunch of its parts were very large and yield more compact subroutines. This makes the code easier to reason about.

rdar://31880847