### PR TITLE
demangler: Support the future final mangling prefix $S

### DIFF
--- a/include/swift/Demangling/Demangle.h
+++ b/include/swift/Demangling/Demangle.h
@@ -216,8 +216,21 @@ public:
   void dump();
 };
 
+/// Returns the length of the swift mangling prefix of the \p SymbolName.
+///
+/// Returns 0 if \p SymbolName is not a mangled swift (>= swift 4.x) name.
+int getManglingPrefixLength(const char *mangledName);
+
+/// Returns true if \p SymbolName is a mangled swift name.
+///
+/// This does not include the old (<= swift 3.x) mangling prefix "_T".
+inline bool isMangledName(llvm::StringRef MangledName) {
+  return getManglingPrefixLength(MangledName.data()) != 0;
+}
+
 /// Returns true if the mangledName starts with the swift mangling prefix.
 ///
+/// This includes the old (<= swift 3.x) mangling prefix "_T".
 /// \param mangledName A null-terminated string containing a mangled name.
 bool isSwiftSymbol(const char *mangledName);
 
@@ -252,8 +265,8 @@ public:
 
   /// Demangle the given symbol and return the parse tree.
   ///
-  /// \param MangledName The mangled symbol string, which start with the
-  /// mangling prefix _T.
+  /// \param MangledName The mangled symbol string, which start a mangling
+  /// prefix: _T, _T0, $S, _$S.
   ///
   /// \returns A parse tree for the demangled string - or a null pointer
   /// on failure.
@@ -263,8 +276,8 @@ public:
 
   /// Demangle the given type and return the parse tree.
   ///
-  /// \param MangledName The mangled type string, which does _not_ start with
-  /// the mangling prefix _T.
+  /// \param MangledName The mangled symbol string, which start a mangling
+  /// prefix: _T, _T0, $S, _$S.
   ///
   /// \returns A parse tree for the demangled string - or a null pointer
   /// on failure.
@@ -274,8 +287,8 @@ public:
   
   /// Demangle the given symbol and return the readable name.
   ///
