### PR TITLE
[QoI] NFC: Remove use of `.flush()` when emitting notes for missing `try`

### DIFF
--- a/lib/Sema/TypeCheckError.cpp
+++ b/lib/Sema/TypeCheckError.cpp
@@ -1048,11 +1048,8 @@ public:
     if (reason.getKind() != PotentialReason::Kind::CallThrows)
       return;
 
-    TC.diagnose(loc, diag::note_forgot_try).fixItInsert(loc, "try ").flush();
-    TC.diagnose(loc, diag::note_error_to_optional)
-        .fixItInsert(loc, "try? ")
-        .flush();
-
+    TC.diagnose(loc, diag::note_forgot_try).fixItInsert(loc, "try ");
+    TC.diagnose(loc, diag::note_error_to_optional).fixItInsert(loc, "try? ");
     TC.diagnose(loc, diag::note_disable_error_propagation)
         .fixItInsert(loc, "try! ");
   }


### PR DESCRIPTION

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
