### PR TITLE
[4.0] Don't consider KeyPathApplication operations when looking up non-SubscriptExprs.

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -2845,6 +2845,11 @@ bool FailureDiagnosis::diagnoseGeneralConversionFailure(Constraint *constraint){
     fromType = sub->getType();
   }
 
+  // Bail on constraints that don't relate two types.
+  if (constraint->getKind() == ConstraintKind::Disjunction
+      || constraint->getKind() == ConstraintKind::BindOverload)
+    return false;
+
   fromType = fromType->getRValueType();
   auto toType = CS->simplifyType(constraint->getSecondType())
                   ->getWithoutImmediateLabel();

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2891,7 +2891,9 @@ performMemberLookup(ConstraintKind constraintKind, DeclName memberName,
   result.OverallResult = MemberLookupResult::HasResults;
   
   // If we're looking for a subscript, consider key path operations.
-  if (memberName.isSimpleName(getASTContext().Id_subscript)) {
+  if (memberName.isSimpleName(getASTContext().Id_subscript)
+      && (isa<SubscriptExpr>(memberLocator->getAnchor())
+          || isa<KeyPathExpr>(memberLocator->getAnchor()))) {
     result.ViableCandidates.push_back(
         OverloadChoice(baseTy, OverloadChoiceKind::KeyPathApplication));
   }

--- a/lib/Sema/ConstraintGraph.cpp
+++ b/lib/Sema/ConstraintGraph.cpp
@@ -641,7 +641,6 @@ static bool shouldContractEdge(ConstraintKind kind) {
   case ConstraintKind::BindParam:
   case ConstraintKind::BindToPointerType:
   case ConstraintKind::Equal:
-  case ConstraintKind::BindOverload:
 
   // We currently only allow subtype contractions for the purpose of 
   // parameter binding constraints.

--- a/test/decl/subscript/quoted-subscript-identifier.swift
+++ b/test/decl/subscript/quoted-subscript-identifier.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-frontend -typecheck -verify %s
+// SR-5513
+
+class OTTextView {
+  func `subscript`(_ sender: Any?) {}
+}
+
+class MyTextView: OTTextView {
+  override func `subscript`(_ sender: Any?) { super.`subscript`(sender) }
+}


### PR DESCRIPTION
Explanation: Introducing the global key path subscript operation introduced an ambiguity bug for code that tried to reference functions named `subscript` (using backtick quoted identifiers). This is fixed more deeply on master by #9989; this is a focused compatibility fix for 4.0.

Scope: Source compatibility regression; impacts ability to use AppKit because `NSText` has a `-subscript:` action.

Issue: SR-5513 | rdar://problem/33413614

Risk: Low, targeted bug fix

Testing: Swift CI, example from Jira