### PR TITLE
[QoI] Ignore implicit conversions during mutation diagnostics

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -623,6 +623,11 @@ resolveImmutableBase(Expr *expr, ConstraintSystem &CS) {
   if (auto *BOE = dyn_cast<BindOptionalExpr>(expr))
     return resolveImmutableBase(BOE->getSubExpr(), CS);
   
+  // Look through implicit conversions
+  if (auto *ICE = dyn_cast<ImplicitConversionExpr>(expr))
+    if (!isa<LoadExpr>(ICE->getSubExpr()))
+      return resolveImmutableBase(ICE->getSubExpr(), CS);
+
   return { expr, nullptr };
 }
 

--- a/test/Parse/pointer_conversion.swift.gyb
+++ b/test/Parse/pointer_conversion.swift.gyb
@@ -59,7 +59,7 @@ func mutablePointerArguments(_ p: UnsafeMutablePointer<Int>,
   takesMutableArrayPointer(&ii)
 
   // We don't allow these conversions outside of function arguments.
-  var x: UnsafeMutablePointer<Int> = &i // expected-error{{cannot pass immutable value of type 'Int' as inout argument}}
+  var x: UnsafeMutablePointer<Int> = &i // expected-error{{cannot pass immutable value as inout argument: 'i' is immutable}}
   x = &ii // expected-error{{cannot assign value of type '[Int]' to type 'Int'}}
   _ = x
 }
@@ -157,7 +157,7 @@ func constPointerArguments(_ p: UnsafeMutablePointer<Int>,
   takesConstPointer([0.0, 1.0, 2.0]) // expected-error{{cannot convert value of type 'Double' to expected element type 'Int'}}
 
   // We don't allow these conversions outside of function arguments.
-  var x: UnsafePointer<Int> = &i // expected-error{{cannot pass immutable value of type 'Int' as inout argument}}
+  var x: UnsafePointer<Int> = &i // expected-error{{cannot pass immutable value as inout argument: 'i' is immutable}}
   x = ii // expected-error{{cannot assign value of type '[Int]' to type 'UnsafePointer<Int>'}}
   x = p // expected-error{{cannot assign value of type 'UnsafeMutablePointer<Int>' to type 'UnsafePointer<Int>'}}
 }

--- a/test/Parse/pointer_conversion_objc.swift.gyb
+++ b/test/Parse/pointer_conversion_objc.swift.gyb
@@ -67,5 +67,5 @@ func autoreleasingPointerArguments(p: UnsafeMutablePointer<Int>,
   takesAutoreleasingPointer(&cc) // expected-error{{cannot convert value of type '[C]' to expected argument type 'C'}}
   takesAutoreleasingPointer(&dd) // expected-error{{cannot convert value of type '[D]' to expected argument type 'C'}}
 
-  let _: AutoreleasingUnsafeMutablePointer<C> = &c // expected-error{{cannot pass immutable value of type 'C' as inout argument}}
+  let _: AutoreleasingUnsafeMutablePointer<C> = &c // expected-error{{cannot pass immutable value as inout argument: 'c' is immutable}}
 }


### PR DESCRIPTION
This change helps diagnoseSubElementFailure() avoid the unknown error
path in more scenarios.

@swift-ci Please smoke test