### PR TITLE
Fix String.UTF8View.Index's conversion init

### DIFF
--- a/stdlib/public/core/StringUTF8.swift
+++ b/stdlib/public/core/StringUTF8.swift
@@ -531,9 +531,15 @@ extension String.UTF8View.Index {
   ///   - sourcePosition: A position in a `String` or one of its views.
   ///   - target: The `UTF8View` in which to find the new position.
   public init?(_ sourcePosition: String.Index, within target: String.UTF8View) {
-    guard String.UnicodeScalarView(target._core)._isOnUnicodeScalarBoundary(
-      sourcePosition) else { return nil }
-    self.init(encodedOffset: sourcePosition.encodedOffset)
+    switch sourcePosition._cache {
+    case .utf8:
+        self.init(encodedOffset: sourcePosition.encodedOffset, transcodedOffset: sourcePosition._transcodedOffset, sourcePosition._cache)
+
+    default:
+        guard String.UnicodeScalarView(target._core)._isOnUnicodeScalarBoundary(
+            sourcePosition) else { return nil }
+        self.init(encodedOffset: sourcePosition.encodedOffset)
+    }
   }
 }
 

--- a/stdlib/public/core/StringUTF8.swift
+++ b/stdlib/public/core/StringUTF8.swift
@@ -533,12 +533,13 @@ extension String.UTF8View.Index {
   public init?(_ sourcePosition: String.Index, within target: String.UTF8View) {
     switch sourcePosition._cache {
     case .utf8:
-        self.init(encodedOffset: sourcePosition.encodedOffset, transcodedOffset: sourcePosition._transcodedOffset, sourcePosition._cache)
+      self.init(encodedOffset: sourcePosition.encodedOffset,
+        transcodedOffset:sourcePosition._transcodedOffset, sourcePosition._cache)
 
     default:
-        guard String.UnicodeScalarView(target._core)._isOnUnicodeScalarBoundary(
-            sourcePosition) else { return nil }
-        self.init(encodedOffset: sourcePosition.encodedOffset)
+      guard String.UnicodeScalarView(target._core)._isOnUnicodeScalarBoundary(
+        sourcePosition) else { return nil }
+      self.init(encodedOffset: sourcePosition.encodedOffset)
     }
   }
 }

--- a/validation-test/stdlib/StringViews.swift
+++ b/validation-test/stdlib/StringViews.swift
@@ -216,6 +216,13 @@ tests.test("index-mapping/utf16-to-utf8/\(id)") {
     summer.utf8.endIndex,
     mapIndex(summer.utf16.endIndex, summer.utf8)!)
 }
+
+tests.test("index-mapping/utf8-to-utf8/\(id)") {
+  // should always succeed
+  for i in winter.utf8.indices {
+    expectEqual(i, mapIndex(i, winter.utf8)!)      
+  }
+}
 }
 checkToUTF8("legacy") { $0.samePosition(in: $1) }
 checkToUTF8("interchange") { i, _ in i }


### PR DESCRIPTION
String.UTF8View.Index's conversion init should check whether sourcePosition is already a utf8 index first. Otherwise it may return nil for a valid utf8 sourcePosition.