### PR TITLE
[4.0] Be a little more permissive in emoji grapheme literals.

### DIFF
--- a/test/Parse/enum.swift
+++ b/test/Parse/enum.swift
@@ -193,6 +193,12 @@ enum RawTypeWithCharacterValues : Character { // expected-error {{'RawTypeWithCh
   case Third = "は"
 }
 
+enum RawTypeWithCharacterValues_Correct : Character {
+  case First = "😅" // ok
+  case Second = "👩‍👩‍👧‍👦" // ok
+  case Third = "👋🏽" // ok
+}
+
 enum RawTypeWithCharacterValues_Error1 : Character { // expected-error {{'RawTypeWithCharacterValues_Error1' declares raw type 'Character', but does not conform to RawRepresentable and conformance could not be synthesized}}
   case First = "abc" // expected-error {{cannot convert value of type 'String' to raw type 'Character'}}
 }

--- a/utils/UnicodeData/GraphemeBreakTest.txt
+++ b/utils/UnicodeData/GraphemeBreakTest.txt
@@ -418,10 +418,10 @@
 # NOTE: disabled because Unicode 9.0. TODO: splat in proper file here. Original: ÷ 1F1F7 × 1F1FA × 1F1F8 × 1F1EA ÷	#  ÷ [0.2] REGIONAL INDICATOR SYMBOL LETTER R (Regional_Indicator) × [8.1] REGIONAL INDICATOR SYMBOL LETTER U (Regional_Indicator) × [8.1] REGIONAL INDICATOR SYMBOL LETTER S (Regional_Indicator) × [8.1] REGIONAL INDICATOR SYMBOL LETTER E (Regional_Indicator) ÷ [0.3]
 ÷ 1F1F7 × 1F1FA ÷ 200B ÷ 1F1F8 × 1F1EA ÷	#  ÷ [0.2] REGIONAL INDICATOR SYMBOL LETTER R (Regional_Indicator) × [8.1] REGIONAL INDICATOR SYMBOL LETTER U (Regional_Indicator) ÷ [5.0] ZERO WIDTH SPACE (Control) ÷ [4.0] REGIONAL INDICATOR SYMBOL LETTER S (Regional_Indicator) × [8.1] REGIONAL INDICATOR SYMBOL LETTER E (Regional_Indicator) ÷ [0.3]
 # NOTE: disabled because Unicode 9.0. TODO: splat in proper file here. Original: ÷ 1F1E6 × 1F1E7 × 1F1E8 ÷	#  ÷ [0.2] REGIONAL INDICATOR SYMBOL LETTER A (Regional_Indicator) × [8.1] REGIONAL INDICATOR SYMBOL LETTER B (Regional_Indicator) × [8.1] REGIONAL INDICATOR SYMBOL LETTER C (Regional_Indicator) ÷ [0.3]
