### PR TITLE
Consistently Pass Parameter Flags

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -4385,10 +4385,7 @@ public:
 
   /// Get the type of the variable within its context. If the context is generic,
   /// this will use archetypes.
-  Type getType() const {
-    assert(!typeInContext.isNull() && "no contextual type set yet");
-    return typeInContext;
-  }
+  Type getType() const;
 
   /// Set the type of the variable within its context.
   void setType(Type t);
@@ -4577,7 +4574,7 @@ public:
   ParameterTypeFlags getParameterFlags() const;
   
   SourceLoc getSpecifierLoc() const { return SpecifierLoc; }
-
+    
   bool isTypeLocImplicit() const { return IsTypeLocImplicit; }
   void setIsTypeLocImplicit(bool val) { IsTypeLocImplicit = val; }
   

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -67,6 +67,7 @@ namespace swift {
   class EnumCaseDecl;
   class EnumElementDecl;
   class ParameterList;
+  class ParameterTypeFlags;
   class Pattern;
   struct PrintOptions;
   class ProtocolDecl;
@@ -4468,6 +4469,9 @@ public:
     VarDeclBits.Specifier = static_cast<unsigned>(Spec);
   }
   
+  bool isInOut() const { return getSpecifier() == Specifier::InOut; }
+  
+  
   /// Is this a type ('static') variable?
   bool isStatic() const { return VarDeclBits.IsStatic; }
   void setStatic(bool IsStatic) { VarDeclBits.IsStatic = IsStatic; }
@@ -4567,7 +4571,11 @@ public:
   /// The resulting source location will be valid if the argument name
   /// was specified separately from the parameter name.
   SourceLoc getArgumentNameLoc() const { return ArgumentNameLoc; }
-
+  
+  /// Retrieve the parameter type flags corresponding to the declaration of
+  /// this parameter's argument type.
+  ParameterTypeFlags getParameterFlags() const;
+  
   SourceLoc getSpecifierLoc() const { return SpecifierLoc; }
 
   bool isTypeLocImplicit() const { return IsTypeLocImplicit; }

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -4466,7 +4466,15 @@ public:
     VarDeclBits.Specifier = static_cast<unsigned>(Spec);
   }
   
-  bool isInOut() const { return getSpecifier() == Specifier::InOut; }
+  /// Is the type of this parameter 'inout'?
+  ///
+  /// FIXME(Remove InOut): This is only valid on ParamDecls but multiple parts
+  /// of the compiler check ParamDecls and VarDecls along the same paths.
+  bool isInOut() const {
+    // FIXME: Re-enable this assertion and fix callers.
+//    assert((getKind() == DeclKind::Param) && "querying 'inout' on var decl?");
+    return getSpecifier() == Specifier::InOut;
+  }
   
   
   /// Is this a type ('static') variable?

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -592,6 +592,15 @@ public:
   /// a base class.
   bool isSuperExpr() const;
 
+  /// Returns whether the semantically meaningful content of this expression is
+  /// an inout expression.
+  ///
+  /// FIXME(Remove InOutType): This should eventually sub-in for
+  /// 'E->getType()->is<InOutType>()' in all cases.
+  bool isSemanticallyInOutExpr() const {
+    return getSemanticsProvidingExpr()->getKind() == ExprKind::InOut;
+  }
+  
   /// Returns false if this expression needs to be wrapped in parens when
   /// used inside of a any postfix expression, true otherwise.
   ///
