### PR TITLE
TBD: includes all symbols from a full build and test

### DIFF
--- a/include/swift/SILGen/SILGenMaterializeForSet.h
+++ b/include/swift/SILGen/SILGenMaterializeForSet.h
@@ -1,0 +1,29 @@
+//===- SILGenMaterializeForSet.h - SILGen for materializeForSet -*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include <string>
+
+namespace swift {
+class ProtocolConformance;
+class FuncDecl;
+
+namespace Lowering {
+/// \brief Compute the name of the callback inside an auto-generated
+/// materializeForSet accessor.
+///
+/// FIXME: this should just be a static function inside
+/// SILGenMaterializeForSet.cpp, but currently these closures end up public,
+/// so TBDGen wants to emit them.
+std::string getMaterializeForSetCallbackName(ProtocolConformance *conformance,
+                                             FuncDecl *requirement);
+}
+}

--- a/lib/SILGen/SILGenMaterializeForSet.cpp
+++ b/lib/SILGen/SILGenMaterializeForSet.cpp
@@ -171,16 +171,15 @@
 #include "swift/SIL/SILArgument.h"
 #include "swift/SIL/SILUndef.h"
 #include "swift/SIL/TypeLowering.h"
+#include "swift/SILGen/SILGenMaterializeForSet.h"
 #include "llvm/Support/raw_ostream.h"
 #include "ASTVisitor.h"
 using namespace swift;
 using namespace Lowering;
 
