### PR TITLE
build: switch libdispatch build to cmake

### DIFF
--- a/tools/SourceKit/CMakeLists.txt
+++ b/tools/SourceKit/CMakeLists.txt
@@ -518,28 +518,30 @@ include_directories(BEFORE
 
 if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
   if(SWIFT_BUILD_SOURCEKIT)
-    add_custom_command(
-      OUTPUT "${SWIFT_PATH_TO_LIBDISPATCH_BUILD}/src/.libs/libdispatch.so"
-      COMMAND autoreconf -fvi
-      COMMAND /usr/bin/env "CC=${PATH_TO_CLANG_BUILD}/bin/clang" "CXX=${PATH_TO_CLANG_BUILD}/bin/clang++" "OBJC=${PATH_TO_CLANG_BUILD}/bin/clang" ${SWIFT_PATH_TO_LIBDISPATCH_SOURCE}/configure --prefix="${CMAKE_INSTALL_PREFIX}"
-      COMMAND /usr/bin/make
-      COMMAND /bin/mkdir -p ${SWIFT_PATH_TO_LIBDISPATCH_BUILD}/src/.libs/
-      COMMAND /bin/cp ${SWIFT_PATH_TO_LIBDISPATCH_SOURCE}/src/.libs/libdispatch.so ${SWIFT_PATH_TO_LIBDISPATCH_BUILD}/src/.libs/libdispatch.so
-      COMMAND /usr/bin/make distclean
-      WORKING_DIRECTORY ${SWIFT_PATH_TO_LIBDISPATCH_SOURCE}
-      COMMENT "Generating libdispatch.so"
-      USES_TERMINAL
-    )
-    add_custom_target(needs-libdispatch
-      DEPENDS "${SWIFT_PATH_TO_LIBDISPATCH_BUILD}/src/.libs/libdispatch.so"
-    )
+    include(ExternalProject)
+    ExternalProject_Add(libdispatch
+                        SOURCE_DIR
+                          "${SWIFT_PATH_TO_LIBDISPATCH_SOURCE}"
+                        BINARY_DIR
+                          "${SWIFT_PATH_TO_LIBDISPATCH_BUILD}"
+                        CMAKE_ARGS
+                          -DCMAKE_C_COMPILER=${PATH_TO_CLANG_BUILD}/bin/clang
+                          -DCMAKE_CXX_COMPILER=${PATH_TO_CLANG_BUILD}/bin/clang++
+                          -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+                        BUILD_BYPRODUCTS
+                          ${SWIFT_PATH_TO_LIBDISPATCH_BUILD}/src/${CMAKE_SHARED_LIBRARY_PREFIX}dispatch${CMAKE_SHARED_LIBRARY_SUFFIX})
+
+    include_directories(AFTER
+                          ${SWIFT_PATH_TO_LIBDISPATCH_SOURCE}/src/BlocksRuntime)
+    link_directories(${SWIFT_PATH_TO_LIBDISPATCH_BUILD})
   endif()
 
   include_directories(AFTER ${SWIFT_PATH_TO_LIBDISPATCH_SOURCE})
 
-  add_library(dispatch SHARED IMPORTED)
-  set_target_properties(dispatch PROPERTIES
-                        IMPORTED_LOCATION ${SWIFT_PATH_TO_LIBDISPATCH_BUILD}/src/.libs/libdispatch.so)
+  add_library(dispatch UNKNOWN IMPORTED)
+  set_target_properties(dispatch
+                        PROPERTIES
+                          IMPORTED_LOCATION ${SWIFT_PATH_TO_LIBDISPATCH_BUILD}/src/${CMAKE_SHARED_LIBRARY_PREFIX}dispatch${CMAKE_SHARED_LIBRARY_SUFFIX})
 
   add_library(swiftCore SHARED IMPORTED)
   set_target_properties(swiftCore PROPERTIES

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1698,6 +1698,7 @@ function cmake_config_opt() {
                 echo "--config ${FOUNDATION_BUILD_TYPE}"
                 ;;
             libdispatch)
+                echo "--config ${LIBDISPATCH_BUILD_TYPE}"
                 ;;
             libicu)
                 ;;
@@ -2447,41 +2448,61 @@ for host in "${ALL_HOSTS[@]}"; do
                 SWIFTC_BIN="$(build_directory_bin ${LOCAL_HOST} swift)/swiftc"
                 LLVM_BIN="$(build_directory_bin ${LOCAL_HOST} llvm)"
 
-                if [[ "${RECONFIGURE}" || ! -f "${LIBDISPATCH_BUILD_DIR}"/config.status ]]; then
-                    echo "Reconfiguring libdispatch"
-                    # First time building; need to run autotools and configure
-                    if [[ "$LIBDISPATCH_BUILD_TYPE" == "Release" ]] ; then
-                        dispatch_build_variant_arg="release"
-                    elif [[ "$LIBDISPATCH_BUILD_TYPE" == "RelWithDebInfo" ]]; then
-                        dispatch_build_variant_arg="releasedebuginfo"
-                    else
-                        dispatch_build_variant_arg="debug"
-                    fi
+                case "${host}" in
+                macosx-*)
+                  if [[ "${RECONFIGURE}" || ! -f "${LIBDISPATCH_BUILD_DIR}"/config.status ]]; then
+                      echo "Reconfiguring libdispatch"
+                      # First time building; need to run autotools and configure
+                      if [[ "$LIBDISPATCH_BUILD_TYPE" == "Release" ]] ; then
+                          dispatch_build_variant_arg="release"
+                      elif [[ "$LIBDISPATCH_BUILD_TYPE" == "RelWithDebInfo" ]]; then
+                          dispatch_build_variant_arg="releasedebuginfo"
+                      else
+                          dispatch_build_variant_arg="debug"
+                      fi
 
