### PR TITLE
Substantially rework how SILGen handles bridging

### DIFF
--- a/include/swift/AST/ForeignInfo.h
+++ b/include/swift/AST/ForeignInfo.h
@@ -1,0 +1,34 @@
+//===--- ForeignInfo.h - Declaration import information ---------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the ForeignInfo structure, which includes
+// structural information about how a foreign API's physical type
+// maps into the Swift type system.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_FOREIGN_INFO_H
+#define SWIFT_FOREIGN_INFO_H
+
+#include "swift/AST/ForeignErrorConvention.h"
+#include "swift/AST/Decl.h"
+
+namespace swift {
+
+struct ForeignInfo {
+  ImportAsMemberStatus Self;
+  Optional<ForeignErrorConvention> Error;
+};
+
+} // end namespace swift
+
+#endif

--- a/include/swift/Basic/ArrayRefView.h
+++ b/include/swift/Basic/ArrayRefView.h
@@ -93,6 +93,10 @@ public:
   Projected front() const { return Project(Array.front()); }
   Projected back() const { return Project(Array.back()); }
 
+  ArrayRefView drop_back(unsigned count = 1) const {
+    return ArrayRefView(Array.drop_back(count));
+  }
+
   ArrayRefView slice(unsigned start) const {
     return ArrayRefView(Array.slice(start));
   }

--- a/include/swift/SIL/AbstractionPattern.h
+++ b/include/swift/SIL/AbstractionPattern.h
@@ -177,16 +177,22 @@ class AbstractionPattern {
     /// function type.  ObjCMethod is valid.  OtherData is an encoded
     /// foreign error index.
     PartialCurriedObjCMethodType,
+    /// The uncurried imported type of a C function imported as a method.
+    /// OrigType is valid and is a function type. ClangType is valid and is
+    /// a function type. OtherData is an encoded ImportAsMemberStatus.
+    CFunctionAsMethodType,
+    /// The uncurried parameter tuple type of a C function imported as a method.
+    /// OrigType is valid and is a function type. ClangType is valid and is
+    /// a tuple type. OtherData is an encoded ImportAsMemberStatus.
+    CFunctionAsMethodParamTupleType,
     /// The curried imported type of a C function imported as a method.
     /// OrigType is valid and is a function type. ClangType is valid and is
-    /// a function type. OtherData is the offset of the parameter imported as
-    /// `self`, or -1 if the function was imported as a static method.
+    /// a function type. OtherData is an encoded ImportAsMemberStatus.
     CurriedCFunctionAsMethodType,
     /// The partially-applied curried imported type of a C function imported as
     /// a method.
     /// OrigType is valid and is a function type. ClangType is valid and is
-    /// a function type. OtherData is the offset of the parameter imported as
-    /// `self`, or ~0 if the function was imported as a static method.
+    /// a function type. OtherData is an encoded ImportAsMemberStatus.
     PartialCurriedCFunctionAsMethodType,
     /// The uncurried imported type of an Objective-C method (that is,
     /// '(Input, Self) -> Result').  OrigType is valid and is a function
@@ -208,8 +214,7 @@ class AbstractionPattern {
     /// A reference to the formal method parameters of a C function that was
     /// imported as a method.
     /// OrigType is valid and is a tuple type. ClangType is valid and is
-    /// a function type. OtherData is the offset of the parameter imported as
-    /// `self`, or ~0 if the function was imported as a static method.
+    /// a function type. OtherData is an encoded ImportAsMemberStatus.
     CFunctionAsMethodFormalParamTupleType,
   };
 
@@ -287,19 +292,33 @@ class AbstractionPattern {
   }
 
   bool hasStoredClangType() const {
-    return (getKind() == Kind::ClangType ||
-            getKind() == Kind::ClangFunctionParamTupleType ||
-            getKind() == Kind::CurriedCFunctionAsMethodType ||
-            getKind() == Kind::PartialCurriedCFunctionAsMethodType ||
-            getKind() == Kind::CFunctionAsMethodFormalParamTupleType);
+    switch (getKind()) {
+    case Kind::ClangType:
+    case Kind::ClangFunctionParamTupleType:
+    case Kind::CFunctionAsMethodType:
+    case Kind::CFunctionAsMethodParamTupleType:
+    case Kind::CurriedCFunctionAsMethodType:
+    case Kind::PartialCurriedCFunctionAsMethodType:
+    case Kind::CFunctionAsMethodFormalParamTupleType:
+      return true;
+
+    default:
+      return false;
+    }
   }
 
   bool hasStoredObjCMethod() const {
-    return (getKind() == Kind::CurriedObjCMethodType ||
-            getKind() == Kind::PartialCurriedObjCMethodType ||
-            getKind() == Kind::ObjCMethodType ||
-            getKind() == Kind::ObjCMethodParamTupleType ||
-            getKind() == Kind::ObjCMethodFormalParamTupleType);
+    switch (getKind()) {
+    case Kind::CurriedObjCMethodType:
+    case Kind::PartialCurriedObjCMethodType:
+    case Kind::ObjCMethodType:
+    case Kind::ObjCMethodParamTupleType:
+    case Kind::ObjCMethodFormalParamTupleType:
+      return true;
+
+    default:
+      return false;
+    }
   }
 
   bool hasStoredForeignErrorInfo() const {
@@ -307,9 +326,17 @@ class AbstractionPattern {
   }
 
   bool hasImportAsMemberStatus() const {
-    return getKind() == Kind::CurriedCFunctionAsMethodType ||
-           getKind() == Kind::PartialCurriedCFunctionAsMethodType ||
-           getKind() == Kind::CFunctionAsMethodFormalParamTupleType;
+    switch (getKind()) {
+    case Kind::CFunctionAsMethodType:
+    case Kind::CFunctionAsMethodParamTupleType:
+    case Kind::CurriedCFunctionAsMethodType:
+    case Kind::PartialCurriedCFunctionAsMethodType:
+    case Kind::CFunctionAsMethodFormalParamTupleType:
+      return true;
+
+    default:
+      return false;
+    }
   }
   
   void initSwiftType(CanGenericSignature signature, CanType origType,
@@ -416,8 +443,35 @@ public:
   getCurriedObjCMethod(CanType origType, const clang::ObjCMethodDecl *method,
                        const Optional<ForeignErrorConvention> &foreignError);
 
+  /// Return an abstraction pattern for the uncurried type of a C function
+  /// imported as a method.
+  ///
+  /// For example, if the original function is:
+  ///   void CCRefrigatorSetTemperature(CCRefrigeratorRef fridge,
+  ///                                   CCRefrigeratorCompartment compartment,
+  ///                                   CCTemperature temperature);
+  /// then the uncurried type is:
+  ///   ((CCRefrigeratorComponent, CCTemperature), CCRefrigerator) -> ()
+  static AbstractionPattern
+  getCFunctionAsMethod(CanType origType, const clang::Type *clangType,
+                       ImportAsMemberStatus memberStatus) {
+    assert(isa<AnyFunctionType>(origType));
+    AbstractionPattern pattern;
+    pattern.initCFunctionAsMethod(nullptr, origType, clangType,
+                                  Kind::CFunctionAsMethodType,
+                                  memberStatus);
+    return pattern;
+  }
+
   /// Return an abstraction pattern for the curried type of a
   /// C function imported as a method.
+  ///
+  /// For example, if the original function is:
+  ///   void CCRefrigatorSetTemperature(CCRefrigeratorRef fridge,
+  ///                                   CCRefrigeratorCompartment compartment,
+  ///                                   CCTemperature temperature);
+  /// then the curried type is:
+  ///   (CCRefrigerator) -> (CCRefrigeratorCompartment, CCTemperature) -> ()
   static AbstractionPattern
   getCurriedCFunctionAsMethod(CanType origType,
                               const AbstractFunctionDecl *function);
@@ -481,6 +535,15 @@ private:
     return pattern;
   }
 
+  /// Return an abstraction pattern for the partially-applied curried
+  /// type of a C function imported as a method.
+  ///
+  /// For example, if the original function is:
+  ///   CCRefrigatorSetTemperature(CCRefrigeratorRef, CCTemperature)
+  /// then the curried type is:
+  ///   (CCRefrigerator) -> (CCTemperature) -> ()
+  /// and the partially-applied curried type is:
+  ///   (CCTemperature) -> ()
   static AbstractionPattern
   getPartialCurriedCFunctionAsMethod(CanGenericSignature signature,
                                      CanType origType,
@@ -524,6 +587,29 @@ private:
     AbstractionPattern pattern;
     pattern.initObjCMethod(signature, origType, method,
                            Kind::ObjCMethodParamTupleType, errorInfo);
+    return pattern;
+  }
+
+  /// Return an abstraction pattern for a tuple representing the
+  /// uncurried parameter clauses of a C function imported as a method.
+  ///
+  /// For example, if the original function is:
+  ///   void CCRefrigatorSetTemperature(CCRefrigeratorRef fridge,
+  ///                                   CCRefrigeratorCompartment compartment,
+  ///                                   CCTemperature temperature);
+  /// then the parameter tuple type is:
+  ///   ((CCRefrigeratorComponent, CCTemperature), CCRefrigerator)
+  static AbstractionPattern
+  getCFunctionAsMethodParamTuple(CanGenericSignature signature,
+                                 CanType origType,
+                                 const clang::Type *type,
+                                 ImportAsMemberStatus memberStatus) {
+    assert(isa<TupleType>(origType));
+    assert(cast<TupleType>(origType)->getNumElements() == 2);
+    AbstractionPattern pattern;
+    pattern.initCFunctionAsMethod(signature, origType, type,
+                                  Kind::CFunctionAsMethodParamTupleType,
+                                  memberStatus);
     return pattern;
   }
 
@@ -669,12 +755,54 @@ public:
     case Kind::ObjCMethodType:
     case Kind::ObjCMethodParamTupleType:
     case Kind::ObjCMethodFormalParamTupleType:
+    case Kind::CFunctionAsMethodType:
+    case Kind::CFunctionAsMethodParamTupleType:
     case Kind::CurriedCFunctionAsMethodType:
     case Kind::PartialCurriedCFunctionAsMethodType:
     case Kind::CFunctionAsMethodFormalParamTupleType:
     case Kind::Type:
     case Kind::Discard:
       return OrigType;
+    }
+    llvm_unreachable("bad kind");
+  }
+
+  /// Do the two given types have the same basic type structure as
+  /// far as abstraction patterns are concerned?
+  ///
+  /// Type structure means tuples, functions, and optionals should
+  /// appear in the same positions.
+  static bool hasSameBasicTypeStructure(CanType l, CanType r);
+
+  /// Rewrite the type of this abstraction pattern without otherwise
+  /// changing its structure.  It is only valid to do this on a pattern
+  /// that already stores a type, and the new type must have the same
+  /// basic type structure as the old one.
+  void rewriteType(CanGenericSignature signature, CanType type) {
+    switch (getKind()) {
+    case Kind::Invalid:
+    case Kind::Opaque:
+    case Kind::Tuple:
+      llvm_unreachable("type cannot be replaced on pattern without type");
+    case Kind::ClangType:
+    case Kind::ClangFunctionParamTupleType:
+    case Kind::CurriedObjCMethodType:
+    case Kind::PartialCurriedObjCMethodType:
+    case Kind::ObjCMethodType:
+    case Kind::ObjCMethodParamTupleType:
+    case Kind::ObjCMethodFormalParamTupleType:
+    case Kind::CFunctionAsMethodType:
+    case Kind::CFunctionAsMethodParamTupleType:
+    case Kind::CurriedCFunctionAsMethodType:
+    case Kind::PartialCurriedCFunctionAsMethodType:
+    case Kind::CFunctionAsMethodFormalParamTupleType:
+    case Kind::Type:
+    case Kind::Discard:
+      assert(signature || !type->hasTypeParameter());
+      assert(hasSameBasicTypeStructure(OrigType, type));
+      GenericSig = (type->hasTypeParameter() ? signature : nullptr);
+      OrigType = type;
+      return;
     }
     llvm_unreachable("bad kind");
   }
@@ -700,6 +828,8 @@ public:
     case Kind::ObjCMethodType:
     case Kind::ObjCMethodParamTupleType:
     case Kind::ObjCMethodFormalParamTupleType:
+    case Kind::CFunctionAsMethodType:
+    case Kind::CFunctionAsMethodParamTupleType:
     case Kind::CurriedCFunctionAsMethodType:
     case Kind::PartialCurriedCFunctionAsMethodType:
     case Kind::CFunctionAsMethodFormalParamTupleType:
@@ -755,6 +885,8 @@ public:
     case Kind::ClangType:
     case Kind::Type:
     case Kind::Discard:
+    case Kind::CFunctionAsMethodType:
+    case Kind::CFunctionAsMethodParamTupleType:
     case Kind::CurriedCFunctionAsMethodType:
     case Kind::PartialCurriedCFunctionAsMethodType:
     case Kind::CFunctionAsMethodFormalParamTupleType:
@@ -786,6 +918,8 @@ public:
     case Kind::ObjCMethodType:
     case Kind::ObjCMethodParamTupleType:
     case Kind::ObjCMethodFormalParamTupleType:
+    case Kind::CFunctionAsMethodType:
+    case Kind::CFunctionAsMethodParamTupleType:
     case Kind::CurriedCFunctionAsMethodType:
     case Kind::PartialCurriedCFunctionAsMethodType:
     case Kind::CFunctionAsMethodFormalParamTupleType:
@@ -814,6 +948,8 @@ public:
     case Kind::ObjCMethodType:
     case Kind::ObjCMethodParamTupleType:
     case Kind::ObjCMethodFormalParamTupleType:
+    case Kind::CFunctionAsMethodType:
+    case Kind::CFunctionAsMethodParamTupleType:
     case Kind::CurriedCFunctionAsMethodType:
     case Kind::PartialCurriedCFunctionAsMethodType:
     case Kind::CFunctionAsMethodFormalParamTupleType:
@@ -839,11 +975,13 @@ public:
     case Kind::Opaque:
     case Kind::PartialCurriedObjCMethodType:
     case Kind::CurriedObjCMethodType:
+    case Kind::CFunctionAsMethodType:
     case Kind::CurriedCFunctionAsMethodType:
     case Kind::PartialCurriedCFunctionAsMethodType:
     case Kind::ObjCMethodType:
       return false;
     case Kind::Tuple:
+    case Kind::CFunctionAsMethodParamTupleType:
     case Kind::ClangFunctionParamTupleType:
     case Kind::ObjCMethodParamTupleType:
     case Kind::ObjCMethodFormalParamTupleType:
@@ -864,6 +1002,7 @@ public:
     case Kind::Opaque:
     case Kind::PartialCurriedObjCMethodType:
     case Kind::CurriedObjCMethodType:
+    case Kind::CFunctionAsMethodType:
     case Kind::CurriedCFunctionAsMethodType:
     case Kind::PartialCurriedCFunctionAsMethodType:
     case Kind::ObjCMethodType:
@@ -874,6 +1013,7 @@ public:
     case Kind::Discard:
     case Kind::ClangType:
     case Kind::ClangFunctionParamTupleType:
+    case Kind::CFunctionAsMethodParamTupleType:
     case Kind::ObjCMethodParamTupleType:
     case Kind::ObjCMethodFormalParamTupleType:
     case Kind::CFunctionAsMethodFormalParamTupleType:

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -426,6 +426,12 @@ public:
                                                         Ty.getSwiftRValueType());
   }
 
+  /// Look through reference-storage types on this type.
+  SILType getReferenceStorageReferentType() const {
+    return SILType(getSwiftRValueType().getReferenceStorageReferent(),
+                   getCategory());
+  }
+
   /// Transform the function type SILType by replacing all of its interface
   /// generic args with the appropriate item from the substitution.
   ///
