### PR TITLE
[swiftc (43 vs. 5572)] Add crasher in swift::Mangle::Mangler::appendIdentifier(...)

### DIFF
--- a/validation-test/compiler_crashers/28809-isdigit-ident-pos-first-char-of-sub-string-may-not-be-a-digit.swift
+++ b/validation-test/compiler_crashers/28809-isdigit-ident-pos-first-char-of-sub-string-may-not-be-a-digit.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol 0{class TextOutputStream


### PR DESCRIPTION
Add test case for crash triggered in `swift::Mangle::Mangler::appendIdentifier(...)`.

Current number of unresolved compiler crashers: 43 (5572 resolved)

/cc @eeckstein - just wanted to let you know that this crasher caused an assertion failure for the assertion `!isDigit(ident[Pos]) && "first char of sub-string may not be a digit"` added on 2016-12-02 by you in commit 684092d7 :-)

Assertion failure in [`include/swift/Demangling/ManglingUtils.h (line 195)`](https://github.com/apple/swift/blob/a45d7e3d2a07c274a64a6a9409ff853db32388aa/include/swift/Demangling/ManglingUtils.h#L195):

```
Assertion `!isDigit(ident[Pos]) && "first char of sub-string may not be a digit"' failed.

When executing: void swift::Mangle::mangleIdentifier(Mangler &, llvm::StringRef) [Mangler = swift::Mangle::Mangler]
```

Assertion context:

```c++
      // Mangle the sub-string up to the next word substitution (or to the end
      // of the identifier - that's why we added the dummy-word).
      // The first thing: we add the encoded sub-string length.
      M.Buffer << (Repl.StringPos - Pos);
      assert(!isDigit(ident[Pos]) &&
             "first char of sub-string may not be a digit");
      do {
        // Update the start position of new added words, so that they refer to
        // the begin of the whole mangled Buffer.
        if (WordsInBuffer < M.Words.size() &&
            M.Words[WordsInBuffer].start == Pos) {
```
Stack trace:

```
0 0x0000000003a81578 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3a81578)
1 0x0000000003a81cb6 SignalHandler(int) (/path/to/swift/bin/swift+0x3a81cb6)
2 0x00007f7279128390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007f727764d428 gsignal /build/glibc-bfm8X4/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f727764f02a abort /build/glibc-bfm8X4/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f7277645bd7 __assert_fail_base /build/glibc-bfm8X4/glibc-2.23/assert/assert.c:92:0
6 0x00007f7277645c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x00000000015f5ccb void swift::Mangle::mangleIdentifier<swift::Mangle::Mangler>(swift::Mangle::Mangler&, llvm::StringRef) (/path/to/swift/bin/swift+0x15f5ccb)
8 0x00000000015f51f6 swift::Mangle::Mangler::appendIdentifier(llvm::StringRef) (/path/to/swift/bin/swift+0x15f51f6)
9 0x00000000014e82f0 swift::Mangle::ASTMangler::appendDeclName(swift::ValueDecl const*) (/path/to/swift/bin/swift+0x14e82f0)
10 0x00000000014e47ab swift::Mangle::ASTMangler::appendAnyGenericType(swift::GenericTypeDecl const*) (/path/to/swift/bin/swift+0x14e47ab)
11 0x00000000014e47a0 swift::Mangle::ASTMangler::appendAnyGenericType(swift::GenericTypeDecl const*) (/path/to/swift/bin/swift+0x14e47a0)
12 0x00000000014e4701 swift::Mangle::ASTMangler::mangleNominalType[abi:cxx11](swift::NominalTypeDecl const*) (/path/to/swift/bin/swift+0x14e4701)
13 0x00000000011124cd swift::ModuleFile::loadExtensions(swift::NominalTypeDecl*) (/path/to/swift/bin/swift+0x11124cd)
14 0x00000000011776b1 swift::SerializedModuleLoader::loadExtensions(swift::NominalTypeDecl*, unsigned int) (/path/to/swift/bin/swift+0x11776b1)
15 0x00000000014a4ae0 swift::ASTContext::loadExtensions(swift::NominalTypeDecl*, unsigned int) (/path/to/swift/bin/swift+0x14a4ae0)
16 0x00000000015e958c swift::ConformanceLookupTable::updateLookupTable(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceStage, swift::LazyResolver*) (/path/to/swift/bin/swift+0x15e958c)
17 0x00000000015e8ecf swift::ConformanceLookupTable::updateLookupTable(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceStage, swift::LazyResolver*) (/path/to/swift/bin/swift+0x15e8ecf)
18 0x00000000015e8df5 swift::ConformanceLookupTable::updateLookupTable(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceStage, swift::LazyResolver*) (/path/to/swift/bin/swift+0x15e8df5)
19 0x00000000015eceee swift::ConformanceLookupTable::getAllProtocols(swift::NominalTypeDecl*, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ProtocolDecl*>&) (/path/to/swift/bin/swift+0x15eceee)
20 0x00000000015c4e26 swift::NominalTypeDecl::getAllProtocols() const (/path/to/swift/bin/swift+0x15c4e26)
21 0x000000000139f941 swift::TypeChecker::findWitnessedObjCRequirements(swift::ValueDecl const*, bool) (/path/to/swift/bin/swift+0x139f941)
22 0x0000000001358fc5 inferObjCName(swift::TypeChecker&, swift::ValueDecl*) (/path/to/swift/bin/swift+0x1358fc5)
23 0x0000000001358977 swift::markAsObjC(swift::TypeChecker&, swift::ValueDecl*, llvm::Optional<swift::ObjCReason>, llvm::Optional<swift::ForeignErrorConvention>) (/path/to/swift/bin/swift+0x1358977)
24 0x000000000136faa7 (anonymous namespace)::DeclChecker::visitDestructorDecl(swift::DestructorDecl*) (/path/to/swift/bin/swift+0x136faa7)
25 0x000000000135c5b4 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x135c5b4)
26 0x000000000135c4c3 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x135c4c3)
27 0x000000000145003d swift::TypeChecker::addImplicitDestructor(swift::ClassDecl*) (/path/to/swift/bin/swift+0x145003d)
28 0x000000000136d190 (anonymous namespace)::DeclChecker::visitClassDecl(swift::ClassDecl*) (/path/to/swift/bin/swift+0x136d190)
29 0x000000000135c6be (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x135c6be)
30 0x000000000136e26b (anonymous namespace)::DeclChecker::visitProtocolDecl(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0x136e26b)
31 0x000000000135c5c4 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x135c5c4)
32 0x000000000135c4c3 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x135c4c3)
33 0x00000000013e7284 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x13e7284)
34 0x0000000000fa3f86 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xfa3f86)
35 0x00000000004abe49 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4abe49)
36 0x00000000004aa3f9 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4aa3f9)
37 0x0000000000465697 main (/path/to/swift/bin/swift+0x465697)
38 0x00007f7277638830 __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:325:0
39 0x0000000000462d39 _start (/path/to/swift/bin/swift+0x462d39)
```