### PR TITLE
SILGen: Fix override handling when a dynamic init is also required.

### DIFF
--- a/include/swift/SIL/SILVTableVisitor.h
+++ b/include/swift/SIL/SILVTableVisitor.h
@@ -56,7 +56,7 @@ template <class T> class SILVTableVisitor {
       bool needsAllocatingEntry = cd->needsNewVTableEntry();
       if (!needsAllocatingEntry)
         if (auto *baseCD = cd->getOverriddenDecl())
-          needsAllocatingEntry = !baseCD->isRequired();
+          needsAllocatingEntry = !baseCD->isRequired() || baseCD->hasClangNode();
       maybeAddEntry(SILDeclRef(cd, SILDeclRef::Kind::Allocator),
                     needsAllocatingEntry);
     }

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -1949,8 +1949,11 @@ static bool requiresNewVTableEntry(SILDeclRef method) {
     return true;
   if (method.kind == SILDeclRef::Kind::Allocator) {
     auto *ctor = cast<ConstructorDecl>(method.getDecl());
-    if (ctor->isRequired() && !ctor->getOverriddenDecl()->isRequired())
-      return true;
+    if (ctor->isRequired()) {
+      if (!ctor->getOverriddenDecl()->isRequired()
+          || ctor->getOverriddenDecl()->hasClangNode())
+        return true;
+    }
   }
   return false;
 }

--- a/test/SILGen/Inputs/objc_dynamic_init.h
+++ b/test/SILGen/Inputs/objc_dynamic_init.h
@@ -1,0 +1,13 @@
+@import Foundation;
+
+@protocol ObjCInitProto
+
+- initWithProto:(NSInteger)x;
+
+@end
+
+@interface ObjCBaseWithInitProto: NSObject <ObjCInitProto>
+
+- initWithProto:(NSInteger)x NS_DESIGNATED_INITIALIZER;
+
+@end

--- a/test/SILGen/objc_dynamic_init.swift
+++ b/test/SILGen/objc_dynamic_init.swift
@@ -1,20 +1,45 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -import-objc-header %S/Inputs/objc_dynamic_init.h -emit-silgen %s | %FileCheck %s
 // REQUIRES: objc_interop
 
 import Foundation
 
-protocol Person {
+protocol Hoozit {
     init()
 }
 
-class Driver: NSObject, Person {
+protocol Wotsit {
+    init()
+}
+
+class Gadget: NSObject, Hoozit {
     required override init() {
         super.init()
     }
 }
 
-// CHECK-LABEL: sil private [transparent] [thunk] @_T{{.*}}DriverC{{.*}}CTW
-// CHECK:         class_method {{%.*}} : $@thick Driver.Type, #Driver.init!allocator.1 :
+class Gizmo: Gadget, Wotsit {
+    required init() {
+        super.init()
+    }
+}
 
-// CHECK-LABEL: sil_vtable Driver {
-// CHECK:         #Driver.init!allocator.1: (Driver.Type) -> () -> Driver : _T{{.*}}DriverC{{.*}}C {{ *}}//
+class Thingamabob: ObjCBaseWithInitProto {
+    required init(proto: Int) {
+        super.init(proto: proto)
+    }
+}
+
+final class Bobamathing: Thingamabob {
+    required init(proto: Int) {
+        super.init(proto: proto)
+    }
+}
+
+// CHECK-LABEL: sil private [transparent] [thunk] @_T{{.*}}GadgetC{{.*}}CTW
+// CHECK:         class_method {{%.*}} : $@thick Gadget.Type, #Gadget.init!allocator.1 :
+
+// CHECK-LABEL: sil_vtable Gadget {
+// CHECK:         #Gadget.init!allocator.1: (Gadget.Type) -> () -> Gadget : _T{{.*}}GadgetC{{.*}}C {{ *}}//
+
+// CHECK-LABEL: sil_vtable Gizmo {
+// CHECK:         #Gadget.init!allocator.1: (Gadget.Type) -> () -> Gadget : _T{{.*}}GizmoC{{.*}}C {{ *}}//


### PR DESCRIPTION
A missed case from #11107. Fixes SR-5542 | rdar://problem/33490780.