### PR TITLE
[4.0] [ClangImporter] Add direct access for import-as-member types.

### DIFF
--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -558,6 +558,18 @@ public:
     return nullptr;
   }
 
+  /// Directly look for a nested type declared within this module inside the
+  /// given nominal type (including any extensions).
+  ///
+  /// This is a fast-path hack to avoid circular dependencies in deserialization
+  /// and the Clang importer.
+  ///
+  /// Private and fileprivate types should not be returned by this lookup.
+  virtual TypeDecl *lookupNestedType(Identifier name,
+                                     const NominalTypeDecl *parent) const {
+    return nullptr;
+  }
+
   /// Find ValueDecls in the module and pass them to the given consumer object.
   ///
   /// This does a simple local lookup, not recursively looking through imports.

--- a/include/swift/ClangImporter/ClangModule.h
+++ b/include/swift/ClangImporter/ClangModule.h
@@ -62,6 +62,10 @@ public:
                            DeclName name, NLKind lookupKind,
                            SmallVectorImpl<ValueDecl*> &results) const override;
 
+  virtual TypeDecl *
+  lookupNestedType(Identifier name,
+                   const NominalTypeDecl *baseType) const override;
+
   virtual void lookupVisibleDecls(ModuleDecl::AccessPathTy accessPath,
                                   VisibleDeclConsumer &consumer,
                                   NLKind lookupKind) const override;

--- a/include/swift/Serialization/ModuleFile.h
+++ b/include/swift/Serialization/ModuleFile.h
@@ -603,7 +603,7 @@ public:
 
   /// Searches the module's nested type decls table for the given member of
   /// the given type.
-  TypeDecl *lookupNestedType(Identifier name, const ValueDecl *parent);
+  TypeDecl *lookupNestedType(Identifier name, const NominalTypeDecl *parent);
 
   /// Searches the module's operators for one with the given name and fixity.
   ///

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -132,6 +132,10 @@ public:
 
   virtual TypeDecl *lookupLocalType(StringRef MangledName) const override;
 
