### PR TITLE
[SourceKit] When Cursor infor resolves to the start of an expression,  we always get the outermost expression.

### DIFF
--- a/include/swift/IDE/Utils.h
+++ b/include/swift/IDE/Utils.h
@@ -188,6 +188,7 @@ class SemaLocResolver : public SourceEntityWalker {
   SourceLoc LocToResolve;
   SemaToken SemaTok;
   Type ContainerType;
+  llvm::SmallVector<Expr*, 4> TrailingExprStack;
 
 public:
   explicit SemaLocResolver(SourceFile &SrcFile) : SrcFile(SrcFile) { }
@@ -216,7 +217,6 @@ private:
                   SourceLoc Loc, bool IsRef, Type Ty = Type());
   bool tryResolve(ModuleEntity Mod, SourceLoc Loc);
   bool tryResolve(Stmt *St);
-  bool tryResolve(Expr *Exp);
   bool visitSubscriptReference(ValueDecl *D, CharSourceRange Range,
                                bool IsOpenBracket) override;
 };

--- a/lib/IDE/SwiftSourceDocInfo.cpp
+++ b/lib/IDE/SwiftSourceDocInfo.cpp
@@ -196,7 +196,7 @@ bool SemaLocResolver::walkToExprPre(Expr *E) {
 bool SemaLocResolver::walkToExprPost(Expr *E) {
   if (isDone())
     return false;
-  if (!TrailingExprStack.empty()) {
+  if (!TrailingExprStack.empty() && TrailingExprStack.back() == E) {
     // We return the outtermost expression in the token info.
     SemaTok = { TrailingExprStack.front() };
     return false;

--- a/lib/IDE/SwiftSourceDocInfo.cpp
+++ b/lib/IDE/SwiftSourceDocInfo.cpp
@@ -108,14 +108,6 @@ bool SemaLocResolver::tryResolve(Stmt *St) {
   return false;
 }
 
-bool SemaLocResolver::tryResolve(Expr *Exp) {
-  if (!Exp->isImplicit() && Exp->getStartLoc() == LocToResolve) {
-    SemaTok = { Exp };
-    return true;
-  }
-  return false;
-}
-
 bool SemaLocResolver::visitSubscriptReference(ValueDecl *D, CharSourceRange Range,
                                               bool IsOpenBracket) {
   // We should treat both open and close brackets equally
@@ -193,6 +185,10 @@ bool SemaLocResolver::walkToExprPre(Expr *E) {
         ContainerType = ME->getBase()->getType();
       }
     }
+
+    // Keep track of trailing expressions.
+    if (!E->isImplicit() && E->getStartLoc() == LocToResolve)
+      TrailingExprStack.push_back(E);
   }
   return true;
 }
@@ -200,7 +196,12 @@ bool SemaLocResolver::walkToExprPre(Expr *E) {
 bool SemaLocResolver::walkToExprPost(Expr *E) {
   if (isDone())
     return false;
-  return !tryResolve(E);
+  if (!TrailingExprStack.empty()) {
+    // We return the outtermost expression in the token info.
+    SemaTok = { TrailingExprStack.front() };
+    return false;
+  }
+  return true;
 }
 
 bool SemaLocResolver::visitCallArgName(Identifier Name, CharSourceRange Range,


### PR DESCRIPTION
The reason is that for clients, getting the offspring of an expression is
much easier that getting parents.
