### PR TITLE
Bridge types during import only if we are in a fully-bridgeable context.

### DIFF
--- a/lib/ClangImporter/ImportMacro.cpp
+++ b/lib/ClangImporter/ImportMacro.cpp
@@ -113,7 +113,7 @@ static ValueDecl *importNumericLiteral(ClangImporter::Implementation &Impl,
     auto clangTy = parsed->getType();
     auto literalType = Impl.importType(clangTy, ImportTypeKind::Value,
                                        isInSystemModule(DC),
-                                       /*isFullyBridgeable*/false);
+                                       Bridgeability::None);
     if (!literalType)
       return nullptr;
 
@@ -123,7 +123,7 @@ static ValueDecl *importNumericLiteral(ClangImporter::Implementation &Impl,
     } else {
       constantType = Impl.importType(castType, ImportTypeKind::Value,
                                      isInSystemModule(DC),
-                                     /*isFullyBridgeable*/false);
+                                     Bridgeability::None);
       if (!constantType)
         return nullptr;
     }
@@ -300,7 +300,7 @@ static Optional<std::pair<llvm::APSInt, Type>>
       auto type  = impl.importType(literal->getType(),
                                    ImportTypeKind::Value,
                                    isInSystemModule(DC),
-                                   /*isFullyBridgeable*/false);
+                                   Bridgeability::None);
       return {{ value, type }};
     }
 

--- a/test/ClangImporter/objc_id_as_any.swift
+++ b/test/ClangImporter/objc_id_as_any.swift
@@ -24,3 +24,10 @@ idLover.takesArray(ofId: &y) // expected-error{{argument type 'Any' does not con
 
 idLover.takesId(x)
 idLover.takesId(y)
+
+install_global_event_handler(idLover) // expected-error {{cannot convert value of type 'NSIdLover' to expected argument type 'event_handler?' (aka 'Optional<@convention(c) (AnyObject) -> ()>')}}
+
+// FIXME: this should not type-check!
+// Function conversions are not legal when converting to a thin function type.
+let handler: @convention(c) (Any) -> () = { object in () }
+install_global_event_handler(handler)

--- a/test/IDE/Inputs/mock-sdk/BoolBridgingTests.framework/Headers/BoolBridgingTests.h
+++ b/test/IDE/Inputs/mock-sdk/BoolBridgingTests.framework/Headers/BoolBridgingTests.h
@@ -40,8 +40,12 @@ ObjCBoolBlock testObjCBoolFnToBlockTypedef(ObjCBoolFn);
 DarwinBooleanBlock testDarwinBooleanFnToBlockTypedef(DarwinBooleanFn);
 
 typedef __typeof(testCBoolFnToBlockTypedef) CBoolFnToBlockType;
-typedef __typeof(testObjCBoolFnToBlockTypedef) ObjCCBoolFnToBlockType;
+typedef __typeof(testObjCBoolFnToBlockTypedef) ObjCBoolFnToBlockType;
 typedef __typeof(testDarwinBooleanFnToBlockTypedef) DarwinBooleanFnToBlockType;
+
+extern ObjCBoolFnToBlockType *globalObjCBoolFnToBlockFP;
+extern ObjCBoolFnToBlockType * __nonnull * __nullable globalObjCBoolFnToBlockFPP;
+extern ObjCBoolFnToBlockType ^globalObjCBoolFnToBlockBP;
 
 extern CBoolFn globalCBoolFn;
 extern ObjCBoolFn globalObjCBoolFn;

--- a/test/IDE/print_clang_bool_bridging.swift
+++ b/test/IDE/print_clang_bool_bridging.swift
@@ -43,8 +43,12 @@ func testObjCBoolFnToBlockTypedef(_: @escaping ObjCBoolFn) -> ObjCBoolBlock
 func testDarwinBooleanFnToBlockTypedef(_: @escaping DarwinBooleanFn) -> DarwinBooleanBlock
 
 typealias CBoolFnToBlockType = (CBoolFn) -> CBoolBlock
-typealias ObjCCBoolFnToBlockType = (ObjCBoolFn) -> (ObjCBool) -> ObjCBool
-typealias DarwinBooleanFnToBlockType = (DarwinBooleanFn) -> (DarwinBoolean) -> DarwinBoolean
+typealias ObjCBoolFnToBlockType = (ObjCBoolFn) -> ObjCBoolBlock
+typealias DarwinBooleanFnToBlockType = (DarwinBooleanFn) -> DarwinBooleanBlock
+
+var globalObjCBoolFnToBlockFP: @convention(c) (ObjCBoolFn) -> @convention(block) (ObjCBool) -> ObjCBool
+var globalObjCBoolFnToBlockFPP: UnsafeMutablePointer<@convention(c) (ObjCBoolFn) -> @convention(block) (ObjCBool) -> ObjCBool>?
+var globalObjCBoolFnToBlockBP: @convention(block) (ObjCBoolFn) -> @convention(block) (ObjCBool) -> ObjCBool
 
 var globalCBoolFn: CBoolFn
 var globalObjCBoolFn: ObjCBoolFn

--- a/test/IDE/print_omit_needless_words.swift
+++ b/test/IDE/print_omit_needless_words.swift
@@ -143,7 +143,7 @@
 // CHECK-FOUNDATION: func doSomethingElse(with: NSCopying & NSObjectProtocol)
 
 // Note: Function type -> "Function".
-// CHECK-FOUNDATION: func sort(_: @escaping @convention(c) (Any, Any) -> Int)
+// CHECK-FOUNDATION: func sort(_: @escaping @convention(c) (AnyObject, AnyObject) -> Int)
 
 // Note: Plural: NSArray without type arguments -> "Objects".
 // CHECK-FOUNDATION: func remove(_: [Any])

--- a/test/Inputs/clang-importer-sdk/usr/include/Foundation.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/Foundation.h
@@ -1110,3 +1110,6 @@ typedef enum __attribute__((ns_error_domain(NSLaundryErrorDomain))) __attribute_
     NSLaundryErrorTooMuchSoap = 1,
     NSLaundryErrorCatInWasher = 2
 };
+
+typedef void (*event_handler)(__nonnull id);
+void install_global_event_handler(__nullable event_handler handler);


### PR DESCRIPTION
Somehow the logic had slipped so that we were basing this decision purely
on the ImportTypeKind and not on whether the broader context is bridgeable.
This was allowing us to use bridged types when e.g. importing the results and
parameters of C function pointer types, which is really bad.

Also, when importing a reference to a typedef of block type, do not use
the typedef in a non-bridgeable context.  We import typedefs of block type
as fully-bridged types, but this means that it is invalid to import a type
using the typedef in a context where the original C type must be used.
Similarly, make sure we use a properly-imported underlying type of the
typedef when the typedef itself is unavailable.

Also, extend the special behavior of block typedefs to abstract-function
typedefs, which seems to be consistent with the expected behavior of the
tests.

Finally, I changed importType to take a new Bridgeability enum instead of
a raw canFullyBridgeTypes bool.  At the time, I was doing that because I
was going to make it tri-valued; that turned out to be unnecessary, but I
think it's an improvement anyway.