### PR TITLE
Small Ownership fixes

### DIFF
--- a/lib/SIL/SILOwnershipVerifier.cpp
+++ b/lib/SIL/SILOwnershipVerifier.cpp
@@ -893,8 +893,10 @@ OwnershipCompatibilityUseChecker::visitStoreUnownedInst(StoreUnownedInst *I) {
 
 OwnershipUseCheckerResult
 OwnershipCompatibilityUseChecker::visitStoreWeakInst(StoreWeakInst *I) {
+  // A store_weak instruction implies that the value to be stored to be live,
+  // but it does not touch the strong reference count of the value.
   if (getValue() == I->getSrc())
-    return {compatibleWithOwnership(ValueOwnershipKind::Owned), true};
+    return {true, false};
   return {compatibleWithOwnership(ValueOwnershipKind::Trivial), false};
 }
 

--- a/lib/SIL/SILOwnershipVerifier.cpp
+++ b/lib/SIL/SILOwnershipVerifier.cpp
@@ -441,7 +441,6 @@ CONSTANT_OWNERSHIP_INST(Guaranteed, false, RefElementAddr)
 CONSTANT_OWNERSHIP_INST(Owned, true, AutoreleaseValue)
 CONSTANT_OWNERSHIP_INST(Owned, true, DeallocBox)
 CONSTANT_OWNERSHIP_INST(Owned, true, DeallocExistentialBox)
-CONSTANT_OWNERSHIP_INST(Owned, true, DeallocPartialRef)
 CONSTANT_OWNERSHIP_INST(Owned, true, DeallocRef)
 CONSTANT_OWNERSHIP_INST(Owned, true, DestroyValue)
 CONSTANT_OWNERSHIP_INST(Owned, true, ReleaseValue)
@@ -687,7 +686,18 @@ FORWARD_CONSTANT_OR_TRIVIAL_OWNERSHIP_INST(Guaranteed, false, StructExtract)
 #undef CONSTANT_OR_TRIVIAL_OWNERSHIP_INST
 
 OwnershipUseCheckerResult
-OwnershipCompatibilityUseChecker::visitEndBorrowArgumentInst(EndBorrowArgumentInst *I) {
+OwnershipCompatibilityUseChecker::visitDeallocPartialRefInst(
+    DeallocPartialRefInst *I) {
+  if (getValue() == I->getInstance()) {
+    return {compatibleWithOwnership(ValueOwnershipKind::Owned), true};
+  }
+
+  return {compatibleWithOwnership(ValueOwnershipKind::Trivial), false};
+}
+
+OwnershipUseCheckerResult
+OwnershipCompatibilityUseChecker::visitEndBorrowArgumentInst(
+    EndBorrowArgumentInst *I) {
   // If we are currently checking an end_borrow_argument as a subobject, then we
   // treat this as just a use.
   if (isCheckingSubObject())

--- a/test/SIL/ownership-verifier/use_verifier.sil
+++ b/test/SIL/ownership-verifier/use_verifier.sil
@@ -379,6 +379,14 @@ bb0(%0 : @owned $Optional<SuperKlass>, %1 : @trivial $*@sil_weak Optional<SuperK
   return %9999 : $()
 }
 
+sil @test_dealloc_partial_ref : $@convention(thin) (@owned SuperKlass) -> () {
+bb0(%0 : @owned $SuperKlass):
+  %1 = metatype $@thick SuperKlass.Type
+  dealloc_partial_ref %0 : $SuperKlass, %1 : $@thick SuperKlass.Type
+  %9999 = tuple()
+  return %9999 : $()
+}
+
 //////////////////////
 // Terminator Tests //
 //////////////////////

--- a/test/SIL/ownership-verifier/use_verifier.sil
+++ b/test/SIL/ownership-verifier/use_verifier.sil
@@ -370,6 +370,15 @@ bb0:
   return %9999 : $()
 }
 
+sil @test_store_weak : $@convention(thin) (@owned Optional<SuperKlass>, @in @sil_weak Optional<SuperKlass>, @guaranteed Optional<SuperKlass>) -> () {
+bb0(%0 : @owned $Optional<SuperKlass>, %1 : @trivial $*@sil_weak Optional<SuperKlass>, %2 : @guaranteed $Optional<SuperKlass>):
+  store_weak %0 to %1 : $*@sil_weak Optional<SuperKlass>
+  store_weak %2 to %1 : $*@sil_weak Optional<SuperKlass>
+  destroy_value %0 : $Optional<SuperKlass>
+  %9999 = tuple()
+  return %9999 : $()
+}
+
 //////////////////////
 // Terminator Tests //
 //////////////////////


### PR DESCRIPTION
This PR contains two small ownership verifier fixes:

1. A store_weak is not a consuming operation of an owned value. Instead it is a use that just requires the value to be stored to be live.
2. dealloc_partial_ref takes in an owned argument and a trivial metatype. Before we were just checking all parameters as being owned arguments.

<rdar://problem/31880847>