### PR TITLE
[NFC] Adjust return type of getTypeOfExpressionWithoutApplying

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -4650,9 +4650,9 @@ static bool diagnoseImplicitSelfErrors(Expr *fnExpr, Expr *argExpr,
       ConcreteDeclRef ref = nullptr;
       auto typeResult =
         TC.getTypeOfExpressionWithoutApplying(el, CS.DC, ref);
-      if (!typeResult.hasValue())
+      if (!typeResult)
         return false;
-      elts.push_back(typeResult.getValue());
+      elts.push_back(typeResult);
     }
 
     argType = TupleType::get(elts, CS.getASTContext());
@@ -6387,12 +6387,12 @@ bool FailureDiagnosis::visitApplyExpr(ApplyExpr *callExpr) {
              "unexpected declaration reference");
 
       ConcreteDeclRef decl = nullptr;
-      Optional<Type> type = CS.TC.getTypeOfExpressionWithoutApplying(
+      Type type = CS.TC.getTypeOfExpressionWithoutApplying(
           fnExpr, CS.DC, decl, FreeTypeVariableBinding::UnresolvedType,
           &listener);
 
-      if (type.hasValue())
-        fnType = getFuncType(type.getValue());
+      if (type)
+        fnType = getFuncType(type);
     } else {
       fnExpr = typeCheckChildIndependently(callExpr->getFn(), Type(),
                                            CTP_CalleeResult, TCC_ForceRecheck,
@@ -7336,7 +7336,7 @@ bool FailureDiagnosis::diagnoseClosureExpr(
       auto type = CS.TC.getTypeOfExpressionWithoutApplying(
           closure, CS.DC, decl, FreeTypeVariableBinding::Disallow);
 
-      if (type && resultTypeProcessor(*type, expectedResultType))
+      if (type && resultTypeProcessor(type, expectedResultType))
         return true;
     }
 
@@ -7821,7 +7821,7 @@ bool FailureDiagnosis::visitKeyPathExpr(KeyPathExpr *KPE) {
         &listener);
 
     if (derivedType) {
-      if (auto *BGT = (*derivedType)->getAs<BoundGenericClassType>()) {
+      if (auto *BGT = derivedType->getAs<BoundGenericClassType>()) {
         auto derivedValueType = BGT->getGenericArgs().back();
         if (!CS.TC.isConvertibleTo(valueType, derivedValueType, CS.DC)) {
           diagnose(KPE->getLoc(),
@@ -8982,7 +8982,7 @@ diagnoseAmbiguousMultiStatementClosure(ClosureExpr *closure) {
       auto type = CS.TC.getTypeOfExpressionWithoutApplying(
           resultExpr, CS.DC, decl, FreeTypeVariableBinding::UnresolvedType);
       if (type)
-        resultType = type.getValue();
+        resultType = type;
     }
     
     // If we found a type, presuppose it was the intended result and insert a

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1814,7 +1814,7 @@ Type TypeChecker::typeCheckExpression(Expr *&expr, DeclContext *dc,
   return cs.getType(expr);
 }
 
-Optional<Type> TypeChecker::
+Type TypeChecker::
 getTypeOfExpressionWithoutApplying(Expr *&expr, DeclContext *dc,
                                    ConcreteDeclRef &referencedDecl,
                                  FreeTypeVariableBinding allowFreeTypeVariables,
@@ -1843,7 +1843,7 @@ getTypeOfExpressionWithoutApplying(Expr *&expr, DeclContext *dc,
                          allowFreeTypeVariables, listener, cs, viable,
                          TypeCheckExprFlags::SuppressDiagnostics)) {
     recoverOriginalType();
-    return None;
+    return Type();
   }
 
   // Get the expression's simplified type.
@@ -1856,7 +1856,7 @@ getTypeOfExpressionWithoutApplying(Expr *&expr, DeclContext *dc,
 
   if (exprType->hasError()) {
     recoverOriginalType();
-    return None;
+    return Type();
   }
 
   // Dig the declaration out of the solution.

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1593,9 +1593,9 @@ public:
   /// events in the type checking of this expression, and which can introduce
   /// additional constraints.
   ///
-  /// \returns the type of \p expr on success, None otherwise.
+  /// \returns the type of \p expr on success, Type() otherwise.
   /// FIXME: expr may still be modified...
-  Optional<Type> getTypeOfExpressionWithoutApplying(
+  Type getTypeOfExpressionWithoutApplying(
       Expr *&expr, DeclContext *dc,
       ConcreteDeclRef &referencedDecl,
       FreeTypeVariableBinding allowFreeTypeVariables =


### PR DESCRIPTION
A companion to #11047

Makes the return type of `getTypeOfExpressionWithoutApplying` just `Type` instead of `Optional<Type>`  to eliminate a potential tri-state.