### PR TITLE
[interface-gen] Support passing Swift compiler arguments for header file interface generation

### DIFF
--- a/test/SourceKit/InterfaceGen/gen_header_swift_args.swift
+++ b/test/SourceKit/InterfaceGen/gen_header_swift_args.swift
@@ -1,5 +1,5 @@
 // REQUIRES: objc_interop
-// RUN: %sourcekitd-test -req=interface-gen -are-swift-args -header %S/Inputs/header.h -- %s -enable-objc-interop -import-objc-header %S/Inputs/header.h > %t.response
+// RUN: %sourcekitd-test -req=interface-gen -using-swift-args -header %S/Inputs/header.h -- %s -enable-objc-interop -import-objc-header %S/Inputs/header.h > %t.response
 // RUN: diff -u %S/gen_header.swift.response %t.response
 
 doSomethingInHead(1)

--- a/test/SourceKit/InterfaceGen/gen_header_swift_args.swift
+++ b/test/SourceKit/InterfaceGen/gen_header_swift_args.swift
@@ -1,0 +1,5 @@
+// REQUIRES: objc_interop
+// RUN: %sourcekitd-test -req=interface-gen -are-swift-args -header %S/Inputs/header.h -- %s -enable-objc-interop -import-objc-header %S/Inputs/header.h > %t.response
+// RUN: diff -u %S/gen_header.swift.response %t.response
+
+doSomethingInHead(1)

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -445,6 +445,7 @@ public:
                                          StringRef Name,
                                          StringRef HeaderName,
                                          ArrayRef<const char *> Args,
+                                         bool AreSwiftArgs,
                                          bool SynthesizedExtensions,
                                          Optional<unsigned> swiftVersion) = 0;
 

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -445,7 +445,7 @@ public:
                                          StringRef Name,
                                          StringRef HeaderName,
                                          ArrayRef<const char *> Args,
-                                         bool AreSwiftArgs,
+                                         bool UsingSwiftArgs,
                                          bool SynthesizedExtensions,
                                          Optional<unsigned> swiftVersion) = 0;
 

--- a/tools/SourceKit/include/SourceKit/Core/ProtocolUIDs.def
+++ b/tools/SourceKit/include/SourceKit/Core/ProtocolUIDs.def
@@ -110,7 +110,7 @@ KEY(EnableDiagnostics, "key.enablediagnostics")
 KEY(GroupName, "key.groupname")
 KEY(ActionName, "key.actionname")
 KEY(SynthesizedExtension, "key.synthesizedextensions")
-KEY(AreSwiftArgs, "key.areswiftargs")
+KEY(UsingSwiftArgs, "key.usingswiftargs")
 
 KEY(Names, "key.names")
 KEY(UIDs, "key.uids")

--- a/tools/SourceKit/include/SourceKit/Core/ProtocolUIDs.def
+++ b/tools/SourceKit/include/SourceKit/Core/ProtocolUIDs.def
@@ -110,6 +110,7 @@ KEY(EnableDiagnostics, "key.enablediagnostics")
 KEY(GroupName, "key.groupname")
 KEY(ActionName, "key.actionname")
 KEY(SynthesizedExtension, "key.synthesizedextensions")
