### PR TITLE
[Constraint system] Properly infer types for collections of vars.

### DIFF
--- a/lib/AST/TypeJoinMeet.cpp
+++ b/lib/AST/TypeJoinMeet.cpp
@@ -25,6 +25,11 @@ Type Type::join(Type type1, Type type2) {
   assert(!type1->hasTypeVariable() && !type2->hasTypeVariable() &&
          "Cannot compute join of types involving type variables");
 
+  assert(type1->getWithoutSpecifierType()->isEqual(type1) &&
+         "Expected simple type!");
+  assert(type2->getWithoutSpecifierType()->isEqual(type2) &&
+         "Expected simple type!");
+
   // FIXME: This algorithm is woefully incomplete, and is only currently used
   // for optimizing away extra exploratory work in the constraint solver. It
   // should eventually encompass all of the subtyping rules of the language.

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -157,10 +157,11 @@ ConstraintSystem::getPotentialBindings(TypeVariableType *typeVar) {
       if (lastSupertypeIndex) {
         // Can we compute a join?
         auto &lastBinding = result.Bindings[*lastSupertypeIndex];
-        if (auto meet =
-                Type::join(lastBinding.BindingType, binding.BindingType)) {
+        auto lastType = lastBinding.BindingType->getWithoutSpecifierType();
+        auto bindingType = binding.BindingType->getWithoutSpecifierType();
+        if (auto join = Type::join(lastType, bindingType)) {
           // Replace the last supertype binding with the join. We're done.
-          lastBinding.BindingType = meet;
+          lastBinding.BindingType = join;
           return;
         }
       }

--- a/test/Constraints/array_literal.swift
+++ b/test/Constraints/array_literal.swift
@@ -155,6 +155,15 @@ func defaultToAny(i: Int, s: String) {
   let _: Int = a6 // expected-error{{value of type '[A]'}}
 }
 
+func noInferAny(iob: inout B, ioc: inout C) {
+  var b = B()
+  var c = C()
+  let _ = [b, c, iob, ioc] // do not infer [Any] when elements are lvalues or inout
+  let _: [A] = [b, c, iob, ioc] // do not infer [Any] when elements are lvalues or inout
+  b = B()
+  c = C()
+}
+
 /// Check handling of 'nil'.
 protocol Proto1 {}
 protocol Proto2 {}


### PR DESCRIPTION
When we saw lvalue- or inout-types we were not appropriately looking at
the underlying types when performing a join. As a result we would infer
Any in cases where we should have inferred a common supertype.

rdar://problem/31127419
