### PR TITLE
[swift-4.0-branch][overlay] Rename scheduleOneShot and scheduleRepeating

### DIFF
--- a/stdlib/public/SDK/Dispatch/Source.swift
+++ b/stdlib/public/SDK/Dispatch/Source.swift
@@ -261,28 +261,341 @@ public extension DispatchSourceProcess {
 }
 
 public extension DispatchSourceTimer {
+	///
+	/// Sets the deadline and leeway for a timer event that fires once.
+	///
+	/// Once this function returns, any pending source data accumulated for the previous timer values
+	/// has been cleared and the next timer event will occur at `deadline`.
+	///
+	/// Delivery of the timer event may be delayed by the system in order to improve power consumption
+	/// and system performance. The upper limit to the allowable delay may be configured with the `leeway`
+	/// argument; the lower limit is under the control of the system.
+	///
+	/// The lower limit to the allowable delay may vary with process state such as visibility of the
+	/// application UI. If the timer source was created with flags `TimerFlags.strict`, the system
+	/// will make a best effort to strictly observe the provided `leeway` value, even if it is smaller
+	/// than the current lower limit. Note that a minimal amount of delay is to be expected even if
+	/// this flag is specified.
+	///
+	/// Calling this method has no effect if the timer source has already been canceled.
+	/// - note: Delivery of the timer event does not cancel the timer source.
+	///
+	/// - parameter deadline: the time at which the timer event will be delivered, subject to the
+	///     leeway and other considerations described above. The deadline is based on Mach absolute
+	///     time.
+	/// - parameter leeway: the leeway for the timer.
+	///
+	@available(swift, deprecated: 4, renamed: "schedule(deadline:repeating:leeway:)")
 	public func scheduleOneshot(deadline: DispatchTime, leeway: DispatchTimeInterval = .nanoseconds(0)) {
 		__dispatch_source_set_timer(self as! DispatchSource, UInt64(deadline.rawValue), ~0, UInt64(leeway.rawValue))
 	}
 
+	///
+	/// Sets the deadline and leeway for a timer event that fires once.
+	///
+	/// Once this function returns, any pending source data accumulated for the previous timer values
+	/// has been cleared and the next timer event will occur at `wallDeadline`.
+	///
+	/// Delivery of the timer event may be delayed by the system in order to improve power consumption
+	/// and system performance. The upper limit to the allowable delay may be configured with the `leeway`
+	/// argument; the lower limit is under the control of the system.
+	///
+	/// The lower limit to the allowable delay may vary with process state such as visibility of the
+	/// application UI. If the timer source was created with flags `TimerFlags.strict`, the system
+	/// will make a best effort to strictly observe the provided `leeway` value, even if it is smaller
+	/// than the current lower limit. Note that a minimal amount of delay is to be expected even if
+	/// this flag is specified.
+	///
+	/// Calling this method has no effect if the timer source has already been canceled.
+	/// - note: Delivery of the timer event does not cancel the timer source.
+	///
+	/// - parameter wallDeadline: the time at which the timer event will be delivered, subject to the
+	///     leeway and other considerations described above. The deadline is based on
+	///     `gettimeofday(3)`.
+	/// - parameter leeway: the leeway for the timer.
+	///
+	@available(swift, deprecated: 4, renamed: "schedule(wallDeadline:repeating:leeway:)")
 	public func scheduleOneshot(wallDeadline: DispatchWallTime, leeway: DispatchTimeInterval = .nanoseconds(0)) {
 		__dispatch_source_set_timer(self as! DispatchSource, UInt64(wallDeadline.rawValue), ~0, UInt64(leeway.rawValue))
 	}
-
+	///
+	/// Sets the deadline, interval and leeway for a timer event that fires at least once.
+	///
+	/// Once this function returns, any pending source data accumulated for the previous timer values
+	/// has been cleared. The next timer event will occur at `deadline` and every `interval` units of
+	/// time thereafter until the timer source is canceled.
+	///
+	/// Delivery of a timer event may be delayed by the system in order to improve power consumption
+	/// and system performance. The upper limit to the allowable delay may be configured with the `leeway`
+	/// argument; the lower limit is under the control of the system.
+	///
+	/// For the initial timer fire at `deadline`, the upper limit to the allowable delay is set to
+	/// `leeway`. For the subsequent timer fires at `deadline + N * interval`, the upper
+	/// limit is the smaller of `leeway` and `interval/2`.
+	///
+	/// The lower limit to the allowable delay may vary with process state such as visibility of the
+	/// application UI. If the timer source was created with flags `TimerFlags.strict`, the system
+	/// will make a best effort to strictly observe the provided `leeway` value, even if it is smaller
+	/// than the current lower limit. Note that a minimal amount of delay is to be expected even if
+	/// this flag is specified.
+	///
+	/// Calling this method has no effect if the timer source has already been canceled.
+	///
+	/// - parameter deadline: the time at which the timer event will be delivered, subject to the
+	///     leeway and other considerations described above. The deadline is based on Mach absolute
+	///     time.
+	/// - parameter interval: the interval for the timer.
+	/// - parameter leeway: the leeway for the timer.
+	///
+	@available(swift, deprecated: 4, renamed: "schedule(deadline:repeating:leeway:)")
 	public func scheduleRepeating(deadline: DispatchTime, interval: DispatchTimeInterval, leeway: DispatchTimeInterval = .nanoseconds(0)) {
-		__dispatch_source_set_timer(self as! DispatchSource, deadline.rawValue, UInt64(interval.rawValue), UInt64(leeway.rawValue))
+		__dispatch_source_set_timer(self as! DispatchSource, deadline.rawValue, interval == .never ? ~0 : UInt64(interval.rawValue), UInt64(leeway.rawValue))
 	}
 
+	///
+	/// Sets the deadline, interval and leeway for a timer event that fires at least once.
+	///
+	/// Once this function returns, any pending source data accumulated for the previous timer values
+	/// has been cleared. The next timer event will occur at `deadline` and every `interval` seconds
+	/// thereafter until the timer source is canceled.
+	///
+	/// Delivery of a timer event may be delayed by the system in order to improve power consumption and
+	/// system performance. The upper limit to the allowable delay may be configured with the `leeway`
+	/// argument; the lower limit is under the control of the system.
+	///
+	/// For the initial timer fire at `deadline`, the upper limit to the allowable delay is set to
+	/// `leeway`. For the subsequent timer fires at `deadline + N * interval`, the upper
+	/// limit is the smaller of `leeway` and `interval/2`.
+	///
+	/// The lower limit to the allowable delay may vary with process state such as visibility of the
+	/// application UI. If the timer source was created with flags `TimerFlags.strict`, the system
+	/// will make a best effort to strictly observe the provided `leeway` value, even if it is smaller
+	/// than the current lower limit. Note that a minimal amount of delay is to be expected even if
+	/// this flag is specified.
+	///
+	/// Calling this method has no effect if the timer source has already been canceled.
+	///
+	/// - parameter deadline: the time at which the timer event will be delivered, subject to the
+	///     leeway and other considerations described above. The deadline is based on Mach absolute
+	///     time.
+	/// - parameter interval: the interval for the timer in seconds.
+	/// - parameter leeway: the leeway for the timer.
+	///
+	@available(swift, deprecated: 4, renamed: "schedule(deadline:repeating:leeway:)")
 	public func scheduleRepeating(deadline: DispatchTime, interval: Double, leeway: DispatchTimeInterval = .nanoseconds(0)) {
-		__dispatch_source_set_timer(self as! DispatchSource, deadline.rawValue, UInt64(interval * Double(NSEC_PER_SEC)), UInt64(leeway.rawValue))
+		__dispatch_source_set_timer(self as! DispatchSource, deadline.rawValue, interval.isInfinite ? ~0 : UInt64(interval * Double(NSEC_PER_SEC)), UInt64(leeway.rawValue))
 	}
 
+	///
+	/// Sets the deadline, interval and leeway for a timer event that fires at least once.
+	///
+	/// Once this function returns, any pending source data accumulated for the previous timer values
+	/// has been cleared. The next timer event will occur at `wallDeadline` and every `interval` units of
+	/// time thereafter until the timer source is canceled.
+	///
+	/// Delivery of a timer event may be delayed by the system in order to improve power consumption and
+	/// system performance. The upper limit to the allowable delay may be configured with the `leeway`
+	/// argument; the lower limit is under the control of the system.
+	///
+	/// For the initial timer fire at `wallDeadline`, the upper limit to the allowable delay is set to
+	/// `leeway`. For the subsequent timer fires at `wallDeadline + N * interval`, the upper
+	/// limit is the smaller of `leeway` and `interval/2`.
+	///
+	/// The lower limit to the allowable delay may vary with process state such as visibility of the
+	/// application UI. If the timer source was created with flags `TimerFlags.strict`, the system
+	/// will make a best effort to strictly observe the provided `leeway` value, even if it is smaller
+	/// than the current lower limit. Note that a minimal amount of delay is to be expected even if
+	/// this flag is specified.
+	///
+	/// Calling this method has no effect if the timer source has already been canceled.
+	///
+	/// - parameter wallDeadline: the time at which the timer event will be delivered, subject to the
+	///     leeway and other considerations described above. The deadline is based on
+	///     `gettimeofday(3)`.
+	/// - parameter interval: the interval for the timer.
+	/// - parameter leeway: the leeway for the timer.
+	///
+	@available(swift, deprecated: 4, renamed: "schedule(wallDeadline:repeating:leeway:)")
 	public func scheduleRepeating(wallDeadline: DispatchWallTime, interval: DispatchTimeInterval, leeway: DispatchTimeInterval = .nanoseconds(0)) {
-		__dispatch_source_set_timer(self as! DispatchSource, wallDeadline.rawValue, UInt64(interval.rawValue), UInt64(leeway.rawValue))
+		__dispatch_source_set_timer(self as! DispatchSource, wallDeadline.rawValue, interval == .never ? ~0 : UInt64(interval.rawValue), UInt64(leeway.rawValue))
 	}
 
+	///
+	/// Sets the deadline, interval and leeway for a timer event that fires at least once.
+	///
+	/// Once this function returns, any pending source data accumulated for the previous timer values
+	/// has been cleared. The next timer event will occur at `wallDeadline` and every `interval` seconds
+	/// thereafter until the timer source is canceled.
+	///
+	/// Delivery of a timer event may be delayed by the system in order to improve power consumption and
+	/// system performance. The upper limit to the allowable delay may be configured with the `leeway`
+	/// argument; the lower limit is under the control of the system.
+	///
+	/// For the initial timer fire at `wallDeadline`, the upper limit to the allowable delay is set to
+	/// `leeway`. For the subsequent timer fires at `wallDeadline + N * interval`, the upper
+	/// limit is the smaller of `leeway` and `interval/2`.
+	///
+	/// The lower limit to the allowable delay may vary with process state such as visibility of the
+	/// application UI. If the timer source was created with flags `TimerFlags.strict`, the system
+	/// will make a best effort to strictly observe the provided `leeway` value, even if it is smaller
+	/// than the current lower limit. Note that a minimal amount of delay is to be expected even if
+	/// this flag is specified.
+	///
+	/// Calling this method has no effect if the timer source has already been canceled.
+	///
+	/// - parameter wallDeadline: the time at which the timer event will be delivered, subject to the
+	///     leeway and other considerations described above. The deadline is based on
+	///     `gettimeofday(3)`.
+	/// - parameter interval: the interval for the timer in seconds.
+	/// - parameter leeway: the leeway for the timer.
+	///
+	@available(swift, deprecated: 4, renamed: "schedule(wallDeadline:repeating:leeway:)")
 	public func scheduleRepeating(wallDeadline: DispatchWallTime, interval: Double, leeway: DispatchTimeInterval = .nanoseconds(0)) {
-		__dispatch_source_set_timer(self as! DispatchSource, wallDeadline.rawValue, UInt64(interval * Double(NSEC_PER_SEC)), UInt64(leeway.rawValue))
+		__dispatch_source_set_timer(self as! DispatchSource, wallDeadline.rawValue, interval.isInfinite ? ~0 : UInt64(interval * Double(NSEC_PER_SEC)), UInt64(leeway.rawValue))
+	}
+
+	///
+	/// Sets the deadline, repeat interval and leeway for a timer event.
+	///
+	/// Once this function returns, any pending source data accumulated for the previous timer values
+	/// has been cleared. The next timer event will occur at `deadline` and every `repeating` units of
+	/// time thereafter until the timer source is canceled. If the value of `repeating` is `.never`,
+	/// or is defaulted, the timer fires only once.
+	///
+	/// Delivery of a timer event may be delayed by the system in order to improve power consumption
+	/// and system performance. The upper limit to the allowable delay may be configured with the `leeway`
+	/// argument; the lower limit is under the control of the system.
+	///
+	/// For the initial timer fire at `deadline`, the upper limit to the allowable delay is set to
+	/// `leeway`. For the subsequent timer fires at `deadline + N * repeating`, the upper
+	/// limit is the smaller of `leeway` and `repeating/2`.
+	///
+	/// The lower limit to the allowable delay may vary with process state such as visibility of the
+	/// application UI. If the timer source was created with flags `TimerFlags.strict`, the system
+	/// will make a best effort to strictly observe the provided `leeway` value, even if it is smaller
+	/// than the current lower limit. Note that a minimal amount of delay is to be expected even if
+	/// this flag is specified.
+	///
+	/// Calling this method has no effect if the timer source has already been canceled.
+	///
+	/// - parameter deadline: the time at which the first timer event will be delivered, subject to the
+	///     leeway and other considerations described above. The deadline is based on Mach absolute
+	///     time.
+	/// - parameter repeating: the repeat interval for the timer, or `.never` if the timer should fire
+	///		only once.
+	/// - parameter leeway: the leeway for the timer.
+	///
+	@available(swift, introduced: 4)
+	public func schedule(deadline: DispatchTime, repeating interval: DispatchTimeInterval = .never, leeway: DispatchTimeInterval = .nanoseconds(0)) {
+		__dispatch_source_set_timer(self as! DispatchSource, deadline.rawValue, interval == .never ? ~0 : UInt64(interval.rawValue), UInt64(leeway.rawValue))
+	}
+
+	///
+	/// Sets the deadline, repeat interval and leeway for a timer event.
+	///
+	/// Once this function returns, any pending source data accumulated for the previous timer values
+	/// has been cleared. The next timer event will occur at `deadline` and every `repeating` seconds
+	/// thereafter until the timer source is canceled. If the value of `repeating` is `.infinity`,
+	/// the timer fires only once.
+	///
+	/// Delivery of a timer event may be delayed by the system in order to improve power consumption
+	/// and system performance. The upper limit to the allowable delay may be configured with the `leeway`
+	/// argument; the lower limit is under the control of the system.
+	///
+	/// For the initial timer fire at `deadline`, the upper limit to the allowable delay is set to
+	/// `leeway`. For the subsequent timer fires at `deadline + N * repeating`, the upper
+	/// limit is the smaller of `leeway` and `repeating/2`.
+	///
+	/// The lower limit to the allowable delay may vary with process state such as visibility of the
+	/// application UI. If the timer source was created with flags `TimerFlags.strict`, the system
+	/// will make a best effort to strictly observe the provided `leeway` value, even if it is smaller
+	/// than the current lower limit. Note that a minimal amount of delay is to be expected even if
+	/// this flag is specified.
+	///
+	/// Calling this method has no effect if the timer source has already been canceled.
+	///
+	/// - parameter deadline: the time at which the timer event will be delivered, subject to the
+	///     leeway and other considerations described above. The deadline is based on Mach absolute
+	///     time.
+	/// - parameter repeating: the repeat interval for the timer in seconds, or `.infinity` if the timer
+	///		should fire only once.
+	/// - parameter leeway: the leeway for the timer.
+	///
+	@available(swift, introduced: 4)
+	public func schedule(deadline: DispatchTime, repeating interval: Double, leeway: DispatchTimeInterval = .nanoseconds(0)) {
+		__dispatch_source_set_timer(self as! DispatchSource, deadline.rawValue, interval.isInfinite ? ~0 : UInt64(interval * Double(NSEC_PER_SEC)), UInt64(leeway.rawValue))
+	}
+
+	///
+	/// Sets the deadline, repeat interval and leeway for a timer event.
+	///
+	/// Once this function returns, any pending source data accumulated for the previous timer values
+	/// has been cleared. The next timer event will occur at `wallDeadline` and every `repeating` units of
+	/// time thereafter until the timer source is canceled. If the value of `repeating` is `.never`,
+	/// or is defaulted, the timer fires only once.
+	///
+	/// Delivery of a timer event may be delayed by the system in order to improve power consumption and
+	/// system performance. The upper limit to the allowable delay may be configured with the `leeway`
+	/// argument; the lower limit is under the control of the system.
+	///
+	/// For the initial timer fire at `wallDeadline`, the upper limit to the allowable delay is set to
+	/// `leeway`. For the subsequent timer fires at `wallDeadline + N * repeating`, the upper
+	/// limit is the smaller of `leeway` and `repeating/2`.
+	///
+	/// The lower limit to the allowable delay may vary with process state such as visibility of the
+	/// application UI. If the timer source was created with flags `TimerFlags.strict`, the system
+	/// will make a best effort to strictly observe the provided `leeway` value, even if it is smaller
+	/// than the current lower limit. Note that a minimal amount of delay is to be expected even if
+	/// this flag is specified.
+	///
+	/// Calling this method has no effect if the timer source has already been canceled.
+	///
+	/// - parameter wallDeadline: the time at which the timer event will be delivered, subject to the
+	///     leeway and other considerations described above. The deadline is based on
+	///     `gettimeofday(3)`.
+	/// - parameter repeating: the repeat interval for the timer, or `.never` if the timer should fire
+	///		only once.
+	/// - parameter leeway: the leeway for the timer.
+	///
+	@available(swift, introduced: 4)
+	public func schedule(wallDeadline: DispatchWallTime, repeating interval: DispatchTimeInterval = .never, leeway: DispatchTimeInterval = .nanoseconds(0)) {
+		__dispatch_source_set_timer(self as! DispatchSource, wallDeadline.rawValue, interval == .never ? ~0 : UInt64(interval.rawValue), UInt64(leeway.rawValue))
+	}
+
+	///
+	/// Sets the deadline, repeat interval and leeway for a timer event that fires at least once.
+	///
+	/// Once this function returns, any pending source data accumulated for the previous timer values
+	/// has been cleared. The next timer event will occur at `wallDeadline` and every `repeating` seconds
+	/// thereafter until the timer source is canceled. If the value of `repeating` is `.infinity`,
+	/// the timer fires only once.
+	///
+	/// Delivery of a timer event may be delayed by the system in order to improve power consumption
+	/// and system performance. The upper limit to the allowable delay may be configured with the `leeway`
+	/// argument; the lower limit is under the control of the system.
+	///
+	/// For the initial timer fire at `wallDeadline`, the upper limit to the allowable delay is set to
+	/// `leeway`. For the subsequent timer fires at `wallDeadline + N * repeating`, the upper
+	/// limit is the smaller of `leeway` and `repeating/2`.
+	///
+	/// The lower limit to the allowable delay may vary with process state such as visibility of the
+	/// application UI. If the timer source was created with flags `TimerFlags.strict`, the system
+	/// will make a best effort to strictly observe the provided `leeway` value, even if it is smaller
+	/// than the current lower limit. Note that a minimal amount of delay is to be expected even if
+	/// this flag is specified.
+	///
+	/// Calling this method has no effect if the timer source has already been canceled.
+	///
+	/// - parameter wallDeadline: the time at which the timer event will be delivered, subject to the
+	///     leeway and other considerations described above. The deadline is based on
+	///     `gettimeofday(3)`.
+	/// - parameter repeating: the repeat interval for the timer in secondss, or `.infinity` if the timer
+	/// 	should fire only once.
+	/// - parameter leeway: the leeway for the timer.
+	///
+	@available(swift, introduced: 4)
+	public func schedule(wallDeadline: DispatchWallTime, repeating interval: Double, leeway: DispatchTimeInterval = .nanoseconds(0)) {
+		__dispatch_source_set_timer(self as! DispatchSource, wallDeadline.rawValue, interval.isInfinite ? ~0 : UInt64(interval * Double(NSEC_PER_SEC)), UInt64(leeway.rawValue))
 	}
 }
 

