### PR TITLE
[swiftc (43 vs. 5582)] Add crasher in swift::TypeChecker::validateExtension(...)

### DIFF
--- a/validation-test/compiler_crashers/28819-formextensioninterfacetype-swift-type-swift-genericparamlist.swift
+++ b/validation-test/compiler_crashers/28819-formextensioninterfacetype-swift-type-swift-genericparamlist.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+class a<a{protocol b}extension a.b


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeChecker::validateExtension(...)`.

Current number of unresolved compiler crashers: 43 (5582 resolved)

Stack trace:

```
0 0x0000000003ae85e8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3ae85e8)
1 0x0000000003ae8d26 SignalHandler(int) (/path/to/swift/bin/swift+0x3ae8d26)
2 0x00007fec1bdbe390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00000000011feb95 formExtensionInterfaceType(swift::Type, swift::GenericParamList*) (/path/to/swift/bin/swift+0x11feb95)
4 0x00000000011feb19 formExtensionInterfaceType(swift::Type, swift::GenericParamList*) (/path/to/swift/bin/swift+0x11feb19)
5 0x00000000011e1682 checkExtensionGenericParams(swift::TypeChecker&, swift::ExtensionDecl*, swift::Type, swift::GenericParamList*) (/path/to/swift/bin/swift+0x11e1682)
6 0x00000000011d4a4f swift::TypeChecker::validateExtension(swift::ExtensionDecl*) (/path/to/swift/bin/swift+0x11d4a4f)
7 0x00000000011eb80b (anonymous namespace)::DeclChecker::visitExtensionDecl(swift::ExtensionDecl*) (/path/to/swift/bin/swift+0x11eb80b)
8 0x00000000011da9b4 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x11da9b4)
9 0x00000000011da883 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x11da883)
10 0x0000000001268514 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x1268514)
11 0x0000000000fb5717 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xfb5717)
12 0x00000000004ad9f8 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4ad9f8)
13 0x00000000004abfa1 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4abfa1)
14 0x00000000004655d4 main (/path/to/swift/bin/swift+0x4655d4)
15 0x00007fec1a2ce830 __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:325:0
16 0x0000000000462ea9 _start (/path/to/swift/bin/swift+0x462ea9)
```