### PR TITLE
[sil-ownership-verifier] Allow class_method to take a metatype or a non-trivial type.

### DIFF
--- a/lib/SIL/SILOwnershipVerifier.cpp
+++ b/lib/SIL/SILOwnershipVerifier.cpp
@@ -552,6 +552,24 @@ ACCEPTS_ANY_OWNERSHIP_INST(UncheckedOwnershipConversion)
 #undef ACCEPTS_ANY_OWNERSHIP_INST
 
 // Trivial if trivial typed, otherwise must accept owned?
+#define ACCEPTS_ANY_NONTRIVIAL_OWNERSHIP_OR_METATYPE(                          \
+    SHOULD_CHECK_FOR_DATAFLOW_VIOLATIONS, INST)                                \
+  OwnershipUseCheckerResult                                                    \
+      OwnershipCompatibilityUseChecker::visit##INST##Inst(INST##Inst *I) {     \
+    assert(I->getNumOperands() && "Expected to have non-zero operands");       \
+    if (getType().is<AnyMetatypeType>()) {                                     \
+      return {true, false};                                                    \
+    }                                                                          \
+    assert(!isAddressOrTrivialType() &&                                        \
+           "Shouldn't have an address or a non trivial type");                 \
+    bool compatible = getOwnershipKind() == ValueOwnershipKind::Any ||         \
+                      !compatibleWithOwnership(ValueOwnershipKind::Trivial);   \
+    return {compatible, SHOULD_CHECK_FOR_DATAFLOW_VIOLATIONS};                 \
+  }
+ACCEPTS_ANY_NONTRIVIAL_OWNERSHIP_OR_METATYPE(false, ClassMethod)
+#undef ACCEPTS_ANY_NONTRIVIAL_OWNERSHIP_OR_METATYPE
+
+// Trivial if trivial typed, otherwise must accept owned?
 #define ACCEPTS_ANY_NONTRIVIAL_OWNERSHIP(SHOULD_CHECK_FOR_DATAFLOW_VIOLATIONS, \
                                          INST)                                 \
   OwnershipUseCheckerResult                                                    \
@@ -565,7 +583,6 @@ ACCEPTS_ANY_OWNERSHIP_INST(UncheckedOwnershipConversion)
   }
 ACCEPTS_ANY_NONTRIVIAL_OWNERSHIP(false, SuperMethod)
 ACCEPTS_ANY_NONTRIVIAL_OWNERSHIP(false, BridgeObjectToWord)
-ACCEPTS_ANY_NONTRIVIAL_OWNERSHIP(false, ClassMethod)
 ACCEPTS_ANY_NONTRIVIAL_OWNERSHIP(false, CopyBlock)
 ACCEPTS_ANY_NONTRIVIAL_OWNERSHIP(false, DynamicMethod)
 ACCEPTS_ANY_NONTRIVIAL_OWNERSHIP(false, OpenExistentialBox)

--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -1568,9 +1568,12 @@ emitCastOperand(SILGenFunction &SGF, SILLocation loc,
     // Okay, if all we need to do is drop the value in an address,
     // this is easy.
     if (!hasAbstraction) {
-      SGF.B.emitStoreValueOperation(
-          loc, src.getFinalManagedValue().forward(SGF), init->getAddress(),
-          StoreOwnershipQualifier::Init);
+      ManagedValue finalValue = src.getFinalManagedValue();
+      if (finalValue.getOwnershipKind() == ValueOwnershipKind::Guaranteed)
+        finalValue = finalValue.copy(SGF, loc);
+      SGF.B.emitStoreValueOperation(loc, finalValue.forward(SGF),
+                                    init->getAddress(),
+                                    StoreOwnershipQualifier::Init);
       init->finishInitialization(SGF);
       ConsumableManagedValue result =
         { init->getManagedAddress(), src.getFinalConsumption() };

--- a/test/SIL/ownership-verifier/use_verifier.sil
+++ b/test/SIL/ownership-verifier/use_verifier.sil
@@ -53,7 +53,9 @@ struct TupleContainingNonTrivialStruct {
   var opt: Optional<Builtin.NativeObject>
 }
 
-class SuperKlass {}
+class SuperKlass {
+  func d() {}
+}
 class SubKlass : SuperKlass {}
 class X {
   @objc func f() { }
@@ -338,6 +340,13 @@ sil @block_invoke_test : $@convention(thin) (@owned @convention(block) () -> ())
 bb0(%0 : @owned $@convention(block) () -> ()):
   apply %0() : $@convention(block) () -> ()
   destroy_value %0 : $@convention(block) () -> ()
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+sil @class_method_metatype_test : $@convention(thin) (@thick SuperKlass.Type) -> () {
+bb0(%0 : @trivial $@thick SuperKlass.Type):
+  %1 = class_method %0 : $@thick SuperKlass.Type, #SuperKlass.d!1 : (SuperKlass) -> () -> (), $@convention(method) (@guaranteed SuperKlass) -> ()
   %9999 = tuple()
   return %9999 : $()
 }

--- a/test/SILGen/ownership.swift
+++ b/test/SILGen/ownership.swift
@@ -1,0 +1,21 @@
+// RUN: %target-swift-frontend -parse-stdlib -module-name Swift -parse-as-library -emit-silgen -enable-sil-ownership %s | %FileCheck %s
+
+protocol Error {}
+
+enum MyError : Error {
+case case1
+}
+
+// CHECK: bb{{[0-9]+}}([[ERROR:%.*]] : @owned $Error):
+// CHECK-NEXT:   [[BORROWED_ERROR:%.*]] = begin_borrow [[ERROR]]
+// CHECK-NEXT:   [[ERROR_SLOT:%.*]] = alloc_stack $Error
+// CHECK-NEXT:   [[COPIED_BORROWED_ERROR:%.*]] = copy_value [[BORROWED_ERROR]]
+// CHECK-NEXT:   store [[COPIED_BORROWED_ERROR]] to [init] [[ERROR_SLOT]]
+// CHECK-NEXT:   [[ERROR_SLOT_CAST_RESULT:%.*]] = alloc_stack $MyError
+// CHECK-NEXT:   checked_cast_addr_br copy_on_success Error in [[ERROR_SLOT]] : $*Error to MyError in [[ERROR_SLOT_CAST_RESULT]] : $*MyError
+func test1(f: () throws -> ()) throws {
+  do {
+    let _ = try f()
+  } catch MyError.case1 {
+  }
+}


### PR DESCRIPTION
[sil-ownership-verifier] Allow class_method to take a metatype or a non-trivial type.

rdar://31880847
