### PR TITLE
[Diag] Change function diagnostics to take a DeclName parameter

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -839,9 +839,9 @@ ERROR(optional_chain_isnt_chaining,none,
 ERROR(pattern_in_expr,none,
       "%0 cannot appear in an expression", (PatternKind))
 NOTE(note_call_to_operator,none,
-     "in call to operator %0", (Identifier))
+     "in call to operator %0", (DeclName))
 NOTE(note_call_to_func,none,
-     "in call to function %0", (Identifier))
+     "in call to function %0", (DeclName))
 NOTE(note_call_to_initializer,none,
      "in call to initializer", ())
 NOTE(note_init_parameter,none,
@@ -1257,7 +1257,7 @@ NOTE(unstable_mangled_name_add_objc,none,
 // Generic types
 ERROR(unsupported_type_nested_in_generic_function,none,
       "type %0 cannot be nested in generic function %1",
-      (Identifier, Identifier))
+      (Identifier, DeclName))
 ERROR(unsupported_type_nested_in_generic_closure,none,
       "type %0 cannot be nested in closure in generic context",
       (Identifier))
@@ -3584,12 +3584,12 @@ ERROR(fixed_layout_attr_on_internal_type,
       none, "'@_fixed_layout' attribute can only be applied to '@_versioned' "
       "or public declarations, but %0 is "
       "%select{private|fileprivate|internal|%error|%error}1",
-      (DeclBaseName, Accessibility))
+      (DeclName, Accessibility))
 
 ERROR(versioned_attr_with_explicit_accessibility,
       none, "'@_versioned' attribute can only be applied to internal "
       "declarations, but %0 is %select{private|fileprivate|%error|public|open}1",
-      (DeclBaseName, Accessibility))
+      (DeclName, Accessibility))
 
 ERROR(versioned_attr_in_protocol,none,
       "'@_versioned' attribute cannot be used in protocols", ())
