### PR TITLE
Untangle some calling-convention mismatches between runtime and IRGen (also fix some warnings)

### DIFF
--- a/include/swift/Runtime/Config.h
+++ b/include/swift/Runtime/Config.h
@@ -38,7 +38,7 @@
 #ifndef SWIFT_USE_SWIFTCALL
 // Clang doesn't support mangling functions with the swiftcall attribute
 // on Windows and crashes during compilation: http://bugs.llvm.org/show_bug.cgi?id=32000
-#if (__has_attribute(swiftcall) || defined(__linux__)) && !defined(_WIN32)
+#if __has_attribute(swiftcall) && !defined(_WIN32)
 #define SWIFT_USE_SWIFTCALL 1
 #else
 #define SWIFT_USE_SWIFTCALL 0

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -26,7 +26,6 @@
 #include <type_traits>
 #include <utility>
 #include <string.h>
-#include "swift/Runtime/Config.h"
 #include "swift/ABI/MetadataValues.h"
 #include "swift/ABI/System.h"
 #include "swift/Basic/Malloc.h"

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -658,7 +658,7 @@ unsigned DeclContext::getSyntacticDepth() const {
 
 unsigned DeclContext::getSemanticDepth() const {
   // For extensions, count the depth of the nominal type being extended.
-  if (auto ext = dyn_cast<ExtensionDecl>(this)) {
+  if (isa<ExtensionDecl>(this)) {
     if (auto nominal = getAsNominalTypeOrNominalTypeExtensionContext())
       return nominal->getSemanticDepth();
 

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -5316,7 +5316,7 @@ Decl *SwiftDeclConverter::importGlobalAsMethod(
               dc->getAsNominalTypeOrNominalTypeExtensionContext()) {
         if (auto clangDCTy = dyn_cast_or_null<clang::TypedefNameDecl>(
                 nominalTypeDecl->getClangDecl()))
-          if (auto newtypeAttr = getSwiftNewtypeAttr(clangDCTy, getVersion()))
+          if (getSwiftNewtypeAttr(clangDCTy, getVersion()))
             if (clangDCTy->getUnderlyingType().getCanonicalType() !=
                 selfParamTy->getPointeeType().getCanonicalType())
               selfIsInOut = false;

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -26,7 +26,6 @@
 #include "clang/CodeGen/ModuleBuilder.h"
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/SIL/SILType.h"
-#include "swift/Runtime/Config.h"
 #include "llvm/IR/CallSite.h"
 #include "llvm/Support/Compiler.h"
 
@@ -109,7 +108,7 @@ static void addInoutParameterAttributes(IRGenModule &IGM,
 
 static llvm::CallingConv::ID getFreestandingConvention(IRGenModule &IGM) {
   // TODO: use a custom CC that returns three scalars efficiently
-  return SWIFT_LLVM_CC(SwiftCC);
+  return IGM.SwiftCC;
 }
 
 /// Expand the requirements of the given abstract calling convention

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -29,7 +29,7 @@
 #include "swift/ClangImporter/ClangModule.h"
 #include "swift/Demangling/ManglingMacros.h"
 #include "swift/IRGen/Linking.h"
-#include "swift/Runtime/HeapObject.h"
+#include "swift/ABI/HeapObject.h"
 #include "swift/SIL/FormalLinkage.h"
 #include "swift/SIL/SILDebugScope.h"
 #include "swift/SIL/SILModule.h"

--- a/lib/SILOptimizer/Mandatory/AccessEnforcementSelection.cpp
+++ b/lib/SILOptimizer/Mandatory/AccessEnforcementSelection.cpp
@@ -255,7 +255,7 @@ void SelectEnforcement::analyzeProjection(ProjectBoxInst *projection) {
 
       continue;
     }
-    if (auto *PAI = dyn_cast<PartialApplyInst>(user))
+    if (isa<PartialApplyInst>(user))
       Captures.emplace_back(AddressCapture(*use));
   }
 }

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -5392,13 +5392,13 @@ static bool isRawRepresentableMismatch(Type fromType, Type toType,
   // First check if this is an attempt to convert from something to
   // raw representable.
   if (conformsToKnownProtocol(fromType, kind, CS)) {
-    if (auto rawType = isRawRepresentable(toType, kind, CS))
+    if (isRawRepresentable(toType, kind, CS))
       return true;
   }
 
   // Otherwise, it might be an attempt to convert from raw representable
   // to its raw value.
-  if (auto rawType = isRawRepresentable(fromType, kind, CS)) {
+  if (isRawRepresentable(fromType, kind, CS)) {
     if (conformsToKnownProtocol(toType, kind, CS))
       return true;
   }

--- a/test/IRGen/dllexport.swift
+++ b/test/IRGen/dllexport.swift
@@ -33,15 +33,15 @@ open class d {
 // CHECK-DAG-OPT: @_T09dllexport1dCACycfc = dllexport alias void (), void ()* @_swift_dead_method_stub
 // CHECK-DAG-OPT: @_T09dllexport1cCACycfc = dllexport alias void (), void ()* @_swift_dead_method_stub
 // CHECK-DAG-OPT: @_T09dllexport1cCACycfC = dllexport alias void (), void ()* @_swift_dead_method_stub
-// CHECK-DAG: define dllexport swiftcc %swift.refcounted* @_T09dllexport1cCfd(%T9dllexport1cC*{{.*}})
-// CHECK-DAG-NO-OPT: define dllexport swiftcc %T9dllexport1cC* @_T09dllexport1cCACycfc(%T9dllexport1cC*)
-// CHECK-DAG-NO-OPT: define dllexport swiftcc %T9dllexport1cC* @_T09dllexport1cCACycfC(%swift.type*)
-// CHECK-DAG: define dllexport swiftcc i8* @_T09dllexport2ciAA1cCfau()
-// CHECK-DAG-NO-OPT: define dllexport swiftcc void @_T09dllexport1dC1m33_C57BA610BA35E21738CC992438E660E9LLyyF(%T9dllexport1dC*)
-// CHECK-DAG-NO-OPT: define dllexport swiftcc void @_T09dllexport1dCfD(%T9dllexport1dC*)
-// CHECK-DAG: define dllexport swiftcc %swift.refcounted* @_T09dllexport1dCfd(%T9dllexport1dC*{{.*}})
+// CHECK-DAG: define dllexport %swift.refcounted* @_T09dllexport1cCfd(%T9dllexport1cC*{{.*}})
+// CHECK-DAG-NO-OPT: define dllexport %T9dllexport1cC* @_T09dllexport1cCACycfc(%T9dllexport1cC*)
+// CHECK-DAG-NO-OPT: define dllexport %T9dllexport1cC* @_T09dllexport1cCACycfC(%swift.type*)
+// CHECK-DAG: define dllexport i8* @_T09dllexport2ciAA1cCfau()
+// CHECK-DAG-NO-OPT: define dllexport void @_T09dllexport1dC1m33_C57BA610BA35E21738CC992438E660E9LLyyF(%T9dllexport1dC*)
+// CHECK-DAG-NO-OPT: define dllexport void @_T09dllexport1dCfD(%T9dllexport1dC*)
+// CHECK-DAG: define dllexport %swift.refcounted* @_T09dllexport1dCfd(%T9dllexport1dC*{{.*}})
 // CHECK-DAG: define dllexport %swift.type* @_T09dllexport1cCMa()
 // CHECK-DAG: define dllexport %swift.type* @_T09dllexport1dCMa()
-// CHECK-DAG-NO-OPT: define dllexport swiftcc %T9dllexport1dC* @_T09dllexport1dCACycfc(%T9dllexport1dC*)
-// CHECK-DAG-OPT: define dllexport swiftcc void @_T09dllexport1dCfD(%T9dllexport1dC*)
+// CHECK-DAG-NO-OPT: define dllexport %T9dllexport1dC* @_T09dllexport1dCACycfc(%T9dllexport1dC*)
+// CHECK-DAG-OPT: define dllexport void @_T09dllexport1dCfD(%T9dllexport1dC*)
 

--- a/test/IRGen/dllimport.swift
+++ b/test/IRGen/dllimport.swift
@@ -46,8 +46,9 @@ public func g() {
 // CHECK-NO-OPT-DAG: @_T09dllexport1pMp = external dllimport global %swift.protocol
 // CHECK-NO-OPT-DAG: @_T0ytN = external dllimport global %swift.full_type
 // CHECK-NO-OPT-DAG: @_T0BoWV = external dllimport global i8*
-// CHECK-NO-OPT-DAG: declare dllimport swiftcc i8* @_T09dllexport2ciAA1cCfau()
-// CHECK-NO-OPT-DAG: declare dllimport swiftcc %swift.refcounted* @_T09dllexport1cCfd(%T9dllexport1cC* swiftself)
+
+// CHECK-NO-OPT-DAG: declare dllimport i8* @_T09dllexport2ciAA1cCfau()
+// CHECK-NO-OPT-DAG: declare dllimport %swift.refcounted* @_T09dllexport1cCfd(%T9dllexport1cC*)
 // CHECK-NO-OPT-DAG: declare dllimport %swift.type* @_T09dllexport1cCMa()
 // CHECK-NO-OPT-DAG: declare dllimport void @swift_deallocClassInstance(%swift.refcounted*, i32, i32)
 // CHECK-NO-OPT-DAG: define linkonce_odr hidden i8* @swift_rt_swift_slowAlloc(i32, i32)
@@ -61,10 +62,10 @@ public func g() {
 // CHECK-OPT-DAG: @_T09dllexport1pMp = external dllimport global %swift.protocol
 // CHECK-OPT-DAG: @_swift_slowAlloc = external dllimport local_unnamed_addr global i8* (i32, i32)*
 // CHECK-OPT-DAG: @_swift_slowDealloc = external dllimport local_unnamed_addr global void (i8*, i32, i32)*
-// CHECK-OPT-DAG: declare dllimport swiftcc i8* @_T09dllexport2ciAA1cCfau()
+// CHECK-OPT-DAG: declare dllimport i8* @_T09dllexport2ciAA1cCfau()
 // CHECK-OPT-DAG: declare dllimport %swift.type* @_T09dllexport1cCMa()
 // CHECK-OPT-DAG: declare dllimport void @swift_deallocClassInstance(%swift.refcounted*, i32, i32)
-// CHECK-OPT-DAG: declare dllimport swiftcc %swift.refcounted* @_T09dllexport1cCfd(%T9dllexport1cC* swiftself)
+// CHECK-OPT-DAG: declare dllimport %swift.refcounted* @_T09dllexport1cCfd(%T9dllexport1cC*)
 // CHECK-OPT-DAG: define linkonce_odr hidden i8* @swift_rt_swift_slowAlloc(i32, i32)
 // CHECK-OPT-DAG: define linkonce_odr hidden void @swift_rt_swift_slowDealloc(i8*, i32, i32)
 


### PR DESCRIPTION
Started as some warning-gardening (mostly triggered by a clang 3.8 linux box); turned into a bit of yak shaving adventure around calling conventions when I realized that it was complaining about a host/target compiler mismatch.