### PR TITLE
[swift-4.0-branch][overlay] Fixing the availability of INSearchCallHistoryIntent.init

### DIFF
--- a/stdlib/public/SDK/Intents/INSearchCallHistoryIntent.swift
+++ b/stdlib/public/SDK/Intents/INSearchCallHistoryIntent.swift
@@ -16,7 +16,7 @@ import Foundation
 #if os(iOS) || os(watchOS)
 @available(iOS 10.0, watchOS 3.2, *)
 extension INSearchCallHistoryIntent {
-  @available(iOS 10.0, watchOS 3.2, *)
+  @available(iOS 11.0, watchOS 4.0, *)
   @nonobjc
   public convenience init(
     dateCreated: INDateComponentsRange? = nil,


### PR DESCRIPTION
* Explanation: Sync the availability of APIs in the overlay with what’s in the headers
* Scope of Issue: Correctly marks the new API as only introduced in iOS 11 and watchOS 4 (backward compatibility is handled by the deprecated overload in the headers)
* Risk: Minimal
* Reviewed By: Robert Burton
* Testing: Automated test suite
* Directions for QA: N/A
* Radar: <rdar://problem/33206673>

(cherry picked from commit 95d46b1ee0ce4b1bfd0d2c2c1c49686996210e1e)