### PR TITLE
[4.0] Codable class fixes

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2081,6 +2081,14 @@ NOTE(codable_codingkeys_type_is_not_an_enum_here,none,
      "cannot automatically synthesize %0 because 'CodingKeys' is not an enum", (Type))
 NOTE(codable_codingkeys_type_does_not_conform_here,none,
      "cannot automatically synthesize %0 because 'CodingKeys' does not conform to CodingKey", (Type))
+NOTE(decodable_no_super_init_here,none,
+     "cannot automatically synthesize %0 because superclass does not have a callable 'init()' or 'init(from:)'", (DeclName))
+NOTE(decodable_super_init_not_designated_here,none,
+     "cannot automatically synthesize %0 because required superclass initializer %1 is not designated", (DeclName, DeclName))
+NOTE(decodable_inaccessible_super_init_here,none,
+     "cannot automatically synthesize %0 because required superclass initializer %1 is inaccessible due to "
+     "'%select{private|fileprivate|internal|%error|%error}2' protection level",
+     (DeclName, DeclName, Accessibility))
 
 // Dynamic Self
 ERROR(dynamic_self_non_method,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2082,13 +2082,15 @@ NOTE(codable_codingkeys_type_is_not_an_enum_here,none,
 NOTE(codable_codingkeys_type_does_not_conform_here,none,
      "cannot automatically synthesize %0 because 'CodingKeys' does not conform to CodingKey", (Type))
 NOTE(decodable_no_super_init_here,none,
-     "cannot automatically synthesize %0 because superclass does not have a callable 'init()' or 'init(from:)'", (DeclName))
+     "cannot automatically synthesize %0 because superclass does not have a callable %1", (DeclName, DeclName))
 NOTE(decodable_super_init_not_designated_here,none,
-     "cannot automatically synthesize %0 because required superclass initializer %1 is not designated", (DeclName, DeclName))
+     "cannot automatically synthesize %0 because implementation would need to call %1, which is not designated", (DeclName, DeclName))
 NOTE(decodable_inaccessible_super_init_here,none,
-     "cannot automatically synthesize %0 because required superclass initializer %1 is inaccessible due to "
+     "cannot automatically synthesize %0 because implementation would need to call %1, which is inaccessible due to "
      "'%select{private|fileprivate|internal|%error|%error}2' protection level",
      (DeclName, DeclName, Accessibility))
