### PR TITLE
Sema: Fix capture analysis for 'defer' [4.0]

### DIFF
--- a/test/SILGen/statements.swift
+++ b/test/SILGen/statements.swift
@@ -523,6 +523,15 @@ func defer_in_generic<T>(_ x: T) {
   generic_callee_3(x)
 }
 
+// CHECK-LABEL: sil hidden @_T010statements017defer_in_closure_C8_genericyxlF : $@convention(thin) <T> (@in T) -> ()
+func defer_in_closure_in_generic<T>(_ x: T) {
+  // CHECK-LABEL: sil private @_T010statements017defer_in_closure_C8_genericyxlFyycfU_ : $@convention(thin) <T> () -> ()
+  _ = {
+    // CHECK-LABEL: sil private @_T010statements017defer_in_closure_C8_genericyxlFyycfU_6$deferL_yylF : $@convention(thin) <T> () -> ()
+    defer { generic_callee_1(T.self) }
+  }
+}
+
 // CHECK-LABEL: sil hidden @_T010statements13defer_mutableySiF
 func defer_mutable(_ x: Int) {
   var x = x


### PR DESCRIPTION
* Description: A 'defer' that uses generic parameters inside of a closure had incorrect capture info computed by Sema, which could trigger various SILGen assertions.

* Scope of the issue: Reported externally and pretty easy to reproduce.

* Origination: User reports this as a regression, but I think this is because capture analysis got more accurate recently. The underlying problem was always there.

* Risk: Low.

* Tested: New test added.

* Reviewed by: @jckarter 

* Radar: <rdar://problem/33353035>