### PR TITLE
Remove CleanupIllFormedExpressionRAII from preCheckExpression.

### DIFF
--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1609,9 +1609,6 @@ bool TypeChecker::preCheckExpression(Expr *&expr, DeclContext *dc) {
     expr = result;
     return false;
   }
-
-  // Pre-check failed. Clean up and return.
-  CleanupIllFormedExpressionRAII::doIt(expr, Context);
   return true;
 }
 


### PR DESCRIPTION
It erases type variables, but none can exist at this point.
