### PR TITLE
[Type checker] Always record used conformances in the source file.

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5540,9 +5540,9 @@ void TypeChecker::markConformanceUsed(ProtocolConformanceRef conformance,
   auto normalConformance =
     conformance.getConcrete()->getRootNormalConformance();
 
-  if (normalConformance->isComplete()) return;
-
-  UsedConformances.insert(normalConformance);
+  // Make sure that the type checker completes this conformance.
+  if (normalConformance->isIncomplete())
+    UsedConformances.insert(normalConformance);
 
   // Record the usage of this conformance in the enclosing source
   // file.


### PR DESCRIPTION
An early exit introduced in PR #10292 meant that we would only record
a protocol conformance as "used" in the first file in which we saw a
reference to the conformance. Make sure we record the conformance as
used in each source file that needs it. Fixes rdar://problem/32978891
and rdar://problem/32980176.
