### PR TITLE
Avoid building conformance lookup tables when we don't have to.

### DIFF
--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -25,9 +25,14 @@
 #include "swift/AST/Types.h"
 #include "swift/AST/TypeWalker.h"
 #include "llvm/ADT/MapVector.h"
+#include "llvm/ADT/Statistic.h"
 #include "llvm/ADT/TinyPtrVector.h"
 #include "llvm/Support/PrettyStackTrace.h"
 #include "llvm/Support/SaveAndRestore.h"
+
+#define DEBUG_TYPE "AST"
+
+STATISTIC(NumConformanceLookupTables, "# of conformance lookup tables built");
 
 using namespace swift;
 
@@ -917,6 +922,7 @@ void NominalTypeDecl::prepareConformanceTable() const {
   auto resolver = ctx.getLazyResolver();
   ConformanceTable = new (ctx) ConformanceLookupTable(ctx, mutableThis,
                                                       resolver);
+  ++NumConformanceLookupTables;
 
   // If this type declaration was not parsed from source code or introduced
   // via the Clang importer, don't add any synthesized conformances.

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2641,6 +2641,9 @@ static void checkBridgedFunctions(TypeChecker &TC) {
 
 /// Infer the Objective-C name for a given declaration.
 static void inferObjCName(TypeChecker &tc, ValueDecl *decl) {
+  if (isa<DestructorDecl>(decl))
+    return;
+
   // If this declaration overrides an @objc declaration, use its name.
   if (auto overridden = decl->getOverriddenDecl()) {
     if (overridden->isObjC()) {

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5581,6 +5581,8 @@ bool TypeChecker::useObjectiveCBridgeableConformances(DeclContext *dc,
       // If we have a nominal type, "use" its conformance to
       // _ObjectiveCBridgeable if it has one.
       if (auto *nominalDecl = ty->getAnyNominal()) {
+        if (isa<ClassDecl>(nominalDecl) || isa<ProtocolDecl>(nominalDecl))
+          return Action::Continue;
         auto result = TC.conformsToProtocol(ty, Proto, DC, options,
                                             /*ComplainLoc=*/SourceLoc(),
                                             Callback);

--- a/lib/Serialization/DeserializationErrors.h
+++ b/lib/Serialization/DeserializationErrors.h
@@ -17,8 +17,13 @@
 #include "swift/AST/Module.h"
 #include "swift/Serialization/ModuleFormat.h"
 #include "llvm/Support/Error.h"
+#include "llvm/Support/PrettyStackTrace.h"
 
 namespace swift {
+class ModuleFile;
+
+StringRef getNameOfModule(const ModuleFile *);
+
 namespace serialization {
 
 class XRefTracePath {
@@ -310,6 +315,20 @@ public:
 
   std::error_code convertToErrorCode() const override {
     return llvm::inconvertibleErrorCode();
+  }
+};
+
+class PrettyStackTraceModuleFile : public llvm::PrettyStackTraceEntry {
+  const char *Action;
+  const ModuleFile &MF;
+public:
+  explicit PrettyStackTraceModuleFile(const char *action, ModuleFile &module)
+      : Action(action), MF(module) {}
+  explicit PrettyStackTraceModuleFile(ModuleFile &module)
+      : PrettyStackTraceModuleFile("While reading from", module) {}
+
+  void print(raw_ostream &os) const override {
+    os << Action << " \'" << getNameOfModule(&MF) << "'\n";
   }
 };
 

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -27,7 +27,6 @@
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/OnDiskHashTable.h"
-#include "llvm/Support/PrettyStackTrace.h"
 
 using namespace swift;
 using namespace swift::serialization;
@@ -296,19 +295,6 @@ std::string ModuleFile::Dependency::getPrettyPrintedPath() const {
   std::replace(output.begin(), output.end(), '\0', '.');
   return output;
 }
-
-namespace {
-  class PrettyModuleFileDeserialization : public llvm::PrettyStackTraceEntry {
-    const ModuleFile &File;
-  public:
-    explicit PrettyModuleFileDeserialization(const ModuleFile &file)
-        : File(file) {}
-
-    void print(raw_ostream &os) const override {
-      os << "While reading from " << File.getModuleFilename() << "\n";
-    }
-  };
-} // end anonymous namespace
 
 /// Used to deserialize entries in the on-disk decl hash table.
 class ModuleFile::DeclTableInfo {
@@ -918,7 +904,7 @@ ModuleFile::ModuleFile(
   assert(getStatus() == Status::Valid);
   Bits.IsFramework = isFramework;
 
-  PrettyModuleFileDeserialization stackEntry(*this);
+  PrettyStackTraceModuleFile stackEntry(*this);
 
   llvm::BitstreamCursor cursor{ModuleInputBuffer->getMemBufferRef()};
 
@@ -1188,7 +1174,7 @@ ModuleFile::ModuleFile(
 
 Status ModuleFile::associateWithFileContext(FileUnit *file,
                                             SourceLoc diagLoc) {
-  PrettyModuleFileDeserialization stackEntry(*this);
+  PrettyStackTraceModuleFile stackEntry(*this);
 
   assert(getStatus() == Status::Valid && "invalid module file");
   assert(!FileContext && "already associated with an AST module");
@@ -1303,7 +1289,7 @@ ModuleFile::~ModuleFile() { }
 
 void ModuleFile::lookupValue(DeclName name,
                              SmallVectorImpl<ValueDecl*> &results) {
-  PrettyModuleFileDeserialization stackEntry(*this);
+  PrettyStackTraceModuleFile stackEntry(*this);
 
   if (TopLevelDecls) {
     // Find top-level declarations with the given name.
@@ -1347,7 +1333,7 @@ void ModuleFile::lookupValue(DeclName name,
 }
 
 TypeDecl *ModuleFile::lookupLocalType(StringRef MangledName) {
-  PrettyModuleFileDeserialization stackEntry(*this);
+  PrettyStackTraceModuleFile stackEntry(*this);
 
   if (!LocalTypeDecls)
     return nullptr;
@@ -1361,7 +1347,7 @@ TypeDecl *ModuleFile::lookupLocalType(StringRef MangledName) {
 
 TypeDecl *ModuleFile::lookupNestedType(Identifier name,
                                        const ValueDecl *parent) {
-  PrettyModuleFileDeserialization stackEntry(*this);
+  PrettyStackTraceModuleFile stackEntry(*this);
 
   if (!NestedTypeDecls)
     return nullptr;
@@ -1387,7 +1373,7 @@ TypeDecl *ModuleFile::lookupNestedType(Identifier name,
 }
 
 OperatorDecl *ModuleFile::lookupOperator(Identifier name, DeclKind fixity) {
-  PrettyModuleFileDeserialization stackEntry(*this);
+  PrettyStackTraceModuleFile stackEntry(*this);
 
   if (!OperatorDecls)
     return nullptr;
@@ -1407,7 +1393,7 @@ OperatorDecl *ModuleFile::lookupOperator(Identifier name, DeclKind fixity) {
 }
 
 PrecedenceGroupDecl *ModuleFile::lookupPrecedenceGroup(Identifier name) {
-  PrettyModuleFileDeserialization stackEntry(*this);
+  PrettyStackTraceModuleFile stackEntry(*this);
 
   if (!PrecedenceGroupDecls)
     return nullptr;
@@ -1424,7 +1410,7 @@ PrecedenceGroupDecl *ModuleFile::lookupPrecedenceGroup(Identifier name) {
 void ModuleFile::getImportedModules(
     SmallVectorImpl<ModuleDecl::ImportedModule> &results,
     ModuleDecl::ImportFilter filter) {
-  PrettyModuleFileDeserialization stackEntry(*this);
+  PrettyStackTraceModuleFile stackEntry(*this);
 
   for (auto &dep : Dependencies) {
     if (filter != ModuleDecl::ImportFilter::All &&
@@ -1506,7 +1492,7 @@ void ModuleFile::getImportDecls(SmallVectorImpl<Decl *> &Results) {
 void ModuleFile::lookupVisibleDecls(ModuleDecl::AccessPathTy accessPath,
                                     VisibleDeclConsumer &consumer,
                                     NLKind lookupKind) {
-  PrettyModuleFileDeserialization stackEntry(*this);
+  PrettyStackTraceModuleFile stackEntry(*this);
   assert(accessPath.size() <= 1 && "can only refer to top-level decls");
 
   if (!TopLevelDecls)
@@ -1542,7 +1528,7 @@ void ModuleFile::lookupVisibleDecls(ModuleDecl::AccessPathTy accessPath,
 }
 
 void ModuleFile::loadExtensions(NominalTypeDecl *nominal) {
-  PrettyModuleFileDeserialization stackEntry(*this);
+  PrettyStackTraceModuleFile stackEntry(*this);
   if (!ExtensionDecls)
     return;
 
@@ -1609,7 +1595,7 @@ void ModuleFile::loadObjCMethods(
 void ModuleFile::lookupClassMember(ModuleDecl::AccessPathTy accessPath,
                                    DeclName name,
                                    SmallVectorImpl<ValueDecl*> &results) {
-  PrettyModuleFileDeserialization stackEntry(*this);
+  PrettyStackTraceModuleFile stackEntry(*this);
   assert(accessPath.size() <= 1 && "can only refer to top-level decls");
 
   if (!ClassMembersByName)
@@ -1658,7 +1644,7 @@ void ModuleFile::lookupClassMember(ModuleDecl::AccessPathTy accessPath,
 
 void ModuleFile::lookupClassMembers(ModuleDecl::AccessPathTy accessPath,
                                     VisibleDeclConsumer &consumer) {
-  PrettyModuleFileDeserialization stackEntry(*this);
+  PrettyStackTraceModuleFile stackEntry(*this);
   assert(accessPath.size() <= 1 && "can only refer to top-level decls");
 
   if (!ClassMembersByName)
@@ -1714,7 +1700,7 @@ ModuleFile::collectLinkLibraries(ModuleDecl::LinkLibraryCallback callback) const
 }
 
 void ModuleFile::getTopLevelDecls(SmallVectorImpl<Decl *> &results) {
-  PrettyModuleFileDeserialization stackEntry(*this);
+  PrettyStackTraceModuleFile stackEntry(*this);
   if (PrecedenceGroupDecls) {
     for (auto entry : PrecedenceGroupDecls->data()) {
       for (auto item : entry)
@@ -1754,7 +1740,7 @@ void ModuleFile::getTopLevelDecls(SmallVectorImpl<Decl *> &results) {
 
 void
 ModuleFile::getLocalTypeDecls(SmallVectorImpl<TypeDecl *> &results) {
-  PrettyModuleFileDeserialization stackEntry(*this);
+  PrettyStackTraceModuleFile stackEntry(*this);
   if (!LocalTypeDecls)
     return;
 
@@ -1770,7 +1756,7 @@ void ModuleFile::getDisplayDecls(SmallVectorImpl<Decl *> &results) {
   if (ShadowedModule)
     ShadowedModule->getDisplayDecls(results);
 
-  PrettyModuleFileDeserialization stackEntry(*this);
+  PrettyStackTraceModuleFile stackEntry(*this);
   getImportDecls(results);
   getTopLevelDecls(results);
 }

--- a/test/SourceKit/DocSupport/doc_clang_module.swift.response
+++ b/test/SourceKit/DocSupport/doc_clang_module.swift.response
@@ -209,13 +209,13 @@ class FooClassBase {
 
     class func fooBaseClassFunc0()
 
-    func _internalMeth3() -> Any!
+    func _internalMeth1() -> Any!
 
     func _internalMeth2() -> Any!
 
     func nonInternalMeth() -> Any!
 
-    func _internalMeth1() -> Any!
+    func _internalMeth3() -> Any!
 }
 class FooClassDerived : FooClassBase, FooProtocolDerived {
 
@@ -235,13 +235,13 @@ class FooClassDerived : FooClassBase, FooProtocolDerived {
 
     class func fooClassFunc0()
 
-    func _internalMeth3() -> Any!
+    func _internalMeth1() -> Any!
 
     func _internalMeth2() -> Any!
 
     func nonInternalMeth() -> Any!
 
-    func _internalMeth1() -> Any!
+    func _internalMeth3() -> Any!
 }
 typealias typedef_int_t = Int32
 var FOO_MACRO_1: Int32 { get }
@@ -301,13 +301,13 @@ class FooClassPropertyOwnership : FooClassBase {
 
     var scalar: Int32
 
-    func _internalMeth3() -> Any!
+    func _internalMeth1() -> Any!
 
     func _internalMeth2() -> Any!
 
     func nonInternalMeth() -> Any!
 
-    func _internalMeth1() -> Any!
+    func _internalMeth3() -> Any!
 }
 var FOO_NIL: ()
 class FooUnavailableMembers : FooClassBase {
@@ -336,13 +336,13 @@ class FooUnavailableMembers : FooClassBase {
 
     func availabilityUnavailableMsg()
 
-    func _internalMeth3() -> Any!
+    func _internalMeth1() -> Any!
 
     func _internalMeth2() -> Any!
 
     func nonInternalMeth() -> Any!
 
-    func _internalMeth1() -> Any!
+    func _internalMeth3() -> Any!
 }
 class FooCFType {
 }
@@ -7041,11 +7041,11 @@ var FooSubUnnamedEnumeratorA1: Int { get }
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
-        key.name: "_internalMeth3()",
-        key.usr: "c:objc(cs)FooClassBase(im)_internalMeth3",
+        key.name: "_internalMeth1()",
+        key.usr: "c:objc(cs)FooClassBase(im)_internalMeth1",
         key.offset: 5048,
         key.length: 29,
-        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth3</decl.name>() -&gt; <decl.function.returntype>Any!</decl.function.returntype></decl.function.method.instance>"
+        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth1</decl.name>() -&gt; <decl.function.returntype>Any!</decl.function.returntype></decl.function.method.instance>"
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
@@ -7065,11 +7065,11 @@ var FooSubUnnamedEnumeratorA1: Int { get }
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
-        key.name: "_internalMeth1()",
-        key.usr: "c:objc(cs)FooClassBase(im)_internalMeth1",
+        key.name: "_internalMeth3()",
+        key.usr: "c:objc(cs)FooClassBase(im)_internalMeth3",
         key.offset: 5154,
         key.length: 29,
-        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth1</decl.name>() -&gt; <decl.function.returntype>Any!</decl.function.returntype></decl.function.method.instance>"
+        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth3</decl.name>() -&gt; <decl.function.returntype>Any!</decl.function.returntype></decl.function.method.instance>"
       }
     ]
   },
@@ -7194,12 +7194,12 @@ var FooSubUnnamedEnumeratorA1: Int { get }
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
-        key.name: "_internalMeth3()",
-        key.usr: "c:objc(cs)FooClassBase(im)_internalMeth3::SYNTHESIZED::c:objc(cs)FooClassDerived",
-        key.original_usr: "c:objc(cs)FooClassBase(im)_internalMeth3",
+        key.name: "_internalMeth1()",
+        key.usr: "c:objc(cs)FooClassBase(im)_internalMeth1::SYNTHESIZED::c:objc(cs)FooClassDerived",
+        key.original_usr: "c:objc(cs)FooClassBase(im)_internalMeth1",
         key.offset: 5542,
         key.length: 29,
-        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth3</decl.name>() -&gt; <decl.function.returntype>Any!</decl.function.returntype></decl.function.method.instance>"
+        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth1</decl.name>() -&gt; <decl.function.returntype>Any!</decl.function.returntype></decl.function.method.instance>"
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
@@ -7221,12 +7221,12 @@ var FooSubUnnamedEnumeratorA1: Int { get }
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
-        key.name: "_internalMeth1()",
-        key.usr: "c:objc(cs)FooClassBase(im)_internalMeth1::SYNTHESIZED::c:objc(cs)FooClassDerived",
-        key.original_usr: "c:objc(cs)FooClassBase(im)_internalMeth1",
+        key.name: "_internalMeth3()",
+        key.usr: "c:objc(cs)FooClassBase(im)_internalMeth3::SYNTHESIZED::c:objc(cs)FooClassDerived",
+        key.original_usr: "c:objc(cs)FooClassBase(im)_internalMeth3",
         key.offset: 5648,
         key.length: 29,
-        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth1</decl.name>() -&gt; <decl.function.returntype>Any!</decl.function.returntype></decl.function.method.instance>"
+        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth3</decl.name>() -&gt; <decl.function.returntype>Any!</decl.function.returntype></decl.function.method.instance>"
       }
     ]
   },
@@ -7582,12 +7582,12 @@ var FooSubUnnamedEnumeratorA1: Int { get }
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
-        key.name: "_internalMeth3()",
-        key.usr: "c:objc(cs)FooClassBase(im)_internalMeth3::SYNTHESIZED::c:objc(cs)FooClassPropertyOwnership",
-        key.original_usr: "c:objc(cs)FooClassBase(im)_internalMeth3",
+        key.name: "_internalMeth1()",
+        key.usr: "c:objc(cs)FooClassBase(im)_internalMeth1::SYNTHESIZED::c:objc(cs)FooClassPropertyOwnership",
+        key.original_usr: "c:objc(cs)FooClassBase(im)_internalMeth1",
         key.offset: 6861,
         key.length: 29,
-        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth3</decl.name>() -&gt; <decl.function.returntype>Any!</decl.function.returntype></decl.function.method.instance>"
+        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth1</decl.name>() -&gt; <decl.function.returntype>Any!</decl.function.returntype></decl.function.method.instance>"
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
@@ -7609,12 +7609,12 @@ var FooSubUnnamedEnumeratorA1: Int { get }
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
-        key.name: "_internalMeth1()",
-        key.usr: "c:objc(cs)FooClassBase(im)_internalMeth1::SYNTHESIZED::c:objc(cs)FooClassPropertyOwnership",
-        key.original_usr: "c:objc(cs)FooClassBase(im)_internalMeth1",
+        key.name: "_internalMeth3()",
+        key.usr: "c:objc(cs)FooClassBase(im)_internalMeth3::SYNTHESIZED::c:objc(cs)FooClassPropertyOwnership",
+        key.original_usr: "c:objc(cs)FooClassBase(im)_internalMeth3",
         key.offset: 6967,
         key.length: 29,
-        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth1</decl.name>() -&gt; <decl.function.returntype>Any!</decl.function.returntype></decl.function.method.instance>"
+        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth3</decl.name>() -&gt; <decl.function.returntype>Any!</decl.function.returntype></decl.function.method.instance>"
       }
     ]
   },
@@ -7850,12 +7850,12 @@ var FooSubUnnamedEnumeratorA1: Int { get }
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
-        key.name: "_internalMeth3()",
-        key.usr: "c:objc(cs)FooClassBase(im)_internalMeth3::SYNTHESIZED::c:objc(cs)FooUnavailableMembers",
-        key.original_usr: "c:objc(cs)FooClassBase(im)_internalMeth3",
+        key.name: "_internalMeth1()",
+        key.usr: "c:objc(cs)FooClassBase(im)_internalMeth1::SYNTHESIZED::c:objc(cs)FooUnavailableMembers",
+        key.original_usr: "c:objc(cs)FooClassBase(im)_internalMeth1",
         key.offset: 7470,
         key.length: 29,
-        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth3</decl.name>() -&gt; <decl.function.returntype>Any!</decl.function.returntype></decl.function.method.instance>"
+        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth1</decl.name>() -&gt; <decl.function.returntype>Any!</decl.function.returntype></decl.function.method.instance>"
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
@@ -7877,12 +7877,12 @@ var FooSubUnnamedEnumeratorA1: Int { get }
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
-        key.name: "_internalMeth1()",
-        key.usr: "c:objc(cs)FooClassBase(im)_internalMeth1::SYNTHESIZED::c:objc(cs)FooUnavailableMembers",
-        key.original_usr: "c:objc(cs)FooClassBase(im)_internalMeth1",
+        key.name: "_internalMeth3()",
+        key.usr: "c:objc(cs)FooClassBase(im)_internalMeth3::SYNTHESIZED::c:objc(cs)FooUnavailableMembers",
+        key.original_usr: "c:objc(cs)FooClassBase(im)_internalMeth3",
         key.offset: 7576,
         key.length: 29,
-        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth1</decl.name>() -&gt; <decl.function.returntype>Any!</decl.function.returntype></decl.function.method.instance>"
+        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth3</decl.name>() -&gt; <decl.function.returntype>Any!</decl.function.returntype></decl.function.method.instance>"
       }
     ]
   },

--- a/validation-test/compiler_crashers_2_fixed/Inputs/sr5330/ObjCPart.h
+++ b/validation-test/compiler_crashers_2_fixed/Inputs/sr5330/ObjCPart.h
@@ -1,0 +1,6 @@
+@interface Base
+@end
+
+@interface MyCollection: Base
+- (id)objectAtIndex:(long)index;
+@end

--- a/validation-test/compiler_crashers_2_fixed/Inputs/sr5330/module.modulemap
+++ b/validation-test/compiler_crashers_2_fixed/Inputs/sr5330/module.modulemap
@@ -1,0 +1,3 @@
+module ObjCPart {
+  header "ObjCPart.h"
+}

--- a/validation-test/compiler_crashers_2_fixed/sr5330.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr5330.swift
@@ -1,0 +1,27 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -o %t %s -I %S/Inputs/sr5330/ -module-name TEST
+// RUN: echo 'import TEST; x' | not %target-swift-frontend -typecheck - -I %S/Inputs/sr5330/ -I %t
+
+// REQUIRES: objc_interop
+
+import ObjCPart
+
+public typealias Alias = MyCollection
+
+extension Alias: Collection {
+    public subscript(index: Int) -> Any {
+        return object(at: index)
+    }
+
+    public func index(after i: Int) -> Int {
+        return i + 1
+    }
+
+    public var startIndex: Int {
+        return 0
+    }
+
+    public var endIndex: Int {
+        return count
+    }
+}


### PR DESCRIPTION
- Deinitializers never get a custom Objective-C name.
- Classes and protocols are never bridged themselves; that only matters for structs and enums.

This avoids another circularity issue like the one in #10707, where the Clang importer ends up importing a class and hands it to the type checker, which then asks about conformances. The conformance lookup table goes to add the extension from the Swift module, except that the Swift module is what asked for the import in the first place.

It's possible there's a more general solution here, but this particular change is good even in the non-crashy cases, and definitely safe for Swift 4.0. Even if the test case is even more idiosyncratic than the last one.

[SR-5330](https://bugs.swift.org/browse/SR-5330) / rdar://problem/32677610