### PR TITLE
[4.0] Avoid building conformance lookup tables when we don't have to.

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2641,6 +2641,9 @@ static void checkBridgedFunctions(TypeChecker &TC) {
 
 /// Infer the Objective-C name for a given declaration.
 static void inferObjCName(TypeChecker &tc, ValueDecl *decl) {
+  if (isa<DestructorDecl>(decl))
+    return;
+
   // If this declaration overrides an @objc declaration, use its name.
   if (auto overridden = decl->getOverriddenDecl()) {
     if (overridden->isObjC()) {

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5581,6 +5581,8 @@ bool TypeChecker::useObjectiveCBridgeableConformances(DeclContext *dc,
       // If we have a nominal type, "use" its conformance to
       // _ObjectiveCBridgeable if it has one.
       if (auto *nominalDecl = ty->getAnyNominal()) {
+        if (isa<ClassDecl>(nominalDecl) || isa<ProtocolDecl>(nominalDecl))
+          return Action::Continue;
         auto result = TC.conformsToProtocol(ty, Proto, DC, options,
                                             /*ComplainLoc=*/SourceLoc(),
                                             Callback);

--- a/test/SourceKit/DocSupport/doc_clang_module.swift.response
+++ b/test/SourceKit/DocSupport/doc_clang_module.swift.response
@@ -209,13 +209,13 @@ class FooClassBase {
 
     class func fooBaseClassFunc0()
 
-    func _internalMeth3() -> Any!
+    func _internalMeth1() -> Any!
 
     func _internalMeth2() -> Any!
 
     func nonInternalMeth() -> Any!
 
-    func _internalMeth1() -> Any!
+    func _internalMeth3() -> Any!
 }
 class FooClassDerived : FooClassBase, FooProtocolDerived {
 
@@ -235,13 +235,13 @@ class FooClassDerived : FooClassBase, FooProtocolDerived {
 
     class func fooClassFunc0()
 
-    func _internalMeth3() -> Any!
+    func _internalMeth1() -> Any!
 
     func _internalMeth2() -> Any!
 
     func nonInternalMeth() -> Any!
 
-    func _internalMeth1() -> Any!
+    func _internalMeth3() -> Any!
 }
 typealias typedef_int_t = Int32
 var FOO_MACRO_1: Int32 { get }
@@ -301,13 +301,13 @@ class FooClassPropertyOwnership : FooClassBase {
 
     var scalar: Int32
 
-    func _internalMeth3() -> Any!
+    func _internalMeth1() -> Any!
 
     func _internalMeth2() -> Any!
 
     func nonInternalMeth() -> Any!
 
-    func _internalMeth1() -> Any!
+    func _internalMeth3() -> Any!
 }
 var FOO_NIL: ()
 class FooUnavailableMembers : FooClassBase {
@@ -336,13 +336,13 @@ class FooUnavailableMembers : FooClassBase {
 
     func availabilityUnavailableMsg()
 
-    func _internalMeth3() -> Any!
+    func _internalMeth1() -> Any!
 
     func _internalMeth2() -> Any!
 
     func nonInternalMeth() -> Any!
 
-    func _internalMeth1() -> Any!
+    func _internalMeth3() -> Any!
 }
 class FooCFType {
 }
@@ -7041,11 +7041,11 @@ var FooSubUnnamedEnumeratorA1: Int { get }
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
-        key.name: "_internalMeth3()",
-        key.usr: "c:objc(cs)FooClassBase(im)_internalMeth3",
+        key.name: "_internalMeth1()",
+        key.usr: "c:objc(cs)FooClassBase(im)_internalMeth1",
         key.offset: 5048,
         key.length: 29,
-        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth3</decl.name>() -&gt; <decl.function.returntype>Any!</decl.function.returntype></decl.function.method.instance>"
+        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth1</decl.name>() -&gt; <decl.function.returntype>Any!</decl.function.returntype></decl.function.method.instance>"
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
@@ -7065,11 +7065,11 @@ var FooSubUnnamedEnumeratorA1: Int { get }
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
-        key.name: "_internalMeth1()",
-        key.usr: "c:objc(cs)FooClassBase(im)_internalMeth1",
+        key.name: "_internalMeth3()",
+        key.usr: "c:objc(cs)FooClassBase(im)_internalMeth3",
         key.offset: 5154,
         key.length: 29,
-        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth1</decl.name>() -&gt; <decl.function.returntype>Any!</decl.function.returntype></decl.function.method.instance>"
+        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth3</decl.name>() -&gt; <decl.function.returntype>Any!</decl.function.returntype></decl.function.method.instance>"
       }
     ]
   },
@@ -7194,12 +7194,12 @@ var FooSubUnnamedEnumeratorA1: Int { get }
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
-        key.name: "_internalMeth3()",
-        key.usr: "c:objc(cs)FooClassBase(im)_internalMeth3::SYNTHESIZED::c:objc(cs)FooClassDerived",
-        key.original_usr: "c:objc(cs)FooClassBase(im)_internalMeth3",
+        key.name: "_internalMeth1()",
+        key.usr: "c:objc(cs)FooClassBase(im)_internalMeth1::SYNTHESIZED::c:objc(cs)FooClassDerived",
+        key.original_usr: "c:objc(cs)FooClassBase(im)_internalMeth1",
         key.offset: 5542,
         key.length: 29,
-        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth3</decl.name>() -&gt; <decl.function.returntype>Any!</decl.function.returntype></decl.function.method.instance>"
+        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth1</decl.name>() -&gt; <decl.function.returntype>Any!</decl.function.returntype></decl.function.method.instance>"
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
@@ -7221,12 +7221,12 @@ var FooSubUnnamedEnumeratorA1: Int { get }
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
-        key.name: "_internalMeth1()",
-        key.usr: "c:objc(cs)FooClassBase(im)_internalMeth1::SYNTHESIZED::c:objc(cs)FooClassDerived",
-        key.original_usr: "c:objc(cs)FooClassBase(im)_internalMeth1",
+        key.name: "_internalMeth3()",
+        key.usr: "c:objc(cs)FooClassBase(im)_internalMeth3::SYNTHESIZED::c:objc(cs)FooClassDerived",
+        key.original_usr: "c:objc(cs)FooClassBase(im)_internalMeth3",
         key.offset: 5648,
         key.length: 29,
-        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth1</decl.name>() -&gt; <decl.function.returntype>Any!</decl.function.returntype></decl.function.method.instance>"
+        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth3</decl.name>() -&gt; <decl.function.returntype>Any!</decl.function.returntype></decl.function.method.instance>"
       }
     ]
   },
@@ -7582,12 +7582,12 @@ var FooSubUnnamedEnumeratorA1: Int { get }
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
-        key.name: "_internalMeth3()",
-        key.usr: "c:objc(cs)FooClassBase(im)_internalMeth3::SYNTHESIZED::c:objc(cs)FooClassPropertyOwnership",
-        key.original_usr: "c:objc(cs)FooClassBase(im)_internalMeth3",
+        key.name: "_internalMeth1()",
+        key.usr: "c:objc(cs)FooClassBase(im)_internalMeth1::SYNTHESIZED::c:objc(cs)FooClassPropertyOwnership",
+        key.original_usr: "c:objc(cs)FooClassBase(im)_internalMeth1",
         key.offset: 6861,
         key.length: 29,
-        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth3</decl.name>() -&gt; <decl.function.returntype>Any!</decl.function.returntype></decl.function.method.instance>"
+        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth1</decl.name>() -&gt; <decl.function.returntype>Any!</decl.function.returntype></decl.function.method.instance>"
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
@@ -7609,12 +7609,12 @@ var FooSubUnnamedEnumeratorA1: Int { get }
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
-        key.name: "_internalMeth1()",
-        key.usr: "c:objc(cs)FooClassBase(im)_internalMeth1::SYNTHESIZED::c:objc(cs)FooClassPropertyOwnership",
-        key.original_usr: "c:objc(cs)FooClassBase(im)_internalMeth1",
+        key.name: "_internalMeth3()",
+        key.usr: "c:objc(cs)FooClassBase(im)_internalMeth3::SYNTHESIZED::c:objc(cs)FooClassPropertyOwnership",
+        key.original_usr: "c:objc(cs)FooClassBase(im)_internalMeth3",
         key.offset: 6967,
         key.length: 29,
-        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth1</decl.name>() -&gt; <decl.function.returntype>Any!</decl.function.returntype></decl.function.method.instance>"
+        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth3</decl.name>() -&gt; <decl.function.returntype>Any!</decl.function.returntype></decl.function.method.instance>"
       }
     ]
   },
