### PR TITLE
[4.0] [stdlib] Surface NSKeyedArchiver issues in Xcode

### DIFF
--- a/include/swift/Runtime/Debug.h
+++ b/include/swift/Runtime/Debug.h
@@ -207,8 +207,13 @@ enum: uintptr_t {
 
 /// Debugger hook. Calling this stops the debugger with a message and details
 /// about the issues.
-void reportToDebugger(uintptr_t flags, const char *message,
-                      RuntimeErrorDetails *details = nullptr);
+///
+/// This is not considered a finalized runtime entry point at this time. Do not
+/// emit calls to it from arbitrary Swift code; it's only meant for libraries
+/// that ship with the runtime (i.e. the stdlib and overlays).
+SWIFT_RUNTIME_EXPORT
+void _swift_reportToDebugger(uintptr_t flags, const char *message,
+                             RuntimeErrorDetails *details = nullptr);
 
 SWIFT_RUNTIME_EXPORT
 bool _swift_reportFatalErrorsToDebugger;

--- a/stdlib/public/SDK/Foundation/CheckClass.mm
+++ b/stdlib/public/SDK/Foundation/CheckClass.mm
@@ -20,6 +20,9 @@ static bool isASCIIIdentifierChar(char c) {
   return false;
 }
 
+template <typename T, size_t N>
+static constexpr size_t arrayLength(T (&)[N]) { return N; }
+
 static void logIfFirstOccurrence(Class objcClass, void (^log)(void)) {
   static auto queue = dispatch_queue_create(
       "SwiftFoundation._checkClassAndWarnForKeyedArchivingQueue",
@@ -164,26 +167,52 @@ static StringRefLite findBaseName(StringRefLite demangledName) {
                                                       /*qualified*/true);
       NSString *demangledString = demangledName.newNSStringNoCopy();
       NSString *mangledString = NSStringFromClass(objcClass);
+
+      NSString *primaryMessage;
       switch (operation) {
       case 1:
-        NSLog(@"Attempting to unarchive generic Swift class '%@' with mangled "
-               "runtime name '%@'. Runtime names for generic classes are "
-               "unstable and may change in the future, leading to "
-               "non-decodable data.", demangledString, mangledString);
+        primaryMessage = [[NSString alloc] initWithFormat:
+            @"Attempting to unarchive generic Swift class '%@' with mangled "
+             "runtime name '%@'. Runtime names for generic classes are "
+             "unstable and may change in the future, leading to "
+             "non-decodable data.", demangledString, mangledString];
         break;
       default:
-        NSLog(@"Attempting to archive generic Swift class '%@' with mangled "
-               "runtime name '%@'. Runtime names for generic classes are "
-               "unstable and may change in the future, leading to "
-               "non-decodable data.", demangledString, mangledString);
+        primaryMessage = [[NSString alloc] initWithFormat:
+            @"Attempting to archive generic Swift class '%@' with mangled "
+             "runtime name '%@'. Runtime names for generic classes are "
+             "unstable and may change in the future, leading to "
+             "non-decodable data.", demangledString, mangledString];
         break;
       }
-      NSLog(@"To avoid this failure, create a concrete subclass and register "
-             "it with NSKeyedUnarchiver.setClass(_:forClassName:) instead, "
-             "using the name \"%@\".", mangledString);
-      NSLog(@"If you need to produce archives compatible with older versions "
-             "of your program, use NSKeyedArchiver.setClassName(_:for:) "
-             "as well.");
+      NSString *generatedNote = [[NSString alloc] initWithFormat:
+          @"To avoid this failure, create a concrete subclass and register "
+           "it with NSKeyedUnarchiver.setClass(_:forClassName:) instead, "
+           "using the name \"%@\".", mangledString];
+      const char *staticNote =
+          "If you need to produce archives compatible with older versions "
+          "of your program, use NSKeyedArchiver.setClassName(_:for:) as well.";
+
+      NSLog(@"%@", primaryMessage);
+      NSLog(@"%@", generatedNote);
+      NSLog(@"%s", staticNote);
+
+      RuntimeErrorDetails::Note notes[] = {
+        { [generatedNote UTF8String], /*numFixIts*/0, /*fixIts*/nullptr },
+        { staticNote, /*numFixIts*/0, /*fixIts*/nullptr },
+      };
+
+      RuntimeErrorDetails errorInfo = {};
+      errorInfo.version = RuntimeErrorDetails::currentVersion;
+      errorInfo.errorType = "nskeyedarchiver-incompatible-class";
+      errorInfo.notes = notes;
+      errorInfo.numNotes = arrayLength(notes);
+
+      _swift_reportToDebugger(RuntimeErrorFlagNone, [primaryMessage UTF8String],
+                              &errorInfo);
+
+      [primaryMessage release];
+      [generatedNote release];
       [demangledString release];
     });
     return 1;
@@ -196,23 +225,28 @@ static StringRefLite findBaseName(StringRefLite demangledName) {
     StringRefLite demangledName = swift_getTypeName(theClass,/*qualified*/true);
     NSString *demangledString = demangledName.newNSStringNoCopy();
     NSString *mangledString = NSStringFromClass(objcClass);
+
+    NSString *primaryMessage;
     switch (operation) {
     case 1:
-      NSLog(@"Attempting to unarchive Swift class '%@' with mangled runtime "
-             "name '%@'. The runtime name for this class is unstable and may "
-             "change in the future, leading to non-decodable data.",
-             demangledString, mangledString);
+      primaryMessage = [[NSString alloc] initWithFormat:
+          @"Attempting to unarchive Swift class '%@' with mangled runtime "
+           "name '%@'. The runtime name for this class is unstable and may "
+           "change in the future, leading to non-decodable data.",
+          demangledString, mangledString];
       break;
     default:
-      NSLog(@"Attempting to archive Swift class '%@' with mangled runtime "
-             "name '%@'. The runtime name for this class is unstable and may "
-             "change in the future, leading to non-decodable data.",
-             demangledString, mangledString);
+      primaryMessage = [[NSString alloc] initWithFormat:
+          @"Attempting to archive Swift class '%@' with mangled runtime "
+           "name '%@'. The runtime name for this class is unstable and may "
+           "change in the future, leading to non-decodable data.",
+          demangledString, mangledString];
       break;
     }
-    [demangledString release];
-    NSLog(@"You can use the 'objc' attribute to ensure that the name will not "
-           "change: \"@objc(%@)\"", mangledString);
+
+    NSString *firstNote = [[NSString alloc] initWithFormat:
+        @"You can use the 'objc' attribute to ensure that the name will not "
+         "change: \"@objc(%@)\"", mangledString];
 
     StringRefLite baseName = findBaseName(demangledName);
     // Offer a more generic message if the base name we found doesn't look like
@@ -222,9 +256,35 @@ static StringRefLite findBaseName(StringRefLite demangledName) {
       baseName = "MyModel";
     }
 
-    NSLog(@"If there are no existing archives containing this class, you "
-           "should choose a unique, prefixed name instead: "
-           "\"@objc(ABC%1$.*2$s)\"", baseName.data, (int)baseName.length);
+    NSString *secondNote = [[NSString alloc] initWithFormat:
+        @"If there are no existing archives containing this class, you should "
+         "choose a unique, prefixed name instead: \"@objc(ABC%1$.*2$s)\"",
+        baseName.data, (int)baseName.length];
+
+    NSLog(@"%@", primaryMessage);
+    NSLog(@"%@", firstNote);
+    NSLog(@"%@", secondNote);
+
+    // FIXME: We could suggest these as fix-its if we had source locations for
+    // the class.
+    RuntimeErrorDetails::Note notes[] = {
+      { [firstNote UTF8String], /*numFixIts*/0, /*fixIts*/nullptr },
+      { [secondNote UTF8String], /*numFixIts*/0, /*fixIts*/nullptr },
+    };
+
+    RuntimeErrorDetails errorInfo = {};
+    errorInfo.version = RuntimeErrorDetails::currentVersion;
+    errorInfo.errorType = "nskeyedarchiver-incompatible-class";
+    errorInfo.notes = notes;
+    errorInfo.numNotes = arrayLength(notes);
+
+    _swift_reportToDebugger(RuntimeErrorFlagNone, [primaryMessage UTF8String],
+                            &errorInfo);
+
+    [primaryMessage release];
+    [firstNote release];
+    [secondNote release];
+    [demangledString release];
   });
   return 2;
 }

