### PR TITLE
redundant load elimination for @in_guaranteed-only funcs

### DIFF
--- a/lib/SILOptimizer/Analysis/MemoryBehavior.cpp
+++ b/lib/SILOptimizer/Analysis/MemoryBehavior.cpp
@@ -241,10 +241,23 @@ MemBehavior MemoryBehaviorVisitor::visitApplyInst(ApplyInst *AI) {
   MemBehavior Behavior = MemBehavior::None;
 
   // We can ignore mayTrap().
-  if (ApplyEffects.mayReadRC() ||
-      (InspectionMode == RetainObserveKind::ObserveRetains &&
-       ApplyEffects.mayAllocObjects())) {
-    Behavior = MemBehavior::MayHaveSideEffects;
+  bool any_in_guaranteed_params = false;
+  for (auto op : enumerate(AI->getArgumentOperands())) {
+    if (op.Value.get() == V &&
+        AI->getSubstCalleeConv().getSILArgumentConvention(op.Index) == swift::SILArgumentConvention::Indirect_In_Guaranteed) {
+      any_in_guaranteed_params = true;
+      break;
+    }
+  }
+
+  if (any_in_guaranteed_params) {
+    // one the parameters in the function call is @in_guaranteed of V, ie. the
+    // callee isn't allowed to modify it.
+    Behavior = MemBehavior::MayRead;
+  } else if (ApplyEffects.mayReadRC() ||
+        (InspectionMode == RetainObserveKind::ObserveRetains &&
+         ApplyEffects.mayAllocObjects())) {
+      Behavior = MemBehavior::MayHaveSideEffects;
   } else {
     auto &GlobalEffects = ApplyEffects.getGlobalEffects();
     Behavior = GlobalEffects.getMemBehavior(InspectionMode);
@@ -265,6 +278,7 @@ MemBehavior MemoryBehaviorVisitor::visitApplyInst(ApplyInst *AI) {
       }
     }
   }
+
   if (Behavior > MemBehavior::None) {
     if (Behavior > MemBehavior::MayRead && isLetPointer(V))
       Behavior = MemBehavior::MayRead;

--- a/test/SILOptimizer/mem-behavior.sil
+++ b/test/SILOptimizer/mem-behavior.sil
@@ -196,3 +196,20 @@ bb0(%0 : $*Int32, %1 : $*Int32):
   %r = tuple()
   return %r : $()
 }
+
+// CHECK-LABEL: @test_in_guaranteed_only_fun_is_ro_entry
+// CHECK:      PAIR #0.
+// CHECK-NEXT:    %2 = apply %1(%0) : $@convention(thin) (@in_guaranteed Int) -> ()
+// CHECK-NEXT:    %0 = argument of bb0 : $*Int
+// CHECK-NEXT:  r=1,w=0,se=0
+sil @test_in_guaranteed_only_fun_is_ro_sink : $@convention(thin) (Int) -> ()
+sil @test_in_guaranteed_only_fun_is_ro_callee : $@convention(thin) (@in_guaranteed Int) -> ()
+
+sil @test_in_guaranteed_only_fun_is_ro_entry : $@convention(thin) (@in Int) -> () {
+bb0(%0 : $*Int):
+  %f_callee = function_ref @test_in_guaranteed_only_fun_is_ro_callee : $@convention(thin) (@in_guaranteed Int) -> ()
+  %r1 = apply %f_callee(%0) : $@convention(thin) (@in_guaranteed Int) -> ()
+
+  %3 = tuple()
+  return %3 : $()
+}

--- a/test/SILOptimizer/redundant_load_elim.sil
+++ b/test/SILOptimizer/redundant_load_elim.sil
@@ -1190,3 +1190,31 @@ bb2(%a : $*Int):
   dealloc_stack %4 : $*Int
   return %r : $Int
 } 
+
+// Make sure that the store is forwarded to the load, ie. the load is
+// eliminated. That's correct as the stored value can't be changed by the
+// callee as it's passed with @in_guaranteed.
+sil @test_rle_in_guaranteed_sink : $@convention(thin) (Int) -> ()
+sil @test_rle_in_guaranteed_callee : $@convention(thin) (@in_guaranteed Int) -> ()
+
+// CHECK-LABEL: sil @test_rle_in_guaranteed_entry
+sil @test_rle_in_guaranteed_entry : $@convention(thin) (@in Int) -> () {
+bb0(%0 : $*Int):
+  %value_raw = integer_literal $Builtin.Int64, 42
+  // CHECK: [[VAL:%.*]] = struct $Int
+  %value = struct $Int (%value_raw : $Builtin.Int64)
+  store %value to %0 : $*Int
+
+  %f_callee = function_ref @test_rle_in_guaranteed_callee : $@convention(thin) (@in_guaranteed Int) -> ()
+  %r1 = apply %f_callee(%0) : $@convention(thin) (@in_guaranteed Int) -> ()
+
+  // CHECK-NOT: load
+  %value_again = load %0 : $*Int
+
+  %f_sink = function_ref @test_rle_in_guaranteed_sink : $@convention(thin) (Int) -> ()
+  // CHECK: ([[VAL]])
+  %r2 = apply %f_sink(%value_again) : $@convention(thin) (Int) -> ()
+
+  %3 = tuple()
+  return %3 : $()
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->

This adds _Redundant Load Elimination_ (RLE) across functions that only have `@in_guaranteed` parameters (which are read-only for the callee).

 - https://lists.swift.org/pipermail/swift-dev/Week-of-Mon-20170717/004934.html

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-5403](https://bugs.swift.org/browse/SR-5403).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

left to do

 - [x] write a test that proves the optimisation works