### PR TITLE
Fix another subtle SE-0110-related break.

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1082,9 +1082,8 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
     if (auto elt = locator.last()) {
       if (elt->getKind() == ConstraintLocator::ApplyArgToParam) {
         if (auto *paren2 = dyn_cast<ParenType>(func2Input.getPointer())) {
-          func2Input = paren2->getUnderlyingType();
-          if (auto *paren1 = dyn_cast<ParenType>(func1Input.getPointer()))
-            func1Input = paren1->getUnderlyingType();
+          if (!isa<ParenType>(func1Input.getPointer()))
+            func2Input = paren2->getUnderlyingType();
         }
       }
     }

--- a/test/Constraints/tuple_arguments.swift
+++ b/test/Constraints/tuple_arguments.swift
@@ -1551,3 +1551,26 @@ extension Sequence where Iterator.Element == (key: String, value: String?) {
     }
   }
 }
+
+func rdar33043106(_ records: [(Int)], _ other: [((Int))]) -> [Int] {
+  let x: [Int] = records.flatMap { _ in
+    let i = 1
+    return i
+  }
+  let y: [Int] = other.flatMap { _ in
+    let i = 1
+    return i
+  }
+
+  return x + y
+}
+
+func itsFalse(_: Int) -> Bool? {
+  return false
+}
+
+func rdar33159366(s: AnySequence<Int>) {
+  _ = s.flatMap(itsFalse)
+  let a = Array(s)
+  _ = a.flatMap(itsFalse)
+}

--- a/validation-test/compiler_crashers_2_fixed/0111-rdar33067102.swift
+++ b/validation-test/compiler_crashers_2_fixed/0111-rdar33067102.swift
@@ -1,4 +1,4 @@
-// RUN: not %target-swift-frontend -swift-version 4 %s -typecheck
+// RUN: %target-swift-frontend -swift-version 4 %s -typecheck
 
 func flatterMap(_ records: [(Int)]) -> [Int] {
   records.flatMap { _ in return 1 } // expected-note {{}}

--- a/validation-test/compiler_crashers_2_fixed/0113-rdar33067102-2.swift
+++ b/validation-test/compiler_crashers_2_fixed/0113-rdar33067102-2.swift
@@ -1,5 +1,0 @@
-// RUN: not %target-swift-frontend -swift-version 4 %s -typecheck
-
-func flatterMap(_ records: [((Int))]) -> [Int] {
-  records.flatMap { _ in return 1 } // expected-note {{}}
-}


### PR DESCRIPTION
The change to roll back a part of SE-0110 to allow multi-argument
functions to be passed in places where functions taking a tuple are
expected resulted in a regression in some cases where the fix would
strip off the last ParenType from single-argument functions.

Instead of stripping off parens from both function types we're trying to
match when they both have them, strip off none. This ensures that we
don't get summarily rejected in the nested matchTypes call by other
SE-0110-related code that bails if the two types do not have the same
"parenness".

Fixes rdar://problem/33043106 / SR-5387.
