### PR TITLE
[Type checker] Bump warning about unavailable witnesses to an error in Swift 4

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1600,7 +1600,10 @@ NOTE(declared_protocol_conformance_here,none,
      "%0 implicitly conforms to protocol %2}1 here",
      (Type, unsigned, DeclName, DeclName))
 
-WARNING(witness_unavailable,none,
+WARNING(witness_unavailable_warn,none,
+        "unavailable %0 %1 was used to satisfy a requirement of protocol %2",
+        (DescriptiveDeclKind, DeclName, DeclName))
+ERROR(witness_unavailable,none,
         "unavailable %0 %1 was used to satisfy a requirement of protocol %2",
         (DescriptiveDeclKind, DeclName, DeclName))
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3023,11 +3023,15 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
 
       break;
 
-    case CheckKind::WitnessUnavailable:
-      diagnoseOrDefer(requirement, /*isError=*/false,
-        [witness, requirement](NormalProtocolConformance *conformance) {
+    case CheckKind::WitnessUnavailable: {
+      bool emitError = !witness->getASTContext().LangOpts.isSwiftVersion3();
+      diagnoseOrDefer(requirement, /*isError=*/emitError,
+        [witness, requirement, emitError](
+                                    NormalProtocolConformance *conformance) {
           auto &diags = witness->getASTContext().Diags;
-          diags.diagnose(witness, diag::witness_unavailable,
+          diags.diagnose(witness,
+                         emitError ? diag::witness_unavailable
+                                   : diag::witness_unavailable_warn,
                          witness->getDescriptiveKind(),
                          witness->getFullName(),
                          conformance->getProtocol()->getFullName());
@@ -3035,6 +3039,7 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
                          requirement->getFullName());
         });
       break;
+    }
     }
 
     ClassDecl *classDecl = Adoptee->getClassOrBoundGenericClass();

--- a/test/Compatibility/unavailable_witness.swift
+++ b/test/Compatibility/unavailable_witness.swift
@@ -1,0 +1,14 @@
+// RUN: %target-typecheck-verify-swift -swift-version 3
+
+class Foo { }
+
+// Complain about unavailable witnesses (error in Swift 4, warning in Swift 3)
+protocol P {
+  func foo(bar: Foo) // expected-note{{requirement 'foo(bar:)' declared here}}
+}
+
+struct ConformsToP : P {
+  @available(*, unavailable)
+  func foo(bar: Foo) { } // expected-warning{{unavailable instance method 'foo(bar:)' was used to satisfy a requirement of protocol 'P'}}
+}
+

--- a/test/decl/protocol/req/unavailable.swift
+++ b/test/decl/protocol/req/unavailable.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -swift-version 4
 
 // An @objc protocol can have 'unavailable'
 // methods.  They are treated as if they
@@ -24,12 +24,12 @@ class Bar : NonObjCProto { // expected-error {{type 'Bar' does not conform to pr
 }
 
 
-// Warn about unavailable witnesses.
+// Complain about unavailable witnesses (error in Swift 4, warning in Swift 3)
 protocol P {
   func foo(bar: Foo) // expected-note{{requirement 'foo(bar:)' declared here}}
 }
 
-struct ConformsToP : P {
+struct ConformsToP : P { // expected-error{{type 'ConformsToP' does not conform to protocol 'P'}}
   @available(*, unavailable)
-  func foo(bar: Foo) { } // expected-warning{{unavailable instance method 'foo(bar:)' was used to satisfy a requirement of protocol 'P'}}
+  func foo(bar: Foo) { } // expected-error{{unavailable instance method 'foo(bar:)' was used to satisfy a requirement of protocol 'P'}}
 }


### PR DESCRIPTION
**Explanation**: Swift < 3 allowed an unavailable declaration to satisfy a protocol requirement, which doesn't make sense. Swift 3.2 warns about it; promote that warning to an error in Swift 4.
**Scope**: This is a source-breaking change in Swift 4 mode, but is unlikely to affect any sane code. This condition is almost certainly a bug.
**Radar**: rdar://problem/32372208
**Risk**: Low; the only risk is that some project we care about has ported to Swift 4 and has ignored the warning.
**Testing**: Compiler regression testing.