### PR TITLE
[SourceKit] Ignore the index-store-path flag for the sourcekitd requests

### DIFF
--- a/test/SourceKit/Misc/ignore_index_store_flag.swift
+++ b/test/SourceKit/Misc/ignore_index_store_flag.swift
@@ -1,0 +1,14 @@
+var s = 10
+s.
+
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: touch %t/t.h
+// RUN: %sourcekitd-test -req=sema %s -- %s -import-objc-header %t/t.h -pch-output-dir %t/pch -index-store-path %t/idx | %FileCheck %s -check-prefix=DIAG
+// RUN: not find %t/idx
+// DIAG: expected member name
+
+// RUN: rm -rf %t/pch %t/idx
+// RUN: %sourcekitd-test -req=complete -pos=2:3 %s -- %s -import-objc-header %t/t.h -pch-output-dir %t/pch -index-store-path %t/idx | %FileCheck %s -check-prefix=COMPLETE
+// RUN: not find %t/idx
+// COMPLETE: littleEndian

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -419,6 +419,10 @@ bool SwiftASTManager::initCompilerInvocation(CompilerInvocation &Invocation,
     FrontendOpts.PlaygroundTransform = false;
   }
 
+  // Disable the index-store functionality for the sourcekitd requests.
+  FrontendOpts.IndexStorePath.clear();
+  ImporterOpts.IndexStorePath.clear();
+
   if (!PrimaryFile.empty()) {
     Optional<unsigned> PrimaryIndex;
     for (auto i : indices(Invocation.getFrontendOptions().InputFilenames)) {


### PR DESCRIPTION
It was active for clang PCH/module creation coming from sourcekitd which was unnecessary index-store data creation.
