### PR TITLE
[stdlib] Drop some @available(introduced:...)

### DIFF
--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -2181,7 +2181,6 @@ extension FixedWidthInteger {
 //===----------------------------------------------------------------------===//
 
 ${operatorComment(x.nonMaskingOperator, True)}
-  @available(swift, introduced: 4)
   @_transparent
   public static func ${x.nonMaskingOperator} <
     Other : BinaryInteger
@@ -2205,7 +2204,6 @@ ${operatorComment(x.nonMaskingOperator, True)}
   }
 #endif
 
-  @available(swift, introduced: 4)
   @_transparent
   public static func ${x.nonMaskingOperator}= <
     Other : BinaryInteger


### PR DESCRIPTION
These annotations make it hard to write code that works in both Swift 3 and Swift 4, so if they aren't needed we should remove them.
