### PR TITLE
[stdlib] Correct UnsafeRawPointer.bindMemory example

### DIFF
--- a/stdlib/public/core/UnsafePointer.swift.gyb
+++ b/stdlib/public/core/UnsafePointer.swift.gyb
@@ -108,7 +108,7 @@
 /// example binds the memory referenced by `uint8Pointer` to one instance of
 /// the `UInt64` type:
 ///
-///     let uint64Pointer = Unsafe${Mutable}RawPointer(uint64Pointer)
+///     let uint64Pointer = Unsafe${Mutable}RawPointer(uint8Pointer)
 ///                               .bindMemory(to: UInt64.self, capacity: 1)
 ///
 /// After rebinding the memory referenced by `uint8Pointer` to `UInt64`,


### PR DESCRIPTION
<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
