### PR TITLE
[swiftc (50 vs. 5582)] Add crasher in swift::constraints::ConstraintSystem::matchTypes

### DIFF
--- a/validation-test/compiler_crashers/28826-type-haserror-should-not-be-assigning-a-type-involving-errortype.swift
+++ b/validation-test/compiler_crashers/28826-type-haserror-should-not-be-assigning-a-type-involving-errortype.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// REQUIRES: asserts
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+protocol A{{}protocol a{extension{class a<a{let d=a(class a<P


### PR DESCRIPTION
Add test case for crash triggered in `swift::constraints::ConstraintSystem::matchTypes`.

Current number of unresolved compiler crashers: 50 (5582 resolved)

/cc @rudkx - just wanted to let you know that this crasher caused an assertion failure for the assertion `!type->hasError() && "Should not be assigning a type involving ErrorType!"` added on 2017-05-24 by you in commit e83131da :-)

Assertion failure in [`lib/Sema/ConstraintSystem.cpp (line 132)`](https://github.com/apple/swift/blob/01510ec93d4f8cf2664cd4576139e78a2c75b879/lib/Sema/ConstraintSystem.cpp#L132):

```
Assertion `!type->hasError() && "Should not be assigning a type involving ErrorType!"' failed.

When executing: void swift::constraints::ConstraintSystem::assignFixedType(swift::TypeVariableType *, swift::Type, bool)
```

Assertion context:

```c++
}

void ConstraintSystem::assignFixedType(TypeVariableType *typeVar, Type type,
                                       bool updateState) {
  assert(!type->hasError() &&
         "Should not be assigning a type involving ErrorType!");

  typeVar->getImpl().assignFixedType(type, getSavedBindings());

  if (!updateState)
    return;
```
Stack trace:

```
0 0x0000000003ae8f28 llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/path/to/swift/bin/swift+0x3ae8f28)
1 0x0000000003ae9666 SignalHandler(int) (/path/to/swift/bin/swift+0x3ae9666)
2 0x00007f17747a4390 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x11390)
3 0x00007f1772cc9428 gsignal /build/glibc-bfm8X4/glibc-2.23/signal/../sysdeps/unix/sysv/linux/raise.c:54:0
4 0x00007f1772ccb02a abort /build/glibc-bfm8X4/glibc-2.23/stdlib/abort.c:91:0
5 0x00007f1772cc1bd7 __assert_fail_base /build/glibc-bfm8X4/glibc-2.23/assert/assert.c:92:0
6 0x00007f1772cc1c82 (/lib/x86_64-linux-gnu/libc.so.6+0x2dc82)
7 0x00000000011a712e (/path/to/swift/bin/swift+0x11a712e)
8 0x00000000011712ae swift::constraints::ConstraintSystem::matchTypes(swift::Type, swift::Type, swift::constraints::ConstraintKind, swift::OptionSet<swift::constraints::ConstraintSystem::TypeMatchFlags, unsigned int>, swift::constraints::ConstraintLocatorBuilder) (/path/to/swift/bin/swift+0x11712ae)
9 0x0000000001180ca8 swift::constraints::ConstraintSystem::addConstraintImpl(swift::constraints::ConstraintKind, swift::Type, swift::Type, swift::constraints::ConstraintLocatorBuilder, bool) (/path/to/swift/bin/swift+0x1180ca8)
10 0x00000000011778ad swift::constraints::ConstraintSystem::addConstraint(swift::constraints::ConstraintKind, swift::Type, swift::Type, swift::constraints::ConstraintLocatorBuilder, bool) (/path/to/swift/bin/swift+0x11778ad)
11 0x00000000011a8e77 swift::constraints::ConstraintSystem::openGeneric(swift::DeclContext*, swift::DeclContext*, swift::GenericSignature*, bool, swift::constraints::ConstraintLocatorBuilder, llvm::DenseMap<swift::GenericTypeParamType*, swift::TypeVariableType*, llvm::DenseMapInfo<swift::GenericTypeParamType*>, llvm::detail::DenseMapPair<swift::GenericTypeParamType*, swift::TypeVariableType*> >&) (/path/to/swift/bin/swift+0x11a8e77)
12 0x00000000011a81d9 swift::constraints::ConstraintSystem::openUnboundGenericType(swift::UnboundGenericType*, swift::constraints::ConstraintLocatorBuilder, llvm::DenseMap<swift::GenericTypeParamType*, swift::TypeVariableType*, llvm::DenseMapInfo<swift::GenericTypeParamType*>, llvm::detail::DenseMapPair<swift::GenericTypeParamType*, swift::TypeVariableType*> >&) (/path/to/swift/bin/swift+0x11a81d9)
13 0x00000000011aee80 swift::Type llvm::function_ref<swift::Type (swift::Type)>::callback_fn<swift::constraints::ConstraintSystem::openUnboundGenericType(swift::Type, swift::constraints::ConstraintLocatorBuilder)::$_1>(long, swift::Type) (/path/to/swift/bin/swift+0x11aee80)
14 0x000000000160bbd6 llvm::Optional<swift::Type> llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>::callback_fn<swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const::$_13>(long, swift::TypeBase*) (/path/to/swift/bin/swift+0x160bbd6)
15 0x0000000001605156 swift::Type::transformRec(llvm::function_ref<llvm::Optional<swift::Type> (swift::TypeBase*)>) const (/path/to/swift/bin/swift+0x1605156)
16 0x00000000015fc6c7 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const (/path/to/swift/bin/swift+0x15fc6c7)
17 0x00000000011a8988 swift::constraints::ConstraintSystem::openUnboundGenericType(swift::Type, swift::constraints::ConstraintLocatorBuilder) (/path/to/swift/bin/swift+0x11a8988)
18 0x00000000011626cf swift::ASTVisitor<(anonymous namespace)::ConstraintGenerator, swift::Type, void, void, void, void, void>::visit(swift::Expr*) (/path/to/swift/bin/swift+0x11626cf)
19 0x00000000011683b8 (anonymous namespace)::ConstraintWalker::walkToExprPost(swift::Expr*) (/path/to/swift/bin/swift+0x11683b8)
20 0x0000000001551a9c (anonymous namespace)::Traversal::visitApplyExpr(swift::ApplyExpr*) (/path/to/swift/bin/swift+0x1551a9c)
21 0x000000000154dbdb swift::Expr::walk(swift::ASTWalker&) (/path/to/swift/bin/swift+0x154dbdb)
22 0x000000000115ed91 swift::constraints::ConstraintSystem::generateConstraints(swift::Expr*) (/path/to/swift/bin/swift+0x115ed91)
23 0x000000000118be18 swift::constraints::ConstraintSystem::solve(swift::Expr*&, swift::Type, swift::ExprTypeCheckListener*, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) (/path/to/swift/bin/swift+0x118be18)
24 0x00000000011bf997 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) (/path/to/swift/bin/swift+0x11bf997)
25 0x00000000011c3795 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem*) (/path/to/swift/bin/swift+0x11c3795)
26 0x00000000011c7f31 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*, bool) (/path/to/swift/bin/swift+0x11c7f31)
27 0x00000000011c81a6 swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int, bool) (/path/to/swift/bin/swift+0x11c81a6)
28 0x00000000011e0a18 validatePatternBindingEntries(swift::TypeChecker&, swift::PatternBindingDecl*) (/path/to/swift/bin/swift+0x11e0a18)
29 0x00000000011dac9d (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x11dac9d)
30 0x00000000011ec4ab (anonymous namespace)::DeclChecker::visitClassDecl(swift::ClassDecl*) (/path/to/swift/bin/swift+0x11ec4ab)
31 0x00000000011dad4e (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x11dad4e)
32 0x00000000011ebd3b (anonymous namespace)::DeclChecker::visitExtensionDecl(swift::ExtensionDecl*) (/path/to/swift/bin/swift+0x11ebd3b)
33 0x00000000011dac84 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x11dac84)
34 0x00000000011ed69b (anonymous namespace)::DeclChecker::visitProtocolDecl(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0x11ed69b)
35 0x00000000011dac54 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x11dac54)
36 0x00000000011ed69b (anonymous namespace)::DeclChecker::visitProtocolDecl(swift::ProtocolDecl*) (/path/to/swift/bin/swift+0x11ed69b)
37 0x00000000011dac54 (anonymous namespace)::DeclChecker::visit(swift::Decl*) (/path/to/swift/bin/swift+0x11dac54)
38 0x00000000011dab53 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) (/path/to/swift/bin/swift+0x11dab53)
39 0x00000000012687e4 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int, unsigned int, unsigned int) (/path/to/swift/bin/swift+0x12687e4)
40 0x0000000000fb59e7 swift::CompilerInstance::performSema() (/path/to/swift/bin/swift+0xfb59e7)
41 0x00000000004ad9f8 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/path/to/swift/bin/swift+0x4ad9f8)
42 0x00000000004abfa1 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/path/to/swift/bin/swift+0x4abfa1)
43 0x00000000004655d4 main (/path/to/swift/bin/swift+0x4655d4)
44 0x00007f1772cb4830 __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:325:0
45 0x0000000000462ea9 _start (/path/to/swift/bin/swift+0x462ea9)
```