### PR TITLE
Use the debugger hook, `reportToDebugger`, for all calls to _swift_stdlib_reportFatalError[InFile]

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -185,6 +185,9 @@ namespace swift {
     /// accesses.
     bool DisableTsanInoutInstrumentation = false;
 
+    /// \brief Staging flag for reporting runtime issues to the debugger.
+    bool ReportErrorsToDebugger = false;
+
     /// \brief Staging flag for class resilience, which we do not want to enable
     /// fully until more code is in place, to allow the standard library to be
     /// tested with value type resilience only.

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -294,6 +294,9 @@ def disable_tsan_inout_instrumentation : Flag<["-"],
   "disable-tsan-inout-instrumentation">,
   HelpText<"Disable treatment of inout parameters as Thread Sanitizer accesses">;
 
+def report_errors_to_debugger : Flag<["-"], "report-errors-to-debugger">,
+  HelpText<"Invoke the debugger hook on fatalError calls">;
+
 def enable_infer_import_as_member :
   Flag<["-"], "enable-infer-import-as-member">,
   HelpText<"Infer when a global could be imported as a member">;

--- a/include/swift/Runtime/Debug.h
+++ b/include/swift/Runtime/Debug.h
@@ -210,6 +210,9 @@ enum: uintptr_t {
 void reportToDebugger(uintptr_t flags, const char *message,
                       RuntimeErrorDetails *details = nullptr);
 
+SWIFT_RUNTIME_EXPORT
+bool _swift_reportFatalErrorsToDebugger;
+
 // namespace swift
 }
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -964,6 +964,9 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.DisableTsanInoutInstrumentation |=
       Args.hasArg(OPT_disable_tsan_inout_instrumentation);
 
+  Opts.ReportErrorsToDebugger |=
+      Args.hasArg(OPT_report_errors_to_debugger);
+
   if (FrontendOpts.InputKind == InputFileKind::IFK_SIL)
     Opts.DisableAvailabilityChecking = true;
   

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -795,6 +795,7 @@ private:
 
   void emitGlobalLists();
   void emitAutolinkInfo();
+  void emitEnableReportErrorsToDebugger();
   void cleanupClangCodeGenMetadata();
 
 //--- Remote reflection metadata --------------------------------------------

--- a/stdlib/public/stubs/Assert.cpp
+++ b/stdlib/public/stubs/Assert.cpp
@@ -21,6 +21,8 @@
 
 using namespace swift;
 
+bool swift::_swift_reportFatalErrorsToDebugger = false;
+
 static int swift_asprintf(char **strp, const char *fmt, ...) {
   va_list args;
   va_start(args, fmt);
@@ -49,6 +51,24 @@ static int swift_asprintf(char **strp, const char *fmt, ...) {
   return result;
 }
 
+static void logPrefixAndMessageToDebugger(
+    const unsigned char *prefix, int prefixLength,
+    const unsigned char *message, int messageLength
+) {
+  if (!_swift_reportFatalErrorsToDebugger)
+    return;
+
+  char *debuggerMessage;
+  if (messageLength) {
+    swift_asprintf(&debuggerMessage, "%.*s: %.*s", prefixLength, prefix,
+        messageLength, message);
+  } else {
+    swift_asprintf(&debuggerMessage, "%.*s", prefixLength, prefix);
+  }
+  reportToDebugger(RuntimeErrorFlagFatal, debuggerMessage);
+  free(debuggerMessage);
+}
+
 void swift::_swift_stdlib_reportFatalErrorInFile(
     const unsigned char *prefix, int prefixLength,
     const unsigned char *message, int messageLength,
@@ -56,6 +76,8 @@ void swift::_swift_stdlib_reportFatalErrorInFile(
     uint32_t line,
     uint32_t flags
 ) {
+  logPrefixAndMessageToDebugger(prefix, prefixLength, message, messageLength);
+
   char *log;
   swift_asprintf(
       &log, "%.*s: %.*s%sfile %.*s, line %" PRIu32 "\n",
@@ -74,6 +96,8 @@ void swift::_swift_stdlib_reportFatalError(
     const unsigned char *message, int messageLength,
     uint32_t flags
 ) {
+  logPrefixAndMessageToDebugger(prefix, prefixLength, message, messageLength);
+
   char *log;
   swift_asprintf(
       &log, "%.*s: %.*s\n",


### PR DESCRIPTION
Use the debugger hook, `reportToDebugger`, for all calls to _swift_stdlib_reportFatalError[InFile].  Only do this when a hidden frontend flag, `-report-errors-to-debugger`, is used.

This PR starts using the debugger hook for reporting runtime-detected issues to the LLDB.  The debugger hook is currently being used only for non-fatal errors and errors where we need to provide extra information to help users debug the issue (exclusivity violations, `@objc` inference issues).  This PR extends this to most common fatal issues coming from user code, including:

- force unwrapping nil
- out-of-bounds indexing into arrays
- precondition failures, assertion failures
- `fatalError()` calls
- exceptions caught with `try!`

In those cases, we'll just hand over the prefix+message to the debugger.  For preconditions, assertions, fatalErrors and exceptions that have a custom message string, this string is also part of the description passed to the debugger.  Note that this does not include arithmetic overflows, which still emit a direct trap instruction, and does not include failed dynamic force-casts with `as!`.

Since this affects a lot of code and triggers new codepaths in LLDB in common scenarios, let's stage this in by hiding it under a flag first.  To use this, add `-Xfrontend -report-errors-to-debugger` to compilation of the main executable.  The staging code which adds, sets and reads the flag is temporary — it will eventually be removed.