### PR TITLE
Explicitly specify target for sanitizer tests.

### DIFF
--- a/test/Sanitizers/asan.swift
+++ b/test/Sanitizers/asan.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swiftc_driver %s -g -sanitize=address -o %t_asan-binary
+// RUN: %target-swiftc_driver %s -target %sanitizers-target-triple -g -sanitize=address -o %t_asan-binary
 // RUN: not env %env-ASAN_OPTIONS=abort_on_error=0 %target-run %t_asan-binary 2>&1 | %FileCheck %s
 // REQUIRES: executable_test
 // REQUIRES: objc_interop

--- a/test/Sanitizers/tsan-ignores-arc-locks.swift
+++ b/test/Sanitizers/tsan-ignores-arc-locks.swift
@@ -1,4 +1,4 @@
-// RUN: %target-build-swift -sanitize=thread %s -o %t_binary
+// RUN: %target-build-swift -target %sanitizers-target-triple -sanitize=thread %s -o %t_binary
 // RUN: %env-TSAN_OPTIONS=ignore_interceptors_accesses=1:halt_on_error=1 %t_binary
 // REQUIRES: executable_test
 // REQUIRES: tsan_runtime

--- a/test/Sanitizers/tsan-inout.swift
+++ b/test/Sanitizers/tsan-inout.swift
@@ -1,5 +1,5 @@
-// RUN: %target-build-swift %S/Inputs/tsan-uninstrumented.swift -module-name TSanUninstrumented -emit-module -emit-module-path %T/TSanUninstrumented.swiftmodule -parse-as-library
-// RUN: %target-build-swift %S/Inputs/tsan-uninstrumented.swift -c -module-name TSanUninstrumented -parse-as-library -o %T/TSanUninstrumented.o
+// RUN: %target-build-swift %S/Inputs/tsan-uninstrumented.swift -target %sanitizers-target-triple -module-name TSanUninstrumented -emit-module -emit-module-path %T/TSanUninstrumented.swiftmodule -parse-as-library
+// RUN: %target-build-swift %S/Inputs/tsan-uninstrumented.swift -target %sanitizers-target-triple -c -module-name TSanUninstrumented -parse-as-library -o %T/TSanUninstrumented.o
 // RUN: %target-swiftc_driver %s %T/TSanUninstrumented.o -I%T -L%T -g -sanitize=thread -o %t_tsan-binary
 // RUN: not env %env-TSAN_OPTIONS=abort_on_error=0 %target-run %t_tsan-binary 2>&1 | %FileCheck %s
 // RUN: not env %env-TSAN_OPTIONS=abort_on_error=0:ignore_interceptors_accesses=0 %target-run %t_tsan-binary 2>&1 | %FileCheck %s --check-prefix CHECK-INTERCEPTORS-ACCESSES

--- a/test/Sanitizers/tsan-norace-block-release.swift
+++ b/test/Sanitizers/tsan-norace-block-release.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swiftc_driver %s -g -sanitize=thread -o %t_tsan-binary
+// RUN: %target-swiftc_driver %s -g -sanitize=thread -target %sanitizers-target-triple -o %t_tsan-binary
 // RUN: env %env-TSAN_OPTIONS=abort_on_error=0:ignore_interceptors_accesses=1 %target-run %t_tsan-binary 2>&1 | %FileCheck %s
 // REQUIRES: executable_test
 // REQUIRES: objc_interop

--- a/test/Sanitizers/tsan-norace-deinit-run-time.swift
+++ b/test/Sanitizers/tsan-norace-deinit-run-time.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swiftc_driver %s -g -sanitize=thread -o %t_tsan-binary
+// RUN: %target-swiftc_driver %s -g -sanitize=thread -target %sanitizers-target-triple -o %t_tsan-binary
 // RUN: env %env-TSAN_OPTIONS=abort_on_error=0:ignore_interceptors_accesses=1 %target-run %t_tsan-binary 2>&1 | %FileCheck %s
 // REQUIRES: executable_test
 // REQUIRES: objc_interop

--- a/test/Sanitizers/tsan-type-metadata.swift
+++ b/test/Sanitizers/tsan-type-metadata.swift
@@ -1,5 +1,5 @@
-// RUN: %target-build-swift -sanitize=thread %s -o %t_binary
-// RUN: %env-TSAN_OPTIONS=ignore_interceptors_accesses=1:halt_on_error=1 %t_binary
+// RUN: %target-swiftc_driver -target %sanitizers-target-triple -sanitize=thread %s -o %t_binary
+// RUN: %env-TSAN_OPTIONS=ignore_interceptors_accesses=1:halt_on_error=1 %target-run %t_binary
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
 // REQUIRES: tsan_runtime

--- a/test/Sanitizers/tsan.swift
+++ b/test/Sanitizers/tsan.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swiftc_driver %s -g -sanitize=thread -o %t_tsan-binary
-// RUN: not env %env-TSAN_OPTIONS=abort_on_error=0 %target-run %t_tsan-binary 2>&1 | %FileCheck %s
+// RUN: %target-swiftc_driver %s -target %sanitizers-target-triple -g -sanitize=thread -o %t_tsan-binary
+// RUN: not env %env-TSAN_OPTIONS="abort_on_error=0" %target-run %t_tsan-binary 2>&1 | %FileCheck %s
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
 // REQUIRES: tsan_runtime

--- a/test/Sanitizers/witness_table_lookup.swift
+++ b/test/Sanitizers/witness_table_lookup.swift
@@ -1,5 +1,5 @@
-// RUN: %target-build-swift -sanitize=thread %s -o %t_binary
-// RUN: %env-TSAN_OPTIONS=ignore_interceptors_accesses=1:halt_on_error=1 %t_binary
+// RUN: %target-build-swift -sanitize=thread -target %sanitizers-target-triple %s -o %t_binary
+// RUN: %env-TSAN_OPTIONS=ignore_interceptors_accesses=1:halt_on_error=1 %target-run %t_binary
 // REQUIRES: executable_test
 // REQUIRES: tsan_runtime
 // REQUIRES: objc_interop

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -540,6 +540,16 @@ else:
 
 # Add substitutions for the run target triple, CPU, OS, and pointer size.
 config.substitutions.append(('%target-triple', config.variant_triple))
+
+# Sanitizers are not supported on iOS7, yet all tests are configured to start
+# testing with the earliest supported platform, which happens to be iOS7 for
+# Swift.
+# Setting target manually makes tests less versatile (a separate test is
+# then required for each OS), thus instead we define a new environment
+# variable which enforces the usage of iOS8+ when iOS is used.
+config.substitutions.append(('%sanitizers-target-triple',
+    config.variant_triple.replace("ios7", "ios8")))
+
 config.substitutions.append(('%target-cpu', run_cpu))
 config.substitutions.append(('%target-os', run_os))
 config.substitutions.append(('%target-ptrsize', run_ptrsize))


### PR DESCRIPTION
When compiling for iOS for a minimal supported version (7) a build error
is encountered when a dylib is used.
This patch avoids this error by changing all sanitizer tests to use iOS
version 8+.
