### PR TITLE
[QoI] Provide fix-it for missing "try" when calling throwing function

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2990,6 +2990,13 @@ ERROR(throwing_operator_without_try,none,
       "operator can throw but expression is not marked with 'try'", ())
 ERROR(throwing_call_without_try,none,
       "call can throw but is not marked with 'try'", ())
+NOTE(note_forgot_try,none,
+      "did you mean to use 'try'?", ())
+NOTE(note_error_to_optional,none,
+      "did you mean to handle error as optional value?", ())
+NOTE(note_disable_error_propagation,none,
+      "did you mean to disable error propagation?", ())
+
 WARNING(no_throw_in_try,none,
         "no calls to throwing functions occur within 'try' expression", ())
 

--- a/lib/Sema/TypeCheckError.cpp
+++ b/lib/Sema/TypeCheckError.cpp
@@ -1037,6 +1037,24 @@ public:
     
     TC.diagnose(loc, message).highlight(highlight);
     maybeAddRethrowsNote(TC, loc, reason);
+
+    // If this is a call without expected 'try[?|!]', like this:
+    //
+    // func foo() throws {}
+    // [let _ = ]foo()
+    //
+    // Let's suggest couple of alternative fix-its
+    // because complete context is unavailable.
+    if (reason.getKind() != PotentialReason::Kind::CallThrows)
+      return;
+
+    TC.diagnose(loc, diag::note_forgot_try).fixItInsert(loc, "try ").flush();
+    TC.diagnose(loc, diag::note_error_to_optional)
+        .fixItInsert(loc, "try? ")
+        .flush();
+
+    TC.diagnose(loc, diag::note_disable_error_propagation)
+        .fixItInsert(loc, "try! ");
   }
 
   void diagnoseThrowInLegalContext(TypeChecker &TC, ASTNode node,

--- a/test/Parse/errors.swift
+++ b/test/Parse/errors.swift
@@ -80,6 +80,9 @@ func testAutoclosures() throws {
   try takesThrowingAutoclosure(genNoError()) // expected-warning {{no calls to throwing functions occur within 'try' expression}}
 
   takesThrowingAutoclosure(genError()) // expected-error {{call can throw but is not marked with 'try'}}
+                                       // expected-note@-1 {{did you mean to use 'try'?}} {{28-28=try }}
+                                       // expected-note@-2 {{did you mean to handle error as optional value?}} {{28-28=try? }}
+                                       // expected-note@-3 {{did you mean to disable error propagation?}} {{28-28=try! }}
   takesThrowingAutoclosure(genNoError())
 }
 

--- a/test/Parse/try.swift
+++ b/test/Parse/try.swift
@@ -24,8 +24,14 @@ var x = try foo() + bar()
 x = try foo() + bar()
 x += try foo() + bar()
 x += try foo() %%%% bar() // expected-error {{'try' following assignment operator does not cover everything to its right}} // expected-error {{call can throw but is not marked with 'try'}} // expected-warning {{result of operator '%%%%' is unused}}
+                          // expected-note@-1 {{did you mean to use 'try'?}} {{21-21=try }}
+                          // expected-note@-2 {{did you mean to handle error as optional value?}} {{21-21=try? }}
+                          // expected-note@-3 {{did you mean to disable error propagation?}} {{21-21=try! }}
 x += try foo() %%% bar()
 x = foo() + try bar() // expected-error {{'try' cannot appear to the right of a non-assignment operator}} // expected-error {{call can throw but is not marked with 'try'}}
+                      // expected-note@-1 {{did you mean to use 'try'?}} {{5-5=try }}
+                      // expected-note@-2 {{did you mean to handle error as optional value?}} {{5-5=try? }}
+                      // expected-note@-3 {{did you mean to disable error propagation?}} {{5-5=try! }}
 
 var y = true ? try foo() : try bar() + 0
 var z = true ? try foo() : try bar() %%% 0 // expected-error {{'try' following conditional operator does not cover everything to its right}}
@@ -34,8 +40,14 @@ var a = try! foo() + bar()
 a = try! foo() + bar()
 a += try! foo() + bar()
 a += try! foo() %%%% bar() // expected-error {{'try!' following assignment operator does not cover everything to its right}} // expected-error {{call can throw but is not marked with 'try'}} // expected-warning {{result of operator '%%%%' is unused}}
+                           // expected-note@-1 {{did you mean to use 'try'?}} {{22-22=try }}
+                           // expected-note@-2 {{did you mean to handle error as optional value?}} {{22-22=try? }}
+                           // expected-note@-3 {{did you mean to disable error propagation?}} {{22-22=try! }}
 a += try! foo() %%% bar()
 a = foo() + try! bar() // expected-error {{'try!' cannot appear to the right of a non-assignment operator}} // expected-error {{call can throw but is not marked with 'try'}}
+                       // expected-note@-1 {{did you mean to use 'try'?}} {{5-5=try }}
+                       // expected-note@-2 {{did you mean to handle error as optional value?}} {{5-5=try? }}
+                       // expected-note@-3 {{did you mean to disable error propagation?}} {{5-5=try! }}
 
 var b = true ? try! foo() : try! bar() + 0
 var c = true ? try! foo() : try! bar() %%% 0 // expected-error {{'try!' following conditional operator does not cover everything to its right}}
@@ -50,10 +62,22 @@ let _: Double = i // expected-error {{cannot convert value of type 'Int?' to spe
 i = try? foo() + bar()
 i ?+= try? foo() + bar()
 i ?+= try? foo() %%%% bar() // expected-error {{'try?' following assignment operator does not cover everything to its right}} // expected-error {{call can throw but is not marked with 'try'}} // expected-warning {{result of operator '%%%%' is unused}}
+                            // expected-note@-1 {{did you mean to use 'try'?}} {{23-23=try }}
+                            // expected-note@-2 {{did you mean to handle error as optional value?}} {{23-23=try? }}
+                            // expected-note@-3 {{did you mean to disable error propagation?}} {{23-23=try! }}
 i ?+= try? foo() %%% bar()
 _ = foo() == try? bar() // expected-error {{'try?' cannot appear to the right of a non-assignment operator}} // expected-error {{call can throw but is not marked with 'try'}}
+                        // expected-note@-1 {{did you mean to use 'try'?}} {{5-5=try }}
+                        // expected-note@-2 {{did you mean to handle error as optional value?}} {{5-5=try? }}
+                        // expected-note@-3 {{did you mean to disable error propagation?}} {{5-5=try! }}
 _ = (try? foo()) == bar() // expected-error {{call can throw but is not marked with 'try'}}
+                          // expected-note@-1 {{did you mean to use 'try'?}} {{21-21=try }}
+                          // expected-note@-2 {{did you mean to handle error as optional value?}} {{21-21=try? }}
+                          // expected-note@-3 {{did you mean to disable error propagation?}} {{21-21=try! }}
 _ = foo() == (try? bar()) // expected-error {{call can throw but is not marked with 'try'}}
+                          // expected-note@-1 {{did you mean to use 'try'?}} {{5-5=try }}
+                          // expected-note@-2 {{did you mean to handle error as optional value?}} {{5-5=try? }}
+                          // expected-note@-3 {{did you mean to disable error propagation?}} {{5-5=try! }}
 _ = (try? foo()) == (try? bar())
 
 let j = true ? try? foo() : try? bar() + 0
@@ -64,6 +88,9 @@ try var singleVar = foo() // expected-error {{'try' must be placed on the initia
 try let uninit: Int // expected-error {{'try' must be placed on the initial value expression}}
 try let (destructure1, destructure2) = (foo(), bar()) // expected-error {{'try' must be placed on the initial value expression}} {{1-5=}} {{40-40=try }}
 try let multi1 = foo(), multi2 = bar() // expected-error {{'try' must be placed on the initial value expression}} expected-error 2 {{call can throw but is not marked with 'try'}}
+                                       // expected-note@-1 {{did you mean to use 'try'?}} {{18-18=try }} expected-note@-1 {{did you mean to use 'try'?}} {{34-34=try }}
+                                       // expected-note@-2 {{did you mean to handle error as optional value?}} {{18-18=try? }} expected-note@-2 {{did you mean to handle error as optional value?}} {{34-34=try? }}
+                                       // expected-note@-3 {{did you mean to disable error propagation?}} {{18-18=try! }} expected-note@-3 {{did you mean to disable error propagation?}} {{34-34=try! }}
 
 func test() throws -> Int {
   try while true { // expected-error {{'try' cannot be used with 'while'}}
@@ -85,6 +112,9 @@ func test() throws -> Int {
 func *(a : String, b : String) throws -> Int { return 42 }
 let _ = "foo"
         *  // expected-error {{operator can throw but expression is not marked with 'try'}}
+           // expected-note@-1 {{did you mean to use 'try'?}} {{9-9=try }}
+           // expected-note@-2 {{did you mean to handle error as optional value?}} {{9-9=try? }}
+           // expected-note@-3 {{did you mean to disable error propagation?}} {{9-9=try! }}
         "bar"
 let _ = try! "foo"*"bar"
 let _ = try? "foo"*"bar"
@@ -95,6 +125,9 @@ let _ = (try? "foo"*"bar") ?? 0
 func rethrowsDispatchError(handleError: ((Error) throws -> ()), body: () throws -> ()) rethrows {
   do {
     body()   // expected-error {{call can throw but is not marked with 'try'}}
+             // expected-note@-1 {{did you mean to use 'try'?}} {{5-5=try }}
+             // expected-note@-2 {{did you mean to handle error as optional value?}} {{5-5=try? }}
+             // expected-note@-3 {{did you mean to disable error propagation?}} {{5-5=try! }}
   } catch {
   }
 }
@@ -110,6 +143,9 @@ struct r21432429 {
 // <rdar://problem/21427855> Swift 2: Omitting try from call to throwing closure in rethrowing function crashes compiler
 func callThrowingClosureWithoutTry(closure: (Int) throws -> Int) rethrows {
   closure(0)  // expected-error {{call can throw but is not marked with 'try'}} expected-warning {{result of call is unused}}
+              // expected-note@-1 {{did you mean to use 'try'?}} {{3-3=try }}
+              // expected-note@-2 {{did you mean to handle error as optional value?}} {{3-3=try? }}
+              // expected-note@-3 {{did you mean to disable error propagation?}} {{3-3=try! }}
 }
 
 func producesOptional() throws -> Int? { return nil }

--- a/test/decl/func/debugger_function.swift
+++ b/test/decl/func/debugger_function.swift
@@ -28,6 +28,9 @@ func test2() -> Int {
     do {
       var x: Int = 0
       x = foo() // expected-error {{call can throw but is not marked with 'try'}}
+      // expected-note@-1 {{did you mean to use 'try'?}} {{11-11=try }}
+      // expected-note@-2 {{did you mean to handle error as optional value?}} {{11-11=try? }}
+      // expected-note@-3 {{did you mean to disable error propagation?}} {{11-11=try! }}
       x = try foo()
       return x
     } catch {

--- a/test/decl/func/rethrows.swift
+++ b/test/decl/func/rethrows.swift
@@ -120,6 +120,9 @@ func testCallACUnhandled() {
   callAC(raise()) // expected-error {{call can throw but is not marked with 'try'}} \
                   // expected-error {{call can throw, but it is not marked with 'try' and the error is not handled}} \
                   // expected-note {{call is to 'rethrows' function, but argument function can throw}}
+		  // expected-note@-3 {{did you mean to use 'try'?}} {{10-10=try }}
+		  // expected-note@-4 {{did you mean to handle error as optional value?}} {{10-10=try? }}
+		  // expected-note@-5 {{did you mean to disable error propagation?}} {{10-10=try! }}
   try callAC(raise()) // expected-error {{call can throw, but the error is not handled}} expected-note {{call is to 'rethrows' function, but argument function can throw}}
 }
 
@@ -127,6 +130,9 @@ func testCallACHandled() throws {
   callAC(noraise())
   try callAC(noraise()) // expected-warning {{no calls to throwing functions occur within 'try'}}
   callAC(raise()) // expected-error 2 {{call can throw but is not marked with 'try'}} expected-note {{call is to 'rethrows' function, but argument function can throw}}
+		  // expected-note@-1 {{did you mean to use 'try'?}} {{10-10=try }}
+		  // expected-note@-2 {{did you mean to handle error as optional value?}} {{10-10=try? }}
+		  // expected-note@-3 {{did you mean to disable error propagation?}} {{10-10=try! }}
   try callAC(raise())
 }
 
@@ -181,6 +187,9 @@ func testMethodCallACUnhandled(_ s: MyStruct) {
   s.callAC(raise()) // expected-error {{call can throw but is not marked with 'try'}} \
                   // expected-error {{call can throw, but it is not marked with 'try' and the error is not handled}} \
                   // expected-note {{call is to 'rethrows' function, but argument function can throw}}
+		  // expected-note@-3 {{did you mean to use 'try'?}} {{12-12=try }}
+		  // expected-note@-4 {{did you mean to handle error as optional value?}} {{12-12=try? }}
+		  // expected-note@-5 {{did you mean to disable error propagation?}} {{12-12=try! }}
   try s.callAC(raise()) // expected-error {{call can throw, but the error is not handled}} expected-note {{call is to 'rethrows' function, but argument function can throw}}
 
   MyStruct.static_callAC(noraise())
@@ -188,6 +197,9 @@ func testMethodCallACUnhandled(_ s: MyStruct) {
   MyStruct.static_callAC(raise()) // expected-error {{call can throw but is not marked with 'try'}} \
                   // expected-error {{call can throw, but it is not marked with 'try' and the error is not handled}} \
                   // expected-note {{call is to 'rethrows' function, but argument function can throw}}
+                  // expected-note@-3 {{did you mean to use 'try'?}} {{26-26=try }}
+                  // expected-note@-4 {{did you mean to handle error as optional value?}} {{26-26=try? }}
+                  // expected-note@-5 {{did you mean to disable error propagation?}} {{26-26=try! }}
   try MyStruct.static_callAC(raise()) // expected-error {{call can throw, but the error is not handled}} expected-note {{call is to 'rethrows' function, but argument function can throw}}
 }
 
@@ -195,11 +207,18 @@ func testMethodCallACHandled(_ s: MyStruct) throws {
   s.callAC(noraise())
   try s.callAC(noraise()) // expected-warning {{no calls to throwing functions occur within 'try'}}
   s.callAC(raise()) // expected-error 2 {{call can throw but is not marked with 'try'}} expected-note {{call is to 'rethrows' function, but argument function can throw}}
+                    // expected-note@-1 {{did you mean to use 'try'?}} {{12-12=try }}
+                    // expected-note@-2 {{did you mean to handle error as optional value?}} {{12-12=try? }}
+                    // expected-note@-3 {{did you mean to disable error propagation?}} {{12-12=try! }}
   try s.callAC(raise())
 
   MyStruct.static_callAC(noraise())
   try MyStruct.static_callAC(noraise()) // expected-warning {{no calls to throwing functions occur within 'try'}}
   MyStruct.static_callAC(raise()) // expected-error 2 {{call can throw but is not marked with 'try'}} expected-note {{call is to 'rethrows' function, but argument function can throw}}
+                                  // expected-note@-1 {{did you mean to use 'try'?}} {{26-26=try }}
+                                  // expected-note@-2 {{did you mean to handle error as optional value?}} {{26-26=try? }}
+                                  // expected-note@-3 {{did you mean to disable error propagation?}} {{26-26=try! }}
+
   try MyStruct.static_callAC(raise())
 }
 
@@ -247,8 +266,11 @@ func testProtoMethodCallACUnhandled(_ s: MyProto) {
   s.callAC(noraise())
   try s.callAC(noraise()) // expected-warning {{no calls to throwing functions occur within 'try'}}
   s.callAC(raise()) // expected-error {{call can throw but is not marked with 'try'}} \
-                  // expected-error {{call can throw, but it is not marked with 'try' and the error is not handled}} \
-                  // expected-note {{call is to 'rethrows' function, but argument function can throw}}
+                    // expected-error {{call can throw, but it is not marked with 'try' and the error is not handled}} \
+                    // expected-note {{call is to 'rethrows' function, but argument function can throw}}
+                    // expected-note@-3 {{did you mean to use 'try'?}} {{12-12=try }}
+                    // expected-note@-4 {{did you mean to handle error as optional value?}} {{12-12=try? }}
+                    // expected-note@-5 {{did you mean to disable error propagation?}} {{12-12=try! }}
   try s.callAC(raise()) // expected-error {{call can throw, but the error is not handled}} expected-note {{call is to 'rethrows' function, but argument function can throw}}
 
   type(of: s).static_callAC(noraise())
@@ -256,6 +278,9 @@ func testProtoMethodCallACUnhandled(_ s: MyProto) {
   type(of: s).static_callAC(raise()) // expected-error {{call can throw but is not marked with 'try'}} \
                   // expected-error {{call can throw, but it is not marked with 'try' and the error is not handled}} \
                   // expected-note {{call is to 'rethrows' function, but argument function can throw}}
+                  // expected-note@-3 {{did you mean to use 'try'?}} {{29-29=try }}
+		  // expected-note@-4 {{did you mean to handle error as optional value?}} {{29-29=try? }}
+		  // expected-note@-5 {{did you mean to disable error propagation?}} {{29-29=try! }}
   try type(of: s).static_callAC(raise()) // expected-error {{call can throw, but the error is not handled}} expected-note {{call is to 'rethrows' function, but argument function can throw}}
 }
 
@@ -263,11 +288,18 @@ func testProtoMethodCallACHandled(_ s: MyProto) throws {
   s.callAC(noraise())
   try s.callAC(noraise()) // expected-warning {{no calls to throwing functions occur within 'try'}}
   s.callAC(raise()) // expected-error 2 {{call can throw but is not marked with 'try'}} expected-note {{call is to 'rethrows' function, but argument function can throw}}
+                    // expected-note@-1 {{did you mean to use 'try'?}} {{12-12=try }}
+                    // expected-note@-2 {{did you mean to handle error as optional value?}} {{12-12=try? }}
+                    // expected-note@-3 {{did you mean to disable error propagation?}} {{12-12=try! }}
+
   try s.callAC(raise())
 
   type(of: s).static_callAC(noraise())
   try type(of: s).static_callAC(noraise()) // expected-warning {{no calls to throwing functions occur within 'try'}}
   type(of: s).static_callAC(raise()) // expected-error 2 {{call can throw but is not marked with 'try'}} expected-note {{call is to 'rethrows' function, but argument function can throw}}
+                                     // expected-note@-1 {{did you mean to use 'try'?}} {{29-29=try }}
+                                     // expected-note@-2 {{did you mean to handle error as optional value?}} {{29-29=try? }}
+                                     // expected-note@-3 {{did you mean to disable error propagation?}} {{29-29=try! }}
   try type(of: s).static_callAC(raise())
 }
 
@@ -303,6 +335,9 @@ func testGenericMethodCallACUnhandled<P: MyProto>(_ s: P) {
   s.callAC(raise()) // expected-error {{call can throw but is not marked with 'try'}} \
                   // expected-error {{call can throw, but it is not marked with 'try' and the error is not handled}} \
                   // expected-note {{call is to 'rethrows' function, but argument function can throw}}
+                  // expected-note@-3 {{did you mean to use 'try'?}} {{12-12=try }}
+                  // expected-note@-4 {{did you mean to handle error as optional value?}} {{12-12=try? }}
+                  // expected-note@-5 {{did you mean to disable error propagation?}} {{12-12=try! }}
   try s.callAC(raise()) // expected-error {{call can throw, but the error is not handled}} expected-note {{call is to 'rethrows' function, but argument function can throw}}
 
   P.static_callAC(noraise())
@@ -310,6 +345,9 @@ func testGenericMethodCallACUnhandled<P: MyProto>(_ s: P) {
   P.static_callAC(raise()) // expected-error {{call can throw but is not marked with 'try'}} \
                   // expected-error {{call can throw, but it is not marked with 'try' and the error is not handled}} \
                   // expected-note {{call is to 'rethrows' function, but argument function can throw}}
+                  // expected-note@-3 {{did you mean to use 'try'?}} {{19-19=try }}
+                  // expected-note@-4 {{did you mean to handle error as optional value?}} {{19-19=try? }}
+                  // expected-note@-5 {{did you mean to disable error propagation?}} {{19-19=try! }}
   try P.static_callAC(raise()) // expected-error {{call can throw, but the error is not handled}} expected-note {{call is to 'rethrows' function, but argument function can throw}}
 }
 
@@ -317,11 +355,17 @@ func testGenericMethodCallACHandled<P: MyProto>(_ s: P) throws {
   s.callAC(noraise())
   try s.callAC(noraise()) // expected-warning {{no calls to throwing functions occur within 'try'}}
   s.callAC(raise()) // expected-error 2 {{call can throw but is not marked with 'try'}} expected-note {{call is to 'rethrows' function, but argument function can throw}}
+                    // expected-note@-1 {{did you mean to use 'try'?}} {{12-12=try }}
+                    // expected-note@-2 {{did you mean to handle error as optional value?}} {{12-12=try? }}
+                    // expected-note@-3 {{did you mean to disable error propagation?}} {{12-12=try! }}
   try s.callAC(raise())
 
   P.static_callAC(noraise())
   try P.static_callAC(noraise()) // expected-warning {{no calls to throwing functions occur within 'try'}}
   P.static_callAC(raise()) // expected-error 2 {{call can throw but is not marked with 'try'}} expected-note {{call is to 'rethrows' function, but argument function can throw}}
+                           // expected-note@-1 {{did you mean to use 'try'?}} {{19-19=try }}
+		           // expected-note@-2 {{did you mean to handle error as optional value?}} {{19-19=try? }}
+                           // expected-note@-3 {{did you mean to disable error propagation?}} {{19-19=try! }}
   try P.static_callAC(raise())
 }
 
@@ -475,6 +519,9 @@ struct Foo {
 func throwWhileGettingFoo() throws -> Foo.Type { return Foo.self }
 
 (throwWhileGettingFoo()).foo(Foo())() // expected-error {{can throw}}
+				      // expected-note@-1 {{did you mean to use 'try'?}} {{2-2=try }}
+		                      // expected-note@-2 {{did you mean to handle error as optional value?}} {{2-2=try? }}
+                                      // expected-note@-3 {{did you mean to disable error propagation?}} {{2-2=try! }}
 (try throwWhileGettingFoo()).foo(Foo())()
 
 // <rdar://problem/31794932> [Source compatibility] Call to sort(by):) can throw, but is not marked with 'try'

--- a/test/decl/func/throwing_functions.swift
+++ b/test/decl/func/throwing_functions.swift
@@ -130,6 +130,9 @@ struct A {
 
 func fi1() throws {
     A(doomed: ()) // expected-error {{call can throw but is not marked with 'try'}} // expected-warning{{unused}}
+    // expected-note@-1 {{did you mean to use 'try'?}} {{5-5=try }}
+    // expected-note@-2 {{did you mean to handle error as optional value?}} {{5-5=try? }}
+    // expected-note@-3 {{did you mean to disable error propagation?}} {{5-5=try! }}
 }
 
 struct B {
@@ -138,3 +141,15 @@ struct B {
 }
 
 B(foo: 0) // expected-warning{{unused}}
+
+// rdar://problem/33040113 - Provide fix-it for missing "try" when calling throwing Swift function
+
+class E_33040113 : Error {}
+func rdar33040113() throws -> Int {
+    throw E_33040113()
+}
+
+let _ = rdar33040113() // expected-error {{call can throw but is not marked with 'try'}}
+// expected-note@-1 {{did you mean to use 'try'?}} {{9-9=try }}
+// expected-note@-2 {{did you mean to handle error as optional value?}} {{9-9=try? }}
+// expected-note@-3 {{did you mean to disable error propagation?}} {{9-9=try! }}

--- a/test/decl/func/throwing_functions_without_try.swift
+++ b/test/decl/func/throwing_functions_without_try.swift
@@ -24,6 +24,9 @@ doLazy(foo())
 var closure: () -> () = {
   _ = foo() // expected-error {{call can throw, but it is not marked with 'try' and the error is not handled}}
   doLazy(foo()) // expected-error {{call can throw but is not marked with 'try'}}
+  // expected-note@-1 {{did you mean to use 'try'?}} {{10-10=try }}
+  // expected-note@-2 {{did you mean to handle error as optional value?}} {{10-10=try? }}
+  // expected-note@-3 {{did you mean to disable error propagation?}} {{10-10=try! }}
 }
 
 // Or any other sort of structure.
@@ -35,6 +38,9 @@ struct A {
 func baz() throws -> Int {
   var x: Int = 0
   x = foo() // expected-error{{call can throw but is not marked with 'try'}}
+  // expected-note@-1 {{did you mean to use 'try'?}} {{7-7=try }}
+  // expected-note@-2 {{did you mean to handle error as optional value?}} {{7-7=try? }}
+  // expected-note@-3 {{did you mean to disable error propagation?}} {{7-7=try! }}
   x = try foo() // no error
   return x
 }


### PR DESCRIPTION
When calling a throwing function without 'try', let's suggest multiple
possibilities of note + fix-it for user to choose from.

Resolves: rdar://problem/33040113

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
