### PR TITLE
Lower Never-typed patterns to unreachable

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -449,9 +449,12 @@ public:
   /// semantics?
   bool hasReferenceSemantics();
 
-  /// Is this an uninhabited type, such as 'Never'?
+  /// Is this a nominally uninhabited type, such as 'Never'?
   bool isUninhabited();
 
+  /// Is this an uninhabited type, such as 'Never' or '(Never, Int)'?
+  bool isStructurallyUninhabited();
+  
   /// Is this the 'Any' type?
   bool isAny();
 

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -134,9 +134,21 @@ bool TypeBase::hasReferenceSemantics() {
 }
 
 bool TypeBase::isUninhabited() {
+  // Empty enum declarations are uninhabited
   if (auto nominalDecl = getAnyNominal())
     if (auto enumDecl = dyn_cast<EnumDecl>(nominalDecl))
       if (enumDecl->getAllElements().empty())
+        return true;
+  return false;
+}
+
+bool TypeBase::isStructurallyUninhabited() {
+  if (isUninhabited()) return true;
+  
+  // Tuples of uninhabited types are uninhabited
+  if (auto *TTy = getAs<TupleType>())
+    for (auto eltTy : TTy->getElementTypes())
+      if (eltTy->isStructurallyUninhabited())
         return true;
   return false;
 }

--- a/test/Sema/exhaustive_switch.swift
+++ b/test/Sema/exhaustive_switch.swift
@@ -332,6 +332,31 @@ func checkPatternCasts() {
   }
 }
 
+enum MyNever {}
+func ~= (_ : MyNever, _ : MyNever) -> Bool { return true }
+func myFatalError() -> MyNever { fatalError() }
+
+func checkUninhabited() {
+  // Scrutinees of uninhabited type may match any number and kind of patterns
+  // that Sema is willing to accept at will.  After all, it's quite a feat to
+  // productively inhabit the type of crashing programs.
+  func test1(x : Never) {
+    switch x {} // No diagnostic.
+  }
+  
+  func test2(x : Never) {
+    switch (x, x) {} // No diagnostic.
+  }
+  
+  func test3(x : MyNever) {
+    switch x { // No diagnostic.
+    case myFatalError(): break
+    case myFatalError(): break
+    case myFatalError(): break
+    }
+  }
+}
+
 enum Runcible {
   case spoon
   case hat


### PR DESCRIPTION
Cuts off a crash in SILGen for switches over uninhabited types.
We can take this a step further and extend the definition of
"uninhabited" to product types with uninhabited components.

// CC @rintaro 