### PR TITLE
[stdlib/Foundation] Swift 3 backward compatibility hack

### DIFF
--- a/stdlib/public/SDK/Foundation/ExtraStringAPIs.swift
+++ b/stdlib/public/SDK/Foundation/ExtraStringAPIs.swift
@@ -21,8 +21,8 @@ extension String.UTF16View.Index {
 
   @available(swift, deprecated: 3.2)
   @available(swift, obsoleted: 4.0)
-  public func distance(to other: String.UTF16View.Index) -> Int {
-    return _offset.distance(to: other._offset)
+  public func distance(to other: String.UTF16View.Index?) -> Int {
+    return _offset.distance(to: other!._offset)
   }
 
   @available(swift, deprecated: 3.2)

--- a/stdlib/public/core/StringUTF16.swift
+++ b/stdlib/public/core/StringUTF16.swift
@@ -487,7 +487,7 @@ extension String.UTF16View {
     swift, obsoleted: 4.0,
     message: "Any String view index conversion can fail in Swift 4; please unwrap the optional index")
   public func index(after i: Index?) -> Index {
-    return index(after: i)
+    return index(after: i!)
   }
   @available(
     swift, obsoleted: 4.0,

--- a/stdlib/public/core/StringUnicodeScalarView.swift
+++ b/stdlib/public/core/StringUnicodeScalarView.swift
@@ -504,7 +504,7 @@ extension String.UnicodeScalarView {
     swift, obsoleted: 4.0,
     message: "Any String view index conversion can fail in Swift 4; please unwrap the optional index")
   public func index(after i: Index?) -> Index {
-    return index(after: i)
+    return index(after: i!)
   }
   @available(
     swift, obsoleted: 4.0,

--- a/test/stdlib/StringCompatibility.swift
+++ b/test/stdlib/StringCompatibility.swift
@@ -196,6 +196,60 @@ Tests.test("String/Legacy/UTF16View.Index/StrideableAPIs") {
   expectEqual(0, i.distance(to: i.samePosition(in: "")))
   expectEqual(i, i.advanced(by: 0))
 }
+
+Tests.test("String/Legacy/UTF16View/OptionalIndices") {
+  let s = "somethingToTest".utf16
+  let i = s.startIndex
+  let j = Optional(i)
+  expectEqual(s.index(after: i), s.index(after: j))
+  expectEqual(s.index(i, offsetBy: 2), s.index(j, offsetBy: 2))
+  expectEqual(
+    s.distance(from: i, to: s.endIndex),
+    s.distance(from: j, to: s.endIndex))
+  expectEqual(
+    s.distance(from: i, to: s.endIndex),
+    s.distance(from: j, to: Optional(s.endIndex)))
+  expectEqual(
+    s.distance(from: i, to: s.endIndex),
+    s.distance(from: i, to: Optional(s.endIndex)))
+  expectEqual(s[i], s[j])
+}
+
+Tests.test("String/Legacy/UTF8View/OptionalIndices") {
+  let s = "somethingToTest".utf8
+  let i = s.startIndex
+  let j = Optional(i)
+  expectEqual(s.index(after: i), s.index(after: j))
+  expectEqual(s.index(i, offsetBy: 2), s.index(j, offsetBy: 2))
+  expectEqual(
+    s.distance(from: i, to: s.endIndex),
+    s.distance(from: j, to: s.endIndex))
+  expectEqual(
+    s.distance(from: i, to: s.endIndex),
+    s.distance(from: j, to: Optional(s.endIndex)))
+  expectEqual(
+    s.distance(from: i, to: s.endIndex),
+    s.distance(from: i, to: Optional(s.endIndex)))
+  expectEqual(s[i], s[j])
+}
+
+Tests.test("String/Legacy/UnicodeScalarView/OptionalIndices") {
+  let s = "somethingToTest".unicodeScalars
+  let i = s.startIndex
+  let j = Optional(i)
+  expectEqual(s.index(after: i), s.index(after: j))
+  expectEqual(s.index(i, offsetBy: 2), s.index(j, offsetBy: 2))
+  expectEqual(
+    s.distance(from: i, to: s.endIndex),
+    s.distance(from: j, to: s.endIndex))
+  expectEqual(
+    s.distance(from: i, to: s.endIndex),
+    s.distance(from: j, to: Optional(s.endIndex)))
+  expectEqual(
+    s.distance(from: i, to: s.endIndex),
+    s.distance(from: i, to: Optional(s.endIndex)))
+  expectEqual(s[i], s[j])
+}
 #endif
 
 Tests.test("String/Range/Slice/ExpectedType/\(swift)") {

--- a/test/stdlib/StringCompatibility.swift
+++ b/test/stdlib/StringCompatibility.swift
@@ -185,7 +185,18 @@ let swift = 3
 
 #endif
 
-var Tests = TestSuite("SubstringCompatibility")
+var Tests = TestSuite("StringCompatibility")
+
+#if !swift(>=4) && _runtime(_ObjC)
+import Foundation
+
+Tests.test("String/Legacy/UTF16View.Index/StrideableAPIs") {
+  let i = String.UTF16View.Index(0)
+  expectEqual(0, i.distance(to: i))
+  expectEqual(0, i.distance(to: i.samePosition(in: "")))
+  expectEqual(i, i.advanced(by: 0))
+}
+#endif
 
 Tests.test("String/Range/Slice/ExpectedType/\(swift)") {
   var s = "hello world"


### PR DESCRIPTION
Since samePosition(in:) now unconditionally returns optionals,
String.UTF16View.Index.distance(to: String.UTF16View.Index) must accept an
optional to keep some code working.

Fixes <rdar://33307780>.