@@ -561,10 +567,9 @@ NON_SIL_TYPE(LValue)
 #undef NON_SIL_TYPE
 
 CanSILFunctionType getNativeSILFunctionType(SILModule &M,
-                        Lowering::AbstractionPattern orig,
-                        CanAnyFunctionType substInterface,
-                        Optional<SILDeclRef> constant = None,
-                        SILDeclRef::Kind kind = SILDeclRef::Kind::Func);
+                        Lowering::AbstractionPattern origType,
+                        CanAnyFunctionType substType,
+                        Optional<SILDeclRef> constant = None);
 
 inline llvm::raw_ostream &operator<<(llvm::raw_ostream &OS, SILType T) {
   T.print(OS);

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1983,7 +1983,17 @@ public:
   }
   void visitTupleShuffleExpr(TupleShuffleExpr *E) {
     printCommon(E, "tuple_shuffle_expr");
-    if (E->isSourceScalar()) OS << " source_is_scalar";
+    switch (E->getTypeImpact()) {
+    case TupleShuffleExpr::ScalarToTuple:
+      OS << " scalar_to_tuple";
+      break;
+    case TupleShuffleExpr::TupleToTuple:
+      OS << " tuple_to_tuple";
+      break;
+    case TupleShuffleExpr::TupleToScalar:
+      OS << " tuple_to_scalar";
+      break;
+    }
     OS << " elements=[";
     for (unsigned i = 0, e = E->getElementMapping().size(); i != e; ++i) {
       if (i) OS << ", ";

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -1788,11 +1788,12 @@ public:
 
       /// Retrieve the ith element type from the resulting tuple type.
       auto getOuterElementType = [&](unsigned i) -> Type {
-        if (!TT) {
+        if (E->isResultScalar()) {
+          assert(i == 0);
           return E->getType()->getWithoutParens();
+        } else {
+          return TT->getElementType(i);
         }
-
-        return TT->getElementType(i);
       };
 
       Type varargsType;

--- a/lib/IDE/TypeReconstruction.cpp
+++ b/lib/IDE/TypeReconstruction.cpp
@@ -695,7 +695,8 @@ static void VisitNodeAddressor(
   // and they bear no connection to their original variable at the interface
   // level
   CanFunctionType swift_can_func_type =
-    CanFunctionType::get({}, ast->TheRawPointerType,
+    CanFunctionType::get(AnyFunctionType::CanParamArrayRef({}),
+                         ast->TheRawPointerType,
                          AnyFunctionType::ExtInfo());
   result._types.push_back(swift_can_func_type.getPointer());
 }

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -1693,7 +1693,8 @@ namespace {
         // All function types look like () -> ().
         // FIXME: It'd be nice not to have to call through the runtime here.
         return IGF.emitTypeMetadataRef(
-                 CanFunctionType::get({ }, C.TheEmptyTupleType,
+                 CanFunctionType::get(AnyFunctionType::CanParamArrayRef({ }),
+                                      C.TheEmptyTupleType,
                                       AnyFunctionType::ExtInfo()));
       case SILFunctionType::Representation::Block:
         // All block types look like Builtin.UnknownObject.
@@ -1877,7 +1878,8 @@ namespace {
       case SILFunctionType::Representation::Thick:
         // All function types look like () -> ().
         return emitFromValueWitnessTable(
-                 CanFunctionType::get({ }, C.TheEmptyTupleType,
+                 CanFunctionType::get(AnyFunctionType::CanParamArrayRef({}),
+                                      C.TheEmptyTupleType,
                                       AnyFunctionType::ExtInfo()));
       case SILFunctionType::Representation::Block:
         // All block types look like Builtin.UnknownObject.

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -928,7 +928,7 @@ void IRGenModule::emitBuiltinReflectionMetadata() {
     // extra inhabitants as these. But maybe it's best not to codify
     // that in the ABI anyway.
     CanType thinFunction = CanFunctionType::get(
-      { }, Context.TheEmptyTupleType,
+      AnyFunctionType::CanParamArrayRef({}), Context.TheEmptyTupleType,
       AnyFunctionType::ExtInfo().withRepresentation(
           FunctionTypeRepresentation::Thin));
     BuiltinTypes.insert(thinFunction);

--- a/lib/SIL/AbstractionPattern.cpp
+++ b/lib/SIL/AbstractionPattern.cpp
@@ -154,6 +154,8 @@ AbstractionPattern::getOptional(AbstractionPattern object,
   case Kind::Tuple:
   case Kind::PartialCurriedObjCMethodType:
   case Kind::CurriedObjCMethodType:
+  case Kind::CFunctionAsMethodType:
+  case Kind::CFunctionAsMethodParamTupleType:
   case Kind::PartialCurriedCFunctionAsMethodType:
   case Kind::CurriedCFunctionAsMethodType:
   case Kind::ObjCMethodType:
@@ -189,6 +191,7 @@ bool AbstractionPattern::matchesTuple(CanTupleType substType) {
   case Kind::CurriedObjCMethodType:
   case Kind::PartialCurriedCFunctionAsMethodType:
   case Kind::CurriedCFunctionAsMethodType:
+  case Kind::CFunctionAsMethodType:
   case Kind::ObjCMethodType:
     return false;
   case Kind::Opaque:
@@ -197,6 +200,7 @@ bool AbstractionPattern::matchesTuple(CanTupleType substType) {
     return getNumTupleElements_Stored() == substType->getNumElements();
   case Kind::ObjCMethodParamTupleType:
   case Kind::ObjCMethodFormalParamTupleType:
+  case Kind::CFunctionAsMethodParamTupleType:
   case Kind::CFunctionAsMethodFormalParamTupleType:
   case Kind::ClangFunctionParamTupleType:
   case Kind::ClangType:
@@ -261,6 +265,7 @@ AbstractionPattern::getTupleElementType(unsigned index) const {
   case Kind::CurriedObjCMethodType:
   case Kind::PartialCurriedCFunctionAsMethodType:
   case Kind::CurriedCFunctionAsMethodType:
+  case Kind::CFunctionAsMethodType:
   case Kind::ObjCMethodType:
     llvm_unreachable("function types are not tuples");
   case Kind::Opaque:
@@ -325,6 +330,17 @@ AbstractionPattern::getTupleElementType(unsigned index) const {
     return AbstractionPattern(getGenericSignature(),
                               getCanTupleElementType(getType(), index),
                      getClangFunctionParameterType(getClangType(), clangIndex));
+  }
+  case Kind::CFunctionAsMethodParamTupleType: {
+    auto tupleType = cast<TupleType>(getType());
+    assert(tupleType->getNumElements() == 2);
+    assert(index < 2);
+
+    auto swiftEltType = tupleType.getElementType(index);
+    if (index != 0) {
+      return getCFunctionAsMethodSelfPattern(swiftEltType);
+    }
+    return getCFunctionAsMethodFormalParamPattern(swiftEltType);
   }
   case Kind::ObjCMethodParamTupleType: {
     auto tupleType = cast<TupleType>(getType());
@@ -483,6 +499,14 @@ AbstractionPattern AbstractionPattern::transformType(
   case Kind::CurriedCFunctionAsMethodType:
     return getCurriedCFunctionAsMethod(transform(getType()), getClangType(),
                                        getImportAsMemberStatus());
+  case Kind::CFunctionAsMethodType:
+    return getCFunctionAsMethod(transform(getType()), getClangType(),
+                                getImportAsMemberStatus());
+  case Kind::CFunctionAsMethodParamTupleType:
+    return getCFunctionAsMethodParamTuple(getGenericSignature(),
+                                          transform(getType()),
+                                          getClangType(),
+                                          getImportAsMemberStatus());
   case Kind::ObjCMethodType:
     return getObjCMethod(transform(getType()), getObjCMethod(),
                          getEncodedForeignErrorInfo());
@@ -553,6 +577,7 @@ AbstractionPattern AbstractionPattern::dropLastTupleElement() const {
     return getOpaque();
   case Kind::CurriedObjCMethodType:
   case Kind::PartialCurriedObjCMethodType:
+  case Kind::CFunctionAsMethodType:
   case Kind::CurriedCFunctionAsMethodType:
   case Kind::PartialCurriedCFunctionAsMethodType:
   case Kind::ObjCMethodType:
@@ -561,6 +586,7 @@ AbstractionPattern AbstractionPattern::dropLastTupleElement() const {
     llvm_unreachable("dropping last element of imported array?");
   case Kind::ObjCMethodParamTupleType:
   case Kind::ObjCMethodFormalParamTupleType:
+  case Kind::CFunctionAsMethodParamTupleType:
   case Kind::CFunctionAsMethodFormalParamTupleType:
     llvm_unreachable("operation is not needed on method abstraction patterns");
   case Kind::Type:
@@ -596,6 +622,8 @@ AbstractionPattern AbstractionPattern::getWithoutSpecifierType() const {
   case Kind::ClangFunctionParamTupleType:
   case Kind::PartialCurriedObjCMethodType:
   case Kind::CurriedObjCMethodType:
+  case Kind::CFunctionAsMethodType:
+  case Kind::CFunctionAsMethodParamTupleType:
   case Kind::CurriedCFunctionAsMethodType:
   case Kind::PartialCurriedCFunctionAsMethodType:
   case Kind::ObjCMethodType:
@@ -630,6 +658,7 @@ AbstractionPattern AbstractionPattern::getFunctionResultType() const {
   case Kind::ClangFunctionParamTupleType:
   case Kind::ObjCMethodParamTupleType:
   case Kind::ObjCMethodFormalParamTupleType:
+  case Kind::CFunctionAsMethodParamTupleType:
   case Kind::CFunctionAsMethodFormalParamTupleType:
   case Kind::Tuple:
     llvm_unreachable("abstraction pattern for tuple cannot be function");
@@ -643,6 +672,7 @@ AbstractionPattern AbstractionPattern::getFunctionResultType() const {
   case Kind::Discard:
     llvm_unreachable("don't need to discard function abstractions yet");
   case Kind::ClangType:
+  case Kind::CFunctionAsMethodType:
   case Kind::PartialCurriedCFunctionAsMethodType: {
     auto clangFunctionType = getClangFunctionType(getClangType());
     return AbstractionPattern(getGenericSignatureForFunctionComponent(),
@@ -677,6 +707,7 @@ AbstractionPattern AbstractionPattern::getFunctionInputType() const {
   case Kind::ClangFunctionParamTupleType:
   case Kind::ObjCMethodParamTupleType:
   case Kind::ObjCMethodFormalParamTupleType:
+  case Kind::CFunctionAsMethodParamTupleType:
   case Kind::CFunctionAsMethodFormalParamTupleType:
   case Kind::Tuple:
     llvm_unreachable("abstraction pattern for tuple cannot be function");
@@ -714,6 +745,15 @@ AbstractionPattern AbstractionPattern::getFunctionInputType() const {
   case Kind::PartialCurriedObjCMethodType:
     return getObjCMethodFormalParamPattern(
                                 cast<AnyFunctionType>(getType()).getInput());
+  case Kind::CFunctionAsMethodType: {
+    // Preserve the Clang type in the resulting abstraction pattern.
+    auto inputType = cast<AnyFunctionType>(getType()).getInput();
+    assert(isa<TupleType>(inputType)); // always at least ((), SelfType)
+    return getCFunctionAsMethodParamTuple(
+                                getGenericSignatureForFunctionComponent(),
+                                inputType, getClangType(),
+                                getImportAsMemberStatus());
+  }
   case Kind::ObjCMethodType: {
     // Preserve the Clang type in the resulting abstraction pattern.
     auto inputType = cast<AnyFunctionType>(getType()).getInput();
@@ -742,6 +782,8 @@ AbstractionPattern AbstractionPattern::getAnyOptionalObjectType() const {
   case Kind::ObjCMethodType:
   case Kind::CurriedObjCMethodType:
   case Kind::PartialCurriedObjCMethodType:
+  case Kind::CFunctionAsMethodType:
+  case Kind::CFunctionAsMethodParamTupleType:
   case Kind::CurriedCFunctionAsMethodType:
   case Kind::PartialCurriedCFunctionAsMethodType:
   case Kind::Tuple:
@@ -783,6 +825,8 @@ AbstractionPattern AbstractionPattern::getReferenceStorageReferentType() const {
   case Kind::PartialCurriedObjCMethodType:
   case Kind::CurriedCFunctionAsMethodType:
   case Kind::PartialCurriedCFunctionAsMethodType:
+  case Kind::CFunctionAsMethodType:
+  case Kind::CFunctionAsMethodParamTupleType:
   case Kind::Tuple:
   case Kind::CFunctionAsMethodFormalParamTupleType:
     return *this;
@@ -839,6 +883,8 @@ void AbstractionPattern::print(raw_ostream &out) const {
   case Kind::ClangFunctionParamTupleType:
   case Kind::CurriedCFunctionAsMethodType:
   case Kind::PartialCurriedCFunctionAsMethodType:
+  case Kind::CFunctionAsMethodType:
+  case Kind::CFunctionAsMethodParamTupleType:
   case Kind::CFunctionAsMethodFormalParamTupleType:
     out << (getKind() == Kind::ClangType
               ? "AP::ClangType(" :
@@ -846,6 +892,10 @@ void AbstractionPattern::print(raw_ostream &out) const {
               ? "AP::ClangFunctionParamTupleType(" :
             getKind() == Kind::CurriedCFunctionAsMethodType
               ? "AP::CurriedCFunctionAsMethodType(" :
+            getKind() == Kind::CFunctionAsMethodType
+              ? "AP::CFunctionAsMethodType(" :
+            getKind() == Kind::CFunctionAsMethodParamTupleType
+              ? "AP::CFunctionAsMethodParamTupleType(" :
             getKind() == Kind::PartialCurriedCFunctionAsMethodType
               ? "AP::PartialCurriedCFunctionAsMethodType(" :
             getKind() == Kind::CFunctionAsMethodFormalParamTupleType
@@ -899,3 +949,49 @@ void AbstractionPattern::print(raw_ostream &out) const {
   llvm_unreachable("bad kind");
 }
 
+bool AbstractionPattern::hasSameBasicTypeStructure(CanType l, CanType r) {
+  if (l == r) return true;
+
+  // Tuples must match.
+  auto lTuple = dyn_cast<TupleType>(l);
+  auto rTuple = dyn_cast<TupleType>(r);
+  if (lTuple && rTuple) {
+    auto lElts = lTuple.getElementTypes();
+    auto rElts = rTuple.getElementTypes();
+    if (lElts.size() != rElts.size())
+      return false;
+    for (auto i : indices(lElts)) {
+      if (!hasSameBasicTypeStructure(lElts[i], rElts[i]))
+        return false;
+    }
+    return true;
+  } else if (lTuple || rTuple) {
+    return false;
+  }
+
+  // Functions must match.
+  auto lFunction = dyn_cast<AnyFunctionType>(l);
+  auto rFunction = dyn_cast<AnyFunctionType>(r);
+  if (lFunction && rFunction) {
+    return hasSameBasicTypeStructure(lFunction.getInput(),
+                                     rFunction.getInput())
+        && hasSameBasicTypeStructure(lFunction.getResult(),
+                                     rFunction.getResult());
+  } else if (lFunction || rFunction) {
+    return false;
+  }
+
+  // Optionals must match, sortof.
+  auto lObject = l.getAnyOptionalObjectType();
+  auto rObject = r.getAnyOptionalObjectType();
+  if (lObject && rObject) {
+    return hasSameBasicTypeStructure(lObject, rObject);
+  } else if (lObject || rObject) {
+    // Allow optionality mis-matches, but require the underlying types to match.
+    return hasSameBasicTypeStructure(lObject ? lObject : l,
+                                     rObject ? rObject : r);
+  }
+
+  // Otherwise, the structure is similar enough.
+  return true;
+}

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -1556,32 +1556,6 @@ TypeConverter::getTypeLowering(AbstractionPattern origType,
   return lowering;
 }
 
-CanSILFunctionType TypeConverter::getSILFunctionType(
-    AbstractionPattern origType,
-    CanFunctionType substFnType,
-    unsigned uncurryLevel) {
-  // First, lower at the AST level by uncurrying and substituting
-  // bridged types.
-  auto substLoweredType =
-    getLoweredASTFunctionType(substFnType, 0, None);
-
-  AbstractionPattern origLoweredType = [&] {
-    if (origType.isExactType(substFnType)) {
-      return AbstractionPattern(origType.getGenericSignature(),
-                                substLoweredType);
-    } else if (origType.isTypeParameter()) {
-      return origType;
-    } else {
-      auto origFnType = cast<AnyFunctionType>(origType.getType());
-      return AbstractionPattern(origType.getGenericSignature(),
-                                getLoweredASTFunctionType(origFnType,
-                                                          0, None));
-    }
-  }();
-
-  return getNativeSILFunctionType(M, origLoweredType, substLoweredType);
-}
-
 CanType TypeConverter::getLoweredRValueType(AbstractionPattern origType,
                                             CanType substType) {
   assert(!substType->hasError() &&
@@ -1592,8 +1566,11 @@ CanType TypeConverter::getLoweredRValueType(AbstractionPattern origType,
   //   - types are turned into their unbridged equivalents, depending
   //     on the abstract CC
   //   - ownership conventions are deduced
-  if (auto substFnType = dyn_cast<FunctionType>(substType))
-    return getSILFunctionType(origType, substFnType, /*uncurryLevel=*/0);
+  if (auto substFnType = dyn_cast<AnyFunctionType>(substType)) {
+    auto bridgedFnType = getBridgedFunctionType(origType, substFnType,
+                                                substFnType->getExtInfo());
+    return getNativeSILFunctionType(M, origType, bridgedFnType);
+  }
 
   // Ignore dynamic self types.
   if (auto selfType = dyn_cast<DynamicSelfType>(substType)) {
@@ -1744,18 +1721,9 @@ static CanAnyFunctionType getDefaultArgGeneratorInterfaceType(
 
   // Get the generic signature from the surrounding context.
   auto funcInfo = TC.getConstantInfo(SILDeclRef(AFD));
-  CanGenericSignature sig;
-  if (auto genTy = dyn_cast<GenericFunctionType>(funcInfo.FormalInterfaceType))
-    sig = genTy.getGenericSignature();
-
-  if (sig) {
-    return CanGenericFunctionType::get(sig,
-                                       TupleType::getEmpty(TC.Context),
-                                       canResultTy,
-                                       AnyFunctionType::ExtInfo());
-  }
-  
-  return CanFunctionType::get(TupleType::getEmpty(TC.Context), canResultTy);
+  return CanAnyFunctionType::get(funcInfo.FormalType.getOptGenericSignature(),
+                                 TupleType::getEmpty(TC.Context),
+                                 canResultTy);
 }
 
 /// Get the type of a stored property initializer, () -> T.
@@ -1768,13 +1736,8 @@ static CanAnyFunctionType getStoredPropertyInitializerInterfaceType(
           ->getCanonicalType();
   auto sig = TC.getEffectiveGenericSignature(DC);
 
-  if (sig)
-    return CanGenericFunctionType::get(sig,
-                                       TupleType::getEmpty(TC.Context),
-                                       resultTy,
-                                       GenericFunctionType::ExtInfo());
-  
-  return CanFunctionType::get(TupleType::getEmpty(TC.Context), resultTy);
+  return CanAnyFunctionType::get(sig, TupleType::getEmpty(TC.Context),
+                                 resultTy);
 }
 
 /// Get the type of a destructor function.
@@ -1804,9 +1767,7 @@ static CanAnyFunctionType getDestructorInterfaceType(TypeConverter &TC,
                       : C.TheNativeObjectType);
 
   auto sig = TC.getEffectiveGenericSignature(dd);
-  if (sig)
-    return CanGenericFunctionType::get(sig, classType, resultTy, extInfo);
-  return CanFunctionType::get(classType, resultTy, extInfo);
+  return CanAnyFunctionType::get(sig, classType, resultTy, extInfo);
 }
 
 /// Retrieve the type of the ivar initializer or destroyer method for
@@ -1829,11 +1790,7 @@ static CanAnyFunctionType getIVarInitDestroyerInterfaceType(TypeConverter &TC,
 
   resultType = CanFunctionType::get(emptyTupleTy, resultType, extInfo);
   auto sig = TC.getEffectiveGenericSignature(cd);
-  if (sig)
-    return CanGenericFunctionType::get(sig,
-                                       classType, resultType,
-                                       extInfo);
-  return CanFunctionType::get(classType, resultType, extInfo);
+  return CanAnyFunctionType::get(sig, classType, resultType, extInfo);
 }
 
 GenericEnvironment *
@@ -1884,14 +1841,8 @@ TypeConverter::getFunctionInterfaceTypeWithCaptures(CanAnyFunctionType funcType,
   auto innerExtInfo = AnyFunctionType::ExtInfo(FunctionType::Representation::Thin,
                                                funcType->throws());
 
-  if (!genericSig)
-    return CanFunctionType::get(funcType->getParams(), funcType.getResult(),
-                                innerExtInfo);
-
-  return CanGenericFunctionType::get(genericSig,
-                                     funcType->getParams(),
-                                     funcType.getResult(),
-                                     innerExtInfo);
+  return CanAnyFunctionType::get(genericSig, funcType.getParams(),
+                                 funcType.getResult(), innerExtInfo);
 }
 
 CanAnyFunctionType TypeConverter::makeConstantInterfaceType(SILDeclRef c) {

--- a/lib/SILGen/ArgumentSource.h
+++ b/lib/SILGen/ArgumentSource.h
@@ -27,6 +27,7 @@
 
 namespace swift {
 namespace Lowering {
+class Conversion;
 
 /// A means of generating an argument.
 ///
@@ -264,6 +265,9 @@ public:
   ManagedValue getAsSingleValue(SILGenFunction &SGF,
                                 AbstractionPattern origFormalType,
                                 SGFContext C = SGFContext()) &&;
+
+  ManagedValue getConverted(SILGenFunction &SGF, const Conversion &conversion,
+                            SGFContext C = SGFContext()) &&;
 
   void forwardInto(SILGenFunction &SGF, Initialization *dest) &&;
   void forwardInto(SILGenFunction &SGF, AbstractionPattern origFormalType,

--- a/lib/SILGen/Conversion.h
+++ b/lib/SILGen/Conversion.h
@@ -1,0 +1,278 @@
+//===--- Conversion.h - Types for value conversion --------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Defines the Conversion class as well as ConvertingInitialization.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_LOWERING_CONVERSION_H
+#define SWIFT_LOWERING_CONVERSION_H
+
+#include "swift/Basic/ExternalUnion.h"
+#include "Initialization.h"
+#include "SGFContext.h"
+
+namespace swift {
+namespace Lowering {
+
+/// An abstraction representing certain kinds of conversion that SILGen can
+/// do automatically in various situations.
+class Conversion {
+public:
+  enum KindTy {
+    /// An implicit bridging conversion to a foreign type.
+    BridgeToObjC,
+
+    /// An implicit bridging conversion from a foreign type.
+    BridgeFromObjC,
+
+    /// An implicit bridging conversion for a function result.
+    BridgeResultFromObjC,
+
+    /// An erasure to Any (possibly wrapped in optional conversions).
+    /// This is sortof a bridging conversion.
+    AnyErasure,
+
+    LastBridgingKind = AnyErasure,
+
+    /// An orig-to-subst conversion.
+    OrigToSubst,
+
+    /// A subst-to-orig conversion.  These can always be annihilated.
+    SubstToOrig,
+  };
+
+  static bool isBridgingKind(KindTy kind) {
+    return kind <= LastBridgingKind;
+  }
+
+private:
+  KindTy Kind;
+
+  struct BridgingTypes {
+    CanType OrigType;
+    CanType ResultType;
+    SILType LoweredResultType;
+    bool IsExplicit;
+  };
+
+  struct ReabstractionTypes {
+    AbstractionPattern OrigType;
+    CanType SubstType;
+  };
+
+  static int getStorageIndexForKind(KindTy kind) {
+    switch (kind) {
+    case BridgeToObjC:
+    case BridgeFromObjC:
+    case BridgeResultFromObjC:
+    case AnyErasure:
+      return 0;
+
+    case OrigToSubst:
+    case SubstToOrig:
+      return 1;
+    }
+    llvm_unreachable("bad kind");
+  }
+
+  ExternalUnion<KindTy, getStorageIndexForKind,
+                BridgingTypes, ReabstractionTypes> Types;
+  static_assert(decltype(Types)::union_is_trivially_copyable,
+                "define the special members if this changes");
+
+  Conversion(KindTy kind, CanType origType, CanType resultType,
+             SILType loweredResultTy, bool isExplicit)
+      : Kind(kind) {
+    Types.emplaceAggregate<BridgingTypes>(kind, origType, resultType,
+                                          loweredResultTy, isExplicit);
+  }
+
+  Conversion(KindTy kind, AbstractionPattern origType, CanType substType)
+      : Kind(kind) {
+    Types.emplaceAggregate<ReabstractionTypes>(kind, origType, substType);
+  }
+
+public:
+  static Conversion getOrigToSubst(AbstractionPattern origType,
+                                   CanType substType) {
+    return Conversion(OrigToSubst, origType, substType);
+  }
+
+  static Conversion getSubstToOrig(AbstractionPattern origType,
+                                   CanType substType) {
+    return Conversion(SubstToOrig, origType, substType);
+  }
+
+  static Conversion getBridging(KindTy kind, CanType origType,
+                                CanType resultType, SILType loweredResultTy,
+                                bool isExplicit = false) {
+    assert(isBridgingKind(kind));
+    return Conversion(kind, origType, resultType, loweredResultTy, isExplicit);
+  }
+
+  KindTy getKind() const {
+    return Kind;
+  }
+
+  bool isBridging() const {
+    return isBridgingKind(getKind());
+  }
+
+  AbstractionPattern getReabstractionOrigType() const {
+    return Types.get<ReabstractionTypes>(Kind).OrigType;
+  }
+
+  CanType getReabstractionSubstType() const {
+    return Types.get<ReabstractionTypes>(Kind).SubstType;
+  }
+
+  bool isBridgingExplicit() const {
+    return Types.get<BridgingTypes>(Kind).IsExplicit;
+  }
+
+  CanType getBridgingSourceType() const {
+    return Types.get<BridgingTypes>(Kind).OrigType;
+  }
+
+  CanType getBridgingResultType() const {
+    return Types.get<BridgingTypes>(Kind).ResultType;
+  }
+
+  SILType getBridgingLoweredResultType() const {
+    return Types.get<BridgingTypes>(Kind).LoweredResultType;
+  }
+
+  ManagedValue emit(SILGenFunction &SGF, SILLocation loc,
+                    ManagedValue source, SGFContext ctxt) const;
+
+  Optional<Conversion> tryPeepholeOptionalInjection() const;
+
+  void dump() const LLVM_ATTRIBUTE_USED;
+  void print(llvm::raw_ostream &out) const;
+};
+
+bool canPeepholeConversions(SILGenFunction &SGF,
+                            const Conversion &outerConversion,
+                            const Conversion &innerConversion);
+
+ManagedValue emitPeepholedConversions(SILGenFunction &SGF, SILLocation loc,
+                                      const Conversion &outerConversion,
+                                      const Conversion &innerConversion,
+                                      SGFContext C,
+                   llvm::function_ref<ManagedValue(SGFContext)> produceValue);
+
+/// An initialization where we ultimately want to apply a conversion to
+/// the value before completing the initialization.
+///
+/// Value generators may call getAsConversion() to check whether an
+/// Initialization is one of these.  If so, they may call either
+/// tryPeephole or setConvertedValue.
+class ConvertingInitialization final : public Initialization {
+private:
+  enum StateTy {
+    /// Nothing has happened.
+    Uninitialized,
+
+    /// The converted value has been set.
+    Initialized,
+
+    /// finishInitialization has been called.
+    Finished,
+
+    /// The converted value has been extracted.
+    Extracted
+  };
+
+  StateTy State;
+
+  /// The conversion that needs to be applied to the formal value.
+  Conversion TheConversion;
+
+  /// The converted value, set if the initializing code calls tryPeephole,
+  /// setReabstractedValue, or copyOrInitValueInto.
+  ManagedValue Value;
+  SGFContext FinalContext;
+
+  StateTy getState() const {
+    return State;
+  }
+
+public:
+  ConvertingInitialization(Conversion conversion, SGFContext finalContext)
+    : State(Uninitialized), TheConversion(conversion),
+      FinalContext(finalContext) {}
+
+  /// Return the conversion to apply to the unconverted value.
+  const Conversion &getConversion() const {
+    return TheConversion;
+  }
+
+  /// Return the context into which to emit the converted value.
+  SGFContext getFinalContext() const {
+    return FinalContext;
+  }
+
+  // The three ways to perform this initialization:
+
+  /// Set the unconverted value for this initialization.
+  void copyOrInitValueInto(SILGenFunction &SGF, SILLocation loc,
+                           ManagedValue value, bool isInit) override;
+
+  /// Given that the result of the given expression needs to sequentially
+  /// undergo the the given conversion and then this conversion, attempt to
+  /// peephole the result.  If successful, the value will be set in this
+  /// initialization.  The initialization will not yet be finished.
+  bool tryPeephole(SILGenFunction &SGF, Expr *E, Conversion innerConversion);
+  bool tryPeephole(SILGenFunction &SGF, SILLocation loc,
+                   Conversion innerConversion,
+                   llvm::function_ref<ManagedValue(SGFContext)> generate);
+  bool tryPeephole(SILGenFunction &SGF, SILLocation loc, ManagedValue value,
+                   Conversion innerConversion);
+
+  /// Set the converted value for this initialization.
+  void setConvertedValue(ManagedValue value) {
+    assert(getState() == Uninitialized);
+    assert(!value.isInContext() || FinalContext.getEmitInto());
+    Value = value;
+    State = Initialized;
+  }
+
+  /// Given the unconverted result, i.e. the result of emitting a
+  /// value formally of the unconverted type with this initialization
+  /// as the SGFContext, produce the converted result.
+  ///
+  /// If this initialization was initialized, the unconverted result
+  /// must be ManagedValue::forInContext(), and vice-versa.
+  ///
+  /// The result of this function may itself be
+  /// ManagedValue::forInContext() if this Initialization was created
+  /// with an SGFContext which contains another Initialization.
+  ManagedValue finishEmission(SILGenFunction &SGF, SILLocation loc,
+                              ManagedValue formalResult);
+
+  // Implement to make the cast work.
+  ConvertingInitialization *getAsConversion() override {
+    return this;
+  }
+
+  // Bookkeeping.
+  void finishInitialization(SILGenFunction &SGF) override {
+    assert(getState() == Initialized);
+    State = Finished;
+  }
+};
+
+} // end namespace Lowering
+} // end namespace swift
+
+#endif

--- a/lib/SILGen/Initialization.h
+++ b/lib/SILGen/Initialization.h
@@ -19,6 +19,7 @@
 #define SWIFT_LOWERING_INITIALIZATION_H
 
 #include "ManagedValue.h"
+#include "swift/SIL/AbstractionPattern.h"
 #include "llvm/ADT/TinyPtrVector.h"
 #include <memory>
 
@@ -30,7 +31,8 @@ class Initialization;
 using InitializationPtr = std::unique_ptr<Initialization>;
 class TemporaryInitialization;
 using TemporaryInitializationPtr = std::unique_ptr<TemporaryInitialization>;
-  
+class ConvertingInitialization;
+
 /// An abstract class for consuming a value.  This is used for initializing
 /// variables, although that is not the only way it is used.
 ///
@@ -58,6 +60,9 @@ using TemporaryInitializationPtr = std::unique_ptr<TemporaryInitialization>;
 ///     must be completely initialized (including calling
 ///     finishInitialization) before finishInitialization is called on the
 ///     outer initialization.
+///
+///   - If getAsConversion() returns non-null, the specialized interface
+//      for that subclass can be used.
 ///
 ///   - copyOrInitValueInto may be called.
 ///
@@ -126,7 +131,12 @@ public:
     llvm_unreachable("Must implement if canSplitIntoTupleElements "
                      "returns true");
   }
-  
+
+  /// Return a non-null pointer if this is a reabstracting initialization.
+  virtual ConvertingInitialization *getAsConversion() {
+    return nullptr;
+  }
+
   /// Initialize this with the given value.  This should be an operation
   /// of last resort: it is generally better to split tuples or evaluate
   /// in-place when the initialization supports that.

--- a/lib/SILGen/SGFContext.h
+++ b/lib/SILGen/SGFContext.h
@@ -1,0 +1,164 @@
+//===--- SGFContext.h - Expression emission context -------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SILGEN_SGFCONTEXT_H
+#define SWIFT_SILGEN_SGFCONTEXT_H
+
+#include "Initialization.h"
+
+namespace swift {
+namespace Lowering {
+
+/// Internal context information for the SILGenFunction visitor.
+///
+/// In general, emission methods which take an SGFContext indicate
+/// that they've initialized the emit-into buffer (if they have) by
+/// returning a "isInContext()" ManagedValue of whatever type.  Callers who
+/// propagate down an SGFContext that might have an emit-into buffer must be
+/// aware of this.
+///
+/// Clients of emission routines that take an SGFContext can also specify that
+/// they are ok getting back an RValue at +0 instead of requiring it to be at
+/// +1.  The client is then responsible for checking the ManagedValue to see if
+/// it got back a ManagedValue at +0 or +1.
+class SGFContext {
+  enum DesiredTransfer {
+    PlusOne,
+    ImmediatePlusZero,
+    GuaranteedPlusZero,
+  };
+  llvm::PointerIntPair<Initialization *, 2, DesiredTransfer> state;
+public:
+  SGFContext() = default;
+
+  enum AllowImmediatePlusZero_t {
+    /// The client is okay with getting a +0 value and plans to use it
+    /// immediately.
+    ///
+    /// For example, in this context, it would be okay to return +0
+    /// even for a load from a mutable variable, because the only way
+    /// the value could be invalidated before it's used is a race
+    /// condition.
+    AllowImmediatePlusZero
+  };
+
+  enum AllowGuaranteedPlusZero_t {
+    /// The client is okay with getting a +0 value as long as it's
+    /// guaranteed to last at least as long as the current evaluation.
+    /// (For expression evaluation, this generally means at least
+    /// until the end of the current statement.)
+    ///
+    /// For example, in this context, it would be okay to return +0
+    /// for a reference to a local 'let' because that will last until
+    /// the 'let' goes out of scope.  However, it would not be okay to
+    /// return +0 for a load from a mutable 'var', because that could
+    /// be mutated before the end of the statement.
+    AllowGuaranteedPlusZero
+  };
+
+  /// Creates an emitInto context that will store the result of the visited expr
+  /// into the given Initialization.
+  explicit SGFContext(Initialization *emitInto) : state(emitInto, PlusOne) {
+  }
+
+  /*implicit*/
+  SGFContext(AllowImmediatePlusZero_t) : state(nullptr, ImmediatePlusZero) {
+  }
+
+  /*implicit*/
+  SGFContext(AllowGuaranteedPlusZero_t) : state(nullptr, GuaranteedPlusZero) {
+  }
+
+  /// Returns a pointer to the Initialization that the current expression should
+  /// store its result to, or null if the expression should allocate temporary
+  /// storage for its result.
+  Initialization *getEmitInto() const {
+    return state.getPointer();
+  }
+
+  /// Try to get the address of the emit-into initialization if we can.
+  /// Otherwise, return an empty SILValue.
+  ///
+  /// Note that, if this returns a non-empty address, the caller must
+  /// finish the emit-into initialization.
+  SILValue getAddressForInPlaceInitialization(SILGenFunction &SGF,
+                                              SILLocation loc) const {
+    if (auto *init = getEmitInto()) {
+      if (init->canPerformInPlaceInitialization())
+        return init->getAddressForInPlaceInitialization(SGF, loc);
+    }
+    return SILValue();
+  }
+
+  /// If getAddressForInPlaceInitialization did (or would have)
+  /// returned a non-null address, finish the initialization and
+  /// return true.  Otherwise, return false.
+  bool finishInPlaceInitialization(SILGenFunction &SGF) const {
+    if (auto *init = getEmitInto()) {
+      if (init->canPerformInPlaceInitialization()) {
+        init->finishInitialization(SGF);
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /// Try to get this context as a conversion initialization.
+  ///
+  /// This does not commit the caller to anything, whether it succeeds
+  /// or fails.
+  ConvertingInitialization *getAsConversion() const {
+    if (auto init = getEmitInto())
+      return init->getAsConversion();
+    return nullptr;
+  }
+
+  /// Return true if a ManagedValue producer is allowed to return at
+  /// +0, given that it cannot guarantee that the value will be valid
+  /// until the end of the current evaluation.
+  bool isImmediatePlusZeroOk() const {
+    return state.getInt() == ImmediatePlusZero;
+  }
+
+  /// Return true if a ManagedValue producer is allowed to return at
+  /// +0 if it can guarantee that the value will be valid until the
+  /// end of the current evaluation.
+  bool isGuaranteedPlusZeroOk() const {
+    // Either ImmediatePlusZero or GuaranteedPlusZero is fine.
+    return state.getInt() >= ImmediatePlusZero;
+  }
+
+  /// Get a context for a sub-expression given that arbitrary side
+  /// effects may follow the subevaluation.
+  SGFContext withFollowingSideEffects() const {
+    SGFContext copy = *this;
+    if (copy.state.getInt() == ImmediatePlusZero) {
+      copy.state.setInt(GuaranteedPlusZero);
+    }
+    return copy;
+  }
+
+  /// Get a context for a sub-expression where we plan to project out
+  /// a value.  The Initialization is not okay to propagate down, but
+  /// the +0/+1-ness is.
+  SGFContext withFollowingProjection() const {
+    SGFContext copy;
+    copy.state.setInt(state.getInt());
+    return copy;
+  }
+};
+
+} // end namespace Lowering
+} // end namespace swift
+
+#endif

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -13,6 +13,7 @@
 #include "ArgumentScope.h"
 #include "ArgumentSource.h"
 #include "Callee.h"
+#include "Conversion.h"
 #include "FormalEvaluation.h"
 #include "Initialization.h"
 #include "LValue.h"
@@ -37,22 +38,75 @@
 using namespace swift;
 using namespace Lowering;
 
-/// Retrieve the type to use for a method found via dynamic lookup.
-static CanAnyFunctionType getDynamicMethodFormalType(SILValue proto,
-                                                     ValueDecl *member,
-                                                     Type memberType) {
-  auto &ctx = member->getASTContext();
-  CanType selfTy;
-  if (member->isInstanceMember()) {
-    selfTy = ctx.TheUnknownObjectType;
-  } else {
-    selfTy = proto->getType().getSwiftRValueType();
-  }
-  auto extInfo = FunctionType::ExtInfo()
-                   .withRepresentation(FunctionType::Representation::Thin);
+/// Return the abstraction pattern to use when calling a function value.
+static AbstractionPattern
+getIndirectApplyAbstractionPattern(SILGenFunction &SGF,
+                                   CanFunctionType fnType) {
+  AbstractionPattern pattern(fnType);
+  switch (fnType->getRepresentation()) {
+  case FunctionTypeRepresentation::Swift:
+  case FunctionTypeRepresentation::Thin:
+    return pattern;
 
-  return CanFunctionType::get(selfTy, memberType->getCanonicalType(),
-                              extInfo);
+  case FunctionTypeRepresentation::CFunctionPointer:
+  case FunctionTypeRepresentation::Block: {
+    // C and block function parameters and results are implicitly
+    // bridged to a foreign type.
+    auto bridgedType =
+      SGF.SGM.Types.getBridgedFunctionType(pattern, fnType,
+                                           fnType->getExtInfo());
+    pattern.rewriteType(CanGenericSignature(), bridgedType);
+    return pattern;
+  }
+  }
+  llvm_unreachable("bad representation");
+}
+
+static CanType getDynamicMethodSelfType(SILValue proto, ValueDecl *member) {
+  if (member->isInstanceMember()) {
+    return member->getASTContext().TheUnknownObjectType;
+  } else {
+    return proto->getType().getSwiftRValueType();
+  }
+}
+
+/// Return the formal type for the partial-apply result type of a
+/// dynamic method invocation.
+static CanFunctionType
+getPartialApplyOfDynamicMethodFormalType(SILGenModule &SGM, SILDeclRef member,
+                                         ConcreteDeclRef memberRef) {
+  auto memberCI = SGM.Types.getConstantInfo(member);
+
+  // Construct a non-generic version of the formal type.
+  // This works because we're only using foreign members, where presumably
+  // substitution doesn't matter.
+  CanAnyFunctionType completeMethodTy = memberCI.LoweredType;
+  if (auto genericFnType = dyn_cast<GenericFunctionType>(completeMethodTy)) {
+    completeMethodTy = cast<FunctionType>(
+      genericFnType->substGenericArgs(memberRef.getSubstitutions())
+                   ->getCanonicalType());
+  }
+
+  // Adjust the parameters by removing the self parameter, which we
+  // will be partially applying.
+  auto params = completeMethodTy.getParams().drop_back();
+
+  // Adjust the result type to replace dynamic-self with AnyObject.
+  CanType resultType = completeMethodTy.getResult();
+  if (auto fnDecl = dyn_cast<FuncDecl>(member.getDecl())) {
+    if (fnDecl->hasDynamicSelf()) {
+      auto anyObjectTy = SGM.getASTContext().getAnyObjectType();
+      resultType = resultType->replaceCovariantResultType(anyObjectTy, 0)
+                             ->getCanonicalType();
+    }
+  }
+
+  // Adjust the ExtInfo by using a Swift representation.
+  auto extInfo = completeMethodTy->getExtInfo()
+                   .withRepresentation(FunctionTypeRepresentation::Swift);
+
+  auto fnType = CanFunctionType::get(params, resultType, extInfo);
+  return fnType;
 }
 
 /// Replace the 'self' parameter in the given type.
@@ -225,7 +279,7 @@ private:
   ManagedValue IndirectValue;
   SILDeclRef Constant;
   SILValue SelfValue;
-  CanAnyFunctionType OrigFormalInterfaceType;
+  AbstractionPattern OrigFormalInterfaceType;
   CanFunctionType SubstFormalInterfaceType;
   SubstitutionList Substitutions;
   Optional<SmallVector<ManagedValue, 2>> Captures;
@@ -245,23 +299,19 @@ private:
     return cast<FunctionType>(substFormalType);
   }
 
-  static CanAnyFunctionType getConstantFormalInterfaceType(SILGenFunction &SGF,
-                                                           SILDeclRef fn) {
-    return SGF.SGM.Types.getConstantInfo(fn).FormalInterfaceType;
-  }
-
   Callee(ManagedValue indirectValue,
-         CanAnyFunctionType origFormalType,
+         AbstractionPattern origFormalType,
+         CanFunctionType substFormalType,
          SILLocation l)
     : kind(Kind::IndirectValue),
       IndirectValue(indirectValue),
       OrigFormalInterfaceType(origFormalType),
-      SubstFormalInterfaceType(cast<FunctionType>(origFormalType)),
+      SubstFormalInterfaceType(substFormalType),
       Loc(l)
   {}
 
   Callee(SILGenFunction &SGF, SILDeclRef standaloneFunction,
-         CanAnyFunctionType origFormalType,
+         AbstractionPattern origFormalType,
          CanAnyFunctionType substFormalType,
          SubstitutionList subs, SILLocation l)
     : kind(Kind::StandaloneFunction), Constant(standaloneFunction),
@@ -277,7 +327,7 @@ private:
          SILGenFunction &SGF,
          SILValue selfValue,
          SILDeclRef methodName,
-         CanAnyFunctionType origFormalType,
+         AbstractionPattern origFormalType,
          CanAnyFunctionType substFormalType,
          SubstitutionList subs,
          SILLocation l)
@@ -293,41 +343,42 @@ private:
 public:
 
   static Callee forIndirect(ManagedValue indirectValue,
-                            CanAnyFunctionType origFormalType,
+                            AbstractionPattern origFormalType,
+                            CanFunctionType substFormalType,
                             SILLocation l) {
-    return Callee(indirectValue, origFormalType, l);
+    return Callee(indirectValue, origFormalType, substFormalType, l);
   }
   static Callee forDirect(SILGenFunction &SGF, SILDeclRef c,
                           SubstitutionList subs,
                           SILLocation l) {
-    auto formalType = getConstantFormalInterfaceType(SGF, c);
-    return Callee(SGF, c, formalType, formalType, subs, l);
+    auto &ci = SGF.getConstantInfo(c);
+    return Callee(SGF, c, ci.FormalPattern, ci.FormalType, subs, l);
   }
   static Callee forEnumElement(SILGenFunction &SGF, SILDeclRef c,
                                SubstitutionList subs,
                                SILLocation l) {
     assert(isa<EnumElementDecl>(c.getDecl()));
-    auto formalType = getConstantFormalInterfaceType(SGF, c);
+    auto &ci = SGF.getConstantInfo(c);
     return Callee(Kind::EnumElement, SGF, SILValue(), c,
-                  formalType, formalType, subs, l);
+                  ci.FormalPattern, ci.FormalType, subs, l);
   }
   static Callee forClassMethod(SILGenFunction &SGF, SILValue selfValue,
                                SILDeclRef c,
                                SubstitutionList subs,
                                SILLocation l) {
     auto base = SGF.SGM.Types.getOverriddenVTableEntry(c);
-    auto formalType = getConstantFormalInterfaceType(SGF, base);
-    auto substType = getConstantFormalInterfaceType(SGF, c);
+    auto &baseCI = SGF.getConstantInfo(base);
+    auto &derivedCI = SGF.getConstantInfo(c);
     return Callee(Kind::ClassMethod, SGF, selfValue, c,
-                  formalType, substType, subs, l);
+                  baseCI.FormalPattern, derivedCI.FormalType, subs, l);
   }
   static Callee forSuperMethod(SILGenFunction &SGF, SILValue selfValue,
                                SILDeclRef c,
                                SubstitutionList subs,
                                SILLocation l) {
-    auto formalType = getConstantFormalInterfaceType(SGF, c);
+    auto &ci = SGF.getConstantInfo(c);
     return Callee(Kind::SuperMethod, SGF, selfValue, c,
-                  formalType, formalType, subs, l);
+                  ci.FormalPattern, ci.FormalType, subs, l);
   }
   static Callee forArchetype(SILGenFunction &SGF,
                              CanType protocolSelfType,
@@ -337,20 +388,45 @@ public:
     auto *protocol = cast<ProtocolDecl>(c.getDecl()->getDeclContext());
     c = c.asForeign(protocol->isObjC());
 
-    auto formalType = getConstantFormalInterfaceType(SGF, c);
+    auto &ci = SGF.getConstantInfo(c);
     return Callee(Kind::WitnessMethod, SGF, SILValue(), c,
-                  formalType, formalType, subs, l);
+                  ci.FormalPattern, ci.FormalType, subs, l);
   }
   static Callee forDynamic(SILGenFunction &SGF, SILValue proto,
-                           SILDeclRef c,
-                           Type substFormalType,
+                           SILDeclRef c, const SubstitutionList &constantSubs,
+                           CanAnyFunctionType partialSubstFormalType,
                            SubstitutionList subs,
                            SILLocation l) {
-    auto formalType = getDynamicMethodFormalType(proto,
-                                                 c.getDecl(),
-                                                 substFormalType);
+    auto &ci = SGF.getConstantInfo(c);
+    AbstractionPattern origFormalType = ci.FormalPattern;
+
+    auto selfType = getDynamicMethodSelfType(proto, c.getDecl());
+
+    // Replace the original self type with the partially-applied subst type.
+    auto origFormalFnType = cast<AnyFunctionType>(origFormalType.getType());
+    if (auto genericFnType = dyn_cast<GenericFunctionType>(origFormalFnType)) {
+      // If we have a generic function type, substitute it.  This is normally
+      // a huge no-no, but the partial-application hacks we're doing here
+      // really kindof mandate it, and it works out because we're always using
+      // a foreign function.  If/when we support native dynamic functions,
+      // this will stop working and we will need a completely different
+      // approach.
+      origFormalFnType =
+        cast<FunctionType>(genericFnType->substGenericArgs(constantSubs)
+                                        ->getCanonicalType());
+    }
+    origFormalFnType = CanFunctionType::get(selfType,
+                                            origFormalFnType.getResult(),
+                                            origFormalFnType->getExtInfo());
+    origFormalType.rewriteType(CanGenericSignature(), origFormalFnType);
+
+    // Add the self type clause to the partially-applied subst type.
+    auto substFormalType = CanFunctionType::get(selfType,
+                                                partialSubstFormalType,
+                                                origFormalFnType->getExtInfo());
+
     return Callee(Kind::DynamicMethod, SGF, proto, c,
-                  formalType, formalType, subs, l);
+                  origFormalType, substFormalType, subs, l);
   }
   Callee(Callee &&) = default;
   Callee &operator=(Callee &&) = default;
@@ -674,16 +750,16 @@ public:
 
   /// Fall back to an unknown, indirect callee.
   void visitExpr(Expr *e) {
-    ManagedValue fn = SGF.emitRValueAsSingleValue(e);
-    auto origType = cast<AnyFunctionType>(e->getType()->getCanonicalType());
-    setCallee(Callee::forIndirect(fn, origType, e));
-  }
-
-  void visitLoadExpr(LoadExpr *e) {
     // TODO: preserve the function pointer at its original abstraction level
+    // when loading from memory.
+
     ManagedValue fn = SGF.emitRValueAsSingleValue(e);
-    auto origType = cast<AnyFunctionType>(e->getType()->getCanonicalType());
-    setCallee(Callee::forIndirect(fn, origType, e));
+    auto substType = cast<FunctionType>(e->getType()->getCanonicalType());
+
+    // When calling an C or block function, there's implicit bridging.
+    auto origType = getIndirectApplyAbstractionPattern(SGF, substType);
+
+    setCallee(Callee::forIndirect(fn, origType, substType, e));
   }
 
   /// Add a call site to the curry.
@@ -1330,7 +1406,8 @@ public:
       return false;
 
     // Only @objc methods can be forced.
-    auto *fd = dyn_cast<FuncDecl>(dynamicMemberRef->getMember().getDecl());
+    auto memberRef = dynamicMemberRef->getMember();
+    auto *fd = dyn_cast<FuncDecl>(memberRef.getDecl());
     if (!fd || !fd->isObjC())
       return false;
 
@@ -1349,9 +1426,11 @@ public:
       // class type of the 'Self' parameter with Builtin.UnknownObject.
       auto member = SILDeclRef(fd).asForeign();
 
-      auto substFormalType = dynamicMemberRef->getType()
-          ->getAnyOptionalObjectType();
+      auto substFormalType =
+        cast<FunctionType>(dynamicMemberRef->getType()->getCanonicalType()
+                                            .getAnyOptionalObjectType());
       setCallee(Callee::forDynamic(SGF, base.getValue(), member,
+                                   memberRef.getSubstitutions(),
                                    substFormalType, {}, e));
     };
 
@@ -1783,15 +1862,16 @@ RValue SILGenFunction::emitApply(ResultPlanPtr &&resultPlan,
 RValue SILGenFunction::emitMonomorphicApply(SILLocation loc,
                                             ManagedValue fn,
                                             ArrayRef<ManagedValue> args,
-                                            CanType resultType,
+                                            CanType foreignResultType,
+                                            CanType nativeResultType,
                                             ApplyOptions options,
                            Optional<SILFunctionTypeRepresentation> overrideRep,
-                     const Optional<ForeignErrorConvention> &foreignError){
+                     const Optional<ForeignErrorConvention> &foreignError,
+                                            SGFContext evalContext) {
   auto fnType = fn.getType().castTo<SILFunctionType>();
   assert(!fnType->isPolymorphic());
-  SGFContext evalContext;
-  CalleeTypeInfo calleeTypeInfo(fnType, AbstractionPattern(resultType),
-                                resultType, foreignError, overrideRep);
+  CalleeTypeInfo calleeTypeInfo(fnType, AbstractionPattern(foreignResultType),
+                                nativeResultType, foreignError, overrideRep);
   ResultPlanPtr resultPlan = ResultPlanBuilder::computeResultPlan(
       *this, calleeTypeInfo, loc, evalContext);
   ArgumentScope argScope(*this, loc);
@@ -2707,9 +2787,9 @@ private:
           return;
 
         // Otherwise, just use the default logic.
-        result = SGF.emitRValueAsSingleValue(expr, contexts.ForEmission);
+        result = SGF.emitRValueAsSingleValue(expr, contexts.FinalContext);
       } else {
-        result = std::move(arg).getAsSingleValue(SGF, contexts.ForEmission);
+        result = std::move(arg).getAsSingleValue(SGF, contexts.FinalContext);
       }
 
       // If it's not already in memory, put it there.
@@ -2787,16 +2867,20 @@ private:
     ManagedValue value;
     auto contexts = getRValueEmissionContexts(loweredSubstArgType, param);
     if (contexts.RequiresReabstraction) {
-      switch (getSILFunctionLanguage(Rep)) {
-      case SILFunctionLanguage::Swift:
-        value = emitSubstToOrigArgument(std::move(arg), loweredSubstArgType,
-                                        origParamType, param);
-        break;
-      case SILFunctionLanguage::C:
-        value = emitNativeToBridgedArgument(
-            std::move(arg), loweredSubstArgType, origParamType, param);
-        break;
-      }
+      auto conversion = [&] {
+        switch (getSILFunctionLanguage(Rep)) {
+        case SILFunctionLanguage::Swift:
+          return Conversion::getSubstToOrig(origParamType, arg.getSubstType());
+        case SILFunctionLanguage::C:
+          return Conversion::getBridging(Conversion::BridgeToObjC,
+                                         arg.getSubstType(),
+                                         origParamType.getType(),
+                                         param.getSILStorageType());
+        }
+        llvm_unreachable("bad language");
+      }();
+      value = emitConvertedArgument(std::move(arg), conversion,
+                                    contexts.FinalContext);
 
     // Peephole certain argument emissions.
     } else if (arg.isExpr()) {
@@ -2807,9 +2891,9 @@ private:
         return;
 
       // Otherwise, just use the default logic.
-      value = SGF.emitRValueAsSingleValue(expr, contexts.ForEmission);
+      value = SGF.emitRValueAsSingleValue(expr, contexts.FinalContext);
     } else {
-      value = std::move(arg).getAsSingleValue(SGF, contexts.ForEmission);
+      value = std::move(arg).getAsSingleValue(SGF, contexts.FinalContext);
     }
 
     if (param.isConsumed() &&
@@ -2936,252 +3020,16 @@ private:
     }
   }
 
-  ManagedValue emitSubstToOrigArgument(ArgumentSource &&arg,
-                                       SILType loweredSubstArgType,
-                                       AbstractionPattern origParamType,
-                                       SILParameterInfo param) {
-    Scope scope(SGF, arg.getLocation());
+  ManagedValue emitConvertedArgument(ArgumentSource &&arg,
+                                     Conversion conversion,
+                                     SGFContext C) {
+    auto loc = arg.getLocation();
+    Scope scope(SGF, loc);
 
-    // TODO: We should take the opportunity to peephole certain abstraction
-    // changes here, for instance, directly emitting a closure literal at the
-    // callee's expected abstraction level instead of emitting it maximally
-    // substituted and thunking.
-    auto emitted = emitArgumentFromSource(std::move(arg), loweredSubstArgType,
-                                          origParamType, param);
-    ManagedValue result = SGF.emitSubstToOrigValue(
-        emitted.loc, std::move(emitted.value).getScalarValue(), origParamType,
-        emitted.value.getType(), emitted.contextForReabstraction);
+    // TODO: honor C here.
+    auto result = std::move(arg).getConverted(SGF, conversion);
+
     return scope.popPreservingValue(result);
-  }
-  
-  CanType getAnyObjectType() {
-    return SGF.getASTContext().getAnyObjectType();
-  }
-  bool isAnyObjectType(CanType t) {
-    return t == getAnyObjectType();
-  }
-  
-  ManagedValue emitNativeToBridgedArgument(ArgumentSource &&arg,
-                                           SILType loweredSubstArgType,
-                                           AbstractionPattern origParamType,
-                                           SILParameterInfo param) {
-    Scope scope(SGF, arg.getLocation());
-
-    // If we're bridging a concrete type to `id` via Any, skip the Any
-    // boxing.
-    
-    // TODO: Generalize. Similarly, when bridging from NSFoo -> Foo -> NSFoo,
-    // we should elide the bridge altogether and pass the original object.
-    auto paramObjTy = param.getType();
-    if (auto objTy = paramObjTy.getAnyOptionalObjectType())
-      paramObjTy = objTy;
-    if (isAnyObjectType(paramObjTy) && !arg.isRValue()) {
-      return scope.popPreservingValue(emitNativeToBridgedObjectArgument(
-          std::move(arg).asKnownExpr(), loweredSubstArgType, origParamType,
-          param));
-    }
-    
-    auto emitted = emitArgumentFromSource(std::move(arg), loweredSubstArgType,
-                                          origParamType, param);
-
-    return scope.popPreservingValue(SGF.emitNativeToBridgedValue(
-        emitted.loc,
-        std::move(emitted.value).getAsSingleValue(SGF, emitted.loc), Rep,
-        param.getType()));
-  }
-  
-  enum class ExistentialPeepholeOptionality {
-    /// A non-optional value erased to a non-optional existential.
-    Nonoptional,
-    
-    /// A non-optional value erased to an optional existential.
-    NonoptionalToOptional,
-    
-    /// An optional value erased to an optional existential.
-    OptionalToOptional,
-  };
-  
-  std::pair<Expr *, ExistentialPeepholeOptionality>
-  lookThroughExistentialErasures(Expr *argExpr) {
-    auto origArgExpr = argExpr;
-  
-    auto optionality = ExistentialPeepholeOptionality::Nonoptional;
-    argExpr = argExpr->getSemanticsProvidingExpr();
-    
-    // Check for an OptionalEvaluation. If we see one we'll want to match it
-    // to the inner BindOptional.
-    if (auto optEval = dyn_cast<OptionalEvaluationExpr>(argExpr)) {
-      
-      // The result of the conversion should be promoted back to optional
-      // at the outermost level.
-      if (auto inject = dyn_cast<InjectIntoOptionalExpr>(
-                       optEval->getSubExpr()->getSemanticsProvidingExpr())) {
-        optionality = ExistentialPeepholeOptionality::OptionalToOptional;
-        argExpr = inject->getSubExpr()->getSemanticsProvidingExpr();
-      }
-    }
-    
-    // Look through a BindOptionalExpr if we have an optional-to-optional
-    // peephole, or fail the peephole if there isn't a BindOptionalToOptional.
-    auto tryToBindOptional =
-      [&](Expr *subExpr) -> std::pair<Expr *, ExistentialPeepholeOptionality> {
-        if (optionality ==
-              ExistentialPeepholeOptionality::OptionalToOptional) {
-          // If we see the binding, look through it.
-          if (auto bind = dyn_cast<BindOptionalExpr>(subExpr))
-            return {bind->getSubExpr()->getSemanticsProvidingExpr(),
-                    optionality};
-          // Otherwise, we don't know what we're seeing. Back out of the
-          // peephole.
-          return {origArgExpr, ExistentialPeepholeOptionality::Nonoptional};
-        }
-        
-        return {subExpr, optionality};
-      };
-    
-    // Look through an optional injection.
-    if (auto inject = dyn_cast<InjectIntoOptionalExpr>(argExpr)) {
-      optionality = ExistentialPeepholeOptionality::NonoptionalToOptional;
-      argExpr = inject->getSubExpr()->getSemanticsProvidingExpr();
-    }
-
-    // When converting from an existential type to a more general existential,
-    // the inner existential is opened first. Look through this pattern.
-    if (auto open = dyn_cast<OpenExistentialExpr>(argExpr)) {
-      auto subExpr = open->getSubExpr()->getSemanticsProvidingExpr();
-      while (auto erasure = dyn_cast<ErasureExpr>(subExpr)) {
-        subExpr = erasure->getSubExpr()->getSemanticsProvidingExpr();
-      }
-      // If we drilled down to the underlying opened existential, look
-      // through it.
-      if (subExpr == open->getOpaqueValue())
-        return tryToBindOptional(open->getExistentialValue());
-      // TODO: Maybe there are other peepholes we could attempt on opened
-      // existentials?
-      return tryToBindOptional(open);
-    }
-    
-    // Look through ErasureExprs and try to bridge the underlying
-    // concrete value instead.
-    while (auto erasure = dyn_cast<ErasureExpr>(argExpr))
-      argExpr = erasure->getSubExpr()->getSemanticsProvidingExpr();
-
-    return tryToBindOptional(argExpr);
-  }
-  
-  /// Emit an argument expression that we know will be bridged to an
-  /// Objective-C object.
-  ManagedValue emitNativeToBridgedObjectArgument(Expr *argExpr,
-                                             SILType loweredSubstArgType,
-                                             AbstractionPattern origParamType,
-                                             SILParameterInfo param) {
-    auto origArgExpr = argExpr;
-    // Look through existential erasures.
-    ExistentialPeepholeOptionality optionality;
-    std::tie(argExpr, optionality) = lookThroughExistentialErasures(argExpr);
-    
-    // TODO: Only do the peephole for trivially-lowered types, since we
-    // unfortunately don't plumb formal types through
-    // emitNativeToBridgedValue, so can't correctly construct the
-    // substitution for the call to _bridgeAnythingToObjectiveC for function
-    // or metatype values.
-    if (!argExpr->getType()->isLegalSILType()) {
-      argExpr = origArgExpr;
-      optionality = ExistentialPeepholeOptionality::Nonoptional;
-    }
-    
-    // Emit the argument.
-    auto contexts = getRValueEmissionContexts(loweredSubstArgType, param);
-    ManagedValue emittedArg = SGF.emitRValue(argExpr, contexts.ForEmission)
-      .getAsSingleValue(SGF, argExpr);
-    
-    // Early exit if we already exactly match the parameter type.
-    if (emittedArg.getType() == SGF.getSILType(param)) {
-      return emittedArg;
-    }
-    
-    // Factor the bridging conversion out in case we need to do it as an
-    // optional-to-optional transform.
-    auto doBridge = [&](SILGenFunction &SGF,
-                        SILLocation loc,
-                        ManagedValue emittedArg,
-                        SILType loweredResultTy,
-                        SGFContext context) -> ManagedValue {
-      // If the argument is not already a class instance, bridge it.
-      if (!emittedArg.getType().getSwiftRValueType()->mayHaveSuperclass()
-          && !emittedArg.getType().isClassExistentialType()) {
-        emittedArg = SGF.emitNativeToBridgedValue(loc, emittedArg, Rep,
-                                        loweredResultTy.getSwiftRValueType());
-      }
-      auto emittedArgTy = emittedArg.getType().getSwiftRValueType();
-      assert(emittedArgTy->mayHaveSuperclass()
-        || emittedArgTy->isClassExistentialType());
-      
-      // Upcast reference types to AnyObject.
-      if (!isAnyObjectType(emittedArgTy)) {
-        // Open class existentials first to upcast the reference inside.
-        if (emittedArgTy->isClassExistentialType()) {
-          emittedArgTy = ArchetypeType::getOpened(emittedArgTy);
-          auto opened = SGF.B.createOpenExistentialRef(loc,
-                               emittedArg.getValue(),
-                               SILType::getPrimitiveObjectType(emittedArgTy));
-          emittedArg = ManagedValue(opened, emittedArg.getCleanup());
-        }
-        
-        auto erased = SGF.B.createInitExistentialRef(loc,
-                         SILType::getPrimitiveObjectType(getAnyObjectType()),
-                         emittedArgTy, emittedArg.getValue(), {});
-        emittedArg = ManagedValue(erased, emittedArg.getCleanup());
-      }
-      
-      assert(isAnyObjectType(emittedArg.getType().getSwiftRValueType()));
-      return emittedArg;
-    };
-    
-    // Bind the optional value if we started with an optional.
-    bool nativeIsOptional = (bool)emittedArg.getType().getSwiftRValueType()
-      ->getAnyOptionalObjectType();
-    bool bridgedIsOptional =
-        (bool)param.getType()->getAnyOptionalObjectType();
-    if (nativeIsOptional && bridgedIsOptional) {
-      return SGF.emitOptionalToOptional(argExpr, emittedArg,
-                                        SGF.getSILType(param), doBridge);
-    } else if (!nativeIsOptional && bridgedIsOptional) {
-      auto paramObjTy = SGF.getSILType(param).getAnyOptionalObjectType();
-      auto transformed = doBridge(SGF, argExpr, emittedArg,
-                                  paramObjTy, SGFContext());
-      // Inject into optional.
-      auto opt = SGF.B.createEnum(argExpr, transformed.getValue(),
-                                  SGF.getASTContext().getOptionalSomeDecl(),
-                                  SGF.getSILType(param));
-      return ManagedValue(opt, transformed.getCleanup());
-    } else {
-      return doBridge(SGF, argExpr, emittedArg, SGF.getSILType(param),
-                      SGFContext());
-    }
-  }
-  
-  struct EmittedArgument {
-    SILLocation loc;
-    RValue value;
-    SGFContext contextForReabstraction;
-  };
-  EmittedArgument emitArgumentFromSource(ArgumentSource &&arg,
-                                         SILType loweredSubstArgType,
-                                         AbstractionPattern origParamType,
-                                         SILParameterInfo param) {
-    auto contexts = getRValueEmissionContexts(loweredSubstArgType, param);
-    Optional<SILLocation> loc;
-    RValue rv;
-    if (arg.isRValue()) {
-      loc = arg.getKnownRValueLocation();
-      rv = std::move(arg).asKnownRValue();
-    } else {
-      Expr *e = std::move(arg).asKnownExpr();
-      loc = e;
-      rv = SGF.emitRValue(e, contexts.ForEmission);
-    }
-    return {*loc, std::move(rv), contexts.ForReabstraction};
   }
   
   void maybeEmitForeignErrorArgument() {
@@ -3202,9 +3050,7 @@ private:
 
   struct EmissionContexts {
     /// The context for emitting the r-value.
-    SGFContext ForEmission;
-    /// The context for reabstracting the r-value.
-    SGFContext ForReabstraction;
+    SGFContext FinalContext;
     /// If the context requires reabstraction
     bool RequiresReabstraction;
   };
@@ -3214,7 +3060,7 @@ private:
         loweredArgType.getSwiftRValueType() != param.getType();
     // If the parameter is consumed, we have to emit at +1.
     if (param.isConsumed()) {
-      return {SGFContext(), SGFContext(), requiresReabstraction};
+      return {SGFContext(), requiresReabstraction};
     }
 
     // Otherwise, we can emit the final value at +0 (but only with a
@@ -3223,34 +3069,9 @@ private:
     // TODO: we can pass at +0 (immediate) to an unowned parameter
     // if we know that there will be no arbitrary side-effects
     // between now and the call.
-    SGFContext finalContext = SGFContext::AllowGuaranteedPlusZero;
-
-    // If the r-value doesn't require reabstraction, the final context
-    // is the emission context.
-    if (!requiresReabstraction) {
-      return {finalContext, SGFContext(), requiresReabstraction};
-    }
-
-    // Otherwise, the final context is the reabstraction context.
-    return {SGFContext(), finalContext, requiresReabstraction};
+    return {SGFContext::AllowGuaranteedPlusZero, requiresReabstraction};
   }
 };
-
-} // end anonymous namespace
-
-/// Decompose a type, whether it is a tuple or a single type, into an
-/// array of tuple type elements.
-static ArrayRef<TupleTypeElt> decomposeTupleOrSingle(Type type,
-                                                     TupleTypeElt &single) {
-  if (auto tupleTy = type->getAs<TupleType>()) {
-    return tupleTy->getElements();
-  }
-
-  single = TupleTypeElt(type);
-  return single;
-}
-
-namespace {
 
 struct ElementExtent {
   /// The parameters which go into this tuple element.
@@ -3290,6 +3111,7 @@ class TupleShuffleArgEmitter {
   ArrayRef<unsigned> variadicArgs;
   Type varargsArrayType;
   AbstractionPattern origParamType;
+  bool isResultScalar;
 
   TupleTypeElt singleOuterElement;
   ArrayRef<TupleTypeElt> outerElements;
@@ -3320,14 +3142,22 @@ public:
         elementMapping(e->getElementMapping()),
         variadicArgs(e->getVariadicArgs()),
         varargsArrayType(e->getVarargsArrayTypeOrNull()),
-        origParamType(origParamType), singleOuterElement(), outerElements(),
+        origParamType(origParamType), isResultScalar(e->isResultScalar()),
         canVarargsArrayType(),
         origInnerElts(innerElts.size(), AbstractionPattern::getInvalid()),
         innerOrigParamType(AbstractionPattern::getInvalid()), innerParams(),
         innerExtents(innerElts.size()), varargsInfo(), variadicParamInfo(),
         innerSpecialDests() {
-    outerElements = decomposeTupleOrSingle(outer->getType()->getCanonicalType(),
-                                           singleOuterElement);
+
+    // Decompose the shuffle result.
+    CanType resultType = e->getType()->getCanonicalType();
+    if (isResultScalar) {
+      singleOuterElement = TupleTypeElt(resultType);
+      outerElements = singleOuterElement;
+    } else {
+      outerElements = cast<TupleType>(resultType)->getElements();
+    }
+
     if (varargsArrayType)
       canVarargsArrayType = varargsArrayType->getCanonicalType();
   }
@@ -3344,6 +3174,15 @@ private:
   void flattenPatternFromInnerExtendIntoInnerParams(ArgEmitter &parent);
   void splitInnerArgumentsCorrectly(ArgEmitter &parent);
   void emitDefaultArgsAndFinalize(ArgEmitter &parent);
+
+  AbstractionPattern getOutputOrigElementType(unsigned index) {
+    if (isResultScalar) {
+      assert(index == 0);
+      return origParamType;
+    } else {
+      return origParamType.getTupleElementType(index);
+    }
+  }
 };
 
 } // end anonymous namespace
@@ -3354,7 +3193,7 @@ void TupleShuffleArgEmitter::constructInnerTupleTypeInfo(ArgEmitter &parent) {
     CanType substEltType =
         outerElements[outerIndex].getType()->getCanonicalType();
     AbstractionPattern origEltType =
-        origParamType.getTupleElementType(outerIndex);
+        getOutputOrigElementType(outerIndex);
     unsigned numParams =
         getFlattenedValueCount(origEltType, substEltType, parent.ForeignSelf);
 
@@ -3524,7 +3363,7 @@ void TupleShuffleArgEmitter::emitDefaultArgsAndFinalize(ArgEmitter &parent) {
       // Otherwise, emit the default initializer, then map that as a
       // default argument.
       CanType eltType = outerElements[outerIndex].getType()->getCanonicalType();
-      auto origType = origParamType.getTupleElementType(outerIndex);
+      auto origType = getOutputOrigElementType(outerIndex);
       RValue value = parent.SGF.emitApplyOfDefaultArgGenerator(
           outer, defaultArgsOwner, outerIndex, eltType, origType);
       parent.emit(ArgumentSource(outer, std::move(value)), origType);
@@ -3536,7 +3375,7 @@ void TupleShuffleArgEmitter::emitDefaultArgsAndFinalize(ArgEmitter &parent) {
     if (innerIndex == TupleShuffleExpr::CallerDefaultInitialize) {
       auto arg = callerDefaultArgs[nextCallerDefaultArg++];
       parent.emit(ArgumentSource(arg),
-                  origParamType.getTupleElementType(outerIndex));
+                  getOutputOrigElementType(outerIndex));
       continue;
     }
 
@@ -3562,7 +3401,7 @@ void TupleShuffleArgEmitter::emitDefaultArgsAndFinalize(ArgEmitter &parent) {
           emitEndVarargs(parent.SGF, outer, std::move(*varargsInfo));
       parent.emit(
           ArgumentSource(outer, RValue(parent.SGF, outer, eltType, varargs)),
-          origParamType.getTupleElementType(outerIndex));
+          getOutputOrigElementType(outerIndex));
       continue;
     }
 
@@ -4197,6 +4036,19 @@ RValue CallEmission::applyNormalCall(
   std::tie(mv, substFnType, foreignError, foreignSelf, initialOptions) =
       callee.getAtUncurryLevel(SGF, uncurryLevel);
 
+  // In C language modes, substitute the type of the AbstractionPattern
+  // so that we won't see type parameters down when we try to form bridging
+  // conversions.
+  CanSILFunctionType calleeFnTy = mv.getType().castTo<SILFunctionType>();
+  if (calleeFnTy->getLanguage() == SILFunctionLanguage::C) {
+    if (auto genericFnType =
+          dyn_cast<GenericFunctionType>(origFormalType.getType())) {
+      auto fnType = genericFnType->substGenericArgs(callee.getSubstitutions());
+      origFormalType.rewriteType(CanGenericSignature(),
+                                 fnType->getCanonicalType());
+    }
+  }
+
   CalleeTypeInfo calleeTypeInfo(
       substFnType, getUncurriedOrigFormalType(origFormalType),
       uncurriedSites.back().getSubstResultType(), foreignError);
@@ -4240,6 +4092,9 @@ RValue CallEmission::applyEnumElementConstructor(
   assert(!assumedPlusZeroSelf);
   SGFContext uncurriedContext = (extraSites.empty() ? C : SGFContext());
 
+  // The uncurry level in an enum element constructor is weird, so
+  // it's quite fortunate that we can completely ignore it.
+
   // Get the callee type information.
   //
   // Enum payloads are always stored at the abstraction level of the
@@ -4249,8 +4104,7 @@ RValue CallEmission::applyEnumElementConstructor(
   // correctly.
   formalType = callee.getSubstFormalType();
   auto origFormalType = callee.getOrigFormalType();
-  auto substFnType = SGF.getSILFunctionType(origFormalType, formalType,
-                                            uncurryLevel);
+  auto substFnType = SGF.getSILFunctionType(origFormalType, formalType);
 
   // Now that we know the substFnType, check if we assumed that we were
   // passing self at +0. If we did and self is not actually passed at +0,
@@ -4305,12 +4159,13 @@ RValue CallEmission::applyPartiallyAppliedSuperMethod(
 
   ApplyOptions initialOptions = ApplyOptions::None;
 
+  assert(uncurryLevel == 0);
+
   // We want to emit the arguments as fully-substituted values
   // because that's what the partially applied super method expects;
   formalType = callee.getSubstFormalType();
   auto origFormalType = AbstractionPattern(formalType);
-  auto substFnType = SGF.getSILFunctionType(origFormalType, formalType,
-                                            uncurryLevel);
+  auto substFnType = SGF.getSILFunctionType(origFormalType, formalType);
 
   // Now that we know the substFnType, check if we assumed that we were
   // passing self at +0. If we did and self is not actually passed at +0,
@@ -4385,13 +4240,14 @@ RValue CallEmission::applySpecializedEmitter(
   ManagedValue mv;
   ApplyOptions initialOptions = ApplyOptions::None;
 
+  assert(uncurryLevel == 0);
+
   // Get the callee type information. We want to emit the arguments as
   // fully-substituted values because that's what the specialized emitters
   // expect.
   formalType = callee.getSubstFormalType();
   auto origFormalType = AbstractionPattern(formalType);
-  auto substFnType = SGF.getSILFunctionType(origFormalType, formalType,
-                                            uncurryLevel);
+  auto substFnType = SGF.getSILFunctionType(origFormalType, formalType);
 
   // Now that we know the substFnType, check if we assumed that we were
   // passing self at +0. If we did and self is not actually passed at +0,
@@ -4543,7 +4399,13 @@ RValue CallEmission::applyRemainingCallSites(
     RValue &&result, CanFunctionType formalType,
     ImportAsMemberStatus foreignSelf,
     Optional<ForeignErrorConvention> foreignError, SGFContext C) {
-  // If there are remaining call sites, apply them to the result function.
+  // Fast path out if we don't have an extra call sites.
+  if (extraSites.empty()) return std::move(result);
+
+  AbstractionPattern origFormalType =
+    getIndirectApplyAbstractionPattern(SGF, formalType);
+
+  // Apply the remaining call sites to the result function.
   // Each chained call gets its own writeback scope.
   for (unsigned i = 0, size = extraSites.size(); i < size; ++i) {
     FormalEvaluationScope writebackScope(SGF);
@@ -4563,11 +4425,8 @@ RValue CallEmission::applyRemainingCallSites(
            !cast<FunctionType>(formalType)->getExtInfo().throws());
     foreignError = None;
 
-    // The result function has already been reabstracted to the substituted
-    // type, so use the substituted formal type as the abstraction pattern
-    // for argument passing now.
-    AbstractionPattern origResultType(formalType.getResult());
-    AbstractionPattern origParamType(claimNextParamClause(formalType));
+    AbstractionPattern origParamType = claimNextParamClause(origFormalType);
+    AbstractionPattern origResultType = origFormalType;
 
     SGFContext context = i == size - 1 ? C : SGFContext();
 
@@ -5389,8 +5248,7 @@ emitMaterializeForSetAccessor(SILLocation loc, SILDeclRef materializeForSet,
   // Project out the optional callback.
   SILValue optionalCallback = results[1].getUnmanagedValue();
 
-  auto origAccessType = SGM.Types.getConstantInfo(materializeForSet)
-      .FormalInterfaceType;
+  auto origAccessType = SGM.Types.getConstantInfo(materializeForSet).FormalType;
 
   auto origSelfType = origAccessType->getInput()
       ->getInOutObjectType()
@@ -5524,11 +5382,12 @@ RValue SILGenFunction::emitApplyConversionFunction(SILLocation loc,
 
 // Create a partial application of a dynamic method, applying bridging thunks
 // if necessary.
-static SILValue emitDynamicPartialApply(SILGenFunction &SGF,
-                                        SILLocation loc,
-                                        SILValue method,
-                                        SILValue self,
-                                        CanFunctionType methodTy) {
+static ManagedValue emitDynamicPartialApply(SILGenFunction &SGF,
+                                            SILLocation loc,
+                                            SILValue method,
+                                            SILValue self,
+                                         CanAnyFunctionType foreignFormalType,
+                                         CanAnyFunctionType nativeFormalType) {
   auto partialApplyTy = SILBuilder::getPartialApplyResultType(method->getType(),
                                             /*argCount*/1,
                                             SGF.SGM.M,
@@ -5540,14 +5399,18 @@ static SILValue emitDynamicPartialApply(SILGenFunction &SGF,
   if (!self->getType().isAddress())
     self = SGF.B.emitCopyValueOperation(loc, self);
 
-  SILValue result = SGF.B.createPartialApply(loc, method, method->getType(), {},
-                                             self, partialApplyTy);
+  SILValue resultValue =
+    SGF.B.createPartialApply(loc, method, method->getType(), {},
+                             self, partialApplyTy);
+  ManagedValue result = SGF.emitManagedRValueWithCleanup(resultValue);
+
   // If necessary, thunk to the native ownership conventions and bridged types.
-  auto nativeTy = SGF.getLoweredLoadableType(methodTy).castTo<SILFunctionType>();
+  auto nativeTy =
+    SGF.getLoweredLoadableType(nativeFormalType).castTo<SILFunctionType>();
 
   if (nativeTy != partialApplyTy.getSwiftRValueType()) {
-    result = SGF.emitBlockToFunc(loc, ManagedValue::forUnmanaged(result),
-                                 nativeTy).forward(SGF);
+    result = SGF.emitBlockToFunc(loc, result, foreignFormalType,
+                                 nativeFormalType, nativeTy);
   }
 
   return result;
@@ -5605,12 +5468,21 @@ RValue SILGenFunction::emitDynamicMemberRefExpr(DynamicMemberRefExpr *e,
 
     // The argument to the has-member block is the uncurried method.
     auto valueTy = e->getType()->getCanonicalType().getAnyOptionalObjectType();
-    auto methodTy = valueTy;
+    CanFunctionType methodTy;
 
     // For a computed variable, we want the getter.
-    if (isa<VarDecl>(e->getMember().getDecl()))
+    if (isa<VarDecl>(e->getMember().getDecl())) {
       methodTy = CanFunctionType::get(TupleType::getEmpty(getASTContext()),
-                                      methodTy);
+                                      valueTy);
+    } else {
+      methodTy = cast<FunctionType>(valueTy);
+    }
+
+    // Build a partially-applied foreign formal type.
+    // TODO: instead of building this and then potentially converting, we
+    // should just build a single thunk.
+    auto foreignMethodTy =
+      getPartialApplyOfDynamicMethodFormalType(SGM, member, e->getMember());
 
     auto memberFnTy = CanFunctionType::get(
                                        operand->getType().getSwiftRValueType(),
@@ -5623,18 +5495,18 @@ RValue SILGenFunction::emitDynamicMemberRefExpr(DynamicMemberRefExpr *e,
         loweredMethodTy, ValueOwnershipKind::Owned);
 
     // Create the result value.
-    SILValue result = emitDynamicPartialApply(*this, e, memberArg, operand,
-                                              cast<FunctionType>(methodTy));
+    ManagedValue result =
+      emitDynamicPartialApply(*this, e, memberArg, operand,
+                              foreignMethodTy, methodTy);
     Scope applyScope(Cleanups, CleanupLocation(e));
     RValue resultRV;
     if (isa<VarDecl>(e->getMember().getDecl())) {
-      resultRV = emitMonomorphicApply(e, ManagedValue::forUnmanaged(result),
-                                      {}, valueTy,
+      resultRV = emitMonomorphicApply(e, result, {},
+                                      foreignMethodTy.getResult(), valueTy,
                                       ApplyOptions::DoesNotThrow,
                                       None, None);
     } else {
-      resultRV = RValue(*this, e, valueTy,
-                        emitManagedRValueWithCleanup(result));
+      resultRV = RValue(*this, e, valueTy, result);
     }
 
     // Package up the result in an optional.
@@ -5707,6 +5579,8 @@ RValue SILGenFunction::emitDynamicSubscriptExpr(DynamicSubscriptExpr *e,
     auto indexTy = e->getIndex()->getType()->getCanonicalType();
     auto methodTy = CanFunctionType::get(indexTy,
                                          valueTy);
+    auto foreignMethodTy =
+      getPartialApplyOfDynamicMethodFormalType(SGM, member, e->getMember());
     
     auto functionTy = CanFunctionType::get(base->getType().getSwiftRValueType(),
                                            methodTy);
@@ -5716,15 +5590,15 @@ RValue SILGenFunction::emitDynamicSubscriptExpr(DynamicSubscriptExpr *e,
     SILValue memberArg = hasMemberBB->createPHIArgument(
         loweredMethodTy, ValueOwnershipKind::Owned);
     // Emit the application of 'self'.
-    SILValue result = emitDynamicPartialApply(*this, e, memberArg, base,
-                                              cast<FunctionType>(methodTy));
+    ManagedValue result = emitDynamicPartialApply(*this, e, memberArg, base,
+                                                  foreignMethodTy, methodTy);
     // Emit the index.
     llvm::SmallVector<ManagedValue, 2> indexArgs;
     std::move(index).getAll(indexArgs);
     
     Scope applyScope(Cleanups, CleanupLocation(e));
-    auto resultRV = emitMonomorphicApply(e, ManagedValue::forUnmanaged(result),
-                                         indexArgs, valueTy,
+    auto resultRV = emitMonomorphicApply(e, result, indexArgs,
+                                         foreignMethodTy.getResult(), valueTy,
                                          ApplyOptions::DoesNotThrow,
                                          None, None);
 

--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -34,11 +34,11 @@ using namespace Lowering;
 /// assumption for a wide variety of types.
 static ManagedValue emitUnabstractedCast(SILGenFunction &SGF, SILLocation loc,
                                          ManagedValue value,
+                                         CanType sourceFormalType,
                                          CanType targetFormalType) {
-  if (value.getType().getSwiftRValueType() == targetFormalType)
+  if (value.getType() == SGF.getLoweredType(targetFormalType))
     return value;
 
-  CanType sourceFormalType = value.getType().getSwiftRValueType();
   return SGF.emitTransformedValue(loc, value,
                                   AbstractionPattern(sourceFormalType),
                                   sourceFormalType,
@@ -88,11 +88,9 @@ static Optional<ManagedValue>
 emitBridgeNativeToObjectiveC(SILGenFunction &SGF,
                              SILLocation loc,
                              ManagedValue swiftValue,
-                             SILType bridgedTy,
+                             CanType swiftValueType,
+                             CanType bridgedType,
                              ProtocolConformance *conformance) {
-  // Dig out the nominal type we're bridging from.
-  Type swiftValueType = swiftValue.getType().getSwiftRValueType();
-
   // Find the _bridgeToObjectiveC requirement.
   auto requirement = SGF.SGM.getBridgeToObjectiveCRequirement(loc);
   if (!requirement) return None;
@@ -160,7 +158,7 @@ emitBridgeNativeToObjectiveC(SILGenFunction &SGF,
 
   // The Objective-C value doesn't necessarily match the desired type.
   bridgedMV = emitUnabstractedCast(SGF, loc, bridgedMV,
-                                   bridgedTy.getSwiftRValueType());
+                                   objcType->getCanonicalType(), bridgedType);
 
   return bridgedMV;
 }
@@ -172,6 +170,7 @@ static Optional<ManagedValue>
 emitBridgeObjectiveCToNative(SILGenFunction &SGF,
                              SILLocation loc,
                              ManagedValue objcValue,
+                             CanType bridgedType,
                              ProtocolConformance *conformance) {
   // Find the _unconditionallyBridgeFromObjectiveC requirement.
   auto requirement =
@@ -208,7 +207,8 @@ emitBridgeObjectiveCToNative(SILGenFunction &SGF,
 
   // The witness takes an _ObjectiveCType?, so convert to that type.
   CanType desiredValueType = OptionalType::get(objcType)->getCanonicalType();
-  objcValue = emitUnabstractedCast(SGF, loc, objcValue, desiredValueType);
+  objcValue = emitUnabstractedCast(SGF, loc, objcValue, bridgedType,
+                                   desiredValueType);
 
   // Call the witness.
   auto metatypeParam = witnessFnTy->getParameters()[1];
@@ -219,7 +219,7 @@ emitBridgeObjectiveCToNative(SILGenFunction &SGF,
     SGF.B.createMetatype(loc, metatypeParam.getSILStorageType());
 
   auto witnessCI = SGF.getConstantInfo(witnessConstant);
-  CanType formalResultTy = witnessCI.LoweredInterfaceType.getResult();
+  CanType formalResultTy = witnessCI.LoweredType.getResult();
 
   auto subs = witness.getSubstitutions();
 
@@ -286,14 +286,88 @@ static ManagedValue emitBridgeForeignBoolToBool(SILGenFunction &SGF,
   return SGF.emitManagedRValueWithCleanup(result);
 }
 
+static ManagedValue emitManagedParameter(SILGenFunction &SGF, SILLocation loc,
+                                         SILParameterInfo param,
+                                         SILValue value) {
+  const TypeLowering &valueTL = SGF.getTypeLowering(value->getType());
+
+  switch (param.getConvention()) {
+  case ParameterConvention::Direct_Owned:
+    // Consume owned parameters at +1.
+    return SGF.emitManagedRValueWithCleanup(value, valueTL);
+
+  case ParameterConvention::Direct_Guaranteed:
+  case ParameterConvention::Direct_Unowned:
+    // We need to independently retain the value.
+    return SGF.emitManagedRetain(loc, value, valueTL);
+
+  case ParameterConvention::Indirect_Inout:
+    return ManagedValue::forLValue(value);
+
+  case ParameterConvention::Indirect_In_Guaranteed:
+  case ParameterConvention::Indirect_In_Constant:
+    if (valueTL.isLoadable()) {
+      return SGF.emitLoad(loc, value, valueTL, SGFContext(), IsNotTake);
+    } else {
+      return SGF.emitManagedRetain(loc, value, valueTL);
+    }
+
+  case ParameterConvention::Indirect_In:
+    if (valueTL.isLoadable()) {
+      return SGF.emitLoad(loc, value, valueTL, SGFContext(), IsTake);
+    } else {
+      return SGF.emitManagedRValueWithCleanup(value, valueTL);
+    }
+
+  case ParameterConvention::Indirect_InoutAliasable:
+    llvm_unreachable("unexpected inout_aliasable argument");
+  }
+  llvm_unreachable("bad convention");
+}
+
+static void expandTupleTypes(CanType type, SmallVectorImpl<CanType> &results) {
+  if (auto tuple = dyn_cast<TupleType>(type)) {
+    for (auto eltType : tuple.getElementTypes())
+      expandTupleTypes(eltType, results);
+  } else {
+    results.push_back(type);
+  }
+}
+
+/// Recursively expand all the tuples in the given parameter list.
+/// Callers assume that the resulting array will line up with the
+/// SILFunctionType's parameter list, which is true as along as there
+/// aren't any indirectly-passed tuples; we should be safe from that
+/// here in the bridging code.
+static SmallVector<CanType, 8>
+expandTupleTypes(AnyFunctionType::CanParamArrayRef params) {
+  SmallVector<CanType, 8> results;
+  for (auto param : params)
+    expandTupleTypes(param.getType(), results);
+  return results;
+}
+
 static void buildFuncToBlockInvokeBody(SILGenFunction &SGF,
                                        SILLocation loc,
+                                       CanAnyFunctionType formalFuncType,
+                                       CanAnyFunctionType formalBlockType,
+                                       CanSILFunctionType funcTy,
                                        CanSILFunctionType blockTy,
-                                       CanSILBlockStorageType blockStorageTy,
-                                       CanSILFunctionType funcTy) {
+                                       CanSILBlockStorageType blockStorageTy) {
   Scope scope(SGF.Cleanups, CleanupLocation::get(loc));
   SILBasicBlock *entry = &*SGF.F.begin();
-  SILModuleConventions silConv(SGF.SGM.M);
+  SILFunctionConventions blockConv(blockTy, SGF.SGM.M);
+  SILFunctionConventions funcConv(funcTy, SGF.SGM.M);
+
+  // Set up the indirect result.
+  SILType blockResultTy = blockTy->getAllResultsType();
+  SILValue indirectResult;
+  if (blockTy->getNumResults() != 0) {
+    auto result = blockTy->getSingleResult();
+    if (result.getConvention() == ResultConvention::Indirect) {
+      indirectResult = entry->createFunctionArgument(blockResultTy);
+    }
+  }
 
   // Get the captured native function value out of the block.
   auto storageAddrTy = SILType::getPrimitiveAddressType(blockStorageTy);
@@ -303,15 +377,17 @@ static void buildFuncToBlockInvokeBody(SILGenFunction &SGF,
   auto fn = SGF.emitLoad(loc, capture, funcTL, SGFContext(), IsNotTake);
 
   // Collect the block arguments, which may have nonstandard conventions.
-  assert(blockTy->getParameters().size()
-         == funcTy->getParameters().size()
+  assert(blockTy->getParameters().size() == funcTy->getParameters().size()
          && "block and function types don't match");
+
+  auto nativeParamTypes = expandTupleTypes(formalFuncType.getParams());
+  auto bridgedParamTypes = expandTupleTypes(formalBlockType.getParams());
 
   SmallVector<ManagedValue, 4> args;
   for (unsigned i : indices(funcTy->getParameters())) {
-    auto &funcParam = funcTy->getParameters()[i];
     auto &param = blockTy->getParameters()[i];
-    SILValue v = entry->createFunctionArgument(silConv.getSILType(param));
+    SILType paramTy = blockConv.getSILType(param);
+    SILValue v = entry->createFunctionArgument(paramTy);
     ManagedValue mv;
     
     // If the parameter is a block, we need to copy it to ensure it lives on
@@ -339,60 +415,65 @@ static void buildFuncToBlockInvokeBody(SILGenFunction &SGF,
       SILValue blockCopy = SGF.B.createCopyBlock(loc, v);
       mv = SGF.emitManagedRValueWithCleanup(blockCopy);
     } else {
-      switch (param.getConvention()) {
-      case ParameterConvention::Direct_Owned:
-        // Consume owned parameters at +1.
-        mv = SGF.emitManagedRValueWithCleanup(v);
-        break;
-
-      case ParameterConvention::Direct_Guaranteed:
-      case ParameterConvention::Direct_Unowned:
-        // We need to independently retain the value.
-        mv = SGF.emitManagedRetain(loc, v);
-        break;
-
-      case ParameterConvention::Indirect_In_Guaranteed:
-      case ParameterConvention::Indirect_In:
-      case ParameterConvention::Indirect_In_Constant:
-      case ParameterConvention::Indirect_Inout:
-      case ParameterConvention::Indirect_InoutAliasable:
-        llvm_unreachable("indirect arguments to blocks not supported");
-      }
+      mv = emitManagedParameter(SGF, loc, param, v);
     }
+
+    CanType formalBridgedType = bridgedParamTypes[i];
+    CanType formalNativeType = nativeParamTypes[i];
+    SILType loweredNativeTy = funcTy->getParameters()[i].getSILStorageType();
     
-    args.push_back(SGF.emitBridgedToNativeValue(loc, mv,
-                                SILFunctionTypeRepresentation::CFunctionPointer,
-                                funcParam.getType()));
+    args.push_back(SGF.emitBridgedToNativeValue(loc, mv, formalBridgedType,
+                                                formalNativeType,
+                                                loweredNativeTy));
   }
 
-  CanType resultType;
-  SILValue indirectResult;
+  auto init = indirectResult
+                ? SGF.useBufferAsTemporary(indirectResult,
+                                SGF.getTypeLowering(indirectResult->getType()))
+                : nullptr;
 
-  if (funcTy->getNumResults() == 0)
-    resultType = TupleType::getEmpty(SGF.SGM.getASTContext());
-  else {
-    auto result = funcTy->getSingleResult();
-    resultType = result.getType();
+  CanType formalNativeResultType = formalFuncType.getResult();
+  CanType formalBridgedResultType = formalBlockType.getResult();
 
-    auto &tl = SGF.getTypeLowering(SGF.getSILType(result));
-    if (tl.isAddressOnly()) {
-      assert(result.getConvention() == ResultConvention::Indirect);
-    }
-  }
+  bool canEmitIntoInit =
+    (indirectResult &&
+     indirectResult->getType()
+       == SGF.getLoweredType(formalNativeResultType).getAddressType());
 
   // Call the native function.
+  SGFContext C(canEmitIntoInit ? init.get() : nullptr);
   ManagedValue result = SGF.emitMonomorphicApply(loc, fn, args,
-                                                 resultType,
+                                                 formalNativeResultType,
+                                                 formalNativeResultType,
                                                  ApplyOptions::None,
-                                                 None, None)
+                                                 None, None, C)
     .getAsSingleValue(SGF, loc);
 
   // Bridge the result back to ObjC.
-  result = SGF.emitNativeToBridgedValue(
-      loc, result, SILFunctionTypeRepresentation::CFunctionPointer,
-      blockTy->getDirectFormalResultsType().getSwiftRValueType());
+  if (!canEmitIntoInit) {
+    result = SGF.emitNativeToBridgedValue(loc, result,
+                                          formalNativeResultType,
+                                          formalBridgedResultType,
+                                          blockResultTy,
+                                          SGFContext(init.get()));
+  }
 
-  auto resultVal = result.forward(SGF);
+  SILValue resultVal;
+
+  // If we have an indirect result, make sure the result is there.
+  if (indirectResult) {
+    if (!result.isInContext()) {
+      init->copyOrInitValueInto(SGF, loc, result, /*isInit*/ true);
+      init->finishInitialization(SGF);
+    }
+    init->getManagedAddress().forward(SGF);
+    resultVal = SGF.B.createTuple(loc, {});
+
+  // Otherwise, return the result at +1.
+  } else {
+    resultVal = result.forward(SGF);
+  }
+
   scope.pop();
 
   SGF.B.createReturn(loc, resultVal);
@@ -401,16 +482,19 @@ static void buildFuncToBlockInvokeBody(SILGenFunction &SGF,
 /// Bridge a native function to a block with a thunk.
 ManagedValue SILGenFunction::emitFuncToBlock(SILLocation loc,
                                              ManagedValue fn,
-                                             CanSILFunctionType blockTy) {
+                                             CanAnyFunctionType funcType,
+                                             CanAnyFunctionType blockType,
+                                             CanSILFunctionType loweredBlockTy){
+  auto loweredFuncTy = fn.getType().castTo<SILFunctionType>();
+
   // Build the invoke function signature. The block will capture the original
   // function value.
-  auto fnTy = fn.getType().castTo<SILFunctionType>();
   auto fnInterfaceTy = cast<SILFunctionType>(
-    F.mapTypeOutOfContext(fnTy)->getCanonicalType());
+    F.mapTypeOutOfContext(loweredFuncTy)->getCanonicalType());
   auto blockInterfaceTy = cast<SILFunctionType>(
-    F.mapTypeOutOfContext(blockTy)->getCanonicalType());
+    F.mapTypeOutOfContext(loweredBlockTy)->getCanonicalType());
 
-  auto storageTy = SILBlockStorageType::get(fnTy);
+  auto storageTy = SILBlockStorageType::get(loweredFuncTy);
   auto storageInterfaceTy = SILBlockStorageType::get(fnInterfaceTy);
 
   // Build the invoke function type.
@@ -428,7 +512,7 @@ ManagedValue SILGenFunction::emitFuncToBlock(SILLocation loc,
   CanGenericSignature genericSig;
   GenericEnvironment *genericEnv = nullptr;
   SubstitutionList subs;
-  if (fnTy->hasArchetype() || blockTy->hasArchetype()) {
+  if (funcType->hasArchetype() || blockType->hasArchetype()) {
     genericSig = F.getLoweredFunctionType()->getGenericSignature();
     genericEnv = F.getGenericEnvironment();
 
@@ -455,8 +539,8 @@ ManagedValue SILGenFunction::emitFuncToBlock(SILLocation loc,
   // thunks, which is what we are in spirit.
   auto thunk = SGM.getOrCreateReabstractionThunk(genericEnv,
                                                  invokeTy,
-                                                 fnTy,
-                                                 blockTy,
+                                                 loweredFuncTy,
+                                                 loweredBlockTy,
                                                  F.isSerialized());
 
   // Build it if necessary.
@@ -464,7 +548,8 @@ ManagedValue SILGenFunction::emitFuncToBlock(SILLocation loc,
     thunk->setGenericEnvironment(genericEnv);
     SILGenFunction thunkSGF(SGM, *thunk);
     auto loc = RegularLocation::getAutoGeneratedLocation();
-    buildFuncToBlockInvokeBody(thunkSGF, loc, blockTy, storageTy, fnTy);
+    buildFuncToBlockInvokeBody(thunkSGF, loc, funcType, blockType,
+                               loweredFuncTy, loweredBlockTy, storageTy);
   }
 
   // Form the block on the stack.
@@ -475,8 +560,8 @@ ManagedValue SILGenFunction::emitFuncToBlock(SILLocation loc,
   auto invokeFn = B.createFunctionRef(loc, thunk);
   
   auto stackBlock = B.createInitBlockStorageHeader(loc, storage, invokeFn,
-                                      SILType::getPrimitiveObjectType(blockTy),
-                                      subs);
+                              SILType::getPrimitiveObjectType(loweredBlockTy),
+                                                   subs);
 
   // Copy the block so we have an independent heap object we can hand off.
   auto heapBlock = B.createCopyBlock(loc, stackBlock);
@@ -486,26 +571,28 @@ ManagedValue SILGenFunction::emitFuncToBlock(SILLocation loc,
 static ManagedValue emitNativeToCBridgedNonoptionalValue(SILGenFunction &SGF,
                                                          SILLocation loc,
                                                          ManagedValue v,
-                                                         SILType bridgedTy,
+                                                         CanType nativeType,
+                                                         CanType bridgedType,
+                                                      SILType loweredBridgedTy,
                                                          SGFContext C) {
-  CanType loweredBridgedTy = bridgedTy.getSwiftRValueType();
-  CanType loweredNativeTy = v.getType().getSwiftRValueType();
-  if (loweredNativeTy == loweredBridgedTy)
+  assert(loweredBridgedTy.isObject());
+  if (v.getType().getObjectType() == loweredBridgedTy)
     return v;
 
   // If the input is a native type with a bridged mapping, convert it.
 #define BRIDGE_TYPE(BridgedModule,BridgedType, NativeModule,NativeType,Opt) \
-  if (loweredNativeTy == SGF.SGM.Types.get##NativeType##Type()              \
-      && loweredBridgedTy == SGF.SGM.Types.get##BridgedType##Type()) {      \
+  if (nativeType == SGF.SGM.Types.get##NativeType##Type()                   \
+      && bridgedType == SGF.SGM.Types.get##BridgedType##Type()) {           \
     return emitBridge##NativeType##To##BridgedType(SGF, loc, v);            \
   }
 #include "swift/SIL/BridgedTypes.def"
 
   // Bridge thick to Objective-C metatypes.
-  if (auto bridgedMetaTy = dyn_cast<AnyMetatypeType>(loweredBridgedTy)) {
-    if (bridgedMetaTy->getRepresentation() == MetatypeRepresentation::ObjC) {
+  if (auto bridgedMetaTy = dyn_cast<AnyMetatypeType>(bridgedType)) {
+    if (bridgedMetaTy->hasRepresentation() &&
+        bridgedMetaTy->getRepresentation() == MetatypeRepresentation::ObjC) {
       SILValue native = SGF.B.emitThickToObjCMetatype(loc, v.getValue(),
-                           SILType::getPrimitiveObjectType(loweredBridgedTy));
+                                                      loweredBridgedTy);
       // *NOTE*: ObjCMetatypes are trivial types. They only gain ARC semantics
       // when they are converted to an object via objc_metatype_to_object.
       assert(!v.hasCleanup() &&
@@ -515,52 +602,54 @@ static ManagedValue emitNativeToCBridgedNonoptionalValue(SILGenFunction &SGF,
   }
 
   // Bridge native functions to blocks.
-  auto bridgedFTy = dyn_cast<SILFunctionType>(loweredBridgedTy);
-  if (bridgedFTy
-      && bridgedFTy->getRepresentation() == SILFunctionType::Representation::Block){
-    auto nativeFTy = cast<SILFunctionType>(loweredNativeTy);
+  auto bridgedFTy = dyn_cast<AnyFunctionType>(bridgedType);
+  if (bridgedFTy && bridgedFTy->getRepresentation()
+                      == AnyFunctionType::Representation::Block) {
+    auto nativeFTy = cast<AnyFunctionType>(nativeType);
 
-    if (nativeFTy->getRepresentation() != SILFunctionType::Representation::Block)
-      return SGF.emitFuncToBlock(loc, v, bridgedFTy);
+    if (nativeFTy->getRepresentation()
+          != AnyFunctionType::Representation::Block)
+      return SGF.emitFuncToBlock(loc, v, nativeFTy, bridgedFTy,
+                                 loweredBridgedTy.castTo<SILFunctionType>());
   }
 
   // If the native type conforms to _ObjectiveCBridgeable, use its
   // _bridgeToObjectiveC witness.
   if (auto conformance =
-          SGF.SGM.getConformanceToObjectiveCBridgeable(loc, loweredNativeTy)) {
-    if (auto result = emitBridgeNativeToObjectiveC(SGF, loc, v, bridgedTy,
-                                                   conformance))
+          SGF.SGM.getConformanceToObjectiveCBridgeable(loc, nativeType)) {
+    if (auto result = emitBridgeNativeToObjectiveC(SGF, loc, v, nativeType,
+                                                   bridgedType, conformance))
       return *result;
 
     assert(SGF.SGM.getASTContext().Diags.hadAnyError() &&
            "Bridging code should have complained");
-    return SGF.emitUndef(loc, bridgedTy);
+    return SGF.emitUndef(loc, bridgedType);
   }
 
   // Bridge Error, or types that conform to it, to NSError.
-  if (shouldBridgeThroughError(SGF.SGM, loweredNativeTy, loweredBridgedTy)) {
+  if (shouldBridgeThroughError(SGF.SGM, nativeType, bridgedType)) {
     auto errorTy = SGF.SGM.Types.getNSErrorType();
-    auto error = SGF.emitNativeToBridgedError(loc, v, errorTy);
-    if (errorTy != loweredBridgedTy) {
-      error = emitUnabstractedCast(SGF, loc, error, loweredBridgedTy);
+    auto error = SGF.emitNativeToBridgedError(loc, v, nativeType, errorTy);
+    if (errorTy != bridgedType) {
+      error = emitUnabstractedCast(SGF, loc, error, errorTy, bridgedType);
     }
     return error;
   }
 
   // Fall back to dynamic Any-to-id bridging.
   // The destination type should be AnyObject in this case.
-  assert(loweredBridgedTy->isEqual(SGF.getASTContext().getAnyObjectType()));
+  assert(bridgedType->isEqual(SGF.getASTContext().getAnyObjectType()));
 
   // If the input argument is known to be an existential, save the runtime
   // some work by opening it.
-  if (loweredNativeTy->isExistentialType()) {
-    auto openedTy = ArchetypeType::getOpened(loweredNativeTy);
+  if (nativeType->isExistentialType()) {
+    auto openedType = ArchetypeType::getOpened(nativeType);
 
     auto openedExistential = SGF.emitOpenExistential(
-        loc, v, openedTy, SGF.getLoweredType(openedTy), AccessKind::Read);
+        loc, v, openedType, SGF.getLoweredType(openedType), AccessKind::Read);
 
     v = SGF.manageOpaqueValue(openedExistential, loc, SGFContext());
-    loweredNativeTy = openedTy;
+    nativeType = openedType;
   }
 
   // Call into the stdlib intrinsic.
@@ -569,9 +658,14 @@ static ManagedValue emitNativeToCBridgedNonoptionalValue(SILGenFunction &SGF,
     auto *genericSig = bridgeAnything->getGenericSignature();
     auto subMap = genericSig->getSubstitutionMap(
       [&](SubstitutableType *t) -> Type {
-        return loweredNativeTy;
+        return nativeType;
       },
       MakeAbstractConformanceForGenericType());
+
+    // The intrinsic takes a T; reabstract to the generic abstraction
+    // pattern.
+    v = SGF.emitSubstToOrigValue(loc, v, AbstractionPattern::getOpaque(),
+                                 nativeType);
 
     // Put the value into memory if necessary.
     assert(v.getType().isTrivial(SGF.SGM.M) || v.hasCleanup());
@@ -585,97 +679,106 @@ static ManagedValue emitNativeToCBridgedNonoptionalValue(SILGenFunction &SGF,
   }
   
   // Shouldn't get here unless the standard library is busted.
-  return SGF.emitUndef(loc, bridgedTy);
+  return SGF.emitUndef(loc, loweredBridgedTy);
 }
 
 static ManagedValue emitNativeToCBridgedValue(SILGenFunction &SGF,
                                               SILLocation loc,
                                               ManagedValue v,
-                                              SILType bridgedTy,
+                                              CanType nativeType,
+                                              CanType bridgedType,
+                                              SILType loweredBridgedTy,
                                               SGFContext C = SGFContext()) {
-  CanType loweredBridgedTy = bridgedTy.getSwiftRValueType();
-  CanType loweredNativeTy = v.getType().getSwiftRValueType();
-  if (loweredNativeTy == loweredBridgedTy)
+  SILType loweredNativeTy = v.getType();
+  if (loweredNativeTy.getObjectType() == loweredBridgedTy.getObjectType())
     return v;
 
-  if (loweredBridgedTy.getAnyOptionalObjectType()
-      && loweredNativeTy.getAnyOptionalObjectType()) {
-    return SGF.emitOptionalToOptional(loc, v, bridgedTy,
-                                      emitNativeToCBridgedValue, C);
+  CanType bridgedObjectType = bridgedType.getAnyOptionalObjectType();
+  CanType nativeObjectType = nativeType.getAnyOptionalObjectType();
+
+  // Check for optional-to-optional conversions.
+  if (bridgedObjectType && nativeObjectType) {
+    auto helper = [&](SILGenFunction &SGF, SILLocation loc,
+                      ManagedValue v, SILType loweredBridgedObjectTy,
+                      SGFContext C) {
+      return emitNativeToCBridgedValue(SGF, loc, v, nativeObjectType,
+                                       bridgedObjectType,
+                                       loweredBridgedObjectTy, C);
+    };
+    return SGF.emitOptionalToOptional(loc, v, loweredBridgedTy, helper, C);
   }
   
   // Check if we need to wrap the bridged result in an optional.
-  if (SILType bridgedObjectType = bridgedTy.getAnyOptionalObjectType()) {
-    auto bridgedPayload
-      = emitNativeToCBridgedNonoptionalValue(SGF, loc, v, bridgedObjectType,
-                                             SGFContext());
-    
-    return SGF.getOptionalSomeValue(loc, bridgedPayload,
-                                    SGF.getTypeLowering(bridgedTy));
+  if (bridgedObjectType) {
+    auto helper = [&](SILGenFunction &SGF, SILLocation loc, SGFContext C) {
+      auto loweredBridgedObjectTy = loweredBridgedTy.getAnyOptionalObjectType();
+      return emitNativeToCBridgedValue(SGF, loc, v, nativeType,
+                                       bridgedObjectType,
+                                       loweredBridgedObjectTy, C);
+    };
+    return SGF.emitOptionalSome(loc, loweredBridgedTy, helper, C);
   }
   
-  return emitNativeToCBridgedNonoptionalValue(SGF, loc, v, bridgedTy, C);
+  return emitNativeToCBridgedNonoptionalValue(SGF, loc, v, nativeType,
+                                              bridgedType, loweredBridgedTy, C);
 }
 
 ManagedValue SILGenFunction::emitNativeToBridgedValue(SILLocation loc,
-                                          ManagedValue v,
-                                          SILFunctionTypeRepresentation destRep,
-                                          CanType loweredBridgedTy,
-                                          SGFContext C) {
-  switch (getSILFunctionLanguage(destRep)) {
-  case SILFunctionLanguage::Swift:
-    // No additional bridging needed for native functions.
-    return v;
-  case SILFunctionLanguage::C:
-    return emitNativeToCBridgedValue(*this, loc, v,
-                           SILType::getPrimitiveObjectType(loweredBridgedTy),
-                                     C);
-  }
-  llvm_unreachable("bad CC");
+                                                      ManagedValue v,
+                                                      CanType nativeTy,
+                                                      CanType bridgedTy,
+                                                      SILType loweredBridgedTy,
+                                                      SGFContext C) {
+  loweredBridgedTy = loweredBridgedTy.getObjectType();
+  return emitNativeToCBridgedValue(*this, loc, v, nativeTy, bridgedTy,
+                                   loweredBridgedTy, C);
 }
 
 static void buildBlockToFuncThunkBody(SILGenFunction &SGF,
                                       SILLocation loc,
+                                      CanAnyFunctionType formalBlockTy,
+                                      CanAnyFunctionType formalFuncTy,
                                       CanSILFunctionType blockTy,
                                       CanSILFunctionType funcTy) {
   // Collect the native arguments, which should all be +1.
   Scope scope(SGF.Cleanups, CleanupLocation::get(loc));
 
-  assert(blockTy->getParameters().size()
-           == funcTy->getParameters().size()
+  assert(blockTy->getNumParameters() == funcTy->getNumParameters()
          && "block and function types don't match");
 
   SmallVector<ManagedValue, 4> args;
   SILBasicBlock *entry = &*SGF.F.begin();
 
-  CanType resultType;
-  SILValue indirectResult;
-
   SILFunctionConventions fnConv(funcTy, SGF.SGM.M);
-  if (funcTy->getNumResults() == 0)
-    resultType = TupleType::getEmpty(SGF.SGM.getASTContext());
-  else {
+
+  // Set up the indirect result slot.
+  SILValue indirectResult;
+  if (funcTy->getNumResults() != 0) {
     auto result = funcTy->getSingleResult();
-    resultType = result.getType();
-
-    auto &tl = SGF.getTypeLowering(resultType);
-    if (tl.isAddressOnly()) {
-      assert(result.getConvention() == ResultConvention::Indirect);
-
-      indirectResult = entry->createFunctionArgument(fnConv.getSILType(result));
+    if (result.getConvention() == ResultConvention::Indirect) {
+      SILType resultTy = fnConv.getSILType(result);
+      indirectResult = entry->createFunctionArgument(resultTy);
     }
   }
 
+  auto formalBlockParams = expandTupleTypes(formalBlockTy.getParams());
+  auto formalFuncParams = expandTupleTypes(formalFuncTy.getParams());
+  assert(formalBlockParams.size() == blockTy->getNumParameters());
+  assert(formalFuncParams.size() == funcTy->getNumParameters());
+
   for (unsigned i : indices(funcTy->getParameters())) {
     auto &param = funcTy->getParameters()[i];
-    auto &blockParam = blockTy->getParameters()[i];
+    CanType formalBlockParamTy = formalBlockParams[i];
+    CanType formalFuncParamTy = formalFuncParams[i];
 
-    auto &tl = SGF.getTypeLowering(param.getType());
-    SILValue v = entry->createFunctionArgument(fnConv.getSILType(param));
-    auto mv = SGF.emitManagedRValueWithCleanup(v, tl);
-    args.push_back(SGF.emitNativeToBridgedValue(loc, mv,
-                              SILFunctionTypeRepresentation::Block,
-                              blockParam.getType()));
+    auto paramTy = fnConv.getSILType(param);
+    SILValue v = entry->createFunctionArgument(paramTy);
+    auto mv = emitManagedParameter(SGF, loc, param, v);
+
+    SILType loweredBlockArgTy = blockTy->getParameters()[i].getSILStorageType();
+    args.push_back(SGF.emitNativeToBridgedValue(loc, mv, formalFuncParamTy,
+                                                formalBlockParamTy,
+                                                loweredBlockArgTy));
   }
 
   // Add the block argument.
@@ -683,25 +786,41 @@ static void buildBlockToFuncThunkBody(SILGenFunction &SGF,
       entry->createFunctionArgument(SILType::getPrimitiveObjectType(blockTy));
   ManagedValue block = SGF.emitManagedRValueWithCleanup(blockV);
 
+  CanType formalResultType = formalFuncTy.getResult();
+
+  auto init = indirectResult
+                ? SGF.useBufferAsTemporary(indirectResult,
+                                SGF.getTypeLowering(indirectResult->getType()))
+                : nullptr;
+
   // Call the block.
-  // TODO: Emit directly into the indirect result.
   ManagedValue result = SGF.emitMonomorphicApply(loc, block, args,
-                           resultType,
+                           formalBlockTy.getResult(),
+                           formalResultType,
                            ApplyOptions::None,
                            /*override CC*/ SILFunctionTypeRepresentation::Block,
-                           /*foreign error*/ None)
+                           /*foreign error*/ None,
+                           SGFContext(init.get()))
     .getAsSingleValue(SGF, loc);
 
-  // Return the result at +1.
-  auto r = result.forward(SGF);
+  SILValue r;
 
+  // If we have an indirect result, make sure the result is there.
   if (indirectResult) {
-    SGF.B.createCopyAddr(loc, r, indirectResult,
-                         IsTake, IsInitialization);
+    if (!result.isInContext()) {
+      init->copyOrInitValueInto(SGF, loc, result, /*isInit*/ true);
+      init->finishInitialization(SGF);
+    }
+    init->getManagedAddress().forward(SGF);
     r = SGF.B.createTuple(loc, fnConv.getSILResultType(), {});
+
+  // Otherwise, return the result at +1.
+  } else {
+    r = result.forward(SGF);
   }
 
   scope.pop();
+
   SGF.B.createReturn(loc, r);
 }
 
@@ -709,9 +828,11 @@ static void buildBlockToFuncThunkBody(SILGenFunction &SGF,
 ManagedValue
 SILGenFunction::emitBlockToFunc(SILLocation loc,
                                 ManagedValue block,
-                                CanSILFunctionType funcTy) {
+                                CanAnyFunctionType blockType,
+                                CanAnyFunctionType funcType,
+                                CanSILFunctionType loweredFuncTy) {
   // Declare the thunk.
-  auto blockTy = block.getType().castTo<SILFunctionType>();
+  auto loweredBlockTy = block.getType().castTo<SILFunctionType>();
 
   SubstitutionMap contextSubs, interfaceSubs;
   GenericEnvironment *genericEnv = nullptr;
@@ -721,14 +842,14 @@ SILGenFunction::emitBlockToFunc(SILLocation loc,
   // type
   CanType inputSubstType, outputSubstType;
 
-  auto thunkTy = buildThunkType(blockTy, funcTy,
+  auto thunkTy = buildThunkType(loweredBlockTy, loweredFuncTy,
                                 inputSubstType, outputSubstType,
                                 genericEnv, interfaceSubs);
 
   auto thunk = SGM.getOrCreateReabstractionThunk(genericEnv,
                                                  thunkTy,
-                                                 blockTy,
-                                                 funcTy,
+                                                 loweredBlockTy,
+                                                 loweredFuncTy,
                                                  F.isSerialized());
 
   // Build it if necessary.
@@ -736,7 +857,8 @@ SILGenFunction::emitBlockToFunc(SILLocation loc,
     SILGenFunction thunkSGF(SGM, *thunk);
     thunk->setGenericEnvironment(genericEnv);
     auto loc = RegularLocation::getAutoGeneratedLocation();
-    buildBlockToFuncThunkBody(thunkSGF, loc, blockTy, funcTy);
+    buildBlockToFuncThunkBody(thunkSGF, loc, blockType, funcType,
+                              loweredBlockTy, loweredFuncTy);
   }
 
   CanSILFunctionType substFnTy = thunkTy;
@@ -753,42 +875,68 @@ SILGenFunction::emitBlockToFunc(SILLocation loc,
   auto thunkedFn = B.createPartialApply(loc, thunkValue,
                                     SILType::getPrimitiveObjectType(substFnTy),
                                     subs, block.forward(*this),
-                                    SILType::getPrimitiveObjectType(funcTy));
+                                SILType::getPrimitiveObjectType(loweredFuncTy));
   return emitManagedRValueWithCleanup(thunkedFn);
 }
 
 static ManagedValue emitCBridgedToNativeValue(SILGenFunction &SGF,
                                               SILLocation loc,
                                               ManagedValue v,
-                                              SILType nativeTy,
+                                              CanType bridgedType,
+                                              CanType nativeType,
+                                              SILType loweredNativeTy,
+                                              bool isCallResult,
                                               SGFContext C) {
-  CanType loweredNativeTy = nativeTy.getSwiftRValueType();
-  CanType loweredBridgedTy = v.getType().getSwiftRValueType();
-  if (loweredNativeTy == loweredBridgedTy)
+  assert(loweredNativeTy.isObject());
+  SILType loweredBridgedTy = v.getType();
+  if (loweredNativeTy == loweredBridgedTy.getObjectType())
     return v;
 
-  if (loweredNativeTy.getAnyOptionalObjectType()) {
-    return SGF.emitOptionalToOptional(loc, v, nativeTy,
-                                      emitCBridgedToNativeValue, C);
+  if (auto nativeObjectType = nativeType.getAnyOptionalObjectType()) {
+    auto bridgedObjectType = bridgedType.getAnyOptionalObjectType();
+
+    // Optional injection.
+    if (!bridgedObjectType) {
+      auto helper = [&](SILGenFunction &SGF, SILLocation loc, SGFContext C) {
+        auto loweredNativeObjectTy = loweredNativeTy.getAnyOptionalObjectType();
+        return emitCBridgedToNativeValue(SGF, loc, v, bridgedType,
+                                         nativeObjectType,
+                                         loweredNativeObjectTy,
+                                         isCallResult, C);
+      };
+      return SGF.emitOptionalSome(loc, loweredNativeTy, helper, C);
+    }
+
+    // Optional-to-optional.
+    auto helper =
+        [=](SILGenFunction &SGF, SILLocation loc, ManagedValue v,
+            SILType loweredNativeObjectTy, SGFContext C) {
+      return emitCBridgedToNativeValue(SGF, loc, v, bridgedObjectType,
+                                       nativeObjectType, loweredNativeObjectTy,
+                                       isCallResult, C);
+    };
+    return SGF.emitOptionalToOptional(loc, v, loweredNativeTy, helper, C);
   }
 
   // Bridge Bool to ObjCBool or DarwinBoolean when requested.
-  if (loweredNativeTy == SGF.SGM.Types.getBoolType()) {
-    if (loweredBridgedTy == SGF.SGM.Types.getObjCBoolType()) {
+  if (nativeType == SGF.SGM.Types.getBoolType()) {
+    if (bridgedType == SGF.SGM.Types.getObjCBoolType()) {
       return emitBridgeForeignBoolToBool(SGF, loc, v,
                                          SGF.SGM.getObjCBoolToBoolFn());
     }
-    if (loweredBridgedTy == SGF.SGM.Types.getDarwinBooleanType()) {
+    if (bridgedType == SGF.SGM.Types.getDarwinBooleanType()) {
       return emitBridgeForeignBoolToBool(SGF, loc, v,
                                          SGF.SGM.getDarwinBooleanToBoolFn());
     }
   }
 
   // Bridge Objective-C to thick metatypes.
-  if (auto bridgedMetaTy = dyn_cast<AnyMetatypeType>(loweredBridgedTy)){
-    if (bridgedMetaTy->getRepresentation() == MetatypeRepresentation::ObjC) {
-      SILValue native = SGF.B.emitObjCToThickMetatype(loc, v.getValue(),
-                                        SGF.getLoweredType(loweredNativeTy));
+  if (auto nativeMetaTy = dyn_cast<AnyMetatypeType>(nativeType)) {
+    auto bridgedMetaTy = cast<AnyMetatypeType>(bridgedType);
+    if (bridgedMetaTy->hasRepresentation() &&
+        bridgedMetaTy->getRepresentation() == MetatypeRepresentation::ObjC) {
+      SILValue native =
+        SGF.B.emitObjCToThickMetatype(loc, v.getValue(), loweredNativeTy);
       // *NOTE*: ObjCMetatypes are trivial types. They only gain ARC semantics
       // when they are converted to an object via objc_metatype_to_object.
       assert(!v.hasCleanup() && "Metatypes are trivial and should not have "
@@ -798,34 +946,47 @@ static ManagedValue emitCBridgedToNativeValue(SILGenFunction &SGF,
   }
 
   // Bridge blocks back into native function types.
-  auto bridgedFTy = dyn_cast<SILFunctionType>(loweredBridgedTy);
-  if (bridgedFTy
-      && bridgedFTy->getRepresentation() == SILFunctionType::Representation::Block){
-    auto nativeFTy = cast<SILFunctionType>(loweredNativeTy);
-
-    if (nativeFTy->getRepresentation() != SILFunctionType::Representation::Block)
-      return SGF.emitBlockToFunc(loc, v, nativeFTy);
+  if (auto nativeFTy = dyn_cast<AnyFunctionType>(nativeType)) {
+    auto bridgedFTy = cast<AnyFunctionType>(bridgedType);
+    if (bridgedFTy->getRepresentation()
+          == AnyFunctionType::Representation::Block
+        && nativeFTy->getRepresentation()
+          != AnyFunctionType::Representation::Block) {
+      return SGF.emitBlockToFunc(loc, v, bridgedFTy, nativeFTy,
+                                 loweredNativeTy.castTo<SILFunctionType>());
+    }
   }
 
   // Bridge via _ObjectiveCBridgeable.
   if (auto conformance =
-        SGF.SGM.getConformanceToObjectiveCBridgeable(loc, loweredNativeTy)) {
-    if (auto result = emitBridgeObjectiveCToNative(SGF, loc, v, conformance))
+        SGF.SGM.getConformanceToObjectiveCBridgeable(loc, nativeType)) {
+    if (auto result = emitBridgeObjectiveCToNative(SGF, loc, v, bridgedType,
+                                                   conformance))
       return *result;
 
     assert(SGF.SGM.getASTContext().Diags.hadAnyError() &&
            "Bridging code should have complained");
-    return SGF.emitUndef(loc, nativeTy);
+    return SGF.emitUndef(loc, nativeType);
   }
 
-  // Bridge NSError to Error.
-  if (loweredBridgedTy == SGF.SGM.Types.getNSErrorType())
-    return SGF.emitBridgedToNativeError(loc, v);
-
   // id-to-Any bridging.
-  if (loweredNativeTy->isAny()) {
-    assert(loweredBridgedTy->isEqual(SGF.getASTContext().getAnyObjectType())
-           && "Any should bridge to AnyObject");
+  if (nativeType->isAny()) {
+    // If this is not a call result, use the normal erasure logic.
+    if (!isCallResult) {
+      return SGF.emitTransformedValue(loc, v, bridgedType, nativeType, C);
+    }
+
+    // Otherwise, we use more complicated logic that handles results that
+    // were unexpetedly null.
+
+    assert(bridgedType.isAnyClassReferenceType());
+
+    // Convert to AnyObject if necessary.
+    CanType anyObjectTy =
+      SGF.getASTContext().getAnyObjectType()->getCanonicalType();
+    if (bridgedType != anyObjectTy) {
+      v = SGF.emitTransformedValue(loc, v, bridgedType, anyObjectTy);
+    }
 
     // TODO: Ever need to handle +0 values here?
     assert(v.hasCleanup());
@@ -836,10 +997,9 @@ static ManagedValue emitCBridgedToNativeValue(SILGenFunction &SGF,
     
     // Bitcast to Optional. This provides a barrier to the optimizer to prevent
     // it from attempting to eliminate null checks.
-    auto optionalBridgedTy = OptionalType::get(loweredBridgedTy)
-      ->getCanonicalType();
-    auto optionalV = SGF.B.createUncheckedBitCast(loc, v.getValue(),
-                          SILType::getPrimitiveObjectType(optionalBridgedTy));
+    auto optionalBridgedTy = SILType::getOptionalType(loweredBridgedTy);
+    auto optionalV =
+      SGF.B.createUncheckedBitCast(loc, v.getValue(), optionalBridgedTy);
     auto optionalMV = ManagedValue(optionalV, v.getCleanup());
     return SGF.emitApplyOfLibraryIntrinsic(loc,
                            SGF.getASTContext().getBridgeAnyObjectToAny(nullptr),
@@ -847,23 +1007,23 @@ static ManagedValue emitCBridgedToNativeValue(SILGenFunction &SGF,
               .getAsSingleValue(SGF, loc);
   }
 
+  // Bridge NSError to Error.
+  if (bridgedType == SGF.SGM.Types.getNSErrorType())
+    return SGF.emitBridgedToNativeError(loc, v);
+
   return v;
 }
 
 ManagedValue SILGenFunction::emitBridgedToNativeValue(SILLocation loc,
-                                          ManagedValue v,
-                                          SILFunctionTypeRepresentation srcRep,
-                                          CanType nativeTy,
-                                          SGFContext C) {
-  switch (getSILFunctionLanguage(srcRep)) {
-  case SILFunctionLanguage::Swift:
-    // No additional bridging needed for native functions.
-    return v;
-
-  case SILFunctionLanguage::C:
-    return emitCBridgedToNativeValue(*this, loc, v, getLoweredType(nativeTy), C);
-  }
-  llvm_unreachable("bad CC");
+                                                      ManagedValue v,
+                                                      CanType bridgedType,
+                                                      CanType nativeType,
+                                                      SILType loweredNativeTy,
+                                                      SGFContext C,
+                                                      bool isCallResult) {
+  loweredNativeTy = loweredNativeTy.getObjectType();
+  return emitCBridgedToNativeValue(*this, loc, v, bridgedType, nativeType,
+                                   loweredNativeTy, isCallResult, C);
 }
 
 /// Bridge a possibly-optional foreign error type to Error.
@@ -907,17 +1067,33 @@ ManagedValue SILGenFunction::emitBridgedToNativeError(SILLocation loc,
 
 /// Bridge Error to a foreign error type.
 ManagedValue SILGenFunction::emitNativeToBridgedError(SILLocation loc,
-                                                  ManagedValue nativeError,
-                                                  CanType bridgedErrorProto) {
-  assert(bridgedErrorProto == SGM.Types.getNSErrorType() &&
+                                                      ManagedValue nativeError,
+                                                      CanType nativeType,
+                                                      CanType bridgedErrorType){
+  // Handle injections into optional.
+  if (auto bridgedObjectType = bridgedErrorType.getAnyOptionalObjectType()) {
+    auto loweredBridgedOptionalTy =
+      SILType::getPrimitiveObjectType(bridgedErrorType);
+    return emitOptionalSome(loc, loweredBridgedOptionalTy,
+                            [&](SILGenFunction &SGF, SILLocation loc,
+                                SGFContext C) {
+      SILType loweredBridgedObjectTy =
+        loweredBridgedOptionalTy.getAnyOptionalObjectType();
+      return emitNativeToBridgedValue(loc, nativeError, nativeType,
+                                      bridgedObjectType,
+                                      loweredBridgedObjectTy);
+    });
+  }
+
+  assert(bridgedErrorType == SGM.Types.getNSErrorType() &&
          "only handling NSError for now");
 
   // The native error might just be a value of a type that conforms to
   // Error.  This should be a subtyping or erasure conversion of the sort
   // that we can do automatically.
   // FIXME: maybe we should use a different entrypoint for this case, to
-  // avoid the code size and performance overhead?
-  nativeError = emitUnabstractedCast(*this, loc, nativeError,
+  // avoid the code size and performance overhead of forming the box?
+  nativeError = emitUnabstractedCast(*this, loc, nativeError, nativeType,
                                      getASTContext().getExceptionType());
 
   auto bridgeFn = emitGlobalFunctionRef(loc, SGM.getErrorToNSErrorFn());
@@ -926,12 +1102,13 @@ ManagedValue SILGenFunction::emitNativeToBridgedError(SILLocation loc,
   assert(bridgeFnType->getNumResults() == 1);
   assert(bridgeFnType->getResults()[0].getConvention()
          == ResultConvention::Owned);
-  auto bridgeErrorType = bridgeFnConv.getSILType(bridgeFnType->getResults()[0]);
+  auto loweredBridgedErrorType =
+    bridgeFnConv.getSILType(bridgeFnType->getResults()[0]);
   assert(bridgeFnType->getParameters()[0].getConvention()
            == ParameterConvention::Direct_Owned);
 
   SILValue bridgedError = B.createApply(loc, bridgeFn, bridgeFn->getType(),
-                                        bridgeErrorType, {},
+                                        loweredBridgedErrorType, {},
                                         nativeError.forward(*this));
   return emitManagedRValueWithCleanup(bridgedError);
 }
@@ -943,13 +1120,15 @@ ManagedValue SILGenFunction::emitNativeToBridgedError(SILLocation loc,
 static SILValue emitBridgeReturnValue(SILGenFunction &SGF,
                                       SILLocation loc,
                                       SILValue result,
-                                      SILFunctionTypeRepresentation fnTypeRepr,
-                                      CanType bridgedTy) {
+                                      CanType formalNativeTy,
+                                      CanType formalBridgedTy,
+                                      SILType loweredBridgedTy) {
   Scope scope(SGF.Cleanups, CleanupLocation::get(loc));
 
   ManagedValue native = SGF.emitManagedRValueWithCleanup(result);
-  ManagedValue bridged = SGF.emitNativeToBridgedValue(loc, native, fnTypeRepr,
-                                      bridgedTy);
+  ManagedValue bridged =
+    SGF.emitNativeToBridgedValue(loc, native, formalNativeTy, formalBridgedTy,
+                                 loweredBridgedTy);
   return bridged.forward(SGF);
 }
 
@@ -968,22 +1147,36 @@ static SILValue emitObjCUnconsumedArgument(SILGenFunction &SGF,
   return lowering.emitCopyValue(SGF.B, loc, arg);
 }
 
+static CanAnyFunctionType substGenericArgs(CanAnyFunctionType fnType,
+                                           const SubstitutionList &subs) {
+  if (auto genericFnType = dyn_cast<GenericFunctionType>(fnType)) {
+    return cast<FunctionType>(genericFnType->substGenericArgs(subs)
+                                           ->getCanonicalType());
+  }
+  return fnType;
+}
+
 /// Bridge argument types and adjust retain count conventions for an ObjC thunk.
 static SILFunctionType *emitObjCThunkArguments(SILGenFunction &SGF,
                                                SILLocation loc,
                                                SILDeclRef thunk,
                                                SmallVectorImpl<SILValue> &args,
                                                SILValue &foreignErrorSlot,
-                              Optional<ForeignErrorConvention> &foreignError) {
+                              Optional<ForeignErrorConvention> &foreignError,
+                                               CanType &nativeFormalResultTy,
+                                               CanType &bridgedFormalResultTy) {
   SILDeclRef native = thunk.asForeign(false);
 
   auto subs = SGF.F.getForwardingSubstitutions();
 
   auto objcInfo = SGF.SGM.Types.getConstantInfo(thunk);
   auto objcFnTy = objcInfo.SILFnType->substGenericArgs(SGF.SGM.M, subs);
+  auto objcFormalFnTy = substGenericArgs(objcInfo.LoweredType, subs);
 
   auto swiftInfo = SGF.SGM.Types.getConstantInfo(native);
   auto swiftFnTy = swiftInfo.SILFnType->substGenericArgs(SGF.SGM.M, subs);
+  auto swiftFormalFnTy = substGenericArgs(swiftInfo.LoweredType, subs);
+  SILFunctionConventions swiftConv(swiftFnTy, SGF.SGM.M);
 
   // We must have the same context archetypes as the unthunked function.
   assert(objcInfo.GenericEnv == swiftInfo.GenericEnv);
@@ -1004,9 +1197,17 @@ static SILFunctionType *emitObjCThunkArguments(SILGenFunction &SGF,
   assert(objcFnTy->getNumIndirectFormalResults() == 0
          && "Objective-C methods cannot have indirect results");
 
+  auto bridgedFormalTypes = expandTupleTypes(objcFormalFnTy.getParams());
+  bridgedFormalResultTy = objcFormalFnTy.getResult();
+
+  auto nativeFormalTypes = expandTupleTypes(swiftFormalFnTy.getParams());
+  nativeFormalResultTy = swiftFormalFnTy.getResult();
+
   // Emit the other arguments, taking ownership of arguments if necessary.
   auto inputs = objcFnTy->getParameters();
   auto nativeInputs = swiftFnTy->getParameters();
+  assert(nativeInputs.size() == bridgedFormalTypes.size());
+  assert(nativeInputs.size() == nativeFormalTypes.size());
   assert(inputs.size() ==
            nativeInputs.size() + unsigned(foreignError.hasValue()));
   for (unsigned i = 0, e = inputs.size(); i < e; ++i) {
@@ -1057,12 +1258,12 @@ static SILFunctionType *emitObjCThunkArguments(SILGenFunction &SGF,
 
   assert(bridgedArgs.size() == nativeInputs.size());
   for (unsigned i = 0, size = bridgedArgs.size(); i < size; ++i) {
-    SILType argTy = SGF.getSILType(swiftFnTy->getParameters()[i]);
     ManagedValue native =
       SGF.emitBridgedToNativeValue(loc,
                                    bridgedArgs[i],
-                                   SILFunctionTypeRepresentation::ObjCMethod,
-                                   argTy.getSwiftRValueType());
+                                   bridgedFormalTypes[i],
+                                   nativeFormalTypes[i],
+                        swiftFnTy->getParameters()[i].getSILStorageType());
     SILValue argValue;
 
     if (nativeInputs[i].isConsumed()) {
@@ -1155,8 +1356,11 @@ void SILGenFunction::emitNativeToForeignThunk(SILDeclRef thunk) {
   // Bridge the arguments.
   Optional<ForeignErrorConvention> foreignError;
   SILValue foreignErrorSlot;
+  CanType nativeFormalResultType, bridgedFormalResultType;
   auto objcFnTy = emitObjCThunkArguments(*this, loc, thunk, args,
-                                         foreignErrorSlot, foreignError);
+                                         foreignErrorSlot, foreignError,
+                                         nativeFormalResultType,
+                                         bridgedFormalResultType);
   SILFunctionConventions objcConv(CanSILFunctionType(objcFnTy), SGM.M);
   SILFunctionConventions nativeConv(CanSILFunctionType(nativeInfo.SILFnType),
                                     SGM.M);
@@ -1165,8 +1369,6 @@ void SILGenFunction::emitNativeToForeignThunk(SILDeclRef thunk) {
 
   // Call the native entry point.
   SILValue nativeFn = emitGlobalFunctionRef(loc, native, nativeInfo);
-
-  CanType bridgedResultType = objcResultTy.getSwiftRValueType();
 
   SILValue result;
   assert(foreignError.hasValue() == substTy->hasErrorResult());
@@ -1185,9 +1387,8 @@ void SILGenFunction::emitNativeToForeignThunk(SILDeclRef thunk) {
     argScope.pop();
 
     // Now bridge the return value.
-    result = emitBridgeReturnValue(*this, loc, result,
-                                   objcFnTy->getRepresentation(),
-                                   bridgedResultType);
+    result = emitBridgeReturnValue(*this, loc, result, nativeFormalResultType,
+                                   bridgedFormalResultType, objcResultTy);
   } else {
     SILBasicBlock *contBB = createBasicBlock();
     SILBasicBlock *errorBB = createBasicBlock();
@@ -1210,8 +1411,9 @@ void SILGenFunction::emitNativeToForeignThunk(SILDeclRef thunk) {
       // by bridging the native return value, but we may need to
       // adjust it slightly.
       SILValue bridgedResult =
-        emitBridgeReturnValueForForeignError(loc, nativeResult, 
-                                             objcFnTy->getRepresentation(),
+        emitBridgeReturnValueForForeignError(loc, nativeResult,
+                                             nativeFormalResultType,
+                                             bridgedFormalResultType,
                                              objcResultTy,
                                              foreignErrorSlot, *foreignError);
       B.createBranch(loc, contBB, bridgedResult);
@@ -1292,13 +1494,16 @@ void SILGenFunction::emitForeignToNativeThunk(SILDeclRef thunk) {
 
   auto fd = cast<AbstractFunctionDecl>(thunk.getDecl());
   auto nativeCI = getConstantInfo(thunk);
-  auto nativeFormalResultTy = nativeCI.LoweredInterfaceType.getResult();
   auto nativeFnTy = F.getLoweredFunctionType();
   assert(nativeFnTy == nativeCI.SILFnType);
 
   // Use the same generic environment as the native entry point.
   F.setGenericEnvironment(nativeCI.GenericEnv);
   
+  SILDeclRef foreignDeclRef = thunk.asForeign(true);
+  SILConstantInfo foreignCI = getConstantInfo(foreignDeclRef);
+  auto foreignFnTy = foreignCI.SILFnType;
+
   // Find the foreign error convention and 'self' parameter index.
   Optional<ForeignErrorConvention> foreignError;
   if (nativeFnTy->hasErrorResult()) {
@@ -1358,10 +1563,6 @@ void SILGenFunction::emitForeignToNativeThunk(SILDeclRef thunk) {
   {
     Scope scope(Cleanups, fd);
 
-    SILDeclRef foreignDeclRef = thunk.asForeign(true);
-    SILConstantInfo foreignCI = getConstantInfo(foreignDeclRef);
-    auto foreignFnTy = foreignCI.SILFnType;
-
     // Bridge all the arguments.
     SmallVector<ManagedValue, 8> args;
     unsigned foreignArgIndex = 0;
@@ -1377,6 +1578,11 @@ void SILGenFunction::emitForeignToNativeThunk(SILDeclRef thunk) {
     };
 
     {
+      auto foreignFormalParams =
+        expandTupleTypes(foreignCI.LoweredType.getParams());
+      auto nativeFormalParams =
+        expandTupleTypes(nativeCI.LoweredType.getParams());
+
       for (unsigned nativeParamIndex : indices(params)) {
         // Bring the parameter to +1.
         auto paramValue = params[nativeParamIndex];
@@ -1427,12 +1633,20 @@ void SILGenFunction::emitForeignToNativeThunk(SILDeclRef thunk) {
           break;
         }
 
+        CanType nativeFormalType =
+          F.mapTypeIntoContext(nativeFormalParams[nativeParamIndex])
+            ->getCanonicalType();
+        CanType foreignFormalType =
+          F.mapTypeIntoContext(foreignFormalParams[nativeParamIndex])
+            ->getCanonicalType();
+
         auto foreignParam = foreignFnTy->getParameters()[foreignArgIndex++];
-        SILType foreignArgTy =
-            F.mapTypeIntoContext(silConv.getSILType(foreignParam));
-        auto bridged = emitNativeToBridgedValue(fd, param,
-                                SILFunctionTypeRepresentation::CFunctionPointer,
-                                foreignArgTy.getSwiftRValueType());
+        SILType foreignLoweredTy =
+          F.mapTypeIntoContext(foreignParam.getSILStorageType());
+
+        auto bridged = emitNativeToBridgedValue(fd, param, nativeFormalType,
+                                                foreignFormalType,
+                                                foreignLoweredTy);
         // Handle C pointer arguments imported as indirect `self` arguments.
         if (foreignParam.getConvention() == ParameterConvention::Indirect_In) {
           auto temp = emitTemporaryAllocation(fd, bridged.getType());
@@ -1459,14 +1673,23 @@ void SILGenFunction::emitForeignToNativeThunk(SILDeclRef thunk) {
     auto fnType = fn->getType().castTo<SILFunctionType>();
     fnType = fnType->substGenericArgs(SGM.M, subs);
 
-    auto substResultTy =
-        fd->mapTypeIntoContext(nativeFormalResultTy)
+    CanType nativeFormalResultType =
+        fd->mapTypeIntoContext(nativeCI.LoweredType.getResult())
+            ->getCanonicalType();
+    CanType bridgedFormalResultType =
+        fd->mapTypeIntoContext(foreignCI.LoweredType.getResult())
             ->getCanonicalType();
     CalleeTypeInfo calleeTypeInfo(
         fnType, AbstractionPattern(nativeFnTy->getGenericSignature(),
-                                   nativeFormalResultTy),
-        substResultTy, foreignError);
-    SGFContext context;
+                                   bridgedFormalResultType),
+        nativeFormalResultType, foreignError);
+
+    auto init = indirectResult
+                ? useBufferAsTemporary(indirectResult,
+                                    getTypeLowering(indirectResult->getType()))
+                : nullptr;
+
+    SGFContext context(init.get());
     ResultPlanPtr resultPlan = ResultPlanBuilder::computeResultPlan(
         *this, calleeTypeInfo, fd, context);
     ArgumentScope argScope(*this, fd);
@@ -1475,9 +1698,13 @@ void SILGenFunction::emitForeignToNativeThunk(SILDeclRef thunk) {
                   ManagedValue::forUnmanaged(fn), subs, args, calleeTypeInfo,
                   ApplyOptions::None, context)
             .getAsSingleValue(*this, fd);
-    // TODO: Emit directly into the indirect result.
+
     if (indirectResult) {
-      resultMV.forwardInto(*this, fd, indirectResult);
+      if (!resultMV.isInContext()) {
+        init->copyOrInitValueInto(*this, fd, resultMV, /*isInit*/ true);
+        init->finishInitialization(*this);
+      }
+      init->getManagedAddress().forward(*this);
       result = emitEmptyTuple(fd);
     } else {
       result = resultMV.forward(*this);

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -368,17 +368,14 @@ SILGenFunction::emitClosureValue(SILLocation loc, SILDeclRef constant,
 
   // Get the lowered AST types:
   //  - the original type
-  auto origLoweredFormalType =
-      AbstractionPattern(constantInfo.LoweredInterfaceType);
+  auto origFormalType = AbstractionPattern(constantInfo.LoweredType);
 
   // - the substituted type
-  auto substFormalType = cast<FunctionType>(expectedType);
-  auto substLoweredFormalType =
-    SGM.Types.getLoweredASTFunctionType(substFormalType, 0, constant);
+  auto substFormalType = expectedType;
 
   // Generalize if necessary.
-  result = emitOrigToSubstValue(loc, result, origLoweredFormalType,
-                                substLoweredFormalType);
+  result = emitOrigToSubstValue(loc, result, origFormalType,
+                                substFormalType);
 
   return result;
 }

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -3061,7 +3061,8 @@ SILGenFunction::emitTransformedValue(SILLocation loc, ManagedValue v,
                                      SGFContext ctxt) {
   return emitTransformedValue(loc, v,
                               AbstractionPattern(inputType), inputType,
-                              AbstractionPattern(outputType), outputType);
+                              AbstractionPattern(outputType), outputType,
+                              ctxt);
 }
 
 ManagedValue
@@ -3291,7 +3292,7 @@ void SILGenFunction::emitProtocolWitness(Type selfType,
 
   // Get the type of the witness.
   auto witnessInfo = getConstantInfo(witness);
-  CanAnyFunctionType witnessSubstTy = witnessInfo.LoweredInterfaceType;
+  CanAnyFunctionType witnessSubstTy = witnessInfo.LoweredType;
   if (!witnessSubs.empty()) {
     witnessSubstTy = cast<FunctionType>(
       cast<GenericFunctionType>(witnessSubstTy)
@@ -3343,7 +3344,7 @@ void SILGenFunction::emitProtocolWitness(Type selfType,
     }
   }
 
-  AbstractionPattern witnessOrigTy(witnessInfo.LoweredInterfaceType);
+  AbstractionPattern witnessOrigTy(witnessInfo.LoweredType);
   TranslateArguments(*this, loc,
                      origParams, witnessParams,
                      witnessFTy->getParameters())

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -61,7 +61,7 @@ SILGenModule::emitVTableMethod(SILDeclRef derived, SILDeclRef base) {
   // abstraction pattern of the base.
   auto baseInfo = Types.getConstantInfo(base);
   auto derivedInfo = Types.getConstantInfo(derived);
-  auto basePattern = AbstractionPattern(baseInfo.LoweredInterfaceType);
+  auto basePattern = AbstractionPattern(baseInfo.LoweredType);
   
   auto overrideInfo = M.Types.getConstantOverrideInfo(derived, base);
 
@@ -105,8 +105,8 @@ SILGenModule::emitVTableMethod(SILDeclRef derived, SILDeclRef base) {
 
   SILGenFunction(*this, *thunk)
     .emitVTableThunk(derived, implFn, basePattern,
-                     overrideInfo.LoweredInterfaceType,
-                     derivedInfo.LoweredInterfaceType);
+                     overrideInfo.LoweredType,
+                     derivedInfo.LoweredType);
 
   return {base, thunk, implLinkage};
 }
@@ -557,8 +557,7 @@ SILGenModule::emitProtocolWitness(ProtocolConformance *conformance,
   GenericEnvironment *genericEnv = nullptr;
 
   // Work out the lowered function type of the SIL witness thunk.
-  auto reqtOrigTy
-    = cast<GenericFunctionType>(requirementInfo.LoweredInterfaceType);
+  auto reqtOrigTy = cast<GenericFunctionType>(requirementInfo.LoweredType);
   CanAnyFunctionType reqtSubstTy;
   SubstitutionList witnessSubs;
   if (witness.requiresSubstitution()) {
@@ -614,10 +613,9 @@ SILGenModule::emitProtocolWitness(ProtocolConformance *conformance,
   }
 
   // Lower the witness thunk type with the requirement's abstraction level.
-  auto witnessSILFnType = getNativeSILFunctionType(M,
-                                                   AbstractionPattern(reqtOrigTy),
-                                                   reqtSubstTy,
-                                                   witnessRef);
+  auto witnessSILFnType =
+    getNativeSILFunctionType(M, AbstractionPattern(reqtOrigTy),
+                             reqtSubstTy, witnessRef);
 
   // Mangle the name of the witness thunk.
   Mangle::ASTMangler NewMangler;

--- a/test/Inputs/ObjCBridging/Appliances.h
+++ b/test/Inputs/ObjCBridging/Appliances.h
@@ -21,3 +21,5 @@
 @interface APPBroken : NSObject
 @property (nonatomic,nonnull,readonly) id thing;
 @end
+
+void takesNonStandardBlock(__attribute__((ns_returns_retained)) id (^)(void));

--- a/test/SILGen/objc_bridging.swift
+++ b/test/SILGen/objc_bridging.swift
@@ -88,25 +88,11 @@ func setFoo(_ f: Foo, s: String) {
 // CHECK: bb0([[ARG0:%.*]] : $Foo, {{%.*}} : $String):
 // CHECK:   [[BORROWED_ARG0:%.*]] = begin_borrow [[ARG0]]
 // CHECK:   [[SET_FOO:%.*]] = class_method [volatile] [[BORROWED_ARG0]] : $Foo, #Foo.setFoo!1.foreign
-// CHECK:   [[NV:%.*]] = load
-// CHECK:   [[OPT_NATIVE:%.*]] = enum $Optional<String>, #Optional.some!enumelt.1, [[NV]]
-// CHECK:   switch_enum [[OPT_NATIVE]] : $Optional<String>, case #Optional.some!enumelt.1: [[SOME_BB:bb[0-9]+]], case #Optional.none!enumelt: [[NONE_BB:bb[0-9]+]]
-//
-// CHECK: [[SOME_BB]]([[NATIVE:%.*]] : $String):
-// CHECK-NOT: unchecked_enum_data
+// CHECK:   [[NATIVE:%.*]] = load
 // CHECK:   [[STRING_TO_NSSTRING:%.*]] = function_ref @_T0SS10FoundationE19_bridgeToObjectiveCSo8NSStringCyF
 // CHECK:   [[BORROWED_NATIVE:%.*]] = begin_borrow [[NATIVE]]
 // CHECK:   [[BRIDGED:%.*]] = apply [[STRING_TO_NSSTRING]]([[BORROWED_NATIVE]])
 // CHECK:   [[OPT_BRIDGED:%.*]] = enum $Optional<NSString>, #Optional.some!enumelt.1, [[BRIDGED]]
-// CHECK:   end_borrow [[BORROWED_NATIVE]] from [[NATIVE]]
-// CHECK:   destroy_value [[NATIVE]]
-// CHECK:   br [[CONT_BB:bb[0-9]+]]([[OPT_BRIDGED]] : $Optional<NSString>)
-//
-// CHECK: [[NONE_BB]]:
-// CHECK:   [[OPT_BRIDGED:%.*]] = enum $Optional<NSString>, #Optional.none!enumelt
-// CHECK:   br [[CONT_BB]]([[OPT_BRIDGED]] : $Optional<NSString>)
-//
-// CHECK: [[CONT_BB]]([[OPT_BRIDGED:%.*]] : $Optional<NSString>):
 // CHECK:   apply [[SET_FOO]]([[OPT_BRIDGED]], [[BORROWED_ARG0]]) : $@convention(objc_method) (Optional<NSString>, Foo) -> ()
 // CHECK:   destroy_value [[OPT_BRIDGED]]
 // CHECK:   end_borrow [[BORROWED_ARG0]] from [[ARG0]]
@@ -273,18 +259,12 @@ func callSetBar(_ s: String) {
 // CHECK-LABEL: sil hidden @_T013objc_bridging10callSetBar{{.*}}F
 // CHECK: bb0({{%.*}} : $String):
 // CHECK:   [[SET_BAR:%.*]] = function_ref @setBar
-// CHECK:   [[NV:%.*]] = load
-// CHECK:   [[OPT_NATIVE:%.*]] = enum $Optional<String>, #Optional.some!enumelt.1, [[NV]]
-// CHECK:   switch_enum [[OPT_NATIVE]] : $Optional<String>, case #Optional.some!enumelt.1: [[SOME_BB:bb[0-9]+]], case #Optional.none!enumelt: [[NONE_BB:bb[0-9]+]]
-
-// CHECK: [[SOME_BB]]([[NATIVE:%.*]] : $String):
-// CHECK-NOT: unchecked_enum_data
+// CHECK:   [[NATIVE:%.*]] = load
 // CHECK:   [[STRING_TO_NSSTRING:%.*]] = function_ref @_T0SS10FoundationE19_bridgeToObjectiveCSo8NSStringCyF
 // CHECK:   [[BORROWED_NATIVE:%.*]] = begin_borrow [[NATIVE]]
 // CHECK:   [[BRIDGED:%.*]] = apply [[STRING_TO_NSSTRING]]([[BORROWED_NATIVE]])
-// CHECK:    = enum $Optional<NSString>, #Optional.some!enumelt.1, [[BRIDGED]]
+// CHECK:   [[OPT_BRIDGED:%.*]] = enum $Optional<NSString>, #Optional.some!enumelt.1, [[BRIDGED]]
 // CHECK:   end_borrow [[BORROWED_NATIVE]] from [[NATIVE]]
-// CHECK: bb3([[OPT_BRIDGED:%.*]] : $Optional<NSString>):
 // CHECK:   apply [[SET_BAR]]([[OPT_BRIDGED]])
 // CHECK:   destroy_value [[OPT_BRIDGED]]
 // CHECK: }
@@ -650,4 +630,10 @@ func updateFridgeTemp(_ home: APPHouse, delta: Double) {
   // XCHECK: end_borrow [[BORROWED_HOME]] from [[HOME]]
   // XCHECK: destroy_value [[HOME]]
   home.fridge.temperature += delta
+}
+
+// CHECK-LABEL: sil hidden @_T013objc_bridging20callNonStandardBlockySi5value_tF
+func callNonStandardBlock(value: Int) {
+  // CHECK: enum $Optional<@convention(block) () -> @owned Optional<AnyObject>>
+  takesNonStandardBlock { return value }
 }

--- a/test/stdlib/TestData.swift
+++ b/test/stdlib/TestData.swift
@@ -773,8 +773,15 @@ class TestData : TestDataSuper {
 
     func test_passing() {
         let object = ImmutableDataVerifier()
-        takesData(object as Data)
+        let object_notPeepholed = object as Data
+        takesData(object_notPeepholed)
         expectTrue(object.verifier.wasCopied)
+    }
+
+    func test_passing_peepholed() {
+        let object = ImmutableDataVerifier()
+        takesData(object as Data)
+        expectFalse(object.verifier.wasCopied) // because of the peephole
     }
     
     // intentionally structured so sizeof() != strideof()


### PR DESCRIPTION
This is part of the ground work for the syntactic bridging peephole.

- Pass source and dest formal types to the bridging routines instead of
  lowered types.

- Change bridging abstraction patterns to store bridged formal types
  instead of the formal type.

- Improve how SIL type lowering deals with import-as-member patterns.

- Fix some AST bugs where inadequate information was being stored in
  various expressions.

- Introduce the idea of a converting SGFContext and use it to regularize
  the existing id-as-Any conversion peephole.

- Improve various places in SILGen to emit directly into contexts.