### PR TITLE
[QoI] Add a fixed crasher which triggers closure return diagnostics

### DIFF
--- a/validation-test/compiler_crashers_2_fixed/0113-rdar33067102-2.swift
+++ b/validation-test/compiler_crashers_2_fixed/0113-rdar33067102-2.swift
@@ -1,0 +1,5 @@
+// RUN: not %target-swift-frontend -swift-version 4 %s -typecheck
+
+func flatterMap(_ records: [((Int))]) -> [Int] {
+  records.flatMap { _ in return 1 } // expected-note {{}}
+}


### PR DESCRIPTION
Related to rdar://problem/33067102

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
