### PR TITLE
[swiftc (42 vs. 5572)] Add crasher in swift::GenericSignatureBuilder::Constraint

### DIFF
--- a/validation-test/compiler_crashers/28808-hasval.swift
+++ b/validation-test/compiler_crashers/28808-hasval.swift
@@ -1,0 +1,13 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol P{typealias a
+protocol A:P{
+typealias a
+}{}class a<a


### PR DESCRIPTION
Add test case for crash triggered in `swift::GenericSignatureBuilder::Constraint`.

Current number of unresolved compiler crashers: 42 (5572 resolved)

Assertion failure in `llvm/include/llvm/ADT/Optional.h (line 129)`:

```
Assertion `hasVal' failed.

When executing: T &llvm::Optional<swift::GenericSignatureBuilder::Constraint<swift::Type> >::operator*() & [T = swift::GenericSignatureBuilder::Constraint<swift::Type>]
```

Assertion context:

```c++
  explicit operator bool() const { return hasVal; }
  bool hasValue() const { return hasVal; }
  const T* operator->() const { return getPointer(); }
  T* operator->() { return getPointer(); }
  const T& operator*() const LLVM_LVALUE_FUNCTION { assert(hasVal); return *getPointer(); }
  T& operator*() LLVM_LVALUE_FUNCTION { assert(hasVal); return *getPointer(); }

  template <typename U>
  constexpr T getValueOr(U &&value) const LLVM_LVALUE_FUNCTION {
    return hasValue() ? getValue() : std::forward<U>(value);
  }
```
Stack trace:

```
0 0x0000000003a81578 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3a81578)
1 0x0000000003a81cb6 SignalHandler(int) (/path/to/swift/bin/swift+0x3a81cb6)
2 0x00007f3195370390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007f3193895428 gsignal /build/glibc-bfm8X4/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f319389702a abort /build/glibc-bfm8X4/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f319388dbd7 __assert_fail_base /build/glibc-bfm8X4/glibc-2.23/assert/assert.c:92:0
6 0x00007f319388dc82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x0000000001599bae swift::GenericSignatureBuilder::Constraint<swift::Type> swift::GenericSignatureBuilder::checkConstraintList<swift::Type, swift::Type>(llvm::ArrayRef<swift::GenericTypeParamType*>, std::vector<swift::GenericSignatureBuilder::Constraint<swift::Type>, std::allocator<swift::GenericSignatureBuilder::Constraint<swift::Type> > >&, llvm::function_ref<bool (swift::GenericSignatureBuilder::Constraint<swift::Type> const&)>, llvm::function_ref<swift::GenericSignatureBuilder::ConstraintRelation (swift::Type const&)>, llvm::Optional<swift::Diag<unsigned int, swift::Type, swift::Type, swift::Type> >, swift::Diag<swift::Type, swift::Type>, swift::Diag<unsigned int, swift::Type, swift::Type>, llvm::function_ref<swift::Type (swift::Type const&)>, bool) (/path/to/swift/bin/swift+0x1599bae)
8 0x000000000158c7b4 swift::GenericSignatureBuilder::checkConcreteTypeConstraints(llvm::ArrayRef<swift::GenericTypeParamType*>, swift::GenericSignatureBuilder::PotentialArchetype*) (/path/to/swift/bin/swift+0x158c7b4)
9 0x0000000001587fd7 swift::GenericSignatureBuilder::finalize(swift::SourceLoc, llvm::ArrayRef<swift::GenericTypeParamType*>, bool) (/path/to/swift/bin/swift+0x1587fd7)
10 0x000000000138cf40 swift::TypeChecker::checkGenericEnvironment(swift::GenericParamList*, swift::DeclContext*, swift::GenericSignature*, bool, llvm::function_ref<void (swift::GenericSignatureBuilder&)>) (/path/to/swift/bin/swift+0x138cf40)
11 0x000000000138d329 swift::TypeChecker::validateGenericTypeSignature(swift::GenericTypeDecl*) (/path/to/swift/bin/swift+0x138d329)
12 0x000000000135e3f0 swift::TypeChecker::validateDecl(swift::ValueDecl*) (/path/to/swift/bin/swift+0x135e3f0)
13 0x000000000136df53 (anonymous namespace)::DeclChecker::visitProtocolDecl(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0x136df53)
14 0x000000000135c5c4 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x135c5c4)
15 0x000000000136e26b (anonymous namespace)::DeclChecker::visitProtocolDecl(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0x136e26b)
16 0x000000000135c5c4 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x135c5c4)
17 0x000000000135c4c3 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x135c4c3)
18 0x00000000013e7284 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x13e7284)
19 0x0000000000fa3f86 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xfa3f86)
20 0x00000000004abe49 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4abe49)
21 0x00000000004aa3f9 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4aa3f9)
22 0x0000000000465697 main (/path/to/swift/bin/swift+0x465697)
23 0x00007f3193880830 __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:325:0
24 0x0000000000462d39 _start (/path/to/swift/bin/swift+0x462d39)
```