### PR TITLE
Fix IndexSet.RangeView indexing with subranges

### DIFF
--- a/stdlib/public/SDK/Foundation/IndexSet.swift
+++ b/stdlib/public/SDK/Foundation/IndexSet.swift
@@ -58,42 +58,16 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
         
         fileprivate var indexSet: IndexSet
         
-        // Range of element values
-        private var intersectingRange : Range<IndexSet.Element>?
-        
         fileprivate init(indexSet : IndexSet, intersecting range : Range<IndexSet.Element>?) {
-            self.indexSet = indexSet
-            self.intersectingRange = range
-            
             if let r = range {
-                if r.lowerBound == r.upperBound {
-                    startIndex = 0
-                    endIndex = 0
-                } else {
-                    let minIndex = indexSet._indexOfRange(containing: r.lowerBound)
-                    let maxIndex = indexSet._indexOfRange(containing: r.upperBound)
-                    
-                    switch (minIndex, maxIndex) {
-                    case (nil, nil):
-                        startIndex = 0
-                        endIndex = 0
-                    case (nil, .some(let max)):
-                        // Start is before our first range
-                        startIndex = 0
-                        endIndex = max + 1
-                    case (.some(let min), nil):
-                        // End is after our last range
-                        startIndex = min
-                        endIndex = indexSet._rangeCount
-                    case (.some(let min), .some(let max)):
-                        startIndex = min
-                        endIndex = max + 1
-                    }
-                }
+                let otherIndexes = IndexSet(integersIn: r)
+                self.indexSet = indexSet.intersection(otherIndexes)
             } else {
-                startIndex = 0
-                endIndex = indexSet._rangeCount
+                self.indexSet = indexSet
             }
+
+            self.startIndex = 0
+            self.endIndex = self.indexSet._rangeCount
         }
         
         public func makeIterator() -> IndexingIterator<RangeView> {
@@ -102,11 +76,7 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
         
         public subscript(index : Index) -> CountableRange<IndexSet.Element> {
             let indexSetRange = indexSet._range(at: index)
-            if let intersectingRange = intersectingRange {
-                return Swift.max(intersectingRange.lowerBound, indexSetRange.lowerBound)..<Swift.min(intersectingRange.upperBound, indexSetRange.upperBound)
-            } else {
-                return indexSetRange.lowerBound..<indexSetRange.upperBound
-            }
+            return indexSetRange.lowerBound..<indexSetRange.upperBound
         }
         
         public subscript(bounds: Range<Index>) -> BidirectionalSlice<RangeView> {

--- a/test/stdlib/TestIndexSet.swift
+++ b/test/stdlib/TestIndexSet.swift
@@ -230,63 +230,69 @@ class TestIndexSet : TestIndexSetSuper {
     }
     
     func testSubrangeIteration() {
-        var someIndexes = IndexSet(integersIn: 2..<5)
-        someIndexes.insert(integersIn: 8..<11)
-        someIndexes.insert(integersIn: 15..<20)
-        someIndexes.insert(integersIn: 30..<40)
-        someIndexes.insert(integersIn: 60..<80)
-        
-        var count = 0
-        for _ in someIndexes.rangeView {
-            count += 1
-        }
-        expectEqual(5, count)
-        
-        
-        count = 0
-        for r in someIndexes.rangeView(of: 9..<35) {
-            if count == 0 {
-                expectEqual(r, 9..<11)
-            }
-            count += 1
-            if count == 3 {
-                expectEqual(r, 30..<35)
-            }
-        }
-        expectEqual(3, count)
-        
-        count = 0
-        for r in someIndexes.rangeView(of: 0...34) {
-            if count == 0 {
-                expectEqual(r, 2..<5)
-            }
-            count += 1
-            if count == 4 {
-                expectEqual(r, 30..<35)
-            }
-        }
-        expectEqual(4, count)
+        func expectRanges(_ ranges: [Range<IndexSet.RangeView.Index>], in view: IndexSet.RangeView) {
+            expectEqual(ranges.count, view.count)
 
-        // Empty intersection, before start
-        count = 0
-        for _ in someIndexes.rangeView(of: 0..<1) {
-            count += 1
+            for i in 0 ..< min(ranges.count, view.count) {
+                expectEqual(Range(ranges[i]), Range(view[i]))
+            }
         }
-        expectEqual(0, count)
 
-        // Empty range
-        count = 0
-        for _ in someIndexes.rangeView(of: 0..<0) {
-            count += 1
-        }
-        expectEqual(0, count)
+        // Inclusive ranges for test:
+        // 2-4, 8-10, 15-19, 30-39, 60-79
+        var indexes = IndexSet()
+        indexes.insert(integersIn: 2..<5)
+        indexes.insert(integersIn: 8...10)
+        indexes.insert(integersIn: Range(15..<20))
+        indexes.insert(integersIn: Range(30...39))
+        indexes.insert(integersIn: 60..<80)
 
-        // Empty intersection, after end
-        count = 0
-        for _ in someIndexes.rangeView(of: 999..<1000) {
-            count += 1
-        }
-        expectEqual(0, count)
+        // Empty ranges should yield no results:
+        expectRanges([], in: indexes.rangeView(of: 0..<0))
+
+        // Ranges below contained indexes should yield no results:
+        expectRanges([], in: indexes.rangeView(of: 0...1))
+
+        // Ranges starting below first index but overlapping should yield a result:
+        expectRanges([2..<3], in: indexes.rangeView(of: 0...2))
+
+        // Ranges starting below first index but enveloping a range should yield a result:
+        expectRanges([2..<5], in: indexes.rangeView(of: 0...6))
+
+        // Ranges within subranges should yield a result:
+        expectRanges([2..<5], in: indexes.rangeView(of: 2...4))
+        expectRanges([3..<5], in: indexes.rangeView(of: 3...4))
+        expectRanges([3..<4], in: indexes.rangeView(of: 3..<4))
+
+        // Ranges starting within subranges and going over the end should yield a result:
+        expectRanges([3..<5], in: indexes.rangeView(of: 3...6))
+
+        // Ranges not matching any indexes should yield no results:
+        expectRanges([], in: indexes.rangeView(of: 5...6))
+        expectRanges([], in: indexes.rangeView(of: 5..<8))
+
+        // Same as above -- overlapping with a range of indexes should slice it appropriately:
+        expectRanges([8..<9], in: indexes.rangeView(of: 6...8))
+        expectRanges([8..<11], in: indexes.rangeView(of: 8...10))
+        expectRanges([8..<11], in: indexes.rangeView(of: 8...13))
+
+        expectRanges([2..<5, 8..<10], in: indexes.rangeView(of: 0...9))
+        expectRanges([2..<5, 8..<11], in: indexes.rangeView(of: 0...12))
+        expectRanges([3..<5, 8..<11], in: indexes.rangeView(of: 3...14))
+
+        expectRanges([3..<5, 8..<11, 15..<18], in: indexes.rangeView(of: 3...17))
+        expectRanges([3..<5, 8..<11, 15..<20], in: indexes.rangeView(of: 3...20))
+        expectRanges([3..<5, 8..<11, 15..<20], in: indexes.rangeView(of: 3...21))
+
+        // Ranges inclusive of the end index should yield all of the contained ranges:
+        expectRanges([2..<5, 8..<11, 15..<20, 30..<40, 60..<80], in: indexes.rangeView(of: 0...80))
+        expectRanges([2..<5, 8..<11, 15..<20, 30..<40, 60..<80], in: indexes.rangeView(of: 2..<80))
+        expectRanges([2..<5, 8..<11, 15..<20, 30..<40, 60..<80], in: indexes.rangeView(of: 2...80))
+
+        // Ranges above the end index should yield no results:
+        expectRanges([], in: indexes.rangeView(of: 90..<90))
+        expectRanges([], in: indexes.rangeView(of: 90...90))
+        expectRanges([], in: indexes.rangeView(of: 90...100))
     }
     
     func testSlicing() {


### PR DESCRIPTION
**What's in this pull request?**
Resolves [SR-5522](https://bugs.swift.org/browse/SR-5522). rdar://problem/33467986

On initialization, IndexSet.RangeView made the erroneous assumption that given an intersection range, a nil _indexOfRange(containing: bound) indicated that the bound was beyond the beginning or end of the index set. Instead, the index could simply not exist.

We now calculate the actual intersection of the parent index set with the given intersection range and use that as the index set to view.

This also makes the unit tests for testing range views more comprehensive.