### PR TITLE
[WIP] [ConstraintSolver] Track score along the solver path

### DIFF
--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2619,7 +2619,7 @@ private:
   std::pair<PotentialBindings, TypeVariableType *> determineBestBindings();
   PotentialBindings getPotentialBindings(TypeVariableType *typeVar);
 
-  bool
+  Optional<Score>
   tryTypeVariableBindings(unsigned depth, TypeVariableType *typeVar,
                           ArrayRef<ConstraintSystem::PotentialBinding> bindings,
                           SmallVectorImpl<Solution> &solutions,
@@ -2643,8 +2643,9 @@ private:
   /// the solution.
   ///
   /// \returns true if an error occurred, false otherwise.
-  bool solveSimplified(SmallVectorImpl<Solution> &solutions,
-                       FreeTypeVariableBinding allowFreeTypeVariables);
+  Optional<Score>
+  solveSimplified(SmallVectorImpl<Solution> &solutions,
+                  FreeTypeVariableBinding allowFreeTypeVariables);
 
   /// \brief Find reduced domains of disjunction constraints for given
   /// expression, this is achieved to solving individual sub-expressions
@@ -2706,8 +2707,8 @@ public:
   /// the solution.
   ///
   /// \returns true if there are no solutions
-  bool solveRec(SmallVectorImpl<Solution> &solutions,
-             FreeTypeVariableBinding allowFreeTypeVariables);
+  Optional<Score> solveRec(SmallVectorImpl<Solution> &solutions,
+                           FreeTypeVariableBinding allowFreeTypeVariables);
 
   /// \brief Solve the system of constraints.
   ///


### PR DESCRIPTION
Threading solution score along the solver current path allows
us to determine precisely is any given overload choice impacted
solution score in any way, which means we could say if e.g.
there were any unavailable choices picked along the current
path or which overload increased the score.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
