### PR TITLE
[QoI] [Parse] Improve error message when parsing integer literal

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -150,7 +150,8 @@ ERROR(lex_invalid_identifier_start_character,none,
 ERROR(lex_expected_digit_in_fp_exponent,none,
        "expected a digit in floating point exponent", ())
 ERROR(lex_expected_digit_in_int_literal,none,
-       "expected a digit after integer literal prefix", ())
+      "expected %select{a binary digit (0-1)|an octal digit (0-7)|a digit|a hex"
+      " digit (0-9,A-F)}0 in integer literal", (unsigned))
 ERROR(lex_expected_binary_exponent_in_hex_float_literal,none,
       "hexadecimal floating point literal must end with an exponent", ())
 ERROR(lex_unexpected_block_comment_end,none,

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -149,9 +149,13 @@ ERROR(lex_invalid_identifier_start_character,none,
        "an identifier cannot begin with this character", ())
 ERROR(lex_expected_digit_in_fp_exponent,none,
        "expected a digit in floating point exponent", ())
-ERROR(lex_expected_digit_in_int_literal,none,
-      "expected %select{a binary digit (0-1)|an octal digit (0-7)|a digit|a hex"
-      " digit (0-9,A-F)}0 in integer literal", (unsigned))
+ERROR(lex_invalid_digit_in_fp_exponent,none,
+      "'%0' is not a valid %select{digit|first character}1 in floating point exponent",
+      (StringRef, bool))
+ERROR(lex_invalid_digit_in_int_literal,none,
+      "'%0' is not a valid %select{binary digit (0 or 1)|octal digit (0-7)|"
+      "digit|hexadecimal digit (0-9, A-F)}1 in integer literal",
+      (StringRef, unsigned))
 ERROR(lex_expected_binary_exponent_in_hex_float_literal,none,
       "hexadecimal floating point literal must end with an exponent", ())
 ERROR(lex_unexpected_block_comment_end,none,

--- a/test/Parse/number_identifier_errors.swift
+++ b/test/Parse/number_identifier_errors.swift
@@ -10,7 +10,7 @@ func 2.0() {}
 // expected-error@-1 {{function name can only start with a letter or underscore, not a number}}
 func 3func() {}
 // expected-error@-1 {{function name can only start with a letter or underscore, not a number}}
-// expected-error@-2 {{expected a digit in integer literal}}
+// expected-error@-2 {{'f' is not a valid digit in integer literal}}
 
 protocol 4 {
   // expected-error@-1 {{protocol name can only start with a letter or underscore, not a number}}
@@ -24,10 +24,10 @@ protocol 6.0 {
 }
 protocol 8protocol {
   // expected-error@-1 {{protocol name can only start with a letter or underscore, not a number}}
-  // expected-error@-2 {{expected a digit in integer literal}}
+  // expected-error@-2 {{'p' is not a valid digit in integer literal}}
   associatedtype 9associatedtype
   // expected-error@-1 {{associatedtype name can only start with a letter or underscore, not a number}}
-  // expected-error@-2 {{expected a digit in integer literal}}
+  // expected-error@-2 {{'a' is not a valid digit in integer literal}}
 }
 
 typealias 10 = Int
@@ -36,7 +36,7 @@ typealias 11.0 = Int
 // expected-error@-1 {{typealias name can only start with a letter or underscore, not a number}}
 typealias 12typealias = Int
 // expected-error@-1 {{typealias name can only start with a letter or underscore, not a number}}
-// expected-error@-2 {{expected a digit in integer literal}}
+// expected-error@-2 {{'t' is not a valid digit in integer literal}}
 
 struct 13 {}
 // expected-error@-1 {{struct name can only start with a letter or underscore, not a number}}
@@ -44,7 +44,7 @@ struct 14.0 {}
 // expected-error@-1 {{struct name can only start with a letter or underscore, not a number}}
 struct 15struct {}
 // expected-error@-1 {{struct name can only start with a letter or underscore, not a number}}
-// expected-error@-2 {{expected a digit in integer literal}}
+// expected-error@-2 {{'s' is not a valid digit in integer literal}}
 
 enum 16 {}
 // expected-error@-1 {{enum name can only start with a letter or underscore, not a number}}
@@ -52,7 +52,7 @@ enum 17.0 {}
 // expected-error@-1 {{enum name can only start with a letter or underscore, not a number}}
 enum 18enum {}
 // expected-error@-1 {{enum name can only start with a letter or underscore, not a number}}
-// expected-error@-2 {{expected a digit in floating point exponent}}
+// expected-error@-2 {{'n' is not a valid digit in floating point exponent}}
 
 class 19 {
   // expected-error@-1 {{class name can only start with a letter or underscore, not a number}}
@@ -67,8 +67,8 @@ class 21.0 {
 
 class 23class {
   // expected-error@-1 {{class name can only start with a letter or underscore, not a number}}
-  // expected-error@-2 {{expected a digit in integer literal}}
+  // expected-error@-2 {{'c' is not a valid digit in integer literal}}
   func 24method() {}
   // expected-error@-1 {{function name can only start with a letter or underscore, not a number}}
-  // expected-error@-2 {{expected a digit in integer literal}}
+  // expected-error@-2 {{'m' is not a valid digit in integer literal}}
 }

--- a/test/Parse/number_identifier_errors.swift
+++ b/test/Parse/number_identifier_errors.swift
@@ -10,7 +10,7 @@ func 2.0() {}
 // expected-error@-1 {{function name can only start with a letter or underscore, not a number}}
 func 3func() {}
 // expected-error@-1 {{function name can only start with a letter or underscore, not a number}}
-// expected-error@-2 {{expected a digit after integer literal prefix}}
+// expected-error@-2 {{expected a digit in integer literal}}
 
 protocol 4 {
   // expected-error@-1 {{protocol name can only start with a letter or underscore, not a number}}
@@ -24,10 +24,10 @@ protocol 6.0 {
 }
 protocol 8protocol {
   // expected-error@-1 {{protocol name can only start with a letter or underscore, not a number}}
-  // expected-error@-2 {{expected a digit after integer literal prefix}}
+  // expected-error@-2 {{expected a digit in integer literal}}
   associatedtype 9associatedtype
   // expected-error@-1 {{associatedtype name can only start with a letter or underscore, not a number}}
-  // expected-error@-2 {{expected a digit after integer literal prefix}}
+  // expected-error@-2 {{expected a digit in integer literal}}
 }
 
 typealias 10 = Int
@@ -36,7 +36,7 @@ typealias 11.0 = Int
 // expected-error@-1 {{typealias name can only start with a letter or underscore, not a number}}
 typealias 12typealias = Int
 // expected-error@-1 {{typealias name can only start with a letter or underscore, not a number}}
-// expected-error@-2 {{expected a digit after integer literal prefix}}
+// expected-error@-2 {{expected a digit in integer literal}}
 
 struct 13 {}
 // expected-error@-1 {{struct name can only start with a letter or underscore, not a number}}
@@ -44,7 +44,7 @@ struct 14.0 {}
 // expected-error@-1 {{struct name can only start with a letter or underscore, not a number}}
 struct 15struct {}
 // expected-error@-1 {{struct name can only start with a letter or underscore, not a number}}
-// expected-error@-2 {{expected a digit after integer literal prefix}}
+// expected-error@-2 {{expected a digit in integer literal}}
 
 enum 16 {}
 // expected-error@-1 {{enum name can only start with a letter or underscore, not a number}}
@@ -67,8 +67,8 @@ class 21.0 {
 
 class 23class {
   // expected-error@-1 {{class name can only start with a letter or underscore, not a number}}
-  // expected-error@-2 {{expected a digit after integer literal prefix}}
+  // expected-error@-2 {{expected a digit in integer literal}}
   func 24method() {}
   // expected-error@-1 {{function name can only start with a letter or underscore, not a number}}
-  // expected-error@-2 {{expected a digit after integer literal prefix}}
+  // expected-error@-2 {{expected a digit in integer literal}}
 }

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -322,11 +322,18 @@ var oct_literal_test: Int64 = 0123
 assert(oct_literal_test == 123)
 
 // ensure that we swallow random invalid chars after the first invalid char
-var invalid_num_literal: Int64 = 0QWERTY  // expected-error{{expected a digit after integer literal prefix}}
-var invalid_bin_literal: Int64 = 0bQWERTY // expected-error{{expected a digit after integer literal prefix}}
-var invalid_hex_literal: Int64 = 0xQWERTY // expected-error{{expected a digit after integer literal prefix}}
-var invalid_oct_literal: Int64 = 0oQWERTY // expected-error{{expected a digit after integer literal prefix}}
+var invalid_num_literal: Int64 = 0QWERTY  // expected-error{{expected a digit in integer literal}}
+var invalid_bin_literal: Int64 = 0bQWERTY // expected-error{{expected a binary digit (0-1) in integer literal}}
+var invalid_hex_literal: Int64 = 0xQWERTY // expected-error{{expected a hex digit (0-9,A-F) in integer literal}}
+var invalid_oct_literal: Int64 = 0oQWERTY // expected-error{{expected an octal digit (0-7) in integer literal}}
 var invalid_exp_literal: Double = 1.0e+QWERTY // expected-error{{expected a digit in floating point exponent}}
+
+// don't emit a partial integer literal if it looks like the 
+var invalid_num_literal_prefix: Int64 = 0a1234567 // expected-error{{expected a digit in integer literal}}
+var invalid_num_literal_middle: Int64 = 0123A5678 // expected-error{{expected a digit in integer literal}}
+var invalid_bin_literal_middle: Int64 = 0b1020101 // expected-error{{expected a binary digit (0-1) in integer literal}}
+var invalid_oct_literal_middle: Int64 = 0o1357864 // expected-error{{expected an octal digit (0-7) in integer literal}}
+var invalid_hex_literal_middle: Int64 = 0x147ADG0 // expected-error{{expected a hex digit (0-9,A-F) in integer literal}}
 
 // rdar://11088443
 var negative_int32: Int32 = -1

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -322,18 +322,22 @@ var oct_literal_test: Int64 = 0123
 assert(oct_literal_test == 123)
 
 // ensure that we swallow random invalid chars after the first invalid char
-var invalid_num_literal: Int64 = 0QWERTY  // expected-error{{expected a digit in integer literal}}
-var invalid_bin_literal: Int64 = 0bQWERTY // expected-error{{expected a binary digit (0-1) in integer literal}}
-var invalid_hex_literal: Int64 = 0xQWERTY // expected-error{{expected a hex digit (0-9,A-F) in integer literal}}
-var invalid_oct_literal: Int64 = 0oQWERTY // expected-error{{expected an octal digit (0-7) in integer literal}}
-var invalid_exp_literal: Double = 1.0e+QWERTY // expected-error{{expected a digit in floating point exponent}}
+var invalid_num_literal: Int64 = 0QWERTY  // expected-error{{'Q' is not a valid digit in integer literal}}
+var invalid_bin_literal: Int64 = 0bQWERTY // expected-error{{'Q' is not a valid binary digit (0 or 1) in integer literal}}
+var invalid_hex_literal: Int64 = 0xQWERTY // expected-error{{'Q' is not a valid hexadecimal digit (0-9, A-F) in integer literal}}
+var invalid_oct_literal: Int64 = 0oQWERTY // expected-error{{'Q' is not a valid octal digit (0-7) in integer literal}}
+var invalid_exp_literal: Double = 1.0e+QWERTY // expected-error{{'Q' is not a valid digit in floating point exponent}}
+var invalid_fp_exp_literal: Double = 0x1p+QWERTY // expected-error{{'Q' is not a valid digit in floating point exponent}}
 
-// don't emit a partial integer literal if it looks like the 
-var invalid_num_literal_prefix: Int64 = 0a1234567 // expected-error{{expected a digit in integer literal}}
-var invalid_num_literal_middle: Int64 = 0123A5678 // expected-error{{expected a digit in integer literal}}
-var invalid_bin_literal_middle: Int64 = 0b1020101 // expected-error{{expected a binary digit (0-1) in integer literal}}
-var invalid_oct_literal_middle: Int64 = 0o1357864 // expected-error{{expected an octal digit (0-7) in integer literal}}
-var invalid_hex_literal_middle: Int64 = 0x147ADG0 // expected-error{{expected a hex digit (0-9,A-F) in integer literal}}
+// don't emit a partial integer literal if the invalid char is valid for identifiers.
+var invalid_num_literal_prefix: Int64 = 0a1234567 // expected-error{{'a' is not a valid digit in integer literal}}
+var invalid_num_literal_middle: Int64 = 0123A5678 // expected-error{{'A' is not a valid digit in integer literal}}
+var invalid_bin_literal_middle: Int64 = 0b1020101 // expected-error{{'2' is not a valid binary digit (0 or 1) in integer literal}}
+var invalid_oct_literal_middle: Int64 = 0o1357864 // expected-error{{'8' is not a valid octal digit (0-7) in integer literal}}
+var invalid_hex_literal_middle: Int64 = 0x147ADG0 // expected-error{{'G' is not a valid hexadecimal digit (0-9, A-F) in integer literal}}
+
+var invalid_hex_literal_exponent_ = 0xffp+12abc // expected-error{{'a' is not a valid digit in floating point exponent}}
+var invalid_float_literal_exponent = 12e1abc // expected-error{{'a' is not a valid digit in floating point exponent}}
 
 // rdar://11088443
 var negative_int32: Int32 = -1
@@ -434,8 +438,8 @@ var fl_separator6: Double = 1_000.200_001e1_000
 var fl_separator7: Double = 0x1_.0FFF_p1_
 var fl_separator8: Double = 0x1_0000.0FFF_ABCDp10_001
 
-var fl_bad_separator1: Double = 1e_ // expected-error {{expected a digit in floating point exponent}}
-var fl_bad_separator2: Double = 0x1p_ // expected-error {{expected a digit in floating point exponent}} expected-error{{'_' can only appear in a pattern or on the left side of an assignment}} expected-error {{consecutive statements on a line must be separated by ';'}} {{37-37=;}}
+var fl_bad_separator1: Double = 1e_ // expected-error {{'_' is not a valid first character in floating point exponent}}
+var fl_bad_separator2: Double = 0x1p_ // expected-error {{'_' is not a valid first character in floating point exponent}}
 
 //===----------------------------------------------------------------------===//
 // String Literals

--- a/test/expr/primary/unqualified_name.swift
+++ b/test/expr/primary/unqualified_name.swift
@@ -81,6 +81,6 @@ struct S1 {
     _ = S1.init(`x`: 1)  // expected-warning {{keyword 'x' does not need to be escaped in argument list}} {{17-18=}} {{19-20=}}
 
     // Test for unknown token.
-    _ = S1.init(x: 0xG) // expected-error {{expected a digit after integer literal prefix}} expected-error {{missing argument for parameter 'x' in call}}
+    _ = S1.init(x: 0xG) // expected-error {{expected a hex digit (0-9,A-F) in integer literal}} expected-error {{missing argument for parameter 'x' in call}}
   }
 }

--- a/test/expr/primary/unqualified_name.swift
+++ b/test/expr/primary/unqualified_name.swift
@@ -81,6 +81,6 @@ struct S1 {
     _ = S1.init(`x`: 1)  // expected-warning {{keyword 'x' does not need to be escaped in argument list}} {{17-18=}} {{19-20=}}
 
     // Test for unknown token.
-    _ = S1.init(x: 0xG) // expected-error {{expected a hex digit (0-9,A-F) in integer literal}} expected-error {{missing argument for parameter 'x' in call}}
+    _ = S1.init(x: 0xG) // expected-error {{'G' is not a valid hexadecimal digit (0-9, A-F) in integer literal}} expected-error {{missing argument for parameter 'x' in call}}
   }
 }


### PR DESCRIPTION
<!-- What's in this pull request? -->
This PR does a few things to improve the clarity of the diagnostics when parsing/lexing integer literals:

1. It rephrases an error message to say "in integer literal" instead of "after integer literal prefix"
2. It provides additional information about what digits are expected (binary, octal, decimal, hexadecimal)
3. It looks ahead once a integer literal has been parsed to check for unexpected digits.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-5263](https://bugs.swift.org/browse/SR-5263).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->