@@ -3241,10 +3250,8 @@ class InOutExpr : public Expr {
   SourceLoc OperLoc;
 
 public:
-  InOutExpr(SourceLoc operLoc, Expr *subExpr, Type type,
-                bool isImplicit = false)
-    : Expr(ExprKind::InOut, isImplicit, type),
-      SubExpr(subExpr), OperLoc(operLoc) {}
+  InOutExpr(SourceLoc operLoc, Expr *subExpr, Type baseType,
+            bool isImplicit = false);
 
   SourceLoc getStartLoc() const { return OperLoc; }
   SourceLoc getEndLoc() const { return SubExpr->getEndLoc(); }

--- a/include/swift/AST/TypeMatcher.h
+++ b/include/swift/AST/TypeMatcher.h
@@ -256,6 +256,28 @@ class TypeMatcher {
           return mismatch(firstFunc.getPointer(), secondFunc, sugaredFirstType);
 
         auto sugaredFirstFunc = sugaredFirstType->castTo<AnyFunctionType>();
+        if (firstFunc->getParams().size() != secondFunc->getParams().size())
+          return mismatch(firstFunc.getInput().getPointer(), secondFunc->getInput(),
+                          sugaredFirstFunc->getInput());
+
+        for (unsigned i = 0, n = firstFunc->getParams().size(); i != n; ++i) {
+          const auto &firstElt = firstFunc->getParams()[i];
+          const auto &secondElt = secondFunc->getParams()[i];
+
+          if (firstElt.getLabel() != secondElt.getLabel() ||
+              firstElt.isVariadic() != secondElt.isVariadic() ||
+              firstElt.isInOut() != secondElt.isInOut())
+            return mismatch(firstFunc.getInput().getPointer(),
+                            secondFunc->getInput(),
+                            sugaredFirstFunc->getInput());
+
+          // Recurse on parameter components.
+          if (!this->visit(firstElt.getType()->getCanonicalType(),
+                           secondElt.getType(),
+                           sugaredFirstFunc->getParams()[i].getType()))
+            return false;
+        }
+
         return this->visit(firstFunc.getInput(), secondFunc->getInput(),
                            sugaredFirstFunc->getInput()) &&
                this->visit(firstFunc.getResult(), secondFunc->getResult(),

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -1449,10 +1449,9 @@ class ParenType : public TypeBase {
   ParameterTypeFlags parameterFlags;
 
   friend class ASTContext;
+  
   ParenType(Type UnderlyingType, RecursiveTypeProperties properties,
-            ParameterTypeFlags flags)
-      : TypeBase(TypeKind::Paren, nullptr, properties),
-        UnderlyingType(UnderlyingType), parameterFlags(flags) {}
+            ParameterTypeFlags flags);
 
 public:
   Type getUnderlyingType() const { return UnderlyingType; }
@@ -1492,8 +1491,9 @@ public:
   
   bool hasName() const { return !Name.empty(); }
   Identifier getName() const { return Name; }
-
-  Type getType() const { return ElementType; }
+  
+  Type getRawType() const { return ElementType; }
+  Type getType() const;
 
   ParameterTypeFlags getParameterFlags() const { return Flags; }
 
@@ -1514,14 +1514,10 @@ public:
   Type getVarargBaseTy() const;
   
   /// Retrieve a copy of this tuple type element with the type replaced.
-  TupleTypeElt getWithType(Type T) const {
-    return TupleTypeElt(T, getName(), getParameterFlags());
-  }
+  TupleTypeElt getWithType(Type T) const;
 
   /// Retrieve a copy of this tuple type element with the name replaced.
-  TupleTypeElt getWithName(Identifier name) const {
-    return TupleTypeElt(getType(), name, getParameterFlags());
-  }
+  TupleTypeElt getWithName(Identifier name) const;
 
   /// Retrieve a copy of this tuple type element with no name
   TupleTypeElt getWithoutName() const { return getWithName(Identifier()); }
@@ -2318,12 +2314,8 @@ public:
   
   class Param {
   public:
-    explicit Param(Type t) : Ty(t), Label(Identifier()), Flags() {}
-    explicit Param(const TupleTypeElt &tte)
-      : Ty(tte.isVararg() ? tte.getVarargBaseTy() : tte.getType()),
-        Label(tte.getName()), Flags(tte.getParameterFlags()) {}
-    explicit Param(Type t, Identifier l, ParameterTypeFlags f)
-      : Ty(t), Label(l), Flags(f) {}
+    explicit Param(const TupleTypeElt &tte);
+    explicit Param(Type t, Identifier l, ParameterTypeFlags f);
     
   private:
     /// The type of the parameter. For a variadic parameter, this is the
@@ -2337,11 +2329,13 @@ public:
     ParameterTypeFlags Flags = {};
     
   public:
-    Type getType() const { return Ty; }
+    Type getType() const;
     CanType getCanType() const {
-      assert(Ty->isCanonical());
-      return CanType(Ty);
+      assert(getType()->isCanonical());
+      return CanType(getType());
     }
+    
+    Type getRawType() const { return Ty; }
     
     Identifier getLabel() const { return Label; }
     
@@ -4787,6 +4781,16 @@ inline Type TupleTypeElt::getVarargBaseTy() const {
   return T;
 }
 
+inline TupleTypeElt TupleTypeElt::getWithName(Identifier name) const {
+  assert(getParameterFlags().isInOut() == getType()->is<InOutType>());
+  return TupleTypeElt(getRawType(), name, getParameterFlags());
+}
+
+inline TupleTypeElt TupleTypeElt::getWithType(Type T) const {
+  auto flags = getParameterFlags().withInOut(T->is<InOutType>());
+  return TupleTypeElt(T->getInOutObjectType(), getName(), flags);
+}
+
 /// Create one from what's present in the parameter decl and type
 inline ParameterTypeFlags
 ParameterTypeFlags::fromParameterType(Type paramTy, bool isVariadic) {
@@ -4794,6 +4798,10 @@ ParameterTypeFlags::fromParameterType(Type paramTy, bool isVariadic) {
                      paramTy->castTo<AnyFunctionType>()->isAutoClosure();
   bool escaping = paramTy->is<AnyFunctionType>() &&
                   !paramTy->castTo<AnyFunctionType>()->isNoEscape();
+  // FIXME(Remove InOut): The last caller that needs this is argument
+  // decomposition.  Start by enabling the assertion there and fixing up those
+  // callers, then remove this, then remove
+  // ParameterTypeFlags::fromParameterType entirely.
   bool inOut = paramTy->is<InOutType>();
   return {isVariadic, autoclosure, escaping, inOut};
 }

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -2335,7 +2335,9 @@ public:
       return CanType(getType());
     }
     
-    Type getRawType() const { return Ty; }
+    /// FIXME(Remove InOutType): This is mostly for copying between param
+    /// types and should go away.
+    Type getPlainType() const { return Ty; }
     
     Identifier getLabel() const { return Label; }
     

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -3225,7 +3225,7 @@ Type AnyFunctionType::composeInput(ASTContext &ctx, ArrayRef<Param> params,
                                    bool canonicalVararg) {
   SmallVector<TupleTypeElt, 4> elements;
   for (const auto &param : params) {
-    Type eltType = param.getRawType();
+    Type eltType = param.getPlainType();
     if (param.isVariadic()) {
       if (canonicalVararg)
         eltType = BoundGenericType::get(ctx.getArrayDecl(), Type(), {eltType});

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -892,9 +892,8 @@ void ASTMangler::appendType(Type type) {
       for (auto &field : layout->getFields()) {
         auto fieldTy = field.getLoweredType();
         // Use the `inout` mangling to represent a mutable field.
-        if (field.isMutable())
-          fieldTy = CanInOutType::get(fieldTy);
-        fieldsList.push_back(TupleTypeElt(fieldTy));
+        auto fieldFlag = ParameterTypeFlags().withInOut(field.isMutable());
+        fieldsList.push_back(TupleTypeElt(fieldTy, Identifier(), fieldFlag));
       }
       appendTypeList(TupleType::get(fieldsList, tybase->getASTContext())
                        ->getCanonicalType());

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -2076,7 +2076,7 @@ public:
 
       // Variables must have materializable type, unless they are parameters,
       // in which case they must either have l-value type or be anonymous.
-      if (!var->getInterfaceType()->isMaterializable()) {
+      if (!var->getInterfaceType()->isMaterializable() || var->isInOut()) {
         if (!isa<ParamDecl>(var)) {
           Out << "Non-parameter VarDecl has non-materializable type: ";
           var->getType().print(Out);

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -496,15 +496,22 @@ namespace {
     }
 
     template <class G>
-    void addParameter(const G &generator, bool isInOut = false) {
+    void addParameter(const G &generator) {
       Type gTyIface = generator.build(*this, false);
-      assert(isInOut || !gTyIface->is<InOutType>());
-      auto iFaceflags = ParameterTypeFlags().withInOut(isInOut);
+      InterfaceParams.push_back({gTyIface->getInOutObjectType(),
+                                 Identifier(), ParameterTypeFlags()});
+      BodyParams.push_back(generator.build(*this, true));
+    }
+
+    template <class G>
+    void addInOutParameter(const G &generator) {
+      Type gTyIface = generator.build(*this, false);
+      auto iFaceflags = ParameterTypeFlags().withInOut(true);
       InterfaceParams.push_back(TupleTypeElt(gTyIface->getInOutObjectType(),
                                              Identifier(), iFaceflags));
       BodyParams.push_back(generator.build(*this, true));
     }
-
+    
     template <class G>
     void setResult(const G &generator) {
       InterfaceResult = generator.build(*this, false);
@@ -663,7 +670,7 @@ static ValueDecl *getIsUniqueOperation(ASTContext &Context, Identifier Id) {
   Type Int1Ty = BuiltinIntegerType::get(1, Context);
 
   BuiltinGenericSignatureBuilder builder(Context);
-  builder.addParameter(makeGenericParam(), /*isInOut*/true);
+  builder.addInOutParameter(makeGenericParam());
   builder.setResult(makeConcrete(Int1Ty));
   return builder.build(Id);
 }
@@ -932,7 +939,7 @@ static ValueDecl *getTSanInoutAccess(ASTContext &Context, Identifier Id) {
 static ValueDecl *getAddressOfOperation(ASTContext &Context, Identifier Id) {
   // <T> (@inout T) -> RawPointer
   BuiltinGenericSignatureBuilder builder(Context);
-  builder.addParameter(makeGenericParam(), /*isInOut*/true);
+  builder.addInOutParameter(makeGenericParam());
   builder.setResult(makeConcrete(Context.TheRawPointerType));
   return builder.build(Id);
 }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4232,6 +4232,11 @@ ParamDecl *ParamDecl::createSelf(SourceLoc loc, DeclContext *DC,
   return selfDecl;
 }
 
+ParameterTypeFlags ParamDecl::getParameterFlags() const {
+  return ParameterTypeFlags::fromParameterType(getType(), isVariadic())
+            .withInOut(isInOut());
+}
+
 /// Return the full source range of this parameter.
 SourceRange ParamDecl::getSourceRange() const {
   SourceLoc APINameLoc = getArgumentNameLoc();

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1617,13 +1617,11 @@ static Type mapSignatureFunctionType(ASTContext &ctx, Type type,
 
     // For the 'self' of a method, strip off 'inout'.
     if (isMethod) {
-      if (auto inoutType = newParamType->getAs<InOutType>())
-        newParamType = inoutType->getObjectType();
-
       newFlags = newFlags.withInOut(false);
     }
 
-    AnyFunctionType::Param newParam(newParamType, param.getLabel(), newFlags);
+    AnyFunctionType::Param newParam(newParamType->getInOutObjectType(),
+                                    param.getLabel(), newFlags);
     newParams.push_back(newParam);
   }
 
@@ -1786,10 +1784,20 @@ bool ValueDecl::hasInterfaceType() const {
 
 Type ValueDecl::getInterfaceType() const {
   assert(hasInterfaceType() && "No interface type was set");
-  return TypeAndAccess.getPointer();
+  auto ty = TypeAndAccess.getPointer();
+  // FIXME(Remove InOutType): This grossness will go away when Sema is weaned
+  // off of InOutType.  Until then we should respect our parameter flags and
+  // return the type it expects.
+  if (auto *VD = dyn_cast<ParamDecl>(this)) {
+    ty = VD->isInOut() ? InOutType::get(ty) : ty;
+  }
+  return ty;
 }
 
 void ValueDecl::setInterfaceType(Type type) {
+  if (!type.isNull() && isa<ParamDecl>(this)) {
+    assert(!type->is<InOutType>() && "caller did not pass a base type");
+  }
   // lldb creates global typealiases with archetypes in them.
   // FIXME: Add an isDebugAlias() flag, like isDebugVar().
   //
@@ -1804,7 +1812,6 @@ void ValueDecl::setInterfaceType(Type type) {
     assert(!type->hasTypeVariable() &&
            "Archetype in interface type");
   }
-
   TypeAndAccess.setPointer(type);
 }
 
@@ -3835,7 +3842,17 @@ static bool isSettable(const AbstractStorageDecl *decl) {
   llvm_unreachable("bad storage kind");
 }
 
+Type VarDecl::getType() const {
+  assert(!typeInContext.isNull() && "no contextual type set yet");
+  // FIXME(Remove InOutType): This grossness will go away when Sema is weaned
+  // off of InOutType.  Until then we should respect our parameter flags and
+  // return the type it expects.
+  if (isInOut()) return InOutType::get(typeInContext);
+  return typeInContext;
+}
+
 void VarDecl::setType(Type t) {
+  assert(t.isNull() || !t->is<InOutType>());
   typeInContext = t;
   if (t && t->hasError())
     setInvalid();
@@ -4220,8 +4237,6 @@ ParamDecl *ParamDecl::createSelf(SourceLoc loc, DeclContext *DC,
   }
     
   if (isInOut) {
-    selfType = InOutType::get(selfType);
-    selfInterfaceType = InOutType::get(selfInterfaceType);
     specifier = VarDecl::Specifier::InOut;
   }
 

--- a/lib/AST/Parameter.cpp
+++ b/lib/AST/Parameter.cpp
@@ -120,13 +120,15 @@ ParameterList *ParameterList::clone(const ASTContext &C,
 Type ParameterList::getType(const ASTContext &C) const {
   if (size() == 0)
     return TupleType::getEmpty(C);
-  
+
   SmallVector<TupleTypeElt, 8> argumentInfo;
   
   for (auto P : *this) {
+    auto type = P->getType();
+    
     argumentInfo.emplace_back(
-        P->getType(), P->getArgumentName(),
-        ParameterTypeFlags::fromParameterType(P->getType(), P->isVariadic()));
+        type->getInOutObjectType(), P->getArgumentName(),
+        ParameterTypeFlags::fromParameterType(type, P->isVariadic()).withInOut(P->isInOut()));
   }
 
   return TupleType::get(argumentInfo, C);
@@ -143,10 +145,10 @@ Type ParameterList::getInterfaceType(const ASTContext &C) const {
   for (auto P : *this) {
     auto type = P->getInterfaceType();
     assert(!type->hasArchetype());
-
+    
     argumentInfo.emplace_back(
-        type, P->getArgumentName(),
-        ParameterTypeFlags::fromParameterType(type, P->isVariadic()));
+        type->getInOutObjectType(), P->getArgumentName(),
+        ParameterTypeFlags::fromParameterType(type, P->isVariadic()).withInOut(P->isInOut()));
   }
 
   return TupleType::get(argumentInfo, C);

--- a/lib/AST/Parameter.cpp
+++ b/lib/AST/Parameter.cpp
@@ -120,7 +120,7 @@ ParameterList *ParameterList::clone(const ASTContext &C,
 Type ParameterList::getType(const ASTContext &C) const {
   if (size() == 0)
     return TupleType::getEmpty(C);
-
+  
   SmallVector<TupleTypeElt, 8> argumentInfo;
   
   for (auto P : *this) {
@@ -145,7 +145,7 @@ Type ParameterList::getInterfaceType(const ASTContext &C) const {
   for (auto P : *this) {
     auto type = P->getInterfaceType();
     assert(!type->hasArchetype());
-    
+
     argumentInfo.emplace_back(
         type->getInOutObjectType(), P->getArgumentName(),
         ParameterTypeFlags::fromParameterType(type, P->isVariadic()).withInOut(P->isInOut()));

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -805,7 +805,7 @@ makeUnionFieldAccessors(ClangImporter::Implementation &Impl,
     auto inoutSelfRef = new (C) DeclRefExpr(inoutSelfDecl, DeclNameLoc(),
                                             /*implicit*/ true);
     auto inoutSelf = new (C) InOutExpr(SourceLoc(), inoutSelfRef,
-      InOutType::get(importedUnionDecl->getDeclaredType()), /*implicit*/ true);
+      importedUnionDecl->getDeclaredType(), /*implicit*/ true);
 
     auto newValueDecl = setterDecl->getParameterList(1)->get(0);
 

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -2108,7 +2108,8 @@ public:
         type = ParamDecl::getVarargBaseTy(type);
 
       Builder.addCallParameter(param->getArgumentName(), type,
-                               param->isVariadic(), true);
+                               param->isVariadic(), /*Outermost*/true,
+                               param->isInOut());
     }
   }
 
@@ -2142,7 +2143,8 @@ public:
       else if (IsTopLevel)
         Builder.addAnnotatedLeftParen();
       Builder.addCallParameter(Identifier(), PT->getUnderlyingType(),
-                               /*IsVarArg*/false, IsTopLevel);
+                               /*IsVarArg*/false, IsTopLevel,
+                               PT->getParameterFlags().isInOut());
       if (IsTopLevel)
         Builder.addRightParen();
       return;
@@ -2153,7 +2155,7 @@ public:
     else if (IsTopLevel)
       Builder.addAnnotatedLeftParen();
 
-    Builder.addCallParameter(Label, T, IsVarArg, IsTopLevel);
+    Builder.addCallParameter(Label, T, IsVarArg, IsTopLevel, /*isInOut*/false);
     if (IsTopLevel)
       Builder.addRightParen();
   }
@@ -2258,9 +2260,10 @@ public:
           auto argName = BodyParams->get(i)->getArgumentName();
           auto bodyName = BodyParams->get(i)->getName();
           Builder.addCallParameter(argName, bodyName, ParamType, TupleElt.isVararg(),
-                                   true);
+                                   true, TupleElt.isInOut());
         } else {
-          Builder.addCallParameter(Name, ParamType, TupleElt.isVararg(), true);
+          Builder.addCallParameter(Name, ParamType, TupleElt.isVararg(),
+                                   /*TopLevel*/true, TupleElt.isInOut());
         }
         modifiedBuilder = true;
         NeedComma = true;
@@ -2268,9 +2271,11 @@ public:
     } else if (!shouldSkipArg(0)) {
       // If it's not a tuple, it could be a unary function.
       Type T = AFT->getInput();
+      bool isInOut = false;
       if (auto *PT = dyn_cast<ParenType>(T.getPointer())) {
         // Only unwrap the paren sugar, if it exists.
         T = PT->getUnderlyingType();
+        isInOut = PT->getParameterFlags().isInOut();
       }
 
       modifiedBuilder = true;
@@ -2278,9 +2283,10 @@ public:
         auto argName = BodyParams->get(0)->getArgumentName();
         auto bodyName = BodyParams->get(0)->getName();
         Builder.addCallParameter(argName, bodyName, T,
-                                 /*IsVarArg*/false, true);
+                                 /*IsVarArg*/false, /*Toplevel*/true, isInOut);
       } else
-        Builder.addCallParameter(Identifier(), T, /*IsVarArg*/false, true);
+        Builder.addCallParameter(Identifier(), T, /*IsVarArg*/false,
+                                 /*TopLevel*/true, isInOut);
     }
 
     return modifiedBuilder;
@@ -2465,12 +2471,16 @@ public:
       Type FirstInputType = FunctionType->castTo<AnyFunctionType>()->getInput();
 
       if (IsImplicitlyCurriedInstanceMethod) {
-        if (auto PT = dyn_cast<ParenType>(FirstInputType.getPointer()))
+        bool isInOut = false;
+        if (auto PT = dyn_cast<ParenType>(FirstInputType.getPointer())) {
           FirstInputType = PT->getUnderlyingType();
+          isInOut = PT->getParameterFlags().isInOut();
+        }
 
         Builder.addLeftParen();
         Builder.addCallParameter(Ctx.Id_self, FirstInputType,
-                                 /*IsVarArg*/ false, true);
+                                 /*IsVarArg*/ false, /*TopLevel*/true,
+                                 isInOut);
         Builder.addRightParen();
       } else if (trivialTrailingClosure) {
         Builder.addBraceStmtWithCursor(" { code }");
@@ -3288,7 +3298,9 @@ public:
     builder.addEqual();
     builder.addWhitespace(" ");
     assert(RHSType && resultType);
-    builder.addCallParameter(Identifier(), Identifier(), RHSType, false, true);
+    builder.addCallParameter(Identifier(), Identifier(), RHSType,
+                             /*IsVarArg*/false, /*TopLevel*/true,
+                             /*IsInOut*/false);
     addTypeAnnotation(builder, resultType);
   }
 
@@ -3311,7 +3323,7 @@ public:
     builder.addWhitespace(" ");
     if (RHSType)
       builder.addCallParameter(Identifier(), Identifier(), RHSType, false,
-                               true);
+                               true, /*IsInOut*/false);
     if (resultType)
       addTypeAnnotation(builder, resultType);
   }
@@ -3563,16 +3575,16 @@ public:
       builder.addTextChunk("#colorLiteral");
       builder.addLeftParen();
       builder.addCallParameter(context.getIdentifier("red"),
-                               floatType, false, true);
+                               floatType, false, true, /*IsInOut*/false);
       builder.addComma();
       builder.addCallParameter(context.getIdentifier("green"), floatType,
-                               false, true);
+                               false, true, /*IsInOut*/false);
       builder.addComma();
       builder.addCallParameter(context.getIdentifier("blue"), floatType,
-                               false, true);
+                               false, true, /*IsInOut*/false);
       builder.addComma();
       builder.addCallParameter(context.getIdentifier("alpha"), floatType,
-                               false, true);
+                               false, true, /*IsInOut*/false);
       builder.addRightParen();
     });
 
@@ -3581,7 +3593,7 @@ public:
       builder.addTextChunk("#imageLiteral");
       builder.addLeftParen();
       builder.addCallParameter(context.getIdentifier("resourceName"),
-                               stringType, false, true);
+                               stringType, false, true, /*IsInOut*/false);
       builder.addRightParen();
     });
 

--- a/lib/IDE/CodeCompletionResultBuilder.h
+++ b/lib/IDE/CodeCompletionResultBuilder.h
@@ -315,7 +315,7 @@ public:
   }
 
   void addCallParameter(Identifier Name, Identifier LocalName, Type Ty,
-                        bool IsVarArg, bool Outermost) {
+                        bool IsVarArg, bool Outermost, bool IsInOut) {
     CurrentNestingLevel++;
 
     addSimpleChunk(CodeCompletionString::Chunk::ChunkKind::CallParameterBegin);
@@ -344,10 +344,10 @@ public:
     }
 
     // 'inout' arguments are printed specially.
