### PR TITLE
Demangler: handle suffixes in the form '.<n>'.

### DIFF
--- a/include/swift/Demangling/Demangler.h
+++ b/include/swift/Demangling/Demangler.h
@@ -328,6 +328,12 @@ protected:
     Pos--;
   }
 
+  StringRef consumeAll() {
+    StringRef str = Text.drop_front(Pos);
+    Pos = Text.size();
+    return str;
+  }
+
   void pushNode(NodePointer Nd) {
     NodeStack.push_back(Nd, *this);
   }

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -418,6 +418,11 @@ NodePointer Demangler::demangleOperator() {
     case 'z': return createType(createWithChild(Node::Kind::InOut,
                                                 popTypeAndGetChild()));
     case '_': return createNode(Node::Kind::FirstElementMarker);
+    case '.':
+      // IRGen still uses '.<n>' to disambiguate partial apply thunks and
+      // outlined copy functions. We treat such a suffix as "unmangled suffix".
+      pushBack();
+      return createNode(Node::Kind::Suffix, consumeAll());
     default:
       pushBack();
       return demangleIdentifier();

--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -264,3 +264,5 @@ _T0A8 ---> _T0A8
 _T0s30ReversedRandomAccessCollectionVyxGTfq3nnpf_nTfq1cn_nTfq4x_n ---> _T0s30ReversedRandomAccessCollectionVyxGTfq3nnpf_nTfq1cn_nTfq4x_n
 _T03abc6testitySiFTm ---> merged abc.testit(Swift.Int) -> ()
 _T04main4TestCACSi1x_tc6_PRIV_Llfc ---> main.Test.(in _PRIV_).init(x: Swift.Int) -> main.Test
+_T0SqWy.17 ---> outlined copy of Swift.Optional with unmangled suffix ".17"
+

--- a/tools/swift-demangle/swift-demangle.cpp
+++ b/tools/swift-demangle/swift-demangle.cpp
@@ -166,7 +166,7 @@ static int demangleSTDIN(const swift::Demangle::DemangleOptions &options) {
   // This doesn't handle Unicode symbols, but maybe that's okay.
   // Also accept the future mangling prefix.
   // TODO: remove the "_S" as soon as MANGLING_PREFIX_STR gets "_S".
-  llvm::Regex maybeSymbol("(_T|_*\\$S|" MANGLING_PREFIX_STR ")[_a-zA-Z0-9$]+");
+  llvm::Regex maybeSymbol("(_T|_*\\$S|" MANGLING_PREFIX_STR ")[_a-zA-Z0-9$.]+");
 
   swift::Demangle::Context DCtx;
   for (std::string mangled; std::getline(std::cin, mangled);) {


### PR DESCRIPTION
Demangle such suffixes as "unmangled suffix"
IRGen still uses '.<n>' to disambiguate partial apply thunks and outlined copy functions.

*) Explanation: This enables demangling of symbol name which have a '.<n>' suffix

*) Scope: Such functions can appear in the lldb backtrace and will now be correctly demangled.

*) Radar: rdar://problem/32934962

*) Risk: Low. It's an extension to the demangler and does not affect the compiler

*) Testing: There is a swift-ci test