### PR TITLE
[silgen] Fix a few uses of UnownedRetain, UnownedRelease, StrongRetai…

### DIFF
--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -1821,18 +1821,25 @@ public:
                                          "Operand of strong_retain_unowned");
     require(unownedType->isLoadable(ResilienceExpansion::Maximal),
             "strong_retain_unowned requires unowned type to be loadable");
+    require(F.hasUnqualifiedOwnership(), "strong_retain_unowned is only in "
+                                         "functions with unqualified "
+                                         "ownership");
   }
   void checkUnownedRetainInst(UnownedRetainInst *RI) {
     auto unownedType = requireObjectType(UnownedStorageType, RI->getOperand(),
                                           "Operand of unowned_retain");
     require(unownedType->isLoadable(ResilienceExpansion::Maximal),
             "unowned_retain requires unowned type to be loadable");
+    require(F.hasUnqualifiedOwnership(),
+            "unowned_retain is only in functions with unqualified ownership");
   }
   void checkUnownedReleaseInst(UnownedReleaseInst *RI) {
     auto unownedType = requireObjectType(UnownedStorageType, RI->getOperand(),
                                          "Operand of unowned_release");
     require(unownedType->isLoadable(ResilienceExpansion::Maximal),
             "unowned_release requires unowned type to be loadable");
+    require(F.hasUnqualifiedOwnership(),
+            "unowned_release is only in functions with unqualified ownership");
   }
   void checkDeallocStackInst(DeallocStackInst *DI) {
     require(isa<SILUndef>(DI->getOperand()) ||

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -2732,9 +2732,7 @@ SILValue SILGenFunction::emitConversionToSemanticRValue(SILLocation loc,
     assert(unownedType->isLoadable(ResilienceExpansion::Maximal));
     (void) unownedType;
 
-    B.createStrongRetainUnowned(loc, src, B.getDefaultAtomicity());
-    return B.createUnownedToRef(loc, src,
-                SILType::getPrimitiveObjectType(unownedType.getReferentType()));
+    return B.createCopyUnownedValue(loc, src);
   }
 
   // For @unowned(unsafe) types, we need to strip the unmanaged box
@@ -2791,14 +2789,20 @@ static SILValue emitLoadOfSemanticRValue(SILGenFunction &SGF,
       return SGF.B.createLoadUnowned(loc, src, isTake);
     }
 
+    // If we are not performing a take, use a load_borrow.
+    if (!isTake) {
+      SILValue unownedValue = SGF.B.createLoadBorrow(loc, src);
+      SILValue strongValue = SGF.B.createCopyUnownedValue(loc, unownedValue);
+      SGF.B.createEndBorrow(loc, unownedValue, src);
+      return strongValue;
+    }
+
+    // Otherwise, we need to perform a load take and destroy the stored value.
     auto unownedValue =
         SGF.B.emitLoadValueOperation(loc, src, LoadOwnershipQualifier::Take);
-    SGF.B.createStrongRetainUnowned(loc, unownedValue, SGF.B.getDefaultAtomicity());
-    if (isTake)
-      SGF.B.createUnownedRelease(loc, unownedValue, SGF.B.getDefaultAtomicity());
-    return SGF.B.createUnownedToRef(
-        loc, unownedValue,
-        SILType::getPrimitiveObjectType(unownedType.getReferentType()));
+    SILValue strongValue = SGF.B.createCopyUnownedValue(loc, unownedValue);
+    SGF.B.createDestroyValue(loc, unownedValue);
+    return strongValue;
   }
 
   // For @unowned(unsafe) types, we need to strip the unmanaged box.
@@ -2861,8 +2865,8 @@ static void emitStoreOfSemanticRValue(SILGenFunction &SGF,
 
     auto unownedValue =
       SGF.B.createRefToUnowned(loc, value, storageType.getObjectType());
-    SGF.B.createUnownedRetain(loc, unownedValue, SGF.B.getDefaultAtomicity());
-    emitUnloweredStoreOfCopy(SGF.B, loc, unownedValue, dest, isInit);
+    auto copiedVal = SGF.B.createCopyValue(loc, unownedValue);
+    emitUnloweredStoreOfCopy(SGF.B, loc, copiedVal, dest, isInit);
     SGF.B.emitDestroyValueOperation(loc, value);
     return;
   }
@@ -2963,7 +2967,7 @@ SILValue SILGenFunction::emitConversionFromSemanticValue(SILLocation loc,
     (void) unownedType;
 
     SILValue unowned = B.createRefToUnowned(loc, semanticValue, storageType);
-    B.createUnownedRetain(loc, unowned, B.getDefaultAtomicity());
+    unowned = B.createCopyValue(loc, unowned);
     B.emitDestroyValueOperation(loc, semanticValue);
     return unowned;
   }

--- a/test/SILGen/closures.swift
+++ b/test/SILGen/closures.swift
@@ -688,21 +688,21 @@ class SuperSub : SuperBase {
 // CHECK:         [[UNOWNED_SELF:%.*]] = ref_to_unowned [[SELF_COPY]] :
 // -- TODO: A lot of fussy r/r traffic and owned/unowned conversions here.
 // -- strong +2, unowned +1
-// CHECK:         unowned_retain [[UNOWNED_SELF]]
-// CHECK:         store [[UNOWNED_SELF]] to [init] [[PB]]
+// CHECK:         [[UNOWNED_SELF_COPY:%.*]] = copy_value [[UNOWNED_SELF]]
+// CHECK:         store [[UNOWNED_SELF_COPY]] to [init] [[PB]]
 // SEMANTIC ARC TODO: This destroy_value should probably be /after/ the load from PB on the next line.
 // CHECK:         destroy_value [[SELF_COPY]]
-// CHECK:         [[UNOWNED_SELF:%.*]] = load [take] [[PB]]
+// CHECK:         [[UNOWNED_SELF:%.*]] = load_borrow [[PB]]
 // -- strong +2, unowned +1
-// CHECK:         strong_retain_unowned [[UNOWNED_SELF]]
-// CHECK:         [[SELF:%.*]] = unowned_to_ref [[UNOWNED_SELF]]
+// CHECK:         [[SELF:%.*]] = copy_unowned_value [[UNOWNED_SELF]]
+// CHECK:         end_borrow [[UNOWNED_SELF]] from [[PB]]
 // CHECK:         [[UNOWNED_SELF2:%.*]] = ref_to_unowned [[SELF]]
 // -- strong +2, unowned +2
-// CHECK:         unowned_retain [[UNOWNED_SELF2]]
+// CHECK:         [[UNOWNED_SELF2_COPY:%.*]] = copy_value [[UNOWNED_SELF2]]
 // -- strong +1, unowned +2
 // CHECK:         destroy_value [[SELF]]
 // -- closure takes unowned ownership
-// CHECK:         [[OUTER_CLOSURE:%.*]] = partial_apply {{%.*}}([[UNOWNED_SELF2]])
+// CHECK:         [[OUTER_CLOSURE:%.*]] = partial_apply {{%.*}}([[UNOWNED_SELF2_COPY]])
 // -- call consumes closure
 // -- strong +1, unowned +1
 // CHECK:         [[INNER_CLOSURE:%.*]] = apply [[OUTER_CLOSURE]]
@@ -732,8 +732,7 @@ class SuperSub : SuperBase {
 // CHECK: sil private @[[INNER_CLOSURE_FUN:_T08closures24UnownedSelfNestedCaptureC06nestedE0yyFACycycfU_ACycfU_]] : $@convention(thin) (@owned @sil_unowned UnownedSelfNestedCapture) -> @owned UnownedSelfNestedCapture {
 // CHECK: bb0([[CAPTURED_SELF:%.*]] : $@sil_unowned UnownedSelfNestedCapture):
 // -- strong +1, unowned +1
-// CHECK:         strong_retain_unowned [[CAPTURED_SELF:%.*]] :
-// CHECK:         [[SELF:%.*]] = unowned_to_ref [[CAPTURED_SELF]]
+// CHECK:         [[SELF:%.*]] = copy_unowned_value [[CAPTURED_SELF:%.*]] :
 // -- strong +1, unowned +0 (claimed by return)
 // CHECK:         destroy_value [[CAPTURED_SELF]]
 // CHECK:         return [[SELF]]

--- a/test/SILGen/unowned.swift
+++ b/test/SILGen/unowned.swift
@@ -13,9 +13,9 @@ _ = A(x: C())
 // CHECK-LABEL: sil hidden @_T07unowned1AV{{[_0-9a-zA-Z]*}}fC
 // CHECK: bb0([[X:%.*]] : $C, %1 : $@thin A.Type):
 // CHECK:   [[X_UNOWNED:%.*]] = ref_to_unowned [[X]] : $C to $@sil_unowned C
-// CHECK:   unowned_retain [[X_UNOWNED]]
+// CHECK:   [[X_UNOWNED_COPY:%.*]] = copy_value [[X_UNOWNED]]
 // CHECK:   destroy_value [[X]]
-// CHECK:   [[A:%.*]] = struct $A ([[X_UNOWNED]] : $@sil_unowned C)
+// CHECK:   [[A:%.*]] = struct $A ([[X_UNOWNED_COPY]] : $@sil_unowned C)
 // CHECK:   return [[A]]
 // CHECK: }
 
@@ -31,8 +31,8 @@ _ = AddressOnly(x: C(), p: X())
 // CHECK: bb0([[RET:%.*]] : $*AddressOnly, [[X:%.*]] : $C, {{.*}}):
 // CHECK:   [[X_ADDR:%.*]] = struct_element_addr [[RET]] : $*AddressOnly, #AddressOnly.x
 // CHECK:   [[X_UNOWNED:%.*]] = ref_to_unowned [[X]] : $C to $@sil_unowned C
-// CHECK:   unowned_retain [[X_UNOWNED]] : $@sil_unowned C
-// CHECK:   store [[X_UNOWNED]] to [init] [[X_ADDR]]
+// CHECK:   [[X_UNOWNED_COPY:%.*]] = copy_value [[X_UNOWNED]] : $@sil_unowned C
+// CHECK:   store [[X_UNOWNED_COPY]] to [init] [[X_ADDR]]
 // CHECK:   destroy_value [[X]]
 // CHECK: }
 
@@ -51,8 +51,8 @@ func test0(c c: C) {
   // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
   // CHECK:   [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
   // CHECK:   [[T2:%.*]] = ref_to_unowned [[ARG_COPY]] : $C  to $@sil_unowned C
-  // CHECK:   unowned_retain [[T2]] : $@sil_unowned C
-  // CHECK:   store [[T2]] to [init] [[PBX]] : $*@sil_unowned C
+  // CHECK:   [[T2_COPY:%.*]] = copy_value [[T2]] : $@sil_unowned C
+  // CHECK:   store [[T2_COPY]] to [init] [[PBX]] : $*@sil_unowned C
   // CHECK:   destroy_value [[ARG_COPY]]
   // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
 
@@ -62,21 +62,21 @@ func test0(c c: C) {
   // CHECK:   [[WRITE:%.*]] = begin_access [modify] [unknown] [[PBA]]
   // CHECK:   [[T1:%.*]] = struct_element_addr [[WRITE]] : $*A, #A.x
   // CHECK:   [[T2:%.*]] = ref_to_unowned [[ARG_COPY]] : $C
-  // CHECK:   unowned_retain [[T2]] : $@sil_unowned C
-  // CHECK:   assign [[T2]] to [[T1]] : $*@sil_unowned C
+  // CHECK:   [[T2_COPY:%.*]] = copy_value [[T2]] : $@sil_unowned C
+  // CHECK:   assign [[T2_COPY]] to [[T1]] : $*@sil_unowned C
   // CHECK:   destroy_value [[ARG_COPY]]
   // CHECK:   end_borrow [[BORROWED_ARG]] from [[ARG]]
 
   a.x = x
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PBX]]
-  // CHECK:   [[T2:%.*]] = load [take] [[READ]] : $*@sil_unowned C     
-  // CHECK:   strong_retain_unowned  [[T2]] : $@sil_unowned C  
-  // CHECK:   [[T3:%.*]] = unowned_to_ref [[T2]] : $@sil_unowned C to $C
+  // CHECK:   [[T2:%.*]] = load_borrow [[READ]] : $*@sil_unowned C     
+  // CHECK:   [[T3:%.*]] = copy_unowned_value  [[T2]] : $@sil_unowned C  
+  // CHECK:   end_borrow [[T2]] from [[READ]]
   // CHECK:   [[WRITE:%.*]] = begin_access [modify] [unknown] [[PBA]]
   // CHECK:   [[XP:%.*]] = struct_element_addr [[WRITE]] : $*A, #A.x
   // CHECK:   [[T4:%.*]] = ref_to_unowned [[T3]] : $C to $@sil_unowned C
-  // CHECK:   unowned_retain [[T4]] : $@sil_unowned C  
-  // CHECK:   assign [[T4]] to [[XP]] : $*@sil_unowned C
+  // CHECK:   [[T4_COPY:%.*]] = copy_value [[T4]] : $@sil_unowned C  
+  // CHECK:   assign [[T4_COPY]] to [[XP]] : $*@sil_unowned C
   // CHECK:   destroy_value [[T3]] : $C
   // CHECK:   destroy_value [[X]]
   // CHECK:   destroy_value [[MARKED_A1]]
@@ -94,15 +94,15 @@ func testunowned_local() -> C {
   // CHECK: [[BORROWED_C:%.*]] = begin_borrow [[C]]
   // CHECK: [[C_COPY:%.*]] = copy_value [[BORROWED_C]]
   // CHECK: [[tmp1:%.*]] = ref_to_unowned [[C_COPY]] : $C to $@sil_unowned C
-  // CHECK: unowned_retain [[tmp1]]
-  // CHECK: store [[tmp1]] to [init] [[PB_UC]]
+  // CHECK: [[tmp1_copy:%.*]] = copy_value [[tmp1]]
+  // CHECK: store [[tmp1_copy]] to [init] [[PB_UC]]
   // CHECK: destroy_value [[C_COPY]]
   // CHECK: end_borrow [[BORROWED_C]] from [[C]]
   unowned let uc = c
 
-  // CHECK: [[tmp2:%.*]] = load [take] [[PB_UC]]
-  // CHECK: strong_retain_unowned [[tmp2]]
-  // CHECK: [[tmp3:%.*]] = unowned_to_ref [[tmp2]]
+  // CHECK: [[tmp2:%.*]] = load_borrow [[PB_UC]]
+  // CHECK: [[tmp3:%.*]] = copy_unowned_value [[tmp2]]
+  // CHECK: end_borrow [[tmp2]] from [[PB_UC]]
   return uc
 
   // CHECK: destroy_value [[UC]]
@@ -119,8 +119,7 @@ func test_unowned_let_capture(_ aC : C) {
 // CHECK-LABEL: sil private @_T07unowned05test_A12_let_captureyAA1CCFSiycfU_ : $@convention(thin) (@owned @sil_unowned C) -> Int {
 // CHECK: bb0([[ARG:%.*]] : $@sil_unowned C):
 // CHECK-NEXT:   debug_value %0 : $@sil_unowned C, let, name "bC", argno 1
-// CHECK-NEXT:   strong_retain_unowned [[ARG]] : $@sil_unowned C
-// CHECK-NEXT:   [[UNOWNED_ARG:%.*]] = unowned_to_ref [[ARG]] : $@sil_unowned C to $C
+// CHECK-NEXT:   [[UNOWNED_ARG:%.*]] = copy_unowned_value [[ARG]] : $@sil_unowned C
 // CHECK-NEXT:   [[FUN:%.*]] = class_method [[UNOWNED_ARG]] : $C, #C.f!1 : (C) -> () -> Int, $@convention(method) (@guaranteed C) -> Int
 // CHECK-NEXT:   [[RESULT:%.*]] = apply [[FUN]]([[UNOWNED_ARG]]) : $@convention(method) (@guaranteed C) -> Int
 // CHECK-NEXT:   destroy_value [[UNOWNED_ARG]]
@@ -146,8 +145,8 @@ class TestUnownedMember {
 // CHECK:   [[FIELDPTR:%.*]] = ref_element_addr [[BORROWED_SELF]] : $TestUnownedMember, #TestUnownedMember.member
 // CHECK:   [[WRITE:%.*]] = begin_access [modify] [dynamic] [[FIELDPTR]] : $*@sil_unowned C
 // CHECK:   [[INVAL:%.*]] = ref_to_unowned [[ARG1_COPY]] : $C to $@sil_unowned C
-// CHECK:   unowned_retain [[INVAL]] : $@sil_unowned C
-// CHECK:   assign [[INVAL]] to [[WRITE]] : $*@sil_unowned C
+// CHECK:   [[INVAL_COPY:%.*]] = copy_value [[INVAL]] : $@sil_unowned C
+// CHECK:   assign [[INVAL_COPY]] to [[WRITE]] : $*@sil_unowned C
 // CHECK:   destroy_value [[ARG1_COPY]] : $C
 // CHECK:   end_borrow [[BORROWED_ARG1]] from [[ARG1]]
 // CHECK:   end_borrow [[BORROWED_SELF]] from [[SELF]]

--- a/test/SILGen/weak_multiple_modules.swift
+++ b/test/SILGen/weak_multiple_modules.swift
@@ -8,8 +8,9 @@ import weak_other
 func doSomething(ui: UI) -> Bool {
   // CHECK: ref_element_addr
   // CHECK-objc: load_unowned
-  // CHECK-native: load [take]
-  // CHECK-native: strong_retain_unowned
+  // CHECK-native: load_borrow
+  // CHECK-native: copy_unowned_value
+  // CHECK-native: end_borrow
   // CHECK: open_existential_ref
   // CHECK: witness_method
   // CHECK: apply


### PR DESCRIPTION
[silgen] Fix a few uses of UnownedRetain, UnownedRelease, StrongRetainUnowned in favor of their ownership counterparts.

The counterparts are:

UnownedRetain -> CopyValue.
UnownedRelease -> DestroyValue.
StrongRetainUnowned -> CopyUnownedValue.

I thought I hit all of these already. When I was fixing some DI stuff I realized
that I missed a few cases in SILGenLValue.cpp. To make sure we do not regress, I
added some verifier checks to make sure these instructions can only be used in
non-ownership sil.

rdar://31880847

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->