### PR TITLE
Add some more tests I've been meaning to add for a while

### DIFF
--- a/test/ClangImporter/objc_parse.swift
+++ b/test/ClangImporter/objc_parse.swift
@@ -8,6 +8,7 @@ import AVFoundation
 import Newtype
 import objc_ext
 import TestProtocols
+import TypeAndValue
 
 import ObjCParseExtras
 import ObjCParseExtrasToo
@@ -628,4 +629,12 @@ class NewtypeUser {
   @objc func stringNewtypeOptional(a: SNTErrorDomain?) {} // expected-error {{'SNTErrorDomain' has been renamed to 'ErrorDomain'}}{{39-53=ErrorDomain}}
   @objc func intNewtype(a: MyInt) {}
   @objc func intNewtypeOptional(a: MyInt?) {} // expected-error {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
+}
+
+func testTypeAndValue() {
+  _ = testStruct()
+  _ = testStruct(value: 0)
+  let _: (testStruct) -> Void = testStruct
+  let _: () -> testStruct = testStruct.init
+  let _: (CInt) -> testStruct = testStruct.init
 }

--- a/test/SILGen/Inputs/usr/include/Gizmo.h
+++ b/test/SILGen/Inputs/usr/include/Gizmo.h
@@ -61,11 +61,6 @@ typedef long NSInteger;
 + (instancetype)gizmoWithStuff:(NSInteger)x;
 + (Gizmo*)gizmoWithExactlyStuff:(NSInteger)x;
 
-- (Gizmo*)nonNilGizmo __attribute__((swift_name("nonNilGizmo()")));
-+ (Gizmo*)nonNilGizmo __attribute__((swift_name("nonNilGizmo()")));
-@property Gizmo* nonNilGizmoProperty;
-@property (unsafe_unretained) Gizmo* unownedNonNilGizmoProperty;
-
 @property id originalName __attribute__((swift_name("renamedProp")));
 @end
 

--- a/test/SILGen/Inputs/usr/include/NonNilTest.apinotes
+++ b/test/SILGen/Inputs/usr/include/NonNilTest.apinotes
@@ -1,16 +1,16 @@
 ---
-Name: gizmo
+Name: NonNilTest
 Classes:
-- Name: Gizmo
+- Name: NonNilTest
   Methods:
-  - Selector: nonNilGizmo
+  - Selector: nonNilObject
     MethodKind: Instance
     NullabilityOfRet: N
-  - Selector: nonNilGizmo
+  - Selector: nonNilObject
     MethodKind: Class
     NullabilityOfRet: N
   Properties:
-  - Name: nonNilGizmoProperty
+  - Name: nonNilObjectProperty
     Nullability: N
-  - Name: unownedNonNilGizmoProperty
+  - Name: unownedNonNilObjectProperty
     Nullability: N

--- a/test/SILGen/Inputs/usr/include/NonNilTest.h
+++ b/test/SILGen/Inputs/usr/include/NonNilTest.h
@@ -1,0 +1,8 @@
+@import ObjectiveC;
+
+@interface NonNilTest: NSObject
+- (NonNilTest *)nonNilObject;
++ (NonNilTest *)nonNilObject;
+@property NonNilTest *nonNilObjectProperty;
+@property (unsafe_unretained) NonNilTest *unownedNonNilObjectProperty;
+@end

--- a/test/SILGen/Inputs/usr/include/module.map
+++ b/test/SILGen/Inputs/usr/include/module.map
@@ -39,3 +39,8 @@ module Newtype {
   header "newtype.h"
   export *
 }
+
+module NonNilTest {
+  header "NonNilTest.h"
+  export *
+}

