### PR TITLE
Name translation: Allow type name translation when cursor points to constructor call. rdar://33163114

### DIFF
--- a/test/SourceKit/NameTranslation/basic.swift
+++ b/test/SourceKit/NameTranslation/basic.swift
@@ -27,6 +27,7 @@ class MyDerived: FooClassDerived {
 // REQUIRES: objc_interop
 // RUN: %sourcekitd-test -req=translate -objc-name FooClassDerived2 -pos=5:30 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK1 %s
 // RUN: %sourcekitd-test -req=translate -objc-selector FooClassDerived2 -pos=3:23 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK11 %s
+// RUN: %sourcekitd-test -req=translate -objc-name FooClassDerived2 -pos=3:23 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK11-1 %s
 // RUN: %sourcekitd-test -req=translate -objc-name fooProperty2 -pos=6:16 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK2 %s
 // RUN: %sourcekitd-test -req=translate -objc-selector fooInstanceFunc1 -pos=7:16 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK3 %s
 // RUN: %sourcekitd-test -req=translate -objc-selector fooInstanceFunc1: -pos=7:16 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK3 %s
@@ -66,6 +67,7 @@ class MyDerived: FooClassDerived {
 // CHECK9: fooProperty11
 // CHECK10: init(nstanceFunc21:)
 // CHECK11: init(lassDerived2:)
+// CHECK11-1: FooClassDerived2
 // CHECK12: init(float2:)
 // CHECK13: init(_:)
 // CHECK14: init

--- a/test/SourceKit/NameTranslation/swiftnames.swift
+++ b/test/SourceKit/NameTranslation/swiftnames.swift
@@ -74,6 +74,7 @@ class C3: NSObject {
 
 // RUN: %sourcekitd-test -req=translate -swift-name "init(a1:b2:)" -pos=10:16 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK10 %s
 // RUN: %sourcekitd-test -req=translate -swift-name "init(_:_:)" -pos=10:16 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK11 %s
+// RUN: %sourcekitd-test -req=translate -swift-name "C11" -pos=10:16 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK9 %s
 // RUN: %sourcekitd-test -req=translate -swift-name "foo(a1:_:)" -pos=10:16 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK12 %s
 
 // RUN: %sourcekitd-test -req=translate -swift-name "A2" -pos=27:10 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK13 %s


### PR DESCRIPTION
When translating objc names to swift names, if the given name is not an objc
function name, and the cursor points to a constructor call, we use the type
declaration instead of the init declaration to translate.