### PR TITLE
[4.0] Allow resolved KeyPath and KeyPathApplication exprs to re-type-check.

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -4567,25 +4567,28 @@ public:
     
     
     llvm::PointerIntPair<Expr *, 3, Kind> SubscriptIndexExprAndKind;
+    ArrayRef<Identifier> SubscriptLabels;
     Type ComponentType;
     SourceLoc Loc;
     
     explicit Component(DeclNameOrRef decl,
                        Expr *indexExpr,
+                       ArrayRef<Identifier> subscriptLabels,
                        Kind kind,
                        Type type,
                        SourceLoc loc)
       : Decl(decl), SubscriptIndexExprAndKind(indexExpr, kind),
+        SubscriptLabels(subscriptLabels),
         ComponentType(type), Loc(loc)
     {}
     
   public:
-    Component() : Component({}, nullptr, Kind::Invalid, Type(), SourceLoc()) {}
+    Component() : Component({}, nullptr, {}, Kind::Invalid, Type(), SourceLoc()) {}
     
     /// Create an unresolved component for a property.
     static Component forUnresolvedProperty(DeclName UnresolvedName,
                                            SourceLoc Loc) {
-      return Component(UnresolvedName, nullptr,
+      return Component(UnresolvedName, nullptr, {},
                        Kind::UnresolvedProperty,
                        Type(),
                        Loc);
@@ -4605,14 +4608,16 @@ public:
     /// You shouldn't add new uses of this overload; use the one that takes a
     /// list of index arguments.
     static Component forUnresolvedSubscriptWithPrebuiltIndexExpr(Expr *index,
-                                                                 SourceLoc loc){
+                                         ArrayRef<Identifier> subscriptLabels,
+                                         SourceLoc loc) {
       
-      return Component({}, index, Kind::UnresolvedSubscript, Type(), loc);
+      return Component({}, index, subscriptLabels, Kind::UnresolvedSubscript,
+                       Type(), loc);
     }
     
     /// Create an unresolved optional force `!` component.
     static Component forUnresolvedOptionalForce(SourceLoc BangLoc) {
-      return Component({}, nullptr,
+      return Component({}, nullptr, {},
                        Kind::OptionalForce,
                        Type(),
                        BangLoc);
@@ -4620,7 +4625,7 @@ public:
     
     /// Create an unresolved optional chain `?` component.
     static Component forUnresolvedOptionalChain(SourceLoc QuestionLoc) {
-      return Component({}, nullptr,
+      return Component({}, nullptr, {},
                        Kind::OptionalChain,
                        Type(),
                        QuestionLoc);
@@ -4630,7 +4635,8 @@ public:
     static Component forProperty(ConcreteDeclRef property,
                                  Type propertyType,
                                  SourceLoc loc) {
-      return Component(property, nullptr, Kind::Property,
+      return Component(property, nullptr, {},
+                       Kind::Property,
                        propertyType,
                        loc);
     }
@@ -4651,20 +4657,23 @@ public:
     /// You shouldn't add new uses of this overload; use the one that takes a
     /// list of index arguments.
     static Component forSubscriptWithPrebuiltIndexExpr(
-      ConcreteDeclRef subscript, Expr *index, Type elementType, SourceLoc loc) {
-      return Component(subscript, index, Kind::Subscript, elementType, loc);
+       ConcreteDeclRef subscript, Expr *index, ArrayRef<Identifier> labels,
+       Type elementType, SourceLoc loc) {
+      return Component(subscript, index, {}, Kind::Subscript, elementType, loc);
     }
     
     /// Create an optional-forcing `!` component.
     static Component forOptionalForce(Type forcedType, SourceLoc bangLoc) {
-      return Component({}, nullptr, Kind::OptionalForce, forcedType,
+      return Component({}, nullptr, {},
+                       Kind::OptionalForce, forcedType,
                        bangLoc);
     }
     
     /// Create an optional-chaining `?` component.
     static Component forOptionalChain(Type unwrappedType,
                                       SourceLoc questionLoc) {
-      return Component({}, nullptr, Kind::OptionalChain, unwrappedType,
+      return Component({}, nullptr, {},
+                       Kind::OptionalChain, unwrappedType,
                        questionLoc);
     }
     
@@ -4672,7 +4681,8 @@ public:
     /// syntax but may appear when the non-optional result of an optional chain
     /// is implicitly wrapped.
     static Component forOptionalWrap(Type wrappedType) {
-      return Component({}, nullptr, Kind::OptionalWrap, wrappedType,
+      return Component({}, nullptr, {},
+                       Kind::OptionalWrap, wrappedType,
                        SourceLoc());
     }
     
@@ -4722,7 +4732,23 @@ public:
         llvm_unreachable("no index expr for this kind");
       }
     }
-    
+
+    ArrayRef<Identifier> getSubscriptLabels() const {
+      switch (getKind()) {
+      case Kind::Subscript:
+      case Kind::UnresolvedSubscript:
+        return SubscriptLabels;
+        
+      case Kind::Invalid:
+      case Kind::OptionalChain:
+      case Kind::OptionalWrap:
+      case Kind::OptionalForce:
+      case Kind::UnresolvedProperty:
+      case Kind::Property:
+        llvm_unreachable("no subscript labels for this kind");
+      }
+    }
+
     DeclName getUnresolvedDeclName() const {
       switch (getKind()) {
       case Kind::UnresolvedProperty:

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -4571,24 +4571,24 @@ public:
     Type ComponentType;
     SourceLoc Loc;
     
-    explicit Component(DeclNameOrRef decl,
+    explicit Component(ASTContext *ctxForCopyingLabels,
+                       DeclNameOrRef decl,
                        Expr *indexExpr,
                        ArrayRef<Identifier> subscriptLabels,
                        Kind kind,
                        Type type,
-                       SourceLoc loc)
-      : Decl(decl), SubscriptIndexExprAndKind(indexExpr, kind),
-        SubscriptLabels(subscriptLabels),
-        ComponentType(type), Loc(loc)
-    {}
+                       SourceLoc loc);
     
   public:
-    Component() : Component({}, nullptr, {}, Kind::Invalid, Type(), SourceLoc()) {}
+    Component()
+      : Component(nullptr, {}, nullptr, {}, Kind::Invalid, Type(), SourceLoc())
+    {}
     
     /// Create an unresolved component for a property.
     static Component forUnresolvedProperty(DeclName UnresolvedName,
                                            SourceLoc Loc) {
-      return Component(UnresolvedName, nullptr, {},
+      return Component(nullptr,
+                       UnresolvedName, nullptr, {},
                        Kind::UnresolvedProperty,
                        Type(),
                        Loc);
@@ -4607,17 +4607,20 @@ public:
     ///
     /// You shouldn't add new uses of this overload; use the one that takes a
     /// list of index arguments.
-    static Component forUnresolvedSubscriptWithPrebuiltIndexExpr(Expr *index,
+    static Component forUnresolvedSubscriptWithPrebuiltIndexExpr(
+                                         ASTContext &context,
+                                         Expr *index,
                                          ArrayRef<Identifier> subscriptLabels,
                                          SourceLoc loc) {
       
-      return Component({}, index, subscriptLabels, Kind::UnresolvedSubscript,
+      return Component(&context,
+                       {}, index, subscriptLabels, Kind::UnresolvedSubscript,
                        Type(), loc);
     }
     
     /// Create an unresolved optional force `!` component.
     static Component forUnresolvedOptionalForce(SourceLoc BangLoc) {
-      return Component({}, nullptr, {},
+      return Component(nullptr, {}, nullptr, {},
                        Kind::OptionalForce,
                        Type(),
                        BangLoc);
@@ -4625,7 +4628,7 @@ public:
     
     /// Create an unresolved optional chain `?` component.
     static Component forUnresolvedOptionalChain(SourceLoc QuestionLoc) {
-      return Component({}, nullptr, {},
+      return Component(nullptr, {}, nullptr, {},
                        Kind::OptionalChain,
                        Type(),
                        QuestionLoc);
@@ -4635,7 +4638,7 @@ public:
     static Component forProperty(ConcreteDeclRef property,
                                  Type propertyType,
                                  SourceLoc loc) {
-      return Component(property, nullptr, {},
+      return Component(nullptr, property, nullptr, {},
                        Kind::Property,
                        propertyType,
                        loc);
@@ -4658,13 +4661,11 @@ public:
     /// list of index arguments.
     static Component forSubscriptWithPrebuiltIndexExpr(
        ConcreteDeclRef subscript, Expr *index, ArrayRef<Identifier> labels,
-       Type elementType, SourceLoc loc) {
-      return Component(subscript, index, {}, Kind::Subscript, elementType, loc);
-    }
+       Type elementType, SourceLoc loc);
     
     /// Create an optional-forcing `!` component.
     static Component forOptionalForce(Type forcedType, SourceLoc bangLoc) {
-      return Component({}, nullptr, {},
+      return Component(nullptr, {}, nullptr, {},
                        Kind::OptionalForce, forcedType,
                        bangLoc);
     }
@@ -4672,7 +4673,7 @@ public:
     /// Create an optional-chaining `?` component.
     static Component forOptionalChain(Type unwrappedType,
                                       SourceLoc questionLoc) {
-      return Component({}, nullptr, {},
+      return Component(nullptr, {}, nullptr, {},
                        Kind::OptionalChain, unwrappedType,
                        questionLoc);
     }
@@ -4681,7 +4682,7 @@ public:
     /// syntax but may appear when the non-optional result of an optional chain
     /// is implicitly wrapped.
     static Component forOptionalWrap(Type wrappedType) {
-      return Component({}, nullptr, {},
+      return Component(nullptr, {}, nullptr, {},
                        Kind::OptionalWrap, wrappedType,
                        SourceLoc());
     }

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -957,6 +957,7 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
                 component.getLoc())
             : KeyPathExpr::Component
                          ::forUnresolvedSubscriptWithPrebuiltIndexExpr(
+                E->getType()->getASTContext(),
                 newIndex, component.getSubscriptLabels(), component.getLoc());
         }
         break;

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -952,10 +952,12 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
             ? KeyPathExpr::Component::forSubscriptWithPrebuiltIndexExpr(
                 component.getDeclRef(),
                 newIndex,
+                component.getSubscriptLabels(),
                 component.getComponentType(),
                 component.getLoc())
-            : KeyPathExpr::Component::forUnresolvedSubscriptWithPrebuiltIndexExpr(
-                newIndex, component.getLoc());
+            : KeyPathExpr::Component
+                         ::forUnresolvedSubscriptWithPrebuiltIndexExpr(
+                newIndex, component.getSubscriptLabels(), component.getLoc());
         }
         break;
       }

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -2126,7 +2126,9 @@ KeyPathExpr::Component::forSubscript(ASTContext &ctx,
                                    trailingClosure, /*implicit*/ false,
                                    indexArgLabelsScratch,
                                    indexArgLabelLocsScratch);
-  return forSubscriptWithPrebuiltIndexExpr(subscript, index, elementType,
+  return forSubscriptWithPrebuiltIndexExpr(subscript, index,
+                                           ctx.AllocateCopy(indexArgLabels),
+                                           elementType,
                                            lSquareLoc);
 }
 
@@ -2145,5 +2147,7 @@ KeyPathExpr::Component::forUnresolvedSubscript(ASTContext &ctx,
                                    trailingClosure, /*implicit*/ false,
                                    indexArgLabelsScratch,
                                    indexArgLabelLocsScratch);
-  return forUnresolvedSubscriptWithPrebuiltIndexExpr(index, lSquareLoc);
+  return forUnresolvedSubscriptWithPrebuiltIndexExpr(index,
+                                               ctx.AllocateCopy(indexArgLabels),
+                                               lSquareLoc);
 }

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -2127,7 +2127,7 @@ KeyPathExpr::Component::forSubscript(ASTContext &ctx,
                                    indexArgLabelsScratch,
                                    indexArgLabelLocsScratch);
   return forSubscriptWithPrebuiltIndexExpr(subscript, index,
-                                           ctx.AllocateCopy(indexArgLabels),
+                                           indexArgLabels,
                                            elementType,
                                            lSquareLoc);
 }
@@ -2147,7 +2147,29 @@ KeyPathExpr::Component::forUnresolvedSubscript(ASTContext &ctx,
                                    trailingClosure, /*implicit*/ false,
                                    indexArgLabelsScratch,
                                    indexArgLabelLocsScratch);
-  return forUnresolvedSubscriptWithPrebuiltIndexExpr(index,
-                                               ctx.AllocateCopy(indexArgLabels),
+  return forUnresolvedSubscriptWithPrebuiltIndexExpr(ctx, index,
+                                               indexArgLabels,
                                                lSquareLoc);
+}
+
+KeyPathExpr::Component::Component(ASTContext *ctxForCopyingLabels,
+                     DeclNameOrRef decl,
+                     Expr *indexExpr,
+                     ArrayRef<Identifier> subscriptLabels,
+                     Kind kind,
+                     Type type,
+                     SourceLoc loc)
+    : Decl(decl), SubscriptIndexExprAndKind(indexExpr, kind),
+      SubscriptLabels(subscriptLabels.empty()
+                       ? subscriptLabels
+                       : ctxForCopyingLabels->AllocateCopy(subscriptLabels)),
+      ComponentType(type), Loc(loc)
+  {}
+
+KeyPathExpr::Component
+KeyPathExpr::Component::forSubscriptWithPrebuiltIndexExpr(
+       ConcreteDeclRef subscript, Expr *index, ArrayRef<Identifier> labels,
+       Type elementType, SourceLoc loc) {
+  return Component(&elementType->getASTContext(),
+                   subscript, index, {}, Kind::Subscript, elementType, loc);
 }

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -3712,7 +3712,9 @@ namespace {
     }
 
     Expr *visitKeyPathApplicationExpr(KeyPathApplicationExpr *expr){
-      llvm_unreachable("Already type-checked");
+      // This should already be type-checked, but we may have had to re-
+      // check it for failure diagnosis.
+      return simplifyExprType(expr);
     }
     
     Expr *visitEnumIsCaseExpr(EnumIsCaseExpr *expr) {

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -4144,9 +4144,10 @@ namespace {
           auto ref = ConcreteDeclRef(cs.getASTContext(), subscript, subs);
           component = KeyPathExpr::Component
             ::forSubscriptWithPrebuiltIndexExpr(ref,
-                                                origComponent.getIndexExpr(),
-                                                resolvedTy,
-                                                origComponent.getLoc());
+                                            origComponent.getIndexExpr(),
+                                            origComponent.getSubscriptLabels(),
+                                            resolvedTy,
+                                            origComponent.getLoc());
           break;
         }
         case KeyPathExpr::Component::Kind::OptionalChain: {

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1030,12 +1030,14 @@ namespace {
     /// \brief Add constraints for a subscript operation.
     Type addSubscriptConstraints(Expr *anchor, Type baseTy, Expr *index,
                                  ValueDecl *declOrNull,
-                                 ConstraintLocator *memberLocator = nullptr) {
+                                 ConstraintLocator *memberLocator = nullptr,
+                                 ConstraintLocator *indexLocator = nullptr) {
       ASTContext &Context = CS.getASTContext();
 
       // Locators used in this expression.
-      auto indexLocator
-        = CS.getConstraintLocator(anchor, ConstraintLocator::SubscriptIndex);
+      if (!indexLocator)
+        indexLocator
+          = CS.getConstraintLocator(anchor, ConstraintLocator::SubscriptIndex);
       auto resultLocator
         = CS.getConstraintLocator(anchor, ConstraintLocator::SubscriptResult);
       
@@ -2841,7 +2843,8 @@ namespace {
           auto memberLocator = CS.getConstraintLocator(E,
                         ConstraintLocator::PathElement::getKeyPathComponent(i));
           base = addSubscriptConstraints(E, base, component.getIndexExpr(),
-                                         /*decl*/ nullptr, memberLocator);
+                                         /*decl*/ nullptr, memberLocator,
+                                         /*index locator*/ memberLocator);
           break;
         }
         

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2714,7 +2714,16 @@ namespace {
       llvm_unreachable("Already type-checked");
     }
     Type visitKeyPathApplicationExpr(KeyPathApplicationExpr *expr) {
-      llvm_unreachable("Already type-checked");
+      // This should only appear in already-type-checked solutions, but we may
+      // need to re-check for failure diagnosis.
+      auto locator = CS.getConstraintLocator(expr);
+      auto projectedTy = CS.createTypeVariable(locator,
+                                               TVO_CanBindToLValue);
+      CS.addKeyPathApplicationConstraint(expr->getKeyPath()->getType(),
+                                         expr->getBase()->getType(),
+                                         projectedTy,
+                                         locator);
+      return projectedTy;
     }
     
     Type visitEnumIsCaseExpr(EnumIsCaseExpr *expr) {
@@ -2798,19 +2807,6 @@ namespace {
                          locator);
       }
       
-      // If a component is already resolved, then all of them should be
-      // resolved, and we can let the expression be. This might happen when
-      // re-checking a failed system for diagnostics.
-      if (E->getComponents().front().isResolved()) {
-        assert([&]{
-          for (auto &c : E->getComponents())
-            if (!c.isResolved())
-              return false;
-          return true;
-        }());
-        return E->getType();
-      }
-      
       bool didOptionalChain = false;
       // We start optimistically from an lvalue base.
       Type base = LValueType::get(root);
@@ -2821,16 +2817,23 @@ namespace {
         case KeyPathExpr::Component::Kind::Invalid:
           break;
         
-        case KeyPathExpr::Component::Kind::UnresolvedProperty: {
+        case KeyPathExpr::Component::Kind::UnresolvedProperty:
+        // This should only appear in resolved ASTs, but we may need to
+        // re-type-check the constraints during failure diagnosis.
+        case KeyPathExpr::Component::Kind::Property: {
           auto memberTy = CS.createTypeVariable(locator,
                                                 TVO_CanBindToLValue |
                                                 TVO_CanBindToInOut);
-          auto refKind = component.getUnresolvedDeclName().isSimpleName()
+          auto lookupName = kind == KeyPathExpr::Component::Kind::UnresolvedProperty
+            ? component.getUnresolvedDeclName()
+            : component.getDeclRef().getDecl()->getFullName();
+          
+          auto refKind = lookupName.isSimpleName()
             ? FunctionRefKind::Unapplied
             : FunctionRefKind::Compound;
           auto memberLocator = CS.getConstraintLocator(E,
                         ConstraintLocator::PathElement::getKeyPathComponent(i));
-          CS.addValueMemberConstraint(base, component.getUnresolvedDeclName(),
+          CS.addValueMemberConstraint(base, lookupName,
                                       memberTy,
                                       CurDC,
                                       refKind,
@@ -2839,7 +2842,11 @@ namespace {
           break;
         }
           
-        case KeyPathExpr::Component::Kind::UnresolvedSubscript: {
+        case KeyPathExpr::Component::Kind::UnresolvedSubscript:
+        // Subscript should only appear in resolved ASTs, but we may need to
+        // re-type-check the constraints during failure diagnosis.
+        case KeyPathExpr::Component::Kind::Subscript: {
+
           auto memberLocator = CS.getConstraintLocator(E,
                         ConstraintLocator::PathElement::getKeyPathComponent(i));
           base = addSubscriptConstraints(E, base, component.getIndexExpr(),
@@ -2870,11 +2877,13 @@ namespace {
           break;
         }
         
-        case KeyPathExpr::Component::Kind::Property:
-        case KeyPathExpr::Component::Kind::Subscript:
-        case KeyPathExpr::Component::Kind::OptionalWrap:
-          llvm_unreachable("already resolved");
-        }        
+        case KeyPathExpr::Component::Kind::OptionalWrap: {
+          // This should only appear in resolved ASTs, but we may need to
+          // re-type-check the constraints during failure diagnosis.
+          base = OptionalType::get(base);
+          break;
+        }
+        }
       }
       
       // If there was an optional chaining component, the end result must be

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3895,6 +3895,8 @@ ConstraintSystem::simplifyKeyPathConstraint(Type keyPathTy,
     case KeyPathExpr::Component::Kind::Invalid:
       break;
       
+    case KeyPathExpr::Component::Kind::Property:
+    case KeyPathExpr::Component::Kind::Subscript:
     case KeyPathExpr::Component::Kind::UnresolvedProperty:
     case KeyPathExpr::Component::Kind::UnresolvedSubscript: {
       // If no choice was made, leave the constraint unsolved.
@@ -3939,10 +3941,11 @@ ConstraintSystem::simplifyKeyPathConstraint(Type keyPathTy,
       // Forcing an optional preserves its lvalue-ness.
       break;
     
-    case KeyPathExpr::Component::Kind::Property:
-    case KeyPathExpr::Component::Kind::Subscript:
     case KeyPathExpr::Component::Kind::OptionalWrap:
-      llvm_unreachable("already resolved");
+      // An optional chain should already have forced the entire key path to
+      // be read-only.
+      assert(capability == ReadOnly);
+      break;
     }
   }
 done:

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -516,27 +516,55 @@ getCalleeDeclAndArgs(ConstraintSystem &cs,
   if (!path.empty() &&
       !(path.size() == 1 &&
         (path.back().getKind() == ConstraintLocator::ApplyArgument ||
-         path.back().getKind() == ConstraintLocator::SubscriptIndex)))
+         path.back().getKind() == ConstraintLocator::SubscriptIndex ||
+         path.back().getKind() == ConstraintLocator::KeyPathComponent)))
     return std::make_tuple(nullptr, 0, argLabels, hasTrailingClosure);
 
   // Dig out the callee.
-  Expr *calleeExpr;
+  ConstraintLocator *targetLocator;
   if (auto call = dyn_cast<CallExpr>(callExpr)) {
-    calleeExpr = call->getDirectCallee();
+    targetLocator = cs.getConstraintLocator(call->getDirectCallee());
     argLabels = call->getArgumentLabels();
     hasTrailingClosure = call->hasTrailingClosure();
   } else if (auto unresolved = dyn_cast<UnresolvedMemberExpr>(callExpr)) {
-    calleeExpr = callExpr;
+    targetLocator = cs.getConstraintLocator(callExpr);
     argLabels = unresolved->getArgumentLabels();
     hasTrailingClosure = unresolved->hasTrailingClosure();
   } else if (auto subscript = dyn_cast<SubscriptExpr>(callExpr)) {
-    calleeExpr = callExpr;
+    targetLocator = cs.getConstraintLocator(callExpr);
     argLabels = subscript->getArgumentLabels();
     hasTrailingClosure = subscript->hasTrailingClosure();
   } else if (auto dynSubscript = dyn_cast<DynamicSubscriptExpr>(callExpr)) {
-    calleeExpr = callExpr;
+    targetLocator = cs.getConstraintLocator(callExpr);
     argLabels = dynSubscript->getArgumentLabels();
     hasTrailingClosure = dynSubscript->hasTrailingClosure();
+  } else if (auto keyPath = dyn_cast<KeyPathExpr>(callExpr)) {
+    if (path.empty()
+        || path.back().getKind() != ConstraintLocator::KeyPathComponent)
+      return std::make_tuple(nullptr, 0, argLabels, hasTrailingClosure);
+    
+    auto componentIndex = path.back().getValue();
+    if (componentIndex >= keyPath->getComponents().size())
+      return std::make_tuple(nullptr, 0, argLabels, hasTrailingClosure);
+
+    auto &component = keyPath->getComponents()[componentIndex];
+    switch (component.getKind()) {
+    case KeyPathExpr::Component::Kind::Subscript:
+    case KeyPathExpr::Component::Kind::UnresolvedSubscript:
+      targetLocator = cs.getConstraintLocator(keyPath, path.back());
+      argLabels = component.getSubscriptLabels();
+      hasTrailingClosure = false; // key paths don't support trailing closures
+      break;
+      
+    case KeyPathExpr::Component::Kind::Invalid:
+    case KeyPathExpr::Component::Kind::UnresolvedProperty:
+    case KeyPathExpr::Component::Kind::Property:
+    case KeyPathExpr::Component::Kind::OptionalForce:
+    case KeyPathExpr::Component::Kind::OptionalChain:
+    case KeyPathExpr::Component::Kind::OptionalWrap:
+      return std::make_tuple(nullptr, 0, argLabels, hasTrailingClosure);
+    }
+
   } else {
     if (auto apply = dyn_cast<ApplyExpr>(callExpr)) {
       argLabels = apply->getArgumentLabels(argLabelsScratch);
@@ -547,11 +575,6 @@ getCalleeDeclAndArgs(ConstraintSystem &cs,
     }
     return std::make_tuple(nullptr, 0, argLabels, hasTrailingClosure);
   }
-
-  // Determine the target locator.
-  // FIXME: Check whether the callee is of an expression kind that
-  // could describe a declaration. This is an optimization.
-  ConstraintLocator *targetLocator = cs.getConstraintLocator(calleeExpr);
 
   // Find the overload choice corresponding to the callee locator.
   // FIXME: This linearly walks the list of resolved overloads, which is

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1464,7 +1464,7 @@ void PreCheckExpression::resolveKeyPathExpr(KeyPathExpr *KPE) {
         // .[0] or just plain [0]
         components.push_back(
             KeyPathExpr::Component::forUnresolvedSubscriptWithPrebuiltIndexExpr(
-                SE->getIndex(), SE->getLoc()));
+                SE->getIndex(), SE->getArgumentLabels(), SE->getLoc()));
 
         expr = SE->getBase();
       } else if (auto BOE = dyn_cast<BindOptionalExpr>(expr)) {

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1464,6 +1464,7 @@ void PreCheckExpression::resolveKeyPathExpr(KeyPathExpr *KPE) {
         // .[0] or just plain [0]
         components.push_back(
             KeyPathExpr::Component::forUnresolvedSubscriptWithPrebuiltIndexExpr(
+                TC.Context,
                 SE->getIndex(), SE->getArgumentLabels(), SE->getLoc()));
 
         expr = SE->getBase();

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -328,6 +328,7 @@ func testKeyPathSubscriptLValue(base: Z, kp: inout KeyPath<Z, Z>) {
 
 struct AA {
   subscript(x: Int) -> Int { return x }
+  subscript(labeled x: Int) -> Int { return x }
   var c: CC? = CC()
 }
 
@@ -352,6 +353,17 @@ func testMoreGeneralContext<T, U>(_: KeyPath<T, U>, with: T.Type) {}
 func testLiteralInMoreGeneralContext() {
   testMoreGeneralContext(\.property, with: A.self)
 }
+
+func testLabeledSubscript() {
+  let _: KeyPath<AA, Int> = \AA.[labeled: 0]
+  let _: KeyPath<AA, Int> = \.[labeled: 0]
+  let k = \AA.[labeled: 0]
+
+  // TODO: These ought to work without errors.
+  let _ = \AA.[keyPath: k] // expected-error{{}}
+  let _ = \AA.[keyPath: \AA.[labeled: 0]] // expected-error{{}}
+}
+
 
 func testSyntaxErrors() { // expected-note{{}}
   _ = \.  ; // expected-error{{expected member name following '.'}}

--- a/test/expr/unary/keypath/salvage-with-other-type-errors.swift
+++ b/test/expr/unary/keypath/salvage-with-other-type-errors.swift
@@ -27,5 +27,32 @@ struct A {
 }
 
 extension A: K {
-    static let j = S(\A.id + "id")
+    static let j = S(\A.id + "id") // expected-error {{'+' cannot be applied}} expected-note {{}}
+}
+
+// SR-5034
+
+struct B {
+    let v: String
+    func f1<T, E>(block: (T) -> E) -> B {
+        return self
+    }
+
+    func f2<T, E: Equatable>(keyPath: KeyPath<T, E>) {
+    }
+}
+func f3() {
+    B(v: "").f1(block: { _ in }).f2(keyPath: \B.v) // expected-error{{}}
+}
+
+// SR-5375
+
+protocol Bindable: class { }
+
+extension Bindable {
+  func test<Value>(to targetKeyPath: ReferenceWritableKeyPath<Self, Value>, change: Value?) {
+    if self[keyPath:targetKeyPath] != change {  // expected-error{{}}
+      self[keyPath: targetKeyPath] = change!
+    }
+  }
 }


### PR DESCRIPTION
Explanation: The compiler would silently fail during failure diagnosis when some expressions involving key path literals failed to type-check.

Scope: Malformed code using key paths would frequently crash the compiler instead of giving meaningful error messages.

Issue: rdar://problem/32488872 | SR-5034

Risk: Low, bug fix isolated to failure recovery on key paths. Should have no effect on correct code.

Testing: Swift CI, test cases from Jira

NB: This builds on the patch from #10863.