### PR TITLE
[ClangImporter] Filter import-as-member decls by preferred submodule.

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -7872,8 +7872,9 @@ ClangImporter::Implementation::loadAllMembers(Decl *D, uint64_t extra) {
     for (auto entry : table->lookupGlobalsAsMembers(effectiveClangContext)) {
       auto decl = entry.get<clang::NamedDecl *>();
 
-      // Only continue members in the same submodule as this extension.
-      if (decl->getImportedOwningModule() != submodule) continue;
+      // Only include members in the same submodule as this extension.
+      if (getClangSubmoduleForDecl(decl) != submodule)
+        continue;
 
       forEachDistinctName(decl, [&](ImportedName newName,
                                     ImportNameVersion nameVersion) {

--- a/test/ClangImporter/Inputs/frameworks/ImportAsMemberSubmodules.framework/Headers/Actual.h
+++ b/test/ClangImporter/Inputs/frameworks/ImportAsMemberSubmodules.framework/Headers/Actual.h
@@ -1,0 +1,3 @@
+struct IAMOuter { int x; };
+
+struct IAMInner { int y; };

--- a/test/ClangImporter/Inputs/frameworks/ImportAsMemberSubmodules.framework/Headers/Fwd.h
+++ b/test/ClangImporter/Inputs/frameworks/ImportAsMemberSubmodules.framework/Headers/Fwd.h
@@ -1,0 +1,3 @@
+// The order of these forward-declarations affects whether there was a bug.
+struct IAMOuter;
+struct IAMInner;

--- a/test/ClangImporter/Inputs/frameworks/ImportAsMemberSubmodules.framework/Headers/ImportAsMemberSubmodules.apinotes
+++ b/test/ClangImporter/Inputs/frameworks/ImportAsMemberSubmodules.framework/Headers/ImportAsMemberSubmodules.apinotes
@@ -1,0 +1,4 @@
+Name: ImportAsMemberSubmodules
+Tags:
+- Name: IAMInner
+  SwiftName: IAMOuter.Inner

--- a/test/ClangImporter/Inputs/frameworks/ImportAsMemberSubmodules.framework/Headers/ImportAsMemberSubmodules.h
+++ b/test/ClangImporter/Inputs/frameworks/ImportAsMemberSubmodules.framework/Headers/ImportAsMemberSubmodules.h
@@ -1,0 +1,3 @@
+// Umbrella header.
+#import <ImportAsMemberSubmodules/Fwd.h>
+#import <ImportAsMemberSubmodules/Actual.h>

--- a/test/ClangImporter/Inputs/frameworks/ImportAsMemberSubmodules.framework/Modules/module.modulemap
+++ b/test/ClangImporter/Inputs/frameworks/ImportAsMemberSubmodules.framework/Modules/module.modulemap
@@ -1,0 +1,5 @@
+framework module ImportAsMemberSubmodules {
+  umbrella header "ImportAsMemberSubmodules.h"
+  export *
+  module * { export * }
+}

--- a/test/ClangImporter/import-as-member.swift
+++ b/test/ClangImporter/import-as-member.swift
@@ -1,0 +1,5 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -F %S/Inputs/frameworks %s -verify
+
+import ImportAsMemberSubmodules
+
+let _: IAMOuter.Inner?


### PR DESCRIPTION
That is, if a member is redeclarable, use the module of the definition if possible, and the canonical declaration otherwise. This is consistent with what we do when we actually import the declaration. Without this, we can end up dropping declarations.

rdar://problem/32816381