### PR TITLE
[stdlib] Have Substring.filter return a String

### DIFF
--- a/stdlib/public/core/Substring.swift.gyb
+++ b/stdlib/public/core/Substring.swift.gyb
@@ -428,6 +428,12 @@ extension Substring {
   public func uppercased() -> String {
     return String(self).uppercased()
   }
+  
+  public func filter(
+  _ isIncluded: (Element) throws -> Bool
+  ) rethrows -> String {
+      return try String(self.lazy.filter(isIncluded))
+  }
 }
 
 extension Substring : TextOutputStream {

--- a/stdlib/public/core/Substring.swift.gyb
+++ b/stdlib/public/core/Substring.swift.gyb
@@ -430,9 +430,9 @@ extension Substring {
   }
   
   public func filter(
-  _ isIncluded: (Element) throws -> Bool
+    _ isIncluded: (Element) throws -> Bool
   ) rethrows -> String {
-      return try String(self.lazy.filter(isIncluded))
+    return try String(self.lazy.filter(isIncluded))
   }
 }
 

--- a/test/stdlib/subString.swift
+++ b/test/stdlib/subString.swift
@@ -92,6 +92,14 @@ SubstringTests.test("Comparison") {
 		["apple", "pen", "pen", "pineapple"])
 }
 
+SubstringTests.test("Filter") {
+	var name = "😂Edward Woodward".dropFirst()
+	var filtered = name.filter { $0 != "d" }
+	expectType(Substring.self, &name)
+	expectType(String.self, &filtered)
+	expectEqual("Ewar Woowar", filtered)
+}
+
 SubstringTests.test("CharacterView") {
   let s = "abcdefg"
   var t = s.characters.dropFirst(2)

--- a/test/stdlib/subString.swift
+++ b/test/stdlib/subString.swift
@@ -93,11 +93,11 @@ SubstringTests.test("Comparison") {
 }
 
 SubstringTests.test("Filter") {
-	var name = "😂Edward Woodward".dropFirst()
-	var filtered = name.filter { $0 != "d" }
-	expectType(Substring.self, &name)
-	expectType(String.self, &filtered)
-	expectEqual("Ewar Woowar", filtered)
+  var name = "😂Edward Woodward".dropFirst()
+  var filtered = name.filter { $0 != "d" }
+  expectType(Substring.self, &name)
+  expectType(String.self, &filtered)
+  expectEqual("Ewar Woowar", filtered)
 }
 
 SubstringTests.test("CharacterView") {


### PR DESCRIPTION
Per guidance in SE-163 that methods that return new strings shouldn't return substrings, `Substring` shouldn't just take the default for `RangeReplaceableCollection.filter` of returning `Self`.
