### PR TITLE
SIL pass names. Allow command line options to specific the pass tag.

### DIFF
--- a/include/swift/SILOptimizer/PassManager/Transforms.h
+++ b/include/swift/SILOptimizer/PassManager/Transforms.h
@@ -75,6 +75,12 @@ namespace swift {
     /// Get the name of the transform.
     llvm::StringRef getName() { return PassKindName(getPassKind()); }
 
+    /// Get the transform's (command-line) tag.
+    llvm::StringRef getTag() { return PassKindTag(getPassKind()); }
+
+    /// Get the transform's name as a C++ identifier.
+    llvm::StringRef getID() { return PassKindID(getPassKind()); }
+
   protected:
     /// \brief Searches for an analysis of type T in the list of registered
     /// analysis. If the analysis is not found, the program terminates.

--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -137,7 +137,9 @@ static bool doPrintBefore(SILTransform *T, SILFunction *F) {
     return false;
 
   auto MatchFun = [&](const std::string &Str) -> bool {
-    return T->getName().find(Str) != StringRef::npos;
+    return T->getName().find(Str) != StringRef::npos
+      || T->getTag().find(Str) != StringRef::npos
+      || T->getID().find(Str) != StringRef::npos;
   };
 
   if (SILPrintBefore.end() !=
@@ -160,7 +162,9 @@ static bool doPrintAfter(SILTransform *T, SILFunction *F, bool Default) {
     return false;
 
   auto MatchFun = [&](const std::string &Str) -> bool {
-    return T->getName().find(Str) != StringRef::npos;
+    return T->getName().find(Str) != StringRef::npos
+      || T->getTag().find(Str) != StringRef::npos
+      || T->getID().find(Str) != StringRef::npos;
   };
 
   if (SILPrintAfter.end() !=
@@ -176,8 +180,11 @@ static bool doPrintAfter(SILTransform *T, SILFunction *F, bool Default) {
 
 static bool isDisabled(SILTransform *T) {
   for (const std::string &NamePattern : SILDisablePass) {
-    if (T->getName().find(NamePattern) != StringRef::npos)
+    if (T->getName().find(NamePattern) != StringRef::npos
+        || T->getTag().find(NamePattern) != StringRef::npos
+        || T->getID().find(NamePattern) != StringRef::npos) {
       return true;
+    }
   }
   return false;
 }
@@ -263,17 +270,19 @@ bool SILPassManager::analysesUnlocked() {
 // Test the function and pass names we're given against the debug
 // options that force us to break prior to a given pass and/or on a
 // given function.
-static bool breakBeforeRunning(StringRef fnName, StringRef passName) {
+static bool breakBeforeRunning(StringRef fnName, SILFunctionTransform *SFT) {
   if (SILBreakOnFun.empty() && SILBreakOnPass.empty())
     return false;
 
-  if (SILBreakOnFun.empty() && passName == SILBreakOnPass)
+  if (SILBreakOnFun.empty()
+      && (SFT->getName() == SILBreakOnPass || SFT->getTag() == SILBreakOnPass))
     return true;
 
   if (SILBreakOnPass.empty() && fnName == SILBreakOnFun)
     return true;
 
-  return fnName == SILBreakOnFun && passName == SILBreakOnPass;
+  return fnName == SILBreakOnFun
+    && (SFT->getName() == SILBreakOnPass || SFT->getTag() == SILBreakOnPass);
 }
 
 void SILPassManager::runPassOnFunction(SILFunctionTransform *SFT,
@@ -294,7 +303,7 @@ void SILPassManager::runPassOnFunction(SILFunctionTransform *SFT,
       !SILDisableSkippingPasses) {
     if (SILPrintPassName)
       llvm::dbgs() << "  (Skip) Stage: " << StageName
-                   << " Pass: " << SFT->getName()
+                   << " Pass: " << SFT->getName() << " (" << SFT->getTag() << ")"
                    << ", Function: " << F->getName() << "\n";
     return;
   }
@@ -302,7 +311,7 @@ void SILPassManager::runPassOnFunction(SILFunctionTransform *SFT,
   if (isDisabled(SFT)) {
     if (SILPrintPassName)
       llvm::dbgs() << "  (Disabled) Stage: " << StageName
-                   << " Pass: " << SFT->getName()
+                   << " Pass: " << SFT->getName() << " (" << SFT->getTag() << ")"
                    << ", Function: " << F->getName() << "\n";
     return;
   }
@@ -311,19 +320,19 @@ void SILPassManager::runPassOnFunction(SILFunctionTransform *SFT,
 
   if (SILPrintPassName)
     llvm::dbgs() << "  #" << NumPassesRun << " Stage: " << StageName
-                 << " Pass: " << SFT->getName()
+                 << " Pass: " << SFT->getName() << " (" << SFT->getTag() << ")"
                  << ", Function: " << F->getName() << "\n";
 
   if (doPrintBefore(SFT, F)) {
     llvm::dbgs() << "*** SIL function before " << StageName << " "
-                 << SFT->getName() << " (" << NumOptimizationIterations
-                 << ") ***\n";
+                 << SFT->getName() << " (" << SFT->getTag() << ")"
+                 << " (#" << NumOptimizationIterations << ") ***\n";
     F->dump(getOptions().EmitVerboseSIL);
   }
 
   llvm::sys::TimePoint<> StartTime = std::chrono::system_clock::now();
   Mod->registerDeleteNotificationHandler(SFT);
-  if (breakBeforeRunning(F->getName(), SFT->getName()))
+  if (breakBeforeRunning(F->getName(), SFT))
     LLVM_BUILTIN_DEBUGTRAP;
   SFT->run();
   assert(analysesUnlocked() && "Expected all analyses to be unlocked!");
@@ -338,8 +347,8 @@ void SILPassManager::runPassOnFunction(SILFunctionTransform *SFT,
   // If this pass invalidated anything, print and verify.
   if (doPrintAfter(SFT, F, CurrentPassHasInvalidated && SILPrintAll)) {
     llvm::dbgs() << "*** SIL function after " << StageName << " "
-                 << SFT->getName() << " (" << NumOptimizationIterations
-                 << ") ***\n";
+                 << SFT->getName() << " (" << SFT->getTag() << ") (#"
+                 << NumOptimizationIterations << ") ***\n";
     F->dump(getOptions().EmitVerboseSIL);
   }
 
@@ -439,8 +448,8 @@ void SILPassManager::runModulePass(SILModuleTransform *SMT) {
 
   if (doPrintBefore(SMT, nullptr)) {
     llvm::dbgs() << "*** SIL module before " << StageName << " "
-                 << SMT->getName() << " (" << NumOptimizationIterations
-                 << ") ***\n";
+                 << SMT->getName() << " (" << SMT->getTag() << ") (#"
+                 << NumOptimizationIterations << ") ***\n";
     printModule(Mod, Options.EmitVerboseSIL);
   }
 
@@ -460,8 +469,8 @@ void SILPassManager::runModulePass(SILModuleTransform *SMT) {
   if (doPrintAfter(SMT, nullptr,
                    CurrentPassHasInvalidated && SILPrintAll)) {
     llvm::dbgs() << "*** SIL module after " << StageName << " "
-                 << SMT->getName() << " (" << NumOptimizationIterations
-                 << ") ***\n";
+                 << SMT->getName() << " (" << SMT->getTag() << ") (#"
+                 << NumOptimizationIterations << ") ***\n";
     printModule(Mod, Options.EmitVerboseSIL);
   }
 

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -591,7 +591,7 @@ void SILPassPipelinePlan::print(llvm::raw_ostream &os) {
                os << "        \"" << Pipeline.Name << "\"";
                for (PassKind Kind : getPipelinePasses(Pipeline)) {
                  os << ",\n        [\"" << PassKindID(Kind) << "\","
-                    << PassKindTag(Kind) << ']';
+                    << "\"" << PassKindTag(Kind) << "\"]";
                }
              },
              [&] { os << "\n    ],\n"; });

--- a/lib/SILOptimizer/PassManager/Passes.cpp
+++ b/lib/SILOptimizer/PassManager/Passes.cpp
@@ -167,7 +167,7 @@ StringRef swift::PassKindTag(PassKind Kind) {
   switch (Kind) {
 #define PASS(ID, TAG, NAME)                                                    \
   case PassKind::ID:                                                           \
-    return #TAG;
+    return TAG;
 #include "swift/SILOptimizer/PassManager/Passes.def"
   case PassKind::invalidPassKind:
     llvm_unreachable("Invalid pass kind?!");
@@ -182,7 +182,7 @@ StringRef swift::PassKindName(PassKind Kind) {
   switch (Kind) {
 #define PASS(ID, TAG, NAME)                                                    \
   case PassKind::ID:                                                           \
-    return #NAME;
+    return NAME;
 #include "swift/SILOptimizer/PassManager/Passes.def"
   case PassKind::invalidPassKind:
     llvm_unreachable("Invalid pass kind?!");

--- a/test/SILOptimizer/pass_printer.swift
+++ b/test/SILOptimizer/pass_printer.swift
@@ -1,0 +1,8 @@
+// RUN: %target-swift-frontend -Xllvm -sil-print-before=definite-init -emit-sil %s -o /dev/null 2>&1 | %FileCheck --check-prefix=BEFORE %s
+// RUN: %target-swift-frontend -Xllvm -sil-print-after=definite-init -emit-sil %s -o /dev/null 2>&1 | %FileCheck --check-prefix=AFTER %s
+// RUN: %target-swift-frontend -Xllvm -sil-disable-pass=definite-init -Xllvm -sil-print-pass-name -emit-sil %s -o /dev/null 2>&1 | %FileCheck --check-prefix=DISABLE %s
+
+// BEFORE: SIL function before Guaranteed Passes Definite Initialization for Diagnostics (definite-init) (#1)
+// AFTER: SIL function after Guaranteed Passes Definite Initialization for Diagnostics (definite-init) (#1)
+// DISABLE: (Disabled) Stage: Guaranteed Passes Pass: Definite Initialization for Diagnostics (definite-init)
+func foo() {}


### PR DESCRIPTION
A pass has an ID (C++ identifier), Tag (shell identifier),
and Name (human identifier).

Command line options that identify passes should obviously be compatibile with
with the pass' command line identifier. This is also what the user is used to
typing for the -debug-only option.