### PR TITLE
[4.0] [QoI] Fix position of the fix-it related to raw representable conversion

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -3638,7 +3638,7 @@ static bool tryRawRepresentableFixIts(InFlightDiagnostic &diag,
                       toType, fromType)
         .highlight(exprRange)
         .fixItInsert(exprRange.Start, fixItBefore)
-        .fixItInsert(exprRange.End, fixItAfter);
+        .fixItInsertAfter(exprRange.End, fixItAfter);
     }
   };
 

--- a/test/Sema/enum_raw_representable.swift
+++ b/test/Sema/enum_raw_representable.swift
@@ -97,11 +97,11 @@ func rdar32431736() {
 
   let myE1: E = items1.first
   // expected-error@-1 {{cannot convert value of type 'String?' to specified type 'E'}}
-  // expected-note@-2 {{construct 'E' from unwrapped 'String' value}} {{17-17=E(rawValue: }} {{24-24=!)}}
+  // expected-note@-2 {{construct 'E' from unwrapped 'String' value}} {{17-17=E(rawValue: }} {{29-29=!)}}
 
   let myE2: E = items2?.first
   // expected-error@-1 {{cannot convert value of type 'String?' to specified type 'E'}}
-  // expected-note@-2 {{construct 'E' from unwrapped 'String' value}} {{17-17=E(rawValue: (}} {{25-25=)!)}}
+  // expected-note@-2 {{construct 'E' from unwrapped 'String' value}} {{17-17=E(rawValue: (}} {{30-30=)!)}}
 }
 
 // rdar://problem/32431165 - improve diagnostic for raw representable argument mismatch


### PR DESCRIPTION
* Description: Part of the fix-it for conversion from optional to raw representable
was inserted at the incorrect position which produces invalid expression.

* Scope of the issue: Fix positioning for the fix-it related to optional to raw representable conversion.

* Origination: Diagnostic improvement previously merged into 4.0 introduced a fix-it which was partially incorrect.

* Risk: Low.

* Tested: Updated related tests, Swift CI.

* Reviewed by: Mark Lacey.

* Resolves: rdar://problem/32431736
(cherry picked from commit 2bec75e0690e52c6c40adea10cccb20e3ae18110)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
