### PR TITLE
SE-0157: Add a frontend flag `-enable-recursive-constraints`.

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -206,6 +206,9 @@ namespace swift {
     /// Should we use \c ASTScope-based resolution for unqualified name lookup?
     bool EnableASTScopeLookup = false;
 
+    /// Enable SE-0157: Recursive Protocol Constraints.
+    bool EnableRecursiveConstraints = false;
+
     /// Whether to use the import as member inference system
     ///
     /// When importing a global, try to infer whether we can import it as a

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -109,6 +109,9 @@ def disable_target_os_checking :
 def enable_astscope_lookup : Flag<["-"], "enable-astscope-lookup">,
   HelpText<"Enable ASTScope-based unqualified name lookup">;
 
+def enable_recursive_constraints : Flag<["-"], "enable-recursive-constraints">,
+  HelpText<"Enable SE-0157: Recursive Protocol Constraints">;
+
 def print_clang_stats : Flag<["-"], "print-clang-stats">,
   HelpText<"Print Clang importer statistics">;
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1007,6 +1007,8 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   }
   
   Opts.EnableASTScopeLookup |= Args.hasArg(OPT_enable_astscope_lookup);
+  Opts.EnableRecursiveConstraints |=
+    Args.hasArg(OPT_enable_recursive_constraints);
   Opts.DebugConstraintSolver |= Args.hasArg(OPT_debug_constraints);
   Opts.EnableConstraintPropagation |= Args.hasArg(OPT_propagate_constraints);
   Opts.IterativeTypeChecker |= Args.hasArg(OPT_iterative_type_checker);

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -99,6 +99,9 @@ Optional<Type> ConstraintSystem::checkTypeOfBinding(TypeVariableType *typeVar,
     return None;
   }
 
+  // Don't bind to a dependent member type.
+  if (type->is<DependentMemberType>()) return None;
+
   // Okay, allow the binding (with the simplified type).
   return type;
 }

--- a/test/decl/protocol/recursive_requirement_ok.swift
+++ b/test/decl/protocol/recursive_requirement_ok.swift
@@ -1,0 +1,13 @@
+// RUN: %target-typecheck-verify-swift -enable-recursive-constraints
+
+protocol P {
+  associatedtype Assoc : P
+
+  var assoc: Assoc { get }
+}
+
+func testP<T: P>(_ t: T) {
+  testP(t.assoc)
+  testP(t.assoc.assoc)
+  testP(t.assoc.assoc.assoc) // FIXME: expected-error{{argument type 'T.Assoc.Assoc.Assoc' does not conform to expected type 'P'}}
+}


### PR DESCRIPTION
Introduce `-enable-recursive-constraints` to disable the error about
direct recursion within a protocol definition. The implementation of
recursive protocol constraints is incomplete, but might be useful for
experimentation.