### PR TITLE
Fix a pair of bugs with variadic subscripts

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -5197,8 +5197,7 @@ void SILGenFunction::emitSetAccessor(SILLocation loc, SILDeclRef set,
     // whether they were written as separate parameters, which should be
     // reflected in the params list.
     // TODO: we should really take an array of RValues.
-    auto params = accessType.getParams();
-    if (params.size() != 2) {
+    if (accessType->getNumParams() != 2) {
       auto subscriptsTupleType = cast<TupleType>(subscripts.getType());
       assert(inputTupleType->getNumElements()
               == 1 + subscriptsTupleType->getNumElements());
@@ -5207,7 +5206,7 @@ void SILGenFunction::emitSetAccessor(SILLocation loc, SILDeclRef set,
       for (auto &elt : eltRVs)
         eltSources.emplace_back(loc, std::move(elt));
     } else {
-      subscripts.rewriteType(params[1].getType());
+      subscripts.rewriteType(inputTupleType.getElementType(1));
       eltSources.emplace_back(loc, std::move(subscripts));
     }
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -1388,8 +1388,8 @@ namespace {
 
       // Figure out the index and result types.
       auto subscriptTy = simplifyType(selected->openedType);
-      auto indexTy = subscriptTy->castTo<AnyFunctionType>()->getInput();
-      auto resultTy = subscriptTy->castTo<AnyFunctionType>()->getResult();
+      auto subscriptFnTy = subscriptTy->castTo<AnyFunctionType>();
+      auto resultTy = subscriptFnTy->getResult();
 
       // If we opened up an existential when performing the subscript, open
       // the base accordingly.
@@ -1403,9 +1403,10 @@ namespace {
       }
 
       // Coerce the index argument.
-      index = coerceToType(index, indexTy,
-                           locator.withPathElement(
-                             ConstraintLocator::SubscriptIndex));
+      index = coerceCallArguments(index, subscriptFnTy, nullptr,
+                                  argLabels, hasTrailingClosure,
+                                  locator.withPathElement(
+                                    ConstraintLocator::SubscriptIndex));
       if (!index)
         return nullptr;
 
@@ -5241,7 +5242,7 @@ Expr *ExprRewriter::coerceCallArguments(
     findCalleeDeclRef(cs, solution, cs.getConstraintLocator(locator));
 
   // Determine the level,
-  unsigned level = computeCallLevel(cs, callee, apply);
+  unsigned level = apply ? computeCallLevel(cs, callee, apply) : 0;
 
   // Determine the parameter bindings.
   auto params = funcType->getParams();

--- a/test/SILGen/variadic-subscript-single-arg.swift
+++ b/test/SILGen/variadic-subscript-single-arg.swift
@@ -7,3 +7,49 @@ struct Butt {
 }
 
 _ = Butt()[1]
+
+struct A {
+	subscript(indices: Int...) -> Int {
+		get { return 0 }
+		set {}
+	}
+}
+
+func testSetVariadicSubscriptNone() {
+	var a = A()
+	a[] = 1
+}
+
+
+func testSetVariadicSubscriptSingle() {
+	var a = A()
+	a[1] = 1
+}
+
+func testSetVariadicSubscriptMultiple() {
+	var a = A()
+	a[1,2,3] = 1
+}
+
+struct B {
+	subscript(indices: (Int, Int)...) -> Int {
+		get { return 0 }
+		set {}
+	}
+}
+
+func testSetVariadicTupleSubscriptNone() {
+	var b = B()
+	b[] = 1
+}
+
+
+func testSetVariadicTupleSubscriptSingle() {
+	var b = B()
+	b[(1,2)] = 1
+}
+
+func testSetVariadicTupleSubscriptMultiple() {
+	var b = B()
+	b[(1,2),(2,3)] = 1
+}


### PR DESCRIPTION
Fix a SILGen bug with variadic subscripts that I recently introduced and a CSApply bug with variadic tuple subscripts that I did not.

The SILGen bug was exposed by the source-compat test suite as part of rdar://33341584.