### PR TITLE
Fix EncodingError/DecodingError bridging to NSError

### DIFF
--- a/stdlib/public/SDK/Foundation/Codable.swift
+++ b/stdlib/public/SDK/Foundation/Codable.swift
@@ -14,59 +14,9 @@
 // Errors
 //===----------------------------------------------------------------------===//
 
-// Adding the following extensions to EncodingError and DecodingError allows them to bridge to NSErrors implicitly.
-
-fileprivate let NSCodingPathErrorKey = "NSCodingPath"
-fileprivate let NSDebugDescriptionErrorKey = "NSDebugDescription"
-
-extension EncodingError : CustomNSError {
-    public static var errorDomain: String = NSCocoaErrorDomain
-
-    public var errorCode: Int {
-        switch self {
-        case .invalidValue(_, _): return CocoaError.coderInvalidValue.rawValue
-        }
-    }
-
-    public var errorUserInfo: [String : Any] {
-        let context: Context
-        switch self {
-        case .invalidValue(_, let c): context = c
-        }
-
-        return [NSCodingPathErrorKey: context.codingPath,
-                NSDebugDescriptionErrorKey: context.debugDescription]
-    }
-}
-
-extension DecodingError : CustomNSError {
-    public static var errorDomain: String = NSCocoaErrorDomain
-
-    public var errorCode: Int {
-        switch self {
-        case .valueNotFound(_, _): fallthrough
-        case .keyNotFound(_, _):
-            return CocoaError._coderValueNotFound.rawValue
-
-        case .typeMismatch(_, _): fallthrough
-        case .dataCorrupted(_):
-            return CocoaError._coderReadCorrupt.rawValue
-        }
-    }
-
-    public var errorUserInfo: [String : Any]? {
-        let context: Context
-        switch self {
-        case .typeMismatch(_, let c): context = c
-        case .valueNotFound(_, let c): context = c
-        case .keyNotFound(_, let c): context = c
-        case .dataCorrupted(let c): context = c
-        }
-
-        return [NSCodingPathErrorKey: context.codingPath,
-                NSDebugDescriptionErrorKey: context.debugDescription]
-    }
-}
+// Both of these error types bridge to NSError, and through the entry points they use, no further work is needed to make them localized.
+extension EncodingError : LocalizedError {}
+extension DecodingError : LocalizedError {}
 
 //===----------------------------------------------------------------------===//
 // Error Utilities

--- a/stdlib/public/core/Codable.swift
+++ b/stdlib/public/core/Codable.swift
@@ -2040,6 +2040,31 @@ public enum EncodingError : Error {
     ///
     /// Contains the attempted value, along with context for debugging.
     case invalidValue(Any, Context)
+
+    // MARK: - Bridging
+
+    // CustomNSError bridging applies only when the CustomNSError conformance is applied in the same module as the declared error type.
+    // Since we cannot access CustomNSError (which is defined in Foundation) from here, we can use the "hidden" entry points.
+
+    public var _domain: String {
+        return "NSCocoaErrorDomain"
+    }
+
+    public var _code: Int {
+        switch self {
+        case .invalidValue(_, _): return 4866
+        }
+    }
+
+    public var _userInfo: AnyObject? {
+        let context: Context
+        switch self {
+        case .invalidValue(_, let c): context = c
+        }
+
+        return ["NSCodingPath": context.codingPath,
+                "NSDebugDescription": context.debugDescription] as AnyObject
+    }
 }
 
 /// An error that occurs during the decoding of a value.
@@ -2081,6 +2106,38 @@ public enum DecodingError : Error {
     ///
     /// Contains context for debugging.
     case dataCorrupted(Context)
+
+    // MARK: - Bridging
+
+    // CustomNSError bridging applies only when the CustomNSError conformance is applied in the same module as the declared error type.
+    // Since we cannot access CustomNSError (which is defined in Foundation) from here, we can use the "hidden" entry points.
+
+    public var _domain: String {
+        return "NSCocoaErrorDomain"
+    }
+
+    public var _code: Int {
+        switch self {
+        case .valueNotFound(_, _): fallthrough
+        case .keyNotFound(_, _):   return 4865
+
+        case .typeMismatch(_, _): fallthrough
+        case .dataCorrupted(_):   return 4864
+        }
+    }
+
+    public var _userInfo: AnyObject? {
+        let context: Context
+        switch self {
+        case .typeMismatch(_, let c): context = c
+        case .valueNotFound(_, let c): context = c
+        case .keyNotFound(_, let c): context = c
+        case .dataCorrupted(let c): context  = c
+        }
+
+        return ["NSCodingPath": context.codingPath,
+                "NSDebugDescription": context.debugDescription] as AnyObject
+    }
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
**What's in this pull request?**
Fixes bridging of these error types to `NSError` and `LocalizedError`. `CustomNSError` conformance only enables bridging for types which are declared in the same module as the conformance. Since we cannot use `CustomNSError` in the stdlib, we need to use other entry points to allow this bridging.