### PR TITLE
[4.0] [QoI] Don't try to lookup members on incorrect type while diagnosing keypath components

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -7537,6 +7537,8 @@ static bool diagnoseKeyPathComponents(ConstraintSystem *CS, KeyPathExpr *KPE,
   auto performLookup = [&](Identifier componentName, SourceLoc componentNameLoc,
                            Type &lookupType) -> LookupResult {
     assert(currentType && "Non-beginning state must have a type");
+    if (!currentType->mayHaveMembers())
+      return LookupResult();
 
     // Determine the type in which the lookup should occur. If we have
     // a bridged value type, this will be the Objective-C class to

--- a/validation-test/compiler_crashers_2_fixed/0112-rdar33135487.swift
+++ b/validation-test/compiler_crashers_2_fixed/0112-rdar33135487.swift
@@ -1,0 +1,8 @@
+// RUN: not %target-swift-frontend %s -typecheck
+
+enum State<StateType> {
+  func put<StateType>() -> StateType {}
+  func put<T>(keyPath: WritableKeyPath<StateType, T>, projection: T) {
+    put(keyPath: \.age, projection: {})
+  }
+}


### PR DESCRIPTION
* Description: While trying to diagnose problems related to keypath components
don't assume that type of the component is always correct, check
before trying to see if it's bridged type or has members.

* Scope of the issue: diagnostic improvements, fixes crash in the keypath diagnostics.

* Risk: Low.

* Tested: Added new tests, Swift CI.

* Reviewed by: Joe Groff.

* Resolves: rdar://problem/33135487

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
