### PR TITLE
Add another test for SE-0110-related regression.

### DIFF
--- a/test/Constraints/tuple_arguments.swift
+++ b/test/Constraints/tuple_arguments.swift
@@ -1574,3 +1574,7 @@ func rdar33159366(s: AnySequence<Int>) {
   let a = Array(s)
   _ = a.flatMap(itsFalse)
 }
+
+func sr5429<T>(t: T) {
+  _ = AnySequence([t]).first(where: { (t: T) in true })
+}


### PR DESCRIPTION
Add another test for the issue fixed in
9f68dee672f5a6efa92c9e077426472bb54f1f5b, this time from the report in
https://bugs.swift.org/browse/SR-5429.
