### PR TITLE
Don't look through arbitrary open-existentials in the bridging peephole

### DIFF
--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -593,6 +593,11 @@ static BridgingConversion getBridgingConversion(Expr *E) {
     return { E, kind, 0 };
   }
 
+  // If we peeked through an opening, and we didn't recognize a specific
+  // pattern above involving the opaque value, make sure we use the opening
+  // as the final expression instead of accidentally look through it.
+  if (open) return { open, None, 0 };
+
   return { E, None, 0 };
 }
 

--- a/test/SILGen/objc_bridging_peephole.swift
+++ b/test/SILGen/objc_bridging_peephole.swift
@@ -472,3 +472,13 @@ func testNullproneSubscriptSet(object: NullproneSubscript, index: AnyObject) {
   // CHECK:      end_borrow [[SELF]] from %0
   object[index] = makeOptNS() as String?
 }
+
+/*** Bugfixes ***************************************************************/
+
+protocol P {
+  var title : String { get }
+}
+
+func foo(p: P) {
+  DummyClass().takeNullableString(p.title)
+}


### PR DESCRIPTION
When looking for non-bridging conversions to peephole into a contextual conversion, make sure we don't peek through open-existentials.

Crashers here look like:

```
Assertion failed: (SGF.OpaqueValues.count(E) && "Didn't bind OpaqueValueExpr"), function visitOpaqueValueExpr, file lib/SILGen/SILGenExpr.cpp, line 4480.
```

with something like this in the backtrace:

```
19 swift 0x000000010d341593 swift::Lowering::SILGenFunction::emitRValueAsSingleValue(swift::Expr*, swift::Lowering::SGFContext) + 83
20 swift 0x000000010d364300 tryEmitAsBridgingConversion(swift::Lowering::SILGenFunction&, swift::Expr*, bool, swift::Lowering::SGFContext)::$_1::operator()(swift::Lowering::SILGenFunction&, swift::SILLocation, swift::Lowering::SGFContext) const + 48
```

Fixes rdar://33341584 (possibly only partially).