### PR TITLE
Sema: Fix capture analysis for 'defer'

### DIFF
--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -25,6 +25,29 @@
 #include "llvm/ADT/SmallPtrSet.h"
 using namespace swift;
 
+static SourceLoc getCaptureLoc(AnyFunctionRef AFR) {
+  if (auto AFD = AFR.getAbstractFunctionDecl()) {
+    if (auto *FD = dyn_cast<FuncDecl>(AFD)) {
+      if (FD->isDeferBody()) {
+        // HACK: Defer statements generate implicit FuncDecls, and hence do
+        // not have valid source locations.  Instead, use the location of
+        // the body.
+        return FD->getBody()->getLBraceLoc();
+      }
+    }
+
+    return AFD->getLoc();
+  } else {
+    auto ACE = AFR.getAbstractClosureExpr();
+    if (auto CE = dyn_cast<ClosureExpr>(ACE)) {
+      if (!CE->getInLoc().isInvalid())
+        return CE->getInLoc();
+    }
+
+    return ACE->getLoc();
+  }
+}
+
 namespace {
 
 class FindCapturedVars : public ASTWalker {
@@ -50,27 +73,7 @@ public:
         DynamicSelfCaptureLoc(DynamicSelfCaptureLoc),
         DynamicSelf(DynamicSelf),
         AFR(AFR) {
-    if (auto AFD = AFR.getAbstractFunctionDecl()) {
-      if (auto *FD = dyn_cast<FuncDecl>(AFD)) {
-        if (FD->isDeferBody()) {
-          // HACK: Defer statements generate implicit FuncDecls, and hence do
-          // not have valid source locations.  Instead, use the location of
-          // the body.
-          CaptureLoc = FD->getBody()->getLBraceLoc();
-        } else {
-          CaptureLoc = AFD->getLoc();
-        }
-      } else {
-        CaptureLoc = AFD->getLoc();
-      }
-    } else {
-      auto ACE = AFR.getAbstractClosureExpr();
-      if (auto closure = dyn_cast<ClosureExpr>(ACE))
-        CaptureLoc = closure->getInLoc();
-
-      if (CaptureLoc.isInvalid())
-        CaptureLoc = ACE->getLoc();
-    }
+    CaptureLoc = getCaptureLoc(AFR);
   }
 
   /// \brief Check if the type of an expression references any generic
@@ -412,11 +415,11 @@ public:
 
     if (GenericParamCaptureLoc.isInvalid())
       if (captureInfo.hasGenericParamCaptures())
-        GenericParamCaptureLoc = innerClosure.getLoc();
+        GenericParamCaptureLoc = getCaptureLoc(innerClosure);
 
     if (DynamicSelfCaptureLoc.isInvalid())
       if (captureInfo.hasDynamicSelfCapture()) {
-        DynamicSelfCaptureLoc = innerClosure.getLoc();
+        DynamicSelfCaptureLoc = getCaptureLoc(innerClosure);
         DynamicSelf = captureInfo.getDynamicSelfType();
       }
   }
@@ -696,7 +699,7 @@ void TypeChecker::computeCaptures(AnyFunctionRef AFR) {
   }
 
   if (AFR.hasType() && !AFR.isObjC()) {
-    finder.checkType(AFR.getType(), AFR.getLoc());
+    finder.checkType(AFR.getType(), getCaptureLoc(AFR));
   }
 
   // If this is an init(), explicitly walk the initializer values for members of

--- a/test/SILGen/statements.swift
+++ b/test/SILGen/statements.swift
@@ -523,6 +523,15 @@ func defer_in_generic<T>(_ x: T) {
   generic_callee_3(x)
 }
 
+// CHECK-LABEL: sil hidden @_T010statements017defer_in_closure_C8_genericyxlF : $@convention(thin) <T> (@in T) -> ()
+func defer_in_closure_in_generic<T>(_ x: T) {
+  // CHECK-LABEL: sil private @_T010statements017defer_in_closure_C8_genericyxlFyycfU_ : $@convention(thin) <T> () -> ()
+  _ = {
+    // CHECK-LABEL: sil private @_T010statements017defer_in_closure_C8_genericyxlFyycfU_6$deferL_yylF : $@convention(thin) <T> () -> ()
+    defer { generic_callee_1(T.self) }
+  }
+}
+
 // CHECK-LABEL: sil hidden @_T010statements13defer_mutableySiF
 func defer_mutable(_ x: Int) {
   var x = x


### PR DESCRIPTION
A 'defer' parses as a DeferStmt and an implicit FuncDecl. The
implicit FuncDecl does not have a valid source location, so
be sure to consistently use the outer function's source
location instead.

Fixes <rdar://problem/33353035> / <https://bugs.swift.org/browse/SR-5464>.
