### PR TITLE
[4.0] [QoI] Don't try to lookup members on incorrect type during Objective-C KeyPath validation

### DIFF
--- a/lib/Sema/TypeCheckExprObjC.cpp
+++ b/lib/Sema/TypeCheckExprObjC.cpp
@@ -166,6 +166,8 @@ Optional<Type> TypeChecker::checkObjCKeyPathExpr(DeclContext *dc,
       return lookupUnqualified(dc, componentName, componentNameLoc);
 
     assert(currentType && "Non-beginning state must have a type");
+    if (!currentType->mayHaveMembers())
+      return LookupResult();
 
     // Determine the type in which the lookup should occur. If we have
     // a bridged value type, this will be the Objective-C class to

--- a/validation-test/compiler_crashers_2_fixed/0113-rdar33044867.swift
+++ b/validation-test/compiler_crashers_2_fixed/0113-rdar33044867.swift
@@ -1,0 +1,15 @@
+// RUN: not %target-swift-frontend %s -typecheck
+
+public class A {
+  var property: UndeclaredType
+  var keyPath: Any {
+    return #keyPath(property.foo)
+  }
+}
+
+public class B {
+  var property: UndeclaredType
+  var keyPath: Any {
+    return [#keyPath(property.foo)]
+  }
+}


### PR DESCRIPTION
* Description: While trying to validate Objective-C keypath components
don't assume that type of the component is always correct, check
before trying to see if it's bridged type or has members.

* Scope of the issue: Fixes crasher related to the member lookup on the invalid type while
trying to validate Objective-C KeyPath components before type-checking.

* Risk: Low.

* Tested: Swift CI.

* Reviewed by: Doug Gregor.

* Resolves: rdar://problem/33044867
(cherry picked from commit 481401f6c3c754c5e88b496b2353f2488fb4b584)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
