### PR TITLE
Change typeCheckExpression() to return Type.

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -495,9 +495,10 @@ namespace {
                   refExpr = declRefExpr;
                 }
 
-                if (tc.typeCheckExpression(refExpr, cs.DC,
-                                           TypeLoc::withoutLoc(expectedFnType),
-                                           CTP_CannotFail))
+                auto resultTy = tc.typeCheckExpression(
+                    refExpr, cs.DC, TypeLoc::withoutLoc(expectedFnType),
+                    CTP_CannotFail);
+                if (!resultTy)
                   return nullptr;
 
                 cs.cacheExprTypes(refExpr);
@@ -3613,14 +3614,12 @@ namespace {
       Expr *callExpr = CallExpr::createImplicit(ctx, fnRef, { argExpr },
                                                 { Identifier() });
 
-      bool invalid = tc.typeCheckExpression(callExpr, cs.DC,
-                                            TypeLoc::withoutLoc(valueType),
-                                            CTP_CannotFail);
+      auto resultTy = tc.typeCheckExpression(
+          callExpr, cs.DC, TypeLoc::withoutLoc(valueType), CTP_CannotFail);
+      assert(resultTy && "Conversion cannot fail!");
+      (void)resultTy;
+
       cs.cacheExprTypes(callExpr);
-
-      (void) invalid;
-      assert(!invalid && "conversion cannot fail");
-
       E->setSemanticExpr(callExpr);
       return E;
     }
