### PR TITLE
[WIP - DO NOT MERGE] [Constraint solver] Enable constraint propagation pass.

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -146,7 +146,7 @@ namespace swift {
 
     /// \brief Enable the experimental constraint propagation in the
     /// type checker.
-    bool EnableConstraintPropagation = false;
+    bool EnableConstraintPropagation = true;
 
     /// \brief Enable the iterative type checker.
     bool IterativeTypeChecker = false;

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1645,9 +1645,6 @@ void ConstraintSystem::shrink(Expr *expr) {
   // Disable the shrink pass when constraint propagation is
   // enabled. They achieve similar effects, and the shrink pass is
   // known to have bad behavior in some cases.
-  if (TC.Context.LangOpts.EnableConstraintPropagation)
-    return;
-
   typedef llvm::SmallDenseMap<Expr *, ArrayRef<ValueDecl *>> DomainMap;
 
   // A collection of original domains of all of the expressions,

--- a/test/Sema/complex_expressions.swift
+++ b/test/Sema/complex_expressions.swift
@@ -1,9 +1,8 @@
-// RUN: %target-typecheck-verify-swift -propagate-constraints
+// RUN: %target-typecheck-verify-swift
 
 // SR-139:
 // Infinite recursion parsing bitwise operators
-// FIXME: SR-4714 tracks re-enabling this
-// let x = UInt32(0x1FF)&0xFF << 24 | UInt32(0x1FF)&0xFF << 16 | UInt32(0x1FF)&0xFF << 8 | (UInt32(0x1FF)&0xFF);
+let x = UInt32(0x1FF)&0xFF << 24 | UInt32(0x1FF)&0xFF << 16 | UInt32(0x1FF)&0xFF << 8 | (UInt32(0x1FF)&0xFF);
 
 // SR-838:
 // expression test_seconds() was too complex to be solved in reasonable time
@@ -94,7 +93,6 @@ func sr1794(pt: P, p0: P, p1: P) -> Bool {
 let v1 = (1 - 2 / 3 * 6) as UInt
 let v2 = (([1 + 2 * 3, 4, 5])) as [UInt]
 let v3 = ["hello": 1 + 2, "world": 3 + 4 + 5 * 3] as Dictionary<String, UInt>
-// expected-warning@-1 {{mixed-type arithmetics}}
 let v4 = [1 + 2 + 3, 4] as [UInt32] + [2 * 3] as [UInt32]
 let v5 = ([1 + 2 + 3, 4] as [UInt32]) + ([2 * 3] as [UInt32])
 let v6 = [1 + 2 + 3, 4] as Set<UInt32>
@@ -123,6 +121,5 @@ struct R32034560 {
   private var R32034560: Array<Array<UInt32>>
   private func foo(x: UInt32) -> UInt32 {
     return ((self.R32034560[0][Int(x >> 24) & 0xFF] &+ self.R32034560[1][Int(x >> 16) & 0xFF]) ^ self.R32034560[2][Int(x >> 8) & 0xFF]) &+ self.R32034560[3][Int(x & 0xFF)]
-    // expected-error@-1 {{expression was too complex to be solved in reasonable time; consider breaking up the expression into distinct sub-expressions}}
   }
 }

--- a/validation-test/Sema/type_checker_perf_failing/rdar30606089.swift.gyb
+++ b/validation-test/Sema/type_checker_perf_failing/rdar30606089.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test -Xfrontend=-propagate-constraints --begin 1 --end 5 --step 1 --select incrementScopeCounter %s --polynomial-threshold 1.3
+// RUN: %scale-test --begin 1 --end 5 --step 1 --select incrementScopeCounter %s --polynomial-threshold 1.3
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 


### PR DESCRIPTION
Enable the constraint propagation pass in an effort to do a pre-pass to
reduce the amount of work we need to do during constraint solving.

There are still improvements that can be made here, but this is
currently passing tests and showing benefit in cases where we have
overloads taking concrete types, so it's worth enabling and then
incrementally improving.

Despite dramatically speeding up some test cases, because this is a
prepass it is going to result in a marginal slow-down in type checking
of some code. The type checking time for the standard library is
approximately 14% slower on my machine with this enabled (14.06s
vs. 16.03s).