### PR TITLE
[4.0] [ClangImporter] Generic parameters can be Hashable too

### DIFF
--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2417,6 +2417,15 @@ bool ClangImporter::Implementation::matchesHashableBound(Type type) {
   if (!NSObjectType)
     return false;
 
+  // Match generic parameters against their bounds.
+  if (auto *genericTy = type->getAs<GenericTypeParamType>()) {
+    if (auto *generic = genericTy->getDecl()) {
+      type = generic->getSuperclass();
+      if (!type)
+        return false;
+    }
+  }
+
   // Class type or existential that inherits from NSObject.
   if (NSObjectType->isExactSuperclassOf(type))
     return true;

--- a/test/ClangImporter/Inputs/custom-modules/ObjCBridgeNonconforming.h
+++ b/test/ClangImporter/Inputs/custom-modules/ObjCBridgeNonconforming.h
@@ -4,3 +4,26 @@
 @interface ObjCBridgeNonconforming
 @property NSSet<NSDictionary<NSString *, id> *> * _Nonnull foo;
 @end
+
+@interface ObjCBridgeGeneric<Element> : NSObject
+@property NSSet<Element> * _Nonnull foo;
+@end
+
+@interface ElementBase : NSObject
+@end
+@protocol ExtraElementProtocol
+@end
+@interface ElementConcrete : ElementBase <ExtraElementProtocol>
+@end
+
+@interface ObjCBridgeGenericConstrained<Element: ElementBase *> : NSObject
+@property NSSet<Element> * _Nonnull foo;
+@end
+
+@interface ObjCBridgeGenericInsufficientlyConstrained<Element: id <NSObject>> : NSObject
+@property NSSet<Element> * _Nonnull foo;
+@end
+
+@interface ObjCBridgeGenericConstrainedExtra<Element: NSObject <ExtraElementProtocol> *> : NSObject
+@property NSSet<Element> * _Nonnull foo;
+@end

--- a/test/ClangImporter/objc_bridging_generics.swift
+++ b/test/ClangImporter/objc_bridging_generics.swift
@@ -398,3 +398,14 @@ func useThird() {
 func testNonconforming(bnc: ObjCBridgeNonconforming) {
   let _: Int = bnc.foo // expected-error{{cannot convert value of type 'Set<AnyHashable>' to specified type 'Int'}}
 }
+
+func testHashableGenerics(
+    any: ObjCBridgeGeneric<ElementConcrete>,
+    constrained: ObjCBridgeGenericConstrained<ElementConcrete>,
+    insufficient: ObjCBridgeGenericInsufficientlyConstrained<ElementConcrete>,
+    extra: ObjCBridgeGenericConstrainedExtra<ElementConcrete>) {
+  let _: Int = any.foo // expected-error{{cannot convert value of type 'Set<AnyHashable>' to specified type 'Int'}}
+  let _: Int = constrained.foo // expected-error{{cannot convert value of type 'Set<ElementConcrete>' to specified type 'Int'}}
+  let _: Int = insufficient.foo // expected-error{{cannot convert value of type 'Set<AnyHashable>' to specified type 'Int'}}
+  let _: Int = extra.foo // expected-error{{cannot convert value of type 'Set<ElementConcrete>' to specified type 'Int'}}
+}


### PR DESCRIPTION
- **Explanation**: When importing NSSet and NSDictionary, we need to make sure the key type is Hashable in Swift. For classes, that just means being a subclass of NSObject. However, the logic to check this didn't handle ObjC lightweight generics that were constrained to being subclasses of NSObject. This is a regression from Swift 3.1.
- **Scope**: Affects NSSet and NSDictionary members of Objective-C generic classes.
- **Issue**: rdar://problem/33222646
- **Reviewed by**: @DougGregor   
- **Risk**: Low. This allows strictly more cases then in previous Swift 4.0 betas, but it's going back to previous behavior that already worked.
- **Testing**: Added new Swift regression tests, verified that the original test project now compiles.