### PR TITLE
Shared parameters do not need a load

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3877,7 +3877,7 @@ bool VarDecl::isSettable(const DeclContext *UseDC,
                          const DeclRefExpr *base) const {
   // If this is a 'var' decl, then we're settable if we have storage or a
   // setter.
-  if (!isLet())
+  if (!isLet() && !isShared())
     return ::isSettable(this);
 
   // If the decl has a value bound to it but has no PBD, then it is


### PR DESCRIPTION
A quick patch up of a downstream callee of `doesStorageProduceLValue` so we don't emit `LoadExpr`s for declrefs of `__shared` parameters.