### PR TITLE
[ConstraintSolver] Prefer same name class properties found on subclass over superclass

### DIFF
--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -977,7 +977,28 @@ ConstraintSystem::compareSolutions(ConstraintSystem &cs,
       ++score1;
     else if (isa<VarDecl>(decl2) && isa<FuncDecl>(decl1))
       ++score2;
-    
+
+    // If both are class properties with the same name, prefer
+    // the one attached to the subclass because it could only be
+    // found if requested directly.
+    if (!decl1->isInstanceMember() && !decl2->isInstanceMember()) {
+      if (isa<VarDecl>(decl1) && isa<VarDecl>(decl2)) {
+        auto *nominal1 = dc1->getAsNominalTypeOrNominalTypeExtensionContext();
+        auto *nominal2 = dc2->getAsNominalTypeOrNominalTypeExtensionContext();
+
+        if (nominal1 && nominal2 && nominal1 != nominal2) {
+          auto base1 = nominal1->getDeclaredType();
+          auto base2 = nominal2->getDeclaredType();
+
+          if (isNominallySuperclassOf(base1, base2))
+            ++score2;
+
+          if (isNominallySuperclassOf(base2, base1))
+            ++score1;
+        }
+      }
+    }
+
     // If we haven't found a refinement, record whether one overload is in
     // any way more constrained than another. We'll only utilize this
     // information in the case of a potential ambiguity.

--- a/test/Sema/Inputs/rdar32973206_a.swift
+++ b/test/Sema/Inputs/rdar32973206_a.swift
@@ -1,0 +1,8 @@
+public class A {
+}
+
+public class B : A {
+}
+
+public class C : B {
+}

--- a/test/Sema/Inputs/rdar32973206_b.swift
+++ b/test/Sema/Inputs/rdar32973206_b.swift
@@ -1,0 +1,5 @@
+import rdar32973206_a
+
+public extension A {
+  public class var foo: Int { get { return 42 } }
+}

--- a/test/Sema/Inputs/rdar32973206_c.swift
+++ b/test/Sema/Inputs/rdar32973206_c.swift
@@ -1,0 +1,5 @@
+import rdar32973206_a
+
+public extension B {
+  public class var foo: Int { get { return 0 } }
+}

--- a/test/Sema/subclass_property_import.swift
+++ b/test/Sema/subclass_property_import.swift
@@ -1,0 +1,19 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: %target-swift-frontend -emit-module -o %t/rdar32973206_a.swiftmodule %S/Inputs/rdar32973206_a.swift
+// RUN: %target-swift-frontend -I %t -emit-module -o %t/rdar32973206_b.swiftmodule %S/Inputs/rdar32973206_b.swift
+// RUN: %target-swift-frontend -I %t -emit-module -o %t/rdar32973206_c.swiftmodule %S/Inputs/rdar32973206_c.swift
+// RUN: %target-swift-frontend -I %t -emit-sil -verify %s | %FileCheck %s
+
+import rdar32973206_a
+import rdar32973206_b
+import rdar32973206_c
+
+// CHECK: A.foo
+let _ = A.foo
+
+// CHECK: B.foo
+let _ = B.foo
+
+// CHECK: B.foo
+let _ = C.foo


### PR DESCRIPTION
If the class property with the same name and type was found on both subclass
and superclass, let's always prefer subclass with all else equal, because
subclass property could only be found if requested directly.

Resolves: rdar://problem/32973206

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
