### PR TITLE
[swiftc (43 vs. 5577)] Add crasher in swift::lookupVisibleMemberDecls

### DIFF
--- a/validation-test/compiler_crashers/28814-basety-hasunboundgenerictype.swift
+++ b/validation-test/compiler_crashers/28814-basety-hasunboundgenerictype.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol P{typealias a=FlattenCollection}{{P.a.a}}protocol P


### PR DESCRIPTION
Add test case for crash triggered in `swift::lookupVisibleMemberDecls`.

Current number of unresolved compiler crashers: 43 (5577 resolved)

/cc @slavapestov - just wanted to let you know that this crasher caused an assertion failure for the assertion `!BaseTy->hasUnboundGenericType()` added on 2017-03-20 by you in commit 573e832f :-)

Assertion failure in [`lib/AST/LookupVisibleDecls.cpp (line 784)`](https://github.com/apple/swift/blob/f0d485c8339f84f707113f800c526fea4c5b7f3d/lib/AST/LookupVisibleDecls.cpp#L784):

```
Assertion `!BaseTy->hasUnboundGenericType()' failed.

When executing: virtual void (anonymous namespace)::OverrideFilteringConsumer::foundDecl(swift::ValueDecl *, swift::DeclVisibilityKind)
```

Assertion context:

```c++

    // Does it make sense to substitute types?

    // Don't pass UnboundGenericType here. If you see this assertion
    // being hit, fix the caller, don't remove it.
    assert(!BaseTy->hasUnboundGenericType());

    // If the base type is AnyObject, we might be doing a dynamic
    // lookup, so the base type won't match the type of the member's
    // context type.
    //
```
Stack trace:

```
0 0x0000000003ac2848 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3ac2848)
1 0x0000000003ac2f86 SignalHandler(int) (/path/to/swift/bin/swift+0x3ac2f86)
2 0x00007f6cbf54b390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007f6cbda70428 gsignal /build/glibc-bfm8X4/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f6cbda7202a abort /build/glibc-bfm8X4/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f6cbda68bd7 __assert_fail_base /build/glibc-bfm8X4/glibc-2.23/assert/assert.c:92:0
6 0x00007f6cbda68c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x00000000015aa1a2 (anonymous namespace)::OverrideFilteringConsumer::foundDecl(swift::ValueDecl*, swift::DeclVisibilityKind) (/path/to/swift/bin/swift+0x15aa1a2)
8 0x00000000015ab3f0 lookupTypeMembers(swift::Type, swift::Type, swift::VisibleDeclConsumer&, swift::DeclContext const*, (anonymous namespace)::LookupState, swift::DeclVisibilityKind, swift::LazyResolver*) (/path/to/swift/bin/swift+0x15ab3f0)
9 0x00000000015a8e40 lookupVisibleMemberDeclsImpl(swift::Type, swift::VisibleDeclConsumer&, swift::DeclContext const*, (anonymous namespace)::LookupState, swift::DeclVisibilityKind, swift::LazyResolver*, swift::GenericSignatureBuilder*, llvm::SmallPtrSet<swift::TypeDecl*, 8u>&) (/path/to/swift/bin/swift+0x15a8e40)
10 0x00000000015a8604 lookupVisibleMemberDecls(swift::Type, swift::VisibleDeclConsumer&, swift::DeclContext const*, (anonymous namespace)::LookupState, swift::DeclVisibilityKind, swift::LazyResolver*, swift::GenericSignatureBuilder*) (/path/to/swift/bin/swift+0x15a8604)
11 0x00000000015a8754 swift::lookupVisibleMemberDecls(swift::VisibleDeclConsumer&, swift::Type, swift::DeclContext const*, swift::LazyResolver*, bool, swift::GenericSignatureBuilder*) (/path/to/swift/bin/swift+0x15a8754)
12 0x000000000139a9c9 swift::TypeChecker::performTypoCorrection(swift::DeclContext*, swift::DeclRefKind, swift::Type, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>, swift::LookupResult&, swift::GenericSignatureBuilder*, unsigned int) (/path/to/swift/bin/swift+0x139a9c9)
13 0x000000000143408a (anonymous namespace)::FailureDiagnosis::diagnoseUnviableLookupResults(swift::constraints::MemberLookupResult&, swift::Type, swift::Expr*, swift::DeclName, swift::DeclNameLoc, swift::SourceLoc) (/path/to/swift/bin/swift+0x143408a)
14 0x0000000001428dae (anonymous namespace)::FailureDiagnosis::diagnoseMemberFailures(swift::Expr*, swift::Expr*, swift::constraints::ConstraintKind, swift::DeclName, swift::FunctionRefKind, swift::constraints::ConstraintLocator*, llvm::Optional<std::function<bool (llvm::ArrayRef<swift::constraints::OverloadChoice>)> >, bool) (/path/to/swift/bin/swift+0x1428dae)
15 0x000000000141f76b swift::ASTVisitor<(anonymous namespace)::FailureDiagnosis, bool, void, void, void, void, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x141f76b)
16 0x000000000141923b swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) (/path/to/swift/bin/swift+0x141923b)
17 0x000000000141ef69 swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) (/path/to/swift/bin/swift+0x141ef69)
18 0x000000000134c348 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0x134c348)
19 0x000000000134fd6f swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x134fd6f)
20 0x0000000001422f3a (anonymous namespace)::FailureDiagnosis::typeCheckChildIndependently(swift::Expr*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<TCCFlags, unsigned int>, swift::ExprTypeCheckListener*, bool) (/path/to/swift/bin/swift+0x1422f3a)
21 0x0000000001439438 (anonymous namespace)::FailureDiagnosis::diagnoseClosureExpr(swift::ClosureExpr*, swift::Type, std::function<bool (swift::Type, swift::Type)>) (/path/to/swift/bin/swift+0x1439438)
22 0x000000000142006c swift::ASTVisitor<(anonymous namespace)::FailureDiagnosis, bool, void, void, void, void, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x142006c)
23 0x000000000141923b swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) (/path/to/swift/bin/swift+0x141923b)
24 0x000000000141ef69 swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) (/path/to/swift/bin/swift+0x141ef69)
25 0x000000000134c348 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0x134c348)
26 0x000000000134fd6f swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x134fd6f)
27 0x0000000001422f3a (anonymous namespace)::FailureDiagnosis::typeCheckChildIndependently(swift::Expr*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<TCCFlags, unsigned int>, swift::ExprTypeCheckListener*, bool) (/path/to/swift/bin/swift+0x1422f3a)
28 0x0000000001439438 (anonymous namespace)::FailureDiagnosis::diagnoseClosureExpr(swift::ClosureExpr*, swift::Type, std::function<bool (swift::Type, swift::Type)>) (/path/to/swift/bin/swift+0x1439438)
29 0x000000000142006c swift::ASTVisitor<(anonymous namespace)::FailureDiagnosis, bool, void, void, void, void, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x142006c)
30 0x000000000141923b swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) (/path/to/swift/bin/swift+0x141923b)
31 0x000000000141ef69 swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) (/path/to/swift/bin/swift+0x141ef69)
32 0x000000000134c348 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0x134c348)
33 0x000000000134fd6f swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x134fd6f)
34 0x00000000013d3016 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13d3016)
35 0x00000000013d2836 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0x13d2836)
36 0x00000000013f1020 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x13f1020)
37 0x0000000000fa6707 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xfa6707)
38 0x00000000004ad858 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4ad858)
39 0x00000000004abe41 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4abe41)
40 0x00000000004656b7 main (/path/to/swift/bin/swift+0x4656b7)
41 0x00007f6cbda5b830 __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:325:0
42 0x0000000000462d59 _start (/path/to/swift/bin/swift+0x462d59)
```