### PR TITLE
Never Bind to ErrorType

### DIFF
--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -422,7 +422,8 @@ getSubstitutionMap(TypeSubstitutionFn subs,
     Type currentReplacement = depTy.subst(subs, lookupConformance,
                                           SubstFlags::UseErrorType);
     if (auto paramTy = dyn_cast<GenericTypeParamType>(canTy))
-      subMap.addSubstitution(paramTy, currentReplacement);
+      if (!currentReplacement->hasError())
+        subMap.addSubstitution(paramTy, currentReplacement);
 
     // Collect the conformances.
     for (auto req: reqs) {

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2922,7 +2922,7 @@ static Type getMemberForBaseType(LookupConformanceFn lookupConformances,
   // Error recovery path.
   // FIXME: Generalized existentials will look here.
   if (substBase->isOpenedExistential())
-    return getDependentMemberType(ErrorType::get(substBase));
+    return failed();
 
   // If the parent is an archetype, extract the child archetype with the
   // given name.
@@ -2933,7 +2933,7 @@ static Type getMemberForBaseType(LookupConformanceFn lookupConformances,
     // If looking for an associated type and the archetype is constrained to a
     // class, continue to the default associated type lookup
     if (!assocType || !archetypeParent->getSuperclass())
-      return getDependentMemberType(ErrorType::get(substBase));
+      return failed();
   }
 
   // If the parent is a type variable or a member rooted in a type variable,

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -148,6 +148,7 @@ ConstraintSystem::getPotentialBindings(TypeVariableType *typeVar) {
   // coalescing supertype bounds when we are able to compute the meet.
   auto addPotentialBinding = [&](PotentialBinding binding,
                                  bool allowJoinMeet = true) {
+    assert(!binding.BindingType->is<ErrorType>());
     // If this is a non-defaulted supertype binding, check whether we can
     // combine it with another supertype binding by computing the 'join' of the
     // types.
@@ -374,6 +375,10 @@ ConstraintSystem::getPotentialBindings(TypeVariableType *typeVar) {
         result.InvolvesTypeVariables = true;
       continue;
     }
+    
+    // Do not attempt to bind to ErrorType.
+    if (type->hasError())
+      continue;
 
     // If the type we'd be binding to is a dependent member, don't try to
     // resolve this type variable yet.

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -128,7 +128,9 @@ bool ConstraintSystem::typeVarOccursInType(TypeVariableType *typeVar,
 
 void ConstraintSystem::assignFixedType(TypeVariableType *typeVar, Type type,
                                        bool updateState) {
-  
+  assert(!type->hasError() &&
+         "Should not be assigning a type involving ErrorType!");
+
   typeVar->getImpl().assignFixedType(type, getSavedBindings());
 
   if (!updateState)

--- a/validation-test/compiler_crashers_fixed/28815-formprotocolrelativetype-swift-protocoldecl-swift-genericsignaturebuilder-potent.swift
+++ b/validation-test/compiler_crashers_fixed/28815-formprotocolrelativetype-swift-protocoldecl-swift-genericsignaturebuilder-potent.swift
@@ -5,6 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 extension CountableRange{{}{}protocol P{typealias a:A{}func 丏
 protocol A:CountableRange


### PR DESCRIPTION
#9900 requires some fairly minimal changes to enforce the invariant that we never bind to an `ErrorType`.

- Member base type substitutions respect `SubstFlags::UseErrorType` on all failure paths.
- Substitutions involving ErrorType (as a result of failed substitutions in dependent members) are not added to the substitution map.
- ErrorType-containing potential type variable bindings are now ignored.