### PR TITLE
Remove an old diagnostic for 'var' in param position

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -4509,7 +4509,7 @@ public:
 class ParamDecl : public VarDecl {
   Identifier ArgumentName;
   SourceLoc ArgumentNameLoc;
-  SourceLoc LetVarInOutLoc;
+  SourceLoc SpecifierLoc;
 
   struct StoredDefaultArgument {
     Expr *DefaultArg = nullptr;
@@ -4530,7 +4530,7 @@ class ParamDecl : public VarDecl {
   DefaultArgumentKind defaultArgumentKind = DefaultArgumentKind::None;
   
 public:
-  ParamDecl(bool isLet, SourceLoc letVarInOutLoc, SourceLoc argumentNameLoc,
+  ParamDecl(bool isLet, SourceLoc specifierLoc, SourceLoc argumentNameLoc,
             Identifier argumentName, SourceLoc parameterNameLoc,
             Identifier parameterName, Type ty, DeclContext *dc);
 
@@ -4548,7 +4548,7 @@ public:
   /// was specified separately from the parameter name.
   SourceLoc getArgumentNameLoc() const { return ArgumentNameLoc; }
 
-  SourceLoc getLetVarInOutLoc() const { return LetVarInOutLoc; }
+  SourceLoc getSpecifierLoc() const { return SpecifierLoc; }
 
   bool isTypeLocImplicit() const { return IsTypeLocImplicit; }
   void setIsTypeLocImplicit(bool val) { IsTypeLocImplicit = val; }

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -814,8 +814,8 @@ ERROR(inout_as_attr_disallowed,none,
 ERROR(parameter_inout_var_let_repeated,none,
       "parameter may not have multiple 'inout', 'var', or 'let' specifiers",
       ())
-ERROR(parameter_let_as_attr,none,
-      "'let' as a parameter attribute is not allowed", ())
+ERROR(parameter_let_var_as_attr,none,
+      "'%select{var|let}0' as a parameter attribute is not allowed", (unsigned))
 
 
 ERROR(expected_behavior_name,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1006,10 +1006,6 @@ ERROR(attribute_requires_operator_identifier,none,
 ERROR(attribute_requires_single_argument,none,
       "'%0' requires a function with one argument", (StringRef))
 
-ERROR(var_parameter_not_allowed,none,
-      "parameters may not have the 'var' specifier", ())
-
-
 ERROR(mutating_invalid_global_scope,none,
       "'mutating' is only valid on methods", ())
 ERROR(mutating_invalid_classes,none,

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -977,15 +977,14 @@ public:
     /// Any declaration attributes attached to the parameter.
     DeclAttributes Attrs;
 
-    /// The location of the 'let', 'var', or 'inout' keyword, if present.
-    SourceLoc LetVarInOutLoc;
+    /// The location of the 'inout' keyword, if present.
+    SourceLoc SpecifierLoc;
 
     enum SpecifierKindTy {
-      Let,
-      Var,
+      None,
       InOut
     };
-    SpecifierKindTy SpecifierKind = Let; // Defaults to let.
+    SpecifierKindTy SpecifierKind = None; // Defaults to 'no value'.
 
     /// The location of the first name.
     ///

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4114,13 +4114,13 @@ void VarDecl::emitLetToVarNoteIfSimple(DeclContext *UseDC) const {
 }
 
 ParamDecl::ParamDecl(bool isLet,
-                     SourceLoc letVarInOutLoc, SourceLoc argumentNameLoc,
+                     SourceLoc specifierLoc, SourceLoc argumentNameLoc,
                      Identifier argumentName, SourceLoc parameterNameLoc,
                      Identifier parameterName, Type ty, DeclContext *dc)
   : VarDecl(DeclKind::Param, /*IsStatic*/false, /*IsLet*/isLet,
             /*IsCaptureList*/false, parameterNameLoc, parameterName, ty, dc),
   ArgumentName(argumentName), ArgumentNameLoc(argumentNameLoc),
-  LetVarInOutLoc(letVarInOutLoc) {
+  SpecifierLoc(specifierLoc) {
 }
 
 /// Clone constructor, allocates a new ParamDecl identical to the first.
@@ -4131,7 +4131,7 @@ ParamDecl::ParamDecl(ParamDecl *PD)
             PD->hasType() ? PD->getType() : Type(), PD->getDeclContext()),
     ArgumentName(PD->getArgumentName()),
     ArgumentNameLoc(PD->getArgumentNameLoc()),
-    LetVarInOutLoc(PD->getLetVarInOutLoc()),
+    SpecifierLoc(PD->getSpecifierLoc()),
     DefaultValueAndIsVariadic(nullptr, PD->DefaultValueAndIsVariadic.getInt()),
     IsTypeLocImplicit(PD->IsTypeLocImplicit),
     defaultArgumentKind(PD->defaultArgumentKind) {

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -671,74 +671,6 @@ static bool validateTypedPattern(TypeChecker &TC, DeclContext *DC,
   return hadError;
 }
 
-static void diagnoseAndMigrateVarParameterToBody(ParamDecl *decl,
-                                                 AbstractFunctionDecl *func,
-                                                 TypeChecker &TC) {
-  if (!func || !func->hasBody()) {
-    // If there is no function body, just suggest removal.
-    TC.diagnose(decl->getLetVarInOutLoc(),
-                diag::var_parameter_not_allowed)
-      .fixItRemove(decl->getLetVarInOutLoc());
-    return;
-  }
-  // Insert the shadow copy. The computations that follow attempt to
-  // 'best guess' the indentation and new lines so that the user
-  // doesn't have to add any whitespace.
-  auto declBody = func->getBody();
-  
-  auto &SM = TC.Context.SourceMgr;
-  
-  SourceLoc insertionStartLoc;
-  std::string start;
-  std::string end;
-  
-  auto lBraceLine = SM.getLineNumber(declBody->getLBraceLoc());
-  auto rBraceLine = SM.getLineNumber(declBody->getRBraceLoc());
-
-  if (!declBody->getNumElements()) {
-    
-    // Empty function body.
-    insertionStartLoc = declBody->getRBraceLoc();
-    
-    if (lBraceLine == rBraceLine) {
-      // Same line braces, means we probably have something
-      // like {} as the func body. Insert directly into body with spaces.
-      start = " ";
-      end = " ";
-    } else {
-      // Different line braces, so use RBrace's indentation.
-      end = "\n" + Lexer::getIndentationForLine(SM, declBody->
-                                                getRBraceLoc()).str();
-      start = "    "; // Guess 4 spaces as extra indentation.
-    }
-  } else {
-    auto firstLine = declBody->getElement(0);
-    insertionStartLoc = firstLine.getStartLoc();
-    if (lBraceLine == SM.getLineNumber(firstLine.getStartLoc())) {
-      // Function on same line, insert with semi-colon. Not ideal but
-      // better than weird space alignment.
-      start = "";
-      end = "; ";
-    } else {
-      start = "";
-      end = "\n" + Lexer::getIndentationForLine(SM, firstLine.
-                                                getStartLoc()).str();
-    }
-  }
-  if (insertionStartLoc.isInvalid()) {
-    TC.diagnose(decl->getLetVarInOutLoc(),
-                diag::var_parameter_not_allowed)
-    .fixItRemove(decl->getLetVarInOutLoc());
-    return;
-  }
-  auto parameterName = decl->getNameStr().str();
-  TC.diagnose(decl->getLetVarInOutLoc(),
-              diag::var_parameter_not_allowed)
-  .fixItRemove(decl->getLetVarInOutLoc())
-  .fixItInsert(insertionStartLoc, start + "var " + parameterName + " = " +
-               parameterName + end);
-}
-
 static bool validateParameterType(ParamDecl *decl, DeclContext *DC,
                                   TypeResolutionOptions options,
                                   GenericTypeResolver &resolver,
@@ -772,7 +704,7 @@ static bool validateParameterType(ParamDecl *decl, DeclContext *DC,
 
   // If the user did not explicitly write 'let', 'var', or 'inout', we'll let
   // type inference figure out what went wrong in detail.
-  if (decl->getLetVarInOutLoc().isValid()) {
+  if (decl->getSpecifierLoc().isValid()) {
     // If the param is not a 'let' and it is not an 'inout'.
     // It must be a 'var'. Provide helpful diagnostics like a shadow copy
     // in the function body to fix the 'var' attribute.
@@ -780,8 +712,6 @@ static bool validateParameterType(ParamDecl *decl, DeclContext *DC,
         !decl->isImplicit() &&
         (Ty.isNull() || !Ty->is<InOutType>()) &&
         !hadError) {
-      auto func = dyn_cast_or_null<AbstractFunctionDecl>(DC);
-      diagnoseAndMigrateVarParameterToBody(decl, func, TC);
       decl->setInvalid();
       hadError = true;
     }

--- a/test/Parse/invalid.swift
+++ b/test/Parse/invalid.swift
@@ -82,18 +82,18 @@ func SR979d(let let a: Int) {}  // expected-error {{'let' as a parameter attribu
 // expected-error @-1 {{parameter may not have multiple 'inout', 'var', or 'let' specifiers}} {{17-21=}}
 func SR979e(inout x: inout String) {} // expected-error {{parameter may not have multiple 'inout', 'var', or 'let' specifiers}} {{13-18=}}
 func SR979f(var inout x : Int) { // expected-error {{parameter may not have multiple 'inout', 'var', or 'let' specifiers}} {{17-23=}}
-// expected-error @-1 {{parameters may not have the 'var' specifier}} {{13-16=}}{{3-3=var x = x\n  }} 
-  x += 10
+// expected-error @-1 {{'var' as a parameter attribute is not allowed}}
+  x += 10     // expected-error {{left side of mutating operator isn't mutable: 'x' is a 'let' constant}}
 }
 func SR979g(inout i: inout Int) {} // expected-error {{parameter may not have multiple 'inout', 'var', or 'let' specifiers}} {{13-18=}}
 func SR979h(let inout x : Int) {}  // expected-error {{parameter may not have multiple 'inout', 'var', or 'let' specifiers}} {{17-23=}}
 // expected-error @-1 {{'let' as a parameter attribute is not allowed}}
 class VarTester {
-  init(var a: Int, var b: Int) {} // expected-error {{parameters may not have the 'var' specifier}} {{8-11=}} {{33-33= var a = a }}
-  // expected-error @-1 {{parameters may not have the 'var' specifier}} {{20-24=}} {{33-33= var b = b }}
-    func x(var b: Int) { //expected-error {{parameters may not have the 'var' specifier}} {{12-15=}} {{9-9=var b = b\n        }}
-        b += 10
-    }
+  init(var a: Int, var b: Int) {} // expected-error {{'var' as a parameter attribute is not allowed}}
+  // expected-error @-1 {{'var' as a parameter attribute is not allowed}}
+  func x(var b: Int) { //expected-error {{'var' as a parameter attribute is not allowed}}
+    b += 10 // expected-error {{left side of mutating operator isn't mutable: 'b' is a 'let' constant}}
+  }
 }
 
 func repeat() {}

--- a/test/Sema/immutability.swift
+++ b/test/Sema/immutability.swift
@@ -348,11 +348,11 @@ func testSelectorStyleArguments3(_ x: Int, bar y: Int) {
 func invalid_inout(inout var x : Int) { // expected-error {{parameter may not have multiple 'inout', 'var', or 'let' specifiers}} {{26-30=}}
 // expected-error @-1 {{'inout' before a parameter name is not allowed, place it before the parameter type instead}}{{20-25=}}{{34-34=inout }}
 }
-func invalid_var(var x: Int) { // expected-error {{parameters may not have the 'var' specifier}}{{18-21=}} {{1-1=    var x = x\n}}
+func invalid_var(var x: Int) { // expected-error {{'var' as a parameter attribute is not allowed}}
   
 }
 func takesClosure(_: (Int) -> Int) {
-  takesClosure { (var d) in d } // expected-error {{parameters may not have the 'var' specifier}}
+  takesClosure { (var d) in d } // expected-error {{'var' as a parameter attribute is not allowed}}
 }
 
 func updateInt(_ x : inout Int) {}

--- a/test/decl/class/override.swift
+++ b/test/decl/class/override.swift
@@ -169,8 +169,8 @@ class H : G {
 
   func manyA(_: AnyObject, _: AnyObject) {}
   func manyB(_ a: AnyObject, b: AnyObject) {}
-  func manyC(var a: AnyObject,  // expected-error {{parameters may not have the 'var' specifier}} {{14-17=}}
-             var b: AnyObject) {} // expected-error {{parameters may not have the 'var' specifier}} {{14-18=}}
+  func manyC(var a: AnyObject,  // expected-error {{'var' as a parameter attribute is not allowed}}
+             var b: AnyObject) {} // expected-error {{'var' as a parameter attribute is not allowed}}
 
   func result() -> AnyObject? { return nil }
   func both(_ x: AnyObject) -> AnyObject? { return x }

--- a/test/decl/var/usage.swift
+++ b/test/decl/var/usage.swift
@@ -12,10 +12,10 @@ func basicTests() -> Int {
   return y
 }
 
-func mutableParameter(_ a : Int, h : Int, var i : Int, j: Int, g: Int) -> Int { // expected-error {{parameters may not have the 'var' specifier}}
-  i += 1
+func mutableParameter(_ a : Int, h : Int, var i : Int, j: Int, g: Int) -> Int { // expected-error {{'var' as a parameter attribute is not allowed}}
+  i += 1 // expected-error {{left side of mutating operator isn't mutable: 'i' is a 'let' constant}}
   var j = j
-  swap(&i, &j)
+  swap(&i, &j) // expected-error {{cannot pass immutable value as inout argument: 'i' is a 'let' constant}}
   return i+g
 }
 


### PR DESCRIPTION
Using the attribute in this position is a relic from the Swift 2
days, and fixing it required letting invalid code fall through to
Sema instead of being diagnosed in Parse proper.  Treat 'var'
in this position like 'let' by simply offering to remove it
instead of extracting it into a separate variable.

This simplifies our model by making the mapping between parsed parameter specifiers and parameter declaration specifiers one-to-one.  In a future commit, these two representations will merge.

This is currently blocking #10695.