### PR TITLE
Sema: Simplifying a KeyPathExpr's type should *bind* to the specific type, not accept a subtype constraint.

### DIFF
--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -336,8 +336,20 @@ func testKeyPathOptional() {
   _ = \AA.c!.i
 }
 
+func testLiteralInAnyContext() {
+  let _: AnyKeyPath = \A.property
+  let _: AnyObject = \A.property
+  let _: Any = \A.property
+  let _: Any? = \A.property
+}
+
+func testMoreGeneralContext<T, U>(_: KeyPath<T, U>, with: T.Type) {}
+
+func testLiteralInMoreGeneralContext() {
+  testMoreGeneralContext(\.property, with: A.self)
+}
+
 func testSyntaxErrors() { // expected-note{{}}
-  // TODO: recovery
   _ = \.  ; // expected-error{{expected member name following '.'}}
   _ = \.a ;
   _ = \[a ;


### PR DESCRIPTION
We want the type of a KeyPathExpr to be the specific *KeyPath<T, U> subclass appropriate for the literal, with upcasts to a more general contextual type, since we rely on that invariant elsewhere to extract the base and projected value types. Fixes SR-5008 | rdar://problem/32395076.