### PR TITLE
[swift-4.0-branch][stdlib] Implement comparison and equality for empty tuples

### DIFF
--- a/stdlib/public/core/Tuple.swift.gyb
+++ b/stdlib/public/core/Tuple.swift.gyb
@@ -23,6 +23,82 @@ comparableOperators = [
 
 }%
 
+/// Returns a Boolean value indicating whether the corresponding components of
+/// two tuples are equal.
+///
+/// All arity zero tuples are equal.
+///
+/// - Parameters:
+///   - lhs: An empty tuple.
+///   - rhs: An empty tuple.
+public func ==(lhs: (), rhs: ()) -> Bool {
+  return true
+}
+
+/// Returns a Boolean value indicating whether any corresponding components of
+/// the two tuples are not equal.
+///
+/// All arity zero tuples are equal.
+///
+/// - Parameters:
+///   - lhs: An empty tuple.
+///   - rhs: An empty tuple.
+public func !=(lhs: (), rhs: ()) -> Bool {
+    return false
+}
+
+/// Returns a Boolean value indicating whether the first tuple is ordered
+/// before the second in a lexicographical ordering.
+///
+/// An arity zero tuple is never strictly before another arity zero tuple in a
+/// lexicographical ordering.
+///
+/// - Parameters:
+///   - lhs: An empty tuple.
+///   - rhs: An empty tuple.
+public func <(lhs: (), rhs: ()) -> Bool {
+    return false
+}
+
+/// Returns a Boolean value indicating whether the first tuple is ordered
+/// before or the same as the second in a lexicographical ordering.
+///
+/// An arity zero tuple is always before or the same as another arity zero tuple
+/// in a lexicographical ordering.
+///
+/// - Parameters:
+///   - lhs: An empty tuple.
+///   - rhs: An empty tuple.
+public func <=(lhs: (), rhs: ()) -> Bool {
+    return true
+}
+
+/// Returns a Boolean value indicating whether the first tuple is ordered
+/// after the second in a lexicographical ordering.
+///
+/// An arity zero tuple is never strictly after another arity zero tuple in a
+/// lexicographical ordering.
+///
+/// - Parameters:
+///   - lhs: An empty tuple.
+///   - rhs: An empty tuple.
+public func >(lhs: (), rhs: ()) -> Bool {
+    return false
+}
+
+/// Returns a Boolean value indicating whether the first tuple is ordered
+/// after or the same as the second in a lexicographical ordering.
+///
+/// An arity zero tuple is always after or the same as another arity zero tuple
+/// in a lexicographical ordering.
+///
+/// - Parameters:
+///   - lhs: An empty tuple.
+///   - rhs: An empty tuple.
+public func >=(lhs: (), rhs: ()) -> Bool {
+    return true
+}
+
 % for arity in range(2,7):
 %   typeParams = [chr(ord("A") + i) for i in range(arity)]
 %   tupleT = "({})".format(",".join(typeParams))

--- a/test/IDE/complete_operators.swift
+++ b/test/IDE/complete_operators.swift
@@ -40,7 +40,7 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename=%s -code-completion-token=INFIX_14 | %FileCheck %s -check-prefix=NO_OPERATORS
 // RUN: %target-swift-ide-test -code-completion -source-filename=%s -code-completion-token=INFIX_15 | %FileCheck %s -check-prefix=INFIX_15
 // RUN: %target-swift-ide-test -code-completion -source-filename=%s -code-completion-token=INFIX_16 | %FileCheck %s -check-prefix=INFIX_16
-// RUN: %target-swift-ide-test -code-completion -source-filename=%s -code-completion-token=INFIX_17 | %FileCheck %s -check-prefix=NO_OPERATORS
+// RUN: %target-swift-ide-test -code-completion -source-filename=%s -code-completion-token=INFIX_17 | %FileCheck %s -check-prefix=VOID_OPERATORS
 // RUN: %target-swift-ide-test -code-completion -source-filename=%s -code-completion-token=INFIX_18 | %FileCheck %s -check-prefix=NO_OPERATORS
 // RUN: %target-swift-ide-test -code-completion -source-filename=%s -code-completion-token=INFIX_19 | %FileCheck %s -check-prefix=EMPTYCLASS_INFIX
 // RUN: %target-swift-ide-test -code-completion -source-filename=%s -code-completion-token=INFIX_20 | %FileCheck %s -check-prefix=NO_OPERATORS
@@ -281,6 +281,16 @@ func testInfix16<T: P where T.T == S2>() {
 func testInfix17(x: Void) {
   x#^INFIX_17^#
 }
+
+// VOID_OPERATORS: Begin completions
+// VOID_OPERATORS-DAG: Decl[InfixOperatorFunction]/OtherModule[Swift]:  != {#()#}[#Bool#]; name=!= ()
+// VOID_OPERATORS-DAG: Decl[InfixOperatorFunction]/OtherModule[Swift]:  == {#()#}[#Bool#]; name=== ()
+// VOID_OPERATORS-DAG: Decl[InfixOperatorFunction]/OtherModule[Swift]:  <= {#()#}[#Bool#]; name=<= ()
+// VOID_OPERATORS-DAG: Decl[InfixOperatorFunction]/OtherModule[Swift]:  >= {#()#}[#Bool#]; name=>= ()
+// VOID_OPERATORS-DAG: Decl[InfixOperatorFunction]/OtherModule[Swift]:  < {#()#}[#Bool#]; name=< ()
+// VOID_OPERATORS-DAG: Decl[InfixOperatorFunction]/OtherModule[Swift]:  > {#()#}[#Bool#]; name=> ()
+// VOID_OPERATORS: End completions
+
 func testInfix18(x: (S2, S2) {
   x#^INFIX_18^#
 }

--- a/test/stdlib/Tuple.swift.gyb
+++ b/test/stdlib/Tuple.swift.gyb
@@ -58,6 +58,14 @@ TupleTestSuite.test("Tuple/equality") {
 
 TupleTestSuite.test("Tuple/equality/sanity-check") {
   // sanity check all arities
+
+  expectTrue(() == ())
+  expectFalse(() != ())
+  expectFalse(() < ())
+  expectTrue(() <= ())
+  expectFalse(() > ())
+  expectTrue(() >= ())
+
 % for arity in range(2, maxArity + 1):
 %   a = str(tuple(range(1, arity + 1)))
 %   b = "({}, 0)".format(", ".join([str(i) for i in range(1, arity)]))


### PR DESCRIPTION
* Explanation: Implement comparison and equality for empty tuples
* Scope of Issue: Purely additive change
* Risk: Minimal
* Reviewed By: Ben Cohen
* Testing: Automated test suite
* Directions for QA: N/A
* Radar: <rdar://problem/33277760>

Resolves: [SR-4172](https://bugs.swift.org/browse/SR-4172)