### PR TITLE
[swiftc (40 vs. 5572)] Add crasher in swift::SILModule::getOrCreateFunction

### DIFF
--- a/validation-test/compiler_crashers/28806-swift-silmodule-get-or-create-function.swift
+++ b/validation-test/compiler_crashers/28806-swift-silmodule-get-or-create-function.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+@_cdecl("main")func x(){}


### PR DESCRIPTION
Add test case for crash triggered in `swift::SILModule::getOrCreateFunction`.

Current number of unresolved compiler crashers: 40 (5572 resolved)

/cc @swiftix - just wanted to let you know that this crasher caused an assertion failure for the assertion `fn->getLoweredFunctionType() == constantType` added on 2015-04-07 by you in commit 0c2fc7c1 :-)

Assertion failure in [`lib/SIL/SILModule.cpp (line 293)`](https://github.com/apple/swift/blob/a8b5a4a18a8251821ade000acdda4f87518fa227/lib/SIL/SILModule.cpp#L293):

```
Assertion `fn->getLoweredFunctionType() == constantType' failed.

When executing: swift::SILFunction *swift::SILModule::getOrCreateFunction(swift::SILLocation, swift::SILDeclRef, swift::ForDefinition_t)
```

Assertion context:

```c++
  auto name = constant.mangle();
  auto constantType = Types.getConstantType(constant).castTo<SILFunctionType>();
  SILLinkage linkage = constant.getLinkage(forDefinition);

  if (auto fn = lookUpFunction(name)) {
    assert(fn->getLoweredFunctionType() == constantType);
    assert(fn->getLinkage() == linkage ||
           (forDefinition == ForDefinition_t::NotForDefinition &&
            fn->getLinkage() ==
                constant.getLinkage(ForDefinition_t::ForDefinition)));
    if (forDefinition) {
```
Stack trace:

```
0 0x0000000003a81578 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3a81578)
1 0x0000000003a81cb6 SignalHandler(int) (/path/to/swift/bin/swift+0x3a81cb6)
2 0x00007fd2db0c4390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007fd2d95e9428 gsignal /build/glibc-bfm8X4/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007fd2d95eb02a abort /build/glibc-bfm8X4/glibc-2.23/stdlib/abort.c:91:0
5 0x00007fd2d95e1bd7 __assert_fail_base /build/glibc-bfm8X4/glibc-2.23/assert/assert.c:92:0
6 0x00007fd2d95e1c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x0000000001084b4f swift::SILModule::getOrCreateFunction(swift::SILLocation, swift::SILDeclRef, swift::ForDefinition_t) (/path/to/swift/bin/swift+0x1084b4f)
8 0x0000000000baf1f0 swift::Lowering::SILGenModule::getFunction(swift::SILDeclRef, swift::ForDefinition_t) (/path/to/swift/bin/swift+0xbaf1f0)
9 0x0000000000c3fc77 swift::Lowering::SILGenModule::emitNativeToForeignThunk(swift::SILDeclRef) (/path/to/swift/bin/swift+0xc3fc77)
10 0x0000000000bb05d0 swift::Lowering::SILGenModule::emitAbstractFuncDecl(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0xbb05d0)
11 0x0000000000baf768 swift::Lowering::SILGenModule::emitFunction(swift::FuncDecl*) (/path/to/swift/bin/swift+0xbaf768)
12 0x0000000000bb58cf swift::ASTVisitor<swift::Lowering::SILGenModule, void, void, void, void, void, void>::visit(swift::Decl*) (/path/to/swift/bin/swift+0xbb58cf)
13 0x0000000000bb4dab swift::Lowering::SILGenModule::emitSourceFile(swift::SourceFile*, unsigned int) (/path/to/swift/bin/swift+0xbb4dab)
14 0x0000000000bb5d54 swift::SILModule::constructSIL(swift::ModuleDecl*, swift::SILOptions&, swift::FileUnit*, llvm::Optional<unsigned int>, bool) (/path/to/swift/bin/swift+0xbb5d54)
15 0x0000000000bb638f swift::performSILGeneration(swift::FileUnit&, swift::SILOptions&, llvm::Optional<unsigned int>) (/path/to/swift/bin/swift+0xbb638f)
16 0x00000000004ad32e performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4ad32e)
17 0x00000000004aa3f9 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4aa3f9)
18 0x0000000000465697 main (/path/to/swift/bin/swift+0x465697)
19 0x00007fd2d95d4830 __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:325:0
20 0x0000000000462d39 _start (/path/to/swift/bin/swift+0x462d39)
```