### PR TITLE
[4.0] SILGen: Project the referent type of property components in key paths.

### DIFF
--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2749,6 +2749,7 @@ RValue RValueEmitter::visitKeyPathExpr(KeyPathExpr *E, SGFContext C) {
       auto decl = cast<VarDecl>(component.getDeclRef().getDecl());
       auto oldBaseTy = baseTy;
       baseTy = baseTy->getTypeOfMember(SGF.SGM.SwiftModule, decl)
+        ->getReferenceStorageReferent()
         ->getCanonicalType();
       
       switch (auto strategy = decl->getAccessStrategy(AccessSemantics::Ordinary,

--- a/test/SILGen/keypaths.swift
+++ b/test/SILGen/keypaths.swift
@@ -209,3 +209,34 @@ func keyPathForOptional() {
   // CHECK-SAME:   stored_property #OptionalFields.x : $Optional<S<Int>>)
   _ = \OptionalFields2.y?.x
 }
+
+class StorageQualified {
+  weak var tooWeak: StorageQualified?
+  unowned var disowned: StorageQualified
+  
+  init() { fatalError() }
+}
+
+final class FinalStorageQualified {
+  weak var tooWeak: StorageQualified?
+  unowned var disowned: StorageQualified
+  
+  init() { fatalError() }
+}
+
+// CHECK-LABEL: sil hidden @{{.*}}keyPathForStorageQualified
+func keyPathForStorageQualified() {
+  // CHECK: = keypath $ReferenceWritableKeyPath<StorageQualified, Optional<StorageQualified>>,
+  // CHECK-SAME: settable_property $Optional<StorageQualified>, id #StorageQualified.tooWeak!getter.1
+  _ = \StorageQualified.tooWeak
+  // CHECK: = keypath $ReferenceWritableKeyPath<StorageQualified, StorageQualified>,
+  // CHECK-SAME: settable_property $StorageQualified, id #StorageQualified.disowned!getter.1
+  _ = \StorageQualified.disowned
+
+  // CHECK: = keypath $ReferenceWritableKeyPath<FinalStorageQualified, Optional<StorageQualified>>,
+  // CHECK-SAME: settable_property $Optional<StorageQualified>, id ##FinalStorageQualified.tooWeak
+  _ = \FinalStorageQualified.tooWeak
+  // CHECK: = keypath $ReferenceWritableKeyPath<FinalStorageQualified, StorageQualified>,
+  // CHECK-SAME: settable_property $StorageQualified, id ##FinalStorageQualified.disowned
+  _ = \FinalStorageQualified.disowned
+}


### PR DESCRIPTION
Explanation: The compiler would crash when a key path referred to a weak or unowned property.

Scope: Without this fix, key paths won't work with weak/unowned properties.

Issue: SR-5408 | rdar://problem/33215221

Risk: Low, one-line fix isolated to key paths.

Testing: Swift CI