### PR TITLE
[Foundation] replaceSubrange in the cases of immutable and mutable backing stores should recalculate length per the reference backing store change and not the length of the replacement

### DIFF
--- a/stdlib/public/SDK/Foundation/Data.swift
+++ b/stdlib/public/SDK/Foundation/Data.swift
@@ -480,12 +480,12 @@ public final class _DataStorage {
             let data = d.mutableCopy() as! NSMutableData
             data.replaceBytes(in: range, withBytes: replacementBytes, length: replacementLength)
             _backing = .mutable(data)
-            _length = replacementLength
+            _length = data.length
             _bytes = data.mutableBytes
         case .mutable(let d):
             d.replaceBytes(in: range, withBytes: replacementBytes, length: replacementLength)
             _backing = .mutable(d)
-            _length = replacementLength
+            _length = d.length
             _bytes = d.mutableBytes
         case .customReference(let d):
             let data = d.mutableCopy() as! NSMutableData

--- a/test/stdlib/TestData.swift
+++ b/test/stdlib/TestData.swift
@@ -1179,6 +1179,35 @@ class TestData : TestDataSuper {
         let expected = Data(bytes: [9, 8, 7, 6, 5, 4, 3, 2, 1])
         expectEqual(expected, reversedData)
     }
+
+    func test_replaceSubrangeReferencingMutable() {
+        let mdataObj = NSMutableData(bytes: [0x01, 0x02, 0x03, 0x04], length: 4)
+        var data = Data(referencing: mdataObj)
+        let expected = data.count
+        data.replaceSubrange(4 ..< 4, with: Data(bytes: []))
+        expectEqual(expected, data.count)
+        data.replaceSubrange(4 ..< 4, with: Data(bytes: []))
+        expectEqual(expected, data.count)
+    }
+
+    func test_replaceSubrangeReferencingImmutable() {
+        let dataObj = NSData(bytes: [0x01, 0x02, 0x03, 0x04], length: 4)
+        var data = Data(referencing: dataObj)
+        let expected = data.count
+        data.replaceSubrange(4 ..< 4, with: Data(bytes: []))
+        expectEqual(expected, data.count)
+        data.replaceSubrange(4 ..< 4, with: Data(bytes: []))
+        expectEqual(expected, data.count)
+    }
+
+    func test_replaceSubrangeFromBridged() {
+        var data = NSData(bytes: [0x01, 0x02, 0x03, 0x04], length: 4) as Data
+        let expected = data.count
+        data.replaceSubrange(4 ..< 4, with: Data(bytes: []))
+        expectEqual(expected, data.count)
+        data.replaceSubrange(4 ..< 4, with: Data(bytes: []))
+        expectEqual(expected, data.count)
+    }
 }
 
 #if !FOUNDATION_XCTEST
@@ -1243,6 +1272,9 @@ DataTests.test("test_sliceOfSliceViaRangeExpression") { TestData().test_sliceOfS
 DataTests.test("test_appendingSlices") { TestData().test_appendingSlices() }
 DataTests.test("test_sequenceInitializers") { TestData().test_sequenceInitializers() }
 DataTests.test("test_reversedDataInit") { TestData().test_reversedDataInit() }
+DataTests.test("test_replaceSubrangeReferencingMutable") { TestData().test_replaceSubrangeReferencingMutable() }
+DataTests.test("test_replaceSubrangeReferencingImmutable") { TestData().test_replaceSubrangeReferencingImmutable() }
+DataTests.test("test_replaceSubrangeFromBridged") { TestData().test_replaceSubrangeFromBridged() }
 
 
 // XCTest does not have a crash detection, whereas lit does


### PR DESCRIPTION
Explanation:
This addresses a failure in Data.replaceSubrange that would inappropriately funnel to a replacement method on backing stores that encompass objective-c stores for either mutable or immutable backing where the length would not be re-calculated per the backing store's length but instead be the replacement region length.

Scope:
This only applies to runtime behavior of the Data.replaceSubrange family of functions

Radar (and possibly SR Issue):
rdar://problem/33098202
https://bugs.swift.org/browse/SR-5449

Risk:
Medium to low risk; the swift backing store appropriately handles most cases but in the cases of bridged Data from objective-c the calculation was clearly incorrect. No one should be relying on this behavior.

Testing:
Additional unit tests were added to validate the correctness of this patch.
