### PR TITLE
[4.0] [Exclusivity] Relax closure enforcement on separate stored properties…

### DIFF
--- a/include/swift/SILOptimizer/Analysis/AccessSummaryAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/AccessSummaryAnalysis.h
@@ -30,34 +30,75 @@ namespace swift {
 
 class AccessSummaryAnalysis : public BottomUpIPAnalysis {
 public:
-  /// Summarizes the accesses that a function begins on an argument.
-  class ArgumentSummary {
+  class SubAccessSummary {
   private:
     /// The kind of access begun on the argument.
-    /// 'None' means no access performed.
-    Optional<SILAccessKind> Kind = None;
+    SILAccessKind Kind;
 
     /// The location of the access. Used for diagnostics.
     SILLocation AccessLoc = SILLocation((Expr *)nullptr);
 
+    const IndexTrieNode *SubPath = nullptr;
+
   public:
-    Optional<SILAccessKind> getAccessKind() const { return Kind; }
+    SubAccessSummary(SILAccessKind Kind, SILLocation AccessLoc,
+                     const IndexTrieNode *SubPath)
+        : Kind(Kind), AccessLoc(AccessLoc), SubPath(SubPath) {}
+
+    SILAccessKind getAccessKind() const { return Kind; }
 
     SILLocation getAccessLoc() const { return AccessLoc; }
 
+    const IndexTrieNode *getSubPath() const { return SubPath; }
+
+    /// The lattice operation on SubAccessSummaries summaries.
+    bool mergeWith(const SubAccessSummary &other);
+
+    /// Merge in an access to the argument of the given kind at the given
+    /// location with the given suppath. Returns true if the merge caused the
+    /// summary to change.
+    bool mergeWith(SILAccessKind otherKind, SILLocation otherLoc,
+                   const IndexTrieNode *otherSubPath);
+
+    /// Returns a description of the summary. For debugging and testing
+    /// purposes.
+    std::string getDescription(SILType BaseType, SILModule &M) const;
+  };
+
+  typedef llvm::SmallDenseMap<const IndexTrieNode *, SubAccessSummary, 8>
+      SubAccessMap;
+
+  /// Summarizes the accesses that a function begins on an argument, including
+  /// the projection subpath that was accessed.
+  class ArgumentSummary {
+  private:
+    SubAccessMap SubAccesses;
+
+  public:
     /// The lattice operation on argument summaries.
     bool mergeWith(const ArgumentSummary &other);
 
     /// Merge in an access to the argument of the given kind at the given
     /// location. Returns true if the merge caused the summary to change.
-    bool mergeWith(SILAccessKind otherKind, SILLocation otherLoc);
+    bool mergeWith(SILAccessKind otherKind, SILLocation otherLoc,
+                   const IndexTrieNode *otherSubPath);
 
     /// Returns a description of the summary. For debugging and testing
     /// purposes.
-    StringRef getDescription() const;
+    std::string getDescription(SILType BaseType, SILModule &M) const;
+
+    /// Returns the accesses that the function performs to subpaths of the
+    /// argument.
+    const SubAccessMap &getSubAccesses() const { return SubAccesses; }
+
+    /// Returns the sorted subaccess summaries into the passed-in storage.
+    /// The accesses are sorted lexicographically by increasing subpath
+    /// length and projection index.
+    void getSortedSubAccesses(SmallVectorImpl<SubAccessSummary> &storage) const;
   };
 
-  /// Summarizes the accesses that a function begins on its arguments.
+  /// Summarizes the accesses that a function begins on its arguments or
+  /// projections from its arguments.
   class FunctionSummary {
   private:
     llvm::SmallVector<ArgumentSummary, 6> ArgAccesses;
@@ -77,10 +118,9 @@ public:
 
     /// Returns the number of argument in the summary.
     unsigned getArgumentCount() const { return ArgAccesses.size(); }
-  };
 
-  friend raw_ostream &operator<<(raw_ostream &os,
-                                 const FunctionSummary &summary);
+    void print(raw_ostream &os, SILFunction *fn) const;
+  };
 
   class FunctionInfo;
   /// Records a flow of a caller's argument to a called function.
@@ -151,6 +191,10 @@ public:
     return SubPathTrie;
   }
 
+  /// Returns an IndexTrieNode that represents the single subpath accessed from
+  /// BAI or the root if no such node exists.
+  const IndexTrieNode *findSubPathAccessed(BeginAccessInst *BAI);
+
   virtual void initialize(SILPassManager *PM) override {}
   virtual void invalidate() override;
   virtual void invalidate(SILFunction *F, InvalidationKind K) override;
@@ -164,6 +208,17 @@ public:
     return S->getKind() == AnalysisKind::AccessSummary;
   }
 
+  /// Returns a description of the subpath suitable for use in diagnostics.
+  /// The base type must be the type of the root of the path.
+  static std::string getSubPathDescription(SILType BaseType,
+                                           const IndexTrieNode *SubPath,
+                                           SILModule &M);
+
+  /// Performs a lexicographic comparison of two subpaths, first by path length
+  /// and then by index of the last path component. Returns true when lhs
+  /// is less than rhs.
+  static bool compareSubPaths(const IndexTrieNode *lhs,
+                              const IndexTrieNode *rhs);
 private:
   typedef BottomUpFunctionOrder<FunctionInfo> FunctionOrder;
 

