### PR TITLE
[4.0] On Linux, make swift_reportError always print backtraces

### DIFF
--- a/stdlib/public/runtime/Errors.cpp
+++ b/stdlib/public/runtime/Errors.cpp
@@ -261,7 +261,7 @@ void swift::reportToDebugger(bool isFatal, const char *message,
 /// Does not crash by itself.
 void swift::swift_reportError(uint32_t flags,
                               const char *message) {
-#if NDEBUG
+#if defined(__APPLE__) && NDEBUG
   flags &= ~FatalErrorFlags::ReportBacktrace;
 #endif
   reportNow(flags, message);

--- a/test/Runtime/crash_without_backtrace.swift
+++ b/test/Runtime/crash_without_backtrace.swift
@@ -6,6 +6,7 @@
 // UNSUPPORTED: OS=watchos
 // UNSUPPORTED: OS=ios
 // UNSUPPORTED: OS=tvos
+// REQUIRES: OS=macosx
 // REQUIRES: swift_stdlib_no_asserts
 // REQUIRES: executable_test
 

--- a/test/Runtime/crash_without_backtrace_optimized.swift
+++ b/test/Runtime/crash_without_backtrace_optimized.swift
@@ -6,6 +6,7 @@
 // UNSUPPORTED: OS=watchos
 // UNSUPPORTED: OS=ios
 // UNSUPPORTED: OS=tvos
+// REQUIRES: OS=macosx
 // REQUIRES: swift_stdlib_no_asserts
 // REQUIRES: executable_test
 

--- a/test/Runtime/linux-fatal-backtrace.swift
+++ b/test/Runtime/linux-fatal-backtrace.swift
@@ -9,7 +9,6 @@
 // Backtraces are not emitted when optimizations are enabled. This test can not
 // run when optimizations are enabled.
 // REQUIRES: swift_test_mode_optimize_none
-// REQUIRES: swift_stdlib_asserts
 
 func funcB() {
     fatalError("linux-fatal-backtrace");


### PR DESCRIPTION
This cherry-picks 150696f8f6de3805d423ca344a9d75b36bc2c2e3 into swift-4.0-branch.

**Explanation**:  Recently, Swift has stopped printing backtraces on fatal errors in release mode, and only restricted the backtraces to be appended to error messages when the stdlib is build with assertions.  On Linux, we don't have a reason to disable printing backtraces, so this brings them back.
**Scope**: For Apple platforms, this doesn't change anything.  For Linux users, this brings back a feature that used to be in the stdlib and worked reliably.
**Radar**: <rdar://problem/31372220>
**Risk**: Very low.  For Apple platforms, this doesn't change anything.
**Testing**: Linux tests were modified to expect backtraces and they pass.