### PR TITLE
[4.0] [ClangImporter] Don't import compatibility methods named 'print'.

### DIFF
--- a/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/APINotesFrameworkTest.apinotes
+++ b/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/APINotesFrameworkTest.apinotes
@@ -2,6 +2,31 @@ Name: APINotesFrameworkTest
 Classes:
   - Name: A
     SwiftObjCMembers: true
+  - Name: PrintingInterference
+    Methods:
+      - Selector: 'print:'
+        MethodKind: Instance
+        SwiftName: 'printDocument(_:)'
+  - Name: PrintingRenamed
+    Methods:
+      - Selector: 'print'
+        MethodKind: Instance
+        SwiftName: 'printDocument()'
+      - Selector: 'print:'
+        MethodKind: Instance
+        SwiftName: 'printDocument(_:)'
+      - Selector: 'print:options:'
+        MethodKind: Instance
+        SwiftName: 'printDocument(_:options:)'
+      - Selector: 'print'
+        MethodKind: Class
+        SwiftName: 'printDocument()'
+      - Selector: 'print:'
+        MethodKind: Class
+        SwiftName: 'printDocument(_:)'
+      - Selector: 'print:options:'
+        MethodKind: Class
+        SwiftName: 'printDocument(_:options:)'
   - Name: TestProperties
     Properties:
       - Name: accessorsOnly
@@ -43,6 +68,31 @@ Tags:
 SwiftVersions:
   - Version: 3.0
     Classes:
+      - Name: PrintingInterference
+        Methods:
+          - Selector: 'print:'
+            MethodKind: Instance
+            SwiftName: 'print(_:)'
+      - Name: PrintingRenamed
+        Methods:
+          - Selector: 'print'
+            MethodKind: Instance
+            SwiftName: 'print()'
+          - Selector: 'print:'
+            MethodKind: Instance
+            SwiftName: 'print(_:)'
+          - Selector: 'print:options:'
+            MethodKind: Instance
+            SwiftName: 'print(_:options:)'
+          - Selector: 'print'
+            MethodKind: Class
+            SwiftName: 'print()'
+          - Selector: 'print:'
+            MethodKind: Class
+            SwiftName: 'print(_:)'
+          - Selector: 'print:options:'
+            MethodKind: Class
+            SwiftName: 'print(_:options:)'
       - Name: TestProperties
         Methods:
           - Selector: accessorsOnlyRenamedRetyped

--- a/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/Classes.h
+++ b/test/APINotes/Inputs/custom-frameworks/APINotesFrameworkTest.framework/Headers/Classes.h
@@ -17,5 +17,20 @@
 @property (nullable) id importantInstanceProperty __attribute__((swift_name("finalInstanceProperty")));
 @end
 
+@interface PrintingRenamed : Base
+- (void)print;
+- (void)print:(id)thing;
+- (void)print:(id)thing options:(id)options;
+
++ (void)print;
++ (void)print:(id)thing;
++ (void)print:(id)thing options:(id)options;
+@end
+
+@interface PrintingInterference : Base
+- (void)print:(id)thing; // Only this one gets renamed.
+- (void)print:(id)thing extra:(id)options;
+@end
+
 #pragma clang assume_nonnull end
 #endif // __OBJC__

--- a/test/APINotes/versioned-objc.swift
+++ b/test/APINotes/versioned-objc.swift
@@ -140,4 +140,46 @@ func testRenamedProtocolMembers(obj: ProtoWithManyRenames) {
   // CHECK-DIAGS-4-NOT: :[[@LINE-1]]:{{[0-9]+}}:
 }
 
+extension PrintingRenamed {
+  func testDroppingRenamedPrints() {
+    // CHECK-DIAGS-3: [[@LINE+1]]:{{[0-9]+}}: warning: use of 'print' treated as a reference to instance method
+    print()
+    // CHECK-DIAGS-4-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+    // CHECK-DIAGS-3: [[@LINE+1]]:{{[0-9]+}}: warning: use of 'print' treated as a reference to instance method
+    print(self)
+    // CHECK-DIAGS-4-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+    // CHECK-DIAGS-3-NOT: [[@LINE+1]]:{{[0-9]+}}:
+    print(self, options: self)
+    // CHECK-DIAGS-4: [[@LINE-1]]:{{[0-9]+}}: error: argument labels '(_:, options:)' do not match any available overloads
+  }
+
+  static func testDroppingRenamedPrints() {
+    // CHECK-DIAGS-3: [[@LINE+1]]:{{[0-9]+}}: warning: use of 'print' treated as a reference to class method
+    print()
+    // CHECK-DIAGS-4-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+    // CHECK-DIAGS-3: [[@LINE+1]]:{{[0-9]+}}: warning: use of 'print' treated as a reference to class method
+    print(self)
+    // CHECK-DIAGS-4-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+    // CHECK-DIAGS-3-NOT: [[@LINE+1]]:{{[0-9]+}}:
+    print(self, options: self)
+    // CHECK-DIAGS-4: [[@LINE-1]]:{{[0-9]+}}: error: argument labels '(_:, options:)' do not match any available overloads
+  }
+}
+
+extension PrintingInterference {
+  func testDroppingRenamedPrints() {
+    // CHECK-DIAGS-3: [[@LINE+1]]:{{[0-9]+}}: warning: use of 'print' treated as a reference to instance method
+    print(self)
+    // CHECK-DIAGS-4: [[@LINE-1]]:{{[0-9]+}}: error: use of 'print' nearly matches global function 'print(_:separator:terminator:)' in module 'Swift' rather than instance method 'print(_:extra:)'
+
+    // CHECK-DIAGS-3-NOT: [[@LINE+1]]:{{[0-9]+}}:
+    print(self, extra: self)
+    // CHECK-DIAGS-4-NOT: [[@LINE-1]]:{{[0-9]+}}:
+  }
+}
+
 let unrelatedDiagnostic: Int = nil


### PR DESCRIPTION
- **Explanation**: NSDocument has a method named [`print(withSettings:​showPrintPanel:​delegate:​didPrint:​contextInfo:)`](https://developer.apple.com/documentation/appkit/nsdocument/1515058-print), as well as a method called [`printDocument(_:)`](https://developer.apple.com/documentation/appkit/nsdocument/1515154-printdocument?changes=latest_minor) that *used* to be called `print(_:)`. When someone tried to use Swift's top-level `print` function inside NSDocument, they got a message saying that the renamed one was unavailable. Normally we'd just look past it, but the presence of the still-valid longer name prevented the compiler from doing so. This patch just removes the "forwarding" declaration for the one that got renamed, which allows the type checker to do a better recovery and suggest `Swift.print`.
- **Scope**: Affects Objective-C methods that were once named `print` when imported into Swift but now aren't.
- **Issue**: rdar://problem/32839733
- **Reviewed by**: @milseman 
- **Risk**: Low. Only affects methods that were already going to be marked unavailable.
- **Testing**: Added regression tests, verified that the NSDocument case improved.