### PR TITLE
[test] Re-disable objc_nonnull_lie_hack.swift.

### DIFF
--- a/test/SILGen/objc_nonnull_lie_hack.swift
+++ b/test/SILGen/objc_nonnull_lie_hack.swift
@@ -2,6 +2,7 @@
 // RUN: %target-swift-frontend -emit-sil -O -sdk %S/Inputs -I %S/Inputs -I %S/Inputs/objc_nonnull_lie_hack/ -enable-source-import -primary-file %s | %FileCheck -check-prefix=OPT %s
 
 // REQUIRES: objc_interop
+// REQUIRES: rdar33495516
 
 import Foundation
 import NonNilTest


### PR DESCRIPTION
The CHECK lines are too restrictive under different optimization. Disable the test to unblock the buildbots. Filed rdar://problem/33495516 to pick it up again later.