### PR TITLE
[swift-4.0-branch] Improve usability of NSItemProvider APIs for bridgeable types

### DIFF
--- a/stdlib/public/SDK/Foundation/CMakeLists.txt
+++ b/stdlib/public/SDK/Foundation/CMakeLists.txt
@@ -31,6 +31,7 @@ add_swift_library(swiftFoundation ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SD
   NSFastEnumeration.swift
   NSGeometry.swift
   NSIndexSet.swift
+  NSItemProvider.swift
   NSNumber.swift
   NSObject.swift
   NSPredicate.swift

--- a/stdlib/public/SDK/Foundation/NSItemProvider.swift
+++ b/stdlib/public/SDK/Foundation/NSItemProvider.swift
@@ -1,0 +1,56 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_exported import Foundation // Clang module
+
+@available(OSX 10.13, iOS 11.0, watchOS 4.0, tvOS 11.0, *)
+extension NSItemProvider  {
+
+  @available(OSX 10.13, iOS 11.0, watchOS 4.0, tvOS 11.0, *)
+  public func registerObject<
+    T : _ObjectiveCBridgeable
+  > (
+    ofClass: T.Type,
+    visibility: NSItemProviderRepresentationVisibility,
+    loadHandler: @escaping ((T?, Error?) -> Void) -> Progress?
+  ) where T._ObjectiveCType : NSItemProviderWriting {
+    self.registerObject(
+      ofClass: T._ObjectiveCType.self, visibility: visibility) {
+      completionHandler in loadHandler {
+        // Using `x as! T._ObjectiveCType?` triggers an assertion in the
+        // compiler, hence the explicit call to `_bridgeToObjectiveC`.
+        (x, error) in completionHandler(x?._bridgeToObjectiveC(), error)
+      }
+    }
+  }
+
+  @available(OSX 10.13, iOS 11.0, watchOS 4.0, tvOS 11.0, *)
+  public func canLoadObject<
+    T : _ObjectiveCBridgeable
+  >(ofClass: T.Type) -> Bool
+  where T._ObjectiveCType : NSItemProviderReading {
+    return self.canLoadObject(ofClass: T._ObjectiveCType.self)
+  }
+
+  @available(OSX 10.13, iOS 11.0, watchOS 4.0, tvOS 11.0, *)
+  public func loadObject<
+    T : _ObjectiveCBridgeable
+  >(
+    ofClass: T.Type,
+    completionHandler: @escaping (T?, Error?) -> Void
+  ) -> Progress where T._ObjectiveCType : NSItemProviderReading {
+    return self.loadObject(ofClass: T._ObjectiveCType.self) {
+      x, error in completionHandler(x as! T?, error)
+    }
+  }
+
+}

--- a/stdlib/public/SDK/UIKit/UIKit.swift
+++ b/stdlib/public/SDK/UIKit/UIKit.swift
@@ -302,25 +302,13 @@ extension UIFocusItem {
 
 #if os(iOS)
 
-public protocol _SwiftDragDropItemProvider {
-  associatedtype _FoundationType : NSObject
-}
-
-extension String : _SwiftDragDropItemProvider {
-  public typealias _FoundationType = NSString
-}
-
-extension URL : _SwiftDragDropItemProvider {
-  public typealias _FoundationType = NSURL
-}
-
 @available(iOS 11.0, *)
 extension UIDragDropSession {
   @available(iOS 11.0, *)
   public func canLoadObjects<
-    T : _SwiftDragDropItemProvider
-  >(ofClass: T.Type) -> Bool where T._FoundationType : NSItemProviderReading {
-    return self.canLoadObjects(ofClass: T._FoundationType.self);
+    T : _ObjectiveCBridgeable
+  >(ofClass: T.Type) -> Bool where T._ObjectiveCType : NSItemProviderReading {
+    return self.canLoadObjects(ofClass: T._ObjectiveCType.self);
   }
 }
 
@@ -328,12 +316,12 @@ extension UIDragDropSession {
 extension UIDropSession {
   @available(iOS 11.0, *)
   public func loadObjects<
-    T : _SwiftDragDropItemProvider
+    T : _ObjectiveCBridgeable
   >(
     ofClass: T.Type,
     completion: @escaping ([T]) -> Void
-  ) -> Progress where T._FoundationType : NSItemProviderReading {
-    return self.loadObjects(ofClass: T._FoundationType.self) { nss in
+  ) -> Progress where T._ObjectiveCType : NSItemProviderReading {
+    return self.loadObjects(ofClass: T._ObjectiveCType.self) { nss in
       let natives = nss.map { $0 as! T }
       completion(natives)
     }
@@ -344,17 +332,17 @@ extension UIDropSession {
 extension UIPasteConfiguration {
   @available(iOS 11.0, *)
   public convenience init<
-    T : _SwiftDragDropItemProvider
-  >(forAccepting _: T.Type) where T._FoundationType : NSItemProviderReading {
-    self.init(forAccepting: T._FoundationType.self)
+    T : _ObjectiveCBridgeable
+  >(forAccepting _: T.Type) where T._ObjectiveCType : NSItemProviderReading {
+    self.init(forAccepting: T._ObjectiveCType.self)
   }
 
   @available(iOS 11.0, *)
   public func addTypeIdentifiers<
-    T : _SwiftDragDropItemProvider
+    T : _ObjectiveCBridgeable
   >(forAccepting aClass: T.Type)
-  where T._FoundationType : NSItemProviderReading {
-    self.addTypeIdentifiers(forAccepting: T._FoundationType.self)
+  where T._ObjectiveCType : NSItemProviderReading {
+    self.addTypeIdentifiers(forAccepting: T._ObjectiveCType.self)
   }
 }
 
@@ -362,21 +350,25 @@ extension UIPasteConfiguration {
 extension UIPasteboard {
   @available(iOS 11.0, *)
   public func setObjects<
-    T : _SwiftDragDropItemProvider
-  >(_ objects: [T]) where T._FoundationType : NSItemProviderWriting {
-    self.setObjects(objects.map { $0 as! T._FoundationType })
+    T : _ObjectiveCBridgeable
+  >(_ objects: [T]) where T._ObjectiveCType : NSItemProviderWriting {
+    // Using a simpler `$0 as! T._ObjectiveCType` triggers and assertion in
+    // the compiler.
+    self.setObjects(objects.map { $0._bridgeToObjectiveC() })
   }
 
   @available(iOS 11.0, *)
   public func setObjects<
-    T : _SwiftDragDropItemProvider
+    T : _ObjectiveCBridgeable
   >(
     _ objects: [T],
     localOnly: Bool,
     expirationDate: Date?
-  ) where T._FoundationType : NSItemProviderWriting {
+  ) where T._ObjectiveCType : NSItemProviderWriting {
     self.setObjects(
-      objects.map { $0 as! T._FoundationType },
+      // Using a simpler `$0 as! T._ObjectiveCType` triggers and assertion in
+      // the compiler.
+      objects.map { $0._bridgeToObjectiveC() },
       localOnly: localOnly,
       expirationDate: expirationDate)
   }

--- a/test/stdlib/NSItemProvider.swift
+++ b/test/stdlib/NSItemProvider.swift
@@ -1,0 +1,62 @@
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+import StdlibUnittest
+
+import Foundation
+
+var tests = TestSuite("NSItemProvider")
+
+if #available(OSX 10.13, iOS 11.0, watchOS 4.0, tvOS 11.0, *) {
+
+  tests.test("overlay") {
+    let itemProvider = NSItemProvider()
+
+    let string = "Hello"
+    let url = URL(string: "https://www.apple.com")
+
+    itemProvider.registerObject(ofClass: String.self, visibility: .all) {
+      (completionBlock) in
+        completionBlock(string, nil)
+        return nil
+    }
+
+    itemProvider.registerObject(ofClass: URL.self, visibility: .all) {
+      (completionBlock) in
+        completionBlock(url, nil)
+        return nil
+    }
+
+    expectTrue(itemProvider.canLoadObject(ofClass: String.self))
+    expectTrue(itemProvider.canLoadObject(ofClass: URL.self))
+
+//  let expectLoadString = expectation("loadString")
+    _ = itemProvider.loadObject(ofClass: String.self) {
+      (string, error) in
+        expectNotNil(string)
+        expectNil(error)
+//      expectLoadString.fulfill()
+    }
+
+//  let expectLoadURL = expectation("loadURL")
+    _ = itemProvider.loadObject(ofClass: String.self) {
+      (url, error) in
+        expectNotNil(url)
+        expectNil(error)
+//      expectLoadURL.fulfill()
+    }
+
+//  wait(for: [expectLoadString, expectLoadURL], 1.0)
+  }
+}
+
+runAllTests()

--- a/test/stdlib/UIKit.swift
+++ b/test/stdlib/UIKit.swift
@@ -154,4 +154,33 @@ UIKitTests.test("UIFocusEnvironment") {
 }
 #endif
 
+#if os(iOS)
+
+UIKitTests.test("NSItemProviderReadingWriting support") {
+  if #available(iOS 11.0, *) {
+    func f<T : UIDragDropSession>(session: T) {
+      _ = session.canLoadObjects(ofClass: String.self)
+      _ = session.canLoadObjects(ofClass: URL.self)
+    }
+    func g<T : UIDropSession>(session: T) {
+      _ = session.loadObjects(ofClass: String.self) { _ in ()}
+      _ = session.loadObjects(ofClass: URL.self) { _ in () }
+    }
+
+    let pc0 = UIPasteConfiguration(forAccepting: String.self)
+    let pc1 = UIPasteConfiguration(forAccepting: URL.self)
+    pc0.addTypeIdentifiers(forAccepting: URL.self)
+    pc1.addTypeIdentifiers(forAccepting: String.self)
+
+    var pb = UIPasteboard.general
+    pb.setObjects(["Hello"])
+    pb.setObjects([URL(string: "https://www.apple.com")!])
+    pb.setObjects(["Hello"], localOnly: true, expirationDate: nil)
+    pb.setObjects([URL(string: "https://www.apple.com")!], localOnly: true, expirationDate: nil)
+  }
+}
+
+#endif
+
+
 runAllTests()


### PR DESCRIPTION
* Explanation: Improves usability of the Drag-n-Drop APIs with the types that can be bridged between ObjC and Swift (String, URL, Data, etc.)
* Scope of Issue: Additive change, as the old overloads are still available
* Risk: Minimal
* Reviewed By: Dave Rahardja
* Testing: Automated test suite with the new cases
* Directions for QA: N/A
* Radar: <rdar://problem/33354388>