-namespace {
-
-static std::string
-getMaterializeForSetCallbackName(ProtocolConformance *conformance,
-                                 FuncDecl *requirement) {
+std::string
+Lowering::getMaterializeForSetCallbackName(ProtocolConformance *conformance,
+                                           FuncDecl *requirement) {
 
   DeclContext *dc = requirement;
   ClosureExpr closure(/*patterns*/ nullptr,
@@ -208,6 +207,8 @@ getMaterializeForSetCallbackName(ProtocolConformance *conformance,
   return Mangler.mangleClosureEntity(&closure,
                                  Mangle::ASTMangler::SymbolKind::Default);
 }
+
+namespace {
 
 /// A helper class for emitting materializeForSet.
 ///

--- a/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
@@ -637,18 +637,7 @@ void FunctionSignatureTransform::createFunctionSignatureOptimizedFunction() {
   // Create the optimized function !
   SILModule &M = F->getModule();
   std::string Name = createOptimizedSILFunctionName();
-
-  // Any function that can be seen in other compilation units within this module
-  // (either because the function is from another module, or because it public
-  // or internal) needs to be considered shared, because those compilation units
-  // may choose to do exactly the same specialization. However, specializations
-  // of serialized functions are serialized too, and so behave more like the
-  // original.
-  SILLinkage linkage = F->getLinkage();
-  auto localVisibleInOtherObjects =
-      !hasPrivateVisibility(linkage) && !F->isSerialized();
-  if (isAvailableExternally(linkage) || localVisibleInOtherObjects)
-    linkage = SILLinkage::Shared;
+  SILLinkage linkage = getSpecializedLinkage(F, F->getLinkage());
 
   DEBUG(llvm::dbgs() << "  -> create specialized function " << Name << "\n");
 

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -395,14 +395,15 @@ void TBDGenVisitor::visitProtocolDecl(ProtocolDecl *PD) {
     addSymbol(LinkEntity::forProtocolDescriptor(PD));
 
 #ifndef NDEBUG
-  // There's no (currently) relevant information about members of a protocol
-  // at individual protocols, each conforming type has to handle them
-  // individually. Let's assert this fact:
+  // There's no (currently) relevant information about members of a protocol at
+  // individual protocols, each conforming type has to handle them individually
+  // (NB. anything within an active IfConfigDecls also appears outside). Let's
+  // assert this fact:
   for (auto *member : PD->getMembers()) {
     auto isExpectedKind =
         isa<TypeAliasDecl>(member) || isa<AssociatedTypeDecl>(member) ||
         isa<AbstractStorageDecl>(member) || isa<PatternBindingDecl>(member) ||
-        isa<AbstractFunctionDecl>(member);
+        isa<AbstractFunctionDecl>(member) || isa<IfConfigDecl>(member);
     assert(isExpectedKind &&
            "unexpected member of protocol during TBD generation");
   }

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -360,8 +360,7 @@ void TBDGenVisitor::visitClassDecl(ClassDecl *CD) {
       continue;
 
     auto var = dyn_cast<VarDecl>(value);
-    auto hasFieldOffset =
-        !isGeneric && var && var->hasStorage() && !var->isStatic();
+    auto hasFieldOffset = var && var->hasStorage() && !var->isStatic();
     if (hasFieldOffset) {
       // FIXME: a field only has one sort of offset, but it is moderately
       // non-trivial to compute which one. Including both is less painful than

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -110,6 +110,8 @@ public:
 
   void visitClassDecl(ClassDecl *CD);
 
+  void visitConstructorDecl(ConstructorDecl *CD);
+
   void visitExtensionDecl(ExtensionDecl *ED);
 
   void visitProtocolDecl(ProtocolDecl *PD);
@@ -369,10 +371,8 @@ void TBDGenVisitor::visitClassDecl(ClassDecl *CD) {
       addSymbol(LinkEntity::forFieldOffset(var, /*isIndirect=*/true));
     }
 
-    // The non-allocating forms of the constructors and destructors.
-    if (auto ctor = dyn_cast<ConstructorDecl>(value)) {
-      addSymbol(SILDeclRef(ctor, SILDeclRef::Kind::Initializer));
-    } else if (auto dtor = dyn_cast<DestructorDecl>(value)) {
+    // The non-allocating forms of the destructors.
+    if (auto dtor = dyn_cast<DestructorDecl>(value)) {
       // ObjC classes don't have a symbol for their destructor.
       if (!isObjC)
         addSymbol(SILDeclRef(dtor, SILDeclRef::Kind::Destroyer));
@@ -380,6 +380,16 @@ void TBDGenVisitor::visitClassDecl(ClassDecl *CD) {
   }
 
   visitNominalTypeDecl(CD);
+}
+
+void TBDGenVisitor::visitConstructorDecl(ConstructorDecl *CD) {
+  if (CD->getParent()->getAsClassOrClassExtensionContext()) {
+    // Class constructors come in two forms, allocating and non-allocating. The
+    // default ValueDecl handling gives the allocating one, so we have to
+    // manually include the non-allocating one.
+    addSymbol(SILDeclRef(CD, SILDeclRef::Kind::Initializer));
+  }
+  visitAbstractFunctionDecl(CD);
 }
 
 void TBDGenVisitor::visitExtensionDecl(ExtensionDecl *ED) {

--- a/stdlib/public/SwiftShims/DispatchOverlayShims.h
+++ b/stdlib/public/SwiftShims/DispatchOverlayShims.h
@@ -166,7 +166,7 @@ static inline void _swift_dispatch_apply_current(
 }
 
 SWIFT_DISPATCH_RETURNS_RETAINED
-__swift_shims_dispatch_data_t 
+static inline __swift_shims_dispatch_data_t
 _swift_dispatch_data_create(
     const void *buffer,
     size_t size,
@@ -177,7 +177,7 @@ _swift_dispatch_data_create(
 
 typedef unsigned int (^__swift_shims_dispatch_data_applier)(__swift_shims_dispatch_data_t, size_t, const void *, size_t);
 
-unsigned int
+static inline unsigned int
 _swift_dispatch_data_apply(
     __swift_shims_dispatch_data_t data,
     __swift_shims_dispatch_data_applier SWIFT_DISPATCH_NOESCAPE applier) {
@@ -186,19 +186,19 @@ _swift_dispatch_data_apply(
   });
 }
 
-void _swift_dispatch_source_set_event_handler(
+static inline void _swift_dispatch_source_set_event_handler(
     dispatch_source_t source,
     __swift_shims_dispatch_block_t _Nullable block) {
   dispatch_source_set_event_handler(source, block);
 }
 
-void _swift_dispatch_source_set_cancel_handler(
+static inline void _swift_dispatch_source_set_cancel_handler(
     dispatch_source_t source,
     __swift_shims_dispatch_block_t _Nullable block) {
   dispatch_source_set_cancel_handler(source, block);
 }
 
-void _swift_dispatch_source_set_registration_handler(
+static inline void _swift_dispatch_source_set_registration_handler(
     dispatch_source_t source,
     __swift_shims_dispatch_block_t _Nullable block) {
   dispatch_source_set_registration_handler(source, block);

--- a/stdlib/public/SwiftShims/NSIndexSetShims.h
+++ b/stdlib/public/SwiftShims/NSIndexSetShims.h
@@ -20,11 +20,11 @@ NS_BEGIN_DECLS
 - (NSUInteger)_indexOfRangeContainingIndex:(NSUInteger)value;
 @end
 
-extern NSUInteger __NSIndexSetRangeCount(NS_NON_BRIDGED(NSIndexSet *)self_) {
+NS_INLINE NSUInteger __NSIndexSetRangeCount(NS_NON_BRIDGED(NSIndexSet *)self_) {
     return [(NSIndexSet *)self_ rangeCount];
 }
 
-extern void __NSIndexSetRangeAtIndex(NS_NON_BRIDGED(NSIndexSet *)self_, NSUInteger rangeIndex, NSUInteger *location, NSUInteger *length) {
+NS_INLINE void __NSIndexSetRangeAtIndex(NS_NON_BRIDGED(NSIndexSet *)self_, NSUInteger rangeIndex, NSUInteger *location, NSUInteger *length) {
     NSRange result = [(NSIndexSet *)self_ rangeAtIndex:rangeIndex];
     *location = result.location;
     *length = result.length;

--- a/test/SILOptimizer/functionsigopts.sil
+++ b/test/SILOptimizer/functionsigopts.sil
@@ -1743,7 +1743,7 @@ bb0(%0 : $*T):
 // Check that we specialized this function by removing the dead argument and
 // copied everything appropriately.
 
-// CHECK-LABEL: sil [serialized] @_T023dead_arg_with_callsitesTfq4dn_n : $@convention(thin) (Builtin.NativeObject) -> () {
+// CHECK-LABEL: sil shared [serialized] @_T023dead_arg_with_callsitesTfq4dn_n : $@convention(thin) (Builtin.NativeObject) -> () {
 // CHECK: bb0([[INPUT_ARG:%[0-9]+]] : $Builtin.NativeObject):
 // CHECK: cond_br undef, bb1, bb2
 // CHECK: bb1:
@@ -1757,16 +1757,16 @@ bb0(%0 : $*T):
 // CHECK-NEXT: tuple
 // CHECK-NEXT: return
 
-// CHECK-LABEL: sil private [serialized] @_T031private_dead_arg_with_callsitesTfq4dn_n : $@convention(thin) (Builtin.NativeObject) -> () {
+// CHECK-LABEL: sil shared [serialized] @_T031private_dead_arg_with_callsitesTfq4dn_n : $@convention(thin) (Builtin.NativeObject) -> () {
 // CHECK: bb0(
 
-// CHECK-LABEL: sil [serialized] @_T037owned_to_guaranteed_with_error_resultTfq4gn_n : $@convention(thin) (@guaranteed Builtin.NativeObject, Int) -> (Int, @error Error) {
+// CHECK-LABEL: sil shared [serialized] @_T037owned_to_guaranteed_with_error_resultTfq4gn_n : $@convention(thin) (@guaranteed Builtin.NativeObject, Int) -> (Int, @error Error) {
 // CHECK-NOT: release
 // CHECK: throw
 
-// CHECK-LABEL: sil [serialized] @_T042owned_to_guaranteed_simple_singlebb_calleeTfq4g_n : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
+// CHECK-LABEL: sil shared [serialized] @_T042owned_to_guaranteed_simple_singlebb_calleeTfq4g_n : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
 
-// CHECK-LABEL: sil [serialized] @_T055owned_to_guaranteed_multibb_callee_with_release_in_exitTfq4dg_n : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
+// CHECK-LABEL: sil shared [serialized] @_T055owned_to_guaranteed_multibb_callee_with_release_in_exitTfq4dg_n : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
 // CHECK: bb0(
 // CHECK:  function_ref user
 // CHECK:  function_ref @user
@@ -1784,7 +1784,7 @@ bb0(%0 : $*T):
 // Also make sure we have change the calling convention to freestanding from
 // method because we have changed the self argument.
 
-// CHECK-LABEL: sil [serialized] @_T014array_semanticTfq4g_n : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
+// CHECK-LABEL: sil shared [serialized] @_T014array_semanticTfq4g_n : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
 // CHECK: bb0(%0 : $Builtin.NativeObject)
 // CHECK:  function_ref user
 // CHECK:  function_ref @user

--- a/test/SILOptimizer/functionsigopts_sroa.sil
+++ b/test/SILOptimizer/functionsigopts_sroa.sil
@@ -908,14 +908,14 @@ bb0(%0 : $SingleFieldLvl1):
 
 // Check Statements for generated code.
 
-// CHECK-LABEL: sil [serialized] @_T029single_level_dead_root_calleeTfq4x_n : $@convention(thin) (Builtin.Int32) -> Builtin.Int32 {
+// CHECK-LABEL: sil shared [serialized] @_T029single_level_dead_root_calleeTfq4x_n : $@convention(thin) (Builtin.Int32) -> Builtin.Int32 {
 // CHECK: bb0([[IN:%.*]] : $Builtin.Int32):
 // CHECK: [[UN:%.*]] = struct $S1 (undef : $Builtin.Int16, [[IN]] : $Builtin.Int32)
 // CHECK: struct_extract [[UN]] : $S1, #S1.f2
 // CHECK: return [[IN]] : $Builtin.Int32
 
 
-// CHECK-LABEL: sil [serialized] @_T029single_level_live_root_calleeTfq4x_n : $@convention(thin) (Builtin.Int16, Builtin.Int32) -> Builtin.Int32 {
+// CHECK-LABEL: sil shared [serialized] @_T029single_level_live_root_calleeTfq4x_n : $@convention(thin) (Builtin.Int16, Builtin.Int32) -> Builtin.Int32 {
 // CHECK: bb0([[IN1:%.*]] : $Builtin.Int16, [[IN2:%.*]] : $Builtin.Int32):
 // CHECK: [[STRUCT:%.*]] = struct $S1 ([[IN1]] : $Builtin.Int16, [[IN2]] : $Builtin.Int32)
 // CHECK: [[STRUCT2:%.*]] = struct $S1 ([[IN1]] : $Builtin.Int16, [[IN2]] : $Builtin.Int32)
@@ -925,7 +925,7 @@ bb0(%0 : $SingleFieldLvl1):
 // CHECK: return [[IN2]]
 
 
-// CHECK-LABEL: sil [serialized] @_T042multiple_level_all_root_fields_used_calleeTfq4x_n : $@convention(thin) (Builtin.Int16, Builtin.Int64) -> (Builtin.Int16, Builtin.Int64) {
+// CHECK-LABEL: sil shared [serialized] @_T042multiple_level_all_root_fields_used_calleeTfq4x_n : $@convention(thin) (Builtin.Int16, Builtin.Int64) -> (Builtin.Int16, Builtin.Int64) {
 // CHECK: bb0([[IN1:%.*]] : $Builtin.Int16, [[IN2:%.*]] : $Builtin.Int64):
 // CHECK: [[STRUCT1:%.*]] = struct $S1 ([[IN1]] : $Builtin.Int16, undef : $Builtin.Int32)
 // CHECK: [[STRUCT2:%.*]] = struct $S2 (%2 : $S1, [[IN2]] : $Builtin.Int64)
@@ -936,7 +936,7 @@ bb0(%0 : $SingleFieldLvl1):
 // CHECK: return [[OUT]]
 
 
-// CHECK-LABEL: sil [serialized] @_T053multiple_level_no_root_fields_have_direct_uses_calleeTfq4x_n : $@convention(thin) (Builtin.Int16, Builtin.Int64) -> (Builtin.Int16, Builtin.Int64) {
+// CHECK-LABEL: sil shared [serialized] @_T053multiple_level_no_root_fields_have_direct_uses_calleeTfq4x_n : $@convention(thin) (Builtin.Int16, Builtin.Int64) -> (Builtin.Int16, Builtin.Int64) {
 // CHECK: bb0([[IN1:%.*]] : $Builtin.Int16, [[IN2:%.*]] : $Builtin.Int64):
 // CHECK: [[STRUCT1:%.*]] = struct $S1 ([[IN1]] : $Builtin.Int16, undef : $Builtin.Int32)
 // CHECK: [[STRUCT2:%.*]] = struct $S2 ([[STRUCT1]] : $S1, [[IN2]] : $Builtin.Int64)
@@ -946,7 +946,7 @@ bb0(%0 : $SingleFieldLvl1):
 // CHECK: return [[OUT]]
 
 
-// CHECK-LABEL: sil [serialized] @_T043multiple_level_root_must_be_reformed_calleeTfq4x_n : $@convention(thin) (Builtin.Int16, Builtin.Int32, Builtin.Int64) -> (Builtin.Int16, Builtin.Int64) {
+// CHECK-LABEL: sil shared [serialized] @_T043multiple_level_root_must_be_reformed_calleeTfq4x_n : $@convention(thin) (Builtin.Int16, Builtin.Int32, Builtin.Int64) -> (Builtin.Int16, Builtin.Int64) {
 // CHECK: bb0([[IN1:%.*]] : $Builtin.Int16, [[IN2:%.*]] : $Builtin.Int32, [[IN3:%.*]] : $Builtin.Int64):
 // CHECK: [[STRUCT1:%.*]] = struct $S1 ([[IN1]] : $Builtin.Int16, [[IN2]] : $Builtin.Int32)
 // CHECK: [[STRUCT3:%.*]] = struct $S2 ([[STRUCT1]] : $S1, [[IN3]] : $Builtin.Int64)
@@ -960,7 +960,7 @@ bb0(%0 : $SingleFieldLvl1):
 
 
 
-// CHECK-LABEL: sil [serialized] @_T021owned_struct_1_calleeTfq4dgX_n : $@convention(thin) (@guaranteed S4, Builtin.Int16, Builtin.Int32) -> (Builtin.Int16, Builtin.Int32, Builtin.Int16, Builtin.Int32) {
+// CHECK-LABEL: sil shared [serialized] @_T021owned_struct_1_calleeTfq4dgX_n : $@convention(thin) (@guaranteed S4, Builtin.Int16, Builtin.Int32) -> (Builtin.Int16, Builtin.Int32, Builtin.Int16, Builtin.Int32) {
 // CHECK: bb0([[IN1:%.*]] : $S4, [[IN2:%.*]] : $Builtin.Int16, [[IN3:%.*]] : $Builtin.Int32):
 // CHECK: [[STRUCT1:%.*]] = struct $S1 ([[IN2]] : $Builtin.Int16, [[IN3]] : $Builtin.Int32)
 // CHECK: [[STRUCT3:%.*]] = struct $S5 ([[IN1]] : $S4, [[STRUCT1]] : $S1)
@@ -970,7 +970,7 @@ bb0(%0 : $SingleFieldLvl1):
 // CHECK: [[OUT:%.*]] = tuple ([[IN2]] : $Builtin.Int16, [[IN3]] : $Builtin.Int32, [[IN2]] : $Builtin.Int16, [[IN3]] : $Builtin.Int32)
 // CHECK: return [[OUT]] : $(Builtin.Int16, Builtin.Int32, Builtin.Int16, Builtin.Int32)
 
-// CHECK-LABEL: sil [serialized] @_T021owned_struct_2_calleeTfq4ndgXdn_n : $@convention(thin) (Builtin.Int256, @guaranteed S4, Builtin.Int16, Builtin.Int32, Builtin.Int128) -> (Builtin.Int256, Builtin.Int16, Builtin.Int32, Builtin.Int128) {
+// CHECK-LABEL: sil shared [serialized] @_T021owned_struct_2_calleeTfq4ndgXdn_n : $@convention(thin) (Builtin.Int256, @guaranteed S4, Builtin.Int16, Builtin.Int32, Builtin.Int128) -> (Builtin.Int256, Builtin.Int16, Builtin.Int32, Builtin.Int128) {
 // CHECK: bb0([[IN1:%.*]] : $Builtin.Int256, [[IN2:%.*]] : $S4, [[IN3:%.*]] : $Builtin.Int16, [[IN4:%.*]] : $Builtin.Int32, [[IN5:%.*]] : $Builtin.Int128):
 // CHECK: [[STRUCT1:%.*]] = struct $S1 ([[IN3]] : $Builtin.Int16, [[IN4]] : $Builtin.Int32)
 // CHECK: [[STRUCT3:%.*]] = struct $S5 ([[IN2]] : $S4, [[STRUCT1]] : $S1)
@@ -983,7 +983,7 @@ bb0(%0 : $SingleFieldLvl1):
 // CHECK: [[OUT]] : $(Builtin.Int256, Builtin.Int16, Builtin.Int32, Builtin.Int128)
 
 
-// CHECK-LABEL: sil [serialized] @_T018ignore_ptrs_calleeTfq4nxx_n : $@convention(thin) (@in S1, Builtin.Int16, Builtin.Int16) -> (Builtin.Int16, Builtin.Int16) {
+// CHECK-LABEL: sil shared [serialized] @_T018ignore_ptrs_calleeTfq4nxx_n : $@convention(thin) (@in S1, Builtin.Int16, Builtin.Int16) -> (Builtin.Int16, Builtin.Int16) {
 // CHECK: bb0([[IN1:%.*]] : $*S1, [[IN2:%.*]] : $Builtin.Int16, [[IN3:%.*]] : $Builtin.Int16):
 // CHECK: [[STRUCT2:%.*]] = struct $S1 ([[IN2]] : $Builtin.Int16, undef : $Builtin.Int32)
 // CHECK: [[STRUCT1:%.*]] = struct $S1 ([[IN3]] : $Builtin.Int16, undef : $Builtin.Int32)
@@ -996,7 +996,7 @@ bb0(%0 : $SingleFieldLvl1):
 // CHECK: [[OUT:%.*]] = tuple ([[IN2]] : $Builtin.Int16, [[IN3]] : $Builtin.Int16)
 // CHECK: return [[OUT]] : $(Builtin.Int16, Builtin.Int16)
 
-// CHECK-LABEL: sil [serialized] @_T030check_out_of_order_uses_calleeTfq4x_n : $@convention(thin) (Builtin.Int16, Builtin.Int32) -> () {
+// CHECK-LABEL: sil shared [serialized] @_T030check_out_of_order_uses_calleeTfq4x_n : $@convention(thin) (Builtin.Int16, Builtin.Int32) -> () {
 // CHECK: bb0([[IN1:%.*]] : $Builtin.Int16, [[IN2:%.*]] : $Builtin.Int32):
 // CHECK: [[STRUCT0:%.*]] = struct $S1 ([[IN1]] : $Builtin.Int16, [[IN2]] : $Builtin.Int32)
 // CHECK: debug_value [[STRUCT0]]
@@ -1008,6 +1008,6 @@ bb0(%0 : $SingleFieldLvl1):
 // CHECK: apply [[FN2]]([[IN1]]) : $@convention(thin) (Builtin.Int16) -> ()
 
 
-// CHECK-LABEL: sil [serialized] @_T014class_callee_1Tfq4gn_n : $@convention(thin) (@guaranteed C1, Builtin.Int32) -> Builtin.Int32 {
+// CHECK-LABEL: sil shared [serialized] @_T014class_callee_1Tfq4gn_n : $@convention(thin) (@guaranteed C1, Builtin.Int32) -> Builtin.Int32 {
 // CHECK: bb0({{%.*}} : $C1, [[IN:%.*]] : $Builtin.Int32):
 // CHECK: return [[IN]] : $Builtin.Int32


### PR DESCRIPTION
With this somewhat of a hack, every test under `-t` results in TBD files that include all the actual symbols, plus some extras.

Being forced to include the internal materializeForSet closure is very ugly, but I'm not sure of an alternative at the moment, since it is serialized and private, which means IRGen promotes it to public. (rdar://problem/32254581)