### PR TITLE
Added sys/xattr.h to glibc modulemap

### DIFF
--- a/stdlib/public/Platform/glibc.modulemap.gyb
+++ b/stdlib/public/Platform/glibc.modulemap.gyb
@@ -440,6 +440,12 @@ module SwiftGlibc [system] {
       header "${GLIBC_INCLUDE_PATH}/utime.h"
       export *
     }
+% if CMAKE_SDK in ["LINUX"]:
+    module xattr {
+        header "${GLIBC_INCLUDE_PATH}/sys/xattr.h"
+        export *
+    }
+% end
   }
 }
 


### PR DESCRIPTION
This adds sys/xattr.h to the glibc modulemap for Linux. This is needed to implement one of the last missing features for NSString in corelibs-foundation.
