### PR TITLE
[Driver] Hack: Add -Xcc -iquote to a bridging header's directory.

### DIFF
--- a/test/ClangImporter/Inputs/sdk-bridging-header/Bridge.h
+++ b/test/ClangImporter/Inputs/sdk-bridging-header/Bridge.h
@@ -1,5 +1,8 @@
 @import ObjectiveC;
 
+@import TheModuleNextDoor;
+#import "TheTextualHeaderNextDoor.h"
+
 @class NSArray;
 
 @interface MyPredicate : NSObject

--- a/test/ClangImporter/Inputs/sdk-bridging-header/TheModuleNextDoor.h
+++ b/test/ClangImporter/Inputs/sdk-bridging-header/TheModuleNextDoor.h
@@ -1,0 +1,1 @@
+extern int TheModuleNextDoorVersion;

--- a/test/ClangImporter/Inputs/sdk-bridging-header/TheTextualHeaderNextDoor.h
+++ b/test/ClangImporter/Inputs/sdk-bridging-header/TheTextualHeaderNextDoor.h
@@ -1,0 +1,1 @@
+extern int TheTextualHeaderNextDoorVersion;

--- a/test/ClangImporter/Inputs/sdk-bridging-header/module.modulemap
+++ b/test/ClangImporter/Inputs/sdk-bridging-header/module.modulemap
@@ -1,0 +1,3 @@
+module TheModuleNextDoor {
+  header "TheModuleNextDoor.h"
+}

--- a/test/ClangImporter/pch-bridging-header.swift
+++ b/test/ClangImporter/pch-bridging-header.swift
@@ -3,31 +3,31 @@
 // RUN: mkdir -p %t/tmp
 
 // First test the explicit frontend-based bridging PCH generation and use works
-// RUN: %target-swift-frontend -emit-pch -o %t/sdk-bridging-header.pch %S/Inputs/sdk-bridging-header.h
-// RUN: %target-swift-frontend -parse -verify %s -import-objc-header %t/sdk-bridging-header.pch
+// RUN: %target-swift-frontend -emit-pch -o %t/sdk-bridging-header.pch %S/Inputs/sdk-bridging-header/Bridge.h -Xcc -iquote -Xcc %S/Inputs/sdk-bridging-header/
+// RUN: %target-swift-frontend -parse -verify %s -import-objc-header %t/sdk-bridging-header.pch -Xcc -iquote -Xcc %S/Inputs/sdk-bridging-header/
 
 // Now test the driver-automated version is inert when disabled
-// RUN: env TMPDIR=%t/tmp/ %target-swiftc_driver -parse -disable-bridging-pch -save-temps %s -import-objc-header %S/Inputs/sdk-bridging-header.h
+// RUN: env TMPDIR=%t/tmp/ %target-swiftc_driver -parse -disable-bridging-pch -save-temps %s -import-objc-header %S/Inputs/sdk-bridging-header/Bridge.h
 // RUN: not ls %t/tmp/*.pch >/dev/null 2>&1
 
 // Test the driver-automated version works by default
-// RUN: env TMPDIR=%t/tmp/ %target-swiftc_driver -parse -save-temps %s -import-objc-header %S/Inputs/sdk-bridging-header.h
+// RUN: env TMPDIR=%t/tmp/ %target-swiftc_driver -parse -save-temps %s -import-objc-header %S/Inputs/sdk-bridging-header/Bridge.h
 // RUN: ls %t/tmp/*.pch >/dev/null 2>&1
 // RUN: llvm-objdump -raw-clang-ast %t/tmp/*.pch | llvm-bcanalyzer -dump | %FileCheck %s
-// CHECK: ORIGINAL_FILE{{.*}}Inputs/sdk-bridging-header.h
+// CHECK: ORIGINAL_FILE{{.*}}Inputs/sdk-bridging-header/Bridge.h
 
 // Test the driver-automated version deletes its PCH file when done
 // RUN: rm %t/tmp/*.pch
-// RUN: env TMPDIR=%t/tmp/ %target-swiftc_driver -parse %s -import-objc-header %S/Inputs/sdk-bridging-header.h
+// RUN: env TMPDIR=%t/tmp/ %target-swiftc_driver -parse %s -import-objc-header %S/Inputs/sdk-bridging-header/Bridge.h
 // RUN: not ls %t/tmp/*.pch >/dev/null 2>&1
 
 // Test -emit-pch invocation but with a persistent PCH
-// RUN: %target-swift-frontend -emit-pch -pch-output-dir %t/pch %S/Inputs/sdk-bridging-header.h
-// RUN: %target-swift-frontend -parse -verify %s -import-objc-header %S/Inputs/sdk-bridging-header.h -pch-output-dir %t/pch -pch-disable-validation
+// RUN: %target-swift-frontend -emit-pch -pch-output-dir %t/pch %S/Inputs/sdk-bridging-header/Bridge.h -Xcc -iquote -Xcc %S/Inputs/sdk-bridging-header/
+// RUN: %target-swift-frontend -parse -verify %s -import-objc-header %S/Inputs/sdk-bridging-header/Bridge.h -pch-output-dir %t/pch -pch-disable-validation -Xcc -iquote -Xcc %S/Inputs/sdk-bridging-header/
 // RUN: ls %t/pch/*.pch >/dev/null 2>&1
 
 // Test implicit use of persistent PCH
-// RUN: %target-swift-frontend -parse -verify %s -import-objc-header %S/Inputs/sdk-bridging-header.h -pch-output-dir %t/pch2
+// RUN: %target-swift-frontend -parse -verify %s -import-objc-header %S/Inputs/sdk-bridging-header/Bridge.h -pch-output-dir %t/pch2 -Xcc -iquote -Xcc %S/Inputs/sdk-bridging-header/
 // RUN: ls %t/pch2/*.pch >/dev/null 2>&1
 
 // RUN: touch %t/header.with.dot.h
