### PR TITLE
[ClangImporter] Update for upstream changes to DiagnosticRenderer.

### DIFF
--- a/lib/ClangImporter/ClangDiagnosticConsumer.cpp
+++ b/lib/ClangImporter/ClangDiagnosticConsumer.cpp
@@ -36,40 +36,36 @@ namespace {
          callback(fn) {}
 
   private:
-    void emitDiagnosticMessage(clang::SourceLocation Loc,
+    void emitDiagnosticMessage(clang::FullSourceLoc Loc,
                                clang::PresumedLoc PLoc,
                                clang::DiagnosticsEngine::Level Level,
                                StringRef Message,
                                ArrayRef<clang::CharSourceRange> Ranges,
-                               const clang::SourceManager *SM,
                                clang::DiagOrStoredDiag Info) override {
-      StringRef bufName = StringRef(SM->getBufferName(Loc));
+      StringRef bufName = StringRef(Loc.getManager().getBufferName(Loc));
       if (bufName == ClangImporter::Implementation::moduleImportBufferName ||
           bufName == ClangImporter::Implementation::bridgingHeaderBufferName) {
         return;
       }
-      callback(clang::FullSourceLoc(Loc, *SM), Level, Message);
+      callback(Loc, Level, Message);
     }
 
-    void emitDiagnosticLoc(clang::SourceLocation Loc, clang::PresumedLoc PLoc,
+    void emitDiagnosticLoc(clang::FullSourceLoc Loc, clang::PresumedLoc PLoc,
                            clang::DiagnosticsEngine::Level Level,
-                           ArrayRef<clang::CharSourceRange> Ranges,
-                           const clang::SourceManager &SM) override {}
+                           ArrayRef<clang::CharSourceRange> Ranges) override {}
 
-    void emitCodeContext(clang::SourceLocation Loc,
+    void emitCodeContext(clang::FullSourceLoc Loc,
                          clang::DiagnosticsEngine::Level Level,
                          SmallVectorImpl<clang::CharSourceRange>& Ranges,
-                         ArrayRef<clang::FixItHint> Hints,
-                         const clang::SourceManager &SM) override {}
+                         ArrayRef<clang::FixItHint> Hints) override {}
 
-    void emitNote(clang::SourceLocation Loc, StringRef Message,
-                  const clang::SourceManager *SM) override {
+    void emitNote(clang::FullSourceLoc Loc, StringRef Message) override {
       // We get invalid note locations when trying to describe where a module
       // is imported and the actual location is in Swift.
       if (Loc.isInvalid())
         return;
       emitDiagnosticMessage(Loc, {}, clang::DiagnosticsEngine::Note, Message,
-                            {}, SM, {});
+                            {}, {});
     }
   };
 } // end anonymous namespace
@@ -228,8 +224,9 @@ void ClangDiagnosticConsumer::HandleDiagnostic(
     auto clangCI = ImporterImpl.getClangInstance();
     ClangDiagRenderer renderer(clangCI->getLangOpts(),
                                &clangCI->getDiagnosticOpts(), emitDiag);
-    renderer.emitDiagnostic(clangDiag.getLocation(), clangDiagLevel, message,
-                            clangDiag.getRanges(), clangDiag.getFixItHints(),
-                            &clangDiag.getSourceManager());
+    clang::FullSourceLoc clangDiagLoc(clangDiag.getLocation(),
+                                      clangDiag.getSourceManager());
+    renderer.emitDiagnostic(clangDiagLoc, clangDiagLevel, message,
+                            clangDiag.getRanges(), clangDiag.getFixItHints());
   }
 }


### PR DESCRIPTION
Use clang::FullSourceLoc instead of passing a separate SourceLocation and SourceManager.

rdar://problem/33031623