### PR TITLE
[silgen] Cleanup ownership around block creation.

### DIFF
--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -471,11 +471,7 @@ ManagedValue SILGenFunction::emitFuncToBlock(SILLocation loc,
   auto storageAddrTy = SILType::getPrimitiveAddressType(storageTy);
   auto storage = emitTemporaryAllocation(loc, storageAddrTy);
   auto capture = B.createProjectBlockStorage(loc, storage);
-  // Store the function to the block without claiming it, so that it still
-  // gets cleaned up in scope. Copying the block will create an independent
-  // reference.
-  B.emitStoreValueOperation(loc, fn.getValue(), capture,
-                            StoreOwnershipQualifier::Init);
+  B.createStore(loc, fn, capture, StoreOwnershipQualifier::Init);
   auto invokeFn = B.createFunctionRef(loc, thunk);
   
   auto stackBlock = B.createInitBlockStorageHeader(loc, storage, invokeFn,

--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -646,6 +646,17 @@ ManagedValue SILGenBuilder::createOpenExistentialRef(SILLocation loc,
   return cloner.clone(openedExistential);
 }
 
+ManagedValue SILGenBuilder::createStore(SILLocation loc, ManagedValue value,
+                                        SILValue address,
+                                        StoreOwnershipQualifier qualifier) {
+  SILModule &M = SGF.F.getModule();
+  CleanupCloner cloner(*this, value);
+  if (value.getType().isTrivial(M) || value.getOwnershipKind() == ValueOwnershipKind::Trivial)
+    qualifier = StoreOwnershipQualifier::Trivial;
+  SILBuilder::createStore(loc, value.forward(SGF), address, qualifier);
+  return cloner.clone(address);
+}
+
 //===----------------------------------------------------------------------===//
 //                            Switch Enum Builder
 //===----------------------------------------------------------------------===//

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -260,6 +260,15 @@ public:
   using SILBuilder::createOptionalSome;
   ManagedValue createOptionalSome(SILLocation Loc, ManagedValue Arg);
   ManagedValue createManagedOptionalNone(SILLocation Loc, SILType Type);
+
+  /// Forward \p value into \p address.
+  ///
+  /// This will forward value's cleanup (if it has one) into the equivalent
+  /// cleanup on address. In practice this means if the value is non-trivial,
+  /// the memory location will at end of scope have a destroy_addr applied to
+  /// it.
+  ManagedValue createStore(SILLocation loc, ManagedValue value,
+                           SILValue address, StoreOwnershipQualifier qualifier);
 };
 
 class SwitchCaseFullExpr;

--- a/test/SILGen/objc_bridging_any.swift
+++ b/test/SILGen/objc_bridging_any.swift
@@ -590,8 +590,8 @@ class SwiftIdLover : NSObject, Anyable {
   // CHECK:       [[THUNK_FN:%.*]] = function_ref @_T0ypIxi_yXlIyBy_TR
   // CHECK-NEXT:  [[BLOCK_HEADER:%.*]] = init_block_storage_header [[BLOCK_STORAGE]] : $*@block_storage @callee_owned (@in Any) -> (), invoke [[THUNK_FN]]
   // CHECK-NEXT:  [[BLOCK:%.*]] = copy_block [[BLOCK_HEADER]]
+  // CHECK-NEXT:  destroy_addr [[BLOCK_STORAGE_ADDR]]
   // CHECK-NEXT:  dealloc_stack [[BLOCK_STORAGE]]
-  // CHECK-NEXT:  destroy_value [[RESULT]]
   // CHECK-NEXT:  return [[BLOCK]]
 
   // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0ypIxi_yXlIyBy_TR : $@convention(c) (@inout_aliasable @block_storage @callee_owned (@in Any) -> (), AnyObject) -> ()
@@ -668,8 +668,8 @@ class SwiftIdLover : NSObject, Anyable {
   // CHECK-NEXT:  [[THUNK_FN:%.*]] = function_ref @_T0ypIxr_yXlIyBa_TR
   // CHECK-NEXT:  [[BLOCK_HEADER:%.*]] = init_block_storage_header [[BLOCK_STORAGE]] : $*@block_storage @callee_owned () -> @out Any, invoke [[THUNK_FN]]
   // CHECK-NEXT:  [[BLOCK:%.*]] = copy_block [[BLOCK_HEADER]]
+  // CHECK-NEXT:  destroy_addr [[BLOCK_STORAGE_ADDR]]
   // CHECK-NEXT:  dealloc_stack [[BLOCK_STORAGE]]
-  // CHECK-NEXT:  destroy_value [[FUNCTION]]
   // CHECK-NEXT:  return [[BLOCK]]
 
   // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @_T0ypIxr_yXlIyBa_TR : $@convention(c) (@inout_aliasable @block_storage @callee_owned () -> @out Any) -> @autoreleased AnyObject

--- a/test/SILOptimizer/access_enforcement_noescape.swift
+++ b/test/SILOptimizer/access_enforcement_noescape.swift
@@ -555,8 +555,8 @@ func noEscapeBlock() {
 // CHECK: [[WRITE:%.*]] = begin_access [modify] [static] %0 : $*Int
 // CHECK: apply %{{.*}}([[ARG]], [[WRITE]]) : $@convention(thin) (@owned @convention(block) () -> (), @inout Int) -> ()
 // CHECK: end_access [[WRITE]] : $*Int
+// CHECK: destroy_addr [[ADDR]] : $*@callee_owned () -> ()
 // CHECK: dealloc_stack [[STORAGE]] : $*@block_storage @callee_owned () -> ()
-// CHECK: strong_release [[PA]] : $@callee_owned () -> ()
 // CHECK-LABEL: } // end sil function '_T027access_enforcement_noescape13noEscapeBlockyyFyycfU_'
 
 // CHECK-LABEL: sil private @_T027access_enforcement_noescape13noEscapeBlockyyFyycfU_yycfU_ : $@convention(thin) (@inout_aliasable Int) -> () {


### PR DESCRIPTION
[silgen] Cleanup ownership around block creation.

Previously we were storing a pointer to the non-yet blockified function and not
cleaning it up. This was safe since we were performing a copy_block on the block
and destroying the SSA value of the non-yet blockified function. This looks like
a double consume to the ownership verifier. To fix this, I changed the bridging
code to use a new entrypoint for storing on SILGenBuilder that just does the
right thing by forwarding the cleanup on the SSA value and transfering it to the
address. This means the address will be destroyed instead of the SSA value,
yielding proper ownership.

rdar://31880847