+NOTE(decodable_super_init_is_failable_here,none,
+     "cannot automatically synthesize %0 because implementation would need to call %1, which is failable", (DeclName, DeclName))
 NOTE(decodable_suggest_overriding_init_here,none,
      "did you mean to override 'init(from:)'?", ())
 NOTE(codable_suggest_overriding_init_here,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2089,6 +2089,10 @@ NOTE(decodable_inaccessible_super_init_here,none,
      "cannot automatically synthesize %0 because required superclass initializer %1 is inaccessible due to "
      "'%select{private|fileprivate|internal|%error|%error}2' protection level",
      (DeclName, DeclName, Accessibility))
+NOTE(decodable_suggest_overriding_init_here,none,
+     "did you mean to override 'init(from:)'?", ())
+NOTE(codable_suggest_overriding_init_here,none,
+     "did you mean to override 'init(from:)' and 'encode(to:)'?", ())
 
 // Dynamic Self
 ERROR(dynamic_self_non_method,none,

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -1197,8 +1197,7 @@ static bool canSynthesize(TypeChecker &tc, NominalTypeDecl *target,
         // already), so just bail with a general error.
         return false;
       } else {
-        auto *initializer =
-          cast<ConstructorDecl>(result.front().getValueDecl());
+        auto *initializer = cast<ConstructorDecl>(result.front().Decl);
         if (!initializer->isDesignatedInit()) {
           // We must call a superclass's designated initializer.
           tc.diagnose(initializer,

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -526,7 +526,7 @@ static CallExpr *createContainerKeyedByCall(ASTContext &C, DeclContext *DC,
 /// Synthesizes the body for `func encode(to encoder: Encoder) throws`.
 ///
 /// \param encodeDecl The function decl whose body to synthesize.
-static void deriveBodyEncodable_encode(AbstractFunctionDecl *encodeDecl) {
+static BraceStmt *deriveBodyEncodable_encode(AbstractFunctionDecl *encodeDecl) {
   // struct Foo : Codable {
   //   var x: Int
   //   var y: String
@@ -693,9 +693,8 @@ static void deriveBodyEncodable_encode(AbstractFunctionDecl *encodeDecl) {
     statements.push_back(tryExpr);
   }
 
-  auto *body = BraceStmt::create(C, SourceLoc(), statements, SourceLoc(),
-                                 /*implicit=*/true);
-  encodeDecl->setBody(body);
+  return BraceStmt::create(C, SourceLoc(), statements, SourceLoc(),
+                           /*implicit=*/true);
 }
 
 /// Synthesizes a function declaration for `encode(to: Encoder) throws` with a
@@ -754,7 +753,7 @@ static FuncDecl *deriveEncodable_encode(TypeChecker &tc, Decl *parentDecl,
                                       TypeLoc::withoutLoc(returnType),
                                       target);
   encodeDecl->setImplicit();
-  encodeDecl->setBodySynthesizer(deriveBodyEncodable_encode);
+  encodeDecl->setBody(deriveBodyEncodable_encode(encodeDecl));
 
   // This method should be marked as 'override' for classes inheriting Encodable
   // conformance from a parent class.
@@ -793,8 +792,12 @@ static FuncDecl *deriveEncodable_encode(TypeChecker &tc, Decl *parentDecl,
 
 /// Synthesizes the body for `init(from decoder: Decoder) throws`.
 ///
+/// \param tc The \c TypeChecker to use in looking up potential superclass
+///           Decodable conformance.
+///
 /// \param initDecl The function decl whose body to synthesize.
-static void deriveBodyDecodable_init(AbstractFunctionDecl *initDecl) {
+static BraceStmt *deriveBodyDecodable_init(TypeChecker &tc,
+                                           AbstractFunctionDecl *initDecl) {
   // struct Foo : Codable {
   //   var x: Int
   //   var y: String
@@ -951,47 +954,96 @@ static void deriveBodyDecodable_init(AbstractFunctionDecl *initDecl) {
     }
   }
 
-  // Classes which inherit from something Decodable should decode super as well.
-  auto *classDecl = dyn_cast<ClassDecl>(targetDecl);
-  if (classDecl && superclassIsDecodable(classDecl)) {
-    // Need to generate `try super.init(from: container.superDecoder())`
+  // Classes which have a superclass must call super.init(from:) if the
+  // superclass is Decodable, or super.init() if it is not.
+  if (auto *classDecl = dyn_cast<ClassDecl>(targetDecl)) {
+    if (auto *superclassDecl = classDecl->getSuperclassDecl()) {
+      auto superType =  superclassDecl->getDeclaredInterfaceType();
+      if (tc.conformsToProtocol(superType,
+                                C.getProtocol(KnownProtocolKind::Decodable),
+                                superclassDecl, ConformanceCheckFlags::Used)) {
+        // Need to generate `try super.init(from: container.superDecoder())`
 
-    // superDecoder()
-    auto *method = new (C) UnresolvedDeclRefExpr(
-        DeclName(C.Id_superDecoder), DeclRefKind::Ordinary, DeclNameLoc());
+        // container.superDecoder
+        auto *superDecoderRef =
+          new (C) UnresolvedDotExpr(containerExpr, SourceLoc(),
+                                    DeclName(C.Id_superDecoder),
+                                    DeclNameLoc(), /*Implicit=*/true);
 
-    // container.superDecoder()
-    auto *superDecoderRef = new (C) DotSyntaxCallExpr(containerExpr,
-                                                      SourceLoc(), method);
+        // container.superDecoder()
+        auto *superDecoderCall =
+          CallExpr::createImplicit(C, superDecoderRef, ArrayRef<Expr *>(),
+                                   ArrayRef<Identifier>());
 
-    // init(from:) expr
-    auto *initDeclRef = new (C) DeclRefExpr(ConcreteDeclRef(initDecl),
-                                            DeclNameLoc(), /*Implicit=*/true);
+        // super
+        auto *superRef = new (C) SuperRefExpr(initDecl->getImplicitSelfDecl(),
+                                              SourceLoc(), /*Implicit=*/true);
 
-    // super
-    auto *superRef = new (C) SuperRefExpr(initDecl->getImplicitSelfDecl(),
-                                          SourceLoc(), /*Implicit=*/true);
+        // super.init(from:)
+        auto initName = DeclName(C, C.Id_init, (Identifier[1]){ C.Id_from });
+        auto *initCall = new (C) UnresolvedDotExpr(superRef, SourceLoc(),
+                                                   initName, DeclNameLoc(),
+                                                   /*Implicit=*/true);
 
-    // super.init(from:)
-    auto *decodeCall = new (C) DotSyntaxCallExpr(superRef, SourceLoc(),
-                                                 initDeclRef);
+        // super.decode(from: container.superDecoder())
+        Expr *args[1] = {superDecoderCall};
+        Identifier argLabels[1] = {C.Id_from};
+        auto *callExpr = CallExpr::createImplicit(C, initCall,
+                                                  C.AllocateCopy(args),
+                                                  C.AllocateCopy(argLabels));
 
-    // super.decode(from: container.superDecoder())
-    Expr *args[1] = {superDecoderRef};
-    Identifier argLabels[1] = {C.Id_from};
-    auto *callExpr = CallExpr::createImplicit(C, decodeCall,
-                                              C.AllocateCopy(args),
-                                              C.AllocateCopy(argLabels));
+        // try super.init(from: container.superDecoder())
+        auto *tryExpr = new (C) TryExpr(SourceLoc(), callExpr, Type(),
+                                        /*Implicit=*/true);
+        statements.push_back(tryExpr);
+      } else {
+        // The explicit constructor name is a compound name taking no arguments.
+        DeclName initName(C, C.Id_init, ArrayRef<Identifier>());
 
-    // try super.init(from: container.superDecoder())
-    auto *tryExpr = new (C) TryExpr(SourceLoc(), callExpr, Type(),
-                                    /*Implicit=*/true);
-    statements.push_back(tryExpr);
+        // We need to look this up in the superclass to see if it throws.
+        // We should have bailed one level up if super.init() is not available.
+        ConstructorDecl *superInitDecl = nullptr;
+        for (auto *decl : superclassDecl->getMembers()) {
+          auto *ctorDecl = dyn_cast<ConstructorDecl>(decl);
+          if (!ctorDecl)
+            continue;
+
+          if (ctorDecl->getParameters()->size() == 0) {
+            superInitDecl = ctorDecl;
+            break;
+          }
+        }
+
+        // We should have bailed one level up if this were not available.
+        assert(superInitDecl);
+
+        // super
+        auto *superRef = new (C) SuperRefExpr(initDecl->getImplicitSelfDecl(),
+                                              SourceLoc(), /*Implicit=*/true);
+
+        // super.init()
+        auto *superInitRef = new (C) UnresolvedDotExpr(superRef, SourceLoc(),
+                                                       initName, DeclNameLoc(),
+                                                       /*Implicit=*/true);
+        // super.init() call
+        auto *callExpr = CallExpr::createImplicit(C, superInitRef,
+                                                  ArrayRef<Expr *>(),
+                                                  ArrayRef<Identifier>());
+
+        if (superInitDecl->hasThrows()) {
+          // try super.init()
+          auto *tryExpr = new (C) TryExpr(SourceLoc(), callExpr, Type(),
+                                          /*Implicit=*/true);
+          statements.push_back(tryExpr);
+        } else {
+          statements.push_back(callExpr);
+        }
+      }
+    }
   }
 
-  auto *body = BraceStmt::create(C, SourceLoc(), statements, SourceLoc(),
-                                 /*implicit=*/true);
-  initDecl->setBody(body);
+  return BraceStmt::create(C, SourceLoc(), statements, SourceLoc(),
+                           /*implicit=*/true);
 }
 
 /// Synthesizes a function declaration for `init(from: Decoder) throws` with a
@@ -1055,7 +1107,7 @@ static ValueDecl *deriveDecodable_init(TypeChecker &tc, Decl *parentDecl,
                                            SourceLoc(), selfDecl, paramList,
                                            /*GenericParams=*/nullptr, target);
   initDecl->setImplicit();
-  initDecl->setBodySynthesizer(deriveBodyDecodable_init);
+  initDecl->setBody(deriveBodyDecodable_init(tc, initDecl));
 
   // This constructor should be marked as `required` for non-final classes.
   if (isa<ClassDecl>(target) && !target->getAttrs().hasAttribute<FinalAttr>()) {
@@ -1104,10 +1156,73 @@ static ValueDecl *deriveDecodable_init(TypeChecker &tc, Decl *parentDecl,
 ///
 /// \param target The type to validate.
 ///
+/// \param requirement The requirement we want to synthesize.
+///
 /// \param proto The *codable protocol to check for validity.
 static bool canSynthesize(TypeChecker &tc, NominalTypeDecl *target,
-                          ProtocolDecl *proto) {
-  // First, look up if the type has a valid CodingKeys enum we can use.
+                          ValueDecl *requirement, ProtocolDecl *proto) {
+  // Before we attempt to look up (or more importantly, synthesize) a CodingKeys
+  // entity on target, we need to make sure the type is otherwise valid.
+  //
+  // If we are synthesizing Decodable and the target is a class with a
+  // superclass, our synthesized init(from:) will need to call either
+  // super.init(from:) or super.init() depending on whether the superclass is
+  // Decodable itself.
+  //
+  // If the required initializer is not available, we shouldn't attempt to
+  // synthesize CodingKeys.
+  ASTContext &C = tc.Context;
+  auto *classDecl = dyn_cast<ClassDecl>(target);
+  if (proto == C.getProtocol(KnownProtocolKind::Decodable) && classDecl) {
+    if (auto *superclassDecl = classDecl->getSuperclassDecl()) {
+      DeclName memberName;
+      auto superType = superclassDecl->getDeclaredInterfaceType();
+      if (tc.conformsToProtocol(superType, proto, superclassDecl,
+                                ConformanceCheckFlags::Used)) {
+        // super.init(from:) must be accessible.
+        memberName = cast<ConstructorDecl>(requirement)->getEffectiveFullName();
+      } else {
+        // super.init() must be accessible.
+        // Passing an empty params array constructs a compound name with no
+        // arguments (as opposed to a simple name when omitted).
+        memberName = DeclName(C, DeclBaseName(C.Id_init),
+                              ArrayRef<Identifier>());
+      }
+
+      auto result = tc.lookupMember(superclassDecl, superType, memberName);
+
+      if (result.empty()) {
+        // No super initializer for us to call.
+        tc.diagnose(superclassDecl, diag::decodable_no_super_init_here,
+                    requirement->getFullName());
+        return false;
+      } else if (result.size() > 1) {
+        // There are multiple results for this lookup. We'll end up producing a
+        // diagnostic later complaining about duplicate methods (if we haven't
+        // already), so just bail with a general error.
+        return false;
+      } else {
+        auto *initializer = cast<ConstructorDecl>(result.front().Decl);
+        if (!initializer->isDesignatedInit()) {
+          // We must call a superclass's designated initializer.
+          tc.diagnose(initializer,
+                      diag::decodable_super_init_not_designated_here,
+                      requirement->getFullName(), memberName);
+          return false;
+        } else if (!initializer->isAccessibleFrom(target)) {
+          // Cannot call an inaccessible method.
+          auto accessScope = initializer->getFormalAccessScope(target);
+          tc.diagnose(initializer, diag::decodable_inaccessible_super_init_here,
+                      requirement->getFullName(), memberName,
+                      accessScope.accessibilityForDiagnostics());
+          return false;
+        }
+      }
+    }
+  }
+
+  // If the target already has a valid CodingKeys enum, we won't need to
+  // synthesize one.
   auto validity = hasValidCodingKeysEnum(tc, target, proto);
 
   // We found a type, but it wasn't valid.
@@ -1165,23 +1280,17 @@ ValueDecl *DerivedConformance::deriveEncodable(TypeChecker &tc,
   auto diagnosticTransaction = DiagnosticTransaction(tc.Context.Diags);
   tc.diagnose(target, diag::type_does_not_conform, target->getDeclaredType(),
               encodableType);
+  tc.diagnose(requirement, diag::no_witnesses, diag::RequirementKind::Func,
+              requirement->getFullName(), encodableType, /*AddFixIt=*/false);
 
   // Check other preconditions for synthesized conformance.
   // This synthesizes a CodingKeys enum if possible.
-  ValueDecl *witness = nullptr;
-  if (canSynthesize(tc, target, encodableProto))
-    witness = deriveEncodable_encode(tc, parentDecl, target);
-
-  if (witness == nullptr) {
-    // We didn't end up synthesizing encode(to:).
-    tc.diagnose(requirement, diag::no_witnesses, diag::RequirementKind::Func,
-                requirement->getFullName(), encodableType, /*AddFixIt=*/false);
-  } else {
-    // We succeeded -- no need to output the false error generated above.
+  if (canSynthesize(tc, target, requirement, encodableProto)) {
     diagnosticTransaction.abort();
+    return deriveEncodable_encode(tc, parentDecl, target);
   }
 
-  return witness;
+  return nullptr;
 }
 
 ValueDecl *DerivedConformance::deriveDecodable(TypeChecker &tc,
@@ -1215,22 +1324,16 @@ ValueDecl *DerivedConformance::deriveDecodable(TypeChecker &tc,
   auto diagnosticTransaction = DiagnosticTransaction(tc.Context.Diags);
   tc.diagnose(target, diag::type_does_not_conform, target->getDeclaredType(),
               decodableType);
+  tc.diagnose(requirement, diag::no_witnesses,
+              diag::RequirementKind::Constructor, requirement->getFullName(),
+              decodableType, /*AddFixIt=*/false);
 
   // Check other preconditions for synthesized conformance.
   // This synthesizes a CodingKeys enum if possible.
-  ValueDecl *witness = nullptr;
-  if (canSynthesize(tc, target, decodableProto))
-    witness = deriveDecodable_init(tc, parentDecl, target);
-
-  if (witness == nullptr) {
-    // We didn't end up synthesizing init(from:).
-    tc.diagnose(requirement, diag::no_witnesses,
-                diag::RequirementKind::Constructor, requirement->getFullName(),
-                decodableType, /*AddFixIt=*/false);
-  } else {
-    // We succeeded -- no need to output the false error generated above.
+  if (canSynthesize(tc, target, requirement, decodableProto)) {
     diagnosticTransaction.abort();
+    return deriveDecodable_init(tc, parentDecl, target);
   }
 
-  return witness;
+  return nullptr;
 }

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -801,12 +801,8 @@ static FuncDecl *deriveEncodable_encode(TypeChecker &tc, Decl *parentDecl,
 
 /// Synthesizes the body for `init(from decoder: Decoder) throws`.
 ///
-/// \param tc The \c TypeChecker to use in looking up potential superclass
-///           Decodable conformance.
-///
 /// \param initDecl The function decl whose body to synthesize.
-static BraceStmt *deriveBodyDecodable_init(TypeChecker &tc,
-                                           AbstractFunctionDecl *initDecl) {
+static void deriveBodyDecodable_init(AbstractFunctionDecl *initDecl) {
   // struct Foo : Codable {
   //   var x: Int
   //   var y: String
@@ -967,10 +963,7 @@ static BraceStmt *deriveBodyDecodable_init(TypeChecker &tc,
   // superclass is Decodable, or super.init() if it is not.
   if (auto *classDecl = dyn_cast<ClassDecl>(targetDecl)) {
     if (auto *superclassDecl = classDecl->getSuperclassDecl()) {
-      auto superType = superclassDecl->getDeclaredInterfaceType();
-      if (tc.conformsToProtocol(superType,
-                                C.getProtocol(KnownProtocolKind::Decodable),
-                                superclassDecl, ConformanceCheckOptions())) {
+      if (superclassIsDecodable(classDecl)) {
         // Need to generate `try super.init(from: container.superDecoder())`
 
         // container.superDecoder
@@ -1010,12 +1003,15 @@ static BraceStmt *deriveBodyDecodable_init(TypeChecker &tc,
         DeclName initName(C, C.Id_init, ArrayRef<Identifier>());
 
         // We need to look this up in the superclass to see if it throws.
-        ConstructorDecl *superInitDecl = nullptr;
         auto result = superclassDecl->lookupDirect(initName);
 
         // We should have bailed one level up if this were not available.
-        assert(!result.empty() &&
-               (superInitDecl = dyn_cast<ConstructorDecl>(result.front())));
+        assert(!result.empty());
+
+        // If the init is failable, we should have already bailed one level
+        // above.
+        ConstructorDecl *superInitDecl = cast<ConstructorDecl>(result.front());
+        assert(superInitDecl->getFailability() == OTK_None);
 
         // super
         auto *superRef = new (C) SuperRefExpr(initDecl->getImplicitSelfDecl(),
@@ -1030,10 +1026,6 @@ static BraceStmt *deriveBodyDecodable_init(TypeChecker &tc,
                                                   ArrayRef<Expr *>(),
                                                   ArrayRef<Identifier>());
 
-        // If super.init is failable, super.init()!
-        if (superInitDecl->getFailability() != OTK_None)
-          callExpr = new (C) ForceValueExpr(callExpr, SourceLoc());
-
         // If super.init throws, try super.init()
         if (superInitDecl->hasThrows())
           callExpr = new (C) TryExpr(SourceLoc(), callExpr, Type(),
@@ -1044,8 +1036,9 @@ static BraceStmt *deriveBodyDecodable_init(TypeChecker &tc,
     }
   }
 
-  return BraceStmt::create(C, SourceLoc(), statements, SourceLoc(),
-                           /*implicit=*/true);
+  auto *body = BraceStmt::create(C, SourceLoc(), statements, SourceLoc(),
+                                 /*implicit=*/true);
+  initDecl->setBody(body);
 }
 
 /// Synthesizes a function declaration for `init(from: Decoder) throws` with a
@@ -1109,7 +1102,7 @@ static ValueDecl *deriveDecodable_init(TypeChecker &tc, Decl *parentDecl,
                                            SourceLoc(), selfDecl, paramList,
                                            /*GenericParams=*/nullptr, target);
   initDecl->setImplicit();
-  initDecl->setBody(deriveBodyDecodable_init(tc, initDecl));
+  initDecl->setBodySynthesizer(deriveBodyDecodable_init);
 
   // This constructor should be marked as `required` for non-final classes.
   if (isa<ClassDecl>(target) && !target->getAttrs().hasAttribute<FinalAttr>()) {
@@ -1224,6 +1217,7 @@ static bool canSynthesize(TypeChecker &tc, NominalTypeDecl *target,
           // isn't failable.
           tc.diagnose(initializer, diag::decodable_super_init_is_failable_here,
                       requirement->getFullName(), memberName);
+          return false;
         }
       }
     }

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -660,8 +660,9 @@ static void deriveBodyEncodable_encode(AbstractFunctionDecl *encodeDecl) {
     // Need to generate `try super.encode(to: container.superEncoder())`
 
     // superEncoder()
-    auto *method = new (C) UnresolvedDeclRefExpr(
-        DeclName(C.Id_superEncoder), DeclRefKind::Ordinary, DeclNameLoc());
+    auto *method = new (C) UnresolvedDeclRefExpr(DeclName(C.Id_superEncoder),
+                                                 DeclRefKind::Ordinary,
+                                                 DeclNameLoc());
 
     // container.superEncoder()
     auto *superEncoderRef = new (C) DotSyntaxCallExpr(containerExpr,
@@ -940,9 +941,10 @@ static void deriveBodyDecodable_init(AbstractFunctionDecl *initDecl) {
                                       /*Implicit=*/true);
 
       auto *selfRef = createSelfDeclRef(initDecl);
-      auto *varExpr = new (C) UnresolvedDotExpr(
-          selfRef, SourceLoc(), DeclName(varDecl->getName()), DeclNameLoc(),
-          /*implicit=*/true);
+      auto *varExpr = new (C) UnresolvedDotExpr(selfRef, SourceLoc(),
+                                                DeclName(varDecl->getName()),
+                                                DeclNameLoc(),
+                                                /*implicit=*/true);
       auto *assignExpr = new (C) AssignExpr(varExpr, SourceLoc(), tryExpr,
                                             /*Implicit=*/true);
       statements.push_back(assignExpr);
@@ -1048,12 +1050,10 @@ static ValueDecl *deriveDecodable_init(TypeChecker &tc, Decl *parentDecl,
   // Func name: init(from: Decoder)
   DeclName name(C, C.Id_init, paramList);
 
-  auto *initDecl = new (C) ConstructorDecl(
-      name, SourceLoc(),
-      /*Failability=*/OTK_None,
-      /*FailabilityLoc=*/SourceLoc(),
-      /*Throws=*/true, /*ThrowsLoc=*/SourceLoc(), selfDecl, paramList,
-      /*GenericParams=*/nullptr, target);
+  auto *initDecl = new (C) ConstructorDecl(name, SourceLoc(), OTK_None,
+                                           SourceLoc(), /*Throws=*/true,
+                                           SourceLoc(), selfDecl, paramList,
+                                           /*GenericParams=*/nullptr, target);
   initDecl->setImplicit();
   initDecl->setBodySynthesizer(deriveBodyDecodable_init);
 
@@ -1082,8 +1082,8 @@ static ValueDecl *deriveDecodable_init(TypeChecker &tc, Decl *parentDecl,
 
   initDecl->setInterfaceType(interfaceType);
   initDecl->setInitializerInterfaceType(initializerType);
-  initDecl->setAccessibility(
-      std::max(target->getFormalAccess(), Accessibility::Internal));
+  initDecl->setAccessibility(std::max(target->getFormalAccess(),
+                                      Accessibility::Internal));
 
   // If the type was not imported, the derived conformance is either from the
   // type itself or an extension, in which case we will emit the declaration

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -184,8 +184,7 @@ static bool
 validateCodingKeysEnum(TypeChecker &tc, EnumDecl *codingKeysDecl,
                        NominalTypeDecl *target, ProtocolDecl *proto) {
   // Look through all var decls in the given type.
-  // * Filter out lazy/computed vars (currently already done by
-  //   getStoredProperties).
+  // * Filter out lazy/computed vars.
   // * Filter out ones which are present in the given decl (by name).
   //
   // If any of the entries in the CodingKeys decl are not present in the type
@@ -197,6 +196,9 @@ validateCodingKeysEnum(TypeChecker &tc, EnumDecl *codingKeysDecl,
   // against its CodingKey entry, it will get removed.
   llvm::SmallDenseMap<Identifier, VarDecl *, 8> properties;
   for (auto *varDecl : target->getStoredProperties(/*skipInaccessible=*/true)) {
+    if (varDecl->getAttrs().hasAttribute<LazyAttr>())
+      continue;
+
     properties[varDecl->getName()] = varDecl;
   }
 
@@ -242,7 +244,7 @@ validateCodingKeysEnum(TypeChecker &tc, EnumDecl *codingKeysDecl,
   // we can skip them on encode. On decode, though, we can only skip them if
   // they have a default value.
   if (!properties.empty() &&
-      proto == tc.Context.getProtocol(KnownProtocolKind::Decodable)) {
+      proto->isSpecificProtocol(KnownProtocolKind::Decodable)) {
     for (auto it = properties.begin(); it != properties.end(); ++it) {
       if (it->second->getParentInitializer() != nullptr) {
         // Var has a default value.
@@ -302,6 +304,9 @@ static CodingKeysValidity hasValidCodingKeysEnum(TypeChecker &tc,
                 proto->getDeclaredType());
     return CodingKeysValidity(/*hasType=*/true, /*isValid=*/false);
   }
+
+  // If the decl hasn't been validated yet, do so.
+  tc.validateDecl(codingKeysTypeDecl);
 
   // CodingKeys may be a typealias. If so, follow the alias to its canonical
   // type.
@@ -381,6 +386,9 @@ static EnumDecl *synthesizeCodingKeysEnum(TypeChecker &tc,
   // conforms to {En,De}codable, add it to the enum.
   bool allConform = true;
   for (auto *varDecl : target->getStoredProperties(/*skipInaccessible=*/true)) {
+    if (varDecl->getAttrs().hasAttribute<LazyAttr>())
+      continue;
+
     auto conformance = varConformsToCodable(tc, target->getDeclContext(),
                                             varDecl, proto);
     switch (conformance) {
@@ -526,7 +534,7 @@ static CallExpr *createContainerKeyedByCall(ASTContext &C, DeclContext *DC,
 /// Synthesizes the body for `func encode(to encoder: Encoder) throws`.
 ///
 /// \param encodeDecl The function decl whose body to synthesize.
-static BraceStmt *deriveBodyEncodable_encode(AbstractFunctionDecl *encodeDecl) {
+static void deriveBodyEncodable_encode(AbstractFunctionDecl *encodeDecl) {
   // struct Foo : Codable {
   //   var x: Int
   //   var y: String
@@ -693,8 +701,9 @@ static BraceStmt *deriveBodyEncodable_encode(AbstractFunctionDecl *encodeDecl) {
     statements.push_back(tryExpr);
   }
 
-  return BraceStmt::create(C, SourceLoc(), statements, SourceLoc(),
-                           /*implicit=*/true);
+  auto *body = BraceStmt::create(C, SourceLoc(), statements, SourceLoc(),
+                                 /*implicit=*/true);
+  encodeDecl->setBody(body);
 }
 
 /// Synthesizes a function declaration for `encode(to: Encoder) throws` with a
@@ -753,7 +762,7 @@ static FuncDecl *deriveEncodable_encode(TypeChecker &tc, Decl *parentDecl,
                                       TypeLoc::withoutLoc(returnType),
                                       target);
   encodeDecl->setImplicit();
-  encodeDecl->setBody(deriveBodyEncodable_encode(encodeDecl));
+  encodeDecl->setBodySynthesizer(deriveBodyEncodable_encode);
 
   // This method should be marked as 'override' for classes inheriting Encodable
   // conformance from a parent class.
@@ -958,10 +967,10 @@ static BraceStmt *deriveBodyDecodable_init(TypeChecker &tc,
   // superclass is Decodable, or super.init() if it is not.
   if (auto *classDecl = dyn_cast<ClassDecl>(targetDecl)) {
     if (auto *superclassDecl = classDecl->getSuperclassDecl()) {
-      auto superType =  superclassDecl->getDeclaredInterfaceType();
+      auto superType = superclassDecl->getDeclaredInterfaceType();
       if (tc.conformsToProtocol(superType,
                                 C.getProtocol(KnownProtocolKind::Decodable),
-                                superclassDecl, ConformanceCheckFlags::Used)) {
+                                superclassDecl, ConformanceCheckOptions())) {
         // Need to generate `try super.init(from: container.superDecoder())`
 
         // container.superDecoder
@@ -980,7 +989,7 @@ static BraceStmt *deriveBodyDecodable_init(TypeChecker &tc,
                                               SourceLoc(), /*Implicit=*/true);
 
         // super.init(from:)
-        auto initName = DeclName(C, C.Id_init, (Identifier[1]){ C.Id_from });
+        auto initName = DeclName(C, C.Id_init, C.Id_from);
         auto *initCall = new (C) UnresolvedDotExpr(superRef, SourceLoc(),
                                                    initName, DeclNameLoc(),
                                                    /*Implicit=*/true);
@@ -1001,21 +1010,12 @@ static BraceStmt *deriveBodyDecodable_init(TypeChecker &tc,
         DeclName initName(C, C.Id_init, ArrayRef<Identifier>());
 
         // We need to look this up in the superclass to see if it throws.
-        // We should have bailed one level up if super.init() is not available.
         ConstructorDecl *superInitDecl = nullptr;
-        for (auto *decl : superclassDecl->getMembers()) {
-          auto *ctorDecl = dyn_cast<ConstructorDecl>(decl);
-          if (!ctorDecl)
-            continue;
-
-          if (ctorDecl->getParameters()->size() == 0) {
-            superInitDecl = ctorDecl;
-            break;
-          }
-        }
+        auto result = superclassDecl->lookupDirect(initName);
 
         // We should have bailed one level up if this were not available.
-        assert(superInitDecl);
+        assert(!result.empty() &&
+               (superInitDecl = dyn_cast<ConstructorDecl>(result.front())));
 
         // super
         auto *superRef = new (C) SuperRefExpr(initDecl->getImplicitSelfDecl(),
@@ -1026,18 +1026,20 @@ static BraceStmt *deriveBodyDecodable_init(TypeChecker &tc,
                                                        initName, DeclNameLoc(),
                                                        /*Implicit=*/true);
         // super.init() call
-        auto *callExpr = CallExpr::createImplicit(C, superInitRef,
+        Expr *callExpr = CallExpr::createImplicit(C, superInitRef,
                                                   ArrayRef<Expr *>(),
                                                   ArrayRef<Identifier>());
 
-        if (superInitDecl->hasThrows()) {
-          // try super.init()
-          auto *tryExpr = new (C) TryExpr(SourceLoc(), callExpr, Type(),
-                                          /*Implicit=*/true);
-          statements.push_back(tryExpr);
-        } else {
-          statements.push_back(callExpr);
-        }
+        // If super.init is failable, super.init()!
+        if (superInitDecl->getFailability() != OTK_None)
+          callExpr = new (C) ForceValueExpr(callExpr, SourceLoc());
+
+        // If super.init throws, try super.init()
+        if (superInitDecl->hasThrows())
+          callExpr = new (C) TryExpr(SourceLoc(), callExpr, Type(),
+                                     /*Implicit=*/true);
+
+        statements.push_back(callExpr);
       }
     }
   }
@@ -1173,14 +1175,14 @@ static bool canSynthesize(TypeChecker &tc, NominalTypeDecl *target,
   // synthesize CodingKeys.
   ASTContext &C = tc.Context;
   auto *classDecl = dyn_cast<ClassDecl>(target);
-  if (proto == C.getProtocol(KnownProtocolKind::Decodable) && classDecl) {
+  if (proto->isSpecificProtocol(KnownProtocolKind::Decodable) && classDecl) {
     if (auto *superclassDecl = classDecl->getSuperclassDecl()) {
       DeclName memberName;
       auto superType = superclassDecl->getDeclaredInterfaceType();
       if (tc.conformsToProtocol(superType, proto, superclassDecl,
                                 ConformanceCheckFlags::Used)) {
         // super.init(from:) must be accessible.
-        memberName = cast<ConstructorDecl>(requirement)->getEffectiveFullName();
+        memberName = cast<ConstructorDecl>(requirement)->getFullName();
       } else {
         // super.init() must be accessible.
         // Passing an empty params array constructs a compound name with no
@@ -1194,7 +1196,7 @@ static bool canSynthesize(TypeChecker &tc, NominalTypeDecl *target,
       if (result.empty()) {
         // No super initializer for us to call.
         tc.diagnose(superclassDecl, diag::decodable_no_super_init_here,
-                    requirement->getFullName());
+                    requirement->getFullName(), memberName);
         return false;
       } else if (result.size() > 1) {
         // There are multiple results for this lookup. We'll end up producing a
@@ -1202,7 +1204,8 @@ static bool canSynthesize(TypeChecker &tc, NominalTypeDecl *target,
         // already), so just bail with a general error.
         return false;
       } else {
-        auto *initializer = cast<ConstructorDecl>(result.front().Decl);
+        auto *initializer =
+          cast<ConstructorDecl>(result.front().getValueDecl());
         if (!initializer->isDesignatedInit()) {
           // We must call a superclass's designated initializer.
           tc.diagnose(initializer,
@@ -1216,6 +1219,11 @@ static bool canSynthesize(TypeChecker &tc, NominalTypeDecl *target,
                       requirement->getFullName(), memberName,
                       accessScope.accessibilityForDiagnostics());
           return false;
+        } else if (initializer->getFailability() != OTK_None) {
+          // We can't call super.init() if it's failable, since init(from:)
+          // isn't failable.
+          tc.diagnose(initializer, diag::decodable_super_init_is_failable_here,
+                      requirement->getFullName(), memberName);
         }
       }
     }

--- a/lib/Sema/DerivedConformanceCodingKey.cpp
+++ b/lib/Sema/DerivedConformanceCodingKey.cpp
@@ -408,8 +408,9 @@ static bool canSynthesizeCodingKey(TypeChecker &tc, Decl *parentDecl,
       return false;
   }
 
-  if (!enumDecl->getInherited().empty() &&
-      enumDecl->getInherited().front().isError())
+  auto inherited = enumDecl->getInherited();
+  if (!inherited.empty() && inherited.front().wasValidated() &&
+      inherited.front().isError())
     return false;
 
   // If it meets all of those requirements, we can synthesize CodingKey

--- a/lib/Sema/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformanceRawRepresentable.cpp
@@ -344,8 +344,9 @@ static bool canSynthesizeRawRepresentable(TypeChecker &tc, Decl *parentDecl,
   auto parentDC = cast<DeclContext>(parentDecl);
   rawType       = parentDC->mapTypeIntoContext(rawType);
 
-  if (!enumDecl->getInherited().empty() &&
-      enumDecl->getInherited().front().isError())
+  auto inherited = enumDecl->getInherited();
+  if (!inherited.empty() && inherited.front().wasValidated() &&
+      inherited.front().isError())
     return false;
 
   // The raw type must be Equatable, so that we have a suitable ~= for

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -7959,8 +7959,8 @@ static void diagnoseClassWithoutInitializers(TypeChecker &tc,
                                     NameLookupFlags::ProtocolMembers |
                                     NameLookupFlags::IgnoreAccessibility);
 
-      if (!result.empty() && !result.front().getValueDecl()->isImplicit())
-        diagDest = result.front().getValueDecl();
+      if (!result.empty() && !result.front()->isImplicit())
+        diagDest = result.front();
 
       auto diagName = diag::decodable_suggest_overriding_init_here;
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -7959,8 +7959,8 @@ static void diagnoseClassWithoutInitializers(TypeChecker &tc,
                                     NameLookupFlags::ProtocolMembers |
                                     NameLookupFlags::IgnoreAccessibility);
 
-      if (!result.empty() && !result.front()->isImplicit())
-        diagDest = result.front();
+      if (!result.empty() && !result.front().getValueDecl()->isImplicit())
+        diagDest = result.front().getValueDecl();
 
       auto diagName = diag::decodable_suggest_overriding_init_here;
 
@@ -7979,7 +7979,7 @@ static void diagnoseClassWithoutInitializers(TypeChecker &tc,
         // subclass doesn't directly implement encode(to:).
         // The direct lookup here won't see an encode(to:) if it is inherited
         // from the superclass.
-        auto encodeTo = DeclName(C, C.Id_encode, (Identifier[1]){ C.Id_to });
+        auto encodeTo = DeclName(C, C.Id_encode, C.Id_to);
         if (classDecl->lookupDirect(encodeTo).empty())
           diagName = diag::codable_suggest_overriding_init_here;
       }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -7927,6 +7927,67 @@ static void diagnoseClassWithoutInitializers(TypeChecker &tc,
   tc.diagnose(classDecl, diag::class_without_init,
               classDecl->getDeclaredType());
 
+  // HACK: We've got a special case to look out for and diagnose specifically to
+  // improve the experience of seeing this, and mitigate some confusion.
+  //
+  // For a class A which inherits from Decodable class B, class A may have
+  // additional members which prevent default initializer synthesis (and
+  // inheritance of other initializers). The user may have assumed that this
+  // case would synthesize Encodable/Decodable conformance for class A the same
+  // way it may have for class B, or other classes.
+  //
+  // It is helpful to suggest here that the user may have forgotten to override
+  // init(from:) (and encode(to:), if applicable) in a note, before we start
+  // listing the members that prevented initializer synthesis.
+  // TODO: Add a fixit along with this suggestion.
+  if (auto *superclassDecl = classDecl->getSuperclassDecl()) {
+    ASTContext &C = tc.Context;
+    auto *decodableProto = C.getProtocol(KnownProtocolKind::Decodable);
+    auto superclassType = superclassDecl->getDeclaredInterfaceType();
+    if (auto ref = tc. conformsToProtocol(superclassType, decodableProto,
+                                          superclassDecl,
+                                          ConformanceCheckOptions(),
+                                          SourceLoc())) {
+      // super conforms to Decodable, so we've failed to inherit init(from:).
+      // Let's suggest overriding it here.
+      //
+      // We're going to diagnose on the concrete init(from:) decl if it exists
+      // and isn't implicit; otherwise, on the subclass itself.
+      ValueDecl *diagDest = classDecl;
+      auto initFrom = DeclName(C, C.Id_init, (Identifier[1]){ C.Id_from });
+      auto result = tc.lookupMember(superclassDecl, superclassType, initFrom,
+                                    NameLookupFlags::ProtocolMembers |
+                                    NameLookupFlags::IgnoreAccessibility);
+
+      if (!result.empty() && !result.front()->isImplicit())
+        diagDest = result.front();
+
+      auto diagName = diag::decodable_suggest_overriding_init_here;
+
+      // This is also a bit of a hack, but the best place we've got at the
+      // moment to suggest this.
+      //
+      // If the superclass also conforms to Encodable, it's quite
+      // likely that the user forgot to override its encode(to:). In this case,
+      // we can produce a slightly different diagnostic to suggest doing so.
+      auto *encodableProto = C.getProtocol(KnownProtocolKind::Encodable);
+      if ((ref = tc.conformsToProtocol(superclassType, encodableProto,
+                                       superclassDecl,
+                                       ConformanceCheckOptions(),
+                                       SourceLoc()))) {
+        // We only want to produce this version of the diagnostic if the
+        // subclass doesn't directly implement encode(to:).
+        // The direct lookup here won't see an encode(to:) if it is inherited
+        // from the superclass.
+        auto encodeTo = DeclName(C, C.Id_encode, (Identifier[1]){ C.Id_to });
+        if (classDecl->lookupDirect(encodeTo).empty())
+          diagName = diag::codable_suggest_overriding_init_here;
+      }
+
+      tc.diagnose(diagDest, diagName);
+    }
+  }
+
   for (auto member : classDecl->getMembers()) {
     auto pbd = dyn_cast<PatternBindingDecl>(member);
     if (!pbd)

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -7944,17 +7944,17 @@ static void diagnoseClassWithoutInitializers(TypeChecker &tc,
     ASTContext &C = tc.Context;
     auto *decodableProto = C.getProtocol(KnownProtocolKind::Decodable);
     auto superclassType = superclassDecl->getDeclaredInterfaceType();
-    if (auto ref = tc. conformsToProtocol(superclassType, decodableProto,
-                                          superclassDecl,
-                                          ConformanceCheckOptions(),
-                                          SourceLoc())) {
+    if (auto ref = tc.conformsToProtocol(superclassType, decodableProto,
+                                         superclassDecl,
+                                         ConformanceCheckOptions(),
+                                         SourceLoc())) {
       // super conforms to Decodable, so we've failed to inherit init(from:).
       // Let's suggest overriding it here.
       //
       // We're going to diagnose on the concrete init(from:) decl if it exists
       // and isn't implicit; otherwise, on the subclass itself.
       ValueDecl *diagDest = classDecl;
-      auto initFrom = DeclName(C, C.Id_init, (Identifier[1]){ C.Id_from });
+      auto initFrom = DeclName(C, C.Id_init, C.Id_from);
       auto result = tc.lookupMember(superclassDecl, superclassType, initFrom,
                                     NameLookupFlags::ProtocolMembers |
                                     NameLookupFlags::IgnoreAccessibility);
@@ -8185,10 +8185,11 @@ void TypeChecker::addImplicitConstructors(NominalTypeDecl *decl) {
   // NOTE: Lookups of synthesized initializers MUST come after
   //       decl->setAddedImplicitInitializers() in case synthesis requires
   //       protocol conformance checking, which might be recursive here.
+  // FIXME: Disable this code and prevent _any_ implicit constructors from doing
+  //        this. Investigate why this hasn't worked otherwise.
   DeclName synthesizedInitializers[1] = {
     // init(from:) is synthesized by derived conformance to Decodable.
-    DeclName(Context, DeclBaseName(Context.Id_init),
-             (Identifier[1]) { Context.Id_from })
+    DeclName(Context, DeclBaseName(Context.Id_init), Context.Id_from)
   };
 
   auto initializerIsSynthesized = [=](ConstructorDecl *initializer) {

--- a/test/decl/protocol/special/coding/class_codable_default_initializer.swift
+++ b/test/decl/protocol/special/coding/class_codable_default_initializer.swift
@@ -1,0 +1,49 @@
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
+
+// A class with no initializers (which has non-initialized properties so a
+// default constructor can be synthesized) should produce an error.
+class NoInitializers { // expected-error {{class 'NoInitializers' has no initializers}}
+// expected-note@-1 {{did you mean 'deinit'?}}
+  var x: Double // expected-note {{stored property 'x' without initial value prevents synthesized initializers}}
+
+  func foo() {
+    // The class should not receive a default constructor.
+    let _ = NoInitializers.init // expected-error {{type 'NoInitializers' has no member 'init'}}
+  }
+}
+
+// A similar class with Codable properties adopting Codable should get a
+// synthesized init(from:), and thus not warn.
+class CodableNoExplicitInitializers : Codable {
+  var x: Double
+
+  func foo() {
+    // The class should receive a synthesized init(from:) and encode(to:)
+    let _ = CodableNoExplicitInitializers.init(from:)
+    let _ = CodableNoExplicitInitializers.encode(to:)
+
+    // It should not, however, receive a default constructor.
+    let _ = CodableNoExplicitInitializers.init
+  }
+}
+
+// A class with all initialized properties should receive a default constructor.
+class DefaultConstructed {
+  var x: Double = .pi
+
+  func foo() {
+    let _ = DefaultConstructed.init
+  }
+}
+
+// A class with all initialized, Codable properties adopting Codable should get
+// the default constructor, along with a synthesized init(from:).
+class CodableDefaultConstructed : Codable {
+  var x: Double = .pi
+
+  func foo() {
+    let _ = CodableDefaultConstructed.init()
+    let _ = CodableDefaultConstructed.init(from:)
+    let _ = CodableDefaultConstructed.encode(to:)
+  }
+}

--- a/test/decl/protocol/special/coding/class_codable_default_initializer.swift
+++ b/test/decl/protocol/special/coding/class_codable_default_initializer.swift
@@ -8,7 +8,7 @@ class NoInitializers { // expected-error {{class 'NoInitializers' has no initial
 
   func foo() {
     // The class should not receive a default constructor.
-    let _ = NoInitializers.init // expected-error {{type 'NoInitializers' has no member 'init'}}
+    let _ = NoInitializers.init() // expected-error {{type 'NoInitializers' has no member 'init'}}
   }
 }
 
@@ -23,7 +23,7 @@ class CodableNoExplicitInitializers : Codable {
     let _ = CodableNoExplicitInitializers.encode(to:)
 
     // It should not, however, receive a default constructor.
-    let _ = CodableNoExplicitInitializers.init
+    let _ = CodableNoExplicitInitializers.init() // expected-error {{missing argument for parameter 'from' in call}}
   }
 }
 
@@ -32,7 +32,7 @@ class DefaultConstructed {
   var x: Double = .pi
 
   func foo() {
-    let _ = DefaultConstructed.init
+    let _ = DefaultConstructed.init()
   }
 }
 

--- a/test/decl/protocol/special/coding/class_codable_failure_diagnostics.swift
+++ b/test/decl/protocol/special/coding/class_codable_failure_diagnostics.swift
@@ -8,12 +8,12 @@ class C1 : Codable {
   var c: Nested = Nested()
 
   // CHECK: error: type 'C1' does not conform to protocol 'Decodable'
-  // CHECK: note: cannot automatically synthesize 'Decodable' because 'C1.Nested' does not conform to 'Decodable'
   // CHECK: note: protocol requires initializer 'init(from:)' with type 'Decodable'
+  // CHECK: note: cannot automatically synthesize 'Decodable' because 'C1.Nested' does not conform to 'Decodable'
 
   // CHECK: error: type 'C1' does not conform to protocol 'Encodable'
-  // CHECK: note: cannot automatically synthesize 'Encodable' because 'C1.Nested' does not conform to 'Encodable'
   // CHECK: note: protocol requires function 'encode(to:)' with type 'Encodable'
+  // CHECK: note: cannot automatically synthesize 'Encodable' because 'C1.Nested' does not conform to 'Encodable'
 }
 
 // Codable class with non-enum CodingKeys.
@@ -30,12 +30,12 @@ class C2 : Codable {
   }
 
   // CHECK: error: type 'C2' does not conform to protocol 'Decodable'
-  // CHECK: note: cannot automatically synthesize 'Decodable' because 'CodingKeys' is not an enum
   // CHECK: note: protocol requires initializer 'init(from:)' with type 'Decodable'
+  // CHECK: note: cannot automatically synthesize 'Decodable' because 'CodingKeys' is not an enum
 
   // CHECK: error: type 'C2' does not conform to protocol 'Encodable'
-  // CHECK: note: cannot automatically synthesize 'Encodable' because 'CodingKeys' is not an enum
   // CHECK: note: protocol requires function 'encode(to:)' with type 'Encodable'
+  // CHECK: note: cannot automatically synthesize 'Encodable' because 'CodingKeys' is not an enum
 }
 
 // Codable class with CodingKeys not conforming to CodingKey.
@@ -51,12 +51,12 @@ class C3 : Codable {
   }
 
   // CHECK: error: type 'C3' does not conform to protocol 'Decodable'
-  // CHECK: note: cannot automatically synthesize 'Decodable' because 'CodingKeys' does not conform to CodingKey
   // CHECK: note: protocol requires initializer 'init(from:)' with type 'Decodable'
+  // CHECK: note: cannot automatically synthesize 'Decodable' because 'CodingKeys' does not conform to CodingKey
 
   // CHECK: error: type 'C3' does not conform to protocol 'Encodable'
-  // CHECK: note: cannot automatically synthesize 'Encodable' because 'CodingKeys' does not conform to CodingKey
   // CHECK: note: protocol requires function 'encode(to:)' with type 'Encodable'
+  // CHECK: note: cannot automatically synthesize 'Encodable' because 'CodingKeys' does not conform to CodingKey
 }
 
 // Codable class with extraneous CodingKeys
@@ -75,16 +75,16 @@ class C4 : Codable {
   }
 
   // CHECK: error: type 'C4' does not conform to protocol 'Decodable'
+  // CHECK: note: protocol requires initializer 'init(from:)' with type 'Decodable'
   // CHECK: note: CodingKey case 'a2' does not match any stored properties
   // CHECK: note: CodingKey case 'b2' does not match any stored properties
   // CHECK: note: CodingKey case 'c2' does not match any stored properties
-  // CHECK: note: protocol requires initializer 'init(from:)' with type 'Decodable'
 
   // CHECK: error: type 'C4' does not conform to protocol 'Encodable'
+  // CHECK: note: protocol requires function 'encode(to:)' with type 'Encodable'
   // CHECK: note: CodingKey case 'a2' does not match any stored properties
   // CHECK: note: CodingKey case 'b2' does not match any stored properties
   // CHECK: note: CodingKey case 'c2' does not match any stored properties
-  // CHECK: note: protocol requires function 'encode(to:)' with type 'Encodable'
 }
 
 // Codable class with non-decoded property (which has no default value).
@@ -98,12 +98,12 @@ class C5 : Codable {
     case c
   }
 
+  // CHECK: error: type 'C5' does not conform to protocol 'Decodable'
+  // CHECK: note: protocol requires initializer 'init(from:)' with type 'Decodable'
+  // CHECK: note: cannot automatically synthesize 'Decodable' because 'b' does not have a matching CodingKey and does not have a default value
+
   // CHECK: error: class 'C5' has no initializers
   // CHECK: note: stored property 'b' without initial value prevents synthesized initializers
-
-  // CHECK: error: type 'C5' does not conform to protocol 'Decodable'
-  // CHECK: note: cannot automatically synthesize 'Decodable' because 'b' does not have a matching CodingKey and does not have a default value
-  // CHECK: note: protocol requires initializer 'init(from:)' with type 'Decodable'
 }
 
 // Codable class with non-decoded property (which has no default value).
@@ -122,8 +122,8 @@ class C6 : Codable {
   }
 
   // CHECK: error: type 'C6' does not conform to protocol 'Decodable'
-  // CHECK: note: cannot automatically synthesize 'Decodable' because 'b' does not have a matching CodingKey and does not have a default value
   // CHECK: note: protocol requires initializer 'init(from:)' with type 'Decodable'
+  // CHECK: note: cannot automatically synthesize 'Decodable' because 'b' does not have a matching CodingKey and does not have a default value
 }
 
 // Classes cannot yet synthesize Encodable or Decodable in extensions.

--- a/test/decl/protocol/special/coding/class_codable_inheritance_diagnostics.swift
+++ b/test/decl/protocol/special/coding/class_codable_inheritance_diagnostics.swift
@@ -1,0 +1,32 @@
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
+
+// Non-Decodable superclasses of synthesized Decodable classes must implement
+// init().
+class NonDecodableSuper { // expected-note {{cannot automatically synthesize 'init(from:)' because superclass does not have a callable 'init()' or 'init(from:)'}}
+  init(_: Int) {}
+}
+
+class NonDecodableSub : NonDecodableSuper, Decodable { // expected-error {{type 'NonDecodableSub' does not conform to protocol 'Decodable'}}
+}
+
+// Non-Decodable superclasses of synthesized Decodable classes must have
+// designated init()'s.
+class NonDesignatedNonDecodableSuper {
+  convenience init() { // expected-note {{cannot automatically synthesize 'init(from:)' because required superclass initializer 'init()' is not designated}}
+    self.init(42)
+  }
+
+  init(_: Int) {}
+}
+
+class NonDesignatedNonDecodableSub : NonDesignatedNonDecodableSuper, Decodable { // expected-error {{type 'NonDesignatedNonDecodableSub' does not conform to protocol 'Decodable'}}
+}
+
+// Non-Decodable superclasses of synthesized Decodable classes must have an
+// accessible init().
+class InaccessibleNonDecodableSuper {
+  private init() {} // expected-note {{cannot automatically synthesize 'init(from:)' because required superclass initializer 'init()' is inaccessible due to 'private' protection level}}
+}
+
+class InaccessibleNonDecodableSub : InaccessibleNonDecodableSuper, Decodable { // expected-error {{type 'InaccessibleNonDecodableSub' does not conform to protocol 'Decodable'}}
+}

--- a/test/decl/protocol/special/coding/class_codable_inheritance_diagnostics.swift
+++ b/test/decl/protocol/special/coding/class_codable_inheritance_diagnostics.swift
@@ -30,3 +30,42 @@ class InaccessibleNonDecodableSuper {
 
 class InaccessibleNonDecodableSub : InaccessibleNonDecodableSuper, Decodable { // expected-error {{type 'InaccessibleNonDecodableSub' does not conform to protocol 'Decodable'}}
 }
+
+// Subclasses of Decodable classes which can't inherit their initializers should
+// produce diagnostics.
+class DecodableSuper : Decodable {
+  var value = 5
+}
+
+class DecodableSubWithoutInitialValue : DecodableSuper { // expected-error {{class 'DecodableSubWithoutInitialValue' has no initializers}}
+  // expected-note@-1 {{did you mean to override 'init(from:)'?}}
+  var value2: Int // expected-note {{stored property 'value2' without initial value prevents synthesized initializers}}
+}
+
+class DecodableSubWithInitialValue : DecodableSuper {
+  var value2 = 10
+}
+
+// Subclasses of Codable classes which can't inherit their initializers should
+// produce diagnostics.
+class CodableSuper : Codable {
+  var value = 5
+}
+
+class CodableSubWithoutInitialValue : CodableSuper { // expected-error {{class 'CodableSubWithoutInitialValue' has no initializers}}
+  // expected-note@-1 {{did you mean to override 'init(from:)' and 'encode(to:)'?}}
+  var value2: Int // expected-note {{stored property 'value2' without initial value prevents synthesized initializers}}
+}
+
+// We should only mention encode(to:) in the diagnostic if the subclass does not
+// override it.
+class EncodableSubWithoutInitialValue : CodableSuper { // expected-error {{class 'EncodableSubWithoutInitialValue' has no initializers}}
+  // expected-note@-1 {{did you mean to override 'init(from:)'?}}
+  var value2: Int // expected-note {{stored property 'value2' without initial value prevents synthesized initializers}}
+
+  override func encode(to: Encoder) throws {}
+}
+
+class CodableSubWithInitialValue : CodableSuper {
+  var value2 = 10
+}

--- a/test/decl/protocol/special/coding/class_codable_inheritance_diagnostics.swift
+++ b/test/decl/protocol/special/coding/class_codable_inheritance_diagnostics.swift
@@ -2,7 +2,7 @@
 
 // Non-Decodable superclasses of synthesized Decodable classes must implement
 // init().
-class NonDecodableSuper { // expected-note {{cannot automatically synthesize 'init(from:)' because superclass does not have a callable 'init()' or 'init(from:)'}}
+class NonDecodableSuper { // expected-note {{cannot automatically synthesize 'init(from:)' because superclass does not have a callable 'init()'}}
   init(_: Int) {}
 }
 
@@ -12,7 +12,7 @@ class NonDecodableSub : NonDecodableSuper, Decodable { // expected-error {{type 
 // Non-Decodable superclasses of synthesized Decodable classes must have
 // designated init()'s.
 class NonDesignatedNonDecodableSuper {
-  convenience init() { // expected-note {{cannot automatically synthesize 'init(from:)' because required superclass initializer 'init()' is not designated}}
+  convenience init() { // expected-note {{cannot automatically synthesize 'init(from:)' because implementation would need to call 'init()', which is not designated}}
     self.init(42)
   }
 
@@ -25,7 +25,7 @@ class NonDesignatedNonDecodableSub : NonDesignatedNonDecodableSuper, Decodable {
 // Non-Decodable superclasses of synthesized Decodable classes must have an
 // accessible init().
 class InaccessibleNonDecodableSuper {
-  private init() {} // expected-note {{cannot automatically synthesize 'init(from:)' because required superclass initializer 'init()' is inaccessible due to 'private' protection level}}
+  private init() {} // expected-note {{cannot automatically synthesize 'init(from:)' because implementation would need to call 'init()', which is inaccessible due to 'private' protection level}}
 }
 
 class InaccessibleNonDecodableSub : InaccessibleNonDecodableSuper, Decodable { // expected-error {{type 'InaccessibleNonDecodableSub' does not conform to protocol 'Decodable'}}

--- a/test/decl/protocol/special/coding/struct_codable_failure_diagnostics.swift
+++ b/test/decl/protocol/special/coding/struct_codable_failure_diagnostics.swift
@@ -6,14 +6,6 @@ struct S1 : Codable {
   var a: String = ""
   var b: Int = 0
   var c: Nested = Nested()
-
-  // CHECK: error: type 'S1' does not conform to protocol 'Decodable'
-  // CHECK: note: cannot automatically synthesize 'Decodable' because 'S1.Nested' does not conform to 'Decodable'
-  // CHECK: note: protocol requires initializer 'init(from:)' with type 'Decodable'
-
-  // CHECK: error: type 'S1' does not conform to protocol 'Encodable'
-  // CHECK: note: cannot automatically synthesize 'Encodable' because 'S1.Nested' does not conform to 'Encodable'
-  // CHECK: note: protocol requires function 'encode(to:)' with type 'Encodable'
 }
 
 // Codable struct with non-enum CodingKeys.
@@ -28,14 +20,6 @@ struct S2 : Codable {
     init?(stringValue: String) {}
     init?(intValue: Int) {}
   }
-
-  // CHECK: error: type 'S2' does not conform to protocol 'Decodable'
-  // CHECK: note: cannot automatically synthesize 'Decodable' because 'CodingKeys' is not an enum
-  // CHECK: note: protocol requires initializer 'init(from:)' with type 'Decodable'
-
-  // CHECK: error: type 'S2' does not conform to protocol 'Encodable'
-  // CHECK: note: cannot automatically synthesize 'Encodable' because 'CodingKeys' is not an enum
-  // CHECK: note: protocol requires function 'encode(to:)' with type 'Encodable'
 }
 
 // Codable struct with CodingKeys not conforming to CodingKey.
@@ -49,14 +33,6 @@ struct S3 : Codable {
     case b
     case c
   }
-
-  // CHECK: error: type 'S3' does not conform to protocol 'Decodable'
-  // CHECK: note: cannot automatically synthesize 'Decodable' because 'CodingKeys' does not conform to CodingKey
-  // CHECK: note: protocol requires initializer 'init(from:)' with type 'Decodable'
-
-  // CHECK: error: type 'S3' does not conform to protocol 'Encodable'
-  // CHECK: note: cannot automatically synthesize 'Encodable' because 'CodingKeys' does not conform to CodingKey
-  // CHECK: note: protocol requires function 'encode(to:)' with type 'Encodable'
 }
 
 // Codable struct with extraneous CodingKeys
@@ -73,18 +49,6 @@ struct S4 : Codable {
     case c
     case c2
   }
-
-  // CHECK: error: type 'S4' does not conform to protocol 'Decodable'
-  // CHECK: note: CodingKey case 'a2' does not match any stored properties
-  // CHECK: note: CodingKey case 'b2' does not match any stored properties
-  // CHECK: note: CodingKey case 'c2' does not match any stored properties
-  // CHECK: note: protocol requires initializer 'init(from:)' with type 'Decodable'
-
-  // CHECK: error: type 'S4' does not conform to protocol 'Encodable'
-  // CHECK: note: CodingKey case 'a2' does not match any stored properties
-  // CHECK: note: CodingKey case 'b2' does not match any stored properties
-  // CHECK: note: CodingKey case 'c2' does not match any stored properties
-  // CHECK: note: protocol requires function 'encode(to:)' with type 'Encodable'
 }
 
 // Codable struct with non-decoded property (which has no default value).
@@ -97,14 +61,60 @@ struct S5 : Codable {
     case a
     case c
   }
-
-  // CHECK: error: type 'S5' does not conform to protocol 'Decodable'
-  // CHECK: note: cannot automatically synthesize 'Decodable' because 'b' does not have a matching CodingKey and does not have a default value
-  // CHECK: note: protocol requires initializer 'init(from:)' with type 'Decodable'
 }
 
 // Structs cannot yet synthesize Encodable or Decodable in extensions.
 struct S6 {}
 extension S6 : Codable {}
+
+// Decodable diagnostics are output first here {
+
+// CHECK: error: type 'S1' does not conform to protocol 'Decodable'
+// CHECK: note: protocol requires initializer 'init(from:)' with type 'Decodable'
+// CHECK: note: cannot automatically synthesize 'Decodable' because 'S1.Nested' does not conform to 'Decodable'
+
+// CHECK: error: type 'S2' does not conform to protocol 'Decodable'
+// CHECK: note: protocol requires initializer 'init(from:)' with type 'Decodable'
+// CHECK: note: cannot automatically synthesize 'Decodable' because 'CodingKeys' is not an enum
+
+// CHECK: error: type 'S3' does not conform to protocol 'Decodable'
+// CHECK: note: protocol requires initializer 'init(from:)' with type 'Decodable'
+// CHECK: note: cannot automatically synthesize 'Decodable' because 'CodingKeys' does not conform to CodingKey
+
+// CHECK: error: type 'S4' does not conform to protocol 'Decodable'
+// CHECK: note: protocol requires initializer 'init(from:)' with type 'Decodable'
+// CHECK: note: CodingKey case 'a2' does not match any stored properties
+// CHECK: note: CodingKey case 'b2' does not match any stored properties
+// CHECK: note: CodingKey case 'c2' does not match any stored properties
+
+// CHECK: error: type 'S5' does not conform to protocol 'Decodable'
+// CHECK: note: protocol requires initializer 'init(from:)' with type 'Decodable'
+// CHECK: note: cannot automatically synthesize 'Decodable' because 'b' does not have a matching CodingKey and does not have a default value
+
 // CHECK: error: implementation of 'Decodable' cannot be automatically synthesized in an extension yet
+
+// }
+
+// Encodable {
+
+// CHECK: error: type 'S1' does not conform to protocol 'Encodable'
+// CHECK: note: protocol requires function 'encode(to:)' with type 'Encodable'
+// CHECK: note: cannot automatically synthesize 'Encodable' because 'S1.Nested' does not conform to 'Encodable'
+
+// CHECK: error: type 'S2' does not conform to protocol 'Encodable'
+// CHECK: note: protocol requires function 'encode(to:)' with type 'Encodable'
+// CHECK: note: cannot automatically synthesize 'Encodable' because 'CodingKeys' is not an enum
+
+// CHECK: error: type 'S3' does not conform to protocol 'Encodable'
+// CHECK: note: protocol requires function 'encode(to:)' with type 'Encodable'
+// CHECK: note: cannot automatically synthesize 'Encodable' because 'CodingKeys' does not conform to CodingKey
+
+// CHECK: error: type 'S4' does not conform to protocol 'Encodable'
+// CHECK: note: protocol requires function 'encode(to:)' with type 'Encodable'
+// CHECK: note: CodingKey case 'a2' does not match any stored properties
+// CHECK: note: CodingKey case 'b2' does not match any stored properties
+// CHECK: note: CodingKey case 'c2' does not match any stored properties
+
 // CHECK: error: implementation of 'Encodable' cannot be automatically synthesized in an extension yet
+
+// }

--- a/test/decl/protocol/special/coding/struct_codable_memberwise_initializer.swift
+++ b/test/decl/protocol/special/coding/struct_codable_memberwise_initializer.swift
@@ -1,0 +1,49 @@
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
+
+// Structs with no initializers should get a memberwise initializer.
+struct NoInitializers {
+  var x: Double // need not have an initial value
+
+  func foo() {
+    // The struct should receive a memberwise initializer.
+    let _ = NoInitializers.init(x:)
+  }
+}
+
+// A similar struct with Codable properties adopting Codable should get a
+// synthesized init(from:), along with the memberwise initializer.
+struct CodableNoExplicitInitializers : Codable {
+  var x: Double
+
+  func foo() {
+    // The struct should receive a synthesized init(from:) and encode(to:).
+    let _ = CodableNoExplicitInitializers.init(from:)
+    let _ = CodableNoExplicitInitializers.encode(to:)
+
+    // It should still receive a memberwise initializer.
+    let _ = CodableNoExplicitInitializers.init(x:)
+  }
+}
+
+// The same should hold for structs whose members all have initial values.
+struct InitialValueNoInitializers {
+  var x: Double = .pi
+
+  func foo() {
+    // The struct should receive a memberwise initializer.
+    let _ = NoInitializers.init(x:)
+  }
+}
+
+struct InitialValueCodableNoExplicitInitializers : Codable {
+  var x: Double = .pi
+
+  func foo() {
+    // The struct should receive a synthesized init(from:) and encode(to:).
+    let _ = CodableNoExplicitInitializers.init(from:)
+    let _ = CodableNoExplicitInitializers.encode(to:)
+
+    // It should still receive a memberwise initializer.
+    let _ = CodableNoExplicitInitializers.init(x:)
+  }
+}

--- a/test/decl/protocol/special/coding/struct_codable_memberwise_initializer.swift
+++ b/test/decl/protocol/special/coding/struct_codable_memberwise_initializer.swift
@@ -31,7 +31,10 @@ struct InitialValueNoInitializers {
 
   func foo() {
     // The struct should receive a memberwise initializer.
-    let _ = NoInitializers.init(x:)
+    let _ = InitialValueNoInitializers.init(x:)
+
+    // The struct should receive a no-argument initializer.
+    let _ = InitialValueNoInitializers.init()
   }
 }
 
@@ -40,10 +43,13 @@ struct InitialValueCodableNoExplicitInitializers : Codable {
 
   func foo() {
     // The struct should receive a synthesized init(from:) and encode(to:).
-    let _ = CodableNoExplicitInitializers.init(from:)
-    let _ = CodableNoExplicitInitializers.encode(to:)
+    let _ = InitialValueCodableNoExplicitInitializers.init(from:)
+    let _ = InitialValueCodableNoExplicitInitializers.encode(to:)
 
     // It should still receive a memberwise initializer.
-    let _ = CodableNoExplicitInitializers.init(x:)
+    let _ = InitialValueCodableNoExplicitInitializers.init(x:)
+
+    // It should still receive a no-argument initializer.
+    let _ = InitialValueCodableNoExplicitInitializers.init()
   }
 }


### PR DESCRIPTION
**What's in this pull request?**
Cherry-picks #11045 to `swift-4.0-branch`.

**Explanation:** Addresses [SR-4772](https://bugs.swift.org/browse/SR-4772) and [SR-5122](https://bugs.swift.org/browse/SR-5122).

This addresses a few issues that prevented classes from properly receiving synthesized `Codable` conformances:
* #10964 allowed classes to override synthesized `Codable` conformances in subclasses; this allows a synthesized `Decodable` class to override a non-`Decodable` class by calling `super.init()` instead of `super.init(from:)` on its parent.
* Improves the diagnostics produced when a class can't receive synthesized `Decodable` implementation due to superclass limitations
* Prevents a synthesized `init(from:)` from further preventing synthesis of a default initializer (on classes) or a memberwise initializer (on structs)
* Provides improved diagnostics for suggesting that a subclass override `init(from:)` and `encode(to:)` if it could not inherit its superclass's `Codable` witnesses

**Scope:** Affects those using classes with the new `Codable` APIs.
**Radar:** rdar://problem/32774777
**Risk:** Low–Medium
**Testing:** Adds unit tests to confirm expected behavior