--- a/stdlib/public/runtime/Errors.cpp
+++ b/stdlib/public/runtime/Errors.cpp
@@ -252,8 +252,8 @@ void _swift_runtime_on_report(uintptr_t flags, const char *message,
                );
 }
 
-void swift::reportToDebugger(uintptr_t flags, const char *message,
-                             RuntimeErrorDetails *details) {
+void swift::_swift_reportToDebugger(uintptr_t flags, const char *message,
+                                    RuntimeErrorDetails *details) {
   _swift_runtime_on_report(flags, message, details);
 }
 

--- a/stdlib/public/runtime/Exclusivity.cpp
+++ b/stdlib/public/runtime/Exclusivity.cpp
@@ -124,7 +124,7 @@ static void reportExclusivityConflict(ExclusivityFlags oldAction, void *oldPC,
   uintptr_t flags = RuntimeErrorFlagNone;
   if (!keepGoing)
     flags = RuntimeErrorFlagFatal;
-  reportToDebugger(flags, message, &details);
+  _swift_reportToDebugger(flags, message, &details);
 
   if (keepGoing) {
     return;

--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -1458,7 +1458,7 @@ void swift_objc_swift3ImplicitObjCEntrypoint(id self, SEL selector,
   uintptr_t runtime_error_flags = RuntimeErrorFlagNone;
   if (reporter == swift::fatalError)
     runtime_error_flags = RuntimeErrorFlagFatal;
-  reportToDebugger(runtime_error_flags, message, &details);
+  _swift_reportToDebugger(runtime_error_flags, message, &details);
 
   reporter(flags,
            "*** %s:%zu:%zu: %s; add explicit '@objc' to the declaration to "

--- a/stdlib/public/stubs/Assert.cpp
+++ b/stdlib/public/stubs/Assert.cpp
@@ -65,7 +65,7 @@ static void logPrefixAndMessageToDebugger(
   } else {
     swift_asprintf(&debuggerMessage, "%.*s", prefixLength, prefix);
   }
-  reportToDebugger(RuntimeErrorFlagFatal, debuggerMessage);
+  _swift_reportToDebugger(RuntimeErrorFlagFatal, debuggerMessage);
   free(debuggerMessage);
 }
 


### PR DESCRIPTION
- **Explanation**: An improvement on top of #10431 to not just log but actually generate "run-time issues" in Xcode when the developer tries to archive a class with a mangled name using NSKeyedArchiver.
- **Scope**: Affects classes that conform to NSCoding that do not have "simple" mangled names, if they are actually archived or unarchived.
- **Issue**: rdar://problem/32900735
- **Reviewed by**: @DougGregor, @kubamracek, @itaiferber
- **Risk**: Low. Calling an existing entry point that has already been used for other things.
- **Testing**: Used a custom-built Swift to build an app and verified that the issue shows up in Xcode.