+  virtual TypeDecl *
+  lookupNestedType(Identifier name,
+                   const NominalTypeDecl *parent) const override;
+
   virtual OperatorDecl *lookupOperator(Identifier name,
                                        DeclKind fixity) const override;
 

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2461,7 +2461,7 @@ ClangModuleUnit::lookupNestedType(Identifier name,
   // FIXME: This is very similar to what's in Implementation::lookupValue and
   // Implementation::loadAllMembers.
   SmallVector<TypeDecl *, 2> results;
-  for (auto entry : lookupTable->lookup(SerializedSwiftName(name.str()),
+  for (auto entry : lookupTable->lookup(name.str(),
                                         baseTypeContext)) {
     // If the entry is not visible, skip it.
     if (!isVisibleClangEntry(clangCtx, entry)) continue;

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2428,6 +2428,91 @@ static bool isVisibleClangEntry(clang::ASTContext &ctx,
   return true;
 }
 
+TypeDecl *
+ClangModuleUnit::lookupNestedType(Identifier name,
+                                  const NominalTypeDecl *baseType) const {
+  // Special case for error code enums: try looking directly into the struct
+  // first. But only if it looks like a synthesized error wrapped struct.
+  if (name == getASTContext().Id_Code && !baseType->hasClangNode() &&
+      isa<StructDecl>(baseType) && !baseType->hasLazyMembers() &&
+      baseType->isChildContextOf(this)) {
+    auto *mutableBase = const_cast<NominalTypeDecl *>(baseType);
+    auto codeEnum = mutableBase->lookupDirect(name,/*ignoreNewExtensions*/true);
+    // Double-check that we actually have a good result. It's possible what we
+    // found is /not/ a synthesized error struct, but just something that looks
+    // like it. But if we still found a good result we should return that.
+    if (codeEnum.size() == 1 && isa<TypeDecl>(codeEnum.front()))
+      return cast<TypeDecl>(codeEnum.front());
+    if (codeEnum.size() > 1)
+      return nullptr;
+    // Otherwise, fall back and try via lookup table.
+  }
+
+  auto lookupTable = owner.findLookupTable(clangModule);
+  if (!lookupTable)
+    return nullptr;
+
+  auto baseTypeContext = owner.getEffectiveClangContext(baseType);
+  if (!baseTypeContext)
+    return nullptr;
+
+  auto &clangCtx = owner.getClangASTContext();
+
+  // FIXME: This is very similar to what's in Implementation::lookupValue and
+  // Implementation::loadAllMembers.
+  SmallVector<TypeDecl *, 2> results;
+  for (auto entry : lookupTable->lookup(SerializedSwiftName(name.str()),
+                                        baseTypeContext)) {
+    // If the entry is not visible, skip it.
+    if (!isVisibleClangEntry(clangCtx, entry)) continue;
+
+    auto clangDecl = entry.dyn_cast<clang::NamedDecl *>();
+    auto clangTypeDecl = dyn_cast_or_null<clang::TypeDecl>(clangDecl);
+    if (!clangTypeDecl)
+      continue;
+
+    clangTypeDecl = cast<clang::TypeDecl>(clangTypeDecl->getMostRecentDecl());
+
+    bool anyMatching = false;
+    TypeDecl *originalDecl = nullptr;
+    owner.forEachDistinctName(clangTypeDecl, [&](ImportedName newName,
+                                                 ImportNameVersion nameVersion){
+      if (anyMatching)
+        return;
+      if (!newName.getDeclName().isSimpleName(name))
+        return;
+
+      auto decl = dyn_cast_or_null<TypeDecl>(
+          owner.importDeclReal(clangTypeDecl, nameVersion));
+      if (!decl)
+        return;
+
+      if (!originalDecl)
+        originalDecl = decl;
+      else if (originalDecl == decl)
+        return;
+
+      auto *importedContext = decl->getDeclContext()->
+          getAsNominalTypeOrNominalTypeExtensionContext();
+      if (importedContext != baseType)
+        return;
+
+      assert(decl->getFullName().matchesRef(name) &&
+             "importFullName behaved differently from importDecl");
+      results.push_back(decl);
+      anyMatching = true;
+    });
+  }
+
+  if (results.size() != 1) {
+    // It's possible that two types were import-as-member'd onto the same base
+    // type with the same name. In this case, fall back to regular lookup.
+    return nullptr;
+  }
+
+  return results.front();
+}
+
 void ClangImporter::loadExtensions(NominalTypeDecl *nominal,
                                    unsigned previousGeneration) {
   // Determine the effective Clang context for this Swift nominal type.
@@ -3124,7 +3209,7 @@ void ClangImporter::Implementation::lookupAllObjCMembers(
 }
 
 EffectiveClangContext ClangImporter::Implementation::getEffectiveClangContext(
-                        NominalTypeDecl *nominal) {
+    const NominalTypeDecl *nominal) {
   // If we have a Clang declaration, look at it to determine the
   // effective Clang context.
   if (auto constClangDecl = nominal->getClangDecl()) {
@@ -3139,7 +3224,7 @@ EffectiveClangContext ClangImporter::Implementation::getEffectiveClangContext(
 
   // Resolve the type.
   if (auto typeResolver = getTypeResolver())
-    typeResolver->resolveDeclSignature(nominal);
+    typeResolver->resolveDeclSignature(const_cast<NominalTypeDecl *>(nominal));
 
   // If it's an @objc entity, go look for it.
   if (nominal->isObjC()) {

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1163,7 +1163,8 @@ public:
                             VisibleDeclConsumer &consumer);
 
   /// Determine the effective Clang context for the given Swift nominal type.
-  EffectiveClangContext getEffectiveClangContext(NominalTypeDecl *nominal);
+  EffectiveClangContext
+  getEffectiveClangContext(const NominalTypeDecl *nominal);
 
   /// Attempts to import the name of \p decl with each possible
   /// ImportNameVersion. \p action will be called with each unique name.

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -1353,9 +1353,13 @@ ModuleFile::resolveCrossReference(ModuleDecl *baseModule, uint32_t pathLen) {
             nestedType = containingFile->lookupNestedType(memberName, baseType);
           }
         } else {
-          // Fault in extensions, then ask every serialized AST in the module.
+          // Fault in extensions, then ask every file in the module.
+          ModuleDecl *extensionModule = M;
+          if (!extensionModule)
+            extensionModule = baseType->getModuleContext();
+
           (void)baseType->getExtensions();
-          for (FileUnit *file : baseType->getModuleContext()->getFiles()) {
+          for (FileUnit *file : extensionModule->getFiles()) {
             if (file == getFile())
               continue;
             nestedType = file->lookupNestedType(memberName, baseType);

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -35,6 +35,10 @@
 STATISTIC(NumDeclsLoaded, "# of decls deserialized");
 STATISTIC(NumMemberListsLoaded,
           "# of nominals/extensions whose members were loaded");
+STATISTIC(NumNormalProtocolConformancesLoaded,
+          "# of normal protocol conformances deserialized");
+STATISTIC(NumNormalProtocolConformancesCompleted,
+          "# of normal protocol conformances completed");
 STATISTIC(NumNestedTypeShortcuts,
           "# of same-module nested types resolved without lookup");
 
@@ -106,18 +110,6 @@ namespace {
 
     void print(raw_ostream &os) const override {
       XRefTracePath::print(os, "\t");
-    }
-  };
-
-  class PrettyStackTraceModuleFile : public llvm::PrettyStackTraceEntry {
-    const char *Action;
-    const ModuleFile *MF;
-  public:
-    explicit PrettyStackTraceModuleFile(const char *action, ModuleFile *module)
-        : Action(action), MF(module) {}
-
-    void print(raw_ostream &os) const override {
-      os << Action << " \'" << getNameOfModule(MF) << "'\n";
     }
   };
 } // end anonymous namespace
@@ -583,7 +575,7 @@ ProtocolConformanceRef ModuleFile::readConformance(
     nominal->lookupConformance(module, proto, conformances);
     PrettyStackTraceModuleFile traceMsg(
         "If you're seeing a crash here, check that your SDK and dependencies "
-        "are at least as new as the versions used to build", this);
+        "are at least as new as the versions used to build", *this);
     // This would normally be an assertion but it's more useful to print the
     // PrettyStackTrace here even in no-asserts builds.
     if (conformances.empty())
@@ -640,6 +632,7 @@ NormalProtocolConformance *ModuleFile::readNormalConformance(
 
   auto proto = cast<ProtocolDecl>(getDecl(protoID));
   PrettyStackTraceDecl traceTo("... to", proto);
+  ++NumNormalProtocolConformancesLoaded;
 
   auto conformance = ctx.getConformance(conformingType, proto, SourceLoc(), dc,
                                         ProtocolConformanceState::Incomplete);
@@ -1598,7 +1591,7 @@ ModuleFile::resolveCrossReference(ModuleDecl *baseModule, uint32_t pathLen) {
     if (M != getAssociatedModule()) {
       traceMsg.emplace("If you're seeing a crash here, check that your SDK "
                          "and dependencies match the versions used to build",
-                       this);
+                       *this);
     }
 
     if (values.empty()) {
@@ -4571,6 +4564,13 @@ ModuleFile::loadAssociatedTypeDefault(const swift::AssociatedTypeDecl *ATD,
 void ModuleFile::finishNormalConformance(NormalProtocolConformance *conformance,
                                          uint64_t contextData) {
   using namespace decls_block;
+
+  PrettyStackTraceModuleFile traceModule("While reading from", *this);
+  PrettyStackTraceType trace(getAssociatedModule()->getASTContext(),
+                             "finishing conformance for",
+                             conformance->getType());
+  PrettyStackTraceDecl traceTo("... to", conformance->getProtocol());
+  ++NumNormalProtocolConformancesCompleted;
 
   // Find the conformance record.
   BCOffsetRAII restoreOffset(DeclTypeCursor);

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -1329,9 +1329,7 @@ ModuleFile::resolveCrossReference(ModuleDecl *baseModule, uint32_t pathLen) {
                                                   &blobData);
     switch (recordID) {
     case XREF_TYPE_PATH_PIECE: {
-      if (values.size() == 1) {
-        ModuleDecl *module = values.front()->getModuleContext();
-
+      if (values.size() == 1 && isa<NominalTypeDecl>(values.front())) {
         // Fast path for nested types that avoids deserializing all
         // members of the parent type.
         IdentifierID IID;
@@ -1344,29 +1342,23 @@ ModuleFile::resolveCrossReference(ModuleDecl *baseModule, uint32_t pathLen) {
           "If you're seeing a crash here, try passing "
             "-Xfrontend -disable-serialization-nested-type-lookup-table"};
 
+        auto *baseType = cast<NominalTypeDecl>(values.front());
         TypeDecl *nestedType = nullptr;
         if (onlyInNominal) {
           // Only look in the file containing the type itself.
           const DeclContext *dc = values.front()->getDeclContext();
-          auto *serializedFile =
-            dyn_cast<SerializedASTFile>(dc->getModuleScopeContext());
-          if (serializedFile) {
-            nestedType =
-              serializedFile->File.lookupNestedType(memberName,
-                                                    values.front());
+          auto *containingFile =
+            dyn_cast<FileUnit>(dc->getModuleScopeContext());
+          if (containingFile) {
+            nestedType = containingFile->lookupNestedType(memberName, baseType);
           }
         } else {
           // Fault in extensions, then ask every serialized AST in the module.
-          (void)cast<NominalTypeDecl>(values.front())->getExtensions();
-          for (FileUnit *file : module->getFiles()) {
+          (void)baseType->getExtensions();
+          for (FileUnit *file : baseType->getModuleContext()->getFiles()) {
             if (file == getFile())
               continue;
-            auto *serializedFile = dyn_cast<SerializedASTFile>(file);
-            if (!serializedFile)
-              continue;
-            nestedType =
-              serializedFile->File.lookupNestedType(memberName,
-                                                    values.front());
+            nestedType = file->lookupNestedType(memberName, baseType);
             if (nestedType)
               break;
           }

--- a/lib/Serialization/DeserializationErrors.h
+++ b/lib/Serialization/DeserializationErrors.h
@@ -17,8 +17,13 @@
 #include "swift/AST/Module.h"
 #include "swift/Serialization/ModuleFormat.h"
 #include "llvm/Support/Error.h"
+#include "llvm/Support/PrettyStackTrace.h"
 
 namespace swift {
+class ModuleFile;
+
+StringRef getNameOfModule(const ModuleFile *);
+
 namespace serialization {
 
 class XRefTracePath {
@@ -310,6 +315,20 @@ public:
 
   std::error_code convertToErrorCode() const override {
     return llvm::inconvertibleErrorCode();
+  }
+};
+
+class PrettyStackTraceModuleFile : public llvm::PrettyStackTraceEntry {
+  const char *Action;
+  const ModuleFile &MF;
+public:
+  explicit PrettyStackTraceModuleFile(const char *action, ModuleFile &module)
+      : Action(action), MF(module) {}
+  explicit PrettyStackTraceModuleFile(ModuleFile &module)
+      : PrettyStackTraceModuleFile("While reading from", module) {}
+
+  void print(raw_ostream &os) const override {
+    os << Action << " \'" << getNameOfModule(&MF) << "'\n";
   }
 };
 

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -1346,7 +1346,7 @@ TypeDecl *ModuleFile::lookupLocalType(StringRef MangledName) {
 }
 
 TypeDecl *ModuleFile::lookupNestedType(Identifier name,
-                                       const ValueDecl *parent) {
+                                       const NominalTypeDecl *parent) {
   PrettyStackTraceModuleFile stackEntry(*this);
 
   if (!NestedTypeDecls)

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -27,7 +27,6 @@
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/OnDiskHashTable.h"
-#include "llvm/Support/PrettyStackTrace.h"
 
 using namespace swift;
 using namespace swift::serialization;
@@ -296,19 +295,6 @@ std::string ModuleFile::Dependency::getPrettyPrintedPath() const {
   std::replace(output.begin(), output.end(), '\0', '.');
   return output;
 }
-
-namespace {
-  class PrettyModuleFileDeserialization : public llvm::PrettyStackTraceEntry {
-    const ModuleFile &File;
-  public:
-    explicit PrettyModuleFileDeserialization(const ModuleFile &file)
-        : File(file) {}
-
-    void print(raw_ostream &os) const override {
-      os << "While reading from " << File.getModuleFilename() << "\n";
-    }
-  };
-} // end anonymous namespace
 
 /// Used to deserialize entries in the on-disk decl hash table.
 class ModuleFile::DeclTableInfo {
@@ -918,7 +904,7 @@ ModuleFile::ModuleFile(
   assert(getStatus() == Status::Valid);
   Bits.IsFramework = isFramework;
 
-  PrettyModuleFileDeserialization stackEntry(*this);
+  PrettyStackTraceModuleFile stackEntry(*this);
 
   llvm::BitstreamCursor cursor{ModuleInputBuffer->getMemBufferRef()};
 
@@ -1188,7 +1174,7 @@ ModuleFile::ModuleFile(
 
 Status ModuleFile::associateWithFileContext(FileUnit *file,
                                             SourceLoc diagLoc) {
-  PrettyModuleFileDeserialization stackEntry(*this);
+  PrettyStackTraceModuleFile stackEntry(*this);
 
   assert(getStatus() == Status::Valid && "invalid module file");
   assert(!FileContext && "already associated with an AST module");
@@ -1303,7 +1289,7 @@ ModuleFile::~ModuleFile() { }
 
 void ModuleFile::lookupValue(DeclName name,
                              SmallVectorImpl<ValueDecl*> &results) {
-  PrettyModuleFileDeserialization stackEntry(*this);
+  PrettyStackTraceModuleFile stackEntry(*this);
 
   if (TopLevelDecls) {
     // Find top-level declarations with the given name.
@@ -1347,7 +1333,7 @@ void ModuleFile::lookupValue(DeclName name,
 }
 
 TypeDecl *ModuleFile::lookupLocalType(StringRef MangledName) {
-  PrettyModuleFileDeserialization stackEntry(*this);
+  PrettyStackTraceModuleFile stackEntry(*this);
 
   if (!LocalTypeDecls)
     return nullptr;
@@ -1361,7 +1347,7 @@ TypeDecl *ModuleFile::lookupLocalType(StringRef MangledName) {
 
 TypeDecl *ModuleFile::lookupNestedType(Identifier name,
                                        const ValueDecl *parent) {
-  PrettyModuleFileDeserialization stackEntry(*this);
+  PrettyStackTraceModuleFile stackEntry(*this);
 
   if (!NestedTypeDecls)
     return nullptr;
@@ -1387,7 +1373,7 @@ TypeDecl *ModuleFile::lookupNestedType(Identifier name,
 }
 
 OperatorDecl *ModuleFile::lookupOperator(Identifier name, DeclKind fixity) {
-  PrettyModuleFileDeserialization stackEntry(*this);
+  PrettyStackTraceModuleFile stackEntry(*this);
 
   if (!OperatorDecls)
     return nullptr;
@@ -1407,7 +1393,7 @@ OperatorDecl *ModuleFile::lookupOperator(Identifier name, DeclKind fixity) {
 }
 
 PrecedenceGroupDecl *ModuleFile::lookupPrecedenceGroup(Identifier name) {
-  PrettyModuleFileDeserialization stackEntry(*this);
+  PrettyStackTraceModuleFile stackEntry(*this);
 
   if (!PrecedenceGroupDecls)
     return nullptr;
@@ -1424,7 +1410,7 @@ PrecedenceGroupDecl *ModuleFile::lookupPrecedenceGroup(Identifier name) {
 void ModuleFile::getImportedModules(
     SmallVectorImpl<ModuleDecl::ImportedModule> &results,
     ModuleDecl::ImportFilter filter) {
-  PrettyModuleFileDeserialization stackEntry(*this);
+  PrettyStackTraceModuleFile stackEntry(*this);
 
   for (auto &dep : Dependencies) {
     if (filter != ModuleDecl::ImportFilter::All &&
@@ -1506,7 +1492,7 @@ void ModuleFile::getImportDecls(SmallVectorImpl<Decl *> &Results) {
 void ModuleFile::lookupVisibleDecls(ModuleDecl::AccessPathTy accessPath,
                                     VisibleDeclConsumer &consumer,
                                     NLKind lookupKind) {
-  PrettyModuleFileDeserialization stackEntry(*this);
+  PrettyStackTraceModuleFile stackEntry(*this);
   assert(accessPath.size() <= 1 && "can only refer to top-level decls");
 
   if (!TopLevelDecls)
@@ -1542,7 +1528,7 @@ void ModuleFile::lookupVisibleDecls(ModuleDecl::AccessPathTy accessPath,
 }
 
 void ModuleFile::loadExtensions(NominalTypeDecl *nominal) {
-  PrettyModuleFileDeserialization stackEntry(*this);
+  PrettyStackTraceModuleFile stackEntry(*this);
   if (!ExtensionDecls)
     return;
 
@@ -1609,7 +1595,7 @@ void ModuleFile::loadObjCMethods(
 void ModuleFile::lookupClassMember(ModuleDecl::AccessPathTy accessPath,
                                    DeclName name,
                                    SmallVectorImpl<ValueDecl*> &results) {
-  PrettyModuleFileDeserialization stackEntry(*this);
+  PrettyStackTraceModuleFile stackEntry(*this);
   assert(accessPath.size() <= 1 && "can only refer to top-level decls");
 
   if (!ClassMembersByName)
@@ -1658,7 +1644,7 @@ void ModuleFile::lookupClassMember(ModuleDecl::AccessPathTy accessPath,
 
 void ModuleFile::lookupClassMembers(ModuleDecl::AccessPathTy accessPath,
                                     VisibleDeclConsumer &consumer) {
-  PrettyModuleFileDeserialization stackEntry(*this);
+  PrettyStackTraceModuleFile stackEntry(*this);
   assert(accessPath.size() <= 1 && "can only refer to top-level decls");
 
   if (!ClassMembersByName)
@@ -1714,7 +1700,7 @@ ModuleFile::collectLinkLibraries(ModuleDecl::LinkLibraryCallback callback) const
 }
 
 void ModuleFile::getTopLevelDecls(SmallVectorImpl<Decl *> &results) {
-  PrettyModuleFileDeserialization stackEntry(*this);
+  PrettyStackTraceModuleFile stackEntry(*this);
   if (PrecedenceGroupDecls) {
     for (auto entry : PrecedenceGroupDecls->data()) {
       for (auto item : entry)
@@ -1754,7 +1740,7 @@ void ModuleFile::getTopLevelDecls(SmallVectorImpl<Decl *> &results) {
 
 void
 ModuleFile::getLocalTypeDecls(SmallVectorImpl<TypeDecl *> &results) {
-  PrettyModuleFileDeserialization stackEntry(*this);
+  PrettyStackTraceModuleFile stackEntry(*this);
   if (!LocalTypeDecls)
     return;
 
@@ -1770,7 +1756,7 @@ void ModuleFile::getDisplayDecls(SmallVectorImpl<Decl *> &results) {
   if (ShadowedModule)
     ShadowedModule->getDisplayDecls(results);
 
-  PrettyModuleFileDeserialization stackEntry(*this);
+  PrettyStackTraceModuleFile stackEntry(*this);
   getImportDecls(results);
   getTopLevelDecls(results);
 }

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -525,6 +525,12 @@ TypeDecl *SerializedASTFile::lookupLocalType(llvm::StringRef MangledName) const{
   return File.lookupLocalType(MangledName);
 }
 
+TypeDecl *
+SerializedASTFile::lookupNestedType(Identifier name,
+                                    const NominalTypeDecl *parent) const {
+  return File.lookupNestedType(name, parent);
+}
+
 OperatorDecl *SerializedASTFile::lookupOperator(Identifier name,
                                                 DeclKind fixity) const {
   return File.lookupOperator(name, fixity);

--- a/test/ClangImporter/Inputs/custom-modules/ImportAsMember.h
+++ b/test/ClangImporter/Inputs/custom-modules/ImportAsMember.h
@@ -57,4 +57,12 @@ extern void IAMStruct1SelfComesLast(double x, struct IAMStruct1 s)
 extern void IAMStruct1SelfComesThird(int a, float b, struct IAMStruct1 s, double x)
     __attribute__((swift_name("Struct1.selfComesThird(a:b:self:x:)")));
 
+
+struct IAMMultipleNested {
+  int value;
+};
+
+typedef int MNInnerInt __attribute__((swift_name("IAMMultipleNested.Inner")));
+typedef float MNInnerFloat __attribute__((swift_name("IAMMultipleNested.Inner")));
+
 #endif // IMPORT_AS_MEMBER_H

--- a/test/ClangImporter/Inputs/frameworks/ImportAsMemberSubmodules.framework/Headers/Actual.h
+++ b/test/ClangImporter/Inputs/frameworks/ImportAsMemberSubmodules.framework/Headers/Actual.h
@@ -1,3 +1,3 @@
-struct IAMOuter { int x; };
+struct IAMSOuter { int x; };
 
-struct IAMInner { int y; };
+struct IAMSInner { int y; };

--- a/test/ClangImporter/Inputs/frameworks/ImportAsMemberSubmodules.framework/Headers/Fwd.h
+++ b/test/ClangImporter/Inputs/frameworks/ImportAsMemberSubmodules.framework/Headers/Fwd.h
@@ -1,3 +1,3 @@
 // The order of these forward-declarations affects whether there was a bug.
-struct IAMOuter;
-struct IAMInner;
+struct IAMSOuter;
+struct IAMSInner;

--- a/test/ClangImporter/Inputs/frameworks/ImportAsMemberSubmodules.framework/Headers/ImportAsMemberSubmodules.apinotes
+++ b/test/ClangImporter/Inputs/frameworks/ImportAsMemberSubmodules.framework/Headers/ImportAsMemberSubmodules.apinotes
@@ -1,4 +1,4 @@
 Name: ImportAsMemberSubmodules
 Tags:
-- Name: IAMInner
-  SwiftName: IAMOuter.Inner
+- Name: IAMSInner
+  SwiftName: IAMSOuter.Inner

--- a/test/ClangImporter/import-as-member.swift
+++ b/test/ClangImporter/import-as-member.swift
@@ -1,5 +1,7 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -F %S/Inputs/frameworks %s -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -F %S/Inputs/frameworks -I %S/Inputs/custom-modules %s -verify
 
+import ImportAsMember
 import ImportAsMemberSubmodules
 
-let _: IAMOuter.Inner?
+let _: IAMSOuter.Inner?
+let _: IAMMultipleNested.Inner? // expected-error {{ambiguous type name 'Inner' in 'IAMMultipleNested'}}

--- a/test/Serialization/Inputs/xref-nested-clang-type/NestedClangTypes.h
+++ b/test/Serialization/Inputs/xref-nested-clang-type/NestedClangTypes.h
@@ -1,0 +1,18 @@
+struct Outer {
+  int value;
+};
+
+struct __attribute__((swift_name("Outer.InterestingValue"))) Inner {
+  int value;
+};
+
+#if __OBJC__
+
+@import Foundation;
+
+extern NSString * const ErrorCodeDomain;
+enum __attribute__((ns_error_domain(ErrorCodeDomain))) ErrorCodeEnum {
+  ErrorCodeEnumA
+};
+
+#endif // __OBJC__

--- a/test/Serialization/Inputs/xref-nested-clang-type/NestedClangTypes.h
+++ b/test/Serialization/Inputs/xref-nested-clang-type/NestedClangTypes.h
@@ -1,3 +1,5 @@
+#include "NestedClangTypesHelper.h"
+
 struct Outer {
   int value;
 };
@@ -5,6 +7,12 @@ struct Outer {
 struct __attribute__((swift_name("Outer.InterestingValue"))) Inner {
   int value;
 };
+
+struct OuterFromOtherModule;
+struct __attribute__((swift_name("OuterFromOtherModule.InterestingValue"))) InnerCrossModule {
+  int value;
+};
+
 
 #if __OBJC__
 

--- a/test/Serialization/Inputs/xref-nested-clang-type/NestedClangTypesHelper.h
+++ b/test/Serialization/Inputs/xref-nested-clang-type/NestedClangTypesHelper.h
@@ -1,0 +1,3 @@
+struct OuterFromOtherModule {
+  int value;
+};

--- a/test/Serialization/Inputs/xref-nested-clang-type/module.modulemap
+++ b/test/Serialization/Inputs/xref-nested-clang-type/module.modulemap
@@ -1,3 +1,9 @@
 module NestedClangTypes {
   header "NestedClangTypes.h"
+  export *
+}
+
+module NestedClangTypesHelper {
+  header "NestedClangTypesHelper.h"
+  export *
 }

--- a/test/Serialization/Inputs/xref-nested-clang-type/module.modulemap
+++ b/test/Serialization/Inputs/xref-nested-clang-type/module.modulemap
@@ -1,0 +1,3 @@
+module NestedClangTypes {
+  header "NestedClangTypes.h"
+}

--- a/test/Serialization/xref-nested-clang-type.swift
+++ b/test/Serialization/xref-nested-clang-type.swift
@@ -1,0 +1,48 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t -I %S/Inputs/xref-nested-clang-type/ %s -module-name Lib
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %t -I %S/Inputs/xref-nested-clang-type/ %s -DCLIENT -verify
+
+// RUN: %empty-directory(%t)
+// RUN: cp %S/Inputs/xref-nested-clang-type/NestedClangTypes.h %t
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t -import-objc-header %t/NestedClangTypes.h %s -module-name Lib -DNO_MODULE
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %t -import-objc-header %t/NestedClangTypes.h %s -DCLIENT -verify
+
+// RUN: %empty-directory(%t)
+// RUN: cp %S/Inputs/xref-nested-clang-type/NestedClangTypes.h %t
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t -import-objc-header %t/NestedClangTypes.h -pch-output-dir %t/PCHCache %s -module-name Lib -DNO_MODULE
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %t -pch-output-dir %t/PCHCache -import-objc-header %t/NestedClangTypes.h %s -DCLIENT -verify
+
+#if CLIENT
+
+import Lib
+
+func test(x: MyInner) {}
+
+#if _runtime(_ObjC)
+import Foundation
+func test(x: MyCode) {}
+#endif // ObjC
+
+#else // CLIENT
+
+#if !NO_MODULE
+import NestedClangTypes
+#endif
+
+public typealias MyOuter = Outer
+public typealias MyInner = Outer.InterestingValue
+
+extension MyOuter {
+  public func use(inner: MyInner) {}
+}
+
+#if _runtime(_ObjC)
+import Foundation
+
+public typealias MyCode = ErrorCodeEnum.Code
+extension ErrorCodeEnum {
+  public func whatever(code: MyCode) {}
+}
+#endif // ObjC
+
+#endif // CLIENT

--- a/tools/sil-passpipeline-dumper/CMakeLists.txt
+++ b/tools/sil-passpipeline-dumper/CMakeLists.txt
@@ -6,6 +6,9 @@ add_swift_host_tool(sil-passpipeline-dumper
     swiftSILOptimizer
     swiftSerialization
     swiftClangImporter
+    # FIXME: Circular dependencies require re-listing these libraries.
+    swiftSema
+    swiftAST
   LLVM_COMPONENT_DEPENDS
     DebugInfoCodeView
   SWIFT_COMPONENT tools

--- a/unittests/Parse/CMakeLists.txt
+++ b/unittests/Parse/CMakeLists.txt
@@ -6,9 +6,10 @@ add_swift_unittest(SwiftParseTests
 
 target_link_libraries(SwiftParseTests
     swiftSIL
-    swiftSema
     swiftClangImporter
     swiftParse
     swiftAST
+    # FIXME: Sema must go last because of circular dependencies with AST.
+    swiftSema
 )
 


### PR DESCRIPTION
- **Explanation**: If a Swift library contains an extension of Objective-C type `A` that has a method that mentions Objective-C type `A.B` (using the "import-as-member" feature), performing the lookup to find `A.B` can lead to a circular dependency between deserialization and the importer, which resulted in a compiler crash. This is not a new problem, but it's more important with the release of Swift 4, where a number of Apple SDK types are now newly imported as member types. (The one in the original bug was NSView.AutoresizingMask, formerly NSAutoresizingMaskOptions.) This change adds a "fast path" for direct lookup of a single, unambiguous type nested in an Objective-C type.
- **Scope**: Affects references in Swift to nested types imported from Objective-C.
- **Issue**: [SR-5284](https://bugs.swift.org/browse/SR-5284) / rdar://problem/32926560
- **Reviewed by**: @milseman (ClangImporter), @jckarter (Serialization)
- **Risk**: Medium-low. These types are not uncommon, but this is just a "fast path"; it should fall back to the old code if it fails.
- **Testing**: Added regression tests, verified that the original test case now passes, passed the source compatibility suite on master.