### PR TITLE
[4.0] [Type checker] Don't allow type variables to bind to dependent members.

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1459,7 +1459,8 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
         // Simplify the right-hand type and perform the "occurs" check.
         typeVar1 = getRepresentative(typeVar1);
         type2 = simplifyType(type2, flags);
-        if (typeVarOccursInType(typeVar1, type2))
+        if (typeVarOccursInType(typeVar1, type2) ||
+            type2->is<DependentMemberType>())
           return formUnsolvedResult();
 
         // Equal constraints allow mixed LValue/RValue bindings, but
@@ -1509,7 +1510,8 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
       // Simplify the left-hand type and perform the "occurs" check.
       typeVar2 = getRepresentative(typeVar2);
       type1 = simplifyType(type1, flags);
-      if (typeVarOccursInType(typeVar2, type1))
+      if (typeVarOccursInType(typeVar2, type1) ||
+          type1->is<DependentMemberType>())
         return formUnsolvedResult();
 
       // Equal constraints allow mixed LValue/RValue bindings, but
@@ -1541,7 +1543,8 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
         // Simplify the left-hand type and perform the "occurs" check.
         typeVar2 = getRepresentative(typeVar2);
         type1 = simplifyType(type1, flags);
-        if (typeVarOccursInType(typeVar2, type1))
+        if (typeVarOccursInType(typeVar2, type1) ||
+            type1->is<DependentMemberType>())
           return formUnsolvedResult();
 
         if (auto *iot = type1->getAs<InOutType>()) {
@@ -1554,7 +1557,8 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
         // Simplify the right-hand type and perform the "occurs" check.
         typeVar1 = getRepresentative(typeVar1);
         type2 = simplifyType(type2, flags);
-        if (typeVarOccursInType(typeVar1, type2))
+        if (typeVarOccursInType(typeVar1, type2) ||
+            type2->is<DependentMemberType>())
           return formUnsolvedResult();
 
         if (auto *lvt = type2->getAs<LValueType>()) {

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -446,3 +446,35 @@ func sr3525_3<T>(t: SR_3525<T>) {
 class testStdlibType {
   let _: Array // expected-error {{reference to generic type 'Array' requires arguments in <...>}} {{15-15=<Any>}}
 }
+
+// rdar://problem/32697033
+protocol P3 {
+    associatedtype InnerAssoc
+}
+
+protocol P4 {
+    associatedtype OuterAssoc: P3
+}
+
+struct S3 : P3 {
+  typealias InnerAssoc = S4
+}
+
+struct S4: P4 {
+  typealias OuterAssoc = S3
+}
+
+public struct S5 {
+    func f<Model: P4, MO> (models: [Model])
+        where Model.OuterAssoc == MO, MO.InnerAssoc == Model {
+    }
+
+    func g<MO, Model: P4> (models: [Model])
+        where Model.OuterAssoc == MO, MO.InnerAssoc == Model {
+    }
+
+    func f(arr: [S4]) {
+        f(models: arr)
+        g(models: arr)
+    }
+}

--- a/validation-test/compiler_crashers_fixed/28754-value-openexistentials-end-didnt-see-this-ove-in-a-containing-openexistentialexp.swift
+++ b/validation-test/compiler_crashers_fixed/28754-value-openexistentials-end-didnt-see-this-ove-in-a-containing-openexistentialexp.swift
@@ -6,7 +6,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 protocol A:RangeReplaceableCollection
 typealias e:a._=A.init(
 [.e


### PR DESCRIPTION
**Explanation**: Addresses a type inference regression introduced in Swift 4 involving certain same-type constraints among two interdependent generic type parameters.
**Scope**: The behavioral change affects code with a set of interesting same-type constraints (we've seen two user-reported instances of this), although the solution is a more general improvement to the type checker.
**Radar**: rdar://problem/32697033 (+ dupes)
**Risk**: Low; in theory we're delaying some type variable bindings that could cause type inference failures, but is appears to be highly unlikely
**Testing**: Compiler regression testing, new tests, source compatibility suite