### PR TITLE
Disable -Xlinker argument reordering test on macOS.

### DIFF
--- a/test/Driver/linker-args-order-linux.swift
+++ b/test/Driver/linker-args-order-linux.swift
@@ -1,4 +1,5 @@
 // Statically link a "hello world" program
+// REQUIRES: OS=linux-gnu
 // REQUIRES: static_stdlib
 print("hello world!")
 // RUN: %empty-directory(%t)


### PR DESCRIPTION
Fixes broken test introduced by https://github.com/apple/swift/pull/9958

The linker argument reordering test should only be run on Linux.
