### PR TITLE
[silgen] Fix createUnsafeCopyUnownedValue to be correct from an ownership perspective.

### DIFF
--- a/lib/SIL/SILOwnershipVerifier.cpp
+++ b/lib/SIL/SILOwnershipVerifier.cpp
@@ -552,6 +552,24 @@ ACCEPTS_ANY_OWNERSHIP_INST(UncheckedOwnershipConversion)
 #undef ACCEPTS_ANY_OWNERSHIP_INST
 
 // Trivial if trivial typed, otherwise must accept owned?
+#define ACCEPTS_ANY_NONTRIVIAL_OWNERSHIP_OR_METATYPE(                          \
+    SHOULD_CHECK_FOR_DATAFLOW_VIOLATIONS, INST)                                \
+  OwnershipUseCheckerResult                                                    \
+      OwnershipCompatibilityUseChecker::visit##INST##Inst(INST##Inst *I) {     \
+    assert(I->getNumOperands() && "Expected to have non-zero operands");       \
+    if (getType().is<AnyMetatypeType>()) {                                     \
+      return {true, false};                                                    \
+    }                                                                          \
+    assert(!isAddressOrTrivialType() &&                                        \
+           "Shouldn't have an address or a non trivial type");                 \
+    bool compatible = getOwnershipKind() == ValueOwnershipKind::Any ||         \
+                      !compatibleWithOwnership(ValueOwnershipKind::Trivial);   \
+    return {compatible, SHOULD_CHECK_FOR_DATAFLOW_VIOLATIONS};                 \
+  }
+ACCEPTS_ANY_NONTRIVIAL_OWNERSHIP_OR_METATYPE(false, ClassMethod)
+#undef ACCEPTS_ANY_NONTRIVIAL_OWNERSHIP_OR_METATYPE
+
+// Trivial if trivial typed, otherwise must accept owned?
 #define ACCEPTS_ANY_NONTRIVIAL_OWNERSHIP(SHOULD_CHECK_FOR_DATAFLOW_VIOLATIONS, \
                                          INST)                                 \
   OwnershipUseCheckerResult                                                    \
@@ -565,7 +583,6 @@ ACCEPTS_ANY_OWNERSHIP_INST(UncheckedOwnershipConversion)
   }
 ACCEPTS_ANY_NONTRIVIAL_OWNERSHIP(false, SuperMethod)
 ACCEPTS_ANY_NONTRIVIAL_OWNERSHIP(false, BridgeObjectToWord)
-ACCEPTS_ANY_NONTRIVIAL_OWNERSHIP(false, ClassMethod)
 ACCEPTS_ANY_NONTRIVIAL_OWNERSHIP(false, CopyBlock)
 ACCEPTS_ANY_NONTRIVIAL_OWNERSHIP(false, DynamicMethod)
 ACCEPTS_ANY_NONTRIVIAL_OWNERSHIP(false, OpenExistentialBox)

