### PR TITLE
[4.0] SILGen: The allocator entry point for an initializer is never `dynamic`.

### DIFF
--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -3194,7 +3194,8 @@ getWitnessDispatchKind(Type selfType, SILDeclRef witness, bool isFree) {
   auto *decl = witness.getDecl();
 
   // If the witness is dynamic, go through dynamic dispatch.
-  if (decl->isDynamic())
+  if (decl->isDynamic()
+      && witness.kind != SILDeclRef::Kind::Allocator)
     return WitnessDispatchKind::Dynamic;
 
   bool isFinal = (decl->isFinal() || C->isFinal());

--- a/lib/SILGen/SILGenThunk.cpp
+++ b/lib/SILGen/SILGenThunk.cpp
@@ -35,6 +35,8 @@ using namespace Lowering;
 
 SILFunction *SILGenModule::getDynamicThunk(SILDeclRef constant,
                                            SILConstantInfo constantInfo) {
+  assert(constant.kind != SILDeclRef::Kind::Allocator &&
+         "allocating entry point for constructor is never dynamic");
   // Mangle the constant with a _TTD header.
   auto name = constant.mangle(SILDeclRef::ManglingKind::DynamicThunk);
 

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -45,7 +45,8 @@ SILGenModule::emitVTableMethod(SILDeclRef derived, SILDeclRef base) {
   // If the member is dynamic, reference its dynamic dispatch thunk so that
   // it will be redispatched, funneling the method call through the runtime
   // hook point.
-  if (derived.getDecl()->isDynamic()) {
+  if (derived.getDecl()->isDynamic()
+      && derived.kind != SILDeclRef::Kind::Allocator) {
     implFn = getDynamicThunk(derived, Types.getConstantInfo(derived));
     implLinkage = SILLinkage::Public;
   } else {

--- a/test/SILGen/objc_dynamic_init.swift
+++ b/test/SILGen/objc_dynamic_init.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-silgen %s | %FileCheck %s
+// REQUIRES: objc_interop
+
+import Foundation
+
+protocol Person {
+    init()
+}
+
+class Driver: NSObject, Person {
+    required override init() {
+        super.init()
+    }
+}
+
+// CHECK-LABEL: sil private [transparent] [thunk] @_T{{.*}}DriverC{{.*}}CTW
+// CHECK:         class_method {{%.*}} : $@thick Driver.Type, #Driver.init!allocator.1 :
+
+// CHECK-LABEL: sil_vtable Driver {
+// CHECK:         #Driver.init!allocator.1: (Driver.Type) -> () -> Driver : _T{{.*}}DriverC{{.*}}C {{ *}}//


### PR DESCRIPTION
Explanation: We would miscompile `required` initializer in subclasses of Objective-C classes, causing an `init` message to be sent to the class object rather than an allocated instance of the object.

Scope: This was a latent bug in `dynamic` initializers, aggravated by our change to make all ObjC-compatible interfaces implicitly `dynamic` in order to ensure cross-language-version compatibility, making it a regression for existing code.

Issue: SR-5223 | rdar://problem/32778104.

Risk: Low, small bug fix.

Testing: Swift CI, compatibility suite, test case from Jira.