### PR TITLE
[semantic-sil] Teach the verifier that an enum return value is a ValueOwnershipKind erasure point.

### DIFF
--- a/lib/SIL/SILOwnershipVerifier.cpp
+++ b/lib/SIL/SILOwnershipVerifier.cpp
@@ -862,6 +862,10 @@ OwnershipCompatibilityUseChecker::visitReturnInst(ReturnInst *RI) {
     Base = MergedValue.getValue();
   }
 
+  if (auto *E = getType().getEnumOrBoundGenericEnum()) {
+    return visitNonTrivialEnum(E, Base);
+  }
+
   return {compatibleWithOwnership(Base), true};
 }
 

--- a/test/SIL/ownership-verifier/use_verifier.sil
+++ b/test/SIL/ownership-verifier/use_verifier.sil
@@ -351,6 +351,12 @@ bb0(%0 : @trivial $@thick SuperKlass.Type):
   return %9999 : $()
 }
 
+sil @trivial_enum_return_value : $@convention(thin) () -> @owned Optional<Builtin.NativeObject> {
+bb0:
+  %0 = enum $Optional<Builtin.NativeObject>, #Optional.none!enumelt
+  return %0 : $Optional<Builtin.NativeObject>
+}
+
 //////////////////////
 // Terminator Tests //
 //////////////////////


### PR DESCRIPTION
[semantic-sil] Teach the verifier that an enum return value is a ValueOwnershipKind erasure point.

This means that a trivial enum case of a non-trivial enum can be returned @owned
even though it is trivial. We already follow this pattern with bb arguments.

rdar://31880847