### PR TITLE
[4.0] Fix RemoteAST support for nested types involving generics

### DIFF
--- a/lib/RemoteAST/RemoteAST.cpp
+++ b/lib/RemoteAST/RemoteAST.cpp
@@ -135,7 +135,7 @@ public:
 
   Type createNominalType(NominalTypeDecl *decl, Type parent) {
     // If the declaration is generic, fail.
-    if (decl->getGenericSignature())
+    if (decl->getGenericParams())
       return Type();
 
     // Validate the parent type.
@@ -148,7 +148,7 @@ public:
   Type createBoundGenericType(NominalTypeDecl *decl, ArrayRef<Type> args,
                               Type parent) {
     // If the declaration isn't generic, fail.
-    if (!decl->getGenericSignature())
+    if (!decl->getGenericParams())
       return Type();
 
     // Validate the parent type.
@@ -212,9 +212,11 @@ public:
           auto nominal = p->castTo<NominalType>();
           simpleComponents.emplace_back(SourceLoc(),
                                         nominal->getDecl()->getName());
+          simpleComponents.back().setValue(nominal->getDecl());
           componentReprs.push_back(&simpleComponents.back());
         }
       }
+      componentReprs.push_back(&genericRepr);
 
       CompoundIdentTypeRepr compoundRepr(componentReprs);
       genericType = checkTypeRepr(&compoundRepr);

--- a/test/RemoteAST/nominal_types.swift
+++ b/test/RemoteAST/nominal_types.swift
@@ -50,26 +50,31 @@ enum G {
   case Gwhatever
 
   struct Foo {}
+  struct Bar<T> {}
 }
 printType(G.self)
 // CHECK: G
 printType(G.Foo.self)
 // CHECK: G.Foo
+printType(G.Bar<A>.self)
+// CHECK: G.Bar<A>
 
-struct H<T, U> {}
+struct H<T, U> {
+  struct Foo {}
+  struct Bar<V, W> {}
+}
 printType(H<A,A>.self)
 // CHECK: H<A, A>
 printType(H<B.Foo, H<B, A>>.self)
 // CHECK: H<B.Foo, H<B, A>>
+printType(H<B, B>.Foo.self)
+// CHECK: H<B, B>.Foo
+printType(H<A, B>.Bar<B, A>.self)
+// CHECK: H<A, B>.Bar<B, A>
 
 class I<T> {}
 printType(I<Int>.self)
 // CHECK: I<Int>
-
-// None of these are currently permitted by Sema.
-// TODO: non-generic types nested in generic types
-// TODO: generic types nested in generic types
-// TODO: generic types nested in non-generic types
 
 protocol J {}
 


### PR DESCRIPTION
RemoteAST, the library that LLDB uses to translate Swift type metadata objects into references to Swift AST types, does not work correctly for nested generic types, and in fact will crash in some cases.  This is because I could not properly test these cases when I implemented RemoteAST because the type-checker did not support them.

This is the swift-4.0-branch version of #10989.  It fixes rdar://31981929.

The patch only affects LLDB because it modifies RemoteAST, which is not linked into anything else.  It potentially affects a wide range of debugging scenarios involving nested generic types, which are sometimes used in the standard library.

The risk is low.  The patch is written in a way that should only affect generic types, and testing shows that it has not introduced regressions in this area.  The largest changes are to a code path for generic types nested within other types which, as written, could never have worked and in fact led to an immediate assertion.

This has been tested only with regression tests.