### PR TITLE
[4.0] Diagnose misplaced associated values in simple enum patterns

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2907,7 +2907,11 @@ ERROR(single_tuple_parameter_mismatch,none,
 ERROR(unknown_single_tuple_parameter_mismatch,none,
       "single parameter of type %0 is expected in call", (Type))
 
-
+ERROR(enum_element_pattern_assoc_values_mismatch,none,
+      "pattern with associated values does not match enum case %0",
+      (Identifier))
+NOTE(enum_element_pattern_assoc_values_remove,none,
+     "remove associated values to make the pattern match", ())
 ERROR(tuple_pattern_length_mismatch,none,
       "tuple pattern has the wrong length for tuple type %0", (Type))
 ERROR(tuple_pattern_label_mismatch,none,

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -1450,16 +1450,25 @@ recur:
 
     // If there is a subpattern, push the enum element type down onto it.
     if (EEP->hasSubPattern()) {
+      Pattern *sub = EEP->getSubPattern();
+      if (!Context.isSwiftVersion3() && !elt->hasAssociatedValues()) {
+        diagnose(EEP->getLoc(),
+                 diag::enum_element_pattern_assoc_values_mismatch,
+                 EEP->getName());
+        diagnose(EEP->getLoc(), diag::enum_element_pattern_assoc_values_remove)
+          .fixItRemove(sub->getSourceRange());
+        return true;
+      }
+      
       Type elementType;
       if (auto argType = elt->getArgumentInterfaceType())
         elementType = enumTy->getTypeOfMember(elt->getModuleContext(),
                                               elt, argType);
       else
         elementType = TupleType::getEmpty(Context);
-      Pattern *sub = EEP->getSubPattern();
       if (coercePatternToType(sub, dc, elementType,
-                     subOptions|TR_FromNonInferredPattern|TR_EnumPatternPayload,
-                     resolver))
+                              subOptions|TR_FromNonInferredPattern|TR_EnumPatternPayload,
+                              resolver))
         return true;
       EEP->setSubPattern(sub);
     } else if (auto argType = elt->getArgumentInterfaceType()) {

--- a/test/Parse/enum_element_pattern_swift4.swift
+++ b/test/Parse/enum_element_pattern_swift4.swift
@@ -27,9 +27,11 @@ func testE(e: E) {
     break
   case E.B<Int>(): // expected-error {{cannot specialize a non-generic definition}} expected-note {{while parsing this '<' as a type parameter bracket}}
     break
-  case .C(): // FIXME: This should be rejected as well.
+  case .C(): // expected-error {{pattern with associated values does not match enum case 'C'}}
+             // expected-note@-1 {{remove associated values to make the pattern match}} {{10-12=}} 
     break
-  case .D(let payload): // FIXME: ditto.
+  case .D(let payload): // expected-error{{pattern with associated values does not match enum case 'D'}}
+                        // expected-note@-1 {{remove associated values to make the pattern match}} {{10-23=}}
     let _: () = payload
     break
   default:
@@ -37,10 +39,10 @@ func testE(e: E) {
   }
 
   guard
-    // Currently, these will be asserted in SILGen,
-    // or in no-assert build, verify-failed in IRGen
-    case .C() = e, // FIXME: Should be rejected.
-    case .D(let payload) = e // FIXME: ditto.
+    case .C() = e, // expected-error {{pattern with associated values does not match enum case 'C'}} 
+                   // expected-note@-1 {{remove associated values to make the pattern match}} {{12-14=}}
+    case .D(let payload) = e // expected-error {{pattern with associated values does not match enum case 'D'}}
+                             // expected-note@-1 {{remove associated values to make the pattern match}} {{12-25=}}
   else { return }
 }
 
@@ -51,8 +53,10 @@ func canThrow() throws {
 
 do {
   try canThrow()
-} catch E.A() { // FIXME: Should be rejected.
+} catch E.A() { // expected-error {{pattern with associated values does not match enum case 'A'}}
+                // expected-note@-1 {{remove associated values to make the pattern match}} {{12-14=}}
   // ..
-} catch E.B(let payload) { // FIXME: ditto.
+} catch E.B(let payload) { // expected-error {{pattern with associated values does not match enum case 'B'}}
+                           // expected-note@-1 {{remove associated values to make the pattern match}} {{12-25=}} 
   let _: () = payload
 }

--- a/test/Parse/matching_patterns.swift
+++ b/test/Parse/matching_patterns.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-source-import
+// RUN: %target-typecheck-verify-swift -swift-version 4 -I %S/Inputs -enable-source-import
 
 import imported_enums
 
@@ -85,8 +85,12 @@ enum Voluntary<T> : Equatable {
       ()
 
     case .Naught,
-         .Naught(),
-         .Naught(_, _): // expected-error{{tuple pattern has the wrong length for tuple type '()'}}
+         .Naught(), // expected-error {{pattern with associated values does not match enum case 'Naught'}}
+                    // expected-note@-1 {{remove associated values to make the pattern match}} {{17-19=}}
+         .Naught(_), // expected-error{{pattern with associated values does not match enum case 'Naught'}}
+                     // expected-note@-1 {{remove associated values to make the pattern match}} {{17-20=}}
+         .Naught(_, _): // expected-error{{pattern with associated values does not match enum case 'Naught'}}
+                        // expected-note@-1 {{remove associated values to make the pattern match}} {{17-23=}}
       ()
 
     case .Mere,
@@ -112,13 +116,21 @@ enum Voluntary<T> : Equatable {
 }
 
 var n : Voluntary<Int> = .Naught
+if case let .Naught(value) = n {} // expected-error{{pattern with associated values does not match enum case 'Naught'}}
+                                  // expected-note@-1 {{remove associated values to make the pattern match}} {{20-27=}}
+if case let .Naught(value1, value2, value3) = n {} // expected-error{{pattern with associated values does not match enum case 'Naught'}}
+                                                   // expected-note@-1 {{remove associated values to make the pattern match}} {{20-44=}}
+
+
 
 switch n {
 case Foo.A: // expected-error{{enum case 'A' is not a member of type 'Voluntary<Int>'}}
   ()
 case Voluntary<Int>.Naught,
-     Voluntary<Int>.Naught(),
-     Voluntary<Int>.Naught(_, _), // expected-error{{tuple pattern has the wrong length for tuple type '()'}}
+     Voluntary<Int>.Naught(), // expected-error {{pattern with associated values does not match enum case 'Naught'}}
+                              // expected-note@-1 {{remove associated values to make the pattern match}} {{27-29=}}
+     Voluntary<Int>.Naught(_, _), // expected-error{{pattern with associated values does not match enum case 'Naught'}}
+                                  // expected-note@-1 {{remove associated values to make the pattern match}} {{27-33=}}
      Voluntary.Naught,
      .Naught:
   ()


### PR DESCRIPTION
• Explanation: Previous versions of Swift allowed non-sensical patterns that try to bind associated values to enum cases without associated values by sometimes lowering these values to Void, and sometimes crashing in SILGen.  Instead, this patch diagnoses this case and offers to remove any errant argument patterns from the case pattern.  Notably, this fix only targets Swift 4.0 because users have noted that this “works” (doesn’t crash) in some cases and hence this patch is subject to Swift 3 compatibility constraints.
• Origination: Noticed by @rintaro [here](https://bugs.swift.org/browse/SR-3466).
• Risk: Low. 
• Reviewed By: Pavel Yaskevich
• Testing: New tests added, existing tests updated, Swift 3 compatibility tests updated.
• Radar URL: rdar://32425041 and rdar://31976739 