### PR TITLE
[Syntax] [NFC] Represent TokenSyntax as a Syntax node

### DIFF
--- a/include/swift/Parse/Lexer.h
+++ b/include/swift/Parse/Lexer.h
@@ -239,7 +239,7 @@ public:
   }
 
   /// Lex a full token including leading and trailing trivia.
-  RC<syntax::TokenSyntax> fullLex();
+  RC<syntax::RawTokenSyntax> fullLex();
 
   bool isKeepingComments() const {
     return RetainComments == CommentRetentionMode::ReturnAsTokens;

--- a/include/swift/Sema/Semantics.h
+++ b/include/swift/Sema/Semantics.h
@@ -18,7 +18,7 @@
 #define SWIFT_SEMA_SEMANTICMODEL_H
 
 #include "swift/AST/ASTNode.h"
-#include "swift/Syntax/SyntaxData.h"
+#include "swift/Syntax/Syntax.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/Optional.h"
 

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -132,9 +132,9 @@ namespace swift {
                               bool TokenizeInterpolatedString = true,
                               ArrayRef<Token> SplitTokens = ArrayRef<Token>());
 
-  /// \brief Lex and return a vector of `RC<TokenSyntax>` tokens, which include
+  /// \brief Lex and return a vector of `TokenSyntax` tokens, which include
   /// leading and trailing trivia.
-  std::vector<std::pair<RC<syntax::TokenSyntax>,
+  std::vector<std::pair<RC<syntax::RawTokenSyntax>,
                                    syntax::AbsolutePosition>>
   tokenizeWithTrivia(const LangOptions &LangOpts,
                      const SourceManager &SM,

--- a/include/swift/Syntax/DeclSyntax.h
+++ b/include/swift/Syntax/DeclSyntax.h
@@ -82,34 +82,34 @@ public:
     : Syntax(Root, Data) {}
 
   /// Return the name of the modifier.
-  RC<TokenSyntax> getName() const;
+  TokenSyntax getName() const;
 
   /// Return a DeclModifierSyntax with the given name.
-  DeclModifierSyntax withName(RC<TokenSyntax> NewName) const;
+  DeclModifierSyntax withName(TokenSyntax NewName) const;
 
   /// Return the left parenthesis '(' token as a part of the argument clause,
   /// if there is one.
-  RC<TokenSyntax> getLeftParenToken() const;
+  TokenSyntax getLeftParenToken() const;
 
   /// Return a DeclModifierSyntax with the given left parenthesis '(' token.
-  DeclModifierSyntax withLeftParenToken(RC<TokenSyntax> NewLeftParen) const;
+  DeclModifierSyntax withLeftParenToken(TokenSyntax NewLeftParen) const;
 
   /// Get the argument to the declaration modifier.
   ///
   /// This is either:
   /// - 'set' for the access modifiers such as 'private' or 'public', or
   /// - 'safe' / 'unsafe' for the 'unowned' modifier.
-  RC<TokenSyntax> getArgument() const;
+  TokenSyntax getArgument() const;
 
   /// Return a DeclModifierSyntax with the given argument.
-  DeclModifierSyntax withArgument(RC<TokenSyntax> NewArgument) const;
+  DeclModifierSyntax withArgument(TokenSyntax NewArgument) const;
 
   /// Return the right parenthesis ')' token as a part of the argument clause,
   /// if there is one.
-  RC<TokenSyntax> getRightParenToken() const;
+  TokenSyntax getRightParenToken() const;
 
   /// Return a DeclModifierSyntax with the given right parenthesis ')' token.
-  DeclModifierSyntax withRightParenToken(RC<TokenSyntax> NewRightParen) const;
+  DeclModifierSyntax withRightParenToken(TokenSyntax NewRightParen) const;
 
   static bool classof(const Syntax *S) {
     return S->getKind() == SyntaxKind::DeclModifier;
@@ -218,16 +218,16 @@ public:
     : DeclSyntax(Root, Data) {}
 
   /// Return the 'struct' keyword attached to the declaration.
-  RC<TokenSyntax> getStructKeyword() const;
+  TokenSyntax getStructKeyword() const;
 
   /// Return a StructDeclSyntax with the given 'struct' keyword.
-  StructDeclSyntax withStructKeyword(RC<TokenSyntax> NewStructKeyword) const;
+  StructDeclSyntax withStructKeyword(TokenSyntax NewStructKeyword) const;
 
   /// Return the identifier of the struct.
-  RC<TokenSyntax> getIdentifier() const;
+  TokenSyntax getIdentifier() const;
 
   /// Return a StructDeclSyntax with the given identifier.
-  StructDeclSyntax withIdentifier(RC<TokenSyntax> NewIdentifier) const;
+  StructDeclSyntax withIdentifier(TokenSyntax NewIdentifier) const;
 
   /// Return the generic parameter clause of the struct declaration.
   GenericParameterClauseSyntax getGenericParameterClause() const;
@@ -245,10 +245,10 @@ public:
   withWhereClause(GenericWhereClauseSyntax NewWhereClause) const;
 
   /// Return the left brace '{' token of the struct declaration.
-  RC<TokenSyntax> getLeftBraceToken() const;
+  TokenSyntax getLeftBraceToken() const;
 
   /// Return a StructDeclSyntax with the given left brace '{' token.
-  StructDeclSyntax withLeftBrace(RC<TokenSyntax> NewLeftBrace) const;
+  StructDeclSyntax withLeftBrace(TokenSyntax NewLeftBrace) const;
 
   /// Return the members' syntax of the struct.
   DeclMembersSyntax getMembers() const;
@@ -257,10 +257,10 @@ public:
   StructDeclSyntax withMembers(DeclMembersSyntax NewMembers) const;
 
   /// Return the right brace '}' token of the struct declaration.
-  RC<TokenSyntax> getRightBraceToken() const;
+  TokenSyntax getRightBraceToken() const;
 
   /// Return a StructDeclSyntax with the given right brace '}' token.
-  StructDeclSyntax withRightBrace(RC<TokenSyntax> NewRightBrace) const;
+  StructDeclSyntax withRightBrace(TokenSyntax NewRightBrace) const;
 
   static bool classof(const Syntax *S) {
     return S->getKind() == SyntaxKind::StructDecl;
@@ -273,9 +273,9 @@ class StructDeclSyntaxBuilder final {
   RawSyntax::LayoutList StructLayout;
 public:
   StructDeclSyntaxBuilder();
-  StructDeclSyntaxBuilder &useStructKeyword(RC<TokenSyntax> StructKeyword);
-  StructDeclSyntaxBuilder &useIdentifier(RC<TokenSyntax> Identifier);
-  StructDeclSyntaxBuilder &useLeftBrace(RC<TokenSyntax> LeftBrace);
+  StructDeclSyntaxBuilder &useStructKeyword(TokenSyntax StructKeyword);
+  StructDeclSyntaxBuilder &useIdentifier(TokenSyntax Identifier);
+  StructDeclSyntaxBuilder &useLeftBrace(TokenSyntax LeftBrace);
 
   StructDeclSyntaxBuilder &
   useGenericParameterClause(GenericParameterClauseSyntax GenericParams);
@@ -284,7 +284,7 @@ public:
   useGenericWhereClause(GenericWhereClauseSyntax GenericWhereClause);
 
   StructDeclSyntaxBuilder &useMembers(DeclMembersSyntax Members);
-  StructDeclSyntaxBuilder &useRightBrace(RC<TokenSyntax> RightBrace);
+  StructDeclSyntaxBuilder &useRightBrace(TokenSyntax RightBrace);
   StructDeclSyntax build() const;
 };
 
@@ -314,19 +314,19 @@ public:
     : DeclSyntax(Root, Data) {}
 
   /// Return the 'typealias' keyword for the declaration.
-  RC<TokenSyntax> getTypealiasKeyword() const {
-    return cast<TokenSyntax>(getRaw()->getChild(Cursor::TypeAliasKeyword));
+  TokenSyntax getTypealiasKeyword() const {
+    return { Root, Data->getChild(Cursor::TypeAliasKeyword).get() };
   }
 
   /// Return a TypeAliasDeclSyntax with the given 'typealias' keyword.
   TypeAliasDeclSyntax
-  withTypeAliasKeyword(RC<TokenSyntax> NewTypeAliasKeyword) const;
+  withTypeAliasKeyword(TokenSyntax NewTypeAliasKeyword) const;
 
   /// Return the identifier for the declaration.
-  RC<TokenSyntax> getIdentifier() const;
+  TokenSyntax getIdentifier() const;
 
   /// Return a TypeAliasDeclSyntax with the given identifier.
-  TypeAliasDeclSyntax withIdentifier(RC<TokenSyntax> NewIdentifier) const;
+  TypeAliasDeclSyntax withIdentifier(TokenSyntax NewIdentifier) const;
 
   /// Return the generic parameter clause of the declaration.
   GenericParameterClauseSyntax getGenericParameterClause() const;
@@ -337,11 +337,11 @@ public:
   const;
 
   /// Return the equal '=' token from the declaration.
-  RC<TokenSyntax> getEqualToken() const;
+  TokenSyntax getEqualToken() const;
 
   /// Return a TypeAliasDeclSyntax with the given equal '=' token.
   TypeAliasDeclSyntax
-  withEqualToken(RC<TokenSyntax> NewEqualToken) const;
+  withEqualToken(TokenSyntax NewEqualToken) const;
 
   /// Return the type syntax to which the type alias is assigned.
   TypeSyntax getTypeSyntax() const;
@@ -362,14 +362,14 @@ public:
   TypeAliasDeclSyntaxBuilder();
 
   TypeAliasDeclSyntaxBuilder &
-  useTypeAliasKeyword(RC<TokenSyntax> TypeAliasKeyword);
+  useTypeAliasKeyword(TokenSyntax TypeAliasKeyword);
 
-  TypeAliasDeclSyntaxBuilder &useIdentifier(RC<TokenSyntax> Identifier);
+  TypeAliasDeclSyntaxBuilder &useIdentifier(TokenSyntax Identifier);
 
   TypeAliasDeclSyntaxBuilder &
   useGenericParameterClause(GenericParameterClauseSyntax GenericParams);
 
-  TypeAliasDeclSyntaxBuilder &useEqualToken(RC<TokenSyntax> EqualToken);
+  TypeAliasDeclSyntaxBuilder &useEqualToken(TokenSyntax EqualToken);
 
   TypeAliasDeclSyntaxBuilder &useType(TypeSyntax ReferentType);
 
@@ -406,27 +406,27 @@ public:
     : Syntax(Root, Data) {}
 
   /// Get the external name of the parameter, if there is one.
-  RC<TokenSyntax> getExternalName() const;
+  TokenSyntax getExternalName() const;
 
   /// Return a FunctionParameterSyntax with the given external name.
   FunctionParameterSyntax
-  withExternalName(RC<TokenSyntax> NewExternalName) const;
+  withExternalName(TokenSyntax NewExternalName) const;
 
   /// Return the local name of the parameter.
-  RC<TokenSyntax> getLocalName() const;
+  TokenSyntax getLocalName() const;
 
   /// Return a FunctionParameterSyntax with the given local name.
   FunctionParameterSyntax
-  withLocalName(RC<TokenSyntax> NewLocalName) const;
+  withLocalName(TokenSyntax NewLocalName) const;
 
   /// Return the colon ':' token between the local name and type of the
   /// parameter.
-  RC<TokenSyntax> getColonToken() const;
+  TokenSyntax getColonToken() const;
 
   /// Return a FunctionParameterSyntax with the given colon token between
   /// the local name and type.
   FunctionParameterSyntax
-  withColonToken(RC<TokenSyntax> NewColonToken) const;
+  withColonToken(TokenSyntax NewColonToken) const;
 
   /// Return the syntax for the type of this parameter.
   llvm::Optional<TypeSyntax> getTypeSyntax() const;
@@ -437,11 +437,11 @@ public:
 
   /// Return the equal '=' token in between the parameter type and the default
   /// value, if there is one.
-  RC<TokenSyntax> getEqualToken() const;
+  TokenSyntax getEqualToken() const;
 
   /// Return a FunctionParameterSyntax with the given equal '=' token in
   /// between the parameter type and the default value.
-  FunctionParameterSyntax withEqualToken(RC<TokenSyntax> NewEqualToken) const;
+  FunctionParameterSyntax withEqualToken(TokenSyntax NewEqualToken) const;
 
   /// Return the expression for the default value of the parameter, if there
   /// is one.
@@ -453,11 +453,11 @@ public:
   withDefaultValue(llvm::Optional<ExprSyntax> NewDefaultValue) const;
 
   /// Return the trailing comma on the parameter, if there is one.
-  RC<TokenSyntax> getTrailingComma() const;
+  TokenSyntax getTrailingComma() const;
 
   /// Return a FunctionParameterSyntax with the given trailing comma.
   FunctionParameterSyntax
-  withTrailingComma(RC<TokenSyntax> NewTrailingComma) const;
+  withTrailingComma(TokenSyntax NewTrailingComma) const;
 
   static bool classof(const Syntax *S) {
     return S->getKind() == SyntaxKind::FunctionParameter;
@@ -498,12 +498,12 @@ public:
     : Syntax(Root, Data) {}
 
   /// Return the left parenthesis '(' token enclosing the parameter list.
-  RC<TokenSyntax> getLeftParenToken() const;
+  TokenSyntax getLeftParenToken() const;
 
   /// Return a FunctionSignatureSyntax with the given left parenthesis '(' token
   /// enclosing the parameter list.
   FunctionSignatureSyntax
-  withLeftParenToken(RC<TokenSyntax> NewLeftParen) const;
+  withLeftParenToken(TokenSyntax NewLeftParen) const;
 
   /// Return the parameter list for this signature.
   FunctionParameterListSyntax getParameterList() const;
@@ -513,31 +513,31 @@ public:
   withParameterList(FunctionParameterListSyntax NewParameterList) const;
 
   /// Return the right parenthesis ')' token enclosing the parameter list.
-  RC<TokenSyntax> getRightParenToken() const;
+  TokenSyntax getRightParenToken() const;
 
   /// Return a FunctionSignatureSyntax with the given right parenthesis ')' token
   /// enclosing the parameter list.
   FunctionSignatureSyntax
-  withRightParenToken(RC<TokenSyntax> NewRightParen) const;
+  withRightParenToken(TokenSyntax NewRightParen) const;
 
   /// Return the 'throws' token in this signature if it exists.
-  RC<TokenSyntax> getThrowsToken() const;
+  TokenSyntax getThrowsToken() const;
 
   /// Return a FunctionSignatureSyntax with the given 'throws' token.
-  FunctionSignatureSyntax withThrowsToken(RC<TokenSyntax> NewThrowsToken) const;
+  FunctionSignatureSyntax withThrowsToken(TokenSyntax NewThrowsToken) const;
 
   /// Return the 'rethrows' token in this signature if it exists;
-  RC<TokenSyntax> getRethrowsToken() const;
+  TokenSyntax getRethrowsToken() const;
 
   /// Return a FunctionSignatureSyntax with the given 'rethrows' token.
   FunctionSignatureSyntax
-  withRethrowsToken(RC<TokenSyntax> NewRethrowsToken) const;
+  withRethrowsToken(TokenSyntax NewRethrowsToken) const;
 
   /// Return the arrow '->' token for the signature.
-  RC<TokenSyntax> getArrowToken() const;
+  TokenSyntax getArrowToken() const;
 
   /// Return a FunctionSignatureSyntax with the given arrow token
-  FunctionSignatureSyntax withArrowToken(RC<TokenSyntax> NewArrowToken) const;
+  FunctionSignatureSyntax withArrowToken(TokenSyntax NewArrowToken) const;
 
   /// Return the return type attributes for the signature.
   TypeAttributesSyntax getReturnTypeAttributes() const;
@@ -595,16 +595,16 @@ public:
   FunctionDeclSyntax withModifiers(DeclModifierListSyntax NewModifiers) const;
 
   /// Return the 'func' keyword of this function declaration.
-  RC<TokenSyntax> getFuncKeyword() const;
+  TokenSyntax getFuncKeyword() const;
 
   /// Return a FunctionDeclSyntax with the given 'func' keyword.
-  FunctionDeclSyntax withFuncKeyword(RC<TokenSyntax> NewFuncKeyword) const;
+  FunctionDeclSyntax withFuncKeyword(TokenSyntax NewFuncKeyword) const;
 
   /// Return the identifier of the function declaration.
-  RC<TokenSyntax> getIdentifier() const;
+  TokenSyntax getIdentifier() const;
 
   /// Return a FunctionDeclSyntax with the given identifier.
-  FunctionDeclSyntax withIdentifier(RC<TokenSyntax> NewIdentifier) const;
+  FunctionDeclSyntax withIdentifier(TokenSyntax NewIdentifier) const;
 
   /// Return the generic parameter clause of the function declaration, if
   /// there is one. Otherwise, return llvm::None.

--- a/include/swift/Syntax/ExprSyntax.h
+++ b/include/swift/Syntax/ExprSyntax.h
@@ -87,17 +87,17 @@ public:
     : ExprSyntax(Root, Data) {}
 
   /// Get the '+' or '-' associated with this integer literal expression.
-  RC<TokenSyntax> getSign() const;
+  TokenSyntax getSign() const;
 
   /// Return a new IntegerLiteralExprSyntax with the given '+' or '-' sign.
-  IntegerLiteralExprSyntax withSign(RC<TokenSyntax> NewSign) const;
+  IntegerLiteralExprSyntax withSign(TokenSyntax NewSign) const;
 
   /// Return the string of digits comprising the number part of the integer
   /// literal expression.
-  RC<TokenSyntax> getDigits() const;
+  TokenSyntax getDigits() const;
 
   /// Return a new IntegerLiteralExprSyntax with the given string of digits.
-  IntegerLiteralExprSyntax withDigits(RC<TokenSyntax> NewDigits) const;
+  IntegerLiteralExprSyntax withDigits(TokenSyntax NewDigits) const;
 
   static bool classof(const Syntax *S) {
     return S->getKind() == SyntaxKind::IntegerLiteralExpr;
@@ -131,11 +131,11 @@ public:
 
 
   /// Get the identifier for the symbol to which this expression refers.
-  RC<TokenSyntax> getIdentifier() const;
+  TokenSyntax getIdentifier() const;
 
   /// Return a new `SymbolicReferenceExprSyntax` with the given identifier.
   SymbolicReferenceExprSyntax
-  withIdentifier(RC<TokenSyntax> NewIdentifier) const;
+  withIdentifier(TokenSyntax NewIdentifier) const;
 
   /// Return the generic arguments this symbolic reference has, if it has one.
   llvm::Optional<GenericArgumentClauseSyntax> getGenericArgumentClause() const;
@@ -176,17 +176,17 @@ public:
     : Syntax(Root, Data) {}
 
   /// Return the label identifier for this argument, if it has one.
-  RC<TokenSyntax> getLabel() const;
+  TokenSyntax getLabel() const;
 
   /// Return a new `FunctionCallArgumentSyntax` with the given label.
-  FunctionCallArgumentSyntax withLabel(RC<TokenSyntax> NewLabel) const;
+  FunctionCallArgumentSyntax withLabel(TokenSyntax NewLabel) const;
 
   /// Get the colon ':' token in between the label and argument,
   /// if there is one.
-  RC<TokenSyntax> getColonToken() const;
+  TokenSyntax getColonToken() const;
 
   /// Return a new `FunctionCallArgumentSyntax` with the given colon ':' token.
-  FunctionCallArgumentSyntax withColonToken(RC<TokenSyntax> NewColon) const;
+  FunctionCallArgumentSyntax withColonToken(TokenSyntax NewColon) const;
 
   /// Returns the expression of the argument.
   llvm::Optional<ExprSyntax> getExpression() const;
@@ -197,12 +197,12 @@ public:
 
   /// Get the comma ',' token immediately following this argument, if there
   /// is one.
-  RC<TokenSyntax> getTrailingComma() const;
+  TokenSyntax getTrailingComma() const;
 
   /// Return a new `FunctionCallArgumentSyntax` with the given comma attached
   /// to the end of the argument.
   FunctionCallArgumentSyntax
-  withTrailingComma(RC<TokenSyntax> NewTrailingComma) const;
+  withTrailingComma(TokenSyntax NewTrailingComma) const;
 
   static bool classof(const Syntax *S) {
     return S->getKind() == SyntaxKind::FunctionCallArgument;
@@ -239,11 +239,11 @@ public:
   withCalledExpression(ExprSyntax NewBaseExpression) const;
 
   /// Return the left parenthesis '(' token in this call.
-  RC<TokenSyntax> getLeftParen() const;
+  TokenSyntax getLeftParen() const;
 
   /// Return a new `FunctionCallExprSyntax` with the given left parenthesis '('
   /// token.
-  FunctionCallExprSyntax withLeftParen(RC<TokenSyntax> NewLeftParen) const;
+  FunctionCallExprSyntax withLeftParen(TokenSyntax NewLeftParen) const;
 
   /// Get the list of arguments in this call expression.
   FunctionCallArgumentListSyntax getArgumentList() const;
@@ -253,11 +253,11 @@ public:
   withArgumentList(FunctionCallArgumentListSyntax NewArgumentList) const;
 
   /// Return the right parenthesis ')' token in this call.
-  RC<TokenSyntax> getRightParen() const;
+  TokenSyntax getRightParen() const;
 
   /// Return a new `FunctionCallExprSyntax` with the given right parenthesis ')'
   /// token.
-  FunctionCallExprSyntax withRightParen(RC<TokenSyntax> NewLeftParen) const;
+  FunctionCallExprSyntax withRightParen(TokenSyntax NewLeftParen) const;
 
   static bool classof(const Syntax *S) {
     return S->getKind() == SyntaxKind::FunctionCallExpr;
@@ -278,14 +278,14 @@ public:
   useCalledExpression(ExprSyntax CalledExpression);
 
   /// Use the given left parenthesis '(' token in the function call.
-  FunctionCallExprSyntaxBuilder &useLeftParen(RC<TokenSyntax> LeftParen);
+  FunctionCallExprSyntaxBuilder &useLeftParen(TokenSyntax LeftParen);
 
   /// Add an additional argument to the layout.
   FunctionCallExprSyntaxBuilder &
   appendArgument(FunctionCallArgumentSyntax AdditionalArgument);
 
   /// Use the given right parenthesis ')' token in the function call.
-  FunctionCallExprSyntaxBuilder &useRightParen(RC<TokenSyntax> RightParen);
+  FunctionCallExprSyntaxBuilder &useRightParen(TokenSyntax RightParen);
 
   /// Return a `FunctionCallExprSyntax` with the arguments added so far.
   FunctionCallExprSyntax build() const;

--- a/include/swift/Syntax/GenericSyntax.h
+++ b/include/swift/Syntax/GenericSyntax.h
@@ -75,14 +75,14 @@ public:
   /// Return a new ConformanceRequirementSyntax with the given conforming
   /// "left-hand" type identifier.
   ConformanceRequirementSyntax
-  withConformingTypeIdentifier(RC<TokenSyntax> NewTypeIdentifier) const;
+  withConformingTypeIdentifier(TokenSyntax NewTypeIdentifier) const;
 
   /// Return the colon token in the conformance requirement.
-  RC<TokenSyntax> getColonToken() const;
+  TokenSyntax getColonToken() const;
 
   /// Return a new ConformanceRequirementSyntax with the given colon token.
   ConformanceRequirementSyntax
-  withColonToken(RC<TokenSyntax> NewColonToken);
+  withColonToken(TokenSyntax NewColonToken);
 
   /// Return the "right-hand" inherited type from the conformance requirement.
   TypeIdentifierSyntax getInheritedType() const;
@@ -128,10 +128,10 @@ public:
   withLeftTypeIdentifier(TypeIdentifierSyntax NewLeftTypeIdentifier) const;
 
   /// Return the equality '==' operator token from the same-type requirement.
-  RC<TokenSyntax> getEqualityToken() const;
+  TokenSyntax getEqualityToken() const;
 
   SameTypeRequirementSyntax
-  withEqualityToken(RC<TokenSyntax> NewEqualityToken) const;
+  withEqualityToken(TokenSyntax NewEqualityToken) const;
 
   /// Return the type syntax from the right side of the same-type requirement.
   TypeSyntax getRightType() const;
@@ -169,19 +169,19 @@ public:
     : Syntax(Root, Data) {}
 
   /// Return the name of the generic parameter.
-  RC<TokenSyntax> getIdentifier() const;
+  TokenSyntax getIdentifier() const;
 
   /// Returns a GenericParameterSyntax with the given parameter identifier
   GenericParameterSyntax
-  withIdentifier(RC<TokenSyntax> NewIdentifier) const;
+  withIdentifier(TokenSyntax NewIdentifier) const;
 
   /// Return the colon token before the inherited type, if applicable.
-  RC<TokenSyntax> getColonToken() const;
+  TokenSyntax getColonToken() const;
 
   /// Return a GenericParameterSyntax with the given colon token before the
   /// inherited type.
   GenericParameterSyntax
-  withColonToken(RC<TokenSyntax> NewColonToken) const;
+  withColonToken(TokenSyntax NewColonToken) const;
 
   /// Return the inherited type or protocol composition to which the
   /// parameter conforms, if applicable.
@@ -222,12 +222,12 @@ public:
                                const SyntaxData *Data)
     : Syntax(Root, Data) {}
   /// Return the left angle bracket '<' token on the generic parameter clause.
-  RC<TokenSyntax> getLeftAngleBracket() const;
+  TokenSyntax getLeftAngleBracket() const;
 
   /// Return a new GenericParameterClauseSyntax with the given left angle
   /// bracket '<' token.
   GenericParameterClauseSyntax
-  withLeftAngleBracket(RC<TokenSyntax> NewLeftAngleBracketToken) const;
+  withLeftAngleBracket(TokenSyntax NewLeftAngleBracketToken) const;
 
   /// Return the GenericParameterListSyntax inside the angle bracket tokens.
   GenericParameterListSyntax getGenericParameterList() const;
@@ -238,12 +238,12 @@ public:
   withGenericParams(GenericParameterListSyntax NewGenericParams) const;
 
   /// Return the right angle bracket '>' token on the generic parameter clause.
-  RC<TokenSyntax> getRightAngleBracket() const;
+  TokenSyntax getRightAngleBracket() const;
 
   /// Return a GenericParameterClauseSyntax with the given right angle
   /// bracket '>' token.
   GenericParameterClauseSyntax
-  withRightAngleBracket(RC<TokenSyntax> NewRightAngleBracketToken) const;
+  withRightAngleBracket(TokenSyntax NewRightAngleBracketToken) const;
   static bool classof(const Syntax *S) {
     return S->getKind() == SyntaxKind::GenericParameterClause;
   }
@@ -252,22 +252,22 @@ public:
 #pragma mark - generic-parameter-clause Builder
 
 class GenericParameterClauseBuilder {
-  RC<TokenSyntax> LeftAngleToken;
+  RC<RawTokenSyntax> LeftAngleToken;
   RawSyntax::LayoutList ParameterListLayout;
-  RC<TokenSyntax> RightAngleToken;
+  RC<RawTokenSyntax> RightAngleToken;
 
 public:
   GenericParameterClauseBuilder();
 
   GenericParameterClauseBuilder &
-  useLeftAngleBracket(RC<TokenSyntax> LeftAngleBracket);
+  useLeftAngleBracket(TokenSyntax LeftAngleBracket);
 
   GenericParameterClauseBuilder &
-  addParameter(llvm::Optional<RC<TokenSyntax>> MaybeComma,
+  addParameter(llvm::Optional<TokenSyntax> MaybeComma,
                GenericParameterSyntax Parameter);
 
   GenericParameterClauseBuilder &
-  useRightAngleBracket(RC<TokenSyntax> RightAngleBracket);
+  useRightAngleBracket(TokenSyntax RightAngleBracket);
 
   GenericParameterClauseSyntax build() const;
 };
@@ -297,12 +297,12 @@ public:
     : Syntax(Root, Data) {}
 
   /// Return the left angle bracket '<' token on the generic argument clause.
-  RC<TokenSyntax> getLeftAngleBracket() const;
+  TokenSyntax getLeftAngleBracket() const;
 
   /// Return a new GenericArgumentClauseSyntax with the given left angle
   /// bracket '<' token.
   GenericArgumentClauseSyntax
-  withLeftAngleBracket(RC<TokenSyntax> NewLeftAngleBracket) const;
+  withLeftAngleBracket(TokenSyntax NewLeftAngleBracket) const;
 
   /// Return the GenericArgumentClauseSyntax inside the angle bracket tokens.
   GenericArgumentListSyntax getGenericParameterList() const;
@@ -313,12 +313,12 @@ public:
   withGenericParams(GenericParameterListSyntax NewGenericParams) const;
 
   /// Return the right angle bracket '>' token on the generic argument clause.
-  RC<TokenSyntax> getRightAngleBracket() const;
+  TokenSyntax getRightAngleBracket() const;
 
   /// Return a new GenericArgumentClauseSyntax with the given right angle
   /// bracket '>' token.
   GenericArgumentClauseSyntax
-  withRightAngleBracket(RC<TokenSyntax> NewRightAngleBracket) const;
+  withRightAngleBracket(TokenSyntax NewRightAngleBracket) const;
 
   static bool classof(const Syntax *S) {
     return S->getKind() == SyntaxKind::GenericArgumentClause;
@@ -328,21 +328,21 @@ public:
 #pragma mark - generic-argument-clause Builder
 
 class GenericArgumentClauseBuilder {
-  RC<TokenSyntax> LeftAngleToken;
+  RC<RawTokenSyntax> LeftAngleToken;
   RawSyntax::LayoutList ArgumentListLayout;
-  RC<TokenSyntax> RightAngleToken;
+  RC<RawTokenSyntax> RightAngleToken;
 public:
   GenericArgumentClauseBuilder();
 
   GenericArgumentClauseBuilder &
-  useLeftAngleBracket(RC<TokenSyntax> LeftAngleBracket);
+  useLeftAngleBracket(TokenSyntax LeftAngleBracket);
 
   GenericArgumentClauseBuilder &
-  addGenericArgument(llvm::Optional<RC<TokenSyntax>> MaybeComma,
+  addGenericArgument(llvm::Optional<TokenSyntax> MaybeComma,
                      TypeSyntax ArgumentTypeSyntax);
 
   GenericArgumentClauseBuilder &
-  useRightAngleBracket(RC<TokenSyntax> RightAngleBracket);
+  useRightAngleBracket(TokenSyntax RightAngleBracket);
 
   GenericArgumentClauseSyntax build() const;
 };
@@ -367,11 +367,11 @@ public:
     : Syntax(Root, Data) {}
 
   /// Return the 'where' keyword in the generic where clause.
-  RC<TokenSyntax> getWhereKeyword() const;
+  TokenSyntax getWhereKeyword() const;
 
   /// Return a GenericWhereClauseSyntax with the given 'where' keyword.
   GenericWhereClauseSyntax
-  withWhereKeyword(RC<TokenSyntax> NewWhereKeyword) const;
+  withWhereKeyword(TokenSyntax NewWhereKeyword) const;
 
   /// Return the requirement list from the where clause.
   GenericRequirementListSyntax getRequirementList() const;

--- a/include/swift/Syntax/LegacyASTTransformer.h
+++ b/include/swift/Syntax/LegacyASTTransformer.h
@@ -31,7 +31,7 @@
 namespace swift {
 namespace syntax {
 
-using TokenPositionList = std::vector<std::pair<RC<TokenSyntax>,
+using TokenPositionList = std::vector<std::pair<RC<RawTokenSyntax>,
                                                 AbsolutePosition>>;
 
 /// Transforms a swift/AST into a swift/Syntax/RC<RawSyntax>.
@@ -93,13 +93,13 @@ public:
 #include "swift/AST/ExprNodes.def"
 };
 
-/// Transform a legacy AST node to a full-fidelity `RC<RawSyntax>`.
+/// Transform a legacy AST node to a full-fidelity `Syntax`.
 ///
-/// If an ASTNode's kind isn't covered by the transform, a `RC<RawSyntax>` for
-/// a SyntaxKind::Unknown will be returned containing all of the TokenSyntaxs that
-/// comprise the node.
+/// If an ASTNode's kind isn't covered by the transform, an `UnknownSyntax`
+/// will be returned containing all of the `TokenSyntax`es that comprise the
+/// node.
 ///
-/// If the node isn't expressible in a `RC<RawSyntax>`, then `None` is returned.
+/// If the node isn't expressible in a `Syntax`, then `None` is returned.
 Optional<Syntax>
 transformAST(ASTNode Node,
              sema::Semantics &Sema,
@@ -108,14 +108,14 @@ transformAST(ASTNode Node,
              const TokenPositionList &Tokens);
 
 /// Do a binary search for a token at the given `Offset`.
-RC<TokenSyntax> findTokenSyntax(tok ExpectedKind,
+TokenSyntax findTokenSyntax(tok ExpectedKind,
                                 OwnedString ExpectedText,
                                 SourceManager &SourceMgr,
                                 SourceLoc Loc,
                                 unsigned BufferID,
                                 const TokenPositionList &Tokens);
 
-//ArrayRef<RC<TokenSyntax>>
+//ArrayRef<TokenSyntax>
 //syntax::tokensInRange(SourceRange Range, const TokenPositionList &Tokens);
 
 } // end namespace syntax

--- a/include/swift/Syntax/RawSyntax.h
+++ b/include/swift/Syntax/RawSyntax.h
@@ -18,7 +18,7 @@
 // They are reference-counted and strictly immutable, so can be shared freely
 // among Syntax nodes and have no specific identity. They could even in theory
 // be shared for expressions like 1 + 1 + 1 + 1 - you don't need 7 syntax nodes
-// to expressSwiftTypeConverter that at this layer.
+// to express that at this layer.
 //
 // These are internal implementation ONLY - do not expose anything involving
 // RawSyntax publicly. Clients of lib/Syntax should not be aware that they
@@ -50,26 +50,29 @@ using llvm::StringRef;
 
 #ifndef NDEBUG
 #define syntax_assert_child_token(Raw, Cursor, TokenKind)                      \
-  (assert(cast<TokenSyntax>(Raw->getChild(Cursor))->getTokenKind() == TokenKind));
+  (assert(cast<RawTokenSyntax>(Raw->getChild(Cursor))->getTokenKind() ==       \
+          TokenKind));
 #else
 #define syntax_assert_child_token(Raw, Cursor, TokenKind) ((void)0);
 #endif
 
 #ifndef NDEBUG
 #define syntax_assert_child_token_text(Raw, Cursor, TokenKind, Text)           \
-  (assert(cast<TokenSyntax>(Raw->getChild(Cursor))->getTokenKind() ==          \
-          TokenKind));                                                         \
-  (assert(cast<TokenSyntax>(Raw->getChild(Cursor))->getText() == Text));
+  ({                                                                           \
+    auto __Child = cast<RawTokenSyntax>(Raw->getChild(Cursor));                \
+    assert(__Child->getTokenKind() == TokenKind);                              \
+    assert(__Child->getText() == Text);                                        \
+  })
 #else
 #define syntax_assert_child_token_text(Raw, Cursor, TokenKind, Text) ((void)0);
 #endif
 
 #ifndef NDEBUG
 #define syntax_assert_token_is(Tok, Kind, Text)                                \
-  {                                                                            \
-    assert(Tok->getTokenKind() == Kind);                                       \
-    assert(Tok->getText() == Text);                                            \
-  }
+  ({                                                                           \
+    assert(Tok.getTokenKind() == Kind);                                        \
+    assert(Tok.getText() == Text);                                             \
+  })
 #else
 #define syntax_assert_token_is(Tok, Kind, Text) ((void)0);
 #endif

--- a/include/swift/Syntax/RawTokenSyntax.h
+++ b/include/swift/Syntax/RawTokenSyntax.h
@@ -1,0 +1,203 @@
+//===------- RawTokenSyntax.h - Swift Raw Token Interface -------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file contains the interface for a `RawTokenSyntax`, which is a token
+// that includes full-fidelity leading and trailing trivia.
+//
+// A `RawTokenSyntax` is an instance of `RawSyntax`, meaning it is immutable,
+// reference counted, and able to be shared. It is an implementation detail;
+// most users of tokens should use `TokenSyntax` instead.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SYNTAX_RAWTOKENSYNTAX_H
+#define SWIFT_SYNTAX_RAWTOKENSYNTAX_H
+
+#include "swift/Syntax/RawSyntax.h"
+#include "swift/Syntax/References.h"
+#include "swift/Syntax/Syntax.h"
+#include "swift/Syntax/TokenKinds.h"
+#include "swift/Syntax/Trivia.h"
+
+namespace swift {
+namespace syntax {
+
+class AbsolutePosition;
+
+struct RawTokenSyntax final : public RawSyntax {
+  friend struct SyntaxFactory;
+  const tok TokenKind;
+  const OwnedString Text;
+  const Trivia LeadingTrivia;
+  const Trivia TrailingTrivia;
+
+private:
+  RawTokenSyntax();
+
+  RawTokenSyntax(tok TokenKind, OwnedString Text,
+                 const SourcePresence Presence);
+
+  RawTokenSyntax(tok TokenKind, OwnedString Text, const SourcePresence Presence,
+                 const Trivia &LeadingTrivia, const Trivia &TrailingTrivia);
+
+public:
+  /// Make a new token.
+  static RC<RawTokenSyntax> make(tok TokenKind, OwnedString Text,
+                                 const SourcePresence Presence,
+                                 const Trivia &LeadingTrivia,
+                                 const Trivia &TrailingTrivia) {
+    return RC<RawTokenSyntax> {
+      new RawTokenSyntax {
+        TokenKind, Text, Presence,
+        LeadingTrivia, TrailingTrivia
+      }
+    };
+  }
+
+  /// Return a token with the specified kind and text, but marked as missing.
+  static RC<RawTokenSyntax> missingToken(const tok Kind, OwnedString Text) {
+    return make(Kind, Text, SourcePresence::Missing, {}, {});
+  }
+
+  /// Return a new token like this one, but with the given leading
+  /// trivia instead.
+  RC<RawTokenSyntax> withLeadingTrivia(const Trivia &NewLeadingTrivia) const {
+    return make(TokenKind, Text, Presence, NewLeadingTrivia, TrailingTrivia);
+  }
+
+  /// Return a new token like this one, but with the given trailing
+  /// trivia instead.
+  RC<RawTokenSyntax> withTrailingTrivia(const Trivia &NewTrailingTrivia) const {
+    return make(TokenKind, Text, Presence, LeadingTrivia, NewTrailingTrivia);
+  }
+
+  /// Returns true if the token is of the expected kind and has the given
+  /// expected text.
+  bool is(tok ExpectedKind, StringRef ExpectedText) const {
+    return getTokenKind() == ExpectedKind && ExpectedText == getText();
+  }
+
+  /// Returns the kind of token this is.
+  tok getTokenKind() const { return TokenKind; }
+
+  /// Returns a reference to the text of this token.
+  StringRef getText() const { return Text.str(); }
+
+  /// True if the token is any keyword.
+  bool isKeyword() const {
+    switch (TokenKind) {
+#define KEYWORD(X) case tok::kw_##X: return true;
+#include "swift/Syntax/TokenKinds.def"
+      default: return false;
+    }
+  }
+
+  /// Returns true if the token is any literal.
+  bool isLiteral() const {
+    switch(TokenKind) {
+      case tok::integer_literal:
+      case tok::floating_literal:
+      case tok::string_literal:
+      case tok::pound_fileLiteral:
+      case tok::pound_colorLiteral:
+      case tok::pound_imageLiteral:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  /// Returns true if this token is of the specified kind.
+  bool is(tok K) const { return TokenKind == K; }
+
+  /// Returns true if this token is not of the specified kind.
+  bool isNot(tok K) const { return TokenKind != K; }
+
+  /// Base case for variadic `isAny`
+  bool isAny(tok K1) const {
+    return is(K1);
+  }
+
+  /// Returns true if this token is any of the provided kinds.
+  template <typename ...T>
+  bool isAny(tok K1, tok K2, T... K) const {
+    if (is(K1))
+      return true;
+    return isAny(K2, K...);
+  }
+
+  /// Returns true if this token is not any of the provided kinds.
+  template <typename ...T>
+  bool isNot(tok K1, T... K) const { return !isAny(K1, K...); }
+
+  bool isPunctuation() const {
+    switch (TokenKind) {
+#define PUNCTUATOR(Name, Str) case tok::Name: return true;
+#include "swift/Syntax/TokenKinds.def"
+      default: return false;
+    }
+  }
+
+  /// Returns true if this token is a binary operator.
+  bool isBinaryOperator() const {
+    return TokenKind == tok::oper_binary_spaced ||
+    TokenKind == tok::oper_binary_unspaced;
+  }
+
+  /// Returns true if this token is any kind of operator.
+  bool isOperator() const {
+    return isBinaryOperator() ||
+    TokenKind == tok::oper_postfix ||
+    TokenKind == tok::oper_prefix;
+  }
+
+  /// Returns true if this token is not an operator.
+  bool isNotOperator() const {
+    return !isOperator();
+  }
+
+  /// Print the leading trivia, text, and trailing trivia of this token to
+  /// the provided output stream.
+  void print(llvm::raw_ostream &OS, unsigned Indent = 0) const {
+    for (const auto &Leader : LeadingTrivia) {
+      Leader.print(OS);
+    }
+
+    if (!isMissing()) {
+      OS << getText();
+    }
+
+    for (const auto &Trailer : TrailingTrivia) {
+      Trailer.print(OS);
+    }
+  }
+
+  /// Advance the provided AbsolutePosition by the token's full width and
+  /// return the AbsolutePosition of the start of the token's nontrivial text.
+  AbsolutePosition accumulateAbsolutePosition(AbsolutePosition &Pos) const;
+
+  /// Dump the textual representation of this token's kind.
+  void dumpKind(llvm::raw_ostream &OS) const;
+
+  /// Dump the layout of this token: its leading trivia, kind, text, and
+  /// trailing trivia.
+  void dump(llvm::raw_ostream &OS, unsigned Indent = 0) const;
+
+  static bool classof(const RawSyntax *RS) {
+    return RS->Kind == SyntaxKind::Token;
+  }
+};
+
+} // end namespace syntax
+} // end namespace swift
+
+#endif // SWIFT_SYNTAX_RAWTOKENSYNTAX_H

--- a/include/swift/Syntax/Serialization/SyntaxSerialization.h
+++ b/include/swift/Syntax/Serialization/SyntaxSerialization.h
@@ -193,7 +193,7 @@ struct ObjectTraits<RC<syntax::RawSyntax>> {
     auto kind = value->Kind;
     switch (kind) {
     case syntax::SyntaxKind::Token: {
-      auto Tok = cast<syntax::TokenSyntax>(value);
+      auto Tok = cast<syntax::RawTokenSyntax>(value);
       auto tokenKind = Tok->getTokenKind();
       auto text = Tok->getText();
       auto description = TokenDescription { tokenKind, text };

--- a/include/swift/Syntax/StmtSyntax.h
+++ b/include/swift/Syntax/StmtSyntax.h
@@ -91,10 +91,10 @@ public:
     : StmtSyntax(Root, Data) {}
 
   /// Returns the left brace of the code block.
-  RC<TokenSyntax> getLeftBraceToken() const;
+  TokenSyntax getLeftBraceToken() const;
 
   /// Returns a new `CodeBlockSyntax` with the specified left brace token.
-  CodeBlockStmtSyntax withLeftBraceToken(RC<TokenSyntax> NewLeftBrace) const;
+  CodeBlockStmtSyntax withLeftBraceToken(TokenSyntax NewLeftBrace) const;
 
   /// Return the n-th element in the code block.
   Syntax getElement(size_t n) const;
@@ -109,10 +109,10 @@ public:
   withElements(const std::vector<Syntax> NewElements) const;
 
   /// Returns the right brace of the code block.
-  RC<TokenSyntax> getRightBraceToken() const;
+  TokenSyntax getRightBraceToken() const;
 
   /// Returns a new `CodeBlockSyntax` with the specified right brace token.
-  CodeBlockStmtSyntax withRightBraceToken(RC<TokenSyntax> NewRightBraces) const;
+  CodeBlockStmtSyntax withRightBraceToken(TokenSyntax NewRightBraces) const;
 
   static bool classof(const Syntax *S) {
     return S->getKind() == SyntaxKind::CodeBlockStmt;
@@ -139,12 +139,12 @@ public:
 
   /// Get the 'fallthrough' keyword associated comprising this
   /// fallthrough statement.
-  RC<TokenSyntax> getFallthroughKeyword() const;
+  TokenSyntax getFallthroughKeyword() const;
 
   /// Return a new FallthroughStmtSyntax with the given fallthrough
   /// keyword.
   FallthroughStmtSyntax
-  withFallthroughKeyword(RC<TokenSyntax> NewFallthroughKeyword) const;
+  withFallthroughKeyword(TokenSyntax NewFallthroughKeyword) const;
 
   static bool classof(const Syntax *S) {
     return S->getKind() == SyntaxKind::FallthroughStmt;
@@ -171,17 +171,17 @@ public:
     : StmtSyntax(Root, Data) {}
 
   /// Return the 'break' keyword associated with this break statement.
-  RC<TokenSyntax> getBreakKeyword() const;
+  TokenSyntax getBreakKeyword() const;
 
   /// Return a new `BreakStmtSyntax` with the given 'break' keyword.
-  BreakStmtSyntax withBreakKeyword(RC<TokenSyntax> NewBreakKeyword) const;
+  BreakStmtSyntax withBreakKeyword(TokenSyntax NewBreakKeyword) const;
 
   /// Return the destination label of this break statement. If it doesn't
   /// have one, the token is marked as missing.
-  RC<TokenSyntax> getLabel() const;
+  TokenSyntax getLabel() const;
 
   /// Return a new `BreakStmtSyntax` with the given destination label.
-  BreakStmtSyntax withLabel(RC<TokenSyntax> NewLabel) const;
+  BreakStmtSyntax withLabel(TokenSyntax NewLabel) const;
 
   static bool classof(const Syntax *S) {
     return S->getKind() == SyntaxKind::BreakStmt;
@@ -208,17 +208,17 @@ public:
     : StmtSyntax(Root, Data) {}
 
   /// Return the 'continue' keyword associated with this continue statement.
-  RC<TokenSyntax> getContinueKeyword() const;
+  TokenSyntax getContinueKeyword() const;
 
   /// Return a new `ContinueStmtSyntax` with the given 'continue' keyword.
-  ContinueStmtSyntax withContinueKeyword(RC<TokenSyntax> NewBreakKeyword) const;
+  ContinueStmtSyntax withContinueKeyword(TokenSyntax NewBreakKeyword) const;
 
   /// Return the destination label of this break statement. If it doesn't
   /// have one, the token is marked as continue.
-  RC<TokenSyntax> getLabel() const;
+  TokenSyntax getLabel() const;
 
   /// Return a new `ContinueStmtSyntax` with the given destination label.
-  ContinueStmtSyntax withLabel(RC<TokenSyntax> NewLabel) const;
+  ContinueStmtSyntax withLabel(TokenSyntax NewLabel) const;
 
   static bool classof(const Syntax *S) {
     return S->getKind() == SyntaxKind::ContinueStmt;
@@ -245,10 +245,10 @@ public:
     : StmtSyntax(Root, Data) {}
 
   /// Return the 'return' keyword associated with this return statement.
-  RC<TokenSyntax> getReturnKeyword() const;
+  TokenSyntax getReturnKeyword() const;
 
   /// Return a new `ReturnStmtSyntax` with the given 'return' keyword.
-  ReturnStmtSyntax withReturnKeyword(RC<TokenSyntax> NewReturnKeyword) const;
+  ReturnStmtSyntax withReturnKeyword(TokenSyntax NewReturnKeyword) const;
 
   /// Return the expression of this return statement.
   Optional<ExprSyntax> getExpression() const;

--- a/include/swift/Syntax/SyntaxData.h
+++ b/include/swift/Syntax/SyntaxData.h
@@ -49,8 +49,6 @@
 namespace swift {
 namespace syntax {
 
-class Syntax;
-
 /// The class for holding parented syntax.
 ///
 /// This structure should not contain significant public
@@ -211,7 +209,7 @@ public:
   ///
   /// SyntaxData = {
   ///   RC<RawSyntax> Raw = {
-  ///     RC<RawTokenSyntax { SyntaxKind::Token, tok::return_kw, "return" },
+  ///     RC<RawTokenSyntax> { SyntaxKind::Token, tok::return_kw, "return" },
   ///     RC<RawSyntax> { SyntaxKind::SomeExpression, ... }
   ///   }
   ///   llvm::SmallVector<AtomicCache<SyntaxData>, 10> Children {

--- a/include/swift/Syntax/SyntaxFactory.h
+++ b/include/swift/Syntax/SyntaxFactory.h
@@ -42,13 +42,18 @@ class DeclSyntax;
 class ExprSyntax;
 class StmtSyntax;
 class UnknownSyntax;
-struct TokenSyntax;
+struct RawTokenSyntax;
 
-/// The Syntax builder - the one-stop shop for making new Syntax nodes.
+/// The Syntax factory - the one-stop shop for making new Syntax nodes.
 struct SyntaxFactory {
+  /// Make any kind of token.
+  static TokenSyntax
+  makeToken(tok Kind, OwnedString Text, SourcePresence Presence,
+            const Trivia &LeadingTrivia, const Trivia &TrailingTrivia);
+
   /// Collect a list of tokens into a piece of "unknown" syntax.
   static UnknownSyntax
-  makeUnknownSyntax(llvm::ArrayRef<RC<TokenSyntax>> Tokens);
+  makeUnknownSyntax(llvm::ArrayRef<TokenSyntax> Tokens);
 
 #pragma mark - Declarations
 
@@ -56,8 +61,8 @@ struct SyntaxFactory {
 
   /// Make a declaration modifier with the specified elements.
   static DeclModifierSyntax
-  makeDeclModifier(RC<TokenSyntax> Name, RC<TokenSyntax> LeftParen,
-                   RC<TokenSyntax> Argument, RC<TokenSyntax> RightParen);
+  makeDeclModifier(TokenSyntax Name, TokenSyntax LeftParen,
+                   TokenSyntax Argument, TokenSyntax RightParen);
 
   /// Make a declaration modifier with all missing elements.
   static DeclModifierSyntax makeBlankDeclModifier();
@@ -73,19 +78,19 @@ struct SyntaxFactory {
 
   /// Make a struct declaration with the specified elements.
   static StructDeclSyntax
-  makeStructDecl(RC<TokenSyntax> StructToken, RC<TokenSyntax> Identifier,
+  makeStructDecl(TokenSyntax StructToken, TokenSyntax Identifier,
                  Syntax GenericParameters, Syntax WhereClause,
-                 RC<TokenSyntax> LeftBrace, Syntax DeclMembers,
-                 RC<TokenSyntax> RightBrace);
+                 TokenSyntax LeftBrace, Syntax DeclMembers,
+                 TokenSyntax RightBrace);
 
   /// Make a struct declaration with all missing elements.
   static StructDeclSyntax makeBlankStructDecl();
 
   /// Make a typealias declaration with the specified elements.
   static TypeAliasDeclSyntax
-  makeTypealiasDecl(RC<TokenSyntax> TypealiasToken, RC<TokenSyntax> Identifier,
+  makeTypealiasDecl(TokenSyntax TypealiasToken, TokenSyntax Identifier,
                     GenericParameterClauseSyntax GenericParams,
-                    RC<TokenSyntax> AssignmentToken, TypeSyntax Type);
+                    TokenSyntax AssignmentToken, TypeSyntax Type);
 
   /// Make a typealias declaration with all missing elements.
   static TypeAliasDeclSyntax makeBlankTypealiasDecl();
@@ -97,8 +102,8 @@ struct SyntaxFactory {
   static FunctionDeclSyntax
   makeFunctionDecl(TypeAttributesSyntax Attributes,
                    DeclModifierListSyntax Modifiers,
-                   RC<TokenSyntax> FuncKeyword,
-                   RC<TokenSyntax> Identifier,
+                   TokenSyntax FuncKeyword,
+                   TokenSyntax Identifier,
                    llvm::Optional<GenericParameterClauseSyntax> GenericParams,
                    FunctionSignatureSyntax Signature,
                    llvm::Optional<GenericWhereClauseSyntax> GenericWhereClause,
@@ -111,13 +116,13 @@ struct SyntaxFactory {
 
   /// Make a function parameter with the given elements.
   static FunctionParameterSyntax
-  makeFunctionParameter(RC<TokenSyntax> ExternalName, RC<TokenSyntax> LocalName,
-                        RC<TokenSyntax> Colon,
+  makeFunctionParameter(TokenSyntax ExternalName, TokenSyntax LocalName,
+                        TokenSyntax Colon,
                         llvm::Optional<TypeSyntax> ParameterTypeSyntax,
-                        RC<TokenSyntax> Ellipsis,
-                        RC<TokenSyntax> Equal,
+                        TokenSyntax Ellipsis,
+                        TokenSyntax Equal,
                         llvm::Optional<ExprSyntax> DefaultValue,
-                        RC<TokenSyntax> TrailingComma);
+                        TokenSyntax TrailingComma);
 
   /// Make a function parameter with all elements marked as missing.
   static FunctionParameterSyntax makeBlankFunctionParameter();
@@ -135,11 +140,11 @@ struct SyntaxFactory {
 
   /// Make a function signature with the given elements.
   static FunctionSignatureSyntax
-  makeFunctionSignature(RC<TokenSyntax> LeftParen,
+  makeFunctionSignature(TokenSyntax LeftParen,
                         FunctionParameterListSyntax ParameterList,
-                        RC<TokenSyntax> RightParen,
-                        RC<TokenSyntax> ThrowsOrRethrows,
-                        RC<TokenSyntax> Arrow,
+                        TokenSyntax RightParen,
+                        TokenSyntax ThrowsOrRethrows,
+                        TokenSyntax Arrow,
                         TypeAttributesSyntax ReturnTypeAttributes,
                         TypeSyntax ReturnTypeSyntax);
 
@@ -156,16 +161,16 @@ struct SyntaxFactory {
 
   /// Make a code block with the specified elements.
   static CodeBlockStmtSyntax
-  makeCodeBlock(RC<TokenSyntax> LeftBraceToken,
+  makeCodeBlock(TokenSyntax LeftBraceToken,
                 StmtListSyntax Elements,
-                RC<TokenSyntax> RightBraceToken);
+                TokenSyntax RightBraceToken);
 
   /// Make a code block with all missing elements.
   static CodeBlockStmtSyntax makeBlankCodeBlock();
 
   /// Make a fallthrough statement with the give `fallthrough` keyword.
   static FallthroughStmtSyntax
-  makeFallthroughStmt(RC<TokenSyntax> FallthroughKeyword);
+  makeFallthroughStmt(TokenSyntax FallthroughKeyword);
 
   /// Make a fallthrough statement with the `fallthrough` keyword
   /// marked as missing.
@@ -174,7 +179,7 @@ struct SyntaxFactory {
   /// Make a break statement with the give `break` keyword and
   /// destination label.
   static BreakStmtSyntax
-  makeBreakStmt(RC<TokenSyntax> BreakKeyword, RC<TokenSyntax> Label);
+  makeBreakStmt(TokenSyntax BreakKeyword, TokenSyntax Label);
 
   /// Make a break statement with the `break` keyword
   /// and destination label marked as missing.
@@ -183,7 +188,7 @@ struct SyntaxFactory {
   /// Make a continue statement with the given `continue` keyword and
   /// destination label.
   static ContinueStmtSyntax
-  makeContinueStmt(RC<TokenSyntax> ContinueKeyword, RC<TokenSyntax> Label);
+  makeContinueStmt(TokenSyntax ContinueKeyword, TokenSyntax Label);
 
   /// Make a continue statement with the `continue` keyword
   /// and destination label marked as missing.
@@ -192,7 +197,7 @@ struct SyntaxFactory {
   /// Make a return statement with the given `return` keyword and returned
   /// expression.
   static ReturnStmtSyntax
-  makeReturnStmt(RC<TokenSyntax> ReturnKeyword, ExprSyntax ReturnedExpression);
+  makeReturnStmt(TokenSyntax ReturnKeyword, ExprSyntax ReturnedExpression);
 
   /// Make a return statement with the `return` keyword and return expression
   /// marked as missing.
@@ -208,7 +213,7 @@ struct SyntaxFactory {
 
   /// Make an integer literal with the given '+'/'-' sign and string of digits.
   static IntegerLiteralExprSyntax
-  makeIntegerLiteralExpr(RC<TokenSyntax> Sign, RC<TokenSyntax> Digits);
+  makeIntegerLiteralExpr(TokenSyntax Sign, TokenSyntax Digits);
 
   /// Make an integer literal with the sign and string of digits marked
   /// as missing.
@@ -217,7 +222,7 @@ struct SyntaxFactory {
   /// Make a symbolic reference with the given identifier and optionally a
   /// generic argument clause.
   static SymbolicReferenceExprSyntax
-  makeSymbolicReferenceExpr(RC<TokenSyntax> Identifier,
+  makeSymbolicReferenceExpr(TokenSyntax Identifier,
     llvm::Optional<GenericArgumentClauseSyntax> GenericArgs);
 
   /// Make a symbolic reference expression with the identifier and
@@ -230,9 +235,9 @@ struct SyntaxFactory {
   /// Make a function call argument based on an expression with the
   /// given elements.
   static FunctionCallArgumentSyntax
-  makeFunctionCallArgument(RC<TokenSyntax> Label, RC<TokenSyntax> Colon,
+  makeFunctionCallArgument(TokenSyntax Label, TokenSyntax Colon,
                            ExprSyntax ExpressionArgument,
-                           RC<TokenSyntax> TrailingComma);
+                           TokenSyntax TrailingComma);
 
   /// Make a function call argument list with the given arguments.
   static FunctionCallArgumentListSyntax
@@ -244,9 +249,9 @@ struct SyntaxFactory {
 
   /// Make a function call expression with the given elements.
   static FunctionCallExprSyntax
-  makeFunctionCallExpr(ExprSyntax CalledExpr, RC<TokenSyntax> LeftParen,
+  makeFunctionCallExpr(ExprSyntax CalledExpr, TokenSyntax LeftParen,
                        FunctionCallArgumentListSyntax Arguments,
-                       RC<TokenSyntax> RightParen);
+                       TokenSyntax RightParen);
 
   /// Make a function call expression with all elements marked as missing.
   static FunctionCallExprSyntax makeBlankFunctionCallExpr();
@@ -254,173 +259,173 @@ struct SyntaxFactory {
 #pragma mark - Tokens
 
   /// Make a 'static' keyword with the specified leading and trailing trivia.
-  static RC<TokenSyntax> makeStaticKeyword(const Trivia &LeadingTrivia,
-                                           const Trivia &TrailingTrivia);
+  static TokenSyntax makeStaticKeyword(const Trivia &LeadingTrivia,
+                                       const Trivia &TrailingTrivia);
 
 
   /// Make a 'public' keyword with the specified leading and trailing trivia.
-  static RC<TokenSyntax> makePublicKeyword(const Trivia &LeadingTrivia,
-                                           const Trivia &TrailingTrivia);
+  static TokenSyntax makePublicKeyword(const Trivia &LeadingTrivia,
+                                       const Trivia &TrailingTrivia);
 
   /// Make a 'func' keyword with the specified leading and trailing trivia.
-  static RC<TokenSyntax> makeFuncKeyword(const Trivia &LeadingTrivia,
-                                         const Trivia &TrailingTrivia);
+  static TokenSyntax makeFuncKeyword(const Trivia &LeadingTrivia,
+                                     const Trivia &TrailingTrivia);
 
   /// Make a 'fallthrough' keyword with the specified leading and
   /// trailing trivia.
-  static RC<TokenSyntax> makeFallthroughKeyword(const Trivia &LeadingTrivia,
-                                                const Trivia &TrailingTrivia);
+  static TokenSyntax makeFallthroughKeyword(const Trivia &LeadingTrivia,
+                                            const Trivia &TrailingTrivia);
 
   /// Make an at-sign '@' token with the specified leading and
   /// trailing trivia.
-  static RC<TokenSyntax> makeAtSignToken(const Trivia &LeadingTrivia,
-                                         const Trivia &TrailingTrivia);
+  static TokenSyntax makeAtSignToken(const Trivia &LeadingTrivia,
+                                     const Trivia &TrailingTrivia);
 
   /// Make a 'break' keyword with the specified leading and
   /// trailing trivia.
-  static RC<TokenSyntax> makeBreakKeyword(const Trivia &LeadingTrivia,
-                                          const Trivia &TrailingTrivia);
+  static TokenSyntax makeBreakKeyword(const Trivia &LeadingTrivia,
+                                      const Trivia &TrailingTrivia);
 
   /// Make a 'continue' keyword with the specified leading and
   /// trailing trivia.
-  static RC<TokenSyntax> makeContinueKeyword(const Trivia &LeadingTrivia,
-                                             const Trivia &TrailingTrivia);
+  static TokenSyntax makeContinueKeyword(const Trivia &LeadingTrivia,
+                                         const Trivia &TrailingTrivia);
 
   /// Make a 'return' keyword with the specified leading and
   /// trailing trivia.
-  static RC<TokenSyntax> makeReturnKeyword(const Trivia &LeadingTrivia,
-                                           const Trivia &TrailingTrivia);
+  static TokenSyntax makeReturnKeyword(const Trivia &LeadingTrivia,
+                                       const Trivia &TrailingTrivia);
 
   /// Make a left angle '<' token with the specified leading and
   /// trailing trivia.
-  static RC<TokenSyntax> makeLeftAngleToken(const Trivia &LeadingTrivia,
-                                            const Trivia &TrailingTrivia);
+  static TokenSyntax makeLeftAngleToken(const Trivia &LeadingTrivia,
+                                        const Trivia &TrailingTrivia);
 
   /// Make a right angle '>' token with the specified leading and
   /// trailing trivia.
-  static RC<TokenSyntax> makeRightAngleToken(const Trivia &LeadingTrivia,
-                                             const Trivia &TrailingTrivia);
+  static TokenSyntax makeRightAngleToken(const Trivia &LeadingTrivia,
+                                         const Trivia &TrailingTrivia);
 
   /// Make a left parenthesis '(' token with the specified leading and
   /// trailing trivia.
-  static RC<TokenSyntax> makeLeftParenToken(const Trivia &LeadingTrivia,
-                                            const Trivia &TrailingTrivia);
+  static TokenSyntax makeLeftParenToken(const Trivia &LeadingTrivia,
+                                        const Trivia &TrailingTrivia);
 
   /// Make a right parenthesis ')' token with the specified leading and
   /// trailing trivia.
-  static RC<TokenSyntax> makeRightParenToken(const Trivia &LeadingTrivia,
-                                            const Trivia &TrailingTrivia);
+  static TokenSyntax makeRightParenToken(const Trivia &LeadingTrivia,
+                                        const Trivia &TrailingTrivia);
 
   /// Make a left brace '{' token with the specified leading and
   /// trailing trivia.
-  static RC<TokenSyntax> makeLeftBraceToken(const Trivia &LeadingTrivia,
-                                            const Trivia &TrailingTrivia);
+  static TokenSyntax makeLeftBraceToken(const Trivia &LeadingTrivia,
+                                        const Trivia &TrailingTrivia);
 
   /// Make a right brace '}' token with the specified leading and
   /// trailing trivia.
-  static RC<TokenSyntax> makeRightBraceToken(const Trivia &LeadingTrivia,
-                                             const Trivia &TrailingTrivia);
+  static TokenSyntax makeRightBraceToken(const Trivia &LeadingTrivia,
+                                         const Trivia &TrailingTrivia);
 
 
   /// Make a left square bracket '[' token with the specified leading and
   /// trailing trivia.
-  static RC<TokenSyntax>
+  static TokenSyntax
   makeLeftSquareBracketToken(const Trivia &LeadingTrivia,
                              const Trivia &TrailingTrivia);
 
   /// Make a right square bracket ']' token with the specified leading and
   /// trailing trivia.
-  static RC<TokenSyntax>
+  static TokenSyntax
   makeRightSquareBracketToken(const Trivia &LeadingTrivia,
                               const Trivia &TrailingTrivia);
 
   /// Make a postfix question '?' token with the specified trailing trivia.
   /// The leading trivia is assumed to be of zero width.
-  static RC<TokenSyntax>
+  static TokenSyntax
   makeQuestionPostfixToken(const Trivia &TrailingTrivia);
 
   /// Make an exclamation '!' token with the specified trailing trivia.
   /// The leading trivia is assumed to be of zero width.
-  static RC<TokenSyntax> makeExclaimPostfixToken(const Trivia &TrailingTrivia);
+  static TokenSyntax makeExclaimPostfixToken(const Trivia &TrailingTrivia);
 
   /// Make an identifier token with the specified leading and trailing trivia.
-  static RC<TokenSyntax> makeIdentifier(OwnedString Name,
+  static TokenSyntax makeIdentifier(OwnedString Name,
                                         const Trivia &LeadingTrivia,
                                         const Trivia &TrailingTrivia);
 
   /// Make a comma ',' token with the specified leading and trailing trivia.
-  static RC<TokenSyntax> makeCommaToken(const Trivia &LeadingTrivia,
-                                        const Trivia &TrailingTrivia);
+  static TokenSyntax makeCommaToken(const Trivia &LeadingTrivia,
+                                    const Trivia &TrailingTrivia);
 
   /// Make a colon ':' token with the specified leading and trailing trivia.
-  static RC<TokenSyntax> makeColonToken(const Trivia &LeadingTrivia,
-                                        const Trivia &TrailingTrivia);
+  static TokenSyntax makeColonToken(const Trivia &LeadingTrivia,
+                                    const Trivia &TrailingTrivia);
 
   /// Make a dot '.' token with the specified leading and trailing trivia.
-  static RC<TokenSyntax> makeDotToken(const Trivia &LeadingTrivia,
-                                      const Trivia &TrailingTrivia);
+  static TokenSyntax makeDotToken(const Trivia &LeadingTrivia,
+                                  const Trivia &TrailingTrivia);
 
   /// Make a 'struct' keyword with the specified leading and trailing trivia.
-  static RC<TokenSyntax> makeStructKeyword(const Trivia &LeadingTrivia,
-                                           const Trivia &TrailingTrivia);
+  static TokenSyntax makeStructKeyword(const Trivia &LeadingTrivia,
+                                       const Trivia &TrailingTrivia);
 
   /// Make a 'where' keyword with the specified leading and trailing trivia.
-  static RC<TokenSyntax> makeWhereKeyword(const Trivia &LeadingTrivia,
-                                          const Trivia &TrailingTrivia);
+  static TokenSyntax makeWhereKeyword(const Trivia &LeadingTrivia,
+                                      const Trivia &TrailingTrivia);
 
   /// Make a 'inout' keyword with the specified leading and trailing trivia.
-  static RC<TokenSyntax> makeInoutKeyword(const Trivia &LeadingTrivia,
-                                          const Trivia &TrailingTrivia);
+  static TokenSyntax makeInoutKeyword(const Trivia &LeadingTrivia,
+                                      const Trivia &TrailingTrivia);
 
   /// Make a 'throws' keyword with the specified leading and trailing trivia.
-  static RC<TokenSyntax> makeThrowsKeyword(const Trivia &LeadingTrivia,
-                                           const Trivia &TrailingTrivia);
+  static TokenSyntax makeThrowsKeyword(const Trivia &LeadingTrivia,
+                                       const Trivia &TrailingTrivia);
 
   /// Make a 'rethrows' keyword with the specified leading and
   /// trailing trivia.
-  static RC<TokenSyntax> makeRethrowsKeyword(const Trivia &LeadingTrivia,
-                                             const Trivia &TrailingTrivia);
+  static TokenSyntax makeRethrowsKeyword(const Trivia &LeadingTrivia,
+                                         const Trivia &TrailingTrivia);
 
   /// Make a 'typealias' keyword with the specified leading and
   /// trailing trivia.
-  static RC<TokenSyntax> makeTypealiasKeyword(const Trivia &LeadingTrivia,
-                                              const Trivia &TrailingTrivia);
+  static TokenSyntax makeTypealiasKeyword(const Trivia &LeadingTrivia,
+                                          const Trivia &TrailingTrivia);
 
   /// Make an equal '=' token with the specified leading and
   /// trailing trivia.
-  static RC<TokenSyntax> makeEqualToken(const Trivia &LeadingTrivia,
-                                        const Trivia &TrailingTrivia);
+  static TokenSyntax makeEqualToken(const Trivia &LeadingTrivia,
+                                    const Trivia &TrailingTrivia);
 
   /// Make an arrow '->' token with the specified leading and trailing trivia.
-  static RC<TokenSyntax> makeArrow(const Trivia &LeadingTrivia,
-                                   const Trivia &TrailingTrivia);
+  static TokenSyntax makeArrow(const Trivia &LeadingTrivia,
+                               const Trivia &TrailingTrivia);
 
   /// Make an equality '==' binary operator with the specified leading and
   /// trailing trivia.
-  static RC<TokenSyntax> makeEqualityOperator(const Trivia &LeadingTrivia,
-                                           const Trivia &TrailingTrivia);
+  static TokenSyntax makeEqualityOperator(const Trivia &LeadingTrivia,
+                                          const Trivia &TrailingTrivia);
 
   /// Make the terminal identifier token `Type`
-  static RC<TokenSyntax> makeTypeToken(const Trivia &LeadingTrivia,
-                                       const Trivia &TrailingTrivia);
+  static TokenSyntax makeTypeToken(const Trivia &LeadingTrivia,
+                                   const Trivia &TrailingTrivia);
 
   /// Make the terminal identifier token `Protocol`
-  static RC<TokenSyntax> makeProtocolToken(const Trivia &LeadingTrivia,
-                                           const Trivia &TrailingTrivia);
+  static TokenSyntax makeProtocolToken(const Trivia &LeadingTrivia,
+                                       const Trivia &TrailingTrivia);
 
   /// Make a token representing the digits of an integer literal.
   ///
   /// Note: This is not a stand-in for the expression, which can contain
   /// a minus sign.
-  static RC<TokenSyntax> makeIntegerLiteralToken(OwnedString Digits,
-                                                 const Trivia &LeadingTrivia,
-                                                 const Trivia &TrailingTrivia);
+  static TokenSyntax makeIntegerLiteralToken(OwnedString Digits,
+                                             const Trivia &LeadingTrivia,
+                                             const Trivia &TrailingTrivia);
 
 #pragma mark - Operators
 
   /// Make a prefix operator with the given text.
-  static RC<TokenSyntax> makePrefixOperator(OwnedString Name,
-                                             const Trivia &LeadingTrivia);
+  static TokenSyntax makePrefixOperator(OwnedString Name,
+                                        const Trivia &LeadingTrivia);
 
 #pragma mark - Types
 
@@ -428,11 +433,11 @@ struct SyntaxFactory {
 
   /// Make a type attribute with the specified elements.
   static TypeAttributeSyntax
-  makeTypeAttribute(RC<TokenSyntax> AtSignToken,
-                    RC<TokenSyntax> Identifier,
-                    RC<TokenSyntax> LeftParen,
+  makeTypeAttribute(TokenSyntax AtSignToken,
+                    TokenSyntax Identifier,
+                    TokenSyntax LeftParen,
                     BalancedTokensSyntax BalancedTokens,
-                    RC<TokenSyntax> RightParen);
+                    TokenSyntax RightParen);
 
   /// Make a type attribute with all elements marked as missing.
   static TypeAttributeSyntax makeBlankTypeAttribute();
@@ -446,7 +451,7 @@ struct SyntaxFactory {
 
   /// Make a list of balanced tokens.
   static BalancedTokensSyntax
-  makeBalancedTokens(RawSyntax::LayoutList Tokens);
+  makeBalancedTokens(llvm::ArrayRef<TokenSyntax> Tokens);
 
   /// Make an empty list of balanced tokens.
   static BalancedTokensSyntax makeBlankBalancedTokens();
@@ -460,7 +465,7 @@ struct SyntaxFactory {
 
   /// Make a generic type identifier.
   static TypeIdentifierSyntax
-  makeTypeIdentifier(RC<TokenSyntax> Identifier,
+  makeTypeIdentifier(TokenSyntax Identifier,
                      GenericArgumentClauseSyntax GenericArgs);
 
   /// Make a bare "Any" type.
@@ -477,20 +482,20 @@ struct SyntaxFactory {
   /// Make a tuple type from a type element list and the provided left/right
   /// paren tokens.
   static TupleTypeSyntax
-  makeTupleType(RC<TokenSyntax> LParen,
+  makeTupleType(TokenSyntax LParen,
                 TupleTypeElementListSyntax Elements,
-                RC<TokenSyntax> RParen);
+                TokenSyntax RParen);
 
   /// Make a tuple type element of the form 'Name: ElementType'
   static TupleTypeElementSyntax
-  makeTupleTypeElement(RC<TokenSyntax> Name, RC<TokenSyntax> Colon,
+  makeTupleTypeElement(TokenSyntax Name, TokenSyntax Colon,
                        TypeSyntax ElementType,
-                       llvm::Optional<RC<TokenSyntax>> MaybeComma = llvm::None);
+                       llvm::Optional<TokenSyntax> MaybeComma = llvm::None);
 
   /// Make a tuple type element without a label.
   static TupleTypeElementSyntax
   makeTupleTypeElement(TypeSyntax ElementType,
-                       llvm::Optional<RC<TokenSyntax>> MaybeComma = llvm::None);
+                       llvm::Optional<TokenSyntax> MaybeComma = llvm::None);
 
   /// Make a tuple type element list.
   static TupleTypeElementListSyntax
@@ -520,8 +525,8 @@ struct SyntaxFactory {
   /// Make a metatype type, as in `T.Type`
   /// `Type` is a terminal token here, not a placeholder for something else.
   static MetatypeTypeSyntax makeMetatypeType(TypeSyntax BaseType,
-                                             RC<TokenSyntax> DotToken,
-                                             RC<TokenSyntax> TypeToken);
+                                             TokenSyntax DotToken,
+                                             TokenSyntax TypeToken);
 
   /// Make a metatype type with all elements marked as missing.
   static MetatypeTypeSyntax makeBlankMetatypeType();
@@ -529,9 +534,9 @@ struct SyntaxFactory {
 #pragma mark - array-type
 
   /// Make a sugared Array type, as in `[MyType]`.
-  static ArrayTypeSyntax makeArrayType(RC<TokenSyntax> LeftSquareBracket,
+  static ArrayTypeSyntax makeArrayType(TokenSyntax LeftSquareBracket,
                                        TypeSyntax ElementType,
-                                       RC<TokenSyntax> RightSquareBracket);
+                                       TokenSyntax RightSquareBracket);
 
   /// Make an array type with all elements marked as missing.
   static ArrayTypeSyntax makeBlankArrayType();
@@ -540,9 +545,9 @@ struct SyntaxFactory {
 
   /// Make a Dictionary type, as in `[Key : Value]`.
   static DictionaryTypeSyntax
-  makeDictionaryType(RC<TokenSyntax> LeftSquareBracket, TypeSyntax KeyType,
-                     RC<TokenSyntax> Colon, TypeSyntax ValueType,
-                     RC<TokenSyntax> RightSquareBracket);
+  makeDictionaryType(TokenSyntax LeftSquareBracket, TypeSyntax KeyType,
+                     TokenSyntax Colon, TypeSyntax ValueType,
+                     TokenSyntax RightSquareBracket);
 
   /// Make an a dictionary type with all elements marked as missing.
   static DictionaryTypeSyntax makeBlankDictionaryType();
@@ -551,18 +556,18 @@ struct SyntaxFactory {
 
   /// Make a function argument type syntax with the specified elements.
   static FunctionTypeArgumentSyntax
-  makeFunctionTypeArgument(RC<TokenSyntax> ExternalParameterName,
-                           RC<TokenSyntax> LocalParameterName,
+  makeFunctionTypeArgument(TokenSyntax ExternalParameterName,
+                           TokenSyntax LocalParameterName,
                            TypeAttributesSyntax TypeAttributes,
-                           RC<TokenSyntax> InoutKeyword,
-                           RC<TokenSyntax> ColonToken,
+                           TokenSyntax InoutKeyword,
+                           TokenSyntax ColonToken,
                            TypeSyntax ParameterTypeSyntax);
 
   /// Make a simple function type argument syntax with the given label and
   /// simple type name.
   static FunctionTypeArgumentSyntax
-  makeFunctionTypeArgument(RC<TokenSyntax> LocalParameterName,
-                           RC<TokenSyntax> ColonToken,
+  makeFunctionTypeArgument(TokenSyntax LocalParameterName,
+                           TokenSyntax ColonToken,
                            TypeSyntax ParameterType);
 
   /// Make a simple function type argument syntax with the given simple
@@ -578,10 +583,10 @@ struct SyntaxFactory {
   /// Make a function type, for example, `(Int, Int) throws -> Int`
   static FunctionTypeSyntax
   makeFunctionType(TypeAttributesSyntax TypeAttributes,
-                   RC<TokenSyntax> LeftParen,
+                   TokenSyntax LeftParen,
                    FunctionParameterListSyntax ArgumentList,
-                   RC<TokenSyntax> RightParen, RC<TokenSyntax> ThrowsOrRethrows,
-                   RC<TokenSyntax> Arrow, TypeSyntax ReturnType);
+                   TokenSyntax RightParen, TokenSyntax ThrowsOrRethrows,
+                   TokenSyntax Arrow, TypeSyntax ReturnType);
 
   /// Make a function type with all elements marked as missing.
   static FunctionTypeSyntax makeBlankFunctionType();
@@ -608,7 +613,7 @@ struct SyntaxFactory {
   /// Any elements are allowed to be marked as missing.
   static SameTypeRequirementSyntax
   makeSameTypeRequirement(TypeIdentifierSyntax LeftTypeIdentifier,
-                          RC<TokenSyntax> EqualityToken, TypeSyntax RightType);
+                          TokenSyntax EqualityToken, TypeSyntax RightType);
 
   /// Make a list of generic requirements with the given loosely collected
   /// requirements/

--- a/include/swift/Syntax/TokenSyntax.h
+++ b/include/swift/Syntax/TokenSyntax.h
@@ -1,4 +1,4 @@
-//===--- TokenSyntax.h - Swift Token Interface ------------------*- C++ -*-===//
+//===----------- TokenSyntax.h - Swift Token Interface ----------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -10,191 +10,88 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// This file contains the interface for a `TokenSyntax`, which is a token that
-// includes full-fidelity leading and trailing trivia.
-//
-// A TokenSyntax is an instance of `RawSyntax`, meaning it is immutable,
-// reference counted, and able to be shared.
+// This file contains the interface for a `TokenSyntax`, which is a token
+// that includes full-fidelity leading and trailing trivia.
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef SWIFT_SYNTAX_TokenSyntax_H
-#define SWIFT_SYNTAX_TokenSyntax_H
+#ifndef SWIFT_SYNTAX_TOKENSYNTAX_H
+#define SWIFT_SYNTAX_TOKENSYNTAX_H
 
-#include "swift/Syntax/RawSyntax.h"
+#include "swift/Syntax/RawTokenSyntax.h"
 #include "swift/Syntax/References.h"
+#include "swift/Syntax/Syntax.h"
 #include "swift/Syntax/TokenKinds.h"
 #include "swift/Syntax/Trivia.h"
 
 namespace swift {
 namespace syntax {
 
-class AbsolutePosition;
-
-struct TokenSyntax final : public RawSyntax {
-  friend struct SyntaxFactory;
-  const tok TokenKind;
-  const OwnedString Text;
-  const Trivia LeadingTrivia;
-  const Trivia TrailingTrivia;
-
-private:
-  TokenSyntax();
-
-  TokenSyntax(tok TokenKind, OwnedString Text, const SourcePresence Presence);
-
-  TokenSyntax(tok TokenKind, OwnedString Text, const SourcePresence Presence,
-            const Trivia &LeadingTrivia, const Trivia &TrailingTrivia);
-
+class TokenSyntax final : public Syntax {
+protected:
+  virtual void validate() const override {
+    assert(getRaw()->isToken());
+  }
 public:
-  /// Make a new token.
-  static RC<TokenSyntax> make(tok TokenKind, OwnedString Text,
-                           const SourcePresence Presence,
-                           const Trivia &LeadingTrivia,
-                           const Trivia &TrailingTrivia) {
-    return RC<TokenSyntax> {
-      new TokenSyntax {
-        TokenKind, Text, Presence,
-        LeadingTrivia, TrailingTrivia
-      }
-    };
+  TokenSyntax(const RC<SyntaxData> Root, const SyntaxData *Data)
+    : Syntax(Root, Data) {}
+
+  RC<RawTokenSyntax> getRawToken() const {
+    return cast<RawTokenSyntax>(getRaw());
   }
 
-  /// Return a token with the specified kind and text, but marked as missing.
-  static RC<TokenSyntax> missingToken(const tok Kind, OwnedString Text) {
-    return make(Kind, Text, SourcePresence::Missing, {}, {});
+  static TokenSyntax missingToken(const tok Kind, OwnedString Text) {
+    return make<TokenSyntax>(RawTokenSyntax::missingToken(Kind, Text));
   }
 
-  /// Return a new token like this one, but with the given leading
-  /// trivia instead.
-  RC<TokenSyntax> withLeadingTrivia(const Trivia &NewLeadingTrivia) const {
-    return make(TokenKind, Text, Presence, NewLeadingTrivia, TrailingTrivia);
+  const Trivia &getLeadingTrivia() const {
+    return getRawToken()->LeadingTrivia;
   }
 
-  /// Return a new token like this one, but with the given trailing
-  /// trivia instead.
-  RC<TokenSyntax> withTrailingTrivia(const Trivia &NewTrailingTrivia) const {
-    return make(TokenKind, Text, Presence, LeadingTrivia, NewTrailingTrivia);
+  const Trivia &getTrailingTrivia() const {
+    return getRawToken()->TrailingTrivia;
   }
 
-  /// Returns true if the token is of the expected kind and has the given
-  /// expected text.
-  bool is(tok ExpectedKind, StringRef ExpectedText) const {
-    return getTokenKind() == ExpectedKind && ExpectedText == getText();
+  TokenSyntax withLeadingTrivia(const Trivia &Trivia) const {
+    auto NewRaw = getRawToken()->withLeadingTrivia(Trivia);
+    return Data->replaceSelf<TokenSyntax>(NewRaw);
   }
 
-  /// Returns the kind of token this is.
-  tok getTokenKind() const { return TokenKind; }
+  TokenSyntax withTrailingTrivia(const Trivia &Trivia) const {
+    auto NewRaw = getRawToken()->withTrailingTrivia(Trivia);
+    return Data->replaceSelf<TokenSyntax>(NewRaw);
+  }
 
-  /// Returns a reference to the text of this token.
-  StringRef getText() const { return Text.str(); }
-
-  /// True if the token is any keyword.
   bool isKeyword() const {
-    switch (TokenKind) {
-#define KEYWORD(X) case tok::kw_##X: return true;
-#include "swift/Syntax/TokenKinds.def"
-      default: return false;
-    }
+    return getRawToken()->isKeyword();
   }
 
-  /// Returns true if the token is any literal.
-  bool isLiteral() const {
-    switch(TokenKind) {
-      case tok::integer_literal:
-      case tok::floating_literal:
-      case tok::string_literal:
-      case tok::pound_fileLiteral:
-      case tok::pound_colorLiteral:
-      case tok::pound_imageLiteral:
-        return true;
-      default:
-        return false;
-    }
+  bool isMissing() const {
+    return getRawToken()->isMissing();
   }
-
-  /// Returns true if this token is of the specified kind.
-  bool is(tok K) const { return TokenKind == K; }
-
-  /// Returns true if this token is not of the specified kind.
-  bool isNot(tok K) const { return TokenKind != K; }
-
-  /// Base case for variadic `isAny`
-  bool isAny(tok K1) const {
-    return is(K1);
-  }
-
-  /// Returns true if this token is any of the provided kinds.
-  template <typename ...T>
-  bool isAny(tok K1, tok K2, T... K) const {
-    if (is(K1))
-      return true;
-    return isAny(K2, K...);
-  }
-
-  /// Returns true if this token is not any of the provided kinds.
-  template <typename ...T>
-  bool isNot(tok K1, T... K) const { return !isAny(K1, K...); }
 
   bool isPunctuation() const {
-    switch (TokenKind) {
-#define PUNCTUATOR(Name, Str) case tok::Name: return true;
-#include "swift/Syntax/TokenKinds.def"
-      default: return false;
-    }
+    return getRawToken()->isPunctuation();
   }
 
-  /// Returns true if this token is a binary operator.
-  bool isBinaryOperator() const {
-    return TokenKind == tok::oper_binary_spaced ||
-           TokenKind == tok::oper_binary_unspaced;
-  }
-
-  /// Returns true if this token is any kind of operator.
   bool isOperator() const {
-    return isBinaryOperator() ||
-    TokenKind == tok::oper_postfix ||
-    TokenKind == tok::oper_prefix;
+    return getRawToken()->isOperator();
   }
 
-  /// Returns true if this token is not an operator.
-  bool isNotOperator() const {
-    return !isOperator();
+  bool isLiteral() const {
+    return getRawToken()->isLiteral();
   }
 
-  /// Print the leading trivia, text, and trailing trivia of this token to
-  /// the provided output stream.
-  void print(llvm::raw_ostream &OS, unsigned Indent = 0) const {
-    for (const auto &Leader : LeadingTrivia) {
-      Leader.print(OS);
-    }
-
-    if (!isMissing()) {
-      OS << getText();
-    }
-
-    for (const auto &Trailer : TrailingTrivia) {
-      Trailer.print(OS);
-    }
+  tok getTokenKind() const {
+    return getRawToken()->getTokenKind();
   }
 
-  /// Advance the provided AbsolutePosition by the token's full width and
-  /// return the AbsolutePosition of the start of the token's nontrivial text.
-  AbsolutePosition accumulateAbsolutePosition(AbsolutePosition &Pos) const;
-
-  /// Dump the textual representation of this token's kind.
-  void dumpKind(llvm::raw_ostream &OS) const;
-
-  /// Dump the layout of this token: its leading trivia, kind, text, and
-  /// trailing trivia.
-  void dump(llvm::raw_ostream &OS, unsigned Indent = 0) const;
-
-  static bool classof(const RawSyntax *RS) {
-    return RS->Kind == SyntaxKind::Token;
+  StringRef getText() const {
+    return getRawToken()->getText();
   }
 };
 
 } // end namespace syntax
 } // end namespace swift
 
-#endif // SWIFT_SYNTAX_TokenSyntax_H
+#endif // SWIFT_SYNTAX_TOKENSYNTAX_H

--- a/include/swift/Syntax/TypeSyntax.h
+++ b/include/swift/Syntax/TypeSyntax.h
@@ -47,7 +47,7 @@ public:
   // TODO: TODO: BalancedTokensSyntax::getBalancedToken
 
   BalancedTokensSyntax
-  addBalancedToken(RC<TokenSyntax> NewBalancedToken) const;
+  addBalancedToken(TokenSyntax NewBalancedToken) const;
 
   static bool classof(const Syntax *S) {
     return S->getKind() == SyntaxKind::BalancedTokens;
@@ -77,23 +77,23 @@ public:
     : Syntax(Root, Data) {}
 
   /// Return the '@' token associated with the type attribute.
-  RC<TokenSyntax> getAtSignToken() const;
+  TokenSyntax getAtSignToken() const;
 
   /// Return a new TypeAttributeSyntax with the given '@' token.
-  TypeAttributeSyntax withAtSignToken(RC<TokenSyntax> NewAtSignToken) const;
+  TypeAttributeSyntax withAtSignToken(TokenSyntax NewAtSignToken) const;
 
   /// Return the name of the type attribute.
-  RC<TokenSyntax> getIdentifier() const;
+  TokenSyntax getIdentifier() const;
 
   /// Return a new TypeAttributeSyntax with the given name.
-  TypeAttributeSyntax withIdentifier(RC<TokenSyntax> NewIdentifier) const;
+  TypeAttributeSyntax withIdentifier(TokenSyntax NewIdentifier) const;
 
   /// Return the left parenthesis '(' token attached to the type attribute.
-  RC<TokenSyntax> getLeftParenToken() const;
+  TokenSyntax getLeftParenToken() const;
 
   /// Return a TypeAttributeSyntax with the given left parenthesis '(' token.
   TypeAttributeSyntax
-  withLeftParenToken(RC<TokenSyntax> NewLeftParenToken) const;
+  withLeftParenToken(TokenSyntax NewLeftParenToken) const;
 
   /// Return the "balanced tokens" of the type attributes; the arguments.
   BalancedTokensSyntax getBalancedTokens() const;
@@ -104,11 +104,11 @@ public:
   withBalancedTokens(BalancedTokensSyntax NewBalancedTokens) const;
 
   /// Return the right parenthesis ')' token attached to the type attribute.
-  RC<TokenSyntax> getRightParenToken() const;
+  TokenSyntax getRightParenToken() const;
 
   /// Return a TypeAttributeSyntax with the given right parenthesis ')' token.
   TypeAttributeSyntax
-  withRightParenToken(RC<TokenSyntax> NewRightParenToken) const;
+  withRightParenToken(TokenSyntax NewRightParenToken) const;
 
   static bool classof(const Syntax *S) {
     return S->getKind() == SyntaxKind::TypeAttribute;
@@ -165,17 +165,17 @@ public:
   TypeIdentifierSyntax(const RC<SyntaxData> Root, const SyntaxData *Data)
     : TypeSyntax(Root, Data) {}
 
-  RC<TokenSyntax> getIdentifier() const;
+  TokenSyntax getIdentifier() const;
 
   TypeIdentifierSyntax
-  withIdentifier(RC<TokenSyntax> NewIdentifier) const;
+  withIdentifier(TokenSyntax NewIdentifier) const;
 
   GenericArgumentClauseSyntax getGenericArgumentClause() const;
   TypeIdentifierSyntax
   withGenericArgumentClause(GenericArgumentClauseSyntax NewGenericArgs) const;
 
-  RC<TokenSyntax> getDotToken() const;
-  TypeIdentifierSyntax withDotToken(RC<TokenSyntax> NewIdentifier) const;
+  TokenSyntax getDotToken() const;
+  TypeIdentifierSyntax withDotToken(TokenSyntax NewIdentifier) const;
 
   TypeIdentifierSyntax getChildType() const;
   TypeIdentifierSyntax addChildType(TypeIdentifierSyntax ChildType) const;
@@ -211,26 +211,26 @@ public:
     : Syntax(Root, Data) {}
   
   /// Return the label of the tuple type element.
-  RC<TokenSyntax> getLabel() const;
+  TokenSyntax getLabel() const;
 
   /// Return a new named tuple type element with the specified identifier.
-  TupleTypeElementSyntax withLabel(RC<TokenSyntax> NewIdentifier) const;
+  TupleTypeElementSyntax withLabel(TokenSyntax NewIdentifier) const;
 
   /// Return the colon token of the tuple type element.
-  RC<TokenSyntax> getColonToken() const;
+  TokenSyntax getColonToken() const;
 
   /// Return a new named tuple type element with a colon token replacement
   /// using the specified leading and trailing trivia.
   TupleTypeElementSyntax
-  withColonToken(RC<TokenSyntax> NewColonToken) const;
+  withColonToken(TokenSyntax NewColonToken) const;
 
   /// Return the comma token of the tuple type element.
-  RC<TokenSyntax> getCommaToken() const;
+  TokenSyntax getCommaToken() const;
 
   /// Return a new named tuple type element with a comma token replacement
   /// using the specified leading and trailing trivia.
   TupleTypeElementSyntax
-  withCommaToken(RC<TokenSyntax> NewCommaToken) const;
+  withCommaToken(TokenSyntax NewCommaToken) const;
 
   /// Return the type attributes for the tuple type element.
   TypeAttributesSyntax getTypeAttributes() const;
@@ -240,10 +240,10 @@ public:
   withTypeAttributes(TypeAttributesSyntax NewTypeAttributes) const;
 
   /// Return the 'inout' token of the tuple type element.
-  RC<TokenSyntax> getInoutToken() const;
+  TokenSyntax getInoutToken() const;
 
   /// Return a new named tuple type element with the 'inout' keyword added.
-  TupleTypeElementSyntax withInoutToken(RC<TokenSyntax> NewInoutToken) const;
+  TupleTypeElementSyntax withInoutToken(TokenSyntax NewInoutToken) const;
 
   TypeSyntax getTypeSyntax() const;
 
@@ -276,8 +276,8 @@ public:
     : TypeSyntax(Root, Data) {}
 
   /// Return the left paren '(' token surrounding the tuple type syntax.
-  RC<TokenSyntax> getLeftParen() const;
-  TupleTypeSyntax withLeftParen(RC<TokenSyntax> NewLeftParen) const;
+  TokenSyntax getLeftParen() const;
+  TupleTypeSyntax withLeftParen(TokenSyntax NewLeftParen) const;
 
   /// Get the type argument list inside the tuple type syntax.
   TupleTypeElementListSyntax getTypeElementList() const;
@@ -287,8 +287,8 @@ public:
   withTypeElementList(TupleTypeElementListSyntax NewTypeElementList) const;
 
   /// Return the right paren ')' token surrounding the tuple type syntax.
-  RC<TokenSyntax> getRightParen() const;
-  TupleTypeSyntax withRightParen(RC<TokenSyntax> NewRightParen) const;
+  TokenSyntax getRightParen() const;
+  TupleTypeSyntax withRightParen(TokenSyntax NewRightParen) const;
 
   static bool classof(const Syntax *S) {
     return S->getKind() == SyntaxKind::TupleType;
@@ -307,14 +307,14 @@ public:
   TupleTypeSyntaxBuilder();
 
   /// Use the given left paren '(' token when building the tuple type syntax.
-  TupleTypeSyntaxBuilder &useLeftParen(RC<TokenSyntax> LeftParen);
+  TupleTypeSyntaxBuilder &useLeftParen(TokenSyntax LeftParen);
 
   /// Add an element type to the eventual tuple type syntax.
   TupleTypeSyntaxBuilder &
   addElementTypeSyntax(TupleTypeElementSyntax ElementTypeSyntax);
 
   /// Use the given left paren '(' token when building the tuple type syntax.
-  TupleTypeSyntaxBuilder &useRightParen(RC<TokenSyntax> RightParen);
+  TupleTypeSyntaxBuilder &useRightParen(TokenSyntax RightParen);
 
   /// Build a TupleTypeSyntax from the elements seen so far.
   ///
@@ -348,17 +348,17 @@ public:
   MetatypeTypeSyntax withBaseTypeSyntax(TypeSyntax NewBaseType) const;
 
   /// Return the dot token.
-  RC<TokenSyntax> getDotToken() const;
+  TokenSyntax getDotToken() const;
 
   /// Return a new metatype type with the given dot token.
-  MetatypeTypeSyntax withDotToken(RC<TokenSyntax> NewDotToken) const;
+  MetatypeTypeSyntax withDotToken(TokenSyntax NewDotToken) const;
 
   /// Return the child type - either the identifiers `Type` or `Protocol`.
-  RC<TokenSyntax> getTypeToken() const;
+  TokenSyntax getTypeToken() const;
 
   /// Return a new metatype type with the given child type - either the
   /// identifiers: `Type` or `Protocol`.
-  MetatypeTypeSyntax withTypeToken(RC<TokenSyntax> NewTypeToken) const;
+  MetatypeTypeSyntax withTypeToken(TokenSyntax NewTypeToken) const;
 
   static bool classof(const Syntax *S) {
     return S->getKind() == SyntaxKind::MetatypeType;
@@ -389,11 +389,11 @@ public:
   OptionalTypeSyntax withBaseTypeSyntax(TypeSyntax NewBaseType) const;
 
   /// Return the question-mark '?' token attached to this optional type syntax.
-  RC<TokenSyntax> getQuestionToken() const;
+  TokenSyntax getQuestionToken() const;
 
   /// Return a new optional type with the given question-mark token.
   OptionalTypeSyntax
-  withQuestionToken(RC<TokenSyntax> NewQuestionToken) const;
+  withQuestionToken(TokenSyntax NewQuestionToken) const;
 
   static bool classof(const Syntax *S) {
     return S->getKind() == SyntaxKind::OptionalType;
@@ -427,12 +427,12 @@ public:
 
   /// Return the exclamation-mark '!' token attached to the end of this
   /// implicitly unwrapped optional type syntax.
-  RC<TokenSyntax> getExclaimToken() const;
+  TokenSyntax getExclaimToken() const;
 
   /// Return a new implicitly unwrapped optional type with the given
   /// exclamation-mark '!' token.
   ImplicitlyUnwrappedOptionalTypeSyntax
-  withExclaimToken(RC<TokenSyntax> NewExclaimToken) const;
+  withExclaimToken(TokenSyntax NewExclaimToken) const;
 
   static bool classof(const Syntax *S) {
     return S->getKind() == SyntaxKind::OptionalType;
@@ -460,22 +460,22 @@ public:
 
   /// Return the left square bracket '[' token surrounding the array
   /// type syntax.
-  RC<TokenSyntax> getLeftSquareBracketToken() const;
+  TokenSyntax getLeftSquareBracketToken() const;
 
   /// Return a new array type with the given left square bracket token.
   ArrayTypeSyntax
-  withLeftSquareBracketToken(RC<TokenSyntax> NewLeftSquareBracketToken) const;
+  withLeftSquareBracketToken(TokenSyntax NewLeftSquareBracketToken) const;
 
   /// Return a new array type with the given element type.
   ArrayTypeSyntax withType(TypeSyntax NewType) const;
 
   /// Return the right square bracket ']' token surrounding the array
   /// type syntax.
-  RC<TokenSyntax> getRightSquareBracketToken() const;
+  TokenSyntax getRightSquareBracketToken() const;
 
   /// Return a new array type with the given right square bracket token.
   ArrayTypeSyntax
-  withRightSquareBracketToken(RC<TokenSyntax> NewRightSquareBracketToken) const;
+  withRightSquareBracketToken(TokenSyntax NewRightSquareBracketToken) const;
 
   static bool classof(const Syntax *S) {
     return S->getKind() == SyntaxKind::ArrayType;
@@ -506,11 +506,11 @@ public:
 
   /// Return the left square bracket '[' token surrounding the dictionary
   /// type syntax.
-  RC<TokenSyntax> getLeftSquareBracketToken() const;
+  TokenSyntax getLeftSquareBracketToken() const;
 
   /// Return a new dictionary type with the given left square bracket token.
   DictionaryTypeSyntax
-  withLeftSquareBracketToken(RC<TokenSyntax> NewLeftSquareBracketToken) const;
+  withLeftSquareBracketToken(TokenSyntax NewLeftSquareBracketToken) const;
 
   /// Return the key type syntax for this dictionary type.
   TypeSyntax getKeyTypeSyntax() const;
@@ -519,10 +519,10 @@ public:
   DictionaryTypeSyntax withKeyTypeSyntax(TypeSyntax NewKeyType) const;
 
   /// Get the colon token in the dictionary type syntax.
-  RC<TokenSyntax> getColonToken() const;
+  TokenSyntax getColonToken() const;
 
   /// Return a new dictionary type with the given colon token.
-  DictionaryTypeSyntax withColon(RC<TokenSyntax> NewColonToken) const;
+  DictionaryTypeSyntax withColon(TokenSyntax NewColonToken) const;
 
   /// Return the value type syntax for this dictionary type.
   TypeSyntax getValueTypeSyntax() const;
@@ -532,11 +532,11 @@ public:
 
   /// Return the right square bracket ']' token surrounding the dictionary
   /// type syntax.
-  RC<TokenSyntax> getRightSquareBracketToken() const;
+  TokenSyntax getRightSquareBracketToken() const;
 
   /// Return a new dictionary type with the given right square bracket token.
   DictionaryTypeSyntax
-  withRightSquareBracketToken(RC<TokenSyntax> NewRightSquareBracketToken) const;
+  withRightSquareBracketToken(TokenSyntax NewRightSquareBracketToken) const;
 
   static bool classof(const Syntax *S) {
     return S->getKind() == SyntaxKind::DictionaryType;
@@ -602,17 +602,17 @@ public:
   withTypeAttributes(TypeAttributesSyntax NewAttributes) const;
 
   /// Return the left parenthesis '(' token surrounding the argument type.
-  RC<TokenSyntax> getLeftArgumentsParen() const;
+  TokenSyntax getLeftArgumentsParen() const;
 
   /// Return a new function type with the given left parenthesis on the type
   /// argument list.
   FunctionTypeSyntax
-  withLeftArgumentsParen(RC<TokenSyntax> NewLeftParen) const;
+  withLeftArgumentsParen(TokenSyntax NewLeftParen) const;
 
   /// Return a new function type with the additional argument type and
   /// optionally a preceding comma token.
   FunctionTypeSyntax
-  addTypeArgument(llvm::Optional<RC<TokenSyntax>> MaybeComma,
+  addTypeArgument(llvm::Optional<TokenSyntax> MaybeComma,
                   FunctionTypeArgumentSyntax NewArgument) const;
 
   /// Return the type arguments list for this function type syntax.
@@ -625,32 +625,32 @@ public:
   withTypeElementList(TupleTypeElementListSyntax NewArgumentList) const;
 
   /// Return the right parenthesis ')' token surrounding the argument type.
-  RC<TokenSyntax> getRightArgumentsParen() const;
+  TokenSyntax getRightArgumentsParen() const;
 
   /// Return a new function type with the given right parenthesis ')'
   /// on the type argument list.
   FunctionTypeSyntax
-  withRightArgumentsParen(RC<TokenSyntax> NewRightParen) const;
+  withRightArgumentsParen(TokenSyntax NewRightParen) const;
 
   /// Return the 'throws' or 'rethrows' keyword on the function type syntax.
-  RC<TokenSyntax> getThrowsOrRethrowsKeyword() const;
+  TokenSyntax getThrowsOrRethrowsKeyword() const;
 
   /// Return a new function type with the given `throws` keyword.
   ///
   /// This fills the same slot held by the `rethrows` keyword.
-  FunctionTypeSyntax withThrowsKeyword(RC<TokenSyntax> NewThrowsKeyword) const;
+  FunctionTypeSyntax withThrowsKeyword(TokenSyntax NewThrowsKeyword) const;
 
   /// Return a new function type with the given `rethrows` keyword.
   ///
   /// This fills the same slot held by the `throws` keyword.
   FunctionTypeSyntax
-  withRethrowsKeyword(RC<TokenSyntax> NewThrowsKeyword) const;
+  withRethrowsKeyword(TokenSyntax NewThrowsKeyword) const;
 
   /// Return the arrow token in the function type syntax.
-  RC<TokenSyntax> getArrow() const;
+  TokenSyntax getArrow() const;
 
   /// Return a new function type with the given arrow token.
-  FunctionTypeSyntax withArrow(RC<TokenSyntax> NewArrow) const;
+  FunctionTypeSyntax withArrow(TokenSyntax NewArrow) const;
 
   // Return the return type syntax for the function type.
   TypeSyntax getReturnTypeSyntax() const;
@@ -677,22 +677,22 @@ public:
   useTypeAttributes(TypeAttributeSyntax NewAttributes);
 
   /// Use the given left paren '(' token on the argument type syntax.
-  FunctionTypeSyntaxBuilder &useLeftArgumentsParen(RC<TokenSyntax> LeftParen);
+  FunctionTypeSyntaxBuilder &useLeftArgumentsParen(TokenSyntax LeftParen);
 
   FunctionTypeSyntaxBuilder &
-  addArgumentTypeSyntax(llvm::Optional<RC<TokenSyntax>> MaybeComma,
+  addArgumentTypeSyntax(llvm::Optional<TokenSyntax> MaybeComma,
                         FunctionTypeArgumentSyntax Argument);
 
   /// Use the given right paren ')' token on the argument type syntax.
-  FunctionTypeSyntaxBuilder &useRightArgumentsParen(RC<TokenSyntax> RightParen);
+  FunctionTypeSyntaxBuilder &useRightArgumentsParen(TokenSyntax RightParen);
 
   /// Use the given 'throws' keyword in the function type syntax.
-  FunctionTypeSyntaxBuilder &useThrowsKeyword(RC<TokenSyntax> ThrowsKeyword);
+  FunctionTypeSyntaxBuilder &useThrowsKeyword(TokenSyntax ThrowsKeyword);
 
   FunctionTypeSyntaxBuilder &
-  useRethrowsKeyword(RC<TokenSyntax> RethrowsKeyword);
+  useRethrowsKeyword(TokenSyntax RethrowsKeyword);
 
-  FunctionTypeSyntaxBuilder &useArrow(RC<TokenSyntax> Arrow);
+  FunctionTypeSyntaxBuilder &useArrow(TokenSyntax Arrow);
   FunctionTypeSyntaxBuilder &useReturnTypeSyntax(TypeSyntax ReturnType);
 
   FunctionTypeSyntax build() const;

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -737,12 +737,12 @@ static bool rangeContainsPlaceholderEnd(const char *CurPtr,
   return false;
 }
 
-RC<syntax::TokenSyntax> Lexer::fullLex() {
+RC<syntax::RawTokenSyntax> Lexer::fullLex() {
   if (NextToken.isEscapedIdentifier()) {
     LeadingTrivia.push_back(syntax::TriviaPiece::backtick());
     TrailingTrivia.push_front(syntax::TriviaPiece::backtick());
   }
-  auto Result = syntax::TokenSyntax::make(NextToken.getKind(),
+  auto Result = syntax::RawTokenSyntax::make(NextToken.getKind(),
                                         OwnedString(NextToken.getText()).copy(),
                                         syntax::SourcePresence::Present,
                                         {LeadingTrivia}, {TrailingTrivia});

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -282,7 +282,7 @@ std::vector<Token> swift::tokenize(const LangOptions &LangOpts,
 }
 
 // TODO: Refactor into common implementation with swift::tokenize.
-std::vector<std::pair<RC<syntax::TokenSyntax>,
+std::vector<std::pair<RC<syntax::RawTokenSyntax>,
                                  syntax::AbsolutePosition>>
 swift::tokenizeWithTrivia(const LangOptions &LangOpts,
                           const SourceManager &SM,
@@ -296,7 +296,7 @@ swift::tokenizeWithTrivia(const LangOptions &LangOpts,
           CommentRetentionMode::AttachToNextToken,
           TriviaRetentionMode::WithTrivia,
           Offset, EndOffset);
-  std::vector<std::pair<RC<syntax::TokenSyntax>,
+  std::vector<std::pair<RC<syntax::RawTokenSyntax>,
                         syntax::AbsolutePosition>> Tokens;
   syntax::AbsolutePosition RunningPos;
   do {

--- a/lib/Syntax/CMakeLists.txt
+++ b/lib/Syntax/CMakeLists.txt
@@ -2,7 +2,7 @@ add_swift_library(swiftSyntax STATIC
   DeclSyntax.cpp
   ExprSyntax.cpp
   Format.cpp
-  TokenSyntax.cpp
+  RawTokenSyntax.cpp
   GenericSyntax.cpp
   LegacyASTTransformer.cpp
   Trivia.cpp

--- a/lib/Syntax/DeclSyntax.cpp
+++ b/lib/Syntax/DeclSyntax.cpp
@@ -31,54 +31,55 @@ DeclModifierSyntax DeclModifierSyntax::makeBlank() {
   return make<DeclModifierSyntax>(
             RawSyntax::make(SyntaxKind::DeclModifier,
                             {
-                              TokenSyntax::missingToken(tok::identifier, ""),
-                              TokenSyntax::missingToken(tok::l_paren, "("),
-                              TokenSyntax::missingToken(tok::identifier, ""),
-                              TokenSyntax::missingToken(tok::r_paren, ")"),
+                              RawTokenSyntax::missingToken(tok::identifier, ""),
+                              RawTokenSyntax::missingToken(tok::l_paren, "("),
+                              RawTokenSyntax::missingToken(tok::identifier, ""),
+                              RawTokenSyntax::missingToken(tok::r_paren, ")"),
                             },
                             SourcePresence::Present));
 }
 
 #pragma mark - declaration-modifier API
 
-RC<TokenSyntax> DeclModifierSyntax::getName() const {
-  return cast<TokenSyntax>(getRaw()->getChild(Cursor::Name));
+TokenSyntax DeclModifierSyntax::getName() const {
+  return { Root, Data->getChild(Cursor::Name).get() };
 }
 
-DeclModifierSyntax DeclModifierSyntax::withName(RC<TokenSyntax> NewName) const {
-  assert(NewName->getTokenKind() == tok::identifier);
-  return Data->replaceChild<DeclModifierSyntax>(NewName, Cursor::Name);
+DeclModifierSyntax DeclModifierSyntax::withName(TokenSyntax NewName) const {
+  assert(NewName.getTokenKind() == tok::identifier);
+  return Data->replaceChild<DeclModifierSyntax>(NewName.getRaw(), Cursor::Name);
 }
 
-RC<TokenSyntax> DeclModifierSyntax::getLeftParenToken() const {
-  return cast<TokenSyntax>(getRaw()->getChild(Cursor::LeftParen));
+TokenSyntax DeclModifierSyntax::getLeftParenToken() const {
+  return { Root, Data->getChild(Cursor::LeftParen).get() };
 }
 
 DeclModifierSyntax
-DeclModifierSyntax::withLeftParenToken(RC<TokenSyntax> NewLeftParen) const {
+DeclModifierSyntax::withLeftParenToken(TokenSyntax NewLeftParen) const {
   syntax_assert_token_is(NewLeftParen, tok::l_paren, "(");
-  return Data->replaceChild<DeclModifierSyntax>(NewLeftParen,
+  return Data->replaceChild<DeclModifierSyntax>(NewLeftParen.getRaw(),
                                                 Cursor::LeftParen);
 }
 
-RC<TokenSyntax> DeclModifierSyntax::getArgument() const {
-  return cast<TokenSyntax>(getRaw()->getChild(Cursor::Argument));
+TokenSyntax DeclModifierSyntax::getArgument() const {
+  return { Root, Data->getChild(Cursor::Argument).get() };
 }
 
 DeclModifierSyntax
-DeclModifierSyntax::withArgument(RC<TokenSyntax> NewArgument) const {
-  assert(NewArgument->getTokenKind() == tok::identifier);
-  return Data->replaceChild<DeclModifierSyntax>(NewArgument, Cursor::Argument);
+DeclModifierSyntax::withArgument(TokenSyntax NewArgument) const {
+  assert(NewArgument.getTokenKind() == tok::identifier);
+  return Data->replaceChild<DeclModifierSyntax>(NewArgument.getRaw(),
+                                                Cursor::Argument);
 }
 
-RC<TokenSyntax> DeclModifierSyntax::getRightParenToken() const {
-  return cast<TokenSyntax>(getRaw()->getChild(Cursor::RightParen));
+TokenSyntax DeclModifierSyntax::getRightParenToken() const {
+  return { Root, Data->getChild(Cursor::RightParen).get() };
 }
 
 DeclModifierSyntax
-DeclModifierSyntax::withRightParenToken(RC<TokenSyntax> NewRightParen) const {
+DeclModifierSyntax::withRightParenToken(TokenSyntax NewRightParen) const {
   syntax_assert_token_is(NewRightParen, tok::r_paren, ")");
-  return Data->replaceChild<DeclModifierSyntax>(NewRightParen,
+  return Data->replaceChild<DeclModifierSyntax>(NewRightParen.getRaw(),
                                                 Cursor::RightParen);
 }
 
@@ -137,40 +138,40 @@ void StructDeclSyntax::validate() const {
 StructDeclSyntax StructDeclSyntax::makeBlank() {
   return make<StructDeclSyntax>(RawSyntax::make(SyntaxKind::StructDecl,
     {
-      TokenSyntax::missingToken(tok::kw_struct, "struct"),
-      TokenSyntax::missingToken(tok::identifier, ""),
+      RawTokenSyntax::missingToken(tok::kw_struct, "struct"),
+      RawTokenSyntax::missingToken(tok::identifier, ""),
       RawSyntax::missing(SyntaxKind::GenericParameterClause),
       RawSyntax::missing(SyntaxKind::GenericWhereClause),
-      TokenSyntax::missingToken(tok::l_brace, "{"),
+      RawTokenSyntax::missingToken(tok::l_brace, "{"),
       RawSyntax::missing(SyntaxKind::DeclMembers),
-      TokenSyntax::missingToken(tok::r_brace, "}"),
+      RawTokenSyntax::missingToken(tok::r_brace, "}"),
     },
     SourcePresence::Present));
 }
 
 #pragma mark - struct-declaration API
 
-RC<TokenSyntax> StructDeclSyntax::getStructKeyword() const {
-  return cast<TokenSyntax>(getRaw()->getChild(Cursor::StructKeyword));
+TokenSyntax StructDeclSyntax::getStructKeyword() const {
+  return { Root, Data->getChild(Cursor::StructKeyword).get() };
 }
 
 StructDeclSyntax
-StructDeclSyntax::withStructKeyword(RC<TokenSyntax> NewStructKeyword)
+StructDeclSyntax::withStructKeyword(TokenSyntax NewStructKeyword)
 const {
   syntax_assert_token_is(NewStructKeyword, tok::kw_struct, "struct");
-  return Data->replaceChild<StructDeclSyntax>(NewStructKeyword,
+  return Data->replaceChild<StructDeclSyntax>(NewStructKeyword.getRaw(),
                                               Cursor::StructKeyword);
 }
 
 StructDeclSyntax
-StructDeclSyntax::withLeftBrace(RC<TokenSyntax> NewLeftBrace) const {
+StructDeclSyntax::withLeftBrace(TokenSyntax NewLeftBrace) const {
   syntax_assert_token_is(NewLeftBrace, tok::l_brace, "{");
-  return Data->replaceChild<StructDeclSyntax>(NewLeftBrace,
+  return Data->replaceChild<StructDeclSyntax>(NewLeftBrace.getRaw(),
                                               Cursor::LeftBrace);
 }
 
-RC<TokenSyntax> StructDeclSyntax::getLeftBraceToken() const {
-  return cast<TokenSyntax>(getRaw()->getChild(Cursor::LeftBrace));
+TokenSyntax StructDeclSyntax::getLeftBraceToken() const {
+  return { Root, Data->getChild(Cursor::LeftBrace).get() };
 }
 
 StructDeclSyntax
@@ -189,26 +190,26 @@ StructDeclSyntaxBuilder::StructDeclSyntaxBuilder()
   : StructLayout(SyntaxFactory::makeBlankStructDecl().getRaw()->Layout) {}
 
 StructDeclSyntaxBuilder &
-StructDeclSyntaxBuilder::useStructKeyword(RC<TokenSyntax> StructKeyword) {
+StructDeclSyntaxBuilder::useStructKeyword(TokenSyntax StructKeyword) {
   syntax_assert_token_is(StructKeyword, tok::kw_struct, "struct");
   auto Index = cursorIndex(StructDeclSyntax::Cursor::StructKeyword);
-  StructLayout[Index] = StructKeyword;
+  StructLayout[Index] = StructKeyword.getRaw();
   return *this;
 }
 
 StructDeclSyntaxBuilder &
-StructDeclSyntaxBuilder::useIdentifier(RC<TokenSyntax> Identifier) {
-  assert(Identifier->getTokenKind() == tok::identifier);
+StructDeclSyntaxBuilder::useIdentifier(TokenSyntax Identifier) {
+  assert(Identifier.getTokenKind() == tok::identifier);
   auto Index = cursorIndex(StructDeclSyntax::Cursor::Identifier);
-  StructLayout[Index] = Identifier;
+  StructLayout[Index] = Identifier.getRaw();
   return *this;
 }
 
 StructDeclSyntaxBuilder &
-StructDeclSyntaxBuilder::useLeftBrace(RC<TokenSyntax> LeftBrace) {
+StructDeclSyntaxBuilder::useLeftBrace(TokenSyntax LeftBrace) {
   syntax_assert_token_is(LeftBrace, tok::l_brace, "{");
   auto Index = cursorIndex(StructDeclSyntax::Cursor::LeftBrace);
-  StructLayout[Index] = LeftBrace;
+  StructLayout[Index] = LeftBrace.getRaw();
   return *this;
 }
 
@@ -220,10 +221,10 @@ StructDeclSyntaxBuilder::useMembers(DeclMembersSyntax Members) {
 }
 
 StructDeclSyntaxBuilder &
-StructDeclSyntaxBuilder::useRightBrace(RC<TokenSyntax> RightBrace) {
+StructDeclSyntaxBuilder::useRightBrace(TokenSyntax RightBrace) {
   syntax_assert_token_is(RightBrace, tok::r_brace, "}");
   auto Index = cursorIndex(StructDeclSyntax::Cursor::RightBrace);
-  StructLayout[Index] = RightBrace;
+  StructLayout[Index] = RightBrace.getRaw();
   return *this;
 }
 
@@ -238,10 +239,10 @@ TypeAliasDeclSyntax
 TypeAliasDeclSyntax::makeBlank() {
   return make<TypeAliasDeclSyntax>(RawSyntax::make(SyntaxKind::TypeAliasDecl,
     {
-      TokenSyntax::missingToken(tok::kw_typealias, "typealias"),
-      TokenSyntax::missingToken(tok::identifier, ""),
+      RawTokenSyntax::missingToken(tok::kw_typealias, "typealias"),
+      RawTokenSyntax::missingToken(tok::identifier, ""),
       RawSyntax::missing(SyntaxKind::GenericParameterClause),
-      TokenSyntax::missingToken(tok::equal, "="),
+      RawTokenSyntax::missingToken(tok::equal, "="),
       RawSyntax::missing(SyntaxKind::MissingType),
     },
     SourcePresence::Present));
@@ -250,16 +251,16 @@ TypeAliasDeclSyntax::makeBlank() {
 #pragma mark - type-alias API
 
 TypeAliasDeclSyntax TypeAliasDeclSyntax::
-withTypeAliasKeyword(RC<TokenSyntax> NewTypeAliasKeyword) const {
+withTypeAliasKeyword(TokenSyntax NewTypeAliasKeyword) const {
   syntax_assert_token_is(NewTypeAliasKeyword, tok::kw_typealias, "typealias");
-  return Data->replaceChild<TypeAliasDeclSyntax>(NewTypeAliasKeyword,
+  return Data->replaceChild<TypeAliasDeclSyntax>(NewTypeAliasKeyword.getRaw(),
                                                  Cursor::TypeAliasKeyword);
 }
 
 TypeAliasDeclSyntax
-TypeAliasDeclSyntax::withIdentifier(RC<TokenSyntax> NewIdentifier) const {
-  assert(NewIdentifier->getTokenKind() == tok::identifier);
-  return Data->replaceChild<TypeAliasDeclSyntax>(NewIdentifier,
+TypeAliasDeclSyntax::withIdentifier(TokenSyntax NewIdentifier) const {
+  assert(NewIdentifier.getTokenKind() == tok::identifier);
+  return Data->replaceChild<TypeAliasDeclSyntax>(NewIdentifier.getRaw(),
                                                  Cursor::Identifier);
 }
 
@@ -271,9 +272,9 @@ const {
 }
 
 TypeAliasDeclSyntax
-TypeAliasDeclSyntax::withEqualToken(RC<TokenSyntax> NewEqualToken) const {
+TypeAliasDeclSyntax::withEqualToken(TokenSyntax NewEqualToken) const {
   syntax_assert_token_is(NewEqualToken, tok::equal, "=");
-  return Data->replaceChild<TypeAliasDeclSyntax>(NewEqualToken,
+  return Data->replaceChild<TypeAliasDeclSyntax>(NewEqualToken.getRaw(),
                                                  Cursor::EqualToken);
 }
 
@@ -290,18 +291,18 @@ TypeAliasDeclSyntaxBuilder::TypeAliasDeclSyntaxBuilder()
   {}
 
 TypeAliasDeclSyntaxBuilder &TypeAliasDeclSyntaxBuilder::
-useTypeAliasKeyword(RC<TokenSyntax> TypeAliasKeyword) {
+useTypeAliasKeyword(TokenSyntax TypeAliasKeyword) {
   syntax_assert_token_is(TypeAliasKeyword, tok::kw_typealias, "typealias");
   auto Index = cursorIndex(TypeAliasDeclSyntax::Cursor::TypeAliasKeyword);
-  TypeAliasLayout[Index] = TypeAliasKeyword;
+  TypeAliasLayout[Index] = TypeAliasKeyword.getRaw();
   return *this;
 }
 
 TypeAliasDeclSyntaxBuilder &
-TypeAliasDeclSyntaxBuilder::useIdentifier(RC<TokenSyntax> Identifier) {
-  assert(Identifier->getTokenKind() == tok::identifier);
+TypeAliasDeclSyntaxBuilder::useIdentifier(TokenSyntax Identifier) {
+  assert(Identifier.getTokenKind() == tok::identifier);
   auto Index = cursorIndex(TypeAliasDeclSyntax::Cursor::Identifier);
-  TypeAliasLayout[Index] = Identifier;
+  TypeAliasLayout[Index] = Identifier.getRaw();
   return *this;
 }
 
@@ -313,9 +314,9 @@ useGenericParameterClause(GenericParameterClauseSyntax GenericParams) {
 }
 
 TypeAliasDeclSyntaxBuilder &
-TypeAliasDeclSyntaxBuilder::useEqualToken(RC<TokenSyntax> EqualToken) {
+TypeAliasDeclSyntaxBuilder::useEqualToken(TokenSyntax EqualToken) {
   auto Index = cursorIndex(TypeAliasDeclSyntax::Cursor::EqualToken);
-  TypeAliasLayout[Index] = EqualToken;
+  TypeAliasLayout[Index] = EqualToken.getRaw();
   return *this;
 }
 
@@ -353,14 +354,14 @@ void FunctionParameterSyntax::validate() const {
 FunctionParameterSyntax FunctionParameterSyntax::makeBlank() {
   auto Raw = RawSyntax::make(SyntaxKind::FunctionParameter,
   {
-    TokenSyntax::missingToken(tok::identifier, ""),
-    TokenSyntax::missingToken(tok::identifier, ""),
-    TokenSyntax::missingToken(tok::colon, ":"),
+    RawTokenSyntax::missingToken(tok::identifier, ""),
+    RawTokenSyntax::missingToken(tok::identifier, ""),
+    RawTokenSyntax::missingToken(tok::colon, ":"),
     RawSyntax::missing(SyntaxKind::MissingType),
-    TokenSyntax::missingToken(tok::identifier, "..."),
-    TokenSyntax::missingToken(tok::equal, "="),
+    RawTokenSyntax::missingToken(tok::identifier, "..."),
+    RawTokenSyntax::missingToken(tok::equal, "="),
     RawSyntax::missing(SyntaxKind::MissingExpr),
-    TokenSyntax::missingToken(tok::comma, ","),
+    RawTokenSyntax::missingToken(tok::comma, ","),
   },
   SourcePresence::Present);
   return make<FunctionParameterSyntax>(Raw);
@@ -369,36 +370,36 @@ FunctionParameterSyntax FunctionParameterSyntax::makeBlank() {
 
 #pragma mark - function-parameter API
 
-RC<TokenSyntax> FunctionParameterSyntax::getExternalName() const {
-  return cast<TokenSyntax>(getRaw()->getChild(Cursor::ExternalName));
+TokenSyntax FunctionParameterSyntax::getExternalName() const {
+  return { Root, Data->getChild(Cursor::ExternalName).get() };
 }
 
 FunctionParameterSyntax FunctionParameterSyntax::
-withExternalName(RC<TokenSyntax> NewExternalName) const {
-  assert(NewExternalName->getTokenKind() == tok::identifier);
-  return Data->replaceChild<FunctionParameterSyntax>(NewExternalName,
+withExternalName(TokenSyntax NewExternalName) const {
+  assert(NewExternalName.getTokenKind() == tok::identifier);
+  return Data->replaceChild<FunctionParameterSyntax>(NewExternalName.getRaw(),
                                                      Cursor::ExternalName);
 }
 
-RC<TokenSyntax> FunctionParameterSyntax::getLocalName() const {
-  return cast<TokenSyntax>(getRaw()->getChild(Cursor::LocalName));
+TokenSyntax FunctionParameterSyntax::getLocalName() const {
+  return { Root, Data->getChild(Cursor::LocalName).get() };
 }
 
 FunctionParameterSyntax FunctionParameterSyntax::
-withLocalName(RC<TokenSyntax> NewLocalName) const {
-  assert(NewLocalName->getTokenKind() == tok::identifier);
-  return Data->replaceChild<FunctionParameterSyntax>(NewLocalName,
+withLocalName(TokenSyntax NewLocalName) const {
+  assert(NewLocalName.getTokenKind() == tok::identifier);
+  return Data->replaceChild<FunctionParameterSyntax>(NewLocalName.getRaw(),
                                                      Cursor::LocalName);
 }
 
-RC<TokenSyntax> FunctionParameterSyntax::getColonToken() const {
-  return cast<TokenSyntax>(getRaw()->getChild(Cursor::Colon));
+TokenSyntax FunctionParameterSyntax::getColonToken() const {
+  return { Root, Data->getChild(Cursor::Colon).get() };
 }
 
 FunctionParameterSyntax FunctionParameterSyntax::
-withColonToken(RC<TokenSyntax> NewColonToken) const {
+withColonToken(TokenSyntax NewColonToken) const {
   syntax_assert_token_is(NewColonToken, tok::colon, ":");
-  return Data->replaceChild<FunctionParameterSyntax>(NewColonToken,
+  return Data->replaceChild<FunctionParameterSyntax>(NewColonToken.getRaw(),
                                                      Cursor::Colon);
 }
 
@@ -422,14 +423,14 @@ withTypeSyntax(llvm::Optional<TypeSyntax> NewType) const {
     NewType.getValue().getRaw(), Cursor::Type);
 }
 
-RC<TokenSyntax> FunctionParameterSyntax::getEqualToken() const {
-  return cast<TokenSyntax>(getRaw()->getChild(Cursor::DefaultEqual));
+TokenSyntax FunctionParameterSyntax::getEqualToken() const {
+  return { Root, Data->getChild(Cursor::DefaultEqual).get() };
 }
 
 FunctionParameterSyntax FunctionParameterSyntax::
-withEqualToken(RC<TokenSyntax> NewEqualToken) const {
-  assert(NewEqualToken->getTokenKind() == tok::equal);
-  return Data->replaceChild<FunctionParameterSyntax>(NewEqualToken,
+withEqualToken(TokenSyntax NewEqualToken) const {
+  assert(NewEqualToken.getTokenKind() == tok::equal);
+  return Data->replaceChild<FunctionParameterSyntax>(NewEqualToken.getRaw(),
                                                      Cursor::DefaultEqual);
 }
 
@@ -454,14 +455,14 @@ withDefaultValue(llvm::Optional<ExprSyntax> NewDefaultValue) const {
     NewDefaultValue.getValue().getRaw(), Cursor::DefaultExpression);
 }
 
-RC<TokenSyntax> FunctionParameterSyntax::getTrailingComma() const {
-  return cast<TokenSyntax>(getRaw()->getChild(Cursor::TrailingComma));
+TokenSyntax FunctionParameterSyntax::getTrailingComma() const {
+  return { Root, Data->getChild(Cursor::TrailingComma).get() };
 }
 
 FunctionParameterSyntax FunctionParameterSyntax::
-withTrailingComma(RC<TokenSyntax> NewTrailingComma) const {
+withTrailingComma(TokenSyntax NewTrailingComma) const {
   syntax_assert_token_is(NewTrailingComma, tok::comma, ",");
-  return Data->replaceChild<FunctionParameterSyntax>(NewTrailingComma,
+  return Data->replaceChild<FunctionParameterSyntax>(NewTrailingComma.getRaw(),
                                                      Cursor::TrailingComma);
 }
 
@@ -481,10 +482,10 @@ void FunctionSignatureSyntax::validate() const {
                                  Cursor::RightParen,
                                  tok::r_paren, ")");
 #ifndef NDEBUG
-  auto ThrowsRethrows = cast<TokenSyntax>(
+  auto ThrowsRethrows = cast<RawTokenSyntax>(
     Raw->getChild(Cursor::ThrowsOrRethrows));
-  assert(cast<TokenSyntax>(ThrowsRethrows)->getTokenKind() == tok::kw_throws ||
-         cast<TokenSyntax>(ThrowsRethrows)->getTokenKind() == tok::kw_rethrows);
+  assert(ThrowsRethrows->getTokenKind() == tok::kw_throws ||
+         ThrowsRethrows->getTokenKind() == tok::kw_rethrows);
 #endif
   syntax_assert_child_token_text(Raw, Cursor::Arrow,
                                  tok::arrow, "->");
@@ -497,11 +498,11 @@ void FunctionSignatureSyntax::validate() const {
 FunctionSignatureSyntax FunctionSignatureSyntax::makeBlank() {
   auto Raw = RawSyntax::make(SyntaxKind::FunctionSignature,
   {
-    TokenSyntax::missingToken(tok::l_paren, "("),
+    RawTokenSyntax::missingToken(tok::l_paren, "("),
     RawSyntax::missing(SyntaxKind::FunctionParameterList),
-    TokenSyntax::missingToken(tok::r_paren, ")"),
-    TokenSyntax::missingToken(tok::kw_throws, "throws"),
-    TokenSyntax::missingToken(tok::arrow, "->"),
+    RawTokenSyntax::missingToken(tok::r_paren, ")"),
+    RawTokenSyntax::missingToken(tok::kw_throws, "throws"),
+    RawTokenSyntax::missingToken(tok::arrow, "->"),
     RawSyntax::missing(SyntaxKind::TypeAttributes),
     RawSyntax::missing(SyntaxKind::MissingType),
   },
@@ -511,14 +512,14 @@ FunctionSignatureSyntax FunctionSignatureSyntax::makeBlank() {
 
 #pragma mark - function-signature API
 
-RC<TokenSyntax> FunctionSignatureSyntax::getLeftParenToken() const {
-  return cast<TokenSyntax>(getRaw()->getChild(Cursor::LeftParen));
+TokenSyntax FunctionSignatureSyntax::getLeftParenToken() const {
+  return { Root, Data->getChild(Cursor::LeftParen).get() };
 }
 
 FunctionSignatureSyntax FunctionSignatureSyntax::
-withLeftParenToken(RC<TokenSyntax> NewLeftParen) const {
+withLeftParenToken(TokenSyntax NewLeftParen) const {
   syntax_assert_token_is(NewLeftParen, tok::l_paren, "(");
-  return Data->replaceChild<FunctionSignatureSyntax>(NewLeftParen,
+  return Data->replaceChild<FunctionSignatureSyntax>(NewLeftParen.getRaw(),
                                                      Cursor::LeftParen);
 }
 
@@ -535,56 +536,57 @@ withParameterList(FunctionParameterListSyntax NewParameterList) const {
                                                      Cursor::ParameterList);
 }
 
-RC<TokenSyntax> FunctionSignatureSyntax::getRightParenToken() const {
-  return cast<TokenSyntax>(getRaw()->getChild(Cursor::RightParen));
+TokenSyntax FunctionSignatureSyntax::getRightParenToken() const {
+  return { Root, Data->getChild(Cursor::RightParen).get() };
 }
 
 FunctionSignatureSyntax FunctionSignatureSyntax::
-withRightParenToken(RC<TokenSyntax> NewRightParen) const {
+withRightParenToken(TokenSyntax NewRightParen) const {
   syntax_assert_token_is(NewRightParen, tok::r_paren, ")");
-  return Data->replaceChild<FunctionSignatureSyntax>(NewRightParen,
+  return Data->replaceChild<FunctionSignatureSyntax>(NewRightParen.getRaw(),
                                                      Cursor::RightParen);
 }
 
-RC<TokenSyntax> FunctionSignatureSyntax::getThrowsToken() const {
-  auto Throw = cast<TokenSyntax>(getRaw()->getChild(Cursor::ThrowsOrRethrows));
-  if (Throw->getTokenKind() != tok::kw_throws) {
+TokenSyntax FunctionSignatureSyntax::getThrowsToken() const {
+  auto Throw = cast<RawTokenSyntax>(
+    getRaw()->getChild(Cursor::ThrowsOrRethrows));
+  if (Throw->isNot(tok::kw_throws)) {
     return TokenSyntax::missingToken(tok::kw_throws, "throws");
   }
-  return Throw;
+  return { Root, Data->getChild(Cursor::ThrowsOrRethrows).get() };
 }
 
 FunctionSignatureSyntax FunctionSignatureSyntax::
-withThrowsToken(RC<TokenSyntax> NewThrowsToken) const {
+withThrowsToken(TokenSyntax NewThrowsToken) const {
   syntax_assert_token_is(NewThrowsToken, tok::kw_throws, "throws");
-  return Data->replaceChild<FunctionSignatureSyntax>(NewThrowsToken,
+  return Data->replaceChild<FunctionSignatureSyntax>(NewThrowsToken.getRaw(),
                                                      Cursor::ThrowsOrRethrows);
 }
 
-RC<TokenSyntax> FunctionSignatureSyntax::getRethrowsToken() const {
-  auto Rethrow = cast<TokenSyntax>(
+TokenSyntax FunctionSignatureSyntax::getRethrowsToken() const {
+  auto Rethrow = cast<RawTokenSyntax>(
     getRaw()->getChild(Cursor::ThrowsOrRethrows));
-  if (Rethrow->getTokenKind() != tok::kw_rethrows) {
+  if (Rethrow->isNot(tok::kw_rethrows)) {
     return TokenSyntax::missingToken(tok::kw_rethrows, "rethrows");
   }
-  return Rethrow;
+  return { Root, Data->getChild(Cursor::ThrowsOrRethrows).get() };
 }
 
 FunctionSignatureSyntax FunctionSignatureSyntax::
-withRethrowsToken(RC<TokenSyntax> NewRethrowsToken) const {
+withRethrowsToken(TokenSyntax NewRethrowsToken) const {
   syntax_assert_token_is(NewRethrowsToken, tok::kw_rethrows, "rethrows");
-  return Data->replaceChild<FunctionSignatureSyntax>(NewRethrowsToken,
+  return Data->replaceChild<FunctionSignatureSyntax>(NewRethrowsToken.getRaw(),
                                                      Cursor::ThrowsOrRethrows);
 }
 
-RC<TokenSyntax> FunctionSignatureSyntax::getArrowToken() const {
-  return cast<TokenSyntax>(getRaw()->getChild(Cursor::Arrow));
+TokenSyntax FunctionSignatureSyntax::getArrowToken() const {
+  return { Root, Data->getChild(Cursor::Arrow).get() };
 }
 
 FunctionSignatureSyntax FunctionSignatureSyntax::
-withArrowToken(RC<TokenSyntax> NewArrowToken) const {
+withArrowToken(TokenSyntax NewArrowToken) const {
   syntax_assert_token_is(NewArrowToken, tok::arrow, "->");
-  return Data->replaceChild<FunctionSignatureSyntax>(NewArrowToken,
+  return Data->replaceChild<FunctionSignatureSyntax>(NewArrowToken.getRaw(),
                                                      Cursor::Arrow);
 }
 
@@ -644,8 +646,8 @@ FunctionDeclSyntax FunctionDeclSyntax::makeBlank() {
     {
       RawSyntax::missing(SyntaxKind::TypeAttributes),
       RawSyntax::missing(SyntaxKind::DeclModifierList),
-      TokenSyntax::missingToken(tok::kw_func, "func"),
-      TokenSyntax::missingToken(tok::identifier, ""),
+      RawTokenSyntax::missingToken(tok::kw_func, "func"),
+      RawTokenSyntax::missingToken(tok::identifier, ""),
       RawSyntax::missing(SyntaxKind::GenericParameterClause),
       RawSyntax::missing(SyntaxKind::FunctionSignature),
       RawSyntax::missing(SyntaxKind::GenericWhereClause),
@@ -677,26 +679,25 @@ FunctionDeclSyntax::withModifiers(DeclModifierListSyntax NewModifiers) const {
                                                 Cursor::Modifiers);
 }
 
-RC<TokenSyntax> FunctionDeclSyntax::getFuncKeyword() const {
-  return cast<TokenSyntax>(getRaw()->getChild(Cursor::FuncKeyword));
+TokenSyntax FunctionDeclSyntax::getFuncKeyword() const {
+  return { Root, Data->getChild(Cursor::FuncKeyword).get() };
 }
 
 FunctionDeclSyntax
-FunctionDeclSyntax::withFuncKeyword(RC<TokenSyntax> NewFuncKeyword) const {
+FunctionDeclSyntax::withFuncKeyword(TokenSyntax NewFuncKeyword) const {
   syntax_assert_token_is(NewFuncKeyword, tok::kw_func, "func");
-  return Data->replaceChild<FunctionDeclSyntax>(NewFuncKeyword,
+  return Data->replaceChild<FunctionDeclSyntax>(NewFuncKeyword.getRaw(),
                                                 Cursor::FuncKeyword);
-
 }
 
-RC<TokenSyntax> FunctionDeclSyntax::getIdentifier() const {
-  return cast<TokenSyntax>(getRaw()->getChild(Cursor::Identifier));
+TokenSyntax FunctionDeclSyntax::getIdentifier() const {
+  return { Root, Data->getChild(Cursor::Identifier).get() };
 }
 
 FunctionDeclSyntax
-FunctionDeclSyntax::withIdentifier(RC<TokenSyntax> NewIdentifier) const {
-  assert(NewIdentifier->getTokenKind() == tok::identifier);
-  return Data->replaceChild<FunctionDeclSyntax>(NewIdentifier,
+FunctionDeclSyntax::withIdentifier(TokenSyntax NewIdentifier) const {
+  assert(NewIdentifier.getTokenKind() == tok::identifier);
+  return Data->replaceChild<FunctionDeclSyntax>(NewIdentifier.getRaw(),
                                                 Cursor::Identifier);
 }
 

--- a/lib/Syntax/ExprSyntax.cpp
+++ b/lib/Syntax/ExprSyntax.cpp
@@ -42,25 +42,25 @@ void IntegerLiteralExprSyntax::validate() const {
 IntegerLiteralExprSyntax IntegerLiteralExprSyntax::makeBlank() {
   auto Raw = RawSyntax::make(SyntaxKind::IntegerLiteralExpr,
     {
-      TokenSyntax::missingToken(tok::oper_prefix, ""),
-      TokenSyntax::missingToken(tok::integer_literal, "")
+      RawTokenSyntax::missingToken(tok::oper_prefix, ""),
+      RawTokenSyntax::missingToken(tok::integer_literal, "")
     },
     SourcePresence::Present);
   return make<IntegerLiteralExprSyntax>(Raw);
 }
 
 IntegerLiteralExprSyntax
-IntegerLiteralExprSyntax::withDigits(RC<TokenSyntax> NewDigits) const {
-  assert(NewDigits->getTokenKind() == tok::integer_literal);
-  return Data->replaceChild<IntegerLiteralExprSyntax>(NewDigits,
+IntegerLiteralExprSyntax::withDigits(TokenSyntax NewDigits) const {
+  assert(NewDigits.getTokenKind() == tok::integer_literal);
+  return Data->replaceChild<IntegerLiteralExprSyntax>(NewDigits.getRaw(),
                                                       Cursor::Digits);
 }
 
 IntegerLiteralExprSyntax
-IntegerLiteralExprSyntax::withSign(RC<swift::syntax::TokenSyntax> NewSign)
-    const {
-    assert(NewSign->getTokenKind() == tok::oper_prefix);
-    return Data->replaceChild<IntegerLiteralExprSyntax>(NewSign, Cursor::Sign);
+IntegerLiteralExprSyntax::withSign(TokenSyntax NewSign) const {
+    assert(NewSign.getTokenKind() == tok::oper_prefix);
+    return Data->replaceChild<IntegerLiteralExprSyntax>(NewSign.getRaw(),
+                                                        Cursor::Sign);
 }
 
 #pragma mark - symbolic-reference API
@@ -75,21 +75,21 @@ void SymbolicReferenceExprSyntax::validate() const {
 SymbolicReferenceExprSyntax SymbolicReferenceExprSyntax::makeBlank() {
   auto Raw = RawSyntax::make(SyntaxKind::SymbolicReferenceExpr,
     {
-      TokenSyntax::missingToken(tok::identifier, ""),
+      RawTokenSyntax::missingToken(tok::identifier, ""),
       RawSyntax::missing(SyntaxKind::GenericArgumentClause),
     },
     SourcePresence::Present);
   return make<SymbolicReferenceExprSyntax>(Raw);
 }
 
-RC<TokenSyntax> SymbolicReferenceExprSyntax::getIdentifier() const {
-  return cast<TokenSyntax>(getRaw()->getChild(Cursor::Identifier));
+TokenSyntax SymbolicReferenceExprSyntax::getIdentifier() const {
+  return { Root, Data->getChild(Cursor::Identifier).get() };
 }
 
 SymbolicReferenceExprSyntax SymbolicReferenceExprSyntax::
-withIdentifier(RC<TokenSyntax> NewIdentifier) const {
-  assert(NewIdentifier->getTokenKind() == tok::identifier);
-  return Data->replaceChild<SymbolicReferenceExprSyntax>(NewIdentifier,
+withIdentifier(TokenSyntax NewIdentifier) const {
+  assert(NewIdentifier.getTokenKind() == tok::identifier);
+  return Data->replaceChild<SymbolicReferenceExprSyntax>(NewIdentifier.getRaw(),
                                                          Cursor::Identifier);
 }
 
@@ -131,10 +131,10 @@ void FunctionCallArgumentSyntax::validate() const {
 FunctionCallArgumentSyntax FunctionCallArgumentSyntax::makeBlank() {
   auto Raw = RawSyntax::make(SyntaxKind::FunctionCallArgument,
                              {
-                               TokenSyntax::missingToken(tok::identifier, ""),
-                               TokenSyntax::missingToken(tok::colon, ":"),
+                               RawTokenSyntax::missingToken(tok::identifier, ""),
+                               RawTokenSyntax::missingToken(tok::colon, ":"),
                                RawSyntax::missing(SyntaxKind::MissingExpr),
-                               TokenSyntax::missingToken(tok::comma, ",")
+                               RawTokenSyntax::missingToken(tok::comma, ",")
                              },
                              SourcePresence::Present);
   return make<FunctionCallArgumentSyntax>(Raw);
@@ -142,25 +142,25 @@ FunctionCallArgumentSyntax FunctionCallArgumentSyntax::makeBlank() {
 
 #pragma mark - function-call-argument API
 
-RC<TokenSyntax> FunctionCallArgumentSyntax::getLabel() const {
-  return cast<TokenSyntax>(getRaw()->getChild(Cursor::Label));
+TokenSyntax FunctionCallArgumentSyntax::getLabel() const {
+  return { Root, Data->getChild(Cursor::Label).get() };
 }
 
 FunctionCallArgumentSyntax
-FunctionCallArgumentSyntax::withLabel(RC<TokenSyntax> NewLabel) const {
-  assert(NewLabel->getTokenKind() == tok::identifier);
-  return Data->replaceChild<FunctionCallArgumentSyntax>(NewLabel,
+FunctionCallArgumentSyntax::withLabel(TokenSyntax NewLabel) const {
+  assert(NewLabel.getTokenKind() == tok::identifier);
+  return Data->replaceChild<FunctionCallArgumentSyntax>(NewLabel.getRaw(),
                                                         Cursor::Label);
 }
 
-RC<TokenSyntax> FunctionCallArgumentSyntax::getColonToken() const {
-  return cast<TokenSyntax>(getRaw()->getChild(Cursor::Colon));
+TokenSyntax FunctionCallArgumentSyntax::getColonToken() const {
+  return { Root, Data->getChild(Cursor::Colon).get() };
 }
 
 FunctionCallArgumentSyntax
-FunctionCallArgumentSyntax::withColonToken(RC<TokenSyntax> NewColon) const {
+FunctionCallArgumentSyntax::withColonToken(TokenSyntax NewColon) const {
   syntax_assert_token_is(NewColon, tok::colon, ":");
-  return Data->replaceChild<FunctionCallArgumentSyntax>(NewColon,
+  return Data->replaceChild<FunctionCallArgumentSyntax>(NewColon.getRaw(),
                                                         Cursor::Colon);
 }
 
@@ -182,15 +182,15 @@ FunctionCallArgumentSyntax::withExpression(ExprSyntax NewExpression) const {
                                                         Cursor::Expression);
 }
 
-RC<TokenSyntax> FunctionCallArgumentSyntax::getTrailingComma() const {
-  return cast<TokenSyntax>(getRaw()->getChild(Cursor::Comma));
+TokenSyntax FunctionCallArgumentSyntax::getTrailingComma() const {
+  return { Root, Data->getChild(Cursor::Comma).get() };
 }
 
 FunctionCallArgumentSyntax FunctionCallArgumentSyntax::
-withTrailingComma(RC<TokenSyntax> NewTrailingComma) const {
+withTrailingComma(TokenSyntax NewTrailingComma) const {
   syntax_assert_token_is(NewTrailingComma, tok::comma, ",");
-  return Data->replaceChild<FunctionCallArgumentSyntax>(NewTrailingComma,
-    FunctionCallArgumentSyntax::Cursor::Comma);
+  return Data->replaceChild<FunctionCallArgumentSyntax>(
+            NewTrailingComma.getRaw(), Cursor::Comma);
 }
 
 #pragma mark - function-call-expression Data
@@ -212,9 +212,9 @@ FunctionCallExprSyntax FunctionCallExprSyntax::makeBlank() {
   auto Raw = RawSyntax::make(SyntaxKind::FunctionCallExpr,
   {
     RawSyntax::missing(SyntaxKind::MissingExpr),
-    TokenSyntax::missingToken(tok::l_paren, "("),
+    RawTokenSyntax::missingToken(tok::l_paren, "("),
     RawSyntax::missing(SyntaxKind::FunctionCallArgumentList),
-    TokenSyntax::missingToken(tok::r_paren, ")"),
+    RawTokenSyntax::missingToken(tok::r_paren, ")"),
   },
   SourcePresence::Present);
   return make<FunctionCallExprSyntax>(Raw);
@@ -235,14 +235,14 @@ withCalledExpression(ExprSyntax NewBaseExpression) const {
                                                     Cursor::CalledExpression);
 }
 
-RC<TokenSyntax> FunctionCallExprSyntax::getLeftParen() const {
-  return cast<TokenSyntax>(getRaw()->getChild(Cursor::LeftParen));
+TokenSyntax FunctionCallExprSyntax::getLeftParen() const {
+  return { Root, Data->getChild(Cursor::LeftParen).get() };
 }
 
 FunctionCallExprSyntax
-FunctionCallExprSyntax::withLeftParen(RC<TokenSyntax> NewLeftParen) const {
+FunctionCallExprSyntax::withLeftParen(TokenSyntax NewLeftParen) const {
   syntax_assert_token_is(NewLeftParen, tok::l_paren, "(");
-  return Data->replaceChild<FunctionCallExprSyntax>(NewLeftParen,
+  return Data->replaceChild<FunctionCallExprSyntax>(NewLeftParen.getRaw(),
                                                     Cursor::LeftParen);
 }
 
@@ -259,14 +259,14 @@ withArgumentList(FunctionCallArgumentListSyntax NewArgumentList) const {
                                                     Cursor::ArgumentList);
 }
 
-RC<TokenSyntax> FunctionCallExprSyntax::getRightParen() const {
-  return cast<TokenSyntax>(getRaw()->getChild(Cursor::RightParen));
+TokenSyntax FunctionCallExprSyntax::getRightParen() const {
+  return { Root, Data->getChild(Cursor::RightParen).get() };
 }
 
 FunctionCallExprSyntax
-FunctionCallExprSyntax::withRightParen(RC<TokenSyntax> NewRightParen) const {
+FunctionCallExprSyntax::withRightParen(TokenSyntax NewRightParen) const {
   syntax_assert_token_is(NewRightParen, tok::r_paren, ")");
-  return Data->replaceChild<FunctionCallExprSyntax>(NewRightParen,
+  return Data->replaceChild<FunctionCallExprSyntax>(NewRightParen.getRaw(),
                                                     Cursor::RightParen);
 }
 
@@ -277,10 +277,10 @@ FunctionCallExprSyntaxBuilder::FunctionCallExprSyntaxBuilder()
     ListLayout(FunctionCallArgumentListSyntax::makeBlank().getRaw()->Layout) {}
 
 FunctionCallExprSyntaxBuilder &
-FunctionCallExprSyntaxBuilder::useLeftParen(RC<TokenSyntax> LeftParen) {
+FunctionCallExprSyntaxBuilder::useLeftParen(TokenSyntax LeftParen) {
   syntax_assert_token_is(LeftParen, tok::l_paren, "(");
   CallLayout[cursorIndex(FunctionCallExprSyntax::Cursor::LeftParen)]
-    = LeftParen;
+    = LeftParen.getRaw();
   return *this;
 }
 
@@ -298,10 +298,10 @@ useCalledExpression(ExprSyntax CalledExpression) {
 }
 
 FunctionCallExprSyntaxBuilder &
-FunctionCallExprSyntaxBuilder::useRightParen(RC<TokenSyntax> RightParen) {
+FunctionCallExprSyntaxBuilder::useRightParen(TokenSyntax RightParen) {
   syntax_assert_token_is(RightParen, tok::r_paren, ")");
   CallLayout[cursorIndex(FunctionCallExprSyntax::Cursor::RightParen)]
-    = RightParen;
+    = RightParen.getRaw();
   return *this;
 }
 

--- a/lib/Syntax/Format.cpp
+++ b/lib/Syntax/Format.cpp
@@ -28,15 +28,15 @@ Syntax syntax::format(Syntax Tree) {
   case SyntaxKind::StructDecl: {
     auto Struct = Tree.castTo<StructDeclSyntax>();
     auto LeftBrace = Struct.getLeftBraceToken();
-    if (!LeftBrace->LeadingTrivia.contains(TriviaKind::Newline)) {
-      auto NewLeading = Trivia::newlines(1) + LeftBrace->LeadingTrivia;
+    if (!LeftBrace.getLeadingTrivia().contains(TriviaKind::Newline)) {
+      auto NewLeading = Trivia::newlines(1) + LeftBrace.getLeadingTrivia();
 
       const auto NewMembers =
         format(Struct.getMembers()).castTo<DeclMembersSyntax>();
 
-      LeftBrace = LeftBrace->withLeadingTrivia(NewLeading);
+      auto NewLeftBrace = LeftBrace.withLeadingTrivia(NewLeading);
 
-      return Struct.withMembers(NewMembers).withLeftBrace(LeftBrace);
+      return Struct.withMembers(NewMembers).withLeftBrace(NewLeftBrace);
     }
     break;
   }

--- a/lib/Syntax/GenericSyntax.cpp
+++ b/lib/Syntax/GenericSyntax.cpp
@@ -39,7 +39,7 @@ ConformanceRequirementSyntax::makeBlank() {
   auto Raw = RawSyntax::make(SyntaxKind::ConformanceRequirement,
                              {
                                RawSyntax::missing(SyntaxKind::TypeIdentifier),
-                               TokenSyntax::missingToken(tok::colon, ":"),
+                               RawTokenSyntax::missingToken(tok::colon, ":"),
                                RawSyntax::missing(SyntaxKind::TypeIdentifier),
                              },
                              SourcePresence::Present);
@@ -55,8 +55,8 @@ void GenericParameterSyntax::validate() const {
 GenericParameterSyntax GenericParameterSyntax::makeBlank() {
   auto Raw = RawSyntax::make(SyntaxKind::GenericParameter,
                              {
-                               TokenSyntax::missingToken(tok::identifier, ""),
-                               TokenSyntax::missingToken(tok::colon, ":"),
+                               RawTokenSyntax::missingToken(tok::identifier, ""),
+                               RawTokenSyntax::missingToken(tok::colon, ":"),
                                RawSyntax::missing(SyntaxKind::MissingType),
                              },
                              SourcePresence::Present);
@@ -83,9 +83,9 @@ GenericParameterClauseSyntax::makeBlank() {
   auto Raw = RawSyntax::make(
                SyntaxKind::GenericParameterClause,
                {
-                 TokenSyntax::missingToken(tok::l_angle, "<"),
+                 RawTokenSyntax::missingToken(tok::l_angle, "<"),
                  RawSyntax::missing(SyntaxKind::GenericParameterList),
-                 TokenSyntax::missingToken(tok::r_angle, ">"),
+                 RawTokenSyntax::missingToken(tok::r_angle, ">"),
                },
                SourcePresence::Present);
   return make<GenericParameterClauseSyntax>(Raw);
@@ -94,35 +94,36 @@ GenericParameterClauseSyntax::makeBlank() {
 #pragma mark - generic-parameter-clause Builder
 
 GenericParameterClauseBuilder::GenericParameterClauseBuilder()
-  : LeftAngleToken(TokenSyntax::missingToken(tok::l_angle, "<")),
+  : LeftAngleToken(RawTokenSyntax::missingToken(tok::l_angle, "<")),
     ParameterListLayout(RawSyntax::missing(SyntaxKind::GenericParameterList)
                           ->Layout),
-    RightAngleToken(TokenSyntax::missingToken(tok::r_angle, ">")) {}
+    RightAngleToken(RawTokenSyntax::missingToken(tok::r_angle, ">")) {}
 
 GenericParameterClauseBuilder &GenericParameterClauseBuilder::
-useLeftAngleBracket(RC<TokenSyntax> LeftAngle) {
+useLeftAngleBracket(TokenSyntax LeftAngle) {
   syntax_assert_token_is(LeftAngle, tok::l_angle, "<");
-  LeftAngleToken = LeftAngle;
+  LeftAngleToken = LeftAngle.getRawToken();
   return *this;
 }
 
 GenericParameterClauseBuilder &GenericParameterClauseBuilder::
-addParameter(llvm::Optional<RC<TokenSyntax>> MaybeComma,
+addParameter(llvm::Optional<TokenSyntax> MaybeComma,
              GenericParameterSyntax Parameter) {
   if (MaybeComma.hasValue()) {
     syntax_assert_token_is(MaybeComma.getValue(), tok::comma, ",");
-    ParameterListLayout.push_back(MaybeComma.getValue());
+    ParameterListLayout.push_back(MaybeComma->getRaw());
   } else {
-    ParameterListLayout.push_back(TokenSyntax::missingToken(tok::comma, ","));
+    ParameterListLayout.push_back(
+                            RawTokenSyntax::missingToken(tok::comma, ","));
   }
   ParameterListLayout.push_back(Parameter.getRaw());
   return *this;
 }
 
 GenericParameterClauseBuilder &GenericParameterClauseBuilder::
-useRightAngleBracket(RC<TokenSyntax> RightAngle) {
+useRightAngleBracket(TokenSyntax RightAngle) {
   syntax_assert_token_is(RightAngle, tok::r_angle, ">");
-  RightAngleToken = RightAngle;
+  RightAngleToken = RightAngle.getRawToken();
   return *this;
 }
 
@@ -156,7 +157,7 @@ GenericWhereClauseSyntax GenericWhereClauseSyntax::makeBlank() {
   auto Raw = RawSyntax::make(
                SyntaxKind::GenericWhereClause,
                {
-                 TokenSyntax::missingToken(tok::kw_where, "where"),
+                 RawTokenSyntax::missingToken(tok::kw_where, "where"),
                  RawSyntax::missing(SyntaxKind::GenericRequirementList),
                },
                SourcePresence::Present);
@@ -164,9 +165,9 @@ GenericWhereClauseSyntax GenericWhereClauseSyntax::makeBlank() {
 }
 
 GenericWhereClauseSyntax GenericWhereClauseSyntax::
-withWhereKeyword(RC<TokenSyntax> NewWhereKeyword) const {
+withWhereKeyword(TokenSyntax NewWhereKeyword) const {
   syntax_assert_token_is(NewWhereKeyword, tok::kw_where, "where");
-  return Data->replaceChild<GenericWhereClauseSyntax>(NewWhereKeyword,
+  return Data->replaceChild<GenericWhereClauseSyntax>(NewWhereKeyword.getRaw(),
                                                       Cursor::WhereKeyword);
 }
 
@@ -193,7 +194,7 @@ SameTypeRequirementSyntax SameTypeRequirementSyntax::makeBlank() {
   auto Raw = RawSyntax::make(SyntaxKind::SameTypeRequirement,
                              {
                                RawSyntax::missing(SyntaxKind::TypeIdentifier),
-                               TokenSyntax::missingToken(tok::equal, "="),
+                               RawTokenSyntax::missingToken(tok::equal, "="),
                                RawSyntax::missing(SyntaxKind::MissingType),
                              },
                              SourcePresence::Present);
@@ -206,9 +207,9 @@ GenericArgumentClauseSyntax
 GenericArgumentClauseSyntax::makeBlank() {
   auto Raw = RawSyntax::make(SyntaxKind::GenericArgumentClause,
                              {
-                               TokenSyntax::missingToken(tok::l_angle, "<"),
+                               RawTokenSyntax::missingToken(tok::l_angle, "<"),
                                RawSyntax::missing(SyntaxKind::GenericArgumentList),
-                               TokenSyntax::missingToken(tok::r_angle, ">"),
+                               RawTokenSyntax::missingToken(tok::r_angle, ">"),
                              },
                              SourcePresence::Present);
   return make<GenericArgumentClauseSyntax>(Raw);
@@ -216,19 +217,19 @@ GenericArgumentClauseSyntax::makeBlank() {
 
 
 GenericArgumentClauseSyntax GenericArgumentClauseSyntax::
-withLeftAngleBracket(RC<TokenSyntax> NewLeftAngleBracket) const {
+withLeftAngleBracket(TokenSyntax NewLeftAngleBracket) const {
   syntax_assert_token_is(NewLeftAngleBracket, tok::l_angle, "<");
   return Data->replaceChild<GenericArgumentClauseSyntax>(
-    NewLeftAngleBracket, Cursor::LeftAngleBracketToken);
+    NewLeftAngleBracket.getRaw(), Cursor::LeftAngleBracketToken);
 }
 
 
 
 GenericArgumentClauseSyntax GenericArgumentClauseSyntax::
-withRightAngleBracket(RC<TokenSyntax> NewRightAngleBracket) const {
+withRightAngleBracket(TokenSyntax NewRightAngleBracket) const {
   syntax_assert_token_is(NewRightAngleBracket, tok::r_angle, ">");
   return Data->replaceChild<GenericArgumentClauseSyntax>(
-    NewRightAngleBracket, Cursor::RightAngleBracketToken);
+    NewRightAngleBracket.getRaw(), Cursor::RightAngleBracketToken);
 }
 
 #pragma mark - generic-argument-clause Builder
@@ -238,29 +239,30 @@ GenericArgumentClauseBuilder::GenericArgumentClauseBuilder()
       SyntaxFactory::makeBlankGenericArgumentClause().getRaw()->Layout) {}
 
 GenericArgumentClauseBuilder &GenericArgumentClauseBuilder::
-useLeftAngleBracket(RC<TokenSyntax> LeftAngle) {
+useLeftAngleBracket(TokenSyntax LeftAngle) {
   syntax_assert_token_is(LeftAngle, tok::l_angle, "<");
-  LeftAngleToken = LeftAngle;
+  LeftAngleToken = LeftAngle.getRawToken();
   return *this;
 }
 
 GenericArgumentClauseBuilder &GenericArgumentClauseBuilder::
-addGenericArgument(llvm::Optional<RC<TokenSyntax>> MaybeComma,
+addGenericArgument(llvm::Optional<TokenSyntax> MaybeComma,
                    TypeSyntax ArgumentTypeSyntax) {
   if (MaybeComma.hasValue()) {
     syntax_assert_token_is(MaybeComma.getValue(), tok::comma, ",");
-    ArgumentListLayout.push_back(MaybeComma.getValue());
+    ArgumentListLayout.push_back(MaybeComma->getRaw());
   } else {
-    ArgumentListLayout.push_back(TokenSyntax::missingToken(tok::comma, ","));
+    ArgumentListLayout.push_back(
+       RawTokenSyntax::missingToken(tok::comma, ","));
   }
   ArgumentListLayout.push_back(ArgumentTypeSyntax.getRaw());
   return *this;
 }
 
 GenericArgumentClauseBuilder &GenericArgumentClauseBuilder::
-useRightAngleBracket(RC<TokenSyntax> RightAngle) {
+useRightAngleBracket(TokenSyntax RightAngle) {
   syntax_assert_token_is(RightAngle, tok::r_angle, ">");
-  RightAngleToken = RightAngle;
+  RightAngleToken = RightAngle.getRawToken();
   return *this;
 }
 

--- a/lib/Syntax/LegacyASTTransformer.cpp
+++ b/lib/Syntax/LegacyASTTransformer.cpp
@@ -26,16 +26,17 @@ using namespace swift::syntax;
 namespace {
   bool
   tokenContainsOffset(unsigned Offset,
-                      const std::pair<RC<TokenSyntax>,
-                      AbsolutePosition> &TokAndPos) {
+                      const std::pair<RC<RawTokenSyntax>,
+                                      AbsolutePosition> &TokAndPos) {
     auto Start = TokAndPos.second.getOffset();
     auto End = Start + TokAndPos.first->getText().size();
     return Offset >= Start && Offset < End;
   }
-  std::vector<RC<TokenSyntax>>
-  getTokenSyntaxsInRange(SourceRange Range, SourceManager &SourceMgr,
-                       unsigned BufferID,
-                       const TokenPositionList &Tokens) {
+
+  std::vector<RC<RawTokenSyntax>>
+  getRawTokenSyntaxesInRange(SourceRange Range, SourceManager &SourceMgr,
+                             unsigned BufferID,
+                             const TokenPositionList &Tokens) {
     auto StartOffset = SourceMgr.getLocOffsetInBuffer(Range.Start, BufferID);
     auto EndOffset = SourceMgr.getLocOffsetInBuffer(Range.End, BufferID);
 
@@ -60,7 +61,7 @@ namespace {
     assert(End.base() != Tokens.end());
     assert(Start <= End.base());
 
-    std::vector<RC<TokenSyntax>> TokensInRange;
+    std::vector<RC<RawTokenSyntax>> TokensInRange;
 
     while (Start < End.base()) {
       TokensInRange.push_back(Start->first);
@@ -141,7 +142,7 @@ SourceLoc LegacyASTTransformer::getEndLocForExpr(const Expr *E) const {
 }
 
 RC<SyntaxData> LegacyASTTransformer::getUnknownSyntax(SourceRange SR) {
-  auto ComprisingTokens = getTokenSyntaxsInRange(SR, SourceMgr,
+  auto ComprisingTokens = getRawTokenSyntaxesInRange(SR, SourceMgr,
                                                  BufferID, Tokens);
   RawSyntax::LayoutList Layout;
   std::copy(ComprisingTokens.begin(),
@@ -155,7 +156,7 @@ RC<SyntaxData> LegacyASTTransformer::getUnknownSyntax(SourceRange SR) {
 
 RC<SyntaxData> LegacyASTTransformer::getUnknownDecl(Decl *D) {
   SourceRange SR {getStartLocForDecl(D),getEndLocForDecl(D)};
-  auto ComprisingTokens = getTokenSyntaxsInRange(SR, SourceMgr,
+  auto ComprisingTokens = getRawTokenSyntaxesInRange(SR, SourceMgr,
                                                  BufferID, Tokens);
   RawSyntax::LayoutList Layout;
   std::copy(ComprisingTokens.begin(),
@@ -169,7 +170,7 @@ RC<SyntaxData> LegacyASTTransformer::getUnknownDecl(Decl *D) {
 
 RC<SyntaxData> LegacyASTTransformer::getUnknownStmt(Stmt *S) {
   SourceRange SR { S->getStartLoc(), getEndLocForStmt(S) };
-  auto ComprisingTokens = getTokenSyntaxsInRange(SR, SourceMgr,
+  auto ComprisingTokens = getRawTokenSyntaxesInRange(SR, SourceMgr,
                                                  BufferID, Tokens);
   RawSyntax::LayoutList Layout;
   std::copy(ComprisingTokens.begin(),
@@ -183,7 +184,7 @@ RC<SyntaxData> LegacyASTTransformer::getUnknownStmt(Stmt *S) {
 
 RC<SyntaxData> LegacyASTTransformer::getUnknownExpr(Expr *E) {
   SourceRange SR { E->getStartLoc(), getEndLocForExpr(E) };
-  auto ComprisingTokens = getTokenSyntaxsInRange(SR, SourceMgr,
+  auto ComprisingTokens = getRawTokenSyntaxesInRange(SR, SourceMgr,
                                                  BufferID, Tokens);
   RawSyntax::LayoutList Layout;
   std::copy(ComprisingTokens.begin(),
@@ -1296,7 +1297,7 @@ LegacyASTTransformer::visitKeyPathDotExpr(KeyPathDotExpr *E,
   return getUnknownExpr(E);
 }
 
-RC<TokenSyntax>
+TokenSyntax
 syntax::findTokenSyntax(tok ExpectedKind,
                         OwnedString ExpectedText,
                         SourceManager &SourceMgr,
@@ -1319,7 +1320,7 @@ syntax::findTokenSyntax(tok ExpectedKind,
     if (Offset == TokStart) {
       if (Tok->getTokenKind() == ExpectedKind &&
           (ExpectedText.empty() || Tok->getText() == ExpectedText.str())) {
-        return Tok;
+        return make<TokenSyntax>(Tok);
       } else {
         return TokenSyntax::missingToken(ExpectedKind, ExpectedText);
       }

--- a/lib/Syntax/README.md
+++ b/lib/Syntax/README.md
@@ -236,7 +236,7 @@ tokens, represented by the `TokenSyntax` class.
 - `RawSyntax` store no parental relationships and can therefore be shared
    among syntax nodes if they have identical content.
 
-### TokenSyntax
+### RawTokenSyntax
 
 These are special cases of `RawSyntax` and represent all terminals in the
 grammar. Aside from the token kind and the text, they have two very important
@@ -245,12 +245,12 @@ pieces of information for full-fidelity source: leading and trailing source
 
 #### TokenSyntax summary
 
-- `TokenSyntax` are `RawSyntax` and represent the terminals in the Swift
+- `RawTokenSyntax` are `RawSyntax` and represent the terminals in the Swift
   grammar.
-- Like `RawSyntax`, `TokenSyntax` are immutable.
-- `TokenSyntax` do not have pointer equality, as they can be shared among syntax
+- Like `RawSyntax`, `RawTokenSyntax` are immutable.
+- `RawTokenSyntax` do have pointer equality, but they can be shared among syntax
   nodes.
-- `TokenSyntax` have *leading-* and *trailing trivia*, the purely syntactic
+- `RawTokenSyntax` have *leading-* and *trailing trivia*, the purely syntactic
   formatting information like whitespace and comments.
 
 ### Trivia
@@ -447,7 +447,7 @@ auto Block = SyntaxFactory::makeBlankCodeBlockStmt()
 
 // Returns a new ReturnStmtSyntax with the root set to the Block
 // above, and the parent set to the StmtListSyntax.
-auto MyReturn = Block.getStatement(0).castTo<ReturnStmt>;
+auto MyReturn = Block.getStatement(0).castTo<ReturnStmt>();
 ```
 
 Here's what the corresponding object diagram would look like starting with
@@ -456,7 +456,7 @@ Here's what the corresponding object diagram would look like starting with
 ![Syntax Example](.doc/SyntaxExample.png)
 
 Legend:
-- Green: `RawSyntax` types (`TokenSyntax` is a `RawSyntax`)
+- Green: `RawSyntax` types (`RawTokenSyntax` is a `RawSyntax`)
 - Red: `SyntaxData` types
 - Blue: `Syntax` types
 - Gray: `Trivia`

--- a/lib/Syntax/RawSyntax.cpp
+++ b/lib/Syntax/RawSyntax.cpp
@@ -36,7 +36,7 @@ void dumpSyntaxKind(llvm::raw_ostream &OS, const SyntaxKind Kind) {
 } // end anonymous namespace
 
 void RawSyntax::print(llvm::raw_ostream &OS) const {
-  if (const auto Tok = dyn_cast<TokenSyntax>(this)) {
+  if (const auto Tok = dyn_cast<RawTokenSyntax>(this)) {
     Tok->print(OS);
   }
 
@@ -71,7 +71,7 @@ void RawSyntax::dump(llvm::raw_ostream &OS, unsigned Indent) const {
     }
     switch ((*LE)->Kind) {
     case SyntaxKind::Token:
-      llvm::cast<TokenSyntax>(*LE)->dump(OS, Indent + 1);
+      llvm::cast<RawTokenSyntax>(*LE)->dump(OS, Indent + 1);
       break;
     default:
       (*LE)->dump(OS, Indent + 1);
@@ -87,7 +87,7 @@ bool RawSyntax::accumulateAbsolutePosition(
   for (auto LE : Layout) {
     switch (LE->Kind) {
     case SyntaxKind::Token: {
-      auto Tok = llvm::cast<TokenSyntax>(LE);
+      auto Tok = llvm::cast<RawTokenSyntax>(LE);
       for (auto Leader : Tok->LeadingTrivia) {
         Leader.accumulateAbsolutePosition(Pos);
       }

--- a/lib/Syntax/RawTokenSyntax.cpp
+++ b/lib/Syntax/RawTokenSyntax.cpp
@@ -1,4 +1,4 @@
-//===--- TokenSyntax.cpp - Swift Token Syntax Implementation --------------===//
+//===--- RawTokenSyntax.cpp - Swift Token Syntax Implementation -----------===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -16,28 +16,28 @@
 using namespace swift;
 using namespace swift::syntax;
 
-TokenSyntax::TokenSyntax()
+RawTokenSyntax::RawTokenSyntax()
   : RawSyntax(SyntaxKind::Token, {}, SourcePresence::Missing),
     TokenKind(tok::NUM_TOKENS), Text(OwnedString()),
     LeadingTrivia({}), TrailingTrivia({}) {}
 
-TokenSyntax::TokenSyntax(tok TokenKind, OwnedString Text,
-                     const SourcePresence Presence)
+RawTokenSyntax::RawTokenSyntax(tok TokenKind, OwnedString Text,
+                               const SourcePresence Presence)
   : RawSyntax(SyntaxKind::Token, {}, Presence),
     TokenKind(TokenKind),
     Text(Text),
     LeadingTrivia({}), TrailingTrivia({}) {}
 
-TokenSyntax::TokenSyntax(tok TokenKind, OwnedString Text,
-                     const SourcePresence Presence,
-                     const Trivia &LeadingTrivia,
-                     const Trivia &TrailingTrivia)
+RawTokenSyntax::RawTokenSyntax(tok TokenKind, OwnedString Text,
+                               const SourcePresence Presence,
+                               const Trivia &LeadingTrivia,
+                               const Trivia &TrailingTrivia)
     : RawSyntax(SyntaxKind::Token, {}, Presence),
                 TokenKind(TokenKind), Text(Text),
                 LeadingTrivia(LeadingTrivia), TrailingTrivia(TrailingTrivia) {}
 
 AbsolutePosition
-TokenSyntax::accumulateAbsolutePosition(AbsolutePosition &Pos) const {
+RawTokenSyntax::accumulateAbsolutePosition(AbsolutePosition &Pos) const {
   for (auto Leader : LeadingTrivia) {
     Leader.accumulateAbsolutePosition(Pos);
   }
@@ -53,7 +53,7 @@ TokenSyntax::accumulateAbsolutePosition(AbsolutePosition &Pos) const {
   return Start;
 }
 
-void TokenSyntax::dumpKind(llvm::raw_ostream &OS) const {
+void RawTokenSyntax::dumpKind(llvm::raw_ostream &OS) const {
   switch (getTokenKind()) {
   case tok::unknown:
     OS << "unknown";
@@ -116,7 +116,7 @@ void TokenSyntax::dumpKind(llvm::raw_ostream &OS) const {
   }
 }
 
-void TokenSyntax::dump(llvm::raw_ostream &OS, unsigned Indent) const {
+void RawTokenSyntax::dump(llvm::raw_ostream &OS, unsigned Indent) const {
   auto indent = [&](unsigned Amount) {
     for (decltype(Amount) i = 0; i < Amount; ++i) {
       OS << ' ';

--- a/lib/Syntax/StmtSyntax.cpp
+++ b/lib/Syntax/StmtSyntax.cpp
@@ -29,7 +29,7 @@ FallthroughStmtSyntax FallthroughStmtSyntax::makeBlank() {
   return make<FallthroughStmtSyntax>(
     RawSyntax::make(SyntaxKind::FallthroughStmt,
     {
-      TokenSyntax::missingToken(tok::kw_fallthrough, "fallthrough"),
+      RawTokenSyntax::missingToken(tok::kw_fallthrough, "fallthrough"),
     },
     SourcePresence::Present));
 }
@@ -41,16 +41,16 @@ void FallthroughStmtSyntax::validate() const {
                                  tok::kw_fallthrough, "fallthrough");
 }
 
-RC<TokenSyntax> FallthroughStmtSyntax::getFallthroughKeyword() const {
-  return cast<TokenSyntax>(getRaw()->getChild(Cursor::FallthroughKeyword));
+TokenSyntax FallthroughStmtSyntax::getFallthroughKeyword() const {
+  return { Root, Data->getChild(Cursor::FallthroughKeyword).get() };
 }
 
 FallthroughStmtSyntax FallthroughStmtSyntax::
-withFallthroughKeyword(RC<TokenSyntax> NewFallthroughKeyword) const {
+withFallthroughKeyword(TokenSyntax NewFallthroughKeyword) const {
   syntax_assert_token_is(NewFallthroughKeyword, tok::kw_fallthrough,
                          "fallthrough");
-  return Data->replaceChild<FallthroughStmtSyntax>(NewFallthroughKeyword,
-                                                   Cursor::FallthroughKeyword);
+  return Data->replaceChild<FallthroughStmtSyntax>(
+                 NewFallthroughKeyword.getRaw(), Cursor::FallthroughKeyword);
 }
 
 #pragma mark code-block API
@@ -59,9 +59,9 @@ CodeBlockStmtSyntax
 CodeBlockStmtSyntax::makeBlank() {
   return make<CodeBlockStmtSyntax>(RawSyntax::make(SyntaxKind::CodeBlockStmt,
                               {
-                                TokenSyntax::missingToken(tok::l_brace, "{"),
+                                RawTokenSyntax::missingToken(tok::l_brace, "{"),
                                 RawSyntax::missing(SyntaxKind::StmtList),
-                                TokenSyntax::missingToken(tok::r_brace, "}"),
+                                RawTokenSyntax::missingToken(tok::r_brace, "}"),
                               },
                               SourcePresence::Present));
 }
@@ -89,39 +89,39 @@ void BreakStmtSyntax::validate() const {
 BreakStmtSyntax BreakStmtSyntax::makeBlank() {
   return make<BreakStmtSyntax>(RawSyntax::make(SyntaxKind::BreakStmt,
                                {
-                                 TokenSyntax::missingToken(tok::kw_break,
+                                 RawTokenSyntax::missingToken(tok::kw_break,
                                                            "break"),
-                                 TokenSyntax::missingToken(tok::identifier, ""),
+                                 RawTokenSyntax::missingToken(tok::identifier, ""),
                                },
                                SourcePresence::Present));
 }
 
-RC<TokenSyntax> BreakStmtSyntax::getBreakKeyword() const {
-  return cast<TokenSyntax>(getRaw()->getChild(Cursor::BreakKeyword));
+TokenSyntax BreakStmtSyntax::getBreakKeyword() const {
+  return { Root, Data->getChild(Cursor::BreakKeyword).get() };
 }
 
 BreakStmtSyntax
-BreakStmtSyntax::withBreakKeyword(RC<TokenSyntax> NewBreakKeyword) const {
+BreakStmtSyntax::withBreakKeyword(TokenSyntax NewBreakKeyword) const {
   syntax_assert_token_is(NewBreakKeyword, tok::kw_break, "break");
-  return Data->replaceChild<BreakStmtSyntax>(NewBreakKeyword,
+  return Data->replaceChild<BreakStmtSyntax>(NewBreakKeyword.getRaw(),
                                              Cursor::BreakKeyword);
 }
 
-RC<TokenSyntax> BreakStmtSyntax::getLabel() const {
-  return cast<TokenSyntax>(getRaw()->getChild(Cursor::Label));
+TokenSyntax BreakStmtSyntax::getLabel() const {
+  return { Root, Data->getChild(Cursor::Label).get() };
 }
 
-BreakStmtSyntax BreakStmtSyntax::withLabel(RC<TokenSyntax> NewLabel) const {
-  assert(NewLabel->getTokenKind() == tok::identifier);
-  return Data->replaceChild<BreakStmtSyntax>(NewLabel, Cursor::Label);
+BreakStmtSyntax BreakStmtSyntax::withLabel(TokenSyntax NewLabel) const {
+  assert(NewLabel.getTokenKind() == tok::identifier);
+  return Data->replaceChild<BreakStmtSyntax>(NewLabel.getRaw(), Cursor::Label);
 }
 
 ContinueStmtSyntax ContinueStmtSyntax::makeBlank() {
   return make<ContinueStmtSyntax>(
             RawSyntax::make(SyntaxKind::ContinueStmt,
             {
-              TokenSyntax::missingToken(tok::kw_continue, "continue"),
-              TokenSyntax::missingToken(tok::identifier, ""),
+              RawTokenSyntax::missingToken(tok::kw_continue, "continue"),
+              RawTokenSyntax::missingToken(tok::identifier, ""),
             },
             SourcePresence::Present));
 }
@@ -137,25 +137,25 @@ void ContinueStmtSyntax::validate() const {
                             tok::identifier);
 }
 
-RC<TokenSyntax> ContinueStmtSyntax::getContinueKeyword() const {
-  return cast<TokenSyntax>(getRaw()->getChild(Cursor::ContinueKeyword));
+TokenSyntax ContinueStmtSyntax::getContinueKeyword() const {
+  return { Root, Data->getChild(Cursor::ContinueKeyword).get() };
 }
 
 ContinueStmtSyntax ContinueStmtSyntax::
-withContinueKeyword(RC<TokenSyntax> NewContinueKeyword) const {
+withContinueKeyword(TokenSyntax NewContinueKeyword) const {
   syntax_assert_token_is(NewContinueKeyword, tok::kw_continue, "continue");
-  return Data->replaceChild<ContinueStmtSyntax>(NewContinueKeyword,
+  return Data->replaceChild<ContinueStmtSyntax>(NewContinueKeyword.getRaw(),
                                                 Cursor::ContinueKeyword);
 }
 
-RC<TokenSyntax> ContinueStmtSyntax::getLabel() const {
-  return cast<TokenSyntax>(getRaw()->getChild(Cursor::Label));
+TokenSyntax ContinueStmtSyntax::getLabel() const {
+  return { Root, Data->getChild(Cursor::Label).get() };
 }
 
 ContinueStmtSyntax
-ContinueStmtSyntax::withLabel(RC<TokenSyntax> NewLabel) const {
-  assert(NewLabel->getTokenKind() == tok::identifier);
-  return Data->replaceChild<ContinueStmtSyntax>(NewLabel, Cursor::Label);
+ContinueStmtSyntax::withLabel(TokenSyntax NewLabel) const {
+  assert(NewLabel.getTokenKind() == tok::identifier);
+  return Data->replaceChild<ContinueStmtSyntax>(NewLabel.getRaw(), Cursor::Label);
 }
 
 #pragma mark - return-statement API
@@ -171,7 +171,7 @@ void ReturnStmtSyntax::validate() const {
 ReturnStmtSyntax ReturnStmtSyntax::makeBlank() {
   auto Raw = RawSyntax::make(SyntaxKind::ReturnStmt,
                              {
-                               TokenSyntax::missingToken(tok::kw_return,
+                               RawTokenSyntax::missingToken(tok::kw_return,
                                                          "return"),
                                RawSyntax::missing(SyntaxKind::MissingExpr),
                              },
@@ -179,14 +179,14 @@ ReturnStmtSyntax ReturnStmtSyntax::makeBlank() {
   return make<ReturnStmtSyntax>(Raw);
 }
 
-RC<TokenSyntax> ReturnStmtSyntax::getReturnKeyword() const {
-  return cast<TokenSyntax>(getRaw()->getChild(Cursor::ReturnKeyword));
+TokenSyntax ReturnStmtSyntax::getReturnKeyword() const {
+  return { Root, Data->getChild(Cursor::ReturnKeyword).get() };
 }
 
 ReturnStmtSyntax ReturnStmtSyntax::
-withReturnKeyword(RC<TokenSyntax> NewReturnKeyword) const {
+withReturnKeyword(TokenSyntax NewReturnKeyword) const {
   syntax_assert_token_is(NewReturnKeyword, tok::kw_return, "return");
-  return Data->replaceChild<ReturnStmtSyntax>(NewReturnKeyword,
+  return Data->replaceChild<ReturnStmtSyntax>(NewReturnKeyword.getRaw(),
                                               Cursor::ReturnKeyword);
 }
 

--- a/lib/Syntax/SyntaxFactory.cpp
+++ b/lib/Syntax/SyntaxFactory.cpp
@@ -24,9 +24,11 @@ using namespace swift;
 using namespace swift::syntax;
 
 UnknownSyntax
-SyntaxFactory::makeUnknownSyntax(llvm::ArrayRef<RC<TokenSyntax>> Tokens) {
+SyntaxFactory::makeUnknownSyntax(llvm::ArrayRef<TokenSyntax> Tokens) {
   RawSyntax::LayoutList Layout;
-  std::copy(Tokens.begin(), Tokens.end(), std::back_inserter(Layout));
+  for (auto &Token : Tokens) {
+    Layout.push_back(Token.getRaw());
+  }
   auto Raw = RawSyntax::make(SyntaxKind::Unknown, Layout,
                              SourcePresence::Present);
   return make<UnknownSyntax>(Raw);
@@ -36,16 +38,16 @@ SyntaxFactory::makeUnknownSyntax(llvm::ArrayRef<RC<TokenSyntax>> Tokens) {
 
 #pragma mark - declaration-modifier
 
-DeclModifierSyntax SyntaxFactory::makeDeclModifier(RC<TokenSyntax> Name,
-                                                   RC<TokenSyntax> LeftParen,
-                                                   RC<TokenSyntax> Argument,
-                                                   RC<TokenSyntax> RightParen) {
+DeclModifierSyntax SyntaxFactory::makeDeclModifier(TokenSyntax Name,
+                                                   TokenSyntax LeftParen,
+                                                   TokenSyntax Argument,
+                                                   TokenSyntax RightParen) {
   auto Raw = RawSyntax::make(SyntaxKind::DeclModifier,
                              {
-                               Name,
-                               LeftParen,
-                               Argument,
-                               RightParen,
+                               Name.getRaw(),
+                               LeftParen.getRaw(),
+                               Argument.getRaw(),
+                               RightParen.getRaw(),
                              },
                              SourcePresence::Present);
   return make<DeclModifierSyntax>(Raw);
@@ -76,20 +78,20 @@ DeclModifierListSyntax SyntaxFactory::makeBlankDeclModifierList() {
 #pragma mark - struct-declaration
 
 StructDeclSyntax
-SyntaxFactory::makeStructDecl(RC<TokenSyntax> StructToken,
-                              RC<TokenSyntax> Identifier,
+SyntaxFactory::makeStructDecl(TokenSyntax StructToken,
+                              TokenSyntax Identifier,
                               Syntax GenericParameters,
-                              Syntax WhereClause, RC<TokenSyntax> LeftBrace,
-                              Syntax DeclMembers, RC<TokenSyntax> RightBrace) {
+                              Syntax WhereClause, TokenSyntax LeftBrace,
+                              Syntax DeclMembers, TokenSyntax RightBrace) {
   auto Raw = RawSyntax::make(SyntaxKind::StructDecl,
                              {
-                               StructToken,
-                               Identifier,
+                               StructToken.getRaw(),
+                               Identifier.getRaw(),
                                GenericParameters.getRaw(),
                                WhereClause.getRaw(),
-                               LeftBrace,
+                               LeftBrace.getRaw(),
                                DeclMembers.getRaw(),
-                               RightBrace
+                               RightBrace.getRaw()
                              },
                              SourcePresence::Present);
   return make<StructDeclSyntax>(Raw);
@@ -102,12 +104,17 @@ StructDeclSyntax SyntaxFactory::makeBlankStructDecl() {
 #pragma mark - type-alias-declaration
 
 TypeAliasDeclSyntax SyntaxFactory::makeTypealiasDecl(
-    RC<TokenSyntax> TypealiasToken, RC<TokenSyntax> Identifier,
-    GenericParameterClauseSyntax GenericParams, RC<TokenSyntax> AssignmentToken,
+    TokenSyntax TypealiasToken, TokenSyntax Identifier,
+    GenericParameterClauseSyntax GenericParams, TokenSyntax AssignmentToken,
     TypeSyntax Type) {
   auto Raw = RawSyntax::make(SyntaxKind::TypeAliasDecl,
-                             {TypealiasToken, Identifier, GenericParams.getRaw(),
-                              AssignmentToken, Type.getRaw()},
+                             {
+                               TypealiasToken.getRaw(),
+                               Identifier.getRaw(),
+                               GenericParams.getRaw(),
+                               AssignmentToken.getRaw(),
+                               Type.getRaw()
+                             },
                              SourcePresence::Present);
   return make<TypeAliasDeclSyntax>(Raw);
 }
@@ -123,28 +130,28 @@ DeclMembersSyntax SyntaxFactory::makeBlankDeclMembers() {
 #pragma mark - function-parameter
 
 FunctionParameterSyntax SyntaxFactory::
-makeFunctionParameter(RC<TokenSyntax> ExternalName,
-                      RC<TokenSyntax> LocalName,
-                      RC<TokenSyntax> Colon,
+makeFunctionParameter(TokenSyntax ExternalName,
+                      TokenSyntax LocalName,
+                      TokenSyntax Colon,
                       llvm::Optional<TypeSyntax> ParameterTypeSyntax,
-                      RC<TokenSyntax> Ellipsis,
-                      RC<TokenSyntax> Equal,
+                      TokenSyntax Ellipsis,
+                      TokenSyntax Equal,
                       llvm::Optional<ExprSyntax> DefaultValue,
-                      RC<TokenSyntax> TrailingComma) {
+                      TokenSyntax TrailingComma) {
   auto Raw = RawSyntax::make(SyntaxKind::FunctionParameter,
                              {
-                               ExternalName,
-                               LocalName,
-                               Colon,
+                               ExternalName.getRaw(),
+                               LocalName.getRaw(),
+                               Colon.getRaw(),
                                ParameterTypeSyntax.hasValue()
                                  ? ParameterTypeSyntax.getValue().getRaw()
                                  : RawSyntax::missing(SyntaxKind::MissingType),
-                               Ellipsis,
-                               Equal,
+                               Ellipsis.getRaw(),
+                               Equal.getRaw(),
                                DefaultValue.hasValue()
                                  ? DefaultValue.getValue().getRaw()
                                  : RawSyntax::missing(SyntaxKind::MissingExpr),
-                               TrailingComma,
+                               TrailingComma.getRaw(),
                              },
                              SourcePresence::Present);
   return make<FunctionParameterSyntax>(Raw);
@@ -169,20 +176,20 @@ FunctionParameterListSyntax SyntaxFactory::makeBlankFunctionParameterList() {
 #pragma mark - function-signature
 
 FunctionSignatureSyntax
-SyntaxFactory::makeFunctionSignature(RC<TokenSyntax> LeftParen,
+SyntaxFactory::makeFunctionSignature(TokenSyntax LeftParen,
                                      FunctionParameterListSyntax ParameterList,
-                                     RC<TokenSyntax> RightParen,
-                                     RC<TokenSyntax> ThrowsOrRethrows,
-                                     RC<TokenSyntax> Arrow,
+                                     TokenSyntax RightParen,
+                                     TokenSyntax ThrowsOrRethrows,
+                                     TokenSyntax Arrow,
                                      TypeAttributesSyntax ReturnTypeAttributes,
                                      TypeSyntax ReturnTypeSyntax) {
   auto Raw = RawSyntax::make(SyntaxKind::FunctionSignature,
                              {
-                               LeftParen,
+                               LeftParen.getRaw(),
                                ParameterList.getRaw(),
-                               RightParen,
-                               ThrowsOrRethrows,
-                               Arrow,
+                               RightParen.getRaw(),
+                               ThrowsOrRethrows.getRaw(),
+                               Arrow.getRaw(),
                                ReturnTypeAttributes.getRaw(),
                                ReturnTypeSyntax.getRaw()
                              },
@@ -199,8 +206,8 @@ FunctionSignatureSyntax SyntaxFactory::makeBlankFunctionSignature() {
 FunctionDeclSyntax SyntaxFactory::
 makeFunctionDecl(TypeAttributesSyntax Attributes,
                  DeclModifierListSyntax Modifiers,
-                 RC<TokenSyntax> FuncKeyword,
-                 RC<TokenSyntax> Identifier,
+                 TokenSyntax FuncKeyword,
+                 TokenSyntax Identifier,
                  llvm::Optional<GenericParameterClauseSyntax> GenericParams,
                  FunctionSignatureSyntax Signature,
                  llvm::Optional<GenericWhereClauseSyntax> GenericWhereClause,
@@ -209,8 +216,8 @@ makeFunctionDecl(TypeAttributesSyntax Attributes,
     {
       Attributes.getRaw(),
       Modifiers.getRaw(),
-      FuncKeyword,
-      Identifier,
+      FuncKeyword.getRaw(),
+      Identifier.getRaw(),
       GenericParams.hasValue()
        ? GenericParams.getValue().getRaw()
        : SyntaxFactory::makeBlankGenericParameterClause().getRaw(),
@@ -233,14 +240,14 @@ FunctionDeclSyntax SyntaxFactory::makeBlankFunctionDecl() {
 #pragma mark - Statements
 
 CodeBlockStmtSyntax
-SyntaxFactory::makeCodeBlock(RC<TokenSyntax> LeftBraceToken,
+SyntaxFactory::makeCodeBlock(TokenSyntax LeftBraceToken,
                              StmtListSyntax Elements,
-                             RC<TokenSyntax> RightBraceToken) {
+                             TokenSyntax RightBraceToken) {
   auto Raw = RawSyntax::make(SyntaxKind::CodeBlockStmt,
                              {
-                               LeftBraceToken,
+                               LeftBraceToken.getRaw(),
                                Elements.getRaw(),
-                               RightBraceToken
+                               RightBraceToken.getRaw()
                              }, SourcePresence::Present);
   return make<CodeBlockStmtSyntax>(Raw);
 }
@@ -250,9 +257,9 @@ CodeBlockStmtSyntax SyntaxFactory::makeBlankCodeBlock() {
 }
 
 FallthroughStmtSyntax
-SyntaxFactory::makeFallthroughStmt(RC<TokenSyntax> FallthroughKeyword) {
+SyntaxFactory::makeFallthroughStmt(TokenSyntax FallthroughKeyword) {
   auto Raw = RawSyntax::make(SyntaxKind::FallthroughStmt, {
-    FallthroughKeyword
+    FallthroughKeyword.getRaw()
   }, SourcePresence::Present);
   return make<FallthroughStmtSyntax>(Raw);
 }
@@ -266,12 +273,12 @@ FallthroughStmtSyntax SyntaxFactory::makeBlankFallthroughStmt() {
 /// Make a break statement with the give `break` keyword and
 /// destination label.
 BreakStmtSyntax
-SyntaxFactory::makeBreakStmt(RC<TokenSyntax> BreakKeyword,
-                               RC<TokenSyntax> Label) {
+SyntaxFactory::makeBreakStmt(TokenSyntax BreakKeyword,
+                               TokenSyntax Label) {
   auto Raw = RawSyntax::make(SyntaxKind::BreakStmt,
                              {
-                               BreakKeyword,
-                               Label,
+                               BreakKeyword.getRaw(),
+                               Label.getRaw(),
                              },
                              SourcePresence::Present);
   return make<BreakStmtSyntax>(Raw);
@@ -286,12 +293,12 @@ BreakStmtSyntax SyntaxFactory::makeBlankBreakStmtSyntax() {
 #pragma mark - continue-statement
 
 ContinueStmtSyntax
-SyntaxFactory::makeContinueStmt(RC<TokenSyntax> ContinueKeyword,
-                                RC<TokenSyntax> Label) {
+SyntaxFactory::makeContinueStmt(TokenSyntax ContinueKeyword,
+                                TokenSyntax Label) {
   auto Raw = RawSyntax::make(SyntaxKind::BreakStmt,
                              {
-                               ContinueKeyword,
-                               Label,
+                               ContinueKeyword.getRaw(),
+                               Label.getRaw(),
                              },
                              SourcePresence::Present);
   return make<ContinueStmtSyntax>(Raw);
@@ -308,11 +315,11 @@ ContinueStmtSyntax SyntaxFactory::makeBlankContinueStmtSyntax() {
 /// Make a return statement with the given `return` keyword and returned
 /// expression.
 ReturnStmtSyntax
-SyntaxFactory::makeReturnStmt(RC<TokenSyntax> ReturnKeyword,
+SyntaxFactory::makeReturnStmt(TokenSyntax ReturnKeyword,
                               ExprSyntax ReturnedExpression) {
   auto Raw = RawSyntax::make(SyntaxKind::ReturnStmt,
                              {
-                               ReturnKeyword,
+                               ReturnKeyword.getRaw(),
                                ReturnedExpression.getRaw(),
                              },
                              SourcePresence::Present);
@@ -322,7 +329,7 @@ SyntaxFactory::makeReturnStmt(RC<TokenSyntax> ReturnKeyword,
 ReturnStmtSyntax SyntaxFactory::makeBlankReturnStmt() {
   auto Raw = RawSyntax::make(SyntaxKind::ReturnStmt,
     {
-     TokenSyntax::missingToken(tok::kw_return, "return"),
+     RawTokenSyntax::missingToken(tok::kw_return, "return"),
      RawSyntax::missing(SyntaxKind::MissingExpr),
     },
     SourcePresence::Present);
@@ -353,12 +360,12 @@ StmtListSyntax SyntaxFactory::makeBlankStmtList() {
 #pragma mark - integer-literal-expression
 
 IntegerLiteralExprSyntax
-SyntaxFactory::makeIntegerLiteralExpr(RC<TokenSyntax> Sign,
-                                      RC<TokenSyntax> Digits) {
+SyntaxFactory::makeIntegerLiteralExpr(TokenSyntax Sign,
+                                      TokenSyntax Digits) {
   auto Raw = RawSyntax::make(SyntaxKind::IntegerLiteralExpr,
                              {
-                               Sign,
-                               Digits,
+                               Sign.getRaw(),
+                               Digits.getRaw(),
                              },
                              SourcePresence::Present);
   return make<IntegerLiteralExprSyntax>(Raw);
@@ -367,8 +374,8 @@ SyntaxFactory::makeIntegerLiteralExpr(RC<TokenSyntax> Sign,
 IntegerLiteralExprSyntax SyntaxFactory::makeBlankIntegerLiteralExpr() {
   auto Raw = RawSyntax::make(SyntaxKind::IntegerLiteralExpr,
     {
-     TokenSyntax::missingToken(tok::oper_prefix, "-"),
-     TokenSyntax::missingToken(tok::integer_literal, ""),
+     RawTokenSyntax::missingToken(tok::oper_prefix, "-"),
+     RawTokenSyntax::missingToken(tok::integer_literal, ""),
     },
     SourcePresence::Present);
   return make<IntegerLiteralExprSyntax>(Raw);
@@ -377,11 +384,11 @@ IntegerLiteralExprSyntax SyntaxFactory::makeBlankIntegerLiteralExpr() {
 #pragma mark - symbolic-reference
 
 SymbolicReferenceExprSyntax
-SyntaxFactory::makeSymbolicReferenceExpr(RC<TokenSyntax> Identifier,
+SyntaxFactory::makeSymbolicReferenceExpr(TokenSyntax Identifier,
   llvm::Optional<GenericArgumentClauseSyntax> GenericArgs) {
   auto Raw = RawSyntax::make(SyntaxKind::SymbolicReferenceExpr,
     {
-      Identifier,
+      Identifier.getRaw(),
       GenericArgs.hasValue()
         ? GenericArgs.getValue().getRaw()
         : RawSyntax::missing(SyntaxKind::GenericArgumentClause)
@@ -401,16 +408,16 @@ FunctionCallArgumentSyntax SyntaxFactory::makeBlankFunctionCallArgument() {
 }
 
 FunctionCallArgumentSyntax
-SyntaxFactory::makeFunctionCallArgument(RC<TokenSyntax> Label,
-                                        RC<TokenSyntax> Colon,
+SyntaxFactory::makeFunctionCallArgument(TokenSyntax Label,
+                                        TokenSyntax Colon,
                                         ExprSyntax ExpressionArgument,
-                                        RC<TokenSyntax> TrailingComma) {
+                                        TokenSyntax TrailingComma) {
   auto Raw = RawSyntax::make(SyntaxKind::FunctionCallArgument,
                              {
-                               Label,
-                               Colon,
+                               Label.getRaw(),
+                               Colon.getRaw(),
                                ExpressionArgument.getRaw(),
-                               TrailingComma
+                               TrailingComma.getRaw()
                              },
                              SourcePresence::Present);
   return make<FunctionCallArgumentSyntax>(Raw);
@@ -442,15 +449,15 @@ SyntaxFactory::makeBlankFunctionCallArgumentList() {
 
 FunctionCallExprSyntax
 SyntaxFactory::makeFunctionCallExpr(ExprSyntax CalledExpr,
-                                    RC<TokenSyntax> LeftParen,
+                                    TokenSyntax LeftParen,
                                     FunctionCallArgumentListSyntax Arguments,
-                                    RC<TokenSyntax> RightParen) {
+                                    TokenSyntax RightParen) {
   auto Raw = RawSyntax::make(SyntaxKind::FunctionCallExpr,
                              {
                                CalledExpr.getRaw(),
-                               LeftParen,
+                               LeftParen.getRaw(),
                                Arguments.getRaw(),
-                               RightParen
+                               RightParen.getRaw()
                              },
                              SourcePresence::Present);
   return make<FunctionCallExprSyntax>(Raw);
@@ -463,323 +470,241 @@ FunctionCallExprSyntax SyntaxFactory::makeBlankFunctionCallExpr() {
 
 #pragma mark - Tokens
 
-RC<TokenSyntax>
+TokenSyntax
+SyntaxFactory::makeToken(tok Kind, OwnedString Text, SourcePresence Presence,
+                         const Trivia &LeadingTrivia,
+                         const Trivia &TrailingTrivia) {
+  return make<TokenSyntax>(RawTokenSyntax::make(Kind, Text, Presence,
+                                                LeadingTrivia, TrailingTrivia));
+}
+
+TokenSyntax
 SyntaxFactory::makeStaticKeyword(const Trivia &LeadingTrivia,
                                  const Trivia &TrailingTrivia) {
-  return TokenSyntax::make(tok::kw_static, "static",
-                           SourcePresence::Present,
-                           LeadingTrivia, TrailingTrivia);
+
+  return makeToken(tok::kw_static, "static", SourcePresence::Present,
+                   LeadingTrivia, TrailingTrivia);
 }
 
-RC<TokenSyntax>
+TokenSyntax
 SyntaxFactory::makePublicKeyword(const Trivia &LeadingTrivia,
                                  const Trivia &TrailingTrivia) {
-  return TokenSyntax::make(tok::kw_public, "public",
-                           SourcePresence::Present,
-                           LeadingTrivia, TrailingTrivia);
+  return makeToken(tok::kw_public, "public", SourcePresence::Present,
+                   LeadingTrivia, TrailingTrivia);
 }
 
-RC<TokenSyntax>
+TokenSyntax
 SyntaxFactory::makeFuncKeyword(const Trivia &LeadingTrivia,
                                       const Trivia &TrailingTrivia) {
-  return TokenSyntax::make(tok::kw_func, "func",
-                           SourcePresence::Present,
-                           LeadingTrivia, TrailingTrivia);
+  return makeToken(tok::kw_func, "func", SourcePresence::Present,
+                   LeadingTrivia, TrailingTrivia);
 }
 
-RC<TokenSyntax>
+TokenSyntax
 SyntaxFactory::makeFallthroughKeyword(const Trivia &LeadingTrivia,
                                       const Trivia &TrailingTrivia) {
-  return TokenSyntax::make(tok::kw_fallthrough, "fallthrough",
-                           SourcePresence::Present,
-                           LeadingTrivia, TrailingTrivia);
+  return makeToken(tok::kw_fallthrough, "fallthrough", SourcePresence::Present,
+                   LeadingTrivia, TrailingTrivia);
 }
 
-RC<TokenSyntax>
+TokenSyntax
 SyntaxFactory::makeAtSignToken(const Trivia &LeadingTrivia,
                                const Trivia &TrailingTrivia) {
-  return TokenSyntax::make(tok::at_sign, "@", SourcePresence::Present,
-                           LeadingTrivia, TrailingTrivia);
+  return makeToken(tok::at_sign, "@", SourcePresence::Present,
+                   LeadingTrivia, TrailingTrivia);
 }
 
-RC<TokenSyntax>
+TokenSyntax
 SyntaxFactory::makeBreakKeyword(const swift::syntax::Trivia &LeadingTrivia,
                                 const swift::syntax::Trivia &TrailingTrivia) {
-  return TokenSyntax::make(tok::kw_break, "break", SourcePresence::Present,
-                           LeadingTrivia, TrailingTrivia);
+  return makeToken(tok::kw_break, "break", SourcePresence::Present,
+                   LeadingTrivia, TrailingTrivia);
 }
 
-RC<TokenSyntax> SyntaxFactory::
+TokenSyntax SyntaxFactory::
 makeContinueKeyword(const swift::syntax::Trivia &LeadingTrivia,
                     const swift::syntax::Trivia &TrailingTrivia) {
-  return TokenSyntax::make(tok::kw_continue, "continue",
-                           SourcePresence::Present,
-                           LeadingTrivia, TrailingTrivia);
+  return makeToken(tok::kw_continue, "continue", SourcePresence::Present,
+                   LeadingTrivia, TrailingTrivia);
 }
 
-RC<TokenSyntax> SyntaxFactory::
+TokenSyntax SyntaxFactory::
 makeReturnKeyword(const swift::syntax::Trivia &LeadingTrivia,
                   const swift::syntax::Trivia &TrailingTrivia) {
-  return TokenSyntax::make(tok::kw_return, "return",
-                           SourcePresence::Present,
-                           LeadingTrivia, TrailingTrivia);
+  return makeToken(tok::kw_return, "return", SourcePresence::Present,
+                   LeadingTrivia, TrailingTrivia);
 }
 
-RC<TokenSyntax>
+TokenSyntax
 SyntaxFactory::makeLeftAngleToken(const Trivia &LeadingTrivia,
                                   const Trivia &TrailingTrivia) {
-  return TokenSyntax::make(tok::l_angle, "<", SourcePresence::Present,
-                           LeadingTrivia, TrailingTrivia);
+  return makeToken(tok::l_angle, "<", SourcePresence::Present,
+                   LeadingTrivia, TrailingTrivia);
 }
 
-RC<TokenSyntax>
+TokenSyntax
 SyntaxFactory::makeRightAngleToken(const Trivia &LeadingTrivia,
                                    const Trivia &TrailingTrivia) {
-  return TokenSyntax::make(tok::r_angle, ">", SourcePresence::Present,
-                           LeadingTrivia, TrailingTrivia);
+  return makeToken(tok::r_angle, ">", SourcePresence::Present,
+                   LeadingTrivia, TrailingTrivia);
 }
 
-RC<TokenSyntax>
+TokenSyntax
 SyntaxFactory::makeLeftParenToken(const Trivia &LeadingTrivia,
                                   const Trivia &TrailingTrivia) {
-  return TokenSyntax::make(tok::l_paren, "(", SourcePresence::Present,
-                           LeadingTrivia, TrailingTrivia);
+  return makeToken(tok::l_paren, "(", SourcePresence::Present,
+                   LeadingTrivia, TrailingTrivia);
 }
 
-RC<TokenSyntax>
+TokenSyntax
 SyntaxFactory::makeRightParenToken(const Trivia &LeadingTrivia,
                                    const Trivia &TrailingTrivia) {
-  return TokenSyntax::make(tok::r_paren, ")", SourcePresence::Present,
-                           LeadingTrivia, TrailingTrivia);
+  return makeToken(tok::r_paren, ")", SourcePresence::Present,
+                   LeadingTrivia, TrailingTrivia);
 }
-RC<TokenSyntax>
+TokenSyntax
 SyntaxFactory::makeLeftBraceToken(const Trivia &LeadingTrivia,
                                   const Trivia &TrailingTrivia) {
-  return TokenSyntax::make(tok::l_brace, "{", SourcePresence::Present,
-                           LeadingTrivia, TrailingTrivia);
+  return makeToken(tok::l_brace, "{", SourcePresence::Present,
+                   LeadingTrivia, TrailingTrivia);
 }
 
-RC<TokenSyntax>
+TokenSyntax
 SyntaxFactory::makeRightBraceToken(const Trivia &LeadingTrivia,
                                    const Trivia &TrailingTrivia) {
-  return TokenSyntax::make(tok::r_brace, "}", SourcePresence::Present,
-                           LeadingTrivia, TrailingTrivia);
+  return makeToken(tok::r_brace, "}", SourcePresence::Present,
+                   LeadingTrivia, TrailingTrivia);
 }
 
-RC<TokenSyntax>
+TokenSyntax
 SyntaxFactory::makeLeftSquareBracketToken(const Trivia &LeadingTrivia,
                                           const Trivia &TrailingTrivia) {
-  return TokenSyntax::make(tok::l_square, "[", SourcePresence::Present,
-                           LeadingTrivia, TrailingTrivia);
+  return makeToken(tok::l_square, "[", SourcePresence::Present,
+                   LeadingTrivia, TrailingTrivia);
 }
 
-RC<TokenSyntax>
+TokenSyntax
 SyntaxFactory::makeRightSquareBracketToken(const Trivia &LeadingTrivia,
                                            const Trivia &TrailingTrivia) {
-  return TokenSyntax::make(tok::r_square, "]", SourcePresence::Present,
-                           LeadingTrivia, TrailingTrivia);
+  return makeToken(tok::r_square, "]", SourcePresence::Present,
+                   LeadingTrivia, TrailingTrivia);
 }
 
-RC<TokenSyntax>
+TokenSyntax
 SyntaxFactory::makeQuestionPostfixToken(const Trivia &TrailingTrivia) {
-  return TokenSyntax::make(tok::question_postfix, "?", SourcePresence::Present,
-                           {}, TrailingTrivia);
+  return makeToken(tok::question_postfix, "?", SourcePresence::Present,
+                   {}, TrailingTrivia);
 }
 
-RC<TokenSyntax>
+TokenSyntax
 SyntaxFactory::makeExclaimPostfixToken(const Trivia &TrailingTrivia) {
-  return TokenSyntax::make(tok::exclaim_postfix, "!", SourcePresence::Present,
-                           {}, TrailingTrivia);
+  return makeToken(tok::exclaim_postfix, "!", SourcePresence::Present,
+                   {}, TrailingTrivia);
 }
 
-RC<TokenSyntax> SyntaxFactory::makeIdentifier(OwnedString Name,
+TokenSyntax SyntaxFactory::makeIdentifier(OwnedString Name,
                                            const Trivia &LeadingTrivia,
                                            const Trivia &TrailingTrivia) {
-  return RC<TokenSyntax>{
-    new TokenSyntax {
-      tok::identifier, Name,
-      SourcePresence::Present,
-      LeadingTrivia,
-      TrailingTrivia
-    }
-  };
+  return makeToken(tok::identifier, Name, SourcePresence::Present,
+                   LeadingTrivia, TrailingTrivia);
 }
 
-RC<TokenSyntax> SyntaxFactory::makeCommaToken(const Trivia &LeadingTrivia,
+TokenSyntax SyntaxFactory::makeCommaToken(const Trivia &LeadingTrivia,
                                              const Trivia &TrailingTrivia) {
-  return RC<TokenSyntax>{
-    new TokenSyntax{tok::comma, ",",
-      SourcePresence::Present,
-      LeadingTrivia,
-      TrailingTrivia
-    }
-  };
+  return makeToken(tok::comma, ",", SourcePresence::Present,
+                   LeadingTrivia, TrailingTrivia);
 }
 
-RC<TokenSyntax> SyntaxFactory::makeColonToken(const Trivia &LeadingTrivia,
+TokenSyntax SyntaxFactory::makeColonToken(const Trivia &LeadingTrivia,
                                              const Trivia &TrailingTrivia) {
-  return RC<TokenSyntax> {
-    new TokenSyntax{tok::colon, ":",
-      SourcePresence::Present,
-      LeadingTrivia,
-      TrailingTrivia
-    }
-  };
+  return makeToken(tok::colon, ":", SourcePresence::Present,
+                   LeadingTrivia, TrailingTrivia);
 }
 
-RC<TokenSyntax> SyntaxFactory::makeDotToken(const Trivia &LeadingTrivia,
+TokenSyntax SyntaxFactory::makeDotToken(const Trivia &LeadingTrivia,
                                            const Trivia &TrailingTrivia) {
-  return RC<TokenSyntax> {
-    new TokenSyntax {
-      tok::period, ".",
-      SourcePresence::Present,
-      LeadingTrivia,
-      TrailingTrivia,
-    }
-  };
+  return makeToken(tok::period, ".", SourcePresence::Present,
+                   LeadingTrivia, TrailingTrivia);
 }
 
-RC<TokenSyntax> SyntaxFactory::makeStructKeyword(const Trivia &LeadingTrivia,
+TokenSyntax SyntaxFactory::makeStructKeyword(const Trivia &LeadingTrivia,
                                                  const Trivia &TrailingTrivia) {
-  return RC<TokenSyntax> {
-    new TokenSyntax{tok::kw_struct, "struct",
-      SourcePresence::Present,
-      LeadingTrivia,
-      TrailingTrivia
-    }
-  };
+  return makeToken(tok::kw_struct, "struct", SourcePresence::Present,
+                   LeadingTrivia, TrailingTrivia);
 }
 
-RC<TokenSyntax> SyntaxFactory::makeWhereKeyword(const Trivia &LeadingTrivia,
+TokenSyntax SyntaxFactory::makeWhereKeyword(const Trivia &LeadingTrivia,
                                                 const Trivia &TrailingTrivia) {
-  return RC<TokenSyntax> {
-    new TokenSyntax{tok::kw_where, "where",
-      SourcePresence::Present,
-      LeadingTrivia,
-      TrailingTrivia
-    }
-  };
+  return makeToken(tok::kw_where, "where", SourcePresence::Present,
+                   LeadingTrivia, TrailingTrivia);
 }
 
-RC<TokenSyntax> SyntaxFactory::makeInoutKeyword(const Trivia &LeadingTrivia,
+TokenSyntax SyntaxFactory::makeInoutKeyword(const Trivia &LeadingTrivia,
                                                 const Trivia &TrailingTrivia) {
-  return RC<TokenSyntax> {
-    new TokenSyntax{tok::kw_inout, "inout",
-      SourcePresence::Present,
-      LeadingTrivia,
-      TrailingTrivia
-    }
-  };
+  return makeToken(tok::kw_inout, "inout", SourcePresence::Present,
+                   LeadingTrivia, TrailingTrivia);
 }
 
-RC<TokenSyntax>
+TokenSyntax
 SyntaxFactory::makeThrowsKeyword(const Trivia &LeadingTrivia,
                                  const Trivia &TrailingTrivia) {
-  return RC<TokenSyntax> {
-    new TokenSyntax {
-      tok::kw_throws, "throws",
-      SourcePresence::Present,
-      LeadingTrivia,
-      TrailingTrivia
-    }
-  };
+  return makeToken(tok::kw_throws, "throws", SourcePresence::Present,
+                   LeadingTrivia, TrailingTrivia);
 }
 
-RC<TokenSyntax>
+TokenSyntax
 SyntaxFactory::makeRethrowsKeyword(const Trivia &LeadingTrivia,
                                    const Trivia &TrailingTrivia) {
-  return RC<TokenSyntax> {
-    new TokenSyntax {
-      tok::kw_rethrows, "rethrows",
-      SourcePresence::Present,
-      LeadingTrivia,
-      TrailingTrivia
-    }
-  };
+  return makeToken(tok::kw_rethrows, "rethrows", SourcePresence::Present,
+                   LeadingTrivia, TrailingTrivia);
 }
 
-RC<TokenSyntax>
+TokenSyntax
 SyntaxFactory::makeTypealiasKeyword(const Trivia &LeadingTrivia,
                                     const Trivia &TrailingTrivia) {
-  return RC<TokenSyntax> {
-    new TokenSyntax {
-      tok::kw_typealias, "typealias",
-      SourcePresence::Present,
-      LeadingTrivia,
-      TrailingTrivia
-    }
-  };
+  return makeToken(tok::kw_typealias, "typealias", SourcePresence::Present,
+                   LeadingTrivia, TrailingTrivia);
 }
 
-RC<TokenSyntax>
+TokenSyntax
 SyntaxFactory::makeEqualToken(const Trivia &LeadingTrivia,
                               const Trivia &TrailingTrivia) {
-  return RC<TokenSyntax> {
-    new TokenSyntax{tok::equal, "=",
-      SourcePresence::Present,
-      LeadingTrivia,
-      TrailingTrivia
-    }
-  };
+  return makeToken(tok::equal, "=", SourcePresence::Present,
+                   LeadingTrivia, TrailingTrivia);
 }
 
-RC<TokenSyntax> SyntaxFactory::makeArrow(const Trivia &LeadingTrivia,
+TokenSyntax SyntaxFactory::makeArrow(const Trivia &LeadingTrivia,
                                       const Trivia &TrailingTrivia) {
-  return RC<TokenSyntax> {
-    new TokenSyntax{tok::arrow, "->",
-      SourcePresence::Present,
-      LeadingTrivia,
-      TrailingTrivia
-    }
-  };
+  return makeToken(tok::arrow, "->", SourcePresence::Present,
+                   LeadingTrivia, TrailingTrivia);
 }
 
-RC<TokenSyntax>
+TokenSyntax
 SyntaxFactory::makeEqualityOperator(const Trivia &LeadingTrivia,
                                     const Trivia &TrailingTrivia) {
-  return RC<TokenSyntax> {
-    new TokenSyntax {
-      tok::oper_binary_spaced, "==",
-      SourcePresence::Present,
-      LeadingTrivia,
-      TrailingTrivia
-    }
-  };
+  return makeToken(tok::oper_binary_spaced, "==", SourcePresence::Present,
+                   LeadingTrivia, TrailingTrivia);
 }
 
-RC<TokenSyntax> SyntaxFactory::makeTypeToken(const Trivia &LeadingTrivia,
+TokenSyntax SyntaxFactory::makeTypeToken(const Trivia &LeadingTrivia,
                                           const Trivia &TrailingTrivia) {
-  return RC<TokenSyntax> {
-    new TokenSyntax {
-      tok::identifier, "Type",
-      SourcePresence::Present,
-      LeadingTrivia,
-      TrailingTrivia
-    }
-  };
+  return makeToken(tok::identifier, "Type", SourcePresence::Present,
+                   LeadingTrivia, TrailingTrivia);
 }
 
-RC<TokenSyntax>
+TokenSyntax
 SyntaxFactory::makeProtocolToken(const Trivia &LeadingTrivia,
                                  const Trivia &TrailingTrivia) {
-  return RC<TokenSyntax> {
-    new TokenSyntax{tok::identifier, "Protocol",
-      SourcePresence::Present,
-      LeadingTrivia,
-      TrailingTrivia
-    }
-  };
+  return makeToken(tok::identifier, "Protocol", SourcePresence::Present,
+                   LeadingTrivia, TrailingTrivia);
 }
 
-RC<TokenSyntax>
+TokenSyntax
 SyntaxFactory::makeIntegerLiteralToken(OwnedString Digits,
                                        const Trivia &LeadingTrivia,
                                        const Trivia &TrailingTrivia) {
-  return RC<TokenSyntax> {
-    new TokenSyntax(tok::integer_literal, Digits, SourcePresence::Present,
-                    LeadingTrivia,
-                    TrailingTrivia)
-  };
+  return makeToken(tok::integer_literal, Digits, SourcePresence::Present,
+                   LeadingTrivia, TrailingTrivia);
 }
 
 #pragma mark - Generics
@@ -804,10 +729,12 @@ SyntaxFactory::makeGenericParameter(OwnedString TypeName,
                                     const Trivia &TrailingTrivia) {
   auto Raw = RawSyntax::make(SyntaxKind::GenericParameter,
                              {
-                               SyntaxFactory::makeIdentifier(TypeName,
-                                                             LeadingTrivia,
-                                                             TrailingTrivia),
-                               TokenSyntax::missingToken(tok::colon, ":"),
+                               RawTokenSyntax::make(tok::identifier,
+                                                    TypeName,
+                                                    SourcePresence::Present,
+                                                    LeadingTrivia,
+                                                    TrailingTrivia),
+                               RawTokenSyntax::missingToken(tok::colon, ":"),
                                RawSyntax::missing(SyntaxKind::TypeIdentifier),
                              },
                              SourcePresence::Present);
@@ -816,12 +743,12 @@ SyntaxFactory::makeGenericParameter(OwnedString TypeName,
 
 SameTypeRequirementSyntax SyntaxFactory::
 makeSameTypeRequirement( TypeIdentifierSyntax LeftTypeIdentifier,
-                        RC<TokenSyntax> EqualityToken,
+                        TokenSyntax EqualityToken,
                         TypeSyntax RightType) {
   auto Raw = RawSyntax::make(SyntaxKind::SameTypeRequirement,
                              {
                                LeftTypeIdentifier.getRaw(),
-                               EqualityToken,
+                               EqualityToken.getRaw(),
                                RightType.getRaw()
                              },
                              SourcePresence::Present);
@@ -850,11 +777,11 @@ GenericRequirementListSyntax SyntaxFactory::makeBlankGenericRequirementList() {
 #pragma mark - Operators
 
 /// Make a prefix operator with the given text.
-RC<TokenSyntax>
+TokenSyntax
 SyntaxFactory::makePrefixOperator(OwnedString Name,
                                    const Trivia &LeadingTrivia) {
-  return TokenSyntax::make(tok::oper_prefix, Name,
-                           SourcePresence::Present, LeadingTrivia, {});
+  return makeToken(tok::oper_prefix, Name,
+                   SourcePresence::Present, LeadingTrivia, {});
 }
 
 #pragma mark - Types
@@ -862,18 +789,18 @@ SyntaxFactory::makePrefixOperator(OwnedString Name,
 #pragma mark - type-attribute
 
 TypeAttributeSyntax
-SyntaxFactory::makeTypeAttribute(RC<TokenSyntax> AtSignToken,
-                                RC<TokenSyntax> Identifier,
-                                RC<TokenSyntax> LeftParen,
+SyntaxFactory::makeTypeAttribute(TokenSyntax AtSignToken,
+                                TokenSyntax Identifier,
+                                TokenSyntax LeftParen,
                                 BalancedTokensSyntax BalancedTokens,
-                                RC<TokenSyntax> RightParen) {
+                                TokenSyntax RightParen) {
   auto Raw = RawSyntax::make(SyntaxKind::TypeAttribute,
                              {
-                               AtSignToken,
-                               Identifier,
-                               LeftParen,
+                               AtSignToken.getRaw(),
+                               Identifier.getRaw(),
+                               LeftParen.getRaw(),
                                BalancedTokens.getRaw(),
-                               RightParen,
+                               RightParen.getRaw(),
                              },
                              SourcePresence::Present);
   return make<TypeAttributeSyntax>(Raw);
@@ -888,9 +815,13 @@ TypeAttributeSyntax SyntaxFactory::makeBlankTypeAttribute() {
 #pragma mark - balanced-tokens
 
 BalancedTokensSyntax
-SyntaxFactory::makeBalancedTokens(RawSyntax::LayoutList Tokens) {
+SyntaxFactory::makeBalancedTokens(llvm::ArrayRef<TokenSyntax> Tokens) {
+  RawSyntax::LayoutList RawTokens;
+  for (auto &Tok : Tokens) {
+    RawTokens.push_back(Tok.getRaw());
+  }
   auto Raw = RawSyntax::make(SyntaxKind::BalancedTokens,
-                             Tokens,
+                             RawTokens,
                              SourcePresence::Present);
   return make<BalancedTokensSyntax>(Raw);
 }
@@ -908,9 +839,13 @@ SyntaxFactory::makeTypeIdentifier(OwnedString Name,
   auto Raw = RawSyntax::make(
                              SyntaxKind::TypeIdentifier,
                              {
-                               SyntaxFactory::makeIdentifier(Name, LeadingTrivia, TrailingTrivia),
+                               RawTokenSyntax::make(tok::identifier,
+                                                    Name,
+                                                    SourcePresence::Present,
+                                                    LeadingTrivia,
+                                                    TrailingTrivia),
                                RawSyntax::missing(SyntaxKind::GenericArgumentClause),
-                               TokenSyntax::missingToken(tok::period, "."),
+                               RawTokenSyntax::missingToken(tok::period, "."),
                                RawSyntax::missing(SyntaxKind::TypeIdentifier),
                              },
                              SourcePresence::Present);
@@ -928,12 +863,12 @@ TypeIdentifierSyntax SyntaxFactory::makeSelfTypeIdentifier() {
 }
 
 TypeIdentifierSyntax
-SyntaxFactory::makeTypeIdentifier(RC<TokenSyntax> Identifier,
+SyntaxFactory::makeTypeIdentifier(TokenSyntax Identifier,
                                   GenericArgumentClauseSyntax GenericArgs) {
   auto Raw = RawSyntax::make(SyntaxKind::TypeIdentifier,
                              {
-                               Identifier, GenericArgs.getRaw(),
-                               TokenSyntax::missingToken(tok::period, "."),
+                               Identifier.getRaw(), GenericArgs.getRaw(),
+                               RawTokenSyntax::missingToken(tok::period, "."),
                                RawSyntax::missing(SyntaxKind::TypeIdentifier),
                              },
                              SourcePresence::Present);
@@ -945,35 +880,33 @@ SyntaxFactory::makeTypeIdentifier(RC<TokenSyntax> Identifier,
 TupleTypeSyntax SyntaxFactory::makeVoidTupleType() {
   auto Raw = RawSyntax::make(SyntaxKind::TupleType,
     {
-      SyntaxFactory::makeLeftParenToken({}, {}),
+      SyntaxFactory::makeLeftParenToken({}, {}).getRaw(),
       RawSyntax::missing(SyntaxKind::TupleTypeElementList),
-      SyntaxFactory::makeRightParenToken({}, {}),
+      SyntaxFactory::makeRightParenToken({}, {}).getRaw(),
     },
     SourcePresence::Present);
   return make<TupleTypeSyntax>(Raw);
 }
 
 TupleTypeSyntax
-SyntaxFactory::makeTupleType(RC<TokenSyntax> LParen,
+SyntaxFactory::makeTupleType(TokenSyntax LParen,
                              TupleTypeElementListSyntax Elements,
-                             RC<TokenSyntax> RParen) {
+                             TokenSyntax RParen) {
   auto Raw = RawSyntax::make(SyntaxKind::TupleType,
-                             { LParen, Elements.getRaw(), RParen },
+                             { LParen.getRaw(),
+                               Elements.getRaw(),
+                               RParen.getRaw() },
                              SourcePresence::Present);
   return make<TupleTypeSyntax>(Raw);
 }
 
 TupleTypeElementSyntax
-SyntaxFactory::makeTupleTypeElement(RC<TokenSyntax> Name,
-                                    RC<TokenSyntax> Colon,
+SyntaxFactory::makeTupleTypeElement(TokenSyntax Name,
+                                    TokenSyntax Colon,
                                     TypeSyntax ElementTypeSyntax,
-                                    Optional<RC<TokenSyntax>> MaybeComma) {
-  RC<TokenSyntax> Comma;
-  if (MaybeComma.hasValue()) {
-    Comma = MaybeComma.getValue();
-  } else {
-    Comma = TokenSyntax::missingToken(tok::comma, ",");
-  }
+                                    Optional<TokenSyntax> MaybeComma) {
+  TokenSyntax Comma = MaybeComma.getValueOr(
+                        TokenSyntax::missingToken(tok::comma, ","));
   return TupleTypeElementSyntax::makeBlank()
     .withLabel(Name)
     .withColonToken(Colon)
@@ -984,13 +917,9 @@ SyntaxFactory::makeTupleTypeElement(RC<TokenSyntax> Name,
 
 TupleTypeElementSyntax
 SyntaxFactory::makeTupleTypeElement(TypeSyntax ElementType,
-                                    Optional<RC<TokenSyntax>> MaybeComma) {
-  RC<TokenSyntax> Comma;
-  if (MaybeComma.hasValue()) {
-    Comma = MaybeComma.getValue();
-  } else {
-    Comma = TokenSyntax::missingToken(tok::comma, ",");
-  }
+                                    Optional<TokenSyntax> MaybeComma) {
+  TokenSyntax Comma = MaybeComma.getValueOr(
+                        TokenSyntax::missingToken(tok::comma, ","));
   return TupleTypeElementSyntax::makeBlank()
     .withTypeSyntax(ElementType)
     .withCommaToken(Comma);
@@ -1011,7 +940,7 @@ SyntaxFactory::makeOptionalType(TypeSyntax BaseType,
   auto Raw = RawSyntax::make(SyntaxKind::OptionalType,
   {
     BaseType.getRaw(),
-    SyntaxFactory::makeQuestionPostfixToken(TrailingTrivia),
+    SyntaxFactory::makeQuestionPostfixToken(TrailingTrivia).getRaw(),
   },
   SourcePresence::Present);
 
@@ -1030,7 +959,7 @@ makeImplicitlyUnwrappedOptionalType(TypeSyntax BaseType,
   auto Raw = RawSyntax::make(SyntaxKind::ImplicitlyUnwrappedOptionalType,
     {
       BaseType.getRaw(),
-      SyntaxFactory::makeExclaimPostfixToken(TrailingTrivia),
+      SyntaxFactory::makeExclaimPostfixToken(TrailingTrivia).getRaw(),
     },
     SourcePresence::Present);
   return make<ImplicitlyUnwrappedOptionalTypeSyntax>(Raw);
@@ -1044,13 +973,13 @@ SyntaxFactory::makeBlankImplicitlyUnwrappedOptionalType() {
 #pragma mark - metatype-type
 
 MetatypeTypeSyntax SyntaxFactory::makeMetatypeType(TypeSyntax BaseType,
-                                                   RC<TokenSyntax> DotToken,
-                                                   RC<TokenSyntax> TypeToken) {
+                                                   TokenSyntax DotToken,
+                                                   TokenSyntax TypeToken) {
   auto Raw = RawSyntax::make(SyntaxKind::MetatypeType,
                              {
                                BaseType.getRaw(),
-                               DotToken,
-                               TypeToken
+                               DotToken.getRaw(),
+                               TypeToken.getRaw()
                              },
                              SourcePresence::Present);
   return make<MetatypeTypeSyntax>(Raw);
@@ -1063,19 +992,19 @@ MetatypeTypeSyntax SyntaxFactory::makeBlankMetatypeType() {
 #pragma mark - function-type
 
 FunctionTypeSyntax SyntaxFactory::makeFunctionType(
-    TypeAttributesSyntax TypeAttributes, RC<TokenSyntax> LeftParen,
-    FunctionParameterListSyntax ArgumentList, RC<TokenSyntax> RightParen,
-    RC<TokenSyntax> ThrowsOrRethrows, RC<TokenSyntax> Arrow,
+    TypeAttributesSyntax TypeAttributes, TokenSyntax LeftParen,
+    FunctionParameterListSyntax ArgumentList, TokenSyntax RightParen,
+    TokenSyntax ThrowsOrRethrows, TokenSyntax Arrow,
     TypeSyntax ReturnType) {
   auto Raw =
       RawSyntax::make(SyntaxKind::FunctionType,
                       {
                         TypeAttributes.getRaw(),
-                        LeftParen,
+                        LeftParen.getRaw(),
                         ArgumentList.getRaw(),
-                        RightParen,
-                        ThrowsOrRethrows,
-                        Arrow,
+                        RightParen.getRaw(),
+                        ThrowsOrRethrows.getRaw(),
+                        Arrow.getRaw(),
                         ReturnType.getRaw()
                       },
                       SourcePresence::Present);
@@ -1089,35 +1018,37 @@ FunctionTypeSyntax SyntaxFactory::makeBlankFunctionType() {
 #pragma mark - function-type-argument
 
 FunctionTypeArgumentSyntax SyntaxFactory::
-makeFunctionTypeArgument(RC<TokenSyntax> ExternalParameterName,
-                         RC<TokenSyntax> LocalParameterName,
+makeFunctionTypeArgument(TokenSyntax ExternalParameterName,
+                         TokenSyntax LocalParameterName,
                          TypeAttributesSyntax TypeAttributes,
-                         RC<TokenSyntax> InoutKeyword,
-                         RC<TokenSyntax> ColonToken,
+                         TokenSyntax InoutKeyword,
+                         TokenSyntax ColonToken,
                          TypeSyntax ParameterTypeSyntax) {
   auto Raw = RawSyntax::make(SyntaxKind::FunctionTypeArgument,
                              {
-                               ExternalParameterName,
-                               LocalParameterName,
+                               ExternalParameterName.getRaw(),
+                               LocalParameterName.getRaw(),
                                TypeAttributes.getRaw(),
-                               InoutKeyword,
-                               ColonToken,
+                               InoutKeyword.getRaw(),
+                               ColonToken.getRaw(),
                                ParameterTypeSyntax.getRaw()
                              }, SourcePresence::Present);
   return make<FunctionTypeArgumentSyntax>(Raw);
 }
 
 FunctionTypeArgumentSyntax SyntaxFactory::
-makeFunctionTypeArgument(RC<TokenSyntax> LocalParameterName,
-                         RC<TokenSyntax> ColonToken,
+makeFunctionTypeArgument(TokenSyntax LocalParameterName,
+                         TokenSyntax ColonToken,
                          swift::syntax::TypeSyntax TypeArgument) {
   auto Raw = RawSyntax::make(SyntaxKind::FunctionTypeArgument,
                              {
-                               TokenSyntax::missingToken(tok::identifier, ""),
-                               LocalParameterName,
+                               RawTokenSyntax::missingToken(tok::identifier,
+                                                            ""),
+                               LocalParameterName.getRaw(),
                                RawSyntax::missing(SyntaxKind::TypeAttributes),
-                               TokenSyntax::missingToken(tok::kw_inout, "inout"),
-                               ColonToken,
+                               RawTokenSyntax::missingToken(tok::kw_inout,
+                                                            "inout"),
+                               ColonToken.getRaw(),
                                TypeArgument.getRaw()
                              }, SourcePresence::Present);
   return make<FunctionTypeArgumentSyntax>(Raw);
@@ -1127,11 +1058,11 @@ FunctionTypeArgumentSyntax
 SyntaxFactory::makeFunctionTypeArgument(TypeSyntax TypeArgument) {
   auto Raw = RawSyntax::make(SyntaxKind::FunctionTypeArgument,
     {
-      TokenSyntax::missingToken(tok::identifier, ""),
-      TokenSyntax::missingToken(tok::identifier, ""),
+      RawTokenSyntax::missingToken(tok::identifier, ""),
+      RawTokenSyntax::missingToken(tok::identifier, ""),
       RawSyntax::missing(SyntaxKind::TypeAttributes),
-      TokenSyntax::missingToken(tok::kw_inout, "inout"),
-      TokenSyntax::missingToken(tok::colon, ":"),
+      RawTokenSyntax::missingToken(tok::kw_inout, "inout"),
+      RawTokenSyntax::missingToken(tok::colon, ":"),
       TypeArgument.getRaw()
     }, SourcePresence::Present);
   return make<FunctionTypeArgumentSyntax>(Raw);
@@ -1151,14 +1082,14 @@ TupleTypeElementListSyntax SyntaxFactory::makeBlankTupleTypeElementList() {
 #pragma mark - array-type
 
 ArrayTypeSyntax
-SyntaxFactory::makeArrayType(RC<TokenSyntax> LeftSquareBracket,
+SyntaxFactory::makeArrayType(TokenSyntax LeftSquareBracket,
                              TypeSyntax ElementType,
-                             RC<TokenSyntax> RightSquareBracket) {
+                             TokenSyntax RightSquareBracket) {
   auto Raw = RawSyntax::make(SyntaxKind::ArrayType,
                              {
-                               LeftSquareBracket,
+                               LeftSquareBracket.getRaw(),
                                ElementType.getRaw(),
-                               RightSquareBracket
+                               RightSquareBracket.getRaw()
                              },
                              SourcePresence::Present);
   return make<ArrayTypeSyntax>(Raw);
@@ -1171,18 +1102,18 @@ ArrayTypeSyntax SyntaxFactory::makeBlankArrayType() {
 #pragma mark - dictionary-type
 
 DictionaryTypeSyntax
-SyntaxFactory::makeDictionaryType(RC<TokenSyntax> LeftSquareBracket,
+SyntaxFactory::makeDictionaryType(TokenSyntax LeftSquareBracket,
                                   TypeSyntax KeyType,
-                                  RC<TokenSyntax> Colon,
+                                  TokenSyntax Colon,
                                   TypeSyntax ValueType,
-                                  RC<TokenSyntax> RightSquareBracket) {
+                                  TokenSyntax RightSquareBracket) {
   auto Raw = RawSyntax::make(SyntaxKind::DictionaryType,
                              {
-                               LeftSquareBracket,
+                               LeftSquareBracket.getRaw(),
                                KeyType.getRaw(),
-                               Colon,
+                               Colon.getRaw(),
                                ValueType.getRaw(),
-                               RightSquareBracket
+                               RightSquareBracket.getRaw()
                              },
                              SourcePresence::Present);
   return make<DictionaryTypeSyntax>(Raw);

--- a/lib/Syntax/TypeSyntax.cpp
+++ b/lib/Syntax/TypeSyntax.cpp
@@ -38,24 +38,24 @@ BalancedTokensSyntax BalancedTokensSyntax::makeBlank() {
 #pragma mark - balanced-tokens API
 
 BalancedTokensSyntax
-BalancedTokensSyntax::addBalancedToken(RC<TokenSyntax> NewBalancedToken) const {
+BalancedTokensSyntax::addBalancedToken(TokenSyntax NewBalancedToken) const {
 #ifndef NDEBUG
-  assert(NewBalancedToken->getTokenKind() != tok::l_paren);
-  assert(NewBalancedToken->getTokenKind() != tok::r_paren);
-  assert(NewBalancedToken->getTokenKind() != tok::l_square);
-  assert(NewBalancedToken->getTokenKind() != tok::r_square);
-  assert(NewBalancedToken->getTokenKind() != tok::l_brace);
-  assert(NewBalancedToken->getTokenKind() != tok::r_brace);
-  auto IsIdentifier = NewBalancedToken->getTokenKind() == tok::identifier;
-  auto IsKeyword = NewBalancedToken->isKeyword();
-  auto IsLiteral = NewBalancedToken->isLiteral();
-  auto IsOperator = NewBalancedToken->isOperator();
-  auto IsPunctuation = NewBalancedToken->isPunctuation();
+  assert(NewBalancedToken.getTokenKind() != tok::l_paren);
+  assert(NewBalancedToken.getTokenKind() != tok::r_paren);
+  assert(NewBalancedToken.getTokenKind() != tok::l_square);
+  assert(NewBalancedToken.getTokenKind() != tok::r_square);
+  assert(NewBalancedToken.getTokenKind() != tok::l_brace);
+  assert(NewBalancedToken.getTokenKind() != tok::r_brace);
+  auto IsIdentifier = NewBalancedToken.getTokenKind() == tok::identifier;
+  auto IsKeyword = NewBalancedToken.isKeyword();
+  auto IsLiteral = NewBalancedToken.isLiteral();
+  auto IsOperator = NewBalancedToken.isOperator();
+  auto IsPunctuation = NewBalancedToken.isPunctuation();
   assert(IsIdentifier || IsKeyword || IsLiteral || IsOperator ||
          IsPunctuation);
 #endif
   auto Layout = getRaw()->Layout;
-  Layout.push_back(NewBalancedToken);
+  Layout.push_back(NewBalancedToken.getRaw());
 
   auto NewRaw = RawSyntax::make(SyntaxKind::BalancedTokens, Layout,
                                 SourcePresence::Present);
@@ -90,34 +90,34 @@ void TypeAttributeSyntax::validate() const {
 TypeAttributeSyntax TypeAttributeSyntax::makeBlank() {
   auto Raw = RawSyntax::make(SyntaxKind::TypeAttribute,
                              {
-                               TokenSyntax::missingToken(tok::at_sign, "@"),
-                               TokenSyntax::missingToken(tok::identifier, ""),
-                               TokenSyntax::missingToken(tok::l_paren, "("),
+                               RawTokenSyntax::missingToken(tok::at_sign, "@"),
+                               RawTokenSyntax::missingToken(tok::identifier, ""),
+                               RawTokenSyntax::missingToken(tok::l_paren, "("),
                                RawSyntax::missing(SyntaxKind::BalancedTokens),
-                               TokenSyntax::missingToken(tok::r_paren, ")"),
+                               RawTokenSyntax::missingToken(tok::r_paren, ")"),
                              },
                              SourcePresence::Present);
   return make<TypeAttributeSyntax>(Raw);
 }
 
 TypeAttributeSyntax
-TypeAttributeSyntax::withAtSignToken(RC<TokenSyntax> NewAtSignToken) const {
+TypeAttributeSyntax::withAtSignToken(TokenSyntax NewAtSignToken) const {
   syntax_assert_token_is(NewAtSignToken, tok::at_sign, "@");
-  return Data->replaceChild<TypeAttributeSyntax>(NewAtSignToken,
+  return Data->replaceChild<TypeAttributeSyntax>(NewAtSignToken.getRaw(),
                                                  Cursor::AtSignToken);
 }
 
 TypeAttributeSyntax
-TypeAttributeSyntax::withIdentifier(RC<TokenSyntax> NewIdentifier) const {
-  assert(NewIdentifier->getTokenKind() == tok::identifier);
-  return Data->replaceChild<TypeAttributeSyntax>(NewIdentifier,
+TypeAttributeSyntax::withIdentifier(TokenSyntax NewIdentifier) const {
+  assert(NewIdentifier.getTokenKind() == tok::identifier);
+  return Data->replaceChild<TypeAttributeSyntax>(NewIdentifier.getRaw(),
                                                  Cursor::Identifier);
 };
 
 TypeAttributeSyntax TypeAttributeSyntax::
-withLeftParenToken(RC<TokenSyntax> NewLeftParenToken) const {
-  assert(NewLeftParenToken->getTokenKind() == tok::l_paren);
-  return Data->replaceChild<TypeAttributeSyntax>(NewLeftParenToken,
+withLeftParenToken(TokenSyntax NewLeftParenToken) const {
+  assert(NewLeftParenToken.getTokenKind() == tok::l_paren);
+  return Data->replaceChild<TypeAttributeSyntax>(NewLeftParenToken.getRaw(),
                                                  Cursor::LeftParenToken);
 };
 
@@ -128,9 +128,9 @@ withBalancedTokens(BalancedTokensSyntax NewBalancedTokens) const {
 }
 
 TypeAttributeSyntax TypeAttributeSyntax::
-withRightParenToken(RC<TokenSyntax> NewRightParenToken) const {
-  assert(NewRightParenToken->getTokenKind() == tok::r_paren);
-  return Data->replaceChild<TypeAttributeSyntax>(NewRightParenToken,
+withRightParenToken(TokenSyntax NewRightParenToken) const {
+  assert(NewRightParenToken.getTokenKind() == tok::r_paren);
+  return Data->replaceChild<TypeAttributeSyntax>(NewRightParenToken.getRaw(),
                                                  Cursor::RightParenToken);
 };
 
@@ -156,9 +156,9 @@ TypeIdentifierSyntax TypeIdentifierSyntax::makeBlank() {
   return make<TypeIdentifierSyntax>(RawSyntax::make(
     SyntaxKind::TypeIdentifier,
     {
-      TokenSyntax::missingToken(tok::identifier, ""),
+      RawTokenSyntax::missingToken(tok::identifier, ""),
       RawSyntax::missing(SyntaxKind::GenericArgumentClause),
-      TokenSyntax::missingToken(tok::period, "."),
+      RawTokenSyntax::missingToken(tok::period, "."),
       RawSyntax::missing(SyntaxKind::TypeIdentifier),
     },
     SourcePresence::Present));
@@ -171,7 +171,7 @@ TypeIdentifierSyntax::addChildType(TypeIdentifierSyntax ChildType) const {
   if (MaybeChild->isMissing()) {
     auto NewRaw =
         getRaw()->replaceChild(Cursor::DotToken,
-                               SyntaxFactory::makeDotToken({}, {}))
+                               SyntaxFactory::makeDotToken({}, {}).getRaw())
             ->replaceChild(Cursor::ChildTypeIdentifier, ChildType.getRaw());
 
     return Data->replaceSelf<TypeIdentifierSyntax>(NewRaw);
@@ -185,18 +185,17 @@ TypeIdentifierSyntax::addChildType(TypeIdentifierSyntax ChildType) const {
 }
 
 TypeIdentifierSyntax
-TypeIdentifierSyntax::withIdentifier(RC<TokenSyntax> NewIdentifier) const {
-  assert(NewIdentifier->getTokenKind() == tok::identifier);
-  auto NewRaw = getRaw()->replaceChild(Cursor::Identifier,
-                                               NewIdentifier);
-  return Data->replaceSelf<TypeIdentifierSyntax>(NewRaw);
+TypeIdentifierSyntax::withIdentifier(TokenSyntax NewIdentifier) const {
+  assert(NewIdentifier.getTokenKind() == tok::identifier);
+  return Data->replaceChild<TypeIdentifierSyntax>(NewIdentifier.getRaw(),
+                                                  Cursor::Identifier);
 }
 
 TypeIdentifierSyntax
-TypeIdentifierSyntax::withDotToken(RC<TokenSyntax> NewDotToken) const {
+TypeIdentifierSyntax::withDotToken(TokenSyntax NewDotToken) const {
   syntax_assert_token_is(NewDotToken, tok::period, ".");
-  auto NewRaw = getRaw()->replaceChild(Cursor::DotToken, NewDotToken);
-  return Data->replaceSelf<TypeIdentifierSyntax>(NewRaw);
+  return Data->replaceChild<TypeIdentifierSyntax>(NewDotToken.getRaw(),
+                                                  Cursor::DotToken);
 }
 
 #pragma mark - tuple-type API
@@ -220,17 +219,18 @@ TupleTypeSyntax::makeBlank() {
   return make<TupleTypeSyntax>(
       RawSyntax::make(SyntaxKind::TupleType,
                       {
-                        TokenSyntax::missingToken(tok::l_paren, "("),
+                        RawTokenSyntax::missingToken(tok::l_paren, "("),
                         RawSyntax::missing(SyntaxKind::TupleTypeElementList),
-                        TokenSyntax::missingToken(tok::r_paren, ")"),
+                        RawTokenSyntax::missingToken(tok::r_paren, ")"),
                       },
                       SourcePresence::Present));
 }
 
 TupleTypeSyntax
-TupleTypeSyntax::withLeftParen(RC<TokenSyntax> NewLeftParen) const {
+TupleTypeSyntax::withLeftParen(TokenSyntax NewLeftParen) const {
   syntax_assert_token_is(NewLeftParen, tok::l_paren, "(");
-  auto NewRaw = getRaw()->replaceChild(Cursor::LeftParenToken, NewLeftParen);
+  auto NewRaw = getRaw()->replaceChild(Cursor::LeftParenToken,
+                                       NewLeftParen.getRaw());
   return Data->replaceSelf<TupleTypeSyntax>(NewRaw);
 }
 
@@ -242,10 +242,10 @@ withTypeElementList(TupleTypeElementListSyntax NewTypeElementList) const {
 }
 
 TupleTypeSyntax TupleTypeSyntax::
-withRightParen(RC<TokenSyntax> NewRightParen) const {
+withRightParen(TokenSyntax NewRightParen) const {
   syntax_assert_token_is(NewRightParen, tok::r_paren, ")");
-  auto NewRaw = getRaw()->replaceChild(Cursor::RightParenToken, NewRightParen);
-  return Data->replaceSelf<TupleTypeSyntax>(NewRaw);
+  return Data->replaceChild<TupleTypeSyntax>(NewRightParen.getRaw(),
+                                             Cursor::RightParenToken);
 }
 
 #pragma mark - tuple-type Builder
@@ -261,14 +261,14 @@ addElementTypeSyntax(TupleTypeElementSyntax ElementTypeSyntax) {
 }
 
 TupleTypeSyntaxBuilder &
-TupleTypeSyntaxBuilder::useLeftParen(RC<TokenSyntax> LeftParen) {
-  LeftParenToken = LeftParen;
+TupleTypeSyntaxBuilder::useLeftParen(TokenSyntax LeftParen) {
+  LeftParenToken = LeftParen.getRaw();
   return *this;
 }
 
 TupleTypeSyntaxBuilder &
-TupleTypeSyntaxBuilder::useRightParen(RC<TokenSyntax> RightParen) {
-  RightParenToken = RightParen;
+TupleTypeSyntaxBuilder::useRightParen(TokenSyntax RightParen) {
+  RightParenToken = RightParen.getRaw();
   return *this;
 }
 
@@ -313,57 +313,57 @@ TupleTypeElementSyntax TupleTypeElementSyntax::makeBlank() {
   return make<TupleTypeElementSyntax>(
       RawSyntax::make(SyntaxKind::TupleTypeElement,
                       {
-                        TokenSyntax::missingToken(tok::identifier, ""),
-                        TokenSyntax::missingToken(tok::colon, ":"),
+                        RawTokenSyntax::missingToken(tok::identifier, ""),
+                        RawTokenSyntax::missingToken(tok::colon, ":"),
                         RawSyntax::missing(SyntaxKind::TypeAttributes),
-                        TokenSyntax::missingToken(tok::kw_inout, "inout"),
+                        RawTokenSyntax::missingToken(tok::kw_inout, "inout"),
                         RawSyntax::missing(SyntaxKind::MissingType),
-                        TokenSyntax::missingToken(tok::comma, ","),
+                        RawTokenSyntax::missingToken(tok::comma, ","),
                       },
                       SourcePresence::Present));
 }
 
 
-RC<TokenSyntax>
+TokenSyntax
 TupleTypeElementSyntax::getLabel() const {
-  auto Label = cast<TokenSyntax>(getRaw()->getChild(Cursor::Label));
-  assert(Label->getTokenKind() == tok::identifier);
-  return Label;
+  TokenSyntax Child = { Root, Data->getChild(Cursor::Label).get() };
+  assert(Child.getTokenKind() == tok::identifier);
+  return Child;
 }
 
 TupleTypeElementSyntax
-TupleTypeElementSyntax::withLabel(RC<TokenSyntax> NewLabel) const {
-  assert(NewLabel->getTokenKind() == tok::identifier);
-  auto NewRaw = getRaw()->replaceChild(Cursor::Label, NewLabel);
-  return Data->replaceSelf<TupleTypeElementSyntax>(NewRaw);
+TupleTypeElementSyntax::withLabel(TokenSyntax NewLabel) const {
+  assert(NewLabel.getTokenKind() == tok::identifier);
+  return Data->replaceChild<TupleTypeElementSyntax>(NewLabel.getRaw(),
+                                                    Cursor::Label);
 }
 
-RC<TokenSyntax>
+TokenSyntax
 TupleTypeElementSyntax::getColonToken() const {
-  auto ColonToken = cast<TokenSyntax>(getRaw()->getChild(Cursor::ColonToken));
+  TokenSyntax ColonToken = { Root, Data->getChild(Cursor::ColonToken).get() };
   syntax_assert_token_is(ColonToken, tok::colon, ":");
   return ColonToken;
 }
 
 TupleTypeElementSyntax
-TupleTypeElementSyntax::withColonToken(RC<TokenSyntax> NewColonToken) const {
-  syntax_assert_token_is(NewColonToken, tok::colon, ":")
-  auto NewRaw = getRaw()->replaceChild(Cursor::ColonToken, NewColonToken);
-  return Data->replaceSelf<TupleTypeElementSyntax>(NewRaw);
+TupleTypeElementSyntax::withColonToken(TokenSyntax NewColonToken) const {
+  syntax_assert_token_is(NewColonToken, tok::colon, ":");
+  return Data->replaceChild<TupleTypeElementSyntax>(NewColonToken.getRaw(),
+                                                    Cursor::ColonToken);
 }
 
-RC<TokenSyntax>
+TokenSyntax
 TupleTypeElementSyntax::getCommaToken() const {
-  auto CommaToken = cast<TokenSyntax>(getRaw()->getChild(Cursor::CommaToken));
+  TokenSyntax CommaToken = { Root, Data->getChild(Cursor::CommaToken).get() };
   syntax_assert_token_is(CommaToken, tok::comma, ",");
   return CommaToken;
 }
 
 TupleTypeElementSyntax
-TupleTypeElementSyntax::withCommaToken(RC<TokenSyntax> NewCommaToken) const {
-  syntax_assert_token_is(NewCommaToken, tok::comma, ",")
-  auto NewRaw = getRaw()->replaceChild(Cursor::CommaToken, NewCommaToken);
-  return Data->replaceSelf<TupleTypeElementSyntax>(NewRaw);
+TupleTypeElementSyntax::withCommaToken(TokenSyntax NewCommaToken) const {
+  syntax_assert_token_is(NewCommaToken, tok::comma, ",");
+  return Data->replaceChild<TupleTypeElementSyntax>(NewCommaToken.getRaw(),
+                                                    Cursor::CommaToken);
 }
 
 TupleTypeElementSyntax TupleTypeElementSyntax::
@@ -374,16 +374,16 @@ withTypeAttributes(TypeAttributesSyntax NewTypeAttributes) const {
 }
 
 TupleTypeElementSyntax TupleTypeElementSyntax::
-withInoutToken(RC<TokenSyntax> NewInoutToken) const {
+withInoutToken(TokenSyntax NewInoutToken) const {
   syntax_assert_token_is(NewInoutToken, tok::kw_inout, "inout");
-  auto NewRaw = getRaw()->replaceChild(Cursor::InoutToken, NewInoutToken);
-  return Data->replaceSelf<TupleTypeElementSyntax>(NewRaw);
+  return Data->replaceChild<TupleTypeElementSyntax>(NewInoutToken.getRaw(),
+                                                    Cursor::InoutToken);
 }
 
 TupleTypeElementSyntax
 TupleTypeElementSyntax::withTypeSyntax(TypeSyntax NewTypeSyntax) const {
-  auto NewRaw = getRaw()->replaceChild(Cursor::Type, NewTypeSyntax.getRaw());
-  return Data->replaceSelf<TupleTypeElementSyntax>(NewRaw);
+  return Data->replaceChild<TupleTypeElementSyntax>(NewTypeSyntax.getRaw(),
+                                                    Cursor::Type);
 }
 
 #pragma mark - metatype-type API
@@ -403,8 +403,9 @@ MetatypeTypeSyntax MetatypeTypeSyntax::makeBlank() {
   auto Raw = RawSyntax::make(SyntaxKind::MetatypeType,
                              {
                                RawSyntax::missing(SyntaxKind::MissingType),
-                               TokenSyntax::missingToken(tok::period, "."),
-                               TokenSyntax::missingToken(tok::identifier, ""),
+                               RawTokenSyntax::missingToken(tok::period, "."),
+                               RawTokenSyntax::missingToken(tok::identifier,
+                                                            ""),
                              },
                              SourcePresence::Present);
   return make<MetatypeTypeSyntax>(Raw);
@@ -418,19 +419,19 @@ MetatypeTypeSyntax::withBaseTypeSyntax(TypeSyntax NewBaseTypeSyntax) const {
 }
 
 MetatypeTypeSyntax
-MetatypeTypeSyntax::withDotToken(RC<TokenSyntax> NewDotToken) const {
+MetatypeTypeSyntax::withDotToken(TokenSyntax NewDotToken) const {
   syntax_assert_token_is(NewDotToken, tok::period, ".");
-  auto NewRaw = getRaw()->replaceChild(Cursor::DotToken, NewDotToken);
-  return Data->replaceSelf<MetatypeTypeSyntax>(NewRaw);
+  return Data->replaceChild<MetatypeTypeSyntax>(NewDotToken.getRaw(),
+                                                Cursor::DotToken);
 }
 
 MetatypeTypeSyntax
-MetatypeTypeSyntax::withTypeToken(RC<TokenSyntax> NewTypeToken) const {
-  assert(NewTypeToken->getTokenKind() == tok::identifier);
-  assert(NewTypeToken->getText() == "Type" ||
-         NewTypeToken->getText() == "Protocol");
-  auto NewRaw = getRaw()->replaceChild(Cursor::TypeToken, NewTypeToken);
-  return Data->replaceSelf<MetatypeTypeSyntax>(NewRaw);
+MetatypeTypeSyntax::withTypeToken(TokenSyntax NewTypeToken) const {
+  assert(NewTypeToken.getTokenKind() == tok::identifier);
+  assert(NewTypeToken.getText() == "Type" ||
+         NewTypeToken.getText() == "Protocol");
+  return Data->replaceChild<MetatypeTypeSyntax>(NewTypeToken.getRaw(),
+                                                Cursor::TypeToken);
 }
 
 #pragma mark - optional-type API
@@ -448,7 +449,7 @@ OptionalTypeSyntax OptionalTypeSyntax::makeBlank() {
   return make<OptionalTypeSyntax>(RawSyntax::make(SyntaxKind::OptionalType,
     {
       RawSyntax::missing(SyntaxKind::MissingType),
-      TokenSyntax::missingToken(tok::question_postfix, "?"),
+      RawTokenSyntax::missingToken(tok::question_postfix, "?"),
     },
     SourcePresence::Present));
 }
@@ -460,10 +461,10 @@ OptionalTypeSyntax::withBaseTypeSyntax(TypeSyntax NewTypeSyntax) const {
 }
 
 OptionalTypeSyntax
-OptionalTypeSyntax::withQuestionToken(RC<TokenSyntax> NewQuestionToken) const {
+OptionalTypeSyntax::withQuestionToken(TokenSyntax NewQuestionToken) const {
   syntax_assert_token_is(NewQuestionToken, tok::question_postfix, "?");
-  auto NewRaw = getRaw()->replaceChild(Cursor::QuestionToken, NewQuestionToken);
-  return Data->replaceSelf<OptionalTypeSyntax>(NewRaw);
+  return Data->replaceChild<OptionalTypeSyntax>(NewQuestionToken.getRaw(),
+                                                Cursor::QuestionToken);
 }
 
 #pragma mark - implicitly-unwrapped-optional-type API
@@ -485,7 +486,7 @@ ImplicitlyUnwrappedOptionalTypeSyntax::makeBlank() {
                SyntaxKind::ImplicitlyUnwrappedOptionalType,
                {
                  RawSyntax::missing(SyntaxKind::MissingType),
-                 TokenSyntax::missingToken(tok::exclaim_postfix, "!"),
+                 RawTokenSyntax::missingToken(tok::exclaim_postfix, "!"),
                },
                SourcePresence::Present);
   return make<ImplicitlyUnwrappedOptionalTypeSyntax>(Raw);
@@ -498,10 +499,10 @@ withBaseTypeSyntax(TypeSyntax NewTypeSyntax) const {
 }
 
 ImplicitlyUnwrappedOptionalTypeSyntax ImplicitlyUnwrappedOptionalTypeSyntax::
-withExclaimToken(RC<TokenSyntax> NewExclaimToken) const {
+withExclaimToken(TokenSyntax NewExclaimToken) const {
   syntax_assert_token_is(NewExclaimToken, tok::exclaim_postfix, "!");
-  auto NewRaw = getRaw()->replaceChild(Cursor::ExclaimToken, NewExclaimToken);
-  return Data->replaceSelf<ImplicitlyUnwrappedOptionalTypeSyntax>(NewRaw);
+  return Data->replaceChild<ImplicitlyUnwrappedOptionalTypeSyntax>(
+           NewExclaimToken.getRaw(), Cursor::ExclaimToken);
 }
 
 #pragma mark - array-type API
@@ -522,20 +523,19 @@ void ArrayTypeSyntax::validate() const {
 ArrayTypeSyntax ArrayTypeSyntax::makeBlank() {
   auto Raw = RawSyntax::make(SyntaxKind::ArrayType,
                              {
-                               TokenSyntax::missingToken(tok::l_square, "["),
+                               RawTokenSyntax::missingToken(tok::l_square, "["),
                                RawSyntax::missing(SyntaxKind::MissingType),
-                               TokenSyntax::missingToken(tok::r_square, "]"),
+                               RawTokenSyntax::missingToken(tok::r_square, "]"),
                              },
                              SourcePresence::Present);
   return make<ArrayTypeSyntax>(Raw);
 }
 
 ArrayTypeSyntax ArrayTypeSyntax::
-withLeftSquareBracketToken(RC<TokenSyntax> NewLeftSquareBracketToken) const {
+withLeftSquareBracketToken(TokenSyntax NewLeftSquareBracketToken) const {
   syntax_assert_token_is(NewLeftSquareBracketToken, tok::l_square, "[");
-  auto NewRaw = getRaw()->replaceChild(Cursor::LeftSquareBracketToken,
-                                     NewLeftSquareBracketToken);
-  return Data->replaceSelf<ArrayTypeSyntax>(NewRaw);
+  return Data->replaceChild<ArrayTypeSyntax>(NewLeftSquareBracketToken.getRaw(),
+                                             Cursor::LeftSquareBracketToken);
 }
 
 ArrayTypeSyntax ArrayTypeSyntax::withType(TypeSyntax NewType) const {
@@ -544,11 +544,11 @@ ArrayTypeSyntax ArrayTypeSyntax::withType(TypeSyntax NewType) const {
 }
 
 ArrayTypeSyntax ArrayTypeSyntax::
-withRightSquareBracketToken(RC<TokenSyntax> NewRightSquareBracketToken) const {
+withRightSquareBracketToken(TokenSyntax NewRightSquareBracketToken) const {
   syntax_assert_token_is(NewRightSquareBracketToken, tok::r_square, "]");
-  auto NewRaw = getRaw()->replaceChild(Cursor::RightSquareBracketToken,
-                                       NewRightSquareBracketToken);
-  return Data->replaceSelf<ArrayTypeSyntax>(NewRaw);
+  return Data->replaceChild<ArrayTypeSyntax>(
+           NewRightSquareBracketToken.getRaw(),
+           Cursor::RightSquareBracketToken);
 }
 
 #pragma mark - dictionary-type API
@@ -573,50 +573,48 @@ void DictionaryTypeSyntax::validate() const {
 DictionaryTypeSyntax DictionaryTypeSyntax::makeBlank() {
   auto Raw = RawSyntax::make(SyntaxKind::DictionaryType,
                              {
-                               TokenSyntax::missingToken(tok::l_square, "["),
+                               RawTokenSyntax::missingToken(tok::l_square, "["),
                                RawSyntax::missing(SyntaxKind::MissingType),
-                               TokenSyntax::missingToken(tok::colon, ":"),
+                               RawTokenSyntax::missingToken(tok::colon, ":"),
                                RawSyntax::missing(SyntaxKind::MissingType),
-                               TokenSyntax::missingToken(tok::r_square, "]"),
+                               RawTokenSyntax::missingToken(tok::r_square, "]"),
                              },
                              SourcePresence::Present);
   return make<DictionaryTypeSyntax>(Raw);
 }
 
 DictionaryTypeSyntax DictionaryTypeSyntax::
-withLeftSquareBracketToken(RC<TokenSyntax> NewLeftSquareBracketToken) const {
+withLeftSquareBracketToken(TokenSyntax NewLeftSquareBracketToken) const {
   syntax_assert_token_is(NewLeftSquareBracketToken, tok::l_square, "[");
-  auto NewRaw = getRaw()->replaceChild(Cursor::LeftSquareBracketToken,
-                                       NewLeftSquareBracketToken);
-  return Data->replaceSelf<DictionaryTypeSyntax>(NewRaw);
+  return Data->replaceChild<DictionaryTypeSyntax>(
+           NewLeftSquareBracketToken.getRaw(), Cursor::LeftSquareBracketToken);
 }
 
 DictionaryTypeSyntax
 DictionaryTypeSyntax::withKeyTypeSyntax(TypeSyntax NewTypeSyntax) const {
-  auto NewRaw = getRaw()->replaceChild(Cursor::KeyType, NewTypeSyntax.getRaw());
-  return Data->replaceSelf<DictionaryTypeSyntax>(NewRaw);
+  return Data->replaceChild<DictionaryTypeSyntax>(NewTypeSyntax.getRaw(),
+                                                  Cursor::KeyType);
 }
 
 DictionaryTypeSyntax
-DictionaryTypeSyntax::withColon(RC<TokenSyntax> NewColonToken) const {
+DictionaryTypeSyntax::withColon(TokenSyntax NewColonToken) const {
   syntax_assert_token_is(NewColonToken, tok::colon, ":");
-  auto NewRaw = getRaw()->replaceChild(Cursor::ColonToken, NewColonToken);
-  return Data->replaceSelf<DictionaryTypeSyntax>(NewRaw);
+  return Data->replaceChild<DictionaryTypeSyntax>(NewColonToken.getRaw(),
+                                                  Cursor::ColonToken);
 }
 
 DictionaryTypeSyntax
 DictionaryTypeSyntax::withValueTypeSyntax(TypeSyntax NewTypeSyntax) const {
-  auto NewRaw = getRaw()->replaceChild(Cursor::ValueType,
-                                       NewTypeSyntax.getRaw());
-  return Data->replaceSelf<DictionaryTypeSyntax>(NewRaw);
+  return Data->replaceChild<DictionaryTypeSyntax>(NewTypeSyntax.getRaw(),
+                                                  Cursor::ValueType);
 }
 
 DictionaryTypeSyntax DictionaryTypeSyntax::
-withRightSquareBracketToken(RC<TokenSyntax> NewRightSquareBracketToken) const {
+withRightSquareBracketToken(TokenSyntax NewRightSquareBracketToken) const {
   syntax_assert_token_is(NewRightSquareBracketToken, tok::r_square, "]");
-  auto NewRaw = getRaw()->replaceChild(Cursor::RightSquareBracketToken,
-                                       NewRightSquareBracketToken);
-  return Data->replaceSelf<DictionaryTypeSyntax>(NewRaw);
+  return Data->replaceChild<DictionaryTypeSyntax>(
+           NewRightSquareBracketToken.getRaw(),
+           Cursor::RightSquareBracketToken);
 }
 
 #pragma mark - function-type-argument API
@@ -626,9 +624,9 @@ void FunctionTypeArgumentSyntax::validate() const {}
 FunctionTypeArgumentSyntax FunctionTypeArgumentSyntax::makeBlank() {
   auto Raw = RawSyntax::make(SyntaxKind::FunctionTypeArgument,
                              {
-                               TokenSyntax::missingToken(tok::identifier, ""),
-                               TokenSyntax::missingToken(tok::identifier, ""),
-                               TokenSyntax::missingToken(tok::colon, ","),
+                               RawTokenSyntax::missingToken(tok::identifier, ""),
+                               RawTokenSyntax::missingToken(tok::identifier, ""),
+                               RawTokenSyntax::missingToken(tok::colon, ","),
                              },
                              SourcePresence::Present);
   return make<FunctionTypeArgumentSyntax>(Raw);
@@ -651,7 +649,7 @@ void FunctionTypeSyntax::validate() const {
                                  tok::r_paren, ")");
 #ifndef NDEBUG
   auto ThrowsOrRethrows =
-    cast<TokenSyntax>(
+    cast<RawTokenSyntax>(
       Raw->getChild(FunctionTypeSyntax::Cursor::ThrowsOrRethrows));
   assert(ThrowsOrRethrows->is(tok::kw_throws, "throws") ||
          ThrowsOrRethrows->is(tok::kw_rethrows, "rethrows"));
@@ -665,11 +663,11 @@ FunctionTypeSyntax FunctionTypeSyntax::makeBlank() {
   return make<FunctionTypeSyntax>(RawSyntax::make(SyntaxKind::FunctionType,
     {
       RawSyntax::missing(SyntaxKind::TypeAttributes),
-      TokenSyntax::missingToken(tok::l_paren, "("),
+      RawTokenSyntax::missingToken(tok::l_paren, "("),
       RawSyntax::missing(SyntaxKind::FunctionParameterList),
-      TokenSyntax::missingToken(tok::r_paren, ")"),
-      TokenSyntax::missingToken(tok::kw_throws, "throws"),
-      TokenSyntax::missingToken(tok::arrow, "->"),
+      RawTokenSyntax::missingToken(tok::r_paren, ")"),
+      RawTokenSyntax::missingToken(tok::kw_throws, "throws"),
+      RawTokenSyntax::missingToken(tok::arrow, "->"),
       RawSyntax::missing(SyntaxKind::MissingType),
     },
     SourcePresence::Present));
@@ -683,65 +681,61 @@ withTypeAttributes(TypeAttributesSyntax NewAttributes) const {
 }
 
 FunctionTypeSyntax
-FunctionTypeSyntax::withLeftArgumentsParen(RC<TokenSyntax> NewLeftParen) const {
+FunctionTypeSyntax::withLeftArgumentsParen(TokenSyntax NewLeftParen) const {
   syntax_assert_token_is(NewLeftParen, tok::l_paren, "(");
-  auto NewRaw = getRaw()->replaceChild(Cursor::LeftParen, NewLeftParen);
-  return Data->replaceSelf<FunctionTypeSyntax>(NewRaw);
+  return Data->replaceChild<FunctionTypeSyntax>(NewLeftParen.getRaw(),
+                                                Cursor::LeftParen);
 }
 
 FunctionTypeSyntax FunctionTypeSyntax::
-addTypeArgument(llvm::Optional<RC<TokenSyntax>> MaybeComma,
+addTypeArgument(llvm::Optional<TokenSyntax> MaybeComma,
                 FunctionTypeArgumentSyntax NewArgument) const {
   auto ArgList = getRaw()->getChild(Cursor::ArgumentList);
 
   if (MaybeComma.hasValue()) {
     syntax_assert_token_is(MaybeComma.getValue(), tok::comma, ",");
-    ArgList = ArgList->append(MaybeComma.getValue());
+    ArgList = ArgList->append(MaybeComma->getRaw());
   } else {
     if (!ArgList->Layout.empty()) {
-      ArgList = ArgList->append(TokenSyntax::missingToken(tok::comma, ","));
+      ArgList = ArgList->append(RawTokenSyntax::missingToken(tok::comma, ","));
     }
   }
   ArgList = ArgList->append(NewArgument.getRaw());
-  auto NewRaw = getRaw()->replaceChild(Cursor::ArgumentList, ArgList);
-  return Data->replaceSelf<FunctionTypeSyntax>(NewRaw);
+  return Data->replaceChild<FunctionTypeSyntax>(ArgList, Cursor::ArgumentList);
 }
 
 FunctionTypeSyntax FunctionTypeSyntax::
-withRightArgumentsParen(RC<TokenSyntax> NewLeftParen) const {
+withRightArgumentsParen(TokenSyntax NewLeftParen) const {
   syntax_assert_token_is(NewLeftParen, tok::r_paren, ")");
-  auto NewRaw = getRaw()->replaceChild(Cursor::RightParen, NewLeftParen);
-  return Data->replaceSelf<FunctionTypeSyntax>(NewRaw);
+  return Data->replaceChild<FunctionTypeSyntax>(NewLeftParen.getRaw(),
+                                                Cursor::RightParen);
 }
 
 FunctionTypeSyntax
-FunctionTypeSyntax::withThrowsKeyword(RC<TokenSyntax> NewThrowsKeyword) const {
+FunctionTypeSyntax::withThrowsKeyword(TokenSyntax NewThrowsKeyword) const {
   syntax_assert_token_is(NewThrowsKeyword, tok::kw_throws, "throws");
-  auto NewRaw = getRaw()->replaceChild(Cursor::ThrowsOrRethrows,
-                                       NewThrowsKeyword);
-  return Data->replaceSelf<FunctionTypeSyntax>(NewRaw);
+  return Data->replaceChild<FunctionTypeSyntax>(NewThrowsKeyword.getRaw(),
+                                                Cursor::ThrowsOrRethrows);
 }
 
 FunctionTypeSyntax FunctionTypeSyntax::
-withRethrowsKeyword(RC<TokenSyntax> NewThrowsKeyword) const {
+withRethrowsKeyword(TokenSyntax NewThrowsKeyword) const {
   syntax_assert_token_is(NewThrowsKeyword, tok::kw_rethrows, "rethrows");
-  auto NewRaw = getRaw()->replaceChild(Cursor::ThrowsOrRethrows,
-                                       NewThrowsKeyword);
-  return Data->replaceSelf<FunctionTypeSyntax>(NewRaw);
+  return Data->replaceChild<FunctionTypeSyntax>(NewThrowsKeyword.getRaw(),
+                                                Cursor::ThrowsOrRethrows);
 }
 
 FunctionTypeSyntax
-FunctionTypeSyntax::withArrow(RC<TokenSyntax> NewArrow) const {
+FunctionTypeSyntax::withArrow(TokenSyntax NewArrow) const {
   syntax_assert_token_is(NewArrow, tok::arrow, "->");
-  auto NewRaw = getRaw()->replaceChild(Cursor::Arrow, NewArrow);
-  return Data->replaceSelf<FunctionTypeSyntax>(NewRaw);
+  return Data->replaceChild<FunctionTypeSyntax>(NewArrow.getRaw(),
+                                                Cursor::Arrow);
 }
 
 FunctionTypeSyntax
 FunctionTypeSyntax::withReturnTypeSyntax(TypeSyntax NewReturnTypeSyntax) const {
-  auto NewRaw = getRaw()->replaceChild(Cursor::ReturnType,
-                                       NewReturnTypeSyntax.getRaw());
-  return Data->replaceSelf<FunctionTypeSyntax>(NewRaw);
+  return Data->replaceChild<FunctionTypeSyntax>(NewReturnTypeSyntax.getRaw(),
+                                                Cursor::ReturnType);
 }
 
 #pragma mark - function-type Builder
@@ -758,33 +752,34 @@ FunctionTypeSyntaxBuilder &FunctionTypeSyntaxBuilder::useTypeAttributes(
 }
 
 FunctionTypeSyntaxBuilder &
-FunctionTypeSyntaxBuilder::useLeftArgumentsParen(RC<TokenSyntax> NewLeftParen) {
+FunctionTypeSyntaxBuilder::useLeftArgumentsParen(TokenSyntax NewLeftParen) {
   syntax_assert_token_is(NewLeftParen, tok::l_paren, "(");
   auto Index = cursorIndex(FunctionTypeSyntax::Cursor::LeftParen);
-  FunctionTypeLayout[Index] = NewLeftParen;
+  FunctionTypeLayout[Index] = NewLeftParen.getRaw();
   return *this;
 }
 
 FunctionTypeSyntaxBuilder &FunctionTypeSyntaxBuilder::
-useRightArgumentsParen(RC<TokenSyntax> NewRightParen) {
+useRightArgumentsParen(TokenSyntax NewRightParen) {
   syntax_assert_token_is(NewRightParen, tok::r_paren, ")");
   auto Index = cursorIndex(FunctionTypeSyntax::Cursor::RightParen);
-  FunctionTypeLayout[Index] = NewRightParen;
+  FunctionTypeLayout[Index] = NewRightParen.getRaw();
   return *this;
 }
 
 FunctionTypeSyntaxBuilder &FunctionTypeSyntaxBuilder::
-addArgumentTypeSyntax(Optional<RC<TokenSyntax>> MaybeComma,
+addArgumentTypeSyntax(Optional<TokenSyntax> MaybeComma,
                       FunctionTypeArgumentSyntax NewTypeArgument) {
   auto Index = cursorIndex(FunctionTypeSyntax::Cursor::ArgumentList);
   auto TypeArgumentsLayout = FunctionTypeLayout[Index]->Layout;
 
   if (MaybeComma.hasValue()) {
     syntax_assert_token_is(MaybeComma.getValue(), tok::comma, ",");
-    TypeArgumentsLayout.push_back(MaybeComma.getValue());
+    TypeArgumentsLayout.push_back(MaybeComma->getRaw());
   } else {
     if (TypeArgumentsLayout.empty()) {
-      TypeArgumentsLayout.push_back(TokenSyntax::missingToken(tok::comma, ","));
+      TypeArgumentsLayout.push_back(RawTokenSyntax::missingToken(tok::comma,
+                                                                 ","));
     }
   }
 
@@ -797,26 +792,26 @@ addArgumentTypeSyntax(Optional<RC<TokenSyntax>> MaybeComma,
 }
 
 FunctionTypeSyntaxBuilder &
-FunctionTypeSyntaxBuilder::useThrowsKeyword(RC<TokenSyntax> NewThrowsKeyword) {
+FunctionTypeSyntaxBuilder::useThrowsKeyword(TokenSyntax NewThrowsKeyword) {
   syntax_assert_token_is(NewThrowsKeyword, tok::kw_throws, "throws");
   auto Index = cursorIndex(FunctionTypeSyntax::Cursor::ThrowsOrRethrows);
-  FunctionTypeLayout[Index] = NewThrowsKeyword;
+  FunctionTypeLayout[Index] = NewThrowsKeyword.getRaw();
   return *this;
 }
 
 FunctionTypeSyntaxBuilder &
-FunctionTypeSyntaxBuilder::useRethrowsKeyword(RC<TokenSyntax> NewRethrowsKeyword) {
+FunctionTypeSyntaxBuilder::useRethrowsKeyword(TokenSyntax NewRethrowsKeyword) {
   syntax_assert_token_is(NewRethrowsKeyword, tok::kw_rethrows, "rethrows");
   auto Index = cursorIndex(FunctionTypeSyntax::Cursor::ThrowsOrRethrows);
-  FunctionTypeLayout[Index] = NewRethrowsKeyword;
+  FunctionTypeLayout[Index] = NewRethrowsKeyword.getRaw();
   return *this;
 }
 
 FunctionTypeSyntaxBuilder &
-FunctionTypeSyntaxBuilder::useArrow(RC<TokenSyntax> NewArrow) {
+FunctionTypeSyntaxBuilder::useArrow(TokenSyntax NewArrow) {
   syntax_assert_token_is(NewArrow, tok::arrow, "->");
   auto Index = cursorIndex(FunctionTypeSyntax::Cursor::Arrow);
-  FunctionTypeLayout[Index] = NewArrow;
+  FunctionTypeLayout[Index] = NewArrow.getRaw();
   return *this;
 }
 

--- a/tools/swift-syntax-test/swift-syntax-test.cpp
+++ b/tools/swift-syntax-test/swift-syntax-test.cpp
@@ -37,7 +37,7 @@ using namespace swift;
 using llvm::StringRef;
 
 enum class ActionType {
-  DumpTokenSyntax,
+  DumpRawTokenSyntax,
   FullLexRoundTrip,
   FullParseRoundTrip,
   SerializeRawTree,
@@ -49,7 +49,7 @@ static llvm::cl::opt<ActionType>
 Action(llvm::cl::desc("Action (required):"),
        llvm::cl::init(ActionType::None),
        llvm::cl::values(
-        clEnumValN(ActionType::DumpTokenSyntax,
+        clEnumValN(ActionType::DumpRawTokenSyntax,
                    "dump-full-tokens",
                    "Lex the source file and dump the tokens "
                    "and their absolute line/column locations"),
@@ -75,7 +75,7 @@ int getTokensFromFile(unsigned BufferID,
                       LangOptions &LangOpts,
                       SourceManager &SourceMgr,
                       DiagnosticEngine &Diags,
-                      std::vector<std::pair<RC<syntax::TokenSyntax>,
+                      std::vector<std::pair<RC<syntax::RawTokenSyntax>,
                       syntax::AbsolutePosition>> &Tokens) {
   Tokens = tokenizeWithTrivia(LangOpts, SourceMgr, BufferID);
   return Diags.hadAnyError() ? EXIT_FAILURE : EXIT_SUCCESS;
@@ -87,7 +87,7 @@ getTokensFromFile(const StringRef InputFilename,
                   LangOptions &LangOpts,
                   SourceManager &SourceMgr,
                   DiagnosticEngine &Diags,
-                  std::vector<std::pair<RC<syntax::TokenSyntax>,
+                  std::vector<std::pair<RC<syntax::RawTokenSyntax>,
                                         syntax::AbsolutePosition>> &Tokens) {
   auto Buffer = llvm::MemoryBuffer::getFile(InputFilename);
   if (!Buffer) {
@@ -106,7 +106,7 @@ int getSyntaxTree(const char *MainExecutablePath,
                   const StringRef InputFilename,
                   CompilerInstance &Instance,
                   llvm::SmallVectorImpl<syntax::Syntax> &TopLevelDecls,
-                  std::vector<std::pair<RC<syntax::TokenSyntax>,
+                  std::vector<std::pair<RC<syntax::RawTokenSyntax>,
                               syntax::AbsolutePosition>> &Tokens) {
   CompilerInvocation Invocation;
   Invocation.addInputFilename(InputFilename);
@@ -175,7 +175,7 @@ int doFullLexRoundTrip(const StringRef InputFilename) {
   PrintingDiagnosticConsumer DiagPrinter;
   Diags.addConsumer(DiagPrinter);
 
-  std::vector<std::pair<RC<syntax::TokenSyntax>,
+  std::vector<std::pair<RC<syntax::RawTokenSyntax>,
                                    syntax::AbsolutePosition>> Tokens;
   if (getTokensFromFile(InputFilename, LangOpts, SourceMgr,
                         Diags, Tokens) == EXIT_FAILURE) {
@@ -189,14 +189,14 @@ int doFullLexRoundTrip(const StringRef InputFilename) {
   return Diags.hadAnyError() ? EXIT_FAILURE : EXIT_SUCCESS;
 }
 
-int doDumpTokenSyntax(const StringRef InputFilename) {
+int doDumpRawTokenSyntax(const StringRef InputFilename) {
   LangOptions LangOpts;
   SourceManager SourceMgr;
   DiagnosticEngine Diags(SourceMgr);
   PrintingDiagnosticConsumer DiagPrinter;
   Diags.addConsumer(DiagPrinter);
 
-  std::vector<std::pair<RC<syntax::TokenSyntax>,
+  std::vector<std::pair<RC<syntax::RawTokenSyntax>,
                         syntax::AbsolutePosition>> Tokens;
   if (getTokensFromFile(InputFilename, LangOpts, SourceMgr,
                         Diags, Tokens) == EXIT_FAILURE) {
@@ -217,7 +217,7 @@ int doFullParseRoundTrip(const char *MainExecutablePath,
                          const StringRef InputFilename) {
 
   llvm::SmallVector<syntax::Syntax, 10> TopLevelDecls;
-  std::vector<std::pair<RC<syntax::TokenSyntax>,
+  std::vector<std::pair<RC<syntax::RawTokenSyntax>,
                         syntax::AbsolutePosition>> Tokens;
   CompilerInstance Instance;
 
@@ -239,7 +239,7 @@ int doSerializeRawTree(const char *MainExecutablePath,
                        const StringRef InputFilename) {
 
   llvm::SmallVector<syntax::Syntax, 10> TopLevelDecls;
-  std::vector<std::pair<RC<syntax::TokenSyntax>,
+  std::vector<std::pair<RC<syntax::RawTokenSyntax>,
                         syntax::AbsolutePosition>> Tokens;
   CompilerInstance Instance;
 
@@ -275,8 +275,8 @@ int main(int argc, char *argv[]) {
   }
 
   switch (options::Action) {
-  case ActionType::DumpTokenSyntax:
-    ExitCode = doDumpTokenSyntax(options::InputSourceFilename);
+  case ActionType::DumpRawTokenSyntax:
+    ExitCode = doDumpRawTokenSyntax(options::InputSourceFilename);
     break;
   case ActionType::FullLexRoundTrip:
     ExitCode = doFullLexRoundTrip(options::InputSourceFilename);

--- a/unittests/Syntax/DeclSyntaxTests.cpp
+++ b/unittests/Syntax/DeclSyntaxTests.cpp
@@ -43,10 +43,10 @@ TEST(DeclSyntaxTests, DeclModifierGetAPIs) {
   auto RParen = SyntaxFactory::makeRightParenToken({}, {});
   auto Mod = SyntaxFactory::makeDeclModifier(Private, LParen, Set, RParen);
 
-  ASSERT_EQ(Private, Mod.getName());
-  ASSERT_EQ(LParen, Mod.getLeftParenToken());
-  ASSERT_EQ(Set, Mod.getArgument());
-  ASSERT_EQ(RParen, Mod.getRightParenToken());
+  ASSERT_EQ(Private.getRaw(), Mod.getName().getRaw());
+  ASSERT_EQ(LParen.getRaw(), Mod.getLeftParenToken().getRaw());
+  ASSERT_EQ(Set.getRaw(), Mod.getArgument().getRaw());
+  ASSERT_EQ(RParen.getRaw(), Mod.getRightParenToken().getRaw());
 }
 
 TEST(DeclSyntaxTests, DeclModifierWithAPIs) {
@@ -252,21 +252,21 @@ TEST(DeclSyntaxTests, FunctionParameterGetAPIs) {
                                                     Colon, Int, NoEllipsis,
                                                     Equal, One, Comma);
 
-  ASSERT_EQ(ExternalName, Param.getExternalName());
-  ASSERT_EQ(LocalName, Param.getLocalName());
-  ASSERT_EQ(Colon, Param.getColonToken());
+  ASSERT_EQ(ExternalName.getRaw(), Param.getExternalName().getRaw());
+  ASSERT_EQ(LocalName.getRaw(), Param.getLocalName().getRaw());
+  ASSERT_EQ(Colon.getRaw(), Param.getColonToken().getRaw());
 
   auto GottenType = Param.getTypeSyntax().getValue();
   auto GottenType2 = Param.getTypeSyntax().getValue();
   ASSERT_TRUE(GottenType.hasSameIdentityAs(GottenType2));
 
-  ASSERT_EQ(Equal, Param.getEqualToken());
+  ASSERT_EQ(Equal.getRaw(), Param.getEqualToken().getRaw());
 
   auto GottenDefaultValue = Param.getDefaultValue().getValue();
   auto GottenDefaultValue2 = Param.getDefaultValue().getValue();
   ASSERT_TRUE(GottenDefaultValue.hasSameIdentityAs(GottenDefaultValue2));
 
-  ASSERT_EQ(Comma, Param.getTrailingComma());
+  ASSERT_EQ(Comma.getRaw(), Param.getTrailingComma().getRaw());
 
   // Test that llvm::None is returned for non-token missing children:
   auto Decimated = Param
@@ -392,7 +392,7 @@ TEST(DeclSyntaxTests, FunctionSignatureGetAPIs) {
   auto Sig = SyntaxFactory::makeFunctionSignature(LParen, List, RParen, Throws,
                                                   Arrow, NoAttributes, Int);
 
-  ASSERT_EQ(LParen, Sig.getLeftParenToken());
+  ASSERT_EQ(LParen.getRaw(), Sig.getLeftParenToken().getRaw());
 
   {
     SmallString<48> Scratch;
@@ -407,10 +407,10 @@ TEST(DeclSyntaxTests, FunctionSignatureGetAPIs) {
               "with radius: Int = -1, ");
   }
 
-  ASSERT_EQ(RParen, Sig.getRightParenToken());
-  ASSERT_EQ(Throws, Sig.getThrowsToken());
-  ASSERT_TRUE(Sig.getRethrowsToken()->isMissing());
-  ASSERT_EQ(Arrow, Sig.getArrowToken());
+  ASSERT_EQ(RParen.getRaw(), Sig.getRightParenToken().getRaw());
+  ASSERT_EQ(Throws.getRaw(), Sig.getThrowsToken().getRaw());
+  ASSERT_TRUE(Sig.getRethrowsToken().isMissing());
+  ASSERT_EQ(Arrow.getRaw(), Sig.getArrowToken().getRaw());
 
   {
     SmallString<48> Scratch;

--- a/unittests/Syntax/ExprSyntaxTests.cpp
+++ b/unittests/Syntax/ExprSyntaxTests.cpp
@@ -72,7 +72,7 @@ TEST(ExprSyntaxTests, SymbolicReferenceExprGetAPIs) {
 
     auto Ref = SyntaxFactory::makeSymbolicReferenceExpr(Array, GenericArgs);
 
-    ASSERT_EQ(Ref.getIdentifier(), Array);
+    ASSERT_EQ(Ref.getIdentifier().getRaw(), Array.getRaw());
 
     auto GottenArgs = Ref.getGenericArgumentClause().getValue();
     auto GottenArgs2 = Ref.getGenericArgumentClause().getValue();
@@ -172,8 +172,8 @@ TEST(ExprSyntaxTests, FunctionCallArgumentGetAPIs) {
     auto Arg = SyntaxFactory::makeFunctionCallArgument(X, Colon, SymbolicRef,
                                                        Comma);
 
-    ASSERT_EQ(X, Arg.getLabel());
-    ASSERT_EQ(Colon, Arg.getColonToken());
+    ASSERT_EQ(X.getRaw(), Arg.getLabel().getRaw());
+    ASSERT_EQ(Colon.getRaw(), Arg.getColonToken().getRaw());
 
     auto GottenExpr = Arg.getExpression().getValue();
     auto GottenExpr2 = Arg.getExpression().getValue();
@@ -183,7 +183,7 @@ TEST(ExprSyntaxTests, FunctionCallArgumentGetAPIs) {
     GottenExpr.print(OS);
     ASSERT_EQ("foo", OS.str().str());
 
-    ASSERT_EQ(Comma, Arg.getTrailingComma());
+    ASSERT_EQ(Comma.getRaw(), Arg.getTrailingComma().getRaw());
   }
 }
 
@@ -407,8 +407,8 @@ TEST(ExprSyntaxTests, FunctionCallExprGetAPIs) {
     ASSERT_EQ(OS.str().str(), "foo");
   }
 
-  ASSERT_EQ(LeftParen, Call.getLeftParen());
-  ASSERT_EQ(RightParen, Call.getRightParen());
+  ASSERT_EQ(LeftParen.getRaw(), Call.getLeftParen().getRaw());
+  ASSERT_EQ(RightParen.getRaw(), Call.getRightParen().getRaw());
 
   {
     auto GottenArgs1 = Call.getArgumentList();

--- a/unittests/Syntax/StmtSyntaxTests.cpp
+++ b/unittests/Syntax/StmtSyntaxTests.cpp
@@ -19,7 +19,8 @@ TEST(StmtSyntaxTests, FallthroughStmtGetAPIs) {
     .withFallthroughKeyword(FallthroughKW);
 
   /// This should be directly shared through reference-counting.
-  ASSERT_EQ(FallthroughKW, Fallthrough.getFallthroughKeyword());
+  ASSERT_EQ(FallthroughKW.getRaw(), Fallthrough.getFallthroughKeyword()
+                                               .getRaw());
 }
 
 TEST(StmtSyntaxTests, FallthroughStmtWithAPIs) {
@@ -50,9 +51,9 @@ TEST(StmtSyntaxTests, FallthroughStmtMakeAPIs) {
     llvm::SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
 
-    FallthroughKW = FallthroughKW->withLeadingTrivia(Trivia::spaces(2));
+    auto NewFallthroughKW = FallthroughKW.withLeadingTrivia(Trivia::spaces(2));
 
-    SyntaxFactory::makeFallthroughStmt(FallthroughKW).print(OS);
+    SyntaxFactory::makeFallthroughStmt(NewFallthroughKW).print(OS);
     ASSERT_EQ(OS.str().str(), "  fallthrough");
   }
 
@@ -60,9 +61,10 @@ TEST(StmtSyntaxTests, FallthroughStmtMakeAPIs) {
     llvm::SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
 
-    FallthroughKW = FallthroughKW->withTrailingTrivia(Trivia::spaces(2));
+    auto NewFallthroughKW = FallthroughKW.withLeadingTrivia(Trivia::spaces(2))
+                                         .withTrailingTrivia(Trivia::spaces(2));
 
-    SyntaxFactory::makeFallthroughStmt(FallthroughKW).print(OS);
+    SyntaxFactory::makeFallthroughStmt(NewFallthroughKW).print(OS);
     ASSERT_EQ(OS.str().str(), "  fallthrough  ");
   }
 
@@ -83,8 +85,8 @@ TEST(StmtSyntaxTests, BreakStmtGetAPIs) {
   auto Break = SyntaxFactory::makeBreakStmt(BreakKW, Label);
 
   /// These should be directly shared through reference-counting.
-  ASSERT_EQ(BreakKW, Break.getBreakKeyword());
-  ASSERT_EQ(Label, Break.getLabel());
+  ASSERT_EQ(BreakKW.getRaw(), Break.getBreakKeyword().getRaw());
+  ASSERT_EQ(Label.getRaw(), Break.getLabel().getRaw());
 }
 
 TEST(StmtSyntaxTests, BreakStmtWithAPIs) {
@@ -115,7 +117,7 @@ TEST(StmtSyntaxTests, BreakStmtWithAPIs) {
   {
     llvm::SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    Break.withBreakKeyword(BreakKW->withTrailingTrivia(Trivia::spaces(1)))
+    Break.withBreakKeyword(BreakKW.withTrailingTrivia(Trivia::spaces(1)))
       .withLabel(Label)
       .print(OS);
     ASSERT_EQ(OS.str().str(), "break theRules"); // sometimes
@@ -148,8 +150,8 @@ TEST(StmtSyntaxTests, ContinueStmtGetAPIs) {
   auto Continue = SyntaxFactory::makeContinueStmt(ContinueKW, Label);
 
   /// These should be directly shared through reference-counting.
-  ASSERT_EQ(ContinueKW, Continue.getContinueKeyword());
-  ASSERT_EQ(Label, Continue.getLabel());
+  ASSERT_EQ(ContinueKW.getRaw(), Continue.getContinueKeyword().getRaw());
+  ASSERT_EQ(Label.getRaw(), Continue.getLabel().getRaw());
 }
 
 TEST(StmtSyntaxTests, ContinueStmtWithAPIs) {
@@ -180,7 +182,7 @@ TEST(StmtSyntaxTests, ContinueStmtWithAPIs) {
     llvm::SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
     Continue
-      .withContinueKeyword(ContinueKW->withTrailingTrivia(Trivia::spaces(1)))
+      .withContinueKeyword(ContinueKW.withTrailingTrivia(Trivia::spaces(1)))
       .withLabel(Label)
       .print(OS);
     ASSERT_EQ(OS.str().str(), "continue toCare"); // for each other
@@ -235,7 +237,7 @@ TEST(StmtSyntaxTests, ReturnStmtGetAPIs) {
   auto MinusOne = SyntaxFactory::makeIntegerLiteralExpr(Minus, OneDigits);
   auto Return = SyntaxFactory::makeReturnStmt(ReturnKW, MinusOne);
 
-  ASSERT_EQ(ReturnKW, Return.getReturnKeyword());
+  ASSERT_EQ(ReturnKW.getRaw(), Return.getReturnKeyword().getRaw());
   auto GottenExpression = Return.getExpression().getValue();
   auto GottenExpression2 = Return.getExpression().getValue();
   ASSERT_TRUE(GottenExpression.hasSameIdentityAs(GottenExpression2));

--- a/unittests/Syntax/SyntaxCollectionTests.cpp
+++ b/unittests/Syntax/SyntaxCollectionTests.cpp
@@ -15,7 +15,7 @@ FunctionCallArgumentSyntax getCannedArgument() {
   auto Colon = SyntaxFactory::makeColonToken({}, Trivia::spaces(1));
   auto SymbolicRef = SyntaxFactory::makeSymbolicReferenceExpr(Foo, llvm::None);
   auto Comma = SyntaxFactory::makeCommaToken({}, Trivia::spaces(1));
-  auto NoComma = TokenSyntax::missingToken(tok::comma, ",");
+  auto NoComma = RawTokenSyntax::missingToken(tok::comma, ",");
 
   return SyntaxFactory::makeFunctionCallArgument(X, Colon, SymbolicRef, Comma);
 }


### PR DESCRIPTION
Previously, users of `TokenSyntax` would always deal with `RC<TokenSyntax>`
which is a subclass of `RawSyntax`. Instead, provide `TokenSyntax` as a
fully-realized `Syntax` node, that will always exist as a leaf in the tree.

This hides the implementation detail of `RawSyntax` and `SyntaxData`
completely from clients of libSyntax, and paves the way for future
generation of `Syntax` nodes.
