### PR TITLE
[4.0jun23][Clang importer/module printing] Correctly print NS_ERROR_ENUMs.

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2272,7 +2272,14 @@ void ClangModuleUnit::getTopLevelDecls(SmallVectorImpl<Decl*> &results) const {
           owner.importDecl(decl, owner.CurrentVersion);
       if (!importedDecl) continue;
 
-      auto ext = dyn_cast<ExtensionDecl>(importedDecl->getDeclContext());
+      // Find the enclosing extension, if there is one.
+      ExtensionDecl *ext = nullptr;
+      for (auto importedDC = importedDecl->getDeclContext();
+           !importedDC->isModuleContext();
+           importedDC = importedDC->getParent()) {
+        ext = dyn_cast<ExtensionDecl>(importedDC);
+        if (ext) break;
+      }
       if (!ext) continue;
 
       if (knownExtensions.insert(ext).second)

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -7921,8 +7921,18 @@ ClangImporter::Implementation::loadAllMembers(Decl *D, uint64_t extra) {
 
         // Then try to import the decl under the specified name.
         auto *member = importDecl(decl, nameVersion);
-        if (!member || member->getDeclContext() != ext)
-          return;
+        if (!member) return;
+
+        // Find the member that will land in an extension context.
+        while (!isa<ExtensionDecl>(member->getDeclContext())) {
+          auto nominal = dyn_cast<NominalTypeDecl>(member->getDeclContext());
+          if (!nominal) return;
+
+          member = nominal;
+          if (member->hasClangNode()) return;
+        }
+
+        if (member->getDeclContext() != ext) return;
         ext->addMember(member);
         
         for (auto alternate : getAlternateDecls(member)) {

--- a/test/IDE/print_clang_decls.swift
+++ b/test/IDE/print_clang_decls.swift
@@ -123,6 +123,17 @@
 // FOUNDATION-NEXT: @available(*, unavailable, message: "Zone-based memory management is unavailable")
 // FOUNDATION-NEXT: NSSetZoneName(_ zone: NSZone, _ name: String)
 
+// FOUNDATION-LABEL: struct FictionalServerError
+// FOUNDATION:         enum Code
+// FOUNDATION:           case meltedDown
+// FOUNDATION:         static var meltedDown: FictionalServerError.Code
+
+// FOUNDATION-LABEL: extension NSLaundromat {
+// FOUNDATION-NEXT:    struct Error
+// FOUNDATION:           enum Code
+// FOUNDATION:           case tooMuchSoap
+// FOUNDATION:         static var tooMuchSoap: NSLaundromat.Error.Code { get }
+
 // CTYPESBITS-NOT: FooStruct1
 // CTYPESBITS: {{^}}typealias DWORD = Int32{{$}}
 // CTYPESBITS-NEXT: {{^}}var MY_INT: Int32 { get }{{$}}

--- a/test/Inputs/clang-importer-sdk/usr/include/Foundation.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/Foundation.h
@@ -1100,3 +1100,13 @@ typedef enum __attribute__((ns_error_domain(FictionalServerErrorDomain))) Fictio
 - (void)bleach:(Coat <Garment, Cotton> * _Nonnull)garment;
 - (Coat <Garment> * _Nonnull)dry;
 @end
+
+@interface NSLaundromat : NSObject
+@end
+
+extern NSString * const NSLaundryErrorDomain;
+
+typedef enum __attribute__((ns_error_domain(NSLaundryErrorDomain))) __attribute__((swift_name("NSLaundromat.Error"))) NSLaundryErrorCode {
+    NSLaundryErrorTooMuchSoap = 1,
+    NSLaundryErrorCatInWasher = 2
+};


### PR DESCRIPTION
**Explanation**: Properly print imported `NS_ERROR_ENUM` types in the module interface; they were getting dropped.
**Scope**: Affects module interface printing.
**Reviewer**: @jrose-apple 
**Radar**: rdar://problem/32497693
**Risk**: Very low; it's printing some declarations that were otherwise dropped.
**Testing**: Compiler regression tests; new tests; printing everything in the iOS SDK and manually inspecting the diffs.
