### PR TITLE
[silgen] Update a group of SILGen tests to run with -enable-sil-ownership.

### DIFF
--- a/test/SILGen/address_only_types.swift
+++ b/test/SILGen/address_only_types.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -parse-as-library -parse-stdlib -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -enable-sil-ownership -parse-as-library -parse-stdlib -emit-silgen %s | %FileCheck %s
 
 precedencegroup AssignmentPrecedence { assignment: true }
 
@@ -14,7 +14,7 @@ protocol Unloadable {
 
 // CHECK-LABEL: sil hidden @_T018address_only_types0a1_B9_argument{{[_0-9a-zA-Z]*}}F
 func address_only_argument(_ x: Unloadable) {
-  // CHECK: bb0([[XARG:%[0-9]+]] : $*Unloadable):
+  // CHECK: bb0([[XARG:%[0-9]+]] : @trivial $*Unloadable):
   // CHECK: debug_value_addr [[XARG]]
   // CHECK-NEXT: destroy_addr [[XARG]]
   // CHECK-NEXT: tuple
@@ -23,7 +23,7 @@ func address_only_argument(_ x: Unloadable) {
 
 // CHECK-LABEL: sil hidden @_T018address_only_types0a1_B17_ignored_argument{{[_0-9a-zA-Z]*}}F
 func address_only_ignored_argument(_: Unloadable) {
-  // CHECK: bb0([[XARG:%[0-9]+]] : $*Unloadable):
+  // CHECK: bb0([[XARG:%[0-9]+]] : @trivial $*Unloadable):
   // CHECK: destroy_addr [[XARG]]
   // CHECK-NOT: dealloc_stack {{.*}} [[XARG]]
   // CHECK: return
@@ -31,7 +31,7 @@ func address_only_ignored_argument(_: Unloadable) {
 
 // CHECK-LABEL: sil hidden @_T018address_only_types0a1_B7_return{{[_0-9a-zA-Z]*}}F
 func address_only_return(_ x: Unloadable, y: Int) -> Unloadable {
-  // CHECK: bb0([[RET:%[0-9]+]] : $*Unloadable, [[XARG:%[0-9]+]] : $*Unloadable, [[YARG:%[0-9]+]] : $Builtin.Int64):
+  // CHECK: bb0([[RET:%[0-9]+]] : @trivial $*Unloadable, [[XARG:%[0-9]+]] : @trivial $*Unloadable, [[YARG:%[0-9]+]] : @trivial $Builtin.Int64):
   // CHECK-NEXT: debug_value_addr [[XARG]] : $*Unloadable, let, name "x"
   // CHECK-NEXT: debug_value [[YARG]] : $Builtin.Int64, let, name "y"
   // CHECK-NEXT: copy_addr [[XARG]] to [initialization] [[RET]]
@@ -48,7 +48,7 @@ func address_only_missing_return() -> Unloadable {
 
 // CHECK-LABEL: sil hidden @_T018address_only_types0a1_B27_conditional_missing_return{{[_0-9a-zA-Z]*}}F
 func address_only_conditional_missing_return(_ x: Unloadable) -> Unloadable {
-  // CHECK: bb0({{%.*}} : $*Unloadable, {{%.*}} : $*Unloadable):
+  // CHECK: bb0({{%.*}} : @trivial $*Unloadable, {{%.*}} : @trivial $*Unloadable):
   // CHECK:   switch_enum {{%.*}}, case #Bool.true_!enumelt: [[TRUE:bb[0-9]+]], case #Bool.false_!enumelt: [[FALSE:bb[0-9]+]]
   switch Bool.true_ {
   case .true_:
@@ -66,7 +66,7 @@ func address_only_conditional_missing_return(_ x: Unloadable) -> Unloadable {
 
 // CHECK-LABEL: sil hidden @_T018address_only_types0a1_B29_conditional_missing_return_2
 func address_only_conditional_missing_return_2(_ x: Unloadable) -> Unloadable {
-  // CHECK: bb0({{%.*}} : $*Unloadable, {{%.*}} : $*Unloadable):
+  // CHECK: bb0({{%.*}} : @trivial $*Unloadable, {{%.*}} : @trivial $*Unloadable):
   // CHECK:   switch_enum {{%.*}}, case #Bool.true_!enumelt: [[TRUE1:bb[0-9]+]], case #Bool.false_!enumelt: [[FALSE1:bb[0-9]+]]
   switch Bool.true_ {
   case .true_:
@@ -95,7 +95,7 @@ func some_address_only_function_2(_ x: Unloadable) -> () {}
 
 // CHECK-LABEL: sil hidden @_T018address_only_types0a1_B7_call_1
 func address_only_call_1() -> Unloadable {
-  // CHECK: bb0([[RET:%[0-9]+]] : $*Unloadable):
+  // CHECK: bb0([[RET:%[0-9]+]] : @trivial $*Unloadable):
   return some_address_only_function_1()
   // FIXME emit into
   // CHECK: [[FUNC:%[0-9]+]] = function_ref @_T018address_only_types05some_a1_B11_function_1AA10Unloadable_pyF
@@ -117,7 +117,7 @@ func address_only_call_1_ignore_return() {
 
 // CHECK-LABEL: sil hidden @_T018address_only_types0a1_B7_call_2{{[_0-9a-zA-Z]*}}F
 func address_only_call_2(_ x: Unloadable) {
-  // CHECK: bb0([[XARG:%[0-9]+]] : $*Unloadable):
+  // CHECK: bb0([[XARG:%[0-9]+]] : @trivial $*Unloadable):
   // CHECK: debug_value_addr [[XARG]] : $*Unloadable
   some_address_only_function_2(x)
   // CHECK: [[FUNC:%[0-9]+]] = function_ref @_T018address_only_types05some_a1_B11_function_2{{[_0-9a-zA-Z]*}}F
@@ -158,7 +158,7 @@ func address_only_materialize() -> Int {
 
 // CHECK-LABEL: sil hidden @_T018address_only_types0a1_B21_assignment_from_temp{{[_0-9a-zA-Z]*}}F
 func address_only_assignment_from_temp(_ dest: inout Unloadable) {
-  // CHECK: bb0([[DEST:%[0-9]+]] : $*Unloadable):
+  // CHECK: bb0([[DEST:%[0-9]+]] : @trivial $*Unloadable):
   dest = some_address_only_function_1()
   // CHECK: [[TEMP:%[0-9]+]] = alloc_stack $Unloadable
   // CHECK: %[[ACCESS:.*]] = begin_access [modify] [unknown] %0 :
@@ -170,7 +170,7 @@ func address_only_assignment_from_temp(_ dest: inout Unloadable) {
 // CHECK-LABEL: sil hidden @_T018address_only_types0a1_B19_assignment_from_lv{{[_0-9a-zA-Z]*}}F
 func address_only_assignment_from_lv(_ dest: inout Unloadable, v: Unloadable) {
   var v = v
-  // CHECK: bb0([[DEST:%[0-9]+]] : $*Unloadable, [[VARG:%[0-9]+]] : $*Unloadable):
+  // CHECK: bb0([[DEST:%[0-9]+]] : @trivial $*Unloadable, [[VARG:%[0-9]+]] : @trivial $*Unloadable):
   // CHECK: [[VBOX:%.*]] = alloc_box ${ var Unloadable }
   // CHECK: [[PBOX:%[0-9]+]] = project_box [[VBOX]]
   // CHECK: copy_addr [[VARG]] to [initialization] [[PBOX]] : $*Unloadable
@@ -202,7 +202,7 @@ func address_only_assignment_from_temp_to_property() {
 
 // CHECK-LABEL: sil hidden @_T018address_only_types0a1_B31_assignment_from_lv_to_property{{[_0-9a-zA-Z]*}}F
 func address_only_assignment_from_lv_to_property(_ v: Unloadable) {
-  // CHECK: bb0([[VARG:%[0-9]+]] : $*Unloadable):
+  // CHECK: bb0([[VARG:%[0-9]+]] : @trivial $*Unloadable):
   // CHECK: debug_value_addr [[VARG]] : $*Unloadable
   // CHECK: [[TEMP:%[0-9]+]] = alloc_stack $Unloadable
   // CHECK: copy_addr [[VARG]] to [initialization] [[TEMP]]
@@ -214,7 +214,7 @@ func address_only_assignment_from_lv_to_property(_ v: Unloadable) {
 
 // CHECK-LABEL: sil hidden @_T018address_only_types0a1_B4_varAA10Unloadable_pyF
 func address_only_var() -> Unloadable {
-  // CHECK: bb0([[RET:%[0-9]+]] : $*Unloadable):
+  // CHECK: bb0([[RET:%[0-9]+]] : @trivial $*Unloadable):
   var x = some_address_only_function_1()
   // CHECK: [[XBOX:%[0-9]+]] = alloc_box ${ var Unloadable }
   // CHECK: [[XPB:%.*]] = project_box [[XBOX]]

--- a/test/SILGen/addressors.swift
+++ b/test/SILGen/addressors.swift
@@ -1,6 +1,6 @@
-// RUN: %target-swift-frontend -parse-stdlib -emit-sil %s | %FileCheck %s
-// RUN: %target-swift-frontend -parse-stdlib -emit-silgen %s | %FileCheck %s -check-prefix=SILGEN
-// RUN: %target-swift-frontend -parse-stdlib -emit-ir %s
+// RUN: %target-swift-frontend -enable-sil-ownership -parse-stdlib -emit-sil %s | %FileCheck %s
+// RUN: %target-swift-frontend -enable-sil-ownership -parse-stdlib -emit-silgen %s | %FileCheck %s -check-prefix=SILGEN
+// RUN: %target-swift-frontend -enable-sil-ownership -parse-stdlib -emit-ir %s
 
 // This test includes some calls to transparent stdlib functions.
 // We pattern match for the absence of access markers in the inlined code.
@@ -32,14 +32,14 @@ struct A {
 }
 
 // CHECK-LABEL: sil hidden @_T010addressors1AV9subscripts5Int32VAFcflu : $@convention(method) (Int32, A) -> UnsafePointer<Int32>
-// CHECK: bb0([[INDEX:%.*]] : $Int32, [[SELF:%.*]] : $A):
+// CHECK: bb0([[INDEX:%.*]] : @trivial $Int32, [[SELF:%.*]] : @trivial $A):
 // CHECK:   [[BASE:%.*]] = struct_extract [[SELF]] : $A, #A.base
 // CHECK:   [[T0:%.*]] = struct_extract [[BASE]] : $UnsafeMutablePointer<Int32>, #UnsafeMutablePointer._rawValue
 // CHECK:   [[T1:%.*]] = struct $UnsafePointer<Int32> ([[T0]] : $Builtin.RawPointer)
 // CHECK:   return [[T1]] : $UnsafePointer<Int32>
 
 // CHECK-LABEL: sil hidden @_T010addressors1AV9subscripts5Int32VAFcfau : $@convention(method) (Int32, @inout A) -> UnsafeMutablePointer<Int32>
-// CHECK: bb0([[INDEX:%.*]] : $Int32, [[SELF:%.*]] : $*A):
+// CHECK: bb0([[INDEX:%.*]] : @trivial $Int32, [[SELF:%.*]] : @trivial $*A):
 // CHECK:   [[READ:%.*]] = begin_access [read] [static] [[SELF]] : $*A
 // CHECK:   [[T0:%.*]] = struct_element_addr [[READ]] : $*A, #A.base
 // CHECK:   [[BASE:%.*]] = load [[T0]] : $*UnsafeMutablePointer<Int32>
@@ -132,7 +132,7 @@ struct B : Subscriptable {
 }
 
 // CHECK-LABEL: sil hidden @_T010addressors6test_ByAA1BVzF : $@convention(thin) (@inout B) -> () {
-// CHECK: bb0([[B:%.*]] : $*B):
+// CHECK: bb0([[B:%.*]] : @trivial $*B):
 // CHECK:   [[T0:%.*]] = integer_literal $Builtin.Int32, 0
 // CHECK:   [[INDEX:%.*]] = struct $Int32 ([[T0]] : $Builtin.Int32)
 // CHECK:   [[RHS:%.*]] = integer_literal $Builtin.Int32, 7
@@ -162,7 +162,7 @@ struct CArray<T> {
 func id_int(_ i: Int32) -> Int32 { return i }
 
 // CHECK-LABEL: sil hidden @_T010addressors11test_carrays5Int32VAA6CArrayVyA2DcGzF : $@convention(thin) (@inout CArray<(Int32) -> Int32>) -> Int32 {
-// CHECK: bb0([[ARRAY:%.*]] : $*CArray<(Int32) -> Int32>):
+// CHECK: bb0([[ARRAY:%.*]] : @trivial $*CArray<(Int32) -> Int32>):
 func test_carray(_ array: inout CArray<(Int32) -> Int32>) -> Int32 {
 // CHECK:   [[WRITE:%.*]] = begin_access [modify] [static] [[ARRAY]] : $*CArray<(Int32) -> Int32>
 // CHECK:   [[T0:%.*]] = function_ref @_T010addressors6CArrayV9subscriptxSicfau :
@@ -191,7 +191,7 @@ struct D : Subscriptable {
 }
 // Setter.
 // SILGEN-LABEL: sil hidden [transparent] @_T010addressors1DV9subscripts5Int32VAFcfs
-// SILGEN: bb0([[VALUE:%.*]] : $Int32, [[I:%.*]] : $Int32, [[SELF:%.*]] : $*D):
+// SILGEN: bb0([[VALUE:%.*]] : @trivial $Int32, [[I:%.*]] : @trivial $Int32, [[SELF:%.*]] : @trivial $*D):
 // SILGEN:   debug_value [[VALUE]] : $Int32
 // SILGEN:   debug_value [[I]] : $Int32
 // SILGEN:   debug_value_addr [[SELF]]
@@ -204,7 +204,7 @@ struct D : Subscriptable {
 
 // materializeForSet.
 // SILGEN-LABEL: sil hidden [transparent] @_T010addressors1DV9subscripts5Int32VAFcfm
-// SILGEN: bb0([[BUFFER:%.*]] : $Builtin.RawPointer, [[STORAGE:%.*]] : $*Builtin.UnsafeValueBuffer, [[I:%.*]] : $Int32, [[SELF:%.*]] : $*D):
+// SILGEN: bb0([[BUFFER:%.*]] : @trivial $Builtin.RawPointer, [[STORAGE:%.*]] : @trivial $*Builtin.UnsafeValueBuffer, [[I:%.*]] : @trivial $Int32, [[SELF:%.*]] : @trivial $*D):
 // SILGEN:   [[T0:%.*]] = function_ref @_T010addressors1DV9subscripts5Int32VAFcfau
 // SILGEN:   [[PTR:%.*]] = apply [[T0]]([[I]], [[SELF]])
 // SILGEN:   [[ADDR_TMP:%.*]] = struct_extract [[PTR]] : $UnsafeMutablePointer<Int32>,
@@ -218,7 +218,7 @@ func make_int() -> Int32 { return 0 }
 func take_int_inout(_ value: inout Int32) {}
 
 // CHECK-LABEL: sil hidden @_T010addressors6test_ds5Int32VAA1DVzF : $@convention(thin) (@inout D) -> Int32
-// CHECK: bb0([[ARRAY:%.*]] : $*D):
+// CHECK: bb0([[ARRAY:%.*]] : @trivial $*D):
 func test_d(_ array: inout D) -> Int32 {
 // CHECK:   [[T0:%.*]] = function_ref @_T010addressors8make_ints5Int32VyF
 // CHECK:   [[V:%.*]] = apply [[T0]]()
@@ -255,7 +255,7 @@ struct E {
 }
 
 // CHECK-LABEL: sil hidden @_T010addressors6test_eyAA1EVF
-// CHECK: bb0([[E:%.*]] : $E):
+// CHECK: bb0([[E:%.*]] : @trivial $E):
 // CHECK:   [[T0:%.*]] = function_ref @_T010addressors1EV5values5Int32Vfau
 // CHECK:   [[T1:%.*]] = apply [[T0]]([[E]])
 // CHECK:   [[T2:%.*]] = struct_extract [[T1]]
@@ -285,7 +285,7 @@ func test_f0(_ f: F) -> Int32 {
   return f.value
 }
 // CHECK-LABEL: sil hidden @_T010addressors7test_f0s5Int32VAA1FCF : $@convention(thin) (@owned F) -> Int32 {
-// CHECK: bb0([[SELF:%0]] : $F):
+// CHECK: bb0([[SELF:%0]] : @owned $F):
 // CHECK:   [[ADDRESSOR:%.*]] = function_ref @_T010addressors1FC5values5Int32Vflo : $@convention(method) (@guaranteed F) -> (UnsafePointer<Int32>, @owned Builtin.NativeObject)
 // CHECK:   [[T0:%.*]] = apply [[ADDRESSOR]]([[SELF]])
 // CHECK:   [[PTR:%.*]] = tuple_extract [[T0]] : $(UnsafePointer<Int32>, Builtin.NativeObject), 0
@@ -302,7 +302,7 @@ func test_f1(_ f: F) {
   f.value = 14
 }
 // CHECK-LABEL: sil hidden @_T010addressors7test_f1yAA1FCF : $@convention(thin) (@owned F) -> () {
-// CHECK: bb0([[SELF:%0]] : $F):
+// CHECK: bb0([[SELF:%0]] : @owned $F):
 // CHECK:   [[T0:%.*]] = integer_literal $Builtin.Int32, 14
 // CHECK:   [[VALUE:%.*]] = struct $Int32 ([[T0]] : $Builtin.Int32)
 // CHECK:   [[ADDRESSOR:%.*]] = function_ref @_T010addressors1FC5values5Int32Vfao : $@convention(method) (@guaranteed F) -> (UnsafeMutablePointer<Int32>, @owned Builtin.NativeObject)
@@ -329,7 +329,7 @@ class G {
   }
 }
 // CHECK-LABEL: sil hidden [transparent] @_T010addressors1GC5values5Int32Vfg : $@convention(method) (@guaranteed G) -> Int32 {
-// CHECK: bb0([[SELF:%0]] : $G):
+// CHECK: bb0([[SELF:%0]] : @guaranteed $G):
 // CHECK:   [[ADDRESSOR:%.*]] = function_ref @_T010addressors1GC5values5Int32Vflo : $@convention(method) (@guaranteed G) -> (UnsafePointer<Int32>, @owned Builtin.NativeObject)
 // CHECK:   [[T0:%.*]] = apply [[ADDRESSOR]]([[SELF]])
 // CHECK:   [[PTR:%.*]] = tuple_extract [[T0]] : $(UnsafePointer<Int32>, Builtin.NativeObject), 0
@@ -342,7 +342,7 @@ class G {
 // CHECK:   return [[VALUE]] : $Int32
 
 // CHECK-LABEL: sil hidden [transparent] @_T010addressors1GC5values5Int32Vfs : $@convention(method) (Int32, @guaranteed G) -> () {
-// CHECK: bb0([[VALUE:%0]] : $Int32, [[SELF:%1]] : $G):
+// CHECK: bb0([[VALUE:%0]] : @trivial $Int32, [[SELF:%1]] : @guaranteed $G):
 // CHECK:   [[ADDRESSOR:%.*]] = function_ref @_T010addressors1GC5values5Int32Vfao : $@convention(method) (@guaranteed G) -> (UnsafeMutablePointer<Int32>, @owned Builtin.NativeObject)
 // CHECK:   [[T0:%.*]] = apply [[ADDRESSOR]]([[SELF]])
 // CHECK:   [[PTR:%.*]] = tuple_extract [[T0]] : $(UnsafeMutablePointer<Int32>, Builtin.NativeObject), 0
@@ -355,7 +355,7 @@ class G {
 
 //   materializeForSet callback for G.value
 // CHECK-LABEL: sil private [transparent] @_T010addressors1GC5values5Int32VfmytfU_ : $@convention(method) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout G, @thick G.Type) -> () {
-// CHECK: bb0([[BUFFER:%0]] : $Builtin.RawPointer, [[STORAGE:%1]] : $*Builtin.UnsafeValueBuffer, [[SELF:%2]] : $*G, [[SELFTYPE:%3]] : $@thick G.Type):
+// CHECK: bb0([[BUFFER:%0]] : @trivial $Builtin.RawPointer, [[STORAGE:%1]] : @trivial $*Builtin.UnsafeValueBuffer, [[SELF:%2]] : @trivial $*G, [[SELFTYPE:%3]] : @trivial $@thick G.Type):
 // CHECK:   [[T0:%.*]] = project_value_buffer $Builtin.NativeObject in [[STORAGE]] : $*Builtin.UnsafeValueBuffer
 // CHECK:   [[OWNER:%.*]] = load [[T0]]
 // CHECK:   strong_release [[OWNER]] : $Builtin.NativeObject
@@ -363,7 +363,7 @@ class G {
 
 //   materializeForSet for G.value
 // CHECK-LABEL: sil hidden [transparent] @_T010addressors1GC5values5Int32Vfm : $@convention(method) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @guaranteed G) -> (Builtin.RawPointer, Optional<Builtin.RawPointer>) {
-// CHECK: bb0([[BUFFER:%0]] : $Builtin.RawPointer, [[STORAGE:%1]] : $*Builtin.UnsafeValueBuffer, [[SELF:%2]] : $G):
+// CHECK: bb0([[BUFFER:%0]] : @trivial $Builtin.RawPointer, [[STORAGE:%1]] : @trivial $*Builtin.UnsafeValueBuffer, [[SELF:%2]] : @guaranteed $G):
 //   Call the addressor.
 // CHECK:   [[ADDRESSOR:%.*]] = function_ref @_T010addressors1GC5values5Int32Vfao : $@convention(method) (@guaranteed G) -> (UnsafeMutablePointer<Int32>, @owned Builtin.NativeObject)
 // CHECK:   [[T0:%.*]] = apply [[ADDRESSOR]]([[SELF]])
@@ -405,7 +405,7 @@ func test_h0(_ f: H) -> Int32 {
   return f.value
 }
 // CHECK-LABEL: sil hidden @_T010addressors7test_h0s5Int32VAA1HCF : $@convention(thin) (@owned H) -> Int32 {
-// CHECK: bb0([[SELF:%0]] : $H):
+// CHECK: bb0([[SELF:%0]] : @owned $H):
 // CHECK:   [[ADDRESSOR:%.*]] = function_ref @_T010addressors1HC5values5Int32Vflp : $@convention(method) (@guaranteed H) -> (UnsafePointer<Int32>, @owned Optional<Builtin.NativeObject>)
 // CHECK:   [[T0:%.*]] = apply [[ADDRESSOR]]([[SELF]])
 // CHECK:   [[PTR:%.*]] = tuple_extract [[T0]] : $(UnsafePointer<Int32>, Optional<Builtin.NativeObject>), 0
@@ -422,7 +422,7 @@ func test_h1(_ f: H) {
   f.value = 14
 }
 // CHECK-LABEL: sil hidden @_T010addressors7test_h1yAA1HCF : $@convention(thin) (@owned H) -> () {
-// CHECK: bb0([[SELF:%0]] : $H):
+// CHECK: bb0([[SELF:%0]] : @owned $H):
 // CHECK:   [[T0:%.*]] = integer_literal $Builtin.Int32, 14
 // CHECK:   [[VALUE:%.*]] = struct $Int32 ([[T0]] : $Builtin.Int32)
 // CHECK:   [[ADDRESSOR:%.*]] = function_ref @_T010addressors1HC5values5Int32VfaP : $@convention(method) (@guaranteed H) -> (UnsafeMutablePointer<Int32>, @owned Optional<Builtin.NativeObject>)
@@ -449,7 +449,7 @@ class I {
   }
 }
 // CHECK-LABEL: sil hidden [transparent] @_T010addressors1IC5values5Int32Vfg : $@convention(method) (@guaranteed I) -> Int32 {
-// CHECK: bb0([[SELF:%0]] : $I):
+// CHECK: bb0([[SELF:%0]] : @guaranteed $I):
 // CHECK:   [[ADDRESSOR:%.*]] = function_ref @_T010addressors1IC5values5Int32Vflp : $@convention(method) (@guaranteed I) -> (UnsafePointer<Int32>, @owned Optional<Builtin.NativeObject>)
 // CHECK:   [[T0:%.*]] = apply [[ADDRESSOR]]([[SELF]])
 // CHECK:   [[PTR:%.*]] = tuple_extract [[T0]] : $(UnsafePointer<Int32>, Optional<Builtin.NativeObject>), 0
@@ -462,7 +462,7 @@ class I {
 // CHECK:   return [[VALUE]] : $Int32
 
 // CHECK-LABEL: sil hidden [transparent] @_T010addressors1IC5values5Int32Vfs : $@convention(method) (Int32, @guaranteed I) -> () {
-// CHECK: bb0([[VALUE:%0]] : $Int32, [[SELF:%1]] : $I):
+// CHECK: bb0([[VALUE:%0]] : @trivial $Int32, [[SELF:%1]] : @guaranteed $I):
 // CHECK:   [[ADDRESSOR:%.*]] = function_ref @_T010addressors1IC5values5Int32VfaP : $@convention(method) (@guaranteed I) -> (UnsafeMutablePointer<Int32>, @owned Optional<Builtin.NativeObject>)
 // CHECK:   [[T0:%.*]] = apply [[ADDRESSOR]]([[SELF]])
 // CHECK:   [[PTR:%.*]] = tuple_extract [[T0]] : $(UnsafeMutablePointer<Int32>, Optional<Builtin.NativeObject>), 0
@@ -475,14 +475,14 @@ class I {
 
 //   materializeForSet callback for I.value
 // CHECK-LABEL: sil private [transparent] @_T010addressors1IC5values5Int32VfmytfU_ : $@convention(method) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout I, @thick I.Type) -> () {
-// CHECK: bb0([[BUFFER:%0]] : $Builtin.RawPointer, [[STORAGE:%1]] : $*Builtin.UnsafeValueBuffer, [[SELF:%2]] : $*I, [[SELFTYPE:%3]] : $@thick I.Type):
+// CHECK: bb0([[BUFFER:%0]] : @trivial $Builtin.RawPointer, [[STORAGE:%1]] : @trivial $*Builtin.UnsafeValueBuffer, [[SELF:%2]] : @trivial $*I, [[SELFTYPE:%3]] : @trivial $@thick I.Type):
 // CHECK:   [[T0:%.*]] = project_value_buffer $Optional<Builtin.NativeObject> in [[STORAGE]] : $*Builtin.UnsafeValueBuffer
 // CHECK:   [[OWNER:%.*]] = load [[T0]]
 // CHECK:   strong_unpin [[OWNER]] : $Optional<Builtin.NativeObject>
 // CHECK:   dealloc_value_buffer $Optional<Builtin.NativeObject> in [[STORAGE]] : $*Builtin.UnsafeValueBuffer
 
 // CHECK-LABEL: sil hidden [transparent] @_T010addressors1IC5values5Int32Vfm : $@convention(method) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @guaranteed I) -> (Builtin.RawPointer, Optional<Builtin.RawPointer>) {
-// CHECK: bb0([[BUFFER:%0]] : $Builtin.RawPointer, [[STORAGE:%1]] : $*Builtin.UnsafeValueBuffer, [[SELF:%2]] : $I):
+// CHECK: bb0([[BUFFER:%0]] : @trivial $Builtin.RawPointer, [[STORAGE:%1]] : @trivial $*Builtin.UnsafeValueBuffer, [[SELF:%2]] : @guaranteed $I):
 //   Call the addressor.
 // CHECK:   [[ADDRESSOR:%.*]] = function_ref @_T010addressors1IC5values5Int32VfaP : $@convention(method) (@guaranteed I) -> (UnsafeMutablePointer<Int32>, @owned Optional<Builtin.NativeObject>)
 // CHECK:   [[T0:%.*]] = apply [[ADDRESSOR]]([[SELF]])

--- a/test/SILGen/arguments.swift
+++ b/test/SILGen/arguments.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -module-name Swift -parse-stdlib -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -module-name Swift -enable-sil-ownership -parse-stdlib -emit-silgen %s | %FileCheck %s
 
 struct Int {}
 struct Float {}
@@ -20,13 +20,13 @@ var i:Int, f:Float, c:UnicodeScalar
 
 func arg_tuple(x: Int, y: Float) {}
 // CHECK-LABEL: sil hidden @_T0s9arg_tupleySi1x_Sf1ytF
-// CHECK: bb0([[X:%[0-9]+]] : $Int, [[Y:%[0-9]+]] : $Float):
+// CHECK: bb0([[X:%[0-9]+]] : @trivial $Int, [[Y:%[0-9]+]] : @trivial $Float):
 
 arg_tuple(x: i, y: f)
 
 func arg_deep_tuples(x: Int, y: (Float, UnicodeScalar)) {}
 // CHECK-LABEL: sil hidden @_T0s15arg_deep_tuplesySi1x_Sf_Sct1ytF
-// CHECK: bb0([[X:%[0-9]+]] : $Int, [[Y_0:%[0-9]+]] : $Float, [[Y_1:%[0-9]+]] : $UnicodeScalar):
+// CHECK: bb0([[X:%[0-9]+]] : @trivial $Int, [[Y_0:%[0-9]+]] : @trivial $Float, [[Y_1:%[0-9]+]] : @trivial $UnicodeScalar):
 
 arg_deep_tuples(x:i, y:(f, c))
 var unnamed_subtuple = (f, c)
@@ -38,7 +38,7 @@ arg_deep_tuples(x:i, y: named_subtuple)
 
 func arg_deep_tuples_2(x: Int, _: (y: Float, z: UnicodeScalar)) {}
 // CHECK-LABEL: sil hidden @_T0s17arg_deep_tuples_2ySi1x_Sf1y_Sc1zttF
-// CHECK: bb0([[X:%[0-9]+]] : $Int, [[Y:%[0-9]+]] : $Float, [[Z:%[0-9]+]] : $UnicodeScalar):
+// CHECK: bb0([[X:%[0-9]+]] : @trivial $Int, [[Y:%[0-9]+]] : @trivial $Float, [[Z:%[0-9]+]] : @trivial $UnicodeScalar):
 
 arg_deep_tuples_2(x: i, (f, c))
 arg_deep_tuples_2(x: i, unnamed_subtuple)
@@ -49,7 +49,7 @@ arg_deep_tuples_2(x: i, unnamed_subtuple)
 
 func arg_default_tuple(x x: Int = i, y: Float = f) {}
 // CHECK-LABEL: sil hidden @_T0s17arg_default_tupleySi1x_Sf1ytF
-// CHECK: bb0([[X:%[0-9]+]] : $Int, [[Y:%[0-9]+]] : $Float):
+// CHECK: bb0([[X:%[0-9]+]] : @trivial $Int, [[Y:%[0-9]+]] : @trivial $Float):
 
 arg_default_tuple()
 arg_default_tuple(x:i)
@@ -59,7 +59,7 @@ arg_default_tuple(x:i, y:f)
 
 func variadic_arg_1(_ x: Int...) {}
 // CHECK-LABEL: sil hidden @_T0s14variadic_arg_1{{[_0-9a-zA-Z]*}}F
-// CHECK: bb0([[X:%[0-9]+]] : $Array<Int>):
+// CHECK: bb0([[X:%[0-9]+]] : @trivial $Array<Int>):
 
 variadic_arg_1()
 variadic_arg_1(i)
@@ -68,7 +68,7 @@ variadic_arg_1(i, i, i)
 
 func variadic_arg_2(_ x: Int, _ y: Float...) {}
 // CHECK-LABEL: sil hidden @_T0s14variadic_arg_2{{[_0-9a-zA-Z]*}}F
-// CHECK: bb0([[X:%[0-9]+]] : $Int, [[Y:%[0-9]+]] : $Array<Float>):
+// CHECK: bb0([[X:%[0-9]+]] : @trivial $Int, [[Y:%[0-9]+]] : @trivial $Array<Float>):
 
 variadic_arg_2(i)
 variadic_arg_2(i, f)
@@ -76,7 +76,7 @@ variadic_arg_2(i, f, f, f)
 
 func variadic_arg_3(_ y: Float..., x: Int) {}
 // CHECK-LABEL: sil hidden @_T0s14variadic_arg_3{{[_0-9a-zA-Z]*}}F
-// CHECK: bb0([[Y:%[0-9]+]] : $Array<Float>, [[X:%[0-9]+]] : $Int):
+// CHECK: bb0([[Y:%[0-9]+]] : @trivial $Array<Float>, [[X:%[0-9]+]] : @trivial $Int):
 
 variadic_arg_3(x: i)
 variadic_arg_3(f, x: i)

--- a/test/SILGen/borrow.swift
+++ b/test/SILGen/borrow.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -parse-stdlib -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -enable-sil-ownership -parse-stdlib -emit-silgen %s | %FileCheck %s
 
 import Swift
 

--- a/test/SILGen/capture_inout.swift
+++ b/test/SILGen/capture_inout.swift
@@ -1,9 +1,9 @@
-// RUN: %target-swift-frontend -parse-stdlib -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -enable-sil-ownership -parse-stdlib -emit-silgen %s | %FileCheck %s
 
 typealias Int = Builtin.Int64
 
 // CHECK: sil hidden @_T013capture_inout8localFooyBi64_z1x_tF
-// CHECK: bb0([[X_INOUT:%.*]] : $*Builtin.Int64):
+// CHECK: bb0([[X_INOUT:%.*]] : @trivial $*Builtin.Int64):
 // CHECK-NOT: alloc_box
 // CHECK:   [[FUNC:%.*]] = function_ref [[CLOSURE:@.*]] : $@convention(thin) (@inout_aliasable Builtin.Int64) -> Builtin.Int64
 // CHECK:   apply [[FUNC]]([[X_INOUT]])
@@ -17,7 +17,7 @@ func localFoo(x: inout Int) {
 }
 
 // CHECK: sil hidden @_T013capture_inout7anonFooyBi64_z1x_tF
-// CHECK: bb0([[X_INOUT:%.*]] : $*Builtin.Int64):
+// CHECK: bb0([[X_INOUT:%.*]] : @trivial $*Builtin.Int64):
 // CHECK-NOT: alloc_box
 // CHECK:   [[FUNC:%.*]] = function_ref [[CLOSURE:@.*]] : $@convention(thin) (@inout_aliasable Builtin.Int64) -> Builtin.Int64
 // CHECK:   apply [[FUNC]]([[X_INOUT]])

--- a/test/SILGen/capture_typealias.swift
+++ b/test/SILGen/capture_typealias.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -parse-stdlib -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -enable-sil-ownership -parse-stdlib -emit-silgen %s | %FileCheck %s
 
 typealias Int = Builtin.Int64
 

--- a/test/SILGen/conditionally_unreachable.swift
+++ b/test/SILGen/conditionally_unreachable.swift
@@ -1,8 +1,8 @@
-// RUN: %target-swift-frontend -emit-silgen -parse-stdlib -primary-file %s | %FileCheck %s -check-prefix=RAW
-// RUN: %target-swift-frontend -emit-sil -assert-config Debug -parse-stdlib -primary-file %s | %FileCheck -check-prefix=DEBUG %s
-// RUN: %target-swift-frontend -emit-sil -O -assert-config Debug -parse-stdlib -primary-file %s | %FileCheck -check-prefix=DEBUG %s
-// RUN: %target-swift-frontend -emit-sil -assert-config Release -parse-stdlib -primary-file %s | %FileCheck -check-prefix=RELEASE %s
-// RUN: %target-swift-frontend -emit-sil -O -assert-config Release -parse-stdlib -primary-file %s | %FileCheck -check-prefix=RELEASE %s
+// RUN: %target-swift-frontend -enable-sil-ownership -emit-silgen -parse-stdlib -primary-file %s | %FileCheck %s -check-prefix=RAW
+// RUN: %target-swift-frontend -enable-sil-ownership -emit-sil -assert-config Debug -parse-stdlib -primary-file %s | %FileCheck -check-prefix=DEBUG %s
+// RUN: %target-swift-frontend -enable-sil-ownership -emit-sil -O -assert-config Debug -parse-stdlib -primary-file %s | %FileCheck -check-prefix=DEBUG %s
+// RUN: %target-swift-frontend -enable-sil-ownership -emit-sil -assert-config Release -parse-stdlib -primary-file %s | %FileCheck -check-prefix=RELEASE %s
+// RUN: %target-swift-frontend -enable-sil-ownership -emit-sil -O -assert-config Release -parse-stdlib -primary-file %s | %FileCheck -check-prefix=RELEASE %s
 
 import Swift
 

--- a/test/SILGen/copy_lvalue_peepholes.swift
+++ b/test/SILGen/copy_lvalue_peepholes.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -parse-stdlib -parse-as-library -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -enable-sil-ownership -parse-stdlib -parse-as-library -emit-silgen %s | %FileCheck %s
 
 precedencegroup AssignmentPrecedence { assignment: true }
 

--- a/test/SILGen/effectsattr.swift
+++ b/test/SILGen/effectsattr.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -parse-stdlib -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -enable-sil-ownership -parse-stdlib -emit-silgen %s | %FileCheck %s
 
 
 //CHECK: [readonly] @func1


### PR DESCRIPTION
[silgen] Update a group of SILGen tests to run with -enable-sil-ownership.

The key thing here is that these do not depend on the standard library, so I can
update them now.

rdar://31880847