### PR TITLE
[4.0][stdlib] Fix array slice self-assignment bug

### DIFF
--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -742,7 +742,10 @@ public struct ${Self}<Element>
     set(rhs) {
       _checkIndex(bounds.lowerBound)
       _checkIndex(bounds.upperBound)
-      if self[bounds]._buffer.identity != rhs._buffer.identity {
+      // If the replacement buffer has same identity, and the ranges match,
+      // then this was a pinned in-place modification, nothing further needed.
+      if self[bounds]._buffer.identity != rhs._buffer.identity
+      || bounds != rhs.startIndex..<rhs.endIndex {
         self.replaceSubrange(bounds, with: rhs)
       }
     }

--- a/test/stdlib/Inputs/CommonArrayTests.gyb
+++ b/test/stdlib/Inputs/CommonArrayTests.gyb
@@ -373,6 +373,23 @@ ${Suite}.test(
 // Special cases and one-off tests.
 //===----------------------------------------------------------------------===//
 
+${Suite}.test(
+  "${ArrayType}/subscriptSelfAssignDifferentRanges") {
+  var arr: ${ArrayType}<Int> = [ 1010, 1020, 1030 ]
+  arr[0..<0] = arr[...]
+  expectEqual([ 1010, 1020, 1030, 1010, 1020, 1030 ], arr)
+  arr[1..<1] = arr[1..<2]
+  expectEqual([ 1010, 1020, 1020, 1030, 1010, 1020, 1030 ], arr)
+  arr[1..<1] = arr[1..<2]
+  expectEqual([ 1010, 1020, 1020, 1020, 1030, 1010, 1020, 1030 ], arr)
+  arr[1..<2] = arr[0..<1]
+  expectEqual([ 1010, 1010, 1020, 1020, 1030, 1010, 1020, 1030 ], arr)
+  arr[0..<5] = arr.dropFirst(5)
+  expectEqual([ 1010, 1020, 1030, 1010, 1020, 1030 ], arr)
+  arr[...] = arr[0..<0]
+  expectEqual([  ], arr)
+}
+
 ${Suite}.test("${ArrayType}<Void>/map") {
   // This code used to crash because it generated an array of Void with
   // stride == 0.


### PR DESCRIPTION
Cherry pick of #10958 onto the 4.0 branch.

* Explanation: When fast-pathing in-place slice mutation, bounds check the slice's ranges match exactly. In-place mutation of an array slice doesn't need assigning back, but there needs to be a check that the assigned slice's bounds matches otherwise unmatched range assignments like `a[1..<1] = a[1..<2]` were getting thrown away.
* Scope of Issue: Correctness fix
* Risk: Minimal. This is checking for a potential no-op fast path. When the check fails, the full `replaceRange` method is called, writing the slice into the collection in full. This is what is desired in this case.
* Reviewed By: Dave Abrahams
* Testing: Automated test suite + new tests for this case
