### PR TITLE
[Gardening] Import the value of a subscript setter as owned

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -1501,7 +1501,7 @@ static FuncDecl *buildSubscriptSetterDecl(ClangImporter::Implementation &Impl,
   auto elementTy = dc->mapTypeIntoContext(elementInterfaceTy);
 
   auto paramVarDecl =
-      new (C) ParamDecl(VarDecl::Specifier::InOut, SourceLoc(), SourceLoc(),
+      new (C) ParamDecl(VarDecl::Specifier::Owned, SourceLoc(), SourceLoc(),
                         Identifier(), loc, valueIndex->get(0)->getName(),
                         elementTy, dc);
   paramVarDecl->setInterfaceType(elementInterfaceTy);


### PR DESCRIPTION
The translation from a bit to the specifiers exposed this instance
in the Clang importer where we hooked up a parameter as mutable
but never reflected that in the interface type.

A future patch requires that this parameter be immutable.

Depends on #10767