### PR TITLE
Sema: Explicitly infer requirements from subscript element type for materializeForSet

### DIFF
--- a/test/SILGen/materializeForSet.swift
+++ b/test/SILGen/materializeForSet.swift
@@ -466,6 +466,28 @@ extension GenericSubscriptProtocol {
 
 struct GenericSubscriptDefaultWitness : GenericSubscriptProtocol { }
 
+// Make sure we correctly infer the 'T : Magic' requirement on all the accessors
+// of the subscript.
+
+struct GenericTypeWithRequirement<T : Magic> {}
+
+protocol InferredRequirementOnSubscriptProtocol {
+  subscript<T>(i: Int) -> GenericTypeWithRequirement<T> { get set }
+}
+
+struct InferredRequirementOnSubscript : InferredRequirementOnSubscriptProtocol {
+  subscript<T>(i: Int) -> GenericTypeWithRequirement<T> {
+    get { }
+    set { }
+  }
+}
+
+// CHECK-LABEL: sil hidden @_T017materializeForSet30InferredRequirementOnSubscriptV9subscriptAA015GenericTypeWithE0VyxGSicAA5MagicRzlufg : $@convention(method) <T where T : Magic> (Int, InferredRequirementOnSubscript) -> GenericTypeWithRequirement<T>
+
+// CHECK-LABEL: sil hidden @_T017materializeForSet30InferredRequirementOnSubscriptV9subscriptAA015GenericTypeWithE0VyxGSicAA5MagicRzlufs : $@convention(method) <T where T : Magic> (GenericTypeWithRequirement<T>, Int, @inout InferredRequirementOnSubscript) -> ()
+
+// CHECK-LABEL: sil hidden [transparent] @_T017materializeForSet30InferredRequirementOnSubscriptV9subscriptAA015GenericTypeWithE0VyxGSicAA5MagicRzlufm : $@convention(method) <T where T : Magic> (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, Int, @inout InferredRequirementOnSubscript) -> (Builtin.RawPointer, Optional<Builtin.RawPointer>)
+
 // Test for materializeForSet vs static properties of structs.
 
 protocol Beverage {


### PR DESCRIPTION
The interface type for materializeForSet does not mention the
element type of a subscript, so Sema was not inferring
requirements that were implied by the element type but not
explicitly stated in the generic signature.

This led to assertion failures in SILGen because the
materializeForSet calls the getter and setter, which does
have these requirements.

Fixes <rdar://problem/33219034>, <https://bugs.swift.org/browse/SR-5420>.