### PR TITLE
SILGen: Do a read-only projection of a writable KeyPath when the lvalue is only read.

### DIFF
--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -1499,10 +1499,33 @@ namespace {
         KeyPath(std::move(KeyPath))
     {}
   
-    ManagedValue offset(SILGenFunction &SGF, SILLocation loc, ManagedValue base,
-                        AccessKind accessKind) && override {
-      assert(SGF.InWritebackScope &&
-             "offsetting l-value for modification without writeback scope");
+    // An rvalue base object is passed indirectly +1 so needs to be
+    // materialized if the base we have is +0 or a loaded value.
+    void makeBaseConsumableMaterializedRValue(SILGenFunction &SGF,
+                                              SILLocation loc,
+                                              ManagedValue &base) {
+      if (base.isLValue()) {
+        auto tmp = SGF.emitTemporaryAllocation(loc, base.getType());
+        SGF.B.createCopyAddr(loc, base.getValue(), tmp,
+                             IsNotTake, IsInitialization);
+        base = SGF.emitManagedBufferWithCleanup(tmp);
+        return;
+      }
+
+      bool isBorrowed = base.isPlusZeroRValueOrTrivial()
+        && !base.getType().isTrivial(SGF.SGM.M);
+      if (!base.getType().isAddress() || isBorrowed) {
+        auto tmp = SGF.emitTemporaryAllocation(loc, base.getType());
+        if (isBorrowed)
+          base.copyInto(SGF, tmp, loc);
+        else
+          base.forwardInto(SGF, loc, tmp);
+        base = SGF.emitManagedBufferWithCleanup(tmp);
+      }
+    }
+  
+    ManagedValue mutableOffset(
+                   SILGenFunction &SGF, SILLocation loc, ManagedValue base) && {
       auto &C = SGF.getASTContext();
       auto keyPathTy = KeyPath.getSubstType()->castTo<BoundGenericType>();
 
@@ -1526,18 +1549,7 @@ namespace {
         projectionFunction = C.getProjectKeyPathWritable(nullptr);
       } else if (keyPathTy->getDecl() == C.getReferenceWritableKeyPathDecl()) {
         projectionFunction = C.getProjectKeyPathReferenceWritable(nullptr);
-        // The base value is passed indirectly +1 so needs to be
-        // materialized if the base we have is +0 or a loaded value.
-        bool isBorrowed = base.isPlusZeroRValueOrTrivial()
-          && !base.getType().isTrivial(SGF.SGM.M);
-        if (!base.getType().isAddress() || isBorrowed) {
-          auto tmp = SGF.emitTemporaryAllocation(loc, base.getType());
-          if (isBorrowed)
-            base.copyInto(SGF, tmp, loc);
-          else
-            base.forwardInto(SGF, loc, tmp);
-          base = SGF.emitManagedBufferWithCleanup(tmp);
-        }
+        makeBaseConsumableMaterializedRValue(SGF, loc, base);
       } else {
         llvm_unreachable("not a writable key path type?!");
       }
@@ -1581,6 +1593,59 @@ namespace {
       return ManagedValue::forLValue(projectedAddr);
     }
 
+    ManagedValue readOnlyOffset(
+                   SILGenFunction &SGF, SILLocation loc, ManagedValue base) && {
+      auto &C = SGF.getASTContext();
+      
+      makeBaseConsumableMaterializedRValue(SGF, loc, base);
+      auto keyPathValue = std::move(KeyPath).getAsSingleValue(SGF);
+      // Upcast the key path operand to the base KeyPath type, as expected by
+      // the read-only projection function.
+      BoundGenericType *keyPathTy
+        = keyPathValue.getType().castTo<BoundGenericType>();
+      if (keyPathTy->getDecl() != C.getKeyPathDecl()) {
+        keyPathTy = BoundGenericType::get(C.getKeyPathDecl(), Type(),
+                                          keyPathTy->getGenericArgs());
+        keyPathValue = SGF.B.createUpcast(loc, keyPathValue,
+                SILType::getPrimitiveObjectType(keyPathTy->getCanonicalType()));
+      }
+      
+      Substitution args[] = {
+        Substitution(keyPathTy->getGenericArgs()[0], {}),
+        Substitution(keyPathTy->getGenericArgs()[1], {}),
+      };
+      auto projectFn = C.getProjectKeyPathReadOnly(nullptr);
+      auto subMap = projectFn->getGenericSignature()
+        ->getSubstitutionMap(args);
+
+      // Allocate a temporary to own the projected value.
+      auto &resultTL = SGF.getTypeLowering(keyPathTy->getGenericArgs()[1]);
+      auto resultInit = SGF.emitTemporary(loc, resultTL);
+
+      auto result = SGF.emitApplyOfLibraryIntrinsic(loc, projectFn,
+        subMap, {base, keyPathValue}, SGFContext(resultInit.get()));
+      if (!result.isInContext())
+        std::move(result).forwardInto(SGF, loc, resultInit.get());
+      
+      // Result should be a temporary we own. Return its address as an lvalue.
+      return ManagedValue::forLValue(resultInit->getAddress());
+    }
+  
+    ManagedValue offset(SILGenFunction &SGF, SILLocation loc, ManagedValue base,
+                        AccessKind accessKind) && override {
+      assert(SGF.InWritebackScope &&
+             "offsetting l-value for modification without writeback scope");
+      switch (accessKind) {
+      case AccessKind::ReadWrite:
+      case AccessKind::Write:
+        return std::move(*this).mutableOffset(SGF, loc, base);
+      case AccessKind::Read:
+        // For a read-only access, project the key path as if immutable,
+        // so that we don't trigger captured writebacks or observers or other
+        // operations that might be enqueued by a mutable projection.
+        return std::move(*this).readOnlyOffset(SGF, loc, base);
+      }
+    }
     void print(raw_ostream &OS) const override {
       OS << "KeyPathApplicationComponent";
     }

--- a/test/SILGen/keypath_application.swift
+++ b/test/SILGen/keypath_application.swift
@@ -26,52 +26,19 @@ func loadable(readonly: A, writable: inout A,
   _ = writable[keyPath: kp]
   _ = readonly[keyPath: wkp]
 
-  // CHECK: [[TEMP:%.*]] = mark_uninitialized
-  // CHECK: [[ROOT_ACCESS:%.*]] = begin_access [read] [unknown] %1 : $*A
-  // CHECK: [[ROOT_RAW_PTR:%.*]] = address_to_pointer [[ROOT_ACCESS]]
-  // CHECK: [[ROOT_PTR:%.*]] = struct $UnsafeMutablePointer<A> ([[ROOT_RAW_PTR]]
-  // CHECK: [[KP_BORROW:%.*]] = begin_borrow %4
-  // CHECK: [[KP_COPY:%.*]] = copy_value [[KP_BORROW]]
-  // CHECK: [[PROJECT:%.*]] = function_ref @{{.*}}_projectKeyPathWritable
-  // CHECK: [[PROJECTED:%.*]] = apply [[PROJECT]]<A, B>([[ROOT_PTR]], [[KP_COPY]])
-  // CHECK: [[PROJECTED_BORROW:%.*]] = begin_borrow [[PROJECTED]]
-  // CHECK: [[PROJECTED_PTR:%.*]] = tuple_extract [[PROJECTED_BORROW]]
-  // CHECK: [[PROJECTED_OWNER_B:%.*]] = tuple_extract [[PROJECTED_BORROW]]
-  // CHECK: [[PROJECTED_OWNER:%.*]] = copy_value [[PROJECTED_OWNER_B]]
-  // CHECK: destroy_value [[PROJECTED]]
-  // CHECK: [[PROJECTED_RAW_PTR:%.*]] = struct_extract [[PROJECTED_PTR]]
-  // CHECK: [[PROJECTED_ADDR:%.*]] = pointer_to_address [[PROJECTED_RAW_PTR]]
-  // CHECK: [[PROJECTED_DEP:%.*]] = mark_dependence [[PROJECTED_ADDR]] : $*B on [[PROJECTED_OWNER]]
-  // CHECK: [[COPY_TMP:%.*]] = load [copy] [[PROJECTED_DEP]] : $*B
-  // CHECK: assign [[COPY_TMP]] to [[TEMP]] : $*B
-  // CHECK: destroy_value [[PROJECTED_OWNER]]
+  // CHECK: function_ref @{{.*}}_projectKeyPathReadOnly
   _ = writable[keyPath: wkp]
 
-  // CHECK: [[TEMP:%.*]] = mark_uninitialized
-  // CHECK: [[ROOT_BORROW:%.*]] = begin_borrow %0
-  // CHECK: [[ROOT_COPY:%.*]] = copy_value [[ROOT_BORROW]]
-  // CHECK: [[ROOT_TMP:%.*]] = alloc_stack $A
-  // CHECK: store [[ROOT_COPY]] to [init] [[ROOT_TMP]]
-  // CHECK: [[KP_BORROW:%.*]] = begin_borrow %5
-  // CHECK: [[KP_COPY:%.*]] = copy_value [[KP_BORROW]]
-  // CHECK: [[PROJECT:%.*]] = function_ref @{{.*}}_projectKeyPathReferenceWritable
-  // CHECK: [[PROJECTED:%.*]] = apply [[PROJECT]]<A, B>([[ROOT_TMP]], [[KP_COPY]])
-  // CHECK: [[PROJECTED_BORROW:%.*]] = begin_borrow [[PROJECTED]]
-  // CHECK: [[PROJECTED_PTR:%.*]] = tuple_extract [[PROJECTED_BORROW]]
-  // CHECK: [[PROJECTED_OWNER_B:%.*]] = tuple_extract [[PROJECTED_BORROW]]
-  // CHECK: [[PROJECTED_OWNER:%.*]] = copy_value [[PROJECTED_OWNER_B]]
-  // CHECK: destroy_value [[PROJECTED]]
-  // CHECK: [[PROJECTED_RAW_PTR:%.*]] = struct_extract [[PROJECTED_PTR]]
-  // CHECK: [[PROJECTED_ADDR:%.*]] = pointer_to_address [[PROJECTED_RAW_PTR]]
-  // CHECK: [[PROJECTED_DEP:%.*]] = mark_dependence [[PROJECTED_ADDR]] : $*B on [[PROJECTED_OWNER]]
-  // CHECK: [[COPY_TMP:%.*]] = load [copy] [[PROJECTED_DEP]] : $*B
-  // CHECK: assign [[COPY_TMP]] to [[TEMP]] : $*B
-  // CHECK: destroy_value [[PROJECTED_OWNER]]
+  // CHECK: function_ref @{{.*}}_projectKeyPathReadOnly
   _ = readonly[keyPath: rkp]
+  // CHECK: function_ref @{{.*}}_projectKeyPathReadOnly
   _ = writable[keyPath: rkp]
 
+  // CHECK: function_ref @{{.*}}_projectKeyPathWritable
   writable[keyPath: wkp] = value
+  // CHECK: function_ref @{{.*}}_projectKeyPathReferenceWritable
   readonly[keyPath: rkp] = value
+  // CHECK: function_ref @{{.*}}_projectKeyPathReferenceWritable
   writable[keyPath: rkp] = value
 }
 
@@ -81,62 +48,26 @@ func addressOnly(readonly: P, writable: inout P,
                  kp: KeyPath<P, Q>,
                  wkp: WritableKeyPath<P, Q>,
                  rkp: ReferenceWritableKeyPath<P, Q>) {
-  // CHECK: [[ROOT_TMP:%.*]] = alloc_stack $P
-  // CHECK: copy_addr %0 to [initialization] [[ROOT_TMP]]
-  // CHECK: [[KP_BORROW:%.*]] = begin_borrow %3
-  // CHECK: [[KP_COPY:%.*]] = copy_value [[KP_BORROW]]
-  // CHECK: [[PROJECT:%.*]] = function_ref @{{.*}}_projectKeyPathReadOnly
-  // CHECK: [[RESULT:%.*]] = alloc_stack $Q
-  // CHECK: apply [[PROJECT]]<P, Q>([[RESULT]], [[ROOT_TMP]], [[KP_COPY]])
-  // CHECK: destroy_addr [[RESULT]]
+  // CHECK: function_ref @{{.*}}_projectKeyPathReadOnly
   _ = readonly[keyPath: kp]
+  // CHECK: function_ref @{{.*}}_projectKeyPathReadOnly
   _ = writable[keyPath: kp]
+  // CHECK: function_ref @{{.*}}_projectKeyPathReadOnly
   _ = readonly[keyPath: wkp]
 
-  // CHECK: [[TEMP:%.*]] = mark_uninitialized
-  // CHECK: [[ROOT_ACCESS:%.*]] = begin_access [read] [unknown] %1 : $*P
-  // CHECK: [[ROOT_RAW_PTR:%.*]] = address_to_pointer [[ROOT_ACCESS]]
-  // CHECK: [[ROOT_PTR:%.*]] = struct $UnsafeMutablePointer<P> ([[ROOT_RAW_PTR]]
-  // CHECK: [[KP_BORROW:%.*]] = begin_borrow %4
-  // CHECK: [[KP_COPY:%.*]] = copy_value [[KP_BORROW]]
-  // CHECK: [[PROJECT:%.*]] = function_ref @{{.*}}_projectKeyPathWritable
-  // CHECK: [[PROJECTED:%.*]] = apply [[PROJECT]]<P, Q>([[ROOT_PTR]], [[KP_COPY]])
-  // CHECK: [[PROJECTED_BORROW:%.*]] = begin_borrow [[PROJECTED]]
-  // CHECK: [[PROJECTED_PTR:%.*]] = tuple_extract [[PROJECTED_BORROW]]
-  // CHECK: [[PROJECTED_OWNER_B:%.*]] = tuple_extract [[PROJECTED_BORROW]]
-  // CHECK: [[PROJECTED_OWNER:%.*]] = copy_value [[PROJECTED_OWNER_B]]
-  // CHECK: destroy_value [[PROJECTED]]
-  // CHECK: [[PROJECTED_RAW_PTR:%.*]] = struct_extract [[PROJECTED_PTR]]
-  // CHECK: [[PROJECTED_ADDR:%.*]] = pointer_to_address [[PROJECTED_RAW_PTR]]
-  // CHECK: [[PROJECTED_DEP:%.*]] = mark_dependence [[PROJECTED_ADDR]] : $*Q on [[PROJECTED_OWNER]]
-  // CHECK: copy_addr [[PROJECTED_DEP]] to [initialization] [[CPY_TMP:%.*]] : $*Q
-  // CHECK: copy_addr [take] [[CPY_TMP]] to [[TEMP]] : $*Q
-  // CHECK: destroy_value [[PROJECTED_OWNER]]
+  // CHECK: function_ref @{{.*}}_projectKeyPathReadOnly
   _ = writable[keyPath: wkp]
 
-  // CHECK: [[TEMP:%.*]] = mark_uninitialized
-  // CHECK: [[ROOT_TMP:%.*]] = alloc_stack $P
-  // CHECK: copy_addr %0 to [initialization] [[ROOT_TMP]]
-  // CHECK: [[KP_BORROW:%.*]] = begin_borrow %5
-  // CHECK: [[KP_COPY:%.*]] = copy_value [[KP_BORROW]]
-  // CHECK: [[PROJECT:%.*]] = function_ref @{{.*}}_projectKeyPathReferenceWritable
-  // CHECK: [[PROJECTED:%.*]] = apply [[PROJECT]]<P, Q>([[ROOT_TMP]], [[KP_COPY]])
-  // CHECK: [[PROJECTED_BORROW:%.*]] = begin_borrow [[PROJECTED]]
-  // CHECK: [[PROJECTED_PTR:%.*]] = tuple_extract [[PROJECTED_BORROW]]
-  // CHECK: [[PROJECTED_OWNER_B:%.*]] = tuple_extract [[PROJECTED_BORROW]]
-  // CHECK: [[PROJECTED_OWNER:%.*]] = copy_value [[PROJECTED_OWNER_B]]
-  // CHECK: destroy_value [[PROJECTED]]
-  // CHECK: [[PROJECTED_RAW_PTR:%.*]] = struct_extract [[PROJECTED_PTR]]
-  // CHECK: [[PROJECTED_ADDR:%.*]] = pointer_to_address [[PROJECTED_RAW_PTR]]
-  // CHECK: [[PROJECTED_DEP:%.*]] = mark_dependence [[PROJECTED_ADDR]] : $*Q on [[PROJECTED_OWNER]]
-  // CHECK: copy_addr [[PROJECTED_DEP]] to [initialization] [[CPY_TMP:%.*]] : $*Q
-  // CHECK: copy_addr [take] [[CPY_TMP]] to [[TEMP]] : $*Q
-  // CHECK: destroy_value [[PROJECTED_OWNER]]
+  // CHECK: function_ref @{{.*}}_projectKeyPathReadOnly
   _ = readonly[keyPath: rkp]
+  // CHECK: function_ref @{{.*}}_projectKeyPathReadOnly
   _ = writable[keyPath: rkp]
 
+  // CHECK: function_ref @{{.*}}_projectKeyPathWritable
   writable[keyPath: wkp] = value
+  // CHECK: function_ref @{{.*}}_projectKeyPathReferenceWritable
   readonly[keyPath: rkp] = value
+  // CHECK: function_ref @{{.*}}_projectKeyPathReferenceWritable
   writable[keyPath: rkp] = value
 }
 
@@ -147,77 +78,26 @@ func reabstracted(readonly: @escaping () -> (),
                   kp: KeyPath<() -> (), (A) -> B>,
                   wkp: WritableKeyPath<() -> (), (A) -> B>,
                   rkp: ReferenceWritableKeyPath<() -> (), (A) -> B>) {
-  // CHECK: [[ROOT_TMP:%.*]] = alloc_stack $@callee_owned (@in ()) -> @out ()
-  // CHECK: [[ROOT_BORROW:%.*]] = begin_borrow %0
-  // CHECK: [[ROOT_COPY:%.*]] = copy_value [[ROOT_BORROW]]
-  // CHECK: [[ROOT_ORIG:%.*]] = partial_apply {{.*}}([[ROOT_COPY]])
-  // CHECK:  store [[ROOT_ORIG]] to [init] [[ROOT_TMP]]
-  // CHECK: [[KP_BORROW:%.*]] = begin_borrow %3
-  // CHECK: [[KP_COPY:%.*]] = copy_value [[KP_BORROW]]
   // CHECK: [[PROJECT:%.*]] = function_ref @{{.*}}_projectKeyPathReadOnly
-  // CHECK: [[RESULT_TMP:%.*]] = alloc_stack $@callee_owned (@in A) -> @out B
-  // CHECK: apply [[PROJECT]]<() -> (), (A) -> B>([[RESULT_TMP]], [[ROOT_TMP]], [[KP_COPY]])
-  // CHECK: [[RESULT_ORIG:%.*]] = load [take] [[RESULT_TMP]]
-  // CHECK: [[RESULT_SUBST:%.*]] = partial_apply {{.*}}([[RESULT_ORIG]])
-  // CHECK: destroy_value [[RESULT_SUBST]]
   _ = readonly[keyPath: kp]
+  // CHECK: [[PROJECT:%.*]] = function_ref @{{.*}}_projectKeyPathReadOnly
   _ = writable[keyPath: kp]
+  // CHECK: [[PROJECT:%.*]] = function_ref @{{.*}}_projectKeyPathReadOnly
   _ = readonly[keyPath: wkp]
 
-  // CHECK: [[TEMP_SUBST:%.*]] = mark_uninitialized {{.*}} : $*@callee_owned (@owned A) -> @owned B
-  // CHECK: [[ROOT_ACCESS:%.*]] = begin_access [read] [unknown] %1 : $*@callee_owned () -> ()
-  // CHECK: [[ROOT_ORIG_TMP:%.*]] = alloc_stack $@callee_owned (@in ()) -> @out ()
-  // CHECK: [[ROOT_SUBST:%.*]] = load [copy] [[ROOT_ACCESS]]
-  // CHECK: [[ROOT_ORIG:%.*]] = partial_apply {{.*}}([[ROOT_SUBST]])
-  // CHECK: store [[ROOT_ORIG]] to [init] [[ROOT_ORIG_TMP]]
-  // CHECK: [[ROOT_RAW_PTR:%.*]] = address_to_pointer [[ROOT_ORIG_TMP]]
-  // CHECK: [[ROOT_PTR:%.*]] = struct $UnsafeMutablePointer<() -> ()> ([[ROOT_RAW_PTR]]
-  // CHECK: [[KP_BORROW:%.*]] = begin_borrow %4
-  // CHECK: [[KP_COPY:%.*]] = copy_value [[KP_BORROW]]
-  // CHECK: [[PROJECT:%.*]] = function_ref @{{.*}}_projectKeyPathWritable
-  // CHECK: [[PROJECTED:%.*]] = apply [[PROJECT]]<() -> (), (A) -> B>([[ROOT_PTR]], [[KP_COPY]])
-  // CHECK: [[PROJECTED_BORROW:%.*]] = begin_borrow [[PROJECTED]]
-  // CHECK: [[PROJECTED_PTR:%.*]] = tuple_extract [[PROJECTED_BORROW]]
-  // CHECK: [[PROJECTED_OWNER_B:%.*]] = tuple_extract [[PROJECTED_BORROW]]
-  // CHECK: [[PROJECTED_OWNER:%.*]] = copy_value [[PROJECTED_OWNER_B]]
-  // CHECK: destroy_value [[PROJECTED]]
-  // CHECK: [[PROJECTED_RAW_PTR:%.*]] = struct_extract [[PROJECTED_PTR]]
-  // CHECK: [[PROJECTED_ORIG_ADDR:%.*]] = pointer_to_address [[PROJECTED_RAW_PTR]] {{.*}} to [strict] $*@callee_owned (@in A) -> @out B
-  // CHECK: [[PROJECTED_DEP:%.*]] = mark_dependence [[PROJECTED_ORIG_ADDR]] : $*@callee_owned (@in A) -> @out B on [[PROJECTED_OWNER]]
-  // CHECK: [[PROJECTED_ORIG:%.*]] = load [copy] [[PROJECTED_DEP]]
-  // CHECK: [[PROJECTED_SUBST:%.*]] = partial_apply {{.*}}([[PROJECTED_ORIG]])
-  // CHECK: destroy_addr [[ROOT_ORIG_TMP]]
-  // CHECK: assign [[PROJECTED_SUBST]] to [[TEMP_SUBST]]
-  // CHECK: destroy_value [[PROJECTED_OWNER]]
+  // CHECK: [[PROJECT:%.*]] = function_ref @{{.*}}_projectKeyPathReadOnly
   _ = writable[keyPath: wkp]
 
-  // CHECK: [[TEMP:%.*]] = mark_uninitialized
-  // CHECK: [[ROOT_BORROW:%.*]] = begin_borrow %0
-  // CHECK: [[ROOT_COPY_SUBST:%.*]] = copy_value [[ROOT_BORROW]]
-  // CHECK: [[ROOT_COPY_ORIG:%.*]] = partial_apply {{.*}}([[ROOT_COPY_SUBST]])
-  // CHECK: [[ROOT_TMP:%.*]] = alloc_stack $@callee_owned (@in ()) -> @out ()
-  // CHECK: store [[ROOT_COPY_ORIG]] to [init] [[ROOT_TMP]]
-  // CHECK: [[KP_BORROW:%.*]] = begin_borrow %5
-  // CHECK: [[KP_COPY:%.*]] = copy_value [[KP_BORROW]]
-  // CHECK: [[PROJECT:%.*]] = function_ref @{{.*}}_projectKeyPathReferenceWritable
-  // CHECK: [[PROJECTED:%.*]] = apply [[PROJECT]]<() -> (), (A) -> B>([[ROOT_TMP]], [[KP_COPY]])
-  // CHECK: [[PROJECTED_BORROW:%.*]] = begin_borrow [[PROJECTED]]
-  // CHECK: [[PROJECTED_PTR:%.*]] = tuple_extract [[PROJECTED_BORROW]]
-  // CHECK: [[PROJECTED_OWNER_B:%.*]] = tuple_extract [[PROJECTED_BORROW]]
-  // CHECK: [[PROJECTED_OWNER:%.*]] = copy_value [[PROJECTED_OWNER_B]]
-  // CHECK: destroy_value [[PROJECTED]]
-  // CHECK: [[PROJECTED_RAW_PTR:%.*]] = struct_extract [[PROJECTED_PTR]]
-  // CHECK: [[PROJECTED_ADDR_ORIG:%.*]] = pointer_to_address [[PROJECTED_RAW_PTR]] {{.*}} to [strict] $*@callee_owned (@in A) -> @out B
-  // CHECK: [[PROJECTED_DEP:%.*]] = mark_dependence [[PROJECTED_ADDR_ORIG]] : $*@callee_owned (@in A) -> @out B on [[PROJECTED_OWNER]]
-  // CHECK: [[PROJECTED_ORIG:%.*]] = load [copy] [[PROJECTED_DEP]]
-  // CHECK: [[PROJECTED_SUBST:%.*]] = partial_apply {{.*}}([[PROJECTED_ORIG]])
-  // CHECK: assign [[PROJECTED_SUBST]] to [[TEMP]]
-  // CHECK: destroy_value [[PROJECTED_OWNER]]
+  // CHECK: [[PROJECT:%.*]] = function_ref @{{.*}}_projectKeyPathReadOnly
   _ = readonly[keyPath: rkp]
+  // CHECK: [[PROJECT:%.*]] = function_ref @{{.*}}_projectKeyPathReadOnly
   _ = writable[keyPath: rkp]
 
+  // CHECK: [[PROJECT:%.*]] = function_ref @{{.*}}_projectKeyPathWritable
   writable[keyPath: wkp] = value
+  // CHECK: [[PROJECT:%.*]] = function_ref @{{.*}}_projectKeyPathReferenceWritable
   readonly[keyPath: rkp] = value
+  // CHECK: [[PROJECT:%.*]] = function_ref @{{.*}}_projectKeyPathReferenceWritable
   writable[keyPath: rkp] = value
 }
 
@@ -241,3 +121,4 @@ func partial<A>(valueA: A,
   // CHECK: apply [[PROJECT]]<Int>
   _ = valueB[keyPath: pkpB]
 }
+


### PR DESCRIPTION
If we project an lvalue using a KeyPath, but the lvalue is only read from, we don't want to trigger writebacks, observers, or other side effects that a mutable projection would normally need to induce. Fixes SR-5338 | rdar://problem/33135489.