### PR TITLE
ArrayElementValuePropagation: Don’t create wrong SIL when trying to optimize ContiguousArray

### DIFF
--- a/lib/SILOptimizer/Transforms/ArrayElementValuePropagation.cpp
+++ b/lib/SILOptimizer/Transforms/ArrayElementValuePropagation.cpp
@@ -320,7 +320,14 @@ public:
     for (const ArrayAllocation::AppendContentOfReplacement &Repl : Repls) {
       ArraySemanticsCall AppendContentsOf(Repl.AppendContentOfCall);
       assert(AppendContentsOf && "Must be AppendContentsOf call");
-      
+
+      NominalTypeDecl *AppendSelfArray = AppendContentsOf.getSelf()->getType().
+        getSwiftRValueType()->getAnyNominal();
+
+      // In case if it's not an Array, but e.g. an ContiguousArray
+      if (AppendSelfArray != Ctx.getArrayDecl())
+        continue;
+
       SILType ArrayType = Repl.Array->getType();
       auto *NTD = ArrayType.getSwiftRValueType()->getAnyNominal();
       SubstitutionMap ArraySubMap = ArrayType.getSwiftRValueType()

--- a/test/SILOptimizer/array_contentof_opt.swift
+++ b/test/SILOptimizer/array_contentof_opt.swift
@@ -53,3 +53,7 @@ public func testString(_ a: inout [String], s: String) {
   a += [s]
 }
 
+// This is not supported yet. Just check that we don't crash on this.`
+public func dontPropagateContiguousArray(_ a: inout ContiguousArray<UInt8>) {
+  a += [4]
+}


### PR DESCRIPTION
Instead just bail on ContiguousArray.

*) Explanation: This fixes a compiler crash when trying to append an array to a ContiguousArray (and not just plain Array).

*) Scope: This is a bug in ArrayElementValuePropagation and only happens in this scenario: var arr: ContiguousArray<UInt8> = []; arr += [4]

*) Jira/Radar: https://bugs.swift.org/browse/SR-5293, rdar://problem/32983212

*) Risk: Low. The fix just adds a bail-out condition

*) Testing: There is a swift-ci test