### PR TITLE
Make coding paths non-optional [DO NOT MERGE]

### DIFF
--- a/stdlib/public/SDK/Foundation/Codable.swift
+++ b/stdlib/public/SDK/Foundation/Codable.swift
@@ -29,7 +29,7 @@ internal extension DecodingError {
     /// - parameter expectation: The type expected to be encountered.
     /// - parameter reality: The value that was encountered instead of the expected type.
     /// - returns: A `DecodingError` with the appropriate path and debug description.
-    internal static func _typeMismatch(at path: [CodingKey?], expectation: Any.Type, reality: Any) -> DecodingError {
+    internal static func _typeMismatch(at path: [CodingKey], expectation: Any.Type, reality: Any) -> DecodingError {
         let description = "Expected to decode \(expectation) but found \(_typeDescription(of: reality)) instead."
         return .typeMismatch(expectation, Context(codingPath: path, debugDescription: description))
     }

--- a/stdlib/public/core/Codable.swift
+++ b/stdlib/public/core/Codable.swift
@@ -75,7 +75,7 @@ public protocol CodingKey {
 public protocol Encoder {
     /// The path of coding keys taken to get to this point in encoding.
     /// A `nil` value indicates an unkeyed container.
-    var codingPath: [CodingKey?] { get }
+    var codingPath: [CodingKey] { get }
 
     /// Any contextual information set by the user for encoding.
     var userInfo: [CodingUserInfoKey : Any] { get }
@@ -108,7 +108,7 @@ public protocol Encoder {
 public protocol Decoder {
     /// The path of coding keys taken to get to this point in decoding.
     /// A `nil` value indicates an unkeyed container.
-    var codingPath: [CodingKey?] { get }
+    var codingPath: [CodingKey] { get }
 
     /// Any contextual information set by the user for decoding.
     var userInfo: [CodingUserInfoKey : Any] { get }
@@ -147,7 +147,7 @@ public protocol KeyedEncodingContainerProtocol {
 
     /// The path of coding keys taken to get to this point in encoding.
     /// A `nil` value indicates an unkeyed container.
-    var codingPath: [CodingKey?] { get }
+    var codingPath: [CodingKey] { get }
 
     /// Encodes a null value for the given key.
     ///
@@ -423,7 +423,7 @@ public struct KeyedEncodingContainer<K : CodingKey> : KeyedEncodingContainerProt
 
     /// The path of coding keys taken to get to this point in encoding.
     /// A `nil` value indicates an unkeyed container.
-    public var codingPath: [CodingKey?] {
+    public var codingPath: [CodingKey] {
         return _box.codingPath
     }
 
@@ -761,7 +761,7 @@ public protocol KeyedDecodingContainerProtocol {
 
     /// The path of coding keys taken to get to this point in decoding.
     /// A `nil` value indicates an unkeyed container.
-    var codingPath: [CodingKey?] { get }
+    var codingPath: [CodingKey] { get }
 
     /// All the keys the `Decoder` has for this container.
     ///
@@ -1136,7 +1136,7 @@ public struct KeyedDecodingContainer<K : CodingKey> : KeyedDecodingContainerProt
 
     /// The path of coding keys taken to get to this point in decoding.
     /// A `nil` value indicates an unkeyed container.
-    public var codingPath: [CodingKey?] {
+    public var codingPath: [CodingKey] {
         return _box.codingPath
     }
 
@@ -1578,7 +1578,10 @@ public struct KeyedDecodingContainer<K : CodingKey> : KeyedDecodingContainerProt
 public protocol UnkeyedEncodingContainer {
     /// The path of coding keys taken to get to this point in encoding.
     /// A `nil` value indicates an unkeyed container.
-    var codingPath: [CodingKey?] { get }
+    var codingPath: [CodingKey] { get }
+
+    /// The number of elements encoded into the container.
+    var count: Int { get }
 
     /// Encodes a null value.
     ///
@@ -1800,7 +1803,7 @@ public protocol UnkeyedEncodingContainer {
 public protocol UnkeyedDecodingContainer {
     /// The path of coding keys taken to get to this point in decoding.
     /// A `nil` value indicates an unkeyed container.
-    var codingPath: [CodingKey?] { get }
+    var codingPath: [CodingKey] { get }
 
     /// Returns the number of elements (if known) contained within this container.
     var count: Int? { get }
@@ -1808,7 +1811,13 @@ public protocol UnkeyedDecodingContainer {
     /// Returns whether there are no more elements left to be decoded in the container.
     var isAtEnd: Bool { get }
 
+    /// The current decoding index of the container (i.e. the index of the next element to be decoded.)
+    /// Incremented after every successful decode call.
+    var currentIndex: Int { get }
+
     /// Decodes a null value.
+    ///
+    /// If the value is not null, does not increment currentIndex.
     ///
     /// - returns: Whether the encountered value was null.
     /// - throws: `DecodingError.valueNotFound` if there are no more values to decode.
@@ -2098,7 +2107,7 @@ public protocol UnkeyedDecodingContainer {
 public protocol SingleValueEncodingContainer {
     /// The path of coding keys taken to get to this point in encoding.
     /// A `nil` value indicates an unkeyed container.
-    var codingPath: [CodingKey?] { get }
+    var codingPath: [CodingKey] { get }
 
     /// Encodes a null value.
     ///
@@ -2216,7 +2225,7 @@ public protocol SingleValueEncodingContainer {
 public protocol SingleValueDecodingContainer {
     /// The path of coding keys taken to get to this point in encoding.
     /// A `nil` value indicates an unkeyed container.
-    var codingPath: [CodingKey?] { get }
+    var codingPath: [CodingKey] { get }
 
     /// Decodes a null value.
     ///
@@ -2385,7 +2394,7 @@ public enum EncodingError : Error {
     /// The context in which the error occurred.
     public struct Context {
         /// The path of `CodingKey`s taken to get to the point of the failing encode call.
-        public let codingPath: [CodingKey?]
+        public let codingPath: [CodingKey]
 
         /// A description of what went wrong, for debugging purposes.
         public let debugDescription: String
@@ -2398,7 +2407,7 @@ public enum EncodingError : Error {
         /// - parameter codingPath: The path of `CodingKey`s taken to get to the point of the failing encode call.
         /// - parameter debugDescription: A description of what went wrong, for debugging purposes.
         /// - parameter underlyingError: The underlying error which caused this error, if any.
-        public init(codingPath: [CodingKey?], debugDescription: String, underlyingError: Error? = nil) {
+        public init(codingPath: [CodingKey], debugDescription: String, underlyingError: Error? = nil) {
             self.codingPath = codingPath
             self.debugDescription = debugDescription
             self.underlyingError = underlyingError
@@ -2454,7 +2463,7 @@ public enum DecodingError : Error {
     /// The context in which the error occurred.
     public struct Context {
         /// The path of `CodingKey`s taken to get to the point of the failing decode call.
-        public let codingPath: [CodingKey?]
+        public let codingPath: [CodingKey]
 
         /// A description of what went wrong, for debugging purposes.
         public let debugDescription: String
@@ -2467,7 +2476,7 @@ public enum DecodingError : Error {
         /// - parameter codingPath: The path of `CodingKey`s taken to get to the point of the failing decode call.
         /// - parameter debugDescription: A description of what went wrong, for debugging purposes.
         /// - parameter underlyingError: The underlying error which caused this error, if any.
-        public init(codingPath: [CodingKey?], debugDescription: String, underlyingError: Error? = nil) {
+        public init(codingPath: [CodingKey], debugDescription: String, underlyingError: Error? = nil) {
             self.codingPath = codingPath
             self.debugDescription = debugDescription
             self.underlyingError = underlyingError
@@ -2541,6 +2550,20 @@ public enum DecodingError : Error {
 
 // The following extensions allow for easier error construction.
 
+internal struct _GenericIndexKey : CodingKey {
+    var stringValue: String
+    var intValue: Int?
+
+    init?(stringValue: String) {
+        return nil
+    }
+
+    init?(intValue: Int) {
+        self.stringValue = "Index \(intValue)"
+        self.intValue = intValue
+    }
+}
+
 public extension DecodingError {
     /// A convenience method which creates a new .dataCorrupted error using a constructed coding path and the given debug description.
     ///
@@ -2562,7 +2585,7 @@ public extension DecodingError {
     /// - param container: The container in which the corrupted data was accessed.
     /// - param debugDescription: A description of the error to aid in debugging.
     static func dataCorruptedError(in container: UnkeyedDecodingContainer, debugDescription: String) -> DecodingError {
-        let context = DecodingError.Context(codingPath: container.codingPath + [nil],
+        let context = DecodingError.Context(codingPath: container.codingPath + [_GenericIndexKey(intValue: container.currentIndex)!],
                                             debugDescription: debugDescription)
         return .dataCorrupted(context)
     }
@@ -2590,7 +2613,7 @@ internal class _KeyedEncodingContainerBase<Key : CodingKey> {
     // These must all be given a concrete implementation in _*Box.
     @_inlineable
     @_versioned
-    internal var codingPath: [CodingKey?] {
+    internal var codingPath: [CodingKey] {
         fatalError("_KeyedEncodingContainerBase cannot be used directly.")
     }
 
@@ -2827,7 +2850,7 @@ internal final class _KeyedEncodingContainerBox<Concrete : KeyedEncodingContaine
 
     @_inlineable
     @_versioned
-    override internal var codingPath: [CodingKey?] {
+    override internal var codingPath: [CodingKey] {
         return concrete.codingPath
     }
 
@@ -3053,7 +3076,7 @@ internal final class _KeyedEncodingContainerBox<Concrete : KeyedEncodingContaine
 internal class _KeyedDecodingContainerBase<Key : CodingKey> {
     @_inlineable
     @_versioned
-    internal var codingPath: [CodingKey?] {
+    internal var codingPath: [CodingKey] {
         fatalError("_KeyedDecodingContainerBase cannot be used directly.")
     }
 
@@ -3296,7 +3319,7 @@ internal final class _KeyedDecodingContainerBox<Concrete : KeyedDecodingContaine
 
     @_inlineable
     @_versioned
-    override var codingPath: [CodingKey?] {
+    override var codingPath: [CodingKey] {
         return concrete.codingPath
     }
 

--- a/test/stdlib/TestPlistEncoder.swift
+++ b/test/stdlib/TestPlistEncoder.swift
@@ -192,27 +192,13 @@ class TestPropertyListEncoder : TestPropertyListEncoderSuper {
 }
 
 // MARK: - Helper Global Functions
-func expectEqualPaths(_ lhs: [CodingKey?], _ rhs: [CodingKey?], _ prefix: String) {
+func expectEqualPaths(_ lhs: [CodingKey], _ rhs: [CodingKey], _ prefix: String) {
   if lhs.count != rhs.count {
-    expectUnreachable("\(prefix) [CodingKey?].count mismatch: \(lhs.count) != \(rhs.count)")
+    expectUnreachable("\(prefix) [CodingKey].count mismatch: \(lhs.count) != \(rhs.count)")
     return
   }
 
-  for (k1, k2) in zip(lhs, rhs) {
-    switch (k1, k2) {
-    case (.none, .none): continue
-    case (.some(let _k1), .none):
-      expectUnreachable("\(prefix) CodingKey mismatch: \(type(of: _k1)) != nil")
-      return
-    case (.none, .some(let _k2)):
-      expectUnreachable("\(prefix) CodingKey mismatch: nil != \(type(of: _k2))")
-      return
-    default: break
-    }
-
-    let key1 = k1!
-    let key2 = k2!
-
+  for (key1, key2) in zip(lhs, rhs) {
     switch (key1.intValue, key2.intValue) {
     case (.none, .none): break
     case (.some(let i1), .none):
@@ -572,7 +558,7 @@ struct NestedContainersTestType : Encodable {
     }
   }
 
-  func _testNestedContainers(in encoder: Encoder, baseCodingPath: [CodingKey?]) {
+  func _testNestedContainers(in encoder: Encoder, baseCodingPath: [CodingKey]) {
     expectEqualPaths(encoder.codingPath, baseCodingPath, "New encoder has non-empty codingPath.")
 
     // codingPath should not change upon fetching a non-nested container.
@@ -606,29 +592,51 @@ struct NestedContainersTestType : Encodable {
     // Nested Unkeyed Container
     do {
       // Nested container for key should have a new key pushed on.
-      var secondLevelContainer = firstLevelContainer.nestedUnkeyedContainer(forKey: .a)
+      var secondLevelContainer = firstLevelContainer.nestedUnkeyedContainer(forKey: .b)
       expectEqualPaths(encoder.codingPath, baseCodingPath, "Top-level Encoder's codingPath changed.")
       expectEqualPaths(firstLevelContainer.codingPath, baseCodingPath, "First-level keyed container's codingPath changed.")
-      expectEqualPaths(secondLevelContainer.codingPath, baseCodingPath + [TopLevelCodingKeys.a], "New second-level keyed container had unexpected codingPath.")
+      expectEqualPaths(secondLevelContainer.codingPath, baseCodingPath + [TopLevelCodingKeys.b], "New second-level keyed container had unexpected codingPath.")
 
       // Appending a keyed container should not change existing coding paths.
       let thirdLevelContainerKeyed = secondLevelContainer.nestedContainer(keyedBy: IntermediateCodingKeys.self)
       expectEqualPaths(encoder.codingPath, baseCodingPath, "Top-level Encoder's codingPath changed.")
       expectEqualPaths(firstLevelContainer.codingPath, baseCodingPath, "First-level keyed container's codingPath changed.")
-      expectEqualPaths(secondLevelContainer.codingPath, baseCodingPath + [TopLevelCodingKeys.a], "Second-level unkeyed container's codingPath changed.")
-      expectEqualPaths(thirdLevelContainerKeyed.codingPath, baseCodingPath + [TopLevelCodingKeys.a, nil], "New third-level keyed container had unexpected codingPath.")
+      expectEqualPaths(secondLevelContainer.codingPath, baseCodingPath + [TopLevelCodingKeys.b], "Second-level unkeyed container's codingPath changed.")
+      expectEqualPaths(thirdLevelContainerKeyed.codingPath, baseCodingPath + [TopLevelCodingKeys.b, _TestKey(index: 0)], "New third-level keyed container had unexpected codingPath.")
 
       // Appending an unkeyed container should not change existing coding paths.
       let thirdLevelContainerUnkeyed = secondLevelContainer.nestedUnkeyedContainer()
       expectEqualPaths(encoder.codingPath, baseCodingPath, "Top-level Encoder's codingPath changed.")
       expectEqualPaths(firstLevelContainer.codingPath, baseCodingPath, "First-level keyed container's codingPath changed.")
-      expectEqualPaths(secondLevelContainer.codingPath, baseCodingPath + [TopLevelCodingKeys.a], "Second-level unkeyed container's codingPath changed.")
-      expectEqualPaths(thirdLevelContainerUnkeyed.codingPath, baseCodingPath + [TopLevelCodingKeys.a, nil], "New third-level unkeyed container had unexpected codingPath.")
+      expectEqualPaths(secondLevelContainer.codingPath, baseCodingPath + [TopLevelCodingKeys.b], "Second-level unkeyed container's codingPath changed.")
+      expectEqualPaths(thirdLevelContainerUnkeyed.codingPath, baseCodingPath + [TopLevelCodingKeys.b, _TestKey(index: 1)], "New third-level unkeyed container had unexpected codingPath.")
     }
   }
 }
 
 // MARK: - Helper Types
+
+/// A key type which can take on any string or integer value.
+/// This needs to mirror _PlistKey.
+fileprivate struct _TestKey : CodingKey {
+  var stringValue: String
+  var intValue: Int?
+
+  init?(stringValue: String) {
+    self.stringValue = stringValue
+    self.intValue = nil
+  }
+
+  init?(intValue: Int) {
+    self.stringValue = "\(intValue)"
+    self.intValue = intValue
+  }
+
+  init(index: Int) {
+    self.stringValue = "Index \(index)"
+    self.intValue = index
+  }
+}
 
 /// Wraps a type T so that it can be encoded at the top level of a payload.
 fileprivate struct TopLevelWrapper<T> : Codable, Equatable where T : Codable, T : Equatable {


### PR DESCRIPTION
**What's in this pull request?**
As laid out in a [proposed update to SE-0166 and SE-0167](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20170619/037672.html), there are changes to unkeyed containers and coding paths that we want to introduce to the Codable API. This implements the remainder of those updates which had not yet been implemented:

* For the benefit of unkeyed containers, coding paths currently contain optional `CodingKey`s — unkeyed containers are allowed to report a `nil` key in a path. However, this is unhelpful for debugging purposes, or inspecting the coding path for context, since any unkeyed container simply reports `nil`, whether it’s at index 1 or 1000

  Now all containers are required to report a non-optional CodingKey for their segment of the coding path, and coding paths are now exposed as `[CodingKey]`
* To support this, `UnkeyedEncodingContainer`s now expose their `count` and `UnkeyedDecodingContainer`s expose their `currentIndex`

**This PR should not be merged on its own.** This must be merged simultaneously with #10729 and apple/swift-corelibs-foundation#1091 to avoid breaking the build.