### PR TITLE
[swift-4.0-branch] Fix warnings in DispatchQueue.sync() implementation when using a comp…

### DIFF
--- a/stdlib/public/SDK/Dispatch/Queue.swift
+++ b/stdlib/public/SDK/Dispatch/Queue.swift
@@ -232,11 +232,13 @@ public extension DispatchQueue {
 	{
 		var result: T?
 		var error: Error?
-		fn {
-			do {
-				result = try work()
-			} catch let e {
-				error = e
+		withoutActuallyEscaping(work) { _work in
+			fn {
+				do {
+					result = try _work()
+				} catch let e {
+					error = e
+				}
 			}
 		}
 		if let e = error {

--- a/test/stdlib/Dispatch.swift
+++ b/test/stdlib/Dispatch.swift
@@ -40,6 +40,13 @@ DispatchAPI.test("DispatchGroup creation") {
   expectNotNil(group)
 }
 
+DispatchAPI.test("Dispatch sync return value") {
+  let value = 24;
+  let q = DispatchQueue(label: "Test")
+  let result = q.sync() { return 24 }
+  expectEqual(value, result)
+}
+
 DispatchAPI.test("dispatch_block_t conversions") {
   var counter = 0
   let closure = { () -> Void in


### PR DESCRIPTION
…iler with SE-0176 support.

Explanation: This change fixes a warning in the Swift overlay for dispatch that was introduced by the compiler changes for SE-0176. It’s needed in Tioga so that the warning can be promoted to an error.
Scope of Issue: The change is internal to the dispatch overlay and will have no effect on developers or library users.
Risk: Since the effect is only to remove a compiler warning and the change is covered by the test suite, this is low risk.
Reviewed By: Daniel Steffen (das@apple.com)
Testing: There are tests in the Dispatch test suite that cover this code change.
Directions for QA: N/A
Radar: rdar://problem/33141772