### PR TITLE
[4.0] [Type checker] Handle inferred @objc for all accessor kinds.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3306,6 +3306,8 @@ ERROR(objc_invalid_on_func_curried,none,
       "cannot be represented in Objective-C", (unsigned))
 ERROR(objc_observing_accessor, none,
       "observing accessors are not allowed to be marked @objc", ())
+ERROR(objc_addressor, none,
+      "addressors are not allowed to be marked @objc", ())
 ERROR(objc_invalid_on_func_variadic,none,
       "method cannot be %" OBJC_ATTR_SELECT "0 because it has a variadic "
       "parameter", (unsigned))

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3503,17 +3503,36 @@ bool TypeChecker::isRepresentableInObjC(
         return false;
       }
 
-      // willSet/didSet implementations are never exposed to objc, they are
-      // always directly dispatched from the synthesized setter.
-      if (FD->isObservingAccessor()) {
+      switch (FD->getAccessorKind()) {
+      case AccessorKind::NotAccessor:
+        llvm_unreachable("already checking for accessor-ness");
+
+      case AccessorKind::IsDidSet:
+      case AccessorKind::IsWillSet:
+          // willSet/didSet implementations are never exposed to objc, they are
+          // always directly dispatched from the synthesized setter.
         if (Diagnose) {
           diagnose(AFD->getLoc(), diag::objc_observing_accessor);
           describeObjCReason(*this, AFD, Reason);
         }
         return false;
+
+      case AccessorKind::IsGetter:
+      case AccessorKind::IsSetter:
+        return true;
+
+      case AccessorKind::IsMaterializeForSet:
+        // materializeForSet is synthesized, so never complain about it
+        return false;
+
+      case AccessorKind::IsAddressor:
+      case AccessorKind::IsMutableAddressor:
+        if (Diagnose) {
+          diagnose(AFD->getLoc(), diag::objc_addressor);
+          describeObjCReason(*this, AFD, Reason);
+        }
+        return false;
       }
-      assert(FD->isGetterOrSetter() && "missing diags for other accessors");
-      return true;
     }
 
     unsigned ExpectedParamPatterns = 1;

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -2262,3 +2262,23 @@ extension SubclassInfersFromProtocol2 {
 @objc class NeverReturningMethod {
   @objc func doesNotReturn() -> Never {}
 }
+
+// SR-5025
+class User: NSObject {
+}
+
+@objc extension User {
+	var name: String {
+		get {
+			return "No name"
+		}
+		set {
+			// Nothing
+		}
+	}
+
+	var other: String {
+    unsafeAddress { // expected-error{{addressors are not allowed to be marked @objc}}
+    }
+  }
+}


### PR DESCRIPTION
**Explanation**: The Swift compiler would assert when given an `@objc` extension with a computed property in it. Suppress the `@objc` in the asserting case (the synthesized `materializeForSet`) and complain in a previously-untested-but-broken case involving addressors.
**Scope**: Only affects the narrow cases of `@objc` extensions with properties.
**Radar / SR**: SR-5025 / rdar://problem/32426538.
**Risk**: Basically zero; expands an incomplete set of `if` statements into a fully-covered switch on accessor kinds.
**Testing**: Compiler regression testing.