### PR TITLE
[swift-4.0-branch] [stdlib] Use minimal bits for stride for indices in String.UTF8View 

### DIFF
--- a/stdlib/public/core/StringIndex.swift
+++ b/stdlib/public/core/StringIndex.swift
@@ -72,7 +72,7 @@ extension String.Index {
     _cache = c
   }
   
-  internal static var _strideBits : Int { return 16 }
+  internal static var _strideBits : Int { return 2 }
   internal static var _mask : UInt64 { return (1 &<< _Self._strideBits) &- 1 }
   
   internal mutating func _setEncodedOffset(_ x: Int) {

--- a/test/stdlib/StringAPI.swift
+++ b/test/stdlib/StringAPI.swift
@@ -366,6 +366,21 @@ StringTests.test("[String].joined() -> String") {
   _ = s == "" // should compile without error
 }
 
+StringTests.test("Regression/rdar-33276845") {
+  // These two cases fail slightly differently when the code is broken
+  // See rdar://33276845
+  do {
+    let s = String(repeating: "x", count: 0xffff)
+    let a = Array(s.utf8)
+    expectNotEqual(0, a.count)
+  }
+  do {
+    let s = String(repeating: "x", count: 0x1_0010)
+    let a = Array(s.utf8)
+    expectNotEqual(0, a.count)
+  }
+}
+
 var CStringTests = TestSuite("CStringTests")
 
 func getNullUTF8() -> UnsafeMutablePointer<UInt8>? {


### PR DESCRIPTION
Fixes <rdar://33276845>
