### PR TITLE
Expose synthesized members in AST lookups

### DIFF
--- a/include/swift/AST/LazyResolver.h
+++ b/include/swift/AST/LazyResolver.h
@@ -91,6 +91,9 @@ public:
   /// Resolve any implicitly-declared constructors within the given nominal.
   virtual void resolveImplicitConstructors(NominalTypeDecl *nominal) = 0;
 
+  /// Resolve an implicitly-generated member with the given name.
+  virtual void resolveImplicitMember(NominalTypeDecl *nominal, DeclName member) = 0;
+
   /// Resolve any implicitly-generated members and conformances for generated
   /// external decls.
   virtual void resolveExternalDeclImplicitMembers(NominalTypeDecl *nominal) = 0;
@@ -154,6 +157,10 @@ public:
 
   void resolveImplicitConstructors(NominalTypeDecl *nominal) override {
     Principal.resolveImplicitConstructors(nominal);
+  }
+
+  void resolveImplicitMember(NominalTypeDecl *nominal, DeclName member) override {
+    Principal.resolveImplicitMember(nominal, member);
   }
 
   void resolveExternalDeclImplicitMembers(NominalTypeDecl *nominal) override {

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1499,9 +1499,13 @@ bool DeclContext::lookupQualified(Type type,
     if (tracker)
       tracker->addUsedMember({current, member.getBaseName()},isLookupCascading);
 
-    // Make sure we've resolved implicit constructors, if we need them.
-    if (member.getBaseName() == ctx.Id_init && typeResolver)
-      typeResolver->resolveImplicitConstructors(current);
+    // Make sure we've resolved implicit members, if we need them.
+    if (typeResolver) {
+      if (member.getBaseName() == ctx.Id_init)
+        typeResolver->resolveImplicitConstructors(current);
+
+      typeResolver->resolveImplicitMember(current, member);
+    }
 
     // Look for results within the current nominal type and its extensions.
     bool currentIsProtocol = isa<ProtocolDecl>(current);

--- a/lib/Sema/DerivedConformanceCodingKey.cpp
+++ b/lib/Sema/DerivedConformanceCodingKey.cpp
@@ -393,6 +393,9 @@ deriveBodyCodingKey_init_stringValue(AbstractFunctionDecl *initDecl) {
 /// \param enumDecl The enum to check.
 static bool canSynthesizeCodingKey(TypeChecker &tc, Decl *parentDecl,
                                    EnumDecl *enumDecl) {
+  // Validate the enum and its raw type.
+  tc.validateDecl(enumDecl);
+
   // If the enum has a raw type (optional), it must be String or Int.
   Type rawType = enumDecl->getRawType();
   if (rawType) {

--- a/lib/Sema/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformanceRawRepresentable.cpp
@@ -334,6 +334,8 @@ static ConstructorDecl *deriveRawRepresentable_init(TypeChecker &tc,
 
 static bool canSynthesizeRawRepresentable(TypeChecker &tc, Decl *parentDecl,
                                           EnumDecl *enumDecl) {
+  // Validate the enum and its raw type.
+  tc.validateDecl(enumDecl);
 
   // It must have a valid raw type.
   Type rawType = enumDecl->getRawType();

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1,3 +1,5 @@
+// A similar struct with Codable properties adopting Codable should get a
+// synthesized init(from:), along with the memberwise initializer.
 //===--- TypeCheckDecl.cpp - Type Checking for Declarations ---------------===//
 //
 // This source file is part of the Swift.org open source project
@@ -8321,6 +8323,96 @@ void TypeChecker::addImplicitConstructors(NominalTypeDecl *decl) {
     }
 
     defineDefaultConstructor(decl);
+  }
+}
+
+void TypeChecker::synthesizeMemberForLookup(NominalTypeDecl *target,
+                                            DeclName member) {
+  auto baseName = member.getBaseName();
+  if (baseName.isSpecial())
+    return;
+
+  // Checks whether the target conforms to the given protocol. If the
+  // conformance is incomplete, check the conformance to force synthesis, if
+  // possible.
+  //
+  // Swallows diagnostics if conformance checking is already in progress (so we
+  // don't display diagnostics twice).
+  //
+  // Returns whether the target conforms to the protocol and the conformance is
+  // complete.
+  auto evaluateTargetConformanceTo = [&](ProtocolDecl *protocol) {
+    auto targetType = target->getDeclaredInterfaceType();
+    if (auto ref = conformsToProtocol(targetType, protocol, target,
+                                      ConformanceCheckFlags::Used,
+                                      SourceLoc())) {
+      if (auto *conformance =
+          dyn_cast_or_null<NormalProtocolConformance>(ref->getConcrete())) {
+        if (conformance->isIncomplete()) {
+          // Check conformance, forcing synthesis.
+          //
+          // If synthesizing conformance fails, this will produce diagnostics.
+          // If conformance checking was already in progress elsewhere, though,
+          // this could produce diagnostics twice.
+          //
+          // To prevent this duplication, we swallow the diagnostics if the
+          // state of the conformance is not Incomplete.
+          DiagnosticTransaction transaction(Context.Diags);
+          auto shouldSwallowDiagnostics =
+            conformance->getState() != ProtocolConformanceState::Incomplete;
+
+          checkConformance(conformance);
+          if (shouldSwallowDiagnostics)
+            transaction.abort();
+
+          return conformance->isComplete();
+        }
+      }
+    }
+
+    return false;
+  };
+
+  if (member.isSimpleName()) {
+    if (baseName.getIdentifier() == Context.Id_CodingKeys) {
+      // CodingKeys is a special type which may be synthesized as part of
+      // Encodable/Decodable conformance. If the target conforms to either
+      // protocol and would derive conformance to either, the type may be
+      // synthesized.
+      // If the target conforms to either and the conformance has not yet been
+      // evaluated, then we should do that here.
+      //
+      // Try to synthesize Decodable first. If that fails, try to synthesize
+      // Encodable. If either succeeds and CodingKeys should have been
+      // synthesized, it will be synthesized.
+      auto *decodableProto = Context.getProtocol(KnownProtocolKind::Decodable);
+      auto *encodableProto = Context.getProtocol(KnownProtocolKind::Encodable);
+      if (!evaluateTargetConformanceTo(decodableProto))
+        (void)evaluateTargetConformanceTo(encodableProto);
+    }
+  } else {
+    auto argumentNames = member.getArgumentNames();
+    if (argumentNames.size() != 1)
+      return;
+
+    auto argumentName = argumentNames.front();
+    if (baseName.getIdentifier() == Context.Id_init &&
+        argumentName == Context.Id_from) {
+      // init(from:) may be synthesized as part of derived confromance to the
+      // Decodable protocol.
+      // If the target should conform to the Decodable protocol, check the
+      // conformance here to attempt synthesis.
+      auto *decodableProto = Context.getProtocol(KnownProtocolKind::Decodable);
+      (void)evaluateTargetConformanceTo(decodableProto);
+    } else if (baseName.getIdentifier() == Context.Id_encode &&
+               argumentName == Context.Id_to) {
+      // encode(to:) may be synthesized as part of derived confromance to the
+      // Encodable protocol.
+      // If the target should conform to the Encodable protocol, check the
+      // conformance here to attempt synthesis.
+      auto *encodableProto = Context.getProtocol(KnownProtocolKind::Encodable);
+      (void)evaluateTargetConformanceTo(encodableProto);
+    }
   }
 }
 

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1264,6 +1264,10 @@ public:
     addImplicitConstructors(nominal);
   }
 
+  virtual void resolveImplicitMember(NominalTypeDecl *nominal, DeclName member) override {
+    synthesizeMemberForLookup(nominal, member);
+  }
+
   virtual void
   resolveExternalDeclImplicitMembers(NominalTypeDecl *nominal) override {
     handleExternalDecl(nominal);
@@ -1437,6 +1441,11 @@ public:
   /// \brief Add the RawRepresentable, Equatable, and Hashable methods to an
   /// enum with a raw type.
   void addImplicitEnumConformances(EnumDecl *ED);
+
+  /// Synthesize the member with the given name on the target if applicable,
+  /// i.e. if the member is synthesizable and has not yet been added to the
+  /// target.
+  void synthesizeMemberForLookup(NominalTypeDecl *target, DeclName member);
 
   /// The specified AbstractStorageDecl \c storage was just found to satisfy
   /// the protocol property \c requirement.  Ensure that it has the full

--- a/test/decl/protocol/special/coding/class_codable_member_lookup.swift
+++ b/test/decl/protocol/special/coding/class_codable_member_lookup.swift
@@ -1,0 +1,18 @@
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
+
+class SynthesizedSuperclass : Codable {
+  let superValue: Double = .pi
+}
+
+// Classes which subclass something Codable should be able to override their
+// superclasses methods (the methods should be visible in member lookup despite
+// being synthesized).
+class ExplicitSubclass : SynthesizedSuperclass {
+  required init(from decoder: Decoder) throws {
+    try super.init(from: decoder)
+  }
+
+  override func encode(to encoder: Encoder) throws {
+    try super.encode(to: encoder)
+  }
+}

--- a/test/decl/protocol/special/coding/class_codable_member_type_lookup.swift
+++ b/test/decl/protocol/special/coding/class_codable_member_type_lookup.swift
@@ -1,0 +1,647 @@
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
+
+// A top-level CodingKeys type to fall back to in lookups below.
+public enum CodingKeys : String, CodingKey {
+  case topLevel
+}
+
+// MARK: - Synthesized CodingKeys Enum
+
+// Classes which get synthesized Codable implementations should have visible
+// CodingKey enums during member type lookup.
+struct SynthesizedClass : Codable {
+  let value: String = "foo"
+
+  // Qualified type lookup should always be unambiguous.
+  public func qualifiedFoo(_ key: SynthesizedClass.CodingKeys) {} // expected-error {{method cannot be declared public because its parameter uses a private type}}
+  internal func qualifiedBar(_ key: SynthesizedClass.CodingKeys) {} // expected-error {{method cannot be declared internal because its parameter uses a private type}}
+  fileprivate func qualfiedBaz(_ key: SynthesizedClass.CodingKeys) {} // expected-warning {{method should not be declared fileprivate because its parameter uses a private type}}
+  private func qualifiedQux(_ key: SynthesizedClass.CodingKeys) {}
+
+  // Unqualified lookups should find the synthesized CodingKeys type instead
+  // of the top-level type above.
+  public func unqualifiedFoo(_ key: CodingKeys) { // expected-error {{method cannot be declared public because its parameter uses a private type}}
+    print(CodingKeys.value) // Not found on top-level.
+  }
+
+  internal func unqualifiedBar(_ key: CodingKeys) { // expected-error {{method cannot be declared internal because its parameter uses a private type}}
+    print(CodingKeys.value) // Not found on top-level.
+  }
+
+  fileprivate func unqualifiedBaz(_ key: CodingKeys) { // expected-warning {{method should not be declared fileprivate because its parameter uses a private type}}
+    print(CodingKeys.value) // Not found on top-level.
+  }
+
+  private func unqualifiedQux(_ key: CodingKeys) {
+    print(CodingKeys.value) // Not found on top-level.
+  }
+
+  // Unqualified lookups should find the most local CodingKeys type available.
+  public func nestedUnqualifiedFoo(_ key: CodingKeys) { // expected-error {{method cannot be declared public because its parameter uses a private type}}
+    enum CodingKeys : String, CodingKey {
+      case nested
+    }
+
+    // CodingKeys should refer to the local unqualified enum.
+    func foo(_ key: CodingKeys) {
+      print(CodingKeys.nested) // Not found on synthesized type or top-level type.
+    }
+
+    foo(CodingKeys.nested)
+  }
+
+  internal func nestedUnqualifiedBar(_ key: CodingKeys) { // expected-error {{method cannot be declared internal because its parameter uses a private type}}
+    enum CodingKeys : String, CodingKey {
+      case nested
+    }
+
+    // CodingKeys should refer to the local unqualified enum.
+    func bar(_ key: CodingKeys) {
+      print(CodingKeys.nested) // Not found on synthesized type or top-level type.
+    }
+
+    bar(CodingKeys.nested)
+  }
+
+  fileprivate func nestedUnqualifiedBaz(_ key: CodingKeys) { // expected-warning {{method should not be declared fileprivate because its parameter uses a private type}}
+    enum CodingKeys : String, CodingKey {
+      case nested
+    }
+
+    // CodingKeys should refer to the local unqualified enum.
+    func baz(_ key: CodingKeys) {
+      print(CodingKeys.nested) // Not found on synthesized type or top-level type.
+    }
+
+    baz(CodingKeys.nested)
+  }
+
+  private func nestedUnqualifiedQux(_ key: CodingKeys) {
+    enum CodingKeys : String, CodingKey {
+      case nested
+    }
+
+    // CodingKeys should refer to the local unqualified enum.
+    func qux(_ key: CodingKeys) {
+      print(CodingKeys.nested) // Not found on synthesized type or top-level type.
+    }
+
+    qux(CodingKeys.nested)
+  }
+
+  // Lookup within nested types should look outside of the type.
+  struct Nested {
+    // Qualified lookup should remain as-is.
+    public func qualifiedFoo(_ key: SynthesizedClass.CodingKeys) {} // expected-error {{method cannot be declared public because its parameter uses a private type}}
+    internal func qualifiedBar(_ key: SynthesizedClass.CodingKeys) {} // expected-error {{method cannot be declared internal because its parameter uses a private type}}
+    fileprivate func qualfiedBaz(_ key: SynthesizedClass.CodingKeys) {} // expected-warning {{method should not be declared fileprivate because its parameter uses a private type}}
+    private func qualifiedQux(_ key: SynthesizedClass.CodingKeys) {}
+
+    // Unqualified lookups should find the SynthesizedClass's synthesized
+    // CodingKeys type instead of the top-level type above.
+    public func unqualifiedFoo(_ key: CodingKeys) { // expected-error {{method cannot be declared public because its parameter uses a private type}}
+      print(CodingKeys.value) // Not found on top-level.
+    }
+
+    internal func unqualifiedBar(_ key: CodingKeys) { // expected-error {{method cannot be declared internal because its parameter uses a private type}}
+      print(CodingKeys.value) // Not found on top-level.
+    }
+
+    fileprivate func unqualifiedBaz(_ key: CodingKeys) { // expected-warning {{method should not be declared fileprivate because its parameter uses a private type}}
+      print(CodingKeys.value) // Not found on top-level.
+    }
+
+    private func unqualifiedQux(_ key: CodingKeys) {
+      print(CodingKeys.value) // Not found on top-level.
+    }
+
+    // Unqualified lookups should find the most local CodingKeys type available.
+    public func nestedUnqualifiedFoo(_ key: CodingKeys) { // expected-error {{method cannot be declared public because its parameter uses a private type}}
+      enum CodingKeys : String, CodingKey {
+        case nested
+      }
+
+      // CodingKeys should refer to the local unqualified enum.
+      func foo(_ key: CodingKeys) {
+        print(CodingKeys.nested) // Not found on synthesized type or top-level type.
+      }
+
+      foo(CodingKeys.nested)
+    }
+
+    internal func nestedUnqualifiedBar(_ key: CodingKeys) { // expected-error {{method cannot be declared internal because its parameter uses a private type}}
+      enum CodingKeys : String, CodingKey {
+        case nested
+      }
+
+      // CodingKeys should refer to the local unqualified enum.
+      func bar(_ key: CodingKeys) {
+        print(CodingKeys.nested) // Not found on synthesized type or top-level type.
+      }
+
+      bar(CodingKeys.nested)
+    }
+
+    fileprivate func nestedUnqualifiedBaz(_ key: CodingKeys) { // expected-warning {{method should not be declared fileprivate because its parameter uses a private type}}
+      enum CodingKeys : String, CodingKey {
+        case nested
+      }
+
+      // CodingKeys should refer to the local unqualified enum.
+      func baz(_ key: CodingKeys) {
+        print(CodingKeys.nested) // Not found on synthesized type or top-level type.
+      }
+
+      baz(CodingKeys.nested)
+    }
+
+    private func nestedUnqualifiedQux(_ key: CodingKeys) {
+      enum CodingKeys : String, CodingKey {
+        case nested
+      }
+
+      // CodingKeys should refer to the local unqualified enum.
+      func qux(_ key: CodingKeys) {
+        print(CodingKeys.nested) // Not found on synthesized type or top-level type.
+      }
+
+      qux(CodingKeys.nested)
+    }
+  }
+}
+
+// MARK: - No CodingKeys Enum
+
+// Classes which don't get synthesized Codable implementations should expose the
+// appropriate CodingKeys type.
+struct NonSynthesizedClass : Codable {
+  // No synthesized type since we implemented both methods.
+  init(from decoder: Decoder) throws {}
+  func encode(to encoder: Encoder) throws {}
+
+  // Qualified type lookup should clearly fail -- we shouldn't get a synthesized
+  // type here.
+  public func qualifiedFoo(_ key: NonSynthesizedClass.CodingKeys) {} // expected-error {{'CodingKeys' is not a member type of 'NonSynthesizedClass'}}
+  internal func qualifiedBar(_ key: NonSynthesizedClass.CodingKeys) {} // expected-error {{'CodingKeys' is not a member type of 'NonSynthesizedClass'}}
+  fileprivate func qualfiedBaz(_ key: NonSynthesizedClass.CodingKeys) {} // expected-error {{'CodingKeys' is not a member type of 'NonSynthesizedClass'}}
+  private func qualifiedQux(_ key: NonSynthesizedClass.CodingKeys) {} // expected-error {{'CodingKeys' is not a member type of 'NonSynthesizedClass'}}
+
+  // Unqualified lookups should find the public top-level CodingKeys type.
+  public func unqualifiedFoo(_ key: CodingKeys) { print(CodingKeys.topLevel) }
+  internal func unqualifiedBar(_ key: CodingKeys) { print(CodingKeys.topLevel) }
+  fileprivate func unqualifiedBaz(_ key: CodingKeys) { print(CodingKeys.topLevel) }
+  private func unqualifiedQux(_ key: CodingKeys) { print(CodingKeys.topLevel) }
+
+  // Unqualified lookups should find the most local CodingKeys type available.
+  public func nestedUnqualifiedFoo(_ key: CodingKeys) {
+    enum CodingKeys : String, CodingKey {
+      case nested
+    }
+
+    // CodingKeys should refer to the local unqualified enum.
+    func foo(_ key: CodingKeys) {
+      print(CodingKeys.nested) // Not found on top-level type.
+    }
+
+    foo(CodingKeys.nested)
+  }
+
+  internal func nestedUnqualifiedBar(_ key: CodingKeys) {
+    enum CodingKeys : String, CodingKey {
+      case nested
+    }
+
+    // CodingKeys should refer to the local unqualified enum.
+    func bar(_ key: CodingKeys) {
+      print(CodingKeys.nested) // Not found on top-level type.
+    }
+
+    bar(CodingKeys.nested)
+  }
+
+  fileprivate func nestedUnqualifiedBaz(_ key: CodingKeys) {
+    enum CodingKeys : String, CodingKey {
+      case nested
+    }
+
+    // CodingKeys should refer to the local unqualified enum.
+    func baz(_ key: CodingKeys) {
+      print(CodingKeys.nested) // Not found on top-level type.
+    }
+
+    baz(CodingKeys.nested)
+  }
+
+  private func nestedUnqualifiedQux(_ key: CodingKeys) {
+    enum CodingKeys : String, CodingKey {
+      case nested
+    }
+
+    // CodingKeys should refer to the local unqualified enum.
+    func qux(_ key: CodingKeys) {
+      print(CodingKeys.nested) // Not found on top-level type.
+    }
+
+    qux(CodingKeys.nested)
+  }
+}
+
+// MARK: - Explicit CodingKeys Enum
+
+// Classes which explicitly define their own CodingKeys types should have
+// visible CodingKey enums during member type lookup.
+struct ExplicitClass : Codable {
+  let value: String = "foo"
+
+  public enum CodingKeys {
+    case a
+    case b
+    case c
+  }
+
+  init(from decoder: Decoder) throws {}
+  func encode(to encoder: Encoder) throws {}
+
+  // Qualified type lookup should always be unambiguous.
+  public func qualifiedFoo(_ key: ExplicitClass.CodingKeys) {}
+  internal func qualifiedBar(_ key: ExplicitClass.CodingKeys) {}
+  fileprivate func qualfiedBaz(_ key: ExplicitClass.CodingKeys) {}
+  private func qualifiedQux(_ key: ExplicitClass.CodingKeys) {}
+
+  // Unqualified lookups should find the synthesized CodingKeys type instead
+  // of the top-level type above.
+  public func unqualifiedFoo(_ key: CodingKeys) {
+    print(CodingKeys.a) // Not found on top-level.
+  }
+
+  internal func unqualifiedBar(_ key: CodingKeys) {
+    print(CodingKeys.a) // Not found on top-level.
+  }
+
+  fileprivate func unqualifiedBaz(_ key: CodingKeys) {
+    print(CodingKeys.a) // Not found on top-level.
+  }
+
+  private func unqualifiedQux(_ key: CodingKeys) {
+    print(CodingKeys.a) // Not found on top-level.
+  }
+
+  // Unqualified lookups should find the most local CodingKeys type available.
+  public func nestedUnqualifiedFoo(_ key: CodingKeys) {
+    enum CodingKeys : String, CodingKey {
+      case nested
+    }
+
+    // CodingKeys should refer to the local unqualified enum.
+    func foo(_ key: CodingKeys) {
+      print(CodingKeys.nested) // Not found on synthesized type or top-level type.
+    }
+
+    foo(CodingKeys.nested)
+  }
+
+  internal func nestedUnqualifiedBar(_ key: CodingKeys) {
+    enum CodingKeys : String, CodingKey {
+      case nested
+    }
+
+    // CodingKeys should refer to the local unqualified enum.
+    func bar(_ key: CodingKeys) {
+      print(CodingKeys.nested) // Not found on synthesized type or top-level type.
+    }
+
+    bar(CodingKeys.nested)
+  }
+
+  fileprivate func nestedUnqualifiedBaz(_ key: CodingKeys) {
+    enum CodingKeys : String, CodingKey {
+      case nested
+    }
+
+    // CodingKeys should refer to the local unqualified enum.
+    func baz(_ key: CodingKeys) {
+      print(CodingKeys.nested) // Not found on synthesized type or top-level type.
+    }
+
+    baz(CodingKeys.nested)
+  }
+
+  private func nestedUnqualifiedQux(_ key: CodingKeys) {
+    enum CodingKeys : String, CodingKey {
+      case nested
+    }
+
+    // CodingKeys should refer to the local unqualified enum.
+    func qux(_ key: CodingKeys) {
+      print(CodingKeys.nested) // Not found on synthesized type or top-level type.
+    }
+
+    qux(CodingKeys.nested)
+  }
+
+  // Lookup within nested types should look outside of the type.
+  struct Nested {
+    // Qualified lookup should remain as-is.
+    public func qualifiedFoo(_ key: ExplicitClass.CodingKeys) {}
+    internal func qualifiedBar(_ key: ExplicitClass.CodingKeys) {}
+    fileprivate func qualfiedBaz(_ key: ExplicitClass.CodingKeys) {}
+    private func qualifiedQux(_ key: ExplicitClass.CodingKeys) {}
+
+    // Unqualified lookups should find the ExplicitClass's synthesized
+    // CodingKeys type instead of the top-level type above.
+    public func unqualifiedFoo(_ key: CodingKeys) {
+      print(CodingKeys.a) // Not found on top-level.
+    }
+
+    internal func unqualifiedBar(_ key: CodingKeys) {
+      print(CodingKeys.a) // Not found on top-level.
+    }
+
+    fileprivate func unqualifiedBaz(_ key: CodingKeys) {
+      print(CodingKeys.a) // Not found on top-level.
+    }
+
+    private func unqualifiedQux(_ key: CodingKeys) {
+      print(CodingKeys.a) // Not found on top-level.
+    }
+
+    // Unqualified lookups should find the most local CodingKeys type available.
+    public func nestedUnqualifiedFoo(_ key: CodingKeys) {
+      enum CodingKeys : String, CodingKey {
+        case nested
+      }
+
+      // CodingKeys should refer to the local unqualified enum.
+      func foo(_ key: CodingKeys) {
+        print(CodingKeys.nested) // Not found on synthesized type or top-level type.
+      }
+
+      foo(CodingKeys.nested)
+    }
+
+    internal func nestedUnqualifiedBar(_ key: CodingKeys) {
+      enum CodingKeys : String, CodingKey {
+        case nested
+      }
+
+      // CodingKeys should refer to the local unqualified enum.
+      func bar(_ key: CodingKeys) {
+        print(CodingKeys.nested) // Not found on synthesized type or top-level type.
+      }
+
+      bar(CodingKeys.nested)
+    }
+
+    fileprivate func nestedUnqualifiedBaz(_ key: CodingKeys) {
+      enum CodingKeys : String, CodingKey {
+        case nested
+      }
+
+      // CodingKeys should refer to the local unqualified enum.
+      func baz(_ key: CodingKeys) {
+        print(CodingKeys.nested) // Not found on synthesized type or top-level type.
+      }
+
+      baz(CodingKeys.nested)
+    }
+
+    private func nestedUnqualifiedQux(_ key: CodingKeys) {
+      enum CodingKeys : String, CodingKey {
+        case nested
+      }
+
+      // CodingKeys should refer to the local unqualified enum.
+      func qux(_ key: CodingKeys) {
+        print(CodingKeys.nested) // Not found on synthesized type or top-level type.
+      }
+
+      qux(CodingKeys.nested)
+    }
+  }
+}
+
+// MARK: - CodingKeys Enums in Extensions
+
+// Classes which get a CodingKeys type in an extension should be able to see
+// that type during member type lookup.
+struct ExtendedClass : Codable {
+  let value: String = "foo"
+
+  // Don't get an auto-synthesized type.
+  init(from decoder: Decoder) throws {}
+  func encode(to encoder: Encoder) throws {}
+
+  // Qualified type lookup should always be unambiguous.
+  public func qualifiedFoo(_ key: ExtendedClass.CodingKeys) {}
+  internal func qualifiedBar(_ key: ExtendedClass.CodingKeys) {}
+  fileprivate func qualfiedBaz(_ key: ExtendedClass.CodingKeys) {}
+  private func qualifiedQux(_ key: ExtendedClass.CodingKeys) {}
+
+  // Unqualified lookups should find the synthesized CodingKeys type instead
+  // of the top-level type above.
+  public func unqualifiedFoo(_ key: CodingKeys) {
+    print(CodingKeys.a) // Not found on top-level.
+  }
+
+  internal func unqualifiedBar(_ key: CodingKeys) {
+    print(CodingKeys.a) // Not found on top-level.
+  }
+
+  fileprivate func unqualifiedBaz(_ key: CodingKeys) {
+    print(CodingKeys.a) // Not found on top-level.
+  }
+
+  private func unqualifiedQux(_ key: CodingKeys) {
+    print(CodingKeys.a) // Not found on top-level.
+  }
+
+  // Unqualified lookups should find the most local CodingKeys type available.
+  public func nestedUnqualifiedFoo(_ key: CodingKeys) {
+    enum CodingKeys : String, CodingKey {
+      case nested
+    }
+
+    // CodingKeys should refer to the local unqualified enum.
+    func foo(_ key: CodingKeys) {
+      print(CodingKeys.nested) // Not found on synthesized type or top-level type.
+    }
+
+    foo(CodingKeys.nested)
+  }
+
+  internal func nestedUnqualifiedBar(_ key: CodingKeys) {
+    enum CodingKeys : String, CodingKey {
+      case nested
+    }
+
+    // CodingKeys should refer to the local unqualified enum.
+    func bar(_ key: CodingKeys) {
+      print(CodingKeys.nested) // Not found on synthesized type or top-level type.
+    }
+
+    bar(CodingKeys.nested)
+  }
+
+  fileprivate func nestedUnqualifiedBaz(_ key: CodingKeys) {
+    enum CodingKeys : String, CodingKey {
+      case nested
+    }
+
+    // CodingKeys should refer to the local unqualified enum.
+    func baz(_ key: CodingKeys) {
+      print(CodingKeys.nested) // Not found on synthesized type or top-level type.
+    }
+
+    baz(CodingKeys.nested)
+  }
+
+  private func nestedUnqualifiedQux(_ key: CodingKeys) {
+    enum CodingKeys : String, CodingKey {
+      case nested
+    }
+
+    // CodingKeys should refer to the local unqualified enum.
+    func qux(_ key: CodingKeys) {
+      print(CodingKeys.nested) // Not found on synthesized type or top-level type.
+    }
+
+    qux(CodingKeys.nested)
+  }
+
+  // Lookup within nested types should look outside of the type.
+  struct Nested {
+    // Qualified lookup should remain as-is.
+    public func qualifiedFoo(_ key: ExtendedClass.CodingKeys) {}
+    internal func qualifiedBar(_ key: ExtendedClass.CodingKeys) {}
+    fileprivate func qualfiedBaz(_ key: ExtendedClass.CodingKeys) {}
+    private func qualifiedQux(_ key: ExtendedClass.CodingKeys) {}
+
+    // Unqualified lookups should find the ExtendedClass's synthesized
+    // CodingKeys type instead of the top-level type above.
+    public func unqualifiedFoo(_ key: CodingKeys) {
+      print(CodingKeys.a) // Not found on top-level.
+    }
+
+    internal func unqualifiedBar(_ key: CodingKeys) {
+      print(CodingKeys.a) // Not found on top-level.
+    }
+
+    fileprivate func unqualifiedBaz(_ key: CodingKeys) {
+      print(CodingKeys.a) // Not found on top-level.
+    }
+
+    private func unqualifiedQux(_ key: CodingKeys) {
+      print(CodingKeys.a) // Not found on top-level.
+    }
+
+    // Unqualified lookups should find the most local CodingKeys type available.
+    public func nestedUnqualifiedFoo(_ key: CodingKeys) {
+      enum CodingKeys : String, CodingKey {
+        case nested
+      }
+
+      // CodingKeys should refer to the local unqualified enum.
+      func foo(_ key: CodingKeys) {
+        print(CodingKeys.nested) // Not found on synthesized type or top-level type.
+      }
+
+      foo(CodingKeys.nested)
+    }
+
+    internal func nestedUnqualifiedBar(_ key: CodingKeys) {
+      enum CodingKeys : String, CodingKey {
+        case nested
+      }
+
+      // CodingKeys should refer to the local unqualified enum.
+      func bar(_ key: CodingKeys) {
+        print(CodingKeys.nested) // Not found on synthesized type or top-level type.
+      }
+
+      bar(CodingKeys.nested)
+    }
+
+    fileprivate func nestedUnqualifiedBaz(_ key: CodingKeys) {
+      enum CodingKeys : String, CodingKey {
+        case nested
+      }
+
+      // CodingKeys should refer to the local unqualified enum.
+      func baz(_ key: CodingKeys) {
+        print(CodingKeys.nested) // Not found on synthesized type or top-level type.
+      }
+
+      baz(CodingKeys.nested)
+    }
+
+    private func nestedUnqualifiedQux(_ key: CodingKeys) {
+      enum CodingKeys : String, CodingKey {
+        case nested
+      }
+
+      // CodingKeys should refer to the local unqualified enum.
+      func qux(_ key: CodingKeys) {
+        print(CodingKeys.nested) // Not found on synthesized type or top-level type.
+      }
+
+      qux(CodingKeys.nested)
+    }
+  }
+}
+
+extension ExtendedClass {
+  enum CodingKeys : String, CodingKey {
+    case a, b, c
+  }
+}
+
+class A {
+  class Inner : Codable {
+    var value: Int = 42
+
+    func foo() {
+      print(CodingKeys.value) // Not found on A.CodingKeys or top-level type.
+    }
+  }
+}
+
+extension A {
+  enum CodingKeys : String, CodingKey {
+    case a
+  }
+}
+
+class B : Codable {
+  // So B conforms to Codable using CodingKeys.b below.
+  var b: Int = 0
+
+  class Inner {
+    var value: Int = 42
+
+    func foo() {
+      print(CodingKeys.b) // Not found on top-level type.
+    }
+  }
+}
+
+extension B {
+  enum CodingKeys : String, CodingKey {
+    case b
+  }
+}
+
+class C : Codable {
+  class Inner : Codable {
+    var value: Int = 42
+
+    func foo() {
+      print(CodingKeys.value) // Not found on C.CodingKeys or top-level type.
+    }
+  }
+}
+
+extension C.Inner {
+  enum CodingKeys : String, CodingKey {
+    case value
+  }
+}

--- a/test/decl/protocol/special/coding/struct_codable_member_type_lookup.swift
+++ b/test/decl/protocol/special/coding/struct_codable_member_type_lookup.swift
@@ -1,0 +1,647 @@
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
+
+// A top-level CodingKeys type to fall back to in lookups below.
+public enum CodingKeys : String, CodingKey {
+  case topLevel
+}
+
+// MARK: - Synthesized CodingKeys Enum
+
+// Structs which get synthesized Codable implementations should have visible
+// CodingKey enums during member type lookup.
+struct SynthesizedStruct : Codable {
+  let value: String = "foo"
+
+  // Qualified type lookup should always be unambiguous.
+  public func qualifiedFoo(_ key: SynthesizedStruct.CodingKeys) {} // expected-error {{method cannot be declared public because its parameter uses a private type}}
+  internal func qualifiedBar(_ key: SynthesizedStruct.CodingKeys) {} // expected-error {{method cannot be declared internal because its parameter uses a private type}}
+  fileprivate func qualfiedBaz(_ key: SynthesizedStruct.CodingKeys) {} // expected-warning {{method should not be declared fileprivate because its parameter uses a private type}}
+  private func qualifiedQux(_ key: SynthesizedStruct.CodingKeys) {}
+
+  // Unqualified lookups should find the synthesized CodingKeys type instead
+  // of the top-level type above.
+  public func unqualifiedFoo(_ key: CodingKeys) { // expected-error {{method cannot be declared public because its parameter uses a private type}}
+    print(CodingKeys.value) // Not found on top-level.
+  }
+
+  internal func unqualifiedBar(_ key: CodingKeys) { // expected-error {{method cannot be declared internal because its parameter uses a private type}}
+    print(CodingKeys.value) // Not found on top-level.
+  }
+
+  fileprivate func unqualifiedBaz(_ key: CodingKeys) { // expected-warning {{method should not be declared fileprivate because its parameter uses a private type}}
+    print(CodingKeys.value) // Not found on top-level.
+  }
+
+  private func unqualifiedQux(_ key: CodingKeys) {
+    print(CodingKeys.value) // Not found on top-level.
+  }
+
+  // Unqualified lookups should find the most local CodingKeys type available.
+  public func nestedUnqualifiedFoo(_ key: CodingKeys) { // expected-error {{method cannot be declared public because its parameter uses a private type}}
+    enum CodingKeys : String, CodingKey {
+      case nested
+    }
+
+    // CodingKeys should refer to the local unqualified enum.
+    func foo(_ key: CodingKeys) {
+      print(CodingKeys.nested) // Not found on synthesized type or top-level type.
+    }
+
+    foo(CodingKeys.nested)
+  }
+
+  internal func nestedUnqualifiedBar(_ key: CodingKeys) { // expected-error {{method cannot be declared internal because its parameter uses a private type}}
+    enum CodingKeys : String, CodingKey {
+      case nested
+    }
+
+    // CodingKeys should refer to the local unqualified enum.
+    func bar(_ key: CodingKeys) {
+      print(CodingKeys.nested) // Not found on synthesized type or top-level type.
+    }
+
+    bar(CodingKeys.nested)
+  }
+
+  fileprivate func nestedUnqualifiedBaz(_ key: CodingKeys) { // expected-warning {{method should not be declared fileprivate because its parameter uses a private type}}
+    enum CodingKeys : String, CodingKey {
+      case nested
+    }
+
+    // CodingKeys should refer to the local unqualified enum.
+    func baz(_ key: CodingKeys) {
+      print(CodingKeys.nested) // Not found on synthesized type or top-level type.
+    }
+
+    baz(CodingKeys.nested)
+  }
+
+  private func nestedUnqualifiedQux(_ key: CodingKeys) {
+    enum CodingKeys : String, CodingKey {
+      case nested
+    }
+
+    // CodingKeys should refer to the local unqualified enum.
+    func qux(_ key: CodingKeys) {
+      print(CodingKeys.nested) // Not found on synthesized type or top-level type.
+    }
+
+    qux(CodingKeys.nested)
+  }
+
+  // Lookup within nested types should look outside of the type.
+  struct Nested {
+    // Qualified lookup should remain as-is.
+    public func qualifiedFoo(_ key: SynthesizedStruct.CodingKeys) {} // expected-error {{method cannot be declared public because its parameter uses a private type}}
+    internal func qualifiedBar(_ key: SynthesizedStruct.CodingKeys) {} // expected-error {{method cannot be declared internal because its parameter uses a private type}}
+    fileprivate func qualfiedBaz(_ key: SynthesizedStruct.CodingKeys) {} // expected-warning {{method should not be declared fileprivate because its parameter uses a private type}}
+    private func qualifiedQux(_ key: SynthesizedStruct.CodingKeys) {}
+
+    // Unqualified lookups should find the SynthesizedStruct's synthesized
+    // CodingKeys type instead of the top-level type above.
+    public func unqualifiedFoo(_ key: CodingKeys) { // expected-error {{method cannot be declared public because its parameter uses a private type}}
+      print(CodingKeys.value) // Not found on top-level.
+    }
+
+    internal func unqualifiedBar(_ key: CodingKeys) { // expected-error {{method cannot be declared internal because its parameter uses a private type}}
+      print(CodingKeys.value) // Not found on top-level.
+    }
+
+    fileprivate func unqualifiedBaz(_ key: CodingKeys) { // expected-warning {{method should not be declared fileprivate because its parameter uses a private type}}
+      print(CodingKeys.value) // Not found on top-level.
+    }
+
+    private func unqualifiedQux(_ key: CodingKeys) {
+      print(CodingKeys.value) // Not found on top-level.
+    }
+
+    // Unqualified lookups should find the most local CodingKeys type available.
+    public func nestedUnqualifiedFoo(_ key: CodingKeys) { // expected-error {{method cannot be declared public because its parameter uses a private type}}
+      enum CodingKeys : String, CodingKey {
+        case nested
+      }
+
+      // CodingKeys should refer to the local unqualified enum.
+      func foo(_ key: CodingKeys) {
+        print(CodingKeys.nested) // Not found on synthesized type or top-level type.
+      }
+
+      foo(CodingKeys.nested)
+    }
+
+    internal func nestedUnqualifiedBar(_ key: CodingKeys) { // expected-error {{method cannot be declared internal because its parameter uses a private type}}
+      enum CodingKeys : String, CodingKey {
+        case nested
+      }
+
+      // CodingKeys should refer to the local unqualified enum.
+      func bar(_ key: CodingKeys) {
+        print(CodingKeys.nested) // Not found on synthesized type or top-level type.
+      }
+
+      bar(CodingKeys.nested)
+    }
+
+    fileprivate func nestedUnqualifiedBaz(_ key: CodingKeys) { // expected-warning {{method should not be declared fileprivate because its parameter uses a private type}}
+      enum CodingKeys : String, CodingKey {
+        case nested
+      }
+
+      // CodingKeys should refer to the local unqualified enum.
+      func baz(_ key: CodingKeys) {
+        print(CodingKeys.nested) // Not found on synthesized type or top-level type.
+      }
+
+      baz(CodingKeys.nested)
+    }
+
+    private func nestedUnqualifiedQux(_ key: CodingKeys) {
+      enum CodingKeys : String, CodingKey {
+        case nested
+      }
+
+      // CodingKeys should refer to the local unqualified enum.
+      func qux(_ key: CodingKeys) {
+        print(CodingKeys.nested) // Not found on synthesized type or top-level type.
+      }
+
+      qux(CodingKeys.nested)
+    }
+  }
+}
+
+// MARK: - No CodingKeys Enum
+
+// Structs which don't get synthesized Codable implementations should expose the
+// appropriate CodingKeys type.
+struct NonSynthesizedStruct : Codable {
+  // No synthesized type since we implemented both methods.
+  init(from decoder: Decoder) throws {}
+  func encode(to encoder: Encoder) throws {}
+
+  // Qualified type lookup should clearly fail -- we shouldn't get a synthesized
+  // type here.
+  public func qualifiedFoo(_ key: NonSynthesizedStruct.CodingKeys) {} // expected-error {{'CodingKeys' is not a member type of 'NonSynthesizedStruct'}}
+  internal func qualifiedBar(_ key: NonSynthesizedStruct.CodingKeys) {} // expected-error {{'CodingKeys' is not a member type of 'NonSynthesizedStruct'}}
+  fileprivate func qualfiedBaz(_ key: NonSynthesizedStruct.CodingKeys) {} // expected-error {{'CodingKeys' is not a member type of 'NonSynthesizedStruct'}}
+  private func qualifiedQux(_ key: NonSynthesizedStruct.CodingKeys) {} // expected-error {{'CodingKeys' is not a member type of 'NonSynthesizedStruct'}}
+
+  // Unqualified lookups should find the public top-level CodingKeys type.
+  public func unqualifiedFoo(_ key: CodingKeys) { print(CodingKeys.topLevel) }
+  internal func unqualifiedBar(_ key: CodingKeys) { print(CodingKeys.topLevel) }
+  fileprivate func unqualifiedBaz(_ key: CodingKeys) { print(CodingKeys.topLevel) }
+  private func unqualifiedQux(_ key: CodingKeys) { print(CodingKeys.topLevel) }
+
+  // Unqualified lookups should find the most local CodingKeys type available.
+  public func nestedUnqualifiedFoo(_ key: CodingKeys) {
+    enum CodingKeys : String, CodingKey {
+      case nested
+    }
+
+    // CodingKeys should refer to the local unqualified enum.
+    func foo(_ key: CodingKeys) {
+      print(CodingKeys.nested) // Not found on top-level type.
+    }
+
+    foo(CodingKeys.nested)
+  }
+
+  internal func nestedUnqualifiedBar(_ key: CodingKeys) {
+    enum CodingKeys : String, CodingKey {
+      case nested
+    }
+
+    // CodingKeys should refer to the local unqualified enum.
+    func bar(_ key: CodingKeys) {
+      print(CodingKeys.nested) // Not found on top-level type.
+    }
+
+    bar(CodingKeys.nested)
+  }
+
+  fileprivate func nestedUnqualifiedBaz(_ key: CodingKeys) {
+    enum CodingKeys : String, CodingKey {
+      case nested
+    }
+
+    // CodingKeys should refer to the local unqualified enum.
+    func baz(_ key: CodingKeys) {
+      print(CodingKeys.nested) // Not found on top-level type.
+    }
+
+    baz(CodingKeys.nested)
+  }
+
+  private func nestedUnqualifiedQux(_ key: CodingKeys) {
+    enum CodingKeys : String, CodingKey {
+      case nested
+    }
+
+    // CodingKeys should refer to the local unqualified enum.
+    func qux(_ key: CodingKeys) {
+      print(CodingKeys.nested) // Not found on top-level type.
+    }
+
+    qux(CodingKeys.nested)
+  }
+}
+
+// MARK: - Explicit CodingKeys Enum
+
+// Structs which explicitly define their own CodingKeys types should have
+// visible CodingKey enums during member type lookup.
+struct ExplicitStruct : Codable {
+  let value: String = "foo"
+
+  public enum CodingKeys {
+    case a
+    case b
+    case c
+  }
+
+  init(from decoder: Decoder) throws {}
+  func encode(to encoder: Encoder) throws {}
+
+  // Qualified type lookup should always be unambiguous.
+  public func qualifiedFoo(_ key: ExplicitStruct.CodingKeys) {}
+  internal func qualifiedBar(_ key: ExplicitStruct.CodingKeys) {}
+  fileprivate func qualfiedBaz(_ key: ExplicitStruct.CodingKeys) {}
+  private func qualifiedQux(_ key: ExplicitStruct.CodingKeys) {}
+
+  // Unqualified lookups should find the synthesized CodingKeys type instead
+  // of the top-level type above.
+  public func unqualifiedFoo(_ key: CodingKeys) {
+    print(CodingKeys.a) // Not found on top-level.
+  }
+
+  internal func unqualifiedBar(_ key: CodingKeys) {
+    print(CodingKeys.a) // Not found on top-level.
+  }
+
+  fileprivate func unqualifiedBaz(_ key: CodingKeys) {
+    print(CodingKeys.a) // Not found on top-level.
+  }
+
+  private func unqualifiedQux(_ key: CodingKeys) {
+    print(CodingKeys.a) // Not found on top-level.
+  }
+
+  // Unqualified lookups should find the most local CodingKeys type available.
+  public func nestedUnqualifiedFoo(_ key: CodingKeys) {
+    enum CodingKeys : String, CodingKey {
+      case nested
+    }
+
+    // CodingKeys should refer to the local unqualified enum.
+    func foo(_ key: CodingKeys) {
+      print(CodingKeys.nested) // Not found on synthesized type or top-level type.
+    }
+
+    foo(CodingKeys.nested)
+  }
+
+  internal func nestedUnqualifiedBar(_ key: CodingKeys) {
+    enum CodingKeys : String, CodingKey {
+      case nested
+    }
+
+    // CodingKeys should refer to the local unqualified enum.
+    func bar(_ key: CodingKeys) {
+      print(CodingKeys.nested) // Not found on synthesized type or top-level type.
+    }
+
+    bar(CodingKeys.nested)
+  }
+
+  fileprivate func nestedUnqualifiedBaz(_ key: CodingKeys) {
+    enum CodingKeys : String, CodingKey {
+      case nested
+    }
+
+    // CodingKeys should refer to the local unqualified enum.
+    func baz(_ key: CodingKeys) {
+      print(CodingKeys.nested) // Not found on synthesized type or top-level type.
+    }
+
+    baz(CodingKeys.nested)
+  }
+
+  private func nestedUnqualifiedQux(_ key: CodingKeys) {
+    enum CodingKeys : String, CodingKey {
+      case nested
+    }
+
+    // CodingKeys should refer to the local unqualified enum.
+    func qux(_ key: CodingKeys) {
+      print(CodingKeys.nested) // Not found on synthesized type or top-level type.
+    }
+
+    qux(CodingKeys.nested)
+  }
+
+  // Lookup within nested types should look outside of the type.
+  struct Nested {
+    // Qualified lookup should remain as-is.
+    public func qualifiedFoo(_ key: ExplicitStruct.CodingKeys) {}
+    internal func qualifiedBar(_ key: ExplicitStruct.CodingKeys) {}
+    fileprivate func qualfiedBaz(_ key: ExplicitStruct.CodingKeys) {}
+    private func qualifiedQux(_ key: ExplicitStruct.CodingKeys) {}
+
+    // Unqualified lookups should find the ExplicitStruct's synthesized
+    // CodingKeys type instead of the top-level type above.
+    public func unqualifiedFoo(_ key: CodingKeys) {
+      print(CodingKeys.a) // Not found on top-level.
+    }
+
+    internal func unqualifiedBar(_ key: CodingKeys) {
+      print(CodingKeys.a) // Not found on top-level.
+    }
+
+    fileprivate func unqualifiedBaz(_ key: CodingKeys) {
+      print(CodingKeys.a) // Not found on top-level.
+    }
+
+    private func unqualifiedQux(_ key: CodingKeys) {
+      print(CodingKeys.a) // Not found on top-level.
+    }
+
+    // Unqualified lookups should find the most local CodingKeys type available.
+    public func nestedUnqualifiedFoo(_ key: CodingKeys) {
+      enum CodingKeys : String, CodingKey {
+        case nested
+      }
+
+      // CodingKeys should refer to the local unqualified enum.
+      func foo(_ key: CodingKeys) {
+        print(CodingKeys.nested) // Not found on synthesized type or top-level type.
+      }
+
+      foo(CodingKeys.nested)
+    }
+
+    internal func nestedUnqualifiedBar(_ key: CodingKeys) {
+      enum CodingKeys : String, CodingKey {
+        case nested
+      }
+
+      // CodingKeys should refer to the local unqualified enum.
+      func bar(_ key: CodingKeys) {
+        print(CodingKeys.nested) // Not found on synthesized type or top-level type.
+      }
+
+      bar(CodingKeys.nested)
+    }
+
+    fileprivate func nestedUnqualifiedBaz(_ key: CodingKeys) {
+      enum CodingKeys : String, CodingKey {
+        case nested
+      }
+
+      // CodingKeys should refer to the local unqualified enum.
+      func baz(_ key: CodingKeys) {
+        print(CodingKeys.nested) // Not found on synthesized type or top-level type.
+      }
+
+      baz(CodingKeys.nested)
+    }
+
+    private func nestedUnqualifiedQux(_ key: CodingKeys) {
+      enum CodingKeys : String, CodingKey {
+        case nested
+      }
+
+      // CodingKeys should refer to the local unqualified enum.
+      func qux(_ key: CodingKeys) {
+        print(CodingKeys.nested) // Not found on synthesized type or top-level type.
+      }
+
+      qux(CodingKeys.nested)
+    }
+  }
+}
+
+// MARK: - CodingKeys Enums in Extensions
+
+// Structs which get a CodingKeys type in an extension should be able to see
+// that type during member type lookup.
+struct ExtendedStruct : Codable {
+  let value: String = "foo"
+
+  // Don't get an auto-synthesized type.
+  init(from decoder: Decoder) throws {}
+  func encode(to encoder: Encoder) throws {}
+
+  // Qualified type lookup should always be unambiguous.
+  public func qualifiedFoo(_ key: ExtendedStruct.CodingKeys) {}
+  internal func qualifiedBar(_ key: ExtendedStruct.CodingKeys) {}
+  fileprivate func qualfiedBaz(_ key: ExtendedStruct.CodingKeys) {}
+  private func qualifiedQux(_ key: ExtendedStruct.CodingKeys) {}
+
+  // Unqualified lookups should find the synthesized CodingKeys type instead
+  // of the top-level type above.
+  public func unqualifiedFoo(_ key: CodingKeys) {
+    print(CodingKeys.a) // Not found on top-level.
+  }
+
+  internal func unqualifiedBar(_ key: CodingKeys) {
+    print(CodingKeys.a) // Not found on top-level.
+  }
+
+  fileprivate func unqualifiedBaz(_ key: CodingKeys) {
+    print(CodingKeys.a) // Not found on top-level.
+  }
+
+  private func unqualifiedQux(_ key: CodingKeys) {
+    print(CodingKeys.a) // Not found on top-level.
+  }
+
+  // Unqualified lookups should find the most local CodingKeys type available.
+  public func nestedUnqualifiedFoo(_ key: CodingKeys) {
+    enum CodingKeys : String, CodingKey {
+      case nested
+    }
+
+    // CodingKeys should refer to the local unqualified enum.
+    func foo(_ key: CodingKeys) {
+      print(CodingKeys.nested) // Not found on synthesized type or top-level type.
+    }
+
+    foo(CodingKeys.nested)
+  }
+
+  internal func nestedUnqualifiedBar(_ key: CodingKeys) {
+    enum CodingKeys : String, CodingKey {
+      case nested
+    }
+
+    // CodingKeys should refer to the local unqualified enum.
+    func bar(_ key: CodingKeys) {
+      print(CodingKeys.nested) // Not found on synthesized type or top-level type.
+    }
+
+    bar(CodingKeys.nested)
+  }
+
+  fileprivate func nestedUnqualifiedBaz(_ key: CodingKeys) {
+    enum CodingKeys : String, CodingKey {
+      case nested
+    }
+
+    // CodingKeys should refer to the local unqualified enum.
+    func baz(_ key: CodingKeys) {
+      print(CodingKeys.nested) // Not found on synthesized type or top-level type.
+    }
+
+    baz(CodingKeys.nested)
+  }
+
+  private func nestedUnqualifiedQux(_ key: CodingKeys) {
+    enum CodingKeys : String, CodingKey {
+      case nested
+    }
+
+    // CodingKeys should refer to the local unqualified enum.
+    func qux(_ key: CodingKeys) {
+      print(CodingKeys.nested) // Not found on synthesized type or top-level type.
+    }
+
+    qux(CodingKeys.nested)
+  }
+
+  // Lookup within nested types should look outside of the type.
+  struct Nested {
+    // Qualified lookup should remain as-is.
+    public func qualifiedFoo(_ key: ExtendedStruct.CodingKeys) {}
+    internal func qualifiedBar(_ key: ExtendedStruct.CodingKeys) {}
+    fileprivate func qualfiedBaz(_ key: ExtendedStruct.CodingKeys) {}
+    private func qualifiedQux(_ key: ExtendedStruct.CodingKeys) {}
+
+    // Unqualified lookups should find the ExtendedStruct's synthesized
+    // CodingKeys type instead of the top-level type above.
+    public func unqualifiedFoo(_ key: CodingKeys) {
+      print(CodingKeys.a) // Not found on top-level.
+    }
+
+    internal func unqualifiedBar(_ key: CodingKeys) {
+      print(CodingKeys.a) // Not found on top-level.
+    }
+
+    fileprivate func unqualifiedBaz(_ key: CodingKeys) {
+      print(CodingKeys.a) // Not found on top-level.
+    }
+
+    private func unqualifiedQux(_ key: CodingKeys) {
+      print(CodingKeys.a) // Not found on top-level.
+    }
+
+    // Unqualified lookups should find the most local CodingKeys type available.
+    public func nestedUnqualifiedFoo(_ key: CodingKeys) {
+      enum CodingKeys : String, CodingKey {
+        case nested
+      }
+
+      // CodingKeys should refer to the local unqualified enum.
+      func foo(_ key: CodingKeys) {
+        print(CodingKeys.nested) // Not found on synthesized type or top-level type.
+      }
+
+      foo(CodingKeys.nested)
+    }
+
+    internal func nestedUnqualifiedBar(_ key: CodingKeys) {
+      enum CodingKeys : String, CodingKey {
+        case nested
+      }
+
+      // CodingKeys should refer to the local unqualified enum.
+      func bar(_ key: CodingKeys) {
+        print(CodingKeys.nested) // Not found on synthesized type or top-level type.
+      }
+
+      bar(CodingKeys.nested)
+    }
+
+    fileprivate func nestedUnqualifiedBaz(_ key: CodingKeys) {
+      enum CodingKeys : String, CodingKey {
+        case nested
+      }
+
+      // CodingKeys should refer to the local unqualified enum.
+      func baz(_ key: CodingKeys) {
+        print(CodingKeys.nested) // Not found on synthesized type or top-level type.
+      }
+
+      baz(CodingKeys.nested)
+    }
+
+    private func nestedUnqualifiedQux(_ key: CodingKeys) {
+      enum CodingKeys : String, CodingKey {
+        case nested
+      }
+
+      // CodingKeys should refer to the local unqualified enum.
+      func qux(_ key: CodingKeys) {
+        print(CodingKeys.nested) // Not found on synthesized type or top-level type.
+      }
+
+      qux(CodingKeys.nested)
+    }
+  }
+}
+
+extension ExtendedStruct {
+  enum CodingKeys : String, CodingKey {
+    case a, b, c
+  }
+}
+
+struct A {
+  struct Inner : Codable {
+    var value: Int = 42
+
+    func foo() {
+      print(CodingKeys.value) // Not found on A.CodingKeys or top-level type.
+    }
+  }
+}
+
+extension A {
+  enum CodingKeys : String, CodingKey {
+    case a
+  }
+}
+
+struct B : Codable {
+  // So B conforms to Codable using CodingKeys.b below.
+  var b: Int = 0
+
+  struct Inner {
+    var value: Int = 42
+
+    func foo() {
+      print(CodingKeys.b) // Not found on top-level type.
+    }
+  }
+}
+
+extension B {
+  enum CodingKeys : String, CodingKey {
+    case b
+  }
+}
+
+struct C : Codable {
+  struct Inner : Codable {
+    var value: Int = 42
+
+    func foo() {
+      print(CodingKeys.value) // Not found on C.CodingKeys or top-level type.
+    }
+  }
+}
+
+extension C.Inner {
+  enum CodingKeys : String, CodingKey {
+    case value
+  }
+}


### PR DESCRIPTION
**What's in this pull request?**
Addresses [SR-5215](https://bugs.swift.org/browse/SR-5215).

Some types and members are synthesized by derived protocol conformances (e.g. the CodingKeys member type or init(from:)/encode(to:) members from Decodable/Encodable conformance) — however, they are not visible in AST lookup if they have not been synthesized.

Exposes a LazyResolver callback for performing member synthesis where relevant during qualified lookups to synthesize these members on demand when needed.

An alternative approach to #10723.