### PR TITLE
[Serialization] Use the correct module for the nested type fast path.

### DIFF
--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -1343,9 +1343,13 @@ ModuleFile::resolveCrossReference(ModuleDecl *baseModule, uint32_t pathLen) {
             nestedType = containingFile->lookupNestedType(memberName, baseType);
           }
         } else {
-          // Fault in extensions, then ask every serialized AST in the module.
+          // Fault in extensions, then ask every file in the module.
+          ModuleDecl *extensionModule = M;
+          if (!extensionModule)
+            extensionModule = baseType->getModuleContext();
+
           (void)baseType->getExtensions();
-          for (FileUnit *file : baseType->getModuleContext()->getFiles()) {
+          for (FileUnit *file : extensionModule->getFiles()) {
             if (file == getFile())
               continue;
             nestedType = file->lookupNestedType(memberName, baseType);

--- a/test/Serialization/Inputs/xref-nested-clang-type/NestedClangTypes.h
+++ b/test/Serialization/Inputs/xref-nested-clang-type/NestedClangTypes.h
@@ -1,3 +1,5 @@
+#include "NestedClangTypesHelper.h"
+
 struct Outer {
   int value;
 };
@@ -5,6 +7,12 @@ struct Outer {
 struct __attribute__((swift_name("Outer.InterestingValue"))) Inner {
   int value;
 };
+
+struct OuterFromOtherModule;
+struct __attribute__((swift_name("OuterFromOtherModule.InterestingValue"))) InnerCrossModule {
+  int value;
+};
+
 
 #if __OBJC__
 

--- a/test/Serialization/Inputs/xref-nested-clang-type/NestedClangTypesHelper.h
+++ b/test/Serialization/Inputs/xref-nested-clang-type/NestedClangTypesHelper.h
@@ -1,0 +1,3 @@
+struct OuterFromOtherModule {
+  int value;
+};

--- a/test/Serialization/Inputs/xref-nested-clang-type/module.modulemap
+++ b/test/Serialization/Inputs/xref-nested-clang-type/module.modulemap
@@ -1,3 +1,9 @@
 module NestedClangTypes {
   header "NestedClangTypes.h"
+  export *
+}
+
+module NestedClangTypesHelper {
+  header "NestedClangTypesHelper.h"
+  export *
 }


### PR DESCRIPTION
Fix-up for #10956, which fixes the crash caused by the new test case I thought of slightly too late.

More [SR-5284](https://bugs.swift.org/browse/SR-5284) / rdar://problem/32926560.