### PR TITLE
[CMake] Sema depends on Serialization these days.

### DIFF
--- a/lib/Sema/CMakeLists.txt
+++ b/lib/Sema/CMakeLists.txt
@@ -57,6 +57,7 @@ add_swift_library(swiftSema STATIC
   LINK_LIBRARIES
     swiftParse
     swiftAST
+    swiftSerialization
   ${EXTRA_TYPECHECKER_FLAGS}
 )
 


### PR DESCRIPTION
Specifically, it uses SerializedASTFile::getLanguageVersionBuiltWith to improve diagnostics. Not having this has led to failures on Linux, where linking order matters.