### PR TITLE
Fix the swap_refcnt test on linux.

### DIFF
--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -269,6 +269,8 @@ PASS(SemanticARCOpts, "semantic-arc-opts",
      "Semantic ARC Optimization")
 PASS(MarkUninitializedFixup, "mark-uninitialized-fixup",
      "Temporary pass for staging in mark_uninitialized changes.")
+PASS(SimplifyUnreachableContainingBlocks, "simplify-unreachable-containing-blocks",
+     "Utility pass. Removes all non-term insts from blocks with unreachable terms")
 PASS(BugReducerTester, "bug-reducer-tester",
      "sil-bug-reducer Tool Testing by Asserting on a Sentinel Function")
 PASS_RANGE(AllPasses, AADumper, BugReducerTester)

--- a/lib/SILOptimizer/UtilityPasses/CMakeLists.txt
+++ b/lib/SILOptimizer/UtilityPasses/CMakeLists.txt
@@ -23,6 +23,7 @@ set(UTILITYPASSES_SOURCES
   UtilityPasses/RCIdentityDumper.cpp
   UtilityPasses/SILDebugInfoGenerator.cpp
   UtilityPasses/SideEffectsDumper.cpp
+  UtilityPasses/SimplifyUnreachableContainingBlocks.cpp
   UtilityPasses/StripDebugInfo.cpp
   UtilityPasses/ValueOwnershipKindDumper.cpp
   PARENT_SCOPE)

--- a/lib/SILOptimizer/UtilityPasses/SimplifyUnreachableContainingBlocks.cpp
+++ b/lib/SILOptimizer/UtilityPasses/SimplifyUnreachableContainingBlocks.cpp
@@ -1,0 +1,61 @@
+//===--- SimplifyUnreachableContainingBlocks.cpp --------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+///
+/// This file contains a simple utility pass that simplifies blocks that contain
+/// unreachables by eliminating all other instructions. This includes
+/// instructions with side-effects and no-return functions. It is only intended
+/// to be used to simplify IR for testing or exploratory purposes.
+///
+//===----------------------------------------------------------------------===//
+
+#include "swift/SILOptimizer/PassManager/Passes.h"
+#include "swift/SIL/SILBasicBlock.h"
+#include "swift/SILOptimizer/PassManager/Transforms.h"
+
+using namespace swift;
+
+namespace {
+
+class SimplifyUnreachableContainingBlocks : public SILFunctionTransform {
+  void run() override {
+    // For each block...
+    for (auto &BB : *getFunction()) {
+      // If the block does not contain an unreachable, just continue. There is
+      // no further work to do.
+      auto *UI = dyn_cast<UnreachableInst>(BB.getTerminator());
+      if (!UI)
+        continue;
+
+      // Otherwise, eliminate all other instructions in the block.
+      for (auto II = BB.begin(); &*II != UI;) {
+        // Avoid iterator invalidation.
+        auto *I = &*II;
+        ++II;
+
+        I->replaceAllUsesWithUndef();
+        I->eraseFromParent();
+      }
+    }
+  }
+};
+
+} // end anonymous namespace
+
+//===----------------------------------------------------------------------===//
+//                           Top Level Entry Point
+//===----------------------------------------------------------------------===//
+
+SILTransform *swift::createSimplifyUnreachableContainingBlocks() {
+  return new SimplifyUnreachableContainingBlocks();
+}

--- a/test/SILOptimizer/simplify_unreachable_containing_blocks.sil
+++ b/test/SILOptimizer/simplify_unreachable_containing_blocks.sil
@@ -1,0 +1,27 @@
+// RUN: %target-sil-opt -simplify-unreachable-containing-blocks -assume-parsing-unqualified-ownership-sil -module-name Swift -enable-sil-verify-all %s | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+
+enum Never {}
+
+sil @blackhole : $@convention(thin) () -> Never
+
+// CHECK-LABEL: sil @test1 : $@convention(thin) () -> () {
+// CHECK-NOT: function_ref
+// CHECK-NOT: apply
+// CHECK: } // end sil function 'test1'
+sil @test1 : $@convention(thin) () -> () {
+bb0:
+  cond_br undef, bb1, bb2
+
+bb1:
+  %0 = function_ref @blackhole : $@convention(thin) () -> Never
+  apply %0() : $@convention(thin) () -> Never
+  unreachable
+
+bb2:
+  %9999 = tuple()
+  return %9999 : $()
+}

--- a/test/SILOptimizer/swap_refcnt.swift
+++ b/test/SILOptimizer/swap_refcnt.swift
@@ -1,14 +1,11 @@
-// RUN: %target-swift-frontend -O -emit-sil %s | %FileCheck %s
+// RUN: %target-swift-frontend -O -emit-sil %s | %target-sil-opt -assume-parsing-unqualified-ownership-sil -simplify-unreachable-containing-blocks | %FileCheck %s
 
-// SILOptimizer/swap_refcnt.swift fails on linux.
-// REQUIRES: rdar30181104
+// Make sure we can swap two values in an array without retaining anything along non-fatalerror paths.
 
-// Make sure we can swap two values in an array without retaining anything.
-
-// CHECK-LABEL: sil @_TF11swap_refcnt11swapByIndex
+// CHECK-LABEL: sil @_T011swap_refcnt0A7ByIndexySays4Int8VGz1A_Si1xSi1ytF : $@convention(thin) (@inout Array<Int8>, Int, Int) -> () {
 // CHECK-NOT: strong_retain
 // CHECK-NOT: strong_release
-// CHECK: return
+// CHECK: } // end sil function '_T011swap_refcnt0A7ByIndexySays4Int8VGz1A_Si1xSi1ytF'
 public func swapByIndex(A: inout [Int8], x : Int, y : Int) {
   swap(&A[x],&A[y])
 }


### PR DESCRIPTION
Fix the swap_refcnt test on linux.

The problem here is that we were performing a naive negative FileCheck test for
retain/release. In certain modes, we would not have any retains/releases along
normal control paths but would have retains on unreachable paths. This test only
is trying to test if normal code paths have this issue.

To work around this issue, I created a small utility pass that prunes all
non-unreachable instructions from blocks with an unreachable terminator. This is
useful functionality in general when analyzing SIL since often times one will
have large fatal error blocks that disguise the true behavior of the
function. In this specific case, I just pipe in the normal sil output and run it
through sil-opt. sil-opt then runs just the utility pass and I then FileCheck
that sil-opt output.

rdar://30181104
(cherry picked from commit 9933f0f3b225b71b06d614c903ea626bdadedfa5)