### PR TITLE
[4.0] [GSB] Cope with elided conformance requirements in concrete nested types

### DIFF
--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -1746,6 +1746,14 @@ static void concretizeNestedTypeFromConcreteParent(
   if (!assocType) return;
 
   auto proto = assocType->getProtocol();
+
+  // If we don't already have a conformance of the parent to this protocol,
+  // add it now; it was elided earlier.
+  if (parentEquiv->conformsTo.count(proto) == 0) {
+    auto source = parentEquiv->concreteTypeConstraints.front().source;
+    parent->addConformance(proto, source, builder);
+  }
+
   assert(parentEquiv->conformsTo.count(proto) > 0 &&
          "No conformance requirement");
   const RequirementSource *parentConcreteSource = nullptr;

--- a/validation-test/compiler_crashers_2_fixed/0112-rdar33139928.swift
+++ b/validation-test/compiler_crashers_2_fixed/0112-rdar33139928.swift
@@ -1,0 +1,4 @@
+// RUN: %target-swift-frontend -swift-version 4 %s -emit-ir
+
+struct X<Elements: Sequence> { }
+extension X where Elements == [Int] { }

--- a/validation-test/compiler_crashers_fixed/28807-parentequiv-conformsto-count-proto-0-no-conformance-requirement.swift
+++ b/validation-test/compiler_crashers_fixed/28807-parentequiv-conformsto-count-proto-0-no-conformance-requirement.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not %target-swift-frontend %s -emit-ir
+class a:RangeReplaceableCollection}protocol P{{}typealias e:a{{}}typealias e:Collection


### PR DESCRIPTION
**Explanation**: Eliminates a compiler crasher in the `GenericSignatureBuilder` that occurs when referencing a nested type of a type that has been made concrete.
**Scope**: The code pattern that triggers this (an extension involving making a type parameter concrete) seems like it should be common, although it didn't show up in our source compatibility suite.
**Radar**:  rdar://problem/33139928
**Risk**: Practically zero; we're replacing a crashing code path with a simple, direct fix.
**Testing**: Compiler regression testing, medium-size project that exhibited the problem.
