### PR TITLE
Substantially rework how IRGen handles function pointers.

### DIFF
--- a/lib/IRGen/CallEmission.h
+++ b/lib/IRGen/CallEmission.h
@@ -35,9 +35,6 @@ public:
   IRGenFunction &IGF;
 
 private:
-  /// The function attributes for the call.
-  llvm::AttributeSet Attrs;
-  
   /// The builtin/special arguments to pass to the call.
   SmallVector<llvm::Value*, 8> Args;
 
@@ -56,13 +53,10 @@ private:
   void emitToUnmappedMemory(Address addr);
   void emitToUnmappedExplosion(Explosion &out);
   llvm::CallSite emitCallSite();
-  llvm::CallSite emitInvoke(llvm::CallingConv::ID cc, llvm::Value *fn,
-                            ArrayRef<llvm::Value*> args,
-                            const llvm::AttributeSet &attrs);
 
 public:
-  CallEmission(IRGenFunction &IGF, const Callee &callee)
-      : IGF(IGF), CurCallee(callee) {
+  CallEmission(IRGenFunction &IGF, Callee &&callee)
+      : IGF(IGF), CurCallee(std::move(callee)) {
     setFromCallee();
   }
   CallEmission(const CallEmission &other) = delete;
@@ -70,7 +64,6 @@ public:
   CallEmission &operator=(const CallEmission &other) = delete;
   ~CallEmission();
 
-  Callee &getMutableCallee() { return CurCallee; }
   const Callee &getCallee() const { return CurCallee; }
 
   SubstitutionList getSubstitutions() const {
@@ -84,8 +77,6 @@ public:
 
   void emitToMemory(Address addr, const LoadableTypeInfo &substResultTI);
   void emitToExplosion(Explosion &out);
-   
-  void invalidate();
 };
 
 

--- a/lib/IRGen/Callee.h
+++ b/lib/IRGen/Callee.h
@@ -36,82 +36,162 @@ namespace irgen {
   class Callee;
   class IRGenFunction;
 
-  class Callee {
+  class CalleeInfo {
+  public:
     /// The unsubstituted function type being called.
     CanSILFunctionType OrigFnType;
 
     /// The substituted result type of the function being called.
     CanSILFunctionType SubstFnType;
 
-    /// The clang information for the function being called, if applicable.
-    ForeignFunctionInfo ForeignInfo;
-
-    /// The pointer to the actual function.
-    llvm::Value *FnPtr;
-
-    /// The data pointer required by the function.  There's an
-    /// invariant that this never stores an llvm::ConstantPointerNull.
-    llvm::Value *DataPtr;
-
     /// The archetype substitutions under which the function is being
     /// called.
     std::vector<Substitution> Substitutions;
 
+    CalleeInfo(CanSILFunctionType origFnType,
+               CanSILFunctionType substFnType,
+               SubstitutionList substitutions)
+      : OrigFnType(origFnType), SubstFnType(substFnType),
+        Substitutions(substitutions.begin(), substitutions.end()) {
+    }
+  };
+
+  /// A function pointer value.
+  class FunctionPointer {
+    /// The actual function pointer.
+    llvm::Value *Value;
+
+    Signature Sig;
+
   public:
-    Callee() = default;
-
-    /// Prepare a callee for a known function with a known data pointer.
-    static Callee forKnownFunction(CanSILFunctionType origFnType,
-                                   CanSILFunctionType substFnType,
-                                   SubstitutionList subs,
-                                   llvm::Value *fn, llvm::Value *data,
-                                   ForeignFunctionInfo foreignInfo) {
-      // Invariant on the function pointer.
-      assert(fn->getType()->getPointerElementType()->isFunctionTy());
-      assert((foreignInfo.ClangInfo != nullptr) ==
-             (origFnType->getLanguage() == SILFunctionLanguage::C));
-
-      Callee result;
-      result.OrigFnType = origFnType;
-      result.SubstFnType = substFnType;
-      result.FnPtr = fn;
-      result.DataPtr = data;
-      result.Substitutions = subs;
-      result.ForeignInfo = foreignInfo;
-      return result;
+    /// Construct a FunctionPointer for an arbitrary pointer value.
+    /// We may add more arguments to this; try to use the other
+    /// constructors/factories if possible.
+    explicit FunctionPointer(llvm::Value *value, const Signature &signature)
+        : Value(value), Sig(signature) {
+      // The function pointer should have function type.
+      assert(value->getType()->getPointerElementType()->isFunctionTy());
+      // TODO: maybe assert similarity to signature.getType()?
     }
-    
+
+    static FunctionPointer forDirect(IRGenModule &IGM,
+                                     llvm::Constant *value,
+                                     CanSILFunctionType fnType);
+
+    static FunctionPointer forDirect(llvm::Constant *value,
+                                     const Signature &signature) {
+      return FunctionPointer(value, signature);
+    }
+
+    static FunctionPointer forExplosionValue(IRGenFunction &IGF,
+                                             llvm::Value *fnPtr,
+                                             CanSILFunctionType fnType);
+
+    /// Return the actual function pointer.
+    llvm::Value *getPointer() const { return Value; }
+
+    /// Given that this value is known to have been constructed from
+    /// a direct function, return the function pointer.
+    llvm::Constant *getDirectPointer() const {
+      return cast<llvm::Constant>(Value);
+    }
+
+    llvm::FunctionType *getFunctionType() const {
+      return cast<llvm::FunctionType>(
+                                  Value->getType()->getPointerElementType());
+    }
+
+    const Signature &getSignature() const {
+      return Sig;
+    }
+
+    llvm::CallingConv::ID getCallingConv() const {
+      return Sig.getCallingConv();
+    }
+
+    llvm::AttributeSet getAttributes() const {
+      return Sig.getAttributes();
+    }
+    llvm::AttributeSet &getMutableAttributes() & {
+      return Sig.getMutableAttributes();
+    }
+
+    ForeignFunctionInfo getForeignInfo() const {
+      return Sig.getForeignInfo();
+    }
+
+    llvm::Value *getExplosionValue(IRGenFunction &IGF,
+                                   CanSILFunctionType fnType) const;
+  };
+
+  class Callee {
+    CalleeInfo Info;
+
+    /// The actual function pointer to invoke.
+    FunctionPointer Fn;
+
+    /// The first data pointer required by the function invocation.
+    llvm::Value *FirstData;
+
+    /// The second data pointer required by the function invocation.
+    llvm::Value *SecondData;
+
+  public:
+    Callee(const Callee &other) = delete;
+    Callee &operator=(const Callee &other) = delete;
+
+    Callee(Callee &&other) = default;
+    Callee &operator=(Callee &&other) = default;
+
+    Callee(CalleeInfo &&info, const FunctionPointer &fn,
+           llvm::Value *firstData = nullptr,
+           llvm::Value *secondData = nullptr);
+
     SILFunctionTypeRepresentation getRepresentation() const {
-      return OrigFnType->getRepresentation();
+      return Info.OrigFnType->getRepresentation();
     }
 
-    CanSILFunctionType getOrigFunctionType() const { return OrigFnType; }
-    CanSILFunctionType getSubstFunctionType() const { return SubstFnType; }
+    CanSILFunctionType getOrigFunctionType() const {
+      return Info.OrigFnType;
+    }
+    CanSILFunctionType getSubstFunctionType() const {
+      return Info.SubstFnType;
+    }
 
-    bool hasSubstitutions() const { return !Substitutions.empty(); }
-    SubstitutionList getSubstitutions() const { return Substitutions; }
+    bool hasSubstitutions() const { return !Info.Substitutions.empty(); }
+    SubstitutionList getSubstitutions() const { return Info.Substitutions; }
 
-    llvm::Value *getFunction() const { return FnPtr; }
+    const FunctionPointer &getFunctionPointer() const { return Fn; }
 
     llvm::FunctionType *getLLVMFunctionType() {
-      return cast<llvm::FunctionType>(FnPtr->getType()->getPointerElementType());
+      return Fn.getFunctionType();
     }
 
-    const ForeignFunctionInfo &getForeignInfo() const {
-      return ForeignInfo;
+    llvm::AttributeSet getAttributes() const {
+      return Fn.getAttributes();
+    }
+    llvm::AttributeSet &getMutableAttributes() & {
+      return Fn.getMutableAttributes();
     }
 
-    /// Return the function pointer as an i8*.
-    llvm::Value *getOpaqueFunctionPointer(IRGenFunction &IGF) const;
+    ForeignFunctionInfo getForeignInfo() const {
+      return Fn.getForeignInfo();
+    }
 
-    /// Return the function pointer as an appropriate pointer-to-function.
-    llvm::Value *getFunctionPointer() const { return FnPtr; }
+    /// If this callee has a value for the Swift context slot, return
+    /// it; otherwise return non-null.
+    llvm::Value *getSwiftContext() const;
 
-    /// Is it possible that this function requires a non-null data pointer?
-    bool hasDataPointer() const { return DataPtr != nullptr; }
+    /// Given that this callee is a block, return the block pointer.
+    llvm::Value *getBlockObject() const;
 
-    /// Return the data pointer as a %swift.refcounted*.
-    llvm::Value *getDataPointer(IRGenFunction &IGF) const;
+    /// Given that this callee is an ObjC method, return the receiver
+    /// argument.  This might not be 'self' anymore.
+    llvm::Value *getObjCMethodReceiver() const;
+
+    /// Given that this callee is an ObjC method, return the receiver
+    /// argument.  This might not be 'self' anymore.
+    llvm::Value *getObjCMethodSelector() const;
   };
 
 } // end namespace irgen

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -1063,18 +1063,23 @@ void SignatureExpansion::expand(SILParameterInfo param) {
   llvm_unreachable("bad parameter convention");
 }
 
-/// Should the given self parameter be given the special treatment
-/// for self parameters?
+/// Does the given function type have a self parameter that should be
+/// given the special treatment for self parameters?
 ///
 /// It's important that this only return true for things that are
 /// passed as a single pointer.
-bool irgen::isSelfContextParameter(SILParameterInfo param) {
+bool irgen::hasSelfContextParameter(CanSILFunctionType fnType) {
+  if (!fnType->hasSelfParam())
+    return false;
+
+  SILParameterInfo param = fnType->getSelfParameter();
+
   // All the indirect conventions pass a single pointer.
   if (param.isFormalIndirect()) {
     return true;
   }
 
-  // Direct conventions depends on the type.
+  // Direct conventions depend on the type.
   CanType type = param.getType();
 
   // Thick or @objc metatypes (but not existential metatypes).
@@ -1103,8 +1108,7 @@ void SignatureExpansion::expandParameters() {
   // context if it has pointer representation.
   auto params = FnType->getParameters();
   bool hasSelfContext = false;
-  if (FnType->hasSelfParam() &&
-      isSelfContextParameter(FnType->getSelfParameter())) {
+  if (hasSelfContextParameter(FnType)) {
     hasSelfContext = true;
     params = params.drop_back();
   }
@@ -1187,7 +1191,8 @@ llvm::Type *SignatureExpansion::expandSignatureTypes() {
   llvm_unreachable("bad abstract calling convention");
 }
 
-Signature Signature::get(IRGenModule &IGM, CanSILFunctionType formalType) {
+Signature Signature::getUncached(IRGenModule &IGM,
+                                 CanSILFunctionType formalType) {
   GenericContextScope scope(IGM, formalType->getGenericSignature());
   SignatureExpansion expansion(IGM, formalType);
   llvm::Type *resultType = expansion.expandSignatureTypes();
@@ -1201,24 +1206,14 @@ Signature Signature::get(IRGenModule &IGM, CanSILFunctionType formalType) {
            (formalType->getLanguage() == SILFunctionLanguage::C) &&
          "C function type without C function info");
 
+  auto callingConv = expandCallingConv(IGM, formalType->getRepresentation());
+
   Signature result;
   result.Type = llvmType;
+  result.CallingConv = callingConv;
   result.Attributes = expansion.Attrs;
   result.ForeignInfo = expansion.ForeignInfo;
   return result;
-}
-
-/// Return this function pointer, bitcasted to an i8*.
-llvm::Value *Callee::getOpaqueFunctionPointer(IRGenFunction &IGF) const {
-  if (FnPtr->getType() == IGF.IGM.Int8PtrTy)
-    return FnPtr;
-  return IGF.Builder.CreateBitCast(FnPtr, IGF.IGM.Int8PtrTy);
-}
-
-/// Return this data pointer.
-llvm::Value *Callee::getDataPointer(IRGenFunction &IGF) const {
-  if (hasDataPointer()) return DataPtr;
-  return IGF.IGM.RefCountedNull;
 }
 
 void irgen::extractScalarResults(IRGenFunction &IGF, llvm::Type *bodyType,
@@ -1300,24 +1295,13 @@ void CallEmission::emitToUnmappedMemory(Address result) {
   assert(LastArgWritten == 1 && "emitting unnaturally to indirect result");
 
   Args[0] = result.getAddress();
-  addIndirectResultAttributes(IGF.IGM, Attrs, 0, true);
+  addIndirectResultAttributes(IGF.IGM, CurCallee.getMutableAttributes(),
+                              0, true);
 #ifndef NDEBUG
   LastArgWritten = 0; // appease an assert
 #endif
   
   emitCallSite();
-}
-
-// FIXME: This doesn't belong on IGF.
-llvm::CallSite CallEmission::emitInvoke(llvm::CallingConv::ID convention,
-                                        llvm::Value *fn,
-                                        ArrayRef<llvm::Value*> args,
-                                        const llvm::AttributeSet &attrs) {
-  // TODO: exceptions!
-  llvm::CallInst *call = IGF.Builder.CreateCall(fn, args);
-  call->setAttributes(attrs);
-  call->setCallingConv(convention);
-  return call;
 }
 
 /// The private routine to ultimately emit a call or invoke instruction.
@@ -1326,14 +1310,9 @@ llvm::CallSite CallEmission::emitCallSite() {
   assert(!EmittedCall);
   EmittedCall = true;
 
-  // Determine the calling convention.
-  // FIXME: collect attributes in the CallEmission.
-  auto cc = expandCallingConv(IGF.IGM, getCallee().getRepresentation());
-
   // Make the call and clear the arguments array.
-  auto fnPtr = getCallee().getFunctionPointer();
-  auto fnPtrTy = cast<llvm::PointerType>(fnPtr->getType());
-  auto fnTy = cast<llvm::FunctionType>(fnPtrTy->getElementType());
+  const auto &fn = getCallee().getFunctionPointer();
+  auto fnTy = fn.getFunctionType();
 
   // Coerce argument types for those cases where the IR type required
   // by the ABI differs from the type used within the function body.
@@ -1345,12 +1324,20 @@ llvm::CallSite CallEmission::emitCallSite() {
       Args[i] = IGF.coerceValue(Args[i], paramTy, IGF.IGM.DataLayout);
   }
 
-  llvm::CallSite call = emitInvoke(cc, fnPtr, Args,
-                                   llvm::AttributeSet::get(fnPtr->getContext(),
-                                                           Attrs));
+  // TODO: exceptions!
+  auto call = IGF.Builder.CreateCall(fn, Args);
+
   Args.clear();
 
   // Return.
+  return call;
+}
+
+llvm::CallInst *IRBuilder::CreateCall(const FunctionPointer &fn,
+                                      ArrayRef<llvm::Value*> args) {
+  llvm::CallInst *call = CreateCall(fn.getPointer(), args);
+  call->setAttributes(fn.getAttributes());
+  call->setCallingConv(fn.getCallingConv());
   return call;
 }
 
@@ -1442,13 +1429,13 @@ void CallEmission::emitToExplosion(Explosion &out) {
 
 CallEmission::CallEmission(CallEmission &&other)
   : IGF(other.IGF),
-    Attrs(other.Attrs),
     Args(std::move(other.Args)),
     CurCallee(std::move(other.CurCallee)),
     LastArgWritten(other.LastArgWritten),
     EmittedCall(other.EmittedCall) {
   // Prevent other's destructor from asserting.
-  other.invalidate();
+  LastArgWritten = 0;
+  EmittedCall = true;
 }
 
 CallEmission::~CallEmission() {
@@ -1456,11 +1443,84 @@ CallEmission::~CallEmission() {
   assert(EmittedCall);
 }
 
-void CallEmission::invalidate() {
-  LastArgWritten = 0;
-  EmittedCall = true;
+Callee::Callee(CalleeInfo &&info, const FunctionPointer &fn,
+               llvm::Value *firstData, llvm::Value *secondData)
+    : Info(std::move(info)), Fn(fn),
+      FirstData(firstData), SecondData(secondData) {
+
+#ifndef NDEBUG
+  // We should have foreign info if it's a foreign call.
+  assert((Fn.getForeignInfo().ClangInfo != nullptr) ==
+         (Info.OrigFnType->getLanguage() == SILFunctionLanguage::C));
+
+  // We should have the right data values for the representation.
+  switch (Info.OrigFnType->getRepresentation()) {
+  case SILFunctionTypeRepresentation::ObjCMethod:
+    assert(FirstData && SecondData);
+    break;
+  case SILFunctionTypeRepresentation::Method:
+  case SILFunctionTypeRepresentation::WitnessMethod:
+    assert((FirstData != nullptr) == hasSelfContextParameter(Info.OrigFnType));
+    assert(!SecondData);
+    break;
+  case SILFunctionTypeRepresentation::Thick:
+  case SILFunctionTypeRepresentation::Block:
+    assert(FirstData && !SecondData);
+    break;
+  case SILFunctionTypeRepresentation::Thin:
+  case SILFunctionTypeRepresentation::Closure:
+  case SILFunctionTypeRepresentation::CFunctionPointer:
+    assert(!FirstData && !SecondData);
+    break;
+  }
+#endif
+
 }
 
+llvm::Value *Callee::getSwiftContext() const {
+  switch (Info.OrigFnType->getRepresentation()) {
+  case SILFunctionTypeRepresentation::Block:
+  case SILFunctionTypeRepresentation::ObjCMethod:
+  case SILFunctionTypeRepresentation::CFunctionPointer:
+  case SILFunctionTypeRepresentation::Thin:
+  case SILFunctionTypeRepresentation::Closure:
+    return nullptr;
+
+  case SILFunctionTypeRepresentation::WitnessMethod:
+  case SILFunctionTypeRepresentation::Method:
+    // This may or may not be null.
+    return FirstData;
+
+  case SILFunctionTypeRepresentation::Thick:
+    assert(FirstData && "no context value set on callee");
+    return FirstData;
+  }
+  llvm_unreachable("bad representation");
+}
+
+llvm::Value *Callee::getBlockObject() const {
+  assert(Info.OrigFnType->getRepresentation() ==
+           SILFunctionTypeRepresentation::Block &&
+         "not a block");
+  assert(FirstData && "no block object set on callee");
+  return FirstData;
+}
+
+llvm::Value *Callee::getObjCMethodReceiver() const {
+  assert(Info.OrigFnType->getRepresentation() ==
+           SILFunctionTypeRepresentation::ObjCMethod &&
+         "not a method");
+  assert(FirstData && "no receiver set on callee");
+  return FirstData;
+}
+
+llvm::Value *Callee::getObjCMethodSelector() const {
+  assert(Info.OrigFnType->getRepresentation() ==
+           SILFunctionTypeRepresentation::ObjCMethod &&
+         "not a method");
+  assert(SecondData && "no selector set on callee");
+  return SecondData;
+}
 
 /// Set up this emitter afresh from the current callee specs.
 void CallEmission::setFromCallee() {
@@ -1475,7 +1535,6 @@ void CallEmission::setFromCallee() {
   LastArgWritten = numArgs;
 
   auto fnType = CurCallee.getOrigFunctionType();
-  Attrs = Signature::get(IGF.IGM, fnType).getAttributes();
 
   if (fnType->getRepresentation()
         == SILFunctionTypeRepresentation::WitnessMethod) {
@@ -1485,9 +1544,7 @@ void CallEmission::setFromCallee() {
     }
   }
 
-  llvm::Value *contextPtr = nullptr;
-  if (CurCallee.hasDataPointer())
-    contextPtr = CurCallee.getDataPointer(IGF);
+  llvm::Value *contextPtr = CurCallee.getSwiftContext();
 
   // Add the error result if we have one.
   if (fnType->hasErrorResult()) {
@@ -1496,11 +1553,11 @@ void CallEmission::setFromCallee() {
     SILFunctionConventions fnConv(fnType, IGF.getSILModule());
     Address errorResultSlot = IGF.getErrorResultSlot(fnConv.getSILErrorType());
 
-    // TODO: Add swift_error attribute.
     assert(LastArgWritten > 0);
     Args[--LastArgWritten] = errorResultSlot.getAddress();
     addAttribute(LastArgWritten + 1, llvm::Attribute::NoCapture);
-    IGF.IGM.addSwiftErrorAttributes(Attrs, LastArgWritten);
+    IGF.IGM.addSwiftErrorAttributes(CurCallee.getMutableAttributes(),
+                                    LastArgWritten);
 
     // Fill in the context pointer if necessary.
     if (!contextPtr) {
@@ -1512,11 +1569,10 @@ void CallEmission::setFromCallee() {
   // (Note that we're emitting backwards, so this correctly goes
   // *before* the error pointer.)
   if (contextPtr) {
-    assert(fnType->getRepresentation() != SILFunctionTypeRepresentation::Block
-           && "block function should not claimed to have data pointer");
     assert(LastArgWritten > 0);
     Args[--LastArgWritten] = contextPtr;
-    IGF.IGM.addSwiftSelfAttributes(Attrs, LastArgWritten);
+    IGF.IGM.addSwiftSelfAttributes(CurCallee.getMutableAttributes(),
+                                   LastArgWritten);
   }
 }
 
@@ -1788,25 +1844,18 @@ static void externalizeArguments(IRGenFunction &IGF, const Callee &callee,
   // corresponds to a logical parameter from params.
   unsigned firstParam = 0;
 
-  auto claimNextDirect = [&] {
-    assert(FI.arg_begin()[firstParam].info.isDirect());
-    assert(!FI.arg_begin()[firstParam].info.getPaddingType());
-    out.add(in.claimNext());
-    firstParam++;
-  };
-
   // Handle the ObjC prefix.
   if (callee.getRepresentation() == SILFunctionTypeRepresentation::ObjCMethod) {
-    // The first two parameters are pointers, and we make some
-    // simplifying assumptions.
-    claimNextDirect();
-    claimNextDirect();
+    // Ignore both the logical and the physical parameters associated
+    // with self and _cmd.
+    firstParam += 2;
     params = params.drop_back();
 
   // Or the block prefix.
   } else if (fnType->getRepresentation()
                 == SILFunctionTypeRepresentation::Block) {
-    claimNextDirect();
+    // Ignore the physical block-object parameter.
+    firstParam += 1;
   }
 
   for (unsigned i = firstParam, e = FI.arg_size(); i != e; ++i) {
@@ -2057,19 +2106,35 @@ void irgen::emitForeignParameter(IRGenFunction &IGF, Explosion &params,
   }
 }
 
+
 /// Add a new set of arguments to the function.
-void CallEmission::setArgs(Explosion &arg, WitnessMetadata *witnessMetadata) {
+void CallEmission::setArgs(Explosion &original,
+                           WitnessMetadata *witnessMetadata) {
   // Convert arguments to a representation appropriate to the calling
   // convention.
-  Explosion adjustedArg;
-  
+  Explosion adjusted;
+
+  auto origCalleeType = CurCallee.getOrigFunctionType();
+  SILFunctionConventions fnConv(origCalleeType, IGF.getSILModule());
+
+  // Pass along the indirect result pointers.
+  original.transferInto(adjusted, fnConv.getNumIndirectSILResults());
+
+  // Translate the formal arguments and handle any special arguments.
   switch (getCallee().getRepresentation()) {
-  case SILFunctionTypeRepresentation::CFunctionPointer:
   case SILFunctionTypeRepresentation::ObjCMethod:
-  case SILFunctionTypeRepresentation::Block: {
-    externalizeArguments(IGF, getCallee(), arg, adjustedArg);
+    adjusted.add(getCallee().getObjCMethodReceiver());
+    adjusted.add(getCallee().getObjCMethodSelector());
+    externalizeArguments(IGF, getCallee(), original, adjusted);
     break;
-  }
+
+  case SILFunctionTypeRepresentation::Block:
+    adjusted.add(getCallee().getBlockObject());
+    LLVM_FALLTHROUGH;
+
+  case SILFunctionTypeRepresentation::CFunctionPointer:
+    externalizeArguments(IGF, getCallee(), original, adjusted);
+    break;
 
   case SILFunctionTypeRepresentation::WitnessMethod:
     assert(witnessMetadata);
@@ -2085,45 +2150,42 @@ void CallEmission::setArgs(Explosion &arg, WitnessMetadata *witnessMetadata) {
   case SILFunctionTypeRepresentation::Method:
   case SILFunctionTypeRepresentation::Thin:
   case SILFunctionTypeRepresentation::Thick: {
-    auto origCalleeType = getCallee().getOrigFunctionType();
-    SILFunctionConventions fnConv(origCalleeType, IGF.getSILModule());
-
-    // Pass along the indirect results.
-    arg.transferInto(adjustedArg, fnConv.getNumIndirectSILResults());
-
     // Check for value arguments that need to be passed indirectly.
     // But don't expect to see 'self' if it's been moved to the context
     // position.
     auto params = origCalleeType->getParameters();
-    if (origCalleeType->hasSelfParam() &&
-        isSelfContextParameter(origCalleeType->getSelfParameter())) {
+    if (hasSelfContextParameter(origCalleeType)) {
       params = params.drop_back();
     }
     for (auto param : params) {
-      addNativeArgument(IGF, arg, param, adjustedArg);
+      addNativeArgument(IGF, original, param, adjusted);
     }
 
-    // Anything else, just pass along.
-    adjustedArg.add(arg.claimAll());
+    // Anything else, just pass along.  This will include things like
+    // generic arguments.
+    adjusted.add(original.claimAll());
+
     break;
   }
   }
 
   // Add the given number of arguments.
-  assert(LastArgWritten >= adjustedArg.size());
+  assert(LastArgWritten >= adjusted.size());
 
-  size_t targetIndex = LastArgWritten - adjustedArg.size();
+  size_t targetIndex = LastArgWritten - adjusted.size();
   assert(targetIndex <= 1);
   LastArgWritten = targetIndex;
   
   auto argIterator = Args.begin() + targetIndex;
-  for (auto value : adjustedArg.claimAll()) {
+  for (auto value : adjusted.claimAll()) {
     *argIterator++ = value;
   }
 }
 
-void CallEmission::addAttribute(unsigned Index, llvm::Attribute::AttrKind Attr) {
-  Attrs = Attrs.addAttribute(IGF.IGM.LLVMContext, Index, Attr);
+void CallEmission::addAttribute(unsigned index,
+                                llvm::Attribute::AttrKind attr) {
+  auto &attrs = CurCallee.getMutableAttributes();
+  attrs = attrs.addAttribute(IGF.IGM.LLVMContext, index, attr);
 }
 
 /// Initialize an Explosion with the parameters of the current
@@ -2713,4 +2775,88 @@ void IRGenFunction::emitScalarReturn(SILType resultType, Explosion &result,
     resultAgg = coerceValue(resultAgg, ABIType, IGM.DataLayout);
 
   Builder.CreateRet(resultAgg);
+}
+
+/// Modify the given variable to hold a pointer whose type is the
+/// LLVM lowering of the given function type, and return the signature
+/// for the type.
+static Signature emitCastOfFunctionPointer(IRGenFunction &IGF,
+                                           llvm::Value *&fnPtr,
+                                           CanSILFunctionType fnType) {
+  // Figure out the function type.
+  auto sig = IGF.IGM.getSignature(fnType);
+
+  // Emit the cast.
+  fnPtr = IGF.Builder.CreateBitCast(fnPtr, sig.getType()->getPointerTo());
+
+  // Return the information.
+  return sig;
+}
+
+Callee irgen::getBlockPointerCallee(IRGenFunction &IGF,
+                                    llvm::Value *blockPtr,
+                                    CalleeInfo &&info) {
+  // Grab the block pointer and make it the first physical argument.
+  llvm::PointerType *blockPtrTy = IGF.IGM.ObjCBlockPtrTy;
+  auto castBlockPtr = IGF.Builder.CreateBitCast(blockPtr, blockPtrTy);
+
+  // Extract the invocation pointer for blocks.
+  auto blockStructTy = blockPtrTy->getElementType();
+  llvm::Value *invokeFnPtrPtr =
+    IGF.Builder.CreateStructGEP(blockStructTy, castBlockPtr, 3);
+  Address invokeFnPtrAddr(invokeFnPtrPtr, IGF.IGM.getPointerAlignment());
+  llvm::Value *invokeFnPtr = IGF.Builder.CreateLoad(invokeFnPtrAddr);
+
+  auto sig = emitCastOfFunctionPointer(IGF, invokeFnPtr, info.OrigFnType);
+
+  FunctionPointer fn(invokeFnPtr, sig);
+
+  return Callee(std::move(info), fn, blockPtr);
+}
+
+Callee irgen::getSwiftFunctionPointerCallee(IRGenFunction &IGF,
+                                            llvm::Value *fnPtr,
+                                            llvm::Value *dataPtr,
+                                            CalleeInfo &&calleeInfo) {
+  auto sig = emitCastOfFunctionPointer(IGF, fnPtr, calleeInfo.OrigFnType);
+
+  FunctionPointer fn(fnPtr, sig);
+
+  return Callee(std::move(calleeInfo), fn, dataPtr);
+}
+
+Callee irgen::getCFunctionPointerCallee(IRGenFunction &IGF,
+                                        llvm::Value *fnPtr,
+                                        CalleeInfo &&calleeInfo) {
+  auto sig = emitCastOfFunctionPointer(IGF, fnPtr, calleeInfo.OrigFnType);
+
+  FunctionPointer fn(fnPtr, sig);
+
+  return Callee(std::move(calleeInfo), fn);
+}
+
+FunctionPointer
+FunctionPointer::forDirect(IRGenModule &IGM, llvm::Constant *fnPtr,
+                           CanSILFunctionType fnType) {
+  return forDirect(fnPtr, IGM.getSignature(fnType));
+}
+
+FunctionPointer
+FunctionPointer::forExplosionValue(IRGenFunction &IGF, llvm::Value *fnPtr,
+                                   CanSILFunctionType fnType) {
+  // Bitcast out of an opaque pointer type.
+  assert(fnPtr->getType() == IGF.IGM.Int8PtrTy);
+  auto sig = emitCastOfFunctionPointer(IGF, fnPtr, fnType);
+
+  return FunctionPointer(fnPtr, sig);
+}
+
+llvm::Value *
+FunctionPointer::getExplosionValue(IRGenFunction &IGF,
+                                   CanSILFunctionType fnType) const {
+  // Bitcast to an opaque pointer type.
+  llvm::Value *fnPtr =
+    IGF.Builder.CreateBitCast(getPointer(), IGF.IGM.Int8PtrTy);
+
+  return fnPtr;
 }

--- a/lib/IRGen/GenCall.h
+++ b/lib/IRGen/GenCall.h
@@ -21,6 +21,7 @@
 #include <stdint.h>
 
 #include "swift/Basic/LLVM.h"
+#include "swift/AST/Types.h"
 #include "llvm/IR/CallingConv.h"
 
 namespace llvm {
@@ -36,14 +37,11 @@ namespace clang {
 }
 
 namespace swift {
-  enum class SILFunctionTypeRepresentation : uint8_t;
-  class SILParameterInfo;
-  class SILType;
-  class Substitution;
-
 namespace irgen {
   class Address;
   class Alignment;
+  class Callee;
+  class CalleeInfo;
   class Explosion;
   class ExplosionSchema;
   class ForeignFunctionInfo;
@@ -64,9 +62,9 @@ namespace irgen {
   llvm::CallingConv::ID expandCallingConv(IRGenModule &IGM,
                                      SILFunctionTypeRepresentation convention);
 
-  /// Should the given self parameter be given the special treatment
-  /// for self parameters?
-  bool isSelfContextParameter(SILParameterInfo parameter);
+  /// Does the given function have a self parameter that should be given
+  /// the special treatment for self parameters?
+  bool hasSelfContextParameter(CanSILFunctionType fnType);
 
   /// Add function attributes to an attribute set for a byval argument.
   void addByvalArgumentAttributes(IRGenModule &IGM,
@@ -112,7 +110,16 @@ namespace irgen {
   void extractScalarResults(IRGenFunction &IGF, llvm::Type *bodyType,
                             llvm::Value *call, Explosion &out);
 
+  Callee getBlockPointerCallee(IRGenFunction &IGF, llvm::Value *blockPtr,
+                               CalleeInfo &&info);
 
+  Callee getCFunctionPointerCallee(IRGenFunction &IGF, llvm::Value *fnPtr,
+                                   CalleeInfo &&info);
+
+  Callee getSwiftFunctionPointerCallee(IRGenFunction &IGF,
+                                       llvm::Value *fnPtr,
+                                       llvm::Value *contextPtr,
+                                       CalleeInfo &&info);
 } // end namespace irgen
 } // end namespace swift
 

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -62,6 +62,7 @@
 #include "IRGenMangler.h"
 #include "IRGenModule.h"
 #include "LoadableTypeInfo.h"
+#include "Signature.h"
 
 using namespace swift;
 using namespace irgen;
@@ -1895,11 +1896,11 @@ llvm::Function *IRGenModule::getAddrOfSILFunction(SILFunction *f,
     IRGen.addLazyFunction(f);
   }
 
-  llvm::AttributeSet attrs;
-  llvm::FunctionType *fnType = getFunctionType(f->getLoweredFunctionType(),
-                                               attrs);
+  Signature signature = getSignature(f->getLoweredFunctionType());
+  llvm::FunctionType *fnType = signature.getType();
+  auto cc = signature.getCallingConv();
+  auto attrs = signature.getAttributes();
 
-  auto cc = expandCallingConv(*this, f->getRepresentation());
   LinkInfo link = LinkInfo::get(*this, entity, forDefinition);
 
   if (f->getInlineStrategy() == NoInline) {

--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -86,6 +86,7 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/ADT/StringSwitch.h"
 
+#include "Callee.h"
 #include "ConstantBuilder.h"
 #include "EnumPayload.h"
 #include "Explosion.h"
@@ -592,7 +593,7 @@ Signature FuncSignatureInfo::getSignature(IRGenModule &IGM) const {
     return TheSignature;
 
   // Update the cache and return.
-  TheSignature = Signature::get(IGM, FormalType);
+  TheSignature = Signature::getUncached(IGM, FormalType);
   assert(TheSignature.isValid());
   return TheSignature;
 }
@@ -614,6 +615,12 @@ getFuncSignatureInfoForLowered(IRGenModule &IGM, CanSILFunctionType type) {
     return ti.as<FuncTypeInfo>();
   }
   llvm_unreachable("bad function type representation");
+}
+
+Signature
+IRGenModule::getSignature(CanSILFunctionType type) {
+  auto &sigInfo = getFuncSignatureInfoForLowered(*this, type);
+  return sigInfo.getSignature(*this);
 }
 
 llvm::FunctionType *
@@ -706,17 +713,16 @@ static CanType getArgumentLoweringType(CanType type,
 static llvm::Function *emitPartialApplicationForwarder(IRGenModule &IGM,
                                    llvm::Function *staticFnPtr,
                                    bool calleeHasContext,
-                                   llvm::Type *fnTy,
-                                   const llvm::AttributeSet &origAttrs,
+                                   const Signature &origSig,
                                    CanSILFunctionType origType,
                                    CanSILFunctionType substType,
                                    CanSILFunctionType outType,
                                    SubstitutionList subs,
                                    HeapLayout const *layout,
                                    ArrayRef<ParameterConvention> conventions) {
-  llvm::AttributeSet outAttrs;
-
-  llvm::FunctionType *fwdTy = IGM.getFunctionType(outType, outAttrs);
+  auto outSig = IGM.getSignature(outType);
+  llvm::AttributeSet outAttrs = outSig.getAttributes();
+  llvm::FunctionType *fwdTy = outSig.getType();
   SILFunctionConventions outConv(outType, IGM.getSILModule());
 
   StringRef FnName;
@@ -730,8 +736,7 @@ static llvm::Function *emitPartialApplicationForwarder(IRGenModule &IGM,
   llvm::Function *fwd =
     llvm::Function::Create(fwdTy, llvm::Function::InternalLinkage,
                            llvm::StringRef(thunkName), &IGM.Module);
-  fwd->setCallingConv(
-      expandCallingConv(IGM, SILFunctionTypeRepresentation::Thick));
+  fwd->setCallingConv(outSig.getCallingConv());
 
   auto initialAttrs = IGM.constructInitialAttributes();
   // Merge initialAttrs with outAttrs.
@@ -940,9 +945,7 @@ static llvm::Function *emitPartialApplicationForwarder(IRGenModule &IGM,
   }
 
   auto haveContextArgument =
-      calleeHasContext ||
-      (origType->hasSelfParam() &&
-       isSelfContextParameter(origType->getSelfParameter()));
+      calleeHasContext || hasSelfContextParameter(origType);
 
   // Witness method calls expect self, followed by the self type followed by,
   // the witness table at the end of the parameter list. But polymorphic
@@ -1000,8 +1003,7 @@ static llvm::Function *emitPartialApplicationForwarder(IRGenModule &IGM,
     if (haveContextArgument)
       argIndex += polyArgs.size();
 
-    llvm::Type *expectedArgTy =
-        fnTy->getPointerElementType()->getFunctionParamType(argIndex);
+    llvm::Type *expectedArgTy = origSig.getType()->getParamType(argIndex);
 
     llvm::Value *argValue;
     if (isIndirectFormalParameter(argConvention)) {
@@ -1146,6 +1148,7 @@ static llvm::Function *emitPartialApplicationForwarder(IRGenModule &IGM,
 
   // Derive the callee function pointer.  If we found a function
   // pointer statically, great.
+  auto fnTy = origSig.getType()->getPointerTo();
   llvm::Value *fnPtr;
   if (staticFnPtr) {
     assert(staticFnPtr->getType() == fnTy && "static function type mismatch?!");
@@ -1222,9 +1225,9 @@ static llvm::Function *emitPartialApplicationForwarder(IRGenModule &IGM,
     call->setCallingConv(staticFnPtr->getCallingConv());
   } else {
     // Otherwise, use the default attributes for the dynamic type.
-    call->setAttributes(origAttrs);
+    call->setAttributes(origSig.getAttributes());
     // Use the calling convention of the partially applied function type.
-    call->setCallingConv(expandCallingConv(IGM, origType->getRepresentation()));
+    call->setCallingConv(origSig.getCallingConv());
   }
   if (addressesToDeallocate.empty() && !needsAllocas &&
       (!consumesContext || !dependsOnContextLifetime))
@@ -1288,7 +1291,7 @@ static llvm::Function *emitPartialApplicationForwarder(IRGenModule &IGM,
 /// set of argument values.
 void irgen::emitFunctionPartialApplication(IRGenFunction &IGF,
                                            SILFunction &SILFn,
-                                           llvm::Value *fnPtr,
+                                           const FunctionPointer &fn,
                                            llvm::Value *fnContext,
                                            Explosion &args,
                                            ArrayRef<SILParameterInfo> params,
@@ -1306,6 +1309,8 @@ void irgen::emitFunctionPartialApplication(IRGenFunction &IGF,
   SmallVector<const TypeInfo *, 4> argTypeInfos;
   SmallVector<SILType, 4> argValTypes;
   SmallVector<ParameterConvention, 4> argConventions;
+
+  llvm::Value *fnPtr = fn.getPointer();
 
   // Reserve space for polymorphic bindings.
   SubstitutionMap subMap;
@@ -1461,13 +1466,11 @@ void irgen::emitFunctionPartialApplication(IRGenFunction &IGF,
     assert(bindings.empty());
     assert(args.size() == 1);
 
-    llvm::AttributeSet attrs;
-    auto fnPtrTy = IGF.IGM.getFunctionType(origType, attrs)
-      ->getPointerTo();
+    auto origSig = IGF.IGM.getSignature(origType);
 
     llvm::Function *forwarder =
       emitPartialApplicationForwarder(IGF.IGM, staticFn, fnContext != nullptr,
-                                      fnPtrTy, attrs, origType, substType,
+                                      origSig, origType, substType,
                                       outType, subs, nullptr, argConventions);
     llvm::Value *forwarderValue =
       IGF.Builder.CreateBitCast(forwarder, IGF.IGM.Int8PtrTy);
@@ -1542,15 +1545,12 @@ void irgen::emitFunctionPartialApplication(IRGenFunction &IGF,
   assert(args.empty() && "unused args in partial application?!");
   
   // Create the forwarding stub.
-  llvm::AttributeSet attrs;
-  auto fnPtrTy = IGF.IGM.getFunctionType(origType, attrs)
-    ->getPointerTo();
+  auto origSig = IGF.IGM.getSignature(origType);
 
   llvm::Function *forwarder = emitPartialApplicationForwarder(IGF.IGM,
                                                               staticFn,
                                                           fnContext != nullptr,
-                                                              fnPtrTy,
-                                                              attrs,
+                                                              origSig,
                                                               origType,
                                                               substType,
                                                               outType,
@@ -1638,7 +1638,7 @@ static llvm::Function *emitBlockDisposeHelper(IRGenModule &IGM,
 void irgen::emitBlockHeader(IRGenFunction &IGF,
                             Address storage,
                             CanSILBlockStorageType blockTy,
-                            llvm::Function *invokeFunction,
+                            llvm::Constant *invokeFunction,
                             CanSILFunctionType invokeTy,
                             ForeignFunctionInfo foreignInfo) {
   auto &storageTL

--- a/lib/IRGen/GenFunc.h
+++ b/lib/IRGen/GenFunc.h
@@ -41,7 +41,7 @@ namespace irgen {
   void emitBlockHeader(IRGenFunction &IGF,
                        Address storage,
                        CanSILBlockStorageType blockTy,
-                       llvm::Function *invokeFunction,
+                       llvm::Constant *invokeFunction,
                        CanSILFunctionType invokeTy,
                        ForeignFunctionInfo foreignInfo);
 
@@ -49,7 +49,7 @@ namespace irgen {
   /// partial set of argument values.
   void emitFunctionPartialApplication(IRGenFunction &IGF,
                                       SILFunction &SILFn,
-                                      llvm::Value *fnPtr,
+                                      const FunctionPointer &fnPtr,
                                       llvm::Value *fnContext,
                                       Explosion &args,
                                       ArrayRef<SILParameterInfo> argTypes,

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -4611,12 +4611,12 @@ namespace {
 } // end anonymous namespace
 
 /// Load the correct virtual function for the given class method.
-llvm::Value *irgen::emitVirtualMethodValue(IRGenFunction &IGF,
-                                           llvm::Value *base,
-                                           SILType baseType,
-                                           SILDeclRef method,
-                                           CanSILFunctionType methodType,
-                                           bool useSuperVTable) {
+FunctionPointer irgen::emitVirtualMethodValue(IRGenFunction &IGF,
+                                              llvm::Value *base,
+                                              SILType baseType,
+                                              SILDeclRef method,
+                                              CanSILFunctionType methodType,
+                                              bool useSuperVTable) {
   AbstractFunctionDecl *methodDecl
     = cast<AbstractFunctionDecl>(method.getDecl());
 
@@ -4661,14 +4661,16 @@ llvm::Value *irgen::emitVirtualMethodValue(IRGenFunction &IGF,
 
   // Use the type of the method we were type-checked against, not the
   // type of the overridden method.
-  llvm::AttributeSet attrs;
-  auto fnTy = IGF.IGM.getFunctionType(methodType, attrs)->getPointerTo();
+  auto sig = IGF.IGM.getSignature(methodType);
 
   auto declaringClass = cast<ClassDecl>(overridden.getDecl()->getDeclContext());
   auto index = FindClassMethodIndex(IGF.IGM, declaringClass, overridden)
                  .getTargetIndex();
 
-  return emitInvariantLoadFromMetadataAtIndex(IGF, metadata, index, fnTy);
+  auto fnPtr = emitInvariantLoadFromMetadataAtIndex(IGF, metadata, index,
+                                             sig.getType()->getPointerTo());
+
+  return FunctionPointer(fnPtr, sig);
 }
 
 unsigned irgen::getVirtualMethodIndex(IRGenModule &IGM,

--- a/lib/IRGen/GenMeta.h
+++ b/lib/IRGen/GenMeta.h
@@ -42,6 +42,7 @@ namespace irgen {
   class ConstantReference;
   class Explosion;
   class FieldTypeInfo;
+  class FunctionPointer;
   class GenericTypeRequirements;
   class IRGenFunction;
   class IRGenModule;
@@ -229,12 +230,12 @@ namespace irgen {
 
   /// Given an instance pointer (or, for a static method, a class
   /// pointer), emit the callee for the given method.
-  llvm::Value *emitVirtualMethodValue(IRGenFunction &IGF,
-                                      llvm::Value *base,
-                                      SILType baseType,
-                                      SILDeclRef method,
-                                      CanSILFunctionType methodType,
-                                      bool useSuperVTable);
+  FunctionPointer emitVirtualMethodValue(IRGenFunction &IGF,
+                                         llvm::Value *base,
+                                         SILType baseType,
+                                         SILDeclRef method,
+                                         CanSILFunctionType methodType,
+                                         bool useSuperVTable);
 
   /// Get the offset of the given class method within the class's vtables.
   unsigned getVirtualMethodIndex(IRGenModule &IGM, SILDeclRef method);

--- a/lib/IRGen/GenObjC.cpp
+++ b/lib/IRGen/GenObjC.cpp
@@ -593,10 +593,10 @@ llvm::Constant *IRGenModule::getAddrOfObjCSelectorRef(SILDeclRef method) {
   return getAddrOfObjCSelectorRef(Selector(method).str());
 }
 
-static void emitSuperArgument(IRGenFunction &IGF, bool isInstanceMethod,
-                              llvm::Value *selfValue,
-                              Explosion &selfValues,
-                              SILType searchClass) {
+static llvm::Value *emitSuperArgument(IRGenFunction &IGF,
+                                      bool isInstanceMethod,
+                                      llvm::Value *selfValue,
+                                      CanType searchClass) {
   // Allocate an objc_super struct.
   Address super = IGF.createAlloca(IGF.IGM.ObjCSuperStructTy,
                                    IGF.IGM.getPointerAlignment(),
@@ -608,16 +608,14 @@ static void emitSuperArgument(IRGenFunction &IGF, bool isInstanceMethod,
   // Generate the search class object reference.
   llvm::Value *searchValue;
   if (isInstanceMethod) {
-    searchValue = emitClassHeapMetadataRef(IGF, searchClass.getSwiftRValueType(),
+    searchValue = emitClassHeapMetadataRef(IGF, searchClass,
                                            MetadataValueType::ObjCClass,
                                            /*allow uninitialized*/ true);
   } else {
-    ClassDecl *searchClassDecl =
-      searchClass.castTo<MetatypeType>().getInstanceType()
-        .getClassOrBoundGenericClass();
+    searchClass = cast<MetatypeType>(searchClass).getInstanceType();
+    ClassDecl *searchClassDecl = searchClass.getClassOrBoundGenericClass();
     if (doesClassMetadataRequireDynamicInitialization(IGF.IGM, searchClassDecl)) {
-      searchValue = emitClassHeapMetadataRef(IGF,
-                                             searchClass.castTo<MetatypeType>().getInstanceType(),
+      searchValue = emitClassHeapMetadataRef(IGF, searchClass,
                                              MetadataValueType::ObjCClass,
                                              /*allow uninitialized*/ true);
       searchValue = emitLoadOfObjCHeapMetadataRef(IGF, searchValue);
@@ -629,25 +627,16 @@ static void emitSuperArgument(IRGenFunction &IGF, bool isInstanceMethod,
   }
   
   // Store the receiver and class to the struct.
-  llvm::Value *selfIndices[2] = {
-    IGF.Builder.getInt32(0),
-    IGF.Builder.getInt32(0)
-  };
-  llvm::Value *selfAddr = IGF.Builder.CreateGEP(super.getAddress(),
-                                                selfIndices);
-  IGF.Builder.CreateStore(self, selfAddr, super.getAlignment());
+  Address selfAddr = IGF.Builder.CreateStructGEP(super, 0, Size(0));
+  IGF.Builder.CreateStore(self, selfAddr);
 
-  llvm::Value *searchIndices[2] = {
-    IGF.Builder.getInt32(0),
-    IGF.Builder.getInt32(1)
-  };
-  llvm::Value *searchAddr = IGF.Builder.CreateGEP(super.getAddress(),
-                                                  searchIndices);
-  IGF.Builder.CreateStore(searchValue, searchAddr, super.getAlignment());
+  Address searchAddr =
+    IGF.Builder.CreateStructGEP(super, 1, IGF.IGM.getPointerSize());
+  IGF.Builder.CreateStore(searchValue, searchAddr);
   
   // Pass a pointer to the objc_super struct to the messenger.
   // Project the ownership semantics of 'self' to the super argument.
-  selfValues.add(super.getAddress());
+  return super.getAddress();
 }
 
 static llvm::FunctionType *getMsgSendSuperTy(IRGenModule &IGM,
@@ -661,14 +650,11 @@ static llvm::FunctionType *getMsgSendSuperTy(IRGenModule &IGM,
   return llvm::FunctionType::get(fnTy->getReturnType(), args, fnTy->isVarArg());
 }
 
-/// Prepare a call using ObjC method dispatch without applying the 'self' and
-/// '_cmd' arguments.
-CallEmission irgen::prepareObjCMethodRootCall(IRGenFunction &IGF,
-                                              SILDeclRef method,
-                                              CanSILFunctionType origFnType,
-                                              CanSILFunctionType substFnType,
-                                              SubstitutionList subs,
-                                              ObjCMessageKind kind) {
+Callee irgen::getObjCMethodCallee(IRGenFunction &IGF,
+                                  const ObjCMethod &methodInfo,
+                                  llvm::Value *selfValue,
+                                  CalleeInfo &&info) {
+  SILDeclRef method = methodInfo.getMethod();
   assert((method.kind == SILDeclRef::Kind::Initializer
           || method.kind == SILDeclRef::Kind::Allocator
           || method.kind == SILDeclRef::Kind::Func
@@ -676,67 +662,46 @@ CallEmission irgen::prepareObjCMethodRootCall(IRGenFunction &IGF,
           || method.kind == SILDeclRef::Kind::Deallocator) &&
          "objc method call must be to a func/initializer/getter/setter/dtor");
 
-  ForeignFunctionInfo foreignInfo;
-  llvm::AttributeSet attrs;
-  auto fnTy = IGF.IGM.getFunctionType(origFnType, attrs, &foreignInfo);
-  bool indirectResult = foreignInfo.ClangInfo->getReturnInfo().isIndirect();
-  if (kind != ObjCMessageKind::Normal)
-    fnTy = getMsgSendSuperTy(IGF.IGM, fnTy, indirectResult);
+  auto kind = methodInfo.getMessageKind();
 
-  // Create the appropriate messenger function.
-  // FIXME: this needs to be target-specific.
-  llvm::Constant *messenger;
-  if (indirectResult && IGF.IGM.TargetInfo.ObjCUseStret) {
-    switch (kind) {
-    case ObjCMessageKind::Normal:
-      messenger = IGF.IGM.getObjCMsgSendStretFn();
-      break;
-
-    case ObjCMessageKind::Peer:
-      messenger = IGF.IGM.getObjCMsgSendSuperStretFn();
-      break;
-
-    case ObjCMessageKind::Super:
-      messenger = IGF.IGM.getObjCMsgSendSuperStret2Fn();
-      break;
-    }
-  } else {
-    switch (kind) {
-    case ObjCMessageKind::Normal:
-      messenger = IGF.IGM.getObjCMsgSendFn();
-      break;
-
-    case ObjCMessageKind::Peer:
-      messenger = IGF.IGM.getObjCMsgSendSuperFn();
-      break;
-
-    case ObjCMessageKind::Super:
-      messenger = IGF.IGM.getObjCMsgSendSuper2Fn();
-      break;
-    }
+  Signature sig = IGF.IGM.getSignature(info.OrigFnType);
+  bool indirectResult =
+    sig.getForeignInfo().ClangInfo->getReturnInfo().isIndirect();
+  if (kind != ObjCMessageKind::Normal) {
+    sig.setType(getMsgSendSuperTy(IGF.IGM, sig.getType(), indirectResult));
   }
 
-  // Cast the messenger to the right type.
-  messenger = llvm::ConstantExpr::getBitCast(messenger, fnTy->getPointerTo());
+  // Create the appropriate messenger function.
+  // FIXME: this needs to be target-specific.  Ask Clang for it!
+  llvm::Constant *messenger = [&]() -> llvm::Constant* {
+    if (indirectResult && IGF.IGM.TargetInfo.ObjCUseStret) {
+      switch (kind) {
+      case ObjCMessageKind::Normal:
+        return IGF.IGM.getObjCMsgSendStretFn();
 
-  CallEmission emission(IGF,
-                        Callee::forKnownFunction(origFnType,
-                                                 substFnType,
-                                                 subs,
-                                                 messenger, nullptr,
-                                                 foreignInfo));
-  return emission;
-}
+      case ObjCMessageKind::Peer:
+        return IGF.IGM.getObjCMsgSendSuperStretFn();
 
-/// Emit the 'self'/'super' and '_cmd' arguments for an ObjC method dispatch.
-void irgen::addObjCMethodCallImplicitArguments(IRGenFunction &IGF,
-                                               Explosion &args,
-                                               SILDeclRef method,
-                                               llvm::Value *self,
-                                               SILType searchType) {
-  // Compute the selector.
-  Selector selector(method);
-    
+      case ObjCMessageKind::Super:
+        return IGF.IGM.getObjCMsgSendSuperStret2Fn();
+      }
+    } else {
+      switch (kind) {
+      case ObjCMessageKind::Normal:
+        return IGF.IGM.getObjCMsgSendFn();
+
+      case ObjCMessageKind::Peer:
+        return IGF.IGM.getObjCMsgSendSuperFn();
+
+      case ObjCMessageKind::Super:
+        return IGF.IGM.getObjCMsgSendSuper2Fn();
+      }
+    }
+  }();
+
+  messenger = llvm::ConstantExpr::getBitCast(messenger,
+                                             sig.getType()->getPointerTo());
+
   // super.constructor references an instance method (even though the
   // decl is really a 'static' member). Similarly, destructors refer
   // to the instance method -dealloc.
@@ -745,15 +710,21 @@ void irgen::addObjCMethodCallImplicitArguments(IRGenFunction &IGF,
       || method.kind == SILDeclRef::Kind::Deallocator
       || method.getDecl()->isInstanceMember();
 
-  if (searchType) {
-    emitSuperArgument(IGF, isInstanceMethod, self, args, searchType);
+  llvm::Value *receiverValue;
+  if (auto searchType = methodInfo.getSearchType()) {
+    receiverValue =
+      emitSuperArgument(IGF, isInstanceMethod, selfValue,
+                        searchType.getSwiftRValueType());
   } else {
-    args.add(self);
+    receiverValue = selfValue;
   }
-  assert(args.size() == 1);
-  
-  // Add the selector value.
-  args.add(IGF.emitObjCSelectorRefLoad(selector.str()));
+
+  // Compute the selector.
+  Selector selector(method);
+  llvm::Value *selectorValue = IGF.emitObjCSelectorRefLoad(selector.str());
+
+  auto fn = FunctionPointer::forDirect(messenger, sig);
+  return Callee(std::move(info), fn, receiverValue, selectorValue);
 }
 
 /// Call [self allocWithZone: nil].
@@ -882,6 +853,10 @@ static llvm::Function *emitObjCPartialApplicationForwarder(IRGenModule &IGM,
   // Translate direct parameters passed indirectly.
   Explosion translatedParams;
 
+  // Add the formal indirect return here.
+  if (formalIndirectResult)
+    translatedParams.add(formalIndirectResult);
+
   // We already handled self.
   assert(origMethodType->hasSelfParam());
   auto origParamInfos = origMethodType->getParameters();
@@ -911,23 +886,11 @@ static llvm::Function *emitObjCPartialApplicationForwarder(IRGenModule &IGM,
   }
 
   // Prepare the call to the underlying method.
+  CallEmission emission(subIGF,
+                        getObjCMethodCallee(subIGF, method, self,
+                          CalleeInfo(origMethodType, origMethodType, {})));
   
-  CallEmission emission
-    = prepareObjCMethodRootCall(subIGF, method.getMethod(),
-                                origMethodType, origMethodType,
-                                SubstitutionList{},
-                                method.getMessageKind());
-  
-  Explosion args;
-
-  // Take care of formal indirect returns ourselves.
-  if (formalIndirectResult)
-    args.add(formalIndirectResult);
-
-  addObjCMethodCallImplicitArguments(subIGF, args, method.getMethod(), self,
-                                     method.getSearchType());
-  args.add(translatedParams.claimAll());
-  emission.setArgs(args);
+  emission.setArgs(translatedParams);
   
   // Cleanup that always has to occur after the function call.
   auto cleanup = [&]{

--- a/lib/IRGen/GenObjC.h
+++ b/lib/IRGen/GenObjC.h
@@ -32,7 +32,8 @@ namespace swift {
   class Substitution;
 
 namespace irgen {
-  class CallEmission;
+  class Callee;
+  class CalleeInfo;
   class ConstantArrayBuilder;
   class IRGenFunction;
   class IRGenModule;
@@ -83,18 +84,9 @@ namespace irgen {
     }
   };
 
-  CallEmission prepareObjCMethodRootCall(IRGenFunction &IGF,
-                                         SILDeclRef method,
-                                         CanSILFunctionType origFnType,
-                                         CanSILFunctionType substFnType,
-                                         SubstitutionList subs,
-                                         ObjCMessageKind kind);
-
-  void addObjCMethodCallImplicitArguments(IRGenFunction &IGF,
-                                          Explosion &emission,
-                                          SILDeclRef method,
-                                          llvm::Value *self,
-                                          SILType superSearchType);
+  /// Prepare a callee for an Objective-C method.
+  Callee getObjCMethodCallee(IRGenFunction &IGF, const ObjCMethod &method,
+                             llvm::Value *selfValue, CalleeInfo &&info);
 
   /// Emit a partial application of an Objective-C method to its 'self'
   /// argument.

--- a/lib/IRGen/GenProto.h
+++ b/lib/IRGen/GenProto.h
@@ -37,7 +37,7 @@ namespace swift {
 namespace irgen {
   class Address;
   class Explosion;
-  class CallEmission;
+  class FunctionPointer;
   class IRGenFunction;
   class IRGenModule;
   class MetadataPath;
@@ -53,12 +53,12 @@ namespace irgen {
   
   /// Extract the method pointer from an archetype's witness table
   /// as a function value.
-  void emitWitnessMethodValue(IRGenFunction &IGF,
-                              CanType baseTy,
-                              llvm::Value **baseMetadataCache,
-                              SILDeclRef member,
-                              ProtocolConformanceRef conformance,
-                              Explosion &out);
+  FunctionPointer emitWitnessMethodValue(IRGenFunction &IGF,
+                                         CanType baseTy,
+                                         llvm::Value **baseMetadataCache,
+                                         SILDeclRef member,
+                                         ProtocolConformanceRef conformance,
+                                         CanSILFunctionType fnType);
 
   /// Given a type T and an associated type X of some protocol P to
   /// which T conforms, return the type metadata for T.X.

--- a/lib/IRGen/IRBuilder.h
+++ b/lib/IRGen/IRBuilder.h
@@ -25,6 +25,7 @@
 
 namespace swift {
 namespace irgen {
+class FunctionPointer;
 
 typedef llvm::IRBuilder<> IRBuilderBase;
 
@@ -295,6 +296,9 @@ public:
     setCallingConvUsingCallee(Call);
     return Call;
   }
+
+  llvm::CallInst *CreateCall(const FunctionPointer &fn,
+                             ArrayRef<llvm::Value *> args);
 };
 
 } // end namespace irgen

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -126,6 +126,7 @@ namespace irgen {
   class LoadableTypeInfo;
   class NecessaryBindings;
   class ProtocolInfo;
+  class Signature;
   class TypeConverter;
   class TypeInfo;
   enum class ValueWitness : unsigned;
@@ -938,6 +939,7 @@ public:
   void finalizeClangCodeGen();
   void finishEmitAfterTopLevel();
 
+  Signature getSignature(CanSILFunctionType fnType);
   llvm::FunctionType *getFunctionType(CanSILFunctionType type,
                                       llvm::AttributeSet &attrs,
                                       ForeignFunctionInfo *foreignInfo=nullptr);

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -81,29 +81,6 @@ using namespace irgen;
 namespace {
 
 class LoweredValue;
-  
-/// Represents a statically-known function as a SIL thin function value.
-class StaticFunction {
-  /// The function reference.
-  llvm::Function *Function;
-
-  ForeignFunctionInfo ForeignInfo;
-
-  /// The function's native representation.
-  SILFunctionTypeRepresentation Rep;
-  
-public:
-  StaticFunction(llvm::Function *function, ForeignFunctionInfo foreignInfo,
-                 SILFunctionTypeRepresentation rep)
-    : Function(function), ForeignInfo(foreignInfo), Rep(rep)
-  {}
-  
-  llvm::Function *getFunction() const { return Function; }
-  SILFunctionTypeRepresentation getRepresentation() const { return Rep; }
-  const ForeignFunctionInfo &getForeignInfo() const { return ForeignInfo; }
-  
-  llvm::Value *getExplosionValue(IRGenFunction &IGF) const;
-};
 
 struct DynamicallyEnforcedAddress {
   Address Addr;
@@ -150,9 +127,8 @@ public:
     /// The special case of a single explosion.
     SingletonExplosion,
 
-    /// A value that represents a statically-known function symbol that
-    /// can be called directly, represented as a StaticFunction.
-    StaticFunction,
+    /// A value that represents a function pointer.
+    FunctionPointer,
 
     /// A value that represents an Objective-C method that must be called with
     /// a form of objc_msgSend.
@@ -176,7 +152,7 @@ private:
     case Kind::DynamicallyEnforcedAddress: return 3;
     case Kind::ExplosionVector: return 4;
     case Kind::SingletonExplosion: return 5;
-    case Kind::StaticFunction: return 6;
+    case Kind::FunctionPointer: return 6;
     case Kind::ObjCMethod: return 7;
     case Kind::EmptyExplosion: return -1;
     }
@@ -189,7 +165,7 @@ private:
                 DynamicallyEnforcedAddress,
                 ExplosionVector,
                 SingletonExplosion,
-                StaticFunction,
+                FunctionPointer,
                 ObjCMethod> Storage;
 
 public:
@@ -228,16 +204,16 @@ public:
     Storage.emplace<ContainedAddress>(kind, address);
   }
   
-  LoweredValue(StaticFunction &&staticFunction)
-      : kind(Kind::StaticFunction) {
-    Storage.emplace<StaticFunction>(kind, std::move(staticFunction));
+  LoweredValue(const FunctionPointer &fn)
+      : kind(Kind::FunctionPointer) {
+    Storage.emplace<FunctionPointer>(kind, fn);
   }
 
   LoweredValue(ObjCMethod &&objcMethod)
       : kind(Kind::ObjCMethod) {
     Storage.emplace<ObjCMethod>(kind, std::move(objcMethod));
   }
-  
+
   LoweredValue(Explosion &e) {
     auto elts = e.claimAll();
     if (elts.empty()) {
@@ -327,8 +303,8 @@ public:
     return Storage.get<SingletonExplosion>(kind);
   }
   
-  const StaticFunction &getStaticFunction() const {
-    return Storage.get<StaticFunction>(kind);
+  const FunctionPointer &getFunctionPointer() const {
+    return Storage.get<FunctionPointer>(kind);
   }
   
   const ObjCMethod &getObjCMethod() const {
@@ -337,14 +313,19 @@ public:
 
   /// Produce an explosion for this lowered value.  Note that many
   /// different storage kinds can be turned into an explosion.
-  Explosion getExplosion(IRGenFunction &IGF) const {
+  Explosion getExplosion(IRGenFunction &IGF, SILType type) const {
     Explosion e;
-    getExplosion(IGF, e);
+    getExplosion(IGF, type, e);
     return e;
   }
-  void getExplosion(IRGenFunction &IGF, Explosion &ex) const;
+  void getExplosion(IRGenFunction &IGF, SILType type, Explosion &ex) const;
 
-  llvm::Value *getSingletonExplosion(IRGenFunction &IGF) const;
+  /// Produce an explosion which is known to be a single value.
+  llvm::Value *getSingletonExplosion(IRGenFunction &IGF, SILType type) const;
+
+  /// Produce a callee from this value.
+  Callee getCallee(IRGenFunction &IGF, llvm::Value *selfValue,
+                   CalleeInfo &&calleeInfo) const;
 };
 
 using PHINodeVector = llvm::TinyPtrVector<llvm::PHINode*>;
@@ -466,15 +447,12 @@ public:
     setLoweredValue(v, LoweredValue(box));
   }
 
-  /// Create a new StaticFunction corresponding to the given SIL value.
-  void setLoweredStaticFunction(SILValue v,
-                                llvm::Function *f,
-                                SILFunctionTypeRepresentation rep,
-                                ForeignFunctionInfo foreignInfo) {
+  /// Map the given SIL value to a FunctionPointer value.
+  void setLoweredFunctionPointer(SILValue v, const FunctionPointer &fnPtr) {
     assert(v->getType().isObject() && "function for address value?!");
     assert(v->getType().is<SILFunctionType>() &&
            "function for non-function value?!");
-    setLoweredValue(v, StaticFunction{f, foreignInfo, rep});
+    setLoweredValue(v, fnPtr);
   }
 
   /// Create a new Objective-C method corresponding to the given SIL value.
@@ -565,18 +543,18 @@ public:
 
   /// Add the unmanaged LLVM values lowered from a SIL value to an explosion.
   void getLoweredExplosion(SILValue v, Explosion &e) {
-    getLoweredValue(v).getExplosion(*this, e);
+    getLoweredValue(v).getExplosion(*this, v->getType(), e);
   }
   /// Create an Explosion containing the unmanaged LLVM values lowered from a
   /// SIL value.
   Explosion getLoweredExplosion(SILValue v) {
-    return getLoweredValue(v).getExplosion(*this);
+    return getLoweredValue(v).getExplosion(*this, v->getType());
   }
 
   /// Return the single member of the lowered explosion for the
   /// given SIL value.
   llvm::Value *getLoweredSingletonExplosion(SILValue v) {
-    return getLoweredValue(v).getSingletonExplosion(*this);
+    return getLoweredValue(v).getSingletonExplosion(*this, v->getType());
   }
   
   LoweredBB &getLoweredBB(SILBasicBlock *bb) {
@@ -1048,11 +1026,8 @@ public:
 
 } // end anonymous namespace
 
-llvm::Value *StaticFunction::getExplosionValue(IRGenFunction &IGF) const {
-  return IGF.Builder.CreateBitCast(Function, IGF.IGM.Int8PtrTy);
-}
-
-void LoweredValue::getExplosion(IRGenFunction &IGF, Explosion &ex) const {
+void LoweredValue::getExplosion(IRGenFunction &IGF, SILType type,
+                                Explosion &ex) const {
   switch (kind) {
   case Kind::StackAddress:
   case Kind::ContainedAddress:
@@ -1074,10 +1049,11 @@ void LoweredValue::getExplosion(IRGenFunction &IGF, Explosion &ex) const {
     ex.add(Storage.get<OwnedAddress>(kind).getOwner());
     return;
 
-  case Kind::StaticFunction:
-    ex.add(Storage.get<StaticFunction>(kind).getExplosionValue(IGF));
+  case Kind::FunctionPointer:
+    ex.add(Storage.get<FunctionPointer>(kind)
+                  .getExplosionValue(IGF, type.castTo<SILFunctionType>()));
     return;
-      
+
   case Kind::ObjCMethod:
     ex.add(Storage.get<ObjCMethod>(kind).getExplosionValue(IGF));
     return;
@@ -1085,7 +1061,8 @@ void LoweredValue::getExplosion(IRGenFunction &IGF, Explosion &ex) const {
   llvm_unreachable("bad kind");
 }
 
-llvm::Value *LoweredValue::getSingletonExplosion(IRGenFunction &IGF) const {
+llvm::Value *LoweredValue::getSingletonExplosion(IRGenFunction &IGF,
+                                                 SILType type) const {
   switch (kind) {
   case Kind::StackAddress:
   case Kind::ContainedAddress:
@@ -1102,8 +1079,9 @@ llvm::Value *LoweredValue::getSingletonExplosion(IRGenFunction &IGF) const {
   case Kind::OwnedAddress:
     return Storage.get<OwnedAddress>(kind).getOwner();
       
-  case Kind::StaticFunction:
-    return Storage.get<StaticFunction>(kind).getExplosionValue(IGF);
+  case Kind::FunctionPointer:
+    return Storage.get<FunctionPointer>(kind)
+                  .getExplosionValue(IGF, type.castTo<SILFunctionType>());
 
   case Kind::ObjCMethod:
     return Storage.get<ObjCMethod>(kind).getExplosionValue(IGF);
@@ -1315,8 +1293,7 @@ static void emitEntryPointArgumentsNativeCC(IRGenSILFunction &IGF,
 
   // The 'self' argument might be in the context position, which is
   // now the end of the parameter list.  Bind it now.
-  if (funcTy->hasSelfParam() &&
-      isSelfContextParameter(funcTy->getSelfParameter())) {
+  if (hasSelfContextParameter(funcTy)) {
     SILArgument *selfParam = params.back();
     params = params.drop_back();
 
@@ -1712,13 +1689,18 @@ void IRGenSILFunction::visitSILBasicBlock(SILBasicBlock *BB) {
 void IRGenSILFunction::visitFunctionRefInst(FunctionRefInst *i) {
   auto fn = i->getReferencedFunction();
 
-  llvm::Function *fnptr = IGM.getAddrOfSILFunction(fn, NotForDefinition);
-  auto foreignInfo = IGM.getForeignFunctionInfo(fn->getLoweredFunctionType());
+  llvm::Constant *fnPtr = IGM.getAddrOfSILFunction(fn, NotForDefinition);
+
+  auto sig = IGM.getSignature(fn->getLoweredFunctionType());
+
+  // Note that the pointer value returned by getAddrOfSILFunction doesn't
+  // necessarily have element type sig.getType(), e.g. if it's imported.
+
+  FunctionPointer fp = FunctionPointer::forDirect(fnPtr, sig);
   
-  // Store the function constant and calling
-  // convention as a StaticFunction so we can avoid bitcasting or thunking if
-  // we don't need to.
-  setLoweredStaticFunction(i, fnptr, fn->getRepresentation(), foreignInfo);
+  // Store the function as a FunctionPointer so we can avoid bitcasting
+  // or thunking if we don't need to.
+  setLoweredFunctionPointer(i, fp);
 }
 
 void IRGenSILFunction::visitAllocGlobalInst(AllocGlobalInst *i) {
@@ -1917,7 +1899,7 @@ static void emitApplyArgument(IRGenSILFunction &IGF,
                         temp, out);
 }
 
-static llvm::Value *getObjCClassForValue(IRGenSILFunction &IGF,
+static llvm::Value *getObjCClassForValue(IRGenFunction &IGF,
                                          llvm::Value *selfValue,
                                          CanAnyMetatypeType selfType) {
   // If we have a Swift metatype, map it to the heap metadata, which
@@ -1973,107 +1955,68 @@ static llvm::Value *emitWitnessTableForLoweredCallee(IRGenSILFunction &IGF,
 
 }
 
-static CallEmission getCallEmissionForLoweredValue(IRGenSILFunction &IGF,
-                                         CanSILFunctionType origCalleeType,
-                                         CanSILFunctionType substCalleeType,
-                                         const LoweredValue &lv,
-                                         llvm::Value *selfValue,
-                                         SubstitutionList substitutions,
-                                         WitnessMetadata *witnessMetadata,
-                                         Explosion &args) {
-  llvm::Value *calleeFn, *calleeData;
-  ForeignFunctionInfo foreignInfo;
-  
-  switch (lv.kind) {
-  case LoweredValue::Kind::StaticFunction:
-    calleeFn = lv.getStaticFunction().getFunction();
-    calleeData = selfValue;
-    foreignInfo = lv.getStaticFunction().getForeignInfo();
+Callee LoweredValue::getCallee(IRGenFunction &IGF,
+                               llvm::Value *selfValue,
+                               CalleeInfo &&calleeInfo) const {
+  switch (kind) {
+  case Kind::FunctionPointer: {
+    auto &fn = getFunctionPointer();
+    return Callee(std::move(calleeInfo), fn, selfValue);
+  }
 
-    if (origCalleeType->getRepresentation()
-          == SILFunctionType::Representation::WitnessMethod) {
-      llvm::Value *wtable = emitWitnessTableForLoweredCallee(
-          IGF, origCalleeType, substitutions);
-      witnessMetadata->SelfWitnessTable = wtable;
-    }
-    break;
-      
-  case LoweredValue::Kind::ObjCMethod: {
+  case Kind::ObjCMethod: {
+    const auto &objcMethod = getObjCMethod();
     assert(selfValue);
-    auto &objcMethod = lv.getObjCMethod();
-    ObjCMessageKind kind = objcMethod.getMessageKind();
 
-    CallEmission emission =
-      prepareObjCMethodRootCall(IGF, objcMethod.getMethod(),
-                                origCalleeType, substCalleeType,
-                                substitutions, kind);
-
-    // Convert a metatype 'self' argument to the ObjC Class pointer.
-    // FIXME: Should be represented in SIL.
+    // Convert a metatype 'self' argument to the ObjC class pointer.
+    // FIXME: why on earth is this not correctly represented in SIL?
     if (auto metatype = dyn_cast<AnyMetatypeType>(
-                          origCalleeType->getSelfParameter().getType())) {
+                       calleeInfo.OrigFnType->getSelfParameter().getType())) {
       selfValue = getObjCClassForValue(IGF, selfValue, metatype);
     }
 
-    addObjCMethodCallImplicitArguments(IGF, args, objcMethod.getMethod(),
-                                       selfValue,
-                                       objcMethod.getSearchType());
-    return emission;
+    return getObjCMethodCallee(IGF, objcMethod, selfValue,
+                               std::move(calleeInfo));
   }
 
-  case LoweredValue::Kind::SingletonExplosion:
-  case LoweredValue::Kind::ExplosionVector: {
-    switch (origCalleeType->getRepresentation()) {
-    case SILFunctionType::Representation::Block: {
+  case Kind::SingletonExplosion: {
+    auto functionValue = getKnownSingletonExplosion();
+
+    switch (calleeInfo.OrigFnType->getRepresentation()) {
+    case SILFunctionType::Representation::Block:
       assert(!selfValue && "block function with self?");
+      return getBlockPointerCallee(IGF, functionValue, std::move(calleeInfo));
 
-      // Grab the block pointer and make it the first physical argument.
-      llvm::PointerType *blockPtrTy = IGF.IGM.ObjCBlockPtrTy;
-      llvm::Value *blockPtr = lv.getSingletonExplosion(IGF);
-      blockPtr = IGF.Builder.CreateBitCast(blockPtr, blockPtrTy);
-      args.add(blockPtr);
-
-      // Extract the invocation pointer for blocks.
-      llvm::Value *invokeFnPtrPtr =
-        IGF.Builder.CreateStructGEP(blockPtrTy->getElementType(), blockPtr, 3);
-      Address invokePtrAddr(invokeFnPtrPtr, IGF.IGM.getPointerAlignment());
-      calleeFn = IGF.Builder.CreateLoad(invokePtrAddr);
-      calleeData = nullptr;
-      break;
-    }
-
-    case SILFunctionType::Representation::Thick: {
-      // @convention(thick) callees are exploded as a pair
-      // consisting of the function and the self value.
-      assert(!selfValue);
-
-      Explosion calleeValues = lv.getExplosion(IGF);
-      calleeFn = calleeValues.claimNext();
-      calleeData = calleeValues.claimNext();
-      break;
-    }
+    case SILFunctionType::Representation::ObjCMethod:
+    case SILFunctionType::Representation::Thick:
+      llvm_unreachable("unexpected function with singleton representation");
 
     case SILFunctionType::Representation::WitnessMethod:
-      witnessMetadata->SelfWitnessTable = emitWitnessTableForLoweredCallee(
-        IGF, origCalleeType, substitutions);
-      LLVM_FALLTHROUGH;
-
     case SILFunctionType::Representation::Thin:
-    case SILFunctionType::Representation::CFunctionPointer:
-    case SILFunctionType::Representation::Method:
     case SILFunctionType::Representation::Closure:
-    case SILFunctionType::Representation::ObjCMethod:
-      calleeFn = lv.getSingletonExplosion(IGF);
-      calleeData = selfValue;
-      break;
-    }
+    case SILFunctionType::Representation::Method:
+      return getSwiftFunctionPointerCallee(IGF, functionValue, selfValue,
+                                           std::move(calleeInfo));
 
-    // Cast the callee pointer to the right function type.
-    llvm::AttributeSet attrs;
-    llvm::FunctionType *fnTy =
-      IGF.IGM.getFunctionType(origCalleeType, attrs, &foreignInfo);
-    calleeFn = IGF.Builder.CreateBitCast(calleeFn, fnTy->getPointerTo());
-    break;
+    case SILFunctionType::Representation::CFunctionPointer:
+      assert(!selfValue && "C function pointer has self?");
+      return getCFunctionPointerCallee(IGF, functionValue,
+                                       std::move(calleeInfo));
+    }
+    llvm_unreachable("bad kind");
+  }
+
+  case Kind::ExplosionVector: {
+    auto vector = getKnownExplosionVector();
+    assert(calleeInfo.OrigFnType->getRepresentation()
+             == SILFunctionType::Representation::Thick);
+
+    assert(!selfValue && "thick function pointer with self?");
+    assert(vector.size() == 2 && "thick function pointer with size != 2");
+    llvm::Value *functionValue = vector[0];
+    llvm::Value *contextValue = vector[1];
+    return getSwiftFunctionPointerCallee(IGF, functionValue, contextValue,
+                                         std::move(calleeInfo));
   }
 
   case LoweredValue::Kind::EmptyExplosion:
@@ -2083,14 +2026,43 @@ static CallEmission getCallEmissionForLoweredValue(IRGenSILFunction &IGF,
   case LoweredValue::Kind::DynamicallyEnforcedAddress:
     llvm_unreachable("not a valid callee");
   }
-  
-  Callee callee = Callee::forKnownFunction(origCalleeType, substCalleeType,
-                                           substitutions, calleeFn, calleeData,
-                                           foreignInfo);
-  CallEmission callEmission(IGF, callee);
+  llvm_unreachable("bad kind");
+}
+
+static CallEmission getCallEmissionForLoweredValue(IRGenSILFunction &IGF,
+                                         CanSILFunctionType origCalleeType,
+                                         CanSILFunctionType substCalleeType,
+                                         const LoweredValue &lv,
+                                         llvm::Value *selfValue,
+                                         const SubstitutionList &substitutions,
+                                         WitnessMetadata *witnessMetadata,
+                                         Explosion &args) {
+  Callee callee = lv.getCallee(IGF, selfValue,
+                               CalleeInfo(origCalleeType, substCalleeType,
+                                          substitutions));
+
+  switch (origCalleeType->getRepresentation()) {
+  case SILFunctionType::Representation::WitnessMethod: {
+    llvm::Value *wtable = emitWitnessTableForLoweredCallee(
+        IGF, origCalleeType, substitutions);
+    witnessMetadata->SelfWitnessTable = wtable;
+    break;
+  }
+
+  case SILFunctionType::Representation::ObjCMethod:
+  case SILFunctionType::Representation::Thick:
+  case SILFunctionType::Representation::Block:
+  case SILFunctionType::Representation::Thin:
+  case SILFunctionType::Representation::CFunctionPointer:
+  case SILFunctionType::Representation::Method:
+  case SILFunctionType::Representation::Closure:
+    break;
+  }
+
+  CallEmission callEmission(IGF, std::move(callee));
   if (IGF.CurSILFn->isThunk())
-    callEmission.addAttribute(llvm::AttributeSet::FunctionIndex, llvm::Attribute::NoInline);
-  
+    callEmission.addAttribute(llvm::AttributeSet::FunctionIndex,
+                              llvm::Attribute::NoInline);
   return callEmission;
 }
 
@@ -2130,8 +2102,7 @@ void IRGenSILFunction::visitFullApplySite(FullApplySite site) {
 
   // Extract 'self' if it needs to be passed as the context parameter.
   llvm::Value *selfValue = nullptr;
-  if (origCalleeType->hasSelfParam() &&
-      isSelfContextParameter(origCalleeType->getSelfParameter())) {
+  if (hasSelfContextParameter(origCalleeType)) {
     SILValue selfArg = args.back();
     args = args.drop_back();
 
@@ -2230,7 +2201,7 @@ void IRGenSILFunction::visitFullApplySite(FullApplySite site) {
 /// \param v A value of possibly-polymorphic SILFunctionType.
 /// \param subs This is the set of substitutions that we are going to be
 /// applying to 'v'.
-static std::tuple<llvm::Value*, llvm::Value*, CanSILFunctionType>
+static std::tuple<FunctionPointer, llvm::Value*, CanSILFunctionType>
 getPartialApplicationFunction(IRGenSILFunction &IGF, SILValue v,
                               SubstitutionList subs) {
   LoweredValue &lv = IGF.getLoweredValue(v);
@@ -2247,14 +2218,13 @@ getPartialApplicationFunction(IRGenSILFunction &IGF, SILValue v,
   case LoweredValue::Kind::ObjCMethod:
     llvm_unreachable("objc method partial application shouldn't get here");
 
-  case LoweredValue::Kind::StaticFunction: {
+  case LoweredValue::Kind::FunctionPointer: {
     llvm::Value *context = nullptr;
-    switch (lv.getStaticFunction().getRepresentation()) {
+    switch (fnType->getRepresentation()) {
     case SILFunctionTypeRepresentation::CFunctionPointer:
     case SILFunctionTypeRepresentation::Block:
     case SILFunctionTypeRepresentation::ObjCMethod:
-      assert(false && "partial_apply of foreign functions not implemented");
-      break;
+      llvm_unreachable("partial_apply of foreign functions not implemented");
         
     case SILFunctionTypeRepresentation::WitnessMethod:
       context = emitWitnessTableForLoweredCallee(IGF, fnType, subs);
@@ -2265,11 +2235,13 @@ getPartialApplicationFunction(IRGenSILFunction &IGF, SILValue v,
     case SILFunctionTypeRepresentation::Closure:
       break;
     }
-    return std::make_tuple(lv.getStaticFunction().getFunction(),
-                           context, v->getType().castTo<SILFunctionType>());
+
+    auto fn = lv.getFunctionPointer();
+    return std::make_tuple(fn, context, fnType);
   }
   case LoweredValue::Kind::SingletonExplosion: {
-    llvm::Value *fn = lv.getSingletonExplosion(IGF);
+    llvm::Value *fnPtr = lv.getKnownSingletonExplosion();
+    auto fn = FunctionPointer::forExplosionValue(IGF, fnPtr, fnType);
     llvm::Value *context = nullptr;
     auto repr = fnType->getRepresentation();
     assert(repr != SILFunctionType::Representation::Block &&
@@ -2282,8 +2254,9 @@ getPartialApplicationFunction(IRGenSILFunction &IGF, SILValue v,
   case LoweredValue::Kind::ExplosionVector: {
     assert(fnType->getRepresentation()
              == SILFunctionType::Representation::Thick);
-    Explosion ex = lv.getExplosion(IGF);
-    llvm::Value *fn = ex.claimNext();
+    Explosion ex = lv.getExplosion(IGF, v->getType());
+    llvm::Value *fnPtr = ex.claimNext();
+    auto fn = FunctionPointer::forExplosionValue(IGF, fnPtr, fnType);
     llvm::Value *context = ex.claimNext();
     return std::make_tuple(fn, context, fnType);
   }
@@ -2337,13 +2310,11 @@ void IRGenSILFunction::visitPartialApplyInst(swift::PartialApplyInst *i) {
   }
   
   // Get the function value.
-  llvm::Value *calleeFn = nullptr;
-  llvm::Value *innerContext = nullptr;
-  CanSILFunctionType origCalleeTy;
-  
-  std::tie(calleeFn, innerContext, origCalleeTy)
-    = getPartialApplicationFunction(*this, i->getCallee(),
-                                    i->getSubstitutions());
+  auto result = getPartialApplicationFunction(*this, i->getCallee(),
+                                              i->getSubstitutions());
+  FunctionPointer calleeFn = std::get<0>(result);
+  llvm::Value *innerContext = std::get<1>(result);
+  CanSILFunctionType origCalleeTy = std::get<2>(result);
 
   // Create the thunk and function value.
   Explosion function;
@@ -3879,7 +3850,7 @@ void IRGenSILFunction::visitProjectBoxInst(swift::ProjectBoxInst *i) {
   } else {
     // The slow-path: we have to emit code to get from the box to it's
     // value address.
-    Explosion box = val.getExplosion(*this);
+    Explosion box = val.getExplosion(*this, i->getOperand()->getType());
     auto addr = emitProjectBox(*this, box.claimNext(), boxTy);
     setLoweredAddress(i, addr);
   }
@@ -4865,14 +4836,15 @@ void IRGenSILFunction::visitInitBlockStorageHeaderInst(
   
   // We currently only support static invoke functions.
   auto &invokeVal = getLoweredValue(i->getInvokeFunction());
-  llvm::Function *invokeFn = nullptr;
+  llvm::Constant *invokeFn = nullptr;
   ForeignFunctionInfo foreignInfo;
-  if (invokeVal.kind != LoweredValue::Kind::StaticFunction) {
+  if (invokeVal.kind != LoweredValue::Kind::FunctionPointer) {
     IGM.unimplemented(i->getLoc().getSourceLoc(),
                       "non-static block invoke function");
   } else {
-    invokeFn = invokeVal.getStaticFunction().getFunction();
-    foreignInfo = invokeVal.getStaticFunction().getForeignInfo();
+    auto &fn = invokeVal.getFunctionPointer();
+    invokeFn = fn.getDirectPointer();
+    foreignInfo = fn.getForeignInfo();
   }
 
   assert(foreignInfo.ClangInfo && "no clang info for block function?");
@@ -4955,14 +4927,15 @@ void IRGenSILFunction::visitWitnessMethodInst(swift::WitnessMethodInst *i) {
   ProtocolConformanceRef conformance = i->getConformance();
   SILDeclRef member = i->getMember();
 
+  auto fnType = i->getType().castTo<SILFunctionType>();
+
   // It would be nice if this weren't discarded.
   llvm::Value *baseMetadataCache = nullptr;
 
-  Explosion lowered;
-  emitWitnessMethodValue(*this, baseTy, &baseMetadataCache,
-                         member, conformance, lowered);
+  auto fn = emitWitnessMethodValue(*this, baseTy, &baseMetadataCache,
+                                   member, conformance, fnType);
   
-  setLoweredExplosion(i, lowered);
+  setLoweredFunctionPointer(i, fn);
 }
 
 void IRGenSILFunction::setAllocatedAddressForBuffer(SILValue v,
@@ -5064,14 +5037,11 @@ void IRGenSILFunction::visitSuperMethodInst(swift::SuperMethodInst *i) {
   auto method = i->getMember();
   auto methodType = i->getType().castTo<SILFunctionType>();
 
-  llvm::Value *fnValue = emitVirtualMethodValue(*this, baseValue,
-                                                baseType,
-                                                method, methodType,
-                                                /*useSuperVTable*/ true);
-  fnValue = Builder.CreateBitCast(fnValue, IGM.Int8PtrTy);
-  Explosion e;
-  e.add(fnValue);
-  setLoweredExplosion(i, e);
+  auto fn = emitVirtualMethodValue(*this, baseValue, baseType,
+                                   method, methodType,
+                                   /*useSuperVTable*/ true);
+
+  setLoweredFunctionPointer(i, fn);
 }
 
 void IRGenSILFunction::visitClassMethodInst(swift::ClassMethodInst *i) {
@@ -5090,14 +5060,12 @@ void IRGenSILFunction::visitClassMethodInst(swift::ClassMethodInst *i) {
  
   // For Swift classes, get the method implementation from the vtable.
   // FIXME: better explosion kind, map as static.
-  llvm::Value *fnValue = emitVirtualMethodValue(*this, baseValue,
-                                                i->getOperand()->getType(),
-                                                method, methodType,
-                                                /*useSuperVTable*/ false);
-  fnValue = Builder.CreateBitCast(fnValue, IGM.Int8PtrTy);
-  Explosion e;
-  e.add(fnValue);
-  setLoweredExplosion(i, e);
+  FunctionPointer fn = emitVirtualMethodValue(*this, baseValue,
+                                              i->getOperand()->getType(),
+                                              method, methodType,
+                                              /*useSuperVTable*/ false);
+
+  setLoweredFunctionPointer(i, fn);
 }
 
 void IRGenModule::emitSILStaticInitializers() {

--- a/lib/IRGen/Signature.h
+++ b/lib/IRGen/Signature.h
@@ -51,17 +51,29 @@ class Signature {
   llvm::FunctionType *Type = nullptr;
   llvm::AttributeSet Attributes;
   ForeignFunctionInfo ForeignInfo;
+  llvm::CallingConv::ID CallingConv;
 
 public:
   bool isValid() const {
     return Type != nullptr;
   }
 
-  static Signature get(IRGenModule &IGM, CanSILFunctionType formalType);
+  /// Compute the signature of the given type.
+  ///
+  /// This is a private detail of the implementation of
+  /// IRGenModule::getSignature(CanSILFunctionType), which is what
+  /// clients should generally be using.
+  static Signature getUncached(IRGenModule &IGM,
+                               CanSILFunctionType formalType);
 
   llvm::FunctionType *getType() const {
     assert(isValid());
     return Type;
+  }
+
+  llvm::CallingConv::ID getCallingConv() const {
+    assert(isValid());
+    return CallingConv;
   }
 
   llvm::AttributeSet getAttributes() const {
@@ -69,10 +81,24 @@ public:
     return Attributes;
   }
 
-  const ForeignFunctionInfo &getForeignInfo() const {
+  ForeignFunctionInfo getForeignInfo() const {
     assert(isValid());
     return ForeignInfo;
   }
+
+  // The mutators below should generally only be used when building up
+  // a callee.
+
+  void setType(llvm::FunctionType *type) {
+    Type = type;
+  }
+
+  llvm::AttributeSet &getMutableAttributes() & {
+    assert(isValid());
+    return Attributes;
+  }
+
+
 };
 
 } // end namespace irgen

--- a/test/IRGen/class_bounded_generics.swift
+++ b/test/IRGen/class_bounded_generics.swift
@@ -93,8 +93,8 @@ func class_bounded_archetype_method<T : ClassBoundBinary>(_ x: T, y: T) {
   x.classBoundBinaryMethod(y)
   // CHECK: [[WITNESS_ENTRY:%.*]] = getelementptr inbounds i8*, i8** %T.ClassBoundBinary, i32 1
   // CHECK: [[WITNESS:%.*]] = load i8*, i8** [[WITNESS_ENTRY]], align 8
-  // CHECK: call void @swift_unknownRetain(%objc_object* [[Y:%.*]])
   // CHECK: [[WITNESS_FUNC:%.*]] = bitcast i8* [[WITNESS]] to void (%objc_object*, %objc_object*, %swift.type*, i8**)
+  // CHECK: call void @swift_unknownRetain(%objc_object* [[Y:%.*]])
   // CHECK: call swiftcc void [[WITNESS_FUNC]](%objc_object* [[Y]], %objc_object* swiftself %0, %swift.type* %T, i8** %T.ClassBoundBinary)
 }
 

--- a/test/IRGen/dynamic_init.sil
+++ b/test/IRGen/dynamic_init.sil
@@ -22,10 +22,8 @@ bb0(%0 : $@thick C.Type):
   // CHECK:   [[META:%[0-9]+]] = bitcast %swift.type* %0 to %T12dynamic_init1CC* (%swift.type*)**
   // CHECK:   [[VTABLE_OFFSET:%[0-9]+]] = getelementptr inbounds %T12dynamic_init1CC* (%swift.type*)*, %T12dynamic_init1CC* (%swift.type*)** [[META]], i64 10
   // CHECK:   [[CTOR:%[0-9]+]] = load %T12dynamic_init1CC* (%swift.type*)*, %T12dynamic_init1CC* (%swift.type*)** [[VTABLE_OFFSET]], align 8
-  // CHECK:   [[CTOR_I8:%[0-9]+]] = bitcast %T12dynamic_init1CC* (%swift.type*)* [[CTOR]] to i8*
-  // CHECK:   [[CTOR_FN:%[0-9]+]] = bitcast i8* [[CTOR_I8]] to %T12dynamic_init1CC* (%swift.type*)*
   %2 = class_method %0 : $@thick C.Type, #C.init!allocator.1 : (C.Type) -> () -> C, $@convention(method) (@thick C.Type) -> @owned C
-  // CHECK:   [[RESULT:%[0-9]+]] = call swiftcc %T12dynamic_init1CC* [[CTOR_FN]](%swift.type* swiftself %0)
+  // CHECK:   [[RESULT:%[0-9]+]] = call swiftcc %T12dynamic_init1CC* [[CTOR]](%swift.type* swiftself %0)
   %3 = apply %2(%0) : $@convention(method) (@thick C.Type) -> @owned C
   // CHECK:   call void bitcast (void (%swift.refcounted*)* @swift_rt_swift_release to void (%T12dynamic_init1CC*)*)(%T12dynamic_init1CC* [[RESULT]])
   strong_release %3 : $C

--- a/test/IRGen/objc_dealloc.sil
+++ b/test/IRGen/objc_dealloc.sil
@@ -95,9 +95,9 @@ bb0(%0 : $SwiftGizmo):
   // CHECK-NEXT: [[SUPER_OBJ:%[a-zA-Z0-9]+]] = bitcast [[GIZMO]]* [[SUPER]] to %objc_object*
   // CHECK-NEXT: [[T0:%.*]] = call %swift.type* @_T012objc_dealloc10SwiftGizmoCMa()
   // CHECK-NEXT: [[T1:%.*]] = bitcast %swift.type* [[T0]] to %objc_class*
-  // CHECK-NEXT: [[OBJC_SUPER_RECEIVER:%[a-zA-Z0-9]+]] = getelementptr %objc_super, %objc_super* [[OBJC_SUPER]], i32 0, i32 0
+  // CHECK-NEXT: [[OBJC_SUPER_RECEIVER:%[a-zA-Z0-9]+]] = getelementptr inbounds %objc_super, %objc_super* [[OBJC_SUPER]], i32 0, i32 0
   // CHECK-NEXT: store %objc_object* [[SUPER_OBJ]], %objc_object** [[OBJC_SUPER_RECEIVER]], align 8
-  // CHECK-NEXT: [[OBJC_SUPER_CLASS:%[a-zA-Z0-9]+]] = getelementptr %objc_super, %objc_super* [[OBJC_SUPER]], i32 0, i32 1
+  // CHECK-NEXT: [[OBJC_SUPER_CLASS:%[a-zA-Z0-9]+]] = getelementptr inbounds %objc_super, %objc_super* [[OBJC_SUPER]], i32 0, i32 1
   // CHECK-NEXT: store %objc_class* [[T1]], %objc_class** [[OBJC_SUPER_CLASS]], align 8
   // CHECK-NEXT: [[DEALLOC_SEL:%[a-zA-Z0-9]+]] = load i8*, i8** @"\01L_selector(dealloc)", align 8
   // CHECK-NEXT: call void bitcast (void ()* @objc_msgSendSuper2 to void (%objc_super*, i8*)*)(%objc_super* [[OBJC_SUPER]], i8* [[DEALLOC_SEL]])

--- a/test/IRGen/objc_super.swift
+++ b/test/IRGen/objc_super.swift
@@ -116,7 +116,7 @@ class GenericRuncer<T> : Gizmo {
     // CHECK-NEXT: [[ISA_MASKED:%.*]] = and i64 [[ISA]], [[ISA_MASK]]
     // CHECK-NEXT: [[ISA_PTR:%.*]] = inttoptr i64 [[ISA_MASKED]] to %swift.type*
     // CHECK-NEXT: [[METACLASS:%.*]] = bitcast %swift.type* [[ISA_PTR]] to %objc_class*
-    // CHECK:      [[METACLASS_ADDR:%.*]] = getelementptr %objc_super, %objc_super* %objc_super, i32 0, i32 1
+    // CHECK:      [[METACLASS_ADDR:%.*]] = getelementptr inbounds %objc_super, %objc_super* %objc_super, i32 0, i32 1
     // CHECK-NEXT: store %objc_class* [[METACLASS]], %objc_class** [[METACLASS_ADDR]], align 8
     // CHECK-NEXT: [[SELECTOR:%.*]] = load i8*, i8** @"\01L_selector(runce)", align 8
     // CHECK-NEXT: call void bitcast (void ()* @objc_msgSendSuper2 to void (%objc_super*, i8*)*)(%objc_super* %objc_super, i8* [[SELECTOR]])

--- a/test/IRGen/partial_apply_objc.sil
+++ b/test/IRGen/partial_apply_objc.sil
@@ -50,6 +50,8 @@ bb0(%0 : $ObjCClass):
 
 // CHECK-LABEL: define{{( protected)?}} swiftcc { i8*, %swift.refcounted* } @indirect_partial_apply(i8*, %swift.refcounted*, i64) {{.*}} {
 // CHECK: entry:
+// CHECK:   [[T0:%.*]] = bitcast i8* %0 to void (i64, %swift.refcounted*)*
+// CHECK:   [[CAST_FN:%.*]] = bitcast void (i64, %swift.refcounted*)* [[T0]] to i8*
 // CHECK:   [[OBJ:%.*]] = call noalias %swift.refcounted* @swift_rt_swift_allocObject(%swift.type* getelementptr inbounds (%swift.full_boxmetadata, %swift.full_boxmetadata* @metadata, i32 0, i32 2), i64 40, i64 7)
 // CHECK:   [[DATA_ADDR:%.*]] = bitcast %swift.refcounted* [[OBJ]] to [[DATA_TYPE:<{ %swift.refcounted, i64, %swift.refcounted\*, i8\* }>]]*
 // CHECK:   [[X_ADDR:%.*]] = getelementptr inbounds [[DATA_TYPE]], [[DATA_TYPE]]* [[DATA_ADDR]], i32 0, i32 1
@@ -57,7 +59,7 @@ bb0(%0 : $ObjCClass):
 // CHECK:   [[CONTEXT_ADDR:%.*]] = getelementptr inbounds [[DATA_TYPE]], [[DATA_TYPE]]* [[DATA_ADDR]], i32 0, i32 2
 // CHECK:   store %swift.refcounted* %1, %swift.refcounted** [[CONTEXT_ADDR]], align 8
 // CHECK:   [[FN_ADDR:%.*]] = getelementptr inbounds [[DATA_TYPE]], [[DATA_TYPE]]* [[DATA_ADDR]], i32 0, i32 3
-// CHECK:   store i8* %0, i8** [[FN_ADDR]], align 8
+// CHECK:   store i8* [[CAST_FN]], i8** [[FN_ADDR]], align 8
 // CHECK:   [[RET:%.*]] = insertvalue { i8*, %swift.refcounted* } { i8* bitcast (void (%swift.refcounted*)* [[INDIRECT_PARTIAL_APPLY_STUB:@_T0TA[A-Za-z0-9_]*]] to i8*), %swift.refcounted* undef }, %swift.refcounted* [[OBJ]], 1
 // CHECK:   ret { i8*, %swift.refcounted* } [[RET]]
 // CHECK: }

--- a/test/IRGen/super.sil
+++ b/test/IRGen/super.sil
@@ -206,7 +206,6 @@ sil_vtable Derived {
 // CHECK: [[BASEMETADATA:%[0-9]+]] = bitcast %swift.type* [[METADATA]] to void (%T5super4BaseC*)**
 // CHECK: [[GEP:%[0-9]+]] = getelementptr inbounds void (%T5super4BaseC*)*, void (%T5super4BaseC*)** [[BASEMETADATA]]
 // CHECK: [[SUPERMT:%[0-9]+]] = load void (%T5super4BaseC*)*, void (%T5super4BaseC*)** [[GEP]]
-// CHECK: bitcast void (%T5super4BaseC*)* [[SUPERMT]] to i8*
 // CHECK: ret void
 sil @test_super_method_of_generic_base : $@convention(method) (@guaranteed Derived) -> () {
 bb0(%0 : $Derived):

--- a/test/IRGen/witness_method_phi.sil
+++ b/test/IRGen/witness_method_phi.sil
@@ -6,10 +6,13 @@ protocol P { func foo() }
 // CHECK-LABEL: define{{( protected)?}} swiftcc void @phi_witness_method(%swift.type* %T, i8** %T.P) #0 {
 sil @phi_witness_method : $@convention(thin) <T: P> () -> () {
 entry:
+  // CHECK: [[LOAD:%.*]] = load i8*, i8** %T.P,
+  // CHECK: [[T0:%.*]] = bitcast i8* [[LOAD]] to void (%swift.type*, i8**, %T18witness_method_phi1PP*, %swift.type*, i8**)*
+  // CHECK: [[FUNC:%.*]] = bitcast void (%swift.type*, i8**, %T18witness_method_phi1PP*, %swift.type*, i8**)* [[T0]] to i8*
   %1 = witness_method $T, #P.foo!1 : $@convention(witness_method) <T: P> (@in P) -> ()
   br bb1(%1 : $@convention(witness_method) <T: P> (@in P) -> ())
 
-// CHECK:         phi i8* [ %0, %entry ]
+// CHECK:         phi i8* [ [[FUNC]], %entry ]
 bb1(%2 : $@convention(witness_method) <T: P> (@in P) -> ()):
   unreachable
 }


### PR DESCRIPTION
The goals here are four-fold:
  - provide cleaner internal abstractions
  - avoid IR bloat from extra bitcasts
  - avoid recomputing function-type lowering information
  - allow more information to be propagated from the function
    access site (e.g. class_method) to the call site

Use this framework immediately for class and protocol methods.

Not NFC but pretty close.