### PR TITLE
[swiftc (42 vs. 5577)] Add crasher in swift::GenericSignature::enumeratePairedRequirements

### DIFF
--- a/validation-test/compiler_crashers/28813-swift-genericsignature-enumeratepairedrequirements-llvm-function-ref-bool-swift-.swift
+++ b/validation-test/compiler_crashers/28813-swift-genericsignature-enumeratepairedrequirements-llvm-function-ref-bool-swift-.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol A:Collection}extension CountableRange{protocol P{protocol P{struct a:A{}typealias a:A}{}typealias e:P


### PR DESCRIPTION
Add test case for crash triggered in `swift::GenericSignature::enumeratePairedRequirements`.

Current number of unresolved compiler crashers: 42 (5577 resolved)

Stack trace:

```
0 0x0000000003ac2848 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3ac2848)
1 0x0000000003ac2f86 SignalHandler(int) (/path/to/swift/bin/swift+0x3ac2f86)
2 0x00007f54410ef390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x000000000157bec8 swift::GenericSignature::enumeratePairedRequirements(llvm::function_ref<bool (swift::Type, llvm::ArrayRef<swift::Requirement>)>) const (/path/to/swift/bin/swift+0x157bec8)
4 0x000000000157d75f swift::GenericSignature::getSubstitutionMap(llvm::ArrayRef<swift::Substitution>) const (/path/to/swift/bin/swift+0x157d75f)
5 0x00000000015cc9d7 swift::SpecializedProtocolConformance::getTypeWitnessAndDecl(swift::AssociatedTypeDecl*, swift::LazyResolver*, swift::SubstOptions) const (/path/to/swift/bin/swift+0x15cc9d7)
6 0x00000000015cc2a2 swift::ProtocolConformance::getTypeWitnessAndDecl(swift::AssociatedTypeDecl*, swift::LazyResolver*, swift::SubstOptions) const (/path/to/swift/bin/swift+0x15cc2a2)
7 0x00000000015cbcb9 swift::ProtocolConformance::getTypeWitness(swift::AssociatedTypeDecl*, swift::LazyResolver*, swift::SubstOptions) const (/path/to/swift/bin/swift+0x15cbcb9)
8 0x00000000015e259f getMemberForBaseType(llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::Type, swift::Type, swift::AssociatedTypeDecl*, swift::Identifier, swift::SubstOptions) (/path/to/swift/bin/swift+0x15e259f)
9 0x00000000015e7143 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x15e7143)
10 0x00000000015e3489 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x15e3489)
11 0x00000000015de735 swift::Type::subst(swift::SubstitutionMap const&, swift::SubstOptions) const (/path/to/swift/bin/swift+0x15de735)
12 0x00000000015ccaf6 swift::SpecializedProtocolConformance::getTypeWitnessAndDecl(swift::AssociatedTypeDecl*, swift::LazyResolver*, swift::SubstOptions) const (/path/to/swift/bin/swift+0x15ccaf6)
13 0x00000000015cc2a2 swift::ProtocolConformance::getTypeWitnessAndDecl(swift::AssociatedTypeDecl*, swift::LazyResolver*, swift::SubstOptions) const (/path/to/swift/bin/swift+0x15cc2a2)
14 0x00000000015cbcb9 swift::ProtocolConformance::getTypeWitness(swift::AssociatedTypeDecl*, swift::LazyResolver*, swift::SubstOptions) const (/path/to/swift/bin/swift+0x15cbcb9)
15 0x0000000001588d01 concretizeNestedTypeFromConcreteParent(swift::GenericSignatureBuilder::PotentialArchetype*, swift::GenericSignatureBuilder::PotentialArchetype*, swift::GenericSignatureBuilder&) (/path/to/swift/bin/swift+0x1588d01)
16 0x000000000159160b swift::GenericSignatureBuilder::addSameTypeRequirementToConcrete(swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type, swift::GenericSignatureBuilder::RequirementSource const*) (/path/to/swift/bin/swift+0x159160b)
17 0x000000000159108c swift::GenericSignatureBuilder::addSameTypeRequirement(llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::FloatingRequirementSource, swift::GenericSignatureBuilder::UnresolvedHandlingKind, llvm::function_ref<void (swift::Type, swift::Type)>) (/path/to/swift/bin/swift+0x159108c)
18 0x0000000001588d90 concretizeNestedTypeFromConcreteParent(swift::GenericSignatureBuilder::PotentialArchetype*, swift::GenericSignatureBuilder::PotentialArchetype*, swift::GenericSignatureBuilder&) (/path/to/swift/bin/swift+0x1588d90)
19 0x000000000159160b swift::GenericSignatureBuilder::addSameTypeRequirementToConcrete(swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type, swift::GenericSignatureBuilder::RequirementSource const*) (/path/to/swift/bin/swift+0x159160b)
20 0x000000000159108c swift::GenericSignatureBuilder::addSameTypeRequirement(llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::FloatingRequirementSource, swift::GenericSignatureBuilder::UnresolvedHandlingKind, llvm::function_ref<void (swift::Type, swift::Type)>) (/path/to/swift/bin/swift+0x159108c)
21 0x0000000001587e06 swift::GenericSignatureBuilder::PotentialArchetype::updateNestedTypeForConformance(llvm::PointerUnion<swift::AssociatedTypeDecl*, swift::TypeDecl*>, swift::ArchetypeResolutionKind) (/path/to/swift/bin/swift+0x1587e06)
22 0x00000000015872b3 swift::GenericSignatureBuilder::PotentialArchetype::getNestedArchetypeAnchor(swift::Identifier, swift::GenericSignatureBuilder&, swift::ArchetypeResolutionKind) (/path/to/swift/bin/swift+0x15872b3)
23 0x00000000015956e3 getLocalAnchor(swift::GenericSignatureBuilder::PotentialArchetype*, swift::GenericSignatureBuilder&) (/path/to/swift/bin/swift+0x15956e3)
24 0x000000000159428c swift::GenericSignatureBuilder::checkSameTypeConstraints(llvm::ArrayRef<swift::GenericTypeParamType*>, swift::GenericSignatureBuilder::PotentialArchetype*) (/path/to/swift/bin/swift+0x159428c)
25 0x00000000015920ba swift::GenericSignatureBuilder::finalize(swift::SourceLoc, llvm::ArrayRef<swift::GenericTypeParamType*>, bool) (/path/to/swift/bin/swift+0x15920ba)
26 0x0000000001597ff3 swift::GenericSignatureBuilder::computeGenericSignature(swift::SourceLoc, bool) (/path/to/swift/bin/swift+0x1597ff3)
27 0x000000000155b6f8 swift::ProtocolDecl::computeRequirementSignature() (/path/to/swift/bin/swift+0x155b6f8)
28 0x00000000013977c8 swift::TypeChecker::validateGenericTypeSignature(swift::GenericTypeDecl*) (/path/to/swift/bin/swift+0x13977c8)
29 0x00000000013686c0 swift::TypeChecker::validateDecl(swift::ValueDecl*) (/path/to/swift/bin/swift+0x13686c0)
30 0x000000000137821f (anonymous namespace)::DeclChecker::visitProtocolDecl(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0x137821f)
31 0x0000000001366894 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x1366894)
32 0x0000000001376d3b (anonymous namespace)::DeclChecker::visitExtensionDecl(swift::ExtensionDecl*) (/path/to/swift/bin/swift+0x1376d3b)
33 0x00000000013668c4 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x13668c4)
34 0x0000000001366793 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x1366793)
35 0x00000000013f0fb4 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x13f0fb4)
36 0x0000000000fa6707 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xfa6707)
37 0x00000000004ad858 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4ad858)
38 0x00000000004abe41 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4abe41)
39 0x00000000004656b7 main (/path/to/swift/bin/swift+0x4656b7)
40 0x00007f543f5ff830 __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:325:0
41 0x0000000000462d59 _start (/path/to/swift/bin/swift+0x462d59)
```