### PR TITLE
AST: Check return value of ProtocolConformance::getTypeWitness() [4.0]

### DIFF
--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -1720,6 +1720,7 @@ static void concretizeNestedTypeFromConcreteParent(
     witnessType =
       conformance.getConcrete()
         ->getTypeWitness(assocType, builder.getLazyResolver());
+    if (!witnessType) return;
   } else {
     witnessType = DependentMemberType::get(concreteParent, assocType);
   }


### PR DESCRIPTION
* Description: Fixes a null pointer dereference that occurs if we're building a generic signature containing a same type constraint involving a type for which we're in the process of checking conformance.

* Scope of the issue: I don't have a reduced test case; the repro requires building the stdlib from a specific git revision, with a patch attached (see the JIRA).

* Origination: The code in question was recently completely redone, but we've had various hard-to-track-down circularity issues involving the standard library forever.

* Risk: Very low, we're bailing out in a code path that used to unconditionally crash.

* Tested: Existing tests pass, and the stdlib no longer crashes with the patch, but I don't have a reduction.

* Reviewed by: @rudkx 

* Radar: <rdar://problem/32296747>