### PR TITLE
[Driver] Darwin: Link in the profile runtime archive first

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -553,6 +553,8 @@ class BuildScriptInvocation(object):
             # have a separate bot that checks for leaks.
             if platform.system() == 'Linux':
                 os.environ['ASAN_OPTIONS'] = 'detect_leaks=0'
+        if args.enable_ubsan:
+            impl_args += ["--enable-ubsan"]
 
         # If we have lsan, we need to export our suppression list. The actual
         # passing in of the LSAN flag is done via the normal cmake method. We

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -83,6 +83,7 @@ KNOWN_SETTINGS=(
     swiftpm-build-type          "Debug"          "the build variant for swiftpm"
     llbuild-enable-assertions   "1"              "enable assertions in llbuild"
     enable-asan                 ""               "enable Address Sanitizer"
+    enable-ubsan                ""               "enable Undefined Behavior Sanitizer"
     cmake                       ""               "path to the cmake binary"
     distcc                      ""               "use distcc in pump mode"
     distcc-pump                 ""               "the path to distcc pump executable. This argument is required if distcc is set."
@@ -1838,6 +1839,13 @@ function set_lldb_xcodebuild_options() {
 	    "${lldb_xcodebuild_options[@]}"
 	    ENABLE_ADDRESS_SANITIZER="YES"
 	    -enableAddressSanitizer=YES
+	)
+    fi
+    if [[ "${ENABLE_UBSAN}" ]] ; then
+	lldb_xcodebuild_options=(
+	    "${lldb_xcodebuild_options[@]}"
+	    ENABLE_UNDEFINED_BEHAVIOR_SANITIZER="YES"
+	    -enableUndefinedBehaviorSanitizer=YES
 	)
     fi
 }


### PR DESCRIPTION
While building a project with code coverage enabled, we can link in
dependencies which export a weak definition of __llvm_profile_filename.

After r306710, linking in the profiling runtime could pull in a weak
definition of this symbol from a dependency, instead of from within the
runtime's archive.

This inconsistency causes issues during API verification, and is also a
practical problem (the symbol would go missing were the dependent dylib
to be switched out). Introduce a LinkFirst runtime link option to make
sure we always search the profiling runtime for this symbol first.

See: https://reviews.llvm.org/D35385

rdar://problem/33271080