### PR TITLE
[stdlib] Silence a compiler warning [NFC]

### DIFF
--- a/stdlib/public/core/FixedArray.swift.gyb
+++ b/stdlib/public/core/FixedArray.swift.gyb
@@ -98,9 +98,9 @@ extension _FixedArray${N} : RandomAccessCollection, MutableCollection {
 
 }
 
-extension _FixedArray${N} where T: IntegerLiteralConvertible {
+extension _FixedArray${N} where T : ExpressibleByIntegerLiteral {
   @inline(__always)
-  internal init(allZeros:()) {
+  internal init(allZeros: ()) {
     self.storage = (
 % for i in range(0, N-1):
     0,


### PR DESCRIPTION
This PR updates `_FixedArray${N}` to conform to `ExpressibleByIntegerLiteral` rather than `IntegerLiteralConvertible`. This silences a compiler warning (actually, several).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
