### PR TITLE
[benchmark] Fix: Run test suite just once

### DIFF
--- a/benchmark/scripts/Benchmark_Driver
+++ b/benchmark/scripts/Benchmark_Driver
@@ -124,13 +124,13 @@ def get_tests(driver_path, args):
     if args.benchmarks or args.filters:
         driver.append('--run-all')
     tests = subprocess.check_output(driver).split()[2:]
-    tests.extend(map(str, range(1, len(tests) + 1)))  # ordinal numbers
     if args.filters:
         regexes = [re.compile(pattern) for pattern in args.filters]
         return sorted(list(set([name for pattern in regexes
                                 for name in tests if pattern.match(name)])))
     if not args.benchmarks:
         return tests
+    tests.extend(map(str, range(1, len(tests) + 1)))  # ordinal numbers
     return sorted(list(set(tests).intersection(set(args.benchmarks))))
 
 


### PR DESCRIPTION
My last change to support running tests from `Benchmark_Driver` by their ordinal number in #10204 introduced a bug where the whole `precommit` test suite would run twice (once as named tests and once as numbered) when using just the `Benchmark_Driver run` command. This wasn't visible outside of console log, because `compare_perf_test` merges the results for the same test together. It just made benchmarking two times slower. 😞 

This PR fixes it to run just once.