### PR TITLE
Avoid using deprecated operators

### DIFF
--- a/stdlib/public/core/Character.swift
+++ b/stdlib/public/core/Character.swift
@@ -299,7 +299,7 @@ extension Character {
     let nonZeroBitCount = type(of: bits).bitWidth - bits.leadingZeroBitCount
     return _UIntBuffer<UInt64, Unicode.UTF16.CodeUnit>(
       _storage: bits,
-      _bitCount: 16 * Swift.max(1, (nonZeroBitCount + 15) / 16)
+      _bitCount: UInt8(16) * UInt8(Swift.max(1, (nonZeroBitCount + 15) / 16))
     )
   }
 

--- a/stdlib/public/core/UTF16.swift
+++ b/stdlib/public/core/UTF16.swift
@@ -44,7 +44,7 @@ extension Unicode.UTF16 : Unicode.Encoding {
     if _fastPath(x < (1 << 16)) {
       return EncodedScalar(_storage: x, _bitCount: 16)
     }
-    let x1 = x - (1 << 16)
+    let x1 = x - UInt32(1 << 16)
     var r = (0xdc00 + (x1 & 0x3ff))
     r &<<= 16
     r |= (0xd800 + (x1 &>> 10 & 0x3ff))


### PR DESCRIPTION
<img width="1131" alt="screen shot 2017-07-10 at 23 58 40" src="https://user-images.githubusercontent.com/147051/28027390-e0c592c2-65d3-11e7-87ca-3b94be94d0c6.png">

When I built `swiftCoreFoundation-macos-x86_64`, warnings are raised.
I fixed them to cast numbers expressly.