### PR TITLE
IRGen: `Builtin.UnknownObject` should not be hardcoded to use ObjC refcounting.

### DIFF
--- a/test/IRGen/enum_value_semantics_special_cases_objc.sil
+++ b/test/IRGen/enum_value_semantics_special_cases_objc.sil
@@ -15,7 +15,7 @@ enum NullableObjCRefcounted {
 // CHECK:   %0 = bitcast %swift.opaque* %object to %T39enum_value_semantics_special_cases_objc22NullableObjCRefcountedO*
 // CHECK:   %1 = bitcast %T39enum_value_semantics_special_cases_objc22NullableObjCRefcountedO* %0 to %objc_object**
 // CHECK:   %2 = load %objc_object*, %objc_object** %1, align 8
-// CHECK:   call void @objc_release(%objc_object* %2) {{#[0-9]+}}
+// CHECK:   call void @swift_unknownRelease(%objc_object* %2) {{#[0-9]+}}
 // CHECK:   ret void
 // CHECK: }
 

--- a/test/IRGen/unknown_object.sil
+++ b/test/IRGen/unknown_object.sil
@@ -1,0 +1,17 @@
+// RUN: %target-swift-frontend -emit-ir %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-%target-runtime %s
+
+sil_stage canonical
+
+import Builtin
+
+// CHECK-LABEL: @retain_release_unknown_object
+sil @retain_release_unknown_object : $@convention(thin) (@guaranteed Builtin.UnknownObject) -> () {
+entry(%x : $Builtin.UnknownObject):
+  // CHECK-native: swift_retain
+  // CHECK-objc: swift_unknownRetain
+  %y = copy_value %x : $Builtin.UnknownObject
+  // CHECK-native: swift_release
+  // CHECK-objc: swift_unknownRelease
+  destroy_value %y : $Builtin.UnknownObject
+  return undef : $()
+}


### PR DESCRIPTION
It's more appropriate to use `Unknown` refcounting, which we correctly handle in the face of non-ObjC-interop elsewhere. Fixes a problem where the Linux standard library would contain an unresolvable reference to `objc_release`.