### PR TITLE
[swift-4.0-branch][stdlib] Underscoring the `countRepresentedWords`

### DIFF
--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -1547,7 +1547,7 @@ extension BinaryInteger {
   ///
   /// This property is a constant for instances of fixed-width integer types.
   @_transparent
-  public var countRepresentedWords: Int {
+  public var _countRepresentedWords: Int {
     return (self.bitWidth + ${word_bits} - 1) / ${word_bits}
   }
 
@@ -1888,11 +1888,11 @@ extension BinaryInteger {
 
 extension BinaryInteger {
   // FIXME(integers): inefficient. Should get rid of _word(at:) and
-  // countRepresentedWords, and make `words` the basic operation.
+  // _countRepresentedWords, and make `words` the basic operation.
   public var words: [UInt] {
     var result = [UInt]()
-    result.reserveCapacity(countRepresentedWords)
-    for i in 0..<self.countRepresentedWords {
+    result.reserveCapacity(_countRepresentedWords)
+    for i in 0..<self._countRepresentedWords {
       result.append(_word(at: i))
     }
     return result
@@ -2287,7 +2287,7 @@ ${unsafeOperationComment(x.operator)}
     else {
       var result: Self = source < (0 as T) ? ~0 : 0
       // start with the most significant word
-      var n = source.countRepresentedWords
+      var n = source._countRepresentedWords
       while n >= 0 {
         // masking is OK here because this we have already ensured
         // that Self.bitWidth > ${word_bits}.  Not masking results in
@@ -2762,7 +2762,7 @@ ${assignmentOperatorComment(x.operator, True)}
   @_transparent
   public func _word(at n: Int) -> UInt {
     _precondition(n >= 0, "Negative word index")
-    if _fastPath(n < countRepresentedWords) {
+    if _fastPath(n < _countRepresentedWords) {
       let shift = UInt(n._value) &* ${word_bits}
       let bitWidth = UInt(self.bitWidth._value)
       _sanityCheck(shift < bitWidth)

--- a/test/Prototypes/BigInt.swift
+++ b/test/Prototypes/BigInt.swift
@@ -121,7 +121,7 @@ public struct _BigInt<Word: FixedWidthInteger & UnsignedInteger> :
     // FIXME: This is broken on 32-bit arch w/ Word = UInt64
     let wordRatio = UInt.bitWidth / Word.bitWidth
     _sanityCheck(wordRatio != 0)
-    for i in 0..<source.countRepresentedWords {
+    for i in 0..<source._countRepresentedWords {
       var sourceWord = source._word(at: i)
       for _ in 0..<wordRatio {
         _data.append(Word(extendingOrTruncating: sourceWord))


### PR DESCRIPTION
* Explanation: Hides the countRepresentedWords property which is not supposed to be used, allowing its removal later.
* Scope of Issue: The API was introduced in Beta 1, so the change is non-breaking
* Risk: Minimal
* Reviewed By: Ben Cohen
* Testing: Automated test suite
* Directions for QA: N/A
* Radar: <rdar://problem/32924828>