### PR TITLE
[4.0] Use the debugger hook, `reportToDebugger`, for all calls to _swift_stdlib_reportFatalError[InFile]

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -185,6 +185,9 @@ namespace swift {
     /// accesses.
     bool DisableTsanInoutInstrumentation = false;
 
+    /// \brief Staging flag for reporting runtime issues to the debugger.
+    bool ReportErrorsToDebugger = false;
+
     /// \brief Staging flag for class resilience, which we do not want to enable
     /// fully until more code is in place, to allow the standard library to be
     /// tested with value type resilience only.

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -294,6 +294,9 @@ def disable_tsan_inout_instrumentation : Flag<["-"],
   "disable-tsan-inout-instrumentation">,
   HelpText<"Disable treatment of inout parameters as Thread Sanitizer accesses">;
 
+def report_errors_to_debugger : Flag<["-"], "report-errors-to-debugger">,
+  HelpText<"Invoke the debugger hook on fatalError calls">;
+
 def enable_infer_import_as_member :
   Flag<["-"], "enable-infer-import-as-member">,
   HelpText<"Infer when a global could be imported as a member">;

--- a/include/swift/Runtime/Debug.h
+++ b/include/swift/Runtime/Debug.h
@@ -176,6 +176,9 @@ struct RuntimeErrorDetails {
 void reportToDebugger(bool isFatal, const char *message,
                       RuntimeErrorDetails *details = nullptr);
 
+SWIFT_RUNTIME_EXPORT
+bool _swift_reportFatalErrorsToDebugger;
+
 // namespace swift
 }
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -955,6 +955,9 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.DisableTsanInoutInstrumentation |=
       Args.hasArg(OPT_disable_tsan_inout_instrumentation);
 
+  Opts.ReportErrorsToDebugger |=
+      Args.hasArg(OPT_report_errors_to_debugger);
+
   if (FrontendOpts.InputKind == InputFileKind::IFK_SIL)
     Opts.DisableAvailabilityChecking = true;
   

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -795,6 +795,7 @@ private:
 
   void emitGlobalLists();
   void emitAutolinkInfo();
+  void emitEnableReportErrorsToDebugger();
   void cleanupClangCodeGenMetadata();
 
 //--- Remote reflection metadata --------------------------------------------

--- a/stdlib/public/stubs/Assert.cpp
+++ b/stdlib/public/stubs/Assert.cpp
@@ -21,6 +21,8 @@
 
 using namespace swift;
 
+bool swift::_swift_reportFatalErrorsToDebugger = false;
+
 static int swift_asprintf(char **strp, const char *fmt, ...) {
   va_list args;
   va_start(args, fmt);
@@ -49,6 +51,24 @@ static int swift_asprintf(char **strp, const char *fmt, ...) {
   return result;
 }
 
+static void logPrefixAndMessageToDebugger(
+    const unsigned char *prefix, int prefixLength,
+    const unsigned char *message, int messageLength
+) {
+  if (!_swift_reportFatalErrorsToDebugger)
+    return;
+
+  char *debuggerMessage;
+  if (messageLength) {
+    swift_asprintf(&debuggerMessage, "%.*s: %.*s", prefixLength, prefix,
+        messageLength, message);
+  } else {
+    swift_asprintf(&debuggerMessage, "%.*s", prefixLength, prefix);
+  }
+  reportToDebugger(RuntimeErrorFlagFatal, debuggerMessage);
+  free(debuggerMessage);
+}
+
 void swift::_swift_stdlib_reportFatalErrorInFile(
     const unsigned char *prefix, int prefixLength,
     const unsigned char *message, int messageLength,
@@ -56,6 +76,8 @@ void swift::_swift_stdlib_reportFatalErrorInFile(
     uint32_t line,
     uint32_t flags
 ) {
+  logPrefixAndMessageToDebugger(prefix, prefixLength, message, messageLength);
+
   char *log;
   swift_asprintf(
       &log, "%.*s: %.*s%sfile %.*s, line %" PRIu32 "\n",
@@ -74,6 +96,8 @@ void swift::_swift_stdlib_reportFatalError(
     const unsigned char *message, int messageLength,
     uint32_t flags
 ) {
+  logPrefixAndMessageToDebugger(prefix, prefixLength, message, messageLength);
+
   char *log;
   swift_asprintf(
       &log, "%.*s: %.*s\n",


### PR DESCRIPTION
Use the debugger hook, `reportToDebugger`, for all calls to _swift_stdlib_reportFatalError[InFile].  Only do this when a hidden frontend flag, `-report-errors-to-debugger`, is used. This cherry-picks 4b88da2a2cc8e8afb1f074a0287faa929d353ea6 onto swift-4.0-branch.

**Explanation**: This extends the "Runtime Issues" debugger hook to be used by most common fatal errors (unwrapping nil, out-of-bounds array access, precondition/assert failures), but hidden under a compiler flag for staging. Unless the flag is used, there's no change in behavior.
**Scope**: The change affects reporting of fatal errors in the Swift runtime and user code.  Unless the flag is used, there's no change in behavior.
**Radar**: <rdar://problem/32991793>
**Risk**: Very low: The change is hidden under a compiler flag.  Unless the flag is used, there's no change in behavior.
**Testing**:  I tested several common cases of fatal errors (unwrapping nil, out-of-bounds array access, precondition/assert failures) and made sure the message is correctly passed to LLDB.