### PR TITLE
Stop swallowing test interruption exceptions thrown during XCTAssert evaluation

### DIFF
--- a/stdlib/public/SDK/XCTest/XCTestCaseAdditions.mm
+++ b/stdlib/public/SDK/XCTest/XCTestCaseAdditions.mm
@@ -143,6 +143,7 @@ NSDictionary<NSString *, NSString *> *_XCTRunThrowableBlockBridge(void (^block)(
     @try {
         block();
     }
+    @catch (_XCTestCaseInterruptionException *interruption) { [interruption raise]; }
     @catch (NSException *exception) {
         result = @{
                    @"type": @"objc",


### PR DESCRIPTION
<!-- What's in this pull request? -->
Rethrow any test interruption exceptions that get caught, mirroring the behavior of the Objective-C XCTAssert macros.

<rdar://problem/33255447>