### PR TITLE
[GSB] Cope with elided conformance requirements in concrete nested types

### DIFF
--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -68,7 +68,6 @@ STATISTIC(NumConcreteTypeConstraints,
 STATISTIC(NumSuperclassConstraints, "# of superclass constraints tracked");
 STATISTIC(NumLayoutConstraints, "# of layout constraints tracked");
 STATISTIC(NumSelfDerived, "# of self-derived constraints removed");
-STATISTIC(NumRecursive, "# of recursive types we bail out on");
 STATISTIC(NumArchetypeAnchorCacheHits,
           "# of hits in the archetype anchor cache");
 STATISTIC(NumArchetypeAnchorCacheMisses,

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -1660,6 +1660,14 @@ static void concretizeNestedTypeFromConcreteParent(
   if (!assocType) return;
 
   auto proto = assocType->getProtocol();
+
+  // If we don't already have a conformance of the parent to this protocol,
+  // add it now; it was elided earlier.
+  if (parentEquiv->conformsTo.count(proto) == 0) {
+    auto source = parentEquiv->concreteTypeConstraints.front().source;
+    parent->addConformance(proto, source, builder);
+  }
+
   assert(parentEquiv->conformsTo.count(proto) > 0 &&
          "No conformance requirement");
   const RequirementSource *parentConcreteSource = nullptr;
@@ -1929,7 +1937,7 @@ PotentialArchetype *PotentialArchetype::updateNestedTypeForConformance(
     }
 
     case ArchetypeResolutionKind::AlreadyKnown:
-        return nullptr;
+      return nullptr;
     }
   }
 

--- a/validation-test/compiler_crashers_2_fixed/0112-rdar33139928.swift
+++ b/validation-test/compiler_crashers_2_fixed/0112-rdar33139928.swift
@@ -1,0 +1,4 @@
+// RUN: %target-swift-frontend -swift-version 4 %s -emit-ir
+
+struct X<Elements: Sequence> { }
+extension X where Elements == [Int] { }

--- a/validation-test/compiler_crashers_fixed/28807-parentequiv-conformsto-count-proto-0-no-conformance-requirement.swift
+++ b/validation-test/compiler_crashers_fixed/28807-parentequiv-conformsto-count-proto-0-no-conformance-requirement.swift
@@ -6,5 +6,5 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 class a:RangeReplaceableCollection}protocol P{{}typealias e:a{{}}typealias e:Collection


### PR DESCRIPTION
If we encounter an associated type reference within a concrete type, but
haven't seen a specific protocol requirement, add the protocol
conformance.

Fixes rdar://problem/33139928 and another crasher.