### PR TITLE
[swift-4.0-branch][stdlib] StringProtocol no longer refines RangeReplaceableCollection

### DIFF
--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -14,7 +14,7 @@ import SwiftShims
 
 /// A type that can represent a string as a collection of characters.
 public protocol StringProtocol
-  : RangeReplaceableCollection, BidirectionalCollection,
+  : BidirectionalCollection,
   CustomDebugStringConvertible,
   CustomReflectable, CustomPlaygroundQuickLookable,
   TextOutputStream, TextOutputStreamable,

--- a/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
+++ b/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-extension String : StringProtocol {
+extension String : StringProtocol, RangeReplaceableCollection {
   /// The index type for subscripting a string.
   public typealias Index = CharacterView.Index
 


### PR DESCRIPTION
* Explanation: StringProtocol used to refine RangeReplaceableCollection which rendered it impossible to conform to by the immutable string types.
* Scope of Issue: Changes the behavior of the protocol introduced in Beta 1
* Risk: Minimal
* Reviewed By: Dave Abrahams
* Testing: AUtomated test suite
* Directions for QA: N/A
* Radar: <rdar://problem/33137388>