### PR TITLE
[4.0] [QoI] Don't assume that contextual type is always present for trailing closure diagnostics

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -6159,28 +6159,30 @@ bool FailureDiagnosis::diagnoseTrailingClosureErrors(ApplyExpr *callExpr) {
       if (!fnType)
         return false;
 
-      auto expectedArgType = FunctionType::get(fnType->getInput(), resultType,
-                                               fnType->getExtInfo());
-
-      auto expectedType =
-          FunctionType::get(expectedArgType, CS->getContextualType());
-
       class ClosureCalleeListener : public ExprTypeCheckListener {
-        Type contextualType;
+        Type InputType;
+        Type ResultType;
 
       public:
-        explicit ClosureCalleeListener(Type contextualType)
-            : contextualType(contextualType) {}
+        explicit ClosureCalleeListener(Type inputType, Type resultType)
+            : InputType(inputType), ResultType(resultType) {}
 
         bool builtConstraints(ConstraintSystem &cs, Expr *expr) override {
+          if (!InputType || !ResultType)
+            return false;
+
+          auto expectedType = FunctionType::get(InputType, ResultType);
           cs.addConstraint(ConstraintKind::Conversion, cs.getType(expr),
-                           contextualType, cs.getConstraintLocator(expr),
+                           expectedType, cs.getConstraintLocator(expr),
                            /*isFavored*/ true);
           return false;
         }
       };
 
-      ClosureCalleeListener listener(expectedType);
+      auto expectedArgType = FunctionType::get(fnType->getInput(), resultType,
+                                               fnType->getExtInfo());
+
+      ClosureCalleeListener listener(expectedArgType, CS->getContextualType());
       return !typeCheckChildIndependently(callExpr->getFn(), Type(),
                                           CTP_CalleeResult, TCC_ForceRecheck,
                                           &listener);

--- a/validation-test/compiler_crashers_2_fixed/0111-rdar33067102.swift
+++ b/validation-test/compiler_crashers_2_fixed/0111-rdar33067102.swift
@@ -1,0 +1,5 @@
+// RUN: not %target-swift-frontend -swift-version 4 %s -typecheck
+
+func flatterMap(_ records: [(Int)]) -> [Int] {
+  records.flatMap { _ in return 1 } // expected-note {{}}
+}


### PR DESCRIPTION
* Description: Fixes crasher in diagnostics related to the fact that contextual type
is not always available when trying to diagnose problems related to
calls with trailing closures.

* Scope of the issue: fixes crasher in diagnostics related to calls with trailing closures.

* Risk: Low.

* Tested: New test cases added, Swift CI.

* Reviewed by: Mark Lacey.

* Resolves: rdar://problem/33067102

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