@@ -4515,13 +4514,12 @@ getCallerDefaultArg(ConstraintSystem &cs, DeclContext *dc,
 
   // Convert the literal to the appropriate type.
   auto defArgType = ownerFn->mapTypeIntoContext(defArg.second);
-  bool invalid = tc.typeCheckExpression(init, dc, 
-                                        TypeLoc::withoutLoc(defArgType),
-                                        CTP_CannotFail);
-  cs.cacheExprTypes(init);
+  auto resultTy = tc.typeCheckExpression(
+      init, dc, TypeLoc::withoutLoc(defArgType), CTP_CannotFail);
+  assert(resultTy && "Conversion cannot fail");
+  (void)resultTy;
 
-  assert(!invalid && "conversion cannot fail");
-  (void)invalid;
+  cs.cacheExprTypes(init);
 
   return {init, defArg.first};
 }

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -3357,7 +3357,7 @@ Expr *FailureDiagnosis::typeCheckChildIndependently(
   // important, isn't itself sufficient because of AST mutation.
   eraseOpenedExistentials(subExpr);
 
-  bool hadError = CS.TC.typeCheckExpression(
+  auto resultTy = CS.TC.typeCheckExpression(
       subExpr, CS.DC, TypeLoc::withoutLoc(convertType), convertTypePurpose,
       TCEOptions, listener, &CS);
 
@@ -3371,12 +3371,12 @@ Expr *FailureDiagnosis::typeCheckChildIndependently(
   
   // If recursive type checking failed, then an error was emitted.  Return
   // null to indicate this to the caller.
-  if (hadError)
+  if (!resultTy)
     return nullptr;
 
   // If we type checked the result but failed to get a usable output from it,
   // just pretend as though nothing happened.
-  if (subExpr->getType()->is<ErrorType>()) {
+  if (resultTy->is<ErrorType>()) {
     subExpr = preCheckedExpr;
     SavedTypeData.restore();
   }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3108,9 +3108,10 @@ static void checkEnumRawValues(TypeChecker &TC, EnumDecl *ED) {
     // Check the raw value expr, if we have one.
     if (auto *rawValue = elt->getRawValueExpr()) {
       Expr *typeCheckedExpr = rawValue;
-      if (!TC.typeCheckExpression(typeCheckedExpr, ED, 
-                                  TypeLoc::withoutLoc(rawTy),
-                                  CTP_EnumCaseRawValue)) {
+      auto resultTy = TC.typeCheckExpression(typeCheckedExpr, ED,
+                                             TypeLoc::withoutLoc(rawTy),
+                                             CTP_EnumCaseRawValue);
+      if (resultTy) {
         elt->setTypeCheckedRawValueExpr(typeCheckedExpr);
       }
       lastExplicitValueElt = elt;
@@ -3125,9 +3126,9 @@ static void checkEnumRawValues(TypeChecker &TC, EnumDecl *ED) {
       }
       elt->setRawValueExpr(nextValue);
       Expr *typeChecked = nextValue;
-      if (!TC.typeCheckExpression(typeChecked, ED, 
-                                  TypeLoc::withoutLoc(rawTy),
-                                  CTP_EnumCaseRawValue))
+      auto resultTy = TC.typeCheckExpression(
+          typeChecked, ED, TypeLoc::withoutLoc(rawTy), CTP_EnumCaseRawValue);
+      if (resultTy)
         elt->setTypeCheckedRawValueExpr(typeChecked);
     }
     prevValue = elt->getRawValueExpr();
@@ -8431,10 +8432,10 @@ void TypeChecker::addImplicitEnumConformances(EnumDecl *ED) {
     if (elt->getTypeCheckedRawValueExpr()) continue;
     Expr *typeChecked = elt->getRawValueExpr();
     Type rawTy = ED->mapTypeIntoContext(ED->getRawType());
-    bool error = typeCheckExpression(typeChecked, ED, 
-                                     TypeLoc::withoutLoc(rawTy),
-                                     CTP_EnumCaseRawValue);
-    assert(!error); (void)error;
+    auto resultTy = typeCheckExpression(
+        typeChecked, ED, TypeLoc::withoutLoc(rawTy), CTP_EnumCaseRawValue);
+    assert(resultTy);
+    (void)resultTy;
     elt->setTypeCheckedRawValueExpr(typeChecked);
     checkEnumElementErrorHandling(elt);
   }

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -918,12 +918,14 @@ bool swift::typeCheckExpression(DeclContext *DC, Expr *&parsedExpr) {
   auto &ctx = DC->getASTContext();
   if (ctx.getLazyResolver()) {
     TypeChecker *TC = static_cast<TypeChecker *>(ctx.getLazyResolver());
-    return TC->typeCheckExpression(parsedExpr, DC);
+    auto resultTy = TC->typeCheckExpression(parsedExpr, DC);
+    return !resultTy;
   } else {
     // Set up a diagnostics engine that swallows diagnostics.
     DiagnosticEngine diags(ctx.SourceMgr);
     TypeChecker TC(ctx, diags);
-    return TC.typeCheckExpression(parsedExpr, DC);
+    auto resultTy = TC.typeCheckExpression(parsedExpr, DC);
+    return !resultTy;
   }
 }
 

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1562,14 +1562,15 @@ public:
   /// otherwise
   ///
   /// \returns true if an error occurred, false otherwise.
-  bool typeCheckExpression(Expr *&expr, DeclContext *dc,
-                           TypeLoc convertType = TypeLoc(),
-                           ContextualTypePurpose convertTypePurpose =CTP_Unused,
-                           TypeCheckExprOptions options =TypeCheckExprOptions(),
-                           ExprTypeCheckListener *listener = nullptr,
-                           constraints::ConstraintSystem *baseCS = nullptr);
+  Type
+  typeCheckExpression(Expr *&expr, DeclContext *dc,
+                      TypeLoc convertType = TypeLoc(),
+                      ContextualTypePurpose convertTypePurpose = CTP_Unused,
+                      TypeCheckExprOptions options = TypeCheckExprOptions(),
+                      ExprTypeCheckListener *listener = nullptr,
+                      constraints::ConstraintSystem *baseCS = nullptr);
 
-  bool typeCheckExpression(Expr *&expr, DeclContext *dc,
+  Type typeCheckExpression(Expr *&expr, DeclContext *dc,
                            ExprTypeCheckListener *listener) {
     return typeCheckExpression(expr, dc, TypeLoc(), CTP_Unused,
                                TypeCheckExprOptions(), listener);


### PR DESCRIPTION
Doing this allows us to return ErrorType in some circumstances where we
want to communicate that we don't have a usable type rather than writing
ErrorType directly into the type of the expression root, avoiding a
mutation of the expression tree in a failure case.