### PR TITLE
Downgrade conditional compilation assignment error to a warning

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -187,9 +187,9 @@ ERROR(invalid_conditional_compilation_flag,none,
       "conditional compilation flags must be valid Swift identifiers (rather than '%0')",
       (StringRef))
 
-ERROR(cannot_assign_value_to_conditional_compilation_flag,none,
-      "conditional compilation flags do not have values in Swift; they are either present or absent"
-      " (rather than '%0')", (StringRef))
+WARNING(cannot_assign_value_to_conditional_compilation_flag,none,
+        "conditional compilation flags do not have values in Swift; they are "
+        "either present or absent (rather than '%0')", (StringRef))
 
 #ifndef DIAG_NO_UNDEF
 # if defined(DIAG)

--- a/test/Frontend/unknown-arguments.swift
+++ b/test/Frontend/unknown-arguments.swift
@@ -9,6 +9,6 @@
 
 // RUN: not %swiftc_driver -D Correct -DAlsoCorrect -D@#%! -D Swift=Cool -D-D -c %s -o %t.o 2>&1 | %FileCheck -check-prefix=INVALID-COND %s
 // INVALID-COND: <unknown>:0: error: conditional compilation flags must be valid Swift identifiers (rather than '@#%!')
-// INVALID-COND-NEXT: <unknown>:0: error: conditional compilation flags do not have values in Swift; they are either present or absent (rather than 'Swift=Cool')
+// INVALID-COND-NEXT: <unknown>:0: warning: conditional compilation flags do not have values in Swift; they are either present or absent (rather than 'Swift=Cool')
 // INVALID-COND-NEXT: <unknown>:0: error: conditional compilation flags must be valid Swift identifiers (rather than '-D')
 


### PR DESCRIPTION
To unblock certain projects that are using malformed flags, downgrade
this specific error to a warning for now.

rdar://33018039

