### PR TITLE
[TSan] Change TSan inout accesses to use __tsan_external_write callback

### DIFF
--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -1210,11 +1210,11 @@ FUNCTION(GetErrorValue, swift_getErrorValue, C_CC,
          ARGS(ErrorPtrTy, Int8PtrPtrTy, OpenedErrorTriplePtrTy),
          ATTRS(NoUnwind))
 
-// void __tsan_write1(void *addr);
+// void __tsan_external_write(void *addr, void *caller_pc, void *tag);
 // This is a Thread Sanitizer instrumentation entry point in compiler-rt.
-FUNCTION(TSanInoutAccess, __tsan_write1, C_CC,
+FUNCTION(TSanInoutAccess, __tsan_external_write, C_CC,
          RETURNS(VoidTy),
-         ARGS(Int8PtrTy),
+         ARGS(Int8PtrTy, Int8PtrTy, Int8PtrTy),
          ATTRS(NoUnwind))
 
 FUNCTION(GetKeyPath, swift_getKeyPath, C_CC,

--- a/test/IRGen/tsan_instrumentation.sil
+++ b/test/IRGen/tsan_instrumentation.sil
@@ -23,7 +23,7 @@ sil @_T020tsan_instrumentation11inoutAccessyyF : $@convention(thin) () -> () {
 bb0:
   %0 = global_addr @_T020tsan_instrumentation1gSiv : $*Int
   %1 = builtin "tsanInoutAccess"(%0 : $*Int) : $()
-// CHECK:  call void @__tsan_write1(i8* bitcast ([[GLOBAL]]* @_T020tsan_instrumentation1gSiv to i8*))
+// CHECK:  call void @__tsan_external_write(i8* bitcast ([[GLOBAL]]* @_T020tsan_instrumentation1gSiv to i8*), i8* null, i8* inttoptr ({{(i32|i64)}} 1 to i8*))
 
   %2 = tuple ()
   return %2 : $()

--- a/test/Sanitizers/tsan-inout.swift
+++ b/test/Sanitizers/tsan-inout.swift
@@ -76,7 +76,7 @@ testRace(name: "GlobalStructMutatingMethod",
         thread: { _ = globalForGlobalStructMutatingMethod.read() },
         thread: { globalForGlobalStructMutatingMethod.mutate() } )
 // CHECK-LABEL: Running GlobalStructMutatingMethod
-// CHECK: ThreadSanitizer: data race
+// CHECK: ThreadSanitizer: Swift access race
 // CHECK: Location is global
 
 var globalForGlobalStructDifferentStoredPropertiesInout = UninstrumentedStruct()
@@ -84,7 +84,7 @@ testRace(name: "GlobalStructDifferentStoredPropertiesInout",
         thread: { uninstrumentedTakesInout(&globalForGlobalStructDifferentStoredPropertiesInout.storedProperty1) },
         thread: { uninstrumentedTakesInout(&globalForGlobalStructDifferentStoredPropertiesInout.storedProperty2) } )
 // CHECK-LABEL: Running GlobalStructDifferentStoredPropertiesInout
-// CHECK: ThreadSanitizer: data race
+// CHECK: ThreadSanitizer: Swift access race
 // CHECK: Location is global
 
 var globalForGlobalStructSameStoredPropertyInout = UninstrumentedStruct()
@@ -92,7 +92,7 @@ testRace(name: "GlobalStructSameStoredPropertyInout",
         thread: { uninstrumentedTakesInout(&globalForGlobalStructSameStoredPropertyInout.storedProperty1) },
         thread: { uninstrumentedTakesInout(&globalForGlobalStructSameStoredPropertyInout.storedProperty1) } )
 // CHECK-LABEL: Running GlobalStructSameStoredPropertyInout
-// CHECK: ThreadSanitizer: data race
+// CHECK: ThreadSanitizer: Swift access race
 
 
 var globalForGlobalStructSubscriptDifferentIndexesInout = UninstrumentedStruct()
@@ -100,7 +100,7 @@ testRace(name: "GlobalStructSubscriptDifferentIndexesInout",
         thread: { uninstrumentedTakesInout(&globalForGlobalStructSubscriptDifferentIndexesInout[0]) },
         thread: { uninstrumentedTakesInout(&globalForGlobalStructSubscriptDifferentIndexesInout[1]) } )
 // CHECK-LABEL: Running GlobalStructSubscriptDifferentIndexes
-// CHECK: ThreadSanitizer: data race
+// CHECK: ThreadSanitizer: Swift access race
 // CHECK: Location is global
 
 
@@ -109,7 +109,7 @@ testRace(name: "GlobalStructSubscriptDifferentIndexesGetSet",
         thread: { _ = globalForGlobalStructSubscriptDifferentIndexesGetSet[0] },
         thread: { globalForGlobalStructSubscriptDifferentIndexesGetSet[1] = 12 } )
 // CHECK-LABEL: Running GlobalStructSubscriptDifferentIndexesGetSet
-// CHECK: ThreadSanitizer: data race
+// CHECK: ThreadSanitizer: Swift access race
 // CHECK: Location is global
 
 var globalForGlobalClassGeneralMethods = UninstrumentedClass()
@@ -117,21 +117,21 @@ testRace(name: "GlobalClassGeneralMethods",
         thread: { _ = globalForGlobalClassGeneralMethods.read() },
         thread: { globalForGlobalClassGeneralMethods.mutate() } )
 // CHECK-LABEL: Running GlobalClassGeneralMethods
-// CHECK-NOT: ThreadSanitizer: data race
+// CHECK-NOT: ThreadSanitizer: {{.*}} race
 
 var globalForGlobalClassDifferentStoredPropertiesInout = UninstrumentedClass()
 testRace(name: "GlobalClassDifferentStoredPropertiesInout",
         thread: { uninstrumentedTakesInout(&globalForGlobalClassDifferentStoredPropertiesInout.storedProperty1) },
         thread: { uninstrumentedTakesInout(&globalForGlobalClassDifferentStoredPropertiesInout.storedProperty2) } )
 // CHECK-LABEL: Running GlobalClassDifferentStoredPropertiesInout
-// CHECK-NOT: ThreadSanitizer: data race
+// CHECK-NOT: ThreadSanitizer: {{.*}} race
 
 var globalForGlobalClassSubscriptDifferentIndexesInout = UninstrumentedClass()
 testRace(name: "GlobalClassSubscriptDifferentIndexesInout",
         thread: { uninstrumentedTakesInout(&globalForGlobalClassSubscriptDifferentIndexesInout[0]) },
         thread: { uninstrumentedTakesInout(&globalForGlobalClassSubscriptDifferentIndexesInout[1]) } )
 // CHECK-LABEL: Running GlobalClassSubscriptDifferentIndexesInout
-// CHECK-NOT: ThreadSanitizer: data race
+// CHECK-NOT: ThreadSanitizer: {{.*}} race
 
 
 var globalForGlobalClassSameStoredPropertyInout = UninstrumentedClass()
@@ -139,7 +139,7 @@ testRace(name: "GlobalClassSameStoredPropertyInout",
         thread: { uninstrumentedTakesInout(&globalForGlobalClassSameStoredPropertyInout.storedProperty1) },
         thread: { uninstrumentedTakesInout(&globalForGlobalClassSameStoredPropertyInout.storedProperty1) } )
 // CHECK-LABEL: Running GlobalClassSameStoredPropertyInout
-// CHECK: ThreadSanitizer: data race
+// CHECK: ThreadSanitizer: Swift access race
 // CHECK: Location is heap block
 
 // These access a global declared in the TSanUninstrumented module
@@ -147,7 +147,7 @@ testRace(name: "InoutAccessToStoredGlobalInUninstrumentedModule",
         thread: { uninstrumentedTakesInout(&storedGlobalInUninstrumentedModule1) },
         thread: { uninstrumentedTakesInout(&storedGlobalInUninstrumentedModule1) } )
 // CHECK-LABEL: Running InoutAccessToStoredGlobalInUninstrumentedModule
-// CHECK: ThreadSanitizer: data race
+// CHECK: ThreadSanitizer: Swift access race
 // CHECK: Location is global
 
 // These access a global declared in the TSanUninstrumented module.
@@ -165,14 +165,14 @@ testRace(name: "InoutAccessToComputedGlobalInUninstrumentedModule",
         thread: { uninstrumentedTakesInout(&computedGlobalInUninstrumentedModule1) },
         thread: { uninstrumentedTakesInout(&computedGlobalInUninstrumentedModule1) } )
 // CHECK-LABEL: Running InoutAccessToComputedGlobalInUninstrumentedModule
-// CHECK-NOT: ThreadSanitizer: data race
+// CHECK-NOT: ThreadSanitizer: {{.*}} race
 
 // These access a computed global declared in the TSanUninstrumented module
 testRace(name: "ReadAndWriteToComputedGlobalInUninstrumentedModule",
         thread: { computedGlobalInUninstrumentedModule2 = 7 },
         thread: { _ = computedGlobalInUninstrumentedModule2 } )
 // CHECK-LABEL: Running ReadAndWriteToComputedGlobalInUninstrumentedModule
-// CHECK-NOT: ThreadSanitizer: data race
+// CHECK-NOT: ThreadSanitizer: {{.*}} race
 
 
 
@@ -183,7 +183,7 @@ testRace(name: "GlobalUninstrumentedClassStoredPropertyMutatingMethod",
         thread: { _ = globalForGlobalUninstrumentedClassStoredPropertyMutatingMethod.storedStructProperty.read() },
         thread: { globalForGlobalUninstrumentedClassStoredPropertyMutatingMethod.storedStructProperty.mutate() } )
 // CHECK-LABEL: Running GlobalUninstrumentedClassStoredPropertyMutatingMethod
-// CHECK-NOT: ThreadSanitizer: data race
+// CHECK-NOT: ThreadSanitizer: {{.*}} race
 
 // Note: TSan doesn't see a race above because it doesn't see any load on the
 // read side because the getter for the class property is not instrumented.
@@ -194,7 +194,7 @@ testRace(name: "GlobalUninstrumentedClassStoredPropertyInout",
         thread: { uninstrumentedTakesInout(&globalForGlobalUninstrumentedClassStoredPropertyInout.storedStructProperty.storedProperty1) },
         thread: { uninstrumentedTakesInout(&globalForGlobalUninstrumentedClassStoredPropertyInout.storedStructProperty.storedProperty2) } )
 // CHECK-LABEL: Running GlobalUninstrumentedClassStoredPropertyInout
-// CHECK: ThreadSanitizer: data race
+// CHECK: ThreadSanitizer: Swift access race
 // CHECK: Location is heap block
 
 // Note: TSan sees the race above because the inout instrumentation adds an
@@ -206,7 +206,7 @@ testRace(name: "GlobalUninstrumentedClassComputedPropertyInout",
         thread: { uninstrumentedTakesInout(&globalForGlobalUninstrumentedClassComputedPropertyInout.computedStructProperty.storedProperty1) },
         thread: { uninstrumentedTakesInout(&globalForGlobalUninstrumentedClassComputedPropertyInout.computedStructProperty.storedProperty1) } )
 // CHECK-LABEL: Running GlobalUninstrumentedClassComputedPropertyInout
-// CHECK-NO: ThreadSanitizer: data race
+// CHECK-NOT: ThreadSanitizer: {{.*}} race
 
 // In the above the write in instrumented code is to the value buffer allocated
 // at the call site so there is no data race if the getter and setters themselves
@@ -219,7 +219,7 @@ testRace(name: "GlobalInstrumentedClassStoredPropertyMutatingMethod",
         thread: { _ = globalForGlobalInstrumentedClassStoredPropertyMutatingMethod.storedStructProperty.read() },
         thread: { globalForGlobalInstrumentedClassStoredPropertyMutatingMethod.storedStructProperty.mutate() } )
 // CHECK-LABEL: Running GlobalInstrumentedClassStoredPropertyMutatingMethod
-// CHECK: ThreadSanitizer: data race
+// CHECK: ThreadSanitizer: Swift access race
 // CHECK: Location is heap block
 //
 // TSan does see this above race because the getter and materializeForSet is instrumented
@@ -250,7 +250,7 @@ func runCapturedLocalStructMutatingMethod() {
          thread: { l.mutate() } )
 }
 // CHECK-LABEL: Running CapturedLocalStructMutatingMethod
-// CHECK: ThreadSanitizer: data race
+// CHECK: ThreadSanitizer: Swift access race
 // CHECK: Location is heap block
 
 
@@ -261,7 +261,7 @@ func runCapturedLocalStructDifferentStoredPropertiesInout() {
          thread: { uninstrumentedTakesInout(&l.storedProperty2) } )
 }
 // CHECK-LABEL: Running CapturedLocalStructDifferentStoredPropertiesInout
-// CHECK: ThreadSanitizer: data race
+// CHECK: ThreadSanitizer: Swift access race
 // CHECK: Location is heap block
 
 
@@ -272,7 +272,7 @@ func runCapturedLocalClassGeneralMethods() {
           thread: { l.mutate() } )
 }
 // CHECK-LABEL: Running CapturedLocalClassGeneralMethods
