### PR TITLE
[4.0][stdlib] Attaching document comment properly to AnyObject. rdar://33155670

### DIFF
--- a/stdlib/public/core/Policy.swift
+++ b/stdlib/public/core/Policy.swift
@@ -248,10 +248,11 @@ public typealias _MaxBuiltinFloatType = Builtin.FPIEEE64
 ///         print("'obj' does not have a 'getIntegerValue()' method")
 ///     }
 ///     // Prints "The value of 'obj' is 100"
+public typealias AnyObject = Builtin.AnyObject
 #else
 /// The protocol to which all classes implicitly conform.
-#endif
 public typealias AnyObject = Builtin.AnyObject
+#endif
 
 /// The protocol to which all class types implicitly conform.
 ///


### PR DESCRIPTION
- Explanation: This change will allow SourceKitd to generate documentation for AnyObject properly.
- Scope: Documentation for Swift stdlib
- Radar: rdar://33155670
- Risk: Almost none
- Testing: Since this change is non-functional, existing tests will cover the behavior.