### PR TITLE
[4.0] SIL: Fix unconditional checked cast's memory behavior

### DIFF
--- a/include/swift/SIL/SILNodes.def
+++ b/include/swift/SIL/SILNodes.def
@@ -282,8 +282,8 @@ ABSTRACT_VALUE(SILInstruction, ValueBase)
     INST(ObjCMetatypeToObjectInst, ConversionInst, objc_metatype_to_object, None, DoesNotRelease)
     INST(ObjCExistentialMetatypeToObjectInst, ConversionInst, objc_existential_metatype_to_object, None,
          DoesNotRelease)
-    INST(UnconditionalCheckedCastValueInst, ConversionInst, unconditional_checked_cast_value, None, DoesNotRelease)
-    INST(UnconditionalCheckedCastInst, ConversionInst, unconditional_checked_cast, None, DoesNotRelease)
+    INST(UnconditionalCheckedCastValueInst, ConversionInst, unconditional_checked_cast_value, MayRead, DoesNotRelease)
+    INST(UnconditionalCheckedCastInst, ConversionInst, unconditional_checked_cast, MayRead, DoesNotRelease)
     VALUE_RANGE(ConversionInst, UpcastInst, UnconditionalCheckedCastInst)
   INST(IsNonnullInst, SILInstruction, is_nonnull, None, DoesNotRelease)
   INST(UnconditionalCheckedCastAddrInst, SILInstruction, unconditional_checked_cast_addr, MayHaveSideEffects,

--- a/lib/SILOptimizer/Analysis/SideEffectAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/SideEffectAnalysis.cpp
@@ -349,6 +349,10 @@ void SideEffectAnalysis::analyzeInstruction(FunctionInfo *FInfo,
       // destructors might be called.
       FInfo->FE.setWorstEffects();
       return;
+    case ValueKind::UnconditionalCheckedCastInst:
+      FInfo->FE.getEffectsOn(cast<UnconditionalCheckedCastInst>(I)->getOperand())->Reads = true;
+      FInfo->FE.Traps = true;
+      return;
     case ValueKind::LoadInst:
       FInfo->FE.getEffectsOn(cast<LoadInst>(I)->getOperand())->Reads = true;
       return;

--- a/test/SILOptimizer/latecodemotion.sil
+++ b/test/SILOptimizer/latecodemotion.sil
@@ -1451,3 +1451,35 @@ bb3(%3 : $X):
   %23 = tuple ()
   return %23 : $()
 }
+
+// CHECK: sil @dont_hoist_release_accross_cast
+// CHECK: retain
+// CHECK: apply
+// CHECK: unconditional_checked_cast
+// CHECK: release
+sil @dont_hoist_release_accross_cast : $@convention(thin) (Builtin.NativeObject, Builtin.NativeObject) -> () {
+bb0(%0 : $Builtin.NativeObject, %1: $Builtin.NativeObject):
+  strong_retain %0: $Builtin.NativeObject
+  %2 = function_ref @blocker : $@convention(thin) () -> ()
+  apply %2() : $@convention(thin) () -> ()
+	%3 = unconditional_checked_cast %0 : $Builtin.NativeObject to $B
+  strong_release %0: $Builtin.NativeObject
+  %5 = tuple()
+  return %5 : $()
+}
+
+// CHECK: sil @dont_hoist_release_accross_cast_value
+// CHECK: retain
+// CHECK: apply
+// CHECK: unconditional_checked_cast
+// CHECK: release
+sil @dont_hoist_release_accross_cast_value : $@convention(thin) (Builtin.NativeObject, Builtin.NativeObject) -> () {
+bb0(%0 : $Builtin.NativeObject, %1: $Builtin.NativeObject):
+  strong_retain %0: $Builtin.NativeObject
+  %2 = function_ref @blocker : $@convention(thin) () -> ()
+  apply %2() : $@convention(thin) () -> ()
+  %c = unconditional_checked_cast_value take_always %0 : $Builtin.NativeObject to $B
+  strong_release %0: $Builtin.NativeObject
+  %5 = tuple()
+  return %5 : $()
+}

--- a/test/SILOptimizer/side-effect.sil
+++ b/test/SILOptimizer/side-effect.sil
@@ -201,7 +201,7 @@ bb0(%0 : $Builtin.Int1):
 }
 
 // CHECK-LABEL: sil @checkedcast
-// CHECK: <func=,param0=;trap>
+// CHECK: <func=,param0=r;trap>
 sil @checkedcast : $@convention(thin) (Builtin.NativeObject) -> () {
 bb0(%0 : $Builtin.NativeObject):
   unconditional_checked_cast %0 : $Builtin.NativeObject to $X


### PR DESCRIPTION
The instruction reads memory (the type).

rdar://32990161

* Update side-effect.sil
* Further refine memory effects of unconditional_checked_cast

• Explanation: The unconditional_checked_cast SIL instruction is given the memory behavior read none which allows for moving the last release on the object that is being casted to be moved before the cast. This leads to reading freed memory. The fix is to assign the proper memory behavior (mayRead).

• Scope of Issue: Causes use after free if the compiler moves the last release across the cast. This happens in overlay code: NSLocale.current.description

• Origination: The bug has been there for several versions of swift

• Risk: Low. We assign the proper memory behavior.

• Testing: A test case was added to the regression suite