### PR TITLE
Small is lowering of value metatype changes

### DIFF
--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -1297,10 +1297,7 @@ public:
   }
 
   ValueMetatypeInst *createValueMetatype(SILLocation Loc, SILType Metatype,
-                                         SILValue Base) {
-    return insert(new (F.getModule()) ValueMetatypeInst(
-        getSILDebugLocation(Loc), Metatype, Base));
-  }
+                                         SILValue Base);
 
   ExistentialMetatypeInst *
   createExistentialMetatype(SILLocation Loc, SILType Metatype, SILValue Base) {

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -496,6 +496,10 @@ public:
   bool hasAbstractionDifference(SILFunctionTypeRepresentation rep,
                                 SILType type2);
 
+  /// Returns true if this SILType could be potentially a lowering of the given
+  /// formal type. Meant for verification purposes/assertions.
+  bool isLoweringOf(SILModule &M, CanType formalType);
+
   /// Returns the hash code for the SILType.
   llvm::hash_code getHashCode() const {
     return llvm::hash_combine(*this);

--- a/lib/SIL/SILBuilder.cpp
+++ b/lib/SIL/SILBuilder.cpp
@@ -427,3 +427,15 @@ void SILBuilder::addOpenedArchetypeOperands(SILInstruction *I) {
     OpenedArchetypes.addOpenedArchetypeOperands(I->getTypeDependentOperands());
   }
 }
+
+ValueMetatypeInst *SILBuilder::createValueMetatype(SILLocation Loc,
+                                                   SILType MetatypeTy,
+                                                   SILValue Base) {
+  assert(
+      Base->getType().isLoweringOf(
+          getModule(), MetatypeTy.castTo<MetatypeType>().getInstanceType()) &&
+      "value_metatype result must be formal metatype of the lowered operand "
+      "type");
+  return insert(new (F.getModule()) ValueMetatypeInst(getSILDebugLocation(Loc),
+                                                      MetatypeTy, Base));
+}

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -1769,60 +1769,8 @@ public:
   }
 
   // Is a SIL type a potential lowering of a formal type?
-  bool isLoweringOf(SILType loweredType,
-                    CanType formalType) {
-    // Optional lowers its contained type. The difference between Optional
-    // and IUO is lowered away.
-    SILType loweredObjectType = loweredType
-        .getAnyOptionalObjectType();
-    CanType formalObjectType = formalType
-        .getAnyOptionalObjectType();
-
-    if (loweredObjectType) {
-      return formalObjectType &&
-             isLoweringOf(loweredObjectType, formalObjectType);
-    }
-
-    // Metatypes preserve their instance type through lowering.
-    if (loweredType.is<MetatypeType>()) {
-      if (auto formalMT = dyn_cast<MetatypeType>(formalType)) {
-        return isLoweringOf(loweredType.getMetatypeInstanceType(F.getModule()),
-                            formalMT.getInstanceType());
-      }
-    }
-    if (auto loweredEMT = loweredType.getAs<ExistentialMetatypeType>()) {
-      if (auto formalEMT = dyn_cast<ExistentialMetatypeType>(formalType)) {
-        return loweredEMT.getInstanceType() == formalEMT.getInstanceType();
-      }
-    }
-    
-    // TODO: Function types go through a more elaborate lowering.
-    // For now, just check that a SIL function type came from some AST function
-    // type.
-    if (loweredType.is<SILFunctionType>())
-      return isa<AnyFunctionType>(formalType);
-    
-    // Tuples are lowered elementwise.
-    // TODO: Will this always be the case?
-    if (auto loweredTT = loweredType.getAs<TupleType>())
-      if (auto formalTT = dyn_cast<TupleType>(formalType)) {
-        if (loweredTT->getNumElements() != formalTT->getNumElements())
-          return false;
-        for (unsigned i = 0, e = loweredTT->getNumElements(); i < e; ++i) {
-          if (!isLoweringOf(SILType::getPrimitiveAddressType(
-                                                   loweredTT.getElementType(i)),
-                            formalTT.getElementType(i)))
-            return false;
-        }
-        return true;
-      }
-
-    // Dynamic self has the same lowering as its contained type.
-    if (auto dynamicSelf = dyn_cast<DynamicSelfType>(formalType))
-      formalType = dynamicSelf.getSelfType();
-
-    // Other types are preserved through lowering.
-    return loweredType.getSwiftRValueType() == formalType;
+  bool isLoweringOf(SILType loweredType, CanType formalType) {
+    return loweredType.isLoweringOf(F.getModule(), formalType);
   }
   
   void checkMetatypeInst(MetatypeInst *MI) {


### PR DESCRIPTION
This PR contains two different improvements around metatypes and verification:

1. It takes the logic for isLoweringOf from the verifier and puts it on SILType. This means that we can use this query in other contexts (for instance in asserts on SILBuilder).
2. I put the isLoweringOf assertion that normally occurs in the verifier also in the SILBuilder code for createValueMetatype. This is useful since it makes that bug very easy to track down since instead of asserting in the verifier, one asserts right where the instruction is being created.

rdar://problem/31880847