+KEY(AreSwiftArgs, "key.areswiftargs")
 
 KEY(Names, "key.names")
 KEY(UIDs, "key.uids")

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
@@ -801,6 +801,7 @@ void SwiftLangSupport::editorOpenHeaderInterface(EditorConsumer &Consumer,
                                                  StringRef Name,
                                                  StringRef HeaderName,
                                                  ArrayRef<const char *> Args,
+                                                 bool AreSwiftArgs,
                                                  bool SynthesizedExtensions,
                                               Optional<unsigned> swiftVersion) {
   CompilerInstance CI;
@@ -810,13 +811,15 @@ void SwiftLangSupport::editorOpenHeaderInterface(EditorConsumer &Consumer,
 
   CompilerInvocation Invocation;
   std::string Error;
-  if (getASTManager().initCompilerInvocation(Invocation, llvm::None, CI.getDiags(),
+
+  ArrayRef<const char *> SwiftArgs = AreSwiftArgs ? Args : llvm::None;
+  if (getASTManager().initCompilerInvocation(Invocation, SwiftArgs, CI.getDiags(),
                                              StringRef(), Error)) {
     Consumer.handleRequestError(Error.c_str());
     return;
   }
 
-  if (initInvocationByClangArguments(Args, Invocation, Error)) {
+  if (!AreSwiftArgs && initInvocationByClangArguments(Args, Invocation, Error)) {
     Consumer.handleRequestError(Error.c_str());
     return;
   }

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
@@ -801,7 +801,7 @@ void SwiftLangSupport::editorOpenHeaderInterface(EditorConsumer &Consumer,
                                                  StringRef Name,
                                                  StringRef HeaderName,
                                                  ArrayRef<const char *> Args,
-                                                 bool AreSwiftArgs,
+                                                 bool UsingSwiftArgs,
                                                  bool SynthesizedExtensions,
                                               Optional<unsigned> swiftVersion) {
   CompilerInstance CI;
@@ -812,14 +812,14 @@ void SwiftLangSupport::editorOpenHeaderInterface(EditorConsumer &Consumer,
   CompilerInvocation Invocation;
   std::string Error;
 
-  ArrayRef<const char *> SwiftArgs = AreSwiftArgs ? Args : llvm::None;
+  ArrayRef<const char *> SwiftArgs = UsingSwiftArgs ? Args : llvm::None;
   if (getASTManager().initCompilerInvocation(Invocation, SwiftArgs, CI.getDiags(),
                                              StringRef(), Error)) {
     Consumer.handleRequestError(Error.c_str());
     return;
   }
 
-  if (!AreSwiftArgs && initInvocationByClangArguments(Args, Invocation, Error)) {
+  if (!UsingSwiftArgs && initInvocationByClangArguments(Args, Invocation, Error)) {
     Consumer.handleRequestError(Error.c_str());
     return;
   }

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -358,6 +358,7 @@ public:
                                  StringRef Name,
                                  StringRef HeaderName,
                                  ArrayRef<const char *> Args,
+                                 bool AreSwiftArgs,
                                  bool SynthesizedExtensions,
                                  Optional<unsigned> swiftVersion) override;
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -358,7 +358,7 @@ public:
                                  StringRef Name,
                                  StringRef HeaderName,
                                  ArrayRef<const char *> Args,
-                                 bool AreSwiftArgs,
+                                 bool UsingSwiftArgs,
                                  bool SynthesizedExtensions,
                                  Optional<unsigned> swiftVersion) override;
 

--- a/tools/SourceKit/tools/sourcekitd-test/Options.td
+++ b/tools/SourceKit/tools/sourcekitd-test/Options.td
@@ -32,6 +32,9 @@ def line : Separate<["-"], "line">,
   HelpText<"line">;
 def line_EQ : Joined<["-"], "line=">, Alias<line>;
 
+def are_swift_args : Flag<["-"], "are-swift-args">,
+  HelpText<"Interpret the compiler arguments as Swift compiler arguments">;
+
 def replace : Separate<["-"], "replace">,
   HelpText<"replace text ('text')">;
 def replace_EQ : Joined<["-"], "replace=">, Alias<replace>;

--- a/tools/SourceKit/tools/sourcekitd-test/Options.td
+++ b/tools/SourceKit/tools/sourcekitd-test/Options.td
@@ -32,7 +32,7 @@ def line : Separate<["-"], "line">,
   HelpText<"line">;
 def line_EQ : Joined<["-"], "line=">, Alias<line>;
 
-def are_swift_args : Flag<["-"], "are-swift-args">,
+def using_swift_args : Flag<["-"], "using-swift-args">,
   HelpText<"Interpret the compiler arguments as Swift compiler arguments">;
 
 def replace : Separate<["-"], "replace">,

--- a/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
@@ -179,8 +179,8 @@ bool TestOptions::parseArgs(llvm::ArrayRef<const char *> Args) {
       break;
     }
 
-    case OPT_are_swift_args: {
-      AreSwiftArgs = true;
+    case OPT_using_swift_args: {
+      UsingSwiftArgs = true;
       break;
     }
 

--- a/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
@@ -179,6 +179,11 @@ bool TestOptions::parseArgs(llvm::ArrayRef<const char *> Args) {
       break;
     }
 
+    case OPT_are_swift_args: {
+      AreSwiftArgs = true;
+      break;
+    }
+
       case OPT_swift_version: {
         unsigned ver;
         if (StringRef(InputArg->getValue()).getAsInteger(10, ver)) {

--- a/tools/SourceKit/tools/sourcekitd-test/TestOptions.h
+++ b/tools/SourceKit/tools/sourcekitd-test/TestOptions.h
@@ -77,6 +77,7 @@ struct TestOptions {
   std::string CachePath;
   llvm::SmallVector<std::string, 4> RequestOptions;
   llvm::ArrayRef<const char *> CompilerArgs;
+  bool AreSwiftArgs;
   std::string USR;
   std::string SwiftName;
   std::string ObjCName;

--- a/tools/SourceKit/tools/sourcekitd-test/TestOptions.h
+++ b/tools/SourceKit/tools/sourcekitd-test/TestOptions.h
@@ -77,7 +77,7 @@ struct TestOptions {
   std::string CachePath;
   llvm::SmallVector<std::string, 4> RequestOptions;
   llvm::ArrayRef<const char *> CompilerArgs;
-  bool AreSwiftArgs;
+  bool UsingSwiftArgs;
   std::string USR;
   std::string SwiftName;
   std::string ObjCName;

--- a/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
@@ -580,6 +580,8 @@ static int handleTestInvocation(ArrayRef<const char *> Args,
       sourcekitd_request_dictionary_set_uid(Req, KeyRequest,
                                             RequestEditorOpenSwiftSourceInterface);
     } else {
+      if (Opts.AreSwiftArgs)
+          sourcekitd_request_dictionary_set_int64(Req, KeyAreSwiftArgs, true);
       sourcekitd_request_dictionary_set_uid(Req, KeyRequest,
                                             RequestEditorOpenHeaderInterface);
     }

--- a/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
@@ -580,8 +580,8 @@ static int handleTestInvocation(ArrayRef<const char *> Args,
       sourcekitd_request_dictionary_set_uid(Req, KeyRequest,
                                             RequestEditorOpenSwiftSourceInterface);
     } else {
-      if (Opts.AreSwiftArgs)
-          sourcekitd_request_dictionary_set_int64(Req, KeyAreSwiftArgs, true);
+      if (Opts.UsingSwiftArgs)
+          sourcekitd_request_dictionary_set_int64(Req, KeyUsingSwiftArgs, true);
       sourcekitd_request_dictionary_set_uid(Req, KeyRequest,
                                             RequestEditorOpenHeaderInterface);
     }

--- a/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
@@ -163,6 +163,7 @@ editorOpenInterface(StringRef Name, StringRef ModuleName,
 static sourcekitd_response_t
 editorOpenHeaderInterface(StringRef Name, StringRef HeaderName,
                           ArrayRef<const char *> Args,
+                          bool AreSwiftArgs,
                           bool SynthesizedExtensions,
                           Optional<unsigned> swiftVersion);
 
@@ -463,11 +464,13 @@ void handleRequestImpl(sourcekitd_object_t ReqObj, ResponseReceiver Rec) {
     int64_t SynthesizedExtension = false;
     Req.getInt64(KeySynthesizedExtension, SynthesizedExtension,
                  /*isOptional=*/true);
+    Optional<int64_t> AreSwiftArgs = Req.getOptionalInt64(KeyAreSwiftArgs);
     Optional<int64_t> swiftVerVal = Req.getOptionalInt64(KeySwiftVersion);
     Optional<unsigned> swiftVer;
     if (swiftVerVal.hasValue())
       swiftVer = *swiftVerVal;
     return Rec(editorOpenHeaderInterface(*Name, *HeaderName, Args,
+                                         AreSwiftArgs.getValueOr(false),
                                          SynthesizedExtension, swiftVer));
   }
 
@@ -1999,6 +2002,7 @@ static sourcekitd_response_t editorConvertMarkupToXML(StringRef Source) {
 static sourcekitd_response_t
 editorOpenHeaderInterface(StringRef Name, StringRef HeaderName,
                           ArrayRef<const char *> Args,
+                          bool AreSwiftArgs,
                           bool SynthesizedExtensions,
                           Optional<unsigned> swiftVersion) {
   SKEditorConsumer EditC(/*EnableSyntaxMap=*/true,
@@ -2006,7 +2010,7 @@ editorOpenHeaderInterface(StringRef Name, StringRef HeaderName,
                          /*EnableDiagnostics=*/false,
                          /*SyntacticOnly=*/false);
   LangSupport &Lang = getGlobalContext().getSwiftLangSupport();
-  Lang.editorOpenHeaderInterface(EditC, Name, HeaderName, Args,
+  Lang.editorOpenHeaderInterface(EditC, Name, HeaderName, Args, AreSwiftArgs,
                                  SynthesizedExtensions, swiftVersion);
   return EditC.createResponse();
 }

--- a/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
@@ -163,7 +163,7 @@ editorOpenInterface(StringRef Name, StringRef ModuleName,
 static sourcekitd_response_t
 editorOpenHeaderInterface(StringRef Name, StringRef HeaderName,
                           ArrayRef<const char *> Args,
-                          bool AreSwiftArgs,
+                          bool UsingSwiftArgs,
                           bool SynthesizedExtensions,
                           Optional<unsigned> swiftVersion);
 
@@ -464,13 +464,13 @@ void handleRequestImpl(sourcekitd_object_t ReqObj, ResponseReceiver Rec) {
     int64_t SynthesizedExtension = false;
     Req.getInt64(KeySynthesizedExtension, SynthesizedExtension,
                  /*isOptional=*/true);
-    Optional<int64_t> AreSwiftArgs = Req.getOptionalInt64(KeyAreSwiftArgs);
+    Optional<int64_t> UsingSwiftArgs = Req.getOptionalInt64(KeyUsingSwiftArgs);
     Optional<int64_t> swiftVerVal = Req.getOptionalInt64(KeySwiftVersion);
     Optional<unsigned> swiftVer;
     if (swiftVerVal.hasValue())
       swiftVer = *swiftVerVal;
     return Rec(editorOpenHeaderInterface(*Name, *HeaderName, Args,
-                                         AreSwiftArgs.getValueOr(false),
+                                         UsingSwiftArgs.getValueOr(false),
                                          SynthesizedExtension, swiftVer));
   }
 
@@ -2002,7 +2002,7 @@ static sourcekitd_response_t editorConvertMarkupToXML(StringRef Source) {
 static sourcekitd_response_t
 editorOpenHeaderInterface(StringRef Name, StringRef HeaderName,
                           ArrayRef<const char *> Args,
-                          bool AreSwiftArgs,
+                          bool UsingSwiftArgs,
                           bool SynthesizedExtensions,
                           Optional<unsigned> swiftVersion) {
   SKEditorConsumer EditC(/*EnableSyntaxMap=*/true,
@@ -2010,7 +2010,7 @@ editorOpenHeaderInterface(StringRef Name, StringRef HeaderName,
                          /*EnableDiagnostics=*/false,
                          /*SyntacticOnly=*/false);
   LangSupport &Lang = getGlobalContext().getSwiftLangSupport();
-  Lang.editorOpenHeaderInterface(EditC, Name, HeaderName, Args, AreSwiftArgs,
+  Lang.editorOpenHeaderInterface(EditC, Name, HeaderName, Args, UsingSwiftArgs,
                                  SynthesizedExtensions, swiftVersion);
   return EditC.createResponse();
 }


### PR DESCRIPTION
<!-- What's in this pull request? -->
To support having Swift main files for ObjC header files included via the bridging header, add a flag to indicate whether the compiler arguments passed to interface generation for header files are Clang or Swift compiler arguments.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves rdar://problem/33249361.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->