### PR TITLE
[stdlib] StringProtocol no longer refines RangeReplaceableCollection

### DIFF
--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -14,7 +14,7 @@ import SwiftShims
 
 /// A type that can represent a string as a collection of characters.
 public protocol StringProtocol
-  : RangeReplaceableCollection, BidirectionalCollection,
+  : BidirectionalCollection,
   TextOutputStream, TextOutputStreamable,
   LosslessStringConvertible, ExpressibleByStringLiteral,
   Hashable, Comparable

--- a/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
+++ b/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-extension String : StringProtocol {
+extension String : StringProtocol, RangeReplaceableCollection {
   /// The index type for subscripting a string.
   public typealias Index = CharacterView.Index
 


### PR DESCRIPTION
https://bugs.swift.org/browse/SR-5379