@@ -7850,12 +7850,12 @@ var FooSubUnnamedEnumeratorA1: Int { get }
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
-        key.name: "_internalMeth3()",
-        key.usr: "c:objc(cs)FooClassBase(im)_internalMeth3::SYNTHESIZED::c:objc(cs)FooUnavailableMembers",
-        key.original_usr: "c:objc(cs)FooClassBase(im)_internalMeth3",
+        key.name: "_internalMeth1()",
+        key.usr: "c:objc(cs)FooClassBase(im)_internalMeth1::SYNTHESIZED::c:objc(cs)FooUnavailableMembers",
+        key.original_usr: "c:objc(cs)FooClassBase(im)_internalMeth1",
         key.offset: 7470,
         key.length: 29,
-        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth3</decl.name>() -&gt; <decl.function.returntype>Any!</decl.function.returntype></decl.function.method.instance>"
+        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth1</decl.name>() -&gt; <decl.function.returntype>Any!</decl.function.returntype></decl.function.method.instance>"
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
@@ -7877,12 +7877,12 @@ var FooSubUnnamedEnumeratorA1: Int { get }
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
-        key.name: "_internalMeth1()",
-        key.usr: "c:objc(cs)FooClassBase(im)_internalMeth1::SYNTHESIZED::c:objc(cs)FooUnavailableMembers",
-        key.original_usr: "c:objc(cs)FooClassBase(im)_internalMeth1",
+        key.name: "_internalMeth3()",
+        key.usr: "c:objc(cs)FooClassBase(im)_internalMeth3::SYNTHESIZED::c:objc(cs)FooUnavailableMembers",
+        key.original_usr: "c:objc(cs)FooClassBase(im)_internalMeth3",
         key.offset: 7576,
         key.length: 29,