-// CHECK-NOT: ThreadSanitizer: data race
+// CHECK-NOT: ThreadSanitizer: {{.*}} race
 
 
 func runCapturedLocalDifferentStoredPropertiesInout() {
@@ -282,7 +282,7 @@ func runCapturedLocalDifferentStoredPropertiesInout() {
           thread: { uninstrumentedTakesInout(&l.storedProperty2) } )
 }
 // CHECK-LABEL: Running CapturedLocalClassDifferentStoredPropertiesInout
-// CHECK-NOT: ThreadSanitizer: data race
+// CHECK-NOT: ThreadSanitizer: {{.*}} race
 
 func runCapturedLocalSameStoredPropertyInout() {
   let l = UninstrumentedClass()
@@ -291,7 +291,7 @@ func runCapturedLocalSameStoredPropertyInout() {
           thread: { uninstrumentedTakesInout(&l.storedProperty1) } )
 }
 // CHECK-LABEL: Running CapturedLocalClassSameStoredPropertyInout
-// CHECK: ThreadSanitizer: data race
+// CHECK: ThreadSanitizer: Swift access race
 // CHECK: Location is heap block
 
 runLocalTests()


### PR DESCRIPTION
Adopt the  __tsan_external_write compiler-rt callbacks when IRGen'ing
the TSan inout access builtin.

rdar://problem/32260994
rdar://problem/33461691