### PR TITLE
On Linux, make swift_reportError always print backtraces

### DIFF
--- a/stdlib/public/runtime/Errors.cpp
+++ b/stdlib/public/runtime/Errors.cpp
@@ -265,7 +265,7 @@ void swift::reportToDebugger(uintptr_t flags, const char *message,
 /// Does not crash by itself.
 void swift::swift_reportError(uint32_t flags,
                               const char *message) {
-#if NDEBUG
+#if defined(__APPLE__) && NDEBUG
   flags &= ~FatalErrorFlags::ReportBacktrace;
 #endif
   reportNow(flags, message);

--- a/test/Runtime/crash_without_backtrace.swift
+++ b/test/Runtime/crash_without_backtrace.swift
@@ -6,6 +6,7 @@
 // UNSUPPORTED: OS=watchos
 // UNSUPPORTED: OS=ios
 // UNSUPPORTED: OS=tvos
+// REQUIRES: OS=macosx
 // REQUIRES: swift_stdlib_no_asserts
 // REQUIRES: executable_test
 

--- a/test/Runtime/crash_without_backtrace_optimized.swift
+++ b/test/Runtime/crash_without_backtrace_optimized.swift
@@ -6,6 +6,7 @@
 // UNSUPPORTED: OS=watchos
 // UNSUPPORTED: OS=ios
 // UNSUPPORTED: OS=tvos
+// REQUIRES: OS=macosx
 // REQUIRES: swift_stdlib_no_asserts
 // REQUIRES: executable_test
 

--- a/test/Runtime/linux-fatal-backtrace.swift
+++ b/test/Runtime/linux-fatal-backtrace.swift
@@ -9,7 +9,6 @@
 // Backtraces are not emitted when optimizations are enabled. This test can not
 // run when optimizations are enabled.
 // REQUIRES: swift_test_mode_optimize_none
-// REQUIRES: swift_stdlib_asserts
 
 func funcB() {
     fatalError("linux-fatal-backtrace");


### PR DESCRIPTION
Recently, Swift runtime changed not to print backtraces in non-assert builds of the runtime. It seems that there shouldn't be any problems with printing backtraces on Linux, even in optimized builds, so this PR makes swift_reportError always print backtraces there.