### PR TITLE
[Foundation] slices of slices that use range expressions incorrectly calculated relative indexing

### DIFF
--- a/test/stdlib/TestData.swift
+++ b/test/stdlib/TestData.swift
@@ -6,8 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
+// RUN: %empty-directory(%t)
 //
 // RUN: %target-clang %S/Inputs/FoundationBridge/FoundationBridge.m -c -o %t/FoundationBridgeObjC.o -g
 // RUN: %target-build-swift %s -I %S/Inputs/FoundationBridge/ -Xlinker %t/FoundationBridgeObjC.o -o %t/TestData
@@ -1073,6 +1072,70 @@ class TestData : TestDataSuper {
         let actual = d2.map { $0 }
         expectEqual(expected, actual)
     }
+
+    func test_dropFirst() {
+        var data = Data([0, 1, 2, 3, 4, 5])
+        let sliced = data.dropFirst()
+        expectEqual(data.count - 1, sliced.count)
+        expectEqual(UInt8(1), sliced[1])
+        expectEqual(UInt8(2), sliced[2])
+        expectEqual(UInt8(3), sliced[3])
+        expectEqual(UInt8(4), sliced[4])
+        expectEqual(UInt8(5), sliced[5])
+    }
+
+    func test_dropFirst2() {
+        var data = Data([0, 1, 2, 3, 4, 5])
+        let sliced = data.dropFirst(2)
+        expectEqual(data.count - 2, sliced.count)
+        expectEqual(UInt8(2), sliced[2])
+        expectEqual(UInt8(3), sliced[3])
+        expectEqual(UInt8(4), sliced[4])
+        expectEqual(UInt8(5), sliced[5])
+    }
+
+    func test_copyBytes1() {
+        var array: [UInt8] = [0, 1, 2, 3]
+        var data = Data(bytes: array)
+        
+        array.withUnsafeMutableBufferPointer {
+            data[1..<3].copyBytes(to: $0.baseAddress!, from: 1..<3)
+        }
+        expectEqual([UInt8(1), UInt8(2), UInt8(2), UInt8(3)], array)
+    }
+    
+    func test_copyBytes2() {
+        let array: [UInt8] = [0, 1, 2, 3]
+        var data = Data(bytes: array)
+        
+        let expectedSlice = array[1..<3]
+        
+        let start = data.index(after: data.startIndex)
+        let end = data.index(before: data.endIndex)
+        let slice = data[start..<end]
+        
+        expectEqual(expectedSlice[expectedSlice.startIndex], slice[slice.startIndex])
+    }
+
+    func test_sliceOfSliceViaRangeExpression() {
+        let data = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+
+        let slice = data[2..<7]
+
+        let sliceOfSlice1 = slice[..<(slice.startIndex + 2)] // this triggers the range expression
+        let sliceOfSlice2 = slice[(slice.startIndex + 2)...] // also triggers range expression
+
+        expectEqual(Data(bytes: [2, 3]), sliceOfSlice1)
+        expectEqual(Data(bytes: [4, 5, 6]), sliceOfSlice2)
+    }
+
+    func test_appendingSlices() {
+        let d1 = Data(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        let slice = d1[1..<2]
+        var d2 = Data()
+        d2.append(slice)
+        expectEqual(Data(bytes: [1]), slice)
+    }
 }
 
 #if !FOUNDATION_XCTEST
@@ -1129,6 +1192,13 @@ DataTests.test("test_sliceEquality") { TestData().test_sliceEquality() }
 DataTests.test("test_sliceEquality2") { TestData().test_sliceEquality2() }
 DataTests.test("test_splittingHttp") { TestData().test_splittingHttp() }
 DataTests.test("test_map") { TestData().test_map() }
+DataTests.test("test_dropFirst") { TestData().test_dropFirst() }
+DataTests.test("test_dropFirst2") { TestData().test_dropFirst2() }
+DataTests.test("test_copyBytes1") { TestData().test_copyBytes1() }
+DataTests.test("test_copyBytes2") { TestData().test_copyBytes2() }
+DataTests.test("test_sliceOfSliceViaRangeExpression") { TestData().test_sliceOfSliceViaRangeExpression() }
+DataTests.test("test_appendingSlices") { TestData().test_appendingSlices() }
+
 
 // XCTest does not have a crash detection, whereas lit does
 DataTests.test("bounding failure subdata") {


### PR DESCRIPTION
The RangeExpression variants of slicing incorrectly passed 0..<R.Bounds.max which should be the slice region of the Data.

This resolves the issues:
rdar://problem/32982494
rdar://problem/32983214 aka [SR-5292]: Another Data slice-related crash


Explanation:
The RangeExpression variants of slicing incorrectly passed 0..<R.Bounds.max which should be the slice region of the Data.

Scope:
This is validation of expectations of regions and appropriate slicing behavior for Data at runtime. No compile time or API changes were made here

Origination:
Feedback provided via radars (and the original version of the proposal had this behavior as well…)

Radar (and possibly SR Issue):
rdar://problem/32982494
rdar://problem/32983214 aka [SR-5292]: Another Data slice-related crash

Risk:
This does have the risk involved that it may catch inappropriate behavior in assertion enabled builds

Testing:
Additional unit tests were added and passed on master
