### PR TITLE
[Sema] Fix crash case in exhaustive check for Never value

### DIFF
--- a/lib/Sema/TypeCheckSwitchStmt.cpp
+++ b/lib/Sema/TypeCheckSwitchStmt.cpp
@@ -957,8 +957,13 @@ namespace {
       }
       
       Space totalSpace(Switch->getSubjectExpr()->getType(), Identifier());
-      Space coveredSpace(spaces);
       size_t totalSpaceSize = totalSpace.getSize(TC);
+      if (totalSpaceSize == 0 && spaces.empty()) {
+        diagnoseMissingCases(TC, Switch, /*justNeedsDefault*/true, Space());
+        return;
+      }
+
+      Space coveredSpace(spaces);
       if (totalSpaceSize > Space::getMaximumSize()) {
         // Because the space is large, we have to extend the size
         // heuristic to compensate for actually exhaustively pattern matching

--- a/test/Sema/exhaustive_switch.swift
+++ b/test/Sema/exhaustive_switch.swift
@@ -533,3 +533,30 @@ func infinitelySized() -> Bool {
   case (.two, .two): return true
   }
 }
+
+func switchNever1(x: Never) -> Bool {
+  switch x {
+    default: return true
+  }
+
+  switch x {
+    // FIXME: Bad diagnostics.
+    case let _b: // expected-warning {{case is already handled by previous patterns; consider removing it}}
+      print(_b)
+      return true
+  }
+
+  switch x { // expected-error {{'switch' statement body must have at least one 'case' or 'default' block; do you want to add a default case?}} {{3-3=default:\n<#code#>\n}}
+  }
+}
+
+struct Generic<T> {
+  let value: T
+}
+
+extension Generic where T == Never {
+  func switchNever2() {
+    switch value { // expected-error {{'switch' statement body must have at least one 'case' or 'default' block; do you want to add a default case?}} {{5-5=default:\n<#code#>\n}}
+    }
+  }
+}


### PR DESCRIPTION
Switch statement must have at least `default` even for `enum` without cases.

This code used to crash in SILGen.
```swift
func check(x: Never) -> Bool {
  switch x {
  }
}
```

CC/ @CodaFi 