### PR TITLE
[SourceKit] Add typealias to doc structure - SR-4828

### DIFF
--- a/include/swift/IDE/SyntaxModel.h
+++ b/include/swift/IDE/SyntaxModel.h
@@ -92,6 +92,7 @@ enum class SyntaxStructureKind : uint8_t {
   ClassVariable,
   EnumCase,
   EnumElement,
+  TypeAlias,
 
   ForEachStatement,
   ForStatement,

--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -954,6 +954,16 @@ bool ModelASTWalker::walkToDeclPre(Decl *D) {
         popStructureNode();
       }
     }
+  } else if (auto *TypeAliasD = dyn_cast<TypeAliasDecl>(D)) {
+    SyntaxStructureNode SN;
+    SN.Dcl = TypeAliasD;
+    SN.Kind = SyntaxStructureKind::TypeAlias;
+    SN.Range = charSourceRangeFromSourceRange(SM,
+                                              TypeAliasD->getSourceRange());
+    SN.NameRange = CharSourceRange(TypeAliasD->getNameLoc(),
+                                   TypeAliasD->getName().getLength());
+    SN.Attrs = TypeAliasD->getAttrs();
+    pushStructureNode(SN, TypeAliasD);
   }
 
   return true;

--- a/test/IDE/structure.swift
+++ b/test/IDE/structure.swift
@@ -184,3 +184,6 @@ class A {
   func perform() {foo(5, animations: {})}
 // CHECK:  <ifunc>func <name>perform()</name> {<call><name>foo</name>(<arg>5</arg>, <arg><name>animations</name>: <brace>{}</brace></arg>)</call>}</ifunc>
 }
+
+// CHECK: <typealias>typealias <name>OtherA</name> = A</typealias>
+typealias OtherA = A

--- a/test/SourceKit/DocumentStructure/access_parse.swift.response
+++ b/test/SourceKit/DocumentStructure/access_parse.swift.response
@@ -650,6 +650,42 @@
           key.bodylength: 0
         }
       ]
+    },
+    {
+      key.kind: source.lang.swift.decl.typealias,
+      key.accessibility: source.lang.swift.accessibility.internal,
+      key.name: "defAlias",
+      key.offset: 1633,
+      key.length: 24,
+      key.nameoffset: 1643,
+      key.namelength: 8
+    },
+    {
+      key.kind: source.lang.swift.decl.typealias,
+      key.accessibility: source.lang.swift.accessibility.public,
+      key.name: "pubAlias",
+      key.offset: 1665,
+      key.length: 24,
+      key.nameoffset: 1675,
+      key.namelength: 8
+    },
+    {
+      key.kind: source.lang.swift.decl.typealias,
+      key.accessibility: source.lang.swift.accessibility.private,
+      key.name: "privAlias",
+      key.offset: 1698,
+      key.length: 25,
+      key.nameoffset: 1708,
+      key.namelength: 9
+    },
+    {
+      key.kind: source.lang.swift.decl.typealias,
+      key.accessibility: source.lang.swift.accessibility.internal,
+      key.name: "intAlias",
+      key.offset: 1733,
+      key.length: 24,
+      key.nameoffset: 1743,
+      key.namelength: 8
     }
   ]
 }

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift.response
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift.response
@@ -4633,6 +4633,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ]
   },
   {
+    key.kind: source.lang.swift.decl.typealias,
+    key.accessibility: source.lang.swift.accessibility.public,
+    key.name: "FooStruct1Pointer",
+    key.offset: 1543,
+    key.length: 62,
+    key.nameoffset: 1553,
+    key.namelength: 17
+  },
+  {
     key.kind: source.lang.swift.decl.struct,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooStruct2",
@@ -4706,6 +4715,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ]
   },
   {
+    key.kind: source.lang.swift.decl.typealias,
+    key.accessibility: source.lang.swift.accessibility.public,
+    key.name: "FooStructTypedef1",
+    key.offset: 1751,
+    key.length: 40,
+    key.nameoffset: 1761,
+    key.namelength: 17
+  },
+  {
     key.kind: source.lang.swift.decl.struct,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooStructTypedef2",
@@ -4777,6 +4795,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         ]
       }
     ]
+  },
+  {
+    key.kind: source.lang.swift.decl.typealias,
+    key.accessibility: source.lang.swift.accessibility.public,
+    key.name: "FooTypedef1",
+    key.offset: 1974,
+    key.length: 29,
+    key.nameoffset: 1984,
+    key.namelength: 11
   },
   {
     key.kind: source.lang.swift.decl.var.global,
@@ -5347,6 +5374,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.namelength: 15
       }
     ]
+  },
+  {
+    key.kind: source.lang.swift.decl.typealias,
+    key.accessibility: source.lang.swift.accessibility.public,
+    key.name: "typedef_int_t",
+    key.offset: 4624,
+    key.length: 31,
+    key.nameoffset: 4634,
+    key.namelength: 13
   },
   {
     key.kind: source.lang.swift.decl.var.global,

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -375,6 +375,8 @@ UIdent SwiftLangSupport::getUIDForSyntaxStructureKind(
       return KindDeclEnumCase;
     case SyntaxStructureKind::EnumElement:
       return KindDeclEnumElement;
+    case SyntaxStructureKind::TypeAlias:
+      return KindDeclTypeAlias;
     case SyntaxStructureKind::Parameter:
       return KindDeclVarParam;
     case SyntaxStructureKind::ForEachStatement:

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -1069,6 +1069,7 @@ private:
       case SyntaxStructureKind::ClassVariable: return "cvar";
       case SyntaxStructureKind::EnumCase: return "enum-case";
       case SyntaxStructureKind::EnumElement: return "enum-elem";
+      case SyntaxStructureKind::TypeAlias: return "typealias";
       case SyntaxStructureKind::Parameter: return "param";
       case SyntaxStructureKind::ForEachStatement: return "foreach";
       case SyntaxStructureKind::ForStatement: return "for";


### PR DESCRIPTION
This adds `typealias` declarations to the SourceKit document structure as included in the response from source.request.editor.open.{ interface/ interface.header/ interface.swiftsource/ interface.swifttype} and editor.replacetext.  Update tests.

Resolves [SR-4828](https://bugs.swift.org/browse/SR-4828).

One reason why it’s important for SourceKit clients to have all declarations included in doc structure is that it is the only interface that includes accessibility.  There are 3-4 decl types missing/wrong right now.

This PR is pretty tentative: I can believe there are Xcode dependencies making it impractical for community changes to this part of the code, but I thought it was worth a shot.  I built a toolchain and Xcode seems happy enough with it, not comprehensive ofc.

Code note: I added the new enum case alongside the other decl enum cases rather than at the end because the enum does not look to get persisted anywhere.