### PR TITLE
[swiftc (47 vs. 5582)] Add crasher in swift::constraints::ConstraintGraph::addConstraint(...)

### DIFF
--- a/validation-test/compiler_crashers/28823-impl-getgraphindex-typevariables-size-out-of-bounds-index.swift
+++ b/validation-test/compiler_crashers/28823-impl-getgraphindex-typevariables-size-out-of-bounds-index.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+{{}as ManagedBuffer}{


### PR DESCRIPTION
Add test case for crash triggered in `swift::constraints::ConstraintGraph::addConstraint(...)`.

Current number of unresolved compiler crashers: 47 (5582 resolved)

/cc @DougGregor - just wanted to let you know that this crasher caused an assertion failure for the assertion `impl.getGraphIndex() < TypeVariables.size() && "Out-of-bounds index"` added on 2013-12-09 by you in commit 11794095 :-)

Assertion failure in [`lib/Sema/ConstraintGraph.cpp (line 50)`](https://github.com/apple/swift/blob/725702c28307491a01c6bad42e5f4123cd9148de/lib/Sema/ConstraintGraph.cpp#L50):

```
Assertion `impl.getGraphIndex() < TypeVariables.size() && "Out-of-bounds index"' failed.

When executing: std::pair<ConstraintGraphNode &, unsigned int> swift::constraints::ConstraintGraph::lookupNode(swift::TypeVariableType *)
```

Assertion context:

```c++
std::pair<ConstraintGraphNode &, unsigned>
ConstraintGraph::lookupNode(TypeVariableType *typeVar) {
  // Check whether we've already created a node for this type variable.
  auto &impl = typeVar->getImpl();
  if (auto nodePtr = impl.getGraphNode()) {
    assert(impl.getGraphIndex() < TypeVariables.size() && "Out-of-bounds index");
    assert(TypeVariables[impl.getGraphIndex()] == typeVar &&
           "Type variable mismatch");
    return { *nodePtr, impl.getGraphIndex() };
  }

```
Stack trace:

```
0 0x0000000003ae8f28 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3ae8f28)
1 0x0000000003ae9666 SignalHandler(int) (/path/to/swift/bin/swift+0x3ae9666)
2 0x00007f7cdb9c7390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007f7cd9eec428 gsignal /build/glibc-bfm8X4/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f7cd9eee02a abort /build/glibc-bfm8X4/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f7cd9ee4bd7 __assert_fail_base /build/glibc-bfm8X4/glibc-2.23/assert/assert.c:92:0
6 0x00007f7cd9ee4c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x000000000119a2bb (/path/to/swift/bin/swift+0x119a2bb)
8 0x000000000119bbdf swift::constraints::ConstraintGraph::addConstraint(swift::constraints::Constraint*) (/path/to/swift/bin/swift+0x119bbdf)
9 0x000000000116a909 swift::constraints::ConstraintSystem::addUnsolvedConstraint(swift::constraints::Constraint*) (/path/to/swift/bin/swift+0x116a909)
10 0x000000000117cf20 swift::constraints::ConstraintSystem::addExplicitConversionConstraint(swift::Type, swift::Type, bool, swift::constraints::ConstraintLocatorBuilder) (/path/to/swift/bin/swift+0x117cf20)
11 0x00000000011618af swift::ASTVisitor<(anonymous namespace)::ConstraintGenerator, swift::Type, void, void, void, void, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x11618af)
12 0x00000000011683b8 (anonymous namespace)::ConstraintWalker::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0x11683b8)
13 0x0000000001550faf swift::ASTVisitor<(anonymous namespace)::Traversal, swift::Expr*, swift::Stmt*, bool, swift::Pattern*, bool, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x1550faf)
14 0x000000000154dbdb swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x154dbdb)
15 0x000000000115ed91 swift::constraints::ConstraintSystem::generateConstraints(swift::Expr*) (/path/to/swift/bin/swift+0x115ed91)
16 0x000000000118be18 swift::constraints::ConstraintSystem::solve(swift::Expr*&, swift::Type, swift::ExprTypeCheckListener*, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0x118be18)
17 0x00000000011bf997 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0x11bf997)
18 0x00000000011c4012 swift::TypeChecker::getPossibleTypesOfExpressionWithoutApplying(swift::Expr*&, swift::DeclContext*, llvm::SmallVectorImpl<swift::Type>&, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*) (/path/to/swift/bin/swift+0x11c4012)
19 0x00000000012b856b (anonymous namespace)::FailureDiagnosis::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0x12b856b)
20 0x000000000129b642 swift::ASTVisitor<(anonymous namespace)::FailureDiagnosis, bool, void, void, void, void, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x129b642)
21 0x0000000001295162 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) (/path/to/swift/bin/swift+0x1295162)
22 0x000000000129b049 swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) (/path/to/swift/bin/swift+0x129b049)
23 0x00000000011bf9d8 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0x11bf9d8)
24 0x00000000011c3795 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x11c3795)
25 0x000000000124aab0 swift::ASTVisitor<(anonymous namespace)::StmtChecker, void, swift::Stmt*, void, void, void, void>::visit(swift::Stmt*) (/path/to/swift/bin/swift+0x124aab0)
26 0x000000000124a2b6 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) (/path/to/swift/bin/swift+0x124a2b6)
27 0x0000000001268850 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x1268850)
28 0x0000000000fb59e7 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xfb59e7)
29 0x00000000004ad9f8 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4ad9f8)
30 0x00000000004abfa1 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4abfa1)
31 0x00000000004655d4 main (/path/to/swift/bin/swift+0x4655d4)
32 0x00007f7cd9ed7830 __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:325:0
33 0x0000000000462ea9 _start (/path/to/swift/bin/swift+0x462ea9)
```