-                    if [ $(true_false "${BUILD_SWIFT_STATIC_STDLIB}") == "TRUE" ]; then
-                        libdispatch_enable_static="--enable-static=yes"
-                    else
-                        libdispatch_enable_static=""
-                    fi
+                      if [ $(true_false "${BUILD_SWIFT_STATIC_STDLIB}") == "TRUE" ]; then
+                          libdispatch_enable_static="--enable-static=yes"
+                      else
+                          libdispatch_enable_static=""
+                      fi
 
-                    call mkdir -p "${LIBDISPATCH_BUILD_DIR}"
-                    with_pushd "${LIBDISPATCH_SOURCE_DIR}" \
-                        call autoreconf -fvi
-                    with_pushd "${LIBDISPATCH_BUILD_DIR}" \
-                        call env CC="${LLVM_BIN}/clang" CXX="${LLVM_BIN}/clang++" SWIFTC="${SWIFTC_BIN}" \
-                            "${LIBDISPATCH_SOURCE_DIR}"/configure --with-swift-toolchain="${SWIFT_BUILD_PATH}" \
-                            --with-build-variant=$dispatch_build_variant_arg \
-                            --prefix="$(get_host_install_destdir ${host})$(get_host_install_prefix ${host})" ${libdispatch_enable_static}
-                else
-                    echo "Skipping reconfiguration of libdispatch"
-                fi
-                with_pushd "${LIBDISPATCH_BUILD_DIR}" \
-                    call make
-                with_pushd "${LIBDISPATCH_BUILD_DIR}/tests" \
-                    call make build-tests
+                      call mkdir -p "${LIBDISPATCH_BUILD_DIR}"
+                      with_pushd "${LIBDISPATCH_SOURCE_DIR}" \
+                          call autoreconf -fvi
+                      with_pushd "${LIBDISPATCH_BUILD_DIR}" \
+                          call env CC="${LLVM_BIN}/clang" CXX="${LLVM_BIN}/clang++" SWIFTC="${SWIFTC_BIN}" \
+                              "${LIBDISPATCH_SOURCE_DIR}"/configure --with-swift-toolchain="${SWIFT_BUILD_PATH}" \
+                              --with-build-variant=$dispatch_build_variant_arg \
+                              --prefix="$(get_host_install_destdir ${host})$(get_host_install_prefix ${host})" ${libdispatch_enable_static}
+                  else
+                      echo "Skipping reconfiguration of libdispatch"
+                  fi
+                  with_pushd "${LIBDISPATCH_BUILD_DIR}" \
+                      call make
+                  with_pushd "${LIBDISPATCH_BUILD_DIR}/tests" \
+                      call make build-tests
 
-                # libdispatch builds itself and doesn't use cmake
-                continue
+                  # libdispatch builds itself and doesn't use cmake
+                  continue
+                ;;
+                *)
+                  cmake_options=(
+                    ${cmake_options[@]}
+                    -DCMAKE_BUILD_TYPE:STRING="${LIBDISPATCH_BUILD_TYPE}"
+                    -DCMAKE_C_COMPILER:PATH="${LLVM_BIN}/clang"
+                    -DCMAKE_CXX_COMPILER:PATH="${LLVM_BIN}/clang++"
+                    -DCMAKE_SWIFT_COMPILER:PATH="${SWIFTC_BIN}"
+                    -DCMAKE_INSTALL_PREFIX:PATH="$(get_host_install_destdir ${host})$(get_host_install_prefix ${host})"
+
+                    -DENABLE_SWIFT=YES
+                    -DSWIFT_RUNTIME_LIBDIR:PATH="${SWIFT_BUILD_PATH}/lib/swift/${SWIFT_HOST_VARIANT}/${SWIFT_HOST_VARIANT_ARCH}"
+
+                    -DENABLE_TESTING=YES
+                  )
+                ;;
+                esac
+
                 ;;
             libicu)
                 SWIFT_BUILD_PATH=$(build_directory ${host} swift)
