### PR TITLE
[NFC] Remove some uses of setLet

### DIFF
--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1678,7 +1678,8 @@ public:
   void visitVarDecl(VarDecl *D);
 
   /// Emit an Initialization for a 'var' or 'let' decl in a pattern.
-  std::unique_ptr<Initialization> emitInitializationForVarDecl(VarDecl *vd);
+  std::unique_ptr<Initialization> emitInitializationForVarDecl(VarDecl *vd,
+                                                               bool immutable);
   
   /// Emit the allocation for a local variable, provides an Initialization
   /// that can be used to initialize it, and registers cleanups in the active


### PR DESCRIPTION
This patch anticipates a larger patch that removes `setLet` in addition to expanding the role of the specifier bit(s) in `ParamDecl` and `VarDecl`.  For now, it just touches a more delicate case in pattern emission specifically.  The remaining uses are to unset `let` from parameters with an `inout` specifier and will be handled later.