### PR TITLE
[swiftc (46 vs. 5582)] Add crasher in swift::GenericSignatureBuilder::FloatingRequirementSource::getSource(...)

### DIFF
--- a/validation-test/compiler_crashers/28822-formprotocolrelativetype-swift-protocoldecl-swift-genericsignaturebuilder-potent.swift
+++ b/validation-test/compiler_crashers/28822-formprotocolrelativetype-swift-protocoldecl-swift-genericsignaturebuilder-potent.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+extension CountableRange{{}func a<a:A
+protocol A{typealias e:a{}class a


### PR DESCRIPTION
Add test case for crash triggered in `swift::GenericSignatureBuilder::FloatingRequirementSource::getSource(...)`.

Current number of unresolved compiler crashers: 46 (5582 resolved)

Stack trace:

```
0 0x0000000003ae8f28 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3ae8f28)
1 0x0000000003ae9666 SignalHandler(int) (/path/to/swift/bin/swift+0x3ae9666)
2 0x00007f9436c6a390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x000000000159e87c formProtocolRelativeType(swift::ProtocolDecl*, swift::GenericSignatureBuilder::PotentialArchetype*, swift::GenericSignatureBuilder::PotentialArchetype*) (/path/to/swift/bin/swift+0x159e87c)
4 0x000000000159e893 formProtocolRelativeType(swift::ProtocolDecl*, swift::GenericSignatureBuilder::PotentialArchetype*, swift::GenericSignatureBuilder::PotentialArchetype*) (/path/to/swift/bin/swift+0x159e893)
5 0x000000000159e6c6 swift::GenericSignatureBuilder::FloatingRequirementSource::getSource(swift::GenericSignatureBuilder::PotentialArchetype*) const (/path/to/swift/bin/swift+0x159e6c6)
6 0x00000000015aaec0 swift::GenericSignatureBuilder::addTypeRequirement(llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::FloatingRequirementSource, swift::GenericSignatureBuilder::UnresolvedHandlingKind) (/path/to/swift/bin/swift+0x15aaec0)
7 0x00000000015a8f0b swift::GenericSignatureBuilder::addRequirement(swift::Requirement const&, swift::GenericSignatureBuilder::FloatingRequirementSource, swift::ModuleDecl*, swift::SubstitutionMap const*) (/path/to/swift/bin/swift+0x15a8f0b)
8 0x00000000015b48fd swift::GenericSignatureBuilder::InferRequirementsWalker::walkToTypePost(swift::Type) (/path/to/swift/bin/swift+0x15b48fd)
9 0x0000000001612467 swift::TypeVisitor<(anonymous namespace)::Traversal, bool>::visit(swift::Type) (/path/to/swift/bin/swift+0x1612467)
10 0x0000000001612416 swift::TypeVisitor<(anonymous namespace)::Traversal, bool>::visit(swift::Type) (/path/to/swift/bin/swift+0x1612416)
11 0x00000000016113c4 swift::Type::walk(swift::TypeWalker&) const (/path/to/swift/bin/swift+0x16113c4)
12 0x00000000015bb0ad swift::GenericSignatureBuilder::ConstraintResult llvm::function_ref<swift::GenericSignatureBuilder::ConstraintResult (swift::Type, swift::TypeRepr const*)>::callback_fn<swift::GenericSignatureBuilder::addInheritedRequirements(swift::TypeDecl*, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::RequirementSource const*, swift::ModuleDecl*)::$_22>(long, swift::Type, swift::TypeRepr const*) (/path/to/swift/bin/swift+0x15bb0ad)
13 0x00000000015b4742 std::_Function_handler<void (swift::Type, swift::TypeRepr const*), visitInherited(llvm::ArrayRef<swift::TypeLoc>, llvm::function_ref<swift::GenericSignatureBuilder::ConstraintResult (swift::Type, swift::TypeRepr const*)>)::$_54>::_M_invoke(std::_Any_data const&, swift::Type&&, swift::TypeRepr const*&&) (/path/to/swift/bin/swift+0x15b4742)
14 0x00000000015a6d81 swift::GenericSignatureBuilder::addInheritedRequirements(swift::TypeDecl*, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::RequirementSource const*, swift::ModuleDecl*) (/path/to/swift/bin/swift+0x15a6d81)
15 0x00000000015a7384 swift::GenericSignatureBuilder::addConformanceRequirement(swift::GenericSignatureBuilder::PotentialArchetype*, swift::ProtocolDecl*, swift::GenericSignatureBuilder::RequirementSource const*) (/path/to/swift/bin/swift+0x15a7384)
16 0x00000000015aaf85 swift::GenericSignatureBuilder::addTypeRequirement(llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::FloatingRequirementSource, swift::GenericSignatureBuilder::UnresolvedHandlingKind) (/path/to/swift/bin/swift+0x15aaf85)
17 0x00000000015bb27f swift::GenericSignatureBuilder::ConstraintResult llvm::function_ref<swift::GenericSignatureBuilder::ConstraintResult (swift::Type, swift::TypeRepr const*)>::callback_fn<swift::GenericSignatureBuilder::addInheritedRequirements(swift::TypeDecl*, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::RequirementSource const*, swift::ModuleDecl*)::$_22>(long, swift::Type, swift::TypeRepr const*) (/path/to/swift/bin/swift+0x15bb27f)
18 0x00000000015b4742 std::_Function_handler<void (swift::Type, swift::TypeRepr const*), visitInherited(llvm::ArrayRef<swift::TypeLoc>, llvm::function_ref<swift::GenericSignatureBuilder::ConstraintResult (swift::Type, swift::TypeRepr const*)>)::$_54>::_M_invoke(std::_Any_data const&, swift::Type&&, swift::TypeRepr const*&&) (/path/to/swift/bin/swift+0x15b4742)
19 0x00000000015a6d81 swift::GenericSignatureBuilder::addInheritedRequirements(swift::TypeDecl*, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::RequirementSource const*, swift::ModuleDecl*) (/path/to/swift/bin/swift+0x15a6d81)
20 0x00000000015a6b9e swift::GenericSignatureBuilder::addGenericParameterRequirements(swift::GenericTypeParamDecl*) (/path/to/swift/bin/swift+0x15a6b9e)
21 0x0000000001209ca2 swift::TypeChecker::checkGenericParamList(swift::GenericSignatureBuilder*, swift::GenericParamList*, swift::GenericSignature*, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0x1209ca2)
22 0x000000000120a9f1 checkGenericFuncSignature(swift::TypeChecker&, swift::GenericSignatureBuilder*, swift::AbstractFunctionDecl*, swift::GenericTypeResolver&) (/path/to/swift/bin/swift+0x120a9f1)
23 0x000000000120a6a9 swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0x120a6a9)
24 0x00000000011efa74 (anonymous namespace)::DeclChecker::visitFuncDecl(swift::FuncDecl*) (/path/to/swift/bin/swift+0x11efa74)
25 0x00000000011dac74 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x11dac74)
26 0x00000000011ebd3b (anonymous namespace)::DeclChecker::visitExtensionDecl(swift::ExtensionDecl*) (/path/to/swift/bin/swift+0x11ebd3b)
27 0x00000000011dac84 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x11dac84)
28 0x00000000011dab53 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x11dab53)
29 0x00000000012687e4 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x12687e4)
30 0x0000000000fb59e7 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xfb59e7)
31 0x00000000004ad9f8 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4ad9f8)
32 0x00000000004abfa1 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4abfa1)
33 0x00000000004655d4 main (/path/to/swift/bin/swift+0x4655d4)
34 0x00007f943517a830 __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:325:0
35 0x0000000000462ea9 _start (/path/to/swift/bin/swift+0x462ea9)
```