### PR TITLE
NSNumber custom AnyHashable fix

### DIFF
--- a/test/stdlib/Inputs/FoundationBridge/FoundationBridge.h
+++ b/test/stdlib/Inputs/FoundationBridge/FoundationBridge.h
@@ -69,4 +69,10 @@ BOOL identityOfData(NSData *data);
 - (BOOL)verifyAutoupdatingLocale:(NSLocale *)locale;
 @end
 
+#pragma mark - NSNumber verification
+
+@interface NumberBridgingTester : NSObject
+- (BOOL)verifyKeysInRange:(NSRange)range existInDictionary:(NSDictionary *)dictionary;
+@end
+
 NS_ASSUME_NONNULL_END

--- a/test/stdlib/Inputs/FoundationBridge/FoundationBridge.m
+++ b/test/stdlib/Inputs/FoundationBridge/FoundationBridge.m
@@ -264,4 +264,16 @@ BOOL identityOfData(NSData *data) {
 
 @end
 
+@implementation NumberBridgingTester
 
+- (BOOL)verifyKeysInRange:(NSRange)range existInDictionary:(NSDictionary *)dictionary {
+    for (NSUInteger i = 0; i < range.length; i += 1) {
+        if (!dictionary[@(range.location + i)]) {
+            return NO;
+        }
+    }
+
+    return YES;
+}
+
+@end

--- a/test/stdlib/TestNSNumberBridging.swift
+++ b/test/stdlib/TestNSNumberBridging.swift
@@ -9,14 +9,20 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-// RUN: %target-run-simple-swift
+//
+// RUN: %empty-directory(%t)
+//
+// RUN: %target-clang %S/Inputs/FoundationBridge/FoundationBridge.m -c -o %t/FoundationBridgeObjC.o -g
+// RUN: %target-build-swift %s -I %S/Inputs/FoundationBridge/ -Xlinker %t/FoundationBridgeObjC.o -o %t/TestNSNumberBridging
+// 
+// RUN: %target-run %t/TestNSNumberBridging
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
-
 
 import StdlibUnittest
 import Foundation
 import CoreGraphics
+import FoundationBridgeObjC
 
 extension Float {
     init?(reasonably value: Float) {
@@ -898,6 +904,17 @@ func testNSNumberBridgeAnyHashable() {
     }
 }
 
+func testNSNumberBridgeAnyHashableObjc() {
+    let range = -Int(UInt8.min) ... Int(UInt8.max)
+    var dict = [AnyHashable : Any]()
+    for i in range {
+        dict[i] = "\(i)"
+    }
+
+    let verifier = NumberBridgingTester()
+    expectTrue(verifier.verifyKeys(in: NSRange(range), existIn: dict))
+}
+
 nsNumberBridging.test("Bridge Int8") { testNSNumberBridgeFromInt8() }
 nsNumberBridging.test("Bridge UInt8") { testNSNumberBridgeFromUInt8() }
 nsNumberBridging.test("Bridge Int16") { testNSNumberBridgeFromInt16() }
@@ -913,4 +930,5 @@ nsNumberBridging.test("Bridge Double") { testNSNumberBridgeFromDouble() }
 nsNumberBridging.test("Bridge CGFloat") { testNSNumberBridgeFromCGFloat() }
 nsNumberBridging.test("bitPattern to exactly") { test_numericBitPatterns_to_floatingPointTypes() }
 nsNumberBridging.test("Bridge AnyHashable") { testNSNumberBridgeAnyHashable() }
+nsNumberBridging.test("Bridge AnyHashable (ObjC)") { testNSNumberBridgeAnyHashableObjc() }
 runAllTests()

--- a/test/stdlib/TestNSNumberBridging.swift
+++ b/test/stdlib/TestNSNumberBridging.swift
@@ -873,6 +873,31 @@ func test_numericBitPatterns_to_floatingPointTypes() {
     }
 }
 
+func testNSNumberBridgeAnyHashable() {
+    var dict = [AnyHashable : Any]()
+    for i in -Int(UInt8.min) ... Int(UInt8.max) {
+        dict[i] = "\(i)"
+    }
+
+    // When bridging a dictionary to NSDictionary, we should be able to access
+    // the keys through either an Int (the original type boxed in AnyHashable)
+    // or NSNumber (the type Int bridged to).
+    let ns_dict = dict as NSDictionary
+    for i in -Int(UInt8.min) ... Int(UInt8.max) {
+        guard let value = ns_dict[i] as? String else {
+            expectUnreachable("Unable to look up value by Int key.")
+            continue
+        }
+
+        guard let ns_value = ns_dict[NSNumber(value: i)] as? String else {
+            expectUnreachable("Unable to look up value by NSNumber key.")
+            continue
+        }
+        
+        expectEqual(value, ns_value)
+    }
+}
+
 nsNumberBridging.test("Bridge Int8") { testNSNumberBridgeFromInt8() }
 nsNumberBridging.test("Bridge UInt8") { testNSNumberBridgeFromUInt8() }
 nsNumberBridging.test("Bridge Int16") { testNSNumberBridgeFromInt16() }
@@ -887,4 +912,5 @@ nsNumberBridging.test("Bridge Float") { testNSNumberBridgeFromFloat() }
 nsNumberBridging.test("Bridge Double") { testNSNumberBridgeFromDouble() }
 nsNumberBridging.test("Bridge CGFloat") { testNSNumberBridgeFromCGFloat() }
 nsNumberBridging.test("bitPattern to exactly") { test_numericBitPatterns_to_floatingPointTypes() }
+nsNumberBridging.test("Bridge AnyHashable") { testNSNumberBridgeAnyHashable() }
 runAllTests()


### PR DESCRIPTION
**What's in this pull request?**
Resolves rdar://problem/33105735.

When we give `NSNumber` a custom `AnyHashable` representation, we want to give it as large a box as possible. When we want to compare it against other `AnyHashable` boxes such as `Int` or `UInt`, it's always possible to upcast the `Int`/`UInt` to a larger integer size like `Int64` or `UInt64` for the comparison. By eliminating the smaller boxes we create, we can maintain the existing behavior that `_SwiftTypePreservingNSNumber` gave us.