### PR TITLE
[ClangImporter] Add direct access for import-as-member types.

### DIFF
--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -555,6 +555,18 @@ public:
     return nullptr;
   }
 
+  /// Directly look for a nested type declared within this module inside the
+  /// given nominal type (including any extensions).
+  ///
+  /// This is a fast-path hack to avoid circular dependencies in deserialization
+  /// and the Clang importer.
+  ///
+  /// Private and fileprivate types should not be returned by this lookup.
+  virtual TypeDecl *lookupNestedType(Identifier name,
+                                     const NominalTypeDecl *parent) const {
+    return nullptr;
+  }
+
   /// Find ValueDecls in the module and pass them to the given consumer object.
   ///
   /// This does a simple local lookup, not recursively looking through imports.

--- a/include/swift/ClangImporter/ClangModule.h
+++ b/include/swift/ClangImporter/ClangModule.h
@@ -62,6 +62,10 @@ public:
                            DeclName name, NLKind lookupKind,
                            SmallVectorImpl<ValueDecl*> &results) const override;
 
+  virtual TypeDecl *
+  lookupNestedType(Identifier name,
+                   const NominalTypeDecl *baseType) const override;
+
   virtual void lookupVisibleDecls(ModuleDecl::AccessPathTy accessPath,
                                   VisibleDeclConsumer &consumer,
                                   NLKind lookupKind) const override;

--- a/include/swift/Serialization/ModuleFile.h
+++ b/include/swift/Serialization/ModuleFile.h
@@ -603,7 +603,7 @@ public:
 
   /// Searches the module's nested type decls table for the given member of
   /// the given type.
-  TypeDecl *lookupNestedType(Identifier name, const ValueDecl *parent);
+  TypeDecl *lookupNestedType(Identifier name, const NominalTypeDecl *parent);
 
   /// Searches the module's operators for one with the given name and fixity.
   ///

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -132,6 +132,10 @@ public:
 
   virtual TypeDecl *lookupLocalType(StringRef MangledName) const override;
 
+  virtual TypeDecl *
+  lookupNestedType(Identifier name,
+                   const NominalTypeDecl *parent) const override;
+
   virtual OperatorDecl *lookupOperator(Identifier name,
                                        DeclKind fixity) const override;
 

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1180,7 +1180,8 @@ public:
                             VisibleDeclConsumer &consumer);
 
   /// Determine the effective Clang context for the given Swift nominal type.