-        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth1</decl.name>() -&gt; <decl.function.returntype>Any!</decl.function.returntype></decl.function.method.instance>"
+        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth3</decl.name>() -&gt; <decl.function.returntype>Any!</decl.function.returntype></decl.function.method.instance>"
       }
     ]
   },

--- a/validation-test/compiler_crashers_2_fixed/Inputs/sr5330/ObjCPart.h
+++ b/validation-test/compiler_crashers_2_fixed/Inputs/sr5330/ObjCPart.h
@@ -1,0 +1,6 @@
+@interface Base
+@end
+
+@interface MyCollection: Base
+- (id)objectAtIndex:(long)index;
+@end

--- a/validation-test/compiler_crashers_2_fixed/Inputs/sr5330/module.modulemap
+++ b/validation-test/compiler_crashers_2_fixed/Inputs/sr5330/module.modulemap
@@ -1,0 +1,3 @@
+module ObjCPart {
+  header "ObjCPart.h"
+}

--- a/validation-test/compiler_crashers_2_fixed/sr5330.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr5330.swift
@@ -1,0 +1,27 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -o %t %s -I %S/Inputs/sr5330/ -module-name TEST
+// RUN: echo 'import TEST; x' | not %target-swift-frontend -typecheck - -I %S/Inputs/sr5330/ -I %t
+
+// REQUIRES: objc_interop
+
+import ObjCPart
+
+public typealias Alias = MyCollection
+
+extension Alias: Collection {
+    public subscript(index: Int) -> Any {
+        return object(at: index)
+    }
+
+    public func index(after i: Int) -> Int {
+        return i + 1
+    }
+
+    public var startIndex: Int {
+        return 0
+    }
+
+    public var endIndex: Int {
+        return count
+    }
+}


### PR DESCRIPTION
- **Explanation**: Checking of the `objc` attribute is very involved, but in multiple cases it was doing much more work than it needed to. In particularly bad cases (including the issues listed below), that would lead to eagerly deserializing protocol conformances, which could result in a circular dependency and crash in deserialization (like #10737). Adding small, clearly-correct early exits avoids this pitfall.
- **Scope**: Very broad: affects all class members marked `@objc`. However, there should be no change in the behavior of anything that was working correctly; the compiler will just do work less eagerly.
- **Issue**: [SR-5330](https://bugs.swift.org/browse/SR-5330) / rdar://problem/32677610
- **Reviewed by**: @DougGregor  
- **Risk**: Medium, due to the broad scope. We definitely want to test this against the compatibility suite.
- **Testing**: Verified that this fixed the original test case.