### PR TITLE
[Type checker] Handle inferred @objc for all accessor kinds.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3296,6 +3296,8 @@ ERROR(objc_invalid_on_func_curried,none,
       "cannot be represented in Objective-C", (unsigned))
 ERROR(objc_observing_accessor, none,
       "observing accessors are not allowed to be marked @objc", ())
+ERROR(objc_addressor, none,
+      "addressors are not allowed to be marked @objc", ())
 ERROR(objc_invalid_on_func_variadic,none,
       "method cannot be %" OBJC_ATTR_SELECT "0 because it has a variadic "
       "parameter", (unsigned))

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1375,6 +1375,13 @@ static void enumerateOptionalConversionRestrictions(
   }
 }
 
+/// Determine whether we can bind the given type variable to the given
+/// fixed type.
+static bool isBindable(TypeVariableType *typeVar, Type type) {
+  return !ConstraintSystem::typeVarOccursInType(typeVar, type) &&
+         !type->is<DependentMemberType>();
+}
+
 ConstraintSystem::SolutionKind
 ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
                              TypeMatchOptions flags,
@@ -1480,8 +1487,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
         // Simplify the right-hand type and perform the "occurs" check.
         typeVar1 = getRepresentative(typeVar1);
         type2 = simplifyType(type2, flags);
-        if (typeVarOccursInType(typeVar1, type2) ||
-            type2->is<DependentMemberType>())
+        if (!isBindable(typeVar1, type2))
           return formUnsolvedResult();
 
         // Equal constraints allow mixed LValue/RValue bindings, but
@@ -1531,8 +1537,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
       // Simplify the left-hand type and perform the "occurs" check.
       typeVar2 = getRepresentative(typeVar2);
       type1 = simplifyType(type1, flags);
-      if (typeVarOccursInType(typeVar2, type1) ||
-          type1->is<DependentMemberType>())
+      if (!isBindable(typeVar2, type1))
         return formUnsolvedResult();
 
       // Equal constraints allow mixed LValue/RValue bindings, but
@@ -1564,8 +1569,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
         // Simplify the left-hand type and perform the "occurs" check.
         typeVar2 = getRepresentative(typeVar2);
         type1 = simplifyType(type1, flags);
-        if (typeVarOccursInType(typeVar2, type1) ||
-            type1->is<DependentMemberType>())
+        if (!isBindable(typeVar2, type1))
           return formUnsolvedResult();
 
         if (auto *iot = type1->getAs<InOutType>()) {
@@ -1578,8 +1582,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
         // Simplify the right-hand type and perform the "occurs" check.
         typeVar1 = getRepresentative(typeVar1);
         type2 = simplifyType(type2, flags);
-        if (typeVarOccursInType(typeVar1, type2) ||
-            type2->is<DependentMemberType>())
+        if (!isBindable(typeVar1, type2))
           return formUnsolvedResult();
 
         if (auto *lvt = type2->getAs<LValueType>()) {

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -2262,3 +2262,23 @@ extension SubclassInfersFromProtocol2 {
 @objc class NeverReturningMethod {
   @objc func doesNotReturn() -> Never {}
 }
+
+// SR-5025
+class User: NSObject {
+}
+
+@objc extension User {
+	var name: String {
+		get {
+			return "No name"
+		}
+		set {
+			// Nothing
+		}
+	}
+
+	var other: String {
+    unsafeAddress { // expected-error{{addressors are not allowed to be marked @objc}}
+    }
+  }
+}


### PR DESCRIPTION
Due to the wanton use of 'if' rather than 'switch', non-observing,
non-get/set ccessors that got marked '@objc' would cause an
assertion. Fix the materializeForSet case from the bug report as well
as the addressor case.

Fixes SR-5025 / rdar://problem/32426538.