### PR TITLE
WIP: [ClangImporter] Allow importing methods on top of properties.

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3570,6 +3570,9 @@ namespace {
       // Look for a matching imported or deserialized member.
       bool result = false;
       for (auto decl : classDecl->lookupDirect(selector, isInstance)) {
+        if (auto *fn = dyn_cast<FuncDecl>(decl))
+          if (fn->isAccessor())
+            continue;
         if (decl->getClangDecl()
             || !decl->getDeclContext()->getParentSourceFile()) {
           result = true;


### PR DESCRIPTION
Accounts for some Swift 3 behavior that changed in #8444: the presence of a property blocks a method and vice versa, even if one or the other comes from a protocol. The change made us more consistently pick whatever was in the original class @‌interface, which of course broke some code.

Still needs much more testing—in particular, this allows you to override the same Objective-C method two different ways. Also doesn't cover the other way around, with properties on top of methods, and it's questionable whether we should only do this when protocols are involved, or even with categories, or maybe all the time.