### PR TITLE
[stdlib] Correct UnsafeBufferPointer._copyContents

### DIFF
--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -180,26 +180,21 @@ public struct Unsafe${Mutable}BufferPointer<Element>
     return startIndex..<endIndex
   }
 
-  /// Copies `self` into the supplied buffer.
+  /// Initializes the memory at `destination.baseAddress` with elements of `self`,
+  /// stopping when either `self` or `destination` is exhausted.
   ///
-  /// - Precondition: The memory in `self` is uninitialized. The buffer must
-  ///   contain sufficient uninitialized memory to accommodate `source.underestimatedCount`.
-  ///
-  /// - Postcondition: The `Pointee`s at `buffer[startIndex..<returned index]` are
-  ///   initialized.
+  /// - Returns: an iterator over any remaining elements of `self` and the
+  ///   number of elements initialized.
+  @inline(__always)
   public func _copyContents(
-    initializing buffer: UnsafeMutableBufferPointer<Element>
-  ) -> (Iterator,UnsafeMutableBufferPointer<Element>.Index) {
-    guard !isEmpty else { return (makeIterator(),buffer.startIndex) }
-
-    guard count <= buffer.count, let ptr = buffer.baseAddress else {
-      fatalError("Insufficient space allocated to copy buffer contents")      
-    }
-  
-    ptr.initialize(from: baseAddress!, count: self.count)
-    var it: Iterator = self.makeIterator()
-    it._position = it._end
-    return (it,buffer.index(buffer.startIndex, offsetBy: self.count))        
+    initializing destination: UnsafeMutableBufferPointer<Element>
+  ) -> (Iterator, UnsafeMutableBufferPointer<Element>.Index) {
+    guard !isEmpty && !destination.isEmpty else { return (makeIterator(), 0) }
+    let s = self.baseAddress._unsafelyUnwrappedUnchecked
+    let d = destination.baseAddress._unsafelyUnwrappedUnchecked
+    let n = Swift.min(destination.count, self.count)
+    d.initialize(from: s, count: n)
+    return (Iterator(_position: s + n, _end: _end), n)
   }
 
   /// Accesses the element at the specified position.

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -185,7 +185,6 @@ public struct Unsafe${Mutable}BufferPointer<Element>
   ///
   /// - Returns: an iterator over any remaining elements of `self` and the
   ///   number of elements initialized.
-  @inline(__always)
   public func _copyContents(
     initializing destination: UnsafeMutableBufferPointer<Element>
   ) -> (Iterator, UnsafeMutableBufferPointer<Element>.Index) {


### PR DESCRIPTION
The implementation imposed stricter requirements on its inputs than those allowed by Sequence
