### PR TITLE
[4.0] SILGen: Ease off +0 peepholes for load exprs.

### DIFF
--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -1081,7 +1081,10 @@ RValue RValueEmitter::visitLoadExpr(LoadExpr *E, SGFContext C) {
   // Any writebacks here are tightly scoped.
   FormalEvaluationScope writeback(SGF);
   LValue lv = SGF.emitLValue(E->getSubExpr(), AccessKind::Read);
-  return SGF.emitLoadOfLValue(E, std::move(lv), C);
+  // We can't load at immediate +0 from the lvalue without deeper analysis,
+  // since the access will be immediately ended and might invalidate the value
+  // we loaded.
+  return SGF.emitLoadOfLValue(E, std::move(lv), C.withFollowingSideEffects());
 }
 
 SILValue SILGenFunction::emitTemporaryAllocation(SILLocation loc,
@@ -2068,7 +2071,9 @@ RValue RValueEmitter::visitMemberRefExpr(MemberRefExpr *E, SGFContext C) {
   FormalEvaluationScope scope(SGF);
 
   LValue lv = SGF.emitLValue(E, AccessKind::Read);
-  return SGF.emitLoadOfLValue(E, std::move(lv), C);
+  // We can't load at +0 without further analysis, since the formal access into
+  // the lvalue will end immediately.
+  return SGF.emitLoadOfLValue(E, std::move(lv), C.withFollowingSideEffects());
 }
 
 RValue RValueEmitter::visitDynamicMemberRefExpr(DynamicMemberRefExpr *E,
@@ -2087,7 +2092,9 @@ RValue RValueEmitter::visitSubscriptExpr(SubscriptExpr *E, SGFContext C) {
   FormalEvaluationScope scope(SGF);
 
   LValue lv = SGF.emitLValue(E, AccessKind::Read);
-  return SGF.emitLoadOfLValue(E, std::move(lv), C);
+  // We can't load at +0 without further analysis, since the formal access into
+  // the lvalue will end immediately.
+  return SGF.emitLoadOfLValue(E, std::move(lv), C.withFollowingSideEffects());
 }
 
 RValue RValueEmitter::visitDynamicSubscriptExpr(

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -3021,7 +3021,7 @@ RValue SILGenFunction::emitLoadOfLValue(SILLocation loc, LValue &&src,
   PathComponent &&component =
     drillToLastComponent(*this, loc, std::move(src), addr, AccessKind::Read);
 
-  // If the last component is physical, just drill down and load from it.
+  // If the last component is physical, drill down and load from it.
   if (component.isPhysical()) {
     addr = std::move(component.asPhysical())
              .offset(*this, loc, addr, AccessKind::Read);
@@ -3031,7 +3031,7 @@ RValue SILGenFunction::emitLoadOfLValue(SILLocation loc, LValue &&src,
                            isGuaranteedValid));
   }
 
-  // If the last component is logical, just emit a get.
+  // If the last component is logical, emit a get.
   return std::move(component.asLogical()).get(*this, loc, addr, C);
 }
 

--- a/test/SILGen/dynamic_lookup.swift
+++ b/test/SILGen/dynamic_lookup.swift
@@ -62,7 +62,7 @@ func direct_to_static_method(_ obj: AnyObject) {
   // CHECK: store [[ARG_COPY]] to [init] [[PBOBJ]] : $*AnyObject
   // CHECK: end_borrow [[BORROWED_ARG]] from [[ARG]]
   // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[PBOBJ]]
-  // CHECK-NEXT: [[OBJCOPY:%[0-9]+]] = load_borrow [[READ]] : $*AnyObject
+  // CHECK-NEXT: [[OBJCOPY:%[0-9]+]] = load [copy] [[READ]] : $*AnyObject
   // CHECK: end_access [[READ]]
   // CHECK-NEXT: [[OBJMETA:%[0-9]+]] = existential_metatype $@thick AnyObject.Type, [[OBJCOPY]] : $AnyObject
   // CHECK-NEXT: [[OPENMETA:%[0-9]+]] = open_existential_metatype [[OBJMETA]] : $@thick AnyObject.Type to $@thick (@opened([[UUID:".*"]]) AnyObject).Type
@@ -141,7 +141,7 @@ func opt_to_static_method(_ obj: AnyObject) {
   // CHECK:   [[OPTBOX:%[0-9]+]] = alloc_box ${ var Optional<@callee_owned () -> ()> }
   // CHECK:   [[PBO:%.*]] = project_box [[OPTBOX]]
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PBOBJ]]
-  // CHECK:   [[OBJCOPY:%[0-9]+]] = load_borrow [[READ]] : $*AnyObject
+  // CHECK:   [[OBJCOPY:%[0-9]+]] = load [copy] [[READ]] : $*AnyObject
   // CHECK:   [[OBJMETA:%[0-9]+]] = existential_metatype $@thick AnyObject.Type, [[OBJCOPY]] : $AnyObject
   // CHECK:   [[OPENMETA:%[0-9]+]] = open_existential_metatype [[OBJMETA]] : $@thick AnyObject.Type to $@thick (@opened
   // CHECK:   [[OBJCMETA:%[0-9]+]] = thick_to_objc_metatype [[OPENMETA]]

--- a/test/SILGen/functions.swift
+++ b/test/SILGen/functions.swift
@@ -176,7 +176,7 @@ func calls(_ i:Int, j:Int, k:Int) {
   // -- Curry the Type onto static method argument lists.
   
   // CHECK: [[READC:%.*]] = begin_access [read] [unknown] [[CADDR]]
-  // CHECK: [[C:%[0-9]+]] = load_borrow [[READC]]
+  // CHECK: [[C:%[0-9]+]] = load [copy] [[READC]]
   // CHECK: [[META:%.*]] = value_metatype $@thick SomeClass.Type, [[C]]
   // CHECK: [[METHOD:%[0-9]+]] = class_method [[META]] : {{.*}}, #SomeClass.static_method!1
   // CHECK: [[READI:%.*]] = begin_access [read] [unknown] [[IADDR]]

--- a/test/SILGen/load_from_lvalue_in_plus_zero_context.swift
+++ b/test/SILGen/load_from_lvalue_in_plus_zero_context.swift
@@ -1,0 +1,32 @@
+// RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s
+
+class A {
+  lazy var b: B = B()
+}
+
+final class B {
+  var c: C? {
+    get { return nil }
+    set {}
+  }
+}
+
+struct C {
+  let d: String
+}
+
+// CHECK-LABEL: sil hidden @{{.*}}test
+func test(a: A) {
+  let s: String?
+  // CHECK:   [[C_TEMP:%.*]] = alloc_stack $Optional<C>
+  // CHECK:   [[TAG:%.*]] = select_enum_addr [[C_TEMP]]
+  // CHECK:   cond_br [[TAG]], [[SOME:bb[0-9]+]], [[NONE:bb[0-9]+]]
+  // CHECK: [[SOME]]:
+  // CHECK:   [[C_PAYLOAD:%.*]] = unchecked_take_enum_data_addr [[C_TEMP]]
+  // -- This must be a copy, since we'll immediately destroy the value in the
+  //    temp buffer
+  // CHECK:   [[LOAD:%.*]] = load [copy] [[C_PAYLOAD]]
+  // CHECK:   destroy_addr [[C_TEMP]]
+  s = a.b.c?.d
+  print(s)
+}


### PR DESCRIPTION
Explanation: Due to stricter handling of lvalues, peepholes that would attempt to load an rvalue without retaining would lead to use-after-free bugs.

Scope: Regression from 3.1

Issue: rdar://problem/32730865

Risk: Low, removal of a peephole optimization, small risk of performance regressions

Testing: Swift CI, project from radar