### PR TITLE
[4.0] IRGen: Fix test case only on x86-64 do we use indirect byval passing

### DIFF
--- a/test/IRGen/c_functions.swift
+++ b/test/IRGen/c_functions.swift
@@ -1,5 +1,6 @@
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -import-objc-header %S/Inputs/c_functions.h -primary-file %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -target x86_64-apple-macosx10.11 -import-objc-header %S/Inputs/c_functions.h -primary-file %s -emit-ir |  %FileCheck %s --check-prefix=x86_64
 
 // This is deliberately not a SIL test so that we can test SILGen too.
 
@@ -18,8 +19,8 @@ func test_indirect_by_val_alignment() {
   log_a_thing(x)
 }
 
-// CHECK-LABEL: define hidden swiftcc void  @_T011c_functions30test_indirect_by_val_alignmentyyF()
-// CHECK: %indirect-temporary = alloca %TSC7a_thingV, align [[ALIGN:[0-9]+]]
-// CHECK: [[CAST:%.*]] = bitcast %TSC7a_thingV* %indirect-temporary to %struct.a_thing*
-// CHECK: call void @log_a_thing(%struct.a_thing* byval align [[ALIGN]] [[CAST]])
-// CHECK: define internal void @log_a_thing(%struct.a_thing* byval align [[ALIGN]]
+// x86_64-LABEL: define hidden swiftcc void  @_T011c_functions30test_indirect_by_val_alignmentyyF()
+// x86_64: %indirect-temporary = alloca %TSC7a_thingV, align [[ALIGN:[0-9]+]]
+// x86_64: [[CAST:%.*]] = bitcast %TSC7a_thingV* %indirect-temporary to %struct.a_thing*
+// x86_64: call void @log_a_thing(%struct.a_thing* byval align [[ALIGN]] [[CAST]])
+// x86_64: define internal void @log_a_thing(%struct.a_thing* byval align [[ALIGN]]

--- a/test/IRGen/c_functions.swift
+++ b/test/IRGen/c_functions.swift
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -import-objc-header %S/Inputs/c_functions.h -primary-file %s -emit-ir | %FileCheck %s
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -target x86_64-apple-macosx10.11 -import-objc-header %S/Inputs/c_functions.h -primary-file %s -emit-ir |  %FileCheck %s --check-prefix=x86_64
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -import-objc-header %S/Inputs/c_functions.h -primary-file %s -emit-ir |  %FileCheck %s --check-prefix=%target-cpu
 
 // This is deliberately not a SIL test so that we can test SILGen too.
 
@@ -24,3 +24,11 @@ func test_indirect_by_val_alignment() {
 // x86_64: [[CAST:%.*]] = bitcast %TSC7a_thingV* %indirect-temporary to %struct.a_thing*
 // x86_64: call void @log_a_thing(%struct.a_thing* byval align [[ALIGN]] [[CAST]])
 // x86_64: define internal void @log_a_thing(%struct.a_thing* byval align [[ALIGN]]
+
+
+// We only want to test x86_64.
+// arm64: define hidden swiftcc void  @_T011c_functions30test_indirect_by_val_alignmentyyF()
+// armv7k: define hidden swiftcc void  @_T011c_functions30test_indirect_by_val_alignmentyyF()
+// armv7s: define hidden swiftcc void  @_T011c_functions30test_indirect_by_val_alignmentyyF()
+// armv7: define hidden swiftcc void  @_T011c_functions30test_indirect_by_val_alignmentyyF()
+// i386: define hidden swiftcc void  @_T011c_functions30test_indirect_by_val_alignmentyyF()


### PR DESCRIPTION
• Explanation: In the fix for rdar://33242303 / https://github.com/apple/swift/pull/10932 I added a test case that only succeeds on x86_64 platforms because it checks for the alignment of indirect byval parameters which we don’t emit on arm64. The test is written in a way that did not add the x86_64 target to the command line and would therefore fail on arm64.

• Scope of Issue: Failing test case because the test case is not narrow enough

• Origination: Recently introduced 

• Risk: Low. This is a fix to a test case.

• Testing: The test case was fixed and should no longer fail during regression tests running on non x86_64 archs


rdar://33376164