@@ -3644,7 +3644,7 @@ ERROR(inlineable_decl_not_public,
 //------------------------------------------------------------------------------
 
 ERROR(specialize_attr_nongeneric_trailing_where,none,
-      "trailing 'where' clause in '_specialize' attribute of non-generic function %0", (Identifier))
+      "trailing 'where' clause in '_specialize' attribute of non-generic function %0", (DeclName))
 ERROR(specialize_missing_where_clause,none,
       "missing 'where' clause in '_specialize' attribute", ())
 ERROR(specialize_empty_where_clause,none,

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -9134,7 +9134,7 @@ void FailureDiagnosis::diagnoseUnboundArchetype(ArchetypeType *archetype,
   
   auto decl = resolved.getDecl();
   if (auto FD = dyn_cast<FuncDecl>(decl)) {
-    auto name = FD->getName();
+    auto name = FD->getFullName();
     auto diagID = name.isOperator() ? diag::note_call_to_operator
                                     : diag::note_call_to_func;
     tc.diagnose(decl, diagID, name);

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1651,7 +1651,8 @@ void AttributeChecker::visitSpecializeAttr(SpecializeAttr *attr) {
   if (!genericSig) {
     // Only generic functions are permitted to have trailing where clauses.
     TC.diagnose(attr->getLocation(),
-                diag::specialize_attr_nongeneric_trailing_where, FD->getName())
+                diag::specialize_attr_nongeneric_trailing_where,
+                FD->getFullName())
         .highlight(trailingWhereClause->getSourceRange());
     return;
   }
@@ -1832,7 +1833,7 @@ void AttributeChecker::visitFixedLayoutAttr(FixedLayoutAttr *attr) {
   if (access < Accessibility::Public) {
     TC.diagnose(attr->getLocation(),
                 diag::fixed_layout_attr_on_internal_type,
-                VD->getBaseName(),
+                VD->getFullName(),
                 access)
         .fixItRemove(attr->getRangeWithAt());
     attr->setInvalid();
@@ -1856,7 +1857,7 @@ void AttributeChecker::visitVersionedAttr(VersionedAttr *attr) {
   if (VD->getFormalAccess() != Accessibility::Internal) {
     TC.diagnose(attr->getLocation(),
                 diag::versioned_attr_with_explicit_accessibility,
-                VD->getBaseName(),
+                VD->getFullName(),
                 VD->getFormalAccess())
         .fixItRemove(attr->getRangeWithAt());
     attr->setInvalid();

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4324,7 +4324,7 @@ public:
           TC.diagnose(NTD->getLoc(),
                       diag::unsupported_type_nested_in_generic_function,
                       NTD->getName(),
-                      AFD->getName());
+                      AFD->getFullName());
         } else {
           TC.diagnose(NTD->getLoc(),
                       diag::unsupported_type_nested_in_generic_closure,

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -167,7 +167,7 @@ func rdar21080030() {
 }
 
 // <rdar://problem/21248136> QoI: problem with return type inference mis-diagnosed as invalid arguments
-func r21248136<T>() -> T { preconditionFailure() } // expected-note 2 {{in call to function 'r21248136'}}
+func r21248136<T>() -> T { preconditionFailure() } // expected-note 2 {{in call to function 'r21248136()'}}
 
 r21248136()            // expected-error {{generic parameter 'T' could not be inferred}}
 let _ = r21248136()    // expected-error {{generic parameter 'T' could not be inferred}}

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -205,7 +205,7 @@ var _ : Int = R24267414.foo() // expected-error {{generic parameter 'T' could no
 
 
 // https://bugs.swift.org/browse/SR-599
-func SR599<T: FixedWidthInteger>() -> T.Type { return T.self }  // expected-note {{in call to function 'SR599'}}
+func SR599<T: FixedWidthInteger>() -> T.Type { return T.self }  // expected-note {{in call to function 'SR599()'}}
 _ = SR599()         // expected-error {{generic parameter 'T' could not be inferred}}
 
 

--- a/test/Generics/materializable_restrictions.swift
+++ b/test/Generics/materializable_restrictions.swift
@@ -15,7 +15,7 @@ func test20807269() {
 func test15921530() {
     struct X {}
 
-    func makef<T>() -> (T) -> () { // expected-note {{in call to function 'makef'}}
+    func makef<T>() -> (T) -> () { // expected-note {{in call to function 'makef()'}}
       return {
         x in ()
       }

--- a/test/Generics/unbound.swift
+++ b/test/Generics/unbound.swift
@@ -59,7 +59,7 @@ class SomeClassWithInvalidMethod {
 // <rdar://problem/20792596> QoI: Cannot invoke with argument list (T), expected an argument list of (T)
 protocol r20792596P {}
 
-// expected-note @+1 {{in call to function 'foor20792596'}}
+// expected-note @+1 {{in call to function 'foor20792596(x:)'}}
 func foor20792596<T: r20792596P>(x: T) -> T {
   return x
 }

--- a/test/attr/attr_specialize.swift
+++ b/test/attr/attr_specialize.swift
@@ -39,7 +39,7 @@ public func twoGenericParams<T, U>(_ t: T, u: U) -> (T, U) {
   return (t, u)
 }
 
-@_specialize(where T == Int) // expected-error{{trailing 'where' clause in '_specialize' attribute of non-generic function 'nonGenericParam'}}
+@_specialize(where T == Int) // expected-error{{trailing 'where' clause in '_specialize' attribute of non-generic function 'nonGenericParam(x:)'}}
 func nonGenericParam(x: Int) {}
 
 // Specialize contextual types.
@@ -94,7 +94,7 @@ func sameTypeRequirement<T : HasElt>(_ t: T) where T.Element == Float {}
 @_specialize(where T == NonSub) // expected-error{{'T' requires that 'NonSub' inherit from 'Base'}}
 func superTypeRequirement<T : Base>(_ t: T) {}
 
-@_specialize(where X:_Trivial(8), Y == Int) // expected-error{{trailing 'where' clause in '_specialize' attribute of non-generic function 'requirementOnNonGenericFunction'}}
+@_specialize(where X:_Trivial(8), Y == Int) // expected-error{{trailing 'where' clause in '_specialize' attribute of non-generic function 'requirementOnNonGenericFunction(x:y:)'}}
 public func requirementOnNonGenericFunction(x: Int, y: Int) {
 }
 

--- a/test/attr/attr_versioned.swift
+++ b/test/attr/attr_versioned.swift
@@ -2,10 +2,10 @@
 // RUN: %target-typecheck-verify-swift -enable-testing
 
 @_versioned private func privateVersioned() {}
-// expected-error@-1 {{'@_versioned' attribute can only be applied to internal declarations, but 'privateVersioned' is private}}
+// expected-error@-1 {{'@_versioned' attribute can only be applied to internal declarations, but 'privateVersioned()' is private}}
 
 @_versioned fileprivate func fileprivateVersioned() {}
-// expected-error@-1 {{'@_versioned' attribute can only be applied to internal declarations, but 'fileprivateVersioned' is fileprivate}}
+// expected-error@-1 {{'@_versioned' attribute can only be applied to internal declarations, but 'fileprivateVersioned()' is fileprivate}}
 
 @_versioned internal func internalVersioned() {}
 // OK
@@ -14,11 +14,11 @@
 // OK
 
 @_versioned public func publicVersioned() {}
-// expected-error@-1 {{'@_versioned' attribute can only be applied to internal declarations, but 'publicVersioned' is public}}
+// expected-error@-1 {{'@_versioned' attribute can only be applied to internal declarations, but 'publicVersioned()' is public}}
 
 internal class internalClass {
   @_versioned public func publicVersioned() {}
-  // expected-error@-1 {{'@_versioned' attribute can only be applied to internal declarations, but 'publicVersioned' is public}}
+  // expected-error@-1 {{'@_versioned' attribute can only be applied to internal declarations, but 'publicVersioned()' is public}}
 }
 
 fileprivate class filePrivateClass {

--- a/test/decl/inherit/initializer.swift
+++ b/test/decl/inherit/initializer.swift
@@ -145,8 +145,8 @@ class SubVariadic : SuperVariadic { } // expected-warning 4{{synthesizing a vari
 // Don't crash with invalid nesting of class in generic function
 
 func testClassInGenericFunc<T>(t: T) {
-  class A { init(t: T) {} } // expected-error {{type 'A' cannot be nested in generic function 'testClassInGenericFunc'}}
-  class B : A {} // expected-error {{type 'B' cannot be nested in generic function 'testClassInGenericFunc'}}
+  class A { init(t: T) {} } // expected-error {{type 'A' cannot be nested in generic function 'testClassInGenericFunc(t:)'}}
+  class B : A {} // expected-error {{type 'B' cannot be nested in generic function 'testClassInGenericFunc(t:)'}}
 
   _ = B(t: t)
 }

--- a/test/decl/nested/type_in_function.swift
+++ b/test/decl/nested/type_in_function.swift
@@ -96,7 +96,7 @@ class OuterGenericClass<T> {
 
 // Name lookup within local classes.
 func f5<T, U>(x: T, y: U) {
-  struct Local { // expected-error {{type 'Local' cannot be nested in generic function 'f5'}}
+  struct Local { // expected-error {{type 'Local' cannot be nested in generic function 'f5(x:y:)'}}
     func f() {
       _ = 17 as T // expected-error{{'Int' is not convertible to 'T'}} {{14-16=as!}}
       _ = 17 as U // okay: refers to 'U' declared within the local class
@@ -110,7 +110,7 @@ struct OuterGenericStruct<A> {
   class MiddleNonGenericClass {
     func nonGenericFunction() {
       class InnerGenericClass<T> : MiddleNonGenericClass {
-      // expected-error@-1 {{type 'InnerGenericClass' cannot be nested in generic function 'nonGenericFunction'}}
+      // expected-error@-1 {{type 'InnerGenericClass' cannot be nested in generic function 'nonGenericFunction()'}}
         override init() { super.init() }
       }
     }
@@ -118,7 +118,7 @@ struct OuterGenericStruct<A> {
 
   func middleFunction() {
     struct ConformingType : Racoon {
-    // expected-error@-1 {{type 'ConformingType' cannot be nested in generic function 'middleFunction'}}
+    // expected-error@-1 {{type 'ConformingType' cannot be nested in generic function 'middleFunction()'}}
       typealias Stripes = A
     }
   }
@@ -127,9 +127,9 @@ struct OuterGenericStruct<A> {
 // Issue with diagnoseUnknownType().
 func genericFunction<T>(t: T) {
   class First : Second<T>.UnknownType { }
-  // expected-error@-1 {{type 'First' cannot be nested in generic function 'genericFunction'}}
+  // expected-error@-1 {{type 'First' cannot be nested in generic function 'genericFunction(t:)'}}
   class Second<T> : Second { }
-  // expected-error@-1 {{type 'Second' cannot be nested in generic function 'genericFunction'}}
+  // expected-error@-1 {{type 'Second' cannot be nested in generic function 'genericFunction(t:)'}}
   // expected-error@-2 2 {{circular class inheritance Second}}
 }
 


### PR DESCRIPTION
The second commit changes several diagnostic parameters from `Identifier` or `DeclBaseName` to `DeclName` so that they provide richer error messages that include the function's parameters. @jrose-apple and me composed the list of diagnostics to change during a WWDC lab.