### PR TITLE
[stdlib] Make String.UTF8View bidirectional

### DIFF
--- a/stdlib/public/core/StringIndex.swift
+++ b/stdlib/public/core/StringIndex.swift
@@ -29,15 +29,19 @@ extension String {
 
 /// Convenience accessors
 extension String.Index._Cache {
+  @_versioned
   var utf16: Void? {
     if case .utf16 = self { return () } else { return nil }
   }
+  @_versioned
   var utf8: String.Index._UTF8Buffer? {
     if case .utf8(let r) = self { return r } else { return nil }
   }
+  @_versioned
   var character: UInt16? {
     if case .character(let r) = self { return r } else { return nil }
   }
+  @_versioned
   var unicodeScalar: UnicodeScalar? {
     if case .unicodeScalar(let r) = self { return r } else { return nil }
   }

--- a/test/stdlib/StringDiagnostics.swift
+++ b/test/stdlib/StringDiagnostics.swift
@@ -71,7 +71,7 @@ func acceptsRandomAccessCollection<C: RandomAccessCollection>(_: C) {}
 
 func testStringCollectionTypes(s: String) {
   acceptsCollection(s.utf8)
-  acceptsBidirectionalCollection(s.utf8) // expected-error{{argument type 'String.UTF8View' does not conform to expected type 'BidirectionalCollection'}}
+  acceptsBidirectionalCollection(s.utf8) 
   acceptsRandomAccessCollection(s.utf8) // expected-error{{argument type 'String.UTF8View' does not conform to expected type 'RandomAccessCollection'}}
 
   acceptsCollection(s.utf16) 

--- a/test/stdlib/StringDiagnostics_without_Foundation.swift
+++ b/test/stdlib/StringDiagnostics_without_Foundation.swift
@@ -7,7 +7,7 @@ func acceptsRandomAccessCollection<I: RandomAccessCollection>(_: I) {}
 
 func testStringCollectionTypes(s: String) {
   acceptsCollection(s.utf8)
-  acceptsBidirectionalCollection(s.utf8) // expected-error{{argument type 'String.UTF8View' does not conform to expected type 'BidirectionalCollection'}}
+  acceptsBidirectionalCollection(s.utf8)
   acceptsRandomAccessCollection(s.utf8) // expected-error{{argument type 'String.UTF8View' does not conform to expected type 'RandomAccessCollection'}}
 
   // UTF16View is random-access with Foundation, bidirectional without

--- a/test/stdlib/UnavailableStringAPIs.swift.gyb
+++ b/test/stdlib/UnavailableStringAPIs.swift.gyb
@@ -26,7 +26,7 @@ func test_UTF16ViewSubscriptByInt(x: String.UTF16View, i: Int, r: Range<Int>) {
 
 func test_UTF8View(s: String.UTF8View, i: String.UTF8View.Index, d: Int) {
   _ = s.index(after: i) // OK
-  _ = s.index(before: i) // expected-error {{before:}} expected-note {{overloads}}
+  _ = s.index(before: i) // OK
   _ = s.index(i, offsetBy: d) // OK
   _ = s.index(i, offsetBy: d, limitedBy: i) // OK
   _ = s.distance(from: i, to: i) // OK

--- a/validation-test/stdlib/String.swift
+++ b/validation-test/stdlib/String.swift
@@ -59,10 +59,10 @@ StringTests.test("AssociatedTypes-UTF8View") {
   expectCollectionAssociatedTypes(
     collectionType: View.self,
     iteratorType: View.Iterator.self,
-    subSequenceType: Slice<View>.self,
+    subSequenceType: BidirectionalSlice<View>.self,
     indexType: View.Index.self,
     indexDistanceType: Int.self,
-    indicesType: DefaultIndices<View>.self)
+    indicesType: DefaultBidirectionalIndices<View>.self)
 }
 
 StringTests.test("AssociatedTypes-UTF16View") {

--- a/validation-test/stdlib/StringViews.swift
+++ b/validation-test/stdlib/StringViews.swift
@@ -728,8 +728,7 @@ tests.test("String.UTF8View/Collection")
   .forEach(in: utfTests) {
   test in
 
-  // FIXME(ABI)#72 : should be `checkBidirectionalCollection`.
-  checkForwardCollection(test.utf8, test.string.utf8) { $0 == $1 }
+  checkBidirectionalCollection(test.utf8, test.string.utf8) { $0 == $1 }
 }
 
 tests.test("String.UTF16View/BidirectionalCollection")


### PR DESCRIPTION
This is a step along the way toward handling backward-compatiblity of UTF8View slicing and preventing inadvertent creation of String instances that keep inaccessible memory alive.
