### PR TITLE
[swiftc (41 vs. 5577)] Add crasher in swift::TypeAliasDecl::getUnboundGenericType(...)

### DIFF
--- a/validation-test/compiler_crashers/28812-getgenericparams.swift
+++ b/validation-test/compiler_crashers/28812-getgenericparams.swift
@@ -1,0 +1,13 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+class a<a{{}
+let d=a
+& a
+P{{{}}}typealias a:A protocol A


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeAliasDecl::getUnboundGenericType(...)`.

Current number of unresolved compiler crashers: 41 (5577 resolved)

/cc @slavapestov - just wanted to let you know that this crasher caused an assertion failure for the assertion `getGenericParams()` added on 2016-12-15 by you in commit 2c6b9f71 :-)

Assertion failure in [`lib/AST/Decl.cpp (line 2410)`](https://github.com/apple/swift/blob/dacbb8750fa1e074e9bdea055201975cd1e7c2ec/lib/AST/Decl.cpp#L2410):

```
Assertion `getGenericParams()' failed.

When executing: swift::UnboundGenericType *swift::TypeAliasDecl::getUnboundGenericType() const
```

Assertion context:

```c++
  // Set the interface type of this declaration.
  setInterfaceType(MetatypeType::get(aliasTy, Ctx));
}

UnboundGenericType *TypeAliasDecl::getUnboundGenericType() const {
  assert(getGenericParams());
  return UnboundGenericType::get(
      const_cast<TypeAliasDecl *>(this),
      getDeclContext()->getDeclaredTypeOfContext(),
      getASTContext());
}
```
Stack trace:

```
0 0x0000000003ac2848 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3ac2848)
1 0x0000000003ac2f86 SignalHandler(int) (/path/to/swift/bin/swift+0x3ac2f86)
2 0x00007f6b83957390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007f6b81e7c428 gsignal /build/glibc-bfm8X4/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f6b81e7e02a abort /build/glibc-bfm8X4/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f6b81e74bd7 __assert_fail_base /build/glibc-bfm8X4/glibc-2.23/assert/assert.c:92:0
6 0x00007f6b81e74c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x0000000001557feb swift::TypeAliasDecl::getUnboundGenericType() const (/path/to/swift/bin/swift+0x1557feb)
8 0x0000000001443557 noteArchetypeSource(swift::TypeLoc const&, swift::ArchetypeType*, swift::constraints::ConstraintSystem&) (/path/to/swift/bin/swift+0x1443557)
9 0x00000000014432be (anonymous namespace)::FailureDiagnosis::diagnoseUnboundArchetype(swift::ArchetypeType*, swift::Expr*) (/path/to/swift/bin/swift+0x14432be)
10 0x000000000141d903 (anonymous namespace)::FailureDiagnosis::diagnoseAmbiguity(swift::Expr*) (/path/to/swift/bin/swift+0x141d903)
11 0x000000000141a723 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) (/path/to/swift/bin/swift+0x141a723)
12 0x000000000141ef69 swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) (/path/to/swift/bin/swift+0x141ef69)
13 0x000000000134c348 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0x134c348)
14 0x000000000134fd6f swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x134fd6f)
15 0x0000000001354234 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*, bool) (/path/to/swift/bin/swift+0x1354234)
16 0x0000000001354496 swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int, bool) (/path/to/swift/bin/swift+0x1354496)
17 0x000000000136c508 validatePatternBindingEntries(swift::TypeChecker&, swift::PatternBindingDecl*) (/path/to/swift/bin/swift+0x136c508)
18 0x00000000013668dd (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x13668dd)
19 0x000000000137749b (anonymous namespace)::DeclChecker::visitClassDecl(swift::ClassDecl*) (/path/to/swift/bin/swift+0x137749b)
20 0x000000000136698e (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x136698e)
21 0x0000000001366793 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x1366793)
22 0x00000000013f0fb4 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x13f0fb4)
23 0x0000000000fa6707 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xfa6707)
24 0x00000000004ad858 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4ad858)
25 0x00000000004abe41 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4abe41)
26 0x00000000004656b7 main (/path/to/swift/bin/swift+0x4656b7)
27 0x00007f6b81e67830 __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:325:0
28 0x0000000000462d59 _start (/path/to/swift/bin/swift+0x462d59)
```