### PR TITLE
Codable Class Fixes

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2072,6 +2072,14 @@ NOTE(codable_codingkeys_type_is_not_an_enum_here,none,
      "cannot automatically synthesize %0 because 'CodingKeys' is not an enum", (Type))
 NOTE(codable_codingkeys_type_does_not_conform_here,none,
      "cannot automatically synthesize %0 because 'CodingKeys' does not conform to CodingKey", (Type))
+NOTE(decodable_no_super_init_here,none,
+     "cannot automatically synthesize %0 because superclass does not have a callable 'init()' or 'init(from:)'", (DeclName))
+NOTE(decodable_super_init_not_designated_here,none,
+     "cannot automatically synthesize %0 because required superclass initializer %1 is not designated", (DeclName, DeclName))
+NOTE(decodable_inaccessible_super_init_here,none,
+     "cannot automatically synthesize %0 because required superclass initializer %1 is inaccessible due to "
+     "'%select{private|fileprivate|internal|%error|%error}2' protection level",
+     (DeclName, DeclName, Accessibility))
 
 // Dynamic Self
 ERROR(dynamic_self_non_method,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2073,13 +2073,15 @@ NOTE(codable_codingkeys_type_is_not_an_enum_here,none,
 NOTE(codable_codingkeys_type_does_not_conform_here,none,
      "cannot automatically synthesize %0 because 'CodingKeys' does not conform to CodingKey", (Type))
 NOTE(decodable_no_super_init_here,none,
-     "cannot automatically synthesize %0 because superclass does not have a callable 'init()' or 'init(from:)'", (DeclName))
+     "cannot automatically synthesize %0 because superclass does not have a callable %1", (DeclName, DeclName))
 NOTE(decodable_super_init_not_designated_here,none,
-     "cannot automatically synthesize %0 because required superclass initializer %1 is not designated", (DeclName, DeclName))
+     "cannot automatically synthesize %0 because implementation would need to call %1, which is not designated", (DeclName, DeclName))
 NOTE(decodable_inaccessible_super_init_here,none,
-     "cannot automatically synthesize %0 because required superclass initializer %1 is inaccessible due to "
+     "cannot automatically synthesize %0 because implementation would need to call %1, which is inaccessible due to "
      "'%select{private|fileprivate|internal|%error|%error}2' protection level",
      (DeclName, DeclName, Accessibility))