-    if (auto *IOT = Ty->getAs<InOutType>()) {
+    if (IsInOut) {
       addChunkWithTextNoCopy(
           CodeCompletionString::Chunk::ChunkKind::Ampersand, "&");
-      Ty = IOT->getObjectType();
+      Ty = Ty->getInOutObjectType();
     }
 
     if (Name.empty() && !LocalName.empty()) {
@@ -395,8 +395,8 @@ public:
   }
 
   void addCallParameter(Identifier Name, Type Ty, bool IsVarArg,
-                        bool Outermost) {
-    addCallParameter(Name, Identifier(), Ty, IsVarArg, Outermost);
+                        bool Outermost, bool IsInOut) {
+    addCallParameter(Name, Identifier(), Ty, IsVarArg, Outermost, IsInOut);
   }
 
   void addGenericParameter(StringRef Name) {

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -2410,7 +2410,10 @@ TypeConverter::getLoweredFormalTypes(SILDeclRef constant,
 
   // Merge inputs and generic parameters from the uncurry levels.
   for (;;) {
-    inputs.push_back(TupleTypeElt(fnType.getInput()));
+    auto canInput = fnType->getInput()->getCanonicalType();
+    auto inputFlags = ParameterTypeFlags().withInOut(isa<InOutType>(canInput));
+    inputs.push_back(TupleTypeElt(canInput->getInOutObjectType(), Identifier(),
+                                  inputFlags));
 
     // The uncurried function calls all of the intermediate function
     // levels and so throws if any of them do.

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -123,7 +123,7 @@ CaptureKind TypeConverter::getDeclCaptureKind(CapturedValue capture) {
         return CaptureKind::Constant;
 
       // In-out parameters are captured by address.
-      if (var->getType()->is<InOutType>()) {
+      if (var->isInOut()) {
         return CaptureKind::StorageAddress;
       }
 

--- a/lib/SILGen/ArgumentSource.cpp
+++ b/lib/SILGen/ArgumentSource.cpp
@@ -183,7 +183,7 @@ ManagedValue ArgumentSource::getAsSingleValue(SILGenFunction &SGF,
   }
   case Kind::Expr: {
     auto e = std::move(*this).asKnownExpr();
-    if (e->getType()->is<InOutType>()) {
+    if (e->isSemanticallyInOutExpr()) {
       return SGF.emitAddressOfLValue(e, SGF.emitLValue(e, AccessKind::ReadWrite),
                                      AccessKind::ReadWrite);
     } else {

--- a/lib/SILGen/ArgumentSource.h
+++ b/lib/SILGen/ArgumentSource.h
@@ -194,7 +194,7 @@ public:
     case Kind::Invalid: llvm_unreachable("argument source is invalid");
     case Kind::RValue: return false;
     case Kind::LValue: return true;
-    case Kind::Expr: return asKnownExpr()->getType()->is<InOutType>();
+    case Kind::Expr: return asKnownExpr()->isSemanticallyInOutExpr();
     case Kind::Tuple: return false;
     }
     llvm_unreachable("bad kind");    

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -376,7 +376,7 @@ void SILGenFunction::emitEnumConstructor(EnumElementDecl *element) {
                                  SourceLoc(),
                                  AC.getIdentifier("$return_value"), Type(),
                                  element->getDeclContext());
-    VD->setInterfaceType(CanInOutType::get(enumIfaceTy));
+    VD->setInterfaceType(enumIfaceTy);
     auto resultSlot =
         F.begin()->createFunctionArgument(enumTI.getLoweredType(), VD);
     dest = std::unique_ptr<Initialization>(

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -2003,7 +2003,7 @@ LValue SILGenLValue::visitRec(Expr *e, AccessKind accessKind,
                               AbstractionPattern orig) {
   // First see if we have an lvalue type. If we do, then quickly handle that and
   // return.
-  if (e->getType()->is<LValueType>() || e->getType()->is<InOutType>()) {
+  if (e->getType()->is<LValueType>() || e->isSemanticallyInOutExpr()) {
     auto lv = visit(e, accessKind);
     // If necessary, handle reabstraction with a SubstToOrigComponent that
     // handles

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -253,11 +253,10 @@ struct ArgumentInitHelper {
     // Create a shadow copy of inout parameters so they can be captured
     // by closures. The InOutDeshadowing guaranteed optimization will
     // eliminate the variable if it is not needed.
-    if (auto inOutTy = vd->getType()->getAs<InOutType>()) {
-
+    if (vd->isInOut()) {
       SILValue address = argrv.getUnmanagedValue();
 
-      CanType objectType = inOutTy->getObjectType()->getCanonicalType();
+      CanType objectType = vd->getType()->getInOutObjectType()->getCanonicalType();
 
       // As a special case, don't introduce a local variable for
       // Builtin.UnsafeValueBuffer, which is not copyable.

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -6328,8 +6328,7 @@ static Type adjustSelfTypeForMember(Type baseTy, ValueDecl *member,
         if (!fd->isMutating() && baseObjectTy->is<ArchetypeType>())
           return baseObjectTy;
 
-      assert(InOutType::get(baseObjectTy)->isEqual(baseTy));
-      return baseTy;
+      return InOutType::get(baseObjectTy);
     }
 
     // Otherwise, return the rvalue type.

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5441,10 +5441,10 @@ Expr *ExprRewriter::coerceCallArguments(
     auto paramType = param.getType();
     if (argType->isEqual(paramType)) {
       toSugarFields.push_back(
-          TupleTypeElt(param.getRawType(), getArgLabel(argIdx),
+          TupleTypeElt(param.getPlainType(), getArgLabel(argIdx),
                        param.getParameterFlags()));
       fromTupleExprFields[argIdx] =
-          TupleTypeElt(param.getRawType(), getArgLabel(argIdx),
+          TupleTypeElt(param.getPlainType(), getArgLabel(argIdx),
                        param.getParameterFlags());
       fromTupleExpr[argIdx] = arg;
       continue;
@@ -6327,7 +6327,7 @@ static Type adjustSelfTypeForMember(Type baseTy, ValueDecl *member,
       if (auto *fd = dyn_cast<FuncDecl>(func))
         if (!fd->isMutating() && baseObjectTy->is<ArchetypeType>())
           return baseObjectTy;
-
+      
       return InOutType::get(baseObjectTy);
     }
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -1495,10 +1495,12 @@ namespace {
       resultTy = resultTy->replaceCovariantResultType(
         selfTy, ctor->getNumParameterLists());
 
+      ParameterTypeFlags flags;
       if (!selfTy->hasReferenceSemantics())
-        selfTy = InOutType::get(selfTy);
+        flags = flags.withInOut(true);
 
-      resultTy = FunctionType::get(selfTy,
+      auto selfParam = AnyFunctionType::Param(selfTy, Identifier(), flags);
+      resultTy = FunctionType::get({selfParam},
                                    resultTy->castTo<FunctionType>()->getResult(),
                                    resultTy->castTo<FunctionType>()->getExtInfo());
 
@@ -2641,7 +2643,9 @@ namespace {
 
     Expr *visitParenExpr(ParenExpr *expr) {
       auto &ctx = cs.getASTContext();
-      cs.setType(expr, ParenType::get(ctx, cs.getType(expr->getSubExpr())));
+      auto pty = cs.getType(expr->getSubExpr());
+      cs.setType(expr, ParenType::get(ctx, pty->getInOutObjectType(),
+                                      ParameterTypeFlags().withInOut(pty->is<InOutType>())));
       return expr;
     }
 
@@ -4594,7 +4598,8 @@ static Type rebuildIdentityExprs(ConstraintSystem &cs, Expr *expr, Type type) {
   ASTContext &ctx = cs.getASTContext();
   if (auto paren = dyn_cast<ParenExpr>(expr)) {
     type = rebuildIdentityExprs(cs, paren->getSubExpr(), type);
-    cs.setType(paren, ParenType::get(ctx, type));
+    cs.setType(paren, ParenType::get(ctx, type->getInOutObjectType(),
+                                     ParameterTypeFlags().withInOut(type->is<InOutType>())));
     return cs.getType(paren);
   }
 
@@ -5436,9 +5441,11 @@ Expr *ExprRewriter::coerceCallArguments(
     auto paramType = param.getType();
     if (argType->isEqual(paramType)) {
       toSugarFields.push_back(
-          TupleTypeElt(argType, getArgLabel(argIdx), param.getParameterFlags()));
+          TupleTypeElt(param.getRawType(), getArgLabel(argIdx),
+                       param.getParameterFlags()));
       fromTupleExprFields[argIdx] =
-          TupleTypeElt(paramType, getArgLabel(argIdx), param.getParameterFlags());
+          TupleTypeElt(param.getRawType(), getArgLabel(argIdx),
+                       param.getParameterFlags());
       fromTupleExpr[argIdx] = arg;
       continue;
     }
@@ -5452,9 +5459,11 @@ Expr *ExprRewriter::coerceCallArguments(
     // Add the converted argument.
     fromTupleExpr[argIdx] = convertedArg;
     fromTupleExprFields[argIdx] = TupleTypeElt(
-        cs.getType(convertedArg), getArgLabel(argIdx), param.getParameterFlags());
+        cs.getType(convertedArg)->getInOutObjectType(),
+        getArgLabel(argIdx), param.getParameterFlags());
     toSugarFields.push_back(
-        TupleTypeElt(argType, param.getLabel(), param.getParameterFlags()));
+        TupleTypeElt(argType->getInOutObjectType(), param.getLabel(),
+                     param.getParameterFlags()));
   }
 
   // Compute a new 'arg', from the bits we have.  We have three cases: the
@@ -6131,13 +6140,13 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
   // coercion.
   if (auto fromLValue = fromType->getAs<LValueType>()) {
     if (auto *toIO = toType->getAs<InOutType>()) {
-      (void)toIO;
       // In an 'inout' operator like "++i", the operand is converted from
       // an implicit lvalue to an inout argument.
       assert(toIO->getObjectType()->isEqual(fromLValue->getObjectType()));
       cs.propagateLValueAccessKind(expr, AccessKind::ReadWrite);
       return cs.cacheType(new (tc.Context)
-                              InOutExpr(expr->getStartLoc(), expr, toType,
+                              InOutExpr(expr->getStartLoc(), expr,
+                                        toIO->getObjectType(),
                                         /*isImplicit*/ true));
     }
 
@@ -6147,7 +6156,7 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
     if (auto toTuple = toType->getAs<TupleType>()) {
       int scalarIdx = toTuple->getElementForScalarInit();
       if (scalarIdx >= 0 &&
-          toTuple->getElementType(scalarIdx)->is<InOutType>())
+          toTuple->getElement(scalarIdx).isInOut())
         performLoad = false;
     }
 
@@ -6309,16 +6318,18 @@ static Type adjustSelfTypeForMember(Type baseTy, ValueDecl *member,
   if (auto func = dyn_cast<AbstractFunctionDecl>(member)) {
     // If 'self' is an inout type, turn the base type into an lvalue
     // type with the same qualifiers.
-    auto selfTy = func->getInterfaceType()->getAs<AnyFunctionType>()->getInput();
-    if (selfTy->is<InOutType>()) {
+    auto selfParam = func->getInterfaceType()->getAs<AnyFunctionType>()->getParams();
+    assert(selfParam.size() == 1 && "found invalid arity of self param");
+    if (selfParam[0].getParameterFlags().isInOut()) {
       // Unless we're looking at a nonmutating existential member.  In which
       // case, the member will be modeled as an inout but ExistentialMemberRef
       // and ArchetypeMemberRef want to take the base as an rvalue.
       if (auto *fd = dyn_cast<FuncDecl>(func))
         if (!fd->isMutating() && baseObjectTy->is<ArchetypeType>())
           return baseObjectTy;
-      
-      return InOutType::get(baseObjectTy);
+
+      assert(InOutType::get(baseObjectTy)->isEqual(baseTy));
+      return baseTy;
     }
 
     // Otherwise, return the rvalue type.
@@ -6369,7 +6380,8 @@ ExprRewriter::coerceObjectArgumentToType(Expr *expr,
     return expr;
 
   // If we're coercing to an rvalue type, just do it.
-  if (!toType->is<InOutType>())
+  auto toInOutTy = toType->getAs<InOutType>();
+  if (!toInOutTy)
     return coerceToType(expr, toType, locator);
 
   assert(fromType->is<LValueType>() && "Can only convert lvalues to inout");
@@ -6379,7 +6391,8 @@ ExprRewriter::coerceObjectArgumentToType(Expr *expr,
   // Use InOutExpr to convert it to an explicit inout argument for the
   // receiver.
   cs.propagateLValueAccessKind(expr, AccessKind::ReadWrite);
-  return cs.cacheType(new (ctx) InOutExpr(expr->getStartLoc(), expr, toType,
+  return cs.cacheType(new (ctx) InOutExpr(expr->getStartLoc(), expr, 
+                                          toInOutTy->getInOutObjectType(),
                                           /*isImplicit*/ true));
 }
 

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -7287,12 +7287,13 @@ bool FailureDiagnosis::diagnoseClosureExpr(
     for (auto param : *params) {
       auto paramType = param->getType();
       // If this is unresolved 'inout' parameter, it's better to drop
-      // 'inout' from type but keep 'mutability' classifier because that
-      // might help to diagnose actual problem e.g. type inference and
-      // doesn't give us much information anyway.
+      // 'inout' from type because that might help to diagnose actual problem
+      // e.g. type inference doesn't give us much information anyway.
       if (paramType->is<InOutType>() && paramType->hasUnresolvedType()) {
+        assert(!param->isLet() || !paramType->is<InOutType>());
         param->setType(CS.getASTContext().TheUnresolvedType);
-        param->setInterfaceType(param->getType());
+        param->setInterfaceType(param->getType()->getInOutObjectType());
+        param->setSpecifier(swift::VarDecl::Specifier::Owned);
       }
     }
 

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -3127,11 +3127,15 @@ namespace {
       for (auto patternElt : PatternTypes)
         patternElt.first->setType(patternElt.second);
       
-      for (auto paramDeclElt : ParamDeclTypes)
-        paramDeclElt.first->setType(paramDeclElt.second);
+      for (auto paramDeclElt : ParamDeclTypes) {
+        assert(!paramDeclElt.first->isLet() || !paramDeclElt.second->is<InOutType>());
+        paramDeclElt.first->setType(paramDeclElt.second->getInOutObjectType());
+      }
       
-      for (auto paramDeclIfaceElt : ParamDeclInterfaceTypes)
-        paramDeclIfaceElt.first->setInterfaceType(paramDeclIfaceElt.second);
+      for (auto paramDeclIfaceElt : ParamDeclInterfaceTypes) {
+        assert(!paramDeclIfaceElt.first->isLet() || !paramDeclIfaceElt.second->is<InOutType>());
+        paramDeclIfaceElt.first->setInterfaceType(paramDeclIfaceElt.second->getInOutObjectType());
+      }
       
       for (auto CSE : CollectionSemanticExprs)
         CSE.first->setSemanticExpr(CSE.second);
@@ -4550,9 +4554,11 @@ typeCheckArgumentChildIndependently(Expr *argExpr, Type argType,
             }
           }
 
+          auto resultTy = CS.getType(exprResult);
           resultElts[inArgNo] = exprResult;
-          resultEltTys[inArgNo] = {CS.getType(exprResult),
-                                   TE->getElementName(inArgNo)};
+          resultEltTys[inArgNo] = {resultTy->getInOutObjectType(),
+                                   TE->getElementName(inArgNo),
+                                   ParameterTypeFlags().withInOut(resultTy->is<InOutType>())};
         }
       }
 

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -201,6 +201,7 @@ static FuncDecl *createSetterPrototype(AbstractStorageDecl *storage,
                             storageType,
                             storageInterfaceType,
                             VarDecl::Specifier::Owned);
+
   params.push_back(buildIndexForwardingParamList(storage, valueDecl));
 
   Type setterRetTy = TupleType::getEmpty(TC.Context);
@@ -304,8 +305,8 @@ static FuncDecl *createMaterializeForSetPrototype(AbstractStorageDecl *storage,
                   ctx.TheRawPointerType,
                   VarDecl::Specifier::Owned),
     buildArgument(loc, DC, "callbackStorage",
-                  InOutType::get(ctx.TheUnsafeValueBufferType),
-                  InOutType::get(ctx.TheUnsafeValueBufferType),
+                  ctx.TheUnsafeValueBufferType,
+                  ctx.TheUnsafeValueBufferType,
                   VarDecl::Specifier::InOut)
   };
   params.push_back(buildIndexForwardingParamList(storage, bufferElements));
@@ -412,7 +413,7 @@ static Expr *buildArgumentForwardingExpr(ArrayRef<ParamDecl*> params,
       return nullptr;
     
     Expr *ref = new (ctx) DeclRefExpr(param, DeclNameLoc(), /*implicit*/ true);
-    if (param->getInterfaceType()->is<InOutType>())
+    if (param->isInOut())
       ref = new (ctx) InOutExpr(SourceLoc(), ref, Type(), /*isImplicit=*/true);
     args.push_back(ref);
     
@@ -1501,9 +1502,8 @@ void TypeChecker::completePropertyBehaviorAccessors(VarDecl *VD,
       auto lvTy = LValueType::get(selfTy);
       selfExpr->setType(lvTy);
       selfExpr->propagateLValueAccessKind(AccessKind::ReadWrite);
-      auto inoutTy = InOutType::get(selfTy);
       selfExpr = new (Context) InOutExpr(SourceLoc(),
-                                         selfExpr, inoutTy, /*implicit*/ true);
+                                         selfExpr, selfTy, /*implicit*/ true);
     }
     return selfExpr;
   };

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -201,7 +201,6 @@ static FuncDecl *createSetterPrototype(AbstractStorageDecl *storage,
                             storageType,
                             storageInterfaceType,
                             VarDecl::Specifier::Owned);
-
   params.push_back(buildIndexForwardingParamList(storage, valueDecl));
 
   Type setterRetTy = TupleType::getEmpty(TC.Context);

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -2244,7 +2244,7 @@ VarDeclUsageChecker::~VarDeclUsageChecker() {
     
     // If this is a vardecl with 'inout' type, then it is an inout argument to a
     // function, never diagnose anything related to it.
-    if (var->getType()->is<InOutType>())
+    if (var->isInOut())
       continue;    
     
     // Consider parameters to always have been read.  It is common to name a

--- a/lib/Sema/PlaygroundTransform.cpp
+++ b/lib/Sema/PlaygroundTransform.cpp
@@ -669,7 +669,7 @@ public:
           useJustFirst = true;
         } else {
           for (Expr *Arg : TE->getElements()) {
-            if (Arg->getType()->is<InOutType>()) {
+            if (Arg->isSemanticallyInOutExpr()) {
               useJustFirst = true;
               break;
             }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1288,10 +1288,7 @@ static void recordSelfContextType(AbstractFunctionDecl *func) {
   auto selfDecl = func->getImplicitSelfDecl();
   Type selfTy = func->computeInterfaceSelfType(/*isInitializingCtor*/true,
                                                /*wantDynamicSelf*/true);
-  if (auto *FD = dyn_cast<FuncDecl>(func)) {
-    assert(FD->isMutating() == selfTy->is<InOutType>());
-  }
-  
+
   selfTy = func->mapTypeIntoContext(selfTy);
   // FIXME(Remove InOutType): 'computeInterfaceSelfType' should tell us if
   // we need to do this.

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -818,32 +818,32 @@ void TypeChecker::configureInterfaceType(AbstractFunctionDecl *func,
                                          GenericSignature *sig) {
   Type funcTy;
   Type initFuncTy = Type();
-  
+
   if (auto fn = dyn_cast<FuncDecl>(func)) {
     funcTy = fn->getBodyResultTypeLoc().getType();
     if (!funcTy)
       funcTy = TupleType::getEmpty(Context);
-    
+
   } else if (auto ctor = dyn_cast<ConstructorDecl>(func)) {
     auto *dc = ctor->getDeclContext();
-    
+
     funcTy = dc->getSelfInterfaceType();
     if (!funcTy)
       funcTy = ErrorType::get(Context);
-    
+
     // Adjust result type for failability.
     if (ctor->getFailability() != OTK_None)
       funcTy = OptionalType::get(ctor->getFailability(), funcTy);
-    
+
     initFuncTy = funcTy;
   } else {
     assert(isa<DestructorDecl>(func));
     funcTy = TupleType::getEmpty(Context);
   }
-  
+
   auto paramLists = func->getParameterLists();
   SmallVector<ParameterList*, 4> storedParamLists;
-  
+
   // FIXME: Destructors don't have the '()' pattern in their signature, so
   // paste it here.
   if (isa<DestructorDecl>(func)) {
@@ -852,7 +852,7 @@ void TypeChecker::configureInterfaceType(AbstractFunctionDecl *func,
     storedParamLists.push_back(ParameterList::createEmpty(Context));
     paramLists = storedParamLists;
   }
-  
+
   bool hasSelf = func->getDeclContext()->isTypeContext();
   for (unsigned i = 0, e = paramLists.size(); i != e; ++i) {
     SmallVector<AnyFunctionType::Param, 4> argTy;
@@ -877,11 +877,11 @@ void TypeChecker::configureInterfaceType(AbstractFunctionDecl *func,
       }
     } else {
       AnyFunctionType::decomposeInput(paramLists[e - i - 1]->getInterfaceType(Context), argTy);
-      
+
       if (initFuncTy)
         initArgTy = argTy;
     }
-    
+
     // 'throws' only applies to the innermost function.
     AnyFunctionType::ExtInfo info;
     if (i == 0 && func->hasThrows())
@@ -893,7 +893,7 @@ void TypeChecker::configureInterfaceType(AbstractFunctionDecl *func,
     assert(!funcTy->hasArchetype());
     if (initFuncTy)
       assert(!initFuncTy->hasArchetype());
-    
+
     if (sig && i == e-1) {
       funcTy = GenericFunctionType::get(sig, argTy, funcTy, info);
       if (initFuncTy)
@@ -904,12 +904,12 @@ void TypeChecker::configureInterfaceType(AbstractFunctionDecl *func,
         initFuncTy = FunctionType::get(initArgTy, initFuncTy, info);
     }
   }
-  
+
   // Record the interface type.
   func->setInterfaceType(funcTy);
   if (initFuncTy)
     cast<ConstructorDecl>(func)->setInitializerInterfaceType(initFuncTy);
-  
+
   // We get bogus errors here with generic subscript materializeForSet.
   if (!isa<FuncDecl>(func) ||
       cast<FuncDecl>(func)->getAccessorKind() !=

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2737,9 +2737,9 @@ Type TypeResolver::resolveTupleType(TupleTypeRepr *repr,
       ty = TC.getArraySliceType(repr->getEllipsisLoc(), ty);
 
     auto paramFlags = isImmediateFunctionInput
-                          ? ParameterTypeFlags::fromParameterType(ty, variadic)
-                          : ParameterTypeFlags();
-    elements.emplace_back(ty, name, paramFlags);
+                    ? ParameterTypeFlags::fromParameterType(ty, variadic).withInOut(tyR->getKind() == TypeReprKind::InOut)
+                    : ParameterTypeFlags();
+    elements.emplace_back(ty->getInOutObjectType(), name, paramFlags);
   }
 
   // Single-element labeled tuples are not permitted outside of declarations

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1733,7 +1733,8 @@ public:
   bool coercePatternToType(Pattern *&P, DeclContext *dc, Type type,
                            TypeResolutionOptions options,
                            GenericTypeResolver *resolver = nullptr,
-                           TypeLoc tyLoc = TypeLoc());
+                           TypeLoc tyLoc = TypeLoc(),
+                           bool forceInOut = false);
   bool typeCheckExprPattern(ExprPattern *EP, DeclContext *DC,
                             Type type);
 

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2793,7 +2793,7 @@ ModuleFile::getDeclChecked(DeclID DID, Optional<DeclContext *> ForcedContext) {
       return nullptr;
     }
 
-    param->setInterfaceType(paramTy);
+    param->setInterfaceType(paramTy->getInOutObjectType());
     break;
   }
 
@@ -3805,7 +3805,7 @@ Expected<Type> ModuleFile::getTypeChecked(TypeID TID) {
       return underlyingTy.takeError();
     
     typeOrOffset = ParenType::get(
-        ctx, underlyingTy.get(),
+        ctx, underlyingTy.get()->getInOutObjectType(),
         ParameterTypeFlags(isVariadic, isAutoClosure, isEscaping, isInOut));
     break;
   }
@@ -3835,7 +3835,7 @@ Expected<Type> ModuleFile::getTypeChecked(TypeID TID) {
         return elementTy.takeError();
       
       elements.emplace_back(
-          elementTy.get(), getIdentifier(nameID),
+          elementTy.get()->getInOutObjectType(), getIdentifier(nameID),
           ParameterTypeFlags(isVariadic, isAutoClosure, isEscaping, isInOut));
     }
 

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -821,7 +821,6 @@ func inoutTests(_ arr: inout Int) {
   (true ? &x : &y)  // expected-error 2 {{'&' can only appear immediately in a call argument list}}
   // expected-warning @-1 {{expression of type 'inout Int' is unused}}
   let a = (true ? &x : &y)  // expected-error 2 {{'&' can only appear immediately in a call argument list}}
-  // expected-error @-1 {{variable has type 'inout Int' which includes nested inout parameters}}
 
   inoutTests(true ? &x : &y);  // expected-error 2 {{'&' can only appear immediately in a call argument list}}
 


### PR DESCRIPTION
This massive pile of code causes the compiler to retain and consistently track parameter type flags through the various representation changes we make during the compilation process.  The idea is that we can rely on these bits instead of `InOutType` et al. and use them to propagate more structural invariants into lower phases instead of relying on its presence or absence.  

This patch also continues the war against `InOutType` by reducing the usages of `is<InOutType>` and `getAs<InOutType>` where possible.  The blessed phase of compilation that should ultimately be able to utter `InOutType::get` is Sema - though I remain hopeful that we can eventually remove this entirely and just use the parameter bits.  `is<InOutType>` and `getAs<InOutType>` are also allowed in the AST Verifier until we can push the `InOutType` changes down as a proper structural invariant.  Everyone else should only speak about base types or ask Exprs and Decls for further information about `inout`-ness.

This patch is supposed to be NFC, but enforcing invariants necessitated changing a hack that altered a diagnostic (see `test/expr/expressions.swift`).