### PR TITLE
When aborting the program due to force unwrapping a nil value, include the type of the value in the error message

### DIFF
--- a/stdlib/public/core/Optional.swift
+++ b/stdlib/public/core/Optional.swift
@@ -299,13 +299,19 @@ public // COMPILER_INTRINSIC
 func _diagnoseUnexpectedNilOptional(_filenameStart: Builtin.RawPointer,
                                     _filenameLength: Builtin.Word,
                                     _filenameIsASCII: Builtin.Int1,
-                                    _line: Builtin.Word) {
-  _preconditionFailure(
-    "unexpectedly found nil while unwrapping an Optional value",
-    file: StaticString(_start: _filenameStart,
-                       utf8CodeUnitCount: _filenameLength,
-                       isASCII: _filenameIsASCII),
-    line: UInt(_line))
+                                    _line: Builtin.Word,
+                                    _typeStart: Builtin.RawPointer,
+                                    _typeLength: Builtin.Word,
+                                    _typeIsASCII: Builtin.Int1) {
+  let type = StaticString(_start: _typeStart,
+                          utf8CodeUnitCount: _typeLength,
+                          isASCII: _typeIsASCII)
+  let file = StaticString(_start: _filenameStart,
+                          utf8CodeUnitCount: _filenameLength,
+                          isASCII: _filenameIsASCII)
+  let message =
+      "unexpectedly found nil while unwrapping value of optional type '\(type)'"
+  preconditionFailure(message, file: file, line: UInt(_line))
 }
 
 /// Returns a Boolean value indicating whether two optional instances are


### PR DESCRIPTION
This PR changes SILGen to include more debug info when emitting a call to `_diagnoseUnexpectedNilOptional`:  It adds the name of type of the value that is being force-unwrapped, and `_diagnoseUnexpectedNilOptional` then includes it in the error message.  The idea here is to improve the message for cases where you may have multiple force-unwraps on the same line:

```
let dict: [String:[Int]] = ...
print(dict["hello"]!.first!)
```

Currently, this aborts with:
> `unexpectedly found nil while unwrapping an Optional value`

Which doesn't tell which of the two bangs is failing.  With this PR, we'll print:
> `unexpectedly found nil while unwrapping value of optional type '[Int]?'`

This helps understand what exactly went wrong.