### PR TITLE
Sema/AST: Fix a couple of protocol typealias validation order bugs [4.0]

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2421,14 +2421,19 @@ void TypeAliasDecl::setUnderlyingType(Type underlying) {
     underlying = mapTypeOutOfContext(underlying);
   UnderlyingTy.setType(underlying);
 
-  // Create a NameAliasType which will resolve to the underlying type.
-  ASTContext &Ctx = getASTContext();
-  auto aliasTy = new (Ctx, AllocationArena::Permanent) NameAliasType(this);
-  aliasTy->setRecursiveProperties(getUnderlyingTypeLoc().getType()
-      ->getRecursiveProperties());
+  // FIXME -- if we already have an interface type, we're changing the
+  // underlying type. See the comment in the ProtocolDecl case of
+  // validateDecl().
+  if (!hasInterfaceType()) {
+    // Create a NameAliasType which will resolve to the underlying type.
+    ASTContext &Ctx = getASTContext();
+    auto aliasTy = new (Ctx, AllocationArena::Permanent) NameAliasType(this);
+    aliasTy->setRecursiveProperties(getUnderlyingTypeLoc().getType()
+        ->getRecursiveProperties());
 
-  // Set the interface type of this declaration.
-  setInterfaceType(MetatypeType::get(aliasTy, Ctx));
+    // Set the interface type of this declaration.
+    setInterfaceType(MetatypeType::get(aliasTy, Ctx));
+  }
 }
 
 UnboundGenericType *TypeAliasDecl::getUnboundGenericType() const {

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3183,6 +3183,14 @@ Type TypeChecker::substMemberTypeWithBase(ModuleDecl *module,
   }
 
   if (auto *aliasDecl = dyn_cast<TypeAliasDecl>(member)) {
+    // FIXME: If this is a protocol typealias and we haven't built the
+    // protocol's generic environment yet, do so now, to ensure the
+    // typealias's underlying type has fully resoved dependent
+    // member types.
+    if (auto *protoDecl = dyn_cast<ProtocolDecl>(aliasDecl->getDeclContext()))
+      if (protoDecl->getGenericEnvironment() == nullptr)
+        validateDecl(protoDecl);
+
     if (aliasDecl->getGenericParams()) {
       return UnboundGenericType::get(
           aliasDecl, baseTy,

--- a/validation-test/compiler_crashers_2_fixed/0114-rdar33189068.swift
+++ b/validation-test/compiler_crashers_2_fixed/0114-rdar33189068.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-frontend %s -typecheck
+
+struct Bar : BarProtocol {
+    typealias Element = Int
+}
+
+struct Foo: FooProtocol {
+    typealias Things = Bar
+    func thing() -> Thing {}
+}
+
+protocol BarProtocol {
+    associatedtype Element
+}
+
+protocol FooProtocol {
+    associatedtype Things: BarProtocol
+    typealias Thing = Things.Element
+}


### PR DESCRIPTION
* Description: Fix a crash when a typealias defined inside a protocol is validated before the protocol itself.

* Origination: Swift 4.0 fixed some issues with protocol typaliases by adding a new code path for validating the typealias before the protocol was completely validated. However some callers depend on the additional invariants established by validating the protocol, and some of these callers did not validate the protocol as they should.

* Scope of the issue: Reported externally as a regression from 3.1.

* Risk: Low; the standard library and the validation test suite's compiler crasher collection exercises recursive validation pretty well.

* Radar: <rdar://problem/33189068>

* Reviewed by: @DougGregor and @huonw 