### PR TITLE
[swiftc (49 vs. 5582)] Add crasher in swift::TypeChecker::substMemberTypeWithBase

### DIFF
--- a/validation-test/compiler_crashers/28825-isa-classdecl-nominaldecl-expected-a-class-here.swift
+++ b/validation-test/compiler_crashers/28825-isa-classdecl-nominaldecl-expected-a-class-here.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol b:a{init(t:a}class a{class a


### PR DESCRIPTION
Add test case for crash triggered in `swift::TypeChecker::substMemberTypeWithBase`.

Current number of unresolved compiler crashers: 49 (5582 resolved)

/cc @slavapestov - just wanted to let you know that this crasher caused an assertion failure for the assertion `isa<ClassDecl>(nominalDecl) && "expected a class here"` added on 2017-04-07 by you in commit 473faf1e :-)

Assertion failure in [`lib/AST/Type.cpp (line 3230)`](https://github.com/apple/swift/blob/e1e759c758c6d08ee05c4a2e904a903b98d85f7d/lib/AST/Type.cpp#L3230):

```
Assertion `isa<ClassDecl>(nominalDecl) && "expected a class here"' failed.

When executing: swift::Type swift::TypeBase::getSuperclassForDecl(const swift::ClassDecl *)
```

Assertion context:

```c++
             "expected a class, archetype or existential");
      t = t->getSuperclass();
      assert(t && "archetype or existential is not class constrained");
      continue;
    }
    assert(isa<ClassDecl>(nominalDecl) && "expected a class here");

    if (nominalDecl == baseClass)
      return t;

    t = t->getSuperclass();
```
Stack trace:

```
0 0x0000000003ae8f28 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3ae8f28)
1 0x0000000003ae9666 SignalHandler(int) (/path/to/swift/bin/swift+0x3ae9666)
2 0x00007f9cb2da7390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007f9cb12cc428 gsignal /build/glibc-bfm8X4/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f9cb12ce02a abort /build/glibc-bfm8X4/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f9cb12c4bd7 __assert_fail_base /build/glibc-bfm8X4/glibc-2.23/assert/assert.c:92:0
6 0x00007f9cb12c4c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x00000000016046d9 (/path/to/swift/bin/swift+0x16046d9)
8 0x0000000001258829 swift::TypeChecker::substMemberTypeWithBase(swift::ModuleDecl*, swift::TypeDecl*, swift::Type) (/path/to/swift/bin/swift+0x1258829)
9 0x00000000012586c0 swift::TypeChecker::resolveTypeInContext(swift::TypeDecl*, swift::DeclContext*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*) (/path/to/swift/bin/swift+0x12586c0)
10 0x000000000126024d resolveTypeDecl(swift::TypeChecker&, swift::TypeDecl*, swift::SourceLoc, swift::DeclContext*, swift::DeclContext*, swift::GenericIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x126024d)
11 0x000000000125fda6 resolveTopLevelIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, swift::ComponentIdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x125fda6)
12 0x000000000125a363 resolveIdentTypeComponent(swift::TypeChecker&, swift::DeclContext*, llvm::ArrayRef<swift::ComponentIdentTypeRepr*>, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x125a363)
13 0x0000000001259cfa swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x1259cfa)
14 0x000000000125aab2 (anonymous namespace)::TypeResolver::resolveType(swift::TypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>) (/path/to/swift/bin/swift+0x125aab2)
15 0x000000000125a9bc swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x125a9bc)
16 0x0000000001259370 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) (/path/to/swift/bin/swift+0x1259370)
17 0x0000000001212e3e validateParameterType(swift::ParamDecl*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver&, swift::TypeChecker&) (/path/to/swift/bin/swift+0x1212e3e)
18 0x0000000001212c3a swift::TypeChecker::typeCheckParameterList(swift::ParameterList*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver&) (/path/to/swift/bin/swift+0x1212c3a)
19 0x000000000120aaac checkGenericFuncSignature(swift::TypeChecker&, swift::GenericSignatureBuilder*, swift::AbstractFunctionDecl*, swift::GenericTypeResolver&) (/path/to/swift/bin/swift+0x120aaac)
20 0x000000000120a6a9 swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) (/path/to/swift/bin/swift+0x120a6a9)
21 0x00000000011ee2d4 (anonymous namespace)::DeclChecker::visitConstructorDecl(swift::ConstructorDecl*) (/path/to/swift/bin/swift+0x11ee2d4)
22 0x00000000011dac64 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x11dac64)
23 0x00000000011ed69b (anonymous namespace)::DeclChecker::visitProtocolDecl(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0x11ed69b)
24 0x00000000011dac54 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x11dac54)
25 0x00000000011dab53 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x11dab53)
26 0x00000000012687e4 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x12687e4)
27 0x0000000000fb59e7 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xfb59e7)
28 0x00000000004ad9f8 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4ad9f8)
29 0x00000000004abfa1 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4abfa1)
30 0x00000000004655d4 main (/path/to/swift/bin/swift+0x4655d4)
31 0x00007f9cb12b7830 __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:325:0
32 0x0000000000462ea9 _start (/path/to/swift/bin/swift+0x462ea9)
```