### PR TITLE
[4.0] JSONEncoder data encoding strategy tweaks

### DIFF
--- a/stdlib/public/SDK/Foundation/JSONEncoder.swift
+++ b/stdlib/public/SDK/Foundation/JSONEncoder.swift
@@ -62,8 +62,11 @@ open class JSONEncoder {
 
     /// The strategy to use for encoding `Data` values.
     public enum DataEncodingStrategy {
+        /// Defer to `Data` for choosing an encoding.
+        case deferredToData
+
         /// Encoded the `Data` as a Base64-encoded string. This is the default strategy.
-        case base64Encode
+        case base64
 
         /// Encode the `Data` as a custom value encoded by the given closure.
         ///
@@ -86,8 +89,8 @@ open class JSONEncoder {
     /// The strategy to use in encoding dates. Defaults to `.deferredToDate`.
     open var dateEncodingStrategy: DateEncodingStrategy = .deferredToDate
 
-    /// The strategy to use in encoding binary data. Defaults to `.base64Encode`.
-    open var dataEncodingStrategy: DataEncodingStrategy = .base64Encode
+    /// The strategy to use in encoding binary data. Defaults to `.base64`.
+    open var dataEncodingStrategy: DataEncodingStrategy = .base64
 
     /// The strategy to use in encoding non-conforming numbers. Defaults to `.throw`.
     open var nonConformingFloatEncodingStrategy: NonConformingFloatEncodingStrategy = .throw
@@ -661,7 +664,12 @@ extension _JSONEncoder {
 
     fileprivate func box(_ data: Data) throws -> NSObject {
         switch self.options.dataEncodingStrategy {
-        case .base64Encode:
+        case .deferredToData:
+            // Must be called with a surrounding with(pushedKey:) call.
+            try data.encode(to: self)
+            return self.storage.popContainer()
+
+        case .base64:
             return NSString(string: data.base64EncodedString())
 
         case .custom(let closure):
@@ -813,8 +821,11 @@ open class JSONDecoder {
 
     /// The strategy to use for decoding `Data` values.
     public enum DataDecodingStrategy {
+        /// Defer to `Data` for decoding.
+        case deferredToData
+
         /// Decode the `Data` from a Base64-encoded string. This is the default strategy.
-        case base64Decode
+        case base64
 
         /// Decode the `Data` as a custom value decoded by the given closure.
         case custom((_ decoder: Decoder) throws -> Data)
@@ -832,8 +843,8 @@ open class JSONDecoder {
     /// The strategy to use in decoding dates. Defaults to `.deferredToDate`.
     open var dateDecodingStrategy: DateDecodingStrategy = .deferredToDate
 
-    /// The strategy to use in decoding binary data. Defaults to `.base64Decode`.
-    open var dataDecodingStrategy: DataDecodingStrategy = .base64Decode
+    /// The strategy to use in decoding binary data. Defaults to `.base64`.
+    open var dataDecodingStrategy: DataDecodingStrategy = .base64
 
     /// The strategy to use in decoding non-conforming numbers. Defaults to `.throw`.
     open var nonConformingFloatDecodingStrategy: NonConformingFloatDecodingStrategy = .throw
@@ -1932,7 +1943,13 @@ extension _JSONDecoder {
         guard !(value is NSNull) else { return nil }
 
         switch self.options.dataDecodingStrategy {
-        case .base64Decode:
+        case .deferredToData:
+            self.storage.push(container: value)
+            let data = try Data(from: self)
+            self.storage.popContainer()
+            return data
+
+        case .base64:
             guard let string = value as? String else {
                 throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
             }

--- a/test/stdlib/TestJSONEncoder.swift
+++ b/test/stdlib/TestJSONEncoder.swift
@@ -123,7 +123,7 @@ class TestJSONEncoder : TestJSONEncoderSuper {
 
   // MARK: - Date Strategy Tests
   func testEncodingDate() {
-    // We can't encode a top-level Date, so it'll be wrapped in an array.
+    // We can't encode a top-level Date, so it'll be wrapped in a dictionary.
     _testRoundTrip(of: TopLevelWrapper(Date()))
   }
 
@@ -132,7 +132,7 @@ class TestJSONEncoder : TestJSONEncoderSuper {
     let seconds = 1000.0
     let expectedJSON = "{\"value\":1000}".data(using: .utf8)!
 
-    // We can't encode a top-level Date, so it'll be wrapped in an array.
+    // We can't encode a top-level Date, so it'll be wrapped in a dictionary.
     _testRoundTrip(of: TopLevelWrapper(Date(timeIntervalSince1970: seconds)),
                    expectedJSON: expectedJSON,
                    dateEncodingStrategy: .secondsSince1970,
@@ -144,7 +144,7 @@ class TestJSONEncoder : TestJSONEncoderSuper {
     let seconds = 1000.0
     let expectedJSON = "{\"value\":1000000}".data(using: .utf8)!
 
-    // We can't encode a top-level Date, so it'll be wrapped in an array.
+    // We can't encode a top-level Date, so it'll be wrapped in a dictionary.
     _testRoundTrip(of: TopLevelWrapper(Date(timeIntervalSince1970: seconds)),
                    expectedJSON: expectedJSON,
                    dateEncodingStrategy: .millisecondsSince1970,
@@ -159,7 +159,7 @@ class TestJSONEncoder : TestJSONEncoderSuper {
       let timestamp = Date(timeIntervalSince1970: 1000)
       let expectedJSON = "{\"value\":\"\(formatter.string(from: timestamp))\"}".data(using: .utf8)!
 
-      // We can't encode a top-level Date, so it'll be wrapped in an array.
+      // We can't encode a top-level Date, so it'll be wrapped in a dictionary.
       _testRoundTrip(of: TopLevelWrapper(timestamp),
                      expectedJSON: expectedJSON,
                      dateEncodingStrategy: .iso8601,
@@ -175,7 +175,7 @@ class TestJSONEncoder : TestJSONEncoderSuper {
     let timestamp = Date(timeIntervalSince1970: 1000)
     let expectedJSON = "{\"value\":\"\(formatter.string(from: timestamp))\"}".data(using: .utf8)!
 
-    // We can't encode a top-level Date, so it'll be wrapped in an array.
+    // We can't encode a top-level Date, so it'll be wrapped in a dictionary.
     _testRoundTrip(of: TopLevelWrapper(timestamp),
                    expectedJSON: expectedJSON,
                    dateEncodingStrategy: .formatted(formatter),
@@ -192,7 +192,7 @@ class TestJSONEncoder : TestJSONEncoderSuper {
     }
     let decode = { (_: Decoder) throws -> Date in return timestamp }
 
-    // We can't encode a top-level Date, so it'll be wrapped in an array.
+    // We can't encode a top-level Date, so it'll be wrapped in a dictionary.
     let expectedJSON = "{\"value\":42}".data(using: .utf8)!
     _testRoundTrip(of: TopLevelWrapper(timestamp),
                    expectedJSON: expectedJSON,
@@ -207,7 +207,7 @@ class TestJSONEncoder : TestJSONEncoderSuper {
     let encode = { (_: Date, _: Encoder) throws -> Void in }
     let decode = { (_: Decoder) throws -> Date in return timestamp }
 
-    // We can't encode a top-level Date, so it'll be wrapped in an array.
+    // We can't encode a top-level Date, so it'll be wrapped in a dictionary.
     let expectedJSON = "{\"value\":{}}".data(using: .utf8)!
     _testRoundTrip(of: TopLevelWrapper(timestamp),
                    expectedJSON: expectedJSON,
@@ -216,10 +216,21 @@ class TestJSONEncoder : TestJSONEncoderSuper {
   }
 
   // MARK: - Data Strategy Tests
+  func testEncodingData() {
+    let data = Data(bytes: [0xDE, 0xAD, 0xBE, 0xEF])
+
+    // We can't encode a top-level Data, so it'll be wrapped in a dictionary.
+    let expectedJSON = "{\"value\":[222,173,190,239]}".data(using: .utf8)!
+    _testRoundTrip(of: TopLevelWrapper(data),
+                   expectedJSON: expectedJSON,
+                   dataEncodingStrategy: .deferredToData,
+                   dataDecodingStrategy: .deferredToData)
+  }
+
   func testEncodingBase64Data() {
     let data = Data(bytes: [0xDE, 0xAD, 0xBE, 0xEF])
 
-    // We can't encode a top-level Data, so it'll be wrapped in an array.
+    // We can't encode a top-level Data, so it'll be wrapped in a dictionary.
     let expectedJSON = "{\"value\":\"3q2+7w==\"}".data(using: .utf8)!
     _testRoundTrip(of: TopLevelWrapper(data), expectedJSON: expectedJSON)
   }
@@ -232,7 +243,7 @@ class TestJSONEncoder : TestJSONEncoderSuper {
     }
     let decode = { (_: Decoder) throws -> Data in return Data() }
 
-    // We can't encode a top-level Data, so it'll be wrapped in an array.
+    // We can't encode a top-level Data, so it'll be wrapped in a dictionary.
     let expectedJSON = "{\"value\":42}".data(using: .utf8)!
     _testRoundTrip(of: TopLevelWrapper(Data()),
                    expectedJSON: expectedJSON,
@@ -245,7 +256,7 @@ class TestJSONEncoder : TestJSONEncoderSuper {
     let encode = { (_: Data, _: Encoder) throws -> Void in }
     let decode = { (_: Decoder) throws -> Data in return Data() }
 
-    // We can't encode a top-level Data, so it'll be wrapped in an array.
+    // We can't encode a top-level Data, so it'll be wrapped in a dictionary.
     let expectedJSON = "{\"value\":{}}".data(using: .utf8)!
     _testRoundTrip(of: TopLevelWrapper(Data()),
                    expectedJSON: expectedJSON,
@@ -352,8 +363,8 @@ class TestJSONEncoder : TestJSONEncoderSuper {
                                  outputFormatting: JSONEncoder.OutputFormatting = [],
                                  dateEncodingStrategy: JSONEncoder.DateEncodingStrategy = .deferredToDate,
                                  dateDecodingStrategy: JSONDecoder.DateDecodingStrategy = .deferredToDate,
-                                 dataEncodingStrategy: JSONEncoder.DataEncodingStrategy = .base64Encode,
-                                 dataDecodingStrategy: JSONDecoder.DataDecodingStrategy = .base64Decode,
+                                 dataEncodingStrategy: JSONEncoder.DataEncodingStrategy = .base64,
+                                 dataDecodingStrategy: JSONDecoder.DataDecodingStrategy = .base64,
                                  nonConformingFloatEncodingStrategy: JSONEncoder.NonConformingFloatEncodingStrategy = .throw,
                                  nonConformingFloatDecodingStrategy: JSONDecoder.NonConformingFloatDecodingStrategy = .throw) where T : Codable, T : Equatable {
     var payload: Data! = nil
@@ -881,6 +892,7 @@ JSONEncoderTests.test("testEncodingDateISO8601") { TestJSONEncoder().testEncodin
 JSONEncoderTests.test("testEncodingDateFormatted") { TestJSONEncoder().testEncodingDateFormatted() }
 JSONEncoderTests.test("testEncodingDateCustom") { TestJSONEncoder().testEncodingDateCustom() }
 JSONEncoderTests.test("testEncodingDateCustomEmpty") { TestJSONEncoder().testEncodingDateCustomEmpty() }
+JSONEncoderTests.test("testEncodingData") { TestJSONEncoder().testEncodingData() }
 JSONEncoderTests.test("testEncodingBase64Data") { TestJSONEncoder().testEncodingBase64Data() }
 JSONEncoderTests.test("testEncodingCustomData") { TestJSONEncoder().testEncodingCustomData() }
 JSONEncoderTests.test("testEncodingCustomDataEmpty") { TestJSONEncoder().testEncodingCustomDataEmpty() }


### PR DESCRIPTION
**What's new in this pull request?**
Cherry-picks #10680 to `swift-4.0-branch`.

**Explanation:**
As laid out in a [proposed update to SE-0166 and SE-0167](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20170619/037672.html), there are JSON data encoding strategies that we wanted to update:

* Add `deferredToData` strategy on encode and decode
* Rename `base64{Encode,Decode}` to `base64` (missed this in previous fixes)
* Add unit test to confirm behavior

**Scope:** Affects those who want to customize the default behavior of encoding and decoding `Data` using `JSONEncoder`/`JSONDecoder`.
**Radar:** rdar://problem/32469875
**Risk:** Low
**Testing:** Adds new unit tests to confirm expected behavior.