### PR TITLE
[4.0] [Exclusivity] Fix unreachable when diagnosing on BoundGenericStructType

### DIFF
--- a/lib/SILOptimizer/Mandatory/DiagnoseStaticExclusivity.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseStaticExclusivity.cpp
@@ -652,8 +652,7 @@ static std::string getPathDescription(DeclName BaseName, SILType BaseType,
   for (unsigned Index : reversed(ReversedIndices)) {
     os << ".";
 
-    if (ContainingType.getAs<StructType>()) {
-      NominalTypeDecl *D = ContainingType.getNominalOrBoundGenericNominal();
+    if (StructDecl *D = ContainingType.getStructOrBoundGenericStruct()) {
       auto Iter = D->getStoredProperties().begin();
       std::advance(Iter, Index);
       VarDecl *VD = *Iter;

--- a/test/SILOptimizer/exclusivity_static_diagnostics.swift
+++ b/test/SILOptimizer/exclusivity_static_diagnostics.swift
@@ -304,3 +304,12 @@ func inoutSamePropertyInSameTuple() {
   // expected-error@-1{{overlapping accesses to 't.name2.f1', but modification requires exclusive access; consider copying to a local variable}}
   // expected-note@-2{{conflicting access is here}}
 }
+
+struct MyStruct<T> {
+  var prop = 7
+  mutating func inoutBoundGenericStruct() {
+    takesTwoInouts(&prop, &prop)
+    // expected-error@-1{{overlapping accesses to 'self.prop', but modification requires exclusive access; consider copying to a local variable}}
+    // expected-note@-2{{conflicting access is here}}
+  }
+}


### PR DESCRIPTION
Fix an unreachable when constructing the description of the accessed subpath
when diagnosing an exclusivity violation on a variable of
BoundGenericStructType.

rdar://problem/33031311

