### PR TITLE
[ClangImporter] Structs lexically in an ObjC class are still top-level.

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -8001,8 +8001,10 @@ ClangImporter::Implementation::loadAllMembers(Decl *D, uint64_t extra) {
   llvm::SmallPtrSet<Decl *, 4> knownAlternateMembers;
   for (const clang::Decl *m : objcContainer->decls()) {
     auto nd = dyn_cast<clang::NamedDecl>(m);
-    if (!nd || nd != nd->getCanonicalDecl())
+    if (!nd || nd != nd->getCanonicalDecl() ||
+        nd->getDeclContext() != objcContainer) {
       continue;
+    }
 
     forEachDistinctName(nd,
                         [&](ImportedName name, ImportNameVersion nameVersion) {

--- a/test/ClangImporter/Inputs/custom-modules/CInsideObjC.h
+++ b/test/ClangImporter/Inputs/custom-modules/CInsideObjC.h
@@ -1,0 +1,35 @@
+@interface Base
+@end
+
+struct AlreadyDeclaredStruct {
+  int value;
+};
+
+#if defined(CLASS)
+@interface Wrapper : Base 
+#elif defined(CATEGORY)
+@interface Wrapper : Base
+@end
+@interface Wrapper (Category)
+#elif defined(PROTOCOL)
+@protocol Wrapper
+#else
+# error "Must pick a variant"
+#endif
+
+extern void nestedFunc(void);
+
+@property struct ForwardDeclaredStruct forward;
+@property struct AlreadyDeclaredStruct backward;
+
+struct NestedDeclaredStruct {
+  int value;
+};
+typedef int NestedTypedef;
+extern const int nestedGlobal;
+
+@end
+
+struct ForwardDeclaredStruct {
+  int value;
+};

--- a/test/ClangImporter/Inputs/custom-modules/module.map
+++ b/test/ClangImporter/Inputs/custom-modules/module.map
@@ -12,6 +12,11 @@ module CFAndObjC {
   export *
 }
 
+module CInsideObjC {
+  header "CInsideObjC.h"
+  export *
+}
+
 module ClangModuleUser {
   header "ClangModuleUser.h"
   export *

--- a/test/ClangImporter/c_inside_objc.swift
+++ b/test/ClangImporter/c_inside_objc.swift
@@ -1,0 +1,33 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print CInsideObjC -I %S/Inputs/custom-modules -source-filename %s -Xcc -DCLASS | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print CInsideObjC -I %S/Inputs/custom-modules -source-filename %s -Xcc -DCATEGORY | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print CInsideObjC -I %S/Inputs/custom-modules -source-filename %s -Xcc -DPROTOCOL | %FileCheck %s
+
+// RUN: %target-swift-frontend -typecheck %s -I %S/Inputs/custom-modules -verify -Xcc -DCLASS
+// RUN: %target-swift-frontend -typecheck %s -I %S/Inputs/custom-modules -verify -Xcc -DCATEGORY
+// RUN: %target-swift-frontend -typecheck %s -I %S/Inputs/custom-modules -verify -Xcc -DPROTOCOL
+
+// REQUIRES: objc_interop
+
+// CHECK-LABEL: struct AlreadyDeclaredStruct {
+
+// CHECK-LABEL: {{class Wrapper : Base {|extension Wrapper {|protocol Wrapper {}}
+// CHECK-NOT: struct
+// CHECK: var forward: ForwardDeclaredStruct
+// CHECK-NOT: struct
+// CHECK: var backward: AlreadyDeclaredStruct
+// CHECK-NOT: struct
+// CHECK: {{^}$}}
+
+// CHECK-LABEL: func nestedFunc()
+// CHECK-LABEL: struct NestedDeclaredStruct {
+// CHECK-LABEL: typealias NestedTypedef = Int32
+// CHECK-LABEL: let nestedGlobal: Int32
+
+// CHECK-LABEL: struct ForwardDeclaredStruct {
+
+import CInsideObjC
+
+func testTypeLookup(_: AlreadyDeclaredStruct) {}
+func testTypeLookup(_: NestedDeclaredStruct) {}
+func testTypeLookup(_: ForwardDeclaredStruct) {}
+func testTypeLookup(_: NestedTypedef) {}


### PR DESCRIPTION
Not every declaration that's syntactically in an Objective-C container is a member of that container. Double-check the decl context before adding it.

This is technically a breaking change in non-asserts builds, because the struct really could be found via member lookup. But that should be considered a bug, and I *suspect* no one is relying on it.

rdar://problem/32451417