--- a/test/SILGen/objc_nonnull_lie_hack.swift
+++ b/test/SILGen/objc_nonnull_lie_hack.swift
@@ -1,22 +1,24 @@
-// RUN: %empty-directory(%t/APINotes)
-// RUN: %clang_apinotes -yaml-to-binary %S/Inputs/gizmo.apinotes -o %t/APINotes/gizmo.apinotesc
-// RUN: %target-swift-frontend -emit-silgen -sdk %S/Inputs -I %S/Inputs -I %t/APINotes -enable-source-import -primary-file %s | %FileCheck -check-prefix=SILGEN %s
-// RUN: %target-swift-frontend -emit-sil -O -sdk %S/Inputs -I %S/Inputs -I %t/APINotes -enable-source-import -primary-file %s | %FileCheck -check-prefix=OPT %s
+// RUN: %target-swift-frontend -emit-silgen -sdk %S/Inputs -I %S/Inputs -I %S/Inputs/objc_nonnull_lie_hack/ -enable-source-import -primary-file %s | %FileCheck -check-prefix=SILGEN %s
+// RUN: %target-swift-frontend -emit-sil -O -sdk %S/Inputs -I %S/Inputs -I %S/Inputs/objc_nonnull_lie_hack/ -enable-source-import -primary-file %s | %FileCheck -check-prefix=OPT %s
 
 // REQUIRES: objc_interop
-// REQUIRES: rdar28313536
 
 import Foundation
-import gizmo
+import NonNilTest
 
-// SILGEN-LABEL: sil hidden @_TF21objc_nonnull_lie_hack10makeObjectFT_GSqCSo8NSObject_
-// SILGEN:         [[INIT:%.*]] = function_ref @_TFCSo8NSObjectC
+func checkThatAPINotesAreBeingUsed() {
+  let hopefullyNotOptional = NonNilTest.nonNilObject()
+  let _: NonNilTest = hopefullyNotOptional
+}
+
+// SILGEN-LABEL: sil hidden @_T021objc_nonnull_lie_hack10makeObjectSo8NSObjectCSgyF
+// SILGEN:         [[INIT:%.*]] = function_ref @_T0So8NSObjectCABycfC
 // SILGEN:         [[NONOPTIONAL:%.*]] = apply [[INIT]]
 // SILGEN:         [[OPTIONAL:%.*]] = unchecked_ref_cast [[NONOPTIONAL]]
 
-// OPT-LABEL: sil hidden @_TF21objc_nonnull_lie_hack10makeObjectFT_GSqCSo8NSObject_
+// OPT-LABEL: sil hidden @_T021objc_nonnull_lie_hack10makeObjectSo8NSObjectCSgyF
 // OPT:         [[OPT:%.*]] = unchecked_ref_cast
