### PR TITLE
JSONEncoder conditional conformance workarounds

### DIFF
--- a/stdlib/public/SDK/Foundation/Data.swift
+++ b/stdlib/public/SDK/Foundation/Data.swift
@@ -1785,11 +1785,27 @@ extension NSData : _HasCustomAnyHashableRepresentation {
 
 extension Data : Codable {
     public init(from decoder: Decoder) throws {
+        // FIXME: This is a hook for bypassing a conditional conformance implementation to apply a strategy (see SR-5206). Remove this once conditional conformance is available.
+        do {
+            let singleValueContainer = try decoder.singleValueContainer()
+            if let decoder = singleValueContainer as? _JSONDecoder {
+                switch decoder.options.dataDecodingStrategy {
+                case .deferredToData:
+                    break /* fall back to default implementation below; this would recurse */
+
+                default:
+                    // _JSONDecoder has a hook for Datas; this won't recurse since we're not going to defer back to Data in _JSONDecoder.
+                    self = try singleValueContainer.decode(Data.self)
+                    return
+                }
+            }
+        } catch { /* fall back to default implementation below */ }
+
         var container = try decoder.unkeyedContainer()
         
         // It's more efficient to pre-allocate the buffer if we can.
         if let count = container.count {
-            self.init(count: count)
+            self = Data(count: count)
             
             // Loop only until count, not while !container.isAtEnd, in case count is underestimated (this is misbehavior) and we haven't allocated enough space.
             // We don't want to write past the end of what we allocated.
@@ -1798,7 +1814,7 @@ extension Data : Codable {
                 self[i] = byte
             }
         } else {
-            self.init()
+            self = Data()
         }
         
         while !container.isAtEnd {
@@ -1808,6 +1824,21 @@ extension Data : Codable {
     }
     
     public func encode(to encoder: Encoder) throws {
+        // FIXME: This is a hook for bypassing a conditional conformance implementation to apply a strategy (see SR-5206). Remove this once conditional conformance is available.
+        // We are allowed to request this container as long as we don't encode anything through it when we need the unkeyed container below.
+        var singleValueContainer = encoder.singleValueContainer()
+        if let encoder = singleValueContainer as? _JSONEncoder {
+            switch encoder.options.dataEncodingStrategy {
+            case .deferredToData:
+                break /* fall back to default implementation below; this would recurse */
+
+            default:
+                // _JSONEncoder has a hook for Datas; this won't recurse since we're not going to defer back to Data in _JSONEncoder.
+                try singleValueContainer.encode(self)
+                return
+            }
+        }
+
         var container = encoder.unkeyedContainer()
         
         // Since enumerateBytes does not rethrow, we need to catch the error, stow it away, and rethrow if we stopped.

--- a/stdlib/public/SDK/Foundation/Date.swift
+++ b/stdlib/public/SDK/Foundation/Date.swift
@@ -287,13 +287,40 @@ extension Date : CustomPlaygroundQuickLookable {
 
 extension Date : Codable {
     public init(from decoder: Decoder) throws {
+        // FIXME: This is a hook for bypassing a conditional conformance implementation to apply a strategy (see SR-5206). Remove this once conditional conformance is available.
         let container = try decoder.singleValueContainer()
+        if let decoder = container as? _JSONDecoder {
+            switch decoder.options.dateDecodingStrategy {
+            case .deferredToDate:
+                break /* fall back to default implementation below; this would recurse */
+
+            default:
+                // _JSONDecoder has a hook for Dates; this won't recurse since we're not going to defer back to Date in _JSONDecoder.
+                self = try container.decode(Date.self)
+                return
+            }
+        }
+
         let timestamp = try container.decode(Double.self)
-        self.init(timeIntervalSinceReferenceDate: timestamp)
+        self = Date(timeIntervalSinceReferenceDate: timestamp)
     }
 
     public func encode(to encoder: Encoder) throws {
+        // FIXME: This is a hook for bypassing a conditional conformance implementation to apply a strategy (see SR-5206). Remove this once conditional conformance is available.
+        // We are allowed to request this container as long as we don't encode anything through it when we need the keyed container below.
         var container = encoder.singleValueContainer()
+        if let encoder = container as? _JSONEncoder {
+            switch encoder.options.dateEncodingStrategy {
+            case .deferredToDate:
+                break /* fall back to default implementation below; this would recurse */
+
+            default:
+                // _JSONEncoder has a hook for Dates; this won't recurse since we're not going to defer back to Date in _JSONEncoder.
+                try container.encode(self)
+                return
+            }
+        }
+
         try container.encode(self.timeIntervalSinceReferenceDate)
     }
 }

--- a/stdlib/public/SDK/Foundation/Decimal.swift
+++ b/stdlib/public/SDK/Foundation/Decimal.swift
@@ -470,6 +470,17 @@ extension Decimal : Codable {
     }
 
     public init(from decoder: Decoder) throws {
+        // FIXME: This is a hook for bypassing a conditional conformance implementation to apply a strategy (see SR-5206). Remove this once conditional conformance is available.
+        do {
+            // We are allowed to request this container as long as we don't decode anything through it when we need the keyed container below.
+            let singleValueContainer = try decoder.singleValueContainer()
+            if singleValueContainer is _JSONDecoder {
+                // _JSONDecoder has a hook for Decimals; this won't recurse since we're not going to defer to Decimal in _JSONDecoder.
+                self  = try singleValueContainer.decode(Decimal.self)
+                return
+            }
+        } catch { /* Fall back to default implementation below. */ }
+
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let exponent = try container.decode(CInt.self, forKey: .exponent)
         let length = try container.decode(CUnsignedInt.self, forKey: .length)
@@ -488,15 +499,24 @@ extension Decimal : Codable {
         mantissa.6 = try mantissaContainer.decode(CUnsignedShort.self)
         mantissa.7 = try mantissaContainer.decode(CUnsignedShort.self)
 
-        self.init(_exponent: exponent,
-                  _length: length,
-                  _isNegative: CUnsignedInt(isNegative ? 1 : 0),
-                  _isCompact: CUnsignedInt(isCompact ? 1 : 0),
-                  _reserved: 0,
-                  _mantissa: mantissa)
+        self = Decimal(_exponent: exponent,
+                       _length: length,
+                       _isNegative: CUnsignedInt(isNegative ? 1 : 0),
+                       _isCompact: CUnsignedInt(isCompact ? 1 : 0),
+                       _reserved: 0,
+                       _mantissa: mantissa)
     }
 
     public func encode(to encoder: Encoder) throws {
+        // FIXME: This is a hook for bypassing a conditional conformance implementation to apply a strategy (see SR-5206). Remove this once conditional conformance is available.
+        // We are allowed to request this container as long as we don't encode anything through it when we need the keyed container below.
+        var singleValueContainer = encoder.singleValueContainer()
+        if singleValueContainer is _JSONEncoder {
+            // _JSONEncoder has a hook for Decimals; this won't recurse since we're not going to defer to Decimal in _JSONEncoder.
+            try singleValueContainer.encode(self)
+            return
+        }
+
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(_exponent, forKey: .exponent)
         try container.encode(_length, forKey: .length)

--- a/stdlib/public/SDK/Foundation/JSONEncoder.swift
+++ b/stdlib/public/SDK/Foundation/JSONEncoder.swift
@@ -99,7 +99,7 @@ open class JSONEncoder {
     open var userInfo: [CodingUserInfoKey : Any] = [:]
 
     /// Options set on the top-level encoder to pass down the encoding hierarchy.
-    fileprivate struct _Options {
+    internal struct _Options {
         let dateEncodingStrategy: DateEncodingStrategy
         let dataEncodingStrategy: DataEncodingStrategy
         let nonConformingFloatEncodingStrategy: NonConformingFloatEncodingStrategy
@@ -155,14 +155,14 @@ open class JSONEncoder {
 
 // MARK: - _JSONEncoder
 
-fileprivate class _JSONEncoder : Encoder {
+internal class _JSONEncoder : Encoder {
     // MARK: Properties
 
     /// The encoder's storage.
     fileprivate var storage: _JSONEncodingStorage
 
     /// Options set on the top-level encoder.
-    fileprivate let options: JSONEncoder._Options
+    internal let options: JSONEncoder._Options
 
     /// The path to the current point in encoding.
     public var codingPath: [CodingKey]
@@ -864,7 +864,7 @@ open class JSONDecoder {
     open var userInfo: [CodingUserInfoKey : Any] = [:]
 
     /// Options set on the top-level encoder to pass down the decoding hierarchy.
-    fileprivate struct _Options {
+    internal struct _Options {
         let dateDecodingStrategy: DateDecodingStrategy
         let dataDecodingStrategy: DataDecodingStrategy
         let nonConformingFloatDecodingStrategy: NonConformingFloatDecodingStrategy
@@ -908,14 +908,14 @@ open class JSONDecoder {
 
 // MARK: - _JSONDecoder
 
-fileprivate class _JSONDecoder : Decoder {
+internal class _JSONDecoder : Decoder {
     // MARK: Properties
 
     /// The decoder's storage.
     fileprivate var storage: _JSONDecodingStorage
 
     /// Options set on the top-level decoder.
-    fileprivate let options: JSONDecoder._Options
+    internal let options: JSONDecoder._Options
 
     /// The path to the current point in encoding.
     private(set) public var codingPath: [CodingKey]

--- a/stdlib/public/SDK/Foundation/URL.swift
+++ b/stdlib/public/SDK/Foundation/URL.swift
@@ -1214,6 +1214,17 @@ extension URL : Codable {
     }
 
     public init(from decoder: Decoder) throws {
+        // FIXME: This is a hook for bypassing a conditional conformance implementation to apply a strategy (see SR-5206). Remove this once conditional conformance is available.
+        do {
+            // We are allowed to request this container as long as we don't decode anything through it when we need the keyed container below.
+            let singleValueContainer = try decoder.singleValueContainer()
+            if singleValueContainer is _JSONDecoder {
+                // _JSONDecoder has a hook for URLs; this won't recurse since we're not going to defer back to URL in _JSONDecoder.
+                self = try singleValueContainer.decode(URL.self)
+                return
+            }
+        } catch { /* Fall back to default implementation below. */ }
+
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let relative = try container.decode(String.self, forKey: .relative)
         let base = try container.decodeIfPresent(URL.self, forKey: .base)
@@ -1227,6 +1238,15 @@ extension URL : Codable {
     }
 
     public func encode(to encoder: Encoder) throws {
+        // FIXME: This is a hook for bypassing a conditional conformance implementation to apply a strategy (see SR-5206). Remove this once conditional conformance is available.
+        // We are allowed to request this container as long as we don't encode anything through it when we need the keyed container below.
+        var singleValueContainer = encoder.singleValueContainer()
+        if singleValueContainer is _JSONEncoder {
+            // _JSONEncoder has a hook for URLs; this won't recurse since we're not going to defer back to URL in _JSONEncoder.
+            try singleValueContainer.encode(self)
+            return
+        }
+
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(self.relativeString, forKey: .relative)
         if let base = self.baseURL {

--- a/test/stdlib/TestJSONEncoder.swift
+++ b/test/stdlib/TestJSONEncoder.swift
@@ -136,6 +136,9 @@ class TestJSONEncoder : TestJSONEncoderSuper {
   func testEncodingDate() {
     // We can't encode a top-level Date, so it'll be wrapped in a dictionary.
     _testRoundTrip(of: TopLevelWrapper(Date()))
+
+    // Optional dates should encode the same way.
+    _testRoundTrip(of: OptionalTopLevelWrapper(Date()))
   }
 
   func testEncodingDateSecondsSince1970() {
@@ -148,6 +151,12 @@ class TestJSONEncoder : TestJSONEncoderSuper {
                    expectedJSON: expectedJSON,
                    dateEncodingStrategy: .secondsSince1970,
                    dateDecodingStrategy: .secondsSince1970)
+
+    // Optional dates should encode the same way.
+    _testRoundTrip(of: OptionalTopLevelWrapper(Date(timeIntervalSince1970: seconds)),
+                   expectedJSON: expectedJSON,
+                   dateEncodingStrategy: .secondsSince1970,
+                   dateDecodingStrategy: .secondsSince1970)
   }
 
   func testEncodingDateMillisecondsSince1970() {
@@ -157,6 +166,12 @@ class TestJSONEncoder : TestJSONEncoderSuper {
 
     // We can't encode a top-level Date, so it'll be wrapped in a dictionary.
     _testRoundTrip(of: TopLevelWrapper(Date(timeIntervalSince1970: seconds)),
+                   expectedJSON: expectedJSON,
+                   dateEncodingStrategy: .millisecondsSince1970,
+                   dateDecodingStrategy: .millisecondsSince1970)
+
+    // Optional dates should encode the same way.
+    _testRoundTrip(of: OptionalTopLevelWrapper(Date(timeIntervalSince1970: seconds)),
                    expectedJSON: expectedJSON,
                    dateEncodingStrategy: .millisecondsSince1970,
                    dateDecodingStrategy: .millisecondsSince1970)
@@ -175,6 +190,13 @@ class TestJSONEncoder : TestJSONEncoderSuper {
                      expectedJSON: expectedJSON,
                      dateEncodingStrategy: .iso8601,
                      dateDecodingStrategy: .iso8601)
+
+
+      // Optional dates should encode the same way.
+      _testRoundTrip(of: OptionalTopLevelWrapper(timestamp),
+                     expectedJSON: expectedJSON,
+                     dateEncodingStrategy: .iso8601,
+                     dateDecodingStrategy: .iso8601)
     }
   }
 
@@ -188,6 +210,12 @@ class TestJSONEncoder : TestJSONEncoderSuper {
 
     // We can't encode a top-level Date, so it'll be wrapped in a dictionary.
     _testRoundTrip(of: TopLevelWrapper(timestamp),
+                   expectedJSON: expectedJSON,
+                   dateEncodingStrategy: .formatted(formatter),
+                   dateDecodingStrategy: .formatted(formatter))
+
+    // Optional dates should encode the same way.
+    _testRoundTrip(of: OptionalTopLevelWrapper(timestamp),
                    expectedJSON: expectedJSON,
                    dateEncodingStrategy: .formatted(formatter),
                    dateDecodingStrategy: .formatted(formatter))
@@ -209,6 +237,12 @@ class TestJSONEncoder : TestJSONEncoderSuper {
                    expectedJSON: expectedJSON,
                    dateEncodingStrategy: .custom(encode),
                    dateDecodingStrategy: .custom(decode))
+
+    // Optional dates should encode the same way.
+    _testRoundTrip(of: OptionalTopLevelWrapper(timestamp),
+                   expectedJSON: expectedJSON,
+                   dateEncodingStrategy: .custom(encode),
+                   dateDecodingStrategy: .custom(decode))
   }
 
   func testEncodingDateCustomEmpty() {
@@ -224,6 +258,12 @@ class TestJSONEncoder : TestJSONEncoderSuper {
                    expectedJSON: expectedJSON,
                    dateEncodingStrategy: .custom(encode),
                    dateDecodingStrategy: .custom(decode))
+
+    // Optional dates should encode the same way.
+    _testRoundTrip(of: OptionalTopLevelWrapper(timestamp),
+                   expectedJSON: expectedJSON,
+                   dateEncodingStrategy: .custom(encode),
+                   dateDecodingStrategy: .custom(decode))
   }
 
   // MARK: - Data Strategy Tests
@@ -236,17 +276,26 @@ class TestJSONEncoder : TestJSONEncoderSuper {
                    expectedJSON: expectedJSON,
                    dataEncodingStrategy: .deferredToData,
                    dataDecodingStrategy: .deferredToData)
+
+    // Optional data should encode the same way.
+    _testRoundTrip(of: OptionalTopLevelWrapper(data),
+                   expectedJSON: expectedJSON,
+                   dataEncodingStrategy: .deferredToData,
+                   dataDecodingStrategy: .deferredToData)
   }
 
-  func testEncodingBase64Data() {
+  func testEncodingDataBase64() {
     let data = Data(bytes: [0xDE, 0xAD, 0xBE, 0xEF])
 
     // We can't encode a top-level Data, so it'll be wrapped in a dictionary.
     let expectedJSON = "{\"value\":\"3q2+7w==\"}".data(using: .utf8)!
     _testRoundTrip(of: TopLevelWrapper(data), expectedJSON: expectedJSON)
+
+    // Optional data should encode the same way.
+    _testRoundTrip(of: OptionalTopLevelWrapper(data), expectedJSON: expectedJSON)
   }
 
-  func testEncodingCustomData() {
+  func testEncodingDataCustom() {
     // We'll encode a number instead of data.
     let encode = { (_ data: Data, _ encoder: Encoder) throws -> Void in
       var container = encoder.singleValueContainer()
@@ -260,9 +309,15 @@ class TestJSONEncoder : TestJSONEncoderSuper {
                    expectedJSON: expectedJSON,
                    dataEncodingStrategy: .custom(encode),
                    dataDecodingStrategy: .custom(decode))
+
+    // Optional data should encode the same way.
+    _testRoundTrip(of: OptionalTopLevelWrapper(Data()),
+                   expectedJSON: expectedJSON,
+                   dataEncodingStrategy: .custom(encode),
+                   dataDecodingStrategy: .custom(decode))
   }
 
-  func testEncodingCustomDataEmpty() {
+  func testEncodingDataCustomEmpty() {
     // Encoding nothing should encode an empty keyed container ({}).
     let encode = { (_: Data, _: Encoder) throws -> Void in }
     let decode = { (_: Decoder) throws -> Data in return Data() }
@@ -270,6 +325,12 @@ class TestJSONEncoder : TestJSONEncoderSuper {
     // We can't encode a top-level Data, so it'll be wrapped in a dictionary.
     let expectedJSON = "{\"value\":{}}".data(using: .utf8)!
     _testRoundTrip(of: TopLevelWrapper(Data()),
+                   expectedJSON: expectedJSON,
+                   dataEncodingStrategy: .custom(encode),
+                   dataDecodingStrategy: .custom(decode))
+
+    // Optional Data should encode the same way.
+    _testRoundTrip(of: OptionalTopLevelWrapper(Data()),
                    expectedJSON: expectedJSON,
                    dataEncodingStrategy: .custom(encode),
                    dataDecodingStrategy: .custom(decode))
@@ -284,12 +345,20 @@ class TestJSONEncoder : TestJSONEncoderSuper {
     _testEncodeFailure(of: TopLevelWrapper(Double.infinity))
     _testEncodeFailure(of: TopLevelWrapper(-Double.infinity))
     _testEncodeFailure(of: TopLevelWrapper(Double.nan))
+
+    // Optional Floats/Doubles should encode the same way.
+    _testEncodeFailure(of: OptionalTopLevelWrapper(Float.infinity))
+    _testEncodeFailure(of: OptionalTopLevelWrapper(-Float.infinity))
+    _testEncodeFailure(of: OptionalTopLevelWrapper(Float.nan))
+
+    _testEncodeFailure(of: OptionalTopLevelWrapper(Double.infinity))
+    _testEncodeFailure(of: OptionalTopLevelWrapper(-Double.infinity))
+    _testEncodeFailure(of: OptionalTopLevelWrapper(Double.nan))
   }
 
   func testEncodingNonConformingFloatStrings() {
     let encodingStrategy: JSONEncoder.NonConformingFloatEncodingStrategy = .convertToString(positiveInfinity: "INF", negativeInfinity: "-INF", nan: "NaN")
     let decodingStrategy: JSONDecoder.NonConformingFloatDecodingStrategy = .convertFromString(positiveInfinity: "INF", negativeInfinity: "-INF", nan: "NaN")
-
 
     _testRoundTrip(of: TopLevelWrapper(Float.infinity),
                    expectedJSON: "{\"value\":\"INF\"}".data(using: .utf8)!,
@@ -320,6 +389,24 @@ class TestJSONEncoder : TestJSONEncoderSuper {
                    expectedJSON: "{\"value\":\"NaN\"}".data(using: .utf8)!,
                    nonConformingFloatEncodingStrategy: encodingStrategy,
                    nonConformingFloatDecodingStrategy: decodingStrategy)
+
+    // Optional Floats and Doubles should encode the same way.
+    _testRoundTrip(of: OptionalTopLevelWrapper(Float.infinity),
+                   expectedJSON: "{\"value\":\"INF\"}".data(using: .utf8)!,
+                   nonConformingFloatEncodingStrategy: encodingStrategy,
+                   nonConformingFloatDecodingStrategy: decodingStrategy)
+    _testRoundTrip(of: OptionalTopLevelWrapper(-Float.infinity),
+                   expectedJSON: "{\"value\":\"-INF\"}".data(using: .utf8)!,
+                   nonConformingFloatEncodingStrategy: encodingStrategy,
+                   nonConformingFloatDecodingStrategy: decodingStrategy)
+    _testRoundTrip(of: OptionalTopLevelWrapper(Double.infinity),
+                   expectedJSON: "{\"value\":\"INF\"}".data(using: .utf8)!,
+                   nonConformingFloatEncodingStrategy: encodingStrategy,
+                   nonConformingFloatDecodingStrategy: decodingStrategy)
+    _testRoundTrip(of: OptionalTopLevelWrapper(-Double.infinity),
+                   expectedJSON: "{\"value\":\"-INF\"}".data(using: .utf8)!,
+                   nonConformingFloatEncodingStrategy: encodingStrategy,
+                   nonConformingFloatDecodingStrategy: decodingStrategy)
   }
 
   // MARK: - Encoder Features
@@ -348,6 +435,9 @@ class TestJSONEncoder : TestJSONEncoderSuper {
     // 1e127 is too big to fit natively in a Double, too, so want to make sure it's encoded as a Decimal.
     let decimal = Decimal(sign: .plus, exponent: 127, significand: Decimal(1))
     _testRoundTrip(of: TopLevelWrapper(decimal), expectedJSON: expectedJSON)
+
+    // Optional Decimals should encode the same way.
+    _testRoundTrip(of: OptionalTopLevelWrapper(decimal), expectedJSON: expectedJSON)
   }
 
   func testInterceptURL() {
@@ -355,6 +445,9 @@ class TestJSONEncoder : TestJSONEncoderSuper {
     let expectedJSON = "{\"value\":\"http:\\/\\/swift.org\"}".data(using: .utf8)!
     let url = URL(string: "http://swift.org")!
     _testRoundTrip(of: TopLevelWrapper(url), expectedJSON: expectedJSON)
+
+    // Optional URLs should encode the same way.
+    _testRoundTrip(of: OptionalTopLevelWrapper(url), expectedJSON: expectedJSON)
   }
 
   // MARK: - Helper Functions
@@ -867,6 +960,34 @@ fileprivate struct TopLevelWrapper<T> : Codable, Equatable where T : Codable, T 
   }
 }
 
+/// Wraps a type T (as T?) so that it can be encoded at the top level of a payload.
+fileprivate struct OptionalTopLevelWrapper<T> : Codable, Equatable where T : Codable, T : Equatable {
+  let value: T?
+
+  init(_ value: T) {
+    self.value = value
+  }
+
+  // Provide an implementation of Codable to encode(forKey:) instead of encodeIfPresent(forKey:).
+  private enum CodingKeys : String, CodingKey {
+    case value
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    value = try container.decode(T?.self, forKey: .value)
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(value, forKey: .value)
+  }
+
+  static func ==(_ lhs: OptionalTopLevelWrapper<T>, _ rhs: OptionalTopLevelWrapper<T>) -> Bool {
+    return lhs.value == rhs.value
+  }
+}
+
 fileprivate struct FloatNaNPlaceholder : Codable, Equatable {
   init() {}
 
@@ -937,9 +1058,9 @@ JSONEncoderTests.test("testEncodingDateFormatted") { TestJSONEncoder().testEncod
 JSONEncoderTests.test("testEncodingDateCustom") { TestJSONEncoder().testEncodingDateCustom() }
 JSONEncoderTests.test("testEncodingDateCustomEmpty") { TestJSONEncoder().testEncodingDateCustomEmpty() }
 JSONEncoderTests.test("testEncodingData") { TestJSONEncoder().testEncodingData() }
-JSONEncoderTests.test("testEncodingBase64Data") { TestJSONEncoder().testEncodingBase64Data() }
-JSONEncoderTests.test("testEncodingCustomData") { TestJSONEncoder().testEncodingCustomData() }
-JSONEncoderTests.test("testEncodingCustomDataEmpty") { TestJSONEncoder().testEncodingCustomDataEmpty() }
+JSONEncoderTests.test("testEncodingDataBase64") { TestJSONEncoder().testEncodingDataBase64() }
+JSONEncoderTests.test("testEncodingDataCustom") { TestJSONEncoder().testEncodingDataCustom() }
+JSONEncoderTests.test("testEncodingDataCustomEmpty") { TestJSONEncoder().testEncodingDataCustomEmpty() }
 JSONEncoderTests.test("testEncodingNonConformingFloats") { TestJSONEncoder().testEncodingNonConformingFloats() }
 JSONEncoderTests.test("testEncodingNonConformingFloatStrings") { TestJSONEncoder().testEncodingNonConformingFloatStrings() }
 JSONEncoderTests.test("testNestedContainerCodingPaths") { TestJSONEncoder().testNestedContainerCodingPaths() }


### PR DESCRIPTION
**What's in this pull request?**
Addresses [SR-5206](https://bugs.swift.org/browse/SR-5206) for `JSONEncoder` and `JSONDecoder`.

One of the limitations of not having conditional conformance at the moment is that the implementation of `init(from:)` and `encode(to:)` on types which require it is that failure to cast dependent types to `Encodable` or `Decodable` is a runtime failure. There is no way to statically guarantee that the wrapped type is `Encodable` or `Decodable`.

As such, in those implementations, at best we can directly call `(element as! Encodable).encode(to: encoder)`, or similar. However, this encodes the element directly into an encoder, without giving the encoder a chance to intercept the type. This is problematic for `JSONEncoder` because it cannot apply a strategy if it doesn't get to intercept the type.

This gives a temporary workaround for JSON strategies because of internal Foundation knowledge.