### PR TITLE
AST: Check return value of ProtocolConformance::getTypeWitness()

### DIFF
--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -1688,6 +1688,7 @@ static void concretizeNestedTypeFromConcreteParent(
     witnessType =
       conformance.getConcrete()
         ->getTypeWitness(assocType, builder.getLazyResolver());
+    if (!witnessType) return;
   } else {
     witnessType = DependentMemberType::get(concreteParent, assocType);
   }


### PR DESCRIPTION
This method returns an empty Type if the conformance is currently
being checked. The other caller of this method in the
GenericSignatureBuilder checked the return value and bailed out,
but one place did not.

This is probably not the right long-term fix, but it matches what
the other caller of getTypeWitness() does in this file.

I don't have a reduced test case either; the repro involves
building a specific revision of the standard library with a patch
applied. However, the fix can't really do any harm, since passing
an empty Type here quickly crashes.

Fixes <rdar://problem/32296747>, <https://bugs.swift.org/browse/SR-4945>.