### PR TITLE
Remove unused code

### DIFF
--- a/stdlib/public/SDK/Foundation/Data.swift
+++ b/stdlib/public/SDK/Foundation/Data.swift
@@ -1500,7 +1500,6 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     @inline(__always)
     public func subdata(in range: Range<Index>) -> Data {
         _validateRange(range)
-        let length = count
         if count == 0 {
             return Data()
         }


### PR DESCRIPTION
This was removed in `swift-corelibs-foundation` in https://github.com/apple/swift-corelibs-foundation/pull/1106

Make the same change to the overlay version, to keep them in sync.

@phausler @bubski