### PR TITLE
Include Editor Mode when downgrading exhaustiveness error to warning

### DIFF
--- a/lib/Sema/TypeCheckSwitchStmt.cpp
+++ b/lib/Sema/TypeCheckSwitchStmt.cpp
@@ -1104,7 +1104,7 @@ namespace {
           }
         }
 
-        TC.diagnose(startLoc, diag::non_exhaustive_switch);
+        TC.diagnose(startLoc, mainDiagType);
         TC.diagnose(startLoc, diag::missing_several_cases, false)
           .fixItInsert(endLoc, buffer.str());
       } else {

--- a/test/stmt/nonexhaustive_switch_stmt_editor.swift
+++ b/test/stmt/nonexhaustive_switch_stmt_editor.swift
@@ -1,0 +1,29 @@
+// RUN: %target-typecheck-verify-swift -diagnostics-editor-mode
+
+typealias TimeInterval = Double
+
+let NSEC_PER_USEC : UInt64 = 1000
+let NSEC_PER_SEC : UInt64 = 1000000000
+
+public enum TemporalProxy {
+  case seconds(Int)
+  case milliseconds(Int)
+  case microseconds(Int)
+  case nanoseconds(Int)
+  @_downgrade_exhaustivity_check
+  case never
+}
+
+func unproxify(t : TemporalProxy) -> TimeInterval {
+  switch t { // expected-warning {{switch must be exhaustive}}
+  // expected-note@-1 {{do you want to add missing cases?}}
+  case let .seconds(s):
+    return TimeInterval(s)
+  case let .milliseconds(ms):
+    return TimeInterval(TimeInterval(ms) / 1000.0)
+  case let .microseconds(us):
+    return TimeInterval( UInt64(us) * NSEC_PER_USEC ) / TimeInterval(NSEC_PER_SEC)
+  case let .nanoseconds(ns):
+    return TimeInterval(ns) / TimeInterval(NSEC_PER_SEC)
+  }
+}


### PR DESCRIPTION
A fix for a boneheaded bug I introduced while writing the error downgrading code.  This adds the downgrade to the editor mode path and a regression test to make sure I don't make this mistake again.