### PR TITLE
[4.0] Support keypaths with dependently-generic computed components.

### DIFF
--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -682,6 +682,14 @@ public:
 
   static LinkInfo get(IRGenModule &IGM, const LinkEntity &entity,
                       ForDefinition_t forDefinition);
+  
+  static LinkInfo get(const UniversalLinkageInfo &linkInfo,
+                      StringRef name,
+                      SILLinkage linkage,
+                      bool isFragile,
+                      bool isSILOnly,
+                      ForDefinition_t isDefinition,
+                      bool isWeakImported);
 
   StringRef getName() const {
     return Name.str();

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -4588,7 +4588,7 @@ class SuperMethodInst
 
   SuperMethodInst(SILDebugLocation DebugLoc, SILValue Operand,
                   SILDeclRef Member, SILType Ty, bool Volatile = false)
-      : UnaryInstructionBase(DebugLoc, Operand, Ty, Member, Volatile) {}
+      : UnaryInstructionBase(DebugLoc, Operand, Ty, Member, Volatile) {}      
 };
 
 /// WitnessMethodInst - Given a type, a protocol conformance,

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1522,6 +1522,23 @@ LinkInfo LinkInfo::get(const UniversalLinkageInfo &linkInfo,
   return result;
 }
 
+LinkInfo LinkInfo::get(const UniversalLinkageInfo &linkInfo,
+                       StringRef name,
+                       SILLinkage linkage,
+                       bool isFragile,
+                       bool isSILOnly,
+                       ForDefinition_t isDefinition,
+                       bool isWeakImported) {
+  LinkInfo result;
+  
+  result.Name += name;
+  std::tie(result.Linkage, result.Visibility, result.DLLStorageClass) =
+    getIRLinkage(linkInfo, linkage, isFragile, isSILOnly,
+                 isDefinition, isWeakImported);
+  result.ForDefinition = isDefinition;
+  return result;
+}
+                       
 static bool isPointerTo(llvm::Type *ptrTy, llvm::Type *objTy) {
   return cast<llvm::PointerType>(ptrTy)->getElementType() == objTy;
 }

