### PR TITLE
[4.0] Hack: allow dropping noescape-ness when overriding ObjC methods

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -248,6 +248,11 @@ enum class TypeMatchFlags {
   AllowTopLevelOptionalMismatch = 1 << 2,
   /// Allow any ABI-compatible types to be considered matching.
   AllowABICompatible = 1 << 3,
+  /// Allow escaping function parameters to override optional non-escaping ones.
+  ///
+  /// This is necessary because Objective-C allows optional function paramaters
+  /// to be non-escaping, but Swift currently does not.
+  IgnoreNonEscapingForOptionalFunctionParam = 1 << 4
 };
 using TypeMatchOptions = OptionSet<TypeMatchFlags>;
 

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2337,23 +2337,31 @@ namespace {
     Parameter,
     ParameterTupleElement
   };
+
+  enum class OptionalUnwrapping {
+    None,
+    OptionalToOptional,
+    ValueToOptional,
+    OptionalToValue
+  };
 } // end anonymous namespace
 
 static bool matches(CanType t1, CanType t2, TypeMatchOptions matchMode,
-                    ParameterPosition paramPosition, bool insideOptional,
+                    ParameterPosition paramPosition,
+                    OptionalUnwrapping insideOptional,
                     LazyResolver *resolver) {
   if (t1 == t2) return true;
 
   // First try unwrapping optionals.
   // Make sure we only unwrap at most one layer of optional.
-  if (!insideOptional) {
+  if (insideOptional == OptionalUnwrapping::None) {
     // Value-to-optional and optional-to-optional.
     if (auto obj2 = t2.getAnyOptionalObjectType()) {
       // Optional-to-optional.
       if (auto obj1 = t1.getAnyOptionalObjectType()) {
         // Allow T? and T! to freely match one another.
         return matches(obj1, obj2, matchMode, ParameterPosition::NotParameter,
-                       /*insideOptional=*/true, resolver);
+                       OptionalUnwrapping::OptionalToOptional, resolver);
       }
 
       // Value-to-optional.
@@ -2364,7 +2372,7 @@ static bool matches(CanType t1, CanType t2, TypeMatchOptions matchMode,
       if (matchMode.contains(TypeMatchFlags::AllowOverride) ||
           matchMode.contains(TypeMatchFlags::AllowTopLevelOptionalMismatch)) {
         return matches(t1, obj2, matchMode, ParameterPosition::NotParameter,
-                       /*insideOptional=*/true, resolver);
+                       OptionalUnwrapping::ValueToOptional, resolver);
       }
 
     } else if (matchMode.contains(
@@ -2372,7 +2380,7 @@ static bool matches(CanType t1, CanType t2, TypeMatchOptions matchMode,
       // Optional-to-value, normally disallowed.
       if (auto obj1 = t1.getAnyOptionalObjectType()) {
         return matches(obj1, t2, matchMode, ParameterPosition::NotParameter,
-                       /*insideOptional=*/true, resolver);
+                       OptionalUnwrapping::OptionalToValue, resolver);
       }
     }
   }
@@ -2396,14 +2404,14 @@ static bool matches(CanType t1, CanType t2, TypeMatchOptions matchMode,
     if (!tuple1 || tuple1->getNumElements() != tuple2->getNumElements()) {
       if (tuple2->getNumElements() == 1) {
         return matches(t1, tuple2.getElementType(0), matchMode, elementPosition,
-                       /*insideOptional=*/false, resolver);
+                       OptionalUnwrapping::None, resolver);
       }
       return false;
     }
 
     for (auto i : indices(tuple1.getElementTypes())) {
       if (!matches(tuple1.getElementType(i), tuple2.getElementType(i),
-                   matchMode, elementPosition, /*insideOptional=*/false,
+                   matchMode, elementPosition, OptionalUnwrapping::None,
                    resolver)){
         return false;
       }
@@ -2432,22 +2440,32 @@ static bool matches(CanType t1, CanType t2, TypeMatchOptions matchMode,
         ext1 = ext1.withThrows(true);
       }
     }
+    // If specified, allow an escaping function parameter to override a
+    // non-escaping function parameter when the parameter is optional.
+    // Note that this is checking 'ext2' rather than 'ext1' because parameters
+    // must be contravariant for the containing function to be covariant.
+    if (matchMode.contains(
+          TypeMatchFlags::IgnoreNonEscapingForOptionalFunctionParam) &&
+        insideOptional == OptionalUnwrapping::OptionalToOptional) {
+      if (!ext2.isNoEscape())
+        ext1 = ext1.withNoEscape(false);
+    }
     if (ext1 != ext2)
       return false;
 
     // Inputs are contravariant, results are covariant.
     return (matches(fn2.getInput(), fn1.getInput(), matchMode,
-                    ParameterPosition::Parameter, /*insideOptional=*/false,
+                    ParameterPosition::Parameter, OptionalUnwrapping::None,
                     resolver) &&
             matches(fn1.getResult(), fn2.getResult(), matchMode,
-                    ParameterPosition::NotParameter, /*insideOptional=*/false,
+                    ParameterPosition::NotParameter, OptionalUnwrapping::None,
                     resolver));
   }
 
   if (matchMode.contains(TypeMatchFlags::AllowNonOptionalForIUOParam) &&
       (paramPosition == ParameterPosition::Parameter ||
        paramPosition == ParameterPosition::ParameterTupleElement) &&
-      !insideOptional) {
+      insideOptional == OptionalUnwrapping::None) {
     // Allow T to override T! in certain cases.
     if (auto obj1 = t1->getImplicitlyUnwrappedOptionalObjectType()) {
       t1 = obj1->getCanonicalType();
@@ -2470,7 +2488,7 @@ static bool matches(CanType t1, CanType t2, TypeMatchOptions matchMode,
 bool TypeBase::matches(Type other, TypeMatchOptions matchMode,
                        LazyResolver *resolver) {
   return ::matches(getCanonicalType(), other->getCanonicalType(), matchMode,
-                   ParameterPosition::NotParameter, /*insideOptional=*/false,
+                   ParameterPosition::NotParameter, OptionalUnwrapping::None,
                    resolver);
 }
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -5816,6 +5816,8 @@ public:
           matchMode |= TypeMatchFlags::AllowTopLevelOptionalMismatch;
         } else if (parentDecl->isObjC()) {
           matchMode |= TypeMatchFlags::AllowNonOptionalForIUOParam;
+          matchMode |=
+              TypeMatchFlags::IgnoreNonEscapingForOptionalFunctionParam;
         }
 
         if (declTy->matches(parentDeclTy, matchMode, &TC)) {

--- a/test/ClangImporter/Inputs/custom-modules/ObjCParseExtras.h
+++ b/test/ClangImporter/Inputs/custom-modules/ObjCParseExtras.h
@@ -187,6 +187,13 @@ typedef SomeCell <NSCopying> *CopyableSomeCell;
 + (BOOL)processValueAndReturnError:(NSError **)error;
 @end
 
+@interface CallbackBase : NSObject
+- (void)performWithHandler:(void(^ _Nonnull)(void))handler;
+- (void)performWithOptHandler:(void(^ _Nullable)(void))handler;
+- (void)performWithNonescapingHandler:(void(__attribute__((noescape)) ^ _Nonnull)(void))handler;
+- (void)performWithOptNonescapingHandler:(void(__attribute__((noescape)) ^ _Nullable)(void))handler;
+@end
+
 @interface SelectorSplittingAccessors : NSObject
 // Note the custom setter name here; this is important.
 @property (setter=takeFooForBar:) BOOL fooForBar;

--- a/test/ClangImporter/objc_override.swift
+++ b/test/ClangImporter/objc_override.swift
@@ -88,6 +88,26 @@ class FailSub : FailBase {
   override class func processValue() {} // expected-error {{overriding a throwing @objc method with a non-throwing method is not supported}}
 }
 
+class CallbackSubA : CallbackBase {
+  override func perform(handler: () -> Void) {} // expected-error {{method does not override any method from its superclass}}
+  // expected-note@-1 {{type does not match superclass instance method with type '(@escaping () -> Void) -> Void'}}
+  override func perform(optHandler: () -> Void) {} // expected-error {{method does not override any method from its superclass}}
+  override func perform(nonescapingHandler: () -> Void) {}
+  override func perform(optNonescapingHandler: () -> Void) {} // expected-error {{cannot override instance method parameter of type '(() -> Void)?' with non-optional type '() -> Void'}}
+}
+class CallbackSubB : CallbackBase {
+  override func perform(handler: (() -> Void)?) {}
+  override func perform(optHandler: (() -> Void)?) {}
+  override func perform(nonescapingHandler: (() -> Void)?) {} // expected-error {{method does not override any method from its superclass}}
+  override func perform(optNonescapingHandler: (() -> Void)?) {}
+}
+class CallbackSubC : CallbackBase {
+  override func perform(handler: @escaping () -> Void) {}
+  override func perform(optHandler: @escaping () -> Void) {} // expected-error {{cannot override instance method parameter of type '(() -> Void)?' with non-optional type '() -> Void'}}
+  override func perform(nonescapingHandler: @escaping () -> Void) {} // expected-error {{method does not override any method from its superclass}}
+  override func perform(optNonescapingHandler: @escaping () -> Void) {} // expected-error {{method does not override any method from its superclass}}
+}
+
 // FIXME: Remove -verify-ignore-unknown.
 // <unknown>:0: error: unexpected note produced: overridden declaration is here
 // <unknown>:0: error: unexpected note produced: setter for 'boolProperty' declared here

--- a/test/decl/class/override.swift
+++ b/test/decl/class/override.swift
@@ -304,3 +304,29 @@ class GenericSubscriptDerived : GenericSubscriptBase {
     }
   }
 }
+
+
+// @escaping
+
+class CallbackBase {
+  func perform(handler: @escaping () -> Void) {} // expected-note * {{here}}
+  func perform(optHandler: (() -> Void)?) {} // expected-note * {{here}}
+  func perform(nonescapingHandler: () -> Void) {} // expected-note * {{here}}
+}
+class CallbackSubA: CallbackBase {
+  override func perform(handler: () -> Void) {} // expected-error {{method does not override any method from its superclass}}
+  // expected-note@-1 {{type does not match superclass instance method with type '(@escaping () -> Void) -> ()'}}
+  override func perform(optHandler: () -> Void) {} // expected-error {{method does not override any method from its superclass}}
+  override func perform(nonescapingHandler: () -> Void) {}
+}
+class CallbackSubB : CallbackBase {
+  override func perform(handler: (() -> Void)?) {}
+  override func perform(optHandler: (() -> Void)?) {}
+  override func perform(nonescapingHandler: (() -> Void)?) {} // expected-error {{method does not override any method from its superclass}}
+}
+class CallbackSubC : CallbackBase {
+  override func perform(handler: @escaping () -> Void) {}
+  override func perform(optHandler: @escaping () -> Void) {} // expected-error {{cannot override instance method parameter of type '(() -> Void)?' with non-optional type '() -> Void'}}
+  override func perform(nonescapingHandler: @escaping () -> Void) {} // expected-error {{method does not override any method from its superclass}}
+}
+


### PR DESCRIPTION
- **Explanation**: In today's Swift, only non-optional function parameters can be non-escaping (and are by default). However, Objective-C *does* allow applying its `noescape` attribute to a callback block marked `nullable`. This patch pokes a very narrow hole into the override checking to accomodate this: if a declaration comes from Objective-C, and it has an optional, non-escaping closure parameter, it's okay to override it in Swift with an optional, escaping closure parameter. This isn't strictly safe because a caller could be relying on the non-escaping-ness, but we don't have anything better for now. (This behavior will probably be deprecated in the future.)
- **Scope**: Affects overrides of methods that are (1) imported from Objective-C (2) with block parameters (3) that are both nullable and non-escaping.
- **Issue**: rdar://problem/32903155
- **Reviewed by**: @jckarter  
- **Risk**: Low. Relaxes existing conditions under very specific circumstances. Any existing code should continue to work.
- **Testing**: Added new C++ unit tests and Swift regression tests.