### PR TITLE
[swift-4.0-branch][overlay] Add INRideOption

### DIFF
--- a/stdlib/public/SDK/Intents/CMakeLists.txt
+++ b/stdlib/public/SDK/Intents/CMakeLists.txt
@@ -10,6 +10,7 @@ add_swift_library(swiftIntents ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_O
   INIntegerResolutionResult.swift
   INParameter.swift
   INRequestRideIntent.swift
+  INRideOption.swift
   INSaveProfileInCarIntent.swift
   INSearchCallHistoryIntent.swift
   INSearchForPhotosIntentResponse.swift

--- a/stdlib/public/SDK/Intents/INRideOption.swift
+++ b/stdlib/public/SDK/Intents/INRideOption.swift
@@ -1,0 +1,54 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_exported import Intents
+import Foundation
+
+#if os(iOS) || os(watchOS)
+
+// Simply extending the INRideOption type doesn't work due to:
+// <rdar://problem/29447066>
+// Compiler incorrectly handles combinations of availability declarations on
+// independent axes.
+internal protocol _INRideOptionMeteredFare {
+  var __usesMeteredFare: NSNumber? { get set }
+}
+
+extension _INRideOptionMeteredFare {
+  @available(swift, obsoleted: 4)
+  @nonobjc
+  public final var usesMeteredFare: NSNumber? {
+    get {
+      return __usesMeteredFare
+    }
+    set(newUsesMeteredFare) {
+      __usesMeteredFare = newUsesMeteredFare
+    }
+  }
+
+  @available(swift, introduced: 4.0)
+  @nonobjc
+  public var usesMeteredFare: Bool? {
+    get {
+      return __usesMeteredFare?.boolValue
+    }
+    set(newUsesMeteredFare) {
+      __usesMeteredFare = newUsesMeteredFare.map { NSNumber(value: $0) }
+    }
+  }
+}
+
+@available(iOS 10.0, watchOS 3.2, *)
+extension INRideOption : _INRideOptionMeteredFare {
+}
+
+#endif

--- a/test/stdlib/Intents.swift
+++ b/test/stdlib/Intents.swift
@@ -1,8 +1,9 @@
 // RUN: %target-run-simple-swift
+// RUN: %target-build-swift %s -o %t/a.out3 -swift-version 3 && %target-run %t/a.out3
+// RUN: %target-build-swift %s -o %t/a.out4 -swift-version 4 && %target-run %t/a.out4
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
 
-// UNSUPPORTED: OS=watchos
 // UNSUPPORTED: OS=tvos
 
 import Intents
@@ -10,13 +11,19 @@ import StdlibUnittest
 
 let IntentsTestSuite = TestSuite("Intents")
 
-if #available(OSX 10.12, iOS 10.0, *) {
+#if swift(>=4)
+let swiftVersion = "4"
+#else
+let swiftVersion = "3"
+#endif
 
-  IntentsTestSuite.test("ErrorDomain") {
+if #available(OSX 10.12, iOS 10.0, watchOS 3.2, *) {
+
+  IntentsTestSuite.test("ErrorDomain/\(swiftVersion)") {
     expectEqual("IntentsErrorDomain", INIntentErrorDomain)
   }
 
-  IntentsTestSuite.test("extension") {
+  IntentsTestSuite.test("extension/\(swiftVersion)") {
     expectEqual("IntentsErrorDomain", INIntentError._nsErrorDomain)
   }
 }
@@ -24,7 +31,7 @@ if #available(OSX 10.12, iOS 10.0, *) {
 #if os(iOS)
 if #available(iOS 11.0, *) {
 
-  IntentsTestSuite.test("INParameter KeyPath") {
+  IntentsTestSuite.test("INParameter KeyPath/\(swiftVersion)") {
     let param = INParameter(keyPath: \INRequestRideIntent.pickupLocation)
     expectEqual("pickupLocation", param?.parameterKeyPath)
     if let typ = param?.parameterClass {
@@ -35,7 +42,26 @@ if #available(iOS 11.0, *) {
     }
   }
 }
+#endif
 
+#if os(iOS) || os(watchOS)
+if #available(iOS 10.0, watchOS 3.2, *) {
+
+  IntentsTestSuite.test("INRideOption usesMeteredFare/\(swiftVersion)") {
+    func f(rideOption: inout INRideOption) {
+#if swift(>=4)
+      rideOption.usesMeteredFare = true
+      expectType(Bool?.self, &rideOption.usesMeteredFare)
+      expectTrue(rideOption.usesMeteredFare ?? false)
+#else
+      rideOption.usesMeteredFare = NSNumber(value: true)
+      expectType(NSNumber?.self, &rideOption.usesMeteredFare)
+      expectTrue(rideOption.usesMeteredFare?.boolValue ?? false)
+#endif
+    }
+  }
+
+}
 #endif
 
 runAllTests()


### PR DESCRIPTION
* Explanation: Fixes backward compatibility for the code using INRideOption.usesMeteredFare
* Scope of Issue: A property has different types in Swift 3 and Swift 4.
* Risk: Minimal
* Reviewed By: Willem Mattelaer
* Testing: Automated test suite + a new test case
* Directions for QA: N/A
* Radar: <rdar://problem/32935297>

(cherry picked from commit 923468be6b294cb4e8b0e718e52b945c4f6a18a2)