### PR TITLE
[DO NOT MERGE] Revert "[ConstraintSystem] Prevent `shrink` from solving "too complex…

### DIFF
--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1472,8 +1472,7 @@ ConstraintSystem::solveSingle(FreeTypeVariableBinding allowFreeTypeVariables) {
   return std::move(solutions[0]);
 }
 
-bool ConstraintSystem::Candidate::solve(
-    llvm::SmallDenseSet<Expr *> &shrunkExprs) {
+bool ConstraintSystem::Candidate::solve() {
   // Don't attempt to solve candidate if there is closure
   // expression involved, because it's handled specially
   // by parent constraint system (e.g. parameter lists).
@@ -1515,11 +1514,6 @@ bool ConstraintSystem::Candidate::solve(
     cleanupImplicitExprs(E);
     return true;
   }
-
-  // If this candidate is too complex given the number
-  // of the domains we have reduced so far, let's bail out early.
-  if (isTooComplexGiven(&cs, shrunkExprs))
-    return false;
 
   if (TC.getLangOpts().DebugConstraintSolver) {
     auto &log = cs.getASTContext().TypeCheckerDebug->getStream();
@@ -1574,7 +1568,7 @@ bool ConstraintSystem::Candidate::solve(
   }
 
   // Record found solutions as suggestions.
-  this->applySolutions(solutions, shrunkExprs);
+  this->applySolutions(solutions);
 
   // Let's double-check if we have any implicit expressions
   // with type variables and nullify their types.
@@ -1586,8 +1580,7 @@ bool ConstraintSystem::Candidate::solve(
 }
 
 void ConstraintSystem::Candidate::applySolutions(
-    llvm::SmallVectorImpl<Solution> &solutions,
-    llvm::SmallDenseSet<Expr *> &shrunkExprs) const {
+                            llvm::SmallVectorImpl<Solution> &solutions) const {
   // A collection of OSRs with their newly reduced domains,
   // it's domains are sets because multiple solutions can have the same
   // choice for one of the type variables, and we want no duplication.
@@ -1634,9 +1627,6 @@ void ConstraintSystem::Candidate::applySolutions(
       = TC.Context.AllocateUninitialized<ValueDecl *>(choices.size());
     std::uninitialized_copy(choices.begin(), choices.end(), decls.begin());
     OSR->setDecls(decls);
-
-    // Record successfully shrunk expression.
-    shrunkExprs.insert(OSR);
   }
 }
 
@@ -1705,8 +1695,7 @@ void ConstraintSystem::shrink(Expr *expr) {
         auto func = applyExpr->getFn();
         // Let's record this function application for post-processing
         // as well as if it contains overload set, see walkToExprPost.
-        ApplyExprs.push_back(
-            {applyExpr, isa<OverloadSetRefExpr>(func) || isa<TypeExpr>(func)});
+        ApplyExprs.push_back({applyExpr, isa<OverloadSetRefExpr>(func)});
       }
 
       return { true, expr };
@@ -1946,12 +1935,11 @@ void ConstraintSystem::shrink(Expr *expr) {
   // so we can start solving them separately.
   expr->walk(collector);
 
-  llvm::SmallDenseSet<Expr *> shrunkExprs;
   for (auto &candidate : collector.Candidates) {
     // If there are no results, let's forget everything we know about the
     // system so far. This actually is ok, because some of the expressions
     // might require manual salvaging.
-    if (candidate.solve(shrunkExprs)) {
+    if (candidate.solve()) {
       // Let's restore all of the original OSR domains for this sub-expression,
       // this means that we can still make forward progress with solving of the
       // top sub-expressions.
@@ -1962,7 +1950,6 @@ void ConstraintSystem::shrink(Expr *expr) {
             return childExpr;
 
           OSR->setDecls(domain->getSecond());
-          shrunkExprs.erase(OSR);
         }
 
         return childExpr;

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1041,45 +1041,15 @@ private:
     /// \brief Try to solve this candidate sub-expression
     /// and re-write it's OSR domains afterwards.
     ///
-    /// \param shrunkExprs The set of expressions which
-    /// domains have been successfully shrunk so far.
-    ///
     /// \returns true on solver failure, false otherwise.
-    bool solve(llvm::SmallDenseSet<Expr *> &shrunkExprs);
+    bool solve();
 
     /// \brief Apply solutions found by solver as reduced OSR sets for
     /// for current and all of it's sub-expressions.
     ///
     /// \param solutions The solutions found by running solver on the
     /// this candidate expression.
-    ///
-    /// \param shrunkExprs The set of expressions which
-    /// domains have been successfully shrunk so far.
-    void applySolutions(llvm::SmallVectorImpl<Solution> &solutions,
-                        llvm::SmallDenseSet<Expr *> &shrunkExprs) const;
-
-    /// Check if attempt at solving of the candidate makes sense given
-    /// the current conditions - number of shrunk domains which is related
-    /// to the given candidate over the total number of disjunctions present.
-    static bool isTooComplexGiven(ConstraintSystem *const cs,
-                                  llvm::SmallDenseSet<Expr *> &shrunkExprs) {
-      SmallVector<Constraint *, 8> disjunctions;
-      cs->collectDisjunctions(disjunctions);
-
-      unsigned unsolvedDisjunctions = disjunctions.size();
-      for (auto *disjunction : disjunctions) {
-        auto *locator = disjunction->getLocator();
-        if (!locator)
-          continue;
-
-        if (auto *anchor = locator->getAnchor()) {
-          if (shrunkExprs.count(anchor) > 0)
-            --unsolvedDisjunctions;
-        }
-      }
-
-      return unsolvedDisjunctions >= 5;
-    }
+    void applySolutions(llvm::SmallVectorImpl<Solution> &solutions) const;
   };
 
   /// \brief Describes the current solver state.

--- a/test/Sema/complex_expressions.swift
+++ b/test/Sema/complex_expressions.swift
@@ -117,12 +117,3 @@ let sr3668Dict2: [Int: (Int, Int) -> Bool] =
      8: { $0 != $1 },  9: { $0 != $1 }, 10: { $0 != $1 }, 11: { $0 != $1 },
     12: { $0 != $1 }, 13: { $0 != $1 }, 14: { $0 != $1 }, 15: { $0 != $1 },
     16: { $0 != $1 }, 17: { $0 != $1 }, 18: { $0 != $1 }, 19: { $0 != $1 } ]
-
-// rdar://problem/32034560 - type-checker hangs trying to solve expression
-struct R32034560 {
-  private var R32034560: Array<Array<UInt32>>
-  private func foo(x: UInt32) -> UInt32 {
-    return ((self.R32034560[0][Int(x >> 24) & 0xFF] &+ self.R32034560[1][Int(x >> 16) & 0xFF]) ^ self.R32034560[2][Int(x >> 8) & 0xFF]) &+ self.R32034560[3][Int(x & 0xFF)]
-    // expected-error@-1 {{expression was too complex to be solved in reasonable time; consider breaking up the expression into distinct sub-expressions}}
-  }
-}


### PR DESCRIPTION
…" sub-expressions"

This reverts commit fea7bcf2323121c112e9ff70db6bb65673d0d85b.

This is just a test run to see what still works if this change is reverted.