### PR TITLE
[4.0] Sema: Coerce [keyPath:] index to rvalue.

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -1312,6 +1312,7 @@ namespace {
       
       // Apply a key path if we have one.
       if (choice.getKind() == OverloadChoiceKind::KeyPathApplication) {
+        index = cs.coerceToRValue(index);
         // The index argument should be (keyPath: KeyPath<Root, Value>).
         auto keyPathTTy = cs.getType(index)->castTo<TupleType>()
           ->getElementType(0);

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -322,6 +322,10 @@ func testKeyPathSubscriptTuple(readonly: (Z,Z), writable: inout (Z,Z),
   writable[keyPath: rkp] = sink
 }
 
+func testKeyPathSubscriptLValue(base: Z, kp: inout KeyPath<Z, Z>) {
+  _ = base[keyPath: kp]
+}
+
 struct AA {
   subscript(x: Int) -> Int { return x }
   var c: CC? = CC()


### PR DESCRIPTION
Explanation: The type checker would attempt to construct an invalid AST for the index argument to a `base[keyPath: kp]` expression when `kp` is an lvalue.

Scope: Affects anyone using `var` key path values.

Issue: SR-5384 | rdar://problem/33160409.

Risk: Low, small bug fix to key paths. Shouldn't affect other code.

Testing: Swift CI