### PR TITLE
[4.0][runtime] swift_getObjectType() must ignore KVO's artificial subclasses.

### DIFF
--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -1835,19 +1835,6 @@ swift::swift_initClassMetadata_UniversalStrategy(ClassMetadata *self,
   return self;
 }
 
-/// \brief Fetch the type metadata associated with the formal dynamic
-/// type of the given (possibly Objective-C) object.  The formal
-/// dynamic type ignores dynamic subclasses such as those introduced
-/// by KVO.
-///
-/// The object pointer may be a tagged pointer, but cannot be null.
-const Metadata *swift::swift_getObjectType(HeapObject *object) {
-  auto classAsMetadata = _swift_getClass(object);
-  if (classAsMetadata->isTypeMetadata()) return classAsMetadata;
-
-  return swift_getObjCClassMetadata(classAsMetadata);
-}
-
 /***************************************************************************/
 /*** Metatypes *************************************************************/
 /***************************************************************************/

--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -103,7 +103,13 @@ const Metadata *swift::swift_getObjectType(HeapObject *object) {
     classAsMetadata = classAsMetadata->SuperClass;
   }
 
-  Class objcClass = [reinterpret_cast<id>(object) class];
+  id objcObject = reinterpret_cast<id>(object);
+  Class objcClass = [objcObject class];
+  if (object_isClass(objcObject)) {
+    // Original object is a class. We want a
+    // metaclass but +class doesn't give that to us.
+    objcClass = object_getClass(objcClass);
+  }
   classAsMetadata = reinterpret_cast<const ClassMetadata *>(objcClass);
   return swift_getObjCClassMetadata(classAsMetadata);
 #endif

--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -88,6 +88,12 @@ const ClassMetadata *swift::_swift_getClass(const void *object) {
 const Metadata *swift::swift_getObjectType(HeapObject *object) {
   auto classAsMetadata = _swift_getClass(object);
 
+#if !SWIFT_OBJC_INTEROP
+  assert(classAsMetadata &&
+         classAsMetadata->isTypeMetadata() &&
+         !classAsMetadata->isArtificialSubclass());
+  return classAsMetadata;
+#else
   // Walk up the superclass chain skipping over artifical Swift classes.
   // If we find a non-Swift class use the result of [object class] instead.
 
@@ -97,13 +103,9 @@ const Metadata *swift::swift_getObjectType(HeapObject *object) {
     classAsMetadata = classAsMetadata->SuperClass;
   }
 
-#if SWIFT_OBJC_INTEROP
   Class objcClass = [reinterpret_cast<id>(object) class];
   classAsMetadata = reinterpret_cast<const ClassMetadata *>(objcClass);
   return swift_getObjCClassMetadata(classAsMetadata);
-#else
-  fatalError(/* flags = */ 0,
-             "swift_getObjectType: object has no Swift superclass");
 #endif
 }
 

--- a/test/Interpreter/SDK/objc_swift_getObjectType.swift
+++ b/test/Interpreter/SDK/objc_swift_getObjectType.swift
@@ -1,0 +1,60 @@
+// RUN: %target-run-simple-swift | %FileCheck %s
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+import Foundation
+
+protocol P: class { }
+
+class AbstractP: P { }
+
+class DelegatedP<D: P>: AbstractP {
+    init(_ d: D) { }
+}
+
+class AnyP: DelegatedP<AbstractP> {
+  init<D: P>(_ d: D) {
+    super.init(DelegatedP<D>(d))
+  }
+}
+
+extension P {
+  var anyP: AnyP {
+    return AnyP(self)
+  }
+}
+
+// SR-4363
+// Test several paths through swift_getObjectType() 
+
+// instance of a Swift class that conforms to P
+class O: NSObject, P { }
+var o = O()
+let obase: NSObject = o
+print(String(cString: object_getClassName(o)))
+_ = (o as P).anyP
+_ = (obase as! P).anyP
+// CHECK: main.O
+
+// ... and KVO's artificial subclass thereof
+o.addObserver(NSObject(), forKeyPath: "xxx", options: [.new], context: nil)
+print(String(cString: object_getClassName(o)))
+_ = (o as P).anyP
+_ = (obase as! P).anyP
+// CHECK-NEXT: NSKVONotifying_main.O
+
+// instance of an ObjC class that conforms to P
+extension NSLock: P { }
+var l = NSLock()
+let lbase: NSObject = l
+print(String(cString: object_getClassName(l)))
+_ = (l as P).anyP
+_ = (lbase as! P).anyP
+// CHECK-NEXT: NSLock
+
+// ... and KVO's artificial subclass thereof
+l.addObserver(NSObject(), forKeyPath: "xxx", options: [.new], context: nil)
+print(String(cString: object_getClassName(l)))
+_ = (l as P).anyP
+_ = (lbase as! P).anyP
+// CHECK-NEXT: NSKVONotifying_NSLock


### PR DESCRIPTION
Fixes SR-4363 and rdar://problem/31275541