### PR TITLE
[Gardening] Rename getInOutOrLValueObjectType to getWithoutSpecifierType

### DIFF
--- a/include/swift/AST/Type.h
+++ b/include/swift/AST/Type.h
@@ -381,7 +381,7 @@ class CanType : public Type {
   static CanType getAnyOptionalObjectTypeImpl(CanType type,
                                               OptionalTypeKind &kind);
   static CanType getReferenceStorageReferentImpl(CanType type);
-  static CanType getLValueOrInOutObjectTypeImpl(CanType type);
+  static CanType getWithoutSpecifierTypeImpl(CanType type);
 
 public:
   explicit CanType(TypeBase *P = 0) : Type(P) {
@@ -459,8 +459,8 @@ public:
     return getReferenceStorageReferentImpl(*this);
   }
   
-  CanType getLValueOrInOutObjectType() const {
-    return getLValueOrInOutObjectTypeImpl(*this);
+  CanType getWithoutSpecifierType() const {
+    return getWithoutSpecifierTypeImpl(*this);
   }
 
   // Direct comparison is allowed for CanTypes - they are known canonical.

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -838,9 +838,10 @@ public:
   /// type.  Otherwise, returns the type itself.
   Type getInOutObjectType();
 
-  /// getLValueOrInOutObjectType - For an @lvalue or inout type, retrieves the
-  /// underlying object type. Otherwise, returns the type itself.
-  Type getLValueOrInOutObjectType();
+  /// getWithoutSpecifierType - For a non-materializable type
+  /// e.g. @lvalue or inout, retrieves the underlying object type.
+  /// Otherwise, returns the type itself.
+  Type getWithoutSpecifierType();
 
   /// Retrieves the rvalue instance type, looking through single-element
   /// tuples, inout types, and metatypes.
@@ -4655,9 +4656,10 @@ inline Type TypeBase::getRValueObjectType() {
   return type->getWithoutImmediateLabel();
 }
 
-/// getLValueOrInOutObjectType - For an @lvalue or inout type, retrieves the
-/// underlying object type. Otherwise, returns the type itself.
-inline Type TypeBase::getLValueOrInOutObjectType() {
+/// getWithoutSpecifierType - For a non-materializable type
+/// e.g. @lvalue or inout, retrieves the underlying object type.
+/// Otherwise, returns the type itself.
+inline Type TypeBase::getWithoutSpecifierType() {
   if (auto iot = getAs<InOutType>())
     return iot->getObjectType();
   if (auto lv = getAs<LValueType>())
@@ -4679,7 +4681,7 @@ inline CanType CanType::getReferenceStorageReferentImpl(CanType type) {
   return type;
 }
 
-inline CanType CanType::getLValueOrInOutObjectTypeImpl(CanType type) {
+inline CanType CanType::getWithoutSpecifierTypeImpl(CanType type) {
   if (auto refType = dyn_cast<InOutType>(type))
     return refType.getObjectType();
   if (auto refType = dyn_cast<LValueType>(type))

--- a/include/swift/SIL/AbstractionPattern.h
+++ b/include/swift/SIL/AbstractionPattern.h
@@ -895,7 +895,7 @@ public:
 
   /// Given that the value being abstracted is an l-value or inout type,
   /// return the abstraction pattern for its object type.
-  AbstractionPattern getLValueOrInOutObjectType() const;
+  AbstractionPattern getWithoutSpecifierType() const;
 
   /// Given that the value being abstracted is a function, return the
   /// abstraction pattern for its result type.

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -1597,7 +1597,7 @@ public:
       }
       
       // The base of a member reference cannot be an existential type.
-      if (E->getBase()->getType()->getLValueOrInOutObjectType()
+      if (E->getBase()->getType()->getWithoutSpecifierType()
             ->isAnyExistentialType()) {
         Out << "Member reference into an unopened existential type\n";
         E->dump(Out);
@@ -1627,7 +1627,7 @@ public:
 
       // The base of a dynamic member reference cannot be an
       // existential type.
-      if (E->getBase()->getType()->getLValueOrInOutObjectType()
+      if (E->getBase()->getType()->getWithoutSpecifierType()
             ->isAnyExistentialType()) {
         Out << "Member reference into an unopened existential type\n";
         E->dump(Out);
@@ -1646,7 +1646,7 @@ public:
       }
 
       // The base of a subscript cannot be an existential type.
-      if (E->getBase()->getType()->getLValueOrInOutObjectType()
+      if (E->getBase()->getType()->getWithoutSpecifierType()
             ->isAnyExistentialType()) {
         Out << "Member reference into an unopened existential type\n";
         E->dump(Out);
@@ -1662,7 +1662,7 @@ public:
       PrettyStackTraceExpr debugStack(Ctx, "verifying DynamicSubscriptExpr", E);
 
       // The base of a subscript cannot be an existential type.
-      if (E->getBase()->getType()->getLValueOrInOutObjectType()
+      if (E->getBase()->getType()->getWithoutSpecifierType()
             ->isAnyExistentialType()) {
         Out << "Member reference into an unopened existential type\n";
         E->dump(Out);

--- a/lib/IRGen/DebugTypeInfo.h
+++ b/lib/IRGen/DebugTypeInfo.h
@@ -85,12 +85,12 @@ public:
   GenericEnvironment *getGenericEnvironment() const { return GenericEnv; }
 
   void unwrapLValueOrInOutType() {
-    Type = Type->getLValueOrInOutObjectType().getPointer();
+    Type = Type->getWithoutSpecifierType().getPointer();
   }
 
   // Determine whether this type is an Archetype itself.
   bool isArchetype() const {
-    return Type->getLValueOrInOutObjectType()->is<ArchetypeType>();
+    return Type->getWithoutSpecifierType()->is<ArchetypeType>();
   }
 
   /// LValues, inout args, and Archetypes are implicitly indirect by

--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -173,7 +173,7 @@ IRGenModule::getAddrOfKeyPathPattern(KeyPathPattern *pattern,
     Lowering::GenericContextScope scope(getSILTypes(),
                                         pattern->getGenericSignature());
     loweredBaseTy = getLoweredType(AbstractionPattern::getOpaque(),
-                                   baseTy->getLValueOrInOutObjectType());
+                                   baseTy->getWithoutSpecifierType());
     auto &component = pattern->getComponents()[i];
     switch (auto kind = component.getKind()) {
     case KeyPathPatternComponent::Kind::StoredProperty: {

--- a/lib/SIL/AbstractionPattern.cpp
+++ b/lib/SIL/AbstractionPattern.cpp
@@ -588,7 +588,7 @@ AbstractionPattern AbstractionPattern::dropLastTupleElement() const {
   llvm_unreachable("bad kind");  
 }
 
-AbstractionPattern AbstractionPattern::getLValueOrInOutObjectType() const {
+AbstractionPattern AbstractionPattern::getWithoutSpecifierType() const {
   switch (getKind()) {
   case Kind::Invalid:
     llvm_unreachable("querying invalid abstraction pattern!");
@@ -607,13 +607,13 @@ AbstractionPattern AbstractionPattern::getLValueOrInOutObjectType() const {
     return *this;
   case Kind::Type:
     return AbstractionPattern(getGenericSignature(),
-                              getType().getLValueOrInOutObjectType());
+                              getType().getWithoutSpecifierType());
   case Kind::Discard:
     return AbstractionPattern::getDiscard(getGenericSignature(),
-                                        getType().getLValueOrInOutObjectType());
+                                        getType().getWithoutSpecifierType());
   case Kind::ClangType:
     return AbstractionPattern(getGenericSignature(),
-                              getType().getLValueOrInOutObjectType(),
+                              getType().getWithoutSpecifierType(),
                               getClangType());
   }
   llvm_unreachable("bad kind");

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -1444,7 +1444,7 @@ static CanTupleType getLoweredTupleType(TypeConverter &tc,
 
     CanType loweredSubstEltType;
     if (auto substLV = dyn_cast<InOutType>(substEltType)) {
-      SILType silType = tc.getLoweredType(origType.getLValueOrInOutObjectType(),
+      SILType silType = tc.getLoweredType(origType.getWithoutSpecifierType(),
                                           substLV.getObjectType());
       loweredSubstEltType = CanInOutType::get(silType.getSwiftRValueType());
 
@@ -1527,8 +1527,8 @@ TypeConverter::getTypeLowering(AbstractionPattern origType,
   // completely removed and represented as 'address' SILTypes.
   if (isa<InOutType>(substType)) {
     // Derive SILType for InOutType from the object type.
-    CanType substObjectType = substType.getLValueOrInOutObjectType();
-    AbstractionPattern origObjectType = origType.getLValueOrInOutObjectType();
+    CanType substObjectType = substType.getWithoutSpecifierType();
+    AbstractionPattern origObjectType = origType.getWithoutSpecifierType();
 
     SILType loweredType = getLoweredType(origObjectType, substObjectType)
       .getAddressType();

--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -1320,7 +1320,7 @@ void SILGenFunction::emitForeignToNativeThunk(SILDeclRef thunk) {
   if (thunk.kind == SILDeclRef::Kind::Allocator) {
     allocatorSelfType = forwardedParameters[0]
       ->getInterfaceType(getASTContext())
-      ->getLValueOrInOutObjectType();
+      ->getWithoutSpecifierType();
     if (F.getGenericEnvironment())
       allocatorSelfType = F.getGenericEnvironment()
         ->mapTypeIntoContext(allocatorSelfType);

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2390,7 +2390,7 @@ RValue RValueEmitter::visitTupleShuffleExpr(TupleShuffleExpr *E,
 }
 
 SILValue SILGenFunction::emitMetatypeOfValue(SILLocation loc, Expr *baseExpr) {
-  Type formalBaseType = baseExpr->getType()->getLValueOrInOutObjectType();
+  Type formalBaseType = baseExpr->getType()->getWithoutSpecifierType();
   CanType baseTy = formalBaseType->getCanonicalType();
 
   // For class, archetype, and protocol types, look up the dynamic metatype.
@@ -2840,7 +2840,7 @@ RValue RValueEmitter::visitKeyPathExpr(KeyPathExpr *E, SGFContext C) {
         // If the stored value would need to be reabstracted in fully opaque
         // context, then we have to treat the component as computed.
         auto componentObjTy =
-          component.getComponentType()->getLValueOrInOutObjectType();
+          component.getComponentType()->getWithoutSpecifierType();
         auto storageTy = SGF.SGM.Types.getSubstitutedStorageType(decl,
                                                                 componentObjTy);
         auto opaqueTy = SGF.getLoweredType(AbstractionPattern::getOpaque(),
@@ -3277,7 +3277,7 @@ RValue RValueEmitter::visitRebindSelfInConstructorExpr(
 }
 
 static bool isVerbatimNullableTypeInC(SILModule &M, Type ty) {
-  ty = ty->getLValueOrInOutObjectType()->getReferenceStorageReferent();
+  ty = ty->getWithoutSpecifierType()->getReferenceStorageReferent();
 
   // Class instances, and @objc existentials are all nullable.
   if (ty->hasReferenceSemantics()) {
@@ -4184,7 +4184,7 @@ void SILGenFunction::emitOpenExistentialExprImpl(
     writebackScope.emplace(*this);
 
     Type formalRValueType =
-      E->getOpaqueValue()->getType()->getLValueOrInOutObjectType();
+      E->getOpaqueValue()->getType()->getWithoutSpecifierType();
 
     accessKind = E->getExistentialValue()->getLValueAccessKind();
     auto lv = emitLValue(E->getExistentialValue(), accessKind);

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -2085,7 +2085,7 @@ LValue SILGenLValue::visitOpaqueValueExpr(OpaqueValueExpr *e,
     lv = SGF.emitOpenExistentialLValue(
         opened, std::move(lv),
         CanArchetypeType(opened->getOpenedArchetype()),
-        e->getType()->getLValueOrInOutObjectType()->getCanonicalType(),
+        e->getType()->getWithoutSpecifierType()->getCanonicalType(),
         accessKind);
     return lv;
   }

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -1589,7 +1589,7 @@ void CalleeCandidateInfo::collectCalleeCandidates(Expr *fn,
       Type baseType;
       if (isa<SelfApplyExpr>(AE) &&
           !isUnresolvedOrTypeVarType(CS->getType(AE->getArg())))
-        baseType = CS->getType(AE->getArg())->getLValueOrInOutObjectType();
+        baseType = CS->getType(AE->getArg())->getWithoutSpecifierType();
 
       for (auto &C : candidates) {
         C.level += 1;
@@ -1599,7 +1599,7 @@ void CalleeCandidateInfo::collectCalleeCandidates(Expr *fn,
         // Compute a new substituted type if we have a base type to apply.
         if (baseType && C.level == 1 && C.getDecl()) {
           baseType = baseType
-              ->getLValueOrInOutObjectType()
+              ->getWithoutSpecifierType()
               ->getRValueInstanceType();
           C.entityType = baseType->getTypeOfMember(CS->DC->getParentModule(),
                                                    C.getDecl(), nullptr);
@@ -1652,7 +1652,7 @@ void CalleeCandidateInfo::collectCalleeCandidates(Expr *fn,
     // If we have useful information about the type we're
     // initializing, provide it.
     if (UDE->getName().getBaseName() == CS->TC.Context.Id_init) {
-      auto selfTy = CS->getType(UDE->getBase())->getLValueOrInOutObjectType();
+      auto selfTy = CS->getType(UDE->getBase())->getWithoutSpecifierType();
       if (!selfTy->hasTypeVariable())
         declName = selfTy.getString() + "." + declName;
     }
@@ -1786,7 +1786,7 @@ CalleeCandidateInfo::CalleeCandidateInfo(Type baseType,
       auto substType = replaceTypeVariablesWithUnresolved(baseType);
       if (substType)
         substType = substType
-            ->getLValueOrInOutObjectType()
+            ->getWithoutSpecifierType()
             ->getRValueInstanceType();
 
       // If this is a DeclViaUnwrappingOptional, then we're actually looking
@@ -5931,7 +5931,7 @@ bool FailureDiagnosis::diagnoseArgumentGenericRequirements(
     // Bindings specify the arguments that source the parameter. The only case
     // this returns a non-singular value is when there are varargs in play.
     for (auto argNo : bindings[i]) {
-      auto argType = args[argNo].getType()->getLValueOrInOutObjectType();
+      auto argType = args[argNo].getType()->getWithoutSpecifierType();
 
       if (argType->is<ArchetypeType>()) {
         diagnoseUnboundArchetype(archetype, fnExpr);
@@ -8283,7 +8283,7 @@ bool FailureDiagnosis::diagnoseMemberFailures(
     if (!baseExpr)
       return true;
 
-    baseTy = CS->getType(baseExpr)->getLValueOrInOutObjectType();
+    baseTy = CS->getType(baseExpr)->getWithoutSpecifierType();
     baseObjTy = baseTy;
   }
 
@@ -8853,7 +8853,7 @@ FailureDiagnosis::validateContextualType(Type contextualType,
   };
 
   bool shouldNullify = false;
-  if (auto objectType = contextualType->getLValueOrInOutObjectType()) {
+  if (auto objectType = contextualType->getWithoutSpecifierType()) {
     // Note that simply checking for `objectType->hasUnresolvedType()` is not
     // appropriate in this case standalone, because if it's in a function,
     // for example, or inout type, we still want to preserve it's skeleton

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -406,7 +406,7 @@ namespace {
     if (lti.collectedTypes.size() == 1) {
       // TODO: Compute the BCT.
 
-      auto favoredTy = (*lti.collectedTypes.begin())->getLValueOrInOutObjectType();
+      auto favoredTy = (*lti.collectedTypes.begin())->getWithoutSpecifierType();
 
       CS.setFavoredType(expr, favoredTy.getPointer());
       
@@ -533,7 +533,7 @@ namespace {
                             Type argTy,
                             Type otherArgTy = Type()) {
     // Determine the argument type.
-    argTy = argTy->getLValueOrInOutObjectType();
+    argTy = argTy->getWithoutSpecifierType();
 
     // Do the types match exactly?
     if (paramTy->isEqual(argTy))
@@ -547,7 +547,7 @@ namespace {
 
     // Dig out the second argument type.
     if (otherArgTy)
-      otherArgTy = otherArgTy->getLValueOrInOutObjectType();
+      otherArgTy = otherArgTy->getWithoutSpecifierType();
 
     // If there is another, concrete argument, check whether it's type
     // conforms to the literal protocol and test against it directly.
@@ -1054,7 +1054,7 @@ namespace {
         auto baseObjTy = baseTy;
         if (baseObjTy->is<LValueType>()) {
           isLValueBase = true;
-          baseObjTy = baseObjTy->getLValueOrInOutObjectType();
+          baseObjTy = baseObjTy->getWithoutSpecifierType();
         }
         
         if (CS.isArrayType(baseObjTy.getPointer())) {
@@ -1501,7 +1501,7 @@ namespace {
       // subexpr type.
       if (CS.TC.getSelfForInitDelegationInConstructor(CS.DC, expr)) {
         auto baseTy = CS.getType(expr->getBase())
-                        ->getLValueOrInOutObjectType();
+                        ->getWithoutSpecifierType();
 
         // 'self' or 'super' will reference an instance, but the constructor
         // is semantically a member of the metatype. This:

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1052,7 +1052,7 @@ static PotentialBindings getPotentialBindings(ConstraintSystem &cs,
     if (kind == AllowedBindingKind::Supertypes &&
         constraint->getKind() >= ConstraintKind::Conversion &&
         constraint->getKind() <= ConstraintKind::OperatorArgumentConversion) {
-      auto innerType = type->getLValueOrInOutObjectType();
+      auto innerType = type->getWithoutSpecifierType();
       if (auto objectType =
           cs.lookThroughImplicitlyUnwrappedOptionalType(innerType)) {
         type = OptionalType::get(objectType);
@@ -2649,8 +2649,8 @@ bool DisjunctionChoice::isSymmetricOperator() const {
     return true;
 
   auto firstType =
-      paramList->get(0)->getInterfaceType()->getLValueOrInOutObjectType();
+      paramList->get(0)->getInterfaceType()->getWithoutSpecifierType();
   auto secondType =
-      paramList->get(1)->getInterfaceType()->getLValueOrInOutObjectType();
+      paramList->get(1)->getInterfaceType()->getWithoutSpecifierType();
   return firstType->isEqual(secondType);
 }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -672,7 +672,7 @@ Type TypeChecker::getUnopenedTypeOfReference(VarDecl *value, Type baseType,
                         ? value->getInterfaceType()
                         : value->getType());
 
-  requestedType = requestedType->getLValueOrInOutObjectType()
+  requestedType = requestedType->getWithoutSpecifierType()
     ->getReferenceStorageReferent();
 
   // If we're dealing with contextual types, and we referenced this type from
@@ -1702,7 +1702,7 @@ Type simplifyTypeImpl(ConstraintSystem &cs, Type type, Fn getFixedTypeFn) {
 
       // FIXME: It's kind of weird in general that we have to look
       // through lvalue, inout and IUO types here
-      Type lookupBaseType = newBase->getLValueOrInOutObjectType();
+      Type lookupBaseType = newBase->getWithoutSpecifierType();
 
       auto *module = cs.DC->getParentModule();
 

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -3663,7 +3663,7 @@ static OmissionTypeName getTypeNameForOmission(Type type) {
     }
 
     // Strip off lvalue/inout types.
-    Type newType = type->getLValueOrInOutObjectType();
+    Type newType = type->getWithoutSpecifierType();
     if (newType.getPointer() != type.getPointer()) {
       type = newType;
       continue;
@@ -3852,7 +3852,7 @@ Optional<Identifier> TypeChecker::omitNeedlessWords(VarDecl *var) {
 
   // Dig out the type of the variable.
   Type type = var->getInterfaceType()->getReferenceStorageReferent()
-                ->getLValueOrInOutObjectType();
+                ->getWithoutSpecifierType();
   while (auto optObjectTy = type->getAnyOptionalObjectType())
     type = optObjectTy;
 

--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -456,9 +456,9 @@ public:
     // doesn't require its type metadata.
     if (auto declRef = dyn_cast<DeclRefExpr>(E))
       return (!declRef->getDecl()->isObjC()
-              && !E->getType()->getLValueOrInOutObjectType()
+              && !E->getType()->getWithoutSpecifierType()
                               ->hasRetainablePointerRepresentation()
-              && !E->getType()->getLValueOrInOutObjectType()
+              && !E->getType()->getWithoutSpecifierType()
                               ->is<AnyMetatypeType>());
 
     // Loading classes or metatypes doesn't require their metadata.


### PR DESCRIPTION
Factored out a simple `sed` to rename this primitive.