### PR TITLE
[sil-ownership-verifier] We can pass unowned, owned, and guaranteed callees to a call site that uses its callee as unowned.

### DIFF
--- a/lib/SIL/SILOwnershipVerifier.cpp
+++ b/lib/SIL/SILOwnershipVerifier.cpp
@@ -824,7 +824,10 @@ OwnershipUseCheckerResult OwnershipCompatibilityUseChecker::visitCallee(
   case ParameterConvention::Indirect_InoutAliasable:
     llvm_unreachable("Illegal convention for callee");
   case ParameterConvention::Direct_Unowned:
-    return {compatibleWithOwnership(ValueOwnershipKind::Trivial), false};
+    if (isAddressOrTrivialType())
+      return {compatibleWithOwnership(ValueOwnershipKind::Trivial), false};
+    // We accept unowned, owned, and guaranteed in unowned positions.
+    return {true, false};
   case ParameterConvention::Direct_Owned:
     return {compatibleWithOwnership(ValueOwnershipKind::Owned), true};
   case ParameterConvention::Direct_Guaranteed:

--- a/test/SIL/ownership-verifier/use_verifier.sil
+++ b/test/SIL/ownership-verifier/use_verifier.sil
@@ -334,6 +334,14 @@ bb0:
   return %9999 : $()
 }
 
+sil @block_invoke_test : $@convention(thin) (@owned @convention(block) () -> ()) -> () {
+bb0(%0 : @owned $@convention(block) () -> ()):
+  apply %0() : $@convention(block) () -> ()
+  destroy_value %0 : $@convention(block) () -> ()
+  %9999 = tuple()
+  return %9999 : $()
+}
+
 //////////////////////
 // Terminator Tests //
 //////////////////////


### PR DESCRIPTION
[sil-ownership-verifier] We can pass unowned, owned, and guaranteed callees to a call site that uses its callee as unowned.

rdar://31880847
