### PR TITLE
[4.0] Include Editor Mode when downgrading exhaustiveness error to warning

### DIFF
--- a/lib/Sema/TypeCheckSwitchStmt.cpp
+++ b/lib/Sema/TypeCheckSwitchStmt.cpp
@@ -1104,7 +1104,7 @@ namespace {
           }
         }
 
-        TC.diagnose(startLoc, diag::non_exhaustive_switch);
+        TC.diagnose(startLoc, mainDiagType);
         TC.diagnose(startLoc, diag::missing_several_cases, false)
           .fixItInsert(endLoc, buffer.str());
       } else {

--- a/test/stmt/nonexhaustive_switch_stmt_editor.swift
+++ b/test/stmt/nonexhaustive_switch_stmt_editor.swift
@@ -1,0 +1,29 @@
+// RUN: %target-typecheck-verify-swift -diagnostics-editor-mode
+
+typealias TimeInterval = Double
+
+let NSEC_PER_USEC : UInt64 = 1000
+let NSEC_PER_SEC : UInt64 = 1000000000
+
+public enum TemporalProxy {
+  case seconds(Int)
+  case milliseconds(Int)
+  case microseconds(Int)
+  case nanoseconds(Int)
+  @_downgrade_exhaustivity_check
+  case never
+}
+
+func unproxify(t : TemporalProxy) -> TimeInterval {
+  switch t { // expected-warning {{switch must be exhaustive}}
+  // expected-note@-1 {{do you want to add missing cases?}}
+  case let .seconds(s):
+    return TimeInterval(s)
+  case let .milliseconds(ms):
+    return TimeInterval(TimeInterval(ms) / 1000.0)
+  case let .microseconds(us):
+    return TimeInterval( UInt64(us) * NSEC_PER_USEC ) / TimeInterval(NSEC_PER_SEC)
+  case let .nanoseconds(ns):
+    return TimeInterval(ns) / TimeInterval(NSEC_PER_SEC)
+  }
+}


### PR DESCRIPTION
• Explanation: When integrating the private @_downgrade_exhausitivity_check attribute, I only updated the diagnostic path that didn’t deal with Xcode.  When editor mode is enabled, this diagnostic would always appear as an error.  This patch is a one-line direct fix for this oversight that also unblocks the compatibility suite.
• Origination: Noticed after overlay change.
• Risk: Extremely Low. 
• Reviewed By: Xi Ge
• Testing: New regression test added specifically for editor mode.
• Radar URL: rdar://33024711 