### PR TITLE
SILGen: Remove unused catch block for a try? expr using SGF.eraseBasicBlock().

### DIFF
--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -1426,7 +1426,7 @@ RValue RValueEmitter::visitOptionalTryExpr(OptionalTryExpr *E, SGFContext C) {
   // If it turns out there are no uses of the catch block, just drop it.
   if (catchBB->pred_empty()) {
     // Remove the dead failureBB.
-    catchBB->eraseFromParent();
+    SGF.eraseBasicBlock(catchBB);
 
     // The value we provide is the one we've already got.
     if (!isByAddress)

--- a/test/SILGen/errors.swift
+++ b/test/SILGen/errors.swift
@@ -778,6 +778,15 @@ func testOptionalTry() {
   _ = try? make_a_cat()
 }
 
+func sudo_make_a_cat() {}
+
+// CHECK-LABEL: sil hidden @{{.*}}testOptionalTryThatNeverThrows
+func testOptionalTryThatNeverThrows() {
+  guard let _ = try? sudo_make_a_cat() else { // expected-warning{{no calls to throwing}}
+    return
+  }
+}
+
 // CHECK-LABEL: sil hidden @_T06errors18testOptionalTryVaryyF
 // CHECK-NEXT: bb0:
 // CHECK-NEXT: [[BOX:%.+]] = alloc_box ${ var Optional<Cat> }


### PR DESCRIPTION
Erasing the block directly from its parent using bb->eraseFromParent() doesn't update SILGenFunction's internal state tracking the postmatter section of the function. Fixes SR-1333 | rdar://problem/33351098.