### PR TITLE
[4.0] [QoI] Add fix-it for cases in switch with optional chaining

### DIFF
--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -1396,8 +1396,17 @@ recur:
             goto recur;
           }
 
-          diagnose(EEP->getLoc(), diag::enum_element_pattern_member_not_found,
-                   EEP->getName().str(), type);
+          auto diag = diagnose(EEP->getLoc(),
+                               diag::enum_element_pattern_member_not_found,
+                               EEP->getName().str(), type);
+
+          // If we have an optional type let's try to see if the case
+          // exists in its base type, if so we can suggest a fix-it for that.
+          if (auto baseType = type->getOptionalObjectType()) {
+            if (lookupEnumMemberElement(*this, dc, baseType, EEP->getName(),
+                                        EEP->getLoc()))
+              diag.fixItInsertAfter(EEP->getEndLoc(), "?");
+          }
         }
         return true;
       }

--- a/test/Constraints/patterns.swift
+++ b/test/Constraints/patterns.swift
@@ -314,3 +314,25 @@ switch staticMembers {
 }
 
 _ = 0
+
+// rdar://problem/32241441 - Add fix-it for cases in switch with optional chaining
+
+struct S_32241441 {
+  enum E_32241441 {
+    case foo
+    case bar
+  }
+
+  var type: E_32241441 = E_32241441.foo
+}
+
+func rdar32241441() {
+  let s: S_32241441? = S_32241441()
+
+  switch s?.type {
+  case .foo: // expected-error {{enum case 'foo' not found in type 'S_32241441.E_32241441?'}} {{12-12=?}}
+    break;
+  case .bar: // expected-error {{enum case 'bar' not found in type 'S_32241441.E_32241441?'}} {{12-12=?}}
+    break;
+  }
+}


### PR DESCRIPTION
* Description: When type-checking switch statements with patterns let's
                        check if we have an optional type and try to see if the case
                        exists in its base type, if so we can suggest a fix-it.

* Scope of the issue: diagnostic improvements for enum cases with optional chaining.

* Risk: Low.

* Tested: New test cases added, Swift CI.

* Reviewed by: Mark Lacey, Jordan Rose.

* Resolves: rdar://problem/32241441

(cherry picked from commit 5f571836543b12b241808f7917ef9eca56eb7e59)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