--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -935,7 +935,7 @@ static llvm::Function *emitPartialApplicationForwarder(IRGenModule &IGM,
     SubstitutionMap subMap;
     if (auto genericSig = origType->getGenericSignature())
       subMap = genericSig->getSubstitutionMap(subs);
-    emitPolymorphicArguments(subIGF, origType, substType, subMap,
+    emitPolymorphicArguments(subIGF, origType, subMap,
                              &witnessMetadata, polyArgs);
   }
 
@@ -1139,7 +1139,7 @@ static llvm::Function *emitPartialApplicationForwarder(IRGenModule &IGM,
       SubstitutionMap subMap;
       if (auto genericSig = origType->getGenericSignature())
         subMap = genericSig->getSubstitutionMap(subs);
-      emitPolymorphicArguments(subIGF, origType, substType, subMap,
+      emitPolymorphicArguments(subIGF, origType, subMap,
                                &witnessMetadata, polyArgs);
     }
   }

--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -18,7 +18,9 @@
 #include "ConstantBuilder.h"
 #include "Explosion.h"
 #include "GenClass.h"
+#include "GenDecl.h"
 #include "GenMeta.h"
+#include "GenProto.h"
 #include "GenStruct.h"
 #include "GenericRequirement.h"
 #include "IRGenDebugInfo.h"
@@ -27,6 +29,7 @@
 #include "ProtocolInfo.h"
 #include "StructLayout.h"
 #include "llvm/ADT/SetVector.h"
+#include "llvm/IR/Module.h"
 #include "swift/SIL/SILInstruction.h"
 #include "swift/SIL/SILLocation.h"
 #include "swift/SIL/TypeLowering.h"
@@ -37,9 +40,211 @@
 #include "swift/AST/DiagnosticsIRGen.h"
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/Types.h"
+#include "swift/IRGen/Linking.h"
 
 using namespace swift;
 using namespace irgen;
+
+enum GetterOrSetter {
+  Getter,
+  Setter,
+};
+
+static llvm::Function *
+getAccessorForComputedComponent(IRGenModule &IGM,
+                                const KeyPathPatternComponent &component,
+                                GetterOrSetter whichAccessor,
+                                GenericEnvironment *genericEnv,
+                                ArrayRef<GenericRequirement> requirements) {
+  SILFunction *accessor;
+  switch (whichAccessor) {
+  case Getter:
+    accessor = component.getComputedPropertyGetter();
+    break;
+  case Setter:
+    accessor = component.getComputedPropertySetter();
+    break;
+  }
+  
+  auto accessorFn = IGM.getAddrOfSILFunction(accessor, NotForDefinition);
+  
+  // If the accessor is not generic, we can use it as is.
+  if (requirements.empty()) {
+    return accessorFn;
+  }
+  
+  auto accessorFnTy = accessorFn->getType()->getPointerElementType();
+  
+  // Otherwise, we need a thunk to unmarshal the generic environment from the
+  // argument area. It'd be nice to have a good way to represent this
+  // directly in SIL, of course...
+  auto thunkType = llvm::FunctionType::get(
+      IGM.VoidTy,
+      { /*sret or newValue*/ accessorFnTy->getFunctionParamType(0),
+        /*base*/ accessorFnTy->getFunctionParamType(1),
+        /*arg*/ IGM.Int8PtrTy },
+      /*vararg*/ false);
+  const char *thunkName;
+  unsigned numArgsToForward = 2;
+  switch (whichAccessor) {
+  case Getter:
+    thunkName = "keypath_get";
+    break;
+  case Setter:
+    thunkName = "keypath_set";
+    break;
+  }
+  
+  auto accessorThunk = llvm::Function::Create(thunkType,
+    llvm::GlobalValue::PrivateLinkage, thunkName, IGM.getModule());
+  accessorThunk->setAttributes(IGM.constructInitialAttributes());
+  // Original accessor's args should be @in or @out, meaning they won't be
+  // captured or aliased.
+  accessorThunk->addAttribute(1, llvm::Attribute::NoCapture);
+  accessorThunk->addAttribute(1, llvm::Attribute::NoAlias);
+  accessorThunk->addAttribute(2, llvm::Attribute::NoCapture);
+  accessorThunk->addAttribute(2, llvm::Attribute::NoAlias);
+  // Getter's output is sret.
+  if (whichAccessor == Getter)
+    accessorThunk->addAttribute(1, llvm::Attribute::StructRet);
+  accessorThunk->setCallingConv(IGM.SwiftCC);
+  
+  {
+    IRGenFunction IGF(IGM, accessorThunk);
+    if (IGM.DebugInfo)
+      IGM.DebugInfo->emitArtificialFunction(IGF, accessorThunk);
+      
+    auto params = IGF.collectParameters();
+    Explosion forwardedArgs;
+    forwardedArgs.add(params.claim(numArgsToForward));
+    
+    // The generic environment is marshaled into the beginning of the component
+    // argument area inside the instance. Bind the generic information out of
+    // the buffer, and advance past it.
+    auto componentArgsBuf = params.claimNext();
+    bindFromGenericRequirementsBuffer(IGF, requirements,
+      Address(componentArgsBuf, IGM.getPointerAlignment()),
+      [&](CanType t) {
+        if (!genericEnv)
+          return t;
+        return genericEnv->mapTypeIntoContext(t)->getCanonicalType();
+      });
+      
+    /* TODO: If the underlying accessor wants index arguments, advance the
+     * pointer past the generic requirements here to pass down. */
+     
+    // Use the bound generic metadata to form a call to the original generic
+    // accessor.
+    WitnessMetadata witnessMetadata;
+    auto forwardingSubs = genericEnv->getGenericSignature()->getSubstitutionMap(
+      genericEnv->getForwardingSubstitutions());
+    emitPolymorphicArguments(IGF, accessor->getLoweredFunctionType(),
+                             forwardingSubs,
+                             &witnessMetadata,
+                             forwardedArgs);
+    auto call = IGF.Builder.CreateCall(accessorFn, forwardedArgs.claimAll());
+    if (whichAccessor == Getter)
+      call->addAttribute(1, llvm::Attribute::StructRet);
+    
+    IGF.Builder.CreateRetVoid();
+  }
+  
+  return accessorThunk;
+}
+
+static llvm::Constant *
+getLayoutFunctionForComputedComponent(IRGenModule &IGM,
+                                    const KeyPathPatternComponent &component,
+                                    GenericEnvironment *genericEnv,
+                                    ArrayRef<GenericRequirement> requirements) {
+  // Generate a function that returns the expected size and alignment necessary
+  // to store captured generic context and subscript index arguments.
+  auto retTy = llvm::StructType::get(IGM.getLLVMContext(),
+                                     {IGM.SizeTy, IGM.SizeTy});
+  auto fnTy = llvm::FunctionType::get(
+    retTy, { IGM.Int8PtrTy }, /*vararg*/ false);
+    
+  auto layoutFn = llvm::Function::Create(fnTy,
+    llvm::GlobalValue::PrivateLinkage, "keypath_get_arg_layout", IGM.getModule());
+    
+  {
+    IRGenFunction IGF(IGM, layoutFn);
+    // TODO: We would need to unmarshal generic arguments to be able to
+    // compute the layout of dependent subscript indexes.
+    (void)IGF.collectParameters().claimNext();
+    
+    // Base size is one pointer for each generic requirement; base alignment
+    // is pointer alignment.
+    llvm::Value *size = llvm::ConstantInt::get(IGM.SizeTy,
+      IGM.getPointerSize().getValue() * requirements.size());
+    llvm::Value *alignMask = llvm::ConstantInt::get(IGM.SizeTy,
+      IGM.getPointerAlignment().getValue() - 1);
+      
+    // TODO: Combine layout of captured index values
+    
+    llvm::Value *retValue = IGF.Builder.CreateInsertValue(
+      llvm::UndefValue::get(retTy), size, 0);
+    retValue = IGF.Builder.CreateInsertValue(
+      retValue, alignMask, 1);
+      
+    IGF.Builder.CreateRet(retValue);
+  }
+  
+  return layoutFn;
+}
+
+static llvm::Constant *
+getWitnessTableForComputedComponent(IRGenModule &IGM,
+                                    const KeyPathPatternComponent &component,
+                                    GenericEnvironment *genericEnv,
+                                    ArrayRef<GenericRequirement> requirements) {
+  // If the only thing we're capturing is generic environment, then we can
+  // use a prefab witness table from the runtime.
+  // TODO: If there were subscript indexes, we'd need to generate something.
+  if (auto existing =
+        IGM.Module.getNamedGlobal("swift_keyPathGenericWitnessTable"))
+    return existing;
+  
+  auto linkInfo = LinkInfo::get(IGM, "swift_keyPathGenericWitnessTable",
+                                SILLinkage::PublicExternal,
+                                /*fragile*/ false,
+                                /*sil only*/ false,
+                                NotForDefinition,
+                                /*weak imported*/ false);
+  
+  return createVariable(IGM, linkInfo,
+                        IGM.Int8PtrTy, IGM.getPointerAlignment());
+}
+
+static llvm::Constant *
+getInitializerForComputedComponent(IRGenModule &IGM,
+                                   const KeyPathPatternComponent &component,
+                                   GenericEnvironment *genericEnv,
+                                   ArrayRef<GenericRequirement> requirements) {
+  auto fnTy = llvm::FunctionType::get(IGM.VoidTy,
+    { /*src*/ IGM.Int8PtrTy,
+      /*dest*/ IGM.Int8PtrTy }, /*vararg*/ false);
+      
+  auto initFn = llvm::Function::Create(fnTy,
+    llvm::GlobalValue::PrivateLinkage, "keypath_arg_init", IGM.getModule());
+    
+  {
+    IRGenFunction IGF(IGM, initFn);
+    auto params = IGF.collectParameters();
+    auto src = params.claimNext();
+    auto dest = params.claimNext();
+    
+    // Transfer all of the requirements into the destination instance.
+    IGF.Builder.CreateMemCpy(dest, src,
+                         IGM.getPointerSize().getValue() * requirements.size(),
+                         IGM.getPointerAlignment().getValue());
+    
+    // TODO: Copy over subscript index values.
+    
+    IGF.Builder.CreateRetVoid();
+  }
+  return initFn;
+}
 
 llvm::Constant *
 IRGenModule::getAddrOfKeyPathPattern(KeyPathPattern *pattern,
@@ -365,7 +570,8 @@ IRGenModule::getAddrOfKeyPathPattern(KeyPathPattern *pattern,
       fields.add(idValue);
       
       if (isInstantiableInPlace) {
-        // No generic arguments, so we can invoke the getter/setter as is.
+        // No generic arguments or indexes, so we can invoke the
+        // getter/setter as is.
         fields.add(getAddrOfSILFunction(component.getComputedPropertyGetter(),
                                         NotForDefinition));
         if (settable)
@@ -375,10 +581,31 @@ IRGenModule::getAddrOfKeyPathPattern(KeyPathPattern *pattern,
         // If there's generic context (TODO: or subscript indexes), embed as
         // arguments in the component. Thunk the SIL-level accessors to give the
         // runtime implementation a polymorphically-callable interface.
-        Context.Diags.diagnose(diagLoc.getSourceLoc(),
-                               diag::not_implemented,
-                               "generic computed key paths");
-        return llvm::UndefValue::get(Int8PtrTy);
+        
+        // Push the accessors, possibly thunked to marshal generic environment.
+        fields.add(getAccessorForComputedComponent(*this, component, Getter,
+                                                     genericEnv, requirements));
+        if (settable)
+          fields.add(getAccessorForComputedComponent(*this, component, Setter,
+                                                     genericEnv, requirements));
+                                                     
+        fields.add(getLayoutFunctionForComputedComponent(*this, component,
+                                                     genericEnv, requirements));
+                                                     
+        // Set up a "witness table" for the component that handles copying,
+        // destroying, equating, and hashing the captured contents of the
+        // component.
+        // If there are only generic parameters, we can use a prefab witness
+        // table from the runtime.
+        // TODO: For subscripts we'd generate functions that dispatch out to
+        // the copy/destroy/equals/hash functionality of the subscript indexes.
+        fields.add(getWitnessTableForComputedComponent(*this, component,
+                                                     genericEnv, requirements));
+        
+        // Add an initializer function that copies generic arguments out of the
+        // pattern argument buffer into the instantiated object.
+        fields.add(getInitializerForComputedComponent(*this, component,
+                                                     genericEnv, requirements));
       }
       break;
     }

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -2424,7 +2424,7 @@ namespace {
                              CanSILFunctionType polyFn)
       : PolymorphicConvention(IGF.IGM, polyFn), IGF(IGF) {}
 
-    void emit(CanSILFunctionType substFnType, const SubstitutionMap &subs,
+    void emit(const SubstitutionMap &subs,
               WitnessMetadata *witnessMetadata, Explosion &out);
 
   private:
@@ -2457,16 +2457,13 @@ namespace {
 /// Pass all the arguments necessary for the given function.
 void irgen::emitPolymorphicArguments(IRGenFunction &IGF,
                                      CanSILFunctionType origFnType,
-                                     CanSILFunctionType substFnType,
                                      const SubstitutionMap &subs,
                                      WitnessMetadata *witnessMetadata,
                                      Explosion &out) {
-  EmitPolymorphicArguments(IGF, origFnType).emit(substFnType, subs,
-                                                 witnessMetadata, out);
+  EmitPolymorphicArguments(IGF, origFnType).emit(subs, witnessMetadata, out);
 }
 
-void EmitPolymorphicArguments::emit(CanSILFunctionType substFnType,
-                                    const SubstitutionMap &subs,
+void EmitPolymorphicArguments::emit(const SubstitutionMap &subs,
                                     WitnessMetadata *witnessMetadata,
                                     Explosion &out) {
   // Add all the early sources.

--- a/lib/IRGen/GenProto.h
+++ b/lib/IRGen/GenProto.h
@@ -117,7 +117,6 @@ namespace irgen {
   /// generics clause.
   void emitPolymorphicArguments(IRGenFunction &IGF,
                                 CanSILFunctionType origType,
-                                CanSILFunctionType substType,
                                 const SubstitutionMap &subs,
                                 WitnessMetadata *witnessMetadata,
                                 Explosion &args);

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -427,7 +427,7 @@ static bool isReturnAttribute(llvm::Attribute::AttrKind Attr) {
 
 llvm::Constant *swift::getRuntimeFn(llvm::Module &Module,
                       llvm::Constant *&cache,
-                      char const *name,
+                      const char *name,
                       llvm::CallingConv::ID cc,
                       llvm::ArrayRef<llvm::Type*> retTypes,
                       llvm::ArrayRef<llvm::Type*> argTypes,

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -2176,7 +2176,7 @@ void IRGenSILFunction::visitFullApplySite(FullApplySite site) {
     SubstitutionMap subMap;
     if (auto genericSig = origCalleeType->getGenericSignature())
       subMap = genericSig->getSubstitutionMap(site.getSubstitutions());
-    emitPolymorphicArguments(*this, origCalleeType, substCalleeType,
+    emitPolymorphicArguments(*this, origCalleeType,
                              subMap, &witnessMetadata, llArgs);
   }
 

--- a/stdlib/public/stubs/CMakeLists.txt
+++ b/stdlib/public/stubs/CMakeLists.txt
@@ -2,6 +2,7 @@ set(swift_stubs_sources
     Assert.cpp
     CommandLine.cpp
     GlobalObjects.cpp
+    KeyPaths.cpp
     LibcShims.cpp
     Stubs.cpp
     UnicodeExtendedGraphemeClusters.cpp.gyb)

--- a/stdlib/public/stubs/KeyPaths.cpp
+++ b/stdlib/public/stubs/KeyPaths.cpp
@@ -1,0 +1,48 @@
+//===--- KeyPaths.cpp - Key path helper symbols ---------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "../SwiftShims/Visibility.h"
+#include "swift/Runtime/Config.h"
+#include <cstdint>
+#include <cstring>
+
+SWIFT_CC(swift)
+static void copyGenericArguments(const void *src, void *dest, size_t bytes) {
+  memcpy(dest, src, bytes);
+}
+
+SWIFT_CC(swift)
+static bool equateGenericArguments(const void *a, const void *b, size_t bytes) {
+  // Generic arguments can't affect equality, since an equivalent key path may
+  // have been formed in a fully concrete context without capturing generic
+  // arguments.
+  return true;
+}
+
+SWIFT_CC(swift)
+static intptr_t hashGenericArguments(const void *src, size_t bytes) {
+  // Generic arguments can't affect equality, since an equivalent key path may
+  // have been formed in a fully concrete context without capturing generic
+  // arguments. The implementation recognizes a hash value return of '0' as
+  // "no effect on the hash".
+  return 0;
+}
+
+/// A prefab witness table for computed key path components that only include
+/// captured generic arguments.
+SWIFT_RUNTIME_EXPORT
+void *(swift_keyPathGenericWitnessTable[]) = {
+  nullptr, // no destructor necessary
+  (void*)(uintptr_t)copyGenericArguments,
+  (void*)(uintptr_t)equateGenericArguments,
+  (void*)(uintptr_t)hashGenericArguments,
+};

--- a/stdlib/public/stubs/Stubs.cpp
+++ b/stdlib/public/stubs/Stubs.cpp
@@ -564,3 +564,4 @@ int swift::_swift_stdlib_putc_stderr(int C) {
 size_t swift::_swift_stdlib_getHardwareConcurrency() {
   return std::thread::hardware_concurrency();
 }
+

--- a/test/IRGen/builtins.swift
+++ b/test/IRGen/builtins.swift
@@ -646,29 +646,34 @@ func acceptsBuiltinUnknownObject(_ ref: inout Builtin.UnknownObject?) {}
 // ObjC
 // CHECK-LABEL: define hidden {{.*}}i1 @_T08builtins8isUniqueBi1_BOSgzF({{%.*}}* nocapture dereferenceable({{.*}})) {{.*}} {
 // CHECK-NEXT: entry:
-// CHECK-NEXT: bitcast [[BUILTIN_UNKNOWN_OBJECT_TY]]* %0 to %objc_object**
-// CHECK-NEXT: load %objc_object*, %objc_object** %1
-// CHECK-NEXT: call i1 @swift_isUniquelyReferencedNonObjC(%objc_object* %2)
+// CHECK-NEXT: bitcast [[BUILTIN_UNKNOWN_OBJECT_TY]]* %0 to [[UNKNOWN_OBJECT:%objc_object|%swift\.refcounted]]**
+// CHECK-NEXT: load [[UNKNOWN_OBJECT]]*, [[UNKNOWN_OBJECT]]** %1
+// CHECK-objc-NEXT: call i1 @swift_isUniquelyReferencedNonObjC([[UNKNOWN_OBJECT]]* %2)
+// CHECK-native-NEXT: call i1 @swift_isUniquelyReferenced_native([[UNKNOWN_OBJECT]]* %2)
 // CHECK-NEXT: ret i1 %3
 func isUnique(_ ref: inout Builtin.UnknownObject?) -> Bool {
   return Builtin.isUnique(&ref)
 }
 
 // ObjC nonNull
-// CHECK-LABEL: define hidden {{.*}}i1 @_T08builtins8isUniqueBi1_BOzF(%objc_object** nocapture dereferenceable({{.*}})) {{.*}} {
+// CHECK-LABEL: define hidden {{.*}}i1 @_T08builtins8isUniqueBi1_BOzF
+// CHECK-SAME:    ([[UNKNOWN_OBJECT]]** nocapture dereferenceable({{.*}})) {{.*}} {
 // CHECK-NEXT: entry:
-// CHECK-NEXT: load %objc_object*, %objc_object** %0
-// CHECK-NEXT: call i1 @swift_isUniquelyReferencedNonObjC_nonNull(%objc_object* %1)
+// CHECK-NEXT: load [[UNKNOWN_OBJECT]]*, [[UNKNOWN_OBJECT]]** %0
+// CHECK-objc-NEXT: call i1 @swift_isUniquelyReferencedNonObjC_nonNull([[UNKNOWN_OBJECT]]* %1)
+// CHECK-native-NEXT: call i1 @swift_rt_swift_isUniquelyReferenced_nonNull_native([[UNKNOWN_OBJECT]]* %1)
 // CHECK-NEXT: ret i1 %2
 func isUnique(_ ref: inout Builtin.UnknownObject) -> Bool {
   return Builtin.isUnique(&ref)
 }
 
 // ObjC pinned nonNull
-// CHECK-LABEL: define hidden {{.*}}i1 @_T08builtins16isUniqueOrPinnedBi1_BOzF(%objc_object** nocapture dereferenceable({{.*}})) {{.*}} {
+// CHECK-LABEL: define hidden {{.*}}i1 @_T08builtins16isUniqueOrPinnedBi1_BOzF
+// CHECK-SAME:    ([[UNKNOWN_OBJECT]]** nocapture dereferenceable({{.*}})) {{.*}} {
 // CHECK-NEXT: entry:
-// CHECK-NEXT: load %objc_object*, %objc_object** %0
-// CHECK-NEXT: call i1 @swift_isUniquelyReferencedOrPinnedNonObjC_nonNull(%objc_object* %1)
+// CHECK-NEXT: load [[UNKNOWN_OBJECT]]*, [[UNKNOWN_OBJECT]]** %0
+// CHECK-native-NEXT: call i1 @swift_rt_swift_isUniquelyReferencedOrPinned_nonNull_native([[UNKNOWN_OBJECT]]* %1)
+// CHECK-objc-NEXT: call i1 @swift_isUniquelyReferencedOrPinnedNonObjC_nonNull([[UNKNOWN_OBJECT]]* %1)
 // CHECK-NEXT: ret i1 %2
 func isUniqueOrPinned(_ ref: inout Builtin.UnknownObject) -> Bool {
   return Builtin.isUniqueOrPinned(&ref)

--- a/test/IRGen/enum_value_semantics_special_cases_objc.sil
+++ b/test/IRGen/enum_value_semantics_special_cases_objc.sil
@@ -15,7 +15,7 @@ enum NullableObjCRefcounted {
 // CHECK:   %0 = bitcast %swift.opaque* %object to %T39enum_value_semantics_special_cases_objc22NullableObjCRefcountedO*
 // CHECK:   %1 = bitcast %T39enum_value_semantics_special_cases_objc22NullableObjCRefcountedO* %0 to %objc_object**
 // CHECK:   %2 = load %objc_object*, %objc_object** %1, align 8
-// CHECK:   call void @objc_release(%objc_object* %2) {{#[0-9]+}}
+// CHECK:   call void @swift_unknownRelease(%objc_object* %2) {{#[0-9]+}}
 // CHECK:   ret void
 // CHECK: }
 

--- a/test/IRGen/keypaths.sil
+++ b/test/IRGen/keypaths.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-%target-os
 
 sil_stage canonical
 import Swift
@@ -290,3 +290,14 @@ entry:
 // CHECK:   [[BUF:%.*]] = bitcast i8* %0
 // CHECK:   [[A:%.*]] = load %swift.type*, %swift.type** [[BUF]]
 // CHECK:   ret %swift.type* [[A]]
+
+// CHECK-LABEL: define{{( protected)?}} swiftcc void @computed_property_generics
+sil @computed_property_generics : $@convention(thin) <T, U> () -> () {
+entry:
+  %n = keypath $WritableKeyPath<T, U>, <UUU, TTT> (root $TTT; settable_property $UUU, id @n_get : $@convention(thin) <UU, TT> (@in TT) -> @out UU, getter @n_get : $@convention(thin) <UU, TT> (@in TT) -> @out UU, setter @n_set : $@convention(thin) <UU, TT> (@in UU, @in TT) -> ()) <U, T>
+
+  return undef : $()
+}
+
+sil @n_get : $@convention(thin) <UU, TT> (@in TT) -> @out UU
+sil @n_set : $@convention(thin) <UU, TT> (@in UU, @in TT) -> ()

--- a/test/IRGen/unknown_object.sil
+++ b/test/IRGen/unknown_object.sil
@@ -1,0 +1,17 @@
+// RUN: %target-swift-frontend -emit-ir %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-%target-runtime %s
+
+sil_stage canonical
+
+import Builtin
+
+// CHECK-LABEL: @retain_release_unknown_object
+sil @retain_release_unknown_object : $@convention(thin) (@guaranteed Builtin.UnknownObject) -> () {
+entry(%x : $Builtin.UnknownObject):
+  // CHECK-native: swift_retain
+  // CHECK-objc: swift_unknownRetain
+  %y = copy_value %x : $Builtin.UnknownObject
+  // CHECK-native: swift_release
+  // CHECK-objc: swift_unknownRelease
+  destroy_value %y : $Builtin.UnknownObject
+  return undef : $()
+}

--- a/test/stdlib/KeyPath.swift
+++ b/test/stdlib/KeyPath.swift
@@ -421,7 +421,6 @@ func makeKeyPathInGenericContext<T>(of: T.Type)
 
 keyPath.test("computed generic key paths") {
   let path = makeKeyPathInGenericContext(of: LifetimeTracked.self)
-
   let z = LifetimeTracked(456)
   let c = C(x: 42, y: LifetimeTracked(123), z: z)
 
@@ -439,9 +438,10 @@ keyPath.test("computed generic key paths") {
 
   let pathNonGeneric = \C<LifetimeTracked>.computed
   expectEqual(path, pathNonGeneric)
-  expectEqual(path.hashValue, path2.hashValue)
+  expectEqual(path.hashValue, pathNonGeneric.hashValue)
 
   let valuePath = path.appending(path: \LifetimeTracked.value)
+
   expectEqual(c[keyPath: valuePath], 789)
 
   let valuePathNonGeneric = pathNonGeneric.appending(path: \LifetimeTracked.value)


### PR DESCRIPTION
Explanation: Adds support for keypaths that reference computed properties requiring the capture of generic context.

Scope: Completes the support for property references in key paths. The previous restriction here is difficult to explain to users otherwise.

Issue: rdar://problem/31768590

Risk: Low. Additive improvement to key paths, should be almost no impact on the rest of the compiler.

Testing: Swift CI