### PR TITLE
Remove imports of SILModule.h from files that don't need it.

### DIFF
--- a/lib/Basic/Statistic.cpp
+++ b/lib/Basic/Statistic.cpp
@@ -12,7 +12,6 @@
 
 #include "swift/Basic/Statistic.h"
 #include "swift/Driver/DependencyGraph.h"
-#include "swift/SIL/SILModule.h"
 #include "llvm/Config/config.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Path.h"

--- a/lib/IDE/TypeReconstruction.cpp
+++ b/lib/IDE/TypeReconstruction.cpp
@@ -11,14 +11,15 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/IDE/Utils.h"
+#include "swift/AST/ASTContext.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/GenericSignature.h"
 #include "swift/AST/NameLookup.h"
+#include "swift/AST/Types.h"
 #include "swift/AST/SubstitutionMap.h"
 #include "swift/Demangling/Demangle.h"
 #include "swift/Demangling/ManglingMacros.h"
 #include "swift/ClangImporter/ClangImporter.h"
-#include "swift/SIL/SILModule.h"
 #include "swift/Strings.h"
 
 #include <cstdio>


### PR DESCRIPTION
No functionality change.