### PR TITLE
[silgenpattern] Perform a copy if we have a borrowed cast operand, before we store it.

### DIFF
--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -1568,9 +1568,12 @@ emitCastOperand(SILGenFunction &SGF, SILLocation loc,
     // Okay, if all we need to do is drop the value in an address,
     // this is easy.
     if (!hasAbstraction) {
-      SGF.B.emitStoreValueOperation(
-          loc, src.getFinalManagedValue().forward(SGF), init->getAddress(),
-          StoreOwnershipQualifier::Init);
+      ManagedValue finalValue = src.getFinalManagedValue();
+      if (finalValue.getOwnershipKind() == ValueOwnershipKind::Guaranteed)
+        finalValue = finalValue.copy(SGF, loc);
+      SGF.B.emitStoreValueOperation(loc, finalValue.forward(SGF),
+                                    init->getAddress(),
+                                    StoreOwnershipQualifier::Init);
       init->finishInitialization(SGF);
       ConsumableManagedValue result =
         { init->getManagedAddress(), src.getFinalConsumption() };

--- a/test/SILGen/ownership.swift
+++ b/test/SILGen/ownership.swift
@@ -1,0 +1,21 @@
+// RUN: %target-swift-frontend -parse-stdlib -module-name Swift -parse-as-library -emit-silgen -enable-sil-ownership %s | %FileCheck %s
+
+protocol Error {}
+
+enum MyError : Error {
+case case1
+}
+
+// CHECK: bb{{[0-9]+}}([[ERROR:%.*]] : @owned $Error):
+// CHECK-NEXT:   [[BORROWED_ERROR:%.*]] = begin_borrow [[ERROR]]
+// CHECK-NEXT:   [[ERROR_SLOT:%.*]] = alloc_stack $Error
+// CHECK-NEXT:   [[COPIED_BORROWED_ERROR:%.*]] = copy_value [[BORROWED_ERROR]]
+// CHECK-NEXT:   store [[COPIED_BORROWED_ERROR]] to [init] [[ERROR_SLOT]]
+// CHECK-NEXT:   [[ERROR_SLOT_CAST_RESULT:%.*]] = alloc_stack $MyError
+// CHECK-NEXT:   checked_cast_addr_br copy_on_success Error in [[ERROR_SLOT]] : $*Error to MyError in [[ERROR_SLOT_CAST_RESULT]] : $*MyError
+func test1(f: () throws -> ()) throws {
+  do {
+    let _ = try f()
+  } catch MyError.case1 {
+  }
+}


### PR DESCRIPTION
[silgenpattern] Perform a copy if we have a borrowed cast operand, before we store it.

Sometimes in SILGenPattern, we need use an indirect cast on object that does
not require re-abstraction as an optimization. A notable case where this happens
are various casts related to NSError. In such a case, if we have a borrowed cast
operand, perform a copy before the store to preserve semantic sil invariants.

rdar://31880847