-÷ 1F1E6 × 200D ÷ 1F1E7 × 1F1E8 ÷	#  ÷ [0.2] REGIONAL INDICATOR SYMBOL LETTER A (Regional_Indicator) × [9.0] ZERO WIDTH JOINER (Extend) ÷ [999.0] REGIONAL INDICATOR SYMBOL LETTER B (Regional_Indicator) × [8.1] REGIONAL INDICATOR SYMBOL LETTER C (Regional_Indicator) ÷ [0.3]
-÷ 1F1E6 × 1F1E7 × 200D ÷ 1F1E8 ÷	#  ÷ [0.2] REGIONAL INDICATOR SYMBOL LETTER A (Regional_Indicator) × [8.1] REGIONAL INDICATOR SYMBOL LETTER B (Regional_Indicator) × [9.0] ZERO WIDTH JOINER (Extend) ÷ [999.0] REGIONAL INDICATOR SYMBOL LETTER C (Regional_Indicator) ÷ [0.3]
-÷ 0020 × 200D ÷ 0646 ÷	#  ÷ [0.2] SPACE (Other) × [9.0] ZERO WIDTH JOINER (Extend) ÷ [999.0] ARABIC LETTER NOON (Other) ÷ [0.3]
-÷ 0646 × 200D ÷ 0020 ÷	#  ÷ [0.2] ARABIC LETTER NOON (Other) × [9.0] ZERO WIDTH JOINER (Extend) ÷ [999.0] SPACE (Other) ÷ [0.3]
+# NOTE: disabled because Unicode 9.0. ÷ 1F1E6 × 200D ÷ 1F1E7 × 1F1E8 ÷	#  ÷ [0.2] REGIONAL INDICATOR SYMBOL LETTER A (Regional_Indicator) × [9.0] ZERO WIDTH JOINER (Extend) ÷ [999.0] REGIONAL INDICATOR SYMBOL LETTER B (Regional_Indicator) × [8.1] REGIONAL INDICATOR SYMBOL LETTER C (Regional_Indicator) ÷ [0.3]
+# NOTE: disabled because Unicode 9.0. ÷ 1F1E6 × 1F1E7 × 200D ÷ 1F1E8 ÷	#  ÷ [0.2] REGIONAL INDICATOR SYMBOL LETTER A (Regional_Indicator) × [8.1] REGIONAL INDICATOR SYMBOL LETTER B (Regional_Indicator) × [9.0] ZERO WIDTH JOINER (Extend) ÷ [999.0] REGIONAL INDICATOR SYMBOL LETTER C (Regional_Indicator) ÷ [0.3]
+# NOTE: disabled because Unicode 9.0. ÷ 0020 × 200D ÷ 0646 ÷	#  ÷ [0.2] SPACE (Other) × [9.0] ZERO WIDTH JOINER (Extend) ÷ [999.0] ARABIC LETTER NOON (Other) ÷ [0.3]
+# NOTE: disabled because Unicode 9.0. ÷ 0646 × 200D ÷ 0020 ÷	#  ÷ [0.2] ARABIC LETTER NOON (Other) × [9.0] ZERO WIDTH JOINER (Extend) ÷ [999.0] SPACE (Other) ÷ [0.3]
 #
 # Lines: 402
 #


### PR DESCRIPTION
(This is a 4.0 cherry-pick of https://github.com/apple/swift/pull/11104)

CCC:
* Explanation: While Swift 4.0 supports emoji newer than Unicode 8, the compiler’s grapheme literal validation does not. This tries the most minimally invasive change to allow the compiler to support newer emoji while not affecting the overall user model.
* Scope: Limited to complex graphemes containing a ZWJ or emoji modifier in them.
* Radar (and possibly SR Issue): https://bugs.swift.org/browse/SR-4546
* Risk: Very low. Biggest risk is that we might permit a grapheme literal in obscure corner cases that’s not really a single grapheme at runtime. Note that this is already the case due to Unicode 8 allowing arbitrary strings of regional indicators as graphemes, but Unicode 9 and later doesn’t.
* Testing: Full CI validation

----

From the master PR:
The user experience with extended grapheme literals is currently:

1. Strict: we hard error on "invalid" grapheme literals.

2. Complete: we validate all literals to either be
known-single-grapheme or not.

3. Incorrect: we have Unicode 8 semantics implemented but applications
will have some other version of Unicode as dictated by the OS they are
running on.

In Swift 4.0, this incorrectness mostly crops up in obscure corner
case areas, where we are overly restrictive in some ways and overly
relaxed in others. But, there is one particularly embarrassing area
where it does come up: we reject emoji introduced after Unicode 8 as
grapheme literals, counter to common user expectations.

In a future (sub-)version of Swift we should completely re-evaluate
this user story, but doing so in time for Swift 4.0 is untenable. This
patch attempts to tweak the way in which we are incorrect in the most
minimally invasive way possible to preserve the same user experience
while permitting many post-Unicode-8 emoji as valid grapheme literals.

This change overrides processing of ZWJ and emoji modifiers to not
declare a grapheme break after/before, respectively.

<!-- What's in this pull request? -->
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-4546](https://bugs.swift.org/browse/SR-4546).


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
