### PR TITLE
[4.0] [ConstraintSolver] NFC: Add option to control early termination of shrinking phase

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -171,6 +171,10 @@ namespace swift {
 
     unsigned SolverBindingThreshold = 1024 * 1024;
 
+    /// \brief The upper bound to number of sub-expressions unsolved
+    /// before termination of the shrink phrase of the constraint solver.
+    unsigned SolverShrinkUnsolvedThreshold = 5;
+
     /// The maximum depth to which to test decl circularity.
     unsigned MaxCircularityDepth = 500;
 

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -256,6 +256,10 @@ def solver_memory_threshold : Separate<["-"], "solver-memory-threshold">,
   Flags<[FrontendOption, HelpHidden, DoesNotAffectIncrementalBuild]>,
   HelpText<"Set the upper bound for memory consumption, in bytes, by the constraint solver">;
 
+def solver_shrink_unsolved_threshold : Separate<["-"], "solver-shrink-unsolved-threshold">,
+Flags<[FrontendOption, HelpHidden, DoesNotAffectIncrementalBuild]>,
+HelpText<"Set The upper bound to number of sub-expressions unsolved before termination of the shrink phrase">;
+
 def value_recursion_threshold : Separate<["-"], "value-recursion-threshold">,
   Flags<[FrontendOption, HelpHidden, DoesNotAffectIncrementalBuild]>,
   HelpText<"Set the maximum depth for direct recursion in value types">;

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -151,6 +151,8 @@ static void addCommonFrontendArgs(const ToolChain &TC,
   inputArgs.AddLastArg(arguments, options::OPT_swift_version);
   inputArgs.AddLastArg(arguments, options::OPT_enforce_exclusivity_EQ);
   inputArgs.AddLastArg(arguments, options::OPT_stats_output_dir);
+  inputArgs.AddLastArg(arguments,
+                       options::OPT_solver_shrink_unsolved_threshold);
 
   // Pass on any build config options
   inputArgs.AddAllArgs(arguments, options::OPT_D);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1058,6 +1058,17 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
     Opts.SolverMemoryThreshold = threshold;
   }
 
+  if (const Arg *A = Args.getLastArg(OPT_solver_shrink_unsolved_threshold)) {
+    unsigned threshold;
+    if (StringRef(A->getValue()).getAsInteger(10, threshold)) {
+      Diags.diagnose(SourceLoc(), diag::error_invalid_arg_value,
+                     A->getAsString(Args), A->getValue());
+      return true;
+    }
+
+    Opts.SolverShrinkUnsolvedThreshold = threshold;
+  }
+
   if (const Arg *A = Args.getLastArg(OPT_value_recursion_threshold)) {
     unsigned threshold;
     if (StringRef(A->getValue()).getAsInteger(10, threshold)) {

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1078,7 +1078,8 @@ private:
         }
       }
 
-      return unsolvedDisjunctions >= 5;
+      unsigned threshold = cs->TC.getLangOpts().SolverShrinkUnsolvedThreshold;
+      return unsolvedDisjunctions >= threshold;
     }
   };
 


### PR DESCRIPTION
* Description: Currently we have a number of unsolved disjunctions hard-coded to 5,
which breaks some existing code by terminating shrinking too early.
This patch makes it a command-line option so users have control over
what that threshold can be.

* Origination: Check added for the shrinking phase of the solver is sometimes too aggressive.

* Risk: Low.

* Tested: Updated related tests, Swift CI.

* Reviewed by: Mark Lacey.

* Resolves: rdar://problem/33433595

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
