### PR TITLE
Hack: allow dropping noescape-ness when overriding ObjC methods

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -234,6 +234,11 @@ enum class TypeMatchFlags {
   AllowTopLevelOptionalMismatch = 1 << 2,
   /// Allow any ABI-compatible types to be considered matching.
   AllowABICompatible = 1 << 3,
+  /// Allow escaping function parameters to override optional non-escaping ones.
+  ///
+  /// This is necessary because Objective-C allows optional function paramaters
+  /// to be non-escaping, but Swift currently does not.
+  IgnoreNonEscapingForOptionalFunctionParam = 1 << 4
 };
 using TypeMatchOptions = OptionSet<TypeMatchFlags>;
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -5823,6 +5823,8 @@ public:
           matchMode |= TypeMatchFlags::AllowTopLevelOptionalMismatch;
         } else if (parentDecl->isObjC()) {
           matchMode |= TypeMatchFlags::AllowNonOptionalForIUOParam;
+          matchMode |=
+              TypeMatchFlags::IgnoreNonEscapingForOptionalFunctionParam;
         }
 
         if (declTy->matches(parentDeclTy, matchMode, &TC)) {

--- a/test/ClangImporter/Inputs/custom-modules/ObjCParseExtras.h
+++ b/test/ClangImporter/Inputs/custom-modules/ObjCParseExtras.h
@@ -187,6 +187,13 @@ typedef SomeCell <NSCopying> *CopyableSomeCell;
 + (BOOL)processValueAndReturnError:(NSError **)error;
 @end
 
+@interface CallbackBase : NSObject
+- (void)performWithHandler:(void(^ _Nonnull)(void))handler;
+- (void)performWithOptHandler:(void(^ _Nullable)(void))handler;
+- (void)performWithNonescapingHandler:(void(__attribute__((noescape)) ^ _Nonnull)(void))handler;
+- (void)performWithOptNonescapingHandler:(void(__attribute__((noescape)) ^ _Nullable)(void))handler;
+@end
+
 @interface SelectorSplittingAccessors : NSObject
 // Note the custom setter name here; this is important.
 @property (setter=takeFooForBar:) BOOL fooForBar;

--- a/test/ClangImporter/objc_override.swift
+++ b/test/ClangImporter/objc_override.swift
@@ -88,6 +88,26 @@ class FailSub : FailBase {
   override class func processValue() {} // expected-error {{overriding a throwing @objc method with a non-throwing method is not supported}}
 }
 
+class CallbackSubA : CallbackBase {
+  override func perform(handler: () -> Void) {} // expected-error {{method does not override any method from its superclass}}
+  // expected-note@-1 {{type does not match superclass instance method with type '(@escaping () -> Void) -> Void'}}
+  override func perform(optHandler: () -> Void) {} // expected-error {{method does not override any method from its superclass}}
+  override func perform(nonescapingHandler: () -> Void) {}
+  override func perform(optNonescapingHandler: () -> Void) {} // expected-error {{cannot override instance method parameter of type '(() -> Void)?' with non-optional type '() -> Void'}}
+}
+class CallbackSubB : CallbackBase {
+  override func perform(handler: (() -> Void)?) {}
+  override func perform(optHandler: (() -> Void)?) {}
+  override func perform(nonescapingHandler: (() -> Void)?) {} // expected-error {{method does not override any method from its superclass}}
+  override func perform(optNonescapingHandler: (() -> Void)?) {}
+}
+class CallbackSubC : CallbackBase {
+  override func perform(handler: @escaping () -> Void) {}
+  override func perform(optHandler: @escaping () -> Void) {} // expected-error {{cannot override instance method parameter of type '(() -> Void)?' with non-optional type '() -> Void'}}
+  override func perform(nonescapingHandler: @escaping () -> Void) {} // expected-error {{method does not override any method from its superclass}}
+  override func perform(optNonescapingHandler: @escaping () -> Void) {} // expected-error {{method does not override any method from its superclass}}
+}
+
 // FIXME: Remove -verify-ignore-unknown.
 // <unknown>:0: error: unexpected note produced: overridden declaration is here
 // <unknown>:0: error: unexpected note produced: setter for 'boolProperty' declared here

--- a/test/decl/class/override.swift
+++ b/test/decl/class/override.swift
@@ -304,3 +304,29 @@ class GenericSubscriptDerived : GenericSubscriptBase {
     }
   }
 }
+
+
+// @escaping
+
+class CallbackBase {
+  func perform(handler: @escaping () -> Void) {} // expected-note * {{here}}
+  func perform(optHandler: (() -> Void)?) {} // expected-note * {{here}}
+  func perform(nonescapingHandler: () -> Void) {} // expected-note * {{here}}
+}
+class CallbackSubA: CallbackBase {
+  override func perform(handler: () -> Void) {} // expected-error {{method does not override any method from its superclass}}
+  // expected-note@-1 {{type does not match superclass instance method with type '(@escaping () -> Void) -> ()'}}
+  override func perform(optHandler: () -> Void) {} // expected-error {{method does not override any method from its superclass}}
+  override func perform(nonescapingHandler: () -> Void) {}
+}
+class CallbackSubB : CallbackBase {
+  override func perform(handler: (() -> Void)?) {}
+  override func perform(optHandler: (() -> Void)?) {}
+  override func perform(nonescapingHandler: (() -> Void)?) {} // expected-error {{method does not override any method from its superclass}}
+}
+class CallbackSubC : CallbackBase {
+  override func perform(handler: @escaping () -> Void) {}
+  override func perform(optHandler: @escaping () -> Void) {} // expected-error {{cannot override instance method parameter of type '(() -> Void)?' with non-optional type '() -> Void'}}
+  override func perform(nonescapingHandler: @escaping () -> Void) {} // expected-error {{method does not override any method from its superclass}}
+}
+


### PR DESCRIPTION
In today's Swift, only non-optional function parameters can be non-escaping (and are by default). An optional function parameter uses a function type as a generic argument to Optional, and like any other generics that's considered an opaque and therefore possibly escaping use of the type. This is certainly unfortunate since it means a function parameter cannot be both Optional and non-escaping.

However, this "unfortunate" becomes a concrete problem when dealing with Objective-C, which *does* allow applying its `noescape` attribute to a callback block marked `nullable`. This is fine for *uses* of methods with such parameters, but prevents anyone from *overriding* these methods.

This patch pokes a very narrow hole into the override checking to accomodate this: if a declaration comes from Objective-C, and it has an optional, non-escaping closure parameter, it's okay to override it in Swift with an optional, escaping closure parameter. This isn't strictly safe because a caller could be relying on the non-escaping-ness, but we don't have anything better for now. (This behavior will probably be deprecated in the future.)

(Some people have noted that the old `noescape` type attribute in Swift still works, albeit with a warning. That's not something people should have to type, though—we want to remove it from the language, as described in [SE-0103](https://github.com/apple/swift-evolution/blob/master/proposals/0103-make-noescape-default.md).)

rdar://problem/32903155