### PR TITLE
Upgrade some deprecation warnings from Swift 3 to errors in Swift 4.

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1314,12 +1314,18 @@ ERROR(attr_noescape_conflicts_escaping_autoclosure,none,
 ERROR(attr_noescape_implied_by_autoclosure,none,
       "@noescape is implied by @autoclosure and should not be "
       "redundantly specified", ())
-WARNING(attr_autoclosure_escaping_deprecated,none,
+WARNING(swift3_attr_autoclosure_escaping_deprecated,none,
         "@autoclosure(escaping) is deprecated; use @autoclosure @escaping instead",
         ())
-WARNING(attr_noescape_deprecated,none,
+ERROR(attr_autoclosure_escaping_deprecated,none,
+      "@autoclosure(escaping) has been removed; use @autoclosure @escaping instead",
+      ())
+WARNING(swift3_attr_noescape_deprecated,none,
         "@noescape is the default and is deprecated",
         ())
+ERROR(attr_noescape_deprecated,none,
+      "@noescape is the default and has been removed",
+      ())
 
 // convention
 ERROR(convention_attribute_expected_lparen,none,

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -851,8 +851,10 @@ ERROR(parameter_curry_syntax_removed,none,
 ERROR(initializer_as_typed_pattern,none,
       "unexpected initializer in pattern; did you mean to use '='?", ())
 
-WARNING(unlabeled_parameter_following_variadic_parameter,none,
+WARNING(swift3_unlabeled_parameter_following_variadic_parameter,none,
         "a parameter following a variadic parameter requires a label", ())
+ERROR(unlabeled_parameter_following_variadic_parameter,none,
+      "a parameter following a variadic parameter requires a label", ())
 
 //------------------------------------------------------------------------------
 // Statement parsing diagnostics

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -413,11 +413,16 @@ ERROR(expected_operator_name_after_operator,PointsToFirstBadToken,
 ERROR(identifier_when_expecting_operator,PointsToFirstBadToken,
       "%0 is considered to be an identifier, not an operator", (Identifier))
 
-WARNING(deprecated_operator_body,PointsToFirstBadToken,
+WARNING(swift3_deprecated_operator_body,PointsToFirstBadToken,
         "operator should no longer be declared with body", ())
-WARNING(deprecated_operator_body_use_group,PointsToFirstBadToken,
+ERROR(deprecated_operator_body,PointsToFirstBadToken,
+      "operator should no longer be declared with body", ())
+WARNING(swift3_deprecated_operator_body_use_group,PointsToFirstBadToken,
         "operator should no longer be declared with body; "
         "use a precedence group instead", ())
+ERROR(deprecated_operator_body_use_group,PointsToFirstBadToken,
+      "operator should no longer be declared with body; "
+      "use a precedence group instead", ())
 ERROR(operator_decl_no_fixity,none,
       "operator must be declared as 'prefix', 'postfix', or 'infix'", ())
 

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -739,12 +739,18 @@ ERROR(expected_rangle_protocol,PointsToFirstBadToken,
 ERROR(disallowed_protocol_composition,PointsToFirstBadToken,
       "protocol-constrained type is neither allowed nor needed here", ())
 
-WARNING(deprecated_protocol_composition,none,
+WARNING(swift3_deprecated_protocol_composition,none,
         "'protocol<...>' composition syntax is deprecated; join the protocols using '&'", ())
-WARNING(deprecated_protocol_composition_single,none,
+ERROR(deprecated_protocol_composition,none,
+      "'protocol<...>' composition syntax has been removed; join the protocols using '&'", ())
+WARNING(swift3_deprecated_protocol_composition_single,none,
         "'protocol<...>' composition syntax is deprecated and not needed here", ())
-WARNING(deprecated_any_composition,none,
+ERROR(deprecated_protocol_composition_single,none,
+        "'protocol<...>' composition syntax has been removed and is not needed here", ())
+WARNING(swift3_deprecated_any_composition,none,
         "'protocol<>' syntax is deprecated; use 'Any' instead", ())
+ERROR(deprecated_any_composition,none,
+      "'protocol<>' syntax has been removed; use 'Any' instead", ())
 
 // SIL box Types
 ERROR(sil_box_expected_var_or_let,none,

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -320,9 +320,12 @@ ERROR(static_func_decl_global_scope,none,
       (StaticSpellingKind))
 ERROR(func_decl_expected_arrow,none,
       "expected '->' after function parameter tuple", ())
-WARNING(operator_static_in_protocol,none,
+WARNING(swift3_operator_static_in_protocol,none,
         "operator '%0' declared in protocol must be 'static'",
         (StringRef))
+ERROR(operator_static_in_protocol,none,
+      "operator '%0' declared in protocol must be 'static'",
+      (StringRef))
 
 // Enum
 ERROR(expected_lbrace_enum,PointsToFirstBadToken,

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1647,7 +1647,9 @@ bool Parser::parseTypeAttribute(TypeAttributes &Attributes, bool justChecking) {
       if (Attributes.has(TAK_noescape)) {
         diagnose(Loc, diag::attr_noescape_conflicts_escaping_autoclosure);
       } else {
-        diagnose(Loc, diag::attr_autoclosure_escaping_deprecated)
+        diagnose(Loc, Context.isSwiftVersion3()
+                          ? diag::swift3_attr_autoclosure_escaping_deprecated
+                          : diag::attr_autoclosure_escaping_deprecated)
             .fixItReplace(autoclosureEscapingParenRange, " @escaping ");
       }
       Attributes.setAttr(TAK_escaping, Loc);
@@ -1669,8 +1671,10 @@ bool Parser::parseTypeAttribute(TypeAttributes &Attributes, bool justChecking) {
     }
 
     // @noescape is deprecated and no longer used
-    diagnose(Loc, diag::attr_noescape_deprecated)
-      .fixItRemove({Attributes.AtLoc,Loc});
+    diagnose(Loc, Context.isSwiftVersion3()
+                      ? diag::swift3_attr_noescape_deprecated
+                      : diag::attr_noescape_deprecated)
+        .fixItRemove({Attributes.AtLoc, Loc});
 
     break;
   case TAK_escaping:

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4719,11 +4719,15 @@ Parser::parseDeclFunc(SourceLoc StaticLoc, StaticSpellingKind StaticSpelling,
     // Within a protocol, recover from a missing 'static'.
     if (Flags & PD_InProtocol) {
       switch (StaticSpelling) {
-      case StaticSpellingKind::None:
-        diagnose(NameLoc, diag::operator_static_in_protocol, SimpleName.str())
-          .fixItInsert(FuncLoc, "static ");
+      case StaticSpellingKind::None: {
+        auto Message = Context.isSwiftVersion3()
+                           ? diag::swift3_operator_static_in_protocol
+                           : diag::operator_static_in_protocol;
+        diagnose(NameLoc, Message, SimpleName.str())
+            .fixItInsert(FuncLoc, "static ");
         StaticSpelling = StaticSpellingKind::KeywordStatic;
         break;
+      }
 
       case StaticSpellingKind::KeywordStatic:
         // Okay, this is correct.

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -5847,9 +5847,15 @@ Parser::parseDeclOperatorImpl(SourceLoc OperatorLoc, Identifier Name,
   SourceLoc lBraceLoc;
   if (consumeIf(tok::l_brace, lBraceLoc)) {
     if (isInfix && !Tok.is(tok::r_brace)) {
-      diagnose(lBraceLoc, diag::deprecated_operator_body_use_group);
+      auto message = Context.isSwiftVersion3()
+                         ? diag::swift3_deprecated_operator_body_use_group
+                         : diag::deprecated_operator_body_use_group;
+      diagnose(lBraceLoc, message);
     } else {
-      auto Diag = diagnose(lBraceLoc, diag::deprecated_operator_body);
+      auto message = Context.isSwiftVersion3()
+                         ? diag::swift3_deprecated_operator_body
+                         : diag::deprecated_operator_body;
+      auto Diag = diagnose(lBraceLoc, message);
       if (Tok.is(tok::r_brace)) {
         SourceLoc lastGoodLoc = precedenceGroupNameLoc;
         if (lastGoodLoc.isInvalid())

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -439,8 +439,11 @@ mapParsedParameters(Parser &parser,
     // Warn when an unlabeled parameter follows a variadic parameter
     if (ellipsisLoc.isValid() && elements.back()->isVariadic() &&
         param.FirstName.empty()) {
-      parser.diagnose(param.FirstNameLoc,
-                      diag::unlabeled_parameter_following_variadic_parameter);
+      auto message =
+          parser.Context.isSwiftVersion3()
+              ? diag::swift3_unlabeled_parameter_following_variadic_parameter
+              : diag::unlabeled_parameter_following_variadic_parameter;
+      parser.diagnose(param.FirstNameLoc, message);
     }
     
     // If this parameter had an ellipsis, check whether it's the last parameter.

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -753,13 +753,16 @@ ParserResult<TypeRepr> Parser::parseOldStyleProtocolComposition() {
       replacement += TrailingContent;
     }
 
+    auto isThree = Context.isSwiftVersion3();
+#define THREEIFY(MESSAGE) (isThree ? diag::swift3_##MESSAGE : diag::MESSAGE)
     // Replace 'protocol<T1, T2>' with 'T1 & T2'
     diagnose(ProtocolLoc,
-      IsEmpty              ? diag::deprecated_any_composition :
-      Protocols.size() > 1 ? diag::deprecated_protocol_composition :
-                             diag::deprecated_protocol_composition_single)
+      IsEmpty              ? THREEIFY(deprecated_any_composition) :
+      Protocols.size() > 1 ? THREEIFY(deprecated_protocol_composition) :
+                             THREEIFY(deprecated_protocol_composition_single))
       .highlight(composition->getSourceRange())
       .fixItReplace(composition->getSourceRange(), replacement);
+#undef THREEIFY
   }
 
   return makeParserResult(Status, composition);

--- a/test/Parse/deprecated_where.swift
+++ b/test/Parse/deprecated_where.swift
@@ -76,7 +76,7 @@ func testCombinedConstraints<T: ProtoA & ProtoB where T: ProtoC>(x: T) {} // exp
 func testCombinedConstraints<T: ProtoA & ProtoB where T: ProtoC>(x: T) where T: ProtoD {} // expected-error {{'where' clause next to generic parameters is obsolete}} {{48-64=}} {{72-77=where T: ProtoC,}}
 
 func testCombinedConstraintsOld<T: protocol<ProtoA, ProtoB> where T: ProtoC>(x: T) {} // expected-error {{'where' clause next to generic parameters is obsolete}} {{60-76=}} {{83-83= where T: ProtoC}}
-// expected-warning@-1 {{'protocol<...>' composition syntax is deprecated}}
+// expected-error@-1 {{'protocol<...>' composition syntax has been removed}}
 func testCombinedConstraintsOld<T: protocol<ProtoA, ProtoB> where T: ProtoC>(x: T) where T: ProtoD {} // expected-error {{'where' clause next to generic parameters is obsolete}} {{60-76=}} {{84-89=where T: ProtoC,}}
-// expected-warning@-1 {{'protocol<...>' composition syntax is deprecated}}
+// expected-error@-1 {{'protocol<...>' composition syntax has been removed}}
 

--- a/test/Parse/swift3_warnings_swift4_errors_version_3.swift
+++ b/test/Parse/swift3_warnings_swift4_errors_version_3.swift
@@ -1,0 +1,26 @@
+// RUN: %target-swift-frontend -typecheck -verify -swift-version 3 %s
+
+protocol Operator {
+  func +(lhs: Self, rhs: Self) -> Self // expected-warning {{operator '+' declared in protocol must be 'static'}}
+}
+
+func foo(x: Int..., _: String) {} // expected-warning {{a parameter following a variadic parameter requires a label}}
+
+protocol P1 {}
+protocol P2 {}
+
+let x: protocol<> // expected-warning {{'protocol<>' syntax is deprecated; use 'Any' instead}}
+let y: protocol<P1> // expected-warning {{'protocol<...>' composition syntax is deprecated and not needed here}}}
+let z: protocol<P1, P2> // expected-warning {{'protocol<...>' composition syntax is deprecated; join the protocols using '&'}}
+
+func bar(f: @noescape () -> ()) {} // expected-warning {{@noescape is the default and is deprecated}}
+
+func baz(f: @autoclosure(escaping) () -> ()) {} // expected-warning {{@autoclosure(escaping) is deprecated; use @autoclosure @escaping instead}}
+
+prefix operator +++ {} // expected-warning {{operator should no longer be declared with body}}
+postfix operator +++ {} // expected-warning {{operator should no longer be declared with body}}
+infix operator +++ {} // expected-warning {{operator should no longer be declared with body}}
+infix operator +++* { // expected-warning {{operator should no longer be declared with body; use a precedence group instead}}
+  associativity right
+}
+

--- a/test/Parse/swift3_warnings_swift4_errors_version_4.swift
+++ b/test/Parse/swift3_warnings_swift4_errors_version_4.swift
@@ -1,0 +1,25 @@
+// RUN: %target-swift-frontend -typecheck -verify -swift-version 4 %s
+
+protocol Operator {
+  func +(lhs: Self, rhs: Self) -> Self // expected-error {{operator '+' declared in protocol must be 'static'}}
+}
+
+func foo(x: Int..., _: String) {} // expected-error {{a parameter following a variadic parameter requires a label}}
+
+protocol P1 {}
+protocol P2 {}
+
+let x: protocol<> // expected-error {{'protocol<>' syntax has been removed; use 'Any' instead}}
+let y: protocol<P1> // expected-error {{'protocol<...>' composition syntax has been removed and is not needed here}}}
+let z: protocol<P1, P2> // expected-error {{'protocol<...>' composition syntax has been removed; join the protocols using '&'}}
+
+func bar(f: @noescape () -> ()) {} // expected-error {{@noescape is the default and has been removed}}
+
+func baz(f: @autoclosure(escaping) () -> ()) {} // expected-error {{@autoclosure(escaping) has been removed; use @autoclosure @escaping instead}}
+
+prefix operator +++ {} // expected-error {{operator should no longer be declared with body}}
+postfix operator +++ {} // expected-error {{operator should no longer be declared with body}}
+infix operator +++ {} // expected-error {{operator should no longer be declared with body}}
+infix operator +++* { // expected-error {{operator should no longer be declared with body; use a precedence group instead}}
+  associativity right
+}

--- a/test/SILOptimizer/devirt_static_witness_method.sil
+++ b/test/SILOptimizer/devirt_static_witness_method.sil
@@ -6,7 +6,7 @@ import Swift
 import SwiftShims
 
 protocol CanAdd {
-  func +(lhs: Self, rhs: Self) -> Self
+  static func +(lhs: Self, rhs: Self) -> Self
 }
 
 extension Int64 : CanAdd {

--- a/test/Serialization/Inputs/has_xref.swift
+++ b/test/Serialization/Inputs/has_xref.swift
@@ -10,7 +10,7 @@ public func numericArray(_ x: IntSlice) {}
 
 
 public protocol ExtraIncrementable {
-  prefix func +++(base: inout Self)
+  static prefix func +++(base: inout Self)
 }
 
 extension SpecialInt : ExtraIncrementable {}

--- a/test/attr/attr_escaping.swift
+++ b/test/attr/attr_escaping.swift
@@ -6,7 +6,7 @@ func paramDeclEscaping(@escaping fn: (Int) -> Void) {} // expected-error {{attri
 func wrongParamType(a: @escaping Int) {} // expected-error {{@escaping attribute only applies to function types}}
 
 func conflictingAttrs(_ fn: @noescape @escaping () -> Int) {} // expected-error {{@escaping conflicts with @noescape}}
- // expected-warning@-1{{@noescape is the default and is deprecated}} {{29-39=}}
+ // expected-error@-1{{@noescape is the default and has been removed}} {{29-39=}}
 
 func takesEscaping(_ fn: @escaping () -> Int) {} // ok
 

--- a/test/type/protocol_composition.swift
+++ b/test/type/protocol_composition.swift
@@ -22,12 +22,12 @@ protocol P4 : P3 {
   func f(_: Double) -> Double
 }
 
-typealias Any1 = protocol<> // expected-warning {{'protocol<>' syntax is deprecated; use 'Any' instead}}
-typealias Any2 = protocol< > // expected-warning {{'protocol<>' syntax is deprecated; use 'Any' instead}}
+typealias Any1 = protocol<> // expected-error {{'protocol<>' syntax has been removed; use 'Any' instead}}
+typealias Any2 = protocol< > // expected-error {{'protocol<>' syntax has been removed; use 'Any' instead}}
 
 // Okay to inherit a typealias for Any type.
 protocol P5 : Any { }
-protocol P6 : protocol<> { } // expected-warning {{'protocol<>' syntax is deprecated; use 'Any' instead}}
+protocol P6 : protocol<> { } // expected-error {{'protocol<>' syntax has been removed; use 'Any' instead}}
                              // expected-error@-1 {{protocol-constrained type is neither allowed nor needed here}}
 typealias P7 = Any & Any1
 
@@ -111,7 +111,7 @@ func testConversion() {
   accept_manyPrintable(sp)
 
   // Conversions among existential types.
-  var x2 : protocol<SuperREPLPrintable, FooProtocol> // expected-warning {{'protocol<...>' composition syntax is deprecated; join the protocols using '&'}} {{12-53=SuperREPLPrintable & FooProtocol}}
+  var x2 : protocol<SuperREPLPrintable, FooProtocol> // expected-error {{'protocol<...>' composition syntax has been removed; join the protocols using '&'}} {{12-53=SuperREPLPrintable & FooProtocol}}
   x2 = x // expected-error{{value of type 'FooProtocol & REPLPrintable' does not conform to 'FooProtocol & SuperREPLPrintable' in assignment}}
   x = x2
 
@@ -119,29 +119,29 @@ func testConversion() {
   var _ : () -> FooProtocol & SuperREPLPrintable = return_superPrintable
 
   // FIXME: closures make ABI conversions explicit. rdar://problem/19517003
-  var _ : () -> protocol<FooProtocol, REPLPrintable> = { return_superPrintable() } // expected-warning {{'protocol<...>' composition syntax is deprecated; join the protocols using '&'}} {{17-53=FooProtocol & REPLPrintable}}
+  var _ : () -> protocol<FooProtocol, REPLPrintable> = { return_superPrintable() } // expected-error {{'protocol<...>' composition syntax has been removed; join the protocols using '&'}} {{17-53=FooProtocol & REPLPrintable}}
 }
 
 // Test the parser's splitting of >= into > and =.
-var x : protocol<P5>= 17 // expected-warning {{'protocol<...>' composition syntax is deprecated and not needed here}} {{9-22=P5=}} expected-error {{'=' must have consistent whitespace on both sides}}
-var y : protocol<P5, P7>= 17 // expected-warning {{'protocol<...>' composition syntax is deprecated; join the protocols using '&'}} {{9-26=P5 & P7=}} expected-error {{'=' must have consistent whitespace on both sides}}
-var z : protocol<P5, P7>?=17 // expected-warning {{'protocol<...>' composition syntax is deprecated; join the protocols using '&'}} {{9-27=(P5 & P7)?=}}
+var x : protocol<P5>= 17 // expected-error {{'protocol<...>' composition syntax has been removed and is not needed here}} {{9-22=P5=}} expected-error {{'=' must have consistent whitespace on both sides}}
+var y : protocol<P5, P7>= 17 // expected-error {{'protocol<...>' composition syntax has been removed; join the protocols using '&'}} {{9-26=P5 & P7=}} expected-error {{'=' must have consistent whitespace on both sides}}
+var z : protocol<P5, P7>?=17 // expected-error {{'protocol<...>' composition syntax has been removed; join the protocols using '&'}} {{9-27=(P5 & P7)?=}}
 
-typealias A1 = protocol<> // expected-warning {{'protocol<>' syntax is deprecated; use 'Any' instead}} {{16-26=Any}}
-typealias A2 = protocol<>? // expected-warning {{'protocol<>' syntax is deprecated; use 'Any' instead}} {{16-27=Any?}}
-typealias B1 = protocol<P1,P2> // expected-warning {{'protocol<...>' composition syntax is deprecated; join the protocols using '&'}} {{16-31=P1 & P2}}
-typealias B2 = protocol<P1, P2> // expected-warning {{'protocol<...>' composition syntax is deprecated; join the protocols using '&'}} {{16-32=P1 & P2}}
-typealias B3 = protocol<P1 ,P2> // expected-warning {{'protocol<...>' composition syntax is deprecated; join the protocols using '&'}} {{16-32=P1 & P2}}
-typealias B4 = protocol<P1 , P2> // expected-warning {{'protocol<...>' composition syntax is deprecated; join the protocols using '&'}} {{16-33=P1 & P2}}
-typealias C1 = protocol<Any, P1> // expected-warning {{'protocol<...>' composition syntax is deprecated and not needed here}} {{16-33=P1}}
-typealias C2 = protocol<P1, Any> // expected-warning {{'protocol<...>' composition syntax is deprecated and not needed here}} {{16-33=P1}}
-typealias D = protocol<P1> // expected-warning {{'protocol<...>' composition syntax is deprecated and not needed here}} {{15-27=P1}}
-typealias E = protocol<Any> // expected-warning {{'protocol<...>' composition syntax is deprecated and not needed here}} {{15-28=Any}}
-typealias F = protocol<Any, Any> // expected-warning {{'protocol<...>' composition syntax is deprecated and not needed here}} {{15-33=Any}}
-typealias G = protocol<P1>.Type // expected-warning {{'protocol<...>' composition syntax is deprecated and not needed here}} {{15-27=P1}}
-typealias H = protocol<P1>! // expected-warning {{'protocol<...>' composition syntax is deprecated and not needed here}} {{15-28=P1!}}
-typealias J = protocol<P1, P2>.Protocol // expected-warning {{'protocol<...>' composition syntax is deprecated; join the protocols using '&'}} {{15-31=(P1 & P2)}}
-typealias K = protocol<P1, P2>? // expected-warning {{'protocol<...>' composition syntax is deprecated; join the protocols using '&'}} {{15-32=(P1 & P2)?}}
+typealias A1 = protocol<> // expected-error {{'protocol<>' syntax has been removed; use 'Any' instead}} {{16-26=Any}}
+typealias A2 = protocol<>? // expected-error {{'protocol<>' syntax has been removed; use 'Any' instead}} {{16-27=Any?}}
+typealias B1 = protocol<P1,P2> // expected-error {{'protocol<...>' composition syntax has been removed; join the protocols using '&'}} {{16-31=P1 & P2}}
+typealias B2 = protocol<P1, P2> // expected-error {{'protocol<...>' composition syntax has been removed; join the protocols using '&'}} {{16-32=P1 & P2}}
+typealias B3 = protocol<P1 ,P2> // expected-error {{'protocol<...>' composition syntax has been removed; join the protocols using '&'}} {{16-32=P1 & P2}}
+typealias B4 = protocol<P1 , P2> // expected-error {{'protocol<...>' composition syntax has been removed; join the protocols using '&'}} {{16-33=P1 & P2}}
+typealias C1 = protocol<Any, P1> // expected-error {{'protocol<...>' composition syntax has been removed and is not needed here}} {{16-33=P1}}
+typealias C2 = protocol<P1, Any> // expected-error {{'protocol<...>' composition syntax has been removed and is not needed here}} {{16-33=P1}}
+typealias D = protocol<P1> // expected-error {{'protocol<...>' composition syntax has been removed and is not needed here}} {{15-27=P1}}
+typealias E = protocol<Any> // expected-error {{'protocol<...>' composition syntax has been removed and is not needed here}} {{15-28=Any}}
+typealias F = protocol<Any, Any> // expected-error {{'protocol<...>' composition syntax has been removed and is not needed here}} {{15-33=Any}}
+typealias G = protocol<P1>.Type // expected-error {{'protocol<...>' composition syntax has been removed and is not needed here}} {{15-27=P1}}
+typealias H = protocol<P1>! // expected-error {{'protocol<...>' composition syntax has been removed and is not needed here}} {{15-28=P1!}}
+typealias J = protocol<P1, P2>.Protocol // expected-error {{'protocol<...>' composition syntax has been removed; join the protocols using '&'}} {{15-31=(P1 & P2)}}
+typealias K = protocol<P1, P2>? // expected-error {{'protocol<...>' composition syntax has been removed; join the protocols using '&'}} {{15-32=(P1 & P2)?}}
 
 typealias T01 = P1.Protocol & P2 // expected-error {{non-protocol, non-class type 'P1.Protocol' cannot be used within a protocol-constrained type}}
 typealias T02 = P1.Type & P2 // expected-error {{non-protocol, non-class type 'P1.Type' cannot be used within a protocol-constrained type}}
@@ -149,7 +149,7 @@ typealias T03 = P1? & P2 // expected-error {{non-protocol, non-class type 'P1?' 
 typealias T04 = P1 & P2! // expected-error {{non-protocol, non-class type 'P2!' cannot be used within a protocol-constrained type}} expected-error {{implicitly unwrapped optionals}} {{24-25=?}}
 typealias T05 = P1 & P2 -> P3 // expected-error {{single argument function types require parentheses}} {{17-17=(}} {{24-24=)}}
 typealias T06 = P1 -> P2 & P3 // expected-error {{single argument function types require parentheses}} {{17-17=(}} {{19-19=)}}
-typealias T07 = P1 & protocol<P2, P3> // expected-warning {{protocol<...>' composition syntax is deprecated; join the protocols using '&'}} {{22-38=P2 & P3}}
+typealias T07 = P1 & protocol<P2, P3> // expected-error {{protocol<...>' composition syntax has been removed; join the protocols using '&'}} {{22-38=P2 & P3}}
 func fT07(x: T07) -> P1 & P2 & P3 { return x } // OK, 'P1 & protocol<P2, P3>' is parsed as 'P1 & P2 & P3'.
 let _: P1 & P2 & P3 -> P1 & P2 & P3 = fT07 // expected-error {{single argument function types require parentheses}} {{8-8=(}} {{20-20=)}}
 
@@ -160,9 +160,9 @@ struct S04<T : P5 & (P6)> {} // expected-error {{inheritance from non-named type
 struct S05<T> where T : P5? & P6 {} // expected-error {{inheritance from non-named type 'P5?'}}
 
 // SR-3124 - Protocol Composition Often Migrated Incorrectly
-struct S3124<T: protocol<P1, P3>> {} // expected-warning {{'protocol<...>' composition syntax is deprecated; join the protocols using '&'}} {{17-34=P1 & P3>}}
-func f3124_1<U where U: protocol<P1, P3>>(x: U)  {} // expected-warning {{'protocol<...>' composition syntax is deprecated; join the protocols using '&'}} {{25-42=P1 & P3>}} // expected-error {{'where' clause}}
-func f3124_2<U : protocol<P1>>(x: U)  {} // expected-warning {{'protocol<...>' composition syntax is deprecated and not needed here}} {{18-31=P1>}}
+struct S3124<T: protocol<P1, P3>> {} // expected-error {{'protocol<...>' composition syntax has been removed; join the protocols using '&'}} {{17-34=P1 & P3>}}
+func f3124_1<U where U: protocol<P1, P3>>(x: U)  {} // expected-error {{'protocol<...>' composition syntax has been removed; join the protocols using '&'}} {{25-42=P1 & P3>}} // expected-error {{'where' clause}}
+func f3124_2<U : protocol<P1>>(x: U)  {} // expected-error {{'protocol<...>' composition syntax has been removed and is not needed here}} {{18-31=P1>}}
 
 // Make sure we correctly form compositions in expression context
 func takesP1AndP2(_: [AnyObject & P1 & P2]) {}


### PR DESCRIPTION
Fixes rdar://problem/28961650 .

Individual commits for relatively easy reverting, if necessary.