### PR TITLE
[stdlib] Workaround to fix getSectionInfo() for Android

### DIFF
--- a/stdlib/public/runtime/ImageInspectionELF.cpp
+++ b/stdlib/public/runtime/ImageInspectionELF.cpp
@@ -68,8 +68,14 @@ static SectionInfo getSectionInfo(const char *imageName,
   SectionInfo sectionInfo = { 0, nullptr };
   void *handle = dlopen(imageName, RTLD_LAZY | RTLD_NOLOAD);
   if (!handle) {
+    #ifdef __ANDROID__
+    // https://bugs.swift.org/browse/SR-5414
+    // The dlopen can fail once on Android so for now, return an empty struct.
+    return sectionInfo;
+    #else
     fatalError(/* flags = */ 0, "dlopen() failed on `%s': %s", imageName,
                dlerror());
+    #endif
   }
   void *symbol = dlsym(handle, sectionName);
   if (symbol) {


### PR DESCRIPTION
As discussed in https://github.com/apple/swift/pull/9869, this is a temporary patch to allow stdlib to run on Android. The function getSectionInfo() in stdlib/public/runtime/ImageInspectionELF.cpp tries to dlopen() an image for which the full path is not available on Android causing a fatalError(). This PR patches this out for now, leaving a warning during compilation to indicating it should be revisted at a later date. No Swift program can run on Android without this patch.

Workaround for [SR-5414](https://bugs.swift.org/browse/SR-5414).