### PR TITLE
[code-completion] Add leading-dot completion for enums

### DIFF
--- a/include/swift/IDE/CodeCompletion.h
+++ b/include/swift/IDE/CodeCompletion.h
@@ -800,6 +800,10 @@ public:
   CompletionKind CodeCompletionKind = CompletionKind::None;
   bool HasExpectedTypeRelation = false;
 
+  /// Whether there may be members that can use implicit member syntax,
+  /// e.g. `x = .foo`.
+  bool MayUseImplicitMemberExpr = false;
+
   CodeCompletionContext(CodeCompletionCache &Cache)
       : Cache(Cache) {}
 

--- a/test/SourceKit/CodeComplete/complete_inner.swift
+++ b/test/SourceKit/CodeComplete/complete_inner.swift
@@ -144,3 +144,28 @@ func test006() {
 // KEYWORD_0-NOT: for_
 // KEYWORD_0-NOT: fortest
 // KEYWORD_0-NOT: for.
+
+enum E0 {
+  case case0
+}
+
+// RUN: %complete-test %s -group=none -no-inner-results -no-inner-operators -tok=LEADING_DOT_0 | %FileCheck %s -check-prefix=LEADING_NODOT_E0
+// RUN: %complete-test %s -group=none -no-inner-results -inner-operators -tok=LEADING_DOT_0 | %FileCheck %s -check-prefix=LEADING_DOT_E0
+func test007() {
+  var e: E0
+  e = #^LEADING_DOT_0^#
+}
+// LEADING_NODOT_E0-NOT: .
+// LEADING_DOT_E0: .
+
+struct WithLeading {
+  static var foo: WithLeading = WithLeading()
+}
+
+// RUN: %complete-test %s -group=none -no-inner-results -inner-operators -tok=LEADING_DOT_1 | %FileCheck %s -check-prefix=LEADING_DOT_S
+func test009() {
+  var e: WithLeading
+  e = #^LEADING_DOT_1^#
+}
+// FIXME: should have leading dot.
+// LEADING_DOT_S-NOT: .

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -141,6 +141,7 @@ class SessionCache : public ThreadSafeRefCountedBase<SessionCache> {
   std::vector<Completion *> sortedCompletions;
   CompletionKind completionKind;
   bool completionHasExpectedTypes;
+  bool completionMayUseImplicitMemberExpr;
   FilterRules filterRules;
   llvm::sys::Mutex mtx;
 
@@ -148,10 +149,12 @@ public:
   SessionCache(CompletionSink &&sink,
                std::unique_ptr<llvm::MemoryBuffer> &&buffer,
                std::vector<std::string> &&args, CompletionKind completionKind,
-               bool hasExpectedTypes, FilterRules filterRules)
+               bool hasExpectedTypes, bool mayUseImplicitMemberExpr,
+               FilterRules filterRules)
       : buffer(std::move(buffer)), args(std::move(args)), sink(std::move(sink)),
         completionKind(completionKind),
         completionHasExpectedTypes(hasExpectedTypes),
+        completionMayUseImplicitMemberExpr(mayUseImplicitMemberExpr),
         filterRules(std::move(filterRules)) {}
   void setSortedCompletions(std::vector<Completion *> &&completions);
   ArrayRef<Completion *> getSortedCompletions();
@@ -160,6 +163,7 @@ public:
   const FilterRules &getFilterRules();
   CompletionKind getCompletionKind();
   bool getCompletionHasExpectedTypes();
+  bool getCompletionMayUseImplicitMemberExpr();
 };
 typedef RefPtr<SessionCache> SessionCacheRef;
 


### PR DESCRIPTION
* Explanation: For clients that opt-in to the lone "." completion, provide it when completing in a context where we expect and enum to enable "implicit member" syntax.
* Scope: Affects code-completion in contexts that expect enums.
* Radar: rdar://problem/31260505
* Risk: Low; only affects clients of the new code-completion API that opt-in to this kind of completion.
* Testing: Regression tests added.