### PR TITLE
[swiftc (44 vs. 5582)] Add crasher in swift::TupleTypeElt::TupleTypeElt

### DIFF
--- a/validation-test/compiler_crashers/28820-fl-isinout-caller-did-not-set-flags-correctly.swift
+++ b/validation-test/compiler_crashers/28820-fl-isinout-caller-did-not-set-flags-correctly.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+.a.i(t:&_


### PR DESCRIPTION
Add test case for crash triggered in `swift::TupleTypeElt::TupleTypeElt`.

Current number of unresolved compiler crashers: 44 (5582 resolved)

/cc Robert Widmann - just wanted to let you know that this crasher caused an assertion failure for the assertion `fl.isInOut() && "caller did not set flags correctly"` added on 2017-07-11 by you in commit 5d5d16393 :-)

Assertion failure in [`lib/AST/ASTContext.cpp (line 2748)`](https://github.com/apple/swift/blob/e6d3e3751932dd485541deec5c165f30bc1cfb3b/lib/AST/ASTContext.cpp#L2748):

```
Assertion `fl.isInOut() && "caller did not set flags correctly"' failed.

When executing: swift::TupleTypeElt::TupleTypeElt(swift::Type, swift::Identifier, swift::ParameterTypeFlags)
```

Assertion context:

```c++
                           ParameterTypeFlags fl)
  : Name(name), ElementType(ty), Flags(fl) {
  if (fl.isInOut())
    assert(!ty->is<InOutType>() && "caller did not pass a base type");
  if (ty->is<InOutType>())
    assert(fl.isInOut() && "caller did not set flags correctly");
}

Type TupleTypeElt::getType() const {
  if (Flags.isInOut()) return InOutType::get(ElementType);
  return ElementType;
```
Stack trace:

```
0 0x0000000003ae85e8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3ae85e8)
1 0x0000000003ae8d26 SignalHandler(int) (/path/to/swift/bin/swift+0x3ae8d26)
2 0x00007f5ee0168390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007f5ede68d428 gsignal /build/glibc-bfm8X4/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f5ede68f02a abort /build/glibc-bfm8X4/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f5ede685bd7 __assert_fail_base /build/glibc-bfm8X4/glibc-2.23/assert/assert.c:92:0
6 0x00007f5ede685c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x00000000014d1488 swift::TupleTypeElt::TupleTypeElt(swift::Type, swift::Identifier, swift::ParameterTypeFlags) (/path/to/swift/bin/swift+0x14d1488)
8 0x00000000012a77b9 (anonymous namespace)::FailureDiagnosis::typeCheckArgumentChildIndependently(swift::Expr*, swift::Type, (anonymous namespace)::CalleeCandidateInfo const&, swift::OptionSet<TCCFlags, unsigned int>) (/path/to/swift/bin/swift+0x12a77b9)
9 0x00000000012b924a (anonymous namespace)::FailureDiagnosis::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0x12b924a)
10 0x000000000129b372 swift::ASTVisitor<(anonymous namespace)::FailureDiagnosis, bool, void, void, void, void, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x129b372)
11 0x0000000001294e92 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) (/path/to/swift/bin/swift+0x1294e92)
12 0x000000000129ad79 swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) (/path/to/swift/bin/swift+0x129ad79)
13 0x00000000011bf708 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0x11bf708)
14 0x00000000011c34c5 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x11c34c5)
15 0x000000000124a7e0 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x124a7e0)
16 0x0000000001249fe6 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0x1249fe6)
17 0x0000000001268580 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x1268580)
18 0x0000000000fb5717 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xfb5717)
19 0x00000000004ad9f8 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4ad9f8)
20 0x00000000004abfa1 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4abfa1)
21 0x00000000004655d4 main (/path/to/swift/bin/swift+0x4655d4)
22 0x00007f5ede678830 __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:325:0
23 0x0000000000462ea9 _start (/path/to/swift/bin/swift+0x462ea9)
```