### PR TITLE
[swiftc (46 vs. 5577)] Add crasher in swift::TypeBase::getDesugaredType(...)

### DIFF
--- a/validation-test/compiler_crashers/28817-swift-typebase-getdesugaredtype.swift
+++ b/validation-test/compiler_crashers/28817-swift-typebase-getdesugaredtype.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+class a{class a}func a:P._=a.a{


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeBase::getDesugaredType(...)`.

Current number of unresolved compiler crashers: 46 (5577 resolved)

Stack trace:

```
0 0x0000000003ac2848 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3ac2848)
1 0x0000000003ac2f86 SignalHandler(int) (/path/to/swift/bin/swift+0x3ac2f86)
2 0x00007f48e24bf390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00000000015dd970 swift::TypeBase::getDesugaredType() (/path/to/swift/bin/swift+0x15dd970)
4 0x0000000000ff53fb swift::TypeBase::mayHaveMembers() (/path/to/swift/bin/swift+0xff53fb)
5 0x00000000014400b6 (anonymous namespace)::CalleeCandidateInfo::collectCalleeCandidates(swift::Expr*, bool) (/path/to/swift/bin/swift+0x14400b6)
6 0x000000000143be81 (anonymous namespace)::FailureDiagnosis::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0x143be81)
7 0x000000000141f532 swift::ASTVisitor<(anonymous namespace)::FailureDiagnosis, bool, void, void, void, void, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x141f532)
8 0x000000000141923b swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) (/path/to/swift/bin/swift+0x141923b)
9 0x000000000141ef69 swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) (/path/to/swift/bin/swift+0x141ef69)
10 0x000000000134c348 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0x134c348)
11 0x000000000134fd6f swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x134fd6f)
12 0x0000000001422f3a (anonymous namespace)::FailureDiagnosis::typeCheckChildIndependently(swift::Expr*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<TCCFlags, unsigned int>, swift::ExprTypeCheckListener*, bool) (/path/to/swift/bin/swift+0x1422f3a)
13 0x0000000001421df3 swift::ASTVisitor<(anonymous namespace)::FailureDiagnosis, bool, void, void, void, void, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x1421df3)
14 0x000000000141923b swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) (/path/to/swift/bin/swift+0x141923b)
15 0x000000000141ef69 swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) (/path/to/swift/bin/swift+0x141ef69)
16 0x000000000134c348 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0x134c348)
17 0x000000000134fd6f swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x134fd6f)
18 0x00000000013d3016 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x13d3016)
19 0x00000000013d2836 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0x13d2836)
20 0x00000000013f1020 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x13f1020)
21 0x0000000000fa6707 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xfa6707)
22 0x00000000004ad858 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4ad858)
23 0x00000000004abe41 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4abe41)
24 0x00000000004656b7 main (/path/to/swift/bin/swift+0x4656b7)
25 0x00007f48e09cf830 __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:325:0
26 0x0000000000462d59 _start (/path/to/swift/bin/swift+0x462d59)
```