### PR TITLE
Sema: Move preCheckExpression() out of solveForExpression()

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -8975,6 +8975,8 @@ diagnoseAmbiguousMultiStatementClosure(ClosureExpr *closure) {
       if (hasUnresolvedParams)
         continue;
 
+      CS->TC.preCheckExpression(resultExpr, CS->DC);
+
       // Obtain type of the result expression without applying solutions,
       // because otherwise this might result in leaking of type variables,
       // since we are not resetting result statement and if expression is

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -844,6 +844,9 @@ static Optional<Type> getTypeOfCompletionContextExpr(
                         CompletionTypeCheckKind kind,
                         Expr *&parsedExpr,
                         ConcreteDeclRef &referencedDecl) {
+  if (TC.preCheckExpression(parsedExpr, DC))
+    return None;
+
   switch (kind) {
   case CompletionTypeCheckKind::Normal:
     // Handle below.

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1493,8 +1493,15 @@ public:
                                      SubstitutionList SelfInterfaceSubs,
                                      SubstitutionList SelfContextSubs);
 
+  /// Pre-check the expression, validating any types that occur in the
+  /// expression and folding sequence expressions.
+  bool preCheckExpression(Expr *&expr, DeclContext *dc);
+
   /// Sets up and solves the constraint system \p cs to type check the given
   /// expression.
+  ///
+  /// The expression should have already been pre-checked with
+  /// preCheckExpression().
   ///
   /// \returns true if an error occurred, false otherwise.
   ///

--- a/validation-test/compiler_crashers_fixed/28817-swift-typebase-getdesugaredtype.swift
+++ b/validation-test/compiler_crashers_fixed/28817-swift-typebase-getdesugaredtype.swift
@@ -5,5 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 class a{class a}func a:P._=a.a{


### PR DESCRIPTION
There are two "RAII cleaners" here:

- CleanupIllFormedExpressionRAII cleans up the Expr in its final state
- ExprCleanser walks the Expr before it is mutated and collects
  sub-expressions, then cleans those up after

The subtle difference comes into play if we started to apply the
solution (which can fail, leaving the AST in an inconsistent state)
or if preCheckExpression() modified the AST.

The latter case was causing an ASan failure because we were not
cleaning up type variables in new nodes introduced by
preCheckExpression().

Fix this by moving the preCheckExpression() call out of
solveForExpression(), so that if solveForExpression() is called
with TypeCheckExprFlags::SkipApplyingSolution, we don't mutate the
AST at all.

Sigh...

Fixes <rdar://problem/33277279>.