### PR TITLE
[QoI] Don't assume that contextual type is always present for trailing closure diagnostics

### DIFF
--- a/validation-test/compiler_crashers_2_fixed/0111-rdar33067102.swift
+++ b/validation-test/compiler_crashers_2_fixed/0111-rdar33067102.swift
@@ -1,0 +1,5 @@
+// RUN: not %target-swift-frontend -swift-version 4 %s -typecheck
+
+func flatterMap(_ records: [(Int)]) -> [Int] {
+  records.flatMap { _ in return 1 } // expected-note {{}}
+}


### PR DESCRIPTION
Fixes crasher in diagnostics related to the fact that contextual type
is not always available when trying to diagnose problems related to
calls with trailing closures.

Resolves: rdar://problem/33067102

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
