### PR TITLE
[semantic-sil] Add a semantic attribute "verify.ownership.sil.never".

### DIFF
--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -456,6 +456,10 @@ public:
   ///          or is raw SIL (so that the mandatory passes still run).
   bool shouldOptimize() const;
 
+  /// Returns true if this is a function that should have its ownership
+  /// verified.
+  bool shouldVerifyOwnership() const;
+
   /// Check if the function has a location.
   /// FIXME: All functions should have locations, so this method should not be
   /// necessary.

--- a/lib/SIL/SILFunction.cpp
+++ b/lib/SIL/SILFunction.cpp
@@ -464,3 +464,7 @@ SubstitutionList SILFunction::getForwardingSubstitutions() {
   ForwardingSubs = env->getForwardingSubstitutions();
   return *ForwardingSubs;
 }
+
+bool SILFunction::shouldVerifyOwnership() const {
+  return !hasSemanticsAttr("verify.ownership.sil.never");
+}

--- a/lib/SIL/SILOwnershipVerifier.cpp
+++ b/lib/SIL/SILOwnershipVerifier.cpp
@@ -2068,9 +2068,10 @@ void SILInstruction::verifyOperandOwnership() const {
   if (!getModule().getOptions().EnableSILOwnership)
     return;
 
-  // If the given function has unqualified ownership, there is nothing to
-  // verify.
-  if (getFunction()->hasUnqualifiedOwnership())
+  // If the given function has unqualified ownership or we have been asked by
+  // the user not to verify this function, there is nothing to verify.
+  if (getFunction()->hasUnqualifiedOwnership() ||
+      !getFunction()->shouldVerifyOwnership())
     return;
 
   // If we are testing the verifier, bail so we only print errors once when
@@ -2116,9 +2117,9 @@ void SILValue::verifyOwnership(SILModule &Mod,
   SILFunction *F = (*this)->getFunction();
   assert(F && "Instructions and arguments should have a function");
 
-  // If the given function has unqualified ownership, there is nothing further
-  // to verify.
-  if (F->hasUnqualifiedOwnership())
+  // If the given function has unqualified ownership or we have been asked by
+  // the user not to verify this function, there is nothing to verify.
+  if (F->hasUnqualifiedOwnership() || !F->shouldVerifyOwnership())
     return;
 
   ErrorBehaviorKind ErrorBehavior;

--- a/test/SIL/ownership-verifier/disable_verifier_using_semantic_tag.sil
+++ b/test/SIL/ownership-verifier/disable_verifier_using_semantic_tag.sil
@@ -1,0 +1,33 @@
+// RUN: %target-sil-opt -enable-sil-ownership -sil-ownership-verifier-enable-testing -enable-sil-verify-all=0 %s -o /dev/null 2>&1 | %FileCheck %s
+// REQUIRES: asserts
+
+// This test makes sure that the ownership verifier can be disabled on specific
+// functions via the usage of the semantic attribute
+// "verify.ownership.sil.never".
+
+sil_stage canonical
+
+import Builtin
+
+sil [_semantics "verify.ownership.sil.never"] @test1 : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%0 : @owned $Builtin.NativeObject):
+  destroy_value %0 : $Builtin.NativeObject
+  destroy_value %0 : $Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-NOT: Function: 'test1'
+// CHECK-LABEL: Function: 'test2'
+// CHECK-NEXT: Found over consume?!
+// CHECK-NEXT: Value:   %0 = argument of bb0 : $Builtin.NativeObject
+// CHECK-NEXT: User:   destroy_value %0 : $Builtin.NativeObject
+// CHECK-NEXT: Block: bb0
+// CHECK-NOT: Function: 'test1'
+sil @test2 : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%0 : @owned $Builtin.NativeObject):
+  destroy_value %0 : $Builtin.NativeObject
+  destroy_value %0 : $Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}


### PR DESCRIPTION
This semantic attribute allows a user to disable ownership verification on
specific functions.

The intention is that once I turn on the sil ownership verifier for parts of the
stdlib, if an engineer exposes an ownership issue, they can disable ownership
verification on that specific function, file a bug, and continue with their
work.

rdar://31880847