### PR TITLE
[4.0] Sema: Simplifying a KeyPathExpr's type should *bind* to the specific type, not accept a subtype constraint.

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3841,7 +3841,8 @@ ConstraintSystem::simplifyKeyPathConstraint(Type keyPathTy,
   // If we're fixed to a bound generic type, trying harvesting context from it.
   // However, we don't want a solution that fixes the expression type to
   // PartialKeyPath; we'd rather that be represented using an upcast conversion.
-  if (auto keyPathBGT = keyPathTy->getAs<BoundGenericType>()) {
+  auto keyPathBGT = keyPathTy->getAs<BoundGenericType>();
+  if (keyPathBGT) {
     if (tryMatchRootAndValueFromKeyPathType(keyPathBGT, /*allowPartial*/false)
           == SolutionKind::Error)
       return SolutionKind::Error;
@@ -3939,9 +3940,19 @@ done:
     break;
   }
   
+  // FIXME: Allow the type to be upcast if the type system has a concrete
+  // KeyPath type assigned to the expression already.
+  if (keyPathBGT) {
+    if (keyPathBGT->getDecl() == getASTContext().getKeyPathDecl())
+      kpDecl = getASTContext().getKeyPathDecl();
+    else if (keyPathBGT->getDecl() == getASTContext().getWritableKeyPathDecl()
+             && capability >= Writable)
+      kpDecl = getASTContext().getWritableKeyPathDecl();
+  }
+  
   auto resolvedKPTy = BoundGenericType::get(kpDecl, nullptr,
                                             {rootTy, valueTy});
-  return matchTypes(resolvedKPTy, keyPathTy, ConstraintKind::Subtype,
+  return matchTypes(resolvedKPTy, keyPathTy, ConstraintKind::Bind,
                     subflags, locator);
 }
 

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -336,8 +336,20 @@ func testKeyPathOptional() {
   _ = \AA.c!.i
 }
 
+func testLiteralInAnyContext() {
+  let _: AnyKeyPath = \A.property
+  let _: AnyObject = \A.property
+  let _: Any = \A.property
+  let _: Any? = \A.property
+}
+
+func testMoreGeneralContext<T, U>(_: KeyPath<T, U>, with: T.Type) {}
+
+func testLiteralInMoreGeneralContext() {
+  testMoreGeneralContext(\.property, with: A.self)
+}
+
 func testSyntaxErrors() { // expected-note{{}}
-  // TODO: recovery
   _ = \.  ; // expected-error{{expected member name following '.'}}
   _ = \.a ;
   _ = \[a ;


### PR DESCRIPTION
Explanation: The compiler would crash when a key path literal was used in an expression with `Any` or `AnyObject` contextual type.

Scope: Affects users trying to `print` key paths or use them in `Mirror`s.

Issue: SR-5008 | rdar://problem/32395076.

Risk: Low, only impacts key paths.

Testing: Swift CI