-  EffectiveClangContext getEffectiveClangContext(NominalTypeDecl *nominal);
+  EffectiveClangContext
+  getEffectiveClangContext(const NominalTypeDecl *nominal);
 
   /// Attempts to import the name of \p decl with each possible
   /// ImportNameVersion. \p action will be called with each unique name.

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -1363,7 +1363,7 @@ TypeDecl *ModuleFile::lookupLocalType(StringRef MangledName) {
 }
 
 TypeDecl *ModuleFile::lookupNestedType(Identifier name,
-                                       const ValueDecl *parent) {
+                                       const NominalTypeDecl *parent) {
   PrettyStackTraceModuleFile stackEntry(*this);
 
   if (!NestedTypeDecls)

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -525,6 +525,12 @@ TypeDecl *SerializedASTFile::lookupLocalType(llvm::StringRef MangledName) const{
   return File.lookupLocalType(MangledName);
 }
 
+TypeDecl *
+SerializedASTFile::lookupNestedType(Identifier name,
+                                    const NominalTypeDecl *parent) const {
+  return File.lookupNestedType(name, parent);
+}
+
 OperatorDecl *SerializedASTFile::lookupOperator(Identifier name,
                                                 DeclKind fixity) const {
   return File.lookupOperator(name, fixity);

--- a/test/ClangImporter/Inputs/custom-modules/ImportAsMember.h
+++ b/test/ClangImporter/Inputs/custom-modules/ImportAsMember.h
@@ -57,4 +57,12 @@ extern void IAMStruct1SelfComesLast(double x, struct IAMStruct1 s)
 extern void IAMStruct1SelfComesThird(int a, float b, struct IAMStruct1 s, double x)
     __attribute__((swift_name("Struct1.selfComesThird(a:b:self:x:)")));
 
+
+struct IAMMultipleNested {
+  int value;
+};
+
+typedef int MNInnerInt __attribute__((swift_name("IAMMultipleNested.Inner")));
+typedef float MNInnerFloat __attribute__((swift_name("IAMMultipleNested.Inner")));
+
 #endif // IMPORT_AS_MEMBER_H

--- a/test/ClangImporter/Inputs/frameworks/ImportAsMemberSubmodules.framework/Headers/Actual.h
+++ b/test/ClangImporter/Inputs/frameworks/ImportAsMemberSubmodules.framework/Headers/Actual.h
@@ -1,3 +1,3 @@
-struct IAMOuter { int x; };
+struct IAMSOuter { int x; };
 
-struct IAMInner { int y; };
+struct IAMSInner { int y; };

--- a/test/ClangImporter/Inputs/frameworks/ImportAsMemberSubmodules.framework/Headers/Fwd.h
+++ b/test/ClangImporter/Inputs/frameworks/ImportAsMemberSubmodules.framework/Headers/Fwd.h
@@ -1,3 +1,3 @@
 // The order of these forward-declarations affects whether there was a bug.
-struct IAMOuter;
-struct IAMInner;
+struct IAMSOuter;
+struct IAMSInner;

--- a/test/ClangImporter/Inputs/frameworks/ImportAsMemberSubmodules.framework/Headers/ImportAsMemberSubmodules.apinotes
+++ b/test/ClangImporter/Inputs/frameworks/ImportAsMemberSubmodules.framework/Headers/ImportAsMemberSubmodules.apinotes
@@ -1,4 +1,4 @@
 Name: ImportAsMemberSubmodules
 Tags:
-- Name: IAMInner
-  SwiftName: IAMOuter.Inner
+- Name: IAMSInner
+  SwiftName: IAMSOuter.Inner

--- a/test/ClangImporter/import-as-member.swift
+++ b/test/ClangImporter/import-as-member.swift
@@ -1,5 +1,7 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -F %S/Inputs/frameworks %s -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -F %S/Inputs/frameworks -I %S/Inputs/custom-modules %s -verify
 
+import ImportAsMember
 import ImportAsMemberSubmodules
 
-let _: IAMOuter.Inner?
+let _: IAMSOuter.Inner?
+let _: IAMMultipleNested.Inner? // expected-error {{ambiguous type name 'Inner' in 'IAMMultipleNested'}}

--- a/test/Serialization/Inputs/xref-nested-clang-type/NestedClangTypes.h
+++ b/test/Serialization/Inputs/xref-nested-clang-type/NestedClangTypes.h
@@ -1,0 +1,7 @@
+struct Outer {
+  int value;
+};
+
+struct __attribute__((swift_name("Outer.InterestingValue"))) Inner {
+  int value;
+};

--- a/test/Serialization/Inputs/xref-nested-clang-type/NestedClangTypes.h
+++ b/test/Serialization/Inputs/xref-nested-clang-type/NestedClangTypes.h
@@ -5,3 +5,14 @@ struct Outer {
 struct __attribute__((swift_name("Outer.InterestingValue"))) Inner {
   int value;
 };
+
+#if __OBJC__
+
+@import Foundation;
+
+extern NSString * const ErrorCodeDomain;
+enum __attribute__((ns_error_domain(ErrorCodeDomain))) ErrorCodeEnum {
+  ErrorCodeEnumA
+};
+
+#endif // __OBJC__

--- a/test/Serialization/Inputs/xref-nested-clang-type/module.modulemap
+++ b/test/Serialization/Inputs/xref-nested-clang-type/module.modulemap
@@ -1,0 +1,3 @@
+module NestedClangTypes {
+  header "NestedClangTypes.h"
+}

--- a/test/Serialization/xref-nested-clang-type.swift
+++ b/test/Serialization/xref-nested-clang-type.swift
@@ -1,8 +1,16 @@
 // RUN: %empty-directory(%t)
-
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t -I %S/Inputs/xref-nested-clang-type/ %s -module-name Lib
-
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %t -I %S/Inputs/xref-nested-clang-type/ %s -DCLIENT -verify
+
+// RUN: %empty-directory(%t)
+// RUN: cp %S/Inputs/xref-nested-clang-type/NestedClangTypes.h %t
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t -import-objc-header %t/NestedClangTypes.h %s -module-name Lib -DNO_MODULE
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %t -import-objc-header %t/NestedClangTypes.h %s -DCLIENT -verify
+
+// RUN: %empty-directory(%t)
+// RUN: cp %S/Inputs/xref-nested-clang-type/NestedClangTypes.h %t
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t -import-objc-header %t/NestedClangTypes.h -pch-output-dir %t/PCHCache %s -module-name Lib -DNO_MODULE
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %t -pch-output-dir %t/PCHCache -import-objc-header %t/NestedClangTypes.h %s -DCLIENT -verify
 
 #if CLIENT
 
@@ -17,7 +25,9 @@ func test(x: MyCode) {}
 
 #else // CLIENT
 
+#if !NO_MODULE
 import NestedClangTypes
+#endif
 
 public typealias MyOuter = Outer
 public typealias MyInner = Outer.InterestingValue

--- a/test/Serialization/xref-nested-clang-type.swift
+++ b/test/Serialization/xref-nested-clang-type.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -emit-module -o %t -I %S/Inputs/xref-nested-clang-type/ %s -module-name Lib
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t -I %S/Inputs/xref-nested-clang-type/ %s -module-name Lib
 
-// RUN: %target-swift-frontend -typecheck -I %t -I %S/Inputs/xref-nested-clang-type/ %s -DCLIENT -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %t -I %S/Inputs/xref-nested-clang-type/ %s -DCLIENT -verify
 
 #if CLIENT
 
@@ -10,7 +10,12 @@ import Lib
 
 func test(x: MyInner) {}
 
-#else
+#if _runtime(_ObjC)
+import Foundation
+func test(x: MyCode) {}
+#endif // ObjC
+
+#else // CLIENT
 
 import NestedClangTypes
 
@@ -21,4 +26,13 @@ extension MyOuter {
   public func use(inner: MyInner) {}
 }
 
-#endif
+#if _runtime(_ObjC)
+import Foundation
+
+public typealias MyCode = ErrorCodeEnum.Code
+extension ErrorCodeEnum {
+  public func whatever(code: MyCode) {}
+}
+#endif // ObjC
+
+#endif // CLIENT

--- a/test/Serialization/xref-nested-clang-type.swift
+++ b/test/Serialization/xref-nested-clang-type.swift
@@ -1,0 +1,24 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -emit-module -o %t -I %S/Inputs/xref-nested-clang-type/ %s -module-name Lib
+
+// RUN: %target-swift-frontend -typecheck -I %t -I %S/Inputs/xref-nested-clang-type/ %s -DCLIENT -verify
+
+#if CLIENT
+
+import Lib
+
+func test(x: MyInner) {}
+
+#else
+
+import NestedClangTypes
+
+public typealias MyOuter = Outer
+public typealias MyInner = Outer.InterestingValue
+
+extension MyOuter {
+  public func use(inner: MyInner) {}
+}
+
+#endif


### PR DESCRIPTION
This avoids having to bring in all members (and extensions!) for an outer type just to look up a nested type. In the test case attached (reduced from the project in [SR-5284](https://bugs.swift.org/browse/SR-5284)), this actually led to a circular dependency between deserialization and the importer, which resulted in a compiler crash.

This is not a new problem, but it's more important with the release of Swift 4, where a number of Apple SDK types are now newly imported as member types. (The one in the original bug was NSView.AutoresizingMask, formerly NSAutoresizingMaskOptions.) Since we always use the Swift 4 name for cross-references, this affected everyone, even those still compiling in Swift 3 mode.

[SR-5284](https://bugs.swift.org/browse/SR-5284) / rdar://problem/32926560

