### PR TITLE
Add fast paths for String to data conversion

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -66,6 +66,7 @@ set(SWIFT_BENCH_MODULES
     single-source/MonteCarloPi
     single-source/NSDictionaryCastToSwift
     single-source/NSError
+    single-source/NSStringAPI
     single-source/NSStringConversion
     single-source/NopDeinit
     single-source/ObjectAllocation

--- a/benchmark/single-source/NSStringAPI.swift
+++ b/benchmark/single-source/NSStringAPI.swift
@@ -1,0 +1,23 @@
+//===--- NSStrignAPI.swift ----------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import TestsUtils
+import Foundation
+
+@inline(never)
+public func run_String_dataUsingEncoding(_ N: Int) {
+	let string = String(repeating: "x", count: 4096)
+	for _ in 1...N*100 {
+		_ = string.data(using: .utf8)
+	}
+}
+

--- a/benchmark/utils/main.swift
+++ b/benchmark/utils/main.swift
@@ -71,6 +71,7 @@ import MonteCarloE
 import MonteCarloPi
 import NSDictionaryCastToSwift
 import NSError
+import NSStringAPI
 import NSStringConversion
 import NopDeinit
 import ObjectAllocation
@@ -424,6 +425,7 @@ addTo(&precommitTests, "StringMatch", run_StringMatch)
 addTo(&precommitTests, "StringUTF16Builder", run_StringUTF16Builder)
 addTo(&precommitTests, "StringWalk", run_StringWalk)
 addTo(&precommitTests, "StringWithCString", run_StringWithCString)
+addTo(&precommitTests, "String_dataUsingEncoding", run_String_dataUsingEncoding)
 addTo(&precommitTests, "SubstringComparable", run_SubstringComparable)
 addTo(&precommitTests, "SubstringEqualString", run_SubstringEqualString)
 addTo(&precommitTests, "SubstringEquatable", run_SubstringEquatable)


### PR DESCRIPTION
This resolves https://bugs.swift.org/browse/SR-5443

When String converts to Data we have some faster paths that can be taken to avoid copies. When matching superset encodings exist such as UTF8 versus ascii String has fast path accessors to reference the contiguous backing buffers of the String. This can allow for much faster Data creation (locally the benchmarks end up being about a 8-10x improvement on current builds of Foundation. As an added bonus the new method is also about an 8-10x improvement on Linux builds as well so this will be something to consider being ported to swift-corelibs-foundation