### PR TITLE
[NOMERGE] Build the standard library in Swift 4 mode

### DIFF
--- a/cmake/modules/SwiftSource.cmake
+++ b/cmake/modules/SwiftSource.cmake
@@ -261,12 +261,12 @@ function(_compile_swift_files
     endif()
   endif()
 
-  # Force swift 3 compatibility mode for Standard Library and overlay.
-  if (SWIFTFILE_IS_STDLIB OR SWIFTFILE_IS_SDK_OVERLAY)
-    list(APPEND swift_flags "-swift-version" "3")
+  if (SWIFTFILE_IS_STDLIB)
+    list(APPEND swift_flags "-swift-version" "4")
   endif()
 
   if(SWIFTFILE_IS_SDK_OVERLAY)
+    list(APPEND swift_flags "-swift-version" "3")
     list(APPEND swift_flags "-autolink-force-load")
   endif()
 

--- a/stdlib/private/StdlibCollectionUnittest/CheckSequenceType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckSequenceType.swift
@@ -1922,7 +1922,7 @@ self.test("\(testNamePrefix)._preprocessingPass/semantics") {
     let s = makeWrappedSequence(test.sequence.map(OpaqueValue.init))
     var wasInvoked = false
     let result = s._preprocessingPass {
-      (sequence) -> OpaqueValue<Int> in
+      () -> OpaqueValue<Int> in
       wasInvoked = true
 
       expectEqualSequence(
@@ -1945,7 +1945,7 @@ self.test("\(testNamePrefix)._preprocessingPass/semantics") {
     var result: OpaqueValue<Int>?
     do {
       result = try s._preprocessingPass {
-        _ -> OpaqueValue<Int> in
+        () -> OpaqueValue<Int> in
         wasInvoked = true
         throw TestError.error2
       }

--- a/stdlib/private/StdlibUnittest/StdlibCoreExtras.swift
+++ b/stdlib/private/StdlibUnittest/StdlibCoreExtras.swift
@@ -27,6 +27,10 @@ import Foundation
 // useful in tests, and stdlib does not have such facilities yet.
 //
 
+func findSubstring(_ haystack: Substring, _ needle: String) -> String.Index? {
+  return findSubstring(String(haystack._ephemeralContent), needle)
+}
+
 func findSubstring(_ string: String, _ substring: String) -> String.Index? {
   if substring.isEmpty {
     return string.startIndex
@@ -48,7 +52,7 @@ func findSubstring(_ string: String, _ substring: String) -> String.Index? {
     while true {
       if needleIndex == needle.endIndex {
         // if we hit the end of the search string, we found the needle
-        return matchStartIndex.samePosition(in: string)
+        return matchStartIndex
       }
       if matchIndex == haystack.endIndex {
         // if we hit the end of the string before finding the end of the needle,
@@ -149,7 +153,7 @@ extension MutableCollection
     var f = subrange.lowerBound
     var l = index(before: subrange.upperBound)
     while f < l {
-      swap(&self[f], &self[l])
+      swapAt(f, l)
       formIndex(after: &f)
       formIndex(before: &l)
     }
@@ -195,7 +199,7 @@ extension MutableCollection
         repeat {
           formIndex(before: &j)
         } while !(elementAtBeforeI < self[j])
-        swap(&self[beforeI], &self[j])
+        swapAt(beforeI, j)
         _reverseSubrange(i..<endIndex)
         return .success
       }

--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
@@ -766,7 +766,7 @@ struct _ParentProcess {
     parameter: Int?
   ) -> (anyExpectFailed: Bool, seenExpectCrash: Bool,
         status: ProcessTerminationStatus?,
-        crashStdout: [String], crashStderr: [String]) {
+        crashStdout: [Substring], crashStderr: [Substring]) {
     if _pid == nil {
       _spawnChild()
     }
@@ -790,15 +790,15 @@ struct _ParentProcess {
     var stderrSeenCrashDelimiter = false
     var stdoutEnd = false
     var stderrEnd = false
-    var capturedCrashStdout: [String] = []
-    var capturedCrashStderr: [String] = []
+    var capturedCrashStdout: [Substring] = []
+    var capturedCrashStderr: [Substring] = []
     var anyExpectFailedInChild = false
 
     func processLine(_ line: String, isStdout: Bool) -> (done: Bool, Void) {
-      var line = line
+      var line = line[...]
       if let index = findSubstring(line, _stdlibUnittestStreamPrefix) {
         let controlMessage =
-            line[index..<line.endIndex]._split(separator: ";")
+            line[index..<line.endIndex].split(separator: ";")
         switch controlMessage[1] {
         case "expectCrash":
           if isStdout {
@@ -830,7 +830,7 @@ struct _ParentProcess {
         if stderrSeenCrashDelimiter {
           capturedCrashStderr.append(line)
           if findSubstring(line, _crashedPrefix) != nil {
-            line = "OK: saw expected \"\(line.lowercased())\""
+            line = "OK: saw expected \"\(line.lowercased())\""[...]
           }
         }
       }
@@ -937,8 +937,8 @@ struct _ParentProcess {
 
     var expectCrash = false
     var childTerminationStatus: ProcessTerminationStatus?
-    var crashStdout: [String] = []
-    var crashStderr: [String] = []
+    var crashStdout: [Substring] = []
+    var crashStderr: [Substring] = []
     if _runTestsInProcess {
       if t.stdinText != nil {
         print("The test \(fullTestName) requires stdin input and can't be run in-process, marking as failed")
@@ -2380,11 +2380,11 @@ public func expectEqualsUnordered<
   Expected.Iterator.Element == Actual.Iterator.Element {
 
   let x: [Expected.Iterator.Element] =
-    expected.sorted(by: compose(compare, { $0.isLT() }))
+    expected.sorted { compare($0, $1).isLT() }
   let y: [Actual.Iterator.Element] =
-    actual.sorted(by: compose(compare, { $0.isLT() }))
+    actual.sorted { compare($0, $1).isLT() }
   expectEqualSequence(
-    x, y, ${trace}, sameValue: compose(compare, { $0.isEQ() }))
+    x, y, ${trace}, sameValue: { compare($0, $1).isEQ() })
 }
 
 public func expectEqualsUnordered<
@@ -2531,12 +2531,6 @@ public func expectEqualUnicodeScalars(
       "expected elements: \"\(asHex(expected))\"\n"
       + "actual: \"\(asHex(actualUnicodeScalars))\"",
       trace: ${trace})
-  }
-}
-
-func compose<A, B, C>(_ f: @escaping (A) -> B, _ g: @escaping (B) -> C) -> (A) -> C {
-  return { a in
-    return g(f(a))
   }
 }
 

--- a/stdlib/public/core/DoubleWidth.swift.gyb
+++ b/stdlib/public/core/DoubleWidth.swift.gyb
@@ -499,11 +499,13 @@ public struct DoubleWidth<Base : FixedWidthInteger> :
 
     lhs._storage.low >>= rhs._storage.low
     if Base.bitWidth > rhs._storage.low {
-      lhs._storage.low |= Low(extendingOrTruncating: lhs._storage.high <<
-        numericCast(numericCast(Base.bitWidth) - rhs._storage.low))
+      lhs._storage.low |= Low(
+        extendingOrTruncating:
+        lhs._storage.high << (numericCast(Base.bitWidth) - rhs._storage.low))
     } else {
-      lhs._storage.low |= Low(extendingOrTruncating: lhs._storage.high >>
-        numericCast(rhs._storage.low - numericCast(Base.bitWidth)))
+      lhs._storage.low |= Low(
+        extendingOrTruncating: lhs._storage.high >>
+        (rhs._storage.low - numericCast(Base.bitWidth)))
     }
     lhs._storage.high >>= High(extendingOrTruncating: rhs._storage.low)
   }

--- a/stdlib/public/core/ExistentialCollection.swift.gyb
+++ b/stdlib/public/core/ExistentialCollection.swift.gyb
@@ -308,7 +308,7 @@ internal class _AnyRandomAccessCollectionBox<Element>
   @_versioned
   @_inlineable
   internal func _index(
-    _ i: _AnyIndexBox, offsetBy n: IntMax
+    _ i: _AnyIndexBox, offsetBy n: Int64
   ) -> _AnyIndexBox {
     _abstract()
   }
@@ -316,21 +316,21 @@ internal class _AnyRandomAccessCollectionBox<Element>
   @_versioned
   @_inlineable
   internal func _index(
-    _ i: _AnyIndexBox, offsetBy n: IntMax, limitedBy limit: _AnyIndexBox
+    _ i: _AnyIndexBox, offsetBy n: Int64, limitedBy limit: _AnyIndexBox
   ) -> _AnyIndexBox? {
     _abstract()
   }
 
   @_versioned
   @_inlineable
-  internal func _formIndex(_ i: inout _AnyIndexBox, offsetBy n: IntMax) {
+  internal func _formIndex(_ i: inout _AnyIndexBox, offsetBy n: Int64) {
     _abstract()
   }
 
   @_versioned
   @_inlineable
   internal func _formIndex(
-    _ i: inout _AnyIndexBox, offsetBy n: IntMax, limitedBy limit: _AnyIndexBox
+    _ i: inout _AnyIndexBox, offsetBy n: Int64, limitedBy limit: _AnyIndexBox
   ) -> Bool {
     _abstract()
   }
@@ -339,7 +339,7 @@ internal class _AnyRandomAccessCollectionBox<Element>
   @_inlineable
   internal func _distance(
     from start: _AnyIndexBox, to end: _AnyIndexBox
-  ) -> IntMax {
+  ) -> Int64 {
     _abstract()
   }
 
@@ -357,7 +357,7 @@ internal class _AnyRandomAccessCollectionBox<Element>
   */
 
   @_versioned
-  internal var _count: IntMax { _abstract() }
+  internal var _count: Int64 { _abstract() }
 
   // TODO: swift-3-indexing-model: forward the following methods.
   /*
@@ -609,7 +609,7 @@ internal final class _${Kind}Box<S : ${Kind}> : _Any${Kind}Box<S.Iterator.Elemen
   @_versioned
   @_inlineable
   internal override func _index(
-    _ i: _AnyIndexBox, offsetBy n: IntMax
+    _ i: _AnyIndexBox, offsetBy n: Int64
   ) -> _AnyIndexBox {
     return _IndexBox(_base: _base.index(_unbox(i), offsetBy: numericCast(n)))
   }
@@ -618,7 +618,7 @@ internal final class _${Kind}Box<S : ${Kind}> : _Any${Kind}Box<S.Iterator.Elemen
   @_inlineable
   internal override func _index(
     _ i: _AnyIndexBox,
-    offsetBy n: IntMax,
+    offsetBy n: Int64,
     limitedBy limit: _AnyIndexBox
   ) -> _AnyIndexBox? {
     return _base.index(
@@ -631,7 +631,7 @@ internal final class _${Kind}Box<S : ${Kind}> : _Any${Kind}Box<S.Iterator.Elemen
   @_versioned
   @_inlineable
   internal override func _formIndex(
-    _ i: inout _AnyIndexBox, offsetBy n: IntMax
+    _ i: inout _AnyIndexBox, offsetBy n: Int64
   ) {
     if let box = i as? _IndexBox<S.Index> {
       return _base.formIndex(&box._base, offsetBy: numericCast(n))
@@ -642,7 +642,7 @@ internal final class _${Kind}Box<S : ${Kind}> : _Any${Kind}Box<S.Iterator.Elemen
   @_versioned
   @_inlineable
   internal override func _formIndex(
-    _ i: inout _AnyIndexBox, offsetBy n: IntMax, limitedBy limit: _AnyIndexBox
+    _ i: inout _AnyIndexBox, offsetBy n: Int64, limitedBy limit: _AnyIndexBox
   ) -> Bool {
     if let box = i as? _IndexBox<S.Index> {
       return _base.formIndex(
@@ -658,13 +658,13 @@ internal final class _${Kind}Box<S : ${Kind}> : _Any${Kind}Box<S.Iterator.Elemen
   internal override func _distance(
     from start: _AnyIndexBox,
     to end: _AnyIndexBox
-  ) -> IntMax {
+  ) -> Int64 {
     return numericCast(_base.distance(from: _unbox(start), to: _unbox(end)))
   }
 
   @_versioned
   @_inlineable
-  internal override var _count: IntMax {
+  internal override var _count: Int64 {
     return numericCast(_base.count)
   }
 
@@ -1079,7 +1079,7 @@ public struct ${Self}<Element>
 %   end
 
   public typealias Index = AnyIndex
-  public typealias IndexDistance = IntMax
+  public typealias IndexDistance = Int64
 
   /// The position of the first element in a non-empty collection.
   ///
@@ -1144,14 +1144,14 @@ public struct ${Self}<Element>
   }
 
   @_inlineable
-  public func index(_ i: AnyIndex, offsetBy n: IntMax) -> AnyIndex {
+  public func index(_ i: AnyIndex, offsetBy n: Int64) -> AnyIndex {
     return AnyIndex(_box: _box._index(i._box, offsetBy: n))
   }
 
   @_inlineable
   public func index(
     _ i: AnyIndex,
-    offsetBy n: IntMax,
+    offsetBy n: Int64,
     limitedBy limit: AnyIndex
   ) -> AnyIndex? {
     return _box._index(i._box, offsetBy: n, limitedBy: limit._box)
@@ -1159,7 +1159,7 @@ public struct ${Self}<Element>
   }
 
   @_inlineable
-  public func formIndex(_ i: inout AnyIndex, offsetBy n: IntMax) {
+  public func formIndex(_ i: inout AnyIndex, offsetBy n: Int64) {
     if _isUnique(&i._box) {
       return _box._formIndex(&i._box, offsetBy: n)
     } else {
@@ -1170,7 +1170,7 @@ public struct ${Self}<Element>
   @_inlineable
   public func formIndex(
     _ i: inout AnyIndex,
-    offsetBy n: IntMax,
+    offsetBy n: Int64,
     limitedBy limit: AnyIndex
   ) -> Bool {
     if _isUnique(&i._box) {
@@ -1185,7 +1185,7 @@ public struct ${Self}<Element>
   }
 
   @_inlineable
-  public func distance(from start: AnyIndex, to end: AnyIndex) -> IntMax {
+  public func distance(from start: AnyIndex, to end: AnyIndex) -> Int64 {
     return _box._distance(from: start._box, to: end._box)
   }
 
@@ -1199,7 +1199,7 @@ public struct ${Self}<Element>
 % end
   /// - Complexity: ${'O(1)' if Traversal == 'RandomAccess' else 'O(*n*)'}
   @_inlineable
-  public var count: IntMax {
+  public var count: Int64 {
     return _box._count
   }
 

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -1739,9 +1739,9 @@ public struct Dictionary<Key : Hashable, Value> :
       self = Dictionary(minimumCapacity: keysAndValues.underestimatedCount)
       // '_MergeError.keyCollision' is caught and handled with an appropriate
       // error message one level down, inside _variantBuffer.merge(_:...).
-      try! _variantBuffer.merge(keysAndValues, uniquingKeysWith: { _ in
-        throw _MergeError.keyCollision
-      })
+      try! _variantBuffer.merge(
+        keysAndValues,
+        uniquingKeysWith: { _, _ in throw _MergeError.keyCollision})
     }
   }
 
@@ -5885,7 +5885,7 @@ extension ${Self} {
   @_inlineable
   @available(swift, obsoleted: 4.0)
   public func filter(
-    _ isIncluded: (Element) throws -> Bool
+    _ isIncluded: (Element) throws -> Bool, obsoletedInSwift4: () = ()
   ) rethrows -> [Element] {
     var result: [Element] = []
     for x in self {

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -2125,7 +2125,7 @@ extension FixedWidthInteger {
   ///
   /// [identity element]:http://en.wikipedia.org/wiki/Identity_element
   /// [fixed point]:http://en.wikipedia.org/wiki/Fixed_point_(mathematics)
-  @available(swift, deprecated: 3.1, obsoleted: 4.0, message: "Use 0")
+  @available(swift, deprecated: 3.1, obsoleted: 4.1, message: "Use 0")
   public static var allZeros: Self { return 0 }
 
   @_inlineable

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -2933,7 +2933,7 @@ ${assignmentOperatorComment(x.operator, True)}
 % end
 
   @available(swift, obsoleted: 4.0, message: "Use initializers instead")
-  public func to${U}IntMax() -> ${U}IntMax {
+  public func to${U}IntMax() -> ${U}Int64 {
     return numericCast(self)
   }
 
@@ -3169,15 +3169,15 @@ extension SignedNumeric where Self : Comparable {
 @available(swift, obsoleted: 4)
 extension BinaryInteger {
   @available(swift, obsoleted: 4)
-  public func toIntMax() -> IntMax {
-    return IntMax(self)
+  public func toIntMax() -> Int64 {
+    return Int64(self)
   }
 }
 
 extension UnsignedInteger {
   @available(swift, obsoleted: 4)
-  public func toUIntMax() -> UIntMax {
-    return UIntMax(self)
+  public func toUIntMax() -> UInt64 {
+    return UInt64(self)
   }
 }
 

--- a/stdlib/public/core/ManagedBuffer.swift
+++ b/stdlib/public/core/ManagedBuffer.swift
@@ -95,7 +95,7 @@ open class ManagedBuffer<Header, Element> {
   public final func withUnsafeMutablePointerToElements<R>(
     _ body: (UnsafeMutablePointer<Element>) throws -> R
   ) rethrows -> R {
-    return try withUnsafeMutablePointers { return try body($0.1) }
+    return try withUnsafeMutablePointers { return try body($1) }
   }
 
   /// Call `body` with `UnsafeMutablePointer`s to the stored `Header`
@@ -269,7 +269,7 @@ public struct ManagedBufferPointer<Header, Element> : Equatable {
   public func withUnsafeMutablePointerToElements<R>(
     _ body: (UnsafeMutablePointer<Element>) throws -> R
   ) rethrows -> R {
-    return try withUnsafeMutablePointers { return try body($0.1) }
+    return try withUnsafeMutablePointers { return try body($1) }
   }
 
   /// Call `body` with `UnsafeMutablePointer`s to the stored `Header`

--- a/stdlib/public/core/Mirror.swift
+++ b/stdlib/public/core/Mirror.swift
@@ -430,7 +430,7 @@ extension Mirror {
       if case let label as String = e {
         position = children.index { $0.label == label } ?? children.endIndex
       }
-      else if let offset = (e as? Int).map({ IntMax($0) }) ?? (e as? IntMax) {
+      else if let offset = (e as? Int).map({ Int64($0) }) ?? (e as? Int64) {
         position = children.index(children.startIndex,
           offsetBy: offset,
           limitedBy: children.endIndex) ?? children.endIndex

--- a/stdlib/public/core/Policy.swift
+++ b/stdlib/public/core/Policy.swift
@@ -470,7 +470,7 @@ public protocol _BitwiseOperations {
   ///
   /// [identity element]:http://en.wikipedia.org/wiki/Identity_element
   /// [fixed point]:http://en.wikipedia.org/wiki/Fixed_point_(mathematics)
-  @available(swift, deprecated: 3.1, obsoleted: 4.0, message: "Use 0 or init() of a type conforming to FixedWidthInteger")
+  @available(swift, deprecated: 3.1, obsoleted: 4.1, message: "Use 0 or init() of a type conforming to FixedWidthInteger")
   static var allZeros: Self { get }
 }
 

--- a/stdlib/public/core/StringIndex.swift
+++ b/stdlib/public/core/StringIndex.swift
@@ -81,7 +81,7 @@ extension String.Index {
   
   /// The offset into a string's UTF-16 encoding for this index.
   public var encodedOffset : Int {
-    return Int(_compoundOffset >> numericCast(_Self._strideBits))
+    return Int(_compoundOffset >> _Self._strideBits)
   }
 
   /// The offset of this index within whatever encoding this is being viewed as

--- a/stdlib/public/core/StringLegacy.swift
+++ b/stdlib/public/core/StringLegacy.swift
@@ -367,12 +367,12 @@ extension String {
   ///     greater than 9, or `false` to use lowercase letters. The default is
   ///     `false`.
   @available(swift, obsoleted: 4, message: "Please use the version for FixedWidthInteger instead.")
-  public init<T : _SignedInteger>(
+  public init<T : SignedInteger>(
     _ value: T, radix: Int = 10, uppercase: Bool = false
   ) {
     _precondition(radix > 1, "Radix must be greater than 1")
     self = _int64ToString(
-      value.toIntMax(), radix: Int64(radix), uppercase: uppercase)
+      Int64(value), radix: Int64(radix), uppercase: uppercase)
   }
   
   /// Creates a string representing the given value in base 10, or some other
@@ -410,7 +410,7 @@ extension String {
   ) {
     _precondition(radix > 1, "Radix must be greater than 1")
     self = _uint64ToString(
-      value.toUIntMax(), radix: Int64(radix), uppercase: uppercase)
+      UInt64(value), radix: Int64(radix), uppercase: uppercase)
   }
 }
 

--- a/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
+++ b/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
@@ -44,7 +44,7 @@ extension String : StringProtocol, RangeReplaceableCollection {
   
   // This initializer satisfies the LosslessStringConvertible conformance
   @available(swift, obsoleted: 4, message: "String.init(_:String) is no longer failable")
-  public init?(_ other: String) {
+  public init?(_ other: String, obsoletedInSwift4: () = ()) {
     self.init(other._core)
   }
 

--- a/stdlib/public/core/StringUTF16.swift
+++ b/stdlib/public/core/StringUTF16.swift
@@ -321,7 +321,7 @@ extension String {
     {
         return nil
     }
-    self = wholeString[start..<end]
+    self = String(wholeString[start..<end])
   }
 
   /// The index type for subscripting a string's `utf16` view.

--- a/stdlib/public/core/StringUTF8.swift
+++ b/stdlib/public/core/StringUTF8.swift
@@ -352,7 +352,7 @@ extension String {
     let wholeString = String(utf8.base._core)
     if let start = utf8.startIndex.samePosition(in: wholeString),
        let end = utf8.endIndex.samePosition(in: wholeString) {
-      self = wholeString[start..<end]
+      self = String(wholeString[start..<end])
       return
     }
     return nil


### PR DESCRIPTION
This is not ready for merge yet because, at the very least, we don't (yet) have an answer for `allZeros` that doesn't force us to keep it around forever.  As long as we build the standard library in Swift 3.2 mode, the compiler's current combination of bugs and features allows us to prevent users from actually using it when they build in Swift 4 mode.

Related radar: <rdar://problem/31725206>