### PR TITLE
Sema: Coerce [keyPath:] index to rvalue.

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -1308,6 +1308,7 @@ namespace {
       
       // Apply a key path if we have one.
       if (choice.getKind() == OverloadChoiceKind::KeyPathApplication) {
+        index = cs.coerceToRValue(index);
         // The index argument should be (keyPath: KeyPath<Root, Value>).
         auto keyPathTTy = cs.getType(index)->castTo<TupleType>()
           ->getElementType(0);

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -322,6 +322,10 @@ func testKeyPathSubscriptTuple(readonly: (Z,Z), writable: inout (Z,Z),
   writable[keyPath: rkp] = sink
 }
 
+func testKeyPathSubscriptLValue(base: Z, kp: inout KeyPath<Z, Z>) {
+  _ = base[keyPath: kp]
+}
+
 struct AA {
   subscript(x: Int) -> Int { return x }
   var c: CC? = CC()


### PR DESCRIPTION
Fixes SR-5384 | rdar://problem/33160409.