### PR TITLE
IRGen: Add the created LLVM function to the current module before the call to the IRGenFunction constructor

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -959,9 +959,9 @@ void IRGenerator::emitEagerClassInitialization() {
                                 llvm::FunctionType::get(IGM->VoidTy, false),
                                 llvm::GlobalValue::PrivateLinkage,
                                 "_swift_eager_class_initialization");
+  IGM->Module.getFunctionList().push_back(RegisterFn);
   IRGenFunction RegisterIGF(*IGM, RegisterFn);
   RegisterFn->setAttributes(IGM->constructInitialAttributes());
-  IGM->Module.getFunctionList().push_back(RegisterFn);
   RegisterFn->setCallingConv(IGM->DefaultCC);
 
   for (ClassDecl *CD : ClassesForEagerInitialization) {


### PR DESCRIPTION

A change in LLVM will require the function to have a module parent when we
insert the epilogue alloca in the IRGenFunction constructor.

rdar://32998781