--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -247,11 +247,14 @@ ManagedValue SILGenBuilder::createCopyUnownedValue(SILLocation loc,
 ManagedValue
 SILGenBuilder::createUnsafeCopyUnownedValue(SILLocation loc,
                                             ManagedValue originalValue) {
+  // *NOTE* The reason why this is unsafe is that we are converting and
+  // unconditionally retaining, rather than before converting from
+  // unmanaged->ref checking that our value is not yet uninitialized.
   auto unmanagedType = originalValue.getType().getAs<UnmanagedStorageType>();
   SILValue result = SILBuilder::createUnmanagedToRef(
       loc, originalValue.getValue(),
       SILType::getPrimitiveObjectType(unmanagedType.getReferentType()));
-  SILBuilder::createUnmanagedRetainValue(loc, result, getDefaultAtomicity());
+  result = SILBuilder::createCopyValue(loc, result);
   return SGF.emitManagedRValueWithCleanup(result);
 }
 

--- a/test/SIL/ownership-verifier/use_verifier.sil
+++ b/test/SIL/ownership-verifier/use_verifier.sil
@@ -53,7 +53,9 @@ struct TupleContainingNonTrivialStruct {
   var opt: Optional<Builtin.NativeObject>
 }
 
-class SuperKlass {}
+class SuperKlass {
+  func d() {}
+}
 class SubKlass : SuperKlass {}
 class X {
   @objc func f() { }
@@ -338,6 +340,13 @@ sil @block_invoke_test : $@convention(thin) (@owned @convention(block) () -> ())
 bb0(%0 : @owned $@convention(block) () -> ()):
   apply %0() : $@convention(block) () -> ()
   destroy_value %0 : $@convention(block) () -> ()
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+sil @class_method_metatype_test : $@convention(thin) (@thick SuperKlass.Type) -> () {
+bb0(%0 : @trivial $@thick SuperKlass.Type):
+  %1 = class_method %0 : $@thick SuperKlass.Type, #SuperKlass.d!1 : (SuperKlass) -> () -> (), $@convention(method) (@guaranteed SuperKlass) -> ()
   %9999 = tuple()
   return %9999 : $()
 }

--- a/test/SILGen/unmanaged_ownership.swift
+++ b/test/SILGen/unmanaged_ownership.swift
@@ -1,0 +1,70 @@
+// RUN: %target-swift-frontend -enable-sil-ownership -parse-stdlib -module-name Swift -emit-silgen %s | %FileCheck %s
+
+class C {}
+
+enum Optional<T> {
+case none
+case some(T)
+}
+
+precedencegroup AssignmentPrecedence {
+  assignment: true
+  associativity: right
+}
+
+struct Holder {
+  unowned(unsafe) var value: C
+}
+
+_ = Holder(value: C())
+// CHECK-LABEL:sil hidden @_T0s6HolderV{{[_0-9a-zA-Z]*}}fC : $@convention(method) (@owned C, @thin Holder.Type) -> Holder
+// CHECK: bb0([[T0:%.*]] : @owned $C,
+// CHECK-NEXT:   [[T1:%.*]] = ref_to_unmanaged [[T0]] : $C to $@sil_unmanaged C
+// CHECK-NEXT:   destroy_value [[T0]] : $C
+// CHECK-NEXT:   [[T2:%.*]] = struct $Holder ([[T1]] : $@sil_unmanaged C)
+// CHECK-NEXT:   return [[T2]] : $Holder
+// CHECK-NEXT: } // end sil function '_T0s6HolderVABs1CC5value_tcfC'
+func set(holder holder: inout Holder) {
+  holder.value = C()
+}
+
+// CHECK-LABEL: sil hidden @_T0s3setys6HolderVz6holder_tF : $@convention(thin) (@inout Holder) -> () {
+// CHECK: bb0([[ADDR:%.*]] : @trivial $*Holder):
+// CHECK:        [[T0:%.*]] = function_ref @_T0s1CC{{[_0-9a-zA-Z]*}}fC
+// CHECK:        [[C:%.*]] = apply [[T0]](
+// CHECK-NEXT:   [[WRITE:%.*]] = begin_access [modify] [unknown] [[ADDR]] : $*Holder
+// CHECK-NEXT:   [[T0:%.*]] = struct_element_addr [[WRITE]] : $*Holder, #Holder.value
+// CHECK-NEXT:   [[T1:%.*]] = ref_to_unmanaged [[C]]
+// CHECK-NEXT:   assign [[T1]] to [[T0]]
+// CHECK-NEXT:   destroy_value [[C]]
+// CHECK-NEXT:   end_access [[WRITE]] : $*Holder
+// CHECK: } // end sil function '_T0s3setys6HolderVz6holder_tF'
+
+func get(holder holder: inout Holder) -> C {
+  return holder.value
+}
+// CHECK-LABEL: sil hidden @_T0s3gets1CCs6HolderVz6holder_tF : $@convention(thin) (@inout Holder) -> @owned C {
+// CHECK: bb0([[ADDR:%.*]] : @trivial $*Holder):
+// CHECK-NEXT:   debug_value_addr %0 : $*Holder, var, name "holder", argno 1 
+// CHECK-NEXT:   [[READ:%.*]] = begin_access [read] [unknown] [[ADDR]] : $*Holder
+// CHECK-NEXT:   [[T0:%.*]] = struct_element_addr [[READ]] : $*Holder, #Holder.value
+// CHECK-NEXT:   [[T1:%.*]] = load [trivial] [[T0]] : $*@sil_unmanaged C
+// CHECK-NEXT:   [[T2:%.*]] = unmanaged_to_ref [[T1]]
+// CHECK-NEXT:   [[T2_COPY:%.*]] = copy_value [[T2]]
+// CHECK-NEXT:   end_access [[READ]] : $*Holder
+// CHECK-NEXT:   return [[T2_COPY]]
+
+func project(fn fn: () -> Holder) -> C {
+  return fn().value
+}
+// CHECK-LABEL: sil hidden @_T0s7projects1CCs6HolderVyc2fn_tF : $@convention(thin) (@owned @callee_owned () -> Holder) -> @owned C {
+// CHECK: bb0([[FN:%.*]] : @owned $@callee_owned () -> Holder):
+// CHECK:      [[BORROWED_FN:%.*]] = begin_borrow [[FN]]
+// CHECK-NEXT: [[BORROWED_FN_COPY:%.*]] = copy_value [[BORROWED_FN]]
+// CHECK-NEXT: [[T0:%.*]] = apply [[BORROWED_FN_COPY]]()
+// CHECK-NEXT: [[T1:%.*]] = struct_extract [[T0]] : $Holder, #Holder.value
+// CHECK-NEXT: [[T2:%.*]] = unmanaged_to_ref [[T1]]
+// CHECK-NEXT: [[COPIED_T2:%.*]] = copy_value [[T2]]
+// CHECK-NEXT: end_borrow [[BORROWED_FN]] from [[FN]]
+// CHECK-NEXT: destroy_value [[FN]]
+// CHECK-NEXT: return [[COPIED_T2]]


### PR DESCRIPTION
[silgen] Fix createUnsafeCopyUnownedValue to be correct from an ownership perspective.

When I originally implemented this, I did not understand why an unowned(unsafe)
value was unsafe. I thought it was unsafe since the value was not meant to be
paired with (which is why I used the unmanaged_retain_value). Instead it just
means that we perform an unconditional copy without checking if the unowned
value is actually live. In contrast, an unowned(safe) value, we use
copy_unowned_value which performs an assert that the unowned value is still
alive before copying.

From a non-semantic sil perspective, since I still was retaining the value
properly, there was not a bug by using the unmanaged_retain_value instruction.

rdar://31880847
