### PR TITLE
[silgen] Add support for creating guaranteed phi arguments.

### DIFF
--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -261,6 +261,12 @@ ManagedValue SILGenBuilder::createOwnedPHIArgument(SILType type) {
   return SGF.emitManagedRValueWithCleanup(arg);
 }
 
+ManagedValue SILGenBuilder::createGuaranteedPHIArgument(SILType type) {
+  SILPHIArgument *arg =
+      getInsertionBB()->createPHIArgument(type, ValueOwnershipKind::Guaranteed);
+  return SGF.emitManagedBorrowedArgumentWithCleanup(arg);
+}
+
 ManagedValue SILGenBuilder::createAllocRef(
     SILLocation loc, SILType refType, bool objc, bool canAllocOnStack,
     ArrayRef<SILType> inputElementTypes,

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -153,6 +153,7 @@ public:
   ManagedValue createUnsafeCopyUnownedValue(SILLocation loc,
                                             ManagedValue originalValue);
   ManagedValue createOwnedPHIArgument(SILType type);
+  ManagedValue createGuaranteedPHIArgument(SILType type);
 
   using SILBuilder::createMarkUninitialized;
   ManagedValue createMarkUninitialized(ValueDecl *decl, ManagedValue operand,

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1218,7 +1218,7 @@ public:
                                                     SILValue borrowedValue);
   ManagedValue emitManagedBorrowedRValueWithCleanup(
       SILValue original, SILValue borrowedValue, const TypeLowering &lowering);
-
+  ManagedValue emitManagedBorrowedArgumentWithCleanup(SILPHIArgument *arg);
   ManagedValue emitFormalEvaluationManagedBorrowedRValueWithCleanup(
       SILLocation loc, SILValue original, SILValue borrowedValue);
   ManagedValue emitFormalEvaluationManagedBorrowedRValueWithCleanup(


### PR DESCRIPTION
The main thing here is that we create a cleanup that inserts the
end_borrow_argument. Once I merge end_borrow with end_borrow_argument, there
will only be one cleanup.

rdar://31880847
