### PR TITLE
SILGen: Fix linkage for stored property initializers of private properties [4.0]

### DIFF
--- a/lib/SIL/SILDeclRef.cpp
+++ b/lib/SIL/SILDeclRef.cpp
@@ -430,6 +430,33 @@ SILLinkage SILDeclRef::getLinkage(ForDefinition_t forDefinition) const {
   if (isClangImported())
     return SILLinkage::Shared;
 
+  // Stored property initializers get the linkage of their containing type.
+  if (isStoredPropertyInitializer()) {
+    // If the property is public, the initializer needs to be public, because
+    // it might be referenced from an inlineable initializer.
+    //
+    // Note that we don't serialize the presence of an initializer, so there's
+    // no way to reference one from another module except for this case.
+    //
+    // This is silly, and we need a proper resilience story here.
+    if (d->getEffectiveAccess() == Accessibility::Public)
+      return maybeAddExternal(SILLinkage::Public);
+
+    d = cast<NominalTypeDecl>(d->getDeclContext());
+
+    // Otherwise, use the visibility of the type itself, because even if the
+    // property is private, we might reference the initializer from another
+    // file.
+    switch (d->getEffectiveAccess()) {
+    case Accessibility::Private:
+    case Accessibility::FilePrivate:
+      return maybeAddExternal(SILLinkage::Private);
+
+    default:
+      return maybeAddExternal(SILLinkage::Hidden);
+    }
+  }
+
   // Otherwise, we have external linkage.
   switch (d->getEffectiveAccess()) {
     case Accessibility::Private:

--- a/test/SILGen/Inputs/struct_with_initializer.swift
+++ b/test/SILGen/Inputs/struct_with_initializer.swift
@@ -2,3 +2,11 @@ struct HasInitValue {
   var x = 10
   var y: String = ""
 }
+
+struct HasPrivateInitValue {
+  private var x = 10
+}
+
+public struct PublicStructHasInitValue {
+  var x = 10
+}

--- a/test/SILGen/extensions_multifile.swift
+++ b/test/SILGen/extensions_multifile.swift
@@ -8,3 +8,15 @@
 extension HasInitValue {
   init(z: Int) {}
 }
+
+// CHECK-LABEL: sil hidden_external [transparent] @_T020extensions_multifile19HasPrivateInitValueV1x33_0A683B047698EED319CF48214D7F519DLLSivfi : $@convention(thin) () -> Int
+
+extension HasPrivateInitValue {
+  init(z: Int) {}
+}
+
+// CHECK-LABEL: sil hidden_external [transparent] @_T020extensions_multifile24PublicStructHasInitValueV1xSivfi : $@convention(thin) () -> Int
+
+extension PublicStructHasInitValue {
+  init(z: Int) {}
+}


### PR DESCRIPTION
* Description: Fixes a regression with extensions of a type that has stored properties with initializer expressions.

* Scope of the issue: Reported as a regression by a user.

* Origination: Introduced in 4.0 beta 1.

* Tested: New tests added

* Reviewed by: @jckarter 

* Radar: <rdar://problem/32743703>