### PR TITLE
stdlib: tweak printf specifier to be more portable

### DIFF
--- a/stdlib/public/runtime/Reflection.mm
+++ b/stdlib/public/runtime/Reflection.mm
@@ -24,6 +24,7 @@
 #include "WeakReference.h"
 #include "llvm/Support/Compiler.h"
 #include <cassert>
+#include <cinttypes>
 #include <cstdio>
 #include <cstring>
 #include <new>
@@ -382,7 +383,7 @@ void swift_TupleMirror_subscript(String *outString,
   if (!hasLabel) {
     // The name is the stringized element number '.0'.
     char buf[32];
-    snprintf(buf, sizeof(buf), ".%zd", i);
+    snprintf(buf, sizeof(buf), ".%" PRIdPTR, i);
     new (outString) String(buf, strlen(buf));
   }
 


### PR DESCRIPTION
This just adjusts the printf specifier to use the standard defined
printf conversion specifier rather than assuming that %zd will convert
properly.  NFC.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
