### PR TITLE
[Driver] Remove built-in `run` subcommand

### DIFF
--- a/test/Driver/subcommands.swift
+++ b/test/Driver/subcommands.swift
@@ -1,4 +1,4 @@
-// Check that each of 'swift', 'swift repl', 'swift run' invoke the REPL.
+// Check that 'swift' and 'swift repl' invoke the REPL.
 //
 // REQUIRES: swift_interpreter
 //
@@ -7,7 +7,6 @@
 // RUN: %hardlink-or-copy(from: %swift_driver_plain, to: %t.dir/usr/bin/swift)
 
 // RUN: %t.dir/usr/bin/swift -### 2>&1 | %FileCheck -check-prefix=CHECK-SWIFT-INVOKES-REPL %s
-// RUN: %t.dir/usr/bin/swift run -### 2>&1 | %FileCheck -check-prefix=CHECK-SWIFT-INVOKES-REPL %s
 // RUN: %t.dir/usr/bin/swift repl -### 2>&1 | %FileCheck -check-prefix=CHECK-SWIFT-INVOKES-REPL %s
 //
 // CHECK-SWIFT-INVOKES-REPL: {{.*}}/swift -frontend -repl

--- a/tools/driver/driver.cpp
+++ b/tools/driver/driver.cpp
@@ -94,9 +94,9 @@ static bool shouldRunAsSubcommand(StringRef ExecName,
   StringRef Subcommand = Args[1];
   Args.erase(&Args[1]);
 
-  // If the subcommand is one of the "built-in" 'repl' or 'run', then use the
+  // If the subcommand is the "built-in" 'repl', then use the
   // normal driver.
-  if (Subcommand == "repl" || Subcommand == "run")
+  if (Subcommand == "repl")
     return false;
 
   // Form the subcommand name.


### PR DESCRIPTION
This is as per discussion in https://bugs.swift.org/browse/SR-5332