@@ -37,13 +37,13 @@
 // RUN: ls %t/pch_with_dot/*swift*clang*.pch | count 2
 
 // Test the driver-automated version using persistent PCH
-// RUN: %target-swiftc_driver -parse -save-temps %s -import-objc-header %S/Inputs/sdk-bridging-header.h -pch-output-dir %t/pch3
+// RUN: %target-swiftc_driver -parse -save-temps %s -import-objc-header %S/Inputs/sdk-bridging-header/Bridge.h -pch-output-dir %t/pch3
 // RUN: ls %t/pch3/*.pch >/dev/null 2>&1
 // RUN: llvm-objdump -raw-clang-ast %t/pch3/*.pch | llvm-bcanalyzer -dump | %FileCheck %s -check-prefix=PERSISTENT
-// PERSISTENT: ORIGINAL_FILE{{.*}}Inputs/sdk-bridging-header.h
+// PERSISTENT: ORIGINAL_FILE{{.*}}Inputs/sdk-bridging-header/Bridge.h
 
 // Test that -pch-disable-validation works in that it won't implicitely create a PCH
-// RUN: not %target-swift-frontend -typecheck %s -import-objc-header %S/Inputs/sdk-bridging-header.h -pch-output-dir %t/no-pch -pch-disable-validation 2>&1 | %FileCheck %s -check-prefix=NO-VALIDATION
+// RUN: not %target-swift-frontend -typecheck %s -import-objc-header %S/Inputs/sdk-bridging-header/Bridge.h -pch-output-dir %t/no-pch -pch-disable-validation 2>&1 | %FileCheck %s -check-prefix=NO-VALIDATION
 // NO-VALIDATION: PCH file {{.*}} not found
 
 import Foundation
@@ -52,3 +52,5 @@ let not = MyPredicate.not()
 let and = MyPredicate.and([])
 let or = MyPredicate.or([not, and])
 
+_ = TheModuleNextDoorVersion
+_ = TheTextualHeaderNextDoorVersion

--- a/test/ClangImporter/sdk-bridging-header.swift
+++ b/test/ClangImporter/sdk-bridging-header.swift
@@ -1,11 +1,11 @@
-// RUN: %target-swift-frontend -typecheck -verify %s -import-objc-header %S/Inputs/sdk-bridging-header.h
+// RUN: %target-swift-frontend -typecheck -verify %s -import-objc-header %S/Inputs/sdk-bridging-header/Bridge.h
 // RUN: not %target-swift-frontend -typecheck %s -import-objc-header %S/Inputs/bad-bridging-header.h 2>&1 | %FileCheck -check-prefix=CHECK-FATAL %s
 
-// RUN: %target-swift-frontend -typecheck -verify %s -Xcc -include -Xcc %S/Inputs/sdk-bridging-header.h -import-objc-header %S/../Inputs/empty.swift
+// RUN: %target-swift-frontend -typecheck -verify %s -Xcc -include -Xcc %S/Inputs/sdk-bridging-header/Bridge.h -import-objc-header %S/../Inputs/empty.swift -DINCLUDE_ONLY
 
 // RUN: not %target-swift-frontend -typecheck %s -Xcc -include -Xcc %S/Inputs/bad-bridging-header.h 2>&1 | %FileCheck -check-prefix=CHECK-INCLUDE %s
 // RUN: not %target-swift-frontend -typecheck %s -Xcc -include -Xcc %S/Inputs/bad-bridging-header.h -import-objc-header %S/../Inputs/empty.swift 2>&1 | %FileCheck -check-prefix=CHECK-INCLUDE %s
-// RUN: not %target-swift-frontend -typecheck %s -Xcc -include -Xcc %S/Inputs/bad-bridging-header.h -import-objc-header %S/Inputs/sdk-bridging-header.h 2>&1 | %FileCheck -check-prefix=CHECK-INCLUDE %s
+// RUN: not %target-swift-frontend -typecheck %s -Xcc -include -Xcc %S/Inputs/bad-bridging-header.h -import-objc-header %S/Inputs/sdk-bridging-header/Bridge.h 2>&1 | %FileCheck -check-prefix=CHECK-INCLUDE %s
 
 // CHECK-FATAL: failed to import bridging header
 
@@ -22,3 +22,9 @@ let and = MyPredicate.and([])
 let or = MyPredicate.or([not, and])
 
 _ = MyPredicate.foobar() // expected-error{{type 'MyPredicate' has no member 'foobar'}}
+
+#if !INCLUDE_ONLY
+_ = TheModuleNextDoorVersion
+#endif
+_ = TheTextualHeaderNextDoorVersion
+_ = checkThatThereAreStillErrors // expected-error{{}}


### PR DESCRIPTION
It turns out that Clang's been happy to pick up module maps from the same directory as a bridging header imported with `-import-objc-header`. People were implicitly relying on this behavior, which broke when we started precompiling bridging headers—suddenly the "same directory" was wherever the precompiled form was (either a temporary directory or a persistent build intermediate). Emulate the old behavior by formally making this directory a Clang search path using the `-iquote` option. Why `-iquote`? Because (a) it always goes first, and (b) it won't disturb textual includes that use angle-brackets, while still getting Clang to check the directory for a module map.

We may want to change this behavior in the future, but for now it's more important to keep things consistent between precompiled and non-precompiled bridging headers, and the easiest way to do that is to follow the old behavior.

rdar://problem/32810754
