### PR TITLE
[swiftc (48 vs. 5582)] Add crasher in swift::SubstitutionMap::lookupConformance

### DIFF
--- a/validation-test/compiler_crashers/28824-hasval.swift
+++ b/validation-test/compiler_crashers/28824-hasval.swift
@@ -1,0 +1,12 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+extension CountableRange{protocol b{typealias a:RangeReplaceableCollection
+protocol P{}
+class a:RangeReplaceableCollection


### PR DESCRIPTION
Add test case for crash triggered in `swift::SubstitutionMap::lookupConformance`.

Current number of unresolved compiler crashers: 48 (5582 resolved)

Assertion failure in `llvm/include/llvm/ADT/Optional.h (line 138)`:

```
Assertion `hasVal' failed.

When executing: T &&llvm::Optional<swift::ProtocolConformanceRef>::operator*() && [T = swift::ProtocolConformanceRef]
```

Assertion context:

```c++
    return hasValue() ? getValue() : std::forward<U>(value);
  }

#if LLVM_HAS_RVALUE_REFERENCE_THIS
  T&& getValue() && { assert(hasVal); return std::move(*getPointer()); }
  T&& operator*() && { assert(hasVal); return std::move(*getPointer()); }

  template <typename U>
  T getValueOr(U &&value) && {
    return hasValue() ? std::move(getValue()) : std::forward<U>(value);
  }
```
Stack trace:

```
0 0x0000000003ae8f28 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3ae8f28)
1 0x0000000003ae9666 SignalHandler(int) (/path/to/swift/bin/swift+0x3ae9666)
2 0x00007fb288bad390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007fb2870d2428 gsignal /build/glibc-bfm8X4/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007fb2870d402a abort /build/glibc-bfm8X4/glibc-2.23/stdlib/abort.c:91:0
5 0x00007fb2870cabd7 __assert_fail_base /build/glibc-bfm8X4/glibc-2.23/assert/assert.c:92:0
6 0x00007fb2870cac82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x00000000015f71a9 swift::SubstitutionMap::lookupConformance(swift::CanType, swift::ProtocolDecl*) const (/path/to/swift/bin/swift+0x15f71a9)
8 0x0000000001603ca0 swift::LookUpConformanceInSubstitutionMap::operator()(swift::CanType, swift::Type, swift::ProtocolType*) const (/path/to/swift/bin/swift+0x1603ca0)
9 0x0000000000c39469 llvm::Optional<swift::ProtocolConformanceRef> llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>::callback_fn<swift::LookUpConformanceInSubstitutionMap>(long, swift::CanType, swift::Type, swift::ProtocolType*) (/path/to/swift/bin/swift+0xc39469)
10 0x00000000016041ad getMemberForBaseType(llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::Type, swift::Type, swift::AssociatedTypeDecl*, swift::Identifier, swift::SubstOptions) (/path/to/swift/bin/swift+0x16041ad)
11 0x0000000001608f09 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x1608f09)
12 0x0000000001605156 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x1605156)
13 0x00000000016003f5 swift::Type::subst(swift::SubstitutionMap const&, swift::SubstOptions) const (/path/to/swift/bin/swift+0x16003f5)
14 0x00000000015ec786 swift::SpecializedProtocolConformance::getTypeWitnessAndDecl(swift::AssociatedTypeDecl*, swift::LazyResolver*, swift::SubstOptions) const (/path/to/swift/bin/swift+0x15ec786)
15 0x00000000015ebec2 swift::ProtocolConformance::getTypeWitnessAndDecl(swift::AssociatedTypeDecl*, swift::LazyResolver*, swift::SubstOptions) const (/path/to/swift/bin/swift+0x15ebec2)
16 0x00000000015eb8d9 swift::ProtocolConformance::getTypeWitness(swift::AssociatedTypeDecl*, swift::LazyResolver*, swift::SubstOptions) const (/path/to/swift/bin/swift+0x15eb8d9)
17 0x0000000001604277 getMemberForBaseType(llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::Type, swift::Type, swift::AssociatedTypeDecl*, swift::Identifier, swift::SubstOptions) (/path/to/swift/bin/swift+0x1604277)
18 0x0000000001608f09 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<substType(swift::Type, llvm::function_ref<swift::Type (swift::SubstitutableType*)>, llvm::function_ref<llvm::Optional<swift::ProtocolConformanceRef> (swift::CanType, swift::Type, swift::ProtocolType*)>, swift::SubstOptions)::$_18>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x1608f09)
19 0x0000000001605156 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x1605156)
20 0x00000000016003f5 swift::Type::subst(swift::SubstitutionMap const&, swift::SubstOptions) const (/path/to/swift/bin/swift+0x16003f5)
21 0x00000000015ec786 swift::SpecializedProtocolConformance::getTypeWitnessAndDecl(swift::AssociatedTypeDecl*, swift::LazyResolver*, swift::SubstOptions) const (/path/to/swift/bin/swift+0x15ec786)
22 0x00000000015ebec2 swift::ProtocolConformance::getTypeWitnessAndDecl(swift::AssociatedTypeDecl*, swift::LazyResolver*, swift::SubstOptions) const (/path/to/swift/bin/swift+0x15ebec2)
23 0x00000000015eb8d9 swift::ProtocolConformance::getTypeWitness(swift::AssociatedTypeDecl*, swift::LazyResolver*, swift::SubstOptions) const (/path/to/swift/bin/swift+0x15eb8d9)
24 0x00000000015a40a2 concretizeNestedTypeFromConcreteParent(swift::GenericSignatureBuilder::PotentialArchetype*, swift::GenericSignatureBuilder::PotentialArchetype*, swift::GenericSignatureBuilder&) (/path/to/swift/bin/swift+0x15a40a2)
25 0x00000000015acb3b swift::GenericSignatureBuilder::addSameTypeRequirementToConcrete(swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type, swift::GenericSignatureBuilder::RequirementSource const*) (/path/to/swift/bin/swift+0x15acb3b)
26 0x00000000015ac5bc swift::GenericSignatureBuilder::addSameTypeRequirement(llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::FloatingRequirementSource, swift::GenericSignatureBuilder::UnresolvedHandlingKind, llvm::function_ref<void (swift::Type, swift::Type)>) (/path/to/swift/bin/swift+0x15ac5bc)
27 0x00000000015a4136 concretizeNestedTypeFromConcreteParent(swift::GenericSignatureBuilder::PotentialArchetype*, swift::GenericSignatureBuilder::PotentialArchetype*, swift::GenericSignatureBuilder&) (/path/to/swift/bin/swift+0x15a4136)
28 0x00000000015acb3b swift::GenericSignatureBuilder::addSameTypeRequirementToConcrete(swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type, swift::GenericSignatureBuilder::RequirementSource const*) (/path/to/swift/bin/swift+0x15acb3b)
29 0x00000000015ac5bc swift::GenericSignatureBuilder::addSameTypeRequirement(llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::FloatingRequirementSource, swift::GenericSignatureBuilder::UnresolvedHandlingKind, llvm::function_ref<void (swift::Type, swift::Type)>) (/path/to/swift/bin/swift+0x15ac5bc)
30 0x00000000015a4136 concretizeNestedTypeFromConcreteParent(swift::GenericSignatureBuilder::PotentialArchetype*, swift::GenericSignatureBuilder::PotentialArchetype*, swift::GenericSignatureBuilder&) (/path/to/swift/bin/swift+0x15a4136)
31 0x00000000015acb3b swift::GenericSignatureBuilder::addSameTypeRequirementToConcrete(swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type, swift::GenericSignatureBuilder::RequirementSource const*) (/path/to/swift/bin/swift+0x15acb3b)
32 0x00000000015ac5bc swift::GenericSignatureBuilder::addSameTypeRequirement(llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, llvm::PointerUnion<swift::GenericSignatureBuilder::PotentialArchetype*, swift::Type>, swift::GenericSignatureBuilder::FloatingRequirementSource, swift::GenericSignatureBuilder::UnresolvedHandlingKind, llvm::function_ref<void (swift::Type, swift::Type)>) (/path/to/swift/bin/swift+0x15ac5bc)
33 0x00000000015a3086 swift::GenericSignatureBuilder::PotentialArchetype::updateNestedTypeForConformance(llvm::PointerUnion<swift::AssociatedTypeDecl*, swift::TypeDecl*>, swift::ArchetypeResolutionKind) (/path/to/swift/bin/swift+0x15a3086)
34 0x00000000015a2513 swift::GenericSignatureBuilder::PotentialArchetype::getNestedArchetypeAnchor(swift::Identifier, swift::GenericSignatureBuilder&, swift::ArchetypeResolutionKind) (/path/to/swift/bin/swift+0x15a2513)
35 0x00000000015b0be6 getLocalAnchor(swift::GenericSignatureBuilder::PotentialArchetype*, swift::GenericSignatureBuilder&) (/path/to/swift/bin/swift+0x15b0be6)
36 0x00000000015af7bc swift::GenericSignatureBuilder::checkSameTypeConstraints(llvm::ArrayRef<swift::GenericTypeParamType*>, swift::GenericSignatureBuilder::PotentialArchetype*) (/path/to/swift/bin/swift+0x15af7bc)
37 0x00000000015ad5ea swift::GenericSignatureBuilder::finalize(swift::SourceLoc, llvm::ArrayRef<swift::GenericTypeParamType*>, bool) (/path/to/swift/bin/swift+0x15ad5ea)
38 0x000000000120d820 swift::TypeChecker::checkGenericEnvironment(swift::GenericParamList*, swift::DeclContext*, swift::GenericSignature*, bool, llvm::function_ref<void (swift::GenericSignatureBuilder&)>) (/path/to/swift/bin/swift+0x120d820)
39 0x000000000120dc13 swift::TypeChecker::validateGenericTypeSignature(swift::GenericTypeDecl*) (/path/to/swift/bin/swift+0x120dc13)
40 0x00000000011dcad2 swift::TypeChecker::validateDecl(swift::ValueDecl*) (/path/to/swift/bin/swift+0x11dcad2)
41 0x00000000011ed37f (anonymous namespace)::DeclChecker::visitProtocolDecl(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0x11ed37f)
42 0x00000000011dac54 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x11dac54)
43 0x00000000011ed69b (anonymous namespace)::DeclChecker::visitProtocolDecl(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0x11ed69b)
44 0x00000000011dac54 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x11dac54)
45 0x00000000011ebd3b (anonymous namespace)::DeclChecker::visitExtensionDecl(swift::ExtensionDecl*) (/path/to/swift/bin/swift+0x11ebd3b)
46 0x00000000011dac84 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x11dac84)
47 0x00000000011dab53 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x11dab53)
48 0x00000000012687e4 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x12687e4)
49 0x0000000000fb59e7 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xfb59e7)
50 0x00000000004ad9f8 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4ad9f8)
51 0x00000000004abfa1 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4abfa1)
52 0x00000000004655d4 main (/path/to/swift/bin/swift+0x4655d4)
53 0x00007fb2870bd830 __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:325:0
54 0x0000000000462ea9 _start (/path/to/swift/bin/swift+0x462ea9)
```