### PR TITLE
Added map, flatMap, filter to Sequence with support of Keypaths

### DIFF
--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -375,6 +375,19 @@ public protocol Sequence {
     _ transform: (Element) throws -> T
   ) rethrows -> [T]
 
+  /// Returns an array containing extracted values behind keypaths of
+  /// the Sequences elements.
+  ///
+  /// In this example, `map` is used to get the number of unicode scalars
+  /// of each String in an array.
+  ///
+  ///     let a = ["a", "foo", "bar"]
+  ///     let b = a.map(keypath: \.count)
+  ///
+  /// - Parameter keyPath: The keypath of the property to extract
+  /// - Returns: An array containing the extracted values of the elements
+  func map<Value>(keyPath: KeyPath<Element, Value>) -> [Value]
+
   /// Returns an array containing, in order, the elements of the sequence
   /// that satisfy the given predicate.
   ///
@@ -847,6 +860,22 @@ extension Sequence {
       result.append(try transform(element))
     }
     return Array(result)
+  }
+
+  /// Returns an array containing extracted values behind keypaths of
+  /// the Sequences elements.
+  ///
+  /// In this example, `map` is used to get the number of unicode scalars
+  /// of each String in an array.
+  ///
+  ///     let a = ["a", "foo", "bar"]
+  ///     let b = a.map(keypath: \.count)
+  ///
+  /// - Parameter keyPath: The keypath of the property to extract
+  /// - Returns: An array containing the extracted values of the elements
+  @_inlineable
+  public func map<Value>(keyPath: KeyPath<Element, Value>) -> [Value] {
+      return self.map { $0[keyPath: keypath] }
   }
 
   /// Returns an array containing, in order, the elements of the sequence

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -407,6 +407,19 @@ public protocol Sequence {
     _ isIncluded: (Element) throws -> Bool
   ) rethrows -> [Element]
 
+  /// Returns an array containing, in order, the extracted properties of the
+  /// elements of the sequence if they evaluate to true.
+  ///
+  /// In this example, `filter(keyPath:)` is used to get all ASCII characters
+  /// from a Sequence of UnicodeScalars.
+  ///
+  ///     "foo😱".unicodeScalars.filter(keyPath: \.isASCII)
+  ///
+  /// - Parameter keyPath: A valid keypath of Element that is of type Bool
+  /// - Returns: The filtered `Sequence` as an array containing only the
+  ///     elements where the extracted value evaluates to true.
+  func filter(keyPath: KeyPath<Element, Bool>) -> [Element]
+
   /// Calls the given closure on each element in the sequence in the same order
   /// as a `for`-`in` loop.
   ///
@@ -916,6 +929,22 @@ extension Sequence {
     }
 
     return Array(result)
+  }
+
+  /// Returns an array containing, in order, the extracted properties of the
+  /// elements of the sequence if they evaluate to true.
+  ///
+  /// In this example, `filter(keyPath:)` is used to get all ASCII characters
+  /// from a Sequence of UnicodeScalars.
+  ///
+  ///     "foo😱".unicodeScalars.filter(keyPath: \.isASCII)
+  ///
+  /// - Parameter keyPath: A valid keypath of Element that is of type Bool
+  /// - Returns: The filtered `Sequence` as an array containing only the
+  ///     elements where the extracted value evaluates to true.
+  @_inlineable
+  func filter(keyPath: KeyPath<Element, Bool>) -> [Element] {
+    return self.filter { $0[keyPath: keyPath] }
   }
 
   /// Returns a subsequence, up to the given maximum length, containing the

--- a/stdlib/public/core/SequenceAlgorithms.swift.gyb
+++ b/stdlib/public/core/SequenceAlgorithms.swift.gyb
@@ -667,6 +667,24 @@ extension Sequence {
     }
     return result
   }
+
+  /// Returns an array containing the extracted members behind the keypath of
+  /// each element, flattened, since the value is a `Sequence` itself.
+  ///
+  /// In this example, `flatMap` maps all elements to it's description (which
+  /// is a Sequence itself) and flattens this to a Sequence of all characters.
+  ///
+  ///     let a = ["foo", "bar"]
+  ///     a.flatMap(keyPath: \.description)
+  ///     // ["f", "o", "o", "b", "a", "r"]
+  ///
+  /// - Parameter keyPath: A valid keypath of `Element` that is a `Sequence`.
+  /// - Returns: The resulting flattened array.
+  @_inlineable
+  func flatMap<SequenceValue: Sequence>(
+    keyPath: KeyPath<Element, SequenceValue>) -> [SequenceValue.Element] {
+    return self.flatMap { $0[keyPath: keyPath] }
+  }
 }
 
 extension Sequence {
@@ -715,6 +733,31 @@ extension Sequence {
       }
     }
     return result
+  }
+
+  /// Returns an array containing the extracted members behind the keypath of
+  /// each element. Since the members are `Optional` it will also filter out
+  /// the `Elements` that are `nil`.
+  ///
+  /// In this example, `flatMap` maps all Person elements to it's name (which
+  /// is optional) and filters the resulting array for it's non-nil values.
+  ///
+  /// struct Person {
+  ///     var name: String?
+  /// }
+  /// 
+  /// let p1 = Person(name: "Tim")
+  /// let p2 = Person(name: nil)
+  /// let p3 = Person(name: "Steve")
+  /// 
+  /// let persons = [p1, p2, p3]
+  /// persons.flatMap(keyPath: \.name)
+  ///
+  /// - Parameter keyPath: A valid keypath of Element that is an `Optional`.
+  /// - Returns: The resulting flattened array.
+  @_inlineable
+  public func flatMap<Value>(keyPath: KeyPath<Element, Value?>) -> [Value] {
+    return self.flatMap { $0[keyPath: keyPath] }
   }
 }
 

--- a/stdlib/public/core/SequenceWrapper.swift
+++ b/stdlib/public/core/SequenceWrapper.swift
@@ -57,6 +57,10 @@ extension _SequenceWrapper where Element == Base.Element {
 ) rethrows -> [T] {
     return try _base.map(transform)
   }
+
+  func map<Value>(keyPath: KeyPath<Element, Value>) -> [Value] {
+    return _base.map(keyPath: keyPath)
+  }
   
   public func filter(
     _ isIncluded: (Element) throws -> Bool


### PR DESCRIPTION
<!-- What's in this pull request? -->
I added a convenience method for `map` in `Sequence` to give a KeyPath instead of a closure. This makes it much easier to extract values of properties out of an array of elements.

Here are some examples of the usage:

```Swift
struct Person {
    var name: String?
}

let p1 = Person(name: "Tim")
let p2 = Person(name: nil)
let p3 = Person(name: "Steve")

let persons = [p1, p2, p3]
persons.flatMap(keyPath: \.name)

let a = ["foo", "", "bar"]
a.map(keyPath: \.removingPercentEncoding)
a.flatMap(keyPath: \.description)
a.filter(keyPath: \.isEmpty)

print("foo😱".unicodeScalars.filter(keyPath: \.isASCII))
```