### PR TITLE
[swiftc (41 vs. 5572)] Add crasher in swift::GenericSignatureBuilder::PotentialArchetype::updateNestedTypeForConformance

### DIFF
--- a/validation-test/compiler_crashers/28807-parentequiv-conformsto-count-proto-0-no-conformance-requirement.swift
+++ b/validation-test/compiler_crashers/28807-parentequiv-conformsto-count-proto-0-no-conformance-requirement.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+class a:RangeReplaceableCollection}protocol P{{}typealias e:a{{}}typealias e:Collection


### PR DESCRIPTION
Add test case for crash triggered in `swift::GenericSignatureBuilder::PotentialArchetype::updateNestedTypeForConformance`.

Current number of unresolved compiler crashers: 41 (5572 resolved)

/cc @DougGregor - just wanted to let you know that this crasher caused an assertion failure for the assertion `parentEquiv->conformsTo.count(proto) > 0 && "No conformance requirement"` added on 2017-06-06 by you in commit 52e52b56 :-)

Assertion failure in [`lib/AST/GenericSignatureBuilder.cpp (line 1750)`](https://github.com/apple/swift/blob/f248c3c83ec6e88e0b1572b24d10f4ae9779332f/lib/AST/GenericSignatureBuilder.cpp#L1750):

```
Assertion `parentEquiv->conformsTo.count(proto) > 0 && "No conformance requirement"' failed.

When executing: void concretizeNestedTypeFromConcreteParent(GenericSignatureBuilder::PotentialArchetype *, GenericSignatureBuilder::PotentialArchetype *, swift::GenericSignatureBuilder &)
```

Assertion context:

```c++
  auto assocType = nestedPA->getResolvedAssociatedType();
  if (!assocType) return;

  auto proto = assocType->getProtocol();
  assert(parentEquiv->conformsTo.count(proto) > 0 &&
         "No conformance requirement");
  const RequirementSource *parentConcreteSource = nullptr;
  for (const auto &constraint : parentEquiv->conformsTo.find(proto)->second) {
    if (constraint.source->kind == RequirementSource::Concrete) {
      parentConcreteSource = constraint.source;
    }
```
Stack trace:

```
0 0x0000000003a81578 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3a81578)
1 0x0000000003a81cb6 SignalHandler(int) (/path/to/swift/bin/swift+0x3a81cb6)
2 0x00007f2aa2563390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007f2aa0a88428 gsignal /build/glibc-bfm8X4/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f2aa0a8a02a abort /build/glibc-bfm8X4/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f2aa0a80bd7 __assert_fail_base /build/glibc-bfm8X4/glibc-2.23/assert/assert.c:92:0
6 0x00007f2aa0a80c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x000000000157e612 concretizeNestedTypeFromConcreteParent(swift::GenericSignatureBuilder::PotentialArchetype*, swift::GenericSignatureBuilder::PotentialArchetype*, swift::GenericSignatureBuilder&) (/path/to/swift/bin/swift+0x157e612)
8 0x000000000157d6ef swift::GenericSignatureBuilder::PotentialArchetype::updateNestedTypeForConformance(llvm::PointerUnion<swift::AssociatedTypeDecl*, swift::TypeDecl*>, swift::ArchetypeResolutionKind) (/path/to/swift/bin/swift+0x157d6ef)
9 0x000000000157d21c swift::GenericSignatureBuilder::PotentialArchetype::updateNestedTypeForConformance(llvm::PointerUnion<swift::AssociatedTypeDecl*, swift::TypeDecl*>, swift::ArchetypeResolutionKind) (/path/to/swift/bin/swift+0x157d21c)
10 0x0000000001580d49 swift::GenericSignatureBuilder::resolve(llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::FloatingRequirementSource) (/path/to/swift/bin/swift+0x1580d49)
11 0x000000000158714b swift::GenericSignatureBuilder::addSameTypeRequirement(llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::FloatingRequirementSource, swift::GenericSignatureBuilder::UnresolvedHandlingKind, llvm::function_ref<void (swift::Type, swift::Type)>) (/path/to/swift/bin/swift+0x158714b)
12 0x0000000001583407 swift::GenericSignatureBuilder::addRequirement(swift::Requirement const&, swift::GenericSignatureBuilder::FloatingRequirementSource, swift::ModuleDecl*, swift::SubstitutionMap const*) (/path/to/swift/bin/swift+0x1583407)
13 0x0000000001581556 swift::GenericSignatureBuilder::addConformanceRequirement(swift::GenericSignatureBuilder::PotentialArchetype*, swift::ProtocolDecl*, swift::GenericSignatureBuilder::RequirementSource const*) (/path/to/swift/bin/swift+0x1581556)
14 0x0000000001585b35 swift::GenericSignatureBuilder::addTypeRequirement(llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::FloatingRequirementSource, swift::GenericSignatureBuilder::UnresolvedHandlingKind) (/path/to/swift/bin/swift+0x1585b35)
15 0x000000000158335b swift::GenericSignatureBuilder::addRequirement(swift::Requirement const&, swift::GenericSignatureBuilder::FloatingRequirementSource, swift::ModuleDecl*, swift::SubstitutionMap const*) (/path/to/swift/bin/swift+0x158335b)
16 0x0000000001581556 swift::GenericSignatureBuilder::addConformanceRequirement(swift::GenericSignatureBuilder::PotentialArchetype*, swift::ProtocolDecl*, swift::GenericSignatureBuilder::RequirementSource const*) (/path/to/swift/bin/swift+0x1581556)
17 0x0000000001585b35 swift::GenericSignatureBuilder::addTypeRequirement(llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::FloatingRequirementSource, swift::GenericSignatureBuilder::UnresolvedHandlingKind) (/path/to/swift/bin/swift+0x1585b35)
18 0x00000000015962d1 swift::GenericSignatureBuilder::ConstraintResult llvm::function_ref<swift::GenericSignatureBuilder::ConstraintResult (swift::Type, swift::TypeRepr const*)>::callback_fn<swift::GenericSignatureBuilder::addInheritedRequirements(swift::TypeDecl*, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::RequirementSource const*, swift::ModuleDecl*)::$_23>(long, swift::Type, swift::TypeRepr const*) (/path/to/swift/bin/swift+0x15962d1)
19 0x000000000158f9a2 std::_Function_handler<void (swift::Type, swift::TypeRepr const*), visitInherited(llvm::ArrayRef<swift::TypeLoc>, llvm::function_ref<swift::GenericSignatureBuilder::ConstraintResult (swift::Type, swift::TypeRepr const*)>)::$_56>::_M_invoke(std::_Any_data const&, swift::Type&&, swift::TypeRepr const*&&) (/path/to/swift/bin/swift+0x158f9a2)
20 0x00000000015812c1 swift::GenericSignatureBuilder::addInheritedRequirements(swift::TypeDecl*, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::RequirementSource const*, swift::ModuleDecl*) (/path/to/swift/bin/swift+0x15812c1)
21 0x0000000001581894 swift::GenericSignatureBuilder::addConformanceRequirement(swift::GenericSignatureBuilder::PotentialArchetype*, swift::ProtocolDecl*, swift::GenericSignatureBuilder::RequirementSource const*) (/path/to/swift/bin/swift+0x1581894)
22 0x0000000001585b35 swift::GenericSignatureBuilder::addTypeRequirement(llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::FloatingRequirementSource, swift::GenericSignatureBuilder::UnresolvedHandlingKind) (/path/to/swift/bin/swift+0x1585b35)
23 0x00000000015962d1 swift::GenericSignatureBuilder::ConstraintResult llvm::function_ref<swift::GenericSignatureBuilder::ConstraintResult (swift::Type, swift::TypeRepr const*)>::callback_fn<swift::GenericSignatureBuilder::addInheritedRequirements(swift::TypeDecl*, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::RequirementSource const*, swift::ModuleDecl*)::$_23>(long, swift::Type, swift::TypeRepr const*) (/path/to/swift/bin/swift+0x15962d1)
24 0x000000000158f9a2 std::_Function_handler<void (swift::Type, swift::TypeRepr const*), visitInherited(llvm::ArrayRef<swift::TypeLoc>, llvm::function_ref<swift::GenericSignatureBuilder::ConstraintResult (swift::Type, swift::TypeRepr const*)>)::$_56>::_M_invoke(std::_Any_data const&, swift::Type&&, swift::TypeRepr const*&&) (/path/to/swift/bin/swift+0x158f9a2)
25 0x00000000015812c1 swift::GenericSignatureBuilder::addInheritedRequirements(swift::TypeDecl*, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::RequirementSource const*, swift::ModuleDecl*) (/path/to/swift/bin/swift+0x15812c1)
26 0x00000000015810de swift::GenericSignatureBuilder::addGenericParameterRequirements(swift::GenericTypeParamDecl*) (/path/to/swift/bin/swift+0x15810de)
27 0x0000000001389922 swift::TypeChecker::checkGenericParamList(swift::GenericSignatureBuilder*, swift::GenericParamList*, swift::GenericSignature*, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0x1389922)
28 0x000000000138cf04 swift::TypeChecker::checkGenericEnvironment(swift::GenericParamList*, swift::DeclContext*, swift::GenericSignature*, bool, llvm::function_ref<void (swift::GenericSignatureBuilder&)>) (/path/to/swift/bin/swift+0x138cf04)
29 0x000000000138d329 swift::TypeChecker::validateGenericTypeSignature(swift::GenericTypeDecl*) (/path/to/swift/bin/swift+0x138d329)
30 0x000000000135e3f0 swift::TypeChecker::validateDecl(swift::ValueDecl*) (/path/to/swift/bin/swift+0x135e3f0)
31 0x000000000136df53 (anonymous namespace)::DeclChecker::visitProtocolDecl(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0x136df53)
32 0x000000000135c5c4 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x135c5c4)
33 0x000000000135c4c3 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x135c4c3)
34 0x00000000013e7284 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x13e7284)
35 0x0000000000fa3f86 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xfa3f86)
36 0x00000000004abe49 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4abe49)
37 0x00000000004aa3f9 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4aa3f9)
38 0x0000000000465697 main (/path/to/swift/bin/swift+0x465697)
39 0x00007f2aa0a73830 __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:325:0
40 0x0000000000462d39 _start (/path/to/swift/bin/swift+0x462d39)
```