### PR TITLE
[4.0] Stop swallowing test interruption exceptions thrown during XCTAssert evaluation.

### DIFF
--- a/stdlib/public/SDK/XCTest/XCTestCaseAdditions.mm
+++ b/stdlib/public/SDK/XCTest/XCTestCaseAdditions.mm
@@ -143,6 +143,7 @@ NSDictionary<NSString *, NSString *> *_XCTRunThrowableBlockBridge(void (^block)(
     @try {
         block();
     }
+    @catch (_XCTestCaseInterruptionException *interruption) { [interruption raise]; }
     @catch (NSException *exception) {
         result = @{
                    @"type": @"objc",


### PR DESCRIPTION
4.0 merge of https://github.com/apple/swift/pull/10905.

**Explanation**: Fix the implementation of the `XCTAssert` functions so that test interruption exceptions thrown by XCTest during evaluation of the expression get rethrown rather than treated as an unexpected test failure.
**Scope**: This affects XCTest users that have set their test case's `continueAfterFailure` property to `false`. Without this change, that setting is effectively is effectively ignored for failures which occur while evaluating an assertion expression. The conditions for this are particularly common during UI tests.
**Radar**: rdar://problem/33255447
**Risk**: Very low. The change is isolated and the rethrowing behavior is well-understood and has been in use for the Objective-C version of the assertions for several releases.
**Testing**: CI testing, including a new unit test exercising this behavior.