@@ -2846,15 +2867,23 @@ for host in "${ALL_HOSTS[@]}"; do
                 continue
                 ;;
             libdispatch)
-                if [[ "${SKIP_TEST_LIBDISPATCH}" ]]; then
-                    continue
-                fi
-                LIBDISPATCH_BUILD_DIR=$(build_directory ${host} ${product})
-                echo "--- Running tests for ${product} ---"
-                with_pushd "${LIBDISPATCH_BUILD_DIR}" \
-                    call env VERBOSE=1 make check
-                echo "--- Finished tests for ${product} ---"
-                continue
+                case "${host}" in
+                macosx-*)
+                  if [[ "${SKIP_TEST_LIBDISPATCH}" ]]; then
+                      continue
+                  fi
+                  LIBDISPATCH_BUILD_DIR=$(build_directory ${host} ${product})
+                  echo "--- Running tests for ${product} ---"
+                  with_pushd "${LIBDISPATCH_BUILD_DIR}" \
+                      call env VERBOSE=1 make check
+                  echo "--- Finished tests for ${product} ---"
+                  continue
+                ;;
+                *)
+                  results_targets=( "test" )
+                  executable_target=""
+                ;;
+                esac
                 ;;
             libicu)
                 if [[ "${SKIP_TEST_LIBICU}" ]]; then
@@ -3098,25 +3127,31 @@ for host in "${ALL_HOSTS[@]}"; do
                 continue
                 ;;
             libdispatch)
-                if [[ -z "${INSTALL_LIBDISPATCH}" ]] ; then
-                    continue
-                fi
-                if [[ -z "${INSTALL_DESTDIR}" ]] ; then
-                    echo "--install-destdir is required to install products."
-                    exit 1
-                fi
-                echo "--- Installing ${product} ---"
-                LIBDISPATCH_BUILD_DIR=$(build_directory ${host} ${product})
-                with_pushd "${LIBDISPATCH_BUILD_DIR}" \
-                    call make install
-                DISPATCH_LIBDIR="${host_install_destdir}${host_install_prefix}/lib/swift/${SWIFT_HOST_VARIANT}"
-                DISPATCH_LIBDIR_STATIC="${host_install_destdir}${host_install_prefix}/lib/swift_static/${SWIFT_HOST_VARIANT}"
-                if [ -f "$DISPATCH_LIBDIR/libdispatch.a" ]; then
-                    mv "$DISPATCH_LIBDIR/libdispatch.a" "$DISPATCH_LIBDIR_STATIC"
-                fi
+                case "${host}" in
+                macosx-*)
+                  if [[ -z "${INSTALL_LIBDISPATCH}" ]] ; then
+                      continue
+                  fi
+                  if [[ -z "${INSTALL_DESTDIR}" ]] ; then
+                      echo "--install-destdir is required to install products."
+                      exit 1
+                  fi
+                  echo "--- Installing ${product} ---"
+                  LIBDISPATCH_BUILD_DIR=$(build_directory ${host} ${product})
+                  with_pushd "${LIBDISPATCH_BUILD_DIR}" \
+                      call make install
+                  DISPATCH_LIBDIR="${host_install_destdir}${host_install_prefix}/lib/swift/${SWIFT_HOST_VARIANT}"
+                  DISPATCH_LIBDIR_STATIC="${host_install_destdir}${host_install_prefix}/lib/swift_static/${SWIFT_HOST_VARIANT}"
+                  if [ -f "$DISPATCH_LIBDIR/libdispatch.a" ]; then
+                      mv "$DISPATCH_LIBDIR/libdispatch.a" "$DISPATCH_LIBDIR_STATIC"
+                  fi
 
-                # As libdispatch installation is self-contained, we break early here.
-                continue
+                  # As libdispatch installation is self-contained, we break early here.
+                  continue
+                ;;
+                *)
+                ;;
+                esac
                 ;;
             libicu)
                 if [[ -z "${INSTALL_LIBICU}" ]]; then


### PR DESCRIPTION
Use the cmake based build system for building libdispatch now that it is
able to build Linux, android, and even possible to cross-compile to
Windows.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