-// OPT:         switch_enum [[OPT]] : $Optional<NSObject>, case #Optional.none!enumelt: [[NIL:bb[0-9]+]]
+// OPT:         switch_enum [[OPT]] : $Optional<NSObject>, case #Optional.some!enumelt.1:
 func makeObject() -> NSObject? {
   let foo: NSObject? = NSObject()
   if foo == nil {
@@ -25,28 +27,28 @@ func makeObject() -> NSObject? {
   return foo
 }
 
-// OPT-LABEL: sil hidden @_TF21objc_nonnull_lie_hack15callClassMethod
-// OPT: [[METATYPE:%[0-9]+]] = metatype $@thick Gizmo.Type
-// OPT: [[METHOD:%[0-9]+]] = class_method [volatile] [[METATYPE]] : $@thick Gizmo.Type, #Gizmo.nonNilGizmo!1.foreign : (Gizmo.Type) -> () -> Gizmo, $@convention(objc_method) (@objc_metatype Gizmo.Type) -> @autoreleased Gizmo
-// OPT: [[OBJC_METATYPE:%[0-9]+]] = metatype $@objc_metatype Gizmo.Type
-// OPT: [[NONOPTIONAL:%[0-9]+]] = apply [[METHOD]]([[OBJC_METATYPE]]) : $@convention(objc_method) (@objc_metatype Gizmo.Type) -> @autoreleased Gizmo
-// OPT: [[OPTIONAL:%[0-9]+]] = unchecked_ref_cast [[NONOPTIONAL]] : $Gizmo to $Optional<Gizmo>
-// OPT: switch_enum [[OPTIONAL]] : $Optional<Gizmo>
-func callClassMethod() -> Gizmo? {
-  let foo: Gizmo? = Gizmo.nonNilGizmo()
+// OPT-LABEL: sil hidden @_T021objc_nonnull_lie_hack15callClassMethodSo10NonNilTestCSgyF
+// OPT: [[METATYPE:%[0-9]+]] = metatype $@thick NonNilTest.Type
+// OPT: [[METHOD:%[0-9]+]] = class_method [volatile] [[METATYPE]] : $@thick NonNilTest.Type, #NonNilTest.nonNilObject!1.foreign : (NonNilTest.Type) -> () -> NonNilTest, $@convention(objc_method) (@objc_metatype NonNilTest.Type) -> @autoreleased NonNilTest
+// OPT: [[OBJC_METATYPE:%[0-9]+]] = metatype $@objc_metatype NonNilTest.Type
+// OPT: [[NONOPTIONAL:%[0-9]+]] = apply [[METHOD]]([[OBJC_METATYPE]]) : $@convention(objc_method) (@objc_metatype NonNilTest.Type) -> @autoreleased NonNilTest
+// OPT: [[OPTIONAL:%[0-9]+]] = unchecked_ref_cast [[NONOPTIONAL]] : $NonNilTest to $Optional<NonNilTest>
+// OPT: switch_enum [[OPTIONAL]] : $Optional<NonNilTest>
+func callClassMethod() -> NonNilTest? {
+  let foo: NonNilTest? = NonNilTest.nonNilObject()
   if foo == nil {
     print("nil")
   }
   return foo  
 }
 
-// OPT-LABEL: sil hidden @_TTSf4g___TF21objc_nonnull_lie_hack18callInstanceMetho
-// OPT: [[METHOD:%[0-9]+]] = class_method [volatile] [[OBJ:%[0-9]+]] : $Gizmo, #Gizmo.nonNilGizmo!1.foreign : (Gizmo) -> () -> Gizmo, $@convention(objc_method) (Gizmo) -> @autoreleased Gizmo
-// OPT: [[NONOPTIONAL:%[0-9]+]] = apply [[METHOD]]([[OBJ]]) : $@convention(objc_method) (Gizmo) -> @autoreleased Gizmo
+// OPT-LABEL: sil shared @_T021objc_nonnull_lie_hack18callInstanceMethodSo10NonNilTestCSgAD3obj_tFTf4g_n
+// OPT: [[METHOD:%[0-9]+]] = class_method [volatile] [[OBJ:%[0-9]+]] : $NonNilTest, #NonNilTest.nonNilObject!1.foreign : (NonNilTest) -> () -> NonNilTest, $@convention(objc_method) (NonNilTest) -> @autoreleased NonNilTest
+// OPT: [[NONOPTIONAL:%[0-9]+]] = apply [[METHOD]]([[OBJ]]) : $@convention(objc_method) (NonNilTest) -> @autoreleased NonNilTest
 // OPT: [[OPTIONAL:%[0-9]+]] = unchecked_ref_cast [[NONOPTIONAL]]
-// OPT: switch_enum [[OPTIONAL]] : $Optional<Gizmo>
-func callInstanceMethod(gizmo: Gizmo) -> Gizmo? {
-  let foo: Gizmo? = gizmo.nonNilGizmo()
+// OPT: switch_enum [[OPTIONAL]] : $Optional<NonNilTest>
+func callInstanceMethod(obj: NonNilTest) -> NonNilTest? {
+  let foo: NonNilTest? = obj.nonNilObject()
 
   if foo == nil {
     print("nil")
@@ -54,26 +56,26 @@ func callInstanceMethod(gizmo: Gizmo) -> Gizmo? {
   return foo
 }
 
-// OPT-LABEL: sil hidden @_TTSf4g___TF21objc_nonnull_lie_hack12loadPropertyFT5gizmoCSo5Gizmo_GSqS0__
-// OPT: [[GETTER:%[0-9]+]] = class_method [volatile] [[OBJ:%[0-9]+]] : $Gizmo, #Gizmo.nonNilGizmoProperty!getter.1.foreign : (Gizmo) -> () -> Gizmo, $@convention(objc_method) (Gizmo) -> @autoreleased Gizmo
-// OPT: [[NONOPTIONAL:%[0-9]+]] = apply [[GETTER]]([[OBJ]]) : $@convention(objc_method) (Gizmo) -> @autoreleased Gizmo
-// OPT: [[OPTIONAL:%[0-9]+]] = unchecked_ref_cast [[NONOPTIONAL]] : $Gizmo to $Optional<Gizmo>
-// OPT: switch_enum [[OPTIONAL]] : $Optional<Gizmo>,
-func loadProperty(gizmo: Gizmo) -> Gizmo? {
-  let foo: Gizmo? = gizmo.nonNilGizmoProperty
+// OPT-LABEL: sil shared @_T021objc_nonnull_lie_hack12loadPropertySo10NonNilTestCSgAD3obj_tFTf4g_n
+// OPT: [[GETTER:%[0-9]+]] = class_method [volatile] [[OBJ:%[0-9]+]] : $NonNilTest, #NonNilTest.nonNilObjectProperty!getter.1.foreign : (NonNilTest) -> () -> NonNilTest, $@convention(objc_method) (NonNilTest) -> @autoreleased NonNilTest
+// OPT: [[NONOPTIONAL:%[0-9]+]] = apply [[GETTER]]([[OBJ]]) : $@convention(objc_method) (NonNilTest) -> @autoreleased NonNilTest
+// OPT: [[OPTIONAL:%[0-9]+]] = unchecked_ref_cast [[NONOPTIONAL]] : $NonNilTest to $Optional<NonNilTest>
+// OPT: switch_enum [[OPTIONAL]] : $Optional<NonNilTest>,
+func loadProperty(obj: NonNilTest) -> NonNilTest? {
+  let foo: NonNilTest? = obj.nonNilObjectProperty
   if foo == nil {
     print("nil")
   }
   return foo  
 }
 
-// OPT-LABEL: sil hidden @_TTSf4g___TF21objc_nonnull_lie_hack19loadUnownedPropertyFT5gizmoCSo5Gizmo_GSqS0__
-// OPT: [[GETTER:%[0-9]+]] = class_method [volatile] [[OBJ:%[0-9]+]] : $Gizmo, #Gizmo.unownedNonNilGizmoProperty!getter.1.foreign : (Gizmo) -> () -> Gizmo, $@convention(objc_method) (Gizmo) -> @autoreleased Gizmo
-// OPT: [[NONOPTIONAL:%[0-9]+]] = apply [[GETTER]]([[OBJ]]) : $@convention(objc_method) (Gizmo) -> @autoreleased Gizmo
-// OPT: [[OPTIONAL:%[0-9]+]] = unchecked_ref_cast [[NONOPTIONAL]] : $Gizmo to $Optional<Gizmo>
-// OPT: switch_enum [[OPTIONAL]] : $Optional<Gizmo>
-func loadUnownedProperty(gizmo: Gizmo) -> Gizmo? {
-  let foo: Gizmo? = gizmo.unownedNonNilGizmoProperty
+// OPT-LABEL: sil shared @_T021objc_nonnull_lie_hack19loadUnownedPropertySo10NonNilTestCSgAD3obj_tFTf4g_n
+// OPT: [[GETTER:%[0-9]+]] = class_method [volatile] [[OBJ:%[0-9]+]] : $NonNilTest, #NonNilTest.unownedNonNilObjectProperty!getter.1.foreign : (NonNilTest) -> () -> NonNilTest, $@convention(objc_method) (NonNilTest) -> @autoreleased NonNilTest
+// OPT: [[NONOPTIONAL:%[0-9]+]] = apply [[GETTER]]([[OBJ]]) : $@convention(objc_method) (NonNilTest) -> @autoreleased NonNilTest
+// OPT: [[OPTIONAL:%[0-9]+]] = unchecked_ref_cast [[NONOPTIONAL]] : $NonNilTest to $Optional<NonNilTest>
+// OPT: switch_enum [[OPTIONAL]] : $Optional<NonNilTest>
+func loadUnownedProperty(obj: NonNilTest) -> NonNilTest? {
+  let foo: NonNilTest? = obj.unownedNonNilObjectProperty
   if foo == nil {
     print("nil")
   }

--- a/test/SILGen/pointer_conversion.swift
+++ b/test/SILGen/pointer_conversion.swift
@@ -122,6 +122,18 @@ func arrayToPointer() {
   // CHECK: [[DEPENDENT:%.*]] = mark_dependence [[POINTER]] : $UnsafeRawPointer on [[OWNER]]
   // CHECK: apply [[TAKES_CONST_RAW_POINTER]]([[DEPENDENT]])
   // CHECK: destroy_value [[OWNER]]
+
+  takesOptConstPointer(ints, and: sideEffect1())
+  // CHECK: [[TAKES_OPT_CONST_POINTER:%.*]] = function_ref @_T018pointer_conversion20takesOptConstPointerySPySiGSg_Si3andtF :
+  // CHECK: [[SIDE1:%.*]] = function_ref @_T018pointer_conversion11sideEffect1SiyF
+  // CHECK: [[RESULT1:%.*]] = apply [[SIDE1]]()
+  // CHECK: [[CONVERT_CONST:%.*]] = function_ref @_T0s35_convertConstArrayToPointerArgument{{[_0-9a-zA-Z]*}}F
+  // CHECK: [[OWNER:%.*]] = apply [[CONVERT_CONST]]<Int, UnsafePointer<Int>>([[POINTER_BUF:%[0-9]*]],
+  // CHECK: [[POINTER:%.*]] = load [trivial] [[POINTER_BUF]]
+  // CHECK: [[DEPENDENT:%.*]] = mark_dependence [[POINTER]] : $UnsafePointer<Int> on [[OWNER]]
+  // CHECK: [[OPTPTR:%.*]] = enum $Optional<UnsafePointer<Int>>, #Optional.some!enumelt.1, [[DEPENDENT]]
+  // CHECK: apply [[TAKES_OPT_CONST_POINTER]]([[OPTPTR]], [[RESULT1]])
+  // CHECK: destroy_value [[OWNER]]
 }
 
 // CHECK-LABEL: sil hidden @_T018pointer_conversion15stringToPointerySSF 
@@ -142,6 +154,18 @@ func stringToPointer(_ s: String) {
   // CHECK: [[POINTER:%.*]] = load [trivial] [[POINTER_BUF]]
   // CHECK: [[DEPENDENT:%.*]] = mark_dependence [[POINTER]] : $UnsafeRawPointer on [[OWNER]]
   // CHECK: apply [[TAKES_CONST_RAW_POINTER]]([[DEPENDENT]])
+  // CHECK: destroy_value [[OWNER]]
+
+  takesOptConstRawPointer(s, and: sideEffect1())
+  // CHECK: [[TAKES_OPT_CONST_RAW_POINTER:%.*]] = function_ref @_T018pointer_conversion23takesOptConstRawPointerySVSg_Si3andtF :
+  // CHECK: [[SIDE1:%.*]] = function_ref @_T018pointer_conversion11sideEffect1SiyF
+  // CHECK: [[RESULT1:%.*]] = apply [[SIDE1]]()
+  // CHECK: [[CONVERT_STRING:%.*]] = function_ref @_T0s40_convertConstStringToUTF8PointerArgument{{[_0-9a-zA-Z]*}}F
+  // CHECK: [[OWNER:%.*]] = apply [[CONVERT_STRING]]<UnsafeRawPointer>([[POINTER_BUF:%[0-9]*]],
+  // CHECK: [[POINTER:%.*]] = load [trivial] [[POINTER_BUF]]
+  // CHECK: [[DEPENDENT:%.*]] = mark_dependence [[POINTER]] : $UnsafeRawPointer on [[OWNER]]
+  // CHECK: [[OPTPTR:%.*]] = enum $Optional<UnsafeRawPointer>, #Optional.some!enumelt.1, [[DEPENDENT]]
+  // CHECK: apply [[TAKES_OPT_CONST_RAW_POINTER]]([[OPTPTR]], [[RESULT1]])
   // CHECK: destroy_value [[OWNER]]
 }
 

--- a/test/SILOptimizer/pointer_conversion.swift
+++ b/test/SILOptimizer/pointer_conversion.swift
@@ -1,0 +1,113 @@
+// RUN: %target-swift-frontend -emit-sil -O %s | %FileCheck %s
+
+// Opaque, unoptimizable functions to call.
+@_silgen_name("takesConstRawPointer")
+func takesConstRawPointer(_ x: UnsafeRawPointer)
+@_silgen_name("takesOptConstRawPointer")
+func takesOptConstRawPointer(_ x: UnsafeRawPointer?)
+@_silgen_name("takesMutableRawPointer")
+func takesMutableRawPointer(_ x: UnsafeMutableRawPointer)
+@_silgen_name("takesOptMutableRawPointer")
+func takesOptMutableRawPointer(_ x: UnsafeMutableRawPointer?)
+
+// Opaque function for generating values
+@_silgen_name("get")
+func get<T>() -> T
+
+// The purpose of these tests is to make sure the storage is never released
+// before the call to the opaque function.
+
+// CHECK-LABEL: sil @_T018pointer_conversion9testArrayyyF
+public func testArray() {
+  let array: [Int] = get()
+  takesConstRawPointer(array)
+  // CHECK: [[FN:%.+]] = function_ref @takesConstRawPointer
+  // CHECK: [[OWNER:%.+]] = enum $Optional<AnyObject>, #Optional.some!enumelt.1,
+  // CHECK-NEXT: [[POINTER:%.+]] = struct $UnsafeRawPointer (
+  // CHECK-NEXT: [[DEP_POINTER:%.+]] = mark_dependence [[POINTER]] : $UnsafeRawPointer on [[OWNER]] : $Optional<AnyObject>
+  // CHECK-NEXT: apply [[FN]]([[DEP_POINTER]])
+  // CHECK-NOT: release
+  // CHECK-NOT: {{^bb[0-9]+:}}
+  // CHECK: strong_release {{%.+}} : ${{Builtin[.]BridgeObject|_ContiguousArrayStorageBase}}
+  // CHECK-NEXT: [[EMPTY:%.+]] = tuple ()
+  // CHECK-NEXT: return [[EMPTY]]
+}
+
+// CHECK-LABEL: sil @_T018pointer_conversion19testArrayToOptionalyyF
+public func testArrayToOptional() {
+  let array: [Int] = get()
+  takesOptConstRawPointer(array)
+  // CHECK: [[FN:%.+]] = function_ref @takesOptConstRawPointer
+  // CHECK: [[OWNER:%.+]] = enum $Optional<AnyObject>, #Optional.some!enumelt.1,
+  // CHECK-NEXT: [[POINTER:%.+]] = struct $UnsafeRawPointer (
+  // CHECK-NEXT: [[DEP_POINTER:%.+]] = mark_dependence [[POINTER]] : $UnsafeRawPointer on [[OWNER]] : $Optional<AnyObject>
+  // CHECK-NEXT: [[OPT_POINTER:%.+]] = enum $Optional<UnsafeRawPointer>, #Optional.some!enumelt.1, [[DEP_POINTER]]
+  // CHECK-NEXT: apply [[FN]]([[OPT_POINTER]])
+  // CHECK-NOT: release
+  // CHECK-NOT: {{^bb[0-9]+:}}
+  // CHECK: strong_release {{%.+}} : ${{Builtin[.]BridgeObject|_ContiguousArrayStorageBase}}
+  // CHECK-NEXT: [[EMPTY:%.+]] = tuple ()
+  // CHECK-NEXT: return [[EMPTY]]
+}
+
+// CHECK-LABEL: sil @_T018pointer_conversion16testMutableArrayyyF
+public func testMutableArray() {
+  var array: [Int] = get()
+  takesMutableRawPointer(&array)
+  // CHECK: [[FN:%.+]] = function_ref @takesMutableRawPointer
+  // CHECK: [[OWNER:%.+]] = enum $Optional<AnyObject>, #Optional.some!enumelt.1,
+  // CHECK-NEXT: [[POINTER:%.+]] = struct $UnsafeMutableRawPointer (
+  // CHECK-NEXT: [[DEP_POINTER:%.+]] = mark_dependence [[POINTER]] : $UnsafeMutableRawPointer on [[OWNER]] : $Optional<AnyObject>
+  // CHECK-NEXT: apply [[FN]]([[DEP_POINTER]])
+  // CHECK-NOT: release
+  // CHECK-NOT: {{^bb[0-9]+:}}
+  // CHECK: strong_release {{%.+}} : ${{Builtin[.]BridgeObject|_ContiguousArrayStorageBase}}
+  // CHECK-NEXT: dealloc_stack {{%.+}} : $*Array<Int>
+  // CHECK-NEXT: [[EMPTY:%.+]] = tuple ()
+  // CHECK-NEXT: return [[EMPTY]]
+}
+
+// CHECK-LABEL: sil @_T018pointer_conversion26testMutableArrayToOptionalyyF
+public func testMutableArrayToOptional() {
+  var array: [Int] = get()
+  takesOptMutableRawPointer(&array)
+  // CHECK: [[FN:%.+]] = function_ref @takesOptMutableRawPointer
+  // CHECK: [[OWNER:%.+]] = enum $Optional<AnyObject>, #Optional.some!enumelt.1,
+  // CHECK-NEXT: [[POINTER:%.+]] = struct $UnsafeMutableRawPointer (
+  // CHECK-NEXT: [[DEP_POINTER:%.+]] = mark_dependence [[POINTER]] : $UnsafeMutableRawPointer on [[OWNER]] : $Optional<AnyObject>
+  // CHECK-NEXT: [[OPT_POINTER:%.+]] = enum $Optional<UnsafeMutableRawPointer>, #Optional.some!enumelt.1, [[DEP_POINTER]]
+  // CHECK-NEXT: apply [[FN]]([[OPT_POINTER]])
+  // CHECK-NOT: release
+  // CHECK-NOT: {{^bb[0-9]+:}}
+  // CHECK: strong_release {{%.+}} : ${{Builtin[.]BridgeObject|_ContiguousArrayStorageBase}}
+  // CHECK-NEXT: dealloc_stack {{%.+}} : $*Array<Int>
+  // CHECK-NEXT: [[EMPTY:%.+]] = tuple ()
+  // CHECK-NEXT: return [[EMPTY]]
+}
+
+// CHECK-LABEL: sil @_T018pointer_conversion17testOptionalArrayyyF
+public func testOptionalArray() {
+  let array: [Int]? = get()
+  takesOptConstRawPointer(array)
+  // CHECK: [[OWNER:%.+]] = enum $Optional<AnyObject>, #Optional.some!enumelt.1,
+  // CHECK-NEXT: [[POINTER:%.+]] = struct $UnsafeRawPointer (
+  // CHECK-NEXT: [[DEP_POINTER:%.+]] = mark_dependence [[POINTER]] : $UnsafeRawPointer on [[OWNER]] : $Optional<AnyObject>
+  // CHECK-NEXT: [[OPT_POINTER:%.+]] = enum $Optional<UnsafeRawPointer>, #Optional.some!enumelt.1, [[DEP_POINTER]]
+  // CHECK-NEXT: br [[CALL_BRANCH:bb[0-9]+]]([[OPT_POINTER]] : $Optional<UnsafeRawPointer>, [[OWNER]] : $Optional<AnyObject>)
+
+  // CHECK: [[CALL_BRANCH]]([[OPT_POINTER:%.+]] : $Optional<UnsafeRawPointer>, [[OWNER:%.+]] : $Optional<AnyObject>):
+  // CHECK-NOT: release
+  // CHECK: [[FN:%.+]] = function_ref @takesOptConstRawPointer
+  // CHECK-NEXT: [[DEP_OPT_POINTER:%.+]] = mark_dependence [[OPT_POINTER]] : $Optional<UnsafeRawPointer> on [[OWNER]] : $Optional<AnyObject>
+  // CHECK-NEXT: apply [[FN]]([[DEP_OPT_POINTER]])
+  // CHECK-NOT: release
+  // CHECK-NOT: {{^bb[0-9]+:}}
+  // CHECK: release_value {{%.+}} : $Optional<Array<Int>>
+  // CHECK-NEXT: [[EMPTY:%.+]] = tuple ()
+  // CHECK-NEXT: return [[EMPTY]]
+
+  // CHECK: {{bb[0-9]+}}:
+  // CHECK-NEXT: [[NO_POINTER:%.+]] = enum $Optional<UnsafeRawPointer>, #Optional.none!enumelt
+  // CHECK-NEXT: [[NO_OWNER:%.+]] = enum $Optional<AnyObject>, #Optional.none!enumelt
+  // CHECK-NEXT: br [[CALL_BRANCH]]([[NO_POINTER]] : $Optional<UnsafeRawPointer>, [[NO_OWNER]] : $Optional<AnyObject>)
+} // CHECK: end sil function '_T018pointer_conversion17testOptionalArrayyyF'


### PR DESCRIPTION
- Can we instantiate a struct with the same name as a function? (yes)
- Factor out a module just for objc_nonnull_lie_hack.swift (and re-enable it)
- More tests for array/string-to-optional-pointer conversions.