### PR TITLE
[swiftc (45 vs. 5572)] Add crasher in swift::TypeBase::getCanonicalType(...)

### DIFF
--- a/validation-test/compiler_crashers/28811-gpdecl-getdepth-generictypeparamdecl-invaliddepth-parameter-hasnt-been-validated.swift
+++ b/validation-test/compiler_crashers/28811-gpdecl-getdepth-generictypeparamdecl-invaliddepth-parameter-hasnt-been-validated.swift
@@ -1,0 +1,11 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+{<a.h=a
+class a<H


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeBase::getCanonicalType(...)`.

Current number of unresolved compiler crashers: 45 (5572 resolved)

/cc @slavapestov - just wanted to let you know that this crasher caused an assertion failure for the assertion `gpDecl->getDepth() != GenericTypeParamDecl::InvalidDepth && "parameter hasn't been validated"` added on 2017-02-22 by you in commit fdb0a186 :-)

Assertion failure in [`lib/AST/Type.cpp (line 1069)`](https://github.com/apple/swift/blob/e2c4e2602ac06b5e07688ba9e1f782bc68c2380f/lib/AST/Type.cpp#L1069):

```
Assertion `gpDecl->getDepth() != GenericTypeParamDecl::InvalidDepth && "parameter hasn't been validated"' failed.

When executing: swift::CanType swift::TypeBase::getCanonicalType()
```

Assertion context:

```c++

  case TypeKind::GenericTypeParam: {
    GenericTypeParamType *gp = cast<GenericTypeParamType>(this);
    auto gpDecl = gp->getDecl();
    assert(gpDecl->getDepth() != GenericTypeParamDecl::InvalidDepth &&
           "parameter hasn't been validated");
    Result = GenericTypeParamType::get(gpDecl->getDepth(), gpDecl->getIndex(),
                                       gpDecl->getASTContext());
    break;
  }

```
Stack trace:

```
0 0x0000000003a81578 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3a81578)
1 0x0000000003a81cb6 SignalHandler(int) (/path/to/swift/bin/swift+0x3a81cb6)
2 0x00007fd371979390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007fd36fe9e428 gsignal /build/glibc-bfm8X4/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007fd36fea002a abort /build/glibc-bfm8X4/glibc-2.23/stdlib/abort.c:91:0
5 0x00007fd36fe96bd7 __assert_fail_base /build/glibc-bfm8X4/glibc-2.23/assert/assert.c:92:0
6 0x00007fd36fe96c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x00000000015cf907 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x15cf907)
8 0x00000000015cee99 swift::TypeBase::getCanonicalType() (/path/to/swift/bin/swift+0x15cee99)
9 0x000000000134f8c1 (anonymous namespace)::PreCheckExpression::simplifyTypeExpr(swift::Expr*) (/path/to/swift/bin/swift+0x134f8c1)
10 0x000000000134e607 (anonymous namespace)::PreCheckExpression::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0x134e607)
11 0x000000000152c78c (anonymous namespace)::Traversal::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0x152c78c)
12 0x000000000152a3a7 swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x152a3a7)
13 0x0000000001528fbb swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x1528fbb)
14 0x0000000001341b85 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0x1341b85)
15 0x00000000013456af swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x13456af)
16 0x00000000013c95d5 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13c95d5)
17 0x00000000013c8c2b swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) (/path/to/swift/bin/swift+0x13c8c2b)
18 0x00000000013ecc4c swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) (/path/to/swift/bin/swift+0x13ecc4c)
19 0x0000000001345791 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x1345791)
20 0x00000000013c95d5 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13c95d5)
21 0x00000000013c8de6 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0x13c8de6)
22 0x00000000013e72f0 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x13e72f0)
23 0x0000000000fa3f86 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xfa3f86)
24 0x00000000004abe49 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4abe49)
25 0x00000000004aa3f9 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4aa3f9)
26 0x0000000000465697 main (/path/to/swift/bin/swift+0x465697)
27 0x00007fd36fe89830 __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:325:0
28 0x0000000000462d39 _start (/path/to/swift/bin/swift+0x462d39)
```