### PR TITLE
[RangeInfo] Using the underlying token array reference to represent the content of a range under selection.

### DIFF
--- a/include/swift/IDE/Utils.h
+++ b/include/swift/IDE/Utils.h
@@ -48,6 +48,7 @@ namespace swift {
   class DeclContext;
   class ClangNode;
   class ClangImporter;
+  class Token;
 
 namespace ide {
 struct SourceCompleteResult {
@@ -270,7 +271,7 @@ struct ReturnInfo {
 struct ResolvedRangeInfo {
   RangeKind Kind;
   ReturnInfo ExitInfo;
-  CharSourceRange Content;
+  ArrayRef<Token> TokensInRange;
   bool HasSingleEntry;
   bool ThrowingUnhandledError;
   OrphanKind Orphan;
@@ -283,13 +284,15 @@ struct ResolvedRangeInfo {
   Expr* CommonExprParent;
 
   ResolvedRangeInfo(RangeKind Kind, ReturnInfo ExitInfo,
-                    CharSourceRange Content, DeclContext* RangeContext,
+                    ArrayRef<Token> TokensInRange,
+                    DeclContext* RangeContext,
                     Expr *CommonExprParent, bool HasSingleEntry,
                     bool ThrowingUnhandledError,
                     OrphanKind Orphan, ArrayRef<ASTNode> ContainedNodes,
                     ArrayRef<DeclaredDecl> DeclaredDecls,
                     ArrayRef<ReferencedDecl> ReferencedDecls): Kind(Kind),
-                      ExitInfo(ExitInfo), Content(Content),
+                      ExitInfo(ExitInfo),
+                      TokensInRange(TokensInRange),
                       HasSingleEntry(HasSingleEntry),
                       ThrowingUnhandledError(ThrowingUnhandledError),
                       Orphan(Orphan), ContainedNodes(ContainedNodes),
@@ -297,15 +300,15 @@ struct ResolvedRangeInfo {
                       ReferencedDecls(ReferencedDecls),
                       RangeContext(RangeContext),
                       CommonExprParent(CommonExprParent) {}
-  ResolvedRangeInfo(CharSourceRange Content) :
-  ResolvedRangeInfo(RangeKind::Invalid, {nullptr, ExitState::Unsure}, Content,
-                    nullptr, /*Commom Expr Parent*/nullptr,
+  ResolvedRangeInfo(ArrayRef<Token> TokensInRange) :
+  ResolvedRangeInfo(RangeKind::Invalid, {nullptr, ExitState::Unsure},
+                    TokensInRange, nullptr, /*Commom Expr Parent*/nullptr,
                     /*Single entry*/true, /*unhandled error*/false,
                     OrphanKind::None, {}, {}, {}) {}
-  ResolvedRangeInfo(): ResolvedRangeInfo(CharSourceRange()) {}
   void print(llvm::raw_ostream &OS);
   ExitState exit() const { return ExitInfo.Exit; }
   Type getType() const { return ExitInfo.ReturnType; }
+  CharSourceRange getContent();
 };
 
 class RangeResolver : public SourceEntityWalker {

--- a/lib/IDE/SwiftSourceDocInfo.cpp
+++ b/lib/IDE/SwiftSourceDocInfo.cpp
@@ -561,7 +561,7 @@ private:
                  unsigned StartIdx, unsigned EndIdx) :
     File(File), Ctx(File.getASTContext()), SM(Ctx.SourceMgr),
     AllTokens(AllTokens),
-    TokensInRange(llvm::makeArrayRef(AllTokens.data() + StartIdx,
+    TokensInRange(llvm::makeArrayRef(this->AllTokens.data() + StartIdx,
                                      EndIdx - StartIdx + 1)),
     StartTok(TokensInRange.front()), EndTok(TokensInRange.back()),
     Start(StartTok.getLoc()), End(EndTok.getLoc()) {

--- a/lib/IDE/SwiftSourceDocInfo.cpp
+++ b/lib/IDE/SwiftSourceDocInfo.cpp
@@ -242,7 +242,7 @@ void ResolvedRangeInfo::print(llvm::raw_ostream &OS) {
   }
   OS << "</Kind>\n";
 
-  OS << "<Content>" << Content.str() << "</Content>\n";
+  OS << "<Content>" << getContent().str() << "</Content>\n";
 
   if (auto Ty = getType()) {
     OS << "<Type>";
@@ -309,6 +309,16 @@ void ResolvedRangeInfo::print(llvm::raw_ostream &OS) {
 
   OS << "<ASTNodes>" << ContainedNodes.size() << "</ASTNodes>\n";
   OS << "<end>\n";
+}
+
+CharSourceRange ResolvedRangeInfo::getContent() {
+  auto StartTok = TokensInRange.front();
+  auto EndTok = TokensInRange.back();
+  auto StartLoc = StartTok.hasComment() ?
+    StartTok.getCommentStart() : StartTok.getLoc();
+  auto EndLoc = EndTok.getRange().getEnd();
+  return CharSourceRange(StartLoc, (char*)EndLoc.getOpaquePointerValue() -
+    (char*)StartLoc.getOpaquePointerValue());
 }
 
 bool DeclaredDecl::operator==(const DeclaredDecl& Other) {
@@ -409,11 +419,12 @@ private:
   };
 
   std::vector<Token> AllTokens;
-  Token &StartTok;
-  Token &EndTok;
+  ArrayRef<Token> TokensInRange;
+  const Token &StartTok;
+  const Token &EndTok;
   SourceLoc Start;
   SourceLoc End;
-  CharSourceRange Content;
+
   Optional<ResolvedRangeInfo> Result;
   std::vector<ContextInfo> ContextStack;
   ContextInfo &getCurrentDC() {
@@ -496,7 +507,7 @@ private:
     if (Node.is<Expr*>())
       return ResolvedRangeInfo(RangeKind::SingleExpression,
                                resolveNodeType(Node, RangeKind::SingleExpression),
-                               Content,
+                               TokensInRange,
                                getImmediateContext(),
                                /*Common Parent Expr*/nullptr,
                                SingleEntry,
@@ -507,7 +518,8 @@ private:
     else if (Node.is<Stmt*>())
       return ResolvedRangeInfo(RangeKind::SingleStatement,
                                resolveNodeType(Node, RangeKind::SingleStatement),
-                               Content, getImmediateContext(),
+                               TokensInRange,
+                               getImmediateContext(),
                                /*Common Parent Expr*/nullptr,
                                SingleEntry,
                                UnhandledError, Kind,
@@ -517,7 +529,8 @@ private:
     else {
       assert(Node.is<Decl*>());
       return ResolvedRangeInfo(RangeKind::SingleDecl,
-                               ReturnInfo(), Content,
+                               ReturnInfo(),
+                               TokensInRange,
                                getImmediateContext(),
                                /*Common Parent Expr*/nullptr,
                                SingleEntry,
@@ -547,8 +560,11 @@ private:
   Implementation(SourceFile &File, std::vector<Token> AllTokens,
                  unsigned StartIdx, unsigned EndIdx) :
     File(File), Ctx(File.getASTContext()), SM(Ctx.SourceMgr),
-    AllTokens(AllTokens), StartTok(AllTokens[StartIdx]), EndTok(AllTokens[EndIdx]),
-    Start(StartTok.getLoc()), End(EndTok.getLoc()), Content(getContentRange()) {
+    AllTokens(AllTokens),
+    TokensInRange(llvm::makeArrayRef(AllTokens.data() + StartIdx,
+                                     EndIdx - StartIdx + 1)),
+    StartTok(TokensInRange.front()), EndTok(TokensInRange.back()),
+    Start(StartTok.getLoc()), End(EndTok.getLoc()) {
       assert(Start.isValid() && End.isValid());
   }
 
@@ -576,7 +592,9 @@ public:
     if (!hasResult() && !Node.isImplicit() && nodeContainSelection(Node)) {
       if (auto Parent = Node.is<Expr*>() ? Node.get<Expr*>() : nullptr) {
         Result = {
-          RangeKind::PartOfExpression, ReturnInfo(), Content,
+          RangeKind::PartOfExpression,
+          ReturnInfo(),
+          TokensInRange,
           getImmediateContext(),
           Parent,
           hasSingleEntryPoint(ContainedASTNodes),
@@ -795,7 +813,8 @@ public:
       Result = {RangeKind::MultiStatement,
                 /* Last node has the type */
                 resolveNodeType(DCInfo.EndMatches.back(),
-                                RangeKind::MultiStatement), Content,
+                                RangeKind::MultiStatement),
+                TokensInRange,
                 getImmediateContext(), nullptr,
                 hasSingleEntryPoint(ContainedASTNodes),
                 hasUnhandledError(ContainedASTNodes),
@@ -842,7 +861,7 @@ public:
   ResolvedRangeInfo getResult() {
     if (Result.hasValue())
       return Result.getValue();
-    return ResolvedRangeInfo(Content);
+    return ResolvedRangeInfo(TokensInRange);
   }
 
   void analyzeDeclRef(ValueDecl *VD, SourceLoc Start, Type Ty,
@@ -894,13 +913,6 @@ private:
       return RangeMatchKind::EndMatch;
     else
       return RangeMatchKind::NoneMatch;
-  }
-
-  CharSourceRange getContentRange() {
-    SourceManager &SM = File.getASTContext().SourceMgr;
-    return CharSourceRange(SM, StartTok.hasComment() ?
-                            StartTok.getCommentStart() : StartTok.getLoc(),
-                           Lexer::getLocForEndOfToken(SM, End));
   }
 };
 
@@ -963,7 +975,7 @@ visitDeclReference(ValueDecl *D, CharSourceRange Range, TypeDecl *CtorTyRef,
 
 ResolvedRangeInfo RangeResolver::resolve() {
   if (!Impl)
-    return ResolvedRangeInfo(CharSourceRange());
+    return ResolvedRangeInfo({});
   Impl->enter(ASTNode());
   walk(Impl->File);
   return Impl->getResult();

--- a/lib/IDE/SwiftSourceDocInfo.cpp
+++ b/lib/IDE/SwiftSourceDocInfo.cpp
@@ -312,6 +312,8 @@ void ResolvedRangeInfo::print(llvm::raw_ostream &OS) {
 }
 
 CharSourceRange ResolvedRangeInfo::getContent() {
+  if (TokensInRange.empty())
+    return CharSourceRange();
   auto StartTok = TokensInRange.front();
   auto EndTok = TokensInRange.back();
   auto StartLoc = StartTok.hasComment() ?

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -1355,7 +1355,7 @@ static void resolveRange(SwiftLangSupport &Lang,
       ASTInvok->applyTo(CompInvok);
       RangeInfo Result;
       Result.RangeKind = Lang.getUIDForRangeKind(Info.Kind);
-      Result.RangeContent = Info.Content.str();
+      Result.RangeContent = Info.getContent().str();
       switch (Info.Kind) {
       case RangeKind::SingleExpression: {
         SmallString<64> SS;


### PR DESCRIPTION
Comparing to CharSourceRange, token stream is a better way because we can preserve comment information at the start of the range.

Needed for rdar://33437855