### PR TITLE
Some convenience apis

### DIFF
--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -476,6 +476,14 @@ public:
         getSILDebugLocation(Loc), text.toStringRef(Out), encoding, F));
   }
 
+  LoadInst *createTrivialLoadOr(SILLocation Loc, SILValue LV,
+                                LoadOwnershipQualifier Qualifier) {
+    if (LV->getType().isTrivial(getModule())) {
+      return createLoad(Loc, LV, LoadOwnershipQualifier::Trivial);
+    }
+    return createLoad(Loc, LV, Qualifier);
+  }
+
   LoadInst *createLoad(SILLocation Loc, SILValue LV,
                        LoadOwnershipQualifier Qualifier) {
     assert((Qualifier != LoadOwnershipQualifier::Unqualified) ||
@@ -517,6 +525,17 @@ public:
   BeginBorrowInst *createBeginBorrow(SILLocation Loc, SILValue LV) {
     return insert(new (F.getModule())
                       BeginBorrowInst(getSILDebugLocation(Loc), LV));
+  }
+
+  /// Utility function that returns a trivial store if the stored type is
+  /// trivial and a \p Qualifier store if the stored type is non-trivial.
+  StoreInst *createTrivialStoreOr(SILLocation Loc, SILValue Src,
+                                  SILValue DestAddr,
+                                  StoreOwnershipQualifier Qualifier) {
+    if (Src->getType().isTrivial(getModule())) {
+      return createStore(Loc, Src, DestAddr, StoreOwnershipQualifier::Trivial);
+    }
+    return createStore(Loc, Src, DestAddr, Qualifier);
   }
 
   StoreInst *createStore(SILLocation Loc, SILValue Src, SILValue DestAddr,

--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -198,6 +198,9 @@ public:
   /// otherwise.
   inline Operand *getSingleUse() const;
 
+  template <class T>
+  inline T *getSingleUserOfType();
+
   /// Pretty-print the value.
   void dump() const;
   void print(raw_ostream &OS) const;
@@ -525,6 +528,19 @@ inline Operand *ValueBase::getSingleUse() const {
 
   // Otherwise, the element that we accessed.
   return Op;
+}
+
+template <class T>
+inline T *ValueBase::getSingleUserOfType() {
+  T *Result = nullptr;
+  for (auto *Op : getUses()) {
+    if (auto *Tmp = dyn_cast<T>(Op->getUser())) {
+      if (Result)
+        return nullptr;
+      Result = Tmp;
+    }
+  }
+  return Result;
 }
 
 /// A constant-size list of the operands of an instruction.


### PR DESCRIPTION
This PR contains two convenience APIs:

1. ValueBase::getSingleUserOfType. Using this API one can find the only user that has a specific instruction type, rather than doing it by hand. I.e.:

```
auto *PBI = I->getSingleUserOfType<ProjectBoxInst>();
```

2. createTrivial{Load,Store}Or. These work by allowing one to pass in the appropriate ownership qualifier for a non-trivial type and if you actually have a trivial type, swap in the trivial ownership qualifier.