--- a/lib/SILOptimizer/Analysis/AccessSummaryAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/AccessSummaryAnalysis.cpp
@@ -66,7 +66,8 @@ void AccessSummaryAnalysis::processArgument(FunctionInfo *info,
     switch (user->getKind()) {
     case ValueKind::BeginAccessInst: {
       auto *BAI = cast<BeginAccessInst>(user);
-      summary.mergeWith(BAI->getAccessKind(), BAI->getLoc());
+      const IndexTrieNode *subPath = findSubPathAccessed(BAI);
+      summary.mergeWith(BAI->getAccessKind(), BAI->getLoc(), subPath);
       // We don't add the users of the begin_access to the worklist because
       // even if these users eventually begin an access to the address
       // or a projection from it, that access can't begin more exclusive
@@ -229,12 +230,48 @@ void AccessSummaryAnalysis::processCall(FunctionInfo *callerInfo,
   propagateFromCalleeToCaller(callerInfo, flow);
 }
 
-bool AccessSummaryAnalysis::ArgumentSummary::mergeWith(SILAccessKind otherKind,
-                                                        SILLocation otherLoc) {
+bool AccessSummaryAnalysis::ArgumentSummary::mergeWith(
+    SILAccessKind otherKind, SILLocation otherLoc,
+    const IndexTrieNode *otherSubPath) {
+  bool changed = false;
+
+  auto found =
+      SubAccesses.try_emplace(otherSubPath, otherKind, otherLoc, otherSubPath);
+  if (!found.second) {
+    // We already have an entry for otherSubPath, so merge with it.
+    changed = found.first->second.mergeWith(otherKind, otherLoc, otherSubPath);
+  } else {
+    // We just added a new entry for otherSubPath.
+    changed = true;
+  }
+
+  return changed;
+}
+
+bool AccessSummaryAnalysis::ArgumentSummary::mergeWith(
+    const ArgumentSummary &other) {
+  bool changed = false;
+
+  const SubAccessMap &otherAccesses = other.SubAccesses;
+  for (auto it = otherAccesses.begin(), e = otherAccesses.end(); it != e;
+       ++it) {
+    const SubAccessSummary &otherSubAccess = it->getSecond();
+    if (mergeWith(otherSubAccess.getAccessKind(), otherSubAccess.getAccessLoc(),
+                  otherSubAccess.getSubPath())) {
+      changed = true;
+    }
+  }
+
+  return changed;
+}
+
+bool AccessSummaryAnalysis::SubAccessSummary::mergeWith(
+    SILAccessKind otherKind, SILLocation otherLoc,
+    const IndexTrieNode *otherSubPath) {
+  assert(otherSubPath == this->SubPath);
   // In the lattice, a modification-like accesses subsume a read access or no
   // access.
-  if (!Kind.hasValue() ||
-      (*Kind == SILAccessKind::Read && otherKind != SILAccessKind::Read)) {
+  if (Kind == SILAccessKind::Read && otherKind != SILAccessKind::Read) {
     Kind = otherKind;
     AccessLoc = otherLoc;
     return true;
@@ -243,11 +280,11 @@ bool AccessSummaryAnalysis::ArgumentSummary::mergeWith(SILAccessKind otherKind,
   return false;
 }
 
-bool AccessSummaryAnalysis::ArgumentSummary::mergeWith(
-    const ArgumentSummary &other) {
-  if (other.Kind.hasValue())
-    return mergeWith(*other.Kind, other.AccessLoc);
-  return false;
+bool AccessSummaryAnalysis::SubAccessSummary::mergeWith(
+    const SubAccessSummary &other) {
+  // We don't currently support merging accesses for different sub paths.
+  assert(SubPath == other.SubPath);
+  return mergeWith(other.Kind, other.AccessLoc, SubPath);
 }
 
 void AccessSummaryAnalysis::recompute(FunctionInfo *initial) {
@@ -289,12 +326,57 @@ void AccessSummaryAnalysis::recompute(FunctionInfo *initial) {
   } while (needAnotherIteration);
 }
 
-StringRef AccessSummaryAnalysis::ArgumentSummary::getDescription() const {
-  if (Optional<SILAccessKind> kind = getAccessKind()) {
-    return getSILAccessKindName(*kind);
+std::string
+AccessSummaryAnalysis::SubAccessSummary::getDescription(SILType BaseType,
+                                                        SILModule &M) const {
+  std::string sbuf;
+  llvm::raw_string_ostream os(sbuf);
+
+  os << AccessSummaryAnalysis::getSubPathDescription(BaseType, SubPath, M);
+
+  if (!SubPath->isRoot())
+    os << " ";
+  os << getSILAccessKindName(getAccessKind());
+  return os.str();
+}
+
+void AccessSummaryAnalysis::ArgumentSummary::getSortedSubAccesses(
+    SmallVectorImpl<SubAccessSummary> &storage) const {
+  for (auto it = SubAccesses.begin(), e = SubAccesses.end(); it != e; ++it) {
+    storage.push_back(it->getSecond());
   }
 
-  return "none";
+  const auto &compare = [](const SubAccessSummary &lhs,
+                           const SubAccessSummary &rhs) {
+    return compareSubPaths(lhs.getSubPath(), rhs.getSubPath());
+  };
+  std::sort(storage.begin(), storage.end(), compare);
+
+  assert(storage.size() == SubAccesses.size());
+}
+
+std::string
+AccessSummaryAnalysis::ArgumentSummary::getDescription(SILType BaseType,
+                                                       SILModule &M) const {
+  std::string sbuf;
+  llvm::raw_string_ostream os(sbuf);
+  os << "[";
+  unsigned index = 0;
+
+  SmallVector<AccessSummaryAnalysis::SubAccessSummary, 8> Sorted;
+  Sorted.reserve(SubAccesses.size());
+  getSortedSubAccesses(Sorted);
+
+  for (auto &subAccess : Sorted) {
+    if (index > 0) {
+      os << ", ";
+    }
+    os << subAccess.getDescription(BaseType, M);
+    index++;
+  }
+  os << "]";
+
+  return os.str();
 }
 
 bool AccessSummaryAnalysis::propagateFromCalleeToCaller(
@@ -345,19 +427,155 @@ SILAnalysis *swift::createAccessSummaryAnalysis(SILModule *M) {
   return new AccessSummaryAnalysis();
 }
 
-raw_ostream &swift::
-operator<<(raw_ostream &os,
-           const AccessSummaryAnalysis::FunctionSummary &summary) {
-  unsigned argCount = summary.getArgumentCount();
-  os << "(";
+/// If the instruction is a field or tuple projection and it has a single
+/// user return a pair of the single user and the projection index.
+/// Otherwise, return a pair with the component nullptr and the second
+/// unspecified.
+static std::pair<SILInstruction *, unsigned>
+getSingleAddressProjectionUser(SILInstruction *I) {
+  SILInstruction *SingleUser = nullptr;
+  unsigned ProjectionIndex = 0;
 
-  if (argCount > 0) {
-    os << summary.getAccessForArgument(0).getDescription();
-    for (unsigned i = 1; i < argCount; i++) {
-      os << ",  " << summary.getAccessForArgument(i).getDescription();
+  for (Operand *Use : I->getUses()) {
+    SILInstruction *User = Use->getUser();
+    if (isa<BeginAccessInst>(I) && isa<EndAccessInst>(User))
+      continue;
+
+    // We have more than a single user so bail.
+    if (SingleUser)
+      return std::make_pair(nullptr, 0);
+
+    switch (User->getKind()) {
+    case ValueKind::StructElementAddrInst:
+      ProjectionIndex = cast<StructElementAddrInst>(User)->getFieldNo();
+      SingleUser = User;
+      break;
+    case ValueKind::TupleElementAddrInst:
+      ProjectionIndex = cast<TupleElementAddrInst>(User)->getFieldNo();
+      SingleUser = User;
+      break;
+    default:
+      return std::make_pair(nullptr, 0);
     }
   }
 
+  return std::make_pair(SingleUser, ProjectionIndex);
+}
+
+const IndexTrieNode *
+AccessSummaryAnalysis::findSubPathAccessed(BeginAccessInst *BAI) {
+  IndexTrieNode *SubPath = SubPathTrie;
+
+  // For each single-user projection of BAI, construct or get a node
+  // from the trie representing the index of the field or tuple element
+  // accessed by that projection.
+  SILInstruction *Iter = BAI;
+  while (true) {
+    std::pair<SILInstruction *, unsigned> ProjectionUser =
+        getSingleAddressProjectionUser(Iter);
+    if (!ProjectionUser.first)
+      break;
+
+    SubPath = SubPath->getChild(ProjectionUser.second);
+    Iter = ProjectionUser.first;
+  }
+
+  return SubPath;
+}
+
+/// Returns a string representation of the SubPath
+/// suitable for use in diagnostic text. Only supports the Projections
+/// that stored-property relaxation supports: struct stored properties
+/// and tuple elements.
+std::string AccessSummaryAnalysis::getSubPathDescription(
+    SILType baseType, const IndexTrieNode *subPath, SILModule &M) {
+  // Walk the trie to the root to collect the sequence (in reverse order).
+  llvm::SmallVector<unsigned, 4> reversedIndices;
+  const IndexTrieNode *I = subPath;
+  while (!I->isRoot()) {
+    reversedIndices.push_back(I->getIndex());
+    I = I->getParent();
+  }
+
+  std::string sbuf;
+  llvm::raw_string_ostream os(sbuf);
+
+  SILType containingType = baseType;
+  for (unsigned index : reversed(reversedIndices)) {
+    os << ".";
+
+    if (StructDecl *D = containingType.getStructOrBoundGenericStruct()) {
+      auto iter = D->getStoredProperties().begin();
+      std::advance(iter, index);
+      VarDecl *var = *iter;
+      os << var->getBaseName();
+      containingType = containingType.getFieldType(var, M);
+      continue;
+    }
+
+    if (auto tupleTy = containingType.getAs<TupleType>()) {
+      Identifier elementName = tupleTy->getElement(index).getName();
+      if (elementName.empty())
+        os << index;
+      else
+        os << elementName;
+      containingType = containingType.getTupleElementType(index);
+      continue;
+    }
+
+    llvm_unreachable("Unexpected type in projection SubPath!");
+  }
+
+  return os.str();
+}
+
+static unsigned subPathLength(const IndexTrieNode *subPath) {
+  unsigned length = 0;
+
+  const IndexTrieNode *iter = subPath;
+  while (iter) {
+    length++;
+    iter = iter->getParent();
+  }
+
+  return length;
+}
+
+bool AccessSummaryAnalysis::compareSubPaths(const IndexTrieNode *lhs,
+                                            const IndexTrieNode *rhs) {
+  unsigned lhsLength = subPathLength(lhs);
+  unsigned rhsLength = subPathLength(rhs);
+
+  if (lhsLength != rhsLength)
+    return lhsLength < rhsLength;
+
+
+  while (lhs) {
+    if (lhs->getIndex() != rhs->getIndex())
+      return lhs->getIndex() < rhs->getIndex();
+
+    lhs = lhs->getParent();
+    rhs = rhs->getParent();
+  }
+
+  assert(!rhs && "Equal paths with different lengths?");
+  // The two paths are equal.
+  return false;
+}
+
+void AccessSummaryAnalysis::FunctionSummary::print(raw_ostream &os,
+                                                   SILFunction *fn) const {
+  unsigned argCount = getArgumentCount();
+  os << "(";
+
+  for (unsigned i = 0; i < argCount; i++) {
+    if (i > 0) {
+      os << ",  ";
+    }
+    SILArgument *arg = fn->getArgument(i);
+    SILModule &m = fn->getModule();
+    os << getAccessForArgument(i).getDescription(arg->getType(), m);
+  }
+
   os << ")";
-  return os;
 }

--- a/lib/SILOptimizer/Mandatory/DiagnoseStaticExclusivity.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseStaticExclusivity.cpp
@@ -635,45 +635,11 @@ tryFixItWithCallToCollectionSwapAt(const BeginAccessInst *Access1,
 static std::string getPathDescription(DeclName BaseName, SILType BaseType,
                                       const IndexTrieNode *SubPath,
                                       SILModule &M) {
-  // Walk the trie to the root to collection the sequence (in reverse order).
-  llvm::SmallVector<unsigned, 4> ReversedIndices;
-  const IndexTrieNode *I = SubPath;
-  while (!I->isRoot()) {
-    ReversedIndices.push_back(I->getIndex());
-    I = I->getParent();
-  }
-
   std::string sbuf;
   llvm::raw_string_ostream os(sbuf);
 
   os << "'" << BaseName;
-
-  SILType ContainingType = BaseType;
-  for (unsigned Index : reversed(ReversedIndices)) {
-    os << ".";
-
-    if (StructDecl *D = ContainingType.getStructOrBoundGenericStruct()) {
-      auto Iter = D->getStoredProperties().begin();
-      std::advance(Iter, Index);
-      VarDecl *VD = *Iter;
-      os << VD->getBaseName();
-      ContainingType = ContainingType.getFieldType(VD, M);
-      continue;
-    }
-
-    if (auto TupleTy = ContainingType.getAs<TupleType>()) {
-      Identifier ElementName = TupleTy->getElement(Index).getName();
-      if (ElementName.empty())
-        os << Index;
-      else
-        os << ElementName;
-      ContainingType = ContainingType.getTupleElementType(Index);
-      continue;
-    }
-
-    llvm_unreachable("Unexpected type in projection SubPath!");
-  }
-
+  os << AccessSummaryAnalysis::getSubPathDescription(BaseType, SubPath, M);
   os << "'";
 
   return os.str();
@@ -848,74 +814,56 @@ static bool isCallToStandardLibrarySwap(ApplyInst *AI, ASTContext &Ctx) {
   return FD == Ctx.getSwap(nullptr);
 }
 
-/// If the instruction is a field or tuple projection and it has a single
-/// user return a pair of the single user and the projection index.
-/// Otherwise, return a pair with the component nullptr and the second
-/// unspecified.
-static std::pair<SILInstruction *, unsigned>
-getSingleAddressProjectionUser(SILInstruction *I) {
-  SILInstruction *SingleUser = nullptr;
-  unsigned ProjectionIndex = 0;
-
-  for (Operand *Use : I->getUses()) {
-    SILInstruction *User = Use->getUser();
-    if (isa<BeginAccessInst>(I) && isa<EndAccessInst>(User))
-      continue;
-
-    // We have more than a single user so bail.
-    if (SingleUser)
-      return std::make_pair(nullptr, 0);
-
-    switch (User->getKind()) {
-    case ValueKind::StructElementAddrInst:
-      ProjectionIndex = cast<StructElementAddrInst>(User)->getFieldNo();
-      SingleUser = User;
-      break;
-    case ValueKind::TupleElementAddrInst:
-      ProjectionIndex = cast<TupleElementAddrInst>(User)->getFieldNo();
-      SingleUser = User;
-      break;
-    default:
-      return std::make_pair(nullptr, 0);
-    }
-  }
-
-  return std::make_pair(SingleUser, ProjectionIndex);
-}
-
-/// Returns an IndexTrieNode that represents the single subpath accessed from
-/// BAI or the root if no such node exists.
-static const IndexTrieNode *findSubPathAccessed(BeginAccessInst *BAI,
-                                                IndexTrieNode *Root) {
-  IndexTrieNode *SubPath = Root;
-
-  // For each single-user projection of BAI, construct or get a node
-  // from the trie representing the index of the field or tuple element
-  // accessed by that projection.
-  SILInstruction *Iter = BAI;
-  while (true) {
-    std::pair<SILInstruction *, unsigned> ProjectionUser =
-        getSingleAddressProjectionUser(Iter);
-    if (!ProjectionUser.first)
-      break;
-
-    SubPath = SubPath->getChild(ProjectionUser.second);
-    Iter = ProjectionUser.first;
-  }
-
-  return SubPath;
-}
-
 /// If making an access of the given kind at the given subpath would
 /// would conflict, returns the first recorded access it would conflict
 /// with. Otherwise, returns None.
-Optional<RecordedAccess> shouldReportAccess(const AccessInfo &Info,
-                                            swift::SILAccessKind Kind,
-                                            const IndexTrieNode *SubPath) {
+static Optional<RecordedAccess>
+shouldReportAccess(const AccessInfo &Info,swift::SILAccessKind Kind,
+                   const IndexTrieNode *SubPath) {
   if (Info.alreadyHadConflict())
     return None;
 
   return Info.conflictsWithAccess(Kind, SubPath);
+}
+
+/// For each projection that the summarized function accesses on its
+/// capture, check whether the access conflicts with already-in-progress
+/// access. Returns the most general summarized conflict -- so if there are
+/// two conflicts in the called function and one is for an access to an
+/// aggregate and another is for an access to a projection from the aggregate,
+/// this will return the conflict for the aggregate. This approach guarantees
+/// determinism and makes it more  likely that we'll diagnose the most helpful
+/// conflict.
+static Optional<ConflictingAccess>
+findConflictingArgumentAccess(const AccessSummaryAnalysis::ArgumentSummary &AS,
+                              const AccessedStorage &AccessedStorage,
+                              const AccessInfo &InProgressInfo) {
+  Optional<RecordedAccess> BestInProgressAccess;
+  Optional<RecordedAccess> BestArgAccess;
+
+  for (const auto &MapPair : AS.getSubAccesses()) {
+    const IndexTrieNode *SubPath = MapPair.getFirst();
+    const auto &SubAccess = MapPair.getSecond();
+    SILAccessKind Kind = SubAccess.getAccessKind();
+    auto InProgressAccess = shouldReportAccess(InProgressInfo, Kind, SubPath);
+    if (!InProgressAccess)
+      continue;
+
+    if (!BestArgAccess ||
+        AccessSummaryAnalysis::compareSubPaths(SubPath,
+                                               BestArgAccess->getSubPath())) {
+        SILLocation AccessLoc = SubAccess.getAccessLoc();
+
+        BestArgAccess = RecordedAccess(Kind, AccessLoc, SubPath);
+        BestInProgressAccess = InProgressAccess;
+    }
+  }
+
+  if (!BestArgAccess)
+    return None;
+
+  return ConflictingAccess(AccessedStorage, *BestInProgressAccess,
+                           *BestArgAccess);
 }
 
 /// Use the summary analysis to check whether a call to the given
@@ -939,8 +887,11 @@ static void checkForViolationWithCall(
 
     const AccessSummaryAnalysis::ArgumentSummary &AS =
         FS.getAccessForArgument(CalleeIndex);
-    Optional<SILAccessKind> Kind = AS.getAccessKind();
-    if (!Kind)
+
+    const auto &SubAccesses = AS.getSubAccesses();
+
+    // Is the capture accessed in the callee?
+    if (SubAccesses.size() == 0)
       continue;
 
     SILValue Argument = Arguments[ArgumentIndex];
@@ -948,18 +899,14 @@ static void checkForViolationWithCall(
 
     const AccessedStorage &Storage = findAccessedStorage(Argument);
     auto AccessIt = Accesses.find(Storage);
+
+    // Are there any accesses in progress at the time of the call?
     if (AccessIt == Accesses.end())
       continue;
-    const AccessInfo &Info = AccessIt->getSecond();
 
-    // TODO: For now, treat a summarized access as an access to the whole
-    // address. Once the summary analysis is sensitive to stored properties,
-    // this should be updated look at the subpaths from the summary.
-    const IndexTrieNode *SubPath = ASA->getSubPathTrieRoot();
-    if (auto Conflict = shouldReportAccess(Info, *Kind, SubPath)) {
-      SILLocation AccessLoc = AS.getAccessLoc();
-      const auto &SecondAccess = RecordedAccess(*Kind, AccessLoc, SubPath);
-      ConflictingAccesses.emplace_back(Storage, *Conflict, SecondAccess);
+    const AccessInfo &Info = AccessIt->getSecond();
+    if (auto Conflict = findConflictingArgumentAccess(AS, Storage, Info)) {
+      ConflictingAccesses.push_back(*Conflict);
     }
   }
 }
@@ -1086,8 +1033,7 @@ static void checkStaticExclusivity(SILFunction &Fn, PostOrderFunctionInfo *PO,
         SILAccessKind Kind = BAI->getAccessKind();
         const AccessedStorage &Storage = findAccessedStorage(BAI->getSource());
         AccessInfo &Info = Accesses[Storage];
-        const IndexTrieNode *SubPath =
-            findSubPathAccessed(BAI, ASA->getSubPathTrieRoot());
+        const IndexTrieNode *SubPath = ASA->findSubPathAccessed(BAI);
         if (auto Conflict = shouldReportAccess(Info, Kind, SubPath)) {
           ConflictingAccesses.emplace_back(Storage, *Conflict,
                                            RecordedAccess(BAI, SubPath));
@@ -1102,8 +1048,7 @@ static void checkStaticExclusivity(SILFunction &Fn, PostOrderFunctionInfo *PO,
         AccessInfo &Info = It->getSecond();
 
         BeginAccessInst *BAI = EAI->getBeginAccess();
-        const IndexTrieNode *SubPath =
-            findSubPathAccessed(BAI, ASA->getSubPathTrieRoot());
+        const IndexTrieNode *SubPath = ASA->findSubPathAccessed(BAI);
         Info.endAccess(EAI, SubPath);
 
         // If the storage location has no more in-progress accesses, remove

--- a/lib/SILOptimizer/UtilityPasses/AccessSummaryDumper.cpp
+++ b/lib/SILOptimizer/UtilityPasses/AccessSummaryDumper.cpp
@@ -39,7 +39,8 @@ class AccessSummaryDumper : public SILModuleTransform {
       }
       const AccessSummaryAnalysis::FunctionSummary &summary =
           analysis->getOrCreateSummary(&fn);
-      llvm::outs() << summary << "\n";
+      summary.print(llvm::outs(), &fn);
+      llvm::outs() << "\n";
     }
   }
 };

--- a/test/SILOptimizer/access_summary_analysis.sil
+++ b/test/SILOptimizer/access_summary_analysis.sil
@@ -11,8 +11,13 @@ struct StructWithStoredProperties {
   @sil_stored var g: Int
 }
 
+struct StructWithStructWithStoredProperties {
+  @sil_stored var a: StructWithStoredProperties
+  @sil_stored var b: StructWithStoredProperties
+}
+
 // CHECK-LABEL: @assignsToCapture
-// CHECK-NEXT: (modify, none)
+// CHECK-NEXT: ([modify], [])
 sil private @assignsToCapture : $@convention(thin) (@inout_aliasable Int, Int) -> () {
 bb0(%0 : $*Int, %1: $Int):
   %2 = begin_access [modify] [unknown] %0 : $*Int
@@ -23,7 +28,7 @@ bb0(%0 : $*Int, %1: $Int):
 }
 
 // CHECK-LABEL: @readsAndModifiesSameCapture
-// CHECK-NEXT: (modify)
+// CHECK-NEXT: ([modify])
 sil private @readsAndModifiesSameCapture : $@convention(thin) (@inout_aliasable Int) -> () {
 bb0(%0 : $*Int):
   %1 = begin_access [read] [unknown] %0 : $*Int
@@ -35,7 +40,7 @@ bb0(%0 : $*Int):
 }
 
 // CHECK-LABEL: @readsAndModifiesSeparateCaptures
-// CHECK-NEXT: (read, modify)
+// CHECK-NEXT: ([read], [modify])
 sil private @readsAndModifiesSeparateCaptures : $@convention(thin) (@inout_aliasable Int, @inout_aliasable Int) -> () {
 bb0(%0 : $*Int, %1 : $*Int):
   %2 = begin_access [read] [unknown] %0 : $*Int
@@ -47,7 +52,7 @@ bb0(%0 : $*Int, %1 : $*Int):
 }
 
 // CHECK-LABEL: @modifyInModifySubAccess
-// CHECK-NEXT: (modify)
+// CHECK-NEXT: ([modify])
 sil private @modifyInModifySubAccess : $@convention(thin) (@inout_aliasable Int) -> () {
 bb0(%0 : $*Int):
   %1 = begin_access [modify] [unknown] %0 : $*Int
@@ -59,7 +64,7 @@ bb0(%0 : $*Int):
 }
 
 // CHECK-LABEL: @readInModifySubAccess
-// CHECK-NEXT: (modify)
+// CHECK-NEXT: ([modify])
 sil private @readInModifySubAccess : $@convention(thin) (@inout_aliasable Int) -> () {
 bb0(%0 : $*Int):
   %1 = begin_access [modify] [unknown] %0 : $*Int
@@ -70,8 +75,107 @@ bb0(%0 : $*Int):
   return %3 : $()
 }
 
+// CHECK-LABEL: @accessSeparateStoredPropertiesOfSameCapture
+// CHECK-NEXT: ([.f modify, .g read])
+sil private @accessSeparateStoredPropertiesOfSameCapture : $@convention(thin) (@inout_aliasable StructWithStoredProperties) -> () {
+bb0(%0 : $*StructWithStoredProperties):
+  %1 = begin_access [modify] [unknown] %0: $*StructWithStoredProperties
+  %2 = struct_element_addr %1 : $*StructWithStoredProperties, #StructWithStoredProperties.f
+  %3 = end_access %1 : $*StructWithStoredProperties
+  %4 = begin_access [read] [unknown] %0: $*StructWithStoredProperties
+  %5 = struct_element_addr %4 : $*StructWithStoredProperties, #StructWithStoredProperties.g
+  %6 = end_access %4 : $*StructWithStoredProperties
+  %7 = tuple ()
+  return %7 : $()
+}
+
+// CHECK-LABEL: @accessSeparateElementsOfSameCapture
+// CHECK-NEXT: ([.0 modify, .1 read])
+sil private @accessSeparateElementsOfSameCapture : $@convention(thin) (@inout_aliasable (Int, Int)) -> () {
+bb0(%0 : $*(Int, Int)):
+  %1 = begin_access [modify] [unknown] %0: $*(Int, Int)
+  %2 = tuple_element_addr %1 : $*(Int, Int), 0
+  %3 = end_access %1 : $*(Int, Int)
+  %4 = begin_access [read] [unknown] %0: $*(Int, Int)
+  %5 = tuple_element_addr %4 : $*(Int, Int), 1
+  %6 = end_access %4 : $*(Int, Int)
+  %7 = tuple ()
+  return %7 : $()
+}
+
+// CHECK-LABEL: @accessSeparateNestedStoredPropertiesOfSameCapture
+// CHECK-NEXT: ([.a.f modify, .b.g modify])
+sil private @accessSeparateNestedStoredPropertiesOfSameCapture : $@convention(thin) (@inout_aliasable StructWithStructWithStoredProperties) -> () {
+bb0(%0 : $*StructWithStructWithStoredProperties):
+  %1 = begin_access [modify] [unknown] %0: $*StructWithStructWithStoredProperties
+  %2 = struct_element_addr %1 : $*StructWithStructWithStoredProperties, #StructWithStructWithStoredProperties.a
+  %3 = struct_element_addr %2 : $*StructWithStoredProperties, #StructWithStoredProperties.f
+  %4 = end_access %1 : $*StructWithStructWithStoredProperties
+  %5 = begin_access [modify] [unknown] %0: $*StructWithStructWithStoredProperties
+  %6 = struct_element_addr %5 : $*StructWithStructWithStoredProperties, #StructWithStructWithStoredProperties.b
+  %7 = struct_element_addr %6 : $*StructWithStoredProperties, #StructWithStoredProperties.g
+  %8 = end_access %5 : $*StructWithStructWithStoredProperties
+  %9 = tuple ()
+  return %9 : $()
+}
+
+
+// CHECK-LABEL: @accessSeparateStoredPropertiesOfSameCaptureOppositeOfDeclarationOrder
+// CHECK-NEXT: ([.f read, .g modify])
+sil private @accessSeparateStoredPropertiesOfSameCaptureOppositeOfDeclarationOrder : $@convention(thin) (@inout_aliasable StructWithStoredProperties) -> () {
+bb0(%0 : $*StructWithStoredProperties):
+  %1 = begin_access [modify] [unknown] %0: $*StructWithStoredProperties
+  %2 = struct_element_addr %1 : $*StructWithStoredProperties, #StructWithStoredProperties.g
+  %3 = end_access %1 : $*StructWithStoredProperties
+  %4 = begin_access [read] [unknown] %0: $*StructWithStoredProperties
+  %5 = struct_element_addr %4 : $*StructWithStoredProperties, #StructWithStoredProperties.f
+  %6 = end_access %4 : $*StructWithStoredProperties
+  %7 = tuple ()
+  return %7 : $()
+}
+
+// CHECK-LABEL: @accessAggregateDoesNotSubsumeAccessStoredProp
+// CHECK-NEXT: ([modify, .g modify])
+sil private @accessAggregateDoesNotSubsumeAccessStoredProp : $@convention(thin) (@inout_aliasable StructWithStoredProperties) -> () {
+bb0(%0 : $*StructWithStoredProperties):
+  %1 = begin_access [modify] [unknown] %0: $*StructWithStoredProperties
+  %3 = end_access %1 : $*StructWithStoredProperties
+  %4 = begin_access [modify] [unknown] %0: $*StructWithStoredProperties
+  %5 = struct_element_addr %4 : $*StructWithStoredProperties, #StructWithStoredProperties.g
+  %6 = end_access %4 : $*StructWithStoredProperties
+  %7 = tuple ()
+  return %7 : $()
+}
+
+// CHECK-LABEL: @accessAggregateDoesNotSubsumeAccessStoredPropWithAggregateSecond
+// CHECK-NEXT: ([modify, .f modify])
+sil private @accessAggregateDoesNotSubsumeAccessStoredPropWithAggregateSecond : $@convention(thin) (@inout_aliasable StructWithStoredProperties) -> () {
+bb0(%0 : $*StructWithStoredProperties):
+  %1 = begin_access [modify] [unknown] %0: $*StructWithStoredProperties
+  %2 = struct_element_addr %1 : $*StructWithStoredProperties, #StructWithStoredProperties.f
+  %3 = end_access %1 : $*StructWithStoredProperties
+  %4 = begin_access [modify] [unknown] %0: $*StructWithStoredProperties
+  %6 = end_access %4 : $*StructWithStoredProperties
+  %7 = tuple ()
+  return %7 : $()
+}
+
+// CHECK-LABEL: @accessSameStoredPropertyOfSameCapture
+// CHECK-NEXT: ([.f modify])
+sil private @accessSameStoredPropertyOfSameCapture : $@convention(thin) (@inout_aliasable StructWithStoredProperties) -> () {
+bb0(%0 : $*StructWithStoredProperties):
+  %1 = begin_access [read] [unknown] %0: $*StructWithStoredProperties
+  %2 = struct_element_addr %1 : $*StructWithStoredProperties, #StructWithStoredProperties.f
+  %3 = end_access %1 : $*StructWithStoredProperties
+  %4 = begin_access [modify] [unknown] %0: $*StructWithStoredProperties
+  %5 = struct_element_addr %4 : $*StructWithStoredProperties, #StructWithStoredProperties.f
+  %6 = end_access %4 : $*StructWithStoredProperties
+  %7 = tuple ()
+  return %7 : $()
+}
+
 // CHECK-LABEL: @addressToPointerOfStructElementAddr
-// CHECK-NEXT: (none)
+// CHECK-NEXT: ([])
 // This mirrors the code pattern for materializeForSet on a struct stored
 // property
 sil private @addressToPointerOfStructElementAddr : $@convention(method) (@inout StructWithStoredProperties) -> (Builtin.RawPointer) {
@@ -82,7 +186,7 @@ bb0(%1 : $*StructWithStoredProperties):
 }
 
 // CHECK-LABEL: @endUnpairedAccess
-// CHECK-NEXT: (none)
+// CHECK-NEXT: ([])
 sil private @endUnpairedAccess : $@convention(method) (@inout Builtin.UnsafeValueBuffer) -> () {
 bb0(%0 : $*Builtin.UnsafeValueBuffer):
   end_unpaired_access [dynamic] %0 : $*Builtin.UnsafeValueBuffer
@@ -91,7 +195,7 @@ bb0(%0 : $*Builtin.UnsafeValueBuffer):
 }
 
 // CHECK-LABEL: @tupleElementAddr
-// CHECK-NEXT: (modify)
+// CHECK-NEXT: ([modify])
 sil private @tupleElementAddr : $@convention(thin) (@inout_aliasable (Int, Int)) -> () {
 bb0(%0 : $*(Int, Int)):
   %1 = tuple_element_addr %0 : $*(Int, Int), 1
@@ -104,7 +208,7 @@ bb0(%0 : $*(Int, Int)):
 sil @closureWithMissingBody : $@convention(thin) (@inout_aliasable Int, Int) -> ()
 
 // CHECK-LABEL: @callClosureWithMissingBody
-// CHECK-NEXT: (none, none)
+// CHECK-NEXT: ([], [])
 sil private @callClosureWithMissingBody : $@convention(thin) (@inout_aliasable Int, Int) -> () {
 bb0(%0 : $*Int, %1 : $Int):
   %2 = function_ref @closureWithMissingBody : $@convention(thin) (@inout_aliasable Int, Int) -> ()
@@ -114,7 +218,7 @@ bb0(%0 : $*Int, %1 : $Int):
 }
 
 // CHECK-LABEL: @callClosureThatModifiesCapture
-// CHECK-NEXT: (modify, none)
+// CHECK-NEXT: ([modify], [])
 sil private @callClosureThatModifiesCapture : $@convention(thin) (@inout_aliasable Int, Int) -> () {
 bb0(%0 : $*Int, %1 : $Int):
   %2 = function_ref @assignsToCapture : $@convention(thin) (@inout_aliasable Int, Int) -> ()
@@ -124,7 +228,7 @@ bb0(%0 : $*Int, %1 : $Int):
 }
 
 // CHECK-LABEL: @throwingClosureThatModifesCapture
-// CHECK-NEXT: (modify)
+// CHECK-NEXT: ([modify])
 sil private @throwingClosureThatModifesCapture : $@convention(thin) (@inout_aliasable Int) -> @error Error {
 bb0(%0 : $*Int):
   %1 = begin_access [modify] [unknown] %0 : $*Int
@@ -133,7 +237,7 @@ bb0(%0 : $*Int):
   return %2 : $()
 }
 // CHECK-LABEL: @callThrowingClosureThatModifiesCapture
-// CHECK-NEXT: (modify)
+// CHECK-NEXT: ([modify])
 sil private @callThrowingClosureThatModifiesCapture : $@convention(thin) (@inout_aliasable Int) -> () {
 bb0(%0 : $*Int):
   %1 = function_ref @throwingClosureThatModifesCapture : $@convention(thin) (@inout_aliasable Int) -> @error Error
@@ -149,7 +253,7 @@ bb2(%5: $Error):
 sil @takesNoEscapeClosure : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
 
 // CHECK-LABEL: @partialApplyPassedOffToFunction
-// CHECK-NEXT: (modify, none)
+// CHECK-NEXT: ([modify], [])
 sil private @partialApplyPassedOffToFunction : $@convention(thin) (@inout_aliasable Int, Int) -> () {
 bb0(%0 : $*Int, %1: $Int):
   %2 = function_ref @assignsToCapture : $@convention(thin) (@inout_aliasable Int, Int) -> ()
@@ -164,7 +268,7 @@ sil @takesNoEscapeClosureTakingArgument : $@convention(thin) (@owned @callee_own
 sil @takesNoEscapeClosureTakingArgumentThrowing : $@convention(thin) (@owned @callee_owned (Int) -> (@error Error)) -> ()
 
 // CHECK-LABEL: @hasThreeCapturesAndTakesArgument
-// CHECK-NEXT: (none, modify, none, read)
+// CHECK-NEXT: ([], [modify], [], [read])
 sil private @hasThreeCapturesAndTakesArgument : $@convention(thin) (Int, @inout_aliasable Int, @inout_aliasable Int, @inout_aliasable Int) -> () {
 bb0(%0 : $Int, %1: $*Int, %2: $*Int, %3: $*Int):
   %4 = begin_access [modify] [unknown] %1 : $*Int
@@ -176,7 +280,7 @@ bb0(%0 : $Int, %1: $*Int, %2: $*Int, %3: $*Int):
 }
 
 // CHECK-LABEL: @partialApplyOfClosureTakingArgumentPassedOffToFunction
-// CHECK-NEXT: (modify, none, read
+// CHECK-NEXT: ([modify], [], [read])
 sil private @partialApplyOfClosureTakingArgumentPassedOffToFunction : $@convention(thin) (@inout_aliasable Int, @inout_aliasable Int, @inout_aliasable Int) -> () {
 bb0(%0 : $*Int, %1 : $*Int, %2 : $*Int):
   %3 = function_ref @hasThreeCapturesAndTakesArgument : $@convention(thin) (Int, @inout_aliasable Int, @inout_aliasable Int, @inout_aliasable Int) -> ()
@@ -188,7 +292,7 @@ bb0(%0 : $*Int, %1 : $*Int, %2 : $*Int):
 }
 
 // CHECK-LABEL: @partialApplyFollowedByConvertFunction
-// CHECK-NEXT: (modify, none, read)
+// CHECK-NEXT: ([modify], [], [read])
 sil private @partialApplyFollowedByConvertFunction : $@convention(thin) (@inout_aliasable Int, @inout_aliasable Int, @inout_aliasable Int) -> () {
 bb0(%0 : $*Int, %1 : $*Int, %2 : $*Int):
   %3 = function_ref @hasThreeCapturesAndTakesArgument : $@convention(thin) (Int, @inout_aliasable Int, @inout_aliasable Int, @inout_aliasable Int) -> ()
@@ -205,7 +309,7 @@ sil @takesAutoClosureReturningGeneric : $@convention(thin) <T where T : Equatabl
 sil @thunkForAutoClosure : $@convention(thin) (@owned @callee_owned () -> (Int, @error Error)) -> (@out Int, @error Error)
 
 // CHECK-LABEL: @readsAndThrows
-// CHECK-NEXT: (read)
+// CHECK-NEXT: ([read])
 sil private  @readsAndThrows : $@convention(thin) (@inout_aliasable Int) -> (Int, @error Error) {
 bb0(%0 : $*Int):
   %3 = begin_access [read] [unknown] %0 : $*Int
@@ -215,7 +319,7 @@ bb0(%0 : $*Int):
 }
 
 // CHECK-LABEL: @passPartialApplyAsArgumentToPartialApply
-// CHECK-NEXT: (read)
+// CHECK-NEXT: ([read])
 sil hidden @passPartialApplyAsArgumentToPartialApply : $@convention(thin) (@inout_aliasable Int) -> () {
 bb0(%0 : $*Int):
   %2 = function_ref @takesAutoClosureReturningGeneric : $@convention(thin) <τ_0_0 where τ_0_0 : Equatable> (@owned @callee_owned () -> (@out τ_0_0, @error Error)) -> ()
@@ -229,7 +333,7 @@ bb0(%0 : $*Int):
 }
 
 // CHECK-LABEL: @reads
-// CHECK-NEXT: (read)
+// CHECK-NEXT: ([read])
 sil private  @reads : $@convention(thin) (@inout_aliasable Int) -> Int {
 bb0(%0 : $*Int):
   %3 = begin_access [read] [unknown] %0 : $*Int
@@ -239,7 +343,7 @@ bb0(%0 : $*Int):
 }
 
 // CHECK-LABEL: @convertPartialApplyAndPassToPartialApply
-// CHECK-NEXT: (read)
+// CHECK-NEXT: ([read])
 sil hidden @convertPartialApplyAndPassToPartialApply : $@convention(thin) (@inout_aliasable Int) -> () {
 bb0(%0 : $*Int):
   %2 = function_ref @takesAutoClosureReturningGeneric : $@convention(thin) <τ_0_0 where τ_0_0 : Equatable> (@owned @callee_owned () -> (@out τ_0_0, @error Error)) -> ()
@@ -254,7 +358,7 @@ bb0(%0 : $*Int):
 }
 
 // CHECK-LABEL: @selfRecursion
-// CHECK-NEXT: (modify, none)
+// CHECK-NEXT: ([modify], [])
 sil private @selfRecursion : $@convention(thin) (@inout_aliasable Int, Int) -> () {
 bb0(%0 : $*Int, %1 : $Int):
   %2 = function_ref @selfRecursion : $@convention(thin) (@inout_aliasable Int, Int) -> ()
@@ -266,7 +370,7 @@ bb0(%0 : $*Int, %1 : $Int):
 }
 
 // CHECK-LABEL: @callsMutuallyRecursive
-// CHECK-NEXT: (modify, none)
+// CHECK-NEXT: ([modify], [])
 sil private @callsMutuallyRecursive : $@convention(thin) (@inout_aliasable Int, Int) -> () {
 bb0(%0 : $*Int, %1 : $Int):
   %2 = function_ref @mutualRecursion1 : $@convention(thin) (@inout_aliasable Int, Int) -> ()
@@ -276,7 +380,7 @@ bb0(%0 : $*Int, %1 : $Int):
 }
 
 // CHECK-LABEL: @mutualRecursion1
-// CHECK-NEXT: (modify, none)
+// CHECK-NEXT: ([modify], [])
 sil private @mutualRecursion1 : $@convention(thin) (@inout_aliasable Int, Int) -> () {
 bb0(%0 : $*Int, %1 : $Int):
   %2 = function_ref @mutualRecursion2 : $@convention(thin) (@inout_aliasable Int, Int) -> ()
@@ -288,7 +392,7 @@ bb0(%0 : $*Int, %1 : $Int):
 }
 
 // CHECK-LABEL: @mutualRecursion2
-// CHECK-NEXT: (modify, none)
+// CHECK-NEXT: ([modify], [])
 sil private @mutualRecursion2 : $@convention(thin) (@inout_aliasable Int, Int) -> () {
 bb0(%0 : $*Int, %1 : $Int):
   %2 = function_ref @mutualRecursion1 : $@convention(thin) (@inout_aliasable Int, Int) -> ()
@@ -312,7 +416,7 @@ bb0(%0 : $*Int, %1 : $Int):
 //     C
 //
 // CHECK-LABEL: @multipleCycleA
-// CHECK-NEXT: (modify)
+// CHECK-NEXT: ([modify])
 sil private @multipleCycleA : $@convention(thin) (@inout_aliasable Int) -> () {
 bb0(%0 : $*Int):
   %1 = function_ref @multipleCycleB : $@convention(thin) (@inout_aliasable Int) -> ()
@@ -324,7 +428,7 @@ bb0(%0 : $*Int):
 }
 
 // CHECK-LABEL: @multipleCycleB
-// CHECK-NEXT: (modify)
+// CHECK-NEXT: ([modify])
 sil private @multipleCycleB : $@convention(thin) (@inout_aliasable Int) -> () {
 bb0(%0 : $*Int):
   %1 = function_ref @multipleCycleA : $@convention(thin) (@inout_aliasable Int) -> ()
@@ -336,7 +440,7 @@ bb0(%0 : $*Int):
 }
 
 // CHECK-LABEL: @multipleCycleC
-// CHECK-NEXT: (modify)
+// CHECK-NEXT: ([modify])
 sil private @multipleCycleC : $@convention(thin) (@inout_aliasable Int) -> () {
 bb0(%0 : $*Int):
   %1 = function_ref @multipleCycleB : $@convention(thin) (@inout_aliasable Int) -> ()

--- a/test/SILOptimizer/exclusivity_static_diagnostics.swift
+++ b/test/SILOptimizer/exclusivity_static_diagnostics.swift
@@ -237,7 +237,7 @@ func callsTakesUnsafePointerAndNoEscapeClosure() {
 }
 
 func takesThrowingAutoClosureReturningGeneric<T: Equatable>(_ : @autoclosure () throws -> T) { }
-func takesInoutAndClosure(_: inout Int, _ : () -> ()) { }
+func takesInoutAndClosure<T>(_: inout T, _ : () -> ()) { }
 
 func callsTakesThrowingAutoClosureReturningGeneric() {
   var i = 0
@@ -304,6 +304,55 @@ func inoutSamePropertyInSameTuple() {
   // expected-error@-1{{overlapping accesses to 't.name2.f1', but modification requires exclusive access; consider copying to a local variable}}
   // expected-note@-2{{conflicting access is here}}
 }
+
+// Noescape closures and separate stored structs
+
+func callsTakesInoutAndNoEscapeClosureNoWarningOnSeparateStored() {
+  var local = StructWithTwoStoredProp()
+  takesInoutAndNoEscapeClosure(&local.f1) {
+    local.f2 = 8 // no-error
+  }
+}
+
+func callsTakesInoutAndNoEscapeClosureWarningOnSameStoredProp() {
+  var local = StructWithTwoStoredProp()
+  takesInoutAndNoEscapeClosure(&local.f1) { // expected-error {{overlapping accesses to 'local.f1', but modification requires exclusive access; consider copying to a local variable}}
+    local.f1 = 8 // expected-note {{conflicting access is here}}
+  }
+}
+
+func callsTakesInoutAndNoEscapeClosureWarningOnAggregateAndStoredProp() {
+  var local = StructWithTwoStoredProp()
+  takesInoutAndNoEscapeClosure(&local) { // expected-error {{overlapping accesses to 'local', but modification requires exclusive access; consider copying to a local variable}}
+    local.f1 = 8 // expected-note {{conflicting access is here}}
+  }
+}
+
+func callsTakesInoutAndNoEscapeClosureWarningOnStoredPropAndAggregate() {
+  var local = StructWithTwoStoredProp()
+  takesInoutAndNoEscapeClosure(&local.f1) { // expected-error {{overlapping accesses to 'local.f1', but modification requires exclusive access; consider copying to a local variable}}
+    local = StructWithTwoStoredProp() // expected-note {{conflicting access is here}}
+  }
+}
+
+func callsTakesInoutAndNoEscapeClosureWarningOnStoredPropAndBothPropertyAndAggregate() {
+  var local = StructWithTwoStoredProp()
+  takesInoutAndNoEscapeClosure(&local.f1) { // expected-error {{overlapping accesses to 'local.f1', but modification requires exclusive access; consider copying to a local variable}}
+    local.f1 = 8
+    // We want the diagnostic on the access for the aggregate and not the projection.
+    local = StructWithTwoStoredProp() // expected-note {{conflicting access is here}}
+  }
+}
+
+func callsTakesInoutAndNoEscapeClosureWarningOnStoredPropAndBothAggregateAndProperty() {
+  var local = StructWithTwoStoredProp()
+  takesInoutAndNoEscapeClosure(&local.f1) { // expected-error {{overlapping accesses to 'local.f1', but modification requires exclusive access; consider copying to a local variable}}
+    // We want the diagnostic on the access for the aggregate and not the projection.
+    local = StructWithTwoStoredProp() // expected-note {{conflicting access is here}}
+    local.f1 = 8
+  }
+}
+
 
 struct MyStruct<T> {
   var prop = 7


### PR DESCRIPTION
… (#10789)

Make the static enforcement of accesses in noescape closures stored-property
sensitive. This will relax the existing enforcement so that the following is
not diagnosed:

struct MyStruct {
   var x = X()
   var y = Y()

  mutating
  func foo() {
    x.mutatesAndTakesClosure() {
      _ = y.read() // no-warning
   }
  }
}

To do this, update the access summary analysis to summarize accesses to
subpaths of a capture.

rdar://problem/32987932