--- a/stdlib/public/SDK/Dispatch/Time.swift
+++ b/stdlib/public/SDK/Dispatch/Time.swift
@@ -114,11 +114,13 @@ extension DispatchWallTime {
   }
 }
 
-public enum DispatchTimeInterval {
+public enum DispatchTimeInterval : Equatable {
 	case seconds(Int)
 	case milliseconds(Int)
 	case microseconds(Int)
 	case nanoseconds(Int)
+	@_downgrade_exhaustivity_check
+	case never
 
 	internal var rawValue: Int64 {
 		switch self {
@@ -126,6 +128,16 @@ public enum DispatchTimeInterval {
 		case .milliseconds(let ms): return Int64(ms) * Int64(NSEC_PER_MSEC)
 		case .microseconds(let us): return Int64(us) * Int64(NSEC_PER_USEC)
 		case .nanoseconds(let ns): return Int64(ns)
+		case .never: return Int64.max
+		}
+	}
+
+	public static func ==(lhs: DispatchTimeInterval, rhs: DispatchTimeInterval) -> Bool {
+		switch (lhs, rhs) {
+		case (.never, .never): return true
+		case (.never, _): return false
+		case (_, .never): return false
+		default: return lhs.rawValue == rhs.rawValue
 		}
 	}
 }

--- a/test/stdlib/Dispatch.swift
+++ b/test/stdlib/Dispatch.swift
@@ -508,3 +508,12 @@ if #available(OSX 10.13, iOS 11.0, watchOS 4.0, tvOS 11.0, *) {
 		expectTrue(result == .success)
 	}
 }
+
+#if swift(>=4.0)
+DispatchAPI.test("DispatchTimeInterval.never.equals") {
+	expectTrue(DispatchTimeInterval.never == DispatchTimeInterval.never)
+	expectTrue(DispatchTimeInterval.seconds(10) != DispatchTimeInterval.never);
+	expectTrue(DispatchTimeInterval.never != DispatchTimeInterval.seconds(10));
+	expectTrue(DispatchTimeInterval.seconds(10) == DispatchTimeInterval.seconds(10));
+}
+#endif


### PR DESCRIPTION
* Explanation: This change deprecates several methods of the `DispatchSourceTimer` struct, replacing them with methods that have more meaningful names. It also introduces the enumeration case `DispatchTimeInterval.never`, which can be used to specify that a timer should never fire or never repeat.
* Scope of Issue: This is not a source-breaking change. The only effect on existing code is that uses of the deprecated methods will be flagged at compile time.
* Risk: Since the existing methods remain and their code is almost unmodified, this is a very low-risk change.
* Reviewed By: Daniel Steffen
* Testing: There are tests in the Dispatch test suite that cover this code change.
* Directions for QA: N/A
* Radar: <rdar://problem/32991313>
