### PR TITLE
[GSB] Distinguish archetype resolution kind for getNestedType().

### DIFF
--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -1596,6 +1596,7 @@ public:
 
   /// \brief Retrieve (or create) a nested type with the given name.
   PotentialArchetype *getNestedType(Identifier Name,
+                                    ArchetypeResolutionKind kind,
                                     GenericSignatureBuilder &builder);
 
   /// \brief Retrieve (or create) a nested type with a known associated type.

--- a/validation-test/compiler_crashers_2/0109-sr4737.swift
+++ b/validation-test/compiler_crashers_2/0109-sr4737.swift
@@ -1,4 +1,4 @@
-// RUN: not %target-swift-frontend %s -typecheck
+// RUN: not --crash %target-swift-frontend %s -typecheck
 
 // REQUIRES: long_test
 


### PR DESCRIPTION
`PotentialArchetype::getNestedType(Identifier...)` was using
`ArchetypeResolutionKind::AlwaysPartial`, even though only one client
(the code that itself handles `AlwaysPartial`) needed it. Add an
`ArchetypeResolutionKind` parameter to pass through, updating clients
accordingly.

Eliminates 5 effective uses of `AlwaysPartial`. Only two left!

Reinstate crasher from SR-4737 / rdar://problem/31905232. It was failing to crash for the wrong reasons; this needs more work (and a proper reduction).