### PR TITLE
[4.0][Exclusivity] Don't suggest copying to a local when swapAt() is appro…

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -92,14 +92,18 @@ NOTE(previous_inout_alias,none,
 WARNING(exclusivity_access_required_swift3,none,
         "overlapping accesses to %0, but "
         "%select{initialization|read|modification|deinitialization}1 requires "
-        "exclusive access; consider copying to a local variable",
-        (StringRef, unsigned))
+        "exclusive access; "
+        "%select{consider copying to a local variable|"
+                "consider calling MutableCollection.swapAt(_:_:)}2",
+        (StringRef, unsigned, bool))
 
 ERROR(exclusivity_access_required,none,
       "overlapping accesses to %0, but "
       "%select{initialization|read|modification|deinitialization}1 requires "
-      "exclusive access; consider copying to a local variable",
-      (StringRef, unsigned))
+      "exclusive access; "
+      "%select{consider copying to a local variable|"
+              "consider calling MutableCollection.swapAt(_:_:)}2",
+      (StringRef, unsigned, bool))
 
 ERROR(exclusivity_access_required_unknown_decl,none,
         "overlapping accesses, but "

--- a/test/SILGen/polymorphic_inout_aliasing.swift
+++ b/test/SILGen/polymorphic_inout_aliasing.swift
@@ -11,7 +11,7 @@ class Story {
   }
 
   func test() {
-    // expected-warning@+2 {{overlapping accesses to 'finalStored', but modification requires exclusive access; consider copying to a local variable}}
+    // expected-warning@+2 {{overlapping accesses to 'finalStored', but modification requires exclusive access; consider calling MutableCollection.swapAt(_:_:)}}
     // expected-note@+1 {{conflicting access is here}}
     swap(&self.finalStored[0], &self.finalStored[1])
     swap(&self.overridableStored[0], &self.overridableStored[1])
@@ -24,7 +24,7 @@ protocol Storied {
 }
 
 func testProtocol<T: Storied>(x: inout T) {
-  // expected-warning@+2 {{overlapping accesses to 'x', but modification requires exclusive access; consider copying to a local variable}}
+  // expected-warning@+2 {{overlapping accesses to 'x', but modification requires exclusive access; consider calling MutableCollection.swapAt(_:_:)}}
   // expected-note@+1 {{conflicting access is here}}
   swap(&x.protocolRequirement[0], &x.protocolRequirement[1])
 }

--- a/test/SILOptimizer/exclusivity_static_diagnostics.swift
+++ b/test/SILOptimizer/exclusivity_static_diagnostics.swift
@@ -27,9 +27,9 @@ func inoutOnInoutParameter(p: inout Int) {
 func swapNoSuppression(_ i: Int, _ j: Int) {
   var a: [Int] = [1, 2, 3]
 
-  // expected-error@+2{{overlapping accesses to 'a', but modification requires exclusive access; consider copying to a local variable}}
+  // expected-error@+2{{overlapping accesses to 'a', but modification requires exclusive access; consider calling MutableCollection.swapAt(_:_:)}}
   // expected-note@+1{{conflicting access is here}}
-  swap(&a[i], &a[j]) // no-warning
+  swap(&a[i], &a[j])
 }
 
 class SomeClass { }

--- a/test/SILOptimizer/exclusivity_static_diagnostics_swift3.swift
+++ b/test/SILOptimizer/exclusivity_static_diagnostics_swift3.swift
@@ -28,3 +28,11 @@ func diagnoseOnSameField() {
   // expected-note@+1{{conflicting access is here}}
   takesTwoInouts(&x.f, &x.f)
 }
+
+func diagnoseSwapOnMutableCollection(_ i: Int, _ j: Int) {
+  var a: [Int] = [1, 2, 3]
+
+  // expected-warning@+2{{overlapping accesses to 'a', but modification requires exclusive access; consider calling MutableCollection.swapAt(_:_:)}}
+  // expected-note@+1{{conflicting access is here}}
+  swap(&a[i], &a[j])
+}


### PR DESCRIPTION
…priate

Update static exclusivity diagnostics to not suggest copying to a local
when a call to swapAt() should be used instead. We already emit a FixIt in
this case, so don't suggest an an helpful fix in the diagnostic.

rdar://problem/32296784