### PR TITLE
Swift 4 06 23 add skip test ios32 flag

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -147,6 +147,11 @@ class HostSpecificConfiguration(object):
                     test = False
 
             name = deployment_target.name
+
+            for skip_test_arch in invocation.platforms_archs_to_skip_test:
+                if deployment_target.name == skip_test_arch.name:
+                    test = False
+
             if build:
                 # Validation and long tests require building the full standard
                 # library, whereas the other targets can build a slightly
@@ -499,6 +504,7 @@ class BuildScriptInvocation(object):
             self.platforms_to_skip_build.add(StdlibDeploymentTarget.Android)
 
         self.platforms_to_skip_test = set()
+        self.platforms_archs_to_skip_test = set()
         if args.skip_test_linux:
             self.platforms_to_skip_test.add(StdlibDeploymentTarget.Linux)
         if args.skip_test_freebsd:
@@ -515,6 +521,9 @@ class BuildScriptInvocation(object):
         if args.skip_test_ios_simulator:
             self.platforms_to_skip_test.add(
                 StdlibDeploymentTarget.iOSSimulator)
+        if args.skip_test_ios_32bit_simulator:
+            self.platforms_archs_to_skip_test.add(
+                StdlibDeploymentTarget.iOSSimulator.i386)
         if args.skip_test_tvos_host:
             self.platforms_to_skip_test.add(StdlibDeploymentTarget.AppleTV)
         else:
@@ -772,6 +781,8 @@ class BuildScriptInvocation(object):
             impl_args += ["--skip-test-ios-host"]
         if args.skip_test_ios_simulator:
             impl_args += ["--skip-test-ios-simulator"]
+        if args.skip_test_ios_32bit_simulator:
+            impl_args += ["--skip-test-ios-32bit-simulator"]
         if args.skip_test_tvos_host:
             impl_args += ["--skip-test-tvos-host"]
         if args.skip_test_tvos_simulator:
@@ -1779,6 +1790,10 @@ iterations with -O",
     skip_test_group.add_argument(
         "--skip-test-ios-simulator",
         help="skip testing iOS simulator targets",
+        action=arguments.action.optional_bool)
+    skip_test_group.add_argument(
+        "--skip-test-ios-32bit-simulator",
+        help="skip testing iOS 32 bit simulator targets",
         action=arguments.action.optional_bool)
     skip_test_group.add_argument(
         "--skip-test-ios-host",

--- a/utils/build-script
+++ b/utils/build-script
@@ -1794,7 +1794,8 @@ iterations with -O",
     skip_test_group.add_argument(
         "--skip-test-ios-32bit-simulator",
         help="skip testing iOS 32 bit simulator targets",
-        action=arguments.action.optional_bool)
+        action=arguments.action.optional_bool,
+        default=True)
     skip_test_group.add_argument(
         "--skip-test-ios-host",
         help="skip testing iOS device targets on the host machine (the phone "

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -142,6 +142,7 @@ KNOWN_SETTINGS=(
     skip-test-freebsd           ""               "set to skip testing Swift stdlibs for FreeBSD"
     skip-test-cygwin            ""               "set to skip testing Swift stdlibs for Cygwin"
     skip-test-osx               ""               "set to skip testing Swift stdlibs for OS X"
+    skip-test-ios-32bit-simulator     ""         "set to skip testing Swift stdlibs for iOS 32bit simulators"
     skip-test-ios-simulator     ""               "set to skip testing Swift stdlibs for iOS simulators (i.e. test devices only)"
     skip-test-ios-host          ""               "set to skip testing the host parts of the iOS toolchain"
     skip-test-tvos-simulator    ""               "set to skip testing Swift stdlibs for tvOS simulators (i.e. test devices only)"
@@ -1355,10 +1356,18 @@ function calculate_targets_for_host() {
                     build_benchmark_this_target=
                 fi
                 ;;
-            iphonesimulator-*)
+            iphonesimulator-x86_64)
                 swift_sdk="IOS_SIMULATOR"
                 build_for_this_target=$(not ${SKIP_BUILD_IOS_SIMULATOR})
                 test_this_target=$(not ${SKIP_TEST_IOS_SIMULATOR})
+                ;;
+            iphonesimulator-i386)
+                swift_sdk="IOS_SIMULATOR"
+                build_for_this_target=$(not ${SKIP_BUILD_IOS_SIMULATOR})
+                if [[ "${SKIP_TEST_IOS_SIMULATOR}" == "1" ]] ; then
+                    SKIP_TEST_IOS_32BIT_SIMULATOR="${SKIP_TEST_IOS_SIMULATOR}"
+                fi
+                test_this_target=$(not ${SKIP_TEST_IOS_32BIT_SIMULATOR})
                 ;;
             appletvos-*)
                 swift_sdk="TVOS"
@@ -1439,6 +1448,7 @@ function calculate_targets_for_host() {
                     test_subset_target_suffix="-only_long"
                 fi
             fi
+
             SWIFT_TEST_TARGETS+=("check-swift${test_subset_target_suffix}${test_target_suffix}-${stdlib_deployment_target}")
             if [[ $(not ${SKIP_TEST_OPTIMIZED}) && ! -n "${test_host_only}" ]] ; then
                 SWIFT_TEST_TARGETS+=("check-swift${test_subset_target_suffix}-optimize-${stdlib_deployment_target}")

--- a/utils/swift_build_support/swift_build_support/targets.py
+++ b/utils/swift_build_support/swift_build_support/targets.py
@@ -92,7 +92,7 @@ class StdlibDeploymentTarget(object):
 
     iOS = DarwinPlatform("iphoneos", archs=["armv7", "armv7s", "arm64"],
                          sdk_name="IOS")
-    iOSSimulator = DarwinPlatform("iphonesimulator", archs=["x86_64"],
+    iOSSimulator = DarwinPlatform("iphonesimulator", archs=["i386", "x86_64"],
                                   sdk_name="IOS_SIMULATOR",
                                   is_simulator=True)
 


### PR DESCRIPTION
• Explanation: Add support to build 32bit simulator slice, and flag to skip 32bit simulator test because iOS 11 does not support 32bit. 
• Risk: Low
• Reviewed By: @zisko 
• Testing: Full PR testing
• Radar URL: rdar://32862833