### PR TITLE
[4.0] Upgrade the warning about non-escaping parameter exclusivity to an error

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -267,8 +267,7 @@ ERROR(incorrect_explicit_closure_result,none,
       "declared closure result %0 is incompatible with contextual type %1",
       (Type, Type))
 
-// FIXME: make this an error when we've fixed the Dispatch problem.
-WARNING(err_noescape_param_call,none,
+ERROR(err_noescape_param_call,none,
       "passing a %select{|closure which captures a }1non-escaping function "
       "parameter %0 to a call to a non-escaping function parameter can allow "
       "re-entrant modification of a variable",

--- a/test/expr/postfix/call/noescape-param-exclusivity.swift
+++ b/test/expr/postfix/call/noescape-param-exclusivity.swift
@@ -3,13 +3,13 @@
 // FIXME: make these errors
 
 func test0(fn: (() -> ()) -> ()) {
-  fn { fn {} } // expected-warning {{passing a closure which captures a non-escaping function parameter 'fn' to a call to a non-escaping function parameter can allow re-entrant modification of a variable}}
+  fn { fn {} } // expected-error {{passing a closure which captures a non-escaping function parameter 'fn' to a call to a non-escaping function parameter can allow re-entrant modification of a variable}}
 }
 
 func test1(fn: (() -> ()) -> ()) { // expected-note {{parameter 'fn' is implicitly non-escaping}}
   // TODO: infer that this function is noescape from its captures
   func foo() {
-    fn { fn {} } // expected-warning {{can allow re-entrant modification}}
+    fn { fn {} } // expected-error {{can allow re-entrant modification}}
     // expected-error@-1 {{declaration closing over non-escaping parameter 'fn' may allow it to escape}}
   }
 }
@@ -25,7 +25,7 @@ func test2(x: inout Int, fn: (() -> ()) -> ()) {
 }
 
 func test3(fn: (() -> ()) -> ()) {
-  { myfn in myfn { fn {} } }(fn) // expected-warning {{can allow re-entrant modification}}
+  { myfn in myfn { fn {} } }(fn) // expected-error {{can allow re-entrant modification}}
 }
 
 func test4(fn: (() -> ()) -> ()) { // expected-note {{parameter 'fn' is implicitly non-escaping}}


### PR DESCRIPTION
The restriction on the use of non-escaping closure parameters in SE-0176 was initially implemented as a warning even in Swift  mode because it broke the Dispatch overlay.  Dispatch has fixed their code (rdar://33065909, https://github.com/apple/swift-corelibs-libdispatch/pull/268), so we can now promote this to an error.  It is important to promote it to an error in Swift 4 in order to make the basic exclusivity model as close as possible to what we want to commit to.

This is the swift-4.0-branch version of #10988.  It is being tracked as rdar://33337020.

The patch turns a warning into an error, and only when compiling as Swift 4.  Compiling as Swift 3 continues to be a warning. 

The risk is low.  It's possible that code will stop compiling, but only when code is being built as Swift 4, and only if the code was previously emitting a warning.

No additional testing beyond CI coverage has been performed.