### PR TITLE
Teach SILFunctionType to start walking parameters

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -2329,6 +2329,10 @@ public:
     
   public:
     Type getType() const { return Ty; }
+    CanType getCanType() const {
+      assert(Ty->isCanonical());
+      return CanType(Ty);
+    }
     
     Identifier getLabel() const { return Label; }
     
@@ -2342,6 +2346,9 @@ public:
     
     /// Whether the parameter is marked '@escaping'
     bool isEscaping() const { return Flags.isEscaping(); }
+    
+    /// Whether the parameter is marked 'inout'
+    bool isInOut() const { return Flags.isInOut(); }
   };
   
   /// \brief A class which abstracts out some details necessary for
@@ -2552,6 +2559,10 @@ BEGIN_CAN_TYPE_WRAPPER(AnyFunctionType, Type)
 
   CanType getInput() const {
     return getPointer()->getInput()->getCanonicalType();
+  }
+  
+  ArrayRef<AnyFunctionType::Param> getParams() const {
+    return getPointer()->getParams();
   }
 
   PROXY_CAN_TYPE_SIMPLE_GETTER(getResult)

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -2664,7 +2664,8 @@ BuiltinVectorType *BuiltinVectorType::get(const ASTContext &context,
 }
 
 ParenType *ParenType::get(const ASTContext &C, Type underlying,
-                          ParameterTypeFlags flags) {
+                          ParameterTypeFlags fl) {
+  auto flags = fl.withInOut(underlying->is<InOutType>());
   auto properties = underlying->getRecursiveProperties();
   auto arena = getArena(properties);
   ParenType *&Result =
@@ -2739,7 +2740,7 @@ Type TupleType::get(ArrayRef<TupleTypeElt> Fields, const ASTContext &C) {
 
 TupleTypeElt::TupleTypeElt(Type ty, Identifier name,
                            ParameterTypeFlags fl)
-: Name(name), ElementType(ty), Flags(fl) {
+: Name(name), ElementType(ty), Flags(fl.withInOut(ty->is<InOutType>())) {
   // FIXME: Re-enable this assertion and hunt down the callers that aren't
   // setting parameter bits correctly.
   // assert((ty->is<InOutType>() && fl.isInOut()) && "caller did not set flags");


### PR DESCRIPTION
This seems to cause random failures in the exclusivity checking code for some reason.

We'll see what happens.