### PR TITLE
swift-api-digester: don't assume super classes are always present in the module dump.

### DIFF
--- a/test/api-digester/Inputs/cake1.swift
+++ b/test/api-digester/Inputs/cake1.swift
@@ -1,3 +1,5 @@
+import APINotesTest
+
 public struct S1 {
   public init(_ : Int) {}
   public func foo1() {}
@@ -21,4 +23,8 @@ public class C3 {}
 public struct Somestruct2 {
   public init(_ : C1) {}
   public static func foo1(_ a : C3) {}
+}
+
+public class C4: OldType {
+  public func foo() {}
 }

--- a/test/api-digester/Inputs/cake2.swift
+++ b/test/api-digester/Inputs/cake2.swift
@@ -1,3 +1,5 @@
+import APINotesTest
+
 public struct S1 {
   public init(_ : Double) {}
   mutating public func foo1() {}
@@ -25,3 +27,5 @@ public typealias C3 = C1
 public struct NSSomestruct2 {
   public static func foo1(_ a : C3) {}
 }
+
+public class C4: NewType {}

--- a/test/api-digester/Outputs/Cake.txt
+++ b/test/api-digester/Outputs/Cake.txt
@@ -2,6 +2,7 @@
 /* Removed Decls */
 Class C3 has been removed
 Constructor Somestruct2.init(_:) has been removed
+Func C4.foo() has been removed
 
 /* Moved Decls */
 

--- a/test/api-digester/compare-dump.swift
+++ b/test/api-digester/compare-dump.swift
@@ -1,9 +1,9 @@
 // RUN: %empty-directory(%t.mod)
 // RUN: %empty-directory(%t.sdk)
 // RUN: %empty-directory(%t.module-cache)
-// RUN: %swift -emit-module -o %t.mod/cake1.swiftmodule %S/Inputs/cake1.swift -parse-as-library
-// RUN: %swift -emit-module -o %t.mod/cake2.swiftmodule %S/Inputs/cake2.swift -parse-as-library
-// RUN: %api-digester -dump-sdk -module cake1 -o %t.dump1.json -module-cache-path %t.module-cache -sdk %t.sdk -swift-version 3 -I %t.mod
-// RUN: %api-digester -dump-sdk -module cake2 -o %t.dump2.json -module-cache-path %t.module-cache -sdk %t.sdk -swift-version 3 -I %t.mod
+// RUN: %swift -emit-module -o %t.mod/cake1.swiftmodule %S/Inputs/cake1.swift -parse-as-library -I %S/Inputs/APINotesLeft
+// RUN: %swift -emit-module -o %t.mod/cake2.swiftmodule %S/Inputs/cake2.swift -parse-as-library -I %S/Inputs/APINotesRight
+// RUN: %api-digester -dump-sdk -module cake1 -o %t.dump1.json -module-cache-path %t.module-cache -sdk %t.sdk -swift-version 3 -I %t.mod -I %S/Inputs/APINotesLeft
+// RUN: %api-digester -dump-sdk -module cake2 -o %t.dump2.json -module-cache-path %t.module-cache -sdk %t.sdk -swift-version 3 -I %t.mod -I %S/Inputs/APINotesRight
 // RUN: %api-digester -diagnose-sdk --input-paths %t.dump1.json -input-paths %t.dump2.json > %t.result
 // RUN: diff -u %S/Outputs/Cake.txt %t.result

--- a/tools/swift-api-digester/swift-api-digester.cpp
+++ b/tools/swift-api-digester/swift-api-digester.cpp
@@ -729,8 +729,10 @@ public:
   Optional<SDKNodeTypeDecl*> getSuperclass() const {
     if (SuperclassUsr.empty())
       return None;
-    return (*getRootNode()->getDescendantByUsr(SuperclassUsr))->
-      getAs<SDKNodeTypeDecl>();
+    if (auto SC = getRootNode()->getDescendantByUsr(SuperclassUsr)) {
+      return (*SC)->getAs<SDKNodeTypeDecl>();
+    }
+    return None;
   }
 
   /// Finding the node through all children, including the inheritted ones,


### PR DESCRIPTION
When we compare the APIs of entire SDKs, we can assume super classes
are always present in the API dump. However, this assumption is invalid
for framework-level API diff checking, where super classes can come from
other modules whose contents are not serialized.

rdar://33110442