### PR TITLE
Use `id` explicitly instead of `auto` to avoid warnings.

### DIFF
--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -926,7 +926,7 @@ bool swift::swift_unknownUnownedIsEqual(UnownedReference *ref, void *value) {
   if (!ref->Value) {
     return value == nullptr;
   } else if (auto objcRef = dyn_cast<ObjCUnownedReference>(ref)) {
-    auto refValue = objc_loadWeakRetained(&objcRef->storage()->WeakRef);
+    id refValue = objc_loadWeakRetained(&objcRef->storage()->WeakRef);
     bool isEqual = (void*)refValue == value;
     // This ObjC case has no deliberate unowned check here,
     // unlike the Swift case.


### PR DESCRIPTION
On Xcode 9 beta 2, a warning is raised when I built `swiftXCTest-macosx-x86_64`.

<img width="1143" alt="screen shot 2017-07-10 at 22 32 11" src="https://user-images.githubusercontent.com/147051/28020579-e7a9c932-65bf-11e7-802e-fd5c273dc329.png">