-  /// \param MangledName The mangled symbol string, which start with the
-  /// mangling prefix _T.
+  /// \param MangledName The mangled symbol string, which start a mangling
+  /// prefix: _T, _T0, $S, _$S.
   ///
   /// \returns The demangled string.
   std::string demangleSymbolAsString(llvm::StringRef MangledName,
@@ -284,7 +297,7 @@ public:
   /// Demangle the given type and return the readable name.
   ///
   /// \param MangledName The mangled type string, which does _not_ start with
-  /// the mangling prefix _T.
+  /// a mangling prefix.
   ///
   /// \returns The demangled string.
   std::string demangleTypeAsString(llvm::StringRef MangledName,

--- a/lib/Demangling/Context.cpp
+++ b/lib/Demangling/Context.cpp
@@ -36,14 +36,9 @@ void Context::clear() {
 }
 
 NodePointer Context::demangleSymbolAsNode(llvm::StringRef MangledName) {
-#ifndef NO_NEW_DEMANGLING
-  if (MangledName.startswith(MANGLING_PREFIX_STR)
-      // Also accept the future mangling prefix.
-      // TODO: remove this line as soon as MANGLING_PREFIX_STR gets "_S".
-      || MangledName.startswith("_S")) {
+  if (isMangledName(MangledName.data())) {
     return D->demangleSymbol(MangledName);
   }
-#endif
   return demangleOldSymbolAsNode(MangledName, *D);
 }
 
@@ -74,10 +69,7 @@ std::string Context::demangleTypeAsString(llvm::StringRef MangledName,
 }
 
 bool Context::isThunkSymbol(llvm::StringRef MangledName) {
-  if (MangledName.startswith(MANGLING_PREFIX_STR)
-      // Also accept the future mangling prefix.
-      // TODO: remove this line as soon as MANGLING_PREFIX_STR gets "_S".
-      || MangledName.startswith("_S")) {
+  if (isMangledName(MangledName)) {
     // First do a quick check
     if (MangledName.endswith("TA") ||  // partial application forwarder
         MangledName.endswith("Ta") ||  // ObjC partial application forwarder
@@ -126,11 +118,7 @@ std::string Context::getThunkTarget(llvm::StringRef MangledName) {
   if (!isThunkSymbol(MangledName))
     return std::string();
 
-  if (MangledName.startswith(MANGLING_PREFIX_STR)
-      // Also accept the future mangling prefix.
-      // TODO: remove this line as soon as MANGLING_PREFIX_STR gets "_S".
-      || MangledName.startswith("_S")) {
-
+  if (isMangledName(MangledName)) {
     // The targets of those thunks not derivable from the mangling.
     if (MangledName.endswith("TR") ||
         MangledName.endswith("Tr") ||

--- a/lib/Demangling/OldDemangler.cpp
+++ b/lib/Demangling/OldDemangler.cpp
@@ -2199,23 +2199,6 @@ private:
 };
 } // end anonymous namespace
 
-
-bool
-swift::Demangle::isSwiftSymbol(const char *mangledName) {
-  // The old mangling.
-  if (mangledName[0] == '_'
-      // Also accept the future mangling prefix.
-      && (mangledName[1] == 'T' || mangledName[1] == 'S'))
-    return true;
-
-  // The new mangling.
-  for (unsigned i = 0; i < sizeof(MANGLING_PREFIX_STR) - 1; i++) {
-    if (mangledName[i] != MANGLING_PREFIX_STR[i])
-      return false;
-  }
-  return true;
-}
-
 NodePointer
 swift::Demangle::demangleOldSymbolAsNode(StringRef MangledName,
                                          NodeFactory &Factory) {

--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -81,8 +81,12 @@ _TToFC3foo3bar3basfT3zimCS_3zim_T_ ---> {T:_TFC3foo3bar3basfT3zimCS_3zim_T_,C} @
 _TTOFSC3fooFTSdSd_Sd ---> {T:_TFSC3fooFTSdSd_Sd} @nonobjc __C.foo(Swift.Double, Swift.Double) -> Swift.Double
 _T03foo3barC3basyAA3zimCAE_tFTo ---> {T:_T03foo3barC3basyAA3zimCAE_tF,C} @objc foo.bar.bas(zim: foo.zim) -> ()
 _T0SC3fooS2d_SdtFTO ---> {T:_T0SC3fooS2d_SdtF} @nonobjc __C.foo(Swift.Double, Swift.Double) -> Swift.Double
-_S3foo3barC3basyAA3zimCAE_tFTo ---> {T:_S3foo3barC3basyAA3zimCAE_tF,C} @objc foo.bar.bas(zim: foo.zim) -> ()
-_SSC3fooS2d_SdtFTO ---> {T:_SSC3fooS2d_SdtF} @nonobjc __C.foo(Swift.Double, Swift.Double) -> Swift.Double
+__$S3foo3barC3basyAA3zimCAE_tFTo ---> {T:_$S3foo3barC3basyAA3zimCAE_tF,C} @objc foo.bar.bas(zim: foo.zim) -> ()
+__$SSC3fooS2d_SdtFTO ---> {T:_$SSC3fooS2d_SdtF} @nonobjc __C.foo(Swift.Double, Swift.Double) -> Swift.Double
+_$S3foo3barC3basyAA3zimCAE_tFTo ---> {T:_$S3foo3barC3basyAA3zimCAE_tF,C} @objc foo.bar.bas(zim: foo.zim) -> ()
+_$SSC3fooS2d_SdtFTO ---> {T:_$SSC3fooS2d_SdtF} @nonobjc __C.foo(Swift.Double, Swift.Double) -> Swift.Double
+$S3foo3barC3basyAA3zimCAE_tFTo ---> {T:$S3foo3barC3basyAA3zimCAE_tF,C} @objc foo.bar.bas(zim: foo.zim) -> ()
+$SSC3fooS2d_SdtFTO ---> {T:$SSC3fooS2d_SdtF} @nonobjc __C.foo(Swift.Double, Swift.Double) -> Swift.Double
 _TTDFC3foo3bar3basfT3zimCS_3zim_T_ ---> dynamic foo.bar.bas(zim: foo.zim) -> ()
 _TFC3foo3bar3basfT3zimCS_3zim_T_ ---> foo.bar.bas(zim: foo.zim) -> ()
 _TF3foooi1pFTCS_3barVS_3bas_OS_3zim ---> foo.+ infix(foo.bar, foo.bas) -> foo.zim

--- a/tools/swift-demangle/swift-demangle.cpp
+++ b/tools/swift-demangle/swift-demangle.cpp
@@ -102,12 +102,15 @@ static void demangle(llvm::raw_ostream &os, llvm::StringRef name,
       remangled = name;
     } else {
       remangled = swift::Demangle::mangleNode(pointer);
-      // Also accept the future mangling prefix.
-      // TODO: remove the special "_S" handling as soon as MANGLING_PREFIX_STR
-      // gets "_S".
-      if (name.startswith("_S")) {
-        assert(remangled.find(MANGLING_PREFIX_STR) == 0);
-        remangled = "_S" + remangled.substr(3);
+      unsigned prefixLen = swift::Demangle::getManglingPrefixLength(remangled.data());
+      assert(prefixLen > 0);
+      // Replace the prefix if we remangled with a different prefix.
+      if (!name.startswith(remangled.substr(0, prefixLen))) {
+        unsigned namePrefixLen =
+          swift::Demangle::getManglingPrefixLength(name.data());
+        assert(namePrefixLen > 0);
+        remangled = name.take_front(namePrefixLen).str() +
+                      remangled.substr(prefixLen);
       }
       if (name != remangled) {
         llvm::errs() << "\nError: re-mangled name \n  " << remangled
@@ -163,7 +166,7 @@ static int demangleSTDIN(const swift::Demangle::DemangleOptions &options) {
   // This doesn't handle Unicode symbols, but maybe that's okay.
   // Also accept the future mangling prefix.
   // TODO: remove the "_S" as soon as MANGLING_PREFIX_STR gets "_S".
-  llvm::Regex maybeSymbol("(_T|_S|" MANGLING_PREFIX_STR ")[_a-zA-Z0-9$]+");
+  llvm::Regex maybeSymbol("(_T|_*\\$S|" MANGLING_PREFIX_STR ")[_a-zA-Z0-9$]+");
 
   swift::Demangle::Context DCtx;
   for (std::string mangled; std::getline(std::cin, mangled);) {


### PR DESCRIPTION
As it’s not clear if we will need underscores, the demangler accepts $S and _$S.
Note that a double underscore is handled by the demangler client.

rdar://problem/32251811

*) Explanation: Support the future final mangling prefix $S

*) Scope: This is an enhancement of the demangler. It does not affect the compiler.

*) Origin: rdar://problem/32251811

*) Risk: Low. It does not affect the compilation.