### PR TITLE
[gardening] Fix broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ work with other SDKs, you'll need to create a second build using Ninja.
 
 ## Testing Swift
 
-See [docs/Testing.rst](docs/Testing.rst).
+See [docs/Testing.md](docs/Testing.md).
 
 ## Contributing to Swift
 


### PR DESCRIPTION
This PR fixes a broken link in the README file; briefly, `docs/Testing.rst` was converted to Markdown at some point in the past, but the corresponding link was not updated to reflect that change.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
