### PR TITLE
Windows [AST], [Serialization] and [IRGen] Fixes

### DIFF
--- a/include/swift/AST/SyntaxASTMap.h
+++ b/include/swift/AST/SyntaxASTMap.h
@@ -35,7 +35,7 @@ namespace syntax {
 /// a mapping from lib/AST nodes to lib/Syntax nodes while we integrate
 /// the infrastructure into the compiler.
 class SyntaxASTMap final {
-  friend class LegacyASTTransformer;
+  friend class swift::syntax::LegacyASTTransformer;
   llvm::DenseMap<RC<syntax::SyntaxData>, ASTNode> SyntaxMap;
 public:
 

--- a/include/swift/Serialization/ModuleFile.h
+++ b/include/swift/Serialization/ModuleFile.h
@@ -432,7 +432,8 @@ public:
 
   /// Emits one last diagnostic, logs the error, and then aborts for the stack
   /// trace.
-  void fatal(llvm::Error error) LLVM_ATTRIBUTE_NORETURN;
+  LLVM_ATTRIBUTE_NORETURN 
+  void fatal(llvm::Error error);
 
   ASTContext &getContext() const {
     assert(FileContext && "no associated context yet");

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -170,7 +170,7 @@ void IRGenModule::addSwiftErrorAttributes(llvm::AttributeSet &attrs,
   // We create a shadow stack location of the swifterror parameter for the
   // debugger on such platforms and so we can't mark the parameter with a
   // swifterror attribute.
-  if (!UseSwiftCC || !this->IsSwiftErrorInRegister)
+  if (!this->IsSwiftErrorInRegister)
     return;
 
   static const llvm::Attribute::AttrKind attrKinds[] = {

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -392,7 +392,7 @@ IRGenModule::IRGenModule(IRGenerator &irgen,
     AtomicBoolAlign = Alignment(ClangASTContext->getTypeSize(atomicBoolTy));
   }
 
-  IsSwiftErrorInRegister =
+  IsSwiftErrorInRegister = UseSwiftCC &&
     clang::CodeGen::swiftcall::isSwiftErrorLoweredInRegister(
       ClangCodeGen->CGM());
 }

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -453,7 +453,7 @@ llvm::Constant *swift::getRuntimeFn(llvm::Module &Module,
     fn->setCallingConv(cc);
 
     if (::useDllStorage(llvm::Triple(Module.getTargetTriple())) &&
-        (fn->getLinkage() == llvm::GlobalValue::ExternalLinkage ||
+        ((fn->isDeclaration() && fn->getLinkage() == llvm::GlobalValue::ExternalLinkage) ||
          fn->getLinkage() == llvm::GlobalValue::AvailableExternallyLinkage))
       fn->setDLLStorageClass(llvm::GlobalValue::DLLImportStorageClass);
 


### PR DESCRIPTION
This pull request contains a few changes to AST, Serialization, and IRGen to enable compiling on Windows against the MSVC toolchain. 

The `LegacyASTTransformer` change to explicit namespacing is somewhat odd, but I was only able to get the compiler to recognise the declaration as being the same as the true definition by doing this; otherwise, it incorrectly infers that `LegacyASTTransformer` is in `swift::` rather than `swift::syntax::`

In IRGen, the change to the condition for DLLImport linkage is directly taken from an assertion within Verifier.cpp in LLVM.