+NOTE(decodable_super_init_is_failable_here,none,
+     "cannot automatically synthesize %0 because implementation would need to call %1, which is failable", (DeclName, DeclName))
 NOTE(decodable_suggest_overriding_init_here,none,
      "did you mean to override 'init(from:)'?", ())
 NOTE(codable_suggest_overriding_init_here,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2080,6 +2080,10 @@ NOTE(decodable_inaccessible_super_init_here,none,
      "cannot automatically synthesize %0 because required superclass initializer %1 is inaccessible due to "
      "'%select{private|fileprivate|internal|%error|%error}2' protection level",
      (DeclName, DeclName, Accessibility))
+NOTE(decodable_suggest_overriding_init_here,none,
+     "did you mean to override 'init(from:)'?", ())
+NOTE(codable_suggest_overriding_init_here,none,
+     "did you mean to override 'init(from:)' and 'encode(to:)'?", ())
 
 // Dynamic Self
 ERROR(dynamic_self_non_method,none,

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -663,8 +663,9 @@ static void deriveBodyEncodable_encode(AbstractFunctionDecl *encodeDecl) {
     // Need to generate `try super.encode(to: container.superEncoder())`
 
     // superEncoder()
-    auto *method = new (C) UnresolvedDeclRefExpr(
-        DeclName(C.Id_superEncoder), DeclRefKind::Ordinary, DeclNameLoc());
+    auto *method = new (C) UnresolvedDeclRefExpr(DeclName(C.Id_superEncoder),
+                                                 DeclRefKind::Ordinary,
+                                                 DeclNameLoc());
 
     // container.superEncoder()
     auto *superEncoderRef = new (C) DotSyntaxCallExpr(containerExpr,
@@ -944,9 +945,10 @@ static void deriveBodyDecodable_init(AbstractFunctionDecl *initDecl) {
                                       /*Implicit=*/true);
 
       auto *selfRef = createSelfDeclRef(initDecl);
-      auto *varExpr = new (C) UnresolvedDotExpr(
-          selfRef, SourceLoc(), DeclName(varDecl->getName()), DeclNameLoc(),
-          /*implicit=*/true);
+      auto *varExpr = new (C) UnresolvedDotExpr(selfRef, SourceLoc(),
+                                                DeclName(varDecl->getName()),
+                                                DeclNameLoc(),
+                                                /*implicit=*/true);
       auto *assignExpr = new (C) AssignExpr(varExpr, SourceLoc(), tryExpr,
                                             /*Implicit=*/true);
       statements.push_back(assignExpr);
@@ -1053,12 +1055,10 @@ static ValueDecl *deriveDecodable_init(TypeChecker &tc, Decl *parentDecl,
   // Func name: init(from: Decoder)
   DeclName name(C, C.Id_init, paramList);
 
-  auto *initDecl = new (C) ConstructorDecl(
-      name, SourceLoc(),
-      /*Failability=*/OTK_None,
-      /*FailabilityLoc=*/SourceLoc(),
-      /*Throws=*/true, /*ThrowsLoc=*/SourceLoc(), selfDecl, paramList,
-      /*GenericParams=*/nullptr, target);
+  auto *initDecl = new (C) ConstructorDecl(name, SourceLoc(), OTK_None,
+                                           SourceLoc(), /*Throws=*/true,
+                                           SourceLoc(), selfDecl, paramList,
+                                           /*GenericParams=*/nullptr, target);
   initDecl->setImplicit();
   initDecl->setBodySynthesizer(deriveBodyDecodable_init);
 
@@ -1087,8 +1087,8 @@ static ValueDecl *deriveDecodable_init(TypeChecker &tc, Decl *parentDecl,
 
   initDecl->setInterfaceType(interfaceType);
   initDecl->setInitializerInterfaceType(initializerType);
-  initDecl->setAccessibility(
-      std::max(target->getFormalAccess(), Accessibility::Internal));
+  initDecl->setAccessibility(std::max(target->getFormalAccess(),
+                                      Accessibility::Internal));
 
   // If the type was not imported, the derived conformance is either from the
   // type itself or an extension, in which case we will emit the declaration

--- a/lib/Sema/DerivedConformanceCodingKey.cpp
+++ b/lib/Sema/DerivedConformanceCodingKey.cpp
@@ -408,8 +408,9 @@ static bool canSynthesizeCodingKey(TypeChecker &tc, Decl *parentDecl,
       return false;
   }
 
-  if (!enumDecl->getInherited().empty() &&
-      enumDecl->getInherited().front().isError())
+  auto inherited = enumDecl->getInherited();
+  if (!inherited.empty() && inherited.front().wasValidated() &&
+      inherited.front().isError())
     return false;
 
   // If it meets all of those requirements, we can synthesize CodingKey

--- a/lib/Sema/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformanceRawRepresentable.cpp
@@ -344,8 +344,9 @@ static bool canSynthesizeRawRepresentable(TypeChecker &tc, Decl *parentDecl,
   auto parentDC = cast<DeclContext>(parentDecl);
   rawType       = parentDC->mapTypeIntoContext(rawType);
 
-  if (!enumDecl->getInherited().empty() &&
-      enumDecl->getInherited().front().isError())
+  auto inherited = enumDecl->getInherited();
+  if (!inherited.empty() && inherited.front().wasValidated() &&
+      inherited.front().isError())
     return false;
 
   // The raw type must be Equatable, so that we have a suitable ~= for

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -7963,17 +7963,17 @@ static void diagnoseClassWithoutInitializers(TypeChecker &tc,
     ASTContext &C = tc.Context;
     auto *decodableProto = C.getProtocol(KnownProtocolKind::Decodable);
     auto superclassType = superclassDecl->getDeclaredInterfaceType();
-    if (auto ref = tc. conformsToProtocol(superclassType, decodableProto,
-                                          superclassDecl,
-                                          ConformanceCheckOptions(),
-                                          SourceLoc())) {
+    if (auto ref = tc.conformsToProtocol(superclassType, decodableProto,
+                                         superclassDecl,
+                                         ConformanceCheckOptions(),
+                                         SourceLoc())) {
       // super conforms to Decodable, so we've failed to inherit init(from:).
       // Let's suggest overriding it here.
       //
       // We're going to diagnose on the concrete init(from:) decl if it exists
       // and isn't implicit; otherwise, on the subclass itself.
       ValueDecl *diagDest = classDecl;
-      auto initFrom = DeclName(C, C.Id_init, (Identifier[1]){ C.Id_from });
+      auto initFrom = DeclName(C, C.Id_init, C.Id_from);
       auto result = tc.lookupMember(superclassDecl, superclassType, initFrom,
                                     NameLookupFlags::ProtocolMembers |
                                     NameLookupFlags::IgnoreAccessibility);
@@ -8204,10 +8204,11 @@ void TypeChecker::addImplicitConstructors(NominalTypeDecl *decl) {
   // NOTE: Lookups of synthesized initializers MUST come after
   //       decl->setAddedImplicitInitializers() in case synthesis requires
   //       protocol conformance checking, which might be recursive here.
+  // FIXME: Disable this code and prevent _any_ implicit constructors from doing
+  //        this. Investigate why this hasn't worked otherwise.
   DeclName synthesizedInitializers[1] = {
     // init(from:) is synthesized by derived conformance to Decodable.
-    DeclName(Context, DeclBaseName(Context.Id_init),
-             (Identifier[1]) { Context.Id_from })
+    DeclName(Context, DeclBaseName(Context.Id_init), Context.Id_from)
   };
 
   auto initializerIsSynthesized = [=](ConstructorDecl *initializer) {

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -8133,14 +8133,48 @@ void TypeChecker::addImplicitConstructors(NominalTypeDecl *decl) {
   bool FoundMemberwiseInitializedProperty = false;
   bool SuppressDefaultInitializer = false;
   bool SuppressMemberwiseInitializer = false;
+  bool FoundSynthesizedInit = false;
   bool FoundDesignatedInit = false;
   decl->setAddedImplicitInitializers();
+
+  // Before we look for constructors, we need to make sure that all synthesized
+  // initializers are properly synthesized.
+  //
+  // NOTE: Lookups of synthesized initializers MUST come after
+  //       decl->setAddedImplicitInitializers() in case synthesis requires
+  //       protocol conformance checking, which might be recursive here.
+  DeclName synthesizedInitializers[1] = {
+    // init(from:) is synthesized by derived conformance to Decodable.
+    DeclName(Context, DeclBaseName(Context.Id_init),
+             (Identifier[1]) { Context.Id_from })
+  };
+
+  auto initializerIsSynthesized = [=](ConstructorDecl *initializer) {
+    if (!initializer->isImplicit())
+      return false;
+
+    for (auto &name : synthesizedInitializers)
+      if (initializer->getFullName() == name)
+        return true;
+
+    return false;
+  };
+
+  for (auto &name : synthesizedInitializers) {
+    synthesizeMemberForLookup(decl, name);
+  }
+
   SmallPtrSet<CanType, 4> initializerParamTypes;
   llvm::SmallPtrSet<ConstructorDecl *, 4> overriddenInits;
   for (auto member : decl->getMembers()) {
     if (auto ctor = dyn_cast<ConstructorDecl>(member)) {
-      if (ctor->isDesignatedInit())
+      // Synthesized initializers others than the default initializer should
+      // not prevent default initializer synthesis.
+      if (initializerIsSynthesized(ctor)) {
+        FoundSynthesizedInit = true;
+      } else if (ctor->isDesignatedInit()) {
         FoundDesignatedInit = true;
+      }
 
       if (!ctor->isInvalid())
         initializerParamTypes.insert(getInitializerParamType(ctor));
@@ -8235,7 +8269,8 @@ void TypeChecker::addImplicitConstructors(NominalTypeDecl *decl) {
 
     // We can't define these overrides if we have any uninitialized
     // stored properties.
-    if (SuppressDefaultInitializer && !FoundDesignatedInit) {
+    if (SuppressDefaultInitializer && !FoundDesignatedInit
+        && !FoundSynthesizedInit) {
       diagnoseClassWithoutInitializers(*this, classDecl);
       return;
     }
@@ -8327,7 +8362,9 @@ void TypeChecker::addImplicitConstructors(NominalTypeDecl *decl) {
 
     // ... unless there are uninitialized stored properties.
     if (SuppressDefaultInitializer) {
-      diagnoseClassWithoutInitializers(*this, classDecl);
+      if (!FoundSynthesizedInit)
+        diagnoseClassWithoutInitializers(*this, classDecl);
+
       return;
     }
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -7978,8 +7978,8 @@ static void diagnoseClassWithoutInitializers(TypeChecker &tc,
                                     NameLookupFlags::ProtocolMembers |
                                     NameLookupFlags::IgnoreAccessibility);
 
-      if (!result.empty() && !result.front()->isImplicit())
-        diagDest = result.front();
+      if (!result.empty() && !result.front().getValueDecl()->isImplicit())
+        diagDest = result.front().getValueDecl();
 
       auto diagName = diag::decodable_suggest_overriding_init_here;
 
@@ -7998,7 +7998,7 @@ static void diagnoseClassWithoutInitializers(TypeChecker &tc,
         // subclass doesn't directly implement encode(to:).
         // The direct lookup here won't see an encode(to:) if it is inherited
         // from the superclass.
-        auto encodeTo = DeclName(C, C.Id_encode, (Identifier[1]){ C.Id_to });
+        auto encodeTo = DeclName(C, C.Id_encode, C.Id_to);
         if (classDecl->lookupDirect(encodeTo).empty())
           diagName = diag::codable_suggest_overriding_init_here;
       }

--- a/test/decl/protocol/special/coding/class_codable_default_initializer.swift
+++ b/test/decl/protocol/special/coding/class_codable_default_initializer.swift
@@ -1,0 +1,49 @@
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
+
+// A class with no initializers (which has non-initialized properties so a
+// default constructor can be synthesized) should produce an error.
+class NoInitializers { // expected-error {{class 'NoInitializers' has no initializers}}
+// expected-note@-1 {{did you mean 'deinit'?}}
+  var x: Double // expected-note {{stored property 'x' without initial value prevents synthesized initializers}}
+
+  func foo() {
+    // The class should not receive a default constructor.
+    let _ = NoInitializers.init // expected-error {{type 'NoInitializers' has no member 'init'}}
+  }
+}
+
+// A similar class with Codable properties adopting Codable should get a
+// synthesized init(from:), and thus not warn.
+class CodableNoExplicitInitializers : Codable {
+  var x: Double
+
+  func foo() {
+    // The class should receive a synthesized init(from:) and encode(to:)
+    let _ = CodableNoExplicitInitializers.init(from:)
+    let _ = CodableNoExplicitInitializers.encode(to:)
+
+    // It should not, however, receive a default constructor.
+    let _ = CodableNoExplicitInitializers.init
+  }
+}
+
+// A class with all initialized properties should receive a default constructor.
+class DefaultConstructed {
+  var x: Double = .pi
+
+  func foo() {
+    let _ = DefaultConstructed.init
+  }
+}
+
+// A class with all initialized, Codable properties adopting Codable should get
+// the default constructor, along with a synthesized init(from:).
+class CodableDefaultConstructed : Codable {
+  var x: Double = .pi
+
+  func foo() {
+    let _ = CodableDefaultConstructed.init()
+    let _ = CodableDefaultConstructed.init(from:)
+    let _ = CodableDefaultConstructed.encode(to:)
+  }
+}

--- a/test/decl/protocol/special/coding/class_codable_default_initializer.swift
+++ b/test/decl/protocol/special/coding/class_codable_default_initializer.swift
@@ -8,7 +8,7 @@ class NoInitializers { // expected-error {{class 'NoInitializers' has no initial
 
   func foo() {
     // The class should not receive a default constructor.
-    let _ = NoInitializers.init // expected-error {{type 'NoInitializers' has no member 'init'}}
+    let _ = NoInitializers.init() // expected-error {{type 'NoInitializers' has no member 'init'}}
   }
 }
 
@@ -23,7 +23,7 @@ class CodableNoExplicitInitializers : Codable {
     let _ = CodableNoExplicitInitializers.encode(to:)
 
     // It should not, however, receive a default constructor.
-    let _ = CodableNoExplicitInitializers.init
+    let _ = CodableNoExplicitInitializers.init() // expected-error {{missing argument for parameter 'from' in call}}
   }
 }
 
@@ -32,7 +32,7 @@ class DefaultConstructed {
   var x: Double = .pi
 
   func foo() {
-    let _ = DefaultConstructed.init
+    let _ = DefaultConstructed.init()
   }
 }
 

--- a/test/decl/protocol/special/coding/class_codable_failure_diagnostics.swift
+++ b/test/decl/protocol/special/coding/class_codable_failure_diagnostics.swift
@@ -8,12 +8,12 @@ class C1 : Codable {
   var c: Nested = Nested()
 
   // CHECK: error: type 'C1' does not conform to protocol 'Decodable'
-  // CHECK: note: cannot automatically synthesize 'Decodable' because 'C1.Nested' does not conform to 'Decodable'
   // CHECK: note: protocol requires initializer 'init(from:)' with type 'Decodable'
+  // CHECK: note: cannot automatically synthesize 'Decodable' because 'C1.Nested' does not conform to 'Decodable'
 
   // CHECK: error: type 'C1' does not conform to protocol 'Encodable'
-  // CHECK: note: cannot automatically synthesize 'Encodable' because 'C1.Nested' does not conform to 'Encodable'
   // CHECK: note: protocol requires function 'encode(to:)' with type 'Encodable'
+  // CHECK: note: cannot automatically synthesize 'Encodable' because 'C1.Nested' does not conform to 'Encodable'
 }
 
 // Codable class with non-enum CodingKeys.
@@ -30,12 +30,12 @@ class C2 : Codable {
   }
 
   // CHECK: error: type 'C2' does not conform to protocol 'Decodable'
-  // CHECK: note: cannot automatically synthesize 'Decodable' because 'CodingKeys' is not an enum
   // CHECK: note: protocol requires initializer 'init(from:)' with type 'Decodable'
+  // CHECK: note: cannot automatically synthesize 'Decodable' because 'CodingKeys' is not an enum
 
   // CHECK: error: type 'C2' does not conform to protocol 'Encodable'
-  // CHECK: note: cannot automatically synthesize 'Encodable' because 'CodingKeys' is not an enum
   // CHECK: note: protocol requires function 'encode(to:)' with type 'Encodable'
+  // CHECK: note: cannot automatically synthesize 'Encodable' because 'CodingKeys' is not an enum
 }
 
 // Codable class with CodingKeys not conforming to CodingKey.
@@ -51,12 +51,12 @@ class C3 : Codable {
   }
 
   // CHECK: error: type 'C3' does not conform to protocol 'Decodable'
-  // CHECK: note: cannot automatically synthesize 'Decodable' because 'CodingKeys' does not conform to CodingKey
   // CHECK: note: protocol requires initializer 'init(from:)' with type 'Decodable'
+  // CHECK: note: cannot automatically synthesize 'Decodable' because 'CodingKeys' does not conform to CodingKey
 
   // CHECK: error: type 'C3' does not conform to protocol 'Encodable'
-  // CHECK: note: cannot automatically synthesize 'Encodable' because 'CodingKeys' does not conform to CodingKey
   // CHECK: note: protocol requires function 'encode(to:)' with type 'Encodable'
+  // CHECK: note: cannot automatically synthesize 'Encodable' because 'CodingKeys' does not conform to CodingKey
 }
 
 // Codable class with extraneous CodingKeys
@@ -75,16 +75,16 @@ class C4 : Codable {
   }
 
   // CHECK: error: type 'C4' does not conform to protocol 'Decodable'
+  // CHECK: note: protocol requires initializer 'init(from:)' with type 'Decodable'
   // CHECK: note: CodingKey case 'a2' does not match any stored properties
   // CHECK: note: CodingKey case 'b2' does not match any stored properties
   // CHECK: note: CodingKey case 'c2' does not match any stored properties
-  // CHECK: note: protocol requires initializer 'init(from:)' with type 'Decodable'
 
   // CHECK: error: type 'C4' does not conform to protocol 'Encodable'
+  // CHECK: note: protocol requires function 'encode(to:)' with type 'Encodable'
   // CHECK: note: CodingKey case 'a2' does not match any stored properties
   // CHECK: note: CodingKey case 'b2' does not match any stored properties
   // CHECK: note: CodingKey case 'c2' does not match any stored properties
-  // CHECK: note: protocol requires function 'encode(to:)' with type 'Encodable'
 }
 
 // Codable class with non-decoded property (which has no default value).
@@ -98,12 +98,12 @@ class C5 : Codable {
     case c
   }
 
+  // CHECK: error: type 'C5' does not conform to protocol 'Decodable'
+  // CHECK: note: protocol requires initializer 'init(from:)' with type 'Decodable'
+  // CHECK: note: cannot automatically synthesize 'Decodable' because 'b' does not have a matching CodingKey and does not have a default value
+
   // CHECK: error: class 'C5' has no initializers
   // CHECK: note: stored property 'b' without initial value prevents synthesized initializers
-
-  // CHECK: error: type 'C5' does not conform to protocol 'Decodable'
-  // CHECK: note: cannot automatically synthesize 'Decodable' because 'b' does not have a matching CodingKey and does not have a default value
-  // CHECK: note: protocol requires initializer 'init(from:)' with type 'Decodable'
 }
 
 // Codable class with non-decoded property (which has no default value).
@@ -122,8 +122,8 @@ class C6 : Codable {
   }
 
   // CHECK: error: type 'C6' does not conform to protocol 'Decodable'
-  // CHECK: note: cannot automatically synthesize 'Decodable' because 'b' does not have a matching CodingKey and does not have a default value
   // CHECK: note: protocol requires initializer 'init(from:)' with type 'Decodable'
+  // CHECK: note: cannot automatically synthesize 'Decodable' because 'b' does not have a matching CodingKey and does not have a default value
 }
 
 // Classes cannot yet synthesize Encodable or Decodable in extensions.

--- a/test/decl/protocol/special/coding/class_codable_inheritance_diagnostics.swift
+++ b/test/decl/protocol/special/coding/class_codable_inheritance_diagnostics.swift
@@ -1,0 +1,32 @@
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
+
+// Non-Decodable superclasses of synthesized Decodable classes must implement
+// init().
+class NonDecodableSuper { // expected-note {{cannot automatically synthesize 'init(from:)' because superclass does not have a callable 'init()' or 'init(from:)'}}
+  init(_: Int) {}
+}
+
+class NonDecodableSub : NonDecodableSuper, Decodable { // expected-error {{type 'NonDecodableSub' does not conform to protocol 'Decodable'}}
+}
+
+// Non-Decodable superclasses of synthesized Decodable classes must have
+// designated init()'s.
+class NonDesignatedNonDecodableSuper {
+  convenience init() { // expected-note {{cannot automatically synthesize 'init(from:)' because required superclass initializer 'init()' is not designated}}
+    self.init(42)
+  }
+
+  init(_: Int) {}
+}
+
+class NonDesignatedNonDecodableSub : NonDesignatedNonDecodableSuper, Decodable { // expected-error {{type 'NonDesignatedNonDecodableSub' does not conform to protocol 'Decodable'}}
+}
+
+// Non-Decodable superclasses of synthesized Decodable classes must have an
+// accessible init().
+class InaccessibleNonDecodableSuper {
+  private init() {} // expected-note {{cannot automatically synthesize 'init(from:)' because required superclass initializer 'init()' is inaccessible due to 'private' protection level}}
+}
+
+class InaccessibleNonDecodableSub : InaccessibleNonDecodableSuper, Decodable { // expected-error {{type 'InaccessibleNonDecodableSub' does not conform to protocol 'Decodable'}}
+}

--- a/test/decl/protocol/special/coding/class_codable_inheritance_diagnostics.swift
+++ b/test/decl/protocol/special/coding/class_codable_inheritance_diagnostics.swift
@@ -30,3 +30,42 @@ class InaccessibleNonDecodableSuper {
 
 class InaccessibleNonDecodableSub : InaccessibleNonDecodableSuper, Decodable { // expected-error {{type 'InaccessibleNonDecodableSub' does not conform to protocol 'Decodable'}}
 }
+
+// Subclasses of Decodable classes which can't inherit their initializers should
+// produce diagnostics.
+class DecodableSuper : Decodable {
+  var value = 5
+}
+
+class DecodableSubWithoutInitialValue : DecodableSuper { // expected-error {{class 'DecodableSubWithoutInitialValue' has no initializers}}
+  // expected-note@-1 {{did you mean to override 'init(from:)'?}}
+  var value2: Int // expected-note {{stored property 'value2' without initial value prevents synthesized initializers}}
+}
+
+class DecodableSubWithInitialValue : DecodableSuper {
+  var value2 = 10
+}
+
+// Subclasses of Codable classes which can't inherit their initializers should
+// produce diagnostics.
+class CodableSuper : Codable {
+  var value = 5
+}
+
+class CodableSubWithoutInitialValue : CodableSuper { // expected-error {{class 'CodableSubWithoutInitialValue' has no initializers}}
+  // expected-note@-1 {{did you mean to override 'init(from:)' and 'encode(to:)'?}}
+  var value2: Int // expected-note {{stored property 'value2' without initial value prevents synthesized initializers}}
+}
+
+// We should only mention encode(to:) in the diagnostic if the subclass does not
+// override it.
+class EncodableSubWithoutInitialValue : CodableSuper { // expected-error {{class 'EncodableSubWithoutInitialValue' has no initializers}}
+  // expected-note@-1 {{did you mean to override 'init(from:)'?}}
+  var value2: Int // expected-note {{stored property 'value2' without initial value prevents synthesized initializers}}
+
+  override func encode(to: Encoder) throws {}
+}
+
+class CodableSubWithInitialValue : CodableSuper {
+  var value2 = 10
+}

--- a/test/decl/protocol/special/coding/class_codable_inheritance_diagnostics.swift
+++ b/test/decl/protocol/special/coding/class_codable_inheritance_diagnostics.swift
@@ -2,7 +2,7 @@
 
 // Non-Decodable superclasses of synthesized Decodable classes must implement
 // init().
-class NonDecodableSuper { // expected-note {{cannot automatically synthesize 'init(from:)' because superclass does not have a callable 'init()' or 'init(from:)'}}
+class NonDecodableSuper { // expected-note {{cannot automatically synthesize 'init(from:)' because superclass does not have a callable 'init()'}}
   init(_: Int) {}
 }
 
@@ -12,7 +12,7 @@ class NonDecodableSub : NonDecodableSuper, Decodable { // expected-error {{type 
 // Non-Decodable superclasses of synthesized Decodable classes must have
 // designated init()'s.
 class NonDesignatedNonDecodableSuper {
-  convenience init() { // expected-note {{cannot automatically synthesize 'init(from:)' because required superclass initializer 'init()' is not designated}}
+  convenience init() { // expected-note {{cannot automatically synthesize 'init(from:)' because implementation would need to call 'init()', which is not designated}}
     self.init(42)
   }
 
@@ -25,7 +25,7 @@ class NonDesignatedNonDecodableSub : NonDesignatedNonDecodableSuper, Decodable {
 // Non-Decodable superclasses of synthesized Decodable classes must have an
 // accessible init().
 class InaccessibleNonDecodableSuper {
-  private init() {} // expected-note {{cannot automatically synthesize 'init(from:)' because required superclass initializer 'init()' is inaccessible due to 'private' protection level}}
+  private init() {} // expected-note {{cannot automatically synthesize 'init(from:)' because implementation would need to call 'init()', which is inaccessible due to 'private' protection level}}
 }
 
 class InaccessibleNonDecodableSub : InaccessibleNonDecodableSuper, Decodable { // expected-error {{type 'InaccessibleNonDecodableSub' does not conform to protocol 'Decodable'}}

--- a/test/decl/protocol/special/coding/struct_codable_failure_diagnostics.swift
+++ b/test/decl/protocol/special/coding/struct_codable_failure_diagnostics.swift
@@ -6,14 +6,6 @@ struct S1 : Codable {
   var a: String = ""
   var b: Int = 0
   var c: Nested = Nested()
-
-  // CHECK: error: type 'S1' does not conform to protocol 'Decodable'
-  // CHECK: note: cannot automatically synthesize 'Decodable' because 'S1.Nested' does not conform to 'Decodable'
-  // CHECK: note: protocol requires initializer 'init(from:)' with type 'Decodable'
-
-  // CHECK: error: type 'S1' does not conform to protocol 'Encodable'
-  // CHECK: note: cannot automatically synthesize 'Encodable' because 'S1.Nested' does not conform to 'Encodable'
-  // CHECK: note: protocol requires function 'encode(to:)' with type 'Encodable'
 }
 
 // Codable struct with non-enum CodingKeys.
@@ -28,14 +20,6 @@ struct S2 : Codable {
     init?(stringValue: String) {}
     init?(intValue: Int) {}
   }
-
-  // CHECK: error: type 'S2' does not conform to protocol 'Decodable'
-  // CHECK: note: cannot automatically synthesize 'Decodable' because 'CodingKeys' is not an enum
-  // CHECK: note: protocol requires initializer 'init(from:)' with type 'Decodable'
-
-  // CHECK: error: type 'S2' does not conform to protocol 'Encodable'
-  // CHECK: note: cannot automatically synthesize 'Encodable' because 'CodingKeys' is not an enum
-  // CHECK: note: protocol requires function 'encode(to:)' with type 'Encodable'
 }
 
 // Codable struct with CodingKeys not conforming to CodingKey.
@@ -49,14 +33,6 @@ struct S3 : Codable {
     case b
     case c
   }
-
-  // CHECK: error: type 'S3' does not conform to protocol 'Decodable'
-  // CHECK: note: cannot automatically synthesize 'Decodable' because 'CodingKeys' does not conform to CodingKey
-  // CHECK: note: protocol requires initializer 'init(from:)' with type 'Decodable'
-
-  // CHECK: error: type 'S3' does not conform to protocol 'Encodable'
-  // CHECK: note: cannot automatically synthesize 'Encodable' because 'CodingKeys' does not conform to CodingKey
-  // CHECK: note: protocol requires function 'encode(to:)' with type 'Encodable'
 }
 
 // Codable struct with extraneous CodingKeys
@@ -73,18 +49,6 @@ struct S4 : Codable {
     case c
     case c2
   }
-
-  // CHECK: error: type 'S4' does not conform to protocol 'Decodable'
-  // CHECK: note: CodingKey case 'a2' does not match any stored properties
-  // CHECK: note: CodingKey case 'b2' does not match any stored properties
-  // CHECK: note: CodingKey case 'c2' does not match any stored properties
-  // CHECK: note: protocol requires initializer 'init(from:)' with type 'Decodable'
-
-  // CHECK: error: type 'S4' does not conform to protocol 'Encodable'
-  // CHECK: note: CodingKey case 'a2' does not match any stored properties
-  // CHECK: note: CodingKey case 'b2' does not match any stored properties
-  // CHECK: note: CodingKey case 'c2' does not match any stored properties
-  // CHECK: note: protocol requires function 'encode(to:)' with type 'Encodable'
 }
 
 // Codable struct with non-decoded property (which has no default value).
@@ -97,14 +61,60 @@ struct S5 : Codable {
     case a
     case c
   }
-
-  // CHECK: error: type 'S5' does not conform to protocol 'Decodable'
-  // CHECK: note: cannot automatically synthesize 'Decodable' because 'b' does not have a matching CodingKey and does not have a default value
-  // CHECK: note: protocol requires initializer 'init(from:)' with type 'Decodable'
 }
 
 // Structs cannot yet synthesize Encodable or Decodable in extensions.
 struct S6 {}
 extension S6 : Codable {}
+
+// Decodable diagnostics are output first here {
+
+// CHECK: error: type 'S1' does not conform to protocol 'Decodable'
+// CHECK: note: protocol requires initializer 'init(from:)' with type 'Decodable'
+// CHECK: note: cannot automatically synthesize 'Decodable' because 'S1.Nested' does not conform to 'Decodable'
+
+// CHECK: error: type 'S2' does not conform to protocol 'Decodable'
+// CHECK: note: protocol requires initializer 'init(from:)' with type 'Decodable'
+// CHECK: note: cannot automatically synthesize 'Decodable' because 'CodingKeys' is not an enum
+
+// CHECK: error: type 'S3' does not conform to protocol 'Decodable'
+// CHECK: note: protocol requires initializer 'init(from:)' with type 'Decodable'
+// CHECK: note: cannot automatically synthesize 'Decodable' because 'CodingKeys' does not conform to CodingKey
+
+// CHECK: error: type 'S4' does not conform to protocol 'Decodable'
+// CHECK: note: protocol requires initializer 'init(from:)' with type 'Decodable'
+// CHECK: note: CodingKey case 'a2' does not match any stored properties
+// CHECK: note: CodingKey case 'b2' does not match any stored properties
+// CHECK: note: CodingKey case 'c2' does not match any stored properties
+
+// CHECK: error: type 'S5' does not conform to protocol 'Decodable'
+// CHECK: note: protocol requires initializer 'init(from:)' with type 'Decodable'
+// CHECK: note: cannot automatically synthesize 'Decodable' because 'b' does not have a matching CodingKey and does not have a default value
+
 // CHECK: error: implementation of 'Decodable' cannot be automatically synthesized in an extension yet
+
+// }
+
+// Encodable {
+
+// CHECK: error: type 'S1' does not conform to protocol 'Encodable'
+// CHECK: note: protocol requires function 'encode(to:)' with type 'Encodable'
+// CHECK: note: cannot automatically synthesize 'Encodable' because 'S1.Nested' does not conform to 'Encodable'
+
+// CHECK: error: type 'S2' does not conform to protocol 'Encodable'
+// CHECK: note: protocol requires function 'encode(to:)' with type 'Encodable'
+// CHECK: note: cannot automatically synthesize 'Encodable' because 'CodingKeys' is not an enum
+
+// CHECK: error: type 'S3' does not conform to protocol 'Encodable'
+// CHECK: note: protocol requires function 'encode(to:)' with type 'Encodable'
+// CHECK: note: cannot automatically synthesize 'Encodable' because 'CodingKeys' does not conform to CodingKey
+
+// CHECK: error: type 'S4' does not conform to protocol 'Encodable'
+// CHECK: note: protocol requires function 'encode(to:)' with type 'Encodable'
+// CHECK: note: CodingKey case 'a2' does not match any stored properties
+// CHECK: note: CodingKey case 'b2' does not match any stored properties
+// CHECK: note: CodingKey case 'c2' does not match any stored properties
+
 // CHECK: error: implementation of 'Encodable' cannot be automatically synthesized in an extension yet
+
+// }

--- a/test/decl/protocol/special/coding/struct_codable_memberwise_initializer.swift
+++ b/test/decl/protocol/special/coding/struct_codable_memberwise_initializer.swift
@@ -1,0 +1,49 @@
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
+
+// Structs with no initializers should get a memberwise initializer.
+struct NoInitializers {
+  var x: Double // need not have an initial value
+
+  func foo() {
+    // The struct should receive a memberwise initializer.
+    let _ = NoInitializers.init(x:)
+  }
+}
+
+// A similar struct with Codable properties adopting Codable should get a
+// synthesized init(from:), along with the memberwise initializer.
+struct CodableNoExplicitInitializers : Codable {
+  var x: Double
+
+  func foo() {
+    // The struct should receive a synthesized init(from:) and encode(to:).
+    let _ = CodableNoExplicitInitializers.init(from:)
+    let _ = CodableNoExplicitInitializers.encode(to:)
+
+    // It should still receive a memberwise initializer.
+    let _ = CodableNoExplicitInitializers.init(x:)
+  }
+}
+
+// The same should hold for structs whose members all have initial values.
+struct InitialValueNoInitializers {
+  var x: Double = .pi
+
+  func foo() {
+    // The struct should receive a memberwise initializer.
+    let _ = NoInitializers.init(x:)
+  }
+}
+
+struct InitialValueCodableNoExplicitInitializers : Codable {
+  var x: Double = .pi
+
+  func foo() {
+    // The struct should receive a synthesized init(from:) and encode(to:).
+    let _ = CodableNoExplicitInitializers.init(from:)
+    let _ = CodableNoExplicitInitializers.encode(to:)
+
+    // It should still receive a memberwise initializer.
+    let _ = CodableNoExplicitInitializers.init(x:)
+  }
+}

--- a/test/decl/protocol/special/coding/struct_codable_memberwise_initializer.swift
+++ b/test/decl/protocol/special/coding/struct_codable_memberwise_initializer.swift
@@ -31,7 +31,10 @@ struct InitialValueNoInitializers {
 
   func foo() {
     // The struct should receive a memberwise initializer.
-    let _ = NoInitializers.init(x:)
+    let _ = InitialValueNoInitializers.init(x:)
+
+    // The struct should receive a no-argument initializer.
+    let _ = InitialValueNoInitializers.init()
   }
 }
 
@@ -40,10 +43,13 @@ struct InitialValueCodableNoExplicitInitializers : Codable {
 
   func foo() {
     // The struct should receive a synthesized init(from:) and encode(to:).
-    let _ = CodableNoExplicitInitializers.init(from:)
-    let _ = CodableNoExplicitInitializers.encode(to:)
+    let _ = InitialValueCodableNoExplicitInitializers.init(from:)
+    let _ = InitialValueCodableNoExplicitInitializers.encode(to:)
 
     // It should still receive a memberwise initializer.
-    let _ = CodableNoExplicitInitializers.init(x:)
+    let _ = InitialValueCodableNoExplicitInitializers.init(x:)
+
+    // It should still receive a no-argument initializer.
+    let _ = InitialValueCodableNoExplicitInitializers.init()
   }
 }


### PR DESCRIPTION
**What's in this pull request?**
Addresses [SR-4772](https://bugs.swift.org/browse/SR-4772) and [SR-5122](https://bugs.swift.org/browse/SR-5122).

This addresses a few issues that prevented classes from properly receiving synthesized `Codable` conformances:
* #10964 allowed classes to override synthesized `Codable` conformances in subclasses; this allows a synthesized `Decodable` class to override a non-`Decodable` class by calling `super.init()` instead of `super.init(from:)` on its parent.
* Improves the diagnostics produced when a class can't receive synthesized `Decodable` implementation due to superclass limitations
* Prevents a synthesized `init(from:)` from further preventing synthesis of a default initializer (on classes) or a memberwise initializer (on structs)
* Provides improved diagnostics for suggesting that a subclass override `init(from:)` and `encode(to:)` if it could not inherit its superclass's `Codable` witnesses

rdar://problem/32774777