### PR TITLE
[GSB] SE-0157: Reprocess delayed requirements when we need a complete PA

### DIFF
--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -90,6 +90,13 @@ struct GenericSignatureBuilder::Implementation {
   /// The set of requirements that have been delayed for some reason.
   SmallVector<DelayedRequirement, 4> DelayedRequirements;
 
+  /// The generation number, which is incremented whenever we successfully
+  /// introduce a new constraint.
+  unsigned Generation = 0;
+
+  /// The generation at which we last processed all of the delayed requirements.
+  unsigned LastProcessedGeneration = 0;
+
 #ifndef NDEBUG
   /// Whether we've already finalized the builder.
   bool finalized = false;
@@ -1399,6 +1406,9 @@ bool PotentialArchetype::addConformance(ProtocolDecl *proto,
     return false;
   }
 
+  // Bump the generation.
+  ++builder.Impl->Generation;
+
   // Add the conformance along with this constraint.
   equivClass->conformsTo[proto].push_back({this, proto, source});
   ++NumConformanceConstraints;
@@ -1866,6 +1876,12 @@ PotentialArchetype *PotentialArchetype::updateNestedTypeForConformance(
   if (!assocType && !concreteDecl)
     return nullptr;
 
+  // If we were asked for a complete, well-formed archetype, make sure we
+  // process delayed requirements if anything changed.
+  SWIFT_DEFER {
+    getBuilder()->processDelayedRequirements();
+  };
+
   Identifier name = assocType ? assocType->getName() : concreteDecl->getName();
   ProtocolDecl *proto =
     assocType ? assocType->getProtocol()
@@ -1900,6 +1916,9 @@ PotentialArchetype *PotentialArchetype::updateNestedTypeForConformance(
     switch (kind) {
     case ArchetypeResolutionKind::CompleteWellFormed:
     case ArchetypeResolutionKind::WellFormed: {
+      // Bump the generation count, because we created a new archetype.
+      ++getBuilder()->Impl->Generation;
+
       if (assocType)
         resultPA = new PotentialArchetype(this, assocType);
       else
@@ -2818,6 +2837,9 @@ ConstraintResult GenericSignatureBuilder::addLayoutRequirement(
     return ConstraintResult::Resolved;
   }
 
+  // Bump the generation.
+  ++Impl->Generation;
+
   auto pa = resolvedSubject->getPotentialArchetype();
   return addLayoutRequirementDirect(pa, layout, source.getSource(pa));
 }
@@ -2901,6 +2923,9 @@ ConstraintResult GenericSignatureBuilder::addSuperclassRequirementDirect(
   T->getOrCreateEquivalenceClass()->superclassConstraints
     .push_back(ConcreteConstraint{T, superclass, source});
   ++NumSuperclassConstraints;
+
+  // Bump the generation.
+  ++Impl->Generation;
 
   // Update the equivalence class with the constraint.
   updateSuperclass(T, superclass, source);
@@ -3061,6 +3086,9 @@ GenericSignatureBuilder::addSameTypeRequirementBetweenArchetypes(
   if (T1 == T2)
     return ConstraintResult::Resolved;
 
+  // Bump the generation.
+  ++Impl->Generation;
+
   unsigned nestingDepth1 = T1->getNestingDepth();
   unsigned nestingDepth2 = T2->getNestingDepth();
 
@@ -3195,6 +3223,9 @@ ConstraintResult GenericSignatureBuilder::addSameTypeRequirementToConcrete(
   equivClass->concreteTypeConstraints.push_back(
                                       ConcreteConstraint{T, Concrete, Source});
   ++NumConcreteTypeConstraints;
+
+  // Bump the generation.
+  ++Impl->Generation;
 
   // If we've already been bound to a type, match that type.
   if (equivClass->concreteType) {
@@ -3978,6 +4009,13 @@ static GenericSignatureBuilder::UnresolvedType asUnresolvedType(
 }
 
 void GenericSignatureBuilder::processDelayedRequirements() {
+  // If we're already up-to-date, do nothing.
+  if (Impl->Generation == Impl->LastProcessedGeneration) return;
+
+  SWIFT_DEFER {
+    Impl->LastProcessedGeneration = Impl->Generation;
+  };
+
   bool anySolved = !Impl->DelayedRequirements.empty();
   while (anySolved) {
     // Steal the delayed requirements so we can reprocess them.

--- a/test/decl/protocol/recursive_requirement_ok.swift
+++ b/test/decl/protocol/recursive_requirement_ok.swift
@@ -9,5 +9,6 @@ protocol P {
 func testP<T: P>(_ t: T) {
   testP(t.assoc)
   testP(t.assoc.assoc)
-  testP(t.assoc.assoc.assoc) // FIXME: expected-error{{argument type 'T.Assoc.Assoc.Assoc' does not conform to expected type 'P'}}
+  testP(t.assoc.assoc.assoc)
+  testP(t.assoc.assoc.assoc.assoc.assoc.assoc.assoc)
 }


### PR DESCRIPTION
Whenever we need a complete, well-formed potential archetype,
reprocess any delayed requirements, so that we pick up additional
requirements on that potential archetype.

This relies on us tracking a generation count for the GSB instance as
a whole, which gets bumped each time we add some new requirement or
create a new potential archetype, and only actually reprocessing
delayed requirements when the generation count exceeds the point at
which we last processed delayed requirements.

This gets the most basic recursive protocol constraint working
end-to-end and doesn't seem to break things.
